### PR TITLE
kea: add pgrep to checkdepends

### DIFF
--- a/srcpkgs/kea/template
+++ b/srcpkgs/kea/template
@@ -12,6 +12,7 @@ makedepends="boost-devel log4cplus-devel python3-devel
  $(vopt_if botan botan-devel libressl-devel)
  $(vopt_if mysql libmysqlclient-devel)
  $(vopt_if pgsql postgresql-libs-devel)"
+checkdepends="procps-ng" #needs pgrep
 depends="libkea>=0"
 conf_files="/etc/kea/*.conf"
 short_desc="Next generation DHCPv4/v6 server"


### PR DESCRIPTION
The tests need pgrep

btw, it then fails like this:
```
<...>
Running test: pgsql_tests.sh

START TEST pgsql.lease-init
Wiping whole database keatest
Assertion failure: 0 != 127, for val1=0, val2=127
pgsql_wipe drop failed, expected exit code: 0, actual: 127
FAILED pgsql.lease-init
```