### PR TITLE
quassel: update to 0.12.5.

### DIFF
--- a/srcpkgs/quassel/template
+++ b/srcpkgs/quassel/template
@@ -1,47 +1,44 @@
 # Template file for 'quassel'
 pkgname=quassel
-version=0.12.4
-revision=2
+version=0.12.5
+revision=1
 build_style=cmake
+configure_args="-DEMBED_DATA=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DWANT_CORE=ON
+ -DUSE_QT5=ON"
+hostmakedepends="pkg-config"
+makedepends="qt5-tools-devel phonon-qt5-devel qca-qt5-devel zlib-devel
+ libdbusmenu-qt5-devel qt5-script-devel qt5-plugin-tds
+ qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-mysql qt5-plugin-odbc"
+depends="qt5-plugin-sqlite quassel-client-shared>=${version}_${revision}"
 _desc="Modern, cross-platform, distributed graphical IRC client"
 short_desc="${_desc} - standalone client"
 maintainer="Toyam Cox <Vaelatern@gmail.com>"
-hostmakedepends="pkg-config"
-makedepends="zlib-devel qt-devel qt-webkit-devel libdbusmenu-qt-devel phonon-devel qca-devel"
-_common_deps="desktop-file-utils"
-depends="${_common_deps} qt-plugin-sqlite quassel-client-shared>=${version}_${revision}"
-license="GPL-3"
-configure_args="-DEMBED_DATA=1 -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DWANT_CORE=ON -DWITH_OPENSSL=ON -DWITH_DBUS=ON -DWITH_PHONON=ON -DWITH_WEBKIT=ON"
+license="GPL-2.0, GPL-3.0"
+homepage="https://www.quassel-irc.org"
+distfiles="https://quassel-irc.org/pub/quassel-${version}.tar.bz2"
+checksum=1894574dfd79654152a5b7427e7df592b055ae908230504f98a4cb48961e74e2
 system_accounts="quassel"
-homepage="http://www.quassel-irc.org"
-distfiles="http://quassel-irc.org/pub/quassel-${version}.tar.bz2"
-checksum=93e4e54cb3743cbe2e5684c2fcba94fd2bc2cd739f7672dee14341b49c29444d
 
 post_install() {
 	vsv quasselcore
 }
 
-quassel-shared_package() {
-	short_desc="${_desc} - common files"
-	unset depends
-	pkg_install() {
-		vmove /usr/share/icons
-		vmove /usr/share/pixmaps
-	}
-}
-
 quassel-client-shared_package() {
+	replaces="quassel-shared>=0"
+	conflicts="quassel-shared>=0"
 	short_desc="${_desc} - common client files"
-	depends="quassel-shared>=${version}_${revision}"
+	depends="desktop-file-utils"
 	pkg_install() {
 		vmove /usr/share/quassel
+		vmove /usr/share/icons
+		vmove /usr/share/pixmaps
 	}
 }
 
 quassel-core_package() {
 	replaces="quasselcore>=0"
 	conflicts="quasselcore>=0"
-	depends="${_common_deps} qt-plugin-sqlite quassel-shared>=${version}_${revision}"
+	depends="qt5-plugin-sqlite"
 	short_desc="${_desc} - server"
 	pkg_install() {
 		vmove /usr/bin/quasselcore
@@ -52,7 +49,7 @@ quassel-core_package() {
 quassel-client_package() {
 	replaces="quasselclient>=0"
 	conflicts="quasselclient>=0"
-	depends="${_common_deps} quassel-client-shared>=${version}_${revision}"
+	depends="quassel-client-shared>=${version}_${revision}"
 	short_desc="${_desc} - distributed client"
 	pkg_install() {
 		vmove /usr/share/applications/quasselclient.desktop


### PR DESCRIPTION
(moved from https://github.com/voidlinux/void-packages/pull/13930)

changelog: https://github.com/quassel/quassel/blob/0.12.5/ChangeLog#L16

- switched qt4 to qt5
- fix license: GPL-2.0 or GPL-3.0 (explicitly, not "2.0-or-later")
- removed three unrecognized configure options
- removed config options correspondig to the default already
- drop deprecated webkit option
- -core doesn't need icons (drop dependency on -shared)
- merge -shared with -client-shared (it only holds icons)