### PR TITLE
New package: ice-ssb-5.3.0

### DIFF
--- a/srcpkgs/ice-ssb/template
+++ b/srcpkgs/ice-ssb/template
@@ -1,0 +1,20 @@
+# Template file for 'ice-ssb'
+pkgname=ice-ssb
+version=5.3.0
+revision=1
+wrksrc="ice-$version"
+depends="gtk+3 python3-BeautifulSoup4 python3-gobject"
+short_desc="Site Specific Browsers (SSBs) manager"
+maintainer="John <johnz@posteo.net>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/peppermintos/ice/"
+distfiles="https://github.com/peppermintos/ice/archive/${version}.tar.gz"
+checksum=bbd69af4d917920d442ef3ed27fa30dbe4fedcc35bd5cae0a63175ddfd3711b2
+
+post_extract() {
+	sed -i -e 's/chromium-browser/chromium/g' usr/bin/ice
+}
+
+do_install() {
+	vcopy usr usr
+}


### PR DESCRIPTION
```
# Ice is a simple Site Specific Browser (SSB) manager for Chromium and
# Chrome specifically intended to integrate with the LXDE menu system.
# Unlike the built-in functions in the browsers, Ice boasts the ability
# to remove SSBs, validate addresses, and prevent overwriting existing
# SSBs. Special thanks to Matt Phillips <labratmatt@gmail.com> for the
# excellent pyfav library that is integrated into this application.
# ADDENDUM: Added support for Firefox (via "ice-firefox") and Vivaldi.
```