### PR TITLE
tomahawk-qt5: update to latest commit

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2130,9 +2130,9 @@ liblastfm_fingerprint5.so.1 liblastfm-qt5-1.0.9_1
 liblastfm5.so.1 liblastfm-qt5-1.0.9_1
 libquazip5.so.1 quazip-qt5-0.7.3_2
 libjreen-qt5.so.1 jreen-qt5-1.2.0_1
-libtomahawk.so.0.8.4 tomahawk-qt5-0.8.4_3
-libtomahawk-playdarapi.so.0.8.4 tomahawk-qt5-0.8.4_3
-libtomahawk-widgets.so.0.8.4 tomahawk-qt5-0.8.4_3
+libtomahawk.so.0.8.99 tomahawk-qt5-0.8.4_13
+libtomahawk-playdarapi.so.0.8.99 tomahawk-qt5-0.8.4_13
+libtomahawk-widgets.so.0.8.99 tomahawk-qt5-0.8.4_13
 libzen.so.0 libzen-0.4.31_1
 libmediainfo.so.0 libmediainfo-0.7.75_1
 libnghttp2.so.14 nghttp2-1.0.2_1

--- a/srcpkgs/tomahawk-qt5/patches/liblastfm.patch
+++ b/srcpkgs/tomahawk-qt5/patches/liblastfm.patch
@@ -1,0 +1,103 @@
+diff --git CMakeModules/FindLibLastFm.cmake CMakeModules/FindLibLastFm.cmake
+index a3488350e..545e39f9b 100644
+--- CMakeModules/FindLibLastFm.cmake
++++ CMakeModules/FindLibLastFm.cmake
+@@ -14,7 +14,7 @@ endif()
+ # Include dir
+ find_path(LIBLASTFM_INCLUDE_DIR
+   # Track.h doesn't exist in liblastfm-0.3.1, was called Track back then
+-  NAMES lastfm${LASTFM_LIB_SUFFIX}/Track.h
++  NAMES lastfm/Track.h
+   PATHS ${KDE4_INCLUDE_DIR}
+ )
+ 
+diff --git src/libtomahawk/accounts/lastfm/LastFmConfig.cpp src/libtomahawk/accounts/lastfm/LastFmConfig.cpp
+index 85b747be8..c1d2e1343 100644
+--- src/libtomahawk/accounts/lastfm/LastFmConfig.cpp
++++ src/libtomahawk/accounts/lastfm/LastFmConfig.cpp
+@@ -30,10 +30,10 @@
+ #include "utils/NetworkAccessManager.h"
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+-#include <lastfm5/ws.h>
+-#include <lastfm5/User.h>
+-#include <lastfm5/XmlQuery.h>
+-#include <lastfm5/Track.h>
++#include <lastfm/ws.h>
++#include <lastfm/User.h>
++#include <lastfm/XmlQuery.h>
++#include <lastfm/Track.h>
+ #else
+ #include <lastfm/ws.h>
+ #include <lastfm/User.h>
+diff --git src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.cpp src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.cpp
+index 277a62e17..f5111fc6f 100644
+--- src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.cpp
++++ src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.cpp
+@@ -35,8 +35,8 @@
+ #include "utils/NetworkAccessManager.h"
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+-#include <lastfm5/ws.h>
+-#include <lastfm5/XmlQuery.h>
++#include <lastfm/ws.h>
++#include <lastfm/XmlQuery.h>
+ #else
+ #include <lastfm/ws.h>
+ #include <lastfm/XmlQuery.h>
+diff --git src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.h src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.h
+index 0eb3b0749..c7de68e98 100644
+--- src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.h
++++ src/libtomahawk/accounts/lastfm/LastFmInfoPlugin.h
+@@ -25,9 +25,9 @@
+ #include "DllMacro.h"
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+-#include <lastfm5/Track.h>
+-#include <lastfm5/Audioscrobbler.h>
+-#include <lastfm5/ScrobblePoint.h>
++#include <lastfm/Track.h>
++#include <lastfm/Audioscrobbler.h>
++#include <lastfm/ScrobblePoint.h>
+ #else
+ #include <lastfm/Track.h>
+ #include <lastfm/Audioscrobbler.h>
+diff --git src/libtomahawk/utils/TomahawkUtils.cpp src/libtomahawk/utils/TomahawkUtils.cpp
+index 0baa27c37..019db4af2 100644
+--- src/libtomahawk/utils/TomahawkUtils.cpp
++++ src/libtomahawk/utils/TomahawkUtils.cpp
+@@ -33,7 +33,7 @@
+ 
+ #ifdef LIBLASTFM_FOUND
+     #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+-    #include <lastfm5/ws.h>
++    #include <lastfm/ws.h>
+     #else
+     #include <lastfm/ws.h>
+     #endif
+diff --git src/tomahawk/Scrobbler.h src/tomahawk/Scrobbler.h
+index 01c26959c..f117c896c 100644
+--- src/tomahawk/Scrobbler.h
++++ src/tomahawk/Scrobbler.h
+@@ -25,7 +25,7 @@
+ 
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+-#include <lastfm5/ScrobblePoint.h>
++#include <lastfm/ScrobblePoint.h>
+ #else
+ #include <lastfm/ScrobblePoint.h>
+ #endif
+diff --git src/tomahawk/TomahawkApp.h src/tomahawk/TomahawkApp.h
+index 953140bd4..eab6b8de4 100644
+--- src/tomahawk/TomahawkApp.h
++++ src/tomahawk/TomahawkApp.h
+@@ -65,7 +65,7 @@ namespace Tomahawk
+ 
+ #ifdef LIBLASTFM_FOUND
+     #if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+-    #include <lastfm5/NetworkAccessManager.h>
++    #include <lastfm/NetworkAccessManager.h>
+     #else
+     #include <lastfm/NetworkAccessManager.h>
+     #endif

--- a/srcpkgs/tomahawk-qt5/template
+++ b/srcpkgs/tomahawk-qt5/template
@@ -1,8 +1,9 @@
 # Template file for 'tomahawk'
 pkgname=tomahawk-qt5
 version=0.8.4
-revision=12
-wrksrc=${pkgname%-*}-${version}
+revision=13
+wrksrc=${pkgname%-*}-${_commit}
+_commit=00f602e10203b76fc28b4615868c567e6bd4ced4
 build_style=cmake
 build_options="upower hatchet kde xmpp"
 desc_option_hatchet="Enable support for http://hatchet.is"
@@ -16,58 +17,26 @@ configure_args="-Wno-dev -DBUILD_RELEASE=ON \
  -DTAGLIB_MIN_VERSION=1.10 \
  $(vopt_if kde '-DWITH_KDE4=ON' '-DWITH_KDE4=OFF') \
  $(vopt_if upower '-DWITH_UPOWER=ON' '-DWITH_UPOWER=OFF')"
-hostmakedepends="pkg-config"
-makedepends="boost-devel Lucene++-devel qt5-devel taglib-devel sparsehash
- gnutls-devel qt5-webkit-devel qca-qt5-devel attica-qt5-devel qtkeychain-qt5-devel
- qt5-svg-devel qt5-tools-devel phonon-qt5-devel liblastfm-qt5-devel quazip-qt5-devel
- libechonest-qt5-devel libressl-devel $(vopt_if hatchet websocketpp)
+hostmakedepends="pkg-config extra-cmake-modules"
+makedepends="Lucene++-devel attica-qt5-devel boost-devel gnutls-devel
+ libechonest-qt5-devel liblastfm-qt5-devel phonon-qt5-devel qca-qt5-devel
+ qt5-svg-devel qt5-tools-devel qt5-webkit-devel qtkeychain-qt5-devel
+ quazip-qt5-devel sparsehash taglib-devel vlc-devel $(vopt_if hatchet websocketpp)
  $(vopt_if xmpp jreen-qt5-devel) $(vopt_if kde telepathy-qt5-devel)"
 depends="virtual?phonon-qt5-backend qt5-plugin-sqlite $(vopt_if xmpp qca-qt5-ossl)"
 short_desc="Multi-source social music player"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-3"
-homepage="http://tomahawk-player.org/"
-distfiles="http://download.tomahawk-player.org/${pkgname%-*}-${version}.tar.bz2"
-checksum=0fb04bc6b7009e17186b3d384057939727c6f289d22f7f9a5ed2c9c9cd800449
+license="GPL-3.0-or-later"
+homepage="https://tomahawk-player.org/"
+distfiles="https://github.com/tomahawk-player/tomahawk/archive/${_commit}.tar.gz"
+checksum=f93d36b246944657dcef98ff71410db8630c53b5565dc283fb15f57e5b301f79
 
 provides="tomahawk-${version}_${revision}"
 replaces="tomahawk>=0"
 
 if [ -n "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-host-tools qt5-devel qt5-svg-devel qt5-tools-devel qt5-webkit-devel"
+	hostmakedepends+=" qt5-host-tools qt5-qmake"
 fi
-
-post_extract() {
-	# fix echonest-qt5 detection
-	sed -i 's|echonest/Track.h|echonest5/Track.h|' CMakeModules/FindEchonest.cmake
-	# fix echonest-qt5 includes
-	sed -i 's|^#include <echonest/|#include <echonest5/|' \
-		src/tomahawk/sourcetree/items/CategoryItems.cpp \
-		src/tomahawk/sourcetree/items/CategoryItems.cpp \
-		src/libtomahawk/playlist/dynamic/echonest/EchonestControl.h \
-		src/libtomahawk/playlist/dynamic/echonest/EchonestSteerer.cpp \
-		src/libtomahawk/playlist/dynamic/echonest/EchonestGenerator.h \
-		src/libtomahawk/EchonestCatalogSynchronizer.cpp \
-		src/libtomahawk/EchonestCatalogSynchronizer.cpp \
-		src/libtomahawk/GlobalActionManager.cpp \
-		src/libtomahawk/EchonestCatalogSynchronizer.h \
-		src/infoplugins/generic/echonest/EchonestPlugin.cpp \
-		src/infoplugins/generic/echonest/EchonestPlugin.h
-	# fix quazip-qt5 detection
-	sed -i CMakeModules/FindQuaZip.cmake \
-		-e 's|quazip/quazip.h|quazip5/quazip.h|' \
-		-e '/^find_library/s|quazip|&5|'
-	sed -i 's|#include <quazip|&5|' src/libtomahawk/utils/TomahawkUtils.cpp
-	# fix qca-qt5 detection
-	sed -i CMakeModules/FindQCA2.cmake \
-		-e 's|qca2|&-qt5|' \
-		-e 's|NAMES qca|&-qt5|'
-	# fix build
-	sed -i '24a#include <QDataStream>' src/libtomahawk/network/acl/AclRegistry.cpp
-	sed -i '30a#include <QDataStream>' src/libtomahawk/utils/TomahawkCache.h
-	# fix musl build
-	sed -i '41a#include <sys/user.h>' src/libtomahawk/accounts/ResolverAccount.cpp
-}
 
 tomahawk-qt5-devel_package() {
 	depends="tomahawk-qt5>=${version}_${revision}"


### PR DESCRIPTION
Our current version does not work with qt5.10 which is fixed in some of the newer commits.