### PR TITLE
[CI Skip] Freecad occt vtk various

### DIFF
--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -5,7 +5,7 @@
 #  - python3: freecad code not yet ready for it, probably at 0.18
 pkgname=freecad
 version=0.17
-revision=7
+revision=8
 wrksrc="FreeCAD-${version}"
 build_style=cmake
 
@@ -15,7 +15,8 @@ _inst_prefix=/usr/lib/${pkgname}
 configure_args="
  -DBUILD_QT5=OFF
  -DCMAKE_INSTALL_PREFIX=${_inst_prefix}
- -DCMAKE_INSTALL_LIBDIR=${_inst_prefix}/lib"
+ -DCMAKE_INSTALL_LIBDIR=${_inst_prefix}/lib
+ -DMEDFILE_INCLUDE_DIRS=/usr/include/med"
 hostmakedepends="pkg-config swig doxygen graphviz dos2unix"
 makedepends="python-devel boost-devel libxerces-c-devel
  zlib-devel occt-devel vtk-devel hdf5-devel openmpi-devel libmed-devel eigen
@@ -27,9 +28,9 @@ depends="python-matplotlib python-pyside qt-devel-tools qt-plugin-sqlite python-
 
 pycompile_dirs="usr/lib/${pkgname}/Mod usr/lib/${pkgname}/data/Mod"
 
-short_desc="A general purpose 3D CAD modeler"
+short_desc="General purpose 3D CAD modeler"
 maintainer="yopito <pierre.bourgin@free.fr>"
-license="LGPL-2.1"
+license="LGPL-2.0-or-later"
 homepage="https://freecadweb.org/"
 distfiles="https://github.com/FreeCAD/FreeCAD/archive/${version}.tar.gz"
 checksum=ae017393476b6dc7f1192bcaf91ceedc2f9b791f2495307ce7c45efadb5266fb

--- a/srcpkgs/med/template
+++ b/srcpkgs/med/template
@@ -1,18 +1,22 @@
 # Template file for 'med'
 pkgname=med
 version=3.3.1
-revision=4
+revision=5
 wrksrc=med-${version}_SRC
 build_style=gnu-configure
-configure_args="--with-swig=yes --with-hdf5-bin=/usr/lib/hdf5-18/bin"
+configure_args="--with-swig=yes --with-hdf5-bin=/usr/lib/hdf5-18/bin
+ --includedir=/usr/include/med"
 hostmakedepends="gcc-fortran swig"
 makedepends="hdf5-18-devel python-devel tk-devel"
+depends="tk" # xmdump* are wish scripts
 short_desc="Data Modelization and Exchanges"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="GPL-3, LGPL-3"
+license="GPL-3.0-only, LGPL-3.0-only"
 homepage="https://www.salome-platform.org"
 distfiles="http://files.salome-platform.org/Salome/other/med-${version}.tar.gz"
 checksum=dd631ef813838bc7413ff0dd6461d7a0d725bcfababdf772ece67610a8d22588
+
+nocross="hdf5 is nocross"
 
 libmed-devel_package() {
 	short_desc+=" library - development files"

--- a/srcpkgs/med/update
+++ b/srcpkgs/med/update
@@ -1,0 +1,1 @@
+site="https://www.salome-platform.org/downloads/"

--- a/srcpkgs/occt/patches/musl-fenv.patch
+++ b/srcpkgs/occt/patches/musl-fenv.patch
@@ -1,5 +1,21 @@
+As stated by srcpkgs/flightgear/patches/musl-fenv.patch:
+"""
+Simply disabling the code which enables floating point exceptions
+is probably wrong, but I don't have a replacement for the
+non-posix functions fegetexcept(3) and feenableexcept(3).
+"""
+
 --- src/OSD/OSD_signal.cxx.orig
 +++ src/OSD/OSD_signal.cxx
+@@ -645,7 +645,7 @@
+ 
+ #include <signal.h>
+ 
+-#if !defined(__ANDROID__) && !defined(__QNX__)
++#if !defined(__ANDROID__) && !defined(__QNX__) && defined(__GLIBC__)
+   #include <sys/signal.h>
+ #endif
+ 
 @@ -687,7 +687,7 @@
    // cout << "OSD::Handler: signal " << (int) theSignal << " occured inside a try block " <<  endl ;
    if ( ADR_ACT_SIGIO_HANDLER != NULL )
@@ -18,20 +34,22 @@
    if (fFltExceptions)
      feenableexcept (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
      //feenableexcept (FE_INVALID | FE_DIVBYZERO);
-@@ -891,14 +891,14 @@
-       cerr << "ieee_handler does not work !!! KO " << endl;
+@@ -892,14 +892,18 @@
  #endif
      }
--#elif defined (__linux__)
-+#elif defined(__linux__) && defined(__GLIBC__)
+ #elif defined (__linux__)
++#if defined(__GLIBC__)
      feenableexcept (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
++#endif
      fFltExceptions = Standard_True;
  #endif
    }
    else
    {
--#if defined (__linux__)
-+#if defined(__linux__) && defined(__GLIBC__)
+ #if defined (__linux__)
++#if defined(__GLIBC__)
      fedisableexcept (FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
++#endif
      fFltExceptions = Standard_False;
  #endif
+   }

--- a/srcpkgs/occt/template
+++ b/srcpkgs/occt/template
@@ -1,8 +1,8 @@
 # Template file for 'occt'
 pkgname=occt
-_gittag="V7_2_0p1"
 version=7.2.0p1
-revision=1
+revision=2
+_gittag="V${version//./_}"
 wrksrc=occt-${_gittag}
 build_style=cmake
 configure_args="-DUSE_FREEIMAGE=ON -DUSE_TBB=ON -DUSE_GL2PS=ON -DUSE_VTK=OFF
@@ -11,13 +11,16 @@ makedepends="freetype-devel glu-devel freeimage-devel gl2ps-devel tbb-devel
  tcl-devel tk-devel"
 short_desc="OpenCASCADE Technology - library for CAD/CAM/CAE applications"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="LGPL-2.1"
+license="LGPL-2.1-only"
 homepage="https://www.opencascade.com"
+# distifile: use git instead of official tarball that requires registration
+# see https://www.opencascade.com/content/packaging-again-debian
 distfiles="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/${_gittag};sf=tgz>occt-${_gittag}.tar.gz"
 checksum=530f9981e6026e6cc04c462ab039b4977a568f943d6086dc502262d100a07a79
 conflicts="oce>=0"
 
 post_install() {
+	rm ${PKGDESTDIR}/usr/share/doc/opencascade/*_LGPL_*.txt
 	vlicense OCCT_LGPL_EXCEPTION.txt
 	rm ${DESTDIR}/usr/bin/custom*.sh
 }
@@ -29,7 +32,6 @@ occt-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/cmake"
-		mkdir -p ${PKGDESTDIR}/usr/share/${pkgname}
-		vcopy samples usr/share/${pkgname}
+		vmove "usr/share/opencascade/samples"
 	}
 }

--- a/srcpkgs/occt/update
+++ b/srcpkgs/occt/update
@@ -1,2 +1,2 @@
-site=https://git.dev.opencascade.org/gitweb/?p=occt.git;a=summary
-pattern="refs/tags/V\K[\d_]*(?=\")"
+site="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=tags"
+pattern=">V\K[\d_p]+(?=</a>)"

--- a/srcpkgs/vtk/template
+++ b/srcpkgs/vtk/template
@@ -4,38 +4,44 @@
 # Here only the bare minimum set of modules for freecad is enabled
 pkgname=vtk
 version=8.1.0
-revision=6
+revision=7
 wrksrc=VTK-${version}
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DVTK_USE_SYSTEM_LIBRARIES=ON
--DVTK_Group_StandAlone=ON
--DModule_vtkIOMPIParallel=ON
--DModule_vtkParallelMPI=ON"
+ -DVTK_FORBID_DOWNLOADS=ON
+ -DVTK_Group_StandAlone=ON
+ -DModule_vtkIOMPIParallel=ON
+ -DModule_vtkParallelMPI=ON"
 
-# vtk needs specific libharu patches, so use built-in.
+# fails, so use built-in
+# vtk needs specific libharu patches:
 # https://github.com/libharu/libharu/pull/157
 configure_args+=" -DVTK_USE_SYSTEM_LIBHARU=OFF"
 
 # fails, so use built-in
+# netcdf XBPS package lacks of c++ interface ?
+# ArchLinux: "VTK fails to compile with recent netcdf-cxx package, VTK should be ported to the latest API"
 configure_args+=" -DVTK_USE_SYSTEM_NETCDFCPP=OFF"
 
-# may be disabled when gl2ps > 1.4.0 is available
-# vtk relies on gl2psTextOptColorBL(), which is not yet in a realeased gl2ps
+# fails, so use built-in
+# vtk relies on gl2psTextOptColorBL(), which is not yet in gl2ps 1.4.0
 configure_args+=" -DVTK_USE_SYSTEM_GL2PS=OFF"
 
 makedepends="zlib-devel freetype-devel liblz4-devel expat-devel MesaLib-devel
-libXt-devel libjpeg-turbo-devel tiff-devel proj-devel hdf5-devel netcdf-devel
-gl2ps-devel libxml2-devel jsoncpp-devel openmpi-devel libogg-devel
-libtheora-devel"
+ libXt-devel libjpeg-turbo-devel tiff-devel proj-devel hdf5-devel netcdf-devel
+ libxml2-devel jsoncpp-devel openmpi-devel libogg-devel libtheora-devel"
 
 short_desc="System for 3D computer graphics, image processing, and visualization"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="https://www.vtk.org"
 distfiles="https://www.vtk.org/files/release/${version:0:3}/VTK-${version}.tar.gz"
 checksum=6e269f07b64fb13774f5925161fb4e1f379f4e6a0131c8408c555f6b58ef3cb7
 
+nocross="hdf5 is nocross"
+
 post_install() {
+	rm ${PKGDESTDIR}/usr/share/doc/${pkgname}-*/Copyright.txt
 	vlicense Copyright.txt
 }
 

--- a/srcpkgs/vtk/update
+++ b/srcpkgs/vtk/update
@@ -1,0 +1,2 @@
+site="https://www.vtk.org/download/"
+ignore="*rc*"


### PR DESCRIPTION

Changes:
* `med`: store its .h files in `/usr/include/med` instead of polluting `/usr/include/`
* `occt`: fix musl patch of  `OSD_signal.cxx`: assign values to data as much as possible
*  fix check-update on various packages
* various small gliches
* labelled `[ci skip]` : this PR is too big for CI constraints. However, personal builds (including cross) and basic runtime are fine

PR move from old repo PR https://github.com/voidlinux/void-packages/pull/14002
