### PR TITLE
Seafile client stack: switch to python3

### DIFF
--- a/srcpkgs/ccnet/patches/python3-syntax.patch
+++ b/srcpkgs/ccnet/patches/python3-syntax.patch
@@ -1,0 +1,22 @@
+--- python/ccnet/packet.py.ORIG
++++ python/ccnet/packet.py
+@@ -72,7 +72,7 @@
+ def parse_header(buf):
+     try:
+         ver, ptype, length, id = struct.unpack(CCNET_HEADER_FORMAT, buf)
+-    except struct.error, e:
++    except struct.error as e:
+         raise NetworkError('error when unpack packet header: %s' % e)
+     
+     return PacketHeader(ver, ptype, length, id)
+--- python/ccnet/async/async_client.py.ORIG
++++ python/ccnet/async/async_client.py
+@@ -26,7 +26,7 @@
+ ]
+ 
+ def debug_print(msg):
+-    print msg
++    print(msg)
+ 
+ class AsyncClient(Client):
+     '''Async mode client'''

--- a/srcpkgs/ccnet/template
+++ b/srcpkgs/ccnet/template
@@ -1,7 +1,7 @@
 # Template file for 'ccnet'
 pkgname=ccnet
 version=6.1.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake libsearpc-codegen libtool pkg-config vala"
@@ -37,8 +37,8 @@ ccnet-python_package() {
 	noarch=yes
 	pycompile_module="ccnet"
 	depends="ccnet"
-	short_desc="Python2 bindings"
+	short_desc="Python3 bindings"
 	pkg_install() {
-		vmove usr/lib/python2.7
+		vmove ${py3_lib}
 	}
 }

--- a/srcpkgs/libsearpc/patches/python3-support.patch
+++ b/srcpkgs/libsearpc/patches/python3-support.patch
@@ -1,0 +1,176 @@
+lib/searpc-codegen.py patch comes from upstream commits:
+  - https://github.com/haiwen/libsearpc/commit/672bb90032b9c226adee5e63a4dd273eaf8f8c12
+  - https://github.com/haiwen/libsearpc/commit/0570df3f4a3c6ae4a5326722b34a9a9fda8cc8ea
+
+--- lib/searpc-codegen.py.ORIG
++++ lib/searpc-codegen.py
+@@ -1,9 +1,10 @@
+-#!/usr/bin/env python2
++#!/usr/bin/env python
+ 
+ """
+ Generate function define macros.
+ """
+ 
++from __future__ import print_function
+ import string
+ import sys
+ import os
+@@ -16,24 +17,24 @@ import os
+ #          <default_ret_value>)
+ type_table = {
+     "string": ("const char*",
+-               "char*", 
++               "char*",
+                "json_array_get_string_or_null_element",
+                "searpc_set_string_to_ret_object",
+                "json_array_add_string_or_null_element",
+                "NULL"),
+-    "int": ("int", 
+-            "int", 
++    "int": ("int",
++            "int",
+             "json_array_get_int_element",
+             "searpc_set_int_to_ret_object",
+             "json_array_add_int_element",
+             "-1"),
+-    "int64": ("gint64", 
+-              "gint64", 
++    "int64": ("gint64",
++              "gint64",
+               "json_array_get_int_element",
+               "searpc_set_int_to_ret_object",
+               "json_array_add_int_element",
+               "-1"),
+-    "object": ("GObject*", 
++    "object": ("GObject*",
+                "GObject*",
+                "",
+                "searpc_set_object_to_ret_object",
+@@ -83,8 +84,8 @@ def generate_marshal(ret_type, arg_types):
+         stmt = "    %s param%d = %s (param_array, %d);\n" %(
+             type_item[0], i+1, type_item[2], i+1)
+         get_parameters += stmt
+-    
+-    # func_prototype should be something like 
++
++    # func_prototype should be something like
+     # GList* (*)(const char*, int, GError **)
+     func_prototype = ret_type_in_c + " (*)("
+     for arg_type in arg_types:
+@@ -98,18 +99,21 @@ def generate_marshal(ret_type, arg_types):
+ 
+     func_call = "%s ret = ((%s)func) (%s);" % (ret_type_in_c, func_prototype,
+                                               func_args)
+-    
++
+     convert_ret = "%s (object, ret);" % ret_type_item[3]
+-    
++
+     return template.substitute(marshal_name=marshal_name,
+                                get_parameters=get_parameters,
+                                func_call=func_call,
+                                convert_ret=convert_ret)
+ 
++def write_file(f, s):
++    f.write(s)
++    f.write('\n')
++
+ def gen_marshal_functions(f):
+-    from rpc_table import func_table
+     for item in func_table:
+-        print >>f, generate_marshal(item[0], item[1])
++        write_file(f, generate_marshal(item[0], item[1]))
+ 
+ 
+ marshal_register_item = r"""
+@@ -135,12 +139,11 @@ def generate_marshal_register_item(ret_type, arg_types):
+         signature_name=signature_name)
+ 
+ def gen_marshal_register_function(f):
+-    from rpc_table import func_table
+-    print >>f, "static void register_marshals()"""
+-    print >>f, "{"
++    write_file(f, "static void register_marshals()""")
++    write_file(f,  "{")
+     for item in func_table:
+-        print >>f, generate_marshal_register_item(item[0], item[1]),
+-    print >>f, "}"
++        write_file(f, generate_marshal_register_item(item[0], item[1]))
++    write_file(f,  "}")
+ 
+ signature_template = r"""
+ inline static gchar *
+@@ -159,20 +162,18 @@ def generate_signature(ret_type, arg_types):
+     else:
+         signature_name = "searpc_signature_" + ret_type + "__" + (
+             '_'.join(arg_types))
+-    
++
+     args = "\"" + ret_type + "\"" + ", " + str(len(arg_types))
+     for arg_type in arg_types:
+         args += ", " + "\"" + arg_type + "\""
+-    
++
+     template = string.Template(signature_template)
+     return template.substitute(signature_name=signature_name, args=args)
+ 
+ def gen_signature_list():
+-    f = open('searpc-signature.h', 'w')
+-    for item in func_table:
+-        print >>f,generate_signature(item[0], item[1])
+-    f.close()
+-
++    with open('searpc-signature.h', 'w') as f:
++        for item in func_table:
++            write_file(f, generate_signature(item[0], item[1]))
+ 
+ if __name__ == "__main__":
+     sys.path.append(os.getcwd())
+@@ -180,20 +181,15 @@ if __name__ == "__main__":
+     # load function table
+     if len(sys.argv) == 2:
+         abspath = os.path.abspath(sys.argv[1])
+-        d = os.path.dirname(abspath)
+-        f = os.path.basename(abspath)
+-        mod = f[:f.rfind('.')]
+-        sys.path.append(d)
+-        rpc_mod = __import__(mod, globals(), locals(), [], -1)
+-        print "loaded func_table from %s" % (rpc_mod.__file__)
+-        func_table = rpc_mod.func_table
++        with open(abspath, 'r') as fp:
++            exec(fp.read())
++        print("loaded func_table from %s" % abspath)
+     else:
+         # load from default rpc_table.py
+         from rpc_table import func_table
+ 
+     # gen code
+-    marshal = open('searpc-marshal.h', 'w')
+-    gen_marshal_functions(marshal)
+-    gen_marshal_register_function(marshal)
+-    marshal.close()
++    with open('searpc-marshal.h', 'w') as marshal:
++        gen_marshal_functions(marshal)
++        gen_marshal_register_function(marshal)
+     gen_signature_list()
+--- pysearpc/server.py
++++ pysearpc/server.py
+@@ -25,7 +25,7 @@ class SearpcServer(object):
+         """input str -> output str"""
+         try:
+             argv = json.loads(fcallstr)
+-        except Exception, e:
++        except Exception as e:
+             raise SearpcError('bad call str: ' + str(e))
+ 
+         service = self.services[svcname]
+@@ -41,7 +41,7 @@ class SearpcServer(object):
+     def call_function(self, svcname, fcallstr):
+         try:
+             retVal = self._call_function(svcname, fcallstr)
+-        except Exception, e:
++        except Exception as e:
+             ret = {'err_code': 555, 'err_msg': str(e)}
+         else:
+             ret = {'ret': retVal}

--- a/srcpkgs/libsearpc/template
+++ b/srcpkgs/libsearpc/template
@@ -1,18 +1,21 @@
 # Template file for 'libsearpc'
 pkgname=libsearpc
-version=3.0.7
+version=3.0.8
 revision=1
+_tagversion=3.1-latest
+wrksrc="${pkgname}-${_tagversion}"
 build_style=gnu-configure
 configure_args="--disable-static --disable-compile-demo"
-hostmakedepends="automake libtool pkg-config python"
+hostmakedepends="automake libtool pkg-config python3"
 makedepends="glib-devel jansson-devel"
-
+python_version=3
+pycompile_module="pysearpc"
 short_desc="Seafile RPC library"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="GPL-3"
 homepage="https://github.com/haiwen/${pkgname}"
-distfiles="https://github.com/haiwen/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=efee6b495f93e70101c87849c78b135014dfd2f0e5c08dcfed9834def47cb939
+distfiles="https://github.com/haiwen/${pkgname}/archive/v${_tagversion}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=83b45fa2f4b7d7ae6dd34ca04d430433551ef493cdaf3cbcc768bd6099377d90
 
 pre_configure() {
 	./autogen.sh
@@ -35,7 +38,7 @@ libsearpc-devel_package() {
 
 libsearpc-codegen_package() {
 	short_desc+=" - code generator"
-	depends="python"
+	depends="python3"
 	noarch=yes
 	pkg_install() {
 		vdoc "AUTHORS"

--- a/srcpkgs/seafile-libclient/template
+++ b/srcpkgs/seafile-libclient/template
@@ -1,14 +1,15 @@
 # Template file for 'seafile-libclient'
 pkgname=seafile-libclient
 version=6.1.8
-revision=1
+revision=2
 _distname="${pkgname/-libclient/}"
 wrksrc="${_distname}-${version}"
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake intltool libsearpc-codegen libtool pkg-config vala"
 makedepends="ccnet-devel libcurl-devel"
-depends="python"
+depends="python3"
+pycompile_module="seafile"
 short_desc="Cloud storage system - client command-line and libraries"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="GPL-2.0-or-later" # Has openssl exception not yet present on SPDX
@@ -21,8 +22,8 @@ pre_configure() {
 }
 
 post_install() {
-	# remove server files
-	rm -rf "${DESTDIR}/usr/lib/python2.7/site-packages/seaserv"
+	# remove server stuff
+	rm -rf ${DESTDIR}${py3_sitelib}/searserv
 
 	vdoc README.markdown
 }


### PR DESCRIPTION
switch all underlying dependencies of seafile-client-qt to python3, that leads to update `libsearpc` package to last version 3.0.8.  
`seafile-client-qt` package does not require an update.  
Personal cross-build is fine.

PR reborn from old repo PR https://github.com/voidlinux/void-packages/pull/15011
