### PR TITLE
adobe-flash-plugin: update to 30.0.0.113

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -1,6 +1,6 @@
 # Template file for 'adobe-flash-plugin'
 pkgname=adobe-flash-plugin
-version=29.0.0.171
+version=30.0.0.113
 revision=1
 # The EULA file
 _eula="https://www.adobe.com/content/dam/Adobe/en/legal/licenses-terms/pdf/PlatformClients_PC_WWEULA-en_US-20150407_1357.pdf"
@@ -8,10 +8,10 @@ _eulacksum=2851b4b39df44a2777c6c07e1f59cbc3055a346d2e775121b9ed38e0a4bf40d2
 _url=http://fpdownload.adobe.com/get/flashplayer/pdc/${version}
 if [ "$XBPS_MACHINE" = "x86_64" ]; then
 	_disttarball="${_url}/flash_player_npapi_linux.x86_64.tar.gz"
-	_distcksum=83610bf1461cab7b0dea7360ab78328720f2dab1aa70a93bb9e170a05f3f859d
+	_distcksum=5470bfa42156ba1f307059ff47605474df1c6ad2bd99e0ab2bff8f982c23bb15
 else
 	_disttarball="${_url}/flash_player_npapi_linux.i386.tar.gz"
-	_distcksum=6b084e6f65a35387eacaa2200e998942b0e3afa93bb92fad88cf8102125bf21a
+	_distcksum=e86d43d797c692fa48b86e6792978331316b3da08cc1372b35cb9afe732ac15e
 fi
 distfiles="${_eula} ${_disttarball}"
 checksum="${_eulacksum} ${_distcksum}"


### PR DESCRIPTION
This PR replaces voidlinux/void-packages#15174 in the old repo