### PR TITLE
New package runit-iptables-20180618

### DIFF
--- a/srcpkgs/runit-iptables/files/91-iptables.sh
+++ b/srcpkgs/runit-iptables/files/91-iptables.sh
@@ -1,0 +1,9 @@
+if [ -e /etc/iptables/iptables.rules ]
+then
+  iptables-restore /etc/iptables/iptables.rules
+fi
+
+if [ -e /etc/iptables/ip6tables.rules ]
+then
+  ip6tables-restore /etc/iptables/ip6tables.rules
+fi

--- a/srcpkgs/runit-iptables/template
+++ b/srcpkgs/runit-iptables/template
@@ -1,0 +1,14 @@
+# Template file for 'runit-iptables'
+pkgname=runit-iptables
+version=20180616
+revision=1
+noarch=yes
+depends="runit-void iptables"
+short_desc="Restore iptables rules on boot"
+maintainer="Nicolas Porcel <nicolasporcel06@gmail.com"
+license="Public Domain"
+homepage="http://www.voidlinux.eu/"
+
+do_install() {
+	vinstall ${FILESDIR}/91-iptables.sh 0644 etc/runit/core-services
+}


### PR DESCRIPTION
This will restore iptables rules before any service starts, thus avoiding conflicts. This is useful for services such as `libvirtd` or `sshguard`.