### PR TITLE
iptables: check xtables lock

### DIFF
--- a/srcpkgs/iptables/files/ip6tables/run
+++ b/srcpkgs/iptables/files/ip6tables/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 [ ! -e /etc/iptables/ip6tables.rules ] && exit 0
-ip6tables-restore /etc/iptables/ip6tables.rules
+ip6tables-restore /etc/iptables/ip6tables.rules -w 3 || exit 1
 exec chpst -b ip6tables pause

--- a/srcpkgs/iptables/files/iptables/run
+++ b/srcpkgs/iptables/files/iptables/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 [ ! -e /etc/iptables/iptables.rules ] && exit 0
-iptables-restore /etc/iptables/iptables.rules
+iptables-restore /etc/iptables/iptables.rules -w 3 || exit 1
 exec chpst -b iptables pause

--- a/srcpkgs/iptables/template
+++ b/srcpkgs/iptables/template
@@ -1,7 +1,7 @@
 # Template file for 'iptables'
 pkgname=iptables
 version=1.6.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --enable-libipq --enable-shared --enable-devel --enable-bpf-compiler"
 hostmakedepends="pkg-config flex"


### PR DESCRIPTION
Wait for the xtables lock for 3 seconds, otherwise exit. This will make the
iptables-restore process more robust.

See this [pull request](https://github.com/voidlinux/void-packages/pull/13051)
from the old void-packages repository