### PR TITLE
New package: fontmatrix-0.6.0.20171228

### DIFF
--- a/srcpkgs/fontmatrix/patches/musl.patch
+++ b/srcpkgs/fontmatrix/patches/musl.patch
@@ -1,0 +1,11 @@
+--- src/fmutils.cpp.orig	2017-08-13 19:07:51.821535347 +0200
++++ src/fmutils.cpp	2017-08-13 19:05:51.995947873 +0200
+@@ -12,7 +12,7 @@
+ 
+ #include "fmutils.h"
+ 
+-#if !defined(_WIN32) && !defined(Q_OS_MAC)
++#if !defined(_WIN32) && !defined(Q_OS_MAC) && defined(__GLIBC__)
+ #include <execinfo.h>
+ #include <cxxabi.h>
+ #include <cstdlib>

--- a/srcpkgs/fontmatrix/template
+++ b/srcpkgs/fontmatrix/template
@@ -1,0 +1,19 @@
+# Template file for 'fontmatrix'
+pkgname=fontmatrix
+version=0.6.0.20171228
+revision=1
+_commit=8108e6ea8b5944a92d7f27c40509b8e890ddaff1
+wrksrc="${pkgname}-${_commit}"
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="fontconfig-devel MesaLib-devel qt-webkit-devel"
+short_desc="Free font collections manager"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/fontmatrix/fontmatrix"
+distfiles="https://github.com/fontmatrix/fontmatrix/archive/${_commit}.tar.gz"
+checksum=1fa442e5bafb08265e1078d522ca0e8a8b864ab8544fb5ce4fd77ebb2f7bfc1d
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt-devel"
+fi


### PR DESCRIPTION
reworked version of https://github.com/voidlinux/void-packages/pull/7371

The 0.6.0 release is about nine years old and there have been quite some fixes so I used the latest commit.