### PR TITLE
spotify: update to 1.0.80

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,24 +1,18 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.0.72
+version=1.0.80
 revision=1
 short_desc="Proprietary music streaming client"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 homepage="https://www.spotify.com"
 license="Proprietary"
 create_wrksrc=yes
-only_for_archs="x86_64 i686"
+only_for_archs="x86_64"
 repository=nonfree
 build_style=fetch
 depends="binutils gtk+ nss GConf libXScrnSaver libatomic"
-
-if [ "${XBPS_TARGET_MACHINE}" = "x86_64" ]; then
-	_sversion=".117.g6bd7cc73-35_amd64"
-	_schecksum=5749c853479a6559b8642a531ba357e40d3c95116314e74e31197569dee62c7a
-else
-	_sversion=".117.g6bd7cc73-35_i386"
-	_schecksum=f5ac29e8374901ce7401825d13471c03bcf6ec8106f8c210c710b0a8d7b22ca9
-fi
+_sversion=".480.g51b03ac3-13_amd64"
+_schecksum=e32f4816ae79dbfa0c14086e76df3bc83d526402aac1dbba534127fc00fe50ea
 
 do_install() {
 	vbin ${FILESDIR}/spotify


### PR DESCRIPTION
Since the 32bit version apparently is not beeing updated anymore I've made the package 64bit only for the time beeing. Maybe a separate solution for the outdated 32bit version can be found later.