### PR TITLE
notepadqq: update to 1.4.0.

### DIFF
--- a/srcpkgs/notepadqq/files/notepadqq
+++ b/srcpkgs/notepadqq/files/notepadqq
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/lib/notepadqq/notepadqq-bin "$@"

--- a/srcpkgs/notepadqq/patches/disable-stats.patch
+++ b/srcpkgs/notepadqq/patches/disable-stats.patch
@@ -1,0 +1,11 @@
+# disable collection of system statics
+--- src/ui/stats.cpp
++++ src/ui/stats.cpp
+@@ -19,6 +19,7 @@
+ 
+ void Stats::init()
+ {
++    return; // statistics collection disabled by Void Linux
+     NqqSettings &settings = NqqSettings::getInstance();
+ 
+     Stats::askUserPermission();

--- a/srcpkgs/notepadqq/template
+++ b/srcpkgs/notepadqq/template
@@ -1,6 +1,6 @@
 # Template file for 'notepadqq'
 pkgname=notepadqq
-version=1.3.6
+version=1.4.0
 revision=1
 build_style=qmake
 hostmakedepends="pkg-config qt5-tools"
@@ -9,15 +9,17 @@ depends="desktop-file-utils hicolor-icon-theme"
 maintainer="Orphaned <orphan@voidlinux.eu>"
 short_desc="Text editor for developers"
 homepage="https://notepadqq.com"
-license="GPL-3"
+license="GPL-3.0-or-later"
 distfiles="https://github.com/notepadqq/notepadqq/archive/v${version}.tar.gz"
-checksum=a2c6b97fe1943c9548eb9cdebac046c192f5b2f71007a8e7d858e124b38ca38f
-
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) broken="https://github.com/voidlinux/void-packages/issues/9481" ;;
-esac
+checksum=f295353224848c06fafcc71c7f6a38780a98890075ab33f0179181ebf21bad08
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-svg-devel qt5-webkit-devel"
 fi
 
+post_install() {
+	# no need for upstream's weird magic, leads to segfaults anyway
+	rm "${DESTDIR}/usr/bin/notepadqq"
+	# use our simple start scipt
+	vbin ${FILESDIR}/notepadqq
+}


### PR DESCRIPTION
This was only tested on a x86_64 glibc system.
It would be great if somebody with a running musl desktop could verify it's not broken anymore as reported here: https://github.com/voidlinux/void-packages/issues/9481

This PR also,
- disables statistics collection
- provides an easier startup script, that does not segfault like upstream's startup script: https://github.com/notepadqq/notepadqq/blob/v1.4.0/support_files/launch/notepadqq