### PR TITLE
kdenlive: update to 18.04.3

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,22 +1,21 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
-version=18.04.0
+version=18.04.3
 revision=1
 build_style=cmake
 hostmakedepends="
- pkg-config extra-cmake-modules qt5-host-tools qt5-qmake python3
- shared-mime-info kdoctools kconfig"
+ extra-cmake-modules kconfig kdoctools pkg-config python3 qt5-host-tools
+ qt5-qmake"
 makedepends="
- karchive-devel kbookmarks-devel kcoreaddons-devel kconfig-devel
- kconfigwidgets-devel kdbusaddons-devel kio-devel kwidgetsaddons-devel
- kplotting-devel knotifyconfig-devel knewstuff-devel kxmlgui-devel
- knotifications-devel kguiaddons-devel ktextwidgets-devel kiconthemes-devel
- kdoctools-devel kcrash-devel kfilemetadata5-devel qt5-declarative-devel
- mlt-devel v4l-utils-devel qt5-webkit-devel"
-depends="breeze-icons frei0r-plugins kinit ffmpeg qt5-quickcontrols vlc dvdauthor"
+ kfilemetadata5-devel knewstuff-devel knotifyconfig-devel kplotting-devel
+ mlt-devel qt5-webkit-devel v4l-utils-devel"
+depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit qt5-quickcontrols vlc"
 short_desc="Non-linear video editor"
 maintainer="johannes <johannes.brechtmann@gmail.com>"
-license="GPL-2"
+license="GPL-3.0-or-later"
 homepage="https://kdenlive.org"
-distfiles="http://download.kde.org/stable/applications/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=50bd6b1ecbab63065f3404f42d31bcfbd253c1870e0dea21c04d461a7564a46c
+distfiles="${KDE_SITE}/applications/${version}/src/${pkgname}-${version}.tar.xz"
+checksum=9505ac2e5f4918932b868f0ccc1d74b1ae545283033081fab92415cc0d1d435f
+
+# needed for mlt to work on musl
+CXXFLAGS="-DHAVE_LOCALE_H=1"


### PR DESCRIPTION
[ci skip] because there are too many warnings during build for travis. ~~Local builds work.~~
Edit: my test script was wrong. aarch64[-musl] builds don't succeed.