### PR TITLE
nfdump: update to 1.6.17

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3153,7 +3153,6 @@ libzuluCryptPluginManager.so.1.0.0 zulucrypt-5.2.0_1
 libzuluCrypt-exe.so.1.2.0 zulucrypt-5.2.0_1
 libzuluCrypt.so.1.2.0 zulucrypt-5.2.0_1
 libaacs.so.0 libaacs-0.9.0_1
-libnfdump-1.6.15.so nfdump-1.6.15_1
 libttfautohint.so.1 ttfautohint-1.8.1_1
 libcob.so.4 gnucobol-libs-2.2_1
 libkrfbprivate.so.5.0 krfb-17.08.1_1

--- a/srcpkgs/nfdump/template
+++ b/srcpkgs/nfdump/template
@@ -1,17 +1,21 @@
 # Template file for 'nfdump'
 pkgname=nfdump
-version=1.6.16
-revision=2
+version=1.6.17
+revision=1
 build_style=gnu-configure
 configure_args+="--enable-sflow --enable-readpcap --enable-nfcapd"
-hostmakedepends="flex"
-makedepends="libpcap-devel bzip2-devel"
+hostmakedepends="automake flex libtool pkg-config"
+makedepends="bzip2-devel libpcap-devel"
 short_desc="A toolset in order to collect and process netflow and sflow data"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="https://github.com/phaag/nfdump"
 distfiles="https://github.com/phaag/nfdump/archive/v${version}.tar.gz"
-checksum=b18479215c51a98fbdf973ef548464780e7a9d9f7fe73e4fab9ab7ec8a3bdc8f
+checksum=f71c2c57bdcd0731b2cfecf6d45f9bf57fc7c946858644caf829f738c67c393d
+
+pre_configure() {
+	autoreconf -fi
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- Make license SPDX compliant
- Remove unnecessary shlibs entry