### PR TITLE
apparmor: run dhcpcd hook wrapper unconfined

### DIFF
--- a/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
@@ -39,50 +39,12 @@ profile dhcpcd /{usr/,}bin/dhcpcd {
   /usr/lib/ld-*.so m,
   /usr/lib/libc-*.so m,
 
-  # Transition to a child profile for hooks
-  /usr/libexec/dhcpcd-run-hooks Cx -> dhcpcd_run_hooks,
+  # Trust hooks and run the wrapper unconfined
+  /usr/libexec/dhcpcd-run-hooks CUx,
 
   /var/db/dhcpcd-*.lease rw,
   /var/db/dhcpcd/** rw,
   /{usr/,}bin/dhcpcd mrix,
-
-  # Child profile for hooks
-  profile dhcpcd_run_hooks {
-    #include <abstractions/base>
-    #include <abstractions/nameservice>
-
-    capability sys_admin,
-    capability sys_tty_config,
-
-    /etc/chrony.conf rw,
-    /etc/ntpd.conf rw,
-    /etc/resolv.conf rw,
-    /etc/wpa_supplicant/wpa_supplicant*.conf r,
-
-    /{var/,}run/dhcpcd/ rw,
-    /{var/,}run/dhcpcd/{ntp,resolv}.conf.** rw,
-    /{var/,}run/dhcpcd/{ntp,resolv}.conf/ rw,
-    /{var/,}run/dhcpcd/{ntp,resolv}.conf/*.dhcp rw,
-
-    /usr/bin/cat mrix,
-    /usr/bin/chmod mrix,
-    /usr/bin/cmp mrix,
-    /usr/bin/dash mr,
-    /usr/bin/hostname-coreutils mrix,
-    /usr/bin/mkdir mrix,
-    /usr/bin/rm mrix,
-    /usr/bin/sed mrix,
-    /usr/bin/util-linux-logger mrix,
-    /usr/bin/wpa_supplicant CUx,
-    /usr/bin/wpa_cli CUx,
-    /usr/bin/resolvconf CUx,
-
-    /usr/libexec/dhcpcd-hooks/ r,
-    /usr/libexec/dhcpcd-hooks/* r,
-    /usr/libexec/dhcpcd-run-hooks r,
-
-    /usr/share/dhcpcd/hooks/* r,
-  }
 
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.bin.dhcpcd>

--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.0
-revision=1
+revision=2
 _short_ver=${version%\.*}
 wrksrc="${pkgname}-v${_short_ver}"
 configure_args="--prefix=/usr --with-perl --with-python"


### PR DESCRIPTION
Fix for https://github.com/void-linux/void-packages/issues/198