### PR TITLE
New package: python-miniupnpc-2.0.2

### DIFF
--- a/srcpkgs/python-miniupnpc/template
+++ b/srcpkgs/python-miniupnpc/template
@@ -1,0 +1,28 @@
+# Template file for 'python-miniupnpc'
+pkgname=python-miniupnpc
+version=2.0.2
+revision=1
+wrksrc="${pkgname#python-}-$version"
+build_style=python-module
+hostmakedepends="python-setuptools python3-setuptools"
+makedepends="python-devel python3-devel miniupnpc-devel"
+depends="python"
+short_desc="Python2 bindings for miniupnpc, a UPnP library"
+maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
+license="BSD-3-Clause"
+homepage="https://pypi.org/project/miniupnpc/"
+distfiles="${PYPI_SITE}/m/${pkgname#python-}/${pkgname#python-}-${version}.tar.gz"
+checksum=7ea46c93486fe1bdb31f0e0c2d911d224fce70bf5ea120e4295d647dfe274931
+
+python3-miniupnpc_package() {
+	depends="python3"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vlicense LICENSE
+		vmove usr/lib/python3*
+	}
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-miniupnpc
+++ b/srcpkgs/python3-miniupnpc
@@ -1,0 +1,1 @@
+python-miniupnpc


### PR DESCRIPTION
A Python UPnP library (bindings for miniupnpc).