### PR TITLE
mate-terminal: readd dependency to mate-desktop

### DIFF
--- a/srcpkgs/mate-terminal/template
+++ b/srcpkgs/mate-terminal/template
@@ -1,11 +1,11 @@
 # Template file for 'mate-terminal'
 pkgname=mate-terminal
 version=1.20.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="glib-devel intltool itstool pkg-config"
 makedepends="libSM-devel vte3-devel dconf-devel"
-depends="dbus"
+depends="dbus mate-desktop"
 short_desc="The MATE Terminal Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
@asergi `mate-desktop` is still needed see #226

@maxice8 