### PR TITLE
dracut: force shutdown

### DIFF
--- a/srcpkgs/dracut/patches/force_poweroff.patch
+++ b/srcpkgs/dracut/patches/force_poweroff.patch
@@ -1,0 +1,19 @@
+diff --git modules.d/99base/dracut-lib.sh modules.d/99base/dracut-lib.sh
+index 99cb9dbc..3df77257 100755
+--- modules.d/99base/dracut-lib.sh
++++ modules.d/99base/dracut-lib.sh
+@@ -1154,11 +1154,11 @@ emergency_shell()
+ 
+     case "$_emergency_action" in
+         reboot)
+-            reboot || exit 1;;
++            reboot -f || exit 1;;
+         poweroff)
+-            poweroff || exit 1;;
++            poweroff -f || exit 1;;
+         halt)
+-            halt || exit 1;;
++            halt -f || exit 1;;
+     esac
+ }
+ 


### PR DESCRIPTION
The shutdown binary is actually provided by runit and expects the runit
init to be running. This is not the case in the initramfs. Forcing the
shutdown, halt or reboot is necessary to ignore this requirement.