### PR TITLE
docker: add apparmor build_option and enable it for arches that have libapparmor available.

### DIFF
--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,13 +1,13 @@
 # Template file for 'docker'
 pkgname=docker
 version=18.05.0
-revision=2
+revision=3
 _subversion='-ce'
 _version="$version$_subversion"
 wrksrc="$pkgname$_subversion-$_version"
-build_wrksrc="components/engine"
+build_wrksrc=components/engine
 hostmakedepends="git go pkg-config curl cmake"
-makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel libapparmor-devel"
+makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel $(vopt_if apparmor libapparmor-devel)"
 short_desc="Pack, ship and run any application as a lightweight container"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
@@ -25,8 +25,15 @@ system_groups="docker"
 
 _docker_components="runc containerd tini proxy dockercli"
 
+build_options="apparmor"
+desc_option_apparmor="apparmor linux kernel security module support"
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) ;;
+	*) build_options_default="apparmor"
+esac
+
 do_build() {
-	AUTO_GOPATH=1 DOCKER_BUILDTAGS='seccomp apparmor' DOCKER_GITCOMMIT=v$_version \
+	AUTO_GOPATH=1 DOCKER_BUILDTAGS='seccomp $(vopt_if apparmor apparmor)' DOCKER_GITCOMMIT=v$_version \
 		hack/make.sh dynbinary
 }
 


### PR DESCRIPTION
This build option allows toggling support for apparmor in docker, it is used so that arches that don't have apparmor (x86_64-musl) can have docker still.

the best case scenario would be apparmor support for musl like alpine seems to have https://git.alpinelinux.org/cgit/aports/tree/testing/apparmor?h=master (possibly a fun project for @olivier-mauras ?)