### PR TITLE
New package: factor-0.97

### DIFF
--- a/srcpkgs/factor/template
+++ b/srcpkgs/factor/template
@@ -1,0 +1,49 @@
+# Template file for 'factor'
+pkgname=factor
+version=0.97
+revision=1
+only_for_archs="i686 x86_64 i686-musl x86_64-musl"
+build_style=gnu-makefile
+hostmakedepends="unzip pkg-config"
+makedepends="gtkglext-devel"
+nostrip_files="a.elf"
+short_desc="Concatenative programming language, similar to Forth"
+maintainer="B. Wilson <x@wilsonb.com>"
+license="BSD-2-Clause"
+homepage="http://factorcode.org/"
+distfiles="http://downloads.factorcode.org/releases/${version}/factor-src-${version}.zip"
+checksum=fd75e765590691c89b866e5265ae16bfb36d0e28eed095702ae1e206114663b8
+
+post_extract() {
+	mv "${XBPS_BUILDDIR}/factor" "${wrksrc}"
+}
+
+post_build() {
+	image=''
+
+	case "${XBPS_TARGET_MACHINE}" in
+		i686*)   image='boot.unix-x86.32.image';;
+		x86_64*) image='boot.unix-x86.64.image';;
+		*) return 1;;
+	esac
+
+	touch /etc/ld.so.cache
+	./factor -i="${image}"
+}
+
+do_install() {
+	vmkdir "usr/lib/${pkgname}"
+	vcopy misc  "usr/lib/${pkgname}"
+	vcopy extra "usr/lib/${pkgname}"
+	vcopy core  "usr/lib/${pkgname}"
+	vcopy basis "usr/lib/${pkgname}"
+
+	vinstall factor       755 "usr/lib/${pkgname}"
+	vinstall factor.image 644 "usr/lib/${pkgname}"
+
+	vmkdir usr/bin
+	ln -sr "${DESTDIR}/usr/lib/${pkgname}/factor" \
+	       "${DESTDIR}/usr/bin/factor-vm"
+
+	vlicense license.txt
+}


### PR DESCRIPTION
## Overview

This is a package for [Factor][1], a concatenative programming language in the tradition of Forth.

## Packaging Considerations

Upstream expects the executable to cohabit a directory with support files, so these are shoved into `/usr/lib/factor` and the binary is symlinked to `/usr/bin`.  Unfortunately however, the binary name conflicts with [coreutils' factor][3] utility, so I followed the lead of ArchLinux and named it `factor-vm`. Overall, the manual `do_install()` mirrors the ArchLinux [PKGBUILD][2].

Ostensibly, upstream supports 32-bit systems; however, I was only able to get this to build on `x86_64`. The only other wonky thing with the package is a non-PIE executable, `a.elf`, bundled in the upstream source. It's perhaps unneeded post-build, but I'm not familiar enough with upstream development to know either way, hence the `nostrip_files` line.

## Final Thoughts

I just threw this together, because I wanted to play with the language and don't mind maintaining another package. However, if there are better---or more idiomatic---ways to package this up, please let me know.


[1]:http://factorcode.org/
[2]:https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=factor
[3]:https://www.gnu.org/software/coreutils/manual/html_node/factor-invocation.html