### PR TITLE
exfat-dkms: bump commit for kernel 4.16+.

### DIFF
--- a/srcpkgs/exfat-dkms/template
+++ b/srcpkgs/exfat-dkms/template
@@ -1,15 +1,15 @@
 # Template file for 'exfat-dkms'
 pkgname=exfat-dkms
 version=1.2.8
-revision=3
-_commit=de4c760bc9a05ead83bc3ec6eec6cf1fb106f523
-wrksrc=exfat-nofuse-${_commit}
+revision=4
+_commit=01c30ad52625a7261e1b0d874553b6ca7af25966
+wrksrc="exfat-nofuse-${_commit}"
 short_desc="Exfat kernel driver (nofuse)"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/dorimanx/exfat-nofuse"
-distfiles="$homepage/archive/$_commit.tar.gz"
-checksum=789e6f1679dde175e44fa18038bb07bae9c524a1fb7b99da1e5e60a5ea219ccb
+distfiles="https://github.com/dorimanx/exfat-nofuse/archive/${_commit}.tar.gz"
+checksum=b88a98f0a7e1b987465f5ccfcafb384b293506c7fec9d3b91b803e0fe5b16e0a
 
 triggers="dkms"
 dkms_modules="exfat ${version}"


### PR DESCRIPTION
https://github.com/voidlinux/void-packages/issues/13968