### PR TITLE
common/slibs: remove kde-workspace entries

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1361,12 +1361,6 @@ libakonadiprotocolinternals.so.1 akonadi-1.9.2_1
 libqimageblitz.so.4 qimageblitz-0.0.6_1
 libxcb-render-util.so.0 xcb-util-renderutil-0.3.8_1
 libkexiv2.so.11 libkexiv2-4.10.4_1
-libkscreensaver.so.5 kde-workspace-4.10.4_1
-libkdecorations.so.4 kde-workspace-4.10.4_1
-libplasmaclock.so.4 kde-workspace-4.10.4_1
-libtaskmanager.so.4 kde-workspace-4.10.4_1
-libkworkspace.so.4 kde-workspace-4.10.4_1
-libprocessui.so.4 kde-workspace-4.10.4_1
 libKPimGAPIContacts.so.5 libkgapi-17.12.3_1
 libKPimGAPIBlogger.so.5 libkgapi-17.12.3_1
 libKPimGAPILatitude.so.5 libkgapi-17.12.3_1


### PR DESCRIPTION
`kde-workspace` got already removed ~23 days ago.