### PR TITLE
freetype: explicitly enable freetype-config

### DIFF
--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,7 +1,7 @@
 # Template file for 'freetype'
 pkgname=freetype
 version=2.9.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="bzip2-devel libpng-devel"
@@ -20,6 +20,8 @@ desc_option_v40="Use default interpreter version 40 (Minimal mode)"
 vopt_conflict v35 v38
 vopt_conflict v35 v40
 vopt_conflict v38 v40
+
+configure_args="--enable-freetype-config"
 
 pre_configure() {
 	CFLAGS+=" -DDEFAULT_TT_INTERPRETER_VERSION=TT_INTERPRETER_VERSION_"


### PR DESCRIPTION
Fixes `freetype-config` not being built by default.

~~Also I have another commit, a small suggestion for not building static libs and `harfbuzz` linking*, but you can ignore that commit if you want.~~

~~**Edit**: `harfbuzz` linking works only when building this package alone, but will cause dependency loop if built indirectly. Can this be fixed?~~