### PR TITLE
gc: add full include directory

### DIFF
--- a/srcpkgs/gc/template
+++ b/srcpkgs/gc/template
@@ -1,7 +1,7 @@
 # Template file for 'gc'
 pkgname=gc
 version=7.6.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake pkg-config libtool"
 makedepends="libatomic_ops-devel"
@@ -22,6 +22,13 @@ post_extract() {
 
 pre_configure() {
 	autoreconf -fi
+}
+
+post_install() {
+	mkdir -p ${DESTDIR}/usr/include/gc/
+	mv ${wrksrc}/include/* ${DESTDIR}/usr/include/gc/
+	mv ${DESTDIR}/usr/include/gc/extra/* ${DESTDIR}/usr/include/
+	rmdir ${DESTDIR}/usr/include/gc/extra
 }
 
 gc-devel_package() {


### PR DESCRIPTION
Required e.g. for building `asymptote`.