### PR TITLE
xbps-triggers: don't delete users and groups on package removal.

### DIFF
--- a/srcpkgs/xbps-triggers/files/system-accounts
+++ b/srcpkgs/xbps-triggers/files/system-accounts
@@ -53,14 +53,11 @@ run)
 	if [ -x sbin/useradd -o -x bin/useradd ]; then
 		USERADD=1
 	fi
-	if [ -x sbin/userdel -o -x bin/userdel ]; then
-		USERDEL=1
+	if [ -x sbin/usermod -o -x bin/usermod ]; then
+		USERMOD=1
 	fi
 	if [ -x sbin/groupadd -o -x bin/groupadd ]; then
 		GROUPADD=1
-	fi
-	if [ -x sbin/groupdel -o -x bin/groupdel ]; then
-		GROUPDEL=1
 	fi
 	if [ -x bin/getent -o -x sbin/getent ]; then
 		GETENT=1
@@ -120,36 +117,34 @@ run)
 					echo "Failed to create ${acct} system user!"
 					exit 1
 				fi
+			else
+				if [ -z "$USERMOD" ]; then
+					echo "WARNING: cannot update ${acct} system user/group (missing usermod)"
+					continue
+				fi
+				usermod -c "${descr}" -s "${shell}" ${_uname} >/dev/null 2>&1
+				if [ $? -eq 0 ]; then
+					echo "Updated shell and comment for ${_uname} (${_uid}) system user."
+				else
+					echo "Failed to update shell and comment for ${acct} system user!"
+					exit 1
+				fi
 			fi
 		done
 		;;
 	pre-remove)
-		#
-		# Only unregister if we aren't updating a package.
-		#
 		if [ "$UPDATE" = "no" ]; then
 			for acct in ${system_accounts}; do
 				_uname="${acct%:*}"
 				_uid="${acct#*:}"
-				if [ -z "$USERDEL" ]; then
-					echo "WARNING: cannot remove ${acct} system user/group (missing userdel)"
+				comment="$(getent passwd "${_uname}" |cut -d: -f5 |head -n1) - for uninstalled package ${PKGNAME}"
+				if [ -z "$USERMOD" ]; then
+					echo "WARNING: cannot disable ${acct} system user/group (missing usermod)"
 					continue
 				fi
-				userdel -f ${_uname} >/dev/null 2>&1
+				usermod -L -s /bin/false -c "${comment}" ${_uname} >/dev/null 2>&1
 				if [ $? -eq 0 ]; then
-					echo "Removed ${_uname} (${_uid}) system user/group."
-				fi
-			done
-			for grp in ${system_groups}; do
-				_uname="${grp%:*}"
-				_uid="${grp#*:}"
-				if [ -z "$GROUPDEL" ]; then
-					echo "WARNING: cannot remove ${grp} system group (missing groupdel)"
-					continue
-				fi
-				groupdel ${_uname} >/dev/null 2>&1
-				if [ $? -eq 0 ]; then
-					echo "Removed ${_uname} (${_uid}) system group."
+					echo "Disabled ${_uname} (${_uid}) system user/group."
 				fi
 			done
 		fi

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.104
+version=0.105
 revision=1
 noarch=yes
 bootstrap=yes


### PR DESCRIPTION
Also, change the shell to /bin/false and insure that the account is locked.
Fixes #345.