### PR TITLE
pam_rundir: patching issue 2/3

### DIFF
--- a/srcpkgs/pam_rundir/patches/fix.diff
+++ b/srcpkgs/pam_rundir/patches/fix.diff
@@ -1,0 +1,21 @@
+--- pam_rundir.c
++++ pam_rundir.c
+@@ -24,6 +24,8 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/file.h>
++#include <sys/prctl.h>
++#include <linux/securebits.h>
+ #include <string.h>
+ #include <pwd.h>
+ #include <fcntl.h>
+@@ -396,6 +398,9 @@ pam_sm_open_session (pam_handle_t *pamh, int flags, int argc, const char **argv)
+             goto done;
+         }
+
++        /* to bypass permission checks for mkdir, in case it isn't group
++         * writable */
++        prctl (PR_SET_SECUREBITS, SECBIT_NO_SETUID_FIXUP);
+         /* set euid so if we do create the dir, it is own by the user */
+         if (seteuid (pw->pw_uid) < 0)
+         {

--- a/srcpkgs/pam_rundir/template
+++ b/srcpkgs/pam_rundir/template
@@ -1,7 +1,7 @@
 # Template file for 'pam_rundir-1.0.0'
 pkgname=pam_rundir
 version=1.0.0
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --with-parentdir=/run/user"
 makedepends="pam-devel"


### PR DESCRIPTION
https://github.com/jjk-jacky/pam_rundir/issues/2
https://github.com/jjk-jacky/pam_rundir/issues/3
It’s temporary, until the author decide to merge his own [patch](//github.com/jjk-jacky/pam_rundir/issues/3#issuecomment-381408688).
P.S.: Don’t forget to append `session optional pam_rundir.so` to `/etc/pam.d/system-login` if you want to use it.