### PR TITLE
mixxx: update to 2.1.1.

### DIFF
--- a/srcpkgs/mixxx/template
+++ b/srcpkgs/mixxx/template
@@ -1,6 +1,6 @@
 # Template file for 'mixxx'
 pkgname=mixxx
-version=2.1.0
+version=2.1.1
 revision=1
 wrksrc="mixxx-release-${version}"
 hostmakedepends="pkg-config scons"
@@ -13,9 +13,9 @@ depends="qt5-plugin-sqlite"
 short_desc="Open source digital DJing software that allows mixing music"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-2.0-or-later"
-homepage="http://www.mixxx.org"
+homepage="https://www.mixxx.org"
 distfiles="https://github.com/mixxxdj/mixxx/archive/release-${version}.tar.gz"
-checksum=148b0ab222fa1c310e62b566d87c0a3d43fdee9435150d40d62055dbc228d396
+checksum=f92f8d9fd34b2b2e7e71dd8c7fd2ce0911180bbbd28407906afeab4db9195236
 _scons_args="shoutcast=1 faad=1 tuned=0 prefix=/usr qt5=1 qtdir=/usr/include/qt5"
 
 nocross="https://build.voidlinux.eu/builders/armv7l_builder/builds/7882/steps/shell_3/logs/stdio"


### PR DESCRIPTION
N̶o̶t̶ ̶t̶e̶s̶t̶e̶d̶ ̶o̶n̶ ̶m̶u̶s̶l̶.̶

Doesn't work on x86_64 musl, unfortunately.
````
Warning [Main]: PortAudio: Start stream error: Internal PortAudio error
Segmentation fault
````