### PR TITLE
linux4.17: use subarch in do_install if available

### DIFF
--- a/srcpkgs/linux4.17/template
+++ b/srcpkgs/linux4.17/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.17'
 pkgname=linux4.17
-version=4.17.3
+version=4.17.4
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz"
-checksum=af32ab2427cd0916c030c751b6b8fd4e72b7359feefd642aefad74838e921ffd
+checksum=66d6370c53626b9f54a32aa2d3e586d0f884e727cf1b042b624d420d09f0ab58
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes
@@ -109,7 +109,7 @@ do_install() {
 	sed -i '2iexit 0' scripts/depmod.sh
 
 	# Install kernel, firmware and modules
-	make ${makejobs} ARCH=$arch INSTALL_MOD_PATH=${DESTDIR} modules_install
+	make ${makejobs} ARCH=${subarch:-$arch} INSTALL_MOD_PATH=${DESTDIR} modules_install
 
 	hdrdest=${DESTDIR}/usr/src/kernel-headers-${_kernver}
 


### PR DESCRIPTION
[ci skip]
Just using the general architecture broke installation on i686, for
further information please refer to
http://lkml.iu.edu/hypermail/linux/kernel/1806.0/05687.html
and the thread associated with it.