### PR TITLE
Rebuild xkeyboard-config and cryptsetup for aarch64

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,7 +1,7 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
 version=2.0.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl $(vopt_enable pwquality)
  --enable-cryptsetup-reencrypt"

--- a/srcpkgs/xkeyboard-config/template
+++ b/srcpkgs/xkeyboard-config/template
@@ -1,7 +1,7 @@
 # Template file for 'xkeyboard-config'
 pkgname=xkeyboard-config
 version=2.24
-revision=1
+revision=2
 noarch=yes
 build_style=gnu-configure
 configure_args="--with-xkb-rules-symlink=xfree86,xorg --enable-compat-rules"


### PR DESCRIPTION
The invalid RSA signature is getting quite annoying. Since both are rather small packages why not just rebuild them for now?