### PR TITLE
[DO NOT MERGE] mono: update to 5.12.0.226

### DIFF
--- a/srcpkgs/mono/template
+++ b/srcpkgs/mono/template
@@ -1,6 +1,6 @@
 # Template file for 'mono'
 pkgname=mono
-version=5.10.1.47
+version=5.12.0.226
 revision=1
 wrksrc="mono-${version}"
 lib32disabled=yes
@@ -15,7 +15,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.mono-project.com"
 license="MIT, 3-clause-BSD, GPL-2, LGPL-2, MPL-1.1"
 distfiles="http://download.mono-project.com/sources/mono/$pkgname-$version.tar.bz2"
-checksum=90c237b5288f95f6fdab4ace1e36ab64a6369e2c9fddd462d604fd788e2545da
+checksum=f0636baa0c1399805526142e799cb697ddccf736e506cf1a30a870eaa2830a89
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) configure_args+=" --disable-boehm --without-sigaltstack" ;;


### PR DESCRIPTION
I don't know if I have to revbump packages that depend on mono. 