### PR TITLE
lilypond: update to 2.19.82

### DIFF
--- a/srcpkgs/lilypond-doc/template
+++ b/srcpkgs/lilypond-doc/template
@@ -1,16 +1,15 @@
 # Template file for 'lilypond-doc'
 pkgname="lilypond-doc"
-version="2.19.80"
-revision=2
-_docrev=1
+version="2.19.82.1"
+revision=1
 noarch=yes
 create_wrksrc=yes
 short_desc="Documentation for the lilypond music engraving program"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="GPL-3"
+license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="http://lilypond.org/"
-distfiles="http://lilypond.org/downloads/binaries/documentation/lilypond-${version}-${_docrev}.documentation.tar.bz2"
-checksum=1875a1ca00f5c0de80e52c609e7756c70447c2e18a0726c4ee61fd5c275c9e03
+distfiles="http://lilypond.org/downloads/binaries/documentation/lilypond-${version%.*}-${version##*.}.documentation.tar.bz2"
+checksum=b95539396580882e498661cfd150cd4a46f4efbc54ec1e170a8fdb57d31dc1ed
 
 do_install() {
 	vmkdir usr

--- a/srcpkgs/lilypond-doc/update
+++ b/srcpkgs/lilypond-doc/update
@@ -1,0 +1,2 @@
+version="${version%.*}-${version##*.}"
+pattern="lilypond-\K[\d.-]+(?=.documentation)"

--- a/srcpkgs/lilypond/template
+++ b/srcpkgs/lilypond/template
@@ -1,24 +1,23 @@
 # Template file for 'lilypond'
 pkgname="lilypond"
-version="2.19.80"
-revision=2
-_tlversion=2017
+version="2.19.82"
+revision=1
+_tlversion=2018
 build_wrksrc="build"
 build_style="gnu-configure"
 configure_script="../configure"
-configure_args="--disable-documentation
+configure_args="--disable-documentation ac_cv_func_isinf=yes
  --with-texgyre-dir=/opt/texlive/${_tlversion}/texmf-dist/fonts/opentype/public/tex-gyre"
-hostmakedepends="automake autogen pkg-config flex bison fontforge gettext
- perl texlive-bin gnupg guile1.8"
-makedepends="guile1.8-devel fontconfig-devel freetype-devel pango-devel
- python-devel libltdl-devel gc-devel"
+hostmakedepends="autogen automake flex fontforge gettext gnupg guile1.8 pkg-config
+ texlive-bin"
+makedepends="gc-devel guile1.8-devel libltdl-devel pango-devel python-devel"
 depends="python ghostscript"
 short_desc="Music engraving program"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 homepage="http://lilypond.org/"
-license="GPL-3, FDL-1.3"
-distfiles="http://download.linuxaudio.org/${pkgname}/source/v2.19/${pkgname}-${version}.tar.gz"
-checksum=3679db30a3f74ce8668691952fb0dd58d8ad6bad099017e815ca3e4312261453
+license="GPL-3.0-or-later, GFDL-1.3-or-later"
+distfiles="http://lilypond.org/downloads/sources/v2.19/lilypond-${version}.tar.gz"
+checksum=a5679cddb3e415828642f75027997596b814922aadb1fa633c8f973238ae291b
 
 if [ -n "${CROSS_BUILD}" ]; then
 	# needs guile-config-1.8 and python-config
@@ -29,6 +28,7 @@ if [ -n "${CROSS_BUILD}" ]; then
 fi
 
 case "$XBPS_TARGET_MACHINE" in
+	x86_64-musl) ;;
 	*-musl) broken="no texlive available yet";;
 esac
 


### PR DESCRIPTION
Also minimized dependencies.

With texlive-2018 it can be built for x86_64-musl now, tested in musl chroot. However, `configure` doesn’t detect `isinf` so I overrode the test and set `ac_cv_func_isinf` manually in `configure_args`.

Added an `update` file to lilypond-doc to fix the update-check.

cc @lemmi