### PR TITLE
perl-File-MimeInfo: add missing dependency (perl-File-DesktopEntry)

### DIFF
--- a/srcpkgs/perl-File-MimeInfo/template
+++ b/srcpkgs/perl-File-MimeInfo/template
@@ -1,12 +1,12 @@
 # Template file for 'perl-File-MimeInfo'
 pkgname=perl-File-MimeInfo
 version=0.28
-revision=1
+revision=2
 noarch=yes
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
-makedepends="${hostmakedepends} perl-File-BaseDir"
+makedepends="${hostmakedepends} perl-File-BaseDir perl-File-DesktopEntry"
 depends="${makedepends}"
 short_desc="Perl utility to detect file mimetypes and open them accordingly"
 maintainer="crater2150 <void@qwertyuiop.de>"


### PR DESCRIPTION
The package installs the `mimeopen` and `mimeutils` tools. However, these depend on `perl-File-DesktopEntry` which is missing from the template.

```
$ mimeopen somefile.jpg
Can't locate File/DesktopEntry.pm in @INC (you may need to install the File::DesktopEntry module) (@INC contains: /usr/lib/perl5/site_perl /usr/share/perl5/site_perl /usr/lib/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/core_perl /usr/share/perl5/core_perl .) at /usr/share/perl5/vendor_perl/File/MimeInfo/Applications.pm line 8.
BEGIN failed--compilation aborted at /usr/share/perl5/vendor_perl/File/MimeInfo/Applications.pm line 8.
Compilation failed in require at (eval 3) line 1.
BEGIN failed--compilation aborted at (eval 3) line 1.
```

cc @crater2150 