### PR TITLE
corebird: add missing dependency (dconf)

### DIFF
--- a/srcpkgs/corebird/template
+++ b/srcpkgs/corebird/template
@@ -1,11 +1,12 @@
 # Template build for 'corebird'.
 pkgname=corebird
 version=1.7.4
-revision=3
+revision=4
 build_style=meson
 hostmakedepends="pkg-config vala"
 makedepends="gtk+3-devel libgee08-devel sqlite-devel gspell-devel
  libsoup-devel json-glib-devel gettext-devel gst-plugins-base1-devel"
+depends="dconf"
 short_desc="Native Gtk+ Twitter Client"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
When `dconf` is not installed, Corebird throws a warning and no accounts/settings will be stored on disk. This is confusing, so add `dconf` as runtime dependency.

```
GLib-GIO-Message: 00:40:53.602: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
```