### PR TITLE
New package: xidle-6.3

### DIFF
--- a/srcpkgs/xidle/template
+++ b/srcpkgs/xidle/template
@@ -1,0 +1,20 @@
+# Template file for 'xidle'
+pkgname=xidle
+version=6.3
+revision=1
+wrksrc="${pkgname}-linux-${version}"
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="pkg-config"
+makedepends="libXScrnSaver-devel"
+short_desc="Run a program on X inactivity"
+maintainer="Frank Steinborn <steinex@nognu.de>"
+license="BSD-2-Clause"
+homepage="https://github.com/steinex/xidle-linux"
+distfiles="https://github.com/steinex/xidle-linux/archive/${version}.tar.gz"
+checksum=f17a99fafb658d467fdbc4001809fa133b52ce0193ac895e6fa9501045ec8218
+
+pre_build() {
+	sed -n '3,25p' < xidle.c > LICENSE
+	vlicense LICENSE
+}


### PR DESCRIPTION
This is a package for `xidle`, a replacement for `xautolock` maintained in the OpenBSD CVS repository. There are no independent releases of this, so the template pulls it from the CVS repo directly. It checks out using the tag of the latest OpenBSD release (or the latest release where a change to xidle did occur). As xidle has no version itself, it uses the matching OpenBSD release as version number.

The package uses a custom Makefile to make it compile with GNU make. And there is a patch to remove pledge() from the source.