### PR TITLE
mpv: update to 0.28.2.

### DIFF
--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,30 +1,44 @@
 # Template file for 'mpv'
 pkgname=mpv
-version=0.27.2
-revision=2
-build_options="smb vapoursynth"
+version=0.28.2
+revision=1
 short_desc="Video player based on MPlayer/mplayer2"
+build_options="alsa caca jack lua oss pulseaudio sdl sdl2 smb sndio vapoursynth
+ vdpau v4l2 wayland x11"
+build_options_default="alsa jack lua pulseaudio sndio vdpau wayland x11 v4l2"
+desc_option_caca="Enable support for libcaca video output"
+desc_option_oss="Enable support for OSS audio output"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2, LGPL-2.1"
+license="GPL-2.0-or-later"
 homepage="https://mpv.io"
 build_style=waf
 configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
  --enable-dvdread --enable-dvdnav --enable-cdda --enable-libmpv-shared
- --enable-dvbin --enable-tv --enable-sndio
- --disable-oss-audio --disable-sdl2
- $(vopt_enable smb libsmbclient) $(vopt_enable vapoursynth)"
-hostmakedepends="pkg-config python-docutils perl"
-makedepends="
- ffmpeg-devel libass-devel lcms2-devel libXinerama-devel lua52-devel v4l-utils-devel
- libXv-devel libxkbcommon-devel libva-glx-devel libvdpau-devel alsa-lib-devel
- pulseaudio-devel libbluray-devel libcdio-paranoia-devel libdvdread-devel
- MesaLib-devel harfbuzz-devel libXScrnSaver-devel jack-devel libdvdnav-devel
- wayland-devel libwayland-egl libuuid-devel libguess-devel libXrandr-devel
- rubberband-devel sndio-devel
- $(vopt_if smb samba-devel) $(vopt_if vapoursynth vapoursynth-devel)"
+ --enable-dvbin $(vopt_enable alsa) $(vopt_enable caca) $(vopt_enable jack)
+ $(vopt_enable lua) $(vopt_enable oss oss-audio)
+ $(vopt_enable pulseaudio pulse) $(vopt_enable sdl sdl1) $(vopt_enable sdl2)
+ $(vopt_enable smb libsmbclient) $(vopt_enable sndio) $(vopt_enable v4l2 tv)
+ $(vopt_enable vapoursynth) $(vopt_enable vdpau) $(vopt_enable wayland)
+ $(vopt_enable x11)"
+hostmakedepends="pkg-config python-docutils perl $(vopt_if wayland wayland-devel)"
+makedepends="MesaLib-devel ffmpeg-devel harfbuzz-devel lcms2-devel libXv-devel
+ libass-devel libbluray-devel libcdio-paranoia-devel libdvdnav-devel
+ libdvdread-devel libguess-devel libuuid-devel libva-glx-devel rubberband-devel
+ $(vopt_if alsa alsa-lib-devel) $(vopt_if caca libcaca-devel)
+ $(vopt_if jack jack-devel) $(vopt_if lua lua52-devel)
+ $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if sdl SDL-devel)
+ $(vopt_if sdl2 SDL2-devel) $(vopt_if smb samba-devel)
+ $(vopt_if sndio sndio-devel) $(vopt_if v4l2 v4l-utils-devel)
+ $(vopt_if vapoursynth vapoursynth-devel) $(vopt_if vdpau libvdpau-devel)
+ $(vopt_if wayland "wayland-devel wayland-protocols libwayland-egl
+	libxkbcommon-devel")
+ $(vopt_if x11 "libXScrnSaver-devel libXinerama-devel libXrandr-devel")
+"
 depends="desktop-file-utils hicolor-icon-theme $(vopt_if vapoursynth vapoursynth-mvtools)"
 distfiles="https://github.com/mpv-player/${pkgname}/archive/v${version}.tar.gz"
-checksum=2ad104d83fd3b2b9457716615acad57e479fd1537b8fc5e37bfe9065359b50be
+checksum=aada14e025317b5b3e8e58ffaf7902e8b6e4ec347a93d25a7c10d3579426d795
+vopt_conflict sdl sdl2
+vopt_conflict sdl2 wayland
 
 if [ -z "$CROSS_BUILD" ]; then
 	configure_args+=" --enable-zsh-comp"


### PR DESCRIPTION
- also implement some build options
- our build of mpv is always gpl2+ (except with `smb` build option, then its gpl3+)
- this should also fix wayland functionality
- ~~musl machines are missing `ffmpeg-devel-4.0.1_1` for a successful build~~