### PR TITLE
netbsd-wtf: fix acronyms file path

### DIFF
--- a/srcpkgs/netbsd-wtf/template
+++ b/srcpkgs/netbsd-wtf/template
@@ -1,7 +1,7 @@
 # Template file for 'netbsd-wtf'
 pkgname=netbsd-wtf
 version=20180621
-revision=1
+revision=2
 _commit=b1e5be48e340146f63b174cc14fef892a783168b
 noarch=yes
 build_style=gnu-makefile
@@ -13,6 +13,7 @@ distfiles="https://github.com/void-linux/netbsd-wtf/archive/$_commit.tar.gz"
 checksum=5da7c6c286673baa8cc0ce2840c16895eef3e884e038a6cb7dedabdd15753de7
 
 wrksrc="$pkgname-$_commit"
+make_build_args="PREFIX=/usr"
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/{wtf,$pkgname}


### PR DESCRIPTION
`netbsd-wtf` fails because `PREFIX` is not set in `do_build` and the Makefile defaults to `/usr/local`
```
$ netbsd-wtf foo  
netbsd-wtf: cannot open acronym database file `/usr/local/share/wtf/acronyms*'
```