### PR TITLE
ncurses: Add libtinfo.so.5 symlink

### DIFF
--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template build file for 'ncurses'.
 pkgname=ncurses
 version=6.1
-revision=1
+revision=2
 short_desc="A System V Release 4.0 curses emulation library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnu.org/software/ncurses/"
@@ -85,6 +85,9 @@ do_install() {
 			${DESTDIR}/usr/lib/lib${f}w.so.5
 	done
 
+	ln -sfr ${DESTDIR}/usr/lib/libncursesw.so.6 \
+		${DESTDIR}/usr/lib/libtinfo.so.5
+
 	# Remove broken symlink.
 	rm -f ${DESTDIR}/usr/lib/terminfo
 
@@ -93,7 +96,8 @@ do_install() {
 }
 
 ncurses-libs_package() {
-	shlib_provides="libformw.so.5 libmenuw.so.5 libpanelw.so.5 libncursesw.so.5"
+	shlib_provides="libformw.so.5 libmenuw.so.5 libpanelw.so.5 libncursesw.so.5
+		libtinfo.so.5"
 	short_desc+=" -- shared libraries"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"


### PR DESCRIPTION
Some projects link to the old `libtinfo.so.5` instead of `libncurses.so.5`.