### PR TITLE
h2o: update to 2.2.5.

### DIFF
--- a/srcpkgs/h2o/patches/fix-libressl-2.7.patch
+++ b/srcpkgs/h2o/patches/fix-libressl-2.7.patch
@@ -1,15 +1,3 @@
---- include/h2o/openssl_backport.h.orig	2018-04-25 12:44:38.649149571 +0200
-+++ include/h2o/openssl_backport.h	2018-04-25 12:44:50.546167553 +0200
-@@ -25,7 +25,8 @@
- #include <stdlib.h>
- 
- /* backports for OpenSSL 1.0.2 */
--#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
-+    (defined (LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
- 
- #define BIO_get_data(bio) ((bio)->ptr)
- #define BIO_set_data(bio, p) ((bio)->ptr = (p))
 --- deps/neverbleed/neverbleed.c.orig	2018-04-25 12:58:28.060403297 +0200
 +++ deps/neverbleed/neverbleed.c	2018-04-25 12:58:09.600375394 +0200
 @@ -547,7 +547,7 @@ static int sign_stub(struct expbuf_t *bu
@@ -21,15 +9,4 @@
  
  static void RSA_get0_key(const RSA *rsa, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
  {
---- deps/picotls/lib/openssl.c.orig	2018-04-25 13:02:07.728735340 +0200
-+++ deps/picotls/lib/openssl.c	2018-04-25 13:01:39.228692266 +0200
-@@ -41,7 +41,7 @@
- #define OPENSSL_1_0_API 0
- #endif
- 
--#if OPENSSL_1_0_API
-+#if OPENSSL_1_0_API && defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL
- 
- #define EVP_PKEY_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_EVP_PKEY)
- #define X509_STORE_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_X509_STORE)
 

--- a/srcpkgs/h2o/template
+++ b/srcpkgs/h2o/template
@@ -1,19 +1,19 @@
 # Template file for 'h2o'
 pkgname=h2o
-version=2.2.4
-revision=3
+version=2.2.5
+revision=1
 build_style=cmake
 conf_files="/etc/h2o.conf"
 system_accounts="h2o"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel libressl-devel"
+makedepends="libressl-devel libuv-devel zlib-devel"
 depends="perl"
-short_desc="An optimized HTTP server with support for HTTP/1.x and HTTP/2"
+short_desc="Optimized HTTP server with support for HTTP/1.x and HTTP/2"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="MIT"
-homepage="https://github.com/h2o/h2o"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=ebacf3b15f40958c950e18e79ad5a647f61e989c6dbfdeea858ce943ef5e3cd8
+homepage="https://h2o.examp1e.net/"
+distfiles="https://github.com/h2o/h2o/archive/v${version}.tar.gz"
+checksum=eafb40aa2d93b3de1af472bb046c17b2335c3e5a894462310e1822e126c97d24
 
 post_install() {
 	vsv h2o


### PR DESCRIPTION
````
=> h2o-2.2.5_1: patching: fix-libressl-2.7.patch.
1 out of 1 hunk FAILED -- saving rejects to file include/h2o/openssl_backport.h.rej
1 out of 1 hunk FAILED -- saving rejects to file deps/picotls/lib/openssl.c.rej
````
I modfied the patch with the help of @newbluemoon , compilation is fine.
Not fully tested !

Missing dependencies:
````
-- Checking for module 'libuv>=1.0.0'
--   No package 'libuv' found
-- Could NOT find LIBUV (missing: LIBUV_LIBRARIES LIBUV_INCLUDE_DIR) 
-- Checking for module 'libwslay'
--   No package 'libwslay' found
-- Could NOT find WSLAY (missing: WSLAY_LIBRARIES WSLAY_INCLUDE_DIR)
````