### PR TITLE
thunderbird: update to 52.9.0, enable rust on i686. [ci skip]

### DIFF
--- a/srcpkgs/thunderbird/patches/Force-use-the-i686-rust-target.patch
+++ b/srcpkgs/thunderbird/patches/Force-use-the-i686-rust-target.patch
@@ -1,0 +1,21 @@
+From: Mike Hommey <mh@glandium.org>
+Date: Tue, 9 May 2017 10:37:08 +0200
+Subject: Force use the i686 rust target
+
+---
+ mozilla/build/moz.configure/rust.configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mozilla/build/moz.configure/rust.configure b/mozilla/build/moz.configure/rust.configure
+index 261768f..3f14978 100644
+--- mozilla/build/moz.configure/rust.configure
++++ mozilla/build/moz.configure/rust.configure
+@@ -105,7 +105,7 @@ def rust_target(rust_compiler, rustc, target, cross_compiling):
+             # OpenBSD
+             ('x86_64', 'OpenBSD'): 'x86_64-unknown-openbsd',
+             # Linux
+-            ('x86', 'Linux'): 'i586-unknown-linux-gnu',
++            ('x86', 'Linux'): 'i686-unknown-linux-gnu',
+             # Linux
+             ('x86_64', 'Linux'): 'x86_64-unknown-linux-gnu',
+             # OS X and iOS

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -1,22 +1,22 @@
-# Template build file for 'thunderbird'.
+# Template file for 'thunderbird'
 #
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/thunderbird-i18n".
 #
 pkgname=thunderbird
-version=52.8.0
+version=52.9.0
 revision=1
 short_desc="Standalone Mail/News reader"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-homepage="http://www.mozilla.org/thunderbird/"
-license="MPL-2.0, GPL-2, LGPL-2.1"
+homepage="https://www.thunderbird.net/"
+license="MPL-2.0, GPL-2.0-or-later, LGPL-2.1-or-later"
 distfiles="${MOZILLA_SITE}/${pkgname}/releases/${version}/source/${pkgname}-${version}.source.tar.xz"
-checksum=35b9a687997d92f36107090c1217941e5d637760b0efa7d13819cde36894eb59
+checksum=7301d61b6ab373f6c37a76c3f562596f4ce1ed10ef12c96dd5a60b37e0c1b8dd
 
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
 lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm
- $(vopt_if rust 'rust cargo')"
+ $(vopt_if rust cargo)"
 makedepends="
  nss-devel libjpeg-turbo-devel gtk+-devel icu-devel pixman-devel
  sqlite-devel libevent-devel libnotify-devel libvpx-devel libXrender-devel
@@ -33,7 +33,7 @@ build_options_default="alsa dbus gtk3 pulseaudio startup_notification xscreensav
 desc_option_rust="Build rust components"
 
 case "$XBPS_TARGET_MACHINE" in
-	x86_64*) build_options_default+=" rust" ;;
+	i686*|x86_64*) build_options_default+=" rust" ;;
 esac
 
 post_extract() {


### PR DESCRIPTION
Patch from Debian: [Force-use-the-i686-rust-target.patch](https://sources.debian.org/patches/thunderbird/1:52.8.0-1/debian-hacks/Force-use-the-i686-rust-target.patch/)