### PR TITLE
lttng-tools: update to 2.10.4.

### DIFF
--- a/srcpkgs/lttng-tools/patches/musl.patch
+++ b/srcpkgs/lttng-tools/patches/musl.patch
@@ -1,10 +1,21 @@
---- src/common/pipe.h	2017-08-03 21:42:22.098586810 +0200
-+++ src/common/pipe.h	2017-12-16 20:27:26.546173345 +0100
-@@ -18,6 +18,7 @@
- #ifndef LTTNG_PIPE_H
- #define LTTNG_PIPE_H
- 
+--- include/lttng/condition/condition-internal.h.orig	2018-04-30 20:47:49.527521481 +0200
++++ include/lttng/condition/condition-internal.h	2018-07-13 10:59:43.759602523 +0200
+@@ -24,6 +24,7 @@
+ #include <stdbool.h>
+ #include <urcu/list.h>
+ #include <stdint.h>
 +#include <sys/types.h>
- #include <pthread.h>
- #include <common/macros.h>
  
+ typedef void (*condition_destroy_cb)(struct lttng_condition *condition);
+ typedef bool (*condition_validate_cb)(const struct lttng_condition *condition);
+--- include/lttng/condition/evaluation-internal.h.orig	2018-04-30 20:47:49.527521481 +0200
++++ include/lttng/condition/evaluation-internal.h	2018-07-13 11:00:26.403873860 +0200
+@@ -22,6 +22,7 @@
+ #include <common/macros.h>
+ #include <common/buffer-view.h>
+ #include <stdbool.h>
++#include <sys/types.h>
+ 
+ typedef void (*evaluation_destroy_cb)(struct lttng_evaluation *evaluation);
+ typedef ssize_t (*evaluation_serialize_cb)(struct lttng_evaluation *evaluation,
+

--- a/srcpkgs/lttng-tools/template
+++ b/srcpkgs/lttng-tools/template
@@ -1,17 +1,17 @@
 # template file for 'lttng-tools'
 pkgname=lttng-tools
-version=2.10.3
+version=2.10.4
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="babeltrace-devel libxml2-devel lttng-modules-dkms lttng-ust-devel"
-system_groups="tracing"
-short_desc="A set of tools to control LTTng tracing"
+short_desc="Set of tools to control LTTng tracing"
 maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
 license="LGPL-2.1-only, GPL-2.0-only"
-homepage="http://lttng.org"
+homepage="https://lttng.org"
 distfiles="${homepage}/files/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=190f7b42cc3e39d96b66374d079c1fe50bab719154afc3fa4d7a14a0af346b74
+checksum=5eedfec1dbef6a7e20bdcfea5dd53d7ce640aa508daca83746aec452d13d7edc
+system_groups="tracing"
 
 lttng-tools-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Recovery of https://github.com/voidlinux/void-packages/pull/13994