### PR TITLE
firefox-esr: add support for FFmpeg 4.0 [ci skip]

### DIFF
--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -4,14 +4,16 @@
 #
 pkgname=firefox-esr
 version=52.9.0
-revision=1
+revision=2
 wrksrc="firefox-${version}esr"
 short_desc="Mozilla Firefox web browser - Extended Support Release (ESR)"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
 homepage="https://www.mozilla.org/firefox/organizations/"
 license="MPL-2.0, GPL-2.0-or-later, LGPL-2.1-or-later"
-distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
-checksum=c01d09658c53c1b3a496e353a24dad03b26b81d3b1d099abc26a06f81c199dd6
+distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz
+ https://aur.archlinux.org/cgit/aur.git/plain/ffmpeg4.patch.gz?h=firefox-esr52>ffmpeg4.patch.gz"
+checksum="c01d09658c53c1b3a496e353a24dad03b26b81d3b1d099abc26a06f81c199dd6
+ 2a285e0c31968e3fe9b65a585838b46f9342ff0a369e786a729b4c3886617034"
 
 lib32disabled=yes
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm
@@ -36,6 +38,8 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_extract() {
+	patch -Np0 -i ../ffmpeg4.patch
+
 	case "$XBPS_TARGET_MACHINE" in
 	*-musl)
 		# fix musl rust triplet


### PR DESCRIPTION
This patch is used in Arch packages: [firefox-esr52](https://aur.archlinux.org/packages/firefox-esr52/) and [firefox-esr-gtk2](https://aur.archlinux.org/packages/firefox-esr-gtk2/).

https://hg.mozilla.org/releases/mozilla-esr60/rev/2f39b32593bd
https://svnweb.freebsd.org/ports/head/www/firefox/files/patch-bug1435212?view=markup&pathrev=468159

Tested with success. Fixed my issues with videos.