### PR TITLE
Fritzing: fix package

### DIFF
--- a/srcpkgs/Fritzing/files/Fritzing
+++ b/srcpkgs/Fritzing/files/Fritzing
@@ -1,0 +1,3 @@
+#! /bin/sh
+cd /usr/share/fritzing/parts
+exec /usr/bin/Fritzing-bin "$@"

--- a/srcpkgs/Fritzing/template
+++ b/srcpkgs/Fritzing/template
@@ -1,20 +1,21 @@
 # Template file for 'Fritzing'
 pkgname=Fritzing
 version=0.9.3b
-revision=1
+revision=2
+_partshash=359eb1933622e4c4fa456ad043543681984a4d64 # 2018-03-14
+wrksrc="fritzing-app-${version}"
 build_style=qmake
 hostmakedepends="qt5-qmake"
 makedepends="qt5-devel qt5-serialport-devel qt5-svg-devel boost-devel libgit2-devel"
 depends="qt5-plugin-sqlite"
 short_desc="Software for electronics prototyping"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
-license="GPL-2,GPL-3, CC-BY-SA-3.0"
+license="GPL-3.0-or-later, CC-BY-SA-3.0"
 homepage="http://fritzing.org"
 distfiles="https://github.com/${pkgname}/${pkgname}-app/archive/${version}.tar.gz>fritzing-app-${version}.tar.gz
- https://github.com/${pkgname}/${pkgname}-parts/archive/${version}.tar.gz>fritzing-parts-${version}.tar.gz"
+ https://github.com/${pkgname}/${pkgname}-parts/archive/${_partshash}.tar.gz>fritzing-parts-${_partshash}.tar.gz"
 checksum="2475a95aad2c1536eef3fdb72665c5c16590644b45bd110a0cde223c916625b8
- c40a9a50df0af78905968792b2ce595896af1935633600d6136eca0cf9797fdb"
-wrksrc="fritzing-app-${version}"
+ 2d5882f0180d04c582ef418fd286bf1d04142409d316a4cd5c9ce3e2d91434dd"
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-serialport-devel qt5-svg-devel"
@@ -32,6 +33,9 @@ post_extract() {
 	 pri/utils.pri
 }
 
-pre_build() {
-	mv ${XBPS_BUILDDIR}/fritzing-parts-$version/ $wrksrc/parts
+post_install() {
+	mv ${XBPS_BUILDDIR}/fritzing-parts-$_partshash/ ${DESTDIR}/usr/share/fritzing/parts
+	mv ${DESTDIR}/usr/bin/Fritzing{,-bin}
+	vbin ${FILESDIR}/Fritzing
+	sed -i -e "s;^Icon=.*;Icon=fritzing;" ${DESTDIR}/usr/share/applications/fritzing.desktop
 }


### PR DESCRIPTION
closes #671 

The part definitions didn’t get packaged. Also, Fritzing needs to run from the parts directory else they aren’t found. I added a wrapper which changes to the correct directory and starts Fritzing.

Tweaked the .desktop file to find the icon.

Removed GPL-2 from `license` because there doesn’t seem to be any code using it. It’s all GPL-3.0-or-later.

However, the last release of the part definitions is rather old (June 2016). Perhaps it’s better to use a recent git checkout?