### PR TITLE
alacritty: package shell completions, man page, config file, and terminfo

### DIFF
--- a/srcpkgs/alacritty-terminfo
+++ b/srcpkgs/alacritty-terminfo
@@ -1,0 +1,1 @@
+alacritty

--- a/srcpkgs/alacritty/INSTALL
+++ b/srcpkgs/alacritty/INSTALL
@@ -1,0 +1,6 @@
+case "$ACTION" in
+post)
+	# Compile the terminfo description.
+	tic -sx usr/share/terminfo/a/alacritty.info
+	;;
+esac

--- a/srcpkgs/alacritty/REMOVE
+++ b/srcpkgs/alacritty/REMOVE
@@ -1,0 +1,7 @@
+case "$ACTION" in
+pre)
+	# Remove compiled terminfo files.
+	rm -f usr/share/terminfo/a/alacritty-256color
+	rm -f usr/share/terminfo/a/alacritty
+	;;
+esac

--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,12 +1,12 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.1.0.20180705
-revision=1
+revision=2
 _commit=7433f45ff9c6efeb48e223e90dd4aa9ee135b5e8
 wrksrc="${pkgname}-${_commit}"
 hostmakedepends="rust cargo cmake pkg-config"
 makedepends="freetype-devel fontconfig-devel"
-depends="libXxf86vm xclip"
+depends="libXxf86vm xclip ncurses"
 short_desc="A cross-platform, GPU-accelerated terminal emulator"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
@@ -23,5 +23,18 @@ do_build() {
 do_install() {
 	vbin target/release/$pkgname
 	vinstall alacritty.desktop 644 usr/share/applications
+	vinstall alacritty-completions.zsh 644 usr/share/zsh/site-functions _alacritty
+	vinstall alacritty-completions.fish 644 usr/share/fish/completions alacritty.fish
+	vinstall alacritty.info 644 usr/share/terminfo/a
 	vlicense LICENSE-APACHE LICENSE
+	vman alacritty.man alacritty.1
+	vsconf alacritty.yml
+}
+
+alacritty-terminfo_package() {
+	short_desc+=" - terminfo data"
+	noarch=yes
+	pkg_install() {
+		vmove usr/share/terminfo
+	}
 }


### PR DESCRIPTION
terminfo is in a split package for server installs, as done with st and rxvt-unicode.