### PR TITLE
tryton: update to 4.8.3, add missing dep.

### DIFF
--- a/srcpkgs/tryton/template
+++ b/srcpkgs/tryton/template
@@ -1,18 +1,18 @@
 # Template file for 'tryton'
 pkgname=tryton
-version=4.8.2
+version=4.8.3
 revision=1
 noarch=yes
 build_style=python2-module
 pycompile_module="tryton"
 hostmakedepends="python-setuptools"
-depends="pygtk python-dateutil"
+depends="pygtk python-dateutil python-gobject"
 short_desc="Three-tier high-level general purpose application platform"
 maintainer="cr6git <quark6@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.tryton.org"
 distfiles="${PYPI_SITE}/t/tryton/tryton-${version}.tar.gz"
-checksum=dda34b57c96bbc88311d4ae94b2208a891d46c2a4d120645b1f04cac79c7560a
+checksum=1e2862bbe7c943afbbdf2232cdc55f75d2357640115c7f1483f0814b2c5a6882
 
 post_install() {
 	vinstall tryton.desktop 644 usr/share/applications


### PR DESCRIPTION
````
$ tryton
Traceback (most recent call last):
  File "/usr/bin/tryton", line 48, in <module>
    from tryton import client
  File "/usr/lib/python2.7/site-packages/tryton/client.py", line 17, in <module>
    import gi
ImportError: No module named gi
````