### PR TITLE
Update cdemu and dependencies to 3.2.0

### DIFF
--- a/srcpkgs/cdemu-client/template
+++ b/srcpkgs/cdemu-client/template
@@ -1,14 +1,14 @@
 # Template file for 'cdemu-client'
 pkgname=cdemu-client
-version=3.1.0
+version=3.2.0
 revision=1
 noarch=yes
 build_style=cmake
-hostmakedepends="python intltool"
-depends="cdemu-daemon python-gobject"
+hostmakedepends="python3 intltool pkg-config"
+depends="cdemu-daemon python3-gobject"
 short_desc="A simple command-line client for controlling CDEmu daemon"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://cdemu.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/cdemu/cdemu-client-${version}.tar.bz2"
-checksum=336a078b0b1f70de81d7ee92ee3e3a1e1957843accc4e90a876aeef28648d868
+checksum=a9fea8c54433b6827ea23e13cb10b931609854370afd99a69bea8a750f4a9fff

--- a/srcpkgs/cdemu-daemon/template
+++ b/srcpkgs/cdemu-daemon/template
@@ -1,6 +1,6 @@
 # Template file for 'cdemu-daemon'
 pkgname=cdemu-daemon
-version=3.1.0
+version=3.2.1
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config intltool"
@@ -8,7 +8,7 @@ makedepends="libmirage-devel glib-devel libao-devel"
 depends="vhba-module-dkms"
 short_desc="The userspace daemon part of the cdemu suite"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://cdemu.sourceforge.net"
-distfiles="${SOURCEFORGE_SITE}/cdemu/cdemu-daemon-3.1.0.tar.bz2"
-checksum=498f0f2fe2225de76acfe0b3dbf9606e4e2eb57ac9d29da9d48064b62587bc4f
+distfiles="${SOURCEFORGE_SITE}/cdemu/cdemu-daemon-${version}.tar.bz2"
+checksum=842d889094be45fb913ee6649cba8f12e6190e83497764536bc63d1c3fc3389c

--- a/srcpkgs/gcdemu/template
+++ b/srcpkgs/gcdemu/template
@@ -1,15 +1,15 @@
 # Template file for gcdemu'
 pkgname=gcdemu
-version=3.1.0
+version=3.2.0
 revision=1
 noarch=yes
 wrksrc="gcdemu-${version}"
 build_style=cmake
-hostmakedepends="python intltool"
-depends="cdemu-daemon python-gobject libnotify gtk+3"
+hostmakedepends="python3 intltool"
+depends="cdemu-daemon python3-gobject libnotify gtk+3"
 short_desc="A GTK application for controlling CDEmu daemon"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://cdemu.sourceforge.net"
-distfiles="${SOURCEFORGE_SITE}/cdemu/gcdemu-3.1.0.tar.bz2"
-checksum=025c801300aa6ef13b9da484d8bd1ec2774c53e898942d44a43b4d27c0e0b666
+distfiles="${SOURCEFORGE_SITE}/cdemu/gcdemu-${version}.tar.bz2"
+checksum=6cd6b6f22b329bf487f07189050d1750161ecf99a532ce3a85211809fe57a418

--- a/srcpkgs/libmirage/template
+++ b/srcpkgs/libmirage/template
@@ -1,17 +1,17 @@
 # Template file for 'libmirage'
 pkgname=libmirage
-version=3.1.0
+version=3.2.0
 revision=1
 build_style=cmake
-hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
-makedepends="glib-devel libsndfile-devel zlib-devel libsamplerate-devel
- liblzma-devel"
+configure_args="-DPOST_INSTALL_HOOKS=OFF"
+hostmakedepends="intltool pkg-config $(vopt_if gir 'gobject-introspection')"
+makedepends="libglib-devel liblzma-devel libsamplerate-devel"
 short_desc="CD-ROM image access library written in C"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://cdemu.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/cdemu/libmirage-${version}.tar.bz2"
-checksum=b67ecc1056cf1986321d637f1a52cb36b0f5bec4fac08fd9c71075dcb7dd7363
+checksum=795916c20ad87e8b83f918a28c492b5392532e7ce8367110b9f476a7c780b7f9
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then
@@ -24,7 +24,7 @@ libmirage-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		if [ -n "$build_option_gir" ]; then
+		if [ "$build_option_gir" ]; then
 			vmove usr/share/gir-1.0
 		fi
 		vmove "usr/lib/*.so"


### PR DESCRIPTION
@maxice8 Since the new cdemu version requires libmirage-3.2.0, I pulled your changes from #750 to compile and PR it together.

Btw, two more packages that transition to python3 :-D