### PR TITLE
atom: update to 1.28.1

### DIFF
--- a/srcpkgs/atom/template
+++ b/srcpkgs/atom/template
@@ -1,17 +1,17 @@
 # Template file for 'atom'
 pkgname=atom
-version=1.26.1
+version=1.28.1
 revision=1
 nocross=yes
 nostrip=yes
-hostmakedepends="git pkg-config python-devel nodejs curl gtk+ libXtst libXScrnSaver nss python alsa-lib"
+hostmakedepends="git pkg-config python-devel nodejs curl gtk+3 libXtst libXScrnSaver nss python alsa-lib"
 makedepends="python-devel GConf-devel libgnome-keyring-devel libX11-devel libxkbfile-devel libsecret-devel"
 short_desc="Chrome-based text editor from Github"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://atom.io"
 distfiles="https://github.com/atom/atom/archive/v${version}.tar.gz"
-checksum=d5c2fab3f671b4162992d0baffb2393bc58e6b361aa37214dcc5c9be1e03c65f
+checksum=24df7ea2017fb7a4c19f685a228af4f6f64b96de42da99084ab6dff29b417247
 only_for_archs="i686 x86_64"
 
 do_install() {


### PR DESCRIPTION
after the xbps-create fix (https://github.com/void-linux/xbps/issues/2) this should update atom to the latest 1.28.1 version