### PR TITLE
Update cura and dependencies to 3.4.1

### DIFF
--- a/srcpkgs/Uranium/template
+++ b/srcpkgs/Uranium/template
@@ -1,7 +1,7 @@
 # Template file for 'Uranium'
 pkgname=Uranium
-version=3.3.0
-revision=2
+version=3.4.1
+revision=1
 noarch=yes
 build_style=cmake
 pycompile_module="UM"
@@ -15,4 +15,4 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/Ultimaker/Uranium"
 distfiles="https://github.com/Ultimaker/Uranium/archive/${version}.tar.gz"
-checksum=7bad5299bef4c2c5f9aa74eb1d5a927266785c330e58dc6138a7f4996180080c
+checksum=7a97385b101a30008d1c0bb576d603b93ca2d0967b8c71faeb6760c9cc9ecb72

--- a/srcpkgs/cura-engine/template
+++ b/srcpkgs/cura-engine/template
@@ -1,18 +1,18 @@
 # Template file for 'cura-engine'
 pkgname=cura-engine
-version=3.3.0
-revision=2
+version=3.4.1
+revision=1
 wrksrc="CuraEngine-${version}"
 build_style=cmake
 configure_args="-DCURA_ENGINE_VERSION=${version}"
-hostmakedepends="protobuf"
+hostmakedepends="protobuf git"
 makedepends="libArcus-devel libgomp-devel protobuf-devel"
 short_desc="Engine for processing 3D models into GCode"
 maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="AGPL-3.0-or-later"
 homepage="https://github.com/Ultimaker/CuraEngine"
 distfiles="https://github.com/Ultimaker/CuraEngine/archive/${version}.tar.gz"
-checksum=a8fd7deb505771d2e7cf3a2c2d7e78479f59e001a990374ed505030804dc71fc
+checksum=478164dec9a71a3c3b044c660b8186ced01c7bf638a5976f6ea61424336f2aed
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/cura-fdm-materials/template
+++ b/srcpkgs/cura-fdm-materials/template
@@ -1,7 +1,7 @@
 # Template file for 'cura-fdm-materials'
 pkgname=cura-fdm-materials
-version=3.3.0
-revision=2
+version=3.4.1
+revision=1
 noarch=yes
 build_style=cmake
 wrksrc="fdm_materials-${version}"
@@ -10,7 +10,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="CC0-1.0"
 homepage="https://github.com/Ultimaker/fdm_materials"
 distfiles="https://github.com/Ultimaker/fdm_materials/archive/${version}.tar.gz"
-checksum=654bfd5b2c908cc250e3d24458e02fe12541840678d96bb2c070d23a8845bb99
+checksum=175f7475e7cd94486041b12cb61990348d50dbb2f0015979509b916eeac4d07f
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/cura/template
+++ b/srcpkgs/cura/template
@@ -1,7 +1,7 @@
 # Template file for 'cura'
 pkgname=cura
-version=3.3.1
-revision=2
+version=3.4.1
+revision=1
 noarch=yes
 wrksrc="Cura-${version}"
 build_style=cmake
@@ -15,4 +15,4 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/Ultimaker/Cura"
 distfiles="https://github.com/Ultimaker/Cura/archive/${version}.tar.gz"
-checksum=275cecbb20df9b52c404747e10010ace31ce3ee4c4ffa4322343fd1de5f789fb
+checksum=059504542f918b87ba48fffebad22e879bd1006264f7b178ae12aa08352bd251

--- a/srcpkgs/libArcus/template
+++ b/srcpkgs/libArcus/template
@@ -1,7 +1,7 @@
 # Template file for 'libArcus'
 pkgname=libArcus
-version=3.3.0
-revision=3
+version=3.4.1
+revision=1
 build_style=cmake
 configure_args="-DBUILD_EXAMPLES=OFF"
 hostmakedepends="protobuf python3-sip-devel"
@@ -12,7 +12,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/Ultimaker/libArcus"
 distfiles="https://github.com/Ultimaker/libArcus/archive/${version}.tar.gz"
-checksum=9416731ccc21fc51c7102431e4c9e2a01075676a7a095bdec2dc2a943359940a
+checksum=c72e20bf7dc95fb5d2b2fd8c7773e40feca3c5cdf894a35f7e03effb4249503a
 
 libArcus-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
I succesfully built, packaged, and tested the new version of cura and its dependencies on x86_64 glibc

one thing of note:
cura-engine added a dependency: stb (specifically one file, stb_image.h)
cura-engine's CMakeLists.txt will search for stb, and if not found, will clone the repo off of github
I'd add a package for stb, however it has not had a release
however stb is public domain, so I can easily add a patch to include the required file

Let me know what you think