### PR TITLE
vulkan-loader: update to 1.1.77.0

### DIFF
--- a/srcpkgs/vulkan-headers/template
+++ b/srcpkgs/vulkan-headers/template
@@ -1,0 +1,14 @@
+# Template file for 'vulkan-headers'
+pkgname=vulkan-headers
+_pkgname=Vulkan-Headers
+version=1.1.77.0
+revision=1
+build_style=cmake
+wrksrc=${_pkgname}-sdk-${version}
+short_desc="Vulkan header files"
+maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
+license="Apache-2.0"
+homepage="https://www.khronos.org/vulkan/"
+distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/sdk-${version}.tar.gz"
+checksum=b2f532bfd1d8e7594f131a4aa79358bfe4fd0aa59d3292dbafd484223d56ef16
+

--- a/srcpkgs/vulkan-headers/template
+++ b/srcpkgs/vulkan-headers/template
@@ -3,12 +3,11 @@ pkgname=vulkan-headers
 _pkgname=Vulkan-Headers
 version=1.1.77.0
 revision=1
+wrksrc="${_pkgname}-sdk-${version}"
 build_style=cmake
-wrksrc=${_pkgname}-sdk-${version}
 short_desc="Vulkan header files"
 maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/sdk-${version}.tar.gz"
 checksum=b2f532bfd1d8e7594f131a4aa79358bfe4fd0aa59d3292dbafd484223d56ef16
-

--- a/srcpkgs/vulkan-headers/update
+++ b/srcpkgs/vulkan-headers/update
@@ -1,0 +1,3 @@
+_pkgname=Vulkan-Headers
+site="https://github.com/KhronosGroup/${_pkgname}/releases"
+pattern="/releases/tag/sdk-\K\d.\d.\d+.\d(?=)"

--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,51 +1,17 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
-_pkgname=Vulkan-LoaderAndValidationLayers
-version=1.1.70.0
+_pkgname=Vulkan-Loader
+version=1.1.77.0
 revision=1
+wrksrc="${_pkgname}-sdk-${version}"
 build_style=cmake
-configure_args="-DBUILD_TESTS=Off"
-wrksrc=${_pkgname}-sdk-${version}
-hostmakedepends="git python3 bison pkg-config"
-makedepends="libxcb-devel libxkbcommon-devel libwayland-egl wayland-devel
- libXrandr-devel"
+configure_args="-DBUILD_TESTS=Off -DVULKAN_HEADERS_INSTALL_DIR=/usr"
+hostmakedepends="python3 pkg-config"
+makedepends="vulkan-headers libxcb-devel libxkbcommon-devel wayland-devel
+ libwayland-egl libXrandr-devel"
 short_desc="Vulkan Installable Client Driver (ICD) loader"
 maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/sdk-${version}.tar.gz"
-checksum=bd30ffe25a0723775ea8427d65e96bbad6f5130674ac6577ec639b54ce811397
-
-nocross="https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/issues/1962"
-nopie=yes
-
-pre_configure() {
-	./update_external_sources.sh
-}
-
-do_install() {
-	for file in build/loader/libvulkan.*; do
-		vinstall ${file} 755 /usr/lib
-	done
-
-	vbin build/demos/vulkaninfo
-
-	vinstall include/vulkan/vk_icd.h 644 /usr/include/vulkan
-	vlicense LICENSE.txt
-}
-
-vulkan-validation-layers_package() {
-	short_desc="Vulkan validation layers"
-	depends="${sourcepkg}>=${version}_${revision}"
-	pkg_install() {
-		cd build
-
-		for file in layers/*.so; do
-			vinstall ${file} 755 /usr/lib
-		done
-
-		for file in layers/*.json; do
-			vinstall ${file} 644 /etc/vulkan/explicit_layer.d
-		done
-	}
-}
+checksum=4d80cd2f56e55812b685fcc90c72ef9fc3d4def7e7aae1330934a9c5cb32e8fd

--- a/srcpkgs/vulkan-loader/update
+++ b/srcpkgs/vulkan-loader/update
@@ -1,3 +1,3 @@
-_pkgname=Vulkan-LoaderAndValidationLayers
+_pkgname=Vulkan-Loader
 site="https://github.com/KhronosGroup/${_pkgname}/releases"
 pattern="/releases/tag/sdk-\K\d.\d.\d+.\d(?=)"


### PR DESCRIPTION
Khronos Group has reorganized their GitHub repos. The headers, loader, and validation layers are now in separate repositories. I've removed the validation layers subpackage from the loader and created a package for the headers, which are required to build the loader.

The validation layers depend on glslang, which has no proper versioning or even a license (at least not one that I could find). As such, I am holding off on creating a package for those. It will likely be more expedient for users to build those from source for the time being.