### PR TITLE
julia: update to 0.6.4.

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,6 +1,6 @@
 # Template file for 'julia'
 pkgname=julia
-version=0.6.3
+version=0.6.4
 revision=1
 wrksrc=julia
 nocross=yes
@@ -24,7 +24,7 @@ maintainer="Francisco Gómez <espectalll@kydara.com>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}.tar.gz"
-checksum=f18dd3fb67ce65137c9cb56b1b338bca4eeb13832a85de9dd3ec5717e68f69ff
+checksum=0cc9855bb56ef15bbae1533aa9987f4eb13c0d5fed839d2b8806fb785e3e8e29
 
 case "$XBPS_TARGET_MACHINE" in
 i686-musl)


### PR DESCRIPTION
Bugfix version bump. Changelog here: https://github.com/JuliaLang/julia/compare/v0.6.3...v0.6.4

No changes of any great significance.

v1.0 will be coming out in the next few months, and I'll see about fixing this up then to include the patches upstream Julia recommends and see if I can eliminate all vendored in packages entirely.