### PR TITLE
rng-tools: critical fix from upstream

### DIFF
--- a/srcpkgs/rng-tools/patches/main-loop.patch
+++ b/srcpkgs/rng-tools/patches/main-loop.patch
@@ -1,0 +1,78 @@
+This patch is already in the upstream source tree, so should be
+deleted when a new version of rng-tools is released.
+
+--- rngd.c.orig	2018-07-05 20:56:58.000000000 +0200
++++ rngd.c	2018-07-09 10:22:52.916258584 +0200
+@@ -215,7 +215,7 @@
+ 		break;
+ 	case 'x':
+ 		idx = strtol(arg, NULL, 10);
+-		if ((idx == LONG_MAX) || (idx > ENT_MAX)) {
++		if ((idx == LONG_MAX) || (idx >= ENT_MAX)) {
+ 			printf("exclude index is out of range: %lu\n", idx);
+ 			return -ERANGE;
+ 		}
+@@ -224,7 +224,7 @@
+ 		break;
+ 	case 'n':
+ 		idx = strtol(arg, NULL, 10);
+-		if ((idx == LONG_MAX) || (idx > ENT_MAX)) {
++		if ((idx == LONG_MAX) || (idx >= ENT_MAX)) {
+ 			printf("enable index is out of range: %lu\n", idx);
+ 			return -ERANGE;
+ 		}
+@@ -308,19 +308,18 @@
+ static void do_loop(int random_step)
+ {
+ 	unsigned char buf[FIPS_RNG_BUFFER_SIZE];
+-	int retval = 0;
+-	int no_work = 0;
+-	static int i = 0;
++	int no_work;
++	bool work_done;
+ 
+-	while (no_work < 100) {
++	for (no_work = 0; no_work < 100; no_work = (work_done ? 0 : no_work+1)) {
+ 		struct rng *iter;
+-		bool work_done;
++		int i, retval;
+ 
+ 		work_done = false;
+-		for (;i=(++i % ENT_MAX);)
++		for (i = 0; i < ENT_MAX; ++i)
+ 		{
+ 			int rc;
+-			printf("I is %d\n", i);
++			/*printf("I is %d\n", i);*/
+ 			iter = &entropy_sources[i];
+ 		retry_same:
+ 			if (!server_running)
+@@ -344,23 +343,23 @@
+ 						iter->failures--;
+ 					iter->success = 0;
+ 				}
+-				break;	/* succeeded, work done */
++				/* succeeded */
++				continue;
+ 			}
+ 
+ 			iter->failures++;
+ 			if (iter->failures <= MAX_RNG_FAILURES/4) {
+ 				/* FIPS tests have false positives */
+ 				goto retry_same;
+-			} else if (iter->failures >= MAX_RNG_FAILURES && !ignorefail) {
++			}
++
++			if (iter->failures >= MAX_RNG_FAILURES && !ignorefail) {
+ 				if (!arguments->quiet)
+ 					message(LOG_DAEMON|LOG_ERR,
+ 					"too many FIPS failures, disabling entropy source\n");
+ 				iter->disabled = true;
+ 			}
+ 		}
+-
+-		if (!work_done)
+-			no_work++;
+ 	}
+ 
+ 	if (!arguments->quiet)

--- a/srcpkgs/rng-tools/template
+++ b/srcpkgs/rng-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'rng-tools'
 pkgname=rng-tools
 version=6.3
-revision=1
+revision=2
 wrksrc=${pkgname}-${version}
 build_style=gnu-configure
 makedepends="libgcrypt-devel libsysfs-devel libcurl-devel libxml2-devel"


### PR DESCRIPTION
A bug in the 6.3 release prevents hw rng devices (/dev/hwrng) from
ever being used. This uses a patch to fix that, until such time as
there is a new upstream release.

Alternatively, a regression to version 6.2 should be forced, until there is a new upstream release.
