### PR TITLE
ruby: Fix conflicting function declarations

### DIFF
--- a/srcpkgs/ruby/patches/cpp_isinf_isnan.patch
+++ b/srcpkgs/ruby/patches/cpp_isinf_isnan.patch
@@ -1,0 +1,48 @@
+From 01839b509c1bb914337124ac3d1f644b05ef90d8 Mon Sep 17 00:00:00 2001
+From: "Urabe, Shyouhei" <shyouhei@ruby-lang.org>
+Date: Tue, 5 Jun 2018 10:26:06 +0900
+Subject: [PATCH] C++11 is so bad it introduces a nightmare.
+
+TL;DR see https://developers.redhat.com/blog/2016/02/29/why-cstdlib-is-more-complicated-than-you-might-think/
+
+ - `isnan` is something relatively new.  We need to provide one for
+   those systems without it.  However:
+ - X/Open defines `int isnan(double)`. Note the `int`.
+ - C99 defines `isnan(x)` to be a macro.
+ - C++11 nukes them all, undefines all the "masking macro"s, and
+   define its own `bool isnan(double)`.  Note the `bool`.
+ - In C++, `int isnan(double)` and `bool isnan(double)` are
+   incompatible.
+ - So the mess.
+
+Signed-off-by: Urabe, Shyouhei <shyouhei@ruby-lang.org>
+---
+ include/ruby/missing.h | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/include/ruby/missing.h b/include/ruby/missing.h
+index dc3fd502b5..8df917498e 100644
+--- include/ruby/missing.h.orig
++++ include/ruby/missing.h
+@@ -168,6 +168,8 @@ RUBY_EXTERN const union bytesequence4_or_float rb_nan;
+ #    include <ieeefp.h>
+ #    endif
+ #  define isinf(x) (!finite(x) && !isnan(x))
++#  elif __cplusplus >= 201103L
++#    include <cmath> // it must include constexpr bool isinf(double);
+ #  else
+ RUBY_EXTERN int isinf(double);
+ #  endif
+@@ -176,7 +178,11 @@ RUBY_EXTERN int isinf(double);
+
+ #ifndef isnan
+ # ifndef HAVE_ISNAN
++#  if __cplusplus >= 201103L
++#    include <cmath> // it must include constexpr bool isnan(double);
++#  else
+ RUBY_EXTERN int isnan(double);
++#  endif
+ # endif
+ #endif
+
+--

--- a/srcpkgs/ruby/template
+++ b/srcpkgs/ruby/template
@@ -3,7 +3,7 @@ _ruby_abiver=2.5.0
 
 pkgname=ruby
 version=2.5.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-shared --disable-rpath
  DOXYGEN=/usr/bin/doxygen DOT=/usr/bin/dot PKG_CONFIG=/usr/bin/pkg-config"


### PR DESCRIPTION
In an attempt to port `vagrant` package to musl-based Void, I had a problem with compiling `unf_ext` gem: `isnan` and `isinf` are being declared twice, with different signatures.  I was going to file a bug report it, but [someone already beat me to it](https://bugs.ruby-lang.org/issues/14816).

This PR ships [the patch from Shyouhei Urabe](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/87402) that fixes this problem.