### PR TITLE
apparmor: add pulseaudio, wpa_supplicant and wpa_cli profiles.

### DIFF
--- a/srcpkgs/apparmor/files/profiles/usr.bin.pulseaudio
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.pulseaudio
@@ -1,0 +1,117 @@
+#include <tunables/global>
+
+/usr/bin/pulseaudio {
+  #include <abstractions/base>
+  #include <abstractions/audio>
+  #include <abstractions/dbus-session>
+  #include <abstractions/dbus-strict>
+  #include <abstractions/nameservice>
+  #include <abstractions/X>
+
+  dbus send
+       bus=system
+       path=/org/freedesktop/RealtimeKit1
+       interface=org.freedesktop.RealtimeKit1
+       member={MakeThreadRealtime,MakeThreadHighPriority}
+       peer=(name=org.freedesktop.RealtimeKit1),
+
+  dbus send
+       bus=system
+       path=/org/freedesktop/RealtimeKit1
+       interface=org.freedesktop.DBus.Properties
+       member=Get,
+
+  unix (connect, receive, send) type=stream peer=(addr="@/tmp/.ICE-unix/[0-9]*"),
+  ptrace (read,trace) peer=@{profile_name},
+
+  /usr/bin/pulseaudio mixr,
+
+  /etc/pulse/ r,
+  /etc/pulse/* r,
+  /etc/udev/udev.conf r,
+  /etc/timidity/.pulse_cookie w,
+
+  /etc/asound.conf r,
+
+  owner @{HOME}/.esd_auth rwk,
+  owner @{HOME}/.pulse-cookie rwk,
+  owner @{HOME}/.config/pulse/cookie rwk,
+  owner @{HOME}/{.config/pulse,.pulse}/ rw,
+  owner @{HOME}/{.config/pulse,.pulse}/* rw,
+
+  owner /run/pulse/ rw,
+  owner /run/pulse/.pulse-cookie rwk,
+  owner /run/pulse/dbus-socket rwk,
+  owner /run/pulse/native rwk,
+  owner /run/pulse/pid rwk,
+  owner /run/user/[0-9]*/pulse/  rw,
+  owner /run/user/[0-9]*/pulse/* rwk,
+  /run/udev/data/+sound:card* r,
+  /run/udev/data/c116:[0-9]* r,
+  /run/udev/data/c14:[0-9]* r,
+
+  # logind
+  /run/user/[0-9]*/dconf/user k,
+
+  /sys/bus/ r,
+  /sys/class/ r,
+  /sys/class/sound/ r,
+  /sys/devices/pci[0-9]*/**/*class r,
+  /sys/devices/pci[0-9]*/**/uevent r,
+  /sys/devices/system/cpu/ r,
+  /sys/devices/system/cpu/online r,
+  /sys/devices/virtual/dmi/id/bios_vendor r,
+  /sys/devices/virtual/dmi/id/board_vendor r,
+  /sys/devices/virtual/dmi/id/sys_vendor r,
+  /sys/devices/virtual/sound/**/uevent r,
+
+  /usr/share/alsa/** r,
+  /usr/share/applications/ r,
+  /usr/share/applications/* r,
+  /usr/share/pulseaudio/** r,
+  /usr/lib/pulse-[1-9]*.[0-9]/modules/*.so mr,
+  /usr/lib/pulseaudio/pulse/gconf-helper Cx,
+
+  owner /var/lib/gdm3/.config/pulse/ rw,
+  owner /var/lib/gdm3/.config/pulse/* rw,
+  owner /var/lib/gdm3/.config/pulse/cookie rwk,
+
+  owner /var/lib/lightdm/.Xauthority r,
+  owner /var/lib/lightdm/.esd_auth rwk,
+  owner /var/lib/lightdm/.config/pulse/cookie rwk,
+  owner /var/lib/lightdm/.config/pulse/ rw,
+  owner /var/lib/lightdm/.config/pulse/* rw,
+
+  # are these needed?
+  /var/lib/pulse/ rw,
+  /var/lib/pulse/*-default-sink rw,
+  /var/lib/pulse/*-default-source rw,
+  /var/lib/pulse/*.tdb rw,
+
+  owner @{PROC}/@{pid}/fd/ r,
+  owner @{PROC}/@{pid}/maps r,
+  owner @{PROC}/@{pid}/stat r,
+
+  owner /tmp/pulse-*/pid rwk,
+  owner /tmp/pulse-*/native rwk,
+  owner /tmp/pulse-*/autospawn.lock rwk,
+  owner /run/user/*/pulse/autospawn.lock rwk,
+
+  owner /tmp/orcexec.* mrw,
+  owner /{,var/}run/user/[0-9]*/orcexec.* mrw,
+  # needed if /tmp is mounted noexec:
+  owner @{HOME}/orcexec.* mrw,
+
+  owner /tmp/.esd-@{pid}*/ rw,
+  owner /tmp/.esd-@{pid}*/socket rw,
+
+  profile /usr/lib/pulseaudio/pulse/gconf-helper {
+    #include <abstractions/base>
+
+    /usr/lib/pulseaudio/pulse/gconf-helper mr,
+  }
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.bin.pulseaudio>
+}
+

--- a/srcpkgs/apparmor/files/profiles/usr.bin.wpa_cli
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.wpa_cli
@@ -1,0 +1,16 @@
+#include <tunables/global>
+
+/usr/bin/wpa_cli {
+  #include <abstractions/base>
+
+  /usr/bin/wpa_cli mr,
+
+  /{var/,}run/wpa_supplicant/ r,
+  owner /tmp/wpa_ctrl_@{pid}-[0-9] rw,
+
+  # for interactive mode
+  /etc/inputrc r,
+  owner @{HOME}/.wpa_cli_history rw,
+
+  #include <local/usr.bin.wpa_cli>
+}

--- a/srcpkgs/apparmor/files/profiles/usr.bin.wpa_supplicant
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.wpa_supplicant
@@ -1,0 +1,47 @@
+#include <tunables/global>
+
+/usr/bin/wpa_supplicant {
+  #include <abstractions/base>
+  #include <abstractions/dbus-strict>
+
+  capability net_admin,
+  capability net_raw,
+  capability chown,
+  capability dac_override,
+  network inet dgram,
+  network inet raw,
+  network packet dgram,
+  network netlink,
+
+  /usr/bin/wpa_supplicant mr,
+
+  /run/wpa_supplicant/ rw,
+  /run/wpa_supplicant/** rw,
+
+  /run/dbus/system_bus_socket rw,
+  /run/sendsigs.omit.d/wpasupplicant.pid rw,
+
+  /etc/wpa_supplicant/ rw,
+  /etc/wpa_supplicant/** rw,
+  
+  /etc/nsswitch.conf r,
+  /etc/group r,
+ 
+  @{PROC}/@{pid}/psched r,
+
+  /dev/rfkill r,
+
+  dbus (send, receive)
+       bus=system
+       path=/fi/w1/wpa_supplicant1,
+
+  dbus (send, receive)
+       bus=system
+       path=/fi/w1/wpa_supplicant1/**,
+
+  dbus (send,receive)
+       bus=system
+       path=/fi/epitest/hostap/WPASupplicant/**,
+
+  #include <local/usr.bin.wpa_supplicant>
+}

--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.0
-revision=5
+revision=6
 _short_ver=${version%\.*}
 wrksrc="${pkgname}-v${_short_ver}"
 configure_args="--prefix=/usr --with-perl --with-python"
@@ -16,6 +16,7 @@ homepage="https://gitlab.com/apparmor/apparmor"
 distfiles="https://gitlab.com/apparmor/apparmor/-/archive/v${_short_ver}/apparmor-v${_short_ver}.tar.gz"
 checksum=fdafa0b71cbf574cce76a1ea1542b4540fa1c1040f80d0f0866fc0056ec37747
 nocross="requires running programs on the host"
+conf_files="/etc/apparmor.d/local/*"
 
 pre_build() {
 	# Replace release profiles by our owns


### PR DESCRIPTION
cc @olivier-mauras 

also makes /etc/apparmor.d/local/* a conf_file zone since users are expected to modify that for their systems.