### PR TITLE
miniflux: update to 2.0.10.

### DIFF
--- a/srcpkgs/miniflux/INSTALL.msg
+++ b/srcpkgs/miniflux/INSTALL.msg
@@ -1,7 +1,0 @@
-1. The pdo_sqlite extension needs to be enabled in /etc/php/php.ini.
-2. The open_basedir directive in /etc/php/php.ini needs to contain
-   /var/lib/miniflux to allow file operations below it.
-3. The process running miniflux should be configured to use the miniflux
-   group to be able to write to /var/lib/miniflux.
-4. A cron job for the miniflux user should be configured to update feeds:
-   cd /usr/share/webapps/miniflux && php cronjob.php

--- a/srcpkgs/miniflux/template
+++ b/srcpkgs/miniflux/template
@@ -1,32 +1,16 @@
 # Template file for 'miniflux'
 pkgname=miniflux
-version=1.2.3
+version=2.0.10
 revision=1
-noarch=yes
-wrksrc=$pkgname
-conf_files="/usr/share/webapps/${pkgname}/config.php"
+build_style=go
+go_import_path="github.com/miniflux/miniflux"
 system_accounts="${pkgname}"
 miniflux_homedir="/var/lib/${pkgname}"
 make_dirs="/var/lib/${pkgname} 2770 ${pkgname} ${pkgname}"
-hostmakedepends="unzip"
-depends="php-sqlite"
-short_desc="A minimalist web-based RSS reader"
+depends="postgresql"
+short_desc="Minimalist and opinionated feed reader written in Go"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
-license="AGPL-3"
-homepage="http://miniflux.net"
-distfiles="${homepage}/${pkgname}-${version}.zip"
-checksum=841eaf9bd537da79e20184391b1cef50c7661e50882c8e15fad655a83aeaf4be
-
-do_install() {
-	local dest=usr/share/webapps/${pkgname}
-
-	vmkdir $dest
-	vcopy ./* $dest
-
-	sed -e "s|\('DATA_DIRECTORY',\).*)|\1 '/var/lib/${pkgname}')|" \
-		-e "s|\('DEBUG',\).*)|\1 false)|" \
-		-e "s|\('ENABLE_AUTO_UPDATE',\).*)|\1 false)|" \
-		config.default.php > ${DESTDIR}/${dest}/config.php
-
-	rm ${DESTDIR}/$dest/LICENSE
-}
+license="Apache-2.0"
+homepage="https://miniflux.app"
+distfiles="https://github.com/miniflux/miniflux/archive/${version}.tar.gz"
+checksum=9169c22fc71f6c9d0f310654f1bd2c74ba0a53414afacb23b7e017c80a81f4ea

--- a/srcpkgs/miniflux/update
+++ b/srcpkgs/miniflux/update
@@ -1,2 +1,2 @@
-site="https://github.com/fguillot/miniflux/tags"
+site="https://github.com/miniflux/miniflux/tags"
 pattern='archive/v?\K[\d.]+(?=\.tar\.gz)'


### PR DESCRIPTION
closes https://github.com/void-linux/void-packages/issues/574
Wasn't thoroughly tested. :innocent: