### PR TITLE
nfs-utils: Add/update runit services for other nfs/rpc daemons

### DIFF
--- a/srcpkgs/nfs-utils/files/nfs-server/finish
+++ b/srcpkgs/nfs-utils/files/nfs-server/finish
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-umount -l /proc/fs/nfsd
-umount -l /var/lib/nfs/rpc_pipefs
+exportfs -ua
 rpc.nfsd -- 0
-exportfs -a -u

--- a/srcpkgs/nfs-utils/files/nfs-server/run
+++ b/srcpkgs/nfs-utils/files/nfs-server/run
@@ -3,26 +3,32 @@
 # Make sure the statd service is running.
 sv check statd >/dev/null || exit 1
 
+# Uncomment and add daemons for kerberos support.
+#sv check rpcidmapd >/dev/null || exit 1
+#sv check rpcsvgssd >/dev/null || exit 1
+
+# Uncomment and add daemon for pNFS support.
+#sv check rpcblkmapd >/dev/null || exit 1
+
 # Get the nfs service parameters from the LFS standard file
 # this sets some envars.
 if [ -e /etc/conf.d/nfs-server.conf ]; then
 	. /etc/conf.d/nfs-server.conf
 fi
 
-modprobe sunrpc || exit 1
-modprobe nfs || exit 1
-modprobe nfsd || exit 1
+# Check/mount rpc_pipefs (loads sunrpc kernel module)
 if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
 	mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs -o defaults || exit 1
 fi
 
-# Uncomment this and add the two daemons if you need kerberos support.
-# sv check idmapd gssd >/dev/null || exit 1
-
+# Check/mount nfsd (loads nfsd kernel module)
 if ! mountpoint -q /proc/fs/nfsd; then
 	mount -t nfsd nfsd /proc/fs/nfsd || exit 1
 fi
+
 exportfs -ra > /dev/null || exit 1
 rpc.nfsd -- ${PROCESSES:=4} || exit 1
+
+sm-notify
 
 exec rpc.mountd --foreground

--- a/srcpkgs/nfs-utils/files/rpcblkmapd/run
+++ b/srcpkgs/nfs-utils/files/rpcblkmapd/run
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Make sure the portmap service is running.
+sv check rpcbind >/dev/null || exit 1
+
+# Check/mount rpc_pipefs (loads sunrpc kernel module)
+if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
+	mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs -o defaults || exit 1
+fi
+
+# Load blkmapd module
+modprobe blocklayoutdriver || exit 1
+
+exec blkmapd -f

--- a/srcpkgs/nfs-utils/files/rpcgssd/run
+++ b/srcpkgs/nfs-utils/files/rpcgssd/run
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Make sure the portmap service is running.
+sv check rpcbind >/dev/null || exit 1
+
+# Check/mount rpc_pipefs (loads sunrpc kernel module)
+if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
+	mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs -o defaults || exit 1
+fi
+
+exec rpc.gssd -f

--- a/srcpkgs/nfs-utils/files/rpcidmapd/run
+++ b/srcpkgs/nfs-utils/files/rpcidmapd/run
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Make sure the portmap service is running.
+sv check rpcbind >/dev/null || exit 1
+
+# Check/mount rpc_pipefs (loads sunrpc kernel module)
+if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
+	mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs -o defaults || exit 1
+fi
+
+# Check/mount nfsd (loads nfsd kernel module)
+if ! mountpoint -q /proc/fs/nfsd; then
+	mount -t nfsd nfsd /proc/fs/nfsd || exit 1
+fi
+
+exec rpc.idmapd -f

--- a/srcpkgs/nfs-utils/files/rpcsvcgssd/run
+++ b/srcpkgs/nfs-utils/files/rpcsvcgssd/run
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Make sure the portmap service is running.
+sv check rpcbind >/dev/null || exit 1
+
+# Check/mount rpc_pipefs (loads sunrpc kernel module)
+if ! mountpoint -q /var/lib/nfs/rpc_pipefs; then
+	mount -t rpc_pipefs rpc_pipefs /var/lib/nfs/rpc_pipefs -o defaults || exit 1
+fi
+
+# Check/mount nfsd (loads nfsd kernel module)
+if ! mountpoint -q /proc/fs/nfsd; then
+	mount -t nfsd nfsd /proc/fs/nfsd || exit 1
+fi
+
+exec rpc.svcgssd -f

--- a/srcpkgs/nfs-utils/files/statd/run
+++ b/srcpkgs/nfs-utils/files/statd/run
@@ -3,4 +3,7 @@
 # Make sure the portmap service is running.
 sv check rpcbind >/dev/null || exit 1
 
-exec rpc.statd -F -d
+# Load nfs module
+modprobe nfs || exit 1
+
+exec rpc.statd -F -d -L

--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,10 +1,10 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
 version=1.3.4
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
- --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-gss
+ --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-svcgss
  --enable-uuid --enable-ipv6 --without-tcp-wrappers
  --with-tirpcinclude=$XBPS_CROSS_BASE/usr/include/tirpc
  --with-krb5=$XBPS_CROSS_BASE"
@@ -45,6 +45,10 @@ post_install() {
 	vconf ${FILESDIR}/exports
 	vconf ${FILESDIR}/idmapd.conf
 	# runit services
+	vsv rpcblkmapd
+	vsv rpcidmapd
+	vsv rpcgssd
+	vsv rpcsvcgssd
 	vsv statd
 	vsv nfs-server
 	# replacement scripts


### PR DESCRIPTION
Added runit services for rpc.idmapd, rpc.gssd, rpc.svcgssd and blkmapd
Fixed configure options to enable building svcgssd
Restructured statd and nfs-server services