### PR TITLE
rpi-base: fix permissions for /dev/vcio and /dev/vcsm

### DIFF
--- a/srcpkgs/rpi-base/template
+++ b/srcpkgs/rpi-base/template
@@ -1,7 +1,7 @@
 # Template file for 'rpi-base'
 pkgname=rpi-base
 version=2.5
-revision=2
+revision=3
 homepage="http://www.voidlinux.eu"
 short_desc="Void Linux RaspberryPi base files"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -18,8 +18,12 @@ do_install() {
 		echo snd-bcm2835 > ${DESTDIR}/usr/lib/modules-load.d/snd_bcm2835.conf
 		;;
 	esac
-	# Fix permissions for the vchiq device.
+	# Fix permissions for the vchiq, vcio, vcsm devices.
 	vmkdir usr/lib/udev/rules.d
 	echo 'SUBSYSTEM=="vchiq", GROUP="video", MODE="0660"' > \
+		${DESTDIR}/usr/lib/udev/rules.d/71-raspberrypi.rules
+	echo 'SUBSYSTEM=="bcm2708_vcio", GROUP="video", MODE="0660"' >> \
+		${DESTDIR}/usr/lib/udev/rules.d/71-raspberrypi.rules
+	echo 'SUBSYSTEM=="vc-sm", GROUP="video", MODE="0660"' >> \
 		${DESTDIR}/usr/lib/udev/rules.d/71-raspberrypi.rules
 }


### PR DESCRIPTION
`/dev/vcio` and `/dev/vcsm` are currently not accessible by users in the `video` group, which results in broken hw-accelerated video decoding for non-root users.