### PR TITLE
lltag: add metaflac patch

### DIFF
--- a/srcpkgs/lltag/patches/fix_flac_tracknumber_reading.patch
+++ b/srcpkgs/lltag/patches/fix_flac_tracknumber_reading.patch
@@ -1,0 +1,16 @@
+diff --git lib/Lltag/FLAC.pm lib/Lltag/FLAC.pm
+index 8c0186d..5c571a6 100644
+--- lib/Lltag/FLAC.pm
++++ lib/Lltag/FLAC.pm
+@@ -23,8 +23,9 @@ sub read_tags {
+ 	if $status ;
+     @output = map {
+ 	my $line = $_ ;
+-	$line =~ s/^\s*comment\[\d+\]\s*:\s*(.*)/$1/ ;
+-	$line =~ s/^TRACKNUMBER=/NUMBER=/ ;
++	$line =~ s/^\s*comment\[\d+\]\s*:\s*(.*)/$1/i ;
++	$line =~ s/^tracknumber=/NUMBER=/i ;
++	$line =~ s/^track number=/NUMBER=/i ;
+ 	$line
+ 	} ( grep { /comment\[\d+\]/ } @output ) ;
+     return Lltag::Tags::convert_tag_stream_to_values ($self, @output) ;

--- a/srcpkgs/lltag/template
+++ b/srcpkgs/lltag/template
@@ -1,7 +1,7 @@
 # Template file for 'lltag'
 pkgname=lltag
 version=0.14.6
-revision=1
+revision=2
 noarch=yes
 wrksrc="lltag-lltag-${version}"
 build_style=gnu-makefile
@@ -10,7 +10,7 @@ makedepends="${hostmakedepends}"
 depends="perl mp3info vorbis-tools flac perl-MP3-Tag"
 short_desc="Automatic command-line mp3/ogg/flac file tagger and renamer"
 maintainer="eater <=@eater.me>"
-license="GPL-2.0"
+license="GPL-2.0-or-later"
 homepage="http://bgoglin.free.fr/lltag/"
 distfiles="https://github.com/bgoglin/lltag/archive/lltag-${version}.tar.gz"
 checksum=e24c88866d89f90c11bcf89d9d1b4e8af78f486f1f7454a28210b10b8af17252


### PR DESCRIPTION
so apparently I went a bit too fast, or expected lltag already to have this patch included

but this is the latest commit of lltag which fixes metaflac tag track number matching (sorry :( )