### PR TITLE
New package: cryfs-0.9.9

### DIFF
--- a/srcpkgs/cryfs/template
+++ b/srcpkgs/cryfs/template
@@ -1,0 +1,13 @@
+# Template file for 'cryfs'
+pkgname=cryfs
+version=0.9.9
+revision=1
+build_style=cmake
+hostmakedepends="python3 boost"
+makedepends="boost-devel crypto++-devel fuse-devel libressl-devel libcurl-devel"
+short_desc="Cryptographic filesystem for the cloud"
+maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
+license="LGPL-3.0-only"
+homepage="https://www.cryfs.org"
+distfiles="https://github.com/cryfs/${pkgname}/archive/${version}.tar.gz"
+checksum=0915454e67c1afb8785d754d539ab339074d0d75f450b1306fe70450985d1812


### PR DESCRIPTION
cryfs is the new default encrypt back-end of plasma-vault 