### PR TITLE
marble5: update to 17.12.3.

### DIFF
--- a/srcpkgs/marble5/template
+++ b/srcpkgs/marble5/template
@@ -1,7 +1,7 @@
 # Template file for 'marble5'
 pkgname=marble5
 version=17.12.3
-revision=1
+revision=2
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 homepage="https://marble.kde.org"
 license="GPL-3"


### PR DESCRIPTION
Revbumping for rebuild.

Local builds fail with
```
[ 84%] Generating org.kde.plasma.worldclock-plasmoids-metadata.json
/bin/sh: /usr/aarch64-linux-gnu/usr/bin/desktoptojson: cannot execute binary file: Exec format error
make[2]: *** [src/plasma/applets/worldclock/CMakeFiles/org.kde.plasma.worldclock-plasmoids-metadata-json.dir/build.make:61: src/plasma/applets/worldclock/org.kde.plasma.worldclock-plasmoids-metadata.json] Error 126
make[1]: *** [CMakeFiles/Makefile2:10729: src/plasma/applets/worldclock/CMakeFiles/org.kde.plasma.worldclock-plasmoids-metadata-json.dir/all] Error 2
```

Full log here: https://pastebin.com/pam1m0t1