### PR TITLE
eyeD3: update to 0.8.7.

### DIFF
--- a/srcpkgs/eyeD3/template
+++ b/srcpkgs/eyeD3/template
@@ -1,18 +1,18 @@
 # Template file for 'eyeD3'
 pkgname=eyeD3
-version=0.8.5
-revision=2
+version=0.8.7
+revision=1
 noarch=yes
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-grako python3-magic python3-setuptools python3-six"
+depends="python3-grako python3-magic python3-pylast python3-setuptools python3-six"
 pycompile_module="eyed3"
 short_desc="Python3 tool for mp3's ID3 tags manipulation"
-homepage="http://eyed3.nicfit.net/"
-license="GPL-3.0-or-later"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-3.0-or-later"
+homepage="http://eyed3.nicfit.net/"
 distfiles="${homepage}/releases/${pkgname}-${version}.tar.gz"
-checksum=f2bdaf1c7351b0d8fd8226a045360dfd493cd61065f910b411d96de8860eb90a
+checksum=ef924eb2e8fffd7c7e3bd4c94dafad4a3b9047fe2dcb76d5dd7d9c37a1f1f8bb
 
 pre_build() {
 	sed -i '/pathlib/d' requirements/requirements.yml  # ugh


### PR DESCRIPTION
There is still a missing dependency for this package:
````
$ eyeD3
eyed3.plugins:WARNING: Plugin '('lastfm.py', '/usr/lib/python3.6/site-packages/eyed3/plugins')' requires packages that are not installed: No module named 'pylast'
Nothing to do
````
No idea what that is?