### PR TITLE
python-google-api-python-client: update to 1.7.4. 

### DIFF
--- a/srcpkgs/python-cachetools/template
+++ b/srcpkgs/python-cachetools/template
@@ -1,0 +1,29 @@
+# Template file for 'python-cachetools'
+pkgname=python-cachetools
+version=2.1.0
+revision=1
+noarch=yes
+wrksrc="cachetools-${version}"
+build_style=python-module
+pycompile_module="cachetools"
+hostmakedepends="python-setuptools python3-setuptools"
+short_desc="Python2 extensible memoizing collections and decorators"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+homepage="https://github.com/tkem/cachetools/"
+license="MIT"
+distfiles="${PYPI_SITE}/c/cachetools/cachetools-${version}.tar.gz"
+checksum=90f1d559512fc073483fe573ef5ceb39bf6ad3d39edc98dc55178a2b2b176fa3
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3-cachetools_package() {
+	noarch=yes
+	pycompile_module="cachetools"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python-google-api-python-client/template
+++ b/srcpkgs/python-google-api-python-client/template
@@ -1,18 +1,18 @@
 # Template file for 'python-google-api-python-client'
 pkgname=python-google-api-python-client
-version=1.6.7
+version=1.7.4
 revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python-module
 pycompile_module="apiclient googleapiclient"
 hostmakedepends="python-setuptools python3-setuptools"
-depends="python-httplib2 python-oauth2client python-uritemplate python-six"
+depends="python-httplib2 python-google-auth python-google-auth-httplib2 python-uritemplate python-six"
 short_desc="Google API client library for Python2"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/google/google-api-python-client/"
 distfiles="${PYPI_SITE}/g/google-api-python-client/google-api-python-client-${version}.tar.gz"
-checksum=05583a386e323f428552419253765314a4b29828c3cee15be735f9ebfa5aebf2
+checksum=5d5cb02c6f3112c68eed51b74891a49c0e35263380672d662f8bfe85b8114d7c
 noarch=yes
 
 python3-google-api-python-client_package() {

--- a/srcpkgs/python-google-auth-httplib2/template
+++ b/srcpkgs/python-google-auth-httplib2/template
@@ -1,0 +1,26 @@
+# Template file for 'python-google-auth-httplib2'
+pkgname=python-google-auth-httplib2
+version=0.0.3
+revision=1
+wrksrc="${pkgname#*-}-${version}"
+build_style=python-module
+pycompile_module="google_auth_httplib2"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-google-auth python-httplib2 python-six"
+short_desc="Google authentication library for Python2"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="Apache-2.0"
+homepage="https://github.com/GoogleCloudPlatform/google-auth-library-python-httplib2"
+distfiles="${PYPI_SITE}/g/google-auth-httplib2/google-auth-httplib2-${version}.tar.gz"
+checksum=098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445
+noarch=yes
+
+python3-google-auth-httplib2_package() {
+	noarch=yes
+	depends="python3-google-auth python3-httplib2 python3-six"
+	pycompile_module="google_auth_httplib2"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python-google-auth/template
+++ b/srcpkgs/python-google-auth/template
@@ -1,0 +1,26 @@
+# Template file for 'python-google-auth'
+pkgname=python-google-auth
+version=1.5.0
+revision=1
+wrksrc="${pkgname#*-}-${version}"
+build_style=python-module
+pycompile_module="google"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-pyasn1-modules python-rsa python-six python-cachetools"
+short_desc="Google authentication library for Python2"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="Apache-2.0"
+homepage="https://google-auth.readthedocs.io/en/latest/"
+distfiles="${PYPI_SITE}/g/google-auth/google-auth-${version}.tar.gz"
+checksum=1745c9066f698eac3da99cef082914495fb71bc09597ba7626efbbb64c4acc57
+noarch=yes
+
+python3-google-auth_package() {
+	noarch=yes
+	depends="python3-pyasn1-modules python3-rsa python3-six python3-cachetools"
+	pycompile_module="google"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python3-cachetools
+++ b/srcpkgs/python3-cachetools
@@ -1,0 +1,1 @@
+python-cachetools

--- a/srcpkgs/python3-google-auth
+++ b/srcpkgs/python3-google-auth
@@ -1,0 +1,1 @@
+python-google-auth

--- a/srcpkgs/python3-google-auth-httplib2
+++ b/srcpkgs/python3-google-auth-httplib2
@@ -1,0 +1,1 @@
+python-google-auth-httplib2


### PR DESCRIPTION
Includes three new packages required as python-google-api-python-client drops python-oauth2client for python-google-auth.