### PR TITLE
libGL: fixed build issue and enabled wayland support in EGL

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -7,7 +7,7 @@ build_style=gnu-configure
 configure_args="--enable-shared-glapi --enable-gbm
  --enable-egl --enable-vdpau --enable-xvmc --enable-osmesa
  --enable-texture-float --enable-gles1 --enable-gles2
- --with-platforms=x11,drm"
+ --with-platforms=x11,drm,wayland"
 hostmakedepends="automake flex libtool libxml2-python llvm pkg-config
  python-Mako"
 makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel
@@ -80,6 +80,7 @@ esac
 
 pre_configure() {
 	libtoolize -f
+	export PKG_CONFIG_PATH=/usr/share/pkgconfig
 	NOCONFIGURE=1 ./autogen.sh
 	case "$XBPS_TARGET_MACHINE" in
 		armv6*) sed -i src/gallium/drivers/vc4/Makefile.am \


### PR DESCRIPTION
A recent update to mesa broke pretty much every Vulkan application on my system. The issue appeared to be that libEGL was not being built with Wayland support, and this change seemed to fix that. Can anyone else confirm this behavior?

The PKG_CONFIG_PATH fix was necessary as pkg-config seems to only look in `/usr/lib/pkgconfig` by default, which is not where libclc was putting its .pc file.