### PR TITLE
New package: wxPython3-4.0.3

### DIFF
--- a/srcpkgs/wxPython3/template
+++ b/srcpkgs/wxPython3/template
@@ -1,0 +1,47 @@
+# Template file for 'wxPython3'
+pkgname=wxPython3
+version=4.0.3
+revision=1
+wrksrc="${pkgname//3/}-${version}"
+hostmakedepends="pkg-config python3-setuptools"
+makedepends="
+ zlib-devel libpng-devel libjpeg-turbo-devel tiff-devel expat-devel gtk+-devel
+ libSM-devel MesaLib-devel glu-devel webkitgtk-devel libXtst-devel SDL-devel
+ libnotify-devel python3-devel wxWidgets-devel gst-plugins-base1-devel"
+depends="python3"
+pycompile_module="wx-3.0-gtk2 wxversion3.py"
+short_desc="The wxWidgets GUI toolkit library (Python3 Bindings)"
+maintainer="Jasper Chan <jasperchan515@gmail.com>"
+homepage="http://www.wxpython.org/"
+license="wxWindows"
+distfiles="https://files.pythonhosted.org/packages/dd/31/bd55ab40e406a026a7fda0bb5eb61f466682544ae91ac26267c750f5e618/wxPython-4.0.3.tar.gz"
+checksum=8d0dfc0146c24749ce00d575e35cc2826372e809d5bc4a57bde6c89031b59e75
+
+if [ -n "${CROSS_BUILD}" ]; then
+	hostmakedepends+=" python3"
+	CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/python${py3_ver}"
+fi
+
+#pre_configure() {
+#	mv wxPython/wx/tools/Editra/{editra,Editra}
+#}
+
+do_build() {
+	#cd wxPython
+	python3 setup.py build
+}
+
+do_install() {
+	# The path where includes are going to be installed is prefixed with WXPREFIX obtained
+	# from 'wx-config --prefix' but in a cross build this is '$XBPS_CROSS_BASE/usr'.
+	python3 setup.py install --root=${DESTDIR}
+	vlicense LICENSE.txt LICENSE
+}
+
+#wxPython3-devel_package() {
+#	depends="wxWidgets-devel ${sourcepkg}>=${version}_${revision}"
+#	short_desc+=" - development files"
+#	pkg_install() {
+#		vmove usr/include
+#	}
+#}


### PR DESCRIPTION
wxPython for Python 3.

As far as I can tell this doesn't come with any kind of development headers like there are in wxPython, so there isn't a -devel package to go with it.