### PR TITLE
common/hooks/pre-configure: fix python3 wrapper [skip ci]

### DIFF
--- a/common/hooks/pre-configure/02-script-wrapper.sh
+++ b/common/hooks/pre-configure/02-script-wrapper.sh
@@ -153,5 +153,5 @@ hook() {
 	generic_wrapper3 libetpan-config
 	generic_wrapper3 giblib-config
 	python_wrapper python-config 2.7
-	python_wrapper python3.4-config 3.4m
+	python_wrapper python3-config 3.6m
 }


### PR DESCRIPTION
The wrapper for python3 is still pointing to 3.4. This adjusts it to use the current version.