### PR TITLE
New packages: beancount and fava (and dependencies)

### DIFF
--- a/srcpkgs/beancount/template
+++ b/srcpkgs/beancount/template
@@ -1,0 +1,17 @@
+# Template file for 'beancount'
+pkgname=beancount
+version=2.2.1
+revision=1
+build_style=python3-module
+pycompile_module="beancount"
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel"
+depends="python3-pytest python3-dateutil python3-ply python3-bottle python3-lxml
+ python3-magic python3-BeautifulSoup4 python3-requests python3-chardet
+ python3-google-api-python-client"
+short_desc="Double-entry accounting system based on plain text files"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="GPL-2.0-only"
+homepage="http://furius.ca/beancount/"
+distfiles="${PYPI_SITE}/b/beancount/beancount-${version}.tar.gz"
+checksum=ebcb59bd7c0e18a858c55d6c30eacee3fa949ee5d2c452a7aa80690e36ae2f77

--- a/srcpkgs/fava/template
+++ b/srcpkgs/fava/template
@@ -1,0 +1,21 @@
+# Template file for 'fava'
+pkgname=fava
+version=1.10
+revision=1
+noarch=yes
+build_style=python3-module
+pycompile_module="fava"
+hostmakedepends="python3-setuptools"
+depends="python3-Babel python3-Cheroot python3-Flask-Babel python3-Flask
+ python3-Jinja2 beancount python3-click python3-markdown2 python3-ply
+ python3-simplejson"
+short_desc="Web interface for Beancount"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://beancount.github.io/fava/"
+distfiles="${PYPI_SITE}/f/fava/fava-${version}.tar.gz"
+checksum=5207d0ee49f86b5f7520ea7d556e769321853bb8eaa760acc606e4f76d49a990
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python-bottle/template
+++ b/srcpkgs/python-bottle/template
@@ -1,0 +1,29 @@
+# Template file for 'python-bottle'
+pkgname=python-bottle
+version=0.12.16
+revision=1
+noarch=yes
+wrksrc="bottle-${version}"
+build_style=python-module
+pycompile_module="bottle"
+hostmakedepends="python-setuptools python3-setuptools"
+short_desc="Fast and simple WSGI-framework for small web-applications (Python2)"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="http://bottlepy.org"
+distfiles="https://github.com/bottlepy/bottle/archive/${version}.tar.gz"
+checksum=@71fc9dbf5159e2f37ae4a79dfa816538cb8ed7a6908f09e1086160055a2d0225
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3-bottle_package() {
+	noarch=yes
+	pycompile_module="bottle"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove "usr/lib/python3*"
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python-markdown2/patches/disable-building-wheel-by-default.patch
+++ b/srcpkgs/python-markdown2/patches/disable-building-wheel-by-default.patch
@@ -1,0 +1,10 @@
+diff --git setup.cfg setup.cfg
+index 4fe3b74..139986d 100644
+--- setup.cfg
++++ setup.cfg
+@@ -1,5 +1,4 @@
+ [aliases]
+-build=sdist bdist_wheel
+ 
+ [wheel]
+ universal = 1

--- a/srcpkgs/python-markdown2/template
+++ b/srcpkgs/python-markdown2/template
@@ -1,0 +1,28 @@
+# Template file for 'python-markdown2'
+pkgname=python-markdown2
+version=2.3.7
+revision=1
+noarch=yes
+build_style=python-module
+pycompile_module="markdown2"
+hostmakedepends="python-setuptools python3-setuptools"
+short_desc="Fast and complete implementation of Markdown in Python2"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://github.com/trentm/python-markdown2"
+distfiles="https://github.com/trentm/python-markdown2/archive/${version}.tar.gz"
+checksum=@4576ebde09526f20c873a73775192851b7e9ed5f521fac34303ed0a8b8eda1ed
+
+post_install() {
+	vlicense LICENSE.txt
+}
+
+python3-markdown2_package() {
+	noarch=yes
+	pycompile_module="markdown2"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove "usr/lib/python3*"
+		vlicense LICENSE.txt
+	}
+}

--- a/srcpkgs/python3-bottle
+++ b/srcpkgs/python3-bottle
@@ -1,0 +1,1 @@
+python-bottle

--- a/srcpkgs/python3-markdown2
+++ b/srcpkgs/python3-markdown2
@@ -1,0 +1,1 @@
+python-markdown2


### PR DESCRIPTION
[Resubmitting](https://github.com/voidlinux/void-packages/pull/14348) from the old repository.