### PR TITLE
llvm3.9: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,7 +1,7 @@
 # Template file for 'julia'
 pkgname=julia
 version=0.6.4
-revision=1
+revision=2
 wrksrc=julia
 nocross=yes
 build_style=gnu-makefile

--- a/srcpkgs/llvm3.9/template
+++ b/srcpkgs/llvm3.9/template
@@ -2,7 +2,7 @@
 # Only a transitional package until Rust works with LLVM 4.0.
 pkgname=llvm3.9
 version=3.9.1
-revision=2
+revision=3
 wrksrc="llvm-${version}.src"
 lib32disabled=yes
 build_style=cmake


### PR DESCRIPTION
[ci skip] This revision bump will resolve the build error on PR #207.