### PR TITLE
stellarium: drop only_for_archs

### DIFF
--- a/srcpkgs/stellarium/patches/cmake-gles.patch
+++ b/srcpkgs/stellarium/patches/cmake-gles.patch
@@ -1,0 +1,27 @@
+--- CMakeLists.txt.orig	2018-07-01 08:04:19.000000000 +0200
++++ CMakeLists.txt	2018-07-17 08:52:24.193931980 +0200
+@@ -418,24 +418,6 @@
+      ADD_DEFINITIONS(-DUSE_OLD_QGLWIDGET)
+ ENDIF()
+ 
+-# Since Qt 5.4, linking to OpenGL is basically not required anymore,
+-# because the QtGui module re-implements the GL functions, and perhaps even
+-# dispatches the calls to a dynamically selected GL library.
+-#
+-# The only exception where this does not work with CMake is for
+-# ES2-only/ANGLE-only builds, which are seemingly not included in
+-# official Qt downloads, but may be required as a custom build
+-# for some embedded systems. Interestingly, this works with qmake,
+-# but CMake needs an explicit link definition.
+-# See also this bug: https://bugreports.qt.io/browse/QTBUG-29132
+-
+-# Check if we have a GLES-only build
+-# On dynamic builds, this property is also "GL"
+-IF(${Qt5Gui_OPENGL_IMPLEMENTATION} MATCHES "GLES")
+-     MESSAGE(STATUS "Building an OpenGL ES build (${Qt5Gui_OPENGL_IMPLEMENTATION})")
+-     SET(STEL_GLES_LIBS Qt5::Gui_EGL Qt5::Gui_GLESv2)
+-ENDIF()
+-
+ 
+ # Tell CMake to run moc when necessary:
+ SET(CMAKE_AUTOMOC ON)

--- a/srcpkgs/stellarium/template
+++ b/srcpkgs/stellarium/template
@@ -13,4 +13,3 @@ license="GPL-2.0-or-later"
 homepage="http://www.stellarium.org/"
 distfiles="https://github.com/Stellarium/stellarium/releases/download/v${version}/stellarium-${version}.tar.gz"
 checksum=38d34538f3dc87943bc2977aeb1c099339b0ea1da63a3565e36409e165e6536e
-only_for_archs="i686 i686-musl x86_64 x86_64-musl"


### PR DESCRIPTION
Stellarium works just fine on my RPi, so I think `only_for_archs` can be dropped. ;)

The only thing necessary is to remove cmake’s check for a GLES-only build, because it tries to link against libraries that aren’t available (?) and it seems Void’s Qt5 provides everything needed as is.