### PR TITLE
ncmpcpp: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/ncmpcpp/template
+++ b/srcpkgs/ncmpcpp/template
@@ -1,7 +1,7 @@
 # Template file for 'ncmpcpp'
 pkgname=ncmpcpp
 version=0.8.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args=" BOOST_LIB_SUFFIX= --enable-clock --enable-outputs
  --enable-unicode --enable-visualizer --with-curl --with-taglib --with-fftw"

--- a/srcpkgs/taglib/template
+++ b/srcpkgs/taglib/template
@@ -1,7 +1,7 @@
 # Template file for 'taglib'
 pkgname=taglib
 version=1.11.1
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DWITH_MP4=ON -DWITH_ASF=ON -DBUILD_SHARED_LIBS=ON"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
https://github.com/void-linux/void-packages/issues/983