### PR TITLE
freecad: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -5,7 +5,7 @@
 #  - python3: freecad code not yet ready for it, probably at 0.18
 pkgname=freecad
 version=0.17
-revision=3
+revision=4
 wrksrc="FreeCAD-${version}"
 build_style=cmake
 


### PR DESCRIPTION
https://github.com/void-linux/void-packages/issues/983