### PR TITLE
 ffmpegthumbnailer: rebiuld for gcc stdc++ dropping gcc4 compat and update deepin-movie-rebron

### DIFF
--- a/srcpkgs/deepin-movie-reborn/template
+++ b/srcpkgs/deepin-movie-reborn/template
@@ -1,7 +1,7 @@
 # Template file for 'deepin-movie-reborn'
 pkgname=deepin-movie-reborn
-version=3.2.7
-revision=2
+version=3.2.8
+revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
 makedepends="dtkwidget-devel ffmpegthumbnailer-devel libdvdnav-devel mpv-devel
@@ -15,18 +15,15 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/linuxdeepin/deepin-movie-reborn"
 changelog="https://github.com/linuxdeepin/deepin-movie-reborn/blob/${version}/CHANGELOG.md"
 distfiles="https://github.com/linuxdeepin/deepin-movie-reborn/archive/${version}.tar.gz"
-checksum=25371d8407060aa791489b3c73127a1333d3396875dacc6074336dc77e8fb39a
-
-
-case $XBPS_TARGET_MACHINE in
-	arm*) broken="https://travis-ci.org/void-linux/void-packages/jobs/394936356";;
-	aarch64*) ;;
-	*) CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0";;
-esac
+checksum=e3236f719fca9b28beefddfbbcf463ce35f2d4b6f47d12b27d831e281335bf2b
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" dtkcore-devel"
 fi
+
+case $XBPS_TARGET_MACHINE in
+	arm*) broken="https://travis-ci.org/void-linux/void-packages/jobs/394936356";;
+esac
 
 deepin-movie-reborn-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/ffmpegthumbnailer/template
+++ b/srcpkgs/ffmpegthumbnailer/template
@@ -1,14 +1,14 @@
 # Template file for 'ffmpegthumbnailer'
 pkgname=ffmpegthumbnailer
 version=2.2.0
-revision=3
+revision=4
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="libpng-devel libjpeg-turbo-devel ffmpeg-devel"
 depends="ffmpeg"
 short_desc="Lightweight video thumbnailer"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/dirkvdb/${pkgname}"
 distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.bz2"
 checksum=e5c31299d064968198cd378f7488e52cd5e738fac998eea780bc77d7f32238c2


### PR DESCRIPTION
Other Packages that depend on ffmpegthumbnailer do not use the only function that will change with this rebuild and therefore have not to be rebuild.