### PR TITLE
New package: links-x11-2.16

### DIFF
--- a/srcpkgs/links-x11/template
+++ b/srcpkgs/links-x11/template
@@ -1,0 +1,22 @@
+# Template file for 'links-x11'
+pkgname=links-x11
+version=2.16
+revision=1
+wrksrc="${pkgname%-x11}-${version}"
+build_style=gnu-configure
+configure_args="--with-ssl --enable-graphics --enable-x"
+hostmakedepends="pkg-config"
+makedepends="bzip2-devel gpm-devel libpng-devel libressl-devel tiff-devel
+ libX11-devel libXt-devel"
+short_desc="Graphics and text mode web browser (with X11 graphics driver)"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="GPL-2.0-or-later"
+homepage="http://links.twibright.com/"
+distfiles="http://links.twibright.com/download/links-${version}.tar.gz"
+checksum=83ab4557d9b121570384d1bd27adf16f962b9b007bac5780ae094e6fff6b3d62
+conflicts="links"
+
+post_install() {
+	mkdir -p ${DESTDIR}/usr/share/doc/
+	mv doc/ ${DESTDIR}/usr/share/doc/links
+}


### PR DESCRIPTION
closes #1082 

Tested on x86_64 and armv7l-musl. Everything looks good. :)

Just not sure if a revbump is required, but since it doesn’t influence packages in the official repo I decided against it.