### PR TITLE
blender: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -1,7 +1,7 @@
 # Template file for 'blender'
 pkgname=blender
 version=2.79b
-revision=4
+revision=5
 build_style="cmake"
 makedepends="
  libgomp-devel libpng-devel tiff-devel python3-devel glu-devel

--- a/srcpkgs/ilmbase/template
+++ b/srcpkgs/ilmbase/template
@@ -1,7 +1,7 @@
 # Template file for 'ilmbase'
 pkgname=ilmbase
 version=2.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Base libraries from ILM for OpenEXR"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/opencollada/patches/004-fix-libpcre-8.42-compat.patch
+++ b/srcpkgs/opencollada/patches/004-fix-libpcre-8.42-compat.patch
@@ -1,0 +1,23 @@
+From 7b4c3ce3407c47619cd4e79052d60db4ce937327 Mon Sep 17 00:00:00 2001
+From: Dennis Schridde <devurandom@gmx.net>
+Date: Thu, 12 Jul 2018 06:52:36 +0200
+Subject: [PATCH] COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h:
+ Include pcre.h
+
+This fixes a compilation error with libpcre-8.42:
+```
+error: conflicting declaration 'typedef struct real_pcre8_or_16 pcre'
+```
+
+--- COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h
++++ COLLADABaseUtils/include/COLLADABUPcreCompiledPattern.h
+@@ -13,8 +13,7 @@
+ 
+ #include "COLLADABUPrerequisites.h"
+ 
+-struct real_pcre;
+-typedef struct real_pcre pcre;
++#include <pcre.h>
+ 
+ 
+ namespace COLLADABU

--- a/srcpkgs/opencollada/template
+++ b/srcpkgs/opencollada/template
@@ -1,7 +1,7 @@
 # Template file for 'opencollada'
 pkgname=opencollada
 version=1.6.62
-revision=1
+revision=2
 wrksrc="OpenCOLLADA-${version}"
 build_style=cmake
 configure_args="-DUSE_SHARED=TRUE"

--- a/srcpkgs/openexr/template
+++ b/srcpkgs/openexr/template
@@ -1,7 +1,7 @@
 # Template file for 'openexr'
 pkgname=openexr
 version=2.2.0
-revision=7
+revision=8
 build_style=gnu-configure
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.openexr.com/"

--- a/srcpkgs/openimageio/template
+++ b/srcpkgs/openimageio/template
@@ -1,7 +1,7 @@
 # Template file for 'openimageio'
 pkgname=openimageio
 version=1.8.12
-revision=4
+revision=5
 wrksrc=oiio-Release-${version}
 build_style=cmake
 configure_args="-DUSE_OPENGL=0 -DUSE_QT=0 -DUSE_PYTHON=0 -DOIIO_BUILD_TESTS=0


### PR DESCRIPTION
Patch for `opencollada` I've taken from [here](https://github.com/devurandom/gentoo-patches/blob/2cca58e47c155282cf514ef85989dd6e1b3f701f/media-libs/opencollada-1.6.62/opencollada-1.6.62-2-fix-libpcre-8.42-compat-7b4c3ce3407c47619cd4e79052d60db4ce937327.patch)
https://github.com/void-linux/void-packages/issues/983