### PR TITLE
polybar: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/polybar/template
+++ b/srcpkgs/polybar/template
@@ -1,7 +1,7 @@
 # Template file for 'polybar'
 pkgname=polybar
 version=3.1.0
-revision=2
+revision=3
 _i3ipcpp_version=0.7.0
 _xpp_version=1.4.0
 build_style=cmake


### PR DESCRIPTION
#983 