### PR TITLE
glibmm: rebuild for gcc stdc++ dropping gcc4 compat (part of rebuilding patchage)

### DIFF
--- a/srcpkgs/glibmm/template
+++ b/srcpkgs/glibmm/template
@@ -1,7 +1,7 @@
 # Template build file for 'glibmm'
 pkgname=glibmm
 version=2.56.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="mm-common"
 makedepends="libglib-devel libsigc++-devel"


### PR DESCRIPTION
`glibmm` needs a rebuild first. Then we can revbump `gtkmm2` and `patchage`.
https://github.com/void-linux/void-packages/issues/1088

https://github.com/void-linux/void-packages/issues/983