### PR TITLE
polybar: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/polybar/patches/Add-support-for-eventstruct.patch
+++ b/srcpkgs/polybar/patches/Add-support-for-eventstruct.patch
@@ -1,0 +1,44 @@
+From 00165e1a6d5dd61bc153e1352b21ec07fc81245d Mon Sep 17 00:00:00 2001
+From: patrick96 <p.ziegler96@gmail.com>
+Date: Sun, 11 Feb 2018 21:27:52 +0100
+Subject: [PATCH] fix(generators): Add support for eventstruct
+
+Newer xcb-proto commits after the 1.12 release require the 'eventstruct'
+key in the output dictionary, otherwise the generator crashes.
+
+I don't see a need for xpp to actually support the eventstruct key and
+thus it uses a NOP lambda function
+---
+ generators/cpp_client.py | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/generators/cpp_client.py b/generators/cpp_client.py
+index 20d116f..709e8d8 100644
+--- lib/xpp/generators/cpp_client.py
++++ lib/xpp/generators/cpp_client.py
+@@ -3130,15 +3130,16 @@ def cpp_type_classes():
+ #           }
+ 
+ # Must create an "output" dictionary before any xcbgen imports.
+-output = {'open'    : c_open,
+-          'close'   : c_close,
+-          'simple'  : c_simple, # lambda x, y: None,
+-          'enum'    : lambda x, y: None,
+-          'struct'  : lambda x, y: None,
+-          'union'   : lambda x, y: None,
+-          'request' : c_request,
+-          'event'   : cpp_event,
+-          'error'   : cpp_error,
++output = {'open'          : c_open,
++          'close'         : c_close,
++          'simple'        : c_simple, # lambda x, y: None,
++          'enum'          : lambda x, y: None,
++          'struct'        : lambda x, y: None,
++          'union'         : lambda x, y: None,
++          'request'       : c_request,
++          'event'         : cpp_event,
++          'error'         : cpp_error,
++          'eventstruct'   : lambda x, y: None,
+           }
+ 
+ # Boilerplate below this point

--- a/srcpkgs/polybar/template
+++ b/srcpkgs/polybar/template
@@ -1,7 +1,7 @@
 # Template file for 'polybar'
 pkgname=polybar
 version=3.1.0
-revision=2
+revision=3
 _i3ipcpp_version=0.7.0
 _xpp_version=1.4.0
 build_style=cmake


### PR DESCRIPTION
resolves https://github.com/void-linux/void-packages/issues/1089