### PR TITLE
pamixer: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/pamixer/template
+++ b/srcpkgs/pamixer/template
@@ -1,7 +1,7 @@
 # Template file for 'pamixer'
 pkgname=pamixer
 version=1.3.1
-revision=5
+revision=6
 build_style=gnu-makefile
 makedepends="pulseaudio-devel boost-devel"
 short_desc="Pulseaudio command line mixer"


### PR DESCRIPTION
resolves https://github.com/void-linux/void-packages/issues/1103