### PR TITLE
xbps-src: update_check.sh: check distfile existence for kde

### DIFF
--- a/srcpkgs/baloo-widgets5/update
+++ b/srcpkgs/baloo-widgets5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/baloo5/update
+++ b/srcpkgs/baloo5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/bluez-qt5/update
+++ b/srcpkgs/bluez-qt5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/kactivities5-stats/update
+++ b/srcpkgs/kactivities5-stats/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname/5/}

--- a/srcpkgs/kactivities5/update
+++ b/srcpkgs/kactivities5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/kate5/update
+++ b/srcpkgs/kate5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/kde-gtk-config5/update
+++ b/srcpkgs/kde-gtk-config5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/kdeplasma-addons5/update
+++ b/srcpkgs/kdeplasma-addons5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/kfilemetadata5/update
+++ b/srcpkgs/kfilemetadata5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/libkexiv25/update
+++ b/srcpkgs/libkexiv25/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/libkipi5/update
+++ b/srcpkgs/libkipi5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/marble5/update
+++ b/srcpkgs/marble5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/modemmanager-qt5/update
+++ b/srcpkgs/modemmanager-qt5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/networkmanager-qt5/update
+++ b/srcpkgs/networkmanager-qt5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/okteta5/update
+++ b/srcpkgs/okteta5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%5}

--- a/srcpkgs/oxygen-gtk+/update
+++ b/srcpkgs/oxygen-gtk+/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname//\+/2}

--- a/srcpkgs/oxygen-gtk+3/update
+++ b/srcpkgs/oxygen-gtk+3/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname//\+/}

--- a/srcpkgs/phonon-qt5-backend-gstreamer/update
+++ b/srcpkgs/phonon-qt5-backend-gstreamer/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname/-qt5/}

--- a/srcpkgs/phonon-qt5-backend-vlc/update
+++ b/srcpkgs/phonon-qt5-backend-vlc/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname/-qt5/}

--- a/srcpkgs/phonon-qt5/update
+++ b/srcpkgs/phonon-qt5/update
@@ -1,0 +1,1 @@
+pkgname=${pkgname%-*}


### PR DESCRIPTION
KDE distfile storage is based on versionned "folder".
An existing folder_version does not mean that the corresponding
distifile exists, so let's check its existence.

This PR provides also the missing `update` files related to this new detection.


Annotated Example:
```
$ ./xbps-src update-check okteta5
okteta5-17.12.1 -> okteta5-17.12.3      ## OK
okteta5-17.12.1 -> okteta5-18.04.0      ## false: no such a release
okteta5-17.12.1 -> okteta5-18.04.1      ## false: no such a release
okteta5-17.12.1 -> okteta5-18.04.2      ## false: no such a release
okteta5-17.12.1 -> okteta5-18.04.3      ## false: no such a release
```

The same with this PR version:
```
$ XBPS_UPDATE_CHECK_VERBOSE=1 ./xbps-src update-check okteta5
=> Using `/build/packages/hostdir/binpkgs/kde.fix.update.check' as local repository.
using okteta5/update overrides
(folder) fetching https://download.kde.org/stable/applications/
fetching https://www.kde.org/applications/utilities/okteta/
fetching https://download.kde.org/stable/applications/17.12.3/src/
fetching https://download.kde.org/stable/applications/18.04.0/src/
fetching https://download.kde.org/stable/applications/18.04.1/src/
fetching https://download.kde.org/stable/applications/18.04.2/src/
fetching https://download.kde.org/stable/applications/18.04.3/src/
found version 17.12.3
okteta5-17.12.1 -> okteta5-17.12.3
```
