### PR TITLE
taglib: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/taglib/template
+++ b/srcpkgs/taglib/template
@@ -1,7 +1,7 @@
 # Template file for 'taglib'
 pkgname=taglib
 version=1.11.1
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DWITH_MP4=ON -DWITH_ASF=ON -DBUILD_SHARED_LIBS=ON"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
fixes https://github.com/void-linux/void-packages/issues/1126