### PR TITLE
gtkmm2: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/gparted/template
+++ b/srcpkgs/gparted/template
@@ -1,7 +1,7 @@
 # Template file for 'gparted'
 pkgname=gparted
 version=0.31.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libparted-dmraid"
 hostmakedepends="gnome-doc-utils intltool pkg-config"

--- a/srcpkgs/gtkmm2/template
+++ b/srcpkgs/gtkmm2/template
@@ -1,7 +1,7 @@
 # Template file for 'gtkmm2'
 pkgname=gtkmm2
 version=2.24.5
-revision=2
+revision=3
 wrksrc="gtkmm-${version}"
 build_style=gnu-configure
 configure_args="--disable-static --disable-documentation"

--- a/srcpkgs/nitrogen/template
+++ b/srcpkgs/nitrogen/template
@@ -1,7 +1,7 @@
 # Template file for 'nitrogen'
 pkgname=nitrogen
 version=1.6.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="gtkmm2-devel libXinerama-devel"

--- a/srcpkgs/patchage/template
+++ b/srcpkgs/patchage/template
@@ -1,7 +1,7 @@
 # Template file for 'patchage'
 pkgname=patchage
 version=1.0.0
-revision=2
+revision=3
 build_style=waf
 hostmakedepends="pkg-config python"
 makedepends="gtkmm2-devel alsa-lib-devel jack-devel boost-devel ganv-devel"


### PR DESCRIPTION
resolves https://github.com/void-linux/void-packages/issues/1088