### PR TITLE
tinyxml, gtkmm, crypto++, pcre and dependants: rebuild for gcc stdc++ dropping gcc4 compat 

### DIFF
--- a/srcpkgs/FreeDoko/template
+++ b/srcpkgs/FreeDoko/template
@@ -1,7 +1,7 @@
 # Template file for 'FreeDoko'
 pkgname=FreeDoko
 version=0.7.17
-revision=1
+revision=2
 wrksrc="FreeDoko_${version}"
 build_style=gnu-makefile
 make_build_target="compile"

--- a/srcpkgs/MEGAcmd/template
+++ b/srcpkgs/MEGAcmd/template
@@ -1,7 +1,7 @@
 # Template file for 'MEGAcmd'
 pkgname=MEGAcmd
 version=0.9.9
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_args='LIBTOOLFLAGS="--tag=CXX"'
 hostmakedepends="autoconf-archive autogen gettext automake libtool pkg-config"

--- a/srcpkgs/MEGAsdk/template
+++ b/srcpkgs/MEGAsdk/template
@@ -1,7 +1,7 @@
 # Template file for 'MEGAsdk'
 pkgname=MEGAsdk
 version=3.3.9
-revision=1
+revision=2
 wrksrc=sdk-${version}
 build_style=gnu-configure
 configure_args="--enable-chat --disable-examples $(vopt_with libuv)"

--- a/srcpkgs/cclive/template
+++ b/srcpkgs/cclive/template
@@ -1,7 +1,7 @@
 # Template file for 'cclive'
 pkgname=cclive
 version=0.7.16
-revision=9
+revision=10
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="boost-devel pcre-devel libcurl-devel libquvi-devel glibmm-devel"

--- a/srcpkgs/cegui07/template
+++ b/srcpkgs/cegui07/template
@@ -1,7 +1,7 @@
 # Template file for 'cegui07'
 pkgname=cegui07
 version=0.7.9
-revision=4
+revision=5
 wrksrc=CEGUI-${version}
 build_style=gnu-configure
 configure_args="--disable-samples"

--- a/srcpkgs/codecrypt/template
+++ b/srcpkgs/codecrypt/template
@@ -1,7 +1,7 @@
 # Template file for 'codecrypt'
 pkgname=codecrypt
 version=1.8
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="crypto++-devel fftw-devel gmp-devel"

--- a/srcpkgs/crypto++/template
+++ b/srcpkgs/crypto++/template
@@ -1,7 +1,7 @@
 # Template build file for 'crypto++'.
 pkgname=crypto++
 version=565
-revision=2
+revision=3
 create_wrksrc=yes
 build_style=gnu-makefile
 make_build_target="libcryptopp.so libcryptopp.a"

--- a/srcpkgs/fifechan/template
+++ b/srcpkgs/fifechan/template
@@ -1,7 +1,7 @@
 # Template file for 'fifechan'
 pkgname=fifechan
 version=0.1.4
-revision=1
+revision=2
 build_style=cmake
 makedepends="SDL2-devel MesaLib-devel SDL2_image-devel"
 short_desc="A C++ GUI library designed for games"

--- a/srcpkgs/fifengine/template
+++ b/srcpkgs/fifengine/template
@@ -1,7 +1,7 @@
 # Template file for 'fifengine'
 pkgname=fifengine
 version=0.4.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="swig python"
 makedepends="SDL2-devel SDL2_image-devel SDL2_ttf-devel boost-devel

--- a/srcpkgs/gnome-system-monitor/template
+++ b/srcpkgs/gnome-system-monitor/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-system-monitor'
 pkgname=gnome-system-monitor
 version=3.26.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-systemd"
 hostmakedepends="pkg-config intltool itstool glib-devel gnome-doc-utils"

--- a/srcpkgs/gnote/template
+++ b/srcpkgs/gnote/template
@@ -1,7 +1,7 @@
 # Template file for 'gnote'
 pkgname=gnote
 version=3.28.0
-revision=1
+revision=2
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-static --with-x11-support --with-cxx11-support"

--- a/srcpkgs/grub-customizer/template
+++ b/srcpkgs/grub-customizer/template
@@ -1,7 +1,7 @@
 # Template file for 'grub-customizer'
 pkgname=grub-customizer
 version=5.0.8
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gtkmm-devel libressl-devel libarchive-devel"

--- a/srcpkgs/gsmartcontrol/template
+++ b/srcpkgs/gsmartcontrol/template
@@ -1,7 +1,7 @@
 # Template file for 'gsmartcontrol'
 pkgname=gsmartcontrol
 version=1.1.3
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtkmm-devel pcre-devel desktop-file-utils"

--- a/srcpkgs/gsmartcontrol/template
+++ b/srcpkgs/gsmartcontrol/template
@@ -1,7 +1,7 @@
 # Template file for 'gsmartcontrol'
 pkgname=gsmartcontrol
 version=1.1.3
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtkmm-devel pcre-devel desktop-file-utils"

--- a/srcpkgs/gtkmm/template
+++ b/srcpkgs/gtkmm/template
@@ -1,7 +1,7 @@
 # Template build file for 'gtkmm'.
 pkgname=gtkmm
 version=3.22.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-documentation"
 hostmakedepends="automake libtool pkg-config mm-common"

--- a/srcpkgs/gtksourceviewmm/template
+++ b/srcpkgs/gtksourceviewmm/template
@@ -1,7 +1,7 @@
 # Template file for 'gtksourceviewmm'
 pkgname=gtksourceviewmm
 version=3.18.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-deprecated-api --disable-documentation"
 hostmakedepends="pkg-config"

--- a/srcpkgs/kodi-rpi/template
+++ b/srcpkgs/kodi-rpi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi-rpi'
 pkgname=kodi-rpi
 version=17.6
-revision=3
+revision=4
 build_style=cmake
 patch_args="-Np1"
 _codename="Krypton"

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=17.6
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DENABLE_INTERNAL_CROSSGUID=OFF"
 patch_args="-Np1"

--- a/srcpkgs/libgdlmm/template
+++ b/srcpkgs/libgdlmm/template
@@ -2,7 +2,7 @@
 pkgname=libgdlmm
 _realname=gdlmm
 version=3.7.3
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"

--- a/srcpkgs/mate-system-monitor/template
+++ b/srcpkgs/mate-system-monitor/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-system-monitor'
 pkgname=mate-system-monitor
 version=1.20.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="glib-devel intltool itstool pkg-config"
 makedepends="dbus-glib-devel gtkmm-devel libgtop-devel librsvg-devel

--- a/srcpkgs/nemiver/template
+++ b/srcpkgs/nemiver/template
@@ -1,7 +1,7 @@
 # Template build file for 'nemiver'.
 pkgname=nemiver
 version=0.9.6
-revision=3
+revision=4
 lib32disabled=yes
 build_style=gnu-configure
 configure_args="--disable-static --enable-gsettings=yes

--- a/srcpkgs/opencolorio/template
+++ b/srcpkgs/opencolorio/template
@@ -1,7 +1,7 @@
 # Template file for 'opencolorio'
 pkgname=opencolorio
 version=1.1.0
-revision=1
+revision=2
 wrksrc=OpenColorIO-${version}
 build_style=cmake
 configure_args="-DUSE_EXTERNAL_TINYXML=ON -DUSE_EXTERNAL_LCMS=ON"

--- a/srcpkgs/pavucontrol/template
+++ b/srcpkgs/pavucontrol/template
@@ -1,7 +1,7 @@
 # Template file for 'pavucontrol'
 pkgname=pavucontrol
 version=3.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="gtkmm-devel libcanberra-devel gtk+3-devel pulseaudio-devel"

--- a/srcpkgs/pcre/template
+++ b/srcpkgs/pcre/template
@@ -1,7 +1,7 @@
 # Template file for 'pcre'
 pkgname=pcre
 version=8.42
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-utf8 --enable-unicode-properties --with-pic
 --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-newline-is-anycrlf

--- a/srcpkgs/rawtherapee/template
+++ b/srcpkgs/rawtherapee/template
@@ -1,7 +1,7 @@
 # Template file for 'rawtherapee'
 pkgname=rawtherapee
 version=5.4
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="fftw-devel gtkmm-devel lensfun-devel libcanberra-devel

--- a/srcpkgs/subtitleeditor/template
+++ b/srcpkgs/subtitleeditor/template
@@ -1,7 +1,7 @@
 # Template file for 'subtitleeditor'
 pkgname=subtitleeditor
 version=0.54.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="autogen automake intltool libtool pkg-config gettext-devel"
 makedepends="gtk+3-devel gtkmm-devel enchant-devel libxml++-devel

--- a/srcpkgs/synfigstudio/template
+++ b/srcpkgs/synfigstudio/template
@@ -1,7 +1,7 @@
 # Template file for 'synfigstudio'
 pkgname=synfigstudio
 version=1.2.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool gettext"
 makedepends="ETL synfig-devel gtkmm-devel libltdl-devel boost-devel"

--- a/srcpkgs/tinyxml/template
+++ b/srcpkgs/tinyxml/template
@@ -1,7 +1,7 @@
 # Template file for 'tinyxml'
 pkgname=tinyxml
 version=2.6.2
-revision=9
+revision=10
 wrksrc="${pkgname}"
 short_desc="A simple, small, C++ XML parser"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/workrave/template
+++ b/srcpkgs/workrave/template
@@ -1,7 +1,7 @@
 # Template file for 'workrave'
 pkgname=workrave
 version=1.10.20
-revision=1
+revision=2
 _realversion="${version//./_}"
 wrksrc="${pkgname}-${_realversion}"
 nocross=yes # gobject-introspection


### PR DESCRIPTION
fixes #1097