### PR TITLE
cargo: update to 0.27.0. [DO NOT MERGE]

### DIFF
--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo'
 pkgname=cargo
 version=0.27.0
-revision=1
+revision=2
 hostmakedepends="rust python curl cmake pkg-config"
 makedepends="libcurl-devel libgit2-devel"
 depends="rust"


### PR DESCRIPTION
Trying to build on travis because builds for #879 fail on x86_64-musl and I can't figure out why.