### PR TITLE
zita-convolver: update to 4.0.0, update shlibs.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2227,7 +2227,7 @@ libKF5I18n.so.5 ki18n-5.26.0_1
 libqtelegram-ae.so.1 libqtelegram-ae-5.0_1
 libtelegramqml.so.1 TelegramQML-0.8.0_1
 libglog.so.0 glog-0.3.4_1
-libzita-convolver.so.3 zita-convolver-3.1.0_1
+libzita-convolver.so.4 zita-convolver-4.0.0_1
 libzita-alsa-pcmi.so.0 zita-alsa-pcmi-0.2.0_1
 libpugixml.so.1 pugixml-1.6_1
 libnewt.so.0.52 newt-0.52.18_1

--- a/srcpkgs/zita-convolver/template
+++ b/srcpkgs/zita-convolver/template
@@ -1,18 +1,18 @@
 # Template file for 'zita-convolver'
 pkgname=zita-convolver
-version=3.1.0
-revision=2
+version=4.0.0
+revision=1
 build_style=gnu-makefile
 make_install_args="LIBDIR=lib"
 hostmakedepends="pkg-config"
 makedepends="fftw-devel"
 build_wrksrc="libs"
-short_desc="A fast partitioned convolution engine library"
+short_desc="Fast partitioned convolution engine library"
 maintainer="silvernode <mollusk@homebutter.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum="bf7e93b582168b78d40666974460ad8142c2fa3c3412e327e4ab960b3fb31993"
+checksum=e3186f807dd76befbbb1c009f6bb4f83567b5d3c93b49a71b334034d1171a73b
 
 pre_build() {
 	sed -i 's/g++/$(CXX)/' Makefile


### PR DESCRIPTION
````
=> zita-convolver-4.0.0_1: running pre-pkg hook: 99-pkglint ...
=> ERROR: zita-convolver-4.0.0_1: SONAME bump detected: libzita-convolver.so.3 -> libzita-convolver.so.4
=> ERROR: zita-convolver-4.0.0_1: please update common/shlibs with this line: "libzita-convolver.so.4 zita-convolver-4.0.0_1"
=> ERROR: zita-convolver-4.0.0_1: all reverse dependencies should also be revbumped to be rebuilt against libzita-convolver.so.4:
=> ERROR:    guitarix2-0.37.1_1
=> ERROR: zita-convolver-4.0.0_1: cannot continue with installation!
=> ERROR: zita-convolver-4.0.0_1: pre-pkg_99-pkglint: 'grep -E "${_pattern}" $mapshlibs' exited with 1
=> ERROR:   in hook() at common/hooks/pre-pkg/99-pkglint.sh:52
=> ERROR:   in run_func() at common/xbps-src/shutils/common.sh:21
=> ERROR:   in run_pkg_hooks() at common/xbps-src/shutils/common.sh:251
=> ERROR:   in main() at common/xbps-src/libexec/xbps-src-prepkg.sh:47
````