### PR TITLE
New package: tmate-2.2.1

### DIFF
--- a/srcpkgs/tmate/patches/0001-Fix-building-with-or-without-backtrace-3.patch
+++ b/srcpkgs/tmate/patches/0001-Fix-building-with-or-without-backtrace-3.patch
@@ -1,0 +1,75 @@
+From 3f6c6d44472a5ccab0403ebf89fc59e7df58b6b2 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Thu, 28 Sep 2017 10:28:42 +0000
+Subject: [PATCH] Fix building with or without backtrace(3)
+
+backtrace(3) and execinfo.h are GNU extensions and may or may not be
+available, and they may be provided via libexecinfo.
+
+Fix detection of libexecinfo and allow building without any support of
+backtrace, in which case we let kernel create core dump.
+
+Fixes #116 #117
+---
+ configure.ac  |  5 +++++
+ tmate-debug.c | 10 ++++++++++
+ 2 files changed, 15 insertions(+)
+
+diff --git configure.ac configure.ac
+index 02d2872..05c1c48 100644
+--- configure.ac
++++ configure.ac
+@@ -102,6 +102,7 @@ AC_CHECK_HEADERS(
+ 		bitstring.h \
+ 		curses.h \
+ 		dirent.h \
++		execinfo.h \
+ 		fcntl.h \
+ 		inttypes.h \
+ 		libutil.h \
+@@ -121,9 +122,13 @@ AC_CHECK_HEADERS(
+ # Look for library needed for flock.
+ AC_SEARCH_LIBS(flock, bsd)
+ 
++# Look for library needed for backtrace
++AC_SEARCH_LIBS(backtrace, execinfo)
++
+ # Check for some functions that are replaced or omitted.
+ AC_CHECK_FUNCS(
+ 	[ \
++		backtrace \
+ 		dirfd \
+ 		flock \
+ 		setproctitle \
+diff --git tmate-debug.c tmate-debug.c
+index f1fd971..f58efe0 100644
+--- tmate-debug.c
++++ tmate-debug.c
+@@ -1,10 +1,19 @@
++#ifdef HAVE_EXECINFO_H
+ #include <execinfo.h>
++#endif
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <regex.h>
+ #include <signal.h>
+ #include "tmate.h"
+ 
++#ifndef HAVE_BACKTRACE
++
++void tmate_print_stack_trace(void) {}
++void tmate_catch_sigsegv(void) {}
++
++#else
++
+ #if DEBUG
+ 
+ static int print_resolved_stack_frame(const char *frame)
+@@ -88,3 +97,4 @@ void tmate_catch_sigsegv(void)
+ {
+ 	signal(SIGSEGV, handle_sigsegv);
+ }
++#endif
+-- 
+2.7.4
+

--- a/srcpkgs/tmate/template
+++ b/srcpkgs/tmate/template
@@ -1,0 +1,21 @@
+# Template file for 'tmate'
+pkgname=tmate
+version=2.2.1
+revision=1
+build_style=gnu-configure
+hostmakedepends="automake pkg-config"
+makedepends="libevent-devel libssh-devel msgpack-devel ncurses-devel"
+short_desc="Instant Terminal Sharing"
+maintainer="Rijk van Wijk <rrvanwijk@fastmail.org>"
+license="ISC"
+homepage="http://tmate.io"
+distfiles="https://github.com/tmate-io/tmate/archive/${version}.tar.gz"
+checksum=d9c2ac59f42e65aac5f500f0548ea8056fd79c9c5285e5af324d833e2a84c305
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+}

--- a/srcpkgs/tmate/update
+++ b/srcpkgs/tmate/update
@@ -1,0 +1,2 @@
+site="https://api.github.com/repos/tmate-io/tmate/releases"
+pattern='"tag_name":\s*"\K[\d.a-z]+(?=")'


### PR DESCRIPTION
The patch for building with musl comes directly off their git repo, and can probably be removed when the next version is released