### PR TITLE
New packages: cross-x86_64-w64-mingw32 and cross-i686-w64-mingw32

### DIFF
--- a/srcpkgs/cross-i686-w64-mingw32
+++ b/srcpkgs/cross-i686-w64-mingw32
@@ -1,0 +1,1 @@
+cross-x86_64-w64-mingw32

--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,14 +1,14 @@
 _binutils_version=2.29.1
-_gcc_version=7.3.0
+_gcc_version=8.2.0
 _gmp_version=6.1.2
-_mpfr_version=4.0.0
+_mpfr_version=4.0.1
 _mpc_version=1.1.0
-_isl_version=0.16.1
+_isl_version=0.19
 _mingw_version=5.0.4
 
 pkgname=cross-x86_64-w64-mingw32
 version=${_mingw_version}
-revision=2
+revision=3
 short_desc="Cross toolchain for Win64 (GCC ${_gcc_version})"
 maintainer="Aleksey Tulinov <aleksey.tulinov@gmail.com>"
 homepage="https://sourceforge.net/projects/mingw-w64/"
@@ -24,11 +24,11 @@ distfiles="
  ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
 checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
- 832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c
+ 196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
  87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912
- fbe2cd1418b321f5c899ce4f0f0f4e73f5ecc7d02145b0e1fd096f5c3afb8a1d
- 412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2
+ 67874a60826303ee2fb6affc6dc0ddd3e749e9bfcb4c8655e3953d0458a6e16e
+ d59726f34f7852a081fbd3defd1ab2136f174110fc2e0c8d10bb122173fa9ed8
  5527e1f6496841e2bb72f97a184fc79affdcd37972eaa9ebf7a5fd05c31ff803"
 
 only_for_archs="i686 x86_64"
@@ -115,6 +115,7 @@ _gcc_bootstrap() {
 		--disable-nls \
 		--disable-multilib \
 		--disable-gcov \
+		--disable-libcc1 \
 		--enable-lto \
 		--enable-shared \
 		--enable-static \
@@ -199,12 +200,12 @@ _gcc_build() {
 _build_cross() {
 	_target=$1
 
-	_binutils_build ${_target}
-	_mingw_headers ${_target}
-	_gcc_bootstrap ${_target}
-	_mingw_crt_build ${_target}
-	_mingw_winpthreads_build ${_target}
-	_gcc_build ${_target}
+	(_binutils_build ${_target})
+	(_mingw_headers ${_target})
+	(_gcc_bootstrap ${_target})
+	(_mingw_crt_build ${_target})
+	(_mingw_winpthreads_build ${_target})
+	(_gcc_build ${_target})
 }
 
 do_build() {

--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -8,32 +8,36 @@ _mingw_version=5.0.4
 
 pkgname=cross-x86_64-w64-mingw32
 version=${_mingw_version}
-revision=1
-short_desc="Cross toolchain for Win64"
+revision=2
+short_desc="Cross toolchain for Win64 (GCC ${_gcc_version})"
 maintainer="Aleksey Tulinov <aleksey.tulinov@gmail.com>"
 homepage="https://sourceforge.net/projects/mingw-w64/"
-license="LGPL-3, GPL-3, ZPL"
+license="GPL-2.0-or-later, GPL-3.0-or-later, ZPL-2.1"
 
 distfiles="
- https://ftp.gnu.org/gnu/binutils/binutils-${_binutils_version}.tar.bz2
- https://ftp.gnu.org/gnu/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
+ ${GNU_SITE}/mpc/mpc-${_mpc_version}.tar.gz
  https://gmplib.org/download/gmp/gmp-${_gmp_version}.tar.xz
  http://www.mpfr.org/mpfr-${_mpfr_version}/mpfr-${_mpfr_version}.tar.xz
- https://ftp.gnu.org/gnu/mpc/mpc-${_mpc_version}.tar.gz
  http://isl.gforge.inria.fr/isl-${_isl_version}.tar.bz2
- https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
+ ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
 checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c
+ 6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
  87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912
  fbe2cd1418b321f5c899ce4f0f0f4e73f5ecc7d02145b0e1fd096f5c3afb8a1d
- 6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
  412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2
  5527e1f6496841e2bb72f97a184fc79affdcd37972eaa9ebf7a5fd05c31ff803"
 
+only_for_archs="i686 x86_64"
 create_wrksrc=yes
 hostmakedepends="perl flex"
 makedepends="zlib-devel"
+# it's ok to build with current's -devel packages
+# although it might break the package during compiler updates
+#makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 nostrip=yes
 nopie=yes
 nodebug=yes
@@ -77,6 +81,7 @@ _mingw_headers() {
 	../mingw-w64-v${_mingw_version}/mingw-w64-headers/configure \
 		--prefix=${_sysroot} \
 		--host=${_target} \
+		--disable-werror \
 		--enable-secure-api \
 		--enable-sdk=all
 
@@ -94,6 +99,7 @@ _gcc_bootstrap() {
 
 	msg_normal "Building GCC bootsrap: ${_target}\n"
 
+	# not needed when using current's -devel packages
 	ln -sf ${wrksrc}/"gmp-${_gmp_version}" ${wrksrc}/"gcc-${_gcc_version}/gmp"
 	ln -sf ${wrksrc}/"mpc-${_mpc_version}" ${wrksrc}/"gcc-${_gcc_version}/mpc"
 	ln -sf ${wrksrc}/"mpfr-${_mpfr_version}" ${wrksrc}/"gcc-${_gcc_version}/mpfr"
@@ -105,6 +111,7 @@ _gcc_bootstrap() {
 		--prefix="/usr" \
 		--with-sysroot=${_sysroot} \
 		--target=${_target} \
+		--disable-werror \
 		--disable-nls \
 		--disable-multilib \
 		--disable-gcov \
@@ -214,7 +221,9 @@ _install_cross() {
 	(cd ${wrksrc}/"build-mingw-crt-${_target}" && DESTDIR="$DESTDIR" make install)
 	(cd ${wrksrc}/"build-mingw-winpthreads-${_target}" && DESTDIR="$DESTDIR" make install)
 
-	vlicense ${wrksrc}/"mingw-w64-v${_mingw_version}/COPYING" ZPL
+	# remove unnecessary stuff
+	rm -rf ${DESTDIR}/usr/share/
+	rm -rf ${DESTDIR}/usr/lib/libcc1*
 }
 
 do_install() {
@@ -237,7 +246,7 @@ do_clean() {
 }
 
 cross-i686-w64-mingw32_package() {
-	short_desc="Cross toolchain for Win32"
+	short_desc="Cross toolchain for Win32 (GCC ${_gcc_version})"
 	nostrip=yes
 	nopie=yes
 	nodebug=yes

--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,0 +1,248 @@
+_binutils_version=2.29.1
+_gcc_version=7.3.0
+_gmp_version=6.1.2
+_mpfr_version=4.0.0
+_mpc_version=1.1.0
+_isl_version=0.16.1
+_mingw_version=5.0.4
+
+pkgname=cross-x86_64-w64-mingw32
+version=${_mingw_version}
+revision=1
+short_desc="Cross toolchain for Win64"
+maintainer="Aleksey Tulinov <aleksey.tulinov@gmail.com>"
+homepage="https://sourceforge.net/projects/mingw-w64/"
+license="LGPL-3, GPL-3, ZPL"
+
+distfiles="
+ https://ftp.gnu.org/gnu/binutils/binutils-${_binutils_version}.tar.bz2
+ https://ftp.gnu.org/gnu/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
+ https://gmplib.org/download/gmp/gmp-${_gmp_version}.tar.xz
+ http://www.mpfr.org/mpfr-${_mpfr_version}/mpfr-${_mpfr_version}.tar.xz
+ https://ftp.gnu.org/gnu/mpc/mpc-${_mpc_version}.tar.gz
+ http://isl.gforge.inria.fr/isl-${_isl_version}.tar.bz2
+ https://sourceforge.net/projects/mingw-w64/files/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
+checksum="
+ 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ 832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c
+ 87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912
+ fbe2cd1418b321f5c899ce4f0f0f4e73f5ecc7d02145b0e1fd096f5c3afb8a1d
+ 6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
+ 412538bb65c799ac98e17e8cfcdacbb257a57362acfaaff254b0fcae970126d2
+ 5527e1f6496841e2bb72f97a184fc79affdcd37972eaa9ebf7a5fd05c31ff803"
+
+create_wrksrc=yes
+hostmakedepends="perl flex"
+makedepends="zlib-devel"
+nostrip=yes
+nopie=yes
+nodebug=yes
+
+# https://sourceforge.net/p/mingw-w64/wiki2/Cross%20Win32%20and%20Win64%20compiler/
+# https://gcc.gnu.org/install/configure.html
+# http://mingw-w64.org/doku.php/configure
+
+_binutils_build() {
+	_target=$1
+	_sysroot="/usr/${_target}"
+	_builddir=${wrksrc}/"build-binutils-${_target}"
+
+	msg_normal "Building binutils: ${_target}\n"
+
+	mkdir -p ${_builddir} && cd ${_builddir}
+
+	../binutils-${_binutils_version}/configure \
+		--prefix="/usr" \
+		--with-sysroot=${_sysroot} \
+		--target=${_target} \
+		--disable-multilib \
+		--disable-shared \
+		--disable-nls \
+		--disable-werror \
+		--enable-lto \
+		--with-system-zlib
+
+	make && make install
+}
+
+_mingw_headers() {
+	_target=$1
+	_sysroot="/usr/${_target}"
+	_builddir=${wrksrc}/"build-mingw-headers-${_target}"
+
+	msg_normal "Building MinGW headers: ${_target}\n"
+
+	mkdir -p ${_builddir} && cd ${_builddir}
+
+	../mingw-w64-v${_mingw_version}/mingw-w64-headers/configure \
+		--prefix=${_sysroot} \
+		--host=${_target} \
+		--enable-secure-api \
+		--enable-sdk=all
+
+	make && make install
+
+	# manually create required symlinks
+	(cd ${_sysroot} && ln -sfT "." "mingw")
+	(cd ${_sysroot} && ln -sf "lib" "lib64")
+}
+
+_gcc_bootstrap() {
+	_target=$1
+	_sysroot="/usr/${_target}"
+	_builddir=${wrksrc}/"build-gcc-${_target}"
+
+	msg_normal "Building GCC bootsrap: ${_target}\n"
+
+	ln -sf ${wrksrc}/"gmp-${_gmp_version}" ${wrksrc}/"gcc-${_gcc_version}/gmp"
+	ln -sf ${wrksrc}/"mpc-${_mpc_version}" ${wrksrc}/"gcc-${_gcc_version}/mpc"
+	ln -sf ${wrksrc}/"mpfr-${_mpfr_version}" ${wrksrc}/"gcc-${_gcc_version}/mpfr"
+	ln -sf ${wrksrc}/"isl-${_isl_version}" ${wrksrc}/"gcc-${_gcc_version}/isl"
+
+	mkdir -p ${_builddir} && cd ${_builddir}
+
+	../gcc-${_gcc_version}/configure \
+		--prefix="/usr" \
+		--with-sysroot=${_sysroot} \
+		--target=${_target} \
+		--disable-nls \
+		--disable-multilib \
+		--disable-gcov \
+		--enable-lto \
+		--enable-shared \
+		--enable-static \
+		--enable-threads=posix \
+		--with-system-zlib \
+		--enable-languages=c,c++,lto
+
+	make all-gcc && make install-gcc
+}
+
+_mingw_crt_build() {
+	_target=$1
+	_sysroot="/usr/${_target}"
+	_builddir=${wrksrc}/"build-mingw-crt-${_target}"
+
+	msg_normal "Building MinGW CRT: ${_target}\n"
+
+	if [ ${_target} == "i686-w64-mingw32" ]; then
+		_crt_configure_args="--disable-lib64 --enable-lib32"
+	elif [ ${_target} == "x86_64-w64-mingw32" ]; then
+		_crt_configure_args="--disable-lib32 --enable-lib64"
+	fi
+
+	mkdir -p ${_builddir} && cd ${_builddir}
+
+	CC="${_target}-gcc" \
+	CPP="${_target}-gcc -E"
+	AR="${_target}-ar" \
+	RANLIB="${_target}-ranlib" \
+	AS="${_target}-as" \
+	STRIP="${_target}-strip" \
+	OBJDUMP="${_target}-objdump" \
+	WINDRES="${_target}-windres" \
+	../mingw-w64-v${_mingw_version}/mingw-w64-crt/configure \
+		--prefix=${_sysroot} \
+		--host=${_target} \
+		${_crt_configure_args}
+
+	make && make install
+}
+
+_mingw_winpthreads_build() {
+	_target=$1
+	_sysroot="/usr/${_target}"
+	_builddir=${wrksrc}/"build-mingw-winpthreads-${_target}"
+
+	msg_normal "Building MinGW winpthreads: ${_target}\n"
+
+	mkdir -p ${_builddir} && cd ${_builddir}
+
+	CC="${_target}-gcc" \
+	CPP="${_target}-gcc -E"
+	AR="${_target}-ar" \
+	RANLIB="${_target}-ranlib" \
+	AS="${_target}-as" \
+	STRIP="${_target}-strip" \
+	OBJDUMP="${_target}-objdump" \
+	WINDRES="${_target}-windres" \
+	../mingw-w64-v${_mingw_version}/mingw-w64-libraries/winpthreads/configure \
+		--prefix=${_sysroot} \
+		--host=${_target} \
+		--enable-static \
+		--enable-shared
+
+	make && make install
+}
+
+_gcc_build() {
+	_target=$1
+	_sysroot="/usr/${_target}"
+	_builddir=${wrksrc}/"build-gcc-${_target}"
+
+	msg_normal "Building GCC: ${_target}\n"
+
+	cd ${_builddir}
+
+	# should be already configured previously
+	# no need for install since this is the last step
+	make
+}
+
+_build_cross() {
+	_target=$1
+
+	_binutils_build ${_target}
+	_mingw_headers ${_target}
+	_gcc_bootstrap ${_target}
+	_mingw_crt_build ${_target}
+	_mingw_winpthreads_build ${_target}
+	_gcc_build ${_target}
+}
+
+do_build() {
+	(_build_cross "x86_64-w64-mingw32")
+	(_build_cross "i686-w64-mingw32")
+}
+
+_install_cross() {
+	_target=$1
+
+	(cd ${wrksrc}/"build-binutils-${_target}" && DESTDIR="$DESTDIR" make install)
+	(cd ${wrksrc}/"build-gcc-${_target}" && DESTDIR="$DESTDIR" make install)
+	(cd ${wrksrc}/"build-mingw-headers-${_target}" && DESTDIR="$DESTDIR" make install)
+	(cd ${wrksrc}/"build-mingw-crt-${_target}" && DESTDIR="$DESTDIR" make install)
+	(cd ${wrksrc}/"build-mingw-winpthreads-${_target}" && DESTDIR="$DESTDIR" make install)
+
+	vlicense ${wrksrc}/"mingw-w64-v${_mingw_version}/COPYING" ZPL
+}
+
+do_install() {
+	_install_cross "x86_64-w64-mingw32"
+	# i686 version will be installed in subpackage (below)
+}
+
+_clean_cross() {
+	_target=$1
+
+	rm -rf /usr/${_target}
+	rm -f  /usr/bin/${_target}*
+	rm -rf /usr/lib/gcc/${_target}
+	rm -rf /usr/libexec/gcc/${_target}
+}
+
+do_clean() {
+	_clean_cross "x86_64-w64-mingw32"
+	_clean_cross "i686-w64-mingw32"
+}
+
+cross-i686-w64-mingw32_package() {
+	short_desc="Cross toolchain for Win32"
+	nostrip=yes
+	nopie=yes
+	nodebug=yes
+
+	pkg_install() {
+		DESTDIR="$PKGDESTDIR" _install_cross "i686-w64-mingw32"
+	}
+}


### PR DESCRIPTION
Two cross-compilers:

* x86_64-w64-mingw32
* i686-w64-mingw32

Template builds both.

Based on GCC 7.3.0 and binutils 2.29.1 (synced with current's GCC). Other components versions: gmp, mpfr, mpc, isl are also synced with `gcc/template`. MinGW-w64 is latest (5.0.4).

Exceptions support - yes (sjlj in i686 and seh in x86_64), threads support - yes (winpthreads). I've checked that compilers work on more or less sophisticated application (SDL, ogg, flac, OpenGL, glm, etc).

License (ZPL) is included into packages.

There also were similar package requests in old issue tracker: 

* https://github.com/voidlinux/void-packages/issues/390
* https://github.com/voidlinux/void-packages/issues/3895