### PR TITLE
meson.sh: Fix cross-compilation

### DIFF
--- a/common/build-style/meson.sh
+++ b/common/build-style/meson.sh
@@ -8,10 +8,23 @@ do_configure() {
 
 	if [ "$CROSS_BUILD" ]; then
 		_MESON_TARGET_ENDIAN=little
-		_MESON_TARGET_CPU=${XBPS_TARGET_MACHINE}
+		# drop the -musl suffix to the target cpu, meson doesn't recognize it
+		_MESON_TARGET_CPU=${XBPS_TARGET_MACHINE/-musl/}
 		case "$XBPS_TARGET_MACHINE" in
 			mips|mips-musl|mipshf-musl)
 				_MESON_TARGET_ENDIAN=big
+				_MESON_CPU_FAMILY=mips
+				;;
+			armv*)
+				_MESON_CPU_FAMILY=arm
+				;;
+			i686*)
+				_MESON_CPU_FAMILY=x86
+				;;
+			*)
+				# if we reached here that means that the cpu and cpu_family
+				# are the same like 'x86_64' and 'aarch64'
+				_MESON_CPU_FAMILY=${_MESON_TARGET_CPU}
 				;;
 		esac
 
@@ -37,13 +50,7 @@ cpp_link_args = ['$(echo ${LDFLAGS} | sed -r "s/\s+/','/g")']
 
 [host_machine]
 system = 'linux'
-cpu_family = '${XBPS_MACHINE}'
-cpu = '${XBPS_MACHINE}'
-endian = 'little'
-
-[target_machine]
-system = 'linux'
-cpu_family = '${_MESON_TARGET_CPU}'
+cpu_family = '${_MESON_CPU_FAMILY}'
 cpu = '${_MESON_TARGET_CPU}'
 endian = '${_MESON_TARGET_ENDIAN}'
 EOF


### PR DESCRIPTION
following https://mesonbuild.com/Cross-compilation.html

- host_machine is our XBPS_TARGET_MACHINE
- build_machine is our XBPS_MACHINE, and meson can find out the details
on it's own
- also don't include -musl in the CPU because meson doesn't recognize it
and projects like Mesa (LibGL) [don't enable](https://cgit.freedesktop.org/mesa/mesa/tree/meson.build#n917) optimizations for it
- cpu_family and cpu are different, they need to be set properly:
 - armv* is arm
 - mips* is mips
 - i686 is x86
 - x86_64 is x86_64
 - aarch64 is aarch64

---

Thanks @Cogitri for helping me work this all out.