### PR TITLE
hdparm: fix license

### DIFF
--- a/srcpkgs/hdparm/template
+++ b/srcpkgs/hdparm/template
@@ -6,8 +6,8 @@ build_style=gnu-makefile
 make_install_args="exec_prefix=/usr sbindir=/usr/bin"
 short_desc="Utility to access IDE device parameters"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://sourceforge.net/projects/hdparm/"
-license="0BSD" # Upstream is very unclear and names their stuff 'bsd-style'
+license="BSD-2-Clause"
+homepage="https://sourceforge.net/projects/hdparm/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=6ff9ed695f1017396eec4101f990f114b7b0e0a04c5aa6369c0394053d16e4da
 


### PR DESCRIPTION
According to Debian's [copyright](http://metadata.ftp-master.debian.org/changelogs/main/h/hdparm/hdparm_9.56+ds-2_copyright) it should be `BSD-2-Clause`.