### PR TITLE
mu: update to 1.0.

### DIFF
--- a/srcpkgs/mu/template
+++ b/srcpkgs/mu/template
@@ -1,7 +1,7 @@
 # Template build file for 'mu'.
 pkgname=mu
 version=1.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config emacs texinfo"
 makedepends="xapian-core-devel gmime-devel libuuid-devel"


### PR DESCRIPTION
at least for musl, the recent emacs update/revision requires mu to be rebuilt, otherwise https://forum.voidlinux.org/t/solved-xapian-mu-issues-under-musl-after-recent-updates/6356/3