### PR TITLE
openscad: revbump

### DIFF
--- a/srcpkgs/openscad/template
+++ b/srcpkgs/openscad/template
@@ -1,17 +1,15 @@
 # Template file for 'openscad'
-
-pkgname="openscad"
-version="2015.03.2"
-revision=7
+pkgname=openscad
+version=2015.03.2
+revision=8
 _distver="${version%.*}-${version##*.}"
+wrksrc="${pkgname}-${_distver}"
 build_style=qmake
+hostmakedepends="bison flex pkg-config"
+makedepends="cgal-devel harfbuzz-devel opencsg-devel qscintilla-qt5-devel"
 short_desc="The programmers solid 3D CAD modeller"
 maintainer="Pierre Allegraud <pierre.allegraud@crans.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.openscad.org"
 distfiles="http://files.openscad.org/${pkgname}-${_distver}.src.tar.gz"
 checksum="a2535bb9e27d96e10e1e19268a596155164c7129d410a0c7f96edc2d09400083"
-wrksrc="${pkgname}-${_distver}"
-
-hostmakedepends="bison flex pkg-config"
-makedepends="cgal-devel harfbuzz-devel opencsg-devel qscintilla-qt5-devel"


### PR DESCRIPTION
Fix: `openscad: symbol lookup error: openscad: undefined symbol: _ZNK5boost15program_options22error_with_option_name23substitute_placeholdersERKSs`
