### PR TITLE
xautolock: add patch to fix silent failure on -restart command

### DIFF
--- a/srcpkgs/xautolock/patches/fix-restart.patch
+++ b/srcpkgs/xautolock/patches/fix-restart.patch
@@ -1,0 +1,11 @@
+--- src/message.c	2018-07-31 01:20:05.740344556 -0400
++++ src/message.c	2018-07-31 01:16:33.521671009 -0400
+@@ -104,7 +104,7 @@
+   {
+     XDeleteProperty (d, root, semaphore);
+     XFlush (d);
+-    execv (argArray[0], argArray);
++    execvp(argArray[0], argArray);
+   }
+ }
+ 

--- a/srcpkgs/xautolock/template
+++ b/srcpkgs/xautolock/template
@@ -1,7 +1,7 @@
 # Template file for 'xautolock'
 pkgname=xautolock
 version=2.2
-revision=5
+revision=6
 hostmakedepends="imake xorg-cf-files"
 makedepends="libXScrnSaver-devel xorgproto"
 short_desc="Autolock utility for X"


### PR DESCRIPTION
If you run 'xautolock' instead of '/usr/bin/xautolock', execv will fail
because it cannot found the path to the program when the -restart
command is requested.  Use execvp instead of execv, which will search
the environmental PATH to find the program, thus allowing you to just
run 'xautolock' rather than the full path.

This fixes the bug where playing a video with mpv accidently kills your
screenlocker since it calls xdg-screensaver reset, which in turn calls
xautolock -restart.