### PR TITLE
protobuf: update to 3.6.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2991,9 +2991,9 @@ libm17n-flt.so.0 m17n-lib-1.7.0_1
 libm17n-gui.so.0 m17n-lib-1.7.0_1
 libm17n-core.so.0 m17n-lib-1.7.0_1
 libm17n.so.0 m17n-lib-1.7.0_1
-libprotobuf-lite.so.16 protobuf-lite-3.6.0_1
-libprotoc.so.16 protobuf-3.6.0_1
-libprotobuf.so.16 protobuf-3.6.0_1
+libprotobuf-lite.so.17 protobuf-lite-3.6.1_1
+libprotoc.so.17 protobuf-3.6.1_1
+libprotobuf.so.17 protobuf-3.6.1_1
 libsombok.so.3 sombok-2.4.0_1
 libdeviceclient.so.0 pragha-1.3.3_1
 libguile-srfi-srfi-1-v-3.so.3 guile1.8-1.8.8_1

--- a/srcpkgs/bitcoin/template
+++ b/srcpkgs/bitcoin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitcoin'
 pkgname=bitcoin
 version=0.16.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-incompatible-bdb --disable-ccache --disable-static --enable-hardening --with-boost=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="pkg-config yasm"

--- a/srcpkgs/clementine/template
+++ b/srcpkgs/clementine/template
@@ -1,7 +1,7 @@
 # Template file for 'clementine'
 pkgname=clementine
 version=1.3.1
-revision=15
+revision=16
 patch_args="-Np1"
 build_style=cmake
 hostmakedepends="sparsehash pkg-config qt-host-tools qt-devel protobuf-c"
@@ -15,8 +15,8 @@ short_desc="A modern music player and library organizer"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-3"
 homepage="https://www.clementine-player.org/"
-wrksrc="Clementine-$version"
-distfiles="https://github.com/clementine-player/Clementine/archive/$version.tar.gz"
+wrksrc="Clementine-${version}"
+distfiles="https://github.com/clementine-player/Clementine/archive/${version}.tar.gz"
 checksum=f885931a9ab7c88607d07b50c64fcce46fc05f13dd2c0a04188c94eff938f37c
 
 build_options="spotify"

--- a/srcpkgs/cura-engine/template
+++ b/srcpkgs/cura-engine/template
@@ -1,7 +1,7 @@
 # Template file for 'cura-engine'
 pkgname=cura-engine
 version=3.4.1
-revision=2
+revision=3
 wrksrc="CuraEngine-${version}"
 build_style=cmake
 configure_args="-DCURA_ENGINE_VERSION=${version}"

--- a/srcpkgs/libArcus/template
+++ b/srcpkgs/libArcus/template
@@ -1,7 +1,7 @@
 # Template file for 'libArcus'
 pkgname=libArcus
 version=3.4.1
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DBUILD_EXAMPLES=OFF"
 hostmakedepends="protobuf python3-sip-devel"

--- a/srcpkgs/litecoin/template
+++ b/srcpkgs/litecoin/template
@@ -1,7 +1,7 @@
 # Template file for 'litecoin'
 pkgname=litecoin
 version=0.16.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-incompatible-bdb --with-gui=qt5 --disable-static --disable-tests
  --with-libressl"

--- a/srcpkgs/mixxx/template
+++ b/srcpkgs/mixxx/template
@@ -1,7 +1,7 @@
 # Template file for 'mixxx'
 pkgname=mixxx
 version=2.1.1
-revision=3
+revision=4
 wrksrc="mixxx-release-${version}"
 hostmakedepends="pkg-config scons"
 makedepends="chromaprint-devel faad2-devel ffmpeg-devel fftw-devel glu-devel

--- a/srcpkgs/mosh/template
+++ b/srcpkgs/mosh/template
@@ -1,7 +1,7 @@
 # Template file for 'mosh'
 pkgname=mosh
 version=1.3.2
-revision=8
+revision=9
 build_style=gnu-configure
 hostmakedepends="pkg-config protobuf-devel"
 makedepends="ncurses-devel protobuf-devel libutempter-devel libressl-devel"

--- a/srcpkgs/mozc/template
+++ b/srcpkgs/mozc/template
@@ -1,14 +1,14 @@
 # Template file for 'mozc'
 pkgname=mozc
 version=2.23.2785.102
-revision=3
+revision=4
 hostmakedepends="ninja pkg-config protobuf-devel python"
 makedepends="gtk+-devel ibus-devel libzinnia-devel protobuf-devel qt5-devel
  fcitx-devel"
 depends="tegaki-zinnia-japanese>=0.3"
 maintainer="Matthias von Faber <mvf@gmx.eu>"
 homepage="https://github.com/google/mozc"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 short_desc="Japanese IME (Open Source version of Google Japanese Input)"
 build_wrksrc=mozc/src
 create_wrksrc=yes

--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,7 +1,7 @@
 # Template file for 'mumble'
 pkgname=mumble
 version=1.2.19
-revision=12
+revision=13
 hostmakedepends="Ice pkg-config protobuf qt-host-tools qt-qmake"
 makedepends="Ice-devel MesaLib-devel avahi-compat-libs-devel boost-devel
  libcap-devel libressl-devel libsndfile-devel opus-devel protobuf-devel

--- a/srcpkgs/nsjail/template
+++ b/srcpkgs/nsjail/template
@@ -1,7 +1,7 @@
 # Template file for 'nsjail'
 pkgname=nsjail
 version=2.7
-revision=4
+revision=5
 build_style=gnu-makefile
 hostmakedepends="bison flex pkg-config protobuf-devel"
 makedepends="libnl3-devel protobuf-devel"

--- a/srcpkgs/protobuf-c/template
+++ b/srcpkgs/protobuf-c/template
@@ -1,7 +1,7 @@
 # Template file for 'protobuf-c'
 pkgname=protobuf-c
 version=1.3.0
-revision=6
+revision=7
 build_style=gnu-configure
 hostmakedepends="pkg-config protobuf"
 makedepends="protobuf-devel boost-devel"

--- a/srcpkgs/protobuf/template
+++ b/srcpkgs/protobuf/template
@@ -1,7 +1,7 @@
 # Template file for 'protobuf'
 pkgname=protobuf
-version=3.6.0.1
-revision=3
+version=3.6.1
+revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="zlib-devel"
@@ -9,9 +9,9 @@ short_desc="Google's data interchange format"
 maintainer="Michael Aldridge <maldridge@voidlinux.eu>"
 license="BSD-3-Clause"
 homepage="https://developers.google.com/protocol-buffers/"
-#changelog="https://raw.githubusercontent.com/google/protobuf/master/CHANGES.txt"
+changelog="https://raw.githubusercontent.com/google/protobuf/master/CHANGES.txt"
 distfiles="https://github.com/google/protobuf/archive/v${version}.tar.gz"
-checksum=1144ef1fa9c50d3c04880f363b988df6ca6a66e337a945f1661cf4256ffba749
+checksum=3d4e589d81b2006ca603c1ab712c9715a76227293032d05b26fca603f90b3f5b
 
 CXXFLAGS="-std=c++14"
 

--- a/srcpkgs/zbackup/template
+++ b/srcpkgs/zbackup/template
@@ -1,7 +1,7 @@
 # Template file for 'zbackup'
 pkgname=zbackup
 version=1.4.4
-revision=11
+revision=12
 build_style=cmake
 hostmakedepends="protobuf"
 makedepends="zlib-devel liblzma-devel protobuf-devel libressl-devel lzo-devel"


### PR DESCRIPTION
Compiling locally (x86_64)

- [x] mixxx
- [x] bitcoin-qt
- [x] clementine
- [x] cura-engine
- [x] libArcus
- [x] litecoin
- [x] mosh
- [x] mozc
- [x] murmur
- [x] nsjail
- [x] protobuf-c
- [x] zbackup