### PR TITLE
gnome-settings-daemon: re-cross

### DIFF
--- a/srcpkgs/gnome-settings-daemon/template
+++ b/srcpkgs/gnome-settings-daemon/template
@@ -16,8 +16,16 @@ license="GPL-3.0-or-later"
 homepage="https://www.gnome.org"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=594f78e194eb42a6f77785d1a92a4cb9cda54b8c3af6ca0c315b4570d38d2d7d
-# https://build.voidlinux.eu/builders/aarch64-musl_builder/builds/11625/steps/shell_3/logs/stdio
-nocross="Can not use target gsd-power-enums-update as a generator because it is cross-built"
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" polkit"
+	pre_configure() {
+		# The power plugin requires compilating gsd-power-enums-update
+		# and running it, which is impossible when cross-compiling, so
+		# we disable it on the meson.build
+		sed -i "/\['power', 'Power'\],/d" plugins/meson.build
+	}
+fi
 
 gnome-settings-daemon-devel_package() {
 	depends="libglib-devel"


### PR DESCRIPTION
changes:

- Remove power plugin line from plugins/meson.build, this prevents the power plugin from being built, there are negative side-effects but it can't be built when cross-compiling.
- add `polkit` to hostmakedepends so we have /usr/share/gettext/its for generating wacom policy rules.