### PR TITLE
linux4.9: update to 4.9.117 [ci skip]

### DIFF
--- a/srcpkgs/linux4.9/files/arm64-dotconfig
+++ b/srcpkgs/linux4.9/files/arm64-dotconfig
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.9.110 Kernel Configuration
+# Linux/arm64 4.9.116 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y
@@ -521,6 +521,7 @@ CONFIG_KEXEC=y
 CONFIG_FORCE_MAX_ZONEORDER=11
 CONFIG_UNMAP_KERNEL_AT_EL0=y
 CONFIG_HARDEN_BRANCH_PREDICTOR=y
+CONFIG_ARM64_SSBD=y
 
 #
 # ARMv8.1 architectural features

--- a/srcpkgs/linux4.9/template
+++ b/srcpkgs/linux4.9/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.9'
 pkgname=linux4.9
-version=4.9.110
+version=4.9.117
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz"
-checksum=379a143a70a79f0eea6c9f6638942b65e6043abdde17ad23264c0abd93c4ea7a
+checksum=8232ea326ac5784d71baa09c0cd7806a2674f8449c0be73e2ae341e6880279b0
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes


### PR DESCRIPTION
aarch64:
````
Speculative Store Bypass Disable (ARM64_SSBD) [Y/n/?] (NEW) y
````