### PR TITLE
gdb: unbreak aarch64-musl

### DIFF
--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -18,10 +18,6 @@ homepage="https://www.gnu.org/software/gdb/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=97dcc3169bd430270fc29adb65145846a58c1b55cdbb73382a4a89307bdad03c
 
-case "$XBPS_TARGET_MACHINE" in
-	aarch64*) broken="/builddir/gdb-8.1.1/gdb/gdbserver/../common/common-utils.c:419: undefined reference to rpl_stat" ;;
-esac
-
 if [ "${CROSS_BUILD}" ]; then
 	# Make python2.7 detection work in cross builds
 	CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/python3.6m"
@@ -37,6 +33,8 @@ vopt_conflict gdbserver static
 
 post_extract() {
 	sed -i 's,sgidefs.h,asm/sgidefs.h,' gdb/mips-linux-nat.c
+	# fixes aarch64-musl cross-build
+	sed -i -e "s/@REPLACE_STAT@/0/" gdb/gnulib/import/sys_stat.in.h
 }
 pre_configure() {
 	configure_args="${configure_args/with-sysroot/with-build-sysroot}"


### PR DESCRIPTION
The problem is similar to this debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=566748

`configure` guesses wrong when cross-building:

    checking whether stat handles trailing slashes on files... guessing no

Although the corresponding `gl_cv_func_stat_file_slash` is set in `common/environment/configure/autoconf_cache/common-linux` it isn’t picked up.

Disabling using the replacement `stat` per `sed` fixes it.