### PR TITLE
geeqie: update to 1.4.

### DIFF
--- a/srcpkgs/geeqie/patches/geeqie-no-changelog.patch
+++ b/srcpkgs/geeqie/patches/geeqie-no-changelog.patch
@@ -1,0 +1,14 @@
+--- Makefile.am	2017-12-31 07:31:21.000000000 -0500
++++ Makefile.am	2018-01-01 15:05:58.742068166 -0500
+@@ -10,9 +10,9 @@
+ readmedir = @readmedir@
+ 
+ if HAVE_MARKDOWN
+-readme_DATA = README.md COPYING ChangeLog TODO README.lirc AUTHORS README.html ChangeLog.html
++readme_DATA = README.md COPYING TODO README.lirc AUTHORS README.html
+ else
+-readme_DATA = README.md COPYING ChangeLog TODO README.lirc AUTHORS ChangeLog.html
++readme_DATA = README.md COPYING TODO README.lirc AUTHORS
+ endif
+ 
+ desktopdir = $(datadir)/applications

--- a/srcpkgs/geeqie/template
+++ b/srcpkgs/geeqie/template
@@ -1,18 +1,18 @@
 # Template file for 'geeqie'
 pkgname=geeqie
-version=1.3
-revision=4
+version=1.4
+revision=1
 build_style=gnu-configure
-hostmakedepends="automake pkg-config intltool glib-devel gtk+3-devel"
-makedepends="gtk+3-devel exiv2-devel lcms2-devel librsvg-devel lua51-devel
+hostmakedepends="automake pkg-config intltool glib-devel gtk+-devel"
+makedepends="gtk+-devel exiv2-devel lcms2-devel librsvg-devel lua51-devel
  ffmpegthumbnailer-devel"
 depends="desktop-file-utils"
 short_desc="Lightweight GTK+ based image viewer"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.geeqie.org/"
 distfiles="http://www.geeqie.org/geeqie-${version}.tar.xz"
-checksum=4b6f566dd1a8badac68c4353c7dd0f4de17f8627b85a7a70d5eb1ae3b540ec3f
+checksum=5c583a165573ec37874c278f9dc57e73df356b30e09a9ccac3179dd5d97e3e32
 CPPFLAGS="-D_FILE_OFFSET_BITS=64"
 
 pre_configure() {


### PR DESCRIPTION
I took this patch in [Arch](https://git.archlinux.org/svntogit/packages.git/tree/trunk/geeqie-no-changelog.patch?h=packages/geeqie), to fix this build error:
````
/usr/bin/install: cannot stat './ChangeLog': No such file or directory
/usr/bin/install: cannot stat './ChangeLog.html': No such file or directory
make[2]: *** [Makefile:644: install-readmeDATA] Error 1
make[2]: Leaving directory '/builddir/geeqie-1.4'
make[1]: *** [Makefile:978: install-am] Error 2
make[1]: Leaving directory '/builddir/geeqie-1.4'
make: *** [Makefile:671: install-recursive] Error 1
````