### PR TITLE
vice: update to 3.2.

### DIFF
--- a/srcpkgs/vice/template
+++ b/srcpkgs/vice/template
@@ -1,7 +1,7 @@
 # Template file for 'vice'
 pkgname=vice
-version=3.1
-revision=2
+version=3.2
+revision=1
 build_style=gnu-configure
 configure_args="
 	$(vopt_enable sdl2 sdlui2)
@@ -10,7 +10,7 @@ configure_args="
 	$(vopt_with gtk3 pulse)
 	--disable-option-checking
 	--enable-cpuhistory"
-hostmakedepends="pkg-config bdftopcf mkfontdir flex"
+hostmakedepends="bdftopcf flex mkfontdir perl pkg-config xa"
 makedepends="
 	zlib-devel
 	readline-devel
@@ -23,10 +23,10 @@ makedepends="
 	$(vopt_if gtk3 pango-devel)"
 short_desc="Emulator for C64, C128, CBM-II, PET, VIC20, Plus4 and C16"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://vice-emu.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/vice-emu/$pkgname-$version.tar.gz"
-checksum=3eb8159633816095006dec36c5c3edd055a87fd8bda193a1194a6801685d1240
+checksum=28d99f5e110720c97ef16d8dd4219cf9a67661d58819835d19378143697ba523
 
 # Package build options
 build_options="sdl2 gtk3"


### PR DESCRIPTION
````
checking for xa... no
checking for xa65... no
configure: error: xa is missing


Making all in html
/bin/sh: ./texi2html: /usr/local/bin/perl: bad interpreter: No such file or directory
````