### PR TITLE
 lxqt-runner and LibreCAD: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/LibreCAD/template
+++ b/srcpkgs/LibreCAD/template
@@ -1,7 +1,7 @@
 # Template file for 'LibreCAD'
 pkgname=LibreCAD
 version=2.1.3
-revision=1
+revision=2
 build_style=qmake
 hostmakedepends="qt5-qmake pkg-config ImageMagick"
 makedepends="qt5-devel qt5-svg-devel boost-devel muparser-devel librsvg-devel"

--- a/srcpkgs/lxqt-runner/template
+++ b/srcpkgs/lxqt-runner/template
@@ -1,7 +1,7 @@
 # Template file for 'lxqt-runner'
 pkgname=lxqt-runner
 version=0.13.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DPULL_TRANSLATIONS=0"
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools"


### PR DESCRIPTION
both packages fail to start after muparser has been rebuilt.