### PR TITLE
avogadro & openbabel: rebuild required due to missing symbol errors

### DIFF
--- a/srcpkgs/avogadro/template
+++ b/srcpkgs/avogadro/template
@@ -1,7 +1,7 @@
 # Template file for 'avogadro'
 pkgname=avogadro
 version=1.2.0
-revision=7
+revision=8
 build_style=cmake
 configure_args="-DENABLE_TESTING:BOOL=OFF"
 hostmakedepends="pkg-config doxygen"

--- a/srcpkgs/openbabel/template
+++ b/srcpkgs/openbabel/template
@@ -1,7 +1,7 @@
 # Template file for 'openbabel'
 pkgname=openbabel
 version=2.4.1
-revision=3
+revision=4
 _ver=${version//./-}
 wrksrc=${pkgname}-${pkgname}-${_ver}
 build_style=cmake


### PR DESCRIPTION
Hi,

This pull is simply a rebuild as presently avogadro-1.2.0_7 fails to launch and gives the error:

```bash
avogadro: symbol lookup error: /usr/bin/../lib/libavogadro.so.1: undefined symbol: _ZN9OpenBabel9OBResidue12GetNumStringEv
```

as this error makes it clear Open Babel is to blame I rebuilt it, then rebuilt Avogadro and the result was it ran. So I'm here to pass on the fix so if any other chemistry enthusiasts running Void want to run Avogadro they can. 

Thanks for your time and patience,
Brenton