### PR TITLE
New package: shaderc-2017.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3396,3 +3396,4 @@ liblinphone.so.9 linphone-3.12.0_1
 liblinphone++.so.9 linphone-3.12.0_1
 libbelr.so.1 belr-0.1.3_1
 libbelcard.so.1 belcard-1.0.2_1
+libshaderc_shared.so shaderc-2017.2_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3397,3 +3397,5 @@ liblinphone++.so.9 linphone-3.12.0_1
 libbelr.so.1 belr-0.1.3_1
 libbelcard.so.1 belcard-1.0.2_1
 libshaderc_shared.so shaderc-2017.2_1
+libglslang.so glslang-6.2.2596_1
+libSPIRV.so glslang-6.2.2596_1

--- a/srcpkgs/SPIRV-Headers/patches/get-rid-of-custom-target.patch
+++ b/srcpkgs/SPIRV-Headers/patches/get-rid-of-custom-target.patch
@@ -1,0 +1,24 @@
+From c44560949ec78dd13fe1394bf2957e4fd5adec79 Mon Sep 17 00:00:00 2001
+From: Brian Evans <grknight@gentoo.org>
+Date: Wed, 14 Mar 2018 20:00:22 -0400
+Subject: [PATCH] Get rid of custom target
+
+---
+ CMakeLists.txt | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -45,7 +45,5 @@ project(SPIRV-Headers)
+ #   3. cmake --build . install-headers
+ 
+ file(GLOB_RECURSE FILES include/spirv/*)
+-add_custom_target(install-headers
+-  COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv ${CMAKE_INSTALL_PREFIX}/include/spirv)
+-
++INSTALL(DIRECTORY include/spirv/ DESTINATION include/spirv)
+ add_subdirectory(example)
+-- 
+2.16.2
+
+

--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,0 +1,17 @@
+# Template file for 'SPIRV-Headers'
+pkgname=SPIRV-Headers
+version=1.3
+revision=1
+noarch=yes
+build_style=cmake
+wrksrc="${pkgname,,}-${version}"
+short_desc="Machine-readable files for the SPIR-V Registry"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/KhronosGroup/SPIRV-Headers"
+distfiles="http://http.debian.net/debian/pool/main/s/spirv-headers/spirv-headers_${version}.orig.tar.gz"
+checksum=5c24fbd14773245dba0c541617513e7a4372b7cec902688697177e80a8dd52af
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/SPIRV-Tools-devel
+++ b/srcpkgs/SPIRV-Tools-devel
@@ -1,0 +1,1 @@
+SPIRV-Tools

--- a/srcpkgs/SPIRV-Tools/template
+++ b/srcpkgs/SPIRV-Tools/template
@@ -1,0 +1,25 @@
+# Template file for 'SPIRV-Tools'
+pkgname=SPIRV-Tools
+version=2018.2
+revision=1
+build_style=cmake
+configure_args="-DSPIRV_SKIP_TESTS=ON -DSPIRV_WERROR=OFF
+ -DSPIRV-Headers_SOURCE_DIR=${XBPS_CROSS_BASE}/usr"
+hostmakedepends="python3"
+makedepends="SPIRV-Headers"
+short_desc="API and commands for processing SPIR-V modules"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/KhronosGroup/SPIRV-Tools"
+distfiles="https://github.com/KhronosGroup/SPIRV-Tools/archive/v${version}.tar.gz"
+checksum=04acadbfab3018cb72dda3aa41081abd7bec9f53c7126e58548f018b602c2f89
+
+SPIRV-Tools-devel_package() {
+	depends="SPIRV-Tools-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+	}
+}

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.29.0
-revision=1
+revision=2
 build_style=waf
 configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
  --enable-dvdread --enable-dvdnav --enable-cdda --enable-libmpv-shared
@@ -10,7 +10,7 @@ configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
  $(vopt_enable pulseaudio pulse) $(vopt_enable sdl2)
  $(vopt_enable smb libsmbclient) $(vopt_enable sndio) $(vopt_enable v4l2 tv)
  $(vopt_enable vapoursynth) $(vopt_enable vdpau) $(vopt_enable wayland)
- $(vopt_enable x11)"
+ $(vopt_enable x11) $(vopt_enable vulkan) $(vopt_enable vulkan shaderc)"
 hostmakedepends="pkg-config python-docutils perl $(vopt_if wayland wayland-devel)"
 makedepends="MesaLib-devel ffmpeg-devel harfbuzz-devel lcms2-devel libXv-devel
  libass-devel libbluray-devel libcdio-paranoia-devel libdvdnav-devel
@@ -22,7 +22,8 @@ makedepends="MesaLib-devel ffmpeg-devel harfbuzz-devel lcms2-devel libXv-devel
  $(vopt_if v4l2 v4l-utils-devel) $(vopt_if vapoursynth vapoursynth-devel)
  $(vopt_if vdpau libvdpau-devel) $(vopt_if wayland "wayland-devel
  wayland-protocols libwayland-egl libxkbcommon-devel")
- $(vopt_if x11 "libXScrnSaver-devel libXinerama-devel libXrandr-devel")"
+ $(vopt_if x11 "libXScrnSaver-devel libXinerama-devel libXrandr-devel")
+ $(vopt_if vulkan 'Vulkan-Headers vulkan-loader shaderc')"
 depends="desktop-file-utils hicolor-icon-theme $(vopt_if vapoursynth vapoursynth-mvtools)"
 short_desc="Video player based on MPlayer/mplayer2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -32,8 +33,8 @@ distfiles="https://github.com/mpv-player/${pkgname}/archive/v${version}.tar.gz"
 checksum=772af878cee5495dcd342788a6d120b90c5b1e677e225c7198f1e76506427319
 
 build_options="alsa caca jack lua oss pulseaudio sdl2 smb sndio vapoursynth
- vdpau v4l2 wayland x11"
-build_options_default="alsa jack lua pulseaudio sndio vdpau wayland x11 v4l2"
+ vdpau v4l2 wayland x11 vulkan"
+build_options_default="alsa jack lua pulseaudio sndio vdpau wayland x11 v4l2 vulkan"
 desc_option_caca="Enable support for libcaca video output"
 desc_option_oss="Enable support for OSS audio output"
 vopt_conflict sdl2 wayland

--- a/srcpkgs/shaderc/patches/fix-glslang-link-order.patch
+++ b/srcpkgs/shaderc/patches/fix-glslang-link-order.patch
@@ -1,0 +1,43 @@
+Original upstream PR: https://github.com/google/shaderc/pull/463
+
+From 21c8be385b3fab5edcb934a6d99f69fd389c4e67 Mon Sep 17 00:00:00 2001
+From: Niklas Haas <git@haasn.xyz>
+Date: Tue, 29 May 2018 07:34:00 +0200
+Subject: [PATCH] Fix the link order of libglslang and libHLSL
+
+libglslang depends on libHLSL, so the latter needs to be specified last.
+This fixes an issue when trying to build shaderc against system-wide
+versions of libglslang/libHLSL, rather than the in-tree versions from
+third_party.
+
+Additionally, libshaderc_util also depends on SPIRV-Tools
+---
+ glslc/CMakeLists.txt           | 2 +-
+ libshaderc_util/CMakeLists.txt | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+--- glslc/CMakeLists.txt
++++ glslc/CMakeLists.txt
+@@ -18,7 +18,7 @@ add_library(glslc STATIC
+ shaderc_default_compile_options(glslc)
+ target_include_directories(glslc PUBLIC ${glslang_SOURCE_DIR})
+ target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
+-  HLSL glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
++  glslang SPIRV HLSL ${CMAKE_THREAD_LIBS_INIT})
+ target_link_libraries(glslc PRIVATE shaderc_util shaderc)
+
+ add_executable(glslc_exe src/main.cc)
+--- libshaderc_util/CMakeLists.txt
++++ libshaderc_util/CMakeLists.txt
+@@ -34,8 +34,8 @@ endif(SHADERC_ENABLE_INSTALL)
+
+ find_package(Threads)
+ target_link_libraries(shaderc_util PRIVATE
+-  glslang OSDependent OGLCompiler HLSL glslang SPIRV
+-  SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
++  glslang OSDependent OGLCompiler glslang HLSL SPIRV
++  SPIRV-Tools-opt SPIRV-Tools ${CMAKE_THREAD_LIBS_INIT})
+
+ shaderc_add_tests(
+   TEST_PREFIX shaderc_util
+

--- a/srcpkgs/shaderc/template
+++ b/srcpkgs/shaderc/template
@@ -1,0 +1,35 @@
+# Template file for 'shaderc'
+pkgname=shaderc
+version=2017.2
+revision=1
+_githash=7a23a01742b88329fb2260eda007172135ba25d4
+wrksrc="shaderc-${_githash}"
+build_style=cmake
+configure_args="-DSHADERC_SKIP_TESTS=ON"
+hostmakedepends="python"
+makedepends="SPIRV-Tools-devel glslang-devel"
+short_desc="Collection of tools, libraries and tests for shader compilation"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/google/shaderc"
+distfiles="https://github.com/google/shaderc/archive/${_githash}.tar.gz"
+checksum=496c2a45e5f3da2dd5a97d982fa5c7848d15143be42a4536fc28cb09c2e641dd
+
+pre_configure() {
+	# Unbundle glslang, SPIRV-Headers, SPIRV-Tools
+	# also remove examples
+	sed -i -e '/add_subdirectory(third_party)/d' \
+		   -e '/add_subdirectory(examples)/d' CMakeLists.txt
+
+	# Disable git versioning
+	sed -i -e '/build-version/d' glslc/CMakeLists.txt
+
+	# Create our own build-version.inc since we disabled git versioning
+	# need to keep this in sync with glslang and SPIRV-Tools versions
+	# this is displayed with 'glslc --version'
+	cat <<- EOF > glslc/src/build-version.inc
+		"shaderc\n"
+		"SPIRV-Tools-2018.2\n"
+		"glslang-6.2.2569\n"
+	EOF
+}


### PR DESCRIPTION
mpv can now use vulkan with `shaderc`

mpv --gpu-api=vulkan --gpu-context=x11vk (or waylandvk if you are a wayland adopter) --spirv-compiler=shaderc (nvidia if you're a nvidia user)

please drop a comment on the following template:

```
[Working fine|failed] on $(xbps-uhelper arch) with [shaderc|nvidia]

===anything else you want to say
```

shaderc is used on intel and amd