### PR TITLE
Fix svnserve startup to "daemonize" but run in foreground. 

### DIFF
--- a/srcpkgs/subversion/files/svnserve/run
+++ b/srcpkgs/subversion/files/svnserve/run
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec svnserve --foreground
+[ -r conf ] && . ./conf
+exec svnserve -d --foreground $OPTS

--- a/srcpkgs/subversion/template
+++ b/srcpkgs/subversion/template
@@ -1,7 +1,7 @@
 # Template file for 'subversion'
 pkgname=subversion
 version=1.10.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-apxs --disable-javahl --disable-static --without-kwallet
  --with-gnome-keyring --with-editor=vi --disable-mod-activation


### PR DESCRIPTION
(One of -d -i -t or -X must be provided.)

Also, fix 'run' script to allow config file with custom run options.