### PR TITLE
New packages: pymol-2.2.0, python3-pmw-2.0.1

### DIFF
--- a/srcpkgs/pymol/files/pymol.desktop
+++ b/srcpkgs/pymol/files/pymol.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=PyMOL
+GenericName=PyMOL
+Comment=PyMOL is a molecular graphics system designed for modelling large molecules
+Exec=/usr/bin/pymol %f
+Terminal=false
+Type=Application
+MimeType=text/plain;chemical/x-cml;chemical/x-pdb;application/xml;application/x-aportisdoc;chemical/x-cif;
+StartupNotify=true
+Icon=pymol
+Categories=Education;Science;Chemistry

--- a/srcpkgs/pymol/template
+++ b/srcpkgs/pymol/template
@@ -1,0 +1,28 @@
+# Template for 'pymol'
+pkgname=pymol
+version=2.2.0
+revision=1
+_commit=4190
+wrksrc="${pkgname}-code-r${_commit}-trunk-${pkgname}"
+build_style="python3-module"
+makedepends="msgpack-devel python3-numpy freetype-devel libfreeglut-devel glew-devel python3-devel libxml2-devel python3-PyQt5 unzip"
+depends="python3-numpy tcsh python3-pmw python3-tkinter python3-PyQt5"
+short_desc="PyMOL molecular visualization system"
+homepage="https://${pkgname}.org/"
+maintainer="Brenton Horne <brentonhorne77@gmail.com>"
+license="${pkgname}"
+distfiles="https://sourceforge.net/code-snapshots/svn/p/py/${pkgname}/code/${pkgname}-code-r4190-trunk-${pkgname}.zip
+https://c.fsdn.com/allura/p/${pkgname}/icon>${pkgname}.png"
+skip_extraction="${pkgname}.png"
+checksum="beee2faa0d4e86a7b9399aa205e9a6dd877b564717fed6654bfc39a56cfc26d5
+ 0ea81faaf336becc669a193777d0dca55475d303d1236b57df25cf67ff7c2bcd"
+
+case $XBPS_TARGET_MACHINE in
+	*-musl) broken="segfaults on start";;
+esac
+
+post_install() {
+	vlicense LICENSE
+	vinstall "${FILESDIR}/${pkgname}.desktop" 755 usr/share/applications
+	vinstall "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}.png" 644 usr/share/pixmaps
+}

--- a/srcpkgs/python3-pmw/files/LICENSE.txt
+++ b/srcpkgs/python3-pmw/files/LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright (c) 2007,2008  David M. Cooke <david.m.cooke@gmail.com>
+Copyright (c) 2009,2010  Francesc Alted <faltet@pytables.org>
+Copyright (c) 2011-      See AUTHORS.txt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/srcpkgs/python3-pmw/template
+++ b/srcpkgs/python3-pmw/template
@@ -1,0 +1,20 @@
+# Template for python-pmw
+pkgname=python3-pmw
+version=2.0.1
+revision=1
+noarch=yes
+short_desc="Python 3 Tkinter widget toolkit"
+homepage="http://pmw.sourceforge.net/"
+license="MIT"
+maintainer="Brenton Horne <brentonhorne77@gmail.com>"
+wrksrc=Pmw-${version}
+build_style=python3-module
+makedepends="python3-devel tk-devel"
+depends="tk python3"
+distfiles="${PYPI_SITE}/P/Pmw/Pmw-${version}.tar.gz"
+checksum=0b9d28f52755a7a081b44591c3dd912054f896e56c9a627db4dd228306ad1120
+
+post_install() {
+	vlicense ${FILESDIR}/LICENSE.txt
+}
+


### PR DESCRIPTION
Hi,

In this pull I'm introducing yet another piece of chemistry software, PyMOL. It is mostly used for visualizing large molecules like proteins, although visualizing smaller molecules is also possible. For example, here's a 3D representation of methotrexate (a common cancer and anti-inflammatory drug; the ball and stick model in it) bound to human dihydrofolate reductase (DHFR), an enzyme involved in the metabolism of vitamin B9 (folic acid); it is this binding and the resulting changes in DHFR's shape and functionality that is believed to underpin most of methotrexate's therapeutic effects. 

![3eig-mtx-hadd-20180805-pr](https://user-images.githubusercontent.com/4717341/43680399-2d1c599e-987d-11e8-9635-db8a1324c555.png)

In order for PyMOL to function to the best of its abilities it needs an additional package, python3-pmw. The template files are largely inspired by the corresponding Arch Linux PKGBUILDs; I even used [their copy](https://git.archlinux.org/svntogit/community.git/tree/trunk/LICENSE.txt?h=packages/python-pmw) of LICENSE.txt for python3-pmw.

PyMOL is compatible with both Python 2 and 3, but I tried splitting it up into two separate packages and it became a whole mess, same with python-pmw. As Python 3 is the Python of the future I decided to keep it and ditch Python 2. 

Thanks for your time and the opportunity to contribute to this fine distro,
Brenton