### PR TITLE
libva: update to 2.2.0.

### DIFF
--- a/srcpkgs/QMPlay2/template
+++ b/srcpkgs/QMPlay2/template
@@ -1,7 +1,7 @@
 # Template file for 'QMPlay2'
 pkgname=QMPlay2
 version=18.07.03
-revision=1
+revision=2
 wrksrc="${pkgname}-src-${version}"
 build_style=cmake
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
@@ -12,6 +12,7 @@ short_desc="Video and audio player which can play most formats and codecs"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="LGPL-3.0-only"
 homepage="http://zaps166.sourceforge.net/?app=QMPlay2"
+changelog="https://raw.githubusercontent.com/zaps166/QMPlay2/master/ChangeLog"
 distfiles="https://github.com/zaps166/QMPlay2/releases/download/${version}/QMPlay2-src-${version}.tar.xz"
 checksum=78cdadea21728f7a902ae240aae15481bcad2b9f34598c20ee7711feeff79122
 

--- a/srcpkgs/avidemux/template
+++ b/srcpkgs/avidemux/template
@@ -1,7 +1,7 @@
 # Template file for 'avidemux'
 pkgname=avidemux
 version=2.7.1
-revision=3
+revision=4
 wrksrc="${pkgname}_${version}"
 hostmakedepends="cmake pkg-config qt5-host-tools qt5-devel yasm"
 makedepends="alsa-lib-devel faac-devel faad2-devel gettext-devel jack-devel glu-devel
@@ -14,8 +14,9 @@ only_for_archs="x86_64 x86_64-musl i686 i686-musl"
 depends="python"
 short_desc="Video editing and processing application"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://avidemux.sourceforge.net/"
+changelog="http://avidemux.sourceforge.net/news.html"
 distfiles="${SOURCEFORGE_SITE}/avidemux/avidemux/${version}/${pkgname}_${version}.tar.gz"
 checksum=3ccd784a329c8957c6741923549fdfb70f3b96d087aeb514f3d52e1cd281e995
 

--- a/srcpkgs/stepmania/template
+++ b/srcpkgs/stepmania/template
@@ -1,7 +1,7 @@
 # Template file for 'stepmania'
 pkgname=stepmania
 version=5.0.12
-revision=1
+revision=2
 build_style=cmake
 cmake_builddir="Build"
 hostmakedepends="nasm yasm pkg-config git"

--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -1,7 +1,7 @@
 # Template file for 'vlc'
 pkgname=vlc
 version=3.0.4
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-gme --disable-libtar --enable-jack
  --disable-live555 --disable-fluidsynth --enable-dvdread
@@ -11,8 +11,9 @@ configure_args="--disable-gme --disable-libtar --enable-jack
  $(vopt_enable lua) $(vopt_enable vaapi libva) $(vopt_enable vdpau)"
 short_desc="A cross-platform multimedia player"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="https://www.videolan.org/vlc/"
 license="GPL-2.0-only, LGPL-2.1-only"
+homepage="https://www.videolan.org/vlc/"
+changelog="https://raw.githubusercontent.com/videolan/vlc/master/NEWS"
 distfiles="https://download.videolan.org/pub/videolan/vlc/${version}/vlc-${version}.tar.xz"
 checksum=01f3db3790714038c01f5e23c709e31ecd6f1c046ac93d19e1dde38b3fc05a9e
 


### PR DESCRIPTION
Building locally on x86_64

- [x] xine-lib
- [x] weston
- [x] vlc
- [x] stepmania
- [x] qtav
- [x] mpv
- [x] libvdpau-va-gl
- [x] kodi
- [x] gstreamer-vaapi
- [x] freshplayerplugin
- [x] ffmpeg
- [x] bomi
- [x] avidemux
- [x] QMPlay2