### PR TITLE
arduino: fix version.txt by passing -Dversion= when running ant build

### DIFF
--- a/srcpkgs/arduino/template
+++ b/srcpkgs/arduino/template
@@ -1,7 +1,7 @@
 # Template file for 'arduino'
 pkgname=arduino
 version=1.8.5
-revision=1
+revision=2
 hostmakedepends="apache-ant unzip ImageMagick openjdk"
 depends="virtual?java-runtime avr-binutils avr-gcc avr-libc avrdude"
 short_desc="IDE for the arduino open-source electronics prototyping platform"
@@ -34,7 +34,7 @@ do_build() {
 		x86_64*) LINUX_BUILD=linux64-build ;;
 		*) LINUX_BUILD=linux-build ;;
 	esac
-	ant $LINUX_BUILD
+	ant -Dversion=${version} $LINUX_BUILD
 	sed -i -e "s#{runtime\.tools\.[^.]*\.path}#/usr#g" \
 		-e "s#\(tools\.avrdude\.config\.path=\).*#\1/etc/avrdude.conf#" \
 		linux/work/hardware/arduino/avr/platform.txt


### PR DESCRIPTION
On 1.8.5_1, `usr/lib/arduino/lib/version.txt` contained `${version}`, and some utilities (Arduino-Makefile, for instance), look for the arduino version in this file. The issue is the build.xml section that normally sets `version` is directly under the `dist` target, and calling `linux64-build` bypasses this part. `version.txt` is written out directly by ant. 

This PR fixes this file by passing in `-Dversion=${version}` when running the ant build.