### PR TITLE
New package: jmol-14.29.17

### DIFF
--- a/srcpkgs/jmol/files/jmol.desktop
+++ b/srcpkgs/jmol/files/jmol.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Jmol
+Comment=An open-source Java viewer for chemical structures in 3D
+GenericName=Jmol
+Exec=jmol %f
+Icon=jmol
+Terminal=0
+Type=Application
+MimeType=text/plain;chemical/x-mdl-molfile;chemical/x-cif;chemical/x-cml;application/xml;application/x-aportisdoc;chemical/x-gamess-output;chemical/x-gaussian-log;chemical/x-mopac-out;chemical/x-pdb;chemical/x-xyz;chemical/x-gaussian-cube;chemical/x-qchem-output;
+Categories=Education;Science;Chemistry;

--- a/srcpkgs/jmol/template
+++ b/srcpkgs/jmol/template
@@ -1,0 +1,30 @@
+# Template for 'jmol'
+pkgname=jmol
+version=14.29.17
+revision=1
+noarch=yes
+maintainer="Brenton Horne <brentonhorne77@gmail.com>"
+homepage="http://jmol.sourceforge.net/"
+hostmakedepends="unzip"
+depends="virtual?java-environment"
+license="LGPL-2.1-or-later"
+short_desc="An open-source Java/JavaScript-based molecule viewer"
+distfiles="${SOURCEFORGE_SITE}/jmol/Jmol/Version%20${version%.*}/Jmol%20${version}/Jmol-${version}-binary.tar.gz
+ http://jmol.sourceforge.net/images/Jmol_icon_128.png"
+skip_extraction="Jmol_icon_128.png"
+checksum="5347e0df0781620d8e1cb7b933cd76ca04d19aef57ceea1b153f2988e25eddb6
+ d84e5e4b5c9b440b3b90432db87e0d4bd5c8237d7d2891c174fac71f0a5a2127"
+
+do_install() {
+	vmkdir usr/bin
+	vmkdir usr/share/${pkgname}
+
+	unzip jsmol.zip -d "${DESTDIR}"/usr/share/
+	rm jsmol.zip
+
+	cp *.jar jmol.sh "${DESTDIR}"/usr/share/${pkgname}
+	ln -s /usr/share/${pkgname}/${pkgname}.sh "$DESTDIR"/usr/bin/${pkgname}
+
+	vinstall "${FILESDIR}/${pkgname}.desktop" 644 usr/share/applications
+	vinstall "${XBPS_SRCDISTDIR}/${pkgname}-${version}/Jmol_icon_128.png" 644 usr/share/pixmaps jmol.png
+}


### PR DESCRIPTION
Hi,

This is the last piece of chemistry software I want to add to this fine distribution. It is present in the repositories of most modern distributions and as its name suggests it is a molecular viewing software that is written in Java. Although, it also comes with a version of it called JSmol that is written in JavaScript and is mostly used in web browsers. 

As an example of this marvellous piece of software at work, my profile picture on GitHub is of esketamine, an anaesthetic that is presently under development as a rapid-acting antidepressant, and the picture was actually produced using Jmol, rendered with POVRay (to give it a transparent background, which I notice is also not in the repositories, I might do something about that too) and edited using GIMP (mostly used just to crop it).

Thanks for your time,
Brenton