### PR TITLE
New package: font-firacode-1.205

### DIFF
--- a/srcpkgs/font-firacode/template
+++ b/srcpkgs/font-firacode/template
@@ -1,0 +1,18 @@
+# Template file for 'font-firacode'
+pkgname=font-firacode
+version=1.205
+revision=1
+noarch=yes
+create_wrksrc=yes
+hostmakedepends="unzip"
+font_dirs="/usr/share/fonts/OTF"
+short_desc="FiraCode: monospaced font with programming ligatures"
+maintainer="Issam Maghni <me@concati.me>"
+license="OFL-1.1"
+homepage="https://github.com/tonsky/${pkgname#*-}"
+distfiles="${homepage}/releases/download/${version}/${pkgname#*-}_${version}.zip"
+checksum=85b2a6de92b71ef0f7715cca32d394484221ec978cb21e5228dc99978a7b7d8d
+
+do_install() {
+	install -Dm644 otf/* -t ${DESTDIR}/${font_dirs}
+}


### PR DESCRIPTION
As requested here https://github.com/voidlinux/void-packages/issues/11476
Maybe you have some suggestions to improve `do_install` block.
`font_dirs` is used in [here](//github.com/void-linux/void-packages/blob/master/srcpkgs/font-awesome/template#L9) but there is no reference in the [manual](//github.com/void-linux/void-packages/blob/master/Manual.md)