### PR TITLE
gnumeric: update to 1.12.41 (crashfix)

### DIFF
--- a/srcpkgs/gnumeric/template
+++ b/srcpkgs/gnumeric/template
@@ -1,6 +1,6 @@
 # Template file for 'gnumeric'
 pkgname=gnumeric
-version=1.12.39
+version=1.12.41
 revision=1
 build_style=gnu-configure
 hostmakedepends="bison gdk-pixbuf-devel glib-devel intltool itstool pkg-config "
@@ -10,7 +10,7 @@ maintainer="Duncaen <duncaen@voidlinux.eu>"
 license="GPL-3.0-or-later"
 homepage="http://gnumeric.org/"
 distfiles="${GNOME_SITE}/gnumeric/${version%.*}/gnumeric-${version}.tar.xz"
-checksum=26cceb7fa97dc7eee7181a79a6251a85b1f1464dcaaaf7624829f7439c5f7d3f
+checksum=66f6e665b7b6d708537295d8cbd00c5cb4efe31f605d5e646f38a7beab565969
 
 if [ "$CROSS_BUILD" ]; then
 	CFLAGS="-I${XBPS_CROSS_BASE}/usr/include"


### PR DESCRIPTION
The rebuild fixes a 100% crash when opening or saving files. Reported on the forums: https://forum.voidlinux.org/t/bug-gnumeric-cannot-open-files-any-longer/6404