### PR TITLE
freeimage: re-add ARM NEON patch, unbreak EmulationStation for aarch64*

### DIFF
--- a/srcpkgs/EmulationStation/template
+++ b/srcpkgs/EmulationStation/template
@@ -13,10 +13,6 @@ homepage="https://github.com/RetroPie/EmulationStation"
 distfiles="https://github.com/RetroPie/EmulationStation/archive/v${version}.tar.gz"
 checksum=07415511cc5abf36ba2e35d97bd2f651947040bcc8af9cffc491724a19afb214
 
-case "$XBPS_TARGET_MACHINE" in
-	aarch64*) broken="/usr/aarch64-linux-musl/usr/lib/libfreeimage.so: undefined reference to png_init_filter_functions_neon" ;;
-esac
-
 pre_configure() {
 	rm -rf external/pugixml
 	git clone https://github.com/zeux/pugixml.git external/pugixml

--- a/srcpkgs/freeimage/patches/disable_arm_neon.patch
+++ b/srcpkgs/freeimage/patches/disable_arm_neon.patch
@@ -1,0 +1,20 @@
+--- fi/Source/LibPNG/pngpriv.h.orig	2018-07-16 11:58:00.000000000 +0200
++++ fi/Source/LibPNG/pngpriv.h	2018-08-07 10:15:53.827327997 +0200
+@@ -107,6 +107,7 @@
+  * this in $(CC), e.g. "CC=gcc -mfpu=neon", but people who build libpng rarely
+  * do this.
+  */
++#define PNG_ARM_NEON_OPT 0
+ #ifndef PNG_ARM_NEON_OPT
+    /* ARM NEON optimizations are being controlled by the compiler settings,
+     * typically the target FPU.  If the FPU has been set to NEON (-mfpu=neon
+--- fip/Source/LibPNG/pngpriv.h.orig	2018-07-16 11:58:00.000000000 +0200
++++ fip/Source/LibPNG/pngpriv.h	2018-08-07 10:15:53.827327997 +0200
+@@ -107,6 +107,7 @@
+  * this in $(CC), e.g. "CC=gcc -mfpu=neon", but people who build libpng rarely
+  * do this.
+  */
++#define PNG_ARM_NEON_OPT 0
+ #ifndef PNG_ARM_NEON_OPT
+    /* ARM NEON optimizations are being controlled by the compiler settings,
+     * typically the target FPU.  If the FPU has been set to NEON (-mfpu=neon

--- a/srcpkgs/freeimage/template
+++ b/srcpkgs/freeimage/template
@@ -1,7 +1,7 @@
 # Template file for 'freeimage'
 pkgname=freeimage
 version=3.18.0
-revision=1
+revision=2
 wrksrc=FreeImage
 build_style=gnu-makefile
 hostmakedepends="unzip"


### PR DESCRIPTION
The way freeimage is built the bundled libPNG chooses ARM NEON automatically when on aarch64. However, the subfolders with the necessary assembler code are left out and so other packages linking to libfreeimage.so will fail.

I re-added the patch to disable ARM NEON which was removed with the recent update.
And this unbreaks EmulationStation. :)

cc @maxice8 @pullmoll 