### PR TITLE
mypaint: add missing librsvg dependency

### DIFF
--- a/srcpkgs/mypaint/template
+++ b/srcpkgs/mypaint/template
@@ -1,11 +1,11 @@
 # Template file for 'mypaint'
 pkgname=mypaint
 version=1.2.1
-revision=3
+revision=4
 hostmakedepends="scons swig pkg-config"
 makedepends="libgomp-devel json-c-devel python-numpy libglib-devel libpng-devel
  lcms2-devel gtk+3-devel python-gobject-devel"
-depends="pygtk python-numpy python-gobject"
+depends="librsvg pygtk python-numpy python-gobject"
 pycompile_dirs="/usr/share/mypaint"
 short_desc="Graphics application for digital painters"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"


### PR DESCRIPTION
Fixes failure to start with:
```
ERROR: gui.application: Missing icon 'mypaint-brush-symbolic': check that librsvg is installed, and update loaders.cache
Traceback (most recent call last):
  File "/usr/share/mypaint/gui/application.py", line 126, in _init_icons
    pixbuf = icon_theme.load_icon(icon_name, 32, 0)
Error: gtk-icon-theme-error-quark: Icon 'mypaint-brush-symbolic' not present in theme Adwaita (0)
CRITICAL: gui.application: Required icon(s) missing
ERROR: gui.application: Icon search path: ['/home/user/.local/share/icons', '/home/user/.icons', '/usr/local/share/icons', '/usr/share/icons', '/usr/local/share/pixmaps', '/usr/share/pixmaps', '/usr/share/icons']
ERROR: gui.application: Mypaint can't run sensibly without its icons; please check your installation. See https://gna.org/bugs/?18460 for possible solutions.
```