### PR TITLE
rpi-kernel: update to 4.14.61.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="ad1d85ad2a7dea6a17e6d3cc32adf6ce0ea844c0"
+_githash="52d350fb107dbd9fa30d44685ed52d2c52b09d96"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.59
+version=4.14.61
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=67bf83e782fe47de7a49061ffcc70b1ea16eb519772f6ad575c39c40c4fcbe1b
+checksum=b339528dc4b0156ebc0613262a415169ddaf6143e5a9971414f1224a075dbc15
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]