### PR TITLE
oidentd: fix license and distfiles URL

### DIFF
--- a/srcpkgs/oidentd/template
+++ b/srcpkgs/oidentd/template
@@ -1,17 +1,17 @@
 # Template file for 'oidentd'
 pkgname=oidentd
 version=2.3.1
-revision=1
+revision=2
 build_style=gnu-configure
 conf_files="/etc/oidentd.conf /etc/oidentd_masq.conf"
 hostmakedepends="flex"
 makedepends="libnetfilter_conntrack-devel libcap-ng-devel"
 short_desc="RFC 1413 compliant ident daemon"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
-license="GPL-2.0-or-later, GFDL-1.1-or-later"
+license="GPL-2.0-only, GFDL-1.1-or-later"
 homepage="https://oidentd.janikrabe.com/"
 changelog="https://raw.githubusercontent.com/janikrabe/${pkgname}/v${version}/ChangeLog"
-distfiles="https://ftp.janikrabe.com/pub/${pkgname}/releases/latest/${pkgname}-${version}.tar.xz"
+distfiles="https://files.janikrabe.com/pub/${pkgname}/releases/${version}/${pkgname}-${version}.tar.xz"
 checksum=f5626a679263dd53c10b61bd0c7c9d59f947426667d3a35e53a22de4b5047635
 
 post_install() {


### PR DESCRIPTION
* Changed license from `GPL-2.0-or-later` to `GPL-2.0-only`
* Changed distfiles URL: `ftp` to `files`, `latest` to `${version}`
* Bumped revision