### PR TITLE
Enabling json-c features

### DIFF
--- a/srcpkgs/json-c/template
+++ b/srcpkgs/json-c/template
@@ -1,21 +1,29 @@
-# Template build file for 'json-c'.
+# Template file for 'json-c'
 pkgname=json-c
 version=0.13.1
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="$(vopt_enable threading) $(vopt_enable rdrand)"
 hostmakedepends="automake libtool"
+checkdepends="valgrind"
 short_desc="A JSON implementation in C"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
-homepage="http://oss.metaparadigm.com/$pkgname"
-distfiles="https://s3.amazonaws.com/json-c_releases/releases/$pkgname-$version.tar.gz"
+homepage="https://${pkgname}.github.io/${pkgname}/"
+distfiles="https://s3.amazonaws.com/${pkgname}_releases/releases/${pkgname}-${version}.tar.gz"
 checksum=b87e608d4d3f7bfdd36ef78d56d53c74e66ab278d318b71e6002a369d36f4873
+
+build_options="threading rdrand"
+build_options_default="threading rdrand"
+desc_option_threading="Enable code to support partly multi-threaded use"
+desc_option_rdrand="Enable RDRAND Hardware RNG Hash Seed generation on supported x86/x64 platforms"
 
 CFLAGS="-Wno-error"
 
 pre_configure() {
 	autoreconf -fi
 }
+
 post_install() {
 	vlicense COPYING
 }


### PR DESCRIPTION
First, is it dangerous to enable `rdrand`, even on non-x86/64?
Second, how to enable `do_check()`?
Third, can I use `make_check_args` instead of `do_check()`?