### PR TITLE
libwacom: update to 0.31.

### DIFF
--- a/srcpkgs/libwacom/template
+++ b/srcpkgs/libwacom/template
@@ -1,16 +1,17 @@
 # Template file for 'libwacom'
 pkgname=libwacom
-version=0.30
+version=0.31
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
-makedepends="libglib-devel libgudev-devel"
+makedepends="libgudev-devel"
 short_desc="Library to identify wacom tablets"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="https://github.com/linuxwacom/libwacom"
+changelog="https://raw.githubusercontent.com/linuxwacom/libwacom/master/NEWS"
 distfiles="https://github.com/linuxwacom/libwacom/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.bz2"
-checksum=523408680514c0f01052e478503d8e89f86d72ddc7129fdd63988c221c492259
+checksum=18d58c254bee88527f5d58f6fd18458a9f0097641a1ee116dc2b6950619fbf03
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Not certain if [this](https://raw.githubusercontent.com/linuxwacom/libwacom/master/NEWS) qualifies as a changelog.