### PR TITLE
qutebrowser: also install userscripts

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,7 +1,7 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
 version=1.4.1
-revision=1
+revision=2
 noarch=yes
 build_style=python3-module
 pycompile_module="$pkgname"
@@ -24,6 +24,8 @@ pre_build() {
 post_install() {
 	vman doc/${pkgname}.1
 	vinstall misc/${pkgname}.desktop 644 usr/share/applications
+	vmkdir usr/share/qutebrowser/
+	vcopy misc/userscripts usr/share/qutebrowser/
 
 	local dim
 	for dim in 16 24 32 48 64 96 128 256 512; do


### PR DESCRIPTION
Qutebrowser has some userscripts included in its repository, but these were not installed.

My revision installs them in the `/usr/share/qutebrowser/userscripts` directory. To activate them, the user should create a symbolic link to the desired userscript in `~/.local/share/qutebrowser/userscripts/`.

For more info: https://github.com/qutebrowser/qutebrowser/blob/master/doc/userscripts.asciidoc