### PR TITLE
quassel: move system_accounts to quassel-core package

### DIFF
--- a/srcpkgs/quassel/template
+++ b/srcpkgs/quassel/template
@@ -1,7 +1,7 @@
 # Template file for 'quassel'
 pkgname=quassel
 version=0.12.5
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DEMBED_DATA=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DWANT_CORE=ON
  -DUSE_QT5=ON"
@@ -17,7 +17,6 @@ license="GPL-2.0, GPL-3.0"
 homepage="https://www.quassel-irc.org"
 distfiles="https://quassel-irc.org/pub/quassel-${version}.tar.bz2"
 checksum=1894574dfd79654152a5b7427e7df592b055ae908230504f98a4cb48961e74e2
-system_accounts="quassel"
 
 post_install() {
 	vsv quasselcore
@@ -40,6 +39,7 @@ quassel-core_package() {
 	conflicts="quasselcore>=0"
 	depends="qt5-plugin-sqlite"
 	short_desc="${_desc} - server"
+	system_accounts="quassel"
 	pkg_install() {
 		vmove /usr/bin/quasselcore
 		vmove /etc/sv


### PR DESCRIPTION
The system_account `quassel` is needed by `quassel-core`, not by the main package.