### PR TITLE
xf86-video-intel: add intel-virtual-output

### DIFF
--- a/srcpkgs/xf86-video-intel/template
+++ b/srcpkgs/xf86-video-intel/template
@@ -1,14 +1,15 @@
 # Template file for 'xf86-video-intel'
 pkgname=xf86-video-intel
 version=2.99.917.831
-revision=2
+revision=3
 _commit=e7bfc9065345085f767235eea8b148c356e5bd2b
 lib32disabled=yes
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
 build_style=gnu-configure
 configure_args="--with-default-dri=3"
 hostmakedepends="git automake libtool pkg-config xorg-util-macros"
-makedepends="libXvMC-devel xorg-server-devel"
+makedepends="libXScrnSaver-devel libXcursor-devel libXinerama-devel
+ libXrandr-devel libXvMC-devel xorg-server-devel"
 depends="virtual?xserver-abi-video-24_1 mesa-intel-dri"
 short_desc="Xorg DDX Intel video driver"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
resolves https://github.com/void-linux/void-packages/issues/1711
````
xf86-video-intel 2.99.917 will be compiled with:
  Xorg Video ABI version: 24.0 (xorg-server-1.20.1)
  pixman version: pixman-1-0.34.0
  Acceleration backends: none *sna uxa
  Additional debugging support? none
  Support for Kernel Mode Setting? yes
  Support for legacy User Mode Setting (for i810)? yes
  Support for Direct Rendering Infrastructure: DRI2 *DRI3 Present
  Support for Xv motion compensation (XvMC and libXvMC): yes
  Support for display hotplug notifications (udev): yes
  Build additional tools and utilities? xf86-video-intel-backlight-helper intel-virtual-output
````