### PR TITLE
lighttpd: update to 1.4.50.

### DIFF
--- a/srcpkgs/lighttpd/template
+++ b/srcpkgs/lighttpd/template
@@ -1,45 +1,30 @@
 # Template file for 'lighttpd'
 pkgname=lighttpd
-version=1.4.49
-revision=4
-makedepends="libuuid-devel libmysqlclient-devel lua-devel libxml2-devel
- sqlite-devel gdbm-devel pcre-devel libressl-devel fcgi-devel libldap-devel attr-devel"
-hostmakedepends="automake pkg-config libtool"
-conf_files="/etc/lighttpd/lighttpd.conf"
-system_accounts="_${pkgname}"
-_lighttpd_homedir="/srv/www/${pkgname}"
+version=1.4.50
+revision=1
+build_style=meson
+configure_args="-Dwith_bzip=true -Dwith_fam=false -Dwith_gdbm=true
+ -Dwith_geoip=false -Dwith_krb5=true -Dwith_ldap=true -Dwith_libev=true
+ -Dwith_libunwind=false -Dwith_lua=true -Dwith_memcached=true
+ -Dwith_mysql=false -Dwith_openssl=true -Dwith_pcre=true -Dwith_pgsql=false
+ -Dwith_sasl=false -Dwith_xattr=true -Dwith_zlib=true -Dwith_webdav_props=true
+ -Dwith_webdav_locks=true -Dsbindir=/usr/bin -Dmoduledir=lib/lighttpd/modules"
+hostmakedepends="pkg-config"
+makedepends="libuuid-devel lua-devel libxml2-devel libev-devel sqlite-devel gdbm-devel
+ pcre-devel libressl-devel fcgi-devel libldap-devel attr-devel libmemcached-devel
+ mit-krb5-devel"
 short_desc="A secure, fast, compliant and very flexible web-server"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="BSD-3-Clause"
-homepage="http://lighttpd.net"
-distfiles="http://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${version}.tar.xz"
-checksum=aedf49d7127d9e4c0ea56618e9e945a17674dc46a37ac7990120f87dd939ce09
-build_style=gnu-configure
-configure_args="
-	--sbindir=/usr/bin \
-	--with-gnu-ld \
-	--libdir=/usr/lib/lighttpd/modules/ \
-	--sysconfdir=/etc/lighttpd \
-	--with-mysql=${XBPS_CROSS_BASE}/usr/bin/mysql_config \
-	--with-ldap \
-	--with-attr \
-	--with-zlib \
-	--with-bzip2 \
-	--with-openssl \
-	--with-pcre \
-	--with-kerberos5 \
-	--without-fam \
-	--with-memcache \
-	--with-webdav-props \
-	--with-webdav-locks \
-	--with-gdbm \
-	--with-memcache \
-	--with-lua"
+homepage="https://lighttpd.net"
+distfiles="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${version}.tar.xz"
+checksum=29378312d8887cbc14ffe8a7fadef2d5a08c7e7e1be942795142346ad95629eb
+
+conf_files="/etc/lighttpd/lighttpd.conf"
+system_accounts="_${pkgname}"
+_lighttpd_homedir="/srv/www/${pkgname}"
 lib32disabled=yes
 
-pre_configure() {
-	autoreconf -fi
-}
 post_install() {
 	vlicense COPYING
 	vsv lighttpd


### PR DESCRIPTION
@Gottox 

- removed mysql until we update to 5.7 which has a pkg-config file
- switched to `meson`
- enable memcached (it was "enabled" twice but the dependency was missing)
- enable libev (was previously disabled)
- enable kerberos (was enabled but didn't have dependency)
- switch homepage= and distfiles= to https

files changes:
```
>>> lighttpd
12d11
< /usr/lib/lighttpd/modules/mod_authn_mysql.so
26d24
< /usr/lib/lighttpd/modules/mod_mysql_vhost.so
45d42
< /usr/lib/lighttpd/modules/mod_vhostdb_mysql.so
49,50d45
< /usr/share/man/man8/lighttpd-angel.8
< /usr/share/man/man8/lighttpd.8
```