### PR TITLE
marvin: update to 18.19.0

### DIFF
--- a/srcpkgs/marvin/template
+++ b/srcpkgs/marvin/template
@@ -1,7 +1,8 @@
 # Template for Marvin
 pkgname=marvin
-version=18.18.0
+version=18.19.0
 revision=1
+noarch=yes
 maintainer="Brenton Horne <brentonhorne77@gmail.com>"
 homepage="https://chemaxon.com/products/marvin"
 license="marvin"
@@ -13,7 +14,7 @@ restricted=yes
 nostrip=yes
 _filename="marvin_linux_$(echo $version | sed 's/.[0-9]*$//g').deb"
 distfiles="https://dl.chemaxon.com/marvin/${version}/${_filename}"
-checksum="d34306eb9e81c3173d2196e5c2144bbc7e99927a2e2233dda7c9df9ca3f9d1e7"
+checksum=f498405166821e6f2f8e75b1357c10fca9b1834cca5ca14d56c7921ed4fb5bcf
 
 do_extract() {
 	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_filename}


### PR DESCRIPTION
Hi,

As per title, I wish to bump marvin to 18.19.0. I also found an error in my initial adding of this package as it is indeed architecture independent so `noarch=yes` is appropriate, although the build restrictions to i686 and x86_64 are also appropriate. 

Thanks for your time and patience,
Brenton