### PR TITLE
build_style/meson.sh: export CFLAGS and CXXFLAGS from host

### DIFF
--- a/common/build-style/meson.sh
+++ b/common/build-style/meson.sh
@@ -60,6 +60,11 @@ EOF
 		# compiling, we need to set those to the host versions.
 		export CC=${CC_host} CXX=${CXX_host}
 
+		# Meson tries to use CFLAGS and CPPFLAGS when compiling under
+		# native: true, so we use XBPS_CFLAGS and XBPS_CPPFLAGS which
+		# are set to (C|CXX)FLAGS_host
+		export CFLAGS=${CFLAGS_host} CXXFLAGS=${CXXFLAGS_host}
+
 		unset _MESON_TARGET_CPU _MESON_TARGET_ENDIAN
 	fi
 


### PR DESCRIPTION
meson when compiling something with 'native: true' (for building
executables that are meant to be run on the host system) uses CFLAGS
and CXXFLAGS environment variables, we "pollute" them with
TARGET system cflags/cxxflags, such as -march= for the cross-compiled
arch.

so to fix it we export CFLAGS and CXXFLAGS to be CFLAGS_host and
CXXFLAGS_host respectively, they are set by XBPS and correspond to
the XBPS_CFLAGS/XBPS_CXXFLAGS. This same set of changes is also done
with CC and CXX see L#61

this was found when cross-compiling lighttpd which created the
'lemon' executable to generate inputs

thanks to @Cogitri from Exherbo for helping me debug this