### PR TITLE
qutebrowser: also install scripts

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,7 +1,7 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
 version=1.4.1
-revision=2
+revision=3
 noarch=yes
 build_style=python3-module
 pycompile_module="$pkgname"
@@ -24,8 +24,10 @@ pre_build() {
 post_install() {
 	vman doc/${pkgname}.1
 	vinstall misc/${pkgname}.desktop 644 usr/share/applications
+
 	vmkdir usr/share/qutebrowser/
 	vcopy misc/userscripts usr/share/qutebrowser/
+	vcopy scripts usr/share/qutebrowser/
 
 	local dim
 	for dim in 16 24 32 48 64 96 128 256 512; do


### PR DESCRIPTION
This revision also installs the normal scripts. These are utility scripts that should be spawned in a normal shell. For example: a script to install dictionary's that can be used by qutebrowser to perform spellchecking.

These scripts should not be confused with userscripts (#1641), which should be spawned _inside_ a qutebrowser window.