### PR TITLE
adobe-flash-plugin: update to 30.0.0.154

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -1,6 +1,6 @@
 # Template file for 'adobe-flash-plugin'
 pkgname=adobe-flash-plugin
-version=30.0.0.134
+version=30.0.0.154
 revision=1
 # The EULA file
 _eula="https://www.adobe.com/content/dam/Adobe/en/legal/licenses-terms/pdf/PlatformClients_PC_WWEULA-en_US-20150407_1357.pdf"
@@ -8,10 +8,10 @@ _eulacksum=2851b4b39df44a2777c6c07e1f59cbc3055a346d2e775121b9ed38e0a4bf40d2
 _url=http://fpdownload.adobe.com/get/flashplayer/pdc/${version}
 if [ "$XBPS_MACHINE" = "x86_64" ]; then
 	_disttarball="${_url}/flash_player_npapi_linux.x86_64.tar.gz"
-	_distcksum=dcd7f22d0891803e347d4ffa017ea9cab590bcc7e5b60309e33b7fe254c9610c
+	_distcksum=04f1323404dd9a9d86807dfee0290877709fea043b9c8483cd653284fc7fd70f
 else
 	_disttarball="${_url}/flash_player_npapi_linux.i386.tar.gz"
-	_distcksum=2cce7fcbca9d742539ae5b5e22953cfcd42d7236770d410b819168e627702c04
+	_distcksum=5d986d67db7a46ac92fbcd62d28ad6744b45039b78b6cdf62397b1544c3c8d66
 fi
 distfiles="${_eula} ${_disttarball}"
 checksum="${_eulacksum} ${_distcksum}"


### PR DESCRIPTION
Makes Adobe Flash installable again now 30.0.0.134 can no longer be downloaded.