### PR TITLE
New package: libbitcoin-explorer

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3401,3 +3401,14 @@ libbelcard.so.1 belcard-1.0.2_1
 libshaderc_shared.so shaderc-2017.2_1
 libglslang.so glslang-6.2.2596_1
 libSPIRV.so glslang-6.2.2596_1
+libsecp256k1.so.0 libsecp256k1-20180813_1
+libbitcoin.so.0 libbitcoin-system-3.5.0_1
+libbitcoin-consensus.so.0 libbitcoin-consensus-3.5.0_1
+libbitcoin-protocol.so.0 libbitcoin-protocol-3.5.0_1
+libbitcoin-client.so.0 libbitcoin-client-3.5.0_1
+libbitcoin-network.so.0 libbitcoin-network-3.5.0_1
+libbitcoin-explorer.so.0 libbitcoin-explorer-3.5.0_1
+libbitcoin-database.so.0 libbitcoin-database-3.5.0_1
+libbitcoin-blockchain.so.0 libbitcoin-blockchain-3.5.0_1
+libbitcoin-node.so.0 libbitcoin-node-3.5.0_1
+libbitcoin-server.so.0 libbitcoin-server-3.5.0_1

--- a/srcpkgs/libbitcoin-blockchain-devel
+++ b/srcpkgs/libbitcoin-blockchain-devel
@@ -1,0 +1,1 @@
+libbitcoin-blockchain

--- a/srcpkgs/libbitcoin-blockchain/template
+++ b/srcpkgs/libbitcoin-blockchain/template
@@ -1,0 +1,49 @@
+# Template file for 'libbitcoin-blockchain'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-blockchain"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Blockchain Library"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-consensus-devel"
+makedepends+=" libbitcoin-database-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" qrencode-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-blockchain"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="03b8362c9172edbeb1e5970c996405cd2738e8274ba459e9b85359d6b838de20"
+build_style="gnu-configure"
+configure_args="--with-gnu-ld"
+shlib_provides="libbitcoin-blockchain.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-blockchain-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-client-devel
+++ b/srcpkgs/libbitcoin-client-devel
@@ -1,0 +1,1 @@
+libbitcoin-client

--- a/srcpkgs/libbitcoin-client/template
+++ b/srcpkgs/libbitcoin-client/template
@@ -1,0 +1,51 @@
+# Template file for 'libbitcoin-client'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-client"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Client Query Library"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-protocol-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" protobuf-devel"
+makedepends+=" qrencode-devel"
+makedepends+=" zeromq-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-client"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="bafa26647f334ecad04fc4bbef507a1954d7e0682f07bd38b90ab66dba5fe0d2"
+build_style="gnu-configure"
+configure_args+=" --with-gnu-ld"
+configure_args+=" --without-examples"
+shlib_provides="libbitcoin-client.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-client-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-consensus-devel
+++ b/srcpkgs/libbitcoin-consensus-devel
@@ -1,0 +1,1 @@
+libbitcoin-consensus

--- a/srcpkgs/libbitcoin-consensus/template
+++ b/srcpkgs/libbitcoin-consensus/template
@@ -1,0 +1,44 @@
+# Template file for 'libbitcoin-consensus'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-consensus"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Consensus Library"
+makedepends+=" boost-devel"
+makedepends+=" libsecp256k1-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-consensus"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="bb29761d4275a9c993151707557008b23572a3d9adecc0e36a3075cfb101dd1e"
+build_style="gnu-configure"
+configure_args+=" --with-gnu-ld"
+configure_args+=" --without-tests"
+shlib_provides="libbitcoin-consensus.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-consensus-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-database-devel
+++ b/srcpkgs/libbitcoin-database-devel
@@ -1,0 +1,1 @@
+libbitcoin-database

--- a/srcpkgs/libbitcoin-database/template
+++ b/srcpkgs/libbitcoin-database/template
@@ -1,0 +1,47 @@
+# Template file for 'libbitcoin-database'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-database"
+version=3.5.0
+revision=1
+short_desc="Bitcoin High Performance Blockchain Database"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" qrencode-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-database"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="376ab5abd8d7734a8b678030b9e997c4b1922e422f6e0a185d7daa3eb251db93"
+build_style="gnu-configure"
+configure_args="--with-gnu-ld"
+shlib_provides="libbitcoin-database.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-database-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-explorer-devel
+++ b/srcpkgs/libbitcoin-explorer-devel
@@ -1,0 +1,1 @@
+libbitcoin-explorer

--- a/srcpkgs/libbitcoin-explorer/template
+++ b/srcpkgs/libbitcoin-explorer/template
@@ -1,0 +1,53 @@
+# Template file for 'libbitcoin-explorer'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-explorer"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Command Line Tool"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-client-devel"
+makedepends+=" libbitcoin-network-devel"
+makedepends+=" libbitcoin-protocol-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" protobuf-devel"
+makedepends+=" qrencode-devel"
+makedepends+=" zeromq-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-explorer"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="630cffd577c0d10345b44ce8160f4604519b0ca69bf201f524f104c207b930aa"
+build_style="gnu-configure"
+configure_args+=" --with-bash-completiondir=/usr/share/bash-completion/completions"
+configure_args+=" --with-gnu-ld"
+shlib_provides="libbitcoin-explorer.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-explorer-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-network-devel
+++ b/srcpkgs/libbitcoin-network-devel
@@ -1,0 +1,1 @@
+libbitcoin-network

--- a/srcpkgs/libbitcoin-network/template
+++ b/srcpkgs/libbitcoin-network/template
@@ -1,0 +1,47 @@
+# Template file for 'libbitcoin-network'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-network"
+version=3.5.0
+revision=1
+short_desc="Bitcoin P2P Network Library"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" qrencode-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-network"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="e065bd95f64ad5d7b0f882e8759f6b0f81a5fb08f7e971d80f3592a1b5aa8db4"
+build_style="gnu-configure"
+configure_args="--with-gnu-ld"
+shlib_provides="libbitcoin-network.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-network-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-node-devel
+++ b/srcpkgs/libbitcoin-node-devel
@@ -1,0 +1,1 @@
+libbitcoin-node

--- a/srcpkgs/libbitcoin-node/template
+++ b/srcpkgs/libbitcoin-node/template
@@ -1,0 +1,52 @@
+# Template file for 'libbitcoin-node'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-node"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Full Node"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-blockchain-devel"
+makedepends+=" libbitcoin-consensus-devel"
+makedepends+=" libbitcoin-database-devel"
+makedepends+=" libbitcoin-network-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" qrencode-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-node"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="e3a0a96155ca93aa6cba75789c18419f40686a69cbd40c77aa77ca84ccc43cab"
+build_style="gnu-configure"
+configure_args+=" --with-bash-completiondir=/usr/share/bash-completion/completions"
+configure_args+=" --with-gnu-ld"
+shlib_provides="libbitcoin-node.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-node-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-protocol-devel
+++ b/srcpkgs/libbitcoin-protocol-devel
@@ -1,0 +1,1 @@
+libbitcoin-protocol

--- a/srcpkgs/libbitcoin-protocol/template
+++ b/srcpkgs/libbitcoin-protocol/template
@@ -1,0 +1,49 @@
+# Template file for 'libbitcoin-protocol'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-protocol"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Blockchain Query Protocol"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" protobuf-devel"
+makedepends+=" qrencode-devel"
+makedepends+=" zeromq-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-protocol"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="9deac6908489e2d59fb9f89c895c49b00e01902d5fdb661f67d4dbe45b22af76"
+build_style="gnu-configure"
+configure_args="--with-gnu-ld"
+shlib_provides="libbitcoin-protocol.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-protocol-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-server-devel
+++ b/srcpkgs/libbitcoin-server-devel
@@ -1,0 +1,1 @@
+libbitcoin-server

--- a/srcpkgs/libbitcoin-server/template
+++ b/srcpkgs/libbitcoin-server/template
@@ -1,0 +1,55 @@
+# Template file for 'libbitcoin-server'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-server"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Full Node and Query Server"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libbitcoin-blockchain-devel"
+makedepends+=" libbitcoin-consensus-devel"
+makedepends+=" libbitcoin-database-devel"
+makedepends+=" libbitcoin-network-devel"
+makedepends+=" libbitcoin-node-devel"
+makedepends+=" libbitcoin-protocol-devel"
+makedepends+=" libbitcoin-system-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" qrencode-devel"
+makedepends+=" zeromq-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin-server"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/$pkgname/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="37ef8d572fb7400565655501ffdea5d07a1de10f3d9fa823d33e2bf68ef8c3ce"
+build_style="gnu-configure"
+configure_args+=" --with-bash-completiondir=/usr/share/bash-completion/completions"
+configure_args+=" --with-gnu-ld"
+shlib_provides="libbitcoin-server.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-server-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libbitcoin-system-devel
+++ b/srcpkgs/libbitcoin-system-devel
@@ -1,0 +1,1 @@
+libbitcoin-system

--- a/srcpkgs/libbitcoin-system/template
+++ b/srcpkgs/libbitcoin-system/template
@@ -1,0 +1,51 @@
+# Template file for 'libbitcoin-system'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libbitcoin-system"
+version=3.5.0
+revision=1
+short_desc="Bitcoin Cross-Platform C++ Development Toolkit"
+makedepends+=" boost-devel"
+makedepends+=" icu-devel"
+makedepends+=" libpng-devel"
+makedepends+=" libsecp256k1-devel"
+makedepends+=" qrencode-devel"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/libbitcoin/libbitcoin"
+license="AGPL-3"
+distfiles="https://codeload.github.com/libbitcoin/${pkgname%-system}/tar.gz/v$version>$pkgname-$version.tar.gz"
+checksum="214d9cd6581330b0e1f6fd8f0c634c46b75ae5515806ecac189f21c0291ae2d9"
+wrksrc="${pkgname%-system}-$version"
+build_style="gnu-configure"
+configure_args+=" --with-gnu-ld"
+configure_args+=" --with-icu"
+configure_args+=" --with-png"
+configure_args+=" --with-qrencode"
+configure_args+=" --without-examples"
+shlib_provides="libbitcoin.so.0"
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libbitcoin-system-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:

--- a/srcpkgs/libsecp256k1-devel
+++ b/srcpkgs/libsecp256k1-devel
@@ -1,0 +1,1 @@
+libsecp256k1

--- a/srcpkgs/libsecp256k1/template
+++ b/srcpkgs/libsecp256k1/template
@@ -1,0 +1,51 @@
+# Template file for 'libsecp256k1'
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+pkgname="libsecp256k1"
+version=20180813
+revision=1
+short_desc="Optimized C library for EC operations on curve secp256k1"
+hostmakedepends+=" autoconf"
+hostmakedepends+=" automake"
+hostmakedepends+=" git"
+hostmakedepends+=" libtool"
+hostmakedepends+=" m4"
+hostmakedepends+=" pkg-config"
+homepage="https://github.com/bitcoin-core/secp256k1"
+license="MIT"
+create_wrksrc="$pkgname-$version"
+build_style="gnu-configure"
+configure_args+=" --disable-benchmark"
+configure_args+=" --disable-coverage"
+configure_args+=" --disable-jni"
+configure_args+=" --disable-openssl-tests"
+configure_args+=" --enable-exhaustive-tests"
+configure_args+=" --enable-module-recovery"
+configure_args+=" --enable-tests"
+configure_args+=" --with-gnu-ld"
+shlib_provides="libsecp256k1.so.0"
+
+do_fetch() {
+	git clone "$homepage" "$wrksrc"
+}
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+	vdoc README.md
+}
+
+libsecp256k1-devel_package() {
+	short_desc+=" - development files"
+	depends="$sourcepkg>=${version}_$revision"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}
+
+# vim: set filetype=sh foldmethod=marker foldlevel=0 nowrap:


### PR DESCRIPTION
As noted on IRC recently, libbitcoin-server and libbitcoin-explorer have shared dependencies. if it's not ok to submit them together, then i can split them up.

Also, I noted the same suspect build issue on every non x86_64 architecture including x86_64-musl, which is that `./configure` fails to find Boost::Chrono.

edit: am splitting this up into two pull requests. partly because the travis build takes too long when it's all thrown together in one PR. partly because libbitcoin-server requires a 64-bit CPU.