### PR TITLE
rubberband: rebuild for gcc stdc++ dropping gcc4 compat

### DIFF
--- a/srcpkgs/rubberband/template
+++ b/srcpkgs/rubberband/template
@@ -1,7 +1,7 @@
 # Template file for 'rubberband'
 pkgname=rubberband
 version=1.8.2
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="ladspa-sdk libsamplerate-devel vamp-plugin-sdk-devel fftw-devel"


### PR DESCRIPTION
sonic-visualiser complained:

> /usr/lib/vamp/vamp-rubberband.so
Unable to open plugin library: /usr/lib/vamp/vamp-rubberband.so: undefined symbol: _ZNK11_VampPlugin4Vamp8RealTime6toTextEb