### PR TITLE
New package endless-sky-gl21

### DIFF
--- a/srcpkgs/endless-sky-gl21-data
+++ b/srcpkgs/endless-sky-gl21-data
@@ -1,0 +1,1 @@
+endless-sky-gl21

--- a/srcpkgs/endless-sky-gl21/patches/paths.patch
+++ b/srcpkgs/endless-sky-gl21/patches/paths.patch
@@ -1,0 +1,20 @@
+--- SConstruct.old	2017-12-06 12:54:20.524502000 -0800
++++ SConstruct	2017-12-12 12:39:21.764384877 -0800
+@@ -18,7 +18,7 @@
+ 	env.Append(LINKFLAGS = ["-static-libstdc++"])
+ 
+ opts = Variables()
+-opts.Add(PathVariable("PREFIX", "Directory to install under", "/usr/local", PathVariable.PathIsDirCreate))
++opts.Add(PathVariable("PREFIX", "Directory to install under", "/usr", PathVariable.PathIsDirCreate))
+ opts.Add(PathVariable("DESTDIR", "Destination root directory", "", PathVariable.PathAccept))
+ opts.Add(EnumVariable("mode", "Compilation mode", "release", allowed_values=("release", "debug", "profile")))
+ opts.Update(env)
+@@ -66,7 +66,7 @@
+ 
+ 
+ # Install the binary:
+-env.Install("$DESTDIR$PREFIX/games", sky)
++env.Install("$DESTDIR$PREFIX/bin", sky)
+ 
+ # Install the desktop file:
+ env.Install("$DESTDIR$PREFIX/share/applications", "endless-sky.desktop")

--- a/srcpkgs/endless-sky-gl21/template
+++ b/srcpkgs/endless-sky-gl21/template
@@ -1,0 +1,25 @@
+# Template file for 'endless-sky-gl21'
+pkgname=endless-sky-gl21
+version=0.9.2.20170822
+revision=1
+_commit=fc707954b0eb61ff2bb6888c5712e6b55d1c2f91
+wrksrc="endless-sky-${_commit}"
+build_style=scons
+hostmakedepends="scons"
+makedepends="SDL2-devel glew-devel libjpeg-turbo-devel libmad-devel libopenal-devel libpng-devel"
+depends="${pkgname}-data"
+conflicts="endless-sky endless-sky-data"
+short_desc="Space exploring, trading, and combat game. opengl21 version"
+maintainer="Benjamín Albiñana <benalb@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/SolraBizna/endless-sky"
+distfiles="https://github.com/SolraBizna/endless-sky/archive/${_commit}.tar.gz"
+checksum=46918d0cc35aaeb1219194099223e3338245aa04aa3f29fd76e3376bf5779376
+
+endless-sky-gl21-data_package() {
+	short_desc+=" - data files"
+	noarch=yes
+	pkg_install() {
+		vmove usr/share/games/endless-sky
+	}
+}


### PR DESCRIPTION
The endless-sky package only works with relative modern hardware, as it depends on opengl3x. There is a fork with support for opengl21. Tested in an old Thinkpad T410. 