### PR TITLE
Add drivers for the Brother MFC-J6720DW printer

### DIFF
--- a/srcpkgs/brother-mfcj6720dw-cupswrapper/INSTALL
+++ b/srcpkgs/brother-mfcj6720dw-cupswrapper/INSTALL
@@ -1,0 +1,8 @@
+case "${ACTION}" in
+post)
+    mkdir -p /usr/share/ppd/cupsfilters
+    /opt/brother/Printers/mfcj6720dw/cupswrapper/cupswrapper.void -i
+    chmod 755 /opt/brother/Printers/mfcj6720dw/cupswrapper
+    ;;
+esac
+

--- a/srcpkgs/brother-mfcj6720dw-cupswrapper/REMOVE
+++ b/srcpkgs/brother-mfcj6720dw-cupswrapper/REMOVE
@@ -1,0 +1,3 @@
+case ${ACTION} in
+    pre) /opt/brother/Printers/mfcj6720dw/cupswrapper/cupswrapper.void -e ;;
+esac

--- a/srcpkgs/brother-mfcj6720dw-cupswrapper/files/43-cups-usb.rules
+++ b/srcpkgs/brother-mfcj6720dw-cupswrapper/files/43-cups-usb.rules
@@ -1,0 +1,21 @@
+# This file is installed by brother-XXXX-cupswrapper
+# To adapt it to you needing make sure you:
+# install usb-utils package
+# launch lsusb and note a line resemblig this one:
+#
+# Bus 004 Device 007: ID 04f9:023e Brother Industries, Ltd
+# Explanation:
+#
+#   Bus xxx Device xxx are the location of the usb port
+#
+#   ID 04f9:xxxx Brother Industries, Ltd
+#
+#   note the xxxx hex number and put it in the field:
+#
+#   ATTR{idProduct}=="023e" at place of 023e (the code for DCP197C)
+#
+# This is needed to make the printer work correctly
+# even if you installed the brother-brsca3 package
+# version date 2014/05/12
+
+ATTR{idVendor}=="04f9", ATTR{idProduct}=="02f4", MODE:="0664", GROUP:="lp", ENV{libsane_matched}:="yes"

--- a/srcpkgs/brother-mfcj6720dw-cupswrapper/files/cupswrapper.void
+++ b/srcpkgs/brother-mfcj6720dw-cupswrapper/files/cupswrapper.void
@@ -1,0 +1,283 @@
+#! /bin/sh
+#
+# Brother Print filter
+# Copyright (C) 2005-2011 Brother. Industries, Ltd.
+
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 2 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# modified for voidlinux by Carlo Dormeletti carlo.dormeletti <at> email.it
+# 2014/04/26 -- first version
+# 2014/08/25 -- adapted to runit
+#
+
+
+printer_model=""mfcj6720dw""
+cups_printer_name=`echo $printer_model | tr '[a-z]' '[A-Z]'`
+device_name=`echo $cups_printer_name | eval sed -e 's/MFC/MFC-/' -e 's/DCP/DCP-/' -e 's/FAX/FAX-/'`
+# pcfilename=`echo $cups_printer_name | tr -d '[A-Z]'`
+device_model="Printers"
+tmp_filter=/var/tmp/brlpdwrapper${printer_model}
+ppd_file_name=/usr/share/ppd/cupsfilters/brother_${printer_model}_printer_en.ppd
+brotherlpdwrapper=/usr/lib/cups/filter/brother_lpdwrapper_${printer_model}
+
+
+if [ "$1" = "-c" ]; then
+  echo "----------  Printer  ----------"
+  echo "printer_model      => " $printer_model
+  echo "cups_printer_name  => " $cups_printer_name
+  echo "device_name        => " $device_name
+  echo "device_model       => " $device_model
+  echo "--------  Filters File  --------"
+  echo "tmp_filter    => " $tmp_filter
+  echo "ppd_file_name => " $ppd_file_name
+
+  exit 0
+fi
+
+
+
+if [ "$1" = '-e' ]; then
+  lpadmin -x ${cups_printer_name}
+  rm -f $ppd_file_name
+  rm -f $brotherlpdwrapper
+
+  sv restart cups
+  exit 0
+fi
+
+if [ "$1" = "-r" ]; then
+  lpadmin -x ${cups_printer_name}
+
+  sv restart cups
+  exit 0
+fi
+
+
+if [ "$1" = "help" ] || [ "$1" = "-h" ]; then
+  echo   'option -h : help'
+  echo   '       -i : install'
+  echo   '       -e : uninstall'
+  echo   '       -r : remove printer'
+  echo   '       -c : check variables'
+  exit 0
+fi
+
+if [ -e "/opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
+  :
+else
+  echo "ERROR : Brother LPD filter is not installed."
+  echo "ERROR : please install it."
+fi
+
+
+cp "/opt/brother/${device_model}/${printer_model}/cupswrapper/brother_${printer_model}_printer_en.ppd" $ppd_file_name
+chmod 644 $ppd_file_name
+
+#
+#	create temporary CUPS Filter
+#
+
+cat <<!ENDOFWFILTER! >$tmp_filter
+#! /bin/sh
+#
+# Brother Print filter  >>
+# Copyright (C) 2005-2011 Brother. Industries, Ltd.
+#                                    Ver1.10
+
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 2 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+# Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# modified for voidlinux by Carlo Dormeletti carlo.dormeletti <at> email.it
+# modify date 201/04/26
+#
+
+LOGFILE="/dev/null"
+LOGLEVEL="1"
+LOGCLEVEL="7"
+DEBUG=0
+NUPENABLE=1
+LOG_LATESTONLY=1
+errorcode=0
+
+if [ \$DEBUG != 0 ]; then
+  LOGFILE=/tmp/br_cupsfilter_debug_log
+fi
+
+PPDC=\`printenv | grep "PPD="\`
+PPDC=\`echo \$PPDC | sed -e 's/PPD=//'\`
+
+if [ "\$PPDC" = "" ]; then
+  PPDC=$ppd_file_name
+fi
+
+
+if [ \$LOGFILE != "/dev/null" ]; then
+  if [ \$LOG_LATESTONLY == "1" ]; then
+    rm -f \$LOGFILE
+    date  >\$LOGFILE
+  else
+    if [ -e \$LOGFILE ]; then
+	    date >>\$LOGFILE
+    else
+	    date >\$LOGFILE
+    fi
+  fi
+    echo "arg0 = \$0"        >>\$LOGFILE
+    echo "arg1 = \$1"        >>\$LOGFILE
+    echo "arg2 = \$2"        >>\$LOGFILE
+    echo "arg3 = \$3"        >>\$LOGFILE
+    echo "arg4 = \$4"        >>\$LOGFILE
+    echo "arg5 = \$5"        >>\$LOGFILE
+    echo "arg6 = \$6"        >>\$LOGFILE
+    echo "PPD  = \$PPD"      >>\$LOGFILE
+fi
+
+INPUT_TEMP_PS=\`mktemp /tmp/br_input_ps.XXXXXX\`
+
+nup="cat"
+if [ "`echo \$5 | grep 'Nup='`" != '' ] && [ \$NUPENABLE != 0 ]; then
+
+  if   [ "`echo \$5 | grep 'Nup=64'`" != '' ]; then
+    nup="psnup -64"
+  elif [ "`echo \$5 | grep 'Nup=32'`" != '' ]; then
+    nup="psnup -32"
+  elif [ "`echo \$5 | grep 'Nup=25'`" != '' ]; then
+    nup="psnup -25"
+  elif [ "`echo \$5 | grep 'Nup=16'`" != '' ]; then
+    nup="psnup -16"
+  elif [ "`echo \$5 | grep 'Nup=8'`" != '' ]; then
+    nup="psnup -8"
+  elif [ "`echo \$5 | grep 'Nup=6'`" != '' ]; then
+    nup="psnup -6"
+  elif [ "`echo \$5 | grep 'Nup=4'`" != '' ]; then
+    nup="psnup -4"
+  elif [ "`echo \$5 | grep 'Nup=2'`" != '' ]; then
+    nup="psnup -2"
+  elif [ "`echo \$5 | grep 'Nup=1'`" != '' ]; then
+    nup="cat"
+  fi
+  echo   "NUP=\$nup"         >>\$LOGFILE
+  if [ -e /usr/bin/psnup ]; then
+    if [ \$# -ge 7 ]; then
+      cat \$6  | \$nup > \$INPUT_TEMP_PS
+    else
+      cat       | \$nup > \$INPUT_TEMP_PS
+    fi
+  else
+    if [ \$# -ge 7 ]; then
+      cp \$6  \$INPUT_TEMP_PS
+    else
+      cat    > \$INPUT_TEMP_PS
+    fi
+  fi
+else
+  if [ \$# -ge 7 ]; then
+    cp \$6  \$INPUT_TEMP_PS
+  else
+    cat    > \$INPUT_TEMP_PS
+  fi
+fi
+
+if [ -e "/opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
+  :
+else
+  echo "ERROR: /opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model} does not exist"   >>\$LOGFILE
+  errorcode=30
+  exit
+fi
+
+CUPSOPTION=\`echo "\$5 Copies=\$4" | sed -e 's/BrMirror=OFF/MirrorPrint=OFF/' -e 's/BrMirror=ON/MirrorPrint=ON/' -e 's/BrChain/Chain/' -e 's/BrBrightness/Brightness/' -e 's/BrContrast/Contrast/' -e 's/BrHalfCut/HalfCut/' -e 's/BrAutoTapeCut/AutoCut/' -e 's/BrHalftonePattern/Halftone/' -e 's/Binary/Binary/' -e 's/Dither/Dither/' -e 's/ErrorDiffusion/ErrorDiffusion/' -e 's/PageSize/media/' -e 's/BrSheets/Sheets/' -e 's/multiple-document-handling/Collate/' -e 's/separate-documents-collated-copies/ON/' -e 's/separate-documents-uncollated-copies/OFF/'\`
+
+if [ -e "/opt/brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1" ]; then
+  if [ \$DEBUG = 0 ]; then
+     /opt/brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${cups_printer_name}  \$PPDC 0 "\$CUPSOPTION" "${printer_model}">> /dev/null
+  else
+     /opt/brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${cups_printer_name}  \$PPDC \$LOGCLEVEL "\$CUPSOPTION" "${printer_model}">>\$LOGFILE
+  fi
+fi
+
+if [ \$DEBUG -lt 10 ]; then
+  cat    \$INPUT_TEMP_PS | /opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model} "\$\$" "CUPS" "USB"
+
+  if [ \$LOGLEVEL -gt 2 ];  then
+    if [ \$LOGFILE != "/dev/null" ]; then
+      echo ""                                  >>\$LOGFILE
+      echo "    ------PostScript Data-------"  >>\$LOGFILE
+      cat    \$INPUT_TEMP_PS                   >>\$LOGFILE
+    fi
+  fi
+fi
+
+rm -f  \$INPUT_TEMP_PS
+
+exit $errorcode
+
+!ENDOFWFILTER!
+
+chmod 755 $tmp_filter
+
+#
+# check brotherlpdwrapper in /usr/lib/cups/filter
+#
+
+if [ -d /usr/lib/cups/filter ]; then
+  rm -f  $brotherlpdwrapper
+  cp $tmp_filter $brotherlpdwrapper
+fi
+
+#
+#  remove temporary script file
+#
+
+rm -f  $tmp_filter
+
+chmod a+w /opt/brother/${device_model}/${printer_model}/inf/br${printer_model}rc
+chmod a+w /opt/brother/${device_model}/${printer_model}/inf
+
+sleep 2s
+
+sv restart cups
+
+port2=`lpinfo -v | grep -i 'usb://Brother/${device_name}' | head -1`
+
+if [ "$port2" = '' ];then
+  port2=`lpinfo -v | grep 'usb://Brother' | head -1`
+fi
+
+if [ "$port2" = '' ];then
+  port2=`lpinfo -v | grep 'usb://' | head -1`
+fi
+
+port=`echo $port2| sed s/direct//g`
+
+if [ "$port" = '' ];then
+  port=usb:/dev/usb/lp0
+fi
+
+lpadmin -p ${cups_printer_name} -E -v $port -P $ppd_file_name
+
+exit 0
+

--- a/srcpkgs/brother-mfcj6720dw-cupswrapper/template
+++ b/srcpkgs/brother-mfcj6720dw-cupswrapper/template
@@ -1,0 +1,25 @@
+pkgname=brother-mfcj6720dw-cupswrapper
+version=3.0.0
+revision=1
+maintainer="Sasha <sasha+develATmarvidDOTfr>"
+homepage="http://support.brother.com/g/b/index.aspx"
+license="GPL-2"
+short_desc="CUPS wrapper driver for the brother MFC-J6720DW printer/scanner"
+distfiles="http://download.brother.com/welcome/dlf100966/mfcj6720dwcupswrapper-${version}-1.i386.deb"
+checksum="ff7895c56b66526f30d288954b282178584ff3eb6d18397548d983c5b6cf3f58"
+only_for_archs="i686 x86_64"
+depends="brother-mfcj6720dw-lpr cups"
+create_wrksrc=yes
+nopie=yes
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/mfcj6720dwcupswrapper-${version}-1.i386.deb
+}
+
+do_install() {
+	mkdir -p ${DESTDIR}
+	tar xzpvf data.tar.gz -C ${DESTDIR}
+	rm ${DESTDIR}/opt/brother/Printers/mfcj6720dw/cupswrapper/cupswrappermfcj6720dw
+	vinstall ${FILESDIR}/cupswrapper.void 755 /opt/brother/Printers/mfcj6720dw/cupswrapper/
+	vinstall ${FILESDIR}/43-cups-usb.rules 644 /usr/lib/udev/rules.d/
+}

--- a/srcpkgs/brother-mfcj6720dw-cupswrapper/template
+++ b/srcpkgs/brother-mfcj6720dw-cupswrapper/template
@@ -1,7 +1,7 @@
 pkgname=brother-mfcj6720dw-cupswrapper
 version=3.0.0
 revision=1
-maintainer="Sasha <sasha+develATmarvidDOTfr>"
+maintainer="Sasha <sasha+devel@marvid.fr>"
 homepage="http://support.brother.com/g/b/index.aspx"
 license="GPL-2"
 short_desc="CUPS wrapper driver for the brother MFC-J6720DW printer/scanner"

--- a/srcpkgs/brother-mfcj6720dw-lpr/INSTALL
+++ b/srcpkgs/brother-mfcj6720dw-lpr/INSTALL
@@ -1,0 +1,6 @@
+case "${ACTION}" in
+    post)
+        mkdir -p /var/spool/lpd
+        /opt/brother/Printers/mfcj6720dw/inf/setupPrintcapij mfcj6720dw -i
+    ;;
+esac

--- a/srcpkgs/brother-mfcj6720dw-lpr/template
+++ b/srcpkgs/brother-mfcj6720dw-lpr/template
@@ -1,0 +1,27 @@
+pkgname=brother-mfcj6720dw-lpr
+version=3.0.0
+revision=1
+maintainer="Sasha <sasha+develATmarvidDOTfr>"
+homepage="http://support.brother.com/g/b/index.aspx"
+license="GPL-2"
+short_desc="LPR driver for the brother MFC-J6720DW printer/scanner"
+distfiles="http://download.brother.com/welcome/dlf100964/mfcj6720dwlpr-${version}-1.i386.deb"
+checksum="3933dfe9f41f81199f487f7d76ba18625666ba1adac6e2672c8a7bbac8d14e6f"
+only_for_archs="i686 x86_64"
+create_wrksrc=yes
+depends="a2ps ghostscript"
+mutable_files="/opt/brother/Printers/mfcj6720pw/inf/brmfcj6720pwrc"
+nopie=yes
+
+if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
+	depends+=" glibc-32bit"
+fi
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/mfcj6720dwlpr-${version}-1.i386.deb
+}
+
+do_install() {
+	mkdir -p ${DESTDIR}
+	tar xzpvf data.tar.gz -C ${DESTDIR}
+}

--- a/srcpkgs/brother-mfcj6720dw-lpr/template
+++ b/srcpkgs/brother-mfcj6720dw-lpr/template
@@ -1,7 +1,7 @@
 pkgname=brother-mfcj6720dw-lpr
 version=3.0.0
 revision=1
-maintainer="Sasha <sasha+develATmarvidDOTfr>"
+maintainer="Sasha <sasha+devel@marvid.fr>"
 homepage="http://support.brother.com/g/b/index.aspx"
 license="GPL-2"
 short_desc="LPR driver for the brother MFC-J6720DW printer/scanner"


### PR DESCRIPTION
I basically copied the package for the Brother DCP-197C, changing the printer name here and there except a few minor things.

I notice I had to create a 'lp' user account because the script provided by brother (in the archive extracted, not in this PR unfortunately)  expects it to exist. Should we add a statement to create it somewhere in the INSTALL files here ? It seems more related to printing in general and not to these brother drivers : I don't really know what this user is for (what process is expected to run as it, what files should it own, etc.) but apparently cups doesn't really need it since it was running without it on my system, so maybe the best fix would be to remove the `chown` statement with a `sed` in the package template, or in the worst case to create this user in the cups package.