### PR TITLE
rpi-kernel: update to 4.14.62.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="52d350fb107dbd9fa30d44685ed52d2c52b09d96"
+_githash="1f89ad77bf9b204c18fb6fdd167b4ee92d064f95"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.61
+version=4.14.62
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=b339528dc4b0156ebc0613262a415169ddaf6143e5a9971414f1224a075dbc15
+checksum=153deef35bf1895fb0825395c0f9fb61832dcf0131987fce99449beb17afa173
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]