### PR TITLE
common/update-check.sh: fix github update-check

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -47,7 +47,7 @@ update_check() {
             *github.com*)
                 githubname="$(printf %s "$url" | cut -d/ -f4,5)"
                 url="https://github.com/$githubname/tags"
-                rx='/archive/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")';;
+                rx='">(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=</li>)';;
             *gitlab.com*|*gitlab.gnome.org*)
                 gitlaburl="$(printf %s "$url" | cut -d/ -f1-5)"
                 url="$gitlaburl/tags"


### PR DESCRIPTION
The result of `curl -Lsk *github.com*/tags` has vastly changed lately and therefore our old update check is completely broken.
```
curl -Lsk https://github.com/telegramdesktop/tdesktop/tags
  <li role="option" class="autocomplete-item">v1.3.12</li>
  <li role="option" class="autocomplete-item">v1.3.11</li>
  <li role="option" class="autocomplete-item">v1.3.10</li>
  <li role="option" class="autocomplete-item">v1.3.9</li>
  <li role="option" class="autocomplete-item">v1.3.8</li>
  <li role="option" class="autocomplete-item">v1.3.7</li>
  <li role="option" class="autocomplete-item">v1.3.6</li>
  <li role="option" class="autocomplete-item">v1.3.5</li>
  <li role="option" class="autocomplete-item">v1.3.4</li>
```