### PR TITLE
kdenlive: update to 18.08.0.

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,6 +1,6 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
-version=18.04.3
+version=18.08.0
 revision=1
 build_style=cmake
 hostmakedepends="
@@ -15,7 +15,7 @@ maintainer="johannes <johannes.brechtmann@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://kdenlive.org"
 distfiles="${KDE_SITE}/applications/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=9505ac2e5f4918932b868f0ccc1d74b1ae545283033081fab92415cc0d1d435f
+checksum=43247d070e6898c26271235b915b45422ee8668e512f38f6df711e5571dca019
 
 # needed for mlt to work on musl
 CXXFLAGS="-DHAVE_LOCALE_H=1"


### PR DESCRIPTION
[ci skip] because too much output from compiler warnings for travis