### PR TITLE
[ci skip] linux4.18: update to 4.18.2.

### DIFF
--- a/srcpkgs/linux4.18/template
+++ b/srcpkgs/linux4.18/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.18'
 pkgname=linux4.18
-version=4.18.1
+version=4.18.2
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ maintainer="cr6git <quark6@protonmail.com>"
 license="GPL-2.0-only"
 homepage="https://www.kernel.org"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz"
-checksum=725fadc6e9d5a1ad6d7269bb75b256bccac5372927995ad0408c059d110cfa42
+checksum=d56082dd9d895c32ab5d898096abb3e7f5525bb0a603e5c3be9f83921484eda5
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes


### PR DESCRIPTION
https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.18.2
````
commit f47e3431b15ae9cae8acc0fdf20fc083422c9f61
Author: Mark Salyzyn <salyzyn@android.com>
Date:   Tue Jul 31 15:02:13 2018 -0700

    Bluetooth: hidp: buffer overflow in hidp_process_report
    
    commit 7992c18810e568b95c869b227137a2215702a805 upstream.
    
    CVE-2018-9363
    
    The buffer length is unsigned at all layers, but gets cast to int and
    checked in hidp_process_report and can lead to a buffer overflow.
    Switch len parameter to unsigned int to resolve issue.
    
    This affects 3.18 and newer kernels.
````