### PR TITLE
elogind: split libraries into libelogind.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2830,7 +2830,7 @@ libsidplayfp.so.4 libsidplayfp-1.8.7_1
 libstilview.so.0 libsidplayfp-1.8.7_1
 libczmq.so.4 czmq-4.0.1_1
 liblz.so.1 lzlib-1.8_1
-libelogind.so.0 elogind-219.12_1
+libelogind.so.0 libelogind-238.1_2
 libnma.so.0 libnm-gtk-1.4.0_1
 libgspell-1.so.2 gspell-1.8.0_1
 libotf.so.1 libotf-0.9.16_1

--- a/srcpkgs/cinnamon-session/template
+++ b/srcpkgs/cinnamon-session/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon-session'
 pkgname=cinnamon-session
 version=3.8.2
-revision=1
+revision=2
 short_desc="The Cinnamon session handler"
 build_style=meson
 hostmakedepends="pkg-config gobject-introspection

--- a/srcpkgs/cinnamon-settings-daemon/template
+++ b/srcpkgs/cinnamon-settings-daemon/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon-settings-daemon'
 pkgname=cinnamon-settings-daemon
 version=3.8.4
-revision=1
+revision=2
 short_desc="The Cinnamon Settings Daemon"
 build_style=gnu-configure
 configure_args=" --disable-static --disable-schemas-compile --disable-gconf"

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,7 +1,7 @@
 # Template file for 'elogind'
 pkgname=elogind
 version=238.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
  -Drootlibexecdir=/usr/libexec/elogind -Dreboot-path=/usr/bin/reboot
@@ -49,12 +49,19 @@ post_install() {
 }
 
 elogind-devel_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="libelogind-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
 		vmove usr/share/man/man3
 		vmove usr/lib/pkgconfig
+	}
+}
+
+libelogind_package() {
+	short_desc+=" - elogind library"
+	pkg_install() {
+		 vmove "usr/lib/libelogind.so.*"
 	}
 }

--- a/srcpkgs/gdm/template
+++ b/srcpkgs/gdm/template
@@ -1,7 +1,7 @@
 # Template file for 'gdm'
 pkgname=gdm
 version=3.28.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection)
  --disable-schemas-compile --disable-static --with-default-pam-config=arch

--- a/srcpkgs/gnome-session/template
+++ b/srcpkgs/gnome-session/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-session'
 pkgname=gnome-session
 version=3.28.1
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="glib-devel intltool pkg-config xmlto"
 configure_args="-Dsystemd_journal=false"

--- a/srcpkgs/libelogind
+++ b/srcpkgs/libelogind
@@ -1,0 +1,1 @@
+elogind

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=3.28.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-static --enable-egl-device"
 hostmakedepends="glib-devel gobject-introspection pkg-config zenity"

--- a/srcpkgs/polkit-elogind/template
+++ b/srcpkgs/polkit-elogind/template
@@ -1,7 +1,7 @@
 # Template file for 'polkit-elogind'
 pkgname=polkit-elogind
 version=0.115
-revision=1
+revision=2
 wrksrc="polkit-${version}"
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection) --disable-static

--- a/srcpkgs/sysprof/template
+++ b/srcpkgs/sysprof/template
@@ -1,7 +1,7 @@
 # Template file for 'sysprof'
 pkgname=sysprof
 version=3.28.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config itstool glib-devel"
 makedepends="gtk+3-devel polkit-devel glib-devel elogind-devel"
@@ -9,14 +9,16 @@ short_desc="A system-wide profiler for Linux"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://sysprof.com/"
-distfiles="https://download.gnome.org/sources/sysprof/${version%.*}/$pkgname-$version.tar.xz"
+distfiles="https://download.gnome.org/sources/sysprof/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=65437778af2fc3bab05bf9c1871fbd8726a4bd6471f1288d7b7a7e3429cee436
 configure_args="-Denable-gtk=true -Dsystemdunitdir=/DELETEME"
+
 case "$XBPS_TARGET_MACHINE" in
-  x64_64-musl|aarch64-musl) CFLAGS="-D__WORDSIZE=64" ;;
-  *-musl) CFLAGS="-D__WORDSIZE=32" ;;
+	x64_64-musl|aarch64-musl) CFLAGS="-D__WORDSIZE=64" ;;
+	*-musl) CFLAGS="-D__WORDSIZE=32" ;;
 esac
-CFLAGS+=" -Wno-error -Wno-error=undef"
+
+CFLAGS=" -Wno-error -Wno-error=undef"
 
 pre_build() {
 	export SHELL=/bin/bash
@@ -33,6 +35,5 @@ sysprof-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"
-		vmove usr/share
 	}
 }


### PR DESCRIPTION
This allows projects that use only sd-event or sd-bus (like Mako, Sway) to use only libelogind instead of the whole stack, the side-effect is that users of the entire stack must explicitly depend on elogind

Building 

- [x] cinnamon-session
- [x] cinnamon-settings-daemon
- [x] gdm
- [x] gnome-session
- [x] mutter
- [x] polkit-elogind
- [x] sysprof

Working

- [ ] cinnamon-session
- [ ] cinnamon-settings-daemon
- [x] gdm
- [x] gnome-session
- [x] mutter
- [x] polkit-elogind
- [x] sysprof

Idea taken from this:
https://forum.voidlinux.org/t/solved-new-packages-that-depend-on-sd-bus-how-to-deal-with-them/6511/7