### PR TITLE
nvidia: for i686, remove nvidia-uvm from dkms.conf

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux (long-lived series)"
 
 pkgname=nvidia
 version=390.77
-revision=1
+revision=2
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Proprietary NVIDIA license"
 homepage="http://www.nvidia.com"
@@ -236,6 +236,14 @@ do_install() {
 	sed -e "s/__PKGVER/${version}/g" \
 		-e "s/__MAKEJOBS/-j$(nproc)/g" \
 		-i ${DESTDIR}/usr/src/nvidia-${version}/dkms.conf
+	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+		# nvidia no longer builds "uvm" submodule for 32-bit
+		# Remove 2 lines for "nvidia-uvm" and repair consecutive enumeration following.
+		sed -e '/nvidia-uvm/,+1d' \
+ 			-e 's/\[2\]/[1]/g' \
+ 			-e 's/\[3\]/[2]/g' \
+ 			-i ${DESTDIR}/usr/src/nvidia-${version}/dkms.conf
+	fi
 
 	# Blacklist nouveau
 	vmkdir usr/lib/modprobe.d


### PR DESCRIPTION
Modifies dkms.conf during install for i686 ONLY. Removes reference to "nvidia-uvm", which nvidia currently does not provide in 32-bit installations. This makes nvidia-dkms functional again on 1686, and fixes issue #1108.