### PR TITLE
quassel-shared: remove obsolete symlink

### DIFF
--- a/srcpkgs/quassel-shared
+++ b/srcpkgs/quassel-shared
@@ -1,1 +1,0 @@
-quassel


### PR DESCRIPTION
f7cf133a4511b4902b4153fffddfc7eb8bd248e8 missed the removal of the symlink
see: https://github.com/void-linux/void-packages/issues/836