### PR TITLE
encfs: update to 1.9.5

### DIFF
--- a/srcpkgs/encfs/template
+++ b/srcpkgs/encfs/template
@@ -1,17 +1,22 @@
 # Template file for 'encfs'
 pkgname=encfs
-version=1.9.1
-revision=4
+version=1.9.5
+revision=1
 build_style=cmake
 hostmakedepends="pkg-config perl"
 makedepends="fuse-devel libressl-devel gettext-devel"
 depends="perl" # for encfssh
 short_desc="Encrypted filesystem in user-space"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-2.0-or-later, LGPL-3.0-or-later"
 homepage="http://www.arg0.net/encfs"
 distfiles="https://github.com/vgough/encfs/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=67203aeff7a06ce7be83df4948db296be89a00cffe1108a0a41c96d7481106a4
+checksum=4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63
+
+# Can't run test programs when cross compiling
+if [ "$CROSS_BUILD" ]; then
+	configure_args="-DBUILD_UNIT_TESTS=0"
+fi
 
 post_install() {
 	chmod +x ${DESTDIR}/usr/bin/encfssh


### PR DESCRIPTION
Updates EncFS to [v1.9.5](https://github.com/vgough/encfs/releases). Works fine for me locally.