### PR TITLE
octave: update to 4.4.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3353,9 +3353,6 @@ libgeos-3.6.2.so geos-3.6.2_1
 libgeos_c.so.1 geos-3.6.2_1
 libspatialindex.so.4 libspatialindex-1.8.5_1
 libspatialindex_c.so.4 libspatialindex-1.8.5_1
-liboctave.so.5 octave-4.4.0_1
-liboctinterp.so.5 octave-4.4.0_1
-liboctgui.so.3 octave-4.4.0_1
 libpapi.so.5 papi-5.6.0_1
 libpfm.so.4 papi-5.6.0_1
 libfifechan.so.0.1.4 fifechan-0.1.4_1

--- a/srcpkgs/octave/template
+++ b/srcpkgs/octave/template
@@ -1,10 +1,9 @@
 # Template file for 'octave'
 pkgname=octave
-version=4.4.0
+version=4.4.1
 revision=4
 build_style=gnu-configure
-configure_args=" --with-blas=openblas --with-lapack=openblas
- $(vopt_if largearrays --enable-64)"
+configure_args=" --with-blas=openblas --with-lapack=openblas"
 hostmakedepends="perl gcc-fortran pkg-config gnuplot"
 makedepends="pcre-devel openblas-devel readline-devel libSM-devel libltdl-devel
  lcms2-devel glpk-devel"
@@ -14,7 +13,7 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
 homepage="https://gnu.org/software/octave/"
 distfiles="${GNU_SITE}/octave/octave-${version}.tar.gz"
-checksum=72f846379fcec7e813d46adcbacd069d72c4f4d8f6003bcd92c3513aafcd6e96
+checksum=09fbd0f212f4ef21e53f1d9c41cf30ce3d7f9450fb44911601e21ed64c67ae97
 
 # Package build options
 # TODO: some options are still missing, such as
@@ -28,7 +27,6 @@ build_options="
 	gui
 	hdf5
 	imagemagick
-	largearrays
 	opengl
 	openmp
 	qhull
@@ -45,7 +43,6 @@ desc_option_gui="Graphical User Interface."
 desc_option_graphicsmagick="Provides 'imread' and 'imwrite' functions."
 desc_option_hdf5="Support for HDF data files."
 desc_option_imagemagick="Provides 'imread' and 'imwrite' functions."
-desc_option_largearrays="Enable large array (64bit pointers)." #req. 64bit BLAS
 desc_option_qhull="Provides 'convhull{,n}', 'delaunay{,n}' and 'voronoi{,n}' functions."
 desc_option_openmp="Enable support for OpenMP SMP multi-threading"
 desc_option_zlib="Support for compressed data."


### PR DESCRIPTION
- remove build option `largearrays` as 64bit is default already
  on 64bit systems.
- remove entries from common/shlibs because nothing uses them.