### PR TITLE
build-style/perl-ModuleBuild.sh: fix cross

### DIFF
--- a/common/build-style/perl-ModuleBuild.sh
+++ b/common/build-style/perl-ModuleBuild.sh
@@ -8,10 +8,21 @@
 #
 do_configure() {
 	if [ -f Build.PL ]; then
+		# When cross compiling Module::Build reads in the build flags from the host perl, not the target:
+		# extract the target specific flags (the ones also set in perl’s template) from
+		# the target perl configuration and use them to override Module::Build’s default
+		_conf="${XBPS_CROSS_BASE}/usr/lib/perl5/core_perl/Config_heavy.pl"
+		_optimize=$(sed -n "s;^optimize='\(.*\)';\1;p" $_conf)
+		_ccflags=$(sed -n "s;^ccflags='\(.*\)';\1;p" $_conf)
+		_lddlflags=$(sed -n "s;^lddlflags='\(.*\)';\1;p" $_conf)
+		_ldflags=$(sed -n "s;^ldflags='\(.*\)';\1;p" $_conf)
+
 		PERL_MM_USE_DEFAULT=1 PERL_MM_OPT="INSTALLDIRS=vendor DESTDIR='$DESTDIR'" \
 			PERL_MB_OPT="--installdirs vendor --destdir '$DESTDIR'" \
 			LD="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \
-			perl Build.PL ${configure_args} INSTALLDIRS=vendor
+			perl Build.PL --config optimize="$_optimize" --config ccflags="$_ccflags" \
+			--config lddlflags="$_lddlflags" --config ldflags="$_ldflags" \
+			${configure_args} INSTALLDIRS=vendor
 	else
 		msg_error "$pkgver: cannot find Build.PL for perl module!\n"
 	fi

--- a/srcpkgs/perl-Params-Classify/template
+++ b/srcpkgs/perl-Params-Classify/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Params-Classify'
 pkgname=perl-Params-Classify
 version=0.015
-revision=1
+revision=2
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-ModuleBuild
 hostmakedepends="perl perl-Module-Build"
@@ -11,6 +11,6 @@ depends="perl"
 short_desc="Argument type classification"
 maintainer="John Regan <john@jrjrtech.com>"
 homepage="https://metacpan.org/release/Params-Classify"
-license="Artistic"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 distfiles="${CPAN_SITE}/Params/${pkgname/perl-/}-${version}.tar.gz"
 checksum=398ec15cd899fcd8bef3db9ea1748bf631f15f6c32be203e475b67df510a5914

--- a/srcpkgs/perl-Params-Validate/template
+++ b/srcpkgs/perl-Params-Validate/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Params-Validate'
 pkgname=perl-Params-Validate
 version=1.29
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-ModuleBuild
 hostmakedepends="perl perl-Module-Build"
@@ -10,6 +10,6 @@ depends="perl perl-Module-Implementation"
 short_desc="Validate method/function parameters"
 maintainer="John Regan <john@jrjrtech.com>"
 homepage="https://metacpan.org/release/Params-Validate"
-license="Artistic"
+license="Artistic-2.0"
 distfiles="${CPAN_SITE}/Params/${pkgname/perl-/}-${version}.tar.gz"
 checksum=49a68dfb430bea028042479111d19068e08095e5a467e320b7ab7bde3d729733


### PR DESCRIPTION
The build-style perl-ModuleBuild doesn’t work when cross-compiling and the package isn’t `noarch=yes`, because Module::Build uses the `{C,LD}FLAGS` of the host read in from the host perl’s `Config.pm`. This modification overrides this and makes it use the right ones for the target.

However, only two packages are affected: perl-Params-Classify and perl-Params-Validate. Their cross versions are broken and only contain `/usr/share` while the native ones also have `/usr/lib`.