### PR TITLE
marvin: update to 18.20.0

### DIFF
--- a/srcpkgs/marvin/template
+++ b/srcpkgs/marvin/template
@@ -1,6 +1,6 @@
 # Template for Marvin
 pkgname=marvin
-version=18.19.0
+version=18.20.0
 revision=1
 noarch=yes
 maintainer="Brenton Horne <brentonhorne77@gmail.com>"
@@ -14,7 +14,7 @@ restricted=yes
 nostrip=yes
 _filename="marvin_linux_${version%.*}.deb"
 distfiles="https://dl.chemaxon.com/marvin/${version}/${_filename}"
-checksum=f498405166821e6f2f8e75b1357c10fca9b1834cca5ca14d56c7921ed4fb5bcf
+checksum=bbb25cbd8307f1f081136397c9f82be114426b96f973b8079980c46e6d62aadc
 
 do_extract() {
 	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_filename}


### PR DESCRIPTION
Hi,

As per title, just bumping Marvin to 18.20.0. I installed this bumped package and it's working as expected, so everything seems fine.

Thanks for your time,
Brenton