### PR TITLE
odroid-c2-uboot: set up timer like Hardkernel does

### DIFF
--- a/srcpkgs/odroid-c2-uboot/files/boot.ini
+++ b/srcpkgs/odroid-c2-uboot/files/boot.ini
@@ -81,5 +81,9 @@ load mmc 0:1 ${loadaddr} /boot/Image
 load mmc 0:1 ${dtb_loadaddr} /boot/dtbs/meson64_odroidc2.dtb
 #load mmc 0:1 ${initrd_loadaddr} /boot/initramfs-linux.img
 
+# Meson Timer
+fdt addr ${dtb_loadaddr}
+fdt rm /timer
+
 #booti ${loadaddr} ${initrd_loadaddr}:${filesize} ${dtb_loadaddr}
 booti ${loadaddr} - ${dtb_loadaddr}

--- a/srcpkgs/odroid-c2-uboot/template
+++ b/srcpkgs/odroid-c2-uboot/template
@@ -1,7 +1,7 @@
 # Template file for 'odroid-c2-uboot'
 pkgname=odroid-c2-uboot
 version=v2015.01
-revision=2
+revision=3
 _githash=f416a769454b89c39d5b217d28bd3c9f5d1594df
 wrksrc="u-boot-${_githash}"
 only_for_archs="aarch64 aarch64-musl"


### PR DESCRIPTION
Executing `sleep 1` on my ODROID-C2 with Void Linux takes around one minute. The underlying problem with timekeeping causes a slew of other issues, of course.

[Hardkernel's `boot.ini`](https://github.com/mdrjr/c2_bootini/blob/master/boot.ini) takes one of two possible courses of action (depending on the value of `mesontimer`) but either of them fixes my problem. My proposed change is to just do the same thing that the official Ubuntu image does by default.