### PR TITLE
[DO NOT MERGE] New package: dmenu2-0.2

### DIFF
--- a/srcpkgs/dmenu2/files/config.h
+++ b/srcpkgs/dmenu2/files/config.h
@@ -1,0 +1,23 @@
+/* See LICENSE file for copyright and license details. */
+/* Default settings; can be overriden by command line. */
+
+static int topbar = 1;                      /* -b  option; if 0, dmenu appears at bottom     */
+/* -fn option overrides fonts[0]; default X11 font or font set */
+static const char *fonts[] = {
+	"monospace:size=10"
+};
+static const char *prompt      = NULL;      /* -p  option; prompt to the left of input field */
+static const char *colors[SchemeLast][2] = {
+	/*     fg         bg       */
+	[SchemeNorm] = { "#bbbbbb", "#222222" },
+	[SchemeSel] = { "#eeeeee", "#005577" },
+	[SchemeOut] = { "#000000", "#00ffff" },
+};
+/* -l option; if nonzero, dmenu uses vertical list with given number of lines */
+static unsigned int lines      = 0;
+
+/*
+ * Characters not considered part of a word while deleting words
+ * for example: " /?\"&[]"
+ */
+static const char worddelimiters[] = " ";

--- a/srcpkgs/dmenu2/files/fuzzymatch.patch
+++ b/srcpkgs/dmenu2/files/fuzzymatch.patch
@@ -1,0 +1,147 @@
+From 34e4ada60c7ca73cfdd83a02c7416af39dfc0dc0 Mon Sep 17 00:00:00 2001
+From: Andrea Brancaleoni <miwaxe@gmail.com>
+Date: Tue, 10 Nov 2015 19:29:45 +0100
+Subject: [PATCH] fuzzymatch-4.6
+
+---
+ dmenu.c | 89 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 85 insertions(+), 4 deletions(-)
+
+diff --git a/dmenu.c b/dmenu.c
+index a07f8e3..c26ecfc 100644
+--- a/dmenu.c
++++ b/dmenu.c
+@@ -32,6 +32,7 @@ struct item {
+ 	char *text;
+ 	struct item *left, *right;
+ 	int out;
++	int distance;
+ };
+ 
+ static char text[BUFSIZ] = "";
+@@ -253,6 +254,86 @@ match(void)
+ 	calcoffsets();
+ }
+ 
++int
++compare_distance(const void *a, const void *b)
++{
++	struct item *da = *(struct item **) a;
++	struct item *db = *(struct item **) b;
++
++	if (!db)
++		return 1;
++	if (!da)
++		return -1;
++
++	return da->distance - db->distance;
++}
++
++void
++fuzzymatch(void)
++{
++	/* bang - we have so much memory */
++	struct item *it;
++	struct item **fuzzymatches = NULL;
++	char c;
++	int number_of_matches = 0, i, pidx, sidx, eidx;
++	int text_len = strlen(text), itext_len;
++
++	matches = matchend = NULL;
++
++	/* walk through all items */
++	for (it = items; it && it->text; it++) {
++		if (text_len) {
++			itext_len = strlen(it->text);
++			pidx = 0;
++			sidx = eidx = -1;
++			/* walk through item text */
++			for (i = 0; i < itext_len && (c = it->text[i]); i++) {
++				/* fuzzy match pattern */
++				if (text[pidx] == c) {
++					if(sidx == -1)
++						sidx = i;
++					pidx++;
++					if (pidx == text_len) {
++						eidx = i;
++						break;
++					}
++				}
++			}
++			/* build list of matches */
++			if (eidx != -1) {
++				/* compute distance */
++				/* factor in 30% of sidx and distance between eidx and total
++				 * text length .. let's see how it works */
++				it->distance = eidx - sidx + (itext_len - eidx + sidx) / 3;
++				appenditem(it, &matches, &matchend);
++				number_of_matches++;
++			}
++		} else {
++			appenditem(it, &matches, &matchend);
++		}
++	}
++
++	if (number_of_matches) {
++		/* initialize array with matches */
++		if (!(fuzzymatches = realloc(fuzzymatches, number_of_matches * sizeof(struct item*))))
++			die("cannot realloc %u bytes:", number_of_matches * sizeof(struct item*));
++		for (i = 0, it = matches; it && i < number_of_matches; i++, it = it->right) {
++			fuzzymatches[i] = it;
++		}
++		/* sort matches according to distance */
++		qsort(fuzzymatches, number_of_matches, sizeof(struct item*), compare_distance);
++		/* rebuild list of matches */
++		matches = matchend = NULL;
++		for (i = 0, it = fuzzymatches[i];  i < number_of_matches && it && \
++				it->text; i++, it = fuzzymatches[i]) {
++			appenditem(it, &matches, &matchend);
++		}
++		free(fuzzymatches);
++	}
++	curr = sel = matches;
++	calcoffsets();
++}
++
+ static void
+ insert(const char *str, ssize_t n)
+ {
+@@ -263,7 +344,7 @@ insert(const char *str, ssize_t n)
+ 	if (n > 0)
+ 		memcpy(&text[cursor], str, n);
+ 	cursor += n;
+-	match();
++	fuzzymatch();
+ }
+ 
+ static size_t
+@@ -308,7 +389,7 @@ keypress(XKeyEvent *ev)
+ 
+ 		case XK_k: /* delete right */
+ 			text[cursor] = '\0';
+-			match();
++			fuzzymatch();
+ 			break;
+ 		case XK_u: /* delete left */
+ 			insert(NULL, 0 - cursor);
+@@ -442,7 +523,7 @@ keypress(XKeyEvent *ev)
+ 		strncpy(text, sel->text, sizeof text - 1);
+ 		text[sizeof text - 1] = '\0';
+ 		cursor = strlen(text);
+-		match();
++		fuzzymatch();
+ 		break;
+ 	}
+ 	drawmenu();
+@@ -584,7 +665,7 @@ setup(void)
+ 	}
+ 	promptw = (prompt && *prompt) ? TEXTW(prompt) : 0;
+ 	inputw = MIN(inputw, mw/3);
+-	match();
++	fuzzymatch();
+ 
+ 	/* create menu window */
+ 	swa.override_redirect = True;
+-- 
+2.6.3
+

--- a/srcpkgs/dmenu2/template
+++ b/srcpkgs/dmenu2/template
@@ -1,0 +1,40 @@
+# Template file for 'dmenu'
+pkgname=dmenu2
+version=0.2
+revision=1
+makedepends="libXinerama-devel libXft-devel freetype-devel"
+short_desc="Fork of dmenu with more customization options"
+maintainer="Jasper Chan <jasperchan515@gmail.com>"
+license="MIT"
+homepage="https://bitbucket.org/melek/dmenu2/"
+distfiles="https://bitbucket.org/melek/dmenu2/downloads/${pkgname}-${version}.tar.gz"
+checksum=b2d7ff5eccd0676942caa2f82cb9c6c6bbea8e5812e19fba9de97140ebc78597
+
+build_options="fuzzymatch"
+desc_option_fuzzymatch="Enable Fuzzymatch support"
+
+post_extract() {
+	if [ "$build_option_fuzzymatch" ]; then
+		msg_normal "Applying fuzzymatch patches"
+		patch -p1 < "${FILESDIR}/fuzzymatch.patch"
+	fi
+	sed -i -e '/CFLAGS/{s/-Os//;s/=/+=/}' \
+		-e '/LDFLAGS/{s/-s//;s/=/+=/}' config.mk
+}
+
+do_build() {
+	cp ${FILESDIR}/config.h config.h
+	sed -i -e "s|^FREETYPEINC|#FREETYPEINC|g" \
+		-e "s|^X11INC|#X11INC|g" \
+		-e "s|^X11LIB|#X11LIB|g" config.mk
+
+	x11inc=$XBPS_CROSS_BASE/usr/include/X11
+	x11lib=$XBPS_CROSS_BASE/usr/lib
+	freetypeinc=$XBPS_CROSS_BASE/usr/include/freetype2
+	make CC="$CC" ${makejobs} X11INC=$x11inc X11LIB=$x11lib FREETYPEINC=$freetypeinc
+}
+
+do_install() {
+	make PREFIX=/usr DESTDIR=${DESTDIR} install
+	vlicense LICENSE
+}


### PR DESCRIPTION
This package should not be installed alongside dmenu and acts as a replacement for it.

I'm guessing I need to create a virtual `dmenu` package and then change all of the things that depend on it to use the virtual package instead?