### PR TITLE
rpi-kernel: update to 4.14.66.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="1f89ad77bf9b204c18fb6fdd167b4ee92d064f95"
+_githash="ceeaae1f33060be3fc26344a0a73c8c0c74db086"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.62
+version=4.14.66
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=153deef35bf1895fb0825395c0f9fb61832dcf0131987fce99449beb17afa173
+checksum=308e5d76a316d02220df852adce94e069d2b50809d5a13fb2af5ae730a2dff44
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]