### PR TITLE
poppler: update to 0.68.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -341,7 +341,7 @@ libMagickCore-6.Q16.so.6 libmagick-6.9.9.44_1
 libMagickWand-6.Q16.so.6 libmagick-6.9.9.44_1
 libMagick++-6.Q16.so.8 libmagick-6.9.9.0_1
 libltdl.so.7 libltdl-2.2.6_1
-libpoppler.so.78 poppler-0.67.0_1
+libpoppler.so.79 poppler-0.68.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1
 libpoppler-cpp.so.0 poppler-cpp-0.18.2_1
 libpoppler-qt5.so.1 poppler-qt5-0.31.0_1

--- a/srcpkgs/apvlv/template
+++ b/srcpkgs/apvlv/template
@@ -1,7 +1,7 @@
 # Template file for 'apvlv'
 pkgname=apvlv
 version=0.1.5
-revision=6
+revision=7
 build_style=cmake
 configure_args="-DAPVLV_WITH_UMD=no -DAPVLV_WITH_DJVU=yes -DAPVLV_WITH_TXT=yes"
 hostmakedepends="pkg-config"

--- a/srcpkgs/atril/template
+++ b/srcpkgs/atril/template
@@ -1,7 +1,7 @@
 # Template file for 'atril'
 pkgname=atril
 version=1.20.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --enable-djvu
  --enable-dvi --enable-t1lib --enable-pixbuf --enable-comics --enable-xps

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.1.0
-revision=8
+revision=9
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON"
 hostmakedepends="automoc4 perl pkg-config extra-cmake-modules"

--- a/srcpkgs/claws-mail/template
+++ b/srcpkgs/claws-mail/template
@@ -1,7 +1,7 @@
 # Template file for 'claws-mail'
 pkgname=claws-mail
 version=3.17.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static --disable-python-plugin --disable-perl-plugin"
 hostmakedepends="pkg-config python-devel"

--- a/srcpkgs/cups-filters/template
+++ b/srcpkgs/cups-filters/template
@@ -1,7 +1,7 @@
 # Template file for 'cups-filters'
 pkgname=cups-filters
 version=1.21.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --with-rcdir=no --enable-avahi
  --with-browseremoteprotocols=DNSSD,CUPS"

--- a/srcpkgs/diff-pdf/template
+++ b/srcpkgs/diff-pdf/template
@@ -1,7 +1,7 @@
 # Template file for 'diff-pdf'
 pkgname=diff-pdf
 version=0.2.20160602
-revision=6
+revision=7
 _commit=ccf96982fa8a35d64a377779cfd80c921f66cefc
 build_style=gnu-configure
 wrksrc="$pkgname-$_commit"

--- a/srcpkgs/efl/template
+++ b/srcpkgs/efl/template
@@ -1,7 +1,7 @@
 # Template file for 'efl'
 pkgname=efl
 version=1.21.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="CXX= --enable-multisense --enable-image-loader-webp --enable-liblz4
  --disable-systemd $(vopt_enable framebuffer fb) $(vopt_enable pulseaudio)

--- a/srcpkgs/epdfview/template
+++ b/srcpkgs/epdfview/template
@@ -1,7 +1,7 @@
 # Template file for 'epdfview'
 pkgname=epdfview
 version=0.1.8
-revision=9
+revision=10
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel poppler-glib-devel"

--- a/srcpkgs/evince/template
+++ b/srcpkgs/evince/template
@@ -1,7 +1,7 @@
 # Template file for 'evince'
 pkgname=evince
 version=3.28.2
-revision=2
+revision=3
 configure_args="$(vopt_enable gir introspection) --disable-schemas-compile
  --enable-comics --disable-static --enable-xps --disable-t1lib
  --disable-browser-plugin"

--- a/srcpkgs/extractpdfmark/template
+++ b/srcpkgs/extractpdfmark/template
@@ -1,7 +1,7 @@
 # Template file for 'extractpdfmark'
 pkgname=extractpdfmark
 version=1.0.2
-revision=4
+revision=5
 build_wrksrc="build"
 build_style=gnu-configure
 configure_script="../configure"

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=2.10.4
-revision=4
+revision=5
 lib32disabled=yes
 build_style=gnu-configure
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool

--- a/srcpkgs/gloobus-preview/template
+++ b/srcpkgs/gloobus-preview/template
@@ -1,7 +1,7 @@
 # Template file for 'gloobus-preview'
 pkgname=gloobus-preview
 version=2015.12.21
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config python3 gettext-devel xz"
 makedepends="gettext-devel boost-devel gtk+-devel gtk+3-devel gtksourceview-devel

--- a/srcpkgs/gummi/template
+++ b/srcpkgs/gummi/template
@@ -1,7 +1,7 @@
 # Template file for 'gummi'
 pkgname=gummi
 version=0.6.6
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="automake intltool pkg-config glib-devel gtk+-devel gettext-devel"
 makedepends="gtksourceview2-devel glib-devel poppler-glib-devel gtkspell-devel gettext-devel"

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.92.3
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
  --without-gnome-vfs --disable-static"

--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -1,7 +1,7 @@
 # Template file for 'ipe'
 pkgname=ipe
 version=7.2.7
-revision=11
+revision=12
 _tools_commit=e5b23399a83d69fd5bb5d4645ef7325b4b57435b
 hostmakedepends="pkg-config qt5-qmake qt5-tools qt5-host-tools wget"
 makedepends="qt5-devel lua52-devel libjpeg-turbo-devel cairo-devel poppler-devel"

--- a/srcpkgs/libgdal/template
+++ b/srcpkgs/libgdal/template
@@ -1,7 +1,7 @@
 # Template file for 'libgdal'
 pkgname=libgdal
 version=2.3.1
-revision=2
+revision=3
 wrksrc=gdal-${version}
 build_style=gnu-configure
 configure_args="--with-liblzma --with-poppler"

--- a/srcpkgs/openjpeg2/template
+++ b/srcpkgs/openjpeg2/template
@@ -1,14 +1,14 @@
 # Template file for 'openjpeg2'
 pkgname=openjpeg2
 version=2.3.0
-revision=1
+revision=2
 wrksrc="openjpeg-${version}"
 build_style=cmake
-maintainer="Orphaned <orphan@voidlinux.eu>"
-homepage="http://www.openjpeg.org/"
-license="2-clause-BSD"
-short_desc="Open-source JPEG 2000 codec written in C language (Version 2)"
 makedepends="libpng-devel lcms2-devel tiff-devel"
+maintainer="Orphaned <orphan@voidlinux.eu>"
+short_desc="Open-source JPEG 2000 codec written in C language (Version 2)"
+homepage="http://www.openjpeg.org/"
+license="BSD-2-Clause"
 distfiles="https://github.com/uclouvain/openjpeg/archive/v${version}.tar.gz"
 checksum=3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a
 
@@ -18,17 +18,18 @@ post_install() {
 
 libopenjpeg2-devel_package() {
 	short_desc+=" - development files"
-	depends="libopenjpeg2>=${version}_${revision}"
+	depends="libopenjpeg2>=${version}_${revision} ${sourcepkg}-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.so
-		vmove usr/lib/openjpeg-2.*
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/openjpeg-2.*"
+		vmove "usr/lib/*.a"
 		vmove usr/lib/pkgconfig
 	}
 }
 libopenjpeg2_package() {
 	short_desc+=" - library files"
 	pkg_install() {
-		vmove usr/lib/*.so.*
+		vmove "usr/lib/*.so.*"
 	}
 }

--- a/srcpkgs/osg/template
+++ b/srcpkgs/osg/template
@@ -2,7 +2,7 @@
 pkgname=osg
 reverts=3.6.0_1
 version=3.4.1
-revision=6
+revision=7
 wrksrc=OpenSceneGraph-OpenSceneGraph-${version}
 build_style=cmake
 # don't use /usr/lib64 on 64bit platforms

--- a/srcpkgs/pdfgrep/template
+++ b/srcpkgs/pdfgrep/template
@@ -1,7 +1,7 @@
 # Template file for 'pdfgrep'
 pkgname=pdfgrep
 version=2.1.1
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libgcrypt-devel poppler-cpp-devel"

--- a/srcpkgs/pdfpc/template
+++ b/srcpkgs/pdfpc/template
@@ -1,7 +1,7 @@
 # Template file for 'pdfpc'
 pkgname=pdfpc
 version=4.1.2
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config vala"
 makedepends="gst-plugins-base1-devel gtk+3-devel libgee08-devel

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -4,7 +4,7 @@
 # A CYCLIC DEPENDENCY: qt5 -> cups -> poppler -> qt5.
 #
 pkgname=poppler-qt5
-version=0.67.0
+version=0.68.0
 revision=1
 wrksrc="poppler-${version}"
 build_style=cmake
@@ -18,7 +18,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/poppler-${version}.tar.xz"
-checksum=a34a4f1a0f5b610c584c65824e92e3ba3e08a89d8ab4622aee11b8ceea5366f9
+checksum=f90d04f0fb8df6923ecb0f106ae866cf9f8761bb537ddac64dfb5322763d0e58
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DTHREADS_PTHREAD_ARG=2"

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -3,7 +3,7 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/poppler-qt5".
 #
 pkgname=poppler
-version=0.67.0
+version=0.68.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_XPDF_HEADERS=on $(vopt_if gir -DENABLE_GLIB=on)
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/${pkgname}-${version}.tar.xz"
-checksum=a34a4f1a0f5b610c584c65824e92e3ba3e08a89d8ab4622aee11b8ceea5366f9
+checksum=f90d04f0fb8df6923ecb0f106ae866cf9f8761bb537ddac64dfb5322763d0e58
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DTHREADS_PTHREAD_ARG=2"

--- a/srcpkgs/tumbler/template
+++ b/srcpkgs/tumbler/template
@@ -1,7 +1,7 @@
 # Template file for 'tumbler'.
 pkgname=tumbler
 version=0.2.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-gstreamer-thumbnailer"
 hostmakedepends="intltool pkg-config glib-devel"

--- a/srcpkgs/xournal/template
+++ b/srcpkgs/xournal/template
@@ -1,7 +1,7 @@
 # Template file for 'xournal'
 pkgname=xournal
 version=0.4.8.2016
-revision=2
+revision=3
 build_style=gnu-configure
 make_install_args="desktop-install"
 hostmakedepends="autoconf automake pkg-config"

--- a/srcpkgs/xreader/template
+++ b/srcpkgs/xreader/template
@@ -1,7 +1,7 @@
 # Template file for 'xreader'
 pkgname=xreader
 version=1.8.5
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-introspection --disable-thumbnailer"
 hostmakedepends="mate-common"

--- a/srcpkgs/zathura-pdf-poppler/template
+++ b/srcpkgs/zathura-pdf-poppler/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura-pdf-poppler'
 pkgname=zathura-pdf-poppler
 version=0.2.9
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="poppler-devel poppler-glib-devel zathura-devel"


### PR DESCRIPTION
rebuild on x86_64

- [x] apvlv
- [x] atril
- [x] calligra
- [x] claws-mail
- [x] cups-filters
- [x] diff-pdf
- [x] efl
- [x] epdfview
- [x] evince
- [x] extractpdfmark
- [x] gimp
- [x] gloobus-preview
- [x] gummi
- [x] inkscape
- [x] ipe
- [x] libgdal
- [x] osg
- [x] pdfgrep
- [x] pdfpc
- [x] tumbler
- [x] xournal
- [x] xreader
- [x] zathura-pdf-poppler