### PR TITLE
python-discogs_client: update to 2.2.1

### DIFF
--- a/srcpkgs/python-discogs_client/template
+++ b/srcpkgs/python-discogs_client/template
@@ -1,9 +1,9 @@
 # Template file for 'python-discogs_client'
 pkgname=python-discogs_client
-version=2.2.0
-revision=3
+version=2.2.1
+revision=1
 noarch=yes
-wrksrc="${pkgname#*-}-${version}"
+wrksrc="discogs-client-${version}"
 build_style=python-module
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python-requests python-six python-oauthlib"
@@ -11,12 +11,15 @@ pycompile_module="discogs_client"
 short_desc="Official Discogs API client for Python2"
 maintainer="Georg Schabel <gescha@posteo.de>"
 homepage="https://github.com/discogs/discogs_client"
-license="2-clause-BSD"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=b31e3fd8f17f46b9c7221182ed6be96774a334ac8be4e434ee99943d27170945
+license="BSD-2-Clause"
+distfiles="${PYPI_SITE}/d/discogs-client/discogs-client-${version}.tar.gz
+ https://raw.githubusercontent.com/discogs/discogs_client/master/LICENSE"
+checksum="9e32b5e45cff41af8025891c71aa3025b3e1895de59b37c11fd203a8af687414
+ 1af62aeddccb57134218ddbdc67d0473524ca736703d7cce01db59b2e07da542"
+skip_extraction="LICENSE"
 
 post_install() {
-	vlicense LICENSE
+	vlicense ${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENSE
 }
 
 python3-discogs_client_package() {
@@ -26,6 +29,6 @@ python3-discogs_client_package() {
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*
-		vlicense LICENSE
+		vlicense ${XBPS_SRCDISTDIR}/${sourcepkg}-${version}/LICENSE
 	}
 }


### PR DESCRIPTION
discogs_client released v2.2.1 in 2018-09-15, but only on PyPI, not on Github; [see](https://pypi.org/project/discogs-client/) for [yourself](https://github.com/discogs/discogs_client/releases).  I tried to use ${PYPI_SITE} instead of Github as source, but "This site can't be reached" is given as response.

v2.2.1 adds UTF-8 string-based search; this feature is used by beets's Discogs plugin, as versions prior to 2.2.1 cause [this issue](https://github.com/beetbox/beets/issues/2387) to happen.

[There's a ticket from 2017](https://github.com/discogs/discogs_client/issues/75) about releasing v2.2.1 on their repo, but so far no answers.

This PR points to the commit from which v.2.2.1 was generated.  It is hacky, but it works.

If someone knows another way to bump version without refering to commits, let me know.