### PR TITLE
opera: fix bogus dependency on rpi-userland (again)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -124,6 +124,7 @@ libGLESv1_CM.so.1 libGLES-1.0_1
 libGLESv2.so.2 libGLES-1.0_1
 libEGL.so rpi-userland-0.0.0.0.20150907_1
 libGLESv2.so rpi-userland-0.0.0.0.20150907_1
+libGLESv2.so opera-55.0.2994.37_2
 libbrcmEGL.so rpi-userland-20180103_2
 libbrcmGLESv2.so rpi-userland-20180103_2
 libbrcmOpenVG.so rpi-userland-20180103_2

--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,21 +1,17 @@
 # Template file for 'opera'
 pkgname=opera
 version=55.0.2994.37
-revision=1
+revision=2
 only_for_archs="x86_64"
 repository="nonfree"
 nostrip=yes
-depends="ffmpeg desktop-file-utils hicolor-icon-theme libGLES"
+depends="ffmpeg desktop-file-utils hicolor-icon-theme"
 short_desc="Fast, secure, easy to use browser"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="Proprietary"
 homepage="https://www.opera.com/computer"
 distfiles="http://get.geo.opera.com/pub/opera/desktop/${version}/linux/${pkgname}-stable_${version}_amd64.deb"
 checksum=780ff37fbbf5adc4b2c683bfab5c9a087e3373ea12e1a21fb9c748a185a5f9d0
-
-# This soname is wrong and is only available on rpi-userland, the correct one is
-# libGLESv2.so.2, skip checking this and add libGLES explicitly to depends=
-skiprdeps="/usr/lib/opera/libGLESv2.so"
 
 do_extract() {
 	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}-stable_${version}_amd64.deb


### PR DESCRIPTION
```
# xbps-install opera
MISSING: rpi-userland>=0.0.0.0.20150907_1
Transaction aborted due to unresolved dependencies.
```

reverts (#1388) 84a1df20218d9c5d8135d15adee8390da0b6ac37 as it doesn't work as intended.

This is an old issue initially fixed in 7cece6a8dd3d0b079f1aa4f9e0e8130a8fa0a706. The fix got removed for unknown reasons in fc294a11bfafcc162b13e22b63a18a036f548640.
