### PR TITLE
iso-codes: update to 4.0.

### DIFF
--- a/srcpkgs/iso-codes/template
+++ b/srcpkgs/iso-codes/template
@@ -1,13 +1,13 @@
 # Template file for 'iso-codes'
 pkgname=iso-codes
-version=3.79
+version=4.0
 revision=1
 noarch=yes
 build_style=gnu-configure
 hostmakedepends="python3"
 short_desc="List of country, language and currency names"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://pkg-isocodes.alioth.debian.org/"
 distfiles="${DEBIAN_SITE}/main/i/iso-codes/${pkgname}_${version}.orig.tar.xz"
-checksum=cbafd36cd4c588a254c0a5c42e682190c3784ceaf2a098da4c9c4a0cbc842822
+checksum=771fe4f87997b9c8ff33b6af7f9bde4de87b54410cdebd2742ac6a38cb746a8c


### PR DESCRIPTION
This version removes .xml files in favour of json ones.