### PR TITLE
Update zita-* packages, fix guitarix2 musl build and update to 0.37.3

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2237,7 +2237,7 @@ libKF5I18n.so.5 ki18n-5.26.0_1
 libqtelegram-ae.so.1 libqtelegram-ae-5.0_1
 libtelegramqml.so.1 TelegramQML-0.8.0_1
 libglog.so.0 glog-0.3.4_1
-libzita-convolver.so.3 zita-convolver-3.1.0_1
+libzita-convolver.so.4 zita-convolver-4.0.3_1
 libzita-alsa-pcmi.so.0 zita-alsa-pcmi-0.2.0_1
 libpugixml.so.1 pugixml-1.6_1
 libnewt.so.0.52 newt-0.52.18_1

--- a/srcpkgs/guitarix2/patches/musl.patch
+++ b/srcpkgs/guitarix2/patches/musl.patch
@@ -1,0 +1,15 @@
+There is no mallopt in musl.
+
+--- src/gx_head/gui/machine.cpp.orig	2018-07-22 06:24:50.000000000 +0200
++++ src/gx_head/gui/machine.cpp	2018-08-26 09:31:01.815078037 +0200
+@@ -44,8 +44,10 @@
+     long int total_size = 0;
+     if (mlockall(MCL_CURRENT | MCL_FUTURE))
+         gx_print_error("system init", "mlockall failed:");
++#ifdef __GLIBC__
+     mallopt(M_TRIM_THRESHOLD, -1);
+     mallopt(M_MMAP_MAX, 0);
++#endif
+     for (unsigned int i = 0; i < sizeof(regions)/sizeof(regions[0]); i++) {
+         total_size +=regions[i].len;
+         if (mlock(regions[i].start, regions[i].len) != 0) {

--- a/srcpkgs/guitarix2/template
+++ b/srcpkgs/guitarix2/template
@@ -1,7 +1,7 @@
 # Template file for 'guitarix2'
 pkgname=guitarix2
-version=0.37.1
-revision=2
+version=0.37.3
+revision=1
 wrksrc="guitarix-${version}"
 build_style=waf
 configure_args="--cxxflags-release=-DNDEBUG --ladspa --new-ladspa --no-faust --no-lv2
@@ -18,7 +18,7 @@ maintainer="cr6git <quark6@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://guitarix.org"
 distfiles="${SOURCEFORGE_SITE}/guitarix/guitarix/guitarix2-${version}.tar.xz"
-checksum=51a9375ef12e0e7242c7a346253fcf7f296d55fcd2a88f1c7fa93fdcbf049318
+checksum=4ca93bd4226cd175456f37612acd28b46e13133db61c0f235917dbcc3347d5f1
 
 build_options="avahi bluez"
 desc_option_avahi="Build with avahi support"
@@ -32,7 +32,6 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 if [ -n "$CROSS_BUILD" ]; then
-	CXXFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/raptor2"
 	post_extract() {
 		# don’t test load the ladspa plugin when cross compiling
 		sed -i "s/\(features='cxx cshlib\) test_loadable/\1/" src/ladspa/wscript

--- a/srcpkgs/zita-ajbridge/template
+++ b/srcpkgs/zita-ajbridge/template
@@ -1,18 +1,13 @@
 # Template file for 'zita-ajbridge'
 pkgname=zita-ajbridge
-version=0.7.0
+version=0.8.2
 revision=1
 build_wrksrc="source"
 build_style=gnu-makefile
 makedepends="zita-resampler-devel zita-alsa-pcmi-devel alsa-lib-devel jack-devel"
 short_desc="Use an ALSA device as a Jack client"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://kokkinizita.linuxaudio.org/linuxaudio/zita-ajbridge-doc/quickguide.html"
 distfiles="https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum=233d5cbfd83124d866b207e261a9fb067590edddec680e956a7d7cfb25417635
-
-pre_build() {
-	# fix installation and use the right compiler
-	sed -i -e "s;install -Dm.*\(zita-[^\s]\+\)\s.*$;&/\1;g" -e "s;g++;$CXX;"  Makefile
-}
+checksum=92985974a2472c83af6f3cbd7559fdae7726a8af29029ad08a51e7c4cd3373bf

--- a/srcpkgs/zita-alsa-pcmi/template
+++ b/srcpkgs/zita-alsa-pcmi/template
@@ -1,20 +1,20 @@
 # Template file for 'zita-alsa-pcmi'
 pkgname=zita-alsa-pcmi
-version=0.2.0
+version=0.3.2
 revision=1
-build_wrksrc="libs"
+build_wrksrc="source"
 build_style=gnu-makefile
-make_install_args="LIBDIR=lib"
+make_install_args="LIBDIR=/usr/lib"
 makedepends="alsa-lib-devel"
 short_desc="Easy access to ALSA PCM devices"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum=491eaf9da24fb20b94723f8e75e2ea3a667fc53555b54d2acd390bf4c418fbe5
+checksum=1a1d9f7e373032bd5702382e4c923407911f4f791c449c0c0f027a725edba789
 
 pre_build() {
-	sed -i -e "s/g++/$CXX/" Makefile
+	sed -i '/march=native/d' Makefile
 }
 
 post_install() {
@@ -27,6 +27,6 @@ zita-alsa-pcmi-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/zita-convolver/template
+++ b/srcpkgs/zita-convolver/template
@@ -1,22 +1,20 @@
 # Template file for 'zita-convolver'
 pkgname=zita-convolver
-version=3.1.0
-reverts="4.0.0_1"
-revision=3
+version=4.0.3
+revision=1
 build_style=gnu-makefile
-make_install_args="LIBDIR=lib"
+make_install_args="LIBDIR=/usr/lib"
 hostmakedepends="pkg-config"
 makedepends="fftw-devel"
-build_wrksrc="libs"
+build_wrksrc="source"
 short_desc="A fast partitioned convolution engine library"
 maintainer="silvernode <mollusk@homebutter.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum="bf7e93b582168b78d40666974460ad8142c2fa3c3412e327e4ab960b3fb31993"
+checksum=9aa11484fb30b4e6ef00c8a3281eebcfad9221e3937b1beb5fe21b748d89325f
 
 pre_build() {
-	sed -i 's/g++/$(CXX)/' Makefile
 	sed -i '/march=native/d' Makefile
 }
 
@@ -30,6 +28,6 @@ zita-convolver-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/zita-resampler/template
+++ b/srcpkgs/zita-resampler/template
@@ -1,20 +1,19 @@
 # Template file for 'zita-resampler'
 pkgname=zita-resampler
-version=1.6.0
-revision=2
+version=1.6.2
+revision=1
 build_style=gnu-makefile
-make_install_args="LIBDIR=lib"
+make_install_args="LIBDIR=/usr/lib"
 hostmakedepends="pkg-config"
-build_wrksrc="libs"
+build_wrksrc="source"
 short_desc="A library for resampling audio signals"
 maintainer="silvernode <mollusk@homebutter.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://kokkinizita.linuxaudio.org/linuxaudio/zita-resampler/resampler.html"
 distfiles="http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum=10888d76299d8072990939be45d6fc5865f5a45d766d7690819c5899d2a588f0
+checksum=233baefee297094514bfc9063e47f848e8138dc7c959d9cd957b36019b98c5d7
 
 pre_build() {
-	sed -i 's/g++/$(CXX)/' Makefile
 	sed -i '/march=native/d' Makefile
 }
 
@@ -28,6 +27,6 @@ zita-resampler-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
I updated all zita packages at once because of some interdependencies. @silvernode hope you’re OK with this. :)

Also could fix the musl build of guitarix2 which can be updated now, too. @cr6git is this OK with you?

Tested guitarix2 on x86_64, x86_64-musl, and armv7l-musl. Starts up ok, everything seems fine. Cannot do much more with it, though. ;)