### PR TITLE
oomox: added missing dependency `python3-Pillow`

### DIFF
--- a/srcpkgs/oomox/template
+++ b/srcpkgs/oomox/template
@@ -1,7 +1,7 @@
 # Template file for 'oomox'
 pkgname=oomox
 version=1.6.2
-revision=1
+revision=2
 _droid_icon_ver=6dc4c92689ea2ce99534d6f461283efdf8ffd270
 _gnome_icon_ver=2f3d8dd3ce59e260803660f158a7a91d643518bf
 _oomoxify_ver=fe1b4279bc5e4d39116c718313bf68e167daaabc
@@ -9,7 +9,7 @@ _materia_theme_ver=125048a8cba7352e69e6d0b7973ded01889e2949
 _oomox_gtk_theme_ver=a0787a875347f1387f390b0e72402842d431eb45
 noarch=yes
 depends="python3 python3-gobject gtk+3 gdk-pixbuf glib-devel glib sassc
- bc sed librsvg librsvg-utils optipng parallel inkscape"
+ bc sed librsvg librsvg-utils optipng parallel inkscape python3-Pillow"
 short_desc="Graphical application for generating color variations of some themes"
 maintainer="Tim Wanders <timwanders241@gmail.com>"
 license="GPL-3"


### PR DESCRIPTION
This fixes themix-project/oomox#159