### PR TITLE
docker: Build docker CLI

### DIFF
--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,19 +1,18 @@
 # Template file for 'docker'
 pkgname=docker
-version=18.06.0
-revision=2
+version=18.06.1
+revision=1
 _subversion='-ce'
 _version="$version$_subversion"
 wrksrc="$pkgname$_subversion-$_version"
-build_wrksrc=components/engine
 hostmakedepends="git go pkg-config curl cmake"
-makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel libapparmor-devel"
+makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel libapparmor-devel libltdl-devel"
 short_desc="Pack, ship and run any application as a lightweight container"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="http://www.docker.io"
 distfiles="https://github.com/docker/docker-ce/archive/v$_version.tar.gz"
-checksum=18754ecb38d7c210fb2b96ee618dc2bdf94e66cd501d4eef0c685903a83e8501
+checksum=153cb489033686260dfe7a42acbdd1753d56f7a9c2d7ad90633f0c8cce563b23
 
 # These are required at run-time.
 depends="iptables xz git"
@@ -26,11 +25,22 @@ system_groups="docker"
 _docker_components="runc containerd tini proxy dockercli"
 
 do_build() {
-	AUTO_GOPATH=1 DOCKER_BUILDTAGS='seccomp apparmor' DOCKER_GITCOMMIT=v$_version \
+	cd components/cli
+# AUTO_GOPATH=1 doesn't seem to work for CLI
+	rm -rf .gopath
+	mkdir -p .gopath/src/github.com/docker
+	ln -sf $wrksrc/components/cli .gopath/src/github.com/docker/
+	GOPATH=$wrksrc/components/cli/.gopath LDFLAGS='' \
+		make VERSION=$_version dynbinary
+	rm -rf .gopath
+
+	cd ../../components/engine
+	AUTO_GOPATH=1 DOCKER_BUILDTAGS='seccomp apparmor' VERSION=$_version DOCKER_GITCOMMIT=v$_version \
 		hack/make.sh dynbinary
 }
 
 pre_build() {
+	cd components/engine
 	vmkdir usr/bin
 	sed -i "s|/usr/local|$DESTDIR/usr|g" hack/dockerfile/install/install.sh
 	for COMPONENT in $_docker_components; do
@@ -41,6 +51,7 @@ pre_build() {
 
 do_install() {
 	vbin ${wrksrc}/components/engine/bundles/dynbinary-daemon/dockerd dockerd
+	vbin ${wrksrc}/components/cli/build/docker docker
 	vinstall ${wrksrc}/components/cli/contrib/completion/bash/docker 644 usr/share/bash-completion/completions
 	vinstall ${wrksrc}/components/cli/contrib/completion/zsh/_docker 644 usr/share/zsh/site-functions
 	vsv docker


### PR DESCRIPTION
Adds building docker CLI instead of just downloading it, which
caused version mismatch between CLI and daemon.