### PR TITLE
openssh: update to 7.8p1.

### DIFF
--- a/srcpkgs/openssh/patches/setproctitle.patch
+++ b/srcpkgs/openssh/patches/setproctitle.patch
@@ -1,0 +1,10 @@
+--- openbsd-compat/setproctitle.c.orig
++++ openbsd-compat/setproctitle.c
+@@ -36,6 +36,7 @@
+ #ifndef HAVE_SETPROCTITLE
+ 
+ #include <stdarg.h>
++#include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+ #ifdef HAVE_SYS_PSTAT_H

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,7 +1,7 @@
 # Template file for 'openssh'
 pkgname=openssh
-version=7.7p1
-revision=2
+version=7.8p1
+revision=1
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
@@ -22,7 +22,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.openssh.org"
 license="BSD"
 distfiles="http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/$pkgname-$version.tar.gz"
-checksum=d73be7e684e99efcd024be15a30bffcbe41b012b2f7b3c9084aed621775e6b8f
+checksum=1a484bb15152c183bb2514e112aa30dd34138c3cfb032eee5490a66c507144ca
 conf_files="/etc/ssh/moduli /etc/ssh/ssh_config /etc/ssh/sshd_config /etc/pam.d/sshd"
 make_dirs="/var/chroot/ssh 0755 root root"
 


### PR DESCRIPTION
Tested on x86_64 glibc as server and client.