### PR TITLE
Manual.md: document the tags variable.

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -598,6 +598,10 @@ i.e `dkms_modules="$pkgname $version zfs 4.14"`
 registered into the system shells database. It is used by the `register-shell` trigger.
 i.e `register_shell="/bin/tcsh /bin/csh"`
 
+- `tags` A white space separated list of tags (categories) that are registered into the
+package metadata and can be queried with `xbps-query` by users.
+i.e for qutebrowser `tags="browser chromium-based qt5 python3"`
+
 <a id="explain_depends"></a>
 #### About the many types of `depends` variable.
 


### PR DESCRIPTION
A forgotten thing, this is an example with a custom mpc

```
$ grep ^tags= srcpkgs/mpc/template
tags="mpd musicplayer"
```

```
$ xbps-query --repository=hostdir/binpkgs/mpc -S mpc
architecture: x86_64
build-date: 2018-08-27 17:21 -03
filename-sha256: 6efe773b82e5a121714d2f3fe599a5ab1aa0c90daa79dc3597ddd0f94445d497
filename-size: 172KB
homepage: http://www.musicpd.org/clients/mpc/
installed_size: 647KB
license: GPL-2.0-or-later
maintainer: maxice8 <thinkabit.ukim@gmail.com>
pkgver: mpc-0.30_3
repository: /home/terran/usr/src/void-packages/hostdir/binpkgs/mpc
shlib-requires:
	libmpdclient.so.2
	libc.so.6
short_desc: Minimalist command line interface to MPD
tags: mpd musicplayer
```

```
$ xbps-query --repository=hostdir/binpkgs/mpc -S mpc -p tags
mpd musicplayer
```