### PR TITLE
rpi-firmware: update to 20180824.

### DIFF
--- a/srcpkgs/rpi-firmware/files/config.txt
+++ b/srcpkgs/rpi-firmware/files/config.txt
@@ -71,3 +71,13 @@
 #core_freq=500
 #sdram_freq=500
 #over_voltage=6
+
+
+## Enable/Disable experimental desktop GL driver
+## requires package: mesa-vc4-dri
+
+## with full kms
+#dtoverlay=vc4-kms-v3d
+
+## with fake kms
+#dtoverlay=vc4-fkms-v3d

--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,18 +1,18 @@
 # Template file for 'rpi-firmware'
-_githash="287af2a2be0787a5d45281d1d6183a2161c798d4"
+_githash="200c2f4dd54b2048b5dcb8661ea3f232beb7d81e"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20180505
+version=20180824
 revision=1
 noarch=yes
 wrksrc="firmware-${_githash}"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=5edff641f216d2e09c75469dc2e9fc66aff290e212a1cd43ed31c499f99ea055
+checksum=a72ddbd1a4e96ca508fc14d0c31784ec119b68edcab2929c9779ae618db15388
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 


### PR DESCRIPTION
to match with 4.14.66

along
 - mark `/boot/config.txt` and `/boot/cmdline.txt` as config files
 - add option to config.txt to enable the openGL driver,
according to:
https://github.com/RPi-Distro/raspi-config/blob/985548d7ca00cab11eccbb734b63750761c1f08a/raspi-config#L1232