### PR TITLE
tweeny: fix cross

### DIFF
--- a/srcpkgs/tweeny/template
+++ b/srcpkgs/tweeny/template
@@ -3,14 +3,13 @@ pkgname=tweeny
 version=2
 revision=1
 build_style=cmake
-makedepends="SDL2-devel"
+configure_args="-DTWEENY_BUILD_EXAMPLES=OFF"
 short_desc="Modern C++ tweening library"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="MIT"
 homepage="https://github.com/mobius3/tweeny"
 distfiles="https://github.com/mobius3/tweeny/archive/${version}.tar.gz"
 checksum=3a5a4171b96ce85e90eea06b7b3bc80793a357b5638d49f6cf0531771fc2234a
-nocross="fails to find headers on cross environment"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
What fails is building the examples which aren’t packaged anyway. So just disable them.