### PR TITLE
texworks: fix cross

### DIFF
--- a/srcpkgs/texworks/patches/cross.patch
+++ b/srcpkgs/texworks/patches/cross.patch
@@ -1,0 +1,53 @@
+--- modules/QtPDF/CMake/Modules/FindPoppler.cmake.orig	2017-04-29 18:23:51.000000000 +0200
++++ modules/QtPDF/CMake/Modules/FindPoppler.cmake	2018-08-29 09:13:02.788284947 +0200
+@@ -69,15 +69,7 @@
+   MESSAGE(STATUS "Could not find libpoppler." )
+ ENDIF ()
+ 
+-# Scan poppler libraries for dependencies on Fontconfig
+-INCLUDE(GetPrerequisites)
+-MARK_AS_ADVANCED(gp_cmd)
+-GET_PREREQUISITES("${POPPLER_BASE_LIBRARIES}" POPPLER_PREREQS TRUE FALSE "" "")
+-IF ("${POPPLER_PREREQS}" MATCHES "fontconfig")
+-  SET(POPPLER_NEEDS_FONTCONFIG TRUE)
+-ELSE ()
+-  SET(POPPLER_NEEDS_FONTCONFIG FALSE)
+-ENDIF ()
++SET(POPPLER_NEEDS_FONTCONFIG TRUE)
+ 
+ 
+ FIND_PATH(POPPLER_QT_INCLUDE_DIR NAMES poppler-qt${QT_VERSION_MAJOR}.h poppler-link.h
+--- CMakeLists.txt.orig	2017-04-29 18:23:51.000000000 +0200
++++ CMakeLists.txt	2018-08-29 10:49:36.290088209 +0200
+@@ -91,7 +91,6 @@
+ SET(TeXworks_VERSION ${TeXworks_VER_MAJOR}.${TeXworks_VER_MINOR}.${TeXworks_VER_PATCH})
+ 
+ # Make sure we have up-to-date git commit infos
+-IF ( NOT CMAKE_CROSSCOMPILING )
+ 	IF ( WIN32 )
+ 		EXECUTE_PROCESS(COMMAND ${CMAKE_SOURCE_DIR}/getGitRevInfo.bat WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+ 		ADD_CUSTOM_TARGET(GitRev ALL COMMAND ${CMAKE_SOURCE_DIR}/getGitRevInfo.bat WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} COMMENT "Update git commit info")
+@@ -99,7 +98,6 @@
+ 		EXECUTE_PROCESS(COMMAND ${CMAKE_SOURCE_DIR}/getGitRevInfo.sh WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+ 		ADD_CUSTOM_TARGET(GitRev ALL COMMAND ${CMAKE_SOURCE_DIR}/getGitRevInfo.sh WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} COMMENT "Update git commit info")
+ 	ENDIF ( WIN32 )
+-ENDIF ( NOT CMAKE_CROSSCOMPILING)
+ MESSAGE( STATUS "Git commit info updated" )
+ 
+ # Recover git commit info from `src/GitRev.h`.
+@@ -361,7 +359,6 @@
+ # Some header files contain components that must be dynamically generated. For
+ # example, `getDefaultBinPaths.sh` is a script that tries to figure out the
+ # appropriate path to TeX binaries on UNIX-like systems.
+-IF ( UNIX AND NOT CMAKE_CROSSCOMPILING )
+   IF ( NOT EXISTS ${TeXworks_SOURCE_DIR}/src/DefaultBinaryPaths.h )
+     MESSAGE(STATUS "Generating DefaultBinaryPaths.h")
+ 
+@@ -371,7 +368,6 @@
+       WORKING_DIRECTORY ${TeXworks_SOURCE_DIR}
+     )
+   ENDIF ()
+-ENDIF ()
+ 
+ # Building
+ # ========

--- a/srcpkgs/texworks/template
+++ b/srcpkgs/texworks/template
@@ -5,8 +5,7 @@ revision=1
 wrksrc=${pkgname}-release-${version}
 build_style=cmake
 configure_args="-DTW_BUILD_ID=Void -DWITH_LUA=ON -DWITH_PYTHON=ON
--DDESIRED_QT_VERSION:STRING=5 gp_tool=$LDD"
-cmake_builddir=build
+-DDESIRED_QT_VERSION:STRING=5"
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools qt5-tools-devel qt5-script-devel
  poppler-qt5-devel hunspell-devel"
 makedepends="lua-devel python-devel qt5-tools-devel qt5-script-devel
@@ -14,8 +13,7 @@ makedepends="lua-devel python-devel qt5-tools-devel qt5-script-devel
 depends="lua python hunspell dejavu-fonts-ttf"
 short_desc="TeX editor"
 maintainer="Bosco <jboscogg@gmail.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://www.tug.org/texworks"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/release-${version}.tar.gz"
 checksum=22885c11d92654b0cba1f4808fc9aa3c2fdd3e5435fd89dff9aa1e67658a6339
-nocross="/usr/share/cmake-3.11/Modules/GetPrerequisites.cmake fails to detect poppler-qt5"


### PR DESCRIPTION
Cmake uses `ldd` to check if poppler is built with fontconfig. This fails when cross-compiling. But we know poppler uses fontconfig so skip (remove) the test and tell cmake to use it.

When configuring, cmake runs two shell scripts only under the condition that it’s not a cross build, but without them it fails for some reason. The first one gets the git revision and the second one tries to find default paths for the TeX binaries. There’s no problem running them in a cross-build, too, so I removed the condition.

Tested on armv7l, no problems found so far.