### PR TITLE
docker: fix server version info

### DIFF
--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -26,7 +26,7 @@ system_groups="docker"
 _docker_components="runc containerd tini proxy dockercli"
 
 do_build() {
-	AUTO_GOPATH=1 DOCKER_BUILDTAGS='seccomp apparmor' DOCKER_GITCOMMIT=v$_version \
+	VERSION=$_version AUTO_GOPATH=1 DOCKER_BUILDTAGS='seccomp apparmor' DOCKER_GITCOMMIT=v$_version \
 		hack/make.sh dynbinary
 }
 


### PR DESCRIPTION
Fixes #2221

```
$ docker version
Client:
 Version:      17.06.0-ce
 API version:  1.30
 Go version:   go1.8.3
 Git commit:   02c1d87
 Built:        Fri Jun 23 21:15:15 2017
 OS/Arch:      linux/amd64
Server:
 Version:      18.06.0-ce
 API version:  1.38 (minimum version 1.12)
 Go version:   go1.11
 Git commit:   v18.06.0-ce
 Built:        Wed Aug 29 17:29:23 2018
 OS/Arch:      linux/amd64
 Experimental: false
```