### PR TITLE
fix lots of license= fields

### DIFF
--- a/srcpkgs/MultiMC/template
+++ b/srcpkgs/MultiMC/template
@@ -1,7 +1,7 @@
 # Template file for 'MultiMC'
 pkgname=MultiMC
 version=0.6.2
-revision=1
+revision=2
 _commithashnbt="4b305bbd2ac0e7a26987baf7949a484a87b474d4"
 _nbtversion="multimc-0.5.0"
 _quazipversion="multimc-2"
@@ -11,7 +11,7 @@ makedepends="qt5-devel qt5-x11extras-devel qt5-svg-devel gtk+-devel"
 depends="virtual?java-environment"
 short_desc="An instanced Minecraft client"
 maintainer="Spencer H <spencernh77@gmail.com>"
-license="Apache 2.0"
+license="Apache-2.0"
 homepage="http://multimc.org"
 distfiles="https://github.com/${pkgname}/${pkgname}5/archive/${version}.tar.gz
 	https://github.com/${pkgname}/libnbtplusplus/archive/${_nbtversion}.tar.gz
@@ -19,7 +19,7 @@ distfiles="https://github.com/${pkgname}/${pkgname}5/archive/${version}.tar.gz
 checksum="d5e5fdc3234ac423e4abf8ea3b46d851c2df54713eae61f2171cb6f85de78fee
 	bcefbdd905f10a04605cf9e8f768d0f60c972e9e219c800512a5fd9c5f7a8498
 	25e1b74f0edef5e09647f7b5344c08fad4eaebbc386b1f288b59286ecdfe07fa"
-wrksrc=${pkgname}5-${version}
+wrksrc="${pkgname}5-${version}"
 skip_extraction="${_nbtversion}.tar.gz ${_quazipversion}.tar.gz"
 
 pre_configure() {

--- a/srcpkgs/VeraCrypt/template
+++ b/srcpkgs/VeraCrypt/template
@@ -1,16 +1,16 @@
-# Template file for 'Veracrypt'
+# Template file for 'VeraCrypt'
 pkgname=VeraCrypt
 version=1.22
-revision=3
+revision=4
 create_wrksrc=1
-build_wrksrc="src"
+build_wrksrc=src
 build_style=gnu-makefile
 make_use_env=1
 hostmakedepends="pkg-config yasm"
 makedepends="fuse-devel wxWidgets-devel"
 short_desc="Disk encryption with strong security based on TrueCrypt"
 maintainer="Gustavo Heinz <gustavoheinz95@gmail.com>"
-license="Apache 2.0, TrueCrypt 3.0"
+license="Apache-2.0, TrueCrypt 3.0"
 homepage="https://www.veracrypt.fr"
 distfiles="https://launchpad.net/veracrypt/trunk/${version}/+download/${pkgname}_${version}_Source.tar.bz2"
 checksum=9e4c0cc0edda0031978ec13d81f420af55c14b4a6b06c8d448760fd06df7b870
@@ -20,7 +20,7 @@ case "$XBPS_TARGET_MACHINE" in
 	*) make_build_args+=' NOASM=1' ;;
 esac
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	make_build_args+=' NOTEST=1'
 fi
 

--- a/srcpkgs/akonadi-contacts/template
+++ b/srcpkgs/akonadi-contacts/template
@@ -1,13 +1,13 @@
 # Template file for 'akonadi-contacts'
 pkgname=akonadi-contacts
 version=18.08.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
 makedepends="kio-devel kcontacts-devel kmime-devel akonadi-mime-devel prison-devel"
 short_desc="Libraries and daemons to implement Contact Management in Akonadi"
 maintainer="John <johnz@posteo.net>"
-license="LGPL-2.0-or-later GPL-2-or-later"
+license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://community.kde.org/KDE_PIM/Akonadi"
 distfiles="${KDE_SITE}/applications/${version}/src/akonadi-contacts-${version}.tar.xz"
 checksum=556821c7f3f3cb658c06a5f859b5e944345fa68b4eff471f9164e07e29051a4b

--- a/srcpkgs/akonadi-mime/template
+++ b/srcpkgs/akonadi-mime/template
@@ -1,13 +1,13 @@
 # Template file for 'akonadi-mime'
 pkgname=akonadi-mime
 version=18.08.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules kdoctools python3"
 makedepends="kmime-devel akonadi5-devel"
 short_desc="Libraries and daemons to implement basic email handling"
 maintainer="John <johnz@posteo.net>"
-license="LGPL-2.1-or-later GPL-2-or-later"
+license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://community.kde.org/KDE_PIM/Akonadi"
 distfiles="${KDE_SITE}/applications/${version}/src/akonadi-mime-${version}.tar.xz"
 checksum=00f5a64363e00c47150e9581fd24f33ef6c2c6b1d745f790cc4c1c287fa0494a

--- a/srcpkgs/argon2/template
+++ b/srcpkgs/argon2/template
@@ -1,16 +1,16 @@
 # Template file for 'argon2'
 pkgname=argon2
 version=20171227
-revision=2
-wrksrc=phc-winner-argon2-${version}
+revision=3
+wrksrc="phc-winner-argon2-${version}"
 build_style=gnu-makefile
 make_use_env=yes
 make_build_args="OPTTARGET=none"
 make_check_args="OPTTARGET=none"
-make_check_target="test"
+make_check_target=test
 short_desc="Password hashing function"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="CC0 1.0 Universal, Apache 2.0"
+license="CC0-1.0, Apache-2.0"
 homepage="https://github.com/P-H-C/phc-winner-argon2"
 distfiles="https://github.com/P-H-C/phc-winner-argon2/archive/${version}.tar.gz"
 checksum=eaea0172c1f4ee4550d1b6c9ce01aab8d1ab66b4207776aa67991eb5872fdcd8

--- a/srcpkgs/astromenace/template
+++ b/srcpkgs/astromenace/template
@@ -1,7 +1,7 @@
 # Template file for 'astromenace'
 pkgname=astromenace
 version=1.3.2
-revision=3
+revision=4
 wrksrc=AstroMenace
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ makedepends="SDL-devel glu-devel libopenal-devel freealut-devel libvorbis-devel
 depends="astromenace-data>=${version}_${revision}"
 short_desc="Hardcore 3D space shooter"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-3 OFL-1.1 CC-BY-SA-3.0"
+license="GPL-3.0-or-later, OFL-1.1, CC-BY-SA-3.0"
 homepage="http://www.viewizard.com/"
 distfiles="${SOURCEFORGE_SITE}/openastromenace/${version}/${pkgname}-src-${version}.tar.bz2"
 checksum=9b775df2b157565b97aca008dd879b867cd3377c07b829cee6b5342639357fe6

--- a/srcpkgs/bsdiff/template
+++ b/srcpkgs/bsdiff/template
@@ -1,13 +1,13 @@
 # Template file for 'bsdiff'
 pkgname=bsdiff
 version=4.3
-revision=3
+revision=4
 makedepends="bzip2-devel"
-homepage="http://www.daemonology.net/bsdiff"
 short_desc="Binary diff/patch utility"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="Simplified BSD"
-distfiles="$homepage/$pkgname-$version.tar.gz"
+license="BSD-2-Clause"
+homepage="http://www.daemonology.net/bsdiff"
+distfiles="${homepage}/${pkgname}-${version}.tar.gz"
 checksum=18821588b2dc5bf159aa37d3bcb7b885d85ffd1e19f23a0c57a58723fea85f48
 
 do_build() {

--- a/srcpkgs/burp-server/template
+++ b/srcpkgs/burp-server/template
@@ -3,10 +3,10 @@ _desc="A network-based backup and restore program"
 
 pkgname=burp-server
 version=1.4.40
-revision=7
+revision=8
 short_desc="${_desc} - Server"
 maintainer="Pierre Bourgin <pierre.bourgin@free.fr>"
-license="AGPL-3, BSD, GPL-2.1 and LGPL-2.1"
+license="AGPL-3.0-only, BSD-3-Clause, GPL-2.0-or-later"
 homepage="http://burp.grke.org/"
 wrksrc="burp-${version}"
 distfiles="https://github.com/grke/burp/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"

--- a/srcpkgs/calligra-plan/template
+++ b/srcpkgs/calligra-plan/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra-plan'
 pkgname=calligra-plan
 version=3.1.0
-revision=2
+revision=3
 wrksrc="${pkgname/-/}-${version}"
 build_style=cmake
 hostmakedepends="extra-cmake-modules kdoctools"
@@ -10,7 +10,7 @@ makedepends="kinit-devel kcmutils-devel kdiagram-devel kholidays-devel
  threadweaver-devel akonadi-contacts-devel"
 short_desc="Project Management"
 maintainer="John <johnz@posteo.net>"
-license="GPL-2.0-or-later LGPL-2.0-or-later GFDL-1.2-or-later"
+license="GPL-2.0-or-later, LGPL-2.0-or-later, GFDL-1.2-or-later"
 homepage="https://www.calligra.org/plan/"
 distfiles="${KDE_SITE}/calligra/${version}/calligraplan-${version}.tar.xz"
 checksum=59f985bae0482789c13c9440af3bf5da0a1d04756c1c1ccf39f68f66cd3e7ddd

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,12 +1,10 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.1.0
-revision=10
+revision=11
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON"
 hostmakedepends="automoc4 perl pkg-config extra-cmake-modules"
-short_desc="Illustration application"
-maintainer="John <johnz@posteo.net>"
 makedepends="akonadi-contacts-devel akonadi5-devel ecm-devel eigen3.2
  exiv2-devel kactivities5-devel gsl-devel
  kcmutils-devel kcontacts-devel kdelibs4support-devel kdiagram-devel
@@ -14,7 +12,9 @@ makedepends="akonadi-contacts-devel akonadi5-devel ecm-devel eigen3.2
  libetonyek-devel libgit2-devel libodfgen-devel libokular-devel
  libopenexr-devel libspnav-devel libvisio-devel libwpg-devel libwps-devel
  poppler-qt5-devel qca-qt5-devel threadweaver-devel marble5-devel"
-license="GPL-2.0-or-later LGPL-2.0-or-later GFDL-1.2-or-later"
+short_desc="Illustration application"
+maintainer="John <johnz@posteo.net>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later, GFDL-1.2-or-later"
 homepage="http://www.calligra-suite.org/"
 distfiles="${KDE_SITE}/calligra/${version}/calligra-${version}.tar.xz"
 checksum=6818cd6e64136321be217eb57cc7d6ac7c7035191fdb1ee336ebe60bc114e870

--- a/srcpkgs/clipper/template
+++ b/srcpkgs/clipper/template
@@ -1,14 +1,14 @@
 # Template file for 'clipper'
 pkgname=clipper
 version=6.4.2
-revision=1
+revision=2
 create_wrksrc=yes
-build_wrksrc="cpp"
+build_wrksrc=cpp
 build_style=cmake
 hostmakedepends="unzip"
 short_desc="Library for clipping and offsetting lines and polygons"
 maintainer="John <johnz@posteo.net>"
-license="Boost Software License 1.0"
+license="BSL-1.0"
 homepage="http://www.angusj.com/delphi/clipper.php"
 distfiles="${SOURCEFORGE_SITE}/polyclipping/clipper_ver${version}.zip"
 checksum=a14320d82194807c4480ce59c98aa71cd4175a5156645c4e2b3edd330b930627

--- a/srcpkgs/envypn-font/template
+++ b/srcpkgs/envypn-font/template
@@ -1,16 +1,15 @@
 # Template file for 'envypn-font'
 pkgname=envypn-font
 version=1.7.1
-revision=1
-noarch="yes"
+revision=2
+noarch=yes
+depends="font-util xbps-triggers"
 short_desc="Readable bitmap font inspired by Envy Code R"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
+license="MirOS"
 homepage="https://ypnose.fr/p/pj/#envypn"
-license="MirOS License"
 distfiles="https://ypnose.fr/files/p/envypn-font/${pkgname}-${version}.tar.gz"
 checksum=bda67b6bc6d5d871a4d46565d4126729dfb8a0de9611dae6c68132a7b7db1270
-makedepends="font-util mkfontdir"
-depends="${makedepends}"
 font_dirs="/usr/share/fonts/envypn"
 
 do_install() {

--- a/srcpkgs/flickcurl/template
+++ b/srcpkgs/flickcurl/template
@@ -1,12 +1,12 @@
 # Template file for 'flickcurl'
 pkgname=flickcurl
 version=1.26
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="libcurl-devel libxml2-devel raptor-devel"
 short_desc="C library for the Flickr API"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
-license="LGPL-2.1 GPL-2 Apache-2.0"
+license="LGPL-2.1-or-later, GPL-2.0-or-later, Apache-2.0"
 homepage="http://librdf.org/flickcurl/"
 distfiles="http://download.dajobe.org/flickcurl/flickcurl-${version}.tar.gz"
 checksum=ff42a36c7c1c7d368246f6bc9b7d792ed298348e5f0f5d432e49f6803562f5a3

--- a/srcpkgs/font-fantasque-sans-ttf/template
+++ b/srcpkgs/font-fantasque-sans-ttf/template
@@ -1,14 +1,14 @@
 # Template file for 'font-fantasque-sans-ttf'
 pkgname=font-fantasque-sans-ttf
 version=1.7.2
-revision=1
+revision=2
 create_wrksrc=yes
-noarch="yes"
+noarch=yes
 font_dirs="/usr/share/fonts/TTF"
 depends="font-util xbps-triggers"
 short_desc="A handwriting-like programming typeface"
 maintainer="Kartik Singh <kartik.ynwa@gmail.com>"
-license="SIL Open Font License"
+license="OFL-1.1"
 homepage="https://fontlibrary.org/en/font/fantasque-sans-mono"
 distfiles="https://github.com/belluzj/fantasque-sans/releases/download/v${version}/FantasqueSansMono-Normal.tar.gz"
 checksum=8d96295a75a71d6ddb3a905ff8db993bd6990602d3b38dd4428827af8f6ef2f7

--- a/srcpkgs/freeimage/template
+++ b/srcpkgs/freeimage/template
@@ -1,13 +1,13 @@
 # Template file for 'freeimage'
 pkgname=freeimage
 version=3.18.0
-revision=2
+revision=3
 wrksrc=FreeImage
 build_style=gnu-makefile
 hostmakedepends="unzip"
 short_desc="Support library for popular graphics image formats"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2.0-or-later FIPL"
+license="GPL-2.0-or-later, FreeImage"
 homepage="http://freeimage.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/freeimage/Source%20Distribution/FreeImage${version//./}.zip"
 checksum=f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd

--- a/srcpkgs/geoip-data/template
+++ b/srcpkgs/geoip-data/template
@@ -1,11 +1,11 @@
 # Template file for 'geoip-data'
 pkgname=geoip-data
 version=20171002
-revision=1
+revision=2
 create_wrksrc=yes
 short_desc="Non-DNS IP-to-country resolver C library and utilities (data files)"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="CC BY-SA 4.0"
+license="CC-BY-SA-4.0"
 homepage="https://dev.maxmind.com/geoip/legacy/geolite/"
 noarch=yes
 

--- a/srcpkgs/gitflow/template
+++ b/srcpkgs/gitflow/template
@@ -2,17 +2,17 @@
 pkgname=gitflow
 reverts=20140609_1
 version=20120925
-revision=1
+revision=2
 _commit=15aab26490facf285acef56cb5d61025eacb3a69
 _shflags_commit=2fb06af13de884e9680f14a00c82e52a67c867f1
-noarch="yes"
+noarch=yes
 hostmakedepends="perl"
 depends="git"
 short_desc="Git extensions to provide high-level repository operations"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="Liberal BSD"
+license="BSD-2-Clause"
 homepage="https://github.com/nvie/gitflow"
-distfiles="$homepage/archive/$_commit.tar.gz https://github.com/nvie/shFlags/archive/$_shflags_commit.tar.gz"
+distfiles="${homepage}/archive/${_commit}.tar.gz https://github.com/nvie/shFlags/archive/${_shflags_commit}.tar.gz"
 checksum="277ecb102afd45c3137d630de11ceac4b267a73d6a5f2ac41ccbd3d96b609ce7 a1c5782a78e106d0c6289a9412fffa376f4cd78f4f86af441eb7bf06cf664594"
 
 wrksrc="$pkgname-$_commit"
@@ -30,4 +30,8 @@ do_build() {
 do_install() {
 	mkdir -p ${DESTDIR}
 	make install prefix=${DESTDIR}/usr
+}
+
+post_install() {
+	vlicense LICENSE
 }

--- a/srcpkgs/heirloom-sh/template
+++ b/srcpkgs/heirloom-sh/template
@@ -1,13 +1,13 @@
 # Template file for 'heirloom-sh'
 pkgname=heirloom-sh
 version=050706
-revision=3
+revision=4
 short_desc="A portable variant of the traditional Unix shell"
 maintainer="allan <mail@may.mooo.com>"
-license="Caldera OpenSolaris"
+license="Caldera"
 homepage="http://heirloom.sourceforge.net/sh.html"
-distfiles="$SOURCEFORGE_SITE/heirloom/$pkgname/$version/$pkgname-$version.tar.bz2"
-checksum="25fb8409e1eb75bb5da21ca32baf2d5eebcb8b84a1288d66e65763a125809e1d"
+distfiles="${SOURCEFORGE_SITE}/heirloom/${pkgname}/${version}/${pkgname}-${version}.tar.bz2"
+checksum=25fb8409e1eb75bb5da21ca32baf2d5eebcb8b84a1288d66e65763a125809e1d
 register_shell="/bin/heirloom-sh"
 
 do_build() {

--- a/srcpkgs/kea/template
+++ b/srcpkgs/kea/template
@@ -1,7 +1,7 @@
 # Template file for 'kea'
 pkgname=kea
 version=1.3.0
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--enable-generate-docs --with-openssl=${XBPS_CROSS_BASE}/usr
  $(vopt_if mysql --with-dhcp-mysql)
@@ -17,7 +17,7 @@ depends="libkea>=0"
 conf_files="/etc/kea/*.conf"
 short_desc="Next generation DHCPv4/v6 server"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="MPL-2 Apache-2.0"
+license="MPL-2.0, Apache-2.0"
 homepage="http://kea.isc.org/wiki"
 distfiles="http://ftp.isc.org/isc/kea/${version}/kea-${version}.tar.gz"
 checksum=6edfcdbf2526c218426a1d1a6a6694a4050c97bb8412953a230285d63415c391

--- a/srcpkgs/kexi/template
+++ b/srcpkgs/kexi/template
@@ -1,7 +1,7 @@
 # Template file for 'kexi'
 pkgname=kexi
 version=3.1.0
-revision=2
+revision=3
 build_style=cmake
 replaces="calligra-kexi>=0"
 hostmakedepends="extra-cmake-modules kdoctools doxygen pkg-config"
@@ -10,9 +10,9 @@ makedepends="ktexteditor-devel kdb-devel kreport-devel qt5-webkit-devel
 depends="breeze-icons"
 short_desc="Visual database applications creator"
 maintainer="John <johnz@posteo.net>"
-license="GPL-2-or-later LGPL-2.0-or-later"
+license="GPL-2-or-later, LGPL-2.0-or-later"
 homepage="http://www.kexi-project.org/"
-distfiles="https://download.kde.org/stable/kexi/src/kexi-${version}.tar.xz"
+distfiles="${KDE_SITE}/kexi/src/kexi-${version}.tar.xz"
 checksum=6d55cd4af177bcb060673a0977d52bc91cc2dd1b1420d008a78f9783312152fb
 
 if [ "$CROSS_BUILD" ];then

--- a/srcpkgs/ladspa-bs2b/template
+++ b/srcpkgs/ladspa-bs2b/template
@@ -1,13 +1,13 @@
 # Template file for 'ladspa-bs2b'
 pkgname=ladspa-bs2b
 version=0.9.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libbs2b-devel ladspa-sdk"
 short_desc="Audiofilter for headphones - LADSPA plugin"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
-license="GPL-2 MIT"
+license="GPL-2.0-or-later, MIT"
 homepage="http://bs2b.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/bs2b/LADSPA%20plugin/${version}/${pkgname}-${version}.tar.gz"
 checksum=e249b46505b280448bc4fe66d464f6dc6b12fcabefb0f5529a45ad20d78d8aac

--- a/srcpkgs/lel/template
+++ b/srcpkgs/lel/template
@@ -1,13 +1,13 @@
 # Template file for 'lel'
 pkgname=lel
 version=0.2
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="libX11-devel"
 depends="farbfeld"
 short_desc="Farbfeld image viewer"
 maintainer="Rubén Santos <kojicomics@cocaine.ninja>"
-license="MIT/X Consortium"
+license="MIT"
 homepage="https://git.2f30.org/lel"
 distfiles="https://dl.2f30.org/releases/lel-${version}.tar.gz"
 checksum=337b69b1c2b6db0d74d36d432df52538d653f7023ca696cc4dc89b50491e17be

--- a/srcpkgs/libe-book/template
+++ b/srcpkgs/libe-book/template
@@ -1,14 +1,14 @@
 # Template file for 'libe-book'
 pkgname=libe-book
 version=0.1.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-werror"
 hostmakedepends="automake libtool gperf doxygen pkg-config"
 makedepends="boost-devel icu-devel libcppunit-devel libxml2-devel librevenge-devel liblangtag-devel"
 short_desc="Import reflowable e-book formats"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="LGPL-2.1 MPL"
+license="MPL-2.0"
 homepage="http://sourceforge.net/projects/libebook/"
 distfiles="${SOURCEFORGE_SITE}/project/libebook/${pkgname}-${version}/${pkgname}-${version}.tar.xz"
 checksum=7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9

--- a/srcpkgs/libfetch/template
+++ b/srcpkgs/libfetch/template
@@ -1,13 +1,13 @@
 # Template file for 'libfetch'
 pkgname=libfetch
 version=2.34
-revision=17
+revision=18
 build_style=gnu-makefile
 makedepends="libressl-devel"
 short_desc="File Transfer Library for URLs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-3-Clause"
 homepage="http://www.NetBSD.org"
-license="Modified BSD"
 distfiles="http://distfiles.voidlinux.de/${pkgname}-${version}/${pkgname}-${version}.tar.xz"
 checksum=4e6d4541f213c9ab42ea94d49c2573f0a6f54b04f14668530960f1424b04f722
 
@@ -21,7 +21,7 @@ libfetch-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/share
-		vmove usr/lib/*.a
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/libticables2/template
+++ b/srcpkgs/libticables2/template
@@ -1,7 +1,7 @@
 # Template file for 'libticables2'
 pkgname=libticables2
 version=1.3.5
-revision=1
+revision=2
 _tilpver=1.18
 build_style=gnu-configure
 configure_args="--enable-libusb10"
@@ -9,12 +9,12 @@ hostmakedepends="automake bison groff intltool libtool pkg-config texinfo"
 makedepends="glib-devel libusb-devel gettext-devel"
 short_desc="TI Link Cable Library"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
-license=" GPL-2.0-or-later"
+license="GPL-2.0-or-later"
 homepage="https://www.ticalc.org"
 distfiles="${SOURCEFORGE_SITE}/tilp/tilp2-linux/tilp2-${_tilpver}/${pkgname}-${version}.tar.bz2"
 checksum=0c6fb6516e72ccab081ddb3aecceff694ed93aec689ddd2edba9c7c7406c4522
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" gettext-devel"
 fi
 

--- a/srcpkgs/libticonv/template
+++ b/srcpkgs/libticonv/template
@@ -1,7 +1,7 @@
 # Template file for 'libticonv'
 pkgname=libticonv
 version=1.1.5
-revision=1
+revision=2
 _tilpver=1.18
 build_style=gnu-configure
 configure_args="--enable-iconv"
@@ -9,7 +9,7 @@ hostmakedepends="automake bison groff intltool libtool pkg-config texinfo"
 makedepends="glib-devel"
 short_desc="TI character set conversion library"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
-license=" GPL-2.0-or-later"
+license="GPL-2.0-or-later"
 homepage="https://www.ticalc.org"
 distfiles="${SOURCEFORGE_SITE}/tilp/tilp2-linux/tilp2-${_tilpver}/${pkgname}-${version}.tar.bz2"
 checksum=316da6a73bf26b266dd23443882abc4c9fe7013edc3a53e5e301d525c2060878

--- a/srcpkgs/libtifiles2/template
+++ b/srcpkgs/libtifiles2/template
@@ -1,19 +1,19 @@
 # Template file for 'libtifiles2'
 pkgname=libtifiles2
 version=1.1.7
-revision=1
+revision=2
 _tilpver=1.18
 build_style=gnu-configure
 hostmakedepends="automake bison groff intltool libtool pkg-config texinfo"
 makedepends="libticonv-devel libarchive-devel gettext-devel"
 short_desc="TI File format library"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
-license=" GPL-2.0-or-later"
+license="GPL-2.0-or-later"
 homepage="https://www.ticalc.org"
 distfiles="${SOURCEFORGE_SITE}/tilp/tilp2-linux/tilp2-${_tilpver}/${pkgname}-${version}.tar.bz2"
 checksum=9ac63b49e97b09b30b37bbc84aeb15fa7967bceb944e56141c5cd5a528acc982
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" gettext-devel"
 fi
 

--- a/srcpkgs/lksctp-tools/template
+++ b/srcpkgs/lksctp-tools/template
@@ -1,12 +1,12 @@
 # Template file for 'lksctp-tools'
 pkgname=lksctp-tools
 version=1.0.17
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool linux-headers"
 short_desc="User-space access to Linux Kernel SCTP"
 maintainer="bitshark <bitshark@bitshark.net>"
-license="GPL-3 GPL-2 LGPL-2"
+license="GPL-2.0-or-later, LGPL-2.1-only"
 homepage="http://lksctp.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/lksctp/${pkgname}-${version}.tar.gz"
 checksum=1aeb204cdb2befc94d9eb3037d1609c9d1d2cd5379d6dd2c0a8ca9b10533aa15

--- a/srcpkgs/mdcat/template
+++ b/srcpkgs/mdcat/template
@@ -1,13 +1,13 @@
 # Template file for 'mdcat'
 pkgname=mdcat
 version=0.9.2
-revision=1
+revision=2
 wrksrc="${pkgname}-${pkgname}-${version}"
 hostmakedepends="cargo cmake pkg-config"
 makedepends="libressl-devel"
 short_desc="Cat for markdown"
 maintainer="Wilson Birney <wpb@360scada.com>"
-license="Apache License 2.0"
+license="Apache-2.0"
 homepage="https://github.com/lunaryorn/mdcat"
 distfiles="https://github.com/lunaryorn/mdcat/archive/mdcat-${version}.tar.gz"
 checksum=50647d42abeea133430cac2d4eb6807ad19d7825996944338df5caaf39e4dc29

--- a/srcpkgs/ncftp/template
+++ b/srcpkgs/ncftp/template
@@ -1,11 +1,11 @@
 # Template file for 'ncftp'
 pkgname=ncftp
 version=3.2.6
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Set of application programs implementing the File Transfer Protocol"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="Clarified Artistic License"
+license="ClArtistic"
 homepage="http://www.ncftp.com/ncftp/"
 distfiles="ftp://ftp.ncftp.com/${pkgname}/${pkgname}-${version}-src.tar.gz"
 checksum=129e5954850290da98af012559e6743de193de0012e972ff939df9b604f81c23

--- a/srcpkgs/nethack/template
+++ b/srcpkgs/nethack/template
@@ -1,14 +1,14 @@
 # Template file for 'nethack'
 pkgname=nethack
 version=3.6.1
-revision=1
+revision=2
 make_dirs="/var/games/nethack/save 0775 nethack nethack"
 system_accounts="$pkgname"
 hostmakedepends="ncurses-devel flex"
 depends="gzip"
 short_desc="Exploring The Mazes of Menace"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="NetHack General Public License"
+license="NGPL"
 homepage="http://www.nethack.org/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version//.}-src.tgz"
 checksum=4b8cbf1cc3ad9f6b9bae892d44a9c63106d44782a210906162a7c3be65040ab6

--- a/srcpkgs/njconnect/template
+++ b/srcpkgs/njconnect/template
@@ -1,13 +1,13 @@
 # Template file for 'njconnect'
 pkgname=njconnect
 version=1.6
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="ncurses-devel jack-devel"
 short_desc="Curses Jack connection manager"
 maintainer="biopsin <biopsin@yahoo.no>"
-license="GPL-2.0 or later"
+license="GPL-2.0-or-later"
 homepage="https://sourceforge.net/projects/njconnect/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/files/${pkgname}-${version}.tar.xz"
 checksum=f62ccadbae29129642a3317169058bbd1c3e3299195152426a618ba154726ddd

--- a/srcpkgs/openldap/template
+++ b/srcpkgs/openldap/template
@@ -1,7 +1,7 @@
 # Template file for 'openldap'
 pkgname=openldap
 version=2.4.45
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--prefix=/usr
  --libexecdir=/usr/libexec
@@ -18,7 +18,7 @@ makedepends="libressl-devel libsasl-devel db-devel libltdl-devel"
 depends="openldap-tools>=${version}_${revision}"
 conf_files="/etc/openldap/ldap.conf /etc/openldap/slapd.conf"
 short_desc="OpenLDAP (Lightweight Directory Access Protocol)"
-license="OpenLDAP License v2.8 - BSD alike"
+license="OLDAP-2.0"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.openldap.org"
 distfiles="https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${version}.tgz"

--- a/srcpkgs/perl-Archive-Extract/template
+++ b/srcpkgs/perl-Archive-Extract/template
@@ -1,16 +1,16 @@
 # Template file for 'perl-Archive-Extract'
 pkgname=perl-Archive-Extract
 version=0.80
-revision=1
+revision=2
 noarch=yes
 wrksrc="Archive-Extract-${version}"
 build_style=perl-module
 hostmakedepends="perl"
-makedepends="${hostmakedepends}"
-depends="${makedepends}"
+makedepends="$hostmakedepends"
+depends="$makedepends"
 short_desc="A generic archive extracting mechanism"
 maintainer="ibrokemypie <ibrokemypie@bastardi.net>"
-license="Artistic 1, GPL-1"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Archive-Extract"
 distfiles="${CPAN_SITE}/Archive/Archive-Extract-${version}.tar.gz"
 checksum=25cbc2d5626c14d39a0b5e4fe8383941e085c9a7e0aa873d86e81b6e709025f4

--- a/srcpkgs/perl-Data-UUID/template
+++ b/srcpkgs/perl-Data-UUID/template
@@ -1,15 +1,19 @@
 # Template file for 'perl-Data-UUID'
 pkgname=perl-Data-UUID
 version=1.221
-revision=5
-wrksrc="Data-UUID-$version"
+revision=6
+wrksrc="Data-UUID-${version}"
 build_style=perl-module
 maintainer="Orphaned <orphan@voidlinux.eu>"
 hostmakedepends=perl
 makedepends=perl
 depends=perl
-license="${pkgname} license"
+license="MIT"
 homepage="https://metacpan.org/release/Data-UUID"
 short_desc="Data::UUID - Globally/Universally Unique Identifiers"
 distfiles="${CPAN_SITE}/Data/Data-UUID-${version}.tar.gz"
 checksum=3cc7b2a3a7b74b45a059e013f7fd878078500ea4b7269036f84556b022078667
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/perl-List-MoreUtils-XS/template
+++ b/srcpkgs/perl-List-MoreUtils-XS/template
@@ -1,8 +1,8 @@
-# Template build file for 'perl-List-MoreUtils-XS'.
+# Template file for 'perl-List-MoreUtils-XS'
 pkgname=perl-List-MoreUtils-XS
 version=0.428
-revision=3
-wrksrc="List-MoreUtils-XS-$version"
+revision=4
+wrksrc="List-MoreUtils-XS-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl perl-Exporter-Tiny"
@@ -10,7 +10,7 @@ depends="${makedepends} perl-List-MoreUtils"
 short_desc="List::MoreUtils::XS - Provide compiled List::MoreUtils functions"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 homepage="https://metacpan.org/release/List-MoreUtils-XS"
-license="Apache 2.0, Artistic, GPL-1"
+license="Apache-2.0, Artistic-1.0, GPL-1.0-or-later"
 conflicts="perl-List-MoreUtils<0.419_1"
 distfiles="${CPAN_SITE}/List/List-MoreUtils-XS-${version}.tar.gz"
 checksum=9d9fe621429dfe7cf2eb1299c192699ddebf060953e5ebdc1b4e293c6d6dd62d

--- a/srcpkgs/perl-List-MoreUtils/template
+++ b/srcpkgs/perl-List-MoreUtils/template
@@ -1,17 +1,17 @@
-# Template build file for 'perl-List-MoreUtils'.
+# Template file for 'perl-List-MoreUtils'
 pkgname=perl-List-MoreUtils
 version=0.428
-revision=1
-wrksrc="List-MoreUtils-$version"
+revision=2
+noarch=yes
+wrksrc="List-MoreUtils-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl perl-Exporter-Tiny"
-depends="${makedepends}"
-noarch=yes
+depends="$makedepends"
 short_desc="List::MoreUtils - Provide the stuff missing in List::Util"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="https://metacpan.org/release/List-MoreUtils-XS"
-license="Apache 2.0, Artistic, GPL-1"
+license="Apache-2.0, Artistic-1.0, GPL-1.0-or-later"
 distfiles="${CPAN_SITE}/List/List-MoreUtils-${version}.tar.gz"
 checksum=713e0945d5f16e62d81d5f3da2b6a7b14a4ce439f6d3a7de74df1fd166476cc2
 

--- a/srcpkgs/poco/template
+++ b/srcpkgs/poco/template
@@ -1,11 +1,11 @@
-# Template build file for 'poco'.
+# Template file for 'poco'
 pkgname=poco
 version=1.8.0.1
-revision=1
+revision=2
 build_style=cmake
 short_desc="C++ class libraries for building network-based applications"
 maintainer="Julien Dehos <dehos@univ-littoral.fr>"
-license="Boost Software License 1.0"
+license="BSL-1.0"
 homepage="https://pocoproject.org"
 distfiles="https://pocoproject.org/releases/${pkgname}-${version}/${pkgname}-${version}-all.tar.gz"
 checksum=cb891540b44b74e844fd0787c796f2699a894dba690329660e29b57efb8f80dd

--- a/srcpkgs/proplib/template
+++ b/srcpkgs/proplib/template
@@ -1,14 +1,14 @@
 # Template file for 'proplib'
 pkgname=proplib
 version=0.6.4
-revision=3
+revision=4
 wrksrc="portableproplib-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 makedepends="zlib-devel"
 short_desc="Portable Property container object library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="Simplified BSD"
+license="BSD-2-Clause"
 homepage="https://github.com/xtraeme/portableproplib"
 distfiles="https://github.com/xtraeme/portableproplib/archive/${version}.tar.gz"
 checksum=b2edac8977fa2e569e8664976d9c27f272bcf13f1aa921e853f129b7fd6b5d86

--- a/srcpkgs/pulseaudio-module-sndio/template
+++ b/srcpkgs/pulseaudio-module-sndio/template
@@ -1,7 +1,7 @@
 # Template file for 'pulseaudio-module-sndio'
 pkgname=pulseaudio-module-sndio
 version=12.0
-revision=3
+revision=4
 build_style=gnu-makefile
 make_use_env=yes
 hostmakedepends="pulseaudio pkg-config"
@@ -9,7 +9,7 @@ makedepends="sndio-devel pulseaudio-devel libltdl-devel libpulseaudio"
 nocross="Can't link -lpulseco{re,mmon}-12.0."
 short_desc="Module for PulseAudio to support playing to sndio servers"
 maintainer="Toyam Cox <Vaelatern@voidlinux.eu>"
-license="LGPL-2 ISC"
+license="LGPL-2.1-or-later, ISC"
 homepage="https://github.com/t6/pulseaudio-module-sndio"
 distfiles="https://github.com/t6/pulseaudio-module-sndio/releases/download/${version}/${pkgname}-${version}.tar.gz"
 checksum=785baffed274241eb8e1642d0d6e66a411f7f6bf0d0257f46dcd51a809feb835

--- a/srcpkgs/python-configobj/template
+++ b/srcpkgs/python-configobj/template
@@ -1,18 +1,22 @@
 # Template file for 'python-configobj'
 pkgname=python-configobj
 version=5.0.6
-revision=3
+revision=4
 noarch=yes
 wrksrc="configobj-${version}"
 build_style=python-module
 hostmakedepends="python-devel python3-devel"
 depends="python-six"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="New BSD"
+license="BSD-3-Clause"
 homepage="https://github.com/DiffSK/configobj"
 short_desc="Simple but powerful config file reader and writer (Python2)"
 distfiles="https://github.com/DiffSK/configobj/archive/v${version}.tar.gz"
 checksum=2e140354efcca6f558ff9ee941b435ae09a617bc071797bef62c8d6ed2033d5e
+
+post_install() {
+	vlicense LICENSE
+}
 
 python3-configobj_package() {
 	noarch=yes

--- a/srcpkgs/python-feedparser/template
+++ b/srcpkgs/python-feedparser/template
@@ -1,7 +1,7 @@
 # Template file for 'python-feedparser'
 pkgname=python-feedparser
 version=5.2.1
-revision=4
+revision=5
 noarch=yes
 wrksrc="feedparser-${version}"
 build_style=python-module
@@ -9,11 +9,15 @@ pycompile_module="feedparser.py"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="Simplified BSD"
+license="BSD-2-Clause"
 homepage="https://pypi.org/project/feedparser/"
 short_desc="Parse Atom and RSS feeds in Python2"
 distfiles="${PYPI_SITE}/f/feedparser/feedparser-${version}.tar.bz2"
 checksum=ce875495c90ebd74b179855449040003a1beb40cd13d5f037a0654251e260b02
+
+post_install() {
+	vlicense LICENSE
+}
 
 python3-feedparser_package() {
 	noarch=yes

--- a/srcpkgs/python-random2/template
+++ b/srcpkgs/python-random2/template
@@ -1,16 +1,16 @@
 # Template file for 'python-random2'
 pkgname=python-random2
 version=1.0.1
-revision=1
-wrksrc=random2-${version}
+revision=2
+wrksrc="random2-${version}"
 build_style=python-module
 hostmakedepends="python-setuptools python3-setuptools unzip"
 depends="python-setuptools"
 short_desc="Python 3 compatible Python 2 random Module"
 maintainer="Wilson Birney <wpb@360scada.com>"
-license="Python 2.1.1"
+license="Python-2.0"
 homepage="https://pypi.org/project/random2/"
-distfiles="${PYPI_SITE}/r/random2/random2-1.0.1.zip"
+distfiles="${PYPI_SITE}/r/random2/random2-${version}.zip"
 checksum=34ad30aac341039872401595df9ab2c9dc36d0b7c077db1cea9ade430ed1c007
 noarch=yes
 

--- a/srcpkgs/slcp/template
+++ b/srcpkgs/slcp/template
@@ -1,12 +1,12 @@
 # Template file for 'slcp'
 pkgname=slcp
 version=0.2
-revision=9
+revision=10
 build_style=gnu-makefile
 makedepends="libgit2-devel"
 short_desc="Simple shell prompt written in C"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="THE BEER-WARE LICENSE (Revision 42)"
+license="Beerware"
 homepage="https://github.com/schachmat/slcp"
 distfiles="https://github.com/schachmat/slcp/archive/${version}.tar.gz"
 checksum=a26e56832e37dbf1c7b776ddb137e422c987c19330575708a5945697e08e7cfe

--- a/srcpkgs/tab/template
+++ b/srcpkgs/tab/template
@@ -1,11 +1,11 @@
 # Template file for 'tab'
 pkgname=tab
 version=6.2.4
-revision=1
-wrksrc="tkatchev-tab-5f844032197b"
+revision=2
+wrksrc=tkatchev-tab-5f844032197b
 short_desc="Shell language for text/number manipulation"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="Boost Software License 1.0"
+license="BSL-1.0"
 homepage="http://tkatchev.bitbucket.io/tab/"
 distfiles="https://bitbucket.org/tkatchev/${pkgname}/get/${version}.tar.bz2"
 checksum=3c3fbdf8d735316c64a654505e44a28baa75d6a7ff4d3065dfcc72bf2cea8411

--- a/srcpkgs/tre/template
+++ b/srcpkgs/tre/template
@@ -1,12 +1,12 @@
 # Template file for 'tre'
 pkgname=tre
 version=0.8.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-static --without-alloca"
 short_desc="The free and portable approximate regex matching library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="Simplified BSD"
+license="BSD-2-Clause"
 homepage="http://laurikari.net/tre/"
 distfiles="http://laurikari.net/tre/tre-${version}.tar.bz2"
 checksum=8dc642c2cde02b2dac6802cdbe2cda201daf79c4ebcbb3ea133915edf1636658

--- a/srcpkgs/yakuake/template
+++ b/srcpkgs/yakuake/template
@@ -1,17 +1,17 @@
 # Template file for 'yakuake'
 pkgname=yakuake
 version=3.0.5
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
 makedepends="knewstuff-devel knotifyconfig-devel kparts-devel"
 short_desc="A drop-down terminal emulator based on KDE konsole technology"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2.0-only GFDL-1.2-only"
+license="GPL-2.0-only, GFDL-1.2-only"
 homepage="http://yakuake.kde.org/"
 distfiles="${KDE_SITE}/${pkgname}/${version}/src/${pkgname}-${version}.tar.xz"
 checksum=08e23bd3ed58732bec44bf1b6797990bbdc58fad0725da7215db39f86c4d2a08
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kconfig python qt5-host-tools qt5-qmake"
 fi


### PR DESCRIPTION
This was caused because i saw `pulseaudio-module-sndio` being updated (https://github.com/void-linux/void-packages/commit/aeb2a66f8ab0d0d3b6c8ee66ae3b753aee467313) and couldn't find a comma between LGPL-2 (ambiguous) and ISC in the license field.

[ci skip]

- [x] proplib
- [x] perl-List-MoreUtils-XS
- [x] perl-List-MoreUtils
- [x] perl-Archive-Extract
- [x] burp-server
- [x] argon2
- [x] VeraCrypt
- [x] calligra-plan
- [x] calligra
- [x] ladspa-bs2b
- [x] openldap
- [x] envypn-font
- [x] MultiMC
- [x] astromenace
- [x] font-fantasque-sans-ttf
- [x] akonadi-contacts
- [x] akonadi-mime
- [x] bsdiff
- [x] clipper
- [x] flickcurl
- [x] freeimage
- [x] geoip-data
- [x] gitflow
- [x] heirloom-sh
- [x] kea
- [x] kexi
- [x] lel
- [x] libe-book
- [x] libfetch
- [x] lksctp-tools
- [x] mdcat
- [x] ncftp
- [x] nethack
- [x] perl-Data-UUID
- [x] poco
- [x] python-configobj
- [x] python-feedparser
- [x] python-random2
- [x] slcp
- [x] tab
- [x] tre
- [x] yakuake
- [x] pulseaudio-module-sndio
- [x] libticables2
- [x] libticonv
- [x] libtifiles2
- [x] njconnect