### PR TITLE
xbanish: update to 1.6.

### DIFF
--- a/srcpkgs/xbanish/template
+++ b/srcpkgs/xbanish/template
@@ -1,15 +1,15 @@
 # Template file for 'xbanish'
 pkgname=xbanish
-version=1.5
+version=1.6
 revision=1
 build_style=gnu-makefile
 makedepends="libXfixes-devel libXt-devel libXi-devel libX11-devel"
 short_desc="Banish the mouse cursor when typing, show it again when the mouse moves"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="https://github.com/jcs/xbanish"
 distfiles="https://github.com/jcs/xbanish/archive/v${version}.tar.gz"
-checksum=d10007a468227bb11549ee341c84ff4b4f1e2f49a3d03a971d5a35a56b117cbc
+checksum=6e9bec35720b3d0f047028ad248a758249c7139c62ef140d9d39df6bd382712d
 
 pre_build() {
 	export LIBS="$LDFLAGS"


### PR DESCRIPTION
Tested on my machine locally (musl), not really sure what else I need to do as this is my first void-package PR :)  Released https://github.com/jcs/xbanish/releases via https://github.com/jcs/xbanish/issues/34.

compile and package

```
dave - temple linux ~/dev/void-packages (git:master) $ ./xbps-src pkg xbanish
[*] Updating `https://repo.voidlinux.eu/current/musl/x86_64-musl-repodata' ...
[*] Updating `https://repo.voidlinux.eu/current/musl/nonfree/x86_64-musl-repodata' ...
[*] Updating `https://repo.voidlinux.eu/current/x86_64-musl-repodata' ...
ERROR: [reposync] failed to fetch file `https://repo.voidlinux.eu/current/x86_64-musl-repodata': Not Found
[*] Updating `https://repo.voidlinux.eu/current/nonfree/x86_64-musl-repodata' ...
ERROR: [reposync] failed to fetch file `https://repo.voidlinux.eu/current/nonfree/x86_64-musl-repodata': Not Found
[*] Updating `https://repo.voidlinux.eu/current/aarch64/x86_64-musl-repodata' ...
ERROR: [reposync] failed to fetch file `https://repo.voidlinux.eu/current/aarch64/x86_64-musl-repodata': Not Found
=> xbanish-1.6_1: removing autodeps, please wait...
=> xbanish-1.6_1: building [gnu-makefile] ...
   [target] libXfixes-devel-5.0.3_3: found (https://repo.voidlinux.eu/current/musl)
   [target] libXt-devel-1.1.5_3: found (https://repo.voidlinux.eu/current/musl)
   [target] libXi-devel-1.7.9_2: found (https://repo.voidlinux.eu/current/musl)
   [target] libX11-devel-1.6.6_1: found (https://repo.voidlinux.eu/current/musl)
=> xbanish-1.6_1: installing target dependency 'libXfixes-devel-5.0.3_3' ...
=> xbanish-1.6_1: installing target dependency 'libXt-devel-1.1.5_3' ...
=> xbanish-1.6_1: installing target dependency 'libXi-devel-1.7.9_2' ...
=> xbanish-1.6_1: installing target dependency 'libX11-devel-1.6.6_1' ...
=> xbanish-1.6_1: running do-fetch hook: 00-distfiles ...
=> xbanish-1.6_1: using known distfile v1.6.tar.gz.
=> xbanish-1.6_1: verifying checksum for distfile 'v1.6.tar.gz'... OK.
=> xbanish-1.6_1: running do-extract hook: 00-distfiles ...
=> xbanish-1.6_1: extracting distfile(s), please wait...
=> xbanish-1.6_1: running post-extract hook: 00-patches ...
=> xbanish-1.6_1: running pre-configure hook: 00-gnu-configure-asneeded ...
=> xbanish-1.6_1: running pre-configure hook: 01-override-config ...
=> xbanish-1.6_1: running pre-configure hook: 02-script-wrapper ...
=> xbanish-1.6_1: running pre-build hook: 02-script-wrapper ...
=> xbanish-1.6_1: running pre_build ...
=> xbanish-1.6_1: running do_build ...
cc -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe    -I/usr/X11R6/include -c xbanish.c -o xbanish.o
cc xbanish.o -L/usr/X11R6/lib -Wl,-z,relro -Wl,-z,now -Wl,--as-needed     -lX11 -lXfixes -lXi -o xbanish
=> xbanish-1.6_1: skipping check (XBPS_CHECK_PKGS is disabled) ...
=> xbanish-1.6_1: running pre-install hook: 00-lib32 ...
=> xbanish-1.6_1: running pre-install hook: 02-script-wrapper ...
=> xbanish-1.6_1: running do_install ...
=> xbanish-1.6_1: running post-install hook: 00-compress-info-files ...
=> xbanish-1.6_1: running post-install hook: 00-uncompress-manpages ...
=> xbanish-1.6_1: running post-install hook: 01-remove-localized-manpages ...
=> xbanish-1.6_1: running post-install hook: 01-remove-misc ...
=> xbanish-1.6_1: running post-install hook: 02-remove-libtool-archives ...
=> xbanish-1.6_1: running post-install hook: 02-remove-perl-files ...
=> xbanish-1.6_1: running post-install hook: 02-remove-python-bytecode-files ...
=> xbanish-1.6_1: running post-install hook: 03-remove-empty-dirs ...
=> xbanish-1.6_1: running post-install hook: 04-create-xbps-metadata-scripts ...
=> xbanish-1.6_1: running post-install hook: 05-generate-gitrevs ...
=> xbanish-1.6_1: running post-install hook: 06-strip-and-debug-pkgs ...
   Stripped position-independent executable: /usr/bin/xbanish
=> xbanish-1.6_1: running post-install hook: 98-lib32 ...
=> xbanish-1.6_1: running pre-pkg hook: 03-rewrite-python-shebang ...
=> xbanish-1.6_1: running pre-pkg hook: 04-generate-runtime-deps ...
   SONAME: libX11.so.6 <-> libX11>=1.2_1
   SONAME: libXfixes.so.3 <-> libXfixes>=4.0.3_1
   SONAME: libXi.so.6 <-> libXi>=1.2.1_1
   SONAME: libc.so <-> musl>=0.9.9_1
=> xbanish-1.6_1: running pre-pkg hook: 05-prepare-32bit ...
=> xbanish-1.6_1: running pre-pkg hook: 06-shlib-provides ...
=> xbanish-1.6_1: running pre-pkg hook: 90-set-timestamps ...
=> xbanish-1.6_1: setting mtimes to Fri Aug 31 18:00:44 UTC 2018
=> xbanish-1.6_1: running pre-pkg hook: 99-pkglint ...
=> xbanish-1.6_1: running do-pkg hook: 00-gen-pkg ...
=> xbanish-1.6_1: skipping existing xbanish-1.6_1.x86_64-musl.xbps pkg...
=> xbanish-1.6_1: running post-pkg hook: 00-register-pkg ...
=> Registering xbanish-1.6_1.x86_64-musl.xbps into /host/binpkgs ...
index: skipping `xbanish-1.6_1' (x86_64-musl), already registered.
index: 1 packages registered.
=> xbanish-1.6_1: removing autodeps, please wait...
=> xbanish-1.6_1: cleaning build directory...
=> xbanish: removing files from destdir...
```

Installed new version

```
dave - temple linux ~/dev/void-packages (git:master) $ sudo xbps-install --repository=hostdir/binpkgs xbanish

Name    Action    Version           New version            Download size
xbanish update    1.5_1             1.6_1                  - 

Size required on disk:          125B
Space available on disk:       222GB

Do you want to continue? [Y/n] 

[*] Downloading binary packages

[*] Verifying package integrity
xbanish-1.6_1: verifying SHA256 hash...

[*] Running transaction tasks
xbanish-1.5_1: updating to 1.6_1 ...
xbanish-1.6_1: unpacking ...

[*] Configuring unpacked packages
xbanish-1.6_1: configuring ...
xbanish-1.6_1: updated successfully.

0 downloaded, 0 installed, 1 updated, 0 configured, 0 removed.
```

it works!

```
dave - temple linux ~/dev/void-packages (git:master) $ xbanish -h
xbanish: unrecognized option: h
usage: xbanish [-d] [-i mod]
```