### PR TITLE
kitty: update to 0.12.0

### DIFF
--- a/srcpkgs/kitty/patches/python-compile-workers.patch
+++ b/srcpkgs/kitty/patches/python-compile-workers.patch
@@ -1,11 +1,11 @@
---- setup.py	2018-05-04 21:16:28.000000000 -0700
-+++ setup.py	2018-05-05 06:30:39.111289470 -0700
-@@ -559,7 +559,7 @@
-     shutil.copytree('kitty', os.path.join(libdir, 'kitty'), ignore=src_ignore)
-     shutil.copytree('kittens', os.path.join(libdir, 'kittens'), ignore=src_ignore)
-     import compileall
--    compileall.compile_dir(libdir, quiet=1, workers=4)
-+    compileall.compile_dir(libdir, quiet=1, workers=1)
-     for root, dirs, files in os.walk(libdir):
+--- setup.py
++++ setup.py
+@@ -584,7 +584,7 @@ def compile_python(base_path):
          for f in files:
-             path = os.path.join(root, f)
+             if f.rpartition('.')[-1] in ('pyc', 'pyo'):
+                 os.remove(os.path.join(root, f))
+-    compileall.compile_dir(base_path, ddir='', force=True, optimize=1, quiet=1, workers=num_workers)
++    compileall.compile_dir(base_path, ddir='', force=True, optimize=1, quiet=1, workers=1)
+ 
+ 
+ def package(args, for_bundle=False, sh_launcher=False):

--- a/srcpkgs/kitty/template
+++ b/srcpkgs/kitty/template
@@ -1,19 +1,18 @@
 # Template file for 'kitty'
 pkgname=kitty
-version=0.11.3
+version=0.12.0
 revision=1
 python_version=3
 hostmakedepends="ncurses pkg-config"
 makedepends="gettext-devel glfw-devel harfbuzz-devel libxkbcommon-devel
  python3-devel wayland-devel wayland-protocols"
 depends="kitty-terminfo"
-conf_files="/etc/kitty/kitty.conf"
 short_desc="Modern, hackable, featureful, OpenGL based terminal emulator"
 maintainer="Benjamin Slade <slade@jnanam.net>"
 license="GPL-3.0-or-later"
 homepage="https://sw.kovidgoyal.net/kitty/"
 distfiles="https://github.com/kovidgoyal/kitty/releases/download/v${version}/kitty-${version}.tar.xz"
-checksum=e36e3d777824030b686003fbf20c1861efb8183e43bf3efc9cb8f92a0aa9a10e
+checksum=21f59e458980c0f2c977f4dcc8f7ac287c49f0315ed7a21dcbcb341691f430d1
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python3-devel wayland-devel wayland-protocols"
@@ -32,8 +31,7 @@ do_build() {
 }
 
 do_install() {
-	vmkdir etc/kitty
-	cp ${DESTDIR}/usr/share/doc/kitty/html/_downloads/kitty.conf ${DESTDIR}/etc/kitty/
+	vsconf ${DESTDIR}/usr/share/doc/kitty/html/_downloads/kitty.conf
 }
 
 kitty-terminfo_package() {


### PR DESCRIPTION
~~`python-compile-workers.patch` removed since number of workers isn't hardcoded anymore.~~ nvm

changed included `conf` file to be used as an example instead of system-wide config file, since it contains all default values so adds nothing except additional config parsing pass.