### PR TITLE
Migrate mirrors to .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ xbps-src can be used in any recent Linux distribution matching the CPU architect
 
 To use xbps-src in your Linux distribution use the following instructions. Let's start downloading the xbps static binaries:
 
-    $ wget http://repo.voidlinux.eu/static/xbps-static-latest.<arch>-musl.tar.xz
+    $ wget http://alpha.de.repo.voidlinux.org/static/xbps-static-latest.<arch>-musl.tar.xz
     $ mkdir ~/XBPS
     $ tar xvf xbps-static-latest.<arch>.tar.xz -C ~/XBPS
     $ export PATH=~/XBPS/usr/bin:$PATH

--- a/common/travis/prepare.sh
+++ b/common/travis/prepare.sh
@@ -5,7 +5,7 @@
 mkdir -p $HOME/bin
 
 /bin/echo -e '\x1b[32mInstalling xbps...\x1b[0m'
-wget -q -O - http://repo.voidlinux.eu/static/xbps-static-latest.x86_64-musl.tar.xz | \
+wget -q -O - http://alpha.de.repo.voidlinux.org/static/xbps-static-latest.x86_64-musl.tar.xz | \
 	unxz | tar x -C $HOME/bin --wildcards "./usr/bin/xbps-*" \
 	--strip-components=3 || exit 1
 

--- a/common/travis/set_mirror.sh
+++ b/common/travis/set_mirror.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-TRAVIS_PROTO=https
-TRAVIS_MIRROR=beta.de.repo.voidlinux.org
+TRAVIS_PROTO=http
+TRAVIS_MIRROR=alpha.us.repo.voidlinux.org
 
 for _i in etc/repos-remote.conf etc/defaults.conf etc/repos-remote-x86_64.conf ; do
     printf '\x1b[32mUpdating %s...\x1b[0m\n' $_i
@@ -11,5 +11,5 @@ for _i in etc/repos-remote.conf etc/defaults.conf etc/repos-remote-x86_64.conf ;
     sed -i "s:https:$TRAVIS_PROTO:g" $_i
 
     # Now set the mirror
-    sed -i "s:repo\.voidlinux\.eu:$TRAVIS_MIRROR:g" $_i
+    sed -i "s:alpha\.de\.repo\.voidlinux\.org:$TRAVIS_MIRROR:g" $_i
 done

--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -17,7 +17,7 @@
 # [OPTIONAL]
 # Enable optional arguments to xbps-install for the host system.
 # Currently used in the binary-bootstrap bootstrap-update targets.
-XBPS_INSTALL_ARGS="--repository=https://repo.voidlinux.eu/current --repository=https://repo.voidlinux.eu/current/musl --repository=https://repo.voidlinux.eu/current/aarch64"
+XBPS_INSTALL_ARGS="--repository=https://alpha.de.repo.voidlinux.org/current --repository=https://alpha.de.repo.voidlinux.org/current/musl --repository=https://alpha.de.repo.voidlinux.org/current/aarch64"
 
 # [OPTIONAL]
 # Native Compilation/Preprocessor flags for C and C++. Additional settings

--- a/etc/repos-remote-x86_64.conf
+++ b/etc/repos-remote-x86_64.conf
@@ -1,3 +1,3 @@
 # Remote repositories
-repository=https://repo.voidlinux.eu/current/multilib
-repository=https://repo.voidlinux.eu/current/multilib/nonfree
+repository=https://alpha.de.repo.voidlinux.org/current/multilib
+repository=https://alpha.de.repo.voidlinux.org/current/multilib/nonfree

--- a/etc/repos-remote.conf
+++ b/etc/repos-remote.conf
@@ -1,9 +1,9 @@
 # Remote repositories
-repository=https://repo.voidlinux.eu/current/musl
-repository=https://repo.voidlinux.eu/current/musl/nonfree
-repository=https://repo.voidlinux.eu/current
-repository=https://repo.voidlinux.eu/current/nonfree
-repository=https://repo.voidlinux.eu/current/aarch64
+repository=https://alpha.de.repo.voidlinux.org/current/musl
+repository=https://alpha.de.repo.voidlinux.org/current/musl/nonfree
+repository=https://alpha.de.repo.voidlinux.org/current
+repository=https://alpha.de.repo.voidlinux.org/current/nonfree
+repository=https://alpha.de.repo.voidlinux.org/current/aarch64
 
 # Additional mirrors
 #

--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -16,7 +16,7 @@ nocross=yes
 case "$XBPS_MACHINE" in
 x86_64-musl)
 	distfiles+="
-	 https://repo.voidlinux.eu/distfiles/cargo-0.29.0-x86_64-unknown-linux-musl-libgit2-27.tar.gz"
+	 https://alpha.de.repo.voidlinux.org/distfiles/cargo-0.29.0-x86_64-unknown-linux-musl-libgit2-27.tar.gz"
 	checksum+="
 	 a46cb16e1008032277d744b74cba16a107539b12b8fbfd763c4cc1f80ee5568c"
 	;;

--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -20,7 +20,7 @@ x86_64)
 	;;
 x86_64-musl)
 	# create with "make binary-dist"
-	distfiles="https://repo.voidlinux.eu/distfiles/ghc-${version}-x86_64-void-linux-musl.tar.xz"
+	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-x86_64-void-linux-musl.tar.xz"
 	checksum=52d72673f3213a9f629f441583c58fad099fa8827a3e86ecddadf4f8334031f9
 	;;
 i686)

--- a/srcpkgs/lxc/files/lxc-void
+++ b/srcpkgs/lxc/files/lxc-void
@@ -154,7 +154,7 @@ EOF
     rm -f ${vkb64}
 
     mkdir -p ${rootfs}/usr/share/xbps.d
-    echo "repository=http://repo.voidlinux.eu/current" > ${rootfs}/usr/share/xbps.d/00-repository-main.conf
+    echo "repository=http://alpha.de.repo.voidlinux.org/current" > ${rootfs}/usr/share/xbps.d/00-repository-main.conf
 
     if ! xbps-install ${xbps_cachedir:+ -c $xbps_cachedir} \
 	    ${xbps_config:+-C $xbps_config} -r "${rootfs}" \
@@ -232,7 +232,7 @@ fi
 
 type xbps-install >/dev/null 2>&1
 if [ ${?} -ne 0 ]; then
-    echo "'xbps-install' command is missing, download xbps from http://repo.voidlinux.eu/static/"
+    echo "'xbps-install' command is missing, download xbps from http://alpha.de.repo.voidlinux.org/static/"
     exit 1
 fi
 

--- a/srcpkgs/lxc/template
+++ b/srcpkgs/lxc/template
@@ -3,7 +3,7 @@ _desc="Linux Containers"
 
 pkgname=lxc
 version=3.0.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-doc --enable-seccomp
  --enable-capabilities --enable-apparmor --with-distro=none

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -5,7 +5,7 @@ revision=1
 _rust_dist_version=1.27.2
 _cargo_dist_version=0.29.0
 # NB. if you push any(!) new version, don't forget to put a build
-# output of musl to https://repo.voidlinux.eu/distfiles/
+# output of musl to https://alpha.de.repo.voidlinux.org/distfiles/
 wrksrc="rustc-${version}-src"
 lib32disabled=yes
 patch_args="-Np1"
@@ -26,9 +26,9 @@ case "$XBPS_MACHINE" in
 x86_64-musl)
 	hostmakedepends+=" libcurl libgit2"
 	distfiles+="
-	 https://repo.voidlinux.eu/distfiles/rustc-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.xz
-	 https://repo.voidlinux.eu/distfiles/rust-std-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.xz
-	 https://repo.voidlinux.eu/distfiles/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.gz"
+	 https://alpha.de.repo.voidlinux.org/distfiles/rustc-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.xz
+	 https://alpha.de.repo.voidlinux.org/distfiles/rust-std-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.xz
+	 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.gz"
 	checksum+="
 	 2da811f9a81f63a93d62cefe15f391efaff663438f2c364fd1a522ef576753f4
 	 e18aea5529d434e0950a77c266c3230ea878e3f3ea8b4114ee5a081092f98037

--- a/srcpkgs/void-repo-multilib/template
+++ b/srcpkgs/void-repo-multilib/template
@@ -1,7 +1,7 @@
 # Template file for 'void-repo-multilib'
 pkgname=void-repo-multilib
 version=6
-revision=1
+revision=2
 build_style=meta
 only_for_archs="x86_64"
 short_desc="Void Linux drop-in file for the multilib repository"
@@ -12,7 +12,7 @@ homepage="http://www.voidlinux.eu"
 do_install() {
 	vmkdir usr/share/xbps.d
 	for f in multilib multilib-nonfree; do
-		echo "repository=https://repo.voidlinux.eu/current/${f/-/\/}" > \
+		echo "repository=https://alpha.de.repo.voidlinux.org/current/${f/-/\/}" > \
 			${DESTDIR}/usr/share/xbps.d/10-repository-${f}.conf
 	done
 }

--- a/srcpkgs/void-repo-nonfree/template
+++ b/srcpkgs/void-repo-nonfree/template
@@ -1,7 +1,7 @@
 # Template file for 'void-repo-nonfree'
 pkgname=void-repo-nonfree
 version=9
-revision=1
+revision=2
 noarch=yes
 build_style=meta
 short_desc="Void Linux drop-in file for the nonfree repository"
@@ -13,15 +13,15 @@ do_install() {
 	vmkdir usr/share/xbps.d
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl)
-			echo "repository=https://repo.voidlinux.eu/current/musl/nonfree" > \
+			echo "repository=https://alpha.de.repo.voidlinux.org/current/musl/nonfree" > \
 				${DESTDIR}/usr/share/xbps.d/10-repository-nonfree.conf
-			echo "repository=https://repo.voidlinux.eu/current/musl/debug" > \
+			echo "repository=https://alpha.de.repo.voidlinux.org/current/musl/debug" > \
 				${DESTDIR}/usr/share/xbps.d/20-repository-debug.conf
 			;;
 		*)
-			echo "repository=https://repo.voidlinux.eu/current/nonfree" > \
+			echo "repository=https://alpha.de.repo.voidlinux.org/current/nonfree" > \
 				${DESTDIR}/usr/share/xbps.d/10-repository-nonfree.conf
-			echo "repository=https://repo.voidlinux.eu/current/debug" > \
+			echo "repository=https://alpha.de.repo.voidlinux.org/current/debug" > \
 				${DESTDIR}/usr/share/xbps.d/20-repository-debug.conf
 			;;
 	esac

--- a/srcpkgs/xbps/template
+++ b/srcpkgs/xbps/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps'
 pkgname=xbps
 version=0.53
-revision=5
+revision=6
 bootstrap=yes
 build_style=configure
 short_desc="The XBPS package system utilities"
@@ -33,15 +33,15 @@ do_configure() {
 post_install() {
 	case "$XBPS_TARGET_MACHINE" in
 	aarch64*) # XXX different repo location
-		echo "repository=https://repo.voidlinux.eu/current/aarch64" > \
+		echo "repository=https://alpha.de.repo.voidlinux.org/current/aarch64" > \
 			${DESTDIR}/usr/share/xbps.d/00-repository-main.conf
 		;;
 	*-musl) # XXX different repo location
-		echo "repository=https://repo.voidlinux.eu/current/musl" > \
+		echo "repository=https://alpha.de.repo.voidlinux.org/current/musl" > \
 			${DESTDIR}/usr/share/xbps.d/00-repository-main.conf
 		;;
 	*)
-		echo "repository=https://repo.voidlinux.eu/current" > \
+		echo "repository=https://alpha.de.repo.voidlinux.org/current" > \
 			${DESTDIR}/usr/share/xbps.d/00-repository-main.conf
 		;;
 	esac


### PR DESCRIPTION
This chain should change the default provided mirror from .eu to .org for all packages that reference it, and should change travis as well.