### PR TITLE
gnome-desktop: depend on bubblewrap

### DIFF
--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,14 +1,14 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
 version=3.28.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-gnome-distributor=VoidLinux"
 hostmakedepends="gnome-doc-utils intltool itstool pkg-config
  $(vopt_if gir 'gobject-introspection')"
 makedepends="gsettings-desktop-schemas-devel gtk+3-devel iso-codes
  libseccomp-devel libxkbfile-devel"
-depends="gsettings-desktop-schemas iso-codes xkeyboard-config"
+depends="bubblewrap gsettings-desktop-schemas iso-codes xkeyboard-config"
 short_desc="GNOME desktop management utilities"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"


### PR DESCRIPTION
Although it's not strictly required, gnome-desktop
auto-detects bwrap during run-time and uses it
to sandbox thumbnail generation. Without bwrap
bugs like [1] can be exploited.

1: https://www.exploit-db.com/exploits/45243/