### PR TITLE
rpi-kernel: update to 4.14.67.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="ceeaae1f33060be3fc26344a0a73c8c0c74db086"
+_githash="55de35d3035993f8c17851cc4ddcdf0df3742c74"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.66
+version=4.14.67
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=308e5d76a316d02220df852adce94e069d2b50809d5a13fb2af5ae730a2dff44
+checksum=4dc42cdd885cd297b3b36834a6086e1a3bbda7e669f9a307fe7c1cadfdb0b246
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]