### PR TITLE
wxWidgets: build against webkit2gtk instead of webkitgtk2

### DIFF
--- a/srcpkgs/wxWidgets/template
+++ b/srcpkgs/wxWidgets/template
@@ -1,13 +1,13 @@
 # Template file for 'wxWidgets'
 pkgname=wxWidgets
 version=3.0.4
-revision=5
+revision=6
 configure_args="--enable-unicode --with-opengl --with-sdl --with-libmspack
  --with-libnotify --enable-mediactrl"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel libjpeg-turbo-devel tiff-devel libSM-devel libnotify-devel
- libXinerama-devel libmspack-devel SDL2-devel glu-devel webkitgtk2-devel
+ libXinerama-devel libmspack-devel SDL2-devel glu-devel webkit2gtk-devel
  gstreamer1-devel gst-plugins-base1-devel"
 short_desc="The wxWidgets GUI toolkit library (version 3)"
 maintainer="Martin Riese <grauehaare@gmx.de>"


### PR DESCRIPTION
It's possible to build against webkit2gtk since 3.0.4.
Webkitgtk2 isn't maintained anymore and has many security
vulnerabilities.