### PR TITLE
use make_dirs instead of .empty for empty directories

### DIFF
--- a/srcpkgs/GConf/template
+++ b/srcpkgs/GConf/template
@@ -1,7 +1,7 @@
 # Template file for 'GConf'
 pkgname=GConf
 version=3.2.6
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--without-openldap --enable-gtk --enable-defaults-service
  --disable-orbit --enable-gsettings-backend --disable-static --disable-gtk-doc-html
@@ -17,6 +17,10 @@ homepage="http://projects.gnome.org/gconf"
 license="GPL-2"
 distfiles="${GNOME_SITE}/GConf/3.2/GConf-${version}.tar.xz"
 checksum=1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c
+make_dirs="/usr/share/gconf/schemas 0755 root root
+ /etc/gconf/gconf.xml.defaults 0755 root root
+ /etc/gconf/gconf.xml.mandatory 0755 root root
+ /etc/gconf/gconf.xml.system 0755 root root"
 
 # Package build options
 build_options="gir"
@@ -28,17 +32,6 @@ fi
 
 pre_configure() {
 	autoreconf -if
-}
-
-post_install() {
-	# Create GCONF_SCHEMAS_DIR
-	vmkdir usr/share/gconf/schemas
-	touch -f ${DESTDIR}/usr/share/gconf/schemas/.empty_on_purpose
-	# Create required sysconfdir dirs.
-	for d in defaults mandatory system; do
-		vmkdir etc/gconf/gconf.xml.${d}
-		touch -f ${DESTDIR}/etc/gconf/gconf.xml.${d}/.empty_on_purpose
-	done
 }
 
 GConf-devel_package() {

--- a/srcpkgs/burp-server/template
+++ b/srcpkgs/burp-server/template
@@ -3,7 +3,7 @@ _desc="A network-based backup and restore program"
 
 pkgname=burp-server
 version=1.4.40
-revision=8
+revision=9
 short_desc="${_desc} - Server"
 maintainer="Pierre Bourgin <pierre.bourgin@free.fr>"
 license="AGPL-3.0-only, BSD-3-Clause, GPL-2.0-or-later"
@@ -25,6 +25,8 @@ build_style=gnu-configure
 configure_args="--sysconfdir=/etc/burp --sbindir=/usr/bin"
 conf_files="/etc/burp/burp-server.conf"
 
+make_dirs="/var/spool/burp 0755 root root"
+
 post_install() {
 	vsv ${pkgname}
 
@@ -35,9 +37,6 @@ post_install() {
 	# /usr/sbin/burp_ca is hardcoded in conf files
 	sed -e "s,/usr/sbin/burp_ca,/usr/bin/burp_ca,g" \
 	    -i ${DESTDIR}/etc/burp/burp-server.conf
-
-	# storage folder
-	touch -f ${PKGDESTDIR}/var/spool/burp/.empty_on_purpose
 }
 
 burp-client_package() {
@@ -45,6 +44,7 @@ burp-client_package() {
 	# openssl binary needed by burp_ca script
 	depends="ca-certificates"
 	conf_files="/etc/burp/burp.conf"
+	make_dirs="/etc/burp/CA-client 0755 root root"
 	pkg_install() {
 		vmove "usr/bin/burp"
 		vmove "usr/bin/burp_ca"
@@ -58,8 +58,5 @@ burp-client_package() {
 		# /usr/sbin/burp_ca is hardcoded in conf files
 		sed -e "s,/usr/sbin/burp_ca,/usr/bin/burp_ca,g" \
 		    -i ${PKGDESTDIR}/etc/burp/burp.conf
-
-		# burp_ca requires directory CA-client
-		touch -f ${PKGDESTDIR}/etc/burp/CA-client/.empty_on_purpose
 	}
 }

--- a/srcpkgs/burp2-server/template
+++ b/srcpkgs/burp2-server/template
@@ -3,7 +3,7 @@ _desc="A network-based backup and restore program"
 
 pkgname=burp2-server
 version=2.1.32
-revision=2
+revision=3
 configure_args="--sysconfdir=/etc/burp --sbindir=/usr/bin"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
@@ -21,8 +21,9 @@ distfiles="https://github.com/grke/burp/archive/${version}.tar.gz"
 checksum=1b2299670032eb5f0fc0783b7989b1cc6227d3d0758452a42b50d167b63d8d30
 
 # 'install-all': also install config files and scripts
-make_install_target="install-all"
+make_install_target=install-all
 conf_files="/etc/burp/burp-server.conf"
+make_dirs="/var/spool/burp 0755 root root"
 
 pre_configure() {
 	autoreconf -fi
@@ -34,9 +35,6 @@ post_install() {
 	vdoc "README"
 	vdoc "UPGRADING"
 	vlicense "LICENSE"
-
-	# storage folder
-	touch -f ${PKGDESTDIR}/var/spool/burp/.empty_on_purpose
 
 	# files for -doc package
 	_docdir="usr/share/examples/burp-doc"
@@ -66,6 +64,7 @@ burp2-client_package() {
 	# burp2-client (v2.x) does not work with burp-server (v1.x):
 	# give a chance to no break everything by refusing upgrade
 	conflicts="burp-client"
+	make_dirs="/etc/burp/CA-client 0755 root root"
 	pkg_install() {
 		vmove "usr/bin/burp"
 		vmove "usr/bin/burp_ca"
@@ -75,9 +74,6 @@ burp2-client_package() {
 		vmove "etc/burp/burp.conf"
 		vdoc "README"
 		vlicense "LICENSE"
-
-		# burp_ca requires directory CA-client
-		touch -f ${PKGDESTDIR}/etc/burp/CA-client/.empty_on_purpose
 	}
 }
 

--- a/srcpkgs/dropbear/template
+++ b/srcpkgs/dropbear/template
@@ -1,8 +1,8 @@
 # Template file for 'dropbear'
 pkgname=dropbear
 version=2018.76
-revision=1
-build_style="gnu-configure"
+revision=2
+build_style=gnu-configure
 configure_args="--enable-zlib"
 makedepends="zlib-devel"
 short_desc="Small SSH server and client"
@@ -11,10 +11,9 @@ license="MIT"
 homepage="https://matt.ucc.asn.au/dropbear/dropbear.html"
 distfiles="https://matt.ucc.asn.au/${pkgname}/releases/${pkgname}-${version}.tar.bz2"
 checksum=f2fb9167eca8cf93456a5fc1d4faf709902a3ab70dd44e352f3acbc3ffdaea65
+make_dirs="/etc/dropbear 0755 root root"
 
 post_install() {
-	vmkdir etc/dropbear
-	touch ${DESTDIR}/etc/dropbear/.empty
 	vsv dropbear
 	vlicense LICENSE
 }

--- a/srcpkgs/libpaper/template
+++ b/srcpkgs/libpaper/template
@@ -1,7 +1,7 @@
 # Template file for 'libpaper'
 pkgname=libpaper
 version=1.1.24+nmu5
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 conf_files="/etc/papersize"
@@ -11,6 +11,7 @@ license="GPL-2"
 homepage="http://packages.debian.org/unstable/source/libpaper"
 distfiles="${DEBIAN_SITE}/main/libp/${pkgname}/${pkgname}_${version}.tar.gz"
 checksum=e29deda4cd7350189c71af0925cbf4a4473f9841d1419a922e1e8ff1954db1f2
+make_dirs="/etc/libpaper.d 0755 root root"
 
 pre_configure() {
 	autoreconf -fi
@@ -20,10 +21,6 @@ post_install() {
 	# add systemwide default papersize read by many office applications
 	vmkdir etc
 	echo '# Simply write the paper name. See papersize(5) for possible values' > ${DESTDIR}/etc/papersize
-
-	# add libpaper.d directory other packages can use to store files
-	vmkdir etc/libpaper.d
-	touch ${DESTDIR}/etc/libpaper.d/.empty
 
 	# add localisation
 	cd debian/po

--- a/srcpkgs/ppp/template
+++ b/srcpkgs/ppp/template
@@ -1,15 +1,16 @@
 # Template file for 'ppp'
 pkgname=ppp
 version=2.4.7
-revision=7
+revision=8
+makedepends="libpcap-devel"
 short_desc="PPP (Point-to-Point Protocol) daemon"
 homepage="https://ppp.samba.org/"
-license="BSD, LGPLv2+, GPLv2+, Public Domain"
+license="BSD-3-Clause, LGPL-2.0-or-later, GPL-2.0-or-later, Public Domain"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="https://ftp.samba.org/pub/ppp/ppp-$version.tar.gz"
 checksum=02e0a3dd3e4799e33103f70ec7df75348c8540966ee7c948e4ed8a42bbccfb30
-
-makedepends="libpcap-devel"
+make_dirs="/etc/ppp/ipv6-down.d 0755 root root
+ /etc/ppp/peers 0755 root root"
 conf_files="
 	/etc/ppp/ip-up
 	/etc/ppp/ip-down
@@ -41,9 +42,11 @@ do_configure() {
 
 	./configure ${configure_args}
 }
+
 do_build() {
 	make COPTS="${CFLAGS} ${LDFLAGS}" ${makejobs}
 }
+
 do_install() {
 	make DESTDIR=${DESTDIR}/usr install
 
@@ -55,7 +58,7 @@ do_install() {
 
 	vmkdir usr/bin
 	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
-	vbin pppd/pppd 
+	vbin pppd/pppd
 	vbin chat/chat
 
 	vinstall ${FILESDIR}/options 644 etc/ppp
@@ -67,8 +70,6 @@ do_install() {
 	vinstall ${FILESDIR}/ip-up.d.dns.sh 755 etc/ppp/ip-up.d 00-dns.sh
 	vinstall ${FILESDIR}/ip-down.d.dns.sh 755 etc/ppp/ip-down.d 00-dns.sh
 	vinstall ${FILESDIR}/ipv6-up.d.iface-config.sh 755 etc/ppp/ipv6-up.d  00-iface-config.sh
-	vmkdir etc/ppp/ipv6-down.d
-	touch ${DESTDIR}/etc/ppp/ipv6-down.d/.empty_on_purpose
 
 	vbin scripts/pon
 	vman scripts/pon.1
@@ -77,9 +78,6 @@ do_install() {
 
 	vinstall etc.ppp/pap-secrets 600 etc/ppp
 	vinstall etc.ppp/chap-secrets 600 etc/ppp
-
-	vmkdir etc/ppp/peers
-	touch -f ${DESTDIR}/etc/ppp/peers/.empty_on_purpose
 }
 
 ppp-devel_package() {

--- a/srcpkgs/rarian/template
+++ b/srcpkgs/rarian/template
@@ -1,20 +1,17 @@
 # Template file for 'rarian'
 pkgname=rarian
 version=0.8.1
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="pkg-config libxslt"
 depends="bash"
 short_desc="Documentation metadata library"
-homepage="http://rarian.freedesktop.org/"
-license="LGPL-2.1"
-distfiles="${GNOME_SITE}/$pkgname/0.8/$pkgname-$version.tar.bz2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
+homepage="http://rarian.freedesktop.org/"
+distfiles="${GNOME_SITE}/${pkgname}/0.8/${pkgname}-${version}.tar.bz2"
 checksum=aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577
-
-post_install() {
-	touch -f ${DESTDIR}/var/lib/rarian/.empty_on_purpose
-}
+make_dirs="/var/lib/rarian 0755 root root"
 
 rarian-devel_package() {
 	depends="rarian>=${version}_${revision}"

--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,7 +1,7 @@
 # Template file for 'strongswan'
 pkgname=strongswan
 version=5.6.3
-revision=1
+revision=2
 build_style=gnu-configure
 # tpm support waits on libtss2
 configure_args="--disable-static --enable-blowfish --enable-curl
@@ -19,15 +19,16 @@ homepage="https://www.strongswan.org/"
 changelog="https://wiki.strongswan.org/projects/strongswan/wiki/Changelog"
 distfiles="https://download.strongswan.org/${pkgname}-${version}.tar.bz2"
 checksum=c3c7dc8201f40625bba92ffd32eb602a8909210d8b3fac4d214c737ce079bf24
+make_dirs="/etc/ipsec.d/ 0755 root root
+ /etc/ipsec.d/aacerts 0755 root root
+ /etc/ipsec.d/acerts 0755 root root
+ /etc/ipsec.d/cacerts 0755 root root
+ /etc/ipsec.d/oscpcerts 0755 root root
+ /etc/ipsec.d/certs 0755 root root
+ /etc/ipsec.d/crls 0755 root root
+ /etc/ipsec.d/reqs 0755 root root
+ /etc/ipsec.d/private 0750 root root"
 
 post_install() {
-	touch .empty
-	# ipsec.d/{,aacerts,acerts,cacerts,certs,crls,oscpcerts,reqs}
-	for dir in /etc/ipsec.d/{,{aa,a,ca,oscp,}certs,crls,reqs}; do
-		vmkdir "$dir"
-		vcopy .empty "$dir"
-	done
-	vmkdir /etc/ipsec.d/private 750
-	vcopy .empty /etc/ipsec.d/private/
 	vsv strongswan
 }

--- a/srcpkgs/vscl/template
+++ b/srcpkgs/vscl/template
@@ -1,7 +1,7 @@
 # Template file for 'vscl'
 pkgname=vscl
 version=6.1.0
-revision=1
+revision=2
 build_style=fetch
 create_wrksrc=yes
 short_desc="McAfee VirusScan Command Line for Linux"
@@ -17,6 +17,7 @@ noshlibprovides=yes
 lib32disabled=yes
 homepage="https://www.mcafee.com/"
 conf_files="/etc/vscl.conf"
+make_dirs="/usr/share/vscl 0755 root root"
 
 _libdir="usr/libexec/${pkgname}"
 _datadir="usr/share/${pkgname}"
@@ -52,9 +53,6 @@ do_extract() {
 
 do_install() {
 	vmkdir ${_libdir}
-	vmkdir ${_datadir}
-
-	touch ${DESTDIR}/${_datadir}/.empty
 
 	vbin ${FILESDIR}/vscl
 	sed -i "s|_libdir|${_libdir}|g" ${DESTDIR}/usr/bin/vscl

--- a/srcpkgs/xbps/template
+++ b/srcpkgs/xbps/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps'
 pkgname=xbps
 version=0.53
-revision=6
+revision=7
 bootstrap=yes
 build_style=configure
 short_desc="The XBPS package system utilities"
@@ -14,6 +14,8 @@ checksum=360b3149141fec46dd6da9019605bcee48ee4d29bffe5aa47a9fd5fa68ccd5f4
 hostmakedepends="pkg-config"
 makedepends="zlib-devel libressl-devel libarchive-devel"
 depends="ca-certificates xbps-triggers"
+
+make_dirs="/etc/xbps.d 0755 root root"
 
 if [ "$CHROOT_READY" ]; then
 	makedepends+=" atf-devel"
@@ -45,8 +47,6 @@ post_install() {
 			${DESTDIR}/usr/share/xbps.d/00-repository-main.conf
 		;;
 	esac
-	vmkdir etc/xbps.d
-	touch ${DESTDIR}/etc/xbps.d/.empty
 	vlicense COPYING
 	vlicense COPYING.3RDPARTY
 }


### PR DESCRIPTION
This PR complete removes usage of .empty to keep empty directories in favour of make_dirs

- [x] vscl
- [x] strongswan
- [x] burp2-server
- [x] burp-server
- [x] rarian
- [x] ppp
- [x] GConf
- [x] dropbear
- [x] libpaper
- [x] xbps