### PR TITLE
New package: libtinfo-6

### DIFF
--- a/srcpkgs/libtinfo/template
+++ b/srcpkgs/libtinfo/template
@@ -1,0 +1,15 @@
+# Template file for 'libtinfo'
+pkgname=libtinfo
+version=6
+revision=1
+depends="ncurses-devel"
+short_desc="symlink to ncurses for use in stack"
+maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
+license="unknown"
+homepage="http://www.gnu.org/software/ncurses/"
+
+do_install() {
+	mkdir -p ${DESTDIR}/usr/lib
+	ln -sf libncursesw.so.${version} -T ${DESTDIR}/usr/lib/libtinfo.so.${version}
+	ln -sf libtinfo.so.${version} -T ${DESTDIR}/usr/lib/libtinfo.so
+}

--- a/srcpkgs/stack/template
+++ b/srcpkgs/stack/template
@@ -1,11 +1,11 @@
 # Template file for 'stack'
 pkgname=stack
 version=1.7.1
-revision=1
+revision=2
 _stackage="lts-12.0"
 hostmakedepends="cabal-install pkg-config unzip"
 makedepends="zlib-devel pcre-devel"
-depends="git iana-etc"
+depends="git iana-etc libtinfo"
 short_desc="Cross-platform program for developing Haskell projects"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="3-clause-BSD"


### PR DESCRIPTION
`stack setup --verbose` fails on my system, complaining about a missing `libtinfo.so.6`. According to https://github.com/commercialhaskell/stack/issues/257#issuecomment-141952652 I could fix this by linking libncursesw to libtinfo, which is what this package does.

I'm not sure if this fix is required or even works anywhere but on my machine, so if someone could test...