### PR TITLE
soundconverter: add drop-gconf.patch

### DIFF
--- a/srcpkgs/soundconverter/patches/drop-gconf.patch
+++ b/srcpkgs/soundconverter/patches/drop-gconf.patch
@@ -1,0 +1,74 @@
+=== modified file 'bin/soundconverter.py'
+--- bin/soundconverter.py	2017-10-29 20:09:01 +0000
++++ bin/soundconverter.py	2018-04-06 11:25:35 +0000
+@@ -66,7 +66,6 @@
+         import gi
+         gi.require_version('Gst', '1.0')
+         gi.require_version('Gtk', '3.0')
+-        gi.require_version('GConf', '2.0')
+         from gi.repository import GObject
+         # force GIL creation - see https://bugzilla.gnome.org/show_bug.cgi?id=710447
+         import threading
+
+=== modified file 'soundconverter/gstreamer.py'
+--- soundconverter/gstreamer.py	2018-03-26 18:14:18 +0000
++++ soundconverter/gstreamer.py	2018-04-06 11:25:35 +0000
+@@ -25,7 +25,7 @@
+ from gettext import gettext as _
+ 
+ import gi
+-from gi.repository import Gst, Gtk, GObject, GConf, Gio
++from gi.repository import Gst, Gtk, GObject, Gio
+ 
+ from soundconverter.fileoperations import vfs_encode_filename, file_encode_filename
+ from soundconverter.fileoperations import unquote_filename, vfs_makedirs, vfs_unlink
+@@ -66,25 +66,29 @@
+ audio_profiles_list = []
+ audio_profiles_dict = {}
+ 
+-_GCONF = GConf.Client.get_default()
+-profiles = _GCONF.all_dirs(_GCONF_PROFILE_LIST_PATH)
+-for name in profiles:
+-    if _GCONF.get_bool(_GCONF_PROFILE_PATH + name + "/active"):
+-        # get profile
+-        description = _GCONF.get_string(_GCONF_PROFILE_PATH + name + "/name")
+-        extension = _GCONF.get_string(_GCONF_PROFILE_PATH + name + "/extension")
+-        pipeline = _GCONF.get_string(_GCONF_PROFILE_PATH + name + "/pipeline")
+-        # check profile validity
+-        if not extension or not pipeline:
+-            continue
+-        if not description:
+-            description = extension
+-        if description in audio_profiles_dict:
+-            continue
+-            # store
+-        profile = description, extension, pipeline
+-        audio_profiles_list.append(profile)
+-        audio_profiles_dict[description] = profile
++try:
++    from gi.repository import GConf
++    _GCONF = GConf.Client.get_default()
++    profiles = _GCONF.all_dirs(_GCONF_PROFILE_LIST_PATH)
++    for name in profiles:
++        if _GCONF.get_bool(_GCONF_PROFILE_PATH + name + "/active"):
++            # get profile
++            description = _GCONF.get_string(_GCONF_PROFILE_PATH + name + "/name")
++            extension = _GCONF.get_string(_GCONF_PROFILE_PATH + name + "/extension")
++            pipeline = _GCONF.get_string(_GCONF_PROFILE_PATH + name + "/pipeline")
++            # check profile validity
++            if not extension or not pipeline:
++                continue
++            if not description:
++                description = extension
++            if description in audio_profiles_dict:
++                continue
++                # store
++            profile = description, extension, pipeline
++            audio_profiles_list.append(profile)
++            audio_profiles_dict[description] = profile
++except ImportError:
++    pass
+ 
+ required_elements = ('decodebin', 'fakesink', 'audioconvert', 'typefind', 'audiorate')
+ for element in required_elements:
+

--- a/srcpkgs/soundconverter/template
+++ b/srcpkgs/soundconverter/template
@@ -1,12 +1,12 @@
 # Template file for 'soundconverter'
 pkgname=soundconverter
 version=3.0.0
-revision=2
+revision=3
 noarch=yes
 build_style=gnu-configure
 hostmakedepends="glib intltool pkg-config python3-gobject"
 makedepends="gtk+3-devel gstreamer1-devel"
-depends="desktop-file-utils GConf gst-plugins-good1 gst-plugins-ugly1
+depends="desktop-file-utils gst-plugins-good1 gst-plugins-ugly1
  hicolor-icon-theme python3-gobject"
 pycompile_dirs="/usr/lib/${pkgname}/python/${pkgname}"
 short_desc="Leading audio file converter for the GNOME Desktop"


### PR DESCRIPTION
This patch is used in [Arch](https://git.archlinux.org/svntogit/community.git/tree/trunk/drop-gconf.patch?h=packages/soundconverter) and [Debian](https://sources.debian.org/patches/soundconverter/3.0.0-2/0002-Only-fetch-profiles-if-GConf-is-still-available.patch/).