### PR TITLE
acct: enable cross build

### DIFF
--- a/srcpkgs/acct/files/locs-glibc
+++ b/srcpkgs/acct/files/locs-glibc
@@ -1,0 +1,4 @@
+WTMP_FILE_LOC=/var/log/wtmp
+ACCT_FILE_LOC=/var/log/account/pacct
+SAVACCT_FILE_LOC=/var/log/account/savacct
+USRACCT_FILE_LOC=/var/log/account/usracct

--- a/srcpkgs/acct/files/locs-musl
+++ b/srcpkgs/acct/files/locs-musl
@@ -1,0 +1,4 @@
+WTMP_FILE_LOC=/dev/null/wtmp
+ACCT_FILE_LOC=/var/log/account/pacct
+SAVACCT_FILE_LOC=/var/log/account/savacct
+USRACCT_FILE_LOC=/var/log/account/usracct

--- a/srcpkgs/acct/patches/cross.patch
+++ b/srcpkgs/acct/patches/cross.patch
@@ -1,0 +1,11 @@
+--- configure.orig	2017-07-02 17:54:06.000000000 +0200
++++ configure	2018-09-05 19:44:40.854646115 +0200
+@@ -29608,7 +29608,7 @@
+ 
+ fi
+ if test "$cross_compiling" = yes; then :
+-  echo "Sorry -- you cannot cross-compile this package (FIXME)."; exit 1
++  . ./locs; rm locs
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */

--- a/srcpkgs/acct/template
+++ b/srcpkgs/acct/template
@@ -1,15 +1,23 @@
 # Template file for 'acct'
 pkgname=acct
 version=6.6.4
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="GNU Accounting Utilities"
 homepage="https://www.gnu.org/software/acct/"
-license="GPL-3"
+license="GPL-3.0-or-later"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=4c15bf2b58b16378bcc83f70e77d4d40ab0b194acf2ebeefdb507f151faa663f
-nocross=yes
+
+if [ "$CROSS_BUILD" ]; then
+	post_extract() {
+		case "$XBPS_TARGET_MACHINE" in
+			*-musl) cp $FILESDIR/locs-musl locs ;;
+			*) cp $FILESDIR/locs-glibc locs ;;
+		esac
+	}
+fi
 
 post_install() {
 	# The last(1) command is provided by util-linux


### PR DESCRIPTION
acct compiles and runs a binary which generates a list with default paths depending on the OS used. This file is then sourced in the makefile.

For Void there’s only a difference if it’s a glibc or musl build. So I put the two variants “pre-generated” in `$FILESDIR` and then copy the corresponding version to the builddir.

Also, I changed `license` to use the SPDX identifier, that’s why the revbump.