### PR TITLE
ffcall: enable cross build

### DIFF
--- a/srcpkgs/ffcall/template
+++ b/srcpkgs/ffcall/template
@@ -10,10 +10,13 @@ license="GPL-2.0-or-later"
 homepage="https://www.gnu.org/software/libffcall"
 distfiles="${GNU_SITE}/libffcall/libffcall-${version}.tar.gz"
 checksum=a091fb8bbabf17c94a2dae2d41161b96a08ab92b5f75d3364157a2c34d538c47
-nocross="configure requires running code to check for features"
 
 # won't work with parallel_build so just turn it off (thanks to JuanRP for the Hint)
 disable_parallel_build=yes
+
+if [ "$CROSS_BUILD" ]; then
+	configure_args+=" ffcall_cv_malloc_mprotect_can_exec=yes"
+fi
 
 do_install() {
 	make DESTDIR=${DESTDIR} htmldir=/usr/share/doc/ffcall install


### PR DESCRIPTION
Override configure running a test binary by providing the corresponding value determined in native builds.