### PR TITLE
Prevent inconsistent staging

### DIFF
--- a/common/hooks/post-pkg/00-register-pkg.sh
+++ b/common/hooks/post-pkg/00-register-pkg.sh
@@ -7,16 +7,7 @@ registerpkg() {
 		msg_error "Unexistent binary package ${repo}/${pkg}!\n"
 	fi
 
-	msg_normal "Registering ${pkg} into ${repo} ...\n"
-	if [ -n "${arch}" ]; then
-		XBPS_TARGET_ARCH=${arch} $XBPS_RINDEX_CMD ${XBPS_BUILD_FORCEMODE:+-f} -a ${repo}/${pkg}
-	else
-		if [ -n "$XBPS_CROSS_BUILD" ]; then
-			$XBPS_RINDEX_XCMD ${XBPS_BUILD_FORCEMODE:+-f} -a ${repo}/${pkg}
-		else
-			$XBPS_RINDEX_CMD ${XBPS_BUILD_FORCEMODE:+-f} -a ${repo}/${pkg}
-		fi
-	fi
+	printf "%s:%s:%s\n" "${arch}" "${repo}" "${pkg}" >> "${XBPS_STATEDIR}/.${sourcepkg}_register_pkg"
 }
 
 hook() {


### PR DESCRIPTION
This PR prevents a situation that occured with the latest icu update where the `icu-devel` package that depended on `icu` was registered before `icu`. When `icu` was registered afterwards staging was triggered, leaving icu-devel with a dangling dependency to `icu` which was in staging.

(Sub-)Packages are now only collected during do-pkg and registered all at once afterwards. That causes stage-triggering for all packages, not only for the first one that introduces inconsistencies.