### PR TITLE
waitforfile: fix template

### DIFF
--- a/srcpkgs/waitforfile/template
+++ b/srcpkgs/waitforfile/template
@@ -2,65 +2,20 @@
 pkgname=waitforfile
 version=0.1.7
 revision=1
+hostmakedepends="cargo"
 short_desc="Wait until the given file exists"
 maintainer="cr6git <quark6@protonmail.com>"
-homepage="https://github.com/nroi/waitforfile"
 license="MIT"
+homepage="https://github.com/nroi/waitforfile"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=cc0d0e71341c45ff4f7b4e3cd76229fa896ff80307ce7de653586f3040250c21
+nocross=yes
 
-if [ -z "$CROSS_BUILD" ]; then
-	# Compile from source
-	hostmakedepends="cargo"
-	distfiles="https://github.com/nroi/waitforfile/archive/v${version}.tar.gz"
-	checksum=cc0d0e71341c45ff4f7b4e3cd76229fa896ff80307ce7de653586f3040250c21
-	do_build() {
-		cargo build --release
-	}
-	do_install() {
-		vlicense LICENSE
-		vbin target/release/waitforfile
-	}
-else
-	## Seems like rust cannot be cross compiled
-	## At least we can use precompiled binaries
-	case "$XBPS_TARGET_MACHINE" in
-		i686)
-			_arch=i686-unknown-linux-gnu
-			checksum=c627920d32b8ae8cb8776a40f00a4fce59d60c3b76093d617dfb40f771ab03f5
-			;;
-		i686-musl)
-			_arch=i686-unknown-linux-musl
-			checksum=2bbd534b5d8b09af9c5868428eba88669cb70d6a2c88d8eb33cf0eff4df303ca
-			;;
-		x86_64)
-			_arch=x86_64-unknown-linux-gnu
-			checksum=544e6545b40c3b823c7fc0e1303c93bb7050270fccd7a391a8df63bd8113d0f0
-			;;
-		x86_64-musl)
-			_arch=x86_64-unknown-linux-musl
-			checksum=62db6433e4e1aa3f6b88459106f219ae864a8a45f8424180d38658ab55db4b18
-			;;
-		*-musl)
-			broken="precompiled binaries not available for these archs."
-			;;
-		aarch64)
-			_arch=aarch64-unknown-linux-gnu
-			checksum=3a86a631c55d65c87a9ac74b5342cd3a3f88500a528d983f761900f921415e71
-			;;
-		armv7*)
-			_arch=armv7-unknown-linux-gnueabihf
-			checksum=237dd158755f10bc739e8a1536fabe83697c27639a67a959c1f57a3cc56d6ebf
-			;;
-		*)
-			broken="precompiled binaries not available for these archs."
-			;;
-	esac
-	distfiles="https://github.com/nroi/waitforfile/releases/download/v${version}/waitforfile-v${version}-${_arch}.tar.gz"
-	create_wrksrc=yes
-	do_install() {
-		vbin waitforfile
-		# The LICENSE file is only present in the source tarball
-		$XBPS_FETCH_CMD https://raw.githubusercontent.com/nroi/waitforfile/master/LICENSE
-		vlicense LICENSE
-	}
-fi
+do_build() {
+	cargo build --release ${makejobs}
+}
 
+do_install() {
+	vbin target/release/waitforfile
+	vlicense LICENSE
+}


### PR DESCRIPTION
current template essentially turns it into binary package. no other template provides this kind of overkill fallback.