### PR TITLE
clamav: fix user creation

### DIFF
--- a/srcpkgs/clamav/template
+++ b/srcpkgs/clamav/template
@@ -8,11 +8,11 @@ build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --libdir=/usr/lib
  --with-openssl=${XBPS_CROSS_BASE}/usr --with-pcre=${XBPS_CROSS_BASE}/usr
  --with-zlib=${XBPS_CROSS_BASE}/usr --with-libbz2-prefix=${XBPS_CROSS_BASE}/usr
- --with-system-libmspack=${XBPS_CROSS_BASE}/usr"
+ --with-system-libmspack=${XBPS_CROSS_BASE}/usr --with-user=_clamav --with-group=_clamav"
 conf_files="/etc/clamd.conf /etc/freshclam.conf"
 system_accounts="_clamav"
-clamav_homedir="/var/lib/_${pkgname}"
-clamav_descr="ClamAV user"
+_clamav_homedir="/var/lib/_${pkgname}"
+_clamav_descr="ClamAV user"
 hostmakedepends="flex pkg-config zip"
 makedepends="json-c-devel libcurl-devel libmspack-devel libxml2-devel
  ncurses-devel pcre-devel tcl-devel"


### PR DESCRIPTION
@pullmoll it was discussed on IRC that due to changing the username will cause inevitable breakage (we can't ensure the uid stays the same) there is a motion to apply this policy only for new packages.

regardless here are a few fixes