### PR TITLE
goproxy: update to 6.0.

### DIFF
--- a/srcpkgs/goproxy/template
+++ b/srcpkgs/goproxy/template
@@ -1,12 +1,13 @@
 # Template file for 'goproxy'
 pkgname=goproxy
-version=5.4
+version=6.0
 revision=1
 build_style=go
 go_import_path="github.com/snail007/goproxy"
+hostmakedepends="git"
 short_desc="High performance HTTP(S), websocket, TCP, UDP, Socks5 proxy server"
 maintainer="cr6git <quark6@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/snail007/goproxy"
 distfiles="https://github.com/snail007/goproxy/archive/v${version}.tar.gz"
-checksum=0c55c730dbb9c29fcc4cdd4e4088fb1e91de3b0c61ca49587610a5326a2051c6
+checksum=a2c9200cdfbd73b55a1cf0f80fe401a09e5d1488b45edc84ebc95d95783c3115


### PR DESCRIPTION
````
=> goproxy-6.0_1: running do_build ...
go: missing Git command. See https://golang.org/s/gogetcmd
package github.com/Yawning/chacha20: exec: "git": executable file not found in $PATH
````
:roll_eyes: 