### PR TITLE
clamav: fix database directory

### DIFF
--- a/srcpkgs/clamav/INSTALL
+++ b/srcpkgs/clamav/INSTALL
@@ -4,11 +4,16 @@ post)
 	# Only if not updating
 	if [ "$UPDATE" != "yes" ]; then
 		# Create the database directory
-		mkdir -p var/lib/clamav
+		mkdir -p var/lib/_clamav
 		# The clamav user owns it
-		chown -R _clamav:_clamav var/lib/clamav
+		chown -R _clamav:_clamav var/lib/_clamav
 		# Let group members write to it
-		chmod g+w var/lib/clamav
+		chmod g+w var/lib/_clamav
+	else
+		if [ -d "var/lib/clamav" ]; then
+			mv var/lib/clamav var/lib/_clamav
+			chown -R _clamav:_clamav var/lib/_clamav
+		fi
 	fi
 	;;
 esac

--- a/srcpkgs/clamav/REMOVE
+++ b/srcpkgs/clamav/REMOVE
@@ -4,7 +4,7 @@ pre)
 	# Only if not updating
 	if [ "$UPDATE" != "yes" ]; then
 		# Remove the clamav database directory and contents
-		rm -rf var/lib/clamav
+		rm -rf var/lib/_clamav
 	fi
 	;;
 esac

--- a/srcpkgs/clamav/template
+++ b/srcpkgs/clamav/template
@@ -1,7 +1,7 @@
 # Template file for 'clamav'
 pkgname=clamav
 version=0.100.1
-revision=4
+revision=5
 build_style=gnu-configure
 # XXX: system llvm is too new (< 3.7 required)
 # Shipped llvm does not build with gcc6


### PR DESCRIPTION
On installation `/var/lib/clamav` is still created. But after the user name change it should be `/var/lib/_clamav`. Some underscores were missing in `INSTALL` as well as in `REMOVE`.

However, this hasn’t any effect on update. So for convenience and easier transition in the update case I also renamed `/var/lib/clamav` to `/var/lib/_clamav` and changed ownership.

But the old clamav user/group still remains and the user has to add himself manually to the new group.