### PR TITLE
libopenal: update to 1.19.0.

### DIFF
--- a/srcpkgs/libopenal/template
+++ b/srcpkgs/libopenal/template
@@ -1,17 +1,18 @@
 # Template file for 'libopenal'
 pkgname=libopenal
-version=1.18.2
-revision=3
-build_style=cmake
+version=1.19.0
+revision=1
 wrksrc="openal-soft-${version}"
+build_style=cmake
+configure_args="-DALSOFT_EXAMPLES=OFF -DALSOFT_TESTS=OFF"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel pulseaudio-devel SDL2-devel ffmpeg-devel jack-devel"
 short_desc="A cross-platform 3D audio library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.0-or-later"
 homepage="http://kcat.strangesoft.net/openal.html"
 distfiles="http://kcat.strangesoft.net/openal-releases/openal-soft-${version}.tar.bz2"
-checksum=9f8ac1e27fba15a59758a13f0c7f6540a0605b6c3a691def9d420570506d7e82
+checksum=f1adf3a6e73e2f9270a0fd00887ea23793968fa787f60dcdec41a3b2f42a0ed6
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in
@@ -22,7 +23,6 @@ pre_configure() {
 }
 
 post_install() {
-	rm -f ${DESTDIR}/usr/share/openal/alsoftrc.sample
 	vsconf alsoftrc.sample
 }
 
@@ -32,6 +32,7 @@ libopenal-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
 		vmove usr/lib/*.so
 	}
 }


### PR DESCRIPTION
```
>>> libopenal-devel
6a7,8
> /usr/lib/cmake/OpenAL/OpenALConfig-release.cmake
> /usr/lib/cmake/OpenAL/OpenALConfig.cmake
>>> libopenal
1,4d0
< /usr/bin/alffplay
< /usr/bin/alrecord
< /usr/bin/altonegen
< /usr/bin/bsincgen
7,10c3,4
< /usr/lib/cmake/OpenAL/OpenALConfig-release.cmake
< /usr/lib/cmake/OpenAL/OpenALConfig.cmake
< /usr/lib/libopenal.so.1 -> /usr/lib/libopenal.so.1.18.2
< /usr/lib/libopenal.so.1.18.2
---
> /usr/lib/libopenal.so.1 -> /usr/lib/libopenal.so.1.19.0
> /usr/lib/libopenal.so.1.19.0
11a6
> /usr/share/openal/alsoftrc.sample
15a11
> /usr/share/openal/presets/itu5.1-nocenter.ambdec
```