### PR TITLE
New package: lightdm-webkit2-greeter-2.2.5 

### DIFF
--- a/srcpkgs/lightdm-webkit-greeter
+++ b/srcpkgs/lightdm-webkit-greeter
@@ -1,0 +1,1 @@
+lightdm-webkit2-greeter

--- a/srcpkgs/lightdm-webkit2-greeter/lightdm-webkit-greeter.INSTALL.msg
+++ b/srcpkgs/lightdm-webkit2-greeter/lightdm-webkit-greeter.INSTALL.msg
@@ -1,0 +1,2 @@
+lightdm-webkit-greeter got replaced by lightdm-webkit2-greeter, you need
+to reconfigure it manually in /etc/lightdm/lightdm-webkit2-greeter.conf.

--- a/srcpkgs/lightdm-webkit2-greeter/patches/conf.patch
+++ b/srcpkgs/lightdm-webkit2-greeter/patches/conf.patch
@@ -1,0 +1,20 @@
+--- data/lightdm-webkit2-greeter.conf	2018-06-26 15:29:27.461313219 +0200
++++ data/lightdm-webkit2-greeter.conf	2018-06-26 18:58:13.649378103 +0200
+@@ -18,7 +18,7 @@
+ secure_mode         = true
+ time_format         = LT
+ time_language       = auto
+-webkit_theme        = antergos
++webkit_theme        = void
+ 
+ #
+ # [branding]
+@@ -31,5 +31,6 @@
+ 
+ [branding]
+ background_images = /usr/share/backgrounds
+-logo              = /usr/share/lightdm-webkit/themes/antergos/img/antergos.png
+-user_image        = /usr/share/lightdm-webkit/themes/antergos/img/antergos-logo-user.png
++logo              = /usr/share/void-artwork/void-transparent.png
++user_image        = /usr/share/void-artwork/void-transparent.png
++

--- a/srcpkgs/lightdm-webkit2-greeter/patches/musl.patch
+++ b/srcpkgs/lightdm-webkit2-greeter/patches/musl.patch
@@ -1,0 +1,11 @@
+--- src/webkit2-extension.c	2017-04-24 19:51:30.000000000 +0000
++++ -	2018-06-23 12:27:53.459279693 +0000
+@@ -1846,7 +1846,7 @@
+ 		return result;
+ 	}
+ 
+-	canonical_path = canonicalize_file_name(file_path);
++	canonical_path = realpath(file_path, NULL);
+ 
+ 	if (NULL != canonical_path) {
+ 		for (iter = paths; iter; iter = iter->next) {

--- a/srcpkgs/lightdm-webkit2-greeter/patches/void.patch
+++ b/srcpkgs/lightdm-webkit2-greeter/patches/void.patch
@@ -1,0 +1,55 @@
+--- themes/meson.build	2017-04-24 21:51:30.000000000 +0200
++++ -	2018-06-26 19:02:25.482098621 +0200
+@@ -1,5 +1,5 @@
+ install_subdir('_vendor', install_dir : get_option('with-theme-dir'))
+ 
+-install_subdir('antergos', install_dir : get_option('with-theme-dir'))
++install_subdir('void', install_dir : get_option('with-theme-dir'))
+ 
+ install_subdir('simple', install_dir : get_option('with-theme-dir'))
+diff -ur themes/antergos/css/style.css themes/void/css/style.css
+--- themes/antergos/css/style.css	2018-06-23 14:29:28.000000000 +0200
++++ themes/void/css/style.css	2018-06-26 16:26:33.210703621 +0200
+@@ -204,6 +204,7 @@
+ 	right: -2px;
+ 	position: fixed;
+ 	z-index: 1;
++	background-color: #478061;
+ }
+ 
+ #bg-switch-wrapper.active {
+@@ -258,7 +259,7 @@
+ 	font-weight: 300;
+ 	line-height: 1em;
+ 	text-decoration: none;
+-	color: #3D73C5;
++	color: #478061;
+ 	background-color: rgb(252, 247, 247);
+ 	transition: 1s ease-out;
+ 	position: relative;
+@@ -277,7 +278,7 @@
+ 
+ .time:hover {
+ 	cursor: pointer;
+-	color: #77ADFF;
++	color: #ABC2AB;
+ 	/* text-shadow: 0px 0px 6px rgba(0, 0, 0, 0.7); */
+ }
+ 
+@@ -430,6 +431,7 @@
+ 
+ #passwordArea .btn {
+ 	padding: 7px 12px;
++	background-color: #478061;
+ }
+ 
+ #passwordArea .btn-group > .btn {
+@@ -496,7 +498,7 @@
+ }
+ 
+ .random.active {
+-	border: 2px solid #3D73C5;
++	border: 2px solid #478061;
+ }
+ 
+ .user-wrap2 {

--- a/srcpkgs/lightdm-webkit2-greeter/template
+++ b/srcpkgs/lightdm-webkit2-greeter/template
@@ -1,0 +1,31 @@
+# Template file for 'lightdm-webkit2-greeter'
+pkgname=lightdm-webkit2-greeter
+version=2.2.5
+revision=1
+wrksrc="web-greeter-${version}"
+build_style=meson
+hostmakedepends="pkg-config glib-devel"
+makedepends="accountsservice-devel gnome-backgrounds lightdm-devel
+ webkit2gtk-devel dbus-glib-devel libxklavier-devel"
+depends="void-artwork lightdm"
+short_desc="Light Display Manager Webkit2 Greeter"
+maintainer="John <johnz@posteo.net>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/Antergos/web-greeter"
+distfiles="https://github.com/Antergos/web-greeter/archive/${version}.tar.gz"
+checksum=f3223db35d0efaae76b2157f312dd10979c133f5a85add8fc75fd66ecb3186e3
+conf_files="/etc/lightdm/lightdm-webkit2-greeter.conf"
+
+post_extract() {
+	mv themes/antergos themes/void
+}
+
+lightdm-webkit-greeter_package() {
+	short_desc+=" - (transitional dummy package)"
+	noarch=yes
+	depends="lightdm-webkit2-greeter>=${version}_${revision}"
+	pkg_install() {
+		vmkdir usr/bin
+		ln -s ./lightdm-webkit2-greeter ${PKGDESTDIR}/usr/bin/lightdm-webkit-greeter
+	}
+}


### PR DESCRIPTION
#2488 
I still have to verify how good it is as a drop-in replacement for lightdm-webkit-greeter. It will need at least a smylink for the binary so that it doesn't fully break existing systems. Also how should I handle the default Antergos theme? Moving it into a subpackage and rebrand, and use the `simple` as default.