### PR TITLE
NetworkManager: update to 1.14.0

### DIFF
--- a/srcpkgs/NetworkManager/patches/fix-musl-include.patch
+++ b/srcpkgs/NetworkManager/patches/fix-musl-include.patch
@@ -1,0 +1,57 @@
+--- shared/n-acd/src/n-acd.c   2018-09-09 12:10:36.626987553 +0200
++++ shared/n-acd/src/n-acd.c   2018-09-09 12:51:36.680798693 +0200
+@@ -23,10 +23,10 @@
+ #include <errno.h>
+ #include <limits.h>
+ #include <linux/filter.h>
+-#include <linux/if_ether.h>
+ #include <linux/if_packet.h>
+ #include <net/ethernet.h>
+ #include <netinet/if_ether.h>
++#include <linux/if_ether.h>
+ #include <netinet/in.h>
+ #include <stddef.h>
+ #include <stdio.h>
+--- src/platform/nm-linux-platform.c
++++ src/platform/nm-linux-platform.c
+@@ -20,6 +20,7 @@
+ #include "nm-default.h"
+ 
+ #include "nm-linux-platform.h"
++#include "wpan/nm-wpan-utils.h"
+ 
+ #include <poll.h>
+ #include <endian.h>
+@@ -33,7 +34,9 @@
+ #include <netinet/icmp6.h>
+ #include <netinet/in.h>
+ #include <linux/ip.h>
+-#include <linux/if_arp.h>
++#if defined(__GLIBC__)
++    #include <linux/if_arp.h>
++#endif
+ #include <linux/if_link.h>
+ #include <linux/if_tun.h>
+ #include <linux/if_tunnel.h>
+@@ -53,7 +56,6 @@
+ #include "nm-platform-private.h"
+ #include "wifi/nm-wifi-utils.h"
+ #include "wifi/nm-wifi-utils-wext.h"
+-#include "wpan/nm-wpan-utils.h"
+ #include "nm-utils/unaligned.h"
+ #include "nm-utils/nm-io-utils.h"
+ #include "nm-utils/nm-udev-utils.h"
+--- src/devices/nm-device.c
++++ src/devices/nm-device.c
+@@ -34,7 +34,9 @@
+ #include <arpa/inet.h>
+ #include <fcntl.h>
+ #include <linux/if_addr.h>
+-#include <linux/if_arp.h>
++#if defined(__GLIBC__)
++    #include <linux/if_arp.h>
++#endif
+ #include <linux/rtnetlink.h>
+ #include <linux/pkt_sched.h>
+ #include <uuid/uuid.h>
+

--- a/srcpkgs/NetworkManager/patches/musl-network-support.patch
+++ b/srcpkgs/NetworkManager/patches/musl-network-support.patch
@@ -12,8 +12,8 @@
  #include <linux/if_infiniband.h>
  
  #include "nm-core-enum-types.h"
---- src/platform/wifi/wifi-utils.h.orig
-+++ src/platform/wifi/wifi-utils.h
+--- src/platform/wifi/nm-wifi-utils.h.orig
++++ src/platform/wifi/nm-wifi-utils.h
 @@ -22,7 +22,11 @@
  #ifndef __WIFI_UTILS_H__
  #define __WIFI_UTILS_H__

--- a/srcpkgs/NetworkManager/patches/musl-process-util.patch
+++ b/srcpkgs/NetworkManager/patches/musl-process-util.patch
@@ -1,6 +1,6 @@
 --- src/systemd/src/basic/process-util.c.orig	2018-03-20 23:12:35.698715891 +0100
 +++ src/systemd/src/basic/process-util.c	2018-03-20 23:17:24.114733986 +0100
-@@ -36,6 +36,9 @@
+@@ -21,6 +21,9 @@
  #include <sys/wait.h>
  #include <syslog.h>
  #include <unistd.h>
@@ -10,7 +10,7 @@
  #if 0 /* NM_IGNORED */
  #if HAVE_VALGRIND_VALGRIND_H
  #include <valgrind/valgrind.h>
-@@ -1015,11 +1018,13 @@ static void reset_cached_pid(void) {
+@@ -1153,11 +1156,13 @@ void reset_cached_pid(void) {
          cached_pid = CACHED_PID_UNSET;
  }
  
@@ -18,21 +18,23 @@
  /* We use glibc __register_atfork() + __dso_handle directly here, as they are not included in the glibc
   * headers. __register_atfork() is mostly equivalent to pthread_atfork(), but doesn't require us to link against
   * libpthread, as it is part of glibc anyway. */
- extern int __register_atfork(void (*prepare) (void), void (*parent) (void), void (*child) (void), void * __dso_handle);
+ extern int __register_atfork(void (*prepare) (void), void (*parent) (void), void (*child) (void), void *dso_handle);
  extern void* __dso_handle __attribute__ ((__weak__));
 +#endif
  
  pid_t getpid_cached(void) {
-         pid_t current_value;
-@@ -1042,7 +1047,11 @@ pid_t getpid_cached(void) {
+         static bool installed = false;
+@@ -1186,7 +1191,12 @@ pid_t getpid_cached(void) {
+                          * only half-documented (glibc doesn't document it but LSB does — though only superficially)
+                          * we'll check for errors only in the most generic fashion possible. */
  
-                 new_pid = getpid();
- 
-+#ifdef __GLIBC__
-                 if (__register_atfork(NULL, NULL, reset_cached_pid, __dso_handle) != 0) {
-+#else
-+                if (pthread_atfork(NULL, NULL, reset_cached_pid) != 0) {
-+#endif
-                         /* OOM? Let's try again later */
-                         cached_pid = CACHED_PID_UNSET;
-                         return new_pid;
+-                        if (__register_atfork(NULL, NULL, reset_cached_pid, __dso_handle) != 0) {
++                        #ifdef __GLIBC__
++                            if (__register_atfork(NULL, NULL, reset_cached_pid, __dso_handle) != 0) {
++                        #else
++                            if (pthread_atfork(NULL, NULL, reset_cached_pid) != 0) {
++                        #endif
++
+                                 /* OOM? Let's try again later */
+                                 cached_pid = CACHED_PID_UNSET;
+                                 return new_pid;

--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -1,31 +1,31 @@
 # Template file for 'NetworkManager'
 pkgname=NetworkManager
-version=1.10.6
-revision=2
+version=1.14.0
+revision=1
 build_style=gnu-configure
 configure_args="--without-dhcpcd --with-dhclient=/usr/bin/dhclient
  --with-system-ca-path=/etc/ssl/certs --enable-more-warnings=no
  --with-crypto=gnutls --disable-static --enable-ppp --with-nmtui
  --with-udev-dir=/usr/lib/udev $(vopt_enable gir introspection)
- --with-kernel-firmware-dir=/usr/lib/firmware
+ --with-kernel-firmware-dir=/usr/lib/firmware --disable-ifcfg-rh
  --with-pppd-plugin-dir=/usr/lib/pppd/2.4.7 --enable-modify-system
  --with-modem-manager-1 --with-resolvconf=/usr/bin/resolvconf
  --with-session-tracking=$(vopt_if elogind logind consolekit)
- --with-suspend-resume=upower
+ --with-suspend-resume=upower --with-libnm-glib --disable-ifupdown
  --with-systemdsystemunitdir=no --enable-polkit-agent --enable-tests=no
  --with-systemd-journal=no --with-systemd-logind=no --disable-gtk-doc
  --with-dbus-sys-dir=/etc/dbus-1/system.d
- --sbindir=/usr/bin --enable-concheck
- --with-dnsmasq=/usr/bin/dnsmasq
+ --sbindir=/usr/bin --enable-concheck --with-libpsl
+ --with-dnsmasq=/usr/bin/dnsmasq --with-config-dhcp-default=dhclient
  ac_cv_file__etc_redhat_release=no ac_cv_file__etc_gentoo_release=no
  ac_cv_file__etc_fedora_release=no ac_cv_file__etc_mandriva_release=no
  ac_cv_file__etc_SuSE_release=no ac_cv_file__etc_debian_version=no"
 short_desc="Network Management daemon"
-maintainer="Juan RP <xtraeme@voidlinux.eu>"
+maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 homepage="https://wiki.gnome.org/Projects/NetworkManager"
 license="GPL-2.0-or-later"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=6af0b1e856a3725f88791f55c4fbb04105dc0b20dbf182aaec8aad16481fac76
+checksum=bdb216eac0f34a6d7e95e455fe1a8a718f80f2a9dd9a377a75672c7338807230
 
 # gtk-doc generation is disabled but gtkdocisze is required by autogen.sh
 hostmakedepends="automake bluez dbus-glib-devel dhclient gettext-devel
@@ -35,6 +35,7 @@ hostmakedepends="automake bluez dbus-glib-devel dhclient gettext-devel
 makedepends="libuuid-devel gnutls-devel dbus-glib-devel libgudev-devel
  libnl3-devel polkit-devel ppp-devel iptables-devel libcurl-devel
  ModemManager-devel readline-devel libndp-devel newt-devel jansson-devel
+ libpsl-devel
  $(vopt_if gir libgirepository-devel) $(vopt_if elogind elogind-devel)"
 # Install host dependency to read the soname. Should be the same on
 # host and target.
@@ -69,8 +70,11 @@ pre_configure() {
 
 	# Fsckd-up check for gi ?
 	sed -e 's,! "$PYTHON" -c ,"$PYTHON" -c,' -i configure
+}
 
-	sed -e "s/HAVE_LIBSYSTEMD/0/" -i src/devices/wwan/nm-modem-manager.c
+do_check() {
+	# src/settings/plugins/ibft/tests/test-ibft errors out in chroot
+	:
 }
 
 post_install() {


### PR DESCRIPTION
Currently is broken on musl due to:

```
aarch64-linux-musl-gcc -Ishared/shared@@n-acd@sta -Ishared -I../shared -I../shared/c-siphash/src -I../shared/c-list/src -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=gnu99 -fdata-sections -ffunction-sections -fPIC -D_FORTIFY_SOURCE=2 -O2 -pipe -march=armv8-a -DHAVE_SECURE_GETENV -Dsecure_getenv=getenv -D__USE_POSIX199309 -DRTLD_DEEPBIND=0 -DHAVE_SECURE_GETENV -Dsecure_getenv=getenv -D__USE_POSIX199309 -DRTLD_DEEPBIND=0 -I/usr/aarch64-linux-musl/usr/include -MD -MQ 'shared/shared@@n-acd@sta/n-acd_src_n-acd.c.o' -MF 'shared/shared@@n-acd@sta/n-acd_src_n-acd.c.o.d' -o 'shared/shared@@n-acd@sta/n-acd_src_n-acd.c.o' -c ../shared/n-acd/src/n-acd.c
In file included from /usr/aarch64-linux-musl/usr/include/net/ethernet.h:10,
                 from ../shared/n-acd/src/n-acd.c:28:
/usr/aarch64-linux-musl/usr/include/netinet/if_ether.h:104:8: error: redefinition of 'struct ethhdr'
 struct ethhdr {
        ^~~~~~
In file included from ../shared/n-acd/src/n-acd.c:26:
/usr/aarch64-linux-musl/usr/include/linux/if_ether.h:142:8: note: originally defined here
 struct ethhdr {
        ^~~~~~
```

Glibc cross seems broken because meson can't find libdl 
