### PR TITLE
praat: update to 6.0.43

### DIFF
--- a/srcpkgs/praat/template
+++ b/srcpkgs/praat/template
@@ -1,7 +1,8 @@
 # Template file for 'praat'
 pkgname=praat
-version=6.0.42
+version=6.0.43
 revision=1
+create_wrksrc=yes
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel gtk+-devel $(vopt_if pulseaudio pulseaudio-devel)"
 short_desc="Speech analysis, synthesis, and manipulation"
@@ -10,17 +11,14 @@ license="GPL-2.0-or-later"
 homepage="http://www.praat.org/"
 changelog="http://www.fon.hum.uva.nl/praat/manual/What_s_new_.html"
 distfiles="https://github.com/praat/praat/archive/v${version}.tar.gz"
-checksum=9bdd2a5159b9fb8c6d8c58d52e984f6fda444983ba4d69b2a5c04c8259908cd2
+checksum=4e933f4255fade38952144326c979176ab0f570062985fb4d968eb43ed5e23d0
 
 build_options="pulseaudio"
+build_options_default="pulseaudio"
 
 do_build() {
-	mkdir /tmp/original
-	mv * /tmp/original/
-	mv /tmp/original .
-
 	for _variant in $(vopt_if pulseaudio pulse alsa) nogui; do
-		cp -a original $_variant
+		cp -a "${pkgname}-${version}" $_variant
 		cd $_variant
 
 		cp makefiles/makefile.defs.linux.${_variant} ./makefile.defs


### PR DESCRIPTION
- improve do_build()
- make pulseaudio default build option

Audio playback using “ALSA via PortAudio” crashes praat shortly after hitting play (this also happens in the current version). My guess is this is because praat doesn’t use the system PortAudio, but a patched bundled version (from 2014, maybe too old?). PulseAudio works fine, so I enabled it per default now. Will ask the authors.