### PR TITLE
New package: archiver-2.0.0.20180907

### DIFF
--- a/srcpkgs/archiver/template
+++ b/srcpkgs/archiver/template
@@ -1,0 +1,20 @@
+# Template file for 'archiver'
+pkgname=archiver
+version=2.0.0.20180907
+revision=1
+_commit=77adc20105e1c2d854573bb49508b0ce315963e0
+wrksrc="${pkgname}-${_commit}"
+build_style=go
+go_import_path="github.com/mholt/archiver"
+go_package="${go_import_path}/cmd/archiver"
+hostmakedepends="git"
+short_desc="Easily create and extract common archive formats"
+maintainer="cr6git <quark6@protonmail.com>"
+license="MIT"
+homepage="https://github.com/mholt/archiver"
+distfiles="https://github.com/mholt/archiver/archive/${_commit}.tar.gz"
+checksum=1619aa8ffb974c24be62be16a876a1d79469ec87657cecb483e23fb012a72def
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
I used the latest commit instead of the tagged release, because issue [#27](https://github.com/mholt/archiver/issues/27) was fixed in [#76](https://github.com/mholt/archiver/pull/76) only very recently.