### PR TITLE
zsh: update to 5.6.

### DIFF
--- a/srcpkgs/zsh/template
+++ b/srcpkgs/zsh/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh'
 pkgname=zsh
-version=5.5.1
-revision=2
+version=5.6
+revision=1
 lib32disabled=yes
 build_style=gnu-configure
 make_build_target="all info"
@@ -21,10 +21,10 @@ makedepends="gdbm-devel pcre-devel libcap-devel ncurses-devel"
 register_shell="/bin/zsh"
 short_desc="The Z SHell"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.zsh.org"
 license="MIT, GPL-3.0-or-later"
-distfiles="http://www.zsh.org/pub/zsh-${version}.tar.gz"
-checksum=774caa89e7aea5f33c3033cbffd93e28707f72ba5149c79709e48e6c2d2ee080
+homepage="http://www.zsh.org"
+distfiles="http://www.zsh.org/pub/zsh-${version}.tar.xz"
+checksum=746b1fcb11e8d129d1454f9ca551448c8145b6bcb157116c12407c518880e6d6
 
 pre_configure() {
 	# Set correct keymap path


### PR DESCRIPTION
fixes CVE-2018-0502 and CVE-2018-13259
@chneukirchen tagging you since you did the last few updates of zsh.