### PR TITLE
libinput: update to 1.12.0.

### DIFF
--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -1,6 +1,6 @@
 # Template file for 'libinput'
 pkgname=libinput
-version=1.11.3
+version=1.12.0
 revision=1
 build_style=meson
 configure_args="-Ddebug-gui=false -Ddocumentation=false"
@@ -11,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libinput"
 distfiles="${FREEDESKTOP_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=f31191d96e425b4f16319842279d65946d9d983dcd3d9e466ae1206aa10ecb06
+checksum=15ac2b78ec0b502c14400d711dbd6b9164a43a724cedeaf21c7fa29960e701a4
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
```
=> libinput-1.12.0_1: running do_check ...
ninja: Entering directory `build'
[1/4] Generating libinput-git-version.h with a custom command.
[1/2] Running all tests.
1/9 validate-quirks                         OK       0.01 s 
2/9 list-devices                            OK       0.01 s 
3/9 tools-builddir-lookup                   OK       0.01 s 
4/9 tools-builddir-lookup-installed         OK       0.02 s 
5/9 symbols-leak-test                       OK       0.02 s 
6/9 leftover-rules                          OK       0.01 s 
7/9 test-litest-selftest                    OK       0.03 s 
8/9 libinput-test-suite-runner              SKIP     0.01 s 
9/9 libinput-test-deviceless                OK       1.68 s 

OK:         8
FAIL:       0
SKIP:       1
TIMEOUT:    0

Full log written to /builddir/libinput-1.12.0/build/meson-logs/testlog.txt
```