### PR TITLE
VeraCrypt: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/VeraCrypt/template
+++ b/srcpkgs/VeraCrypt/template
@@ -1,13 +1,14 @@
 # Template file for 'VeraCrypt'
 pkgname=VeraCrypt
 version=1.22
-revision=5
+revision=6
 create_wrksrc=1
 build_wrksrc=src
 build_style=gnu-makefile
+make_build_args="WX_CONFIG=wx-config-gtk3"
 make_use_env=1
 hostmakedepends="pkg-config yasm"
-makedepends="fuse-devel wxWidgets-devel"
+makedepends="fuse-devel wxWidgets-gtk3-devel"
 short_desc="Disk encryption with strong security based on TrueCrypt"
 maintainer="Gustavo Heinz <gustavoheinz95@gmail.com>"
 license="Apache-2.0, TrueCrypt 3.0"


### PR DESCRIPTION
Tested on x86_64-musl and armv7l-musl. Startup, navigation through menus, creating and opening a container all ok.

@gustavoheinz Are you ok with the switch?