### PR TITLE
openbabel: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/openbabel/template
+++ b/srcpkgs/openbabel/template
@@ -1,22 +1,33 @@
 # Template file for 'openbabel'
 pkgname=openbabel
 version=2.4.1
-revision=6
+revision=7
 _ver=${version//./-}
 wrksrc=${pkgname}-${pkgname}-${_ver}
 build_style=cmake
 hostmakedepends="pkg-config"
-makedepends="cairo-devel libxml2-devel eigen3.2 wxWidgets-devel"
+makedepends="cairo-devel libxml2-devel eigen3.2 wxWidgets-gtk3-devel"
 short_desc="The Open Source Chemistry Toolbox"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://openbabel.org"
 distfiles="https://github.com/openbabel/openbabel/archive/openbabel-${_ver}.tar.gz"
 checksum=594c7f8a83f3502381469d643f7b185882da1dd4bc2280c16502ef980af2a776
 
-if [ -n "${CROSS_BUILD}" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python"
 fi
+
+pre_configure() {
+	# workaround for cmake to find wx-config-gtk3
+	if [ "$CROSS_BUILD" ]; then
+		# cannot override wxWidgets_CONFIG_EXECUTABLE set in
+		# the cross toolchain file otherwise
+		ln -s ${XBPS_WRAPPERDIR}/wx-config{-gtk3,}
+	else
+		sed -i "1i\SET(wxWidgets_CONFIG_EXECUTABLE wx-config-gtk3)" CMakeLists.txt
+	fi
+}
 
 openbabel-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
@@ -28,3 +39,4 @@ openbabel-devel_package() {
 		vmove usr/lib/pkgconfig
 	}
 }
+


### PR DESCRIPTION
Tested on x86_64-musl, armv7l-musl. Startup, navigation through menus ok, can’t really do much else with it.

Finding `wx-config-gtk3` is a bit hacky, but when all packages are migrated to wxWidgets-gtk3 and the ‘normal’ wxWidgets might get removed some day this can be simplified again.