### PR TITLE
treesheets: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/treesheets/template
+++ b/srcpkgs/treesheets/template
@@ -1,12 +1,13 @@
 # Template file for 'treesheets'
 pkgname=treesheets
 version=1.0.0
-revision=5
+revision=6
 build_style=gnu-makefile
-makedepends="wxWidgets-devel"
+make_build_args="WX_CONFIG=wx-config-gtk3"
+makedepends="wxWidgets-gtk3-devel"
 short_desc="Free Form Data Organizer"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="ZLIB"
+license="Zlib"
 homepage="http://strlen.com/treesheets/"
 distfiles="https://github.com/aardappel/treesheets/archive/v${version}.tar.gz"
 checksum=13c01c48a6442e309e77126aeeed51d4e0a768ad808459c0dcd83ecc1d246c0f


### PR DESCRIPTION
Tested on x86_64-musl, armv7l-musl. Startup, navigation, creating a new document and playing around with it a bit all worked fine.

@Piraty Do you agree with the switch?