### PR TITLE
xchm: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/xchm/template
+++ b/srcpkgs/xchm/template
@@ -1,12 +1,13 @@
 # Template file for 'xchm'
 pkgname=xchm
 version=1.23
-revision=7
+revision=8
 build_style=gnu-configure
-makedepends="libchmlib-devel wxWidgets-devel"
+configure_args="--with-wx-config=wx-config-gtk3"
+makedepends="libchmlib-devel wxWidgets-gtk3-devel"
 short_desc="The CHM viewer for Unix"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://xchm.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=8f8f5c60954f340e50f1613913eaca6ff489c10ca36b2570b360d8ccba77c062


### PR DESCRIPTION
Tested on x86_64-musl, armv7l-musl. Startup, opening a .chm file and navigating through it all worked fine.

@chneukirchen Do you agree with the changes?