### PR TITLE
SLADE: remove wxWebview usage for startpage and documentation

### DIFF
--- a/srcpkgs/SLADE/template
+++ b/srcpkgs/SLADE/template
@@ -1,9 +1,9 @@
 # Template file for 'SLADE'
 pkgname=SLADE
 version=3.1.1.5
-revision=3
+revision=4
 build_style=cmake
-configure_args="-DUSE_WEBVIEW_STARTPAGE=ON"
+configure_args="-DUSE_WEBVIEW_STARTPAGE=OFF"
 hostmakedepends="pkg-config zip"
 makedepends="SFML-devel fluidsynth-devel freeimage-devel ftgl-devel glew-devel
  gtk+-devel libcurl-devel wxWidgets-devel"


### PR DESCRIPTION
Disabling this functionality removes the dependency on wxWidget's webview library which uses the outdated `webkitgtk2`. Without that enabled, a static version of the startpage is displayed and the application launches a browser when the user accesses the online documentation instead of displaying it inline. The functionality can be enabled again once a new release is put out that allows building with gtk3.

CC @Johnnynator as the maintainer of the package