### PR TITLE
DarkRadiant: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/DarkRadiant/template
+++ b/srcpkgs/DarkRadiant/template
@@ -1,12 +1,12 @@
 # Template file for 'DarkRadiant'
 pkgname=DarkRadiant
 version=2.6.0
-revision=3
+revision=4
 build_style=gnu-configure
-configure_args="--enable-darkmod-plugins"
+configure_args="--enable-darkmod-plugins --with-wx-config=wx-config-gtk3"
 hostmakedepends="automake libtool pkg-config"
 makedepends="ftgl-devel glew-devel libjpeg-turbo-devel libsigc++-devel
- libvorbis-devel libxml2-devel wxWidgets-devel python-devel"
+ libvorbis-devel libxml2-devel wxWidgets-gtk3-devel python-devel"
 short_desc="Map editor for The Dark Mod and other idTech4/Doom3-based games"
 maintainer="John <johnz@posteo.net>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
I have tested that it compiles and runs. As I'm not a regular use of the application, I couldn't test any advanced functionality. It should be fine though as even upstream recommends building against gtk3.

CC @Johnnynator as the maintainer of the package