### PR TITLE
codeblocks: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/codeblocks/template
+++ b/srcpkgs/codeblocks/template
@@ -1,14 +1,14 @@
 # Template file for 'codeblocks'
 pkgname=codeblocks
 version=17.12
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config zip"
-makedepends="gtk+-devel wxWidgets-devel tinyxml-devel"
-configure_args="--with-wx-config=wx-config-3.0"
+makedepends="gtk+3-devel wxWidgets-gtk3-devel tinyxml-devel"
+configure_args="--with-wx-config=wx-config-gtk3"
 short_desc="Free C, C++ and Fortran IDE"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="http://www.codeblocks.org"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/Sources/${version}/${pkgname}_${version}.tar.xz"
 checksum=13881a0a72769694e82e531b8e7814d51fbf1fa122c73c5004e186560fbc57e0


### PR DESCRIPTION
Tested that compilation and basic functionality (creating project, adding files, etc.) works.

CC @pullmoll 