### PR TITLE
wxWidgets: disable webview

### DIFF
--- a/srcpkgs/codelite/template
+++ b/srcpkgs/codelite/template
@@ -1,7 +1,7 @@
 # Template file for 'codelite'
 pkgname=codelite
 version=12.0
-revision=5
+revision=6
 build_style=cmake
 configure_args="-DENABLE_CLANG=1 -DENABLE_LLDB=1 -DWITH_MYSQL=1"
 hostmakedepends="pkg-config clang"

--- a/srcpkgs/wxPython/template
+++ b/srcpkgs/wxPython/template
@@ -1,12 +1,12 @@
 # Template file for 'wxPython'
 pkgname=wxPython
 version=3.0.2.0
-revision=9
+revision=10
 wrksrc="${pkgname}-src-${version}"
 hostmakedepends="pkg-config"
 makedepends="
  zlib-devel libpng-devel libjpeg-turbo-devel tiff-devel expat-devel gtk+-devel
- libSM-devel MesaLib-devel glu-devel webkitgtk2-devel
+ libSM-devel MesaLib-devel glu-devel
  libnotify-devel python-devel wxWidgets-devel"
 depends="python"
 pycompile_module="wx-3.0-gtk2 wxversion.py"

--- a/srcpkgs/wxWidgets/template
+++ b/srcpkgs/wxWidgets/template
@@ -1,13 +1,13 @@
 # Template file for 'wxWidgets'
 pkgname=wxWidgets
 version=3.0.4
-revision=8
+revision=9
 configure_args="--enable-unicode --with-opengl --with-sdl --with-libmspack
- --with-libnotify --enable-mediactrl --with-gtk=2"
+ --with-libnotify --enable-mediactrl --with-gtk=2 --disable-webview"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel libjpeg-turbo-devel tiff-devel libSM-devel libnotify-devel
- libXinerama-devel libmspack-devel SDL2-devel glu-devel webkitgtk2-devel
+ libXinerama-devel libmspack-devel SDL2-devel glu-devel
  gstreamer1-devel gst-plugins-base1-devel"
 depends="wxWidgets-common>=${version}"
 short_desc="The wxWidgets GUI toolkit library (version 3)"


### PR DESCRIPTION
This PR must not be merged before the other PRs eliminating webview dependencies are merged to avoid staging. It disables the webview functionality in `wxWidgets` thus eliminating the dependency on `webkitgtk2`.

For codelite this disables the built-in web browser for the php plugin. @thypon Is that alright with you?