### PR TITLE
hugin: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/hugin/template
+++ b/srcpkgs/hugin/template
@@ -1,14 +1,14 @@
 # Template file for 'hugin'
 pkgname=hugin
 version=2018.0.0
-revision=6
+revision=7
 wrksrc="${pkgname}-${version}"
 build_style=cmake
 pycompile_module="hpi.py hsi.py"
 pycompile_dirs="usr/share/hugin/data/plugins usr/share/hugin/data/plugins-templates"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 hostmakedepends="pkg-config exiftool swig"
-makedepends="wxWidgets-devel tiff-devel libpng-devel libopenexr-devel libgomp-devel
+makedepends="wxWidgets-gtk3-devel tiff-devel libpng-devel libopenexr-devel libgomp-devel
  exiv2-devel libfreeglut-devel libpano13-devel boost-devel vigra-devel sqlite-devel
  lensfun-devel python-devel glew-devel libXmu-devel libXi-devel glu-devel
  lcms2-devel lapack-devel"
@@ -28,4 +28,14 @@ pre_configure() {
 	sed -i 's|-O3||g' src/celeste/CMakeLists.txt
 	# Fix compiling against lensfun-0.3.0
 	sed '/LF_DIST_MODEL_FOV1/d' -i src/hugin_base/lensdb/LensDB.cpp
+
+	# workaround for cmake to find wx-config-gtk3
+	# can be removed once there is only one 'wx-config'
+	if [ "$CROSS_BUILD" ]; then
+		# cannot override wxWidgets_CONFIG_EXECUTABLE set in
+		# the cross toolchain file otherwise
+		ln -s ${XBPS_WRAPPERDIR}/wx-config{-gtk3,}
+	else
+		sed -i "1i\set(wxWidgets_CONFIG_EXECUTABLE wx-config-gtk3)" CMakeLists.txt
+	fi
 }


### PR DESCRIPTION
Similar to openbabel and passwordsafe.

Tests on x86_64-musl showed no problem, loaded some images and  played around with them a bit.

On armv7l-musl the package is built ok, but shortly after start it crashes with
```
Assertion failed: src_index <= 0xffff (../src/gallium/drivers/vc4/vc4_resource.c: vc4_get_shadow_index_buffer: 1196)
```
However, this also happens with the current version. So it’s got nothing to do with wxWidgets, but with the vc4 driver, apparently. I don’t know if other drivers work that’s why I didn’t set it `broken`.

cc @lemmi