### PR TITLE
diff-pdf: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/diff-pdf/template
+++ b/srcpkgs/diff-pdf/template
@@ -1,12 +1,13 @@
 # Template file for 'diff-pdf'
 pkgname=diff-pdf
 version=0.2.20160602
-revision=8
+revision=9
 _commit=ccf96982fa8a35d64a377779cfd80c921f66cefc
 build_style=gnu-configure
+configure_args="--with-wx-config=wx-config-gtk3"
 wrksrc="$pkgname-$_commit"
 hostmakedepends="automake pkg-config"
-makedepends="wxWidgets-devel cairo-devel poppler-devel poppler-glib-devel"
+makedepends="wxWidgets-gtk3-devel cairo-devel poppler-devel poppler-glib-devel"
 short_desc="A simple tool for visually comparing two PDF files"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2"


### PR DESCRIPTION
Tested on x86_64 and armv7l-musl, works ok. There’s just a window showing the diff between two pdfs. Not much to test. ;)

@thypon Are you ok with this change?