### PR TITLE
gnuplot: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/gnuplot/template
+++ b/srcpkgs/gnuplot/template
@@ -1,7 +1,7 @@
 # Template file for 'gnuplot'
 pkgname=gnuplot
 version=5.2.4
-revision=4
+revision=5
 configure_args="--with-readline=builtin"
 hostmakedepends="pkg-config lua52"
 makedepends="zlib-devel libX11-devel gd-devel lua52-devel"
@@ -15,7 +15,7 @@ checksum=1515f000bd373aaa53b16183f274189d4f5e0ae47d22f434857933d16a4770cb
 
 subpackages="gnuplot-common"
 if [ -z "$CROSS_BUILD" ]; then
-	makedepends+=" cairo-devel pango-devel wxWidgets-devel qt5-tools-devel qt5-svg-devel"
+	makedepends+=" cairo-devel pango-devel wxWidgets-gtk3-devel qt5-tools-devel qt5-svg-devel"
 	subpackages+=" gnuplot-wx gnuplot-qt"
 fi
 
@@ -46,7 +46,7 @@ do_configure() {
 		cd ${wrksrc}/x11
 		./configure ${configure_args} --disable-wxwidgets --without-cairo --without-qt
 		cd ${wrksrc}/wx
-		./configure ${configure_args} --without-qt ac_cv_path_WX_CONFIG=/usr/bin/wx-config-3.0 LIBS="-lX11"
+		./configure ${configure_args} --without-qt ac_cv_path_WX_CONFIG=wx-config-gtk3 LIBS="-lX11"
 		cd ${wrksrc}/qt
 		./configure ${configure_args} --with-qt --disable-wxwidgets
 	else


### PR DESCRIPTION
Tested on x86_64, plotted some functions, all ok. wxWidgets isn’t enabled in cross-builds so nothing to do there. ;)

cc @chneukirchen 