### PR TITLE
owncloudclient: update to 2.4.3.

### DIFF
--- a/srcpkgs/owncloudclient/template
+++ b/srcpkgs/owncloudclient/template
@@ -1,22 +1,22 @@
 # Template file for 'owncloudclient'
 pkgname=owncloudclient
-version=2.4.1
+version=2.4.3
 revision=1
 build_style=cmake
-configure_args="-Wno-dev"
+configure_args="-Wno-dev -DNO_SHIBBOLETH=TRUE"
 hostmakedepends="pkg-config"
-makedepends="qtkeychain-qt5-devel sqlite-devel qt5-webkit-devel qt5-declarative-devel
+makedepends="qtkeychain-qt5-devel sqlite-devel qt5-declarative-devel
  qt5-tools-devel qt5-plugin-odbc qt5-plugin-tds qt5-plugin-pgsql qt5-plugin-mysql
  qt5-plugin-sqlite"
 depends="qt5-plugin-sqlite"
 conf_files="/etc/ownCloud/sync-exclude.lst"
 short_desc="Connect to ownCloud servers"
 maintainer="Samuel Chodur <samuelchodur@gmail.com>"
-license="GPL-2"
-homepage="http://www.owncloud.org"
+license="GPL-2.0-or-later"
+homepage="https://www.owncloud.org"
 distfiles="https://download.owncloud.com/desktop/stable/${pkgname}-${version}.tar.xz"
-checksum=4462ae581c281123dc62f3604f1aa54c8f4a60cd8157b982e2d76faac0f7aa23
+checksum=f3b3ff13d06a8a38a40398630d670775eafbfa9fee4fa5b39ea480bac3ebe6bf
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-tools-devel"
 fi


### PR DESCRIPTION
- disable SHIBBOLETH. It needs the insecure qt5-webkit and
Owncloud/Nextcloud supports (much more secure) app passwords
since version 11.x