### PR TITLE
gjs: update to 1.54.0.

### DIFF
--- a/srcpkgs/gjs/template
+++ b/srcpkgs/gjs/template
@@ -1,29 +1,34 @@
 # Template file for 'gjs'
 pkgname=gjs
-version=1.52.3
+version=1.54.0
 revision=1
 configure_args="--without-dbus-tests"
 build_style=gnu-configure
 hostmakedepends="glib-devel gobject-introspection intltool pkg-config"
-makedepends="dbus-glib-devel libgirepository-devel mozjs52-devel readline-devel"
+makedepends="dbus-glib-devel libgirepository-devel mozjs60-devel readline-devel"
 short_desc="Mozilla-based javascript bindings for the GNOME platform"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT, LGPL-2.0-or-later"
-#changelog="https://gitlab.gnome.org/GNOME/gjs/blob/gnome-3-28/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gjs/blob/gnome-3-30/NEWS"
 homepage="https://wiki.gnome.org/action/show/Projects/Gjs"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=ce21d8a83f6077b011b8834c4936281be65b2b62387f0745c3eb9adf780996fc
+checksum=e22c63f4dbf243d7a5a6660f6443ca3e5768695a48fc9fdf078bce7cf7aa657d
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) configure_args+=" --disable-profiler" # https://gitlab.gnome.org/GNOME/gjs/issues/132
 esac
+
+do_check() {
+	# GJS's test try to use Cairo and GTK+ which need X
+	:
+}
 
 post_install() {
 	vlicense COPYING
 }
 
 gjs-devel_package() {
-	depends="libgirepository-devel mozjs52-devel ${sourcepkg}>=${version}_${revision}"
+	depends="libgirepository-devel mozjs60-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
Needs https://github.com/void-linux/void-packages/pull/2721 to compile correctly on musl.