### PR TITLE
perl-Text-Bidi: enable cross build

### DIFF
--- a/srcpkgs/perl-Text-Bidi/template
+++ b/srcpkgs/perl-Text-Bidi/template
@@ -4,16 +4,15 @@ version=2.12
 revision=6
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
-hostmakedepends="perl fribidi-devel"
+hostmakedepends="perl"
 makedepends="perl fribidi-devel perl-ExtUtils-PkgConfig"
 depends="perl"
 short_desc="Text::Bidi - Unicode bidi algorithm using libfribidi"
 maintainer="DirectorX <void.directorx@protonmail.com>"
 homepage="https://metacpan.org/release/Text-Bidi"
-license="GPL-1, Artistic"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 distfiles="$CPAN_SITE/Text/Text-Bidi-${version}.tar.gz"
 checksum=72e700cc4e7f48eb479989cc9d38362d24c58ea6fb1e0fe3390a832903943fa7
-nocross=yes
 
 urxvt-bidi_package() {
 	depends="${sourcepkg}>=${version}_${revision} rxvt-unicode"


### PR DESCRIPTION
Just removed `nocross`. It actually builds fine now.

Also removed fribidi-devel from `hostmakedepends`; I think it should only be in `makedepends`. @DirectorX is there a reason I might not see why it was there and are you alright with these changes? :)

A simple `perl -e "use Text::Bidi"` on armv7l-musl loaded the module successfully.