### PR TITLE
pycharm-community: update to 2018.2.3.

### DIFF
--- a/srcpkgs/pycharm-community/template
+++ b/srcpkgs/pycharm-community/template
@@ -1,6 +1,6 @@
 # Template file for 'pycharm-community'
 pkgname=pycharm-community
-version=2018.1.4
+version=2018.2.3
 revision=1
 depends="virtual?java-environment giflib libXtst"
 short_desc="Python integrated development environment"
@@ -8,7 +8,7 @@ maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/pycharm/"
 distfiles="https://download-cf.jetbrains.com/python/${pkgname}-${version}.tar.gz"
-checksum=90953ca424bb331348e3575975fab4e189ab126ddc367223e3a7cb01b1563f3b
+checksum=fc09868135282588d64a4d50c3c0dc140dddc9e9e9b86bc0a7a3f3dfaaf86e2b
 repository=nonfree
 nopie=yes
 only_for_archs="i686 x86_64"
@@ -21,6 +21,14 @@ do_install() {
 	mv -v bin lib plugins helpers ${DESTDIR}/usr/share/pycharm
 	mv -v license ${DESTDIR}/usr/share/doc/pycharm
 	rm -vf ${DESTDIR}/usr/share/pycharm/bin/fsnotifier-arm
+	for i in _pydevd_bundle _pydevd_frame_eval; do
+		rm -vf ${DESTDIR}/usr/share/pycharm/helpers/pydev/"$i"/pydevd_*_darwin_*.so
+		rm -vf ${DESTDIR}/usr/share/pycharm/helpers/pydev/"$i"/pydevd_*_win32_*.pyd
+	done
+	rm -vf ${DESTDIR}/usr/share/pycharm/helpers/pydev/pydevd_attach_to_process/attach_*.dll
+	rm -vf ${DESTDIR}/usr/share/pycharm/helpers/pydev/pydevd_attach_to_process/attach_*.dylib
+	rm -vf ${DESTDIR}/usr/share/pycharm/helpers/pydev/third_party/wrapped_for_pydev/ctypes/_ctypes.dll
+
 	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		rm -vf ${DESTDIR}/usr/share/pycharm/bin/fsnotifier
 		rm -vf ${DESTDIR}/usr/share/pycharm/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so


### PR DESCRIPTION
Also added logic to remove Win32/Darwin libraries which we don't need to distribute.