### PR TITLE
 syndication: update to 5.50.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3395,7 +3395,7 @@ libglslang.so glslang-6.2.2596_1
 libSPIRV.so glslang-6.2.2596_1
 libmaxminddb.so.0 libmaxminddb-1.3.2_1
 libmysqlpp.so mysql++-3.2.4_1
-libKF5Syndication.so.5 syndication-18.08.0_1
+libKF5Syndication.so.5 syndication-5.50.0_1
 liblqr-1.so.0 liblqr-0.4.2_1
 libmozjs-60.so.0 mozjs60-60.0.2_1
 libgtksourceview-4.so.0 gtksourceview4-4.0.2_1

--- a/srcpkgs/akregator/template
+++ b/srcpkgs/akregator/template
@@ -1,7 +1,7 @@
 # Template file for 'akregator'
 pkgname=akregator
 version=18.08.1
-revision=1
+revision=2
 build_style=cmake
 configure_args=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kdoctools

--- a/srcpkgs/syndication/template
+++ b/srcpkgs/syndication/template
@@ -1,6 +1,7 @@
 # Template file for 'syndication'
 pkgname=syndication
-version=18.08.1
+reverts="18.08.0_1 18.08.0_2 18.08.1_1"
+version=5.50.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools"
@@ -9,8 +10,8 @@ short_desc="RSS/Atom parser library"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
 homepage="https://community.kde.org/KDE_PIM"
-distfiles="${KDE_SITE}/applications/${version}/src/syndication-${version}.tar.xz"
-checksum=a06155e69b94271850fbba2a1e642fe297c72a47699b38a99a4586f5515e3952
+distfiles="${KDE_SITE}/frameworks/${version%.*}/syndication-${version}.tar.xz"
+checksum=6355e2b14966e455dd0d6fd9cdb6691e905ab62be1981b9efbfb3727305de3c4
 
 syndication-devel_package() {
 	short_desc+=" - development"


### PR DESCRIPTION
syndication is now part of kde-frameworks and therefore also following
the kde framework versioning, which results in a lower number than
before.

CC @Hoshpak 