### PR TITLE
compton: update to 2.

### DIFF
--- a/srcpkgs/compton/template
+++ b/srcpkgs/compton/template
@@ -1,9 +1,7 @@
 # Template file for 'compton'
 pkgname=compton
-version=0.0.20180811
+version=2
 revision=1
-_githash=cac8094ce12cd40706fb48f9ab35354d9ee7c48f
-wrksrc="compton-${_githash}"
 build_style=gnu-makefile
 hostmakedepends="pkg-config asciidoc"
 makedepends="dbus-devel libXcomposite-devel libXrandr-devel pcre-devel
@@ -13,12 +11,12 @@ short_desc="Compositor for X11 (fork of xcompmgr-dana)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="https://github.com/yshui/compton/"
-distfiles="https://github.com/yshui/compton/archive/${_githash}.tar.gz"
-checksum=26fcdb1b67a6f29e20011f22b8f852120c84bbb82a145ea4420ee7d5e7b76caa
+distfiles="https://github.com/yshui/compton/archive/v${version}.tar.gz"
+checksum=3569b35e42ba83261e7cf4aa8e3861b6bd7d43743ca3b26bc9a8956718a2e2b0
 replaces="compton-git>=0"
 
 pre_build() {
-	export COMPTON_VERSION="v0.1_beta2"
+	export COMPTON_VERSION="v${version}"
 }
 post_install() {
 	vsconf compton.sample.conf


### PR DESCRIPTION
"Since compton is unlikely to get a major update in the future, we will use a simple version number system from now on: the version name will only contain a single number which is bumped every release."