### PR TITLE
obs: include additional submodules

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -1,8 +1,11 @@
 # Template file for 'obs'
 pkgname=obs
 version=22.0.3
-revision=1
-wrksrc=obs-studio-${version}
+revision=2
+_commit_hash_obs_browser="a321928756ae8ed4315d6d7b35a113e76493297c"
+_commit_hash_obs_vst="b0f046f0ac0c8181d018f7148c7617b577a1e085"
+_commit_hash_ftl_sdk="98289f7c2ed754c647d451899b3356850c0c1fa3"
+wrksrc="obs-studio-${version}"
 only_for_archs="i686 x86_64 i686-musl x86_64-musl"
 build_style=cmake
 configure_args="-DOBS_VERSION_OVERRIDE=${version}"
@@ -15,8 +18,23 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2.0-or-later"
 homepage="https://obsproject.com"
 changelog="https://github.com/obsproject/obs-studio/releases"
-distfiles="https://github.com/jp9000/obs-studio/archive/${version}.tar.gz"
-checksum=86a3dbfbec5eee8305ece08d4ce6e7993d20f15ea206b4ab1bdf424f2af74c12
+distfiles="https://github.com/obsproject/obs-studio/archive/${version}.tar.gz
+https://github.com/obsproject/obs-browser/archive/${_commit_hash_obs_browser}.tar.gz>obs_browser.tgz
+https://github.com/obsproject/obs-vst/archive/${_commit_hash_obs_vst}.tar.gz>obs_vst.tgz
+https://github.com/Mixer/ftl-sdk/archive/${_commit_hash_ftl_sdk}.tar.gz>ftl_sdk.tgz"
+checksum="86a3dbfbec5eee8305ece08d4ce6e7993d20f15ea206b4ab1bdf424f2af74c12
+f780f811f3477e196602dbe405c0c680e9a2e12ede415489339ffaee73e2c729
+3e5ad62918a7324fe5ab6c16a5d58e67ba511c387f9d96cf71718cf530af26e3
+00bb0d9dfe9cccd865eea4ebbe77e3a1f4a138b4a18ab4efb25ec3cddb6d1fd1"
+
+post_extract() {
+	rmdir ./plugins/obs-browser;
+	mv -T "../obs-browser-${_commit_hash_obs_browser}" ./plugins/obs-browser;
+	rmdir ./plugins/obs-vst;
+	mv -T "../obs-vst-${_commit_hash_obs_vst}" ./plugins/obs-vst;
+	rmdir ./plugins/obs-outputs/ftl-sdk;
+	mv -T "../ftl-sdk-${_commit_hash_ftl_sdk}" ./plugins/obs-outputs/ftl-sdk;
+}
 
 obs-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Currently the obs package misses a lot of features, because the submodules are not included, one of those e.g. is FTL streaming used on e.g. mixer