### PR TITLE
linux4.14: update to 4.14.70. [ci skip]

### DIFF
--- a/srcpkgs/linux4.14/template
+++ b/srcpkgs/linux4.14/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.14'
 pkgname=linux4.14
-version=4.14.69
+version=4.14.70
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz"
-checksum=61bdd5fbb0e33362d27476e7d8aade0aa1ad11ddb5959a27094c254cc03b19f0
+checksum=c5dfd832477f8856b5b094ab62cc8c8491d04b76b2ec5ebb0126e554891ee32c
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes


### PR DESCRIPTION
fixes CVE-2018-6554 and CVE-2018-6555.