### PR TITLE
build-style/meson: enable Link-Time-Optimization by default.

### DIFF
--- a/common/build-style/meson.sh
+++ b/common/build-style/meson.sh
@@ -34,7 +34,7 @@ do_configure() {
 [binaries]
 c = '${CC}'
 cpp = '${CXX}'
-ar = '${AR}'
+ar = '${XBPS_CROSS_TRIPLET}-gcc-ar'
 nm = '${NM}'
 ld = '${LD}'
 strip = '${STRIP}'
@@ -76,7 +76,12 @@ EOF
 		unset _MESON_CPU_FAMILY _MESON_TARGET_CPU _MESON_TARGET_ENDIAN
 	fi
 
-	${meson_cmd} --prefix=/usr --buildtype=plain ${configure_args} . ${meson_builddir}
+	# The binutils ar cannot perform LTO on static libraries so we have to use
+	# the gcc-ar wrapper that that calls the correct plugin
+	# https://github.com/mesonbuild/meson/issues/1646
+	export AR="gcc-ar"
+
+	${meson_cmd} --prefix=/usr -Db_lto=true --buildtype=plain ${configure_args} . ${meson_builddir}
 }
 
 do_build() {

--- a/srcpkgs/fuse3/template
+++ b/srcpkgs/fuse3/template
@@ -4,7 +4,7 @@ version=3.2.6
 revision=1
 wrksrc="fuse-${version}"
 build_style=meson
-configure_args="--sbindir=bin"
+configure_args="--sbindir=bin -Db_lto=false"
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="Filesystem in Userspace 3.x"

--- a/srcpkgs/fwupd/template
+++ b/srcpkgs/fwupd/template
@@ -7,7 +7,7 @@ build_style=meson
 # tests require unpackaged umockdev
 configure_args="-Dbootdir=/boot/EFI -Dconsolekit=false -Dgtkdoc=false
  -Dintrospection=true -Dsystemd=false -Dplugin_altos=false -Dtests=false
- -Dman=false -Dpkcs7=false"
+ -Dman=false -Dpkcs7=false -Db_lto=false"
 hostmakedepends="dejavu-fonts-ttf gnutls-tools help2man pkg-config gcab
  gobject-introspection"
 makedepends="appstream-glib-devel cairo-devel colord-devel

--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -7,7 +7,8 @@ build_style=meson
 configure_args="-Dshared-glapi=true -Dgbm=true -Degl=true
  -Dgallium-vdpau=true -Dgallium-xvmc=true -Dosmesa=gallium
  -Dtexture-float=true -Dgles1=true -Dgles2=true -Dgallium-va=true
- -Dplatforms=x11,drm,wayland,surfaceless -Dllvm=true -Dlmsensors=true"
+ -Dplatforms=x11,drm,wayland,surfaceless -Dllvm=true -Dlmsensors=true
+ -Db_lto=false"
 hostmakedepends="flex libxml2-python llvm pkg-config
  python-Mako wayland-protocols wayland-devel"
 makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel


### PR DESCRIPTION
This PR enables [Link Time Optimization](https://gcc.gnu.org/wiki/LinkTimeOptimization) or LTO by default on all meson builds

changes:

switch to using the gcc-ar wrapper that passes the correct plugin paths for static libraries (this is working around a binutils bug). See: https://github.com/mesonbuild/meson/issues/1646

- [x] AppStream
- [x] Marker
- [x] Minder
- [x] bolt
- [x] gnome-tweaks
- [x] FeedReader
- [x] accountsservice
- [x] appstream-glib
- [x] at-spi2-atk
- [x] atk
- [x] atomix
- [x] at-spi2-core
- [x] bijiben
- [x] brisk-menu
- [x] baobab
- [x] cinnamon-desktop
- [x] cinnamon-session
- [x] colord
- [x] corebird
- [x] cozy
- [x] dconf-editor
- [x] dconf
- [x] devhelp
- [x] elogind
- [x] enlightenment
- [x] eog
- [x] epiphany
- [ ] file-roller
- [x] five-or-more
- [x] fuse3
- [x] fwupd
- [x] gcab
- [x] gdk-pixbuf
- [x] geocode-glib
- [x] girara
- [x] glib-networking
- [x] gnome-backgrounds
- [x] gnome-bluetooth
- [x] gnome-chess
- [x] gnome-builder
- [x] gnome-calculator
- [x] gnome-calendar
- [x] gnome-characters
- [x] gnome-boxes
- [x] gnome-clocks
- [x] gnome-color-manager
- [x] gnome-contacts
- [x] gnome-control-center
- [x] gnome-dictionary
- [x] gnome-disk-utility
- [x] gnome-documents
- [x] gnome-font-viewer
- [x] gnome-initial-setup
- [x] gnome-maps
- [x] gnome-mines
- [x] gnome-multi-writer
- [x] gnome-music
- [x] gnome-power-manager
- [x] gnome-recipes
- [x] gnome-screenshot
- [x] gnome-settings-daemon
- [x] gnome-session
- [x] gnome-shell-extensions
- [x] gnome-shell
- [x] gnome-sudoku
- [x] gnome-system-monitor
- [x] gnome-todo
- [x] gobject-introspection
- [x] gradio
- [x] grilo-plugins
- [x] fuse-sshfs
- [x] gvfs
- [x] hexchat
- [x] intel-gpu-tools
- [x] json-glib
- [x] jsonrpc-glib
- [x] kiwix-lib
- [x] kiwix-tools
- [x] ksh
- [x] libcloudproviders
- [x] libdazzle
- [x] libdrm
- [x] libepoxy
- [x] libgepub
- [x] libgit2-glib
- [x] libgusb
- [x] libgweather
- [x] libinput
- [x] libmpdclient
- [x] libxkbcommon
- [x] libzim
- [x] lightsoff
- [x] lighttpd
- [x] linux-driver-management
- [x] lollypop
- [x] mpc
- [x] nautilus
- [x] ncmpc
- [x] nemo
- [x] nautilus-sendto
- [x] gnome-mpv
- [x] pantheon-screenshot
- [x] paper-icon-theme
- [x] paprefs
- [x] pipewire
- [x] playerctl
- [x] pithos
- [x] polari
- [x] pulseeffects
- [x] libGL
- [x] gnome-twitch
- [x] rage-player
- [x] razergenie
- [x] seahorse
- [x] shotwell
- [x] simple-scan
- [x] spice-protocol
- [x] swell-foop
- [x] sysprof
- [x] totem-pl-parser
- [x] terminology
- [x] totem
- [x] vapoursynth-mvtools
- [x] template-glib
- [x] viewnior
- [x] xapps
- [x] eolie
- [x] xorg-server
- [x] zathura-cb
- [x] zathura-pdf-poppler
- [x] zathura-pdf-mupdf
- [x] zathura
- [x] zathura-ps
- [x] zathura-djvu
- [x] taisei
- [x] goodvibes
- [x] gnome-usage
- [x] io.elementary.calculator
- [x] libratbag
- [x] libplacebo
- [x] io.elementary.videos
- [x] zim-tools
- [x] sequeler
- [x] io.elementary.terminal
- [x] pdftag
- [x] piper
- [x] pscircle
- [x] zchunk
- [ ] quickDocs
- [ ] scrcpy
- [x] pantheon-agent-polkit