### PR TITLE
linux4.9: update to 4.9.127. [ci skip]

### DIFF
--- a/srcpkgs/linux4.9/template
+++ b/srcpkgs/linux4.9/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.9'
 pkgname=linux4.9
-version=4.9.124
+version=4.9.127
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz"
-checksum=5ca6b0d48c8dd1265005169f1b97149a4e893668c0d8aa566a73c7663c8e4311
+checksum=9477aeaded97589a40d7cbbfeebfa7a8f863130c0729a8dc5cdbcf48eb6fdd0f
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes


### PR DESCRIPTION
fixes CVE-2018-6554 and CVE-2018-6555.