### PR TITLE
linux4.4: update to 4.4.156. [ci skip]

### DIFF
--- a/srcpkgs/linux4.4/template
+++ b/srcpkgs/linux4.4/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.4'
 pkgname=linux4.4
-version=4.4.152
+version=4.4.156
 revision=1
 wrksrc="linux-${version}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -8,7 +8,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="${KERNEL_SITE}/kernel/v4.x/linux-${version}.tar.xz"
-checksum=1bee76891686a03e3129e84a9b17f2a3c659481bfccdbb4a37e7abc5c8f1d3cb
+checksum=0442d8d8ca967211cd181f5d9655e1658aa84a9ec265417223dd29c4983d48aa
 
 nocross=yes
 nodebug=yes


### PR DESCRIPTION
fixes CVE-2018-6554 and CVE-2018-6555.