### PR TITLE
common/shlibs:  remove entries from packages that don't exist anymore

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -798,8 +798,6 @@ libgdk-3.so.0 gtk+3-3.0.0_1
 libgtk-3.so.0 gtk+3-3.0.0_1
 libgailutil-3.so.0 gtk+3-3.0.0_1
 liblightdm-gobject-1.so.0 liblightdm-gobject-1.2.2_1
-liblightdm-qt-3.so.0 liblightdm-qt-1.10.1_1
-liblightdm-qt5-3.so.0  liblightdm-qt5-1.12.2_3
 libcelt0.so.2 celt-0.11.1_1
 libspice-server.so.1 spice-0.6.4_1
 libbrasero-burn3.so.1 brasero-2.91.90_1
@@ -985,10 +983,7 @@ libgtksourceviewmm-3.0.so.0 gtksourceviewmm-3.2.0_1
 libyajl.so.2 yajl-2.0.1_1
 libconfuse.so.2 confuse-3.2.1_1
 libclang.so.6 clang-6.0.0_1
-libLLVM-3.8.so libllvm3.8-3.8.0_1
-libLLVM-3.8.1.so libllvm3.8-3.8.1_1
 libLLVM-3.9.so libllvm3.9-3.9.0_1
-libLLVM-4.0.so libllvm4.0-4.0.0_1
 libLLVM-6.0.so libllvm6.0-6.0.0_1
 libisofs.so.6 libisofs-0.6.24_1
 libmpack.so.0 libmpack-1.0.5_1
@@ -1180,7 +1175,6 @@ libwayland-server.so.0 wayland-1.6.0_1
 libwayland-client.so.0 wayland-1.10.0_1
 libwayland-cursor.so.0 wayland-1.6.0_1
 libtomcrypt.so.1 libtomcrypt-1.18.0_1
-libOpenCL.so.1 libOpenCL-1.0_1
 libHX.so.28 libHX-3.14_1
 libxkbcommon.so.0 libxkbcommon-0.2.0_1
 libxkbcommon-x11.so.0 libxkbcommon-x11-0.4.2_1
@@ -3006,13 +3000,6 @@ libGammu.so.8 gammu-1.39.0_1
 libz3.so z3-4.6.0_2
 libngspice.so.0 ngspice-27_2
 libvulkan.so.1 vulkan-loader-1.0.57.0_1
-libVkLayer_core_validation.so vulkan-validation-layers-1.0.57.0_1
-libVkLayer_device_profile_api.so vulkan-validation-layers-1.0.57.0_1
-libVkLayer_object_tracker.so vulkan-validation-layers-1.0.57.0_1
-libVkLayer_parameter_validation.so vulkan-validation-layers-1.0.57.0_1
-libVkLayer_threading.so vulkan-validation-layers-1.0.57.0_1
-libVkLayer_unique_objects.so vulkan-validation-layers-1.0.57.0_1
-libVkLayer_utils.so vulkan-validation-layers-1.0.57.0_1
 libembb_mtapi_cpp.so embb-devel-1.0.0_1
 libembb_mtapi_c.so embb-devel-1.0.0_1
 libembb_mtapi_network_c.so embb-devel-1.0.0_1


### PR DESCRIPTION
This removes entries from packages that are available in the repos but not used by any package.