### PR TITLE
linux3.18: update to 3.18.122. [ci skip]

### DIFF
--- a/srcpkgs/linux3.18/template
+++ b/srcpkgs/linux3.18/template
@@ -1,6 +1,6 @@
 # Template file for 'linux3.18'
 pkgname=linux3.18
-version=3.18.118
+version=3.18.122
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="${KERNEL_SITE}/kernel/v3.x/linux-${version}.tar.xz"
-checksum=f94c9e2931829f4c972f005a7dc643f7e0c8eac87239c2a1060af763b8e3f8af
+checksum=675b1ce36af23caa500cb1d4f0ec2976791fb0a97ebb6486a5e2ebcb5527ade5
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
note: CVE-2018-9363 was fixed in 3.18.119.