### PR TITLE
virt-manager: move tools to virt-manager-tools subpackage

### DIFF
--- a/srcpkgs/virt-manager-tools
+++ b/srcpkgs/virt-manager-tools
@@ -1,0 +1,1 @@
+virt-manager

--- a/srcpkgs/virt-manager/template
+++ b/srcpkgs/virt-manager/template
@@ -1,16 +1,14 @@
 # Template file for 'virt-manager'
 pkgname=virt-manager
 version=2.0.0
-revision=1
+revision=2
 noarch=yes
 nocross=yes
 build_style=python3-module
-hostmakedepends="intltool python3-devel glib-devel gtk-update-icon-cache"
-depends="libosinfo python3-gobject gnome-ssh-askpass openbsd-netcat yajl
- libvirt-python3 python3-urllib3 libxml2-python3
- gir-freedesktop libvirt-glib spice-gtk gtk-vnc vte3 python3-requests dmidecode"
-pycompile_dirs="/usr/share/${pkgname}"
-pycompile_version="$py3_ver"
+hostmakedepends="intltool python-devel glib-devel gtk-update-icon-cache"
+depends="gnome-ssh-askpass openbsd-netcat yajl python-gconf
+ python-urlgrabber gir-freedesktop libvirt-glib spice-gtk gtk-vnc vte3
+ dmidecode virt-manager-tools"
 short_desc="User interface for managing virtual machines"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-or-later"
@@ -21,4 +19,29 @@ checksum=eb6fa4d7b7d539fb006d0822760a5e97ddf99b1f131806d08eaea6d4f3ea88ac
 post_install() {
 	rm $DESTDIR/usr/share/glib-2.0/schemas/gschemas.compiled \
 		$DESTDIR/usr/share/icons/hicolor/icon-theme.cache
+}
+
+virt-manager-tools_package() {
+	noarch=yes
+	short_desc="Programs to create and clone virtual machines"
+	depends="libosinfo python3-gobject libvirt-python3 python3-urllib3 libxml2-python3 python3-requests"
+	pycompile_dirs="/usr/share/${sourcepkg}"
+	pycompile_version="$py3_ver"
+	pkg_install() {
+		vmove usr/bin/virt-clone
+		vmove usr/bin/virt-convert
+		vmove usr/bin/virt-install
+		vmove usr/bin/virt-xml
+		vmove usr/share/man/man1/virt-install.1
+		vmove usr/share/man/man1/virt-convert.1
+		vmove usr/share/man/man1/virt-clone.1
+		vmove usr/share/man/man1/virt-xml.1
+		vmove usr/share/virt-manager/virt-clone
+		vmove usr/share/virt-manager/virt-convert
+		vmove usr/share/virt-manager/virt-install
+		vmove usr/share/virt-manager/virt-xml
+		vmove usr/share/virt-manager/virtcli
+		vmove usr/share/virt-manager/virtconv
+		vmove usr/share/virt-manager/virtinst
+	}
 }


### PR DESCRIPTION
Continuation of https://github.com/voidlinux/void-packages/pull/13513