### PR TITLE
vala: update to 0.42.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2930,7 +2930,8 @@ libsysprof-2.so sysprof-3.24.1_1
 libsysprof-ui-2.so sysprof-3.24.1_1
 libmozjs-52.so mozjs52-52.3.0_1
 libmozjs-52.so.0 mozjs52-52.3.0_1
-libvala-0.40.so.0 libvala-0.40.2_1
+libvala-0.42.so.0 libvala-0.42.1_1
+libvaladoc-0.42.so.0 libvala-0.42.1_1
 libphodav-2.0.so.0 phodav-2.2_1
 libgfshare.so.2 libgfshare-2.0.0_1
 libtracker-miner-2.0.so.0 libtracker-2.0.1_1

--- a/srcpkgs/anjuta/template
+++ b/srcpkgs/anjuta/template
@@ -1,7 +1,7 @@
 # Template file for 'anjuta'
 pkgname=anjuta
 version=3.28.0
-revision=4
+revision=5
 build_style=gnu-configure
 build_options="gir"
 configure_args="$(vopt_enable gir introspection)"

--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-builder'
 pkgname=gnome-builder
 version=3.30.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_webkit=true"
 hostmakedepends="appdata-tools desktop-file-utils flex gobject-introspection

--- a/srcpkgs/gnome-usage/patches/fix-vala-0-42-build.patch
+++ b/srcpkgs/gnome-usage/patches/fix-vala-0-42-build.patch
@@ -1,0 +1,20 @@
+--- src/speedometer.vala
++++ src/speedometer.vala
+@@ -33,7 +33,7 @@ namespace Usage
+ 
+         private Gtk.CssProvider css_provider;
+ 
+-        private int _percentage;
++        private int _percentage = 0;
+         public int percentage {
+             get {
+                 return _percentage;
+@@ -43,7 +43,7 @@ namespace Usage
+ 
+                 _percentage = value;
+             }
+-            default = 0; }
++        }
+ 
+         construct {
+             css_provider = new Gtk.CssProvider();

--- a/srcpkgs/granite/patches/fix-build-with-vala-0-42.patch
+++ b/srcpkgs/granite/patches/fix-build-with-vala-0-42.patch
@@ -1,0 +1,40 @@
+--- lib/Widgets/SeekBar.vala
++++ lib/Widgets/SeekBar.vala
+@@ -26,7 +26,7 @@
+ 
+ public class Granite.SeekBar : Gtk.Grid {
+     private double _playback_duration;
+-    private double _playback_progress;
++    private double _playback_progress = 0.0;
+ 
+     /*
+      * The time of the full duration of the playback.
+@@ -68,7 +68,6 @@ public class Granite.SeekBar : Gtk.Grid {
+             scale.set_value (progress);
+             progression_label.label = DateTime.seconds_to_time ((int) (progress * playback_duration));
+         }
+-        default = 0.0;
+     }
+ 
+     /*
+--- lib/Widgets/StorageBar.vala
++++ lib/Widgets/StorageBar.vala
+@@ -83,7 +83,7 @@ public class Granite.Widgets.StorageBar : Gtk.Box {
+         }
+     }
+ 
+-    private uint64 _total_usage;
++    private uint64 _total_usage = 0;
+ 
+     public uint64 total_usage {
+         get {
+@@ -94,8 +94,6 @@ public class Granite.Widgets.StorageBar : Gtk.Box {
+             _total_usage = uint64.min (value, storage);
+             update_size_description ();
+         }
+-
+-        default = 0;
+     }
+ 
+     public int inner_margin_sides {
+

--- a/srcpkgs/vala/patches/libvaladoc-Allow-disabling-the-graphviz-dependency.patch
+++ b/srcpkgs/vala/patches/libvaladoc-Allow-disabling-the-graphviz-dependency.patch
@@ -1,0 +1,220 @@
+From eb716dc856c20b3da146a4e83e9800bd1f53c739 Mon Sep 17 00:00:00 2001
+From: Rico Tzschichholz <ricotz@ubuntu.com>
+Date: Wed, 6 Sep 2017 18:52:55 +0200
+Subject: [PATCH] libvaladoc: Allow disabling the graphviz dependency of
+ valadoc
+
+https://bugzilla.gnome.org/show_bug.cgi?id=787375
+Rebased for 0.42
+diff --git a/configure.ac b/configure.ac
+index 730c72d..af81986 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -119,34 +119,38 @@ PKG_CHECK_MODULES(GMODULE, gmodule-2.0 >= $GLIB_REQUIRED)
+ AC_SUBST(GMODULE_CFLAGS)
+ AC_SUBST(GMODULE_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBGVC, libgvc >= $LIBGVC_REQUIRED)
+-AC_MSG_CHECKING([for CGRAPH])
+-cgraph_tmp_LIBADD="$LIBADD"
+-cgraph_tmp_CFLAGS="$CFLAGS"
+-LIBADD="$LIBADD $LIBGVC_LIBS"
+-CFLAGS="$CFLAGS $LIBGVC_CFLAGS"
+-AC_RUN_IFELSE(
+-	[AC_LANG_SOURCE([
+-		#include <gvc.h>
+-
+-		int main(void) {
+-			#ifdef WITH_CGRAPH
+-				return 0;
+-			#else
+-				return -1;
+-			#endif
+-		}
+-	])], [
+-		AC_MSG_RESULT([yes])
+-		VALAFLAGS="$VALAFLAGS -D WITH_CGRAPH"
+-		have_cgraph=yes
+-	], [
+-		AC_MSG_RESULT([no])
+-		have_cgraph=no
+-	]
+-)
+-LIBADD="$cgraph_tmp_LIBADD"
+-CFLAGS="$cgraph_tmp_CFLAGS"
++AC_ARG_ENABLE(graphviz, AS_HELP_STRING([--disable-graphviz], [Disable graphviz usage for valadoc]), enable_graphviz=$enableval, enable_graphviz=yes)
++if test x$enable_graphviz = xyes; then
++	PKG_CHECK_MODULES(LIBGVC, libgvc >= $LIBGVC_REQUIRED)
++	AC_MSG_CHECKING([for CGRAPH])
++	VALAFLAGS="$VALAFLAGS -D HAVE_GRAPHVIZ"
++	cgraph_tmp_LIBADD="$LIBADD"
++	cgraph_tmp_CFLAGS="$CFLAGS"
++	LIBADD="$LIBADD $LIBGVC_LIBS"
++	CFLAGS="$CFLAGS $LIBGVC_CFLAGS"
++	AC_RUN_IFELSE(
++		[AC_LANG_SOURCE([
++			#include <gvc.h>
++			int main(void) {
++				#ifdef WITH_CGRAPH
++					return 0;
++				#else
++					return -1;
++				#endif
++			}
++		])], [
++			AC_MSG_RESULT([yes])
++			VALAFLAGS="$VALAFLAGS -D WITH_CGRAPH"
++			have_cgraph=yes
++		], [
++			AC_MSG_RESULT([no])
++			have_cgraph=no
++		]
++	)
++	LIBADD="$cgraph_tmp_LIBADD"
++	CFLAGS="$cgraph_tmp_CFLAGS"
++fi
++AM_CONDITIONAL(ENABLE_GRAPHVIZ, test x$enable_graphviz = xyes)
+ AM_CONDITIONAL(HAVE_CGRAPH, test "$have_cgraph" = "yes")
+ 
+ AC_PATH_PROG([XSLTPROC], [xsltproc], :)
+diff --git a/libvaladoc/Makefile.am b/libvaladoc/Makefile.am
+index 384292f..604ab54 100644
+--- a/libvaladoc/Makefile.am
++++ b/libvaladoc/Makefile.am
+@@ -126,10 +126,6 @@ libvaladoc_la_VALASOURCES = \
+ 	content/tablerow.vala \
+ 	content/taglet.vala \
+ 	content/text.vala \
+-	charts/chart.vala \
+-	charts/chartfactory.vala \
+-	charts/hierarchychart.vala \
+-	charts/simplechartfactory.vala \
+ 	parser/manyrule.vala \
+ 	parser/oneofrule.vala \
+ 	parser/optionalrule.vala \
+@@ -156,17 +152,30 @@ libvaladoc_la_VALASOURCES = \
+ 	highlighter/codetoken.vala \
+ 	highlighter/highlighter.vala \
+ 	html/basicdoclet.vala \
+-	html/htmlchartfactory.vala \
+ 	html/linkhelper.vala \
+ 	html/cssclassresolver.vala \
+ 	html/htmlmarkupwriter.vala \
+ 	html/htmlrenderer.vala \
+ 	$(NULL)
+ 
++if ENABLE_GRAPHVIZ
++libvaladoc_la_VALASOURCES += \
++	charts/chart.vala \
++	charts/chartfactory.vala \
++	charts/hierarchychart.vala \
++	charts/simplechartfactory.vala \
++	html/htmlchartfactory.vala \
++	$(NULL)
++
++LIBGVC_PKG = --vapidir $(top_srcdir)/vapi --pkg libgvc
++endif
++
+ libvaladoc@PACKAGE_SUFFIX@_la_SOURCES = \
+ 	libvaladoc.vala.stamp \
+ 	$(libvaladoc_la_VALASOURCES:.vala=.c) \
++if ENABLE_GRAPHVIZ
+ 	gvc-compat.c \
++endif
+ 	$(NULL)
+ 
+ valadoc@PACKAGE_SUFFIX@.vapi valadoc.h: libvaladoc.vala.stamp
+@@ -182,8 +191,8 @@ libvaladoc.vala.stamp: $(libvaladoc_la_VALASOURCES)
+ 		--library valadoc \
+ 		--vapi valadoc@PACKAGE_SUFFIX@.vapi \
+ 		--vapidir $(top_srcdir)/vapi --pkg gmodule-2.0 \
+-		--vapidir $(top_srcdir)/vapi --pkg libgvc \
+ 		--vapidir $(top_srcdir)/gee --pkg gee \
++		$(LIBGVC_PKG) \
+ 		--vapidir $(top_srcdir)/vala --pkg vala \
+ 		--pkg config \
+ 		$(filter %.vala %.c,$^)
+@@ -211,6 +220,9 @@ nodist_pkgconfig_DATA = valadoc@PACKAGE_SUFFIX@.pc
+ 
+ valadoc@PACKAGE_SUFFIX@.pc: valadoc.pc
+ 	cp $< $@
++if !ENABLE_GRAPHVIZ
++	sed -i "s/libgvc //g" $@
++endif
+ 
+ vapidir = $(datadir)/vala/vapi
+ dist_vapi_DATA = valadoc@PACKAGE_SUFFIX@.vapi
+@@ -218,6 +230,9 @@ nodist_vapi_DATA = valadoc@PACKAGE_SUFFIX@.deps
+ 
+ valadoc@PACKAGE_SUFFIX@.deps: valadoc.deps
+ 	cp $< $@
++if !ENABLE_GRAPHVIZ
++	sed -i "s/libgvc//g" $@
++endif
+ 
+ EXTRA_DIST = \
+ 	$(libvaladoc_la_VALASOURCES) \
+diff --git a/libvaladoc/html/basicdoclet.vala b/libvaladoc/html/basicdoclet.vala
+index 37c731c..e0326ef 100644
+--- a/libvaladoc/html/basicdoclet.vala
++++ b/libvaladoc/html/basicdoclet.vala
+@@ -46,7 +46,11 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 	protected HtmlRenderer _renderer;
+ 	protected Html.MarkupWriter writer;
+ 	protected Html.CssClassResolver cssresolver;
++#if HAVE_GRAPHVIZ
+ 	protected Charts.Factory image_factory;
++#else
++	protected void* image_factory;
++#endif
+ 	protected ErrorReporter reporter;
+ 	protected string package_list_link = "../index.html";
+ 
+@@ -120,7 +124,9 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 		this.linker = new LinkHelper ();
+ 
+ 		_renderer = new HtmlRenderer (settings, this.linker, this.cssresolver);
++#if HAVE_GRAPHVIZ
+ 		this.image_factory = new SimpleChartFactory (settings, linker);
++#endif
+ 	}
+ 
+ 
+@@ -1025,6 +1031,7 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 	}
+ 
+ 	protected void write_image_block (Api.Node element) {
++#if HAVE_GRAPHVIZ
+ 		if (element is Class || element is Interface || element is Struct) {
+ 			unowned string format = (settings.use_svg_images ? "svg" : "png");
+ 			var chart = new Charts.Hierarchy (image_factory, element);
+@@ -1044,6 +1051,7 @@ public abstract class Valadoc.Html.BasicDoclet : Api.Visitor, Doclet {
+ 									   this.get_img_path_html (element, format)});
+ 			writer.add_usemap (chart);
+ 		}
++#endif
+ 	}
+ 
+ 	public void write_namespace_content (Namespace node, Api.Node? parent) {
+diff --git a/libvaladoc/html/htmlmarkupwriter.vala b/libvaladoc/html/htmlmarkupwriter.vala
+index 5aa4afd..80781c2 100644
+--- a/libvaladoc/html/htmlmarkupwriter.vala
++++ b/libvaladoc/html/htmlmarkupwriter.vala
+@@ -51,13 +51,16 @@ public class Valadoc.Html.MarkupWriter : Valadoc.MarkupWriter {
+ 		}
+ 	}
+ 
++#if HAVE_GRAPHVIZ
+ 	public unowned MarkupWriter add_usemap (Charts.Chart chart) {
+ 		string? buf = (string?) chart.write_buffer ("cmapx");
+ 		if (buf != null) {
+ 			raw_text ("\n");
+ 			raw_text ((!) buf);
+ 		}
+-
++#else
++	public MarkupWriter add_usemap (void* chart) {
++#endif
+ 		return this;
+ 	}
+ 

--- a/srcpkgs/vala/template
+++ b/srcpkgs/vala/template
@@ -1,8 +1,10 @@
 # Template file for 'vala'
 pkgname=vala
-version=0.40.9
+version=0.42.1
 revision=1
+patch_args="-Np1"
 build_style=gnu-configure
+configure_args="--disable-graphviz"
 hostmakedepends="flex libxslt pkg-config automake libtool"
 makedepends="libfl-devel libglib-devel"
 checkdepends="dbus libgirepository-devel"
@@ -10,16 +12,18 @@ short_desc="Compiler for the GObject type system"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="LGPL-2.1-or-later"
 homepage="https://live.gnome.org/Vala"
-changelog="https://raw.githubusercontent.com/GNOME/vala/0.40/NEWS"
+changelog="https://raw.githubusercontent.com/GNOME/vala/0.42/NEWS"
 distfiles="${GNOME_SITE}/vala/${version%.*}/vala-${version}.tar.xz"
-checksum=c7ff0480779b2d78d6ff78f5fd165b3ba972e4fa9e9da1b411ff4375a78c6a7b
+checksum=b4a52524207aadc77f4b39e29e4375387d2b6efe40738b33434e3298ebdabb11
+
+# for valadoc
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" vala"
+else
+	make_build_args="VALAC="${XBPS_BUILDDIR}/${pkgname}-${version}/compiler/valac""
+fi
 
 pre_configure() {
-	# https://gitlab.gnome.org/GNOME/vala/issues/596
-	# http://www.linuxfromscratch.org/blfs/view/svn/general/vala.html
-	sed -i '115d; 121,137d; 139,140d' configure.ac
-	sed -i '/libvaladoc/d; /valadoc/d' Makefile.am
-	sed -i '/valadoc.1/d' doc/Makefile.am
 	autoreconf -fi
 }
 


### PR DESCRIPTION
Not quite sure if stuff other than vala itself actually links to libvaladoc. Currently building everything that needs vala with 0.42 to check that nothing's broken.