### PR TITLE
[WIP] Dxpb fixes

### DIFF
--- a/srcpkgs/grml-rescueboot/template
+++ b/srcpkgs/grml-rescueboot/template
@@ -1,9 +1,8 @@
 # Template file for 'grml-rescueboot'
 pkgname=grml-rescueboot
 version=0.5.0
-revision=1
+revision=2
 only_for_archs="i686 x86_64"
-noarch=yes
 build_style="gnu-makefile"
 conf_files="/etc/default/grml-rescueboot"
 make_dirs="/boot/grml 0755 root root"

--- a/srcpkgs/intel-ucode/template
+++ b/srcpkgs/intel-ucode/template
@@ -1,9 +1,8 @@
 # Template file for 'intel-ucode'
 pkgname=intel-ucode
 version=20180807
-revision=1
+revision=2
 _dlid=28039
-noarch=yes
 create_wrksrc=yes
 short_desc="Microcode update files for Intel CPUs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/marvin/template
+++ b/srcpkgs/marvin/template
@@ -1,14 +1,13 @@
 # Template for Marvin
 pkgname=marvin
 version=18.20.0
-revision=1
+revision=2
 noarch=yes
 maintainer="Brenton Horne <brentonhorne77@gmail.com>"
 homepage="https://chemaxon.com/products/marvin"
 license="marvin"
 depends="virtual?java-environment"
 short_desc="Skeletal structure drawing program by ChemAxon"
-only_for_archs="i686 x86_64"
 repository=nonfree
 restricted=yes
 nostrip=yes

--- a/srcpkgs/musl-legacy-compat/template
+++ b/srcpkgs/musl-legacy-compat/template
@@ -1,17 +1,26 @@
 # Template file for 'musl-legacy-compat'
 pkgname=musl-legacy-compat
 version=0.3
-revision=1
-noarch=yes
+revision=2
 bootstrap=yes
-only_for_archs="i686-musl x86_64-musl armv5tel-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipshf-musl mipsel-musl mipselhf-musl"
 short_desc="Legacy compatibility headers for the musl libc"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="BSD"
+license="BSD-2-Clause, BSD-3-Clause"
 homepage="http://www.voidlinux.eu"
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) ;;
+	#*) broken="Only valid for musl systems";;
+esac
 
 do_install() {
 	for f in ${FILESDIR}/*.h; do
 		vinstall ${f} 644 usr/include/sys
 	done
+
+	sed -n '3,32p' < ${FILESDIR}/queue.h > LICENSE.BSD-3-Clause
+	sed -n '2,26p' < ${FILESDIR}/tree.h > LICENSE.BSD-2-Clause
+
+	vlicense LICENSE.BSD-3-Clause
+	vlicense LICENSE.BSD-2-Clause
 }


### PR DESCRIPTION
dxpb doesn't understand how a package can be noarch and yet care about the arch for which it's built.
Thus, constructs like the attached are now considered obsolete.

Please review all commits carefully.

I have placed revbumps. I do not now that these are actually necessary under the current build system.

To clarify, dxpb does not care if a subpackage is noarch, but may (if the package depends on that subpackage) try to build the subpackage first... thus getting xbps-src to try the main package. This at least should fail in a productive manner when `only_for_archs` is set.