### PR TITLE
Manual.md: Document a few good practices when removing a package.

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -39,6 +39,7 @@ packages for XBPS, the `Void Linux` native packaging system.
 	* [Go packages](#pkgs_go)
 	* [Haskell packages](#pkgs_haskell)
 	* [Font packages](#pkgs_font)
+	* [Removing a package](#pkg_remove)
 	* [Notes](#notes)
 	* [Contributing via git](#contributing)
 * [Help](#help)
@@ -1301,6 +1302,36 @@ following variables:
 cache during the install/removal of the package
 - `font_dirs`: which should be set to the directory where the package
 installs its fonts
+
+<a id="pkg_remove"></a>
+### Removing a package
+
+Follows a list of things that should be done to help guarantee that a
+package template removal and by extension its binary packages from
+Void Linux's repositories goes smoothly.
+
+Before removing a package template:
+
+- Guarantee that no package depends on it or any of its subpackages.
+For that you can search the templates for references to the package
+with `grep -r '\bpkg\b' srcpkgs/`.
+- Guarantee that no package depends on shlibs provided by it.
+
+When removing the package template:
+
+- Remove all symlinks that point to the package.
+`find srcpkgs/ -lname <pkg>` should be enough.
+- If the package provides shlibs make sure to remove them from
+common/shlibs.
+- Some packages use patches and files from other packages using symlinks,
+generally those packages are the same but have been split as to avoid
+cyclic dependencies. Make sure that the package you're removing is not
+the source of those patches/files.
+
+For the one doing the merge of the removal:
+
+- Remove the package from the repository index or contact a team member
+that can do so.
 
 <a id="notes"></a>
 ### Notes


### PR DESCRIPTION
Most people forget about these when removing packages so i think it is nice that we document these `best practices` and point it to people when they try to remove a package.

I don't know if Manual.md is the best place for these since it also touches on Void Linux binary repositories (one of the planned best practices is 'contact a Void Linux team member that can manage repo indexes to guarantee a timely removal of the package from the binary repos')

anyways i'm sleepy as hell and this problably has a lot of mistakes i'll rewrite tomorrow