### PR TITLE
ConsoleKit2: make runit service more robust (wait for dbus functional). [ci skip]

### DIFF
--- a/srcpkgs/ConsoleKit2/files/consolekit/run
+++ b/srcpkgs/ConsoleKit2/files/consolekit/run
@@ -2,4 +2,7 @@
 if [ -e /var/service/cgmanager ]; then
 	sv check cgmanager >/dev/null || exit 1
 fi
+if [ -e /var/service/dbus ]; then
+	sv check dbus >/dev/null || exit 1
+fi
 exec console-kit-daemon --no-daemon

--- a/srcpkgs/ConsoleKit2/template
+++ b/srcpkgs/ConsoleKit2/template
@@ -1,7 +1,7 @@
 # Template file for 'ConsoleKit2'
 pkgname=ConsoleKit2
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_file__sys_class_tty_tty0_active=yes
  --with-rundir=/run --enable-udev-acl --enable-pam-module


### PR DESCRIPTION
In short `consolekit2` depends on `dbus`, the current runit service checks for `cgmanager`.

This seems ok since `cgmanager` also depends on `dbus` as well. Yet somehow `consolekit` still manages to occasionally start without `dbus` being all the way up.

This fixes that by making the dependency on `dbus` explicit.

I think the issue may be caused by `cgmanager` not having a proper `check` file in it's service, while `dbus` has one. That said this is just speculation.

Either way this fixes the issue. 