### PR TITLE
skype: update to 8.30.0.50.

### DIFF
--- a/srcpkgs/skype/template
+++ b/srcpkgs/skype/template
@@ -1,7 +1,8 @@
 # Template file for 'skype'
 # This just repackages the debian package.
 pkgname=skype
-version=8.30.76.41
+reverts="8.30.76.41_1"
+version=8.30.0.50
 revision=1
 only_for_archs="x86_64"
 repository="nonfree"
@@ -12,7 +13,7 @@ maintainer="Lon Willett <xgit@lonw.net>"
 license="skype"
 homepage="https://www.skype.com"
 distfiles="https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_${version}_amd64.deb"
-checksum=2d380466801e1cb0f7eccdd1235d6c32f65613e56d31c772499da9c35670a1a6
+checksum=fd7c93394945135c0bb97bddb6b88367d5b48396cbc36a296246d7e9402b9884
 
 do_extract() {
 	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/skypeforlinux_${version}_amd64.deb data.tar.xz | tar xJpf - ./usr

--- a/srcpkgs/skype/update
+++ b/srcpkgs/skype/update
@@ -1,0 +1,2 @@
+ignore="*.76.*"
+pattern="skypeforlinux_\K[\d.]+(?=_amd64.deb)"


### PR DESCRIPTION
the x.x.76.x versions are unstable versions so they shouldn't be used

CC @pullmoll I don't know if thise fixes the other issue but at least we would have the stable version of skype finally