### PR TITLE
New package: cri-tools-1.11.1

### DIFF
--- a/srcpkgs/cri-tools/template
+++ b/srcpkgs/cri-tools/template
@@ -1,0 +1,16 @@
+# Template file for 'cri-tools'
+pkgname=cri-tools
+version=1.11.1
+revision=1
+build_style=go
+go_import_path=github.com/kubernetes-sigs/cri-tools
+short_desc="CLI and validation tools for Kubelet Container Runtime Interface (CRI)"
+maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
+license="Apache-2.0"
+homepage="https://github.com/kubernetes-sigs/cri-tools"
+distfiles="https://github.com/kubernetes-sigs/cri-tools/archive/v${version}.tar.gz"
+checksum=a357c67c891896032865f7a34f7ec330e5a00fe7f20b6d8be50399b91c99a4ac
+
+do_build() {
+	make ${makejobs}
+}


### PR DESCRIPTION
The `kubeadm` executable in the `kubernetes` package requires this.
I've not added it as a dependency for the `kubernetes` package since kubeadm is an optional utility, and will helpfully inform the user they need to install `crictl` if they run it.

Another option is to split `kubeadm` out of `kubernetes` into its own package and have it depend on this, but I'm not sure that's useful to users.