### PR TITLE
Fix packages failing to build with glibc 2.28

### DIFF
--- a/srcpkgs/findutils/patches/gnulib-freadahead.patch
+++ b/srcpkgs/findutils/patches/gnulib-freadahead.patch
@@ -1,0 +1,11 @@
+--- gl/lib/freadahead.c
++++ gl/lib/freadahead.c
+@@ -30,7 +30,7 @@ extern size_t __sreadahead (FILE *);
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)

--- a/srcpkgs/findutils/patches/gnulib-mountlist.patch
+++ b/srcpkgs/findutils/patches/gnulib-mountlist.patch
@@ -1,0 +1,15 @@
+--- gl/lib/mountlist.c
++++ gl/lib/mountlist.c
+@@ -37,6 +37,12 @@
+ # include <sys/param.h>
+ #endif
+ 
++#if MAJOR_IN_MKDEV
++# include <sys/mkdev.h>
++#elif MAJOR_IN_SYSMACROS
++# include <sys/sysmacros.h>
++#endif
++
+ #if defined MOUNTED_GETFSSTAT   /* OSF_1 and Darwin1.3.x */
+ # if HAVE_SYS_UCRED_H
+ #  include <grp.h> /* needed on OSF V4.0 for definition of NGROUPS,

--- a/srcpkgs/findutils/patches/gnulib-stdio-impl.patch
+++ b/srcpkgs/findutils/patches/gnulib-stdio-impl.patch
@@ -1,0 +1,14 @@
+--- gl/lib/stdio-impl.h
++++ gl/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */

--- a/srcpkgs/gzip/patches/gnulib-fseterr.patch
+++ b/srcpkgs/gzip/patches/gnulib-fseterr.patch
@@ -1,0 +1,11 @@
+--- lib/fseterr.c
++++ lib/fseterr.c
+@@ -29,7 +29,7 @@ fseterr (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */

--- a/srcpkgs/m4/patches/gnulib-freadahead.patch
+++ b/srcpkgs/m4/patches/gnulib-freadahead.patch
@@ -1,0 +1,11 @@
+--- lib/freadahead.c
++++ lib/freadahead.c
+@@ -30,7 +30,7 @@ extern size_t __sreadahead (FILE *);
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)

--- a/srcpkgs/m4/patches/gnulib-stdio-impl.patch
+++ b/srcpkgs/m4/patches/gnulib-stdio-impl.patch
@@ -1,0 +1,14 @@
+--- lib/stdio-impl.h
++++ lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */


### PR DESCRIPTION
Gnulib components in some packages fail to build with glibc 2.28 as it removed some obsolete functions. These patches substitute the obsolete functions with the new functions.
Patches taken from:
https://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commitdiff;h=4da63c58
https://git.savannah.gnu.org/gitweb/?p=gnulib.git;a=commitdiff;h=4af4a4a7
And modified for specific packages.