### PR TITLE
plymouth: add gtk3 and pango build options

### DIFF
--- a/srcpkgs/plymouth/patches/0002-Fix-build-with-glibc-2.28.patch
+++ b/srcpkgs/plymouth/patches/0002-Fix-build-with-glibc-2.28.patch
@@ -1,0 +1,34 @@
+From 0c0345303b7971d6cec478fd8b81d64bc1fbe0f6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20M=C3=BCller?= <schnitzeltony@gmail.com>
+Date: Tue, 21 Aug 2018 23:26:45 +0200
+Subject: [PATCH] Fix build with >= glibc 2.28
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Stolen from [1]
+
+[1] https://bugs.freedesktop.org/show_bug.cgi?id=102191
+
+Upstream-Status: Pending
+
+Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+---
+ src/libply-splash-core/ply-terminal.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/libply-splash-core/ply-terminal.c b/src/libply-splash-core/ply-terminal.c
+index a0954f2..f3b32fe 100644
+--- src/libply-splash-core/ply-terminal.c
++++ src/libply-splash-core/ply-terminal.c
+@@ -32,6 +32,7 @@
+ #include <sys/socket.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
++#include <sys/sysmacros.h>
+ #include <termios.h>
+ #include <unistd.h>
+ #include <wchar.h>
+--
+2.14.4
+

--- a/srcpkgs/plymouth/template
+++ b/srcpkgs/plymouth/template
@@ -1,16 +1,17 @@
 # Template file for 'plymouth'
 pkgname=plymouth
 version=0.9.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-system-root-install=no \
  --without-rhgb-compat-link --enable-systemd-integration=no \
- --enable-gtk --enable-gdm-transition --enable-pango \
+ --enable-gdm-transition $(vopt_enable gtk3 gtk) $(vopt_enable pango) \
  --with-logo=/usr/share/void-artwork/void-transparent.png --localstatedir=/ \
  --disable-documentation"
 conf_files="/etc/plymouth/plymouthd.conf"
 hostmakedepends="pkg-config"
-makedepends="pango-devel libdrm-devel gtk+3-devel void-artwork"
+makedepends="libdrm-devel libpng-devel void-artwork
+ $(vopt_if gtk3 gtk+3-devel) $(vopt_if pango pango-devel)"
 depends="plymouth-data>=0"
 short_desc="Graphical boot animation and logger"
 maintainer="William OD <obirik2005@gmail.com>"
@@ -18,6 +19,10 @@ homepage="https://www.freedesktop.org/wiki/Software/Plymouth/"
 license="GPL-2"
 distfiles="${FREEDESKTOP_SITE}/plymouth/releases/$pkgname-$version.tar.xz"
 checksum=9f8dd08a90ceaf6228dcd8c27759adf18fc9482f15b6c56dcbcced268b4e4a74
+
+build_options="gtk3 pango"
+build_options_default="gtk3 pango"
+desc_option_pango="Enable building with Pango (for password/question prompts)"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" musl-rpmatch-devel"


### PR DESCRIPTION
Continuation of https://github.com/voidlinux/void-packages/pull/14828.