### PR TITLE
polkit: add polkitd service

### DIFF
--- a/srcpkgs/polkit/files/polkitd/run
+++ b/srcpkgs/polkit/files/polkitd/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/lib/polkit-1/polkitd --no-debug

--- a/srcpkgs/polkit/template
+++ b/srcpkgs/polkit/template
@@ -1,13 +1,13 @@
 # Template file for 'polkit'
 pkgname=polkit
 version=0.115
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection) --disable-systemd
  --disable-libsystemd-login --disable-libelogind --disable-static
  --with-authfw=pam  --with-os-type=void --with-mozjs=mozjs-52.0"
 hostmakedepends="autoconf-archive automake gettext-devel git glib-devel
- gobject-introspection gtk-doc intltool pkg-config"
+ gobject-introspection gtk-doc intltool libtool pkg-config"
 makedepends="libglib-devel mozjs52-devel pam-devel"
 short_desc="Authorization Toolkit"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -42,6 +42,7 @@ post_configure() {
 
 post_install() {
 	vinstall ${FILESDIR}/polkit-1.pam 644 etc/pam.d polkit-1
+	vsv polkitd
 }
 
 polkit-devel_package() {


### PR DESCRIPTION
Continuation of https://github.com/voidlinux/void-packages/pull/14357

This service is useful on setups where D-Bus service activation is not desired (or available).


