### PR TITLE
rtkit: add rtkit service

### DIFF
--- a/srcpkgs/rtkit/files/rtkit/run
+++ b/srcpkgs/rtkit/files/rtkit/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/libexec/rtkit-daemon

--- a/srcpkgs/rtkit/template
+++ b/srcpkgs/rtkit/template
@@ -1,7 +1,7 @@
 # Template file for 'rtkit'
 pkgname=rtkit
 version=0.11
-revision=13
+revision=14
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="dbus-devel libcap-devel"
@@ -21,4 +21,5 @@ post_install() {
 
 	sed -n '7,28p' < rtkit.h > LICENSE
 	vlicense LICENSE
+	vsv rtkit
 }


### PR DESCRIPTION
Continuation of https://github.com/voidlinux/void-packages/pull/14357

This service is useful on setups where D-Bus service activation is not desired (or available).