### PR TITLE
icewm: depends on shared-mime-info

### DIFF
--- a/srcpkgs/icewm/template
+++ b/srcpkgs/icewm/template
@@ -1,17 +1,18 @@
 # Template file for 'icewm'
 pkgname=icewm
 version=1.4.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="--enable-shaped-decorations --enable-gradients
  --enable-guievents --with-icesound=ALSA,OSS --disable-menus-gnome2"
 hostmakedepends="asciidoc gettext-devel libtool mkfontdir pkg-config"
 makedepends="libXrandr-devel libXft-devel libSM-devel libXinerama-devel gdk-pixbuf-devel"
+depends="shared-mime-info"
 short_desc="Window Manager designed for speed, usability, and consistency"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2"
+license="LGPL-2.0-or-later"
 homepage="http://www.icewm.org/"
-distfiles="https://github.com/bbidulock/icewm/archive/${version}.tar.gz"
-checksum=7c05a742a175c31fd3e3362649163e08b1033284f589460b90c49265a5fc9015
+distfiles="https://github.com/bbidulock/icewm/releases/download/${version}/icewm-${version}.tar.bz2"
+checksum=9920901c5eadb6df95af68dcb4f044b16e76e80ccd2c420b66c2ab83559477a7
 
 CXXFLAGS="-Wno-error=narrowing -fno-delete-null-pointer-checks"


### PR DESCRIPTION
IceWM will not display themes or graphics without shared-mime-info. Same fix as Debian:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=790423