### PR TITLE
[DO NOT MERGE] pulseeffects: update to 4.3.5

### DIFF
--- a/srcpkgs/gst-plugins-bad1/patches/libressl.patch
+++ b/srcpkgs/gst-plugins-bad1/patches/libressl.patch
@@ -1,0 +1,11 @@
+--- ext/dtls/gstdtlsagent.c
++++ ext/dtls/gstdtlsagent.c
+@@ -176,7 +176,7 @@
+ 
+   ERR_clear_error ();
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(LIBRESSL_VERSION_NUMBER)
+   priv->ssl_context = SSL_CTX_new (DTLS_method ());
+ #else
+   priv->ssl_context = SSL_CTX_new (DTLSv1_method ());

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.14.3
-revision=1
+revision=2
 wrksrc="${pkgname/1/}-${version}"
 lib32disabled=yes
 build_style=gnu-configure

--- a/srcpkgs/pulseeffects/template
+++ b/srcpkgs/pulseeffects/template
@@ -1,18 +1,18 @@
 # Template file for 'pulseeffects'
 pkgname=pulseeffects
-reverts="4.3.4_1"
-version=3.2.3
-revision=3
+version=4.3.5
+revision=1
 build_style=meson
 pycompile_module="PulseEffects PulseEffectsTest"
-hostmakedepends="pkg-config"
-makedepends="gsettings-desktop-schemas-devel gst-plugins-bad1-devel
- gtk+3-devel libbs2b-devel pulseaudio-devel python-gobject-devel"
-depends="ConsoleKit2 calf gsettings-desktop-schemas gst-plugins-bad1
- gst-plugins-good1 pulseaudio python3-gobject python3-numpy python3-scipy"
+hostmakedepends="itstool pkg-config"
+makedepends="boost-devel glib-devel gsettings-desktop-schemas-devel
+ gst-plugins-bad1-devel gtkmm-devel libbs2b-devel libebur128-devel
+ lilv-devel pulseaudio-devel python-gobject-devel sratom-devel"
+depends="ConsoleKit2 calf gst-plugins-bad1 gst-plugins-good1 lilv pulseaudio
+ python3-gobject python3-scipy"
 short_desc="Sound effects for Pulseaudio applications"
-maintainer="cr6git <quark6@protonmail.com>"
-license="GPL-3"
+maintainer="Frank Steinborn <steinex@nognu.de>"
+license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/pulseeffects"
 distfiles="https://github.com/wwmm/pulseeffects/archive/v${version}.tar.gz"
-checksum=049a9d9c162a17790d392b7de9a0cc1397de32bd4324ae6490a45b96c92e5528
+checksum=b2de620edabe30e74d69a0a9e56b0e187fbd261fc91d51d5fb57fc32d6a20646


### PR DESCRIPTION
Continuation of #2566

This PR includes a commit that patches `gst-plugins-bad1` for LibreSSL, otherwise the new pulseeffects throws an error on start.

There is still an issue with pulseeffects not finding plugins from `calf` that needs to be figured out - do not merge!

@cr6git asked me in #2566 if I could maintain pulseeffects, so the PR also changes maintainership to myself.