### PR TITLE
perl-Net-DNS: update to 1.18.

### DIFF
--- a/srcpkgs/perl-Net-DNS/template
+++ b/srcpkgs/perl-Net-DNS/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-Net-DNS'
 pkgname=perl-Net-DNS
-version=1.17
+version=1.18
 revision=1
 noarch=yes
 wrksrc="${pkgname/perl-/}-${version}"
@@ -13,4 +13,4 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="https://metacpan.org/release/Net-DNS"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 distfiles="${CPAN_SITE}/Net/Net-DNS-${version}.tar.gz"
-checksum=9a79fd8fea1a708726c18d193ae4437479206ccb20ffa7f0971371e172e2c2e0
+checksum=52ce1494fc9707fd5a60ed71db5cde727157b7f2363787d730d4d1bd9800a9d3


### PR DESCRIPTION
All tests successful.
Files=99, Tests=2906, 146 wallclock secs ( 0.42 usr  0.09 sys +  9.02 cusr  1.29 csys = 10.82 CPU)
Result: PASS