### PR TITLE
libpoppler: update to 0.69.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -340,7 +340,7 @@ libMagickCore-6.Q16.so.6 libmagick6-6.9.10.11_1
 libMagickWand-6.Q16.so.6 libmagick6-6.9.10.11_1
 libMagick++-6.Q16.so.8 libmagick6-6.9.10.11_1
 libltdl.so.7 libltdl-2.2.6_1
-libpoppler.so.79 poppler-0.68.0_1
+libpoppler.so.80 poppler-0.69.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1
 libpoppler-cpp.so.0 poppler-cpp-0.18.2_1
 libpoppler-qt5.so.1 poppler-qt5-0.31.0_1

--- a/srcpkgs/cups-filters/patches/fix-poppler-069.patch
+++ b/srcpkgs/cups-filters/patches/fix-poppler-069.patch
@@ -1,0 +1,77 @@
+From 6b0747c1630dd973acd138f927dbded4ea45e360 Mon Sep 17 00:00:00 2001
+From: Olivier Schonken <olivier.schonken@gmail.com>
+Date: Fri, 5 Oct 2018 12:05:31 +0200
+Subject: [PATCH] Poppler removed memCheck and gMemReport functions
+
+Only use gMemReport and memCheck functions if poppler version less
+than 0.69.0
+
+The poppler project removed the memCheck and gMemReport functions in
+commits c362ab1b97f20c5b73b3bad8d52015f679178748 - Remove DEBUG_MEM
+from Object since this uses RAII now and hence cannot leak.
+(The existing tracking also is not thread-safe and hence unreliable.)
+
+and
+
+f89446f6917a869b0f1a80fcc8ce81a7213dade4 - Remove generic heap debugging
+from gmem since external tools and compiler instrumentation achieve the
+same effect.
+
+This commit solves https://github.com/OpenPrinting/cups-filters/issues/62
+
+Signed-off-by: Olivier Schonken <olivier.schonken@gmail.com>
+---
+ filter/pdftoijs.cxx            | 2 ++
+ filter/pdftoopvp/pdftoopvp.cxx | 2 ++
+ filter/pdftoraster.cxx         | 2 ++
+ 3 files changed, 6 insertions(+)
+
+diff --git a/filter/pdftoijs.cxx b/filter/pdftoijs.cxx
+index 22bc33f4..dd6b6fa0 100644
+--- filter/pdftoijs.cxx
++++ filter/pdftoijs.cxx
+@@ -503,9 +503,11 @@ int main(int argc, char *argv[]) {
+   ppdClose(ppd);
+   free(outputfile);
+ 
++#if POPPLER_VERSION_MAJOR == 0 && POPPLER_VERSION_MINOR < 69
+   // Check for memory leaks
+   Object::memCheck(stderr);
+   gMemReport(stderr);
++#endif
+ 
+   return exitCode;
+ }
+diff --git a/filter/pdftoopvp/pdftoopvp.cxx b/filter/pdftoopvp/pdftoopvp.cxx
+index 024941ab..bf25983b 100644
+--- filter/pdftoopvp/pdftoopvp.cxx
++++ filter/pdftoopvp/pdftoopvp.cxx
+@@ -763,9 +763,11 @@ fprintf(stderr,"JobInfo=%s\n",jobInfo);
+  err0:
+   delete globalParams;
+ 
++#if POPPLER_VERSION_MAJOR == 0 && POPPLER_VERSION_MINOR < 69
+   // check for memory leaks
+   Object::memCheck(stderr);
+   gMemReport(stderr);
++#endif
+ 
+ }
+ /* muntrace(); */
+diff --git a/filter/pdftoraster.cxx b/filter/pdftoraster.cxx
+index 0c63ab8d..4ebf02b0 100644
+--- filter/pdftoraster.cxx
++++ filter/pdftoraster.cxx
+@@ -2162,9 +2162,11 @@ int main(int argc, char *argv[]) {
+     cmsDeleteTransform(colorTransform);
+   }
+ 
++#if POPPLER_VERSION_MAJOR == 0 && POPPLER_VERSION_MINOR < 69
+   // Check for memory leaks
+   Object::memCheck(stderr);
+   gMemReport(stderr);
++#endif
+ 
+   return exitCode;
+ }
+

--- a/srcpkgs/cups-filters/template
+++ b/srcpkgs/cups-filters/template
@@ -1,7 +1,7 @@
 # Template file for 'cups-filters'
 pkgname=cups-filters
 version=1.21.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --with-rcdir=no --enable-avahi
  --with-browseremoteprotocols=DNSSD,CUPS"

--- a/srcpkgs/extractpdfmark/template
+++ b/srcpkgs/extractpdfmark/template
@@ -1,8 +1,8 @@
 # Template file for 'extractpdfmark'
 pkgname=extractpdfmark
 version=1.0.2
-revision=5
-build_wrksrc="build"
+revision=6
+build_wrksrc=build
 build_style=gnu-configure
 configure_script="../configure"
 hostmakedepends="pkg-config automake autogen gettext-devel"

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.92.3
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
  --without-gnome-vfs --disable-static"

--- a/srcpkgs/libgdal/template
+++ b/srcpkgs/libgdal/template
@@ -1,8 +1,8 @@
 # Template file for 'libgdal'
 pkgname=libgdal
 version=2.3.2
-revision=1
-wrksrc=gdal-${version}
+revision=2
+wrksrc="gdal-${version}"
 build_style=gnu-configure
 configure_args="--with-liblzma --with-poppler"
 hostmakedepends="gettext-devel pkg-config python-numpy json-c-devel"

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -4,7 +4,7 @@
 # A CYCLIC DEPENDENCY: qt5 -> cups -> poppler -> qt5.
 #
 pkgname=poppler-qt5
-version=0.68.0
+version=0.69.0
 revision=1
 wrksrc="poppler-${version}"
 build_style=cmake
@@ -18,7 +18,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/poppler-${version}.tar.xz"
-checksum=f90d04f0fb8df6923ecb0f106ae866cf9f8761bb537ddac64dfb5322763d0e58
+checksum=637ff943f805f304ff1da77ba2e7f1cbd675f474941fd8ae1e0fc01a5b45a3f9
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DTHREADS_PTHREAD_ARG=2"

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -3,7 +3,7 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/poppler-qt5".
 #
 pkgname=poppler
-version=0.68.0
+version=0.69.0
 revision=1
 build_style=cmake
 configure_args="-DENABLE_XPDF_HEADERS=on $(vopt_if gir -DENABLE_GLIB=on)
@@ -14,10 +14,10 @@ makedepends="libpng-devel libglib-devel cairo-devel tiff-devel lcms2-devel
 depends="poppler-data"
 short_desc="PDF rendering library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://poppler.freedesktop.org"
 distfiles="${homepage}/${pkgname}-${version}.tar.xz"
-checksum=f90d04f0fb8df6923ecb0f106ae866cf9f8761bb537ddac64dfb5322763d0e58
+checksum=637ff943f805f304ff1da77ba2e7f1cbd675f474941fd8ae1e0fc01a5b45a3f9
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DTHREADS_PTHREAD_ARG=2"


### PR DESCRIPTION
- [ ] libgdal (Requires patches)
- [ ] ipe (Requires patches)
- [ ] inkscape (Requires patches)
- [x] extractpdfmark
- [ ] calligra
- [x] cups-filters