### PR TITLE
nix: Added default value for NIX_PATH inside nix.sh

### DIFF
--- a/srcpkgs/nix/files/nix.sh
+++ b/srcpkgs/nix/files/nix.sh
@@ -43,3 +43,4 @@ fi
 
 export PATH=/nix/var/nix/profiles/default/bin:$PATH
 export PATH=$HOME/.nix-profile/bin:$PATH
+export NIX_PATH=$HOME/.nix-defexpr/channels

--- a/srcpkgs/nix/template
+++ b/srcpkgs/nix/template
@@ -1,7 +1,7 @@
 # Template file for 'nix'
 pkgname=nix
 version=2.0.4
-revision=1
+revision=2
 build_style=gnu-configure
 # Use /nix/var as suggested by the official Manual.
 configure_args="--localstatedir=/nix/var"


### PR DESCRIPTION
Without NIX_PATH, nix-shell would fail with the following error:

```error: file 'nixpkgs' was not found in the Nix search path (add it using $NIX_PATH or -I), at (string):1:13```