### PR TITLE
python-CherryPy: seperate into distinct packages for python 2/3

### DIFF
--- a/srcpkgs/python-CherryPy/template
+++ b/srcpkgs/python-CherryPy/template
@@ -2,12 +2,12 @@
 pkgname=python-CherryPy
 reverts="18.0.1_1 18.0.0_1"
 version=17.4.0
-revision=2
+revision=3
 noarch=yes
 wrksrc="CherryPy-${version}"
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools"
-depends="python-setuptools python-six python-Cheroot python-portend"
+build_style=python2-module
+hostmakedepends="python-setuptools"
+depends="python-setuptools python-six python-Cheroot python-portend python-contextlib2 python-zc.lockfile"
 pycompile_module="cherrypy"
 short_desc="Object-oriented HTTP framework (Python2)"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
@@ -23,18 +23,6 @@ pre_build() {
 		-e "s|use_scm_version=True|version='${version}'|"
 }
 post_install() {
+	mv ${DESTDIR}/usr/bin/cherryd ${DESTDIR}/usr/bin/cherryd2
 	vlicense LICENSE.md
-}
-
-python3-CherryPy_package() {
-	noarch=yes
-	depends="python3-setuptools python3-six python3-Cheroot python3-portend"
-	pycompile_module="cherrypy"
-	short_desc="${short_desc/Python2/Python3}"
-	alternatives="cherrypy:cherryd:/usr/bin/cherryd3"
-	pkg_install() {
-		vmove usr/bin/cherryd3
-		vmove usr/lib/python3*
-		vlicense LICENSE.md
-	}
 }

--- a/srcpkgs/python-zc.lockfile/template
+++ b/srcpkgs/python-zc.lockfile/template
@@ -1,0 +1,31 @@
+# Template file for 'python-zc.lockfile'
+pkgname=python-zc.lockfile
+version=1.3.0
+revision=1
+noarch=yes
+wrksrc="${pkgname#*-}-${version}"
+build_style=python-module
+pycompile_module="zc/lockfile"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-setuptools"
+short_desc="Basic inter-process locks (Python2)"
+maintainer="Lon Willett <xgit@lonw.net>"
+homepage="https://github.com/zopefoundation/zc.lockfile"
+license="ZPL-2.1"
+distfiles="${PYPI_SITE}/z/zc.lockfile/zc.lockfile-${version}.tar.gz"
+checksum=96cb13769e042988ea25d23d44cf09342ea0f887083d0f9736968f3617665853
+
+post_install() {
+	vlicense LICENSE.txt LICENSE
+}
+
+python3-zc.lockfile_package() {
+	noarch=yes
+	pycompile_module="zc/lockfile"
+	depends="python3-setuptools"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+		vlicense LICENSE.txt LICENSE
+	}
+}

--- a/srcpkgs/python3-CherryPy
+++ b/srcpkgs/python3-CherryPy
@@ -1,1 +1,0 @@
-python-CherryPy

--- a/srcpkgs/python3-CherryPy/template
+++ b/srcpkgs/python3-CherryPy/template
@@ -1,0 +1,28 @@
+# Template file for 'python3-CherryPy'
+pkgname=python3-CherryPy
+version=18.0.1
+revision=2
+noarch=yes
+wrksrc="CherryPy-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools python3-Cheroot python3-portend python3-zc.lockfile"
+pycompile_module="cherrypy"
+short_desc="Object-oriented HTTP framework (Python3)"
+maintainer="Andrea Brancaleoni <abc@pompel.me>"
+license="BSD-3-Clause"
+homepage="https://cherrypy.org/"
+distfiles="${PYPI_SITE}/C/CherryPy/CherryPy-${version}.tar.gz"
+checksum=3002fc47b982c3df4d08dbe5996b093fd73f85b650ab8df19e8b9b95f5c00520
+alternatives="cherrypy:cherryd:/usr/bin/cherryd3"
+
+pre_build() {
+	sed -i setup.py \
+		-e '/setuptools_scm/d' \
+		-e "s|use_scm_version=True|version='${version}'|"
+}
+
+post_install() {
+	mv ${DESTDIR}/usr/bin/cherryd ${DESTDIR}/usr/bin/cherryd3
+	vlicense LICENSE.md
+}

--- a/srcpkgs/python3-zc.lockfile
+++ b/srcpkgs/python3-zc.lockfile
@@ -1,0 +1,1 @@
+python-zc.lockfile


### PR DESCRIPTION
CherryPy 18.* does not support python2. So it is necessary to have
seperate packages for python2 and python3, with python2 remaining at version
17.*.