### PR TITLE
New package: residualvm-0.3.1

### DIFF
--- a/srcpkgs/residualvm/template
+++ b/srcpkgs/residualvm/template
@@ -1,0 +1,43 @@
+# Template file for 'residualvm'
+pkgname=residualvm
+version=0.3.1
+revision=1
+build_style=configure
+configure_args="--prefix=/usr --enable-all-engines --enable-release
+ --enable-flac --enable-faad --enable-fluidsynth $(vopt_enable sndio)"
+hostmakedepends="pkg-config"
+makedepends="SDL2-devel libvorbis-devel libmad-devel libjpeg-turbo-devel
+ libpng-devel libtheora-devel zlib-devel libmpeg2-devel freetype-devel
+ glew-devel libflac-devel fluidsynth-devel faad2-devel $(vopt_if sndio sndio-devel)"
+short_desc="Cross-platform 3D game interpreter"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD, ISC, MIT, Zlib"
+homepage="http://www.residualvm.org/"
+distfiles="http://www.residualvm.org/downloads/release/${version}/residualvm-${version}-sources.tar.bz2"
+checksum=f50c83bbc55a8121eefc279e83982b6ec590e608e145b7f750006619dd0bf9e9
+
+build_options="sndio"
+
+if [ -n "$CROSS_BUILD" ]; then
+	configure_args+=" --host=${XBPS_CROSS_TRIPLET}"
+
+	pre_configure() {
+		# - sdl-config wrapper already sets --prefix
+		# - freetype-config wrapper already sets --prefix
+		sed -i -e "s;_ranlib=ranlib;_ranlib=${XBPS_CROSS_TRIPLET}-ranlib;" \
+		 -e "s;_strip=strip;_strip=${XBPS_CROSS_TRIPLET}-strip;" \
+		 -e "s;_ar=\"ar cru\";_ar=\"${XBPS_CROSS_TRIPLET}-ar cru\";" \
+		 -e "s;_as=\"as\";_as=\"${XBPS_CROSS_TRIPLET}-as\";" \
+		 -e 's;--prefix="$_sdlpath";;' \
+		 -e 's;--prefix="$_freetypepath";;' \
+		 -e "s;^_host_cpu=\"\";_host_cpu=\"${XBPS_TARGET_MACHINE}\";" \
+		 -e 's;^_host_os="";_host_os="linux";' \
+		 configure
+	}
+fi
+
+post_install() {
+	# move licenses to the right place
+	vmkdir usr/share/licenses/residualvm
+	mv ${DESTDIR}/usr/share/doc/residualvm/COPYING* ${DESTDIR}/usr/share/licenses/residualvm/
+}


### PR DESCRIPTION
residualvm uses some third party code under a variety of licenses. The licenses are installed by default to `usr/share/doc/residualvm` so the easiest way seemed to be to move them to `usr/share/licenses/residualvm`. However, `xlint` complains about not using `vlicense`, but they’re there, anyway.

Regarding the BSD license: I could only find it in `video/theora_decoder.cpp`, but it’s only mentioned as ‘BSD-STYLE’ so no idea what the right SPDX identifier would be.