### PR TITLE
roxterm: update to 3.7.1.

### DIFF
--- a/srcpkgs/roxterm/template
+++ b/srcpkgs/roxterm/template
@@ -1,6 +1,6 @@
 # Template file for 'roxterm'
 pkgname=roxterm
-version=3.6.2
+version=3.7.1
 revision=1
 build_style=cmake
 hostmakedepends="ImageMagick itstool librsvg-utils libtool pkg-config po4a xmlto"
@@ -11,4 +11,8 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2.0-or-later, LGPL-3.0-only"
 homepage="https://github.com/realh/roxterm"
 distfiles="https://github.com/realh/roxterm/archive/${version}.tar.gz"
-checksum=242b50aef6507b233b307c59a43f3453fe7f9540202af6e480b4db4896abd0d1
+checksum=cab9ac94c2ccf02f0804057fea7cd296309a1033b7e18fbf131c6580746ff0e2
+
+pre_configure() {
+	echo -n ${version} > version
+}


### PR DESCRIPTION
Added a `pre_configure()` step because the version is not correctly set by [version.sh](https://github.com/realh/roxterm/blob/3.7.1/version.sh) and throws an error:
````
=> roxterm-3.7.1_1: running do_configure ...
-- The C compiler identification is GNU 8.2.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2") 
cat: version: No such file or directory
````