### PR TITLE
exa: Modified install directory for bash completion script

### DIFF
--- a/srcpkgs/exa/template
+++ b/srcpkgs/exa/template
@@ -1,7 +1,7 @@
 # Template file for 'exa'
 pkgname=exa
 version=0.8.0
-revision=3
+revision=4
 hostmakedepends="rust cargo cmake"
 makedepends="libgit2-devel"
 short_desc="A replacement for ls"
@@ -26,7 +26,7 @@ do_build() {
 do_install() {
 	vbin target/release/exa
 	vman contrib/man/exa.1
-	vinstall contrib/completions.bash 0644 usr/share/bash-completions exa
+	vinstall contrib/completions.bash 0644 usr/share/bash-completion/completions exa
 	vinstall contrib/completions.zsh 0644 usr/share/zsh/site-functions _exa
 	vlicense LICENCE
 }


### PR DESCRIPTION
Changed the location of bash completion from /usr/share/bash-completions
to /usr/share/bash-completion/completions

Other packages use the directory /usr/share/bash-completion/completions .