### PR TITLE
libostree: Modified install directory for bash completion script

### DIFF
--- a/srcpkgs/libostree/template
+++ b/srcpkgs/libostree/template
@@ -1,7 +1,7 @@
 # Template file for 'libostree'
 pkgname=libostree
 version=2018.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-builtin-grub2-mkconfig --with-openssl"
 hostmakedepends="bison docbook-xsl glib-devel libxslt pkg-config"
@@ -17,7 +17,7 @@ distfiles="https://github.com/ostreedev/ostree/releases/download/v${version}/lib
 checksum=beef6debb0065bf1dc7538cd036c5f0348ac102ca4ad6d8651feff146130a844
 
 post_install() {
-	vinstall bash/ostree 644 usr/share/bash-completions/completions
+	vinstall bash/ostree 644 usr/share/bash-completion/completions
 }
 
 libostree-devel_package() {


### PR DESCRIPTION
Changed the location of bash completion from /usr/share/bash-completions/completions
to /usr/share/bash-completion/completions

Other packages use /usr/share/bash-completion/completions