### PR TITLE
pinentry-gnome: depend on libgnome-keyring

### DIFF
--- a/srcpkgs/pinentry/template
+++ b/srcpkgs/pinentry/template
@@ -1,7 +1,7 @@
 # Template file for 'pinentry'
 pkgname=pinentry
 version=1.1.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-rpath --without-libcap --disable-pinentry-gtk
  --enable-pinentry-curses --enable-fallback-curses --enable-pinentry-gtk2
@@ -16,7 +16,7 @@ homepage="https://www.gnupg.org/related_software/pinentry/index.html"
 distfiles="ftp://ftp.gnupg.org/gcrypt/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools"
 fi
 
@@ -61,7 +61,7 @@ pinentry-emacs_package() {
 }
 
 pinentry-gnome_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="libgnome-keyring ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" for the GNOME desktop"
 	pkg_install() {
 		vmove usr/bin/pinentry-gnome3


### PR DESCRIPTION
required for some functionality, such as secure password saving.