### PR TITLE
metalog: update to 2018510

### DIFF
--- a/srcpkgs/metalog/template
+++ b/srcpkgs/metalog/template
@@ -1,19 +1,22 @@
 # Template file for 'metalog'
 pkgname=metalog
-version=3
-revision=6
+version=2018510
+revision=1
+wrksrc="$pkgname-$pkgname-$version"
 build_style=gnu-configure
-configure_args="--sbindir=/usr/bin"
-hostmakedepends="pkg-config"
+hostmakedepends="autoconf autoconf-archive automake pkg-config"
 makedepends="pcre-devel"
 conf_files="/etc/metalog.conf"
-short_desc="A modern replacement for syslogd and klogd"
+short_desc="Modern replacement for syslogd and klogd"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
-homepage="http://metalog.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=0c3a1e19008b3d525eab6e5548a4e8cbb0fb235f2804dc41aace82c67ceeebe0
-broken="fseterr.c:77:3: error: #error Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."
+license="GPL-2.0-only"
+homepage="https://github.com/hvisage/metalog"
+distfiles="https://github.com/hvisage/metalog/archive/metalog-${version}.tar.gz"
+checksum=a325df34c3ae77cb2096bce5d5c1130f00d0b9c4f4ddfa185f4e42cafaa7ca05
+
+pre_configure() {
+	./autogen.sh
+}
 
 post_install() {
 	vsv metalog


### PR DESCRIPTION
resolves #3015

It’s home moved to github with a new release that has gnulib (which caused the trouble) removed.