### PR TITLE
rakudo: update to 2018.09.

### DIFF
--- a/srcpkgs/rakudo/template
+++ b/srcpkgs/rakudo/template
@@ -1,19 +1,41 @@
 # Template file for 'rakudo'
 pkgname=rakudo
-version=2018.08
+version=2018.09
 revision=1
 build_style=configure
 make_check_target=test
+make_install_args="RAKUDO_LOG_PRECOMP=1 RAKUDO_RERESOLVE_DEPENDENCIES=0"
 configure_script="perl Configure.pl"
 configure_args="--prefix=/usr --backends=moar"
 hostmakedepends="perl"
 makedepends="libatomic_ops-devel libffi-devel libtommath-devel libuv-devel nqp"
 depends="nqp"
-short_desc="Rakudo is an implementation of Perl 6 language"
+short_desc="Production-ready, stable implementation of the Perl 6 language"
 maintainer="Ruslan <axetwe@gmail.com>"
 license="Artistic-2.0"
 homepage="https://rakudo.org"
 changelog="https://raw.githubusercontent.com/rakudo/rakudo/master/docs/ChangeLog"
-distfiles="https://github.com/rakudo/rakudo/archive/${version}.tar.gz"
-checksum=7e20fc8126da443e7d06f1abf2000695b46e1906a9a49e2b0f6b82a0938e046a
+distfiles="https://rakudo.perl6.org/downloads/$pkgname/$pkgname-$version.tar.gz"
+checksum=4934b84f844adb61ec949b5f4fd31fbc86a83e2195fb2498a1bc2b77d9d859fb
 nocross=yes
+make_dirs="
+ /usr/share/perl6/bin 0755 root root
+ /usr/share/perl6/lib 0755 root root
+ /usr/share/perl6/resources 0755 root root
+ /usr/share/perl6/site/bin 0755 root root
+ /usr/share/perl6/site/dist 0755 root root
+ /usr/share/perl6/site/precomp 0755 root root
+ /usr/share/perl6/site/resources 0755 root root
+ /usr/share/perl6/site/short 0755 root root
+ /usr/share/perl6/site/sources 0755 root root
+ /usr/share/perl6/vendor/bin 0755 root root
+ /usr/share/perl6/vendor/dist 0755 root root
+ /usr/share/perl6/vendor/precomp 0755 root root
+ /usr/share/perl6/vendor/resources 0755 root root
+ /usr/share/perl6/vendor/short 0755 root root
+ /usr/share/perl6/vendor/sources 0755 root root"
+provides="perl6-${version}_$revision"
+
+post_install() {
+	vbin tools/install-dist.p6 perl6-install-dist
+}


### PR DESCRIPTION
- use official release tarball
- make_install_args as recommended by @niner
- provides=perl6-${version}_$revision
- make_dirs and vinstall perl6-install-dist for future compatibility
  with build_style=perl6