### PR TITLE
alert-after: add makejobs to cargo build [ci skip]

### DIFF
--- a/srcpkgs/alert-after/template
+++ b/srcpkgs/alert-after/template
@@ -6,14 +6,14 @@ hostmakedepends="cargo pkg-config"
 makedepends="dbus-devel"
 short_desc="Get a desktop notification after a command finishes executing"
 maintainer="cr6git <quark6@protonmail.com>"
-homepage="https://crates.io/crates/alert-after"
 license="Apache-2.0"
+homepage="https://crates.io/crates/alert-after"
 distfiles="https://github.com/frewsxcv/alert-after/archive/${version}.tar.gz"
 checksum=e0d80e1b4c9cb78f4759a78495f197fa3865eacf9658653ec14ddb010e117b3d
 nocross=yes
 
 do_build() {
-	cargo build --release
+	cargo build --release ${makejobs}
 }
 
 do_install() {


### PR DESCRIPTION
https://github.com/void-linux/void-packages/pull/2436