### PR TITLE
fluidsynth: update to 2.0.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -957,7 +957,7 @@ libfftw3l_omp.so.3 libfftw-3.3.5_1
 libfftw3f_threads.so.3 libfftw-3.3_1
 libfftw3f.so.3 libfftw-3.3_1
 libfftw3f_omp.so.3 libfftw-3.3.5_1
-libfluidsynth.so.1 libfluidsynth-1.1.5_1
+libfluidsynth.so.2 libfluidsynth-2.0.0_1
 liblo.so.7 liblo-0.26_1
 libvamp-sdk.so.2 libvamp-plugin-sdk-2.2_1
 librubberband.so.2 librubberband-1.6.0_1

--- a/srcpkgs/fluidsynth/template
+++ b/srcpkgs/fluidsynth/template
@@ -1,6 +1,6 @@
 # Template file for 'fluidsynth'
 pkgname=fluidsynth
-version=1.1.11
+version=2.0.0
 revision=1
 build_style=cmake
 configure_args="-DLIB_SUFFIX=
@@ -12,7 +12,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1-or-later"
 homepage="http://www.fluidsynth.org/"
 distfiles="https://github.com/FluidSynth/fluidsynth/archive/v${version}.tar.gz"
-checksum=da8878ff374d12392eecf87e96bad8711b8e76a154c25a571dd8614d1af80de8
+checksum=5ca094efbe13fdb880cfd0431354a7b85daf7239c344939493a2aaeca4e59ed5
 
 libfluidsynth_package() {
 	short_desc+=" - runtime library"


### PR DESCRIPTION
According to xbps, after the update following packages will need to be rebuilt.
Carla-1.9.8_2
Carla-devel-1.9.8_2
SLADE-3.1.1.5_4
audacious-plugins-3.10_1
calf-0.90.1_2
csound-6.11.0_1
fluidsynth-1.1.11_1
lmms-1.2.0rc6_1
prboom-plus-2.5.1.4_1
qsynth-0.5.2_1
scummvm-2.0.0_1
tuxguitar-1.5.2_1