### PR TITLE
glusterfs: update to 3.12.14.

### DIFF
--- a/srcpkgs/glusterfs/template
+++ b/srcpkgs/glusterfs/template
@@ -1,11 +1,12 @@
 # Template file for 'glusterfs'
 pkgname=glusterfs
-version=3.10.12
+version=3.12.14
 revision=1
 build_style=gnu-configure
-configure_args="--disable-glupy --enable-crypt-xlator
- --sbindir=/usr/bin --with-mountutildir=/usr/bin
- ac_cv_file__etc_debian_version=no ac_cv_file__etc_SuSE_release=no
+configure_args="
+ --disable-glupy --enable-crypt-xlator --with-mountutildir=/usr/bin
+ ac_cv_file__etc_debian_version=no
+ ac_cv_file__etc_SuSE_release=no
  ac_cv_file__etc_redhat_release=no"
 hostmakedepends="automake flex libtool pkg-config python"
 makedepends="acl-devel fuse-devel libaio-devel liblvm2app-devel libressl-devel
@@ -18,7 +19,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2.0-or-later, LGPL-3.0-only"
 homepage="http://www.gluster.org/"
 distfiles="https://download.gluster.org/pub/gluster/glusterfs/${version%.*}/${version}/${pkgname}-${version}.tar.gz"
-checksum=2f5f604b1da0db014f522bc0c9052425018ede7d3e07c5f52d546cb7abdada07
+checksum=a692c263eefecb9640e8a4154fe0c5bc1613a0b0ed3a92209ff0b628f5945509
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="not yet supported";;


### PR DESCRIPTION
This should get some testing by somebody who actually uses the package. I only verified that it built correctly.

The 3.10.x series was EOL'd back in June. This version will likely be EOL'd sometime next month. The package should be upgraded to the 4.1.x series before then. See the [release schedule](https://www.gluster.org/release-schedule/) for more information.