### PR TITLE
xbps-triggers: rework some triggers

### DIFF
--- a/srcpkgs/xbps-triggers/files/appstream-cache
+++ b/srcpkgs/xbps-triggers/files/appstream-cache
@@ -15,8 +15,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 # The appstreamcli binary program.
 APPSTREAMCLI="usr/bin/appstreamcli"
 

--- a/srcpkgs/xbps-triggers/files/gconf-schemas
+++ b/srcpkgs/xbps-triggers/files/gconf-schemas
@@ -24,8 +24,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 # The gconftool-2 binary program.
 GCONFTOOL2="usr/bin/gconftool-2"
 

--- a/srcpkgs/xbps-triggers/files/gdk-pixbuf-loaders
+++ b/srcpkgs/xbps-triggers/files/gdk-pixbuf-loaders
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 pixbuf_bin=usr/bin/gdk-pixbuf-query-loaders
 pixbuf_cache=usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 

--- a/srcpkgs/xbps-triggers/files/gio-modules
+++ b/srcpkgs/xbps-triggers/files/gio-modules
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 gioquery=usr/bin/gio-querymodules
 giocachedir=usr/lib/gio/modules
 

--- a/srcpkgs/xbps-triggers/files/gsettings-schemas
+++ b/srcpkgs/xbps-triggers/files/gsettings-schemas
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 # The glib-compile-schemas binary program.
 GSCHEMASCOMP="usr/bin/glib-compile-schemas"
 

--- a/srcpkgs/xbps-triggers/files/gtk-icon-cache
+++ b/srcpkgs/xbps-triggers/files/gtk-icon-cache
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 iconcache_bin=usr/bin/gtk-update-icon-cache
 
 case "$ACTION" in
@@ -31,10 +29,10 @@ run)
 				echo "cache for ${dir}."
 			fi
 		done
-		break
+		exit 0
 	fi
 
-	if [ ! -x ${iconcache_bin} ]; then
+	if [ ! -x $iconcache_bin ]; then
 		exit 0
 	fi
 

--- a/srcpkgs/xbps-triggers/files/gtk-immodules
+++ b/srcpkgs/xbps-triggers/files/gtk-immodules
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 immodules_bin=usr/bin/gtk-query-immodules-2.0
 immodules_cache=usr/lib/gtk-2.0/2.10.0/immodules.cache
 
@@ -26,7 +24,7 @@ targets)
 run)
 	if [ "$TARGET" = "post-remove" -a "${PKGNAME}" = "gtk+" ]; then
 		[ -f ${immodules_cache} ] && rm -f ${immodules_cache}
-		break
+		exit 0
 	fi
 	case "$TARGET" in
 	post-*)
@@ -34,10 +32,13 @@ run)
 			echo "Removing obsolete conf file: etc/gtk-2.0/gtk.immodules"
 			rm -f etc/gtk-2.0/gtk.immodules
 		fi
-		if [ -x ${immodules_bin} ]; then
-			echo "Updating GTK+ immodules cache..."
-			${immodules_bin} --update-cache
+
+		if [ ! -x $immodules_bin ]; then
+			exit 0
 		fi
+
+		echo "Updating GTK+ immodules cache..."
+		$immodules_bin --update-cache
 		;;
 	esac
 	;;

--- a/srcpkgs/xbps-triggers/files/gtk3-immodules
+++ b/srcpkgs/xbps-triggers/files/gtk3-immodules
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 immodules_bin=usr/bin/gtk-query-immodules-3.0
 immodules_cache=usr/lib/gtk-3.0/3.0.0/immodules.cache
 
@@ -26,7 +24,7 @@ targets)
 run)
 	if [ "$TARGET" = "post-remove" -a "${PKGNAME}" = "gtk+3" ]; then
 		[ -f ${immodules_cache} ] && rm -f ${immodules_cache}
-		break
+		exit 0
 	fi
 	case "$TARGET" in
 	post-*)
@@ -34,10 +32,13 @@ run)
 			echo "Removing obsolete conf file: etc/gtk-3.0/gtk.immodules"
 			rm -f etc/gtk-3.0/gtk.immodules
 		fi
-		if [ -x ${immodules_bin} ]; then
-			echo "Updating GTK+3 immodules cache..."
-			${immodules_bin} --update-cache
+
+		if [ ! -x $immodules_bin ]; then
+			exit 0
 		fi
+
+		echo "Updating GTK+3 immodules cache..."
+		$immodules_bin --update-cache
 		;;
 	esac
 	;;

--- a/srcpkgs/xbps-triggers/files/hwdb.d-dir
+++ b/srcpkgs/xbps-triggers/files/hwdb.d-dir
@@ -14,12 +14,19 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
+udevadm=usr/bin/udevadm
+
 case "$ACTION" in
 targets)
 	echo "post-install pre-remove"
 	;;
 run)
-	usr/bin/udevadm hwdb --root=. --update
+	if [ ! -x $udevadm ]; then
+		exit 0
+	fi
+
+	echo "Updating udev hardware database ..."
+	$udevadm hwdb --root=. --update
 	;;
 *)
 	exit 1

--- a/srcpkgs/xbps-triggers/files/info-files
+++ b/srcpkgs/xbps-triggers/files/info-files
@@ -29,8 +29,6 @@ run)
 		exit 1
 	fi
 
-	HOSTARCH=$(uname -m)
-
 	for f in ${info_files}; do
 		if [ "$f" = "/usr/share/info/dir" ]; then
 			continue
@@ -49,10 +47,6 @@ run)
 			;;
 		esac
 
-		if [ "$XBPS_TARGET_ARCH" != "$HOST_ARCH" ]; then
-			# Use host utility
-			installinfo=install-info
-		fi
 		$installinfo $infoargs ./$f $infodir/dir 2>/dev/null
 		if [ $? -eq 0 ]; then
 			echo "done."

--- a/srcpkgs/xbps-triggers/files/kernel-hooks
+++ b/srcpkgs/xbps-triggers/files/kernel-hooks
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 RUN_TARGETS="pre-install post-install pre-remove post-remove"
 
 case "$ACTION" in

--- a/srcpkgs/xbps-triggers/files/mimedb
+++ b/srcpkgs/xbps-triggers/files/mimedb
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 mimedb_bin=usr/bin/update-mime-database
 
 case "$ACTION" in
@@ -25,10 +23,12 @@ targets)
 run)
 	case "$TARGET" in
 	post-*)
-		if [ -x ${mimedb_bin} ]; then
-			echo "Updating shared-mime-info database..."
-			PKGSYSTEM_ENABLE_FSYNC=0 ${mimedb_bin} -n usr/share/mime > /dev/null
+		if [ ! -x ${mimedb_bin} ]; then
+			exit 0
 		fi
+
+		echo "Updating shared-mime-info database..."
+		PKGSYSTEM_ENABLE_FSYNC=0 ${mimedb_bin} -n usr/share/mime > /dev/null
 		;;
 	esac
 	;;

--- a/srcpkgs/xbps-triggers/files/mkdirs
+++ b/srcpkgs/xbps-triggers/files/mkdirs
@@ -18,8 +18,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 case "$ACTION" in
 targets)
 	echo "post-install post-remove"

--- a/srcpkgs/xbps-triggers/files/pango-modules
+++ b/srcpkgs/xbps-triggers/files/pango-modules
@@ -20,8 +20,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 pango_modules=etc/pango/pango.modules
 
 case "$ACTION" in

--- a/srcpkgs/xbps-triggers/files/register-shell
+++ b/srcpkgs/xbps-triggers/files/register-shell
@@ -14,8 +14,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 case "$ACTION" in
 targets)
 	echo "post-install post-remove"

--- a/srcpkgs/xbps-triggers/files/update-desktopdb
+++ b/srcpkgs/xbps-triggers/files/update-desktopdb
@@ -26,11 +26,15 @@ targets)
 run)
 	if [ "$TARGET" = "post-remove" -a "${PKGNAME}" = "desktop-file-utils" ]; then
 		[ -f ${desktopdb_cache} ] && rm -f ${desktopdb_cache}
-		break
+		exit 0
 	fi
 	case "$TARGET" in
 	post-*)
-		if [ -x ${desktopdb_bin} -a -d $desktopdb_dir ]; then
+		if [ ! -x $desktopdb_bin ]; then
+			exit 0
+		fi
+
+		if [ -d $desktopdb_dir ]; then
 			echo "Updating MIME database..."
 			${desktopdb_bin} ${desktopdb_dir}
 		fi

--- a/srcpkgs/xbps-triggers/files/x11-fonts
+++ b/srcpkgs/xbps-triggers/files/x11-fonts
@@ -16,8 +16,6 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 mkfontdir=usr/bin/mkfontdir
 mkfontscale=usr/bin/mkfontscale
 fccache=usr/bin/fc-cache
@@ -27,7 +25,11 @@ targets)
 	echo "post-install post-remove"
 	;;
 run)
-	if [ ! -x ${mkfontdir} -a ! -x ${mkfontscale} ]; then
+	if [ ! -x $mkfontdir ]; then
+		exit 0
+	fi
+
+	if [ ! -x $mkfontscale ]; then
 		exit 0
 	fi
 

--- a/srcpkgs/xbps-triggers/files/xml-catalog
+++ b/srcpkgs/xbps-triggers/files/xml-catalog
@@ -15,10 +15,10 @@ PKGNAME="$3"
 VERSION="$4"
 UPDATE="$5"
 
-export PATH="$PATH:/usr/local/bin"
-
 sgml_catalog=usr/share/sgml/catalog
 xml_catalog=usr/share/xml/catalog
+
+xmlcatmgr=usr/bin/xmlcatmgr
 
 register_entries()
 {
@@ -26,7 +26,7 @@ register_entries()
 		echo -n "Registering SGML catalog entries... "
 		set -- ${sgml_entries}
 		while [ $# -gt 0 ]; do
-			xmlcatmgr -sc ${sgml_catalog} add "$1" "$2" "$3"
+			$xmlcatmgr -sc ${sgml_catalog} add "$1" "$2" "$3"
 			shift; shift; shift;
 		done
 		echo "done."
@@ -36,7 +36,7 @@ register_entries()
 		echo -n "Registering XML catalog entries... "
 		set -- ${xml_entries}
 		while [ $# -gt 0 ]; do
-			xmlcatmgr -c ${xml_catalog} add "$1" "$2" "$3"
+			$xmlcatmgr -c ${xml_catalog} add "$1" "$2" "$3"
 			shift; shift; shift;
 		done
 		echo "done."
@@ -49,7 +49,7 @@ unregister_entries()
 		echo -n "Unregistering SGML catalog entries... "
 		set -- ${sgml_entries}
 		while [ $# -gt 0 ]; do
-			xmlcatmgr -sc ${sgml_catalog} remove "$1" "$2" \
+			$xmlcatmgr -sc ${sgml_catalog} remove "$1" "$2" \
 				2>/dev/null
 			shift; shift; shift
 		done
@@ -59,7 +59,7 @@ unregister_entries()
 		echo -n "Unregistering XML catalog entries... "
 		set -- ${xml_entries}
 		while [ $# -gt 0 ]; do
-			xmlcatmgr -c ${xml_catalog} remove "$1" "$2" \
+			$xmlcatmgr -c ${xml_catalog} remove "$1" "$2" \
 				2>/dev/null
 			shift; shift; shift
 		done

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.109
+version=0.110
 revision=1
 noarch=yes
 bootstrap=yes


### PR DESCRIPTION
This lists changes per-trigger, triggers that changed the same thing
are listed under the same group

appstream-cache:
gconf-schemas:
gdk-pixbuf-loaders:
gsettings-schemas:
kernel-hooks:
mkdirs:
pango-modules:
register-shell:
update-dektopdb:
update-desktopdb:
x11-fonts:

- remove useless PATH expansion that is already done in the hook script.

gtk-icon-cache:
gtk-immodules:
gtk3-immodules:

- remove useless PATH expansion that is already done in the hook script.
- use exit 0 instead of break

hwdb.d:

- check if tooling is available

info-files

- Remove support for using host tooling

mimedb:

- remove useless PATH expansion that is already done in the hook script.
- check if tooling is available

xml-catalog:

- remove useless PATH expansion that is already done in the hook script.
- add a xmlcatmgr variable so that the first check not always fails

[ci skip]

