### PR TITLE
linux3.18: update to 3.18.123. [ci skip]

### DIFF
--- a/srcpkgs/linux3.18/template
+++ b/srcpkgs/linux3.18/template
@@ -1,7 +1,7 @@
 # Template file for 'linux3.18'
 pkgname=linux3.18
-version=3.18.122
-revision=2
+version=3.18.123
+revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -9,7 +9,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="${KERNEL_SITE}/kernel/v3.x/linux-${version}.tar.xz"
-checksum=675b1ce36af23caa500cb1d4f0ec2976791fb0a97ebb6486a5e2ebcb5527ade5
+checksum=c10de32c9b31fb619b016a00d77afc394db5a4542e258e927f06a5ead86f8c64
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
fixes CVE-2018-6554 / CVE-2018-6555.