### PR TITLE
multibootusb: fix path in polkit policy

### DIFF
--- a/srcpkgs/multibootusb/template
+++ b/srcpkgs/multibootusb/template
@@ -1,7 +1,7 @@
 # Template file for 'multibootusb'
 pkgname=multibootusb
 version=9.2.0
-revision=1
+revision=2
 noarch=yes
 build_style=python3-module
 pycompile_module="scripts"
@@ -15,3 +15,7 @@ homepage="http://multibootusb.org/"
 changelog="https://raw.githubusercontent.com/mbusb/multibootusb/master/CHANGELOG"
 distfiles="https://github.com/mbusb/multibootusb/archive/v${version}.tar.gz"
 checksum=1f1539e11e5ac8af2fc2379a22c2ad6b73759b2babbc165f7ff716240e922d7d
+
+pre_build() {
+	sed -i -e 's#local/bin#bin#g' org.debian.pkexec.run-multibootusb.policy
+}


### PR DESCRIPTION
the multibootusb install script only cares about debian or rpm based
distros, therefore we have to fix the path in the template

resolves #3151