### PR TITLE
chromium: disable kAccountConsistencyName by default

### DIFF
--- a/srcpkgs/chromium/patches/disable-account-consistency-name.patch
+++ b/srcpkgs/chromium/patches/disable-account-consistency-name.patch
@@ -1,0 +1,11 @@
+--- chrome/browser/about_flags.cc.orig	2018-09-28 20:23:00.831827041 +0200
++++ chrome/browser/about_flags.cc	2018-09-28 20:23:27.702828427 +0200
+@@ -1837,7 +1837,7 @@
+      SINGLE_VALUE_TYPE(switches::kEnableWebGLDraftExtensions)},
+ #if BUILDFLAG(ENABLE_DICE_SUPPORT)
+     {"account-consistency", flag_descriptions::kAccountConsistencyName,
+-     flag_descriptions::kAccountConsistencyDescription, kOsAll,
++     flag_descriptions::kAccountConsistencyDescription, 0,
+      FEATURE_WITH_PARAMS_VALUE_TYPE(kAccountConsistencyFeature,
+                                     kAccountConsistencyFeatureVariations,
+                                     "AccountConsistencyVariations")},

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -2,7 +2,7 @@
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
 version=69.0.3497.100
-revision=1
+revision=2
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 homepage="https://www.chromium.org/"


### PR DESCRIPTION
Disable the much discussed auto login (to your Google account) feature by default for all OSes.
Rationale e.g. https://blog.cryptographyengineering.com/2018/09/23/why-im-leaving-chrome/
I don't know if we want to start patching Chromium. Opinions?