### PR TITLE
chromium: build with clang for i686

### DIFF
--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -18,6 +18,10 @@ nopie=yes  # contains tools that are not PIE, enables PIE itself
 build_options="clang"
 desc_option_clang="Use clang to build"
 
+case $XBPS_TARGET_MACHINE in
+	i686) build_options_default+=" clang" ;;
+esac
+
 hostmakedepends="$(vopt_if clang clang) yasm python pkg-config perl gperf bison ninja nodejs hwids
  libatomic-devel libevent-devel libglib-devel"
 makedepends="libpng-devel gtk+-devel gtk+3-devel nss-devel pciutils-devel


### PR DESCRIPTION
chromium fails to build on i686 because gcc aligns int64_t with 4 bytes
clang instead aligns int64_t with 8 bytes

[ci skip]