### PR TITLE
linux4.14: update to 4.14.73. [ci skip]

### DIFF
--- a/srcpkgs/linux4.14/template
+++ b/srcpkgs/linux4.14/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.14'
 pkgname=linux4.14
-version=4.14.72
+version=4.14.73
 revision=1
 patch_args="-Np1"
 wrksrc="linux-${version}"
@@ -9,7 +9,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${version}.tar.xz"
-checksum=df925906250bbc40fcf0137d7ad0fb8edc528d926832634f1233b7540564557f
+checksum=999e38141ccc447df7bf7ce10b8803c12b32274b76d3d5400bf3fd88eee0e31e
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes


### PR DESCRIPTION
fixes CVE-2018-14633.