### PR TITLE
linux4.4: update to 4.4.159. [ci skip]

### DIFF
--- a/srcpkgs/linux4.4/template
+++ b/srcpkgs/linux4.4/template
@@ -1,6 +1,6 @@
 # Template file for 'linux4.4'
 pkgname=linux4.4
-version=4.4.156
+version=4.4.159
 revision=1
 wrksrc="linux-${version}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -8,7 +8,7 @@ homepage="https://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel and modules (${version%.*} series)"
 distfiles="${KERNEL_SITE}/kernel/v4.x/linux-${version}.tar.xz"
-checksum=0442d8d8ca967211cd181f5d9655e1658aa84a9ec265417223dd29c4983d48aa
+checksum=0e00bbdb055ee202572b9af21f77e4373412ad197fc50434b94c13ef6ff83bc2
 
 nocross=yes
 nodebug=yes


### PR DESCRIPTION
fixes CVE-2018-14633.