### PR TITLE
postgis: update to 2.5.0 & adopt package (resolves #3227)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3238,7 +3238,7 @@ libmedC.so.1 libmed-3.3.1_1
 libmed.so.1 libmed-3.3.1_1
 libeog.so eog-3.28.0_4
 libfreexl.so.1 freexl-1.0.5_1
-libgeos-3.6.2.so geos-3.6.2_1
+libgeos-3.7.0.so geos-3.7.0_1
 libgeos_c.so.1 geos-3.6.2_1
 libspatialindex.so.4 libspatialindex-1.8.5_1
 libspatialindex_c.so.4 libspatialindex-1.8.5_1

--- a/srcpkgs/geos/template
+++ b/srcpkgs/geos/template
@@ -1,6 +1,6 @@
 # Template file for 'geos'
 pkgname=geos
-version=3.6.3
+version=3.7.0
 revision=1
 build_style=gnu-configure
 short_desc="C++ port of the Java Topology Suite (JTS)"
@@ -8,7 +8,7 @@ maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="LGPL-2.1-or-later"
 homepage="https://trac.osgeo.org/geos"
 distfiles="http://download.osgeo.org/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=ab9eaa0a67f7068866ac1e4dbf717b0c49f96254d65e9ce23ed7af1cccbe3e4b
+checksum=4fbf41a792fd74293ab59e0a980e8654cd411a9d45416d66eaa12d53d1393fd7
 
 geos-devel_package() {
 	depends="${makedepends} ${sourcepkg}-${version}_${revision}"

--- a/srcpkgs/postgis/template
+++ b/srcpkgs/postgis/template
@@ -1,23 +1,22 @@
 # Template file for 'postgis'
 pkgname=postgis
-version=2.4.4
+version=2.5.0
 revision=1
 build_style=gnu-configure
 configure_args="--with-projdir=${XBPS_CROSS_BASE}/usr
-  --with-projdir=${XBPS_CROSS_BASE}/usr
-  --with-jsondir=${XBPS_CROSS_BASE}/usr
-  --with-protobufdir=${XBPS_CROSS_BASE}/usr"
+ --with-projdir=${XBPS_CROSS_BASE}/usr
+ --with-jsondir=${XBPS_CROSS_BASE}/usr
+ --with-protobufdir=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="automake libtool perl pkg-config geos libgdal-tools postgresql-libs-devel"
 makedepends="geos-devel postgresql-libs-devel libgdal-devel libpqxx-devel
  libxml2-devel proj-devel protobuf-c-devel json-c"
-short_desc="A spatial database extender for PostgreSQL"
-maintainer="Árni Dagur <arnidg00@gmail.com>"
+short_desc="Spatial database extender for PostgreSQL"
+maintainer="cr6git <quark6@protonmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://postgis.net/"
 distfiles="https://download.osgeo.org/postgis/source/postgis-${version}.tar.gz"
-checksum=0663efb589210d5048d95c817e5cf29552ec8180e16d4c6ef56c94255faca8c2
+checksum=be73abd747e9665f29748e0e7dc6b3f7b1ce98f32e3567f08259420ca10e36d5
 nocross="FIXME: Cannot run test program to determine PROJ version"
-disable_parallel_build=yes
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
I also updated `geos` to 3.7.0, because:
````
configure: WARNING:  --------- GEOS VERSION WARNING ------------ 
configure: WARNING:   You are building against GEOS 3.6.3 
configure: WARNING:   To take advantage of all the features of 
configure: WARNING:   this PostGIS version requires GEOS 3.7.0 or higher.
````