### PR TITLE
rust: cross build (&template cleanup)

### DIFF
--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo'
 pkgname=cargo
-version=0.29.0
-revision=2
+version=0.30.0
+revision=1
 hostmakedepends="rust python curl cmake pkg-config"
 makedepends="libcurl-devel libgit2-devel"
 depends="rust"
@@ -10,45 +10,86 @@ maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT, Apache-2.0"
 homepage="https://crates.io/"
 distfiles="https://github.com/rust-lang/cargo/archive/${version}.tar.gz"
-checksum=9aedb9536ec0b92059ed06b79a72798daf14e3fbcf29fac308ac07d23a9493d3
-nocross=yes
+checksum=82f3ba49192b74b115b8aeca9db24deca022ee5e6351292611ab5b50e4455251
+_cargo_dist_version=0.30.0
 
-case "$XBPS_MACHINE" in
-x86_64-musl)
-	distfiles+="
-	 https://alpha.de.repo.voidlinux.org/distfiles/cargo-0.29.0-x86_64-unknown-linux-musl-libgit2-27.tar.gz"
-	checksum+="
-	 a46cb16e1008032277d744b74cba16a107539b12b8fbfd763c4cc1f80ee5568c"
-	;;
-x86_64)
-	distfiles+="
-	 https://static.rust-lang.org/dist/cargo-0.29.0-x86_64-unknown-linux-gnu.tar.gz"
-	checksum+="
-	 a5e7749767c47669ed9b6e32c6fb8eda6b0fe1c63ac73a6d4666b5c1352bad24"
-	;;
-i686)
-	distfiles+="
-	 https://static.rust-lang.org/dist/cargo-0.29.0-i686-unknown-linux-gnu.tar.gz"
-	checksum+="
-	 ec9ba3aa064719222bb59de4cf8f2ad061bb31288e7dd4e98b80215203aa5876"
-	;;
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" cargo"
+	makedepends+=" rust"
+else
+	case "$XBPS_MACHINE" in
+	x86_64-musl)
+		distfiles+="
+		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.gz"
+		checksum+="
+		 e9344cbf3db669383cb3492d12bcd42d9130665f577be9ad4d2028011c7b1fae"
+		;;
+	x86_64)
+		distfiles+="
+		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-x86_64-unknown-linux-gnu.tar.gz"
+		checksum+="
+		 b6012ef67923b67b9b558628cc41dd90a688742bf23e9b46ad8839d898f1b0b1"
+		;;
+	i686)
+		distfiles+="
+		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-i686-unknown-linux-gnu.tar.gz"
+		checksum+="
+		 2fc5f7f5b128de456a9e1e3f5f4ef2c6d3169dbfe078931d9fcf38c9aa9b45ba"
+		;;
+	esac
+fi
+
+case $XBPS_TARGET_MACHINE in
+	i686) _host_triplet=i686-unknown-linux-gnu;;
+	x86_64) _host_triplet=x86_64-unknown-linux-gnu;;
+	x86_64-musl) _host_triplet=x86_64-unknown-linux-musl;;
+	armv6l) _host_triplet=arm-unknown-linux-gnueabihf;;
+	armv6l-musl) _host_triplet=arm-unknown-linux-musleabihf;;
+	armv7l) _host_triplet=armv7-unknown-linux-gnueabihf;;
+	armv7l-musl) _host_triplet=armv7-unknown-linux-musleabihf;;
+	aarch64) _host_triplet=aarch64-unknown-linux-gnu;;
+	aarch64-musl) _host_triplet=aarch64-unknown-linux-musl;;
+	*) broken="Please add your triplet to the cargo template!";;
 esac
 
 post_extract() {
-	mkdir -p target/snapshot
-	case "$XBPS_MACHINE" in
-		x86_64-musl) cp ../cargo cargo;;
-		*) cp ../cargo-*/cargo/bin/cargo cargo;;
-	esac
+	if [ -z "$CROSS_BUILD" ]; then
+		mkdir -p target/snapshot
+		case "$XBPS_MACHINE" in
+			x86_64-musl) cp ../cargo cargo;;
+			*) cp ../cargo-${_cargo_dist_version}-${_host_triplet}/cargo/bin/cargo cargo;;
+		esac
+	fi
 }
+do_configure() {
+	# Actually use the config we set below
+	export CARGO_HOME="$wrksrc/.cargo"
+
+	mkdir -p .cargo
+
+	cat >> .cargo/config <<EOF
+[build]
+jobs = ${makejobs#*j}
+target = "${_host_triplet}"
+[target.${_host_triplet}]
+linker = "${CC}"
+EOF
+}
+
 do_build() {
 	export LIBGIT2_SYS_USE_PKG_CONFIG=yes
-	export CARGO_HOME="${wrksrc}/.cargo"
 	export RUST_BACKTRACE=1
-	./cargo build --release
+	export PKG_CONFIG_ALLOW_CROSS=1
+	export RUSTFLAGS="--sysroot=${XBPS_CROSS_BASE}/usr"
+	if [ "$CROSS_BUILD" ]; then
+		cargo build --release
+	else
+		./cargo build --release
+	fi
 }
+
 do_install() {
-	vbin target/release/cargo
+	vbin target/${_host_triplet}/release/cargo
 	for f in src/etc/man/*.?; do
 		vman $f
 	done

--- a/srcpkgs/rust/patches/use-correct-llvm-when-cross.patch
+++ b/srcpkgs/rust/patches/use-correct-llvm-when-cross.patch
@@ -1,0 +1,15 @@
+Reason: rustc_codegen_llvm attempts to link against the host's llvm without this patch
+--- rustc-1.28.0-src/src/librustc_llvm/build.rs.orig    2018-10-01 04:00:15.481334857 +0200
++++ rustc-1.28.0-src/src/librustc_llvm/build.rs 2018-10-01 04:01:15.145790417 +0200
+@@ -227,8 +227,8 @@
+             println!("cargo:rustc-link-search=native={}", &lib[9..]);
+         } else if is_crossed {
+             if lib.starts_with("-L") {
+-                println!("cargo:rustc-link-search=native={}",
+-                         lib[2..].replace(&host, &target));
++                println!("cargo:rustc-link-search=native={}{}",
++                         env::var("XBPS_CROSS_BASE").unwrap(), &lib[2..]);
+             }
+         } else if lib.starts_with("-l") {
+             println!("cargo:rustc-link-lib={}", &lib[2..]);
+

--- a/srcpkgs/rust/template.orig
+++ b/srcpkgs/rust/template.orig
@@ -1,9 +1,9 @@
 # Template file for 'rust'
 pkgname=rust
 version=1.28.0
-revision=2
-_rust_dist_version=1.28.0
-_cargo_dist_version=0.30.0
+revision=1
+_rust_dist_version=1.27.2
+_cargo_dist_version=0.29.0
 # NB. if you push any(!) new version, don't forget to put a build
 # output of musl to https://alpha.de.repo.voidlinux.org/distfiles/
 wrksrc="rustc-${version}-src"
@@ -35,9 +35,9 @@ else
 		 https://alpha.de.repo.voidlinux.org/distfiles/rust-std-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.xz
 		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.gz"
 		checksum+="
-		 1c54d595b0a1f3e283e453ff142800b3fdfb20dc2e45ceb71317693d2a278362
-		 17d52f198877228788f012acf7b3ccbcbf9240553d42502b6816a3431806d9e1
-		 e9344cbf3db669383cb3492d12bcd42d9130665f577be9ad4d2028011c7b1fae"
+		 2da811f9a81f63a93d62cefe15f391efaff663438f2c364fd1a522ef576753f4
+		 e18aea5529d434e0950a77c266c3230ea878e3f3ea8b4114ee5a081092f98037
+		 d54f7b4c6e8af657e6173e9e0200130b2f297f365ed4c06a4e9029762d975836"
 		;;
 	x86_64)
 		# extract from src/stage0.txt
@@ -46,9 +46,9 @@ else
 		 https://static.rust-lang.org/dist/rust-std-${_rust_dist_version}-x86_64-unknown-linux-gnu.tar.gz
 		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-x86_64-unknown-linux-gnu.tar.xz"
 		checksum+="
-		 008bb3d714544bc991594b29a98a154441914c4771007130361bbadfb54143d0
-		 c5aed4c7ef362b5754526d26acaccdc9300942fd12e5cc67cc56fc89576a9dab
-		 9524db722356307669c9068bb7df8dbd57e153717e62071b62560eb22ce2f3cd"
+		 ec3efc17ddbe6625840957049e15ebae960f447c8e8feb7da40c28dd6adf655f
+		 68984f2233853d3e9c7c56edd72a91b5822157f28fdb42023fb311af68f842dd
+		 2e62f91aab9ea496209a060e7ec62f088f5081b568a28b88f3c8ea7073db9829"
 		;;
 	i686)
 		# extract from src/stage0.txt
@@ -57,9 +57,9 @@ else
 		 https://static.rust-lang.org/dist/rust-std-${_rust_dist_version}-i686-unknown-linux-gnu.tar.gz
 		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-i686-unknown-linux-gnu.tar.xz"
 		checksum+="
-		30fa399934c90024275a08aa8992e76e98e04f152fc65b8aad3ca1fe231db39e
-		fbf71c10787fa1cd4fbde0a1ef6805fa4978705c809959f48917bb7c5b5b6d61
-		4b828c263283241ad1c99f30e0b5d8554b6dac2737d09cfd466b4c15b0d7296a"
+		 a9ba9c97cf4818ab14966617390eadfc3dfd5221033f8f749aebd86c1d722ef9
+		 0ac6356223f53ec5f21cea6a9e9e5cd2fee3d45916f831e1ca54853893ec0b73
+		 2bc3468b9b470824bf366f7404ad36644ad4d5a41f1be29601fd6a138d3b72a5"
 		;;
 	esac
 fi
@@ -93,16 +93,13 @@ post_extract() {
 		*-musl) patch -p1 < $FILESDIR/musl.patch ;;
 	esac
 
-	if [ -z "$CROSS_BUILD" ]; then
+	if ! [ "$CROSS_BUILD" ]; then
 		mkdir -p stage0
-		cp -bflr ../rustc-*/rustc/* stage0
-		cp -bflr ../rust-std-*/rust-std-*/* stage0
+		cp -flr ../rustc-*/rustc/* stage0
+		cp -flr ../rust-std-*/rust-std-*/* stage0
 		case "$XBPS_MACHINE" in
-			*-musl) cp -bflr ../cargo stage0/bin;;
-			*)
-				rm ../cargo-*/cargo/manifest.in
-				cp -flr ../cargo-*/cargo/* stage0
-				;;
+			*-musl) cp -flr ../cargo stage0/bin;;
+			*) cp -flr ../cargo-*/cargo/* stage0;;
 		esac
 	fi
 
@@ -123,18 +120,18 @@ do_configure() {
 		--disable-docs
 		--disable-codegen-tests
 		--llvm-root=/usr
-		--set=target.${_build_triplet}.llvm-config=/usr/bin/llvm-config
+		--enable-local-rebuild
+		--set=target.${_build_triplet}.llvm-config="/usr/bin/llvm-config"
 	"
 
 	# Disable jemalloc for now. It increases the size of small programs
 	# significantly (hello world without jemalloc 130KB vs with jemalloc
 	# 300KB) and provides worse performance in some cases.
-	configure_args+=" --disable-jemalloc"
+	configure_args=+" --disable-jemalloc"
 
 	if [ "$CROSS_BUILD" ]; then
 		configure_args+="
 			--local-rust-root=/usr
-			--enable-local-rebuild
 		"
 
 		# Set the appropriate values for the native compilation tools
@@ -142,7 +139,7 @@ do_configure() {
 			--set=target.${_build_triplet}.cc=${CC_host}
 			--set=target.${_build_triplet}.cxx=${CXX_host}
 			--set=target.${_build_triplet}.ar=${AR_host}
-			--set=target.${_build_triplet}.linker=${CC_host}
+			--set=target.${_build_triplet}.linker=${LD_host}
 		"
 
 		# Set 'llvm-config' for the cross target (host) so that we don't build
@@ -151,11 +148,11 @@ do_configure() {
 			--set=target.${_host_triplet}.llvm-config="/usr/bin/llvm-config"
 		"
 	else
-		configure_args+=" --local-rust-root=$wrksrc/stage0"
+		configure_args+="--local-rust-root=$wrksrc/stage0"
 	fi
 	case "$XBPS_TARGET_MACHINE" in
 	*-musl)
-		configure_args+=" --musl-root=/usr"
+		configure_args+="--musl-root=/usr"
 		;;
 	esac
 
@@ -173,10 +170,9 @@ pre_build() {
 }
 
 # Set the correct CFLAGS for the build host, we have to compile libbacktrace
-# for it during stage1. Otherwise it attemps to use CFLAGS, which are the CFLAGS
-# of the cross host.
+# for it during stage1
 do_build() {
-	env CFLAGS_${_build_triplet}="${CFLAGS_host}" make ${makejobs} ${make_build_args}
+       env CFLAGS_${_build_triplet}="${CFLAGS_host}" make ${makejobs} ${make_build_args}
 }
 
 do_install() {

--- a/srcpkgs/rust/template.rej
+++ b/srcpkgs/rust/template.rej
@@ -1,0 +1,41 @@
+--- srcpkgs/rust/template
++++ srcpkgs/rust/template
+@@ -30,9 +30,9 @@ x86_64-musl)
+ 	 https://alpha.de.repo.voidlinux.org/distfiles/rust-std-${_rust_dist_version}-x86_64-unknown-linux-musl.tar.xz
+ 	 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.gz"
+ 	checksum+="
+-	 2da811f9a81f63a93d62cefe15f391efaff663438f2c364fd1a522ef576753f4
+-	 e18aea5529d434e0950a77c266c3230ea878e3f3ea8b4114ee5a081092f98037
+-	 d54f7b4c6e8af657e6173e9e0200130b2f297f365ed4c06a4e9029762d975836"
++	 1c54d595b0a1f3e283e453ff142800b3fdfb20dc2e45ceb71317693d2a278362
++	 17d52f198877228788f012acf7b3ccbcbf9240553d42502b6816a3431806d9e1
++	 e9344cbf3db669383cb3492d12bcd42d9130665f577be9ad4d2028011c7b1fae"
+ 	;;
+ x86_64)
+ 	# extract from src/stage0.txt
+@@ -41,9 +41,9 @@ x86_64)
+ 	 https://static.rust-lang.org/dist/rust-std-${_rust_dist_version}-x86_64-unknown-linux-gnu.tar.gz
+ 	 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-x86_64-unknown-linux-gnu.tar.xz"
+ 	checksum+="
+-	 ec3efc17ddbe6625840957049e15ebae960f447c8e8feb7da40c28dd6adf655f
+-	 68984f2233853d3e9c7c56edd72a91b5822157f28fdb42023fb311af68f842dd
+-	 2e62f91aab9ea496209a060e7ec62f088f5081b568a28b88f3c8ea7073db9829"
++	 008bb3d714544bc991594b29a98a154441914c4771007130361bbadfb54143d0
++	 c5aed4c7ef362b5754526d26acaccdc9300942fd12e5cc67cc56fc89576a9dab
++	 9524db722356307669c9068bb7df8dbd57e153717e62071b62560eb22ce2f3cd"
+ 	;;
+ i686)
+ 	# extract from src/stage0.txt
+@@ -52,9 +52,9 @@ i686)
+ 	 https://static.rust-lang.org/dist/rust-std-${_rust_dist_version}-i686-unknown-linux-gnu.tar.gz
+ 	 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-i686-unknown-linux-gnu.tar.xz"
+ 	checksum+="
+-	 a9ba9c97cf4818ab14966617390eadfc3dfd5221033f8f749aebd86c1d722ef9
+-	 0ac6356223f53ec5f21cea6a9e9e5cd2fee3d45916f831e1ca54853893ec0b73
+-	 2bc3468b9b470824bf366f7404ad36644ad4d5a41f1be29601fd6a138d3b72a5"
++	 30fa399934c90024275a08aa8992e76e98e04f152fc65b8aad3ca1fe231db39e
++	 fbf71c10787fa1cd4fbde0a1ef6805fa4978705c809959f48917bb7c5b5b6d61
++	 4b828c263283241ad1c99f30e0b5d8554b6dac2737d09cfd466b4c15b0d7296a"
+ 	;;
+ esac
+ 


### PR DESCRIPTION
Continuation of #3101. @Gottox currently seems to be very busy,
so I offered to get this working in #xbps earlier. Currently
building x86_64 -> aarch64, which doesn't work as of now, but early progresses somewhat further than before. However,
there's still stuff to be done:

- [x] Test if other arches actually build
- [ ] Test if the cross built binaries actually work
- [x] Adjust #2837 to work if cross (should be easy enough)