### PR TITLE
glibc: update upstream patches

### DIFF
--- a/srcpkgs/glibc/patches/glibc-upstream-13.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-13.patch
@@ -50,3 +50,4 @@ index cf0213ece5..85239cedbf 100644
        new_argv[0] = (char *) _PATH_BSHELL;
        new_argv[1] = (char *) args->file;
        if (argc > 1)
+

--- a/srcpkgs/glibc/patches/glibc-upstream-14.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-14.patch
@@ -1,0 +1,60 @@
+From e7d22db29cfdd2f1fb97a70a76fa53d151569945 Mon Sep 17 00:00:00 2001
+From: Mingli Yu <Mingli.Yu@windriver.com>
+Date: Thu, 20 Sep 2018 12:41:13 +0200
+Subject: [PATCH 14] Linux gethostid: Check for NULL value from
+ gethostbyname_r [BZ #23679]
+
+A NULL value can happen with certain gethostbyname_r failures.
+
+(cherry picked from commit 1214ba06e6771acb953a190091b0f6055c64fd25)
+---
+ ChangeLog                           | 5 +++++
+ NEWS                                | 1 +
+ sysdeps/unix/sysv/linux/gethostid.c | 4 ++--
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index d9e7e6f1d8..fc1ea1e418 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,8 @@
++2018-09-20  Mingli Yu  <Mingli.Yu@windriver.com>
++
++	* sysdeps/unix/sysv/linux/gethostid.c (gethostid): Check for NULL
++	value from gethostbyname_r.
++
+ 2018-09-06  Stefan Liebler  <stli@linux.ibm.com>
+ 
+ 	* sysdeps/unix/sysv/linux/spawni.c (maybe_script_execute):
+diff --git a/NEWS b/NEWS
+index 2855ffde58..502e0c19f5 100644
+--- a/NEWS
++++ b/NEWS
+@@ -13,6 +13,7 @@ The following bugs are resolved with this release:
+   [23521] nss_files aliases database file stream leak
+   [23538] pthread_cond_broadcast: Fix waiters-after-spinning case
+   [23578] regex: Fix memory overread in re_compile_pattern
++  [23679] gethostid: Missing NULL check for gethostbyname_r result
+ 
+ 
+ Version 2.28
+diff --git a/sysdeps/unix/sysv/linux/gethostid.c b/sysdeps/unix/sysv/linux/gethostid.c
+index 2e20f034dc..ee0190e7f9 100644
+--- a/sysdeps/unix/sysv/linux/gethostid.c
++++ b/sysdeps/unix/sysv/linux/gethostid.c
+@@ -102,12 +102,12 @@ gethostid (void)
+     {
+       int ret = __gethostbyname_r (hostname, &hostbuf,
+ 				   tmpbuf.data, tmpbuf.length, &hp, &herr);
+-      if (ret == 0)
++      if (ret == 0 && hp != NULL)
+ 	break;
+       else
+ 	{
+ 	  /* Enlarge the buffer on ERANGE.  */
+-	  if (herr == NETDB_INTERNAL && errno == ERANGE)
++	  if (ret != 0 && herr == NETDB_INTERNAL && errno == ERANGE)
+ 	    {
+ 	      if (!scratch_buffer_grow (&tmpbuf))
+ 		return 0;
+

--- a/srcpkgs/glibc/patches/glibc-upstream-15.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-15.patch
@@ -1,0 +1,166 @@
+From 307d04334d516bb180f484a2b283f97310bfee66 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 20 Sep 2018 12:03:01 +0200
+Subject: [PATCH 15] misc: New test misc/tst-gethostid
+
+The empty /etc/hosts file used to trigger bug 23679.
+
+(cherry picked from commit db9a8ad4ff3fc58e3773a9a4d0cabe3c1bc9c94c)
+---
+ ChangeLog            |   6 +++
+ misc/Makefile        |   7 +++
+ misc/tst-gethostid.c | 108 +++++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 121 insertions(+)
+ create mode 100644 misc/tst-gethostid.c
+
+diff --git a/ChangeLog b/ChangeLog
+index fc1ea1e418..b380048e1e 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,9 @@
++2018-09-20  Florian Weimer  <fweimer@redhat.com>
++
++	* misc/tst-gethostid.c: New file.
++	* misc/Makefile [$(build-shared)] (tests): Add tst-gethostid.
++	(tst-gethostid): Link with -ldl.
++
+ 2018-09-20  Mingli Yu  <Mingli.Yu@windriver.com>
+ 
+ 	* sysdeps/unix/sysv/linux/gethostid.c (gethostid): Check for NULL
+diff --git a/misc/Makefile b/misc/Makefile
+index b7be2bc19a..c9f81515ac 100644
+--- a/misc/Makefile
++++ b/misc/Makefile
+@@ -86,6 +86,11 @@ tests := tst-dirname tst-tsearch tst-fdset tst-efgcvt tst-mntent tst-hsearch \
+ 	 tst-preadvwritev tst-preadvwritev64 tst-makedev tst-empty \
+ 	 tst-preadvwritev2 tst-preadvwritev64v2
+ 
++# Tests which need libdl.
++ifeq (yes,$(build-shared))
++tests += tst-gethostid
++endif
++
+ tests-internal := tst-atomic tst-atomic-long tst-allocate_once
+ tests-static := tst-empty
+ 
+@@ -145,3 +150,5 @@ tst-allocate_once-ENV = MALLOC_TRACE=$(objpfx)tst-allocate_once.mtrace
+ $(objpfx)tst-allocate_once-mem.out: $(objpfx)tst-allocate_once.out
+ 	$(common-objpfx)malloc/mtrace $(objpfx)tst-allocate_once.mtrace > $@; \
+ 	$(evaluate-test)
++
++$(objpfx)tst-gethostid: $(libdl)
+diff --git a/misc/tst-gethostid.c b/misc/tst-gethostid.c
+new file mode 100644
+index 0000000000..1490aaf3f5
+--- /dev/null
++++ b/misc/tst-gethostid.c
+@@ -0,0 +1,108 @@
++/* Basic test for gethostid.
++   Copyright (C) 2018 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++#include <gnu/lib-names.h>
++#include <nss.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <support/namespace.h>
++#include <support/support.h>
++#include <support/temp_file.h>
++#include <support/xdlfcn.h>
++#include <support/xstdio.h>
++#include <support/xunistd.h>
++#include <unistd.h>
++
++/* Initial test is run outside a chroot, to increase the likelihood of
++   success.  */
++static void
++outside_chroot (void *closure)
++{
++  long id = gethostid ();
++  printf ("info: host ID outside chroot: 0x%lx\n", id);
++}
++
++/* The same, but this time perform a chroot operation.  */
++static void
++in_chroot (void *closure)
++{
++  const char *chroot_path = closure;
++  xchroot (chroot_path);
++  long id = gethostid ();
++  printf ("info: host ID in chroot: 0x%lx\n", id);
++}
++
++static int
++do_test (void)
++{
++  support_isolate_in_subprocess (outside_chroot, NULL);
++
++  /* Now run the test inside a chroot.  */
++  support_become_root ();
++  if (!support_can_chroot ())
++    /* Cannot perform further tests.  */
++    return 0;
++
++  /* Only use nss_files.  */
++  __nss_configure_lookup ("hosts", "files");
++
++  /* Load the DSO outside of the chroot.  */
++  xdlopen (LIBNSS_FILES_SO, RTLD_LAZY);
++
++  char *chroot_dir = support_create_temp_directory ("tst-gethostid-");
++  support_isolate_in_subprocess (in_chroot, chroot_dir);
++
++  /* Tests with /etc/hosts in the chroot.  */
++  {
++    char *path = xasprintf ("%s/etc", chroot_dir);
++    add_temp_file (path);
++    xmkdir (path, 0777);
++    free (path);
++    path = xasprintf ("%s/etc/hosts", chroot_dir);
++    add_temp_file (path);
++
++    FILE *fp = xfopen (path, "w");
++    xfclose (fp);
++    printf ("info: chroot test with an empty /etc/hosts file\n");
++    support_isolate_in_subprocess (in_chroot, chroot_dir);
++
++    char hostname[1024];
++    int ret = gethostname (hostname, sizeof (hostname));
++    if (ret < 0)
++      printf ("warning: invalid result from gethostname: %d\n", ret);
++    else if (strlen (hostname) == 0)
++      puts ("warning: gethostname returned empty string");
++    else
++      {
++        printf ("info: chroot test with IPv6 address in /etc/hosts for: %s\n",
++                hostname);
++        fp = xfopen (path, "w");
++        /* Use an IPv6 address to induce another lookup failure.  */
++        fprintf (fp, "2001:db8::1 %s\n", hostname);
++        xfclose (fp);
++        support_isolate_in_subprocess (in_chroot, chroot_dir);
++      }
++    free (path);
++  }
++  free (chroot_dir);
++
++  return 0;
++}
++
++#include <support/test-driver.c>
+

--- a/srcpkgs/glibc/patches/glibc-upstream-16.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-16.patch
@@ -1,0 +1,118 @@
+From a55e109709af55e6ed67d3f9536cac5d929c982e Mon Sep 17 00:00:00 2001
+From: Carlos O'Donell <carlos@redhat.com>
+Date: Wed, 5 Sep 2018 01:16:42 -0400
+Subject: [PATCH 16] Fix tst-setcontext9 for optimized small stacks.
+
+If the compiler reduces the stack usage in function f1 before calling
+into function f2, then when we swapcontext back to f1 and continue
+execution we may overwrite registers that were spilled to the stack
+while f2 was executing.  Later when we return to f2 the corrupt
+registers will be reloaded from the stack and the test will crash.  This
+was most commonly observed on i686 with __x86.get_pc_thunk.dx and
+needing to save and restore $edx.  Overall i686 has few registers and
+the spilling to the stack is bound to happen, therefore the solution to
+making this test robust is to split function f1 into two parts f1a and
+f1b, and allocate f1b it's own stack such that subsequent execution does
+not overwrite the stack in use by function f2.
+
+Tested on i686 and x86_64.
+
+Signed-off-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 791b350dc725545e3f9b5db0f97ebdbc60c9735f)
+---
+ ChangeLog                |  6 +++++
+ stdlib/tst-setcontext9.c | 47 ++++++++++++++++++++++++++++++++--------
+ 2 files changed, 44 insertions(+), 9 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index b380048e1e..bda963483f 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,9 @@
++2018-09-19  Carlos O'Donell  <carlos@redhat.com>
++
++	* stdlib/tst-setcontext9.c (f1): Rename to...
++	(f1a): ... this.
++	(f1b): New function implementing lower half of f1 in alternate stack.
++
+ 2018-09-20  Florian Weimer  <fweimer@redhat.com>
+ 
+ 	* misc/tst-gethostid.c: New file.
+diff --git a/stdlib/tst-setcontext9.c b/stdlib/tst-setcontext9.c
+index 4636ce9030..db8355766c 100644
+--- a/stdlib/tst-setcontext9.c
++++ b/stdlib/tst-setcontext9.c
+@@ -41,26 +41,55 @@ f2 (void)
+ }
+ 
+ static void
+-f1 (void)
++f1b (void)
+ {
+-  puts ("start f1");
+-  if (getcontext (&ctx[2]) != 0)
+-    {
+-      printf ("%s: getcontext: %m\n", __FUNCTION__);
+-      exit (EXIT_FAILURE);
+-    }
+   if (done)
+     {
+-      puts ("set context in f1");
++      puts ("set context in f1b");
+       if (setcontext (&ctx[3]) != 0)
+ 	{
+ 	  printf ("%s: setcontext: %m\n", __FUNCTION__);
+ 	  exit (EXIT_FAILURE);
+ 	}
+     }
++  exit (EXIT_FAILURE);
++}
++
++static void
++f1a (void)
++{
++  char st2[32768];
++  puts ("start f1a");
++  if (getcontext (&ctx[2]) != 0)
++    {
++      printf ("%s: getcontext: %m\n", __FUNCTION__);
++      exit (EXIT_FAILURE);
++    }
++  ctx[2].uc_stack.ss_sp = st2;
++  ctx[2].uc_stack.ss_size = sizeof st2;
++  ctx[2].uc_link = &ctx[0];
++  makecontext (&ctx[2], (void (*) (void)) f1b, 0);
+   f2 ();
+ }
+ 
++/* The execution path through the test looks like this:
++   do_test (call)
++   -> "making contexts"
++   -> "swap contexts"
++   f1a (via swapcontext to ctx[1], with alternate stack)
++   -> "start f1a"
++   f2 (call)
++   -> "swap contexts in f2"
++   f1b (via swapcontext to ctx[2], with alternate stack)
++   -> "set context in f1b"
++   do_test (via setcontext to ctx[3], main stack)
++   -> "setcontext"
++   f2 (via setcontext to ctx[4], with alternate stack)
++   -> "end f2"
++
++   We must use an alternate stack for f1b, because if we don't then the
++   result of executing an earlier caller may overwrite registers
++   spilled to the stack in f2.  */
+ static int
+ do_test (void)
+ {
+@@ -79,7 +108,7 @@ do_test (void)
+   ctx[1].uc_stack.ss_sp = st1;
+   ctx[1].uc_stack.ss_size = sizeof st1;
+   ctx[1].uc_link = &ctx[0];
+-  makecontext (&ctx[1], (void (*) (void)) f1, 0);
++  makecontext (&ctx[1], (void (*) (void)) f1a, 0);
+   puts ("swap contexts");
+   if (swapcontext (&ctx[3], &ctx[1]) != 0)
+     {
+

--- a/srcpkgs/glibc/patches/glibc-upstream-17.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-17.patch
@@ -1,0 +1,130 @@
+From 0ef2f4400c06927af34c515555f68840a70ba409 Mon Sep 17 00:00:00 2001
+From: Wilco Dijkstra <wdijkstr@arm.com>
+Date: Wed, 19 Sep 2018 16:50:18 +0100
+Subject: [PATCH 17] Fix strstr bug with huge needles (bug 23637)
+
+The generic strstr in GLIBC 2.28 fails to match huge needles.  The optimized
+AVAILABLE macro reads ahead a large fixed amount to reduce the overhead of
+repeatedly checking for the end of the string.  However if the needle length
+is larger than this, two_way_long_needle may confuse this as meaning the end
+of the string and return NULL.  This is fixed by adding the needle length to
+the amount to read ahead.
+
+	[BZ #23637]
+	* string/test-strstr.c (pr23637): New function.
+	(test_main): Add tests with longer needles.
+	* string/strcasestr.c (AVAILABLE): Fix readahead distance.
+	* string/strstr.c (AVAILABLE): Likewise.
+
+    (cherry picked from commit 83a552b0bb9fc2a5e80a0ab3723c0a80ce1db9f2)
+---
+ ChangeLog            |  8 ++++++++
+ string/strcasestr.c  |  5 +++--
+ string/strstr.c      |  5 +++--
+ string/test-strstr.c | 30 ++++++++++++++++++++++++++++++
+ 4 files changed, 44 insertions(+), 4 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index bda963483f..a111f0131b 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,11 @@
++2018-09-19  Wilco Dijkstra  <wdijkstr@arm.com>
++
++	[BZ #23637]
++	* string/test-strstr.c (pr23637): New function.
++	(test_main): Add tests with longer needles.
++	* string/strcasestr.c (AVAILABLE): Fix readahead distance.
++	* string/strstr.c (AVAILABLE): Likewise.
++
+ 2018-09-19  Carlos O'Donell  <carlos@redhat.com>
+ 
+ 	* stdlib/tst-setcontext9.c (f1): Rename to...
+diff --git a/string/strcasestr.c b/string/strcasestr.c
+index 5909fe3cdb..421764bd1b 100644
+--- a/string/strcasestr.c
++++ b/string/strcasestr.c
+@@ -37,8 +37,9 @@
+ /* Two-Way algorithm.  */
+ #define RETURN_TYPE char *
+ #define AVAILABLE(h, h_l, j, n_l)			\
+-  (((j) + (n_l) <= (h_l)) || ((h_l) += __strnlen ((void*)((h) + (h_l)), 512), \
+-			      (j) + (n_l) <= (h_l)))
++  (((j) + (n_l) <= (h_l)) \
++   || ((h_l) += __strnlen ((void*)((h) + (h_l)), (n_l) + 512), \
++       (j) + (n_l) <= (h_l)))
+ #define CHECK_EOL (1)
+ #define RET0_IF_0(a) if (!a) goto ret0
+ #define CANON_ELEMENT(c) TOLOWER (c)
+diff --git a/string/strstr.c b/string/strstr.c
+index 265e9f310c..79ebcc7532 100644
+--- a/string/strstr.c
++++ b/string/strstr.c
+@@ -33,8 +33,9 @@
+ 
+ #define RETURN_TYPE char *
+ #define AVAILABLE(h, h_l, j, n_l)			\
+-  (((j) + (n_l) <= (h_l)) || ((h_l) += __strnlen ((void*)((h) + (h_l)), 512), \
+-			      (j) + (n_l) <= (h_l)))
++  (((j) + (n_l) <= (h_l)) \
++   || ((h_l) += __strnlen ((void*)((h) + (h_l)), (n_l) + 512), \
++       (j) + (n_l) <= (h_l)))
+ #define CHECK_EOL (1)
+ #define RET0_IF_0(a) if (!a) goto ret0
+ #define FASTSEARCH(S,C,N) (void*) strchr ((void*)(S), (C))
+diff --git a/string/test-strstr.c b/string/test-strstr.c
+index 8d99716ff3..5861b01b73 100644
+--- a/string/test-strstr.c
++++ b/string/test-strstr.c
+@@ -151,6 +151,32 @@ check2 (void)
+     }
+ }
+ 
++#define N 1024
++
++static void
++pr23637 (void)
++{
++  char *h = (char*) buf1;
++  char *n = (char*) buf2;
++
++  for (int i = 0; i < N; i++)
++    {
++      n[i] = 'x';
++      h[i] = ' ';
++      h[i + N] = 'x';
++    }
++
++  n[N] = '\0';
++  h[N * 2] = '\0';
++
++  /* Ensure we don't match at the first 'x'.  */
++  h[0] = 'x';
++
++  char *exp_result = stupid_strstr (h, n);
++  FOR_EACH_IMPL (impl, 0)
++    check_result (impl, h, n, exp_result);
++}
++
+ static int
+ test_main (void)
+ {
+@@ -158,6 +184,7 @@ test_main (void)
+ 
+   check1 ();
+   check2 ();
++  pr23637 ();
+ 
+   printf ("%23s", "");
+   FOR_EACH_IMPL (impl, 0)
+@@ -202,6 +229,9 @@ test_main (void)
+ 	do_test (15, 9, hlen, klen, 1);
+ 	do_test (15, 15, hlen, klen, 0);
+ 	do_test (15, 15, hlen, klen, 1);
++
++	do_test (15, 15, hlen + klen * 4, klen * 4, 0);
++	do_test (15, 15, hlen + klen * 4, klen * 4, 1);
+       }
+ 
+   do_test (0, 0, page_size - 1, 16, 0);
+

--- a/srcpkgs/glibc/patches/glibc-upstream-18.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-18.patch
@@ -1,0 +1,115 @@
+From 2339d6a55eb7a7e040ae888e906adc49eeb59eab Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Wed, 12 Sep 2018 08:40:59 -0700
+Subject: [PATCH 18] i386: Use ENTRY and END in start.S [BZ #23606]
+
+Wrapping the _start function with ENTRY and END to insert ENDBR32 at
+function entry when CET is enabled.  Since _start now includes CFI,
+without "cfi_undefined (eip)", unwinder may not terminate at _start
+and we will get
+
+Program received signal SIGSEGV, Segmentation fault.
+0xf7dc661e in ?? () from /lib/libgcc_s.so.1
+Missing separate debuginfos, use: dnf debuginfo-install libgcc-8.2.1-3.0.fc28.i686
+(gdb) bt
+ #0  0xf7dc661e in ?? () from /lib/libgcc_s.so.1
+ #1  0xf7dc7c18 in _Unwind_Backtrace () from /lib/libgcc_s.so.1
+ #2  0xf7f0d809 in __GI___backtrace (array=array@entry=0xffffc7d0,
+    size=size@entry=20) at ../sysdeps/i386/backtrace.c:127
+ #3  0x08049254 in compare (p1=p1@entry=0xffffcad0, p2=p2@entry=0xffffcad4)
+    at backtrace-tst.c:12
+ #4  0xf7e2a28c in msort_with_tmp (p=p@entry=0xffffca5c, b=b@entry=0xffffcad0,
+    n=n@entry=2) at msort.c:65
+ #5  0xf7e29f64 in msort_with_tmp (n=2, b=0xffffcad0, p=0xffffca5c)
+    at msort.c:53
+ #6  msort_with_tmp (p=p@entry=0xffffca5c, b=b@entry=0xffffcad0, n=n@entry=5)
+    at msort.c:53
+ #7  0xf7e29f64 in msort_with_tmp (n=5, b=0xffffcad0, p=0xffffca5c)
+    at msort.c:53
+ #8  msort_with_tmp (p=p@entry=0xffffca5c, b=b@entry=0xffffcad0, n=n@entry=10)
+    at msort.c:53
+ #9  0xf7e29f64 in msort_with_tmp (n=10, b=0xffffcad0, p=0xffffca5c)
+    at msort.c:53
+ #10 msort_with_tmp (p=p@entry=0xffffca5c, b=b@entry=0xffffcad0, n=n@entry=20)
+    at msort.c:53
+ #11 0xf7e2a5b6 in msort_with_tmp (n=20, b=0xffffcad0, p=0xffffca5c)
+    at msort.c:297
+ #12 __GI___qsort_r (b=b@entry=0xffffcad0, n=n@entry=20, s=s@entry=4,
+    cmp=cmp@entry=0x8049230 <compare>, arg=arg@entry=0x0) at msort.c:297
+ #13 0xf7e2a84d in __GI_qsort (b=b@entry=0xffffcad0, n=n@entry=20, s=s@entry=4,
+    cmp=cmp@entry=0x8049230 <compare>) at msort.c:308
+ #14 0x080490f6 in main (argc=2, argv=0xffffcbd4) at backtrace-tst.c:39
+
+FAIL: debug/backtrace-tst
+
+	[BZ #23606]
+	* sysdeps/i386/start.S: Include <sysdep.h>
+	(_start): Use ENTRY/END to insert ENDBR32 at entry when CET is
+	enabled.  Add cfi_undefined (eip).
+
+Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+
+(cherry picked from commit 5a274db4ea363d6b0b92933f085a92daaf1be2f2)
+---
+ ChangeLog            |  8 ++++++++
+ NEWS                 |  1 +
+ sysdeps/i386/start.S | 10 ++++++----
+ 3 files changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index a111f0131b..84503e3a0c 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,11 @@
++2018-09-21  H.J. Lu  <hongjiu.lu@intel.com>
++	    Xuepeng Guo  <xuepeng.guo@intel.com>
++
++	[BZ #23606]
++	* sysdeps/i386/start.S: Include <sysdep.h>
++	(_start): Use ENTRY/END to insert ENDBR32 at entry when CET is
++	enabled.  Add cfi_undefined (eip).
++
+ 2018-09-19  Wilco Dijkstra  <wdijkstr@arm.com>
+ 
+ 	[BZ #23637]
+diff --git a/NEWS b/NEWS
+index 502e0c19f5..d1f1dd4b22 100644
+--- a/NEWS
++++ b/NEWS
+@@ -13,6 +13,7 @@ The following bugs are resolved with this release:
+   [23521] nss_files aliases database file stream leak
+   [23538] pthread_cond_broadcast: Fix waiters-after-spinning case
+   [23578] regex: Fix memory overread in re_compile_pattern
++  [23606] Missing ENDBR32 in sysdeps/i386/start.S
+   [23679] gethostid: Missing NULL check for gethostbyname_r result
+ 
+ 
+diff --git a/sysdeps/i386/start.S b/sysdeps/i386/start.S
+index 91035fa83f..e35e9bd31b 100644
+--- a/sysdeps/i386/start.S
++++ b/sysdeps/i386/start.S
+@@ -52,10 +52,11 @@
+ 					NULL
+ */
+ 
+-	.text
+-	.globl _start
+-	.type _start,@function
+-_start:
++#include <sysdep.h>
++
++ENTRY (_start)
++	/* Clearing frame pointer is insufficient, use CFI.  */
++	cfi_undefined (eip)
+ 	/* Clear the frame pointer.  The ABI suggests this be done, to mark
+ 	   the outermost frame obviously.  */
+ 	xorl %ebp, %ebp
+@@ -131,6 +132,7 @@ _start:
+ 1:	movl	(%esp), %ebx
+ 	ret
+ #endif
++END (_start)
+ 
+ /* To fulfill the System V/i386 ABI we need this symbol.  Yuck, it's so
+    meaningless since we don't support machines < 80386.  */
+

--- a/srcpkgs/glibc/patches/glibc-upstream-19.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-19.patch
@@ -1,0 +1,65 @@
+From 3a67c72c1512f778304a5644dea2fcf5bdece274 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Thu, 27 Sep 2018 12:37:06 +0200
+Subject: [PATCH 19] Fix stack overflow in tst-setcontext9 (bug 23717)
+
+The function f1a, executed on a stack of size 32k, allocates an object of
+size 32k on the stack.  Make the stack variables static to reduce
+excessive stack usage.
+
+(cherry picked from commit f841c97e515a1673485a2b12b3c280073d737890)
+---
+ ChangeLog                | 6 ++++++
+ NEWS                     | 1 +
+ stdlib/tst-setcontext9.c | 4 ++--
+ 3 files changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 84503e3a0c..4fbb9e2ad8 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,9 @@
++2018-09-27  Andreas Schwab  <schwab@suse.de>
++
++	[BZ #23717]
++	* stdlib/tst-setcontext9.c (f1a): Make st2 static.
++	(do_test): Make st1 static.
++
+ 2018-09-21  H.J. Lu  <hongjiu.lu@intel.com>
+ 	    Xuepeng Guo  <xuepeng.guo@intel.com>
+ 
+diff --git a/NEWS b/NEWS
+index d1f1dd4b22..bc568bcec0 100644
+--- a/NEWS
++++ b/NEWS
+@@ -15,6 +15,7 @@ The following bugs are resolved with this release:
+   [23578] regex: Fix memory overread in re_compile_pattern
+   [23606] Missing ENDBR32 in sysdeps/i386/start.S
+   [23679] gethostid: Missing NULL check for gethostbyname_r result
++  [23717] Fix stack overflow in stdlib/tst-setcontext9
+ 
+ 
+ Version 2.28
+diff --git a/stdlib/tst-setcontext9.c b/stdlib/tst-setcontext9.c
+index db8355766c..009928235d 100644
+--- a/stdlib/tst-setcontext9.c
++++ b/stdlib/tst-setcontext9.c
+@@ -58,7 +58,7 @@ f1b (void)
+ static void
+ f1a (void)
+ {
+-  char st2[32768];
++  static char st2[32768];
+   puts ("start f1a");
+   if (getcontext (&ctx[2]) != 0)
+     {
+@@ -93,7 +93,7 @@ f1a (void)
+ static int
+ do_test (void)
+ {
+-  char st1[32768];
++  static char st1[32768];
+   puts ("making contexts");
+   if (getcontext (&ctx[0]) != 0)
+     {
+

--- a/srcpkgs/glibc/patches/glibc-upstream-20.patch
+++ b/srcpkgs/glibc/patches/glibc-upstream-20.patch
@@ -1,0 +1,239 @@
+From 044c96f0d5595aeb0bb4e79355081c5a7f4faca5 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Wed, 29 Aug 2018 16:36:44 -0300
+Subject: [PATCH 20] Fix misreported errno on preadv2/pwritev2 (BZ#23579)
+
+The fallback code of Linux wrapper for preadv2/pwritev2 executes
+regardless of the errno code for preadv2, instead of the case where
+the syscall is not supported.
+
+This fixes it by calling the fallback code iff errno is ENOSYS. The
+patch also adds tests for both invalid file descriptor and invalid
+iov_len and vector count.
+
+The only discrepancy between preadv2 and fallback code regarding
+error reporting is when an invalid flags are used.  The fallback code
+bails out earlier with ENOTSUP instead of EINVAL/EBADF when the syscall
+is used.
+
+Checked on x86_64-linux-gnu on a 4.4.0 and 4.15.0 kernel.
+
+	[BZ #23579]
+	* misc/tst-preadvwritev2-common.c (do_test_with_invalid_fd): New
+	test.
+	* misc/tst-preadvwritev2.c, misc/tst-preadvwritev64v2.c (do_test):
+	Call do_test_with_invalid_fd.
+	* sysdeps/unix/sysv/linux/preadv2.c (preadv2): Use fallback code iff
+	errno is ENOSYS.
+	* sysdeps/unix/sysv/linux/preadv64v2.c (preadv64v2): Likewise.
+	* sysdeps/unix/sysv/linux/pwritev2.c (pwritev2): Likewise.
+	* sysdeps/unix/sysv/linux/pwritev64v2.c (pwritev64v2): Likewise.
+
+(cherry picked from commit 7a16bdbb9ff4122af0a28dc20996c95352011fdd)
+---
+ ChangeLog                             | 14 ++++++
+ NEWS                                  |  1 +
+ misc/tst-preadvwritev2-common.c       | 65 +++++++++++++++++++++++++--
+ misc/tst-preadvwritev2.c              |  2 +
+ misc/tst-preadvwritev64v2.c           |  2 +
+ sysdeps/unix/sysv/linux/preadv2.c     |  2 +-
+ sysdeps/unix/sysv/linux/preadv64v2.c  |  2 +-
+ sysdeps/unix/sysv/linux/pwritev2.c    |  2 +-
+ sysdeps/unix/sysv/linux/pwritev64v2.c |  2 +-
+ 9 files changed, 85 insertions(+), 7 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 4fbb9e2ad8..11a9b8d98e 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,17 @@
++2018-09-28  Adhemerval Zanella  <adhemerval.zanella@linaro.org>
++
++	[BZ #23579]
++	* misc/tst-preadvwritev2-common.c (do_test_with_invalid_fd,
++	do_test_with_invalid_iov): New tests.
++	* misc/tst-preadvwritev2.c, misc/tst-preadvwritev64v2.c (do_test):
++	Call do_test_with_invalid_fd and do_test_with_invalid_iov.
++	* sysdeps/unix/sysv/linux/preadv2.c (preadv2): Use fallback code iff
++	errno is ENOSYS.
++	* sysdeps/unix/sysv/linux/preadv64v2.c (preadv64v2): Likewise.
++	* sysdeps/unix/sysv/linux/pwritev2.c (pwritev2): Likewise.
++	* sysdeps/unix/sysv/linux/pwritev64v2.c (pwritev64v2): Likewise.
++	* NEWS: Add bug fixed.
++
+ 2018-09-27  Andreas Schwab  <schwab@suse.de>
+ 
+ 	[BZ #23717]
+diff --git a/NEWS b/NEWS
+index bc568bcec0..fd14941128 100644
+--- a/NEWS
++++ b/NEWS
+@@ -13,6 +13,7 @@ The following bugs are resolved with this release:
+   [23521] nss_files aliases database file stream leak
+   [23538] pthread_cond_broadcast: Fix waiters-after-spinning case
+   [23578] regex: Fix memory overread in re_compile_pattern
++  [23579] libc: Errors misreported in preadv2
+   [23606] Missing ENDBR32 in sysdeps/i386/start.S
+   [23679] gethostid: Missing NULL check for gethostbyname_r result
+   [23717] Fix stack overflow in stdlib/tst-setcontext9
+diff --git a/misc/tst-preadvwritev2-common.c b/misc/tst-preadvwritev2-common.c
+index f889a21544..50b9da3fea 100644
+--- a/misc/tst-preadvwritev2-common.c
++++ b/misc/tst-preadvwritev2-common.c
+@@ -19,9 +19,6 @@
+ #include <limits.h>
+ #include <support/check.h>
+ 
+-static void
+-do_test_with_invalid_flags (void)
+-{
+ #ifndef RWF_HIPRI
+ # define RWF_HIPRI 0
+ #endif
+@@ -39,6 +36,68 @@ do_test_with_invalid_flags (void)
+ #endif
+ #define RWF_SUPPORTED	(RWF_HIPRI | RWF_DSYNC | RWF_SYNC | RWF_NOWAIT \
+ 			 | RWF_APPEND)
++
++static void
++do_test_with_invalid_fd (void)
++{
++  char buf[256];
++  struct iovec iov = { buf, sizeof buf };
++
++  /* Check with flag being 0 to use the fallback code which calls pwritev
++     or writev.  */
++  TEST_VERIFY (preadv2 (-1, &iov, 1, -1, 0) == -1);
++  TEST_COMPARE (errno, EBADF);
++  TEST_VERIFY (pwritev2 (-1, &iov, 1, -1, 0) == -1);
++  TEST_COMPARE (errno, EBADF);
++
++  /* Same tests as before but with flags being different than 0.  Since
++     there is no emulation for any flag value, fallback code returns
++     ENOTSUP.  This is different running on a kernel with preadv2/pwritev2
++     support, where EBADF is returned).  */
++  TEST_VERIFY (preadv2 (-1, &iov, 1, 0, RWF_HIPRI) == -1);
++  TEST_VERIFY (errno == EBADF || errno == ENOTSUP);
++  TEST_VERIFY (pwritev2 (-1, &iov, 1, 0, RWF_HIPRI) == -1);
++  TEST_VERIFY (errno == EBADF || errno == ENOTSUP);
++}
++
++static void
++do_test_with_invalid_iov (void)
++{
++  {
++    char buf[256];
++    struct iovec iov;
++
++    iov.iov_base = buf;
++    iov.iov_len = (size_t)SSIZE_MAX + 1;
++
++    TEST_VERIFY (preadv2 (temp_fd, &iov, 1, 0, 0) == -1);
++    TEST_COMPARE (errno, EINVAL);
++    TEST_VERIFY (pwritev2 (temp_fd, &iov, 1, 0, 0) == -1);
++    TEST_COMPARE (errno, EINVAL);
++
++    /* Same as for invalid file descriptor tests, emulation fallback
++       first checks for flag value and return ENOTSUP.  */
++    TEST_VERIFY (preadv2 (temp_fd, &iov, 1, 0, RWF_HIPRI) == -1);
++    TEST_VERIFY (errno == EINVAL || errno == ENOTSUP);
++    TEST_VERIFY (pwritev2 (temp_fd, &iov, 1, 0, RWF_HIPRI) == -1);
++    TEST_VERIFY (errno == EINVAL || errno == ENOTSUP);
++  }
++
++  {
++    /* An invalid iovec buffer should trigger an invalid memory access
++       or an error (Linux for instance returns EFAULT).  */
++    struct iovec iov[IOV_MAX+1] = { 0 };
++
++    TEST_VERIFY (preadv2 (temp_fd, iov, IOV_MAX + 1, 0, RWF_HIPRI) == -1);
++    TEST_VERIFY (errno == EINVAL || errno == ENOTSUP);
++    TEST_VERIFY (pwritev2 (temp_fd, iov, IOV_MAX + 1, 0, RWF_HIPRI) == -1);
++    TEST_VERIFY (errno == EINVAL || errno == ENOTSUP);
++  }
++}
++
++static void
++do_test_with_invalid_flags (void)
++{
+   /* Set the next bit from the mask of all supported flags.  */
+   int invalid_flag = RWF_SUPPORTED != 0 ? __builtin_clz (RWF_SUPPORTED) : 2;
+   invalid_flag = 0x1 << ((sizeof (int) * CHAR_BIT) - invalid_flag);
+diff --git a/misc/tst-preadvwritev2.c b/misc/tst-preadvwritev2.c
+index be22802dbe..cb58cbe41e 100644
+--- a/misc/tst-preadvwritev2.c
++++ b/misc/tst-preadvwritev2.c
+@@ -30,6 +30,8 @@ do_test (void)
+ {
+   do_test_with_invalid_flags ();
+   do_test_without_offset ();
++  do_test_with_invalid_fd ();
++  do_test_with_invalid_iov ();
+ 
+   return do_test_with_offset (0);
+ }
+diff --git a/misc/tst-preadvwritev64v2.c b/misc/tst-preadvwritev64v2.c
+index 8d3cc32b28..6a9de54c78 100644
+--- a/misc/tst-preadvwritev64v2.c
++++ b/misc/tst-preadvwritev64v2.c
+@@ -32,6 +32,8 @@ do_test (void)
+ {
+   do_test_with_invalid_flags ();
+   do_test_without_offset ();
++  do_test_with_invalid_fd ();
++  do_test_with_invalid_iov ();
+ 
+   return do_test_with_offset (0);
+ }
+diff --git a/sysdeps/unix/sysv/linux/preadv2.c b/sysdeps/unix/sysv/linux/preadv2.c
+index c8bf0764ef..bb08cbc5fd 100644
+--- a/sysdeps/unix/sysv/linux/preadv2.c
++++ b/sysdeps/unix/sysv/linux/preadv2.c
+@@ -32,7 +32,7 @@ preadv2 (int fd, const struct iovec *vector, int count, off_t offset,
+ # ifdef __NR_preadv2
+   ssize_t result = SYSCALL_CANCEL (preadv2, fd, vector, count,
+ 				   LO_HI_LONG (offset), flags);
+-  if (result >= 0)
++  if (result >= 0 || errno != ENOSYS)
+     return result;
+ # endif
+   /* Trying to emulate the preadv2 syscall flags is troublesome:
+diff --git a/sysdeps/unix/sysv/linux/preadv64v2.c b/sysdeps/unix/sysv/linux/preadv64v2.c
+index d7400a0252..b72a047347 100644
+--- a/sysdeps/unix/sysv/linux/preadv64v2.c
++++ b/sysdeps/unix/sysv/linux/preadv64v2.c
+@@ -30,7 +30,7 @@ preadv64v2 (int fd, const struct iovec *vector, int count, off64_t offset,
+ #ifdef __NR_preadv64v2
+   ssize_t result = SYSCALL_CANCEL (preadv64v2, fd, vector, count,
+ 				   LO_HI_LONG (offset), flags);
+-  if (result >= 0)
++  if (result >= 0 || errno != ENOSYS)
+     return result;
+ #endif
+   /* Trying to emulate the preadv2 syscall flags is troublesome:
+diff --git a/sysdeps/unix/sysv/linux/pwritev2.c b/sysdeps/unix/sysv/linux/pwritev2.c
+index 29c2264c8f..26333ebd43 100644
+--- a/sysdeps/unix/sysv/linux/pwritev2.c
++++ b/sysdeps/unix/sysv/linux/pwritev2.c
+@@ -28,7 +28,7 @@ pwritev2 (int fd, const struct iovec *vector, int count, off_t offset,
+ # ifdef __NR_pwritev2
+   ssize_t result = SYSCALL_CANCEL (pwritev2, fd, vector, count,
+ 				   LO_HI_LONG (offset), flags);
+-  if (result >= 0)
++  if (result >= 0 || errno != ENOSYS)
+     return result;
+ # endif
+   /* Trying to emulate the pwritev2 syscall flags is troublesome:
+diff --git a/sysdeps/unix/sysv/linux/pwritev64v2.c b/sysdeps/unix/sysv/linux/pwritev64v2.c
+index 42da321149..17ea905aa6 100644
+--- a/sysdeps/unix/sysv/linux/pwritev64v2.c
++++ b/sysdeps/unix/sysv/linux/pwritev64v2.c
+@@ -30,7 +30,7 @@ pwritev64v2 (int fd, const struct iovec *vector, int count, off64_t offset,
+ #ifdef __NR_pwritev64v2
+   ssize_t result = SYSCALL_CANCEL (pwritev64v2, fd, vector, count,
+ 				   LO_HI_LONG (offset), flags);
+-  if (result >= 0)
++  if (result >= 0 || errno != ENOSYS)
+     return result;
+ #endif
+   /* Trying to emulate the pwritev2 syscall flags is troublesome:

--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.28
-revision=1
+revision=2
 bootstrap=yes
 short_desc="The GNU C library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
Fixes the gethostid segfault reported in https://forum.voidlinux.org/t/solved-gnucash-dependencies/6926 among others.