### PR TITLE
batman-adv: update to 2018.3.

### DIFF
--- a/srcpkgs/batman-adv/template
+++ b/srcpkgs/batman-adv/template
@@ -1,13 +1,13 @@
-# Template file for 'batman-adv14'
+# Template file for 'batman-adv'
 pkgname=batman-adv
-version=2017.1
+version=2018.3
 revision=1
 short_desc="B.A.T.M.A.N. routing protocol kernel module"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later, MIT"
 homepage="http://www.open-mesh.org/"
 distfiles="http://downloads.open-mesh.org/batman/releases/batman-adv-${version}/batman-adv-${version}.tar.gz"
-checksum=ec1848023308c41710eeefb544580f5853d68b88a627a3f2dabaa3472b988c15
+checksum=33f3f942203732e0568a6bc0226a0fe8eb147c961f0d0c13b2e6b16237d412ff
 
 dkms_modules="batman-adv ${version}"
 depends="dkms"
@@ -16,4 +16,5 @@ do_install() {
 	vmkdir usr/src/${pkgname}-${version}
 	cp -r * $DESTDIR/usr/src/${pkgname}-${version}
 	vcopy ${FILESDIR}/dkms.conf usr/src/${pkgname}-${version}
+	vlicense LICENSES/preferred/MIT
 }


### PR DESCRIPTION
Removed `14` as this comes from package batman-adv14. Copy paste error.