### PR TITLE
qtcurve: drop qt4 support

### DIFF
--- a/srcpkgs/qtcurve/template
+++ b/srcpkgs/qtcurve/template
@@ -1,16 +1,16 @@
 # Template file for 'qtcurve'
 pkgname=qtcurve
 version=1.9.1
-revision=1
+revision=2
 build_style=cmake
-hostmakedepends="pkg-config extra-cmake-modules automoc4 perl qt-qmake"
-makedepends="libxcb-devel libX11-devel qt-devel qt5-devel gtk+-devel
+configure_args="-DENABLE_QT4=OFF"
+hostmakedepends="pkg-config extra-cmake-modules perl qt5-host-tools qt5-qmake"
+makedepends="libxcb-devel libX11-devel qt5-devel gtk+-devel
  phonon-devel qt5-svg-devel qt5-x11extras-devel frameworkintegration-devel
  ki18n-devel kdelibs4support-devel"
-homepage="https://quickgit.kde.org/?p=qtcurve.git"
 short_desc="A configurable set of widget styles for KDE and Gtk"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
-license="LGPL-2.1"
-configure_args="-DQT_QMAKE_EXECUTABLE=/usr/bin/qmake-qt4 -DQTC_QT4_ENABLE_KDE=false"
+license="LGPL-2.1-or-later"
+homepage="https://quickgit.kde.org/?p=qtcurve.git"
 distfiles="https://github.com/KDE/qtcurve/archive/${version}.tar.gz"
 checksum=fbfdafdac90d4c540dd55a4accfecfc3a17c1f532c5241e28003348beafaca15


### PR DESCRIPTION
Do not merge until all qt4 stuff is thrown into the garbage