### PR TITLE
boost: revbump to add boost-build to aarch64[-musl] repodata

### DIFF
--- a/srcpkgs/boost/template
+++ b/srcpkgs/boost/template
@@ -1,7 +1,7 @@
-# Template file for 'boost'.
+# Template file for 'boost'
 pkgname=boost
 version=1.65.1
-revision=3
+revision=4
 wrksrc="${pkgname}_${version//\./_}"
 hostmakedepends="bzip2-devel icu-devel python-devel"
 makedepends="zlib-devel bzip2-devel icu-devel python-devel"


### PR DESCRIPTION
previous change wasn't enough to trigger a rebuild