### PR TITLE
tiff: Apply security patches from debian

### DIFF
--- a/srcpkgs/tiff/patches/CVE-2017-11613_part1.patch
+++ b/srcpkgs/tiff/patches/CVE-2017-11613_part1.patch
@@ -1,0 +1,40 @@
+From 3719385a3fac5cfb20b487619a5f08abbf967cf8 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 11 Mar 2018 11:14:01 +0100
+Subject: [PATCH] ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+
+In ChopUpSingleUncompressedStrip(), if the computed number of strips is big
+enough and we are in read only mode, validate that the file size is consistent
+with that number of strips to avoid useless attempts at allocating a lot of
+memory for the td_stripbytecount and td_stripoffset arrays.
+
+Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+---
+ libtiff/tif_dirread.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 3fc0c8e..1a3259c 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5698,6 +5698,17 @@ ChopUpSingleUncompressedStrip(TIFF* tif)
+         if( nstrips == 0 )
+             return;
+ 
++        /* If we are going to allocate a lot of memory, make sure that the */
++        /* file is as big as needed */
++        if( tif->tif_mode == O_RDONLY &&
++            nstrips > 1000000 &&
++            (tif->tif_dir.td_stripoffset[0] >= TIFFGetFileSize(tif) ||
++             tif->tif_dir.td_stripbytecount[0] >
++                    TIFFGetFileSize(tif) - tif->tif_dir.td_stripoffset[0]) )
++        {
++            return;
++        }
++
+ 	newcounts = (uint64*) _TIFFCheckMalloc(tif, nstrips, sizeof (uint64),
+ 				"for chopped \"StripByteCounts\" array");
+ 	newoffsets = (uint64*) _TIFFCheckMalloc(tif, nstrips, sizeof (uint64),
+--
+libgit2 0.27.0
+

--- a/srcpkgs/tiff/patches/CVE-2017-11613_part2.patch
+++ b/srcpkgs/tiff/patches/CVE-2017-11613_part2.patch
@@ -1,0 +1,33 @@
+From 7a092f8af2568d61993a8cc2e7a35a998d7d37be Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 17 Mar 2018 09:36:29 +0100
+Subject: [PATCH] ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+
+Rework fix done in 3719385a3fac5cfb20b487619a5f08abbf967cf8 to work in more
+cases like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6979.
+Credit to OSS Fuzz
+
+Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+---
+ libtiff/tif_dirread.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 1a3259c..6baa7b3 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -5702,9 +5702,8 @@ ChopUpSingleUncompressedStrip(TIFF* tif)
+         /* file is as big as needed */
+         if( tif->tif_mode == O_RDONLY &&
+             nstrips > 1000000 &&
+-            (tif->tif_dir.td_stripoffset[0] >= TIFFGetFileSize(tif) ||
+-             tif->tif_dir.td_stripbytecount[0] >
+-                    TIFFGetFileSize(tif) - tif->tif_dir.td_stripoffset[0]) )
++            (offset >= TIFFGetFileSize(tif) ||
++             stripbytes > (TIFFGetFileSize(tif) - offset) / (nstrips - 1)) )
+         {
+             return;
+         }
+--
+libgit2 0.27.0
+

--- a/srcpkgs/tiff/patches/CVE-2017-17095.patch
+++ b/srcpkgs/tiff/patches/CVE-2017-17095.patch
@@ -1,0 +1,40 @@
+From 9171da596c88e6a2dadcab4a3a89dddd6e1b4655 Mon Sep 17 00:00:00 2001
+From: Nathan Baker <elitebadger@gmail.com>
+Date: Thu, 25 Jan 2018 21:28:15 +0000
+Subject: [PATCH] Add workaround to pal2rgb buffer overflow.
+
+---
+ tools/pal2rgb.c | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/tools/pal2rgb.c b/tools/pal2rgb.c
+index 0423598..01fcf94 100644
+--- a/tools/pal2rgb.c
++++ b/tools/pal2rgb.c
+@@ -184,8 +184,21 @@ main(int argc, char* argv[])
+ 	{ unsigned char *ibuf, *obuf;
+ 	  register unsigned char* pp;
+ 	  register uint32 x;
+-	  ibuf = (unsigned char*)_TIFFmalloc(TIFFScanlineSize(in));
+-	  obuf = (unsigned char*)_TIFFmalloc(TIFFScanlineSize(out));
++	  tmsize_t tss_in = TIFFScanlineSize(in);
++	  tmsize_t tss_out = TIFFScanlineSize(out);
++	  if (tss_out / tss_in < 3) {
++		/*
++		 * BUG 2750: The following code does not know about chroma
++		 * subsampling of JPEG data. It assumes that the output buffer is 3x
++		 * the length of the input buffer due to exploding the palette into
++		 * RGB tuples. If this assumption is incorrect, it could lead to a
++		 * buffer overflow. Go ahead and fail now to prevent that.
++		 */
++		fprintf(stderr, "Could not determine correct image size for output. Exiting.\n");
++		return -1;
++      }
++	  ibuf = (unsigned char*)_TIFFmalloc(tss_in);
++	  obuf = (unsigned char*)_TIFFmalloc(tss_out);
+ 	  switch (config) {
+ 	  case PLANARCONFIG_CONTIG:
+ 		for (row = 0; row < imagelength; row++) {
+--
+libgit2 0.27.0
+

--- a/srcpkgs/tiff/patches/CVE-2017-18013.patch
+++ b/srcpkgs/tiff/patches/CVE-2017-18013.patch
@@ -1,0 +1,34 @@
+From c6f41df7b581402dfba3c19a1e3df4454c551a01 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sun, 31 Dec 2017 15:09:41 +0100
+Subject: [PATCH] libtiff/tif_print.c: TIFFPrintDirectory(): fix null pointer dereference on corrupted file. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2770
+
+---
+ libtiff/tif_print.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/libtiff/tif_print.c b/libtiff/tif_print.c
+index 9959d35..8deceb2 100644
+--- a/libtiff/tif_print.c
++++ b/libtiff/tif_print.c
+@@ -667,13 +667,13 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
+ #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
+ 			fprintf(fd, "    %3lu: [%8I64u, %8I64u]\n",
+ 			    (unsigned long) s,
+-			    (unsigned __int64) td->td_stripoffset[s],
+-			    (unsigned __int64) td->td_stripbytecount[s]);
++			    td->td_stripoffset ? (unsigned __int64) td->td_stripoffset[s] : 0,
++			    td->td_stripbytecount ? (unsigned __int64) td->td_stripbytecount[s] : 0);
+ #else
+ 			fprintf(fd, "    %3lu: [%8llu, %8llu]\n",
+ 			    (unsigned long) s,
+-			    (unsigned long long) td->td_stripoffset[s],
+-			    (unsigned long long) td->td_stripbytecount[s]);
++			    td->td_stripoffset ? (unsigned long long) td->td_stripoffset[s] : 0,
++			    td->td_stripbytecount ? (unsigned long long) td->td_stripbytecount[s] : 0);
+ #endif
+ 	}
+ }
+--
+libgit2 0.26.0
+

--- a/srcpkgs/tiff/patches/CVE-2017-9935.patch
+++ b/srcpkgs/tiff/patches/CVE-2017-9935.patch
@@ -1,0 +1,117 @@
+diff --git a/libtiff/tif_dir.c b/libtiff/tif_dir.c
+index 2ccaf44..cbf2b69 100644
+--- a/libtiff/tif_dir.c
++++ b/libtiff/tif_dir.c
+@@ -1067,6 +1067,9 @@ _TIFFVGetField(TIFF* tif, uint32 tag, va_list ap)
+ 			if (td->td_samplesperpixel - td->td_extrasamples > 1) {
+ 				*va_arg(ap, uint16**) = td->td_transferfunction[1];
+ 				*va_arg(ap, uint16**) = td->td_transferfunction[2];
++			} else {
++				*va_arg(ap, uint16**) = NULL;
++				*va_arg(ap, uint16**) = NULL;
+ 			}
+ 			break;
+ 		case TIFFTAG_REFERENCEBLACKWHITE:
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index d1a9b09..484776c 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -237,7 +237,7 @@ typedef struct {
+ 	float tiff_whitechromaticities[2];
+ 	float tiff_primarychromaticities[6];
+ 	float tiff_referenceblackwhite[2];
+-	float* tiff_transferfunction[3];
++	uint16* tiff_transferfunction[3];
+ 	int pdf_image_interpolate;	/* 0 (default) : do not interpolate,
+ 					   1 : interpolate */
+ 	uint16 tiff_transferfunctioncount;
+@@ -1047,6 +1047,8 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+ 	uint16 pagen=0;
+ 	uint16 paged=0;
+ 	uint16 xuint16=0;
++	uint16 tiff_transferfunctioncount=0;
++	uint16* tiff_transferfunction[3];
+ 
+ 	directorycount=TIFFNumberOfDirectories(input);
+ 	t2p->tiff_pages = (T2P_PAGE*) _TIFFmalloc(TIFFSafeMultiply(tmsize_t,directorycount,sizeof(T2P_PAGE)));
+@@ -1147,26 +1149,48 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+                 }
+ #endif
+ 		if (TIFFGetField(input, TIFFTAG_TRANSFERFUNCTION,
+-                                 &(t2p->tiff_transferfunction[0]),
+-                                 &(t2p->tiff_transferfunction[1]),
+-                                 &(t2p->tiff_transferfunction[2]))) {
+-			if((t2p->tiff_transferfunction[1] != (float*) NULL) &&
+-                           (t2p->tiff_transferfunction[2] != (float*) NULL) &&
+-                           (t2p->tiff_transferfunction[1] !=
+-                            t2p->tiff_transferfunction[0])) {
+-				t2p->tiff_transferfunctioncount = 3;
+-				t2p->tiff_pages[i].page_extra += 4;
+-				t2p->pdf_xrefcount += 4;
+-			} else {
+-				t2p->tiff_transferfunctioncount = 1;
+-				t2p->tiff_pages[i].page_extra += 2;
+-				t2p->pdf_xrefcount += 2;
+-			}
+-			if(t2p->pdf_minorversion < 2)
+-				t2p->pdf_minorversion = 2;
++                                 &(tiff_transferfunction[0]),
++                                 &(tiff_transferfunction[1]),
++                                 &(tiff_transferfunction[2]))) {
++
++                        if((tiff_transferfunction[1] != (uint16*) NULL) &&
++                           (tiff_transferfunction[2] != (uint16*) NULL)
++                          ) {
++                            tiff_transferfunctioncount=3;
++                        } else {
++                            tiff_transferfunctioncount=1;
++                        }
+                 } else {
+-			t2p->tiff_transferfunctioncount=0;
++			tiff_transferfunctioncount=0;
+ 		}
++
++                if (i > 0){
++                    if (tiff_transferfunctioncount != t2p->tiff_transferfunctioncount){
++                        TIFFError(
++                            TIFF2PDF_MODULE,
++                            "Different transfer function on page %d",
++                            i);
++                        t2p->t2p_error = T2P_ERR_ERROR;
++                        return;
++                    }
++                }
++
++                t2p->tiff_transferfunctioncount = tiff_transferfunctioncount;
++                t2p->tiff_transferfunction[0] = tiff_transferfunction[0];
++                t2p->tiff_transferfunction[1] = tiff_transferfunction[1];
++                t2p->tiff_transferfunction[2] = tiff_transferfunction[2];
++                if(tiff_transferfunctioncount == 3){
++                        t2p->tiff_pages[i].page_extra += 4;
++                        t2p->pdf_xrefcount += 4;
++                        if(t2p->pdf_minorversion < 2)
++                                t2p->pdf_minorversion = 2;
++                } else if (tiff_transferfunctioncount == 1){
++                        t2p->tiff_pages[i].page_extra += 2;
++                        t2p->pdf_xrefcount += 2;
++                        if(t2p->pdf_minorversion < 2)
++                                t2p->pdf_minorversion = 2;
++                }
++
+ 		if( TIFFGetField(
+ 			input, 
+ 			TIFFTAG_ICCPROFILE, 
+@@ -1827,10 +1851,9 @@ void t2p_read_tiff_data(T2P* t2p, TIFF* input){
+ 			 &(t2p->tiff_transferfunction[0]),
+ 			 &(t2p->tiff_transferfunction[1]),
+ 			 &(t2p->tiff_transferfunction[2]))) {
+-		if((t2p->tiff_transferfunction[1] != (float*) NULL) &&
+-                   (t2p->tiff_transferfunction[2] != (float*) NULL) &&
+-                   (t2p->tiff_transferfunction[1] !=
+-                    t2p->tiff_transferfunction[0])) {
++		if((t2p->tiff_transferfunction[1] != (uint16*) NULL) &&
++                   (t2p->tiff_transferfunction[2] != (uint16*) NULL)
++                  ) {
+ 			t2p->tiff_transferfunctioncount=3;
+ 		} else {
+ 			t2p->tiff_transferfunctioncount=1;

--- a/srcpkgs/tiff/patches/CVE-2018-10963.patch
+++ b/srcpkgs/tiff/patches/CVE-2018-10963.patch
@@ -1,0 +1,31 @@
+From de144fd228e4be8aa484c3caf3d814b6fa88c6d9 Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 12 May 2018 14:24:15 +0200
+Subject: [PATCH] TIFFWriteDirectorySec: avoid assertion. Fixes
+ http://bugzilla.maptools.org/show_bug.cgi?id=2795. CVE-2018-10963
+
+---
+ libtiff/tif_dirwrite.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/libtiff/tif_dirwrite.c b/libtiff/tif_dirwrite.c
+index 2430de6d0..c15a28dbd 100644
+--- a/libtiff/tif_dirwrite.c
++++ b/libtiff/tif_dirwrite.c
+@@ -697,8 +697,11 @@ TIFFWriteDirectorySec(TIFF* tif, int isimage, int imagedone, uint64* pdiroff)
+ 								}
+ 								break;
+ 							default:
+-								assert(0);   /* we should never get here */
+-								break;
++								TIFFErrorExt(tif->tif_clientdata,module,
++								            "Cannot write tag %d (%s)",
++								            TIFFFieldTag(o),
++                                                                            o->field_name ? o->field_name : "unknown");
++								goto bad;
+ 						}
+ 					}
+ 				}
+-- 
+2.17.1
+

--- a/srcpkgs/tiff/patches/CVE-2018-5784.patch
+++ b/srcpkgs/tiff/patches/CVE-2018-5784.patch
@@ -1,0 +1,105 @@
+diff --git a/contrib/addtiffo/tif_overview.c b/contrib/addtiffo/tif_overview.c
+index c61ffbb..03b3573 100644
+--- a/contrib/addtiffo/tif_overview.c
++++ b/contrib/addtiffo/tif_overview.c
+@@ -65,6 +65,8 @@
+ #  define MAX(a,b)      ((a>b) ? a : b)
+ #endif
+ 
++#define TIFF_DIR_MAX  65534
++
+ void TIFFBuildOverviews( TIFF *, int, int *, int, const char *,
+                          int (*)(double,void*), void * );
+ 
+@@ -91,6 +93,7 @@ uint32 TIFF_WriteOverview( TIFF *hTIFF, uint32 nXSize, uint32 nYSize,
+ {
+     toff_t	nBaseDirOffset;
+     toff_t	nOffset;
++    tdir_t	iNumDir;
+ 
+     (void) bUseSubIFDs;
+ 
+@@ -147,7 +150,16 @@ uint32 TIFF_WriteOverview( TIFF *hTIFF, uint32 nXSize, uint32 nYSize,
+         return 0;
+ 
+     TIFFWriteDirectory( hTIFF );
+-    TIFFSetDirectory( hTIFF, (tdir_t) (TIFFNumberOfDirectories(hTIFF)-1) );
++    iNumDir = TIFFNumberOfDirectories(hTIFF);
++    if( iNumDir > TIFF_DIR_MAX )
++    {
++        TIFFErrorExt( TIFFClientdata(hTIFF),
++                      "TIFF_WriteOverview",
++                      "File `%s' has too many directories.\n",
++                      TIFFFileName(hTIFF) );
++        exit(-1);
++    }
++    TIFFSetDirectory( hTIFF, (tdir_t) (iNumDir - 1) );
+ 
+     nOffset = TIFFCurrentDirOffset( hTIFF );
+ 
+diff --git a/tools/tiff2pdf.c b/tools/tiff2pdf.c
+index 984ef65..832a247 100644
+--- a/tools/tiff2pdf.c
++++ b/tools/tiff2pdf.c
+@@ -68,6 +68,8 @@ extern int getopt(int, char**, char*);
+ 
+ #define PS_UNIT_SIZE	72.0F
+ 
++#define TIFF_DIR_MAX    65534
++
+ /* This type is of PDF color spaces. */
+ typedef enum {
+ 	T2P_CS_BILEVEL = 0x01,	/* Bilevel, black and white */
+@@ -1051,6 +1053,14 @@ void t2p_read_tiff_init(T2P* t2p, TIFF* input){
+ 	uint16* tiff_transferfunction[3];
+ 
+ 	directorycount=TIFFNumberOfDirectories(input);
++	if(directorycount > TIFF_DIR_MAX) {
++		TIFFError(
++			TIFF2PDF_MODULE,
++			"TIFF contains too many directories, %s",
++			TIFFFileName(input));
++		t2p->t2p_error = T2P_ERR_ERROR;
++		return;
++	}
+ 	t2p->tiff_pages = (T2P_PAGE*) _TIFFmalloc(TIFFSafeMultiply(tmsize_t,directorycount,sizeof(T2P_PAGE)));
+ 	if(t2p->tiff_pages==NULL){
+ 		TIFFError(
+diff --git a/tools/tiffcrop.c b/tools/tiffcrop.c
+index 91a38f6..e466dae 100644
+--- a/tools/tiffcrop.c
++++ b/tools/tiffcrop.c
+@@ -217,6 +217,8 @@ extern int getopt(int argc, char * const argv[], const char *optstring);
+ #define DUMP_TEXT   1
+ #define DUMP_RAW    2
+ 
++#define TIFF_DIR_MAX  65534
++
+ /* Offsets into buffer for margins and fixed width and length segments */
+ struct offset {
+   uint32  tmargin;
+@@ -2233,7 +2235,7 @@ main(int argc, char* argv[])
+     pageNum = -1;
+   else
+     total_images = 0;
+-  /* read multiple input files and write to output file(s) */
++  /* Read multiple input files and write to output file(s) */
+   while (optind < argc - 1)
+     {
+     in = TIFFOpen (argv[optind], "r");
+@@ -2241,7 +2243,14 @@ main(int argc, char* argv[])
+       return (-3);
+ 
+     /* If only one input file is specified, we can use directory count */
+-    total_images = TIFFNumberOfDirectories(in); 
++    total_images = TIFFNumberOfDirectories(in);
++    if (total_images > TIFF_DIR_MAX)
++      {
++      TIFFError (TIFFFileName(in), "File contains too many directories");
++      if (out != NULL)
++        (void) TIFFClose(out);
++      return (1);
++      }
+     if (image_count == 0)
+       {
+       dirnum = 0;

--- a/srcpkgs/tiff/patches/CVE-2018-7456.patch
+++ b/srcpkgs/tiff/patches/CVE-2018-7456.patch
@@ -1,0 +1,170 @@
+From be4c85b16e8801a16eec25e80eb9f3dd6a96731b Mon Sep 17 00:00:00 2001
+From: Hugo Lefeuvre <hle@debian.org>
+Date: Sun, 8 Apr 2018 14:07:08 -0400
+Subject: [PATCH] Fix NULL pointer dereference in TIFFPrintDirectory
+
+The TIFFPrintDirectory function relies on the following assumptions,
+supposed to be guaranteed by the specification:
+
+(a) A Transfer Function field is only present if the TIFF file has
+    photometric type < 3.
+
+(b) If SamplesPerPixel > Color Channels, then the ExtraSamples field
+    has count SamplesPerPixel - (Color Channels) and contains
+    information about supplementary channels.
+
+While respect of (a) and (b) are essential for the well functioning of
+TIFFPrintDirectory, no checks are realized neither by the callee nor
+by TIFFPrintDirectory itself. Hence, following scenarios might happen
+and trigger the NULL pointer dereference:
+
+(1) TIFF File of photometric type 4 or more has illegal Transfer
+    Function field.
+
+(2) TIFF File has photometric type 3 or less and defines a
+    SamplesPerPixel field such that SamplesPerPixel > Color Channels
+    without defining all extra samples in the ExtraSamples fields.
+
+In this patch, we address both issues with respect of the following
+principles:
+
+(A) In the case of (1), the defined transfer table should be printed
+    safely even if it isn't 'legal'. This allows us to avoid expensive
+    checks in TIFFPrintDirectory. Also, it is quite possible that
+    an alternative photometric type would be developed (not part of the
+    standard) and would allow definition of Transfer Table. We want
+    libtiff to be able to handle this scenario out of the box.
+
+(B) In the case of (2), the transfer table should be printed at its
+    right size, that is if TIFF file has photometric type Palette
+    then the transfer table should have one row and not three, even
+    if two extra samples are declared.
+
+In order to fulfill (A) we simply add a new 'i < 3' end condition to
+the broken TIFFPrintDirectory loop. This makes sure that in any case
+where (b) would be respected but not (a), everything stays fine.
+
+(B) is fulfilled by the loop condition
+'i < td->td_samplesperpixel - td->td_extrasamples'. This is enough as
+long as (b) is respected.
+
+Naturally, we also make sure (b) is respected. This is done in the
+TIFFReadDirectory function by making sure any non-color channel is
+counted in ExtraSamples.
+
+This commit addresses CVE-2018-7456.
+---
+ libtiff/tif_dirread.c | 62 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ libtiff/tif_print.c   |  2 +-
+ 2 files changed, 63 insertions(+), 1 deletion(-)
+
+diff --git a/libtiff/tif_dirread.c b/libtiff/tif_dirread.c
+index 6baa7b3..af5b84a 100644
+--- a/libtiff/tif_dirread.c
++++ b/libtiff/tif_dirread.c
+@@ -167,6 +167,7 @@ static int TIFFFetchStripThing(TIFF* tif, TIFFDirEntry* dir, uint32 nstrips, uin
+ static int TIFFFetchSubjectDistance(TIFF*, TIFFDirEntry*);
+ static void ChopUpSingleUncompressedStrip(TIFF*);
+ static uint64 TIFFReadUInt64(const uint8 *value);
++static int _TIFFGetMaxColorChannels(uint16 photometric);
+ 
+ static int _TIFFFillStrilesInternal( TIFF *tif, int loadStripByteCount );
+ 
+@@ -3507,6 +3508,35 @@ static void TIFFReadDirEntryOutputErr(TIFF* tif, enum TIFFReadDirEntryErr err, c
+ }
+ 
+ /*
++ * Return the maximum number of color channels specified for a given photometric
++ * type. 0 is returned if photometric type isn't supported or no default value
++ * is defined by the specification.
++ */
++static int _TIFFGetMaxColorChannels( uint16 photometric )
++{
++    switch (photometric) {
++	case PHOTOMETRIC_PALETTE:
++	case PHOTOMETRIC_MINISWHITE:
++	case PHOTOMETRIC_MINISBLACK:
++            return 1;
++	case PHOTOMETRIC_YCBCR:
++	case PHOTOMETRIC_RGB:
++	case PHOTOMETRIC_CIELAB:
++            return 3;
++	case PHOTOMETRIC_SEPARATED:
++	case PHOTOMETRIC_MASK:
++            return 4;
++	case PHOTOMETRIC_LOGL:
++	case PHOTOMETRIC_LOGLUV:
++	case PHOTOMETRIC_CFA:
++	case PHOTOMETRIC_ITULAB:
++	case PHOTOMETRIC_ICCLAB:
++	default:
++            return 0;
++    }
++}
++
++/*
+  * Read the next TIFF directory from a file and convert it to the internal
+  * format. We read directories sequentially.
+  */
+@@ -3522,6 +3552,7 @@ TIFFReadDirectory(TIFF* tif)
+ 	uint32 fii=FAILED_FII;
+         toff_t nextdiroff;
+     int bitspersample_read = FALSE;
++        int color_channels;
+ 
+ 	tif->tif_diroff=tif->tif_nextdiroff;
+ 	if (!TIFFCheckDirOffset(tif,tif->tif_nextdiroff))
+@@ -4026,6 +4057,37 @@ TIFFReadDirectory(TIFF* tif)
+ 			}
+ 		}
+ 	}
++
++	/*
++	 * Make sure all non-color channels are extrasamples.
++	 * If it's not the case, define them as such.
++	 */
++        color_channels = _TIFFGetMaxColorChannels(tif->tif_dir.td_photometric);
++        if (color_channels && tif->tif_dir.td_samplesperpixel - tif->tif_dir.td_extrasamples > color_channels) {
++                uint16 old_extrasamples;
++                uint16 *new_sampleinfo;
++
++                TIFFWarningExt(tif->tif_clientdata,module, "Sum of Photometric type-related "
++                    "color channels and ExtraSamples doesn't match SamplesPerPixel. "
++                    "Defining non-color channels as ExtraSamples.");
++
++                old_extrasamples = tif->tif_dir.td_extrasamples;
++                tif->tif_dir.td_extrasamples = (tif->tif_dir.td_samplesperpixel - color_channels);
++
++                // sampleinfo should contain information relative to these new extra samples
++                new_sampleinfo = (uint16*) _TIFFcalloc(tif->tif_dir.td_extrasamples, sizeof(uint16));
++                if (!new_sampleinfo) {
++                    TIFFErrorExt(tif->tif_clientdata, module, "Failed to allocate memory for "
++                                "temporary new sampleinfo array (%d 16 bit elements)",
++                                tif->tif_dir.td_extrasamples);
++                    goto bad;
++                }
++
++                memcpy(new_sampleinfo, tif->tif_dir.td_sampleinfo, old_extrasamples * sizeof(uint16));
++                _TIFFsetShortArray(&tif->tif_dir.td_sampleinfo, new_sampleinfo, tif->tif_dir.td_extrasamples);
++                _TIFFfree(new_sampleinfo);
++        }
++
+ 	/*
+ 	 * Verify Palette image has a Colormap.
+ 	 */
+diff --git a/libtiff/tif_print.c b/libtiff/tif_print.c
+index 8deceb2..1d86adb 100644
+--- a/libtiff/tif_print.c
++++ b/libtiff/tif_print.c
+@@ -546,7 +546,7 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
+ 				uint16 i;
+ 				fprintf(fd, "    %2ld: %5u",
+ 				    l, td->td_transferfunction[0][l]);
+-				for (i = 1; i < td->td_samplesperpixel; i++)
++				for (i = 1; i < td->td_samplesperpixel - td->td_extrasamples && i < 3; i++)
+ 					fprintf(fd, " %5u",
+ 					    td->td_transferfunction[i][l]);
+ 				fputc('\n', fd);
+--
+libgit2 0.27.0
+

--- a/srcpkgs/tiff/patches/CVE-2018-8905.patch
+++ b/srcpkgs/tiff/patches/CVE-2018-8905.patch
@@ -1,0 +1,52 @@
+From 58a898cb4459055bb488ca815c23b880c242a27d Mon Sep 17 00:00:00 2001
+From: Even Rouault <even.rouault@spatialys.com>
+Date: Sat, 12 May 2018 15:32:31 +0200
+Subject: [PATCH] LZWDecodeCompat(): fix potential index-out-of-bounds write.
+ Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2780 / CVE-2018-8905
+
+The fix consists in using the similar code LZWDecode() to validate we
+don't write outside of the output buffer.
+---
+ libtiff/tif_lzw.c | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/libtiff/tif_lzw.c b/libtiff/tif_lzw.c
+index 4ccb443c8..94d85e38b 100644
+--- a/libtiff/tif_lzw.c
++++ b/libtiff/tif_lzw.c
+@@ -604,6 +604,7 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
+ 	char *tp;
+ 	unsigned char *bp;
+ 	int code, nbits;
++	int len;
+ 	long nextbits, nextdata, nbitsmask;
+ 	code_t *codep, *free_entp, *maxcodep, *oldcodep;
+ 
+@@ -755,13 +756,18 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
+ 				}  while (--occ);
+ 				break;
+ 			}
+-			assert(occ >= codep->length);
+-			op += codep->length;
+-			occ -= codep->length;
+-			tp = op;
++			len = codep->length;
++			tp = op + len;
+ 			do {
+-				*--tp = codep->value;
+-			} while( (codep = codep->next) != NULL );
++				int t;
++				--tp;
++				t = codep->value;
++				codep = codep->next;
++				*tp = (char)t;
++			} while (codep && tp > op);
++			assert(occ >= len);
++			op += len;
++			occ -= len;
+ 		} else {
+ 			*op++ = (char)code;
+ 			occ--;
+-- 
+2.17.1
+

--- a/srcpkgs/tiff/template
+++ b/srcpkgs/tiff/template
@@ -1,7 +1,8 @@
-# Template build file for 'tiff'.
+# Template file for 'tiff'
 pkgname=tiff
 version=4.0.9
-revision=1
+revision=2
+patch_args="-Np1"
 build_style=gnu-configure
 configure_args="--enable-cxx --without-x"
 hostmakedepends="automake libtool"


### PR DESCRIPTION
Before

$ ./cve-check tiff
using srcpkgs/tiff/cve-check.
CVE: CVE-2017-17095 SEVERITY: 6.8
CVE: CVE-2017-17942 SEVERITY: 6.8
CVE: CVE-2017-18013 SEVERITY: 4.3
CVE: CVE-2018-10126 SEVERITY: 4.3
CVE: CVE-2018-10963 SEVERITY: 4.3
CVE: CVE-2018-12900 SEVERITY: 6.8
CVE: CVE-2018-5784 SEVERITY: 4.3
CVE: CVE-2018-7456 SEVERITY: 4.3
CVE: CVE-2018-8905 SEVERITY: 6.8

After

$ cve-check tiff
using srcpkgs/tiff/cve-check.
CVE: CVE-2017-17942 SEVERITY: 6.8
CVE: CVE-2018-10126 SEVERITY: 4.3
CVE: CVE-2018-12900 SEVERITY: 6.8