### PR TITLE
mupdf: fix CVE-2018-10289

### DIFF
--- a/srcpkgs/mupdf/patches/CVE-2018-10289.patch
+++ b/srcpkgs/mupdf/patches/CVE-2018-10289.patch
@@ -1,0 +1,25 @@
+From: Sebastian Rasmussen <sebras@gmail.com>
+Date: Tue, 21 Aug 2018 11:07:57 +0000 (+0800)
+Subject: Bug 699271: Fix eternal loop when skipping space before EOF.
+X-Git-Tag: 1.14.0-rc1~81
+X-Git-Url: http://git.ghostscript.com/?p=mupdf.git;a=commitdiff_plain;h=2e43685dc8a8a886fc9df9b3663cf199404f7637;hp=5606857245ed81253a4e06bed73eaa813e684070
+
+Bug 699271: Fix eternal loop when skipping space before EOF.
+
+Thanks to Michael J Gruber for providing this oneliner.
+---
+
+diff --git a/source/pdf/pdf-xref.c b/source/pdf/pdf-xref.c
+index 682a3dd..431755d 100644
+--- source/pdf/pdf-xref.c
++++ source/pdf/pdf-xref.c
+@@ -649,7 +649,7 @@ fz_skip_space(fz_context *ctx, fz_stream *stm)
+ 	do
+ 	{
+ 		int c = fz_peek_byte(ctx, stm);
+-		if (c > 32 && c != EOF)
++		if (c == EOF || c > 32)
+ 			return;
+ 		(void)fz_read_byte(ctx, stm);
+ 	}
+

--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -1,13 +1,13 @@
 # Template file for 'mupdf'
 pkgname=mupdf
 version=1.13.0
-revision=2
+revision=3
 wrksrc="${pkgname}-${version}-source"
 hostmakedepends="pkg-config zlib-devel libcurl-devel freetype-devel
  libjpeg-turbo-devel jbig2dec-devel libXext-devel libXcursor-devel
  libXrandr-devel libXinerama-devel harfbuzz-devel
  MesaLib-devel libopenjpeg2-devel glu-devel libXi-devel"
-makedepends="${hostmakedepends}"
+makedepends="$hostmakedepends"
 depends="desktop-file-utils"
 short_desc="Lightweight PDF and XPS viewer"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-10289
http://git.ghostscript.com/?p=mupdf.git;h=2e43685dc8a8a886fc9df9b3663cf199404f7637
https://bugs.ghostscript.com/show_bug.cgi?id=699271