### PR TITLE
[DO NOT MERGE] graphviz: fix CVE-2018-10196

### DIFF
--- a/srcpkgs/graphviz/patches/CVE-2018-10196.patch
+++ b/srcpkgs/graphviz/patches/CVE-2018-10196.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/dotgen/conc.c b/lib/dotgen/conc.c
+index dd13e936b..f7307d23b 100644
+--- lib/dotgen/conc.c
++++ lib/dotgen/conc.c
+@@ -159,7 +159,11 @@ static void rebuild_vlists(graph_t * g)
+ 
+     for (r = GD_minrank(g); r <= GD_maxrank(g); r++) {
+ 	lead = GD_rankleader(g)[r];
+-	if (GD_rank(dot_root(g))[r].v[ND_order(lead)] != lead) {
++	if (lead == NULL) {
++		agerr(AGERR, "rebuiltd_vlists: lead is null for rank %d\n", r);
++		longjmp(jbuf, 1);
++	}
++	else if (GD_rank(dot_root(g))[r].v[ND_order(lead)] != lead) {
+ 	    agerr(AGERR, "rebuiltd_vlists: rank lead %s not in order %d of rank %d\n", 
+ 		agnameof(lead), ND_order(lead), r);
+ 	    longjmp(jbuf, 1);

--- a/srcpkgs/graphviz/template
+++ b/srcpkgs/graphviz/template
@@ -1,7 +1,7 @@
 # Template file for 'graphviz'
 pkgname=graphviz
 version=2.40.1
-revision=1
+revision=2
 replaces="graphviz-libs<2.38.0_3"
 build_style=gnu-configure
 hostmakedepends="automake libtool flex pkg-config libltdl-devel"


### PR DESCRIPTION
Needs triaging

https://gitlab.com/graphviz/graphviz/issues/1367
https://nvd.nist.gov/vuln/detail/CVE-2018-10196