### PR TITLE
update-check: fix sourceforge.net

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -75,7 +75,7 @@ update_check() {
         if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
             echo "fetching $url" 1>&2
         fi
-        curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain' -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$url" |
+        curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml' -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$url" |
             grep -Po -i "$rx"
     done |
     tr _ . |


### PR DESCRIPTION
[ci skip]

When fetching the URL to do the update-check `application/rss+xml` needs to be accepted for sourceforge.net. Else nothing is returned.