### PR TITLE
libsndfile: apply security fixes from upstream

### DIFF
--- a/srcpkgs/libsndfile/patches/CVE-2017-12562.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-12562.patch
@@ -1,0 +1,65 @@
+Fix CVE-2017-12562
+
+See:
+
+  https://nvd.nist.gov/vuln/detail/CVE-2017-12562
+  https://github.com/erikd/libsndfile/issues/292
+
+for more details.
+
+Changes come from the upstream committed fix at:
+
+https://github.com/erikd/libsndfile/commit/cf7a8182c2642c50f1cf90dddea9ce96a8bad2e8
+
+--- libsndfile-1.0.28/src/common.c.orig	2017-08-07 07:13:53.056875691 +0000
++++ libsndfile-1.0.28/src/common.c	2017-08-07 07:23:57.493033443 +0000
+@@ -675,16 +675,16 @@
+ 					/* Write a C string (guaranteed to have a zero terminator). */
+ 					strptr = va_arg (argptr, char *) ;
+ 					size = strlen (strptr) + 1 ;
+-					size += (size & 1) ;
+ 
+-					if (psf->header.indx + (sf_count_t) size >= psf->header.len && psf_bump_header_allocation (psf, 16))
++					if (psf->header.indx + 4 + (sf_count_t) size + (sf_count_t) (size & 1) > psf->header.len && psf_bump_header_allocation (psf, 4 + size + (size & 1)))
+ 						return count ;
+ 
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+-						header_put_be_int (psf, size) ;
++						header_put_be_int (psf, size + (size & 1)) ;
+ 					else
+-						header_put_le_int (psf, size) ;
++						header_put_le_int (psf, size + (size & 1)) ;
+ 					memcpy (&(psf->header.ptr [psf->header.indx]), strptr, size) ;
++					size += (size & 1) ;
+ 					psf->header.indx += size ;
+ 					psf->header.ptr [psf->header.indx - 1] = 0 ;
+ 					count += 4 + size ;
+@@ -697,16 +697,15 @@
+ 					*/
+ 					strptr = va_arg (argptr, char *) ;
+ 					size = strlen (strptr) ;
+-					if (psf->header.indx + (sf_count_t) size > psf->header.len && psf_bump_header_allocation (psf, size))
++					if (psf->header.indx + 4 + (sf_count_t) size + (sf_count_t) (size & 1) > psf->header.len && psf_bump_header_allocation (psf, 4 + size + (size & 1)))
+ 						return count ;
+ 					if (psf->rwf_endian == SF_ENDIAN_BIG)
+ 						header_put_be_int (psf, size) ;
+ 					else
+ 						header_put_le_int (psf, size) ;
+-					memcpy (&(psf->header.ptr [psf->header.indx]), strptr, size + 1) ;
++					memcpy (&(psf->header.ptr [psf->header.indx]), strptr, size + (size & 1)) ;
+ 					size += (size & 1) ;
+ 					psf->header.indx += size ;
+-					psf->header.ptr [psf->header.indx] = 0 ;
+ 					count += 4 + size ;
+ 					break ;
+ 
+@@ -718,7 +717,7 @@
+ 					size = (size & 1) ? size : size + 1 ;
+ 					size = (size > 254) ? 254 : size ;
+ 
+-					if (psf->header.indx + (sf_count_t) size > psf->header.len && psf_bump_header_allocation (psf, size))
++					if (psf->header.indx + 1 + (sf_count_t) size > psf->header.len && psf_bump_header_allocation (psf, 1 + size))
+ 						return count ;
+ 
+ 					header_put_byte (psf, size) ;
+

--- a/srcpkgs/libsndfile/patches/CVE-2017-14245-and-CVE-2017-14246.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-14245-and-CVE-2017-14246.patch
@@ -1,0 +1,114 @@
+From 2d54514a4f6437b67829717c05472d2e3300a258 Mon Sep 17 00:00:00 2001
+From: Fabian Greffrath <fabian@greffrath.com>
+Date: Wed, 27 Sep 2017 14:46:17 +0200
+Subject: [PATCH] sfe_copy_data_fp: check value of "max" variable for being
+ normal
+
+and check elements of the data[] array for being finite.
+
+Both checks use functions provided by the <math.h> header as declared
+by the C99 standard.
+
+Fixes #317
+CVE-2017-14245
+CVE-2017-14246
+---
+ programs/common.c          | 20 ++++++++++++++++----
+ programs/common.h          |  2 +-
+ programs/sndfile-convert.c |  6 +++++-
+ 3 files changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/programs/common.c b/programs/common.c
+index a21e62ca..a249a585 100644
+--- a/programs/common.c
++++ b/programs/common.c
+@@ -36,6 +36,7 @@
+ #include <string.h>
+ #include <ctype.h>
+ #include <stdint.h>
++#include <math.h>
+ 
+ #include <sndfile.h>
+ 
+@@ -45,7 +46,7 @@
+ 
+ #define	MIN(x, y)	((x) < (y) ? (x) : (y))
+ 
+-void
++int
+ sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize)
+ {	static double	data [BUFFER_LEN], max ;
+ 	sf_count_t		frames, readcount, k ;
+@@ -54,6 +55,8 @@ sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize
+ 	readcount = frames ;
+ 
+ 	sf_command (infile, SFC_CALC_SIGNAL_MAX, &max, sizeof (max)) ;
++	if (!isnormal (max)) /* neither zero, subnormal, infinite, nor NaN */
++		return 1 ;
+ 
+ 	if (!normalize && max < 1.0)
+ 	{	while (readcount > 0)
+@@ -67,12 +70,16 @@ sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize
+ 		while (readcount > 0)
+ 		{	readcount = sf_readf_double (infile, data, frames) ;
+ 			for (k = 0 ; k < readcount * channels ; k++)
+-				data [k] /= max ;
++			{	data [k] /= max ;
++
++				if (!isfinite (data [k])) /* infinite or NaN */
++					return 1;
++				}
+ 			sf_writef_double (outfile, data, readcount) ;
+ 			} ;
+ 		} ;
+ 
+-	return ;
++	return 0 ;
+ } /* sfe_copy_data_fp */
+ 
+ void
+@@ -252,7 +259,12 @@ sfe_apply_metadata_changes (const char * filenames [2], const METADATA_INFO * in
+ 
+ 		/* If the input file is not the same as the output file, copy the data. */
+ 		if ((infileminor == SF_FORMAT_DOUBLE) || (infileminor == SF_FORMAT_FLOAT))
+-			sfe_copy_data_fp (outfile, infile, sfinfo.channels, SF_FALSE) ;
++		{	if (sfe_copy_data_fp (outfile, infile, sfinfo.channels, SF_FALSE) != 0)
++			{	printf ("Error : Not able to decode input file '%s'\n", filenames [0]) ;
++				error_code = 1 ;
++				goto cleanup_exit ;
++				} ;
++			}
+ 		else
+ 			sfe_copy_data_int (outfile, infile, sfinfo.channels) ;
+ 		} ;
+diff --git a/programs/common.h b/programs/common.h
+index eda2d7d7..986277ee 100644
+--- a/programs/common.h
++++ b/programs/common.h
+@@ -62,7 +62,7 @@ typedef SF_BROADCAST_INFO_VAR (2048) SF_BROADCAST_INFO_2K ;
+ 
+ void sfe_apply_metadata_changes (const char * filenames [2], const METADATA_INFO * info) ;
+ 
+-void sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize) ;
++int sfe_copy_data_fp (SNDFILE *outfile, SNDFILE *infile, int channels, int normalize) ;
+ 
+ void sfe_copy_data_int (SNDFILE *outfile, SNDFILE *infile, int channels) ;
+ 
+diff --git a/programs/sndfile-convert.c b/programs/sndfile-convert.c
+index dff7f793..e6de5935 100644
+--- a/programs/sndfile-convert.c
++++ b/programs/sndfile-convert.c
+@@ -335,7 +335,11 @@ main (int argc, char * argv [])
+ 			|| (outfileminor == SF_FORMAT_DOUBLE) || (outfileminor == SF_FORMAT_FLOAT)
+ 			|| (infileminor == SF_FORMAT_DOUBLE) || (infileminor == SF_FORMAT_FLOAT)
+ 			|| (infileminor == SF_FORMAT_VORBIS) || (outfileminor == SF_FORMAT_VORBIS))
+-		sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) ;
++	{	if (sfe_copy_data_fp (outfile, infile, sfinfo.channels, normalize) != 0)
++		{	printf ("Error : Not able to decode input file %s.\n", infilename) ;
++			return 1 ;
++			} ;
++		}
+ 	else
+ 		sfe_copy_data_int (outfile, infile, sfinfo.channels) ;
+ 
+

--- a/srcpkgs/libsndfile/patches/CVE-2017-14634.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-14634.patch
@@ -1,0 +1,36 @@
+From 85c877d5072866aadbe8ed0c3e0590fbb5e16788 Mon Sep 17 00:00:00 2001
+From: Fabian Greffrath <fabian@greffrath.com>
+Date: Thu, 28 Sep 2017 12:15:04 +0200
+Subject: [PATCH] double64_init: Check psf->sf.channels against upper bound
+
+This prevents division by zero later in the code.
+
+While the trivial case to catch this (i.e. sf.channels < 1) has already
+been covered, a crafted file may report a number of channels that is
+so high (i.e. > INT_MAX/sizeof(double)) that it "somehow" gets
+miscalculated to zero (if this makes sense) in the determination of the
+blockwidth. Since we only support a limited number of channels anyway,
+make sure to check here as well.
+
+CVE-2017-14634
+
+Closes: https://github.com/erikd/libsndfile/issues/318
+Signed-off-by: Erik de Castro Lopo <erikd@mega-nerd.com>
+---
+ src/double64.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/double64.c b/src/double64.c
+index b318ea86..78dfef7f 100644
+--- a/src/double64.c
++++ b/src/double64.c
+@@ -91,7 +91,7 @@ int
+ double64_init	(SF_PRIVATE *psf)
+ {	static int double64_caps ;
+ 
+-	if (psf->sf.channels < 1)
++	if (psf->sf.channels < 1 || psf->sf.channels > SF_MAX_CHANNELS)
+ 	{	psf_log_printf (psf, "double64_init : internal error : channels = %d\n", psf->sf.channels) ;
+ 		return SFE_INTERNAL ;
+ 		} ;
+

--- a/srcpkgs/libsndfile/patches/CVE-2017-6892.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-6892.patch
@@ -1,0 +1,18 @@
+Description: Fix for CVE-2017-6892
+Author: Erik de Castro Lopez
+Origin: https://github.com/erikd/libsndfile/commit/f833c53cb596e9e1792949f762e0b33661822748
+Applied-Upstream: https://github.com/erikd/libsndfile/commit/f833c53cb596e9e1792949f762e0b33661822748
+Last-Update: 2017-06-20
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- libsndfile.orig/src/aiff.c
++++ libsndfile/src/aiff.c
+@@ -1905,7 +1905,7 @@
+ 		psf_binheader_readf (psf, "j", dword - bytesread) ;
+ 
+ 	if (map_info->channel_map != NULL)
+-	{	size_t chanmap_size = psf->sf.channels * sizeof (psf->channel_map [0]) ;
++	{	size_t chanmap_size = SF_MIN (psf->sf.channels, layout_tag & 0xffff) * sizeof (psf->channel_map [0]) ;
+ 
+ 		free (psf->channel_map) ;
+ 

--- a/srcpkgs/libsndfile/patches/CVE-2017-8362.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-8362.patch
@@ -1,0 +1,33 @@
+Description: fixed yet another buffer read overflow in FLAC code
+ CVE-2017-8362
+Author: Erik de Castro Lopo
+Origin: upstream
+Applied-Upstream: https://github.com/erikd/libsndfile/commit/ef1dbb2df1c0e741486646de40bd638a9c4cd808
+Last-Update: 2017-05-28
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- libsndfile.orig/src/flac.c
++++ libsndfile/src/flac.c
+@@ -169,6 +169,14 @@
+ 	const int32_t* const *buffer = pflac->wbuffer ;
+ 	unsigned i = 0, j, offset, channels, len ;
+ 
++	if (psf->sf.channels != (int) frame->header.channels)
++	{	psf_log_printf (psf, "Error: FLAC frame changed from %d to %d channels\n"
++									"Nothing to do but to error out.\n" ,
++									psf->sf.channels, frame->header.channels) ;
++		psf->error = SFE_FLAC_CHANNEL_COUNT_CHANGED ;
++		return 0 ;
++		} ;
++
+ 	/*
+ 	**	frame->header.blocksize is variable and we're using a constant blocksize
+ 	**	of FLAC__MAX_BLOCK_SIZE.
+@@ -202,7 +210,6 @@
+ 		return 0 ;
+ 		} ;
+ 
+-
+ 	len = SF_MIN (pflac->len, frame->header.blocksize) ;
+ 
+ 	if (pflac->remain % channels != 0)

--- a/srcpkgs/libsndfile/patches/CVE-2017-8363.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-8363.patch
@@ -1,0 +1,44 @@
+Description: fixing another memory leak in FLAC code
+ CVE-2017-8363
+Author: Erik de Castro Lopo
+Origin: upstream
+Applied-Upstream: https://github.com/erikd/libsndfile/commit/cd7da8dbf6ee4310d21d9e44b385d6797160d9e8 & https://github.com/erikd/libsndfile/commit/5206a9b65e61598fde44d276c81b0585bc428562
+Last-Update: 2017-05-28
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- libsndfile.orig/src/flac.c
++++ libsndfile/src/flac.c
+@@ -430,8 +430,7 @@
+ static void
+ sf_flac_meta_callback (const FLAC__StreamDecoder * UNUSED (decoder), const FLAC__StreamMetadata *metadata, void *client_data)
+ {	SF_PRIVATE *psf = (SF_PRIVATE*) client_data ;
+-	FLAC_PRIVATE* pflac = (FLAC_PRIVATE*) psf->codec_data ;
+-	int bitwidth = 0, i ;
++	int bitwidth = 0 ;
+ 
+ 	switch (metadata->type)
+ 	{	case FLAC__METADATA_TYPE_STREAMINFO :
+@@ -481,12 +480,6 @@
+ 
+ 			if (bitwidth > 0)
+ 				psf_log_printf (psf, "  Bit width   : %d\n", bitwidth) ;
+-
+-
+-			for (i = 0 ; i < psf->sf.channels ; i++)
+-				pflac->rbuffer [i] = calloc (FLAC__MAX_BLOCK_SIZE, sizeof (int32_t)) ;
+-
+-			pflac->wbuffer = (const int32_t* const*) pflac->rbuffer ;
+ 			break ;
+ 
+ 		case FLAC__METADATA_TYPE_VORBIS_COMMENT :
+@@ -848,7 +841,9 @@
+ 
+ 	psf_log_printf (psf, "End\n") ;
+ 
+-	if (psf->error == 0)
++	if (psf->error != 0)
++		FLAC__stream_decoder_delete (pflac->fsd) ;
++	else
+ 	{	FLAC__uint64 position ;
+ 
+ 		FLAC__stream_decoder_get_decode_position (pflac->fsd, &position) ;

--- a/srcpkgs/libsndfile/patches/CVE-2017-8365.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2017-8365.patch
@@ -1,0 +1,50 @@
+Description: fixing buffer read/write overruns in FLAC-code
+ CVE-2017-8365, CVE-2017-8363, CVE-2017-8361
+Author: Erik de Castro Lopo
+Origin: upstream
+Applied-Upstream: https://github.com/erikd/libsndfile/commit/fd0484aba8e51d16af1e3a880f9b8b857b385eb3
+Last-Update: 2017-05-28
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- libsndfile.orig/src/common.h
++++ libsndfile/src/common.h
+@@ -725,6 +725,7 @@
+ 	SFE_FLAC_INIT_DECODER,
+ 	SFE_FLAC_LOST_SYNC,
+ 	SFE_FLAC_BAD_SAMPLE_RATE,
++	SFE_FLAC_CHANNEL_COUNT_CHANGED,
+ 	SFE_FLAC_UNKOWN_ERROR,
+ 
+ 	SFE_WVE_NOT_WVE,
+--- libsndfile.orig/src/flac.c
++++ libsndfile/src/flac.c
+@@ -435,6 +435,19 @@
+ 
+ 	switch (metadata->type)
+ 	{	case FLAC__METADATA_TYPE_STREAMINFO :
++			if (psf->sf.channels > 0 && psf->sf.channels != (int) metadata->data.stream_info.channels)
++			{	psf_log_printf (psf, "Error: FLAC stream changed from %d to %d channels\n"
++									"Nothing to be but to error out.\n" ,
++									psf->sf.channels, metadata->data.stream_info.channels) ;
++				psf->error = SFE_FLAC_CHANNEL_COUNT_CHANGED ;
++				return ;
++				} ;
++
++			if (psf->sf.channels > 0 && psf->sf.samplerate != (int) metadata->data.stream_info.sample_rate)
++			{	psf_log_printf (psf, "Warning: FLAC stream changed sample rates from %d to %d.\n"
++									"Carrying on as if nothing happened.",
++									psf->sf.samplerate, metadata->data.stream_info.sample_rate) ;
++				} ;
+ 			psf->sf.channels = metadata->data.stream_info.channels ;
+ 			psf->sf.samplerate = metadata->data.stream_info.sample_rate ;
+ 			psf->sf.frames = metadata->data.stream_info.total_samples ;
+--- libsndfile.orig/src/sndfile.c
++++ libsndfile/src/sndfile.c
+@@ -245,6 +245,7 @@
+ 	{	SFE_FLAC_INIT_DECODER	, "Error : problem with initialization of the flac decoder." },
+ 	{	SFE_FLAC_LOST_SYNC		, "Error : flac decoder lost sync." },
+ 	{	SFE_FLAC_BAD_SAMPLE_RATE, "Error : flac does not support this sample rate." },
++	{	SFE_FLAC_CHANNEL_COUNT_CHANGED, "Error : flac channel changed mid stream." },
+ 	{	SFE_FLAC_UNKOWN_ERROR	, "Error : unknown error in flac decoder." },
+ 
+ 	{	SFE_WVE_NOT_WVE			, "Error : not a WVE file." },

--- a/srcpkgs/libsndfile/patches/CVE-2018-13139.patch
+++ b/srcpkgs/libsndfile/patches/CVE-2018-13139.patch
@@ -1,0 +1,32 @@
+From aaea680337267bfb6d2544da878890ee7f1c5077 Mon Sep 17 00:00:00 2001
+From: "Brett T. Warden" <brett.t.warden@intel.com>
+Date: Tue, 28 Aug 2018 12:01:17 -0700
+Subject: [PATCH] Check MAX_CHANNELS in sndfile-deinterleave
+
+Allocated buffer has space for only 16 channels. Verify that input file
+meets this limit.
+
+Fixes #397
+---
+ programs/sndfile-deinterleave.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/programs/sndfile-deinterleave.c b/programs/sndfile-deinterleave.c
+index 53660310..225b4d54 100644
+--- a/programs/sndfile-deinterleave.c
++++ b/programs/sndfile-deinterleave.c
+@@ -89,6 +89,13 @@ main (int argc, char **argv)
+ 		exit (1) ;
+ 		} ;
+ 
++	if (sfinfo.channels > MAX_CHANNELS)
++	{	printf ("\nError : Input file '%s' has too many (%d) channels. Limit is %d.\n",
++			argv [1], sfinfo.channels, MAX_CHANNELS) ;
++		exit (1) ;
++		} ;
++
++
+ 	state.channels = sfinfo.channels ;
+ 	sfinfo.channels = 1 ;
+ 
+

--- a/srcpkgs/libsndfile/template
+++ b/srcpkgs/libsndfile/template
@@ -1,7 +1,8 @@
 # Template file for 'libsndfile'
 pkgname=libsndfile
 version=1.0.28
-revision=1
+revision=2
+patch_args="-Np1"
 build_style=gnu-configure
 hostmakedepends="pkg-config python"
 makedepends="alsa-lib-devel libvorbis-devel libflac-devel sqlite-devel"
@@ -9,7 +10,7 @@ short_desc="C library for reading and writing files containing sampled sound"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.mega-nerd.com/libsndfile"
 license="LGPL-2.1"
-distfiles="http://www.mega-nerd.com/$pkgname/files/$pkgname-$version.tar.gz"
+distfiles="http://www.mega-nerd.com/${pkgname}/files/${pkgname}-${version}.tar.gz"
 checksum=1ff33929f042fa333aed1e8923aa628c3ee9e1eb85512686c55092d1e5a9dfa9
 
 libsndfile-progs_package() {


### PR DESCRIPTION
fixes:
    CVE-2017-12562
    CVE-2017-14245
    CVE-2017-14246
    CVE-2017-14634
    CVE-2017-6892
    CVE-2017-8362
    CVE-2017-8363
    CVE-2017-8365
    CVE-2018-13139

unresolved (upstream):
	CVE-2018-13419