### PR TITLE
lrzip: apply applicable security patches from upstream

### DIFF
--- a/srcpkgs/lrzip/patches/CVE-2017-8842.patch
+++ b/srcpkgs/lrzip/patches/CVE-2017-8842.patch
@@ -1,0 +1,24 @@
+From 38386bd482c0a8102a79958cb3eddcb97a167ca3 Mon Sep 17 00:00:00 2001
+From: Con Kolivas <kernel@kolivas.org>
+Date: Fri, 9 Mar 2018 17:39:40 +1100
+Subject: [PATCH] CVE-2017-8842 Fix divide-by-zero in bufRead::get
+
+---
+ libzpaq/libzpaq.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libzpaq/libzpaq.h b/libzpaq/libzpaq.h
+index 93387da..cbe211d 100644
+--- a/libzpaq/libzpaq.h
++++ b/libzpaq/libzpaq.h
+@@ -465,7 +465,8 @@ struct bufRead: public libzpaq::Reader {
+ 
+ 	int get() {
+ 		if (progress && !(*s_len % 128)) {
+-			int pct = (total_len - *s_len) * 100 / total_len;
++			int pct = (total_len > 0) ?
++				(total_len - *s_len) * 100 / total_len : 100;
+ 
+ 			if (pct / 10 != *last_pct / 10) {
+ 				int i;
+

--- a/srcpkgs/lrzip/patches/CVE-2017-8844.patch
+++ b/srcpkgs/lrzip/patches/CVE-2017-8844.patch
@@ -1,0 +1,35 @@
+From dc57230636fe8da068674e1023b2f07c593ec21b Mon Sep 17 00:00:00 2001
+From: Con Kolivas <kernel@kolivas.org>
+Date: Wed, 16 May 2018 14:30:15 +1000
+Subject: [PATCH] Cope with compressed length being longer than uncompressed
+ and rounding up, attending to CVE-2017-8844.
+
+---
+ stream.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/stream.c b/stream.c
+index 4ef910e..01b883a 100644
+--- a/stream.c
++++ b/stream.c
+@@ -1564,7 +1564,7 @@ static void *ucompthread(void *data)
+ /* fill a buffer from a stream - return -1 on failure */
+ static int fill_buffer(rzip_control *control, struct stream_info *sinfo, int streamno)
+ {
+-	i64 u_len, c_len, last_head, padded_len, header_length;
++	i64 u_len, c_len, last_head, padded_len, header_length, max_len;
+ 	uchar enc_head[25 + SALT_LEN], blocksalt[SALT_LEN];
+ 	struct stream *s = &sinfo->s[streamno];
+ 	stream_thread_struct *st;
+@@ -1639,7 +1639,9 @@ static int fill_buffer(rzip_control *control, struct stream_info *sinfo, int str
+ 
+ 	if (unlikely(u_len > control->maxram))
+ 		fatal_return(("Unable to malloc buffer of size %lld in this environment\n", u_len), -1);
+-	s_buf = malloc(MAX(u_len, MIN_SIZE));
++	max_len = MAX(u_len, MIN_SIZE);
++	max_len = MAX(max_len, c_len);
++	s_buf = malloc(max_len);
+ 	if (unlikely(u_len && !s_buf))
+ 		fatal_return(("Unable to malloc buffer of size %lld in fill_buffer\n", u_len), -1);
+ 	sinfo->ram_alloced += u_len;
+

--- a/srcpkgs/lrzip/patches/CVE-2017-8845.patch
+++ b/srcpkgs/lrzip/patches/CVE-2017-8845.patch
@@ -1,0 +1,26 @@
+From 4893e869e3fc36c65123ce8fedafeb82cba745a4 Mon Sep 17 00:00:00 2001
+From: Con Kolivas <kernel@kolivas.org>
+Date: Wed, 16 May 2018 16:55:41 +1000
+Subject: [PATCH] Add sanity check for invalid values during decompression,
+ addressing CVE-2017-8845.
+
+---
+ stream.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/stream.c b/stream.c
+index af4a4aa..79890ba 100644
+--- a/stream.c
++++ b/stream.c
+@@ -1632,6 +1632,10 @@ static int fill_buffer(rzip_control *control, struct stream_info *sinfo, int str
+ 	c_len = le64toh(c_len);
+ 	u_len = le64toh(u_len);
+ 	last_head = le64toh(last_head);
++	if (unlikely(c_len < 1 || u_len < 1 || last_head < 0)) {
++		fatal_return(("Invalid data compressed len %lld uncompressed %lld last_head %lld\n",
++			     c_len, u_len, last_head), -1);
++	}
+ 	print_maxverbose("Fill_buffer stream %d c_len %lld u_len %lld last_head %lld\n", streamno, c_len, u_len, last_head);
+ 
+ 	padded_len = MAX(c_len, MIN_SIZE);
+

--- a/srcpkgs/lrzip/patches/CVE-2018-5650.patch
+++ b/srcpkgs/lrzip/patches/CVE-2018-5650.patch
@@ -1,0 +1,24 @@
+From 50cfb3b9f68c7458822795e8b87a07dc06b39816 Mon Sep 17 00:00:00 2001
+From: Con Kolivas <kernel@kolivas.org>
+Date: Wed, 16 May 2018 19:26:15 +1000
+Subject: [PATCH] Prevent infinite loop from crafted/corrupt archive in
+ unzip_match.
+
+---
+ runzip.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/runzip.c b/runzip.c
+index 667ae05..44e886d 100644
+--- a/runzip.c
++++ b/runzip.c
+@@ -219,6 +219,8 @@ static i64 unzip_match(rzip_control *control, void *ss, i64 len, uint32 *cksum,
+ 
+ 	while (len) {
+ 		n = MIN(len, offset);
++		if (unlikely(n < 1))
++			fatal_return(("Failed fd history in unzip_match due to corrupt archive\n"), -1);
+ 
+ 		if (unlikely(read_fdhist(control, off_buf, (size_t)n) != (ssize_t)n)) {
+ 			dealloc(buf);
+

--- a/srcpkgs/lrzip/template
+++ b/srcpkgs/lrzip/template
@@ -1,14 +1,15 @@
 # Template file for 'lrzip'
 pkgname=lrzip
 version=0.631
-revision=1
+revision=2
+patch_args="-Np1"
 build_style="gnu-configure"
 hostmakedepends="perl automake libtool"
 makedepends="zlib-devel bzip2-devel lzo-devel"
-maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://lrzip.kolivas.org/"
-license="GPL-2"
 short_desc="Multi-threaded compression using the rzip/lzma, lzo, and zpaq algorithms"
+maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2"
+homepage="http://lrzip.kolivas.org/"
 distfiles="https://github.com/ckolivas/lrzip/archive/v${version}.tar.gz"
 checksum=10315c20d5a47590e7220c210735ba169677824d5672509266682eccec84d952
 


### PR DESCRIPTION
Upstream has a few more CVEs but didn't make a new release yet.

In the meantime we patch what we can

Fixes:
    - CVE-2017-8842
    - CVE-2017-8844
    - CVE-2017-8845
    - CVE-2018-5650

The CVEs left remaining to be fixed by upstream are

( Removed CVE- prefix as to not confuse tools that grep for those
values)

CVE: 2017-8843 SEVERITY: 4.3
CVE: 2017-8846 SEVERITY: 4.3
CVE: 2017-8847 SEVERITY: 4.3
CVE: 2017-9928 SEVERITY: 4.3
CVE: 2017-9929 SEVERITY: 4.3
CVE: 2018-11496 SEVERITY: 4.3
CVE: 2018-5747 SEVERITY: 4.3