### PR TITLE
libsass: apply security fixes from upstream

### DIFF
--- a/srcpkgs/libsass/patches/CVE-2018-11693.patch
+++ b/srcpkgs/libsass/patches/CVE-2018-11693.patch
@@ -1,0 +1,23 @@
+From b3374e3fd1a0c3658644d2bad24e4a0ff2e0dcea Mon Sep 17 00:00:00 2001
+From: xzyfer <xzyfer@gmail.com>
+Date: Thu, 21 Jun 2018 21:21:26 +1000
+Subject: [PATCH] Fix handling of unclosed interpolant in url
+
+Fixes #2661
+---
+ src/parser.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/parser.cpp b/src/parser.cpp
+index d99636dd4..66ca4dc94 100644
+--- a/src/parser.cpp
++++ b/src/parser.cpp
+@@ -2163,6 +2163,7 @@ namespace Sass {
+       while (pp && peek< exactly< hash_lbrace > >(pp)) {
+         pp = sequence< interpolant, real_uri_value >(pp);
+       }
++      if (!pp) return 0;
+       position = pp;
+       return parse_interpolated_chunk(Token(p, position));
+     }
+

--- a/srcpkgs/libsass/patches/CVE-2018-11696.patch
+++ b/srcpkgs/libsass/patches/CVE-2018-11696.patch
@@ -1,0 +1,24 @@
+From 38f4c3699d06b64128bebc7cf1e8b3125be74dc4 Mon Sep 17 00:00:00 2001
+From: xzyfer <xzyfer@gmail.com>
+Date: Wed, 4 Jul 2018 20:36:29 +1000
+Subject: [PATCH] Fix possible bug with handling empty reference combinators
+
+Fixes #2665
+---
+ src/inspect.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/inspect.cpp b/src/inspect.cpp
+index bd0389224..b56fd89aa 100644
+--- a/src/inspect.cpp
++++ b/src/inspect.cpp
+@@ -1042,7 +1042,7 @@ namespace Sass {
+       case Complex_Selector::REFERENCE:
+         append_mandatory_space();
+         append_string("/");
+-        c->reference()->perform(this);
++        if (c->reference()) c->reference()->perform(this);
+         append_string("/");
+         append_mandatory_space();
+       break;
+

--- a/srcpkgs/libsass/patches/CVE-2018-11697.patch
+++ b/srcpkgs/libsass/patches/CVE-2018-11697.patch
@@ -1,0 +1,178 @@
+From 02428e022a1804426fc7e06ff158f186a9f281ca Mon Sep 17 00:00:00 2001
+From: xzyfer <xzyfer@gmail.com>
+Date: Wed, 4 Jul 2018 21:45:59 +1000
+Subject: [PATCH] Fix possible out of band read in prelexer
+
+Fixes #2656
+---
+ src/lexer.cpp | 13 ++++++++++++-
+ src/lexer.hpp | 14 +++++++-------
+ 2 files changed, 19 insertions(+), 8 deletions(-)
+
+diff --git a/src/lexer.cpp b/src/lexer.cpp
+index be7f67713..5a5464cf8 100644
+--- a/src/lexer.cpp
++++ b/src/lexer.cpp
+@@ -33,30 +33,35 @@ namespace Sass {
+ 
+     bool is_alpha(const char& chr)
+     {
++      if (!chr) return false;
+       return unsigned(chr - 'A') <= 'Z' - 'A' ||
+              unsigned(chr - 'a') <= 'z' - 'a';
+     }
+ 
+     bool is_space(const char& chr)
+     {
++      if (!chr) return false;
+       // adapted the technique from is_alpha
+       return chr == ' ' || unsigned(chr - '\t') <= '\r' - '\t';
+     }
+ 
+     bool is_digit(const char& chr)
+     {
++      if (!chr) return false;
+       // adapted the technique from is_alpha
+       return unsigned(chr - '0') <= '9' - '0';
+     }
+ 
+     bool is_number(const char& chr)
+     {
++      if (!chr) return false;
+       // adapted the technique from is_alpha
+       return is_digit(chr) || chr == '-' || chr == '+';
+     }
+ 
+     bool is_xdigit(const char& chr)
+     {
++      if (!chr) return false;
+       // adapted the technique from is_alpha
+       return unsigned(chr - '0') <= '9' - '0' ||
+              unsigned(chr - 'a') <= 'f' - 'a' ||
+@@ -65,6 +70,7 @@ namespace Sass {
+ 
+     bool is_punct(const char& chr)
+     {
++      if (!chr) return false;
+       // locale independent
+       return chr == '.';
+     }
+@@ -77,6 +83,7 @@ namespace Sass {
+     // check if char is outside ascii range
+     bool is_unicode(const char& chr)
+     {
++      if (!chr) return false;
+       // check for unicode range
+       return unsigned(chr) > 127;
+     }
+@@ -85,6 +92,7 @@ namespace Sass {
+     // but with specific ranges (copied from Ruby Sass)
+     bool is_nonascii(const char& chr)
+     {
++      if (!chr) return false;
+       unsigned int cmp = unsigned(chr);
+       return (
+         (cmp >= 128 && cmp <= 15572911) ||
+@@ -97,6 +105,7 @@ namespace Sass {
+     // valid in a uri (copied from Ruby Sass)
+     bool is_uri_character(const char& chr)
+     {
++      if (!chr) return false;
+       unsigned int cmp = unsigned(chr);
+       return (cmp > 41 && cmp < 127) ||
+              cmp == ':' || cmp == '/';
+@@ -106,6 +115,7 @@ namespace Sass {
+     // valid for escaping (copied from Ruby Sass)
+     bool is_escapable_character(const char& chr)
+     {
++      if (!chr) return false;
+       unsigned int cmp = unsigned(chr);
+       return cmp > 31 && cmp < 127;
+     }
+@@ -113,6 +123,7 @@ namespace Sass {
+     // Match word character (look ahead)
+     bool is_character(const char& chr)
+     {
++      if (!chr) return false;
+       // valid alpha, numeric or unicode char (plus hyphen)
+       return is_alnum(chr) || is_unicode(chr) || chr == '-';
+     }
+@@ -148,7 +159,7 @@ namespace Sass {
+     const char* any_char(const char* src) { return *src ? src + 1 : src; }
+ 
+     // Match word boundary (zero-width lookahead).
+-    const char* word_boundary(const char* src) { return is_character(*src) || *src == '#' ? 0 : src; }
++    const char* word_boundary(const char* src) { return (*src && (is_character(*src) || *src == '#')) ? 0 : src; }
+ 
+     // Match linefeed /(?:\n|\r\n?)/
+     const char* re_linebreak(const char* src)
+diff --git a/src/lexer.hpp b/src/lexer.hpp
+index 5838c291c..16627d796 100644
+--- a/src/lexer.hpp
++++ b/src/lexer.hpp
+@@ -90,7 +90,7 @@ namespace Sass {
+     // Regex equivalent: /(?:x)/
+     template <char chr>
+     const char* exactly(const char* src) {
+-      return *src == chr ? src + 1 : 0;
++      return (*src && *src == chr) ? src + 1 : 0;
+     }
+ 
+     // Match the full string literal.
+@@ -99,10 +99,9 @@ namespace Sass {
+     const char* exactly(const char* src) {
+       if (str == NULL) return 0;
+       const char* pre = str;
+-      if (src == NULL) return 0;
+       // there is a small chance that the search string
+       // is longer than the rest of the string to look at
+-      while (*pre && *src == *pre) {
++      while (*src && *pre && *src == *pre) {
+         ++src, ++pre;
+       }
+       // did the matcher finish?
+@@ -115,7 +114,7 @@ namespace Sass {
+     // only define lower case alpha chars
+     template <char chr>
+     const char* insensitive(const char* src) {
+-      return *src == chr || *src+32 == chr ? src + 1 : 0;
++      return (*src && (*src == chr || *src+32 == chr)) ? src + 1 : 0;
+     }
+ 
+     // Match the full string literal.
+@@ -128,7 +127,7 @@ namespace Sass {
+       if (src == NULL) return 0;
+       // there is a small chance that the search string
+       // is longer than the rest of the string to look at
+-      while (*pre && (*src == *pre || *src+32 == *pre)) {
++      while (*src && *pre && (*src == *pre || *src+32 == *pre)) {
+         ++src, ++pre;
+       }
+       // did the matcher finish?
+@@ -139,6 +138,7 @@ namespace Sass {
+     // Regex equivalent: /[axy]/
+     template <const char* char_class>
+     const char* class_char(const char* src) {
++      if (src == NULL) return 0;
+       const char* cc = char_class;
+       while (*cc && *src != *cc) ++cc;
+       return *cc ? src + 1 : 0;
+@@ -157,7 +157,7 @@ namespace Sass {
+     // Regex equivalent: /[^axy]/
+     template <const char* neg_char_class>
+     const char* neg_class_char(const char* src) {
+-      if (*src == 0) return 0;
++      if (src == NULL) return 0;
+       const char* cc = neg_char_class;
+       while (*cc && *src != *cc) ++cc;
+       return *cc ? 0 : src + 1;
+@@ -261,7 +261,7 @@ namespace Sass {
+     // Regex equivalent: /(?:$mx)*?(?=$delim)\b/
+     template <prelexer mx, prelexer delim>
+     const char* non_greedy(const char* src) {
+-      while (!delim(src)) {
++      while (*src && !delim(src)) {
+         const char* p = mx(src);
+         if (p == src) return 0;
+         if (p == 0) return 0;
+

--- a/srcpkgs/libsass/patches/CVE-2018-11698.patch
+++ b/srcpkgs/libsass/patches/CVE-2018-11698.patch
@@ -1,0 +1,28 @@
+From d4448c9379c72815b9ed5339dd3b07628eb944fd Mon Sep 17 00:00:00 2001
+From: xzyfer <xzyfer@gmail.com>
+Date: Thu, 21 Jun 2018 22:19:06 +1000
+Subject: [PATCH] Fix invalid utf-8 error reporting
+
+Fixes #2662
+---
+ src/sass_context.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/sass_context.cpp b/src/sass_context.cpp
+index 7a0a49ce1..642f435ee 100644
+--- a/src/sass_context.cpp
++++ b/src/sass_context.cpp
+@@ -81,7 +81,12 @@ namespace Sass {
+         while (line_end && *line_end && *line_end != '\n') {
+           if (*line_end == '\n') break;
+           if (*line_end == '\r') break;
++          const char* before = line_end;
+           utf8::unchecked::next(line_end);
++          if (!utf8::is_valid(line_beg, line_end)) {
++            line_end = before;
++            break;
++          }
+         }
+         if (line_end && *line_end != 0) ++ line_end;
+         size_t line_len = line_end - line_beg;
+

--- a/srcpkgs/libsass/template
+++ b/srcpkgs/libsass/template
@@ -1,7 +1,8 @@
 # Template file for 'libsass'
 pkgname=libsass
 version=3.5.4
-revision=1
+revision=2
+patch_args="-Np1"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="C implementation of Sass CSS preprocessor"


### PR DESCRIPTION
fixes:
    - CVE-2018-11693
    - CVE-2018-11696
    - CVE-2018-11697
    - CVE-2018-11698

Remain unfixed upstream:

( CVE prefix removed to not confuse tools that grep for those values )

CVE: 2018-11499 SEVERITY: 7.5
CVE: 2018-11694 SEVERITY: 6.8