### PR TITLE
libid3tag: lots of fixes

### DIFF
--- a/srcpkgs/libid3tag/patches/CVE-2004-2779.patch
+++ b/srcpkgs/libid3tag/patches/CVE-2004-2779.patch
@@ -1,0 +1,23 @@
+diff -urNad libid3tag-0.15.1b/utf16.c /tmp/dpep.tKvO7a/libid3tag-0.15.1b/utf16.c
+--- libid3tag-0.15.1b/utf16.c	2006-01-13 15:26:29.000000000 +0100
++++ libid3tag-0.15.1b/utf16.c	2006-01-13 15:27:19.000000000 +0100
+@@ -282,5 +282,18 @@
+ 
+   free(utf16);
+ 
++  if (end == *ptr && length % 2 != 0)
++  {
++     /* We were called with a bogus length.  It should always
++      * be an even number.  We can deal with this in a few ways:
++      * - Always give an error.
++      * - Try and parse as much as we can and
++      *   - return an error if we're called again when we
++      *     already tried to parse everything we can.
++      *   - tell that we parsed it, which is what we do here.
++      */
++     (*ptr)++;
++  }
++
+   return ucs4;
+ }
+

--- a/srcpkgs/libid3tag/patches/CVE-2008-2109.patch
+++ b/srcpkgs/libid3tag/patches/CVE-2008-2109.patch
@@ -1,0 +1,11 @@
+--- a/field.c	2008-05-05 09:49:15.000000000 -0400
++++ b/field.c	2008-05-05 09:49:25.000000000 -0400
+@@ -291,7 +291,7 @@
+ 
+       end = *ptr + length;
+ 
+-      while (end - *ptr > 0) {
++      while (end - *ptr > 0 && **ptr != '\0') {
+ 	ucs4 = id3_parse_string(ptr, end - *ptr, *encoding, 0);
+ 	if (ucs4 == 0)
+ 	  goto fail;

--- a/srcpkgs/libid3tag/patches/CVE-2017-11550.patch
+++ b/srcpkgs/libid3tag/patches/CVE-2017-11550.patch
@@ -1,0 +1,29 @@
+diff -urNad libid3tag-0.15.1b~/render.c libid3tag-0.15.1b/render.c
+--- libid3tag-0.15.1b~/render.c	2004-01-23 10:41:32.000000000 +0100
++++ libid3tag-0.15.1b/render.c	2009-11-09 17:17:48.000000000 +0100
+@@ -183,18 +183,16 @@
+   end  = data + length;
+ 
+   if (ucs4) {
+-    while (*ucs4 && end - data > 0) {
++    while (*ucs4 && end - data > 0)
+       *data++ = *ucs4++;
+-
+-      if (data[-1] == '\n')
+-	data[-1] = ' ';
+-    }
+   }
+ 
+-  while (end - data > 0)
+-    *data++ = ' ';
+-
+   *data = 0;
+ 
+-  return id3_latin1_serialize(ptr, padded, 0);
++  id3_latin1_serialize(ptr, padded, 0);
++
++  if (end - data > 0)
++    id3_render_padding(ptr, 0, end - data);
++
++  return length;
+ }

--- a/srcpkgs/libid3tag/patches/CVE-2017-11551.patch
+++ b/srcpkgs/libid3tag/patches/CVE-2017-11551.patch
@@ -1,0 +1,28 @@
+diff -urNad libid3tag-0.15.1b~/compat.gperf libid3tag-0.15.1b/compat.gperf
+--- libid3tag-0.15.1b~/compat.gperf	2004-01-23 09:41:32.000000000 +0000
++++ libid3tag-0.15.1b/compat.gperf	2007-01-14 14:36:53.000000000 +0000
+@@ -236,6 +236,10 @@
+ 
+     encoding = id3_parse_uint(&data, 1);
+     string   = id3_parse_string(&data, end - data, encoding, 0);
++    if (!string)
++    {
++	continue;
++    }
+ 
+     if (id3_ucs4_length(string) < 4) {
+       free(string);
+diff -urNad libid3tag-0.15.1b~/parse.c libid3tag-0.15.1b/parse.c
+--- libid3tag-0.15.1b~/parse.c	2004-01-23 09:41:32.000000000 +0000
++++ libid3tag-0.15.1b/parse.c	2007-01-14 14:37:34.000000000 +0000
+@@ -165,6 +165,9 @@
+   case ID3_FIELD_TEXTENCODING_UTF_8:
+     ucs4 = id3_utf8_deserialize(ptr, length);
+     break;
++  default:
++  	/* FIXME: Unknown encoding! Print warning? */
++	return NULL;
+   }
+ 
+   if (ucs4 && !full) {
+

--- a/srcpkgs/libid3tag/patches/libid3tag-gperf.patch
+++ b/srcpkgs/libid3tag/patches/libid3tag-gperf.patch
@@ -1,0 +1,27 @@
+Index: libid3tag-0.15.1b/frametype.h
+===================================================================
+--- libid3tag-0.15.1b.orig/frametype.h
++++ libid3tag-0.15.1b/frametype.h
+@@ -37,6 +37,6 @@ extern struct id3_frametype const id3_fr
+ extern struct id3_frametype const id3_frametype_obsolete;
+ 
+ struct id3_frametype const *id3_frametype_lookup(register char const *,
+-						 register unsigned int);
++						 register size_t);
+ 
+ # endif
+Index: libid3tag-0.15.1b/compat.h
+===================================================================
+--- libid3tag-0.15.1b.orig/compat.h
++++ libid3tag-0.15.1b/compat.h
+@@ -34,7 +34,7 @@ struct id3_compat {
+ };
+ 
+ struct id3_compat const *id3_compat_lookup(register char const *,
+-					   register unsigned int);
++					   register size_t);
+ 
+ int id3_compat_fixup(struct id3_tag *);
+ 
+
+

--- a/srcpkgs/libid3tag/template
+++ b/srcpkgs/libid3tag/template
@@ -1,16 +1,21 @@
 # Template file for 'libid3tag'
 pkgname=libid3tag
 version=0.15.1b
-revision=7
+revision=8
+patch_args="-Np1"
 build_style=gnu-configure
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config gperf"
 makedepends="zlib-devel"
 short_desc="ID3 tag library, part of MAD (MPEG Audio Decoder)"
-homepage="http://sourceforge.net/projects/mad/"
-license="GPL-2+"
+license="GPL-2.0-or-later"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-distfiles="ftp://ftp.mars.org/pub/mpeg/$pkgname-$version.tar.gz"
+homepage="http://sourceforge.net/projects/mad/"
+distfiles="http://distfiles.exherbo.org/distfiles/libid3tag-${version}.tar.gz"
 checksum=63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151
+
+pre_configure() {
+	rm compat.c frametype.c # regenerate them with gperf
+}
 
 post_install() {
 	vinstall ${FILESDIR}/id3tag.pc 644 usr/lib/pkgconfig


### PR DESCRIPTION
fixes:
    - CVE-2004-2779.patch
    - CVE-2008-2109.patch
    - CVE-2017-11550.patch
    - CVE-2017-11551.patch

regenerate gperf values

switch to non-ftp mirror because ftp mirrors suck on Travis and
sometimes on our builders