### PR TITLE
xbps-src: Migrate from build_style for 32bit pkgs

### DIFF
--- a/common/environment/build-style/perl-ModuleBuild.sh
+++ b/common/environment/build-style/perl-ModuleBuild.sh
@@ -1,0 +1,1 @@
+lib32disabled=yes

--- a/common/environment/build-style/ruby-module.sh
+++ b/common/environment/build-style/ruby-module.sh
@@ -1,0 +1,1 @@
+lib32disabled=yes

--- a/common/hooks/pre-pkg/05-prepare-32bit.sh
+++ b/common/hooks/pre-pkg/05-prepare-32bit.sh
@@ -12,14 +12,6 @@
 hook() {
 	local destdir32=${XBPS_DESTDIR}/${pkgname}-32bit-${version}
 
-	# Do not build 32bit pkgs for:
-	#	- perl modules
-	#	- python modules
-	#	- ruby modules
-	if [[ $build_style =~ (perl|python|ruby) ]]; then
-		return
-	fi
-
 	# By default always enabled unless "lib32disabled" is set.
 	if [ -n "$lib32disabled" ]; then
 		return


### PR DESCRIPTION
This allows dxpb to have a simpler test for whether or not a 32bit
package will be built. More importantly, it makes our way of shortcutting
the 32bit package creation process easier.

I suspect -32bit packages are a "sometimes" package, and many packages
just don't end up with a -32bit package, if the correct dirs are not populated.

This is fun for me because it means there are packages that dxpb needs to look for but not depend on as being there.