### PR TITLE
rpi-kernel: update to 4.14.73.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="d35190b95c4948082882fca2a7e069a20ab67c5f"
+_githash="e117f3e9fd92ada9cd061672d261c8c9ddf2ccdc"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.72
+version=4.14.73
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=0b365320941ae6d8aa26b6c9b7b7d64e7462eefdc614b92cc845d55dac228fdc
+checksum=2f76eb236f4c0f85910a12bf2e7899fafa134f2a1711b88d3e0328219cbc79d5
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]