### PR TITLE
libwmf: make patches be explicit about what CVEs they are fixing in a greppable way.

### DIFF
--- a/srcpkgs/libwmf/patches/01_player.c-integer-overflow-cve-2006-3376.patch
+++ b/srcpkgs/libwmf/patches/01_player.c-integer-overflow-cve-2006-3376.patch
@@ -1,3 +1,5 @@
+fixes CVE-2006-3376
+
 --- src/player.c
 +++ src/player.c
 @@ -23,6 +23,7 @@

--- a/srcpkgs/libwmf/patches/04_gd-gd_clip.c-use-after-free-cve-2009-1364.patch
+++ b/srcpkgs/libwmf/patches/04_gd-gd_clip.c-use-after-free-cve-2009-1364.patch
@@ -1,3 +1,5 @@
+fixes CVE-2009-1364
+
 --- src/extra/gd/gd_clip.c
 +++ src/extra/gd/gd_clip.c
 @@ -70,6 +70,7 @@

--- a/srcpkgs/libwmf/patches/CVE-2015-0848_CVE-2015-4588_CVE-2015-4695_CVE-2015-4696.patch
+++ b/srcpkgs/libwmf/patches/CVE-2015-0848_CVE-2015-4588_CVE-2015-4695_CVE-2015-4696.patch
@@ -1,3 +1,4 @@
+fixes CVE-2015-0848 CVE-2015-4588 CVE-2015-4695 CVE-2015-4969
 --- src/player/meta.h
 +++ src/player/meta.h
 @@ -1565,7 +1565,7 @@ static int meta_rgn_create (wmfAPI* API,


### PR DESCRIPTION
@Duncaen is this kind of thing ok to merge ?