### PR TITLE
base-devel: update to 20181003.

### DIFF
--- a/srcpkgs/base-devel/template
+++ b/srcpkgs/base-devel/template
@@ -1,15 +1,16 @@
 # Template file for 'base-devel'
 pkgname=base-devel
-version=20170527
+version=20181003
 revision=1
 build_style=meta
 depends="autoconf automake bc binutils bison ed flex gcc gettext
  groff libtool m4 make patch pkg-config texinfo unzip xz"
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) depends+=" musl";;
-	*) depends+=" glibc-devel";;
-esac
 short_desc="Void Linux development tools meta package"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"
 homepage="http://www.voidlinux.eu/"
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) depends+=" musl-devel";;
+	*) depends+=" glibc-devel";;
+esac


### PR DESCRIPTION
This adds musl-devel to the depends, if my git investigation is correct this was updated to add glibc-devel and musl before musl had a corresponding musl-devel package, and only worked because gcc depends on musl-devel.

@chneukirchen