### PR TITLE
factor: update to 0.98

### DIFF
--- a/srcpkgs/factor/template
+++ b/srcpkgs/factor/template
@@ -1,34 +1,34 @@
 # Template file for 'factor'
 pkgname=factor
-version=0.97
+version=0.98
 revision=1
-only_for_archs="i686 x86_64 x86_64-musl"
+only_for_archs="i686 x86_64"
 build_style=gnu-makefile
 hostmakedepends="unzip pkg-config"
-makedepends="gtkglext-devel"
+makedepends="gtk+-devel gtkglext-devel"
+depends="gtk+-devel gtkglext-devel"
+wrksrc="factor"
 nostrip_files="a.elf"
 short_desc="Concatenative programming language, similar to Forth"
 maintainer="B. Wilson <x@wilsonb.com>"
 license="BSD-2-Clause"
 homepage="http://factorcode.org/"
 distfiles="http://downloads.factorcode.org/releases/${version}/factor-src-${version}.zip"
-checksum=fd75e765590691c89b866e5265ae16bfb36d0e28eed095702ae1e206114663b8
-
-post_extract() {
-	mv "${XBPS_BUILDDIR}/factor" "${wrksrc}"
-}
+checksum=318fb8cdf84528fce17a83f7e9d76e55292ccc779c71d180d99a6465574d3706
 
 post_build() {
 	image=''
 
 	case "${XBPS_TARGET_MACHINE}" in
-		i686*)   image='boot.unix-x86.32.image';;
-		x86_64*) image='boot.unix-x86.64.image';;
+		i686*)   image='boot.unix-x86.32.image'
+		         sse_version=0;;
+		x86_64*) image='boot.unix-x86.64.image'
+		         sse_version=20;;
 		*) return 1;;
 	esac
 
 	touch /etc/ld.so.cache
-	./factor -i="${image}"
+	./factor -i="${image}" -sse-version="${sse_version}"
 }
 
 do_install() {
@@ -45,5 +45,5 @@ do_install() {
 	ln -sr "${DESTDIR}/usr/lib/${pkgname}/factor" \
 	       "${DESTDIR}/usr/bin/factor-vm"
 
-	vlicense license.txt
+	vlicense LICENSE.txt
 }


### PR DESCRIPTION
This also fixes a problem with `depends` from version `0.97`. If it would be better to split that from the version bump, let me know.