### PR TITLE
pkgconf: prepare for replacing pkg-config

### DIFF
--- a/srcpkgs/pkg-config/template
+++ b/srcpkgs/pkg-config/template
@@ -1,7 +1,7 @@
-# Template build file for 'pkg-config'
+# Template file for 'pkg-config'
 pkgname=pkg-config
 version=0.29.2
-revision=1
+revision=2
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--with-internal-glib --disable-host-tool"
@@ -9,11 +9,22 @@ configure_args="--with-internal-glib --disable-host-tool"
 hostmakedepends="gcc"
 short_desc="System for managing library compile/link flags"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://pkgconfig.freedesktop.org/wiki/"
 license="GPL-2"
-distfiles="http://pkgconfig.freedesktop.org/releases/$pkgname-$version.tar.gz"
+homepage="http://pkgconfig.freedesktop.org/wiki/"
+distfiles="http://pkgconfig.freedesktop.org/releases/${pkgname}-${version}.tar.gz"
 checksum=6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
+alternatives="
+ pkg-config:pkg-config:/usr/bin/pkg-config.pkg-config
+ pkg-config:pkg-config.1:/usr/share/man/man1/pkg-config.1.pkg-config
+ pkg-config:pkg.m4:/usr/share/aclocal/pkg.m4.pkg-config"
 
 case "$XBPS_TARGET_MACHINE" in
 	mips*) configure_args+=" glib_cv_stack_grows=no glib_cv_uscore=no" ;;
 esac
+
+post_install() {
+	# Add pkg-config suffix to files that are on alternatives
+	mv ${DESTDIR}/usr/bin/pkg-config{,.pkg-config}
+	mv ${DESTDIR}/usr/share/man/man1/pkg-config.1{,.pkg-config}
+	mv ${DESTDIR}/usr/share/aclocal/pkg.m4{,.pkg-config}
+}

--- a/srcpkgs/pkgconf-devel
+++ b/srcpkgs/pkgconf-devel
@@ -1,1 +1,0 @@
-pkgconf

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -5,18 +5,24 @@ revision=2
 short_desc="Provides compiler and linker configuration"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT"
+checkdepends="kyua"
 homepage="https://git.dereferenced.org/pkgconf/pkgconf"
 build_style=gnu-configure # cmake and meson also available
 configure_args="--disable-shared --disable-static"
-checkdepends="kyua"
 changelog="https://git.dereferenced.org/pkgconf/pkgconf/raw/branch/master/NEWS"
 distfiles="https://distfiles.dereferenced.org/pkgconf/${pkgname}-${version}.tar.xz"
 checksum=d3468308553c94389dadfd10c4d1067269052b5364276a9d24a643c88485f715
 
+alternatives="
+ pkg-config:pkg-config:/usr/bin/pkgconf
+ pkg-config:pkg-config.1:/usr/share/man/man1/pkgconf.1
+ pkg-config:pkg.m4:/usr/share/aclocal/pkg.m4.pkgconf"
+
 post_install() {
 	vlicense COPYING
-	rm -r $DESTDIR/usr/include
-	ln -sr $DESTDIR/usr/bin/pkgconf $DESTDIR/usr/bin/pkg-config
-	ln -sr $DESTDIR/usr/share/man/man1/pkgconf.1 \
-		$DESTDIR/usr/share/man/man1/pkg-config.1
+
+	rm -rf $DESTDIR/usr/include
+
+	# Suffix file that conflicts with pkg-config
+	mv ${DESTDIR}/usr/share/aclocal/pkg.m4{,.pkgconf}
 }

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -17,4 +17,6 @@ post_install() {
 	vlicense COPYING
 	rm -r $DESTDIR/usr/include
 	ln -sr $DESTDIR/usr/bin/pkgconf $DESTDIR/usr/bin/pkg-config
+	ln -sr $DESTDIR/usr/share/man/man1/pkgconf.1 \
+		$DESTDIR/usr/share/man/man1/pkg-config.1
 }

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -11,7 +11,7 @@ build_style=gnu-configure # cmake and meson also available
 configure_args="--disable-shared --disable-static"
 changelog="https://git.dereferenced.org/pkgconf/pkgconf/raw/branch/master/NEWS"
 distfiles="https://distfiles.dereferenced.org/pkgconf/${pkgname}-${version}.tar.xz"
-checksum=d3468308553c94389dadfd10c4d1067269052b5364276a9d24a643c88485f715
+checksum=9c5864a4e08428ef52f05a41c948529555458dec6d283b50f8b7d32463c54664
 
 alternatives="
  pkg-config:pkg-config:/usr/bin/pkgconf

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -1,32 +1,20 @@
 # Template file for 'pkgconf'
 pkgname=pkgconf
 version=1.5.4
-revision=1
-conflicts="pkg-config"
-build_style=gnu-configure # cmake and meson also available
-hostmakedepends="libtool"
-checkdepends="kyua"
+revision=2
 short_desc="Provides compiler and linker configuration"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT"
 homepage="https://git.dereferenced.org/pkgconf/pkgconf"
+build_style=gnu-configure # cmake and meson also available
+configure_args="--disable-shared --disable-static"
+checkdepends="kyua"
 changelog="https://git.dereferenced.org/pkgconf/pkgconf/raw/branch/master/NEWS"
 distfiles="https://distfiles.dereferenced.org/pkgconf/${pkgname}-${version}.tar.xz"
-checksum=9c5864a4e08428ef52f05a41c948529555458dec6d283b50f8b7d32463c54664
+checksum=d3468308553c94389dadfd10c4d1067269052b5364276a9d24a643c88485f715
 
 post_install() {
 	vlicense COPYING
-}
-
-pkgconf-devel_package() {
-	depends="pkgconf-${version}_${revision}"
-	short_desc+=" - development files"
-	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove usr/share/aclocal
-		vmove usr/share/man/man7
-		vmove "usr/lib/*.so"
-		vmove "usr/lib/*.a"
-	}
+	rm -r $DESTDIR/usr/include
+	ln -sr $DESTDIR/usr/bin/pkgconf $DESTDIR/usr/bin/pkg-config
 }

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -2,13 +2,13 @@
 pkgname=pkgconf
 version=1.5.4
 revision=2
+build_style=gnu-configure # cmake and meson also available
+configure_args="--disable-shared --disable-static"
+checkdepends="kyua"
 short_desc="Provides compiler and linker configuration"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT"
-checkdepends="kyua"
 homepage="https://git.dereferenced.org/pkgconf/pkgconf"
-build_style=gnu-configure # cmake and meson also available
-configure_args="--disable-shared --disable-static"
 changelog="https://git.dereferenced.org/pkgconf/pkgconf/raw/branch/master/NEWS"
 distfiles="https://distfiles.dereferenced.org/pkgconf/${pkgname}-${version}.tar.xz"
 checksum=9c5864a4e08428ef52f05a41c948529555458dec6d283b50f8b7d32463c54664


### PR DESCRIPTION
* libpkgconf is removed.
* pkgconf-devel package is removed
* correctly conflicts with pkg-config
* set a link from /usr/bin/pkg-config to pkgconf

addresses #3391.