### PR TITLE
musl: update to 1.1.20.

### DIFF
--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=aarch64-linux-musl
@@ -10,7 +10,7 @@ _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -25,7 +25,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=arm-linux-musleabi
@@ -11,7 +11,7 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=arm-linux-musleabihf
@@ -11,7 +11,7 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=armv7l-linux-musleabihf
@@ -11,7 +11,7 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=i686-linux-musl
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -25,7 +25,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=mips-linux-musl
@@ -11,7 +11,7 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mips-linux-muslhf/template
+++ b/srcpkgs/cross-mips-linux-muslhf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=mips-linux-muslhf
@@ -11,7 +11,7 @@ _archflags="-march=mips32r2 -mhard-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for MIPS32r2 BE hardfloat target (musl)"
 maintainer="hipperson0 <hipperson0@gmail.com>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=mipsel-linux-musl
@@ -11,7 +11,7 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=mipsel-linux-muslhf
@@ -11,7 +11,7 @@ _archflags="-march=mips32r2 -mhard-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -26,7 +26,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -2,14 +2,14 @@
 #
 _binutils_version=2.29.1
 _gcc_version=8.2.0
-_musl_version=1.1.19
+_musl_version=1.1.20
 _linux_version=4.9.8
 
 _triplet=x86_64-linux-musl
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.27
+version=0.28
 revision=1
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -24,7 +24,7 @@ checksum="
  1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/musl-bootstrap/template
+++ b/srcpkgs/musl-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'musl-bootstrap'.
 pkgname=musl-bootstrap
-version=1.1.19
+version=1.1.20
 revision=1
 lib32disabled=yes
 wrksrc="musl-${version}"
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="http://www.musl-libc.org/"
 distfiles="http://www.musl-libc.org/releases/musl-${version}.tar.gz"
-checksum=db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9
+checksum=44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
 
 post_install() {
 	mv ${DESTDIR}/lib/* ${DESTDIR}/usr/lib/

--- a/srcpkgs/musl/patches/fix-race-condition.patch
+++ b/srcpkgs/musl/patches/fix-race-condition.patch
@@ -1,0 +1,54 @@
+From 0db393d3a77bb9f300a356c6a5484fc2dddb161d Mon Sep 17 00:00:00 2001
+From: Kaarle Ritvanen <kaarle.ritvanen@datakunkku.fi>
+Date: Tue, 18 Sep 2018 10:03:27 +0300
+Subject: fix race condition in file locking
+
+The condition occurs when
+- thread #1 is holding the lock
+- thread #2 is waiting for it on __futexwait
+- thread #1 is about to release the lock and performs a_swap
+- thread #3 enters the __lockfile function and manages to grab the lock
+  before thread #1 calls __wake, resetting the MAYBE_WAITERS flag
+- thread #1 calls __wake
+- thread #2 wakes up but goes again to __futexwait as the lock is
+  held by thread #3
+- thread #3 releases the lock but does not call __wake as the
+  MAYBE_WAITERS flag is not set
+
+This condition results in thread #2 not being woken up. This patch fixes
+the problem by making the woken up thread ensure that the flag is
+properly set before going to sleep again.
+
+Mainainer's note: This fixes a regression introduced in commit
+c21f750727515602a9e84f2a190ee8a0a2aeb2a1.
+---
+ src/stdio/__lockfile.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git src/stdio/__lockfile.c.orig src/stdio/__lockfile.c
+index 2ff75d8a..0dcb2a42 100644
+--- src/stdio/__lockfile.c.orig
++++ src/stdio/__lockfile.c
+@@ -8,13 +8,13 @@ int __lockfile(FILE *f)
+ 	int owner = f->lock, tid = __pthread_self()->tid;
+ 	if ((owner & ~MAYBE_WAITERS) == tid)
+ 		return 0;
+-	for (;;) {
+-		owner = a_cas(&f->lock, 0, tid);
+-		if (!owner) return 1;
+-		if (a_cas(&f->lock, owner, owner|MAYBE_WAITERS)==owner) break;
++	owner = a_cas(&f->lock, 0, tid);
++	if (!owner) return 1;
++	while ((owner = a_cas(&f->lock, 0, tid|MAYBE_WAITERS))) {
++		if ((owner & MAYBE_WAITERS) ||
++		    a_cas(&f->lock, owner, owner|MAYBE_WAITERS)==owner)
++			__futexwait(&f->lock, owner|MAYBE_WAITERS, 1);
+ 	}
+-	while ((owner = a_cas(&f->lock, 0, tid|MAYBE_WAITERS)))
+-		__futexwait(&f->lock, owner, 1);
+ 	return 1;
+ }
+ 
+-- 
+cgit v1.2.1
+

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -1,6 +1,6 @@
 # Template file for 'musl'.
 pkgname=musl
-version=1.1.19
+version=1.1.20
 revision=1
 build_style=gnu-configure
 configure_args="--prefix=/usr --disable-gcc-wrapper"
@@ -11,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="http://www.musl-libc.org/"
 distfiles="http://www.musl-libc.org/releases/musl-${version}.tar.gz"
-checksum=db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9
+checksum=44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
 
 nostrip_files="libc.so"
 shlib_provides="libc.so"


### PR DESCRIPTION
This patch is a continuation/revival of #2370, but it updates the cross toolchains too.
I could only test so much, as my T61 got quite sad when I tried to compile the cross toolchains, should be working with no problem, though.

musl and cross-arm-musleabihf build on my machine without a problem.

FYI: The actual cross bump was something like this:
```sh
for chain in cross-aarch64-linux-musl cross-arm-linux-musleabi{,hf} cross-armv7l-linux-musleabihf cross-i686-linux-musl cross-mips{,el}-linux-musl{,hf} cross-x86_64-linux-musl; do
  sed  -i 's/_musl_version=1.1.19/_musl_version=1.1.20/;s/version=0.27/version=0.28/;s/db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9/44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61/' srcpkgs/$chain/template
  git add srcpkgs/$chain
  git commit -m "$chain: update musl to 1.1.20."
done
```
Might be handy for future bumps.