### PR TITLE
rng-tools: add patch from upstream to fix rngd

### DIFF
--- a/srcpkgs/rng-tools/patches/rdrand.patch
+++ b/srcpkgs/rng-tools/patches/rdrand.patch
@@ -1,0 +1,24 @@
+This patch from upstream (https://github.com/nhorman/rng-tools/commit/f12a80185a4bbf65fbc860f2d2e25af67c70ad6b)
+will allow rngd to run. It can safely be deleted as soon as there is another upstream release.
+
+Without this patch, rngd will die with a "smashed stack" on 64-bit machines that support the RDRAND instruction.
+
+
+--- rngd_rdrand.c.orig	2018-09-25 19:54:05.000000000 +0200
++++ rngd_rdrand.c	2018-10-01 05:42:38.655982555 +0200
+@@ -246,7 +246,14 @@
+ 	if (ent_src->rng_options[DRNG_OPT_AES].int_val)
+ 		return xread_drng_with_aes(buf, size, ent_src);
+ 
+-	x86_rdrand_bytes(buf, size);
++	/* NB: x86_rdrand_bytes might overrun end of buffer, if not a multiple of 8 */
++	if (size > 7)
++		x86_rdrand_bytes(buf, (size&~7));
++	if ((size&7) != 0) {
++		unsigned char tempbuf[8];
++		x86_rdrand_bytes(tempbuf, (size&7));
++		memcpy((unsigned char *)buf+(size&~7), tempbuf, (size&7));
++	}
+ 	return 0;
+ }
+ 

--- a/srcpkgs/rng-tools/template
+++ b/srcpkgs/rng-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'rng-tools'
 pkgname=rng-tools
 version=6.5
-revision=1
+revision=2
 wrksrc=${pkgname}-${version}
 build_style=gnu-configure
 makedepends="libgcrypt-devel libsysfs-devel libcurl-devel libxml2-devel"


### PR DESCRIPTION
"rngd" currently crashes (smashed stack) on 64-bit machines that
support the RDRAND instruction, unless you expicitly disable its use.
This fixes the problem.

The next upstream release will be fixed, and this patch can then be
dispensed with.

Alternatively, forcing a revert to the prior version would work.