### PR TITLE
New package: efivar-makeguids

### DIFF
--- a/srcpkgs/efivar-makeguids/template
+++ b/srcpkgs/efivar-makeguids/template
@@ -1,0 +1,26 @@
+# Template file for 'efivar-makeguids'
+# This package builds an internal efivar tool
+# that is used for cross-compiling efivar
+# IT SHOULD BE UPDATED BEFORE EFIVAR
+pkgname=efivar-makeguids
+version=36
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config"
+short_desc="Tools to manipulate EFI variables"
+maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/rhinstaller/efivar"
+distfiles="https://github.com/rhboot/efivar/releases/download/${version}/efivar-${version}.tar.bz2"
+checksum=94bfccc20889440978a85f08d5af4619040ee199001b62588d47d676f58c0d33
+wrksrc=efivar-${version}
+build_wrksrc=src
+make_build_target=makeguids
+
+pre_build() {
+	export make_build_args="CC_FOR_BUILD=${CC}"
+}
+
+do_install() {
+	vbin makeguids efivar-makeguids
+}


### PR DESCRIPTION
Internal efivar tool needed to enable efivar cross compilation
and make UEFI tools available on non-x86 architectures.