### PR TITLE
tinyproxy: fix default config location on the runit service

### DIFF
--- a/srcpkgs/tinyproxy/files/tinyproxy/run
+++ b/srcpkgs/tinyproxy/files/tinyproxy/run
@@ -1,5 +1,4 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-install -d -m 0755 -o _tinyproxy -g _tinyproxy \
-	/var/log/tinyproxy /var/run/tinyproxy
-exec chpst -1 tinyproxy ${OPTS:=-d -c /etc/tinyproxy.conf}
+install -d -m 0755 -o _tinyproxy -g _tinyproxy /run/tinyproxy
+exec chpst -1 tinyproxy -d $OPTS

--- a/srcpkgs/tinyproxy/template
+++ b/srcpkgs/tinyproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'tinyproxy'
 pkgname=tinyproxy
 version=1.10.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-transparent --localstatedir=/var tinyproxy_cv_regex_broken=no"
 hostmakedepends="asciidoc"
@@ -13,6 +13,7 @@ distfiles="https://github.com/tinyproxy/${pkgname}/releases/download/${version}/
 checksum=59be87689c415ba0d9c9bc6babbdd3df3b372d60b21e526b118d722dbc995682
 system_accounts="_tinyproxy"
 conf_files="/etc/tinyproxy/tinyproxy.conf"
+make_dirs="/var/log/tinyproxy 755 _tinyproxy _tinyproxy"
 
 post_install() {
 	sed -i $DESTDIR/etc/tinyproxy/tinyproxy.conf \


### PR DESCRIPTION
resolves void-linux/void-packages@3491