### PR TITLE
New package: lmdb++-0.9.14.0+20160229

### DIFF
--- a/srcpkgs/lmdb++/template
+++ b/srcpkgs/lmdb++/template
@@ -1,0 +1,14 @@
+# Template file for 'lmdb++'
+pkgname=lmdb++
+version=0.9.14.0+20160229
+revision=1
+_commit=0b43ca87d8cfabba392dfe884eb1edb83874de02
+wrksrc="lmdbxx-${_commit}"
+build_style=gnu-makefile
+depends="lmdb-devel"
+short_desc="C++11 wrapper for the LMDB database library"
+maintainer="John <johnz@posteo.net>"
+license="Unlicense"
+homepage="https://github.com/drycpp/lmdbxx/"
+distfiles="https://github.com/drycpp/lmdbxx/archive/${_commit}.tar.gz"
+checksum=93721132bbf5045d38ad62de2997655e9984c48ea5c9886746d42128f4b26fbd


### PR DESCRIPTION
needed for #3256
nheko requires the latest commit, compilation fails when I try to use the release version