### PR TITLE
sddm: update to 0.18.0.

### DIFF
--- a/srcpkgs/sddm/patches/remove-consolekit-detection.patch
+++ b/srcpkgs/sddm/patches/remove-consolekit-detection.patch
@@ -1,0 +1,24 @@
+Source: Hoshpak
+Upstream: https://github.com/sddm/sddm/issues/903 and https://github.com/sddm/sddm/pull/923
+Reason: removes detection for the ConsoleKit interface because the ConsoleKit2 code path is 
+ currently broken and would cause sddm to fail to start with ConsoleKit2 present
+--- src/daemon/LogindDBusTypes.cpp	2018-10-07 17:40:49.944625726 +0200
++++ src/daemon/LogindDBusTypes.cpp	2018-10-07 17:41:01.590479575 +0200
+@@ -58,17 +58,6 @@
+         return;
+     }
+ 
+-    if (QDBusConnection::systemBus().interface()->isServiceRegistered(QStringLiteral("org.freedesktop.ConsoleKit"))) {
+-        qDebug() << "Console kit interface found";
+-        available = true;
+-        serviceName = QStringLiteral("org.freedesktop.ConsoleKit");
+-        managerPath = QStringLiteral("/org/freedesktop/ConsoleKit/Manager");
+-        managerIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Manager"); //note this doesn't match logind
+-        seatIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Seat");
+-        sessionIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.Session");
+-        userIfaceName = QStringLiteral("org.freedesktop.ConsoleKit.User");
+-        return;
+-    }
+     qDebug() << "No session manager found";
+ }
+ 

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -1,8 +1,7 @@
 # Template file for 'sddm'
 pkgname=sddm
-reverts=0.16.0_1
-version=0.15.0
-revision=3
+version=0.18.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_MAN_PAGES=1 -DNO_SYSTEMD=1 -DUSE_ELOGIND=1
  -DLOGIN_DEFS_PATH=${XBPS_SRCPKGDIR}/shadow/files/login.defs
@@ -15,7 +14,7 @@ maintainer="Michael Aldridge <maldridge@VoidLinux.eu>"
 license="GPL-2.0-or-later"
 homepage="http://github.com/sddm/sddm"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=7a84089b2e424097664bf7cfb24bdc5896ba0eebf8d54eb77bcac6d16db1e358
+checksum=9c50b6194f1b4dbf6e1a1b21f23c2c5e384871172985e192b91585986d38eec4
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" sddm qt5-host-tools qt5-qmake qt5-tools"
@@ -25,7 +24,6 @@ system_accounts="sddm"
 sddm_homedir="/var/lib/sddm"
 sddm_groups="video"
 conf_files="
- /etc/sddm.conf
  /etc/pam.d/sddm
  /etc/pam.d/sddm-greeter
  /etc/pam.d/sddm-autologin"


### PR DESCRIPTION
removes Consolekit2 detection for now to avoid using the broken Consolekit
code path.

Alternative to #3311 as discussed there. Tested on my system (sddm with Consolekit2 and lxqt), results in
```
[18:04:02.807] (II) DAEMON: No session manager found
```

An succesfully starting sddm without ConsoleKit interaction as it worked before.

@the-maldridge @maxice8 @travankor 