### PR TITLE
thunderbird: replace intl.locale.matchOS with intl.locale.requested i…

### DIFF
--- a/srcpkgs/thunderbird/files/vendor.js
+++ b/srcpkgs/thunderbird/files/vendor.js
@@ -1,5 +1,5 @@
 // Use LANG environment variable to choose locale
-pref("intl.locale.matchOS", true);
+pref("intl.locale.requested", "");
 
 // Disable default mailer checking.
 pref("mail.shell.checkDefaultMail", false);

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -4,7 +4,7 @@
 #
 pkgname=thunderbird
 version=60.2.1
-revision=1
+revision=2
 short_desc="Standalone Mail/News reader"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 homepage="https://www.thunderbird.net/"


### PR DESCRIPTION
…n vendor.js

as documented in https://bugzilla.mozilla.org/show_bug.cgi?id=1413866#c21
resolves #3527
[skip ci]

CC @Gottox 