### PR TITLE
libGL: add missing `b_ndebug` option

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,14 +1,14 @@
 # Template file for 'libGL'
 pkgname=libGL
 version=18.2.2
-revision=1
+revision=2
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dshared-glapi=true -Dgbm=true -Degl=true
  -Dgallium-vdpau=true -Dgallium-xvmc=true -Dosmesa=gallium
  -Dgles1=true -Dgles2=true -Dgallium-va=true -Dlmsensors=true
  -Dplatforms=x11,drm,wayland,surfaceless -Dllvm=true
- -Db_lto=false"
+ -Db_lto=false -Db_ndebug=true"
 hostmakedepends="flex libxml2-python llvm pkg-config
  python-Mako wayland-protocols wayland-devel"
 makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel


### PR DESCRIPTION
This removes remaining debug info and greatly improves dxvk performance.