### PR TITLE
python-pafy: switch upstream to mps-youtube

### DIFF
--- a/srcpkgs/python-pafy/template
+++ b/srcpkgs/python-pafy/template
@@ -11,8 +11,8 @@ depends="youtube-dl"
 short_desc="Python2 library to download YouTube content and retrieve metadata"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-3"
-homepage="https://github.com/np1/pafy"
-distfiles="https://github.com/np1/pafy/archive/v${version}.tar.gz"
+homepage="https://github.com/mps-youtube/pafy"
+distfiles="https://github.com/mps-youtube/pafy/archive/v${version}.tar.gz"
 checksum=a2f9fe7c6175264993190081e1558516b2f2b5987f13a581a55cd9d838df973b
 alternatives="pafy:ytdl:/usr/bin/ytdl2"
 


### PR DESCRIPTION
original upstream is dead, the repo is removed from github, mps-youtube
uses it and has adopted it.

@Asergi