### PR TITLE
ImageMagick: disable openmp on musl arches

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -3,7 +3,7 @@ pkgname=ImageMagick
 _majorver=7.0.8
 _patchver=12
 version="${_majorver}.${_patchver}"
-revision=1
+revision=2
 wrksrc="${pkgname}-${_majorver}-${_patchver}"
 build_style=gnu-configure
 configure_args="--without-autotrace --with-wmf=yes
@@ -13,8 +13,8 @@ configure_args="--without-autotrace --with-wmf=yes
  --with-dejavu-font-dir=/usr/share/fonts/TTF --enable-opencl --disable-static"
 hostmakedepends="automake libtool pkg-config"
 makedepends="djvulibre-devel fftw-devel ghostscript-devel glib-devel lcms2-devel
- libXt-devel libgomp-devel libltdl-devel librsvg-devel libwebp-devel
- libwmf-devel ocl-icd-devel pango-devel"
+ libXt-devel libltdl-devel librsvg-devel libwebp-devel libwmf-devel ocl-icd-devel
+ pango-devel"
 short_desc="Package for display and interactive manipulation of images"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="ImageMagick"
@@ -33,6 +33,17 @@ if [ -z "$CROSS_BUILD" ]; then
 	hostmakedepends+=" perl"
 	subpackages+=" libmagick-perl"
 fi
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl)
+		# https://github.com/void-linux/void-packages/issues/3649
+		# breaks php-imagick
+		configure_args+=" --disable-openmp"
+		;;
+	*)
+		makedepends+=" libgomp-devel "
+		;;
+esac
 
 pre_configure() {
 	autoreconf -if


### PR DESCRIPTION
fixes php-imagick which has this error

PHP Warning:  PHP Startup: Unable to load dynamic library 'imagick' (tried: /usr/lib/php/modules/imagick (Error loading shared library /usr/lib/php/modules/imagick: No such file or directory), /usr/lib/php/modules/imagick.so (Error relocating /lib/libgomp.so.1: __cxa_finalize: initial-exec TLS resolves to dynamic definition in /lib/libgomp.so.1)) in Unknown on line 0

resolves void-linux/void-packages#3649