### PR TITLE
New package: cups-pk-helper-0.2.6

### DIFF
--- a/srcpkgs/cups-pk-helper/template
+++ b/srcpkgs/cups-pk-helper/template
@@ -1,0 +1,13 @@
+# Template file for 'cups-pk-helper'
+pkgname=cups-pk-helper
+version=0.2.6
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config intltool glib-devel"
+makedepends="cups-devel polkit-devel libglib-devel"
+short_desc="PolicyKit helper to configure cups with fine-grained privileges"
+maintainer="Cameron Nemo <camerontnorman@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://www.freedesktop.org/wiki/Software/cups-pk-helper"
+distfiles="$FREEDESKTOP_SITE/cups-pk-helper/releases/${pkgname}-${version}.tar.xz"
+checksum=959af8f2f5a2761e7e498b61c9caf25ae963335031eae9972d999e9a0d97a228


### PR DESCRIPTION
[builds okay](https://travis-ci.org/void-linux/void-packages/builds/440532531)

[and lints okay too](https://travis-ci.org/void-linux/void-packages/builds/440541876)

the CI failures are due to errors in the bootstrap phase