### PR TITLE
zenity: add webkit build_option

### DIFF
--- a/srcpkgs/zenity/template
+++ b/srcpkgs/zenity/template
@@ -3,11 +3,17 @@ pkgname=zenity
 version=3.30.0
 revision=1
 build_style=gnu-configure
+configure_args="$(vopt_enable webkit webkitgtk)"
 hostmakedepends="gettext-devel itstool perl pkg-config"
-makedepends="gtk+3-devel libglib-devel libnotify-devel webkit2gtk-devel"
+makedepends="gtk+3-devel libglib-devel libnotify-devel $(vopt_if webkit webkit2gtk-devel)"
 short_desc="Display GNOME dialogs from the command line"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 license="LGPL-2.0-or-later"
 homepage="https://help.gnome.org/users/zenity/"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=995ef696616492c40be6da99919851d41faed6643a97c9d24743b46bc8b537f2
+
+build_options="webkit"
+build_options_default="webkit"
+
+desc_option_webkit="Enable support for webkit"


### PR DESCRIPTION
I've been using zenity without webkit for some time as it was the only package on my system that pulled in `webkit2gtk`.

I'm not using zenity with many programs so I don't know if this would be a good default, for the programs that I use it works fine without webkit/html support.