### PR TITLE
atom: update to 1.31.2

### DIFF
--- a/srcpkgs/atom/patches/electronVersion.patch
+++ b/srcpkgs/atom/patches/electronVersion.patch
@@ -1,0 +1,11 @@
+--- package.json
++++ package.json
+@@ -12,7 +12,7 @@
+     "url": "https://github.com/atom/atom/issues"
+   },
+   "license": "MIT",
+-  "electronVersion": "2.0.7",
++  "electronVersion": "2.0.11",
+   "dependencies": {
+     "@atom/nsfw": "^1.0.18",
+     "@atom/source-map-support": "^0.3.4",

--- a/srcpkgs/atom/template
+++ b/srcpkgs/atom/template
@@ -1,21 +1,27 @@
 # Template file for 'atom'
 pkgname=atom
-version=1.26.1
+version=1.31.2
 revision=1
 nocross=yes
 nostrip=yes
-hostmakedepends="git pkg-config python-devel nodejs curl gtk+ libXtst libXScrnSaver nss python alsa-lib"
-makedepends="python-devel GConf-devel libgnome-keyring-devel libX11-devel libxkbfile-devel libsecret-devel"
+hostmakedepends="git pkg-config python-devel nodejs curl gtk+3 libXtst libXScrnSaver nss python alsa-lib"
+makedepends="python-devel GConf-devel libgnome-keyring-devel gtk+3-devel libX11-devel libxkbfile-devel libsecret-devel"
 short_desc="Chrome-based text editor from Github"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://atom.io"
 distfiles="https://github.com/atom/atom/archive/v${version}.tar.gz"
-checksum=d5c2fab3f671b4162992d0baffb2393bc58e6b361aa37214dcc5c9be1e03c65f
-only_for_archs="i686 x86_64"
+checksum=baff1b23e03c638584d01817bda15503e66eff1c231c3952670c94b345588628
+only_for_archs="x86_64"
 
 do_install() {
+	npm install -g gyp
 	vmkdir /usr/share/icons/hicolor
 	script/build --install=$DESTDIR/usr
 	vlicense LICENSE.md
+}
+
+post_install() {
+	#very hackish, git-imap-send is linked to openssl's libssl/libcrypto. Removing it allows it to package
+	rm ${DESTDIR}/usr/share/atom/resources/app.asar.unpacked/node_modules/dugite/git/libexec/git-core/git-imap-send
 }


### PR DESCRIPTION
Any ideas how to properly handle the git-imap-send linking to openssl?? removing it works and doesn't seem to affect atom, but there should be a cleaner way

Also removed i686 as it is not officially supported by atom