### PR TITLE
xmonad-contrib: update to 0.15.

### DIFF
--- a/srcpkgs/xmonad-contrib/files/stack.yaml
+++ b/srcpkgs/xmonad-contrib/files/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-12.13
+packages:
+  - .
+extra-deps:
+  - xmonad-0.15

--- a/srcpkgs/xmonad-contrib/template
+++ b/srcpkgs/xmonad-contrib/template
@@ -1,18 +1,16 @@
-broken="requires xmonad>=0.14"
 # Template file for 'xmonad-contrib'
 pkgname=xmonad-contrib
-version=0.14
+version=0.15
 revision=1
 build_style=haskell-stack
-stackage=lts-11.17
 hostmakedepends="pkg-config"
-makedepends="libX11-devel libXinerama-devel libXrandr-devel libXft-devel"
+makedepends="libX11-devel libXinerama-devel libXrandr-devel libXft-devel libXScrnSaver-devel"
 short_desc="Third party extensions for xmonad"
 maintainer="xaltsc <xaltsc@protonmail.ch>"
 license="BSD-3-Clause"
 homepage="https://xmonad.org/"
 distfiles="https://hackage.haskell.org/package/${pkgname}-${version}/${pkgname}-${version}.tar.gz"
-checksum=deccbc44f19977fc860024d2eb2ff63b5856058e3b078d16c234bb05fbe0c098
+checksum=ba7686007037fc081de09fc05914fbb84cad8123e1f4eedb8895c863fcfb3e65
 
 nocross=yes
 


### PR DESCRIPTION
Please merge #2200 before merging this.

I had to use a stack.yaml in order to add the xmonad-0.15 dependency. This is most probably a temporary fix.