### PR TITLE
rust: link libc dynamic on musl

### DIFF
--- a/srcpkgs/rust/patches/link-musl-dynamically.patch
+++ b/srcpkgs/rust/patches/link-musl-dynamically.patch
@@ -47,3 +47,20 @@
  /// Configure cargo to compile the standard library, adding appropriate env vars
  /// and such.
  pub fn std_cargo(builder: &Builder,
+
+--- rustc-1.28.0-src/src/liblibc/src/unix/mod.rs.orig   2018-10-14 16:54:15.555482375 +0200
++++ rustc-1.28.0-src/src/liblibc/src/unix/mod.rs        2018-10-14 16:54:47.153240177 +0200
+@@ -276,13 +276,6 @@
+     } else if #[cfg(feature = "use_std")] {
+         // cargo build, don't pull in anything extra as the libstd dep
+         // already pulls in all libs.
+-    } else if #[cfg(target_env = "musl")] {
+-        #[cfg_attr(feature = "stdbuild",
+-                   link(name = "c", kind = "static",
+-                        cfg(target_feature = "crt-static")))]
+-        #[cfg_attr(feature = "stdbuild",
+-                   link(name = "c", cfg(not(target_feature = "crt-static"))))]
+-        extern {}
+     } else if #[cfg(target_os = "emscripten")] {
+         #[link(name = "c")]
+         extern {}

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -1,7 +1,7 @@
 # Template file for 'rust'
 pkgname=rust
 version=1.28.0
-revision=2
+revision=3
 _rust_dist_version=1.28.0
 _cargo_dist_version=0.30.0
 # NB. if you push any(!) new version, don't forget to put a build


### PR DESCRIPTION
Static linked libc causes problems when cross compiling, because targets get linked against the host libc.
This patch was used for earlier versions of rust already.