### PR TITLE
acpilight: use latest commit to fix udev rules

### DIFF
--- a/srcpkgs/acpilight/template
+++ b/srcpkgs/acpilight/template
@@ -1,16 +1,17 @@
 # Template file for 'acpilight'
 pkgname=acpilight
 version=1.1
-revision=2
-wrksrc="${pkgname}-v${version}"
+revision=3
+_commit=f54865ed9a11eedaeffa71af320a3bf36c89f15d
+wrksrc="${pkgname}-${_commit}"
 noarch=yes
 depends="python3"
 short_desc="Backward-compatibile xbacklight replacement"
 maintainer="cr6git <quark6@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/wavexx/acpilight"
-distfiles="https://gitlab.com/wavexx/acpilight/-/archive/v${version}/${pkgname}-v${version}.tar.bz2"
-checksum=0a5ef16a39c05c1eb195823d906c08f8f912aa48122b31e6dd364c7f9d6c37aa
+distfiles="https://gitlab.com/wavexx/acpilight/-/archive/${_commit}/${pkgname}-${_commit}.tar.bz2"
+checksum=f78603f2d1f64a2c32890e58b4072d1604d038c6d0d86017db3acb7a54eebe25
 replaces="xbacklight>=0"
 provides="xbacklight-${version}_${revision}"
 


### PR DESCRIPTION
replaces #3774 