### PR TITLE
Added libaom build option for ffmpeg

### DIFF
--- a/common/options.description
+++ b/common/options.description
@@ -1,6 +1,7 @@
 desc_option_aalib="Enable support for aalib video output"
 desc_option_acl="Enable support for ACLs and Extended Attributes"
 desc_option_alsa="Enable support for ALSA"
+desc_option_aom="Enable support for the AV1 codec"
 desc_option_backtrace="Enable support for backtraces via libunwind"
 desc_option_bluetooth="Enable support for bluetooth"
 desc_option_cdparanoia="Enable support for CD audio (cdparanoia)"

--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.0.2
-revision=3
+revision=4
 short_desc="Decoding, encoding and streaming software"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="GPL-3.0-or-later"
@@ -19,9 +19,9 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  ocl-icd-devel $(vopt_if x265 x265-devel) $(vopt_if vaapi libva-devel)
  $(vopt_if vdpau libvdpau-devel) $(vopt_if v4l2 v4l-utils-devel) libbs2b-devel
  libvidstab-devel $(vopt_if faac faac-devel) $(vopt_if fdk_aac fdk-aac-devel)
- $(vopt_if vpx libvpx-devel)"
+ $(vopt_if vpx libvpx-devel) $(vopt_if aom libaom-devel)"
 
-build_options="x265 v4l2 vaapi vdpau vpx faac fdk_aac"
+build_options="x265 v4l2 vaapi vdpau vpx faac fdk_aac aom"
 build_options_default="x265 v4l2 vpx"
 
 case "$XBPS_TARGET_MACHINE" in
@@ -64,7 +64,7 @@ do_configure() {
 		--enable-postproc --enable-opencl ${_args} \
 		$(vopt_if x265 '--enable-libx265' '--disable-libx265') \
 		$(vopt_if v4l2 '--enable-libv4l2' '--disable-libv4l2') \
-		$(vopt_enable vaapi) $(vopt_enable vdpau) \
+		$(vopt_enable aom libaom) $(vopt_enable vaapi) $(vopt_enable vdpau) \
 		--enable-libbs2b --enable-avresample --enable-libvidstab
 }
 do_build() {


### PR DESCRIPTION
When the `aom` build option is enabled, ffmpeg will be built with the `--enable-libaom` flag, which enables support for the AV1 codec. If considered appropriate, it could be added to the default build options as well.