### PR TITLE
python-zc.lockfile: trigger rebuild

### DIFF
--- a/srcpkgs/python-zc.lockfile/template
+++ b/srcpkgs/python-zc.lockfile/template
@@ -1,7 +1,7 @@
 # Template file for 'python-zc.lockfile'
 pkgname=python-zc.lockfile
 version=1.3.0
-revision=1
+revision=2
 noarch=yes
 wrksrc="${pkgname#*-}-${version}"
 build_style=python-module


### PR DESCRIPTION
Rebuild, as it was removed from repo by #2854.