### PR TITLE
rtkit: change username back to rtkit

### DIFF
--- a/srcpkgs/rtkit/template
+++ b/srcpkgs/rtkit/template
@@ -1,7 +1,7 @@
 # Template file for 'rtkit'
 pkgname=rtkit
 version=0.11
-revision=14
+revision=15
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="dbus-devel libcap-devel"
@@ -12,7 +12,7 @@ homepage="http://git.0pointer.de/?p=rtkit.git"
 distfiles="http://0pointer.de/public/${pkgname}-${version}.tar.xz"
 checksum=68859108cff6410901502b58365eb7607da37110a06b837762f771735f58acd0
 
-system_accounts="_rtkit"
+system_accounts="rtkit"
 _rtkit_homedir="/proc"
 
 post_install() {


### PR DESCRIPTION
In a5c06ac7c1f1a198cef17af989abe11ff5da5cb4 the template was changed to create the `_rtkit` user. This was incomplete, as rtkit still was using the `rtkit` user.

#2583 would have done the changes needed to make rtkit actually use `_rtkit`, however, it got closed.

The template as it stands now is broken for new installations as it will create `_rtkit` and then can't function because there is no `rtkit` user on the system.

cc @maxice8 

(This is just meant to bring back rtkit into a working state for now and to make people aware.)