### PR TITLE
rtkit: fix homedir of user

### DIFF
--- a/srcpkgs/rtkit/template
+++ b/srcpkgs/rtkit/template
@@ -1,7 +1,7 @@
 # Template file for 'rtkit'
 pkgname=rtkit
 version=0.11
-revision=15
+revision=16
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="dbus-devel libcap-devel"
@@ -13,7 +13,7 @@ distfiles="http://0pointer.de/public/${pkgname}-${version}.tar.xz"
 checksum=68859108cff6410901502b58365eb7607da37110a06b837762f771735f58acd0
 
 system_accounts="rtkit"
-_rtkit_homedir="/proc"
+rtkit_homedir="/proc"
 
 post_install() {
 	# DBus configuration


### PR DESCRIPTION
#3884 has set the user back to `rtkit`, but I forgot to also reset to `rtkit_homedir`.

Sorry!

@maxice8 