### PR TITLE
Remove gnome-icon-theme dependencies when not needed

### DIFF
--- a/srcpkgs/evolution/template
+++ b/srcpkgs/evolution/template
@@ -1,7 +1,7 @@
 # Template file for 'evolution'
 pkgname=evolution
 version=3.30.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DENABLE_AUTOAR=OFF -DENABLE_LIBCRYPTUI=OFF -DENABLE_GTKSPELL=OFF
  -DENABLE_TEXT_HIGHLIGHT=OFF -DENABLE_PST_IMPORT=OFF
@@ -11,7 +11,7 @@ hostmakedepends="gnome-doc-utils gobject-introspection intltool itstool
 makedepends="GConf-devel NetworkManager-devel clutter-gtk-devel enchant-devel
  evolution-data-server-devel gnome-desktop-devel gtkhtml-devel libcanberra-devel
  $(vopt_if gir libgweather-devel) libnotify-devel webkit2gtk-devel ytnef-devel"
-depends="gnome-icon-theme gnome-keyring gtkhtml"
+depends="gnome-keyring gtkhtml"
 short_desc="Integrated mail, addressbook and calendaring for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="LGPL-2.1-or-later, LGPL-3.0-or-later, GPL-2.0-or-later"

--- a/srcpkgs/gedit/template
+++ b/srcpkgs/gedit/template
@@ -1,7 +1,7 @@
 # Template file for 'gedit'
 pkgname=gedit
 version=3.30.1
-revision=2
+revision=3
 build_style=gnu-configure
 pycompile_module="gi/overrides"
 pycompile_dirs="usr/lib/gedit/plugins"
@@ -11,7 +11,7 @@ hostmakedepends="gnome-doc-utils intltool itstool pkg-config
  $(vopt_if gir 'gobject-introspection')"
 makedepends="gsettings-desktop-schemas-devel gspell-devel gtksourceview-devel
  libpeas-devel $(vopt_if gir 'python-gobject-devel')"
-depends="desktop-file-utils gsettings-desktop-schemas gnome-icon-theme
+depends="desktop-file-utils gsettings-desktop-schemas
  iso-codes"
 short_desc="A text editor for GNOME"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"

--- a/srcpkgs/system-config-printer/template
+++ b/srcpkgs/system-config-printer/template
@@ -1,7 +1,7 @@
 # Template file for 'system-config-printer'
 pkgname=system-config-printer
 version=1.5.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-udev-rules"
 make_build_args="udevhelperdir=/usr/lib/udev"
@@ -9,8 +9,8 @@ make_install_args="udevhelperdir=/usr/lib/udev udevrulesdir=/usr/lib/udev/rules.
 hostmakedepends="pkg-config intltool python3-devel xmlto desktop-file-utils"
 makedepends="glib-devel cups-devel eudev-libudev-devel libusb-devel"
 depends="python3-cups python3-dbus python3-curl python3-smbc python3-gobject
- python3-requests gir-freedesktop libnotify gtk+3 gnome-icon-theme libgnome-keyring
- polkit-gnome dconf desktop-file-utils"
+ python3-requests gir-freedesktop libnotify gtk+3 libgnome-keyring polkit-gnome
+ dconf desktop-file-utils"
 pycompile_module="cupshelpers"
 pycompile_dirs="/usr/share/system-config-printer"
 short_desc="A CUPS printer configuration tool and status applet"

--- a/srcpkgs/virt-manager/template
+++ b/srcpkgs/virt-manager/template
@@ -1,15 +1,14 @@
 # Template file for 'virt-manager'
 pkgname=virt-manager
 version=1.5.1
-revision=1
+revision=2
 noarch=yes
 nocross=yes
 build_style=python2-module
 hostmakedepends="intltool python-devel glib-devel gtk-update-icon-cache"
-depends="libosinfo python-gobject gnome-icon-theme gnome-ssh-askpass
- openbsd-netcat yajl python-gconf libvirt-python python-urlgrabber
- libxml2-python python-ipaddr gir-freedesktop libvirt-glib
- spice-gtk gtk-vnc vte3 python-requests dmidecode"
+depends="libosinfo python-gobject gnome-ssh-askpass openbsd-netcat yajl
+ python-gconf libvirt-python python-urlgrabber libxml2-python python-ipaddr
+ gir-freedesktop libvirt-glib spice-gtk gtk-vnc vte3 python-requests dmidecode"
 pycompile_dirs="/usr/share/$pkgname"
 short_desc="User interface for managing virtual machines"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"


### PR DESCRIPTION
Today most gnome-applications bring their own icons or depend on adwaita. gnome-icon-themes are quite outdated and result in ugly low resolution icons on the gnome-desktop.