### PR TITLE
[RFC] elfutils: standardize shared object handling

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -713,9 +713,9 @@ libopen-pal.so.40 libopenmpi-3.0.1_1
 libopen-rte.so.40 libopenmpi-3.0.1_1
 liboshmem.so.40 libopenmpi-3.0.1_1
 libmtp.so.9 libmtp-1.1.4_1
-libelf.so.1 libelf-0.155_1
-libdw.so.1 libelf-0.155_1
-libasm.so.1 libelf-0.155_1
+libelf.so.1 elfutils-devel-0.174_2
+libdw.so.1 elfutils-devel-0.174_2
+libasm.so.1 elfutils-devel-0.174_2
 libgtksourceview-3.0.so.1 gtksourceview-3.8.0_1
 libtalloc.so.2 talloc-2.0.1_1
 libmount.so.1 libmount-2.18_1

--- a/srcpkgs/avrdude/template
+++ b/srcpkgs/avrdude/template
@@ -1,7 +1,7 @@
 # Template file for 'avrdude'
 pkgname="avrdude"
 version=6.3
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="An utility to manipulate ROM and EEPROM of AVR microcontrollers"
 maintainer="allan <mail@may.mooo.com>"

--- a/srcpkgs/babeltrace/template
+++ b/srcpkgs/babeltrace/template
@@ -1,10 +1,10 @@
 # template file for 'babeltrace'
 pkgname=babeltrace
 version=1.5.6
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
-makedepends="libelf glib-devel popt-devel"
+makedepends="elfutils-devel glib-devel popt-devel"
 short_desc="Open source trace format converter"
 maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
 license="MIT, GPL-2.0-or-later, LGPL-2.1-or-later"

--- a/srcpkgs/bcc/template
+++ b/srcpkgs/bcc/template
@@ -1,7 +1,7 @@
 # Template file for 'bcc'
 pkgname=bcc
 version=0.7.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DREVISION=${version}"
 hostmakedepends="flex"

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -2,7 +2,7 @@
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
 version=69.0.3497.100
-revision=1
+revision=2
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 homepage="https://www.chromium.org/"

--- a/srcpkgs/dynamips/template
+++ b/srcpkgs/dynamips/template
@@ -1,7 +1,7 @@
 # Template file for 'dynamips'
 pkgname=dynamips
 version=0.2.18
-revision=1
+revision=2
 build_style=cmake
 makedepends="elfutils-devel libpcap-devel"
 depends="iouyap"

--- a/srcpkgs/elfutils/template
+++ b/srcpkgs/elfutils/template
@@ -1,7 +1,7 @@
 # Template file for 'elfutils'
 pkgname=elfutils
 version=0.174
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--program-prefix=eu-"
 hostmakedepends="automake libtool"
@@ -38,7 +38,7 @@ pre_configure() {
 libelf_package() {
 	short_desc+=" - runtime library"
 	pkg_install() {
-		vmove "usr/lib/*.so*"
+		vmove "usr/lib/*.so.*"
 		vmove usr/lib/elfutils
 	}
 }
@@ -50,5 +50,6 @@ elfutils-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/fwupdate/template
+++ b/srcpkgs/fwupdate/template
@@ -1,7 +1,7 @@
 # Template file for 'fwupdate'
 pkgname=fwupdate
 version=12
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="elfutils-devel gnu-efi-libs libefivar-devel popt-devel"

--- a/srcpkgs/glib/template
+++ b/srcpkgs/glib/template
@@ -1,7 +1,7 @@
 # Template file for 'glib'
 pkgname=glib
 version=2.58.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libelf --disable-fam --with-pcre=system --enable-static"
 hostmakedepends="automake libtool pkg-config python3 libxslt docbook-xsl"

--- a/srcpkgs/kcov/template
+++ b/srcpkgs/kcov/template
@@ -1,7 +1,7 @@
 # Template file for 'kcov'
 pkgname=kcov
 version=35
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="python pkg-config"
 makedepends="binutils-devel libcurl-devel elfutils-devel"

--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,7 +1,7 @@
 # Template file for 'libGL'
 pkgname=libGL
 version=18.2.2
-revision=3
+revision=4
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dshared-glapi=true -Dgbm=true -Degl=true

--- a/srcpkgs/libabigail/template
+++ b/srcpkgs/libabigail/template
@@ -1,7 +1,7 @@
 # Template file for 'libabigail'
 pkgname=libabigail
 version=1.4
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake cpio dpkg libtool pkg-config python3-Sphinx"
 makedepends="elfutils-devel libxml2-devel"

--- a/srcpkgs/libdwarf/template
+++ b/srcpkgs/libdwarf/template
@@ -1,7 +1,7 @@
 # Template file for 'libdwarf'
 pkgname=libdwarf
 version=20180809
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--prefix=/usr --enable-shared"
 makedepends="elfutils-devel"

--- a/srcpkgs/ltrace/template
+++ b/srcpkgs/ltrace/template
@@ -1,7 +1,7 @@
 # Template file for 'ltrace'
 pkgname=ltrace
 version=0.7.3.20160924
-revision=2
+revision=3
 _githash=82c66409c7a93ca6ad2e4563ef030dfb7e6df4d4
 wrksrc="${pkgname}-${_githash}"
 build_style=gnu-configure

--- a/srcpkgs/makedumpfile/template
+++ b/srcpkgs/makedumpfile/template
@@ -1,7 +1,7 @@
 # Template file for 'makedumpfile'
 pkgname=makedumpfile
 version=1.6.4
-revision=1
+revision=2
 makedepends="elfutils-devel zlib-devel bzip2-devel liblzma-devel lzo-devel"
 depends="perl"
 short_desc="Make a small dumpfile of kdump"

--- a/srcpkgs/prelink/template
+++ b/srcpkgs/prelink/template
@@ -1,7 +1,7 @@
 # Template file for 'prelink'
 pkgname=prelink
 version=20130503
-revision=4
+revision=5
 wrksrc=prelink
 build_style=gnu-configure
 makedepends="elfutils-devel"

--- a/srcpkgs/rmlint/template
+++ b/srcpkgs/rmlint/template
@@ -1,7 +1,7 @@
 # Template file for 'rmlint'
 pkgname=rmlint
 version=2.7.0
-revision=1
+revision=2
 build_style=scons
 hostmakedepends="pkg-config python3-Sphinx glib-devel"
 makedepends="libblkid-devel elfutils-devel json-glib-devel"

--- a/srcpkgs/rpm/template
+++ b/srcpkgs/rpm/template
@@ -1,7 +1,7 @@
 # Template file for 'rpm'
 pkgname=rpm
 version=4.14.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-lua --with-cap --with-acl --with-external-db
  --enable-python PYTHON=python2"

--- a/srcpkgs/sysdig/template
+++ b/srcpkgs/sysdig/template
@@ -1,7 +1,7 @@
 # Template file for 'sysdig'
 pkgname=sysdig
 version=0.24.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DSYSDIG_VERSION=${version} -DUSE_BUNDLED_DEPS=OFF
  -DUSE_BUNDLED_B64=ON -DUSE_BUNDLED_JQ=ON -DBUILD_DRIVER=OFF"

--- a/srcpkgs/systemtap/template
+++ b/srcpkgs/systemtap/template
@@ -1,7 +1,7 @@
 # Template file for 'systemtap'
 pkgname=systemtap
 version=3.3
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="python"
 makedepends="elfutils-devel"

--- a/srcpkgs/uftrace/template
+++ b/srcpkgs/uftrace/template
@@ -1,7 +1,7 @@
 # Template file for 'uftrace'
 pkgname=uftrace
 version=0.9
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pandoc pkg-config"
 makedepends="elfutils-devel ncurses-devel"


### PR DESCRIPTION
Previously, elfutils did not follow the widely used convention of installing shared objects with version number attached in the `lib$NAME` subpackage. This brings elfutils in sync with the rest of `srcpkgs/*`.