### PR TITLE
kicad: rebuild against boost-1.68.0

### DIFF
--- a/srcpkgs/kicad/template
+++ b/srcpkgs/kicad/template
@@ -1,7 +1,7 @@
 # Template file for 'kicad'
 pkgname=kicad
 version=5.0.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DKICAD_BUILD_VERSION=${version} -DKICAD_SCRIPTING=ON
 -DKICAD_SCRIPTING_MODULES=ON -DKICAD_SCRIPTING_WXPYTHON=ON


### PR DESCRIPTION
kicad seems to link only for arm architectures against boost and therefore I missed it.

```
Inconsistent shlibs:
  libboost_atomic.so.1.65.1 (provided by: boost; used by: kicad)
```

[ci skip]