### PR TITLE
librime: rebuild against boost-1.68.0_1

### DIFF
--- a/srcpkgs/librime/template
+++ b/srcpkgs/librime/template
@@ -1,7 +1,7 @@
-# Template file for 'rime'
+# Template file for 'librime'
 pkgname=librime
 version=1.3.1
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DENABLE_LOGGING=Off -DBUILD_TEST=Off"
 wrksrc="librime-rime-${version}"


### PR DESCRIPTION
The librime revbump accidentally  got dropped while rebasing the boost branch.