### PR TITLE
xorg-server: fix libfbdevhw

### DIFF
--- a/srcpkgs/xorg-server/patches/fix-libfbdevhw.patch
+++ b/srcpkgs/xorg-server/patches/fix-libfbdevhw.patch
@@ -1,0 +1,26 @@
+source upstream master:
+
+Misplaced parenthesis caused us to compare the sizeof,
+not the readlink return value.
+https://gitlab.freedesktop.org/xorg/xserver/commit/bd5fe7593fd0df236f3b2be1f062166ddba7d67c
+
+ensure the readlink buffer is null-terminated
+https://gitlab.freedesktop.org/xorg/xserver/commit/71703e4e8bd00719eefad53c2ed6c604079f87ea
+
+--- hw/xfree86/fbdevhw/fbdevhw.c.orig
++++ hw/xfree86/fbdevhw/fbdevhw.c
+@@ -331,12 +331,12 @@
+ 
+     /* only touch non-PCI devices on this path */
+     {
+-        char buf[PATH_MAX];
++        char buf[PATH_MAX] = {0};
+         char *sysfs_path = NULL;
+         char *node = strrchr(dev, '/') + 1;
+ 
+         if (asprintf(&sysfs_path, "/sys/class/graphics/%s", node) < 0 ||
+-            readlink(sysfs_path, buf, sizeof(buf) < 0) ||
++            readlink(sysfs_path, buf, sizeof(buf) - 1) < 0 ||
+             strstr(buf, "devices/pci")) {
+             free(sysfs_path);
+             close(fd);

--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=1.20.2
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb


### PR DESCRIPTION
When using e.g. xf86-video-fbturbo on the Raspberry Pi X fails to start saying no screens found. Other devices using fbdevhw should be affected, too.

The problems lies in `hw/xfree86/fbdevhw/fbdevhw.c` and was introduced here:
https://gitlab.freedesktop.org/xorg/xserver/commit/fc78bcca21e767697de6ad4d8e03b6728856f613

It has been fixed in upstream/master shortly after the 1.20.2 release:
https://gitlab.freedesktop.org/xorg/xserver/commit/bd5fe7593fd0df236f3b2be1f062166ddba7d67c
https://gitlab.freedesktop.org/xorg/xserver/commit/71703e4e8bd00719eefad53c2ed6c604079f87ea

Tested on armv7l-musl. X with fbturbo works as it should again.