### PR TITLE
gatling: add patch for libowfat-0.32.

### DIFF
--- a/srcpkgs/gatling/template
+++ b/srcpkgs/gatling/template
@@ -12,7 +12,7 @@ distfiles="https://www.fefe.de/gatling/$pkgname-$version.tar.xz"
 checksum=6fa329d0ced0c80deb8dde5460e9d9e984bee94f265043d7fdec0e253dce9aa4
 make_build_target="gatling dl getlinks"
 make_install_args="prefix=/usr MANDIR=/usr/share/man"
-CFLAGS+=" -std=c99"
+CFLAGS+=" -std=c99 -I${XBPS_CROSS_BASE}/usr/include/libowfat"
 
 pre_install() {
 	vmkdir usr/share/man/man1


### PR DESCRIPTION
libowfat headers now live in `<libowfat/*>`