### PR TITLE
Rebuild packages for missing metadata

### DIFF
--- a/srcpkgs/atomicparsley/template
+++ b/srcpkgs/atomicparsley/template
@@ -1,11 +1,11 @@
-# Template file for 'atomicparsley'.
+# Template file for 'atomicparsley'
 pkgname=atomicparsley
 version=0.9.0
-revision=2
+revision=3
 hostmakedepends="unzip"
 short_desc="Lightweight program for manipulating MPEG-4 metadata"
 maintainer="svenper <svenper@users.noreply.github.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://atomicparsley.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/AtomicParsley-source-${version}.zip"
 checksum=de83f219f95e6fe59099b277e3ced86f0430ad9468e845783092821dff15a72e

--- a/srcpkgs/dosfstools/template
+++ b/srcpkgs/dosfstools/template
@@ -1,15 +1,15 @@
 # Template file for 'dosfstools'
 pkgname=dosfstools
 version=4.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-compat-symlinks"
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="DOS filesystem tools"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-3.0-or-later"
 homepage="https://github.com/dosfstools/dosfstools"
-license="GPL-3"
 distfiles="https://github.com/$pkgname/$pkgname/releases/download/v$version/${pkgname}-${version}.tar.xz"
 checksum=e6b2aca70ccc3fe3687365009dd94a2e18e82b688ed4e260e04b7412471cc173
 

--- a/srcpkgs/drawterm/template
+++ b/srcpkgs/drawterm/template
@@ -1,7 +1,7 @@
 # Template file for 'drawterm'
 pkgname=drawterm
 version=0.0.20170121
-revision=1
+revision=2
 _hghash=a5098deb5e1c
 makedepends="libX11-devel libXt-devel"
 short_desc="Connect to Plan 9 CPU servers from other operating systems"

--- a/srcpkgs/dssi/template
+++ b/srcpkgs/dssi/template
@@ -1,7 +1,7 @@
 # Template file for 'dssi'
 pkgname=dssi
 version=1.1.1
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="

--- a/srcpkgs/dvdauthor/template
+++ b/srcpkgs/dvdauthor/template
@@ -1,9 +1,9 @@
 # Template file for 'dvdauthor'
-pkgname="dvdauthor"
-version="0.7.2"
-revision=1
-build_style=gnu-configure
+pkgname=dvdauthor
+version=0.7.2
+revision=2
 wrksrc="${pkgname}"
+build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libpng-devel freetype-devel fribidi-devel libxml2-devel libdvdnav-devel"
 short_desc="DVD authoring tools, generate a DVD movie from MPEG2 stream"

--- a/srcpkgs/ebook-tools/template
+++ b/srcpkgs/ebook-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'ebook-tools'
 pkgname=ebook-tools
 version=0.2.2
-revision=2
+revision=3
 build_style=cmake
 makedepends="libxml2-devel libzip-devel"
 short_desc="Tools for accessing and converting various ebook file formats"

--- a/srcpkgs/ed/template
+++ b/srcpkgs/ed/template
@@ -1,12 +1,12 @@
 # Template file for 'ed'
 pkgname=ed
 version=1.14.2
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="lzip"
 short_desc="GNU Line-oriented text editor"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/ed/ed.html"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.lz"
 checksum=f57962ba930d70d02fc71d6be5c5f2346b16992a455ab9c43be7061dec9810db

--- a/srcpkgs/fbxkb/template
+++ b/srcpkgs/fbxkb/template
@@ -1,13 +1,12 @@
-# Template for fbxkb
-
-pkgname="fbxkb"
-version="0.6"
-revision=1
+# Template file for 'fbxkb'
+pkgname=fbxkb
+version=0.6
+revision=2
 build_style=configure
-short_desc="Lightweight X keyboard layout indicator, uses GTK+2"
-maintainer="Pavel Kiselev <kispash@yandex.ru>"
 hostmakedepends="pkg-config"
 makedepends="xorg-server-devel gtk+-devel"
+short_desc="Lightweight X keyboard layout indicator, uses GTK+2"
+maintainer="Pavel Kiselev <kispash@yandex.ru>"
 license="MIT"
 homepage="http://fbxkb.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tgz"

--- a/srcpkgs/jeti-filemanager/template
+++ b/srcpkgs/jeti-filemanager/template
@@ -1,13 +1,13 @@
 # Template file for 'jeti-filemanager'
 pkgname=jeti-filemanager
 version=2.0.1
-revision=1
+revision=2
 build_style=gnu-makefile
-homepage="https://github.com/mrshampoo/jeti-filemanager/"
 makedepends="ncurses-devel"
 short_desc="Total Commander filemanager ncurses clone"
 maintainer="Harri Leino <mr.leino@gmail.com>"
 license="GPL-3"
+homepage="https://github.com/mrshampoo/jeti-filemanager/"
 distfiles="https://github.com/mrshampoo/jeti-filemanager/archive/${version}.tar.gz"
 checksum=4da4ddee8fe6774b91ea473810d6c6898777c9bbcb8816996d72095dc0e18691
 

--- a/srcpkgs/kbd/template
+++ b/srcpkgs/kbd/template
@@ -1,7 +1,7 @@
 # Template file for 'kbd'
 pkgname=kbd
 version=2.0.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/kbd --localedir=/usr/share/kbd/locale"
 hostmakedepends="automake libtool gettext-devel flex pkg-config"
@@ -9,7 +9,7 @@ makedepends="pam-devel"
 depends="kbd-data"
 short_desc="Linux keyboard utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.kbd-project.org/"
 distfiles="${KERNEL_SITE}/utils/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=5fd90af6beb225a9bb9b9fb414c090fba53c9a55793e172f508cd43652e59a88

--- a/srcpkgs/libdiscid/template
+++ b/srcpkgs/libdiscid/template
@@ -1,19 +1,19 @@
 # Template file for 'libdiscid'
 pkgname=libdiscid
 version=0.6.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 short_desc="A Library for creating MusicBrainz DiscIDs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="LGPL-2.1-or-later"
 homepage="http://musicbrainz.org/doc/libdiscid"
 distfiles="http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/${pkgname}-${version}.tar.gz"
 checksum=f9e443ac4c0dd4819c2841fcc82169a46fb9a626352cdb9c7f65dd3624cd31b9
 
 libdiscid-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
-	short_desc+=" -- development files"
+	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig

--- a/srcpkgs/libgadu/template
+++ b/srcpkgs/libgadu/template
@@ -1,14 +1,14 @@
 # Template file for 'libgadu'
 pkgname=libgadu
 version=1.12.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-c99-vsnprintf"
 hostmakedepends="automake libtool pkg-config perl protobuf-c"
 makedepends="gnutls-devel libcurl-devel expat-devel libxml2-devel zlib-devel"
 short_desc="Gadu-Gadu instant messaging protocol library"
 maintainer="Jürgen Buchüller <pullmoll@t-online.de>"
-license="LGPL-2.1"
+license="LGPL-2.1-only"
 homepage="https://www.wasilczyk.pl/en/projects/libgadu/"
 distfiles="https://github.com/wojtekka/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=f53e703d7ad93ce222dbf7fc0cec77f62813af38817a3678e799e91f1c69c94d

--- a/srcpkgs/lxappearance/template
+++ b/srcpkgs/lxappearance/template
@@ -1,7 +1,7 @@
 # Template file for 'lxappearance'
 pkgname=lxappearance
 version=0.6.3
-revision=1
+revision=2
 build_style=gnu-configure
 build_options="gtk3 dbus"
 build_options_default="dbus"
@@ -10,8 +10,8 @@ hostmakedepends="pkg-config intltool"
 makedepends="$(vopt_if gtk3 gtk+3-devel gtk+-devel) $(vopt_if dbus dbus-glib-devel)"
 depends="desktop-file-utils"
 short_desc="LXDE Theme Switcher"
-homepage="http://lxde.org/"
-license="GPL-2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
+homepage="http://lxde.org/"
 distfiles="${SOURCEFORGE_SITE}/lxde/${pkgname}-${version}.tar.xz"
 checksum=7222d858b8fef4b7967c42142d61e82ded6dd42dc5ef1d59caad775795928b38

--- a/srcpkgs/lxpanel/template
+++ b/srcpkgs/lxpanel/template
@@ -1,7 +1,7 @@
 # Template file for 'lxpanel'
 pkgname=lxpanel
 version=0.9.3
-revision=2
+revision=3
 lib32disabled=yes
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
@@ -11,7 +11,7 @@ makedepends="
 depends="lxmenu-data"
 short_desc="LXDE Standard panel"
 homepage="http://lxde.org/"
-license="GPL-2"
+license="GPL-2.0-or-later"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="${SOURCEFORGE_SITE}/lxde/${pkgname}-${version}.tar.xz"
 checksum=342cfa205f255acf69c76ba0ca6c77c890f3955a879b755931c80ffae4d98fb1

--- a/srcpkgs/lxtask/template
+++ b/srcpkgs/lxtask/template
@@ -1,14 +1,14 @@
 # Template file for 'lxtask'
 pkgname=lxtask
 version=0.1.8
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="gtk+-devel"
 depends="desktop-file-utils"
 short_desc="LXDE Task Manager"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://lxde.org/"
 distfiles="${SOURCEFORGE_SITE}/lxde/${pkgname}-${version}.tar.xz"
 checksum=dfb443805f72857b5ad711d4bb862a9cd3db0cd2df16d0c24f23ed679b0bef40

--- a/srcpkgs/m4/template
+++ b/srcpkgs/m4/template
@@ -1,7 +1,7 @@
 # Template file for 'm4'
 pkgname=m4
 version=1.4.18
-revision=1
+revision=2
 patch_args="-Np1"
 bootstrap=yes
 replaces="chroot-m4>=0"
@@ -9,7 +9,7 @@ build_style=gnu-configure
 configure_args="--enable-changeword --enable-threads"
 short_desc="GNU version of UNIX m4 macro language processor"
 homepage="https://www.gnu.org/software/m4/"
-license="GPL-3"
+license="GPL-3.0-or-later"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=f2c1e86ca0a404ff281631bdc8377638992744b175afb806e25871a24a934e07

--- a/srcpkgs/mktorrent/template
+++ b/srcpkgs/mktorrent/template
@@ -1,13 +1,13 @@
 # Template file for 'mktorrent'
 pkgname=mktorrent
 version=1.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="USE_OPENSSL=1"
 makedepends="libressl-devel"
 short_desc="Simple command line utility to create BitTorrent metainfo files"
 maintainer="Georg Schabel <gescha@posteo.de>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/Rudde/mktorrent"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=d0f47500192605d01b5a2569c605e51ed319f557d24cfcbcb23a26d51d6138c9

--- a/srcpkgs/nkf/template
+++ b/srcpkgs/nkf/template
@@ -1,12 +1,12 @@
 # Template file for 'nkf'
 pkgname=nkf
 version=2.1.4
-revision=1
+revision=2
 build_style=gnu-makefile
 make_install_args="prefix=\${DESTDIR}/usr"
 short_desc="Yet another kanji code converter"
 maintainer="Kazuho Sakoda <hyonhyoro.kazuho@gmail.com>"
-license="zlib"
+license="Zlib"
 homepage="https://ja.osdn.net/projects/nkf/"
 distfiles="http://osdn.dl.osdn.jp/nkf/64158/${pkgname}-${version}.tar.gz"
 checksum=b4175070825deb3e98577186502a8408c05921b0c8ff52e772219f9d2ece89cb

--- a/srcpkgs/parcellite/template
+++ b/srcpkgs/parcellite/template
@@ -1,14 +1,14 @@
 # Template file for 'parcellite'
 pkgname=parcellite
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake intltool gettext-devel glib-devel pkg-config"
 makedepends="gtk+-devel"
 depends="desktop-file-utils"
 short_desc="GTK+ clipboard manager"
 maintainer="Thomas Adam <thomas.adam22@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://parcellite.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/parcellite/${version}/parcellite-${version}.tar.gz"
 checksum=aba1c7c56c7607e219ce9855723eefa552c5376982891aefbfb5a2d3297ef046

--- a/srcpkgs/pelican/template
+++ b/srcpkgs/pelican/template
@@ -1,7 +1,7 @@
 # Template file for 'pelican'
 pkgname=pelican
 version=3.7.1
-revision=1
+revision=2
 noarch=yes
 build_style=python2-module
 pycompile_module="pelican"
@@ -11,7 +11,11 @@ depends="python-setuptools python-feedgenerator python-Jinja2 python-Pygments
  python-dateutil"
 short_desc="Static site generator written in Python"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://getpelican.com/"
 license="AGPL-3"
+homepage="http://getpelican.com/"
 distfiles="${PYPI_SITE}/p/pelican/pelican-${version}.tar.gz"
 checksum=2a5347fe47464ee743bff99b6e81d1b5823f2e70e7be5bd6ed66a5bdd5f3578b
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/perl-LWP-Protocol-https/template
+++ b/srcpkgs/perl-LWP-Protocol-https/template
@@ -1,17 +1,17 @@
-# Template build file for 'perl-LWP-Protocol-https'.
+# Template file for 'perl-LWP-Protocol-https'
 pkgname=perl-LWP-Protocol-https
 version=6.07
-revision=1
+revision=2
+noarch="yes"
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="${hostmakedepends} perl-IO-Socket-SSL perl-Mozilla-CA perl-Net-HTTP perl-LWP"
-checkdepends="perl-Test-RequiresInternet"
 depends="${makedepends}"
-noarch="yes"
+checkdepends="perl-Test-RequiresInternet"
 short_desc="LWP::Protocol::https - Provide https support for LWP::UserAgent"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/LWP-Protocol-https"
-license="Artistic, GPL-1"
-distfiles="${CPAN_SITE}/LWP/${pkgname/perl-/}-$version.tar.gz"
+distfiles="${CPAN_SITE}/LWP/${pkgname/perl-/}-${version}.tar.gz"
 checksum=522cc946cf84a1776304a5737a54b8822ec9e79b264d0ba0722a70473dbfb9e7

--- a/srcpkgs/perl-Log-Log4perl/template
+++ b/srcpkgs/perl-Log-Log4perl/template
@@ -1,7 +1,8 @@
-# Template build file for 'perl-Log-Log4perl'
+# Template file for 'perl-Log-Log4perl'
 pkgname=perl-Log-Log4perl
 version=1.49
-revision=1
+revision=2
+noarch=yes
 wrksrc="Log-Log4perl-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,8 +10,7 @@ makedepends="perl"
 depends="perl"
 short_desc="Log::Log4perl - Log4j implementation for Perl"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Log-Log4perl"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Log/Log-Log4perl-${version}.tar.gz"
 checksum=b739187f519146cb6bebcfc427c64b1f4138b35c5f4c96f46a21ed4a43872e16
-noarch=yes

--- a/srcpkgs/polkit-qt/template
+++ b/srcpkgs/polkit-qt/template
@@ -1,16 +1,16 @@
 # Template file for 'polkit-qt'
 pkgname=polkit-qt
 version=0.112.0
-revision=3
+revision=4
+wrksrc="polkit-qt-1-$version"
 build_style=cmake
 hostmakedepends="pkg-config automoc4 git"
 makedepends="polkit-devel qt-devel"
 short_desc="Qt-style PolicyKit API"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.0-or-later"
 homepage="https://projects.kde.org/projects/kdesupport/polkit-qt-1"
-license="LGPL-2.1"
-wrksrc="polkit-qt-1-$version"
-distfiles="http://download.kde.org/stable/apps/KDE4.x/admin/polkit-qt-1-${version}.tar.bz2"
+distfiles="${KDE_SITE}/apps/KDE4.x/admin/polkit-qt-1-${version}.tar.bz2"
 checksum=67fb03bf6ca3e0bdbd98d374dfb5b1651a07d17ae6c23e11a81b4b084447e7c6
 
 if [ -n "$CROSS_BUILD" ]; then

--- a/srcpkgs/puddletag/template
+++ b/srcpkgs/puddletag/template
@@ -1,7 +1,7 @@
 # Template file for 'puddletag'
 pkgname=puddletag
 version=1.2.0
-revision=1
+revision=2
 noarch=yes
 build_wrksrc=source
 build_style=python2-module
@@ -10,7 +10,7 @@ hostmakedepends="python-devel"
 depends="mutagen python-PyQt4 python-parsing python-configobj python-musicbrainzngs"
 short_desc="MP3 tagging GUI"
 maintainer="allan <mail@may.mooo.com>"
-license="GPL-2"
+license="GPL-3.0-or-later"
 homepage="http://puddletag.sourceforge.net"
-distfiles=https://github.com/keithgg/puddletag/archive/v${version}.tar.gz
+distfiles="https://github.com/keithgg/puddletag/archive/v${version}.tar.gz"
 checksum=95e4867fd04c5349f19de1b5f3c1f2336d3b66da08c076fb175ef8f7589dc80d

--- a/srcpkgs/python-pyx/template
+++ b/srcpkgs/python-pyx/template
@@ -1,7 +1,7 @@
 # Template file for 'python-pyx'
 pkgname=python-pyx
 version=0.12.1
-revision=2
+revision=3
 noarch=yes
 wrksrc="PyX-${version}"
 build_style=python2-module
@@ -10,7 +10,7 @@ hostmakedepends="python-setuptools"
 depends="python texlive-bin"
 short_desc="Python library for the creation of PostScript and PDF files"
 maintainer="cipr3s <cipr3s@gmx.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://pyx.sourceforge.net"
 distfiles="${PYPI_SITE}/p/pyx/pyx-${version}.tar.gz"
 checksum=e837b26a8b1c27524cf3f3dd6c0d563451249159edaa2e366d87e7143a867e8e

--- a/srcpkgs/python-urlgrabber/template
+++ b/srcpkgs/python-urlgrabber/template
@@ -1,7 +1,7 @@
 # Template file for 'python-urlgrabber'
 pkgname=python-urlgrabber
 version=3.10.2
-revision=1
+revision=2
 noarch=yes
 wrksrc="urlgrabber-${version}"
 build_style=python2-module
@@ -9,8 +9,8 @@ pycompile_module="urlgrabber"
 hostmakedepends="python-devel"
 depends="python-curl"
 short_desc="High-level cross-protocol url-grabber (Python2)"
-homepage="http://urlgrabber.baseurl.org/"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
+homepage="http://urlgrabber.baseurl.org/"
 distfiles="http://urlgrabber.baseurl.org/download/urlgrabber-${version}.tar.gz"
 checksum=53691185e3d462bb0fa8db853a205ee79cdd4089687cddd22cabb8b3d4280142

--- a/srcpkgs/qtchooser/template
+++ b/srcpkgs/qtchooser/template
@@ -2,7 +2,7 @@
 pkgname=qtchooser
 reverts=20150315_2
 version=63
-revision=1
+revision=2
 _commit=g13a3d08
 wrksrc="qtchooser-$version-$_commit"
 build_style=gnu-makefile
@@ -16,6 +16,11 @@ checksum=ce436e8df1d18ee0510b4815b2543226b2ee97e34ed843fd80e13616ef568416
 
 do_build() {
 	make CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LFLAGS="$LDFLAGS"
+}
+
+do_check() {
+	# uses qmake managed by qtchooser: dependency loop
+	:
 }
 
 do_install() {

--- a/srcpkgs/radamsa/template
+++ b/srcpkgs/radamsa/template
@@ -1,7 +1,7 @@
 # Template file for 'radamsa'
 pkgname=radamsa
 version=0.5
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="Test case generator for robustness testing"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/rdfind/template
+++ b/srcpkgs/rdfind/template
@@ -1,12 +1,12 @@
 # Template file for 'rdfind'
 pkgname=rdfind
 version=1.3.5
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="nettle-devel"
 short_desc="A program that finds duplicate files"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://rdfind.pauldreik.se"
 distfiles="http://rdfind.pauldreik.se/rdfind-${version}.tar.gz"
 checksum=c36e0a1ea35b06ddf1d3d499de4c2e4287984ae47c44a8512d384ecea970c344

--- a/srcpkgs/run-mailcap/template
+++ b/srcpkgs/run-mailcap/template
@@ -1,7 +1,7 @@
 # Template file for 'run-mailcap'
-pkgname="run-mailcap"
-version="3.60"
-revision=2
+pkgname=run-mailcap
+version=3.60
+revision=3
 short_desc="Execute programs via entries in the mailcap file"
 maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="Public Domain"

--- a/srcpkgs/shared-color-targets/template
+++ b/srcpkgs/shared-color-targets/template
@@ -1,7 +1,7 @@
 # Template file for 'shared-color-targets'
 pkgname=shared-color-targets
 version=0.1.7
-revision=1
+revision=2
 noarch=yes
 build_style=gnu-configure
 short_desc="Shared color targets for creating color profiles"

--- a/srcpkgs/swig/template
+++ b/srcpkgs/swig/template
@@ -1,14 +1,14 @@
 # Template file for 'swig'
 pkgname=swig
 version=3.0.12
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-pcre-prefix=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="bison"
 makedepends="zlib-devel pcre-devel"
 short_desc="Simplified Wrapper and Interface Generator"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-3.0-or-later"
 homepage="http://www.swig.org"
-license="GPL-3"
-distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/swig/swig-${version}.tar.gz"
 checksum=7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d

--- a/srcpkgs/tuxc/template
+++ b/srcpkgs/tuxc/template
@@ -1,7 +1,7 @@
 # Template file for 'tuxc'
 pkgname=tuxc
 version=1.1
-revision=1
+revision=2
 build_style="gnu-makefile"
 hostmakedepends="pkg-config"
 makedepends="lua-devel"

--- a/srcpkgs/vile/template
+++ b/srcpkgs/vile/template
@@ -1,7 +1,7 @@
 # Template file for 'vile'
 pkgname=vile
 version=9.8s
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-stripping"
 hostmakedepends="flex"

--- a/srcpkgs/xfce4-netload-plugin/template
+++ b/srcpkgs/xfce4-netload-plugin/template
@@ -1,13 +1,13 @@
 # Template file for 'xfce4-netload-plugin'
 pkgname=xfce4-netload-plugin
 version=1.3.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="xfce4-panel-devel"
 short_desc="A netload plugin for the Xfce panel"
 maintainer="Alexander Mamay <alexander@mamay.su>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://goodies.xfce.org/projects/panel-plugins/xfce4-netload-plugin"
 distfiles="https://archive.xfce.org/src/panel-plugins/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
 checksum=99762781099d1e0ab9aa6a7b30c2bd94d8f658dbe61c760410d5d42d0766391c

--- a/srcpkgs/xfce4-systemload-plugin/template
+++ b/srcpkgs/xfce4-systemload-plugin/template
@@ -1,13 +1,13 @@
 # Template file for 'xfce4-systemload-plugin'
 pkgname=xfce4-systemload-plugin
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="xfce4-panel-devel"
 short_desc="A system load plugin for the Xfce4 panel"
 maintainer="Alexander Mamay <alexander@mamay.su>"
-license="2-clause-BSD"
+license="BSD-2-Clause"
 homepage="https://goodies.xfce.org/projects/panel-plugins/xfce4-systemload-plugin"
 distfiles="https://archive.xfce.org/src/panel-plugins/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
 checksum=2bf7d0802534a1eb2e9f251af2bb97abc3f58608c1f01511d302c06111d34812

--- a/srcpkgs/xiccd/template
+++ b/srcpkgs/xiccd/template
@@ -1,13 +1,13 @@
 # Template file for 'xiccd'
 pkgname=xiccd
 version=0.2.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="libX11-devel libXrandr-devel glib-devel colord-devel"
 short_desc="Simple bridge between colord and X"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/agalakhov/xiccd"
 distfiles="https://github.com/agalakhov/xiccd/archive/v${version}.tar.gz"
 checksum=9bf45ade74fad4fa1509769e3111cbc921b2651acfceea144e7bb07b69bbf7bd

--- a/srcpkgs/xtitle/template
+++ b/srcpkgs/xtitle/template
@@ -1,7 +1,7 @@
 # Template file for 'xtitle'
 pkgname=xtitle
 version=0.4.3
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="libxcb-devel xcb-util-devel xcb-util-wm-devel"
 short_desc="Outputs X window titles"

--- a/srcpkgs/xtrlock/template
+++ b/srcpkgs/xtrlock/template
@@ -1,14 +1,14 @@
 # Template file for 'xtrlock'
 pkgname=xtrlock
 version=3.4
-revision=1
+revision=2
 wrksrc="xtrlock-pam-${version}"
 build_style=configure
 hostmakedepends="pkg-config python"
 makedepends="libX11-devel pam-devel"
 short_desc="PAM based X11 screen locker"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/aanatoly/xtrlock-pam"
 distfiles="https://github.com/aanatoly/xtrlock-pam/archive/${version}.tar.gz"
 checksum=dcc4b37a1ec303a99c9ef96412f6ba875f0c06355cdfdf4605a2a0a9e144c5d2

--- a/srcpkgs/ykneomgr/template
+++ b/srcpkgs/ykneomgr/template
@@ -1,14 +1,14 @@
 # Template file for 'ykneomgr'
 pkgname=ykneomgr
 version=0.1.8
-revision=3
+revision=4
 wrksrc="libykneomgr-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config gengetopt help2man"
 makedepends="pcsclite-devel libzip-devel zlib-devel"
 short_desc="Yubikey NEO Manager"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="LGPL-3"
+license="LGPL-3.0-or-later"
 homepage="https://developers.yubico.com/libykneomgr/"
 distfiles="https://developers.yubico.com/libykneomgr/Releases/libykneomgr-${version}.tar.gz"
 checksum=2749ef299a1772818e63c0ff5276f18f1694f9de2137176a087902403e5df889


### PR DESCRIPTION
This is a proposition to rebuild packages for complement missing metadata in *-repodata indexes in order to make them suitable to use by Repology, so Void Linux could be finally added there.

All packages was build on x86_64, x86_64-musl, armv7hf and aarch64-musl and passed check stage on x86_64 and x86_64-musl. Nothing was tested manually whether it still works.

564 more packages remain to rebuild.

[ci skip]