### PR TITLE
xfce4-terminal: depend on gsettings-desktop-schemas

### DIFF
--- a/srcpkgs/xfce4-terminal/template
+++ b/srcpkgs/xfce4-terminal/template
@@ -1,11 +1,11 @@
 # Template file for 'xfce4-terminal'
 pkgname=xfce4-terminal
 version=0.8.7.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="intltool pkg-config"
 makedepends="exo-devel vte3-devel"
-depends="desktop-file-utils hicolor-icon-theme"
+depends="desktop-file-utils hicolor-icon-theme gsettings-desktop-schemas"
 short_desc="A modern terminal emulator primarly for the Xfce desktop environment"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
xfce4-terminal crashed when setting certain options,
complaining about missing xorg.gnome.desktop.<...>