### PR TITLE
icdiff: add python{,3}-setuptools to depends

### DIFF
--- a/srcpkgs/icdiff/template
+++ b/srcpkgs/icdiff/template
@@ -1,13 +1,13 @@
 # Template file for 'icdiff'
 pkgname=icdiff
 version=1.9.4
-revision=1
+revision=2
 wrksrc="${pkgname}-release-${version}"
 noarch=yes
 build_style=python-module
 pycompile_module="icdiff.py"
 hostmakedepends="python-setuptools python3-setuptools"
-depends="python"
+depends="python python-setuptools"
 short_desc="Improved colored diff (Python2)"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
 license="Python-2.0"
@@ -26,7 +26,7 @@ post_install() {
 
 python3-icdiff_package() {
 	noarch=yes
-	depends="python3"
+	depends="python3 python3-setuptools"
 	pycompile_module="icdiff.py"
 	alternatives="
 	 icdiff:icdiff:/usr/bin/icdiff3


### PR DESCRIPTION
icdiff does not run without setuptools.