### PR TITLE
wlroots: missing dependencies

### DIFF
--- a/srcpkgs/wlroots/template
+++ b/srcpkgs/wlroots/template
@@ -12,6 +12,7 @@ makedepends="elogind-devel libcap-devel wayland-devel wayland-protocols
  libxcb-devel xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel
  xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel
  xcb-util-errors-devel xcb-util-xrm-devel"
+depends="elogind"
 short_desc="Module Wayland compositor library"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="MIT"
@@ -24,7 +25,8 @@ post_install() {
 }
 
 wlroots-devel_package() {
-	depends="wlroots-${version}_${revision}"
+	depends="wlroots-${version}_${revision} libcap-devel elogind-devel
+	 wayland-devel libinput-devel libxkbcommon-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/wlroots/template
+++ b/srcpkgs/wlroots/template
@@ -1,7 +1,7 @@
 # Template file for 'wlroots'
 pkgname=wlroots
 version=0.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dlibcap=enabled -Dlogind=enabled -Dlogind-provider=elogind
  -Dxcb-errors=enabled -Dxcb-icccm=enabled -Dxcb-xkb=enabled -Dxwayland=enabled


### PR DESCRIPTION
Missing dependencies for wlroots-devel. You can see them by installing it and running "pkg-config wlroots --cflags --libs". Otherwise, it won't run correctly.

elogind is needed on distributions which don't have systemd.