### PR TITLE
nvidia: 'altdir' build-option to install shlibs to opt/lib/nvidia

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -17,8 +17,9 @@ short_desc="${_desc} - Libraries and Utilities"
 depends="nvidia-gtklibs-${version}_${revision} nvidia-dkms-${version}_${revision} pkg-config"
 conflicts="catalyst>=0 xserver-abi-video>24_1"
 
-build_options="glvnd"
+build_options="glvnd altdir"
 desc_option_glvnd="Add support for NVIDIA's GL Vendor Neutral Dispatch implementation"
+desc_option_altdir="Install shlibs to alternate directory, so it's possible to install alongside the liGL* drivers"
 build_options_default="glvnd"
 
 if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
@@ -52,109 +53,111 @@ do_install() {
 	# X driver
 	vinstall nvidia_drv.so 755 usr/lib/xorg/modules/drivers
 
+	install_dir=$(vopt_if altdir opt/lib/nvidia usr/lib)
+
 	# GLX extension module for X
-	vinstall libglx.so.${version} 755 usr/lib/xorg/modules/extensions
-	ln -sf libglx.so.${version} ${DESTDIR}/usr/lib/xorg/modules/extensions/libglx.so
+	vinstall libglx.so.${version} 755 $(vopt_if altdir opt/lib/nvidia usr/lib/xorg/modules/extensions)
+	ln -sf libglx.so.${version} ${DESTDIR}$(vopt_if altdir /opt/lib/nvidia/libglx.so /usr/lib/xorg/modules/extensions/libglx.so)
 
 	# GLX client libs
 	if [ "${build_option_glvnd}" ]; then
 		# ----- Also provided by the libglvnd package (todo)
-		vinstall libGL.so.1.7.0 755 usr/lib
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
+		vinstall libGL.so.1.7.0 755 ${install_dir}
+		ln -sf libGL.so.1.7.0 ${DESTDIR}/${install_dir}/libGL.so
+		ln -sf libGL.so.1.7.0 ${DESTDIR}/${install_dir}/libGL.so.1
 
-		vinstall libGLX.so.0 755 usr/lib
-		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
+		vinstall libGLX.so.0 755 ${install_dir}
+		ln -sf libGLX.so.0 ${DESTDIR}/${install_dir}/libGLX.so
 		# --------------------------------------------------
 
 		# Required for GLVND option
-		vinstall libGLX_nvidia.so.${version} 755 usr/lib
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
+		vinstall libGLX_nvidia.so.${version} 755 ${install_dir}
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/${install_dir}/libGLX_nvidia.so.0
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/${install_dir}/libGLX_indirect.so.0
 	else
-		vinstall libGL.so.${version} 755 usr/lib
-		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so.1
+		vinstall libGL.so.${version} 755 ${install_dir}
+		ln -sf libGL.so.${version} ${DESTDIR}/${install_dir}/libGL.so
+		ln -sf libGL.so.${version} ${DESTDIR}/${install_dir}/libGL.so.1
 
 		# Not required for non-GLVND option but recommended
 		# more info: https://devtalk.nvidia.com/default/topic/915640/multiple-glx-client-libraries-in-the-nvidia-linux-driver-installer-package/
-		vinstall libGLX_nvidia.so.${version} 755 usr/lib
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
+		vinstall libGLX_nvidia.so.${version} 755 ${install_dir}
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/${install_dir}/libGLX_nvidia.so.0
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/${install_dir}/libGLX_indirect.so.0
 
 	fi
 
 	# OpenGL core library
-	vinstall libnvidia-glcore.so.${version} 755 usr/lib
-	vinstall libnvidia-eglcore.so.${version} 755 usr/lib
-	vinstall libnvidia-glsi.so.${version} 755 usr/lib
+	vinstall libnvidia-glcore.so.${version} 755 ${install_dir}
+	vinstall libnvidia-eglcore.so.${version} 755 ${install_dir}
+	vinstall libnvidia-glsi.so.${version} 755 ${install_dir}
 
 	# EGL
 	# ----- Also provided by the libglvnd package (todo)
-	vinstall libOpenGL.so.0 755 usr/lib
-	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
+	vinstall libOpenGL.so.0 755 ${install_dir}
+	ln -sf libOpenGL.so.0 ${DESTDIR}/${install_dir}/libOpenGL.so
 
-	vinstall libGLdispatch.so.0 755 usr/lib
+	vinstall libGLdispatch.so.0 755 ${install_dir}
 
-	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
+	vinstall libGLESv1_CM.so.1.2.0 755 ${install_dir}
+	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/${install_dir}/libGLESv1_CM.so
+	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/${install_dir}/libGLESv1_CM.so.1
 
-	vinstall libGLESv2.so.2.1.0 755 usr/lib
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
+	vinstall libGLESv2.so.2.1.0 755 ${install_dir}
+	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/${install_dir}/libGLESv2.so
+	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/${install_dir}/libGLESv2.so.2
 
-	vinstall libnvidia-egl-wayland.so.1.0.2 755 usr/lib
-	ln -sf libnvidia-egl-wayland.so.1.0.2 ${DESTDIR}/usr/lib/libnvidia-egl-wayland.so.1
+	vinstall libnvidia-egl-wayland.so.1.0.2 755 ${install_dir}
+	ln -sf libnvidia-egl-wayland.so.1.0.2 ${DESTDIR}/${install_dir}/libnvidia-egl-wayland.so.1
 
 	vinstall 10_nvidia.json 755 usr/share/glvnd/egl_vendor.d
 	vinstall 10_nvidia_wayland.json 755 usr/share/egl/egl_external_platform.d
 	# --------------------------------------------------
 
-	vinstall libEGL.so.1.1.0 755 usr/lib
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
+	vinstall libEGL.so.1.1.0 755 ${install_dir}
+	ln -sf libEGL.so.1.1.0 ${DESTDIR}/${install_dir}/libEGL.so
+	ln -sf libEGL.so.1.1.0 ${DESTDIR}/${install_dir}/libEGL.so.1
 
-	vinstall libEGL_nvidia.so.${version} 755 usr/lib
-	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/usr/lib/libEGL_nvidia.so.0
+	vinstall libEGL_nvidia.so.${version} 755 ${install_dir}
+	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/${install_dir}/libEGL_nvidia.so.0
 
-	vinstall libGLESv1_CM_nvidia.so.${version} 755 usr/lib
-	ln -sf libGLESv1_CM_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLESv1_CM_nvidia.so.1
+	vinstall libGLESv1_CM_nvidia.so.${version} 755 ${install_dir}
+	ln -sf libGLESv1_CM_nvidia.so.${version} ${DESTDIR}/${install_dir}/libGLESv1_CM_nvidia.so.1
 
-	vinstall libGLESv2_nvidia.so.${version} 755 usr/lib
-	ln -sf libGLESv2_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLESv2_nvidia.so.2
+	vinstall libGLESv2_nvidia.so.${version} 755 ${install_dir}
+	ln -sf libGLESv2_nvidia.so.${version} ${DESTDIR}/${install_dir}/libGLESv2_nvidia.so.2
 
 	# Thread Local Storage
-	vinstall tls/libnvidia-tls.so.${version} 755 usr/lib
+	vinstall tls/libnvidia-tls.so.${version} 755 ${install_dir}
 
 	# VDPAU
-	vinstall libvdpau_nvidia.so.${version} 755 usr/lib/vdpau
-	ln -sf libvdpau_nvidia.so.${version} ${DESTDIR}/usr/lib/vdpau/libvdpau_nvidia.so.1
+	vinstall libvdpau_nvidia.so.${version} 755 ${install_dir}/vdpau
+	ln -sf libvdpau_nvidia.so.${version} ${DESTDIR}/${install_dir}/vdpau/libvdpau_nvidia.so.1
 
 	# misc libraries
-	vinstall libnvidia-cfg.so.${version} 755 usr/lib
-	ln -sf libnvidia-cfg.so.${version} ${DESTDIR}/usr/lib/libnvidia-cfg.so
-	ln -sf libnvidia-cfg.so.${version} ${DESTDIR}/usr/lib/libnvidia-cfg.so.1
+	vinstall libnvidia-cfg.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-cfg.so.${version} ${DESTDIR}/${install_dir}/libnvidia-cfg.so
+	ln -sf libnvidia-cfg.so.${version} ${DESTDIR}/${install_dir}/libnvidia-cfg.so.1
 
-	vinstall libnvidia-ml.so.${version} 755 usr/lib
-	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/usr/lib/libnvidia-ml.so
-	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/usr/lib/libnvidia-ml.so.1
+	vinstall libnvidia-ml.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/${install_dir}/libnvidia-ml.so
+	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/${install_dir}/libnvidia-ml.so.1
 
-	vinstall libnvidia-encode.so.${version} 755 usr/lib
-	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/usr/lib/libnvidia-encode.so
-	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/usr/lib/libnvidia-encode.so.1
+	vinstall libnvidia-encode.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/${install_dir}/libnvidia-encode.so
+	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/${install_dir}/libnvidia-encode.so.1
 
-	vinstall libnvidia-ifr.so.${version} 755 usr/lib
-	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/usr/lib/libnvidia-ifr.so
-	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/usr/lib/libnvidia-ifr.so.1
+	vinstall libnvidia-ifr.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/${install_dir}/libnvidia-ifr.so
+	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/${install_dir}/libnvidia-ifr.so.1
 
-	vinstall libnvidia-fbc.so.${version} 755 usr/lib
-	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/usr/lib/libnvidia-fbc.so
-	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/usr/lib/libnvidia-fbc.so.1
+	vinstall libnvidia-fbc.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/${install_dir}/libnvidia-fbc.so
+	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/${install_dir}/libnvidia-fbc.so.1
 
-	vinstall libnvidia-fatbinaryloader.so.${version} 755 usr/lib
-	ln -sf libnvidia-fatbinaryloader.so.${version} ${DESTDIR}/usr/lib/libnvidia-fatbinaryloader.so.1
-	ln -sf libnvidia-fatbinaryloader.so.1 ${DESTDIR}/usr/lib/libnvidia-fatbinaryloader.so
+	vinstall libnvidia-fatbinaryloader.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-fatbinaryloader.so.${version} ${DESTDIR}/${install_dir}/libnvidia-fatbinaryloader.so.1
+	ln -sf libnvidia-fatbinaryloader.so.1 ${DESTDIR}/${install_dir}/libnvidia-fatbinaryloader.so
 
 	# CUDA
 	vbin nvidia-cuda-mps-control
@@ -162,17 +165,17 @@ do_install() {
 	gzip -d nvidia-cuda-mps-control.1.gz
 	vman nvidia-cuda-mps-control.1
 
-	vinstall libcuda.so.${version} 755 usr/lib
-	ln -sf libcuda.so.${version} ${DESTDIR}/usr/lib/libcuda.so
-	ln -sf libcuda.so.${version} ${DESTDIR}/usr/lib/libcuda.so.1
+	vinstall libcuda.so.${version} 755 ${install_dir}
+	ln -sf libcuda.so.${version} ${DESTDIR}/${install_dir}/libcuda.so
+	ln -sf libcuda.so.${version} ${DESTDIR}/${install_dir}/libcuda.so.1
 
-	vinstall libnvcuvid.so.${version} 755 usr/lib
-	ln -sf libnvcuvid.so.${version} ${DESTDIR}/usr/lib/libnvcuvid.so
-	ln -sf libnvcuvid.so.${version} ${DESTDIR}/usr/lib/libnvcuvid.so.1
+	vinstall libnvcuvid.so.${version} 755 ${install_dir}
+	ln -sf libnvcuvid.so.${version} ${DESTDIR}/${install_dir}/libnvcuvid.so
+	ln -sf libnvcuvid.so.${version} ${DESTDIR}/${install_dir}/libnvcuvid.so.1
 
-	vinstall libnvidia-ptxjitcompiler.so.${version} 755 usr/lib
-	ln -sf libnvidia-ptxjitcompiler.so.${version} ${DESTDIR}/usr/lib/libnvidia-ptxjitcompiler.so.1
-	ln -sf libnvidia-ptxjitcompiler.so.1 ${DESTDIR}/usr/lib/libnvidia-ptxjitcompiler.so
+	vinstall libnvidia-ptxjitcompiler.so.${version} 755 ${install_dir}
+	ln -sf libnvidia-ptxjitcompiler.so.${version} ${DESTDIR}/${install_dir}/libnvidia-ptxjitcompiler.so.1
+	ln -sf libnvidia-ptxjitcompiler.so.1 ${DESTDIR}/${install_dir}/libnvidia-ptxjitcompiler.so
 
 	# nvidia-xconfig
 	vbin nvidia-xconfig
@@ -189,8 +192,8 @@ do_install() {
 		-e 's:__PIXMAP_PATH__:/usr/share/pixmaps:' \
 		-i ${DESTDIR}/usr/share/applications/nvidia-settings.desktop
 
-	vinstall libnvidia-gtk3.so.${version} 755 usr/lib
-	vinstall libnvidia-gtk2.so.${version} 755 usr/lib
+	vinstall libnvidia-gtk3.so.${version} 755 ${install_dir}
+	vinstall libnvidia-gtk2.so.${version} 755 ${install_dir}
 
 	# application profiles (needed by nvidia-settings)
 	vinstall nvidia-application-profiles-${version}-key-documentation 644 usr/share/nvidia
@@ -218,13 +221,13 @@ do_install() {
 	# opencl pkg
 	vinstall nvidia.icd 644 etc/OpenCL/vendors
 
-	vinstall libnvidia-compiler.so.${version} 755 usr/lib
+	vinstall libnvidia-compiler.so.${version} 755 ${install_dir}
 
-	vinstall libnvidia-opencl.so.${version} 755 usr/lib
+	vinstall libnvidia-opencl.so.${version} 755 ${install_dir}
 	ln -sf libnvidia-opencl.so.${version} \
-		${DESTDIR}/usr/lib/libnvidia-opencl.so
+		${DESTDIR}/${install_dir}/libnvidia-opencl.so
 	ln -sf libnvidia-opencl.so.${version} \
-		${DESTDIR}/usr/lib/libnvidia-opencl.so.1
+		${DESTDIR}/${install_dir}/libnvidia-opencl.so.1
 
 	# vulkan icd
 	vinstall nvidia_icd.json 644 usr/share/vulkan/icd.d
@@ -260,17 +263,31 @@ do_install() {
 
 nvidia-gtklibs_package() {
 	short_desc="${_desc} - GTK+ libraries"
-	pkg_install() {
-		vmove usr/lib/lib*gtk*.so*
-	}
+	if [ "${build_option_altdir}" ]
+	then
+		pkg_install() {
+			vmove opt/lib/nvidia/lib*gtk*.so*
+		}
+	else
+		pkg_install() {
+			vmove usr/lib/lib*gtk*.so*
+		}
+	fi
 }
 nvidia-libs_package() {
 	short_desc="${_desc} - common libraries"
-	provides="libEGL-${version}_${revision} libGL-${version}_${revision} libGLES-${version}_${revision}"
-	replaces="libEGL>=0 libGL>=0 libGLES>=0"
-	pkg_install() {
-		vmove usr/lib
-	}
+	if [ "${build_option_altdir}" ]
+	then
+		pkg_install() {
+			vmove opt/lib/nvidia
+		}
+	else
+		provides="libEGL-${version}_${revision} libGL-${version}_${revision} libGLES-${version}_${revision}"
+		replaces="libEGL>=0 libGL>=0 libGLES>=0"
+		pkg_install() {
+			vmove usr/lib
+		}
+	fi
 }
 nvidia-dkms_package() {
 	short_desc="${_desc} - DKMS kernel module"
@@ -286,8 +303,14 @@ nvidia-opencl_package() {
 	short_desc="${_desc} - OpenCL implementation"
 	depends="libOpenCL"
 	pkg_install() {
-		vmove "usr/lib/libnvidia-compiler*"
-		vmove "usr/lib/libnvidia-opencl*"
+		if [ "${build_option_altdir}" ]
+		then
+			vmove "opt/lib/nvidia/libnvidia-compiler*"
+			vmove "opt/lib/nvidia/libnvidia-opencl*"
+		else
+			vmove "usr/lib/libnvidia-compiler*"
+			vmove "usr/lib/libnvidia-opencl*"
+		fi
 		vmove etc/OpenCL
 	}
 }


### PR DESCRIPTION
A build option shouldn't be too intrusive, and being able to have both the libGL* packages shlibs, and the nvidia ones is really useful for Optimus laptops