### PR TITLE
qbittorrent: don't compile with c++11

### DIFF
--- a/srcpkgs/qbittorrent/patches/cpp14-x11.patch
+++ b/srcpkgs/qbittorrent/patches/cpp14-x11.patch
@@ -1,0 +1,39 @@
+diff -ru build-x11.orig/src/src.pro build-x11/src/src.pro
+Fix a SEGFAULT in qbittorrent when opening with existing torrents 
+or when adding a new torrent.
+qbittorrent is compiled using -std=c++11 but boost and libtorrent-rasterbar 
+are compiled with whatever gcc uses as default and that seems to have switched
+recently to c++14 in Void.
+However switching below option to c++14 actually adds the 
+compile flag -std=g++1y which is a gnu variant of c++14 I am not sure if that
+causes another trouble later.
+Let's just mimic what the other packages do: do not set the support level 
+and let the compiler handle it.
+PS: src/CMakeList.txt sets the support level based on compiler support but Void
+builds using qmake instead of cmake.
+see also https://github.com/qbittorrent/qBittorrent/issues/9485
+--- build-x11.orig/src/src.pro	2018-10-24 16:22:14.256256510 +0200
++++ build-x11/src/src.pro	2018-10-24 16:50:50.260499780 +0200
+@@ -2,9 +2,6 @@
+ TEMPLATE = app
+ CONFIG += qt thread silent
+ 
+-# C++11 support
+-CONFIG += c++11
+-
+ # Platform specific configuration
+ win32: include(../winconf.pri)
+ macx: include(../macxconf.pri)
+diff -ru build-nox.orig/src/src.pro build-nox/src/src.pro
+--- build-nox.orig/src/src.pro	2018-10-24 16:22:14.256256510 +0200
++++ build-nox/src/src.pro	2018-10-24 16:50:50.260499780 +0200
+@@ -2,9 +2,6 @@
+ TEMPLATE = app
+ CONFIG += qt thread silent
+ 
+-# C++11 support
+-CONFIG += c++11
+-
+ # Platform specific configuration
+ win32: include(../winconf.pri)
+ macx: include(../macxconf.pri)

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
 version=4.1.3
-revision=2
+revision=3
 create_wrksrc=yes
 build_style=qmake
 hostmakedepends="automake libtool pkg-config qt5-host-tools qt5-tools"


### PR DESCRIPTION
fixes https://github.com/void-linux/void-packages/issues/4124

This change should fix building a proper qbittorrent on Void

The fix simply removes using C++11 standard when compiling qbittorrent.
If a user still has a problem then they may have to clean bad .fastresumes files in $HOME/.local/share/data/qBittorrent/BT_backup/
https://github.com/qbittorrent/qBittorrent/issues/9485#issuecomment-422382421

More info can be found at https://github.com/qbittorrent/qBittorrent/issues/9485

I have not tested qbitorrent-nox myself.

tagging as requested: @maxice8