### PR TITLE
rustup: don't conflict with rust

### DIFF
--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,7 +1,7 @@
 # Template file for 'rustup'
 pkgname=rustup
 version=1.14.0
-revision=2
+revision=3
 wrksrc="${pkgname}.rs-${version}"
 build_style=cargo
 configure_args="--features no-self-update --bin rustup-init"
@@ -14,13 +14,8 @@ homepage="https://www.rustup.rs"
 distfiles="https://github.com/rust-lang-nursery/${pkgname}.rs/archive/${version}.tar.gz"
 checksum=ab125d9b12bf0f3f7e7ad98e826035fa1ae3dbe6ba8b78be4c82f9cde00bc59f
 
-conflicts="rust cargo"
-
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init rustup
-	for cmd in cargo rust-gdb rust-lldb rustc rustdoc; do
-		ln -s rustup ${DESTDIR}/usr/bin/${cmd}
-	done
 
 	if ! [ "$CROSS_BUILD" ]; then
 		# generate shell completions


### PR DESCRIPTION
We don't need the symlinks in /usr/bin because rustup
sets PATH to include the downloaded binaries.