### PR TITLE
rpi-kernel: update to 4.14.78.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="3f8c1fd4b21a317e7329d4c8f67ac34d886e08c2"
+_githash="af3ff2aed7d3d8991296d882febff75418ab6f83"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.76
+version=4.14.78
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=9df5b6ab77ecb2498e9d2e1382602e9d8fbf2cdac7b6332154e6b68d9c077323
+checksum=9fdc3cff1d02e34b59b2162ba2643e41f293838f68c1a7151724ae5eac25a69e
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]