### PR TITLE
libconfig: revbump

### DIFF
--- a/srcpkgs/libconfig/template
+++ b/srcpkgs/libconfig/template
@@ -1,7 +1,7 @@
 # Template file for 'libconfig'
 pkgname=libconfig
 version=1.7.2
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake byacc flex libtool"
 short_desc="C Configuration File Library"


### PR DESCRIPTION
Revbump rebuild with switched off gcc4 c++abi compat to stop weird errors.
 https://forum.voidlinux.org/t/weird-linker-error-with-libconfig/7157/2?u=cardinal