### PR TITLE
ansible: update to 2.7.1

### DIFF
--- a/srcpkgs/ansible/template
+++ b/srcpkgs/ansible/template
@@ -1,6 +1,6 @@
 # Template file for 'ansible'
 pkgname=ansible
-version=2.7.0
+version=2.7.1
 revision=1
 noarch=yes
 build_style=python3-module
@@ -13,12 +13,11 @@ maintainer="Michael Aldridge <maldridge@VoidLinux.eu>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 distfiles="https://releases.ansible.com/ansible/${pkgname}-${version}.tar.gz"
-checksum=a1ab8e0f13e79a20661ad6546f45a142afeaeb664deb2c290e32362d8ae5b618
+checksum=e7953472347fcc6dca10839111b576a9f790e00056344f2dcf448e6c452fe939
 
 post_install() {
-	for f in examples/*; do
-		vsconf ${f}
-	done
+	vsconf examples/ansible.cfg
+	vsconf examples/hosts
 	for m in docs/man/man1/*.1; do
 		vman ${m}
 	done


### PR DESCRIPTION
I changed
```bash
	for f in examples/*; do
		vsconf ${f}
	done
```
For
```bash
        vsconf examples/ansible.cfg
	vsconf examples/hosts
```

Because build was failing on post_install section:
```
changing mode of /destdir//ansible-2.7.1/usr/bin/ansible-inventory to 755
changing mode of /destdir//ansible-2.7.1/usr/bin/ansible to 755
changing mode of /destdir//ansible-2.7.1/usr/bin/ansible-vault to 755
=> ansible-2.7.1_1: running post_install ...
/usr/bin/install: omitting directory 'examples/scripts'
=> ERROR: ansible-2.7.1_1: post_install: 'install -Dm${mode} "${file}" "${_destdir}/${targetdir}/${file##*/}"' exited with 1
=> ERROR:   in _vinstall() at common/environment/setup/install.sh:166
=> ERROR:   in _noglob_helper() at common/environment/setup/install.sh:12
=> ERROR:   in _vsconf() at common/environment/setup/install.sh:126
=> ERROR:   in _noglob_helper() at common/environment/setup/install.sh:12
=> ERROR:   in post_install() at srcpkgs/ansible/template:20
```