### PR TITLE
system-config-printer: add missing dependency on libsecret

### DIFF
--- a/srcpkgs/system-config-printer/template
+++ b/srcpkgs/system-config-printer/template
@@ -1,7 +1,7 @@
 # Template file for 'system-config-printer'
 pkgname=system-config-printer
 version=1.5.11
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-udev-rules"
 make_build_args="udevhelperdir=/usr/lib/udev"
@@ -10,7 +10,7 @@ hostmakedepends="pkg-config intltool python3-devel xmlto desktop-file-utils"
 makedepends="glib-devel cups-devel eudev-libudev-devel libusb-devel"
 depends="python3-cups python3-dbus python3-curl python3-smbc python3-gobject
  python3-requests gir-freedesktop libnotify gtk+3 libgnome-keyring polkit-gnome
- dconf desktop-file-utils"
+ dconf desktop-file-utils libsecret"
 pycompile_module="cupshelpers"
 pycompile_dirs="/usr/share/system-config-printer"
 short_desc="A CUPS printer configuration tool and status applet"


### PR DESCRIPTION
Please reference this forum post:
https://forum.voidlinux.org/t/solved-system-config-printer-problems/7152