### PR TITLE
shlibs: remove webkitgtk2 shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -543,9 +543,7 @@ libpsl.so.5 libpsl-0.20.2_1
 libsoup-2.4.so.1 libsoup-2.34.0_1
 libsoup-gnome-2.4.so.1 libsoup-gnome-2.34.0_1
 libunique-3.0.so.0 libunique-2.91.4_1
-libwebkitgtk-1.0.so.0 webkitgtk2-2.4.8_2
 libwebkit2gtk-4.0.so.37 webkit2gtk-2.6.2_1
-libjavascriptcoregtk-1.0.so.0 webkitgtk2-2.4.8_2
 libjavascriptcoregtk-4.0.so.18 webkit2gtk-2.6.2_1
 libgimp-2.0.so.0 libgimp-2.10.0_1
 libgimpwidgets-2.0.so.0 libgimp-2.10.0_1

--- a/srcpkgs/webkitgtk2
+++ b/srcpkgs/webkitgtk2
@@ -1,1 +1,0 @@
-webkitgtk

--- a/srcpkgs/webkitgtk2-devel
+++ b/srcpkgs/webkitgtk2-devel
@@ -1,1 +1,0 @@
-webkitgtk


### PR DESCRIPTION
was removed on 977f88d9e0dcd9cabc8d18e5d34332c74e85b5ea