### PR TITLE
rakudo: update to 2018.10

### DIFF
--- a/srcpkgs/nqp/template
+++ b/srcpkgs/nqp/template
@@ -1,6 +1,6 @@
 # Template file for 'nqp'
 pkgname=nqp
-version=2018.09
+version=2018.10
 revision=1
 build_style=configure
 make_check_target=test
@@ -8,11 +8,11 @@ configure_script="perl Configure.pl"
 configure_args="--prefix=/usr --backends=moar"
 hostmakedepends="perl"
 makedepends="MoarVM"
-depends="MoarVM"
+depends="MoarVM-${version}_${revision}"
 short_desc="Not Quite Perl, a lightweight Perl 6-like environment for VMs"
 maintainer="Ruslan <axetwe@gmail.com>"
 license="Artistic-2.0"
 homepage="https://github.com/perl6/nqp"
-distfiles="https://rakudo.perl6.org/downloads/$pkgname/$pkgname-$version.tar.gz"
-checksum=8effea7b14a52a4c09a000bf6cde4cbf13385246af9b31a5da4dab27361ca905
+distfiles="https://rakudo.perl6.org/downloads/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=ea97fd1ff3f9cf3efe10bcff8795bc0a6d1e0f316eb213f061c8fc1585f891c7
 nocross=yes

--- a/srcpkgs/rakudo/template
+++ b/srcpkgs/rakudo/template
@@ -1,6 +1,6 @@
 # Template file for 'rakudo'
 pkgname=rakudo
-version=2018.09
+version=2018.10
 revision=1
 build_style=configure
 make_check_target=test
@@ -9,14 +9,14 @@ configure_script="perl Configure.pl"
 configure_args="--prefix=/usr --backends=moar"
 hostmakedepends="perl"
 makedepends="libatomic_ops-devel libffi-devel libtommath-devel libuv-devel nqp"
-depends="nqp"
+depends="nqp-${version}_${revision}"
 short_desc="Production-ready, stable implementation of the Perl 6 language"
 maintainer="Ruslan <axetwe@gmail.com>"
 license="Artistic-2.0"
 homepage="https://rakudo.org"
 changelog="https://raw.githubusercontent.com/rakudo/rakudo/master/docs/ChangeLog"
-distfiles="https://rakudo.perl6.org/downloads/$pkgname/$pkgname-$version.tar.gz"
-checksum=4934b84f844adb61ec949b5f4fd31fbc86a83e2195fb2498a1bc2b77d9d859fb
+distfiles="https://rakudo.perl6.org/downloads/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=09f87ea4f869febceffe682f3391495cba829ae3119e7ea2e3d40b88b59cab45
 nocross=yes
 make_dirs="
  /usr/share/perl6/bin 0755 root root
@@ -34,7 +34,7 @@ make_dirs="
  /usr/share/perl6/vendor/resources 0755 root root
  /usr/share/perl6/vendor/short 0755 root root
  /usr/share/perl6/vendor/sources 0755 root root"
-provides="perl6-${version}_$revision"
+provides="perl6-${version}_${revision}"
 
 post_install() {
 	vbin tools/install-dist.p6 perl6-install-dist


### PR DESCRIPTION
- specify exact version number for perl6 dependencies