### PR TITLE
grub: add /etc/grub.d/* to conf_files

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,12 +1,12 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.02
-revision=3
+revision=4
 hostmakedepends="flex freetype-devel"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel font-unifont-bdf fuse-devel"
 depends="os-prober"
-conf_files="/etc/default/grub /etc/grub.d/40_custom"
+conf_files="/etc/default/grub /etc/grub.d/*"
 short_desc="GRand Unified Bootloader 2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3"


### PR DESCRIPTION
- allows GRUB password protection for all but default menu entries to survive package upgrades
  - https://selivan.github.io/2017/12/21/grub2-password-for-all-but-default-menu-entries.html
  - https://wiki.archlinux.org/index.php/Talk:GRUB/Tips_and_tricks