### PR TITLE
build_style=perl6-dist: add

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -790,6 +790,9 @@ Additional install arguments can be specified via `make_install_args`.
 - `perl-module` For packages that use the Perl
 [ExtUtils::MakeMaker](http://perldoc.perl.org/ExtUtils/MakeMaker.html) build method.
 
+- `perl6-dist` For packages that use the Rakudo Perl 6
+`perl6-install-dist` build method with rakudo.
+
 - `waf3` For packages that use the Python3 `waf` build method with python3.
 
 - `waf` For packages that use the Python `waf` method with python2.

--- a/common/build-style/perl6-dist.sh
+++ b/common/build-style/perl6-dist.sh
@@ -1,0 +1,16 @@
+#
+# This helper is for Rakudo Perl 6 package templates.
+#
+
+do_check() {
+	PERL6LIB=lib prove -r -e perl6 t/
+}
+
+do_install() {
+	export RAKUDO_LOG_PRECOMP=1
+	export RAKUDO_RERESOLVE_DEPENDENCIES=0
+	perl6-install-dist \
+		--to=${DESTDIR}/usr/share/perl6/vendor \
+		--for=vendor \
+		--from=.
+}

--- a/common/environment/build-style/perl6-dist.sh
+++ b/common/environment/build-style/perl6-dist.sh
@@ -1,0 +1,3 @@
+depends+=" rakudo"
+checkdepends+=" perl"
+hostmakedepends+=" rakudo"


### PR DESCRIPTION
- allow installing Rakudo Perl 6 distributions with `perl6-install-dist`, a utility included with `rakudo`