### PR TITLE
Manual.md: Reference SPDX license identifiers

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -93,7 +93,7 @@ revision=1
 build_style=gnu-configure
 short_desc="A short description max 72 chars"
 maintainer="name <email>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.foo.org"
 distfiles="http://www.foo.org/foo-${version}.tar.gz"
 checksum="fea0a94d4b605894f3e2d5572e3f96e4413bcad3a085aae7367c2cf07908b2ff"
@@ -364,8 +364,8 @@ The list of mandatory variables for a template:
 
 - `homepage` A string pointing to the `upstream` homepage.
 
-- `license` A string matching any license file available in `/usr/share/licenses`.
-Multiple licenses should be separated by commas, Example: `GPL-3, LGPL-2.1`.
+- `license` A string matching the license's [SPDX Short identifier](https://spdx.org/licenses)
+Multiple licenses should be separated by commas, Example: `GPL-3.0-or-later, LGPL-2.1-only`.
 
 - `maintainer` A string in the form of `name <user@domain>`.  The
   email for this field must be a valid email that you can be reached
@@ -1129,7 +1129,7 @@ revision=1
 build_style=gnu-configure
 short_desc="A short description max 72 chars"
 maintainer="name <email>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.foo.org"
 distfiles="http://www.foo.org/foo-${version}.tar.gz"
 checksum="fea0a94d4b605894f3e2d5572e3f96e4413bcad3a085aae7367c2cf07908b2ff"


### PR DESCRIPTION
Over in pull request #4268, @maxice8 points out that I should be using SPDX identifiers for the `license` field in package templates. As far as I can tell, this is never mentioned in the *XBPS source packages manual*, which in fact instructs using strings to match filenames in `/usr/share/licenses`. The example templates do not use SPDX identifiers as well.

Looking at the history of pull request comments, it appears this is a common issue, and so I'm wondering if the manual should be updated. In this pull request, I just did a dumb text search for the word "license" and updated the few locations that seemed appropriate.