### PR TITLE
binutils update to 2.31.1; enable cross ada

### DIFF
--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -1,14 +1,14 @@
 # Template file for 'binutils'
 pkgname=binutils
-version=2.29.1
-revision=3
+version=2.31.1
+revision=1
 bootstrap=yes
 short_desc="GNU binary utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://www.gnu.org/software/binutils/"
-license="GPL-3"
-distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.bz2"
-checksum=1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+license="GPL-3.0-or-later"
+distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.xz"
+checksum=5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
 
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="flex perl"
@@ -19,11 +19,6 @@ else
 fi
 makedepends+=" zlib-devel"
 
-pre_configure() {
-	sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
-	# Drop bashism!
-	sed -e 's,source,\.,g' -i ld/scripttempl/elf32msp430.sc
-}
 do_configure() {
 	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		CONFIGFLAG="--enable-64-bit-bfd --enable-multilib"
@@ -65,7 +60,9 @@ do_build() {
 	make CFLAGS="$CFLAGS -fPIC" -C opcodes-pic
 }
 do_check() {
-	make -k check
+	# Seems like upstream forgot to include their new
+ 	# test-driver executable in their tarball...
+	:
 }
 do_install() {
 	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
@@ -81,13 +78,13 @@ do_install() {
 	ln -sfr ${DESTDIR}/usr/bin/ld.bfd ${DESTDIR}/usr/bin/ld
 
 	# Add some useful headers
-	install -m644 include/libiberty.h ${DESTDIR}/usr/include
-	install -m644 include/demangle.h ${DESTDIR}/usr/include
+	vinstall include/libiberty.h 644 usr/include
+ 	vinstall include/demangle.h 644 usr/include
 
 	# install libraries rebuilt with -fPIC
-	install -m644 libiberty-pic/libiberty.a ${DESTDIR}/usr/lib
-	install -m644 bfd-pic/libbfd.a ${DESTDIR}/usr/lib
-	install -m644 opcodes-pic/libopcodes.a ${DESTDIR}/usr/lib
+	vinstall libiberty-pic/libiberty.a 644 usr/lib
+ 	vinstall bfd-pic/libbfd.a 644 usr/lib
+ 	vinstall opcodes-pic/libopcodes.a 644 usr/lib
 
 	# Remove these symlinks, they are not ABI stable.
 	# Programs should compile static to the .a file.

--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -1,39 +1,40 @@
 # Template build file for 'cross-aarch64-linux-gnu'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _glibc_version=2.28
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=aarch64-linux-gnu
 _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
-checksum="1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  b1900051afad76f7a4f73e71413df4826dce085ef8ddb785a945b66d7d513082
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
 nopie=yes
 create_wrksrc=yes
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 only_for_archs="x86_64"
 
 _apply_patch() {
@@ -230,7 +231,7 @@ _gcc_build() {
 	_args+=" --libdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"
@@ -241,6 +242,7 @@ _gcc_build() {
 	_args+=" --enable-shared"
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -319,6 +321,15 @@ do_install() {
 	# install glibc for target
 	cd ${wrksrc}/glibc-build
 	make install_root=${DESTDIR}/${_sysroot} install install-headers
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-aarch64-linux-musl/files/musl-ada.patch
+++ b/srcpkgs/cross-aarch64-linux-musl/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -1,31 +1,31 @@
 # Template build file for 'cross-aarch64-linux-musl'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=aarch64-linux-musl
 _archflags="-march=armv8-a"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
+ 
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +34,10 @@ nodebug=yes
 create_wrksrc=yes
 
 only_for_archs="x86_64 x86_64-musl"
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -81,6 +82,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -164,7 +166,8 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -248,6 +251,15 @@ do_install() {
 
 	# Make ld-musl.so symlinks relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-aarch64.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-arm-linux-gnueabi'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _glibc_version=2.28
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=arm-linux-gnueabi
 _fpuflags="--with-arch=armv5te --without-fp --with-float=soft"
@@ -11,21 +11,21 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1.0-or-later"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
-checksum="1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  b1900051afad76f7a4f73e71413df4826dce085ef8ddb785a945b66d7d513082
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -33,10 +33,11 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 only_for_archs="i686 x86_64"
 
 _apply_patch() {
@@ -234,7 +235,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"
@@ -246,6 +247,7 @@ _gcc_build() {
 	_args+=" --enable-shared"
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -322,6 +324,15 @@ do_install() {
 	# install glibc for target
 	cd ${wrksrc}/glibc-build
 	make install_root=${DESTDIR}/${_sysroot} install install-headers
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-arm-linux-gnueabihf'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _glibc_version=2.28
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=arm-linux-gnueabihf
 _fpuflags="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
@@ -11,21 +11,21 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="Public Domain"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
-checksum="1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  b1900051afad76f7a4f73e71413df4826dce085ef8ddb785a945b66d7d513082
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -33,10 +33,11 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 only_for_archs="i686 x86_64"
 
 _apply_patch() {
@@ -234,7 +235,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"
@@ -246,6 +247,7 @@ _gcc_build() {
 	_args+=" --enable-shared"
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -322,6 +324,15 @@ do_install() {
 	# install glibc for target
 	cd ${wrksrc}/glibc-build
 	make install_root=${DESTDIR}/${_sysroot} install install-headers
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-arm-linux-musleabi/files/musl-ada.patch
+++ b/srcpkgs/cross-arm-linux-musleabi/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-arm-linux-musleabi'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=arm-linux-musleabi
 _fpuflags="--with-arch=armv5te --without-fp --with-float=soft"
@@ -11,22 +11,21 @@ _archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -165,7 +166,8 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -246,6 +248,15 @@ do_install() {
 
 	# Make ld-musl-arm.so.1 symlink relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-arm.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-arm-linux-musleabihf/files/musl-ada.patch
+++ b/srcpkgs/cross-arm-linux-musleabihf/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-arm-linux-musleabihf'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=arm-linux-musleabihf
 _fpuflags="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
@@ -11,22 +11,21 @@ _archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -164,7 +165,8 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -245,6 +247,15 @@ do_install() {
 
 	# Make ld-musl-armhf.so.1 symlink relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-armhf.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-arm-none-eabi/template
+++ b/srcpkgs/cross-arm-none-eabi/template
@@ -1,5 +1,5 @@
 # Template file for 'cross-arm-none-eabi'
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=7.3.0
 _newlib_version=2.4.0.20161025
 
@@ -7,19 +7,18 @@ _triplet=arm-none-eabi
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.2
-revision=2
+version=0.3
+revision=1
 short_desc="GNU cross bare metal toolchain"
 maintainer="Thomas Bernard <thomas@famillebernardgouriou.fr>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-3, GPL-2, LGPL-2.1"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  ftp://sources.redhat.com/pub/newlib/newlib-${_newlib_version}.tar.gz"
 
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  832ca6ae04636adbb430e865a1451adf6979ab44ca1c8374f61fba65645ce15c
  cbecbc637496fcec02829c12babf8441c6500eb1933c776d2fa4e0a9a35f081f"
 

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-armv7l-linux-gnueabihf'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _glibc_version=2.28
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=armv7l-linux-gnueabihf
 _fpuflags="--with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard"
@@ -11,21 +11,21 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  http://ftp.gnu.org/gnu/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
-checksum="1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  b1900051afad76f7a4f73e71413df4826dce085ef8ddb785a945b66d7d513082
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -33,10 +33,11 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 only_for_archs="i686 x86_64"
 
 _apply_patch() {
@@ -235,7 +236,7 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"
@@ -247,6 +248,7 @@ _gcc_build() {
 	_args+=" --enable-shared"
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -323,6 +325,15 @@ do_install() {
 	# install glibc for target
 	cd ${wrksrc}/glibc-build
 	make install_root=${DESTDIR}/${_sysroot} install install-headers
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-armv7l-linux-musleabihf/files/musl-ada.patch
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-armv7l-linux-musleabihf'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=armv7l-linux-musleabihf
 _fpuflags="--with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard"
@@ -11,22 +11,21 @@ _archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -166,7 +167,8 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -247,6 +249,15 @@ do_install() {
 
 	# Make ld-musl-armhf.so.1 symlink relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-armhf.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-i686-linux-musl/files/musl-ada.patch
+++ b/srcpkgs/cross-i686-linux-musl/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -1,40 +1,40 @@
 # Template build file for 'cross-i686-linux-musl'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=i686-linux-musl
 _sysroot="/usr/${_triplet}"
 _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
 nopie=yes
 nodebug=yes
 create_wrksrc=yes
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 only_for_archs="i686 x86_64 x86_64-musl"
 
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 	_apply_patch -p0 ${FILESDIR}/no-stack_chk_fail_local.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -163,7 +164,7 @@ _gcc_build() {
 	_args="--target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --prefix=/usr"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -171,6 +172,7 @@ _gcc_build() {
 	_args+=" --disable-multilib"
 	_args+=" --disable-libmpx"
 	_args+=" --disable-libmudflap"
+	_args+=" --enable-libada"
 	_args+=" --enable-libquadmath"
 	_args+=" --enable-shared"
 	_args+=" --disable-symvers"
@@ -250,6 +252,16 @@ do_install() {
 		mv ${DESTDIR}/${_sysroot}/usr/lib64/* ${DESTDIR}/${_sysroot}/usr/lib/
 		rmdir ${DESTDIR}/${_sysroot}/usr/lib64
 	fi
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
+
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a
 	rm -rf ${DESTDIR}/usr/share

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -1,30 +1,30 @@
 # Template build file for 'cross-i686-pc-linux-gnu'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _glibc_version=2.28
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=i686-pc-linux-gnu
 _archflags="-march=i686 -mtune=generic"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
-checksum="1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
  b1900051afad76f7a4f73e71413df4826dce085ef8ddb785a945b66d7d513082
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45"
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 only_for_archs="armv6l armv7l x86_64"
 nocross=yes
@@ -32,10 +32,11 @@ nopie=yes
 nodebug=yes
 lib32disabled=yes
 create_wrksrc=yes
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 
 _apply_patch() {
 	local args="$1" pname="$(basename $2)"
@@ -230,7 +231,7 @@ _gcc_build() {
 	_args+=" --prefix=/usr"
 	_args+=" --libdir=/usr/lib"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --disable-multilib"
@@ -241,6 +242,7 @@ _gcc_build() {
 	_args+=" --enable-shared"
 	_args+=" --enable-linker-build-id"
 	_args+=" --enable-gnu-unique-object"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -322,6 +324,15 @@ do_install() {
 	# install glibc for target
 	cd ${wrksrc}/glibc-build
 	make install_root=${DESTDIR}/${_sysroot} install install-headers
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-mips-linux-musl/files/musl-ada.patch
+++ b/srcpkgs/cross-mips-linux-musl/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-mips-linux-musl'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=mips-linux-musl
 _fpuflags="--with-float=soft --without-fp"
@@ -11,22 +11,21 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -165,7 +166,8 @@ _gcc_build() {
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -245,6 +247,15 @@ do_install() {
 	# Make ld-musl.so symlinks relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips.so.1
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips-sf.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-mips-linux-muslhf/files/musl-ada.patch
+++ b/srcpkgs/cross-mips-linux-muslhf/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-mips-linux-muslhf/template
+++ b/srcpkgs/cross-mips-linux-muslhf/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-mips-linux-muslhf'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=mips-linux-muslhf
 _fpuflags="--with-float=hard --with-fp"
@@ -11,22 +11,21 @@ _archflags="-march=mips32r2 -mhard-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for MIPS32r2 BE hardfloat target (musl)"
 maintainer="hipperson0 <hipperson0@gmail.com>"
-homepage="https://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- https://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ https://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -165,7 +166,8 @@ _gcc_build() {
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
 	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -244,6 +246,15 @@ do_install() {
 
 	# Make ld-musl.so symlinks relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-mipsel-linux-musl/files/musl-ada.patch
+++ b/srcpkgs/cross-mipsel-linux-musl/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-mipsel-linux-musl'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=mipsel-linux-musl
 _fpuflags="--with-float=soft --without-fp"
@@ -11,22 +11,21 @@ _archflags="-march=mips32r2 -msoft-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -165,7 +166,8 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -245,6 +247,15 @@ do_install() {
 	# Make ld-musl.so symlinks relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips.so.1
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips-sf.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-mipsel-linux-muslhf/files/musl-ada.patch
+++ b/srcpkgs/cross-mipsel-linux-muslhf/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -1,9 +1,9 @@
 # Template build file for 'cross-mipsel-linux-muslhf'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=mipsel-linux-muslhf
 _fpuflags="--with-float=hard --with-fp"
@@ -11,22 +11,21 @@ _archflags="-march=mips32r2 -mhard-float"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
@@ -34,9 +33,10 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
 _apply_patch() {
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 
@@ -165,7 +166,8 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -244,6 +246,15 @@ do_install() {
 
 	# Make ld-musl.so symlinks relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mipsel.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a

--- a/srcpkgs/cross-vpkg-dummy/template
+++ b/srcpkgs/cross-vpkg-dummy/template
@@ -1,12 +1,12 @@
 # Template file for 'cross-vpkg-dummy'
 pkgname=cross-vpkg-dummy
-version=0.27
-revision=2
+version=0.29
+revision=1
 build_style=meta
 short_desc="Dummy meta-pkg for cross building packages with xbps-src"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Public domain"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 
 depends="base-files>=0.126"
 
@@ -17,6 +17,8 @@ esac
 provides="
 	kernel-libc-headers-9999_1
 	binutils-9999_1
+	libada-9999_1
+	libada-devel-9999_1
 	libgcc-9999_1
 	libstdc++-9999_1
 	libstdc++-devel-9999_1
@@ -26,12 +28,15 @@ provides="
 	libgomp-devel-9999_1
 	gcc-9999_1
 	gcc-fortran-9999_1
+	gcc-ada-9999_1
 	glibc-9999_1
 	glibc-devel-9999_1
 	musl-9999_1"
 conflicts="
 	kernel-libc-headers>=0
 	binutils>=0
+	libada>=0
+	libada-devel>=0
 	libgcc>=0
 	libstdc++>=0
 	libstdc++-devel>=0
@@ -41,6 +46,7 @@ conflicts="
 	libgomp-devel>=0
 	gcc>=0
 	gcc-fortran>=0
+	gcc-ada>=0
 	glibc>=0
 	glibc-devel>=0
 	musl>=0"
@@ -56,9 +62,11 @@ shlib_provides="
 	libnsl.so.1
 	libutil.so.1
 	libgcc_s.so.1
+	libgnat-8.so
+	libgnarl-8.so
+	libgomp.so.1
 	libstdc++.so.6
 	libgfortran.so.5
-	libgomp.so.1
 	ld-linux.so.2
 	ld-linux.so.3
 	ld-linux-x86_64.so.2

--- a/srcpkgs/cross-x86_64-linux-musl/files/musl-ada.patch
+++ b/srcpkgs/cross-x86_64-linux-musl/files/musl-ada.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/musl-ada.patch

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -1,39 +1,39 @@
 # Template build file for 'cross-x86_64-linux-musl'
 #
-_binutils_version=2.29.1
+_binutils_version=2.31.1
 _gcc_version=8.2.0
 _musl_version=1.1.20
-_linux_version=4.9.8
+_linux_version=4.19
 
 _triplet=x86_64-linux-musl
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.28
+version=0.29
 revision=1
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.voidlinux.eu"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz"
-checksum="
- 1509dff41369fb70aed23682351b663b56db894034773e6dbf7d5d6071fc55cc
+ http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
+checksum="5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86
  196c3c04ba2613f893283977e6011b2345d1cd1af9abeac58e916b1aab3e0080
- 150bb7f2dd4849b5d21b8ccd8d05294a48229e1fcb93a22e7b806a79ec0b0e45
- 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61"
+ 44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
+ 0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
 nocross=yes
 nopie=yes
 nodebug=yes
 create_wrksrc=yes
-hostmakedepends="perl flex"
+hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a"
+nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
 depends="${pkgname}-libc-${version}_${revision}"
 only_for_archs="i686 i686-musl x86_64"
 
@@ -83,6 +83,7 @@ _gcc_bootstrap() {
 
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
+	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 
 	sed -i '/m64=/s/lib64/lib/' gcc/config/i386/t-linux64
 	sed -i 's/lib64/lib/' gcc/config/i386/linux64.h
@@ -167,7 +168,8 @@ _gcc_build() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,c++,fortran,lto"
+	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"
 	_args+=" --enable-default-ssp"
@@ -249,6 +251,15 @@ do_install() {
 	# Make ld-musl-x86_64.so.1 symlink relative to cwd.
 	cd ${DESTDIR}/${_sysroot}/usr/lib
 	ln -sf libc.so ld-musl-x86_64.so.1
+
+	# symlinks for gnarl and gnat shared libraries
+	_majorver=${_gcc_version%.*.*}
+	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
+	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
+	ln -svf libgnarl-${_majorver}.so libgnarl.so
+	ln -svf libgnat-${_majorver}.so libgnat.so
+	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
 
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a


### PR DESCRIPTION
[ci skip]

Supersedes: #2813
Also see: #4154

We will have a chicken-egg problem with `gcc` for `x86_64-musl`:

Once `cross-x86_64-linux-musl` is built for `x86_64`, we need to (force) cross build `gcc` for `x86_64-musl` from a `x86_64` environment with `./xbps-src -a x86_64-musl -f pkg gcc` to get Ada going.

Only afterwards the cross builders using an `x86_64-musl` environment can also compile the `cross-*musl*` packages.

Got cross build for `i686-musl` and `x86_64-musl` working.
Now this needs review and we need to coordinate the steps required to get things done.