### PR TITLE
build-style cargo: move cargo config from wrksrc to home

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -3,12 +3,11 @@
 #
 
 do_configure() {
-	mkdir -p .cargo
+	mkdir -p ${HOME}/.cargo
 	# respect makejobs, do cross stuff
-	cat > .cargo/config <<EOF
+	cat > ${HOME}/.cargo/config <<EOF
 [build]
 jobs = ${makejobs#*j}
-target = "${RUST_TARGET}"
 
 [target.${RUST_TARGET}]
 linker = "${CC}"
@@ -18,7 +17,7 @@ EOF
 do_build() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} build --release ${configure_args}
+	${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}
 }
 
 do_check() {
@@ -30,6 +29,7 @@ do_check() {
 do_install() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} install --root="${DESTDIR}/usr" ${make_install_args}
+	${make_cmd} install --path . --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
+		${make_install_args}
 	rm "${DESTDIR}"/usr/.crates.toml
 }

--- a/common/environment/build-style/cargo.sh
+++ b/common/environment/build-style/cargo.sh
@@ -4,7 +4,4 @@ if [ "$CROSS_BUILD" ]; then
 	makedepends+=" rust-std"
 fi
 
-# Use the config we set in do_configure
-export CARGO_HOME="$wrksrc/.cargo"
-
 export PKG_CONFIG_ALLOW_CROSS=1


### PR DESCRIPTION
since cargo 0.31.0 ${wrksrc}/.cargo/config is ignored for cargo install
fixes: https://github.com/void-linux/void-packages/issues/4328

@Cogitri @Gottox 