### PR TITLE
crystal: update to 0.27.0

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,9 +1,9 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.26.1
+version=0.27.0
 revision=1
 _shardsversion=0.8.1
-_bootstrapversion=0.26.1
+_bootstrapversion=0.27.0
 _bootstraprevision=1
 hostmakedepends="git llvm"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -18,7 +18,8 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="b7c755a7d0f49f572ae5c08b8b0139fcb1c6862c9479dfae74f00e2c8424fcb0
+checksum="
+ 43c8ac1b5c59ccea3cd58c9bd2a7af07a56f96cf1eff1e54d93f648b5340e83a
  75c74ab6acf2d5c59f61a7efd3bbc3c4b1d65217f910340cb818ebf5233207a5"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -31,11 +32,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" 610bb650d20c161ba6900f23b2044a5d12b5669d5c8e466ea419e42f1a6d13f1"
+		checksum+=" a6a6966e1089df2c3467ceb200db9a282dcbfef54418865638bf152f3cd36642"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 684c33366d80ca89b2cf14c7770fc9a182596ea19105db4334eca6bda2e9bf98"
+		checksum+=" 7d495b9e51f6665c6745f7d297a40bcbfb842fbb2f29ed91fb037a6813c75fd7"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"
@@ -54,14 +55,6 @@ do_extract() {
 		tar xf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-${XBPS_TARGET_MACHINE}.tar.gz \
 			--strip-components=1 -C ${wrksrc}/bootstrap
 	fi
-}
-
-post_extract() {
-	# Check for libtls to determine if libssl is coming from LibreSSL, as suggested by Vaelatern
-	sed -i 's/OPENSSL_102 = .*/OPENSSL_102 = {{ `command -v pkg-config > \/dev\/null \&\& pkg-config --atleast-version=1.0.2 libssl \&\& pkg-config --exists libtls || printf succ`.stringify == "succ" }}/' ${wrksrc}/src/openssl/lib_ssl.cr
-	sed -i 's/OPENSSL_102 = .*/OPENSSL_102 = {{ `command -v pkg-config > \/dev\/null \&\& pkg-config --atleast-version=1.0.2 libcrypto \&\& pkg-config --exists libtls || printf succ`.stringify == "succ" }}/' ${wrksrc}/src/openssl/lib_crypto.cr
-	sed -i 's/OPENSSL_110 = .*/OPENSSL_110 = {{ `command -v pkg-config > \/dev\/null \&\& pkg-config --atleast-version=1.1.0 libssl \&\& pkg-config --exists libtls || printf succ`.stringify == "succ" }}/' ${wrksrc}/src/openssl/lib_ssl.cr
-	sed -i 's/OPENSSL_110 = .*/OPENSSL_110 = {{ `command -v pkg-config > \/dev\/null \&\& pkg-config --atleast-version=1.1.0 libcrypto \&\& pkg-config --exists libtls || printf succ`.stringify == "succ" }}/' ${wrksrc}/src/openssl/lib_crypto.cr
 }
 
 do_build() {


### PR DESCRIPTION
Removed the LibreSSL hack because it's fixed in `0.27.0`.