### PR TITLE
lutris: update to 0.4.22

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,16 +1,16 @@
 # Template file for 'lutris'
 pkgname=lutris
-version=0.4.21
+version=0.4.22
 revision=1
 noarch=yes
 build_style=python3-module
 pycompile_module="${pkgname}"
-hostmakedepends="python3-setuptools python3-gobject"
-depends="python3-dbus python3-gobject python3-yaml xrandr"
+hostmakedepends="python3-setuptools python3-gobject gtk+3-devel"
+depends="python3-dbus python3-gobject python3-yaml python3-evdev pciutils"
 short_desc="Open gaming platform for managing games in a unified way"
 maintainer="Jan Wey. <janwey.git@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://lutris.net"
 changelog="https://raw.githubusercontent.com/lutris/lutris/master/debian/changelog"
 distfiles="https://github.com/lutris/lutris/archive/v${version}.tar.gz"
-checksum=0b46d6b06bbe09b7781f781a12f8f37e98939af413365927c4fda92b342efdfd
+checksum=e849ae01b702f8b39d1783c5e2a3f935b50cd31aa3952f0c0f0f7530a8a7d4b2


### PR DESCRIPTION
* [Changelog](https://github.com/lutris/lutris/releases/tag/v0.4.22)
* Now requires `gtk+3-devel` to build ( Wouldn't this also it should `depends` on `gtk+3` ?)
* Added `python3-evdev` to depends for 'out of the box' controller support
* Replaced `xrandr` with `pciutils` as that is now how lutris finds GPUs