### PR TITLE
mpv: rebuild for ffmpeg 4.1

### DIFF
--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.29.1
-revision=2
+revision=3
 build_style=waf
 configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
  --enable-dvdread --enable-dvdnav --enable-cdda --enable-libmpv-shared


### PR DESCRIPTION
mpv won't run against new version of ffmpeg installed