### PR TITLE
hexchat: unbreak cross builds

### DIFF
--- a/srcpkgs/hexchat/template
+++ b/srcpkgs/hexchat/template
@@ -28,8 +28,8 @@ esac
 lib32disabled=yes
 
 if [ "$CROSS_BUILD" ]; then
-	broken="cross currently broken"
-	hostmakedepends+=" dbus-glib-devel libxml2-devel gdk-pixbuf perl"
+	hostmakedepends+=" dbus-glib-devel libxml2-devel gdk-pixbuf perl
+	 shared-mime-info"
 fi
 
 post_install() {


### PR DESCRIPTION
Needs shared-mime-info for the host, because gdk-pixpuf determines which image loader to use via MIME types.

```
glib-compile-resources ../src/fe-gtk/../../data/hexchat.gresource.xml --sourcedir ../src/fe-gtk/../../data --sourcedir ../src/fe-gtk ->
failed to load "../src/fe-gtk/../../data/icons/hexchat.png": Couldn?t recognize the image file format for file ?../src/fe-gtk/../../data/icons/hexchat.png?
```