### PR TITLE
new package: afew-1.3.0 + dependencies

### DIFF
--- a/srcpkgs/afew/template
+++ b/srcpkgs/afew/template
@@ -1,0 +1,25 @@
+# Template file for 'afew'
+pkgname=afew
+version=1.3.0
+revision=1
+noarch=yes
+build_style=python3-module
+pycompile_module="afew"
+hostmakedepends="git python3-setuptools python3-Sphinx pkg-config"
+depends="python3-setuptools notmuch-python3 python3-dkimpy"
+short_desc="An initial tagging script for notmuch mail"
+maintainer="Alexander Gehrke <void@qwertyuiop.de>"
+license="ISC"
+homepage="https://github.com/afewmail/afew"
+distfiles="${PYPI_SITE}/a/afew/afew-${version}.tar.gz"
+checksum=ff790342fccd2a83e8e23bd508c16ca93bbab5eabd8132fec272de492b7d0504
+
+post_build() {
+	cd ${wrksrc}/docs
+	make man
+}
+
+post_install() {
+	vlicense LICENSE
+	vman docs/build/man/afew.1
+}

--- a/srcpkgs/notmuch-python3
+++ b/srcpkgs/notmuch-python3
@@ -1,0 +1,1 @@
+notmuch

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -2,7 +2,7 @@
 pkgname=notmuch
 version=0.28
 revision=1
-hostmakedepends="perl pkg-config python-Sphinx python-devel"
+hostmakedepends="perl pkg-config python-Sphinx python-devel python3-Sphinx python3-devel"
 makedepends="bash-completion gmime-devel talloc-devel xapian-core-devel"
 short_desc="Thread-based email index, search, and tagging"
 maintainer="Jan S. <jan.schreib@gmail.com>"
@@ -11,7 +11,7 @@ homepage="https://notmuchmail.org"
 distfiles="${DEBIAN_SITE}/main/n/notmuch/notmuch_${version}.orig.tar.xz"
 checksum=3b08a925f9fac87120a3aae9a0efbbc581894cd021cd8d6201056a74b59f7e11
 
-subpackages="libnotmuch libnotmuch-devel notmuch-mutt notmuch-python"
+subpackages="libnotmuch libnotmuch-devel notmuch-mutt notmuch-python notmuch-python3"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)
@@ -37,12 +37,15 @@ do_build() {
 	make -C bindings
 	cd bindings/python
 	python2 setup.py build --build-base=build-2
+	python3 setup.py build --build-base=build-3
 }
 
 do_install() {
 	make DESTDIR=${DESTDIR} install
 	cd bindings/python
 	python2 setup.py build --build-base=build-2 \
+		install --prefix=/usr --root=${DESTDIR}
+	python3 setup.py build --build-base=build-3 \
 		install --prefix=/usr --root=${DESTDIR}
 }
 
@@ -88,5 +91,14 @@ notmuch-python_package() {
 	pycompile_module="notmuch"
 	pkg_install() {
 		vmove ${py2_sitelib}
+	}
+}
+
+notmuch-python3_package() {
+	depends="libnotmuch-devel>=${version}_${revision}"
+	short_desc+=" - Python3 bindings"
+	pycompile_module="notmuch"
+	pkg_install() {
+		vmove ${py3_sitelib}
 	}
 }

--- a/srcpkgs/python-dkimpy/template
+++ b/srcpkgs/python-dkimpy/template
@@ -1,0 +1,48 @@
+# Template file for 'python-dkimpy'
+pkgname=python-dkimpy
+version=0.9.0
+revision=1
+noarch=yes
+wrksrc="dkimpy-${version}"
+build_style=python-module
+pycompile_module="dkim"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-dnspython"
+short_desc="DKIM and ARC email signing and verification library (Python2)"
+maintainer="Alexander Gehrke <void@qwertyuiop.de>"
+license="BSD-3-Clause"
+homepage="https://launchpad.net/dkimpy"
+distfiles="${PYPI_SITE}/d/dkimpy/dkimpy-${version}.tar.gz"
+checksum=d2c6b2c6f29434fde48fcd685974cee423d77930dfc6e2d3cb932fecb414d2b1
+alternatives="
+	dkimpy:arcsign:/usr/bin/arcsign2
+	dkimpy:arcverify:/usr/bin/arcverify2
+	dkimpy:dkimsign:/usr/bin/dkimsign2
+	dkimpy:dkimverify:/usr/bin/dkimverify2
+	dkimpy:dknewkey:/usr/bin/dknewkey2"
+
+pre_configure() {
+	sed -n '3,22p' setup.py > LICENSE
+}
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3-dkimpy_package() {
+	noarch=yes
+	pycompile_module="dkim"
+	depends="python3-dnspython"
+	short_desc="${short_desc/Python2/Python3}"
+	alternatives="
+		dkimpy:arcsign:/usr/bin/arcsign3
+		dkimpy:arcverify:/usr/bin/arcverify3
+		dkimpy:dkimsign:/usr/bin/dkimsign3
+		dkimpy:dkimverify:/usr/bin/dkimverify3
+		dkimpy:dknewkey:/usr/bin/dknewkey3"
+	pkg_install() {
+		vmove usr/lib/python3*
+		vmove usr/bin/*3
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python3-dkimpy
+++ b/srcpkgs/python3-dkimpy
@@ -1,0 +1,1 @@
+python-dkimpy


### PR DESCRIPTION
I'm not sure how to handle manpages for python-dkimpy, which is built for python2 and python3. In the current version of the template, only the python2 subpackage contains the manpages, which is consistent with how youtube-dl handles it. All other python cross-version packages I checked had no man pages at all.