### PR TITLE
Add missing novaboot dependency (perl-IO-Stty)

### DIFF
--- a/srcpkgs/novaboot/template
+++ b/srcpkgs/novaboot/template
@@ -1,12 +1,12 @@
 # Template file for 'novaboot'
 pkgname=novaboot
 version=20180323
-revision=1
+revision=2
 noarch=yes
-build_style="gnu-makefile"
+build_style=gnu-makefile
 hostmakedepends="perl"
 makedepends="perl"
-depends="perl perl-Expect"
+depends="perl perl-Expect perl-IO-Stty"
 short_desc="Tool that automates booting of operating systems on hardware or in qemu"
 maintainer="adam <ametisf@gmail.com>"
 license="GPL-2.0-only"

--- a/srcpkgs/perl-IO-Stty/template
+++ b/srcpkgs/perl-IO-Stty/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-IO-Stty'
+pkgname=perl-IO-Stty
+version=0.03
+revision=1
+noarch=yes
+wrksrc="IO-Stty-${version}"
+build_style=perl-ModuleBuild
+hostmakedepends="perl perl-Module-Build"
+makedepends="perl"
+depends="perl"
+short_desc="Stty - Change and print terminal line settings"
+maintainer="adam <ametisf@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://github.com/toddr/IO-Stty"
+distfiles="https://github.com/toddr/IO-Stty/archive/${version}.tar.gz"
+checksum=108eeae3ac48511b49097032570ab02095222ca1fc1c796776c5b1d2503e9115


### PR DESCRIPTION
Hi, I missed a dependency of novaboot on perl IO:Stty package when trying it first, here is a fix.