### PR TITLE
rtorrent: rebuild for libressl-2.8.

### DIFF
--- a/srcpkgs/rtorrent/template
+++ b/srcpkgs/rtorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'rtorrent'
 pkgname=rtorrent
 version=0.9.7
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-xmlrpc-c"
 hostmakedepends="automake libtool pkg-config"
@@ -9,7 +9,7 @@ makedepends="cppunit-devel libsigc++-devel libtorrent-devel ncurses-devel
  xmlrpc-c-devel"
 short_desc="Ncurses BitTorrent client based on libTorrent"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/rakshasa/rtorrent"
 distfiles="https://github.com/rakshasa/${pkgname}/archive/v${version}.tar.gz"
 checksum=5a7c9ded6b92d5ffc5ae32c19816f2328848d70841a4ce7d2739a5024d3587ca


### PR DESCRIPTION
rtorrent fails to start:
```
rtorrent: symbol lookup error: rtorrent: undefined symbol: _ZN7torrent11input_error10initializeERKSs
```

I guess it has something to do to with the recent [rebuild](https://github.com/void-linux/void-packages/commit/af112a130e38c523f00a023cdb834a973bb7e829) of `libtorrent`.

EDIT: https://github.com/void-linux/void-packages/issues/4400#issuecomment-437590879