### PR TITLE
New package: termeter

### DIFF
--- a/srcpkgs/termeter/template
+++ b/srcpkgs/termeter/template
@@ -2,18 +2,18 @@
 pkgname=termeter
 version=1
 revision=1
-wrksrc=${pkgname}-master
 build_style=go
 go_import_path="github.com/atsaki/termeter"
+go_package="github.com/atsaki/termeter/cmd/termeter"
+go_get="yes"
 hostmakedepends="git"
 short_desc="Visualize data in the terminal"
 maintainer="EmmChriss <emmchris@protonmail.com>"
 license="MIT"
 homepage="https://${go_import_path}"
-distfiles="${homepage}/archive/master.tar.gz"
-checksum="aebb3ad490c3efe9f1a0864aa4cf6619f6e79611a34453db65e73519aadf6774"
 
 post_install() {
+	cd _build-termeter-xbps/src/github.com/atsaki/termeter
 	vlicense LICENSE
 	vdoc README.md
 }

--- a/srcpkgs/termeter/template
+++ b/srcpkgs/termeter/template
@@ -1,0 +1,19 @@
+# Template file for 'termeter'
+pkgname=termeter
+version=1
+revision=1
+wrksrc=${pkgname}-master
+build_style=go
+go_import_path="github.com/atsaki/termeter"
+hostmakedepends="git"
+short_desc="Visualize data in the terminal"
+maintainer="EmmChriss <emmchris@protonmail.com>"
+license="MIT"
+homepage="https://${go_import_path}"
+distfiles="${homepage}/archive/master.tar.gz"
+checksum="aebb3ad490c3efe9f1a0864aa4cf6619f6e79611a34453db65e73519aadf6774"
+
+post_install() {
+	vlicense LICENSE
+	vdoc README.md
+}


### PR DESCRIPTION
Termeter has no releases, so it uses master, but the project is dead, so it's very unlikely, that new commits will happen to the repo.
Still, it's a helpful little project for terminal 2d data plotting.

EDIT: Using go_get now, should be better, than having master.tar.gz as the distfile