### PR TITLE
libu2f-host: do not use plugdev group in udev rules

### DIFF
--- a/srcpkgs/libu2f-host/template
+++ b/srcpkgs/libu2f-host/template
@@ -1,7 +1,7 @@
 # Template file for 'libu2f-host'
 pkgname=libu2f-host
 version=1.1.6
-revision=3
+revision=4
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 configure_args="--with-openssl=yes --with-udevrulesdir=/usr/lib/udev/rules.d"
@@ -21,7 +21,7 @@ pre_configure() {
 }
 
 post_install() {
-	sed -i 's:TAG+="uaccess":MODE="0660", GROUP="plugdev":' ${DESTDIR}/usr/lib/udev/rules.d/70-u2f.rules
+	sed -i 's:TAG+="uaccess":TAG+="uaccess", MODE="0660", GROUP="users":' ${DESTDIR}/usr/lib/udev/rules.d/70-u2f.rules
 }
 
 libu2f-host-devel_package() {


### PR DESCRIPTION
This group does not exist in Void Linux, and other references to it are removals rather than additions.

In this PR, I preserve the uaccess tag and use the group `users` to apply permissions to the devices in place of `plugdev`.