### PR TITLE
libu2f-host: mark 70-u2f.rules as config file

### DIFF
--- a/srcpkgs/libu2f-host/template
+++ b/srcpkgs/libu2f-host/template
@@ -1,7 +1,7 @@
 # Template file for 'libu2f-host'
 pkgname=libu2f-host
 version=1.1.6
-revision=2
+revision=3
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 configure_args="--with-openssl=yes --with-udevrulesdir=/usr/lib/udev/rules.d"
@@ -14,6 +14,7 @@ homepage="https://developers.yubico.com/libu2f-host/"
 #changelog="https://raw.githubusercontent.com/Yubico/libu2f-host/master/NEWS"
 distfiles="https://github.com/Yubico/libu2f-host/archive/libu2f-host-${version}.tar.gz"
 checksum=45beabd3ba5a08643f3aea4642ea4c68f34f0ad701878f3ad447c5b3c13ecb21
+conf_files="/usr/lib/udev/rules.d/70-u2f.rules"
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
According to @the-maldridge "that file should be defined as a conf_file, if it isn't that's a bug"
So just a minor fix to the template