### PR TITLE
base-files: vkpurge: add wildcard support

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -3,7 +3,7 @@
 # A simple script to remove old kernel files/modules.
 # Brought to you by yours truly Juan RP in the Public Domain.
 #
-: ${progname:=$(basename $0)}
+: "${progname:="$(basename "$0")"}"
 
 case "$(xbps-uhelper arch)" in
     aarch64*) KIMAGE="vmlinux";;
@@ -13,97 +13,120 @@ esac
 usage()
 {
 	cat <<_EOF
-Usage: $progname <target> [<version>]
+Usage: $progname <MODE> [<VERSION>]
 
-Targets:
- list			Lists old installed kernels.
- rm <version...|all>	Remove kernel <version> or all old kernels.
+MODE
+ list [<VERSION>]		lists old kernels
+ rm (all | <VERSION>...)	remove old kernels
 
-Example:
+Examples:
 	$ $progname list
-	$ $progname rm 4.9.81_1
+	$ $progname list 4.18.*
+	$ $progname rm all
+	$ $progname rm 4.18.17_1 4.18.17_2
+	$ $progname rm 4.18.17_*
+	$ $progname rm 4.18.*
 _EOF
 	exit 1
 }
 
 list_kernels()
 {
-	local k kpkg installed kver _f
+	local installed
+	local kpkg
+	local k
 
-	for k in /boot/$KIMAGE-*; do
-		_f=$(basename $k)
-		kver=$(echo ${_f}|sed -e 's|-rc|rc|')
-		installed=$(xbps-query -o "$k" 2>/dev/null)
-		[ -n "$installed" ] && continue
-		kpkg="$(xbps-uhelper getpkgversion ${_f} 2>/dev/null)"
+	if [ "$1" = "all" ]; then
+		shift
+	fi
+
+	if [ -n "$1" ] && ! echo "$1" | grep -Eq '^([0-9]+\.+){1,2}(\*|[0-9]+_([0-9]+|\*))$'; then
+		echo "$1"
+		exit 1
+	fi
+
+	installed="$(xbps-query -o "/boot/$KIMAGE-*" 2>/dev/null | awk '{print $2}')"
+
+	for k in /boot/"$KIMAGE"-*; do
+		(echo "$installed" | grep -q "$k") && continue
+
+		kpkg="$(xbps-uhelper getpkgversion "$(basename "$k")" 2>/dev/null)"
 		[ "$(uname -r)" = "$kpkg" ] && continue
-		[ -n "$kpkg" ] && echo "$kpkg"
+
+		[ -n "$kpkg" ] && [ -z "$1" ] || (echo "$kpkg" | grep -Eq "${1}") && echo "$kpkg"
 	done
 }
 
 run_hooks()
 {
+	local d
 	local dir="$1"
 	local kver="$2"
-	local d
 
-	for d in /etc/kernel.d/${dir}/*; do
+	for d in /etc/kernel.d/"${dir}"/*; do
 		[ ! -x "$d" ] && continue
-		echo "Running ${dir} kernel hook: $(basename $d)..."
-		$d kernel $kver
+
+		echo "Running ${dir} kernel hook: $(basename "$d")..."
+		$d kernel "$kver" 2>&1 | sed "s/^/\t/"
 	done
 }
 
 remove_kernel()
 {
 	local rmkver="$1"
-	local installed f kfile
+	local installed
+	local prefix
 
-	if [ ! -f /boot/$KIMAGE-${rmkver} -a ! -d /lib/modules/${rmkver} ]; then
+	if [ ! -f "/boot/$KIMAGE-${rmkver}" ] && [ ! -d "/lib/modules/${rmkver}" ]; then
 		echo "Kernel ${rmkver} not installed."
 		exit 0
 	fi
 
-	installed=$(xbps-uhelper version "linux${rmkver%*.*}" 2>/dev/null)
-	if [ -n "$installed" -a "$installed" = "$rmkver" ]; then
+	installed="$(xbps-uhelper version "linux${rmkver%*.*}" 2>/dev/null)"
+	if [ -n "$installed" ] && [ "$installed" = "$rmkver" ]; then
 		echo "Kernel $rmkver is currently installed."
 		exit 0
 	fi
 
 	# Execute pre-remove kernel hooks.
-	run_hooks pre-remove $rmkver
+	run_hooks pre-remove "$rmkver"
+
 	# Remove kernel files in /boot.
-	for f in config System.map $KIMAGE; do
-		kfile="/boot/${f}-${rmkver}"
-		[ ! -f "${kfile}" ] && continue
-		echo "Removing ${kfile}..."
-		rm -f ${kfile}
+	for prefix in config System.map "$KIMAGE"; do
+		[ ! -f "/boot/${prefix}-${rmkver}" ] && continue
+
+		echo "Removing /boot/${prefix}-${rmkver}..."
+		rm -f "/boot/${prefix}-${rmkver}"
 	done
+
 	# Remove kernel modules
 	if [ -d "/lib/modules/${rmkver}" ]; then
 		echo "Removing /lib/modules/${rmkver}..."
-		rm -rf /lib/modules/${rmkver}
+		rm -rf "/lib/modules/${rmkver}"
 	fi
+
 	# Execute post-remove kernel hooks.
-	run_hooks post-remove $rmkver
+	run_hooks post-remove "$rmkver"
+
 	# Remove kernel-headers.
-	if [ -d /usr/src/kernel-headers-${rmkver} ]; then
-		rm -rf /usr/src/kernel-headers-${rmkver}
+	if [ -d "/usr/src/kernel-headers-${rmkver}" ]; then
+		echo "Removing /usr/src/kernel-headers-${rmkver}..."
+		rm -rf "/usr/src/kernel-headers-${rmkver}"
 	fi
+
 	# Remove debugging symbols.
-	dfile=/usr/lib/debug/boot/vmlinux-${rmkver}
-	if [ -f "${dfile}" ]; then
-		echo "Removing ${dfile}..."
-		rm -f ${dfile}
+	if [ -f "/usr/lib/debug/boot/vmlinux-${rmkver}" ]; then
+		echo "Removing /usr/lib/debug/boot/vmlinux-${rmkver}..."
+		rm -f "/usr/lib/debug/boot/vmlinux-${rmkver}"
 	fi
-	if [ -d /usr/lib/debug/usr/lib/modules/${rmkver} ]; then
-                echo "Removing /usr/lib/debug/usr/lib/modules/${rmkver}..."
-                rm -rf /usr/lib/debug/usr/lib/modules/${rmkver}
+	if [ -d "/usr/lib/debug/usr/lib/modules/${rmkver}" ]; then
+		echo "Removing /usr/lib/debug/usr/lib/modules/${rmkver}..."
+		rm -rf "/usr/lib/debug/usr/lib/modules/${rmkver}"
 	fi
 }
 
 if [ "$1" = "list" ]; then
-	list_kernels
+	list_kernels "$2"
 elif [ "$1" = "rm" ]; then
 	if [ "$(id -u)" -ne 0 ]; then
 		echo "You have to run this script as root!"
@@ -112,19 +135,15 @@ elif [ "$1" = "rm" ]; then
 
 	if [ -z "$2" ]; then
 		usage
-	elif [ "$2" = "all" ]; then
-		kernels=$(list_kernels)
-		for k in ${kernels}; do
-			echo "Removing kernel $k files ..."
-			remove_kernel "$k"
-		done
-	else
-		shift
-		for k; do
-			echo "Removing kernel $k files ..."
-			remove_kernel "$k"
-		done
 	fi
+
+	shift
+	for k; do
+		for rk in $(list_kernels "$k"); do
+			echo "Removing kernel ${rk}..."
+			remove_kernel "$rk" | sed "s/^/\t/"
+		done
+	done
 else
 	usage
 fi

--- a/srcpkgs/base-files/files/vkpurge.8
+++ b/srcpkgs/base-files/files/vkpurge.8
@@ -1,4 +1,4 @@
-.Dd July 24, 2016
+.Dd November 11, 2018
 .Dt VKPURGE 8
 .Os
 .Sh NAME
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Cm list
+.Op version
 .Nm
 .Cm rm
 .Op Ar versions\ ... | Cm all
@@ -24,10 +25,11 @@ for example 4.3.4_4, but it would need to leave behind 4.3.4_3.
 .Sh OPTIONS
 .Bl -tag -width Ds
 .It Ic list
-Provide a list of installed kernel versions.
+Provide a list of installed kernel versions. Can accept a version wildcard
+to show only some versions.
 .It Ic rm
 Remove kernels.
-Must be followed by either a version number or the literal
+Must be followed by either a version number/wildcard or the literal
 .Sq Ic all .
 .El
 .Sh EXIT STATUS
@@ -44,6 +46,11 @@ The following will list all installed kernels.
 $ vkpurge list
 .Ed
 .Pp
+The following will list all installed kernels part of 4.18.
+.Bd -literal -offset indent
+$ vkpurge list 4.18.*
+.Ed
+.Pp
 The following command will delete the kernel version 2.6.39_2 with all
 kernel-specific files such as compiled modules.
 .Bd -literal -offset indent
@@ -53,6 +60,12 @@ kernel-specific files such as compiled modules.
 The following command will delete the kernels with version 2.6.39_2 and 4.3.4_1
 .Bd -literal -offset indent
 # vkpurge rm 2.6.39_2 4.3.4_1
+.Ed
+.Pp
+The following command will delete the kernels part of 2.6 and all revisions of
+4.3.4
+.Bd -literal -offset indent
+# vkpurge rm 2.6.* 4.3.4_*
 .Ed
 .Sh SEE ALSO
 .Xr xbps-install 1 ,

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.139
-revision=10
+revision=11
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
Wildcard support for vkpurge.

Also, `list` has been speed up, by simply storing a list of all know to xbps kernel images and not calling `xbps-query -o "/boot/....` for every file. 

Everything is also shellcheck-ed. And should not have any issue running under all void flavors. 

Examples:

Remove all kernels in the 4.18 line.
```bash
$ vkpurge rm 4.18.* 
```
Remove all kernel revisions for the in the 4.19.0 kernel.
```bash
$ vkpurge rm 4.19.0_* 
```
There is no problem to give it more then 1 version argument, be it with wildcard or not.
```bash
$ vkpurge rm 4.19.0_* 4.18.18_1
```
Also `list` can now be used to get a list of single kernel line.
```bash
$ vkpurge list 4.19.0_*
> 4.19.0_1
> 4.19.0_2
> 4.19.0_3
```

P.S Excuse me if something is wrong. Wasn't 100% sure how such changes should be submitted. 