### PR TITLE
kio-extras: fix CVE-2018-19120.

### DIFF
--- a/srcpkgs/kio-extras/template
+++ b/srcpkgs/kio-extras/template
@@ -1,7 +1,7 @@
 # Template file for 'kio-extras'
 pkgname=kio-extras
 version=18.08.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"
 hostmakedepends="extra-cmake-modules pkg-config gperf qt5-qmake qt5-host-tools
@@ -16,3 +16,9 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://cgit.kde.org/kio-extras.git"
 distfiles="${KDE_SITE}/applications/${version}/src/${pkgname}-${version}.tar.xz"
 checksum=450d69b16a873da51190c9397b2b0ecb08bc0dcae0d2a07f7ab1d2efcd02c280
+
+post_install() {
+	# workaround for CVE-2018-19120
+	rm "${DESTDIR}/usr/lib/qt5/plugins/htmlthumbnail.so"
+	rm "${DESTDIR}/usr/share/kservices5/htmlthumbnail.desktop"
+}


### PR DESCRIPTION
> The HTML thumbnailer was incorrectly accessing some content of
> remote URLs listed in HTML files. This meant that the owners of the servers
> referred in HTML files in your system could have seen in their access logs
> your IP address every time the thumbnailer tried to create the thumbnail.