### PR TITLE
linux4.19: install dtbs in a kernel specific directory

### DIFF
--- a/srcpkgs/linux4.19/template
+++ b/srcpkgs/linux4.19/template
@@ -1,7 +1,7 @@
 # Template file for 'linux4.19'
 pkgname=linux4.19
 version=4.19.1
-revision=1
+revision=2
 patch_args="-Np1"
 wrksrc="linux-${version}"
 short_desc="The Linux kernel and modules (${version%.*} series)"
@@ -122,13 +122,11 @@ do_install() {
 			;;
 		arm)
 			vinstall arch/arm/boot/zImage 644 boot
-			vmkdir boot/dtbs
-			cp arch/arm/boot/dts/*.dtb ${DESTDIR}/boot/dtbs
+			make ${makejobs} ARCH=${subarch:-$arch} INSTALL_DTBS_PATH=${DESTDIR}/boot/dtbs/dtbs-${_kernver} dtbs_install
 			;;
 		arm64)
 			vinstall arch/arm64/boot/Image 644 boot vmlinux-${_kernver}
-			vmkdir boot/dtbs
-			cp arch/arm64/boot/dts/*/*.dtb ${DESTDIR}/boot/dtbs
+			make ${makejobs} ARCH=${subarch:-$arch} INSTALL_DTBS_PATH=${DESTDIR}/boot/dtbs/dtbs-${_kernver} dtbs_install
 			;;
 	esac
 


### PR DESCRIPTION
At the moment, every kernel install overrides the dtbs in boot/dtbs, which is not great as you might boot a kernel that is not the last installed one.

This PR proposes to install the dtbs in a kernel specific directory, on the model of the vmlinuz/initramfs/System files, by appending the kernel version to the directory name.

It will only affect arm and arm64 architectures.