### PR TITLE
git: correct ac_cv_fread_reads_directories on musl

### DIFF
--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,10 +1,10 @@
 # Template file for 'git'
 pkgname=git
 version=2.19.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2
- ac_cv_fread_reads_directories=no ac_cv_snprintf_returns_bogus=no"
+ ac_cv_snprintf_returns_bogus=no"
 make_install_args="NO_INSTALL_HARDLINKS=1 INSTALLDIRS=vendor
  perllibdir=/usr/share/perl5/vendor_perl"
 hostmakedepends="asciidoc perl tk xmlto"
@@ -22,6 +22,11 @@ checksum=345056aa9b8084280b1b9fe1374d232dec05a34e8849028a20bfdb56e920dbb5
 make_check_target=test
 
 subpackages="git-cvs git-svn gitk git-gui git-all"
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) configure_args+=" ac_cv_fread_reads_directories=yes" ;;
+	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
+esac
 
 post_build() {
 	make ${makejobs} -C Documentation man


### PR DESCRIPTION
git build system relies on FREAD_READS_DIRECTORIES flag to check
if we're on a system which succeeds when attempting to fopen a directory
or read from an fopen-ed directory.

System with musl libc is one of such systems.
The current template lies git build system on this matter.

Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>
