### PR TITLE
librpoxy: renamed /usr/bin/proxy to libproxy-proxy to avoid conflict with 3proxy

### DIFF
--- a/srcpkgs/libproxy/template
+++ b/srcpkgs/libproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'libproxy'
 pkgname=libproxy
 version=0.4.15
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWITH_GNOME=0 -DWITH_KDE4=0 -DWITH_MOZJS=0 -DWITH_NM=0
  -DWITH_PERL=0 -DWITH_PYTHON=1 -DWITH_WEBKIT=0"
@@ -30,4 +30,8 @@ libproxy-python_package() {
 	pkg_install() {
 		vmove "usr/lib/python*"
 	}
+}
+
+post_install() {
+	mv ${DESTDIR}/usr/bin/proxy ${DESTDIR}/usr/bin/libproxy-proxy
 }


### PR DESCRIPTION
Fixes an [old issue](https://github.com/voidlinux/void-packages/issues/12996) that was lost during the migration to the new repo