### PR TITLE
ccsm: fix broken python config

### DIFF
--- a/srcpkgs/ccsm/template
+++ b/srcpkgs/ccsm/template
@@ -1,12 +1,12 @@
 # Template file for 'ccsm'
 pkgname=ccsm
 version=0.8.16
-revision=1
+revision=2
 noarch=yes
-build_style=python2-module
-hostmakedepends="automake intltool libtool pkg-config python"
-makedepends="compiz-core-devel compizconfig-python python-cairo-devel pygtk-devel"
-depends="compizconfig-python python-cairo"
+build_style=python3-module
+hostmakedepends="automake intltool libtool pkg-config python3"
+makedepends="compiz-core-devel compizconfig-python python3-cairo-devel pygtk-devel"
+depends="compizconfig-python python3-cairo"
 short_desc="Compiz Configuration Seetings Manager for Compiz Reloaded"
 maintainer="CoolOhm <micvlas@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
The most recent update broke ccsm by making it a weird mix of python2 and python3. This fixes the problem by making ccsm a python3 program.