### PR TITLE
3proxy: renamed /usr/bin/proxy to 3proxy-proxy to avoid conflict with…

### DIFF
--- a/srcpkgs/3proxy/template
+++ b/srcpkgs/3proxy/template
@@ -1,12 +1,12 @@
 # Template file for '3proxy'
 pkgname=3proxy
 version=0.8.12
-revision=1
-distfiles="https://github.com/z3APA3A/3proxy/archive/$version.tar.gz"
+revision=2
 short_desc="3proxy tiny proxy server"
 maintainer="iaroki <iaroki@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://3proxy.ru"
+distfiles="https://github.com/z3APA3A/3proxy/archive/$version.tar.gz"
 checksum=c2ad3798b4f0df06cfcc7b49f658304e451d60e4834e2705ef83ddb85a03f849
 
 do_build() {
@@ -19,6 +19,8 @@ do_install() {
 
 post_install() {
 	vinstall cfg/3proxy.cfg.sample 644 /etc/3proxy
+	vinstall cfg/counters.sample 644 /etc/3proxy
 	vlicense copying
 	vsv 3proxy
+	mv ${DESTDIR}/usr/bin/proxy ${DESTDIR}/usr/bin/3proxy-proxy
 }


### PR DESCRIPTION
… libproxy