### PR TITLE
WildMidi: fix memory leak

### DIFF
--- a/srcpkgs/WildMidi/patches/0001-fix_medata_handling.patch
+++ b/srcpkgs/WildMidi/patches/0001-fix_medata_handling.patch
@@ -1,0 +1,28 @@
+From 9302455eca76835cf27c6d5832314f5588c2fca7 Mon Sep 17 00:00:00 2001
+From: sezero <sezero@users.sourceforge.net>
+Date: Wed, 31 Oct 2018 14:20:00 +0300
+Subject: [PATCH] freeMDI: free() mdi->tmp_info->copyright and mdi->tmp_info
+
+closes https://github.com/Mindwerks/wildmidi/issues/204
+
+commit d5d2b2780e36 had removed free()ing of mdi->tmp_info
+without saying why, but it seems wrong?
+---
+ src/internal_midi.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/internal_midi.c b/src/internal_midi.c
+index 53062da..ad05346 100644
+--- src/internal_midi.c
++++ src/internal_midi.c
+@@ -1996,6 +1996,10 @@ void _WM_freeMDI(struct _mdi *mdi) {
+     free(mdi->events);
+     _WM_free_reverb(mdi->reverb);
+     free(mdi->mix_buffer);
++    if (mdi->tmp_info) {
++        free(mdi->tmp_info->copyright);
++        free(mdi->tmp_info);
++    }
+     free(mdi);
+ }
+ 

--- a/srcpkgs/WildMidi/template
+++ b/srcpkgs/WildMidi/template
@@ -1,7 +1,7 @@
 # Template file for 'WildMidi'
 pkgname=WildMidi
 version=0.4.2
-revision=1
+revision=2
 wrksrc="wildmidi-wildmidi-${version}"
 build_style=cmake
 makedepends="alsa-lib-devel libopenal-devel"


### PR DESCRIPTION
This just applies a patch from wildmidi's upstream repo so that wildmidi properly frees the metadata.