### PR TITLE
xorg-minimal: add xorg-fonts

### DIFF
--- a/srcpkgs/xorg-minimal/template
+++ b/srcpkgs/xorg-minimal/template
@@ -1,9 +1,9 @@
 # Template file for 'xorg-minimal'
 pkgname=xorg-minimal
 version=1.2
-revision=2
+revision=3
 build_style=meta
-depends="xorg-server xauth xinit xf86-input-libinput"
+depends="xorg-server xauth xinit xf86-input-libinput xorg-fonts"
 short_desc="Xorg meta-package including xorg-xserver and needed tools"
 homepage="http://xorg.freedesktop.org/"
 license="MIT"


### PR DESCRIPTION
Is there a good reason xorg-minimal should not have xorg-fonts as a dependency?

There is documentation on the wiki about this dependency, but as a user who runs xorg-minimal(or whatever the distro provides), wm, and terminal, on a base install I don't see why xorg-fonts is not installed with the xorg-minimal package. I would think niche uses could roll their own dependencies off of xorg-server.

Also, for full disclosure, I am making this pull request because I am trying to get void-docs in order, and came across this dependency on the wiki, but also, I have forgotten to install xorg-fonts before and had to look into why xorg would not start.