### PR TITLE
shutils/common.sh: don't require license when build_style=meta

### DIFF
--- a/common/hooks/do-pkg/00-gen-pkg.sh
+++ b/common/hooks/do-pkg/00-gen-pkg.sh
@@ -74,9 +74,9 @@ genpkg() {
 		${_alternatives:+--alternatives "${_alternatives}"} \
 		${_preserve:+--preserve} \
 		${tags:+--tags "${tags}"} \
+		${license:+--license "${license}"} \
 		--architecture ${arch} \
 		--homepage "${homepage}" \
-		--license "${license}" \
 		--maintainer "${maintainer}" \
 		--desc "${desc}" \
 		--pkgver "${pkgver}" \

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -350,7 +350,13 @@ setup_pkg() {
     fi
 
     # Check if required vars weren't set.
-    _vars="pkgname version short_desc revision homepage license"
+    _vars="pkgname version short_desc revision homepage"
+
+    # Only require license to be set when building metapackages
+    if [ "$build_style" != "meta" ]; then
+        _vars+=" license"
+    fi
+
     for f in ${_vars}; do
         eval val="\$$f"
         if [ -z "$val" -o -z "$f" ]; then


### PR DESCRIPTION
metapackages have no content to be licensed under, there is no reason
to have a license when you aren't actually providing anything for the
users.