### PR TITLE
Signal-Desktop: update to 1.18.0

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=1.14.4
+version=1.18.0
 revision=1
 hostmakedepends="git python nodejs-lts yarn"
 depends="libnotify libappindicator"
@@ -9,7 +9,7 @@ maintainer="Julio Galvan <juliogalvan@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=538c50de7fb2bd442e470f5128a76ddb07490f612a597183d342a95f26b89940
+checksum=db0adab206282504ce2ed768f0365f13db06d7a144bedb36cfe55f6d6777db59
 # Due to electron
 only_for_archs="x86_64 i686"
 nostrip_files="signal-desktop"


### PR DESCRIPTION
The previous version was segfaulting on my machine. Update fixed it.