### PR TITLE
flameshot: add missing qt5-svg dependency.

### DIFF
--- a/srcpkgs/flameshot/template
+++ b/srcpkgs/flameshot/template
@@ -1,11 +1,11 @@
 # Template file for 'flameshot'
 pkgname=flameshot
 version=0.6.0
-revision=1
+revision=2
 build_style=qmake
 configure_args="CONFIG+=packaging"
 makedepends="qt5-svg-devel"
-depends="desktop-file-utils"
+depends="desktop-file-utils qt5-svg"
 short_desc="Powerful yet simple to use screenshot software for GNU/Linux"
 maintainer="Orphaned <orphan@voidlinux.eu>"
 license="GPL-3.0-or-later"
@@ -13,7 +13,7 @@ homepage="https://github.com/lupoDharkael/flameshot"
 distfiles="https://github.com/lupoDharkael/flameshot/archive/v${version}.tar.gz"
 checksum=61b3a1969d6e17d80d5d90a3fce53ca5ae78fa21f9a45e5a19b0b32ea815a589
 
-if [ -n "$CROSS_BUILD" ]; then
+if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-svg-devel"
 fi
 


### PR DESCRIPTION
fixes void-linux/void-packages#4767

@paoloschi can you test this works ?