### PR TITLE
New package: ruby-travis-1.8.9

### DIFF
--- a/common/build-style/gem.sh
+++ b/common/build-style/gem.sh
@@ -61,4 +61,8 @@ do_install() {
 	fi
 
 	rm -rf ${_INSTDIR}/etc
+
+	# Ignore the ~> operator, replace it with >=
+	sed 's|~>|>=|g' \
+		-i ${DESTDIR}/${_GEMDIR}/specifications/${pkgname#ruby-}-${version}.gemspec
 }

--- a/common/build-style/gemspec.sh
+++ b/common/build-style/gemspec.sh
@@ -83,6 +83,8 @@ EOF
 		fi
 	done
 
+	sed 's|~>|>=|g' -i $gemspec
+
 	$gem_cmd build --verbose ${gemspec}
 
 	if [ "$CROSS_BUILD" ]; then

--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -68,7 +68,7 @@ update_check() {
                 rx='href="\K[\d\.]+(?=/")';;
             *rubygems.org*)
                 url="https://rubygems.org/gems/${pkgname#ruby-}"
-                rx='versions/\K[\d\.]+' ;;
+                rx='href="/gems/'${pkgname#ruby-}'/versions/\K[\d\.]*(?=")' ;;
             esac
         fi
 

--- a/srcpkgs/ruby-addressable/template
+++ b/srcpkgs/ruby-addressable/template
@@ -1,0 +1,12 @@
+# Template file for 'ruby-addressable'
+pkgname=ruby-addressable
+version=2.5.2
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-public_suffix>=2.0.2 ruby-public_suffix<4.0"
+short_desc="Replacement for Ruby's standard library URI implementation"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/sporkmonger/addressable"
+checksum=73771ea960b3900d96e6b3729bd203e66f387d0717df83304411bf37efd7386e

--- a/srcpkgs/ruby-backports/template
+++ b/srcpkgs/ruby-backports/template
@@ -1,0 +1,15 @@
+# Template file for 'ruby-backports'
+pkgname=ruby-backports
+version=3.11.4
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Essential backports that enable many of the nice features of Ruby"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/marcandre/backports"
+checksum=0ff9c1601e381e51f93fca3b9931b5e0de4ff0f359da536603fa40c1799750c3
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/ruby-connection_pool/template
+++ b/srcpkgs/ruby-connection_pool/template
@@ -1,0 +1,15 @@
+# Template file for 'ruby-connection_pool'
+pkgname=ruby-connection_pool
+version=2.2.2
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Generic connection pool for Ruby"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/mperham/connection_pool"
+checksum=c8cc9446bcc51034103c1259ad70b91dc9f5297d13460b2c0cce7e5a93e8d451
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-ethon/template
+++ b/srcpkgs/ruby-ethon/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-ethon'
+pkgname=ruby-ethon
+version=0.11.0
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-ffi>=1.3.0"
+short_desc="Lightweight wrapper around libcurl"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/typhoeus/ethon"
+checksum=88ec7960a8e00f76afc96ed15dcc8be0cb515f963fe3bb1d4e0b5c51f9d7e078
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-faraday/template
+++ b/srcpkgs/ruby-faraday/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-faraday'
+pkgname=ruby-faraday
+version=0.15.3
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-multipart-post>=1.2 ruby-multipart-post<3"
+short_desc="HTTP/REST API client library"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/lostisland/faraday"
+checksum=a2d4d2d05f557c2a6f87ae91cf3d61f757fc9c031dcac9ac9acf7cb011eb1c9a
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/ruby-faraday_middleware/template
+++ b/srcpkgs/ruby-faraday_middleware/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-faraday_middleware'
+pkgname=ruby-faraday_middleware
+version=0.12.2
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-faraday>=0.7.4 ruby-faraday<1.0"
+short_desc="Various middleware for Faraday"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/lostisland/faraday_middleware"
+checksum=2d90093c18c23e7f5a6f602ed3114d2c62abc3f7f959dd3046745b24a863f1dc
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/ruby-ffi/template
+++ b/srcpkgs/ruby-ffi/template
@@ -1,0 +1,18 @@
+# Template file for 'ruby-ffi'
+pkgname=ruby-ffi
+version=1.9.25
+revision=1
+wrksrc="ffi-${version}"
+build_style=gemspec
+hostmakedepends="libffi-devel"
+makedepends="libffi-devel"
+short_desc="Ruby FFI library"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://wiki.github.com/ffi/ffi"
+distfiles="https://rubygems.org/downloads/ffi-${version}.gem"
+checksum=f854f08f08190fec772a12e863f33761d02ad3efea3c3afcdeffc8a06313f54a
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-gh/template
+++ b/srcpkgs/ruby-gh/template
@@ -1,0 +1,17 @@
+# Template file for 'ruby-gh'
+pkgname=ruby-gh
+version=0.15.1
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-addressable>=2.4.0 ruby-backports ruby-faraday>=0.8
+ ruby-multi_json>=1.0 ruby-net-http-persistent>=2.9 ruby-net-http-pipeline"
+short_desc="Multi-layer client for the GitHub v3 API"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/travis-ci/gh"
+checksum=ef733f81c17846f217f5ad9616105e9adc337775d41de1cc330133ad25708d3c
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-highline/template
+++ b/srcpkgs/ruby-highline/template
@@ -1,0 +1,11 @@
+# Template file for 'ruby-highline'
+pkgname=ruby-highline
+version=2.0.0
+revision=1
+noarch=yes
+build_style=gem
+short_desc="High-level IO library for comamndline interfaces"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="Ruby"
+homepage="https://github.com/JEG2/highline"
+checksum=74524686caf43dd56465ba847bd2c33b552028cf23973c4f1fbb5e5971f93a19

--- a/srcpkgs/ruby-launchy/template
+++ b/srcpkgs/ruby-launchy/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-launchy'
+pkgname=ruby-launchy
+version=2.4.3
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-addressable>=2.3 ruby-addressable<3.0"
+short_desc="Helper class for launching cross-platform applications"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="ISC"
+homepage="https://github.com/copiousfreetime/launchy"
+checksum=42f52ce12c6fe079bac8a804c66522a0eefe176b845a62df829defe0e37214a4
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-multi_json/template
+++ b/srcpkgs/ruby-multi_json/template
@@ -1,0 +1,15 @@
+# Template file for 'ruby-multi_json'
+pkgname=ruby-multi_json
+version=1.13.1
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Common interface for multiple JSON parsing libraries"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/intridea/multi_json"
+checksum=db8613c039b9501e6b2fb85efe4feabb02f55c3365bae52bba35381b89c780e6
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/ruby-multipart-post/template
+++ b/srcpkgs/ruby-multipart-post/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-multipart-post'
+pkgname=ruby-multipart-post
+version=2.0.0
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Use with Net::HTTP to do multipart form posts"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/nicksieger/multipart-post"
+checksum=3dc44e50d3df3d42da2b86272c568fd7b75c928d8af3cc5f9834e2e5d9586026
+
+post_install() {
+	sed -n '58,77p' README.md > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-net-http-persistent/template
+++ b/srcpkgs/ruby-net-http-persistent/template
@@ -1,0 +1,17 @@
+# Template file for 'ruby-net-http-persistent'
+pkgname=ruby-net-http-persistent
+version=3.0.0
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-connection_pool>=2.2 ruby-connection_pool<3.0"
+short_desc="Manages persistent connections using Net::HTTP"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="http://docs.seattlerb.org/net-http-persistent"
+checksum=285cbf0bc3eb6312a86f883e0f5148e764aed76127075f3836dff5b74adad994
+
+post_install() {
+	sed -n '63,82p' README.rdoc > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-net-http-pipeline/template
+++ b/srcpkgs/ruby-net-http-pipeline/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-net-http-pipeline'
+pkgname=ruby-net-http-pipeline
+version=1.0.1
+revision=1
+noarch=yes
+build_style=gem
+short_desc="HTTP/1.1 pipelining implementation atop Net::HTTP"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="http://docs.seattlerb.org/net-http-pipeline"
+checksum=6923ce2f28bfde589a9f385e999395eead48ccfe4376d4a85d9a77e8c7f0b22f
+
+post_install() {
+	sed -n '40,59p' README.txt > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-public_suffix/template
+++ b/srcpkgs/ruby-public_suffix/template
@@ -1,0 +1,15 @@
+# Template file for 'ruby-public_suffix'
+pkgname=ruby-public_suffix
+version=3.0.3
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Parse domain names into top level domain, domain and subdomains"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://simonecarletti.com/code/publicsuffix-ruby"
+checksum=d4f4addffbd1ad3e7b5bb2e258a761ccef5670c23c29b0476b2299bcca220623
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/ruby-pusher-client/template
+++ b/srcpkgs/ruby-pusher-client/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-pusher-client'
+pkgname=ruby-pusher-client
+version=0.6.2
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-websocket>=1.0 ruby-websocket<2.0"
+short_desc="Client for consuming WebSockets from http://pusher.com"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/pusher/pusher-ruby-client"
+checksum=c405c931090e126c056d99f6b69a01b1bcb6cbfdde02389c93e7d547c6efd5a3
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/ruby-travis/template
+++ b/srcpkgs/ruby-travis/template
@@ -1,0 +1,18 @@
+# Template file for 'ruby-travis'
+pkgname=ruby-travis
+version=1.8.9
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-backports ruby-faraday>=0.9 ruby-faraday_middleware>=0.9.1
+ ruby-gh>=0.13 ruby-highline>=1.6 ruby-launchy>=2.1 ruby-pusher-client>=0.4
+ ruby-typhoeus>=0.6.8"
+short_desc="CLI and Ruby library client for Travis CI"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/travis-ci/travis.rb"
+checksum=dc0f7337439e859f80c66b6bc7cb00af9c1492c4a99b5a6760517191bf018253
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-typhoeus/template
+++ b/srcpkgs/ruby-typhoeus/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-typhoeus'
+pkgname=ruby-typhoeus
+version=1.3.1
+revision=1
+noarch=yes
+build_style=gem
+depends="ruby-ethon>=0.9.0"
+short_desc="Parallel HTTP requests runner"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/typhoeus/typhoeus"
+checksum=257e7163d50bed15e52c3c25bde890ea3ad854f3bd2e3fd16ce0b216c342d132
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-websocket/template
+++ b/srcpkgs/ruby-websocket/template
@@ -1,0 +1,16 @@
+# Template file for 'ruby-websocket'
+pkgname=ruby-websocket
+version=1.2.8
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Universal Ruby library to handle WebSocket protocol"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="MIT"
+homepage="https://github.com/imanel/websocket-ruby"
+checksum=1d8155c1cdaab8e8e72587a60e08423c9dd84ee44e4e827358ce3d4c2ccb2138
+
+post_install() {
+	sed -n '125,131p' README.md > LICENSE
+	vlicense LICENSE
+}


### PR DESCRIPTION
This pull requests adds ruby-travis a commandline client for Travis CI

It also changes the gemspec and gem build_style to ignore the ~> operator
and use >= instead.

~> is a special rubygems operator that says: "Update to all version of the last version specified
but don't update to the next version of the second-to-last specifier"

example

~> 2.4.0 

means

>= 2.4.0, < 2.5

Problem is that some packages use this operator but then fail to update, ruby gems that have dead upstream still depend on old versions that work fine.

Proof is this PR which has ~> restrictions removed for ruby-gh and it is working fine.