### PR TITLE
hooks/pre-pkg: safely pass arguments to printf

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -41,7 +41,7 @@ store_pkgdestdir_rundeps() {
                      -z "$($XBPS_UHELPER_CMD getpkgname ${_curdep} 2>/dev/null)" ]; then
                     _curdep="${_curdep}>=0"
                 fi
-                printf "${_curdep} " >> ${PKGDESTDIR}/rdeps
+                printf -- "${_curdep} " >> ${PKGDESTDIR}/rdeps
             done
         fi
 }


### PR DESCRIPTION
Ran into this:

https://travis-ci.org/void-linux/void-packages/jobs/455845843#L2142