### PR TITLE
pulseaudio: enable native bluez5 headset support

### DIFF
--- a/srcpkgs/pulseaudio/template
+++ b/srcpkgs/pulseaudio/template
@@ -1,20 +1,21 @@
 # Template file for 'pulseaudio'
 pkgname=pulseaudio
 version=12.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-oss-output --disable-oss-wrapper --disable-tcpwrap
  --enable-jack --disable-lirc --disable-hal-compat --disable-gconf --enable-orc
  --with-database=tdb --with-udev-rules-dir=/usr/lib/udev/rules.d --disable-bluez4
  --disable-esound --disable-gtk3 --enable-bluez5 --disable-bluez5-ofono-headset
  --disable-systemd-login --disable-systemd-daemon --disable-systemd-journal
- --enable-webrtc-aec --with-bash-completion-dir=/usr/share/bash-completion/completions"
+ --enable-webrtc-aec --with-bash-completion-dir=/usr/share/bash-completion/completions
+ --enable-bluez5-native-headset"
 hostmakedepends="automake gettext-devel intltool libtool orc-devel pkg-config"
 makedepends="avahi-libs-devel eudev-libudev-devel fftw-devel jack-devel
- libSM-devel libXtst-devel libasyncns-devel libcap-devel libcap-progs
- libglib-devel libltdl-devel libressl-devel libsndfile-devel libsoxr-devel
- orc-devel sbc-devel speex-devel tdb-devel webrtc-audio-processing-devel
- xcb-util-devel"
+libSM-devel libXtst-devel libasyncns-devel libbluetooth-devel
+libcap-devel libcap-progs libglib-devel libltdl-devel libressl-devel
+libsndfile-devel libsoxr-devel orc-devel sbc-devel speex-devel tdb-devel
+webrtc-audio-processing-devel xcb-util-devel"
 depends="rtkit"
 conf_files="/etc/pulse/*"
 short_desc="A featureful, general-purpose sound server"


### PR DESCRIPTION
Enables users to use a bluetooth headset in HSP profile (otherwise just AD2P), which allows for e.g. microphone input.

Needs the addition of `libbluetooth-devel` to makedepends.