### PR TITLE
mongroup: remove

### DIFF
--- a/srcpkgs/mongroup/INSTALL.msg
+++ b/srcpkgs/mongroup/INSTALL.msg
@@ -1,0 +1,1 @@
+mongroup is no longer provided by Void Linux, and will be fully removed from the repos on 17/12/2018

--- a/srcpkgs/mongroup/template
+++ b/srcpkgs/mongroup/template
@@ -1,20 +1,9 @@
 # Template file for 'mongroup'
 pkgname=mongroup
 version=0.4.1
-revision=1
-short_desc="Monitor a group of processes with mon"
-maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-3"
-depends="mon"
-homepage="https://github.com/jgallen23/mongroup"
-distfiles="https://github.com/jgallen23/mongroup/archive/${version}.tar.gz"
-checksum=50c6fb0eb6880fa837238a2036f9bc77d2f6db8c66b8c9a041479e2771a925ae
+revision=2
 noarch=yes
-
-do_install() {
-	vbin bin/mongroup
-	vsconf example/alert.js
-	vsconf example/server.js
-	vconf example/mongroup.conf
-	vdoc README.md
-}
+build_style=meta
+short_desc="Monitor a group of processes with mon (removed package)"
+license="metapackage"
+homepage="https://github.com/jgallen23/mongroup"


### PR DESCRIPTION
It says the license is GPL-3 but there is no license file present.

AUR uses MIT but doesn't provide a license file.

There is no LICENSE file or COPYRIGHT file or anything so by default it is fully propietary.

@the-maldridge @Vaelatern