### PR TITLE
ttyload-git: remove

### DIFF
--- a/srcpkgs/ttyload-git/INSTALL.msg
+++ b/srcpkgs/ttyload-git/INSTALL.msg
@@ -1,0 +1,1 @@
+ttyload-git is no longer provided by Void Linux, and will be fully removed from the repos on 17/12/2018

--- a/srcpkgs/ttyload-git/template
+++ b/srcpkgs/ttyload-git/template
@@ -1,29 +1,9 @@
 # Template file for 'ttyload-git'
 pkgname=ttyload-git
 version=20141117
-revision=3
-hostmakedepends="git"
-short_desc="An ASCII colour-coded graph of load averages over time"
-maintainer="Thomas Adam <thomas.adam22@gmail.com>"
-license="ISC"
+revision=4
+noarch=yes
+build_style=meta
+short_desc="An ASCII colour-coded graph of load averages over time (removed package)"
+license="metapackage"
 homepage="http://www.daveltd.com/src/util/ttyload/"
-provides="ttyload-${version}_${revision}"
-replaces="ttyload>=0"
-
-do_fetch() {
-	local url="git://github.com/lindes/ttyload.git"
-	msg_normal "Fetching source from $url ...\n"
-	git clone ${url} ${pkgname}-${version}
-}
-
-pre_build() {
-	echo "echo '$LDFLAGS'" > ./ldflags
-}
-
-do_build() {
-	make CC=$CC OTHER_FLAGS="$CFLAGS"
-}
-
-do_install() {
-	vbin ttyload
-}


### PR DESCRIPTION
- Git package
- No upstream activity since 2013 besides tagging Pull requests