### PR TITLE
urlmatch-git: remove

### DIFF
--- a/srcpkgs/urlmatch-git/INSTALL.msg
+++ b/srcpkgs/urlmatch-git/INSTALL.msg
@@ -1,0 +1,1 @@
+urlmatch-git is no longer provided by Void Linux, and will be fully removed from the repos on 2019/02/17

--- a/srcpkgs/urlmatch-git/template
+++ b/srcpkgs/urlmatch-git/template
@@ -1,19 +1,9 @@
 # Template file for 'urlmatch-git'
 pkgname=urlmatch-git
 version=20141116
-revision=1
-build_style=gnu-makefile
-hostmakedepends="git"
-makedepends="zlib-devel"
-short_desc="A fast URL matcher library (git snapshot)"
-maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="AGPL-3"
+revision=2
+noarch=yes
+build_style=meta
+short_desc="A fast URL matcher library (git snapshot) (removed package)"
+license="metapackage"
 homepage="https://github.com/clbr/urlmatch"
-
-do_fetch() {
-	git clone git://github.com/clbr/urlmatch ${wrksrc}
-}
-do_install() {
-	vinstall urlmatch.h 644 usr/include
-	vinstall liburlmatch.a 644 usr/lib
-}


### PR DESCRIPTION
- Git package
- Has a release nobody bothered to update to, the release is from 2015
- The last release is from 2015
- The last commit is from 2015