### PR TITLE
common: merge only_for_archs and noarch=yes into one.

### DIFF
--- a/common/environment/setup-subpkg/subpkg.sh
+++ b/common/environment/setup-subpkg/subpkg.sh
@@ -43,3 +43,6 @@ unset -v binfmts
 
 # xbps-triggers: register-shell
 unset -v register_shell
+
+# deprecated
+unset -v noarch

--- a/common/environment/setup-subpkg/subpkg.sh
+++ b/common/environment/setup-subpkg/subpkg.sh
@@ -2,7 +2,7 @@
 # a package template and can also be used in subpkgs.
 
 ## VARIABLES
-unset -v noarch conf_files mutable_files preserve triggers alternatives
+unset -v conf_files mutable_files preserve triggers alternatives
 unset -v depends run_depends replaces provides conflicts tags
 
 # hooks/post-install/03-strip-and-debug-pkgs

--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -3,7 +3,7 @@
 
 ## VARIABLES
 unset -v pkgname version revision short_desc homepage license maintainer
-unset -v only_for_archs distfiles checksum build_style build_helper nocross broken
+unset -v archs only_for_archs distfiles checksum build_style build_helper nocross broken
 unset -v configure_script configure_args wrksrc build_wrksrc create_wrksrc
 unset -v make_build_args make_check_args make_install_args
 unset -v make_build_target make_check_target make_install_target

--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -33,3 +33,6 @@ unset -f pre_build do_build post_build
 unset -f pre_check do_check post_check
 unset -f pre_install do_install post_install
 unset -f do_clean
+
+# deprecated
+unset -v only_for_arch

--- a/common/hooks/do-pkg/00-gen-pkg.sh
+++ b/common/hooks/do-pkg/00-gen-pkg.sh
@@ -97,14 +97,14 @@ hook() {
 	local arch= binpkg= repo= _pkgver= _desc= _pkgn= _pkgv= _provides= \
 		_replaces= _reverts= f= found_dbg_subpkg=
 
-	if [ -n "$noarch" ]; then
+	if [ "${archs// /}" = "noarch" ]; then
 		arch=noarch
 	elif [ -n "$XBPS_TARGET_MACHINE" ]; then
 		arch=$XBPS_TARGET_MACHINE
 	else
 		arch=$XBPS_MACHINE
 	fi
-	if [ -z "$noarch" -a -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
+	if [ "${archs// /}" != "noarch" -a -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
 		arch=${XBPS_ARCH}
 	fi
 

--- a/common/hooks/post-install/06-strip-and-debug-pkgs.sh
+++ b/common/hooks/post-install/06-strip-and-debug-pkgs.sh
@@ -59,7 +59,7 @@ create_debug_pkg() {
 hook() {
 	local fname= x= f= _soname= STRIPCMD=
 
-	if [ -n "$nostrip" -o -n "$noarch" ]; then
+	if [ -n "$nostrip" -o "${archs// /}" = "noarch" ]; then
 		return 0
 	fi
 

--- a/common/hooks/post-pkg/00-register-pkg.sh
+++ b/common/hooks/post-pkg/00-register-pkg.sh
@@ -13,14 +13,14 @@ registerpkg() {
 hook() {
 	local arch= binpkg= pkgdir=
 
-	if [ -n "$noarch" ]; then
+	if [ "${archs// /}" = "noarch" ]; then
 		arch=noarch
 	elif [ -n "$XBPS_TARGET_MACHINE" ]; then
 		arch=$XBPS_TARGET_MACHINE
 	else
 		arch=$XBPS_MACHINE
 	fi
-	if [ -z "$noarch" -a -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
+	if [ "${archs// /}" != "noarch" -a -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
 		arch=${XBPS_ARCH}
 	fi
 	if [ -n "$repository" ]; then

--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -56,7 +56,7 @@ hook() {
 
     mapshlibs=$XBPS_COMMONDIR/shlibs
 
-    if [ -n "$noarch" -o -n "$noverifyrdeps" ]; then
+    if [ "${archs// /}" = "noarch" -o -n "$noverifyrdeps" ]; then
         store_pkgdestdir_rundeps
         return 0
     fi

--- a/common/hooks/pre-pkg/05-prepare-32bit.sh
+++ b/common/hooks/pre-pkg/05-prepare-32bit.sh
@@ -21,7 +21,7 @@ hook() {
 		return
 	fi 
 	# Ignore noarch pkgs.
-	if [ -n "$noarch" ]; then
+	if [ "${archs// /}" = "noarch" ]; then
 		return
 	fi
 	if [ -z "$lib32mode" ]; then

--- a/common/hooks/pre-pkg/06-shlib-provides.sh
+++ b/common/hooks/pre-pkg/06-shlib-provides.sh
@@ -45,7 +45,7 @@ collect_sonames() {
 hook() {
 	local _destdir32=${XBPS_DESTDIR}/${pkgname}-32bit-${version}
 
-	if [ -z "$shlib_provides" -a -n "$noarch" -o -n "$noshlibprovides" ]; then
+	if [ -z "$shlib_provides" -a "${archs// /}" = "noarch" -o -n "$noshlibprovides" ]; then
 		return 0
 	fi
 

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -347,6 +347,22 @@ setup_pkg() {
         source_file ${XBPS_SRCPKGDIR}/${basepkg}/template
     fi
 
+    # Backward compatibility to noarch and only_for_archs
+    if [ -n "$only_for_archs" ] && [ -n "$noarch" ]; then
+        msg_error "only_for_archs and noarch can't be used together\n"
+    fi
+    if [ -n "$only_for_archs" ]; then
+        archs="$only_for_archs"
+        unset only_for_archs
+        msg_warn "deprecated property 'only_for_archs'. Use archs=\"$only_for_archs\" instead!\n"
+    fi
+    if [ -n "$noarch" ]; then
+        archs=noarch
+        unset noarch
+        msg_warn "deprecated property 'noarch'. Use archs=noarch instead!\n"
+    fi
+
+
     # Check if required vars weren't set.
     _vars="pkgname version short_desc revision homepage license"
     for f in ${_vars}; do

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -411,7 +411,8 @@ setup_pkg() {
     fi
     makejobs="-j$XBPS_MAKEJOBS"
 
-    if [ -n "$noarch" ]; then
+    # strip whitespaces to make "  noarch  " valid too.
+    if [ "${archs// /}" = "noarch" ]; then
         arch="noarch"
     else
         arch="$XBPS_TARGET_MACHINE"

--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -1,9 +1,9 @@
 # vim: set ts=4 sw=4 et:
 
 check_pkg_arch() {
-    local cross="$1" _arch f found
+    local cross="$1" _arch f match nonegation
 
-    if [ -n "$only_for_archs" ]; then
+    if [ -n "$archs" -o "${archs// /}" != "noarch" ]; then
         if [ -n "$cross" ]; then
             _arch="$XBPS_TARGET_MACHINE"
         elif [ -n "$XBPS_ARCH" ]; then
@@ -11,13 +11,16 @@ check_pkg_arch() {
         else
             _arch="$XBPS_MACHINE"
         fi
-        for f in ${only_for_archs}; do
-            if [ "$f" = "${_arch}" ]; then
-                found=1
-                break
-            fi
+        set -f
+        for f in ${archs}; do
+            set +f
+            nonegation=${f##\~*}
+            f=${f#\~}
+            case "${_arch}" in
+                $f) match=1; break ;;
+            esac
         done
-        if [ -z "$found" ]; then
+        if [ -z "$nonegation" -a -n "$match" ] || [ -n "$nonegation" -a -z "$match" ]; then
             msg_red "$pkgname: this package cannot be built for ${_arch}.\n"
             exit 2
         fi

--- a/common/xbps-src/shutils/show.sh
+++ b/common/xbps-src/shutils/show.sh
@@ -12,7 +12,9 @@ show_pkg() {
     for i in ${checksum}; do
         [ -n "$i" ] && echo "checksum:	$i"
     done
-    [ -n "$noarch" ] && echo "noarch:		yes"
+    for i in ${archs}; do
+        [ -n "$i" ] && echo "archs:		$i"
+    done
     echo "maintainer:	$maintainer"
     [ -n "$homepage" ] && echo "Upstream URL:	$homepage"
     [ -n "$license" ] && echo "License(s):	$license"


### PR DESCRIPTION
(reopened from https://github.com/voidlinux/void-packages/pull/3109)

- noarch=yes is replaced with archs=noarch
- only_for_archs= is renamed to archs=
- archs= allows the use of wildcards and negations; first matching rule applies:
  - archs="*-musl" will build the pkg only for musl-libcs
  - archs="~*-musl" will build the pkg only on non-musl-libc
  - archs="x86_64-musl ~*-musl" will build for x86_64-musl and any non-musl
    arch.
- archs= defaults to "*"
