### PR TITLE
rawtherapee : rebuild fix error

### DIFF
--- a/srcpkgs/rawtherapee/template
+++ b/srcpkgs/rawtherapee/template
@@ -1,7 +1,7 @@
 # Template file for 'rawtherapee'
 pkgname=rawtherapee
 version=5.4
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="fftw-devel gtkmm-devel lensfun-devel libcanberra-devel
@@ -9,7 +9,7 @@ makedepends="fftw-devel gtkmm-devel lensfun-devel libcanberra-devel
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Free RAW converter and digital photo processing software"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://rawtherapee.com/"
 license="GPL-3.0-or-later"
+homepage="http://rawtherapee.com/"
 distfiles="http://rawtherapee.com/shared/source/rawtherapee-${version}.tar.xz"
 checksum=ed08c1c3caf5dd34b41ea3261d215c729eabe9734c78181e6690088471874988


### PR DESCRIPTION
Symbol `jpeg_std_message_table' has different size in shared object, consider re-linking

Signed-off-by: Gerardo Di Iorio <arete74@gmail.com>