### PR TITLE
system-config-printer: remove old dependencies

### DIFF
--- a/srcpkgs/python3-cupshelpers
+++ b/srcpkgs/python3-cupshelpers
@@ -1,0 +1,1 @@
+system-config-printer

--- a/srcpkgs/system-config-printer-udev
+++ b/srcpkgs/system-config-printer-udev
@@ -1,0 +1,1 @@
+system-config-printer

--- a/srcpkgs/system-config-printer/template
+++ b/srcpkgs/system-config-printer/template
@@ -1,21 +1,39 @@
 # Template file for 'system-config-printer'
 pkgname=system-config-printer
 version=1.5.11
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-udev-rules"
 make_build_args="udevhelperdir=/usr/lib/udev"
 make_install_args="udevhelperdir=/usr/lib/udev udevrulesdir=/usr/lib/udev/rules.d"
 hostmakedepends="pkg-config intltool python3-devel xmlto desktop-file-utils"
-makedepends="glib-devel cups-devel eudev-libudev-devel libusb-devel"
-depends="python3-cups python3-dbus python3-curl python3-smbc python3-gobject
- python3-requests gir-freedesktop libnotify gtk+3 libgnome-keyring polkit-gnome
- dconf desktop-file-utils libsecret"
-pycompile_module="cupshelpers"
-pycompile_dirs="/usr/share/system-config-printer"
-short_desc="A CUPS printer configuration tool and status applet"
+makedepends="libglib-devel cups-devel eudev-libudev-devel libusb-devel"
+depends="python3-cupshelpers python3-smbc python3-gobject gir-freedesktop
+ libnotify gtk+3 dconf desktop-file-utils libsecret"
+pycompile_version="${py3_ver}"
+pycompile_dirs="usr/share/system-config-printer"
+short_desc="CUPS printer configuration tool and status applet"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/zdohnal/system-config-printer"
 distfiles="${homepage}/releases/download/${version}/system-config-printer-${version}.tar.gz"
 checksum=ab4a4553f536487bf2be1143529749ed9926edd84bd97c2b42666a7111d60b7f
+
+python3-cupshelpers_package() {
+	noarch=yes
+	depends="python3-cups python3-dbus python3-requests"
+	short_desc="Python utility modules around the CUPS printing system"
+	pycompile_module="cupshelpers"
+	pkg_install() {
+		vmove etc/cupshelpers
+		vmove "usr/lib/python3*"
+	}
+}
+
+system-config-printer-udev_package() {
+	depends="python3-cupshelpers"
+	short_desc="CUPS printer configuration tool (udev integration)"
+	pkg_install() {
+		vmove usr/lib/udev
+	}
+}


### PR DESCRIPTION
This commit also splits out the udev integration, which is almost useless without systemd.