### PR TITLE
Initial libgnome-keyring removal

### DIFF
--- a/srcpkgs/mate-power-manager/template
+++ b/srcpkgs/mate-power-manager/template
@@ -1,12 +1,11 @@
 # Template file for 'mate-power-manager'
 pkgname=mate-power-manager
 version=1.20.2
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--disable-schemas-compile"
+configure_args="--disable-schemas-compile --without-keyring"
 hostmakedepends="pkg-config intltool itstool libtool glib-devel dbus-glib-devel"
-makedepends="libcanberra-devel libgnome-keyring-devel libmate-panel-devel
- libnotify-devel upower-devel"
+makedepends="libcanberra-devel libmate-panel-devel libnotify-devel upower-devel"
 depends="dconf upower"
 short_desc="Power management tool for the MATE desktop"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/pinentry/template
+++ b/srcpkgs/pinentry/template
@@ -1,14 +1,15 @@
 # Template file for 'pinentry'
 pkgname=pinentry
 version=1.1.0
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-rpath --without-libcap --disable-pinentry-gtk
  --enable-pinentry-curses --enable-fallback-curses --enable-pinentry-gtk2
  --enable-pinentry-emacs --enable-pinentry-qt --enable-pinentry-tty
- --enable-pinentry-gnome3"
+ --enable-pinentry-gnome3 --enable-libsecret"
 hostmakedepends="pkg-config"
-makedepends="ncurses-devel gcr-devel gtk+-devel libassuan-devel libgpg-error-devel qt5-devel"
+makedepends="ncurses-devel gcr-devel gtk+-devel libsecret-devel libassuan-devel
+ libgpg-error-devel qt5-devel"
 short_desc="PIN or passphrase entry dialogs for GnuPG"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"
@@ -67,7 +68,7 @@ pinentry-emacs_package() {
 }
 
 pinentry-gnome_package() {
-	depends="libgnome-keyring ${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" for the GNOME desktop"
 	alternatives="pinentry:pinentry:/usr/bin/pinentry-gnome3"
 	pkg_install() {

--- a/srcpkgs/xfce4-taskmanager/template
+++ b/srcpkgs/xfce4-taskmanager/template
@@ -1,11 +1,11 @@
 # Template file for 'xfce4-taskmanager'
 pkgname=xfce4-taskmanager
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config intltool"
-makedepends="libxfce4ui-devel xfce4-panel-devel libwnck2-devel libgksu-devel libXmu-devel"
+makedepends="libxfce4ui-devel xfce4-panel-devel libwnck2-devel libXmu-devel"
 depends="hicolor-icon-theme desktop-file-utils"
 short_desc="XFCE task manager plugin"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
@Cogitri please test pinentry-gnome, considering you added the libgnome-keyring dependency there

Also see mate-desktop/mate-power-manager#239