### PR TITLE
 geth: Fix license

### DIFF
--- a/srcpkgs/geth/template
+++ b/srcpkgs/geth/template
@@ -1,14 +1,14 @@
 # Template file for 'geth'
 pkgname=geth
 version=1.8.18
-revision=1
+revision=2
 wrksrc="go-ethereum-${version}"
 build_style=go
 go_import_path="github.com/ethereum/go-ethereum"
 go_package="${go_import_path}/cmd/geth"
 short_desc="Official Go implementation of the Ethereum protocol"
 maintainer="Hoang Nguyen <hoang@wetrust.io>"
-license="LGPL-3.0-only"
+license="GPL-3.0-only"
 homepage="https://geth.ethereum.org"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
 checksum=cbab18a733298830c9ed1e19c1ece37edf417fd55ec8f198803048ecc3ffa0b9


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum#license

Anything inside `cmd` folder is `GPL-3.0`