### PR TITLE
Rebuild packages for missing metadata vol. 5

### DIFF
--- a/srcpkgs/libIDL/template
+++ b/srcpkgs/libIDL/template
@@ -1,14 +1,14 @@
-# Template build file for 'libIDL'.
+# Template file for 'libIDL'
 pkgname=libIDL
 version=0.8.14
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config flex"
 makedepends="libglib-devel"
 short_desc="CORBA Interface Definition Language parser"
-homepage="http://projects.gnome.org/ORBit2/"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.0-or-later"
+homepage="http://projects.gnome.org/ORBit2/"
 distfiles="${GNOME_SITE}/$pkgname/0.8/$pkgname-$version.tar.bz2"
 checksum=c5d24d8c096546353fbc7cedf208392d5a02afe9d56ebcc1cccb258d7c4d2220
 

--- a/srcpkgs/libXaw/template
+++ b/srcpkgs/libXaw/template
@@ -1,15 +1,15 @@
-# Template build file for 'libXaw'.
+# Template file for 'libXaw'
 pkgname=libXaw
 version=1.0.13
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-xmlto"
 hostmakedepends="pkg-config"
 makedepends="libXext-devel libXt-devel libXmu-devel libXpm-devel"
 short_desc="X Athena Widgets Library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://xorg.freedesktop.org"
 license="MIT"
+homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/lib/$pkgname-$version.tar.bz2"
 checksum=8ef8067312571292ccc2bbe94c41109dcf022ea5a4ec71656a83d8cce9edb0cd
 

--- a/srcpkgs/libart/template
+++ b/srcpkgs/libart/template
@@ -1,14 +1,14 @@
-# Template build file for 'libart'.
+# Template file for 'libart'
 pkgname=libart
 version=2.3.21
-revision=6
+revision=7
 wrksrc="libart_lgpl-$version"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 short_desc="High-performance 2D graphics library"
-homepage="http://www.levien.com/libart/"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.0-or-later"
+homepage="http://www.levien.com/libart/"
 distfiles="${GNOME_SITE}/libart_lgpl/2.3/libart_lgpl-$version.tar.bz2"
 checksum=fdc11e74c10fc9ffe4188537e2b370c0abacca7d89021d4d303afdf7fd7476fa
 

--- a/srcpkgs/libasr/template
+++ b/srcpkgs/libasr/template
@@ -1,17 +1,17 @@
 # Template file for 'libasr'
 pkgname=libasr
 version=1.0.2
-revision=2
+revision=3
+wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 makedepends="libressl-devel"
 short_desc="Simple and portable asynchronous resolver library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="ISC, BSD"
+license="BSD-2-Clause"
 homepage="https://www.opensmtpd.org/"
 distfiles="https://github.com/OpenSMTPD/${pkgname}/archive/${pkgname}-${version}.tar.gz"
 checksum=4ab54264206e255fd6c2de982764bb5ce7857ec8f649ad3ee45771244593b6e1
-wrksrc="${pkgname}-${pkgname}-${version}"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) ;;

--- a/srcpkgs/libatasmart/template
+++ b/srcpkgs/libatasmart/template
@@ -1,15 +1,15 @@
 # Template file for 'libatasmart'
 pkgname=libatasmart
 version=0.19
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --disable-static"
 hostmakedepends="automake libtool pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="ATA S.M.A.R.T. Reading and Parsing Library"
-homepage="http://0pointer.de/blog/projects/being-smart.html"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
+homepage="http://0pointer.de/blog/projects/being-smart.html"
 distfiles="http://0pointer.de/public/$pkgname-$version.tar.xz"
 checksum=61f0ea345f63d28ab2ff0dc352c22271661b66bf09642db3a4049ac9dbdb0f8d
 

--- a/srcpkgs/libbs2b/template
+++ b/srcpkgs/libbs2b/template
@@ -1,13 +1,13 @@
 # Template file for 'libbs2b'
 pkgname=libbs2b
 version=3.1.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libsndfile-devel"
 short_desc="Audiofilter for headphones"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
-license="GPL-2, MIT"
+license="MIT"
 homepage="http://bs2b.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/bs2b/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
 checksum=6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528

--- a/srcpkgs/libchardet/template
+++ b/srcpkgs/libchardet/template
@@ -1,13 +1,13 @@
-# Template build file for 'libchardet'.
+# Template file for 'libchardet'
 pkgname=libchardet
 version=1.0.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="perl"
 short_desc="Mozilla's Universal Charset Detector C/C++ API"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://ftp.oops.org/pub/oops/libchardet/"
 license="MPL-1.1"
+homepage="http://ftp.oops.org/pub/oops/libchardet/"
 distfiles="http://ftp.oops.org/pub/oops/libchardet/libchardet-${version}.tar.bz2"
 checksum=f43f5a63901f19780b5cd61ad130d432a9414e2e4da2abc0e1b80845895a7c33
 

--- a/srcpkgs/libcryptui/template
+++ b/srcpkgs/libcryptui/template
@@ -1,18 +1,18 @@
 # Template file for 'libcryptui'
 pkgname=libcryptui
 version=3.12.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-update-mime-database
 --disable-schemas-compile"
-hostmakedepends="pkg-config intltool"
+hostmakedepends="pkg-config intltool dbus-glib-devel glib gnupg"
 makedepends="libSM-devel dbus-glib-devel gtk+3-devel gpgme-devel
- libnotify-devel libgnome-keyring-devel gnupg"
+ libnotify-devel libgnome-keyring-devel"
 depends="hicolor-icon-theme libgnome-keyring>=3.10 gnupg"
 short_desc="GNOME Interface components for OpenPGP"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://www.gnome.org"
-license="GPL-2, LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=71ead1a7b496f07f6c5102ae79945dd2515b7b9342c6edefe58b47318be20866
 

--- a/srcpkgs/libdaemon/template
+++ b/srcpkgs/libdaemon/template
@@ -1,14 +1,14 @@
 # Template file for 'libdaemon'
 pkgname=libdaemon
 version=0.14
-revision=8
+revision=9
 build_style=gnu-configure
 configure_args="--disable-static --disable-lynx"
 short_desc="Lightweight C library that eases the writing of UNIX daemons"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://0pointer.de/lennart/projects/$pkgname"
-license="LGPL-2.1"
-distfiles="http://pkgs.fedoraproject.org/repo/pkgs/libdaemon/libdaemon-0.14.tar.gz/509dc27107c21bcd9fbf2f95f5669563/libdaemon-0.14.tar.gz"
+distfiles="http://pkgs.fedoraproject.org/repo/pkgs/libdaemon/libdaemon-${version}.tar.gz/509dc27107c21bcd9fbf2f95f5669563/libdaemon-${version}.tar.gz"
 checksum=fd23eb5f6f986dcc7e708307355ba3289abe03cc381fc47a80bca4a50aa6b834
 
 libdaemon-devel_package() {

--- a/srcpkgs/libdbusmenu-qt/template
+++ b/srcpkgs/libdbusmenu-qt/template
@@ -1,13 +1,13 @@
 # Template file for 'libdbusmenu-qt'
 pkgname=libdbusmenu-qt
 version=0.9.2
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="doxygen qt-host-tools qt-devel"
 makedepends="qt-devel"
 short_desc="A library that provides a Qt implementation of the DBusMenu spec"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://launchpad.net/libdbusmenu-qt"
 distfiles="http://launchpad.net/${pkgname}/trunk/${version}/+download/${pkgname}-${version}.tar.bz2"
 checksum=ae6c1cb6da3c683aefed39df3e859537a31d80caa04f3023315ff09e5e8919ec

--- a/srcpkgs/libdmtx/template
+++ b/srcpkgs/libdmtx/template
@@ -1,14 +1,18 @@
 # Template file for 'libdmtx'
 pkgname=libdmtx
 version=0.7.4
-revision=2
+revision=3
 build_style=gnu-configure
-maintainer="Orphaned <orphan@voidlinux.eu>"
-license="BSD-2"
-homepage="http://www.libdmtx.org/"
 short_desc="Library for reading and writing Data Matrix barcodes"
+maintainer="Orphaned <orphan@voidlinux.eu>"
+license="BSD-2-Clause"
+homepage="http://www.libdmtx.org/"
 distfiles="$SOURCEFORGE_SITE/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=b62c586ac4fad393024dadcc48da8081b4f7d317aa392f9245c5335f0ee8dd76
+
+post_install() {
+	vlicense LICENSE
+}
 
 libdmtx-devel_package() {
 	depends="${sourcepkg}-${version}_${revision}"

--- a/srcpkgs/libee/template
+++ b/srcpkgs/libee/template
@@ -1,14 +1,14 @@
 # Template file for 'libee'
 pkgname=libee
 version=0.4.1
-revision=3
+revision=4
 build_style=gnu-configure
-configure_args="--sbindir=/usr/bin --disable-static"
+configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libestr-devel"
 short_desc="Event expression library inspired by CEE"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://www.libee.org"
 distfiles="$homepage/files/download/$pkgname-$version.tar.gz"
 checksum=c0dac01938593deee06c3d161e4eda4ecc0fd7317e1321bd96e301aceb7fb027

--- a/srcpkgs/libev/template
+++ b/srcpkgs/libev/template
@@ -1,11 +1,11 @@
 # Template file for 'libev'
 pkgname=libev
 version=4.24
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="High-performance event loop loosely modelled after libevent"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2, 2-clause-BSD"
+license="GPL-2.0-or-later, BSD-2-Clause"
 homepage="http://software.schmorp.de/pkg/libev.html"
 distfiles="http://dist.schmorp.de/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=973593d3479abdf657674a55afe5f78624b0e440614e2b8cb3a07f16d4d7f821
@@ -13,6 +13,7 @@ checksum=973593d3479abdf657674a55afe5f78624b0e440614e2b8cb3a07f16d4d7f821
 post_install() {
 	# Conflicts with libevent, not necessary.
 	rm -f ${DESTDIR}/usr/include/event.h
+	vlicense LICENSE
 }
 
 libev-devel_package() {

--- a/srcpkgs/libfirm/template
+++ b/srcpkgs/libfirm/template
@@ -1,16 +1,20 @@
 # Template file for 'libfirm'
 pkgname=libfirm
 version=1.22.0
-revision=1
+revision=2
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-makefile
 hostmakedepends="perl python"
 short_desc="Graph based SSA intermediate code representation"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="LGPL-2.1"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="LGPL-2.1-or-later"
 homepage="http://libfirm.org/"
 distfiles="https://github.com/MatzeB/${pkgname}/archive/${pkgname}-${version}.tar.gz"
 checksum=2e681db62610a41394f1aa3a62583acff8a67cea138354be6b3d2d8d390665c3
+
+case "$XBPS_TARGET_MACHINE" in
+	aarch64*) broken="Unsupported long double format" ;;
+esac
 
 do_configure() {
 	cat <<EOF >config.mak

--- a/srcpkgs/libgee/template
+++ b/srcpkgs/libgee/template
@@ -1,14 +1,14 @@
 # Template file for 'libgee'
 pkgname=libgee
 version=0.6.8
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config intltool glib-devel"
 makedepends="libglib-devel vala-devel"
 short_desc="GObject collection library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/Libgee"
 distfiles="${GNOME_SITE}/$pkgname/0.6/$pkgname-$version.tar.xz"
 checksum=a61f8d796173d41f6144a030d4bd22461f0bb3fa18a3ebe02341b315feebf5d3

--- a/srcpkgs/libgnome-keyring/template
+++ b/srcpkgs/libgnome-keyring/template
@@ -1,15 +1,16 @@
 # Template file for 'libgnome-keyring'
 pkgname=libgnome-keyring
 version=3.12.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection)"
 hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
 makedepends="dbus-devel libglib-devel libgcrypt-devel"
+checkdepends="glib-devel"
 short_desc="GNOME keyring client library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://www.gnome.org"
-license="GPL-2, LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783
 

--- a/srcpkgs/libgnomecanvas/template
+++ b/srcpkgs/libgnomecanvas/template
@@ -1,15 +1,15 @@
 # Template file for 'libgnomecanvas'
 pkgname=libgnomecanvas
 version=2.30.3
-revision=8
+revision=9
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config intltool glib-devel"
 makedepends="gtk+-devel libart-devel"
 short_desc="GNOME Canvas library"
-homepage="http://gnome.org/"
-license="LGPL-2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.0-or-later"
+homepage="http://gnome.org/"
 distfiles="${GNOME_SITE}/$pkgname/2.30/$pkgname-$version.tar.bz2"
 checksum=859b78e08489fce4d5c15c676fec1cd79782f115f516e8ad8bed6abcb8dedd40
 

--- a/srcpkgs/libgssglue/template
+++ b/srcpkgs/libgssglue/template
@@ -1,19 +1,20 @@
 # Template file for 'libgssglue'
 pkgname=libgssglue
 version=0.4
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--disable-static"
 conf_files="/etc/gssapi_mech.conf"
 short_desc="Mechanism-switch gssapi library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="http://www.citi.umich.edu/projects/nfsv4/linux/"
 distfiles="$homepage/$pkgname/$pkgname-$version.tar.gz"
 checksum=3f791a75502ba723e5e85e41e5e0c711bb89e2716b7c0ec6e74bd1df6739043a
 
 post_install() {
 	vconf ${FILESDIR}/gssapi_mech.conf
+	vlicense COPYING
 }
 
 libgssglue-devel_package() {

--- a/srcpkgs/libguess/template
+++ b/srcpkgs/libguess/template
@@ -1,14 +1,14 @@
 # Template file for 'libguess'
 pkgname=libguess
 version=1.2
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libmowgli-devel"
 short_desc="High-speed character set detection library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-3-clause"
 homepage="http://www.atheme.org/project/libguess"
-license="3-clause-BSD"
 distfiles="http://rabbit.dereferenced.org/~nenolod/distfiles/libguess-${version}.tar.bz2"
 checksum=8019a16bdc7ca9d2efbdcc1429d48d033d5053d42e45fccea10abf98074f05f8
 

--- a/srcpkgs/libieee1284/template
+++ b/srcpkgs/libieee1284/template
@@ -1,14 +1,14 @@
 # Template file for 'libieee1284'
 pkgname=libieee1284
 version=0.2.11
-revision=3
+revision=4
 only_for_archs="i686 i686-musl x86_64 x86_64-musl"
 build_style=gnu-configure
 configure_args="--disable-static --without-python"
 short_desc="A library to query devices connected in parallel port"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://cyberelk.net/tim/libieee1284"
-license="GPL-2"
 distfiles="$SOURCEFORGE_SITE/$pkgname/$pkgname-$version.tar.bz2"
 checksum=7730de107782e5d2b071bdcb5b06a44da74856f00ef4a9be85d1ba4806a38f1a
 

--- a/srcpkgs/libkeybinder3/template
+++ b/srcpkgs/libkeybinder3/template
@@ -1,7 +1,7 @@
 # Template file for 'libkeybinder3'
 pkgname=libkeybinder3
 version=0.3.1
-revision=1
+revision=2
 wrksrc="keybinder-keybinder-3.0-v${version}"
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection)"

--- a/srcpkgs/libmad/template
+++ b/srcpkgs/libmad/template
@@ -1,13 +1,13 @@
 # Template file for 'libmad'
 pkgname=libmad
 version=0.15.1b
-revision=8
+revision=9
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 short_desc="High-quality MPEG audio decoder"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://www.underbit.com/products/mad/"
-license="GPL-2"
 distfiles="${SOURCEFORGE_SITE}/mad/$pkgname-$version.tar.gz"
 checksum=bbfac3ed6bfbc2823d3775ebb931087371e142bb0e9bb1bee51a76a6e0078690
 

--- a/srcpkgs/libmcrypt/template
+++ b/srcpkgs/libmcrypt/template
@@ -1,11 +1,11 @@
 # Template file for 'libmcrypt'
 pkgname=libmcrypt
 version=2.5.8
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="A data encryption library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://mcrypt.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/mcrypt/$pkgname-$version.tar.bz2"
 checksum=bf2f1671f44af88e66477db0982d5ecb5116a5c767b0a0d68acb34499d41b793

--- a/srcpkgs/libmms/template
+++ b/srcpkgs/libmms/template
@@ -1,14 +1,14 @@
 # Template file for 'libmms'
 pkgname=libmms
 version=0.6.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
 short_desc="MMS stream protocol library"
-homepage="http://sourceforge.net/projects/libmms/"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.0-or-later"
+homepage="http://sourceforge.net/projects/libmms/"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=3c05e05aebcbfcc044d9e8c2d4646cd8359be39a3f0ba8ce4e72a9094bee704f
 

--- a/srcpkgs/libmng/template
+++ b/srcpkgs/libmng/template
@@ -1,15 +1,19 @@
-# Template build file for 'libmng'.
+# Template file for 'libmng'
 pkgname=libmng
 version=2.0.3
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libjpeg-turbo-devel zlib-devel lcms2-devel"
 short_desc="Multiple-image Network Graphics (MNG) reference library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="custom"
 homepage="http://www.libmng.com"
-license="BSD"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=4a462fdd48d4bc82c1d7a21106c8a18b62f8cc0042454323058e6da0dbb57dd3
+
+post_install() {
+	vlicense LICENSE
+}
 
 libmng-devel_package() {
 	depends="${makedepends} libmng>=${version}_${revision}"

--- a/srcpkgs/libmpcdec/template
+++ b/srcpkgs/libmpcdec/template
@@ -1,14 +1,18 @@
 # Template file for 'libmpcdec'
 pkgname=libmpcdec
 version=1.2.6
-revision=5
+revision=6
 build_style=gnu-configure
 short_desc="Portable Musepack decoder library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-3-Clause"
 homepage="http://musepack.net/"
-license="BSD"
 distfiles="http://files.musepack.net/source/$pkgname-$version.tar.bz2"
 checksum=4bd54929a80850754f27b568d7891e1e3e1b8d2f208d371f27d1fda09e6f12a8
+
+post_install() {
+	vlicense COPYING
+}
 
 libmpcdec-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libmpd/template
+++ b/srcpkgs/libmpd/template
@@ -1,13 +1,13 @@
 # Template file for 'libmpd'
 pkgname=libmpd
 version=11.8.17
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
 short_desc="Signal based wrapper around libmpdclient"
 maintainer="Dave Davenport <qball@gmpclient.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://gmpc.wikia.com/wiki/Gnome_Music_Player_Client"
 distfiles="http://download.sarine.nl/Programs/gmpc/${version%.*}/${pkgname}-${version}.tar.gz"
 checksum=fe20326b0d10641f71c4673fae637bf9222a96e1712f71f170fca2fc34bf7a83

--- a/srcpkgs/libnfnetlink/template
+++ b/srcpkgs/libnfnetlink/template
@@ -1,12 +1,12 @@
 # Template file for 'libnfnetlink'
 pkgname=libnfnetlink
 version=1.0.1
-revision=3
+revision=4
 build_style=gnu-configure
+short_desc="Low-level library for netfilter kernel/userspace communication"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.netfilter.org/projects/libnfnetlink/index.html"
-short_desc="A low-level library for netfilter kernel/userspace communication"
 distfiles="http://www.netfilter.org/projects/${pkgname}/files/${pkgname}-${version}.tar.bz2"
 checksum=f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a
 

--- a/srcpkgs/libnfsidmap/template
+++ b/srcpkgs/libnfsidmap/template
@@ -1,17 +1,21 @@
 # Template file for 'libnfsidmap'
 pkgname=libnfsidmap
 version=0.26
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake libtool"
 makedepends="libldap-devel"
 short_desc="Library to help mapping IDs, mainly for NFSv4"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="http://www.citi.umich.edu/projects/nfsv4/linux/"
 distfiles="https://fedorapeople.org/~steved/${pkgname}/${version}/${pkgname}-${version}.tar.bz2"
 checksum=391cd35a8aa48bcba1678b483c3e2525d0990eca963bb035962fcf1e3ee2a8bf
+
+post_install() {
+	vlicense COPYING
+}
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/liboauth/template
+++ b/srcpkgs/liboauth/template
@@ -1,15 +1,15 @@
 # Template file for 'liboauth'
 pkgname=liboauth
 version=1.0.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-nss"
 hostmakedepends="pkg-config"
 makedepends="libcurl-devel nss-devel"
 short_desc="C library implementing OAuth Core RFC 5849"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://liboauth.sourceforge.net"
 license="MIT"
+homepage="http://liboauth.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=0df60157b052f0e774ade8a8bac59d6e8d4b464058cc55f9208d72e41156811f
 

--- a/srcpkgs/liboil/template
+++ b/srcpkgs/liboil/template
@@ -1,15 +1,19 @@
-# Template build file for 'liboil'.
+# Template file for 'liboil'
 pkgname=liboil
 version=0.3.17
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 short_desc="Library of Optimized Inner Loops, CPU optimized functions"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-2-Clause"
 homepage="${XORG_HOME}"
-license="BSD"
 distfiles="http://liboil.freedesktop.org/download/$pkgname-$version.tar.gz"
 checksum=105f02079b0b50034c759db34b473ecb5704ffa20a5486b60a8b7698128bfc69
+
+post_install() {
+	vlicense COPYING
+}
 
 liboil-devel_package() {
 	depends="liboil>=${version}_${revision}"

--- a/srcpkgs/libpano13/template
+++ b/srcpkgs/libpano13/template
@@ -1,17 +1,18 @@
 # Template file for 'libpano13'
 pkgname=libpano13
 version=2.9.19
-revision=1
-short_desc="Panorama Pictures Tools library"
-maintainer="Martin Riese <grauehaare@gmx.de>"
-license="GPL-2"
-homepage="http://panotools.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/panotools/${pkgname}/${pkgname}-2.9.19/${pkgname}-${version}.tar.gz"
-checksum="037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8"
+revision=2
+wrksrc="libpano13-${version}"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="zlib-devel libpng-devel libjpeg-turbo-devel tiff-devel"
-wrksrc=${pkgname}-2.9.19
+checkdepends="perl"
+short_desc="Panorama Pictures Tools library"
+maintainer="Martin Riese <grauehaare@gmx.de>"
+license="GPL-2.0-or-later"
+homepage="http://panotools.sourceforge.net/"
+distfiles="${SOURCEFORGE_SITE}/panotools/libpano13/libpano13-${version}/libpano13-${version}.tar.gz"
+checksum=037357383978341dea8f572a5d2a0876c5ab0a83dffda431bd393357e91d95a8
 
 libpano13-devel_package() {
 	depends="libpano13>=${version}_${revision}"

--- a/srcpkgs/libquvi/template
+++ b/srcpkgs/libquvi/template
@@ -1,18 +1,18 @@
 # Template file for 'libquvi'
 pkgname=libquvi
 version=0.4.1
-revision=7
+revision=8
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="lua52-devel libcurl-devel libquvi-scripts"
 depends="libquvi-scripts>=${version}"
-replaces="quvi<0.4.0"
 short_desc="C library that can be used to parse flash media stream URLs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://quvi.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/quvi/$pkgname-$version.tar.gz"
 checksum=143c92b065b7ddc2ac87c4b9679ee99df0f1dccd2d0dbda15da0a54ae280dec8
+replaces="quvi<0.4.0"
 
 pre_configure() {
 	sed -i configure -e 's;"lua >= 5.1";"lua5.2 >= 5.1";g'

--- a/srcpkgs/librlog/template
+++ b/srcpkgs/librlog/template
@@ -1,12 +1,12 @@
 # Template file for 'librlog'
 pkgname=librlog
 version=1.4
-revision=4
+revision=5
 wrksrc="rlog-$version"
 build_style=gnu-configure
 short_desc="Flexible message logging facility for C++ programs and libraries"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://www.arg0.net/rlog"
 distfiles="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rlog/rlog-$version.tar.gz"
 checksum=a938eeedeb4d56f1343dc5561bc09ae70b24e8f70d07a6f8d4b6eed32e783f79

--- a/srcpkgs/libshout/template
+++ b/srcpkgs/libshout/template
@@ -1,12 +1,12 @@
 # Template file for 'libshout'
 pkgname=libshout
 version=2.4.1
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libtheora-devel libvorbis-devel speex-devel"
 short_desc="Icecast client library"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-3"
+license="LGPL-2.0-or-later"
 homepage="http://www.icecast.org/"
 distfiles="http://downloads.xiph.org/releases/libshout/libshout-$version.tar.gz"
 checksum=f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d

--- a/srcpkgs/libspiro/template
+++ b/srcpkgs/libspiro/template
@@ -1,12 +1,12 @@
 # Template file for 'libspiro'
 pkgname=libspiro
 version=0.5.20150702
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="Simplifies the drawing of beautiful curves"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-3"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-3.0-or-later"
 homepage="https://github.com/fontforge/libspiro"
 distfiles="https://github.com/fontforge/${pkgname}/archive/${version}.tar.gz"
 checksum=14f761d83c7fa6be31c4e0317251ed1201b367dc5b2a8678e2da179d74938fc7

--- a/srcpkgs/libstatgrab/template
+++ b/srcpkgs/libstatgrab/template
@@ -1,15 +1,15 @@
 # Template file for 'libstatgrab'
 pkgname=libstatgrab
 version=0.91
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="autoconf"
 makedepends="ncurses-devel"
 short_desc="Library being useful interface to system statistics"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="http://www.i-scream.org/libstatgrab"
-license="LGPL-2.1, GPL-2"
 distfiles="http://www.mirrorservice.org/sites/ftp.i-scream.org/pub/i-scream/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=03e9328e4857c2c9dcc1b0347724ae4cd741a72ee11acc991784e8ef45b7f1ab
 

--- a/srcpkgs/libtheora/template
+++ b/srcpkgs/libtheora/template
@@ -1,17 +1,21 @@
-# Template file for 'libtheora'.
+# Template file for 'libtheora'
 pkgname=libtheora
 version=1.1.1
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--disable-examples --disable-vorbistest --disable-sdltest"
 hostmakedepends="pkg-config"
 makedepends="libogg-devel"
 short_desc="Theora Video Compression Codec"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-3-Clause"
 homepage="http://www.theora.org"
-license="BSD"
 distfiles="http://downloads.xiph.org/releases/theora/$pkgname-$version.tar.xz"
 checksum=f36da409947aa2b3dcc6af0a8c2e3144bc19db2ed547d64e9171c59c66561c61
+
+post_install() {
+	vlicense COPYING
+}
 
 libtheora-devel_package() {
 	depends="libogg-devel libtheora>=${version}_${revision}"

--- a/srcpkgs/libtsm/template
+++ b/srcpkgs/libtsm/template
@@ -1,7 +1,7 @@
 # Template file for 'libtsm'
 pkgname=libtsm
 version=3
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libxkbcommon-devel"

--- a/srcpkgs/libunique/template
+++ b/srcpkgs/libunique/template
@@ -1,15 +1,15 @@
-# Template file for 'libunique'.
+# Template file for 'libunique'
 pkgname=libunique
 version=3.0.2
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--enable-bacon=yes --enable-dbus=yes"
 hostmakedepends="pkg-config glib-devel"
 makedepends="dbus-glib-devel gtk+3-devel"
 short_desc="Library for writing single instance applications"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/LibUnique"
-license="LGPL-2.1"
 distfiles="${GNOME_SITE}/$pkgname/3.0/$pkgname-$version.tar.bz2"
 checksum=50269a87c7aabf1e25f01b3bbb280133138ffd7b6776289894c614a4b6ca968d
 

--- a/srcpkgs/libunique1/template
+++ b/srcpkgs/libunique1/template
@@ -1,19 +1,19 @@
-# Template file for 'libunique1'.
+# Template file for 'libunique1'
 pkgname=libunique1
 version=1.1.6
-revision=8
+revision=9
 wrksrc="libunique-${version}"
-patch_args="-Np1"
 build_style=gnu-configure
 configure_args="--disable-static --disable-dbus $(vopt_if gir gobject-introspection)"
 hostmakedepends="libtool automake pkg-config glib-devel"
 makedepends="libSM-devel gtk+-devel"
 short_desc="Library for writing single instance applications (GTK+2)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/LibUnique"
-license="LGPL-2.1"
 distfiles="${GNOME_SITE}/libunique/1.1/libunique-$version.tar.bz2"
 checksum=e5c8041cef8e33c55732f06a292381cb345db946cf792a4ae18aa5c66cdd4fbb
+patch_args="-Np1"
 
 CFLAGS="-Wno-deprecated-declarations"
 

--- a/srcpkgs/libusb-compat/template
+++ b/srcpkgs/libusb-compat/template
@@ -1,13 +1,13 @@
 # Template file for 'libusb-compat'
 pkgname=libusb-compat
 version=0.1.5
-revision=6
+revision=7
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libusb-devel"
 short_desc="A libusb-0.1 compatibility library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://libusb.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/libusb/$pkgname-$version.tar.bz2"
 checksum=404ef4b6b324be79ac1bfb3d839eac860fbc929e6acb1ef88793a6ea328bc55a

--- a/srcpkgs/libutempter/template
+++ b/srcpkgs/libutempter/template
@@ -1,11 +1,11 @@
 # Template file for 'libutempter'
 pkgname=libutempter
 version=1.1.6
-revision=4
+revision=5
 build_style=gnu-makefile
 short_desc="Library interface to record user sessions in utmp/wtmp files"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://freecode.com/projects/libutempter"
 distfiles="http://ftp.altlinux.org/pub/people/ldv/utempter/${pkgname}-${version}.tar.bz2"
 checksum=b898565f31ced7e5c1fa0a2eaa0f6ff0ed862b5fe375d26375b64bfbdfeac397

--- a/srcpkgs/libvisual/template
+++ b/srcpkgs/libvisual/template
@@ -1,13 +1,13 @@
-# Template file for 'libvisual'.
+# Template file for 'libvisual'
 pkgname=libvisual
 version=0.4.0
-revision=8
+revision=9
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 short_desc="Abstraction library for audio visualisation plugins"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://sourceforge.net/projects/libvisual/"
-license="LGPL-2.1"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=0b4dfdb87125e129567752089e3c8b54cefed601eef169d2533d8659da8dc1d7
 

--- a/srcpkgs/libvterm/template
+++ b/srcpkgs/libvterm/template
@@ -1,7 +1,7 @@
 # Template file for 'libvterm'
 pkgname=libvterm
 version=0.0.20151229
-revision=1
+revision=2
 _commit=04c0777b139cfbddb057c0cbfc007677dd9f1b4f
 wrksrc="${pkgname}-${_commit}"
 build_style=gnu-makefile

--- a/srcpkgs/libwnck2/template
+++ b/srcpkgs/libwnck2/template
@@ -1,7 +1,7 @@
-# Template build file for 'libwnck2'.
+# Template file for 'libwnck2'
 pkgname=libwnck2
 version=2.30.7
-revision=5
+revision=6
 wrksrc="${pkgname/2/}-${version}"
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection)"
@@ -9,8 +9,8 @@ hostmakedepends="pkg-config intltool gdk-pixbuf-devel $(vopt_if gir gobject-intr
 makedepends="startup-notification-devel libXres-devel gtk+-devel"
 short_desc="Library for layout and rendering of text (GTK+2)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://www.gnome.org/"
-license="LGPL-2.1"
 distfiles="${GNOME_SITE}/libwnck/2.30/libwnck-$version.tar.bz2"
 checksum=8aabbe6c87b89b170dbd6e1577a89d248323da128fff0b3ab673010f0cd6156c
 

--- a/srcpkgs/libxdg-basedir/template
+++ b/srcpkgs/libxdg-basedir/template
@@ -1,12 +1,12 @@
 # Template file for 'libxdg-basedir'
 pkgname=libxdg-basedir
 version=1.2.0
-revision=2
+revision=3
 build_style=gnu-configure
-homepage="http://n.ethz.ch/student/nevillm/download/libxdg-basedir"
 short_desc="Implementation of the XDG Base Directory Specifications"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
+homepage="http://n.ethz.ch/student/nevillm/download/libxdg-basedir"
 #distfiles="${homepage}/${pkgname}-${version}.tar.gz"
 distfiles="http://pkgs.fedoraproject.org/lookaside/pkgs/${pkgname}/${pkgname}-${version}.tar.gz/027aaf1495f6ffa4b5a563b511d5d3f3/${pkgname}-${version}.tar.gz"
 checksum=dbabd6967130a443003eef8d5df46e518e7c929c56fc0aab6caa135508b874ce

--- a/srcpkgs/libxfce4ui/template
+++ b/srcpkgs/libxfce4ui/template
@@ -1,16 +1,16 @@
 # Template file for 'libxfce4ui'
 pkgname=libxfce4ui
 version=4.12.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
+conf_files="/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml"
 hostmakedepends="xfce4-dev-tools pkg-config intltool glib-devel gettext-devel"
 makedepends="gtk+-devel gtk+3-devel libxfce4util-devel xfconf-devel dbus-glib-devel
  libxml2-devel startup-notification-devel libSM-devel"
-conf_files="/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml"
 short_desc="Replacement of the old libxfcegui4 library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2, LGPL-2.1"
+license="LGPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
 checksum=3d619811bfbe7478bb984c16543d980cadd08586365a7bc25e59e3ca6384ff43

--- a/srcpkgs/libxfce4util/template
+++ b/srcpkgs/libxfce4util/template
@@ -1,17 +1,16 @@
 # Template file for 'libxfce4util'
 pkgname=libxfce4util
 version=4.12.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="libglib-devel"
 short_desc="Utility library for the Xfce4 desktop environment"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
 checksum=876bdefa2e13cbf68b626b2158892fb93e824e1ef59cf951123a96cefbc8881d
-configure_args="--sbindir=/usr/bin"
 
 libxfce4util-devel_package() {
 	depends="libglib-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libzapojit/template
+++ b/srcpkgs/libzapojit/template
@@ -1,14 +1,14 @@
 # Template file for 'libzapojit'
 pkgname=libzapojit
 version=0.0.3
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
 makedepends="json-glib-devel rest-devel gnome-online-accounts-devel"
 short_desc="GLib/GObject wrapper for the SkyDrive and Hotmail REST APIs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/Zapojit"
 distfiles="${GNOME_SITE}/$pkgname/0.0/$pkgname-$version.tar.xz"
 checksum=3d25f99329105abb99d1e9651b0aa1842065456ea54c22970a7330e9f3d1c37e


### PR DESCRIPTION
All packages was build for x86_64, x86_64-musl, armv7hf and aarch64-musl and passed check stage on x86_64 and x86_64-musl. Nothing was tested manually whether it still works.

libfirm also built for armv6hf-musl, as it's broken on aarch64-musl.

317 more packages remain to rebuild.