### PR TITLE
[RFC] build-style/cargo.sh: export common variables to avoid static linking

### DIFF
--- a/common/environment/build-style/cargo.sh
+++ b/common/environment/build-style/cargo.sh
@@ -5,3 +5,9 @@ if [ "$CROSS_BUILD" ]; then
 fi
 
 export PKG_CONFIG_ALLOW_CROSS=1
+
+export LIBGIT2_SYS_USE_PKG_CONFIG=1
+export GETTEXT_BIN_DIR=/usr/bin
+export GETTEXT_LIB_DIR="${XBPS_CROSS_BASE}/usr/lib/gettext"
+export GETTEXT_INCLUDE_DIR="${XBPS_CROSS_BASE}/usr/include"
+export LIBSSH2_SYS_USE_PKG_CONFIG=1


### PR DESCRIPTION
Some rust -sys crates try to build their own vendored c libraries to link them statically.
Currently I'm aware of `libgit2-sys` and `gettext-sys`.
Exporting these variables in the build style avoids static linking by accident.

Please comment if you think this is useful or not.