### PR TITLE
wrk: update to 4.1.0.

### DIFF
--- a/srcpkgs/wrk/patches/zmalloc-arm-alignment.patch
+++ b/srcpkgs/wrk/patches/zmalloc-arm-alignment.patch
@@ -1,0 +1,51 @@
+From fb6e30dad970865c6da254cc3ee62579e97805e5 Mon Sep 17 00:00:00 2001
+From: Noel Cower <ncower@gmail.com>
+Date: Mon, 19 Nov 2018 14:07:14 -0800
+Subject: [PATCH] [PATCH] wrk: Fix zmalloc prefix alignment
+
+Adjust zmalloc's prefix size so that whatever follows the prefix stays
+8- or 16-byte aligned.
+
+This mainly affects ARM systems where size_t is 4 bytes. That causes
+data following the prefix to be misaligned by 4 bytes. The effect of
+this is only noticeable when wrk performs an atomic increment on memory
+allocated for its statistics. Since wrk uses uint64_t counters (8-byte
+aligned), the counters end up being offset by 4 bytes. As a result, when
+wrk uses a __sync_fetch_and_add on one of its counters, it raises
+a SIGBUS.
+
+This patch is based on <https://github.com/wg/wrk/pull/154>.
+---
+ src/zmalloc.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/src/zmalloc.c b/src/zmalloc.c
+index 094dd80..c4ca366 100644
+--- a/src/zmalloc.c
++++ b/src/zmalloc.c
+@@ -45,13 +45,20 @@ void zlibc_free(void *ptr) {
+ #include "zmalloc.h"
+ #include "atomicvar.h"
+ 
++#ifdef _LP64
++#define ALIGNMENT (16)
++#else
++#define ALIGNMENT (8)
++#endif
++#define ALIGN_SIZE(sz) (((sz) + (ALIGNMENT - 1)) & -ALIGNMENT)
++
+ #ifdef HAVE_MALLOC_SIZE
+ #define PREFIX_SIZE (0)
+ #else
+ #if defined(__sun) || defined(__sparc) || defined(__sparc__)
+-#define PREFIX_SIZE (sizeof(long long))
++#define PREFIX_SIZE (ALIGN_SIZE(sizeof(long long)))
+ #else
+-#define PREFIX_SIZE (sizeof(size_t))
++#define PREFIX_SIZE (ALIGN_SIZE(sizeof(size_t)))
+ #endif
+ #endif
+ 
+-- 
+2.19.1
+

--- a/srcpkgs/wrk/template
+++ b/srcpkgs/wrk/template
@@ -1,7 +1,7 @@
 # Template file for 'wrk'
 pkgname=wrk
-version=4.0.2
-revision=5
+version=4.1.0
+revision=1
 build_style=gnu-makefile
 make_build_args="VER=${version} WITH_OPENSSL=/usr WITH_LUAJIT=/usr"
 hostmakedepends="LuaJIT"
@@ -11,7 +11,8 @@ maintainer="Noel Cower <ncower@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/wg/wrk"
 distfiles="https://github.com/wg/wrk/archive/${version}.tar.gz"
-checksum=a4a6ad6727733023771163e7250189a9a23e6253b5e5025191baa6092d5a26fb
+checksum=6fa1020494de8c337913fd139d7aa1acb9a020de6f7eb9190753aa4b1e74271e
+patch_args="-Np1"
 
 pre_build() {
 	case "$XBPS_TARGET_MACHINE" in
@@ -31,13 +32,13 @@ pre_build() {
 			;;
 	esac
 	# Borrow flags from Makefile
-	CFLAGS="-std=c99 -Wall -D_REENTRANT -D_POSIX_C_SOURCE=200112L -D_BSD_SOURCE -D_DEFAULT_SOURCE ${CFLAGS}"
+	CFLAGS="-std=c99 -Wall -D_REENTRANT -D_POSIX_C_SOURCE=200112L -D_BSD_SOURCE -D_DEFAULT_SOURCE -I${XBPS_CROSS_BASE}/usr/include/luajit-2.0 ${CFLAGS}"
 	LDFLAGS="-Wl,-E ${LDFLAGS}"
 }
 
 do_install() {
 	vbin wrk
-	vdoc README
+	vdoc README.md
 	vdoc CHANGES
 	vdoc SCRIPTING
 	vlicense LICENSE


### PR DESCRIPTION
This includes a patch to adjust zmalloc's prefix size so that the
memory following it is aligned correctly. This is to prevent a SIGBUS
on armv[5-7] systems when wrk increments its stats counters.