### PR TITLE
compiz: revbump components to sync with compiz-core [CI SKIP]

### DIFF
--- a/srcpkgs/compiz-plugins-experimental/template
+++ b/srcpkgs/compiz-plugins-experimental/template
@@ -1,7 +1,7 @@
 # Template file for 'compiz-plugins-experimental'
 pkgname=compiz-plugins-experimental
 version=0.8.16
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake compiz-bcop intltool libtool pkg-config gettext-devel glib-devel"

--- a/srcpkgs/compiz-plugins-extra/template
+++ b/srcpkgs/compiz-plugins-extra/template
@@ -1,7 +1,7 @@
 # Template file for 'compiz-plugins-extra'
 pkgname=compiz-plugins-extra
 version=0.8.16
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake compiz-bcop gettext-devel intltool libtool pkg-config"

--- a/srcpkgs/compiz-plugins-main/template
+++ b/srcpkgs/compiz-plugins-main/template
@@ -1,7 +1,7 @@
 # Template file for 'compiz-plugins-main'
 pkgname=compiz-plugins-main
 version=0.8.16
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake compiz-bcop gettext-devel intltool libtool pkg-config"

--- a/srcpkgs/compizconfig-python/template
+++ b/srcpkgs/compizconfig-python/template
@@ -1,7 +1,7 @@
 # Template file for 'compizconfig-python'
 pkgname=compizconfig-python
 version=0.8.16
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake intltool libtool pkg-config glib-devel gettext-devel python3-Cython"

--- a/srcpkgs/libcompizconfig/template
+++ b/srcpkgs/libcompizconfig/template
@@ -1,7 +1,7 @@
 # Template file for 'libcompizconfig'
 pkgname=libcompizconfig
 version=0.8.16
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake intltool libtool pkg-config protobuf"


### PR DESCRIPTION
compiz-core was updated to 0.8.16.1 and in that particular update the compiz plugin ABI version changed. Thus the other packages that depend on that ABI must be updated to link against it correctly.