### PR TITLE
rustup: crate symlinks for cargo, rustc and friends

### DIFF
--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,7 +1,7 @@
 # Template file for 'rustup'
 pkgname=rustup
 version=1.14.0
-revision=4
+revision=5
 wrksrc="${pkgname}.rs-${version}"
 build_style=cargo
 configure_args="--features no-self-update --bin rustup-init"
@@ -13,6 +13,7 @@ license="Apache-2.0, MIT"
 homepage="https://www.rustup.rs"
 distfiles="https://github.com/rust-lang-nursery/${pkgname}.rs/archive/${version}.tar.gz"
 checksum=ab125d9b12bf0f3f7e7ad98e826035fa1ae3dbe6ba8b78be4c82f9cde00bc59f
+conflicts="rust cargo"
 
 pre_build() {
 	cargo update --package openssl-sys --precise 0.9.35
@@ -20,6 +21,11 @@ pre_build() {
 
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init rustup
+
+	# rustup doesn't set PATH correctly to include these.
+	for cmd in cargo rust-gdb rust-lldb rustc rustdoc; do
+		ln -s rustup ${DESTDIR}/usr/bin/${cmd}
+	done
 
 	if ! [ "$CROSS_BUILD" ]; then
 		# generate shell completions


### PR DESCRIPTION
This effectively reverts commit c5d3df3 (#4160). It appears that
rustup has some problems setting PATH properly for some users,
so we _need_ this behaviour.