### PR TITLE
base-files: lower lexicographic priority of sysctl file

### DIFF
--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.140
-revision=5
+revision=6
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
@@ -58,7 +58,7 @@ do_install() {
 	vinstall ${FILESDIR}/usb-load-ehci-first 644 usr/lib/modprobe.d usb-load-ehci-first.conf
 	vinstall ${FILESDIR}/blacklist.conf 644 usr/lib/modprobe.d
 	# sysctl(8) files
-	vinstall ${FILESDIR}/sysctl.conf 644 usr/lib/sysctl.d void.conf
+	vinstall ${FILESDIR}/sysctl.conf 644 usr/lib/sysctl.d 10-void.conf
 
 	# Install common licenses, from Debian.
 	vmkdir usr/share/licenses


### PR DESCRIPTION
Why is this necessary?

The defaults should not overwrite values specified by packages or admins. Thus, they must have a reasonably low lexicographical priority.