### PR TITLE
chroot-git: correct ac_cv_fread_reads_directories on musl

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,14 +1,14 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
 version=2.19.1
-revision=1
+revision=2
 bootstrap=yes
 wrksrc="git-$version"
 build_style=gnu-configure
 configure_args="--without-curl --without-openssl
  --without-python --without-expat --without-tcltk
  ac_cv_lib_curl_curl_global_init=no ac_cv_lib_expat_XML_ParserCreate=no
- ac_cv_fread_reads_directories=no ac_cv_snprintf_returns_bogus=no"
+ ac_cv_snprintf_returns_bogus=no"
 makedepends="zlib-devel"
 make_build_args="CC_LD_DYNPATH=-L"
 make_install_args="NO_INSTALL_HARDLINKS=1"
@@ -24,6 +24,11 @@ if [ "$CHROOT_READY" ]; then
 else
 	configure_args+=" --with-zlib=${XBPS_MASTERDIR}/usr"
 fi
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) configure_args+=" ac_cv_fread_reads_directories=yes" ;;
+	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
+esac
 
 do_install() {
 	# remove unneeded stuff.


### PR DESCRIPTION
git build system relies on FREAD_READS_DIRECTORIES flag to check
if we're on a system which succeeds when attempting to fopen a directory
or read from an fopen-ed directory.

System with musl libc is one of such systems.
The current template lies git build system on this matter.
Effectively, t1308 is failing on musl system.

cf: commit bf8bba61b8, ("git: correct ac_cv_fread_reads_directories
on musl", 2018-11-14)

Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>