### PR TITLE
rust: link against zlib and ncurses explicitly

### DIFF
--- a/srcpkgs/rust/patches/llvm-with-dependencies.patch
+++ b/srcpkgs/rust/patches/llvm-with-dependencies.patch
@@ -1,0 +1,13 @@
+--- rustc-1.30.0-src/src/librustc_llvm/lib.rs.orig
++++ rustc-1.30.0-src/src/librustc_llvm/lib.rs
+@@ -121,3 +121,10 @@
+                  LLVMInitializeWebAssemblyTargetMC,
+                  LLVMInitializeWebAssemblyAsmPrinter);
+ }
++
++#[link(name = "ffi")]
++extern {}
++#[link(name = "z")]
++extern {}
++#[link(name = "ncursesw")]
++extern {}

--- a/srcpkgs/rust/patches/llvm-with-ffi.patch
+++ b/srcpkgs/rust/patches/llvm-with-ffi.patch
@@ -1,9 +1,0 @@
---- rustc-1.21.0-src/src/librustc_llvm/lib.rs.orig
-+++ rustc-1.21.0-src/src/librustc_llvm/lib.rs
-@@ -425,3 +425,6 @@
-         }
-     }
- }
-+
-+#[link(name = "ffi")]
-+extern {}


### PR DESCRIPTION
Cross compiled rustc fails to run because `librustc_codegen_llvm-llvm.so` doesn't get linked against `zlib` and `ncursesw` without this patch (#4379).