### PR TITLE
steam: removed xterm dependency

### DIFF
--- a/srcpkgs/steam/template
+++ b/srcpkgs/steam/template
@@ -1,10 +1,10 @@
 # Template file for 'steam'
 pkgname=steam
 version=1.0.0.55
-revision=1
+revision=2
 wrksrc=steam
 only_for_archs="i686 x86_64"
-depends="zenity xterm xz curl dbus freetype gdk-pixbuf hicolor-icon-theme desktop-file-utils liberation-fonts-ttf"
+depends="zenity xz curl dbus freetype gdk-pixbuf hicolor-icon-theme desktop-file-utils liberation-fonts-ttf"
 repository="nonfree"
 short_desc="Digital distribution client bootstrap package - Valve's steam client"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
Steam uses xterm only in case there is no zenity (to show a message), or in the steamdeps script, which is broken on void either way. No point in having xterm as a dependency

Some proofs: https://hastebin.com/axatisevud.bash