### PR TITLE
rpi-kernel: update to 4.14.83.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="2efa7450a8f408084d40b28cfa3fa75cf488d473"
+_githash="6f01a4d6c982764a4e142b31bd3c2de6507f7a0c"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.82
+version=4.14.83
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=93912f59845043b0f185bac1b357d9d16912a9dcc1579b271c0271df008e4317
+checksum=2bdc466f8b27650ab242904c5df0a20b13202c75ce634d5c097a03a6f9054040
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]