### PR TITLE
Rebuild packages for missing metadata vol. 7

### DIFF
--- a/srcpkgs/AlsaMixer.app/template
+++ b/srcpkgs/AlsaMixer.app/template
@@ -1,11 +1,11 @@
 # Template file for 'AlsaMixer.app'
 pkgname=AlsaMixer.app
 version=0.1
-revision=3
+revision=4
 makedepends="alsa-lib-devel libX11-devel libXext-devel libXpm-devel"
 short_desc="Simple dockable mixer application for Linux with ALSA drivers"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="https://github.com/thinrope/AlsaMixer.app"
 distfiles="http://distfiles.gentoo.org/distfiles/AlsaMixer.app-${version}.tar.gz"
 checksum=7d55d3ba5ffd82bcddcb546e0aa33ab8638df5d1418aa170e91c42e35c0c8c15

--- a/srcpkgs/alfred-json/template
+++ b/srcpkgs/alfred-json/template
@@ -1,13 +1,13 @@
 # Template file for 'alfred-json'
 pkgname=alfred-json
 version=0.3.1
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="jansson-devel zlib-devel"
 short_desc="Simple alfred client with JSON output"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/tcatm/alfred-json"
 distfiles="https://github.com/tcatm/alfred-json/archive/v${version}.tar.gz"
 checksum=573565bc6bce7b2b62143df13281f0378932b2130e915a6014684958c63ebfce

--- a/srcpkgs/automoc4/template
+++ b/srcpkgs/automoc4/template
@@ -1,17 +1,22 @@
 # Template file for 'automoc4'
 pkgname=automoc4
 version=0.9.88
-revision=3
+revision=4
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="qt-devel"
 short_desc="Automatic moc for Qt 4 packages"
-homepage="http://techbase.kde.org/Development/Tools/Automoc4"
-license="BSD"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-distfiles="http://download.kde.org/stable/${pkgname}/${version}/${pkgname}-${version}.tar.bz2"
+license="BSD-2-Clause"
+homepage="http://techbase.kde.org/Development/Tools/Automoc4"
+distfiles="${KDE_SITE}/automoc4/${version}/automoc4-${version}.tar.bz2"
 checksum=234116f4c05ae21d828594d652b4c4a052ef75727e2d8a4f3a4fb605de9e4c49
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt-qmake qt-host-tools"
 fi
+
+post_install() {
+	sed -n '/Copyright/,/SUCH\./p' kde4automoc.cpp > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/b43-fwcutter/template
+++ b/srcpkgs/b43-fwcutter/template
@@ -1,11 +1,11 @@
 # Template file for 'b43-fwcutter'
 pkgname=b43-fwcutter
 version=019
-revision=2
+revision=3
 build_style=gnu-makefile
 short_desc="Firmware extraction tool for Broadcom wireless driver"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
-license="2-clause-BSD"
+license="BSD-2-Clause"
 homepage="http://wireless.kernel.org/en/users/Drivers/b43"
 distfiles="http://bues.ch/b43/fwcutter/$pkgname-$version.tar.bz2"
 checksum=d6ea85310df6ae08e7f7e46d8b975e17fc867145ee249307413cfbe15d7121ce

--- a/srcpkgs/base91/template
+++ b/srcpkgs/base91/template
@@ -1,10 +1,10 @@
 # Template file for 'base91'
 pkgname=base91
 version=0.6.0
-revision=2
+revision=3
 short_desc="Advanced method for encoding binary data as ASCII characters"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="http://base91.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=02cfae7322c1f865ca6ce8f2e0bb8d38c8513e76aed67bf1c94eab1343c6c651

--- a/srcpkgs/beaglebone-base/template
+++ b/srcpkgs/beaglebone-base/template
@@ -1,11 +1,11 @@
 # Template file for 'beaglebone-base'
 pkgname=beaglebone-base
 version=2.4
-revision=1
+revision=2
+only_for_archs="armv7l armv7l-musl"
 build_style=meta
-homepage="http://www.voidlinux.eu"
+depends="virtual?ntp-daemon beaglebone-uboot beaglebone-kernel linux-firmware-network"
 short_desc="Void Linux BeagleBone/BeagleBone Black platform package"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Public Domain"
-only_for_archs="armv7l armv7l-musl"
-depends="virtual?ntp-daemon beaglebone-uboot beaglebone-kernel linux-firmware-network"
+homepage="http://www.voidlinux.eu"

--- a/srcpkgs/c-client/template
+++ b/srcpkgs/c-client/template
@@ -1,16 +1,16 @@
-# Template build file for 'c-client'
+# Template file for 'c-client'
 pkgname=c-client
 version=2007f
-revision=2
+revision=3
+wrksrc="imap-${version}"
+makedepends="pam-devel libressl-devel e2fsprogs-devel"
 short_desc="IMAP client library"
 maintainer="John Regan <john@jrjrtech.com>"
 license="Apache-2.0"
 homepage="http://www.washington.edu/imap"
 distfiles="http://ftp.ntua.gr/pub/net/mail/imap/imap-${version}.tar.gz"
-checksum="53e15a2b5c1bc80161d42e9f69792a3fa18332b7b771910131004eb520004a28"
-wrksrc="imap-${version}"
-makedepends="pam-devel libressl-devel e2fsprogs-devel"
-nocross="yes"
+checksum=53e15a2b5c1bc80161d42e9f69792a3fa18332b7b771910131004eb520004a28
+nocross=yes
 
 do_configure() {
 	sed \

--- a/srcpkgs/ccd2iso/template
+++ b/srcpkgs/ccd2iso/template
@@ -1,11 +1,11 @@
 # Template file for 'ccd2iso'
 pkgname=ccd2iso
 version=0.3
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="CloneCD image to ISO image file converter"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/ccd2iso"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=f874b8fe26112db2cdb016d54a9f69cf286387fbd0c8a55882225f78e20700fc

--- a/srcpkgs/cd-discid/template
+++ b/srcpkgs/cd-discid/template
@@ -1,12 +1,12 @@
 # Template file for 'cd-discid'
 pkgname=cd-discid
 version=1.4
-revision=4
+revision=5
 build_style=gnu-makefile
-maintainer="Philipp Hirsch <itself@hanspolo.net>"
-license="GPL-2"
-homepage="http://linukz.org/cd-discid.shtml"
 short_desc="An utility to get CDDB discid information from a CD-ROM disc"
+maintainer="Philipp Hirsch <itself@hanspolo.net>"
+license="GPL-2.0-or-later"
+homepage="http://linukz.org/cd-discid.shtml"
 distfiles="http://linukz.org/download/${pkgname}-${version}.tar.gz"
 checksum=ffd68cd406309e764be6af4d5cbcc309e132c13f3597c6a4570a1f218edd2c63
 

--- a/srcpkgs/chrpath/template
+++ b/srcpkgs/chrpath/template
@@ -1,13 +1,13 @@
 # Template file for 'chrpath'
 pkgname=chrpath
 version=0.16
-revision=2
+revision=3
 build_style="gnu-configure"
 short_desc="Change or delete the rpath or runpath in ELF files"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://directory.fsf.org/project/chrpath/"
-distfiles="https://alioth.debian.org/frs/download.php/latestfile/813/chrpath-${version}.tar.gz"
+distfiles="${DEBIAN_SITE}/main/c/chrpath/chrpath_${version}.orig.tar.gz"
 checksum=bb0d4c54bac2990e1bdf8132f2c9477ae752859d523e141e72b3b11a12c26e7b
 
 post_install() {

--- a/srcpkgs/cmatrix/template
+++ b/srcpkgs/cmatrix/template
@@ -1,13 +1,13 @@
 # Template file for 'cmatrix'
 pkgname=cmatrix
 version=1.2a
-revision=3
+revision=4
 build_style=gnu-configure
+hostmakedepends="kbd"
+makedepends="ncurses-devel"
 short_desc="Simulates the display from The Matrix"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-makedepends="ncurses-devel"
-hostmakedepends="kbd"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.asty.org/cmatrix"
-distfiles="http://www.asty.org/$pkgname/dist/$pkgname-$version.tar.gz"
+distfiles="${DEBIAN_SITE}/main/c/cmatrix/cmatrix_${version}.orig.tar.gz"
 checksum=1fa6e6caea254b6fe70a492efddc1b40ad7ccb950a5adfd80df75b640577064c

--- a/srcpkgs/connman-gtk/template
+++ b/srcpkgs/connman-gtk/template
@@ -1,14 +1,14 @@
 # Template file for 'connman-gtk'
 pkgname=connman-gtk
 version=1.1.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="intltool autoconf automake pkg-config gettext-devel glib-devel"
 makedepends="gtk+3-devel gettext-devel"
 depends="connman"
 short_desc="GTK GUI for ConnMan"
 maintainer="Alexander Mamay <alexander@mamay.su>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/jgke/connman-gtk"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=fc1da266c4216d34db7c38f7329c698b42666389ce32a8df58a818af9eee2262

--- a/srcpkgs/cubieboard2-base/template
+++ b/srcpkgs/cubieboard2-base/template
@@ -1,12 +1,12 @@
 # Template file for 'cubieboard2-base'
 pkgname=cubieboard2-base
 version=2.5
-revision=1
+revision=2
 build_style=meta
-homepage="http://www.voidlinux.eu"
 short_desc="Void Linux Cubieboard2 platform package"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="Public Domain"
+homepage="http://www.voidlinux.eu"
 
 only_for_archs="armv7l armv7l-musl"
 depends="virtual?ntp-daemon cubieboard2-uboot sun7i-kernel linux-firmware-network"

--- a/srcpkgs/dev86/template
+++ b/srcpkgs/dev86/template
@@ -1,17 +1,17 @@
 # Template file for 'dev86'
 pkgname=dev86
 version=0.16.21
-revision=3
-nostrip=yes
+revision=4
+only_for_archs="i686 x86_64 i686-musl x86_64-musl"
 makedepends="bin86"
 depends="${makedepends}"
 short_desc="8086 cross development compiler, assembler and linker"
-license="GPL+, GPL-2+, LGPL-2+"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-1.0-or-later, GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://v3.sk/~lkundrak/dev86/"
 distfiles="${homepage}/Dev86src-$version.tar.gz"
 checksum=234b110e6df9b7f6843e2ee53473127c2211243a16748f229fc0127845f68d94
-only_for_archs="i686 x86_64 i686-musl x86_64-musl"
+nostrip=yes
 nopie=yes
 
 do_build() {

--- a/srcpkgs/dzen2/template
+++ b/srcpkgs/dzen2/template
@@ -2,7 +2,7 @@
 pkgname=dzen2
 reverts=20140623_1
 version=20130923
-revision=1
+revision=2
 _commit=488ab66019f475e35e067646621827c18a879ba1
 wrksrc=dzen-$_commit
 hostmakedepends="pkg-config"

--- a/srcpkgs/ex-vi/template
+++ b/srcpkgs/ex-vi/template
@@ -1,19 +1,19 @@
 # Template file for 'ex-vi'
 pkgname=ex-vi
 version=050325
-revision=9
+revision=10
 wrksrc="ex-${version}"
 build_style=gnu-makefile
 make_build_args="PREFIX=/usr TERMLIB=ncurses PRESERVEDIR=/var/tmp LARGEF=-DLARGEF"
 make_install_args="INSTALL=/usr/bin/install PRESERVEDIR=/var/tmp STRIP="
-CFLAGS=-I.
 makedepends="ncurses-devel"
 short_desc="The original ex/vi text editor (Heirloom version)"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="BSD"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="BSD-4-Clause-UC"
 homepage="http://ex-vi.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/ex-${version}.tar.bz2"
 checksum=da4be7cf67e94572463b19e56850aa36dc4e39eb0d933d3688fe8574bb632409
+CFLAGS=-I.
 disable_parallel_build=yes
 
 alternatives="

--- a/srcpkgs/ext4magic/template
+++ b/srcpkgs/ext4magic/template
@@ -1,17 +1,17 @@
 # Template file for 'ext4magic'
 pkgname=ext4magic
 version=0.3.2
-revision=2
-patch_args="-Np1"
+revision=3
 build_style=gnu-configure
 configure_args="--enable-expert-mode --enable-file-attr"
 makedepends="e2fsprogs-devel file-devel zlib-devel bzip2-devel"
 short_desc="Recover deleted or overwritten files on ext3 and ext4 filesystems"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/ext4magic/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=8d9c6a594f212aecf4eb5410d277caeaea3adc03d35378257dfd017ef20ea115
+patch_args="-Np1"
 
 CFLAGS='-DHAVE_SYS_TYPES_H'
 post_extract() {

--- a/srcpkgs/font-util/template
+++ b/srcpkgs/font-util/template
@@ -1,8 +1,7 @@
-# Template build file for 'font-util'.
+# Template file for 'font-util'
 pkgname=font-util
 version=1.3.1
-revision=2
-lib32disabled=yes
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config bdftopcf"
 #
@@ -16,6 +15,7 @@ license="MIT"
 homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/font/$pkgname-$version.tar.bz2"
 checksum=aa7ebdb0715106dd255082f2310dbaa2cd7e225957c2a77d719720c7cc92b921
+lib32disabled=yes
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/fortune-mod/template
+++ b/srcpkgs/fortune-mod/template
@@ -1,12 +1,12 @@
 # Template file for 'fortune-mod'
 pkgname=fortune-mod
 version=1.99.1
-revision=3
+revision=4
 hostmakedepends="recode"
 makedepends="recode-devel"
 short_desc="Implementation of the BSDGames 'fortune' program"
 maintainer="Tj Vanderpoel (bougyman) <tj@rubyists.com>"
-license="GPL-2"
+license="BSD-4-Clause-UC"
 homepage="http://www.redellipse.net/code/fortune"
 distfiles="${DEBIAN_SITE}/main/f/fortune-mod/${pkgname}_${version}.orig.tar.gz"
 checksum=fc51aee1f73c936c885f4e0f8b6b48f4f68103e3896eaddc6a45d2b71e14eace

--- a/srcpkgs/fuse-usmb/template
+++ b/srcpkgs/fuse-usmb/template
@@ -1,14 +1,14 @@
 # Template file for 'fuse-usmb'
 pkgname=fuse-usmb
 version=20130204
-revision=5
+revision=6
 _commit=aa94e13
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config git"
 makedepends="glib-devel libxml2-devel fuse-devel samba-devel"
 short_desc="FUSE filesystem for SMB/CIFS shares"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="http://ametros.net/code.html#usmb"
 distfiles="http://repo.or.cz/w/usmb.git/snapshot/$_commit.tar.gz"
 checksum=d10bea16001b3b778a589477e2fff22a359a2b278dc5c2e497de876a95892a25

--- a/srcpkgs/gbdfed/template
+++ b/srcpkgs/gbdfed/template
@@ -1,14 +1,14 @@
 # Template file for 'gbdfed'
 pkgname=gbdfed
 version=1.6
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="ac_cv_file_hbf_c=no"
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel"
 short_desc="A GTK2 bitmap font editor"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2"
 homepage="http://www.math.nmsu.edu/~mleisher/Software/gbdfed/"
-distfiles="http://www.math.nmsu.edu/~mleisher/Software/${pkgname}/${pkgname}-${version}.tbz2>${pkgname}-${version}.tar.bz2"
+distfiles="https://src.fedoraproject.org/repo/pkgs/gbdfed/gbdfed-${version}.tar.bz2/2a2e1cbfe8566db6d302f0b9ab79b8dd/gbdfed-${version}.tar.bz2"
 checksum=5db25d4ce688dcb188dee056e58614a94a5e4fce4b6066fbb310951ab999093c

--- a/srcpkgs/gcolor2/template
+++ b/srcpkgs/gcolor2/template
@@ -1,13 +1,13 @@
 # Template file for 'gcolor2'
 pkgname=gcolor2
 version=0.4
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config perl-XML-Parser"
 makedepends="gtk+-devel"
 short_desc="A simple GTK+2 color selector"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-only"
 homepage="http://downloads.sourceforge.net/sourceforge/gcolor2/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=89bd6c6d27ba5a679ec60057de8497855072f520515b490e5986fc3509774f23

--- a/srcpkgs/gmtk/template
+++ b/srcpkgs/gmtk/template
@@ -1,17 +1,17 @@
 # Template file for 'gmtk'
 pkgname=gmtk
 version=1.0.9
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-gtk3"
 hostmakedepends="pkg-config intltool glib"
 makedepends="gtk+3-devel dconf-devel alsa-lib-devel pulseaudio-devel"
 short_desc="Common functions for gnome-mplayer and gecko-mediaplayer"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://gmtk.googlecode.com/"
 license="GPL-2"
+homepage="http://gmtk.googlecode.com/"
 #distfiles="https://gmtk.googlecode.com/svn/packages/gmtk-${version}.tar.gz"
-distfiles="https://ftp.heanet.ie/mirrors/ftp.openbsd.org/distfiles/gmtk-${version}.tar.gz"
+distfiles="${DEBIAN_SITE}/main/g/gmtk/gmtk_${version}.orig.tar.gz"
 checksum=d633832ab3b223f9a669934d168c74574ab47a6a21f76d942c05ad78c56bf87a
 
 gmtk-devel_package() {

--- a/srcpkgs/gnome-themes-standard-metacity/template
+++ b/srcpkgs/gnome-themes-standard-metacity/template
@@ -1,20 +1,20 @@
-# Template build file for 'gnome-themes-standard'.
+# Template file for 'gnome-themes-standard-metacity'
 pkgname=gnome-themes-standard-metacity
 _pkgname=gnome-themes-standard
 version=3.14.2.3
-revision=1
-lib32disabled=yes
+revision=2
+wrksrc=$_pkgname-$version
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool librsvg-utils glib-devel"
 makedepends="gtk+-devel gtk+3-devel librsvg-devel"
 depends="cantarell-fonts adwaita-icon-theme"
 short_desc="Standard GNOME themes for metacity"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://www.gnome.org"
-license="LGPL-2.1"
 distfiles="${GNOME_SITE}/$_pkgname/${version%.*.*}/$_pkgname-$version.tar.xz"
 checksum=d82a1cf90be3397deadea46d3ba396a46943c7e141ebc70cf833956b5794e479
-wrksrc=$_pkgname-$version
+lib32disabled=yes
 
 post_install() {
 	# Remove everything but the metacity themes

--- a/srcpkgs/gob2/template
+++ b/srcpkgs/gob2/template
@@ -1,13 +1,13 @@
 # Template file for 'gob2'
 pkgname=gob2
 version=2.0.20
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
 short_desc="Simple preprocessor for easily creating GTK objects"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later, GPL-3.0-or-later"
 homepage="http://www.5z.com/jirka/gob.html"
 distfiles="http://ftp.5z.com/pub/gob/gob2-${version}.tar.xz"
 checksum=f7ee84c07ca88ae96e5a60461957cc4dd0aa69d61804433d1c85de3d50be8026

--- a/srcpkgs/gtk-engine-murrine/template
+++ b/srcpkgs/gtk-engine-murrine/template
@@ -1,16 +1,16 @@
 # Template file for 'gtk-engine-murrine'
 pkgname=gtk-engine-murrine
 version=0.98.2
-revision=5
-lib32disabled=yes
+revision=6
 wrksrc="murrine-${version}"
-distfiles="${GNOME_SITE}/murrine/0.98/murrine-${version}.tar.xz"
-checksum="e9c68ae001b9130d0f9d1b311e8121a94e5c134b82553ba03971088e57d12c89"
 build_style="gnu-configure"
 configure_args="--enable-animation"
 hostmakedepends="pkg-config intltool"
 makedepends="gtk+-devel"
-maintainer="Steven R <dev@styez.com>"
-homepage="http://cimitan.com/murrine/project/murrine"
-license="LGPL-3"
 short_desc="GTK2 engine to make your desktop look like a murrina"
+maintainer="Steven R <dev@styez.com>"
+license="LGPL-2.0-or-later"
+homepage="http://cimitan.com/murrine/project/murrine"
+distfiles="${GNOME_SITE}/murrine/0.98/murrine-${version}.tar.xz"
+checksum=e9c68ae001b9130d0f9d1b311e8121a94e5c134b82553ba03971088e57d12c89
+lib32disabled=yes

--- a/srcpkgs/gtk2-engines/template
+++ b/srcpkgs/gtk2-engines/template
@@ -1,7 +1,7 @@
-# Template file for 'gtk-engines'
+# Template file for 'gtk2-engines'
 pkgname=gtk2-engines
 version=2.21.0
-revision=3
+revision=4
 wrksrc=gtk-engines-${version}
 build_style=gnu-configure
 configure_args="--enable-animation"
@@ -9,7 +9,7 @@ hostmakedepends="pkg-config intltool"
 makedepends="gtk+-devel"
 short_desc="GTK+2 Theme engines"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://live.gnome.org/GnomeArt"
 license="GPL-2"
-distfiles="http://ftp.iitm.ac.in/archlinux/other/gtk-engines/gtk-engines-${version}.tar.gz"
+homepage="http://live.gnome.org/GnomeArt"
+distfiles="https://sources.archlinux.org/other/gtk-engines/gtk-engines-${version}.tar.gz"
 checksum=6c38c297c3b95d667c5159c1f379384806fedb53a828d44ac73ff54570ed185b

--- a/srcpkgs/gtk2fontsel/template
+++ b/srcpkgs/gtk2fontsel/template
@@ -1,13 +1,13 @@
 # Template file for 'gtk2fontsel'
 pkgname=gtk2fontsel
 version=0.1
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel"
 short_desc="Font selection and preview tool"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://gtk2fontsel.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=5cd6396fc3c6e7f9bc358cc5ad30592ba446cdb0138a811216497b6453905a68

--- a/srcpkgs/id3v2/template
+++ b/srcpkgs/id3v2/template
@@ -1,11 +1,11 @@
 # Template file for 'id3v2'
 pkgname=id3v2
 version=0.1.12
-revision=2
+revision=3
 makedepends="id3lib-devel zlib-devel"
 short_desc="A command line editor for id3v2 tags"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="LGPL-2.1"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://id3v2.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=8105fad3189dbb0e4cb381862b4fa18744233c3bbe6def6f81ff64f5101722bf

--- a/srcpkgs/lbreakout2/template
+++ b/srcpkgs/lbreakout2/template
@@ -1,15 +1,15 @@
 # Template file for 'lbreakout2'
 pkgname=lbreakout2
 version=2.6.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-sdl-net --localstatedir=/var/games/$pkgname"
 make_install_args="doc_dir=/usr/share/doc"
 makedepends="zlib-devel libpng-devel SDL_mixer-devel SDL_net-devel"
 short_desc="Breakout-style arcade game"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://lgames.sourceforge.net"
-license="GPL-2"
 distfiles="${SOURCEFORGE_SITE}/lgames/$pkgname-$version.tar.gz"
 checksum=9104d6175553da3442dc6a5fc407a669e2f5aff3eedc5d30409eb003b7a78d6f
 

--- a/srcpkgs/lightdm-gtk-greeter/template
+++ b/srcpkgs/lightdm-gtk-greeter/template
@@ -1,19 +1,19 @@
 # Template file for 'lightdm-gtk-greeter'
 pkgname=lightdm-gtk-greeter
 version=1.8.5
-revision=3
-patch_args="-Np1"
+revision=4
 build_style=gnu-configure
 configure_args="--disable-static --with-gtk2
  --enable-compile-warnings=no"
+conf_files="/etc/lightdm/lightdm-gtk-greeter.conf"
 hostmakedepends="pkg-config intltool"
 makedepends="gtk+-devel lightdm-devel libxklavier-devel"
 depends="lightdm hicolor-icon-theme"
-conf_files="/etc/lightdm/lightdm-gtk-greeter.conf"
-conflicts="lightdm-gtk3-greeter>=0"
 short_desc="Light Display Manager GTK+ Greeter (GTK+ 2.x)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3, LGPL-3"
+license="GPL-3.0-or-later"
 homepage="https://launchpad.net/lightdm-gtk-greeter"
 distfiles="${homepage}/${version%.*}/${version}/+download/${pkgname}-${version}.tar.gz"
 checksum=22386e787dc64ac372c63cf2cdce47bfa1c791d1cf8b5d3df68df24ecfbf7d68
+conflicts="lightdm-gtk3-greeter>=0"
+patch_args="-Np1"

--- a/srcpkgs/llvm3.9/template
+++ b/srcpkgs/llvm3.9/template
@@ -2,9 +2,8 @@
 # Only a transitional package until Rust works with LLVM 4.0.
 pkgname=llvm3.9
 version=3.9.1
-revision=3
+revision=4
 wrksrc="llvm-${version}.src"
-lib32disabled=yes
 build_style=cmake
 configure_args="
  -Wno-dev
@@ -17,13 +16,14 @@ configure_args="
  -DLLVM_BUILD_TESTS=OFF
  -DLLVM_BINUTILS_INCDIR=/usr/include
  -DCMAKE_INSTALL_DO_STRIP=0"
-nodebug=yes  # while -DLLVM_LINK_LLVM_DYLIB=OFF
 short_desc="Low Level Virtual Machine (3.9.x series)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="NCSA"
 homepage="http://www.llvm.org"
-license="BSD"
 distfiles="http://www.llvm.org/releases/${version}/llvm-${version}.src.tar.xz"
 checksum=1fd90354b9cf19232e8f168faf2220e79be555df3aa743242700879e8fd329ee
+nodebug=yes  # while -DLLVM_LINK_LLVM_DYLIB=OFF
+lib32disabled=yes
 
 # XXX Investigate ocaml bindings.
 hostmakedepends="groff perl python zlib-devel libffi-devel swig"

--- a/srcpkgs/lua51-BitOp/template
+++ b/srcpkgs/lua51-BitOp/template
@@ -1,9 +1,12 @@
 # Template file for 'lua51-BitOp'
 pkgname=lua51-BitOp
 version=1.0.2
-revision=3
-makedepends="lua51-devel lua51"
+revision=4
+wrksrc="LuaBitOp-${version}"
+build_style=gnu-makefile
+make_build_args="INCLUDES=-I${XBPS_CROSS_BASE}/usr/include/lua5.1"
 hostmakedepends="lua51"
+makedepends="lua51-devel lua51"
 depends="lua51"
 short_desc="C extension module for Lua which adds bitwise operations on numbers"
 maintainer="Tj Vanderpoel (bougyman) <tj@rubyists.com>"
@@ -11,9 +14,6 @@ license="MIT"
 homepage="http://bitop.luajit.org/"
 distfiles="${homepage}/download/LuaBitOp-${version}.tar.gz"
 checksum=1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99
-build_style=gnu-makefile
-wrksrc="LuaBitOp-${version}"
-make_build_args="INCLUDES=-I${XBPS_CROSS_BASE}/usr/include/lua5.1"
 
 do_install() {
 	mod_path="${DESTDIR}$(lua5.1 installpath.lua bit)"

--- a/srcpkgs/lua52-BitOp/template
+++ b/srcpkgs/lua52-BitOp/template
@@ -1,9 +1,12 @@
 # Template file for 'lua52-BitOp'
 pkgname=lua52-BitOp
 version=1.0.2
-revision=2
-makedepends="lua52-devel lua52"
+revision=3
+wrksrc="LuaBitOp-${version}"
+build_style=gnu-makefile
+make_build_args="INCLUDES=-I${XBPS_CROSS_BASE}/usr/include/lua5.2"
 hostmakedepends="lua52"
+makedepends="lua52-devel lua52"
 depends="lua52>=5.2"
 short_desc="C extension module for Lua which adds bitwise operations on numbers"
 maintainer="Tj Vanderpoel (bougyman) <tj@rubyists.com>"
@@ -11,9 +14,6 @@ license="MIT"
 homepage="http://bitop.luajit.org/"
 distfiles="${homepage}/download/LuaBitOp-${version}.tar.gz"
 checksum=1207c9293dcd52eb9dca6538d1b87352bd510f4e760938f5048433f7f272ce99
-build_style=gnu-makefile
-wrksrc="LuaBitOp-${version}"
-make_build_args="INCLUDES=-I${XBPS_CROSS_BASE}/usr/include/lua5.2"
 replaces="lua-BitOp>=0"
 
 do_install() {

--- a/srcpkgs/monsterwm-git/template
+++ b/srcpkgs/monsterwm-git/template
@@ -2,22 +2,22 @@
 pkgname=monsterwm-git
 reverts=20140803_1
 version=20120304
-revision=1
+revision=2
 _commit=eb3820f877a624e00be5a0ee28feb943889cb915
-makedepends="libX11-devel"
+wrksrc="monsterwm-$_commit"
 build_style=gnu-makefile
 make_build_args="INCS=-I. LIBS=-lX11"
+makedepends="libX11-devel"
 short_desc="Minimal and lightweight dynamic tiling window manager"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="MIT"
 homepage="https://github.com/c00kiemon5ter/monsterwm"
-provides="monsterwm-${version}_${revision}"
-replaces="monsterwm>=0"
-CFLAGS="-DVERSION=${version} -std=c11"
-LDFLAGS="-lX11"
-wrksrc="monsterwm-$_commit"
 distfiles="${homepage}/archive/${_commit}.tar.gz"
 checksum=404dc50128daee172af2e3c836d4979b675814491db59fde1b039fc6069aca54
+LDFLAGS="-lX11"
+CFLAGS="-DVERSION=${version} -std=c11"
+replaces="monsterwm>=0"
+provides="monsterwm-${version}_${revision}"
 
 pre_build() {
 	[ -e ${FILESDIR}/config.h ] && cp ${FILESDIR}/config.h config.h

--- a/srcpkgs/moon-buggy/template
+++ b/srcpkgs/moon-buggy/template
@@ -1,14 +1,14 @@
 # Template file for 'moon-buggy'
 pkgname=moon-buggy
 version=1.0.51
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--sharedstatedir=/var/db"
 make_dirs="/var/db/moon-buggy 777 root root"
+makedepends="ncurses-devel"
 short_desc="A simple character graphics game"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
-makedepends="ncurses-devel"
+license="GPL-2.0-only"
 homepage="http://www.seehuhn.de/pages/moon-buggy"
 distfiles="http://m.seehuhn.de/programs/$pkgname-$version.tar.gz"
 checksum=352dc16ccae4c66f1e87ab071e6a4ebeb94ff4e4f744ce1b12a769d02fe5d23f

--- a/srcpkgs/musl-obstack/template
+++ b/srcpkgs/musl-obstack/template
@@ -1,14 +1,14 @@
 # Template file for 'musl-obstack'
 pkgname=musl-obstack
 version=1.1
-revision=2
-build_style=gnu-configure
-hostmakedepends="automake libtool"
-configure_args="--disable-shared"
+revision=3
 only_for_archs="aarch64-musl armv5tel-musl armv6l-musl armv7l-musl i686-musl mips-musl mipshf-musl mipsel-musl mipselhf-musl x86_64-musl"
+build_style=gnu-configure
+configure_args="--disable-shared"
+hostmakedepends="automake libtool"
 short_desc="Implementation of obstack for musl libc"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/pullmoll/musl-obstack"
 distfiles="https://github.com/pullmoll/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=52a216613e7d55e8725e43d017bb2d49a4b1ffa1e06da472f03c7f9875df7d0d

--- a/srcpkgs/notify-osd/template
+++ b/srcpkgs/notify-osd/template
@@ -1,15 +1,18 @@
 # Template file for 'notify-osd'
-
 pkgname=notify-osd
 version=0.9.34
-revision=1
+revision=2
 build_style=gnu-configure
-short_desc="Canonical's on-screen-display notification agent"
-maintainer="Emanuel Serpa <emanuel@openmailbox.org>"
 hostmakedepends="pkg-config  glib-devel dbus-glib-devel"
 makedepends="libwnck-devel libnotify-devel dbus-glib-devel"
-provides="notification-daemon-0_1"
-license="GPL-3"
+short_desc="Canonical's on-screen-display notification agent"
+maintainer="Emanuel Serpa <emanuel@openmailbox.org>"
+license="GPL-3.0-only"
 homepage="https://launchpad.net/notify-osd"
 distfiles="https://launchpad.net/notify-osd/precise/${version}/+download/notify-osd-${version}.tar.gz"
-checksum="12080deeaa5e1e10b420117351c2bd5db3421b0d1efcab8ee8052c808c3aaa3c"
+checksum=12080deeaa5e1e10b420117351c2bd5db3421b0d1efcab8ee8052c808c3aaa3c
+provides="notification-daemon-0_1"
+
+do_check() {
+	: # requires xserver
+}

--- a/srcpkgs/odt2txt/template
+++ b/srcpkgs/odt2txt/template
@@ -1,12 +1,12 @@
 # Template file for 'odt2txt'
 pkgname=odt2txt
 version=0.5
-revision=2
+revision=3
 build_style=gnu-makefile
 makedepends="zlib-devel"
 short_desc="Simple converter from OpenDocument Text to plain text"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-only"
 homepage="https://github.com/dstosberg/odt2txt"
 distfiles="https://github.com/dstosberg/odt2txt/archive/v${version}.tar.gz"
 checksum=23a889109ca9087a719c638758f14cc3b867a5dcf30a6c90bf6a0985073556dd

--- a/srcpkgs/openbsd-rs/template
+++ b/srcpkgs/openbsd-rs/template
@@ -1,11 +1,11 @@
 # Template file for 'openbsd-rs'
 pkgname=openbsd-rs
 version=1.22
-revision=5
+revision=6
 wrksrc="rs-${version}"
 short_desc="Reshape a data array text file"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="BSD"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="BSD-3-Clause"
 homepage="http://github.com/chneukirchen/rs"
 distfiles="https://github.com/chneukirchen/rs/archive/v${version}.tar.gz"
 checksum=30727538ed5c5347fd2f23c483ecece0409befff72cd27f34591520bb636a99c

--- a/srcpkgs/pam_radius_auth/template
+++ b/srcpkgs/pam_radius_auth/template
@@ -1,15 +1,15 @@
 # Template file for 'pam_radius_auth'
 pkgname=pam_radius_auth
 version=1.4.0
-revision=1
-build_style=gnu-configure
+revision=2
 wrksrc="pam_radius-${version}"
+build_style=gnu-configure
 conf_files="/etc/raddb/server"
 makedepends="pam-devel"
 depends="pam"
 short_desc="PAM to RADIUS authentication module"
 maintainer="Toyam Cox <Vaelatern@gmail.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://freeradius.org/pam_radius_auth/"
 distfiles="ftp://ftp.freeradius.org/pub/radius/pam_radius-${version}.tar.gz"
 checksum=742d79fc39824726c098e746bd3dc3484f983f5ee082c621c1e848b2c3725305

--- a/srcpkgs/pbzip2/template
+++ b/srcpkgs/pbzip2/template
@@ -1,12 +1,12 @@
-# Template build file for 'pbzip2'.
+# Template file for 'pbzip2'
 pkgname=pbzip2
 version=1.1.13
-revision=1
+revision=2
 makedepends="bzip2-devel"
 short_desc="Parallel bzip2 file compressor"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-4-Clause"
 homepage="http://compression.ca/pbzip2/"
-license="BSD"
 distfiles="https://launchpad.net/pbzip2/${version%.*}/${version}/+download/pbzip2-${version}.tar.gz"
 checksum=8fd13eaaa266f7ee91f85c1ea97c86d9c9cc985969db9059cdebcb1e1b7bdbe6
 

--- a/srcpkgs/pekwm/template
+++ b/srcpkgs/pekwm/template
@@ -1,7 +1,7 @@
-# Template file for 'pekwm'.
+# Template file for 'pekwm'
 pkgname=pekwm
 version=0.1.17
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-pkg-exec-prefix=/usr
  ac_cv_lib_X11_XOpenDisplay=yes ac_cv_lib_Xft_XftFontOpen=yes
@@ -12,7 +12,7 @@ short_desc="Window manager based on aewm++"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="https://www.pekwm.org/projects/pekwm"
-distfiles="http://www.pekwm.org/projects/pekwm/files/pekwm-$version.tar.bz2"
+distfiles="${DEBIAN_SITE}/main/p/pekwm/pekwm_${version}.orig.tar.bz2"
 checksum=8a1fd3bf9f38e8c7bb2b2864c090f986b60cec2281ecf1bba462d120fb327d00
 
 hostmakedepends="pkg-config"

--- a/srcpkgs/pidgin-libnotify/template
+++ b/srcpkgs/pidgin-libnotify/template
@@ -1,15 +1,15 @@
 # Template file for 'pidgin-libnotify'
 pkgname=pidgin-libnotify
 version=0.14
-revision=1
-lib32disabled=yes
+revision=2
 build_style=gnu-configure
 configure_args="--disable-deprecated --disable-static"
 hostmakedepends="intltool pkg-config"
 makedepends="pidgin-devel libnotify-devel"
 short_desc="Pidgin plugin that enables popups when someone logs in or messages you"
 maintainer="Kharlamov Alexey <der@2-47.ru>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://gaim-libnotify.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/gaim-libnotify/${pkgname}-${version}.tar.gz"
 checksum=74f4a9f20e0a483df39974178f1f2380786176189512bcd438e4ada280ec3abe
+lib32disabled=yes

--- a/srcpkgs/pod2mdoc/template
+++ b/srcpkgs/pod2mdoc/template
@@ -1,7 +1,7 @@
 # Template file for 'pod2mdoc'
 pkgname=pod2mdoc
 version=0.2
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="Convert perl documentation (POD) into man pages (mdoc)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -16,4 +16,6 @@ post_extract() {
 do_install() {
 	vbin pod2mdoc
 	vman pod2mdoc.1
+	sed -n '/Copyright/,/CONNECTION\./p' pod2mdoc.c > LICENSE
+	vlicense LICENSE
 }

--- a/srcpkgs/polkit-gnome/template
+++ b/srcpkgs/polkit-gnome/template
@@ -1,14 +1,14 @@
 # Template file for 'polkit-gnome'
 pkgname=polkit-gnome
 version=0.105
-revision=6
+revision=7
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool gobject-introspection"
 makedepends="polkit-devel gtk+3-devel"
 short_desc="PolicyKit integration for the GNOME desktop"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/PolicyKit"
-license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/$version/$pkgname-$version.tar.xz"
 checksum=1784494963b8bf9a00eedc6cd3a2868fb123b8a5e516e66c5eda48df17ab9369
 

--- a/srcpkgs/prboom-plus/template
+++ b/srcpkgs/prboom-plus/template
@@ -1,7 +1,7 @@
 # Template file for 'prboom-plus'
 pkgname=prboom-plus
 version=2.5.1.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-cpu-opt --disable-dogs"
 hostmakedepends="pcre-devel fluidsynth-devel libmad-devel SDL_mixer-devel SDL_net-devel
@@ -9,8 +9,8 @@ hostmakedepends="pcre-devel fluidsynth-devel libmad-devel SDL_mixer-devel SDL_ne
 makedepends="${hostmakedepends}"
 short_desc="Doom source port developed from the original PrBoom"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
+license="GPL-2.0-or-later"
 homepage="http://prboom-plus.sourceforge.net/"
-license="GPL-2"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=e0e2241d174839b107f1a42b191aa9895dc6749e477cbc850ad520fba2353b94
 

--- a/srcpkgs/purple-plugin-pack/template
+++ b/srcpkgs/purple-plugin-pack/template
@@ -1,13 +1,13 @@
 # Template file for 'purple-plugin-pack'
 pkgname=purple-plugin-pack
 version=2.7.0
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool python"
 makedepends="libpurple-devel pidgin-devel finch-devel"
 short_desc="Compilation of plugins for the libpurple family of IM clients"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="https://bitbucket.org/rekkanoryo/purple-plugin-pack"
 distfiles="https://bitbucket.org/rekkanoryo/$pkgname/downloads/$pkgname-$version.tar.bz2"
 checksum=2bbcf5e778a33968ba7f2864d2a6cb526a8984be3e4151642a583eee8eafb03c

--- a/srcpkgs/python-notify/template
+++ b/srcpkgs/python-notify/template
@@ -1,22 +1,22 @@
 # Template file for 'python-notify'
 pkgname=python-notify
 version=0.1.1
-revision=12
-lib32disabled=yes
-patch_args="-Np1"
+revision=13
 wrksrc="notify-python-${version}"
 build_style=gnu-configure
+pycompile_module="gtk-2.0/pynotify"
 hostmakedepends="pkg-config python-devel python-gobject2-devel pygtk-devel"
 makedepends="libnotify-devel gtk+-devel dbus-glib-devel pygtk-devel"
 depends="pygtk"
-replaces="notify-python>=0"
-pycompile_module="gtk-2.0/pynotify"
 short_desc="Python2 bindings for libnotify"
-homepage="http://www.galago-project.org/"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-only"
+homepage="http://www.galago-project.org/"
 distfiles="http://www.galago-project.org/files/releases/source/notify-python/notify-python-${version}.tar.gz"
 checksum=8c5ee28017fdc5b110c31cb76503e535e15e0c60b9a1f1e95ff6c018dd806022
+replaces="notify-python>=0"
+patch_args="-Np1"
+lib32disabled=yes
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/rdiff-backup/template
+++ b/srcpkgs/rdiff-backup/template
@@ -1,7 +1,7 @@
 # Template file for 'rdiff-backup'
 pkgname=rdiff-backup
 version=1.2.8
-revision=1
+revision=2
 build_style=python2-module
 pycompile_module="rdiff_backup"
 hostmakedepends="python"
@@ -9,7 +9,7 @@ makedepends="python-devel librsync-devel"
 depends="python"
 short_desc="Local/remote mirroring and incremental backups"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://rdiff-backup.nongnu.org/"
 distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=0d91a85b40949116fa8aaf15da165c34a2d15449b3cbe01c8026391310ac95db

--- a/srcpkgs/remind/template
+++ b/srcpkgs/remind/template
@@ -1,12 +1,12 @@
 # Template file for 'remind'
 pkgname=remind
 version=03.01.15
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 short_desc="A sophisticated calendar and alarm program"
 maintainer="Farhad Shahbazi <grauwolf@geekosphere.org>"
 license="GPL-2"
 homepage="https://www.roaringpenguin.com/products/remind"
-distfiles="https://www.roaringpenguin.com/files/download/${pkgname}-${version}.tar.gz"
+distfiles="${DEBIAN_SITE}/main/r/remind/remind_${version}.orig.tar.gz"
 checksum=8adab4c0b30a556c34223094c5c74779164d5f3b8be66b8039f44b577e678ec1

--- a/srcpkgs/shntool/template
+++ b/srcpkgs/shntool/template
@@ -1,13 +1,11 @@
 # Template file for 'shntool'
 pkgname=shntool
 version=3.0.10
-revision=1
-short_desc="A multi-purpose WAVE data processing and reporting utility"
-homepage="http://www.etree.org/shnutils/shntool/"
-license="GPL-2"
-maintainer="Georg S. <gescha@posteo.de>"
-
+revision=2
 build_style=gnu-configure
-
-distfiles="http://www.etree.org/shnutils/shntool/dist/src/${pkgname}-${version}.tar.gz"
+short_desc="A multi-purpose WAVE data processing and reporting utility"
+maintainer="Georg S. <gescha@posteo.de>"
+license="GPL-2"
+homepage="http://www.etree.org/shnutils/shntool/"
+distfiles="${DEBIAN_SITE}/main/s/shntool/shntool_${version}.orig.tar.gz"
 checksum=74302eac477ca08fb2b42b9f154cc870593aec8beab308676e4373a5e4ca2102

--- a/srcpkgs/silc-client/template
+++ b/srcpkgs/silc-client/template
@@ -1,16 +1,16 @@
 # Template file for 'silc-client'
 pkgname=silc-client
 version=1.1.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-debug --enable-ipv6 --disable-optimizations
  ac_cv_func_pthread_rwlock_init=set ac_cv_func_epoll_wait=set"
-makedepends="silc-toolkit-devel ncurses-devel pcre-devel glib-devel"
-hostmakedepends="pkg-config"
 conf_files="/etc/silc.conf"
+hostmakedepends="pkg-config"
+makedepends="silc-toolkit-devel ncurses-devel pcre-devel glib-devel"
 short_desc="Secure Internet Live Conferencing client"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.silcnet.org/client.html"
 distfiles="${SOURCEFORGE_SITE}/silc/silc/client/sources/$pkgname-$version.tar.bz2"
 checksum=36dfc3782e5949433fb8b0f1acf599426fb706555d343095641a49dbaa1b978d

--- a/srcpkgs/spawn-fcgi/template
+++ b/srcpkgs/spawn-fcgi/template
@@ -1,7 +1,7 @@
 # Template file for 'spawn-fcgi'
 pkgname=spawn-fcgi
 version=1.6.4
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="Spawn FastCGI applications"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"

--- a/srcpkgs/sunxi-tools/template
+++ b/srcpkgs/sunxi-tools/template
@@ -2,17 +2,17 @@
 pkgname=sunxi-tools
 reverts=20150526_1
 version=20150226
-revision=2
+revision=3
 _commit=b80e7ce7bd5c2015465c2fd0e5990d47c05c7f8e
+wrksrc="$pkgname-$_commit"
 hostmakedepends="pkg-config git"
 makedepends="libusb-devel"
 short_desc="Tools to help hacking Allwinner AXX (aka sunxi) based devices"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/linux-sunxi/sunxi-tools"
 distfiles="$homepage/archive/$_commit.tar.gz"
 checksum=93922d654df5153d468b0f7900f96fe858fe457894ff2dd0f5dfb5c94b65475b
-wrksrc="$pkgname-$_commit"
 
 CFLAGS="-std=c99 -I./include"
 

--- a/srcpkgs/t1lib/template
+++ b/srcpkgs/t1lib/template
@@ -1,16 +1,17 @@
 # Template file for 't1lib'
 pkgname=t1lib
 version=5.1.2
-revision=3
+revision=4
 build_style=gnu-configure
 make_build_target="without_doc"
 makedepends="libXaw-devel"
 short_desc="Rasterizer library for Adobe Type 1 fonts"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://www.ibiblio.org/pub/Linux/libs/graphics/!INDEX.html"
 distfiles="http://www.ibiblio.org/pub/Linux/libs/graphics/$pkgname-$version.tar.gz"
 checksum=821328b5054f7890a0d0cd2f52825270705df3641dbd476d58d17e56ed957b59
+nocross="checking \"which ANSI integer type is 64 bit\"... configure: error: cannot run test program while cross compiling"
 
 libt1_package() {
 	short_desc+=" - runtime libraries"

--- a/srcpkgs/texlive2014-bin/template
+++ b/srcpkgs/texlive2014-bin/template
@@ -1,17 +1,17 @@
-# Template file for 'texlive-bin'
+# Template file for 'texlive2014-bin'
 pkgname=texlive2014-bin
 version=2014
-revision=7
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-homepage="http://tug.org/texlive/"
-license="GPL-2"
-short_desc="TeX Live Binary distribution through tl-install"
+revision=8
+create_wrksrc=yes
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+short_desc="TeX Live Binary distribution through tl-install"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2"
+homepage="http://tug.org/texlive/"
 distfiles="ftp://ftp.tug.org/texlive/historic/${version}/tlnet-final/install-tl-unx.tar.gz"
 checksum=051e6425d604767eb12289c67c87ccdb1af0750b0b1d22383fd9387926234217
-create_wrksrc=yes
 
 # Package build options
 build_options="basic small medium full"
@@ -21,12 +21,12 @@ desc_option_small="Install TeXLive using scheme-small"
 desc_option_medium="Install TeXLive using scheme-medium"
 desc_option_full="Install TeXLive using scheme-full"
 
-pre_install(){
+pre_install() {
 	rm -rf ${wrksrc}/install-tl*/tlpkg/installer/xz \
 		${wrksrc}/install-tl*/tlpkg/installer/wget
 }
 
-do_install(){
+do_install() {
 	vmkdir opt/texlive${version}-installer
 	vcopy "install-tl-*/*" /opt/texlive${version}-installer
 	vinstall ${FILESDIR}/void.profile 644 opt/texlive${version}-installer

--- a/srcpkgs/thunar-volman/template
+++ b/srcpkgs/thunar-volman/template
@@ -1,14 +1,14 @@
-# Template file for 'thunar-volman'.
+# Template file for 'thunar-volman'
 pkgname=thunar-volman
 version=0.8.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="libgudev-devel libnotify-devel libxfce4ui-devel exo-devel"
 depends="hicolor-icon-theme desktop-file-utils"
 short_desc="Thunar Volume Manager"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
 checksum=5a08bb5ce32c296a64dfbdb2406d4e45a208b2c91e4efa831dc28f1d6c2ac2bd

--- a/srcpkgs/tpacpi-bat/template
+++ b/srcpkgs/tpacpi-bat/template
@@ -1,12 +1,12 @@
 # Template file for 'tpacpi-bat'
 pkgname=tpacpi-bat
 version=3.1
-revision=1
-depends="acpi_call-dkms perl"
+revision=2
 only_for_archs="i686 x86_64 x86_64-musl"
+depends="acpi_call-dkms perl"
 short_desc="ThinkPad ACPI Battery Util using acpi_call"
 maintainer="Daniel A. Maierhofer <git@damadmai.at>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/teleshoes/$pkgname"
 distfiles="$homepage/archive/v$version.tar.gz"
 checksum=017084cc82061ebf2837373adb516f1fd1beb78694bbef257a1d112d6081d9d6

--- a/srcpkgs/usbarmory-base/template
+++ b/srcpkgs/usbarmory-base/template
@@ -1,11 +1,11 @@
 # Template file for 'usbarmory-base'
 pkgname=usbarmory-base
 version=1.0
-revision=1
-homepage="http://www.voidlinux.eu"
+revision=2
 short_desc="Void Linux USBarmory base files"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="Public Domain"
+homepage="http://www.voidlinux.eu"
 
 only_for_archs="armv7l armv7l-musl"
 depends="virtual?ntp-daemon usbarmory-u-boot usbarmory-kernel"

--- a/srcpkgs/v4l2grab/template
+++ b/srcpkgs/v4l2grab/template
@@ -1,11 +1,11 @@
 # Template file for 'v4l2grab'
 pkgname=v4l2grab
 version=0.4.1
-revision=3
+revision=4
 makedepends="libjpeg-turbo-devel v4l-utils-devel"
 short_desc="Utility for grabbing JPEGs from V4L2 devices"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://github.com/twam/v4l2grab"
 distfiles="https://github.com/twam/${pkgname}/archive/${version}.tar.gz"
 checksum=eac1cf81a4e5c136e7cacf0b2fd8240e5a6f148df1170cc7acf9661654fe78f8

--- a/srcpkgs/xsane/template
+++ b/srcpkgs/xsane/template
@@ -1,7 +1,7 @@
 # Template file for 'xsane'
 pkgname=xsane
 version=0.999
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel lcms-devel sane-devel gimp-devel"
 depends="sane"
@@ -9,8 +9,9 @@ short_desc="GTK-based X11 frontend for SANE"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-2"
 homepage="http://www.xsane.org"
-distfiles="http://www.xsane.org/download/${pkgname}-${version}.tar.gz"
+distfiles="${DEBIAN_SITE}/main/x/xsane/xsane_${version}.orig.tar.gz"
 checksum=5782d23e67dc961c81eef13a87b17eb0144cae3d1ffc5cf7e0322da751482b4b
+nocross="configure: error: cannot run C compiled programs. If you meant to cross compile, use '--host'."
 
 do_build() {
 	local _args="--prefix=/usr --sbindir=/usr/bin --mandir=/usr/share/man"


### PR DESCRIPTION
All packages was build (when available) for x86_64, x86_64-musl, armv7hf and aarch64-musl and passed check stage on x86_64 and x86_64-musl. Nothing was tested manually whether it still works.

Homepage is down for chrpath to xsane, so sources are get from elsewhere. Homepage fields itself are not changed.

203 more packages remain to rebuild.