### PR TITLE
libX11: enable static libraries.

### DIFF
--- a/srcpkgs/libX11/template
+++ b/srcpkgs/libX11/template
@@ -1,10 +1,10 @@
 # Template file for 'libX11'
 pkgname=libX11
 version=1.6.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-ipv6 --enable-xlocaledir --without-xmlto
- --disable-static --enable-malloc0returnsnull"
+ --enable-static --enable-malloc0returnsnull"
 hostmakedepends="pkg-config xorg-util-macros"
 makedepends="xorgproto xtrans libxcb-devel"
 short_desc="Base X libraries from Xorg"
@@ -36,6 +36,7 @@ libX11-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
 		vmove usr/share/man/man3
 	}
 }


### PR DESCRIPTION
There are quite a few users that want them to statically compile dwm.

The reasons are not well understood but the cost is restricted to the
-devel package and not the main one.

So lets do it.