### PR TITLE
goffice: update to 0.10.44.

### DIFF
--- a/srcpkgs/goffice/template
+++ b/srcpkgs/goffice/template
@@ -1,18 +1,18 @@
 # Template file for 'goffice'
 pkgname=goffice
-version=0.10.43
-revision=3
-hostmakedepends="automake pkg-config pcre gettext-devel intltool libtool glib-devel gtk-doc"
-makedepends="GConf-devel gtk+3-devel librsvg-devel libgsf-devel libxml2-devel pcre-devel libxslt-devel"
+version=0.10.44
+revision=1
 build_style=gnu-configure
+hostmakedepends="automake pkg-config pcre gettext-devel intltool libtool
+ glib-devel gtk-doc"
+makedepends="gtk+3-devel librsvg-devel libgsf-devel libxml2-devel pcre-devel
+ libxslt-devel"
+short_desc="Document-centric objects and utilities for GLib and Gtk+"
 maintainer="Philipp Hirsch <itself@hanspolo.net>"
 license="GPL-2.0-or-later"
-short_desc="Document-centric objects and utilities for GLib and Gtk+"
 homepage="https://github.com/GNOME/goffice"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=550fceefa74622b8fe57dd0b030003e31db50edf7f87068ff5e146365108b64e
-
-makedepends+=" mozjs52-devel"
+checksum=6d6042af92cd962604068dbced5925948af6c812c2138defc3153c204d65a7b9
 
 pre_configure() {
 	autoreconf -if


### PR DESCRIPTION
#5100 except it fixes the last couple lint errors and removes the unnecessary make dependency on gconf.