### PR TITLE
New package: voidvault-1.7.2

### DIFF
--- a/srcpkgs/voidvault/template
+++ b/srcpkgs/voidvault/template
@@ -1,0 +1,25 @@
+# Template file for 'voidvault'
+pkgname=voidvault
+version=1.7.2
+revision=1
+archs="i686* x86_64*"
+build_style=perl6-dist
+depends="btrfs-progs coreutils cryptsetup dialog dosfstools e2fsprogs efibootmgr
+ expect gptfdisk grub kbd kmod libressl procps-ng tzdata util-linux xbps"
+short_desc="Bootstrap Void with FDE"
+maintainer="Andy Weidenbaum <archbaum@gmail.com>"
+license="Unlicense"
+homepage="https://github.com/atweiden/voidvault"
+distfiles="https://github.com/atweiden/voidvault/releases/download/${version}/${pkgname}-${version}.tar.gz"
+checksum=c4ab12bf67a990242c2a875eedcb65363489fdfc012b2368f01426fb157810dc
+
+post_install() {
+	vlicense UNLICENSE
+	vdoc INSTALL.md
+	vdoc README.md
+	vcopy doc usr/share/doc/${pkgname}
+	vcopy examples usr/share/doc/${pkgname}
+	vcopy man usr/share/doc/${pkgname}
+	vcopy resources usr/share/doc/${pkgname}
+	vcopy scripts usr/share/doc/${pkgname}
+}


### PR DESCRIPTION
- add opinionated Void installer written in Perl 6
  - includes `void-chroot`, `voidstrap` utils for system recovery inspired by `arch-chroot` and `pacstrap` utils respectively