### PR TITLE
Portaudio: added patch for sndio support

### DIFF
--- a/srcpkgs/Quaternion/template
+++ b/srcpkgs/Quaternion/template
@@ -1,13 +1,14 @@
 # Template file for 'Quaternion'
 pkgname=Quaternion
-version=0.0.9.2
+version=0.0.9.3
 revision=1
-_libqmatrix_version=0.3.0.2
+_libqmatrix_version=0.4.0
 create_wrksrc=yes
 build_wrksrc="Quaternion-${version}"
 build_style=cmake
+configure_args="-DUSE_INTREE_LIBQMC=1"
 hostmakedepends="qt5-qmake qt5-host-tools"
-makedepends="qt5-declarative-devel qt5-quickcontrols"
+makedepends="qt5-declarative-devel qt5-quickcontrols qt5-tools-devel"
 depends="qt5-quickcontrols"
 short_desc="Qt5-based IM client for the Matrix protocol"
 maintainer="Julio Galvan <juliogalvan@protonmail.com>"
@@ -17,8 +18,8 @@ distfiles="
  https://github.com/QMatrixClient/Quaternion/archive/v${version}.tar.gz
  https://github.com/QMatrixClient/libqmatrixclient/archive/v${_libqmatrix_version}.tar.gz"
 checksum="
- e859b232802ca0ce68a3fd97bd44bf4252718324c95d1d740bc20a1d02bf5568
- c363af0c9d1e357000ed3f50af70722a35d6511c6bd2b9faec287da101a7877a"
+ 7f92c3acc73bb7e44efe94bd1085ae9fd5b58efa51efc28a931cace131c22230
+ 8c0a1e0c52e9be06a9883487893cff005287fb199e378033182b681949c521c3"
 
 post_extract() {
 	mv libqmatrixclient-${_libqmatrix_version}/* ${build_wrksrc}/lib

--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,8 +1,8 @@
 # Template file for 'SPIRV-Headers'
 pkgname=SPIRV-Headers
-version=1.3.44
+version=1.3.47
 revision=1
-_githash=a2c529b5dda18838ab4b52f816acfebd774eaab3
+_githash=282879ca34563020dbe73fd8f7d45bed6755626a
 noarch=yes
 wrksrc="${pkgname}-${_githash}"
 build_style=cmake
@@ -11,7 +11,7 @@ maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/KhronosGroup/SPIRV-Headers"
 distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/${_githash}.tar.gz"
-checksum=ff732d21622bb7b2180c794949a5ad2cda71850e2f46cce70b02556d7c789342
+checksum=118b05250825bd65098b37fc6d6aec851d19380dde0e97615953f2007e020712
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/eselect/template
+++ b/srcpkgs/eselect/template
@@ -1,0 +1,17 @@
+# Template file for 'eselect'
+pkgname=eselect
+version=1.4.13
+revision=1
+build_style=gnu-configure
+hostmakedepends="automake libtool"
+depends="bash"
+short_desc="Modular configuration framework for Gentoo systems"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://wiki.gentoo.org/wiki/Project:Eselect"
+distfiles="https://gitweb.gentoo.org/proj/eselect.git/snapshot/eselect-${version}.tar.gz"
+checksum=fedb799b4d7ac00b9e51f32250cf0aa2865468f8701666edd125cd7d5dffd208
+
+pre_configure() {
+	./autogen.bash
+}

--- a/srcpkgs/fwupd/template
+++ b/srcpkgs/fwupd/template
@@ -1,6 +1,6 @@
 # Template file for 'fwupd'
 pkgname=fwupd
-version=1.2.0
+version=1.2.1
 revision=1
 build_style=meson
 # manpages fail to build
@@ -19,7 +19,7 @@ maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/hughsie/fwupd"
 distfiles="https://github.com/hughsie/fwupd/archive/${version}.tar.gz"
-checksum=f829cad4cead1fff16ccf8c771887b5b62c2ea6c51cf60a7ca72ce8ed759c469
+checksum=7ff2bb6979a7f7dbecf03e5e817d3835a698d5114a0c780a3c8de64a2fe4ae63
 nocross="depends on python3-gobject whether or not introspection is enabled"
 conf_files="/etc/dbus-1/system.d/org.freedesktop.fwupd.conf
  /etc/fwupd/daemon.conf /etc/fwupd/remotes.d/*.conf"

--- a/srcpkgs/portage/template
+++ b/srcpkgs/portage/template
@@ -1,0 +1,22 @@
+# Template file for 'portage'
+pkgname=portage
+version=2.3.51
+revision=1
+wrksrc="${pkgname}-${pkgname}-${version}"
+build_style=python3-module
+pycompile_module="portage _emerge"
+make_install_args="--sbindir=/usr/bin"
+hostmakedepends="python3"
+depends="python3 rsync xmlto eselect"
+short_desc="Gentoo's package management system"
+maintainer="teldra <teldra@rotce.de>"
+license="GPL-2.0-only"
+homepage="https://wiki.gentoo.org/wiki/Portage"
+distfiles="https://github.com/gentoo/${pkgname}/archive/${pkgname}-${version}.tar.gz"
+checksum=1d617cbdebfd46253d056ed3b5af18b6021f6e6c17caa94a5f0fe687ec359465
+
+conf_files="
+	/etc/dispatch-conf.conf
+	/etc/etc-update.conf
+	/etc/logrotate.d/elog-save-summary
+	/etc/portage/repo.postsync.d/example"

--- a/srcpkgs/portaudio/patches/sndio-portaudio.patch
+++ b/srcpkgs/portaudio/patches/sndio-portaudio.patch
@@ -1,0 +1,890 @@
+diff -Naur portaudio-orig/Makefile.in portaudio/Makefile.in
+--- portaudio-orig/Makefile.in	2018-11-27 14:33:02.442999726 +0100
++++ portaudio/Makefile.in	2018-11-27 14:38:09.544966833 +0100
+@@ -44,7 +44,7 @@
+ PAINC = include/portaudio.h
+ 
+ PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
+-	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS)_.*" \
++	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaSndio|PaAsio|PaOSS)_.*" \
+ 	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
+ 
+ COMMON_OBJS = \
+@@ -140,6 +140,7 @@
+ SRC_DIRS = \
+ 	src/common \
+ 	src/hostapi/alsa \
++	src/hostapi/sndio \
+ 	src/hostapi/asihpi \
+ 	src/hostapi/asio \
+ 	src/hostapi/coreaudio \
+diff -Naur portaudio-orig/configure.in portaudio/configure.in
+--- portaudio-orig/configure.in	2018-11-27 14:33:02.448999725 +0100
++++ portaudio/configure.in	2018-11-27 14:43:04.712935218 +0100
+@@ -24,6 +24,10 @@
+             AS_HELP_STRING([--with-alsa], [Enable support for ALSA @<:@autodetect@:>@]),
+             [with_alsa=$withval])
+ 
++AC_ARG_WITH(sndio,
++            AS_HELP_STRING([--with-sndio], [Enable support for sndio @<:@autodetect@:>@]),
++            [with_sndio=$withval])
++
+ AC_ARG_WITH(jack,
+             AS_HELP_STRING([--with-jack], [Enable support for JACK @<:@autodetect@:>@]),
+             [with_jack=$withval])
+@@ -120,6 +124,10 @@
+ if test "x$with_alsa" != "xno"; then
+     AC_CHECK_LIB(asound, snd_pcm_open, have_alsa=yes, have_alsa=no)
+ fi
++have_sndio=no
++if test "x$with_sndio" != "xno"; then
++    AC_CHECK_LIB(sndio, sio_open, have_sndio=yes, have_sndio=no)
++fi
+ have_asihpi=no
+ if test "x$with_asihpi" != "xno"; then
+     AC_CHECK_LIB(hpi, HPI_SubSysCreate, have_asihpi=yes, have_asihpi=no, -lm)
+@@ -406,6 +414,13 @@
+            AC_DEFINE(PA_USE_ALSA,1)
+         fi
+ 
++        if [[ "$have_sndio" = "yes" -a "$with_sndio" != "no" ]] ; then
++           DLL_LIBS="$DLL_LIBS -lsndio"
++           LIBS="$LIBS -lsndio"
++           OTHER_OBJS="$OTHER_OBJS src/hostapi/sndio/pa_sndio.o"
++           AC_DEFINE(PA_USE_SNDIO,1)
++        fi
++
+         if [[ "$have_jack" = "yes" ] && [ "$with_jack" != "no" ]] ; then
+            DLL_LIBS="$DLL_LIBS $JACK_LIBS"
+            CFLAGS="$CFLAGS $JACK_CFLAGS"
+@@ -484,6 +499,7 @@
+ 
+ case "$target_os" in *linux*)
+     AC_MSG_RESULT([
++  Sndio ....................... $have_sndio
+   ALSA ........................ $have_alsa
+   ASIHPI ...................... $have_asihpi])
+     ;;
+@@ -509,6 +525,7 @@
+         ;;
+      *)
+ 	AC_MSG_RESULT([
++  Sndio ....................... $have_sndio
+   OSS ......................... $have_oss
+   JACK ........................ $have_jack
+ ])
+diff -Naur portaudio-orig/include/portaudio.h portaudio/include/portaudio.h
+--- portaudio-orig/include/portaudio.h	2018-11-27 14:33:02.449999725 +0100
++++ portaudio/include/portaudio.h	2018-11-27 14:54:37.905860971 +0100
+@@ -287,7 +287,8 @@
+     paWDMKS=11,
+     paJACK=12,
+     paWASAPI=13,
+-    paAudioScienceHPI=14
++    paAudioScienceHPI=14,
++    paSndio=15
+ } PaHostApiTypeId;
+ 
+ 
+diff -Naur portaudio-orig/src/hostapi/sndio/pa_sndio.c portaudio/src/hostapi/sndio/pa_sndio.c
+--- portaudio-orig/src/hostapi/sndio/pa_sndio.c	1970-01-01 01:00:00.000000000 +0100
++++ portaudio/src/hostapi/sndio/pa_sndio.c	2018-11-27 14:36:43.241976077 +0100
+@@ -0,0 +1,765 @@
++/*
++ * Copyright (c) 2009 Alexandre Ratchov <alex@caoua.org>
++ *
++ * Permission to use, copy, modify, and distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ */
++#include <sys/types.h>
++#include <pthread.h>
++#include <poll.h>
++#include <errno.h>
++#include <string.h>
++#include <stdlib.h>
++#include <stdio.h>
++#include <sndio.h>
++
++#include "pa_util.h"
++#include "pa_hostapi.h"
++#include "pa_stream.h"
++#include "pa_process.h"
++#include "pa_allocation.h"
++
++#if 0
++#define DPR(...) do { fprintf(stderr, __VA_ARGS__); } while (0)
++#else
++#define DPR(...) do {} while (0)
++#endif
++
++/*
++ * per-stream data
++ */
++typedef struct PaSndioStream
++{
++	PaUtilStreamRepresentation base;
++	PaUtilBufferProcessor bufproc;	/* format conversion */
++	struct sio_hdl *hdl;		/* handle for device i/o */
++	struct sio_par par;		/* current device parameters */	
++	unsigned mode;			/* SIO_PLAY, SIO_REC or both */
++	int stopped;			/* stop requested or not started */
++	int active;			/* thread is running */
++	unsigned long long realpos;	/* frame number h/w is processing */
++	char *rbuf, *wbuf;		/* bounce buffers for conversions */
++	unsigned long long rpos, wpos;	/* bytes read/written */
++	pthread_t thread;		/* thread of the callback interface */
++} PaSndioStream;
++
++/*
++ * api "class" data, common to all streams
++ */
++typedef struct PaSndioHostApiRepresentation
++{
++	PaUtilHostApiRepresentation base;
++	PaUtilStreamInterface callback;
++	PaUtilStreamInterface blocking;
++	/*
++	 * sndio has no device discovery mechanism and PortAudio has
++	 * no way of accepting raw device strings from users.
++	 * Normally we just expose the default device, which can be
++	 * changed via the AUDIODEVICE environment variable, but we
++	 * also allow specifying a list of up to 16 devices via the
++	 * PA_SNDIO_AUDIODEVICES environment variable.
++	 *
++	 * Example:
++	 * PA_SNDIO_AUDIODEVICES=default:snd/0.monitor:snd@remote/0
++	 */
++#define PA_SNDIO_AUDIODEVICES_MAX	16
++	PaDeviceInfo device_info[PA_SNDIO_AUDIODEVICES_MAX];
++	PaDeviceInfo *infos[PA_SNDIO_AUDIODEVICES_MAX];
++	char *audiodevices;
++} PaSndioHostApiRepresentation;
++
++/*
++ * callback invoked when blocks are processed by the hardware
++ */
++static void
++sndioOnMove(void *addr, int delta)
++{
++	PaSndioStream *s = (PaSndioStream *)addr;
++
++	s->realpos += delta;
++}
++
++/*
++ * convert PA encoding to sndio encoding, return true on success
++ */
++static int
++sndioSetFmt(struct sio_par *sio, PaSampleFormat fmt)
++{
++	switch (fmt & ~paNonInterleaved) {
++	case paInt32:
++		sio->sig = 1;
++		sio->bits = 32;
++		break;
++	case paInt24:
++		sio->sig = 1;
++		sio->bits = 24;
++		sio->bps = 3;	/* paInt24 is packed format */
++		break;
++	case paInt16:
++	case paFloat32:
++		sio->sig = 1;
++		sio->bits = 16;
++		break;
++	case paInt8:
++		sio->sig = 1;
++		sio->bits = 8;
++		break;
++	case paUInt8:
++		sio->sig = 0;
++		sio->bits = 8;
++		break;
++	default:
++		DPR("sndioSetFmt: %x: unsupported\n", fmt);
++		return 0;
++	}
++	sio->le = SIO_LE_NATIVE;
++	return 1;
++}
++
++/*
++ * convert sndio encoding to PA encoding, return true on success
++ */
++static int
++sndioGetFmt(struct sio_par *sio, PaSampleFormat *fmt)
++{
++	if ((sio->bps * 8 != sio->bits && !sio->msb) ||
++	    (sio->bps > 1 && sio->le != SIO_LE_NATIVE)) {
++		DPR("sndioGetFmt: bits = %u, le = %u, msb = %u, bps = %u\n",
++		    sio->bits, sio->le, sio->msb, sio->bps);
++		return 0;
++	}
++
++	switch (sio->bits) {
++	case 32:
++		if (!sio->sig)
++			return 0;
++		*fmt = paInt32;
++		break;
++	case 24:
++		if (!sio->sig)
++			return 0;
++		*fmt = (sio->bps == 3) ? paInt24 : paInt32;
++		break;
++	case 16:
++		if (!sio->sig)
++			return 0;
++		*fmt = paInt16;
++		break;
++	case 8:
++		*fmt = sio->sig ? paInt8 : paUInt8;
++		break;
++	default:
++		DPR("sndioGetFmt: %u: unsupported\n", sio->bits);
++		return 0;
++	}
++	return 1;
++}
++
++/*
++ * I/O loop for callback interface
++ */
++static void *
++sndioThread(void *arg)
++{
++	PaSndioStream *s = (PaSndioStream *)arg;
++	PaStreamCallbackTimeInfo ti;
++	unsigned char *data;
++	unsigned todo, rblksz, wblksz;
++	int n, result;
++	
++	rblksz = s->par.round * s->par.rchan * s->par.bps;
++	wblksz = s->par.round * s->par.pchan * s->par.bps;
++	
++	DPR("sndioThread: mode = %x, round = %u, rblksz = %u, wblksz = %u\n",
++	    s->mode, s->par.round, rblksz, wblksz);
++	
++	while (!s->stopped) {
++		if (s->mode & SIO_REC) {
++			todo = rblksz;
++			data = s->rbuf;
++			while (todo > 0) {
++				n = sio_read(s->hdl, data, todo);
++				if (n == 0) {
++					DPR("sndioThread: sio_read failed\n");
++					goto failed;
++				}
++				todo -= n;
++				data += n;
++			}
++			s->rpos += s->par.round;
++			ti.inputBufferAdcTime = 
++			    (double)s->realpos / s->par.rate;
++		}
++		if (s->mode & SIO_PLAY) {
++			ti.outputBufferDacTime =
++			    (double)(s->realpos + s->par.bufsz) / s->par.rate;
++		}
++		ti.currentTime = s->realpos / (double)s->par.rate;
++		PaUtil_BeginBufferProcessing(&s->bufproc, &ti, 0);
++		if (s->mode & SIO_PLAY) {
++			PaUtil_SetOutputFrameCount(&s->bufproc, s->par.round);
++			PaUtil_SetInterleavedOutputChannels(&s->bufproc,
++			    0, s->wbuf, s->par.pchan);
++		}
++		if (s->mode & SIO_REC) {
++			PaUtil_SetInputFrameCount(&s->bufproc, s->par.round);
++			PaUtil_SetInterleavedInputChannels(&s->bufproc,
++			    0, s->rbuf, s->par.rchan);
++		}
++		result = paContinue;
++		n = PaUtil_EndBufferProcessing(&s->bufproc, &result);
++		if (n != s->par.round) {
++			DPR("sndioThread: %d < %u frames, result = %d\n",
++			    n, s->par.round, result);
++		}
++		if (result != paContinue) {
++			break;
++		}
++		if (s->mode & SIO_PLAY) {
++			n = sio_write(s->hdl, s->wbuf, wblksz);
++			if (n < wblksz) {
++				DPR("sndioThread: sio_write failed\n");
++				goto failed;
++			}
++			s->wpos += s->par.round;
++		}
++	}
++ failed:
++	s->active = 0;
++	DPR("sndioThread: done\n");
++}
++
++static PaError
++OpenStream(struct PaUtilHostApiRepresentation *hostApi,
++    PaStream **stream,
++    const PaStreamParameters *inputPar,
++    const PaStreamParameters *outputPar,
++    double sampleRate,
++    unsigned long framesPerBuffer,
++    PaStreamFlags streamFlags,
++    PaStreamCallback *streamCallback,
++    void *userData)
++{
++	PaSndioHostApiRepresentation *sndioHostApi = (PaSndioHostApiRepresentation *)hostApi;
++	PaSndioStream *s;
++	PaError err;
++	struct sio_hdl *hdl;
++	struct sio_par par;
++	unsigned mode;
++	int inch, onch;
++	PaSampleFormat ifmt, ofmt, siofmt;
++	const char *dev;
++
++	DPR("OpenStream:\n");
++
++	mode = 0;
++	inch = onch = 0;
++	ifmt = ofmt = 0;
++	sio_initpar(&par);
++
++	if (outputPar && outputPar->channelCount > 0) {
++		if (outputPar->device >= sndioHostApi->base.info.deviceCount) {
++			DPR("OpenStream: %d: bad output device\n", outputPar->device);
++			return paInvalidDevice;
++		}
++		if (outputPar->hostApiSpecificStreamInfo) {
++			DPR("OpenStream: output specific info\n");
++			return paIncompatibleHostApiSpecificStreamInfo;
++		}
++		if (!sndioSetFmt(&par, outputPar->sampleFormat)) {
++			return paSampleFormatNotSupported;
++		}
++		ofmt = outputPar->sampleFormat;
++		onch = par.pchan = outputPar->channelCount;
++		mode |= SIO_PLAY;
++	}
++	if (inputPar && inputPar->channelCount > 0) {
++		if (inputPar->device >= sndioHostApi->base.info.deviceCount) {
++			DPR("OpenStream: %d: bad input device\n", inputPar->device);
++			return paInvalidDevice;
++		}
++		if (inputPar->hostApiSpecificStreamInfo) {
++			DPR("OpenStream: input specific info\n");
++			return paIncompatibleHostApiSpecificStreamInfo;
++		}
++		if (!sndioSetFmt(&par, inputPar->sampleFormat)) {
++			return paSampleFormatNotSupported;
++		}
++		ifmt = inputPar->sampleFormat;
++		inch = par.rchan = inputPar->channelCount;
++		mode |= SIO_REC;
++	}
++	par.rate = sampleRate;
++	if (framesPerBuffer != paFramesPerBufferUnspecified)
++		par.round = framesPerBuffer;
++
++	DPR("OpenStream: mode = %x, trying rate = %u\n", mode, par.rate);
++
++	if (outputPar) {
++		dev = sndioHostApi->device_info[outputPar->device].name;
++	} else if (inputPar) {
++		dev = sndioHostApi->device_info[inputPar->device].name;
++	} else {
++		return paUnanticipatedHostError;
++	}
++	hdl = sio_open(dev, mode, 0);
++	if (hdl == NULL)
++		return paUnanticipatedHostError;
++	if (!sio_setpar(hdl, &par)) {
++		sio_close(hdl);
++		return paUnanticipatedHostError;
++	}
++	if (!sio_getpar(hdl, &par)) {
++		sio_close(hdl);
++		return paUnanticipatedHostError;
++	}
++	if (!sndioGetFmt(&par, &siofmt)) {
++		sio_close(hdl);
++		return paSampleFormatNotSupported;
++	}
++	if ((mode & SIO_REC) && par.rchan != inputPar->channelCount) {
++		DPR("OpenStream: rchan(%u) != %d\n", par.rchan, inputPar->channelCount);
++		sio_close(hdl);
++		return paInvalidChannelCount;
++	}
++	if ((mode & SIO_PLAY) && par.pchan != outputPar->channelCount) {
++		DPR("OpenStream: pchan(%u) != %d\n", par.pchan, outputPar->channelCount);
++		sio_close(hdl);
++		return paInvalidChannelCount;
++	}
++	if ((double)par.rate < sampleRate * 0.995 ||
++	    (double)par.rate > sampleRate * 1.005) {
++		DPR("OpenStream: rate(%u) != %g\n", par.rate, sampleRate);
++		sio_close(hdl);
++		return paInvalidSampleRate;
++	}
++	
++	s = (PaSndioStream *)PaUtil_AllocateMemory(sizeof(PaSndioStream));
++	if (s == NULL) {
++		sio_close(hdl);
++		return paInsufficientMemory;
++	}
++	PaUtil_InitializeStreamRepresentation(&s->base, 
++	    streamCallback ? &sndioHostApi->callback : &sndioHostApi->blocking,
++	    streamCallback, userData);
++	DPR("inch = %d, onch = %d, ifmt = %x, ofmt = %x\n", 
++	    inch, onch, ifmt, ofmt);
++	err = PaUtil_InitializeBufferProcessor(&s->bufproc,
++	    inch, ifmt, siofmt,
++	    onch, ofmt, siofmt,
++	    sampleRate,
++	    streamFlags,
++	    framesPerBuffer,
++	    par.round,
++	    paUtilFixedHostBufferSize, 
++	    streamCallback, userData);
++	if (err) {
++		DPR("OpenStream: PaUtil_InitializeBufferProcessor failed\n");
++		PaUtil_FreeMemory(s);
++		sio_close(hdl);
++		return err;
++	}
++	if (mode & SIO_REC) {
++		s->rbuf = malloc(par.round * par.rchan * par.bps);
++		if (s->rbuf == NULL) {
++			DPR("OpenStream: failed to allocate rbuf\n");
++			PaUtil_FreeMemory(s);
++			sio_close(hdl);
++			return paInsufficientMemory;
++		}
++	}
++	if (mode & SIO_PLAY) {
++		s->wbuf = malloc(par.round * par.pchan * par.bps);
++		if (s->wbuf == NULL) {
++			DPR("OpenStream: failed to allocate wbuf\n");
++			free(s->rbuf);
++			PaUtil_FreeMemory(s);
++			sio_close(hdl);
++			return paInsufficientMemory;
++		}
++	}	
++	s->base.streamInfo.inputLatency = 0;
++	s->base.streamInfo.outputLatency = (mode & SIO_PLAY) ?
++	    (double)(par.bufsz + PaUtil_GetBufferProcessorOutputLatencyFrames(&s->bufproc)) / (double)par.rate : 0;
++	s->base.streamInfo.sampleRate = par.rate;
++	s->active = 0;
++	s->stopped = 1;
++	s->mode = mode;
++	s->hdl = hdl;
++	s->par = par;
++	*stream = s;	
++	DPR("OpenStream: done\n");
++	return paNoError;
++}
++
++static PaError
++BlockingReadStream(PaStream *stream, void *data, unsigned long numFrames)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++	unsigned n, res, todo;
++	void *buf;
++	
++	while (numFrames > 0) {
++		n = s->par.round;
++		if (n > numFrames)
++			n = numFrames;
++		buf = s->rbuf;
++		todo = n * s->par.rchan * s->par.bps;
++		while (todo > 0) {
++			res = sio_read(s->hdl, buf, todo);
++			if (res == 0)
++				return paUnanticipatedHostError;
++			buf = (char *)buf + res;
++			todo -= res;
++		}
++		s->rpos += n;
++		PaUtil_SetInputFrameCount(&s->bufproc, n);
++		PaUtil_SetInterleavedInputChannels(&s->bufproc, 0, s->rbuf, s->par.rchan);
++		res = PaUtil_CopyInput(&s->bufproc, &data, n);
++		if (res != n) {
++			DPR("BlockingReadStream: copyInput: %u != %u\n");
++			return paUnanticipatedHostError;
++		}
++		numFrames -= n;
++	}
++	return paNoError;
++}
++
++static PaError
++BlockingWriteStream(PaStream* stream, const void *data, unsigned long numFrames)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++	unsigned n, res;
++
++	while (numFrames > 0) {
++		n = s->par.round;
++		if (n > numFrames)
++			n = numFrames;
++		PaUtil_SetOutputFrameCount(&s->bufproc, n);
++		PaUtil_SetInterleavedOutputChannels(&s->bufproc, 0, s->wbuf, s->par.pchan);
++		res = PaUtil_CopyOutput(&s->bufproc, &data, n);
++		if (res != n) {
++			DPR("BlockingWriteStream: copyOutput: %u != %u\n");
++			return paUnanticipatedHostError;
++		}
++		res = sio_write(s->hdl, s->wbuf, n * s->par.pchan * s->par.bps);
++		if (res == 0)
++			return paUnanticipatedHostError;		
++		s->wpos += n;
++		numFrames -= n;
++	}
++	return paNoError;
++}
++
++static signed long
++BlockingGetStreamReadAvailable(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++	struct pollfd pfd;
++	int n, events;
++
++	n = sio_pollfd(s->hdl, &pfd, POLLIN);
++	while (poll(&pfd, n, 0) < 0) {
++		if (errno == EINTR)
++			continue;
++		perror("poll");
++		abort();
++	}
++	events = sio_revents(s->hdl, &pfd);
++	if (!(events & POLLIN))
++		return 0;
++
++	return s->realpos - s->rpos;
++}
++
++static signed long
++BlockingGetStreamWriteAvailable(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++	struct pollfd pfd;
++	int n, events;
++
++	n = sio_pollfd(s->hdl, &pfd, POLLOUT);
++	while (poll(&pfd, n, 0) < 0) {
++		if (errno == EINTR)
++			continue;
++		perror("poll");
++		abort();
++	}
++	events = sio_revents(s->hdl, &pfd);
++	if (!(events & POLLOUT))
++		return 0;
++
++	return s->par.bufsz - (s->wpos - s->realpos);
++}
++
++static PaError
++BlockingWaitEmpty( PaStream *stream )
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++
++	/*
++	 * drain playback buffers; sndio always does it in background
++	 * and there is no way to wait for completion
++	 */
++	DPR("BlockingWaitEmpty: s=%d, a=%d\n", s->stopped, s->active);
++
++	return paNoError;
++}
++
++static PaError
++StartStream(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++	unsigned primes, wblksz;
++	int err;
++
++	DPR("StartStream: s=%d, a=%d\n", s->stopped, s->active);
++
++	if (!s->stopped) {
++		DPR("StartStream: already started\n");
++		return paNoError;
++	}
++	s->stopped = 0;
++	s->active = 1;
++	s->realpos = 0;
++	s->wpos = 0;
++	s->rpos = 0;
++	PaUtil_ResetBufferProcessor(&s->bufproc);
++	if (!sio_start(s->hdl))
++		return paUnanticipatedHostError;
++
++	/*
++	 * send a complete buffer of silence
++	 */
++	if (s->mode & SIO_PLAY) {
++		wblksz = s->par.round * s->par.pchan * s->par.bps;
++		memset(s->wbuf, 0, wblksz);
++		for (primes = s->par.bufsz / s->par.round; primes > 0; primes--)
++			s->wpos += sio_write(s->hdl, s->wbuf, wblksz);
++	}
++	if (s->base.streamCallback) {
++		err = pthread_create(&s->thread, NULL, sndioThread, s);
++		if (err) {
++			DPR("SndioStartStream: couldn't create thread\n");
++			return paUnanticipatedHostError;
++		}
++		DPR("StartStream: started...\n");
++	}
++	return paNoError;
++}
++
++static PaError
++StopStream(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++	void *ret;
++	int err;
++
++	DPR("StopStream: s=%d, a=%d\n", s->stopped, s->active);
++
++	if (s->stopped) {
++		DPR("StartStream: already started\n");
++		return paNoError;
++	}
++	s->stopped = 1;
++	if (s->base.streamCallback) {
++		err = pthread_join(s->thread, &ret);
++		if (err) {
++			DPR("SndioStop: couldn't join thread\n");
++			return paUnanticipatedHostError;
++		}
++	}
++	if (!sio_stop(s->hdl))
++		return paUnanticipatedHostError;
++	return paNoError;
++}
++
++static PaError
++CloseStream(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++
++	DPR("CloseStream:\n");
++
++	if (!s->stopped)
++		StopStream(stream);
++
++	if (s->mode & SIO_REC)
++		free(s->rbuf);
++	if (s->mode & SIO_PLAY)
++		free(s->wbuf);
++	sio_close(s->hdl);
++        PaUtil_TerminateStreamRepresentation(&s->base);
++	PaUtil_TerminateBufferProcessor(&s->bufproc);
++	PaUtil_FreeMemory(s);
++	return paNoError;
++}
++
++static PaError
++AbortStream(PaStream *stream)
++{
++	DPR("AbortStream:\n");
++
++	return StopStream(stream);
++}
++
++static PaError
++IsStreamStopped(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++
++	//DPR("IsStreamStopped: s=%d, a=%d\n", s->stopped, s->active);
++
++	return s->stopped;
++}
++
++static PaError
++IsStreamActive(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++
++	//DPR("IsStreamActive: s=%d, a=%d\n", s->stopped, s->active);
++
++	return s->active;
++}
++
++static PaTime
++GetStreamTime(PaStream *stream)
++{
++	PaSndioStream *s = (PaSndioStream *)stream;
++
++	return (double)s->realpos / s->base.streamInfo.sampleRate;
++}
++
++static PaError
++IsFormatSupported(struct PaUtilHostApiRepresentation *hostApi,
++    const PaStreamParameters *inputPar,
++    const PaStreamParameters *outputPar,
++    double sampleRate)
++{
++	return paFormatIsSupported;
++}
++
++static void
++Terminate(struct PaUtilHostApiRepresentation *hostApi)
++{
++	PaSndioHostApiRepresentation *sndioHostApi;
++	sndioHostApi = (PaSndioHostApiRepresentation *)hostApi;
++	free(sndioHostApi->audiodevices);
++	PaUtil_FreeMemory(hostApi);
++}
++
++static void
++InitDeviceInfo(PaDeviceInfo *info, PaHostApiIndex hostApiIndex, const char *name)
++{
++	info->structVersion = 2;
++	info->name = name;
++	info->hostApi = hostApiIndex;
++	info->maxInputChannels = 128;
++	info->maxOutputChannels = 128;
++	info->defaultLowInputLatency = 0.01;
++	info->defaultLowOutputLatency = 0.01;
++	info->defaultHighInputLatency = 0.5;
++	info->defaultHighOutputLatency = 0.5;
++	info->defaultSampleRate = 48000;
++}
++
++PaError
++PaSndio_Initialize(PaUtilHostApiRepresentation **hostApi, PaHostApiIndex hostApiIndex)
++{
++	PaSndioHostApiRepresentation *sndioHostApi;
++	PaDeviceInfo *info;
++	struct sio_hdl *hdl;
++	char *audiodevices;
++	char *device;
++	size_t deviceCount;
++
++	DPR("PaSndio_Initialize: initializing...\n");
++
++	/* unusable APIs should return paNoError and a NULL hostApi */
++	*hostApi = NULL;
++
++	sndioHostApi = PaUtil_AllocateMemory(sizeof(PaSndioHostApiRepresentation));
++	if (sndioHostApi == NULL)
++		return paNoError;
++
++	// Add default device
++	info = &sndioHostApi->device_info[0];
++	InitDeviceInfo(info, hostApiIndex, SIO_DEVANY);
++	sndioHostApi->infos[0] = info;
++	deviceCount = 1;
++
++	// Add additional devices as specified in the PA_SNDIO_AUDIODEVICES
++	// environment variable as a colon separated list
++	sndioHostApi->audiodevices = NULL;
++	audiodevices = getenv("PA_SNDIO_AUDIODEVICES");
++	if (audiodevices != NULL) {
++		sndioHostApi->audiodevices = strdup(audiodevices);
++		if (sndioHostApi->audiodevices == NULL)
++			return paNoError;
++
++		audiodevices = sndioHostApi->audiodevices;
++		while ((device = strsep(&audiodevices, ":")) != NULL &&
++			deviceCount < PA_SNDIO_AUDIODEVICES_MAX) {
++			if (*device == '\0')
++				continue;
++			info = &sndioHostApi->device_info[deviceCount];
++			InitDeviceInfo(info, hostApiIndex, device);
++			sndioHostApi->infos[deviceCount] = info;
++			deviceCount++;
++		}
++	}
++
++	*hostApi = &sndioHostApi->base;
++	(*hostApi)->info.structVersion = 1;
++	(*hostApi)->info.type = paSndio;
++	(*hostApi)->info.name = "sndio";
++	(*hostApi)->info.deviceCount = deviceCount;
++	(*hostApi)->info.defaultInputDevice = 0;
++	(*hostApi)->info.defaultOutputDevice = 0;
++	(*hostApi)->deviceInfos = sndioHostApi->infos;
++	(*hostApi)->Terminate = Terminate;
++	(*hostApi)->OpenStream = OpenStream;
++	(*hostApi)->IsFormatSupported = IsFormatSupported;
++	
++	PaUtil_InitializeStreamInterface(&sndioHostApi->blocking,
++	    CloseStream,
++	    StartStream,
++	    StopStream,
++	    AbortStream,
++	    IsStreamStopped,
++	    IsStreamActive,
++	    GetStreamTime,
++	    PaUtil_DummyGetCpuLoad,
++	    BlockingReadStream,
++	    BlockingWriteStream,
++	    BlockingGetStreamReadAvailable,
++	    BlockingGetStreamWriteAvailable);
++
++	PaUtil_InitializeStreamInterface(&sndioHostApi->callback,
++	    CloseStream,
++	    StartStream,
++	    StopStream,
++	    AbortStream,
++	    IsStreamStopped,
++	    IsStreamActive,
++	    GetStreamTime,
++	    PaUtil_DummyGetCpuLoad,
++	    PaUtil_DummyRead,
++	    PaUtil_DummyWrite,
++	    PaUtil_DummyGetReadAvailable,
++	    PaUtil_DummyGetWriteAvailable);
++
++	DPR("PaSndio_Initialize: done\n");
++	return paNoError;
++}
+diff -Naur portaudio-orig/src/os/unix/pa_unix_hostapis.c portaudio/src/os/unix/pa_unix_hostapis.c
+--- portaudio-orig/src/os/unix/pa_unix_hostapis.c	2018-11-27 14:33:02.454999725 +0100
++++ portaudio/src/os/unix/pa_unix_hostapis.c	2018-11-27 14:56:51.801846630 +0100
+@@ -44,6 +44,7 @@
+ 
+ PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+ PaError PaAlsa_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
++PaError PaSndio_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+ PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+ /* Added for IRIX, Pieter, oct 2, 2003: */
+ PaError PaSGI_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
+@@ -59,6 +60,10 @@
+     {
+ #ifdef __linux__
+ 
++#ifdef PA_USE_SNDIO
++	PaSndio_Initialize,
++#endif
++
+ #if PA_USE_ALSA
+         PaAlsa_Initialize,
+ #endif
+@@ -69,6 +74,10 @@
+ 
+ #else   /* __linux__ */
+ 
++#ifdef PA_USE_SNDIO
++	PaSndio_Initialize,
++#endif
++
+ #if PA_USE_OSS
+         PaOSS_Initialize,
+ #endif

--- a/srcpkgs/portaudio/patches/sndio-portaudio.patch
+++ b/srcpkgs/portaudio/patches/sndio-portaudio.patch
@@ -75,14 +75,21 @@ diff -Naur portaudio-orig/configure.in portaudio/configure.in
  ])
 diff -Naur portaudio-orig/include/portaudio.h portaudio/include/portaudio.h
 --- portaudio-orig/include/portaudio.h	2018-11-27 14:33:02.449999725 +0100
-+++ portaudio/include/portaudio.h	2018-11-27 14:54:37.905860971 +0100
-@@ -287,7 +287,8 @@
++++ portaudio/include/portaudio.h	2018-11-27 16:31:38.419237546 +0100
+@@ -281,13 +281,14 @@
+     paSoundManager=4,
+     paCoreAudio=5,
+     paOSS=7,
+-    paALSA=8,
++    paSndio=8,
+     paAL=9,
+     paBeOS=10,
      paWDMKS=11,
      paJACK=12,
      paWASAPI=13,
 -    paAudioScienceHPI=14
 +    paAudioScienceHPI=14,
-+    paSndio=15
++    paALSA=15
  } PaHostApiTypeId;
  
  

--- a/srcpkgs/portaudio/template
+++ b/srcpkgs/portaudio/template
@@ -1,14 +1,15 @@
 # Template file for 'portaudio'
 pkgname=portaudio
 version=190600.20161030
-revision=1
+revision=2
 wrksrc=portaudio
 build_style=gnu-configure
-configure_args="--enable-cxx --with-jack"
+configure_args="--enable-cxx --with-jack --with-sndio"
 hostmakedepends="automake libtool pkg-config"
-makedepends="alsa-lib-devel jack-devel"
+makedepends="alsa-lib-devel jack-devel sndio-devel"
 homepage="http://www.portaudio.com"
 license="MIT"
+patch_args="-Np1"
 short_desc="Portable cross-platform audio I/O library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 distfiles="http://www.${pkgname}.com/archives/pa_stable_v${version%.*}_${version#*.}.tgz"

--- a/srcpkgs/portaudio/template
+++ b/srcpkgs/portaudio/template
@@ -7,11 +7,11 @@ build_style=gnu-configure
 configure_args="--enable-cxx --with-jack --with-sndio"
 hostmakedepends="automake libtool pkg-config"
 makedepends="alsa-lib-devel jack-devel sndio-devel"
-homepage="http://www.portaudio.com"
 license="MIT"
 patch_args="-Np1"
 short_desc="Portable cross-platform audio I/O library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+homepage="http://www.portaudio.com"
 distfiles="http://www.${pkgname}.com/archives/pa_stable_v${version%.*}_${version#*.}.tgz"
 checksum=f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
 

--- a/srcpkgs/qtfm/template
+++ b/srcpkgs/qtfm/template
@@ -1,6 +1,6 @@
 # Template file for 'qtfm'
 pkgname=qtfm
-version=6.1.3
+version=6.1.4
 revision=1
 build_style=qmake
 configure_args="CONFIG+=release"
@@ -10,9 +10,9 @@ short_desc="Lightweight file manager for Linux desktops based on pure Qt"
 maintainer="Orphaned <orphan@voidlinux.eu>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/rodlie/qtfm"
-distfiles="https://github.com/rodlie/qtfm/archive/${version}.tar.gz"
 changelog="https://raw.githubusercontent.com/rodlie/qtfm/master/ChangeLog"
-checksum=567904b5709a803fd5b4a4234e99e46ca9b41c5fbdd4b21e9afa93b66e43d097
+distfiles="https://github.com/rodlie/qtfm/archive/${version}.tar.gz"
+checksum=bcddbcf7eaa73830a3283562c315a4aa935ef973fb0be65fa2d2426df991ac6f
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-devel"

--- a/srcpkgs/quassel/INSTALL.msg
+++ b/srcpkgs/quassel/INSTALL.msg
@@ -1,0 +1,11 @@
+(taken verbatim from quassel's release announcement)
+https://quassel-irc.org/node/134
+
+Before you upgrade, please be aware that both the database schema and the
+config file formats have been updated since 0.12. Quassel will automatically
+upgrade both once the new version is started for the first time, however no
+rollback is possible, so do make a backup before starting the new version! The
+upgrade may take a long time (up to several hours) if your database is
+(un)reasonably large, during which the core or mono client cannot be used. The
+upgrade may also temporarily require up to double the disk space. Do not
+interrupt the upgrade process, otherwise your database may become corrupted!

--- a/srcpkgs/quassel/template
+++ b/srcpkgs/quassel/template
@@ -1,22 +1,25 @@
 # Template file for 'quassel'
 pkgname=quassel
 version=0.13.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DEMBED_DATA=ON -DWANT_QTCLIENT=ON -DWANT_MONO=ON -DWANT_CORE=ON
- -DUSE_QT5=ON"
+ -DUSE_QT5=ON -DWITH_BUNDLED_ICONS=OFF"
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
 makedepends="qt5-tools-devel phonon-qt5-devel qca-qt5-devel zlib-devel
  libdbusmenu-qt5-devel qt5-script-devel qt5-plugin-tds
- qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-mysql qt5-plugin-odbc"
+ qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-mysql qt5-plugin-odbc
+ qt5-multimedia-devel $(vopt_if ldap libldap-devel)"
 depends="qt5-plugin-sqlite quassel-client-shared>=${version}_${revision}"
 _desc="Modern, cross-platform, distributed graphical IRC client"
 short_desc="${_desc} - standalone client"
 maintainer="Toyam Cox <Vaelatern@voidlinux.eu>"
-license="GPL-2.0, GPL-3.0"
+license="GPL-2.0-only or GPL-3.0-only"
 homepage="https://www.quassel-irc.org"
 distfiles="https://quassel-irc.org/pub/quassel-${version}.tar.bz2"
 checksum=d9822002de5bb1fd1002cccd537e5a0bc8ec365d355fdff4fb7818daefade976
+
+build_options="ldap"
 
 post_install() {
 	vsv quasselcore

--- a/srcpkgs/ruby-faraday/template
+++ b/srcpkgs/ruby-faraday/template
@@ -1,6 +1,6 @@
 # Template file for 'ruby-faraday'
 pkgname=ruby-faraday
-version=0.15.3
+version=0.15.4
 revision=1
 noarch=yes
 build_style=gem
@@ -9,7 +9,7 @@ short_desc="HTTP/REST API client library"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="MIT"
 homepage="https://github.com/lostisland/faraday"
-checksum=a2d4d2d05f557c2a6f87ae91cf3d61f757fc9c031dcac9ac9acf7cb011eb1c9a
+checksum=00e6ffd6f1bccd9dc9e3b993a0004e69680559422206ce4cbb81fd2d0ba8e268
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/shadowsocks-libev/template
+++ b/srcpkgs/shadowsocks-libev/template
@@ -1,6 +1,6 @@
 # Template file for 'shadowsocks-libev'
 pkgname=shadowsocks-libev
-version=3.2.1
+version=3.2.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-pcre=${XBPS_CROSS_BASE}/usr"
@@ -11,7 +11,7 @@ maintainer="whoami <whoami@systemli.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/shadowsocks/shadowsocks-libev"
 distfiles="${homepage}/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=988fc151474d0d2fb7a6005621949656e7a7f79400b4514624e09fd4b22969f6
+checksum=83906826135ba8e0c7cd3d46f892d28c7bf83583d15a91240ae2632dc90e28aa
 
 system_accounts="shadowsocks"
 make_dirs="/etc/${pkgname} 0750 shadowsocks shadowsocks"

--- a/srcpkgs/sublime-merge/template
+++ b/srcpkgs/sublime-merge/template
@@ -1,6 +1,6 @@
 # Template file for 'sublime-merge'
 pkgname=sublime-merge
-version=1075
+version=1084
 revision=1
 only_for_archs="x86_64"
 repository="nonfree"
@@ -10,7 +10,7 @@ maintainer="Adelmo Junior <noblehelm@gmail.com>"
 license="Proprietary"
 homepage="https://www.sublimemerge.com"
 distfiles="https://download.sublimetext.com/sublime_merge_build_${version}_x64.tar.xz"
-checksum=db790ff9f77fdc10a9af0bd8c12bce6362868bd79deb4c5fe6f5e38ea9c6276e
+checksum=eb5823206a777f5b34c7aa780a6f47c63277dc77c1551bed4e52d9f19a3844b3
 wrksrc="sublime_merge"
 nopie=yes
 

--- a/srcpkgs/tmplgen/template
+++ b/srcpkgs/tmplgen/template
@@ -1,6 +1,6 @@
 # Template file for 'tmplgen'
 pkgname=tmplgen
-version=0.5.1
+version=0.5.3
 revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -10,4 +10,4 @@ maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Cogitri/tmplgen"
 distfiles="https://static.crates.io/crates/tmplgen/tmplgen-${version}.crate"
-checksum=41cd990cbec9112bc8fd2bcd9bbc72aa93f89e5cf8c4b6e7164db7d1d0b978bb
+checksum=afc403bf69ad4da168938961b0f02da86ef29d655967cfcbacc8201e1327aff4

--- a/srcpkgs/topgrade/template
+++ b/srcpkgs/topgrade/template
@@ -1,6 +1,6 @@
 # Template file for 'topgrade'
 pkgname=topgrade
-version=1.0.1
+version=1.1.0
 revision=1
 build_style=cargo
 short_desc="Meta upgrade tool for pip, flatpak, your distro and everything else"
@@ -8,4 +8,4 @@ maintainer="jcgruenhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-darwish/topgrade"
 distfiles="https://github.com/r-darwish/topgrade/archive/v${version}.tar.gz"
-checksum=e3551da7763e7219217a695a3445855d634e1428737c8a01a6e5832d31a7fc8d
+checksum=d4966b2acdbec7f3f8127782fb8fd1d47239cac08c54f4b4354ceef0bee6705f

--- a/srcpkgs/zabbix/template
+++ b/srcpkgs/zabbix/template
@@ -1,6 +1,6 @@
 # Template file for 'zabbix'
 pkgname=zabbix
-version=4.0.1
+version=4.0.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-libxml2 --with-gnutls --with-libcurl --with-net-snmp
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.zabbix.com"
 changelog="https://www.zabbix.com/rn/rn${version}"
 distfiles="${SOURCEFORGE_SITE}/zabbix/zabbix-${version}.tar.gz"
-checksum=c73d54074885ae68c23dddc060e9e7f24c96f808eb502c5ee648c2820790e2fd
+checksum=1cef52e89dc8d20343d8b9c3881490bf86e98102de2229a3b852009f1659780c
 conf_files="/etc/zabbix_server.conf"
 system_accounts="_zabbix_server"
 system_groups="_zabbix_server"


### PR DESCRIPTION
I've converted the patches from FreeBSD / OpenBSD for portaudio. This should enable SNDIO support.

See: https://svnweb.freebsd.org/ports/head/audio/portaudio/files/