### PR TITLE
Rebuild packages for missing metadata, failing tests

### DIFF
--- a/srcpkgs/ORBit2/template
+++ b/srcpkgs/ORBit2/template
@@ -1,14 +1,14 @@
 # Template file for 'ORBit2'
 pkgname=ORBit2
 version=2.14.19
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libglib-devel libIDL-devel"
 short_desc="Thin/fast CORBA ORB"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2, LGPL-2.1"
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://projects.gnome.org/ORBit2/"
 distfiles="http://ftp.acc.umu.se/pub/gnome/sources/${pkgname}/2.14/${pkgname}-${version}.tar.bz2"
 checksum=55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550

--- a/srcpkgs/celt/template
+++ b/srcpkgs/celt/template
@@ -1,17 +1,21 @@
 # Template file for 'celt'
 pkgname=celt
 version=0.11.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-ogg=${XBPS_CROSS_BASE} --enable-float-approx --enable-custom-modes --disable-oggtest"
 hostmakedepends="pkg-config"
 makedepends="libogg-devel"
 short_desc="An audio codec for use in low-delay speech and audio communication"
-homepage="http://www.celt-codec.org/"
-license="BSD"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-2-Clause"
+homepage="http://www.celt-codec.org/"
 distfiles="http://downloads.us.xiph.org/releases/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=7e64815d4a8a009d0280ecd235ebd917da3abdcfd8f7d0812218c085f9480836
+
+post_install() {
+	vlicense COPYING
+}
 
 celt-devel_package() {
 	depends="libogg-devel celt>=${version}_${revision}"

--- a/srcpkgs/cloog/template
+++ b/srcpkgs/cloog/template
@@ -1,15 +1,15 @@
 # Template file for 'cloog'
 pkgname=cloog
 version=0.18.4
-revision=1
+revision=2
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--with-isl=system --with-gmp=system --with-gmp-exec-prefix=${XBPS_CROSS_BASE}"
 makedepends="isl-devel"
 short_desc="Library that generates loops for scanning polyhedra"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://www.bastoul.net/cloog/"
-license="GPL-2"
 distfiles="http://www.bastoul.net/cloog/pages/download/cloog-$version.tar.gz"
 checksum=325adf3710ce2229b7eeb9e84d3b539556d093ae860027185e7af8a8b00a750e
 

--- a/srcpkgs/colord-gtk/template
+++ b/srcpkgs/colord-gtk/template
@@ -1,15 +1,15 @@
 # Template file for 'colord-gtk'
 pkgname=colord-gtk
 version=0.1.26
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile $(vopt_enable gir introspection)"
 hostmakedepends="pkg-config intltool glib-devel vala-devel $(vopt_if gir gobject-introspection)"
 makedepends="colord-devel gtk+3-devel"
 short_desc="GTK support library for colord"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="http://www.freedesktop.org/software/colord"
-license="LGPL-2"
 distfiles="${FREEDESKTOP_SITE}/colord/releases/${pkgname}-${version}.tar.xz"
 checksum=28d00b7f157ea3e2ea5315387b2660fde82faba16674861c50465e55d61a3e45
 

--- a/srcpkgs/ctpl/template
+++ b/srcpkgs/ctpl/template
@@ -1,14 +1,14 @@
 # Template file for 'ctpl'
 pkgname=ctpl
 version=0.3.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
 short_desc="Template library written in C"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://ctpl.tuxfamily.org/"
 distfiles="http://download.tuxfamily.org/${pkgname}/releases/${pkgname}-${version}.tar.gz"
 checksum=3a95fdd03437ed3ae222339cb0de2d2c1240d627faa6c77bf46f1a9b761729fb

--- a/srcpkgs/distcc/template
+++ b/srcpkgs/distcc/template
@@ -1,21 +1,21 @@
 # Template file for 'distcc'
 pkgname=distcc
 version=3.2rc1
-revision=15
+revision=16
 build_style=gnu-configure
 configure_args="--disable-Werror --with-gtk"
-hostmakedepends="pkg-config"
-makedepends="python-devel popt-devel avahi-libs-devel gtk+-devel"
-conflicts="chroot-distcc>=0"
 conf_files="
 	/etc/distcc/hosts
 	/etc/distcc/clients.allow"
+hostmakedepends="pkg-config"
+makedepends="python-devel popt-devel avahi-libs-devel gtk+-devel"
 short_desc="Distributed compilation for faster C/C++ builds"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="https://distcc.github.io"
-license="GPL-2"
 distfiles="https://github.com/distcc/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.bz2"
 checksum=311671e844625d7fdb18dd3d096cd855751cfe8de13827682bcb7beff9133b30
+conflicts="chroot-distcc>=0"
 
 post_install() {
 	local f x

--- a/srcpkgs/geda/template
+++ b/srcpkgs/geda/template
@@ -1,16 +1,17 @@
 # Template file for 'geda'
 pkgname=geda
 version=1.8.2
-revision=6
+revision=7
 wrksrc="${pkgname}-gaf-${version}"
 build_style=gnu-configure
 configure_args="--with-sysroot=/${XBPS_CROSS_BASE}"
 hostmakedepends="pkg-config guile desktop-file-utils shared-mime-info"
 makedepends="gc-devel gtk+-devel guile-devel"
 depends="guile geda-data"
+checkdepends="perl"
 short_desc="Electronic Design Automation tool"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.geda-project.org/"
 distfiles="http://ftp.geda-project.org/geda-gaf/stable/v${version%.*}/${version}/geda-gaf-${version}.tar.gz"
 checksum=bbf4773aef1b5a51a8d6f4c3fa288c047340cc62dd6e14d7928fcc6e4051b721

--- a/srcpkgs/gfbgraph/template
+++ b/srcpkgs/gfbgraph/template
@@ -1,14 +1,14 @@
 # Template file for 'gfbgraph'
 pkgname=gfbgraph
 version=0.2.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config intltool $(vopt_if gir gobject-introspection)"
 makedepends="rest-devel json-glib-devel gnome-online-accounts-devel"
 short_desc="GLib/GObject wrapper for the SkyDrive and Hotmail REST APIs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/gfbgraph"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=da1179083cde2b649d7491c745250a00d292e390fd620b7dd2dd95a122dae0b6

--- a/srcpkgs/injeqt/patches/gcc7-fix.patch
+++ b/srcpkgs/injeqt/patches/gcc7-fix.patch
@@ -1,0 +1,22 @@
+From de025e0c472bdb2fcabbc9dc2fd443b91ab28e28 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bart=C5=82omiej=20Burdukiewicz?=
+ <bartlomiej.burdukiewicz@gmail.com>
+Date: Wed, 24 May 2017 18:52:20 +0200
+Subject: [PATCH] fix compilation for GCC 7.1.0
+
+---
+ src/internal/containers.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git src/internal/containers.h b/src/internal/containers.h
+index 8da4298..78dd212 100644
+--- src/internal/containers.h
++++ src/internal/containers.h
+@@ -23,6 +23,7 @@
+ #include "internal.h"
+ 
+ #include <algorithm>
++#include <functional>
+ #include <vector>
+ 
+ /**

--- a/srcpkgs/injeqt/template
+++ b/srcpkgs/injeqt/template
@@ -1,13 +1,13 @@
 # Template file for 'injeqt'
 pkgname=injeqt
 version=1.2.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="qt5-devel"
 short_desc="Dependency injection framework for Qt"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="https://github.com/vogel/injeqt/"
 distfiles="https://github.com/vogel/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=77540cedb0b26affe993dd18124d796059e34c80a51d9ae6433fdff1860db135

--- a/srcpkgs/js/template
+++ b/srcpkgs/js/template
@@ -1,15 +1,15 @@
 # Template file for 'js'
 pkgname=js
 version=1.8.5
-revision=10
+revision=11
 build_wrksrc="js/src"
 build_style=gnu-configure
 hostmakedepends="zip python perl nspr-devel"
 makedepends="nspr-devel"
 short_desc="Spidermonkey JavaScript interpreter and library"
-homepage="https://developer.mozilla.org/en/docs/SpiderMonkey"
-license="MPL-1.1, GPL-2, LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="MPL-1.1, GPL-2.0-only, LGPL-2.1-only"
+homepage="https://developer.mozilla.org/en/docs/SpiderMonkey"
 distfiles="${MOZILLA_SITE}/js/js185-1.0.0.tar.gz"
 checksum=5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687
 

--- a/srcpkgs/kadu/patches/gcc7.patch
+++ b/srcpkgs/kadu/patches/gcc7.patch
@@ -1,0 +1,12 @@
+diff --git kadu-core/plugin/dependency-graph/plugin-dependency-graph-builder.h kadu-core/plugin/dependency-graph/plugin-dependency-graph-builder.h
+index 1e6a500..a231cba 100644
+--- kadu-core/plugin/dependency-graph/plugin-dependency-graph-builder.h
++++ kadu-core/plugin/dependency-graph/plugin-dependency-graph-builder.h
+@@ -22,6 +22,7 @@
+ #include <QtCore/QObject>
+ #include <map>
+ #include <set>
++#include <functional>
+ 
+ #include "exports.h"
+ #include "plugin/dependency-graph/plugin-dependency-graph.h"

--- a/srcpkgs/kadu/template
+++ b/srcpkgs/kadu/template
@@ -1,7 +1,7 @@
 # Template file for 'kadu'
 pkgname=kadu
 version=4.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DCMAKE_PREFIX_PATH=${XBPS_CROSS_BASE}/usr
  -DQCA2_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include/QtCrypto
@@ -19,7 +19,7 @@ depends="${pkgname}-data-${version}_${revision} hicolor-icon-theme qca-qt5-ossl
  $(vopt_if tds qt5-plugin-tds)"
 short_desc="Instant Messenger client"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2"
+license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.kadu.im/"
 distfiles="http://download.kadu.im/stable/${pkgname}-${version}.tar.bz2"
 checksum=ad5d1cbb908c3cd07f2955d343d44b993cd5639427a48a2912441955cfd2bd6e

--- a/srcpkgs/lcms/template
+++ b/srcpkgs/lcms/template
@@ -1,7 +1,7 @@
-# Template build file for 'lcms'.
+# Template file for 'lcms'
 pkgname=lcms
 version=1.19
-revision=9
+revision=10
 wrksrc=${pkgname}-${version%[a-z]*}
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -9,10 +9,14 @@ hostmakedepends="pkg-config"
 makedepends="libjpeg-turbo-devel tiff-devel"
 short_desc="Light Color Management System -- a color management library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="MIT"
 homepage="http://www.littlecms.com"
-license="BSD"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=80ae32cb9f568af4dc7ee4d3c05a4c31fc513fc3e31730fed0ce7378237273a9
+
+post_install() {
+	vlicense COPYING
+}
 
 lcms-devel_package() {
 	depends="libjpeg-turbo-devel tiff-devel lcms>=${version}_${revision}"

--- a/srcpkgs/libcddb/template
+++ b/srcpkgs/libcddb/template
@@ -1,12 +1,12 @@
 # Template file for 'libcddb'
 pkgname=libcddb
 version=1.3.2
-revision=8
+revision=9
 build_style=gnu-configure
 short_desc="Library to access data on a CDDB server"
-homepage="http://libcddb.sourceforge.net/"
-license="LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.0-or-later"
+homepage="http://libcddb.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=68e9b53918b9bea727fb2db78936526671c039dcd7396cb82ecd6854e866048c
 

--- a/srcpkgs/libechonest-qt5/template
+++ b/srcpkgs/libechonest-qt5/template
@@ -1,7 +1,7 @@
-# Template file for 'libechonest'
+# Template file for 'libechonest-qt5'
 pkgname=libechonest-qt5
 version=2.3.1
-revision=1
+revision=2
 wrksrc=${pkgname%-*}-${version}
 build_style=cmake
 configure_args="-DBUILD_WITH_QT4=OFF"
@@ -9,7 +9,7 @@ hostmakedepends="qt5-qmake"
 makedepends="boost-devel qt5-xmlpatterns-devel"
 short_desc="A C++/Qt wrapper around the wonderful echo nest api"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://projects.kde.org/projects/playground/libs/libechonest"
 distfiles="http://files.lfranchi.com/${pkgname%-*}-${version}.tar.bz2"
 checksum=56756545fd1cb3d9067479f52215b6157c1ced2bc82b895e72fdcd9bebb47889

--- a/srcpkgs/libechonest/template
+++ b/srcpkgs/libechonest/template
@@ -1,7 +1,7 @@
 # Template file for 'libechonest'
 pkgname=libechonest
 version=2.3.1
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="qt-qmake"
 makedepends="qjson-devel boost-devel"

--- a/srcpkgs/liblastfm-qt5/template
+++ b/srcpkgs/liblastfm-qt5/template
@@ -1,14 +1,14 @@
-# Template file for 'liblastfm'
+# Template file for 'liblastfm-qt5'
 pkgname=liblastfm-qt5
 version=1.0.9
-revision=3
+revision=4
 wrksrc=${pkgname%-*}-${version}
 build_style=cmake
 makedepends="qt5-devel qt5-plugin-pgsql qt5-plugin-mysql qt5-plugin-sqlite
  qt5-plugin-odbc qt5-plugin-tds libsamplerate-devel fftw-devel"
 short_desc="A Qt5 C++ library for the Last.fm webservices"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/lastfm/liblastfm"
 distfiles="https://github.com/lastfm/${pkgname%-*}/archive/${version}.tar.gz"
 checksum=5276b5fe00932479ce6fe370ba3213f3ab842d70a7d55e4bead6e26738425f7b

--- a/srcpkgs/liblastfm/template
+++ b/srcpkgs/liblastfm/template
@@ -1,12 +1,12 @@
 # Template file for 'liblastfm'
 pkgname=liblastfm
 version=1.0.9
-revision=1
+revision=2
 build_style=cmake
 makedepends="qt-devel libsamplerate-devel fftw-devel"
 short_desc="A Qt4 C++ library for the Last.fm webservices"
 maintainer="Logen K <logen@sudotask.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/lastfm/liblastfm"
 distfiles="https://github.com/lastfm/${pkgname}/archive/${version}.tar.gz"
 checksum=5276b5fe00932479ce6fe370ba3213f3ab842d70a7d55e4bead6e26738425f7b

--- a/srcpkgs/make/template
+++ b/srcpkgs/make/template
@@ -1,20 +1,20 @@
 # Template file for 'make'
 pkgname=make
 version=4.2.1
-revision=3
-patch_args="-Np1"
+revision=4
 bootstrap=yes
 build_style=gnu-configure
-build_options=guile
 configure_args="$(vopt_with guile)"
 hostmakedepends="$(vopt_if guile pkg-config)"
 makedepends="$(vopt_if guile 'gc-devel guile-devel')"
 short_desc="The GNU make system"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/make"
 distfiles="${GNU_SITE}/make/${pkgname}-${version}.tar.bz2"
 checksum=d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589
+build_options=guile
+patch_args="-Np1"
 
 # This should be temporary until upstream releases a new version with fixes
 if [ -n "$CHROOT_READY" ]; then

--- a/srcpkgs/nodm/template
+++ b/srcpkgs/nodm/template
@@ -1,13 +1,13 @@
 # Template file for 'nodm'
 pkgname=nodm
 version=0.13
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="help2man automake pkg-config"
 makedepends="pam-devel xorg-server-devel"
 short_desc="Minimalistic display manager for automatic logins"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/spanezz/nodm"
 distfiles="https://github.com/spanezz/nodm/archive/${version}.tar.gz"
 checksum=ef11667ae82846801a9633df36c20f632cc03319bb1da35f062ac0f950771273

--- a/srcpkgs/opensp/template
+++ b/srcpkgs/opensp/template
@@ -1,20 +1,20 @@
 # Template file for 'opensp'
 pkgname=opensp
 version=1.5.2
-revision=7
+revision=8
 wrksrc="OpenSP-${version}"
 build_style=gnu-configure
 configure_args="--enable-http --enable-default-catalog=/usr/share/sgml/catalog"
 hostmakedepends="automake gettext-devel xmlto libtool"
 makedepends="docbook-xsl xmlcatmgr"
 depends="xmlcatmgr"
-sgml_entries="CATALOG /usr/share/OpenSP/catalog --"
 short_desc="SGML parser, successor to sp"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="X11"
 homepage="http://openjade.sourceforge.net/"
-license="MIT"
 distfiles="${SOURCEFORGE_SITE}/openjade/OpenSP-$version.tar.gz"
 checksum=57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce
+sgml_entries="CATALOG /usr/share/OpenSP/catalog --"
 
 keep_libtool_archives=yes
 
@@ -23,6 +23,7 @@ pre_configure() {
 }
 post_install() {
 	ln -s onsgmls ${DESTDIR}/usr/bin/nsgmls
+	vlicense COPYING
 }
 
 opensp-devel_package() {

--- a/srcpkgs/perl-Linux-Distribution/template
+++ b/srcpkgs/perl-Linux-Distribution/template
@@ -1,7 +1,8 @@
-# Template build file for 'perl-Linux-Distribution'.
+# Template file for 'perl-Linux-Distribution'
 pkgname=perl-Linux-Distribution
 version=0.23
-revision=1
+revision=2
+noarch=yes
 wrksrc="Linux-Distribution-$version"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,8 +10,7 @@ makedepends="perl"
 depends="perl"
 short_desc="Linux::Distribution - Detect the running Linux distribution"
 maintainer="Orphaned <orphan@voidlinux.eu>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Linux-Distribution"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Linux/Linux-Distribution-${version}.tar.gz"
 checksum=603e27da607b3e872a669d7a66d75982f0969153eab2d4b20c341347b4ebda5f
-noarch=yes

--- a/srcpkgs/python-gconf/template
+++ b/srcpkgs/python-gconf/template
@@ -1,24 +1,25 @@
 # Template file for 'python-gconf'
 pkgname=python-gconf
 version=2.28.1
-revision=4
-lib32disabled=yes
+revision=5
 wrksrc="gnome-python-${version}"
 build_style=gnu-configure
 configure_args="--enable-gconf --disable-gnome --disable-gnomeui
 --disable-gnomecanvas --disable-gnomevfs --disable-gnomevfsbonobo
 --disable-pyvfsmodule --disable-bonobo_activation --disable-bonobo
 --disable-bonoboui"
+pycompile_dirs="usr/share/pygtk/2.0"
 hostmakedepends="pkg-config python-devel"
 makedepends="python-devel pygtk-devel GConf-devel"
-pycompile_dirs="usr/share/pygtk/2.0"
 depends="pygtk"
 short_desc="Python bindings for interacting with GConf"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="LGPL-2.0-or-later"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/gnome-python/2.28/gnome-python-${version}.tar.bz2"
 checksum=759ce9344cbf89cf7f8449d945822a0c9f317a494f56787782a901e4119b96d8
+nocross="could not find Python headers or library"
+lib32disabled=yes
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/pkgconfig

--- a/srcpkgs/ucspi-tcp/template
+++ b/srcpkgs/ucspi-tcp/template
@@ -1,15 +1,15 @@
 # Template file for 'ucspi-tcp'
 pkgname=ucspi-tcp
-patch_args="-Np1"
 version=0.88
-revision=2
+revision=3
+build_style=gnu-makefile
 short_desc="Command-line tools for building TCP client-server applications"
 maintainer="Nikolay Hristov <geroy@horizon9.org>"
 license="public domain"
-build_style=gnu-makefile
 homepage="http://cr.yp.to/ucspi-tcp.html"
 distfiles="http://cr.yp.to/ucspi-tcp/ucspi-tcp-${version}.tar.gz"
 checksum=4a0615cab74886f5b4f7e8fd32933a07b955536a3476d74ea087a3ea66a23e9c
+patch_args="-Np1"
 
 do_install() {
 	vbin addcr

--- a/srcpkgs/xauth/template
+++ b/srcpkgs/xauth/template
@@ -1,7 +1,7 @@
-# Template build file for 'xauth'.
+# Template file for 'xauth'
 pkgname=xauth
 version=1.0.10
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="xtrans libXau-devel libXext-devel libXmu-devel"

--- a/srcpkgs/yabasic/template
+++ b/srcpkgs/yabasic/template
@@ -1,7 +1,7 @@
 # Template file for 'yabasic'
 pkgname=yabasic
 version=2.81.1
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libXt-devel ncurses-devel"
 short_desc="Yet another Basic"

--- a/srcpkgs/zpaq/template
+++ b/srcpkgs/zpaq/template
@@ -1,15 +1,15 @@
-# template for 'zpaq'
+# Template file for 'zpaq'
 pkgname=zpaq
 version=7.15
-revision=1
-license="GPL-3"
-short_desc="Incremental Journaling Backup Utility and Archiver"
+revision=2
+create_wrksrc=yes
 build_style=gnu-makefile
 hostmakedepends="unzip perl"
+short_desc="Incremental Journaling Backup Utility and Archiver"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Unlicense"
 homepage="http://mattmahoney.net/dc/zpaq.html"
 distfiles="http://mattmahoney.net/dc/zpaq${version//\./}.zip"
-create_wrksrc=yes
 checksum=e85ec2529eb0ba22ceaeabd461e55357ef099b80f61c14f377b429ea3d49d418
 
 do_build() {


### PR DESCRIPTION
Check stage fails for these packages.

All packages was build for x86_64, x86_64-musl, armv7hf and aarch64-musl. Nothing was tested manually whether it still works.

179 more packages remain to rebuild.