### PR TITLE
audacious-plugins: build SID player plugin

### DIFF
--- a/srcpkgs/audacious-plugins/template
+++ b/srcpkgs/audacious-plugins/template
@@ -1,17 +1,17 @@
 # Template file for 'audacious-plugins'
 pkgname=audacious-plugins
 version=3.10
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="audacious-devel alsa-lib-devel pulseaudio-devel jack-devel
  lame-devel libvorbis-devel libflac-devel mpg123-devel faad2-devel ffmpeg-devel
  libmodplug-devel fluidsynth-devel libcdio-paranoia-devel wavpack-devel libnotify-devel
  libcurl-devel libmtp-devel neon-devel libmms-devel gtk+-devel libxml2-devel
- libbs2b-devel libsoxr-devel"
+ libbs2b-devel libsoxr-devel libsidplayfp-devel"
 short_desc="Plugins for the Audacious media player"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="BSD"
+license="BSD-2-Clause"
 homepage="http://audacious-media-player.org/"
 distfiles="http://distfiles.audacious-media-player.org/${pkgname}-${version}.tar.bz2"
 checksum=5061ebb20169eb4d3f15aafbe83b43363762dc8d19ca0cd83f5556dc577e618f

--- a/srcpkgs/libsidplayfp/template
+++ b/srcpkgs/libsidplayfp/template
@@ -1,7 +1,7 @@
 # Template file for 'libsidplayfp'
 pkgname=libsidplayfp
 version=1.8.8
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Library to play Commodore 64 SID music"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"


### PR DESCRIPTION
- `audacious-plugins`: add `libsidplayfp-devel` to makedepends to build the [SID](https://en.wikipedia.org/wiki/MOS_Technology_6582) player plugin
- `libsidplayfp`: trigger a rebuild with the current version of `libstdc++` - this is needed in my Void x86_64 (glibc) to fix a segfault in Audacious when playing a SID file