### PR TITLE
fio: add --disable-native to the configure options

### DIFF
--- a/srcpkgs/fio/template
+++ b/srcpkgs/fio/template
@@ -19,7 +19,7 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 do_configure() {
-	./configure --prefix=/usr --extra-cflags="$CFLAGS"
+	./configure --prefix=/usr --extra-cflags="$CFLAGS" --disable-native
 }
 
 post_install() {


### PR DESCRIPTION
fio by default is passing the -march=native flag to
gcc, which causes it to emit specific optimized
instructions that are not available on all cpu models.

More specifically, the particular cause was that it
was enabling the BMI2 instruction set on the x86_64
builder and emitting shlx instructions which were
crashing fio (as illegal opcodes) on machines with
older cpus.

Signed-off-by: Anthony Iliopoulos <ailiop@altatus.com>