### PR TITLE
gcc: rebuild for metadata

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -7,7 +7,7 @@ _isl_version=0.19
 
 pkgname=gcc
 version=${_majorver}.0
-revision=6
+revision=7
 short_desc="The GNU C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://gcc.gnu.org"


### PR DESCRIPTION
Gcc with subpkgs lack `source-revisions` on x86_64-musl (build time: 2018-11-20 02:20).

Not tested.

Not urgent, can also wait until gcc is rebuilt because of changes.