### PR TITLE
tcc: add alternative for cc

### DIFF
--- a/srcpkgs/tcc/template
+++ b/srcpkgs/tcc/template
@@ -1,7 +1,7 @@
 # Template file for 'tcc'
 pkgname=tcc
 version=0.9.27
-revision=2
+revision=3
 _gitrev=d348a9a51d32cece842b7885d27a411436d7887b
 wrksrc=tinycc-${_gitrev:0:7}
 nopie=yes
@@ -11,10 +11,11 @@ hostmakedepends="perl"
 short_desc="The Tiny C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="http://bellard.org/tcc/"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 distfiles="http://repo.or.cz/tinycc.git/snapshot/${_gitrev}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=1c3a4150b4aaab9751af2112e8bfd8a93fd1a9d36af048e996ebfc0fd1f07e48
 nocross=yes
+alternatives="cc:cc:/usr/bin/tcc"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) configure_args="--config-musl";;


### PR DESCRIPTION
it compiles my toy programs fine

i also have a question: shouldn't this package depend on glibc-devel/musl-devel like [gcc](https://github.com/void-linux/void-packages/blob/master/srcpkgs/gcc/template#L104) and [llvm](https://github.com/void-linux/void-packages/blob/master/srcpkgs/llvm/template#L192)? it currently doesn't and you have to install them yourself to compile c programs