### PR TITLE
messagelib: fix CVE-2018-19516

### DIFF
--- a/srcpkgs/messagelib/patches/CVE-2018-19516.patch
+++ b/srcpkgs/messagelib/patches/CVE-2018-19516.patch
@@ -1,0 +1,28 @@
+From 34765909cdf8e55402a8567b48fb288839c61612 Mon Sep 17 00:00:00 2001
+From: Laurent Montel <montel@kde.org>
+Date: Fri, 23 Nov 2018 07:37:02 +0100
+Subject: Exclude Refresh from MetaData (Not necessary)
+
+---
+ messageviewer/src/messagepartthemes/default/defaultrenderer.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/messageviewer/src/messagepartthemes/default/defaultrenderer.cpp b/messageviewer/src/messagepartthemes/default/defaultrenderer.cpp
+index 15ffe44..07de293 100644
+--- a/messageviewer/src/messagepartthemes/default/defaultrenderer.cpp
++++ b/messageviewer/src/messagepartthemes/default/defaultrenderer.cpp
+@@ -308,6 +308,11 @@ QString processHtml(const QString &htmlSource, QString &extraHead)
+             return htmlSource;
+         }
+         extraHead = s.mid(startIndex + 6 , endIndex - startIndex - 6);
++        //Don't authorize to refresh content.
++        if (s.contains(QStringLiteral("http-equiv=\"REFRESH\""), Qt::CaseInsensitive)) {
++            extraHead.clear();
++        }
++
+         s = s.mid(endIndex + 7).trimmed();
+     }
+ 
+-- 
+cgit v0.11.2
+

--- a/srcpkgs/messagelib/template
+++ b/srcpkgs/messagelib/template
@@ -1,7 +1,7 @@
 # Template file for 'messagelib'
 pkgname=messagelib
 version=18.08.3
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python kconfig"
 makedepends="akonadi-contacts-devel gpgmeqt-devel kdepim-apps-libs-devel
@@ -13,6 +13,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://community.kde.org/KDE_PIM"
 distfiles="${KDE_SITE}/applications/${version}/src/messagelib-${version}.tar.xz"
 checksum=5fcb7984d8422e290323fed16d12d80d65701f21222a94219967ede132eeaa6e
+patch_args="-Np1"
 
 if [ "$CROSS_BUILD" ]; then
 	LDFLAGS=" -Wl,-rpath-link,../../bin"


### PR DESCRIPTION
https://www.kde.org/info/security/advisory-20181128-1.txt

> messagelib: HTML email can open browser window automatically