### PR TITLE
Rebuild packages for missing metadata vol. 8

### DIFF
--- a/srcpkgs/jpeginfo/template
+++ b/srcpkgs/jpeginfo/template
@@ -1,12 +1,12 @@
 # Template file for 'jpeginfo'
 pkgname=jpeginfo
 version=1.6.1
-revision=3
+revision=4
 build_style=gnu-configure
 makedepends="libjpeg-turbo-devel"
 short_desc="Prints information and tests integrity of JPEG/JFIF files"
 maintainer="bougyman <bougyman@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.kokkonen.net/tjko/projects.html"
 distfiles="http://www.kokkonen.net/tjko/src/jpeginfo-${version}.tar.gz"
 checksum=629e31cf1da0fa1efe4a7cc54c67123a68f5024f3d8e864a30457aeaed1d7653

--- a/srcpkgs/keylaunch/template
+++ b/srcpkgs/keylaunch/template
@@ -1,12 +1,12 @@
 # Template file for 'keylaunch'
 pkgname=keylaunch
 version=1.3.9
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libX11-devel"
 short_desc="A small utility for binding commands to a hot key"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.oroborus.org/?node=Download"
 distfiles="${DEBIAN_SITE}/main/k/keylaunch/keylaunch_${version}.tar.gz"
 checksum=213da77e9263e6aa7edbb1204402ef55d5daff2cd66add2cacbf84a1206da1ef

--- a/srcpkgs/leafpad/template
+++ b/srcpkgs/leafpad/template
@@ -1,16 +1,15 @@
 # Template file for 'leafpad'
-
-pkgname="leafpad"
-version="0.8.18.1"
-revision=3
+pkgname=leafpad
+version=0.8.18.1
+revision=4
 build_style=gnu-configure
-short_desc="GTK+ Simple text editor"
-maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
-license="GPL-2"
 hostmakedepends="intltool pkg-config"
 makedepends="gettext-devel gtk+-devel desktop-file-utils hicolor-icon-theme"
 depends="desktop-file-utils hicolor-icon-theme"
+short_desc="GTK+ Simple text editor"
+maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
+license="GPL-2.0-or-later"
 homepage="http://tarot.freeshell.org/leafpad/"
 distfiles="http://download-mirror.savannah.gnu.org/releases/leafpad/leafpad-${version}.tar.gz"
-checksum="959d22ae07f22803bc66ff40d373a854532a6e4732680bf8a96a3fbcb9f80a2c"
+checksum=959d22ae07f22803bc66ff40d373a854532a6e4732680bf8a96a3fbcb9f80a2c
 

--- a/srcpkgs/logpp/template
+++ b/srcpkgs/logpp/template
@@ -1,11 +1,11 @@
 # Template file for 'logpp'
 pkgname=logpp
 version=0.16
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="A tool for preprocessing event logs"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://logpp.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/project/logpp/logpp/${version}/logpp-${version}.tar.gz"
 checksum=3aaf5488a5190a59084617c4fbadc61f5a08d5a414d8b9d0a211c0a951bcb35b

--- a/srcpkgs/lsdvd/template
+++ b/srcpkgs/lsdvd/template
@@ -1,13 +1,13 @@
 # Template file for 'lsdvd'
 pkgname=lsdvd
 version=0.17
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libdvdread-devel"
 short_desc="Console application that displays the content of a dvd"
 maintainer="Martin Riese <grauehaare@gmx.de>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://sourceforge.net/projects/lsdvd/"
 distfiles="${SOURCEFORGE_SITE}/lsdvd/lsdvd-${version}.tar.gz"
 checksum=7d2c5bd964acd266b99a61d9054ea64e01204e8e3e1a107abe41b1274969e488

--- a/srcpkgs/luaexpat/template
+++ b/srcpkgs/luaexpat/template
@@ -1,7 +1,7 @@
 # Template file for 'luaexpat'
 pkgname=luaexpat
 version=1.3.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="LUA_INC=-I${XBPS_CROSS_BASE}/usr/include/lua5.1 EXPAT_INC=-I${XBPS_CROSS_BASE}/usr/include"
 makedepends="lua51-devel expat-devel"
@@ -10,5 +10,10 @@ short_desc="XML Expat parsing for the Lua programming language"
 maintainer="Duncaen <mail@duncano.de>"
 license="MIT"
 homepage="https://matthewwild.co.uk/projects/luaexpat/"
-distfiles="https://matthewwild.co.uk/projects/${pkgname}/${pkgname}-${version}.tar.gz"
+distfiles="https://matthewwild.co.uk/projects/luaexpat/luaexpat-${version}.tar.gz"
 checksum=d060397960d87b2c89cf490f330508b7def1a0677bdc120531c571609fc57dc3
+
+post_install() {
+	sed -n '/Copyright/,/SOFTWARE\./p' doc/us/license.html > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/luasocket/template
+++ b/srcpkgs/luasocket/template
@@ -1,7 +1,7 @@
 # Template file for 'luasocket'
 pkgname=luasocket
 version=2.0.2
-revision=5
+revision=6
 build_style=gnu-makefile
 makedepends="lua51-devel"
 depends="lua51"
@@ -9,9 +9,13 @@ short_desc="Network support for the Lua language "
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
 homepage="http://w3.impa.br/~diego/software/luasocket/"
-distfiles="http://luaforge.net/frs/download.php/2664/luasocket-$version.tar.gz"
+distfiles="http://luaforge.net/frs/download.php/2664/luasocket-${version}.tar.gz"
 checksum=4fd9c775cfd98841299851e29b30176caf289370fea1ff1e00bb67c2d6842ca6
 
 do_build() {
 	make CC=$CC LD=$CC LUAINC=-I${XBPS_CROSS_BASE}/usr/include/lua5.1 ${makejobs}
+}
+
+post_install() {
+	vlicense LICENSE
 }

--- a/srcpkgs/macchanger/template
+++ b/srcpkgs/macchanger/template
@@ -1,13 +1,13 @@
 # Template file for 'macchanger'
 pkgname=macchanger
 version=1.7.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_script="./autogen.sh"
 hostmakedepends="automake"
 short_desc="Small utility to change your NIC's MAC address"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/macchanger"
 distfiles="https://github.com/alobbs/macchanger/archive/${version}.tar.gz"
 checksum=1d75c07a626321e07b48a5fe2dbefbdb98c3038bb8230923ba8d32bda5726e4f

--- a/srcpkgs/mcwm/template
+++ b/srcpkgs/mcwm/template
@@ -2,11 +2,10 @@
 pkgname=mcwm
 _distver=20130209
 _patchver=2
-wrksrc="${pkgname}-${_distver}-${_patchver}"
 version="${_distver}.${_patchver}"
-revision=6
+revision=7
+wrksrc="${pkgname}-${_distver}-${_patchver}"
 build_style=gnu-makefile
-conflicts="2bwm>=0"
 makedepends="libxcb-devel xcb-proto xcb-util-devel xcb-util-keysyms-devel xcb-util-wm-devel"
 short_desc="A minimalist stacking X window manager based on XCB"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
@@ -14,6 +13,7 @@ license="ISC"
 homepage="http://hack.org/mc/projects/mcwm/"
 distfiles="http://hack.org/mc/hacks/${pkgname}/${pkgname}-${_distver}-${_patchver}.tar.bz2"
 checksum=2d2f9ced77bc6f90cb9fbdbf790eed97f3be28caefb0de496ac28813aed606be
+conflicts="2bwm>=0"
 
 do_build() {
 	[ -e ${FILESDIR}/config.h ] && cp ${FILESDIR}/config.h config.h

--- a/srcpkgs/minised/template
+++ b/srcpkgs/minised/template
@@ -1,11 +1,11 @@
 # Template file for 'minised'
 pkgname=minised
 version=1.15
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="A smaller, cheaper, faster sed implementation"
 maintainer="Richard Taityr <dicktyr@yahoo.co.uk>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="http://exactcode.com/opensource/minised/"
 distfiles="http://dl.exactcode.de/oss/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=ada36a55b71d1f2eb61f2f3b95f112708ce51e69f601bf5ea5d7acb7c21b3481

--- a/srcpkgs/mopag/template
+++ b/srcpkgs/mopag/template
@@ -1,18 +1,18 @@
 # Template file for 'mopag'
 pkgname=mopag
 version=0.0.0.20150613
-revision=1
-makedepends="libX11-devel"
+revision=2
+wrksrc="${pkgname}-master"
 build_style=gnu-makefile
 make_build_args="INCS=-I. LIBS=-lX11"
+makedepends="libX11-devel"
 short_desc="A small pager for monsterwm"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="Public Domain"
 homepage="https://github.com/c00kiemon5ter/${pkgname}"
 distfiles="https://github.com/c00kiemon5ter/${pkgname}/archive/master.tar.gz"
-checksum="23fd37f589f0f306c995f817bf88c32972ca5b0b53d064c4c3b5a877105d9204"
+checksum=23fd37f589f0f306c995f817bf88c32972ca5b0b53d064c4c3b5a877105d9204
 replaces="mopag>=0"
-wrksrc="${pkgname}-master"
 
 pre_build() {
 	sed -i 's|^CPPFLAGS *=|override CPPFLAGS +=|g' Makefile

--- a/srcpkgs/mousetweaks/template
+++ b/srcpkgs/mousetweaks/template
@@ -1,15 +1,15 @@
 # Template file for 'mousetweaks'
 pkgname=mousetweaks
 version=3.12.0
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool glib-devel $(vopt_if gir gobject-introspection)"
 makedepends="gsettings-desktop-schemas-devel gtk+3-devel libXtst-devel"
 depends="gsettings-desktop-schemas>=3.12 desktop-file-utils"
 short_desc="Mouse accessibility enhancements for the GNOME desktop"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-3.0-or-later"
 homepage="http://www.gnome.org"
-license="FDL, GPL-3"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=c0db478ccb390665e3201e9d1ce08b1c6573a697b797c9e828debb94b1ae3b97
 

--- a/srcpkgs/mrxvt/template
+++ b/srcpkgs/mrxvt/template
@@ -1,16 +1,15 @@
 # Template file for 'mrxvt'
-
-pkgname="mrxvt"
-version="0.5.4"
-revision=1
+pkgname=mrxvt
+version=0.5.4
+revision=2
 build_style=gnu-configure
 configure_args="--disable-debug --disable-lastlog --enable-xft --enable-text-shadow --with-save-lines=200 --with-x"
 hostmakedepends="pkg-config"
 makedepends="libXft-devel"
 short_desc="Multi-tabbed rxvt based terminal"
 maintainer="Dan Kociela <dkociela@gmail.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://materm.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/materm/mrxvt-${version}.tar.gz"
-checksum="f403ad5a908fcd38a55ed0a7e1b85584cb77be8781199653a39b8af1a9ad10d7"
+checksum=f403ad5a908fcd38a55ed0a7e1b85584cb77be8781199653a39b8af1a9ad10d7
 

--- a/srcpkgs/mtpfs/template
+++ b/srcpkgs/mtpfs/template
@@ -1,13 +1,13 @@
 # Template file for 'mtpfs'
 pkgname=mtpfs
 version=1.1
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="fuse-devel libmtp-devel libmad-devel libglib-devel libid3tag-devel"
 short_desc="A FUSE filesystem that supports reading and writing from any MTP device"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://www.adebenham.com/mtpfs/"
 distfiles="http://www.adebenham.com/files/mtp/mtpfs-${version}.tar.gz"
 checksum=1baf357de16995a5f0b5bc1b6833517a77456481d861cdba70f1ce1316ce4c1d

--- a/srcpkgs/multitail/template
+++ b/srcpkgs/multitail/template
@@ -1,17 +1,18 @@
 # Template file for 'multitail'
 pkgname=multitail
 version=6.4.2
-revision=1
+revision=2
 build_style=gnu-makefile
-CFLAGS='-funsigned-char -DLinux -DVERSION=\"\$(VERSION)\" -DCONFIG_FILE=\"\$(CONFIG_FILE)\" -DUTF8_SUPPORT'
-LDFLAGS='-lpanelw -lncursesw -lutil -lm'
 makedepends="ncurses-devel"
+checkdepends="clang-analyzer cppcheck perl"
 short_desc="Tail multiple logfiles"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-only"
 homepage="http://www.vanheusden.com/multitail"
 distfiles="${homepage}/${pkgname}-${version}.tgz"
 checksum=af1d5458a78ad3b747c5eeb135b19bdca281ce414cefdc6ea0cff6d913caa1fd
+LDFLAGS='-lpanelw -lncursesw -lutil -lm'
+CFLAGS='-funsigned-char -DLinux -DVERSION=\"\$(VERSION)\" -DCONFIG_FILE=\"\$(CONFIG_FILE)\" -DUTF8_SUPPORT'
 
 post_extract() {
 	sed -i 's,<ncursesw/,<,g' mt.h

--- a/srcpkgs/nausea/template
+++ b/srcpkgs/nausea/template
@@ -1,12 +1,12 @@
 # Template file for 'nausea'
 pkgname=nausea
 version=0.3
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="ncurses-devel fftw-devel"
 short_desc="A curses audio visualizer"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
-license="BSD"
+license="BSD-2-Clause"
 homepage="http://git.2f30.org/nausea/"
 distfiles="http://dl.2f30.org/releases/${pkgname}-${version}.tar.gz"
 checksum=264a8298098269ac34aee8209323e379bbd38605ebab3bcf89ce5ac5ffc10939

--- a/srcpkgs/netcat/template
+++ b/srcpkgs/netcat/template
@@ -1,12 +1,12 @@
 # Template file for 'netcat'
 pkgname=netcat
 version=0.7.1
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--program-prefix=g"
 short_desc="The GNU netcat utility"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://netcat.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=30719c9a4ffbcf15676b8f528233ccc54ee6cba96cb4590975f5fd60c68a066f

--- a/srcpkgs/ngetty/template
+++ b/srcpkgs/ngetty/template
@@ -1,10 +1,10 @@
 # Template file for 'ngetty'
 pkgname=ngetty
 version=1.1
-revision=5
+revision=6
 short_desc="Daemon for virtual console terminals"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://riemann.fmi.uni-sofia.bg/ngetty/"
 distfiles="${DEBIAN_SITE}/main/n/${pkgname}/${pkgname}_${version}.orig.tar.gz"
 checksum=15a0649b552aa47eeb80c7cc57ec6f562a89e271b14386838fbdb90244c546b0

--- a/srcpkgs/obconf/template
+++ b/srcpkgs/obconf/template
@@ -1,14 +1,14 @@
 # Template file for 'obconf'
 pkgname=obconf
 version=2.0.4
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel libglade-devel libSM-devel imlib2-devel openbox-devel startup-notification-devel"
 depends="desktop-file-utils shared-mime-info"
 short_desc="A GTK2 based configuration tool for the Openbox windowmanager"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://openbox.org/wiki/ObConf:About"
 distfiles="http://openbox.org/dist/obconf/obconf-${version}.tar.gz"
 checksum=71a3e5f4ee246a27421ba85044f09d449f8de22680944ece9c471cd46a9356b9

--- a/srcpkgs/obexfs/template
+++ b/srcpkgs/obexfs/template
@@ -1,13 +1,14 @@
 # Template file for 'obexfs'
 pkgname=obexfs
 version=0.12
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="fuse-devel libbluetooth-devel libobexftp-devel"
 short_desc="FUSE based filesystem using ObexFTP"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://openobex.triq.net/obexfs"
 distfiles="http://pkgs.fedoraproject.org/repo/pkgs/obexfs/obexfs-0.12.tar.gz/0f505672b025cdb505e215ee707a2e2f/obexfs-0.12.tar.gz"
 checksum=72a62aeb4d4decff962f22239513651843857492e9d6b50f515c9bf9fccd73bc
+nocross="libobexftp is nocross"

--- a/srcpkgs/odo/template
+++ b/srcpkgs/odo/template
@@ -1,7 +1,7 @@
 # Template file for 'odo'
 pkgname=odo
 version=0.2.2
-revision=2
+revision=3
 short_desc="An atomic odometer for the command line"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="ISC"
@@ -18,4 +18,6 @@ do_build() {
 do_install() {
 	vbin odo
 	vman man/odo.1
+	sed -n '/Copyright/,/PERFORMANCE/p' main.c > LICENSE
+	vlicense LICENSE
 }

--- a/srcpkgs/ogmtools/template
+++ b/srcpkgs/ogmtools/template
@@ -1,19 +1,19 @@
 # Template file for 'ogmtools'
 pkgname=ogmtools
 version=1.5
-revision=2
-short_desc="Tools for information,extractions or creation of OGG media streams"
-maintainer="Martin Riese <grauehaare@gmx.de>"
-license="GPL-2"
-homepage="http://www.bunkus.org/videotools/ogmtools/"
-distfiles="http://www.bunkus.org/videotools/ogmtools/ogmtools-1.5.tar.bz2"
-checksum="c8d61d1dbceb981dc7399c1a85e43b509fd3d071fb8d3ca89ea9385e6e40fdea"
+revision=3
 build_style=gnu-configure
 configure_args="--disable-oggtest --disable-vorbistest --with-dvdread
-	--with-dvdread-includes=${XBPS_CROSS_BASE}/usr
-	--with-dvdread-libs=${XBPS_CROSS_BASE}/usr/lib"
+ --with-dvdread-includes=${XBPS_CROSS_BASE}/usr
+ --with-dvdread-libs=${XBPS_CROSS_BASE}/usr/lib"
 hostmakedepends="automake libtool pkg-config"
 makedepends="libvorbis-devel libdvdread-devel"
+short_desc="Tools for information,extractions or creation of OGG media streams"
+maintainer="Martin Riese <grauehaare@gmx.de>"
+license="GPL-2.0-only"
+homepage="http://www.bunkus.org/videotools/ogmtools/"
+distfiles="http://www.bunkus.org/videotools/ogmtools/ogmtools-${version}.tar.bz2"
+checksum=c8d61d1dbceb981dc7399c1a85e43b509fd3d071fb8d3ca89ea9385e6e40fdea
 
 CFLAGS="-I./avilib"
 CXXFLAGS="${CFLAGS}"

--- a/srcpkgs/openjpeg/template
+++ b/srcpkgs/openjpeg/template
@@ -1,17 +1,21 @@
 # Template file for 'openjpeg'
 pkgname=openjpeg
 version=1.5.2
-revision=1
+revision=2
 build_style=cmake
-maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
-homepage="http://www.openjpeg.org/"
-license="BSD"
-short_desc="Open-source JPEG 2000 codec written in C language"
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libpng-devel lcms2-devel tiff-devel doxygen"
+short_desc="Open-source JPEG 2000 codec written in C language"
+maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
+license="BSD-2-Clause"
+homepage="http://www.openjpeg.org/"
 distfiles="$SOURCEFORGE_SITE/openjpeg.mirror/${version}/${pkgname}-${version}.tar.gz"
-checksum="15df7b194a5d8dba0052cd21c17a4dc761149a770a907d73fffb972078c28a87"
+checksum=15df7b194a5d8dba0052cd21c17a4dc761149a770a907d73fffb972078c28a87
+
+post_install() {
+	vlicense LICENSE
+}
 
 libopenjpeg-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/oroborus/template
+++ b/srcpkgs/oroborus/template
@@ -1,12 +1,12 @@
 # Template file for 'oroborus'
 pkgname=oroborus
 version=2.0.20
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libX11-devel libICE-devel libSM-devel libXext-devel libXpm-devel"
 short_desc="A minimalistic window manager"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.oroborus.org/"
 distfiles="${DEBIAN_SITE}/main/o/oroborus/oroborus_${version}.tar.gz"
 checksum=5220a540bcf6812c6773fbe583d9ea3f54f452cbac55bedcaadeba8c3a9a7b89

--- a/srcpkgs/patchutils/template
+++ b/srcpkgs/patchutils/template
@@ -1,13 +1,13 @@
 # Template file for 'patchutils'
 pkgname=patchutils
 version=0.3.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="perl"
 depends="perl"
 short_desc="Collection of programs that operate on patch files"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://cyberelk.net/tim/software/patchutils/"
 distfiles="http://cyberelk.net/tim/data/patchutils/stable/${pkgname}-${version}.tar.xz"
 checksum=cf55d4db83ead41188f5b6be16f60f6b76a87d5db1c42f5459d596e81dabe876

--- a/srcpkgs/pipenightdreams/template
+++ b/srcpkgs/pipenightdreams/template
@@ -1,15 +1,14 @@
 # Template file for 'pipenightdreams'
 pkgname=pipenightdreams
 version=0.10.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args=""
 hostmakedepends="automake flex libtool pkg-config"
 makedepends="SDL_image-devel"
 short_desc="Just another pipe trip"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-3"
-homepage="https://www.libsdl.org/projects/${pkgname}"
+license="GPL-2.0-or-later"
+homepage="https://www.libsdl.org/projects/pipenightdreams"
 distfiles="${homepage}/packages/${pkgname}-${version}.tar.bz2"
 checksum=302f8ce6e0eb32ebd779700527095cf086c2c7132d47095bae9a43c346245541
 

--- a/srcpkgs/pixz/template
+++ b/srcpkgs/pixz/template
@@ -1,18 +1,22 @@
 # Template file for 'pixz'
 pkgname=pixz
 version=1.0.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_file_src_pixz_1=no"
 hostmakedepends="automake libtool pkg-config asciidoc"
 makedepends="liblzma-devel libarchive-devel"
 short_desc="A parallel, indexing version of XZ"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="2-clause-BSD"
+license="BSD-2-Clause"
 homepage="https://github.com/vasi/pixz"
 distfiles="https://github.com/vasi/pixz/archive/v$version.tar.gz"
 checksum=ebde85148e927ed96abaeb9ab2166435c78d31e7c6b2847e8c8d6249b17f1b60
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
+}
+
+post_install() {
+	vlicense LICENSE
 }

--- a/srcpkgs/ptii/template
+++ b/srcpkgs/ptii/template
@@ -1,7 +1,7 @@
 # Template file for 'ptii'
 pkgname=ptii
 version=0.4
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="inotify-tools-devel"
 short_desc="A simple program you can use with ii"

--- a/srcpkgs/pwnat/template
+++ b/srcpkgs/pwnat/template
@@ -1,17 +1,17 @@
 # Template file for 'pwnat'
 pkgname=pwnat
 version=0.3
-revision=1
+revision=2
 # the git-hash of v0.3 as it isn't tagged
 _githash=572fcfb76a1b4b46faaa6b36817a39671b6f3c7e
-homepage="http://samy.pl/pwnat/"
-distfiles="https://github.com/samyk/pwnat/archive/${_githash}.tar.gz"
-short_desc="serverless NAT to NAT hole punching"
-maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-3"
-checksum=365da981ba1a39d7e3c8427fbcd9e7fcd3dd16cd30ae7e3b0aca50511fd8e1b1
 wrksrc="${pkgname}-${_githash}"
 build_style=gnu-makefile
+short_desc="Serverless NAT to NAT hole punching"
+maintainer="Enno Boland <gottox@voidlinux.eu>"
+license="GPL-3.0-or-later"
+homepage="http://samy.pl/pwnat/"
+distfiles="https://github.com/samyk/pwnat/archive/${_githash}.tar.gz"
+checksum=365da981ba1a39d7e3c8427fbcd9e7fcd3dd16cd30ae7e3b0aca50511fd8e1b1
 
 do_configure() {
 	sed -i 's#sys/unistd.h#unistd.h#' $(find -name '*.[ch]')

--- a/srcpkgs/pygtksourceview/template
+++ b/srcpkgs/pygtksourceview/template
@@ -1,8 +1,7 @@
 # Template file for 'pygtksourceview'
 pkgname=pygtksourceview
 version=2.10.1
-revision=4
-lib32disabled=yes
+revision=5
 build_style=gnu-configure
 configure_args="--disable-static --disable-docs"
 hostmakedepends="pkg-config intltool python-devel pygtk-devel"
@@ -10,10 +9,11 @@ makedepends="python-devel gtksourceview2-devel pygtk-devel"
 depends="pygtk"
 short_desc="Python bindings for gtksourceview2"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://www.gnome.org"
-license="GPL-2"
 distfiles="${GNOME_SITE}/${pkgname}/2.10/${pkgname}-${version}.tar.bz2"
 checksum=b4b47c5aeb67a26141cb03663091dfdf5c15c8a8aae4d69c46a6a943ca4c5974
+lib32disabled=yes
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/quvi/template
+++ b/srcpkgs/quvi/template
@@ -1,13 +1,13 @@
 # Template file for 'quvi'
 pkgname=quvi
 version=0.4.2
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libquvi-devel"
 short_desc="Command-line tool for parsing video download links"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://quvi.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/quvi/quvi-$version.tar.gz"
 checksum=85a54308bb0b682db9d4a8a4e7341d3d3bc9d3037c15f5ddad104efb45dbc5c4

--- a/srcpkgs/rakarrack/template
+++ b/srcpkgs/rakarrack/template
@@ -1,13 +1,13 @@
 # Template file for 'rakarrack'
 pkgname=rakarrack
 version=0.6.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="alsa-utils"
 makedepends="jack-devel libsndfile-devel libXpm-devel fltk-devel libsamplerate-devel"
 short_desc="Versatile guitar multi-effects processor"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://rakarrack.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.bz2"
 checksum=7696d27a4814b140fe651d137612ddfa1f167858eccc119e278c14dbee30eee6

--- a/srcpkgs/recordmydesktop/template
+++ b/srcpkgs/recordmydesktop/template
@@ -1,13 +1,13 @@
 # Template file for 'recordmydesktop'
 pkgname=recordmydesktop
 version=0.3.8.1
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="zlib-devel alsa-lib-devel libvorbis-devel libtheora-devel libXext-devel libXdamage-devel libSM-devel"
 short_desc="A X11 desktop session recorder"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://recordmydesktop.sourceforge.net/about.php"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=33a2e208186ae78e2db2a27b0f5047b50fb7819c47fe15483b0765200b9d738c

--- a/srcpkgs/reiserfsprogs/template
+++ b/srcpkgs/reiserfsprogs/template
@@ -1,7 +1,7 @@
 # Template file for 'reiserfsprogs'
 pkgname=reiserfsprogs
 version=3.6.24
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="libuuid-devel"

--- a/srcpkgs/rsstail/template
+++ b/srcpkgs/rsstail/template
@@ -1,12 +1,13 @@
 # Template file for 'rsstail'
 pkgname=rsstail
 version=2.1
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="libmrss-devel"
+checkdepends="cppcheck"
 short_desc="More or less an rss reader"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.vanheusden.com/rsstail/"
 distfiles="http://www.vanheusden.com/${pkgname}/${pkgname}-${version}.tgz"
 checksum=42cb452178b21c15c470bafbe5b8b5339a7fb5b980bf8d93d36af89864776e71

--- a/srcpkgs/runawk/template
+++ b/srcpkgs/runawk/template
@@ -1,12 +1,12 @@
 # Template file for 'runawk'
 pkgname=runawk
 version=1.6.0
-revision=1
+revision=2
 wrksrc="${pkgname}-${pkgname}-${version}"
 hostmakedepends="mk-configure perl"
 depends="virtual?awk"
 short_desc="Powerful wrapper for AWK interpreter"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://github.com/cheusov/runawk"
 distfiles="https://github.com/cheusov/${pkgname}/archive/${pkgname}-${version}.tar.gz"

--- a/srcpkgs/sandy/template
+++ b/srcpkgs/sandy/template
@@ -1,16 +1,16 @@
 # Template file for 'sandy'
 pkgname=sandy
 version=0.4
-revision=3
-makedepends="ncurses-devel"
+revision=4
 build_style=gnu-makefile
 make_build_args="INCS=-I. LIBS=-lncurses"
+makedepends="ncurses-devel"
 short_desc="A simple ncurses text editor"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="MIT"
 homepage="http://tools.suckless.org/${pkgname}"
 distfiles="${SOURCEFORGE_SITE}/sandyeditor/files/${pkgname}-${version}.tar.gz"
-checksum="3c51a891efa2ec9e2aa6ae3c1aa290beaf8075dae9abb9a46b5a7d619cb2fb67"
+checksum=3c51a891efa2ec9e2aa6ae3c1aa290beaf8075dae9abb9a46b5a7d619cb2fb67
 replaces="sandy-git>=0"
 
 pre_build() {

--- a/srcpkgs/scrotty/template
+++ b/srcpkgs/scrotty/template
@@ -1,14 +1,14 @@
 # Template file for 'scrotty'
 pkgname=scrotty
 version=2.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config auto-auto-complete"
 makedepends="libpng-devel"
 depends="ImageMagick"
 short_desc="Framebuffer screenshoter"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/maandree/scrotty"
 distfiles="https://github.com/maandree/scrotty/archive/${version}.tar.gz"
 checksum=466528d6ecf0138f57c40541258389686e22771c28d40f28c00825faaeaab1a3

--- a/srcpkgs/setxkbmap/template
+++ b/srcpkgs/setxkbmap/template
@@ -1,15 +1,15 @@
-# Template build file for 'setxkbmap'.
+# Template file for 'setxkbmap'
 pkgname=setxkbmap
 version=1.3.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libX11-devel libxkbfile-devel"
 short_desc="Set the keyboard map using the X Keyboard Extension"
-homepage="http://xorg.freedesktop.org"
-license="MIT"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-distfiles="${XORG_SITE}/app/$pkgname-$version.tar.bz2"
+license="MIT"
+homepage="http://xorg.freedesktop.org"
+distfiles="${XORG_SITE}/app/setxkbmap-${version}.tar.bz2"
 checksum=a9ddb3963f263ba13f0ea105d8c45a531832140530217cc559587bb94f02d3e1
 
 post_install() {

--- a/srcpkgs/sic/template
+++ b/srcpkgs/sic/template
@@ -1,7 +1,7 @@
 # Template file for 'sic'
 pkgname=sic
 version=1.2
-revision=4
+revision=5
 build_style=gnu-makefile
 make_build_args="INCS=-I. LIBS="
 short_desc="Simple irc client"
@@ -9,7 +9,7 @@ maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="MIT"
 homepage="http://tools.suckless.org/${pkgname}"
 distfiles="http://dl.suckless.org/tools/${pkgname}-${version}.tar.gz"
-checksum="ac07f905995e13ba2c43912d7a035fbbe78a628d7ba1c256f4ca1372fb565185"
+checksum=ac07f905995e13ba2c43912d7a035fbbe78a628d7ba1c256f4ca1372fb565185
 replaces="sic-git>=0"
 
 pre_build() {

--- a/srcpkgs/signify/template
+++ b/srcpkgs/signify/template
@@ -1,15 +1,15 @@
 # Template file for 'signify'
 pkgname=signify
 version=20141230
-revision=2
+revision=3
+wrksrc="signify-portable-${version}"
 build_style=gnu-makefile
 short_desc="OpenBSD cryptographic signing and verification tool"
-maintainer='Juan RP <xtraeme@voidlinux.eu>'
+maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="ISC"
 homepage="http://www.tedunangst.com/flak/post/signify"
-distfiles="${SOURCEFORGE_SITE}/slackdepot/${pkgname}/${pkgname}-portable-${version}.tar.bz2"
+distfiles="${SOURCEFORGE_SITE}/slackdepot/signify/signify-portable-${version}.tar.bz2"
 checksum=11c0a1ac0ca8075d2f00036f8de53a213346c4b2ecf44dacedc60d160569f6b2
-wrksrc="${pkgname}-portable-${version}"
 
 pre_build() {
 	sed -e 's|^mandir=${prefix}/man|mandir=${prefix}/share/man|g' \
@@ -26,4 +26,6 @@ pre_build() {
 post_install() {
 	vdoc README
 	vdoc BACKGROUND
+	sed -n '/Copyright/,/PERFORMANCE/p' signify.c > LICENSE
+	vlicense LICENSE
 }

--- a/srcpkgs/silc/template
+++ b/srcpkgs/silc/template
@@ -1,7 +1,8 @@
 # Template file for 'silc'
 pkgname=silc
 version=1.1.19
-revision=2
+revision=3
+wrksrc="silc-server-${version}"
 build_style=gnu-configure
 configure_args="--enable-debug --disable-optimizations --enable-ipv6 --with-logsdir=/var/log/silc
  --with-silcd-pid-file=/var/run/silcd.pid ac_cv_func_pthread_rwlock_init=set ac_cv_func_epoll_wait=set
@@ -9,8 +10,7 @@ configure_args="--enable-debug --disable-optimizations --enable-ipv6 --with-logs
 makedepends="silc-toolkit"
 short_desc="Secure Internet Live Conferencing server"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.silcnet.org/server.html"
-distfiles="${SOURCEFORGE_SITE}/silc/silc/server/sources/silc-server-$version.tar.bz2"
+distfiles="${SOURCEFORGE_SITE}/silc/silc/server/sources/silc-server-${version}.tar.bz2"
 checksum=b2fdfb9aca1c8886e7de9aa888f856247848aaf19b78b4fa64ca69c7210e76ce
-wrksrc="$pkgname-server-$version"

--- a/srcpkgs/since/template
+++ b/srcpkgs/since/template
@@ -1,10 +1,10 @@
 # Template file for 'since'
 pkgname=since
 version=1.1
-revision=1
+revision=2
 short_desc="Stateful tail"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://web.archive.org/web/20161220221905/http://welz.org.za/projects/since"
 distfiles="${DEBIAN_SITE}/main/s/since/${pkgname}_${version}.orig.tar.gz"
 checksum=739b7f161f8a045c1dff184e0fc319417c5e2deb3c7339d323d4065f7a3d0f45

--- a/srcpkgs/sinit/template
+++ b/srcpkgs/sinit/template
@@ -1,14 +1,14 @@
 # Template file for 'sinit'
 pkgname=sinit
 version=1.0
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="A simple init, initially based on Rich Felker’s minimal init"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="MIT"
 homepage="http://tools.suckless.org/sinit/"
 distfiles="http://dl.suckless.org/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum="78c2120a97a5e93b80606c5403bd731152f8a344e47aa4ab74970c1c11dc6fc0"
+checksum=78c2120a97a5e93b80606c5403bd731152f8a344e47aa4ab74970c1c11dc6fc0
 
 pre_build() {
 	LD=$CC

--- a/srcpkgs/slim/template
+++ b/srcpkgs/slim/template
@@ -1,21 +1,21 @@
 # Template file for 'slim'
 pkgname=slim
 version=1.3.6
-revision=11
-lib32disabled=yes
+revision=12
 build_style=cmake
 configure_args="-DUSE_CONSOLEKIT=1 -DUSE_PAM=yes
  -DFREETYPE_INCLUDE_DIR_freetype2=${XBPS_CROSS_BASE}/usr/include/freetype2"
+conf_files="/etc/slim.conf /etc/pam.d/slim"
 hostmakedepends="pkg-config"
 makedepends="libpng-devel freetype-devel libjpeg-turbo-devel libXrandr-devel
  libXmu-devel libXft-devel pam-devel ConsoleKit2-devel"
-conf_files="/etc/slim.conf /etc/pam.d/slim"
 short_desc="Desktop-independent graphical login manager for X11"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/slim.berlios/"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}.berlios/${pkgname}-${version}.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/slim.berlios/slim-${version}.tar.gz"
 checksum=21defeed175418c46d71af71fd493cd0cbffd693f9d43c2151529125859810df
+lib32disabled=yes
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) CXXFLAGS="-DNEEDS_BASENAME";;

--- a/srcpkgs/smproxy/template
+++ b/srcpkgs/smproxy/template
@@ -1,15 +1,15 @@
-# Template build file for 'smproxy'.
+# Template file for 'smproxy'
 pkgname=smproxy
 version=1.0.6
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libSM-devel libXt-devel libXmu-devel"
 short_desc="X11R6 session management application"
-homepage="http://xorg.freedesktop.org"
-license="MIT"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-distfiles="${XORG_SITE}/app/$pkgname-$version.tar.bz2"
+license="MIT"
+homepage="http://xorg.freedesktop.org"
+distfiles="${XORG_SITE}/app/smproxy-${version}.tar.bz2"
 checksum=6cf19155a2752237f36dbf8bc4184465ea190d2652f887faccb4e2a6ebf77266
 
 post_install() {

--- a/srcpkgs/smu/template
+++ b/srcpkgs/smu/template
@@ -1,7 +1,7 @@
 # Template file for 'smu'
 pkgname=smu
 version=1.4
-revision=3
+revision=4
 build_style=gnu-makefile
 make_build_args="INCS=-I. LIBS="
 short_desc="Simple markup - markdown like syntax"
@@ -9,7 +9,7 @@ maintainer='Juan RP <xtraeme@voidlinux.eu>'
 license="MIT"
 homepage="https://github.com/Gottox/smu/"
 distfiles="https://github.com/Gottox/smu/archive/v${version}.tar.gz"
-checksum="378f24e6cff54dcfcbc7a17a88f16efb59c0cda1d35f58967e16fd990ba15f45"
+checksum=378f24e6cff54dcfcbc7a17a88f16efb59c0cda1d35f58967e16fd990ba15f45
 
 pre_build() {
 	sed -i 's|^CFLAGS =.*|override CFLAGS += -DVERSION=\"${VERSION}\"|g' config.mk

--- a/srcpkgs/socklog/template
+++ b/srcpkgs/socklog/template
@@ -1,13 +1,13 @@
 # Template file for 'socklog'
 pkgname=socklog
 version=2.1.0
-revision=4
+revision=5
 wrksrc=admin/${pkgname}-${version}
 short_desc="Small and secure syslogd replacement for use with runit"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="custom"
 homepage="http://smarden.org/socklog/"
-distfiles="http://smarden.org/socklog/${pkgname}-${version}.tar.gz"
+distfiles="http://smarden.org/socklog/socklog-${version}.tar.gz"
 checksum=aa869a787ee004da4e5509b5a0031bcc17a4ab4ac650c2ce8d4e488123acb455
 
 build_options="static"

--- a/srcpkgs/starplot/template
+++ b/srcpkgs/starplot/template
@@ -1,14 +1,14 @@
 # Template file for 'starplot'
 pkgname=starplot
 version=0.95.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-rpath"
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel"
 short_desc="View 3d perspective maps of stars"
 maintainer="beefcurtains <beefcurtains@users.noreply.github.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://starplot.org/"
 distfiles="${homepage}downloads/${pkgname}-${version}.tar.gz"
 checksum=e320f141b736b3a6468e7d0c08a93961db6615e9eb4d533d554eea31c3fa845a

--- a/srcpkgs/sutils/template
+++ b/srcpkgs/sutils/template
@@ -1,7 +1,7 @@
 # Template file for 'sutils'
 pkgname=sutils
 version=0.2
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="alsa-lib-devel"
 short_desc="Small command-line utilities"

--- a/srcpkgs/swm/template
+++ b/srcpkgs/swm/template
@@ -1,7 +1,7 @@
 # Template file for 'swm'
 pkgname=swm
 version=1.0
-revision=2
+revision=3
 makedepends="libxcb-devel"
 short_desc="A simple window manager"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'

--- a/srcpkgs/tabbed/template
+++ b/srcpkgs/tabbed/template
@@ -1,16 +1,16 @@
 # Template file for 'tabbed'
 pkgname=tabbed
 version=0.6
-revision=3
-homepage="http://tools.suckless.org/${pkgname}/"
-distfiles="http://dl.suckless.org/tools/${pkgname}-${version}.tar.gz"
+revision=4
 build_style=gnu-makefile
 make_build_args="INCS=-I. LIBS=-lX11"
 makedepends="libX11-devel"
 short_desc="Tab interface for application supporting Xembed"
-maintainer='Juan RP <xtraeme@voidlinux.eu>'
+maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
-checksum="7651ea3acbec5d6a25469e8665da7fc70aba2b4fa61a2a6a5449eafdfd641c42"
+homepage="http://tools.suckless.org/tabbed/"
+distfiles="http://dl.suckless.org/tools/tabbed-${version}.tar.gz"
+checksum=7651ea3acbec5d6a25469e8665da7fc70aba2b4fa61a2a6a5449eafdfd641c42
 
 pre_build() {
 	sed -i 's|-O0 ||g' config.mk

--- a/srcpkgs/tree/template
+++ b/srcpkgs/tree/template
@@ -1,13 +1,13 @@
 # Template file for 'tree'
 pkgname=tree
 version=1.7.0
-revision=2
+revision=3
 build_style=gnu-makefile
-homepage="http://mama.indstate.edu/users/ice/tree"
-distfiles="$homepage/src/tree-$version.tgz"
 short_desc="Resursive directory listing program"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
+homepage="http://mama.indstate.edu/users/ice/tree"
+distfiles="http://mama.indstate.edu/users/ice/tree/src/tree-${version}.tgz"
 checksum=6957c20e82561ac4231638996e74f4cfa4e6faabc5a2f511f0b4e3940e8f7b12
 
 do_install() {

--- a/srcpkgs/trollock/template
+++ b/srcpkgs/trollock/template
@@ -1,15 +1,15 @@
 # Template file for 'trollock'
 pkgname=trollock
 version=4.1
-revision=1
+revision=2
 build_style=gnu-configure
-short_desc="Xtrlock fork with PAM support"
-maintainer="Andrea Brancaleoni <abc@pompel.me>"
 hostmakedepends="python pkg-config"
 makedepends="libX11-devel pam-devel"
-license="GPL-2"
+short_desc="Xtrlock fork with PAM support"
+maintainer="Andrea Brancaleoni <abc@pompel.me>"
+license="GPL-2.0-or-later"
 homepage="https://github.com/thypon/trollock"
-distfiles="$homepage/archive/v$version.tar.gz"
+distfiles="https://github.com/thypon/trollock/archive/v${version}.tar.gz"
 checksum=3e48ef9d129e91206e79b73df03757375c785296b3193d9148d044a9f9e84229
 
 do_configure() {

--- a/srcpkgs/tsocks/template
+++ b/srcpkgs/tsocks/template
@@ -1,17 +1,17 @@
 # Template file for 'tsocks'
 pkgname=tsocks
 version=1.8beta5
-revision=3
+revision=4
 wrksrc="tsocks-1.8"
 build_style=gnu-configure
 configure_args="--libdir=/usr/lib"
+hostmakedepends="automake"
 short_desc="Transparent SOCKS proxying library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://tsocks.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/tsocks/tsocks-$version.tar.gz"
 checksum=849d7ef5af80d03e76cc05ed9fb8fa2bcc2b724b51ebfd1b6be11c7863f5b347
-hostmakedepends="automake"
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/udevil/template
+++ b/srcpkgs/udevil/template
@@ -1,15 +1,15 @@
 # Template file for 'udevil'
 pkgname=udevil
 version=0.4.4
-revision=3
+revision=4
 build_style=gnu-configure
-hostmakedepends="pkg-config intltool"
 configure_args="--disable-systemd"
-makedepends="libglib-devel eudev-libudev-devel"
 conf_files="/etc/udevil/udevil.conf"
+hostmakedepends="pkg-config intltool"
+makedepends="libglib-devel eudev-libudev-devel"
 short_desc="CLI which mounts and unmounts removable devices without a password"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://ignorantguru.github.io/udevil/"
 distfiles="https://github.com/IgnorantGuru/udevil/archive/${version}.tar.gz"
 checksum=ad2fd8375bd62622718a04235e9772119459089938dbb78e657955e595822b7c

--- a/srcpkgs/udisks/template
+++ b/srcpkgs/udisks/template
@@ -1,19 +1,19 @@
 # Template file for 'udisks'
 pkgname=udisks
 version=1.0.5
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-static --enable-lvm2"
+make_dirs="/var/lib/udisks 0750 root root"
 hostmakedepends="pkg-config intltool libxslt docbook-xsl glib-devel dbus-glib-devel"
 makedepends="libglib-devel device-mapper-devel
  liblvm2app-devel libparted-devel libatasmart-devel polkit-devel
  dbus-glib-devel libgudev-devel sg3_utils-devel"
 depends="dbus"
-make_dirs="/var/lib/udisks 0750 root root"
 short_desc="Disk Management Service"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/udisks"
-license="GPL-2"
 distfiles="http://hal.freedesktop.org/releases/$pkgname-$version.tar.gz"
 checksum=f2ec82eb0ea7e01dc299b5b29b3c18cdf861236ec43dcff66b3552b4b31c6f71
 
@@ -21,6 +21,9 @@ pre_configure() {
 	# Switch to /usr.
 	sed -i -e "s|\(slashlibdir\)=.*|\1=/usr/lib|g" \
 		-e "s|\(slashsbindir\)=.*|\1=/usr/bin|g" configure
+}
+do_check() {
+	: # requires sudo
 }
 post_install() {
 	vmkdir usr/share/bash-completion/completions

--- a/srcpkgs/unifdef/template
+++ b/srcpkgs/unifdef/template
@@ -1,12 +1,12 @@
 # Template file for 'unifdef'
 pkgname=unifdef
 version=2.11
-revision=1
+revision=2
 build_style=gnu-makefile
 make_install_args="prefix=/usr"
 short_desc="Selectively remove C preprocessor conditionals"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
-license="2-clause-BSD"
+license="BSD-2-Clause"
 homepage="http://dotat.at/prog/unifdef/"
 distfiles="${homepage}/unifdef-${version}.tar.xz"
 checksum=828ffc270ac262b88fe011136acef2780c05b0dc3c5435d005651740788d4537

--- a/srcpkgs/usbmuxd/template
+++ b/srcpkgs/usbmuxd/template
@@ -1,20 +1,20 @@
 # Template file for 'usbmuxd'
 pkgname=usbmuxd
 version=1.1.0
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--without-systemd"
-hostmakedepends="pkg-config"
-system_accounts="usbmux"
-usbmux_homedir="/var/lib/lockdown"
 make_dirs="/var/lib/lockdown 0755 usbmux usbmux"
+hostmakedepends="pkg-config"
 makedepends="libusb-devel libimobiledevice-devel"
 short_desc="USB Multiplex Daemon"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2,GPL-3"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://marcan.st/blog/iphonelinux/usbmuxd/"
 distfiles="http://www.libimobiledevice.org/downloads/${pkgname}-${version}.tar.bz2"
 checksum=3e8948b4fe4250ee5c4bd41ccd1b83c09b8a6f5518a7d131a66fd38bd461b42d
+usbmux_homedir="/var/lib/lockdown"
+system_accounts="usbmux"
 
 post_install() {
 	vsv usbmuxd

--- a/srcpkgs/viking/template
+++ b/srcpkgs/viking/template
@@ -1,7 +1,7 @@
 # Template file for 'viking'
 pkgname=viking
 version=1.6.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-realtime-gps-tracking --disable-bluemarble
  --disable-bing --disable-terraserver --disable-spotmaps

--- a/srcpkgs/vorbisgain/template
+++ b/srcpkgs/vorbisgain/template
@@ -1,14 +1,14 @@
 # Template file for 'vorbisgain'
-pkgname="vorbisgain"
-version="0.37"
-revision=2
+pkgname=vorbisgain
+version=0.37
+revision=3
 build_style=gnu-configure
 configure_args="--enable-recursive"
 hostmakedepends="pkg-config"
 makedepends="libvorbis-devel"
 short_desc="A utility that computes the ReplayGain values for Ogg Vorbis files"
 maintainer="Farhad Shahbazi <grauwolf@geekosphere.org>"
-license="LGPL-2.1"
+license="LGPL-2.1-only"
 homepage="http://sjeng.org/vorbisgain.html"
-distfiles="http://sjeng.org/ftp/vorbis/${pkgname}-${version}.tar.gz"
+distfiles="http://sjeng.org/ftp/vorbis/vorbisgain-${version}.tar.gz"
 checksum=dd6db051cad972bcac25d47b4a9e40e217bb548a1f16328eddbb4e66613530ec

--- a/srcpkgs/vpnc/template
+++ b/srcpkgs/vpnc/template
@@ -1,23 +1,24 @@
 # Template file for 'vpnc'
 pkgname=vpnc
 version=0.5.3
-revision=5
+revision=6
 hostmakedepends="perl"
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=' vpnc'
-fi
 makedepends="libgcrypt-devel"
 depends="net-tools"
 short_desc="Client for cisco vpn concentrator"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://www.unix-ag.uni-kl.de/~massar/vpnc/"
-distfiles="https://www.unix-ag.uni-kl.de/~massar/vpnc/vpnc-$version.tar.gz"
+distfiles="https://www.unix-ag.uni-kl.de/~massar/vpnc/vpnc-${version}.tar.gz"
 checksum=46cea3bd02f207c62c7c6f2f22133382602baeda1dc320747809e94881414884
 
 conf_files="
  /etc/vpnc/default.conf
  /etc/vpnc/vpnc-script"
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" vpnc"
+fi
 
 do_configure() {
 	if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/wemux/template
+++ b/srcpkgs/wemux/template
@@ -1,7 +1,7 @@
 # Template file for 'wemux'
 pkgname=wemux
 version=3.2.0
-revision=1
+revision=2
 depends="tmux"
 short_desc="Multi-User Tmux Made Easy"
 maintainer="Diogo Leal <diogo@diogoleal.com>"


### PR DESCRIPTION
All packages was build (when available) for x86_64, x86_64-musl, armv7hf and aarch64-musl and passed check stage on x86_64 and x86_64-musl. Nothing was tested manually whether it still works.

104 more packages remain to rebuild.