### PR TITLE
Rebuild packages for missing metadata vol. 9

### DIFF
--- a/srcpkgs/acpi/template
+++ b/srcpkgs/acpi/template
@@ -1,11 +1,11 @@
 # Template file for 'acpi'
 pkgname=acpi
 version=1.7
-revision=3
+revision=4
 build_style=gnu-configure
-short_desc="Displays informations about ACPI devices (battery, thermal sensors and power)"
-maintainer='Juan RP <xtraeme@voidlinux.eu>'
-license="GPL-2"
+short_desc="Informations about ACPI devices (battery, thermal sensors and power)"
+maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/acpiclient/"
-distfiles="${SOURCEFORGE_SITE}/acpiclient/$pkgname-$version.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/acpiclient/acpi-${version}.tar.gz"
 checksum=d7a504b61c716ae5b7e81a0c67a50a51f06c7326f197b66a4b823de076a35005

--- a/srcpkgs/antiword/template
+++ b/srcpkgs/antiword/template
@@ -1,10 +1,10 @@
 # Template file for 'antiword'
 pkgname=antiword
 version=0.37
-revision=1
+revision=2
 short_desc="Converts the binary files from Word to plain text and to PostScript"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="http://www.winfield.demon.nl/"
 distfiles="http://www.winfield.demon.nl/linux/antiword-${version}.tar.gz
  http://sources.debian.net/data/main/a/antiword/0.37-10/debian/patches/docx.patch"

--- a/srcpkgs/arptables/template
+++ b/srcpkgs/arptables/template
@@ -1,15 +1,15 @@
 # Template file for 'arptables'
 pkgname=arptables
 version=0.0.4
-revision=1
+revision=2
 wrksrc="${pkgname}-v${version}"
 build_style=gnu-makefile
 depends="perl"
 short_desc="ARP table administration"
 maintainer="beefcurtains <beefcurtains@users.noreply.github.com>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://ebtables.sourceforge.net/"
-distfiles="ftp://ftp.netfilter.org/pub/arptables/arptables-v0.0.4.tar.gz"
+distfiles="ftp://ftp.netfilter.org/pub/arptables/arptables-v${version}.tar.gz"
 checksum=277985e29ecd93bd759a58242cad0e02ba9d4a6e1b7795235e3b507661bc0049
 
 do_install() {

--- a/srcpkgs/autocutsel/template
+++ b/srcpkgs/autocutsel/template
@@ -1,12 +1,12 @@
 # Template file for 'autocutsel'
 pkgname=autocutsel
 version=0.10.0
-revision=5
+revision=6
 build_style=gnu-configure
 makedepends="libXaw-devel"
 short_desc="Synchronize the two copy/paste buffers used by X applications"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="https://github.com/sigmike/autocutsel"
 distfiles="https://github.com/sigmike/autocutsel/releases/download/$version/autocutsel-$version.tar.gz"
 checksum=a2376330aa1a65f36621595a5a4eb5c2cabc16854b69d66c285f11f89bd05e3f

--- a/srcpkgs/bff/template
+++ b/srcpkgs/bff/template
@@ -1,13 +1,13 @@
 # Template file for 'bff'
 pkgname=bff
 version=1.0
-revision=1
+revision=2
 build_style=fetch
 short_desc="Brainfuck interpreter (DBFI dialect)"
 maintainer="ananteris <ananteris@mailinator.com>"
+license="Public Domain"
 homepage="http://mazonka.com/brainf/"
 distfiles="${homepage}/bff4.c"
-license="Public Domain"
 checksum=6139b587a7ac40b0bda023064172e9bbccfce15cd8c879ec601e8ee70b83aec3
 
 do_install() {

--- a/srcpkgs/bgs/template
+++ b/srcpkgs/bgs/template
@@ -1,15 +1,15 @@
 # Template file for 'bgs'
 pkgname=bgs
 version=0.8
-revision=1
-homepage="http://github.com/Gottox/bgs"
-distfiles="$homepage/archive/v${version}.tar.gz"
-makedepends="imlib2-devel libXinerama-devel"
-hostmakedepends="pkg-config"
-short_desc="An extremely fast and small background setter for X"
+revision=2
 build_style=gnu-makefile
+hostmakedepends="pkg-config"
+makedepends="imlib2-devel libXinerama-devel"
+short_desc="An extremely fast and small background setter for X"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT"
+homepage="http://github.com/Gottox/bgs"
+distfiles="http://github.com/Gottox/bgs/archive/v${version}.tar.gz"
 checksum=c52220a503f0ae1a200a2991893229ea981ae33722f41e9bc87bdf399f8d89e7
 
 do_build() {

--- a/srcpkgs/biew/template
+++ b/srcpkgs/biew/template
@@ -1,13 +1,13 @@
 # Template file for 'biew'
 pkgname=biew
 version=6.1.0
-revision=3
+revision=4
 _shortversion=${version//.}
 wrksrc="${pkgname}-${_shortversion}"
 build_style=gnu-configure
 short_desc="Console hex viewer/editor and disassembler"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://beye.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/beye/${pkgname}/${version}/${pkgname}-${_shortversion}-src.tar.bz2"
 checksum=2e85f03c908dd6ec832461fbfbc79169a33f4caccf48c8fe60cbd29f5fb06d17

--- a/srcpkgs/bootchart/template
+++ b/srcpkgs/bootchart/template
@@ -1,12 +1,11 @@
 # Template file for 'bootchart'
 pkgname=bootchart
 version=1.20
-revision=3
+revision=4
 build_style=gnu-configure
 short_desc="Startup graphing tool"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/sofar/bootchart"
 distfiles="http://foo-projects.org/~sofar/bootchart/bootchart-${version}.tar.gz"
-checksum="abce2fe0483ee23a522200fd630d7f288a337117c078dfaa220e1c55cdc2e896"
-configure_args="--sbindir=/usr/bin"
+checksum=abce2fe0483ee23a522200fd630d7f288a337117c078dfaa220e1c55cdc2e896

--- a/srcpkgs/clamz/template
+++ b/srcpkgs/clamz/template
@@ -1,13 +1,13 @@
-# Template build file for 'clamz'
+# Template file for 'clamz'
 pkgname=clamz
 version=0.5
-revision=1
+revision=2
 build_style=gnu-configure
-short_desc="Downloads MP3 files from Amazon.com's music store"
-maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-3"
-homepage="https://clamz.googlecode.com"
-distfiles="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/clamz/clamz-${version}.tar.gz"
 hostmakedepends="pkg-config"
 makedepends="expat-devel libcurl-devel libgcrypt-devel"
+short_desc="Downloads MP3 files from Amazon.com's music store"
+maintainer="Enno Boland <gottox@voidlinux.eu>"
+license="GPL-3.0-or-later"
+homepage="https://clamz.googlecode.com"
+distfiles="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/clamz/clamz-${version}.tar.gz"
 checksum=5a63f23f15dfa6c2af00ff9531ae9bfcca0facfe5b1aa82790964f050a09832b

--- a/srcpkgs/clens/template
+++ b/srcpkgs/clens/template
@@ -1,7 +1,7 @@
 # Template file for 'clens'
 pkgname=clens
 version=0.7.0
-revision=2
+revision=3
 makedepends="libbsd-devel"
 short_desc="Convenience library to aid in porting code from OpenBSD"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/cntlm/template
+++ b/srcpkgs/cntlm/template
@@ -1,11 +1,11 @@
 # Template file for 'cntlm'
 pkgname=cntlm
 version=0.92.3
-revision=5
+revision=6
 build_style=gnu-configure
 short_desc="NTLM / NTLM Session Response / NTLMv2 authenticating HTTP proxy"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://cntlm.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=9c3ad10924d43f7248df9ecd33cbc033afbd7ea8d9545de0d68a2782fed76298

--- a/srcpkgs/cparser/template
+++ b/srcpkgs/cparser/template
@@ -1,16 +1,20 @@
 # Template file for 'cparser'
 pkgname=cparser
 version=1.22.0
-revision=1
-wrksrc="${pkgname}-${pkgname}-${version}"
+revision=2
+wrksrc="cparser-cparser-${version}"
 makedepends="libfirm-devel"
-depends="gcc" # to link and assemble
+depends="gcc"
 short_desc="C99 parser (with GNU extensions) and libfirm frontend"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2"
 homepage="http://libfirm.org/"
-distfiles="https://github.com/MatzeB/${pkgname}/archive/${pkgname}-${version}.tar.gz"
+distfiles="https://github.com/MatzeB/cparser/archive/cparser-${version}.tar.gz"
 checksum=0965aa23d8ed7d4cce309806fec2d2c18ad20a74a084340baed0dc874b24175b
+
+case "$XBPS_TARGET_MACHINE" in
+	aarch64*) broken="requires broken libfirm" ;;
+esac
 
 post_extract() {
 	rmdir libfirm

--- a/srcpkgs/cpio/template
+++ b/srcpkgs/cpio/template
@@ -1,13 +1,13 @@
 # Template file for 'cpio'
 pkgname=cpio
 version=2.12
-revision=1
+revision=2
 build_style=gnu-configure
-checkdepends="bash" # required for symlink-long test
 configure_args="--with-rmt=/usr/bin/rmt"
+checkdepends="bash"
 short_desc="GNU copy-in/out (cpio) with remote magnetic tape (rmt) support"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/cpio/"
-license="GPL-3"
-distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.bz2"
+distfiles="${GNU_SITE}/cpio/cpio-${version}.tar.bz2"
 checksum=70998c5816ace8407c8b101c9ba1ffd3ebbecba1f5031046893307580ec1296e

--- a/srcpkgs/cronutils/template
+++ b/srcpkgs/cronutils/template
@@ -1,7 +1,7 @@
 # Template file for 'cronutils'
 pkgname=cronutils
 version=1.9
-revision=1
+revision=2
 wrksrc="${pkgname}-version-${version}"
 build_style=gnu-makefile
 make_install_args="prefix=/usr"

--- a/srcpkgs/ctags/template
+++ b/srcpkgs/ctags/template
@@ -1,7 +1,7 @@
 # Template file for 'ctags'
 pkgname=ctags
 version=5.8
-revision=6
+revision=7
 build_style=gnu-configure
 short_desc="Generates an index file of language objects found in source files"
 maintainer="Jan S. <jan.schreib@gmail.com>"

--- a/srcpkgs/cuetools/template
+++ b/srcpkgs/cuetools/template
@@ -1,15 +1,13 @@
 # Template file for 'cuetools'
 pkgname=cuetools
 version=1.4.1
-revision=1
-short_desc="Cue and toc file parsers and utilities"
-homepage="https://github.com/svend/cuetools"
-license="GPL-2"
-maintainer="Georg S. <gescha@posteo.de>"
-
-hostmakedepends="automake bison flex"
+revision=2
 build_style=gnu-configure
-
+hostmakedepends="automake bison flex"
+short_desc="Cue and toc file parsers and utilities"
+maintainer="Georg S. <gescha@posteo.de>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/svend/cuetools"
 distfiles="https://github.com/svend/${pkgname}/archive/${version}.tar.gz"
 checksum=24a2420f100c69a6539a9feeb4130d19532f9f8a0428a8b9b289c6da761eb107
 

--- a/srcpkgs/ddpt/template
+++ b/srcpkgs/ddpt/template
@@ -1,13 +1,13 @@
 # Template file for 'ddpt'
 pkgname=ddpt
 version=0.95
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="sg3_utils-devel"
 short_desc="A variant of the standard Unix command dd which copies files"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-3-Clause"
 homepage="http://sg.danny.cz/sg/ddpt.html"
-license="BSD"
 distfiles="http://sg.danny.cz/sg/p/${pkgname}-${version}.tgz"
 checksum=84a3c2a9ed7d5bff33ae298fb8bbbf650d5db3235a2bfe90033518e759144bb5
 

--- a/srcpkgs/dhex/template
+++ b/srcpkgs/dhex/template
@@ -1,16 +1,16 @@
 # Template file for 'dhex'
 pkgname=dhex
 version=0.68
-revision=4
+revision=5
+wrksrc="${pkgname}_${version}"
 build_style=gnu-makefile
 makedepends="ncurses-devel"
 short_desc="Hex editor and diff tool using ncurses"
 maintainer="Alex Brem <alex@fluktuation.net>"
-license="GPL-2,GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://www.dettus.net/dhex/"
 distfiles="${homepage}${pkgname}_${version}.tar.gz"
 checksum=126c34745b48a07448cfe36fe5913d37ec562ad72d3f732b99bd40f761f4da08
-wrksrc="${pkgname}_${version}"
 
 do_install() {
 	vbin dhex

--- a/srcpkgs/duff/template
+++ b/srcpkgs/duff/template
@@ -1,11 +1,11 @@
 # Template file for 'duff'
 pkgname=duff
 version=0.5.2
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Duplicate file finder"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
-license="zlib"
+license="Zlib"
 homepage="http://duff.dreda.org/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=15b721f7e0ea43eba3fd6afb41dbd1be63c678952bf3d80350130a0e710c542e

--- a/srcpkgs/dvtm/template
+++ b/srcpkgs/dvtm/template
@@ -1,13 +1,13 @@
 # Template file for 'dvtm'
 pkgname=dvtm
 version=0.15
-revision=1
+revision=2
 makedepends="ncurses-devel"
 depends="ncurses" # needs tic at post-install
 short_desc="Tiling window manager for the console"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.brain-dump.org/projects/dvtm/"
 license="MIT"
+homepage="http://www.brain-dump.org/projects/dvtm/"
 distfiles="http://www.brain-dump.org/projects/dvtm/$pkgname-$version.tar.gz"
 checksum=8f2015c05e2ad82f12ae4cf12b363d34f527a4bbc8c369667f239e4542e1e510
 

--- a/srcpkgs/dwm/template
+++ b/srcpkgs/dwm/template
@@ -1,13 +1,13 @@
 # Template file for 'dwm'
 pkgname=dwm
 version=6.1
-revision=1
-homepage="http://dwm.suckless.org"
-distfiles="https://dl.suckless.org/dwm/dwm-${version}.tar.gz"
+revision=2
 makedepends="libXinerama-devel libXft-devel freetype-devel"
 short_desc="A dynamic window manager for X"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
+homepage="http://dwm.suckless.org"
+distfiles="https://dl.suckless.org/dwm/dwm-${version}.tar.gz"
 checksum=c2f6c56167f0acdbe3dc37cca9c1a19260c040f2d4800e3529a21ad7cce275fe
 
 do_build() {

--- a/srcpkgs/evilwm/template
+++ b/srcpkgs/evilwm/template
@@ -1,15 +1,15 @@
 # Template file for 'evilwm'
 pkgname=evilwm
 version=1.1.1
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="libXrandr-devel"
 short_desc="A minimalist window manager for the X Window System"
 maintainer='Juan RP <xtraeme@voidlinux.eu>'
-homepage="http://evilwm.sourceforge.net"
 license="Public Domain"
+homepage="http://evilwm.sourceforge.net"
 distfiles="http://www.6809.org.uk/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum="79589c296a5915ee0bae1d231e8912601fc794d9f0a9cacb6b648ff9a5f2602a"
+checksum=79589c296a5915ee0bae1d231e8912601fc794d9f0a9cacb6b648ff9a5f2602a
 
 pre_build() {
 	sed -i 's|^CFLAGS|#CFLAGS|g' Makefile

--- a/srcpkgs/fbgrab/template
+++ b/srcpkgs/fbgrab/template
@@ -1,13 +1,13 @@
 # Template file for 'fbgrab'
 pkgname=fbgrab
 version=1.3
-revision=1
+revision=2
 build_style=gnu-makefile
-homepage="http://fbgrab.monells.se/"
 makedepends="zlib-devel libpng-devel"
 short_desc="A linux framebuffer screenshot program"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-only"
+homepage="http://fbgrab.monells.se/"
 distfiles="http://fbgrab.monells.se/fbgrab-$version.tar.gz"
 checksum=5fab478cbf8731fbacefaa76236a8f8b38ccff920c53b3a8253bc35509fba8ed
 

--- a/srcpkgs/fbset/template
+++ b/srcpkgs/fbset/template
@@ -1,17 +1,17 @@
 # Template file for 'fbset'
 pkgname=fbset
 version=2.1
-revision=4
-patch_args="-Np1"
+revision=5
+conf_files="/etc/fb.modes"
 hostmakedepends="flex"
 makedepends="libfl-devel"
-conf_files="/etc/fb.modes"
 short_desc="Framebuffer device maintenance program"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2"
 homepage="http://users.telenet.be/geertu/Linux/fbdev/"
 distfiles="${DEBIAN_SITE}/main/f/fbset/fbset_${version}.orig.tar.gz"
 checksum=517fa062d7b2d367f931a1c6ebb2bef84907077f0ce3f0c899e34490bbea9338
+patch_args="-Np1"
 
 do_build() {
 	case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/fbv/template
+++ b/srcpkgs/fbv/template
@@ -1,12 +1,12 @@
 # Template file for 'fbv'
 pkgname=fbv
 version=1.0b
-revision=1
+revision=2
 build_style=configure
 makedepends="libpng-devel libjpeg-turbo-devel giflib-devel"
 short_desc="Framebuffer image viewer"
 maintainer="Duncaen <duncaen@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.eclis.ch/fbv/"
 distfiles="http://s-tech.elsat.net.pl/fbv/fbv-${version}.tar.gz"
 checksum=9b55b9dafd5eb01562060d860e267e309a1876e8ba5ce4d3303484b94129ab3c

--- a/srcpkgs/frotz/template
+++ b/srcpkgs/frotz/template
@@ -1,14 +1,14 @@
 # Template file for 'frotz'
 pkgname=frotz
 version=2.44
-revision=2
+revision=3
 build_style=gnu-makefile
 make_build_target="frotz dfrotz"
 make_install_target="install install_dumb"
 makedepends="ncurses-devel"
 short_desc="Infocom-style interactive fiction player for Unix and DOS"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://frotz.sourceforge.net/"
 distfiles="https://github.com/DavidGriffith/frotz/archive/${version}.tar.gz"
 checksum=dbb5eb3bc95275dcb984c4bdbaea58bc1f1b085b20092ce6e86d9f0bf3ba858f

--- a/srcpkgs/fsv/template
+++ b/srcpkgs/fsv/template
@@ -1,14 +1,14 @@
 # Template file for 'fsv'
 pkgname=fsv
 version=0.9.1
-revision=1
+revision=2
 wrksrc="fsv-fsv-0.9-1"
 build_style=gnu-configure
 hostmakedepends="automake gettext-devel libtool pkg-config"
 makedepends="gtkmm-devel ftgl-devel gtkglarea-devel"
 short_desc="GTK2 port of fsv, the filesystem visualizer"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="http://fsv.sourceforge.net/"
 distfiles="https://github.com/mcuelenaere/fsv/archive/fsv-0.9-1.tar.gz"
 checksum=aede9d231858016d410eb1cc47f5315055eafc259f80a9e82a5846ea2f682d18

--- a/srcpkgs/fswebcam/template
+++ b/srcpkgs/fswebcam/template
@@ -1,12 +1,12 @@
 # Template file for 'fswebcam'
 pkgname=fswebcam
 version=20140113
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="gd-devel"
 short_desc="A neat and simple webcam app"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.firestorm.cx/fswebcam/"
 distfiles="http://www.firestorm.cx/fswebcam/files/fswebcam-${version}.tar.gz"
 checksum=3ee389f72a7737700d22e0c954720b1e3bbadc8a0daad6426c25489ba9dc3199

--- a/srcpkgs/gdmap/template
+++ b/srcpkgs/gdmap/template
@@ -1,14 +1,14 @@
 # Template file for 'gdmap'
 pkgname=gdmap
 version=0.8.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="LIBS=-lm"
 hostmakedepends="pkg-config intltool"
 makedepends="gtk+-devel libxml2-devel"
 short_desc="Graphical Disk Map"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-only"
 homepage="http://gdmap.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=a200c98004b349443f853bf611e49941403fce46f2335850913f85c710a2285b

--- a/srcpkgs/gmrun/template
+++ b/srcpkgs/gmrun/template
@@ -1,13 +1,13 @@
 # Template file for 'gmrun'
 pkgname=gmrun
 version=0.9.2
-revision=3
+revision=4
 build_style=gnu-configure
-makedepends="gtk+-devel popt-devel"
 hostmakedepends="pkg-config"
+makedepends="gtk+-devel popt-devel"
 short_desc="A simple program which provides an X 'run program' window"
 maintainer="bougyman <bougyman@rubyists.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sf.net/projects/gmrun"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=17297bce53249ccc7145931db22251b47f77ac355f78cf8abf1e87ae16341fa0

--- a/srcpkgs/goomwwm/template
+++ b/srcpkgs/goomwwm/template
@@ -1,7 +1,7 @@
 # Template file for 'goomwwm'
 pkgname=goomwwm
 version=1.0.0
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="libXft-devel libXinerama-devel"

--- a/srcpkgs/gpart/template
+++ b/srcpkgs/gpart/template
@@ -1,12 +1,12 @@
 # Template file for 'gpart'
 pkgname=gpart
 version=0.3
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake"
 short_desc="Partition table rescue/guessing tool"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/baruch/gpart"
 distfiles="https://github.com/baruch/gpart/archive/${version}.tar.gz"
 checksum=ec56d12ec9ffdb9877c12692ea6e51620b1ae44473d3d253b27fc31ed9ebb4dd

--- a/srcpkgs/hostaliases/template
+++ b/srcpkgs/hostaliases/template
@@ -1,7 +1,7 @@
 # Template file for 'hostaliases'
 pkgname=hostaliases
 version=2
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="HOSTALIASES libc independent support"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
@@ -9,3 +9,7 @@ license="MIT"
 homepage="https://github.com/thypon/hostaliases"
 distfiles="https://github.com/thypon/hostaliases/archive/v${version}.tar.gz"
 checksum=a29411e576fa485742d7b16ed838b960a462cdd862086fcd3250c7175d19ba93
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/hydrogen/template
+++ b/srcpkgs/hydrogen/template
@@ -1,7 +1,7 @@
 # Template file for 'hydrogen'
 pkgname=hydrogen
 version=0.9.7
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWANT_LRDF=ON -DWANT_CPPUNIT=OFF"
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ makedepends="libsndfile-devel libarchive-devel liblrdf-devel
 depends="desktop-file-utils"
 short_desc="Advanced drum machine"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.hydrogen-music.org/"
 distfiles="https://github.com/hydrogen-music/hydrogen/archive/${version}.tar.gz"
 checksum=1e0f3d9eae901ef5f11a61e2a446b1d819f3b38e2476a2b382cc02dea693c2b7

--- a/srcpkgs/iftop/template
+++ b/srcpkgs/iftop/template
@@ -1,13 +1,12 @@
 # Template file for 'iftop'
 pkgname=iftop
 version=1.0pre4
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="libpcap-devel ncurses-devel"
 short_desc="Top-like tool to display bandwidth usage on an interface"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.ex-parrot.com/pdw/iftop/"
 distfiles="${homepage}/download/$pkgname-$version.tar.gz"
 checksum=f733eeea371a7577f8fe353d86dd88d16f5b2a2e702bd96f5ffb2c197d9b4f97
-configure_args="--sbindir=/usr/bin"

--- a/srcpkgs/incron/template
+++ b/srcpkgs/incron/template
@@ -1,12 +1,12 @@
 # Template file for 'incron'
 pkgname=incron
 version=0.5.10
-revision=4
+revision=5
 make_dirs="/var/spool/incron 0755 root root
-	   /etc/incron.d 0755 root root"
+ /etc/incron.d 0755 root root"
 short_desc="A daemon that executes commands due to inotify events"
 maintainer="allan <mail@may.mooo.com>"
-license="GPL-2, LGPL-2.1"
+license="X11"
 homepage="http://inotify.aiken.cz"
 distfiles="http://inotify.aiken.cz/download/incron/incron-${version}.tar.gz"
 checksum=5d4abadb5f16c26e4f728a6433ad22f7655663b5812fbd4f94e852050f38e78a
@@ -26,4 +26,5 @@ do_build() {
 do_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install
 	vsv incron
+	vlicense LICENSE-X11
 }

--- a/srcpkgs/iodine/template
+++ b/srcpkgs/iodine/template
@@ -1,16 +1,16 @@
 # Template file for 'iodine'
 pkgname=iodine
 version=0.7.0
-revision=5
-replaces="iodine-server>=0"
-homepage="http://code.kryo.se/iodine/"
-distfiles="http://code.kryo.se/${pkgname}/${pkgname}-${version}.tar.gz"
+revision=6
 makedepends="zlib-devel"
 depends="net-tools"
-short_desc="iodine lets you tunnel IPv4 data through a DNS server"
+short_desc="Lets you tunnel IPv4 data through a DNS server"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="MIT"
+homepage="http://code.kryo.se/iodine/"
+distfiles="http://code.kryo.se/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=ad2b40acf1421316ec15800dcde0f587ab31d7d6f891fa8b9967c4ded93c013e
+replaces="iodine-server>=0"
 
 do_build() {
 	case "$XBPS_TARGET_MACHINE" in
@@ -22,4 +22,6 @@ do_build() {
 }
 do_install() {
 	make prefix=/usr DESTDIR=${DESTDIR} sbindir=/usr/bin install
+	sed -n '/Copyright/,/reserved/p' README > LICENSE
+	vlicense LICENSE
 }

--- a/srcpkgs/numlockx/template
+++ b/srcpkgs/numlockx/template
@@ -1,15 +1,15 @@
 # Template file for 'numlockx'
-pkgname="numlockx"
+pkgname=numlockx
 version=1.2
-revision=3
+revision=4
 build_style=gnu-configure
+makedepends="libX11-devel libSM-devel libXext-devel libXtst-devel"
 short_desc="Activate NumLock at startup"
 maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
-license="numlockx"
-makedepends="libX11-devel libSM-devel libXext-devel libXtst-devel"
+license="JSON"
 homepage="http://www.mike-devlin.com/linux/README-numlockx.htm"
 distfiles="${DEBIAN_SITE}/main/n/${pkgname}/${pkgname}_${version}.orig.tar.gz"
-checksum="e468eb9121c94c9089dc6a287eeb347e900ce04a14be37da29d7696cbce772e4"
+checksum=e468eb9121c94c9089dc6a287eeb347e900ce04a14be37da29d7696cbce772e4
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/paps/template
+++ b/srcpkgs/paps/template
@@ -1,13 +1,13 @@
 # Template file for 'paps'
 pkgname=paps
 version=0.6.8
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="pango-devel freetype-devel"
 short_desc="UTF-8 to PostScript converter via Pango"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="LGPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="LGPL-2.0-or-later"
 homepage="http://paps.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=db214c4ea7ecde2f7986b869f6249864d3ff364e6f210c15aa2824bcbd850a20

--- a/srcpkgs/qimageblitz/template
+++ b/srcpkgs/qimageblitz/template
@@ -1,15 +1,15 @@
 # Template file for 'qimageblitz'
 pkgname=qimageblitz
 version=0.0.6
-revision=2
+revision=3
 build_style=cmake
-hostmakedepends="automoc4 pkg-config"
+hostmakedepends="automoc4 pkg-config qt-host-tools qt-qmake"
 makedepends="qt-devel"
 short_desc="A graphical effect and filter library for KDE"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
-homepage="http://www.kde.org"
-distfiles="http://download.kde.org/stable/${pkgname}/${pkgname}-${version}.tar.bz2"
+license="BSD-2-Clause"
+homepage="https://www.kde.org"
+distfiles="${KDE_SITE}/qimageblitz/qimageblitz-${version}.tar.bz2"
 checksum=9f102269dec50641440e23a449df215a0db9efef9a3969939d618c5e78a5010f
 
 qimageblitz-devel_package() {

--- a/srcpkgs/udns/template
+++ b/srcpkgs/udns/template
@@ -1,16 +1,16 @@
 # Template file for 'udns'
 pkgname=udns
 version=0.4
-revision=2
+revision=3
 build_style=configure
+configure_args="--enable-ipv6"
+make_build_target="shared"
 short_desc="Asynchronous DNS resolver library"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
-license="LGPL-2"
+license="LGPL-2.1-or-later"
 homepage="http://www.corpit.ru/mjt/udns.html"
 distfiles="http://www.corpit.ru/mjt/udns/udns-${version}.tar.gz"
 checksum=115108dc791a2f9e99e150012bcb459d9095da2dd7d80699b584ac0ac3768710
-configure_args="--enable-ipv6"
-make_build_target="shared"
 
 pre_configure() {
 	sed -i \


### PR DESCRIPTION
All packages was build (when available) for x86_64, x86_64-musl, armv7hf and aarch64-musl and passed check stage on x86_64 and x86_64-musl. Nothing was tested manually whether it still works.

63 more packages remain to rebuild.