### PR TITLE
io.elementary.icons: use unquoted globs with rm

### DIFF
--- a/srcpkgs/io.elementary.icons/template
+++ b/srcpkgs/io.elementary.icons/template
@@ -1,7 +1,7 @@
 # Template file for 'io.elementary.icons'
 pkgname=io.elementary.icons
 version=5.0
-revision=1
+revision=2
 wrksrc="icons-${version}"
 build_style=meson
 short_desc="Named, vector icons for elementary OS"
@@ -13,7 +13,7 @@ checksum=7ef504b8766855e66dfac0fc09135433131cacfdb58bad142151943cf39f6313
 
 post_install() {
 	# How did that get there?
-	rm -f "${DESTDIR}/.VolumeIcon*"
+	rm -- "${DESTDIR}/.VolumeIcon."*
 	# elementary branding ¯\_O_/¯
-	rm -f "${DESTDIR}/usr/share/icons/elementary/*/*/distributor-logo*"
+	rm -- "${DESTDIR}/usr/share/icons/elementary/"*/*/distributor-logo*
 }


### PR DESCRIPTION
@maxice8 If you quote globs, they won't be expanded. When you are passing to a shell function like vinstall, that is typically what you want. But in this case, `rm` can't handle the globs itself. It needs the shell to expand them into multiple arguments.