### PR TITLE
Rebuild packages for missing metadata vol. 10

### DIFF
--- a/srcpkgs/beanstalkd/template
+++ b/srcpkgs/beanstalkd/template
@@ -1,7 +1,7 @@
 # Template file for 'beanstalkd'
 pkgname=beanstalkd
 version=1.10
-revision=2
+revision=3
 short_desc="A simple, fast, general-purpose work queue"
 maintainer="bougyman <bougyman@voidlinux.eu>"
 license="MIT"

--- a/srcpkgs/crimson/template
+++ b/srcpkgs/crimson/template
@@ -1,13 +1,13 @@
 # Template file for 'crimson'
 pkgname=crimson
 version=0.5.3
-revision=1
+revision=2
 build_style=gnu-configure
-nocross=yes
 makedepends="SDL-devel SDL_mixer-devel SDL_net-devel SDL_ttf-devel"
 short_desc="Tactical war game in the tradition of the popular Battle Isle"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://crimson.seul.org"
 distfiles="http://crimson.seul.org/files/crimson-${version}.tar.bz2"
 checksum=d59858c05e340367c61c8ca1dd00c36642a0c56d10d1d9a1626c5ba7d88b40d6
+nocross=yes

--- a/srcpkgs/dclock/template
+++ b/srcpkgs/dclock/template
@@ -1,12 +1,12 @@
 # Template file for 'dclock'
 pkgname=dclock
 version=2.2.2
-revision=2
+revision=3
 hostmakedepends="pkg-config"
 makedepends="libXft-devel libXt-devel"
 short_desc="Digital clock for X"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://opencircuitdesign.com/~tim/programs/dclock/"
 distfiles="${DEBIAN_SITE}/main/d/${pkgname}/${pkgname}_${version}.orig.tar.gz"
 checksum=d14ebc107b4b837ac3ee79ea639c32d7cec658df653687e665979640cd339c3c

--- a/srcpkgs/ddate/template
+++ b/srcpkgs/ddate/template
@@ -1,11 +1,11 @@
 # Template file for 'ddate'
 pkgname=ddate
 version=0.2.2
-revision=2
+revision=3
 build_style=cmake
 short_desc="Convert Gregorian dates to Discordian dates"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"
 homepage="https://github.com/bo0ts/ddate"
-distfiles="https://github.com/bo0ts/ddate/archive/v0.2.2.tar.gz"
+distfiles="https://github.com/bo0ts/ddate/archive/v${version}.tar.gz"
 checksum=d53c3f0af845045f39d6d633d295fd4efbe2a792fd0d04d25d44725d11c678ad

--- a/srcpkgs/dialogbox/template
+++ b/srcpkgs/dialogbox/template
@@ -1,13 +1,13 @@
 # Template file for 'dialogbox'
 pkgname=dialogbox
 version=1.0
-revision=1
+revision=2
 build_style=qmake
 hostmakedepends="qt5-host-tools qt5-devel"
 makedepends="qt5-devel"
 short_desc="Scriptable engine with customizable GUI for shell scripts"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/martynets/dialogbox"
 distfiles="https://github.com/martynets/dialogbox/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=554e59712a616772cff5734206e2a223171ad57c0e922421d8383a763b11640e

--- a/srcpkgs/eom/template
+++ b/srcpkgs/eom/template
@@ -1,7 +1,7 @@
 # Template file for 'eom'
 pkgname=eom
 version=1.20.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-schemas-compile $(vopt_enable gir introspection)"
 hostmakedepends="dbus-glib-devel mate-common
@@ -15,6 +15,7 @@ license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=35375d5d55128e03c9a4f9e5559878873275c6e182b159058767180ca449347d
+nocross="libgirepository-devel is nocross"
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then

--- a/srcpkgs/gavl/template
+++ b/srcpkgs/gavl/template
@@ -1,16 +1,17 @@
 # Template file for 'gavl'
 pkgname=gavl
 version=1.4.0
-revision=2
+revision=3
 build_style=gnu-configure
-nocross="yes"
 hostmakedepends="doxygen"
 short_desc="Low level library, upon which multimedia APIs can be built"
 maintainer="Logen K <logen@sudotask.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://gmerlin.sourceforge.net/gavl.html"
-distfiles="${SOURCEFORGE_SITE}/gmerlin/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/gmerlin/gavl/${version}/gavl-${version}.tar.gz"
 checksum=51aaac41391a915bd9bad07710957424b046410a276e7deaff24a870929d33ce
+nocross="yes"
+CFLAGS="-lm"
 
 gavl-devel_package() {
 	depends="gavl>=${version}_${revision}"

--- a/srcpkgs/gengetopt/template
+++ b/srcpkgs/gengetopt/template
@@ -1,14 +1,14 @@
 # Template file for 'gengetopt'
 pkgname=gengetopt
 version=2.22.6
-revision=1
-disable_parallel_build=yes
+revision=2
 build_style=gnu-configure
 hostmakedepends="flex"
 makedepends="libfl-devel"
 short_desc="A tool to write cli option parsing code for C programs"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/${pkgname}"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=30b05a88604d71ef2a42a2ef26cd26df242b41f5b011ad03083143a31d9b01f7
+disable_parallel_build=yes

--- a/srcpkgs/gnome-shell-mousewheel-zoom/template
+++ b/srcpkgs/gnome-shell-mousewheel-zoom/template
@@ -1,17 +1,18 @@
 # Template file for 'gnome-shell-mousewheel-zoom'
 pkgname=gnome-shell-mousewheel-zoom
 version=0.8.0
-revision=1
-short_desc="Enable mousewheel zoom using left-alt key using gnome-shell"
-homepage="https://github.com/tobiasquinn/gnome-shell-mousewheel-zoom"
-license="GPL-3"
-depends="gnome-shell"
-makedepends="libglib-devel libX11-devel"
-hostmakedepends="vala pkg-config"
-distfiles="https://github.com/tobiasquinn/gnome-shell-mousewheel-zoom/archive/upstream/$version.tar.gz"
-checksum=5f57affb89ef5091d94e03f7c074e0dc89da7952efbb399d4a7bf2b0848d8a40
+revision=2
 wrksrc=gnome-shell-mousewheel-zoom-upstream-0.8.0
+hostmakedepends="vala pkg-config"
+makedepends="libglib-devel libX11-devel"
+depends="gnome-shell"
+short_desc="Enable mousewheel zoom using left-alt key using gnome-shell"
+license="GPL-3.0-or-later"
+homepage="https://github.com/tobiasquinn/gnome-shell-mousewheel-zoom"
+distfiles="https://github.com/tobiasquinn/gnome-shell-mousewheel-zoom/archive/upstream/${version}.tar.gz"
+checksum=5f57affb89ef5091d94e03f7c074e0dc89da7952efbb399d4a7bf2b0848d8a40
 nopie=yes
+nocross="gobject-introspection is nocross"
 
 do_build() {
 	make -f makefile

--- a/srcpkgs/gtkimageview/template
+++ b/srcpkgs/gtkimageview/template
@@ -1,17 +1,17 @@
 # Template file for 'gtkimageview'
 pkgname=gtkimageview
 version=1.6.4
-revision=1
+revision=2
 _githash=77abd2122c19d2eca21599404a2d3aece35081e2
 wrksrc="${pkgname}-${_githash}"
 build_style=gnu-configure
 configure_script="./autogen.sh"
-maintainer="Orphaned <orphan@voidlinux.eu>"
 hostmakedepends="gnome-common pkg-config gtk-doc libtool glib-devel"
 makedepends="gtk+-devel"
-license="LGPL-2.1"
-homepage="https://github.com/GNOME/gtkimageview"
 short_desc="Widget that provides a zoomable and panable view of a GdkPixbuf"
+maintainer="Orphaned <orphan@voidlinux.eu>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/GNOME/gtkimageview"
 distfiles="https://github.com/GNOME/gtkimageview/archive/${_githash}.tar.gz"
 checksum=2d61c9957500e515419b2b3b0d9a3d5efb67a6a8384743926121dcd618a9ef35
 

--- a/srcpkgs/hardinfo/patches/hardinfo-0.5.1.patch
+++ b/srcpkgs/hardinfo/patches/hardinfo-0.5.1.patch
@@ -1,0 +1,35 @@
+From f11d5624be68e95e9c2a8c7779b182ef97b7973c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Piotr=20W=C3=B3jcik?= <chocimier@tlen.pl>
+Date: Fri, 30 Nov 2018 11:29:13 +0100
+Subject: [PATCH] Fix inline strend
+
+
+diff --git hardinfo.h hardinfo.h
+index 9f52f63..6c7044d 100644
+--- hardinfo.h
++++ hardinfo.h
+@@ -65,7 +65,7 @@ struct _ModuleAbout {
+ 
+ /* String utility functions */
+ inline void  remove_quotes(gchar *str);
+-inline char *strend(gchar *str, gchar chr);
++char *strend(gchar *str, gchar chr);
+ inline void  remove_linefeed(gchar *str);
+ gchar       *strreplace(gchar *string, gchar *replace, gchar new_char);
+ 
+diff --git util.c util.c
+index 266ce4e..068889f 100644
+--- util.c
++++ util.c
+@@ -123,7 +123,7 @@ inline gchar *size_human_readable(gfloat size)
+     return g_strdup_printf("%.1f GiB", size / GiB);
+ }
+ 
+-inline char *strend(gchar * str, gchar chr)
++char *strend(gchar * str, gchar chr)
+ {
+     if (!str)
+ 	return NULL;
+-- 
+2.19.1
+

--- a/srcpkgs/hardinfo/template
+++ b/srcpkgs/hardinfo/template
@@ -1,18 +1,18 @@
 # Template file for 'hardinfo'
 pkgname=hardinfo
 version=0.5.1
-revision=4
-lib32disabled=yes
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel libsoup-devel desktop-file-utils"
 depends="desktop-file-utils"
 short_desc="A system information and benchmark tool"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/hardinfo.berlios/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}.berlios/${pkgname}-${version}.tar.bz2"
 checksum=a0df6c0d7c92a7d20710b8eb551197398a965aaae053782b89a32a160b731b7a
+lib32disabled=yes
 nocross=yes
 
 pre_configure() {

--- a/srcpkgs/hdapsd/template
+++ b/srcpkgs/hdapsd/template
@@ -1,13 +1,12 @@
 # Template file for 'hdapsd'
 pkgname=hdapsd
 version=20141024
-revision=3
+revision=4
 only_for_archs="i686 x86_64 i686-musl x86_64-musl"
 build_style=gnu-configure
 short_desc="HDAPS userspace hard drive protection daemon"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/hdaps/"
 distfiles="${SOURCEFORGE_SITE}/hdaps/$pkgname-$version.tar.gz"
 checksum=4a9f7c4d6351bd31757f236ad832ceccf10280d32bcaf4c25d15dc4ecc84581f
-configure_args="--sbindir=/usr/bin"

--- a/srcpkgs/jfsutils/patches/jfsutils-1.1.15-sysmacros.patch
+++ b/srcpkgs/jfsutils/patches/jfsutils-1.1.15-sysmacros.patch
@@ -1,0 +1,15 @@
+https://bugs.gentoo.org/580056
+
+--- libfs/devices.c
++++ libfs/devices.c
+@@ -30,6 +30,10 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
++#if HAVE_SYS_SYSMACROS_H
++#include <sys/sysmacros.h>
++#endif
++
+ #ifdef HAVE_SYS_MOUNT_H
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>

--- a/srcpkgs/jfsutils/template
+++ b/srcpkgs/jfsutils/template
@@ -1,12 +1,12 @@
 # Template file for 'jfsutils'
 pkgname=jfsutils
 version=1.1.15
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libuuid-devel"
 short_desc="JFS filesystem utilities"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://jfs.sourceforge.net"
 distfiles="http://jfs.sourceforge.net/project/pub/${pkgname}-${version}.tar.gz"
 checksum=244a15f64015ce3ea17e49bdf6e1a0fb4f9af92b82fa9e05aa64cb30b5f07a4d

--- a/srcpkgs/midori/template
+++ b/srcpkgs/midori/template
@@ -1,12 +1,13 @@
 # Template file for 'midori'
 pkgname=midori
 version=6.0
-revision=1
+revision=2
+create_wrksrc=yes
 build_style=cmake
 hostmakedepends="glib-devel gobject-introspection intltool librsvg-utils
-pkg-config vala-devel"
+ pkg-config vala-devel"
 makedepends="gcr-devel libpeas-devel librsvg-devel libsoup-gnome-devel
-vala-devel webkit2gtk-devel"
+ vala-devel webkit2gtk-devel"
 depends="hicolor-icon-theme desktop-file-utils"
 short_desc="Lightweight web browser using WebKit GTK+"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -14,5 +15,5 @@ license="LGPL-2.1-or-later"
 homepage="https://midori-browser.org/"
 distfiles="https://github.com/midori-browser/core/releases/download/v6/midori-v${version}.tar.gz"
 checksum=2120b40424da286380ff5cf3f00674f80ed58a1aa8f52a6a8a59e01e131aaf5e
-create_wrksrc=yes
 lib32disabled=yes
+nocross="libgirepository-devel is nocross"

--- a/srcpkgs/miruo/template
+++ b/srcpkgs/miruo/template
@@ -1,12 +1,12 @@
 # Template file for 'miruo'
 pkgname=miruo
 version=0.9.6
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libpcap-devel"
 short_desc="Pretty-print TCP session monitor/analyzer"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-3"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-3.0-only"
 homepage="https://github.com/KLab/miruo"
 distfiles="https://github.com/KLab/${pkgname}/archive/${version}.tar.gz"
 checksum=bbb2989cad13b7a7541413352044dff9733121fcc82c29ced3bdfbf6b829d9b4

--- a/srcpkgs/mmv/template
+++ b/srcpkgs/mmv/template
@@ -1,12 +1,12 @@
 # Template file for 'mmv'
 pkgname=mmv
 version=1.01b
-revision=2
+revision=3
 wrksrc=${pkgname}-${version}.orig
 build_style=gnu-makefile
 short_desc="Utility for wildcard renaming, copying, etc"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.usinglinux.org/misc/mmv.html"
 distfiles="http://mirrors.kernel.org/gentoo/distfiles/${pkgname}_${version}.orig.tar.gz"
 checksum=0399c027ea1e51fd607266c1e33573866d4db89f64a74be8b4a1d2d1ff1fdeef

--- a/srcpkgs/most/template
+++ b/srcpkgs/most/template
@@ -1,16 +1,16 @@
 # Template file for 'most'
-pkgname="most"
+pkgname=most
 version=5.0.0a
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--with-slang=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="slang-devel"
 makedepends="slang-devel"
-short_desc="Paging program that displays, one windowful at a time, the contents of a file"
+short_desc="Paging program that displays, one windowful at a time, file contents"
 maintainer="Jens E. Becker <v2px@v2px.de>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="ftp://space.mit.edu/pub/davis/most/"
-distfiles="ftp://space.mit.edu/pub/davis//${pkgname}/${pkgname}-${version}.tar.bz2"
+distfiles="ftp://space.mit.edu/pub/davis//most/most-${version}.tar.bz2"
 checksum=94cb5a2e71b6b9063116f4398a002a757e59cd1499f1019dde8874f408485aa9
 
 post_configure() {

--- a/srcpkgs/mozplugger/template
+++ b/srcpkgs/mozplugger/template
@@ -1,14 +1,14 @@
 # Template file for 'mozplugger'
 pkgname=mozplugger
 version=2.1.6
-revision=3
+revision=4
 build_style=gnu-configure
+conf_files="/etc/mozpluggerrc"
 makedepends="libX11-devel"
 depends="m4"
-conf_files="/etc/mozpluggerrc"
 short_desc="Firefox plugin to embed arbitrary applications"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://mozplugger.mozdev.org"
 distfiles="http://mozplugger.mozdev.org/files/${pkgname}-${version}.tar.gz"
 checksum=294cf06ad37b8d89e57ee9c4dc9e7549fd1b0dcec9769171d65dad36099e5fef

--- a/srcpkgs/neverball/template
+++ b/srcpkgs/neverball/template
@@ -1,15 +1,16 @@
 # Template file for 'neverball'
 pkgname=neverball
 version=1.6.0
-revision=3
+revision=4
 makedepends="libpng-devel libjpeg-turbo-devel libvorbis-devel SDL2_ttf-devel physfs-devel"
 depends="desktop-file-utils"
 short_desc="Puzzle/action game similar to Super Monkey Ball"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.neverball.org"
 license="GPL-2"
+homepage="http://www.neverball.org"
 distfiles="http://www.neverball.org/$pkgname-$version.tar.gz"
 checksum=73fe63cca4f96e2d355480d03bc0b2904e83a0abdf65fe8c52db5cc3cca88fa0
+nocross="./mapc: ./mapc: cannot execute binary file"
 
 do_build() {
 	make ${makejobs} CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \

--- a/srcpkgs/par/template
+++ b/srcpkgs/par/template
@@ -1,11 +1,11 @@
 # Template file for 'par'
 pkgname=par
 version=1.52
-revision=2
-build_style=gnu-configure
+revision=3
 wrksrc=Par152
+build_style=gnu-configure
 short_desc="Paragraph reformatter"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="custom"
 homepage="http://www.nicemice.net/par/"
 distfiles="http://www.nicemice.net/par/Par152-autoconf.tar.gz

--- a/srcpkgs/perl-IPC-Run3/template
+++ b/srcpkgs/perl-IPC-Run3/template
@@ -1,15 +1,15 @@
-# Template build file for 'perl-IPC-Run3'.
+# Template file for 'perl-IPC-Run3'
 pkgname=perl-IPC-Run3
 version=0.048
-revision=1
+revision=2
+noarch=yes
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 depends="perl"
 short_desc='IPC::Run3 -  run a subprocess and redirect stdin, stdout, and/or stderr'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
+license="Aristic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/IPC-Run3"
-license="Artistic, BSD, GPL-1, GPL-2, GPL-3"
 distfiles="$CPAN_SITE/IPC/IPC-Run3-${version}.tar.gz"
 checksum=3d81c3cc1b5cff69cca9361e2c6e38df0352251ae7b41e2ff3febc850e463565
-noarch=yes

--- a/srcpkgs/perl-Term-ShellUI/template
+++ b/srcpkgs/perl-Term-ShellUI/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Term-ShellUI'
 pkgname=perl-Term-ShellUI
 version=0.92
-revision=2
+revision=3
 noarch=yes
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
@@ -10,7 +10,7 @@ makedepends="perl"
 depends="${hostmakedepends}"
 short_desc="Term::ShellUI - A fully-featured shell-like command line environment"
 maintainer="Kevin Berry <kevin@opensourcealchemist.com>"
-homepage="https://metacpan.org/release/Term-ShellUI"
 license="MIT"
+homepage="https://metacpan.org/release/Term-ShellUI"
 distfiles="${CPAN_SITE}/Term/Term-ShellUI-${version}.tar.gz"
 checksum=3279c01c76227335eeff09032a40f4b02b285151b3576c04cacd15be05942bdb

--- a/srcpkgs/polkit-qt5/template
+++ b/srcpkgs/polkit-qt5/template
@@ -1,16 +1,16 @@
 # Template file for 'polkit-qt5'
 pkgname=polkit-qt5
 version=0.112.0
-revision=2
+revision=3
+wrksrc="polkit-qt-1-${version}"
 build_style=cmake
 hostmakedepends="pkg-config automoc4 git"
 makedepends="polkit-devel qt5-devel"
 short_desc="Qt-style PolicyKit API (Qt5)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="https://projects.kde.org/projects/kdesupport/polkit-qt-1"
-license="LGPL-2.1"
-wrksrc="polkit-qt-1-$version"
-distfiles="http://download.kde.org/stable/apps/KDE4.x/admin/polkit-qt-1-${version}.tar.bz2"
+distfiles="${KDE_SITE}/apps/KDE4.x/admin/polkit-qt-1-${version}.tar.bz2"
 checksum=67fb03bf6ca3e0bdbd98d374dfb5b1651a07d17ae6c23e11a81b4b084447e7c6
 
 if [ -n "$CROSS_BUILD" ]; then

--- a/srcpkgs/profile-sync-daemon/template
+++ b/srcpkgs/profile-sync-daemon/template
@@ -2,17 +2,19 @@
 pkgname=profile-sync-daemon
 reverts=6.12_1
 version=5.75
-revision=2
+revision=3
 noarch=yes
 depends="rsync"
 short_desc="Syncs browser profiles to tmpfs"
 maintainer="graysky <graysky AT archlinux DOT us>"
 license="MIT"
 homepage="https://github.com/graysky2/profile-sync-daemon"
-distfiles="http://repo-ck.com/source/$pkgname/$pkgname-$version.tar.xz"
+distfiles="http://repo-ck.com/source/$pkgname/profile-sync-daemon-${version}.tar.xz"
 checksum=ecb9acc0f274eb645b7dcb0510f692194feda8dbeffa3bb2834ce91cba76fcf6
 
 do_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install-bin install-man
 	vsv psd
+	vlicense LICENCE
+	vlicense MIT
 }

--- a/srcpkgs/quimup/template
+++ b/srcpkgs/quimup/template
@@ -1,20 +1,25 @@
 # Template file for 'quimup'
 pkgname=quimup
 version=1.4.0
-revision=3
+revision=4
+wrksrc="quimup ${version}"
 build_style=qmake
-wrksrc="${pkgname} ${version}"
-hostmakedepends="pkg-config qt5-qmake"
+configure_args="INCLUDEPATH+='${XBPS_CROSS_BASE}/usr/include/qt5'
+ INCLUDEPATH+='${XBPS_CROSS_BASE}/usr/include/qt5/QtCore'
+ INCLUDEPATH+='${XBPS_CROSS_BASE}/usr/include/qt5/QtGui'
+ INCLUDEPATH+='${XBPS_CROSS_BASE}/usr/include/qt5/QtNetwork'
+ INCLUDEPATH+='${XBPS_CROSS_BASE}/usr/include/qt5/QtWidgets'"
+hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
 makedepends="libmpdclient-devel qt5-devel taglib-devel"
 short_desc="Client for MPD written in c++ and QT5"
 maintainer="beefcurtains <beefcurtains@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://coonsden.com/?cat=4"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}%20${version}/${pkgname}_${version}_src.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/quimup/quimup%20${version}/quimup_${version}_src.tar.gz"
 checksum=b46f8ff651b9154a43cf90b005c160cbbddcc2fb8c6b17dfdee9b6c4a2e131ea
 
 do_install() {
-	vbin ${pkgname}
-	vinstall ${FILESDIR}/${pkgname}.desktop 644 usr/share/applications
-	vinstall src/resources/mn_icon.png 644 usr/share/icons/hicolor/32x32/apps ${pkgname}.png
+	vbin quimup
+	vinstall ${FILESDIR}/quimup.desktop 644 usr/share/applications
+	vinstall src/resources/mn_icon.png 644 usr/share/icons/hicolor/32x32/apps quimup.png
 }

--- a/srcpkgs/sample/template
+++ b/srcpkgs/sample/template
@@ -1,17 +1,19 @@
 # Template file for 'sample'
 pkgname=sample
 version=0.1.0
-revision=2
+revision=3
 build_style=gnu-makefile
-CFLAGS='-std=c99 -D_BSD_SOURCE'
 short_desc="Filter for random sampling of input"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="MIT"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="custom"
 homepage="https://github.com/silentbicycle/sample/"
 distfiles="https://github.com/silentbicycle/sample/archive/v${version}.tar.gz"
 checksum=2ca15f1d293e80915abb98c311ddeeb2b99243df07aea554053ce296181a949d
+CFLAGS='-std=c99 -D_BSD_SOURCE'
 
 do_install() {
 	vbin sample
 	vdoc README.md
+	sed -n '/Copyright/,/PERFORMANCE/p' main.c > LICENSE
+	vlicense LICENSE
 }

--- a/srcpkgs/sc/template
+++ b/srcpkgs/sc/template
@@ -1,19 +1,19 @@
 # Template file for 'sc'
 pkgname=sc
 version=7.16
-revision=2
+revision=3
 build_style=gnu-makefile
-CFLAGS='-DSYSV3'
 hostmakedepends="bison"
 makedepends="ncurses-devel"
 short_desc="A free curses-based spreadsheet program"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"
 homepage="http://ibiblio.org/pub/linux/apps/financial/spreadsheet/!INDEX.html"
-distfiles="http://ibiblio.org/pub/linux/apps/financial/spreadsheet/${pkgname}-${version}.tar.gz
- https://launchpadlibrarian.net/1281150/${pkgname}_${version}-2.diff.gz"
+distfiles="http://ibiblio.org/pub/linux/apps/financial/spreadsheet/sc-${version}.tar.gz
+ https://launchpadlibrarian.net/1281150/sc_${version}-2.diff.gz"
 checksum="1997a00b6d82d189b65f6fd2a856a34992abc99e50d9ec463bbf1afb750d1765
  37116b9619790564650c4090b4a6264c08aa59fa1e24c63ca073011cd70507cb"
+CFLAGS='-DSYSV3'
 
 post_extract() {
 	patch -Np1 <../${pkgname}_${version}-2.diff

--- a/srcpkgs/schedtool/template
+++ b/srcpkgs/schedtool/template
@@ -1,12 +1,12 @@
 # Template file for 'schedtool'
 pkgname=schedtool
 version=1.3.0
-revision=2
+revision=3
 build_style=gnu-makefile
 make_install_args="DESTPREFIX=/usr"
 short_desc="Query and set CPU scheduling parameters"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-only"
 homepage="http://freequaos.host.sk/schedtool/"
 distfiles="ftp://mirrors.tera-byte.com/pub/gentoo/distfiles//${pkgname}-${version}.tar.bz2"
 checksum=4e002a2a619d592f7c9b9d284381ffc004d8a71c38945aa95d5d53f2e4c0c8cf

--- a/srcpkgs/sex/template
+++ b/srcpkgs/sex/template
@@ -1,9 +1,9 @@
 # Template file for 'sex'
 pkgname=sex
 version=1.0
-revision=2
+revision=3
 short_desc="Spout silly, random porn-like text"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"
 homepage="http://spatula.net/software/sex/"
 distfiles="http://spatula.net/software/sex//${pkgname}-${version}.tar.gz"

--- a/srcpkgs/sopwith/template
+++ b/srcpkgs/sopwith/template
@@ -1,15 +1,15 @@
 # Template file for 'sopwith'
 pkgname=sopwith
 version=1.8.4
-revision=1
+revision=2
 build_style=gnu-configure
+hostmakedepends="automake SDL-devel"
 makedepends="SDL-devel"
-hostmakedepends="automake ${makedepends}"
 short_desc="Sidescrolling shoot 'em up game"
 maintainer="beefcurtains <beefcurtains@users.noreply.github.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://sdl-sopwith.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/sdl-sopwith/sdl_sopwith/${version}/${pkgname}-${version}.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/sdl-sopwith/sdl_sopwith/${version}/sopwith-${version}.tar.gz"
 checksum=a5ecb795a7aeff6be3ebfb99f1c6218054b73048786809f8468a92c952c17bd0
 
 pre_configure() {
@@ -18,6 +18,6 @@ pre_configure() {
 }
 
 post_install() {
-	vinstall ${FILESDIR}/${pkgname}.png 644 usr/share/pixmaps
-	vinstall ${FILESDIR}/${pkgname}.desktop 644 usr/share/applications
+	vinstall ${FILESDIR}/sopwith.png 644 usr/share/pixmaps
+	vinstall ${FILESDIR}/sopwith.desktop 644 usr/share/applications
 }

--- a/srcpkgs/sysfsutils/template
+++ b/srcpkgs/sysfsutils/template
@@ -1,13 +1,13 @@
 # Template file for 'sysfsutils'
 pkgname=sysfsutils
 version=2.1.0
-revision=6
+revision=7
 build_style=gnu-configure
 short_desc="System Utilities Based on Sysfs"
-homepage="http://linux-diag.sourceforge.net/Sysfsutils.html"
-license="GPL-2, LGPL-2.1"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-distfiles="${SOURCEFORGE_SITE}/linux-diag/$pkgname-$version.tar.gz"
+license="GPL-2.0-only, LGPL-2.1-or-later"
+homepage="http://linux-diag.sourceforge.net/Sysfsutils.html"
+distfiles="${SOURCEFORGE_SITE}/linux-diag/sysfsutils-${version}.tar.gz"
 checksum=e865de2c1f559fff0d3fc936e660c0efaf7afe662064f2fb97ccad1ec28d208a
 
 libsysfs_package() {

--- a/srcpkgs/trn/template
+++ b/srcpkgs/trn/template
@@ -1,18 +1,19 @@
 # Template file for 'trn'
 pkgname=trn
 version=4.0test77
-revision=5
+revision=6
 wrksrc=$pkgname-${version/test/-test}
 build_style=gnu-makefile
 hostmakedepends="groff bison"
-makedepends="ncurses-devel"
+makedepends="ncurses-devel gettext-devel"
 depends="virtual?smtp-server"
 short_desc="Text-based threaded Usenet newsreader"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="custom"
 homepage="http://trn.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}4/${wrksrc}.tar.gz"
 checksum=9ab0430244903ad86ed74fcc2fdc39dc043d23968888e071313050a967b8a6ff
+nocross="sh: ./try: cannot execute binary file: Exec format error"
 
 post_extract() {
 	sed -i 's/pipe2/pipetwo/g' filter.c

--- a/srcpkgs/vdesk/template
+++ b/srcpkgs/vdesk/template
@@ -1,11 +1,11 @@
 # Template file for 'vdesk'
 pkgname=vdesk
 version=1.2
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="libX11-devel"
 short_desc="A lightweight virtual desktop manager"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="custom"
 homepage="http://offog.org/code/vdesk.html"
 distfiles="http://offog.org/files/${pkgname}-${version}.tar.gz"

--- a/srcpkgs/wmctrl/template
+++ b/srcpkgs/wmctrl/template
@@ -1,13 +1,13 @@
 # Template file for 'wmctrl'
-pkgname="wmctrl"
-version="1.07"
-revision=4
+pkgname=wmctrl
+version=1.07
+revision=5
 build_style=gnu-configure
-short_desc="CLI tool to interact with EWMH compliant WMs"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
 hostmakedepends="pkg-config"
 makedepends="libXmu-devel glib-devel"
+short_desc="CLI tool to interact with EWMH compliant WMs"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="https://sites.google.com/site/tstyblo/wmctrl/"
-distfiles="https://sites.google.com/site/tstyblo/wmctrl/wmctrl-1.07.tar.gz"
-checksum="d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9"
+distfiles="https://sites.google.com/site/tstyblo/wmctrl/wmctrl-${version}.tar.gz"
+checksum=d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9

--- a/srcpkgs/xbindkeys/template
+++ b/srcpkgs/xbindkeys/template
@@ -1,13 +1,14 @@
 # Template file for 'xbindkeys'
 pkgname=xbindkeys
 version=1.8.6
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="pkg-config libX11-devel guile-devel guile gc-devel"
 depends="guile"
 short_desc="Launch shell commands with your keyboard or your mouse under X"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://www.nongnu.org/xbindkeys/xbindkeys.html"
 distfiles="http://www.nongnu.org/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=6c0d18be19fc19ab9b4595edf3a23c0a6946c8a5eb5c1bc395471c8f9a710d18
+nocross="configure: error: guile required but not found"

--- a/srcpkgs/xcb-util-image/template
+++ b/srcpkgs/xcb-util-image/template
@@ -1,16 +1,16 @@
-# Template build for 'xcb-util-image'.
+# Template file for 'xcb-util-image'
 pkgname=xcb-util-image
 version=0.4.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="xcb-util-devel"
 short_desc="Utility libraries for XC Binding - Port of Xlib's XImage and XShmImage functions"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="X11"
 homepage="http://xcb.freedesktop.org"
-license="GPL-2"
-distfiles="http://xcb.freedesktop.org/dist/$pkgname-$version.tar.bz2"
+distfiles="http://xcb.freedesktop.org/dist/xcb-util-image-${version}.tar.bz2"
 checksum=2db96a37d78831d643538dd1b595d7d712e04bdccf8896a5e18ce0f398ea2ffc
 
 xcb-util-image-devel_package() {

--- a/srcpkgs/xcb-util-keysyms/template
+++ b/srcpkgs/xcb-util-keysyms/template
@@ -1,16 +1,16 @@
-# Template build for 'xcb-util-keysyms'.
+# Template file for 'xcb-util-keysyms'
 pkgname=xcb-util-keysyms
 version=0.4.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libxcb-devel xcb-util-devel"
 short_desc="Utility libraries for XC Binding - Standard X key constants and conversion to/from keycodes"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="X11"
 homepage="http://xcb.freedesktop.org"
-license="GPL-2"
-distfiles="http://xcb.freedesktop.org/dist/$pkgname-$version.tar.bz2"
+distfiles="http://xcb.freedesktop.org/dist/xcb-util-keysyms-${version}.tar.bz2"
 checksum=0ef8490ff1dede52b7de533158547f8b454b241aa3e4dcca369507f66f216dd9
 
 xcb-util-keysyms-devel_package() {

--- a/srcpkgs/xcb-util-renderutil/template
+++ b/srcpkgs/xcb-util-renderutil/template
@@ -1,16 +1,16 @@
-# Template build for 'xcb-util-renderutil'.
+# Template file for 'xcb-util-renderutil'
 pkgname=xcb-util-renderutil
 version=0.3.9
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libxcb-devel xcb-util-devel"
 short_desc="Utility libraries for XC Binding - Convenience functions for the Render extension"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="X11"
 homepage="http://xcb.freedesktop.org"
-license="GPL-2"
-distfiles="http://xcb.freedesktop.org/dist/$pkgname-$version.tar.bz2"
+distfiles="http://xcb.freedesktop.org/dist/xcb-util-renderutil-${version}.tar.bz2"
 checksum=c6e97e48fb1286d6394dddb1c1732f00227c70bd1bedb7d1acabefdd340bea5b
 
 xcb-util-renderutil-devel_package() {

--- a/srcpkgs/xdaliclock/template
+++ b/srcpkgs/xdaliclock/template
@@ -1,15 +1,15 @@
 # Template file for 'xdaliclock'
 pkgname=xdaliclock
 version=2.43
-revision=2
+revision=3
 build_wrksrc=X11
 build_style=gnu-configure
 makedepends="libXext-devel libXt-devel"
 short_desc="Melting digital clock"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="MIT/X11"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="X11"
 homepage="http://www.jwz.org/xdaliclock/"
-distfiles="http://www.jwz.org/${pkgname}/${pkgname}-${version}.tar.gz"
+distfiles="http://www.jwz.org/xdaliclock/xdaliclock-${version}.tar.gz"
 checksum=6b573a8bac23a72e87a1cd9966c28f1d653bdb0b28bb8fd11633a1a4c2fd9fa4
 
 pre_configure() {
@@ -21,4 +21,6 @@ pre_configure() {
 do_install() {
 	vbin xdaliclock
 	vman xdaliclock.man xdaliclock.1
+	sed -n '/Jamie/,/warranty/p' xdaliclock.c > LICENSE
+	vlicense LICENSE
 }

--- a/srcpkgs/xmlstarlet/template
+++ b/srcpkgs/xmlstarlet/template
@@ -1,14 +1,18 @@
 # Template file for 'xmlstarlet'
 pkgname=xmlstarlet
 version=1.6.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-libxml-prefix=$XBPS_CROSS_BASE/usr
-		--with-libxslt-prefix=$XBPS_CROSS_BASE/usr"
+ --with-libxslt-prefix=$XBPS_CROSS_BASE/usr"
 makedepends="libxslt-devel"
 short_desc="Command line utilities to transform, query, validate, and edit XML"
 maintainer="allan <mail@may.mooo.com>"
 license="MIT"
 homepage="http://xmlstar.sourceforge.net/"
-distfiles="$SOURCEFORGE_SITE/xmlstar/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/xmlstar/xmlstarlet/${version}/xmlstarlet-${version}.tar.gz"
 checksum=15d838c4f3375332fd95554619179b69e4ec91418a3a5296e7c631b7ed19e7ca
+
+post_install() {
+	vlicense COPYING
+}

--- a/srcpkgs/xorg/template
+++ b/srcpkgs/xorg/template
@@ -1,10 +1,10 @@
 # Template file for 'xorg'
 pkgname=xorg
 version=7.6
-revision=4
+revision=5
 build_style=meta
 depends="xorg-fonts xorg-server xorg-apps xorg-input-drivers xorg-video-drivers"
 short_desc="X.org meta-package"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="metapackage"
 homepage="http://xorg.freedesktop.org"
-license="MIT"

--- a/srcpkgs/xoris/template
+++ b/srcpkgs/xoris/template
@@ -1,12 +1,12 @@
 # Template file for 'xoris'
 pkgname=xoris
 version=0.1e
-revision=2
+revision=3
 makedepends="libX11-devel"
 depends="rgb"
 short_desc="Grabs color from the screen and dumps it to stdout"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="MIT/X11"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="X11"
 homepage="http://sourceforge.net/projects/xoris/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=8902d391bfb1a15f21afdd7626634fb3dfa6240814d6c2bcde2ee06377bd675c

--- a/srcpkgs/xrootconsole/template
+++ b/srcpkgs/xrootconsole/template
@@ -1,14 +1,14 @@
 # Template file for 'xrootconsole'
 pkgname=xrootconsole
 version=0.6r3
-revision=2
+revision=3
 create_wrksrc=yes
 build_wrksrc="${pkgname}-${version%r*}"
 build_style=gnu-makefile
 makedepends="libX11-devel"
 short_desc="Fancy X console display"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/source/sid/xrootconsole"
 distfiles="${DEBIAN_SITE}/main/x/${pkgname}/${pkgname}_${version%r*}.orig.tar.gz
  ${DEBIAN_SITE}/main/x/${pkgname}/${pkgname}_${version/r/-}.debian.tar.gz"

--- a/srcpkgs/xteddy/template
+++ b/srcpkgs/xteddy/template
@@ -1,13 +1,13 @@
 # Template file for 'xteddy'
 pkgname=xteddy
 version=2.2
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="imlib2-devel libXext-devel"
 short_desc="Your virtual comfort when things get rough"
-maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="GPL-2"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="GPL-2.0-or-later"
 homepage="http://webstaff.itn.liu.se/~stegu/xteddy/"
 distfiles="http://webstaff.itn.liu.se/~stegu/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=d8885a1e2e08787cb469857a9404619cadab9bddcae7fa398a565d53633291e2

--- a/srcpkgs/yasm/template
+++ b/srcpkgs/yasm/template
@@ -1,13 +1,13 @@
 # Template file for 'yasm'
 pkgname=yasm
 version=1.3.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="xmlto python"
 short_desc="Complete rewrite of the NASM assembler"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-3-Clause, Artistic-1.0, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.tortall.net/projects/yasm/"
-license="BSD, Artistic, GPL-2, LGPL-2.1"
 distfiles="http://www.tortall.net/projects/yasm/releases/yasm-$version.tar.gz"
 checksum=3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f
 


### PR DESCRIPTION
All packages was build (when available) for x86_64, x86_64-musl, armv7hf and aarch64-musl and passed check stage on x86_64 and x86_64-musl. Nothing was tested manually whether it still works.

xdaliclock license is https://fedoraproject.org/wiki/Licensing:MIT#Old_Style, and not what spdx calls MIT

18 more packages remain to rebuild, mostly failing to build.