### PR TITLE
linux4.{14,19}: include patch for xen

### DIFF
--- a/srcpkgs/linux4.14/patches/xen-boot.patch
+++ b/srcpkgs/linux4.14/patches/xen-boot.patch
@@ -1,0 +1,30 @@
+From https://lists.xenproject.org/archives/html/xen-devel/2018-11/msg03410.html
+
+diff --git a/arch/x86/mm/dump_pagetables.c b/arch/x86/mm/dump_pagetables.c
+index a12afff146d1..8c04fadc4423 100644
+--- a/arch/x86/mm/dump_pagetables.c
++++ b/arch/x86/mm/dump_pagetables.c
+@@ -496,8 +496,8 @@ static inline bool is_hypervisor_range(int idx)
+         * ffff800000000000 - ffff87ffffffffff is reserved for
+         * the hypervisor.
+         */
+-       return  (idx >= pgd_index(__PAGE_OFFSET) - 16) &&
+-               (idx <  pgd_index(__PAGE_OFFSET));
++       return  (idx >= pgd_index(LDT_BASE_ADDR) - 16) &&
++               (idx <  pgd_index(LDT_BASE_ADDR));
+ #else
+        return false;
+ #endif
+diff --git a/arch/x86/xen/mmu_pv.c b/arch/x86/xen/mmu_pv.c
+index 2c84c6ad8b50..b078a5b0ac91 100644
+--- a/arch/x86/xen/mmu_pv.c
++++ b/arch/x86/xen/mmu_pv.c
+@@ -652,7 +652,7 @@ static int __xen_pgd_walk(struct mm_struct *mm, pgd_t *pgd,
+         * will end up making a zero-sized hole and so is a no-op.
+         */
+        hole_low = pgd_index(USER_LIMIT);
+-       hole_high = pgd_index(PAGE_OFFSET);
++       hole_high = pgd_index(LDT_BASE_ADDR);
+ 
+        nr = pgd_index(limit) + 1;
+        for (i = 0; i < nr; i++) {

--- a/srcpkgs/linux4.14/template
+++ b/srcpkgs/linux4.14/template
@@ -1,7 +1,7 @@
 # Template file for 'linux4.14'
 pkgname=linux4.14
 version=4.14.84
-revision=1
+revision=2
 patch_args="-Np1"
 wrksrc="linux-${version}"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"

--- a/srcpkgs/linux4.19/patches/xen-boot.patch
+++ b/srcpkgs/linux4.19/patches/xen-boot.patch
@@ -1,0 +1,30 @@
+From https://lists.xenproject.org/archives/html/xen-devel/2018-11/msg03410.html
+
+diff --git a/arch/x86/mm/dump_pagetables.c b/arch/x86/mm/dump_pagetables.c
+index a12afff146d1..8c04fadc4423 100644
+--- a/arch/x86/mm/dump_pagetables.c
++++ b/arch/x86/mm/dump_pagetables.c
+@@ -496,8 +496,8 @@ static inline bool is_hypervisor_range(int idx)
+         * ffff800000000000 - ffff87ffffffffff is reserved for
+         * the hypervisor.
+         */
+-       return  (idx >= pgd_index(__PAGE_OFFSET) - 16) &&
+-               (idx <  pgd_index(__PAGE_OFFSET));
++       return  (idx >= pgd_index(LDT_BASE_ADDR) - 16) &&
++               (idx <  pgd_index(LDT_BASE_ADDR));
+ #else
+        return false;
+ #endif
+diff --git a/arch/x86/xen/mmu_pv.c b/arch/x86/xen/mmu_pv.c
+index 2c84c6ad8b50..b078a5b0ac91 100644
+--- a/arch/x86/xen/mmu_pv.c
++++ b/arch/x86/xen/mmu_pv.c
+@@ -652,7 +652,7 @@ static int __xen_pgd_walk(struct mm_struct *mm, pgd_t *pgd,
+         * will end up making a zero-sized hole and so is a no-op.
+         */
+        hole_low = pgd_index(USER_LIMIT);
+-       hole_high = pgd_index(PAGE_OFFSET);
++       hole_high = pgd_index(LDT_BASE_ADDR);
+ 
+        nr = pgd_index(limit) + 1;
+        for (i = 0; i < nr; i++) {

--- a/srcpkgs/linux4.19/template
+++ b/srcpkgs/linux4.19/template
@@ -1,7 +1,7 @@
 # Template file for 'linux4.19'
 pkgname=linux4.19
 version=4.19.5
-revision=1
+revision=2
 patch_args="-Np1"
 wrksrc="linux-${version}"
 short_desc="The Linux kernel and modules (${version%.*} series)"


### PR DESCRIPTION
If using xen, then without this patch, the kernels crash immediately
(oops while initialising).

I encountered this using virtual machines from a service.  The patch
originators experienced the same with dom0. So pretty much all xen
machines seem to be broken.