### PR TITLE
 Rebuild packages for missing metadata vol. 11

### DIFF
--- a/srcpkgs/gcal/patches/fseeko.patch
+++ b/srcpkgs/gcal/patches/fseeko.patch
@@ -1,0 +1,75 @@
+diff --git lib/fseeko.c lib/fseeko.c
+index 5ae106f..d47481d 100644
+--- lib/fseeko.c
++++ lib/fseeko.c
+@@ -1,9 +1,9 @@
+ /* An fseeko() function that, together with fflush(), is POSIX compliant.
+-   Copyright (C) 2007-2017 Free Software Foundation, Inc.
++   Copyright (C) 2007-2018 Free Software Foundation, Inc.
+ 
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+-   the Free Software Foundation; either version 3, or (at your option)
++   the Free Software Foundation; either version 2, or (at your option)
+    any later version.
+ 
+    This program is distributed in the hope that it will be useful,
+@@ -12,7 +12,7 @@
+    GNU General Public License for more details.
+ 
+    You should have received a copy of the GNU General Public License along
+-   with this program; if not, see <http://www.gnu.org/licenses/>.  */
++   with this program; if not, see <https://www.gnu.org/licenses/>.  */
+ 
+ #include <config.h>
+ 
+@@ -33,9 +33,9 @@ fseeko (FILE *fp, off_t offset, int whence)
+ #endif
+ #if _GL_WINDOWS_64_BIT_OFF_T
+ # undef fseeko
+-# if HAVE__FSEEKI64 /* msvc, mingw64 */
++# if HAVE__FSEEKI64 && HAVE_DECL__FSEEKI64 /* msvc, mingw since msvcrt8.0, mingw64 */
+ #  define fseeko _fseeki64
+-# else /* mingw */
++# else /* mingw before msvcrt8.0 */
+ #  define fseeko fseeko64
+ # endif
+ #endif
+@@ -47,7 +47,8 @@ fseeko (FILE *fp, off_t offset, int whence)
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
++  /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -80,7 +81,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+ #elif defined __minix               /* Minix */
+   if (fp_->_ptr == fp_->_buf
+       && (fp_->_ptr == NULL || fp_->_count == 0))
+-#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel */
++#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+   if (fp_->_ptr == fp_->_base
+       && (fp_->_ptr == NULL || fp_->_cnt == 0))
+ #elif defined __UCLIBC__            /* uClibc */
+@@ -123,7 +124,8 @@ fseeko (FILE *fp, off_t offset, int whence)
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
++      /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+@@ -150,7 +152,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+       fp_->_flags &= ~__SEOF;
+ #elif defined __EMX__               /* emx+gcc */
+       fp->_flags &= ~_IOEOF;
+-#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel */
++#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+       fp_->_flag &= ~_IOEOF;
+ #elif defined __MINT__              /* Atari FreeMiNT */
+       fp->__offset = pos;

--- a/srcpkgs/gcal/template
+++ b/srcpkgs/gcal/template
@@ -1,13 +1,13 @@
 # Template file for 'gcal'
 pkgname=gcal
 version=4.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="tzutils perl"
 makedepends="ncurses-devel"
 short_desc="Display hybrid and proleptic Julian and Gregorian calendar sheets"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/gcal/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=91b56c40b93eee9bda27ec63e95a6316d848e3ee047b5880ed71e5e8e60f61ab

--- a/srcpkgs/gksu/template
+++ b/srcpkgs/gksu/template
@@ -1,15 +1,15 @@
 # Template file for 'gksu'
 pkgname=gksu
 version=2.0.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static --disable-nautilus-extension"
 hostmakedepends="pkg-config intltool gtk-doc"
 makedepends="gtk+-devel libgksu-devel"
 depends="desktop-file-utils xauth"
-short_desc="A graphical frontend for su"
+short_desc="Graphical frontend for su"
 maintainer="Alexey Rochev <equeim@gmail.com>"
+license="GPL-2.0-or-later"
 homepage="http://www.nongnu.org/gksu/index.html"
-license="GPL-2"
-distfiles="http://people.debian.org/~kov/gksu/$pkgname-$version.tar.gz"
+distfiles="http://people.debian.org/~kov/gksu/gksu-${version}.tar.gz"
 checksum=a1de3dca039d88c195fcdc9516379439a1d699750417f1e655aa2101a955ee5a

--- a/srcpkgs/lbzip2/patches/fseterr.patch
+++ b/srcpkgs/lbzip2/patches/fseterr.patch
@@ -1,0 +1,50 @@
+diff --git lib/fseterr.c lib/fseterr.c
+index 1e212e4..81f51ed 100644
+--- lib/fseterr.c
++++ lib/fseterr.c
+@@ -1,5 +1,5 @@
+ /* Set the error indicator of a stream.
+-   Copyright (C) 2007-2014 Free Software Foundation, Inc.
++   Copyright (C) 2007-2018 Free Software Foundation, Inc.
+ 
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+@@ -12,7 +12,7 @@
+    GNU General Public License for more details.
+ 
+    You should have received a copy of the GNU General Public License
+-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+ 
+ #include <config.h>
+ 
+@@ -23,21 +23,26 @@
+ 
+ #include "stdio-impl.h"
+ 
++/* This file is not used on systems that have the __fseterr function,
++   namely musl libc.  */
++
+ void
+ fseterr (FILE *fp)
+ {
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
++  /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+-#elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
++#elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
++  /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+   fp_->_flags |= __SERR;
+ #elif defined __EMX__               /* emx+gcc */
+   fp->_flags |= _IOERR;
+ #elif defined __minix               /* Minix */
+   fp->_flags |= _IOERR;
+-#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, NonStop Kernel */
++#elif defined _IOERR                /* AIX, HP-UX, IRIX, OSF/1, Solaris, OpenServer, mingw, MSVC, NonStop Kernel, OpenVMS */
+   fp_->_flag |= _IOERR;
+ #elif defined __UCLIBC__            /* uClibc */
+   fp->__modeflags |= __FLAG_ERROR;

--- a/srcpkgs/lbzip2/template
+++ b/srcpkgs/lbzip2/template
@@ -1,11 +1,11 @@
 # Template file for 'lbzip2'
 pkgname=lbzip2
 version=2.5
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Parallel bzip2 compression utility"
 maintainer="bra1nwave <brainwave@openmailbox.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://lbzip2.org/"
-distfiles="http://archive.lbzip2.org/${pkgname}-${version}.tar.gz"
+distfiles="http://archive.lbzip2.org/lbzip2-${version}.tar.gz"
 checksum=46c75ee93cc95eedc6005625442b2b8e59a2bef3ba80987d0491f055185650e9

--- a/srcpkgs/libqzeitgeist/template
+++ b/srcpkgs/libqzeitgeist/template
@@ -1,17 +1,18 @@
 # Template file for 'libqzeitgeist'
 pkgname=libqzeitgeist
 version=0.8.0
-revision=4
+revision=5
 build_style=cmake
 configure_args="-DDECLARATIVE_IMPORT_PREFIX=/usr/lib/qt/imports/"
 hostmakedepends="automoc4 python"
 makedepends="zeitgeist qt-devel"
 short_desc="Qt interface to the Zeitgeist event tracking system"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="LGPL-2.1-or-later"
 homepage="https://projects.kde.org/projects/kdesupport/libqzeitgeist"
-distfiles="http://download.kde.org/stable/${pkgname}/${version}/src/${pkgname}-${version}.tar.bz2"
+distfiles="${KDE_SITE}/libqzeitgeist/${version}/src/libqzeitgeist-${version}.tar.bz2"
 checksum=0a8aa980d64549cce93691705807681fd7e3e079a48aee68fc4b2653f17d61ad
+nocross="zeitgeist is nocross"
 
 libqzeitgeist-devel_package() {
 	depends="qt-devel ${sourcepkg}-${version}_${revision}"

--- a/srcpkgs/libzeitgeist/template
+++ b/srcpkgs/libzeitgeist/template
@@ -1,16 +1,16 @@
 # Template file for 'libzeitgeist'
 pkgname=libzeitgeist
 version=0.3.18
-revision=4
+revision=5
 build_style=gnu-configure
+configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
-configure_args="--disable-static"
 short_desc="Zeitgeist Client Library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="LGPL-2.1-or-later"
 homepage="https://launchpad.net/libzeitgeist"
-license="LGPL-2.1"
-distfiles="https://launchpad.net/${pkgname}/0.3/${version}/+download/${pkgname}-${version}.tar.gz"
+distfiles="https://launchpad.net/libzeitgeist/0.3/${version}/+download/libzeitgeist-${version}.tar.gz"
 checksum=82c128d97a68600518b8e3e65ef4d5b123c57f3d5dfa977c7ff733c0fdf80f73
 
 post_install() {

--- a/srcpkgs/obexfs/template
+++ b/srcpkgs/obexfs/template
@@ -1,7 +1,7 @@
 # Template file for 'obexfs'
 pkgname=obexfs
 version=0.12
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="fuse-devel libbluetooth-devel libobexftp-devel"

--- a/srcpkgs/qv4l2/template
+++ b/srcpkgs/qv4l2/template
@@ -1,7 +1,7 @@
 # Template file for 'qv4l2'
 pkgname=qv4l2
 version=1.16.2
-revision=2
+revision=3
 wrksrc="v4l-utils-${version}"
 build_style=gnu-configure
 configure_args="--enable-qv4l2 --with-udevdir=/usr/lib/udev"

--- a/srcpkgs/rkt/template
+++ b/srcpkgs/rkt/template
@@ -1,7 +1,7 @@
 # Template file for 'rkt'
 pkgname=rkt
 version=1.30.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake wget cpio squashfs-tools bc gnupg git go"
 makedepends="acl-devel zlib-devel libressl-devel"
@@ -10,7 +10,7 @@ short_desc="App Container runtime for Linux"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="https://github.com/coreos/rkt"
-distfiles="$homepage/archive/v$version.tar.gz"
+distfiles="https://github.com/coreos/rkt/archive/v${version}.tar.gz"
 checksum=4d22c742b87d15c226cc28970c7daf66a64c6a95af9d752f5b72d9a4012aca1d
 
 patch_args="-Np1"

--- a/srcpkgs/seahorse-nautilus/template
+++ b/srcpkgs/seahorse-nautilus/template
@@ -1,17 +1,18 @@
 # Template file for 'seahorse-nautilus'
 pkgname=seahorse-nautilus
 version=3.10.1
-revision=3
-lib32disabled=yes
+revision=4
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
 hostmakedepends="pkg-config intltool gnome-doc-utils gpgme-devel"
 makedepends="gtk+3-devel nautilus-devel libnotify-devel
  gpgme-devel libcryptui-devel gcr-devel libgnome-keyring-devel"
 depends="gnupg desktop-file-utils"
-short_desc="A Nautilus plugin for OpenPGP file encryption/decryption"
+short_desc="Nautilus plugin for OpenPGP file encryption/decryption"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="GPL-2.0-or-later"
 homepage="http://www.gnome.org/projects/seahorse/"
-license="GPL-2"
-distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
+distfiles="${GNOME_SITE}/seahorse-nautilus/${version%.*}/seahorse-nautilus-${version}.tar.xz"
 checksum=eacaf33bba920cf117641393a6eef483dbc075009349082e77d22f79afbd823a
+lib32disabled=yes
+nocross=yes

--- a/srcpkgs/wireless_tools/template
+++ b/srcpkgs/wireless_tools/template
@@ -1,14 +1,16 @@
 # Template file for 'wireless_tools'
 pkgname=wireless_tools
 version=29
-revision=8
-wrksrc="${pkgname}.${version}"
+revision=9
+wrksrc="wireless_tools.${version}"
+hostmakedepends="wget"
 short_desc="Set of tools allowing to manipulate the Wireless Extensions"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html"
 license="GPL-2"
-distfiles="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/$pkgname.$version.tar.gz"
+homepage="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html"
+distfiles="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/wireless_tools.${version}.tar.gz"
 checksum=6fb80935fe208538131ce2c4178221bab1078a1656306bce8909c19887e2e5a1
+XBPS_FETCH_CMD="wget --no-check-certificate"
 
 do_build() {
 	sed -i -e 's|CFLAGS=|CFLAGS+=|g' -e 's|-shared|& $(LDFLAGS)|g' Makefile

--- a/srcpkgs/wmx/template
+++ b/srcpkgs/wmx/template
@@ -1,17 +1,18 @@
 # Template file for 'wmx'
 pkgname=wmx
 version=8
-revision=2
+revision=3
 build_style=gnu-configure
+make_build_args="LDFLAGS+=-lXft LDFLAGS+=-lfontconfig
+ CXXFLAGS+=-I${XBPS_CROSS_BASE}/usr/include/freetype2"
 makedepends="libX11-devel libXext-devel libXmu-devel libXpm-devel freetype-devel
  libXft-devel fontconfig-devel libXcomposite-devel"
-short_desc="a simple window manager for X"
+short_desc="Simple window manager for X"
 maintainer="Enno Boland <gottox@voidlinux.eu>"
 license="BSD"
 homepage="http://www.all-day-breakfast.com/wmx"
 distfiles="http://www.all-day-breakfast.com/wmx/wmx-${version}.tar.gz"
 checksum=7316090e59fa8988219d6819e426870c6d8c0739818d77e8770e8108ddf0aedd
-make_build_args="LDFLAGS+=-lXft LDFLAGS+=-lfontconfig CXXFLAGS+=-I${XBPS_CROSS_BASE}/usr/include/freetype2"
 
 do_install() {
 	vbin wmx


### PR DESCRIPTION
All packages was build (when available) for x86_64, x86_64-musl, armv7hf and aarch64-musl. Nothing was tested manually whether it still works.

All but gksu, libzeitgeist, libqzeitgeist, rkt passed check stage on x86_64 and x86_64-musl.

wmx does not seem to include its license.
