### PR TITLE
rustup: update to 1.15.0.

### DIFF
--- a/srcpkgs/rustup/files/rustup.sh
+++ b/srcpkgs/rustup/files/rustup.sh
@@ -1,0 +1,2 @@
+# Export PATH ourselves so we don't need to run rustup-init
+export PATH="$PATH:$HOME/.cargo/bin"

--- a/srcpkgs/rustup/patches/libressl-2.8.patch
+++ b/srcpkgs/rustup/patches/libressl-2.8.patch
@@ -1,9 +1,0 @@
---- Cargo.toml
-+++ Cargo.toml
-@@ -77,3 +77,6 @@
- name = "rustup-init"
- path = "src/rustup-cli/main.rs"
- test = false # no unit tests
-+
-+[patch.crates-io]
-+openssl-sys = {git = 'https://github.com/jnbr/rust-openssl', rev = "d5471c97ae86e5bd1032eb6fd95005933f507c49"}

--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,7 +1,7 @@
 # Template file for 'rustup'
 pkgname=rustup
-version=1.14.0
-revision=5
+version=1.15.0
+revision=1
 wrksrc="${pkgname}.rs-${version}"
 build_style=cargo
 configure_args="--features no-self-update --bin rustup-init"
@@ -12,20 +12,10 @@ maintainer="Daniel Lee Ramírez <dleeram@protonmail.com>"
 license="Apache-2.0, MIT"
 homepage="https://www.rustup.rs"
 distfiles="https://github.com/rust-lang-nursery/${pkgname}.rs/archive/${version}.tar.gz"
-checksum=ab125d9b12bf0f3f7e7ad98e826035fa1ae3dbe6ba8b78be4c82f9cde00bc59f
-conflicts="rust cargo"
-
-pre_build() {
-	cargo update --package openssl-sys --precise 0.9.35
-}
+checksum=470441d59dbb33f4e3e52e3f7420734dae0066598802c2b3b4f89f5b3a6a9e45
 
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init rustup
-
-	# rustup doesn't set PATH correctly to include these.
-	for cmd in cargo rust-gdb rust-lldb rustc rustdoc; do
-		ln -s rustup ${DESTDIR}/usr/bin/${cmd}
-	done
 
 	if ! [ "$CROSS_BUILD" ]; then
 		# generate shell completions
@@ -38,6 +28,8 @@ do_install() {
 		vinstall rustup.bash 0644 usr/share/bash-completion/completions/ rustup
 		vinstall rustup.fish 0644 usr/share/fish/completions/
 	fi
+
+	vinstall ${FILESDIR}/rustup.sh 0644 etc/profile.d/
 
 	vdoc README.md
 	vlicense LICENSE-APACHE


### PR DESCRIPTION
* Instead of doing a bad job at symlinking binaries (it doesn't
work if you install new components, e.g. cargo-clippy) install
the rustup binary as rustup-init and let that setup PATH