### PR TITLE
cura: add libSavitar as a dependency

### DIFF
--- a/srcpkgs/cura/template
+++ b/srcpkgs/cura/template
@@ -1,7 +1,7 @@
 # Template file for 'cura'
 pkgname=cura
 version=3.6.0
-revision=1
+revision=2
 noarch=yes
 wrksrc="Cura-${version}"
 build_style=cmake
@@ -9,7 +9,8 @@ configure_args="-DCURA_VERSION=${version}"
 pycompile_module="cura"
 pycompile_dirs="usr/lib/cura/plugins"
 makedepends="Uranium libArcus-devel"
-depends="Uranium cura-engine cura-fdm-materials python3-pyserial python3-zeroconf"
+depends="Uranium cura-engine cura-fdm-materials python3-pyserial python3-zeroconf
+ libSavitar-python3"
 short_desc="3D printer / slicing GUI"
 maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="LGPL-3.0-or-later"


### PR DESCRIPTION
Sorry didnt realize that [deprecating curaproject files](https://ultimaker.com/en/products/ultimaker-cura-software/release-notes) would break stuff.