### PR TITLE
noto-fonts-ttf: update to 20181202

### DIFF
--- a/srcpkgs/noto-fonts-ttf/template
+++ b/srcpkgs/noto-fonts-ttf/template
@@ -1,9 +1,9 @@
 # Template file for 'noto-fonts-ttf'
 pkgname=noto-fonts-ttf
-version=20181106
+version=20181202
 revision=1
 noarch=yes
-_githash=64f57055a31ee72789437d786e969ded9a1231f9
+_githash=85e78f831469323c85847e23f95026c894159135
 wrksrc="noto-fonts-${_githash}"
 depends="font-util"
 font_dirs="/usr/share/fonts/noto"
@@ -12,9 +12,10 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="OFL-1.1"
 homepage="https://www.google.com/get/noto/"
 distfiles="https://github.com/googlei18n/noto-fonts/archive/${_githash}.tar.gz"
-checksum=d349032b65c4d34588857d33d7acbc99174407ac42e943892fe9eeacaa8acc7c
+checksum=4649a3a66fd08c7676eefddefced98a5a9d4beaebed79495aa5b0a55f3943104
 
 do_install() {
+	install -Dm644 unhinted/Noto*.ttf -t ${DESTDIR}/usr/share/fonts/noto
 	install -Dm644 hinted/Noto*.ttf -t ${DESTDIR}/usr/share/fonts/noto
 }
 
@@ -22,8 +23,18 @@ noto-fonts-ttf-extra_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - additional variants"
 	pkg_install() {
-		vmove usr/share/fonts/noto/Noto*Condensed*.ttf
-		vmove usr/share/fonts/noto/Noto*SemiBold*.ttf
-		vmove usr/share/fonts/noto/Noto*Extra*.ttf
+		vmove usr/share/fonts/noto/Noto*-ExtraCondensed*.ttf
+		vmove usr/share/fonts/noto/Noto*-Condensed*.ttf
+		vmove usr/share/fonts/noto/Noto*-SemiCondensed*.ttf
+
+		vmove usr/share/fonts/noto/Noto*-Thin*.ttf
+		vmove usr/share/fonts/noto/Noto*-ExtraLight*.ttf
+		vmove usr/share/fonts/noto/Noto*-Light*.ttf
+		# keep *-Regular*
+		vmove usr/share/fonts/noto/Noto*-Medium*.ttf
+		vmove usr/share/fonts/noto/Noto*-SemiBold*.ttf
+		# keep *-Bold*
+		vmove usr/share/fonts/noto/Noto*-ExtraBold*.ttf
+		vmove usr/share/fonts/noto/Noto*-Black*.ttf
 	}
 }


### PR DESCRIPTION
* Where there is no hinted font, use the unhinted version.
* Move all widths and weights other than uncondensed Regular/Bold into the -extra subpackage.