### PR TITLE
gettext-tiny: update to 0.3.1.

### DIFF
--- a/srcpkgs/gettext-tiny/template
+++ b/srcpkgs/gettext-tiny/template
@@ -1,13 +1,13 @@
-# Template build file for 'gettext-tiny'.
+# Template file for 'gettext-tiny'
 pkgname=gettext-tiny
-version=0.2.0
+version=0.3.1
 revision=1
 short_desc="Tiny Internationalized Message Handling Library and tools"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="https://github.com/rofl0r/gettext-tiny"
 license="MIT"
+homepage="https://github.com/rofl0r/gettext-tiny"
 distfiles="https://github.com/rofl0r/${pkgname}/archive/v${version}.tar.gz"
-checksum=1e0b57c4befb76f8f5c55f57ea4f1c2dbe62f57b80c34276fd49d870edf03dcb
+checksum=654dcd52f2650476c8822b60bee89c20a0aa7f6a1bf6001701eeacd71a9e388b
 
 conflicts="gettext>=0"
 
@@ -21,10 +21,11 @@ do_install() {
 }
 
 gettext-tiny-devel_package() {
-	conflicts="glibc-devel>=0 musl>=0"
+	conflicts="glibc-devel>=0 musl-devel>=0"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib
+		vmove usr/share/aclocal
 	}
 }


### PR DESCRIPTION
@chneukirchen is the conflicts= on the subpackage from musl to musl-devel ok ?