### PR TITLE
New package: ghdl-20181129

### DIFF
--- a/srcpkgs/ghdl/template
+++ b/srcpkgs/ghdl/template
@@ -1,0 +1,14 @@
+# Template file for 'ghdl'
+pkgname=ghdl
+version=20181129
+revision=1
+only_for_archs="i686 x86_64"
+build_style=configure
+configure_args="--prefix=/usr"
+makedepends="zlib-devel"
+short_desc="VHDL 2008/93/87 simulator - mcode backend"
+maintainer="m3tav3rse <n6maa10816@tuta.io>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/ghdl/ghdl"
+distfiles="https://github.com/ghdl/ghdl/archive/${version}.tar.gz"
+checksum=f5d4f8f7d0f5643ad937ab76dfc88219fbd7d90eb7d35fad690cd743acd04e42


### PR DESCRIPTION
I'm not sure about this variable in common, also: crossbuilding with "./xbps-src -a i686 pkg ghdl" doesn't work, but with i686 masterdir builds fine.