### PR TITLE
xfsprogs: Patch to fix compilation issue on MIPS.

### DIFF
--- a/srcpkgs/xfsprogs/patches/00-patch-for-mips.diff
+++ b/srcpkgs/xfsprogs/patches/00-patch-for-mips.diff
@@ -1,0 +1,26 @@
+--- io/mmap.c
++++ io/mmap.c
+@@ -189,7 +189,11 @@
+ 			prot |= PROT_EXEC;
+ 			break;
+ 		case 'S':
++ 			#ifdef MAP_SYNC
+ 			flags = MAP_SYNC | MAP_SHARED_VALIDATE;
++ 			#else
++ 			flags = MAP_SHARED_VALIDATE;
++ 			#endif
+ 
+ 			/*
+ 			 * If MAP_SYNC and MAP_SHARED_VALIDATE aren't defined
+@@ -269,7 +273,11 @@
+ 	mapping->offset = offset;
+ 	mapping->name = filename;
+ 	mapping->prot = prot;
++ 	#ifdef MAP_SYNC
+ 	mapping->map_sync = (flags == (MAP_SYNC | MAP_SHARED_VALIDATE));
++ 	#else
++ 	mapping->map_sync = (flags == (MAP_SHARED_VALIDATE));
++ 	#endif
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
xfsprogs is part of base-system and will not compile on MIPS as MAP_SYNC seems to be undefined under there. This is a simple patch which checks for MAP_SYNC's availability before using it.