### PR TITLE
New package: palapeli-18.08.3

### DIFF
--- a/srcpkgs/palapeli/template
+++ b/srcpkgs/palapeli/template
@@ -1,0 +1,14 @@
+# Template file for 'palapeli'
+pkgname=palapeli
+version=18.08.3
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules"
+makedepends="libkdegames-devel kdoctools"
+depends="qhull"
+short_desc="Jigsaw puzzle game"
+maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
+license="GPL-2.0-or-later"
+homepage="https://kde.org/applications/games/palapeli"
+distfiles="$KDE_SITE/applications/$version/src/palapeli-$version.tar.xz"
+checksum=289744cff0d3d0f01cc0f1c31c26e330f44cf3e0925c3ee6750cf232631ecf18


### PR DESCRIPTION
Adding KDE jigsaw puzzle game. Tested locally on x86-64 glibc with no visible issues.