### PR TITLE
kernel-libc-headers: fix redefinition of sigcontext from libc on aarch64

### DIFF
--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.29
-revision=1
+revision=2
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 homepage="https://www.voidlinux.org/"

--- a/srcpkgs/kernel-libc-headers/patches/1-7-musl-aarch64-asm-ptrace.patch
+++ b/srcpkgs/kernel-libc-headers/patches/1-7-musl-aarch64-asm-ptrace.patch
@@ -1,0 +1,28 @@
+Work around redefinition of sigcontext in libc headers
+
+Introduced with:
+https://github.com/torvalds/linux/commit/43d4da2c45b2f5d62f8a79ff7c6f95089bb24656
+
+diff --git a/arch/arm64/include/uapi/asm/ptrace.h b/arch/arm64/include/uapi/asm/ptrace.h
+index 98c4ce5..c44efed 100644
+--- arch/arm64/include/uapi/asm/ptrace.h
++++ arch/arm64/include/uapi/asm/ptrace.h
+@@ -23,8 +23,6 @@
+ #include <linux/types.h>
+ 
+ #include <asm/hwcap.h>
+-#include <asm/sigcontext.h>
+-
+ 
+ /*
+  * PSR bits
+@@ -64,8 +62,6 @@
+ 
+ #ifndef __ASSEMBLY__
+ 
+-#include <linux/prctl.h>
+-
+ /*
+  * User structures for general purpose, floating point and debug registers.
+  */
+

--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -1,7 +1,7 @@
 # Template file for 'kernel-libc-headers'
 pkgname=kernel-libc-headers
 version=4.19.0
-revision=1
+revision=2
 bootstrap=yes
 nostrip=yes
 noverifyrdeps=yes


### PR DESCRIPTION
redefinition of `sigcontext` in `usr/include/asm/ptrace.h` breaks some packages for `aarch64-musl`, e.g. `libvirt` and `radare2`.
source: https://git.alpinelinux.org/cgit/aports/commit/?id=f3c86ef81958f9bdbcda0f34559ff77d64f87b95