### PR TITLE
efivar: update to 37

### DIFF
--- a/srcpkgs/efivar/template
+++ b/srcpkgs/efivar/template
@@ -1,6 +1,6 @@
 # Template file for 'efivar'
 pkgname=efivar
-version=36
+version=37
 revision=1
 patch_args="-Np1"
 build_style=gnu-makefile
@@ -10,7 +10,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/rhinstaller/efivar"
 distfiles="https://github.com/rhboot/efivar/releases/download/${version}/efivar-${version}.tar.bz2"
-checksum=94bfccc20889440978a85f08d5af4619040ee199001b62588d47d676f58c0d33
+checksum=3c67feb93f901b98fbb897d5ca82931a6698b5bcd6ac34f0815f670d77747b9f
 make_build_args="libdir=/usr/lib"
 make_build_target="all test"
 make_install_args="libdir=/usr/lib"


### PR DESCRIPTION
this contains important bugfixes that led to efivars not correctly working on some efi systems