### PR TITLE
ckb-next: move udev rules to /usr/lib/udev/rules.d

### DIFF
--- a/srcpkgs/ckb-next/template
+++ b/srcpkgs/ckb-next/template
@@ -1,7 +1,7 @@
 # Template file for 'ckb-next'
 pkgname=ckb-next
 version=0.3.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DDISABLE_UPDATER=1"
 hostmakedepends="qt5-devel"
@@ -10,9 +10,12 @@ short_desc="Corsair RGB Driver for Linux"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ckb-next/ckb-next"
-distfiles="$homepage/archive/v$version.tar.gz"
+distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=4a1a91610353189e827985108621ad92fb8336a322bd70a3733775251d735c31
 
 post_install() {
 	vsv ckb-next-daemon
+
+	vmkdir usr/lib/udev/rules.d
+	mv ${DESTDIR}/etc/udev/rules.d/* ${DESTDIR}/usr/lib/udev/rules.d
 }


### PR DESCRIPTION
\#5472