### PR TITLE
Update calibre to 3.35.0

### DIFF
--- a/srcpkgs/calibre/template
+++ b/srcpkgs/calibre/template
@@ -1,11 +1,11 @@
 # Template file for 'calibre'
 pkgname=calibre
-version=3.32.0
-revision=3
+version=3.35.0
+revision=1
 hostmakedepends="qt5-qmake python-devel pkg-config
  python-dateutil python-lxml python-Pillow python-msgpack
  python-PyQt5-webkit python-apsw python-cssutils python-CherryPy"
-makedepends="python-PyQt5-devel glib-devel libwmf-devel
+makedepends="python-PyQt5-devel glib-devel libwmf-devel python-enum34
  fontconfig-devel libmagick-devel libressl-devel icu-devel sqlite-devel
  libchmlib-devel libpodofo-devel qt5-devel libusb-devel libmtp-devel
  libinput-devel libxkbcommon-devel tslib-devel"
@@ -18,10 +18,10 @@ depends="python-six python-dateutil python-cssutils python-CherryPy
  shared-mime-info desktop-file-utils gtk-update-icon-cache optipng"
 short_desc="Ebook management application"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="https://calibre-ebook.com"
 distfiles="https://download.calibre-ebook.com/${version}/calibre-${version}.tar.xz"
-checksum=57254b147d8f8caf16f774f090266e112281c19bf7bc4170e65d22ab9b58d8ac
+checksum=3f1cb12804de37ea0bbe4119b378ac60fac5e1f0b113d28cca0c3af2252fa1bd
 
 nocross=yes
 pycompile_dirs="/usr/lib/calibre/"


### PR DESCRIPTION
 - Added python-enum34 as a makedep. Required since PyQt 5.11.2

#5412