### PR TITLE
New package: xrectsel-0.3.2

### DIFF
--- a/srcpkgs/xrectsel/template
+++ b/srcpkgs/xrectsel/template
@@ -1,0 +1,17 @@
+# Template file for 'xrectsel'
+pkgname=xrectsel
+version=0.3.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config autoconf automake"
+makedepends="libX11-devel"
+short_desc="Print the geometry of a rectangular screen region"
+maintainer="Franc[e]sco <lolisamurai@tfwno.gf>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/lolilolicon/xrectsel"
+distfiles="https://github.com/lolilolicon/xrectsel/archive/$version.tar.gz"
+checksum=1b4b928bb7270e0531467c1e7f93322c784c7c0dedc13d1d5e53034417fde785
+
+pre_configure() {
+	./bootstrap
+}


### PR DESCRIPTION
prints the geometry of a rectangular screen region, tested on x86_64