### PR TITLE
arcan: update to 0.5.5.2.

### DIFF
--- a/srcpkgs/acfgfs/template
+++ b/srcpkgs/acfgfs/template
@@ -1,7 +1,7 @@
 # Template file for 'acfgfs'
 # needs to be synced with the arcan package
 pkgname=acfgfs
-version=0.5.5
+version=0.5.5.2
 revision=1
 wrksrc=arcan-${version}
 build_wrksrc=src/tools/acfgfs
@@ -12,7 +12,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="BSD-3-Clause"
 homepage="https://arcan-fe.com"
 distfiles="https://github.com/letoram/arcan/archive/${version}.tar.gz"
-checksum=578ed860a99a02cf1cf963efac830eb8af08093e4322832b2be6554d8c922ff2
+checksum=a5f775789e22f6a4f16742ae9375bb5b7999aab83398adeab2bdc3f70c321cc0
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686|armv6l|armv7l)

--- a/srcpkgs/aclip/template
+++ b/srcpkgs/aclip/template
@@ -1,7 +1,7 @@
 # Template file for 'aclip'
 # needs to be synced with the arcan package
 pkgname=aclip
-version=0.5.5
+version=0.5.5.2
 revision=1
 wrksrc=arcan-${version}
 build_wrksrc=src/tools/aclip
@@ -12,7 +12,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="BSD-3-Clause"
 homepage="https://arcan-fe.com/"
 distfiles="https://github.com/letoram/arcan/archive/${version}.tar.gz"
-checksum=578ed860a99a02cf1cf963efac830eb8af08093e4322832b2be6554d8c922ff2
+checksum=a5f775789e22f6a4f16742ae9375bb5b7999aab83398adeab2bdc3f70c321cc0
 
 post_install() {
 	vlicense ../../../COPYING

--- a/srcpkgs/aloadimage/template
+++ b/srcpkgs/aloadimage/template
@@ -1,7 +1,7 @@
 # Template file for 'aloadimage'
 # needs to be synced with the arcan package
 pkgname=aloadimage
-version=0.5.5
+version=0.5.5.2
 revision=1
 wrksrc="arcan-${version}"
 build_wrksrc=src/tools/aloadimage
@@ -13,7 +13,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="BSD-3-Clause"
 homepage="https://arcan-fe.com/"
 distfiles="https://github.com/letoram/arcan/archive/${version}.tar.gz"
-checksum=578ed860a99a02cf1cf963efac830eb8af08093e4322832b2be6554d8c922ff2
+checksum=a5f775789e22f6a4f16742ae9375bb5b7999aab83398adeab2bdc3f70c321cc0
 
 post_install() {
 	vlicense ../../../COPYING

--- a/srcpkgs/arcan-wayland/template
+++ b/srcpkgs/arcan-wayland/template
@@ -1,11 +1,11 @@
 # Template file for 'arcan-wayland'
 # needs to be synced with the arcan package
 pkgname=arcan-wayland
-version=0.5.5
+version=0.5.5.2
 revision=1
-build_style=cmake
 wrksrc=arcan-${version}
 build_wrksrc=src/tools/waybridge
+build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="MesaLib-devel arcan-devel libseccomp-devel libxkbcommon-devel
  wayland-devel wayland-protocols"
@@ -14,7 +14,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="BSD-3-Clause"
 homepage="https://arcan-fe.com/"
 distfiles="https://github.com/letoram/arcan/archive/${version}.tar.gz"
-checksum=578ed860a99a02cf1cf963efac830eb8af08093e4322832b2be6554d8c922ff2
+checksum=a5f775789e22f6a4f16742ae9375bb5b7999aab83398adeab2bdc3f70c321cc0
 
 if [ "$CROSS_BUILD" ];then
 	hostmakedepends+=" wayland-devel"

--- a/srcpkgs/arcan/patches/010-tesseract-include.patch
+++ b/srcpkgs/arcan/patches/010-tesseract-include.patch
@@ -1,0 +1,8 @@
+--- src/frameserver/encode/default/ocr.c
++++ src/frameserver/encode/default/ocr.c
+@@ -1,4 +1,4 @@
+-#include <capi.h>
++#include <tesseract/capi.h>
+ #include <leptonica/allheaders.h>
+ #include <arcan_shmif.h>
+ #include "util/utf8.c"

--- a/srcpkgs/arcan/template
+++ b/srcpkgs/arcan/template
@@ -1,13 +1,13 @@
 # Template file for 'arcan'
 pkgname=arcan
-version=0.5.5
+version=0.5.5.2
 revision=1
-build_style=cmake
 build_wrksrc=src
+build_style=cmake
 configure_args="-DDISTR_TAG='Void Linux' -DVIDEO_PLATFORM=egl-dri"
 makedepends="ffmpeg-devel harfbuzz-devel liblzma-devel
  libopenal-devel libusb-devel libvncserver-devel libxkbcommon-devel sqlite-devel
- $(vopt_if tesseract tesseract-ocr-devel) vlc-devel"
+ $(vopt_if tesseract "tesseract-ocr-devel leptonica-devel") vlc-devel"
 short_desc="Combined display server, multimedia framework and game engine"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, BSD-3-Clause"
@@ -15,7 +15,7 @@ homepage="https://arcan-fe.com/"
 _versionOpenal=0.5.4
 distfiles="https://github.com/letoram/${pkgname}/archive/${version}.tar.gz
  https://github.com/letoram/openal/archive/${_versionOpenal}.tar.gz>openal_arcan.${_versionOpenal}.tar.gz"
-checksum="578ed860a99a02cf1cf963efac830eb8af08093e4322832b2be6554d8c922ff2
+checksum="a5f775789e22f6a4f16742ae9375bb5b7999aab83398adeab2bdc3f70c321cc0
  3a50a87c05b67c466a868cc77f8dc7f9cfc9466aeeafcd823daca0d108c504da"
 
 case "${XBPS_TARGET_MACHINE}" in


### PR DESCRIPTION
- enable net frameserver
- dependency `harfbuzz` is not recognized by arcan's cmake
- fix tesseract detection