### PR TITLE
emacs: Fix hunspell issues

### DIFF
--- a/srcpkgs/emacs/files/hunspell_1.7.patch
+++ b/srcpkgs/emacs/files/hunspell_1.7.patch
@@ -1,0 +1,16 @@
+--- a/lisp/textmodes/ispell.el
++++ b/lisp/textmodes/ispell.el
+@@ -1113,7 +1113,12 @@ dictionary from that list was found."
+ 				 null-device
+ 				 t
+ 				 nil
+-				 "-D")
++                                 ;; Hunspell 1.7.0 (and later?) won't
++                                 ;; show LOADED DICTIONARY unless
++                                 ;; there's at least one file argument
++                                 ;; on the command line.  So we feed
++                                 ;; it with the null device.
++				 "-D" null-device)
+ 	    (buffer-string))
+ 	  "[\n\r]+"
+ 	  t))


### PR DESCRIPTION
Fixes bug reported [here]( https://debbugs.gnu.org/cgi/bugreport.cgi?bug=33493) which appeared with `hunspell-1.7`.