### PR TITLE
rebar3: update to 3.7.5.

### DIFF
--- a/srcpkgs/rebar3/template
+++ b/srcpkgs/rebar3/template
@@ -1,6 +1,6 @@
 # Template file for 'rebar3'
 pkgname=rebar3
-version=3.6.2
+version=3.7.5
 revision=1
 noarch=yes
 hostmakedepends=erlang
@@ -10,7 +10,7 @@ maintainer="Noel Cower <ncower@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.rebar3.org/"
 distfiles="https://github.com/erlang/rebar3/archive/${version}.tar.gz"
-checksum=7f358170025b54301bce9a10ec7ad07d4e88a80eaa7b977b73b32b45ea0b626e
+checksum=46d9991c8af1dc85a1de8edc6618c3e6dc9c3de60c67e8139a98d2e4c2d047ad
 
 do_build() {
 	./bootstrap
@@ -18,4 +18,6 @@ do_build() {
 
 do_install() {
 	vbin rebar3
+	vsconf rebar.config.sample rebar.config
+	vman manpages/rebar3.1
 }


### PR DESCRIPTION
In addition, adds the license, sample config (which rebar3 will
generate anyway), and manpage.