### PR TITLE
micro: update to 1.4.1.

### DIFF
--- a/srcpkgs/micro/template
+++ b/srcpkgs/micro/template
@@ -1,11 +1,12 @@
 # Template file for 'micro'
 pkgname=micro
-version=1.4.0
-revision=5
+version=1.4.1
+revision=1
 # This will need to be updated along with version as it cannot currently be
-# obtained from git before fetching, and is necessary if the user is to make
-# error reports upsteam.
-_commithash=af520cf047a7296ec292f15aa04114ad9f9052ae
+# obtained from the tarball, and is necessary if the user is to make error
+# reports upsteam.
+_commithash=1856891622af0e4616288df6207451553622d465
+wrksrc=micro
 build_style=go
 go_import_path="github.com/zyedidia/micro"
 go_package="${go_import_path}/cmd/micro"
@@ -15,26 +16,8 @@ short_desc="A modern and intuitive terminal-based text editor"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="MIT"
 homepage="https://micro-editor.github.io"
-
-do_fetch() {
-	# We need the git repository since dependencies are vendored in submodules.
-	# These submodules aren't included in the tarball. Go get then tries to get
-	# the current versions which will cause the build to fail.
-
-	git clone --branch v${version} https://github.com/zyedidia/micro $wrksrc
-	cd $wrksrc
-
-	# Simulate normal fetch error messages
-	head=$(git rev-parse HEAD)
-	msg_normal "$pkgver: verifying checksum for https://github.com/zyedidia/micro"
-	if [[ "$_commithash" != "$head" ]]; then
-		echo
-		msg_red "SHA256 mismatch for 'https://github.com/zyedidia/micro' :\n$head\n"
-		exit 1
-	fi
-
-	git submodule update --init --recursive --recommend-shallow
-}
+distfiles="https://github.com/zyedidia/micro/releases/download/v${version}/micro-${version}-src.tar.gz"
+checksum=0b516826226cf1ddf2fbb274f049cab456a5c162efe3d648f0871564fadcf812
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Upstream prepares tarball with all sources, let's use it.