### PR TITLE
xl2tpd: make run directory

### DIFF
--- a/srcpkgs/xl2tpd/files/xl2tpd/run
+++ b/srcpkgs/xl2tpd/files/xl2tpd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
+[ -d /var/run/xl2tpd ] || mkdir /var/run/xl2tpd
 exec xl2tpd -D "${OPTS:=-c /etc/xl2tpd/xl2tpd.conf}"

--- a/srcpkgs/xl2tpd/template
+++ b/srcpkgs/xl2tpd/template
@@ -1,7 +1,7 @@
 # Template file for 'xl2tpd'
 pkgname=xl2tpd
 version=1.3.13
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=yes
 make_build_args="KERNELSRC=${XBPS_CROSS_BASE}/usr"


### PR DESCRIPTION
xl2tpd won't start because it needs /var/run/xl2tpd which doens't exist by default. I just added mkdir /var/run/xl2tpd to sv run script, but I'm awful at bash so feel free to tell if i do it wrong.