### PR TITLE
kyua: revbump and fix tests

### DIFF
--- a/srcpkgs/kyua/template
+++ b/srcpkgs/kyua/template
@@ -1,7 +1,7 @@
 # Template file for 'kyua'
 pkgname=kyua
 version=0.13
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="
  kyua_cv_attribute_noreturn=yes kyua_cv_lchmod_works=no
@@ -11,12 +11,17 @@ configure_args="
 hostmakedepends="pkg-config automake libtool atf-devel"
 makedepends="atf-devel lutok-devel sqlite-devel"
 depends="atf>=0.21"
+checkdepends="atf"
 short_desc="Kyua (automated testing framework) - Command line interface"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="2-clause-BSD"
 homepage="https://github.com/jmmv/kyua"
 distfiles="https://github.com/jmmv/kyua/releases/download/kyua-${version}/kyua-${version}.tar.gz"
 checksum=db6e5d341d5cf7e49e50aa361243e19087a00ba33742b0855d2685c0b8e721d6
+
+post_install() {
+	vlicense LICENSE
+}
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
revbump because the package wasn't working. Also, some tests were failing because `atf` was not installed.