### PR TITLE
kig: fix python scripting

### DIFF
--- a/srcpkgs/kig/patches/boost-python.patch
+++ b/srcpkgs/kig/patches/boost-python.patch
@@ -1,0 +1,77 @@
+--- CMakeLists.txt	2018-12-07 01:17:42.000000000 +0100
++++ CMakeLists.txt	2018-12-14 15:13:57.262633921 +0100
+@@ -40,7 +40,15 @@
+ 
+ include(KigConfigureChecks.cmake)
+ 
++find_package(Boost)
++find_package(PythonLibs 2.7)
++
++if(${Boost_VERSION} GREATER 106699)
++  find_package(Boost COMPONENTS python27)
++  set(Boost_PYTHON_LIBRARY ${Boost_PYTHON27_LIBRARY})
++else()
++  find_package(Boost COMPONENTS python)
++endif()
+-find_package(BoostPython)
+ 
+ add_subdirectory( doc )
+ add_subdirectory( icons )
+@@ -52,10 +60,10 @@
+ add_subdirectory( data )
+ add_subdirectory( pykig )
+ 
++if(Boost_FOUND)
+-if(BoostPython_FOUND)
+   add_subdirectory( scripting )
+   add_definitions(-DKIG_ENABLE_PYTHON_SCRIPTING)
++endif(Boost_FOUND)
+-endif(BoostPython_FOUND)
+ 
+ set_package_properties(
+    BoostPython PROPERTIES
+@@ -76,9 +84,10 @@
+ feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
+ 
+ include_directories( ${CMAKE_SOURCE_DIR}/modes )
++if(Boost_FOUND)
++  include_directories(${Boost_INCLUDE_DIRS})
++  include_directories(${PYTHON_INCLUDE_PATH})
++endif(Boost_FOUND)
+-if(BoostPython_FOUND)
+-  include_directories(${BoostPython_INCLUDE_DIRS})
+-endif(BoostPython_FOUND)
+ 
+ # kigpart
+ 
+@@ -216,7 +225,7 @@
+    misc/kigcoordinateprecisiondialog.ui
+ )
+ 
++if(Boost_FOUND)
+-if(BoostPython_FOUND)
+   set(kigpart_PART_SRCS ${kigpart_PART_SRCS}
+      modes/popup/scriptactionsprovider.cc
+      scripting/newscriptwizard.cc
+@@ -227,7 +236,7 @@
+   )
+ 
+   kde_source_files_enable_exceptions(scripting/python_scripter.cc)
++endif(Boost_FOUND)
+-endif(BoostPython_FOUND)
+ 
+ 
+ add_library(kigpart MODULE ${kigpart_PART_SRCS})
+@@ -247,9 +256,9 @@
+   ${KDE5_KUTILS_LIBS}
+ )
+ 
++if(Boost_FOUND)
++  target_link_libraries(kigpart ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARY} ${KDE5_KTEXTEDITOR_LIBS})
++endif(Boost_FOUND)
+-if(BoostPython_FOUND)
+-  target_link_libraries(kigpart ${BoostPython_LIBRARIES} ${KDE5_KTEXTEDITOR_LIBS})
+-endif(BoostPython_FOUND)
+ 
+ if (Qt5XmlPatterns_FOUND)
+   target_link_libraries(kigpart Qt5::XmlPatterns)

--- a/srcpkgs/kig/template
+++ b/srcpkgs/kig/template
@@ -1,7 +1,7 @@
 # Template file for 'kig'
 pkgname=kig
 version=18.12.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules pkg-config python"
 makedepends="boost-devel boost-python kparts-devel ktexteditor-devel python-devel"


### PR DESCRIPTION
@Chocimier The Boost python detection is broken since 1.67, I missed to notice it when updating to Boost 1.68