### PR TITLE
iverilog: add zlib-devel to makedepends

### DIFF
--- a/srcpkgs/iverilog/template
+++ b/srcpkgs/iverilog/template
@@ -1,14 +1,14 @@
 # Template file for 'iverilog'
 pkgname=iverilog
 version=10.2
-revision=1
+revision=2
 wrksrc="${pkgname}-${version/./_}"
 build_style=gnu-configure
 hostmakedepends="automake flex gperf"
-makedepends="readline-devel"
+makedepends="readline-devel zlib-devel"
 short_desc="Verilog simulation and synthesis tool"
 maintainer="Orphaned <orphan@voidlinux.eu>"
-license="GPL-2, LGPL-2.1"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://iverilog.icarus.com/"
 distfiles="https://github.com/steveicarus/iverilog/archive/v${version/./_}.tar.gz"
 checksum=f54d91821223c71c70f4735a1fb2af39c62efbccdeb9b0060ea1cf9c67647ee3


### PR DESCRIPTION
zlib is required for LXT2 format support