### PR TITLE
[TEST] lxd: rebuild for go 1.11.3.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.11.2
+version=1.11.3
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@VoidLinux.eu>"
 homepage="http://golang.org/"
 license="3-clause-BSD"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=042fba357210816160341f1002440550e952eb12678f7c9e7e9d389437942550
+checksum=7ec5140f384db2bd42b396c93c231dfba342ee137ad8a4b33120016951eb1231
 
 nostrip=yes
 noverifyrdeps=yes

--- a/srcpkgs/lxd/template
+++ b/srcpkgs/lxd/template
@@ -1,7 +1,7 @@
 # Template file for 'lxd'
 pkgname=lxd
 version=3.8
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/lxc/lxd"
 go_build_tags="libsqlite3"


### PR DESCRIPTION
This bumps the go version and rebuilds the lxd package. Used to trigger the CI, as maldridge saw a build error but I was unable to.