### PR TITLE
hooks/uncompress-manpages: prevent hang

### DIFF
--- a/common/hooks/post-install/00-uncompress-manpages.sh
+++ b/common/hooks/post-install/00-uncompress-manpages.sh
@@ -20,6 +20,6 @@ hook() {
 		rm $f
 	done
 
-	find $mandir -type f -name '*.gz' -exec gunzip -v {} + &>/dev/null
-	find $mandir -type f -name '*.bz2' -exec bunzip2 -v {} + &>/dev/null
+	find $mandir -type f -name '*.gz' -exec gunzip -v -f {} + &>/dev/null
+	find $mandir -type f -name '*.bz2' -exec bunzip2 -v -f {} + &>/dev/null
 }


### PR DESCRIPTION
In case when file to be uncompressed existed, decompressors asked
whether to overwrite it.
As output is muted, building hung silently waiting for input.