### PR TITLE
update: libxdg-basedir

### DIFF
--- a/srcpkgs/libxdg-basedir/template
+++ b/srcpkgs/libxdg-basedir/template
@@ -1,15 +1,21 @@
 # Template file for 'libxdg-basedir'
 pkgname=libxdg-basedir
 version=1.2.0
-revision=3
+revision=4
+_githash=86ea74ee174c6bee204729293b2b292492d35cb3
+wrksrc="${pkgname}-${_githash}"
 build_style=gnu-configure
+hostmakedepends="autoconf automake libtool"
 short_desc="Implementation of the XDG Base Directory Specifications"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="MIT"
-homepage="http://n.ethz.ch/student/nevillm/download/libxdg-basedir"
-#distfiles="${homepage}/${pkgname}-${version}.tar.gz"
-distfiles="http://pkgs.fedoraproject.org/lookaside/pkgs/${pkgname}/${pkgname}-${version}.tar.gz/027aaf1495f6ffa4b5a563b511d5d3f3/${pkgname}-${version}.tar.gz"
-checksum=dbabd6967130a443003eef8d5df46e518e7c929c56fc0aab6caa135508b874ce
+homepage="https://github.com/devnev/libxdg-basedir"
+distfiles="${homepage}/archive/${_githash}.tar.gz"
+checksum=27013e5f9224f92c6dd4bbdbb67666b7b659850c7f63ef087f7e6047b5a7cbc4
+
+pre_configure() {
+	autoreconf -fi
+}
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Use the latest git commit which fixed a buffer overflow bug.