### PR TITLE
docker: mount systemd cgroup at startup

### DIFF
--- a/srcpkgs/docker/files/docker/run
+++ b/srcpkgs/docker/files/docker/run
@@ -1,4 +1,8 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
 modprobe -q loop || exit 1
+mountpoint -q /sys/fs/cgroup/systemd || {
+    mkdir -p /sys/fs/cgroup/systemd;
+    mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
+}
 exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>/dev/null

--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,7 +1,7 @@
 # Template file for 'docker'
 pkgname=docker
 version=18.09.1
-revision=1
+revision=2
 wrksrc="${pkgname}-ce-${version}"
 hostmakedepends="git go pkg-config curl cmake"
 makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel libapparmor-devel libltdl-devel"


### PR DESCRIPTION
* mount systemd cgroups before running docker to fix error described in [wiki](https://wiki.voidlinux.eu/Docker#Troubleshooting)