### PR TITLE
chroot-bash: make sure to always use bundled termcap library

### DIFF
--- a/srcpkgs/chroot-bash/template
+++ b/srcpkgs/chroot-bash/template
@@ -6,7 +6,10 @@ version="${_bash_distver}.${_bash_patchlevel}"
 revision=1
 wrksrc="bash-${_bash_distver}"
 build_style=gnu-configure
-configure_args="--without-bash-malloc --without-curses --without-installed-readline --disable-nls"
+# need 'bash_cv_termcap_lib=gnutermcap' in order to force bash to use the
+# bundled termcap library when bootstrapping from source on a foreign system
+configure_args="--without-bash-malloc --without-curses
+ --without-installed-readline --disable-nls bash_cv_termcap_lib=gnutermcap"
 short_desc="The GNU Bourne Again Shell -- for xbps-src use"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
When bootstrapping from source on foreign systems with readline
support enabled (even bundled), the build system will always
prefer external terminfo library (e.g. libtinfo.so.6, even
with curses disabled) over the bundled termcap library.

We don't want this to happen as the resulting chroot-bash must
run within the minimal chroot where this external library will
not be present, and it will also break shlibs by introducing
a new shlib not in the shlibs file.