### PR TITLE
chroot-util-linux: disable ncursesw and systemd explicitly

### DIFF
--- a/srcpkgs/chroot-util-linux/template
+++ b/srcpkgs/chroot-util-linux/template
@@ -4,23 +4,23 @@ version=2.32.1
 revision=1
 wrksrc="${pkgname/chroot-/}-${version}"
 bootstrap=yes
-conflicts="util-linux>=0"
-provides="util-linux-${version}_${revision}"
-makedepends="zlib-devel"
 build_style=gnu-configure
-configure_args="--without-ncurses --without-udev --disable-libuuid
---disable-libblkid --disable-libmount --disable-mount --disable-losetup
---disable-fsck --disable-partx --disable-uuidd --disable-mountpoint
---disable-fallocate --disable-unshare --disable-nls --disable-wall
---disable-chfn-chsh-password --disable-su --disable-sulogin
+configure_args="--without-ncurses --without-ncursesw --without-udev
+--without-systemd --disable-libuuid --disable-libblkid --disable-libmount
+--disable-mount --disable-losetup --disable-fsck --disable-partx --disable-uuidd
+--disable-mountpoint --disable-fallocate --disable-unshare --disable-nls
+--disable-wall --disable-chfn-chsh-password --disable-su --disable-sulogin
 --disable-login --disable-runuser --disable-setpriv --disable-libsmartcols
  scanf_cv_alloc_modifier=as"
+makedepends="zlib-devel"
 short_desc="Miscellaneous linux utilities -- for xbps-src use"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2.0-or-later"
 homepage="http://userweb.kernel.org/~kzak/util-linux-ng"
 distfiles="${KERNEL_SITE}/utils/util-linux/v${version%.*}/util-linux-${version}.tar.xz"
 checksum=86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2
+conflicts="util-linux>=0"
+provides="util-linux-${version}_${revision}"
 
 if [ -z "$CHROOT_READY" ]; then
 	CFLAGS+=" -I${XBPS_MASTERDIR}/usr/include"


### PR DESCRIPTION
On non-Void systems, this introduces wrong shlibs during boostrap
so we need to disable them explicitly to prevent the linkage.

It does not introduce any functional changes for our existing packages built in a Void environment.