### PR TITLE
ocl-icd: fix broken distfile url

### DIFF
--- a/srcpkgs/ocl-icd/template
+++ b/srcpkgs/ocl-icd/template
@@ -1,19 +1,23 @@
 # Template file for 'ocl-icd'
 pkgname=ocl-icd
 version=2.2.12
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="ruby xmlto asciidoc"
+hostmakedepends="ruby xmlto asciidoc automake libtool"
 makedepends="opencl2-headers"
 short_desc="Generic OpenCL ICD loader/demultiplexer"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="https://forge.imag.fr/projects/ocl-icd/"
 license="BSD-2-Clause"
-distfiles="https://forge.imag.fr/frs/download.php/836/${pkgname}-${version}.tar.gz"
-checksum=7665f368354e3d2b7787ba4a23c6f061db1181195ba1914dd1cdcd462eca4df4
+homepage="https://forge.imag.fr/projects/ocl-icd/"
+distfiles="https://github.com/OCL-dev/${pkgname}/archive/v${version}.tar.gz"
+checksum=17500e5788304eef5b52dbe784cec197bdae64e05eecf38317840d2d05484272
 
 provides="libOpenCL-1.2_1"
 replaces="libOpenCL>=0"
+
+pre_configure() {
+	./bootstrap
+}
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
I'm not sure if pointing it to our own sources like this is a good idea, but the original URL is down and there doesn't seem to be any other mirror with the tarball.