### PR TITLE
rtmpdump: fix broken distfile url

### DIFF
--- a/srcpkgs/rtmpdump/template
+++ b/srcpkgs/rtmpdump/template
@@ -7,9 +7,9 @@ create_wrksrc=yes
 makedepends="zlib-devel libressl-devel"
 short_desc="Toolkit for RTMP streams"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://rtmpdump.mplayerhq.hu/"
 license="GPL-2, LGPL-2.1"
-distfiles="http://dev.gentoo.org/~hwoarang/distfiles/${pkgname}-${version%.*}_p${_patchlevel}.tar.gz"
+homepage="http://rtmpdump.mplayerhq.hu/"
+distfiles="https://alpha.de.repo.voidlinux.org/distfiles/${pkgname}-${version%.*}_p${_patchlevel}.tar.gz"
 checksum=d6da3b683f1045f02d94a81b0c583318dba021f69bdab970c5d5d73e8c38860f
 
 CFLAGS="-Wno-unused-const-variable -Wno-unused-but-set-variable"


### PR DESCRIPTION
I'm not sure if pointing it to our own sources like this is a good idea, but the original URL is down and there doesn't seem to be any other mirror with the tarball.