### PR TITLE
xbps: backport macro conflict fix

### DIFF
--- a/srcpkgs/xbps/patches/fix-namespace-violation.patch
+++ b/srcpkgs/xbps/patches/fix-namespace-violation.patch
@@ -1,0 +1,475 @@
+From 0f338597015271ee504100c32fd2c4926efdb423 Mon Sep 17 00:00:00 2001
+From: Foxlet <foxlet@furcode.co>
+Date: Tue, 17 Jul 2018 22:24:26 -0400
+Subject: [PATCH] Fix namespace violation
+
+---
+ bin/xbps-alternatives/main.c        |  2 +-
+ bin/xbps-create/main.c              |  4 +--
+ bin/xbps-install/main.c             |  4 +--
+ bin/xbps-install/state_cb.c         |  2 +-
+ bin/xbps-pkgdb/check.c              |  6 ++---
+ bin/xbps-pkgdb/check_pkg_unneeded.c |  2 +-
+ bin/xbps-query/list.c               | 38 ++++++++++++++---------------
+ bin/xbps-query/ownedby.c            | 10 ++++----
+ bin/xbps-query/search.c             |  8 +++---
+ bin/xbps-reconfigure/main.c         |  2 +-
+ bin/xbps-remove/clean-cache.c       |  4 +--
+ bin/xbps-remove/main.c              |  2 +-
+ bin/xbps-rindex/index-clean.c       |  4 +--
+ bin/xbps-rindex/remove-obsoletes.c  |  2 +-
+ bin/xbps-uchroot/main.c             |  4 +--
+ configure                           |  2 +-
+ lib/package_orphans.c               |  2 +-
+ lib/plist_fetch.c                   |  6 ++---
+ lib/rpool.c                         |  6 ++---
+ lib/transaction_conflicts.c         |  2 +-
+ 20 files changed, 56 insertions(+), 56 deletions(-)
+
+diff --git bin/xbps-alternatives/main.c bin/xbps-alternatives/main.c
+index c722a74b..94ab31e8 100644
+--- bin/xbps-alternatives/main.c
++++ bin/xbps-alternatives/main.c
+@@ -55,7 +55,7 @@ usage(bool fail)
+ }
+ 
+ static int
+-state_cb(const struct xbps_state_cb_data *xscd, void *cbd _unused)
++state_cb(const struct xbps_state_cb_data *xscd, void *cbd UNUSED)
+ {
+ 	bool slog = false;
+ 
+diff --git bin/xbps-create/main.c bin/xbps-create/main.c
+index aac9676a..2c211215 100644
+--- bin/xbps-create/main.c
++++ bin/xbps-create/main.c
+@@ -199,7 +199,7 @@ process_one_alternative(const char *altgrname, const char *val)
+ 
+ 
+ static void
+-process_dict_of_arrays(const char *key _unused, const char *val)
++process_dict_of_arrays(const char *key UNUSED, const char *val)
+ {
+ 	char *altgrname, *args, *p, *saveptr;
+ 
+@@ -302,7 +302,7 @@ entry_is_conf_file(const char *file)
+ }
+ 
+ static int
+-ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir _unused)
++ftw_cb(const char *fpath, const struct stat *sb, const struct dirent *dir UNUSED)
+ {
+ 	struct xentry *xe = NULL;
+ 	xbps_dictionary_t fileinfo = NULL;
+diff --git bin/xbps-install/main.c bin/xbps-install/main.c
+index b57f2fe9..da20da1a 100644
+--- bin/xbps-install/main.c
++++ bin/xbps-install/main.c
+@@ -68,7 +68,7 @@ usage(bool fail)
+ }
+ 
+ static void
+-unpack_progress_cb(const struct xbps_unpack_cb_data *xpd, void *cbdata _unused)
++unpack_progress_cb(const struct xbps_unpack_cb_data *xpd, void *cbdata UNUSED)
+ {
+ 	if (xpd->entry == NULL || xpd->entry_total_count <= 0)
+ 		return;
+@@ -80,7 +80,7 @@ unpack_progress_cb(const struct xbps_unpack_cb_data *xpd, void *cbdata _unused)
+ }
+ 
+ static int
+-repo_import_key_cb(struct xbps_repo *repo, void *arg _unused, bool *done _unused)
++repo_import_key_cb(struct xbps_repo *repo, void *arg UNUSED, bool *done UNUSED)
+ {
+ 	int rv;
+ 
+diff --git bin/xbps-install/state_cb.c bin/xbps-install/state_cb.c
+index 5189b9a9..a2063cea 100644
+--- bin/xbps-install/state_cb.c
++++ bin/xbps-install/state_cb.c
+@@ -32,7 +32,7 @@
+ #include "defs.h"
+ 
+ int
+-state_cb(const struct xbps_state_cb_data *xscd, void *cbdata _unused)
++state_cb(const struct xbps_state_cb_data *xscd, void *cbdata UNUSED)
+ {
+ 	xbps_dictionary_t pkgd;
+ 	const char *instver, *newver;
+diff --git bin/xbps-pkgdb/check.c bin/xbps-pkgdb/check.c
+index ed393398..6ae11db7 100644
+--- bin/xbps-pkgdb/check.c
++++ bin/xbps-pkgdb/check.c
+@@ -36,11 +36,11 @@
+ #include "defs.h"
+ 
+ static int
+-pkgdb_cb(struct xbps_handle *xhp _unused,
++pkgdb_cb(struct xbps_handle *xhp UNUSED,
+ 		xbps_object_t obj,
+-		const char *key _unused,
++		const char *key UNUSED,
+ 		void *arg,
+-		bool *done _unused)
++		bool *done UNUSED)
+ {
+ 	const char *pkgver;
+ 	char *pkgname;
+diff --git bin/xbps-pkgdb/check_pkg_unneeded.c bin/xbps-pkgdb/check_pkg_unneeded.c
+index d2249304..2b137b3f 100644
+--- bin/xbps-pkgdb/check_pkg_unneeded.c
++++ bin/xbps-pkgdb/check_pkg_unneeded.c
+@@ -43,7 +43,7 @@
+  * 	  and remove them if that was true.
+  */
+ int
+-check_pkg_unneeded(struct xbps_handle *xhp _unused, const char *pkgname, void *arg)
++check_pkg_unneeded(struct xbps_handle *xhp UNUSED, const char *pkgname, void *arg)
+ {
+ 	xbps_array_t replaces;
+ 	xbps_dictionary_t pkgd = arg;
+diff --git bin/xbps-query/list.c bin/xbps-query/list.c
+index ddda8be8..f08334c3 100644
+--- bin/xbps-query/list.c
++++ bin/xbps-query/list.c
+@@ -38,11 +38,11 @@ struct list_pkgver_cb {
+ };
+ 
+ int
+-list_pkgs_in_dict(struct xbps_handle *xhp _unused,
++list_pkgs_in_dict(struct xbps_handle *xhp UNUSED,
+ 		  xbps_object_t obj,
+-		  const char *key _unused,
++		  const char *key UNUSED,
+ 		  void *arg,
+-		  bool *loop_done _unused)
++		  bool *loop_done UNUSED)
+ {
+ 	struct list_pkgver_cb *lpc = arg;
+ 	const char *pkgver, *short_desc, *state_str;
+@@ -88,11 +88,11 @@ list_pkgs_in_dict(struct xbps_handle *xhp _unused,
+ }
+ 
+ int
+-list_manual_pkgs(struct xbps_handle *xhp _unused,
++list_manual_pkgs(struct xbps_handle *xhp UNUSED,
+ 		 xbps_object_t obj,
+-		 const char *key _unused,
+-		 void *arg _unused,
+-		 bool *loop_done _unused)
++		 const char *key UNUSED,
++		 void *arg UNUSED,
++		 bool *loop_done UNUSED)
+ {
+ 	const char *pkgver;
+ 	bool automatic = false;
+@@ -107,11 +107,11 @@ list_manual_pkgs(struct xbps_handle *xhp _unused,
+ }
+ 
+ int
+-list_hold_pkgs(struct xbps_handle *xhp _unused,
++list_hold_pkgs(struct xbps_handle *xhp UNUSED,
+ 		xbps_object_t obj,
+-		const char *key _unused,
+-		void *arg _unused,
+-		bool *loop_done _unused)
++		const char *key UNUSED,
++		void *arg UNUSED,
++		bool *loop_done UNUSED)
+ {
+ 	const char *pkgver;
+ 
+@@ -124,11 +124,11 @@ list_hold_pkgs(struct xbps_handle *xhp _unused,
+ }
+ 
+ int
+-list_repolock_pkgs(struct xbps_handle *xhp _unused,
++list_repolock_pkgs(struct xbps_handle *xhp UNUSED,
+ 		xbps_object_t obj,
+-		const char *key _unused,
+-		void *arg _unused,
+-		bool *loop_done _unused)
++		const char *key UNUSED,
++		void *arg UNUSED,
++		bool *loop_done UNUSED)
+ {
+ 	const char *pkgver;
+ 
+@@ -171,7 +171,7 @@ list_pkgs_pkgdb(struct xbps_handle *xhp)
+ }
+ 
+ static int
+-repo_list_uri_cb(struct xbps_repo *repo, void *arg _unused, bool *done _unused)
++repo_list_uri_cb(struct xbps_repo *repo, void *arg UNUSED, bool *done UNUSED)
+ {
+ 	const char *signedby = NULL;
+ 	uint16_t pubkeysize = 0;
+@@ -219,11 +219,11 @@ struct fflongest {
+ };
+ 
+ static int
+-_find_longest_pkgver_cb(struct xbps_handle *xhp _unused,
++_find_longest_pkgver_cb(struct xbps_handle *xhp UNUSED,
+ 			xbps_object_t obj,
+-			const char *key _unused,
++			const char *key UNUSED,
+ 			void *arg,
+-			bool *loop_done _unused)
++			bool *loop_done UNUSED)
+ {
+ 	struct fflongest *ffl = arg;
+ 	const char *pkgver;
+diff --git bin/xbps-query/ownedby.c bin/xbps-query/ownedby.c
+index fc8684dc..11f76a99 100644
+--- bin/xbps-query/ownedby.c
++++ bin/xbps-query/ownedby.c
+@@ -97,9 +97,9 @@ match_files_by_pattern(xbps_dictionary_t pkg_filesd,
+ static int
+ ownedby_pkgdb_cb(struct xbps_handle *xhp,
+ 		xbps_object_t obj,
+-		const char *obj_key _unused,
++		const char *obj_key UNUSED,
+ 		void *arg,
+-		bool *done _unused)
++		bool *done UNUSED)
+ {
+ 	xbps_dictionary_t pkgmetad;
+ 	xbps_array_t files_keys;
+@@ -129,9 +129,9 @@ ownedby_pkgdb_cb(struct xbps_handle *xhp,
+ static int
+ repo_match_cb(struct xbps_handle *xhp,
+ 		xbps_object_t obj,
+-		const char *key _unused,
++		const char *key UNUSED,
+ 		void *arg,
+-		bool *done _unused)
++		bool *done UNUSED)
+ {
+ 	xbps_dictionary_t filesd;
+ 	xbps_array_t files_keys;
+@@ -163,7 +163,7 @@ repo_match_cb(struct xbps_handle *xhp,
+ }
+ 
+ static int
+-repo_ownedby_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
++repo_ownedby_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
+ {
+ 	xbps_array_t allkeys;
+ 	struct ffdata *ffd = arg;
+diff --git bin/xbps-query/search.c bin/xbps-query/search.c
+index 4b7ef054..41e1211d 100644
+--- bin/xbps-query/search.c
++++ bin/xbps-query/search.c
+@@ -94,11 +94,11 @@ print_results(struct xbps_handle *xhp, struct search_data *sd)
+ }
+ 
+ static int
+-search_array_cb(struct xbps_handle *xhp _unused,
++search_array_cb(struct xbps_handle *xhp UNUSED,
+ 		xbps_object_t obj,
+-		const char *key _unused,
++		const char *key UNUSED,
+ 		void *arg,
+-		bool *done _unused)
++		bool *done UNUSED)
+ {
+ 	xbps_object_t obj2;
+ 	struct search_data *sd = arg;
+@@ -210,7 +210,7 @@ search_array_cb(struct xbps_handle *xhp _unused,
+ }
+ 
+ static int
+-search_repo_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
++search_repo_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
+ {
+ 	xbps_array_t allkeys;
+ 	struct search_data *sd = arg;
+diff --git bin/xbps-reconfigure/main.c bin/xbps-reconfigure/main.c
+index 814959a8..1508c375 100644
+--- bin/xbps-reconfigure/main.c
++++ bin/xbps-reconfigure/main.c
+@@ -52,7 +52,7 @@ usage(bool fail)
+ }
+ 
+ static int
+-state_cb(const struct xbps_state_cb_data *xscd, void *cbd _unused)
++state_cb(const struct xbps_state_cb_data *xscd, void *cbd UNUSED)
+ {
+ 	bool slog = false;
+ 
+diff --git bin/xbps-remove/clean-cache.c bin/xbps-remove/clean-cache.c
+index dacc9a59..b3e00622 100644
+--- bin/xbps-remove/clean-cache.c
++++ bin/xbps-remove/clean-cache.c
+@@ -38,8 +38,8 @@
+ 
+ static int
+ cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj,
+-		const char *key _unused, void *arg,
+-		bool *done _unused)
++		const char *key UNUSED, void *arg,
++		bool *done UNUSED)
+ {
+ 	xbps_dictionary_t repo_pkgd;
+ 	const char *binpkg, *rsha256;
+diff --git bin/xbps-remove/main.c bin/xbps-remove/main.c
+index 25554e8c..838e610b 100644
+--- bin/xbps-remove/main.c
++++ bin/xbps-remove/main.c
+@@ -64,7 +64,7 @@ usage(bool fail)
+ }
+ 
+ static int
+-state_cb_rm(const struct xbps_state_cb_data *xscd, void *cbdata _unused)
++state_cb_rm(const struct xbps_state_cb_data *xscd, void *cbdata UNUSED)
+ {
+ 	bool slog = false;
+ 
+diff --git bin/xbps-rindex/index-clean.c bin/xbps-rindex/index-clean.c
+index 364d57ed..27cedd6e 100644
+--- bin/xbps-rindex/index-clean.c
++++ bin/xbps-rindex/index-clean.c
+@@ -47,9 +47,9 @@ struct CleanerCbInfo {
+ static int
+ idx_cleaner_cb(struct xbps_handle *xhp,
+ 		xbps_object_t obj,
+-		const char *key _unused,
++		const char *key UNUSED,
+ 		void *arg,
+-		bool *done _unused)
++		bool *done UNUSED)
+ {
+ 	struct CleanerCbInfo *info = arg;
+ 	const char *arch, *pkgver, *sha256;
+diff --git bin/xbps-rindex/remove-obsoletes.c bin/xbps-rindex/remove-obsoletes.c
+index f426fe7c..80cf2fff 100644
+--- bin/xbps-rindex/remove-obsoletes.c
++++ bin/xbps-rindex/remove-obsoletes.c
+@@ -65,7 +65,7 @@ remove_pkg(const char *repodir, const char *file)
+ }
+ 
+ static int
+-cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj, const char *key _unused, void *arg, bool *done _unused)
++cleaner_cb(struct xbps_handle *xhp, xbps_object_t obj, const char *key UNUSED, void *arg, bool *done UNUSED)
+ {
+ 	struct xbps_repo *repo = ((struct xbps_repo **)arg)[0], *stage = ((struct xbps_repo **)arg)[1];
+ 	const char *binpkg;
+diff --git bin/xbps-uchroot/main.c bin/xbps-uchroot/main.c
+index 0ee13253..c232de8e 100644
+--- bin/xbps-uchroot/main.c
++++ bin/xbps-uchroot/main.c
+@@ -109,8 +109,8 @@ die(const char *fmt, ...)
+ }
+ 
+ static int
+-ftw_cb(const char *fpath, const struct stat *sb _unused, int type,
+-		struct FTW *ftwbuf _unused)
++ftw_cb(const char *fpath, const struct stat *sb UNUSED, int type,
++		struct FTW *ftwbuf UNUSED)
+ {
+ 	int sverrno = 0;
+ 
+diff --git configure configure
+index 32cc5569..ebef990a 100755
+--- configure
++++ configure
+@@ -192,7 +192,7 @@ echo "CPPFLAGS +=	-DXBPS_SYSCONF_PATH=\\\"${ETCDIR}\\\"" >>$CONFIG_MK
+ echo "CPPFLAGS +=	-DXBPS_SYSDEFCONF_PATH=\\\"${SHAREDIR}/xbps.d\\\"" >>$CONFIG_MK
+ echo "CPPFLAGS +=	-DXBPS_VERSION=\\\"${VERSION}\\\"" >>$CONFIG_MK
+ echo "CPPFLAGS +=	-DXBPS_META_PATH=\\\"${DBDIR}\\\"" >>$CONFIG_MK
+-echo "CPPFLAGS +=	-D_unused=\"__attribute__((__unused__))\"" >>$CONFIG_MK
++echo "CPPFLAGS +=	-DUNUSED=\"__attribute__((__unused__))\"" >>$CONFIG_MK
+ 
+ if [ -d .git ]; then
+ 	_gitrev=$(git rev-parse --short HEAD)
+diff --git lib/package_orphans.c lib/package_orphans.c
+index 4a31fe1d..b908c049 100644
+--- lib/package_orphans.c
++++ lib/package_orphans.c
+@@ -60,7 +60,7 @@
+  */
+ 
+ xbps_array_t
+-xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user _unused)
++xbps_find_pkg_orphans(struct xbps_handle *xhp, xbps_array_t orphans_user UNUSED)
+ {
+ 	xbps_array_t rdeps, reqby, array = NULL;
+ 	xbps_dictionary_t pkgd, deppkgd;
+diff --git lib/plist_fetch.c lib/plist_fetch.c
+index a1535515..fedd8ce8 100644
+--- lib/plist_fetch.c
++++ lib/plist_fetch.c
+@@ -46,7 +46,7 @@ struct fetch_archive {
+ };
+ 
+ static int
+-fetch_archive_open(struct archive *a _unused, void *client_data)
++fetch_archive_open(struct archive *a UNUSED, void *client_data)
+ {
+ 	struct fetch_archive *f = client_data;
+ 
+@@ -59,7 +59,7 @@ fetch_archive_open(struct archive *a _unused, void *client_data)
+ }
+ 
+ static ssize_t
+-fetch_archive_read(struct archive *a _unused, void *client_data, const void **buf)
++fetch_archive_read(struct archive *a UNUSED, void *client_data, const void **buf)
+ {
+ 	struct fetch_archive *f = client_data;
+ 
+@@ -68,7 +68,7 @@ fetch_archive_read(struct archive *a _unused, void *client_data, const void **bu
+ }
+ 
+ static int
+-fetch_archive_close(struct archive *a _unused, void *client_data)
++fetch_archive_close(struct archive *a UNUSED, void *client_data)
+ {
+ 	struct fetch_archive *f = client_data;
+ 
+diff --git lib/rpool.c lib/rpool.c
+index 9acc1181..94af7298 100644
+--- lib/rpool.c
++++ lib/rpool.c
+@@ -120,7 +120,7 @@ xbps_rpool_get_repo(const char *url)
+ }
+ 
+ void
+-xbps_rpool_release(struct xbps_handle *xhp _unused)
++xbps_rpool_release(struct xbps_handle *xhp UNUSED)
+ {
+ 	struct xbps_repo *repo;
+ 
+@@ -195,7 +195,7 @@ find_pkg_cb(struct xbps_repo *repo, void *arg, bool *done)
+ }
+ 
+ static int
+-find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
++find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
+ {
+ 	struct rpool_fpkg *rpf = arg;
+ 	xbps_array_t revdeps = NULL;
+@@ -216,7 +216,7 @@ find_pkg_revdeps_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
+ }
+ 
+ static int
+-find_best_pkg_cb(struct xbps_repo *repo, void *arg, bool *done _unused)
++find_best_pkg_cb(struct xbps_repo *repo, void *arg, bool *done UNUSED)
+ {
+ 	struct rpool_fpkg *rpf = arg;
+ 	xbps_dictionary_t pkgd;
+diff --git lib/transaction_conflicts.c lib/transaction_conflicts.c
+index 09975cee..387895a4 100644
+--- lib/transaction_conflicts.c
++++ lib/transaction_conflicts.c
+@@ -148,7 +148,7 @@ pkg_conflicts_trans(struct xbps_handle *xhp, xbps_array_t array,
+ 
+ static int
+ pkgdb_conflicts_cb(struct xbps_handle *xhp, xbps_object_t obj,
+-		const char *key _unused, void *arg, bool *done _unused)
++		const char *key UNUSED, void *arg, bool *done UNUSED)
+ {
+ 	xbps_array_t pkg_cflicts, trans_cflicts, pkgs = arg;
+ 	xbps_dictionary_t pkgd;
+-- 
+2.19.1
+


### PR DESCRIPTION
xbps defined the macro _unused, which violates the C standard and
conflicts with a struct field name on ppc64 linux.

This does not fail on x86 platforms, but is necessary to have xbps build on ppc; the commit is already in upstream xbps. I intend to be upstreaming a ppc64 port in the coming days, so this is one of the preparatory steps. I did not bump the revision because it doesn't introduce any functional change, just a build fix for specific platforms.