### PR TITLE
emacs: Backport fixes for Bug#21559 to fix magit issue #2708

### DIFF
--- a/srcpkgs/emacs/patches/0001-Fix-for-25.0.50-auto-revert-mode-breaks-git-rebase-B.patch
+++ b/srcpkgs/emacs/patches/0001-Fix-for-25.0.50-auto-revert-mode-breaks-git-rebase-B.patch
@@ -1,0 +1,55 @@
+From 6a11fbebd8459a987a2e5878b468e5f1f9e0dd75 Mon Sep 17 00:00:00 2001
+From: Alexei Khlebnikov <alexei.khlebnikov@gmail.com>
+Date: Thu, 22 Feb 2018 12:21:49 +0100
+Subject: [PATCH 1/2] Fix for: "25.0.50; auto-revert-mode breaks git rebase"
+ (Bug#21559)
+
+* lisp/autorevert.el (auto-revert-handler):
+Set "revert-buffer-in-progress-p" flag before calling
+"vc-refresh-state".
+
+* lisp/vc/vc-git.el (vc-git-command):
+If "revert-buffer-in-progress-p" flag is set, prepend
+"GIT_OPTIONAL_LOCKS=0" to "process-environment".  (Bug#21559)
+---
+ lisp/autorevert.el | 3 ++-
+ lisp/vc/vc-git.el  | 9 ++++++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git lisp/autorevert.el lisp/autorevert.el
+index 7b8302695f..13cc25043d 100644
+--- lisp/autorevert.el
++++ lisp/autorevert.el
+@@ -719,7 +719,8 @@ This is an internal function used by Auto-Revert Mode."
+     ;; `preserve-modes' avoids changing the (minor) modes.  But we do
+     ;; want to reset the mode for VC, so we do it manually.
+     (when (or revert auto-revert-check-vc-info)
+-      (vc-refresh-state))))
++      (let ((revert-buffer-in-progress-p t))
++        (vc-refresh-state)))))
+ 
+ (defun auto-revert-tail-handler (size)
+   (let ((modified (buffer-modified-p))
+diff --git lisp/vc/vc-git.el lisp/vc/vc-git.el
+index efe853e5ee..0cea5334f4 100644
+--- lisp/vc/vc-git.el
++++ lisp/vc/vc-git.el
+@@ -1564,7 +1564,14 @@ The difference to vc-do-command is that this function always invokes
+          (or coding-system-for-read vc-git-log-output-coding-system))
+ 	(coding-system-for-write
+          (or coding-system-for-write vc-git-commits-coding-system))
+-        (process-environment (cons "GIT_DIR" process-environment)))
++        (process-environment
++         (append
++          `("GIT_DIR"
++            ;; Avoid repository locking during background operations
++            ;; (bug#21559).
++            ,@(when revert-buffer-in-progress-p
++                '("GIT_OPTIONAL_LOCKS=0")))
++          process-environment)))
+     (apply 'vc-do-command (or buffer "*vc*") okstatus vc-git-program
+ 	   ;; https://debbugs.gnu.org/16897
+ 	   (unless (and (not (cdr-safe file-or-list))
+-- 
+2.19.0
+

--- a/srcpkgs/emacs/patches/0002-vc-git.el-make-sure-bug-21559-applies-to-git-status.patch
+++ b/srcpkgs/emacs/patches/0002-vc-git.el-make-sure-bug-21559-applies-to-git-status.patch
@@ -1,0 +1,40 @@
+From 1842a410263aa9d6ddd23efc7603122f9ce6bcb3 Mon Sep 17 00:00:00 2001
+From: Andrew Ruder <andy@aeruder.net>
+Date: Mon, 24 Sep 2018 21:29:00 -0700
+Subject: [PATCH 2/2] vc-git.el: make sure bug#21559 applies to git status
+
+The fix for Bug#21559 is mostly right, but the one command we were
+trying to protect, git status --porcelain, doesn't go through
+vc-git-command and doesn't actually get the GIT_OPTIONAL_LOCKS=0 treatment.
+
+* lisp/vc/vc-git.el (vc-git--call): Override GIT_OPTIONAL_LOCKS=0
+  during revert-buffer-in-progress-p
+---
+ lisp/vc/vc-git.el | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git lisp/vc/vc-git.el lisp/vc/vc-git.el
+index 0cea5334f4..e779109191 100644
+--- lisp/vc/vc-git.el
++++ lisp/vc/vc-git.el
+@@ -1598,8 +1598,15 @@ The difference to vc-do-command is that this function always invokes
+          (or coding-system-for-read vc-git-log-output-coding-system))
+ 	(coding-system-for-write
+          (or coding-system-for-write vc-git-commits-coding-system))
+-	(process-environment (cons "PAGER=" process-environment)))
+-    (push "GIT_DIR" process-environment)
++	(process-environment
++	 (append
++	  `("GIT_DIR"
++	    "PAGER="
++	    ;; Avoid repository locking during background operations
++	    ;; (bug#21559).
++	    ,@(when revert-buffer-in-progress-p
++		'("GIT_OPTIONAL_LOCKS=0")))
++	  process-environment)))
+     (apply 'process-file vc-git-program nil buffer nil command args)))
+ 
+ (defun vc-git--out-ok (command &rest args)
+-- 
+2.19.0
+

--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -1,7 +1,7 @@
 # Template file for 'emacs'
 pkgname=emacs
 version=26.1
-revision=4
+revision=5
 build_style="gnu-configure"
 configure_args="--with-file-notification=inotify --with-modules
  $(vopt_with jpeg) $(vopt_with tiff) $(vopt_with gif) $(vopt_with png)


### PR DESCRIPTION
Backport fixes for emacs Bug#21559 (25.0.50; auto-revert-mode breaks git rebase)
in order to fix magit issue #2708 (Make magit more robust in the face of
transient index.lock collisions).

References:

- Emacs Bug#21559 <https://debbugs.gnu.org/cgi/bugreport.cgi?bug=21559>

- Magit issue #2708 <https://github.com/magit/magit/issues/2708>