### PR TITLE
blender: add patches for opencollada-1.6.68

### DIFF
--- a/srcpkgs/blender/patches/collada-1.6.68_DocumentImporter.cpp.patch
+++ b/srcpkgs/blender/patches/collada-1.6.68_DocumentImporter.cpp.patch
@@ -1,0 +1,14 @@
+--- a/source/blender/collada/DocumentImporter.cpp
++++ b/source/blender/collada/DocumentImporter.cpp
+@@ -1340,6 +1340,11 @@ bool DocumentImporter::writeAnimationLis
+ 	return anim_importer.write_animation_list(animationList);
+ }
+ 
++bool DocumentImporter::writeAnimationClip(const COLLADAFW::AnimationClip *AnimationClip)
++{
++	return true;
++}
++
+ /** When this method is called, the writer must write the skin controller data.
+  * \return The writer should return true, if writing succeeded, false otherwise.*/
+ bool DocumentImporter::writeSkinControllerData(const COLLADAFW::SkinControllerData *skin)

--- a/srcpkgs/blender/patches/collada-1.6.68_DocumentImporter.h.patch
+++ b/srcpkgs/blender/patches/collada-1.6.68_DocumentImporter.h.patch
@@ -1,0 +1,11 @@
+--- a/source/blender/collada/DocumentImporter.h.orig	2018-12-03 07:38:12 UTC
++++ b/source/blender/collada/DocumentImporter.h
+@@ -107,6 +107,8 @@ public:
+ 	bool writeAnimation(const COLLADAFW::Animation*);
+ 
+ 	bool writeAnimationList(const COLLADAFW::AnimationList*);
++	
++	bool writeAnimationClip( const COLLADAFW::AnimationClip* );
+ 
+ 	bool writeGeometry(const COLLADAFW::Geometry*);
+ 


### PR DESCRIPTION
The Current repo version doesn't build without patching it. Patches taken form FreeBSD.