### PR TITLE
python-google-auth: update to 1.6.2.

### DIFF
--- a/srcpkgs/python-google-auth/template
+++ b/srcpkgs/python-google-auth/template
@@ -1,6 +1,6 @@
 # Template file for 'python-google-auth'
 pkgname=python-google-auth
-version=1.6.1
+version=1.6.2
 revision=1
 noarch=yes
 wrksrc="${pkgname#*-}-${version}"
@@ -13,7 +13,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/GoogleCloudPlatform/google-auth-library-python"
 distfiles="${PYPI_SITE}/g/google-auth/google-auth-${version}.tar.gz"
-checksum=b08a27888e9d1c17a891b3688aacc9c6f2019d7f6c5a2e73588e6bb9a2c0fa98
+checksum=e8d64e9bc8cb6f0fc5360c693f86dc9ee6964081ee702e3b5ddc937f99efc950
 
 python3-google-auth_package() {
 	noarch=yes


### PR DESCRIPTION
Yes i am aware 2.7 is deprecated now