### PR TITLE
sonic-visualiser: update to 3.2

### DIFF
--- a/srcpkgs/sonic-visualiser/patches/crash-on-exit-fix.patch
+++ b/srcpkgs/sonic-visualiser/patches/crash-on-exit-fix.patch
@@ -1,0 +1,44 @@
+Source: upstream
+https://code.soundsoftware.ac.uk/projects/svapp/repository/revisions/fffb78793ca7
+https://code.soundsoftware.ac.uk/projects/svapp/repository/revisions/f54722b34c3a
+
+diff -r f54722b34c3a -r fffb78793ca7 framework/MainWindowBase.cpp
+--- svapp/framework/MainWindowBase.cpp
++++ svapp/framework/MainWindowBase.cpp
+@@ -277,8 +277,8 @@
+     connect(m_viewManager, SIGNAL(viewCentreFrameChanged(View *, sv_frame_t)),
+             this, SLOT(viewCentreFrameChanged(View *, sv_frame_t)));
+ 
+-    connect(m_viewManager, SIGNAL(viewZoomLevelChanged(View *, int, bool)),
+-            this, SLOT(viewZoomLevelChanged(View *, int, bool)));
++    connect(m_viewManager, SIGNAL(viewZoomLevelChanged(View *, ZoomLevel, bool)),
++            this, SLOT(viewZoomLevelChanged(View *, ZoomLevel, bool)));
+ 
+     connect(Preferences::getInstance(),
+             SIGNAL(propertyChanged(PropertyContainer::PropertyName)),
+diff -r 109a1dd59f45 -r f54722b34c3a framework/MainWindowBase.cpp
+--- svapp/framework/MainWindowBase.cpp
++++ svapp/framework/MainWindowBase.cpp
+@@ -328,14 +328,16 @@
+     delete m_viewManager;
+     delete m_midiInput;
+ 
+-    disconnect(m_oscQueueStarter, 0, 0, 0);
+-    m_oscQueueStarter->wait(1000);
+-    if (m_oscQueueStarter->isRunning()) {
+-        m_oscQueueStarter->terminate();
++    if (m_oscQueueStarter) {
++        disconnect(m_oscQueueStarter, 0, 0, 0);
+         m_oscQueueStarter->wait(1000);
++        if (m_oscQueueStarter->isRunning()) {
++            m_oscQueueStarter->terminate();
++            m_oscQueueStarter->wait(1000);
++        }
++        delete m_oscQueueStarter;
++        delete m_oscQueue;
+     }
+-    delete m_oscQueueStarter;
+-    delete m_oscQueue;
+     
+     Profiles::getInstance()->dump();
+ }

--- a/srcpkgs/sonic-visualiser/template
+++ b/srcpkgs/sonic-visualiser/template
@@ -1,9 +1,9 @@
 # Template file for 'sonic-visualiser'
 pkgname=sonic-visualiser
-version=3.1.1
-revision=2
+version=3.2
+revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config capnproto-devel automake libtool"
+hostmakedepends="pkg-config capnproto-devel"
 makedepends="capnproto-devel jack-devel libfishsound-devel libid3tag-devel
  liblo-devel liblrdf-devel libmad-devel liboggz-devel libsamplerate-devel
  portaudio-devel pulseaudio-devel qt5-svg-devel rubberband-devel sord-devel
@@ -13,8 +13,8 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.sonicvisualiser.org/"
 changelog="https://code.soundsoftware.ac.uk/projects/sonic-visualiser/repository/entry/CHANGELOG"
-distfiles="https://code.soundsoftware.ac.uk/attachments/download/2391/${pkgname}-${version}.tar.gz"
-checksum=d02a0d8c8efc44810b7078311f02d23909b433c50179c0aec55117cde373d0c1
+distfiles="https://code.soundsoftware.ac.uk/attachments/download/2420/${pkgname}-${version}.tar.gz"
+checksum=55f9a5b431b2340c232b87840cce845a762bcc152002e4f679c91ecd46c61293
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-qmake qt5-svg-devel"
@@ -29,15 +29,6 @@ post_extract() {
 		 test-svcore-data-model.pro \
 		 test-svcore-system.pro
 	fi
-
-	sed -e 's/c++11/c++14/g' -i *.pr* configure.ac* svcore/svcore.pro \
-		svapp/svapp.pro checker/*.pr* svgui/svgui.pro {bqaudioio,piper-cpp}/Makefile \
-		piper-cpp/vamp-client/qt/test.pro piper-cpp/ext/json11/Makefile \
-		dataquay/{lib.pro,tests/tests.pro}
-}
-
-pre_configure() {
-	autoreconf -fi
 }
 
 do_install() {
@@ -53,4 +44,3 @@ do_install() {
 	vinstall icons/sv-icon-light.svg 644 usr/share/pixmaps
 	vinstall deploy/linux/deb-skeleton/usr/share/applications/sonic-visualiser.desktop 644 usr/share/applications
 }
-


### PR DESCRIPTION
The patch is from upstream, fixing a segmentation fault on exit which was introduced in version 3.2 and can be removed when the next release is available.

https://code.soundsoftware.ac.uk/projects/svapp/repository/revisions/fffb78793ca7
https://code.soundsoftware.ac.uk/projects/svapp/repository/revisions/f54722b34c3a

Not sure when a new release will be available but the patch is a rather small one. So I hope it’s OK to update now and not wait. :)