### PR TITLE
ImageMagick: update to 7.0.8-18.

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
 _majorver=7.0.8
-_patchver=17
+_patchver=18
 version="${_majorver}.${_patchver}"
 revision=1
 wrksrc="${pkgname}-${_majorver}-${_patchver}"
@@ -20,7 +20,7 @@ maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org/"
 distfiles="https://www.imagemagick.org/download/ImageMagick-${_majorver}-${_patchver}.tar.xz"
-checksum=4a041fcdf54a7beba3596c93be7de0dfea7ed9f45f215a31dce87000c83b9ffc
+checksum=5daac74aed53f8115082bed1e79da85730db71a36d5d625be261b1271a0cacf1
 
 subpackages="libmagick libmagick-devel"
 


### PR DESCRIPTION
ImageMagick updated again, apparently with a minor build fix. For some reason they remove older release archives so it no longer builds without updating.