### PR TITLE
New package: termite-14

### DIFF
--- a/srcpkgs/termite-terminfo
+++ b/srcpkgs/termite-terminfo
@@ -1,0 +1,1 @@
+termite

--- a/srcpkgs/termite/patches/fix-makefile.patch
+++ b/srcpkgs/termite/patches/fix-makefile.patch
@@ -1,0 +1,13 @@
+Upstream: No
+Reason: tarball has no git metadata
+
+diff --git Makefile Makefile
+index b115f42..49030e9 100644
+--- Makefile
++++ Makefile
+@@ -1,4 +1,4 @@
+-VERSION = $(shell git describe --tags)
++VERSION = v14
+ PREFIX = /usr/local
+ GTK = gtk+-3.0
+ VTE = vte-2.91

--- a/srcpkgs/termite/template
+++ b/srcpkgs/termite/template
@@ -1,0 +1,30 @@
+# Template file for 'termite'
+pkgname=termite
+version=14
+revision=1
+_utilcommit=62faf9e
+build_style=gnu-makefile
+hostmakedepends="ncurses pkg-config"
+makedepends="vte3-devel"
+depends="termite-terminfo"
+short_desc="Keyboard-centric VTE-based terminal"
+maintainer="Christian Buschau <christian.buschau@mailbox.org>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/thestinger/termite"
+distfiles="https://github.com/thestinger/termite/archive/v${version}.tar.gz>termite-${version}.tar.gz
+ https://github.com/thestinger/util/archive/${_utilcommit}.tar.gz>util-${_utilcommit}.tar.gz"
+checksum="0ef2ffaf2c7490b958ead45ff93dd5618636cfb5a5449ce4c87d068c748fe722
+ c62be725845c52751d9bd7a8defaff9ad1b29c473c0c279ad64f2cc59befaf2b"
+
+post_extract() {
+	rmdir ${wrksrc}/util
+	mv ../util-${_utilcommit}* ${wrksrc}/util
+}
+
+termite-terminfo_package() {
+	short_desc+=" - terminfo data"
+	noarch=yes
+	pkg_install() {
+		vmove usr/share/terminfo
+	}
+}

--- a/srcpkgs/vte3/patches/vte-ng.patch
+++ b/srcpkgs/vte3/patches/vte-ng.patch
@@ -1,0 +1,178 @@
+Source: `git diff --no-prefix 0.54.2 0.54.2-ng` in https://github.com/thestinger/vte-ng.git
+Upstream: No https://bugzilla.gnome.org/show_bug.cgi?id=679658
+Reason: Exposes parts of the API which termite needs
+
+diff --git src/vte/vteterminal.h src/vte/vteterminal.h
+index 89539cc4..8bdbde30 100644
+--- src/vte/vteterminal.h
++++ src/vte/vteterminal.h
+@@ -175,6 +175,12 @@ void vte_terminal_feed_child_binary(VteTerminal *terminal,
+                                     const guint8 *data,
+                                     gsize length) _VTE_GNUC_NONNULL(1);
+ 
++_VTE_PUBLIC
++void vte_terminal_connect_pty_read(VteTerminal *terminal);
++
++_VTE_PUBLIC
++void vte_terminal_disconnect_pty_read(VteTerminal *terminal);
++
+ /* Copy currently-selected text to the clipboard, or from the clipboard to
+  * the terminal. */
+ _VTE_PUBLIC
+@@ -190,6 +196,17 @@ _VTE_PUBLIC
+ void vte_terminal_select_all(VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
+ _VTE_PUBLIC
+ void vte_terminal_unselect_all(VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++gboolean vte_terminal_get_selection_block_mode(VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++void vte_terminal_set_selection_block_mode(VteTerminal *terminal,
++                                            gboolean block_mode) _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++void vte_terminal_select_text(VteTerminal *terminal, long start_col, long start_row,
++			      long end_col, long end_row) _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++char *
++vte_terminal_get_selection(VteTerminal *terminal) _VTE_GNUC_NONNULL(1);
+ 
+ /* By-word selection */
+ _VTE_PUBLIC
+@@ -377,6 +394,11 @@ _VTE_PUBLIC
+ void vte_terminal_get_cursor_position(VteTerminal *terminal,
+ 				      glong *column,
+                                       glong *row) _VTE_GNUC_NONNULL(1);
++_VTE_PUBLIC
++void vte_terminal_set_cursor_position(VteTerminal *terminal,
++                                      glong column,
++                                      glong row) _VTE_GNUC_NONNULL(1);
++
+ 
+ _VTE_PUBLIC
+ char *vte_terminal_hyperlink_check_event(VteTerminal *terminal,
+diff --git src/vtegtk.cc src/vtegtk.cc
+index 89e3d7a8..0067e58a 100644
+--- src/vtegtk.cc
++++ src/vtegtk.cc
+@@ -2389,6 +2389,58 @@ vte_terminal_unselect_all(VteTerminal *terminal)
+ 
+         IMPL(terminal)->deselect_all();
+ }
++/**
++ * vte_terminal_get_selection_block_mode:
++ * @terminal: a #VteTerminal
++ *
++ * Checks whether or not block selection is enabled.
++ *
++ * Returns: %TRUE if block selection is enabled, %FALSE if not
++ */
++
++gboolean vte_terminal_get_selection_block_mode(VteTerminal *terminal) {
++        g_return_val_if_fail(VTE_IS_TERMINAL(terminal), FALSE);
++	return IMPL(terminal)->m_selection_block_mode;
++}
++/**
++ * vte_terminal_set_selection_block_mode:
++ * @terminal: a #VteTerminal
++ * @block_mode: whether block selection is enabled
++ *
++ * Sets whether or not block selection is enabled.
++ */
++void
++vte_terminal_set_selection_block_mode(VteTerminal *terminal, gboolean block_mode) {
++	g_return_if_fail (VTE_IS_TERMINAL (terminal));
++	IMPL(terminal)->m_selection_block_mode = block_mode;
++}
++
++/**
++ * vte_terminal_select_text:
++ * @terminal: a #VteTerminal
++ * @start_col: the starting column for the selection
++ * @start_row: the starting row for the selection
++ * @end_col: the end column for the selection
++ * @end_row: the end row for the selection
++ *
++ * Sets the current selection region.
++ */
++void
++vte_terminal_select_text(VteTerminal *terminal,
++		         long start_col, long start_row,
++			 long end_col, long end_row)
++{
++	g_return_if_fail (VTE_IS_TERMINAL (terminal));
++
++        IMPL(terminal)->select_text(start_col, start_row, end_col, end_row);
++}
++
++char *
++vte_terminal_get_selection(VteTerminal *terminal)
++{
++	g_return_val_if_fail(VTE_IS_TERMINAL(terminal), NULL);
++	return g_strdup (IMPL(terminal)->m_selection[VTE_SELECTION_PRIMARY]->str);
++}
+ 
+ /**
+  * vte_terminal_get_cursor_position:
+@@ -2415,6 +2467,30 @@ vte_terminal_get_cursor_position(VteTerminal *terminal,
+ 	}
+ }
+ 
++/**
++ * vte_terminal_set_cursor_position
++ * @terminal: a #VteTerminal
++ * @column: the new cursor column
++ * @row: the new cursor row
++ *
++ * Set the location of the cursor.
++ */
++void
++vte_terminal_set_cursor_position(VteTerminal *terminal,
++		                 long column, long row)
++{
++	g_return_if_fail(VTE_IS_TERMINAL(terminal));
++
++        auto impl = IMPL(terminal);
++	impl->invalidate_cursor_once(FALSE);
++	impl->m_screen->cursor.col = column;
++	impl->m_screen->cursor.row = row;
++	impl->invalidate_cursor_once(FALSE);
++	impl->check_cursor_blink();
++	impl->queue_cursor_moved();
++
++}
++
+ /**
+  * vte_terminal_pty_new_sync:
+  * @terminal: a #VteTerminal
+@@ -2780,6 +2856,32 @@ vte_terminal_feed_child(VteTerminal *terminal,
+         IMPL(terminal)->feed_child(text, length);
+ }
+ 
++/**
++ * vte_terminal_connect_pty_read:
++ * @terminal: a #VteTerminal
++ *
++ * Unpause output
++ */
++void
++vte_terminal_connect_pty_read(VteTerminal *terminal)
++{
++	g_return_if_fail(VTE_IS_TERMINAL(terminal));
++	IMPL(terminal)->connect_pty_read();
++}
++
++/**
++ * vte_terminal_disconnect_pty_read:
++ * @terminal: a #VteTerminal
++ *
++ * Pause output
++ */
++void
++vte_terminal_disconnect_pty_read(VteTerminal *terminal)
++{
++	g_return_if_fail(VTE_IS_TERMINAL(terminal));
++	IMPL(terminal)->disconnect_pty_read();
++}
++
+ /**
+  * vte_terminal_feed_child_binary:
+  * @terminal: a #VteTerminal

--- a/srcpkgs/vte3/template
+++ b/srcpkgs/vte3/template
@@ -1,7 +1,7 @@
 # Template file for 'vte3'
 pkgname=vte3
 version=0.54.3
-revision=1
+revision=2
 wrksrc="vte-${version}"
 build_style=gnu-configure
 configure_args="--disable-static


### PR DESCRIPTION
This was already discussed in https://github.com/voidlinux/void-packages/issues/5760 and https://github.com/voidlinux/void-packages/pull/3822. The situation didn't really change since then, upstream won't accept the patch for vte. Termite is special beacause it has full keyboard navigation and it's really easy to adapt the patch for vte3 to future releases, so please consider merging this.