### PR TITLE
brltty: add setuptools host dependency

### DIFF
--- a/srcpkgs/brltty/template
+++ b/srcpkgs/brltty/template
@@ -3,9 +3,9 @@ pkgname=brltty
 version=5.6
 revision=3
 build_style=gnu-configure
-hostmakedepends="pkg-config python3-Cython"
-makedepends="ncurses-devel alsa-lib-devel gpm-devel icu-devel python3-devel libbluetooth-devel"
 configure_args="--enable-gpm --with-screen-driver=lx,sc --with-tables-directory=/usr/share/brltty PYTHON=/usr/bin/python3"
+hostmakedepends="pkg-config python3-Cython python3-setuptools
+makedepends="ncurses-devel alsa-lib-devel gpm-devel icu-devel python3-devel libbluetooth-devel"
 short_desc="Braille display driver for Linux/Unix"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="GPL-2, LGPL-2.1"


### PR DESCRIPTION
This should not even build without it, but somehow it did.

It does not change the result so it doesn't need a revbump.