### PR TITLE
polkit-elogind: add libtool as a host dependency

### DIFF
--- a/srcpkgs/polkit-elogind/template
+++ b/srcpkgs/polkit-elogind/template
@@ -6,8 +6,8 @@ wrksrc="polkit-${version}"
 build_style=gnu-configure
 configure_args="$(vopt_enable gir introspection) --disable-static
  --with-authfw=pam --with-os-type=void --with-mozjs=mozjs-52.0"
-hostmakedepends="automake gettext-devel git glib-devel gobject-introspection
- gtk-doc intltool pkg-config"
+hostmakedepends="automake libtool gettext-devel git glib-devel
+ gobject-introspection gtk-doc intltool pkg-config"
 makedepends="elogind-devel libglib-devel mozjs52-devel pam-devel"
 system_accounts="polkitd"
 short_desc="Authorization Toolkit"


### PR DESCRIPTION
Libtool is needed to bootstrap the autotools configure script,
so it should not build without it. I'm not sure how it did,
but add the dependency properly.

No functional change, so no revbump.