### PR TITLE
gnome-initial-setup: disable software-sources

### DIFF
--- a/srcpkgs/gnome-initial-setup/template
+++ b/srcpkgs/gnome-initial-setup/template
@@ -3,6 +3,7 @@ pkgname=gnome-initial-setup
 version=3.30.0
 revision=1
 build_style=meson
+configure_args="-Dsoftware-sources=disabled"
 hostmakedepends="pkg-config glib-devel"
 makedepends="NetworkManager-devel accountsservice-devel libglib-devel
  gnome-desktop-devel cheese-devel libgweather-devel webkit2gtk-devel


### PR DESCRIPTION
We do not have packagekit in the repository, upon which this feature depends. It seems to complain at least on my system, so disable it explicitly.

No revbump, because it must have been building with the feature disabled in the first place.