### PR TITLE
build-styles: Add support for Go modules.

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1324,6 +1324,10 @@ The following variables influence how Go packages are built:
   packages; using a versioned distfile is preferred.
 - `go_build_tags`: An optional, space-separated list of build tags to
   pass to Go.
+- `go_mod_mode`: The module download mode to use. May be `off` to ignore
+  any go.mod files, `default` to use Go's default behavior, or anything
+  accepted by `go build -mod MODE`.  Defaults to `vendor` if there's
+  a vendor directory, otherwise `default`.
 
 Occasionally it is necessary to perform operations from within the Go
 source tree.  This is usually needed by programs using go-bindata or


### PR DESCRIPTION
Adds support for Go modules by detecting a go.mod file and, if
available, using it. In addition, to continue supporting vendoring (and
avoid the need for git on all module builds), if a package includes
a vendor directory, the module mode will switch to vendor mode if not
already set. This will use vendored source code for dependencies
instead of downloading that code again using the descriptions under
go.mod.

go_mod_mode=vendor also skips the go.sum check because nothing is
downloaded that isn't already verified, so this fixes packages with
vendored code that have checksum mismatches due to Go 1.11.4 module
checksum changes.