### PR TITLE
libssh: fix distfile url

### DIFF
--- a/srcpkgs/libssh/template
+++ b/srcpkgs/libssh/template
@@ -10,8 +10,8 @@ short_desc="Multiplatform C library implementing the SSH v2 protocol"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="LGPL-2.1-or-later"
 homepage="https://www.libssh.org/"
-distfiles="https://git.libssh.org/projects/libssh.git/snapshot/${pkgname}-${version}.tar.bz2"
-checksum=3160293b02d4ef86ca17ac95302f172b2abe3258bbf8c9ee2950f458832c25c3
+distfiles="https://git.libssh.org/projects/libssh.git/snapshot/${pkgname}-${version}.tar.gz"
+checksum=6921c0b71c2cb455039dc6a53e51bbc11d1d31bd3da9b7becc15348401f062f1
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) configure_args="-DHAVE_GLOB=0" ;;


### PR DESCRIPTION
They no longer offer tar.bz2 archives, so switch to tar.gz and update checksum accordingly.