### PR TITLE
python-Cython: add setuptools to depends

### DIFF
--- a/srcpkgs/python-Cython/template
+++ b/srcpkgs/python-Cython/template
@@ -1,16 +1,17 @@
 # Template file for 'python-Cython'
 pkgname=python-Cython
 version=0.29
-revision=1
+revision=2
 wrksrc="Cython-${version}"
 build_style=python-module
+pycompile_module="Cython pyximport cython.py"
 hostmakedepends="python-devel python3-devel python-setuptools python3-setuptools"
 makedepends="${hostmakedepends}"
-pycompile_module="Cython pyximport cython.py"
+depends="python-setuptools"
 short_desc="C-Extensions for Python2"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://cython.org/"
 license="Apache-2.0"
+homepage="https://cython.org/"
 distfiles="${PYPI_SITE}/C/Cython/Cython-${version}.tar.gz"
 checksum=94916d1ede67682638d3cc0feb10648ff14dc51fb7a7f147f4fedce78eaaea97
 
@@ -31,6 +32,7 @@ python3-Cython_package() {
 	 cython:cythonize:/usr/bin/cythonize3"
 	pycompile_module="Cython pyximport cython.py"
 	short_desc="${short_desc/Python2/Python3}"
+	depends="python3-setuptools"
 	pkg_install() {
 		vmove usr/bin/*3
 		vmove usr/lib/python3*


### PR DESCRIPTION
Without this, packages host-depending on Cython will consistently fail to build, with this error message:

```
Traceback (most recent call last):
  File "/usr/bin/cython3", line 6, in <module>
    from pkg_resources import load_entry_point
```

Instead of adding setuptools to each individual package, it's better to add it to cython, as it's cython itself that fails, see the traceback above. We need setuptools for both host depends (so that cython itself can build, that's already there), and depends (so that when installing cython as a host dependency, it will also pull in the respective native setuptools)