### PR TITLE
owncloudclient: add a shibboleth option

### DIFF
--- a/srcpkgs/owncloudclient/template
+++ b/srcpkgs/owncloudclient/template
@@ -3,11 +3,11 @@ pkgname=owncloudclient
 version=2.4.3
 revision=1
 build_style=cmake
-configure_args="-Wno-dev -DNO_SHIBBOLETH=TRUE"
+configure_args="-Wno-dev -DNO_SHIBBOLETH=$(vopt_if shibboleth FALSE TRUE)"
 hostmakedepends="pkg-config"
 makedepends="qtkeychain-qt5-devel sqlite-devel qt5-declarative-devel
  qt5-tools-devel qt5-plugin-odbc qt5-plugin-tds qt5-plugin-pgsql qt5-plugin-mysql
- qt5-plugin-sqlite"
+ qt5-plugin-sqlite $(vopt_if shibboleth qt5-webkit-devel)"
 depends="qt5-plugin-sqlite"
 conf_files="/etc/ownCloud/sync-exclude.lst"
 short_desc="Connect to ownCloud servers"
@@ -16,6 +16,8 @@ license="GPL-2.0-or-later"
 homepage="https://www.owncloud.org"
 distfiles="https://download.owncloud.com/desktop/stable/${pkgname}-${version}.tar.xz"
 checksum=f3b3ff13d06a8a38a40398630d670775eafbfa9fee4fa5b39ea480bac3ebe6bf
+build_options="shibboleth"
+desc_option_shibboleth="add support for the shibboleth single-sign-on system"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-tools-devel"


### PR DESCRIPTION
In the template, shibboleth is disabled by default.
This can be an inconvenience in environments where it is
used, because it forces the user to sign in on every start
of the client application.