### PR TITLE
libdbusmenu-qt: remove

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1298,7 +1298,6 @@ libphonon.so.4 phonon-4.6.0_1
 libphononexperimental.so.4 phonon-4.6.0_1
 libdbusmenu-glib.so.4 libdbusmenu-glib-12.10.2_1
 libdbusmenu-gtk3.so.4 libdbusmenu-gtk3-12.10.2_1
-libdbusmenu-qt.so.2 libdbusmenu-qt-0.9.2_1
 libGrantlee_Templates.so.5 grantlee5-5.0.0_1
 libGrantlee_TextDocument.so.5 grantlee5-5.0.0_1
 libqca.so.2 qca-2.0.3_1

--- a/srcpkgs/libdbusmenu-qt-devel
+++ b/srcpkgs/libdbusmenu-qt-devel
@@ -1,1 +1,0 @@
-libdbusmenu-qt

--- a/srcpkgs/libdbusmenu-qt/INSTALL.msg
+++ b/srcpkgs/libdbusmenu-qt/INSTALL.msg
@@ -1,0 +1,1 @@
+libdbusmenu-qt is no longer provided by Void Linux, and will be fully removed from the repos on 2019/03/20

--- a/srcpkgs/libdbusmenu-qt/template
+++ b/srcpkgs/libdbusmenu-qt/template
@@ -1,22 +1,9 @@
 # Template file for 'libdbusmenu-qt'
 pkgname=libdbusmenu-qt
 version=0.9.2
-revision=3
-build_style=cmake
-hostmakedepends="doxygen qt-host-tools qt-devel"
-makedepends="qt-devel"
-short_desc="A library that provides a Qt implementation of the DBusMenu spec"
-maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3.0-or-later"
+revision=4
+noarch=yes
+build_style=meta
+short_desc="A library that provides a Qt implementation of the DBusMenu spec (removed package)"
+license="metapackage"
 homepage="https://launchpad.net/libdbusmenu-qt"
-distfiles="http://launchpad.net/${pkgname}/trunk/${version}/+download/${pkgname}-${version}.tar.bz2"
-checksum=ae6c1cb6da3c683aefed39df3e859537a31d80caa04f3023315ff09e5e8919ec
-
-libdbusmenu-qt-devel_package() {
-	depends="${sourcepkg}-${version}_${revision}"
-	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove usr/share/doc
-	}
-}


### PR DESCRIPTION
From debian:

Plasma ships an updated fork in plasma-workspace.git; probably required as long as there are Qt4 applications which depend on it

We have none that depends on it in the repos.