### PR TITLE
eudev: use /usr/lib/udev/hwdb.d instead of /etc/udev/hwdb.d

### DIFF
--- a/srcpkgs/eudev/template
+++ b/srcpkgs/eudev/template
@@ -4,7 +4,7 @@ _UDEV_VERSION="220" # compatible udev version provided
 
 pkgname=eudev
 version=3.2.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-hwdb --enable-manpages --disable-introspection"
 hostmakedepends="automake libtool pkg-config gperf libxslt docbook-xsl"
@@ -22,6 +22,7 @@ pre_configure() {
 }
 
 post_install() {
+	mv "${DESTDIR}/etc/udev/hwdb.d" "${DESTDIR}/usr/lib/udev"
 	vsv udevd
 }
 


### PR DESCRIPTION
This is necessary since revision 7bd2eae which introduced a lint check that prevents eudev from building.

This fixes https://github.com/void-linux/void-packages/issues/6075