### PR TITLE
qt5: revert commit that enabled glibc statx usage

### DIFF
--- a/srcpkgs/qt5/patches/0033-revert_remove_our_use_of_syscall_for-statx.patch
+++ b/srcpkgs/qt5/patches/0033-revert_remove_our_use_of_syscall_for-statx.patch
@@ -1,0 +1,119 @@
+Description: revert upstream commit that removes use of syscall() and statx(2)
+ The commit https://code.qt.io/cgit/qt/qtbase.git/commit/?id=b7887f9b4faad222
+ removes the use of the above mentioned syscalls. This makes Qt not able
+ to run on current stable servers under a testing/unstable VM.
+ .
+ This patch should be removed in testing/unstable after Buster gets released.
+Author: Lisandro Damián Nicanor Pérez Meyer <lisandro@debian.org>
+Forwarded: not-needed
+
+---
+ src/corelib/global/minimum-linux_p.h      |    7 ----
+ src/corelib/io/qfilesystemengine_unix.cpp |   45 ++++++++++++++++++++++++++++--
+ 2 files changed, 43 insertions(+), 9 deletions(-)
+
+--- qtbase/src/corelib/global/minimum-linux_p.h
++++ qtbase/src/corelib/global/minimum-linux_p.h
+@@ -75,14 +75,9 @@ QT_BEGIN_NAMESPACE
+  * - accept4                    2.6.28
+  * - renameat2                  3.16                    QT_CONFIG(renameat2)
+  * - getrandom                  3.17                    QT_CONFIG(getentropy)
+- * - statx                      4.11                    QT_CONFIG(statx)
+  */
+ 
+-#if QT_CONFIG(statx)
+-#  define MINLINUX_MAJOR        4
+-#  define MINLINUX_MINOR        11
+-#  define MINLINUX_PATCH        0
+-#elif QT_CONFIG(getentropy)
++#if QT_CONFIG(getentropy)
+ #  define MINLINUX_MAJOR        3
+ #  define MINLINUX_MINOR        17
+ #  define MINLINUX_PATCH        0
+--- qtbase/src/corelib/io/qfilesystemengine_unix.cpp
++++ qtbase/src/corelib/io/qfilesystemengine_unix.cpp
+@@ -1,6 +1,6 @@
+ /****************************************************************************
+ **
+-** Copyright (C) 2018 Intel Corporation.
++** Copyright (C) 2017 Intel Corporation.
+ ** Copyright (C) 2016 The Qt Company Ltd.
+ ** Copyright (C) 2013 Samuel Gaist <samuel.gaist@edeltech.ch>
+ ** Contact: https://www.qt.io/licensing/
+@@ -88,6 +88,7 @@ extern "C" NSString *NSTemporaryDirector
+ 
+ #if defined(Q_OS_LINUX)
+ #  include <sys/ioctl.h>
++#  include <sys/syscall.h>
+ #  include <sys/sendfile.h>
+ #  include <linux/fs.h>
+ 
+@@ -95,6 +96,28 @@ extern "C" NSString *NSTemporaryDirector
+ #ifndef FICLONE
+ #  define FICLONE       _IOW(0x94, 9, int)
+ #endif
++
++#  if defined(Q_OS_ANDROID)
++// renameat2() and statx() are disabled on Android because quite a few systems
++// come with sandboxes that kill applications that make system calls outside a
++// whitelist and several Android vendors can't be bothered to update the list.
++#    undef SYS_renameat2
++#    undef SYS_statx
++#    undef STATX_BASIC_STATS
++#  else
++#    if !QT_CONFIG(renameat2) && defined(SYS_renameat2)
++static int renameat2(int oldfd, const char *oldpath, int newfd, const char *newpath, unsigned flags)
++{ return syscall(SYS_renameat2, oldfd, oldpath, newfd, newpath, flags); }
++#    endif
++
++#    if !QT_CONFIG(statx) && defined(SYS_statx)
++#      include <linux/stat.h>
++static int statx(int dirfd, const char *pathname, int flag, unsigned mask, struct statx *statxbuf)
++{ return syscall(SYS_statx, dirfd, pathname, flag, mask, statxbuf); }
++#    elif !QT_CONFIG(statx) && !defined(SYS_statx)
++#      undef STATX_BASIC_STATS
++#    endif
++#  endif // !Q_OS_ANDROID
+ #endif
+ 
+ #if defined(Q_OS_ANDROID)
+@@ -315,8 +338,22 @@ mtime(const T &statBuffer, int)
+ #ifdef STATX_BASIC_STATS
+ static int qt_real_statx(int fd, const char *pathname, int flags, struct statx *statxBuffer)
+ {
++#ifdef Q_ATOMIC_INT8_IS_SUPPORTED
++    static QBasicAtomicInteger<qint8> statxTested  = Q_BASIC_ATOMIC_INITIALIZER(0);
++#else
++    static QBasicAtomicInt statxTested = Q_BASIC_ATOMIC_INITIALIZER(0);
++#endif
++
++    if (statxTested.load() == -1)
++        return -ENOSYS;
++
+     unsigned mask = STATX_BASIC_STATS | STATX_BTIME;
+     int ret = statx(fd, pathname, flags, mask, statxBuffer);
++    if (ret == -1 && errno == ENOSYS) {
++        statxTested.store(-1);
++        return -ENOSYS;
++    }
++    statxTested.store(1);
+     return ret == -1 ? -errno : 0;
+ }
+ 
+@@ -1252,12 +1289,14 @@ bool QFileSystemEngine::renameFile(const
+     if (Q_UNLIKELY(srcPath.isEmpty() || tgtPath.isEmpty()))
+         return emptyFileEntryWarning(), false;
+ 
+-#if defined(RENAME_NOREPLACE) && QT_CONFIG(renameat2)
++#if defined(RENAME_NOREPLACE) && (QT_CONFIG(renameat2) || defined(SYS_renameat2))
+     if (renameat2(AT_FDCWD, srcPath, AT_FDCWD, tgtPath, RENAME_NOREPLACE) == 0)
+         return true;
+ 
++    // If we're using syscall(), check for ENOSYS;
++    // if renameat2 came from libc, we don't accept ENOSYS.
+     // We can also get EINVAL for some non-local filesystems.
+-    if (errno != EINVAL) {
++    if ((QT_CONFIG(renameat2) || errno != ENOSYS) && errno != EINVAL) {
+         error = QSystemError(errno, QSystemError::StandardLibraryError);
+         return false;
+     }

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
 version=5.11.3
-revision=1
+revision=2
 wrksrc="qt-everywhere-src-${version}"
 build_style=gnu-configure
 hostmakedepends="cmake clang flex git glib-devel gperf ninja pkg-config


### PR DESCRIPTION
 adds the revert_remove_our_use_of_syscall_for-statx.patch from the
 Debian repo

 resolves #5916