### PR TITLE
icu: fix cross-build

### DIFF
--- a/srcpkgs/icu/template
+++ b/srcpkgs/icu/template
@@ -35,7 +35,7 @@ pre_configure() {
 		cd host-build
 		env CC=cc LD=ld CXX=g++ AR=ar RANLIB=ranlib \
 			AS=as STRIP=strip CFLAGS="-Os -fPIE" CXXFLAGS="-Os -fPIE" \
-			../configure --prefix=/
+			LDFLAGS="" ../configure --prefix=/
 		make ${makejobs}
 		mkdir -p ${wrksrc}/host-icu/config
 		cp config/icucross.* ${wrksrc}/host-icu/config


### PR DESCRIPTION
When crossing to certain platforms, particularly when target platform is binary compatible with host (e.g. X to X-musl). we need to reset the LDFLAGS as otherwise `-Lcross-toolchain/usr/lib` would leak into the host build and cause incorrect linkage, preventing configuration or build.

In my case, it was causing configure to fail when testing whether C compiler could create executables, as it'd result in undefined references within the executable linkage.