### PR TITLE
mame: remove automoc4 hostdep

### DIFF
--- a/srcpkgs/mame/template
+++ b/srcpkgs/mame/template
@@ -3,14 +3,14 @@ pkgname=mame
 version=0204
 revision=1
 wrksrc="mame-mame${version}"
-homepage="http://mamedev.org"
-distfiles="https://github.com/mamedev/mame/archive/mame${version}.tar.gz"
 short_desc="The Multiple Arcade Machine Emulator"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-2.0-or-later"
+homepage="http://mamedev.org"
+distfiles="https://github.com/mamedev/mame/archive/mame${version}.tar.gz"
 checksum=eeb6e304502dc1f1ce5a9c73d59a32865fc6e374c14ecef85d85b6de98a76e42
 
-hostmakedepends="automoc4 perl pkg-config python"
+hostmakedepends="perl pkg-config python"
 makedepends="SDL2_ttf-devel glm libjpeg-turbo-devel libutf8proc-devel
  libuv-devel lua-devel portaudio-devel portmidi-devel rapidjson
  $(vopt_if qt 'qt5-devel')"


### PR DESCRIPTION
It is not necessary for build (builds just fine without, tested), besides it uses qt5 and this dep makes it pull in qt4 for no reason.