### PR TITLE
phonon-qt5: remove hostdeps on automoc4 and zeitgeist

### DIFF
--- a/srcpkgs/phonon-qt5/template
+++ b/srcpkgs/phonon-qt5/template
@@ -5,7 +5,7 @@ revision=1
 wrksrc=${pkgname%-*}-${version}
 build_style=cmake
 configure_args="-DPHONON_BUILD_PHONON4QT5=ON -DPHONON_INSTALL_QT_EXTENSIONS_INTO_SYSTEM_QT=ON"
-hostmakedepends="automoc4 extra-cmake-modules"
+hostmakedepends="extra-cmake-modules qt5-host-tools qt5-devel"
 makedepends="glib-devel qt5-devel pulseaudio-devel"
 short_desc="The multimedia framework for KDE"
 maintainer="Juan RP <xtraeme@gmail.com>"
@@ -13,15 +13,6 @@ license="LGPL-2.1"
 homepage="http://phonon.kde.org/"
 distfiles="http://download.kde.org/stable/${pkgname%-*}/${version}/${pkgname%-*}-${version}.tar.xz"
 checksum=67bee986f85ca8b575186c8ba58a85886cb3b1c3567c86a118d56129f221e69c
-
-if [ -z "$CROSS_BUILD" ]; then
-	makedepends+=" libqzeitgeist-devel"
-else
-	# Don't depend on libqzeitgeist-devel because
-	# zeitgeist depends on python-gobject which can
-	# not be cross compiled.
-	hostmakedepends+=" qt5-host-tools qt5-devel"
-fi
 
 phonon-qt5-devel_package() {
 	depends="qt5-devel ${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
automoc4 is not needed for qt5, and qzeitgeist has never been ported to qt5 so there is no use enabling it for phonon-qt5.