### PR TITLE
Update Imagemagick

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
 _majorver=7.0.8
-_patchver=19
+_patchver=20
 version="${_majorver}.${_patchver}"
 revision=1
 wrksrc="${pkgname}-${_majorver}-${_patchver}"
@@ -19,9 +19,9 @@ short_desc="Package for display and interactive manipulation of images"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org/"
-changelog="http://imagemagick.org/script/changelog.php"
-distfiles="https://www.imagemagick.org/download/ImageMagick-${_majorver}-${_patchver}.tar.xz"
-checksum=e35ba756447b38be793ee7ea3c493d0f04d913cbfd4dc4eca9f5bfef68ac86ad
+changelog="https://imagemagick.org/script/changelog.php"
+distfiles="https://github.com/ImageMagick/ImageMagick/archive/${_majorver}-${_patchver}.tar.gz"
+checksum=b3c72367f39299f8d35f3df9c6284f5925dc74e43fc914f6b09aab89bd5809ea
 
 subpackages="libmagick libmagick-devel"
 

--- a/srcpkgs/ImageMagick/update
+++ b/srcpkgs/ImageMagick/update
@@ -1,2 +1,0 @@
-site="http://www.imagemagick.org/download/"
-pattern="${pkgname}-\K[\d.-]+(?=\.tar\.xz)"

--- a/srcpkgs/ImageMagick6/template
+++ b/srcpkgs/ImageMagick6/template
@@ -1,10 +1,10 @@
 # Template file for 'ImageMagick6'
 pkgname=ImageMagick6
 _majorver=6.9.10
-_patchver=19
+_patchver=20
 version="${_majorver}.${_patchver}"
 revision=1
-wrksrc="ImageMagick-${_majorver}-${_patchver}"
+wrksrc="${pkgname}-${_majorver}-${_patchver}"
 build_style=gnu-configure
 configure_args="--without-autotrace --with-wmf=yes
  --without-dps --without-fpx --without-gvc --without-jbig --with-gslib=yes
@@ -19,8 +19,8 @@ short_desc="Package for display and interactive manipulation of images"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org/"
-distfiles="https://www.imagemagick.org/download/ImageMagick-${_majorver}-${_patchver}.tar.xz"
-checksum=d3906bdfcb7c22c7d0945f6d19c992d496c3cf3acf5a555cfc8ba59a8e961889
+distfiles="https://github.com/ImageMagick/ImageMagick6/archive/${_majorver}-${_patchver}.tar.gz"
+checksum=8c0a36b441f487bb1642b8e768a4021721b9033f8ec88ed2fa9b1fd3c3fd1117
 
 keep_libtool_archives=yes
 conf_files="/etc/ImageMagick-${_majorver%%.*}/*.xml"
@@ -36,13 +36,13 @@ if [ -z "$CROSS_BUILD" ]; then
 	subpackages+=" libmagick6-perl"
 fi
 
-post_extract() {
-	sed -i '/VERSION/s/6\.9A/6.99/g' version.sh PerlMagick/Makefile.PL \
-		PerlMagick/*/Makefile.PL PerlMagick/quantum/quantum.pm
-}
-
 pre_configure() {
 	autoreconf -if
+}
+
+post_configure() {
+	sed -i '/VERSION/s/6\.9A/6.99/g' version.sh PerlMagick/Makefile.PL \
+		PerlMagick/*/Makefile.PL PerlMagick/quantum/quantum.pm
 }
 
 do_check() {

--- a/srcpkgs/ImageMagick6/update
+++ b/srcpkgs/ImageMagick6/update
@@ -1,2 +1,0 @@
-site="http://www.imagemagick.org/download/"
-pattern="${pkgname/6/}-\K6[\d.-]+(?=\.tar\.xz)"


### PR DESCRIPTION
This pull request switches to downloading the source from GitHub. This resolves a repository consistency issue that results when ImageMagick releases a new version and removes the old version from imagemagick.org. Justification for preferring GitHub:

>The authoritative source code repository is https://github.com/ImageMagick. We maintain a source code mirror at https://git.imagemagick.org/repos/ImageMagick. We test and deploy ImageMagick with Travis CI and AppVeyor.

https://imagemagick.org/script/install-source.php