### PR TITLE
base-files: preserve PATH preset by environment

### DIFF
--- a/srcpkgs/base-files/files/profile
+++ b/srcpkgs/base-files/files/profile
@@ -2,8 +2,23 @@
 
 # System wide environment and startup programs.
 
+appendpath () {
+    case ":$PATH:" in
+        *:"$1":*)
+            ;;
+        *)
+            PATH="${PATH:+$PATH:}$1"
+    esac
+}
+
 # Set our default path (/usr/sbin:/sbin:/bin included for non-Void chroots)
-PATH="/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin"
+appendpath /usr/local/sbin
+appendpath /usr/local/bin
+appendpath /usr/bin
+appendpath /usr/sbin
+appendpath /sbin
+appendpath /bin
+
 export PATH
 
 # Set default umask


### PR DESCRIPTION
This delta aligns the value of `PATH` variable with other
shells/distros, which in their default configuration preserve
(append) the old value.
For instance: https://src.fedoraproject.org/rpms/bash/blob/master/f/dot-bashrc#_9.

In order to exercise interoperability with Win32 applications
in WSL, the subsystem process injects Windows environment's
PATH to the Linux OS, which in this case gets lost.