### PR TITLE
New package: t2ec-1.1

### DIFF
--- a/srcpkgs/t2ec/template
+++ b/srcpkgs/t2ec/template
@@ -1,0 +1,23 @@
+# Template file for 't2ec'
+pkgname=t2ec
+version=1.1
+revision=1
+noarch=yes
+depends="python3>=3.5 acpi xbacklight alsa-utils wireless_tools wget"
+short_desc="Scripts to display info icons and controls in Tint2 or other panels"
+maintainer="nwg-piotr <nwg.piotr@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/nwg-piotr/t2ec"
+distfiles="https://github.com/nwg-piotr/t2ec/archive/v${version}.tar.gz"
+checksum=fd56b972cc8dcfb36175f6923349f52d43b9b0fe05ed6223777b88f10f338fdc
+
+do_install() {
+	vmkdir usr/bin
+	vmkdir usr/share/${pkgname}
+	vmkdir usr/lib/${pkgname}
+	vmkdir usr/share/tint2
+	vcopy "images/*.*" usr/share/${pkgname}
+	vcopy "scripts-void/*.*" usr/lib/${pkgname}
+	vcopy "configs-void/*.*" usr/share/tint2
+	ln -sf /usr/lib/t2ec/t2ec ${DESTDIR}/usr/bin
+}


### PR DESCRIPTION
t2ec is a collection of scripts suitable for use in the Tint2 panel executors. It provides various system information and controls, either in graphical (icon + value) or textual (name + value) form. It also contains commands to change system settings, e.g.:

`t2ec --volume` displays the icon and current volume level
`t2ec --volume [up] | [down] | [level]` allow to change the volume level, and may be attached to mouse click events.

Textual display (`-N` for fixed name or `-M"custom name"`) may also be used in panels other than Tint2.

The setup below contains commands: `--weather`, `--wifi`, `--desktop`, `--volume`, `--brightness` and `--battery`. Sample tint2 config files included in the package.

![t2ec-sample](https://user-images.githubusercontent.com/20579136/50482255-099e2d00-09e6-11e9-92ea-7183e3291670.png)

More detailed description there's in [README.md](https://github.com/nwg-piotr/t2ec/blob/master/README.md).