### PR TITLE
munge: set homedir to non-runtime directory owned by the package.

### DIFF
--- a/srcpkgs/munge/template
+++ b/srcpkgs/munge/template
@@ -1,7 +1,7 @@
 # Template file for 'munge'
 pkgname=munge
 version=0.5.13
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--with-crypto-lib=openssl
  --with-openssl-prefix=${XBPS_CROSS_BASE}/usr
@@ -20,7 +20,7 @@ make_dirs="/etc/munge 0755 munge munge
  /var/lib/munge 0711 munge munge"
 
 system_accounts="munge"
-munge_homedir="/var/run/munge"
+munge_homedir="/var/log/munge"
 
 pre_install() {
 	# needs this to install pc files in cross compilation.


### PR DESCRIPTION
\#5066