### PR TITLE
mkinitcpio: Use rc.conf instead of vconsole.conf

### DIFF
--- a/srcpkgs/mkinitcpio/patches/use-rc-conf.patch
+++ b/srcpkgs/mkinitcpio/patches/use-rc-conf.patch
@@ -1,0 +1,38 @@
+From: Christian Poulwey <christian.poulwey@t-online.de>
+Date: Fri Dec 28 12:31:28 2018 +0100
+Subject: Use the correct config file for keymap and font
+    
+By default, mkinitcpio tries to source the file
+/etc/vconsole.conf, which is the configuration
+file in which keymap and consolefont are defined
+on SystemD-based systems.
+As void is based on runit, those settings are
+defined in /etc/rc.conf and the mkinitcpio
+package should source this file.
+
+diff --git a/install/consolefont b/install/consolefont
+index c10b65d..dad38e2 100644
+--- a/install/consolefont
++++ b/install/consolefont
+@@ -3,7 +3,7 @@
+ build() {
+     # subshell to avoid namespace pollution
+     (
+-        [[ -s /etc/vconsole.conf ]] && . /etc/vconsole.conf
++        [[ -s /etc/rc.conf ]] && . /etc/rc.conf
+ 
+         if [[ $FONT ]]; then
+             for file in "/usr/share/kbd/consolefonts/$FONT".@(fnt|psf?(u))?(.gz); do
+diff --git a/install/keymap b/install/keymap
+index 7de6acb..beb4f7f 100644
+--- a/install/keymap
++++ b/install/keymap
+@@ -7,7 +7,7 @@ build() {
+         l=$LANG
+         unset LANG
+ 
+-        for cfg in /etc/{vconsole,locale}.conf; do
++        for cfg in /etc/{rc,locale}.conf; do
+             [[ -s $cfg ]] && . "$cfg"
+         done
+ 

--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=24
-revision=1
+revision=2
 noarch=yes
 build_style=gnu-makefile
 depends="busybox-static bsdtar bash"


### PR DESCRIPTION
By default, mkinitcpio tries to source the file
/etc/vconsole.conf, which is the configuration
file in which keymap and consolefont are defined
on SystemD-based systems.
As void is based on runit, those settings are
defined in /etc/rc.conf and the mkinitcpio
package should source this file.