### PR TITLE
libqmi: add --enable-mbim-qmux to configure_args

### DIFF
--- a/srcpkgs/libqmi/template
+++ b/srcpkgs/libqmi/template
@@ -1,15 +1,15 @@
 # Template file for 'libqmi'
 pkgname=libqmi
 version=1.20.2
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--disable-static"
+configure_args="--disable-static --enable-mbim-qmux"
 hostmakedepends="glib-devel pkg-config"
-makedepends="libglib-devel libgudev-devel"
+makedepends="libglib-devel libgudev-devel libmbim-devel"
 short_desc="QMI modem protocol helper library"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.freedesktop.org/wiki/Software/libqmi/"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="http://www.freedesktop.org/wiki/Software/libqmi/"
 distfiles="${FREEDESKTOP_SITE}/$pkgname/$pkgname-$version.tar.xz"
 checksum=c73459ca8bfe1213f8047858d4946fc1f58e164d4f488a7a6904edee25e2ca44
 


### PR DESCRIPTION
To properly initialize some 3G/4G Sierra modems and force them off low power mode, they must be sent an "FCCAuth" command, which can only be done through QMI-over-MBIM.

This needs libqmi to be build with `--enable-mbim-qmux`.

While here, fix xlint warning by moving `homepage` under `license`.