### PR TITLE
kcoreaddons: drop gamin dependency

### DIFF
--- a/srcpkgs/kcoreaddons/template
+++ b/srcpkgs/kcoreaddons/template
@@ -1,11 +1,11 @@
 # Template file for 'kcoreaddons'
 pkgname=kcoreaddons
 version=5.53.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools qt5-tools-devel"
-makedepends="qt5-devel qt5-tools-devel gamin-devel"
+makedepends="qt5-devel qt5-tools-devel"
 depends="shared-mime-info"
 short_desc="Qt5 addon library with a collection of non-GUI utilities"
 maintainer="John <johnz@posteo.net>"


### PR DESCRIPTION
Gamin/FAM backend in KDirWatch is buggy and causes freezes and decreased performance (especially for NFS and ntfs-3g fielsystems).

See also:
https://bugzilla.gnome.org/show_bug.cgi?id=777997
https://src.fedoraproject.org/rpms/kf5-kcoreaddons/c/f69fb11cc8f0771cb3d141ab89c8c19a4d2e7d9f?branch=master
https://bugs.archlinux.org/task/49794
https://bugs.kde.org/show_bug.cgi?id=400583