### PR TITLE
gendesk: update to 1.0.2

### DIFF
--- a/srcpkgs/gendesk/template
+++ b/srcpkgs/gendesk/template
@@ -1,6 +1,6 @@
 # Template file for 'gendesk'
 pkgname=gendesk
-version=1.0.1
+version=1.0.2
 revision=1
 build_style=go
 go_import_path=github.com/xyproto/gendesk
@@ -11,7 +11,7 @@ license="MIT"
 homepage="http://roboticoverlords.org/gendesk/"
 distfiles="https://github.com/xyproto/${pkgname}/archive/${version}.tar.gz
  http://roboticoverlords.org/images/default.png"
-checksum="ae9a65b559ec71d9fa63c696350a4810a5c9dc969e50c1850c067d2a8e16c1b9
+checksum="9a2a58c6c3b14bdb5800abf3a30bbfc05285cfba2f9ae0f914b96ae87006f65c
  4d96eded48e536d02e35727c36dc20844c2e44654e81baf78e10aee4eb48e837"
 skip_extraction="default.png"
 


### PR DESCRIPTION
Changes from 1.0.1 to 1.0.2

  Set version to 1.0 instead of 1.2 when generating .desktop files, to support a wider range of distributions.
