### PR TITLE
cgdb: Add patch to fix memory leak

### DIFF
--- a/srcpkgs/cgdb/patches/fix-memory-leak.patch
+++ b/srcpkgs/cgdb/patches/fix-memory-leak.patch
@@ -1,0 +1,18 @@
+--- lib/tgdb/tgdb.cpp.orig	2018-12-30 13:23:23.260656690 -0600
++++ lib/tgdb/tgdb.cpp	2018-12-30 13:24:33.484655276 -0600
+@@ -1039,11 +1039,14 @@
+                     request->choice.debugger_command.c);
+             break;
+         case TGDB_REQUEST_MODIFY_BREAKPOINT:
+-            command = tgdb_client_modify_breakpoint_call(tgdb,
++            str = tgdb_client_modify_breakpoint_call(tgdb,
+                     request->choice.modify_breakpoint.file,
+                     request->choice.modify_breakpoint.line,
+                     request->choice.modify_breakpoint.addr,
+                     request->choice.modify_breakpoint.b);
++            command = str;
++            free(str);
++            str = NULL;
+             break;
+         case TGDB_REQUEST_COMPLETE:
+             str = sys_aprintf("server interpreter-exec mi"

--- a/srcpkgs/cgdb/template
+++ b/srcpkgs/cgdb/template
@@ -1,7 +1,7 @@
 # Template file for 'cgdb'
 pkgname=cgdb
 version=0.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-installed-readline=${XBPS_CROSS_BASE}/usr ac_cv_rl_version=6.3"
 hostmakedepends="flex help2man"


### PR DESCRIPTION
Requested upstream release containing memory leak fix: https://github.com/cgdb/cgdb/issues/196
For now, back-ported the patch for current release