### PR TITLE
luakit: update to 2.1

### DIFF
--- a/srcpkgs/luakit/files/Makefile.patch
+++ b/srcpkgs/luakit/files/Makefile.patch
@@ -1,0 +1,39 @@
+--- Makefile.orig	2018-12-30 16:13:10.512451500 -0600
++++ Makefile	2018-12-30 16:15:27.507448741 -0600
+@@ -17,7 +17,7 @@
+ # Must be kept in sync with doc/docgen.ld
+ DOC_SRCS = $(filter-out lib/markdown.lua lib/lousy/init.lua,$(shell for d in doc/luadoc lib common/clib; do find $$d -type f; done)) tests/lib.lua
+ 
+-all: options newline luakit luakit.1.gz luakit.so apidoc
++all: options newline luakit luakit.1.gz luakit.so
+ 
+ options:
+ 	@echo luakit build options:
+@@ -79,27 +79,10 @@
+ luakit.1.gz: luakit.1
+ 	@gzip -c $< > $@
+ 
+-doc/apidocs/index.html: $(DOC_SRCS) $(wildcard build-utils/docgen/*)
+-	rm -rf doc/apidocs
+-	mkdir doc/apidocs
+-	$(LUA_BIN_NAME) ./build-utils/docgen/makedoc.lua
+-
+-apidoc: doc/apidocs/index.html
+-
+-doc: buildopts.h $(THEAD) $(TSRC)
+-	doxygen -s doc/luakit.doxygen
+-
+-clean:
+-	rm -rf doc/apidocs doc/html luakit $(OBJS) $(EXT_OBJS) $(TSRC) $(THEAD) buildopts.h luakit.1 luakit.1.gz luakit.so
+-
+ install: all
+ 	install -d $(DESTDIR)$(PREFIX)/share/luakit/
+ 	install -d $(DESTDIR)$(DOCDIR) $(DESTDIR)$(DOCDIR)/classes $(DESTDIR)$(DOCDIR)/modules $(DESTDIR)$(DOCDIR)/pages
+ 	install -m644 README.md AUTHORS COPYING.GPLv3 $(DESTDIR)$(DOCDIR)
+-	install -m644 doc/apidocs/classes/* $(DESTDIR)$(DOCDIR)/classes
+-	install -m644 doc/apidocs/modules/* $(DESTDIR)$(DOCDIR)/modules
+-	install -m644 doc/apidocs/pages/* $(DESTDIR)$(DOCDIR)/pages
+-	install -m644 doc/apidocs/*.html $(DESTDIR)$(DOCDIR)
+ 	install -d $(DESTDIR)$(PREFIX)/share/luakit/lib $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy/widget
+ 	install -m644 lib/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib
+ 	install -m644 lib/lousy/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy

--- a/srcpkgs/luakit/template
+++ b/srcpkgs/luakit/template
@@ -1,21 +1,34 @@
 # Template file for 'luakit'
 pkgname=luakit
-version=2017.08.10
+version=2.1
 revision=1
-nocross=yes
-hostmakedepends="pkg-config"
+conf_files="/etc/xdg/luakit/*.lua"
+hostmakedepends="pkg-config LuaJIT"
 makedepends="webkit2gtk-devel luafilesystem LuaJIT-devel"
 depends="luafilesystem"
-conf_files="/etc/xdg/luakit/*.lua"
 short_desc="Fast, small, webkit based browser framework extensible by Lua"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://luakit.org/"
+changelog="https://github.com/luakit/luakit/blob/develop/CHANGELOG.md"
 distfiles="https://github.com/luakit/luakit/archive/${version}.tar.gz"
-checksum=23d98b6b51b66c85b6823cd287e161e1093b80639f06f1da9b0a7290b0859d37
+checksum=ecbfa23316712f444714387b2ffd846626dab6e40b444d3def4475c145d56f26
+
+case "${XBPS_TARGET_MACHINE}" in
+	aarch64) broken="LuaJIT-devel marked as unsupported";;
+esac
+
+pre_build() {
+	# Builds fail if apidoc is attempted (lfs.lua is missing)
+	case "${XBPS_TARGET_MACHINE}" in
+		armv7l|*-musl)
+		patch -p0 < ${FILESDIR}/Makefile.patch
+	esac
+}
 
 do_build() {
-	make DEVELOPMENT_PATHS=0 USE_LUAJIT=1 PREFIX=/usr all
+	make DEVELOPMENT_PATHS=0 LUA_BIN_NAME=luajit USE_LUAJIT=1 \
+ PREFIX=/usr all
 }
 do_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install


### PR DESCRIPTION
Update to version 2.1
Fixed cross-build, excluding musl builds due to missing module error
Fixed license format
