### PR TITLE
New package: t2ec-1.1

### DIFF
--- a/srcpkgs/t2ec/template
+++ b/srcpkgs/t2ec/template
@@ -1,0 +1,23 @@
+# Template file for 't2ec'
+pkgname=t2ec
+version=1.1
+revision=1
+noarch=yes
+depends="python3>=3.5 acpi xbacklight alsa-utils wireless_tools wget jgmenu"
+short_desc="Scripts to display info icons and controls in Tint2 or other panels"
+maintainer="nwg-piotr <nwg.piotr@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/nwg-piotr/t2ec"
+distfiles="https://github.com/nwg-piotr/t2ec/archive/v${version}.tar.gz"
+checksum=6b118cfcb4161920b8b66f04bd5ee24a019aa6e3e0bce77e74aa78db14e36ac5
+
+do_install() {
+	vmkdir usr/bin
+	vmkdir usr/share/${pkgname}
+	vmkdir usr/lib/${pkgname}
+	vmkdir usr/share/tint2
+	vcopy "images/*.*" usr/share/${pkgname}
+	vcopy "scripts-void/*.*" usr/lib/${pkgname}
+	vcopy "configs-void/*.*" usr/share/tint2
+	ln -sf /usr/lib/${pkgname}/${pkgname}.sh ${DESTDIR}/usr/bin/${pkgname}
+}


### PR DESCRIPTION
The package is a collection of scripts suitable for use in the Tint2 panel executors. It provides various system information and controls, either in graphical (icon + value) or textual (name + value) form. It also contains commands to change system settings, e.g.:

`t2ec --volume` displays the icon and current volume level
`t2ec --volume [up] | [down] |[toggle] | [level]` allow to change the volume level, and may be attached to mouse click events.

Textual display (`-N` for fixed name or `-M"custom name"`) may also be used in panels other than Tint2.

The setup below contains commands: --weather, --update, --desktop, --volume, --brightness and --battery. 

![t2ec-void-icons](https://user-images.githubusercontent.com/20579136/50553622-9416b300-0caa-11e9-8d9e-ceed65317106.png)

Same script launched with the `-N` argument for textual display:

![t2ec-void-text](https://user-images.githubusercontent.com/20579136/50553629-e48e1080-0caa-11e9-8937-a734d97c23d9.png)

Full set of commands described in [README](https://github.com/nwg-piotr/t2ec/blob/master/README.md). Sample tint2 config files included in the package.