### PR TITLE
swiften: unbreak on aarch64 and armv7l

### DIFF
--- a/srcpkgs/swiften/template
+++ b/srcpkgs/swiften/template
@@ -11,7 +11,11 @@ license="GPL-3"
 homepage="http://swift.im/"
 distfiles="http://swift.im/git/swift/snapshot/swift-${version}.tar.bz2"
 checksum=2e48f081d337f471b4eba7c0c807a7b640216a76ed3568ced55abb5b927c7fd2
-nocross="fails to cross-compile internal boost, boost-1.69 isn't supported"
+
+case $XBPS_TARGET_MACHINE in
+	armv6*) broken="https://build.voidlinux.org/builders/armv6l_builder/builds/14130/steps/shell_3/logs/stdio"
+		;;
+esac
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/libxml2 -DBOOST_FILESYSTEM_VERSION=3 -DBOOST_SIGNALS_NO_DEPRECATION_WARNING=1"
 _scons_options="assertions=1 build_examples=1 max_jobs=1 optimize=1 debug=0 swiften_dll=1"


### PR DESCRIPTION
the failure to build only affects armv6