### PR TITLE
ModemManager: revbump to build against changed libqmi-devel

### DIFF
--- a/srcpkgs/ModemManager/template
+++ b/srcpkgs/ModemManager/template
@@ -1,7 +1,7 @@
 # Template file for 'ModemManager'
 pkgname=ModemManager
 version=1.8.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --with-polkit=permissive
  --with-udev-base-dir=/usr/lib/udev $(vopt_enable gir introspection)"


### PR DESCRIPTION
The change introduced in 33fbb03478770d302dab9971a6b1b23d6ee87292 is relevant for ModemManager too.

revbump so it can bring many Sierra Modems to life.