### PR TITLE
dcron: fix upstream URL

### DIFF
--- a/srcpkgs/dcron/template
+++ b/srcpkgs/dcron/template
@@ -1,15 +1,16 @@
 # Template file for 'dcron'
 pkgname=dcron
 version=4.5
-revision=32
+revision=33
 conf_files="/var/spool/cron/root"
-provides="cron-daemon-0_1"
 short_desc="Dillon's lightweight cron daemon"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-homepage="http://www.jimpryor.net/linux/dcron.html"
-license="GPL-2"
-distfiles="http://www.jimpryor.net/linux/releases/dcron-${version}.tar.gz"
-checksum=9e50edb6f5bd8153b16bad05087d985e5153ce45cc01ae77e7f842213fb4a824
+license="GPL-2.0-only"
+homepage="https://github.com/dubiousjim/dcron"
+changelog="https://raw.githubusercontent.com/dubiousjim/dcron/v${version}/CHANGELOG"
+distfiles="https://github.com/dubiousjim/dcron/archive/v${version}.tar.gz"
+checksum=7c047194b9339b781971b000bf5512c11e856d20a14fe5323d5a1823f04c2a3f
+provides="cron-daemon-0_1"
 
 alternatives="
  crond:crond:/etc/sv/dcron
@@ -30,11 +31,13 @@ make_dirs="
 do_configure() {
 	sed -i 's,-[og] root,,g' Makefile
 }
+
 do_build() {
 	make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \
 		PREFIX=/usr CRONTAB_GROUP=$(whoami) CRONTABS=/var/spool/cron \
 		CRONSTAMPS=/var/spool/cronstamps ${makejobs}
 }
+
 do_install() {
 	make SBINDIR=/usr/bin DESTDIR=${DESTDIR} install
 


### PR DESCRIPTION
For consistency, set `license` to `GPL-2.0-only` as it [appears to be ambiguous](https://github.com/dubiousjim/dcron/issues/14).