### PR TITLE
minicom: Add CVE-2017-7467 patch

### DIFF
--- a/srcpkgs/minicom/patches/Add-ARRAY_SIZE-macro.patch
+++ b/srcpkgs/minicom/patches/Add-ARRAY_SIZE-macro.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Adam Lackorzynski <adam@os.inf.tu-dresden.de>
+# Date 1440364600 -7200
+# Node ID 4eff7b4cde33a56d9caf64e44722186c89e26922
+# Parent  3cb4335d5819099c85a30dae714f0a213fa4a44c
+Add ARRAY_SIZE macro
+
+diff -r 3cb4335d5819 -r 4eff7b4cde33 src/minicom.h
+--- src/minicom.h	Mon Jun 29 21:16:14 2015 +0200
++++ src/minicom.h	Sun Aug 23 23:16:40 2015 +0200
+@@ -302,6 +302,7 @@
+ int lockfile_create(int no_msgs);
+ void lockfile_remove(void);
+ 
++#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+ 
+ 
+ /* We want the ANSI offsetof macro to do some dirty stuff. */
+

--- a/srcpkgs/minicom/patches/CVE-2017-7467.patch
+++ b/srcpkgs/minicom/patches/CVE-2017-7467.patch
@@ -1,0 +1,33 @@
+# HG changeset patch
+# User Adam Lackorzynski <adam@os.inf.tu-dresden.de>
+# Date 1492510834 -7200
+# Node ID c33d24938f3ed3dc2b7d328fe255794468a814eb
+# Parent  c72edf0e43bca463239ea15594d128ecbc0d2574
+Fix CVE-2017-7467, a remote exploitalbe out of bound access
+
+This fixes an out of bounds data access that can lead to a
+remotely exploitable code execution.
+
+This issue was found by Solar Designer of Openwall during a
+security audit of the Virtuozzo 7 product, which contains
+derived downstream code in its prl-vzvncserver component.
+The corresponding Virtuozzo 7 fix is:
+
+https://src.openvz.org/projects/OVZ/repos/prl-vzvncserver/commits/6d95404e75b98f36b1cc85ee23df99dcf06ca13f
+
+Openwall would like to thank the Virtuozzo company for
+funding the effort.
+
+diff -r c72edf0e43bc -r c33d24938f3e src/vt100.c
+--- src/vt100.c	Sat Sep 17 02:17:37 2016 +0200
++++ src/vt100.c	Tue Apr 18 12:20:34 2017 +0200
+@@ -427,7 +427,7 @@
+   }
+   /* Separation between numbers ? */
+   if (c == ';') {
+-    if (ptr < 7)
++    if (ptr < (int)ARRAY_SIZE(escparms) - 1)
+       ptr++;
+     return;
+   }
+

--- a/srcpkgs/minicom/template
+++ b/srcpkgs/minicom/template
@@ -1,12 +1,12 @@
 # Template file for 'minicom'
 pkgname=minicom
 version=2.7.1
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="ncurses-devel"
 short_desc="Menu driven communications program"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
-homepage="http://alioth.debian.org/projects/minicom/"
-distfiles="https://alioth.debian.org/frs/download.php/file/4215/minicom-${version}.tar.gz"
+license="GPL-2.0-or-later"
+homepage="https://tracker.debian.org/pkg/minicom"
+distfiles="https://deb.debian.org/debian/pool/main/m/minicom/minicom_${version}.orig.tar.gz"
 checksum=532f836b7a677eb0cb1dca8d70302b73729c3d30df26d58368d712e5cca041f1


### PR DESCRIPTION
Add CVE patch from https://sources.debian.org/patches/minicom/2.7.1-1/CVE-2017-7467.diff/
The Add-ARRAY_SIZE patch is need, to fix undefined variable

Changed homepage and source, as I was getting unable to resolve site
Fix license format