### PR TITLE
par2cmdline: avoid corrupt build workdir

### DIFF
--- a/srcpkgs/par2cmdline/patches/avoid-corrupt-files-in-wrkdir.patch
+++ b/srcpkgs/par2cmdline/patches/avoid-corrupt-files-in-wrkdir.patch
@@ -1,0 +1,25 @@
+From 2d94e1e2aa8a927b00b666f1091cb2344d754f06 Mon Sep 17 00:00:00 2001
+From: BlackEagle <ike.devolder@gmail.com>
+Date: Sat, 6 Jan 2018 23:08:53 +0100
+Subject: [PATCH] Add .DELETE_ON_ERROR to avoid corrupt files in workdir
+
+@see http://rdiez.shoutwiki.com/wiki/GNU_Make_and_Autotools#.DELETE_ON_ERROR_is_a_must
+
+Signed-off-by: BlackEagle <ike.devolder@gmail.com>
+---
+ Makefile.am | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git Makefile.am Makefile.am
+index f404fd0..64ed9d2 100755
+--- Makefile.am
++++ Makefile.am
+@@ -19,6 +19,8 @@
+ 
+ AUTOMAKE_OPTIONS = subdir-objects
+ 
++.DELETE_ON_ERROR:
++
+ bin_PROGRAMS = par2
+ man_MANS = man/par2.1
+ 

--- a/srcpkgs/par2cmdline/template
+++ b/srcpkgs/par2cmdline/template
@@ -1,13 +1,13 @@
 # Template file for 'par2cmdline'
 pkgname=par2cmdline
 version=0.8.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake"
 makedepends="libgomp-devel"
 short_desc="PAR 2.0 compatible file verification and repair tool"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/Parchive/par2cmdline"
 distfiles="https://github.com/Parchive/par2cmdline/archive/v${version}.tar.gz"
 checksum=461b45627a0d800061657b2d800c432c7d1c86c859b40a3ced35a0cc6a85faca


### PR DESCRIPTION
While here, fix license format