### PR TITLE
xwininfo: roots should be freed

### DIFF
--- a/srcpkgs/xwininfo/patches/0001-roots-should-be-freed.patch
+++ b/srcpkgs/xwininfo/patches/0001-roots-should-be-freed.patch
@@ -1,0 +1,32 @@
+From 941ee65327f67348a43f2528a1648a968a85b9b7 Mon Sep 17 00:00:00 2001
+From: David Hill <dhill@mindcry.org>
+Date: Wed, 11 Dec 2013 04:05:19 +0000
+Subject: [PATCH] In Find_Client, if (win == XCB_WINDOW_NONE), roots should be
+ freed.
+
+https://bugs.freedesktop.org/show_bug.cgi?id=72583
+
+Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>
+---
+ clientwin.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git clientwin.c clientwin.c
+index 2b1de04..be38a0d 100644
+--- clientwin.c
++++ clientwin.c
+@@ -219,8 +219,10 @@ Find_Client(xcb_connection_t * dpy, xcb_window_t root, xcb_window_t subwin)
+         if (subwin != roots[i])
+             continue;
+         win = Find_Child_At_Pointer(dpy, subwin);
+-        if (win == XCB_WINDOW_NONE)
++        if (win == XCB_WINDOW_NONE) {
++            free (roots);
+             return subwin;      /* No child - Return virtual root. */
++        }
+         subwin = win;
+         break;
+     }
+-- 
+2.20.1
+

--- a/srcpkgs/xwininfo/template
+++ b/srcpkgs/xwininfo/template
@@ -1,14 +1,14 @@
-# Template build file for 'xwininfo'.
+# Template file for 'xwininfo'
 pkgname=xwininfo
 version=1.1.4
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libX11-devel"
 short_desc="Query information about X windows"
-homepage="http://xorg.freedesktop.org"
-license="MIT"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="MIT"
+homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/app/$pkgname-$version.tar.bz2"
 checksum=839498aa46b496492a5c65cd42cd2e86e0da88149b0672e90cb91648f8cd5b01
 


### PR DESCRIPTION
Cherry-picked from https://gitlab.freedesktop.org/xorg/app/xwininfo/compare/xwininfo-1.1.4...master
Fix variable order, per xlint