### PR TITLE
Fix nginx http_geoip configure option.

### DIFF
--- a/srcpkgs/nginx/template
+++ b/srcpkgs/nginx/template
@@ -68,7 +68,7 @@ do_configure() {
 		--with-http_realip_module \
 		--with-http_ssl_module \
 		--with-http_stub_status_module \
-		$(vopt_with geoip http_geoip_module)
+		$(vopt_if geoip --with-http_geoip_module)
 
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
There is no `--without-http_geoip_module` for the configure script, so we
use `vopt_if` instead of `vopt_with`.