### PR TITLE
convmv: generate manpage

### DIFF
--- a/srcpkgs/convmv/template
+++ b/srcpkgs/convmv/template
@@ -1,9 +1,9 @@
 # Template file for 'convmv'
 pkgname=convmv
 version=2.05
-revision=1
+revision=2
 build_style=gnu-makefile
-checkdepends="perl"
+hostmakedepends="perl"
 short_desc="Tool for converting filesystem encodings"
 maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
This fixes convmv "generating" a zero byte manpage when it's built.