### PR TITLE
deheader: fix multiple spelling errors

### DIFF
--- a/srcpkgs/deheader/patches/0001-Fix-spelling-error-in-manpage.patch
+++ b/srcpkgs/deheader/patches/0001-Fix-spelling-error-in-manpage.patch
@@ -1,0 +1,25 @@
+From e455d0a71612cdf614afaceaef10822454434d33 Mon Sep 17 00:00:00 2001
+From: Reiner Herrmann <reiner@reiner-h.de>
+Date: Sat, 23 Sep 2017 13:55:45 +0200
+Subject: [PATCH 1/3] Fix spelling error in manpage
+
+---
+ deheader.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git deheader.xml deheader.xml
+index b6aab5a..1db58a9 100644
+--- deheader.xml
++++ deheader.xml
+@@ -92,7 +92,7 @@ deheader descends into the subdirectory of the source file and retries
+ compiling inside there.</para>
+ 
+ <para>At verbosity level 0, only messages indicating removable headers
+-are issued.  At verbosity 1, test compilations are timed and progess
++are issued.  At verbosity 1, test compilations are timed and progress
+ indicated with a twirling-baton prompt. At verbosity level 2, you get
+ verbose progress messages on the analysis.  At verbosity level 3, you
+ see the output from the make and compilation commands.</para>
+-- 
+2.20.1
+

--- a/srcpkgs/deheader/patches/0002-Fix-filename-of-header-for-f-statvfs.patch
+++ b/srcpkgs/deheader/patches/0002-Fix-filename-of-header-for-f-statvfs.patch
@@ -1,0 +1,30 @@
+From 73acaddd6e676e639e2976f89ac220ace066efa4 Mon Sep 17 00:00:00 2001
+From: Reiner Herrmann <reiner@reiner-h.de>
+Date: Sat, 23 Sep 2017 13:57:24 +0200
+Subject: [PATCH 2/3] Fix filename of header for (f)statvfs
+
+Fixes #8
+Reported-by: Petter Reinholdtsen <pere@hungry.com>
+Bug-Debian: https://bugs.debian.org/842945
+---
+ deheader | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git deheader deheader
+index 5b7d06f..48463ae 100755
+--- deheader
++++ deheader
+@@ -364,8 +364,8 @@ requirements = (
+     # fstat - get file status
+     (r"fstat()",         ["<sys/types.h>", "<sys/stat.h>"]),
+     # fstatvfs, statvfs - get file system information
+-    (r"fstatvfs()",      ["<sys/fstatvfs.h>"]),
+-    (r"statvfs()",       ["<sys/fstatvfs.h>"]),
++    (r"fstatvfs()",      ["<sys/statvfs.h>"]),
++    (r"statvfs()",       ["<sys/statvfs.h>"]),
+     # fsync - synchronise changes to a file
+     (r"fsync()",         ["<unistd.h>"]),
+     # ftell, ftello - return a file offset in a stream
+-- 
+2.20.1
+

--- a/srcpkgs/deheader/patches/0003-Typo-fix.patch
+++ b/srcpkgs/deheader/patches/0003-Typo-fix.patch
@@ -1,0 +1,25 @@
+From b37e3523fe7d70edf418aad7c70c4a3433562676 Mon Sep 17 00:00:00 2001
+From: "Eric S. Raymond" <esr@thyrsus.com>
+Date: Tue, 17 Apr 2018 19:34:55 -0400
+Subject: [PATCH 3/3] Typo fix.
+
+---
+ deheader.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git deheader.xml deheader.xml
+index 1db58a9..549bf1f 100644
+--- deheader.xml
++++ deheader.xml
+@@ -192,7 +192,7 @@ spot. <command>deheader</command> has an internal table of rules that
+ heads off the most common problems by suppressing deletion of headers
+ that are required for portability, but your mileage may vary.</para>
+ 
+-<para>The depenedency scanner does not ignore the text of comments.
++<para>The dependency scanner does not ignore the text of comments.
+ This, e.g, a reference to "log10" in a comment will produce a spurious
+ warning that &lt;math.h&gt;  is required for portability.</para>
+ 
+-- 
+2.20.1
+

--- a/srcpkgs/deheader/template
+++ b/srcpkgs/deheader/template
@@ -1,13 +1,13 @@
 # Template file for 'deheader'
 pkgname=deheader
 version=1.6
-revision=2
+revision=3
 noarch="yes"
 depends="python"
 short_desc="C and C++ header analyzer"
-homepage="http://www.catb.org/~esr/deheader/"
-license="2-clause-BSD"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
+license="BSD-2-Clause"
+homepage="http://www.catb.org/~esr/deheader/"
 distfiles="http://www.catb.org/~esr/deheader/$pkgname-$version.tar.gz"
 checksum=3b99665c4f0dfda31d200bf2528540d6898cb846499ee91effa2e8f72aff3a60
 


### PR DESCRIPTION
While here, correct order of variables and fix license format