### PR TITLE
docker: relax requests dependency upper bounds

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,7 +1,7 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
 version=1.23.2
-revision=1
+revision=2
 noarch=yes
 wrksrc="compose-${version}"
 build_style=python3-module
@@ -18,8 +18,8 @@ distfiles="https://github.com/docker/compose/archive/${version}.tar.gz"
 checksum=18ff12f80e21011e76e04d2579745224316e232a5ca94c79a2865dac5c66eef6
 
 pre_build() {
-	# relax texttable upper bound
-	sed -i '/texttable/s/, < 0.10//' setup.py
+	# relax texttable and requests upper bound
+	sed -i '/texttable/s/, < 0.10//;/requests/s/, < 2\.21//' setup.py
 }
 post_install() {
 	vinstall contrib/completion/bash/docker-compose 644 \


### PR DESCRIPTION
Requests has been updated to 2.21, which is outside the dependency upper bound. it still seems to work fine, in comparison to not working at all ofc.