### PR TITLE
packer: update to 1.3.3.

### DIFF
--- a/srcpkgs/packer/template
+++ b/srcpkgs/packer/template
@@ -1,35 +1,17 @@
 # Template file for 'packer'
 pkgname=packer
-version=1.3.2
+version=1.3.3
 revision=1
-replaces="packer-bin>=0"
+build_style=go
+go_import_path="github.com/hashicorp/packer"
 short_desc="Create identical multiplatform machine images from a single source"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-build_style=go
-hostmakedepends="git"
 license="MPL-2"
 homepage="http://www.packer.io"
-go_import_path="github.com/mitchellh/packer"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=2297c0111bdb6a4173458ae5caf58b7a735ab309cdbec12d92009fca24c1b54a
+checksum=c2866669a291822b3957a95fae9aa869270931d1501ea7a0979ac62580ef970f
+replaces="packer-bin>=0"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|arm*) broken="https://build.voidlinux.eu/builders/i686_builder/builds/9375/steps/shell_3/logs/stdio";;
 esac
-
-post_build() {
-	for F in $(find -type f -name main.go); do
-		go get -x $go_import_path/${F%/*}
-	done
-}
-
-do_install() {
-	find "${GOPATH}/bin" -type f -executable | while read line
-	do
-		if [ "$(basename $line)" = packer ]; then
-			vbin $line
-		else
-			vbin $line packer-$(basename $line)
-		fi
-	done
-}


### PR DESCRIPTION
Uses github.com/hashicorp/packer instead of
github.com/mitchellh/packer, since that's the wrong repository to
package from.

Removes template functions since they're not required.

git is no longer required.

Some template lines rearranged to satisfy xlint.