### PR TITLE
blackbox_exporter: remove broken= variable.

### DIFF
--- a/srcpkgs/blackbox_exporter/template
+++ b/srcpkgs/blackbox_exporter/template
@@ -8,7 +8,6 @@ go_ldflags="-X ${go_import_path}/version.Version=${version}
  -X ${go_import_path}/version.Revision=${version}
  -X ${go_import_path}/version.Branch=${version}
  -X ${go_import_path}/version.BuildUser=VoidLinux"
-hostmakedepends="git"
 short_desc="Allows blackbox probing of endpoints over HTTP, DNS, TCP and ICMP"
 maintainer="Toyam Cox <Vaelatern@voidlinux.eu>"
 license="Apache-2.0"
@@ -24,5 +23,3 @@ post_install() {
 	vdoc CONFIGURATION.md
 	vsv blackbox_exporter
 }
-
-broken="upstream checksum problems"


### PR DESCRIPTION
Also removes git dependency. Not needed since dependencies are
vendored.