### PR TITLE
cpio: fix CVE-2016-2037 ; out-of-bounds and segfaults

### DIFF
--- a/srcpkgs/cpio/patches/0001-Fix-out-of-bounds-read.patch
+++ b/srcpkgs/cpio/patches/0001-Fix-out-of-bounds-read.patch
@@ -1,0 +1,71 @@
+From d9723286ea5c32645f36baf83a7860bad46fec36 Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org.ua>
+Date: Thu, 10 Nov 2016 12:48:19 +0200
+Subject: [PATCH 1/4] Fix out-of-bounds read
+
+* src/copyin.c (process_copy_in): Skip records with zero filename length.
+---
+ src/copyin.c | 41 +++++++++++++++++++++++------------------
+ 1 file changed, 23 insertions(+), 18 deletions(-)
+
+diff --git src/copyin.c src/copyin.c
+index cde911e..05279d2 100644
+--- src/copyin.c
++++ src/copyin.c
+@@ -1378,30 +1378,35 @@ process_copy_in ()
+ 
+ 	}
+ #endif
+-      /* Is this the header for the TRAILER file?  */
+-      if (strcmp (CPIO_TRAILER_NAME, file_hdr.c_name) == 0)
++      if (file_hdr.c_namesize == 0)
++	skip_file = true;
++      else
+ 	{
+-	  done = true;
+-	  break;
+-	}
++	  /* Is this the header for the TRAILER file?  */
++	  if (strcmp (CPIO_TRAILER_NAME, file_hdr.c_name) == 0)
++	    {
++	      done = true;
++	      break;
++	    }
+ 
+-      cpio_safer_name_suffix (file_hdr.c_name, false, !no_abs_paths_flag,
+-			      false);
++	  cpio_safer_name_suffix (file_hdr.c_name, false, !no_abs_paths_flag,
++				  false);
+       
+-      /* Does the file name match one of the given patterns?  */
+-      if (num_patterns <= 0)
+-	skip_file = false;
+-      else
+-	{
+-	  skip_file = copy_matching_files;
+-	  for (i = 0; i < num_patterns
+-	       && skip_file == copy_matching_files; i++)
++	  /* Does the file name match one of the given patterns?  */
++	  if (num_patterns <= 0)
++	    skip_file = false;
++	  else
+ 	    {
+-	      if (fnmatch (save_patterns[i], file_hdr.c_name, 0) == 0)
+-		skip_file = !copy_matching_files;
++	      skip_file = copy_matching_files;
++	      for (i = 0; i < num_patterns
++		     && skip_file == copy_matching_files; i++)
++		{
++		  if (fnmatch (save_patterns[i], file_hdr.c_name, 0) == 0)
++		    skip_file = !copy_matching_files;
++		}
+ 	    }
+ 	}
+-
++      
+       if (skip_file)
+ 	{
+ 	  /* If we're skipping a file with links, there might be other
+-- 
+2.20.1
+

--- a/srcpkgs/cpio/patches/0002-Fix-signed-integer-overflow-big-block-sizes.patch
+++ b/srcpkgs/cpio/patches/0002-Fix-signed-integer-overflow-big-block-sizes.patch
@@ -1,0 +1,50 @@
+From 33ff2b0de5e9bd556b64fa8e0c20dbb72c41c0fc Mon Sep 17 00:00:00 2001
+From: grajagandev <dmoorefo@gmail.com>
+Date: Mon, 8 Feb 2016 07:58:45 -0800
+Subject: [PATCH 2/4] Fix signed integer overflow - big block sizes
+
+---
+ src/main.c         | 2 +-
+ tests/Makefile.am  | 3 ++-
+ tests/testsuite.at | 1 +
+ 3 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git src/main.c src/main.c
+index a13861f..5a30a7b 100644
+--- src/main.c
++++ src/main.c
+@@ -321,7 +321,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
+ 
+     case BLOCK_SIZE_OPTION:		/* --block-size */
+       io_block_size = atoi (arg);
+-      if (io_block_size < 1)
++      if (io_block_size < 1 || io_block_size > INT_MAX/512)
+ 	USAGE_ERROR ((0, 0, _("invalid block size")));
+       io_block_size *= 512;
+       break;
+diff --git tests/Makefile.am tests/Makefile.am
+index 2fbee29..863f46c 100644
+--- tests/Makefile.am
++++ tests/Makefile.am
+@@ -55,7 +55,8 @@ TESTSUITE_AT = \
+  symlink-bad-length.at\
+  symlink-long.at\
+  symlink-to-stdout.at\
+- version.at
++ version.at\
++ big-block-size.at
+ 
+ TESTSUITE = $(srcdir)/testsuite
+ 
+diff --git tests/testsuite.at tests/testsuite.at
+index 81e205b..b11c4a0 100644
+--- tests/testsuite.at
++++ tests/testsuite.at
+@@ -42,3 +42,4 @@ m4_include([setstat02.at])
+ m4_include([setstat03.at])
+ m4_include([setstat04.at])
+ m4_include([setstat05.at])
++m4_include([big-block-size.at])
+-- 
+2.20.1
+

--- a/srcpkgs/cpio/patches/0003-CVE-2016-2037-1-byte-out-of-bounds-write.patch
+++ b/srcpkgs/cpio/patches/0003-CVE-2016-2037-1-byte-out-of-bounds-write.patch
@@ -1,0 +1,340 @@
+From 5abe86f88de3c61e369483a55afe771cce646135 Mon Sep 17 00:00:00 2001
+From: Pavel Raiskup <praiskup@redhat.com>
+Date: Tue, 26 Jan 2016 23:17:54 +0100
+Subject: [PATCH 3/4] CVE-2016-2037 - 1 byte out-of-bounds write
+
+Ensure that cpio_safer_name_suffix always works with dynamically
+allocated buffer, and that it has size of at least 32 bytes.
+Then, any call to cpio_safer_name_suffix is safe (it requires at
+least 2 bytes in the buffer).
+
+Also ensure that c_namesize is always correctly initialized (by
+cpio_set_c_name) to avoid undefined behavior when reading
+file_hdr.c_namesize (previously happened for tar archives).
+
+References:
+http://www.mail-archive.com/bug-cpio@gnu.org/msg00545.html
+
+* src/copyin.c (query_rename): Drop the hack, as we now work with
+dynamically allocated buffer.  Use cpio_set_c_name.
+(create_defered_links_to_skipped): Use cpio_set_c_name rather than
+manual assignment.
+(read_name_from_file): New function to avoid C&P.
+(read_in_old_ascii, read_in_new_ascii, read_in_binary): Use
+read_name_from_file.
+(process_copy_in): Initialize file_hdr.c_namesize.
+* src/copyout.c (process_copy_out): Use cpio_set_c_name.
+* src/cpiohdr.h (cpio_set_c_name): New prototype.
+* src/tar.c (read_in_tar_header): Use cpio_set_c_name.
+* src/util.c (cpio_set_c_name): New function to set
+file_hdr->c_name and c_namesize from arbitrary string.
+(cpio_safer_name_suffix): Some docs fixes.
+* tests/inout.at: Also test copy-in, and try various formats.
+---
+ src/copyin.c   | 68 ++++++++++++++++----------------------------------
+ src/copyout.c  | 13 ++++------
+ src/cpiohdr.h  |  1 +
+ src/tar.c      | 10 +++++---
+ src/util.c     | 32 +++++++++++++++++++++++-
+ tests/inout.at | 19 ++++++++++++--
+ 6 files changed, 82 insertions(+), 61 deletions(-)
+
+diff --git src/copyin.c src/copyin.c
+index 05279d2..06ee1c3 100644
+--- src/copyin.c
++++ src/copyin.c
+@@ -76,28 +76,7 @@ query_rename(struct cpio_file_stat* file_hdr, FILE *tty_in, FILE *tty_out,
+       return -1;
+     }
+   else
+-  /* Debian hack: file_hrd.c_name is sometimes set to
+-     point to static memory by code in tar.c.  This
+-     causes a segfault.  This has been fixed and an
+-     additional check to ensure that the file name
+-     is not too long has been added.  (Reported by
+-     Horst Knobloch.)  This bug has been reported to
+-     "bug-gnu-utils@prep.ai.mit.edu". (99/1/6) -BEM */
+-    {
+-      if (archive_format != arf_tar && archive_format != arf_ustar)
+-	{
+-	  free (file_hdr->c_name);
+-	  file_hdr->c_name = xstrdup (new_name.ds_string);
+-	}
+-      else
+-	{
+-	  if (is_tar_filename_too_long (new_name.ds_string))
+-	    error (0, 0, _("%s: file name too long"),
+-		   new_name.ds_string);
+-	  else
+-	    strcpy (file_hdr->c_name, new_name.ds_string);
+-	}
+-    }
++    cpio_set_c_name (file_hdr, new_name.ds_string);
+   return 0;
+ }
+ 
+@@ -344,8 +323,7 @@ create_defered_links_to_skipped (struct cpio_file_stat *file_hdr,
+ 	    d_prev->next = d->next;
+ 	  else
+ 	    deferments = d->next;
+-	  free (file_hdr->c_name);
+-	  file_hdr->c_name = xstrdup(d->header.c_name);
++	  cpio_set_c_name (file_hdr, d->header.c_name);
+ 	  free_deferment (d);
+ 	  copyin_regular_file(file_hdr, in_file_des);
+ 	  return 0;
+@@ -1064,6 +1042,22 @@ read_in_header (struct cpio_file_stat *file_hdr, int in_des)
+     }
+ }
+ 
++static void
++read_name_from_file (struct cpio_file_stat *file_hdr, int fd, uintmax_t len)
++{
++  static char *tmp_filename;
++  static size_t buflen;
++
++  if (buflen < len)
++    {
++      buflen = len;
++      tmp_filename = xrealloc (tmp_filename, buflen);
++    }
++
++  tape_buffered_read (tmp_filename, fd, len);
++  cpio_set_c_name (file_hdr, tmp_filename);
++}
++
+ /* Fill in FILE_HDR by reading an old-format ASCII format cpio header from
+    file descriptor IN_DES, except for the magic number, which is
+    already filled in.  */
+@@ -1090,14 +1084,8 @@ read_in_old_ascii (struct cpio_file_stat *file_hdr, int in_des)
+   file_hdr->c_rdev_min = minor (dev);
+ 
+   file_hdr->c_mtime = FROM_OCTAL (ascii_header.c_mtime);
+-  file_hdr->c_namesize = FROM_OCTAL (ascii_header.c_namesize);
+   file_hdr->c_filesize = FROM_OCTAL (ascii_header.c_filesize);
+-  
+-  /* Read file name from input.  */
+-  if (file_hdr->c_name != NULL)
+-    free (file_hdr->c_name);
+-  file_hdr->c_name = (char *) xmalloc (file_hdr->c_namesize + 1);
+-  tape_buffered_read (file_hdr->c_name, in_des, (long) file_hdr->c_namesize);
++  read_name_from_file (file_hdr, in_des, FROM_OCTAL (ascii_header.c_namesize));
+ 
+   /* HP/UX cpio creates archives that look just like ordinary archives,
+      but for devices it sets major = 0, minor = 1, and puts the
+@@ -1152,14 +1140,8 @@ read_in_new_ascii (struct cpio_file_stat *file_hdr, int in_des)
+   file_hdr->c_dev_min = FROM_HEX (ascii_header.c_dev_min);
+   file_hdr->c_rdev_maj = FROM_HEX (ascii_header.c_rdev_maj);
+   file_hdr->c_rdev_min = FROM_HEX (ascii_header.c_rdev_min);
+-  file_hdr->c_namesize = FROM_HEX (ascii_header.c_namesize);
+   file_hdr->c_chksum = FROM_HEX (ascii_header.c_chksum);
+-  
+-  /* Read file name from input.  */
+-  if (file_hdr->c_name != NULL)
+-    free (file_hdr->c_name);
+-  file_hdr->c_name = (char *) xmalloc (file_hdr->c_namesize);
+-  tape_buffered_read (file_hdr->c_name, in_des, (long) file_hdr->c_namesize);
++  read_name_from_file (file_hdr, in_des, FROM_HEX (ascii_header.c_namesize));
+ 
+   /* In SVR4 ASCII format, the amount of space allocated for the header
+      is rounded up to the next long-word, so we might need to drop
+@@ -1207,16 +1189,9 @@ read_in_binary (struct cpio_file_stat *file_hdr,
+   file_hdr->c_rdev_min = minor (short_hdr->c_rdev);
+   file_hdr->c_mtime = (unsigned long) short_hdr->c_mtimes[0] << 16
+                       | short_hdr->c_mtimes[1];
+-
+-  file_hdr->c_namesize = short_hdr->c_namesize;
+   file_hdr->c_filesize = (unsigned long) short_hdr->c_filesizes[0] << 16
+                       | short_hdr->c_filesizes[1];
+-
+-  /* Read file name from input.  */
+-  if (file_hdr->c_name != NULL)
+-    free (file_hdr->c_name);
+-  file_hdr->c_name = (char *) xmalloc (file_hdr->c_namesize);
+-  tape_buffered_read (file_hdr->c_name, in_des, (long) file_hdr->c_namesize);
++  read_name_from_file (file_hdr, in_des, short_hdr->c_namesize);
+ 
+   /* In binary mode, the amount of space allocated in the header for
+      the filename is `c_namesize' rounded up to the next short-word,
+@@ -1297,6 +1272,7 @@ process_copy_in ()
+       read_pattern_file ();
+     }
+   file_hdr.c_name = NULL;
++  file_hdr.c_namesize = 0;
+ 
+   if (rename_batch_file)
+     {
+diff --git src/copyout.c src/copyout.c
+index 1f0987a..bb39559 100644
+--- src/copyout.c
++++ src/copyout.c
+@@ -660,8 +660,7 @@ process_copy_out ()
+ 	  cpio_safer_name_suffix (input_name.ds_string, false,
+ 				  !no_abs_paths_flag, true);
+ #ifndef HPUX_CDF
+-	  file_hdr.c_name = input_name.ds_string;
+-	  file_hdr.c_namesize = strlen (input_name.ds_string) + 1;
++	  cpio_set_c_name (&file_hdr, input_name.ds_string);
+ #else
+ 	  if ( (archive_format != arf_tar) && (archive_format != arf_ustar) )
+ 	    {
+@@ -670,16 +669,15 @@ process_copy_out ()
+ 		 properly recreate the directory as hidden (in case the
+ 		 files of a directory go into the archive before the
+ 		 directory itself (e.g from "find ... -depth ... | cpio")).  */
+-	      file_hdr.c_name = add_cdf_double_slashes (input_name.ds_string);
+-	      file_hdr.c_namesize = strlen (file_hdr.c_name) + 1;
++              cpio_set_c_name (&file_hdr,
++                               add_cdf_double_slashes (input_name.ds_string));
+ 	    }
+ 	  else
+ 	    {
+ 	      /* We don't mark CDF's in tar files.  We assume the "hidden"
+ 		 directory will always go into the archive before any of
+ 		 its files.  */
+-	      file_hdr.c_name = input_name.ds_string;
+-	      file_hdr.c_namesize = strlen (input_name.ds_string) + 1;
++              cpio_set_c_name (&file_hdr, input_name.ds_string);
+ 	    }
+ #endif
+ 
+@@ -866,8 +864,7 @@ process_copy_out ()
+   file_hdr.c_chksum = 0;
+ 
+   file_hdr.c_filesize = 0;
+-  file_hdr.c_namesize = 11;
+-  file_hdr.c_name = CPIO_TRAILER_NAME;
++  cpio_set_c_name (&file_hdr, CPIO_TRAILER_NAME);
+   if (archive_format != arf_tar && archive_format != arf_ustar)
+     write_out_header (&file_hdr, out_file_des);
+   else
+diff --git src/cpiohdr.h src/cpiohdr.h
+index b29e6fb..f4c63be 100644
+--- src/cpiohdr.h
++++ src/cpiohdr.h
+@@ -129,5 +129,6 @@ struct cpio_file_stat /* Internal representation of a CPIO header */
+   char *c_tar_linkname;
+ };
+ 
++void cpio_set_c_name(struct cpio_file_stat *file_hdr, char *name);
+ 
+ #endif /* cpiohdr.h */
+diff --git src/tar.c src/tar.c
+index a2ce171..e41f89d 100644
+--- src/tar.c
++++ src/tar.c
+@@ -282,7 +282,7 @@ read_in_tar_header (struct cpio_file_stat *file_hdr, int in_des)
+       if (null_block ((long *) &tar_rec, TARRECORDSIZE))
+ #endif
+ 	{
+-	  file_hdr->c_name = CPIO_TRAILER_NAME;
++	  cpio_set_c_name (file_hdr, CPIO_TRAILER_NAME);
+ 	  return;
+ 	}
+ #if 0
+@@ -316,9 +316,11 @@ read_in_tar_header (struct cpio_file_stat *file_hdr, int in_des)
+ 	}
+ 
+       if (archive_format != arf_ustar)
+-	file_hdr->c_name = stash_tar_filename (NULL, tar_hdr->name);
++        cpio_set_c_name (file_hdr, stash_tar_filename (NULL, tar_hdr->name));
+       else
+-	file_hdr->c_name = stash_tar_filename (tar_hdr->prefix, tar_hdr->name);
++        cpio_set_c_name (file_hdr, stash_tar_filename (tar_hdr->prefix,
++                                                      tar_hdr->name));
++
+       file_hdr->c_nlink = 1;
+       file_hdr->c_mode = FROM_OCTAL (tar_hdr->mode);
+       file_hdr->c_mode = file_hdr->c_mode & 07777;
+@@ -398,7 +400,7 @@ read_in_tar_header (struct cpio_file_stat *file_hdr, int in_des)
+ 	case AREGTYPE:
+ 	  /* Old tar format; if the last char in filename is '/' then it is
+ 	     a directory, otherwise it's a regular file.  */
+-	  if (file_hdr->c_name[strlen (file_hdr->c_name) - 1] == '/')
++	  if (file_hdr->c_name[file_hdr->c_namesize - 1] == '/')
+ 	    file_hdr->c_mode |= CP_IFDIR;
+ 	  else
+ 	    file_hdr->c_mode |= CP_IFREG;
+diff --git src/util.c src/util.c
+index 6ff6032..4f3c073 100644
+--- src/util.c
++++ src/util.c
+@@ -1410,8 +1410,34 @@ set_file_times (int fd,
+     utime_error (name);
+ }
+ 
++
++void
++cpio_set_c_name (struct cpio_file_stat *file_hdr, char *name)
++{
++  static size_t buflen = 0;
++  size_t len = strlen (name) + 1;
++
++  if (buflen == 0)
++    {
++      buflen = len;
++      if (buflen < 32)
++        buflen = 32;
++      file_hdr->c_name = xmalloc (buflen);
++    }
++  else if (buflen < len)
++    {
++      buflen = len;
++      file_hdr->c_name = xrealloc (file_hdr->c_name, buflen);
++    }
++
++  file_hdr->c_namesize = len;
++  memmove (file_hdr->c_name, name, len);
++}
++
+ /* Do we have to ignore absolute paths, and if so, does the filename
+-   have an absolute path?  */
++   have an absolute path?  Before calling this function make sure that the
++   allocated NAME buffer has capacity at least 2 bytes. */
++
+ void
+ cpio_safer_name_suffix (char *name, bool link_target, bool absolute_names,
+ 			bool strip_leading_dots)
+@@ -1426,6 +1452,10 @@ cpio_safer_name_suffix (char *name, bool link_target, bool absolute_names,
+ 	  ++p;
+       }
+   if (p != name)
++    /* The 'p' string is shortened version of 'name' with one exception;  when
++       the 'name' points to an empty string (buffer where name[0] == '\0') the
++       'p' then points to static string ".".  So caller needs to ensure there
++       are at least two bytes available in 'name' buffer so memmove succeeds. */
+     memmove (name, p, (size_t)(strlen (p) + 1));
+ }
+ 
+diff --git tests/inout.at tests/inout.at
+index 60c3716..730cbd2 100644
+--- tests/inout.at
++++ tests/inout.at
+@@ -35,7 +35,22 @@ while read NAME LENGTH
+ do
+ 	genfile --length $LENGTH > $NAME
+ 	echo $NAME
+-done < filelist |
+- cpio --quiet -o > archive])
++done < filelist > filelist_raw
++
++for format in bin odc newc crc tar ustar hpbin hpodc
++do
++    cpio --format=$format --quiet -o < filelist_raw > archive.$format
++    rm -rf output
++    mkdir output && cd output
++    cpio -i --quiet < ../archive.$format
++
++    while read file
++    do
++        test -f $file || echo "$file not found"
++    done < ../filelist_raw
++
++    cd ..
++done
++])
+ 
+ AT_CLEANUP
+-- 
+2.20.1
+

--- a/srcpkgs/cpio/patches/0004-Fix-sigfault-when-appending-to-archive.patch
+++ b/srcpkgs/cpio/patches/0004-Fix-sigfault-when-appending-to-archive.patch
@@ -1,0 +1,48 @@
+From ea9b0ecd469afe005137f6955b6237bcc252397b Mon Sep 17 00:00:00 2001
+From: Sergey Poznyakoff <gray@gnu.org>
+Date: Sat, 1 Dec 2018 11:40:02 +0200
+Subject: [PATCH 4/4] Fix sigfault when appending to archive
+
+Bug reported by Ross Burton. See
+<http://lists.gnu.org/archive/html/bug-cpio/2018-11/msg00000.html>
+
+* src/util.c: Keep static copy of the buffer pointer; always
+assign it to file_hdr->c_name. Use x2realloc for memory management.
+---
+ src/util.c | 17 ++++-------------
+ 1 file changed, 4 insertions(+), 13 deletions(-)
+
+diff --git src/util.c src/util.c
+index 4f3c073..41916d4 100644
+--- src/util.c
++++ src/util.c
+@@ -1414,22 +1414,13 @@ set_file_times (int fd,
+ void
+ cpio_set_c_name (struct cpio_file_stat *file_hdr, char *name)
+ {
++  static char *buf = NULL;
+   static size_t buflen = 0;
+   size_t len = strlen (name) + 1;
+ 
+-  if (buflen == 0)
+-    {
+-      buflen = len;
+-      if (buflen < 32)
+-        buflen = 32;
+-      file_hdr->c_name = xmalloc (buflen);
+-    }
+-  else if (buflen < len)
+-    {
+-      buflen = len;
+-      file_hdr->c_name = xrealloc (file_hdr->c_name, buflen);
+-    }
+-
++  while (buflen < len)
++    buf = x2realloc (buf, &buflen);
++  file_hdr->c_name = buf;
+   file_hdr->c_namesize = len;
+   memmove (file_hdr->c_name, name, len);
+ }
+-- 
+2.20.1
+

--- a/srcpkgs/cpio/template
+++ b/srcpkgs/cpio/template
@@ -1,9 +1,10 @@
 # Template file for 'cpio'
 pkgname=cpio
 version=2.12
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-rmt=/usr/bin/rmt"
+hostmakedepends="automake gettext-devel"
 checkdepends="bash"
 short_desc="GNU copy-in/out (cpio) with remote magnetic tape (rmt) support"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"
@@ -11,3 +12,7 @@ license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/cpio/"
 distfiles="${GNU_SITE}/cpio/cpio-${version}.tar.bz2"
 checksum=70998c5816ace8407c8b101c9ba1ffd3ebbecba1f5031046893307580ec1296e
+
+pre_configure() {
+	autoreconf -if
+}


### PR DESCRIPTION
Adds several security fixes
Corrects order of variables

hostmakedepends addition was needed for the build of tests/

Patches cherry-picked from http://git.savannah.gnu.org/cgit/cpio.git/log/