### PR TITLE
gendesk: add go_mod_mode=default option.

### DIFF
--- a/srcpkgs/gendesk/template
+++ b/srcpkgs/gendesk/template
@@ -1,9 +1,10 @@
 # Template file for 'gendesk'
 pkgname=gendesk
 version=1.0.2
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/xyproto/gendesk
+go_mod_mode=default
 hostmakedepends="git"
 short_desc="Utility to generate .desktop files and download icons"
 maintainer="Juan RP <xtraeme@voidlinux.eu>"


### PR DESCRIPTION
This fixes vendor detection with Go modules by forcing default Go
behavior to download dependencies, despite the presence of a vendor
dir. This is necessary because the vendor dir exists but is empty,
since it's a skeleton for Git submodules.