### PR TITLE
darkhttpd: fix service, read from conf file

### DIFF
--- a/srcpkgs/darkhttpd/files/darkhttpd/run
+++ b/srcpkgs/darkhttpd/files/darkhttpd/run
@@ -1,2 +1,4 @@
 #!/bin/sh
-exec darkhttpd /srv/www/darkhttpd --chroot --uid _darkhttpd --gid _darkhttpd --no-server-id &>/var/log/darkhttpd/darkhttpd.log
+[ -r conf ] && . ./conf
+: ${WWWDIR:=/srv/www/darkhttpd}
+exec darkhttpd "${WWWDIR}" --chroot --uid _darkhttpd --gid _darkhttpd $OPTS 2>&1 >>/var/log/darkhttpd/darkhttpd.log

--- a/srcpkgs/darkhttpd/template
+++ b/srcpkgs/darkhttpd/template
@@ -1,7 +1,7 @@
 # Template file for 'darkhttpd'
 pkgname=darkhttpd
 version=1.12
-revision=2
+revision=3
 short_desc="Small and secure static webserver"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="ISC"


### PR DESCRIPTION
The darkhttpd process would be backgrounded if /bin/sh does not support
"&>" syntax. If /bin/sh does support "&>" the log file would be started
afresh each time.

Let the directory to be served and other options be set in a conf file.