### PR TITLE
elfutils: fix CVE-2018-18310

### DIFF
--- a/srcpkgs/elfutils/patches/0001-libdwfl-Sanity-check-partial-core-file-data-reads.patch
+++ b/srcpkgs/elfutils/patches/0001-libdwfl-Sanity-check-partial-core-file-data-reads.patch
@@ -1,0 +1,76 @@
+From fdb44bb84a4db0fb418f3af6119811b83aa9523d Mon Sep 17 00:00:00 2001
+From: Mark Wielaard <mark@klomp.org>
+Date: Sun, 14 Oct 2018 16:45:48 +0200
+Subject: [PATCH] libdwfl: Sanity check partial core file data reads.
+
+There were two issues when reading note data from a core file.
+We didn't check if the data we already had in a buffer was big
+enough. And if we did get the data, we should check if we got
+everything, or just a part of the data.
+
+https://sourceware.org/bugzillshow_bug.cgi?id=23752
+
+Signed-off-by: Mark Wielaard <mark@klomp.org>
+---
+ libdwfl/ChangeLog                    | 11 +++++++++++
+ libdwfl/dwfl_segment_report_module.c | 13 +++++++++++--
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git libdwfl/ChangeLog libdwfl/ChangeLog
+index 5e9b986d..2e7efd45 100644
+--- libdwfl/ChangeLog
++++ libdwfl/ChangeLog
+@@ -1,3 +1,14 @@
++2018-10-14  Mark Wielaard  <mark@klomp.org>
++
++	* dwfl_segment_report_module.c (read_portion): Check requested
++	filesz isn't larger than buffer_available.
++	(dwfl_segment_report_module): Check data_size vs filesz after
++	read_portion call.
++
++2018-10-02  Andreas Schwab  <schwab@suse.de>
++
++	* relocate.c (relocate): Handle ADD/SUB relocations.
++
+ 2018-09-13  Mark Wielaard  <mark@klomp.org>
+ 
+ 	* dwfl_segment_report_module.c (dwfl_segment_report_module):
+diff --git libdwfl/dwfl_segment_report_module.c libdwfl/dwfl_segment_report_module.c
+index 36e5c823..87498846 100644
+--- libdwfl/dwfl_segment_report_module.c
++++ libdwfl/dwfl_segment_report_module.c
+@@ -1,5 +1,5 @@
+ /* Sniff out modules from ELF headers visible in memory segments.
+-   Copyright (C) 2008-2012, 2014, 2015 Red Hat, Inc.
++   Copyright (C) 2008-2012, 2014, 2015, 2018 Red Hat, Inc.
+    This file is part of elfutils.
+ 
+    This file is free software; you can redistribute it and/or modify
+@@ -301,7 +301,10 @@ dwfl_segment_report_module (Dwfl *dwfl, int ndx, const char *name,
+   inline bool read_portion (void **data, size_t *data_size,
+ 			    GElf_Addr vaddr, size_t filesz)
+   {
+-    if (vaddr - start + filesz > buffer_available
++    /* Check whether we will have to read the segment data, or if it
++       can be returned from the existing buffer.  */
++    if (filesz > buffer_available
++	|| vaddr - start > buffer_available - filesz
+ 	/* If we're in string mode, then don't consider the buffer we have
+ 	   sufficient unless it contains the terminator of the string.  */
+ 	|| (filesz == 0 && memchr (vaddr - start + buffer, '\0',
+@@ -459,6 +462,12 @@ dwfl_segment_report_module (Dwfl *dwfl, int ndx, const char *name,
+     if (read_portion (&data, &data_size, vaddr, filesz))
+       return;
+ 
++    /* data_size will be zero if we got everything from the initial
++       buffer, otherwise it will be the size of the new buffer that
++       could be read.  */
++    if (data_size != 0)
++      filesz = data_size;
++
+     assert (sizeof (Elf32_Nhdr) == sizeof (Elf64_Nhdr));
+ 
+     void *notes;
+-- 
+2.20.1
+

--- a/srcpkgs/elfutils/template
+++ b/srcpkgs/elfutils/template
@@ -2,7 +2,7 @@
 pkgname=elfutils
 reverts="0.175_1"
 version=0.174
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--program-prefix=eu-"
 hostmakedepends="automake libtool"


### PR DESCRIPTION
Patch is from 
https://sourceware.org/ml/elfutils-devel/2018-q4/msg00022.htm

CVE 
https://www.cvedetails.com/cve/CVE-2018-18310
/