### PR TITLE
gthumb: fix CVE-2018-18718

### DIFF
--- a/srcpkgs/gthumb/patches/cve-2018-18718.patch
+++ b/srcpkgs/gthumb/patches/cve-2018-18718.patch
@@ -1,0 +1,21 @@
+Description: CVE-2018-18718
+             An issue was discovered in gThumb through 3.6.2. There is a 
+             double-free vulnerability in the add_themes_from_dir method in 
+             dlg-contact-sheet.c because of two successive calls of g_free,
+             each of which frees the same buffer.
+             Thanks Tianjun Wu - https://gitlab.gnome.org/leoaccount
+             https://gitlab.gnome.org/GNOME/gthumb/issues/18
+Author: Herbert Parentes Fortes Neto <hpfn@debian.org>
+Last-Update: 2018-10-30
+Index: gthumb/extensions/contact_sheet/dlg-contact-sheet.c
+===================================================================
+--- extensions/contact_sheet/dlg-contact-sheet.c
++++ extensions/contact_sheet/dlg-contact-sheet.c
+@@ -352,6 +352,7 @@ add_themes_from_dir (DialogData *data,
+ 		if (! g_key_file_load_from_data (key_file, buffer, size, G_KEY_FILE_NONE, NULL)) {
+ 			g_key_file_free (key_file);
+ 			g_free (buffer);
++			buffer = NULL;
+ 			g_object_unref (file);
+ 			g_object_unref (file_info);
+ 		}

--- a/srcpkgs/gthumb/template
+++ b/srcpkgs/gthumb/template
@@ -1,7 +1,7 @@
 # Template file for 'gthumb'
 pkgname=gthumb
 version=3.6.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --disable-static
  $(vopt_enable tiff) $(vopt_enable clutter)
@@ -13,11 +13,11 @@ makedepends="webkit2gtk-devel json-glib-devel gnome-desktop-devel
  $(vopt_if tiff tiff-devel) $(vopt_if clutter clutter-gtk-devel)
  $(vopt_if gstreamer gstreamer1-devel) $(vopt_if soup libsoup-gnome-devel)
  $(vopt_if brasero brasero-devel)"
-short_desc='An image viewer and browser for the GNOME Desktop'
+short_desc='Image viewer and browser for the GNOME Desktop'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
 license="GPL-2.0-or-later"
 homepage="http://live.gnome.org/gthumb"
-distfiles="${GNOME_SITE}/gthumb/${version%.*}/gthumb-${version}.tar.xz"
+distfiles=${GNOME_SITE}/gthumb/${version%.*}/gthumb-${version}.tar.xz
 checksum=c9bf6bb7502659f5e990069527584bb96193f7f5f9492f0bf5f65828f5024b66
 
 ## Package build options


### PR DESCRIPTION
Add patch to fix CVE from Debian 
https://sources.debian.org/patches/gthumb/3:3.6.2-3/cve-2018-18718.patch/

CVE: 
https://nvd.nist.gov/vuln/detail/CVE-2018-18718