### PR TITLE
New package: glava-1.5.8

### DIFF
--- a/srcpkgs/glava/patches/0001-Fix-musl-build.patch
+++ b/srcpkgs/glava/patches/0001-Fix-musl-build.patch
@@ -1,0 +1,27 @@
+From 4705699bb680e574469b11a037acfc83f091d232 Mon Sep 17 00:00:00 2001
+From: Daniel Santana <daniel@santana.tech>
+Date: Fri, 4 Jan 2019 22:23:52 -0200
+Subject: [PATCH] Fix musl build
+
+---
+ glava.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/glava.c b/glava.c
+index dcb650f..758c8f0 100644
+--- a/glava.c
++++ b/glava.c
+@@ -69,6 +69,10 @@
+ #error "Unsupported target system"
+ #endif
+ 
++#ifndef ACCESSPERMS
++#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO) /* 0777 */
++#endif
++
+ /* Copy installed shaders/configuration from the installed location
+    (usually /etc/xdg). Modules (folders) will be linked instead of
+    copied. */
+-- 
+2.20.1
+

--- a/srcpkgs/glava/patches/0001-Use-SONAMEs-when-loading-GLX-libs-dinamically.patch
+++ b/srcpkgs/glava/patches/0001-Use-SONAMEs-when-loading-GLX-libs-dinamically.patch
@@ -1,0 +1,27 @@
+From 3ef23f0db8c81fd6091a7303214901ba0d68d0c0 Mon Sep 17 00:00:00 2001
+From: Daniel Santana <daniel@santana.tech>
+Date: Fri, 4 Jan 2019 21:57:52 -0200
+Subject: [PATCH] Use SONAMEs when loading GLX libs dinamically
+
+---
+ glx_wcb.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/glx_wcb.c b/glx_wcb.c
+index 4827152..d0afc0b 100644
+--- a/glx_wcb.c
++++ b/glx_wcb.c
+@@ -193,8 +193,8 @@ static void init(void) {
+     maximized   = false;
+     transparent = false;
+ 
+-    void* hgl  = dlopen("libGL.so", RTLD_LAZY);
+-    void* hglx = dlopen("libGLX.so", RTLD_LAZY);
++    void* hgl  = dlopen("libGL.so.1", RTLD_LAZY);
++    void* hglx = dlopen("libGLX.so.0", RTLD_LAZY);
+ 
+     if (!hgl && !hglx) {
+         fprintf(stderr, "Failed to load GLX functions (libGL and libGLX do not exist!)\n");
+-- 
+2.20.1
+

--- a/srcpkgs/glava/template
+++ b/srcpkgs/glava/template
@@ -1,0 +1,14 @@
+# Template file for 'glava'
+pkgname=glava
+version=1.5.8
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+makedepends="libX11-devel libXcomposite-devel libXext-devel libXrender-devel pulseaudio-devel"
+short_desc="OpenGL audio spectrum visualizer"
+maintainer="Daniel Santana <daniel@santana.tech>"
+license="GPL-3.0-only"
+homepage="https://github.com/wacossusca34/glava"
+distfiles="https://github.com/wacossusca34/glava/archive/v${version}.tar.gz"
+checksum=3dab12f87512f97c43a309da7aee5014c48a1cc7188949712c0665777f9a98d7
+patch_args="-Np1"


### PR DESCRIPTION
This package needs a patch to find libGL, as the current `libGL` package is not providing `libGL.so` symlink anymore (it was moved to `MesaLib-devel`). I believe this was an accident on 534b0595fb0, is that right @maxice8? Or should I upstream this fix?