### PR TITLE
owncloudclient: update to 2.5.1.10973.

### DIFF
--- a/srcpkgs/owncloudclient/template
+++ b/srcpkgs/owncloudclient/template
@@ -1,21 +1,21 @@
 # Template file for 'owncloudclient'
 pkgname=owncloudclient
-version=2.4.3
+version=2.5.1.10973
 revision=1
 build_style=cmake
 configure_args="-Wno-dev -DNO_SHIBBOLETH=TRUE"
+conf_files="/etc/ownCloud/sync-exclude.lst"
 hostmakedepends="pkg-config"
 makedepends="qtkeychain-qt5-devel sqlite-devel qt5-declarative-devel
  qt5-tools-devel qt5-plugin-odbc qt5-plugin-tds qt5-plugin-pgsql qt5-plugin-mysql
  qt5-plugin-sqlite"
 depends="qt5-plugin-sqlite"
-conf_files="/etc/ownCloud/sync-exclude.lst"
 short_desc="Connect to ownCloud servers"
 maintainer="Samuel Chodur <samuelchodur@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.owncloud.org"
 distfiles="https://download.owncloud.com/desktop/stable/${pkgname}-${version}.tar.xz"
-checksum=f3b3ff13d06a8a38a40398630d670775eafbfa9fee4fa5b39ea480bac3ebe6bf
+checksum=33eba1451696981a189e086f7f7cb1018782c332c8f7f0af86c79d87edcaa4a7
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-tools-devel"


### PR DESCRIPTION
It looks like the version number includes a build number now. Don't know if I should that write to a different variable to keep the two-dot version number.