### PR TITLE
lumina: switch to oxygen-icons5

### DIFF
--- a/srcpkgs/lumina/template
+++ b/srcpkgs/lumina/template
@@ -1,22 +1,22 @@
-# Template file for 'lumina'.
+# Template file for 'lumina'
 pkgname=lumina
 version=1.4.0p1
-revision=1
+revision=2
 wrksrc=lumina-qt5-${version%p*}
 build_style=qmake
+configure_args="QT5LIBDIR=/usr/lib/qt5 L_ETCDIR=/etc"
 hostmakedepends="qt5-host-tools"
 makedepends="qt5-devel qt5-x11extras-devel qt5-multimedia-devel qt5-svg-devel
  qt5-declarative-devel libXrender-devel libXcomposite-devel libXdamage-devel
  xcb-util-devel xcb-util-wm-devel xcb-util-image-devel pulseaudio-devel poppler-qt5-devel"
-depends="fluxbox numlockx xbacklight alsa-utils acpi xscreensaver oxygen-icons"
+depends="fluxbox numlockx xbacklight alsa-utils acpi xscreensaver oxygen-icons5"
 short_desc="Lumina Desktop Environment"
 maintainer="hipperson0 <hipperson0@gmail.com>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="https://github.com/trueos/lumina"
 distfiles="https://github.com/trueos/lumina/archive/qt5/${version}.tar.gz"
 checksum=5a25aed682489d460a8333466b0b333c6633f380de72410cff71c5bbfca88034
 replaces="lumina-git>=0"
-configure_args="QT5LIBDIR=/usr/lib/qt5 L_ETCDIR=/etc"
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-tools-devel qt5-x11extras-devel qt5-multimedia-devel qt5-svg-devel poppler-qt5-devel"


### PR DESCRIPTION
oxygen-icons pulls in qt4, while everything else uses qt5.

i think we could also remove the oxygen-icons package, as nothing uses it, and oxygen-icons5 provides the same stuff