### PR TITLE
cross-powerpc64*: add cpu/abi into bootstrap gcc

### DIFF
--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -99,6 +99,8 @@ _gcc_bootstrap() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
+	_args+=" --with-cpu=${_cpu}"
+	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c"
 	_args+=" --enable-decimal-float=no"
 	_args+=" --enable-secureplt"

--- a/srcpkgs/cross-powerpc64le-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64le-linux-gnu/template
@@ -95,6 +95,8 @@ _gcc_bootstrap() {
 
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
+	_args+=" --with-cpu=${_cpu}"
+	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c"
 	_args+=" --disable-libssp"
 	_args+=" --disable-libitm"

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -99,6 +99,8 @@ _gcc_bootstrap() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
+	_args+=" --with-cpu=${_cpu}"
+	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c"
 	_args+=" --enable-decimal-float=no"
 	_args+=" --enable-secureplt"


### PR DESCRIPTION
This is necessary to get things to build at all, and was formerly there, but got lost during a rebase.