### PR TITLE
dracut: patch for better dash compatibility

### DIFF
--- a/srcpkgs/dracut/patches/0001-remove-bashism-in-various-boot-scripts.patch
+++ b/srcpkgs/dracut/patches/0001-remove-bashism-in-various-boot-scripts.patch
@@ -1,0 +1,89 @@
+From 033921aa8346516d92ffe74fc1244089b9d61454 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C4=90o=C3=A0n=20Tr=E1=BA=A7n=20C=C3=B4ng=20Danh?=
+ <congdanhqx@gmail.com>
+Date: Sun, 6 Jan 2019 11:48:02 +0700
+Subject: [PATCH] remove bashism in various boot scripts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When using dash as initramfs shell, the boot process is broken.
+
+Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1663651
+Signed-off-by: Đoàn Trần Công Danh <congdanhqx@gmail.com>
+---
+ modules.d/90crypt/crypt-lib.sh         | 2 +-
+ modules.d/90crypt/parse-keydev.sh      | 2 +-
+ modules.d/91crypt-gpg/crypt-gpg-lib.sh | 2 +-
+ modules.d/95dcssblk/parse-dcssblk.sh   | 2 +-
+ modules.d/98syslog/rsyslogd-start.sh   | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git modules.d/90crypt/crypt-lib.sh modules.d/90crypt/crypt-lib.sh
+index bbf485e0..688ea251 100755
+--- modules.d/90crypt/crypt-lib.sh
++++ modules.d/90crypt/crypt-lib.sh
+@@ -191,7 +191,7 @@ readkey() {
+     local device="$3"
+ 
+     # No mounting needed if the keyfile resides inside the initrd
+-    if [ "/" == "$keydev" ]; then
++    if [ "/" = "$keydev" ]; then
+         local mntp=/
+     else
+         # This creates a unique single mountpoint for *, or several for explicitly
+diff --git modules.d/90crypt/parse-keydev.sh modules.d/90crypt/parse-keydev.sh
+index a45b2fb5..04813414 100755
+--- modules.d/90crypt/parse-keydev.sh
++++ modules.d/90crypt/parse-keydev.sh
+@@ -18,7 +18,7 @@ if getargbool 1 rd.luks -n rd_NO_LUKS && \
+         fi
+ 
+         # A keydev of '/' is treated as the initrd itself
+-        if [ "/" == "$keydev" ]; then
++        if [ "/" = "$keydev" ]; then
+             [ -z "$luksdev" ] && luksdev='*'
+             echo "$luksdev:$keydev:$keypath" >> /tmp/luks.keys
+             continue
+diff --git modules.d/91crypt-gpg/crypt-gpg-lib.sh modules.d/91crypt-gpg/crypt-gpg-lib.sh
+index b85ed2b8..c051b430 100755
+--- modules.d/91crypt-gpg/crypt-gpg-lib.sh
++++ modules.d/91crypt-gpg/crypt-gpg-lib.sh
+@@ -53,7 +53,7 @@ gpg_decrypt() {
+         --tries 3 --tty-echo-off
+ 
+     # Clean up the smartcard gpg-agent
+-    if [ "${useSmartcard}" == "1" ]; then
++    if [ "${useSmartcard}" = "1" ]; then
+         GNUPGHOME="$gpghome" gpg-connect-agent 1>/dev/null killagent /bye
+     fi
+ 
+diff --git modules.d/95dcssblk/parse-dcssblk.sh modules.d/95dcssblk/parse-dcssblk.sh
+index 8f174408..27ac1d8d 100644
+--- modules.d/95dcssblk/parse-dcssblk.sh
++++ modules.d/95dcssblk/parse-dcssblk.sh
+@@ -2,7 +2,7 @@
+ # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+ # ex: ts=8 sw=4 sts=4 et filetype=sh
+ dcssblk_arg=$(getarg rd.dcssblk=)
+-if [ $? == 0 ];then
++if [ $? = 0 ];then
+ 	info "Loading dcssblk segments=$dcssblk_arg"
+ 	modprobe dcssblk segments=$dcssblk_arg
+ fi
+diff --git modules.d/98syslog/rsyslogd-start.sh modules.d/98syslog/rsyslogd-start.sh
+index c64f2121..86ad50ea 100755
+--- modules.d/98syslog/rsyslogd-start.sh
++++ modules.d/98syslog/rsyslogd-start.sh
+@@ -38,7 +38,7 @@ rsyslog_config() {
+ [ -f /tmp/syslog.conf ] && read conf < /tmp/syslog.conf
+ [ -z "$conf" ] && conf="/etc/rsyslog.conf" && echo "$conf" > /tmp/syslog.conf
+ 
+-if [ $type == "rsyslogd" ]; then
++if [ $type = "rsyslogd" ]; then
+     template=/etc/templates/rsyslog.conf
+     if [ -n "$server" ]; then
+         rsyslog_config "$server" "$template" "$filters" > $conf
+-- 
+2.20.1
+

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,17 +1,17 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=048
-revision=2
+revision=3
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
+conf_files="/etc/dracut.conf"
 hostmakedepends="asciidoc pkg-config"
 makedepends="libkmod-devel"
 depends="bash coreutils cpio psmisc"
-conf_files="/etc/dracut.conf"
-homepage="http://www.kernel.org/pub/linux/utils/boot/dracut/dracut.html"
-short_desc="A new initramfs infrastructure"
+short_desc="Low-level tool for generating an initramfs/initrd image"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="http://www.kernel.org/pub/linux/utils/boot/dracut/dracut.html"
 distfiles="${KERNEL_SITE}/utils/boot/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=0750d6b71b7f95d8dfa338404372bfeb0e5c30e7fe2a21ba55c6dbf3dbcf6a79
 


### PR DESCRIPTION
Upstream bug report:
https://bugzilla.redhat.com/show_bug.cgi?id=1663651

Steps to reproduce:
- Full disk encryption,
- Luks key is encrypted with gpg
- luks key is embedded in initramfs
- cmdline is: rd.luks.key=/etc/luks/key.gpg:/
- add_dracutmodules+=" dash "
- omit_dracutmodues+=" bash "
- build dracut Expectation:
- the system should boot with new initramfs Actual:
- The system failed to pick the key in initramfs
- replace dash by bash and system can pick up the correct key

Root Cause:
There's some bashism inside runtime script,
which uses == instead of = to compare.