### PR TITLE
fix aarch64 cross sed'ing a shared library + fix ppc64le glibc cross

### DIFF
--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -221,9 +221,9 @@ _gcc_build() {
 	# Make this link to target libs.
 	if [ ! -f .sed_subst_done ]; then
 		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so ${_sysroot}/lib/libpthread.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so ${_sysroot}/lib/libpthread.so
+			-i ${_sysroot}/lib/libc.so
+		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
+			-i ${_sysroot}/lib/libc.so
 		touch .sed_subst_done
 	fi
 

--- a/srcpkgs/cross-powerpc64le-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64le-linux-gnu/template
@@ -185,16 +185,19 @@ _glibc_build() {
 	[ ! -d glibc-build ] && mkdir glibc-build
 	cd glibc-build
 
+	echo "slibdir=/usr/lib" > configparms
+
 	echo "libc_cv_forced_unwind=yes" > config.cache
 	echo "libc_cv_c_cleanup=yes" >> config.cache
 
 	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
 		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
 		NM="${_triplet}-nm"
-	export CFLAGS="-O2 -pipe -Wno-error ${_archflags}"
+	export CFLAGS="-O2 -pipe -Wno-error"
 
-	_args="--host=${_triplet}"
-	_args+=" --prefix=/usr"
+	_args="--prefix=/usr"
+	_args+=" --libdir=/usr/lib"
+	_args+=" --host=${_triplet}"
 	_args+=" --with-headers=${_sysroot}/usr/include"
 	_args+=" --config-cache"
 	_args+=" --enable-obsolete-rpc"
@@ -225,9 +228,9 @@ _gcc_build() {
 	# Make this link to target libs.
 	if [ ! -f .sed_subst_done ]; then
 		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so ${_sysroot}/lib/libpthread.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so ${_sysroot}/lib/libpthread.so
+			-i ${_sysroot}/usr/lib/libc.so
+		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
+			-i ${_sysroot}/usr/lib/libc.so
 		touch .sed_subst_done
 	fi
 
@@ -298,6 +301,10 @@ do_install() {
 				${DESTDIR}/${_sysroot}/${f}
 		fi
 	done
+	mkdir -p ${DESTDIR}/${_sysroot}/usr/lib
+	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
+	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
+	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib
 
 	# install linux API headers
 	cd ${wrksrc}/linux-${_linux_version}


### PR DESCRIPTION
This fixes some substitutions that were incorrectly copy-pasted before in aarch64, and does the same fixes plus other stuff in ppc64le glibc cross to make it work.

The same substitutions are also performed in the i686 glibc cross package, which i suspect was the source of the copy-paste; it should be checked whether libpthread.so there is also a shared library and fixed in the same manner, sadly I don't have an easy way to test it myself, so someone else will have to test and possibly fix it.

Fortunately, the incorrect substitution doesn't actually match anything, which means the builds are not actually affected, but it's still bad to keep this around - generally the aarch64 build does not change, so there is no need to bump its revision (it's just for correctness)

cc @chneukirchen @Gottox