### PR TITLE
yara: fix buffer overflow

### DIFF
--- a/srcpkgs/yara/patches/0001-Fix-buffer-overflow-in-dotnet-module.patch
+++ b/srcpkgs/yara/patches/0001-Fix-buffer-overflow-in-dotnet-module.patch
@@ -1,0 +1,36 @@
+From 7290feb9ee04c2e212b705dc2627a92382367595 Mon Sep 17 00:00:00 2001
+From: "Victor M. Alvarez" <vmalvarez@virustotal.com>
+Date: Wed, 19 Dec 2018 12:34:12 +0100
+Subject: [PATCH] Fix buffer overflow in dotnet module.
+
+Credit to OSS-Fuzz.
+---
+ libyarmodules/dotnet.c                         |  10 +++++++---
+ ...case-minimized-dotnet_fuzzer-5725060321509376 | Bin 0 -> 1024 bytes
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+ create mode 100644 tests/oss-fuzz/dotnet_fuzzer_corpus/clusterfuzz-testcase-minimized-dotnet_fuzzer-5725060321509376
+
+diff --git libyara/modules/dotnet.c libyara/modules/dotnet.c
+index 1fb1f0e..4a5f1a1 100644
+--- libyara/modules/dotnet.c
++++ libyarmodules/dotnet.c
+@@ -208,9 +208,13 @@ void dotnet_parse_us(
+   const uint8_t* offset = pe->data + metadata_root + us_header->Offset;
+   const uint8_t* end_of_header = offset + us_header->Size;
+ 
+-  // Make sure end of header is not past end of PE, and the first entry MUST be
+-  // a single NULL byte.
+-  if (!fits_in_pe(pe, offset, us_header->Size) || *offset != 0x00)
++  // Make sure the header size is larger than 0 and its end is not past the
++  // end of PE.
++  if (us_header->Size == 0 || !fits_in_pe(pe, offset, us_header->Size))
++    return;
++
++  // The first entry MUST be single NULL byte.
++  if (*offset != 0x00)
+     return;
+ 
+   offset++;
+-- 
+2.20.1
+

--- a/srcpkgs/yara/template
+++ b/srcpkgs/yara/template
@@ -1,15 +1,15 @@
 # Template file for 'yara'
 pkgname=yara
 version=3.8.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-magic --enable-cuckoo"
 hostmakedepends="automake libtool"
 makedepends="libressl-devel file-devel jansson-devel"
 short_desc="Pattern matching swiss knife for malware researchers"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="3-clause-BSD"
-homepage="http://virustotal.github.io/yara/"
+license="BSD-3-Clause"
+homepage="https://virustotal.github.io/yara/"
 distfiles="https://github.com/VirusTotal/yara/archive/v${version}.tar.gz"
 checksum=283527711269354d3c60e2705f7f74b1f769d2d35ddba8f7f9ce97d0fd5cb1ca
 


### PR DESCRIPTION
Patch is from upstream https://github.com/VirusTotal/yara/compare/v3.8.1...master
Used cherry-pick do to it having a binary blob in it, in which can't be patched

Fixed license format