### PR TITLE
enable aarch64 crosstoolchains on ppc64le hosts

### DIFF
--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -35,7 +35,7 @@ makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a"
-only_for_archs="x86_64"
+only_for_archs="x86_64 ppc64le"
 
 _apply_patch() {
 	local args="$1" pname="$(basename $2)"

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -33,7 +33,7 @@ nopie=yes
 nodebug=yes
 create_wrksrc=yes
 
-only_for_archs="x86_64 x86_64-musl"
+only_for_archs="x86_64 x86_64-musl ppc64le"
 hostmakedepends="perl flex gcc-ada libada-devel"
 makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a


### PR DESCRIPTION
This is just so I can do some aarch64 software builds on my ppc64le host system. It's already tested and works fine, both of them.