### PR TITLE
llvm7: add support for ppc64 targets

### DIFF
--- a/srcpkgs/llvm7/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
+++ b/srcpkgs/llvm7/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
@@ -1,0 +1,17 @@
+--- clang/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:52:16.174867512 +0100
++++ clang/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:56:25.040531791 +0100
+@@ -502,12 +502,12 @@
+     Loader = "ld.so.1";
+     break;
+   case llvm::Triple::ppc64:
+-    LibDir = "lib64";
++    LibDir = "lib";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+     break;
+   case llvm::Triple::ppc64le:
+-    LibDir = "lib64";
++    LibDir = "lib";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
+     break;

--- a/srcpkgs/llvm7/template
+++ b/srcpkgs/llvm7/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm7'
 pkgname=llvm7
 version=7.0.1
-revision=1
+revision=2
 wrksrc="llvm-${version}.src"
 lib32disabled=yes
 build_style=cmake
@@ -128,6 +128,7 @@ pre_configure() {
 		armv7*) _arch="Armv7";;
 		aarch64*) _arch="AArch64";;
 		mips*) _arch="Mips";;
+		ppc64*) _arch="PowerPC";;
 	esac
 	configure_args+=" -DLLVM_TARGET_ARCH=${_arch}"
 	configure_args+=" -DLLVM_DEFAULT_TARGET_TRIPLE=${XBPS_CROSS_TRIPLET:-$XBPS_TRIPLET}"


### PR DESCRIPTION
Besides supporting the arch itself, this also adds a patch to change the glibc dynamic linker path on ppc64 from lib64 to lib to match the same behavior on musl and x86_64 platforms.

Bumping rev is necessary here, as clang is always a cross-compiler and the patch will fix compiling for ppc64le from existing hosts.