### PR TITLE
nodejs: set nocross for 32-bit target and 64-bit host

### DIFF
--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -32,13 +32,20 @@ replaces="iojs>=0"
 conflicts="nodejs-lts"
 provides="nodejs-runtime-0_1"
 
+case "$XBPS_TARGET_MACHINE" in
+	arm*)
+		case "$XBPS_MACHINE" in
+			x86_64*|aarch64*)
+				nocross="Can't cross-compile to 32bit-host from 64bit-host";;
+		esac ;;
+esac
+
 do_configure() {
 	local _args
 
 	export LD="$CXX"
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
-			arm*) msg_error "Can only build Node for ARMv[5-7] from a 32-bit host.\n" ;;
 			aarch64*) _args="--dest-cpu=arm64 --without-snapshot" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
 		esac


### PR DESCRIPTION
@Cogitri