### PR TITLE
libjpeg-turbo: fix CVE-2018-19664 and additional int overflow

### DIFF
--- a/srcpkgs/libjpeg-turbo/patches/0001-tjLoadImage-Fix-int-overflow-segfault-w-big-BMP.patch
+++ b/srcpkgs/libjpeg-turbo/patches/0001-tjLoadImage-Fix-int-overflow-segfault-w-big-BMP.patch
@@ -1,0 +1,42 @@
+From 1e18a1a09af9f143400cedc54a210f616c80ffb9 Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Tue, 1 Jan 2019 18:57:36 -0600
+Subject: [PATCH] tjLoadImage(): Fix int overflow/segfault w/big BMP
+
+Fixes #304
+---
+diff --git turbojpeg.c turbojpeg.c
+index 90a9ce6..3f7cd64 100644
+--- turbojpeg.c
++++ turbojpeg.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (C)2009-2018 D. R. Commander.  All Rights Reserved.
++ * Copyright (C)2009-2019 D. R. Commander.  All Rights Reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+  * modification, are permitted provided that the following conditions are met:
+@@ -1960,7 +1960,8 @@ DLLEXPORT unsigned char *tjLoadImage(const char *filename, int *width,
+                                      int align, int *height, int *pixelFormat,
+                                      int flags)
+ {
+-  int retval = 0, tempc, pitch;
++  int retval = 0, tempc;
++  size_t pitch;
+   tjhandle handle = NULL;
+   tjinstance *this;
+   j_compress_ptr cinfo = NULL;
+@@ -2013,7 +2014,9 @@ DLLEXPORT unsigned char *tjLoadImage(const char *filename, int *width,
+   *pixelFormat = cs2pf[cinfo->in_color_space];
+ 
+   pitch = PAD((*width) * tjPixelSize[*pixelFormat], align);
+-  if ((dstBuf = (unsigned char *)malloc(pitch * (*height))) == NULL)
++  if ((unsigned long long)pitch * (unsigned long long)(*height) >
++      (unsigned long long)((size_t)-1) ||
++      (dstBuf = (unsigned char *)malloc(pitch * (*height))) == NULL)
+     _throwg("tjLoadImage(): Memory allocation failure");
+ 
+   if (setjmp(this->jerr.setjmp_buffer)) {
+-- 
+2.20.1
+

--- a/srcpkgs/libjpeg-turbo/patches/0002-wrbmp.c-Don-t-allow-quantization-w-non-RGB-CS.patch
+++ b/srcpkgs/libjpeg-turbo/patches/0002-wrbmp.c-Don-t-allow-quantization-w-non-RGB-CS.patch
@@ -1,0 +1,30 @@
+From 64bbd161f2a82c76db1f62a44714416ef44648a7 Mon Sep 17 00:00:00 2001
+From: DRC <information@libjpeg-turbo.org>
+Date: Tue, 1 Jan 2019 20:32:40 -0600
+Subject: [PATCH] wrbmp.c: Don't allow quantization w/ non-RGB CS
+
+If cinfo->quantize_colors == 1, then jpeg_calc_output_dimensions() will
+set cinfo->output_components to 1, and if cinfo->out_color_space is not
+RGB (or extended RGB), hilarity will ensue.
+
+Fixes #305
+---
+diff --git wrbmp.c wrbmp.c
+index 38a64e8..3489f14 100644
+--- wrbmp.c
++++ wrbmp.c
+@@ -506,8 +506,9 @@ jinit_write_bmp(j_decompress_ptr cinfo, boolean is_os2,
+       dest->pub.put_pixel_rows = put_gray_rows;
+     else
+       dest->pub.put_pixel_rows = put_pixel_rows;
+-  } else if (cinfo->out_color_space == JCS_RGB565 ||
+-             cinfo->out_color_space == JCS_CMYK) {
++  } else if (!cinfo->quantize_colors &&
++             (cinfo->out_color_space == JCS_RGB565 ||
++              cinfo->out_color_space == JCS_CMYK)) {
+     dest->pub.put_pixel_rows = put_pixel_rows;
+   } else {
+     ERREXIT(cinfo, JERR_BMP_COLORSPACE);
+-- 
+2.20.1
+

--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,14 +1,14 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
 version=2.0.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWITH_JPEG8=1 -DCMAKE_INSTALL_LIBDIR=/usr/lib"
 hostmakedepends="yasm"
 short_desc="Derivative of libjpeg which uses SIMD instructions"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="IJG, BSD-3-Clause, Zlib"
-homepage="http://libjpeg-turbo.virtualgl.org/"
+homepage="https://libjpeg-turbo.org/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=e5f86cec31df1d39596e0cca619ab1b01f99025a27dafdfc97a30f3a12f866ff
 


### PR DESCRIPTION
Patches from:
https://github.com/libjpeg-turbo/libjpeg-turbo/commit/3d9c64e9f8aa1ee954d1d0bb3390fc894bb84da3
https://github.com/libjpeg-turbo/libjpeg-turbo/commit/f8cca819a4fb42aafa5f70df43c45e8c416d716f

Homepage URL has changed