### PR TITLE
nodejs, nodejs-lts: enable cross for ppc64le targets, break ppc64be

### DIFF
--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -24,6 +24,11 @@ replaces="iojs>=0"
 conflicts="nodejs"
 provides="nodejs-runtime-0_1"
 
+case "$XBPS_TARGET_MACHINE" in
+        ppc64le*) ;;
+        ppc64*) broken="Node is not supported on ppc64 BE Linux";;
+esac
+
 do_configure() {
 	local _args
 
@@ -32,6 +37,7 @@ do_configure() {
 		case "$XBPS_TARGET_MACHINE" in
 			arm*) _args="--dest-cpu=arm --without-snapshot" ;;
 			aarch64*) _args="--dest-cpu=arm64 --without-snapshot" ;;
+			ppc64le*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}\n" ;;
 		esac
 	fi

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -38,6 +38,8 @@ case "$XBPS_TARGET_MACHINE" in
 			x86_64*|aarch64*)
 				nocross="Can't cross-compile to 32bit-host from 64bit-host";;
 		esac ;;
+	ppc64le*) ;;
+	ppc64*) broken="Node is not supported on ppc64 BE Linux";;
 esac
 
 do_configure() {
@@ -47,6 +49,7 @@ do_configure() {
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
 			aarch64*) _args="--dest-cpu=arm64 --without-snapshot" ;;
+			ppc64le*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
 		esac
 	fi


### PR DESCRIPTION
Upstream explicitly does not support big endian, so don't bother building it, even if it "builds" it will come out broken.