### PR TITLE
mongodb: enable build on ppc64 targets (with wiredtiger)

### DIFF
--- a/srcpkgs/mongodb/template
+++ b/srcpkgs/mongodb/template
@@ -3,20 +3,20 @@ pkgname=mongodb
 version=3.4.17
 revision=3
 wrksrc="mongodb-src-r${version}"
+only_for_archs="aarch64 x86_64 aarch64-musl x86_64-musl ppc64le ppc64le-musl ppc64-musl"
+conf_files="/etc/mongodb/mongodb.conf"
 hostmakedepends="scons"
 makedepends="pcre-devel snappy-devel libressl-devel libpcap-devel
  gperftools libsasl-devel yaml-cpp-devel"
 depends="cyrus-sasl-modules"
-conf_files="/etc/mongodb/mongodb.conf"
-system_accounts="mongodb"
-mongodb_homedir="/var/lib/mongodb"
 short_desc="High-performance, schema-free document-oriented database"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-homepage="http://www.mongodb.org"
 license="AGPL-3.0-only"
+homepage="http://www.mongodb.org"
 distfiles="https://fastdl.mongodb.org/src/mongodb-src-r${version}.tar.gz"
 checksum=6044e4c811a87bffd512a96fd2a4e4af9513af12f407bf7cd7c6281ccfb46484
-only_for_archs="aarch64 x86_64 aarch64-musl x86_64-musl"
+system_accounts="mongodb"
+mongodb_homedir="/var/lib/mongodb"
 
 make_dirs="
  /var/lib/mongodb 0700 mongodb mongodb
@@ -30,7 +30,7 @@ case "${XBPS_TARGET_MACHINE}" in
 		# error: conflicting types for 'wchar_t'
 		broken="https://build.voidlinux.eu/builders/aarch64-musl_builder/builds/2739/steps/shell_3/logs/stdio"
 		;;
-	x86_64*|aarch64*) makedepends+=" wiredtiger-devel";;
+	x86_64*|aarch64*|ppc64*) makedepends+=" wiredtiger-devel";;
 esac
 
 do_configure() {
@@ -44,7 +44,7 @@ do_configure() {
 do_build() {
 	# Choose storage engine
 	case "$XBPS_TARGET_MACHINE" in
-		x86_64*|aarch64*) _scons_args="--wiredtiger=on --use-system-wiredtiger";;
+		x86_64*|aarch64*|ppc64*) _scons_args="--wiredtiger=on --use-system-wiredtiger";;
 		i686*|arm*) _scons_args="--wiredtiger=off --mmapv1=on";;
 		*) _scons_args="--wiredtiger=off";;
 	esac


### PR DESCRIPTION
Depends on https://github.com/void-linux/void-packages/pull/6739.