### PR TITLE
go: use gcc-go to bootstrap on non-x86 host platforms

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -4,7 +4,6 @@ version=1.11.4
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
-hostmakedepends="go1.4-bootstrap"
 short_desc="The Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 homepage="http://golang.org/"
@@ -15,12 +14,24 @@ checksum=4cfd42720a6b1e79a8024895fa6607b69972e8e32446df76d6ce79801bbadb15
 nostrip=yes
 noverifyrdeps=yes
 
+# on x86 hosts (glibc/musl) we can use go1.4-bootstrap
+# on non-x86 hosts, gcc-go can be used instead
+case "${XBPS_MACHINE}" in
+    i686*|x86_64*)
+        hostmakedepends="go1.4-bootstrap"
+        _go14_bootstrap=yes
+        ;;
+    *) hostmakedepends="gcc-go gcc-go-tools";;
+esac
+
 case "${XBPS_TARGET_MACHINE}" in
 	aarch64*) _goarch=arm64 ;;
 	arm*) _goarch=arm ;;
 	mips*) _goarch=mips ;;
 	i686*) _goarch=386 ;;
 	x86_64*) _goarch=amd64 ;;
+	ppc64le*) _goarch=ppc64le ;;
+	ppc64*) broken="Upstream does not support ELFv2 for big endian ppc64";;
 	*) _goarch=${XBPS_TARGET_MACHINE} ;;
 esac
 
@@ -30,11 +41,15 @@ do_build() {
 	# dependency
 	unset CGO_CXXFLAGS CGO_CFLAGS CGO_ENABLED
 
+	if [ "$_go14_bootstrap" ]; then
+		export GOROOT_BOOTSTRAP="/usr/lib/go1.4"
+	else
+		export GOROOT_BOOTSTRAP="$(env -i go env GOROOT)"
+	fi
 
 	export GOCACHE=off
 	export GOROOT=$PWD
 	export GOROOT_FINAL="/usr/lib/go"
-	export GOROOT_BOOTSTRAP="/usr/lib/go1.4"
 	export GOARCH=${_goarch}
 
 	cd "src"


### PR DESCRIPTION
~~Since the go1.4 bootstrap compiler only works on x86 hosts, add the option to bootstrap using an existing go package (this will only work for cross, otherwise causes a loop when the binary package is older) as well as default to gcc-go on non-x86 glibc hosts.~~

~~On non-x86 musl hosts, mark broken, except when bootstrapping using an existing package.~~

Now depends on https://github.com/void-linux/void-packages/pull/6780.

Since the go1.4 bootstrap compiler only works on x86 hosts, fall back to gcc-go on those.

