### PR TITLE
hooks: Add hook to check for ELF files in /usr/share

### DIFF
--- a/common/hooks/post-install/11-pkglint-elf-in-usrshare.sh
+++ b/common/hooks/post-install/11-pkglint-elf-in-usrshare.sh
@@ -1,0 +1,30 @@
+# vim: set ts=4 sw=4 et:
+#
+# This hook executes the following tasks:
+#   - Looks on all packages for binary files being installed to /usr/share
+
+hook() {
+    local matches
+
+    if [ ! -d ${PKGDESTDIR}/usr/share ]; then
+        return 0
+    fi
+
+    # Find all binaries in /usr/share and add them to the pool
+    for f in $(find $PKGDESTDIR/usr/share -type f); do
+        case "$(file -bi "$f")" in
+            application/x-sharedlib*|application/x-pie-executable*)
+                matches+=" ${f#$PKGDESTDIR}" ;;
+        esac
+    done
+
+    if [ -z "$matches" ]; then
+        return 0
+    fi
+
+    msg_red "${pkgver}: ELF files found in /usr/share:\n"
+    for f in $matches; do
+        msg_red "   ${f}\n"
+    done
+    msg_error "${pkgver}: cannot continue with installation!\n"
+}


### PR DESCRIPTION
Inspired by #6731 

Example:

```
=> musikcube-0.60.1_1: running post-install hook: 11-pkglint-elf-in-usrshare ...
=> ERROR: musikcube-0.60.1_1: ELF files found in /usr/share:
=> ERROR:    /usr/share/musikcube/plugins/libalsaout.so
=> ERROR:    /usr/share/musikcube/plugins/libffmpegdecoder.so
=> ERROR:    /usr/share/musikcube/plugins/libhttpdatastream.so
=> ERROR:    /usr/share/musikcube/plugins/libnullout.so
=> ERROR:    /usr/share/musikcube/plugins/libpulseout.so
=> ERROR:    /usr/share/musikcube/plugins/libserver.so
=> ERROR:    /usr/share/musikcube/plugins/libstockencoders.so
=> ERROR:    /usr/share/musikcube/plugins/libsupereqdsp.so
=> ERROR:    /usr/share/musikcube/plugins/libtaglibreader.so
=> ERROR:    /usr/share/musikcube/libmusikcore.so
=> ERROR:    /usr/share/musikcube/musikcube
=> ERROR:    /usr/share/musikcube/musikcubed
=> ERROR: musikcube-0.60.1_1: cannot continue with installation!
```