### PR TITLE
poppler: update to 0.73.0.

### DIFF
--- a/srcpkgs/inkscape/patches/poppler-073.patch
+++ b/srcpkgs/inkscape/patches/poppler-073.patch
@@ -1,0 +1,13 @@
+diff --git a/src/extension/internal/pdfinput/pdf-parser.h b/src/extension/internal/pdfinput/pdf-parser.h
+index 0c04d87..082e007 100644
+--- src/extension/internal/pdfinput/pdf-parser.h
++++ src/extension/internal/pdfinput/pdf-parser.h
+@@ -27,7 +27,6 @@ namespace Inkscape {
+ using Inkscape::Extension::Internal::SvgBuilder;
+ 
+ #include "glib/poppler-features.h"
+-#include "goo/gtypes.h"
+ #include "Object.h"
+ 
+ class GooString;
+

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.92.3
-revision=9
+revision=10
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
  --without-gnome-vfs --disable-static"

--- a/srcpkgs/ipe/patches/poppler-073.patch
+++ b/srcpkgs/ipe/patches/poppler-073.patch
@@ -1,0 +1,27 @@
+diff --git a/ipe-tools/pdftoipe/parseargs.h b/ipe-tools/pdftoipe/parseargs.h
+index 8530bd1..bf87418 100644
+--- ipe-tools/pdftoipe/parseargs.h
++++ ipe-tools/pdftoipe/parseargs.h
+@@ -27,8 +27,6 @@
+ extern "C" {
+ #endif
+ 
+-#include "goo/gtypes.h"
+-
+ /*
+  * Argument kinds.
+  */
+diff --git a/ipe-tools/pdftoipe/xmloutputdev.cpp b/ipe-tools/pdftoipe/xmloutputdev.cpp
+index 3c38f2e..7186437 100644
+--- ipe-tools/pdftoipe/xmloutputdev.cpp
++++ ipe-tools/pdftoipe/xmloutputdev.cpp
+@@ -330,7 +330,7 @@ void XmlOutputDev::drawImage(GfxState *state, Object *ref, Stream *str,
+   finishText();
+ 
+   ImageStream *imgStr;
+-  Guchar *p;
++  unsigned char *p;
+   GfxRGB rgb;
+   int x, y;
+   int c;
+

--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -1,7 +1,7 @@
 # Template file for 'ipe'
 pkgname=ipe
 version=7.2.7
-revision=14
+revision=15
 _tools_commit=e5b23399a83d69fd5bb5d4645ef7325b4b57435b
 hostmakedepends="pkg-config qt5-qmake qt5-tools qt5-host-tools wget"
 makedepends="qt5-devel lua52-devel libjpeg-turbo-devel cairo-devel poppler-devel"
@@ -28,9 +28,9 @@ post_extract() {
 }
 
 do_build() {
-	make ${makejobs} -C src IPEPREFIX=/usr LUA_PACKAGE=lua5.2 CXX="$CXX"
-	make ${makejobs} -C ipe-tools/figtoipe CXX="$CXX"
-	make ${makejobs} -C ipe-tools/pdftoipe CXX="$CXX"
+	make ${makejobs} -C src IPEPREFIX=/usr LUA_PACKAGE=lua5.2 CXX="$CXX" CXXFLAGS="$CXXFLAGS"
+	make ${makejobs} -C ipe-tools/figtoipe CXX="$CXX" CXXFLAGS="$CXXFLAGS"
+	make ${makejobs} -C ipe-tools/pdftoipe CXX="$CXX" CXXFLAGS="$CXXFLAGS"
 }
 
 do_install() {

--- a/srcpkgs/libgdal/patches/poppler-073.patch
+++ b/srcpkgs/libgdal/patches/poppler-073.patch
@@ -1,0 +1,64 @@
+diff --git a/frmts/pdf/pdfio.cpp b/frmts/pdf/pdfio.cpp
+index b00560d..f9b4955 100644
+--- frmts/pdf/pdfio.cpp
++++ frmts/pdf/pdfio.cpp
+@@ -389,7 +389,7 @@ GBool VSIPDFFileStream::hasGetChars()
+ /*                            getChars()                                */
+ /************************************************************************/
+ 
+-int VSIPDFFileStream::getChars(int nChars, Guchar *buffer)
++int VSIPDFFileStream::getChars(int nChars, unsigned char *buffer)
+ {
+     int nRead = 0;
+     while (nRead < nChars)
+diff --git a/frmts/pdf/pdfio.h b/frmts/pdf/pdfio.h
+index 795fc2b..f73bb99 100644
+--- frmts/pdf/pdfio.h
++++ frmts/pdf/pdfio.h
+@@ -30,6 +30,7 @@
+ #ifndef PDFIO_H_INCLUDED
+ #define PDFIO_H_INCLUDED
+ 
++#include <goo/gfile.h>
+ #include "cpl_vsi_virtual.h"
+ 
+ /************************************************************************/
+@@ -46,9 +47,9 @@
+ #define moveStart_delta_type Goffset
+ #else
+ #define getPos_ret_type int
+-#define getStart_ret_type Guint
+-#define makeSubStream_offset_type Guint
+-#define setPos_offset_type Guint
++#define getStart_ret_type unsigned int
++#define makeSubStream_offset_type unsigned int
++#define setPos_offset_type unsigned int
+ #define moveStart_delta_type int
+ #endif
+ 
+@@ -109,10 +110,10 @@ class VSIPDFFileStream final: public BaseStream
+          * but will still compile correctly.
+          */
+         virtual GBool hasGetChars() override;
+-        virtual int getChars(int nChars, Guchar *buffer) override;
++        virtual int getChars(int nChars, unsigned char *buffer) override;
+ #else
+         virtual GBool hasGetChars() ;
+-        virtual int getChars(int nChars, Guchar *buffer) ;
++        virtual int getChars(int nChars, unsigned char *buffer) ;
+ #endif
+ 
+         VSIPDFFileStream  *poParent;
+diff --git a/frmts/pdf/pdfsdk_headers.h b/frmts/pdf/pdfsdk_headers.h
+index 9150b0f..5e0f669 100644
+--- frmts/pdf/pdfsdk_headers.h
++++ frmts/pdf/pdfsdk_headers.h
+@@ -50,7 +50,6 @@
+ #pragma warning( disable : 4244 ) /* conversion from 'const int' to 'Guchar', possible loss of data */
+ #endif
+ 
+-#include <goo/gtypes.h>
+ #include <goo/GooList.h>
+ 
+ /* begin of poppler xpdf includes */
+

--- a/srcpkgs/libgdal/template
+++ b/srcpkgs/libgdal/template
@@ -1,7 +1,7 @@
 # Template file for 'libgdal'
 pkgname=libgdal
 version=2.4.0
-revision=1
+revision=2
 wrksrc="gdal-${version}"
 build_style=gnu-configure
 configure_args="--with-liblzma --with-poppler"


### PR DESCRIPTION
- [x] calligra-filters
- [x] cups-filters
- [x] extractpdfmark
- [x] inkscape
- [x] ipe
- [x] libgdal