### PR TITLE
[wip] gcc: enable gcc-go on musl

### DIFF
--- a/srcpkgs/gcc/patches/libgo-use-off64_t.patch
+++ b/srcpkgs/gcc/patches/libgo-use-off64_t.patch
@@ -1,0 +1,30 @@
+--- libgo/go/syscall/libcall_linux.go
++++ libgo/go/syscall/libcall_linux.go
+@@ -334,19 +334,19 @@ func Sendfile(outfd int, infd int, offset *int64, count int) (written int, err e
+ //sys	Setxattr(path string, attr string, data []byte, flags int) (err error)
+ //setxattr(path *byte, name *byte, value *byte, size Size_t, flags _C_int) _C_int
+ 
+-//sys	splice(rfd int, roff *_loff_t, wfd int, woff *_loff_t, len int, flags int) (n int64, err error)
+-//splice(rfd _C_int, roff *_loff_t, wfd _C_int, woff *_loff_t, len Size_t, flags _C_uint) Ssize_t
++//sys	splice(rfd int, roff *_off64_t, wfd int, woff *_off64_t, len int, flags int) (n int64, err error)
++//splice(rfd _C_int, roff *_off64_t, wfd _C_int, woff *_off64_t, len Size_t, flags _C_uint) Ssize_t
+ func Splice(rfd int, roff *int64, wfd int, woff *int64, len int, flags int) (n int64, err error) {
+-	var lroff _loff_t
+-	var plroff *_loff_t
++	var lroff _off64_t
++	var plroff *_off64_t
+ 	if roff != nil {
+-		lroff = _loff_t(*roff)
++		lroff = _off64_t(*roff)
+ 		plroff = &lroff
+ 	}
+-	var lwoff _loff_t
+-	var plwoff *_loff_t
++	var lwoff _off64_t
++	var plwoff *_off64_t
+ 	if woff != nil {
+-		lwoff = _loff_t(*woff)
++		lwoff = _off64_t(*woff)
+ 		plwoff = &lwoff
+ 	}
+ 	n, err = splice(rfd, plroff, wfd, plwoff, len, flags)

--- a/srcpkgs/gcc/patches/musl-libgo-go-signal.c.patch
+++ b/srcpkgs/gcc/patches/musl-libgo-go-signal.c.patch
@@ -1,0 +1,45 @@
+--- libgo/runtime/go-signal.c
++++ libgo/runtime/go-signal.c
+@@ -4,6 +4,8 @@
+    Use of this source code is governed by a BSD-style
+    license that can be found in the LICENSE file.  */
+ 
++#include <asm/ptrace.h>
++
+ #include <signal.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+@@ -222,7 +224,7 @@ getSiginfo(siginfo_t *info, void *context __attribute__((unused)))
+ #endif
+ #ifdef __PPC__
+   #ifdef __linux__
+-       ret.sigpc = ((ucontext_t*)(context))->uc_mcontext.regs->nip;
++       ret.sigpc = ((struct pt_regs *)((ucontext_t*)(context))->uc_mcontext.regs)->nip;
+   #endif
+   #ifdef _AIX
+        ret.sigpc = ((ucontext_t*)(context))->uc_mcontext.jmp_context.iar;
+@@ -349,14 +351,16 @@ dumpregs(siginfo_t *info __attribute__((unused)), void *context __attribute__((u
+                mcontext_t *m = &((ucontext_t*)(context))->uc_mcontext;
+                int i;
+ 
++               struct pt_regs *regs = m->regs;
++
+                for (i = 0; i < 32; i++)
+-                       runtime_printf("r%d %X\n", i, m->regs->gpr[i]);
+-               runtime_printf("pc  %X\n", m->regs->nip);
+-               runtime_printf("msr %X\n", m->regs->msr);
+-               runtime_printf("cr  %X\n", m->regs->ccr);
+-               runtime_printf("lr  %X\n", m->regs->link);
+-               runtime_printf("ctr %X\n", m->regs->ctr);
+-               runtime_printf("xer %X\n", m->regs->xer);
++                       runtime_printf("r%d %X\n", i, regs->gpr[i]);
++               runtime_printf("pc  %X\n", regs->nip);
++               runtime_printf("msr %X\n", regs->msr);
++               runtime_printf("cr  %X\n", regs->ccr);
++               runtime_printf("lr  %X\n", regs->link);
++               runtime_printf("ctr %X\n", regs->ctr);
++               runtime_printf("xer %X\n", regs->xer);
+          }
+   #endif
+ #endif
+

--- a/srcpkgs/gcc/patches/musl-libgo-pt_regs.patch
+++ b/srcpkgs/gcc/patches/musl-libgo-pt_regs.patch
@@ -1,0 +1,18 @@
+--- libgo/sysinfo.c
++++ libgo/sysinfo.c
+@@ -105,6 +105,7 @@
+ #if defined(HAVE_LINUX_PTRACE_H)
+ /* Avoid https://sourceware.org/bugzilla/show_bug.cgi?id=762 .  */
+ #define ia64_fpreg pt_ia64_fpreg
++#define pt_regs pt_ignore_regs
+ #define pt_all_user_regs pt_ia64_all_user_regs
+ /* Avoid redefinition of ptrace_peeksiginfo from <sys/ptrace.h>.
+    https://gcc.gnu.org/PR81324 .  */
+@@ -112,6 +113,7 @@
+ #include <linux/ptrace.h>
+ #undef ia64_fpreg
+ #undef pt_all_user_regs
++#undef pt_regs
+ #undef ptrace_peeksiginfo_args
+ #endif
+ #if defined(HAVE_LINUX_RTNETLINK_H)

--- a/srcpkgs/gcc/patches/musl-libgo-types.patch
+++ b/srcpkgs/gcc/patches/musl-libgo-types.patch
@@ -1,0 +1,13 @@
+--- libgo/sysinfo.c
++++ libgo/sysinfo.c
+@@ -288,3 +288,10 @@ enum {
+   epoll_data_offset = offsetof(struct epoll_event, data)
+ };
+ #endif
++
++/* on musl off64_t is a macro, define it for real so go can use it */
++#if defined(HAVE_OFF64_T) && defined(off64_t)
++typedef off64_t real_off64_t;
++#undef off64_t
++typedef real_off64_t off64_t;
++#endif

--- a/srcpkgs/gcc/patches/musl-libgo-ucontext.patch
+++ b/srcpkgs/gcc/patches/musl-libgo-ucontext.patch
@@ -1,0 +1,14 @@
+--- libgo/configure
++++ libgo/configure
+@@ -13854,6 +13854,11 @@ case "$target" in
+ esac
+ 
+ 
++case "$target" in
++    *-*-linux-musl*)
++       LIBS="-lucontext $LIBS"
++    ;;
++esac
+ 
+   test -z "$HWCAP_CFLAGS" && HWCAP_CFLAGS=''
+ 

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -7,7 +7,7 @@ _isl_version=0.19
 
 pkgname=gcc
 version=${_majorver}.0
-revision=8
+revision=9
 short_desc="The GNU C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="http://gcc.gnu.org"
@@ -69,11 +69,10 @@ if [ "$CHROOT_READY" ]; then
 	subpackages+=" gcc-fortran libgfortran-devel libgfortran"
 	if [ -z "$CROSS_BUILD" ]; then
 		subpackages+=" gcc-objc gcc-objc++ libobjc-devel libobjc"
+		subpackages+=" gcc-go gcc-go-tools libgo-devel libgo"
 		case "$XBPS_TARGET_MACHINE" in
-		*-musl)	# Go won't link for musl libc
-			;;
-		*)	subpackages+=" gcc-go gcc-go-tools libgo-devel libgo"
-			;;
+			*-musl) makedepends+=" libucontext-devel";;
+			*) ;;
 		esac
 	fi
 fi
@@ -218,13 +217,7 @@ do_configure() {
 		export LD_LIBRARY_PATH="${XBPS_MASTERDIR}/usr/lib"
 		_args+=" --build=${_triplet}"
 	else
-		_langs="c,c++,objc,obj-c++,fortran,lto"
-		case "$XBPS_TARGET_MACHINE" in
-			*-musl)	# Linking libgo.so is broken for musl libc
-				;;
-			*)	_langs+=",go"
-				;;
-		esac
+		_langs="c,c++,objc,obj-c++,fortran,go,lto"
 		_args+=" --build=${_triplet}"
 		_args+=" --enable-fast-character"
 	fi


### PR DESCRIPTION
This does not enable it when cross compiling, as that would also require modifying and rebuilding the cross toolchains, but it allows for having a bootstrap compiler for Go on non-x86 musl platforms where go1.4-bootstrap does not work.