### PR TITLE
calcurse: fix missing dependency for caldav

### DIFF
--- a/srcpkgs/calcurse/template
+++ b/srcpkgs/calcurse/template
@@ -1,15 +1,16 @@
 # Template file for 'calcurse'
 pkgname=calcurse
 version=4.3.0
-revision=1
+revision=2
 build_style=gnu-configure
-short_desc="Ncurses planner"
 makedepends="ncurses-devel"
+depends="python3-httplib2"
+short_desc="Ncurses planner"
 maintainer="silvernode <mollusk@homebutter.com>"
-license="2-clause-BSD"
+license="BSD-2-Clause"
 homepage="http://calcurse.org"
 distfiles="http://calcurse.org/files/${pkgname}-${version}.tar.gz"
-checksum=31ecc3dc09e1e561502b4c94f965ed6b167c03e9418438c4a7ad5bad2c785f9a
+checksum=750051d322a8afc3b808e705ceffcc71f916510fe9195df14cf7746fe3ed8cc5
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Prevents:
```
[void@void ~]$ calcurse-caldav 
Traceback (most recent call last):
  File "/usr/bin/calcurse-caldav", line 6, in <module>
    import httplib2
ModuleNotFoundError: No module named 'httplib2'

```