### PR TITLE
gdb: update to 8.2.1.

### DIFF
--- a/srcpkgs/gdb/patches/aarch64-headers.patch
+++ b/srcpkgs/gdb/patches/aarch64-headers.patch
@@ -1,0 +1,17 @@
+Source: https://git.alpinelinux.org/aports/tree/main/gdb/aarch64-headers.patch
+Upstream: Yes
+Reason: FTBFS
+
+diff --git a/gdb/nat/aarch64-sve-linux-ptrace.h b/gdb/nat/aarch64-sve-linux-ptrace.h
+index 029e753..172ae39 100644
+--- a/gdb/nat/aarch64-sve-linux-ptrace.h
++++ b/gdb/nat/aarch64-sve-linux-ptrace.h
+@@ -20,7 +20,7 @@
+ #ifndef AARCH64_SVE_LINUX_PTRACE_H
+ #define AARCH64_SVE_LINUX_PTRACE_H
+ 
+-#include <asm/sigcontext.h>
++#include <signal.h>
+ #include <sys/utsname.h>
+ #include <sys/ptrace.h>
+ #include <asm/ptrace.h>

--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -1,8 +1,7 @@
 # Template file for 'gdb'
 pkgname=gdb
-version=8.1.1
+version=8.2.1
 revision=1
-patch_args="-Np1"
 build_style=gnu-configure
 pycompile_dirs="/usr/share/gdb"
 configure_args="--disable-werror --disable-nls --with-system-readline
@@ -16,7 +15,8 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/gdb/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=97dcc3169bd430270fc29adb65145846a58c1b55cdbb73382a4a89307bdad03c
+checksum=0a6a432907a03c5c8eaad3c3cffd50c00a40c3a5e3c4039440624bae703f2202
+patch_args="-Np1"
 
 if [ "${CROSS_BUILD}" ]; then
 	# Make python3.x detection work in cross builds


### PR DESCRIPTION
Builds on aarch64-musl, too. See https://github.com/void-linux/void-packages/pull/2487.