### PR TITLE
testssl.sh: update to 3.0rc3.

### DIFF
--- a/srcpkgs/testssl.sh/template
+++ b/srcpkgs/testssl.sh/template
@@ -1,17 +1,25 @@
 # Template file for 'testssl.sh'
 pkgname=testssl.sh
-version=2.9.5r5
+version=3.0rc3
 revision=1
-wrksrc="${pkgname}-${version/r/-}"
+noarch=yes
 depends="libressl"
 short_desc="Command line tool which checks a server for the support of TLS/SSL"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
-homepage="http://testssl.sh"
-distfiles="https://github.com/drwetter/testssl.sh/archive/v${version/r/-}.tar.gz"
-checksum=836a7b45455c95f17c4d7eec9468028a7fc6b613fd4b3c8e8e125b7b8206b89d
-noarch=yes
+homepage="https://testssl.sh"
+distfiles="https://github.com/drwetter/testssl.sh/archive/${version}.tar.gz"
+checksum=45f8aed24ad749175608a29c50566240a8a1b8ebcb32531d7bf6231ec269f4a5
+
+pre_install() {
+	# Set TESTSSL_INSTALL_DIR so that we can install to a custom dir
+	sed 's|LL_DIR:-""|LL_DIR:-/usr/share/testssl.sh/|' -i testssl.sh
+}
 
 do_install() {
 	vbin testssl.sh
+	vmkdir /usr/share/testssl.sh
+	vcopy etc/ /usr/share/testssl.sh/
+	vdoc Readme.md
+	vman doc/testssl.1
 }


### PR DESCRIPTION
Upstream encourages us to use the 3.x version:

"
  All distributors and others who use it also for
  production-like environment are encouraged
  to switch to this branch
"

@Gottox