### PR TITLE
NetworkManager: Fix suspend and resume detection.

### DIFF
--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager'
 pkgname=NetworkManager
 version=1.14.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-dhcpcd --with-dhclient=/usr/bin/dhclient
  --with-system-ca-path=/etc/ssl/certs --enable-more-warnings=no
@@ -11,7 +11,7 @@ configure_args="--without-dhcpcd --with-dhclient=/usr/bin/dhclient
  --with-pppd-plugin-dir=/usr/lib/pppd/2.4.7 --enable-modify-system
  --with-modem-manager-1 --with-resolvconf=/usr/bin/resolvconf
  --with-session-tracking=$(vopt_if elogind logind consolekit)
- --with-suspend-resume=upower --with-libnm-glib --disable-ifupdown
+ --with-suspend-resume=consolekit --with-libnm-glib --disable-ifupdown
  --with-systemdsystemunitdir=no --enable-polkit-agent --enable-tests=no
  --with-systemd-journal=no --with-systemd-logind=no --disable-gtk-doc
  --with-dbus-sys-dir=/etc/dbus-1/system.d


### PR DESCRIPTION
Upower dropped suspend and resume functionality and this was added into
Consolekit2 via the inhibit API.