### PR TITLE
rpi-kernel: update to 4.14.92.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="a0911976a8732eb0d9ad1088865e60e1f28c0099"
+_githash="4de3f6305841c2121257b8fdbda5c3c0bf77e669"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.91
+version=4.14.92
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=7b33e26592206082efc3b4aef9a0f874f20536237e614df2982eabcd83649e85
+checksum=67a32d7af975cf1ae9154d68bf883799ca23d14f7ee18b53ea1d344d795b9406
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]