### PR TITLE
build-style/cmake.sh: Use -DCMAKE_BUILD_TYPE=RelWithDebInfo when having XBPS_DEBUG_PKGS set

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -40,7 +40,13 @@ SET(wxWidgets_CONFIG_EXECUTABLE ${XBPS_WRAPPERDIR}/${wx_config:=wx-config})
 _EOF
 		cmake_args+=" -DCMAKE_TOOLCHAIN_FILE=cross_${XBPS_CROSS_TRIPLET}.cmake"
 	fi
-	cmake_args+=" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release"
+	cmake_args+=" -DCMAKE_INSTALL_PREFIX=/usr"
+
+	if [ -n "$XBPS_DEBUG_PKGS" ]; then
+		cmake_args+=" -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+	else
+		cmake_args+=" -DCMAKE_BUILD_TYPE=Release"
+	fi
 
 	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 		cmake_args+=" -DCMAKE_INSTALL_LIBDIR=lib32"


### PR DESCRIPTION
Currently a few cmake Projects have emtpy debug packages because the binaries never contained the dbug symbols, setting RelWithDebInfo builds them with symbols.

Edit: Cogitri pointed out that there is also the `None` Build Type, this may be what we actually want (?)