### PR TITLE
patch: CVE-2018-6952

### DIFF
--- a/srcpkgs/patch/patches/0001-Fix-swapping-fake-lines-in-pch_swap.patch
+++ b/srcpkgs/patch/patches/0001-Fix-swapping-fake-lines-in-pch_swap.patch
@@ -1,0 +1,30 @@
+From 80edff20a6fbbd9f31774dbf390b40273baa2426 Mon Sep 17 00:00:00 2001
+From: Andreas Gruenbacher <agruen@gnu.org>
+Date: Fri, 17 Aug 2018 13:35:40 +0200
+Subject: [PATCH] Fix swapping fake lines in pch_swap
+
+* src/pch.c (pch_swap): Fix swapping p_bfake and p_efake when there is a
+blank line in the middle of a context-diff hunk: that empty line stays
+in the middle of the hunk and isn't swapped.
+
+Fixes: https://savannah.gnu.org/bugs/index.php?53133
+---
+ src/pch.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/pch.c b/src/pch.c
+index ff9ed2c..e71daa0 100644
+--- a/src/pch.c
++++ b/src/pch.c
+@@ -2113,7 +2113,7 @@ pch_swap (void)
+     }
+     if (p_efake >= 0) {			/* fix non-freeable ptr range */
+ 	if (p_efake <= i)
+-	    n = p_end - i + 1;
++	    n = p_end - p_ptrn_lines;
+ 	else
+ 	    n = -i;
+ 	p_efake += n;
+-- 
+2.20.1
+

--- a/srcpkgs/patch/template
+++ b/srcpkgs/patch/template
@@ -1,8 +1,7 @@
 # Template file for 'patch'
 pkgname=patch
 version=2.7.6
-revision=2
-patch_args="-Np1"
+revision=3
 bootstrap=yes
 build_style=gnu-configure
 makedepends="attr-devel"
@@ -12,3 +11,4 @@ license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/patch/patch.html"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd
+patch_args="-Np1"


### PR DESCRIPTION
Patch found from https://savannah.gnu.org/bugs/index.php?53133#comment4
Fixes: https://nvd.nist.gov/vuln/detail/CVE-2018-6952