### PR TITLE
New package: brother-mfc5490cn-cupswrapper-1.1.2

### DIFF
--- a/srcpkgs/brother-mfc5490cn-cupswrapper/INSTALL
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/INSTALL
@@ -1,7 +1,7 @@
 case "${ACTION}" in
 post)
-    /opt/brother/Printers/mfc5490cn/cupswrapper/cupswrappermfc5490cn -i
-    chmod 755 /opt/brother/Printers/mfc5490cn/cupswrapper
+    opt/brother/Printers/mfc5490cn/cupswrapper/cupswrappermfc5490cn -i
+    chmod 755 opt/brother/Printers/mfc5490cn/cupswrapper
     ;;
 esac
 

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/INSTALL
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/INSTALL
@@ -1,0 +1,7 @@
+case "${ACTION}" in
+post)
+    /opt/brother/Printers/mfc5490cn/cupswrapper/cupswrappermfc5490cn -i
+    chmod 755 /opt/brother/Printers/mfc5490cn/cupswrapper
+    ;;
+esac
+

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/REMOVE
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/REMOVE
@@ -1,0 +1,3 @@
+case ${ACTION} in
+    pre) /opt/brother/Printers/mfc5490cn/cupswrapper/cupswrappermfc5490cn -e ;;
+esac

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/files/43-cups-usb.rules
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/files/43-cups-usb.rules
@@ -1,0 +1,21 @@
+# This file is installed by brother-XXXX-cupswrapper
+# To adapt it to you needing make sure you:
+# install usb-utils package
+# launch lsusb and note a line resemblig this one:
+# 
+# Bus 004 Device 007: ID 04f9:023e Brother Industries, Ltd 
+# Explanation:
+# 
+#   Bus xxx Device xxx are the location of the usb port
+#
+#   ID 04f9:xxxx Brother Industries, Ltd
+# 
+#   note the xxxx hex number and put it in the field:
+#
+#   ATTR{idProduct}=="023e" at place of 023e (the code for DCP197C)
+#
+# This is needed to make the printer work correctly
+# even if you installed the brother-brsca3 package
+# version date 2014/05/12
+
+ATTR{idVendor}=="04f9", ATTR{idProduct}=="023e", MODE:="0664", GROUP:="lp", ENV{libsane_matched}:="yes"

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/files/cupswrappermfc5490cn.patch
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/files/cupswrappermfc5490cn.patch
@@ -1,0 +1,141 @@
+--- mfc5490cn/cupswrapper/cupswrappermfc5490cn	2008-10-21 09:07:10.000000000 +0000
++++ mfc5490cn/cupswrapper/cupswrappermfc5490cn.void	2017-01-31 11:48:41.119329004 +0000
+@@ -22,30 +22,25 @@
+ printer_name=`echo $printer_model | tr '[a-z]' '[A-Z]'`
+ device_name=`echo $printer_name | eval sed -e 's/MFC/MFC-/' -e 's/DCP/DCP-/' -e 's/FAX/FAX-/'`
+ pcfilename=`echo $printer_name | tr -d '[A-Z]'`
+-device_model="Printer"
++device_model="Printers"
+ if [ "$1" = '-e' ]; then
+   lpadmin -x ${printer_name}
+   rm -f /usr/share/cups/model/br${printer_model}.ppd
+   rm -f /usr/share/ppd/br${printer_model}.ppd
+   rm -f /usr/lib/cups/filter/brlpdwrapper${printer_model}
+   rm -f /usr/lib64/cups/filter/brlpdwrapper${printer_model}
+-  rm -f /usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1
+-if [  -e /etc/init.d/cups ]; then
+-   /etc/init.d/cups restart
+-elif [  -e /etc/init.d/cupsys ]; then
+-   /etc/init.d/cupsys restart
++if [  -e /var/service/cupsd ]; then
++   sv restart cupsd
+ fi
+-#  /etc/init.d/cups restart
++#  sv restart cupsd
+   exit 0
+ fi
+ if [ "$1" = "-r" ]; then
+   lpadmin -x ${printer_name}
+-if [  -e /etc/init.d/cups ]; then
+-   /etc/init.d/cups restart
+-elif [  -e /etc/init.d/cupsys ]; then
+-   /etc/init.d/cupsys restart
++if [  -e /var/service/cupsd ]; then
++   sv restart cupsd
+ fi
+-#  /etc/init.d/cups restart
++#  sv restart cupsd
+   exit 0
+ fi
+ if [ "$1" = "help" ] || [ "$1" = "-h" ]; then
+@@ -55,10 +50,10 @@
+   echo   '       -r : remove printer'
+   exit 0
+ fi
+-#mkdir -p /usr/local/Brother/${device_model}/${printer_model}/filter
++#mkdir -p /opt/brother/${device_model}/${printer_model}/filter
+ #mkdir -p /usr/lib/cups/filter
+ 
+-if [ -e "/usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
++if [ -e "/opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
+   :
+ else
+   echo "ERROR : Brother LPD filter is not installed."
+@@ -67,7 +62,9 @@
+ if [ -d "/usr/share/cups/model" ]; then
+   ppd_file_name=/usr/share/cups/model/br${printer_model}.ppd
+ else
+-  ppd_file_name=/usr/share/ppd/br${printer_model}.ppd
++  ppd_dir=/usr/share/ppd
++  mkdir -p ${ppd_dir}
++  ppd_file_name=${ppd_dir}/br${printer_model}.ppd
+ fi
+ #ppd_file_name=/usr/share/cups/model/br${printer_model}.ppd
+ 
+@@ -829,25 +826,25 @@
+       cat    > \$INPUT_TEMP_PS
+    fi
+ fi
+-if [ -e "/usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
++if [ -e "/opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model}" ]; then
+        :
+ else
+-    echo "ERROR: /usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model} does not exist"   >>\$LOGFILE
++    echo "ERROR: /opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model} does not exist"   >>\$LOGFILE
+     errorcode=30
+     exit
+ fi
+ 
+ CUPSOPTION=\`echo "\$5 Copies=\$4" | sed -e 's/BrMirror=OFF/MirrorPrint=OFF/' -e 's/BrMirror=ON/MirrorPrint=ON/' -e 's/BrChain/Chain/' -e 's/BrBrightness/Brightness/' -e 's/BrContrast/Contrast/' -e 's/BrHalfCut/HalfCut/' -e 's/BrAutoTapeCut/AutoCut/' -e 's/BrHalftonePattern/Halftone/' -e 's/Binary/Binary/' -e 's/Dither/Dither/' -e 's/ErrorDiffusion/ErrorDiffusion/' -e 's/PageSize/media/' -e 's/BrSheets/Sheets/' -e 's/multiple-document-handling/Collate/' -e 's/separate-documents-collated-copies/ON/' -e 's/separate-documents-uncollated-copies/OFF/'\`
+-if [ -e "/usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1" ]; then
++if [ -e "/opt/brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1" ]; then
+   if [ \$DEBUG = 0 ]; then
+-     /usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC 0 "\$CUPSOPTION" "${printer_model}">> /dev/null
++     /opt/brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC 0 "\$CUPSOPTION" "${printer_model}">> /dev/null
+   else
+-     /usr/local/Brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC \$LOGCLEVEL "\$CUPSOPTION" "${printer_model}">>\$LOGFILE
++     /opt/brother/${device_model}/${printer_model}/cupswrapper/brcupsconfpt1  ${printer_name}  \$PPDC \$LOGCLEVEL "\$CUPSOPTION" "${printer_model}">>\$LOGFILE
+   fi
+ fi
+ 
+ if [ \$DEBUG -lt 10 ]; then
+-    cat    \$INPUT_TEMP_PS | /usr/local/Brother/${device_model}/${printer_model}/lpd/filter${printer_model} "\$\$" "CUPS" "USB"
++    cat    \$INPUT_TEMP_PS | /opt/brother/${device_model}/${printer_model}/lpd/filter${printer_model} "\$\$" "CUPS" "USB"
+ 
+     if [ \$LOGLEVEL -gt 2 ];  then
+ 	   if [ \$LOGFILE != "/dev/null" ]; then
+@@ -868,40 +865,13 @@
+ #   cp $brotherlpdwrapper  $brotherlpdwrapper64
+ #fi
+ 
+-chmod a+w /usr/local/Brother/${device_model}/${printer_model}/inf/br${printer_model}rc
+-chmod a+w /usr/local/Brother/${device_model}/${printer_model}/inf
+-if [ -e /etc/init.d/lpd ]; then
+-   /etc/init.d/lpd stop
+-fi
+-if [  -e /etc/init.d/lprng ]; then
+-   /etc/init.d/lprng stop
+-fi
+-
+-
+-if [  -e /etc/init.d/cups ]; then
+-   /etc/init.d/cups restart
+-elif [  -e /etc/init.d/cupsys ]; then
+-   /etc/init.d/cupsys restart
++chmod a+w /opt/brother/${device_model}/${printer_model}/inf/br${printer_model}rc
++chmod a+w /opt/brother/${device_model}/${printer_model}/inf
++if [  -e /var/service/cupsd ]; then
++   sv restart cupsd
+ fi
+ 
+ sleep 2s
+ 
+-
+-port2=`lpinfo -v | grep -i 'usb://Brother/${device_name}' | head -1`
+-if [ "$port2" = '' ];then
+-    port2=`lpinfo -v | grep 'usb://Brother' | head -1`
+-fi
+-
+-if [ "$port2" = '' ];then
+-    port2=`lpinfo -v | grep 'usb://' | head -1`
+-fi
+-port=`echo $port2| sed s/direct//g`
+-
+-if [ "$port" = '' ];then
+-    port=usb:/dev/usb/lp0
+-fi
+-#lpadmin -p ${printer_name} -E -v $port -m br${printer_model}.ppd
+-lpadmin -p ${printer_name} -E -v $port -P $ppd_file_name
+-
+ exit 0
+ 

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/template
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/template
@@ -2,17 +2,17 @@
 pkgname=brother-mfc5490cn-cupswrapper
 version=1.1.2
 revision=2
+only_for_archs="i686"
+depends="brother-mfc5490cn-lpr cups"
 short_desc="CUPS wrapper driver for the Brother MFC-5490CN printer/scanner"
 maintainer="Henner M. Kruse <github@hmkruse.de>"
 license="GPL-2.0-only"
 homepage="http://support.brother.com/g/b/index.aspx"
 distfiles="http://download.brother.com/welcome/dlf006158/mfc5490cncupswrapper-${version}-2.i386.deb"
 checksum=6ecf0d967bfd8a1f8e3957551126a119c7bd929fd16348da8e664a6f7e25940f
-repository="nonfree"
-only_for_archs="i686"
 lib32mode="full"
-depends="brother-mfc5490cn-lpr cups"
 lib32depends="brother-mfc5490cn-lpr-32bit>=0 cups>=0"
+repository="nonfree"
 nopie=yes
 
 do_extract() {

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/template
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/template
@@ -1,0 +1,26 @@
+# Template file for 'brother-mfc5490cn-cupswrapper'
+pkgname=brother-mfc5490cn-cupswrapper
+version=1.1.2
+revision=1
+create_wrksrc=yes
+only_for_archs="i686 x86_64"
+depends="brother-mfc5490cn-lpr cups"
+short_desc="CUPS wrapper driver for the Brother MFC-5490CN printer/scanner"
+maintainer="Henner M. Kruse <github@hmkruse.de>"
+license="GPL-2"
+homepage="http://support.brother.com/g/b/index.aspx"
+distfiles="http://download.brother.com/welcome/dlf006158/mfc5490cncupswrapper-${version}-2.i386.deb"
+checksum=6ecf0d967bfd8a1f8e3957551126a119c7bd929fd16348da8e664a6f7e25940f
+nopie=yes
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/mfc5490cncupswrapper-${version}-2.i386.deb
+}
+
+do_install() {
+	mkdir -p ${DESTDIR}/opt/brother/Printers
+	tar xzpvf data.tar.gz -C ${DESTDIR}/opt/brother/Printers ./usr/local/Brother/Printer/mfc5490cn --strip-components=5
+	cd ${DESTDIR}/opt/brother/Printers
+	patch -p0 < ${FILESDIR}/cupswrappermfc5490cn.patch
+	vinstall ${FILESDIR}/43-cups-usb.rules 644 /usr/lib/udev/rules.d/
+}

--- a/srcpkgs/brother-mfc5490cn-cupswrapper/template
+++ b/srcpkgs/brother-mfc5490cn-cupswrapper/template
@@ -1,16 +1,18 @@
 # Template file for 'brother-mfc5490cn-cupswrapper'
 pkgname=brother-mfc5490cn-cupswrapper
 version=1.1.2
-revision=1
-create_wrksrc=yes
-only_for_archs="i686 x86_64"
-depends="brother-mfc5490cn-lpr cups"
+revision=2
 short_desc="CUPS wrapper driver for the Brother MFC-5490CN printer/scanner"
 maintainer="Henner M. Kruse <github@hmkruse.de>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://support.brother.com/g/b/index.aspx"
 distfiles="http://download.brother.com/welcome/dlf006158/mfc5490cncupswrapper-${version}-2.i386.deb"
 checksum=6ecf0d967bfd8a1f8e3957551126a119c7bd929fd16348da8e664a6f7e25940f
+repository="nonfree"
+only_for_archs="i686"
+lib32mode="full"
+depends="brother-mfc5490cn-lpr cups"
+lib32depends="brother-mfc5490cn-lpr-32bit>=0 cups>=0"
 nopie=yes
 
 do_extract() {

--- a/srcpkgs/brother-mfc5490cn-lpr/INSTALL
+++ b/srcpkgs/brother-mfc5490cn-lpr/INSTALL
@@ -1,0 +1,6 @@
+case "${ACTION}" in
+    post)
+        mkdir -p /var/spool/lpd
+        opt/brother/Printers/mfc5490cn/inf/setupPrintcapij mfc5490cn -i
+    ;;
+esac

--- a/srcpkgs/brother-mfc5490cn-lpr/REMOVE
+++ b/srcpkgs/brother-mfc5490cn-lpr/REMOVE
@@ -1,6 +1,5 @@
 case ${ACTION} in
     pre)
-    	opt/brother/Printers/mfc5490cn/cupswrapper/cupswrappermfc5490cn -e ;;
 	cd opt
 	rmdir -p brother/Printers/mfc5490cn/
 esac

--- a/srcpkgs/brother-mfc5490cn-lpr/template
+++ b/srcpkgs/brother-mfc5490cn-lpr/template
@@ -2,16 +2,16 @@
 pkgname=brother-mfc5490cn-lpr
 version=1.1.2
 revision=2
+only_for_archs="i686"
+depends="a2ps ghostscript"
 short_desc="LPR driver for Brother MFC-5490CN printer/scanner"
 maintainer="Henner M. Kruse <github@hmkruse.de>"
 license="proprietary"
 homepage="http://support.brother.com/g/b/index.aspx"
 distfiles="http://download.brother.com/welcome/dlf006156/mfc5490cnlpr-${version}-2.i386.deb"
 checksum=4a361dea157994cd825dbeba529ff560b279a591643ce8a0e0b1acce72f0bac5
-repository="nonfree"
-only_for_archs="i686"
 lib32mode="full"
-depends="a2ps ghostscript"
+repository="nonfree"
 nopie=yes
 #mutable_files="/opt/brother/Printers/mfc5490cn/inf/brmfc5490cnrc"
 

--- a/srcpkgs/brother-mfc5490cn-lpr/template
+++ b/srcpkgs/brother-mfc5490cn-lpr/template
@@ -1,0 +1,27 @@
+# Template file for 'brother-mfc5490cn-lpr'
+pkgname=brother-mfc5490cn-lpr
+version=1.1.2
+revision=2
+short_desc="LPR driver for Brother MFC-5490CN printer/scanner"
+maintainer="Henner M. Kruse <github@hmkruse.de>"
+license="proprietary"
+homepage="http://support.brother.com/g/b/index.aspx"
+distfiles="http://download.brother.com/welcome/dlf006156/mfc5490cnlpr-${version}-2.i386.deb"
+checksum=4a361dea157994cd825dbeba529ff560b279a591643ce8a0e0b1acce72f0bac5
+repository="nonfree"
+only_for_archs="i686"
+lib32mode="full"
+depends="a2ps ghostscript"
+nopie=yes
+#mutable_files="/opt/brother/Printers/mfc5490cn/inf/brmfc5490cnrc"
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/mfc5490cnlpr-${version}-2.i386.deb
+}
+
+do_install() {
+	mkdir -p ${DESTDIR}/opt/brother/Printers
+	tar xzpvf data.tar.gz -C ${DESTDIR} ./usr/bin/brprintconf_mfc5490cn
+	tar xzpvf data.tar.gz -C ${DESTDIR}/opt/brother/Printers ./usr/local/Brother/Printer/mfc5490cn --strip-components=5
+	sed -i "s/\/usr\/local\/Brother\/Printer/\/opt\/brother\/Printers/g" ${DESTDIR}/opt/brother/Printers/mfc5490cn/{inf/setupPrintcapij,lpd/filtermfc5490cn}
+}


### PR DESCRIPTION
CUPSwrapper printer driver for Brother MFC-5490CN

depends on #7034 

[binary source](https://support.brother.com/g/b/downloadend.aspx?c=us&lang=en&prod=mfc5490cn_all&os=128&dlid=dlf006158_000&flang=4&type3=561)