### PR TITLE
gnuradio: Fix gnuradio package creation

### DIFF
--- a/srcpkgs/gnuradio/template
+++ b/srcpkgs/gnuradio/template
@@ -24,6 +24,8 @@ if [ -n "$CROSS_BUILD" ]; then
 fi
 
 post_install() {
+	rm ${DESTDIR}/usr/share/gnuradio/examples/audio/dial_tone \
+		${DESTDIR}/usr/share/gnuradio/examples/fcd/fcd_nfm_rx
 	vinstall grc/scripts/freedesktop/gnuradio-grc.desktop 644 \
 		usr/share/applications
 	vinstall grc/scripts/freedesktop/gnuradio_logo_icon-square.svg 644 \


### PR DESCRIPTION
Remove compiled examples fixing 11-pkglint-elf-in-usrshare hook for
gnuradio package
