### PR TITLE
msmtp: OpenSSL is discouraged, use GnuTLS instead

### DIFF
--- a/srcpkgs/msmtp/template
+++ b/srcpkgs/msmtp/template
@@ -1,12 +1,15 @@
 # Template file for 'msmtp'
 pkgname=msmtp
 version=1.8.2
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-tls=openssl $(vopt_with idn libidn)
- $(vopt_with sasl libgsasl) $(vopt_with gnome libsecret)"
+configure_args="$(vopt_with msmtpd)
+ $(vopt_with idn libidn)
+ $(vopt_with sasl libgsasl)
+ $(vopt_with gnome libsecret)"
 hostmakedepends="pkg-config"
-makedepends="libressl-devel $(vopt_if idn libidn-devel)
+makedepends="gnutls-devel
+ $(vopt_if idn libidn2-devel)
  $(vopt_if sasl gsasl-devel)
  $(vopt_if gnome libsecret-devel)"
 short_desc="Mini SMTP client"
@@ -16,8 +19,7 @@ homepage="https://marlam.de/msmtp/"
 distfiles="https://marlam.de/msmtp/releases/msmtp-${version}.tar.xz"
 checksum=d1185c1969ed00d0e2c57dbcd5eb09a9f82156042b21309d558f761978a58793
 
-build_options="idn sasl gnome"
-build_options_default="idn"
+build_options="idn sasl gnome msmtpd"
 
 post_install() {
 	vsconf doc/msmtprc-system.example


### PR DESCRIPTION
- why OpenSSL is discouraged: https://marlam.de/msmtp/news/openssl-discouraged/
- update IDN to use libidn2, but it is not required anymore since GnuTLS has build-in support for IDN
- disable msmtpd by default