### PR TITLE
grub: enable ppc64 builds (without a native platform for now)

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -14,7 +14,7 @@ homepage="https://www.gnu.org/software/grub/"
 distfiles="${GNU_SITE}/grub/grub-${version}.tar.xz"
 checksum=810b3798d316394f94096ec2797909dbf23c858e48f7b3830826b8daa06b7b0f
 
-only_for_archs="i686 i686-musl x86_64 x86_64-musl aarch64 aarch64-musl"
+only_for_archs="i686 i686-musl x86_64 x86_64-musl aarch64 aarch64-musl ppc64le ppc64le-musl ppc64-musl"
 nopie=yes
 
 subpackages="grub-utils"
@@ -35,6 +35,14 @@ case "$XBPS_TARGET_MACHINE" in
 	aarch64*)
 		_NATIVE_PLATFORM=efi
 		subpackages+=" grub-arm64-efi"
+		;;
+	ppc64*)
+		# don't have a native platform for now, ieee1275 needs a compiler
+		# capable of generating big-endian 32-bit binaries; only build utils
+		# for now, so we can generate config files to be used by petitboot etc.
+		# TODO: look into building with the below later
+		#_NATIVE_PLATFORM=ieee1275
+		configure_args+=" --with-platform=none"
 		;;
 esac
 


### PR DESCRIPTION
The correct way would be to build grub-ieee1275 but that needs a compiler capable of generating 32-bit big endian binaries which we don't yet have (possible solutions: enable multiarch in gcc, or use 32-bit ppc crosstoolchain for this once the 32-bit ppc support is merged). It is, however, still useful to build grub utils as they can manage the configuration files in /boot, which can subsequently be read by bootloaders such as petitboot (for example found on the Raptor Talos 2 POWER9 system), which makes it useful alone.

Once building a native platform becomes useful, I will submit it as a separate pull request.