### PR TITLE
msmtp: add support for building with gnutls

### DIFF
--- a/srcpkgs/msmtp/template
+++ b/srcpkgs/msmtp/template
@@ -1,14 +1,16 @@
 # Template file for 'msmtp'
 pkgname=msmtp
 version=1.8.2
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-tls=openssl $(vopt_with idn libidn)
+configure_args="--with-tls=$(vopt_if gnutls gnutls openssl) $(vopt_with idn libidn)
  $(vopt_with sasl libgsasl) $(vopt_with gnome libsecret)"
 hostmakedepends="pkg-config"
-makedepends="libressl-devel $(vopt_if idn libidn-devel)
+makedepends="$(vopt_if idn libidn-devel)
  $(vopt_if sasl gsasl-devel)
- $(vopt_if gnome libsecret-devel)"
+ $(vopt_if gnome libsecret-devel)
+ $(vopt_if ssl libressl-devel)
+ $(vopt_if gnutls gnutls-devel)"
 short_desc="Mini SMTP client"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -16,8 +18,8 @@ homepage="https://marlam.de/msmtp/"
 distfiles="https://marlam.de/msmtp/releases/msmtp-${version}.tar.xz"
 checksum=d1185c1969ed00d0e2c57dbcd5eb09a9f82156042b21309d558f761978a58793
 
-build_options="idn sasl gnome"
-build_options_default="idn"
+build_options="idn sasl gnome gnutls ssl"
+build_options_default="idn ssl"
 
 post_install() {
 	vsconf doc/msmtprc-system.example


### PR DESCRIPTION
Upstream is now deprecating support for OpenSSL:

    https://marlam.de/msmtp/news/openssl-discouraged/

This adds support for building with GnuTLS.  OpenSSL is still the
default option, but now users can build with GnuTLS support.
Eventually, we may wish to make the switch.

Currently, when I use msmtp-1.8.2_1 with TLS provided by OpenSSL, I get the following error:

```
msmtp: cannot set X509 system trust for TLS session: feature not yet implemented for OpenSSL
```

The GnuTLS version of msmtp does not have this problem.