### PR TITLE
rdiff-backup: update to 1.3.3

### DIFF
--- a/srcpkgs/rdiff-backup/template
+++ b/srcpkgs/rdiff-backup/template
@@ -1,18 +1,19 @@
 # Template file for 'rdiff-backup'
 pkgname=rdiff-backup
-version=1.2.8
-revision=2
+version=1.3.3
+revision=1
+noarch=yes
 build_style=python2-module
 pycompile_module="rdiff_backup"
 hostmakedepends="python"
 makedepends="python-devel librsync-devel"
-depends="python"
-short_desc="Local/remote mirroring and incremental backups"
+depends="python librsync"
+short_desc="Local/remote mirroring and incremental backups (Python2)"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://rdiff-backup.nongnu.org/"
 distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=0d91a85b40949116fa8aaf15da165c34a2d15449b3cbe01c8026391310ac95db
+checksum=ee030ce638df0eb1047cf72578e0de15d9a3ee9ab24da2dc0023e2978be30c06
 
 pre_build() {
 	sed -i -e 's;RS_DEFAULT_STRONG_LEN;8, RS_MD4_SIG_MAGIC;' _librsyncmodule.c


### PR DESCRIPTION
@Duncaen 

Attempted to run rdiff-backup, gave missing library, so added it to depends