### PR TITLE
qownnotes: update 19.1.3

### DIFF
--- a/srcpkgs/qownnotes/template
+++ b/srcpkgs/qownnotes/template
@@ -1,18 +1,21 @@
 # Template file for 'qownnotes'
 pkgname=qownnotes
-version=18.12.3
+version=19.1.3
 revision=1
 build_style=qmake
 hostmakedepends="qt5-qmake"
-makedepends="qt5-declarative-devel qt5-svg-devel qt5-xmlpatterns-devel"
+makedepends="qt5-declarative-devel qt5-svg-devel qt5-xmlpatterns-devel
+ qt5-websockets-devel"
+depends="qt5-plugin-sqlite"
 short_desc="Plain-text file notepad and todo-list manager with markdown support"
 maintainer="travankor <travankor@tuta.io>"
 license="GPL-2.0-only"
 homepage="https://www.qownnotes.org"
 changelog="https://www.qownnotes.org/changelog/QOwnNotes"
 distfiles="https://download.tuxfamily.org/${pkgname}/src/${pkgname}-${version}.tar.xz"
-checksum=e658240fd5d8e9574258c2faf4fb3ce55a019b7c188786627eba61485f4dcdc7
+checksum=89394958490daacb5ec15e7ad4fb550f8dc21a327df94e2fa10adeb190fc2606
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-host-tools qt5-declarative-devel qt5-svg-devel qt5-xmlpatterns-devel"
+	hostmakedepends+=" qt5-host-tools qt5-declarative-devel qt5-svg-devel qt5-xmlpatterns-devel
+	 qt5-websockets-devel"
 fi


### PR DESCRIPTION
Added qt5-plugin-sqlite as running package, gives error sqlite module missing. I believe it may be needed to save notes, atleast in a database.