### PR TITLE
qt5-webkit: add patch to include functional

### DIFF
--- a/srcpkgs/qt5-webkit/patches/include_functional.diff
+++ b/srcpkgs/qt5-webkit/patches/include_functional.diff
@@ -1,0 +1,14 @@
+Description: add missing #include <functional>
+Origin: upstream, https://github.com/annulen/webkit/commit/4ce8ebc4094512b9
+Last-Update: 2018-04-15
+
+--- Source/WebCore/dom/SlotAssignment.h
++++ Source/WebCore/dom/SlotAssignment.h
+@@ -28,6 +28,7 @@
+ 
+ #if ENABLE(SHADOW_DOM) || ENABLE(DETAILS_ELEMENT)
+ 
++#include <functional>
+ #include <wtf/HashMap.h>
+ #include <wtf/HashSet.h>
+ #include <wtf/Vector.h>


### PR DESCRIPTION
This is from upstream, and is needed to build on some platforms, notably ppc64 and i686, apparently.

@pullmoll you forgot to add this one, and it seems to be the reason i686 is failing now, so let's see if this can get it to build