### PR TITLE
qt5-webkit: enable all-in-one build on ppc64

### DIFF
--- a/srcpkgs/qt5-webkit/template
+++ b/srcpkgs/qt5-webkit/template
@@ -32,7 +32,7 @@ case "$XBPS_TARGET_MACHINE" in
 		LIBS+=" -latomic"
 		;;
 	ppc64*)	# no JIT on ppc64 and other build workarounds
-		configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON -DENABLE_ALLINONE_BUILD=OFF"
+		configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON"
 		;;
 	i686*) 	# try to reduce memory footprint when linking
 		configure_args+=" -DENABLE_ALLINONE_BUILD=OFF"


### PR DESCRIPTION
Ubuntu disables it, as a workaround for compiler ICEs. Turns out that is not a problem anymore with our GCC 8.2.0, so enable AIO build just like on every other platform.