### PR TITLE
Add xlint git hook

### DIFF
--- a/hooks/xlint
+++ b/hooks/xlint
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# This hook checks for template files that fail xlint.
+# Symlink it to .git/hooks/pre-commit to enable it:
+# ln -s hooks/xlint .git/hooks/pre-commit
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+
+exec 1>&2
+
+
+ret=0
+for f in $(git diff --cached --name-only --diff-filter=d $against); do
+    if [ "$(basename $f)" = "template" ] && ! xlint $f; then
+        echo "xlint failed for template: ${f}"
+        ret=1
+    fi
+done
+
+exit $ret


### PR DESCRIPTION
This hook runs `xlint` on any changed `tempate`s if you install it as `.git/hooks/pre-commit` and aborts the commit if you are trying to do something dumb.

I've used and tested it for about half a year or so and it prevented me from doing a lot of mistakes.