### PR TITLE
qt5-webkit: force debug off for i686

### DIFF
--- a/srcpkgs/qt5-webkit/template
+++ b/srcpkgs/qt5-webkit/template
@@ -34,9 +34,9 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc64*)	# no JIT on ppc64 and other build workarounds
 		configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON"
 		;;
-	i686*) 	# try to reduce memory footprint when linking by using gold
+	i686*) 	# reduce memory footprint by turning off debug
 		nodebug=1
-		configure_args+=" -DENABLE_ALLINONE_BUILD=OFF"
+		configure_args+=" -DCMAKE_BUILD_TYPE=Release"
 		;;
 esac
 


### PR DESCRIPTION
Looks like nodebug on its own does not make cmake do the right thing, so we need to force that in order to disable debug symbols.