### PR TITLE
playonlinux: remove noarch and restrict to glibc intel platforms

### DIFF
--- a/srcpkgs/playonlinux/template
+++ b/srcpkgs/playonlinux/template
@@ -1,9 +1,10 @@
 # Template file for 'playonlinux'
 pkgname=playonlinux
 version=4.3.4
-revision=1
-noarch=yes
-wrksrc="$pkgname"
+revision=2
+wrksrc="${pkgname}"
+# contains pre-compiled binaries linked against glibc
+only_for_archs="i686 x86_64"
 depends="icoutils netcat ImageMagick xterm wxPython cabextract unzip glxinfo
  gnupg xdg-user-dirs libXmu wget p7zip curl jq"
 short_desc="GUI for managing Windows programs under linux"


### PR DESCRIPTION
the package contains compressed pre-compiled binaries linked against glibc