### PR TITLE
llvm7: add triples for ppc64/ppc64le musl

### DIFF
--- a/srcpkgs/llvm7/files/patches/cfe/cfe-004-add-musl-triples.patch
+++ b/srcpkgs/llvm7/files/patches/cfe/cfe-004-add-musl-triples.patch
@@ -1,18 +1,5 @@
---- clang/lib/Driver/ToolChains/Gnu.cpp.orig
+--- clang/lib/Driver/ToolChains/Gnu.cpp
 +++ clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -1813,7 +1814,9 @@
-   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
-                                              "armv7hl-redhat-linux-gnueabi",
-                                              "armv6hl-suse-linux-gnueabi",
--                                             "armv7hl-suse-linux-gnueabi"};
-+                                             "armv7hl-suse-linux-gnueabi",
-+                                             "arm-linux-musleabihf",
-+                                             "armv7l-linux-musleabihf"};
-   static const char *const ARMebLibDirs[] = {"/lib"};
-   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi",
-                                              "armeb-linux-androideabi"};
---- clang/lib/Driver/ToolChains/Gnu.cpp.orig	2018-09-19 11:56:30.981980945 -0300
-+++ clang/lib/Driver/ToolChains/Gnu.cpp	2018-09-19 11:58:26.467979348 -0300
 @@ -1812,7 +1812,7 @@
    static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
    static const char *const AArch64Triples[] = {
@@ -22,7 +9,18 @@
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
-@@ -1837,14 +1837,15 @@
+@@ -1822,7 +1822,9 @@
+   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+-                                             "armv7hl-suse-linux-gnueabi"};
++                                             "armv7hl-suse-linux-gnueabi",
++                                             "arm-linux-musleabihf",
++                                             "armv7l-linux-musleabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi"};
+   static const char *const ARMebHFTriples[] = {
+@@ -1835,14 +1837,15 @@
        "x86_64-redhat-linux",    "x86_64-suse-linux",
        "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
        "x86_64-slackware-linux", "x86_64-unknown-linux",
@@ -36,7 +34,23 @@
        "i586-redhat-linux",    "i386-redhat-linux",     "i586-suse-linux",
 -      "i486-slackware-linux", "i686-montavista-linux", "i586-linux-gnu"};
 +      "i486-slackware-linux", "i686-montavista-linux", "i586-linux-gnu",
-+	  "i686-linux-musl"};
++      "i686-linux-musl"};
  
    static const char *const MIPSLibDirs[] = {"/lib"};
    static const char *const MIPSTriples[] = {"mips-linux-gnu", "mips-mti-linux",
+@@ -1869,11 +1872,13 @@
+   static const char *const PPC64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const PPC64Triples[] = {
+       "powerpc64-linux-gnu", "powerpc64-unknown-linux-gnu",
+-      "powerpc64-suse-linux", "ppc64-redhat-linux"};
++      "powerpc64-suse-linux", "ppc64-redhat-linux",
++      "powerpc64-linux-musl"};
+   static const char *const PPC64LELibDirs[] = {"/lib64", "/lib"};
+   static const char *const PPC64LETriples[] = {
+       "powerpc64le-linux-gnu", "powerpc64le-unknown-linux-gnu",
+-      "powerpc64le-suse-linux", "ppc64le-redhat-linux"};
++      "powerpc64le-suse-linux", "ppc64le-redhat-linux",
++      "powerpc64le-linux-musl"};
+ 
+   static const char *const RISCV32LibDirs[] = {"/lib", "/lib32"};
+   static const char *const RISCVTriples[] = {"riscv32-unknown-linux-gnu",

--- a/srcpkgs/llvm7/template
+++ b/srcpkgs/llvm7/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm7'
 pkgname=llvm7
 version=7.0.1
-revision=2
+revision=3
 wrksrc="llvm-${version}.src"
 lib32disabled=yes
 build_style=cmake


### PR DESCRIPTION
It is necessary to revbump here as Clang is a cross-compiler.