### PR TITLE
notmuch: fix broken notmuch-emacs-mua

### DIFF
--- a/srcpkgs/notmuch/patches/bash_absolute.patch
+++ b/srcpkgs/notmuch/patches/bash_absolute.patch
@@ -1,0 +1,10 @@
+--- configure.orig
++++ configure
+@@ -563,6 +563,7 @@ printf "Checking for bash... "
+ if command -v ${BASH} > /dev/null; then
+     have_bash=1
+     bash_absolute=$(command -v ${BASH})
++    bash_absolute=$(readlink -f "$bash_absolute")
+     printf "Yes (%s).\n" "$bash_absolute"
+ else
+     have_bash=0

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -1,7 +1,7 @@
 # Template file for 'notmuch'
 pkgname=notmuch
 version=0.28
-revision=2
+revision=3
 hostmakedepends="perl pkg-config python-Sphinx python-devel python3-Sphinx python3-devel"
 makedepends="bash-completion gmime3-devel talloc-devel xapian-core-devel"
 short_desc="Thread-based email index, search, and tagging"


### PR DESCRIPTION
The old notmuch-emacs-mua's shebang is `/bin/sh`,
but that script requires some bashisms.

I haven't investigate much time into the `configure` script
to figure out why it resolve to `/bin/sh`.

In my Arch Linux install, it also shows `/bin/sh`, this behavior is
somewhat reproducible in both platforms.

I'll report to upstream later.