### PR TITLE
consistency_check.sh: use return instead of continue when appropiate.

### DIFF
--- a/common/xbps-src/shutils/consistency_check.sh
+++ b/common/xbps-src/shutils/consistency_check.sh
@@ -56,7 +56,7 @@ consistency_check_smart () {
         (
             XBPS_TARGET_PKG=$dep
             read_pkg
-            xbps-uhelper pkgmatch "$depdef" "${pkgname}-${version}_${revision}" && continue
+            xbps-uhelper pkgmatch "$depdef" "${pkgname}-${version}_${revision}" && return
             msg_red "unsatisfied $deplabel in $origname: $dep is $version, but required is $depdef\n";
         )
     done
@@ -70,7 +70,7 @@ consistency_check() {
             read_pkg
             [ "$depends" ] && printf "%s $pkgname depends\n" $depends
             [ "$conflicts" ] && printf "%s $pkgname conflicts\n" $conflicts
-            [ -L "$XBPS_SRCPKGDIR/$XBPS_TARGET_PKG" ] && continue
+            [ -L "$XBPS_SRCPKGDIR/$XBPS_TARGET_PKG" ] && return
             [ "$makedepends" ] && printf "%s $pkgname makedepends\n" $makedepends
             [ "$hostmakedepends" ] && printf "%s $pkgname hostmakedepends\n" $hostmakedepends
             [ "$checkdepends" ] && printf "%s $pkgname checkdepends\n" $checkdepends


### PR DESCRIPTION
Those are not meant to be continue as they are not in a loop they are in
a subshell.