### PR TITLE
build-styles: use go install instead of go build.

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -33,7 +33,7 @@ do_build() {
 			# default behavior.
 			go_mod_mode=
 		fi
-		go build -o "${GOPATH}/bin/$(basename ${go_package})" -mod="${go_mod_mode}" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
+		go install -mod="${go_mod_mode}" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}
 	else
 		# Otherwise, build using GOPATH
 		go get -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" ${go_package}


### PR DESCRIPTION
Fixes multi-package builds by switching to `go install` (using `go build -o <path>` broke them).

Related to #7394.