### PR TITLE
New package: cookie-0.1.1

### DIFF
--- a/srcpkgs/bashlibs/template
+++ b/srcpkgs/bashlibs/template
@@ -1,0 +1,17 @@
+# Template file for 'bashlibs'
+pkgname=bashlibs
+version=0.1.0
+revision=1
+noarch=yes
+build_style=gnu-makefile
+depends="bash"
+short_desc="Global utility for shell scripts"
+maintainer="Nathan Owens <ndowens04@gmail.com>"
+license="MIT"
+homepage="https://github.com/bbugyi200/bashlibs"
+distfiles="https://github.com/bbugyi200/bashlibs/archive/v${version}.tar.gz"
+checksum=5a35f56c48f1c0345a74c08f121f760f77e3e938e5c9822a427115b2944bcf06
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/cookie/template
+++ b/srcpkgs/cookie/template
@@ -1,0 +1,22 @@
+# Template file for 'cookie'
+pkgname=cookie
+version=0.2.0
+revision=1
+noarch=yes
+build_style=gnu-makefile
+depends="bash bashlibs"
+short_desc="Template-based File Generator"
+maintainer="Nathan Owens <ndowens04@gmail.com>"
+license="MIT"
+homepage="https://github.com/bbugyi200/cookie"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=4af67b9376b60e9e40ef34b5be3e4be768ed550cc6e16baf5df0a04fd7e541e3
+
+post_extract() {
+	sed -i 's:sudo::
+		/git/d' Makefile
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Fixes: #7088

Separated the packages. There is no license info on bashlibs, not even in the script headers