### PR TITLE
gopass: fix checksum

### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,18 +1,18 @@
 # Template file for 'gopass'
 pkgname=gopass
 version=1.8.4
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/gopasspw/gopass
 makedepends="gnupg2"
 depends="gnupg2 git"
-short_desc="The slightly more awesome standard unix password manager for teams"
+short_desc="Slightly more awesome standard unix password manager for teams"
 maintainer="Dominic Monroe <monroef4@googlemail.com>"
 license="MIT"
 homepage="https://www.justwatch.com/gopass/"
 changelog="https://raw.githubusercontent.com/justwatchcom/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/v${version}.tar.gz"
-checksum=4d35dc565457d5dde05faa538be9e8c1e99527d48d7d759c1a7e4e5566f27171
+checksum=314b317c49ee7f8c59758ab82cf5f6942ce9179c97e53f0f952741dbd0e5471a
 
 if [ "$CROSS_BUILD" ]; then
 	# Depend on system gopass to generate completions


### PR DESCRIPTION
Bump revision because the source is different for the same version.

Tweak short_desc for xlint.