### PR TITLE
rpi-kernel: update to 4.14.93.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="4de3f6305841c2121257b8fdbda5c3c0bf77e669"
+_githash="efdcb6d2b15d216fbccf99969caa5551d3f1c5b9"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.92
+version=4.14.93
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=67a32d7af975cf1ae9154d68bf883799ca23d14f7ee18b53ea1d344d795b9406
+checksum=0415cede7aee1d5b67475c99ba01c75dc44c95f82cc61f64513507b22f6643c6
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]