### PR TITLE
aterm: fix broken download, disable kanji and chinese due to broken kterm terminfo

### DIFF
--- a/srcpkgs/aterm/template
+++ b/srcpkgs/aterm/template
@@ -1,17 +1,16 @@
-# Template file for 'aterm'.
+# Template file for 'aterm'
 pkgname=aterm
 version=1.0.1
-revision=3
+revision=4
 build_style=gnu-configure
-configure_args="--enable-transparency --enable-kanji --enable-big5
- --enable-greek --enable-thai"
+configure_args="--enable-transparency --enable-greek --enable-thai"
 hostmakedepends="pkg-config"
 makedepends="libXt-devel libXext-devel"
 short_desc="AfterStepX Terminal Emulator"
 maintainer="pancake <pancake@nopcode.org>"
+license="GPL-2.0-or-later"
 homepage="http://www.afterstep.org/aterm.php"
-license="MIT/X11"
-distfiles="ftp://ftp.afterstep.org/apps/aterm/$pkgname-$version.tar.bz2"
+distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.bz2"
 checksum=a161c3b2d9c7149130a41963899993af21eae92e8e362f4b5b3c7c4cb16760ce
 
 pre_build() {


### PR DESCRIPTION
it seems that when kanji or chinese are enabled, aterm sets TERM to kterm. out of the box there's no kterm terminfo installed (it's some old xterm fork) so it breaks everything. after tracking down and installing the actual kterm terminfo is it's still buggy in curses apps:
* ```TERM=xterm-16color``` : https://i.imgur.com/OdXLlvq.png
* ```TERM=kterm``` : https://i.imgur.com/Vv2evI0.png

so i'd say just disable kanji and chinese (which is what the arch aur and parabola packages do), which makes it use ```TERM=rxvt``` which works fine

btw, according to src/rxvt.h kanji and chinese are mutually exclusive, also either of them is mutually exclusive with greek. so enabling chinese and greek support effectively does nothing because kanji is enabled

```c
/* sort out conflicts in feature.h */
#ifdef KANJI
# undef ZH			/* remove Chinese big5 support        */
# undef GREEK_SUPPORT		/* Kanji/Greek together is too weird  */
# undef DEFINE_XTERM_COLOR	/* since kterm-color doesn't exist?   */
#endif

#ifdef ZH
# undef KANJI			/* can't put Chinese/Kanji together   */
# undef GREEK_SUPPORT
# undef DEFINE_XTERM_COLOR
#endif
```

of course, you can also decide to drop this package since aterm is deprecated and unmaintained for years, but with these changes it still works perfectly fine