### PR TITLE
New package: thinkpad-scripts-4.11.0.

### DIFF
--- a/srcpkgs/thinkpad-scripts/template
+++ b/srcpkgs/thinkpad-scripts/template
@@ -2,9 +2,10 @@
 pkgname=thinkpad-scripts
 version=4.11.0
 revision=1
-build_style=gnu-makefile
-hostmakedepends="gettext python3 python3-setuptools python3-Sphinx"
-depends="acpid alsa-utils python3 python3-setuptools eudev xinput xrandr"
+build_style=python3-module
+hostmakedepends="gettext python3-devel python3-Sphinx"
+makedepends="python3-devel"
+depends="acpid alsa-utils eudev xinput xrandr"
 short_desc="Screen rotation, docking, and more for ThinkPad X220 and X230 Tablet"
 maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
 license="GPL-3.0-or-later"
@@ -13,7 +14,6 @@ distfiles="https://github.com/martin-ueding/thinkpad-scripts/archive/v${version}
 checksum=a24bf13793d02348778465e8e608429570a2ce676e1d15f57da69beff2697684
 
 post_install() {
-	python3 setup.py install --single-version-externally-managed --root="${DESTDIR}"
+	make install PREFIX=/usr DESTDIR=${DESTDIR} ${make_install_args}
 	mv "${DESTDIR}/lib/udev" "${DESTDIR}/usr/lib/"
-	rmdir "${DESTDIR}/lib"
 }

--- a/srcpkgs/thinkpad-scripts/template
+++ b/srcpkgs/thinkpad-scripts/template
@@ -1,0 +1,19 @@
+# Template file for 'thinkpad-scripts'
+pkgname=thinkpad-scripts
+version=4.11.0
+revision=1
+build_style=gnu-makefile
+hostmakedepends="gettext python3 python3-setuptools python3-Sphinx"
+depends="acpid alsa-utils python3 python3-setuptools eudev xinput xrandr"
+short_desc="Screen rotation, docking, and more for ThinkPad X220 and X230 Tablet"
+maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/martin-ueding/thinkpad-scripts"
+distfiles="https://github.com/martin-ueding/thinkpad-scripts/archive/v${version}.tar.gz"
+checksum=a24bf13793d02348778465e8e608429570a2ce676e1d15f57da69beff2697684
+
+post_install() {
+	python3 setup.py install --single-version-externally-managed --root="${DESTDIR}"
+	mv "${DESTDIR}/lib/udev" "${DESTDIR}/usr/lib/"
+	rmdir "${DESTDIR}/lib"
+}


### PR DESCRIPTION
Since this is only useful on the specific Thinkpad models in question, should I set `only_for_archs="x86_64 x86_64-musl i686 i686-musl"`?