### PR TITLE
mirrorbits: update to 0.5.1.

### DIFF
--- a/srcpkgs/mirrorbits/template
+++ b/srcpkgs/mirrorbits/template
@@ -1,23 +1,36 @@
 # Template file for 'mirrorbits'
 pkgname=mirrorbits
-version=0.4
-revision=2
+version=0.5.1
+revision=1
 build_style=go
 go_import_path="github.com/etix/mirrorbits"
-# from Makefile
-# we use tarball, so no
 go_ldflags="-X ${go_import_path}/core.VERSION=${VERSION}"
-hostmakedepends="govendor git pkg-config"
+_go_protobuf_version=52132540909e117f2b98b0694383dc0ab1e1deca
+hostmakedepends="govendor git pkg-config protobuf-devel"
 makedepends="geoip-devel"
 depends="geoip-data redis"
 short_desc="Geographical download redirector"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="MIT"
 homepage="https://github.com/etix/mirrorbits"
-distfiles="https://github.com/etix/mirrorbits/archive/v0.4.tar.gz"
-checksum=4da8f19aae0e63befe53370c9922cb91a656459e7607f8f1b42be07c789e37a0
+distfiles="
+ https://github.com/etix/mirrorbits/archive/v${version}.tar.gz
+ https://github.com/golang/protobuf/archive/${_go_protobuf_version}.tar.gz"
+checksum="
+ c713c312877aa039415b1f336bf8ca456aa3089a5759c9e6aa9aac8853e165fb
+ 5ef8723453af0aeea20f7b6f322345c009560ec23b85d430838bfb5d2f1cde4a"
+patch_args="-Np1"
 
 pre_build() {
+	# Build the protoc-gen-go Protobuf plugin.
+	mkdir -p "${GOPATH}/src/github.com/golang"
+	ln -s "${XBPS_BUILDDIR}/protobuf-${_go_protobuf_version}" "${GOPATH}/src/github.com/golang/protobuf"
+	GOOS= GOARCH= go install github.com/golang/protobuf/protoc-gen-go
+	# Generate mirrorbits RPC code.
+	PATH="${GOPATH}/bin:${PATH}" protoc -I rpc rpc/rpc.proto --go_out=plugins=grpc:rpc
+	# Clean up protoc-gen-go so do_install doesn't package it.
+	rm "${GOPATH}/bin/protoc-gen-go"
+
 	cd "${GOPATH}/src/${go_import_path}"
 	govendor sync
 }


### PR DESCRIPTION
This requires some trickery due to mirrobits depending on an older
version of the protoc-gen-go package. Because the Protobuf originally
generated for the project isn't included, pre_build needs to fetch and
install the correct plugin version, since newer releases are not
compatible with the Protobuf library mirrorbits depends on.

As such, this fetches the github.com/golang/protobuf library at the
commit used by mirrorbits and installs the Protobuf plugin from that.
Once installed, it can generate its the RPC Protobuf code with protoc.

This skips using make in the interest of not patching a makefile.