### PR TITLE
gnome-builder: add missing devhelp runtime dep

### DIFF
--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-builder'
 pkgname=gnome-builder
 version=3.30.3
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_webkit=true"
 hostmakedepends="appdata-tools desktop-file-utils flex gobject-introspection
@@ -11,7 +11,7 @@ makedepends="cairo-devel clang devhelp-devel enchant2-devel flatpak-devel
  libdazzle-devel libgit2-glib-devel libglib-devel libostree-devel libpeas-devel
  libxml2-devel template-glib-devel vala-devel vte3-devel webkit2gtk-devel
  python-gobject-devel"
-depends="desktop-file-utils flatpak-builder python3-lxml"
+depends="desktop-file-utils flatpak-builder python3-lxml devhelp"
 short_desc="IDE for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Without it, it wouldn't even start.