### PR TITLE
libostree: update to 2019.1

### DIFF
--- a/srcpkgs/libostree/template
+++ b/srcpkgs/libostree/template
@@ -1,6 +1,6 @@
 # Template file for 'libostree'
 pkgname=libostree
-version=2018.9
+version=2019.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-builtin-grub2-mkconfig --with-openssl
@@ -15,7 +15,7 @@ license="LGPL-2.0-or-later"
 homepage="https://ostree.readthedocs.io/en/latest/"
 changelog="https://github.com/ostreedev/ostree/releases"
 distfiles="https://github.com/ostreedev/ostree/releases/download/v${version}/libostree-${version}.tar.xz"
-checksum=9a3c17af133e6d381bb997473c6371ef8f048c1cfb6bd0acdb5662ede712aa5a
+checksum=15f734e7c65875f62c967b9937894704354a11927e92a91cb5ad8041bbb6c723
 
 build_options="gir"
 if [ -z "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Built against others that depends on this and they built fine

@Duncaen 