### PR TITLE
nodejs,nodejs-lts: enable ppc64 big endian support

### DIFF
--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -24,11 +24,6 @@ replaces="iojs>=0"
 conflicts="nodejs"
 provides="nodejs-runtime-0_1"
 
-case "$XBPS_TARGET_MACHINE" in
-        ppc64le*) ;;
-        ppc64*) broken="Node is not supported on ppc64 BE Linux";;
-esac
-
 do_configure() {
 	local _args
 
@@ -37,7 +32,7 @@ do_configure() {
 		case "$XBPS_TARGET_MACHINE" in
 			arm*) _args="--dest-cpu=arm --without-snapshot" ;;
 			aarch64*) _args="--dest-cpu=arm64 --without-snapshot" ;;
-			ppc64le*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
+			ppc64*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}\n" ;;
 		esac
 	fi

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -38,8 +38,6 @@ case "$XBPS_TARGET_MACHINE" in
 			x86_64*|aarch64*)
 				nocross="Can't cross-compile to 32bit-host from 64bit-host";;
 		esac ;;
-	ppc64le*) ;;
-	ppc64*) broken="Node is not supported on ppc64 BE Linux";;
 esac
 
 do_configure() {
@@ -49,7 +47,7 @@ do_configure() {
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
 			aarch64*) _args="--dest-cpu=arm64 --without-snapshot" ;;
-			ppc64le*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
+			ppc64*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
 		esac
 	fi


### PR DESCRIPTION
While node does not officially list ppc64 big-endian on Linux in its supported targets, it has been confirmed to work without problems on the exact target we need, i.e. ppc64 big endian musl; it's also unlikely to break, as big endian support is necessary for AIX. Since node is now a dependency for software like Firefox (necessary for build), it's probably a good idea to enable it.