### PR TITLE
Enable building base-* packages for ppc

### DIFF
--- a/srcpkgs/base-chroot-musl/template
+++ b/srcpkgs/base-chroot-musl/template
@@ -11,7 +11,7 @@ license="Public domain"
 
 conflicts="base-chroot>=0"
 provides="base-chroot-${version}_${revision}"
-only_for_archs="i686-musl x86_64-musl armv5tel-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipshf-musl mipsel-musl mipselhf-musl ppc64le-musl ppc64-musl"
+only_for_archs="i686-musl x86_64-musl armv5tel-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipshf-musl mipsel-musl mipselhf-musl ppc-musl ppc64le-musl ppc64-musl"
 
 depends="
  base-files kernel-libc-headers musl-devel musl-legacy-compat

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -96,6 +96,8 @@ case "$XBPS_TARGET_MACHINE" in
 	armv7l-musl) _triplet="armv7l-linux-musleabihf";;
 	aarch64) _triplet="aarch64-linux-gnu";;
 	aarch64-musl) _triplet="aarch64-linux-musl";;
+	ppc) _triplet="powerpc-linux-gnu";;
+	ppc-musl) _triplet="powerpc-linux-musl";;
 	ppc64le) _triplet="powerpc64le-linux-gnu";;
 	ppc64le-musl) _triplet="powerpc64le-linux-musl";;
 	ppc64-musl) _triplet="powerpc64-linux-musl";;
@@ -175,6 +177,8 @@ do_configure() {
 			_args+=" --with-arch=armv8-a"
 			sed -i '/m64=/s/lib64/lib/' gcc/config/aarch64/t-aarch64-linux
 			;;
+		ppc) _args+=" --with-cpu=powerpc --target=powerpc-linux-gnu";;
+		ppc-musl) _args+=" --with-cpu=powerpc --target=powerpc-linux-musl --disable-decimal-float --with-long-double=64";;
 		ppc64le*) # use lib not lib64 by default
 			_args+=" --with-cpu=powerpc64le --with-abi=elfv2"
 			sed -i '/OSDIRNAMES/s/lib64/lib/' gcc/config/rs6000/t-linux
@@ -243,7 +247,7 @@ do_configure() {
 	esac
 
 	case "$XBPS_TARGET_MACHINE" in
-		ppc64*) _args+=" --disable-vtable-verify";;
+		ppc*) _args+=" --disable-vtable-verify";;
 		*) _args+=" --enable-vtable-verify";;
 	esac
 

--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -54,7 +54,7 @@ makedepends="kernel-libc-headers"
 lib32files="/usr/lib/gconv/gconv-modules"
 lib32symlinks="ld-linux.so.2"
 # There's no point in building this for musl.
-only_for_archs="i686 x86_64 armv5tel armv6l armv7l aarch64 ppc64le"
+only_for_archs="i686 x86_64 armv5tel armv6l armv7l aarch64 ppc ppc64le"
 nopie=yes
 
 do_configure() {

--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -22,7 +22,7 @@ case "$XBPS_TARGET_MACHINE" in
 	arm*) _arch="arm";;
 	aarch64*) _arch="arm64";;
 	mips*) _arch="mips";;
-	ppc64*) _arch="powerpc";;
+	ppc*) _arch="powerpc";;
 	*) msg_error "$pkgname: unknown architecture.\n";;
 esac
 

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -15,7 +15,7 @@ checksum=44be8771d0e6c6b5f82dd15662eb2957c9a3173a19a8b49966ac0542bbd40d61
 
 nostrip_files="libc.so"
 shlib_provides="libc.so"
-only_for_archs="i686-musl x86_64-musl armv5tel-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipshf-musl mipsel-musl mipselhf-musl ppc64le-musl ppc64-musl"
+only_for_archs="i686-musl x86_64-musl armv5tel-musl armv6l-musl armv7l-musl aarch64-musl mips-musl mipshf-musl mipsel-musl mipselhf-musl ppc-musl ppc64le-musl ppc64-musl"
 
 post_build() {
 	$CC $CFLAGS $LDFLAGS ${FILESDIR}/getent.c -o getent

--- a/srcpkgs/pkg-config/template
+++ b/srcpkgs/pkg-config/template
@@ -19,7 +19,7 @@ alternatives="
  pkg-config:pkg.m4:/usr/share/aclocal/pkg.m4.pkg-config"
 
 case "$XBPS_TARGET_MACHINE" in
-	mips*) configure_args+=" glib_cv_stack_grows=no glib_cv_uscore=no" ;;
+	mips*|ppc|ppc-musl) configure_args+=" glib_cv_stack_grows=no glib_cv_uscore=no" ;;
 esac
 
 post_install() {

--- a/srcpkgs/python3/patches/tweak-MULTIARCH-for-powerpc-linux-musl.patch
+++ b/srcpkgs/python3/patches/tweak-MULTIARCH-for-powerpc-linux-musl.patch
@@ -1,0 +1,13 @@
+--- configure
++++ configure
+@@ -5205,6 +5205,10 @@
+ 
+ MULTIARCH=$($CC --print-multiarch 2>/dev/null)
+ 
++if test x$MULTIARCH = xpowerpc-linux-musl
++then
++	MULTIARCH="powerpc-linux-gnu"
++fi
+ 
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the platform triplet based on compiler characteristics" >&5
+ $as_echo_n "checking for the platform triplet based on compiler characteristics... " >&6; }


### PR DESCRIPTION
Necessary patches to allow building all of the base-* packages for ppc and ppc-musl.

The python3 patch was taken from [openembedded](https://github.com/openembedded/openembedded-core/blob/master/meta/recipes-devtools/python/python3/tweak-MULTIARCH-for-powerpc-linux-musl.patch) and changed to patch configure directly rather than configure.ac.

