### PR TITLE
timeshift: update to 19.01

### DIFF
--- a/srcpkgs/timeshift/template
+++ b/srcpkgs/timeshift/template
@@ -1,18 +1,23 @@
 # Template file for 'timeshift'
 pkgname=timeshift
-version=18.9.1
+version=19.01
 revision=1
 build_style=gnu-makefile
+conf_files="/etc/default/timeshift.json"
 hostmakedepends="pkg-config vala"
 makedepends="libgee08-devel json-glib-devel gtk+3-devel vte3-devel libgirepository-devel"
 depends="rsync"
-conf_files="/etc/default/timeshift.json"
 short_desc="System restore tool"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.teejeetech.in/p/timeshift.html"
 distfiles="https://github.com/teejee2008/timeshift/archive/v${version}.tar.gz"
-checksum=18b10e10938cadf34df14b7aa2b81bd9382daed50b830613a58b6802de595b37
+checksum=557223cf0b9ab0c4848455e1cc4d9068c607b9f5492a2de4935a2f40393e3c5f
+
+# Remove hard-dep on crontab, leave up to user to decide
+post_extract() {
+	sed -i '/dependencies/s:"crontab",::' src/Core/Main.vala
+}
 
 post_install() {
 	rm "${DESTDIR}/usr/bin/timeshift-uninstall"


### PR DESCRIPTION
@abenson 

Added cronie, due to launching gtk part, gives error of missing crontab. Tested to see if it will launch, but I don't have BTRFS to test with.