### PR TITLE
ucspi-ssl: update to 0.99e

### DIFF
--- a/srcpkgs/ucspi-ssl/template
+++ b/srcpkgs/ucspi-ssl/template
@@ -1,24 +1,23 @@
 # Template file for 'ucspi-ssl'
 pkgname=ucspi-ssl
-version=0.99d
-revision=6
-short_desc="Command-line tools for building SSL client-server applications"
-maintainer="Evan Deaubl <evan@deaubl.name>"
-license="Public Domain"
+version=0.99e
+revision=1
+create_wrksrc=yes
+build_wrksrc="host/superscript.com/net/${pkgname}-${version}/src"
 build_style=gnu-makefile
 hostmakedepends="perl libressl-devel"
 makedepends="libressl-devel"
 depends="ucspi-tcp"
+short_desc="Command-line tools for building SSL client-server applications"
+maintainer="Evan Deaubl <evan@deaubl.name>"
+license="Public Domain"
 homepage="http://www.fehcom.de/ipnet/ucspi-ssl.html"
-#distfiles="http://www.fehcom.de/ipnet/ucspi-ssl/${pkgname}-${version}.tgz"
-distfiles="https://sources.voidlinux.eu/${pkgname}-${version}/${pkgname}-${version}.tgz"
-checksum=f056deb954f4396123cdd97c8c8adc6386a51b49b0be6e22a9eb4a24e43e7f69
-wrksrc="${pkgname}-${version}"
-create_wrksrc=yes
-build_wrksrc="host/superscript.com/net/${pkgname}-${version}/src"
+distfiles="http://www.fehcom.de/ipnet/ucspi-ssl/ucspi-ssl-${version}.tgz"
+checksum=b246a4cdab48a0a47854892ce683caf5444096af0c2b8ccd04e5b4d604e75633
 # ad hoc build system breaks parallel build and cross-compilation
 disable_parallel_build=yes
 nocross=yes
+export SSL_NO_VERIFY_PEER=yes
 
 pre_build() {
 	pwd >home
@@ -41,4 +40,10 @@ do_install() {
 	vman ../man/sslserver.1
 	vman ../man/ucspi-tls.2
 	vdoc ../doc/UCSPI-SSL
+}
+
+# Fix exec location in scripts
+post_install() {
+	sed -i 's:/builddir/.*:/usr/bin/sslclient:' \
+		${DESTDIR}/usr/bin/sslcat ${DESTDIR}/usr/bin/https@
 }


### PR DESCRIPTION
Fixed variable order, tested to see if the scripts atleast ran, fixed the ones that didn't do due to exec /builddir/ being used; also version currently in repo has the same issue.

After this one is merged, if we still are hosting older version of distfile, it can be removed