### PR TITLE
nspr: fix ppc64 support, and --enable-64bit on aarch64

### DIFF
--- a/srcpkgs/nspr/patches/ppc64-default-stack-size.diff
+++ b/srcpkgs/nspr/patches/ppc64-default-stack-size.diff
@@ -1,0 +1,22 @@
+set a minimum stack size on ppc64 to prevent crashes
+
+Firefox, a user of nspr, attempts to set a stack size of 32k in its
+JS watchdog, which the pthreads impl doesn't like and fails.
+
+Coincidentally, nspr here is compiled with debug on, which means it has
+assertions turned on; under normal circumstances, those would be disabled,
+the stack size set call would fail and everything would fall back on the
+default 2M stacksize, but it would still be wrong - therefore, establish
+a minimum, just like for aarch64.
+
+--- nspr/pr/include/md/_linux.h
++++ nspr/pr/include/md/_linux.h
+@@ -71,7 +71,7 @@
+ #define _MD_DEFAULT_STACK_SIZE	65536L
+ #define _MD_MMAP_FLAGS          MAP_PRIVATE
+ 
+-#if defined(__aarch64__) || defined(__mips__)
++#if defined(__aarch64__) || defined(__mips__) || defined(__powerpc64__)
+ #define _MD_MINIMUM_STACK_SIZE  0x20000
+ #endif
+ 

--- a/srcpkgs/nspr/template
+++ b/srcpkgs/nspr/template
@@ -2,13 +2,13 @@
 pkgname=nspr
 version=4.20
 revision=1
-build_style=gnu-configure
 build_wrksrc=nspr
+build_style=gnu-configure
 makedepends="zlib-devel"
 short_desc="NetScape Portable Runtime"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-homepage="http://www.mozilla.org/projects/nspr/"
 license="MPL-2.0"
+homepage="http://www.mozilla.org/projects/nspr/"
 distfiles="${MOZILLA_SITE}/nspr/releases/v${version}/src/${pkgname}-${version}.tar.gz"
 checksum=2c8964913da89ffbaf464d49ce44d79e8804e1794ef9a8c52a7bff7224d1556e
 
@@ -19,7 +19,7 @@ do_configure() {
 		_args+=" --target=$XBPS_CROSS_TRIPLET"
 	fi
 	case "$XBPS_TARGET_MACHINE" in
-		x86_64*) _args+=" --enable-64bit";;
+		x86_64*|ppc64*|aarch64*) _args+=" --enable-64bit";;
 	esac
 
 	./configure --build=${XBPS_TRIPLET} --prefix=/usr --libdir=/usr/lib \


### PR DESCRIPTION
The latter is for correctness. It only currently affects SPARC builds it seems (i checked every use of USE_64 in the makefiles and none of it affects Linux anyhow), but enable it in case it's needed in the future.

The patch is something I figured out while debugging why Firefox would crash on startup.