### PR TITLE
firefox: add a jemalloc patch for ppc/ppc64

### DIFF
--- a/srcpkgs/firefox/patches/ppc-no-static-sizes.patch
+++ b/srcpkgs/firefox/patches/ppc-no-static-sizes.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# Parent b735e618c2a860972197942f6680c941e3c9a67f
+# User Gustavo Luiz Duarte <gustavold@linux.vnet.ibm.com>
+Bug 997353 - Do not use compile-time page size for PowerPC.
+
+The PowerPC architecture allows various memory page sizes, making it impossible
+to predict the runtime page size.
+
+--- memory/build/mozjemalloc.cpp
++++ memory/build/mozjemalloc.cpp
+@@ -369,7 +369,7 @@
+ // Debug builds are opted out too, for test coverage.
+ #ifndef MOZ_DEBUG
+ #if !defined(__ia64__) && !defined(__sparc__) && !defined(__mips__) &&         \
+-  !defined(__aarch64__)
++  !defined(__aarch64__) && !defined(__powerpc__) && !defined(__powerpc64__)
+ #define MALLOC_STATIC_PAGESIZE 1
+ #endif
+ #endif


### PR DESCRIPTION
Firefox also needs https://github.com/void-linux/void-packages/pull/7534 to work.