### PR TITLE
musikcube: fix realpath buffer overflow

### DIFF
--- a/srcpkgs/musikcube/patches/fix-musikcube-buffer-overflow.patch
+++ b/srcpkgs/musikcube/patches/fix-musikcube-buffer-overflow.patch
@@ -1,0 +1,33 @@
+From 3fb2c0658ab3d3ab7a92587dac426b057433fcf8 Mon Sep 17 00:00:00 2001
+From: eater <=@eater.me>
+Date: Sun, 20 Jan 2019 15:21:59 +0100
+Subject: [PATCH] Fix: let libc set length of resolved  in realpath
+
+---
+ src/plugins/gmedecoder/Constants.h | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git src/plugins/gmedecoder/Constants.h src/plugins/gmedecoder/Constants.h
+index bcd887c7..62ef2e00 100644
+--- src/plugins/gmedecoder/Constants.h
++++ src/plugins/gmedecoder/Constants.h
+@@ -221,6 +221,12 @@ static inline std::string canonicalizePath(const std::string& path) {
+         delete[] dest;
+     }
+     return result8;
++#elif __gnu_linux__
++    char* realname = realpath(path.c_str(), NULL);
++    if (!realname) {
++	return "";
++    }
++    return std::string(realname);
+ #else
+     char realname[_POSIX_PATH_MAX];
+     if (realpath(path.c_str(), realname) == 0) {
+@@ -228,4 +234,4 @@ static inline std::string canonicalizePath(const std::string& path) {
+     }
+     return std::string(realname);
+ #endif
+-}
+\ No newline at end of file
++}

--- a/srcpkgs/musikcube/template
+++ b/srcpkgs/musikcube/template
@@ -1,7 +1,7 @@
 # Template file for 'musikcube'
 pkgname=musikcube
 version=0.61.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DNO_NCURSESW=1"
 makedepends="boost-devel libogg-devel libmicrohttpd-devel ffmpeg-devel


### PR DESCRIPTION
Cherry picked a bug fix for musikcube

https://github.com/clangen/musikcube/commit/3fb2c0658ab3d3ab7a92587dac426b057433fcf8 
https://github.com/clangen/musikcube/pull/232

Currently on all my computers it will result in a buffer overflow