### PR TITLE
hexchat: enable luajit on aarch64

### DIFF
--- a/srcpkgs/hexchat/template
+++ b/srcpkgs/hexchat/template
@@ -1,7 +1,7 @@
 # Template file for 'hexchat'
 pkgname=hexchat
 version=2.14.2
-revision=3
+revision=4
 build_style=meson
 configure_args="-Dwith-dbus=true -Dwith-ssl=true -Dwith-text=false
  -Dwith-perl=/usr/bin/perl -Dwith-python=python3
@@ -22,7 +22,6 @@ build_options="LuaJIT"
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*-musl) : "LuaJIT is broken for musl cross arches" ;;
-	aarch64*) : "LuaJIT is not supported on aarch64" ;;
 	*) build_options_default+=" LuaJIT" ;;
 esac
 lib32disabled=yes


### PR DESCRIPTION
This depends on https://github.com/void-linux/void-packages/pull/6682 being merged first, as LuaJIT 2.0.5 does not support aarch64.