### PR TITLE
readline: update to 8.0.000.

### DIFF
--- a/srcpkgs/octave/template
+++ b/srcpkgs/octave/template
@@ -1,7 +1,7 @@
 # Template file for 'octave'
 pkgname=octave
 version=4.4.1
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args=" --with-blas=openblas --with-lapack=openblas"
 hostmakedepends="perl gcc-fortran pkg-config gnuplot"

--- a/srcpkgs/opensc/template
+++ b/srcpkgs/opensc/template
@@ -1,7 +1,7 @@
 # Template file for 'opensc'
 pkgname=opensc
 version=0.19.0
-revision=3
+revision=4
 wrksrc="OpenSC-${version}"
 build_style=gnu-configure
 configure_args="--enable-man  --enable-sm --enable-static=no --enable-doc


### PR DESCRIPTION
- [x] yoshimi
- [x] yaz
- [x] xorriso
- [x] xfsprogs
- [x] wpa_supplicant
- [x] wcalc
- [x] virtuoso
- [x] vice
- [x] varnish
- [x] util-linux
- [x] unixodbc
- [x] units
- [x] udftools
- [x] tftp-hpa
- [x] swi-prolog
- [x] sqlcipher
- [x] socat
- [x] slurm-wlm
- [x] sdcv
- [x] scanmem
- [x] samba
- [x] ruby
- [x] rlwrap
- [x] renameutils
- [x] rc
- [x] qalculate
- [x] python3
- [x] python
- [x] profanity
- [x] postgresql
- [x] pilot-link
- [x] php
- [x] perl-Term-ReadLine-Gnu
- [x] pcre2
- [x] parted
- [x] opensc
- [x] octave
- [x] nickle
- [x] ngspice
- [x] nftables
- [x] newlisp
- [x] ncmpcpp
- [x] mvwm-git
- [x] mspdebug
- [x] mozjs60
- [x] mozjs52
- [x] monero
- [x] minitalk
- [x] mdbtools
- [x] lvm2
- [x] lua52
- [x] lua51
- [x] lua
- [x] lnav
- [x] libxml2
- [x] libvirt
- [x] libgda
- [x] lftp
- [x] ldapvi
- [x] kid3
- [x] jack
- [x] iwd
- [x] inetutils
- [x] hstr
- [x] hamlib
- [x] guile1.8
- [x] guile
- [x] gsasl
- [x] gphoto2
- [x] gnupg2
- [x] gnupg
- [x] gnuchess
- [x] gnubg
- [x] glusterfs
- [x] gjs
- [x] giac
- [x] genius
- [x] gdb
- [x] gawk
- [x] fvwm
- [x] freetds
- [x] freeciv
- [x] fontforge
- [x] folks
- [x] fluidsynth
- [x] fcron
- [x] eukleides
- [x] es
- [x] edbrowse
- [x] connman
- [x] cjs
- [x] cgdb
- [x] cdecl
- [x] canto-curses
- [x] cadaver
- [x] bluez
- [x] bird
- [x] bind
- [x] bcal
- [x] bc
- [x] augeas
- [x] atari800
- [x] android-file-transfer-linux
- [x] abook
- [x] R
- [x] NetworkManager
- [x] MEGAcmd
- [x] iverilog
- [x] grv