### PR TITLE
libgcrypt: fix configuration error on ppc

### DIFF
--- a/srcpkgs/libgcrypt/template
+++ b/srcpkgs/libgcrypt/template
@@ -12,6 +12,10 @@ homepage="https://www.gnupg.org"
 distfiles="https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${version}.tar.bz2"
 checksum=f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227
 
+case "$XBPS_TARGET_MACHINE" in
+	ppc|ppc-musl) configure_args+=" ac_cv_sys_symbol_underscore=no" ;;
+esac
+
 post_configure() {
 	case "$XBPS_TARGET_MACHINE" in
 	armv[5-6]*)


### PR DESCRIPTION
Same fix as [buildroot](https://github.com/maximeh/buildroot/blob/master/package/libgcrypt/libgcrypt.mk)