### PR TITLE
glib: Fix configuration error on ppc

### DIFF
--- a/srcpkgs/glib/template
+++ b/srcpkgs/glib/template
@@ -17,7 +17,7 @@ checksum=8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" glib-devel"
 	case "$XBPS_TARGET_MACHINE" in
-		mips*)	# It seems common/environment/configure/autoconf_cache/mips-linux is not read?
+		mips*|ppc|ppc-musl)	# It seems mips/ppc autoconf cache is not read?
 			configure_args+=" glib_cv_stack_grows=no glib_cv_rtldglobal_broken=no glib_cv_uscore=no" ;;
 	esac
 fi


### PR DESCRIPTION
Looks like the autoconf cache isn't read on ppc either.