### PR TITLE
Mark ndctl as broken on ppc

### DIFF
--- a/srcpkgs/libblockdev/template
+++ b/srcpkgs/libblockdev/template
@@ -5,7 +5,7 @@ revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config python3"
 makedepends="cryptsetup-devel device-mapper-devel dmraid-devel libbytesize-devel
- libglib-devel libkmod-devel libndctl-devel libparted-devel nss-devel
+ libglib-devel libkmod-devel libparted-devel nss-devel
  volume_key-devel libyaml-devel"
 short_desc="A library for manipulating block devices"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
@@ -16,6 +16,14 @@ distfiles="https://github.com/storaged-project/libblockdev/releases/download/${v
 checksum=f87873aefebbd43976b73b823cd6e53f15e4e364611bd288b2886c2fcbb45a24
 conf_files="/etc/libblockdev/conf.d/10-lvm-dbus.cfg
  /etc/libblockdev/conf.d/00-default.cfg"
+
+#ndctl not present on ppc
+case "$XBPS_TARGET_MACHINE" in
+	ppc|ppc-musl)
+		configure_args+=" --without-nvdimm" ;;
+	*)
+		makedepends+=" libndctl-devel" ;;
+esac
 
 libblockdev-devel_package() {
 	depends="libblockdev-${version}_${revision} glib-devel"

--- a/srcpkgs/ndctl/template
+++ b/srcpkgs/ndctl/template
@@ -15,6 +15,10 @@ distfiles="https://github.com/pmem/ndctl/archive/v${version}.tar.gz"
 checksum=c9822c46f6b366427da8ae9cb6f9706fa88ee7e33e91c273e325d9f0666998ac
 conf_files="/etc/ndctl/monitor.conf"
 
+case "$XBPS_TARGET_MACHINE" in
+	ppc|ppc-musl) broken="broken on ppc" ;;
+esac
+
 pre_configure() {
 	./autogen.sh
 }


### PR DESCRIPTION
Mark ndctl as broken on ppc and remove it as a dependency of libblockdev if building on ppc.