### PR TITLE
libmpeg2: Explicitly disable altivec on ppc

### DIFF
--- a/srcpkgs/libmpeg2/template
+++ b/srcpkgs/libmpeg2/template
@@ -13,6 +13,10 @@ homepage="http://libmpeg2.sourceforge.net/"
 distfiles="http://libmpeg2.sourceforge.net/files/libmpeg2-${version}.tar.gz"
 checksum=dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
 
+case "$XBPS_MACHINE" in
+	ppc|ppc-musl) CFLAGS+=" -mno-altivec" ;;
+esac
+
 libmpeg2-devel_package() {
 	depends="libmpeg2>=${version}_${revision}"
 	short_desc+=" - development files"


### PR DESCRIPTION
libmpeg2 seems to think that all ppc cpus have altivec. 