### PR TITLE
qt5: fix webengine+ppc64le, disable webengine where needed

### DIFF
--- a/srcpkgs/qt5/patches/qtwebengine-chromium-ppc64.patch
+++ b/srcpkgs/qt5/patches/qtwebengine-chromium-ppc64.patch
@@ -1,0 +1,2112 @@
+This patches the bundled Chromium enough to allow it to build and work on
+little endian ppc64. The patchset is rebased regularly on top of latest
+Chromium codebase, so there should be no problem keeping it up to date.
+
+Ping q66 if you're updating qt5 and the patch does not apply anymore.
+
+Source: https://wiki.raptorcs.com/w/index.php?title=Porting/Chromium
+Upstream: Chromium does not accept additional platform support, downstream
+          patching necessary
+
+diff --git qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/page_allocator.h qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/page_allocator.h
+index a39b4e301..5e62e7a23 100644
+--- qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/page_allocator.h
++++ qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/page_allocator.h
+@@ -15,7 +15,7 @@
+ 
+ namespace base {
+ 
+-#if defined(OS_WIN)
++#if defined(OS_WIN) || defined(ARCH_CPU_PPC64)
+ static const size_t kPageAllocationGranularityShift = 16;  // 64KB
+ #elif defined(_MIPS_ARCH_LOONGSON)
+ static const size_t kPageAllocationGranularityShift = 14;  // 16KB
+@@ -31,6 +31,10 @@ static const size_t kPageAllocationGranularityBaseMask =
+ 
+ #if defined(_MIPS_ARCH_LOONGSON)
+ static const size_t kSystemPageSize = 16384;
++#elif defined(ARCH_CPU_PPC64)
++// TODO: modern ppc64 can do 4k and 64k page sizes
++// for now, 64k is assumed
++static constexpr size_t kSystemPageSize = 65536;
+ #else
+ static const size_t kSystemPageSize = 4096;
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.h qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.h
+index 6e5143b09..74c7cf88f 100644
+--- qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.h
++++ qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/partition_alloc.h
+@@ -99,6 +99,8 @@ static const size_t kBucketShift = (kAllocationGranularity == 8) ? 3 : 2;
+ // up against the end of a system page.
+ #if defined(_MIPS_ARCH_LOONGSON)
+ static const size_t kPartitionPageShift = 16;  // 64KB
++#elif defined(ARCH_CPU_PPC64)
++static const size_t kPartitionPageShift = 18;  // 256 KiB
+ #else
+ static const size_t kPartitionPageShift = 14;  // 16KB
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.cc qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.cc
+index 272016c76..4b02d3ce5 100644
+--- qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.cc
++++ qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.cc
+@@ -55,6 +55,8 @@ const char kArch[] =
+     "mips64el";
+ #elif defined(__mips__)
+     "mipsel";
++#elif defined(__powerpc64__)
++    "ppc64";
+ #else
+ #error "unknown arch"
+ #endif
+@@ -127,6 +129,8 @@ const char* UpdateQueryParams::GetNaclArch() {
+   return "mips32";
+ #elif defined(ARCH_CPU_MIPS64EL)
+   return "mips64";
++#elif defined(ARCH_CPU_PPC64)
++  return "ppc64";
+ #else
+ // NOTE: when adding new values here, please remember to update the
+ // comment in the .h file about possible return values from this function.
+diff --git qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.h qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.h
+index a35e4c377..e315e144c 100644
+--- qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.h
++++ qtwebengine/src/3rdparty/chromium/components/update_client/update_query_params.h
+@@ -45,7 +45,7 @@ class UpdateQueryParams {
+   // Returns the value we use for the "nacl_arch" parameter. Note that this may
+   // be different from the "arch" parameter above (e.g. one may be 32-bit and
+   // the other 64-bit). Possible return values include: "x86-32", "x86-64",
+-  // "arm", and "mips32".
++  // "arm", "mips32", and "ppc64".
+   static const char* GetNaclArch();
+ 
+   // Returns the current version of Chrome/Chromium.
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/features.gni qtwebengine/src/3rdparty/chromium/sandbox/features.gni
+index 89693c54c..6017c7eea 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/features.gni
++++ qtwebengine/src/3rdparty/chromium/sandbox/features.gni
+@@ -12,6 +12,6 @@ use_seccomp_bpf =
+     (is_linux || is_android) &&
+     (current_cpu == "x86" || current_cpu == "x64" || current_cpu == "arm" ||
+      current_cpu == "arm64" || current_cpu == "mipsel" ||
+-     current_cpu == "mips64el")
++     current_cpu == "mips64el" || current_cpu == "ppc64")
+ 
+ use_seccomp_bpf = use_seccomp_bpf || is_nacl_nonsfi
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/BUILD.gn qtwebengine/src/3rdparty/chromium/sandbox/linux/BUILD.gn
+index 9d4726f89..9348f6461 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/BUILD.gn
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/BUILD.gn
+@@ -423,6 +423,8 @@ component("sandbox_services") {
+ 
+ source_set("sandbox_services_headers") {
+   sources = [
++    "system_headers/ppc64_linux_syscalls.h",
++    "system_headers/ppc64_linux_ucontext.h",
+     "system_headers/arm64_linux_syscalls.h",
+     "system_headers/arm64_linux_ucontext.h",
+     "system_headers/arm_linux_syscalls.h",
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
+index 334a00bb9..272d65b2a 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
+@@ -53,6 +53,13 @@
+ #define MAX_PUBLIC_SYSCALL 279u
+ #define MAX_SYSCALL MAX_PUBLIC_SYSCALL
+ 
++#elif defined(__powerpc64__)
++
++#include <asm/unistd.h>
++#define MIN_SYSCALL 0u
++#define MAX_PUBLIC_SYSCALL 386u
++#define MAX_SYSCALL MAX_PUBLIC_SYSCALL
++
+ #else
+ #error "Unsupported architecture"
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
+index e4e8142c4..6a926f904 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/bpf_dsl/seccomp_macros.h
+@@ -16,6 +16,9 @@
+ #if defined(__mips__)
+ // sys/user.h in eglibc misses size_t definition
+ #include <stddef.h>
++#elif defined(__powerpc64__)
++// Manually define greg_t on ppc64
++typedef unsigned long long greg_t;
+ #endif
+ #endif
+ 
+@@ -345,6 +348,51 @@ struct regs_struct {
+ #define SECCOMP_PT_PARM4(_regs) (_regs).regs[3]
+ #define SECCOMP_PT_PARM5(_regs) (_regs).regs[4]
+ #define SECCOMP_PT_PARM6(_regs) (_regs).regs[5]
++
++#elif defined(__powerpc64__)
++#include <asm/ptrace.h>
++
++typedef struct pt_regs regs_struct;
++
++#ifdef ARCH_CPU_LITTLE_ENDIAN
++#define SECCOMP_ARCH AUDIT_ARCH_PPC64LE
++#else
++#define SECCOMP_ARCH AUDIT_ARCH_PPC64
++#endif
++
++#define SECCOMP_REG(_ctx, _reg) ((_ctx)->uc_mcontext.regs->gpr[_reg])
++
++#define SECCOMP_RESULT(_ctx) SECCOMP_REG(_ctx, 3)
++#define SECCOMP_SYSCALL(_ctx) SECCOMP_REG(_ctx, 0)
++#define SECCOMP_IP(_ctx) (_ctx)->uc_mcontext.regs->nip
++#define SECCOMP_PARM1(_ctx) SECCOMP_REG(_ctx, 3)
++#define SECCOMP_PARM2(_ctx) SECCOMP_REG(_ctx, 4)
++#define SECCOMP_PARM3(_ctx) SECCOMP_REG(_ctx, 5)
++#define SECCOMP_PARM4(_ctx) SECCOMP_REG(_ctx, 6)
++#define SECCOMP_PARM5(_ctx) SECCOMP_REG(_ctx, 7)
++#define SECCOMP_PARM6(_ctx) SECCOMP_REG(_ctx, 8)
++
++#define SECCOMP_NR_IDX (offsetof(struct arch_seccomp_data, nr))
++#define SECCOMP_ARCH_IDX (offsetof(struct arch_seccomp_data, arch))
++#define SECCOMP_IP_MSB_IDX \
++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
++#define SECCOMP_IP_LSB_IDX \
++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 0)
++#define SECCOMP_ARG_MSB_IDX(nr) \
++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
++#define SECCOMP_ARG_LSB_IDX(nr) \
++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
++
++#define SECCOMP_PT_RESULT(_regs) (_regs).gpr[3]
++#define SECCOMP_PT_SYSCALL(_regs) (_regs).gpr[0]
++#define SECCOMP_PT_IP(_regs) (_regs).nip
++#define SECCOMP_PT_PARM1(_regs) (_regs).gpr[3]
++#define SECCOMP_PT_PARM2(_regs) (_regs).gpr[4]
++#define SECCOMP_PT_PARM3(_regs) (_regs).gpr[5]
++#define SECCOMP_PT_PARM4(_regs) (_regs).gpr[6]
++#define SECCOMP_PT_PARM5(_regs) (_regs).gpr[7]
++#define SECCOMP_PT_PARM6(_regs) (_regs).gpr[8]
++
+ #else
+ #error Unsupported target platform
+ 
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index 6aab37a88..0a4d49729 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -86,7 +86,7 @@ bool IsBaselinePolicyWatched(int sysno) {
+          SyscallSets::IsNuma(sysno) ||
+          SyscallSets::IsPrctl(sysno) ||
+          SyscallSets::IsProcessGroupOrSession(sysno) ||
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+          SyscallSets::IsSocketCall(sysno) ||
+ #endif
+ #if defined(__arm__)
+@@ -186,7 +186,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   }
+ 
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+   if (sysno == __NR_mmap)
+     return RestrictMmapFlags();
+ #endif
+@@ -203,7 +203,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+     return RestrictPrctl();
+ 
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+   if (sysno == __NR_socketpair) {
+     // Only allow AF_UNIX, PF_UNIX. Crash if anything else is seen.
+     static_assert(AF_UNIX == PF_UNIX,
+@@ -241,7 +241,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+     return Error(EPERM);
+   }
+ 
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+   if (SyscallSets::IsSocketCall(sysno))
+     return RestrictSocketcallCommand();
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+index 155e52e9b..595c27377 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+@@ -36,6 +36,11 @@
+ #include <sys/ioctl.h>
+ #endif
+ 
++// On PPC64, TCGETS is defined in terms of struct termios, so we must include termios.h
++#ifdef __powerpc64__
++#include <termios.h>
++#endif
++
+ #if defined(OS_ANDROID)
+ 
+ #if !defined(F_DUPFD_CLOEXEC)
+@@ -98,6 +103,15 @@ inline bool IsArchitectureMips() {
+ #endif
+ }
+ 
++inline bool IsArchitecturePPC64() {
++#if defined(__powerpc64__)
++  return true;
++#else
++  return false;
++#endif
++}
++
++
+ // Ubuntu's version of glibc has a race condition in sem_post that can cause
+ // it to call futex(2) with bogus op arguments. To workaround this, we need
+ // to allow those futex(2) calls to fail with EINVAL, instead of crashing the
+@@ -239,7 +253,8 @@ ResultExpr RestrictFcntlCommands() {
+   // operator.
+   // Glibc overrides the kernel's O_LARGEFILE value. Account for this.
+   uint64_t kOLargeFileFlag = O_LARGEFILE;
+-  if (IsArchitectureX86_64() || IsArchitectureI386() || IsArchitectureMips())
++  if (IsArchitectureX86_64() || IsArchitectureI386() || IsArchitectureMips() \
++      || IsArchitecturePPC64())
+     kOLargeFileFlag = 0100000;
+ 
+   const Arg<int> cmd(1);
+@@ -262,7 +277,7 @@ ResultExpr RestrictFcntlCommands() {
+       .Default(CrashSIGSYS());
+ }
+ 
+-#if defined(__i386__) || defined(__mips__)
++#if defined(__i386__) || defined(__mips__) || defined(__powerpc64__)
+ ResultExpr RestrictSocketcallCommand() {
+   // Unfortunately, we are unable to restrict the first parameter to
+   // socketpair(2). Whilst initially sounding bad, it's noteworthy that very
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h
+index 71c56093d..f8b9c0c6b 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.h
+@@ -48,7 +48,7 @@ SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictMprotectFlags();
+ // O_NONBLOCK | O_SYNC | O_LARGEFILE | O_CLOEXEC | O_NOATIME.
+ SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictFcntlCommands();
+ 
+-#if defined(__i386__) || defined(__mips__)
++#if defined(__i386__) || defined(__mips__) || defined(__powerpc64__)
+ // Restrict socketcall(2) to only allow socketpair(2), send(2), recv(2),
+ // sendto(2), recvfrom(2), shutdown(2), sendmsg(2) and recvmsg(2).
+ SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictSocketcallCommand();
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+index 6259639c9..f2f511d70 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -28,7 +28,8 @@ bool SyscallSets::IsKill(int sysno) {
+ bool SyscallSets::IsAllowedGettime(int sysno) {
+   switch (sysno) {
+     case __NR_gettimeofday:
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips32__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR_time:
+ #endif
+       return true;
+@@ -42,7 +43,7 @@ bool SyscallSets::IsAllowedGettime(int sysno) {
+     case __NR_ftime:  // Obsolete.
+ #endif
+     case __NR_settimeofday:  // Privileged.
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_stime:
+ #endif
+     default:
+@@ -108,7 +109,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
+     case __NR_faccessat:  // EPERM not a valid errno.
+     case __NR_fchmodat:
+     case __NR_fchownat:  // Should be called chownat ?
+-#if defined(__x86_64__) || defined(__aarch64__)
++#if defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_newfstatat:  // fstatat(). EPERM not a valid errno.
+ #elif defined(__i386__) || defined(__arm__) || defined(__mips32__)
+     case __NR_fstatat64:
+@@ -125,7 +126,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
+     case __NR_memfd_create:
+     case __NR_mkdirat:
+     case __NR_mknodat:
+-#if defined(__i386__)
++#if defined(__i386__) || defined(__powerpc64__)
+     case __NR_oldlstat:
+     case __NR_oldstat:
+ #endif
+@@ -146,7 +147,8 @@ bool SyscallSets::IsFileSystem(int sysno) {
+     case __NR_truncate64:
+ #endif
+     case __NR_unlinkat:
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_utime:
+ #endif
+     case __NR_utimensat:  // New.
+@@ -164,7 +166,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+ #endif
+       return true;
+ // TODO(jln): these should be denied gracefully as well (moved below).
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_fadvise64:  // EPERM not a valid errno.
+ #endif
+ #if defined(__i386__)
+@@ -176,7 +179,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+     case __NR_fdatasync:  // EPERM not a valid errno.
+     case __NR_flock:      // EPERM not a valid errno.
+     case __NR_fstatfs:    // Give information about the whole filesystem.
+-#if defined(__i386__) || defined(__arm__) || defined(__mips32__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR_fstatfs64:
+ #endif
+     case __NR_fsync:  // EPERM not a valid errno.
+@@ -188,6 +192,8 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+     case __NR_sync_file_range:  // EPERM not a valid errno.
+ #elif defined(__arm__)
+     case __NR_arm_sync_file_range:  // EPERM not a valid errno.
++#elif defined(__powerpc64__)
++    case __NR_sync_file_range2: // EPERM not a valid errno.
+ #endif
+     default:
+       return false;
+@@ -211,7 +217,7 @@ bool SyscallSets::IsDeniedFileSystemAccessViaFd(int sysno) {
+     case __NR_getdents:    // EPERM not a valid errno.
+ #endif
+     case __NR_getdents64:  // EPERM not a valid errno.
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_readdir:
+ #endif
+       return true;
+@@ -252,7 +258,7 @@ bool SyscallSets::IsGetSimpleId(int sysno) {
+ bool SyscallSets::IsProcessPrivilegeChange(int sysno) {
+   switch (sysno) {
+     case __NR_capset:
+-#if defined(__i386__) || defined(__x86_64__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
+     case __NR_ioperm:  // Intel privilege.
+     case __NR_iopl:    // Intel privilege.
+ #endif
+@@ -301,7 +307,8 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
+     case __NR_rt_sigaction:
+     case __NR_rt_sigprocmask:
+     case __NR_rt_sigreturn:
+-#if defined(__i386__) || defined(__arm__) || defined(__mips32__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR_sigaction:
+     case __NR_sigprocmask:
+     case __NR_sigreturn:
+@@ -317,7 +324,8 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
+     case __NR_signalfd:
+ #endif
+     case __NR_signalfd4:
+-#if defined(__i386__) || defined(__arm__) || defined(__mips32__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR_sigpending:
+     case __NR_sigsuspend:
+ #endif
+@@ -340,7 +348,7 @@ bool SyscallSets::IsAllowedOperationOnFd(int sysno) {
+ #endif
+     case __NR_dup3:
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_shutdown:
+ #endif
+       return true;
+@@ -372,7 +380,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
+     case __NR_exit_group:
+     case __NR_wait4:
+     case __NR_waitid:
+-#if defined(__i386__)
++#if defined(__i386__) || defined(__powerpc64__)
+     case __NR_waitpid:
+ #endif
+ #if !defined(__GLIBC__)
+@@ -443,7 +451,7 @@ bool SyscallSets::IsAllowedGetOrModifySocket(int sysno) {
+       return true;
+     default:
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_socketpair:  // We will want to inspect its argument.
+ #endif
+       return false;
+@@ -453,7 +461,7 @@ bool SyscallSets::IsAllowedGetOrModifySocket(int sysno) {
+ bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
+   switch (sysno) {
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_accept:
+     case __NR_accept4:
+     case __NR_bind:
+@@ -467,7 +475,7 @@ bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
+   }
+ }
+ 
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+ // Big multiplexing system call for sockets.
+ bool SyscallSets::IsSocketCall(int sysno) {
+   switch (sysno) {
+@@ -481,7 +489,8 @@ bool SyscallSets::IsSocketCall(int sysno) {
+ }
+ #endif
+ 
+-#if defined(__x86_64__) || defined(__arm__) || defined(__mips__)
++#if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
++    defined(__powerpc64__)
+ bool SyscallSets::IsNetworkSocketInformation(int sysno) {
+   switch (sysno) {
+     case __NR_getpeername:
+@@ -509,7 +518,7 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+     case __NR_mincore:
+     case __NR_mlockall:
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_mmap:
+ #endif
+ #if defined(__i386__) || defined(__arm__) || defined(__mips32__)
+@@ -538,7 +547,8 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
+ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+   switch (sysno) {
+     case __NR_lseek:
+-#if defined(__i386__) || defined(__arm__) || defined(__mips32__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR__llseek:
+ #endif
+ #if !defined(__aarch64__)
+@@ -548,25 +558,26 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+     case __NR_pselect6:
+     case __NR_read:
+     case __NR_readv:
+-#if defined(__arm__) || defined(__mips32__)
++#if defined(__arm__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_recv:
+ #endif
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_recvfrom:  // Could specify source.
+     case __NR_recvmsg:   // Could specify source.
+ #endif
+-#if defined(__i386__) || defined(__x86_64__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc64__)
+     case __NR_select:
+ #endif
+-#if defined(__i386__) || defined(__arm__) || defined(__mips__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR__newselect:
+ #endif
+-#if defined(__arm__) || defined(__mips32__)
++#if defined(__arm__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_send:
+ #endif
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_sendmsg:  // Could specify destination.
+     case __NR_sendto:   // Could specify destination.
+ #endif
+@@ -622,7 +633,8 @@ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
+     case __NR_nanosleep:
+       return true;
+     case __NR_getpriority:
+-#if defined(__i386__) || defined(__arm__) || defined(__mips32__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR_nice:
+ #endif
+     case __NR_setpriority:
+@@ -633,7 +645,8 @@ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
+ 
+ bool SyscallSets::IsAdminOperation(int sysno) {
+   switch (sysno) {
+-#if defined(__i386__) || defined(__arm__) || defined(__mips32__)
++#if defined(__i386__) || defined(__arm__) || defined(__mips32__) || \
++    defined(__powerpc64__)
+     case __NR_bdflush:
+ #endif
+     case __NR_kexec_load:
+@@ -649,7 +662,8 @@ bool SyscallSets::IsAdminOperation(int sysno) {
+ 
+ bool SyscallSets::IsKernelModule(int sysno) {
+   switch (sysno) {
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_create_module:
+     case __NR_get_kernel_syms:  // Should ENOSYS.
+     case __NR_query_module:
+@@ -681,7 +695,7 @@ bool SyscallSets::IsFsControl(int sysno) {
+     case __NR_quotactl:
+     case __NR_swapoff:
+     case __NR_swapon:
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_umount:
+ #endif
+     case __NR_umount2:
+@@ -697,7 +711,7 @@ bool SyscallSets::IsNuma(int sysno) {
+     case __NR_getcpu:
+     case __NR_mbind:
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_migrate_pages:
+ #endif
+     case __NR_move_pages:
+@@ -726,13 +740,13 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
+   switch (sysno) {
+     case __NR_acct:  // Privileged.
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+     case __NR_getrlimit:
+ #endif
+-#if defined(__i386__) || defined(__arm__)
++#if defined(__i386__) || defined(__arm__) || defined(__powerpc64__)
+     case __NR_ugetrlimit:
+ #endif
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_ulimit:
+ #endif
+     case __NR_getrusage:
+@@ -766,7 +780,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
+ #endif
+     case __NR_sysinfo:
+     case __NR_uname:
+-#if defined(__i386__)
++#if defined(__i386__) || defined(__powerpc64__)
+     case __NR_olduname:
+     case __NR_oldolduname:
+ #endif
+@@ -857,7 +871,7 @@ bool SyscallSets::IsSystemVMessageQueue(int sysno) {
+ }
+ #endif
+ 
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+ // Big system V multiplexing system call.
+ bool SyscallSets::IsSystemVIpc(int sysno) {
+   switch (sysno) {
+@@ -876,7 +890,7 @@ bool SyscallSets::IsAnySystemV(int sysno) {
+     || defined(__mips64__)
+   return IsSystemVMessageQueue(sysno) || IsSystemVSemaphores(sysno) ||
+          IsSystemVSharedMemory(sysno);
+-#elif defined(__i386__) || defined(__mips32__)
++#elif defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+   return IsSystemVIpc(sysno);
+ #endif
+ }
+@@ -929,7 +943,8 @@ bool SyscallSets::IsFaNotify(int sysno) {
+ bool SyscallSets::IsTimer(int sysno) {
+   switch (sysno) {
+     case __NR_getitimer:
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_alarm:
+ #endif
+     case __NR_setitimer:
+@@ -988,16 +1003,18 @@ bool SyscallSets::IsMisc(int sysno) {
+     case __NR_syncfs:
+     case __NR_vhangup:
+ // The system calls below are not implemented.
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_afs_syscall:
+ #endif
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_break:
+ #endif
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_getpmsg:
+ #endif
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_gtty:
+     case __NR_idle:
+     case __NR_lock:
+@@ -1005,19 +1022,20 @@ bool SyscallSets::IsMisc(int sysno) {
+     case __NR_prof:
+     case __NR_profil:
+ #endif
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++    defined(__powerpc64__)
+     case __NR_putpmsg:
+ #endif
+ #if defined(__x86_64__)
+     case __NR_security:
+ #endif
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+     case __NR_stty:
+ #endif
+-#if defined(__x86_64__)
++#if defined(__x86_64__) || defined(__powerpc64__)
+     case __NR_tuxcall:
+ #endif
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__powerpc64__)
+     case __NR_vserver:
+ #endif
+       return true;
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
+index c31d5e9c1..7898be9e1 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
+@@ -42,13 +42,13 @@ class SANDBOX_EXPORT SyscallSets {
+   static bool IsAllowedGetOrModifySocket(int sysno);
+   static bool IsDeniedGetOrModifySocket(int sysno);
+ 
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+   // Big multiplexing system call for sockets.
+   static bool IsSocketCall(int sysno);
+ #endif
+ 
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+   static bool IsNetworkSocketInformation(int sysno);
+ #endif
+ 
+@@ -85,7 +85,7 @@ class SANDBOX_EXPORT SyscallSets {
+   static bool IsSystemVMessageQueue(int sysno);
+ #endif
+ 
+-#if defined(__i386__) || defined(__mips32__)
++#if defined(__i386__) || defined(__mips32__) || defined(__powerpc64__)
+   // Big system V multiplexing system call.
+   static bool IsSystemVIpc(int sysno);
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc
+index d6db70f0d..4937b25a4 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/syscall.cc
+@@ -15,7 +15,7 @@ namespace sandbox {
+ namespace {
+ 
+ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
+-    defined(ARCH_CPU_MIPS_FAMILY)
++    defined(ARCH_CPU_MIPS_FAMILY) || defined (ARCH_CPU_PPC64_FAMILY)
+ // Number that's not currently used by any Linux kernel ABIs.
+ const int kInvalidSyscallNumber = 0x351d3;
+ #else
+@@ -307,12 +307,56 @@ asm(// We need to be able to tell the kernel exactly where we made a
+     // Enter the kernel
+     "svc 0\n"
+     "2:ret\n"
++    ".cfi_endproc\n"
++    ".size SyscallAsm, .-SyscallAsm\n"
++#elif defined(__powerpc64__)
++    ".text\n"
++    ".align 4\n"
++    ".type SyscallAsm @function\n"
++    "SyscallAsm:\n"
++    ".cfi_startproc\n"
++
++    // Check if r3 is negative
++    "cmpdi 3, 0\n"
++    "bgt 2f\n"
++
++    // Load address of 3f into r3 and return
++    "mflr 10\n"
++    "bl 1f\n"
++    "1: mflr 3\n"
++    "mtlr 10\n"
++    "addi 3, 3, 4*13\n"
++    "blr\n"
++
++    // Load arguments from array into r3-8
++    // save param 3 in r10
++    "2:\n"
++    "mr 0, 3\n"
++    "ld 3, 0(4)\n"
++    "ld 5, 16(4)\n"
++    "ld 6, 24(4)\n"
++    "ld 7, 32(4)\n"
++    "ld 8, 40(4)\n"
++    "ld 4, 8(4)\n"
++    "li 9, 0\n"
++
++    // Enter kernel
++    "sc\n"
++
++    // Magic return address
++    "3:\n"
++    // Like MIPS, ppc64 return values are always positive.
++    // Check for error in cr0.SO and negate upon error
++    "bc 4, 3, 4f\n"
++    "neg 3, 3\n"
++    "4: blr\n"
++
+     ".cfi_endproc\n"
+     ".size SyscallAsm, .-SyscallAsm\n"
+ #endif
+     );  // asm
+ 
+-#if defined(__x86_64__)
++#if defined(__x86_64__) || defined(__powerpc64__)
+ extern "C" {
+ intptr_t SyscallAsm(intptr_t nr, const intptr_t args[6]);
+ }
+@@ -426,6 +470,8 @@ intptr_t Syscall::Call(int nr,
+     ret = inout;
+   }
+ 
++#elif defined(__powerpc64__)
++  intptr_t ret = SyscallAsm(nr, args);
+ #else
+ #error "Unimplemented architecture"
+ #endif
+@@ -442,8 +488,18 @@ void Syscall::PutValueInUcontext(intptr_t ret_val, ucontext_t* ctx) {
+     // needs to be changed back.
+     ret_val = -ret_val;
+     SECCOMP_PARM4(ctx) = 1;
+-  } else
++  } else {
+     SECCOMP_PARM4(ctx) = 0;
++  }
++#endif
++#if defined(__powerpc64__)
++  // Same as MIPS, need to invert ret and set error register (cr0.SO)
++  if (ret_val <= -1 && ret_val >= -4095) {
++    ret_val = -ret_val;
++    ctx->uc_mcontext.regs->ccr |= (1 << 28);
++  } else {
++    ctx->uc_mcontext.regs->ccr &= ~(1 << 28);
++  }
+ #endif
+   SECCOMP_RESULT(ctx) = static_cast<greg_t>(ret_val);
+ }
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc
+index e9c51940c..35a8f0d67 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf/trap.cc
+@@ -230,6 +230,20 @@ void Trap::SigSys(int nr, LinuxSigInfo* info, ucontext_t* ctx) {
+       SetIsInSigHandler();
+     }
+ 
++#if defined(__powerpc64__)
++    // On ppc64+glibc, some syscalls seem to accidentally negate the first
++    // parameter which causes checks against it to fail. For now, manually
++    // negate them back.
++    // TODO(shawn@anastas.io): investigate this issue further
++    auto nr = SECCOMP_SYSCALL(ctx);
++    if (nr == __NR_openat || nr == __NR_mkdirat || nr == __NR_faccessat || nr == __NR_readlinkat ||
++        nr == __NR_renameat || nr == __NR_renameat2 || nr == __NR_newfstatat || nr == __NR_unlinkat) {
++        if (static_cast<int>(SECCOMP_PARM1(ctx)) > 0) {
++            SECCOMP_PARM1(ctx) = -SECCOMP_PARM1(ctx);
++        }
++    }
++#endif
++
+     // Copy the seccomp-specific data into a arch_seccomp_data structure. This
+     // is what we are showing to TrapFnc callbacks that the system call
+     // evaluator registered with the sandbox.
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc
+index 65b63adfe..1b4e62e46 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/services/credentials.cc
+@@ -77,7 +77,7 @@ bool ChrootToSafeEmptyDir() {
+   pid_t pid = -1;
+   alignas(16) char stack_buf[PTHREAD_STACK_MIN];
+ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
+-    defined(ARCH_CPU_MIPS_FAMILY)
++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_PPC64_FAMILY)
+   // The stack grows downward.
+   void* stack = stack_buf + sizeof(stack_buf);
+ #else
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h
+index a60fe2ad3..9dccdb51d 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_seccomp.h
+@@ -29,6 +29,9 @@
+ #ifndef EM_AARCH64
+ #define EM_AARCH64 183
+ #endif
++#ifndef EM_PPC64
++#define EM_PPC64 21
++#endif
+ 
+ #ifndef __AUDIT_ARCH_64BIT
+ #define __AUDIT_ARCH_64BIT 0x80000000
+@@ -54,6 +57,12 @@
+ #ifndef AUDIT_ARCH_AARCH64
+ #define AUDIT_ARCH_AARCH64 (EM_AARCH64 | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE)
+ #endif
++#ifndef AUDIT_ARCH_PPC64
++#define AUDIT_ARCH_PPC64 (EM_PPC64 | __AUDIT_ARCH_64BIT)
++#endif
++#ifndef AUDIT_ARCH_PPC64LE
++#define AUDIT_ARCH_PPC64LE (EM_PPC64 | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE)
++#endif
+ 
+ // For prctl.h
+ #ifndef PR_SET_SECCOMP
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h
+index 5ac4fdb42..b27b4ea5f 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_signal.h
+@@ -11,7 +11,7 @@
+ // (not undefined, but defined different values and in different memory
+ // layouts). So, fill the gap here.
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__powerpc64__)
+ 
+ #define LINUX_SIGHUP 1
+ #define LINUX_SIGINT 2
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h
+index 761c08abe..28ebf2f4e 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_syscalls.h
+@@ -33,5 +33,9 @@
+ #include "sandbox/linux/system_headers/arm64_linux_syscalls.h"
+ #endif
+ 
++#if defined(__powerpc64__)
++#include "sandbox/linux/system_headers/ppc64_linux_syscalls.h"
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SYSCALLS_H_
+ 
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_ucontext.h qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_ucontext.h
+index e97d7277d..f3f05849a 100644
+--- qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_ucontext.h
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_ucontext.h
+@@ -19,6 +19,8 @@
+ #include "sandbox/linux/system_headers/mips64_linux_ucontext.h"
+ #elif defined(__aarch64__)
+ #include "sandbox/linux/system_headers/arm64_linux_ucontext.h"
++#elif defined(__powerpc64__)
++#include "sandbox/linux/system_headers/ppc64_linux_ucontext.h"
+ #else
+ #error "No support for your architecture in Android or PNaCl header"
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/ppc64_linux_syscalls.h qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/ppc64_linux_syscalls.h
+new file mode 100644
+index 000000000..ccacffe22
+--- /dev/null
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/ppc64_linux_syscalls.h
+@@ -0,0 +1,12 @@
++// Copyright 2014 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_SYSCALLS_H_
++#define SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_SYSCALLS_H_
++
++#include <asm/unistd.h>
++
++//TODO: is it necessary to redefine syscall numbers for PPC64?
++
++#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_SYSCALLS_H_
+diff --git qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h
+new file mode 100644
+index 000000000..07728e087
+--- /dev/null
++++ qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/ppc64_linux_ucontext.h
+@@ -0,0 +1,12 @@
++// Copyright 2014 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_UCONTEXT_H_
++#define SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_UCONTEXT_H_
++
++#include <sys/ucontext.h>
++
++//TODO: is it necessary to redefine ucontext on PPC64?
++
++#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_PPC64_LINUX_UCONTEXT_H_
+diff --git qtwebengine/src/3rdparty/chromium/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc qtwebengine/src/3rdparty/chromium/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
+index bbeb3152d..156cd0d24 100644
+--- qtwebengine/src/3rdparty/chromium/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
++++ qtwebengine/src/3rdparty/chromium/services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc
+@@ -15,6 +15,11 @@
+ #include "sandbox/linux/system_headers/linux_syscalls.h"
+ #include "services/service_manager/sandbox/linux/sandbox_linux.h"
+ 
++// On PPC64, TCGETS is defined in terms of struct termios, so we must include termios.h
++#ifdef __powerpc64__
++#include <termios.h>
++#endif
++
+ #if defined(OS_CHROMEOS)
+ // TODO(vignatti): replace the local definitions below with #include
+ // <linux/dma-buf.h> once kernel version 4.6 becomes widely used.
+diff --git qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/HeapPage.h qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/HeapPage.h
+index 20674563e..49f45fede 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/HeapPage.h
++++ qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/HeapPage.h
+@@ -62,11 +62,12 @@ constexpr size_t kBlinkPageBaseMask = ~kBlinkPageOffsetMask;
+ constexpr size_t kBlinkPagesPerRegion = 10;
+ 
+ // TODO(nya): Replace this with something like #if ENABLE_NACL.
+-#if 0
++#if defined(ARCH_CPU_PPC64)
+ // NaCl's system page size is 64 KiB. This causes a problem in Oilpan's heap
+ // layout because Oilpan allocates two guard pages for each Blink page (whose
+ // size is kBlinkPageSize = 2^17 = 128 KiB). So we don't use guard pages in
+ // NaCl.
++// The same issue holds for ppc64 systems, which use a 64k page size.
+ constexpr size_t kBlinkGuardPageSize = 0;
+ #else
+ constexpr size_t kBlinkGuardPageSize = base::kSystemPageSize;
+diff --git qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/BUILD.gn qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/BUILD.gn
+index 6c87950f4..a2fab32b3 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/BUILD.gn
++++ qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/BUILD.gn
+@@ -46,6 +46,10 @@ if (current_cpu == "x86" || current_cpu == "x64") {
+       sources = [
+         "SaveRegisters_mips64.S",
+       ]
++    } else if (current_cpu == "ppc64") {
++      sources = [
++        "SaveRegisters_ppc64.S",
++      ]
+     }
+ 
+     if (current_cpu == "arm") {
+diff --git qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/SaveRegisters_ppc64.S qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/SaveRegisters_ppc64.S
+new file mode 100644
+index 000000000..ecd139ae1
+--- /dev/null
++++ qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/heap/asm/SaveRegisters_ppc64.S
+@@ -0,0 +1,59 @@
++/*
++ * typedef void (*PushAllRegistersCallback)(SafePointBarrier*, ThreadState*, intptr_t*);
++ * extern "C" void PushAllRegisters(SafePointBarrier*, ThreadState*, PushAllRegistersCallback)
++ */
++
++.type PushAllRegisters, %function
++.global PushAllRegisters
++.hidden PushAllRegisters
++PushAllRegisters:
++        // Push all callee-saves registers to get them
++        // on the stack for conservative stack scanning.
++        // Reserve space for callee-saved registers and minimal stack frame.
++        mflr 0         # r0 = LR
++        std 0,16(1)    # store LR at addr sp+16
++        stdu 1,-176(1) # grow stack by 176 bytes and store new stack top ptr to r1
++            # 3218*8 = min stack  non-volatile registers
++
++        // Save the callee-saved registers
++        std 31,168(1)  # store r31 to addr sp+168 
++        std 30,160(1)  # etc...
++        std 29,152(1)
++        std 28,144(1)
++        std 27,136(1)
++        std 26,128(1)
++        std 25,120(1)
++        std 24,112(1)
++        std 23,104(1)
++        std 22,96(1)
++        std 21,88(1)
++        std 20,80(1)
++        std 19,72(1)
++        std 18,64(1)
++        std 17,56(1)
++        std 16,48(1)
++        std 15,40(1)
++        std 14,32(1)
++        
++        // Note: the callee-saved floating point registers do not need to be
++        // copied to the stack, because fp registers never hold heap pointers
++        // and so do not need to be kept visible to the garbage collector.
++        
++        // Pass the two first arguments untouched in r3 and r4 and the
++        // stack pointer to the callback.
++
++        std 2, 24(1)   # save r2 to sp+24 addr
++        mtctr 5        # copy 3rd function arg (callback fn pointer) to CTR
++        mr 12, 5       # r12 must hold address of callback we are going to call 
++                       #  for position-idependent functions inside the callback to work
++        mr 5, 1        # set current sp (stack top) as 3rd argument for the callback
++        bctrl          # set LR to PC+4 and call the callback
++        ld 2, 24(1)    # restore r2 from sp+24 addr
++
++        // Adjust stack, restore return address and return.
++        // Note: the copied registers do not need to be reloaded here,
++        // because they were preserved by the called routine.
++        addi 1,1,176   # restore original SP by doing sp += 176
++        ld 0,16(1)     # restore original LR from addr sp+16
++        mtlr 0         # ... copy it to the actual LR
++        blr            # return to LR addr
+diff --git qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/wtf/dtoa/utils.h qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/wtf/dtoa/utils.h
+index 7f1b1c6ca..65adc0e6d 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/wtf/dtoa/utils.h
++++ qtwebengine/src/3rdparty/chromium/third_party/WebKit/Source/platform/wtf/dtoa/utils.h
+@@ -45,7 +45,7 @@
+ // disabled.)
+ // On Linux,x86 89255e-22 != Div_double(89255.0/1e22)
+ #if defined(_M_X64) || defined(__x86_64__) || defined(__ARMEL__) || \
+-    defined(__aarch64__) || defined(__MIPSEL__)
++    defined(__aarch64__) || defined(__MIPSEL__) || defined(__powerpc64__)
+ #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
+ #elif defined(_M_IX86) || defined(__i386__)
+ #if defined(_WIN32)
+diff --git qtwebengine/src/3rdparty/chromium/third_party/angle/src/libANGLE/Constants.h qtwebengine/src/3rdparty/chromium/third_party/angle/src/libANGLE/Constants.h
+index 2fe921af3..0a0bfe442 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/angle/src/libANGLE/Constants.h
++++ qtwebengine/src/3rdparty/chromium/third_party/angle/src/libANGLE/Constants.h
+@@ -9,6 +9,7 @@
+ #ifndef LIBANGLE_CONSTANTS_H_
+ #define LIBANGLE_CONSTANTS_H_
+ 
++#include <cstddef>
+ #include "common/platform.h"
+ 
+ namespace gl
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/raw_context_cpu.h qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/raw_context_cpu.h
+index e2ef45df5..e295bd76b 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/raw_context_cpu.h
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/raw_context_cpu.h
+@@ -44,6 +44,8 @@ typedef MDRawContextARM RawContextCPU;
+ typedef MDRawContextARM64 RawContextCPU;
+ #elif defined(__mips__)
+ typedef MDRawContextMIPS RawContextCPU;
++#elif defined(__powerpc64__)
++typedef MDRawContextPPC64 RawContextCPU;
+ #else
+ #error "This code has not been ported to your platform yet."
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.cc
+index 0a1041d62..d2a7b3394 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.cc
+@@ -270,7 +270,42 @@ void ThreadInfo::FillCPUContext(RawContextCPU* out) const {
+   out->float_save.fir = mcontext.fpc_eir;
+ #endif
+ }
+-#endif  // __mips__
++
++#elif defined(__powerpc64__)
++
++uintptr_t ThreadInfo::GetInstructionPointer() const {
++    return mcontext.gp_regs[PT_NIP];
++}
++
++void ThreadInfo::FillCPUContext(RawContextCPU* out) const {
++    out->context_flags = MD_CONTEXT_PPC64_FULL;
++    for (int i = 0; i < MD_CONTEXT_PPC64_GPR_COUNT; i++)
++        out->gpr[i] = mcontext.gp_regs[i];
++
++    out->lr = mcontext.gp_regs[PT_LNK];
++    out->srr0 = mcontext.gp_regs[PT_NIP];
++    out->srr1 = mcontext.gp_regs[PT_MSR];
++    out->cr = mcontext.gp_regs[PT_CCR];
++    out->xer = mcontext.gp_regs[PT_XER];
++    out->ctr = mcontext.gp_regs[PT_CTR];
++    
++    for (int i = 0; i < MD_FLOATINGSAVEAREA_PPC_FPR_COUNT; i++)
++        out->float_save.fpregs[i] = mcontext.fp_regs[i];
++
++    out->float_save.fpscr = mcontext.fp_regs[NFPREG-1];
++
++    for (int i = 0; i < MD_VECTORSAVEAREA_PPC_VR_COUNT; i++)
++        out->vector_save.save_vr[i] = \
++            {(((uint64_t)vregs.vrregs[i][0]) << 32) 
++                          | vregs.vrregs[i][1], 
++            (((uint64_t)vregs.vrregs[i][2]) << 32)
++                         | vregs.vrregs[i][3]};
++
++    out->vrsave = vregs.vrsave;
++    out->vector_save.save_vscr = {0, vregs.vscr.vscr_word};
++    out->vector_save.save_vrvalid = 0xFFFFFFFF; 
++}
++#endif  // __powerpc64__
+ 
+ void ThreadInfo::GetGeneralPurposeRegisters(void** gp_regs, size_t* size) {
+   assert(gp_regs || size);
+@@ -279,6 +314,11 @@ void ThreadInfo::GetGeneralPurposeRegisters(void** gp_regs, size_t* size) {
+     *gp_regs = mcontext.gregs;
+   if (size)
+     *size = sizeof(mcontext.gregs);
++#elif defined(__powerpc64__)
++  if (gp_regs)
++    *gp_regs = mcontext.gp_regs;
++  if (size)
++    *size = sizeof(mcontext.gp_regs);
+ #else
+   if (gp_regs)
+     *gp_regs = &regs;
+@@ -294,6 +334,11 @@ void ThreadInfo::GetFloatingPointRegisters(void** fp_regs, size_t* size) {
+     *fp_regs = &mcontext.fpregs;
+   if (size)
+     *size = sizeof(mcontext.fpregs);
++#elif defined(__powerpc64__)
++  if (fp_regs)
++    *fp_regs = &mcontext.fp_regs;
++  if (size)
++    *size = sizeof(mcontext.fp_regs);
+ #else
+   if (fp_regs)
+     *fp_regs = &fpregs;
+@@ -302,4 +347,13 @@ void ThreadInfo::GetFloatingPointRegisters(void** fp_regs, size_t* size) {
+ #endif
+ }
+ 
++#if defined(__powerpc64__)
++void ThreadInfo::GetVectorRegisters(void** v_regs, size_t* size) {
++    if (v_regs)
++        *v_regs = &vregs;
++    if (size)
++        *size = sizeof(vregs);
++}
++#endif
++
+ }  // namespace google_breakpad
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
+index fb216fa6d..fb669126f 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/thread_info.h
+@@ -68,6 +68,10 @@ struct ThreadInfo {
+   // Use the structures defined in <sys/user.h>
+   struct user_regs_struct regs;
+   struct user_fpsimd_struct fpregs;
++#elif defined(__powerpc64__)
++  // Use the structures defined in <sys/ucontext.h>.
++  mcontext_t mcontext;
++  struct _libc_vrstate vregs;
+ #elif defined(__mips__)
+   // Use the structure defined in <sys/ucontext.h>.
+   mcontext_t mcontext;
+@@ -84,6 +88,11 @@ struct ThreadInfo {
+ 
+   // Returns the pointer and size of float point register area.
+   void GetFloatingPointRegisters(void** fp_regs, size_t* size);
++
++#if defined(__powerpc64__)
++  // Returns the pointer and size of the vector register area. (PPC64 only)
++  void GetVectorRegisters(void** v_regs, size_t* size);
++#endif
+ };
+ 
+ }  // namespace google_breakpad
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
+index 95b0fb44e..82b428fa9 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
+@@ -254,6 +254,48 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+   out->float_save.fir = uc->uc_mcontext.fpc_eir;  // Unused.
+ #endif
+ }
++
++#elif defined(__powerpc64__)
++
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
++    return uc->uc_mcontext.gp_regs[MD_CONTEXT_PPC64_REG_SP];
++}
++
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
++    return uc->uc_mcontext.gp_regs[PT_NIP];
++}
++
++void UContextReader::FillCPUContext(RawContextCPU* out, const ucontext_t* uc,
++                                    const struct _libc_vrstate* vregs) {
++    out->context_flags = MD_CONTEXT_PPC64_FULL;
++
++    for (int i = 0; i < MD_CONTEXT_PPC64_GPR_COUNT; i++)
++        out->gpr[i] = uc->uc_mcontext.gp_regs[i];
++
++    out->lr = uc->uc_mcontext.gp_regs[PT_LNK];    
++    out->srr0 = uc->uc_mcontext.gp_regs[PT_NIP];
++    out->srr1 = uc->uc_mcontext.gp_regs[PT_MSR];
++    out->cr = uc->uc_mcontext.gp_regs[PT_CCR];
++    out->xer = uc->uc_mcontext.gp_regs[PT_XER];
++    out->ctr = uc->uc_mcontext.gp_regs[PT_CTR];
++    
++    for (int i = 0; i < MD_FLOATINGSAVEAREA_PPC_FPR_COUNT; i++)
++        out->float_save.fpregs[i] = uc->uc_mcontext.fp_regs[i];
++
++    out->float_save.fpscr = uc->uc_mcontext.fp_regs[NFPREG-1];
++
++    for (int i = 0; i < MD_VECTORSAVEAREA_PPC_VR_COUNT; i++)
++        out->vector_save.save_vr[i] =
++            {(((uint64_t)vregs->vrregs[i][0]) << 32) 
++                         | vregs->vrregs[i][1], 
++             (((uint64_t)vregs->vrregs[i][2]) << 32)
++                         | vregs->vrregs[i][3]};
++
++    out->vrsave = vregs->vrsave;
++    out->vector_save.save_vscr = {0, vregs->vscr.vscr_word};
++    out->vector_save.save_vrvalid = 0xFFFFFFFF; 
++}
++
+ #endif
+ 
+ }  // namespace google_breakpad
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.h qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
+index f3dde1f4d..5c1f16e56 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
+@@ -54,6 +54,9 @@ struct UContextReader {
+ #elif defined(__aarch64__)
+   static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct fpsimd_context* fpregs);
++#elif defined(__powerpc64__)
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
++                             const struct _libc_vrstate* vregs);
+ #else
+   static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc);
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc
+index 303e8edb9..8874b388a 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.cc
+@@ -460,9 +460,16 @@ bool ExceptionHandler::HandleSignal(int /*sig*/, siginfo_t* info, void* uc) {
+     memcpy(&g_crash_context_.float_state, fp_ptr,
+            sizeof(g_crash_context_.float_state));
+   }
++#elif defined(__powerpc64__)
++  // On PPC64, we must copy VR state
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
++  if (uc_ptr->uc_mcontext.v_regs) {
++    memcpy(&g_crash_context_.vector_state, uc_ptr->uc_mcontext.v_regs,
++           sizeof(g_crash_context_.vector_state));
++  }
+ #elif !defined(__ARM_EABI__) && !defined(__mips__)
+   // FP state is not part of user ABI on ARM Linux.
+-  // In case of MIPS Linux FP state is already part of ucontext_t
++  // In case of MIPS, Linux FP state is already part of ucontext_t
+   // and 'float_state' is not a member of CrashContext.
+   ucontext_t* uc_ptr = (ucontext_t*)uc;
+   if (uc_ptr->uc_mcontext.fpregs) {
+@@ -700,11 +707,19 @@ bool ExceptionHandler::WriteMinidump() {
+   }
+ #endif
+ 
+-#if !defined(__ARM_EABI__) && !defined(__aarch64__) && !defined(__mips__)
++#if !defined(__ARM_EABI__) && !defined(__aarch64__) && !defined(__mips__) \
++    && !defined(__powerpc64__)
+   // FPU state is not part of ARM EABI ucontext_t.
+   memcpy(&context.float_state, context.context.uc_mcontext.fpregs,
+          sizeof(context.float_state));
+ #endif
++
++#if defined(__powerpc64__)
++  // Vector registers must be copied on PPC64
++  memcpy(&context.vector_state, context.context.uc_mcontext.v_regs,
++         sizeof(context.vector_state));
++#endif
++
+   context.tid = sys_gettid();
+ 
+   // Add an exception stream to the minidump for better reporting.
+@@ -725,6 +740,9 @@ bool ExceptionHandler::WriteMinidump() {
+ #elif defined(__mips__)
+   context.siginfo.si_addr =
+       reinterpret_cast<void*>(context.context.uc_mcontext.pc);
++#elif defined(__powerpc64__)
++  context.siginfo.si_addr =
++      reinterpret_cast<void*>(context.context.uc_mcontext.gp_regs[PT_NIP]);
+ #else
+ #error "This code has not been ported to your platform yet."
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.h qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.h
+index d246f6019..0af893878 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.h
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler.h
+@@ -192,7 +192,11 @@ class ExceptionHandler {
+     siginfo_t siginfo;
+     pid_t tid;  // the crashing thread.
+     ucontext_t context;
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++    // PPC64's FP state is a part of ucontext_t like MIPS but the vector
++    // state is not, so a struct is needed.
++    vstate_t vector_state;
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+     // #ifdef this out because FP state is not part of user ABI for Linux ARM.
+     // In case of MIPS Linux FP state is already part of ucontext_t so
+     // 'float_state' is not required.
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler_unittest.cc
+index 193a76e7b..165fff6fa 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/handler/exception_handler_unittest.cc
+@@ -494,6 +494,8 @@ const unsigned char kIllegalInstruction[] = {
+ #if defined(__mips__)
+   // mfc2 zero,Impl - usually illegal in userspace.
+   0x48, 0x00, 0x00, 0x48
++#elif defined(__powerpc64__)
++  0x01, 0x01, 0x01, 0x01 // Crashes on a tested POWER9 cpu
+ #else
+   // This crashes with SIGILL on x86/x86-64/arm.
+   0xff, 0xff, 0xff, 0xff
+@@ -689,10 +691,10 @@ TEST(ExceptionHandlerTest, InstructionPointerMemoryMaxBound) {
+ 
+   // These are defined here so the parent can use them to check the
+   // data from the minidump afterwards.
+-  // Use 4k here because the OS will hand out a single page even
++  // Use the page size here because the OS will hand out a single page even
+   // if a smaller size is requested, and this test wants to
+   // test the upper bound of the memory range.
+-  const uint32_t kMemorySize = 4096;  // bytes
++  const uint32_t kMemorySize = getpagesize();  // bytes
+   const int kOffset = kMemorySize - sizeof(kIllegalInstruction);
+ 
+   const pid_t child = fork();
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer.cc
+index 180873f40..2921fd387 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer.cc
+@@ -138,7 +138,9 @@ class MicrodumpWriter {
+                   const MicrodumpExtraInfo& microdump_extra_info,
+                   LinuxDumper* dumper)
+       : ucontext_(context ? &context->context : NULL),
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++        vector_state_(context ? &context->vector_state : NULL),
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+         float_state_(context ? &context->float_state : NULL),
+ #endif
+         dumper_(dumper),
+@@ -337,6 +339,8 @@ class MicrodumpWriter {
+ # else
+ #  error "This mips ABI is currently not supported (n32)"
+ #endif
++#elif defined(__powerpc64__)
++    const char kArch[] = "ppc64";
+ #else
+ #error "This code has not been ported to your platform yet"
+ #endif
+@@ -409,7 +413,9 @@ class MicrodumpWriter {
+   void DumpCPUState() {
+     RawContextCPU cpu;
+     my_memset(&cpu, 0, sizeof(RawContextCPU));
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++    UContextReader::FillCPUContext(&cpu, ucontext_, vector_state_);
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+     UContextReader::FillCPUContext(&cpu, ucontext_, float_state_);
+ #else
+     UContextReader::FillCPUContext(&cpu, ucontext_);
+@@ -605,7 +611,9 @@ class MicrodumpWriter {
+   void* Alloc(unsigned bytes) { return dumper_->allocator()->Alloc(bytes); }
+ 
+   const ucontext_t* const ucontext_;
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++  const google_breakpad::vstate_t* const vector_state_;
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;
+ #endif
+   LinuxDumper* dumper_;
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer_unittest.cc
+index c2fea0225..8c62c524a 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/microdump_writer/microdump_writer_unittest.cc
+@@ -278,10 +278,19 @@ TEST(MicrodumpWriterTest, BasicWithMappings) {
+   CrashAndGetMicrodump(mappings, MicrodumpExtraInfo(), &buf);
+   ASSERT_TRUE(ContainsMicrodump(buf));
+ 
++  int page_size = getpagesize();
+ #ifdef __LP64__
+-  ASSERT_NE(std::string::npos,
+-            buf.find("M 0000000000001000 000000000000002A 0000000000001000 "
+-                     "33221100554477668899AABBCCDDEEFF0 libfoo.so"));
++  // This test is only available for the following page sizes
++  ASSERT_TRUE((page_size == 4096) || (page_size == 65536));
++  if (page_size == 4096) { 
++    ASSERT_NE(std::string::npos,
++              buf.find("M 0000000000001000 000000000000002A 0000000000001000 "
++                       "33221100554477668899AABBCCDDEEFF0 libfoo.so"));
++  } else {
++    ASSERT_NE(std::string::npos,
++              buf.find("M 0000000000010000 000000000000002A 0000000000010000 "
++                       "33221100554477668899AABBCCDDEEFF0 libfoo.so"));
++  }
+ #else
+   ASSERT_NE(std::string::npos,
+             buf.find("M 00001000 0000002A 00001000 "
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc
+index 9be375333..f29ae5e63 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc
+@@ -116,6 +116,9 @@ bool LinuxCoreDumper::GetThreadInfoByIndex(size_t index, ThreadInfo* info) {
+ #elif defined(__mips__)
+   stack_pointer =
+       reinterpret_cast<uint8_t*>(info->mcontext.gregs[MD_CONTEXT_MIPS_REG_SP]);
++#elif defined(__powerpc64__)
++  stack_pointer =
++      reinterpret_cast<uint8_t*>(info->mcontext.gp_regs[MD_CONTEXT_PPC64_REG_SP]);
+ #else
+ #error "This code hasn't been ported to your platform yet."
+ #endif
+@@ -200,7 +203,10 @@ bool LinuxCoreDumper::EnumerateThreads() {
+         memset(&info, 0, sizeof(ThreadInfo));
+         info.tgid = status->pr_pgrp;
+         info.ppid = status->pr_ppid;
+-#if defined(__mips__)
++#if defined(__powerpc64__)
++        for (int i = 0; i < 31; i++)
++            info.mcontext.gp_regs[i] = status->pr_reg[i];
++#elif defined(__mips__)
+ #if defined(__ANDROID__)
+         for (int i = EF_R0; i <= EF_R31; i++)
+           info.mcontext.gregs[i - EF_R0] = status->pr_reg[i];
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.cc
+index 515af3ff4..a32995076 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.cc
+@@ -791,7 +791,9 @@ bool LinuxDumper::GetStackInfo(const void** stack, size_t* stack_len,
+       reinterpret_cast<uint8_t*>(int_stack_pointer & ~(page_size - 1));
+ 
+   // The number of bytes of stack which we try to capture.
+-  static const ptrdiff_t kStackToCapture = 32 * 1024;
++  // This now depends on page_size to avoid missing data
++  // on systems with larger page sizes.
++  static const ptrdiff_t kStackToCapture = 8 * page_size;
+ 
+   const MappingInfo* mapping = FindMapping(stack_pointer);
+   if (!mapping)
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.h qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.h
+index 4a4e0b0af..caa0fab63 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.h
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper.h
+@@ -60,7 +60,8 @@ namespace google_breakpad {
+  (defined(__mips__) && _MIPS_SIM == _ABIO32)
+ typedef Elf32_auxv_t elf_aux_entry;
+ #elif defined(__x86_64) || defined(__aarch64__) || \
+-     (defined(__mips__) && _MIPS_SIM != _ABIO32)
++     (defined(__mips__) && _MIPS_SIM != _ABIO32) || \
++     defined(__powerpc64__)
+ typedef Elf64_auxv_t elf_aux_entry;
+ #endif
+ 
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc
+index 3ad48e501..1688c365e 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_dumper_unittest_helper.cc
+@@ -51,6 +51,8 @@
+ #define TID_PTR_REGISTER "rcx"
+ #elif defined(__mips__)
+ #define TID_PTR_REGISTER "$1"
++#elif defined(__powerpc64__)
++#define TID_PTR_REGISTER "r8"
+ #else
+ #error This test has not been ported to this platform.
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper.cc
+index 8a3f04e29..e607b28d5 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper.cc
+@@ -154,19 +154,27 @@ bool LinuxPtraceDumper::CopyFromProcess(void* dest, pid_t child,
+   return true;
+ }
+ 
+-bool LinuxPtraceDumper::ReadRegisterSet(ThreadInfo* info, pid_t tid)
+-{
++bool LinuxPtraceDumper::ReadRegisterSet(ThreadInfo* info, pid_t tid) {
+ #ifdef PTRACE_GETREGSET
+   struct iovec io;
+   info->GetGeneralPurposeRegisters(&io.iov_base, &io.iov_len);
+-  if (sys_ptrace(PTRACE_GETREGSET, tid, (void*)NT_PRSTATUS, (void*)&io) == -1) {
++  if (ptrace(PTRACE_GETREGSET, tid, (void*)NT_PRSTATUS, (void*)&io) == -1) {
+     return false;
+   }
+ 
+   info->GetFloatingPointRegisters(&io.iov_base, &io.iov_len);
+-  if (sys_ptrace(PTRACE_GETREGSET, tid, (void*)NT_FPREGSET, (void*)&io) == -1) {
++  if (ptrace(PTRACE_GETREGSET, tid, (void*)NT_FPREGSET, (void*)&io) == -1) {
+     return false;
+   }
++
++#if defined(__powerpc64__)
++  // Grab the vector registers on PPC64 too
++  info->GetVectorRegisters(&io.iov_base, &io.iov_len);
++  if (ptrace(PTRACE_GETREGSET, tid, (void*)NT_PPC_VMX, (void*)&io) == -1) {
++    return false;
++  }
++#endif // defined(__powerpc64__)
++
+   return true;
+ #else
+   return false;
+@@ -303,6 +311,9 @@ bool LinuxPtraceDumper::GetThreadInfoByIndex(size_t index, ThreadInfo* info) {
+ #elif defined(__mips__)
+   stack_pointer =
+       reinterpret_cast<uint8_t*>(info->mcontext.gregs[MD_CONTEXT_MIPS_REG_SP]);
++#elif defined(__powerpc64__)
++  stack_pointer =
++      reinterpret_cast<uint8_t*>(info->mcontext.gp_regs[MD_CONTEXT_PPC64_REG_SP]);
+ #else
+ #error "This code hasn't been ported to your platform yet."
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper_unittest.cc
+index a4a0fd9b6..52c150704 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper_unittest.cc
+@@ -457,6 +457,9 @@ TEST(LinuxPtraceDumperTest, VerifyStackReadWithMultipleThreads) {
+ #elif defined(__mips__)
+     pid_t* process_tid_location =
+         reinterpret_cast<pid_t*>(one_thread.mcontext.gregs[1]);
++#elif defined(__powerpc64__)
++    pid_t* process_tid_location =
++        reinterpret_cast<pid_t*>(one_thread.mcontext.gp_regs[8]);
+ #else
+ #error This test has not been ported to this platform.
+ #endif
+@@ -553,6 +556,8 @@ TEST_F(LinuxPtraceDumperTest, SanitizeStackCopy) {
+   uintptr_t heap_addr = thread_info.regs.rcx;
+ #elif defined(__mips__)
+   uintptr_t heap_addr = thread_info.mcontext.gregs[1];
++#elif defined(__powerpc64__)
++  uintptr_t heap_addr = thread_info.mcontext.gp_regs[8];
+ #else
+ #error This test has not been ported to this platform.
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.cc
+index c71614345..a98f9afa5 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.cc
+@@ -136,7 +136,9 @@ class MinidumpWriter {
+       : fd_(minidump_fd),
+         path_(minidump_path),
+         ucontext_(context ? &context->context : NULL),
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++        vector_state_(context ? &context->vector_state : NULL),
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+         float_state_(context ? &context->float_state : NULL),
+ #endif
+         dumper_(dumper),
+@@ -468,7 +470,9 @@ class MinidumpWriter {
+         if (!cpu.Allocate())
+           return false;
+         my_memset(cpu.get(), 0, sizeof(RawContextCPU));
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++        UContextReader::FillCPUContext(cpu.get(), ucontext_, vector_state_);
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+         UContextReader::FillCPUContext(cpu.get(), ucontext_, float_state_);
+ #else
+         UContextReader::FillCPUContext(cpu.get(), ucontext_);
+@@ -888,7 +892,7 @@ class MinidumpWriter {
+     dirent->location.rva = 0;
+   }
+ 
+-#if defined(__i386__) || defined(__x86_64__) || defined(__mips__)
++#if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || defined(__powerpc64__)
+   bool WriteCPUInformation(MDRawSystemInfo* sys_info) {
+     char vendor_id[sizeof(sys_info->cpu.x86_cpu_info.vendor_id) + 1] = {0};
+     static const char vendor_id_name[] = "vendor_id";
+@@ -908,7 +912,9 @@ class MinidumpWriter {
+ 
+     // processor_architecture should always be set, do this first
+     sys_info->processor_architecture =
+-#if defined(__mips__)
++#if defined(__powerpc64__)
++        MD_CPU_ARCHITECTURE_PPC64;
++#elif defined(__mips__)
+ # if _MIPS_SIM == _ABIO32
+         MD_CPU_ARCHITECTURE_MIPS;
+ # elif _MIPS_SIM == _ABI64
+@@ -1324,7 +1330,9 @@ class MinidumpWriter {
+   const char* path_;  // Path to the file where the minidum should be written.
+ 
+   const ucontext_t* const ucontext_;  // also from the signal handler
+-#if !defined(__ARM_EABI__) && !defined(__mips__)
++#if defined(__powerpc64__)
++  const google_breakpad::vstate_t* const vector_state_;
++#elif !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;  // ditto
+ #endif
+   LinuxDumper* dumper_;
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.h qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.h
+index d1cc5624c..403495295 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.h
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer.h
+@@ -47,6 +47,8 @@ class ExceptionHandler;
+ 
+ #if defined(__aarch64__)
+ typedef struct fpsimd_context fpstate_t;
++#elif defined(__powerpc64__)
++typedef struct _libc_vrstate vstate_t;
+ #elif !defined(__ARM_EABI__) && !defined(__mips__)
+ typedef struct _fpstate fpstate_t;
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer_unittest.cc
+index 583ddda86..5e3deccfd 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/client/linux/minidump_writer/minidump_writer_unittest.cc
+@@ -710,6 +710,9 @@ TEST(MinidumpWriterTest, InvalidStackPointer) {
+ #elif defined(__mips__)
+   context.context.uc_mcontext.gregs[MD_CONTEXT_MIPS_REG_SP] =
+       invalid_stack_pointer;
++#elif defined(__powerpc64__)
++  context.context.uc_mcontext.gp_regs[MD_CONTEXT_PPC64_REG_SP] =
++      invalid_stack_pointer;
+ #else
+ # error "This code has not been ported to your platform yet."
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file.cc
+index 4e938269f..f0ff15d96 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file.cc
+@@ -65,8 +65,7 @@ bool MemoryMappedFile::Map(const char* path, size_t offset) {
+   }
+ 
+ #if defined(__x86_64__) || defined(__aarch64__) || \
+-   (defined(__mips__) && _MIPS_SIM == _ABI64)
+-
++   (defined(__mips__) && _MIPS_SIM == _ABI64) || defined(__powerpc64__)
+   struct kernel_stat st;
+   if (sys_fstat(fd, &st) == -1 || st.st_size < 0) {
+ #else
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file_unittest.cc
+index fad59f40c..616496d67 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/linux/memory_mapped_file_unittest.cc
+@@ -176,9 +176,10 @@ TEST_F(MemoryMappedFileTest, RemapAfterMap) {
+ TEST_F(MemoryMappedFileTest, MapWithOffset) {
+   // Put more data in the test file this time. Offsets can only be
+   // done on page boundaries, so we need a two page file to test this.
+-  const int page_size = 4096;
+-  char data1[2 * page_size];
+-  size_t data1_size = sizeof(data1);
++  const int page_size = getpagesize();
++  char *data1 = static_cast<char*>(malloc(2 * page_size));
++  EXPECT_TRUE(data1 != NULL);
++  size_t data1_size = (2 * page_size);
+   for (size_t i = 0; i < data1_size; ++i) {
+     data1[i] = i & 0x7f;
+   }
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/memory_allocator_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/memory_allocator_unittest.cc
+index 43c86314c..27325b813 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/memory_allocator_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/common/memory_allocator_unittest.cc
+@@ -57,8 +57,9 @@ TEST(PageAllocatorTest, LargeObject) {
+ 
+   EXPECT_EQ(0U, allocator.pages_allocated());
+   uint8_t *p = reinterpret_cast<uint8_t*>(allocator.Alloc(10000));
++  uint64_t expected_pages = 1 + ((10000 - 1) / getpagesize());
+   ASSERT_FALSE(p == NULL);
+-  EXPECT_EQ(3U, allocator.pages_allocated());
++  EXPECT_EQ(expected_pages, allocator.pages_allocated());
+   for (unsigned i = 1; i < 10; ++i) {
+     uint8_t *p = reinterpret_cast<uint8_t*>(allocator.Alloc(i));
+     ASSERT_FALSE(p == NULL);
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_linux.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_linux.cc
+index ccc9f1459..debaed4d6 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_linux.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_linux.cc
+@@ -202,12 +202,14 @@ bool ExploitabilityLinux::EndedOnIllegalWrite(uint64_t instruction_ptr) {
+   // Check architecture and set architecture variable to corresponding flag
+   // in objdump.
+   switch (context->GetContextCPU()) {
++#if defined(__i386) || defined(__x86_64)
+     case MD_CONTEXT_X86:
+       architecture = "i386";
+       break;
+     case MD_CONTEXT_AMD64:
+       architecture = "i386:x86-64";
+       break;
++#endif
+     default:
+       // Unsupported architecture. Note that ARM architectures are not
+       // supported because objdump does not support ARM.
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_unittest.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_unittest.cc
+index 528ee5f21..72764d6c1 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_unittest.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/processor/exploitability_unittest.cc
+@@ -104,6 +104,8 @@ ExploitabilityFor(const string& filename) {
+ }
+ 
+ TEST(ExploitabilityTest, TestWindowsEngine) {
++// The following tests are only executable on an x86-class linux machine.
++#if !defined(_WIN32) && (defined(__i386) || defined(__x86_64))
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_HIGH,
+             ExploitabilityFor("ascii_read_av.dmp"));
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_HIGH,
+@@ -136,9 +138,12 @@ TEST(ExploitabilityTest, TestWindowsEngine) {
+             ExploitabilityFor("read_av_clobber_write.dmp"));
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_LOW,
+             ExploitabilityFor("read_av_conditional.dmp"));
++#endif
+ }
+ 
+ TEST(ExploitabilityTest, TestLinuxEngine) {
++// The following tests are only executable on an x86-class linux machine.
++#if defined(__i386) || defined(__x86_64)
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_INTERESTING,
+             ExploitabilityFor("linux_null_read_av.dmp"));
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_HIGH,
+@@ -171,7 +176,8 @@ TEST(ExploitabilityTest, TestLinuxEngine) {
+             ExploitabilityFor("linux_executable_heap.dmp"));
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_HIGH,
+             ExploitabilityFor("linux_jmp_to_module_not_exe_region.dmp"));
+-#ifndef _WIN32
++#endif
++#if !defined(_WIN32) && (defined(__i386) || defined(__x86_64))
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_HIGH,
+             ExploitabilityFor("linux_write_to_nonwritable_module.dmp"));
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_HIGH,
+@@ -182,10 +188,10 @@ TEST(ExploitabilityTest, TestLinuxEngine) {
+             ExploitabilityFor("linux_write_to_outside_module_via_math.dmp"));
+   ASSERT_EQ(google_breakpad::EXPLOITABILITY_INTERESTING,
+             ExploitabilityFor("linux_write_to_under_4k.dmp"));
+-#endif  // _WIN32
++#endif  // !defined(_WIN32) && (!defined(__i386) && !defined(__x86_64))
+ }
+ 
+-#ifndef _WIN32
++#if !defined(_WIN32) && (defined(__i386) || defined(__x86_64))
+ TEST(ExploitabilityLinuxUtilsTest, DisassembleBytesTest) {
+   ASSERT_FALSE(ExploitabilityLinuxTest::DisassembleBytes("", NULL, 5, NULL));
+   uint8_t bytes[6] = {0xc7, 0x0, 0x5, 0x0, 0x0, 0x0};
+@@ -301,6 +307,7 @@ TEST(ExploitabilityLinuxUtilsTest, CalculateAddressTest) {
+                                                          context,
+                                                          &write_address));
+ }
+-#endif  // _WIN32
++#endif  // !defined(_WIN32) && (defined(__i386) || defined(__x86_64))
++
+ 
+ }  // namespace
+diff --git qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
+index 8cc07a6ef..f67556914 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/breakpad/breakpad/src/tools/linux/md2core/minidump-2-core.cc
+@@ -76,6 +76,8 @@
+   #define ELF_ARCH  EM_MIPS
+ #elif defined(__aarch64__)
+   #define ELF_ARCH  EM_AARCH64
++#elif defined(__powerpc64__)
++  #define ELF_ARCH  EM_PPC64
+ #endif
+ 
+ #if defined(__arm__)
+@@ -86,6 +88,8 @@ typedef user_regs user_regs_struct;
+ #elif defined (__mips__)
+ // This file-local typedef simplifies the source code.
+ typedef gregset_t user_regs_struct;
++#elif defined(__powerpc64__)
++typedef struct pt_regs user_regs_struct;
+ #endif
+ 
+ using google_breakpad::MDTypeHelper;
+@@ -320,6 +324,9 @@ struct CrashedProcess {
+ #endif
+ #if defined(__aarch64__)
+     user_fpsimd_struct fpregs;
++#endif
++#if defined(__powerpc64__)
++    mcontext_t mcontext;
+ #endif
+     uintptr_t stack_addr;
+     const uint8_t* stack;
+@@ -523,6 +530,38 @@ ParseThreadRegisters(CrashedProcess::Thread* thread,
+   thread->mcontext.fpc_eir = rawregs->float_save.fir;
+ #endif
+ }
++#elif defined(__powerpc64__)
++static void
++ParseThreadRegisters(CrashedProcess::Thread* thread,
++                     const MinidumpMemoryRange& range) {
++  const MDRawContextPPC64* rawregs = range.GetData<MDRawContextPPC64>(0);
++
++  for (int i = 0; i < MD_CONTEXT_PPC64_GPR_COUNT; i++)
++    thread->mcontext.gp_regs[i] = rawregs->gpr[i];
++
++  thread->mcontext.gp_regs[PT_LNK] = rawregs->lr;
++  thread->mcontext.gp_regs[PT_NIP] = rawregs->srr0;
++  thread->mcontext.gp_regs[PT_MSR] = rawregs->srr1;
++  thread->mcontext.gp_regs[PT_CCR] = rawregs->cr;
++  thread->mcontext.gp_regs[PT_XER] = rawregs->xer;
++  thread->mcontext.gp_regs[PT_CTR] = rawregs->ctr;
++  thread->mcontext.v_regs->vrsave = rawregs->vrsave;
++
++  for (int i = 0; i < MD_FLOATINGSAVEAREA_PPC_FPR_COUNT; i++)
++      thread->mcontext.fp_regs[i] = rawregs->float_save.fpregs[i];
++
++  thread->mcontext.fp_regs[NFPREG-1] = rawregs->float_save.fpscr;
++
++  for (int i = 0; i < MD_VECTORSAVEAREA_PPC_VR_COUNT; i++) {
++      thread->mcontext.v_regs->vrregs[i][0] = rawregs->vector_save.save_vr[i].high >> 32;
++      thread->mcontext.v_regs->vrregs[i][1] = rawregs->vector_save.save_vr[i].high;
++      thread->mcontext.v_regs->vrregs[i][2] = rawregs->vector_save.save_vr[i].low >> 32;
++      thread->mcontext.v_regs->vrregs[i][3] = rawregs->vector_save.save_vr[i].low;
++  }
++
++  thread->mcontext.v_regs->vscr.vscr_word = rawregs->vector_save.save_vscr.low & 0xFFFFFFFF;
++}
++
+ #else
+ #error "This code has not been ported to your platform yet"
+ #endif
+@@ -611,6 +650,12 @@ ParseSystemInfo(const Options& options, CrashedProcess* crashinfo,
+ # else
+ #  error "This mips ABI is currently not supported (n32)"
+ # endif
++#elif defined(__powerpc64__)
++  if (sysinfo->processor_architecture != MD_CPU_ARCHITECTURE_PPC64) {
++    fprintf(stderr,
++            "This version of minidump-2-core only supports PPC64.\n");
++    exit(1);
++  }
+ #else
+ #error "This code has not been ported to your platform yet"
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
+index c1e24892f..ee18d3315 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
+@@ -122,6 +122,8 @@ std::string MinidumpMiscInfoDebugBuildString() {
+   static constexpr char kCPU[] = "arm";
+ #elif defined(ARCH_CPU_ARM64)
+   static constexpr char kCPU[] = "arm64";
++#elif defined(ARCH_CPU_PPC64)
++  static constexpr char kCPU[] = "ppc64";
+ #else
+ #error define kCPU for this CPU
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/lss/linux_syscall_support.h qtwebengine/src/3rdparty/chromium/third_party/lss/linux_syscall_support.h
+index e81e7b420..511a54e4e 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/lss/linux_syscall_support.h
++++ qtwebengine/src/3rdparty/chromium/third_party/lss/linux_syscall_support.h
+@@ -3914,7 +3914,7 @@ struct kernel_statfs {
+       LSS_REG(2, buf);
+       LSS_BODY(void*, mmap2, "0"(__r2));
+     }
+-#else
++#elif !defined(__powerpc64__) /* ppc64 doesn't have mmap2 */
+     #define __NR__mmap2 __NR_mmap2
+     LSS_INLINE _syscall6(void*, _mmap2,            void*, s,
+                          size_t,                   l, int,               p,
+@@ -4045,7 +4045,7 @@ struct kernel_statfs {
+   #if defined(__i386__) ||                                                    \
+       defined(__ARM_ARCH_3__) || defined(__ARM_EABI__) ||                     \
+      (defined(__mips__) && _MIPS_SIM == _MIPS_SIM_ABI32) ||                   \
+-      defined(__PPC__) ||                                                     \
++     (defined(__PPC__) && !defined(__powerpc64__)) ||                                                     \
+      (defined(__s390__) && !defined(__s390x__))
+     /* On these architectures, implement mmap() with mmap2(). */
+     LSS_INLINE void* LSS_NAME(mmap)(void *s, size_t l, int p, int f, int d,
+diff --git qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.h qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.h
+index aee253248..25ee401e8 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.h
++++ qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.h
+@@ -16,7 +16,7 @@
+ namespace pdfium {
+ namespace base {
+ 
+-#if defined(OS_WIN)
++#if defined(OS_WIN) || defined(ARCH_CPU_PPC64)
+ static const size_t kPageAllocationGranularityShift = 16;  // 64KB
+ #elif defined(_MIPS_ARCH_LOONGSON)
+ static const size_t kPageAllocationGranularityShift = 14;  // 16KB
+@@ -35,6 +35,10 @@ static const size_t kPageAllocationGranularityBaseMask =
+ // Loongson have 16384 sized system pages.
+ #if defined(_MIPS_ARCH_LOONGSON)
+ static const size_t kSystemPageSize = 16384;
++#elif defined(ARCH_CPU_PPC64)
++// TODO: modern ppc64 can do 4k and 64k page sizes
++// for now, 64k is assumed
++static constexpr size_t kSystemPageSize = 65536;
+ #else
+ static const size_t kSystemPageSize = 4096;
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.h qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.h
+index 7e8415c76..998eb6e14 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.h
++++ qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.h
+@@ -97,6 +97,8 @@ static const size_t kBucketShift = (kAllocationGranularity == 8) ? 3 : 2;
+ // against the end of a system page.
+ #if defined(_MIPS_ARCH_LOONGSON)
+ static const size_t kPartitionPageShift = 16;  // 64KB
++#elif defined(ARCH_CPU_PPC64)
++static const size_t kPartitionPageShift = 18;  // 256KB
+ #else
+ static const size_t kPartitionPageShift = 14;  // 16KB
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/spin_lock.cc qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/spin_lock.cc
+index 8d7151a8b..596c5e1b9 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/spin_lock.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/spin_lock.cc
+@@ -37,6 +37,8 @@
+ // Don't bother doing using .word here since r2 is the lowest supported mips64
+ // that Chromium supports.
+ #define YIELD_PROCESSOR __asm__ __volatile__("pause")
++#elif defined(ARCH_CPU_PPC64_FAMILY)
++#define YIELD_PROCESSOR __asm__ __volatile__("or 31,31,31")
+ #endif
+ #endif
+ 
+diff --git qtwebengine/src/3rdparty/chromium/third_party/sqlite/amalgamation/sqlite3.c qtwebengine/src/3rdparty/chromium/third_party/sqlite/amalgamation/sqlite3.c
+index c5283dd02..672068973 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/sqlite/amalgamation/sqlite3.c
++++ qtwebengine/src/3rdparty/chromium/third_party/sqlite/amalgamation/sqlite3.c
+@@ -12920,7 +12920,8 @@ typedef INT16_TYPE LogEst;
+ # if defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+      defined(__x86_64) || defined(__x86_64__) || defined(_M_X64)  ||    \
+      defined(_M_AMD64) || defined(_M_ARM)     || defined(__x86)   ||    \
+-     defined(__arm__)
++     defined(__arm__) || (defined(__powerpc64__) && \
++     (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+ #   define SQLITE_BYTEORDER    1234
+ # elif defined(sparc)    || defined(__ppc__)
+ #   define SQLITE_BYTEORDER    4321
+diff --git qtwebengine/src/3rdparty/chromium/third_party/sqlite/src/src/sqliteInt.h qtwebengine/src/3rdparty/chromium/third_party/sqlite/src/src/sqliteInt.h
+index d12148d42..39efa80d4 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/sqlite/src/src/sqliteInt.h
++++ qtwebengine/src/3rdparty/chromium/third_party/sqlite/src/src/sqliteInt.h
+@@ -825,7 +825,8 @@ typedef INT16_TYPE LogEst;
+ # if defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+      defined(__x86_64) || defined(__x86_64__) || defined(_M_X64)  ||    \
+      defined(_M_AMD64) || defined(_M_ARM)     || defined(__x86)   ||    \
+-     defined(__arm__)
++     defined(__arm__) || (defined(__powerpc64__) && \
++     (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
+ #   define SQLITE_BYTEORDER    1234
+ # elif defined(sparc)    || defined(__ppc__)
+ #   define SQLITE_BYTEORDER    4321
+diff --git qtwebengine/src/3rdparty/chromium/third_party/webrtc/modules/desktop_capture/differ_block.cc qtwebengine/src/3rdparty/chromium/third_party/webrtc/modules/desktop_capture/differ_block.cc
+index 331524723..f10394043 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/webrtc/modules/desktop_capture/differ_block.cc
++++ qtwebengine/src/3rdparty/chromium/third_party/webrtc/modules/desktop_capture/differ_block.cc
+@@ -30,11 +30,7 @@ bool VectorDifference(const uint8_t* image1, const uint8_t* image2) {
+   static bool (*diff_proc)(const uint8_t*, const uint8_t*) = nullptr;
+ 
+   if (!diff_proc) {
+-#if defined(WEBRTC_ARCH_ARM_FAMILY) || defined(WEBRTC_ARCH_MIPS_FAMILY)
+-    // For ARM and MIPS processors, always use C version.
+-    // TODO(hclam): Implement a NEON version.
+-    diff_proc = &VectorDifference_C;
+-#else
++#if defined(WEBRTC_ARCH_X86_FAMILY)
+     bool have_sse2 = WebRtc_GetCPUInfo(kSSE2) != 0;
+     // For x86 processors, check if SSE2 is supported.
+     if (have_sse2 && kBlockSize == 32) {
+@@ -44,6 +40,10 @@ bool VectorDifference(const uint8_t* image1, const uint8_t* image2) {
+     } else {
+       diff_proc = &VectorDifference_C;
+     }
++#else
++    // For other processors, always use C version.
++    // TODO(hclam): Implement a NEON version.
++    diff_proc = &VectorDifference_C;
+ #endif
+   }
+ 
+diff --git qtwebengine/src/3rdparty/chromium/third_party/webrtc/typedefs.h qtwebengine/src/3rdparty/chromium/third_party/webrtc/typedefs.h
+index 727bf83de..d3a2ba6a4 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/webrtc/typedefs.h
++++ qtwebengine/src/3rdparty/chromium/third_party/webrtc/typedefs.h
+@@ -50,6 +50,18 @@
+ #elif defined(__MIPSEB__)
+ #define WEBRTC_ARCH_MIPS_FAMILY
+ #define WEBRTC_ARCH_BIG_ENDIAN
++#elif defined(__PPC__)
++#define WEBRTC_ARCH_PPC_FAMILY
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
++#define WEBRTC_ARCH_LITTLE_ENDIAN
++#else
++#define WEBRTC_ARCH_BIG_ENDIAN
++#endif
++#if defined(__LP64__)
++#define WEBRTC_ARCH_64_BITS
++#else
++#define WEBRTC_ARCH_32_BITS
++#endif
+ #else
+ #error Please add support for your architecture in typedefs.h
+ #endif
+diff --git qtwebengine/src/3rdparty/chromium/third_party/webrtc/webrtc.gni qtwebengine/src/3rdparty/chromium/third_party/webrtc/webrtc.gni
+index fb1d77cad..22fc76697 100644
+--- qtwebengine/src/3rdparty/chromium/third_party/webrtc/webrtc.gni
++++ qtwebengine/src/3rdparty/chromium/third_party/webrtc/webrtc.gni
+@@ -177,7 +177,7 @@ declare_args() {
+   }
+ 
+   if (!is_ios && (current_cpu != "arm" || arm_version >= 7) &&
+-      current_cpu != "mips64el" && !build_with_mozilla) {
++      current_cpu != "mips64el" && current_cpu != "ppc64" && !build_with_mozilla) {
+     rtc_use_openmax_dl = true
+   } else {
+     rtc_use_openmax_dl = false
+diff --git qtwebengine/src/3rdparty/chromium/v8/BUILD.gn qtwebengine/src/3rdparty/chromium/v8/BUILD.gn
+index 2f4202a1b..cce339b88 100644
+--- qtwebengine/src/3rdparty/chromium/v8/BUILD.gn
++++ qtwebengine/src/3rdparty/chromium/v8/BUILD.gn
+@@ -450,6 +450,12 @@ config("toolchain") {
+     }
+     if (host_byteorder == "little") {
+       defines += [ "V8_TARGET_ARCH_PPC_LE" ]
++        cflags += [
++        # Enable usage of AltiVec, VSX, and other POWER8 and higher features
++        "-mcpu=power8",
++        "-maltivec",
++        "-mvsx",
++      ]
+     } else if (host_byteorder == "big") {
+       defines += [ "V8_TARGET_ARCH_PPC_BE" ]
+       if (current_os == "aix") {
+diff --git qtwebengine/src/3rdparty/chromium/v8/src/builtins/ppc/builtins-ppc.cc qtwebengine/src/3rdparty/chromium/v8/src/builtins/ppc/builtins-ppc.cc
+index 34da70ff0..a87ac196a 100644
+--- qtwebengine/src/3rdparty/chromium/v8/src/builtins/ppc/builtins-ppc.cc
++++ qtwebengine/src/3rdparty/chromium/v8/src/builtins/ppc/builtins-ppc.cc
+@@ -6,6 +6,7 @@
+ 
+ #include "src/assembler-inl.h"
+ #include "src/code-stubs.h"
++#include "src/counters.h"
+ #include "src/debug/debug.h"
+ #include "src/deoptimizer.h"
+ #include "src/frame-constants.h"
+diff --git qtwebengine/src/3rdparty/chromium/v8/src/builtins/s390/builtins-s390.cc qtwebengine/src/3rdparty/chromium/v8/src/builtins/s390/builtins-s390.cc
+index 020b04b91..5ac7e5659 100644
+--- qtwebengine/src/3rdparty/chromium/v8/src/builtins/s390/builtins-s390.cc
++++ qtwebengine/src/3rdparty/chromium/v8/src/builtins/s390/builtins-s390.cc
+@@ -6,6 +6,7 @@
+ 
+ #include "src/assembler-inl.h"
+ #include "src/code-stubs.h"
++#include "src/counters.h"
+ #include "src/debug/debug.h"
+ #include "src/deoptimizer.h"
+ #include "src/frame-constants.h"
+diff --git qtwebengine/src/3rdparty/chromium/v8/src/ppc/macro-assembler-ppc.cc qtwebengine/src/3rdparty/chromium/v8/src/ppc/macro-assembler-ppc.cc
+index 8d7c3d05b..be83229a8 100644
+--- qtwebengine/src/3rdparty/chromium/v8/src/ppc/macro-assembler-ppc.cc
++++ qtwebengine/src/3rdparty/chromium/v8/src/ppc/macro-assembler-ppc.cc
+@@ -12,6 +12,7 @@
+ #include "src/bootstrapper.h"
+ #include "src/callable.h"
+ #include "src/code-stubs.h"
++#include "src/counters.h"
+ #include "src/debug/debug.h"
+ #include "src/external-reference-table.h"
+ #include "src/frames-inl.h"
+diff --git qtwebengine/src/3rdparty/chromium/v8/src/s390/macro-assembler-s390.cc qtwebengine/src/3rdparty/chromium/v8/src/s390/macro-assembler-s390.cc
+index fe2488437..decbbb43a 100644
+--- qtwebengine/src/3rdparty/chromium/v8/src/s390/macro-assembler-s390.cc
++++ qtwebengine/src/3rdparty/chromium/v8/src/s390/macro-assembler-s390.cc
+@@ -12,6 +12,7 @@
+ #include "src/bootstrapper.h"
+ #include "src/callable.h"
+ #include "src/code-stubs.h"
++#include "src/counters.h"
+ #include "src/debug/debug.h"
+ #include "src/external-reference-table.h"
+ #include "src/frames-inl.h"

--- a/srcpkgs/qt5/patches/qtwebengine-enable-ppc64.patch
+++ b/srcpkgs/qt5/patches/qtwebengine-enable-ppc64.patch
@@ -1,0 +1,41 @@
+This adds the necessary bits to make qt attempt building webengine on ppc64.
+Since the patch is only sufficient for ppc64le, keep it commented out and
+let the packaging template remove the comment later, as there is no good
+way to check endianness directly in the file.
+
+We also have to disable jumbo build for the time being because it results
+in build failures otherwise, most likely because of compiler miscompiling
+the code.
+--- qtwebengine/mkspecs/features/functions.prf
++++ qtwebengine/mkspecs/features/functions.prf
+@@ -95,6 +95,7 @@
+     contains(qtArch, "arm64"): return(arm64)
+     contains(qtArch, "mips"): return(mipsel)
+     contains(qtArch, "mips64"): return(mips64el)
++    contains(qtArch, "power64"): return(ppc64)
+     return(unknown)
+ }
+ 
+--- qtwebengine/mkspecs/features/platform.prf
++++ qtwebengine/mkspecs/features/platform.prf
+@@ -82,6 +82,7 @@
+     contains(QT_ARCH, "arm")|contains(QT_ARCH, "arm64"): return(true)
+     contains(QT_ARCH, "mips"): return(true)
+ #     contains(QT_ARCH, "mips64"): return(true)
++#ppc64le    contains(QT_ARCH, "power64"): return(true)
+ 
+     skipBuild("QtWebEngine can only be built for x86, x86-64, ARM, Aarch64, and MIPSel architectures.")
+     return(false)
+--- qtwebengine/src/core/config/linux.pri
++++ qtwebengine/src/core/config/linux.pri
+@@ -90,6 +90,10 @@
+     else: contains(QMAKE_CFLAGS, "-mdsp"): gn_args += mips_dsp_rev=1
+ }
+ 
++contains(QT_ARCH, "power64") {
++    gn_args += use_jumbo_build=false
++}
++
+ host_build {
+     gn_args += custom_toolchain=\"$$QTWEBENGINE_OUT_ROOT/src/toolchain:host\"
+     GN_HOST_CPU = $$gnArch($$QT_ARCH)

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -16,19 +16,46 @@ makedepends="SDL2-devel Vulkan-Headers alsa-lib-devel double-conversion-devel
  unixodbc-devel xcb-util-image-devel xcb-util-keysyms-devel
  xcb-util-renderutil-devel xcb-util-wm-devel"
 depends="qtchooser"
-replaces="qt5-doc<5.6.0 qt5-quick1<5.6.0 qt5-quick1-devel<5.6.0 qt5-webkit<5.6.0 qt5-webkit-devel<5.6.0
- qt5-enginio<5.7.1 qt5-enginio-devel<5.7.1 qt5-plugin-gtk<5.7.1"
-homepage="https://qt.io/"
 short_desc="Cross-platform application and UI framework (QT5)"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://qt.io/"
 distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/single/qt-everywhere-src-${version}.tar.xz"
 checksum=859417642713cee2493ee3646a7fee782c9f1db39e41d7bb1322bba0c5f0ff4d
+replaces="qt5-doc<5.6.0 qt5-quick1<5.6.0 qt5-quick1-devel<5.6.0 qt5-webkit<5.6.0 qt5-webkit-devel<5.6.0
+ qt5-enginio<5.7.1 qt5-enginio-devel<5.7.1 qt5-plugin-gtk<5.7.1"
+
+build_options="webengine"
+desc_option_webengine="Build Chromium-based WebEngine component"
 
 case "$XBPS_TARGET_MACHINE" in
-	armv5tel*) broken="qtwebengine use VSM assembler commands";;
-	mips*) broken="qtwebengine fails to build";;
+	x86_64*|i686*|ppc64le*) build_options_default="webengine";;
+	armv5tel*) ;; # qtwebengine uses VSM assembler commands
+	arm*|aarch64*) build_options_default="webengine";;
+	*) ;; # assume no webengine
 esac
+
+subpackages="qt5-3d qt5-3d-devel qt5-canvas3d qt5-charts qt5-charts-devel
+ qt5-connectivity qt5-connectivity-devel qt5-datavis3d qt5-datavis3d-devel
+ qt5-declarative qt5-declarative-devel qt5-devel qt5-examples qt5-gamepad
+ qt5-gamepad-devel qt5-graphicaleffects qt5-host-tools qt5-imageformats
+ qt5-location qt5-location-devel qt5-multimedia qt5-multimedia-devel
+ qt5-networkauth qt5-networkauth-devel qt5-plugin-mysql qt5-plugin-odbc
+ qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds qt5-purchasing
+ qt5-purchasing-devel qt5-qmake qt5-quickcontrols qt5-quickcontrols2
+ qt5-quickcontrols2-devel qt5-remoteobjects qt5-remoteobjects-devel
+ qt5-script qt5-script-devel qt5-scxml qt5-scxml-devel qt5-sensors
+ qt5-sensors-devel qt5-serialbus qt5-serialbus-devel qt5-serialport
+ qt5-serialport-devel qt5-speech qt5-speech-devel qt5-svg qt5-svg-devel
+ qt5-tools qt5-tools-devel qt5-translations qt5-virtualkeyboard
+ qt5-virtualkeyboard-devel qt5-wayland qt5-wayland-devel qt5-webchannel
+ qt5-webchannel-devel qt5-webglplugin qt5-webglplugin-devel qt5-websockets
+ qt5-websockets-devel qt5-webview qt5-webview-devel qt5-x11extras
+ qt5-x11extras-devel qt5-xmlpatterns qt5-xmlpatterns-devel"
+
+if [ "$build_option_webengine" ]; then
+	subpackages+=" qt5-webengine qt5-webengine-devel"
+fi
 
 if [ "${XBPS_MACHINE%%-musl}" = i686 ]; then
 	nodebug=yes  # prevent OOM
@@ -44,7 +71,9 @@ if [ "$CROSS_BUILD" ]; then
 	# wayland-devel contains /usr/bin/wayland-scanner
 	hostmakedepends+=" icu-devel wayland-devel zlib-devel"
 	# Cross building qtwebengine requires some more host packages
-	hostmakedepends+=" nss-devel libevent-devel"
+	if [ "$build_option_webengine" ]; then
+		hostmakedepends+=" nss-devel libevent-devel"
+	fi
 fi
 
 _cleanup_wrksrc_leak() {
@@ -179,6 +208,9 @@ do_configure() {
 		sed -i qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/spin_lock.cc \
 			qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/spin_lock.cc \
 			-e 's;"yield";"nop";'
+		;;
+	ppc64le*) # enable webengine but not on BE ppc64 for now
+		sed -i qtwebengine/mkspecs/features/platform.prf -e 's;#ppc64le;;'
 		;;
 	esac
 
@@ -330,6 +362,11 @@ do_configure() {
 	opts+=" -webengine-v8-snapshot"
 	opts+=" -silent"
 	# opts+=" -v"
+
+	# make sure to disable webengine on platforms that we don't build it for
+	if [ -z "$build_option_webengine" ]; then
+		opts+=" -skip qtwebengine"
+	fi
 
 	LDFLAGS+=" -Wl,--no-keep-memory"  # needs more than 8GB RAM else
 	if [ -n "$CROSS_BUILD" ]; then


### PR DESCRIPTION
This allows qt5 to be built with webengine on ppc64 little endian. Since webengine is broken on a lot of other archs, this also adds code to disable webengine where otherwise broken, so we can allow building qt5 on every architecture instead of marking it broken (should fix mips and armv5tel).

Patch is a bit on the bigger side, but there is no way to get Google/Chromium to upstream it (though I hear there is some pressure from IBM's side on merging the support in). The source of the patch updates it against latest chromium git regularly, and it doesn't seem to be much of a problem to apply things against qtwebengine's codebase (only took me about an hour to resolve conflicts and test and so on), so I don't have a problem with doing the maintenance of the downstream patch myself.

@pullmoll