### PR TITLE
jwm: fix desktop switching on dvorak layouts

### DIFF
--- a/srcpkgs/jwm/patches/fix_dvorak.patch
+++ b/srcpkgs/jwm/patches/fix_dvorak.patch
@@ -1,0 +1,22 @@
+diff --git src/key.c src/key.c
+index 4b00d26..caefe42 100644
+--- src/key.c
++++ src/key.c
+@@ -18,6 +18,8 @@
+ #include "root.h"
+ #include "tray.h"
+ 
++#include <X11/XKBlib.h>
++
+ #define MASK_NONE    0
+ #define MASK_SHIFT   (1 << ShiftMapIndex)
+ #define MASK_LOCK    (1 << LockMapIndex)
+@@ -396,7 +398,7 @@ void InsertBinding(KeyType key, const char *modifiers,
+ 
+             for(temp[offset] = '1'; temp[offset] <= '9'; temp[offset]++) {
+ 
+-               sym = ParseKeyString(temp);
++               sym = XkbKeycodeToKeysym(display, temp[offset] - '1' + 10, 0, 0);
+                if(sym == NoSymbol) {
+                   Release(temp);
+                   return;

--- a/srcpkgs/jwm/template
+++ b/srcpkgs/jwm/template
@@ -1,7 +1,7 @@
 # Template file for 'jwm'
 pkgname=jwm
 version=2.3.7
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="


### PR DESCRIPTION
Without this patch an important feature of JWM (switching desktops through Mod+[1-9] keys) is broken on certain keyboard layouts. 

My pull request to the upstream: https://github.com/joewing/jwm/pull/481