### PR TITLE
Fix/puppet/missing semantic puppet

### DIFF
--- a/srcpkgs/puppet/template
+++ b/srcpkgs/puppet/template
@@ -1,12 +1,12 @@
 # Template file for 'puppet'
 pkgname=puppet
 version=6.1.0
-revision=1
+revision=2
 noarch=yes
 build_style=ruby-module
 hostmakedepends="ruby facter-devel hiera"
 makedepends="facter-devel"
-depends="ruby>=2.2 facter hiera"
+depends="ruby facter hiera ruby-semantic_puppet"
 short_desc="Server automation framework and application"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="Apache-2.0"

--- a/srcpkgs/ruby-semantic_puppet/template
+++ b/srcpkgs/ruby-semantic_puppet/template
@@ -1,0 +1,11 @@
+# Template file for 'ruby-semantic_puppet'
+pkgname=ruby-semantic_puppet
+version=1.0.2
+revision=1
+noarch=yes
+build_style=gem
+short_desc="Tools for working with Semantic Versions"
+maintainer="eater <=@eater.me>"
+license="Apache-2.0"
+homepage="https://github.com/puppetlabs/semantic_puppet"
+checksum=605be0ec9ca8354ece1da9481b58128327c48e68b1afa3cff96e5fde7221d510


### PR DESCRIPTION
Currently if puppet is installed, it will complain about missing semantic_puppet