### PR TITLE
[WIP] New package: parsec-147

### DIFF
--- a/srcpkgs/parsec/template
+++ b/srcpkgs/parsec/template
@@ -1,0 +1,32 @@
+# Template file for 'parsec'
+pkgname=parsec
+version=147
+revision=1
+only_for_archs="x86_64"
+short_desc="Low latency game streamer"
+maintainer="Young Jin Park <youngjinpark20@gmail.com>"
+license="proprietary"
+homepage="https://parsecgaming.com/"
+distfiles="https://s3.amazonaws.com/parsec-build/package/parsec-linux.deb"
+checksum=beed951ebee0189e8c22aa3d9190e1ddc7691c4703379e146a8b812c21b3a273
+
+_subversion=9
+repository=nonfree
+nopie=yes
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/parsec-linux.deb
+	tar xf data.tar.xz
+}
+
+do_install() {
+	vbin usr/bin/parsecd
+	vinstall usr/share/applications/parsec.desktop 755 usr/share/applications/
+	vinstall usr/share/icons/hicolor/256x256/apps/parsec.png 755 \
+		usr/share/icons/hicolor/256x256/apps/
+	vinstall usr/share/parsec/skel/appdata.json 755 \
+		usr/share/parsec/skel
+	vinstall usr/share/parsec/skel/parsecd-${version}-${_subversion}.so 755 \
+		usr/lib
+	ln -s /usr/lib/parsecd-${version}-${_subversion}.so ${DESTDIR}/usr/share/parsec/skel
+}


### PR DESCRIPTION
First of all, I'm not sure if this is even allowed to be packaged, as it is redistributing a binary. Perhaps it should be made with a `restricted` tag, I'm not sure.
Second, this package install a .so file to /usr/share/ with conflicts with post-install hook 11. I've tried to temporarily work around this by installing it to /usr/lib and using a symlink, but to no avail. Any input would be appreciated. 