### PR TITLE
gcc: enable 32-bit powerpc targets on ppc64

### DIFF
--- a/srcpkgs/gcc/patches/ppc64-pure64.patch
+++ b/srcpkgs/gcc/patches/ppc64-pure64.patch
@@ -1,0 +1,57 @@
+--- gcc/config/rs6000/t-linux
++++ gcc/config/rs6000/t-linux
+@@ -2,7 +2,8 @@
+ # or soft-float.
+ ifeq (,$(filter $(with_cpu),$(SOFT_FLOAT_CPUS))$(findstring soft,$(with_float)))
+ ifneq (,$(findstring powerpc64,$(target)))
+-MULTILIB_OSDIRNAMES := .=../lib64$(call if_multiarch,:powerpc64-linux-gnu)
++MULTILIB_OSDIRNAMES := m64=../lib
++MULTILIB_OSDIRNAMES += m32=../lib32
+ else
+ ifneq (,$(findstring spe,$(target)))
+ MULTIARCH_DIRNAME := powerpc-linux-gnuspe$(if $(findstring 8548,$(with_cpu)),,v1)
+@@ -14,7 +15,8 @@
+ MULTIARCH_DIRNAME := $(subst -linux,le-linux,$(MULTIARCH_DIRNAME))
+ endif
+ ifneq (,$(findstring powerpc64le,$(target)))
+-MULTILIB_OSDIRNAMES := $(subst -linux,le-linux,$(MULTILIB_OSDIRNAMES))
++MULTILIB_OSDIRNAMES := m64=../lib
++MULTILIB_OSDIRNAMES += m32=../lib32
+ endif
+ endif
+ 
+--- gcc/config/rs6000/t-linux64
++++ gcc/config/rs6000/t-linux64
+@@ -28,8 +28,8 @@
+ MULTILIB_OPTIONS    := m64/m32
+ MULTILIB_DIRNAMES   := 64 32
+ MULTILIB_EXTRA_OPTS := 
+-MULTILIB_OSDIRNAMES := m64=../lib64$(call if_multiarch,:powerpc64-linux-gnu)
+-MULTILIB_OSDIRNAMES += m32=$(if $(wildcard $(shell echo $(SYSTEM_HEADER_DIR))/../../usr/lib32),../lib32,../lib)$(call if_multiarch,:powerpc-linux-gnu)
++MULTILIB_OSDIRNAMES := m64=../lib
++MULTILIB_OSDIRNAMES += m32=../lib32
+ 
+ rs6000-linux.o: $(srcdir)/config/rs6000/rs6000-linux.c
+ 	$(COMPILE) $<
+--- gcc/config/rs6000/t-linux64bele
++++ gcc/config/rs6000/t-linux64bele
+@@ -2,6 +2,6 @@
+ 
+ MULTILIB_OPTIONS    += mlittle
+ MULTILIB_DIRNAMES   += le
+-MULTILIB_OSDIRNAMES += $(subst =,.mlittle=,$(subst lible32,lib32le,$(subst lible64,lib64le,$(subst lib,lible,$(subst -linux,le-linux,$(MULTILIB_OSDIRNAMES))))))
+-MULTILIB_OSDIRNAMES += $(subst $(if $(findstring 64,$(target)),m64,m32).,,$(filter $(if $(findstring 64,$(target)),m64,m32).mlittle%,$(MULTILIB_OSDIRNAMES)))
++MULTILIB_OSDIRNAMES = m64=../lib
++MULTILIB_OSDIRNAMES+= m32=../lib32
+ MULTILIB_MATCHES    := ${MULTILIB_MATCHES_ENDIAN}
+--- gcc/config/rs6000/t-linux64lebe
++++ gcc/config/rs6000/t-linux64lebe
+@@ -2,6 +2,6 @@
+ 
+ MULTILIB_OPTIONS    += mbig
+ MULTILIB_DIRNAMES   += be
+-MULTILIB_OSDIRNAMES += $(subst =,.mbig=,$(subst libbe32,lib32be,$(subst libbe64,lib64be,$(subst lib,libbe,$(subst le-linux,-linux,$(MULTILIB_OSDIRNAMES))))))
+-MULTILIB_OSDIRNAMES += $(subst $(if $(findstring 64,$(target)),m64,m32).,,$(filter $(if $(findstring 64,$(target)),m64,m32).mbig%,$(MULTILIB_OSDIRNAMES)))
++MULTILIB_OSDIRNAMES := m64=../lib
++MULTILIB_OSDIRNAMES += m32=../lib32
+ MULTILIB_MATCHES    := ${MULTILIB_MATCHES_ENDIAN}

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -183,15 +183,11 @@ do_configure() {
 		ppc) _args+=" --with-cpu=powerpc --target=powerpc-linux-gnu";;
 		ppc-musl) _args+=" --with-cpu=powerpc --target=powerpc-linux-musl --disable-decimal-float --with-long-double=64";;
 		ppc64le*) # use lib not lib64 by default
-			_args+=" --with-cpu=powerpc64le --with-abi=elfv2"
-			sed -i '/OSDIRNAMES/s/lib64/lib/' gcc/config/rs6000/t-linux
-			sed -i '/m64=/s/lib64/lib/' gcc/config/rs6000/t-linux64
+			_args+=" --target=${_triplet} --with-abi=elfv2 --enable-secureplt --enable-targets=powerpcle-linux"
 			sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
 			;;
 		ppc64*) # use lib not lib64 by default
-			_args+=" --with-cpu=powerpc64 --with-abi=elfv2"
-			sed -i '/OSDIRNAMES/s/lib64/lib/' gcc/config/rs6000/t-linux
-			sed -i '/m64=/s/lib64/lib/' gcc/config/rs6000/t-linux64
+			_args+=" --target=${_triplet} --with-abi=elfv2 --enable-secureplt --enable-targets=powerpc-linux"
 			sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
 			;;
 		x86_64*) # use lib not lib64 by default
@@ -203,7 +199,7 @@ do_configure() {
 	# fix: unknown long double size, cannot define BFP_FMT
 	case "$XBPS_TARGET_MACHINE" in
 		ppc64le-musl|ppc64-musl)
-			_args+=" --enable-decimal-float=no --disable-libquadmath --enable-secureplt"
+			_args+=" --enable-decimal-float=no --disable-libquadmath"
 		;;
 		*) ;;
 	esac


### PR DESCRIPTION
This is not multilib per se, but it will allow gcc to emit 32-bit code, therefore enabling things like native GRUB to be built.

Also, while at it, enable secureplt for all ppc64 targets.