### PR TITLE
cross-powerpc64le-linux-gnu: enable 32-bit powerpc targets

### DIFF
--- a/srcpkgs/cross-powerpc64le-linux-gnu/files/ppc64-pure64.patch
+++ b/srcpkgs/cross-powerpc64le-linux-gnu/files/ppc64-pure64.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/ppc64-pure64.patch

--- a/srcpkgs/cross-powerpc64le-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64le-linux-gnu/template
@@ -4,13 +4,12 @@ _gcc_version=8.2.0
 _glibc_version=2.28
 _linux_version=4.19
 
-_cpu=powerpc64le
-_triplet="${_cpu}-linux-gnu"
+_triplet="powerpc64le-linux-gnu"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.29
-revision=1
+revision=2
 short_desc="GNU cross toolchain for the ${_triplet} targets (binutils/gcc/glibc)"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -83,9 +82,8 @@ _gcc_bootstrap() {
 	cd ${wrksrc}/gcc-${_gcc_version}
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 	_apply_patch -p0 ${FILESDIR}/fix-ppc64-float128-libstdc++.patch
+	_apply_patch -p0 ${FILESDIR}/ppc64-pure64.patch
 
-	sed -i '/OSDIRNAMES/s/lib64/lib/' gcc/config/rs6000/t-linux
-	sed -i '/m64=/s/lib64/lib/' gcc/config/rs6000/t-linux64
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
 
 	msg_normal "Building cross gcc bootstrap\n"
@@ -95,9 +93,10 @@ _gcc_bootstrap() {
 
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
-	_args+=" --with-cpu=${_cpu}"
 	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c"
+	_args+=" --enable-secureplt"
+	_args+=" --enable-targets=powerpcle-linux"
 	_args+=" --disable-libssp"
 	_args+=" --disable-libitm"
 	_args+=" --without-headers"
@@ -239,9 +238,10 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-cpu=${_cpu}"
 	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c,ada,c++,fortran,lto"
+	_args+=" --enable-secureplt"
+	_args+=" --enable-targets=powerpcle-linux"
 	_args+=" --with-gnu-as"
 	_args+=" --with-gnu-ld"
 	_args+=" --enable-libada"


### PR DESCRIPTION
This is to match changes in gcc. Depends on https://github.com/void-linux/void-packages/pull/7711