### PR TITLE
cross-powerpc64le-linux-musl: enable 32-bit powerpc targets

### DIFF
--- a/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-pure64.patch
+++ b/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-pure64.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/ppc64-pure64.patch

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -4,13 +4,12 @@ _gcc_version=8.2.0
 _musl_version=1.1.21
 _linux_version=4.19
 
-_cpu=powerpc64le
-_triplet="${_cpu}-linux-musl"
+_triplet="powerpc64le-linux-musl"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.29
-revision=3
+revision=4
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -85,10 +84,9 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 	_apply_patch -p0 ${FILESDIR}/fix-ppc64-float128-libstdc++.patch
 	_apply_patch -p0 ${FILESDIR}/0010-ldbl128-config.patch
+	_apply_patch -p0 ${FILESDIR}/ppc64-pure64.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
-	sed -i '/OSDIRNAMES/s/lib64/lib/' gcc/config/rs6000/t-linux
-	sed -i '/m64=/s/lib64/lib/' gcc/config/rs6000/t-linux64
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
 
 	msg_normal "Building cross gcc bootstrap\n"
@@ -100,17 +98,18 @@ _gcc_bootstrap() {
 	_args="--prefix=/usr"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-cpu=${_cpu}"
 	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c"
 	_args+=" --enable-decimal-float=no"
 	_args+=" --enable-secureplt"
+	_args+=" --enable-targets=powerpcle-linux"
 	_args+=" --with-newlib"
 	_args+=" --disable-libssp"
 	_args+=" --disable-nls"
 	_args+=" --disable-libquadmath"
 	_args+=" --disable-threads"
 	_args+=" --disable-shared"
+	_args+=" --disable-multilib"
 	_args+=" --disable-libmudflap"
 	_args+=" --disable-libgomp"
 	_args+=" --disable-libatomic"
@@ -174,11 +173,11 @@ _gcc_build() {
 	_args+=" --libexecdir=/usr/lib"
 	_args+=" --target=${_triplet}"
 	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-cpu=${_cpu}"
 	_args+=" --with-abi=elfv2"
 	_args+=" --enable-languages=c,ada,c++,fortran,lto"
 	_args+=" --enable-decimal-float=no"
 	_args+=" --enable-secureplt"
+	_args+=" --enable-targets=powerpcle-linux"
 	_args+=" --enable-libada"
 	_args+=" --enable-lto"
 	_args+=" --enable-default-pie"


### PR DESCRIPTION
This is to match changes in gcc. Depends on https://github.com/void-linux/void-packages/pull/7711