### PR TITLE
libmpeg2: Use XBPS_TARGET_MACHINE instead of XBPS_MACHINE

### DIFF
--- a/srcpkgs/libmpeg2/template
+++ b/srcpkgs/libmpeg2/template
@@ -13,7 +13,7 @@ homepage="http://libmpeg2.sourceforge.net/"
 distfiles="http://libmpeg2.sourceforge.net/files/libmpeg2-${version}.tar.gz"
 checksum=dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
 
-case "$XBPS_MACHINE" in
+case "$XBPS_TARGET_MACHINE" in
 	ppc|ppc-musl) CFLAGS+=" -mno-altivec" ;;
 esac
 


### PR DESCRIPTION
Accidentally used XBPS_MACHINE instead of XBPS_TARGET_MACHINE.
Won't cross-compile properly without it. Oops..