### PR TITLE
Allow building librtas, powerpc-utils and grub on ppc

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -14,7 +14,7 @@ homepage="https://www.gnu.org/software/grub/"
 distfiles="${GNU_SITE}/grub/grub-${version}.tar.xz"
 checksum=810b3798d316394f94096ec2797909dbf23c858e48f7b3830826b8daa06b7b0f
 
-only_for_archs="i686 i686-musl x86_64 x86_64-musl aarch64 aarch64-musl ppc64le ppc64le-musl ppc64-musl"
+only_for_archs="i686 i686-musl x86_64 x86_64-musl aarch64 aarch64-musl ppc ppc-musl ppc64le ppc64le-musl ppc64-musl"
 nopie=yes
 
 subpackages="grub-utils"

--- a/srcpkgs/librtas/template
+++ b/srcpkgs/librtas/template
@@ -2,7 +2,7 @@
 pkgname=librtas
 version=2.0.2
 revision=1
-only_for_archs="ppc64le ppc64le-musl ppc64-musl"
+only_for_archs="ppc ppc-musl ppc64le ppc64le-musl ppc64-musl"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="Librtas library for Linux on Power systems"

--- a/srcpkgs/powerpc-utils/template
+++ b/srcpkgs/powerpc-utils/template
@@ -2,7 +2,7 @@
 pkgname=powerpc-utils
 version=1.3.6
 revision=1
-only_for_archs="ppc64le ppc64le-musl ppc64-musl"
+only_for_archs="ppc ppc-musl ppc64le ppc64le-musl ppc64-musl"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 makedepends="librtas-devel zlib-devel"


### PR DESCRIPTION
Tested grub and (applicable) powerpc-utils. Seemed to work fine.