### PR TITLE
common/build-style/waf,waf3: explicitly pass libdir

### DIFF
--- a/common/build-style/waf.sh
+++ b/common/build-style/waf.sh
@@ -4,7 +4,7 @@
 do_configure() {
 	: ${configure_script:=waf}
 
-	PYTHON=/usr/bin/python2 python2 ${configure_script} configure --prefix=/usr ${configure_args}
+	PYTHON=/usr/bin/python2 python2 ${configure_script} configure --prefix=/usr --libdir=/usr/lib ${configure_args}
 }
 
 do_build() {

--- a/common/build-style/waf3.sh
+++ b/common/build-style/waf3.sh
@@ -4,7 +4,7 @@
 do_configure() {
 	: ${configure_script:=waf}
 
-	PYTHON=/usr/bin/python3 python3 ${configure_script} configure --prefix=/usr ${configure_args}
+	PYTHON=/usr/bin/python3 python3 ${configure_script} configure --prefix=/usr --libdir=/usr/lib ${configure_args}
 }
 
 do_build() {


### PR DESCRIPTION
Waf has a utility function (`lib64` in waflib/Utils.py) which either returns an empty string or `64` depending on if either of the paths `/usr/lib64` or `/usr/local/lib64` exist. Then, the build system itself decides its default `LIBDIR` to be either `/usr/lib` or `/usr/lib64` depending on the result of that function, except when `--libdir` is passed explicitly.

We don't allow `lib64` in our packages. We do have the `/usr/lib64` path as that is a symlink, at least on glibc. Therefore, do not ever allow waf to configure the path that way.