### PR TITLE
vapoursynth-editor: unmark nocross

### DIFF
--- a/srcpkgs/vapoursynth-editor/template
+++ b/srcpkgs/vapoursynth-editor/template
@@ -14,7 +14,6 @@ license="MIT"
 homepage="https://bitbucket.org/mystery_keeper/vapoursynth-editor"
 distfiles="${homepage}/get/r${version}.tar.gz"
 checksum=41e09a6c1411536f7a223a16263145b31de4715189cfe2ebe62b4ad69d6ec342
-nocross="vapoursynth is nocross"
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel qt5-websockets-devel"


### PR DESCRIPTION
I missed that vapoursynth is not nocross, it is only broken on aarch64*.