### PR TITLE
minio: lots of fixes.

### DIFF
--- a/srcpkgs/minio/INSTALL.msg
+++ b/srcpkgs/minio/INSTALL.msg
@@ -1,5 +1,2 @@
-To customize minio's initialization edit:
-	/etc/default/minio
-
 Before starting the service edit /etc/minio/config.json
 and set the "accessKey" and "secretKey".

--- a/srcpkgs/minio/files/minio.confd
+++ b/srcpkgs/minio/files/minio.confd
@@ -1,2 +1,0 @@
-# Local export path.
-MINIO_VOLUMES="/var/lib/minio/data/"

--- a/srcpkgs/minio/files/minio/run
+++ b/srcpkgs/minio/files/minio/run
@@ -1,5 +1,2 @@
 #!/bin/sh
-. /etc/default/minio
-: ${MINIO_VOLUMES:="/var/lib/minio/data/"}
-chown -R  _minio:_minio $MINIO_VOLUMES
-exec chpst -u _minio:_minio minio -C /etc/minio/ server $MINIO_VOLUMES 
+exec chpst -u _minio:_minio minio -C /etc/minio/ server /var/lib/minio/data

--- a/srcpkgs/minio/template
+++ b/srcpkgs/minio/template
@@ -1,15 +1,11 @@
 # Template file for 'minio'
 pkgname=minio
 version=2019.01.23
-revision=1
+revision=2
 _version="${version//./-}T23-18-58Z"
-wrksrc=${pkgname}-RELEASE.${_version}
+wrksrc="${pkgname}-RELEASE.${_version}"
 build_style=go
-go_import_path="github.com/minio/minio"
-_minio_homedir="/var/lib/minio"
-_minio_descr="Minio Daemon User"
-conf_files="/etc/default/minio /etc/minio/config.json"
-make_dirs="/etc/minio 0755 _minio _minio /var/lib/minio 0755 _minio _minio"
+go_import_path=github.com/minio/minio
 hostmakedepends="git"
 short_desc="Object storage server compatible with Amazon S3"
 maintainer="Gerardo Di Iorio <arete74@gmail.com>"
@@ -17,16 +13,19 @@ license="Apache-2.0"
 homepage="https://github.com/minio/minio"
 distfiles="${homepage}/archive/RELEASE.${_version}.tar.gz"
 checksum=dfd2a46f5daf97c39c318e3c455f85b0250a14841c26e6fc49d6962dcd2e4ced
-system_accounts="_minio"
 
-do_check() {
-	:
-}
+system_accounts="_minio"
+_minio_homedir="/var/lib/minio"
+_minio_descr="Minio Daemon User"
+
+conf_files="/etc/minio/config.json"
+make_dirs="
+ /etc/minio 0755 _minio _minio
+ /var/lib/minio 0755 _minio _minio
+ /var/lib/minio/data 0755 _minio _minio"
 
 post_install() {
 	vdoc README.md
-	vlicense LICENSE
-	vinstall ${FILESDIR}/${pkgname}.confd 644 etc/default ${pkgname}
 	vinstall ${FILESDIR}/config.json 644 etc/minio config.json
 	vsv minio
 }


### PR DESCRIPTION
- Don't use /etc/default/minio, just hardcode the values
- adjust variable ordering and make_dirs
- don't chown /var/lib/minio/data
- remove unnecessary vlicense
- create /var/lib/minio/data with make_dirs