### PR TITLE
portaudio: depend on sndio-devel in portaudio-devel

### DIFF
--- a/srcpkgs/portaudio/template
+++ b/srcpkgs/portaudio/template
@@ -1,7 +1,7 @@
 # Template file for 'portaudio'
 pkgname=portaudio
 version=190600.20161030
-revision=2
+revision=3
 wrksrc=portaudio
 build_style=gnu-configure
 configure_args="--enable-cxx --with-jack --enable-sndio"
@@ -32,7 +32,7 @@ post_install() {
 }
 
 portaudio-devel_package() {
-	depends="portaudio>=${version}_${revision}"
+	depends="portaudio>=${version}_${revision} sndio-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove "usr/include/*.h"


### PR DESCRIPTION
This is necessary because portaudio.pc has `-lsndio` in it.