### PR TITLE
New package: calicoctl34-3.4.0

### DIFF
--- a/srcpkgs/calicoctl34/template
+++ b/srcpkgs/calicoctl34/template
@@ -1,0 +1,22 @@
+# Template file for 'calicoctl34'
+pkgname=calicoctl34
+_pkgname=calicoctl
+version=3.4.0
+revision=1
+build_style=go
+go_import_path="github.com/projectcalico/calicoctl"
+go_package="${go_import_path}/calicoctl"
+hostmakedepends="glide"
+short_desc="CLI tool for Project Calico"
+maintainer="Frank Steinborn <steinex@nognu.de>"
+license="Apache-2.0"
+homepage="https://www.projectcalico.org"
+distfiles="https://github.com/projectcalico/calicoctl/archive/v${version}.tar.gz"
+checksum=15d0edbacef5ad7205eaf20b444c134b30f2cfe0153e4f84d0f2dd3b3485023a
+wrksrc=$_pkgname-$version
+conflicts="calico>=0"
+
+pre_build() {
+	cd $GOSRCPATH
+	glide install
+}


### PR DESCRIPTION
As I merged #7786, it might be that this PR has broken older calico releases. This PR re adds this package. @steinex please verify. Sry for premature merging.