### PR TITLE
libetonyek: force mdds to be 1.4

### DIFF
--- a/srcpkgs/libetonyek/template
+++ b/srcpkgs/libetonyek/template
@@ -3,6 +3,7 @@ pkgname=libetonyek
 version=0.1.9
 revision=1
 build_style=gnu-configure
+configure_args="--with-mdds=1.4"
 hostmakedepends="pkg-config"
 makedepends="libxml2-devel boost-devel libcppunit-devel librevenge-devel
  glm mdds liblangtag-devel"


### PR DESCRIPTION
The configure by default checks for 1.2, and fails because we actually depend on 1.4.

@Gottox