### PR TITLE
perl-Crypt-DH: unbreak aarch64

### DIFF
--- a/srcpkgs/perl-Crypt-DH/patches/force_require_bigint_gmp.patch
+++ b/srcpkgs/perl-Crypt-DH/patches/force_require_bigint_gmp.patch
@@ -1,0 +1,18 @@
+--- Makefile.PL
++++ Makefile.PL
+@@ -15,14 +15,8 @@ include 'ExtUtils::AutoInstall';
+ 
+ perl_version '5.006';
+ build_requires 'Test::More' => 0.47;
+-eval { assertlibs lib => 'gmp', header => 'gmp.h'; };
+-unless ($@) {
+-  requires 'Math::BigInt::GMP' => 1.24;
+-}
+-else {
+-  requires 'Math::BigInt::Pari' => 1.13;
+-}
+ 
++requires('Math::BigInt::GMP' => '1.24');
+ requires('Math::BigInt' => '1.60');
+ 
+ githubmeta;

--- a/srcpkgs/perl-Crypt-DH/template
+++ b/srcpkgs/perl-Crypt-DH/template
@@ -1,20 +1,16 @@
-# Template build file for 'perl-Crypt-DH'.
+# Template file for 'perl-Crypt-DH'
 pkgname=perl-Crypt-DH
 version=0.07
-revision=8
+revision=9
+noarch="yes"
 wrksrc="Crypt-DH-${version}"
 build_style=perl-module
 hostmakedepends="perl perl-Math-BigInt-GMP perl-Archive-Zip"
 makedepends="${hostmakedepends}"
 depends="${makedepends}"
-noarch="yes"
 short_desc="Crypt::DH - Diffie-Hellman key exchange system"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Crypt-DH"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Crypt/Crypt-DH-${version}.tar.gz"
 checksum=c88cf3423b01e6782e8986d7fe5304436ab84b0925c4498c6fdfa17ef9a37f5f
-case "$XBPS_TARGET_MACHINE" in
-	aarch*) broken=https://build.voidlinux.eu/builders/aarch64-musl_builder/builds/10370/steps/shell_3/logs/stdio ;;
-esac
-


### PR DESCRIPTION
The makefile checks for presence of libgmp-devel files, and based on that it enables either the GMP version of the respective bigint lib or the other one. We don't have the other one. Make sure the proper one is used.