### PR TITLE
SFML: disable examples

### DIFF
--- a/srcpkgs/SFML/template
+++ b/srcpkgs/SFML/template
@@ -1,8 +1,9 @@
 # Template file for 'SFML'
 pkgname=SFML
 version=2.5.1
-revision=1
+revision=2
 build_style=cmake
+configure_args="-DSFML_BUILD_EXAMPLES=0 -DSFML_BUILD_DOC=1 -DSFML_INSTALL_PKGCONFIG_FILES=1"
 hostmakedepends="doxygen"
 makedepends="libsndfile-devel libXrandr-devel libjpeg-turbo-devel
  libopenal-devel glew-devel freetype-devel MesaLib-devel glu-devel
@@ -13,7 +14,6 @@ license="Zlib"
 homepage="http://www.sfml-dev.org/"
 distfiles="https://github.com/LaurentGomila/${pkgname}/archive/${version}.tar.gz"
 checksum=438c91a917cc8aa19e82c6f59f8714da353c488584a007d401efac8368e1c785
-configure_args="-DSFML_BUILD_EXAMPLES=1 -DSFML_BUILD_DOC=1 -DSFML_INSTALL_PKGCONFIG_FILES=1"
 
 post_install() {
 	rm -f ${DESTDIR}/usr/sfml-*.pc


### PR DESCRIPTION
This would otherwise fail with ELF in /usr/share.