### PR TITLE
kcgi: enable ppc64 targets and a wider range of hosts

### DIFF
--- a/srcpkgs/kcgi/patches/ppc64-sandbox.patch
+++ b/srcpkgs/kcgi/patches/ppc64-sandbox.patch
@@ -1,0 +1,15 @@
+--- configure
++++ configure
+@@ -438,6 +438,12 @@ if [ ${HAVE_SECCOMP_FILTER} -eq 1 ]; then
+ 		arm*)
+ 			echo "#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARM"
+ 			;;
++                ppc64le)
++                        echo "#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64LE"
++                        ;;
++                ppc64)
++                        echo "#define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64"
++                        ;;
+ 	esac
+ fi
+ 

--- a/srcpkgs/kcgi/template
+++ b/srcpkgs/kcgi/template
@@ -19,18 +19,27 @@ case "$XBPS_TARGET_MACHINE" in
 	aarch64*) broken="sandbox-seccomp-filter.c:76:34: error: initializer element is not constant"
 esac
 
+seccomp_audit_get_suffix() {
+	case "$1" in
+		i686*) echo "X86" ;;
+		x86_64*) echo "X86_64" ;;
+		arm*) echo "ARM" ;;
+		aarch64*) echo "AARCH64" ;;
+		ppc64le*) echo "PPC64LE" ;;
+		ppc64*) echo "PPC64" ;;
+		*) echo "UNKNOWN" ;;
+	esac
+}
 
 post_configure() {
-	local suffix
-	case "${XBPS_TARGET_MACHINE}" in
-	i686*) suffix="X86" ;;
-	x86_64*) suffix="X86_64" ;;
-	arm*) suffix="ARM" ;;
-	aarch64*) suffix="AARCH64" ;;
-	esac
-	[ -z "$suffix" ] \
-		&& sed -i "/AUDIT_ARCH_X86_64/d" config.h \
-		|| sed -i "s/AUDIT_ARCH_X86_64/AUDIT_ARCH_${suffix}/" config.h
+	local suffix origsuffix
+	suffix="$(seccomp_audit_get_suffix ${XBPS_TARGET_MACHINE})"
+	origsuffix="$(seccomp_audit_get_suffix ${XBPS_MACHINE})"
+	if [ "$suffix" != "UNKNOWN" ]; then
+		sed -i "s/AUDIT_ARCH_${origsuffix}/AUDIT_ARCH_${suffix}/" config.h
+	else
+		sed -i "/AUDIT_ARCH_${origsuffix}/d" config.h
+	fi
 }
 
 post_install() {


### PR DESCRIPTION
This assumed the build host was x86_64, now it should work on a wider range of hosts. It also patches in seccomp stuff for ppc64.