### PR TITLE
VeraCrypt: update to 1.23, switch distfile source

### DIFF
--- a/srcpkgs/VeraCrypt/template
+++ b/srcpkgs/VeraCrypt/template
@@ -1,8 +1,8 @@
 # Template file for 'VeraCrypt'
 pkgname=VeraCrypt
-version=1.22
-revision=6
-create_wrksrc=1
+version=1.23
+revision=1
+wrksrc=${pkgname}-${pkgname}_${version}
 build_wrksrc=src
 build_style=gnu-makefile
 make_build_args="WX_CONFIG=wx-config-gtk3"
@@ -13,8 +13,8 @@ short_desc="Disk encryption with strong security based on TrueCrypt"
 maintainer="Gustavo Heinz <gustavoheinz95@gmail.com>"
 license="Apache-2.0, TrueCrypt 3.0"
 homepage="https://www.veracrypt.fr"
-distfiles="https://launchpad.net/veracrypt/trunk/${version}/+download/${pkgname}_${version}_Source.tar.bz2"
-checksum=9e4c0cc0edda0031978ec13d81f420af55c14b4a6b06c8d448760fd06df7b870
+distfiles="https://github.com/veracrypt/${pkgname}/archive/${pkgname}_${version}.tar.gz"
+checksum=a97e7a18d98ad08530b6b2deca8ab1b064ac9baf8f0bb51908c09cf5229b142a
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) ;;


### PR DESCRIPTION
The former source has broken permissions in the archive (none of the files/dirs are writable), so use another source.