### PR TITLE
freeimage: disable vsx on ppc64 for the bundled libpng

### DIFF
--- a/srcpkgs/freeimage/template
+++ b/srcpkgs/freeimage/template
@@ -12,7 +12,7 @@ homepage="http://freeimage.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/freeimage/Source%20Distribution/FreeImage${version//./}.zip"
 checksum=f41379682f9ada94ea7b34fe86bf9ee00935a3147be41b6569c9605a53e438fd
 
-CFLAGS="-fPIC -DPIC -fexceptions -fvisibility=hidden"
+CFLAGS="-fPIC -DPIC -fexceptions -fvisibility=hidden -DPNG_POWERPC_VSX_OPT=0"
 CXXFLAGS="${CFLAGS} -Wno-ctor-dtor-privacy"
 subpackages="freeimage-plus freeimage-devel freeimage-plus-devel"
 


### PR DESCRIPTION
The files are missing, as they were not carried over from libpng, so disable it.