### PR TITLE
libguestfs: update to 1.40.1, enable on ppc64le

### DIFF
--- a/srcpkgs/libguestfs/template
+++ b/srcpkgs/libguestfs/template
@@ -1,7 +1,7 @@
 # Template file for 'libguestfs'
 pkgname=libguestfs
-version=1.39.11
-revision=2
+version=1.40.1
+revision=1
 _version_short=${version%.*}
 build_style=gnu-configure
 make_install_args="INSTALLDIRS=vendor"
@@ -21,8 +21,8 @@ short_desc="Access and modify virtual machine disk image"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2"
 homepage="http://libguestfs.org"
-distfiles="http://libguestfs.org/download/${_version_short}-development/${pkgname}-${version}.tar.gz"
-checksum=6bdb72e3879cf7073372e8760fca40de70992e51e33b453fe5074022c17826b9
+distfiles="http://libguestfs.org/download/${_version_short}-stable/${pkgname}-${version}.tar.gz"
+checksum=c8084b4f34a93b71f555ab1d61438f965df1b773349d6b809d30558f90f44dc8
 
 conf_files="etc/libguestfs-tools.conf
  etc/xdg/virt-builder/repos.d/libguestfs.conf
@@ -31,7 +31,7 @@ conf_files="etc/libguestfs-tools.conf
 nocross=yes
 disable_parallel_build=yes
 
-only_for_archs="i686 x86_64"
+only_for_archs="i686 x86_64 ppc64le"
 
 build_options="ruby python go php lua fuse"
 build_options_default="ruby fuse"


### PR DESCRIPTION
The older version no longer exists in the archive.