### PR TITLE
newlisp: define NEWLISP64 on aarch64 and ppc64

### DIFF
--- a/srcpkgs/newlisp/template
+++ b/srcpkgs/newlisp/template
@@ -1,7 +1,7 @@
 # Template file for 'newlisp'
 pkgname=newlisp
 version=10.7.1
-revision=3
+revision=4
 makedepends="readline-devel libffi-devel"
 short_desc="Lisp-like, general-purpose scripting language"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -12,7 +12,7 @@ checksum=2e300c8bed365a564d284bf3ad6c49e036256e7fc3f469ebda0b45e6e196a7cc
 
 do_build() {
 	case "$XBPS_TARGET_MACHINE" in
-		x86_64*) export CFLAGS+=" -DNEWLISP64";;
+		x86_64*|aarch64*|ppc64*) export CFLAGS+=" -DNEWLISP64";;
 	esac
 
 	make -f makefile_linuxLP64_utf8_ffi ${makejobs}


### PR DESCRIPTION
Without this, a lot of incorrect code will be chosen.