### PR TITLE
taskd: fix service and log to stdout

### DIFF
--- a/srcpkgs/taskd/INSTALL
+++ b/srcpkgs/taskd/INSTALL
@@ -2,8 +2,7 @@
 case "$ACTION" in
 post)
 	if [ "$UPDATE" != "yes" ]; then
-		taskd init --data var/lib/taskd
-		taskd config --data var/lib/taskd log var/log/taskd.log
+		taskd init --data var/lib/taskd --log=-
 		chown -R taskd:taskd var/lib/taskd
 	fi
 	;;

--- a/srcpkgs/taskd/files/taskd/run
+++ b/srcpkgs/taskd/files/taskd/run
@@ -3,4 +3,4 @@
 : ${TASKDDATA:=/var/lib/taskd}
 : ${TASKDUSER:=taskd}
 exec 2>&1
-exec chpst -u ${TASKDUSER} taskd --data ${TASKDDATA}
+exec chpst -u ${TASKDUSER} taskd server --data ${TASKDDATA}

--- a/srcpkgs/taskd/template
+++ b/srcpkgs/taskd/template
@@ -1,7 +1,7 @@
 # Template file for 'taskd'
 pkgname=taskd
 version=1.1.0
-revision=3
+revision=4
 build_style=cmake
 makedepends="libuuid-devel gnutls-devel"
 depends="gnutls-tools"


### PR DESCRIPTION
`taskd` user can't access /var/log/taskd.log anyway.

Closes https://github.com/void-linux/void-packages/issues/6074