### PR TITLE
 audacity: use system portaudio

### DIFF
--- a/srcpkgs/audacity/patches/PaUtil_GetTime.patch
+++ b/srcpkgs/audacity/patches/PaUtil_GetTime.patch
@@ -1,0 +1,33 @@
+Source: https://svnweb.freebsd.org/ports/head/audio/audacity/files/patch-src_AudioIO.cpp?view=markup
+Upstream: No
+Reason: For system portaudio
+
+
+diff --git src/AudioIO.cpp src/AudioIO.cpp
+index 03972d700..51913ce9f 100644
+--- src/AudioIO.cpp
++++ src/AudioIO.cpp
+@@ -467,7 +467,6 @@ TimeTrack and AudioIOListener and whether the playback is looped.
+    #define ROUND(x) (int) ((x)+0.5)
+    //#include <string.h>
+    #include "../lib-src/portmidi/pm_common/portmidi.h"
+-   #include "../lib-src/portaudio-v19/src/common/pa_util.h"
+    #include "NoteTrack.h"
+ #endif
+ 
+@@ -787,6 +786,15 @@ private:
+ // return the system time as a double
+ static double streamStartTime = 0; // bias system time to small number
+ 
++// PaUtil_GetTime is an internal PortAudio function.  Unfortunately
++// it's used twice in AudioIO.cpp.  It's a simple function so just
++// provide the implementation here.
++static double PaUtil_GetTime(void) {
++   struct timespec tp;
++   clock_gettime(CLOCK_REALTIME, &tp);
++   return (double)(tp.tv_sec + tp.tv_nsec * 1e-9);
++}
++
+ static double SystemTime(bool usingAlsa)
+ {
+ #ifdef __WXGTK__

--- a/srcpkgs/audacity/template
+++ b/srcpkgs/audacity/template
@@ -1,7 +1,7 @@
 # Template file for 'audacity'
 pkgname=audacity
 version=2.3.0
-revision=1
+revision=2
 wrksrc="${pkgname}-Audacity-${version}"
 build_style=gnu-configure
 configure_args="--with-ffmpeg=system --with-libsndfile=system --with-expat=system
@@ -10,7 +10,7 @@ hostmakedepends="pkg-config cmake libtool m4"
 makedepends="jack-devel wxWidgets-gtk3-devel gtk+3-devel
  libmad-devel soundtouch-devel libsoxr-devel
  vamp-plugin-sdk-devel lame-devel libid3tag-devel libflac-devel
- ffmpeg-devel twolame-devel"
+ ffmpeg-devel twolame-devel portaudio-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Graphical cross-platform audio editor"
 maintainer="Leah Neukirchen <leah@vuxu.org>"

--- a/srcpkgs/portaudio/patches/audacity-compat.patch
+++ b/srcpkgs/portaudio/patches/audacity-compat.patch
@@ -1,0 +1,344 @@
+Source: https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/patches/portaudio-audacity-compat.patch
+Upstream: No
+Reason: Audacity needs Pa_GetStreamHostApiType to use system wide portaudio
+
+
+diff --git configure.in configure.in
+index 13816fb..83c239a 100644
+--- configure.in
++++ configure.in
+@@ -420,6 +420,7 @@ case "${host_os}" in
+                    DLL_LIBS="$DLL_LIBS -lossaudio"
+                    LIBS="$LIBS -lossaudio"
+            fi
++           INCLUDES="$INCLUDES pa_unix_oss.h"
+            AC_DEFINE(PA_USE_OSS,1)
+         fi
+ 
+diff --git include/pa_unix_oss.h include/pa_unix_oss.h
+new file mode 100644
+index 0000000..64e04cb
+--- /dev/null
++++ include/pa_unix_oss.h
+@@ -0,0 +1,104 @@
++#ifndef PA_UNIX_OSS_H
++#define PA_UNIX_OSS_H
++
++/*
++ * $Id: portaudio.patch,v 1.10 2009-06-30 04:52:59 llucius Exp $
++ * PortAudio Portable Real-Time Audio Library
++ * OSS-specific extensions
++ *
++ * Copyright (c) 1999-2000 Ross Bencina and Phil Burk
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * Any person wishing to distribute modifications to the Software is
++ * requested to send the modifications to the original developer so that
++ * they can be incorporated into the canonical version.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
++ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
++ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
++ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ *
++ */
++
++/** @file
++ * OSS-specific PortAudio API extension header file.
++ */
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++const char *PaOSS_GetStreamInputDevice( PaStream *s );
++
++const char *PaOSS_GetStreamOutputDevice( PaStream *s );
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif
++#ifndef PA_UNIX_OSS_H
++#define PA_UNIX_OSS_H
++
++/*
++ * $Id: portaudio.patch,v 1.10 2009-06-30 04:52:59 llucius Exp $
++ * PortAudio Portable Real-Time Audio Library
++ * OSS-specific extensions
++ *
++ * Copyright (c) 1999-2000 Ross Bencina and Phil Burk
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * Any person wishing to distribute modifications to the Software is
++ * requested to send the modifications to the original developer so that
++ * they can be incorporated into the canonical version.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
++ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
++ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
++ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ *
++ */
++
++/** @file
++ * OSS-specific PortAudio API extension header file.
++ */
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++const char *PaOSS_GetStreamInputDevice( PaStream *s );
++
++const char *PaOSS_GetStreamOutputDevice( PaStream *s );
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif
+diff --git include/pa_win_ds.h include/pa_win_ds.h
+index 5d38641..ba1c245 100644
+--- include/pa_win_ds.h
++++ include/pa_win_ds.h
+@@ -86,6 +86,21 @@ typedef struct PaWinDirectSoundStreamInfo{
+ 
+ }PaWinDirectSoundStreamInfo;
+ 
++/** Retrieve the GUID of the input device.
++
++ @param stream The stream to query.
++
++ @return A pointer to the GUID, or NULL if none.
++*/
++LPGUID PaWinDS_GetStreamInputGUID( PaStream* s );
++
++/** Retrieve the GUID of the output device.
++
++ @param stream The stream to query.
++
++ @return A pointer to the GUID, or NULL if none.
++*/
++LPGUID PaWinDS_GetStreamOutputGUID( PaStream* s );
+ 
+ 
+ #ifdef __cplusplus
+diff --git include/portaudio.h include/portaudio.h
+index 8a94aaf..9c8a295 100644
+--- include/portaudio.h
++++ include/portaudio.h
+@@ -1197,6 +1197,15 @@ signed long Pa_GetStreamReadAvailable( PaStream* stream );
+ signed long Pa_GetStreamWriteAvailable( PaStream* stream );
+ 
+ 
++/** Retrieve the host type handling an open stream.
++
++ @return Returns a non-negative value representing the host API type
++ handling an open stream or, a PaErrorCode (which are always negative)
++ if PortAudio is not initialized or an error is encountered.
++*/
++PaHostApiTypeId Pa_GetStreamHostApiType( PaStream* stream );
++
++
+ /* Miscellaneous utilities */
+ 
+ 
+diff --git src/common/pa_front.c src/common/pa_front.c
+index 188cee9..52f44a6 100644
+--- src/common/pa_front.c
++++ src/common/pa_front.c
+@@ -1257,8 +1257,10 @@ PaError Pa_OpenStream( PaStream** stream,
+                                   hostApiInputParametersPtr, hostApiOutputParametersPtr,
+                                   sampleRate, framesPerBuffer, streamFlags, streamCallback, userData );
+ 
+-    if( result == paNoError )
++    if( result == paNoError ) {
+         AddOpenStream( *stream );
++        PA_STREAM_REP(*stream)->hostApiType = hostApi->info.type;
++    }
+ 
+ 
+     PA_LOGAPI(("Pa_OpenStream returned:\n" ));
+@@ -1770,6 +1772,32 @@ signed long Pa_GetStreamWriteAvailable( PaStream* stream )
+     return result;
+ }
+ 
++PaHostApiTypeId Pa_GetStreamHostApiType( PaStream* stream )
++{
++    PaError error = PaUtil_ValidateStreamPointer( stream );
++    PaHostApiTypeId result;
++
++#ifdef PA_LOG_API_CALLS
++    PaUtil_DebugPrint("Pa_GetStreamHostApiType called:\n" );
++    PaUtil_DebugPrint("\tPaStream* stream: 0x%p\n", stream );
++#endif
++
++    if( error == paNoError )
++    {
++        result = PA_STREAM_REP(stream)->hostApiType;
++    }
++    else
++    {
++        result = (PaHostApiTypeId) error;
++    }
++
++#ifdef PA_LOG_API_CALLS
++    PaUtil_DebugPrint("Pa_GetStreamHostApiType returned:\n" );
++    PaUtil_DebugPrint("\tPaError: %d ( %s )\n\n", result, Pa_GetErrorText( result ) );
++#endif
++
++    return result;
++}
+ 
+ PaError Pa_GetSampleSize( PaSampleFormat format )
+ {
+diff --git src/common/pa_stream.c src/common/pa_stream.c
+index 03a0ee6..c4376f9 100644
+--- src/common/pa_stream.c
++++ src/common/pa_stream.c
+@@ -93,6 +93,8 @@ void PaUtil_InitializeStreamRepresentation( PaUtilStreamRepresentation *streamRe
+     streamRepresentation->streamInfo.inputLatency = 0.;
+     streamRepresentation->streamInfo.outputLatency = 0.;
+     streamRepresentation->streamInfo.sampleRate = 0.;
++
++    streamRepresentation->hostApiType = 0;
+ }
+ 
+ 
+diff --git src/common/pa_stream.h src/common/pa_stream.h
+index 678e2ad..70572c7 100644
+--- src/common/pa_stream.h
++++ src/common/pa_stream.h
+@@ -152,6 +152,7 @@ typedef struct PaUtilStreamRepresentation {
+     PaStreamFinishedCallback *streamFinishedCallback;
+     void *userData;
+     PaStreamInfo streamInfo;
++    PaHostApiTypeId hostApiType;
+ } PaUtilStreamRepresentation;
+ 
+ 
+diff --git src/hostapi/alsa/pa_linux_alsa.c src/hostapi/alsa/pa_linux_alsa.c
+index 584cde8..558fb3d 100644
+--- src/hostapi/alsa/pa_linux_alsa.c
++++ src/hostapi/alsa/pa_linux_alsa.c
+@@ -621,6 +621,7 @@ typedef struct
+     StreamDirection streamDir;
+ 
+     snd_pcm_channel_area_t *channelAreas;  /* Needed for channel adaption */
++    int card;
+ } PaAlsaStreamComponent;
+ 
+ /* Implementation specific stream structure */
+@@ -1873,6 +1874,7 @@ static PaError PaAlsaStreamComponent_Initialize( PaAlsaStreamComponent *self, Pa
+ {
+     PaError result = paNoError;
+     PaSampleFormat userSampleFormat = params->sampleFormat, hostSampleFormat = paNoError;
++    snd_pcm_info_t* pcmInfo;
+     assert( params->channelCount > 0 );
+ 
+     /* Make sure things have an initial value */
+@@ -1900,6 +1902,9 @@ static PaError PaAlsaStreamComponent_Initialize( PaAlsaStreamComponent *self, Pa
+     self->device = params->device;
+ 
+     PA_ENSURE( AlsaOpen( &alsaApi->baseHostApiRep, params, streamDir, &self->pcm ) );
++
++    snd_pcm_info_alloca( &pcmInfo );
++    self->card = snd_pcm_info_get_card( pcmInfo );
+     self->nfds = alsa_snd_pcm_poll_descriptors_count( self->pcm );
+ 
+     PA_ENSURE( hostSampleFormat = PaUtil_SelectClosestAvailableFormat( GetAvailableFormats( self->pcm ), userSampleFormat ) );
+@@ -4605,9 +4610,7 @@ PaError PaAlsa_GetStreamInputCard( PaStream* s, int* card )
+     /* XXX: More descriptive error? */
+     PA_UNLESS( stream->capture.pcm, paDeviceUnavailable );
+ 
+-    alsa_snd_pcm_info_alloca( &pcmInfo );
+-    PA_ENSURE( alsa_snd_pcm_info( stream->capture.pcm, pcmInfo ) );
+-    *card = alsa_snd_pcm_info_get_card( pcmInfo );
++    *card = stream->capture.card;
+ 
+ error:
+     return result;
+@@ -4624,9 +4627,7 @@ PaError PaAlsa_GetStreamOutputCard( PaStream* s, int* card )
+     /* XXX: More descriptive error? */
+     PA_UNLESS( stream->playback.pcm, paDeviceUnavailable );
+ 
+-    alsa_snd_pcm_info_alloca( &pcmInfo );
+-    PA_ENSURE( alsa_snd_pcm_info( stream->playback.pcm, pcmInfo ) );
+-    *card = alsa_snd_pcm_info_get_card( pcmInfo );
++    *card = stream->playback.card;
+ 
+ error:
+     return result;
+diff --git src/hostapi/coreaudio/pa_mac_core_blocking.c src/hostapi/coreaudio/pa_mac_core_blocking.c
+index 679c6ba..a69e085 100644
+--- src/hostapi/coreaudio/pa_mac_core_blocking.c
++++ src/hostapi/coreaudio/pa_mac_core_blocking.c
+@@ -66,6 +66,9 @@
+ #ifdef MOSX_USE_NON_ATOMIC_FLAG_BITS
+ # define OSAtomicOr32( a, b ) ( (*(b)) |= (a) )
+ # define OSAtomicAnd32( a, b ) ( (*(b)) &= (a) )
++#elif MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_3
++# define OSAtomicOr32( a, b ) BitOrAtomic( a, (UInt32 *) b )
++# define OSAtomicAnd32( a, b ) BitAndAtomic( a, (UInt32 *) b )
+ #else
+ # include <libkern/OSAtomic.h>
+ #endif
+diff --git src/hostapi/oss/pa_unix_oss.c src/hostapi/oss/pa_unix_oss.c
+index 51e9630..f257d80 100644
+--- src/hostapi/oss/pa_unix_oss.c
++++ src/hostapi/oss/pa_unix_oss.c
+@@ -2043,3 +2043,26 @@ error:
+ #endif
+ }
+ 
++const char *PaOSS_GetStreamInputDevice( PaStream* s )
++{
++    PaOssStream *stream = (PaOssStream*)s;
++
++    if( stream->capture )
++    {
++      return stream->capture->devName;
++    }
++
++   return NULL;
++}
++
++const char *PaOSS_GetStreamOutputDevice( PaStream* s )
++{
++    PaOssStream *stream = (PaOssStream*)s;
++
++    if( stream->playback )
++    {
++      return stream->playback->devName;
++    }
++
++   return NULL;
++}

--- a/srcpkgs/portaudio/patches/sndio.patch
+++ b/srcpkgs/portaudio/patches/sndio.patch
@@ -1,25 +1,29 @@
---- Makefile.in	2018-11-27 14:33:02.442999726 +0100
-+++ Makefile.in	2018-11-27 14:38:09.544966833 +0100
-@@ -44,7 +44,7 @@
+diff --git Makefile.in Makefile.in
+index 5e1a764..2747f73 100644
+--- Makefile.in
++++ Makefile.in
+@@ -44,7 +44,7 @@ PALIB = libportaudio.la
  PAINC = include/portaudio.h
  
  PA_LDFLAGS = $(LDFLAGS) $(SHARED_FLAGS) -rpath $(libdir) -no-undefined \
 -	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS)_.*" \
-+	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaSndio|PaAsio|PaOSS)_.*" \
++	     -export-symbols-regex "(Pa|PaMacCore|PaJack|PaAlsa|PaAsio|PaOSS|PaSndio)_.*" \
  	     -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
  
  COMMON_OBJS = \
-@@ -140,6 +140,7 @@
- SRC_DIRS = \
- 	src/common \
- 	src/hostapi/alsa \
+@@ -146,6 +146,7 @@ SRC_DIRS = \
+ 	src/hostapi/dsound \
+ 	src/hostapi/jack \
+ 	src/hostapi/oss \
 +	src/hostapi/sndio \
- 	src/hostapi/asihpi \
- 	src/hostapi/asio \
- 	src/hostapi/coreaudio \
---- configure.in	2018-11-27 14:33:02.448999725 +0100
-+++ configure.in	2018-11-27 14:43:04.712935218 +0100
-@@ -24,6 +24,10 @@
+ 	src/hostapi/wasapi \
+ 	src/hostapi/wdmks \
+ 	src/hostapi/wmme \
+diff --git configure.in configure.in
+index 13816fb..4c06d10 100644
+--- configure.in
++++ configure.in
+@@ -24,6 +24,10 @@ AC_ARG_WITH(alsa,
              AS_HELP_STRING([--with-alsa], [Enable support for ALSA @<:@autodetect@:>@]),
              [with_alsa=$withval])
  
@@ -30,7 +34,7 @@
  AC_ARG_WITH(jack,
              AS_HELP_STRING([--with-jack], [Enable support for JACK @<:@autodetect@:>@]),
              [with_jack=$withval])
-@@ -120,6 +124,10 @@
+@@ -120,6 +124,10 @@ have_alsa=no
  if test "x$with_alsa" != "xno"; then
      AC_CHECK_LIB(asound, snd_pcm_open, have_alsa=yes, have_alsa=no)
  fi
@@ -41,29 +45,21 @@
  have_asihpi=no
  if test "x$with_asihpi" != "xno"; then
      AC_CHECK_LIB(hpi, HPI_SubSysCreate, have_asihpi=yes, have_asihpi=no, -lm)
-@@ -406,6 +414,13 @@
+@@ -406,6 +414,13 @@ case "${host_os}" in
             AC_DEFINE(PA_USE_ALSA,1)
          fi
  
 +        if [[ "$have_sndio" = "yes" -a "$with_sndio" != "no" ]] ; then
-+           DLL_LIBS="$DLL_LIBS -lsndio"
-+           LIBS="$LIBS -lsndio"
-+           OTHER_OBJS="$OTHER_OBJS src/hostapi/sndio/pa_sndio.o"
-+           AC_DEFINE(PA_USE_SNDIO,1)
++            DLL_LIBS="$DLL_LIBS -lsndio"
++            LIBS="$LIBS -lsndio"
++            OTHER_OBJS="$OTHER_OBJS src/hostapi/sndio/pa_sndio.o"
++            AC_DEFINE(PA_USE_SNDIO,1)
 +        fi
 +
          if [[ "$have_jack" = "yes" ] && [ "$with_jack" != "no" ]] ; then
             DLL_LIBS="$DLL_LIBS $JACK_LIBS"
             CFLAGS="$CFLAGS $JACK_CFLAGS"
-@@ -484,6 +499,7 @@
- 
- case "$target_os" in *linux*)
-     AC_MSG_RESULT([
-+  Sndio ....................... $have_sndio
-   ALSA ........................ $have_alsa
-   ASIHPI ...................... $have_asihpi])
-     ;;
-@@ -509,6 +525,7 @@
+@@ -509,6 +524,7 @@ case "$target_os" in
          ;;
       *)
  	AC_MSG_RESULT([
@@ -71,27 +67,25 @@
    OSS ......................... $have_oss
    JACK ........................ $have_jack
  ])
---- include/portaudio.h	2018-11-27 14:33:02.449999725 +0100
-+++ include/portaudio.h	2018-11-27 16:31:38.419237546 +0100
-@@ -281,13 +281,14 @@
-     paSoundManager=4,
-     paCoreAudio=5,
-     paOSS=7,
--    paALSA=8,
-+    paSndio=8,
-     paAL=9,
-     paBeOS=10,
+diff --git include/portaudio.h include/portaudio.h
+index 8a94aaf..f94d9c4 100644
+--- include/portaudio.h
++++ include/portaudio.h
+@@ -287,7 +287,8 @@ typedef enum PaHostApiTypeId
      paWDMKS=11,
      paJACK=12,
      paWASAPI=13,
 -    paAudioScienceHPI=14
 +    paAudioScienceHPI=14,
-+    paALSA=15
++    paSndio=15
  } PaHostApiTypeId;
  
  
---- src/hostapi/sndio/pa_sndio.c	1970-01-01 01:00:00.000000000 +0100
-+++ src/hostapi/sndio/pa_sndio.c	2018-11-27 14:36:43.241976077 +0100
+diff --git src/hostapi/sndio/pa_sndio.c src/hostapi/sndio/pa_sndio.c
+new file mode 100644
+index 0000000..725ef47
+--- /dev/null
++++ src/hostapi/sndio/pa_sndio.c
 @@ -0,0 +1,765 @@
 +/*
 + * Copyright (c) 2009 Alexandre Ratchov <alex@caoua.org>
@@ -858,8 +852,10 @@
 +	DPR("PaSndio_Initialize: done\n");
 +	return paNoError;
 +}
---- src/os/unix/pa_unix_hostapis.c	2018-11-27 14:33:02.454999725 +0100
-+++ src/os/unix/pa_unix_hostapis.c	2018-11-27 14:56:51.801846630 +0100
+diff --git src/os/unix/pa_unix_hostapis.c src/os/unix/pa_unix_hostapis.c
+index a9b4a05..c3fa2a3 100644
+--- src/os/unix/pa_unix_hostapis.c
++++ src/os/unix/pa_unix_hostapis.c
 @@ -44,6 +44,7 @@
  
  PaError PaJack_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
@@ -868,25 +864,14 @@
  PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
  /* Added for IRIX, Pieter, oct 2, 2003: */
  PaError PaSGI_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
-@@ -59,6 +60,10 @@
-     {
- #ifdef __linux__
+@@ -79,6 +80,10 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
+ 
+ #endif  /* __linux__ */
  
 +#ifdef PA_USE_SNDIO
-+	PaSndio_Initialize,
++	    PaSndio_Initialize,
 +#endif
 +
- #if PA_USE_ALSA
-         PaAlsa_Initialize,
- #endif
-@@ -69,6 +74,10 @@
- 
- #else   /* __linux__ */
- 
-+#ifdef PA_USE_SNDIO
-+	PaSndio_Initialize,
-+#endif
-+
- #if PA_USE_OSS
-         PaOSS_Initialize,
+ #if PA_USE_JACK
+         PaJack_Initialize,
  #endif

--- a/srcpkgs/portaudio/template
+++ b/srcpkgs/portaudio/template
@@ -1,12 +1,12 @@
 # Template file for 'portaudio'
 pkgname=portaudio
 version=190600.20161030
-revision=3
+revision=4
 wrksrc=portaudio
 build_style=gnu-configure
-configure_args="--enable-cxx --with-jack --enable-sndio"
+configure_args="--enable-cxx --with-jack $(vopt_enable sndio)"
 hostmakedepends="automake libtool pkg-config"
-makedepends="alsa-lib-devel jack-devel sndio-devel"
+makedepends="alsa-lib-devel jack-devel $(vopt_if sndio sndio-devel)"
 short_desc="Portable cross-platform audio I/O library"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="MIT"
@@ -14,6 +14,9 @@ homepage="http://www.portaudio.com"
 distfiles="http://www.${pkgname}.com/archives/pa_stable_v${version%.*}_${version#*.}.tgz"
 checksum=f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
 disable_parallel_build=yes
+
+build_options="sndio"
+build_options_default="sndio"
 
 pre_configure() {
 	# depcomp is required when building the bindings/cpp extension
@@ -32,7 +35,7 @@ post_install() {
 }
 
 portaudio-devel_package() {
-	depends="portaudio>=${version}_${revision} sndio-devel"
+	depends="${makedepends} portaudio>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove "usr/include/*.h"
@@ -41,12 +44,14 @@ portaudio-devel_package() {
 		vmove usr/lib/pkgconfig/portaudio-2.0.pc
 	}
 }
+
 portaudio-cpp_package() {
 	short_desc+=" - C++ Bindings"
 	pkg_install() {
 		vmove "usr/lib/libportaudiocpp.so.*"
 	}
 }
+
 portaudio-cpp-devel_package() {
 	depends="portaudio-cpp>=${version}_${revision} portaudio-devel>=${version}_${revision}"
 	short_desc+=" - C++ bindings development files"


### PR DESCRIPTION
Has benefits like sndio support.
Old portaudio patch was working fine, but it added some things twice. Current patch is from OpenBSD ports tree.