### PR TITLE
amdvlk: make x86 only

### DIFF
--- a/srcpkgs/amdvlk/template
+++ b/srcpkgs/amdvlk/template
@@ -9,6 +9,7 @@ _llvm_commit=3c7dbb214c3680803f7d3e3c3aed02fddb2f7dbb
 _wsa_commit=f558403d3292039de4d17334e562bda58abfc72c
 create_wrksrc=yes
 build_wrksrc="xgl"
+only_for_archs="i686 i686-musl x86_64 x86_64-musl"
 build_style=cmake
 configure_args="-DBUILD_WAYLAND_SUPPORT=ON -DBUILD_WSA=ON"
 hostmakedepends="pkg-config python3 perl"
@@ -30,10 +31,6 @@ checksum="5ad6dfbad5ade7cf26c81468b9c890c07e0d14e93edf356a349952f323dafd26
  c3e04b461b7410136f2c58ec7e53692a715335ec57f3aae7a7bdcf45f107edaf
  9f17bbf37b92640589ba017030ca8fd569226325e6346aa1a75cceb0010c2301
  b23e9453fa7b14bb13157fb645936ec74b18b12cdef301758452a92b23f27705"
-
-case $XBPS_TARGET_MACHINE in
-	arm*|aarch64*) broken="https://travis-ci.com/Johnnynator/void-packages/jobs/173227514"
-esac
 
 post_extract() {
 	mv ${wrksrc}/AMDVLK-v-${version} ${wrksrc}/AMDVLK


### PR DESCRIPTION
I tried patching it to make it build on ppc64 and aarch64 at least, and I half succeeded until I reached code that was strictly for x86 and x86_64 (e.g. sections relying on `cpuid.h`) so it's best to assume it's not available anywhere else at least for the time being.

@Johnnynator