### PR TITLE
zsh: fix vcs info infinite recursion

### DIFF
--- a/srcpkgs/zsh/patches/vcs-info-infinite-recursion.patch
+++ b/srcpkgs/zsh/patches/vcs-info-infinite-recursion.patch
@@ -1,0 +1,31 @@
+commit b70919e0d9dadc93893e9d18bc3ef13b88756ecf
+Author: dana <dana@dana.is>
+Date:   Sun Jan 27 00:26:31 2019 -0600
+
+    44020: VCS_INFO_detect_p4: Fix infinite recursion
+
+diff --git ChangeLog ChangeLog
+index 81668ccc9..be243c1b8 100644
+--- ChangeLog
++++ ChangeLog
+@@ -1,3 +1,8 @@
++2018-01-27  dana  <dana@dana.is>
++
++	* 44020: Functions/VCS_Info/Backends/VCS_INFO_detect_p4: Fix
++	infinite recursion
++
+ 2018-01-24  dana  <dana@dana.is>
+ 
+ 	* unposted: Config/version.mk: Post-release version bump
+diff --git Functions/VCS_Info/Backends/VCS_INFO_detect_p4 Functions/VCS_Info/Backends/VCS_INFO_detect_p4
+index d171c68ee..5ec21da9f 100644
+--- Functions/VCS_Info/Backends/VCS_INFO_detect_p4
++++ Functions/VCS_Info/Backends/VCS_INFO_detect_p4
+@@ -44,7 +44,6 @@ VCS_INFO_p4_get_server() {
+ }
+ 
+ 
+-(( ${+functions[VCS_INFO_detect_p4]} )) ||
+ VCS_INFO_detect_p4() {
+   local serverport p4where
+ 

--- a/srcpkgs/zsh/template
+++ b/srcpkgs/zsh/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh'
 pkgname=zsh
 version=5.7
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_target="all info"
 make_install_args="install.info"


### PR DESCRIPTION
Since zsh 5.7 this is printed after every command or just pressing Ctrl+C: 
```
VCS_INFO_detect_p4:79: maximum nested function level reached; increase FUNCNEST?
```