### PR TITLE
atk: don't guard gir introspection behind cross_build check.

### DIFF
--- a/srcpkgs/atk/patches/fix-cross-gir.patch
+++ b/srcpkgs/atk/patches/fix-cross-gir.patch
@@ -1,0 +1,14 @@
+diff --git a/atk/meson.build b/atk/meson.build
+index 616a3e6..941ded8 100644
+--- atk/meson.build
++++ atk/meson.build
+@@ -137,7 +137,7 @@ libatk_dep = declare_dependency(link_with: libatk,
+                                 dependencies: gobject_dep,
+                                 sources: atk_enum_h)
+ 
+-if not meson.is_cross_build() and get_option('introspection')
++if get_option('introspection')
+   gnome.generate_gir(libatk,
+                      sources: atk_sources + atk_headers + [ atk_enum_h ] + [ atk_version_h ],
+                      namespace: 'Atk',
+


### PR DESCRIPTION
upstream issue: https://gitlab.gnome.org/GNOME/atk/merge_requests/12