### PR TITLE
deadbeef-{fb,waveform-seekbar}: add gtk3 build option

### DIFF
--- a/srcpkgs/deadbeef-fb/template
+++ b/srcpkgs/deadbeef-fb/template
@@ -1,13 +1,13 @@
 # Template file for 'deadbeef-fb'
 pkgname=deadbeef-fb
 version=0.92.20170214
-revision=1
+revision=2
 _commit=47bc3fe0fe151dfbb75f90f9e4d5e9a7affd280a
 wrksrc="${pkgname}-${_commit}-${_commit}"
 build_style=gnu-configure
-configure_args="--disable-gtk2 --disable-static"
+configure_args="$(vopt_if gtk3 --disable-gtk2 --disable-gtk3) --disable-static"
 hostmakedepends="autogen automake libtool pkg-config"
-makedepends="deadbeef-devel gtk+3-devel"
+makedepends="deadbeef-devel $(vopt_if gtk3 gtk+3-devel gtk+-devel)"
 depends="deadbeef"
 short_desc="Filebrowser plugin for the DeaDBeeF audio player"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
@@ -15,6 +15,8 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/zykure/deadbeef-fb"
 distfiles="https://gitlab.com/zykure/${pkgname}/repository/${_commit}/archive.tar.bz2>${pkgname}-${version}.tar.bz2"
 checksum=15b36c26a04f6e4438a4582b75ef7e0fd2756d15e71611410d200a9301d9444a
+build_options="gtk3"
+build_options_default="gtk3"
 
 pre_configure() {
 	./autogen.sh

--- a/srcpkgs/deadbeef-waveform-seekbar/template
+++ b/srcpkgs/deadbeef-waveform-seekbar/template
@@ -1,14 +1,14 @@
 # Template file for 'deadbeef-waveform-seekbar'
 pkgname=deadbeef-waveform-seekbar
 version=0.5.20180417
-revision=1
+revision=2
 _commit=52b37e8a95c36d93a348eb78b11bb54dfb039b9d
 wrksrc="ddb_waveform_seekbar-${_commit}"
 build_style=gnu-makefile
 make_use_env=yes
-make_build_args="gtk3"
+make_build_args="$(vopt_if gtk3 gtk3 gtk2)"
 hostmakedepends="pkg-config"
-makedepends="deadbeef-devel gtk+3-devel sqlite-devel"
+makedepends="deadbeef-devel sqlite-devel $(vopt_if gtk3 gtk+3-devel gtk+-devel)"
 depends="deadbeef"
 short_desc="Waveform Seekbar plugin for DeaDBeeF audio player"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
@@ -16,9 +16,11 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/cboxdoerfer/ddb_waveform_seekbar"
 distfiles="https://github.com/cboxdoerfer/ddb_waveform_seekbar/archive/${_commit}.tar.gz"
 checksum=42870d818dc0e89975f4524d3365a44c6b5fb0f119d7e7ec49d07bf92bb29b83
+build_options="gtk3"
+build_options_default="gtk3"
 LDFLAGS+=" -lm"
 
 do_install() {
 	vmkdir usr/lib/deadbeef
-	vinstall gtk3/ddb_misc_waveform_GTK3.so 755 usr/lib/deadbeef
+	vinstall $(vopt_if gtk3 gtk3/ddb_misc_waveform_GTK3.so gtk2/ddb_misc_waveform_GTK2.so) 755 usr/lib/deadbeef
 }


### PR DESCRIPTION
the plugins have to be compiled for the same gtk version as deadbeef which already has the gtk3 option