### PR TITLE
wpa_supplicant: better service

### DIFF
--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/auto
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/auto
@@ -1,0 +1,15 @@
+# find interface from wpa_supplicant-*.conf files
+for f in /etc/wpa_supplicant/wpa_supplicant-*.conf \
+	/etc/wpa_supplicant-*.conf; do
+	case "$f" in *"/wpa_supplicant-*.conf") continue ;; esac
+	iface=${f#*/wpa_supplicant-}
+	if [ -z "$AUTO" ]; then
+		AUTO="${AUTO} -c ${f} -i ${iface%.conf}"
+	else
+		AUTO="${AUTO} -N -c ${f} -i ${iface%.conf}"
+	fi
+done
+
+# match all configuration
+[ -r /etc/wpa_supplicant/wpa_supplicant.conf ] &&
+	AUTO="${AUTO} -M -c /etc/wpa_supplicant/wpa_supplicant.conf"

--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
@@ -1,4 +1,11 @@
 #!/bin/sh
-[ -r ./conf ] && . ./conf
+if [ -r ./conf ]; then
+	. ./conf
+	: ${OPTS:=-M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} -s}
+else
+	. ./auto
+	OPTS="${AUTO} -s"
+fi
+
 exec 2>&1
-exec wpa_supplicant -M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} ${OPTS:--s}
+exec wpa_supplicant ${OPTS}

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -2,7 +2,7 @@
 pkgname=wpa_supplicant
 reverts="2.7_1"
 version=2.6
-revision=15
+revision=16
 build_wrksrc="$pkgname"
 short_desc="WPA/WPA2/IEEE 802.1X Supplicant"
 maintainer="Juan RP <xtraeme@voidlinux.org>"


### PR DESCRIPTION
This adds support for `wpa_supplicant-*.conf` files.

There is not really a point in having `${OPTS}`, `${CONF_FILE}` and `${WPA_INTERFACE}`.

This makes `OPTS` the master configuration option, the other two variables are used if `OPTS` is not set to allow old/simple reconfiguration for just one interface/config file.

With the old behavior if you want to configure multiple devices one would have to set `WPA_INTERFACE` and `CONF_FILE` and then add additional devices to `OPTS` which is imo a bit backwards and not necessary.