### PR TITLE
cargo: add support for ppc64 hosts

### DIFF
--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -36,6 +36,24 @@ else
 		checksum+="
 		 0dcb32f2b17f505b5b74e85ffcc7fa6902d600a4f5767f43303761f7cd27efa9"
 		;;
+	ppc64le)
+		distfiles+="
+		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64le-unknown-linux-gnu.tar.xz"
+		checksum+="
+		 bf426e52beb08e0f663b00b23a89053e713ec15c8e6d69b3f5ae85fe23ad7e18"
+		;;
+	ppc64le-musl)
+		distfiles+="
+		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64le-unknown-linux-musl.tar.xz"
+		checksum+="
+		 d9d91997a781753474e89dbb9b7dbbef2f6cfad9387def076d51d654f6bc21fa"
+		;;
+	ppc64-musl)
+		distfiles+="
+		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64-unknown-linux-musl.tar.xz"
+		checksum+="
+		 ec846d1e9674f60dbd4416d54f74a618288114cea4907b61363adc71b3c8c26f"
+		;;
 	esac
 fi
 
@@ -43,7 +61,7 @@ post_extract() {
 	if [ -z "$CROSS_BUILD" ]; then
 		mkdir -p target/snapshot
 		case "$XBPS_MACHINE" in
-			x86_64-musl) cp ../cargo cargo;;
+			x86_64-musl|ppc64*) cp ../cargo cargo;;
 			*) cp ../cargo-${_cargo_dist_version}-${RUST_TARGET}/cargo/bin/cargo cargo;;
 		esac
 	fi


### PR DESCRIPTION
We need a custom build of cargo on glibc because official binary
crashes with SIGILL since 0.32. We will also need custom ones for
musl anyway.

This uses the same binaries as rust does.

@jnbr @Cogitri 