### PR TITLE
amp: patch termbox-sys for now to fix build

### DIFF
--- a/srcpkgs/amp/patches/termbox-fix.patch
+++ b/srcpkgs/amp/patches/termbox-fix.patch
@@ -1,0 +1,10 @@
+Status: submitted upstream https://github.com/gchp/termbox-sys/pull/20
+--- Cargo.toml
++++ Cargo.toml
+@@ -43,3 +43,6 @@ bench = []
+ name = "draw_buffer"
+ path = "benches/view/draw_buffer.rs"
+ harness = false
++
++[patch.crates-io]
++termbox-sys = { git = 'https://github.com/q66/termbox-sys' }


### PR DESCRIPTION
termbox-sys, which is an indirect dependency of amp, builds its own termbox using waf, but forgets about libdir, which results in the library being installed in a different location and the build won't find it. Fix it here until upstream makes a release.