### PR TITLE
bc: add bc-gh as an alternative bc

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,0 +1,32 @@
+# Template file for 'bc-gh'
+pkgname=bc-gh
+version=1.1.1
+revision=1
+wrksrc="bc-${version}"
+short_desc="Implementation of POSIX bc with GNU extensions"
+maintainer="Gavin D. Howard <yzena.tech@gmail.com>"
+license="BSD-2-Clause"
+homepage="https://github.com/gavinhoward/bc"
+distfiles="${homepage}/releases/download/${version}/bc-${version}.tar.xz"
+checksum=7e8d427c37223aa7da2dd83ef8503236834ed6c0bd0b94fcba041699e4bc125d
+alternatives="
+ bc:bc:/usr/bin/bc-gh
+ dc:dc:/usr/bin/dc-gh"
+
+do_configure() {
+	PREFIX=/usr DESTDIR="${DESTDIR}" EXECSUFFIX=-gh CC="${CC}" CFLAGS="${CFLAGS}" \
+	HOSTCC="${CC_FOR_BUILD}" HOSTCFLAGS="${CFLAGS_FOR_BUILD}" ./configure.sh -GM
+}
+do_build() {
+	make ${makejobs}
+}
+do_check() {
+	make test
+}
+do_install() {
+	# Note that make install is used because of a symlink.
+	make install
+	vman manuals/bc.1
+	vman manuals/dc.1
+	vlicense LICENSE.md
+}

--- a/srcpkgs/bc/template
+++ b/srcpkgs/bc/template
@@ -1,17 +1,20 @@
 # Template file for 'bc'
 pkgname=bc
 version=1.07.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-readline"
 hostmakedepends="ed flex"
 makedepends="readline-devel"
-short_desc="An arbitrary precision numeric processing language"
+short_desc="Arbitrary precision numeric processing language"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/${pkgname}/"
-license="GPL-3"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=62adfca89b0a1c0164c2cdca59ca210c1d44c3ffc46daf9931cf4942664cb02a
+alternatives="
+ bc:bc:/usr/bin/gnu-bc
+ dc:dc:/usr/bin/gnu-dc"
 disable_parallel_build=yes
 
 if [ "$CROSS_BUILD" ]; then
@@ -43,4 +46,8 @@ do_check() {
 	else
 		echo "TESTS PASSED"
 	fi
+}
+post_install() {
+	mv ${DESTDIR}/usr/bin/{,gnu-}bc
+	mv ${DESTDIR}/usr/bin/{,gnu-}dc
 }


### PR DESCRIPTION
This PR adds `bc-gh` as an alternative `bc` and `dc` package and adds an `alternatives=` line to the `bc` package.

This PR also fixes `xlint` on the `bc` package.