### PR TITLE
suil: fix build by patching out a check, remove nocross

### DIFF
--- a/srcpkgs/suil/patches/ftbfs-cocoa.patch
+++ b/srcpkgs/suil/patches/ftbfs-cocoa.patch
@@ -1,0 +1,16 @@
+For whatever reason, Qt5 ships this header on Linux, it does on other
+distros as well, therefore this check is incorrect and breaks build.
+
+--- wscript
++++ wscript
+@@ -91,10 +91,6 @@ def configure(conf):
+         if not conf.options.no_qt5:
+             autowaf.check_pkg(conf, 'Qt5Widgets', uselib_store='QT5',
+                               atleast_version='5.1.0', mandatory=False)
+-            if conf.check_cxx(header_name = 'QMacCocoaViewContainer',
+-                              uselib      = 'QT5',
+-                              mandatory   = False):
+-                autowaf.define(conf, 'SUIL_WITH_COCOA_IN_QT5', 1)
+ 
+     conf.check_cc(define_name   = 'HAVE_LIBDL',
+                   lib           = 'dl',

--- a/srcpkgs/suil/template
+++ b/srcpkgs/suil/template
@@ -11,7 +11,6 @@ license="MIT"
 homepage="http://drobilla.net/software/suil/"
 distfiles="http://download.drobilla.net/${pkgname}-${version}.tar.bz2"
 checksum=9f445910627fb30f4c182b9ee00d1030324910d8a9ce7c9654c34465411da401
-nocross="Objective-C++ compiler not installed on this system"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel"


### PR DESCRIPTION
Qt5 ships this header even on non-Macs => the check breaks build as the respective obj-c stuff tries to include Cocoa. This also removes the requirement of an Obj-C++ compiler, so cross should
work.