### PR TITLE
apache-maven: fix ELF in /usr/share by removing jansi

### DIFF
--- a/srcpkgs/apache-maven/template
+++ b/srcpkgs/apache-maven/template
@@ -2,9 +2,9 @@
 pkgname=apache-maven
 version=3.6.0
 revision=1
+noarch=yes
 hostmakedepends="openjdk"
 depends="virtual?java-environment"
-noarch=yes
 short_desc="Software project management and comprehension tool"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Apache-2.0"
@@ -19,6 +19,11 @@ do_build() {
 }
 
 do_install() {
+	# contains bundled native libraries that might not match the platform
+	# disables ansi color support
+	rm -rf ${DESTDIR}/usr/share/${pkgname}/lib/jansi-native
+	rm -f ${DESTDIR}/usr/share/${pkgname}/lib/jansi-*.jar
+
 	mkdir -p ${DESTDIR}/etc/profile.d
 	vinstall ${FILESDIR}/apache-maven.sh 0755 etc/profile.d/
 	vlicense LICENSE


### PR DESCRIPTION
This fixes the problem at cost of losing ANSI color output. The jansi component depends on a native library, which is bundled in a prebuilt form with the module, for x86 only, which means things likely already don't work on non-x86 in general.

This is the lazy way out. Proper way would be to separately package `jansi`, `jansi-native` and probably also `hawtjni`, and build them all using `apache-maven-bin`. But I dunno. @the-maldridge, ideas? Right now it doesn't build at all, because of lint.