### PR TITLE
add threading option (default=on) to pkcs11-helper package

### DIFF
--- a/srcpkgs/pkcs11-helper/template
+++ b/srcpkgs/pkcs11-helper/template
@@ -1,18 +1,21 @@
 # Template file for 'pkcs11-helper'
 pkgname=pkcs11-helper
 version=1.25.1
-revision=2
+revision=3
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
-configure_args="--enable-doc --disable-static"
+configure_args="--enable-doc --disable-static $(vopt_enable threading slotevent) $(vopt_enable threading)"
 hostmakedepends="automake libtool pkg-config doxygen"
 makedepends="libressl-devel"
-short_desc="A library to help simplify interacting with PKCS#11 providers"
+short_desc="Library to help simplify interacting with PKCS#11 providers"
 maintainer="Aloz1 <kno0001@gmail.com>"
 license="GPL-2.0-only, BSD-3-Clause"
 homepage="https://github.com/OpenSC/${pkgname}/wiki"
 distfiles="https://github.com/OpenSC/${pkgname}/archive/${pkgname}-${version}.tar.gz"
 checksum=fbcec9dd15a71d6ef22b09f63934c66d7d0292fefbaf3a60703ee4a9a73bf6a5
+build_options="threading"
+build_options_default="threading"
+desc_option_threading="Enable threading and slotevent support"
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
openvpn + opensc + pkcs11-helper + yubikey do not work well together if pkcs11-helper is build with threading eanbled (which is the default case for now) this package version introduces a build option to disable threading (and slotevents). we need this for two-factor auth and openvpn at work.