### PR TITLE
build-style/cargo: pass '--verbose' to cargo

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -5,19 +5,19 @@
 do_build() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}
+	${make_cmd} build --verbose --release --target ${RUST_TARGET} ${configure_args}
 }
 
 do_check() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} test --release ${make_check_args}
+	${make_cmd} test --verbose --release ${make_check_args}
 }
 
 do_install() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} install --path . --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
+	${make_cmd} install --verbose --path . --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
 		${make_install_args}
 	rm "${DESTDIR}"/usr/.crates.toml
 }


### PR DESCRIPTION
Otherwise cargo just outputs _very_ not so helpful errors if dependencies
of a crate can't be compiled, e.g.:

'error: Could not compile `xi-core-lib`.'

Not quite sure if this too much for Travis CI though.

@jnbr