### PR TITLE
bc-gh: update to 1.1.2

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,6 +1,6 @@
 # Template file for 'bc-gh'
 pkgname=bc-gh
-version=1.1.1
+version=1.1.2
 revision=1
 wrksrc="bc-${version}"
 short_desc="Implementation of POSIX bc with GNU extensions"
@@ -8,7 +8,7 @@ maintainer="Gavin D. Howard <yzena.tech@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/gavinhoward/bc"
 distfiles="${homepage}/releases/download/${version}/bc-${version}.tar.xz"
-checksum=7e8d427c37223aa7da2dd83ef8503236834ed6c0bd0b94fcba041699e4bc125d
+checksum=6ac9b359d894824eb62b9365260f3ebfc9405bd8d51a7b312547875ec6f5b991
 alternatives="
  bc:bc:/usr/bin/bc-gh
  dc:dc:/usr/bin/dc-gh"


### PR DESCRIPTION
With a release out, bug reports have started coming in. This release fixes a regression in the history implementation where the down arrow did not work.

The problem was a bad cast.