### PR TITLE
qimgv: actually enable webm support

### DIFF
--- a/srcpkgs/qimgv/template
+++ b/srcpkgs/qimgv/template
@@ -3,7 +3,8 @@ pkgname=qimgv
 version=0.7.3
 revision=1
 build_style=cmake
-makedepends="qt5-devel mpv-devel"
+configure_args="$(vopt_if video -DVIDEO_SUPPORT=ON)"
+makedepends="qt5-devel $(vopt_if video mpv-devel)"
 depends="hicolor-icon-theme"
 short_desc="Cross-platform image viewer with webm support"
 maintainer="travankor <travankor@tuta.io>"
@@ -11,6 +12,9 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/easymodo/qimgv"
 distfiles="https://github.com/easymodo/qimgv/archive/v${version}.tar.gz"
 checksum=f5c9e4dfdc0e9842c6cec5d2d546e6f77b2c33312f5cb416eaf50a29a0dc65a1
+build_options="video"
+build_options_default="video"
+desc_option_video="Enable video support"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-qmake"


### PR DESCRIPTION
why aren't we splitting `libmpv`, by the way?