### PR TITLE
New package: ncdc-1.20

### DIFF
--- a/srcpkgs/ncdc/template
+++ b/srcpkgs/ncdc/template
@@ -1,0 +1,22 @@
+# Template file for 'ncdc'
+pkgname=ncdc
+version=1.20
+revision=1
+build_style=gnu-configure
+configure_args="--with-geoip"
+hostmakedepends="pkg-config"
+makedepends="libglib-devel ncurses-devel sqlite-devel gnutls-devel geoip-devel zlib-devel bzip2-devel"
+short_desc="Modern and lightweight direct connect client with a ncurses interface"
+maintainer="whoami <whoami@systemli.org>"
+license="MIT"
+homepage="https://dev.yorhel.nl/ncdc"
+distfiles="https://dev.yorhel.nl/download/$pkgname-$version.tar.gz"
+checksum=8a998857df6289b6bd44287fc06f705b662098189f2a8fe95b1a5fbc703b9631
+
+pre_build() {
+	make CC=$CC_FOR_BUILD CFLAGS=$BUILD_CFLAGS makeheaders
+}
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
eiskaltdcpp-qt not support IPv6 hubs 
https://github.com/eiskaltdcpp/eiskaltdcpp/issues/165
https://github.com/eiskaltdcpp/eiskaltdcpp/issues/308
and they say, IPv6 never be in eiskaltdcpp 
https://github.com/eiskaltdcpp/eiskaltdcpp/issues/308#issuecomment-124264074

I've test it right now, it's not support IPv6 hubs on today.
But, in ADC standard they say "The protocol natively supports IPv6." https://en.wikipedia.org/wiki/Advanced_Direct_Connect
So eiskaltdcpp-qt is broken

I realy want to have `ncdc` ncurses client, cause it's works with ADC and IPv6 hubs. Because in our meshnet community in telegram (http://t.me/meshnet) we are using IPv6-only mesh networks (cjdns, yggdrasil)
It's also the same author as `ncdu`

https://dev.yorhel.nl/ncdc
https://g.blicky.net/ncdc.git/

I not really understand difference hostmakedepends and makedepends with depends in https://github.com/void-linux/void-packages/blob/master/Manual.md 
But seems this template works for me.