### PR TITLE
xbps-src: make `binary-bootstrap` use etc/*.conf files.

### DIFF
--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -17,7 +17,8 @@
 # [OPTIONAL]
 # Enable optional arguments to xbps-install for the host system.
 # Currently used in the binary-bootstrap bootstrap-update targets.
-XBPS_INSTALL_ARGS="--repository=https://alpha.de.repo.voidlinux.org/current --repository=https://alpha.de.repo.voidlinux.org/current/musl --repository=https://alpha.de.repo.voidlinux.org/current/aarch64"
+#
+#XBPS_INSTALL_ARGS=""
 
 # [OPTIONAL]
 # Native Compilation/Preprocessor flags for C and C++. Additional settings

--- a/xbps-src
+++ b/xbps-src
@@ -300,13 +300,24 @@ install_bbootstrap() {
             _subarch="-${XBPS_TARGET_PKG#*-}"
         fi
     fi
+
     mkdir -p $XBPS_MASTERDIR/var/db/xbps/keys
     cd $XBPS_MASTERDIR
     cp -f $XBPS_COMMONDIR/repo-keys/*.plist $XBPS_MASTERDIR/var/db/xbps/keys
-    ${_bootstrap_arch} $XBPS_INSTALL_CMD ${XBPS_INSTALL_ARGS:+-S $XBPS_INSTALL_ARGS} -y base-chroot${_subarch}
-    if [ $? -ne 0 ]; then
-        msg_error "Failed to install bootstrap packages!\n"
-    fi
+
+    (
+        _cfdir=$(mktemp -dt x.XXXXXXXX)
+        _cfdir=$(realpath -e "$_cfdir")
+        cp -f ${XBPS_DISTDIR}/etc/*.conf ${_cfdir}
+        sed -e "s:/host:${XBPS_DISTDIR}/hostdir:g" -i ${_cfdir}/*.conf
+        ${_bootstrap_arch} $XBPS_INSTALL_CMD -C ${_cfdir} -S ${XBPS_INSTALL_ARGS} -y base-chroot${_subarch}
+        _rv=$?
+        rm -rf ${_cfdir}
+        if [ $_rv -ne 0 ]; then
+            msg_error "Failed to install bootstrap packages!\n"
+        fi
+    )
+
     # Reconfigure base-files to create dirs/symlinks.
     if xbps-query -r $XBPS_MASTERDIR base-files &>/dev/null; then
         XBPS_ARCH=$XBPS_TARGET_PKG xbps-reconfigure -r $XBPS_MASTERDIR -f base-files &>/dev/null


### PR DESCRIPTION
This makes it work with the same ordering than while building via chroot.