### PR TITLE
dwm: update to 6.2.

### DIFF
--- a/srcpkgs/dwm/template
+++ b/srcpkgs/dwm/template
@@ -1,14 +1,14 @@
 # Template file for 'dwm'
 pkgname=dwm
-version=6.1
-revision=2
+version=6.2
+revision=1
 makedepends="libXinerama-devel libXft-devel freetype-devel"
-short_desc="A dynamic window manager for X"
+short_desc="Dynamic window manager for X"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="MIT"
 homepage="http://dwm.suckless.org"
 distfiles="https://dl.suckless.org/dwm/dwm-${version}.tar.gz"
-checksum=c2f6c56167f0acdbe3dc37cca9c1a19260c040f2d4800e3529a21ad7cce275fe
+checksum=97902e2e007aaeaa3c6e3bed1f81785b817b7413947f1db1d3b62b8da4cd110e
 
 do_build() {
 	[ -e ${FILESDIR}/config.h ] && cp ${FILESDIR}/config.h config.h


### PR DESCRIPTION
not fully tested.

I'm a user of a manual build dwm, and I'm not comfortable with Mod1 as modifier key.