### PR TITLE
astroid: apply upstream patch to prevent crashes

### DIFF
--- a/srcpkgs/astroid/patches/03e05bbdae9939cf4716ca2ff47dee75f1f3f57e.patch
+++ b/srcpkgs/astroid/patches/03e05bbdae9939cf4716ca2ff47dee75f1f3f57e.patch
@@ -1,0 +1,53 @@
+From 03e05bbdae9939cf4716ca2ff47dee75f1f3f57e Mon Sep 17 00:00:00 2001
+From: Gaute Hope <eg@gaute.vetsj.com>
+Date: Sat, 20 Oct 2018 19:38:01 +0200
+Subject: [PATCH] ae: correctly allocate buffer array (-pedantic)
+
+char[n] is technically not allowed in C++, and seems to cause trouble in
+this case.
+---
+ .../thread_view/webextension/ae_protocol.cc     | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/src/modes/thread_view/webextension/ae_protocol.cc b/src/modes/thread_view/webextension/ae_protocol.cc
+index 735b219b..6687b97b 100644
+--- a/src/modes/thread_view/webextension/ae_protocol.cc
++++ b/src/modes/thread_view/webextension/ae_protocol.cc
+@@ -59,7 +59,12 @@ namespace Astroid {
+     s &= ostream->write_all ((char*) &mt, sizeof (mt), written);
+ 
+     /* send message */
+-    s &= ostream->write_all (o, written);
++    try {
++      s &= ostream->write_all (o, written);
++    } catch (Gio::Error &ex) {
++      LOG (error) << "ae: error: " << ex.what ();
++      throw;
++    }
+     ostream->flush ();
+ 
+     if (!s) {
+@@ -154,8 +159,13 @@ namespace Astroid {
+     }
+ 
+     /* read message */
+-    gchar buffer[msg_sz + 1]; buffer[msg_sz] = '\0';
+-    s = istream->read_all (buffer, msg_sz, read, reader_cancel);
++    gchar * buffer = new gchar[msg_sz];
++    try {
++      s = istream->read_all (buffer, msg_sz, read, reader_cancel);
++    } catch (Gio::Error &ex) {
++      LOG (error) << "ae: error (read): " << ex.code() << ", " <<  ex.what ();
++      throw;
++    }
+ 
+     if (!s || read != msg_sz) {
+       LOG (error) << "reader: error while reading message (size: " << msg_sz << ")";
+@@ -163,6 +173,7 @@ namespace Astroid {
+     }
+ 
+     msg_str = std::string (buffer, msg_sz);
++    delete [] buffer;
+     return mt;
+   }
+ 

--- a/srcpkgs/astroid/template
+++ b/srcpkgs/astroid/template
@@ -1,7 +1,7 @@
 # Template file for 'astroid'
 pkgname=astroid
 version=0.14
-revision=4
+revision=5
 build_style=cmake
 hostmakedepends="pkg-config scdoc"
 makedepends="libnotmuch-devel gtkmm-devel webkit2gtk-devel libsass-devel
@@ -13,3 +13,4 @@ license="GPL-3.0-or-later"
 homepage="http://astroidmail.github.io/"
 distfiles="https://github.com/astroidmail/astroid/archive/v${version}.tar.gz"
 checksum=f2642968919527008d383b4c32d4b038c7b6f785ea084dde1222a65162ebc5ca
+patch_args="-p1"


### PR DESCRIPTION
Upstream patch prevents crashes while opening very long mails.
The last astroid 0.14 release happened a long time ago, so this patch is still not available in void. I'm not sure if it's common to apply upstream patches. Feel free to comment on this.

See https://github.com/astroidmail/astroid/issues/573 and https://github.com/astroidmail/astroid/pull/580/commits/03e05bbdae9939cf4716ca2ff47dee75f1f3f57e for more information.