### PR TITLE
Explicitly disable altivec

### DIFF
--- a/common/build-profiles/ppc-musl.sh
+++ b/common/build-profiles/ppc-musl.sh
@@ -1,4 +1,4 @@
-XBPS_TARGET_CFLAGS="-mcpu=powerpc -mtune=G4 -mlong-double-64"
+XBPS_TARGET_CFLAGS="-mcpu=powerpc -mno-altivec -mtune=G4 -mlong-double-64"
 XBPS_TARGET_CXXFLAGS="$XBPS_TARGET_CFLAGS"
 XBPS_TARGET_FFLAGS=""
 XBPS_TRIPLET="powerpc-linux-musl"

--- a/common/build-profiles/ppc.sh
+++ b/common/build-profiles/ppc.sh
@@ -1,4 +1,4 @@
-XBPS_TARGET_CFLAGS="-mcpu=powerpc -mtune=G4"
+XBPS_TARGET_CFLAGS="-mcpu=powerpc -mno-altivec -mtune=G4"
 XBPS_TARGET_CXXFLAGS="$XBPS_TARGET_CFLAGS"
 XBPS_TARGET_FFLAGS=""
 XBPS_TRIPLET="powerpc-linux-gnu"

--- a/common/cross-profiles/ppc-musl.sh
+++ b/common/cross-profiles/ppc-musl.sh
@@ -2,7 +2,7 @@
 
 XBPS_TARGET_MACHINE="ppc-musl"
 XBPS_CROSS_TRIPLET="powerpc-linux-musl"
-XBPS_CROSS_CFLAGS="-mcpu=powerpc -mtune=G4 -mlong-double-64"
+XBPS_CROSS_CFLAGS="-mcpu=powerpc -mno-altivec -mtune=G4 -mlong-double-64"
 XBPS_CROSS_CXXFLAGS="$XBPS_CROSS_CFLAGS"
 XBPS_CROSS_FFLAGS=""
 XBPS_CROSS_RUSTFLAGS="--sysroot=${XBPS_CROSS_BASE}/usr"

--- a/common/cross-profiles/ppc.sh
+++ b/common/cross-profiles/ppc.sh
@@ -2,7 +2,7 @@
 
 XBPS_TARGET_MACHINE="ppc"
 XBPS_CROSS_TRIPLET="powerpc-linux-gnu"
-XBPS_CROSS_CFLAGS="-mcpu=powerpc -mtune=G4"
+XBPS_CROSS_CFLAGS="-mcpu=powerpc -mno-altivec -mtune=G4"
 XBPS_CROSS_CXXFLAGS="$XBPS_CROSS_CFLAGS"
 XBPS_CROSS_FFLAGS=""
 XBPS_CROSS_RUSTFLAGS="--sysroot=${XBPS_CROSS_BASE}/usr"

--- a/srcpkgs/libmpeg2/template
+++ b/srcpkgs/libmpeg2/template
@@ -13,10 +13,6 @@ homepage="http://libmpeg2.sourceforge.net/"
 distfiles="http://libmpeg2.sourceforge.net/files/libmpeg2-${version}.tar.gz"
 checksum=dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4
 
-case "$XBPS_TARGET_MACHINE" in
-	ppc|ppc-musl) CFLAGS+=" -mno-altivec" ;;
-esac
-
 libmpeg2-devel_package() {
 	depends="libmpeg2>=${version}_${revision}"
 	short_desc+=" - development files"


### PR DESCRIPTION
Explicitly disable altivec on ppc. Causes problems for few packages that assume altivec is present for all PowerPC processors. 