### PR TITLE
minikube: clean up template

### DIFF
--- a/srcpkgs/minikube/INSTALL.msg
+++ b/srcpkgs/minikube/INSTALL.msg
@@ -2,8 +2,3 @@ You might also need install one of the following for Minikube to work:
 
   * virtualbox-ose (for VirtualBox driver)
   * docker-machine-driver-kvm2 (for KVM2 driver)
-
-For bash completions, install the 'bash-completion' package.
-For zsh completions, put the following code in your ~/.zshrc:
-
-  source /usr/share/minikube/completion.zsh

--- a/srcpkgs/minikube/template
+++ b/srcpkgs/minikube/template
@@ -1,13 +1,15 @@
 # Template file for 'minikube'
 pkgname=minikube
 version=0.33.1
-revision=1
+revision=2
+build_wrksrc="src/k8s.io/minikube"
 only_for_archs="x86_64 x86_64-musl ppc64le ppc64le-musl"
 build_style=go
 go_import_path="k8s.io/minikube"
 hostmakedepends="git go-bindata python pkg-config"
 makedepends="libvirt-devel"
-short_desc="Minikube is a tool that makes it easy to run Kubernetes locally"
+depends="kubectl"
+short_desc="Tool to make it easy to run Kubernetes locally"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="Apache-2.0"
 homepage="https://github.com/kubernetes/minikube"
@@ -15,10 +17,15 @@ homepage="https://github.com/kubernetes/minikube"
 do_fetch() {
 	# We must clone it instead of downloading the tarball because the build
 	# process expects the directory to be a git repository
-	git clone -b v${version} https://github.com/kubernetes/minikube $wrksrc
+	rm -rf $wrksrc
+	mkdir -p $wrksrc/src/k8s.io
+	git clone -b v${version} https://github.com/kubernetes/minikube \
+		$wrksrc/src/k8s.io/minikube
 }
 
 do_build() {
+	export GOPATH="$wrksrc"
+
 	make
 	make out/docker-machine-driver-kvm2
 
@@ -30,7 +37,7 @@ do_install() {
 	vbin out/minikube
 	vbin out/docker-machine-driver-kvm2
 	vinstall completion.bash 644 usr/share/bash-completion/completions minikube
-	vinstall completion.zsh 644 usr/share/$pkgname
+	vinstall completion.zsh 644 usr/share/zsh/site-functions/_minikube
 	vlicense LICENSE
 }
 


### PR DESCRIPTION
- Disable GOPATH warning during compile
- Tweak description
- Depend on kubectl
- Install zsh completion at right place and remove INSTALL.msg crud

Please review, @dan-santana 