### PR TITLE
megatools: backport download speed limit and re-download fixes

### DIFF
--- a/srcpkgs/megatools/patches/0001-fix-download-speed-limit.patch
+++ b/srcpkgs/megatools/patches/0001-fix-download-speed-limit.patch
@@ -1,0 +1,46 @@
+diff --git lib/mega.c lib/mega.c
+index 432a02d..e8f733b 100644
+--- lib/mega.c
++++ lib/mega.c
+@@ -4224,7 +4224,6 @@ gboolean mega_session_download_data(struct mega_session *s, struct mega_download
+ 	gc_object_unref GFileIOStream *iostream = NULL;
+ 	gc_object_unref GFileOutputStream *ostream = NULL;
+ 	GSeekable* seekable = NULL;
+-	gc_http_free struct http *h = NULL;
+ 	struct get_data_state state = { .s = s };
+ 	gc_free gchar *tmp_path = NULL, *file_path = NULL, *tmp_name = NULL;
+ 	guint64 download_from = 0;
+@@ -4373,12 +4372,6 @@ gboolean mega_session_download_data(struct mega_session *s, struct mega_download
+ 
+ 	send_status(s, &status_data);
+ 
+-	// perform download
+-	h = http_new();
+-	http_set_progress_callback(h, progress_dl, &state);
+-	http_set_speed(h, s->max_ul, s->max_dl);
+-	http_set_proxy(h, s->proxy);
+-
+ 	// We'll download the file sequentially in 256MB increments (chunks),
+ 	// re-trying if a chunk fails. We will pre-encrypt and pre-calculate mac
+ 	// for the chunk so that we don't need to do it again when download
+@@ -4403,12 +4396,20 @@ gboolean mega_session_download_data(struct mega_session *s, struct mega_download
+ 		state.mac_saved = state.mac;
+ 		guint tries = 0;
+ 		gboolean download_ok;
++		struct http *h;
+ 		gc_free gchar *url = g_strdup_printf("%s/%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT,
+ 						     params->download_url,
+ 						     from, to - 1);
+ 
+ retry:
++		// perform download
++		h = http_new();
++		http_set_progress_callback(h, progress_dl, &state);
++		http_set_speed(h, s->max_ul, s->max_dl);
++		http_set_proxy(h, s->proxy);
+ 		download_ok = http_post_stream_download(h, url, get_data_cb, &state, &local_err);
++		http_free(h);
++
+ 		if (!download_ok) {
+ 			// try 3 times at most (we only retry if we can seek the stream)
+ 			tries++;

--- a/srcpkgs/megatools/patches/0002-check-file-exists.patch
+++ b/srcpkgs/megatools/patches/0002-check-file-exists.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/mega.c b/lib/mega.c
+index 432a02d..e15b10f 100644
+--- lib/mega.c
++++ lib/mega.c
+@@ -5365,6 +5365,12 @@ gboolean mega_session_dl_compat(struct mega_session *s, const gchar *handle, con
+ 	if (local_path) {
+ 		if (!file)
+ 			file = g_file_get_child(parent_dir, params.node_name);
++		if (g_file_query_exists(file, NULL)) {
++			g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER,
++					"Local file already exists: %s/%s", local_path, params.node_name);
++			mega_download_data_free(&params);
++			return FALSE;
++		}
+ 	}
+ 
+ 	gboolean status = mega_session_download_data(s, &params, file, err);

--- a/srcpkgs/megatools/template
+++ b/srcpkgs/megatools/template
@@ -1,7 +1,7 @@
 # Template file for 'megatools'
 pkgname=megatools
 version=1.10.2
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config asciidoc"
 makedepends="glib-networking gobject-introspection libressl-devel libcurl-devel fuse-devel libsodium-devel glib-devel"


### PR DESCRIPTION
this backports two fixes that will be in megatools 1.11. it doesn't look like 1.11 is gonna be released anytime soon so I decided to backport for the time being.

* Don't download data when file already exists when using megadl megous/megatools@70c624e8ad57ff71e85425bc33d028f3ed9d5c53
* Fix download speed limit not being applied by curl if handle is re-used megous/megatools@1ea525ea3b488104e822ab48fc86ba75a0567c9e

these patches should be removed when 1.11 is released