### PR TITLE
orca: use python3-gobject-devel

### DIFF
--- a/srcpkgs/orca/template
+++ b/srcpkgs/orca/template
@@ -6,7 +6,7 @@ noarch=yes
 build_style=gnu-configure
 pycompile_module="orca"
 hostmakedepends="intltool itstool pkg-config"
-makedepends="at-spi2-atk-devel liblouis-devel python-gobject-devel"
+makedepends="at-spi2-atk-devel liblouis-devel python3-gobject-devel"
 depends="desktop-file-utils gst-plugins-good1 hicolor-icon-theme liblouis
  python3-atspi python3-brlapi python3-dbus python3-xdg speech-dispatcher"
 short_desc="Screen reader for individuals who are blind or visually impaired"


### PR DESCRIPTION
This is needed because all the other dependencies orca checks for are python3 and the minimum python version for orca is 3.3. Without this the build fails when checking for the gi module