### PR TITLE
flatbuffers: make sure all files are installed

### DIFF
--- a/srcpkgs/flatbuffers/patches/install.patch
+++ b/srcpkgs/flatbuffers/patches/install.patch
@@ -1,0 +1,20 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -320,7 +320,7 @@ if(FLATBUFFERS_INSTALL)
+     install(
+       TARGETS flatc EXPORT FlatcTargets
+       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+-      CONFIGURATIONS Release
++      CONFIGURATIONS Release RelWithDebInfo
+     )
+ 
+     install(
+@@ -328,7 +328,7 @@ if(FLATBUFFERS_INSTALL)
+       FILE FlatcTargets.cmake
+       NAMESPACE flatbuffers::
+       DESTINATION ${FB_CMAKE_DIR}
+-      CONFIGURATIONS Release
++      CONFIGURATIONS Release RelWithDebInfo
+     )
+   endif()
+ 


### PR DESCRIPTION
The project seems to be restricting installation of certain components to the Release target, while we switched to the RelWithDebInfo target a while ago. Patch the build system so that things are still installed and packaging doesn't fail.