### PR TITLE
go: bump revision

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,7 +1,7 @@
 # Template file for 'go'
 pkgname=go
 version=1.11.5
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc=go
 hostmakedepends="go1.4-bootstrap"


### PR DESCRIPTION
Go was originally updated to 1.11.5 already, as a part of the a2f0a976d11d63c2b867ccc813e847fe83028d57 commit, which the 2b4f08ec8081654e5279763b249c01a909f9a011 commit did not assume, resulting in a partial merge of #8064 that changes short desc but does not bump.

@maxice8 