### PR TITLE
template-glib: enable gir, remove gir and vala build_option

### DIFF
--- a/srcpkgs/template-glib/patches/fix-gir-cross.patch
+++ b/srcpkgs/template-glib/patches/fix-gir-cross.patch
@@ -1,0 +1,17 @@
+diff --git a/src/meson.build b/src/meson.build
+index 08d325b..5adef72 100644
+--- src/meson.build
++++ src/meson.build
+@@ -174,7 +174,10 @@ if get_option('with_introspection')
+                 install: true,
+         install_dir_gir: girdir,
+     install_dir_typelib: typelibdir,
+-             extra_args: [ '--c-include=tmpl-glib.h' ],
++             extra_args: [
++               '--c-include=tmpl-glib.h',
++               '-DTMPL_GLIB_COMPILATION',
++             ],
+   )
+ 
+   if get_option('with_vapi')
+

--- a/srcpkgs/template-glib/template
+++ b/srcpkgs/template-glib/template
@@ -2,10 +2,11 @@
 pkgname=template-glib
 version=3.30.0
 revision=2
-configure_args="-Denable_gtk_doc=false -Dwith_vapi=$(vopt_if gir true false)
- -Dwith_introspection=$(vopt_if gir true false)"
 build_style=meson
-hostmakedepends="pkg-config $(vopt_if gir 'gobject-introspection vala') glib-devel flex"
+build_helper="gir"
+configure_args="-Denable_gtk_doc=false -Dwith_introspection=true
+ -Dwith_vapi=true"
+hostmakedepends="pkg-config vala glib-devel flex"
 makedepends="libglib-devel"
 short_desc="Supports calling into GObject Introspection from templates"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
@@ -13,12 +14,11 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/template-glib"
 distfiles="${GNOME_SITE}/template-glib/${version%.*}/template-glib-${version}.tar.xz"
 checksum=cf690d391bfc71036e31867df6da90315a3db83f739a8657f580b941b96e3649
-nocross="hard-requires gobject-introspection"
 
-build_options="gir"
-if [ -z "$CROSS_BUILD" ]; then
-	build_options_default+=" gir"
-fi
+case "$XBPS_TARGET_MACHINE" in
+	x86_64-musl) ;;
+	*-musl) broken="hard-requires gobject-introspection" ;;
+esac
 
 template-glib-devel_package() {
 	depends="${sourcepkg}-${version}_${revision} gtk+3-devel"
@@ -27,10 +27,8 @@ template-glib-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-		if [ "$build_option_gir" ]; then
-			vmove usr/share/gir-1.0
-			vmove usr/share/vala
-		fi
+		vmove usr/share/gir-1.0
+		vmove usr/share/vala
 	}
 }
 


### PR DESCRIPTION
Gobject introspection is hard required, so there is no reason
to avoid it with gir and vala