### PR TITLE
swayidle: add logind support & remove the git build dependency.

### DIFF
--- a/srcpkgs/swayidle/template
+++ b/srcpkgs/swayidle/template
@@ -1,16 +1,15 @@
 # Template file for 'swayidle'
 pkgname=swayidle
 version=1.2
-revision=1
+revision=2
 build_style=meson
-configure_args="-Dlogind=disabled"
-hostmakedepends="pkg-config wayland-devel scdoc git"
-makedepends="wayland-devel wayland-protocols"
+hostmakedepends="pkg-config wayland-devel scdoc"
+makedepends="wayland-devel wayland-protocols elogind-devel"
 short_desc="Idle management daemon for Wayland"
 maintainer="Derriick <derriick.ensiie@yahoo.com>"
 license="MIT"
-homepage="http://swaywm.org"
-distfiles="https://github.com/swaywm/swayidle/archive/${version}.tar.gz"
+homepage="https://swaywm.org"
+distfiles="https://github.com/swaywm/${pkgname}/archive/${version}.tar.gz"
 checksum=d65533d6f1fd9b105fa3e2c26d593e12fbfb5b24f48af446707d605cd817c758
 
 post_install() {


### PR DESCRIPTION
- logind support added with elogind-devel in makedepends
- git removed from hostmakedepends and as proposed in #8272 