### PR TITLE
common: unset rust-cross specific variables for native builds

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -16,6 +16,8 @@ if [ "$CROSS_BUILD" ]; then
 	# [build]
 	# target = ${RUST_TARGET}
 	export CARGO_BUILD_TARGET="$RUST_TARGET"
+else
+	unset CARGO_BUILD_TARGET
 fi
 
 # For cross-compiling rust -sys crates

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -313,6 +313,7 @@ setup_pkg() {
         export XBPS_TARGET_MACHINE=${XBPS_ARCH:-$XBPS_MACHINE}
         unset XBPS_CROSS_BASE XBPS_CROSS_LDFLAGS XBPS_CROSS_FFLAGS
         unset XBPS_CROSS_CFLAGS XBPS_CROSS_CXXFLAGS XBPS_CROSS_CPPFLAGS
+        unset XBPS_CROSS_RUSTFLAGS XBPS_CROSS_RUST_TARGET
 
         XBPS_INSTALL_XCMD="$XBPS_INSTALL_CMD"
         XBPS_QUERY_XCMD="$XBPS_QUERY_CMD"
@@ -546,6 +547,7 @@ setup_pkg() {
         unset CC_host CXX_host CPP_host GCC_host FC_host LD_host AR_host AS_host
         unset RANLIB_host STRIP_host OBJDUMP_host OBJCOPY_host NM_host READELF_host
         unset CFLAGS_host CXXFLAGS_host CPPFLAGS_host LDFLAGS_host
+        unset RUSTFLAGS
     fi
 
     # Setup some specific package vars.


### PR DESCRIPTION
this is needed when a native build is encapsulated in a cross build (e.g. cargo cross build needs cargo for the host)