### PR TITLE
font-kakwafont: rebuild for missing archs

### DIFF
--- a/srcpkgs/font-kakwafont/template
+++ b/srcpkgs/font-kakwafont/template
@@ -1,7 +1,8 @@
 # Template file for 'font-kakwafont'
 pkgname=font-kakwafont
 version=0.1.1
-revision=1
+revision=2
+noarch=yes
 wrksrc="kakwafont-${version}"
 build_style=gnu-makefile
 make_install_args="INDEX=true"


### PR DESCRIPTION
It is not build for some arches, especially x86_64, strange.