### PR TITLE
perl: ppc support

### DIFF
--- a/srcpkgs/perl/template
+++ b/srcpkgs/perl/template
@@ -170,7 +170,7 @@ do_configure() {
 	# perl-cross autodetection fails. Need perl -V:lseeksize = 8.
 	# (default on musl.)
 	case "$XBPS_TARGET_MACHINE" in
-	i686|armv5tel|armv6l|armv7l|aarch64|ppc64le)
+	i686|armv5tel|armv6l|armv7l|aarch64|ppc64le|ppc)
 		HOSTLDFLAGS+=" -pthread"
 		export HOSTLDFLAGS
 		CFLAGS+=" -D_FILE_OFFSET_BITS=64 -DLARGE_FILE_SUPPORT64 ";;


### PR DESCRIPTION
Enables 32-bit PPC platform support for perl.