### PR TITLE
libGL: remove gallium-xa

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -40,13 +40,13 @@ i686*|x86_64*)
 	subpackages+=" mesa-vmwgfx-dri mesa-opencl"
 	;;
 ppc*)
-	# No OpenCL and a bunch of other things but otherwise complete
+	# Enable all ppc drivers.
 	configure_args+=" -Dgallium-drivers=r300,r600,radeonsi,swrast,nouveau,virgl"
 	configure_args+=" -Ddri-drivers=r100,r200,nouveau"
-	configure_args+=" -Dgallium-xa=true -Ddri3=true"
 	configure_args+=" -Dvulkan-drivers=amd"
+	configure_args+=" -Ddri3=true"
 	hostmakedepends+=" clang"
-	subpackages+=" libxatracker mesa-ati-dri mesa-nouveau-dri"
+	subpackages+=" mesa-ati-dri mesa-nouveau-dri"
 	;;
 aarch64*)
 	configure_args+=" -Dgallium-drivers=nouveau,tegra,swrast,vc4"


### PR DESCRIPTION
The XA state tracker is only used for x86 VMWare guest drivers, which does not apply to PowerPC systems.