### PR TITLE
dhewm3: fix build on ppc/ppc64

### DIFF
--- a/srcpkgs/dhewm3/patches/ppc64.patch
+++ b/srcpkgs/dhewm3/patches/ppc64.patch
@@ -1,0 +1,26 @@
+Fixes build as the altivec bits include a MacOS-specific header.
+
+Original author: <frediz@linux.vnet.ibm.com>
+
+--- neo/idlib/math/Simd_AltiVec.cpp	2017-07-12 12:34:33.000000000 +0000
++++ neo/idlib/math/Simd_AltiVec.cpp	2017-07-12 12:43:51.863029647 +0000
+@@ -45,7 +45,7 @@
+ //
+ //===============================================================
+ 
+-#if defined(__GNUC__) && defined(__ALTIVEC__)
++#if defined(MACOS_X) && defined(__GNUC__) && defined(__ALTIVEC__)
+ 
+ #ifdef PPC_INTRINSICS
+ 	// for square root estimate instruction
+--- neo/idlib/math/Simd_AltiVec.h	2017-07-12 12:34:33.000000000 +0000
++++ neo/idlib/math/Simd_AltiVec.h	2017-07-12 12:38:38.083750262 +0000
+@@ -110,7 +110,7 @@
+ //#define DRAWVERT_PADDED
+ 
+ class idSIMD_AltiVec : public idSIMD_Generic {
+-#if defined(__GNUC__) && defined(__ALTIVEC__)
++#if defined(MACOS_X) && defined(__GNUC__) && defined(__ALTIVEC__)
+ public:
+ 
+ 	virtual const char * VPCALL GetName( void ) const;


### PR DESCRIPTION
This disables some altivec bits specific to MacOS on Linux.