### PR TITLE
mozjs60: update to 60.5.0.

### DIFF
--- a/srcpkgs/mozjs60/template
+++ b/srcpkgs/mozjs60/template
@@ -1,7 +1,7 @@
 # Template file for 'mozjs60'
 pkgname=mozjs60
-version=60.4.0
-revision=4
+version=60.5.0
+revision=1
 wrksrc="firefox-${version}"
 build_wrksrc=js/src
 build_style=gnu-configure
@@ -12,7 +12,7 @@ maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/js/"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
-checksum=205258548c3f245d42377b338f0db1272df39489d61305c39b83e52750ebff85
+checksum=1a1f69ee87092637f75aef7f3fa588b0eef0b2c8bcc160094a036450c49c4025
 patch_args="-Np1"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 


### PR DESCRIPTION
Seems like this doesn't need a gjs rebuild, but please
do test @Gottox