### PR TITLE
scons: fix checksum.

### DIFF
--- a/srcpkgs/scons/template
+++ b/srcpkgs/scons/template
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://www.scons.org/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz
  https://raw.githubusercontent.com/SCons/scons/master/LICENSE>LICENSE.txt"
-checksum="d6a47d6b02d1442b19ebd94d8556af643813c6df477ff84f5bd1ab73ec62fbcb
+checksum="e2b8b36e25492720a05c0f0a92a219b42d11ce0c51e3397a1e8296dfea1d9b1a
  159d5c59118f24519f12d39a129ee0dba4a601f8a41b8de324d399005aba6eb6"
 
 


### PR DESCRIPTION
There was a re-release on 2019-01-23 that appears to have updated the documentation (changes file has a note about pypi) and some docbook files, along with all Python files' revision dates.