### PR TITLE
libGL: remove incorrect dependency

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -142,7 +142,7 @@ MesaLib-devel_package() {
 	 libOSMesa>=${version}_${revision} libgbm>=${version}_${revision}
 	 libGLES>=${version}_${revision}"
 	case "$XBPS_TARGET_MACHINE" in
-		i686*|x86_64*|ppc64*)  depends+=" libxatracker>=${version}_${revision}";;
+		i686*|x86_64*)  depends+=" libxatracker>=${version}_${revision}";;
 	esac
 	short_desc+=" - development files"
 	pkg_install() {


### PR DESCRIPTION
This subpackage does not exist.