### PR TITLE
dkms: compile kernel scripts on target for cross-compiled architectures

### DIFF
--- a/srcpkgs/dkms/files/kernel.d/dkms.postinst
+++ b/srcpkgs/dkms/files/kernel.d/dkms.postinst
@@ -17,6 +17,10 @@ if [ ! -e /lib/modules/${VERSION}/build/include ] ; then
 	exit 0
 fi
 
+if [ ! -f /lib/modules/${VERSION}/build/scripts/basic/fixdep ] ; then
+	make -C /lib/modules/${VERSION}/build scripts
+fi
+
 # Check available DKMS modules
 for _mod_ in /var/lib/dkms/*; do
 	[ ! -d ${_mod_} ] && continue

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,15 +1,19 @@
 # Template file for 'dkms'
 pkgname=dkms
 version=2.6.1
-revision=1
+revision=2
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils linux-headers"
-homepage="https://github.com/dell/dkms"
-distfiles="${homepage}/archive/v${version}.tar.gz"
 short_desc="Dynamic Kernel Modules System"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later"
+homepage="https://github.com/dell/dkms"
+distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=9a34f42a80e01682efcb13c513692e72f1d21570bbc7a9eba855dde30f116ce7
+
+if [ "$CROSS_BUILD" ]; then
+	depends+=" libressl-devel gmp-devel libada-devel libmpc-devel"
+fi
 
 do_install() {
 	# We are only interested in the bare minimum.


### PR DESCRIPTION
WIth https://github.com/void-linux/void-packages/pull/8251 should fix #4641