### PR TITLE
bind: only use seccomp for x86 targets

### DIFF
--- a/srcpkgs/bind/template
+++ b/srcpkgs/bind/template
@@ -31,9 +31,9 @@ make_dirs="/var/named 0770 root named"
 build_options="geoip seccomp"
 build_options_default="geoip"
 
-if [ -z "$CROSS_BUILD" ]; then
-	build_options_default+=" seccomp"
-fi
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*|i686*) build_options_default+=" seccomp";;
+esac
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
The old conditional was incorrect, as seccomp support is not dependent on cross, but rather bind only has the code for x86.