### PR TITLE
expose build-profile in cross environment

### DIFF
--- a/common/build-profiles/README
+++ b/common/build-profiles/README
@@ -9,3 +9,7 @@ for a specific architecture:
 	- XBPS_CXXFLAGS		(C++ compiler flags for the host compiler)
 	- XBPS_FFLAGS		(Fortran compiler flags for the host compiler)
 	- XBPS_RUST_TARGET	(the compiler triplet for usage by cargo)
+
+These properties are also set in a cross environment, but the compiler
+flags are not added into the global flags. XBPS_RUST_TARGET is also
+exposed as RUST_BUILD instead of RUST_TARGET.

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -430,21 +430,21 @@ setup_pkg() {
         dbgflags="-g"
     fi
 
-    if [ -z "$cross" ]; then
-        if [ -z "$CHROOT_READY" ]; then
-            source_file ${XBPS_COMMONDIR}/build-profiles/bootstrap.sh
-        else
-            source_file ${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh
-        fi
+    # build profile is used always in order to expose the host triplet,
+    # but the compiler flags from it are only used when not crossing
+    if [ -z "$CHROOT_READY" ]; then
+        source_file ${XBPS_COMMONDIR}/build-profiles/bootstrap.sh
+    else
+        source_file ${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh
     fi
 
     set_build_options
 
-    export CFLAGS="$XBPS_TARGET_CFLAGS $XBPS_CFLAGS $XBPS_CROSS_CFLAGS $CFLAGS $dbgflags"
-    export CXXFLAGS="$XBPS_TARGET_CXXFLAGS $XBPS_CXXFLAGS $XBPS_CROSS_CXXFLAGS $CXXFLAGS $dbgflags"
-    export FFLAGS="$XBPS_TARGET_FFLAGS $XBPS_FFLAGS $XBPS_CROSS_FFLAGS $FFLAGS"
-    export CPPFLAGS="$XBPS_TARGET_CPPFLAGS $XBPS_CPPFLAGS $XBPS_CROSS_CPPFLAGS $CPPFLAGS"
-    export LDFLAGS="$XBPS_TARGET_LDFLAGS $XBPS_LDFLAGS $XBPS_CROSS_LDFLAGS $LDFLAGS"
+    export CFLAGS="$XBPS_CFLAGS $XBPS_CROSS_CFLAGS $CFLAGS $dbgflags"
+    export CXXFLAGS="$XBPS_CXXFLAGS $XBPS_CROSS_CXXFLAGS $CXXFLAGS $dbgflags"
+    export FFLAGS="$XBPS_FFLAGS $XBPS_CROSS_FFLAGS $FFLAGS"
+    export CPPFLAGS="$XBPS_CPPFLAGS $XBPS_CROSS_CPPFLAGS $CPPFLAGS"
+    export LDFLAGS="$XBPS_LDFLAGS $XBPS_CROSS_LDFLAGS $LDFLAGS"
 
     export BUILD_CC="cc"
     export BUILD_CFLAGS="$XBPS_CFLAGS"
@@ -524,7 +524,16 @@ setup_pkg() {
         export RUSTFLAGS="$XBPS_CROSS_RUSTFLAGS"
         # Rust target, which differs from our triplets
         export RUST_TARGET="$XBPS_CROSS_RUST_TARGET"
+        # Rust build, which is the host system, may also differ
+        export RUST_BUILD="$XBPS_RUST_TARGET"
     else
+        # Target flags from build-profile
+        export CFLAGS="$XBPS_TARGET_CFLAGS $CFLAGS"
+        export CXXFLAGS="$XBPS_TARGET_CXXFLAGS $CXXFLAGS"
+        export FFLAGS="$XBPS_TARGET_FFLAGS $FFLAGS"
+        export CPPFLAGS="$XBPS_TARGET_CPPFLAGS $CPPFLAGS"
+        export LDFLAGS="$XBPS_TARGET_LDFLAGS $LDFLAGS"
+        # Tools
         export CC="cc"
         export CXX="g++"
         export CPP="cpp"
@@ -540,6 +549,7 @@ setup_pkg() {
         export NM="nm"
         export READELF="readelf"
         export RUST_TARGET="$XBPS_RUST_TARGET"
+        export RUST_BUILD="$XBPS_RUST_TARGET"
         # Unset cross evironment variables
         unset CC_target CXX_target CPP_target GCC_target FC_target LD_target AR_target AS_target
         unset RANLIB_target STRIP_target OBJDUMP_target OBJCOPY_target NM_target READELF_target

--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -87,13 +87,8 @@ do_build() {
 			ac_cv_sqlite_enable_unlock_notify=yes \
 			ac_cv_prog_hostcxx_works=1
 
-		case "$XBPS_TARGET_MACHINE" in
-			*-musl) _host_triplet=${XBPS_MACHINE%-musl}-unknown-linux-musl;;
-			*) _host_triplet=${XBPS_MACHINE}-unknwon-linux-gnu;;
-		esac
-
 		echo "ac_add_options --target=$XBPS_CROSS_TRIPLET" >>.mozconfig
-		echo "ac_add_options --host=$_host_triplet" >>.mozconfig
+		echo "ac_add_options --host=$XBPS_TRIPLET" >>.mozconfig
 	else
 		echo "ac_add_options --target=$XBPS_TRIPLET" >>.mozconfig
 		echo "ac_add_options --host=$XBPS_TRIPLET" >>.mozconfig

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -87,13 +87,8 @@ do_build() {
 			ac_cv_sqlite_enable_unlock_notify=yes \
 			ac_cv_prog_hostcxx_works=1
 
-		case "$XBPS_TARGET_MACHINE" in
-			*-musl) _host_triplet=${XBPS_MACHINE%-musl}-unknown-linux-musl;;
-			*) _host_triplet=${XBPS_MACHINE}-unknwon-linux-gnu;;
-		esac
-
 		echo "ac_add_options --target=$XBPS_CROSS_TRIPLET" >>.mozconfig
-		echo "ac_add_options --host=$_host_triplet" >>.mozconfig
+		echo "ac_add_options --host=$XBPS_TRIPLET" >>.mozconfig
 	else
 		echo "ac_add_options --target=$XBPS_TRIPLET" >>.mozconfig
 		echo "ac_add_options --host=$XBPS_TRIPLET" >>.mozconfig

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -43,7 +43,7 @@ do_build() {
 	cp ${FILESDIR}/mozconfig .mozconfig
 
 	if [ "$CROSS_BUILD" ]; then
-		echo "ac_add_options --host=${XBPS_CROSS_TRIPLET}" >>.mozconfig
+		echo "ac_add_options --host=${XBPS_TRIPLET}" >>.mozconfig
 		echo "ac_add_options --target=${XBPS_CROSS_TRIPLET}" >>.mozconfig
 	else
 		echo "ac_add_options --host=${XBPS_TRIPLET}" >>.mozconfig

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -98,17 +98,6 @@ else
 	esac
 fi
 
-# In rust terminology 'build' is the build host ($CBUILD) and `target`
-# and `host` are the triplets that are supposed to run the built binaries
-# ($CTARGET)
-case $XBPS_MACHINE in
-	ppc64le) _build_triplet=powerpc64le-unknown-linux-gnu;;
-	ppc64le-musl) _build_triplet=powerpc64le-unknown-linux-musl;;
-	ppc64-musl) _build_triplet=powerpc64-unknown-linux-musl;;
-	*-musl) _build_triplet=${XBPS_MACHINE%-musl}-unknown-linux-musl;;
-	*) _build_triplet=${XBPS_MACHINE}-unknown-linux-gnu;;
-esac
-
 post_extract() {
 	if [ "$build_option_internal_llvm" ]; then
 		# patches for Rust's bundled LLVM
@@ -152,7 +141,7 @@ do_configure() {
 		--prefix=/usr
 		--host=${RUST_TARGET}
 		--target=${RUST_TARGET}
-		--build=${_build_triplet}
+		--build=${RUST_BUILD}
 		--disable-full-bootstrap
 		--release-channel=stable
 		--disable-rpath
@@ -163,7 +152,7 @@ do_configure() {
 	if ! [ "$build_option_internal_llvm" ]; then
 		configure_args+="
 			--llvm-root=/usr
-			--set=target.${_build_triplet}.llvm-config=/usr/bin/llvm-config
+			--set=target.${RUST_BUILD}.llvm-config=/usr/bin/llvm-config
 			--set=target.${RUST_TARGET}.llvm-config=/usr/bin/llvm-config
 			--enable-llvm-link-shared
 		"
@@ -177,10 +166,10 @@ do_configure() {
 
 		# Set the appropriate values for the native compilation tools
 		configure_args+="
-			--set=target.${_build_triplet}.cc=${CC_host}
-			--set=target.${_build_triplet}.cxx=${CXX_host}
-			--set=target.${_build_triplet}.ar=${AR_host}
-			--set=target.${_build_triplet}.linker=${CC_host}
+			--set=target.${RUST_BUILD}.cc=${CC_host}
+			--set=target.${RUST_BUILD}.cxx=${CXX_host}
+			--set=target.${RUST_BUILD}.ar=${AR_host}
+			--set=target.${RUST_BUILD}.linker=${CC_host}
 		"
 	else
 		configure_args+=" --local-rust-root=$wrksrc/stage0"
@@ -209,7 +198,7 @@ pre_build() {
 # of the cross host.
 # Unset LDFLAGS, otherwise cross builds to the same arch will fail
 do_build() {
-	env CFLAGS_${_build_triplet}="${CFLAGS_host}" LDFLAGS=''  make ${makejobs} ${make_build_args}
+	env CFLAGS_${RUST_BUILD}="${CFLAGS_host}" LDFLAGS=''  make ${makejobs} ${make_build_args}
 }
 
 do_install() {


### PR DESCRIPTION
This is useful particularly in language toolchains to accurately know the triplet of the host, without having to make pessimizing assumptions.

As far as I can see it seems fine but testing would be appreciated (e.g. if @jnbr could cross-compile Firefox)