### PR TITLE
Adapta: remove gnome-shell from hostmakedepends.

### DIFF
--- a/srcpkgs/Adapta/template
+++ b/srcpkgs/Adapta/template
@@ -1,16 +1,16 @@
 # Template file for 'Adapta'
 pkgname=Adapta
 version=3.95.0.11
-revision=1
+revision=2
 noarch=yes
-build_style=gnu-configure
 wrksrc="adapta-gtk-theme-$version"
-hostmakedepends="automake glib-devel gnome-shell inkscape parallel pkg-config
+build_style=gnu-configure
+hostmakedepends="automake glib-devel inkscape parallel pkg-config
  procps-ng sassc"
 makedepends="glib-devel librsvg-devel"
-short_desc="An adaptive Gtk+ theme based on Material Design Guidelines"
+short_desc="Adaptive Gtk+ theme based on Material Design Guidelines"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2"
+license="GPL-2.0-or-later, CC-BY-SA-4.0"
 homepage=https://github.com/adapta-project/adapta-gtk-theme
 distfiles="https://github.com/adapta-project/adapta-gtk-theme/archive/$version.tar.gz"
 checksum=fb8fc11b770be59e1673b8f2d917704fc34e53aee5fb02fed70d83909d3309bd


### PR DESCRIPTION
This isn't used -- builds of Adapta produced with and without it
produce the same package, other than files.plist mtimes.

Additional template changes are to satisfy xlint.