### PR TITLE
rpi-kernel: update to 4.14.97.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
 
-_githash="83b36f98e1a48d143f0b466fcf9f8c4e382c9a1c"
+_githash="28c5c6ab2a4a8ae0a4dffae2237da2e56cd943c9"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.95
+version=4.14.97
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=fd1a2698737b4a02245e63cf005d64d960a1ce645e1aaf67fc8152d127821bf3
+checksum=9fa498c743dcd0db572ec2f2dd33354cd1bb1eef312747245908007ced8c6fed
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]