### PR TITLE
xbps-src: add clean-repocache command

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -44,6 +44,9 @@ clean [pkgname]
     If <pkgname> argument is specified, package files from <masterdir>/destdir and its
     build directory in <masterdir>/buiddir are removed.
 
+clean-repocache
+    Removes obsolete packages from <hostdir>/repocache.
+
 configure <pkgname>
     Configure a package (fetch + extract + configure).
 
@@ -708,6 +711,10 @@ case "$XBPS_TARGET" in
             fi
             remove_pkg $XBPS_CROSS_BUILD
         fi
+        ;;
+    clean-repocache)
+        export XBPS_TARGET_ARCH="${XBPS_CROSS_BUILD:-$XBPS_TARGET_MACHINE}"
+        $XBPS_REMOVE_CMD -C /dev/null -c $XBPS_HOSTDIR/repocache -O
         ;;
     consistency-check)
         consistency_check


### PR DESCRIPTION
This just runs `xbps-remove -O` on the `<hostdir>/repoache` with the architecture of the masterdir or the cross architecture if `-a` is specified.

Maybe in the future something like `./xbps-src clean-repocache all` to iterate over all architectures could be added.