### PR TITLE
alacritty: remove soft dependency xclip

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,11 +1,11 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.2.9
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="freetype-devel fontconfig-devel"
-depends="libXxf86vm xclip ncurses alacritty-terminfo-${version}_${revision}"
+depends="libXxf86vm ncurses alacritty-terminfo-${version}_${revision}"
 short_desc="Cross-platform, GPU-accelerated terminal emulator"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"


### PR DESCRIPTION
Since 0.2.8, if `xclip` is missing when copying/pasting text, `alacritty` displays an explicit warning about this.