### PR TITLE
cookie: fix build

### DIFF
--- a/srcpkgs/cookie/template
+++ b/srcpkgs/cookie/template
@@ -4,6 +4,7 @@ version=0.2.0
 revision=1
 noarch=yes
 build_style=gnu-makefile
+hostmakedepends="bashlibs"
 depends="bash bashlibs"
 short_desc="Template-based File Generator"
 maintainer="Nathan Owens <ndowens04@gmail.com>"
@@ -11,11 +12,6 @@ license="MIT"
 homepage="https://github.com/bbugyi200/cookie"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=4af67b9376b60e9e40ef34b5be3e4be768ed550cc6e16baf5df0a04fd7e541e3
-
-post_extract() {
-	sed -i 's:sudo::
-		/git/d' Makefile
-}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This doesn't really work and dunno how it ever did, as erasing the git commands prevents a submodule pull which in turn removes pulling in bashlibs, and everything fails as without presence of system bashlibs it tries to install them, and fails to do so as it hasn't previously pulled in the submodule.