### PR TITLE
iniparser: fix ELF in /usr/share (remove example binary)

### DIFF
--- a/srcpkgs/iniparser/template
+++ b/srcpkgs/iniparser/template
@@ -1,10 +1,10 @@
 # Template file for 'iniparser'
 pkgname=iniparser
 version=4.1
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="doxygen chrpath"
-short_desc="A free stand-alone ini file parsing library"
+short_desc="Free stand-alone ini file parsing library"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="MIT"
 homepage="http://ndevilla.free.fr/iniparser/"
@@ -14,11 +14,6 @@ checksum=960daa800dd31d70ba1bacf3ea2d22e8ddfc2906534bf328319495966443f3ae
 CFLAGS="-fPIC"
 
 post_build() {
-	sed -i example/Makefile \
-		-e"s;^\(CFLAGS.*=.*\);& $CFLAGS;" \
-		-e"s;^\(LFLAGS.*=.*\);& $LDFLAGS;" \
-		-e's;$(CC) $(CFLAGS);& $(LDFLAGS);'
-	make CC=$CC example
 	make docs
 }
 
@@ -70,6 +65,7 @@ iniparser-doc_package() {
 }
 iniparser-example_package() {
 	short_desc+=" - example code"
+	noarch=yes
 	pkg_install() {
 		vmove usr/share/iniparser/example
 	}


### PR DESCRIPTION
This also means the examples package can become noarch as it only contains source code.