### PR TITLE
cfitsio: fix build

### DIFF
--- a/srcpkgs/cfitsio/template
+++ b/srcpkgs/cfitsio/template
@@ -4,6 +4,7 @@ version=3.450
 revision=1
 wrksrc=cfitsio
 build_style=cmake
+makedepends="libcurl-devel"
 short_desc="Library for reading and writing data files in FITS data format"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="NASA license"


### PR DESCRIPTION
libcurl is searched for during configure, but it is not found.