### PR TITLE
ccextractor: fix ppc64 build

### DIFF
--- a/srcpkgs/ccextractor/template
+++ b/srcpkgs/ccextractor/template
@@ -14,7 +14,7 @@ homepage="https://www.ccextractor.org/"
 changelog="https://raw.githubusercontent.com/CCExtractor/ccextractor/master/docs/CHANGES.TXT"
 distfiles="https://github.com/CCExtractor/${pkgname}/archive/v${version}.tar.gz"
 checksum=10c3d88fba531aa6f5f6937e8eccc4df2ac96abaa4d77cb4a1b1349a8b94346f
-CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/tesseract"
+CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/tesseract -DPNG_POWERPC_VSX_OPT=0"
 
 pre_configure() {
 	sed -i -e "s/tesseract --version/tesseract-ocr --version/g" configure.ac


### PR DESCRIPTION
This bundles libpng source but without the vsx asm, so building fails on ppc64. Manually disable vsx asm usage.