### PR TITLE
marble5: switch to phonon-qt5

### DIFF
--- a/srcpkgs/marble5/template
+++ b/srcpkgs/marble5/template
@@ -1,13 +1,13 @@
 # Template file for 'marble5'
 pkgname=marble5
 version=18.12.2
-revision=1
+revision=2
 wrksrc="marble-${version}"
 build_style=cmake
 configure_args="-DBUILD_MARBLE_TESTS=NO -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules kconfig-devel kcoreaddons-devel kdoctools
  perl qt5-host-tools qt5-qmake"
-makedepends="gpsd-devel knewstuff-devel kparts-devel krunner-devel phonon-devel
+makedepends="gpsd-devel knewstuff-devel kparts-devel krunner-devel phonon-qt5-devel
  qt5-location-devel qt5-serialport-devel qt5-webkit-devel shapelib-devel"
 short_desc="Virtual globe and world atlas"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"


### PR DESCRIPTION
This is a qt5 application but for some reason still depended on qt4 phonon.