### PR TITLE
ffmpeg: enable nvenc for x86 only, nv-codec-headers: make x86 only

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -27,14 +27,10 @@ build_options="x265 v4l2 vaapi vdpau vpx faac fdk_aac aom nvenc sndio"
 build_options_default="x265 v4l2 vpx sndio"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc64*) build_options_default+=" vaapi vdpau";;
+	i686*|x86_64*) build_options_default+=" vaapi vdpau nvenc";;
+	ppc64*) build_options_default+=" vaapi vdpau";;
 	mips*) CFLAGS="-mnan=legacy";;
 esac
-
-# nvenc support is broken for cross builds
-if [ -z "$CROSS_BUILD" ]; then
-	build_options_default+=" nvenc"
-fi
 
 do_configure() {
 	# Fix gcc on x86_64-musl only

--- a/srcpkgs/nv-codec-headers/template
+++ b/srcpkgs/nv-codec-headers/template
@@ -4,6 +4,7 @@ version=8.2.15.6
 revision=1
 noarch=yes
 wrksrc="nv-codec-headers-n${version}"
+only_for_archs="i686 i686-musl x86_64 x86_64-musl"
 build_style=gnu-makefile
 short_desc="FFmpeg version of headers required to interface with Nvidias codec APIs"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"


### PR DESCRIPTION
The codec headers make x86 specific assumptions, which generally applies as the nvidia drivers and CUDA are only consistently available for x86, and these headers runtime depend on them (the driver and CUDA are technically also available on ppc64le, but that is through a separate distribution channel with separate versioning and the headers do not assume that).

I'm thinking maybe we should go even further and enable this stuff only on non-musl targets as well, but then it probably does no harm to enable it on x86 musl, it is technically possible to get the drivers to work there (with a lot of manual effort), might as well just have things fail at runtime OOTB.

@jnbr