### PR TITLE
gobject-introspection: add missing architectures

### DIFF
--- a/srcpkgs/gobject-introspection/files/g-ir-scanner-qemuwrapper
+++ b/srcpkgs/gobject-introspection/files/g-ir-scanner-qemuwrapper
@@ -8,6 +8,15 @@ case "$XBPS_TARGET_MACHINE" in
 	i686) _MACHINE=i386 ;;
 	aarch64*) _MACHINE=aarch64 ;;
 	armv*) _MACHINE=arm ;;
+	mipsel*) _MACHINE=mipsel ;;
+	mips*) _MACHINE=mips ;;
+	ppc64le*) _MACHINE=ppc64le ;;
+	ppc64*) _MACHINE=ppc64 ;;
+	ppc*) _MACHINE=ppc ;;
+	*)
+		echo "unknown qemu architecture: $XBPS_TARGET_MACHINE"
+		exit 1
+	;;
 esac
 
 /usr/bin/qemu-${_MACHINE}-static \

--- a/srcpkgs/gobject-introspection/template
+++ b/srcpkgs/gobject-introspection/template
@@ -1,7 +1,7 @@
 # Template file for 'gobject-introspection'
 pkgname=gobject-introspection
 version=1.58.3
-revision=2
+revision=3
 build_style=meson
 pycompile_dirs="usr/lib/${pkgname}/giscanner"
 hostmakedepends="flex pkg-config"


### PR DESCRIPTION
This adds missing arches into the qemuwrapper.

@maxice8 