### PR TITLE
Enable GNU TLS in inspircd

### DIFF
--- a/srcpkgs/inspircd/template
+++ b/srcpkgs/inspircd/template
@@ -1,10 +1,10 @@
 # Template file for 'inspircd'
 pkgname=inspircd
 version=2.0.27
-revision=2
+revision=3
 build_style=gnu-makefile
 hostmakedepends="perl pkg-config"
-makedepends="geoip-devel libressl-devel sqlite-devel"
+makedepends="geoip-devel libressl-devel sqlite-devel gnutls-devel"
 short_desc="Modular Internet Relay Chat server"
 maintainer="Alexander Gehrke <void@qwertyuiop.de>"
 license="GPL-2.0-only"
@@ -27,6 +27,7 @@ do_configure() {
 		--uid inspircd \
 		--disable-interactive \
 		--enable-openssl \
+		--enable-gnutls \
 		--enable-epoll
 	sed -i 's/-ldl/& -lm/' GNUmakefile
 }


### PR DESCRIPTION
This enables gnu-tls, I think it should be enabled by default, as it's the recommended method in InspIRCd documentation https://wiki.inspircd.org/Modules/2.0/ssl_gnutls (section OpenSSL vs. GnuTLS).