### PR TITLE
cargo: add option for static linked builds

### DIFF
--- a/srcpkgs/cargo/patches/link-static.patch
+++ b/srcpkgs/cargo/patches/link-static.patch
@@ -1,0 +1,8 @@
+--- Cargo.toml	2019-01-02 22:49:06.000000000 +0100
++++ Cargo.toml	2019-02-13 15:12:44.616810828 +0100
+@@ -107,3 +107,5 @@
+ [features]
+ vendored-openssl = ['openssl/vendored']
+ pretty-env-logger = ['pretty_env_logger']
++
++all-static = ['curl-sys/static-curl']

--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -13,6 +13,7 @@ homepage="https://crates.io/"
 distfiles="https://github.com/rust-lang/cargo/archive/${version}.tar.gz"
 checksum=914d715ff1a4ac4280b63d05c0f848d38889900a5559888d4a20c9600f87e6a4
 _cargo_dist_version=0.33.0
+build_options="static"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" cargo"
@@ -69,11 +70,22 @@ post_extract() {
 }
 
 do_build() {
-	if [ "$CROSS_BUILD" ]; then
-		cargo build --release
-	else
-		./cargo build --release
+	if [ "$build_option_static" ]; then
+		unset LIBGIT2_SYS_USE_PKG_CONFIG
+		unset LIBSSH2_SYS_USE_PKG_CONFIG
+		export OPENSSL_STATIC=1
+		# rust-openssl can not be linked static if pkg-config is used
+		export OPENSSL_NO_PKG_CONFIG
+		export OPENSSL_DIR="${XBPS_CROSS_BASE}/usr"
 	fi
+
+	if [ "$CROSS_BUILD" ]; then
+		cargo="cargo"
+	else
+		cargo="./cargo"
+	fi
+
+	$cargo build --release $(vopt_if static --features="all-static")
 }
 
 do_install() {


### PR DESCRIPTION
This option is intended for our bootstrapping cargo binaries only.
WIP because currently libssl is still linked dynamic.