### PR TITLE
 python-BeautifulSoup4: add missing dependency on soupsieve

### DIFF
--- a/srcpkgs/python-BeautifulSoup4/template
+++ b/srcpkgs/python-BeautifulSoup4/template
@@ -1,13 +1,13 @@
 # Template file for 'python-BeautifulSoup4'
 pkgname=python-BeautifulSoup4
 version=4.7.1
-revision=1
+revision=2
 noarch=yes
 wrksrc="beautifulsoup4-${version}"
 build_style=python-module
 pycompile_module="bs4"
 hostmakedepends="python-setuptools python3-setuptools"
-depends="python"
+depends="python python-soupsieve"
 short_desc="Python2 HTML/XML parser"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="MIT"
@@ -21,7 +21,7 @@ post_install() {
 
 python3-BeautifulSoup4_package() {
 	noarch=yes
-	depends="python3"
+	depends="python3 python3-soupsieve"
 	pycompile_module="bs4"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {

--- a/srcpkgs/python-soupsieve/template
+++ b/srcpkgs/python-soupsieve/template
@@ -1,0 +1,40 @@
+# Template file for 'python-soupsieve'
+pkgname=python-soupsieve
+version=1.7.3
+revision=1
+archs=noarch
+wrksrc="soupsieve-${version}"
+build_style=python-module
+pycompile_module="soupsieve"
+hostmakedepends="python-setuptools python3-setuptools"
+checkdepends="python-pytest python-lxml python-html5lib python-BeautifulSoup4
+ python-backports.functools_lru_cache python3-pytest python3-lxml
+ python3-html5lib python3-BeautifulSoup4"
+short_desc="CSS4 selector implementation for Python2 Beautiful Soup"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://facelessuser.github.io/soupsieve/"
+distfiles="https://github.com/facelessuser/soupsieve/archive/${version}.tar.gz"
+checksum=@ee7798ee2621a6c598924a4ce8b952a46d6e17d6504531c6333aec0b73b449eb
+
+do_check() {
+	PY2PATH="${PWD}/build-2.7/lib"
+	PY3PATH="${PWD}/build-${py3_ver}/lib"
+
+	PYTHONPATH="${PY2PATH}" python2 -m pytest
+	PYTHONPATH="${PY3PATH}" python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE.md
+}
+
+python3-soupsieve_package() {
+	archs=noarch
+	pycompile_module="soupsieve"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove "usr/lib/python3*"
+		vlicense LICENSE.md
+	}
+}

--- a/srcpkgs/python3-soupsieve
+++ b/srcpkgs/python3-soupsieve
@@ -1,0 +1,1 @@
+python-soupsieve


### PR DESCRIPTION
This new dependency was added on 4.7.0 but was missed by the update.

Also, I'm unable to test soupsieve on python2 because `python-more_itertools` (a test dependency somewhere down the chain) is now at 6.0.0, but the last release supporting python2 was 5.0.0. I don't know if there's already a procedure to deal with this.