### PR TITLE
New package: pypy3.6-7.1.0

### DIFF
--- a/srcpkgs/pypy3.6/files/musl.patch
+++ b/srcpkgs/pypy3.6/files/musl.patch
@@ -1,0 +1,17 @@
+--- rpython/rlib/rfile.py.orig	2019-02-21 01:43:11.042842404 +0100
++++ rpython/rlib/rfile.py	2019-02-21 01:43:49.301840835 +0100
+@@ -106,11 +106,11 @@
+ c_ferror = llexternal('ferror', [FILEP], rffi.INT)
+ c_clearerr = llexternal('clearerr', [FILEP], lltype.Void)
+ 
+-c_stdin = rffi.CExternVariable(FILEP, 'stdin', eci, c_type='FILE*',
++c_stdin = rffi.CExternVariable(FILEP, 'stdin', eci, c_type='FILE *const',
+                                getter_only=True)
+-c_stdout = rffi.CExternVariable(FILEP, 'stdout', eci, c_type='FILE*',
++c_stdout = rffi.CExternVariable(FILEP, 'stdout', eci, c_type='FILE *const',
+                                 getter_only=True)
+-c_stderr = rffi.CExternVariable(FILEP, 'stderr', eci, c_type='FILE*',
++c_stderr = rffi.CExternVariable(FILEP, 'stderr', eci, c_type='FILE *const',
+                                 getter_only=True)
+ 
+

--- a/srcpkgs/pypy3.6/patches/libressl.patch
+++ b/srcpkgs/pypy3.6/patches/libressl.patch
@@ -1,0 +1,40 @@
+--- ./lib_pypy/_cffi_ssl/_cffi_src/openssl/x509.py.orig 2019-02-17 04:27:29.778408202 +0100
++++ ./lib_pypy/_cffi_ssl/_cffi_src/openssl/x509.py      2019-02-17 04:29:05.433404279 +0100
+@@ -258,7 +258,7 @@
+ const X509_ALGOR *X509_get0_tbs_sigalg(const X509 *);
+ 
+ /* in 1.1.0 becomes const ASN1_BIT_STRING, const X509_ALGOR */
+-void X509_get0_signature(ASN1_BIT_STRING **, X509_ALGOR **, X509 *);
++void X509_get0_signature(const ASN1_BIT_STRING **, const X509_ALGOR **, const X509 *);
+ 
+ long X509_get_version(X509 *);
+ 
+@@ -343,7 +343,7 @@
+    opaquing. */
+ #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_102 || defined(LIBRESSL_VERSION_NUMBER)
+ /* from x509/x_x509.c version 1.0.2 */
+-void X509_get0_signature(ASN1_BIT_STRING **psig, X509_ALGOR **palg,
++void X509_get0_signature(const ASN1_BIT_STRING **psig, const X509_ALGOR **palg,
+                          const X509 *x)
+ {
+     if (psig)
+--- ./lib_pypy/_cffi_ssl/_cffi_src/openssl/x509_vfy.py.orig     2019-02-17 04:31:05.820399342 +0100
++++ ./lib_pypy/_cffi_ssl/_cffi_src/openssl/x509_vfy.py  2019-02-17 04:31:27.573398450 +0100
+@@ -204,7 +204,7 @@
+ X509_OBJECT *sk_X509_OBJECT_value(Cryptography_STACK_OF_X509_OBJECT *, int);
+ X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *);
+ Cryptography_STACK_OF_X509_OBJECT *X509_STORE_get0_objects(X509_STORE *);
+-X509 *X509_OBJECT_get0_X509(X509_OBJECT *);
++X509 *X509_OBJECT_get0_X509(const X509_OBJECT *);
+ int X509_OBJECT_get_type(const X509_OBJECT *);
+ """
+ 
+@@ -293,7 +293,7 @@
+ #endif
+ 
+ #if CRYPTOGRAPHY_OPENSSL_LESS_THAN_110PRE5 || defined(LIBRESSL_VERSION_NUMBER)
+-X509 *X509_OBJECT_get0_X509(X509_OBJECT *x) {
++X509 *X509_OBJECT_get0_X509(const X509_OBJECT *x) {
+     return x->data.x509;
+ }
+ #endif

--- a/srcpkgs/pypy3.6/template
+++ b/srcpkgs/pypy3.6/template
@@ -1,0 +1,39 @@
+# Template file for 'pypy3.6'
+pkgname=pypy3.6
+version=7.1.0
+revision=1
+wrksrc="pypy3.6-v${version}-src"
+hostmakedepends="pkg-config python python-cffi"
+makedepends="bzip2-devel gdbm-devel libffi-devel liblzma-devel
+ libressl-devel ncurses-devel sqlite-devel tk-devel zlib-devel"
+short_desc="JIT-enabled implementation of Python 3.6 written in RPython"
+license="MIT"
+homepage="http://pypy.org/"
+distfiles="https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v${version}-src.tar.bz2"
+checksum=faa81f469bb2a7cbd22c64f22d4b4ddc5a1f7c798d43b7919b629b932f9b1c6f
+nocross="Tries to execute cross-compiled code"
+
+do_build() {
+	case "$XBPS_TARGET_MACHINE" in
+	*-musl)
+		patch -Np0 -i ${FILESDIR}/musl.patch
+		;;
+	esac
+
+	cd pypy/goal
+	python ../../rpython/bin/rpython --opt=jit --cc=${CC} \
+		--make-jobs=$XBPS_MAKEJOBS
+	PYTHONPATH=../.. ./pypy3-c ../tool/build_cffi_imports.py
+}
+
+do_install() {
+	vdoc README.rst
+	vlicense LICENSE
+	vmkdir /opt
+	vmkdir /usr/bin
+	# Upstream recommends installing under /opt and symlinking
+	python pypy/tool/release/package.py --archive-name=$pkgname \
+		--targetdir=. --no-keep-debug
+	tar -xpf $pkgname.tar.bz2 -C ${PKGDESTDIR}/opt
+	ln -s /opt/$pkgname/bin/pypy3 ${PKGDESTDIR}/usr/bin/$pkgname
+}


### PR DESCRIPTION
With this release, _most_ of the issues with LibreSSL support have been resolved and PyPy builds successfully after a very minimal patch.

Note that this builds Tk bindings, so pulls in `tk` as a dependency, unlike the regular `python` package. If this is undesirable, I will change it.

I am unsure if skipping CI is appropriate here, with this being a new package. There is a chance the build will complete in time, but it's not very large (takes ~1h on my admittedly underpowered machine).