### PR TITLE
alertmanager: fixed service to use double dashes in config file option

### DIFF
--- a/srcpkgs/alertmanager/files/alertmanager/run
+++ b/srcpkgs/alertmanager/files/alertmanager/run
@@ -5,7 +5,7 @@
 
 : ${USER:=_alertmanager}
 : ${CONF_FILE:=/etc/alertmanager.yml}
-: ${CONF_FLAG:=-config.file=$CONF_FILE}
+: ${CONF_FLAG:=--config.file=$CONF_FILE}
 : ${WRKDIR:=/var/lib/alertmanager}
 
 cd "$WRKDIR"

--- a/srcpkgs/alertmanager/template
+++ b/srcpkgs/alertmanager/template
@@ -1,7 +1,7 @@
 # Template file for 'alertmanager'
 pkgname=alertmanager
 version=0.16.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/prometheus/alertmanager"
 go_package="${go_import_path}/cmd/alertmanager ${go_import_path}/cmd/amtool"


### PR DESCRIPTION
The alertmanager service provided with the package gave the config file option with a single dash. 

The alertmanager binary expects the config file option to be provided with double dashes as shown in the [Alert Manager readme](https://github.com/prometheus/alertmanager#compiling-the-binary).

As a result the existing alertmanager service will not start. This PR fixes that.