### PR TITLE
bookworm: add missing runtime dependency

### DIFF
--- a/srcpkgs/bookworm/template
+++ b/srcpkgs/bookworm/template
@@ -1,11 +1,12 @@
 # Template file for 'bookworm'
 pkgname=bookworm
 version=1.1.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config glib-devel"
 makedepends="gtk+3-devel libgee08-devel granite-devel webkit2gtk-devel sqlite-devel
  poppler-glib-devel libxml2-devel glib-devel"
+depends="poppler"
 short_desc="Simple, focused eBook reader"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
It requires poppler since it converts PDFs to html before opening :scream: 