### PR TITLE
ORBit2: reenable

### DIFF
--- a/srcpkgs/ORBit2/template
+++ b/srcpkgs/ORBit2/template
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://projects.gnome.org/ORBit2/"
 distfiles="http://ftp.acc.umu.se/pub/gnome/sources/${pkgname}/2.14/${pkgname}-${version}.tar.bz2"
 checksum=55c900a905482992730f575f3eef34d50bda717c197c97c08fa5a6eafd857550
-broken="undefined reference to ORBit_CosNaming_NamingContextExt_create"
+disable_parallel_build=yes
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" ORBit2"


### PR DESCRIPTION
It doesn't seem to fail but there is some kind of race in the build system, resulting in a static library being erased, so disable parallel build.