### PR TITLE
memcached: include termios.h properly

### DIFF
--- a/srcpkgs/memcached/patches/termios.patch
+++ b/srcpkgs/memcached/patches/termios.patch
@@ -1,0 +1,12 @@
+This fixes build (errors about an incomplete struct) as the
+code uses TCGETS.
+--- linux_priv.c	2019-02-10 17:37:43.939089097 +0100
++++ linux_priv.c	2019-02-10 17:37:31.180435066 +0100
+@@ -3,6 +3,7 @@
+ #include <errno.h>
+ #include <stdlib.h>
+ #include <sys/ioctl.h>
++#include <termios.h>
+ #include "memcached.h"
+ 
+ // If anything crosses the policy, kill the process.


### PR DESCRIPTION
The file uses a struct from termios.h but misses the include.