### PR TITLE
biew: fix build on some targets

### DIFF
--- a/srcpkgs/biew/patches/bool.patch
+++ b/srcpkgs/biew/patches/bool.patch
@@ -1,0 +1,26 @@
+The two underscores in the front violate namespace and
+break build at least on some systems, as __bool might be
+a builtin type name.
+
+--- plugins/bin/ne.c
++++ plugins/bin/ne.c
+@@ -465,16 +465,16 @@ static void __FASTCALL__ ShowProcListNE( int modno )
+ {
+  BGLOBAL handle;
+  char ptitle[80],name[50];
+- tBool __bool;
++ tBool b;
+  memArray* obj;
+  TWindow *w;
+  handle = ne_cache;
+  bioSeek(handle,0L,SEEK_SET);
+  w = PleaseWaitWnd();
+  if(!(obj = ma_Build(0,True))) return;
+- __bool = __ReadProcListNE(handle,obj,modno);
++ b = __ReadProcListNE(handle,obj,modno);
+  CloseWnd(w);
+- if(__bool)
++ if(b)
+  {
+      if(!obj->nItems)  { NotifyBox(NOT_ENTRY,MOD_REFER); return; }
+      rd_ImpName(name,sizeof(name),modno+1,False);


### PR DESCRIPTION
This patch fixes a namespace violation resulting in conflicts and build failure on some targets.