### PR TITLE
assimp: restrict a patch that breaks build on ppc

### DIFF
--- a/srcpkgs/assimp/patches/0001-glext_h_conflict.patch
+++ b/srcpkgs/assimp/patches/0001-glext_h_conflict.patch
@@ -4,7 +4,7 @@
  /// \author smal.root@gmail.com
  /// \date   2016
 
-+#if !defined(__x86_64__) && !defined(__i386__)
++#if defined(__arm__)
 +// Avoid conflict for types GLsizeiptr and GLintptr
 +#define GL_VERSION_1_5
 +


### PR DESCRIPTION
Since before ppc, the only relevant non-x86 targets were the ARM ones, and it builds fine on ppc64, restrict this patch to ARM only.