### PR TITLE
flatpak: depend on gnupg2

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,7 +1,7 @@
 # Template file for 'flatpak'
 pkgname=flatpak
 version=1.2.3
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-documentation --with-system-bubblewrap
@@ -9,7 +9,7 @@ configure_args="--disable-documentation --with-system-bubblewrap
 hostmakedepends="bubblewrap glib-devel libxslt pkg-config bison"
 makedepends="appstream-glib-devel gpgme-devel json-glib-devel libcap-devel
  libostree-devel libseccomp-devel polkit-devel dconf-devel"
-depends="bubblewrap"
+depends="bubblewrap gnupg2"
 checkdepends="bubblewrap dbus"
 short_desc="Application sandboxing and distribution framework"
 maintainer="Duncaen <duncaen@voidlinux.org>"


### PR DESCRIPTION
Required for adding remotes.

closes #8263