### PR TITLE
Orocos KDL

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3412,3 +3412,4 @@ libCOIN.so libogdf-2018.03_1
 librocksdb.so.5 rocksdb-5.17.2_1
 libfrr.so.0 libfrr-6.0_1
 libfrrospfapiclient.so.0 libfrrospfapiclient-6.0_1
+liborocos-kdl.so.1.4 orocos-kdl-1.4.0_1

--- a/srcpkgs/orocos-kdl-devel
+++ b/srcpkgs/orocos-kdl-devel
@@ -1,0 +1,1 @@
+orocos-kdl

--- a/srcpkgs/orocos-kdl/template
+++ b/srcpkgs/orocos-kdl/template
@@ -1,0 +1,25 @@
+# Template file for 'orocos-kdl'
+pkgname=orocos-kdl
+version=1.4.0
+revision=1
+wrksrc=orocos_kinematics_dynamics-${version}
+build_wrksrc=orocos_kdl
+build_style=cmake
+makedepends="eigen3.2"
+short_desc="Orocos Kinematics and Dynamics C++ library"
+maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
+license="LGPL-2.1-only"
+homepage="http://www.orocos.org/kdl"
+distfiles="https://github.com/orocos/orocos_kinematics_dynamics/archive/v${version}.tar.gz"
+checksum=05b93e759923684dc07433ccae1e476d158d89b3c2be5079c20062406da7b4dd
+
+orocos-kdl-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+		vmove usr/share
+	}
+}

--- a/srcpkgs/python3-orocos-kdl/template
+++ b/srcpkgs/python3-orocos-kdl/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-orocos-kdl'
+pkgname=python3-orocos-kdl
+version=1.4.0
+revision=1
+wrksrc=orocos_kinematics_dynamics-${version}
+build_wrksrc=python_orocos_kdl
+build_style=cmake
+configure_args="-DPYTHON_VERSION=3"
+hostmakedepends="python3 python3-sip"
+makedepends="python3-sip-devel python3-devel orocos-kdl-devel eigen3.2"
+depends="python3 python3-sip"
+short_desc="Python3 Bindings for Orocos Kinematics and Dynamics C++ library"
+maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
+license="LGPL-2.1-only"
+homepage="http://www.orocos.org/kdl"
+distfiles="https://github.com/orocos/orocos_kinematics_dynamics/archive/v${version}.tar.gz"
+checksum=05b93e759923684dc07433ccae1e476d158d89b3c2be5079c20062406da7b4dd


### PR DESCRIPTION
New packages for Orocos KDL #8799 
The python packages fail to build because they depend on orocos-kdl. That is, when scanning for rdeps, it detects the shared library provided by orocos-kdl, but it's obviously not present yet.
If necessary, I can submit this as two PR's and wait on the python one until the other is merged.

The python packages each have their own template, since it's not an ordinary python build (not `build_style=python-module`) but is instead built with cmake.