### PR TITLE
build-style/python3-module.sh: add do_check

### DIFF
--- a/common/build-style/python3-module.sh
+++ b/common/build-style/python3-module.sh
@@ -17,6 +17,20 @@ do_build() {
 	fi
 }
 
+do_check() {
+	local _default_target=test
+
+	if [ -z "$make_check_target" ]; then
+		if ! python3 setup.py --help ${_default_target} >/dev/null 2>&1; then
+			msg_warn "No command '${_default_target}' defined by setup.py.\n"
+			return 0
+		fi
+	fi
+
+	: ${make_check_target:=${_default_target}}
+	python3 setup.py ${make_check_target} ${make_check_args}
+}
+
 do_install() {
 	if [ -n "$CROSS_BUILD" ]; then
 		PYPREFIX="$XBPS_CROSS_BASE"


### PR DESCRIPTION
For now most packages fail to test because of not defined checkdepends, but also some pass, some has no tests etc.

This can't be trivially copied to python-module as `setup.py test` do not accept `--build-base`.