### PR TITLE
Update Gluster to 5.3

### DIFF
--- a/srcpkgs/glusterfs/template
+++ b/srcpkgs/glusterfs/template
@@ -1,7 +1,7 @@
 # Template file for 'glusterfs'
 pkgname=glusterfs
-version=3.12.14
-revision=3
+version=5.3
+revision=1
 build_style=gnu-configure
 configure_args="--disable-glupy --enable-crypt-xlator
  --with-mountutildir=/usr/bin ac_cv_file__etc_debian_version=no
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-3.0-only"
 homepage="http://www.gluster.org/"
 distfiles="https://download.gluster.org/pub/gluster/glusterfs/${version%.*}/${version}/${pkgname}-${version}.tar.gz"
-checksum=a692c263eefecb9640e8a4154fe0c5bc1613a0b0ed3a92209ff0b628f5945509
+checksum=293542b1f43e681741282d1ba2aefe9b501321c782e896f518cca36072414448
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="not yet supported";;


### PR DESCRIPTION
Gluster has a fast-paced update schedule and not a very long support window.  Currently, 3.12 is very outdated and no longer receiving updates.  4.1 and 5.x are both receiving updates.  After a few months of use on 5.x branch, I've had no issues and it is backwards compatible with all earlier versions still.

This pull updates Gluster packages to 5.3.

FYI, this is my first pull request, so not sure if all of the sub packages need to be merged as well.