### PR TITLE
glusterfs: update to 5.3

### DIFF
--- a/srcpkgs/glusterfs/template
+++ b/srcpkgs/glusterfs/template
@@ -1,7 +1,7 @@
 # Template file for 'glusterfs'
 pkgname=glusterfs
-version=3.12.14
-revision=3
+version=5.3
+revision=1
 build_style=gnu-configure
 configure_args="--disable-glupy --enable-crypt-xlator
  --with-mountutildir=/usr/bin ac_cv_file__etc_debian_version=no
@@ -9,7 +9,7 @@ configure_args="--disable-glupy --enable-crypt-xlator
 pycompile_dirs="/usr/libexec/glusterfs/python/syncdaemon"
 hostmakedepends="automake flex libtool pkg-config python"
 makedepends="acl-devel fuse-devel libaio-devel liblvm2app-devel libressl-devel
- liburcu-devel libxml2-devel sqlite-devel"
+ liburcu-devel libxml2-devel rdma-core-devel sqlite-devel"
 # python is required by gsyncd.
 depends="python"
 short_desc="Free and open source software scalable network filesystem (client)"
@@ -17,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-3.0-only"
 homepage="http://www.gluster.org/"
 distfiles="https://download.gluster.org/pub/gluster/glusterfs/${version%.*}/${version}/${pkgname}-${version}.tar.gz"
-checksum=a692c263eefecb9640e8a4154fe0c5bc1613a0b0ed3a92209ff0b628f5945509
+checksum=293542b1f43e681741282d1ba2aefe9b501321c782e896f518cca36072414448
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="not yet supported";;


### PR DESCRIPTION
Gluster 3.12 is no longer supported upstream.  Gluster 4.1 will soon lose support as well.  Gluster 5.x is the latest series receiving monthly updates and has worked well for me since it was released.

The current version is 5.3.

The Gluster release schedule can be found [here](https://www.gluster.org/release-schedule/).