### PR TITLE
keepalived: update to 2.0.13

### DIFF
--- a/srcpkgs/keepalived/template
+++ b/srcpkgs/keepalived/template
@@ -1,18 +1,18 @@
 # Template file for 'keepalived'
 pkgname=keepalived
-version=1.4.2
-revision=3
-conf_files="/etc/${pkgname}/${pkgname}.conf"
+version=2.0.13
+revision=1
 build_style=gnu-configure
 configure_args="--enable-sha1"
+conf_files="/etc/${pkgname}/${pkgname}.conf"
 hostmakedepends="pkg-config"
 makedepends="libressl-devel libnl3-devel popt-devel libnfnetlink-devel"
 short_desc="Failover and monitoring daemon for LVS clusters"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="GPL-2"
+license="GPL-2-or-later"
 homepage="http://www.keepalived.org/"
 distfiles="http://www.keepalived.org/software/$pkgname-$version.tar.gz"
-checksum=4e2d7cc01a6ee29a3955f5c622d47704ba7d9dd758189f15e9def016a2d1faa3
+checksum=c7fb38e8a322fb898fb9f6d5d566827a30aa5a4cd1774f474bb4041c85bcbc46
 
 post_install() {
 	vsv $pkgname


### PR DESCRIPTION
The 1.x versions of keepalived are unsupported and is not receiving backports according to a front page note on the [keepalived.org](http://www.keepalived.org/)  website.

This will update keepalived to the latest supported version.