### PR TITLE
nvidia: update to 418.43

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -142,7 +142,7 @@ libnvidia-glcore.so.346.47 nvidia340-libs-340.46_1 ignore
 libnvidia-glcore.so.390.87 nvidia390-libs-390.87_1 ignore
 libnvidia-glsi.so.346.72 nvidia-libs-346.72_1 ignore
 libnvidia-fatbinaryloader.so.390.87 nvidia390-libs-390.87_1 ignore
-libnvidia-fatbinaryloader.so.410.93 nvidia-libs-410.93_1 ignore
+libnvidia-fatbinaryloader.so.418.43 nvidia-libs-418.43_1 ignore
 libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
 librsvg-2.so.2 librsvg-2.26.0_1

--- a/srcpkgs/nvidia/INSTALL
+++ b/srcpkgs/nvidia/INSTALL
@@ -1,10 +1,10 @@
 case "${ACTION}" in
 post)
-	# Regenerate initramfs.
-	echo "Regenerating initramfs, please wait..."
-	dracut -f -q --regenerate-all
-
-	if [ "${ARCH}" = "i686" ]; then
+	if [ "${ARCH}" = "x86_64" ]; then
+		# Regenerate initramfs.
+		echo "Regenerating initramfs, please wait..."
+		dracut -f -q --regenerate-all
+	else
 		echo "Nvidia has dropped support for 32-bit kernels.\n"
 		echo "Please consider installing the nvidia390 package as an alternative.\n"
 		echo "This package is now only useful if you're using a x86_64 kernel.\n"

--- a/srcpkgs/nvidia/REMOVE
+++ b/srcpkgs/nvidia/REMOVE
@@ -1,7 +1,9 @@
 # Regenerate initramfs.
 case ${ACTION} in
 purge)
-	echo "Regenerating initramfs, please wait..."
-	dracut -f -q --regenerate-all
+	if [ "${ARCH}" = "x86_64" ]; then
+		echo "Regenerating initramfs, please wait..."
+		dracut -f -q --regenerate-all
+	fi
 	;;
 esac

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -1,41 +1,40 @@
 # Template file for 'nvidia'
 
-_desc="NVIDIA drivers for linux (long-lived series)"
+_desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
-version=410.93
+version=418.43
 revision=1
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="Proprietary NVIDIA license"
 homepage="http://www.nvidia.com"
 
-only_for_archs="i686 x86_64"
+archs="i686 x86_64"
 nopie=yes
 repository="nonfree"
 create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
 conflicts="catalyst>=0 xserver-abi-video>24_1"
 
-if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-	depends="nvidia-gtklibs-${version}_${revision} nvidia-dkms-${version}_${revision} pkg-config"
-else
-	depends="pkg-config"
-fi
-
 build_options="glvnd"
 desc_option_glvnd="Add support for NVIDIA's GL Vendor Neutral Dispatch implementation"
 build_options_default="glvnd"
 
-if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
-	_pkg="NVIDIA-Linux-x86_64-${version}"
-	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=33bee52be25dc680e9f83997a0faa00ebdaa800c51c7131428900809721e2161
-	subpackages="nvidia-libs"
-else
+if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_pkg="NVIDIA-Linux-x86_64-${version}-no-compat32"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=b1ce054f8307080a257538ab82873e8b8022183f68e08e20fbb07089f7ddbb08
-	subpackages="nvidia-gtklibs nvidia-dkms nvidia-opencl nvidia-libs"
+	checksum=55cb410c5337f46a48636c2bd5ecb42bf1f4367059394e374b16a8f067de3187
+	subpackages="nvidia-gtklibs nvidia-dkms
+	 nvidia-opencl nvidia-libs"
+	depends="nvidia-libs-${version}_${revision}
+	 nvidia-gtklibs-${version}_${revision}
+	 nvidia-dkms-${version}_${revision} pkgconf"
+else
+	_pkg="NVIDIA-Linux-x86_64-${version}"
+	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
+	checksum=18be2c83dee3323bd57fe77fddbbbbd5d760ada674781fb9b39321e6386a327f
+	subpackages="nvidia-libs"
+	depends="pkgconf"
 fi
 
 do_extract() {
@@ -54,153 +53,34 @@ pre_install() {
 do_install() {
 	cd ${_pkg}
 
-	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
-		cd 32
-	else
+	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		# X driver
 		vinstall nvidia_drv.so 755 usr/lib/xorg/modules/drivers
 
 		# GLX extension module for X
 		vinstall libglxserver_nvidia.so.${version} 755 usr/lib/xorg/modules/extensions
-		ln -sf libglxserver_nvidia.so.${version} ${DESTDIR}/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so
-		ln -sf libglxserver_nvidia.so.${version} ${DESTDIR}/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so.1
-	fi
+		ln -sf libglxserver_nvidia.so.${version} \
+			${DESTDIR}/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so
+		ln -sf libglxserver_nvidia.so.${version} \
+			${DESTDIR}/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so.1
 
-	# GLX client libs
-	if [ "${build_option_glvnd}" ]; then
-		# ----- Also provided by the libglvnd package (todo)
-		vinstall libGL.so.1.7.0 755 usr/lib
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
-
-		vinstall libGLX.so.0 755 usr/lib
-		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
-		# --------------------------------------------------
-
-		# Required for GLVND option
-		vinstall libGLX_nvidia.so.${version} 755 usr/lib
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
-	else
-		vinstall libGL.so.${version} 755 usr/lib
-		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so.1
-
-		# Not required for non-GLVND option but recommended
-		# more info: https://devtalk.nvidia.com/default/topic/915640/multiple-glx-client-libraries-in-the-nvidia-linux-driver-installer-package/
-		vinstall libGLX_nvidia.so.${version} 755 usr/lib
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
-
-	fi
-
-	# OpenGL core library
-	vinstall libnvidia-glcore.so.${version} 755 usr/lib
-	vinstall libnvidia-eglcore.so.${version} 755 usr/lib
-	vinstall libnvidia-glsi.so.${version} 755 usr/lib
-
-	# Vulkan core library
-	vinstall libnvidia-glvkspirv.so.${version} 755 usr/lib
-
-	# EGL
-	# ----- Also provided by the libglvnd package (todo)
-	vinstall libOpenGL.so.0 755 usr/lib
-	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
-
-	vinstall libGLdispatch.so.0 755 usr/lib
-
-	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
-
-	vinstall libGLESv2.so.2.1.0 755 usr/lib
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
-
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-		vinstall libnvidia-egl-wayland.so.1.1.0 755 usr/lib
-		ln -sf libnvidia-egl-wayland.so.1.1.0 ${DESTDIR}/usr/lib/libnvidia-egl-wayland.so.1
+		vinstall libnvidia-egl-wayland.so.1.1.2 755 usr/lib
+		ln -sf libnvidia-egl-wayland.so.1.1.2 \
+			${DESTDIR}/usr/lib/libnvidia-egl-wayland.so.1
 
 		vinstall 10_nvidia.json 755 usr/share/glvnd/egl_vendor.d
-		vinstall 10_nvidia_wayland.json 755 usr/share/egl/egl_external_platform.d
-	fi
+		vinstall 10_nvidia_wayland.json \
+			755 usr/share/egl/egl_external_platform.d
 
-	# --------------------------------------------------
-
-	vinstall libEGL.so.1.1.0 755 usr/lib
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
-
-	vinstall libEGL_nvidia.so.${version} 755 usr/lib
-	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/usr/lib/libEGL_nvidia.so.0
-
-	vinstall libGLESv1_CM_nvidia.so.${version} 755 usr/lib
-	ln -sf libGLESv1_CM_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLESv1_CM_nvidia.so.1
-
-	vinstall libGLESv2_nvidia.so.${version} 755 usr/lib
-	ln -sf libGLESv2_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLESv2_nvidia.so.2
-
-	# Thread Local Storage
-	vinstall tls/libnvidia-tls.so.${version} 755 usr/lib/tls
-	ln -sf libnvidia-tls.so.${version} ${DESTDIR}/usr/lib/libnvidia-tls.so.${version}
-
-	# VDPAU
-	vinstall libvdpau_nvidia.so.${version} 755 usr/lib/vdpau
-	ln -sf libvdpau_nvidia.so.${version} ${DESTDIR}/usr/lib/vdpau/libvdpau_nvidia.so.1
-
-	# misc libraries
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		vinstall libnvidia-cfg.so.${version} 755 usr/lib
 		ln -sf libnvidia-cfg.so.${version} ${DESTDIR}/usr/lib/libnvidia-cfg.so
 		ln -sf libnvidia-cfg.so.${version} ${DESTDIR}/usr/lib/libnvidia-cfg.so.1
-	fi
 
-	vinstall libnvidia-ml.so.${version} 755 usr/lib
-	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/usr/lib/libnvidia-ml.so
-	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/usr/lib/libnvidia-ml.so.1
-
-	vinstall libnvidia-encode.so.${version} 755 usr/lib
-	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/usr/lib/libnvidia-encode.so
-	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/usr/lib/libnvidia-encode.so.1
-
-	vinstall libnvidia-ifr.so.${version} 755 usr/lib
-	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/usr/lib/libnvidia-ifr.so
-	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/usr/lib/libnvidia-ifr.so.1
-
-	vinstall libnvidia-fbc.so.${version} 755 usr/lib
-	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/usr/lib/libnvidia-fbc.so
-	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/usr/lib/libnvidia-fbc.so.1
-
-	vinstall libnvidia-fatbinaryloader.so.${version} 755 usr/lib
-	ln -sf libnvidia-fatbinaryloader.so.${version} ${DESTDIR}/usr/lib/libnvidia-fatbinaryloader.so.1
-	ln -sf libnvidia-fatbinaryloader.so.1 ${DESTDIR}/usr/lib/libnvidia-fatbinaryloader.so
-
-	# CUDA
-
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		vbin nvidia-cuda-mps-control
 		vbin nvidia-cuda-mps-server
 		gzip -d nvidia-cuda-mps-control.1.gz
 		vman nvidia-cuda-mps-control.1
-	fi
 
-	vinstall libcuda.so.${version} 755 usr/lib
-	ln -sf libcuda.so.${version} ${DESTDIR}/usr/lib/libcuda.so
-	ln -sf libcuda.so.${version} ${DESTDIR}/usr/lib/libcuda.so.1
-
-	vinstall libnvcuvid.so.${version} 755 usr/lib
-	ln -sf libnvcuvid.so.${version} ${DESTDIR}/usr/lib/libnvcuvid.so
-	ln -sf libnvcuvid.so.${version} ${DESTDIR}/usr/lib/libnvcuvid.so.1
-
-	vinstall libnvidia-ptxjitcompiler.so.${version} 755 usr/lib
-	ln -sf libnvidia-ptxjitcompiler.so.${version} ${DESTDIR}/usr/lib/libnvidia-ptxjitcompiler.so.1
-	ln -sf libnvidia-ptxjitcompiler.so.1 ${DESTDIR}/usr/lib/libnvidia-ptxjitcompiler.so
-
-	# helper libs for approved partners' GRID remote apps
-	vinstall libnvidia-ifr.so.${version} 755 usr/lib
-	vinstall libnvidia-fbc.so.${version} 755 usr/lib
-
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		# nvidia-xconfig
 		vbin nvidia-xconfig
 		gzip -d nvidia-xconfig.1.gz
@@ -220,7 +100,8 @@ do_install() {
 		vinstall libnvidia-gtk2.so.${version} 755 usr/lib
 
 		# application profiles (needed by nvidia-settings)
-		vinstall nvidia-application-profiles-${version}-key-documentation 644 usr/share/nvidia
+		vinstall nvidia-application-profiles-${version}-key-documentation \
+			644 usr/share/nvidia
 		vinstall nvidia-application-profiles-${version}-rc 644 usr/share/nvidia
 
 		# nvidia-bug-report
@@ -267,37 +148,158 @@ do_install() {
 			-i ${DESTDIR}/usr/src/nvidia-${version}/dkms.conf
 
 		vmkdir /usr/share/X11/xorg.conf.d/
-		vinstall nvidia-drm-outputclass.conf 644 /usr/share/X11/xorg.conf.d 30-nvidia-drm-outputclass.conf
+		vinstall nvidia-drm-outputclass.conf 644 \
+			/usr/share/X11/xorg.conf.d 30-nvidia-drm-outputclass.conf
+
+		# Blacklist nouveau
+		vmkdir usr/lib/modprobe.d
+		echo "blacklist nouveau" > ${DESTDIR}/usr/lib/modprobe.d/nvidia.conf
+		chmod 644 ${DESTDIR}/usr/lib/modprobe.d/nvidia.conf
+
+		# Omit drm dracut module too
+		vmkdir usr/lib/dracut/dracut.conf.d
+		echo "omit_dracutmodules+=\" drm \"" > \
+		${DESTDIR}/usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+
+		# License and documentation
+		vlicense LICENSE
+		vdoc README.txt README
+		vdoc NVIDIA_Changelog
+	else
+		cd 32
 	fi
 
-	# Blacklist nouveau
-	vmkdir usr/lib/modprobe.d
-	echo "blacklist nouveau" > ${DESTDIR}/usr/lib/modprobe.d/nvidia.conf
-	chmod 644 ${DESTDIR}/usr/lib/modprobe.d/nvidia.conf
+	# Following libs are common between x86_64 and i686
 
-	# Omit drm dracut module too
-	vmkdir usr/lib/dracut/dracut.conf.d
-	echo "omit_dracutmodules+=\" drm \"" > ${DESTDIR}/usr/lib/dracut/dracut.conf.d/99-nvidia.conf
+	# GLX client libs
+	if [ "${build_option_glvnd}" ]; then
+		# ----- Also provided by the libglvnd package (todo)
+		vinstall libGL.so.1.7.0 755 usr/lib
+		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
+		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
 
-	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
-		cd ..
+		vinstall libGLX.so.0 755 usr/lib
+		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
+		# --------------------------------------------------
+
+		# Required for GLVND option
+		vinstall libGLX_nvidia.so.${version} 755 usr/lib
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
+	else
+		vinstall libGL.so.${version} 755 usr/lib
+		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so
+		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so.1
+
+		# Not required for non-GLVND option but recommended
+		# more info: https://devtalk.nvidia.com/default/topic/915640/multiple-glx-client-libraries-in-the-nvidia-linux-driver-installer-package/
+		vinstall libGLX_nvidia.so.${version} 755 usr/lib
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
+		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
 	fi
 
-	# License and documentation
-	vlicense LICENSE
-	vdoc README.txt README
-	vdoc NVIDIA_Changelog
+	# OpenGL core library
+	vinstall libnvidia-glcore.so.${version} 755 usr/lib
+	vinstall libnvidia-eglcore.so.${version} 755 usr/lib
+	vinstall libnvidia-glsi.so.${version} 755 usr/lib
+
+	# Vulkan core library
+	vinstall libnvidia-glvkspirv.so.${version} 755 usr/lib
+
+	# EGL
+	vinstall libOpenGL.so.0 755 usr/lib
+	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
+
+	vinstall libGLdispatch.so.0 755 usr/lib
+
+	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
+	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
+	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
+
+	vinstall libGLESv2.so.2.1.0 755 usr/lib
+	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
+	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
+
+	vinstall libEGL.so.1.1.0 755 usr/lib
+	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
+	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
+
+	vinstall libEGL_nvidia.so.${version} 755 usr/lib
+	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/usr/lib/libEGL_nvidia.so.0
+
+	vinstall libGLESv1_CM_nvidia.so.${version} 755 usr/lib
+	ln -sf libGLESv1_CM_nvidia.so.${version} \
+		${DESTDIR}/usr/lib/libGLESv1_CM_nvidia.so.1
+
+	vinstall libGLESv2_nvidia.so.${version} 755 usr/lib
+	ln -sf libGLESv2_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLESv2_nvidia.so.2
+
+	# Thread Local Storage
+	vinstall libnvidia-tls.so.${version} 755 usr/lib/
+
+	# VDPAU
+	vinstall libvdpau_nvidia.so.${version} 755 usr/lib/vdpau
+	ln -sf libvdpau_nvidia.so.${version} \
+		${DESTDIR}/usr/lib/vdpau/libvdpau_nvidia.so.1
+
+	vinstall libnvidia-ml.so.${version} 755 usr/lib
+	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/usr/lib/libnvidia-ml.so
+	ln -sf libnvidia-ml.so.${version} ${DESTDIR}/usr/lib/libnvidia-ml.so.1
+
+	vinstall libnvidia-encode.so.${version} 755 usr/lib
+	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/usr/lib/libnvidia-encode.so
+	ln -sf libnvidia-encode.so.${version} ${DESTDIR}/usr/lib/libnvidia-encode.so.1
+
+	vinstall libnvidia-ifr.so.${version} 755 usr/lib
+	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/usr/lib/libnvidia-ifr.so
+	ln -sf libnvidia-ifr.so.${version} ${DESTDIR}/usr/lib/libnvidia-ifr.so.1
+
+	vinstall libnvidia-fbc.so.${version} 755 usr/lib
+	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/usr/lib/libnvidia-fbc.so
+	ln -sf libnvidia-fbc.so.${version} ${DESTDIR}/usr/lib/libnvidia-fbc.so.1
+
+	vinstall libnvidia-fatbinaryloader.so.${version} 755 usr/lib
+	ln -sf libnvidia-fatbinaryloader.so.${version} \
+		${DESTDIR}/usr/lib/libnvidia-fatbinaryloader.so.1
+	ln -sf libnvidia-fatbinaryloader.so.1 \
+		${DESTDIR}/usr/lib/libnvidia-fatbinaryloader.so
+
+	# CUDA
+	vinstall libcuda.so.${version} 755 usr/lib
+	ln -sf libcuda.so.${version} ${DESTDIR}/usr/lib/libcuda.so
+	ln -sf libcuda.so.${version} ${DESTDIR}/usr/lib/libcuda.so.1
+
+	vinstall libnvcuvid.so.${version} 755 usr/lib
+	ln -sf libnvcuvid.so.${version} ${DESTDIR}/usr/lib/libnvcuvid.so
+	ln -sf libnvcuvid.so.${version} ${DESTDIR}/usr/lib/libnvcuvid.so.1
+
+	vinstall libnvidia-opticalflow.so.${version} 755 usr/lib
+	ln -sf libnvidia-opticalflow.so.${version} \
+		${DESTDIR}/usr/lib/libnvidia-opticalflow.so
+	ln -sf libnvidia-opticalflow.so.${version} \
+		${DESTDIR}/usr/lib/libnvidia-opticalflow.so.1
+
+	vinstall libnvidia-ptxjitcompiler.so.${version} 755 usr/lib
+	ln -sf libnvidia-ptxjitcompiler.so.${version} \
+		${DESTDIR}/usr/lib/libnvidia-ptxjitcompiler.so.1
+	ln -sf libnvidia-ptxjitcompiler.so.1 \
+		${DESTDIR}/usr/lib/libnvidia-ptxjitcompiler.so
+
+	# helper libs for approved partners' GRID remote apps
+	vinstall libnvidia-ifr.so.${version} 755 usr/lib
+	vinstall libnvidia-fbc.so.${version} 755 usr/lib
 }
 
 nvidia-gtklibs_package() {
 	short_desc="${_desc} - GTK+ libraries"
 	pkg_install() {
-		vmove usr/lib/lib*gtk*.so*
+		vmove "usr/lib/lib*gtk*.so*"
 	}
 }
 nvidia-libs_package() {
 	short_desc="${_desc} - common libraries"
-	provides="libEGL-${version}_${revision} libGL-${version}_${revision} libGLES-${version}_${revision}"
+	provides="libEGL-${version}_${revision}
+	 libGL-${version}_${revision} libGLES-${version}_${revision}"
 	replaces="libEGL>=0 libGL>=0 libGLES>=0"
 	pkg_install() {
 		vmove usr/lib

--- a/srcpkgs/nvidia/update
+++ b/srcpkgs/nvidia/update
@@ -1,2 +1,2 @@
 site="http://www.nvidia.com/object/unix.html"
-pattern='Long Lived.+>\K[\d.]+(?=</A>)'
+pattern='Branch Version.+>\K[\d.]+(?=</A>)'


### PR DESCRIPTION
This PR is a (better?) alternative to PR #8920, and also fixes #8182. See @Hoshpak [comment](https://github.com/void-linux/void-packages/pull/8920#issuecomment-465704618)

This update moves the nvidia package over to the latest version on the short lived branch. This branch provides support for the TITAN RTX and RTX 2060 graphics cards, as well as various vulkan fixes/improvements.
Potentially a nvidia-lts package could be created to track the current long lived branch if that is useful to anyone. I've decided against including a nvidia410 package as that major version may not become the next legacy release.

~~Do Not Merge. This package should work as it's a copy from the other PR but I'm yet to test it with nvidia hardware.~~

Tested this is working ok.