### PR TITLE
New Package: qperf-0.4.11

### DIFF
--- a/srcpkgs/qperf/template
+++ b/srcpkgs/qperf/template
@@ -1,0 +1,23 @@
+# Template file for 'qperf'
+pkgname=qperf
+version=0.4.11
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf automake"
+short_desc="Measure RDMA and TCP/UDP latency and throughput performance"
+maintainer="Rich G <rich@richgannon.net>"
+license="GPL-2.0"
+homepage="https://github.com/linux-rdma/qperf"
+distfiles="https://github.com/linux-rdma/qperf/archive/v${version}.tar.gz"
+checksum=b0ef2ffe050607566d06102b4ef6268aad08fdc52898620d429096e7b0767e75
+
+pre_configure() {
+	for f in NEWS README ChangeLog; do
+		[ -e "$f" ] || touch "$f"
+	done
+
+	aclocal
+	automake --foreign --add-missing --copy
+	autoconf
+}
+

--- a/srcpkgs/qperf/template
+++ b/srcpkgs/qperf/template
@@ -3,10 +3,10 @@ pkgname=qperf
 version=0.4.11
 revision=1
 build_style=gnu-configure
-hostmakedepends="autoconf automake"
+hostmakedepends="automake"
 short_desc="Measure RDMA and TCP/UDP latency and throughput performance"
 maintainer="Rich G <rich@richgannon.net>"
-license="GPL-2.0"
+license="GPL-2.0-or-later"
 homepage="https://github.com/linux-rdma/qperf"
 distfiles="https://github.com/linux-rdma/qperf/archive/v${version}.tar.gz"
 checksum=b0ef2ffe050607566d06102b4ef6268aad08fdc52898620d429096e7b0767e75
@@ -16,8 +16,6 @@ pre_configure() {
 		[ -e "$f" ] || touch "$f"
 	done
 
-	aclocal
-	automake --foreign --add-missing --copy
-	autoconf
+	autoreconf -fi
 }
 


### PR DESCRIPTION
This is a useful benchmarking tool for RDMA and TCP/UDP links.  It measures throughput in a simpler way than iperf, but it also gives latency results and CPU usage for the tests, which iperf does not.

With this build, RDMA support is not yet working.  rdma-core libraries need to be installed, which I am working on now.  This shall be upped to 0.4.11_2 (or later) once rdma-core is ready.