### PR TITLE
suricata: add build time options for luajit and rust

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3419,3 +3419,4 @@ libappmenu-gtk3-parser.so.0 appmenu-gtk3-module-0.7.1_1
 libqhttpengine.so.1 qhttpengine-1.0.1_1
 libqmdnsengine.so.0 qmdnsengine-0.1.0_1
 libyang.so.0.16 libyang-0.16r3_1
+libhtp.so.2 suricata-4.1.2_2

--- a/srcpkgs/suricata/patches/configure.patch
+++ b/srcpkgs/suricata/patches/configure.patch
@@ -1,0 +1,27 @@
+--- configure.orig	2019-02-22 22:09:50.521219706 +0100
++++ configure	2019-02-22 22:23:32.663207196 +0100
+@@ -26682,24 +26681,0 @@ $as_echo "#define HAVE_RUST 1" >>confdef
+-            as_ac_File=`$as_echo "ac_cv_file_$srcdir/rust/vendor" | $as_tr_sh`
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $srcdir/rust/vendor" >&5
+-$as_echo_n "checking for $srcdir/rust/vendor... " >&6; }
+-if eval \${$as_ac_File+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  test "$cross_compiling" = yes &&
+-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+-if test -r "$srcdir/rust/vendor"; then
+-  eval "$as_ac_File=yes"
+-else
+-  eval "$as_ac_File=no"
+-fi
+-fi
+-eval ac_res=\$$as_ac_File
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
+-if eval test \"x\$"$as_ac_File"\" = x"yes"; then :
+-
+-cat >>confdefs.h <<_ACEOF
+-#define `$as_echo "HAVE_$srcdir/rust/vendor" | $as_tr_cpp` 1
+-_ACEOF
+-have_rust_vendor="yes"
+-fi

--- a/srcpkgs/suricata/template
+++ b/srcpkgs/suricata/template
@@ -1,27 +1,37 @@
 # Template file for 'suricata'
 pkgname=suricata
 version=4.1.2
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--disable-gccmarch-native"
-hostmakedepends="pkg-config"
-makedepends="libnet-devel libpcap-devel pcre-devel libyaml-devel libcap-ng-devel file-devel"
-short_desc="Next Generation Intrusion Detection and Prevention Engine"
+build_helper="$(vopt_if rust_support rust)"
+configure_args="--disable-gccmarch-native $(vopt_enable rust_support rust)
+ $(vopt_if luajit --enable-luajit) $(vopt_if lua --enable-lua)
+ $(vopt_if hiredis --enable-hiredis) --disable-suricata-update --disable-static"
+hostmakedepends="pkg-config $(vopt_if rust_support cargo)"
+makedepends="libnet-devel libpcap-devel pcre-devel libyaml-devel libcap-ng-devel
+ liblz4-devel liblzma-devel file-devel jansson-devel nss-devel $(vopt_if luajit LuaJIT-devel)
+ $(vopt_if lua lua-devel) $(vopt_if hiredis 'hiredis-devel libevent-devel')"
+short_desc="Suricata is a network IDS, IPS and NSM engine"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="https://suricata-ids.org/"
 distfiles="https://www.openinfosecfoundation.org/download/$pkgname-$version.tar.gz"
 checksum=73575b041a50cc48a2a53f6503ab4d355166d7acbd4997cd04045f848f8bea96
+build_options="hiredis lua luajit rust_support"
+build_options_default="hiredis"
+desc_option_hiredis="Enable hiredis support"
+desc_option_luajit="Enable lua support through LuaJIT"
+desc_option_lua="Enable lua support"
+desc_option_rust_support="Enable rust protocol parsers"
+
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" luajit rust_support"
+fi
+
+vopt_conflict lua luajit
 
 system_accounts="$pkgname"
 conf_files="/etc/$pkgname/*.* /etc/$pkgname/rules/*"
-nocross=y
-
-post_extract() {
-	$XBPS_FETCH_CMD https://rules.emergingthreats.net/open/suricata/emerging.rules.tar.gz
-	mkdir -p erules
-	tar xf emerging.rules.tar.gz -C erules
-}
 
 post_build() {
 	sed -i 's|#run-as:|run-as:|g' $pkgname.yaml
@@ -38,6 +48,4 @@ post_install() {
 	vinstall threshold.config 644 etc/$pkgname
 	vmkdir etc/$pkgname/rules
 	vcopy rules/*.rules etc/$pkgname/rules
-	vcopy erules/rules/*.rules etc/$pkgname/rules
-	vlicense erules/rules/LICENSE  emerging-rules.LICENSE
 }


### PR DESCRIPTION
- provide option to enable luajit (default on)
- provide option to enable rust protocol parser support (default on)
  - all "new" parsers have to be written in rust.
  - this option is a requirement for future suricata versions
- add neccessary library dependencies to enable filestore v2 (v1 is deprecated)

the suricata release tarball includes `libhtp` and therefore drops `libhtp.so` during install. a cleaner
solution would be providing `libhtp` as separate package. anyhow, `libhtp.so` is referenced in `common/shlibs`. 