### PR TITLE
New package: chirp-20190220

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,0 +1,14 @@
+# Template file for 'chirp'
+pkgname=chirp
+version=20190220
+revision=1
+wrksrc="chirp-daily-${version}"
+build_style=python2-module
+makedepends="libxml2-python python-pyserial"
+depends="libxml2-python python-pyserial"
+short_desc="Open-source tool for programming an amateur radio"
+maintainer="Rich G <rich@richgannon.net>"
+license="GPL-3.0-or-later"
+homepage="https://chirp.danplanet.com/"
+distfiles="https://trac.chirp.danplanet.com/chirp_daily/daily-${version}/chirp-daily-${version}.tar.gz"
+checksum=260697c8cf132cee7558cef02e0bd404ddd9b676860b57f5238aad3838a08093


### PR DESCRIPTION
Chirp is a useful Python tool to program amateur (HAM) radios.  Only daily builds are available upstream.  I tested to ensure it works with my handheld, and no problems encountered.

I am fairly certain I have everything right this time for this pull request (still learning git and Void requirements).