### PR TITLE
common: add chroot-style none and needed utilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# This dockerfile may be ran from a zap'ed void-package git clone
+# You can mount .void-packages/hostdir from your host so build packages are available from host
+# from there on it's just running ./xbps-src pkg [your package]
+# If desired you may also mount your own srcpkgs over .void-packages/srcpkgs to build your own packages
+# Don't forget to also mount .git on .void-packages/.git then
+FROM d.xr.to/base
+COPY .git .void-packages/.git
+COPY srcpkgs .void-packages/srcpkgs
+COPY etc .void-packages/etc
+COPY common .void-packages/common
+COPY xbps-src .void-packages/xbps-src
+WORKDIR /.void-packages
+RUN xbps-install -Sy coreutils git chroot-util-linux chroot-gawk \
+      && echo XBPS_ALLOW_CHROOT_BREAKOUT=yes >> etc/conf \
+      && echo XBPS_CHROOT_CMD=none >> etc/conf
+RUN ./xbps-src binary-bootstrap-host

--- a/common/chroot-style/none.sh
+++ b/common/chroot-style/none.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+#
+# This chroot script uses symlinks to emulate being in a chroot,
+# While the chroot is actually the host machine itself
+# This is useful for privilege less environments as Docker containers
+#
+
+readonly MASTERDIR="$1"
+readonly DISTDIR="$2"
+readonly HOSTDIR="$3"
+readonly EXTRA_ARGS="$4"
+readonly CMD="$5"
+shift 5
+
+if [ -z "$MASTERDIR" -o -z "$DISTDIR" ]; then
+  echo "$0 MASTERDIR/DISTDIR not set"
+  exit 1
+fi
+
+msg_red() {
+    # error messages in bold/red
+    [ -n "$NOCOLORS" ] || printf >&2 "\033[1m\033[31m"
+    printf >&2 "=> ERROR: $@"
+    [ -n "$NOCOLORS" ] || printf >&2 "\033[m"
+}
+
+fake_mount() {
+  #
+  # Fake mount works by removing the dir, and replacing it with a symlink
+  # This created the illusion of a bind.
+  #
+
+  local FROM="$1";
+  local TO="$2"
+  if [ -d "$TO" ]; then
+    rmdir "$TO";
+    if [ -d "$TO" ]; then
+      msg_red "Can't mount $FROM to $TO because $TO is a non-empty dir\n";
+      exit 1;
+    fi
+  fi
+  ln -s "$FROM" "$TO";
+}
+
+fake_umount() {
+  #
+  # Remove the symlink and recreate the dir
+  #
+
+  rm "$1";
+  mkdir "$1";
+}
+
+check_explicit_setting() {
+  . etc/conf
+  if [ -z "${XBPS_ALLOW_CHROOT_BREAKOUT}" -o "${XBPS_ALLOW_CHROOT_BREAKOUT}" != "yes" ]; then
+    msg_red "You're trying to use chroot-style none, this chroot style however affects your host machine\n"
+    msg_red "If you're sure about this run 'echo XBPS_ALLOW_CHROOT_BREAKOUT=yes >> etc/conf'\n"
+    exit 1;
+  fi
+}
+
+check_masterdir_is_root() {
+  if [ "$(readlink "${MASTERDIR}")" != "/" ]; then
+    msg_red "masterdir (${MASTERDIR}) should be symlinked to /, can't continue\n";
+    exit 1;
+  fi
+}
+
+run_chroot() {
+  fake_mount $DISTDIR $MASTERDIR/void-packages;
+
+  if [ ! -z "$HOSTDIR" ]; then
+    fake_mount $HOSTDIR $MASTERDIR/host;
+  fi
+
+  local mounts=""
+  local from=""
+  local to=""
+  # xbps-src may send some other binds, parse them here
+  while getopts 'b:' c -- "$EXTRA_ARGS"; do
+    # Skip everything that's not a bind
+    [ "$c" = "b" ] || continue;
+
+    from="$(cut -d: -f1 <<< "$OPTARG")";
+    to="$(cut -d: -f2 <<< "$OPTARG")";
+    fake_mount "${from}" "${to}";
+    # Save created mounts so we can clean them up later
+    mounts+="${to} "
+  done
+
+  local old_pwd="${PWD}";
+  # To give the illusion we entered the chroot, cd to /
+  cd /;
+  # Tell xbps-src that we are "in the chroot"
+  # Start with `env` so our environment var's stay the same
+  env IN_CHROOT=1 $CMD $@;
+  # Save exit code for after clean up
+  local ret="$?";
+  # cd back to the old pwd, so everything is the same again
+  cd "${old_pwd}";
+
+  if [ ! -z "$HOSTDIR" ]; then
+    fake_umount $MASTERDIR/host;
+  fi
+
+  fake_umount $MASTERDIR/void-packages;
+
+  # "umount" on demand created "mounts"
+  for i in $mounts; do
+    fake_umount "$i";
+  done
+
+  # Exit with the returned exit code
+  exit "${ret}";
+}
+
+check_explicit_setting;
+check_masterdir_is_root;
+run_chroot "$@";

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -383,7 +383,7 @@ setup_pkg() {
     esac
 
     # Check if base-chroot is already installed.
-    if [ -z "$bootstrap" -a "z$show_problems" != "zignore-problems" ]; then
+    if [ -z "$bootstrap" -a "z$show_problems" != "zignore-problems" -a ! -f "${XBPS_MASTERDIR}/.xbps_manual_boostrap" ]; then
         check_installed_pkg base-chroot-0.1_1
         if [ $? -ne 0 ]; then
             msg_red "${pkg} is not a bootstrap package and cannot be built without it.\n"

--- a/xbps-src
+++ b/xbps-src
@@ -20,6 +20,10 @@ binary-bootstrap [arch]
     from this architecture, and its required xbps utilities. The <masterdir>
     will be initialized for chroot operations.
 
+binary-bootstrap-host
+    Install bootstrap packages from host repositories onto the host itself.
+    This can be used combined with chroot-style none
+
 bootstrap
     Build and install from source the bootstrap packages into <masterdir>.
 
@@ -319,6 +323,46 @@ install_bbootstrap() {
     chroot_prepare $XBPS_TARGET_PKG || msg_error "Failed to initialize chroot!\n"
     chroot_check
     chroot_handler clean
+}
+
+install_bbootstrap_host() {
+  if [ -z "${XBPS_ALLOW_CHROOT_BREAKOUT}" -o "${XBPS_ALLOW_CHROOT_BREAKOUT}" != "yes" ]; then
+    msg_red "You're trying to install bootstrap packages on your host, this may not be what you want\n"
+    msg_red "If you're sure about this run 'echo XBPS_ALLOW_CHROOT_BREAKOUT=yes >> etc/conf'\n"
+    exit 1;
+  fi
+
+  msg_normal "Installing bootstrap on host from binary package repositories...\n";
+  # Grab all requirements from base-chroot and filter out conflicting packages
+  local packages="$(xbps-query -Rx base-chroot | sed 's:>=.*::' | grep -vf <(xbps-query -l | awk '$1 == "ii" {sub(/-[^-]+$/,"",$2);print "^\\(chroot-\\)\\?"$2"$"}'))";
+  # Install non-conflicting packages
+  xbps-install -Sy ${packages};
+  msg_normal "Installed bootstrap successfully!\n"
+  if [ -d "$XBPS_MASTERDIR" ]; then
+    # builddir and destdir, may be removed if empty
+    [ -d "${XBPS_MASTERDIR}/builddir" ] && rmdir "${XBPS_MASTERDIR}/builddir";
+    [ -d "${XBPS_MASTERDIR}/destdir" ] && rmdir "${XBPS_MASTERDIR}/destdir";
+
+    rmdir "$XBPS_MASTERDIR" &>/dev/null;
+    if [ $? -ne 0 ]; then
+      ls -lisah $XBPS_MASTERDIR;
+      msg_error "Failed to remove masterdir is it not empty?\n"
+    fi
+  fi
+
+  ln -s / $XBPS_MASTERDIR &>/dev/null;
+  if [ $? -ne 0 ]; then
+    msg_error "Failed to symlink masterdir to / does the directory still exist?\n"
+  fi
+
+  msg_normal "Symlinked masterdir to root\n"
+
+  # Tell xbps-src we bootstrapped this manually without installing base-chroot
+  touch $XBPS_MASTERDIR/.xbps_manual_boostrap;
+
+  chroot_prepare || msg_error "Failed to initialize chroot!\n"
+  chroot_check
+  chroot_handler clean
 }
 
 reconfigure_bootstrap_pkgs() {
@@ -663,6 +707,9 @@ reconfigure_bootstrap_pkgs
 case "$XBPS_TARGET" in
     binary-bootstrap)
         install_bbootstrap ${XBPS_TARGET_PKG:=$XBPS_MACHINE}
+        ;;
+    binary-bootstrap-host)
+        install_bbootstrap_host;
         ;;
     bootstrap)
         # bootstrap from sources


### PR DESCRIPTION
This PR adds the chroot-style "none" which will basically build all packages on the host system, the use case for this is e.g. unprivileged Docker containers, but may also be used for travis, since we don't require _any_ privileges anymore :)

This also adds a `Dockerfile` which will build a building capable container, it's currently based on [`d.xr.to/base`](https://github.com/dxrto/base) which is a minimal Void docker container. it may be desired to move this out of this project, please advise.

cc: @the-maldridge 