### PR TITLE
rpi-kernel: update to 4.19.23

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,18 +1,18 @@
 # Template file for 'rpi-firmware'
-_githash="f0694b1ec66a88abab334c460f212ebf19ab7cd8"
+_githash="d095b96ac33de9eb4b95539cb3261f35a3c74509"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20190114
+version=20190218
 revision=1
-noarch=yes
+archs=noarch
 wrksrc="firmware-${_githash}"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=03b38adf9e04163ef3da1d8135a0e3f2393489738b99b55fd6113dcf48c4e719
+checksum=058c1c1411ef1830a9cf5faa29cada8dad89c2bc84ce1a449952ef56f8662fc0
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -1,15 +1,15 @@
 # Template file for 'rpi-kernel'
 #
 # We track the latest Raspberry Pi LTS kernel as that is what is used in the
-# official Raspbian distribution. This is currently 4.14:
+# official Raspbian distribution. This is currently 4.19:
 #
-#   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=197689
+#   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="28c5c6ab2a4a8ae0a4dffae2237da2e56cd943c9"
+_githash="e2d2941326922b63d722ebc46520c3a2287b675f"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.14.97
+version=4.19.23
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=9fa498c743dcd0db572ec2f2dd33354cd1bb1eef312747245908007ced8c6fed
+checksum=1de0667036ac8aad0762796a027a9e45c12204b7c4a09c1ee5080cfdea025b1a
 
 _kernver="${version}_${revision}"
 
@@ -27,8 +27,8 @@ noverifyrdeps=yes
 noshlibprovides=yes
 
 # RPi, RPi2, RPi3
-only_for_archs="armv6l armv6l-musl armv7l armv7l-musl aarch64 aarch64-musl"
-hostmakedepends="perl kmod uboot-mkimage libressl-devel bc"
+archs="armv6l* armv7l* aarch64*"
+hostmakedepends="perl kmod uboot-mkimage libressl-devel bc bison flex"
 makedepends="ncurses-devel"
 triggers="kernel-hooks"
 # These files could be modified when an external module is built.


### PR DESCRIPTION
Upstream has move to 4.19 kernel series.  rpi-firmware is also updated to match kernel version.