### PR TITLE
dracut-crypt-ssh: Require PEM when generating ssh key

### DIFF
--- a/srcpkgs/dracut-crypt-ssh/patches/fix_ssh-keygen.patch
+++ b/srcpkgs/dracut-crypt-ssh/patches/fix_ssh-keygen.patch
@@ -1,0 +1,13 @@
+diff --git modules/60crypt-ssh/module-setup.sh modules/60crypt-ssh/module-setup.sh
+index c3b6584..80e7dbe 100644
+--- modules/60crypt-ssh/module-setup.sh
++++ modules/60crypt-ssh/module-setup.sh
+@@ -40,7 +40,7 @@ install() {
+     
+     case ${state} in
+       GENERATE )
+-        ssh-keygen -t $keyType -f $osshKey -q -N "" || {
++        ssh-keygen -t $keyType -f $osshKey -q -N "" -m PEM || {
+           derror "SSH ${msgKeyType} key creation failed"
+           rm -rf "$tmpDir"
+           return 1

--- a/srcpkgs/dracut-crypt-ssh/template
+++ b/srcpkgs/dracut-crypt-ssh/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut-crypt-ssh'
 pkgname=dracut-crypt-ssh
 version=1.0.7
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="dracut"
 makedepends="libblkid-devel"


### PR DESCRIPTION
This is pulled from the upstream commit https://github.com/dracut-crypt-ssh/dracut-crypt-ssh/commit/2204f72479a42e36e13b7571315c8ad7f0c87c28 .

Newer versions of ssh-keygen (such as installed in Void) do not output a usable key for dropbearconvert anymore.  By using PEM format, this corrects the failure when executing this dracut module.

Tested and working on my servers.