### PR TITLE
New package: libibmad-1.3.13

### DIFF
--- a/srcpkgs/libibmad-devel
+++ b/srcpkgs/libibmad-devel
@@ -1,0 +1,1 @@
+libibmad

--- a/srcpkgs/libibmad/template
+++ b/srcpkgs/libibmad/template
@@ -1,0 +1,22 @@
+# Template file for 'libibmad'
+pkgname=libibmad
+version=1.3.13
+revision=1
+build_style=gnu-configure
+makedepends="rdma-core-devel"
+short_desc="OpenFabrics Alliance InfiniBand diagnostic and management library"
+maintainer="Rich Gannon <rich@richgannon.net>"
+license="GPL-2.0-or-later"
+homepage="https://openfabrics.org"
+distfiles="https://www.openfabrics.org/downloads/management/libibmad-${version}.tar.gz"
+checksum=17cdd721c81fecefc366601c46c55a4d44c93799980a0a34c271b12bc544520b
+
+libibmad-devel_package() {
+	depends="libibmad-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
libibmad is used for managing and diagnosing infiniband hardware and is used by several other related utilities.