### PR TITLE
qperf: Require rdma-core and libibmad for IB/RDMA support

### DIFF
--- a/srcpkgs/qperf/template
+++ b/srcpkgs/qperf/template
@@ -1,11 +1,12 @@
 # Template file for 'qperf'
 pkgname=qperf
 version=0.4.11
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake"
+makedepends="rdma-core-devel libibmad-devel"
 short_desc="Measure RDMA and TCP/UDP latency and throughput performance"
-maintainer="Rich G <rich@richgannon.net>"
+maintainer="Rich Gannon <rich@richgannon.net>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/linux-rdma/qperf"
 distfiles="https://github.com/linux-rdma/qperf/archive/v${version}.tar.gz"


### PR DESCRIPTION
This change will enable support measuring RDMA statistics with libibmad and rdma-core.