### PR TITLE
gnome-session: source profile for wayland sessions too

### DIFF
--- a/srcpkgs/gnome-session/patches/include-profile-env-variables.patch
+++ b/srcpkgs/gnome-session/patches/include-profile-env-variables.patch
@@ -1,0 +1,21 @@
+By default GNOME folks want us to put all stuff in /usr/share/gdm/env.d
+(which is a lot of effort for no good reason for us) or use the systemd
+specific /etc/environment.d to set environment variables. With this
+patch we just force gnome-session's hand to include the env variables
+of /etc/profile.
+
+--- gnome-session/gnome-session.in
++++ gnome-session/gnome-session.in
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ 
+ if [ "x$XDG_SESSION_TYPE" = "xwayland" ] &&
+    [ "x$XDG_SESSION_CLASS" != "xgreeter" ] &&
+@@ -25,4 +25,6 @@ if [ -n "$REGION" ]; then
+   export LC_PAPER=$REGION
+ fi
+ 
++source /etc/profile
++
+ exec @libexecdir@/gnome-session-binary "$@"

--- a/srcpkgs/gnome-session/template
+++ b/srcpkgs/gnome-session/template
@@ -1,18 +1,18 @@
 # Template file for 'gnome-session'
 pkgname=gnome-session
 version=3.30.1
-revision=1
+revision=2
 build_style=meson
-hostmakedepends="glib-devel intltool pkg-config xmlto"
 configure_args="-Dsystemd_journal=false"
+hostmakedepends="glib-devel intltool pkgconf xmlto"
 makedepends="elogind-devel gnome-desktop-devel gtk+3-devel json-glib-devel
  libglib-devel libICE-devel libSM-devel libXtst-devel startup-notification-devel
  upower-devel xtrans"
-depends="alsa-plugins-pulseaudio dconf desktop-file-utils
+depends="alsa-plugins-pulseaudio dconf desktop-file-utils bash
  gsettings-desktop-schemas hicolor-icon-theme polkit-elogind"
 short_desc="GNOME session management utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-homepage="http://www.gnome.org"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="https://gitlab.gnome.org/GNOME/gnome-session"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=eafe85972689186c7c6b5fe1d3bb4dc204a1e0e6b6e763e24b8fb43a40c07739


### PR DESCRIPTION
By default gnome-session doesn't source this. Since GDM Wayland
isn't launched from a shell it doesn't source profile either and
instead wants us to use /usr/share/gdm/env.d or /etc/enviroment.d
(which is systemd specific). So instead we force gnome-session's
hand to just source /etc/profile.

fixes #8613

Please test @glats