### PR TITLE
libaccounts-glib: use python3-gobject-devel

### DIFF
--- a/srcpkgs/libaccounts-glib/template
+++ b/srcpkgs/libaccounts-glib/template
@@ -1,11 +1,11 @@
 # Template file for 'libaccounts-glib'
 pkgname=libaccounts-glib
 version=1.24
-revision=1
+revision=2
 wrksrc="${pkgname}-VERSION_${version}-8948717702424ce15f4e23e5db2c8ce0799ec120"
 build_style=meson
 hostmakedepends="gtk-doc pkg-config glib-devel gobject-introspection vala"
-makedepends="sqlite-devel libxml2-devel libglib-devel python-gobject-devel
+makedepends="sqlite-devel libxml2-devel libglib-devel python3-gobject-devel
  check-devel"
 short_desc="GLib-based client library for the accounts database"
 maintainer="John Rowley <enterthevoid@codesector.co>"


### PR DESCRIPTION
A check that is inside of this specifically asks for python3.