### PR TITLE
bluez-alsa: install plugins into correct dir when cross compiling

### DIFF
--- a/srcpkgs/bluez-alsa/template
+++ b/srcpkgs/bluez-alsa/template
@@ -3,7 +3,8 @@ pkgname=bluez-alsa
 version=1.3.1
 revision=7
 build_style=gnu-configure
-configure_args="--enable-aac --disable-hcitop --enable-debug"
+configure_args="--enable-aac --disable-hcitop --enable-debug
+ --with-alsaplugindir=/usr/lib/alsa-lib"
 hostmakedepends="pkgconf automake libtool"
 makedepends="alsa-lib-devel fdk-aac-devel libbluetooth-devel libglib-devel
  ortp-devel sbc-devel"


### PR DESCRIPTION
resolves #9147