### PR TITLE
glibc: add C.UTF-8 locale

### DIFF
--- a/srcpkgs/glibc/patches/glibc-c-utf8-locale.patch
+++ b/srcpkgs/glibc/patches/glibc-c-utf8-locale.patch
@@ -1,0 +1,286 @@
+Short description: Add C.UTF-8 support.
+Author(s): Fedora glibc team <glibc@lists.fedoraproject.org>
+Origin: PATCH
+Upstream status: not-submitted
+
+This patch needs to upstream as part of Carlos O'Donell
+<carlos@redhat.com>'s work on enabling upstream C.UTF-8 support. This
+work is currently blocked on cleaning up the test results to prove that
+full code-point sorting is working as intended.
+
+Note that this patch does not provide full code-point sorting as
+expected.
+
+This patch needs to upstream as soon as possible since it would be nice
+to have this in F29 and fixed.
+
+From 2eda7b462b415105f5a05c1323372d4e39d46439 Mon Sep 17 00:00:00 2001
+From: Mike FABIAN <mfabian@redhat.com>
+Date: Mon, 10 Aug 2015 15:58:12 +0200
+Subject: [PATCH] Add a C.UTF-8 locale
+
+---
+ localedata/SUPPORTED |   1 +
+ localedata/locales/C | 238 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 239 insertions(+)
+ create mode 100644 localedata/locales/C
+
+diff --git a/localedata/SUPPORTED b/localedata/SUPPORTED
+index 8ca023e..2a78391 100644
+--- a/localedata/SUPPORTED
++++ b/localedata/SUPPORTED
+@@ -1,6 +1,7 @@
+ # This file names the currently supported and somewhat tested locales.
+ # If you have any additions please file a glibc bug report.
+ SUPPORTED-LOCALES=\
++C.UTF-8/UTF-8 \
+ aa_DJ.UTF-8/UTF-8 \
+ aa_DJ/ISO-8859-1 \
+ aa_ER/UTF-8 \
+diff --git a/localedata/locales/C b/localedata/locales/C
+new file mode 100644
+index 0000000..fdf460e
+--- /dev/null
++++ b/localedata/locales/C
+@@ -0,0 +1,238 @@
++escape_char /
++comment_char %
++% Locale for C locale in UTF-8
++
++LC_IDENTIFICATION
++title      "C locale"
++source     ""
++address    ""
++contact    ""
++email      "mfabian@redhat.com"
++tel        ""
++fax        ""
++language   "C"
++territory  ""
++revision   "1.0"
++date       "2015-08-10"
++%
++category  "i18n:2012";LC_IDENTIFICATION
++category  "i18n:2012";LC_CTYPE
++category  "i18n:2012";LC_COLLATE
++category  "i18n:2012";LC_TIME
++category  "i18n:2012";LC_NUMERIC
++category  "i18n:2012";LC_MONETARY
++category  "i18n:2012";LC_MESSAGES
++category  "i18n:2012";LC_PAPER
++category  "i18n:2012";LC_NAME
++category  "i18n:2012";LC_ADDRESS
++category  "i18n:2012";LC_TELEPHONE
++category  "i18n:2012";LC_MEASUREMENT
++END LC_IDENTIFICATION
++
++LC_CTYPE
++copy "i18n"
++
++translit_start
++include "translit_combining";""
++translit_end
++
++END LC_CTYPE
++
++LC_COLLATE
++order_start forward
++<U0000>
++..
++<UFFFF>
++<U10000>
++..
++<U1FFFF>
++<U20000>
++..
++<U2FFFF>
++<UE0000>
++..
++<UEFFFF>
++<UF0000>
++..
++<UFFFFF>
++<U100000>
++..
++<U10FFFF>
++UNDEFINED
++order_end
++END LC_COLLATE
++
++LC_MONETARY
++% This is the 14652 i18n fdcc-set definition for
++% the LC_MONETARY category
++% (except for the int_curr_symbol and currency_symbol, they are empty in
++% the 14652 i18n fdcc-set definition and also empty in
++% glibc/locale/C-monetary.c. But localedef complains in that case).
++%
++% Using "USD" for int_curr_symbol. But maybe "XXX" would be better?
++% XXX is "No currency" (https://en.wikipedia.org/wiki/ISO_4217)
++int_curr_symbol     "<U0055><U0053><U0044><U0020>"
++% Using "$" for currency_symbol. But maybe <U00A4> would be better?
++% U+00A4 is the "generic currency symbol"
++% (https://en.wikipedia.org/wiki/Currency_sign_%28typography%29)
++currency_symbol     "<U0024>"
++mon_decimal_point   "<U002E>"
++mon_thousands_sep   ""
++mon_grouping        -1
++positive_sign       ""
++negative_sign       "<U002D>"
++int_frac_digits     -1
++frac_digits         -1
++p_cs_precedes       -1
++int_p_sep_by_space  -1
++p_sep_by_space      -1
++n_cs_precedes       -1
++int_n_sep_by_space  -1
++n_sep_by_space      -1
++p_sign_posn         -1
++n_sign_posn         -1
++%
++END LC_MONETARY
++
++LC_NUMERIC
++% This is the POSIX Locale definition for
++% the LC_NUMERIC category.
++%
++decimal_point   "<U002E>"
++thousands_sep   ""
++grouping        -1
++END LC_NUMERIC
++
++LC_TIME
++% This is the POSIX Locale definition for
++% the LC_TIME category.
++%
++% Abbreviated weekday names (%a)
++abday       "<U0053><U0075><U006E>";"<U004D><U006F><U006E>";/
++            "<U0054><U0075><U0065>";"<U0057><U0065><U0064>";/
++            "<U0054><U0068><U0075>";"<U0046><U0072><U0069>";/
++            "<U0053><U0061><U0074>"
++
++% Full weekday names (%A)
++day         "<U0053><U0075><U006E><U0064><U0061><U0079>";/
++            "<U004D><U006F><U006E><U0064><U0061><U0079>";/
++            "<U0054><U0075><U0065><U0073><U0064><U0061><U0079>";/
++            "<U0057><U0065><U0064><U006E><U0065><U0073><U0064><U0061><U0079>";/
++            "<U0054><U0068><U0075><U0072><U0073><U0064><U0061><U0079>";/
++            "<U0046><U0072><U0069><U0064><U0061><U0079>";/
++            "<U0053><U0061><U0074><U0075><U0072><U0064><U0061><U0079>"
++
++% Abbreviated month names (%b)
++abmon       "<U004A><U0061><U006E>";"<U0046><U0065><U0062>";/
++            "<U004D><U0061><U0072>";"<U0041><U0070><U0072>";/
++            "<U004D><U0061><U0079>";"<U004A><U0075><U006E>";/
++            "<U004A><U0075><U006C>";"<U0041><U0075><U0067>";/
++            "<U0053><U0065><U0070>";"<U004F><U0063><U0074>";/
++            "<U004E><U006F><U0076>";"<U0044><U0065><U0063>"
++
++% Full month names (%B)
++mon         "<U004A><U0061><U006E><U0075><U0061><U0072><U0079>";/
++            "<U0046><U0065><U0062><U0072><U0075><U0061><U0072><U0079>";/
++            "<U004D><U0061><U0072><U0063><U0068>";/
++            "<U0041><U0070><U0072><U0069><U006C>";/
++            "<U004D><U0061><U0079>";/
++            "<U004A><U0075><U006E><U0065>";/
++            "<U004A><U0075><U006C><U0079>";/
++            "<U0041><U0075><U0067><U0075><U0073><U0074>";/
++            "<U0053><U0065><U0070><U0074><U0065><U006D><U0062><U0065><U0072>";/
++            "<U004F><U0063><U0074><U006F><U0062><U0065><U0072>";/
++            "<U004E><U006F><U0076><U0065><U006D><U0062><U0065><U0072>";/
++            "<U0044><U0065><U0063><U0065><U006D><U0062><U0065><U0072>"
++
++% Week description, consists of three fields:
++% 1. Number of days in a week.
++% 2. Gregorian date that is a first weekday (19971130 for Sunday, 19971201 for Monday).
++% 3. The weekday number to be contained in the first week of the year.
++%
++% ISO 8601 conforming applications should use the values 7, 19971201 (a
++% Monday), and 4 (Thursday), respectively.
++week    7;19971201;4
++first_weekday	1
++first_workday	1
++
++% Appropriate date and time representation (%c)
++%	"%a %b %e %H:%M:%S %Y"
++d_t_fmt "<U0025><U0061><U0020><U0025><U0062><U0020><U0025><U0065><U0020><U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U0059>"
++
++% Appropriate date representation (%x)
++%	"%m/%d/%y"
++d_fmt   "<U0025><U006D><U002F><U0025><U0064><U002F><U0025><U0079>"
++
++% Appropriate time representation (%X)
++%	"%H:%M:%S"
++t_fmt   "<U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053>"
++
++% Appropriate AM/PM time representation (%r)
++%	"%I:%M:%S %p"
++t_fmt_ampm "<U0025><U0049><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U0070>"
++
++% Equivalent of AM/PM (%p)      "AM"/"PM"
++%
++am_pm	"<U0041><U004D>";"<U0050><U004D>"
++
++% Appropriate date representation (date(1))   "%a %b %e %H:%M:%S %Z %Y"
++date_fmt	"<U0025><U0061><U0020><U0025><U0062><U0020><U0025><U0065><U0020><U0025><U0048><U003A><U0025><U004D><U003A><U0025><U0053><U0020><U0025><U005A><U0020><U0025><U0059>"
++END LC_TIME
++
++LC_MESSAGES
++% This is the POSIX Locale definition for
++% the LC_NUMERIC category.
++%
++yesexpr "<U005E><U005B><U0079><U0059><U005D>"
++noexpr  "<U005E><U005B><U006E><U004E><U005D>"
++yesstr  "<U0059><U0065><U0073>"
++nostr   "<U004E><U006F>"
++END LC_MESSAGES
++
++LC_PAPER
++% This is the ISO/IEC 14652 "i18n" definition for
++% the LC_PAPER category.
++% (A4 paper, this is also used in the built in C/POSIX
++% locale in glibc/locale/C-paper.c)
++height   297
++width    210
++END LC_PAPER
++
++LC_NAME
++% This is the ISO/IEC 14652 "i18n" definition for
++% the LC_NAME category.
++% "%p%t%g%t%m%t%f"
++% (also used in the built in C/POSIX locale in glibc/locale/C-name.c)
++name_fmt    "<U0025><U0070><U0025><U0074><U0025><U0067><U0025><U0074>/
++<U0025><U006D><U0025><U0074><U0025><U0066>"
++END LC_NAME
++
++LC_ADDRESS
++% This is the ISO/IEC 14652 "i18n" definition for
++% the LC_ADDRESS category.
++% "%a%N%f%N%d%N%b%N%s %h %e %r%N%C-%z %T%N%c%N"
++% (also used in the built in C/POSIX locale in glibc/locale/C-address.c)
++postal_fmt    "<U0025><U0061><U0025><U004E><U0025><U0066><U0025><U004E>/
++<U0025><U0064><U0025><U004E><U0025><U0062><U0025><U004E><U0025><U0073>/
++<U0020><U0025><U0068><U0020><U0025><U0065><U0020><U0025><U0072><U0025>/
++<U004E><U0025><U0043><U002D><U0025><U007A><U0020><U0025><U0054><U0025>/
++<U004E><U0025><U0063><U0025><U004E>"
++END LC_ADDRESS
++
++LC_TELEPHONE
++% This is the ISO/IEC 14652 "i18n" definition for
++% the LC_TELEPHONE category.
++% "+%c %a %l"
++tel_int_fmt    "<U002B><U0025><U0063><U0020><U0025><U0061><U0020><U0025>/
++<U006C>"
++% (also used in the built in C/POSIX locale in glibc/locale/C-telephone.c)
++END LC_TELEPHONE
++
++LC_MEASUREMENT
++% This is the ISO/IEC 14652 "i18n" definition for
++% the LC_MEASUREMENT category.
++% (same as in the built in C/POSIX locale in glibc/locale/C-measurement.c)
++%metric
++measurement    1
++END LC_MEASUREMENT
++
+-- 
+2.4.3
+

--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.29
-revision=1
+revision=2
 bootstrap=yes
 short_desc="GNU C library"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -54,7 +54,7 @@ makedepends="kernel-libc-headers"
 lib32files="/usr/lib/gconv/gconv-modules"
 lib32symlinks="ld-linux.so.2"
 # There's no point in building this for musl.
-only_for_archs="i686 x86_64 armv5tel armv6l armv7l aarch64 ppc ppc64le"
+archs="~*-musl"
 nopie=yes
 
 do_configure() {
@@ -186,7 +186,7 @@ glibc-devel_package() {
 	}
 }
 glibc-locales_package() {
-	noarch=yes
+	archs="noarch"
 	conf_files="/etc/default/libc-locales"
 	short_desc+=" - locale data files"
 	pkg_install() {


### PR DESCRIPTION
Patch taken from Fedora.  Debian also provides this locale.
musl has C.UTF-8 built-in.

Fix archs= in flyby.