### PR TITLE
moc: build with libsamplerate for resampling support

### DIFF
--- a/srcpkgs/moc/template
+++ b/srcpkgs/moc/template
@@ -1,13 +1,13 @@
 # Template file for 'moc'
 pkgname=moc
 version=2.5.2
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="db-devel ncurses-devel libcurl-devel popt-devel ffmpeg-devel
  jack-devel alsa-lib-devel libltdl-devel libflac-devel libvorbis-devel
  libmad-devel libmpcdec-devel libmodplug-devel libid3tag-devel faad2-devel
- taglib-devel libsndfile-devel wavpack-devel speex-devel"
+ taglib-devel libsndfile-devel wavpack-devel speex-devel libsamplerate-devel"
 short_desc="Console-based audio player"
 maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Helpful if you need to play music with various sampling rates via JACK without having to restart the server, or if the audio hardware doesn't support the sampling rate.