### PR TITLE
New package: yaru-r28

### DIFF
--- a/srcpkgs/yaru/template
+++ b/srcpkgs/yaru/template
@@ -1,0 +1,14 @@
+# Template file for 'yaru'
+pkgname=yaru
+version=r28
+revision=1
+archs=noarch
+build_style=meson
+hostmakedepends="glib-devel sassc pkg-config"
+makedepends="gtk+3-devel libglib-devel"
+short_desc="Default Ubuntu 18.10+ theme"
+maintainer="Dawid Potocki <dawidpotocki@disroot.org>"
+license="GPL-3.0-or-later, CC-BY-SA-4.0"
+homepage="https://github.com/ubuntu/yaru"
+distfiles="https://github.com/ubuntu/yaru/archive/$version.tar.gz"
+checksum=2948de72fafc468a2d646a5f1d0f45a544bd59d07f8ec516e02634b8a040d426


### PR DESCRIPTION
[Yaru](https://github.com/ubuntu/yaru) is a GTK and icon theme used by default in Ubuntu 18.10+. I personally need it to check how my programs would look under Ubuntu. I hope that I made template file right :P.