### PR TITLE
firefox: remove x11 wrapper.

### DIFF
--- a/srcpkgs/firefox/files/firefox-x11
+++ b/srcpkgs/firefox/files/firefox-x11
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export GDK_BACKEND=x11
-
-exec /usr/lib/firefox/firefox "$@"

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -4,7 +4,7 @@
 #
 pkgname=firefox
 version=65.0.1
-revision=1
+revision=2
 build_helper="rust"
 short_desc="Mozilla Firefox web browser"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
@@ -163,9 +163,5 @@ do_install() {
 	# https://bugzilla.mozilla.org/show_bug.cgi?id=658850
 	ln -sf firefox ${DESTDIR}/usr/lib/firefox/firefox-bin
 
-	vbin ${FILESDIR}/firefox-x11
 	vbin ${FILESDIR}/firefox-wayland
-
-	# Default to x11 for now, FF wayland is somewhat broken
-	ln -sf /usr/bin/firefox-x11 ${DESTDIR}/usr/bin/firefox
 }


### PR DESCRIPTION
x11 is already the default if not explicitly overwritten by GDK_BACKEND.