### PR TITLE
New package: perwindowlayout-0.6

### DIFF
--- a/srcpkgs/PerWindowLayout/template
+++ b/srcpkgs/PerWindowLayout/template
@@ -1,0 +1,13 @@
+# Template file for 'PerWindowLayout'
+pkgname=PerWindowLayout
+version=0.6
+revision=1
+wrksrc="perwindowlayoutd-${version}"
+build_style=gnu-configure
+makedepends="libX11-devel"
+short_desc="Per window keyboard layout under X11"
+maintainer="SolitudeSF <solitudesf@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://sourceforge.net/projects/perwindowlayout/"
+distfiles="${SOURCEFORGE_SITE}/perwindowlayout/perwindowlayoutd-${version}.tar.gz"
+checksum=982ae890e4885b5cbd720d00eab8b46294835afcbc7d8ded363beca56c203a12


### PR DESCRIPTION
project name is `perwindowlayout`, but tarball and binary name is `perwindowlayoutd`. which one is source of truth?