### PR TITLE
use reverts to update

### DIFF
--- a/srcpkgs/emacs-ess/template
+++ b/srcpkgs/emacs-ess/template
@@ -1,7 +1,8 @@
 # Template file for 'emacs-ess'
 pkgname=emacs-ess
+reverts="18.10r1_1"
 version=18.10.2
-revision=1
+revision=2
 archs=noarch
 wrksrc="ess-${version}"
 makedepends="emacs perl"

--- a/srcpkgs/luakit/template
+++ b/srcpkgs/luakit/template
@@ -1,7 +1,8 @@
 # Template file for 'luakit'
 pkgname=luakit
+reverts="2017.08.10_1"
 version=2.1
-revision=1
+revision=2
 conf_files="/etc/xdg/luakit/*.lua"
 hostmakedepends="pkg-config LuaJIT"
 makedepends="webkit2gtk-devel luafilesystem LuaJIT-devel"

--- a/srcpkgs/yabasic/template
+++ b/srcpkgs/yabasic/template
@@ -1,7 +1,8 @@
 # Template file for 'yabasic'
 pkgname=yabasic
+reverts="2.769_1"
 version=2.82.0
-revision=1
+revision=3
 build_style=gnu-configure
 makedepends="libXt-devel ncurses-devel"
 short_desc="Yet another Basic"


### PR DESCRIPTION
Some packages were updated to versions that xbps see as lower. Using `reverts` to update packages in index.