### PR TITLE
libapparmor-devel: don't depend on apparmor

### DIFF
--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.2
-revision=4
+revision=5
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure
@@ -87,7 +87,7 @@ libapparmor_package() {
 
 libapparmor-devel_package() {
 	short_desc+=" - Library development files"
-	depends="${sourcepkg}-${version}_${revision}"
+	depends="lib${sourcepkg}-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include/
 		vmove "usr/lib/*.a"


### PR DESCRIPTION
Before:
```
# xbps-install libapparmor-devel

Name                Action    Version           New version            Download size
runit-void-apparmor install   -                 20180623_2             -
libapparmor         install   -                 2.13.2_4               -
apparmor            install   -                 2.13.2_4               -
libapparmor-devel   install   -                 2.13.2_4               -
```
After:
```
# xbps-install libapparmor-devel

Name              Action    Version           New version            Download size
libapparmor       install   -                 2.13.2_5               -
libapparmor-devel install   -                 2.13.2_5               -
```