### PR TITLE
glib: update to 2.60.0.

### DIFF
--- a/srcpkgs/glib/template
+++ b/srcpkgs/glib/template
@@ -1,30 +1,28 @@
 # Template file for 'glib'
 pkgname=glib
-version=2.58.3
-revision=2
-build_style=gnu-configure
-configure_args="--enable-libelf --disable-fam --with-pcre=system --enable-static"
-hostmakedepends="automake libtool pkg-config python3 libxslt docbook-xsl"
+version=2.60.0
+revision=1
+build_style=meson
+configure_args="-Dfam=false -Dman=true -Dselinux=disabled
+ -Dgtk_doc=$(vopt_if gtk_doc true false)"
+hostmakedepends="pkg-config libxslt docbook-xsl $(vopt_if gtk_doc gtk-doc)"
 makedepends="zlib-devel pcre-devel libffi-devel dbus-devel elfutils-devel libmount-devel"
+checkdepends="desktop-file-utils shared-mime-info tzdata"
 short_desc="GNU library of C routines"
-maintainer="Juan RP <xtraeme@voidlinux.org>"
+maintainer="Rasmus Thomsen <oss@cogitri.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GLib"
 changelog="https://gitlab.gnome.org/GNOME/glib/raw/master/NEWS"
 distfiles="${GNOME_SITE}/glib/${version%.*}/glib-${version}.tar.xz"
-checksum=8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481
+checksum=20865d8b96840d89d9340fc485b4b1131c1bb24d16a258a22d642c3bb1b44353
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" glib-devel"
-	case "$XBPS_TARGET_MACHINE" in
-		mips*|ppc|ppc-musl)	# It seems mips/ppc autoconf cache is not read?
-			configure_args+=" glib_cv_stack_grows=no glib_cv_rtldglobal_broken=no glib_cv_uscore=no" ;;
-	esac
+build_options="gtk_doc"
+
+desc_option_gtk_doc="Build GTK API docs"
+
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gtk_doc"
 fi
-
-pre_configure() {
-	NOCONFIGURE=1 ./autogen.sh
-}
 
 libglib-devel_package() {
 	depends="${makedepends} glib>=${version}_${revision}"
@@ -35,7 +33,6 @@ libglib-devel_package() {
 		vmove usr/lib/glib-2.0
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-		vmove "usr/lib/*.a"
 	}
 }
 

--- a/srcpkgs/libglib-static/patches/gobject_init_on_demand.patch
+++ b/srcpkgs/libglib-static/patches/gobject_init_on_demand.patch
@@ -1,0 +1,91 @@
+Initialize the gobject system on demand, i.e. before it is
+expected to be initialized. Do this only once by checking
+a local static variable gobject_initialized.
+
+--- gobject/gtype.c	2016-08-17 17:20:47.000000000 +0200
++++ gobject/gtype.c	2016-09-01 21:56:31.777406646 +0200
+@@ -209,6 +209,9 @@
+ static gboolean				type_node_is_a_L		(TypeNode		*node,
+ 									 TypeNode		*iface_node);
+ 
++#if !defined(__GLIBC__)
++static void gobject_init (void);
++#endif
+ 
+ /* --- enumeration --- */
+ 
+@@ -2631,7 +2634,10 @@
+ 			     GTypeFlags			 flags)
+ {
+   TypeNode *node;
+-  
++ 
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (type_id > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -2749,6 +2755,9 @@
+   TypeNode *pnode, *node;
+   GType type = 0;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (parent_type > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -2804,6 +2813,9 @@
+   TypeNode *pnode, *node;
+   GType type;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   g_return_val_if_fail (parent_type > 0, 0);
+   g_return_val_if_fail (type_name != NULL, 0);
+@@ -3319,6 +3331,9 @@
+ {
+   TypeNode *node;
+   
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+   
+   node = lookup_type_node_I (type);
+@@ -4343,6 +4358,9 @@
+ void
+ g_type_init_with_debug_flags (GTypeDebugFlags debug_flags)
+ {
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+ 
+   if (debug_flags)
+@@ -4361,6 +4379,9 @@
+ void
+ g_type_init (void)
+ {
++#if !defined(__GLIBC__)
++  gobject_init();
++#endif 
+   g_assert_type_system_initialized ();
+ }
+ 
+@@ -4372,6 +4393,12 @@
+   TypeNode *node;
+   GType type;
+ 
++#if !defined(__GLIBC__)
++  static int gobject_initialized = 0;
++  if (gobject_initialized)
++    return;
++  gobject_initialized = 1;
++#endif
+   /* Ensure GLib is initialized first, see
+    * https://bugzilla.gnome.org/show_bug.cgi?id=756139
+    */

--- a/srcpkgs/libglib-static/patches/quark_init_on_demand.patch
+++ b/srcpkgs/libglib-static/patches/quark_init_on_demand.patch
@@ -1,0 +1,37 @@
+musl does not run ctors in the assumed order that glib-2.46 expects.
+Call g_quark_init() where it is expected to have been called.
+
+
+--- glib/gquark.c	2016-08-17 17:20:47.000000000 +0200
++++ glib/gquark.c	2016-08-30 07:49:13.298234757 +0200
+@@ -57,6 +57,9 @@
+ void
+ g_quark_init (void)
+ {
++  if (quark_ht)
++    return;
++
+   g_assert (quark_seq_id == 0);
+   quark_ht = g_hash_table_new (g_str_hash, g_str_equal);
+   quarks = g_new (gchar*, QUARK_BLOCK_SIZE);
+@@ -138,9 +141,12 @@
+     return 0;
+ 
+   G_LOCK (quark_global);
++#if !defined(__GLIBC__)
++  g_quark_init ();
++#endif
+   quark = GPOINTER_TO_UINT (g_hash_table_lookup (quark_ht, string));
+   G_UNLOCK (quark_global);
+
+   return quark;
+ }
+ 
+@@ -280,6 +286,7 @@
+   GQuark quark;
+   gchar **quarks_new;
+ 
++  g_quark_init ();
+   if (quark_seq_id % QUARK_BLOCK_SIZE == 0)
+     {
+       quarks_new = g_new (gchar*, quark_seq_id + QUARK_BLOCK_SIZE);

--- a/srcpkgs/libglib-static/template
+++ b/srcpkgs/libglib-static/template
@@ -1,0 +1,39 @@
+# Template file for 'libglib-static'
+#
+# This is only used for qemu-user-static until meson figures out building static
+# glib 2.60.0 via meson.
+#
+pkgname=libglib-static
+version=2.58.3
+revision=3
+wrksrc="glib-${version}"
+build_style=gnu-configure
+configure_args="--enable-libelf --disable-fam --disable-shared --with-pcre=system
+ --enable-static"
+hostmakedepends="automake libtool pkg-config python3 libxslt docbook-xsl"
+makedepends="zlib-devel pcre-devel libffi-devel dbus-devel elfutils-devel libmount-devel"
+depends="$makedepends"
+short_desc="GNU library of C routines"
+maintainer="Rasmus Thomsen <oss@cogitri.dev>"
+license="LGPL-2.1-or-later"
+homepage="https://wiki.gnome.org/Projects/GLib"
+changelog="https://gitlab.gnome.org/GNOME/glib/raw/master/NEWS"
+distfiles="${GNOME_SITE}/glib/${version%.*}/glib-${version}.tar.xz"
+checksum=8f43c31767e88a25da72b52a40f3301fefc49a665b56dc10ee7cc9565cbe7481
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" glib-devel"
+	case "$XBPS_TARGET_MACHINE" in
+		mips*|ppc|ppc-musl)	# It seems mips/ppc autoconf cache is not read?
+			configure_args+=" glib_cv_stack_grows=no glib_cv_rtldglobal_broken=no glib_cv_uscore=no" ;;
+	esac
+fi
+
+pre_configure() {
+	NOCONFIGURE=1 ./autogen.sh
+}
+
+post_install() {
+	rm -r $DESTDIR/usr/bin
+	rm -r $DESTDIR/usr/share
+}

--- a/srcpkgs/qemu-user-static/template
+++ b/srcpkgs/qemu-user-static/template
@@ -1,10 +1,10 @@
 # Template file for 'qemu-user-static'
 pkgname=qemu-user-static
 version=3.1.0
-revision=3
+revision=4
 wrksrc="qemu-${version}"
 hostmakedepends="pkg-config automake python"
-makedepends="dtc-devel libglib-devel pixman-devel libuuid-devel"
+makedepends="dtc-devel libglib-static pixman-devel libuuid-devel"
 short_desc="QEMU User-mode emulators (statically compiled)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"


### PR DESCRIPTION
We can't update yet because glib's static libs are broken,
which breaks qemu-user-static. See https://github.com/mesonbuild/meson/pull/3939