### PR TITLE
julia: rebuild against libgit2.so.28

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,7 +1,7 @@
 # Template file for 'julia'
 pkgname=julia
 version=1.1.0
-revision=1
+revision=2
 archs="i686* x86_64* ppc64le*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc USE_SYSTEM_LLVM=0 USE_LLVM_SHLIB=1


### PR DESCRIPTION
[ci skip] for building llvm.

Julia 1.1 now looks for libgit2.so at runtime; not sure why. This can be seen by
running `julia -e 'import Pkg; Pkg.instantiate()'`.