### PR TITLE
python-voluptuous: fix permissions

### DIFF
--- a/srcpkgs/python-voluptuous/template
+++ b/srcpkgs/python-voluptuous/template
@@ -1,7 +1,7 @@
 # Template file for 'python-voluptuous'
 pkgname=python-voluptuous
 version=0.11.5
-revision=1
+revision=2
 archs=noarch
 wrksrc="voluptuous-${version}"
 build_style=python-module
@@ -18,6 +18,7 @@ checksum=567a56286ef82a9d7ae0628c5842f65f516abcb496e74f3f59f1d7b28df314ef
 
 post_install() {
 	vlicense COPYING
+	chmod o+r -R ${DESTDIR}/usr/lib
 }
 
 python3-voluptuous_package() {


### PR DESCRIPTION
Otherwise pip fails to run with that package installed.