### PR TITLE
update to ver 2.10.8 rev 1

### DIFF
--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
-version=2.10.4
-revision=8
+version=2.10.8
+revision=1
 lib32disabled=yes
 build_style=gnu-configure
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool
@@ -19,7 +19,7 @@ maintainer="Kartik S <kartik.ynwa@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://www.gimp.org"
 distfiles="https://download.gimp.org/pub/gimp/v${version%.*}/gimp-${version}.tar.bz2"
-checksum=ffb0768de14a2631b3d7ed71f283731441a1b48461766c23f0574dce0706f192
+checksum=d849c1cf35244938ae82e521b92b720ab48b8e9ed092d5de92c2464ef5244b9b
 
 pre_configure() {
 	NOCONFIGURE=1 autoreconf -fi
@@ -60,7 +60,7 @@ gimp-python_package() {
 	pycompile_dirs="usr/lib/gimp/2.0"
 	short_desc+=" - Python2 bindings"
 	pkg_install() {
-		vmove usr/lib/gimp/2.0/python
-		vmove "usr/lib/gimp/2.0/plug-ins/*.py"
+		vmove "usr/lib/gimp/2.0/python"
+		vmove "usr/lib/gimp/2.0/plug-ins/*/*.py"
 	}
 }


### PR DESCRIPTION
Was working with some people in IRC the other day and got this to build.
Does not have any gegl-0.4.14 building issues.

Had to add a different path for /usr/lib/gimp/2.0/plug-ins/\*/\*.py - not entirely sure why that changed or if there's a way of stripping the directory.

I'm not a heavy Gimp user but this is better than the 2.10.4_7 which did not allow me to make new images.

If merged, gegl can probably be put back to 0.4.14 (I saw a downgrade to .12 in xbps)