### PR TITLE
boost: fix musl compatibility in is_running.hpp

### DIFF
--- a/srcpkgs/boost/patches/is_running.hpp-musl.patch
+++ b/srcpkgs/boost/patches/is_running.hpp-musl.patch
@@ -1,0 +1,32 @@
+From 502169a5adbb8125c92fbdc19a860b399018db6a Mon Sep 17 00:00:00 2001
+From: Jacob Barrett <jbarrett@pivotal.io>
+Date: Thu, 27 Sep 2018 07:36:03 -0700
+Subject: [PATCH] Changes still_active constant to support Solaris.
+
+The use of the WIFSTOPPED bits did not go far enough on Solaris. It
+is expected to also have a non-zero value in the next bytes. This
+new value is tested be valid on Linux, MacOS and Solaris.
+
+Fixes #51
+---
+ include/boost/process/detail/posix/is_running.hpp | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/include/boost/process/detail/posix/is_running.hpp b/include/boost/process/detail/posix/is_running.hpp
+index 0d431a912..1d92513d1 100644
+--- boost/process/detail/posix/is_running.hpp
++++ boost/process/detail/posix/is_running.hpp
+@@ -16,8 +16,11 @@ namespace boost { namespace process { namespace detail { namespace posix {
+ // Use the "stopped" state (WIFSTOPPED) to indicate "not terminated".
+ // This bit arrangement of status codes is not guaranteed by POSIX, but (according to comments in
+ // the glibc <bits/waitstatus.h> header) is the same across systems in practice.
+-constexpr int still_active = 0x7F;
+-static_assert(!WIFEXITED(still_active) && !WIFSIGNALED(still_active), "Internal Error");
++constexpr int still_active = 0x017f;
++static_assert(WIFSTOPPED(still_active), "Expected still_active to indicate WIFSTOPPED");
++static_assert(!WIFEXITED(still_active), "Expected still_active to not indicate WIFEXITED");
++static_assert(!WIFSIGNALED(still_active), "Expected still_active to not indicate WIFSIGNALED");
++static_assert(!WIFCONTINUED(still_active), "Expected still_active to not indicate WIFCONTINUED");
+ 
+ inline bool is_running(int code)
+ {

--- a/srcpkgs/boost/template
+++ b/srcpkgs/boost/template
@@ -1,7 +1,7 @@
 # Template file for 'boost'
 pkgname=boost
 version=1.69.0
-revision=1
+revision=2
 wrksrc="${pkgname}_${version//\./_}"
 hostmakedepends="bzip2-devel icu-devel python-devel python3-devel"
 makedepends="zlib-devel bzip2-devel icu-devel python-devel python3-devel"


### PR DESCRIPTION
Short version, `constexpr int still_active = 0x7F;` was wrong, should have been `constexpr int still_active = 0x017F`