### PR TITLE
mozjs60: update to 60.5.2.

### DIFF
--- a/srcpkgs/mozjs60/template
+++ b/srcpkgs/mozjs60/template
@@ -1,6 +1,6 @@
 # Template file for 'mozjs60'
 pkgname=mozjs60
-version=60.5.0
+version=60.5.2
 revision=1
 wrksrc="firefox-${version}"
 build_wrksrc=js/src
@@ -8,11 +8,11 @@ build_style=gnu-configure
 hostmakedepends="perl python pkg-config automake autoconf213 autoconf-archive"
 makedepends="icu-devel libffi-devel nspr-devel python-devel readline-devel zlib-devel"
 short_desc="Mozilla JavaScript interpreter and library (60.x series)"
-maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
+maintainer="Rasmus Thomsen <oss@cogitri.dev>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/js/"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
-checksum=1a1f69ee87092637f75aef7f3fa588b0eef0b2c8bcc160094a036450c49c4025
+checksum=b95585982225a5246b663298de2fed275179d9299c46790468c49b6eee08cea4
 patch_args="-Np1"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 
@@ -44,6 +44,12 @@ do_configure() {
 
 do_check() {
 	dist/bin/jsapi-tests
+}
+
+post_install() {
+	# Fix the '-include' directive, otherwise it tries to use the hosts' header
+	vsed 's|^Cflags:.*|Cflags: -include ${pc_sysrootdir}/${includedir}/mozjs-60/js/RequiredDefines.h -I${includedir}/mozjs-60|' \
+		-i ${DESTDIR}/usr/lib/pkgconfig/mozjs-60.pc
 }
 
 mozjs60-devel_package() {


### PR DESCRIPTION
Also fixes cross compilation of application which depend on mozjs60
via pkg-config