### PR TITLE
lollypop: update to 0.9.925

### DIFF
--- a/srcpkgs/lollypop/template
+++ b/srcpkgs/lollypop/template
@@ -1,19 +1,20 @@
 # Template file for 'lollypop'
 pkgname=lollypop
-version=0.9.924
+version=0.9.925
 revision=1
 # Gitlab upload tag hash
-_uhash=36a5107e745cbbbc87254de9613c5848
+_uhash=ef81ac8a37493bb94af9fdc63357ab4b
 archs=noarch
 build_style=meson
 pycompile_module="lollypop"
 hostmakedepends="git glib-devel gobject-introspection intltool itstool pkg-config"
 makedepends="gtk+3-devel python3-devel"
-depends="gst-libav libnotify libsecret python3-dbus python3-gobject
- python3-pylast python3-wikipedia python3-youtube-dl totem-pl-parser"
+depends="dconf gst-libav libnotify libsecret python3-dbus python3-gobject
+ python3-pylast python3-wikipedia python3-youtube-dl python3-Pillow
+ totem-pl-parser"
 short_desc="Music player for GNOME"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Lollypop"
 distfiles="https://gitlab.gnome.org/World/${pkgname}/uploads/${_uhash}/${pkgname}-${version}.tar.xz"
-checksum=b76754c28ec6ed2e5cbb4fe11c10882e0728fa8dee2269e4e167d4ccec036511
+checksum=20ac91d09a1ffd7a7cc43b184147c6d8c2f8b642ccedc57b4a1975698a1ed6e3


### PR DESCRIPTION
- lollypop needs python3-Pillow
- dconf is needed for storing settings