### PR TITLE
[WIP] gnome-control-center: update to 3.32.0.

### DIFF
--- a/srcpkgs/gnome-control-center/template
+++ b/srcpkgs/gnome-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-control-center'
 pkgname=gnome-control-center
-version=3.30.3
-revision=3
+version=3.32.0
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Dcheese=$(vopt_if cheese true false)"
@@ -23,7 +23,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-control-center"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=39615b45fee4b9662f9263d70ad4ad112cf828d5041c30ee1c00ed852b0b303e
+checksum=969f120c793c6eabf91f871b536a01b80685fdecf3c3912a1da760a32c7728c0
 
 build_options="cheese"
 desc_option_cheese="Add support for adding user account images with your webcam"


### PR DESCRIPTION
Needs gsettings schemas >= 3.32