### PR TITLE
libglib-devel: fix 32bit multilib install

### DIFF
--- a/srcpkgs/glib/template
+++ b/srcpkgs/glib/template
@@ -1,7 +1,7 @@
 # Template file for 'glib'
 pkgname=glib
 version=2.58.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libelf --disable-fam --with-pcre=system --enable-static"
 hostmakedepends="automake libtool pkg-config python3 libxslt docbook-xsl"
@@ -29,6 +29,7 @@ pre_configure() {
 libglib-devel_package() {
 	depends="${makedepends} glib>=${version}_${revision}"
 	short_desc+=" - development files"
+	lib32files="/usr/lib/glib-2.0/include/glibconfig.h"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/glib-2.0


### PR DESCRIPTION
I ran into an issue with `/usr/lib32/glib-2.0/include/glibconfig.h` missing when installing `libglib-devel-32bit` on an x86_64 system. I found a bug regarding it in the old voidlinux/void-packages repo. I'm not sure how to link tickets in the old repo in this one, so here is the link: https://github.com/voidlinux/void-packages/issues/7527.