### PR TITLE
New package: CImg 2.4.5

### DIFF
--- a/srcpkgs/CImg/template
+++ b/srcpkgs/CImg/template
@@ -1,0 +1,22 @@
+# Template file for 'CImg'
+pkgname=CImg
+version=2.4.5
+revision=1
+archs=noarch
+wrksrc="CImg-v.${version}"
+depends="libgraphicsmagick-devel fftw-devel"
+short_desc="Open-source C++ toolkit for image processing"
+maintainer="Robert Lowry <bobertlo@gmail.com>"
+license="CECILL-2.0, CECILL-C"
+homepage="http://cimg.eu"
+distfiles="https://framagit.org/dtschump/CImg/-/archive/v.${version}/CImg-v.${version}.tar.bz2"
+checksum=16351995f077b2eafac574897246a2abc0199f8103ed1c66b4334f88af7abc42
+
+do_install() {
+	vlicense Licence_CeCILL_V2-en.txt
+	vlicense Licence_CeCILL-C_V1-en.txt
+	vinstall CImg.h 644 usr/include
+	vmkdir usr/include/CImg
+	vcopy "plugins/*.h" usr/include/CImg
+}
+


### PR DESCRIPTION
Note: This package is only C++ headers, which depend on other image processing libraries.