### PR TITLE
New package: ensure-access-0.1.0

### DIFF
--- a/srcpkgs/ensure-access/template
+++ b/srcpkgs/ensure-access/template
@@ -1,0 +1,17 @@
+# Template file for 'ensure-access'
+pkgname=ensure-access
+version=0.1.0
+revision=1
+build_style=go
+go_import_path=github.com/Noah-Huppert/ensure-access
+hostmakedepends="git"
+short_desc="Tool which ensures permissions exists for files and directories"
+maintainer="Noah Huppert <contact@noahh.io>"
+license="MIT"
+homepage="https://github.com/Noah-Huppert/ensure-access"
+distfiles="https://github.com/Noah-Huppert/ensure-access/archive/v${version}.tar.gz"
+checksum=6bc6dace2aa7b808927e73e8270c7e497be386a60e3ede282cdaf8419b6bd8b5
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
https://github.com/Noah-Huppert/ensure-access

This tool is useful for guaranteeing that files in a directory have a minimum level of access. For example when a user on your server rsync's a change to a web server static directory but the permissions on their files are wrong and the web server can't read them.