### PR TITLE
stow: remove unnecessary dependency on perl-Stow

### DIFF
--- a/srcpkgs/stow/template
+++ b/srcpkgs/stow/template
@@ -1,17 +1,17 @@
 # Template file for 'stow'
 pkgname=stow
 version=2.2.2
-revision=1
+revision=2
 archs=noarch
 build_style=gnu-configure
-hostmakedepends="perl-Stow"
+make_check_target="test"
+hostmakedepends="perl"
 makedepends="${hostmakedepends}"
-checkdepends="perl-Test-Output perl-IO-stringy"
 depends="${makedepends}"
+checkdepends="perl-Test-Output perl-IO-stringy"
 short_desc="GNU Stow is a symlink manager"
 maintainer="Martin Harrigan <martinharrigan@gmail.com>"
 license="GPL-3"
 homepage="https://www.gnu.org/software/stow/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=e2f77649301b215b9adbc2f074523bedebad366812690b9dc94457af5cf273df
-make_check_target="test"


### PR DESCRIPTION
stow and perl-Stow both provide `/usr/bin/chkstow` and `/usr/bin/stow`. I don't know what the purpose of perl-Stow is. As nothing depends on it any more, perhaps it can be removed?