### PR TITLE
calicoctl: remove

### DIFF
--- a/srcpkgs/calicoctl/INSTALL.msg
+++ b/srcpkgs/calicoctl/INSTALL.msg
@@ -1,0 +1,1 @@
+calicoctl is no longer provided by Void Linux, and will be fully removed from the repos on 2019/04/14

--- a/srcpkgs/calicoctl/template
+++ b/srcpkgs/calicoctl/template
@@ -1,19 +1,8 @@
 # Template file for 'calicoctl'
 pkgname=calicoctl
 version=3.5.2
-revision=1
-build_style=go
-go_import_path="github.com/projectcalico/calicoctl"
-go_package="${go_import_path}/calicoctl"
-hostmakedepends="glide"
-short_desc="CLI tool for Project Calico"
-maintainer="Frank Steinborn <steinex@nognu.de>"
-license="Apache-2.0"
+revision=2
+build_style=meta
+short_desc="CLI tool for Project Calico (removed package)"
+license="metapackage"
 homepage="https://www.projectcalico.org"
-distfiles="https://github.com/projectcalico/calicoctl/archive/v${version}.tar.gz"
-checksum=a0a4a85dcdb72f54baf6d2f1b242682530215d5111a58330ec70781fedec1e0d
-
-pre_build() {
-	cd $GOSRCPATH
-	glide install
-}


### PR DESCRIPTION
Upstream maintains 5 different versions, writes to clusters running
calico should only happen with matching calicoctl. Remove, as it's
pointless to keep this updated while big deployments are often on older
versions of calico.