### PR TITLE
New package: WebTorrent-v0.20.0

### DIFF
--- a/srcpkgs/webtorrent-desktop/files/webtorrent-desktop.desktop
+++ b/srcpkgs/webtorrent-desktop/files/webtorrent-desktop.desktop
@@ -1,0 +1,29 @@
+[Desktop Entry]
+Name=WebTorrent
+Version=1.0
+GenericName=BitTorrent Client
+X-GNOME-FullName=WebTorrent
+Comment=Download and share files over BitTorrent
+Encoding=UTF-8
+Type=Application
+Icon=webtorrent-desktop
+Terminal=false
+Exec=WebTorrent %U
+TryExec=/usr/bin/WebTorrent
+StartupNotify=false
+Categories=Network;FileTransfer;P2P;
+MimeType=application/x-bittorrent;x-scheme-handler/magnet;x-scheme-handler/stream-magnet;
+
+Actions=CreateNewTorrent;OpenTorrentFile;OpenTorrentAddress;
+
+[Desktop Action CreateNewTorrent]
+Name=Create New Torrent...
+Exec=WebTorrent -n
+
+[Desktop Action OpenTorrentFile]
+Name=Open Torrent File...
+Exec=WebTorrent -o
+
+[Desktop Action OpenTorrentAddress]
+Name=Open Torrent Address...
+Exec=WebTorrent -u

--- a/srcpkgs/webtorrent-desktop/template
+++ b/srcpkgs/webtorrent-desktop/template
@@ -1,0 +1,40 @@
+# Template file for 'webtorrent-desktop'
+pkgname=webtorrent-desktop
+version=0.20.0
+revision=1
+archs="x86_64"
+hostmakedepends="git nodejs zip"
+short_desc="Streaming torrent application, desktop version"
+maintainer="destanyol <dani.estanyol@gmail.com>"
+license="MIT"
+homepage="https://webtorrent.io/desktop"
+distfiles="https://github.com/webtorrent/webtorrent-desktop/archive/v${version}.tar.gz"
+checksum=2eec644337f2e8a47187c54d702491e3b4c1f1236dae48cb494c4e99ba0a9796
+nopie=yes
+tags="torrent streaming"
+
+case "${XBPS_TARGET_MACHINE}" in
+	x86_64*) _target="x64";;
+	*) broken="This architecture is not currently supported by WebTorrent Desktop builds";;
+esac
+
+do_configure() {
+	sed -i 's/"buble": "^0.19.3"/"buble": "0.19.3"/g' package.json
+	sed -i 's/"parse-torrent": "^5.7.3"/"parse-torrent": "5.7.3"/g' package.json
+}
+
+do_build() {
+	npm install
+	npm run package -- linux --package=zip
+}
+
+do_install() {
+	vmkdir /opt/webtorrent-desktop
+	vcopy dist/WebTorrent-linux-${_target}/* /opt/webtorrent-desktop
+	vmkdir /usr/bin
+	ln -s /opt/webtorrent-desktop/WebTorrent ${DESTDIR}/usr/bin/
+	vmkdir usr/share/applications
+	vcopy ${FILESDIR}/webtorrent-desktop.desktop usr/share/applications/
+	vlicense LICENSE
+	vinstall static/WebTorrent.png 644 /usr/share/icons/hicolor/256x256/apps/ ${pkgname}.png
+}


### PR DESCRIPTION
The Travis tests for i686 does not build, I do not know why. It works for me on local and I cannot replicate the error.

As you can see, the template that is currently requested to be merged on this PR is only for x64. I can push the i686 one as well if you want but in this case I think that this PR should skip tests.