### PR TITLE
nix: fix sandbox-shell path

### DIFF
--- a/srcpkgs/nix/template
+++ b/srcpkgs/nix/template
@@ -1,15 +1,23 @@
 # Template file for 'nix'
 pkgname=nix
 version=2.2.1
-revision=2
+revision=3
 build_style=gnu-configure
-# Use /nix/var as suggested by the official Manual.
-configure_args="--localstatedir=/nix/var"
 hostmakedepends="autoconf automake curl libtool pkg-config flex"
 makedepends="boost-devel brotli-devel bzip2-devel gc-devel libcurl-devel
  liblzma-devel libressl-devel libsodium-devel pkg-config sqlite-devel
  libseccomp-devel editline-devel"
 depends="curl xz"
+short_desc="Purely functional package manager"
+maintainer="Juan RP <xtraeme@voidlinux.org>"
+license="LGPL-2.1-or-later"
+homepage="https://nixos.org/nix/"
+changelog="https://nixos.org/releases/${pkgname}/${pkgname}-${version}/manual/#sec-relnotes"
+distfiles="https://nixos.org/releases/${pkgname}/${pkgname}-${version}/${pkgname}-${version}.tar.xz"
+checksum=85f8d3518060803e44e51b1a9ada1a39cea904b36a632ba1844043a0b63be515
+
+# Use /nix/var as suggested by the official Manual.
+configure_args="--localstatedir=/nix/var --with-sandbox-shell=/bin/sh"
 # Default configuration file.
 conf_files="/etc/nix/nix.conf"
 # Create required build users/groups.
@@ -31,13 +39,6 @@ make_dirs="
 	/nix/var/nix/userpool 0755 root root
 	/nix/var/nix/db 0755 root root
 	/nix/store 1775 root nixbld"
-short_desc="Purely functional package manager"
-maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="LGPL-2.1-or-later"
-homepage="https://nixos.org/nix/"
-changelog="https://nixos.org/releases/${pkgname}/${pkgname}-${version}/manual/#sec-relnotes"
-distfiles="https://nixos.org/releases/${pkgname}/${pkgname}-${version}/${pkgname}-${version}.tar.xz"
-checksum=85f8d3518060803e44e51b1a9ada1a39cea904b36a632ba1844043a0b63be515
 
 case "${XBPS_TARGET_MACHINE}" in
 	armv[56]*)


### PR DESCRIPTION
This fixes #9805 which prevents newly-installed nix from working
as no sandbox shell has been set during the configure step.