### PR TITLE
gnome-desktop: add missing dependency to devel package

### DIFF
--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
 version=3.32.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dgnome-distributor=VoidLinux -Dudev=enabled
@@ -26,8 +26,10 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 gnome-desktop-devel_package() {
-	depends="libxkbfile-devel gsettings-desktop-schemas-devel>=3.12
-		gtk+3-devel ${sourcepkg}>=${version}_${revision}"
+	depends="gtk+3-devel gsettings-desktop-schemas-devel>=3.12
+	 gdk-pixbuf-devel iso-codes libX11-devel libglib-devel libseccomp-devel
+	 libxkbfile-devel xkeyboard-config eudev-libudev-devel"
+	 ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
The pkg-config file for gnome-desktop depends on libseccomp, without this dependency it will be incomplete and anything that depends on gnome-desktop will fail to find it.