### PR TITLE
erlang: disable hipe on musl.

### DIFF
--- a/srcpkgs/erlang/template
+++ b/srcpkgs/erlang/template
@@ -1,7 +1,7 @@
 # Template file for 'erlang'
 pkgname=erlang
 version=21.3
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc="otp-OTP-${version}"
 build_style=gnu-configure
@@ -20,7 +20,7 @@ checksum=64a6eea6c1dc2353ad80e29ef57f6ec4192c91478ac2b854d0417b6b2bf4d9bf
 build_options="x11"
 
 case "$XBPS_TARGET_MACHINE" in
-	x86_64-musl) broken="dlvsym not available" ;;
+	*-musl) configure_args+=" --disable-hipe" ;;
 esac
 
 pre_configure() {


### PR DESCRIPTION
Fixes builds on x86_64-musl by disabling hipe on musl. It's not enabled
on ARM already, so it's unaffected right now, but this blanket disables
it for musl so that other architectures won't be affected later if
they'd be picked up by the configure script.