### PR TITLE
Remove google-fonts conflict

### DIFF
--- a/srcpkgs/noto-fonts-emoji/template
+++ b/srcpkgs/noto-fonts-emoji/template
@@ -1,7 +1,7 @@
 # Template build file for 'noto-fonts-emoji'.
 pkgname=noto-fonts-emoji
 version=20180810
-revision=1
+revision=2
 archs=noarch
 _githash=07ad7f0f4dc1bfb03221c2004c7cc60c6b79b25e
 wrksrc="noto-emoji-${_githash}"
@@ -13,7 +13,6 @@ license="OFL-1.1"
 homepage="https://www.google.com/get/noto/"
 distfiles="https://github.com/googlei18n/noto-emoji/archive/${_githash}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=ec53029d47743d41c5979aa180353b9ce4652d76aac5f04fedac6990bf9c40a9
-conflicts="google-fonts-ttf>=0"
 
 do_install() {
 	vmkdir usr/share/fonts/noto


### PR DESCRIPTION
The emoji font is not provided by google-fonts, so no conflict should be set here.

Fixes #9928 