### PR TITLE
font-adobe-source-code-pro: update to 1.010

### DIFF
--- a/srcpkgs/font-adobe-source-code-pro/template
+++ b/srcpkgs/font-adobe-source-code-pro/template
@@ -1,21 +1,23 @@
 # Template file for 'font-adobe-source-code-pro'
 pkgname=font-adobe-source-code-pro
-version=2.030R
+version=1.010
 revision=1
-wrksrc="source-code-pro-${version}-ro-1.050R-it"
 archs=noarch
+build_style=fetch
 depends="font-util"
-font_dirs="/usr/share/fonts/OTF/"
 short_desc="Monospaced font family for user interface and coding environments"
 maintainer="Piero La Terza <platerza@protonmail.com>"
 license="OFL-1.1"
 homepage="https://adobe-fonts.github.io/source-code-pro/"
-distfiles="https://github.com/adobe-fonts/source-code-pro/archive/${version}-ro/1.050R-it.tar.gz"
-checksum=a4e4dd59b8e0a436b934f0f612c2e91b5932910c6d1c3b7d1a5a9f389c86302b
+distfiles="https://github.com/adobe-fonts/source-code-pro/releases/download/variable-fonts/SourceCodeVariable-Italic.otf
+ https://github.com/adobe-fonts/source-code-pro/releases/download/variable-fonts/SourceCodeVariable-Roman.otf"
+checksum="b2ca3a3c1fe0701ad74aa7c66c37972d07b1237197a816a1a5646c7e42a11353
+ af8fdd265f6208816fde44062a27b79ce2a594ded44ea96055a1655b6869992d"
+font_dirs="/usr/share/fonts/OTF/"
 
 do_install() {
-	for i in ${wrksrc}/OTF/*.otf; do
-		vinstall $i 644 usr/share/fonts/OTF/
+	for i in ${wrksrc}/*; do
+		vinstall $i 644 ${font_dirs}
 	done
 }
 


### PR DESCRIPTION
A note: the package was renamed #2084, ~6 months ago. This left a subpackage with the old name, so that people will get the new package when they update. What is the policy on how long before these get cleaned up?