### PR TITLE
sddm: respect system locale

### DIFF
--- a/srcpkgs/sddm/files/sddm/run
+++ b/srcpkgs/sddm/files/sddm/run
@@ -9,4 +9,7 @@ if [ -x /usr/bin/elogind-inhibit ]; then
                 string:org.freedesktop.login1 uint32:0
 fi
 
+# respect system locale
+[ -r /etc/locale.conf ] && . /etc/locale.conf && export LANG
+
 exec sddm 2>&1

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -1,7 +1,7 @@
 # Template file for 'sddm'
 pkgname=sddm
 version=0.18.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DBUILD_MAN_PAGES=1 -DNO_SYSTEMD=1 -DUSE_ELOGIND=1
  -DLOGIN_DEFS_PATH=${XBPS_SRCPKGDIR}/shadow/files/login.defs


### PR DESCRIPTION
sddm always defaults to en_US, sourcing `/etc/locale.conf` solves it.

Fixes: #9954