### PR TITLE
rpi-kernel: update to 4.19.29.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="c0e09b3420442df016ee7906985535d644481e4b"
+_githash="3667ae0605bfbed9e25bd48365457632cf660d78"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.27
+version=4.19.29
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=324fbf7069daed4047bbeb050413104f4f0914772ef57316b2774d3bb69816d9
+checksum=b868127a4e8a38d5f9433ddfb7628078a98ffacb042b545e93984f3460d17c8e
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]