### PR TITLE
MultiMC: have cmake install (almost) everything 

### DIFF
--- a/srcpkgs/MultiMC/files/MultiMC.sh
+++ b/srcpkgs/MultiMC/files/MultiMC.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/libexec/multimc/MultiMC -d ~/.multimc
+/usr/libexec/multimc/multimc -d ~/.multimc

--- a/srcpkgs/MultiMC/template
+++ b/srcpkgs/MultiMC/template
@@ -1,12 +1,13 @@
 # Template file for 'MultiMC'
 pkgname=MultiMC
 version=0.6.5
-revision=3
+revision=4
 wrksrc="${pkgname}5-${version}"
 _commithashnbt="4b305bbd2ac0e7a26987baf7949a484a87b474d4"
 _nbtversion="multimc-0.5.0"
 _quazipversion="multimc-2"
 build_style=cmake
+configure_args='-DMultiMC_BUILD_PLATFORM=Void -DMultiMC_LAYOUT=lin-system'
 hostmakedepends="openjdk xxd git-all"
 makedepends="qt5-devel qt5-x11extras-devel qt5-svg-devel gtk+-devel"
 depends="virtual?java-environment"
@@ -29,18 +30,13 @@ pre_configure() {
 	tar zxvf "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_quazipversion}.tar.gz" -C "${wrksrc}/libraries/quazip" --strip-components 1
 }
 
-do_install() {
-	vmkdir usr/bin
+post_install() {
 	vmkdir usr/libexec/multimc
-	vmkdir usr/share/multimc/jars
-	vcopy build/MultiMC usr/libexec/multimc
-	vcopy build/jars/*.jar usr/share/multimc/jars
-	vinstall build/libMultiMC_gui.so 755 /usr/lib
-	vinstall build/libMultiMC_rainbow.so 755 /usr/lib
-	vinstall build/libMultiMC_logic.so 755 /usr/lib
+	mv "${DESTDIR}/usr/bin/multimc" "${DESTDIR}/usr/libexec/multimc"
+	vbin "${FILESDIR}/MultiMC.sh" MultiMC
 	vinstall build/libMultiMC_nbt++.so 755 /usr/lib
-	vinstall build/libMultiMC_unpack200.so 755 /usr/lib
 	vinstall build/libMultiMC_quazip.so 755 /usr/lib
-	vinstall build/libMultiMC_iconfix.so 755 /usr/lib
-	vbin ${FILESDIR}/MultiMC.sh MultiMC
+	vinstall application/package/linux/multimc.desktop 644 /usr/share/applications
+	vsed -i "${DESTDIR}/usr/share/applications/multimc.desktop" -e 's/Exec=multimc/Exec=MultiMC/'
+	vinstall application/resources/multimc/scalable/multimc.svg 644 /usr/share/pixmaps
 }


### PR DESCRIPTION
I was trying to fix MultiMC not knowing where it's *.jar files where when I noticed a cmake configure_arg that does 90% of what we want, the catch is upstream wants the user's multimc dir to be ~/.local/share/multimc instead of ~/.multimc (what the script had been using.)

Note that despite installing the icon it doesn't appear to get used (by rofi at least, I don't know about other launchers.)