### PR TITLE
cronie: update to 1.5.4.

### DIFF
--- a/srcpkgs/cronie/template
+++ b/srcpkgs/cronie/template
@@ -1,6 +1,6 @@
 # Template file for 'cronie'
 pkgname=cronie
-version=1.5.3
+version=1.5.4
 revision=1
 build_style=gnu-configure
 configure_args="--with-inotify --without-selinux --with-pam
@@ -12,8 +12,8 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/cronie-crond/cronie"
 changelog="https://raw.githubusercontent.com/cronie-crond/cronie/master/NEWS"
-distfiles="${homepage}/releases/download/cronie-${version}/cronie-${version}.tar.gz"
-checksum=4f73b351273662f28bb392c34c1ca550d78eb97540ce3acc2d1d20548e1a2e7c
+distfiles="${homepage}/releases/download/cronie-${version}-final/cronie-${version}.tar.gz"
+checksum=af8970559cad4262f8ffd7ec72abf682d2dcce04fdfb8f206a71d96566aba882
 make_dirs="
 	/etc/cron.d 0755 root root
 	/etc/cron.hourly 0755 root root


### PR DESCRIPTION
This fixes upstream regression where only the first job is run.