### PR TITLE
R-cran-tibble: update to 2.1.1.

### DIFF
--- a/srcpkgs/R-cran-tibble/template
+++ b/srcpkgs/R-cran-tibble/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-tibble'
 pkgname=R-cran-tibble
-version=2.0.1
+version=2.1.1
 revision=1
 build_style=R-cran
 makedepends="R-cran-cli R-cran-crayon R-cran-pillar R-cran-rlang R-cran-pkgconfig"
@@ -9,7 +9,7 @@ short_desc="Simple Data Frames"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="MIT"
 homepage="http://tibble.tidyverse.org/"
-checksum=7ab2cc295eecf00a5310993c99853cd6622ad468e7a60d004b8a73957a713d13
+checksum=45c777e9fb3731cb15126ce67e70a71eac97022d59efdefc840742d920a03284
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
report for changes on 'R-cran-tibble' (mainpackage)
size=
-1793KB
+457KB
depends=
-glibc>=2.28_1
+glibc>=2.29_1
files=
-/usr/lib/R/library/tibble/help/figures/logo.svg