### PR TITLE
apache-tomcat: update to 9.0.17.

### DIFF
--- a/srcpkgs/apache-tomcat/template
+++ b/srcpkgs/apache-tomcat/template
@@ -1,6 +1,6 @@
 # Template file for 'apache-tomcat'
 pkgname=apache-tomcat
-version=9.0.16
+version=9.0.17
 revision=1
 wrksrc="${pkgname}-${version}-src"
 hostmakedepends="openjdk apache-ant"
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://tomcat.apache.org"
 distfiles="http://mirrors.gigenet.com/apache/tomcat/tomcat-9/v${version}/src/${pkgname}-${version}-src.tar.gz"
-checksum=43371139d18ca99a0f8a624dd61cec4ca8fa5e2fbdf8d65b987ac34b2fcc090b
+checksum=ed097c2d8f22b58abbbbe5626fb4d413160f4b520f3defb42fd5bdd9402d7896
 
 system_accounts="tomcat"
 make_dirs="/usr/share/${pkgname}/webapps 0755 tomcat tomcat \


### PR DESCRIPTION
@maldridge

changes on 'apache-tomcat' (mainpackage)
size=
-9478KB
+9489KB

changes on 'apache-tomcat-doc' (subpackage)
depends=
-apache-tomcat>=9.0.16_1
+apache-tomcat>=9.0.17_1
size=
-3195KB
+3210KB

changes on 'apache-tomcat-examples' (subpackage)
depends=
-apache-tomcat>=9.0.16_1
+apache-tomcat>=9.0.17_1

changes on 'apache-tomcat-host-manager' (subpackage)
depends=
-apache-tomcat>=9.0.16_1
+apache-tomcat>=9.0.17_1

changes on 'apache-tomcat-manager' (subpackage)
depends=
-apache-tomcat>=9.0.16_1
+apache-tomcat>=9.0.17_1