### PR TITLE
Clp: update to 1.17.1.

### DIFF
--- a/srcpkgs/Clp/template
+++ b/srcpkgs/Clp/template
@@ -1,6 +1,6 @@
 # Template file for 'Clp'
 pkgname=Clp
-version=1.16.12
+version=1.17.1
 revision=1
 build_style=gnu-configure
 depends="libClp>=${version}_${revision}"
@@ -9,7 +9,7 @@ maintainer="nexolight <snow.dream.ch@gmail.com>"
 license="EPL-1.0"
 homepage="http://projects.coin-or.org/Clp"
 distfiles="https://www.coin-or.org/Tarballs/${pkgname}/${pkgname}-${version}.tgz"
-checksum=48aa83686c18dbd833f9c4892f39c6228e21b8c65b5f2ab671e994e1ee551b52
+checksum=69c25eed9e9566537ffc7f0952a3a98019af11d35c4642467233c6f18040aff1
 
 libClp-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
changes on 'Clp' (mainpackage)
depends=
-libClp>=1.16.12_1
+libClp>=1.17.1_1

changes on 'libClp' (subpackage)
files=
-/usr/lib/libClp.so.1 -> /usr/lib/libClp.so.1.13.12
-/usr/lib/libClp.so.1.13.12
-/usr/lib/libClpSolver.so.1 -> /usr/lib/libClpSolver.so.1.13.12
-/usr/lib/libClpSolver.so.1.13.12
-/usr/lib/libCoinUtils.so.3 -> /usr/lib/libCoinUtils.so.3.10.15
-/usr/lib/libCoinUtils.so.3.10.15
-/usr/lib/libOsi.so.1 -> /usr/lib/libOsi.so.1.12.10
-/usr/lib/libOsi.so.1.12.10
-/usr/lib/libOsiClp.so.1 -> /usr/lib/libOsiClp.so.1.13.12
-/usr/lib/libOsiClp.so.1.13.12
-/usr/lib/libOsiCommonTests.so.1 -> /usr/lib/libOsiCommonTests.so.1.12.10
-/usr/lib/libOsiCommonTests.so.1.12.10
+/usr/lib/libClp.so.1 -> /usr/lib/libClp.so.1.14.1
+/usr/lib/libClp.so.1.14.1
+/usr/lib/libClpSolver.so.1 -> /usr/lib/libClpSolver.so.1.14.1
+/usr/lib/libClpSolver.so.1.14.1
+/usr/lib/libCoinUtils.so.3 -> /usr/lib/libCoinUtils.so.3.11.1
+/usr/lib/libCoinUtils.so.3.11.1
+/usr/lib/libOsi.so.1 -> /usr/lib/libOsi.so.1.13.3
+/usr/lib/libOsi.so.1.13.3
+/usr/lib/libOsiClp.so.1 -> /usr/lib/libOsiClp.so.1.14.1
+/usr/lib/libOsiClp.so.1.14.1
+/usr/lib/libOsiCommonTests.so.1 -> /usr/lib/libOsiCommonTests.so.1.13.3
+/usr/lib/libOsiCommonTests.so.1.13.3
size=
-4756KB
+4848KB

changes on 'libClp-devel' (subpackage)
depends=
-libClp>=1.16.12_1
+libClp>=1.17.1_1
files=
+/usr/include/coin/ClpCholeskyPardiso.hpp
+/usr/include/coin/ClpPEDualRowDantzig.hpp
+/usr/include/coin/ClpPEDualRowSteepest.hpp
+/usr/include/coin/ClpPEPrimalColumnDantzig.hpp
+/usr/include/coin/ClpPEPrimalColumnSteepest.hpp
+/usr/include/coin/ClpPESimplex.hpp
-/usr/lib/libClp.so -> /usr/lib/libClp.so.1.13.12
-/usr/lib/libClpSolver.so -> /usr/lib/libClpSolver.so.1.13.12
-/usr/lib/libCoinUtils.so -> /usr/lib/libCoinUtils.so.3.10.15
-/usr/lib/libOsi.so -> /usr/lib/libOsi.so.1.12.10
-/usr/lib/libOsiClp.so -> /usr/lib/libOsiClp.so.1.13.12
-/usr/lib/libOsiCommonTests.so -> /usr/lib/libOsiCommonTests.so.1.12.10
+/usr/lib/libClp.so -> /usr/lib/libClp.so.1.14.1
+/usr/lib/libClpSolver.so -> /usr/lib/libClpSolver.so.1.14.1
+/usr/lib/libCoinUtils.so -> /usr/lib/libCoinUtils.so.3.11.1
+/usr/lib/libOsi.so -> /usr/lib/libOsi.so.1.13.3
+/usr/lib/libOsiClp.so -> /usr/lib/libOsiClp.so.1.14.1
+/usr/lib/libOsiCommonTests.so -> /usr/lib/libOsiCommonTests.so.1.13.3