### PR TITLE
python3-mypy: add missing dependency on python3-typed-ast

### DIFF
--- a/srcpkgs/python3-mypy/template
+++ b/srcpkgs/python3-mypy/template
@@ -1,13 +1,13 @@
 # Template file for 'python3-mypy'
 pkgname=python3-mypy
 version=0.670
-revision=3
+revision=4
 archs=noarch
 wrksrc="mypy-${version}"
 build_style=python3-module
 pycompile_module="mypy"
 hostmakedepends="python3-setuptools"
-depends="python3-mypy_extensions"
+depends="python3-mypy_extensions python3-typed-ast"
 short_desc="Optional static typing for Python3"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="MIT"

--- a/srcpkgs/python3-typed-ast/template
+++ b/srcpkgs/python3-typed-ast/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-typed-ast'
+pkgname=python3-typed-ast
+version=1.3.1
+revision=1
+wrksrc="typed-ast-${version}"
+build_style=python3-module
+pycompile_module="typed_ast"
+hostmakedepends="python3-devel python3-setuptools"
+makedepends="python3-devel"
+short_desc="Ast module with type comment support"
+maintainer="whoami <whoami@systemli.org>"
+license="Apache-2.0"
+homepage="https://github.com/python/typed_ast"
+distfiles="${PYPI_SITE}/t/typed-ast/typed-ast-${version}.tar.gz"
+checksum=606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424
+nocross="https://travis-ci.org/void-linux/void-packages/jobs/509366923#L1009"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
```
$ mypy -h
Traceback (most recent call last):
  File "/usr/bin/mypy", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/home/user/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3126, in <module>
    @_call_aside
  File "/home/user/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3110, in _call_aside
    f(*args, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3139, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/home/user/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 581, in _build_master
    ws.require(__requires__)
  File "/home/user/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 898, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/user/.local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 784, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'typed-ast<1.4.0,>=1.3.1' distribution was not found and is required by mypy
```