### PR TITLE
jj: add missing hostmakedepend

### DIFF
--- a/srcpkgs/jj/template
+++ b/srcpkgs/jj/template
@@ -5,6 +5,7 @@ revision=1
 build_style=go
 go_import_path="github.com/tidwall/jj"
 go_package="${go_import_path}/cmd/jj"
+hostmakedepends="git"
 short_desc="JSON Stream Editor"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
 license="MIT"


### PR DESCRIPTION
Otherwise this fails with:

```
=> jj-1.2.2_1: running do_build ...
go: missing Git command. See https://golang.org/s/gogetcmd
```