### PR TITLE
New package: easyrsa-3.0.6

### DIFF
--- a/srcpkgs/easyrsa/template
+++ b/srcpkgs/easyrsa/template
@@ -1,0 +1,21 @@
+# Template file for 'easyrsa'
+pkgname=easyrsa
+version=3.0.6
+revision=1
+archs=noarch
+wrksrc=EasyRSA-v$version
+depends="libressl"
+short_desc="Simple shell based CA utility"
+maintainer="Adam Gausmann <agausmann@fastmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/OpenVPN/easy-rsa"
+distfiles="https://github.com/OpenVPN/easy-rsa/releases/download/v$version/EasyRSA-unix-v$version.tgz"
+checksum=cb29aed2d27824e59dbaad547f11dcab380a53c9fe05681249e804af436f1396
+conf_files="/etc/easyrsa/vars /etc/easyrsa/openssl-easyrsa.cnf /etc/easyrsa/x509-types/*"
+
+do_install() {
+	vinstall easyrsa 755 etc/easyrsa
+	vinstall openssl-easyrsa.cnf 644 etc/easyrsa
+	vinstall vars.example 644 etc/easyrsa vars
+	vcopy x509-types etc/easyrsa
+}


### PR DESCRIPTION
Re-added EasyRSA, since they have support for LibreSSL since v3.0.5. Tested on amd64 and works as expected.

Current issues:

- The previous maintainer was @Gottox. I did not want to presume that he would be willing to continue maintaining this package, so I put my own information; however, maybe it would be better if the current maintainer of the `openvpn` package (@xtraeme) took it.

- EasyRSA assumes that it will be installed in a single directory, with the script and configuration files adjacent. The previous package installed the script with `vbin` which broke the detection system built-in (it set the `EASYRSA` directory to `/bin`). For now, I've preferred to install the script in `/etc/easyrsa/` to avoid patching it downstream, but that is open for discussion.