### PR TITLE
New package: glider-0.7.0

### DIFF
--- a/srcpkgs/glider/files/glider/run
+++ b/srcpkgs/glider/files/glider/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec chpst -u nobody:nogroup glider -config /etc/glider/config

--- a/srcpkgs/glider/template
+++ b/srcpkgs/glider/template
@@ -1,0 +1,24 @@
+# Template file for 'glider'
+pkgname=glider
+version=0.7.0
+revision=1
+build_style=go
+go_import_path=github.com/nadoo/glider
+hostmakedepends="git"
+short_desc="Forward proxy with multiple protocols support"
+maintainer="whoami <whoami@systemli.org>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/nadoo/glider"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=6289b1b202849bfc0b00c74955535522cc1113ae8ccc6614a9493407fcacee35
+conf_files="/etc/glider/config /etc/glider/rules.d/*"
+
+post_install() {
+	vmkdir etc/glider/rules.d
+	vmkdir usr/share/examples/glider
+	vcopy "config/examples/*" usr/share/examples/glider
+	vcopy config/glider.conf.example etc/glider/config
+	vcopy config/rules.d etc/glider
+	vsv glider
+	vlicense LICENSE
+}


### PR DESCRIPTION
this app replaces me http/socks proxy server, shadowsocks proxy client/server, dns forwarder and it can combine any proxy chains, for traffic obfuscation for example. it can forward requests to .onion, .i2p domains to upstream proxy

https://github.com/nadoo/glider/releases/tag/v0.7.0