### PR TITLE
telegram-desktop: disable auto update

### DIFF
--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
 version=1.6.1
-revision=1
+revision=2
 _libtgvoip_commit=16711e202393ae7e1b160436f4291c5f06a3d375
 _GSL_commit=d846fe50a3f0bb7767c7e087a05f4be95f4da0ec
 _variant_commit=550ac2f159ca883d360c196149b466955c77a573
@@ -39,7 +39,7 @@ checksum="eb092e6752c3802250f54f95af39d2e7c2f346a587caff8e8dc501d91c3de5b4
 build_options="clang custom_api_id pulseaudio"
 build_options_default="pulseaudio custom_api_id"
 
-CXXFLAGS="-DTDESKTOP_API_ID=209235 -DTDESKTOP_API_HASH=169ee702e1df4b6e66d80311db36cc43"
+CXXFLAGS="-DTDESKTOP_API_ID=209235 -DTDESKTOP_API_HASH=169ee702e1df4b6e66d80311db36cc43 -DTDESKTOP_DISABLE_AUTOUPDATE=1"
 
 if [ "$build_option_clang" ]; then
 	CFLAGS="-fPIE -fPIC -fstack-protector-strong"


### PR DESCRIPTION
Autoupdate at default doesn't work, because the binaries are handled via xbps