### PR TITLE
glusterfs: update to 5.5

### DIFF
--- a/srcpkgs/glusterfs/template
+++ b/srcpkgs/glusterfs/template
@@ -1,6 +1,6 @@
 # Template file for 'glusterfs'
 pkgname=glusterfs
-version=5.3
+version=5.5
 revision=1
 build_style=gnu-configure
 configure_args="--disable-glupy --enable-crypt-xlator
@@ -8,17 +8,17 @@ configure_args="--disable-glupy --enable-crypt-xlator
  ac_cv_file__etc_SuSE_release=no ac_cv_file__etc_redhat_release=no
  ac_cv_file__etc_centos_release=no"
 pycompile_dirs="/usr/libexec/glusterfs/python/syncdaemon"
-hostmakedepends="automake flex libtool pkg-config python"
-makedepends="acl-devel fuse-devel libaio-devel liblvm2app-devel libressl-devel
- liburcu-devel libxml2-devel rdma-core-devel sqlite-devel"
+hostmakedepends="automake flex libtool pkg-config python3"
+makedepends="acl-devel fuse3-devel libaio-devel libtirpc-devel liblvm2app-devel
+ libressl-devel liburcu-devel libxml2-devel rdma-core-devel sqlite-devel"
 # python is required by gsyncd.
-depends="python"
+depends="python3"
 short_desc="Free and open source software scalable network filesystem (client)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-3.0-only"
 homepage="http://www.gluster.org/"
 distfiles="https://download.gluster.org/pub/gluster/glusterfs/${version%.*}/${version}/${pkgname}-${version}.tar.gz"
-checksum=293542b1f43e681741282d1ba2aefe9b501321c782e896f518cca36072414448
+checksum=781da2e9e955eec6b411abd8df5851353936e5cc6f6aef9b8e6c8b970610cdf4
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="not yet supported";;


### PR DESCRIPTION
Updated Gluster to latest upstream version.
Included libtirpc support.
Switch from python2 to python3.
Switch from fuse2 to fuse3.

Tested on my Gluster environment with no issues.