### PR TITLE
syncthing: update to 1.1.0.

### DIFF
--- a/srcpkgs/syncthing/template
+++ b/srcpkgs/syncthing/template
@@ -1,8 +1,9 @@
 # Template file for 'syncthing'
 pkgname=syncthing
 version=1.1.0
-revision=1
+revision=2
 build_style=go
+wrksrc=syncthing
 go_import_path="github.com/syncthing/syncthing"
 go_package="${go_import_path}/cmd/strelaysrv ${go_import_path}/cmd/syncthing"
 go_build_tags="noupgrade"
@@ -13,11 +14,21 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MPL-2.0"
 #changelog="https://github.com/syncthing/syncthing/releases"
 homepage="http://syncthing.net/"
-distfiles="https://github.com/syncthing/${pkgname}/archive/v${version}.tar.gz"
-checksum=e5503640568c852a2aba03534b800021d0c531455c294718e8b2586c6807e29e
+distfiles="https://github.com/syncthing/${pkgname}/releases/download/v${version}/syncthing-source-v${version}.tar.gz"
+checksum=6565fd30d704f7039d350c522875925acc287c8e45e18a7d42f22512860a7ac6
 
 pre_build() {
 	GOARCH= go run script/genassets.go gui > ./lib/auto/gui.files.go
+}
+
+do_build() {
+	go_package=${go_package:-$go_import_path}
+	go_mod_mode=vendor
+	go run -mod="${go_mod_mode}" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}" build.go
+}
+
+do_install() {
+	vbin bin/syncthing
 }
 
 post_install() {
@@ -38,7 +49,7 @@ syncthing-relaysrv_package() {
 	 /var/lib/relaysrv 700 relaysrv relaysrv"
 
 	pkg_install() {
-		vmove usr/bin/strelaysrv
+		vbin bin/strelaysrv
 		vlicense cmd/strelaysrv/LICENSE
 		vsv relaysrv
 	}


### PR DESCRIPTION
Using the default build method and the github tagged releases results in syncthing to report its version as `unknown-dev`. 
This becomes a problem because some features only work when the client correctly reports it's own version (i.e. symlinks don't get synced unless the version reported is higher than 0.14)

Using the [official release archive](https://forum.syncthing.net/t/source-tar-archive-is-missing-release-file/11478/3) fixes this issue but you have to [use the supplied build.go file](https://docs.syncthing.net/dev/building.html#building-unix) for it to work.