### PR TITLE
firefox-esr: fix build with rust 1.33

### DIFF
--- a/srcpkgs/firefox-esr/patches/rust133.patch
+++ b/srcpkgs/firefox-esr/patches/rust133.patch
@@ -1,0 +1,24 @@
+This fixes build errors under recent Rust.
+
+--- servo/components/style_traits/lib.rs
++++ servo/components/style_traits/lib.rs
+@@ -9,7 +9,7 @@
+ #![crate_name = "style_traits"]
+ #![crate_type = "rlib"]
+ 
+-#![deny(unsafe_code, missing_docs)]
++#![deny(unsafe_code)]
+ 
+ extern crate app_units;
+ #[macro_use] extern crate bitflags;
+--- servo/components/style/lib.rs
++++ servo/components/style/lib.rs
+@@ -23,8 +23,6 @@
+ //! [cssparser]: ../cssparser/index.html
+ //! [selectors]: ../selectors/index.html
+ 
+-#![deny(missing_docs)]
+-
+ extern crate app_units;
+ extern crate arrayvec;
+ extern crate atomic_refcell;


### PR DESCRIPTION
This is the same patch that was previously applied to thunderbird.