### PR TITLE
[UNTESTED] csound: unset nocross, set arm* to broken

### DIFF
--- a/srcpkgs/csound/template
+++ b/srcpkgs/csound/template
@@ -18,7 +18,10 @@ license="LGPL-2.1-or-later"
 homepage="https://csound.com/"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/${version}.tar.gz"
 checksum=39f4872b896eb1cbbf596fcacc0f2122fd3e5ebbb5cec14a81b4207d6b8630ff
-nocross=yes
+
+case "$XBPS_TARGET_MACHINE" in
+	arm*) broken=yes;;
+esac
 
 CXXFLAGS="-Wno-error"
 


### PR DESCRIPTION
it at least cross compiles to aarch64, armv7l doesn't compile haven't looked at it yet