### PR TITLE
godot: update to 3.1

### DIFF
--- a/srcpkgs/godot/patches/10-fix-musl.patch
+++ b/srcpkgs/godot/patches/10-fix-musl.patch
@@ -11,17 +11,3 @@
  #define LONG_BITS (sizeof(long) * 8)
  #define test_bit(nr, addr) (((1UL << ((nr) % LONG_BITS)) & ((addr)[(nr) / LONG_BITS])) != 0)
  #define NBITS(x) ((((x)-1) / LONG_BITS) + 1)
-
-diff --git thirdparty/thekla_atlas/nvmath/nvmath.h thirdparty/thekla_atlas/nvmath/nvmath.h
-index f2b6942..5b15bd1 100644
---- thirdparty/thekla_atlas/nvmath/nvmath.h
-+++ thirdparty/thekla_atlas/nvmath/nvmath.h
-@@ -196,7 +196,7 @@ namespace nv
-     {
- #if NV_OS_WIN32 || NV_OS_XBOX || NV_OS_DURANGO
-         return _isnan(f) != 0;
--#elif NV_OS_DARWIN || NV_OS_FREEBSD || NV_OS_OPENBSD || NV_OS_ORBIS
-+#elif NV_OS_DARWIN || NV_OS_FREEBSD || NV_OS_OPENBSD || NV_OS_ORBIS || !defined(__GLIBC__)
-         return isnan(f);
- #elif NV_OS_LINUX
-         return isnanf(f);

--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,22 +1,22 @@
 # Template file for 'godot'
 pkgname=godot
-version=3.0.6
+version=3.1
 revision=2
 wrksrc="${pkgname}-${version}-stable"
 build_style=scons
 # Godot contains private copies of libraries
 # that already have been packaged elsewhere.
-make_build_args="use_llvm=yes platform=x11 tools=yes target=release_debug dev=no progress=no pulseaudio=no"
+make_build_args="platform=x11 tools=yes target=release_debug dev=no progress=no pulseaudio=no"
 hostmakedepends="pkg-config clang"
 makedepends="
  alsa-lib-devel freetype-devel glu-devel libXcursor-devel libXi-devel
  libXinerama-devel libXrender-devel libXrandr-devel libressl-devel libX11-devel"
-short_desc="A multiplatform 2D and 3D engine"
+short_desc="Multiplatform 2D and 3D engine"
 maintainer="Nick Hahn <nick.hahn@hotmail.de>"
 license="MIT"
 homepage="https://www.godotengine.org/"
 distfiles="https://github.com/godotengine/${pkgname}/archive/${version}-stable.tar.gz"
-checksum=50431e021ee5ec21002cc23435f530f8fde518c6eb7085c9f7f1027abaae2581
+checksum=cd66354b2397f28193ba3add8d8cc5c3562775f662887b56f16de82974f041e3
 nocross=https://build.voidlinux.eu/builders/armv7l_builder/builds/6342/steps/shell_3/logs/stdio
 
 CFLAGS+=" -fPIE -fPIC"
@@ -37,7 +37,7 @@ do_install() {
 	vinstall ${wrksrc}/logo.png 644 /usr/share/pixmaps/ godot.png
 
 	case "$XBPS_TARGET_MACHINE" in
-		x86_64*|aarch64*|ppc64*) vbin bin/godot.x11.opt.tools.64.llvm godot;;
-		*) vbin bin/godot.x11.opt.tools.32.llvm godot;;
+		x86_64*|aarch64*|ppc64*) vbin bin/godot.x11.opt.tools.64 godot;;
+		*) vbin bin/godot.x11.opt.tools.32 godot;;
 	esac
 }


### PR DESCRIPTION
* nvmath.h patch is not necessary anymore (it uses isnan for linux now)
* fixed lint error on short_desc
* clang doesn't support -fstack-clash-protection so I have to strip it out of cflags. exporting stripped CFLAGS or adding them to make args didn't work so I had to make this little clang++ wrapper script