### PR TITLE
simh: fix segfault with vax guests

### DIFF
--- a/srcpkgs/simh/template
+++ b/srcpkgs/simh/template
@@ -1,7 +1,7 @@
 # Template file for 'simh'
 pkgname=simh
 version=3.9
-revision=1
+revision=2
 wrksrc=${pkgname}-${version}
 create_wrksrc=yes
 hostmakedepends="libpcap-devel unzip"
@@ -10,8 +10,9 @@ short_desc="Emulator for historical computers including PDP-11 and VAX"
 maintainer="Daniel James <djames@orcadian.net>"
 license="MIT"
 homepage="http://simh.trailing-edge.com/"
-distfiles="http://simh.trailing-edge.com/sources/simhv39-0.zip"
+distfiles="http://simh.trailing-edge.com/sources/simhv${version/.}-0.zip"
 checksum=e49b259b66ad6311ca9066dee3d3693cd915106a6938a52ed685cdbada8eda3b
+nopie=yes
 
 do_build() {
 	mkdir -p BIN


### PR DESCRIPTION
I also fixed the distfiles version. 

There is a v3.10 release available as of last month, but the author did not provide a tarball/zip/etc, so I contacted them asking to provide one.