### PR TITLE
[UNTESTED] cross-arm-none-eabi: don't strip target binaries

### DIFF
--- a/srcpkgs/cross-arm-none-eabi/template
+++ b/srcpkgs/cross-arm-none-eabi/template
@@ -8,7 +8,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.3
-revision=2
+revision=3
 short_desc="GNU cross bare metal toolchain"
 maintainer="Thomas Bernard <thomas@famillebernardgouriou.fr>"
 homepage="https://www.voidlinux.org/"
@@ -346,10 +346,6 @@ do_install() {
 
 	cd ${wrksrc}/newlib-build
 	make DESTDIR=${DESTDIR} install
-
-	# strip target binaries
-	find ${DESTDIR}/${_sysroot}/usr/lib \( -name "*.a" -or -name "*.o" \) -exec ${_triplet}-strip '{}' \;
-	find ${DESTDIR}/usr/lib/gcc/${_triplet}/${_gcc_version} \( -name "*.a" -or -name "*.o" \) -exec ${_triplet}-strip '{}' \;
 
 	# strip host binaries
 	find ${DESTDIR}/usr/lib/gcc/${_triplet}/${_gcc_version} -type f -and \( -executable \) -exec /usr/bin/strip '{}' \;


### PR DESCRIPTION
[skip ci]

This PR should fix #1824. You can use [this project][0] for testing.

[0]: https://github.com/elmot/stm32f3-cpp-example 