### PR TITLE
libpeas: fix python loader

### DIFF
--- a/srcpkgs/libpeas/template
+++ b/srcpkgs/libpeas/template
@@ -1,26 +1,31 @@
 # Template file for 'libpeas'
 pkgname=libpeas
 version=1.22.0
-revision=2
+revision=3
 build_style=gnu-configure
 build_helper="gir"
-hostmakedepends="pkg-config intltool glib-devel"
-makedepends="vala-devel gtk+3-devel python-gobject-devel
- python3-gobject-devel"
-depends="python-gobject hicolor-icon-theme gjs>=1.38"
+hostmakedepends="pkg-config intltool glib-devel python python3 lua51"
+makedepends="vala-devel gtk+3-devel python3-gobject-devel python-gobject-devel
+ glade3-devel lua51-devel"
+depends="python3-gobject hicolor-icon-theme gjs>=1.38
+ $(vopt_if python2 python-gobject)"
 short_desc="Gobject-based plugins engine"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-2"
-homepage="http://www.gtk.org/"
+license="LGPL-2.1-or-later"
+homepage="https://wiki.gnome.org/Projects/Libpeas"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=5b2fc0f53962b25bca131a5ec0139e6fef8e254481b6e777975f7a1d2702a962
-
-LDFLAGS="-lpython2.7 -lpython3.6m"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686-musl|x86_64-musl) ;;
 	*-musl) broken="gobject-introspection" ;;
 esac
+
+pre_build() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed 's|tests||g' -i Makefile
+	fi
+}
 
 post_install() {
 	# Remove demo.
@@ -37,5 +42,6 @@ libpeas-devel_package() {
 		vmove "usr/lib/*.so"
 		vmove usr/share/gir-1.0
 		vmove usr/share/gtk-doc
+		vmove usr/share/glade
 	}
 }


### PR DESCRIPTION
Simply linking against both python versions doesn't work, we get the error
'Attempting to mix incompatible Python versions' upon loading Python plugins.
Also enables glade catalog generation while we're at it.

Gonna ask Upstream about this tomorrow.