### PR TITLE
New package: boringtun

### DIFF
--- a/srcpkgs/boringtun/template
+++ b/srcpkgs/boringtun/template
@@ -1,0 +1,19 @@
+# Template file for 'boringtun'
+pkgname=boringtun
+version=0.2.0
+revision=1
+build_style=cargo
+short_desc="Implementation of the WireGuard protocol"
+maintainer="Zach Nedwich <zach@znedw.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/cloudflare/boringtun"
+distfiles="https://github.com/cloudflare/${pkgname}/archive/v${version}.tar.gz"
+checksum=544c72fc482b636e7f6460bfee205adafc55de534067819e4e4914980f0d1350
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) broken="ioctl function signature differs on glibc and musl" ;;
+esac
+
+post_install() {
+	vlicense LICENSE.md
+}


### PR DESCRIPTION
Note, GH release is version 'vTEST2' but crate is 0.2.0, let's hope CF start naming their releases something sane