### PR TITLE
memtest86+: fix build

### DIFF
--- a/srcpkgs/memtest86+/patches/05.memtest86+-5.01-fno-stack-protector.patch
+++ b/srcpkgs/memtest86+/patches/05.memtest86+-5.01-fno-stack-protector.patch
@@ -1,0 +1,11 @@
+--- Makefile.orig	2019-03-29 16:41:29.629879497 +0100
++++ Makefile	2019-03-29 16:41:55.351031244 +0100
+@@ -53,7 +53,7 @@
+ 	$(CC) -c $(CFLAGS) -fno-strict-aliasing reloc.c
+ 
+ test.o: test.c
+-	$(CC) -c -Wall -march=i486 -m32 -O0 -fomit-frame-pointer -fno-builtin -ffreestanding test.c
++	$(CC) -c -Wall -march=i486 -m32 -O0 -fomit-frame-pointer -fno-builtin -ffreestanding -fno-stack-protector test.c
+ 
+ random.o: random.c
+ 	$(CC) -c -Wall -march=i486 -m32 -O3 -fomit-frame-pointer -fno-builtin -ffreestanding random.c


### PR DESCRIPTION
closes #10359 

The rule for `test.o` doesn’t use `$CFLAGS` so `-fno-stack-protector` has to be added additionally.