### PR TITLE
weston: fix ppc build

### DIFF
--- a/srcpkgs/weston/patches/simple-dmabuf-drm-disable.patch
+++ b/srcpkgs/weston/patches/simple-dmabuf-drm-disable.patch
@@ -1,0 +1,11 @@
+--- meson_options.txt
++++ meson_options.txt
+@@ -167,7 +167,7 @@ option(
+ option(
+ 	'simple-dmabuf-drm',
+ 	type: 'array',
+-	choices: [ 'auto', 'intel', 'freedreno', 'etnaviv' ],
++	choices: [ 'none', 'auto', 'intel', 'freedreno', 'etnaviv' ],
+ 	value: [ 'intel', 'freedreno', 'etnaviv' ],
+ 	description: 'List of DRM drivers to be supported by weston-simple-dmabuf-drm'
+ )

--- a/srcpkgs/weston/template
+++ b/srcpkgs/weston/template
@@ -27,9 +27,13 @@ build_options="elogind vaapi"
 desc_option_elogind="Use elogind for suidless startup"
 
 case "$XBPS_TARGET_MACHINE" in
-	x86_64*|i686*|ppc64*)
+	x86_64*|i686*)
 		build_options_default+=" vaapi"
 		configure_args+=" -Dsimple-dmabuf-drm=intel"
+		;;
+	ppc*)
+		build_options_default+=" vaapi"
+		configure_args+=" -Dsimple-dmabuf-drm=none"
 		;;
 	armv*|aarch*)
 		configure_args+=" -Dsimple-dmabuf-drm=freedreno"


### PR DESCRIPTION
For whatever reason the build system doesn't define an option to disable this stuff even though the build system logic accounts for it. There is no libdrm_intel on ppc and neither there is arm-specific etnaviv or freedreno.