### PR TITLE
yggdrasil: redirect service stdout to /dev/null to avoid flooding tty1

### DIFF
--- a/srcpkgs/yggdrasil/files/yggdrasil/run
+++ b/srcpkgs/yggdrasil/files/yggdrasil/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 if [ -f /etc/yggdrasil.conf ]; then
-	exec /usr/bin/yggdrasil --useconffile /etc/yggdrasil.conf
+	exec /usr/bin/yggdrasil --useconffile /etc/yggdrasil.conf 1>/dev/null
 else
-	exec /usr/bin/yggdrasil --autoconf
+	exec /usr/bin/yggdrasil --autoconf 1>/dev/null
 fi

--- a/srcpkgs/yggdrasil/template
+++ b/srcpkgs/yggdrasil/template
@@ -1,7 +1,7 @@
 # Template file for 'yggdrasil'
 pkgname=yggdrasil
 version=0.3.5
-revision=1
+revision=2
 wrksrc="yggdrasil-go-${version}"
 build_style=go
 go_import_path=github.com/yggdrasil-network/yggdrasil-go


### PR DESCRIPTION
too much noise in TTY1, can't use TTY1. Just redirect stdout to /dev/null