### PR TITLE
gvfs: move gvfsd-google to gvfs-goa

### DIFF
--- a/srcpkgs/gvfs/template
+++ b/srcpkgs/gvfs/template
@@ -1,7 +1,7 @@
 # Template file for 'gvfs'
 pkgname=gvfs
 version=1.40.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsystemduserunitdir=no -Dtmpfilesdir=no -Dlogind=false
  -Dman=true"
@@ -71,6 +71,8 @@ gvfs-goa_package() {
 	depends="gvfs-${version}_${revision}"
 	pkg_install() {
 		vmove usr/libexec/gvfs-goa-volume-monitor
+		vmove usr/libexec/gvfsd-google
+		vmove usr/share/gvfs/mounts/google.mount
 		vmove usr/share/dbus-1/services/org.gtk.vfs.GoaVolumeMonitor.service
 		vmove usr/share/gvfs/remote-volume-monitors/goa.monitor
 	}


### PR DESCRIPTION
it depends on gnome-online-accounts and we rather not depend on it.

closes #10416


Please test @b1scu1t