### PR TITLE
ncdc: remove geoip-devel from makedepends (switched to libmaxminddb-devel)

### DIFF
--- a/srcpkgs/ncdc/template
+++ b/srcpkgs/ncdc/template
@@ -1,12 +1,13 @@
 # Template file for 'ncdc'
 pkgname=ncdc
 version=1.21
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-geoip"
 hostmakedepends="pkg-config"
-makedepends="libglib-devel ncurses-devel sqlite-devel gnutls-devel geoip-devel zlib-devel bzip2-devel libmaxminddb-devel"
-short_desc="Modern and lightweight direct connect client with a ncurses interface"
+makedepends="libglib-devel ncurses-devel sqlite-devel gnutls-devel zlib-devel
+ bzip2-devel libmaxminddb-devel"
+short_desc="Modern and lightweight DC client with a ncurses interface"
 maintainer="whoami <whoami@systemli.org>"
 license="MIT"
 homepage="https://dev.yorhel.nl/ncdc"


### PR DESCRIPTION
When updating, I forgot to delete `geoip-devel` when I added `libmaxminddb-devel`

https://dev.yorhel.nl/ncdc/changes

> 1.21 - 2019-03-26 - ncdc-1.21.tar.gz
>     Switch to libmaxminddb for GeoIP lookups

from:
```
140 AS_IF([test "x$with_geoip" == xyes],
141       [PKG_CHECK_MODULES([GEOIP],
142                          [geoip >= 1.2.0],
143                          [AC_DEFINE(USE_GEOIP, 1, [Use libgeoip for IP-to-country lookups])])])
```
to:
```
140 AS_IF([test "x$with_geoip" = xyes],
141       [PKG_CHECK_MODULES([GEOIP],
142                          [libmaxminddb >= 1.0],
143                          [AC_DEFINE(USE_GEOIP, 1, [Use libmaxminddb for IP-to-country lookups])])])
```