### PR TITLE
Signal-Desktop: fix icon installation

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
 version=1.23.2
-revision=1
+revision=2
 # Due to electron
 # 32-bit is not supported https://github.com/signalapp/Signal-Desktop/issues/1661
 archs="x86_64"
@@ -30,10 +30,10 @@ do_install() {
 	ln -s /usr/lib/signal-desktop/signal-desktop ${DESTDIR}/usr/bin/
 
 	vmkdir usr/share/applications
-	vcopy ${FILESDIR}/signal.desktop usr/share/applications/
+	vinstall ${FILESDIR}/signal.desktop 644 usr/share/applications/
 
 	vmkdir usr/share/icons/hicolor
 	for size in 16 32 48 128 256 1024; do
-		vinstall images/icon_${size}.png 644 usr/share/icons/hicolor/${size}x${size}/apps/signal.png
+		vinstall images/icon_${size}.png 644 usr/share/icons/hicolor/${size}x${size}/apps/ signal.png
 	done
 }


### PR DESCRIPTION
Derp, sorry for messing that up previously. Fixes #10438.