### PR TITLE
dep: set correct version information in final binary

### DIFF
--- a/srcpkgs/dep/template
+++ b/srcpkgs/dep/template
@@ -3,13 +3,14 @@ pkgname=dep
 version=0.5.1
 revision=1
 build_style=go
+go_import_path="github.com/golang/dep"
+go_package="$go_import_path/cmd/dep"
+go_ldflags="-X main.version=v${version}"
 hostmakedepends="git"
 depends="git go"
 short_desc="Go dependency management tool"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache"
-go_import_path="github.com/golang/dep"
-go_package="$go_import_path/cmd/dep"
 homepage="https://$go_import_path"
 distfiles="$homepage/archive/v$version.tar.gz"
 checksum=720752ee3a089a8c6ee6a8ebecc7c70881bf2d994d3183d192a588398484b8d4


### PR DESCRIPTION
Before:

```
$ dep version
dep:
 version     : devel
 build date  : 
 git hash    : 
 go version  : go1.12
 go compiler : gc
 platform    : linux/amd64
 features    : ImportDuringSolve=false
$ 
```

After:

```
$ dep version
dep:
 version     : v0.5.1
 build date  : 
 git hash    : 
 go version  : go1.12.1
 go compiler : gc
 platform    : linux/amd64
 features    : ImportDuringSolve=false
$ 
```
