### PR TITLE
openttd: update to 1.9.0.

### DIFF
--- a/srcpkgs/openttd/template
+++ b/srcpkgs/openttd/template
@@ -1,11 +1,10 @@
 # Template file for 'openttd'
 pkgname=openttd
-version=1.8.0
-revision=3
-_gfxver=0.5.4
+version=1.9.0
+revision=1
+_gfxver=0.5.5
 _sfxver=0.2.3
 build_style=gnu-configure
-configure_args="--menu-name=OpenTTD --personal-dir=.openttd"
 hostmakedepends="pkg-config unzip"
 makedepends="SDL-devel icu-devel fontconfig-devel libpng-devel lzo-devel liblzma-devel
  libxdg-basedir-devel"
@@ -14,16 +13,13 @@ short_desc="Open Source version of Transport Tycoon Deluxe"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-2 Custom"
 homepage="https://www.openttd.org/"
-distfiles="
- http://binaries.openttd.org/releases/${version}/openttd-${version}-source.tar.xz
- http://bundles.openttdcoop.org/opengfx/releases/${_gfxver}/opengfx-${_gfxver}.zip
- http://bundles.openttdcoop.org/opensfx/releases/${_sfxver}/opensfx-${_sfxver}.zip
-"
-checksum="
- c2d32d9d736d27202a020027a3729ae763f5432ae6f424891e57a4095eeb087f
- 3d136d776906dbe8b5df1434cb9a68d1249511a3c4cfaca55cc24cc0028ae078
- 3574745ac0c138bae53b56972591db8d778ad9faffd51deae37a48a563e71662
-"
+distfiles="https://proxy.binaries.openttd.org/openttd-releases/${version}/openttd-${version}-source.tar.xz
+ https://bundles.openttdcoop.org/opengfx/releases/${_gfxver}/opengfx-${_gfxver}.zip
+ https://bundles.openttdcoop.org/opensfx/releases/${_sfxver}/opensfx-${_sfxver}.zip"
+checksum="45fded554d973328496f6e01b0769d7b8b64048a8fe2cf252242194c08ea7419
+ c648d56c41641f04e48873d83f13f089135909cc55342a91ed27c5c1683f0dfe
+ 3574745ac0c138bae53b56972591db8d778ad9faffd51deae37a48a563e71662"
+
 
 CXXFLAGS=' -DU_USING_ICU_NAMESPACE=1'
 
@@ -35,8 +31,6 @@ post_extract() {
 
 do_configure() {
 	./configure --prefix-dir=/usr \
-		--endian=LE \
-		--host=${XBPS_CROSS_TRIPLET} \
 		--cc-build=gcc \
 		--cxx-build=g++ \
 		--binary-dir=bin \


### PR DESCRIPTION
I had to remove --endian=LE und --host={XBPS_CROSS_TRIPLET} because it couldn't find them. It does not break the build, so it should be ok.

configure_args should not be used (so I removed it), because do_configure was manually defined.