### PR TITLE
gobject-introspection: don't add a / after ${pc_sysrootdir}

### DIFF
--- a/srcpkgs/gobject-introspection/template
+++ b/srcpkgs/gobject-introspection/template
@@ -1,7 +1,7 @@
 # Template file for 'gobject-introspection'
 pkgname=gobject-introspection
 version=1.60.0
-revision=1
+revision=2
 build_style=meson
 pycompile_dirs="usr/lib/${pkgname}/giscanner"
 hostmakedepends="flex pkg-config"
@@ -49,12 +49,12 @@ post_install() {
 
 	# modify the pkg-config files to respect ${pc_sysrootdir} for variables that are
 	# meant to be called with 'pkg-config --variable'
-	vsed -e 's|^g_ir_scanner=.*|g_ir_scanner=${pc_sysrootdir}/${bindir}/g-ir-scanner|g' \
-		 -e 's|^g_ir_compiler=.*|g_ir_compiler=${pc_sysrootdir}/${bindir}/g-ir-compiler|g' \
-		 -e 's|^g_ir_generate=.*|g_ir_generate=${pc_sysrootdir}/${bindir}/g-ir-generate|g' \
-		 -e 's|^gidatadir.*|gidatadir=${pc_sysrootdir}/${datadir}/gobject-introspection-1.0|g' \
-		 -e 's|^girdir.*|girdir=${pc_sysrootdir}/${datadir}/gir-1.0|g' \
-		 -e 's|^typelibdir.*|typelibdir=${pc_sysrootdir}/${libdir}/girepository-1.0|g' \
+	vsed -e 's|^g_ir_scanner=.*|g_ir_scanner=${pc_sysrootdir}${bindir}/g-ir-scanner|g' \
+		 -e 's|^g_ir_compiler=.*|g_ir_compiler=${pc_sysrootdir}${bindir}/g-ir-compiler|g' \
+		 -e 's|^g_ir_generate=.*|g_ir_generate=${pc_sysrootdir}${bindir}/g-ir-generate|g' \
+		 -e 's|^gidatadir.*|gidatadir=${pc_sysrootdir}${datadir}/gobject-introspection-1.0|g' \
+		 -e 's|^girdir.*|girdir=${pc_sysrootdir}${datadir}/gir-1.0|g' \
+		 -e 's|^typelibdir.*|typelibdir=${pc_sysrootdir}${libdir}/girepository-1.0|g' \
 		 -i ${DESTDIR}/usr/lib/pkgconfig/gobject-introspection-1.0.pc \
 		 -i ${DESTDIR}/usr/lib/pkgconfig/gobject-introspection-no-export-1.0.pc
 


### PR DESCRIPTION
pc_sysrootdir will return / if it is not set, so we don't need to add a
safety / to guarantee the path is absolute.