### PR TITLE
xbps-src: make all variables that can be passed as cmdline args readonly

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -289,8 +289,6 @@ setup_pkg() {
 
     unset_package_funcs
 
-    . $XBPS_CONFIG_FILE 2>/dev/null
-
     if [ -n "$cross" ]; then
         source_file $XBPS_CROSSPFDIR/${cross}.sh
 

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -409,10 +409,13 @@ setup_pkg() {
     DESTDIR=$XBPS_DESTDIR/$XBPS_CROSS_TRIPLET/${sourcepkg}-${version}
     PKGDESTDIR=$XBPS_DESTDIR/$XBPS_CROSS_TRIPLET/${pkg}-${version}
 
-    if [ -n "$disable_parallel_build" -o -z "$XBPS_MAKEJOBS" ]; then
-        XBPS_MAKEJOBS=1
+    if [ -n "$XBPS_MAKEJOBS" ]; then
+        makejobs="-j$XBPS_MAKEJOBS"
     fi
-    makejobs="-j$XBPS_MAKEJOBS"
+
+    if [ -n "$disable_parallel_build" -o -z "$XBPS_MAKEJOBS" ]; then
+        makejobs="-j1"
+    fi
 
     # strip whitespaces to make "  noarch  " valid too.
     if [ "${archs// /}" = "noarch" ]; then

--- a/xbps-src
+++ b/xbps-src
@@ -434,7 +434,7 @@ eval set -- $(getopt "$XBPS_OPTSTRING" "$@");
 
 while getopts "$XBPS_OPTSTRING" opt; do
     case $opt in
-        1) export XBPS_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
+        1) readonly XBPS_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
         a) readonly XBPS_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
         C) readonly XBPS_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;
         E) readonly XBPS_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
@@ -443,17 +443,17 @@ while getopts "$XBPS_OPTSTRING" opt; do
         g) readonly XBPS_DEBUG_PKGS=1; XBPS_OPTIONS+=" -g";;
         H) readonly XBPS_HOSTDIR="$(readlink -f $OPTARG 2>/dev/null)"; XBPS_OPTIONS+=" -H $XBPS_HOSTDIR";;
         h) usage && exit 0;;
-        i) export XBPS_INFORMATIVE_RUN=1; XBPS_OPTIONS+=" -i";;
+        i) readonly XBPS_INFORMATIVE_RUN=1; XBPS_OPTIONS+=" -i";;
         I) readonly XBPS_SKIP_DEPS=1; XBPS_OPTIONS+=" -I";;
-        j) export XBPS_MAKEJOBS="$OPTARG"; XBPS_OPTIONS+=" -j $OPTARG";;
-        L) export NOCOLORS=1; XBPS_OPTIONS+=" -L";;
+        j) readonly XBPS_MAKEJOBS="$OPTARG"; XBPS_OPTIONS+=" -j $OPTARG";;
+        L) readonly NOCOLORS=1; XBPS_OPTIONS+=" -L";;
         m) readonly XBPS_MASTERDIR=$(readlink -f $OPTARG 2>/dev/null); XBPS_OPTIONS+=" -m $XBPS_MASTERDIR";;
         N) readonly XBPS_SKIP_REMOTEREPOS=1; XBPS_OPTIONS+=" -N";;
         o) readonly XBPS_PKG_OPTIONS="$OPTARG"; XBPS_OPTIONS+=" -o $OPTARG";;
-        q) export XBPS_QUIET=1; XBPS_OPTIONS+=" -q";;
-        Q) export XBPS_CHECK_PKGS=1; XBPS_OPTIONS+=" -Q";;
+        q) readonly XBPS_QUIET=1; XBPS_OPTIONS+=" -q";;
+        Q) readonly XBPS_CHECK_PKGS=1; XBPS_OPTIONS+=" -Q";;
         r) readonly XBPS_ALT_REPOSITORY="$OPTARG"; XBPS_OPTIONS+=" -r $OPTARG";;
-        t) export XBPS_TEMP_MASTERDIR=1; XBPS_OPTIONS+=" -t -C";;
+        t) readonly XBPS_TEMP_MASTERDIR=1; XBPS_OPTIONS+=" -t -C";;
         V) echo $XBPS_SRC_VERSION && exit 0;;
         --) shift; break;;
     esac


### PR DESCRIPTION
This is a massive fun hack, the previous commit made so we don't source
the config file in any other location but the initial xbps-src process.

That means if we put these variables as readonly and then source all
configuration inside the same file we can now simulate the effect of
commandline arguments overriding configuration in etc/conf.