### PR TITLE
gocryptfs: set correct version information in final binary

### DIFF
--- a/srcpkgs/gocryptfs/template
+++ b/srcpkgs/gocryptfs/template
@@ -1,11 +1,12 @@
 # Template file for 'gocryptfs'
 pkgname=gocryptfs
 version=1.7
-revision=1
+revision=2
 wrksrc="${pkgname}_v${version}_src-deps"
 build_style=go
 go_import_path="github.com/rfjakob/gocryptfs"
 go_build_tags="without_openssl"
+go_ldflags="-X main.GitVersion=v${version} -X main.GitVersionFuse="[vendored]" -X main.BuildDate=$(date +%Y-%m-%d)"
 depends="fuse"
 short_desc="Encrypted overlay filesystem written in Go"
 maintainer="mustaqim <mustaqim+void@pm.me>"


### PR DESCRIPTION
Currently, the version info looks like this:
`gocryptfs [GitVersion not set - please compile using ./build.bash] without_openssl; go-fuse [GitVersionFuse not set - please compile using ./build.bash]; 0000-00-00 go1.12.1`
because the GO_LDFLAGS is set in `build.bash` which isn't used by xbps.