### PR TITLE
x42-plugins: enable all arches

### DIFF
--- a/srcpkgs/x42-plugins/patches/fix-cross.patch
+++ b/srcpkgs/x42-plugins/patches/fix-cross.patch
@@ -1,0 +1,12 @@
+--- convoLV2/Makefile
++++ convoLV2/Makefile
+@@ -76,9 +76,6 @@ ifneq ($(BUILDGTK), no)
+ endif
+ 
+ ifeq ($(LIBZITACONVOLVER),)
+-  ifeq ($(shell test -f /usr/include/zita-convolver.h -o -f /usr/local/include/zita-convolver.h || echo no ), no)
+-    $(error "libzita-convolver3 or 4, is required")
+-  endif
+   LOADLIBES += -lzita-convolver
+ endif
+ 

--- a/srcpkgs/x42-plugins/template
+++ b/srcpkgs/x42-plugins/template
@@ -1,8 +1,7 @@
 # Template file for 'x42-plugins'
 pkgname=x42-plugins
 version=20190206
-revision=1
-archs="i686* x86_64*"
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="cairo-devel pango-devel glu-devel jack-devel libsndfile-devel
@@ -14,3 +13,6 @@ homepage="https://github.com/x42/x42-plugins"
 distfiles="http://gareus.org/misc/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=0dab84018f9a8b5beca214d1fbe09d3900124c4329430e02a140e48f2a455767
 
+pre_build() {
+	export OPTIMIZATIONS="-fomit-frame-pointer -O3 -fno-finite-math-only -DNDEBUG"
+}


### PR DESCRIPTION
Fixing the other-arch builds is actually very easy, it only took a little bit of investigation. @bluntphenomena