### PR TITLE
New package: papis-0.8

### DIFF
--- a/srcpkgs/papis/template
+++ b/srcpkgs/papis/template
@@ -1,0 +1,21 @@
+# Template file for 'papis'
+pkgname=papis
+version=0.8
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-requests python3-yaml python3-chardet python3-BeautifulSoup4
+ python3-colorama python3-click python3-slugify python3-prompt_toolkit
+ python3-tqdm python3-Pygments python3-stevedore python3-parsing
+ python3-filetype python3-bibtexparser python3-habanero python3-arxiv2bib
+ python3-pylibgen python3-isbnlib python3 python3-setuptools"
+short_desc="Command-line based document and bibliography manager"
+maintainer="xaltsc <xaltsc@protonmail.ch>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/papis/papis"
+distfiles="https://github.com/papis/papis/archive/v${version}.tar.gz"
+checksum=6c5493d5f7062a960bc2b1351ddde001ed585e407aa06e7c07092c61040c696a
+
+pre_build() {
+	sed -i '/configparser/d' setup.py
+}


### PR DESCRIPTION
_Hello papi mais qué pasa ?_ 🎵

There are unsatisfied dependencies I'm working on to resolve right now. Also, there are outdated dependencies.

This pacakge depends on python-prompt_toolkit-2. Do not merge it until it is updated and until the other packages are merged.