### PR TITLE
New package: python-bibtexparser-1.1.0

### DIFF
--- a/srcpkgs/python-bibtexparser/template
+++ b/srcpkgs/python-bibtexparser/template
@@ -1,0 +1,26 @@
+# Template file for 'python-bibtexparser'
+pkgname=python-bibtexparser
+version=1.1.0
+revision=1
+archs=noarch
+wrksrc="bibtexparser-${version}"
+build_style=python-module
+pycompile_module="bibtexparser"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python python-parsing python-future"
+short_desc="Python2 package for parsing BibTeX"
+maintainer="xaltsc <xaltsc@protonmail.ch>"
+license="LGPL-3.0-only, BSD-3-Clause"
+homepage="https://github.com/sciunto-org/python-bibtexparser"
+distfiles="${PYPI_SITE}/b/bibtexparser/bibtexparser-${version}.tar.gz"
+checksum=df8966ea752db6d74657a69b9d684a61aa33457ad6d9d50e41c50ef7f374907f
+
+python3-bibtexparser_package() {
+	archs=noarch
+	pycompile_module="bibtexparser"
+	depends="python3 python3-parsing python3-future"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python3-bibtexparser
+++ b/srcpkgs/python3-bibtexparser
@@ -1,0 +1,1 @@
+python-bibtexparser


### PR DESCRIPTION
I couldn't copy the license which is not provided in the destfiles.