### PR TITLE
New package: libselinux-2.9

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3446,3 +3446,4 @@ libbitcoin-blockchain.so.0 libbitcoin-blockchain-3.5.0_1
 libbitcoin-node.so.0 libbitcoin-node-3.5.0_1
 libbitcoin-server.so.0 libbitcoin-server-3.5.0_1
 libsepol.so.1 libsepol-2.9_1
+libselinux.so.1 libselinux-2.9_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3445,3 +3445,4 @@ libbitcoin-database.so.0 libbitcoin-database-3.5.0_1
 libbitcoin-blockchain.so.0 libbitcoin-blockchain-3.5.0_1
 libbitcoin-node.so.0 libbitcoin-node-3.5.0_1
 libbitcoin-server.so.0 libbitcoin-server-3.5.0_1
+libsepol.so.1 libsepol-2.9_1

--- a/srcpkgs/libselinux-devel
+++ b/srcpkgs/libselinux-devel
@@ -1,0 +1,1 @@
+libselinux

--- a/srcpkgs/libselinux/template
+++ b/srcpkgs/libselinux/template
@@ -1,0 +1,32 @@
+# Template file for 'libselinux'
+pkgname=libselinux
+version=2.9
+revision=1
+_release=20190315
+archs="~*-musl"
+build_style=gnu-makefile
+hostmakedepends="python3 pkg-config"
+makedepends="pcre-devel libsepol-devel"
+short_desc="SELinux runtime shared libraries"
+maintainer="Jasper Chan <jasperchan515@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/SELinuxProject/selinux"
+distfiles="https://github.com/SELinuxProject/selinux/releases/download/${_release}/libselinux-${version}.tar.gz"
+checksum=1bccc8873e449587d9a2b2cf253de9b89a8291b9fbc7c59393ca9e5f5f4d2693
+
+post_install() {
+	mv $DESTDIR/lib/* $DESTDIR/usr/lib/
+	mv $DESTDIR/usr/sbin $DESTDIR/usr/bin
+}
+
+libselinux-devel_package() {
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
+	}
+}
+

--- a/srcpkgs/libsepol-devel
+++ b/srcpkgs/libsepol-devel
@@ -1,0 +1,1 @@
+libsepol

--- a/srcpkgs/libsepol/template
+++ b/srcpkgs/libsepol/template
@@ -1,0 +1,29 @@
+# Template file for 'libsepol'
+pkgname=libsepol
+version=2.9
+revision=1
+_release=20190315
+build_style=gnu-makefile
+hostmakedepends="flex"
+short_desc="SELinux library for manipulating binary security policies"
+maintainer="Jasper Chan <jasperchan515@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/SELinuxProject/selinux"
+distfiles="https://github.com/SELinuxProject/selinux/releases/download/${_release}/libsepol-${version}.tar.gz"
+checksum=a34b12b038d121e3e459b1cbaca3c9202e983137819c16baf63658390e3f1d5d
+
+post_install() {
+	mv $DESTDIR/lib/* $DESTDIR/usr/lib
+}
+
+libsepol-devel_package() {
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
+	}
+}
+


### PR DESCRIPTION
libselinux is needed to make a lot of MATLAB's menus work properly.
These templates seem to build correctly but I'm not sure if there's a better way to do the installation than manually moving files after  `make install`