### PR TITLE
skim: Install skim's extras

### DIFF
--- a/srcpkgs/skim/template
+++ b/srcpkgs/skim/template
@@ -15,5 +15,17 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_install() {
+	cd ${wrksrc}
+	vbin bin/sk-tmux
+	vman man/man1/sk.1
+	vman man/man1/sk-tmux.1
 	vlicense LICENSE
+
+	vinstall plugin/skim.vim 644 usr/share/vim/vimfiles/plugin
+
+	vinstall shell/completion.bash 644 usr/share/bash-completion/completions skim-completion.bash
+	vinstall shell/key-bindings.bash 644 usr/share/bash-completion/completions skim-key-bindings.bash
+	vinstall shell/key-bindings.fish 644 usr/share/fish_vendor_completions.d skim-key-bindings.fish
+	vinstall shell/completion.zsh 644 usr/share/zsh/site-functions skim-completion.zsh
+	vinstall shell/key-bindings.zsh 644 usr/share/zsh/site-functions skim-key-bindings.zsh
 }


### PR DESCRIPTION
`skim`, in addition to the main executable `sk`, also includes shell completions (for `bash`, `fish`, and `zsh`), a `vim` plugin, a `sk-tmux` executable, and a man page.
This change installs of the above.

Change based on the template for the `fzf` package.