### PR TITLE
New package: spdx-licenses-list-3.5

### DIFF
--- a/srcpkgs/spdx-licenses-html
+++ b/srcpkgs/spdx-licenses-html
@@ -1,0 +1,1 @@
+spdx-licenses-list

--- a/srcpkgs/spdx-licenses-json
+++ b/srcpkgs/spdx-licenses-json
@@ -1,0 +1,1 @@
+spdx-licenses-list

--- a/srcpkgs/spdx-licenses-list/template
+++ b/srcpkgs/spdx-licenses-list/template
@@ -1,0 +1,47 @@
+# Template file for 'spdx-licenses-list'
+pkgname=spdx-licenses-list
+version=3.5
+revision=1
+archs=noarch
+wrksrc="license-list-data-${version}"
+short_desc="SPDX License List"
+maintainer="maxice8 <thinkabit.ukim@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://spdx.org"
+distfiles="https://github.com/spdx/license-list-data/archive/v${version}.tar.gz"
+checksum=5666aff8c3a7116970122c39ec41fd40f2076f89826266d3df4f59629ee71a61
+
+do_install() {
+	vmkdir usr/share/spdx
+	for i in text/*.txt; do
+		i=${i##*/}
+		echo ${i%.*} >> ${DESTDIR}/usr/share/spdx/license.lst
+	done
+}
+
+spdx-licenses-text_package() {
+	archs=noarch
+	short_desc="SPDX licenses in plain text"
+	pkg_install() {
+		vmkdir usr/share/spdx
+		vcopy text usr/share/spdx
+	}
+}
+
+spdx-licenses-json_package() {
+	archs=noarch
+	short_desc="SPDX licenses in JSON"
+	pkg_install() {
+		vmkdir usr/share/spdx
+		vcopy json usr/share/spdx
+	}
+}
+
+spdx-licenses-html_package() {
+	archs=noarch
+	short_desc="SPDX licenses in HTML"
+	pkg_install() {
+		vmkdir usr/share/spdx
+		vcopy html usr/share/spdx
+	}
+}

--- a/srcpkgs/spdx-licenses-text
+++ b/srcpkgs/spdx-licenses-text
@@ -1,0 +1,1 @@
+spdx-licenses-list


### PR DESCRIPTION
Can be grepped by xlint to find all licenses we allow.