### PR TITLE
llvm8: restore incorrectly removed patches

### DIFF
--- a/srcpkgs/llvm8/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
@@ -1,0 +1,17 @@
+--- clang/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:52:16.174867512 +0100
++++ clang/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:56:25.040531791 +0100
+@@ -502,12 +502,12 @@
+     Loader = "ld.so.1";
+     break;
+   case llvm::Triple::ppc64:
+-    LibDir = "lib64";
++    LibDir = "lib";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+     break;
+   case llvm::Triple::ppc64le:
+-    LibDir = "lib64";
++    LibDir = "lib";
+     Loader =
+         (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
+     break;

--- a/srcpkgs/llvm8/files/patches/cfe/cfe-006-ppc64-musl-elfv2.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-006-ppc64-musl-elfv2.patch
@@ -1,0 +1,30 @@
+--- clang/lib/Basic/Targets/PPC.h
++++ clang/lib/Basic/Targets/PPC.h
+@@ -358,7 +358,10 @@ public:
+       ABI = "elfv2";
+     } else {
+       resetDataLayout("E-m:e-i64:64-n32:64");
+-      ABI = "elfv1";
++      if (Triple.getEnvironment() == llvm::Triple::Musl)
++        ABI = "elfv2";
++      else
++        ABI = "elfv1";
+     }
+ 
+     switch (getTriple().getOS()) {
+diff --git a/tools/clang/lib/Driver/ToolChains/Clang.cpp b/tools/clang/lib/Driver/ToolChains/Clang.cpp
+index 8e9c4c6a..40817ec3 100644
+--- clang/lib/Driver/ToolChains/Clang.cpp
++++ clang/lib/Driver/ToolChains/Clang.cpp
+@@ -1618,7 +1618,10 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
+         break;
+       }
+ 
+-      ABIName = "elfv1";
++      if (getToolChain().getTriple().getEnvironment() == llvm::Triple::Musl)
++        ABIName = "elfv2";
++      else
++        ABIName = "elfv1";
+       break;
+     }
+     case llvm::Triple::ppc64le:


### PR DESCRIPTION
The following revs:

https://github.com/void-linux/void-packages/commit/c86d7346c8d918913f05a200074c4016f0df82a6
https://github.com/void-linux/void-packages/commit/4fb6e622fec390347c4afaaade36f87e2736edc6

removed some patches in error, after a prefix was introduced
by mistake which resulted in the patches not applying. This
restores the former behavior.