### PR TITLE
nomad: update to 0.9.0.

### DIFF
--- a/srcpkgs/nomad/patches/0001-Allow-compiling-without-nvidia-integration.patch
+++ b/srcpkgs/nomad/patches/0001-Allow-compiling-without-nvidia-integration.patch
@@ -1,0 +1,90 @@
+From a09e3bf1a130cdc70dd07b0d5adc5ab17d0f9131 Mon Sep 17 00:00:00 2001
+From: Mahmood Ali <mahmood@hashicorp.com>
+Date: Wed, 10 Apr 2019 09:07:08 -0400
+Subject: [PATCH] Allow compiling without nvidia integration
+
+nvidia library use of dynamic library seems to conflict with alpine and
+musl based OSes.  This adds a `nonvidia` tag to allow compiling nomad
+for alpine images.
+
+The nomad releases currently only support glibc based OS environments,
+so we default to compiling with nvidia.
+---
+ drivers/docker/driver.go                           |  6 ++++--
+ helper/pluginutils/catalog/register_linux.go       |  2 --
+ .../pluginutils/catalog/register_nvidia_linux.go   | 14 ++++++++++++++
+ 3 files changed, 18 insertions(+), 4 deletions(-)
+ create mode 100644 helper/pluginutils/catalog/register_nvidia_linux.go
+
+diff --git a/drivers/docker/driver.go b/drivers/docker/driver.go
+index 3403c2621..62830089b 100644
+--- a/drivers/docker/driver.go
++++ b/drivers/docker/driver.go
+@@ -18,7 +18,6 @@ import (
+ 	multierror "github.com/hashicorp/go-multierror"
+ 	plugin "github.com/hashicorp/go-plugin"
+ 	"github.com/hashicorp/nomad/client/taskenv"
+-	"github.com/hashicorp/nomad/devices/gpu/nvidia"
+ 	"github.com/hashicorp/nomad/drivers/docker/docklog"
+ 	"github.com/hashicorp/nomad/drivers/shared/eventer"
+ 	nstructs "github.com/hashicorp/nomad/nomad/structs"
+@@ -56,6 +55,9 @@ var (
+ 	// taskHandleVersion is the version of task handle which this driver sets
+ 	// and understands how to decode driver state
+ 	taskHandleVersion = 1
++
++	// Nvidia-container-runtime environment variable names
++	nvidiaVisibleDevices = "NVIDIA_VISIBLE_DEVICES"
+ )
+ 
+ type Driver struct {
+@@ -684,7 +686,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
+ 		PidsLimit: driverConfig.PidsLimit,
+ 	}
+ 
+-	if _, ok := task.DeviceEnv[nvidia.NvidiaVisibleDevices]; ok {
++	if _, ok := task.DeviceEnv[nvidiaVisibleDevices]; ok {
+ 		if !d.gpuRuntime {
+ 			return c, fmt.Errorf("requested docker-runtime %q was not found", d.config.GPURuntimeName)
+ 		}
+diff --git a/helper/pluginutils/catalog/register_linux.go b/helper/pluginutils/catalog/register_linux.go
+index bb5175d11..42314cb57 100644
+--- a/helper/pluginutils/catalog/register_linux.go
++++ b/helper/pluginutils/catalog/register_linux.go
+@@ -1,7 +1,6 @@
+ package catalog
+ 
+ import (
+-	"github.com/hashicorp/nomad/devices/gpu/nvidia"
+ 	"github.com/hashicorp/nomad/drivers/rkt"
+ )
+ 
+@@ -10,5 +9,4 @@ import (
+ // register_XXX.go file.
+ func init() {
+ 	RegisterDeferredConfig(rkt.PluginID, rkt.PluginConfig, rkt.PluginLoader)
+-	Register(nvidia.PluginID, nvidia.PluginConfig)
+ }
+diff --git a/helper/pluginutils/catalog/register_nvidia_linux.go b/helper/pluginutils/catalog/register_nvidia_linux.go
+new file mode 100644
+index 000000000..a50cbe833
+--- /dev/null
++++ b/helper/pluginutils/catalog/register_nvidia_linux.go
+@@ -0,0 +1,14 @@
++// +build !nonvidia
++
++package catalog
++
++import (
++	"github.com/hashicorp/nomad/devices/gpu/nvidia"
++)
++
++// This file is where all builtin plugins should be registered in the catalog.
++// Plugins with build restrictions should be placed in the appropriate
++// register_XXX.go file.
++func init() {
++	Register(nvidia.PluginID, nvidia.PluginConfig)
++}
+-- 
+2.21.0
+

--- a/srcpkgs/nomad/template
+++ b/srcpkgs/nomad/template
@@ -1,25 +1,32 @@
 # Template file for 'nomad'
 pkgname=nomad
-version=0.8.7
+version=0.9.0
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/nomad"
-hostmakedepends="git govendor"
+go_build_tags="ui"
+_git_commit=28e768721992df5097203eea6e2b247abd56ca6f
+go_ldflags="-X github.com/hashicorp/nomad/version.GitCommit=${_git_commit}"
+hostmakedepends="git nodejs-lts python yarn"
 short_desc="Cluster scheduler designed to easily integrate into existing workflows"
 maintainer="iaroki <iaroki@protonmail.com>"
 license="MPL-2.0"
 homepage="https://www.nomadproject.io/"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=f74eac627de69190e586358b1956573a0ae1a40d0755ecdee163016949f9c7fe
+checksum=fb6a0afd6895540dd5e18c878421c39e2a2759e90af8eb771c84802d082475df
 patch_args="-Np1"
 
+case "$XBPS_MACHINE" in
+	i686*) broken="yarn is broken on i686" ;;
+esac
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) go_build_tags+=" nonvidia" ;;
+esac
+
 pre_build() {
-	# NOTE: This can probably be removed in nomad 0.9.x if Hashicorp updates
-	# their golang.org/x/crypto/blake2b dependency.
-	cd "$GOSRCPATH"
-	govendor fetch golang.org/x/sys/cpu@1b2967e3c290b7c545b3db0deeda16e9be4f98a2
-	govendor fetch golang.org/x/crypto/blake2b@de0752318171da717af4ce24d0a2e8626afaeb11
-	cd -
+	local depbin="${wrksrc}/_build-depbin"
+	GOOS= GOARCH= CGO_ENABLED=0 PATH="$depbin:$PATH" GOBIN="$depbin" make deps ember-dist static-assets
 }
 
 post_install() {


### PR DESCRIPTION
- Updated to build new UI with yarn. Broken on i686 because yarn can't
  be built for it -- works fine when cross-compiling.

- Commit now set in version string. _git_commit must be updated to the
  version's tag alongside the version for this to be correct.

- Removed golang.org/x/crypto/blake2b version workaround.