### PR TITLE
gede: drop support for qt4

### DIFF
--- a/srcpkgs/gede/template
+++ b/srcpkgs/gede/template
@@ -1,23 +1,21 @@
 # Template file for 'gede'
 pkgname=gede
 version=2.12.3
-revision=1
+revision=2
+build_wrksrc=src
 build_style=qmake
-build_options="qt5"
-build_options_default="qt5"
-build_wrksrc="src"
-hostmakedepends="python $(vopt_if qt5 qt5-qmake qt-qmake)"
-makedepends="$(vopt_if qt5 qt5-devel qt-devel)"
+hostmakedepends="python qt5-qmake"
+makedepends="qt5-devel"
 depends="gdb ctags"
 short_desc="Graphical frontend (GUI) to GDB written in Qt"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="BSD"
+license="BSD-2-Clause"
 homepage="http://acidron.com/gede"
 distfiles="http://gede.acidron.com/uploads/source/${pkgname}-${version}.tar.xz"
 checksum=b7dd593f9ec3e8a99f05a4be2bfdbcc0e6e9d8aac2fad1cf5a8cb614fcda3c10
 
-if [ -n "$CROSS_BUILD" ]; then
-	hostmakedepends+=" $(vopt_if qt5 'qt5-host-tools qt5-devel' 'qt-host-tools qt-devel')"
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt5-host-tools qt5-devel"
 fi
 
 do_install() {


### PR DESCRIPTION
- Qt4 is obsolete and unmaintained
- Usage of Qt4 blocks removal from the repos