### PR TITLE
ccls: update to 0.20190314.

### DIFF
--- a/srcpkgs/ccls/template
+++ b/srcpkgs/ccls/template
@@ -1,16 +1,14 @@
 # Template file for 'ccls'
 pkgname=ccls
-version=0.20181225.8
-revision=2
+version=0.20190314
+revision=1
 build_style=cmake
-configure_args="-DSYSTEM_CLANG=ON -DUSE_SHARED_LLVM=ON -DLLVM_ENABLE_RTTI=ON"
-hostmakedepends="clang llvm rapidjson"
-makedepends="ncurses-devel zlib-devel"
-depends="$hostmakedepends"
+hostmakedepends="clang-tools-extra"
+makedepends="clang llvm ncurses-devel rapidjson zlib-devel"
 short_desc="C/C++/ObjC language server"
 maintainer="Nathan Owens <ndowens04@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/MaskRay/ccls"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=3cb24048f0d9d34a5a55fb180f239ef467c5d80e0fb77acad86b4e821e74d7f0
-nocross="During cross-build, headers/libraries can not be found"
+checksum=aaefa603a76325bb94e5222d144e19c432771346990c8b84165832bf37d15bb3
+nocross="Clang cannot be installed as makedep"


### PR DESCRIPTION
* updated to latest version
* functionality tested on x86_64
* removed obsolete configure_args, see [upstream's release note](https://github.com/MaskRay/ccls/releases/tag/0.20190314).
* small dependency rework
    * all dependencies are makedeps as ccls needs them for linking
    * added hostmakedep: clang-tools-extra (`/usr/bin/clang-rename` needed by cmake during build)
* cross-build not working due to clang not being able to be installed as makedep during cross-build attempt (seems to be a known issue)