### PR TITLE
Unindex packages when they are removed

### DIFF
--- a/common/hooks/post-pkg/00-register-pkg.sh
+++ b/common/hooks/post-pkg/00-register-pkg.sh
@@ -1,13 +1,17 @@
 # This hook registers a XBPS binary package into the specified local repository.
 
 registerpkg() {
-	local repo="$1" pkg="$2" arch="$3"
+	local repo="$1" pkg="$2" arch="$3" mode="add"
 
 	if [ ! -f ${repo}/${pkg} ]; then
 		msg_error "Unexistent binary package ${repo}/${pkg}!\n"
 	fi
 
-	printf "%s:%s:%s\n" "${arch}" "${repo}" "${pkg}" >> "${XBPS_STATEDIR}/.${sourcepkg}_register_pkg"
+	if [ -n "${removed}" ]; then
+		mode="remove"
+	fi
+
+	printf "%s:%s:%s:%s\n" "${arch}" "${repo}" "${pkg}" "${mode}" >> "${XBPS_STATEDIR}/.${sourcepkg}_register_pkg"
 }
 
 hook() {


### PR DESCRIPTION
This prevents installing packages not delivered anymore by removing them from index rather than providing empty packages.

Removing current installations is covered by #9745.

Proposed workflow is to set `removed=yes` in template additionally to modifying template in way currently described in manual.
Template can be removed just after builders do the job, not months later.

If two phase process is not convenient enough, builders could unindex packages when templates are removed.

Requires https://github.com/void-linux/xbps/pull/76.
