### PR TITLE
dolphin-emu: add patch for soundtouch 2.1.2 and enable ppc64le

### DIFF
--- a/srcpkgs/dolphin-emu/patches/soundtouch212.patch
+++ b/srcpkgs/dolphin-emu/patches/soundtouch212.patch
@@ -1,0 +1,17 @@
+Description: Fix FTBFS with SoundTouch 2.1.2
+ Explicitly disable exceptions in SoundTouch headers because Dolphin
+ is compiled with -fno-exceptions.
+Author: James Cowgill <jcowgill@debian.org>
+Bug-Debian: https://bugs.debian.org/917671
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- Source/Core/AudioCommon/OpenALStream.h
++++ Source/Core/AudioCommon/OpenALStream.h
+@@ -32,6 +32,7 @@
+ #define BOOL SoundTouch_BOOL
+ #endif
+ 
++#define ST_NO_EXCEPTION_HANDLING
+ #include <soundtouch/SoundTouch.h>
+ #include <soundtouch/STTypes.h>
+ 

--- a/srcpkgs/dolphin-emu/template
+++ b/srcpkgs/dolphin-emu/template
@@ -1,12 +1,10 @@
 # Template file for 'dolphin-emu'
-archs="x86_64*"
-
 pkgname=dolphin-emu
 version=5.0
-revision=17
+revision=18
+archs="x86_64* ppc64le*"
 wrksrc="dolphin-${version}"
 build_style=cmake
-nopie=yes
 configure_args="-DUSE_X11=1 -DUSE_EGL=0
  -DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-3.0"
 hostmakedepends="pkg-config"
@@ -16,12 +14,18 @@ makedepends="
  portaudio-devel libopenal-devel soundtouch-devel lzo-devel wxWidgets-devel
  mbedtls-devel SFML-devel libenet-devel"
 depends="desktop-file-utils"
-short_desc="A Gamecube / Wii / Triforce emulator"
+short_desc="Gamecube / Wii / Triforce emulator"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://dolphin-emu.org"
 distfiles="https://github.com/dolphin-emu/dolphin/archive/${version}.tar.gz"
 checksum=62c4602055767ab314ff50a3b94ea57f792832aa1629e6b1117ebce10518dc0b
+nopie=yes
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*|aarch64*) ;;
+	*) configure_args+=" -DENABLE_GENERIC=ON" ;;
+esac
 
 post_install() {
 	rm -f ${DESTDIR}/usr/lib/*.a


### PR DESCRIPTION
Technically this should also work on aarch64 but I haven't tested that, so I'm not enabling it. Building for ppc64le as well as any other little endian architecture requires a generic (architecture independent) build to be enabled.

Also, add a patch to fix compilation with soundtouch 2.1.2. Also, fix lint issues, and appropriately bump revision.