### PR TITLE
New Package: Dwarf-Therapist v41.0.3

### DIFF
--- a/srcpkgs/Dwarf-Therapist/patches/DT.patch
+++ b/srcpkgs/Dwarf-Therapist/patches/DT.patch
@@ -1,0 +1,23 @@
+--- CMakeLists.txt	2019-03-30 18:03:55.398912681 +0800
++++ CMakeLists.txt	2019-03-30 18:03:23.606908598 +0800
+@@ -36,7 +36,7 @@
+         set(MACOSX_BUNDLE_GUI_IDENTIFIER "io.github.dwarf-therapist.DwarfTherapist")
+     else() # Linux
+         set(SOURCES ${SOURCES} src/dfinstancelinux.cpp)
+-	set(EXE_NAME "dwarftherapist")
++	set(EXE_NAME "DwarfTherapist")
+     endif()
+ else()
+     message(FATAL_ERROR "unsupported target")
+
+--- ./dist/ptrace_cap_wrapper/dwarftherapist	2019-03-30 23:30:37.564429710 +0800
++++ ./dist/ptrace_cap_wrapper/dwarftherapist	2019-03-30 23:30:52.730431657 +0800
+@@ -37,7 +37,7 @@
+ ## $_DT_BINARY
+ ## Set path to 'DwarfTherapist' binary
+ _DT_BINARY="`which DwarfTherapist`"
+-PREFIX="${_DT_BINARY%%/bin/DwarfTherapist}"
++PREFIX="/usr"
+ 
+ ## $_ETC_BASE_FOLDER
+ ## Set folder containing 'etc/memory_layouts/linux/*'

--- a/srcpkgs/Dwarf-Therapist/template
+++ b/srcpkgs/Dwarf-Therapist/template
@@ -1,0 +1,17 @@
+# Template file for 'Dwarf-Therapist'
+pkgname=Dwarf-Therapist
+version=41.0.3
+revision=1
+build_style=cmake
+makedepends="qt5-declarative-devel libcap-devel hicolor-icon-theme"
+depends="dwarffortress-0.44.12_2"
+short_desc="Management tool designed to run side-by-side with Dwarf Fortress"
+maintainer="Robert Stancil <robert.stancil@mavs.uta.edu>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/Dwarf-Therapist/Dwarf-Therapist/"
+distfiles="https://github.com/Dwarf-Therapist/Dwarf-Therapist/archive/v${version}.tar.gz"
+checksum=72d1a5cd0dfdcb49586403dfbdba31e3d9dfb53d092a427f9f35f8f825686863
+
+post_install() {
+	vbin dist/ptrace_cap_wrapper/dwarftherapist
+}


### PR DESCRIPTION
Complementary software to dwarffortress. Currently lists dwarffortress as a dependency because versions need to be compatible but Dwarf-Therapist does not link to dwarffortress in any way; if dwarffortress is not accepted as a package the dependency will need to be removed.