### PR TITLE
valabind: update to 1.7.1 and unbreak

### DIFF
--- a/srcpkgs/r2-bindings/template
+++ b/srcpkgs/r2-bindings/template
@@ -17,3 +17,5 @@ makedepends="valabind python-devel radare2 file-devel"
 pycompile_module="r2"
 depends="radare2>=${version}"
 noverifyrdeps=1
+
+broken="out of date, lots of bindings are broken even in latest version"

--- a/srcpkgs/valabind/template
+++ b/srcpkgs/valabind/template
@@ -1,6 +1,6 @@
 # Template file for 'valabind'
 pkgname=valabind
-version=1.4.0
+version=1.7.1
 revision=1
 build_style=gnu-makefile
 hostmakedepends="pkg-config vala-devel git"
@@ -11,5 +11,4 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="LGPL-3"
 homepage="http://radare.org"
 distfiles="https://github.com/radare/valabind/archive/${version}.tar.gz"
-checksum=b2e4939912feada6138b8269d228ea82fb0f1391fd2e2e7003f404677b0cdbc9
-broken="Broken with vala-0.38: swigwriter.vala:25.24-25.38: error: The name 'CCodeBaseModule' does not exist in the context of 'SwigWriter.add_includes'"
+checksum=b463b18419de656e218855a2f30a71051f03a9c4540254b4ceaea475fb79102e


### PR DESCRIPTION
I updated this as a part of an effort to unbreak r2-bindings and bokken, which was ultimately unsuccessful. r2-bindings is completely broken even with latest radare2 and r2-bindings (several of the language modules fail to build, python2 support has been deprecated/removed and bokken won't take python3), bokken hasn't seen any changes since 2015, so maybe it'd be best to remove it, as it doesn't build right now anyway and hasn't built for a long time. But at least it is possible to unbreak/update valabind, so here it is, and while at it, I marked r2-bindings broken so that it doesn't attempt to build (previously it was indirectly broken through valabind).