### PR TITLE
puddletag: remove

### DIFF
--- a/srcpkgs/puddletag/INSTALL.msg
+++ b/srcpkgs/puddletag/INSTALL.msg
@@ -1,0 +1,1 @@
+puddletag is no longer provided by Void Linux, and will be fully removed from the repos on 2019-07-12

--- a/srcpkgs/puddletag/template
+++ b/srcpkgs/puddletag/template
@@ -1,16 +1,9 @@
 # Template file for 'puddletag'
 pkgname=puddletag
 version=1.2.0
-revision=2
+revision=3
 archs=noarch
-build_wrksrc=source
-build_style=python2-module
-pycompile_module="puddlestuff"
-hostmakedepends="python-devel"
-depends="mutagen python-PyQt4 python-parsing python-configobj python-musicbrainzngs"
-short_desc="MP3 tagging GUI"
-maintainer="allan <mail@may.mooo.com>"
-license="GPL-3.0-or-later"
+build_style=meta
+short_desc="MP3 tagging GUI (removed package)"
+license="BSD-2-Clause"
 homepage="http://puddletag.sourceforge.net"
-distfiles="https://github.com/keithgg/puddletag/archive/v${version}.tar.gz"
-checksum=95e4867fd04c5349f19de1b5f3c1f2336d3b66da08c076fb175ef8f7589dc80d


### PR DESCRIPTION
Upstream is quitting, is python3 only and depends on PyQt4