### PR TITLE
nftables: stop mandoc from crashing

### DIFF
--- a/srcpkgs/nftables/files/man/nft.8.diff
+++ b/srcpkgs/nftables/files/man/nft.8.diff
@@ -1,0 +1,10 @@
+--- nft.8.orig	2019-04-13 11:08:20.952278328 +0700
++++ nft.8	2019-04-13 11:07:49.857276845 +0700
+@@ -791,6 +791,7 @@
+ T}	T{
+ automatic merge of adjacent/overlapping set elements (only for interval sets)
+ T}	T{
++
+ T}
+ .TE
+ .SH MAPS

--- a/srcpkgs/nftables/template
+++ b/srcpkgs/nftables/template
@@ -1,7 +1,7 @@
 # Template file for 'nftables'
 pkgname=nftables
 version=0.9.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin CONFIG_MAN=y DB2MAN=docbook2man"
 hostmakedepends="docbook2x flex pkg-config"
@@ -15,6 +15,7 @@ checksum=ad8181b5fcb9ca572f444bed54018749588522ee97e4c21922648bb78d7e7e91
 
 post_install() {
 	vsv nftables
+	patch "${PKGDESTDIR}/usr/share/man/man8/nft.8" < "${FILESDIR}/man/nft.8.diff"
 }
 
 libnftables_package() {


### PR DESCRIPTION
My setup:

% xbps-alternatives -g man -l
man
 - mdocml (current)
 - man:/usr/bin/mandoc
 - whatis:/usr/bin/mandoc
 - apropos:/usr/bin/mandoc
 - man.1:/usr/share/man/man1/mandoc-man.1
 - whatis.1:/usr/share/man/man1/mandoc-whatis.1
 - apropos.1:/usr/share/man/man1/mandoc-apropos.1

	man 8 nft

crashed when trying to render empty table cell.

I'm not sure if this is mandoc's problem,
or the original nft.8 is malformed.

This patch is a quick workaround before someone (tm)
can take a deeper look into this problem.