### PR TITLE
python-prompt_toolkit: revbump

### DIFF
--- a/srcpkgs/python-prompt_toolkit1/template
+++ b/srcpkgs/python-prompt_toolkit1/template
@@ -2,7 +2,7 @@
 pkgname=python-prompt_toolkit1
 reverts="2.0.9_1"
 version=1.0.15
-revision=2
+revision=3
 archs=noarch
 wrksrc="prompt_toolkit-${version}"
 build_style=python-module

--- a/srcpkgs/python-prompt_toolkit2/template
+++ b/srcpkgs/python-prompt_toolkit2/template
@@ -1,7 +1,7 @@
 # Template file for 'python-prompt_toolkit2'
 pkgname=python-prompt_toolkit2
 version=2.0.9
-revision=2
+revision=3
 archs=noarch
 wrksrc="prompt_toolkit-${version}"
 build_style=python-module


### PR DESCRIPTION
reverting `python-prompt_toolkit` didn't work, so they were removed from the repos manually. This PR re-adds them.