### PR TITLE
[WIP] [RFC] mariadb: update to 10.3.14

### DIFF
--- a/srcpkgs/mariadb/patches/fix-cross.patch
+++ b/srcpkgs/mariadb/patches/fix-cross.patch
@@ -1,8 +1,8 @@
---- ./CMakeLists.txt.orig	2015-09-17 15:47:59.794784111 -0400
-+++ ./CMakeLists.txt	2015-09-19 19:42:16.751348473 -0400
-@@ -362,10 +376,10 @@
+--- CMakeLists.txt.orig	2019-04-13 15:56:16.853115799 -0400
++++ CMakeLists.txt	2019-04-13 15:56:43.169656287 -0400
+@@ -356,10 +356,10 @@
  
- CHECK_PCRE()
+ CHECK_SYSTEMD()
  
 -IF(CMAKE_CROSSCOMPILING)
 -  SET(IMPORT_EXECUTABLES "IMPORTFILE-NOTFOUND" CACHE FILEPATH "Path to import_executables.cmake from a native build")

--- a/srcpkgs/mariadb/template
+++ b/srcpkgs/mariadb/template
@@ -1,7 +1,7 @@
 # Template file for 'mariadb'
 pkgname=mariadb
-version=10.1.30
-revision=5
+version=10.3.14
+revision=1
 build_style=cmake
 configure_args="-DMYSQL_DATADIR=/var/lib/mysql
  -DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock -DDEFAULT_CHARSET=utf8
@@ -17,23 +17,23 @@ configure_args="-DMYSQL_DATADIR=/var/lib/mysql
  -DWITHOUT_EXAMPLE_STORAGE_ENGINE=1 -DWITHOUT_FEDERATED_STORAGE_ENGINE=1
  -DWITH_EXTRA_CHARSETS=complex -DWITH_LIBWRAP=OFF -DSTACK_DIRECTION=1
  -DWITHOUT_PBXT_STORAGE_ENGINE=1 -DWITH_INNOBASE_STORAGE_ENGINE=1"
-lib32disabled=yes
 hostmakedepends="perl bison ncurses-devel libressl-devel"
 makedepends="zlib-devel ncurses-devel libressl-devel readline-devel pcre-devel"
 depends="mariadb-client"
-provides="mysql-${version}_${revision}"
-replaces="mysql>=0"
 conf_files="/etc/mysql/my.cnf"
-system_accounts="mysql"
-mysql_homedir="/var/lib/mysql"
 short_desc="Fast SQL database server, drop-in replacement for MySQL"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
+license="GPL-2-or-later"
 homepage="https://mariadb.org/"
-license="GPL-2"
 distfiles="http://archive.mariadb.org/$pkgname-$version/source/$pkgname-$version.tar.gz"
-checksum=173a5e5a24819e0a469c3bd09b5c98491676c37c6095882a2ea34c5af0996c88
+checksum=ba1c94d92fc8ebdf9b8a1d1b93ed6aeeead33da507efbbd4afcf49f32023e054
+provides="mysql-${version}_${revision}"
+replaces="mysql>=0"
+lib32disabled=yes
 disable_parallel_build=yes
 CFLAGS="-w"
+system_accounts="mysql"
+mysql_homedir="/var/lib/mysql"
 
 case "$XBPS_TARGET_MACHINE" in
 	armv[56]*) LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -latomic"
@@ -84,9 +84,6 @@ post_install() {
 	# Remove unneeded stuff.
 	rm -rf ${DESTDIR}/usr/{sql-bench,mysql-test,data}
 	rm -f ${DESTDIR}/usr/share/man/man1/mysql-test-run.pl.1
-
-	# Configuration file.
-	install -Dm644 ${DESTDIR}/usr/share/mysql/my-medium.cnf ${DESTDIR}/etc/mysql/my.cnf
 
 	vsv mysqld
 }


### PR DESCRIPTION
This is the latest GA release of MariaDB which includes the wsrep patch in the source which is used for Galera Cluster.

I'm having trouble getting this to work with this latest version.  Currently, I am stuck at:

> => libmariadbclient-10.3.14_1: running pre-install hook: 00-lib32 ...
=> libmariadbclient-10.3.14_1: running pre-install hook: 02-script-wrapper ...
=> libmariadbclient-10.3.14_1: running pkg_install ...
mv: cannot stat '/destdir//mariadb-10.3.14/usr/lib/libmysqld.so.*': No such file or directory
=> ERROR: libmariadbclient-10.3.14_1: pkg_install: 'mv ${_destdir}/$files ${_pkgdestdir}/${_targetdir}' exited with 1
=> ERROR:   in _vmove() at common/environment/setup/install.sh:227
=> ERROR:   in _noglob_helper() at common/environment/setup/install.sh:12
=> ERROR:   in pkg_install() at srcpkgs/libmariadbclient/template:96