### PR TITLE
xbps-src: vsv: force linking on forced rebuild

### DIFF
--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -19,10 +19,15 @@ done
 
 _vsv() {
 	local service="$1"
+	local LN_OPTS="-s"
 
 	if [ $# -lt 1 ]; then
 		msg_red "$pkgver: vsv: 1 argument expected: <service>\n"
 		return 1
+	fi
+
+	if [ -n "$XBPS_BUILD_FORCEMODE" ]; then
+		LN_OPTS+="f"
 	fi
 
 	vmkdir etc/sv
@@ -31,10 +36,10 @@ _vsv() {
 	if [ -r ${PKGDESTDIR}/etc/sv/${service}/finish ]; then
 		chmod 755 ${PKGDESTDIR}/etc/sv/${service}/finish
 	fi
-	ln -s /run/runit/supervise.${service} ${PKGDESTDIR}/etc/sv/${service}/supervise
+	ln ${LN_OPTS} /run/runit/supervise.${service} ${PKGDESTDIR}/etc/sv/${service}/supervise
 	if [ -r ${PKGDESTDIR}/etc/sv/${service}/log/run ]; then
 		chmod 755 ${PKGDESTDIR}/etc/sv/${service}/log/run
-		ln -s /run/runit/supervise.${service}-log ${PKGDESTDIR}/etc/sv/${service}/log/supervise
+		ln ${LN_OPTS} /run/runit/supervise.${service}-log ${PKGDESTDIR}/etc/sv/${service}/log/supervise
 	fi
 }
 


### PR DESCRIPTION
re-run `xbps-src -f install pkg` on packages with service files failed
because the link was created from previous run.