### PR TITLE
profanity: update to 0.6.0.

### DIFF
--- a/srcpkgs/profanity/template
+++ b/srcpkgs/profanity/template
@@ -1,22 +1,26 @@
 # Template file for 'profanity'
 pkgname=profanity
-version=0.5.1
-revision=3
+version=0.6.0
+revision=1
 build_style=gnu-configure
-configure_args="$(vopt_enable notify notifications) $(vopt_with xscreensaver)
- --disable-python-plugins"
-hostmakedepends="pkg-config python-devel"
-makedepends="libcurl-devel libgcrypt-devel libglib-devel libotr-devel
- libstrophe-devel python-devel readline-devel cmocka-devel
- $(vopt_if notify 'libnotify-devel')
- $(vopt_if xscreensaver 'libXScrnSaver-devel')"
-short_desc="A console based XMPP client"
+configure_args="$(vopt_enable notify notifications) $(vopt_enable otr)
+$(vopt_enable pgp) $(vopt_enable python python-plugins)
+$(vopt_with xscreensaver)"
+hostmakedepends="pkg-config $(vopt_if python python-devel)"
+makedepends="libcurl-devel libglib-devel libstrophe-devel readline-devel
+ $(vopt_if notify libnotify-devel) $(vopt_if otr 'libotr-devel libgcrypt-devel')
+ $(vopt_if pgp gpgme-devel) $(vopt_if python python-devel)
+ $(vopt_if xscreensaver libXScrnSaver-devel)"
+checkdepends="cmocka-devel"
+short_desc="Console based XMPP client"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.profanity.im/"
-distfiles="http://www.profanity.im/${pkgname}-${version}.tar.gz"
-checksum=e3513713e74ec3363fbdbac2919bdc17e249988780cc5a4589d1425807a7feb8
+distfiles="https://github.com/boothj5/profanity/releases/download/${version}/profanity-${version}.tar.gz"
+checksum=f1b2773b79eb294297686f3913e9489c20effae5e3a335c8956db18f6ee2f660
 
 # Package build options
-build_options="notify xscreensaver"
-build_options_default="notify xscreensaver"
+build_options="notify otr pgp python xscreensaver"
+build_options_default="notify otr pgp xscreensaver"
+desc_option_otr="Enable support for OTR encryption"
+desc_option_pgp="Enable support for OpenPGP encryption"


### PR DESCRIPTION
* updated to latest version
* added build_options:
    * `pgp`: Support for OpenPGP encryption via gpgme
    * `python`: Support for python plugins
* OTR encryption support now as build_option