### PR TITLE
osg: set nodebug

### DIFF
--- a/srcpkgs/osg/template
+++ b/srcpkgs/osg/template
@@ -23,6 +23,12 @@ homepage="http://www.openscenegraph.org"
 distfiles="https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-${version}.tar.gz"
 checksum=930eb46f05781a76883ec16c5f49cfb29a059421db131005d75bec4d78401fd5
 
+# necessary because OSG's cmake script don't properly account for RelWithDebInfo
+# this results in shared libraries with the 'rd' prefix added, but the cmake
+# library find scripts for OSG only assume either release or debug, so these
+# libs will never be found
+nodebug=1
+
 # Append CFLAGS and CXXFLAGS to set work around code which gcc6 would
 # otherwise regard as out-of-specification and allow it to produce a
 # working program.


### PR DESCRIPTION
The reason for this is that OSG will add suffixes to library names with `RelWithDebInfo` or `Debug` (`rd` for `RelWithDebInfo`) but its cmake macros never assume existence of `RelWithDebInfo`, only `Release` or `Debug`, which means they will never find the libraries when OSG is built with `RelWithDebInfo`. This issue clearly manifests with e.g. `openmw`, which fails to build with OSG built without `nodebug`, with this kind of problem:

```
-- Could NOT find osgDB (missing: OSGDB_LIBRARY) 
-- Could NOT find osgViewer (missing: OSGVIEWER_LIBRARY) 
-- Could NOT find osgText (missing: OSGTEXT_LIBRARY) 
-- Could NOT find osgGA (missing: OSGGA_LIBRARY) 
-- Could NOT find osgParticle (missing: OSGPARTICLE_LIBRARY) 
-- Could NOT find osgUtil (missing: OSGUTIL_LIBRARY) 
-- Could NOT find osgFX (missing: OSGFX_LIBRARY) 
-- Could NOT find osg (missing: OSG_LIBRARY) 
-- Could NOT find OpenThreads (missing: OPENTHREADS_LIBRARY) 
CMake Error at /usr/share/cmake-3.14/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find OpenSceneGraph (missing: OPENSCENEGRAPH_LIBRARIES
  OSGDB_FOUND OSGVIEWER_FOUND OSGTEXT_FOUND OSGGA_FOUND OSGPARTICLE_FOUND
  OSGUTIL_FOUND OSGFX_FOUND OSG_FOUND OPENTHREADS_FOUND) (found suitable
  version "3.4.1", minimum required is "3.3.4")
```

This is because e.g. `libosg.so` is actually called `libosgrd.so` with `RelWithDebInfo` build.

The 6638dc55268eed63b3bfd7a65f0eb9450054a586 commit introduced the breakage, but OSG was last built before the breakage happened, so there is no need to bump this.

@Johnnynator 