### PR TITLE
New package: fcitx-unikey-0.2.7

### DIFF
--- a/srcpkgs/fcitx-unikey/template
+++ b/srcpkgs/fcitx-unikey/template
@@ -1,0 +1,20 @@
+# Template file for 'fcitx-unikey'
+pkgname=fcitx-unikey
+version=0.2.7
+revision=1
+build_style=cmake
+configure_args="-DENABLE_QT=$(vopt_if qt5 ON OFF)"
+hostmakedepends="pkg-config gobject-introspection"
+makedepends="fcitx-devel gettext-devel $(vopt_if qt5 libfcitx-qt5-devel)"
+short_desc="Support unikey (Vietnamese input method) for fcitx"
+maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.com/fcitx/fcitx-unikey"
+distfiles="https://download.fcitx-im.org/${pkgname}/${pkgname}-${version}.tar.xz"
+checksum=e750774b73b08e51148b963736d8207e50c3973e5456b6569cb7ad86831e0e59
+build_options="qt5"
+desc_option_qt5="Support Qt5 applications"
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" fcitx"
+fi


### PR DESCRIPTION
Tested with:

- urxvt, st: No special instruction required
- firefox, chromium: with those LC_CTYPE:

	- ja_JP.UTF-8: work, (should work with ko and zh locale, too)
	- vi_VN.UTF-8 and en_US: requires libfcitx-gtk3.
	I'm not sure if I should write a post-install script
	to advice users about it.
	- c.f: https://fcitx-im.org/wiki/FAQ#Emacs