### PR TITLE
luarocks: specify package alternatives

### DIFF
--- a/srcpkgs/luarocks/template
+++ b/srcpkgs/luarocks/template
@@ -1,7 +1,7 @@
 # Template file for 'luarocks'
 pkgname=luarocks
 version=3.0.4
-revision=1
+revision=2
 archs=noarch
 build_style=configure
 configure_args="
@@ -18,6 +18,9 @@ license="MIT"
 homepage="https://luarocks.org/"
 distfiles="https://luarocks.org/releases/luarocks-${version}.tar.gz"
 checksum=1236a307ca5c556c4fed9fdbd35a7e0e80ccf063024becc8c3bf212f37ff0edf
+alternatives="
+ luarocks:luarocks:/usr/bin/luarocks-5.3
+ luarocks:luarocks-admin:/usr/bin/luarocks-admin-5.3"
 
 conf_files="/etc/luarocks/config-5.3.lua"
 
@@ -40,18 +43,21 @@ post_install() {
 	vlicense COPYING
 
 	vmkdir usr/bin
-	for lv in 5.1 5.2; do
+	for lv in 5.1 5.2 5.3; do
 		make DESTDIR="${DESTDIR}" LUA_VERSION=$lv install-config
 		make DESTDIR="${DESTDIR}" LUA_VERSION=$lv install-config
 
 		echo "#!/bin/sh" > ${DESTDIR}/usr/bin/luarocks-$lv
-		echo "exec luarocks --lua-version $lv \"\$@\"" >> ${DESTDIR}/usr/bin/luarocks-$lv
+		echo "exec luarocks.lua --lua-version $lv \"\$@\"" >> ${DESTDIR}/usr/bin/luarocks-$lv
 		chmod +x ${DESTDIR}/usr/bin/luarocks-$lv
 
 		echo "#!/bin/sh" > ${DESTDIR}/usr/bin/luarocks-admin-$lv
-		echo "exec luarocks-admin --lua-version $lv \"\$@\"" >> ${DESTDIR}/usr/bin/luarocks-admin-$lv
+		echo "exec luarocks-admin.lua --lua-version $lv \"\$@\"" >> ${DESTDIR}/usr/bin/luarocks-admin-$lv
 		chmod +x ${DESTDIR}/usr/bin/luarocks-admin-$lv
 	done
+
+	mv ${DESTDIR}/usr/bin/luarocks{,.lua}
+	mv ${DESTDIR}/usr/bin/luarocks-admin{,.lua}
 }
 
 luarocks-lua52_package() {
@@ -59,6 +65,9 @@ luarocks-lua52_package() {
 	short_desc+=" - Lua52"
 	depends="luarocks>=${version}_${revision} lua52"
 	conf_files="/etc/luarocks/config-5.2.lua"
+	alternatives="
+		luarocks:luarocks:/usr/bin/luarocks-5.2
+		luarocks:luarocks-admin:/usr/bin/luarocks-admin-5.2"
 	pkg_install() {
 		vmove usr/bin/luarocks-5.2
 		vmove usr/bin/luarocks-admin-5.2
@@ -71,6 +80,9 @@ luarocks-lua51_package() {
 	short_desc+=" - Lua51"
 	depends="luarocks>=${version}_${revision} lua51"
 	conf_files="/etc/luarocks/config-5.1.lua"
+	alternatives="
+		luarocks:luarocks:/usr/bin/luarocks-5.1
+		luarocks:luarocks-admin:/usr/bin/luarocks-admin-5.1"
 	pkg_install() {
 		vmove usr/bin/luarocks-5.1
 		vmove usr/bin/luarocks-admin-5.1


### PR DESCRIPTION
Subpackages for lua51 and lua52 provide wrapper scripts around
`luarocks` and `luarocks-admin` to call with the correct lua version.
This extends that to fully support XBPS' package alternatives mechanism.