### PR TITLE
New package: dotnet-sdk-2.2.203

### DIFF
--- a/srcpkgs/dotnet-sdk/files/LICENSE
+++ b/srcpkgs/dotnet-sdk/files/LICENSE
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/srcpkgs/dotnet-sdk/template
+++ b/srcpkgs/dotnet-sdk/template
@@ -1,0 +1,46 @@
+# Template file for 'dotnet-sdk'
+pkgname=dotnet-sdk
+version=2.2.203
+revision=1
+archs="x86_64 armv7 aarch64"
+wrksrc="${pkgname}-${version}"
+create_wrksrc=yes
+short_desc="Provides the .NET SDK components"
+maintainer="Anachron <gith@cron.world>"
+license="MIT"
+homepage="https://dotnet.microsoft.com"
+nopie=yes
+
+case "${XBPS_TARGET_MACHINE}" in
+	x86_64)
+	_arch="x64"
+	_path="647f8505-3bf0-48c5-ac0f-3839be6816d7/d0c2762ded5a1ded3c79b1e495e43b7c"
+	distfiles="https://download.visualstudio.microsoft.com/download/pr/${_path}/${pkgname}-${version}-linux-${_arch}.tar.gz"
+	checksum="d1e2368b1335a6a5f496b887950ad5da3d85783ec76f74a663214989817bb497"
+	;;
+	armv7)
+	_arch="arm"
+	_path="e5573b57-df74-4b5b-8cd8-06973b66c3ac/b9ee29318ad2d87fa05adfaf74a8271c"
+	distfiles="https://download.visualstudio.microsoft.com/download/pr/${_path}/${pkgname}-${version}-linux-${_arch}.tar.gz"
+	checksum="76488566b7c81f12a517274562bf5bbb77e003cd9ca568f90d9bfb2865de3242"
+	;;
+	aarch64)
+	_arch="arm64"
+	_path="50979c85-1634-4c40-a4d0-4d25c9dae08d/cfa1d7e5ef765cef1d2c9127c9e14599"
+	distfiles="https://download.visualstudio.microsoft.com/download/pr/${_path}/${pkgname}-${version}-linux-${_arch}.tar.gz"
+	checksum="6f49fa85aef7f69ec04bbb4f61e4029a472d5a01ea5a4154986df27e26521879"
+	;;
+esac
+
+_target='opt/dotnet'
+
+do_install() {
+	vmkdir usr/bin
+	ln -sf "/${_target}/dotnet" "${DESTDIR}/usr/bin/dotnet"
+	vmkdir "${_target}"
+	vcopy dotnet "${_target}"
+	vcopy host "${_target}"
+	vcopy shared "${_target}"
+	vcopy sdk "${_target}"
+	vlicense "${FILESDIR}/LICENSE"
+}


### PR DESCRIPTION
Right now I decided to not add a PR for `dotnet-runtime` because it doesn't seem to work without the `sdk`. Should resolve #10773.

Here is an example output of `dotnet --info` after installation:
```
.NET Core SDK (reflecting any global.json):
 Version:   2.2.203
 Commit:    e5bab63eca

Runtime Environment:
 OS Name:     void
 OS Version:  
 OS Platform: Linux
 RID:         linux-x64
 Base Path:   /opt/dotnet/sdk/2.2.203/

Host (useful for support):
  Version: 2.2.4
  Commit:  f95848e524

.NET Core SDKs installed:
  2.2.203 [/opt/dotnet/sdk]

.NET Core runtimes installed:
  Microsoft.AspNetCore.All 2.2.4 [/opt/dotnet/shared/Microsoft.AspNetCore.All]
  Microsoft.AspNetCore.App 2.2.4 [/opt/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 2.2.4 [/opt/dotnet/shared/Microsoft.NETCore.App]

To install additional .NET Core runtimes or SDKs:
  https://aka.ms/dotnet-download
```