### PR TITLE
r2-bindings: remove

### DIFF
--- a/srcpkgs/r2-bindings/INSTALL.msg
+++ b/srcpkgs/r2-bindings/INSTALL.msg
@@ -1,0 +1,1 @@
+r2-bindings is no longer provided by Void Linux, and will be fully removed from the repos on 2019-07-15

--- a/srcpkgs/r2-bindings/template
+++ b/srcpkgs/r2-bindings/template
@@ -1,19 +1,9 @@
 # Template file for 'r2-bindings'
 pkgname=r2-bindings
 version=1.0.1
-revision=1
-build_style=gnu-configure
-wrksrc="radare2-${version}"
-short_desc="Advanced command line debugger and hexadecimal editor (bindings)"
-maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="LGPL-3"
+revision=2
+archs=noarch
+build_style=meta
+short_desc="Advanced command line debugger and hexadecimal editor (bindings) (removed package)"
+license="BSD-2-Clause"
 homepage="http://www.radare.org"
-distfiles="${homepage}/get/radare2-bindings-${version}.tar.xz"
-checksum=c65f16ed642993a4da8ad6e4e20b0f9cd4ed4965b7f4891860481eeaec20abc1
-
-wrksrc="radare2-bindings-${version}"
-hostmakedepends="pkg-config swig"
-makedepends="valabind python-devel radare2 file-devel"
-pycompile_module="r2"
-depends="radare2>=${version}"
-noverifyrdeps=1


### PR DESCRIPTION
This appears to be broken and mostly in a state of disarray upstream, with some of the bindings not building at all.

Additionally, there are no users left in the repo, and it has been broken in Void for quite some time, and even if it gets fixed eventually, it should be split into individual langs properly.