### PR TITLE
orc: updated homepage due to link rot

### DIFF
--- a/srcpkgs/orc/template
+++ b/srcpkgs/orc/template
@@ -1,14 +1,14 @@
 # Template file for 'orc'
 pkgname=orc
 version=0.4.29
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake pkg-config libtool"
 short_desc="Oild Runtime Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-2-Clause"
-homepage="http://code.entropywave.com/orc/"
+homepage="https://cgit.freedesktop.org/gstreamer/orc"
 distfiles="http://gstreamer.freedesktop.org/src/orc/orc-${version}.tar.xz"
 checksum=4f8901f9144b5ec17dffdb33548b5f4c7f8049b0d1023be3462cdd64ec5a3ab2
 


### PR DESCRIPTION
Had some free time, so decided to do the quick fix for #10988 myself. I've set the new homepage to https://cgit.freedesktop.org/gstreamer/orc as I can't find anything better.