### PR TITLE
teamspeak3: update template file

### DIFF
--- a/srcpkgs/teamspeak3/files/teamspeak3
+++ b/srcpkgs/teamspeak3/files/teamspeak3
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/share/teamspeak3/ts3client_runscript.sh $@
+exec /usr/lib/teamspeak3/ts3client_runscript.sh $@

--- a/srcpkgs/teamspeak3/template
+++ b/srcpkgs/teamspeak3/template
@@ -1,10 +1,10 @@
 # Template file for 'teamspeak3'
 pkgname=teamspeak3
 version=3.2.3
-revision=1
+revision=2
+archs="i686 x86_64"
 wrksrc=teamspeak3
 create_wrksrc=yes
-archs="i686 x86_64"
 short_desc="Popular proprietary voice chat for gaming"
 maintainer="Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>"
 license="Proprietary"
@@ -12,6 +12,8 @@ homepage="http://www.teamspeak.com/"
 restricted=yes
 repository="nonfree"
 nopie=yes
+nostrip=yes
+noverifyrdeps=yes
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_pkg="TeamSpeak3-Client-linux_amd64-${version}"
@@ -39,8 +41,8 @@ do_install() {
 	find -name *.so | xargs chmod 755
 	chmod +x ts3client*
 
-	vmkdir "usr/share/teamspeak3"
-	vcopy * "usr/share/teamspeak3"
+	vmkdir "usr/lib/teamspeak3"
+	vcopy * "usr/lib/teamspeak3"
 
 	# Install desktop file
 	vinstall "${FILESDIR}/teamspeak3.desktop" 644 "usr/share/applications"


### PR DESCRIPTION
Updated the template file because of the error:
`=> ERROR: teamspeak3-3.2.3_1: ELF files found in /usr/share`

Changes:
- Moved teamspeak3 from /usr to /opt
- Added flag nostrip and noverifyrdeps