### PR TITLE
New package: orjail-1.1

### DIFF
--- a/srcpkgs/orjail/template
+++ b/srcpkgs/orjail/template
@@ -1,0 +1,23 @@
+# Template file for 'orjail'
+pkgname=orjail
+version=1.1
+revision=1
+archs=noarch
+hostmakedepends="ruby-ronn"
+depends="bash bc-gh coreutils grep iproute2 ncurses tor util-linux"
+short_desc="Force a program to exclusively use the Tor network"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+license="WTFPL"
+homepage="https://orjail.github.io/"
+distfiles="https://github.com/orjail/orjail/archive/v${version}.tar.gz"
+checksum=85d4ae032a64d37b183f53d6d3d267b7c241f579f188d3107d6c9b160fab4e39
+
+pre_install() {
+	ronn man/orjail.8.ronn
+}
+
+do_install() {
+	vbin usr/sbin/orjail
+	vman man/orjail.8
+	vlicense COPYING
+}


### PR DESCRIPTION
Simple bash-script which uses network namespaces and iptable rules to
force a program's network traffic through Tor. (optional isolation with
firejail)