### PR TITLE
mksh: build lksh as /bin/sh alternative and remove lto

### DIFF
--- a/srcpkgs/mksh/template
+++ b/srcpkgs/mksh/template
@@ -1,23 +1,22 @@
 # Template file for 'mksh'
 pkgname=mksh
 version=R57
-revision=1
+revision=2
 wrksrc=mksh
 checkdepends="perl ed"
-register_shell="/bin/mksh"
-short_desc="The MirBSD Korn Shell"
-maintainer='Andrea Brancaleoni <abc@pompel.me>'
+short_desc="MirBSD Korn Shell"
+maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MirOS"
 homepage="https://www.mirbsd.org/mksh.htm"
 distfiles="https://www.mirbsd.org/MirOS/dist/mir/${pkgname}/${pkgname}-${version}.tgz"
 checksum=3d101154182d52ae54ef26e1360c95bc89c929d28859d378cc1c84f3439dbe75
 
+register_shell="/bin/mksh"
 alternatives="
- sh:sh:/usr/bin/mksh
- sh:sh.1:/usr/share/man/man1/mksh.1
+ sh:sh:/usr/bin/lksh
+ sh:sh.1:/usr/share/man/man1/lksh.1
  ksh:ksh:/usr/bin/mksh
- ksh:ksh.1:/usr/share/man/man1/mksh.1
-"
+ ksh:ksh.1:/usr/share/man/man1/mksh.1"
 
 build_options="static"
 
@@ -26,16 +25,25 @@ do_build() {
 		CFLAGS+=" -static"
 		LDFLAGS+=" -static"
 	fi
-	sh ./Build.sh -r -c lto
+	sh ./Build.sh -r
+	mkdir -p lksh
+	cd lksh
+	CPPFLAGS="$CPPFLAGS -DMKSH_BINSHPOSIX" sh ../Build.sh -L -r
+	cd ..
 }
 
 do_check() {
 	./test.sh
+	cd lksh
+	./test.sh
+	cd ..
 }
 
 do_install() {
 	vbin mksh
+	vbin lksh/lksh
 	vman mksh.1
+	vman lksh.1
 	vinstall dot.mkshrc 644 etc/skel .mkshrc
 	vlicense ${FILESDIR}/TaC-mksh.txt
 }


### PR DESCRIPTION
mksh(1) is not meant to be a /bin/sh alternative and ships with
lksh(1) which has better compatibility with POSIX sh.

Disabling lto because there is a GCC bug which broke a test case:

```
mira|AO | duncaen: that’s the one that fails if your compiler is buggy with LTO
mira|AO | duncaen: remove “-c lto” from the Build.sh invocation and retry
mira|AO | the problem is that this occurs in an interpreter, so it’s really hard to figure out
mira|AO | GCC people also don’t care about -fwhole-program --combine or LTO bugs
mira|AO | I’ve begun dropping LTO use from my packages peu à peu
```