### PR TITLE
New package: pgcli-2.1.0

### DIFF
--- a/srcpkgs/pgcli/patches/relax-dependencies.patch
+++ b/srcpkgs/pgcli/patches/relax-dependencies.patch
@@ -1,0 +1,16 @@
+Seemingly the only breaking change in these updates is dropping support
+for old Python releases, so we should be fine.
+
+--- setup.py
++++ setup.py
+@@ -16,8 +16,8 @@ install_requirements = [
+     'click >= 4.1',
+     'Pygments >= 2.0',  # Pygments has to be Capitalcased. WTF?
+     'prompt_toolkit>=2.0.6,<2.1.0',
+-    'psycopg2 >= 2.7.4,<2.8',
+-    'sqlparse >=0.2.2,<0.3.0',
++    'psycopg2 >= 2.7.4,<2.9',
++    'sqlparse >=0.2.2,<0.4.0',
+     'configobj >= 5.0.6',
+     'humanize >= 0.5.1',
+     'cli_helpers[styles] >= 1.2.0',

--- a/srcpkgs/pgcli/template
+++ b/srcpkgs/pgcli/template
@@ -1,0 +1,26 @@
+# Template file for 'pgcli'
+pkgname=pgcli
+version=2.1.0
+revision=1
+archs=noarch
+build_style=python3-module
+pycompile_module="pgcli"
+hostmakedepends="python3-setuptools"
+depends="python3-pgspecial python3-click python3-Pygments python3-prompt_toolkit2
+ python3-psycopg2 python3-sqlparse python3-configobj python3-humanize
+ python3-cli_helpers python3-setproctitle"
+short_desc="PostgreSQL CLI with autocompletion and syntax highlighting"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="BSD-3-Clause"
+homepage="https://www.pgcli.com"
+distfiles="${PYPI_SITE}/p/pgcli/pgcli-${version}.tar.gz"
+checksum=3791a3c7734802fd14fefe9d18082a95687a02631f3287bd154cd27b4f12c05c
+
+do_check() {
+	# pgcli tests require a PostgreSQL server; skip them.
+	:
+}
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-cli_helpers/patches/use-python3-mock-on-tests.patch
+++ b/srcpkgs/python3-cli_helpers/patches/use-python3-mock-on-tests.patch
@@ -1,0 +1,13 @@
+diff --git tests/test_config.py tests/test_config.py
+index 3cbe211..4d2bc77 100644
+--- tests/test_config.py
++++ tests/test_config.py
+@@ -4,7 +4,7 @@
+ from __future__ import unicode_literals
+ import os
+ 
+-from mock import MagicMock
++from unittest.mock import MagicMock
+ import pytest
+ 
+ from cli_helpers.compat import MAC, text_type, WIN

--- a/srcpkgs/python3-cli_helpers/template
+++ b/srcpkgs/python3-cli_helpers/template
@@ -1,0 +1,26 @@
+# Template file for 'python3-cli_helpers'
+pkgname=python3-cli_helpers
+version=1.2.0
+revision=1
+archs=noarch
+wrksrc="cli_helpers-${version}"
+build_style=python3-module
+pycompile_module="cli_helpers"
+hostmakedepends="python3-setuptools"
+depends="python3-configobj python3-tabulate python3-terminaltables
+ python3-wcwidth"
+checkdepends="python3-pytest ${depends}"
+short_desc="Python helpers for building command-line apps"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="BSD-3-Clause"
+homepage="https://github.com/dbcli/cli_helpers"
+distfiles="${PYPI_SITE}/c/cli_helpers/cli_helpers-${version}.tar.gz"
+checksum=d211192b4d5a61de0020c516213ba67bbf1662ccd8c0624e6696dedb1a9d3e5d
+
+do_check() {
+	python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-colorclass/template
+++ b/srcpkgs/python3-colorclass/template
@@ -1,0 +1,24 @@
+# Template file for 'python3-colorclass'
+pkgname=python3-colorclass
+version=2.2.0
+revision=1
+archs=noarch
+wrksrc="colorclass-${version}"
+build_style=python3-module
+pycompile_module="colorclass"
+hostmakedepends="python3-setuptools"
+checkdepends="python3-pytest python3-docopt"
+short_desc="Colorful worry-free console applications"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://github.com/Robpol86/colorclass"
+distfiles="https://github.com/Robpol86/colorclass/archive/v${version}.tar.gz"
+checksum=@4b1dff3a5736f909f229429396131365d31cffac0c497bdf46a1fa61e8c2d6f7
+
+do_check() {
+	PYTHONPATH="${PWD}/build-${py3_ver}/lib" python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-humanize/patches/use-python3-mock-on-tests.patch
+++ b/srcpkgs/python3-humanize/patches/use-python3-mock-on-tests.patch
@@ -1,0 +1,25 @@
+diff --git setup.py setup.py
+index 327388d..4f59508 100644
+--- setup.py
++++ setup.py
+@@ -36,7 +36,6 @@ setup(
+     include_package_data=True,
+     zip_safe=False,
+     test_suite="tests",
+-    tests_require=['mock'],
+     install_requires=[
+       # -*- Extra requirements: -*-
+     ],
+diff --git tests/time.py tests/time.py
+index 7747c87..669d063 100644
+--- tests/time.py
++++ tests/time.py
+@@ -3,7 +3,7 @@
+ 
+ """Tests for time humanizing."""
+ 
+-from mock import patch
++from unittest.mock import patch
+ 
+ from humanize import time
+ from datetime import date, datetime, timedelta

--- a/srcpkgs/python3-humanize/template
+++ b/srcpkgs/python3-humanize/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-humanize'
+pkgname=python3-humanize
+version=0.5.1
+revision=1
+archs=noarch
+wrksrc="humanize-${version}"
+build_style=python3-module
+pycompile_module="humanize"
+hostmakedepends="python3-setuptools"
+short_desc="Python humanize utilities"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://github.com/jmoiron/humanize"
+distfiles="https://github.com/jmoiron/humanize/archive/${version}.tar.gz"
+checksum=@ce798ec45142598f4eb5a580c1c99b1f10d573c1896afd73e4aa8e216b22608b
+
+post_install() {
+	vlicense LICENCE
+}

--- a/srcpkgs/python3-pgspecial/template
+++ b/srcpkgs/python3-pgspecial/template
@@ -1,0 +1,25 @@
+# Template file for 'python3-pgspecial'
+pkgname=python3-pgspecial
+version=1.11.5
+revision=1
+archs=noarch
+wrksrc="pgspecial-${version}"
+build_style=python3-module
+pycompile_module="pgspecial"
+hostmakedepends="python3-setuptools"
+depends="python3-click python3-sqlparse python3-psycopg2"
+short_desc="Meta-commands handler for PostgreSQL"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="BSD-3-Clause"
+homepage="https://www.dbcli.com"
+distfiles="${PYPI_SITE}/p/pgspecial/pgspecial-${version}.tar.gz"
+checksum=f44dd48db53fd93dc78d61ebac0ca2cc3c58203f94b30edc730b02bfd3ee747b
+
+do_check() {
+	# pgspecial tests require a PostgreSQL server; skip them.
+	:
+}
+
+post_install() {
+	vlicense License.txt
+}

--- a/srcpkgs/python3-terminaltables/template
+++ b/srcpkgs/python3-terminaltables/template
@@ -1,0 +1,24 @@
+# Template file for 'python3-terminaltables'
+pkgname=python3-terminaltables
+version=3.1.0
+revision=1
+archs=noarch
+wrksrc="terminaltables-${version}"
+build_style=python3-module
+pycompile_module="terminaltables"
+hostmakedepends="python3-setuptools"
+checkdepends="python3-pytest python3-colorama python3-colorclass python3-termcolor"
+short_desc="Generate simple tables for terminals"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://github.com/Robpol86/terminaltables"
+distfiles="https://github.com/Robpol86/terminaltables/archive/v${version}.tar.gz"
+checksum=@2c97ec30468b515f1b9dce9a1dded25e1017a4038f03bd8c17d49ca6817a859f
+
+do_check() {
+	python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Currently I manually patch out python-mock with unittests.mock on Python 3; might be worth packaging python3-mock instead.