### PR TITLE
sbsigntools + efitools for UEFI secure boot

### DIFF
--- a/srcpkgs/efitools-efi
+++ b/srcpkgs/efitools-efi
@@ -1,0 +1,1 @@
+efitools

--- a/srcpkgs/efitools/patches/libressl-compatibility.patch
+++ b/srcpkgs/efitools/patches/libressl-compatibility.patch
@@ -1,0 +1,11 @@
+--- a/cert-to-efi-hash-list.c	2018-04-21 20:59:24.814748503 +0200
++++ b/cert-to-efi-hash-list.c	2018-04-21 20:59:51.868581307 +0200
+@@ -135,7 +135,7 @@
+         X509 *cert = PEM_read_bio_X509(cert_bio, NULL, NULL, NULL);
+ 	unsigned char *cert_buf = NULL;
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ 	int cert_len = i2d_X509_CINF(cert->cert_info, &cert_buf);
+ #else
+ 	int cert_len = i2d_re_X509_tbs(cert, &cert_buf);

--- a/srcpkgs/efitools/patches/makefile-enable-harden-local-files.patch
+++ b/srcpkgs/efitools/patches/makefile-enable-harden-local-files.patch
@@ -1,0 +1,45 @@
+diff --git a/Makefile b/Makefile
+index 30e236b..31004a6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -82,31 +82,31 @@ HelloWorld.so: lib/lib-efi.a
+ ShimReplace.so: lib/lib-efi.a
+ 
+ cert-to-efi-sig-list: cert-to-efi-sig-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a -lcrypto
+ 
+ sig-list-to-certs: sig-list-to-certs.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a -lcrypto
+ 
+ sign-efi-sig-list: sign-efi-sig-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a -lcrypto
+ 
+ hash-to-efi-sig-list: hash-to-efi-sig-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a
+ 
+ cert-to-efi-hash-list: cert-to-efi-hash-list.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a -lcrypto
+ 
+ efi-keytool: efi-keytool.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a
+ 
+ efi-readvar: efi-readvar.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a -lcrypto
+ 
+ efi-updatevar: efi-updatevar.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a -lcrypto
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a -lcrypto
+ 
+ flash-var: flash-var.o lib/lib.a
+-	$(CC) $(ARCH3264) -o $@ $< lib/lib.a
++	$(CC) $(ARCH3264) -o $@ $< $(CFLAGS) $(LDFLAGS) lib/lib.a
+ 
+ clean:
+ 	rm -f PK.* KEK.* DB.* $(EFIFILES) $(EFISIGNED) $(BINARIES) *.o *.so

--- a/srcpkgs/efitools/patches/makefile-keep-freestanding-flag.patch
+++ b/srcpkgs/efitools/patches/makefile-keep-freestanding-flag.patch
@@ -1,0 +1,81 @@
+diff --git a/Make.rules b/Make.rules
+index 489ad8c..ac46165 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -14,9 +14,9 @@ else
+ $(error unknown architecture $(ARCH))
+ endif
+ INCDIR	   = -I$(TOPDIR)include/ -I/usr/include/efi -I/usr/include/efi/$(ARCH) -I/usr/include/efi/protocol
+-CPPFLAGS   = -DCONFIG_$(ARCH)
+-CFLAGS	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
+-LDFLAGS	   = -nostdlib
++EFI_CPPFLAGS   = -DCONFIG_$(ARCH)
++EFI_CFLAGS	   = -O2 -g $(ARCH3264) -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check
++EFI_LDFLAGS	   = -nostdlib
+ CRTOBJ		= crt0-efi-$(ARCH).o
+ CRTPATHS	= /lib /lib64 /lib/efi /lib64/efi /usr/lib /usr/lib64 /usr/lib/efi /usr/lib64/efi /usr/lib/gnuefi /usr/lib64/gnuefi
+ CRTPATH		= $(shell for f in $(CRTPATHS); do if [ -e $$f/$(CRTOBJ) ]; then echo $$f; break; fi; done)
+@@ -24,7 +24,7 @@ CRTOBJS		= $(CRTPATH)/$(CRTOBJ)
+ # there's a bug in the gnu tools ... the .reloc section has to be
+ # aligned otherwise the file alignment gets screwed up
+ LDSCRIPT	= elf_$(ARCH)_efi.lds
+-LDFLAGS		+= -shared -Bsymbolic $(CRTOBJS) -L $(CRTPATH) -L /usr/lib -L /usr/lib64 -T $(LDSCRIPT)
++EFI_LDFLAGS		+= -shared -Bsymbolic $(CRTOBJS) -L $(CRTPATH) -L /usr/lib -L /usr/lib64 -T $(LDSCRIPT)
+ LOADLIBES	= -lefi -lgnuefi $(shell $(CC) $(ARCH3264) -print-libgcc-file-name)
+ FORMAT		= --target=efi-app-$(ARCH)
+ OBJCOPY		= objcopy
+@@ -36,23 +36,23 @@ EFIDIR		= $(DESTDIR)/usr/share/efitools/efi
+ DOCDIR		= $(DESTDIR)/usr/share/efitools
+ 
+ # globally use EFI calling conventions (requires gcc >= 4.7)
+-CFLAGS += -DGNU_EFI_USE_MS_ABI
++EFI_CFLAGS += -DGNU_EFI_USE_MS_ABI
+ 
+ ifeq ($(ARCH),x86_64)
+-  CFLAGS += -DEFI_FUNCTION_WRAPPER -mno-red-zone
++  EFI_CFLAGS += -DEFI_FUNCTION_WRAPPER -mno-red-zone
+ endif
+ 
+ ifeq ($(ARCH),ia32)
+-  CFLAGS += -mno-red-zone
++  EFI_CFLAGS += -mno-red-zone
+ endif
+ 
+ ifeq ($(ARCH),arm)
+-  LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
++  EFI_LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
+   FORMAT = -O binary
+ endif
+ 
+ ifeq ($(ARCH),aarch64)
+-  LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
++  EFI_LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
+   FORMAT = -O binary
+ endif
+ 
+@@ -61,7 +61,7 @@ endif
+ 		   -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+ 		   -j .reloc $(FORMAT) $*.so $@
+ %.so: %.o
+-	$(LD) $(LDFLAGS) $^ -o $@ $(LOADLIBES)
++	$(LD) $(EFI_LDFLAGS) $^ -o $@ $(LOADLIBES)
+ 	# check we have no undefined symbols
+ 	nm -D $@ | grep ' U ' && exit 1 || exit 0
+ 
+@@ -99,13 +99,13 @@ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else ec
+ 	./sign-efi-sig-list -a -c PK.crt -k PK.key dbx $< $@
+ 
+ %.o: %.c
+-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
++	$(CC) $(INCDIR) $(EFI_CFLAGS) $(EFI_CPPFLAGS) -c $< -o $@
+ 
+ %.efi.o: %.c
+-	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
++	$(CC) $(INCDIR) $(EFI_CFLAGS) $(EFI_CPPFLAGS) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
+ 
+ %.efi.s: %.c
+-	$(CC) -S $(INCDIR) $(CFLAGS) $(CPPFLAGS) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
++	$(CC) -S $(INCDIR) $(EFI_CFLAGS) $(EFI_CPPFLAGS) -fno-toplevel-reorder -DBUILD_EFI -c $< -o $@
+ 
+ %.crt:
+ 	openssl req -new -x509 -newkey rsa:2048 -subj "/CN=$*/" -keyout $*.key -out $@ -days 3650 -nodes -sha256

--- a/srcpkgs/efitools/patches/makefile-remove-useless-problematic-target.patch
+++ b/srcpkgs/efitools/patches/makefile-remove-useless-problematic-target.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 7d471da..30e236b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,4 +1,4 @@
+-EFIFILES = HelloWorld.efi LockDown.efi Loader.efi ReadVars.efi UpdateVars.efi \
++EFIFILES = HelloWorld.efi Loader.efi ReadVars.efi UpdateVars.efi \
+ 	KeyTool.efi HashTool.efi SetNull.efi ShimReplace.efi
+ BINARIES = cert-to-efi-sig-list sig-list-to-certs sign-efi-sig-list \
+ 	hash-to-efi-sig-list efi-readvar efi-updatevar cert-to-efi-hash-list \
+@@ -27,20 +27,14 @@ include Make.rules
+ 
+ EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
+ 
+-all: $(EFISIGNED) $(BINARIES) $(MANPAGES) noPK.auth $(KEYAUTH) \
+-	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
+-
++all: $(EFIFILES) $(BINARIES)
+ 
+ install: all
+-	$(INSTALL) -m 755 -d $(MANDIR)
+-	$(INSTALL) -m 644 $(MANPAGES) $(MANDIR)
+ 	$(INSTALL) -m 755 -d $(EFIDIR)
+ 	$(INSTALL) -m 755 $(EFIFILES) $(EFIDIR)
+ 	$(INSTALL) -m 755 -d $(BINDIR)
+ 	$(INSTALL) -m 755 $(BINARIES) $(BINDIR)
+ 	$(INSTALL) -m 755 mkusb.sh $(BINDIR)/efitool-mkusb
+-	$(INSTALL) -m 755 -d $(DOCDIR)
+-	$(INSTALL) -m 644 README COPYING $(DOCDIR)
+ 
+ lib/lib.a lib/lib-efi.a: FORCE
+ 	$(MAKE) -C lib $(notdir $@)

--- a/srcpkgs/efitools/template
+++ b/srcpkgs/efitools/template
@@ -1,0 +1,43 @@
+# Template file for 'efitools'
+pkgname=efitools
+version=1.9.2
+revision=1
+build_style=gnu-makefile
+hostmakedepends="perl-File-Slurp"
+makedepends="gnu-efi-libs libressl-devel"
+short_desc="Tools to manipulate EFI secure boot platforms"
+maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git"
+distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/snapshot/${pkgname}-${version}.tar.gz"
+checksum=0f315b36e7d1ba74bfc97ab9f304f0a3072c47578bbe5e42594acae381f9acfe
+patch_args="-Nup1"
+
+post_patch() {
+	[ ! "$CROSS_BUILD" ] && return
+
+	case "${XBPS_TARGET_MACHINE}" in
+		arm*) _ARCH=arm ;;
+		i686*) _ARCH=ia32 ;;
+		*) _ARCH="${XBPS_TARGET_MACHINE%-musl}" ;;
+	esac
+	# 1: correct target arch
+	# 2,3,4: include and lib inside sysroot
+	# 5: use cross-objcopy
+	sed -i -e "/^ARCH[[:space:]]*=/s/=.*/=${_ARCH}/" \
+		-e "s,^\(CRTPATH.*=\).*,\1${XBPS_CROSS_BASE}/usr/lib," \
+		-e "/^INCDIR/s,I\(/usr/include\),I${XBPS_CROSS_BASE}\1,g" \
+		-e "s,-L /usr/lib,-L ${XBPS_CROSS_BASE}/usr/lib,g" \
+		-e "/^OBJCOPY/d" \
+		Make.rules
+}
+
+efitools-efi_package() {
+	short_desc+=" - bare metal tools"
+	nostrip=yes
+	noverifyrdeps=yes
+	noshlibprovides=yes
+	pkg_install() {
+		vmove usr/share/efitools
+	}
+}

--- a/srcpkgs/sbsigntool/files/kernel.d/sbsigntool.post-install
+++ b/srcpkgs/sbsigntool/files/kernel.d/sbsigntool.post-install
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Kernel hook for sbsigntool.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+
+PKGNAME="$1"
+VERSION="$2"
+
+msg() {
+	echo "EFI sbsign hook: $1"
+}
+
+. "${ROOTDIR}/etc/default/sbsigntool-kernel-hook"
+if [ "x${SBSIGN_EFI_KERNEL}" != x1 ]; then
+	exit 0
+fi
+
+if [ ! -f "${EFI_KEY_FILE}" ] || [ ! -f "${EFI_CERT_FILE}" ]; then
+	msg "key and/or certificate is not available"
+	exit 1
+fi
+
+key_stat=$(stat --dereference --format="%a %u" "${EFI_KEY_FILE}")
+
+# check if go=00 owner=0
+if [ "${key_stat}" = "${key_stat%00 0}" ]; then
+	msg "Please  chown root:root '${EFI_KEY_FILE}'"
+	msg "and     chmod go-rwx '${EFI_KEY_FILE}'"
+	exit 1
+fi
+
+# this part is completely untested
+options=""
+if [ "x${EFI_SIGN_ENGINE}" != x ]; then
+	options="--engine=${EFI_SIGN_ENGINE}"
+fi
+
+if ! sbsign $options -k "${EFI_KEY_FILE}" -c "${EFI_CERT_FILE}" \
+	"/boot/vmlinuz-${VERSION}"; then
+	msg "failed to sign kernel"
+	exit 1
+fi
+
+if ! sbverify -c "${EFI_CERT_FILE}" "/boot/vmlinuz-${VERSION}.signed"; then
+	msg "failed to verify the signature"
+	exit 1
+fi
+
+if [ "x${EFI_KEEP_UNSIGNED}" = "x1" ]; then
+	mv -f "/boot/vmlinuz-${VERSION}" "/boot/vmlinuz-${VERSION}.unsigned"
+fi
+mv -f "/boot/vmlinuz-${VERSION}.signed" "/boot/vmlinuz-${VERSION}"

--- a/srcpkgs/sbsigntool/files/sbsigntool-kernel-hook.conf
+++ b/srcpkgs/sbsigntool/files/sbsigntool-kernel-hook.conf
@@ -1,0 +1,21 @@
+# Options for kernel hook script installed by the sbsigntool package
+
+# set this option to 1 to sign the kernel with default hook
+SBSIGN_EFI_KERNEL=0
+
+# The key and certificate to sign
+#
+# sbsigntool will only sign if `EFI_KEY_FILE':
+#  - owner: root
+#  - permission: 0*00
+EFI_KEY_FILE=/etc/efikeys/db.key
+EFI_CERT_FILE=/etc/efikeys/db.crt
+
+# set to 1 to keep the unsigned backup
+EFI_KEEP_UNSIGNED=0
+
+# OpenSSL/LibreSSL engine to load the key
+# Completely untested, but here is your option
+# See `efi-updatevar', `sbsign', and `sbvarsign'
+# Don't uncomment this option unless you know what you're doing
+# EFI_SIGN_ENGINE=

--- a/srcpkgs/sbsigntool/patches/Align-signature-data-to-8-bytes.patch
+++ b/srcpkgs/sbsigntool/patches/Align-signature-data-to-8-bytes.patch
@@ -1,0 +1,26 @@
+From 8b6b7a9904881757254b92a928b95dfb8634605b Mon Sep 17 00:00:00 2001
+From: Steve Langasek <steve.langasek@canonical.com>
+Date: Fri, 12 Oct 2012 16:27:13 -0700
+Subject: [PATCH] Align signature data to 8 bytes
+
+Before appending the signature data to our binary, pad the file out to
+8-byte alignment.  This matches the Microsoft signing implementation, which
+enables us to use sbattach to verify the integrity of the binaries returned
+by the SysDev signing service.
+---
+ src/image.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+Index: sbsigntool/src/image.c
+===================================================================
+--- sbsigntool.orig/src/image.c
++++ sbsigntool/src/image.c
+@@ -495,6 +495,8 @@ reparse:
+ 	 * we've calculated during the pecoff parsing, so we need to redo that
+ 	 * too.
+ 	 */
++	image->data_size = align_up(image->data_size, 8);
++
+ 	if (image->data_size > image->size) {
+ 		image->buf = talloc_realloc(image, image->buf, uint8_t,
+ 				image->data_size);

--- a/srcpkgs/sbsigntool/patches/libressl.patch
+++ b/srcpkgs/sbsigntool/patches/libressl.patch
@@ -1,0 +1,11 @@
+--- a/src/sbverify.c
++++ b/src/sbverify.c
+@@ -56,7 +56,7 @@
+ #include <openssl/pem.h>
+ #include <openssl/x509v3.h>
+ 
+-#if OPENSSL_VERSION_NUMBER < 0x10100000L
++#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+ #define X509_OBJECT_get0_X509(obj) ((obj)->data.x509)
+ #define X509_OBJECT_get_type(obj) ((obj)->type)
+ #define X509_STORE_CTX_get0_cert(ctx) ((ctx)->cert)

--- a/srcpkgs/sbsigntool/patches/sbsign_check_write_return.patch
+++ b/srcpkgs/sbsigntool/patches/sbsign_check_write_return.patch
@@ -1,0 +1,52 @@
+Index: sbsigntool/src/sbsign.c
+===================================================================
+--- sbsigntool.orig/src/sbsign.c
++++ sbsigntool/src/sbsign.c
+@@ -242,12 +242,12 @@ int main(int argc, char **argv)
+ 
+ 		for (i = 0; !image_get_signature(ctx->image, i, &buf, &len); i++)
+ 			;
+-		image_write_detached(ctx->image, i - 1, ctx->outfilename);
++		rc = image_write_detached(ctx->image, i - 1, ctx->outfilename);
+ 	} else
+-		image_write(ctx->image, ctx->outfilename);
++		rc = image_write(ctx->image, ctx->outfilename);
+ 
+ 	talloc_free(ctx);
+ 
+-	return EXIT_SUCCESS;
++	return (rc == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+ }
+ 
+Index: sbsigntool/src/fileio.c
+===================================================================
+--- sbsigntool.orig/src/fileio.c
++++ sbsigntool/src/fileio.c
+@@ -201,12 +201,12 @@ int fileio_write_file(const char *filena
+ 
+ 	fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+ 	if (fd < 0) {
+-		perror("open");
++		perror("fileio_write_file/open");
+ 		return -1;
+ 	}
+ 
+ 	if (!write_all(fd, buf, len)) {
+-		perror("write_all");
++		perror("fileio_write_file/write_all");
+ 		close(fd);
+ 		return -1;
+ 	}
+Index: sbsigntool/src/image.c
+===================================================================
+--- sbsigntool.orig/src/image.c
++++ sbsigntool/src/image.c
+@@ -658,7 +658,7 @@ int image_write(struct image *image, con
+ 
+ 	fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+ 	if (fd < 0) {
+-		perror("open");
++		perror("image_write/open");
+ 		return -1;
+ 	}
+ 

--- a/srcpkgs/sbsigntool/template
+++ b/srcpkgs/sbsigntool/template
@@ -1,0 +1,48 @@
+# Template file for 'sbsigntool'
+pkgname=sbsigntool
+version=0.9.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf automake pkg-config"
+makedepends="binutils-devel libressl-devel libuuid-devel gnu-efi-libs"
+depends="libcrypto44 libuuid"
+short_desc="Signing utility for UEFI secure boot"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/"
+distfiles="${DEBIAN_SITE}/main/s/${pkgname}/${pkgname}_${version}.orig.tar.gz"
+checksum=1dc1e1de5f2dda50dbd2e6a83355fe7ae38ca0f79daeb404026421af70606653
+patch_args="-Np1"
+
+if [ ! "$CROSS_BUILD" ]; then
+	hostmakedepends+=" help2man"
+fi
+
+pre_patch() {
+	[ ! "$CROSS_BUILD" ] && return
+
+	case "${XBPS_TARGET_MACHINE}" in
+		arm*) _ARCH=arm ;;
+		i686*) _ARCH=ia32 ;;
+		*) _ARCH="${XBPS_TARGET_MACHINE%-musl}" ;;
+	esac
+	sed -i -e "/^EFI_ARCH=/s/=.*/=${_ARCH}/" \
+		-e "s,^\(for path in\).*;,\1 ${XBPS_CROSS_BASE}/usr/lib ;," \
+		-e "/^EFI_CPPFLAGS=/s,I\(/usr/include\),I${XBPS_CROSS_BASE}\1,g" \
+		configure.ac
+	sed -i -e "/^man/s/=.*/=/" docs/Makefile.am
+}
+
+pre_configure() {
+	autoreconf -i
+}
+
+post_install() {
+	vmkdir etc/
+	vinstall "${FILESDIR}/sbsigntool-kernel-hook.conf" 644 \
+		etc/default sbsigntool-kernel-hook
+	# grub is 50, I don't use grub
+	# and I'm not sure about their interaction
+	vinstall ${FILESDIR}/kernel.d/sbsigntool.post-install 744 \
+		etc/kernel.d/post-install 40-sbsigntool
+}


### PR DESCRIPTION
- Compiled on x86_64 for:
    - x86_64
    - aarch64
    - aarch64-musl

- Run with secure boot enabled on:
    - x86_64 on ThinkPad T480