### PR TITLE
SDL2: enable gles/wayland build options on aarch64/x86/ppc.

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
 version=2.0.9
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
  --enable-clock_gettime --disable-nas --disable-arts --disable-x11-shared
@@ -17,14 +17,14 @@ distfiles="http://www.libsdl.org/release/${pkgname}-${version}.tar.gz"
 checksum=255186dc676ecd0c1dbf10ec8a2cc5d6869b5079d8a38194c2aecdff54b324b1
 
 # Package build options
-build_options="gles opengl pulseaudio sndio wayland x11 vulkan"
+build_options="gles opengl pulseaudio sndio vulkan wayland x11"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*|ppc*)
-		build_options_default="opengl pulseaudio x11 vulkan sndio"
+		build_options_default="gles opengl pulseaudio sndio vulkan wayland x11"
 		;;
 	aarch64*)
-		build_options_default="gles opengl pulseaudio x11 sndio"
+		build_options_default="gles opengl pulseaudio sndio x11"
 		;;
 	arm*)
 		# Enable OpenGL/ES on rpi platforms
@@ -50,7 +50,6 @@ if [ "$build_option_gles" ]; then
 	*)
 		# libGLESv2.so.2 is dynamically loaded with dlopen.
 		shlib_requires="libGLESv2.so.2"
-		makedepends+=" glu-devel"
 		depends="libGLES"
 		;;
 	esac
@@ -63,9 +62,12 @@ if [ "$build_option_opengl" ]; then
 	shlib_requires="libGL.so.1"
 	depends="libGL"
 	configure_args+=" --enable-video-opengl"
-	makedepends+=" glu-devel"
 else
 	configure_args+=" --disable-video-opengl"
+fi
+
+if [ "$build_option_opengl" -o "$build_option_gles" ]; then
+	makedepends+=" glu-devel"
 fi
 
 if [ "$build_option_pulseaudio" ]; then
@@ -83,8 +85,8 @@ else
 fi
 
 if [ "$build_option_wayland" ]; then
-	if [ "$build_option_opengl" ]; then
-		msg_error "$pkgname: wayland option requires gles and not opengl.\n"
+	if [ -z "$build_option_gles" ]; then
+		msg_error "$pkgname: wayland option requires gles.\n"
 	fi
 	configure_args+=" --enable-video-wayland --disable-wayland-shared"
 	makedepends+=" libxkbcommon-devel wayland-devel wayland-protocols"


### PR DESCRIPTION
This way we can just set the envvar "SDL_VIDEODRIVER=wayland"
to make this work with no changes.

Tested on sway with neverball.