### PR TITLE
glfw: update to 3.3.

### DIFF
--- a/srcpkgs/glfw/template
+++ b/srcpkgs/glfw/template
@@ -1,17 +1,27 @@
 # Template file for 'glfw'
 pkgname=glfw
-version=3.2.1
+version=3.3
 revision=1
 build_style=cmake
-makedepends="MesaLib-devel libXrandr-devel libXi-devel glu-devel libXcursor-devel
- libXinerama-devel"
+configure_args="
+ $(vopt_if wayland '-DGLFW_USE_WAYLAND=1') -DBUILD_SHARED_LIBS=1"
+hostmakedepends="pkg-config
+ $(vopt_if wayland 'wayland-devel extra-cmake-modules')"
+makedepends="MesaLib-devel
+ $(vopt_if wayland 'wayland-protocols wayland-devel libxkbcommon-devel' \
+	'libXrandr-devel libXi-devel libXcursor-devel libXinerama-devel')"
 short_desc="Multi-platform library for creating windows with OpenGL contexts"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="BSD-3"
+license="BSD-3-Clause"
 homepage="http://www.glfw.org"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=9a9681bc720fa00a4fd104108f2667e0fe4f0f20b7e0034c64b21e1d1e73634a
-configure_args="-DBUILD_SHARED_LIBS=ON"
+checksum=32797630af0da94a1a05302bca0435eae352f593197a04670d797de2e492a5a5
+
+build_options="wayland"
+
+post_install() {
+	vlicense LICENSE.md
+}
 
 glfw-devel_package() {
 	depends="glfw>=${version}_${revision} $makedepends"


### PR DESCRIPTION
Added wayland build option (off), we can't enable it by default
otherwise X11 is disabled.