### PR TITLE
bc-gh: update to 1.2.6

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,6 +1,6 @@
 # Template file for 'bc-gh'
 pkgname=bc-gh
-version=1.2.3
+version=1.2.6
 revision=1
 wrksrc="bc-${version}"
 short_desc="Implementation of POSIX bc with GNU extensions"
@@ -8,7 +8,7 @@ maintainer="Gavin D. Howard <yzena.tech@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/gavinhoward/bc"
 distfiles="${homepage}/releases/download/${version}/bc-${version}.tar.xz"
-checksum=2285c804ae0984743fa85af1fc2506c4a3e91f031f47ecb12700db0771c23349
+checksum=56ee9256f6864e4b5c2ec053dd2ecd95e6230de9590348101f142c6be69f2f6b
 alternatives="
  bc:bc:/usr/bin/bc-gh
  dc:dc:/usr/bin/dc-gh"


### PR DESCRIPTION
This release contains more locales, removes dependence on the non-POSIX `local` in shell scripts, updates the dc man page to fix a small omission, and fixes a rare and subtle use-after-free bug in dc.