### PR TITLE
[DONOTMERGE] New packages: nx-libs, perl-Switch, x2goclient & x2goserver

### DIFF
--- a/srcpkgs/nx-libs/template
+++ b/srcpkgs/nx-libs/template
@@ -1,0 +1,20 @@
+# Template file for 'nx-libs'
+pkgname=nx-libs
+version=3.5.99.16
+revision=1
+build_style=gnu-makefile
+make_install_args="PREFIX=/usr"
+hostmakedepends="autoconf automake libtool pkg-config"
+makedepends="xorgproto zlib-devel libjpeg-turbo-devel libpng-devel"
+short_desc="NX X11 protocol compression libraries"
+maintainer="Anachron <gith@cron.world>"
+license="GPL-2.0-only"
+homepage="http://www.x2go.org"
+distfiles="https://code.x2go.org/releases/source/${pkgname}/${pkgname}-${version}-lite.tar.gz"
+checksum=02c2e382ad27d1b3a0febe31c19f0c2868460f0703b85e8c98ef6203074f7fd4
+
+do_build() {
+  make ${makejobs} PREFIX=/usr \
+  CONFIGURE="./configure ${configure_args} --prefix=/usr --libdir=/usr/lib \
+ --libexecdir=/usr/lib --includedir=/usr/include"
+}

--- a/srcpkgs/perl-Switch/template
+++ b/srcpkgs/perl-Switch/template
@@ -1,0 +1,14 @@
+# Template file for 'perl-Switch'
+pkgname=perl-Switch
+version=2.17
+revision=1
+wrksrc="${pkgname#*-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+depends="perl"
+short_desc="Switch statement for Perl"
+maintainer="Anachron <gith@cron.world>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/pod/Switch"
+distfiles="https://cpan.metacpan.org/authors/id/C/CH/CHORNY/Switch-${version}.tar.gz"
+checksum=31354975140fe6235ac130a109496491ad33dd42f9c62189e23f49f75f936d75

--- a/srcpkgs/x2goclient/patches/fix-printwidget-qt5.patch
+++ b/srcpkgs/x2goclient/patches/fix-printwidget-qt5.patch
@@ -1,0 +1,11 @@
+--- src/printwidget.cpp.orig
++++ src/printwidget.cpp
+@@ -23,6 +23,7 @@
+ #include "x2gosettings.h"
+ #include "x2gologdebug.h"
+ #include <QDir>
++#include <QButtonGroup>
+ #ifdef Q_OS_WIN
+ #include "wapi.h"
+ #endif
+

--- a/srcpkgs/x2goclient/patches/no-ssh_threads.patch
+++ b/srcpkgs/x2goclient/patches/no-ssh_threads.patch
@@ -1,0 +1,11 @@
+--- x2goclient.pro.orig 2018-09-12 20:49:18.127265853 -0700
++++ x2goclient.pro  2018-09-12 20:49:30.592340872 -0700
+@@ -132,7 +132,7 @@
+            src/compat.cpp \
+            src/pulsemanager.cpp
+
+-LIBS += -lssh -lssh_threads
++LIBS += -lssh
+ win32:LIBS += -lAdvAPI32 -lshell32 -lUser32
+
+ RC_FILE = res/x2goclient.rc

--- a/srcpkgs/x2goclient/template
+++ b/srcpkgs/x2goclient/template
@@ -1,0 +1,24 @@
+# Template file for 'x2goclient'
+pkgname=x2goclient
+version=4.1.2.1
+revision=1
+build_style=gnu-makefile
+make_build_target="build_client build_man"
+make_install_target="install_client install_man"
+hostmakedepends="qt5-tools"
+makedepends="qt5-devel qt5-svg-devel qt5-x11extras-devel libldap-devel libssh-devel libXpm-devel cups-devel"
+depends="nx-libs"
+short_desc="Client for the X2Go remote desktop solution"
+maintainer="Anachron <gith@cron.world>"
+license="GPL-2.0-or-later"
+homepage="https://wiki.x2go.org/doku.php/doc:usage:x2goclient"
+distfiles="http://code.x2go.org/releases/source/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum="1c18981f0a39929624de9472b0e6c3fa2ac7842837dd306db318af54c5fff2af"
+
+if [ "${CROSS_BUILD}"]; then
+	hostmakedepends+=" qt5-svg-devel qt5-x11extras-devel"
+fi
+
+pre_build() {
+	sed -i -e 's/qt4/qt5/g' Makefile
+}

--- a/srcpkgs/x2goserver/INSTALL.msg
+++ b/srcpkgs/x2goserver/INSTALL.msg
@@ -1,0 +1,2 @@
+Run the following command to initialize the SQLite database:
+  # x2godbadmin --createdb

--- a/srcpkgs/x2goserver/files/x2goserver/run
+++ b/srcpkgs/x2goserver/files/x2goserver/run
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+/usr/sbin/x2gocleansessions
+pid=$(cat '/run/x2goserver.pid')
+trap "kill ${pid}" EXIT
+tail --pid="${pid}" -f /dev/null

--- a/srcpkgs/x2goserver/template
+++ b/srcpkgs/x2goserver/template
@@ -1,0 +1,38 @@
+# Template file for 'x2goserver'
+pkgname=x2goserver
+version=4.1.0.3
+revision=1
+build_style=gnu-makefile
+make_build_args="PERL_INSTALLDIRS=vendor"
+makedepends="perl perl-ExtUtils-Helpers"
+depends="perl-DBI perl-DBD-SQLite perl-Config-Simple perl-Capture-Tiny
+ perl-File-BaseDir perl-File-Which perl-Try-Tiny xwininfo setxkbmap dbus
+ lsof psmisc pwgen fuse-sshfs xauth desktop-file-utils shared-mime-info
+ perl-Switch"
+short_desc="OS graphical RD and terminal server based on NX technology"
+maintainer="Anachron <gith@cron.world>"
+license="GPL-2.0-or-later"
+homepage="https://wiki.x2go.org/doku.php/wiki:advanced:x2goserver-in-detail"
+distfiles="http://code.x2go.org/releases/source/x2goserver/${pkgname}-${version}.tar.gz"
+checksum=6776aaa354f5a44e349f0b3c176d4988c88a618c2edf46c98a37ae89c069dcd0
+system_accounts="x2gouser:111 x2goprint:112"
+x2gouser_homedir="/var/lib/x2go"
+x2goprint_homedir="/var/spool/x2go"
+make_dirs="
+ ${x2gouser_homedir} 0750 x2gouser
+ ${x2goprint_homedir} 0750 x2goprint"
+
+pre_build() {
+	for mf in $(find . -type f -name Makefile); do
+		sed -i -e 's/^MAN2HTML_BIN.*/MAN2HTML_BIN =/g' $mf
+		sed -i -e 's/^SBINDIR.*/SBINDIR=$(PREFIX)\/bin/g' $mf
+		sed -i -e 's/^PREFIX.*/PREFIX ?= \/usr/g' $mf
+		sed -i "s:-o root -g root ::g" $mf
+	done
+
+	sed -i -e '/xsession/s/^/#/' Makefile
+}
+
+post_install() {
+	vsv "${pkgname}"
+}


### PR DESCRIPTION
[ci skip]

Everything builds and installs, yet somehow `x2goclient` cannot connect to `x2goserver` and throws the following error:

```
/usr/lib/x2go/x2gocheckport: Zeile 131: 
connect('dbname=/var/lib/x2go/x2go_sessions','',...): 
Syntaxfehler im Ausdruck. (Fehlerverursachendes Zeichen ist \"
('dbname=/var/lib/x2go/x2go_sessions','',...)\"). 
Unable to find free display port or insert new session into database; parameters: port (50), 
hostname (void-lap) and session name (). 
```

If someone wants to chime in and help out I'll be glad.

Edit:
Error comes out from `x2goserver/bin/x2gostartagent` line 270:
```
if [[ "${output}" != 'inserted' ]]; then
  typeset msg="Unable to find free display port or insert new session into datab
  "${X2GO_LIB_PATH}/x2gosyslog" "${0}" 'err' "${msg}"

  # Make x2goclient fail.
  echo "${msg}" >&2
  exit '10'
fi
```