### PR TITLE
gtk-engine-murrine: enable 32bit package

### DIFF
--- a/srcpkgs/gtk-engine-murrine/template
+++ b/srcpkgs/gtk-engine-murrine/template
@@ -1,9 +1,9 @@
 # Template file for 'gtk-engine-murrine'
 pkgname=gtk-engine-murrine
 version=0.98.2
-revision=6
+revision=7
 wrksrc="murrine-${version}"
-build_style="gnu-configure"
+build_style=gnu-configure
 configure_args="--enable-animation"
 hostmakedepends="pkg-config intltool"
 makedepends="gtk+-devel"
@@ -13,4 +13,3 @@ license="LGPL-2.0-or-later"
 homepage="http://cimitan.com/murrine/project/murrine"
 distfiles="${GNOME_SITE}/murrine/0.98/murrine-${version}.tar.xz"
 checksum=e9c68ae001b9130d0f9d1b311e8121a94e5c134b82553ba03971088e57d12c89
-lib32disabled=yes


### PR DESCRIPTION
closes #10225