### PR TITLE
SDL2: fix runtime when starting in wayland video mode.

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
 version=2.0.9
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
  --enable-clock_gettime --disable-nas --disable-arts --disable-x11-shared
@@ -59,8 +59,8 @@ fi
 
 if [ "$build_option_opengl" ]; then
 	# libGL.so.1 is dynamically loaded with dlopen.
-	shlib_requires="libGL.so.1"
-	depends="libGL"
+	shlib_requires+=" libGL.so.1"
+	depends+=" libGL"
 	configure_args+=" --enable-video-opengl"
 else
 	configure_args+=" --disable-video-opengl"


### PR DESCRIPTION
if gles and opengl build options are both enabled, the libEGL
runtime dependency as well as shlib_requires is overwritten
later by the opengl build option block.