### PR TITLE
musl: revert to 1.1.21.

### DIFF
--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -1,7 +1,8 @@
 # Template file for 'musl'.
 pkgname=musl
-version=1.1.22
-revision=1
+reverts="1.1.22_1"
+version=1.1.21
+revision=3
 archs="*-musl"
 build_style=gnu-configure
 configure_args="--prefix=/usr --disable-gcc-wrapper"
@@ -12,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="MIT"
 homepage="http://www.musl-libc.org/"
 distfiles="http://www.musl-libc.org/releases/musl-${version}.tar.gz"
-checksum=8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+checksum=c742b66f6f49c9e5f52f64d8b79fecb5a0f6e0203fca176c70ca20f6be285f44
 
 nostrip_files="libc.so"
 shlib_provides="libc.so"


### PR DESCRIPTION
musl-1.1.22 broke firefox and chromium (see #11149).
I think it is best to revert to 1.1.21 until someone finds time to fix the browsers.