### PR TITLE
libGL: get rid of unnecessary libudev runtime dependency.

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,7 +1,7 @@
 # Template file for 'libGL'
 pkgname=libGL
 version=19.0.2
-revision=1
+revision=2
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dshared-glapi=true -Dgbm=true -Degl=true
@@ -99,7 +99,6 @@ post_install() {
 }
 
 libglapi_package() {
-	depends="libudev"
 	short_desc="Free implementation of the GL API - shared library"
 	pkg_install() {
 		vmove "usr/lib/libglapi.so.*"
@@ -121,7 +120,6 @@ libEGL_package() {
 }
 
 libGLES_package() {
-	depends="libudev"
 	short_desc="Free implementation of the OpenGL|ES 1.x and 2.x API"
 	pkg_install() {
 		vmove "usr/lib/libGLES*.so.*"


### PR DESCRIPTION
I think those were added long ago and probably we don't need
it anymore.