### PR TITLE
[DO NOT MERGE] android-studio: update to 3.4.2

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,23 +1,21 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=3.3.2
+version=3.4.2
 revision=1
 # _studio_build and _studio_rev are for downloading the zip from dl.google.com
 # https://developer.android.com/studio/#resources as of 2018-07-12
-_studio_build=182.5314842
+_studio_build=183.5692245
 _studio_rev=0
 archs="x86_64 i686"
 create_wrksrc=yes
-build_style=fetch
-hostmakedepends="unzip"
 depends="gtk+ libGL"
 short_desc="Official Android IDE"
 maintainer="Jordyn Carattini <onlinecloud1@gmail.com>"
 license="Apache-2.0"
 homepage="http://tools.android.com/"
 # changelog="https://developer.android.com/studio/releases/index.html"
-distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}.${_studio_rev}/android-studio-ide-${_studio_build}-linux.zip"
-checksum=8257d3eab61c3da088e26689888a13e53e210c109a4e775ed71158b4471bb06a
+distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}.${_studio_rev}/android-studio-ide-${_studio_build}-linux.tar.gz"
+checksum=35eb8c74837d1aab59229101fc91568a607ac04854a40209f7a0ba7ac0601924
 repository=nonfree
 nopie=yes
 nostrip=yes
@@ -34,14 +32,17 @@ skiprdeps="/opt/android-studio/plugins/android/resources/installer/arm64-v8a/ins
  /opt/android-studio/plugins/android/resources/perfd/armeabi-v7a/perfd
  /opt/android-studio/plugins/android/resources/perfd/x86/perfd"
 
+do_extract() {
+	tar xfz ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}-ide-183.5692245-linux.tar.gz --strip-components=1 -C ${wrksrc}
+}
+
 do_install() {
-	unzip android-studio-ide-${_studio_build}-linux.zip
 	vmkdir opt/${pkgname}
-	vcopy android-studio/bin opt/${pkgname}/
-	vcopy android-studio/gradle opt/${pkgname}/
-	vcopy android-studio/lib opt/${pkgname}/
-	vcopy android-studio/jre opt/${pkgname}/
-	vcopy android-studio/plugins opt/${pkgname}/
+	vcopy bin opt/${pkgname}/
+	vcopy gradle opt/${pkgname}/
+	vcopy lib opt/${pkgname}/
+	vcopy jre opt/${pkgname}/
+	vcopy plugins opt/${pkgname}/
 	vmkdir usr/bin
 	ln -s /opt/android-studio/bin/studio.sh ${DESTDIR}/usr/bin/android-studio
 	vinstall "${FILESDIR}/android-studio.desktop" 644 usr/share/applications/


### PR DESCRIPTION
Please don't merge yet, I'm getting the following error when trying to install:
```zsh
$> sudo xbps-install --repository=hostdir/binpkgs/android-studio-update-branch/nonfree android-studio
Password:
android-studio-3.4.0_1: broken, unresolvable shlib `ld-linux.so.2'
android-studio-3.4.0_1: broken, unresolvable shlib `libncurses.so.5'
Transaction aborted due to unresolved shlibs.
```