### PR TITLE
crystal: update to 0.28.0.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,9 +1,9 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.27.2
+version=0.28.0
 revision=1
 _shardsversion=0.8.1
-_bootstrapversion=0.27.0
+_bootstrapversion=0.28.0
 _bootstraprevision=1
 hostmakedepends="git llvm6.0"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -18,7 +18,7 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="d2fe8a025668b143e8ff70b3cd407765140ed10e52523dd08253139f9322171b
+checksum="4206f57c6345454504ec4cd8cbd1b9354b9be29fae4cdcdd173f4a28cc13b102
  75c74ab6acf2d5c59f61a7efd3bbc3c4b1d65217f910340cb818ebf5233207a5"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -31,11 +31,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" a6a6966e1089df2c3467ceb200db9a282dcbfef54418865638bf152f3cd36642"
+		checksum+=" 0ae13581b0d30740f232c9a29e444184121fc263b22c01d2c94290660860982e"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 7d495b9e51f6665c6745f7d297a40bcbfb842fbb2f29ed91fb037a6813c75fd7"
+		checksum+=" a6879503badb064c9420d92f126ab08b0441a2b49d84e4fe238a52214a65ac33"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"


### PR DESCRIPTION
Built on x86_64 with glibc without errors.