### PR TITLE
webkit2gtk: fix build by enabling SSE2 on i686

### DIFF
--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -36,7 +36,7 @@ CXXFLAGS="-Wno-expansion-to-defined"
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) configure_args+=" -DUSE_LD_GOLD=0";;
-        i686*) broken="https://build.voidlinux.org/builders/i686_builder/builds/17230/steps/shell_3/logs/stdio";;
+	i686*) CXXFLAGS+="-O2 -msse2";;
 esac
 
 # Package build options


### PR DESCRIPTION
We already need SSE2 anyway due to gst-plugins-base1, which also uses it.

fixes #11162

[ci skip]