### PR TITLE
pcc snapshot that really works

### DIFF
--- a/srcpkgs/pcc-libs/template
+++ b/srcpkgs/pcc-libs/template
@@ -1,14 +1,22 @@
 # Template file for 'pcc-libs'
 pkgname=pcc-libs
-version=1.1.0
+_snapshot=20190420
+_distver=1.1.0
+version=${_distver}.${_snapshot}
 revision=1
-wrksrc=${pkgname}-${version}
+wrksrc=${pkgname}-${_distver}.BETA
 build_style=gnu-configure
 hostmakedepends="flex"
 short_desc="Portable C Compiler - Support Libraries"
-homepage="http://pcc.ludd.ltu.se/"
-license="BSD"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-distfiles="http://pcc.ludd.ltu.se/ftp/pub/pcc-releases/$pkgname-$version.tgz"
-checksum=dd4cb124da0b2edcda6ceb823c3ca8fc05919d35c89c34dec617517afe6bbfee
-archs="i686 x86_64"
+license="BSD-2-clause"
+homepage="http://pcc.ludd.ltu.se/"
+distfiles="http://pcc.ludd.ltu.se/ftp/pub/pcc-beta/${pkgname}-${_distver}.BETA-${_snapshot}.tgz"
+checksum=e810aa4d6683e769f490f734b13a296b33c2511ddba646bc526eb85532f1a23a
+nodebug=1
+nocross=1
+
+post_install() {
+	sed -n '2,25p' libpcc/cxmuldiv.c > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/pcc/patches/void.patch
+++ b/srcpkgs/pcc/patches/void.patch
@@ -1,0 +1,40 @@
+--- os/linux/ccconfig.h.orig	2019-04-21 12:16:53.029059057 +0200
++++ os/linux/ccconfig.h	2019-04-21 12:18:19.757287684 +0200
+@@ -39,26 +39,31 @@
+ 
+ #if defined(mach_i386)
+ #define CPPMDADD	{ "-D__i386__", NULL, }
+-#define DYNLINKER	{ "-dynamic-linker", "/lib/ld-linux.so.2", NULL }
++#define DYNLINKER	{ "-dynamic-linker", "/usr/lib/ld-linux.so.2", NULL }
+ #elif defined(mach_powerpc)
+ #define CPPMDADD	{ "-D__ppc__", NULL, }
+-#define DYNLINKER	{ "-dynamic-linker", "/lib/ld-linux.so.2", NULL }
++#define DYNLINKER	{ "-dynamic-linker", "/usr/lib/ld-linux.so.2", NULL }
+ #elif defined(mach_amd64)
+ #define CPPMDADD	{ "-D__x86_64__", "-D__x86_64", "-D__amd64__", \
+ 	"-D__amd64", "-D__LP64__", "-D_LP64", NULL, }
+-#define	DYNLINKER { "-dynamic-linker", "/lib64/ld-linux-x86-64.so.2", NULL }
++#define	DYNLINKER { "-dynamic-linker", "/usr/lib/ld-linux-x86-64.so.2", NULL }
+ #ifndef MULTIARCH_PATH
+-#define	DEFLIBDIRS	{ "/usr/lib64/", 0 }
++#define	DEFLIBDIRS	{ "/usr/lib/", 0 }
+ #else
+-#define	DEFLIBDIRS	{ "/usr/lib64/", "/usr/lib/" MULTIARCH_PATH "/", 0 }
++#define	DEFLIBDIRS	{ "/usr/lib/", "/usr/lib32/" MULTIARCH_PATH "/", 0 }
+ #endif
+ #elif defined(mach_mips)
+ #define CPPMDADD { "-D__mips__", NULL, }
+-#define DYNLINKER { "-dynamic-linker", "/lib/ld.so.1", NULL }
++#define DYNLINKER { "-dynamic-linker", "/usr/lib/ld.so.1", NULL }
+ #else
+ #error defines for arch missing
+ #endif
+ 
++/* musl */
++#ifndef __GLIBC__
++#define DYNLINKER { "-dynamic-linker", "/usr/lib/libc.so", NULL }
++#endif
++
+ /* fixup small m options */
+ #if defined(mach_amd64)
+ #define PCC_EARLY_ARG_CHECK	{					\

--- a/srcpkgs/pcc/template
+++ b/srcpkgs/pcc/template
@@ -1,24 +1,32 @@
 # Template file for 'pcc'
 pkgname=pcc
-version=1.1.0
-revision=2
+_snapshot=20190420
+_distver=1.1.0
+version=${_distver}.${_snapshot}
+revision=1
+wrksrc=${pkgname}-${_distver}.BETA
 build_style=gnu-configure
-configure_args="--enable-tls"
+configure_args="--enable-tls --enable-native"
 hostmakedepends="flex"
 makedepends="pcc-libs"
-depends="pcc-libs>=${version}"
+depends="binutils pcc-libs>=${version}"
 short_desc="Portable C Compiler"
-homepage="http://pcc.ludd.ltu.se/"
-license="BSD"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-distfiles="http://pcc.ludd.ltu.se/ftp/pub/pcc-releases/pcc-$version.tgz"
-checksum=d9e3fed84c767dcddefb6b1f854d5da8921f3f65d8bd02997743412f41474d64
-archs="i686 x86_64"
+license="BSD-2-clause"
+homepage="http://pcc.ludd.ltu.se/"
+distfiles="http://pcc.ludd.ltu.se/ftp/pub/pcc-beta/pcc-${_distver}.BETA-${_snapshot}.tgz"
+checksum=a114dfca04b8b0559ea5d67b87d2d0fcb2bae2b4d9b9ba16ebc27960b921c812
+nocross=1
 
 pre_configure() {
-	sed -i '/GNUC_MINOR/s,3,1,g' cc/cc/cc.c cc/driver/platform.c
+	vsed -i '/GNUC_MINOR/s,3,1,g' cc/cc/cc.c cc/driver/platform.c
+}
+pre_build() {
+	cp common/*.[ch] mip
 }
 post_install() {
+	sed -n '2,27p' arch/i386/code.c > LICENSE
+	vlicense LICENSE
 	# Rename conflicting cpp.1 manpage.
 	mv ${DESTDIR}/usr/share/man/man1/{cpp,pcc-cpp}.1
 }


### PR DESCRIPTION
I had to update pcc to a recent snapshot to fix the issue with stdarg.

This now also builds and runs for musl for basic testing.