### PR TITLE
TerraState: update to 0.2

### DIFF
--- a/srcpkgs/TerraState/template
+++ b/srcpkgs/TerraState/template
@@ -1,22 +1,17 @@
 # Template file for 'TerraState'
 pkgname=TerraState
-version=0.1
-revision=3
+version=0.2
+revision=1
 build_style=go
 go_import_path="github.com/the-maldridge/TerraState"
 go_package="${go_import_path}/cmd/terrastate"
-hostmakedepends="dep"
+hostmakedepends="git"
 short_desc="Remote state for TerraForm"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/the-maldridge/TerraState"
 distfiles="https://github.com/the-maldridge/TerraState/archive/v$version.tar.gz"
-checksum=c36693ea0da06944a3303cd5ccbbbd48ff62ae910b7e9a6f986bd60b490c6579
-
-pre_build() {
-	cd $GOSRCPATH
-	dep ensure
-}
+checksum=e74f532ceb44ee28cb36ad619e9f8f3b9cd13ea52a747d808f4e819ae42b34ff
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This somehow got missed during the upgrade to the current release set from NetAuth.  Until this gets rebuilt there's no way to push terraform changes.