### PR TITLE
tcc: update to 0.9.27_3.

### DIFF
--- a/srcpkgs/tcc/template
+++ b/srcpkgs/tcc/template
@@ -1,19 +1,19 @@
 # Template file for 'tcc'
 pkgname=tcc
 version=0.9.27
-revision=2
-_gitrev=d348a9a51d32cece842b7885d27a411436d7887b
+revision=3
+_gitrev=85483f321d8df6cce08ef88d86f50c9a60b307ef
 wrksrc=tinycc-${_gitrev:0:7}
-nopie=yes
 build_style=gnu-configure
 make_check_target="test"
 hostmakedepends="perl"
-short_desc="The Tiny C Compiler"
+short_desc="Tiny C Compiler"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-homepage="http://bellard.org/tcc/"
 license="LGPL-2.1"
+homepage="http://bellard.org/tcc/"
 distfiles="http://repo.or.cz/tinycc.git/snapshot/${_gitrev}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=1c3a4150b4aaab9751af2112e8bfd8a93fd1a9d36af048e996ebfc0fd1f07e48
+checksum=6fd34260bd8df776f3710252aa9c2385d390729d20bff85de652610160fc8e35
+nopie=yes
 nocross=yes
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Update to a more recent snapshot, which should have a fix when
compiling with -pthread.

See https://lists.gnu.org/archive/html/tinycc-devel/2017-12/msg00034.html