### PR TITLE
firefox: allow SYS_membarrier in sandbox

### DIFF
--- a/srcpkgs/firefox/patches/fix-sandbox-membarrier.patch
+++ b/srcpkgs/firefox/patches/fix-sandbox-membarrier.patch
@@ -1,0 +1,52 @@
+allow usage of SYS_membarrier, needed since musl-1.1.22
+
+--- security/sandbox/linux/SandboxFilter.cpp
++++ security/sandbox/linux/SandboxFilter.cpp
+@@ -283,6 +283,8 @@
+       case __NR_set_tid_address:
+         return Allow();
+ #endif
++      case __NR_membarrier:
++        return Allow();
+ 
+         // prctl
+       case __NR_prctl: {
+
+--- security/sandbox/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
++++ security/sandbox/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
+@@ -1385,6 +1385,10 @@
+ #define __NR_memfd_create (__NR_SYSCALL_BASE+385)
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier (__NR_SYSCALL_BASE+389)
++#endif
++
+ // ARM private syscalls.
+ #if !defined(__ARM_NR_BASE)
+ #define __ARM_NR_BASE (__NR_SYSCALL_BASE + 0xF0000)
+
+--- security/sandbox/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
++++ security/sandbox/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
+@@ -1290,5 +1290,9 @@
+ #define __NR_memfd_create 319
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 324
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_64_LINUX_SYSCALLS_H_
+ 
+--- security/sandbox/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
++++ security/sandbox/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
+@@ -1490,5 +1490,9 @@
+ #define __NR_shutdown 373
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 375
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_32_LINUX_SYSCALLS_H_
+ 

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -4,7 +4,7 @@
 #
 pkgname=firefox
 version=66.0.3
-revision=1
+revision=2
 build_helper="rust"
 short_desc="Mozilla Firefox web browser"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"


### PR DESCRIPTION
needed for musl-1.1.22