### PR TITLE
chromium: allow usage of membarrier in sandbox

### DIFF
--- a/srcpkgs/chromium/patches/sandbox-membarrier.patch
+++ b/srcpkgs/chromium/patches/sandbox-membarrier.patch
@@ -1,0 +1,60 @@
+--- sandbox/linux/system_headers/arm64_linux_syscalls.h
++++ sandbox/linux/system_headers/arm64_linux_syscalls.h
+@@ -1063,4 +1063,8 @@
+ #define __NR_memfd_create 279
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 283
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_ARM64_LINUX_SYSCALLS_H_
+
+--- sandbox/linux/system_headers/arm_linux_syscalls.h
++++ sandbox/linux/system_headers/arm_linux_syscalls.h
+@@ -1385,6 +1385,10 @@
+ #define __NR_memfd_create (__NR_SYSCALL_BASE+385)
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier (__NR_SYSCALL_BASE+389)
++#endif
++
+ // ARM private syscalls.
+ #if !defined(__ARM_NR_BASE)
+ #define __ARM_NR_BASE (__NR_SYSCALL_BASE + 0xF0000)
+
+--- sandbox/linux/system_headers/x86_32_linux_syscalls.h
++++ sandbox/linux/system_headers/x86_32_linux_syscalls.h
+@@ -1422,5 +1422,9 @@
+ #define __NR_memfd_create 356
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 375
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_32_LINUX_SYSCALLS_H_
+ 
+--- sandbox/linux/system_headers/x86_64_linux_syscalls.h
++++ sandbox/linux/system_headers/x86_64_linux_syscalls.h
+@@ -1290,5 +1290,9 @@
+ #define __NR_memfd_create 319
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 324
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_64_LINUX_SYSCALLS_H_
+ 
+--- sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+@@ -370,6 +370,7 @@
+   switch (sysno) {
+     case __NR_exit:
+     case __NR_exit_group:
++    case __NR_membarrier:
+     case __NR_wait4:
+     case __NR_waitid:
+ #if defined(__i386__)

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -2,7 +2,7 @@
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
 version=72.0.3626.121
-revision=1
+revision=2
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"


### PR DESCRIPTION
needed for musl-1.1.22