### PR TITLE
ladspa-sdk: update to 1.15.

### DIFF
--- a/srcpkgs/alsaequal/template
+++ b/srcpkgs/alsaequal/template
@@ -1,7 +1,7 @@
 # Template file for 'alsaequal'
 pkgname=alsaequal
 version=0.7.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=yes
 makedepends="alsa-lib-devel ladspa-sdk"

--- a/srcpkgs/amsynth/template
+++ b/srcpkgs/amsynth/template
@@ -1,7 +1,7 @@
 # Template file for 'amsynth'
 pkgname=amsynth
 version=1.8.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pandoc intltool pkg-config"
 makedepends="dssi-devel ladspa-sdk gtk+-devel jack-devel alsa-lib-devel

--- a/srcpkgs/calf/template
+++ b/srcpkgs/calf/template
@@ -1,7 +1,7 @@
 # Template file for 'calf'
 pkgname=calf
 version=0.90.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-experimental"
 hostmakedepends="automake libtool pkg-config"

--- a/srcpkgs/caps/template
+++ b/srcpkgs/caps/template
@@ -1,7 +1,7 @@
 # Template file for 'caps'
 pkgname=caps
 version=0.9.26
-revision=2
+revision=3
 build_style=gnu-makefile
 make_use_env=yes
 makedepends="ladspa-sdk"

--- a/srcpkgs/cmt/template
+++ b/srcpkgs/cmt/template
@@ -1,7 +1,7 @@
 # Template file for 'cmt'
 pkgname=cmt
 version=1.17
-revision=1
+revision=2
 wrksrc="${pkgname}_${version}"
 build_wrksrc="src"
 build_style=gnu-makefile

--- a/srcpkgs/dssi-vst/template
+++ b/srcpkgs/dssi-vst/template
@@ -1,20 +1,18 @@
 # Template file for 'dssi-vst'
 pkgname=dssi-vst
 version=0.9.2.20140805
-revision=1
+revision=2
 _commit=b061c4360a89d3b69bfc44f63bc1bd33e2807f6c
+archs=i686
+wrksrc="dssi-vst-${_commit}"
 hostmakedepends="pkg-config git"
 makedepends="zlib-devel jack-devel alsa-lib-devel liblo-devel
  dssi-devel ladspa-sdk wine wine-devel"
 depends="dssi ladspa-sdk ladspa-sdk-progs wine"
 short_desc="Run Windows VST plugins on Linux"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="GPL"
+license="GPL-2.0-only"
 homepage="http://breakfastquay.com/dssi-vst/"
-
-archs=i686
-
-wrksrc="$pkgname-$_commit"
 distfiles="https://github.com/falkTX/dssi-vst/archive/$_commit.tar.gz"
 checksum=f93da35b11a09d51263dcd76be79721151ba629dec946f80bf3e5f1201643a91
 

--- a/srcpkgs/dssi/template
+++ b/srcpkgs/dssi/template
@@ -1,7 +1,7 @@
 # Template file for 'dssi'
 pkgname=dssi
 version=1.1.1
-revision=6
+revision=7
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="

--- a/srcpkgs/guitarix2/template
+++ b/srcpkgs/guitarix2/template
@@ -1,7 +1,7 @@
 # Template file for 'guitarix2'
 pkgname=guitarix2
 version=0.37.3
-revision=3
+revision=4
 wrksrc="guitarix-${version}"
 build_style=waf
 configure_args="--cxxflags-release=-DNDEBUG --ladspa --new-ladspa --no-faust --no-lv2

--- a/srcpkgs/hexter/template
+++ b/srcpkgs/hexter/template
@@ -1,7 +1,7 @@
 # Template file for 'hexter'
 pkgname=hexter
 version=1.1.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel dssi-devel liblo-devel ladspa-sdk alsa-lib-devel"

--- a/srcpkgs/invada-studio-plugins/template
+++ b/srcpkgs/invada-studio-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'invada-studio-plugins'
 pkgname=invada-studio-plugins
 version=0.3.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=yes
 makedepends="ladspa-sdk"

--- a/srcpkgs/ladspa-bs2b/template
+++ b/srcpkgs/ladspa-bs2b/template
@@ -1,7 +1,7 @@
 # Template file for 'ladspa-bs2b'
 pkgname=ladspa-bs2b
 version=0.9.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libbs2b-devel ladspa-sdk"

--- a/srcpkgs/ladspa-sdk/patches/fix-cross.patch
+++ b/srcpkgs/ladspa-sdk/patches/fix-cross.patch
@@ -1,5 +1,5 @@
---- src/makefile	2007-11-06 11:42:45.000000000 +0100
-+++ src/makefile	2015-09-28 12:37:57.171530771 +0200
+--- src/Makefile	2007-11-06 11:42:45.000000000 +0100
++++ src/Makefile	2015-09-28 12:37:57.171530771 +0200
 @@ -46,17 +46,8 @@
  # TARGETS
  #
@@ -19,4 +19,4 @@
 +	@echo No testing.
  
  install:	targets
- 	-mkdirhier $(INSTALL_PLUGINS_DIR)
+ 	-mkdir -p $(INSTALL_PLUGINS_DIR)

--- a/srcpkgs/ladspa-sdk/patches/fix-pie.patch
+++ b/srcpkgs/ladspa-sdk/patches/fix-pie.patch
@@ -1,32 +1,34 @@
 --- src/makefile.orig
-+++ src/makefile
++++ src/Makefile
 @@ -15,7 +15,7 @@
  
  INCLUDES	=	-I.
  LIBRARIES	=	-ldl -lm
--CFLAGS		=	$(INCLUDES) -Wall -Werror -O3 -fPIC
-+CFLAGS		+=	$(INCLUDES) -Wall -Werror -O3 -fPIC
+-CFLAGS		=	$(INCLUDES) -Wall -Werror -O2 -fPIC 		\
++CFLAGS		+=	$(INCLUDES) -Wall -Werror -O2 -fPIC 		\
+ 			-DDEFAULT_LADSPA_PATH=$(INSTALL_PLUGINS_DIR)
+ BINFLAGS	=	-fPIE -pie
  CXXFLAGS	=	$(CFLAGS)
- PLUGINS		=	../plugins/amp.so				\
- 			../plugins/delay.so				\
 @@ -83,17 +83,17 @@
  ../bin/applyplugin:	applyplugin.o load.o default.o
- 	$(CC) $(CFLAGS) $(LIBRARIES)					\
+ 	$(CC) $(CFLAGS) $(BINFLAGS)					\
  		-o ../bin/applyplugin					\
--		applyplugin.o load.o default.o
-+		applyplugin.o load.o default.o $(LDFLAGS)
+-		applyplugin.o load.o default.o				\
++		applyplugin.o load.o default.o $(LDFLAGS)		\
+ 		$(LIBRARIES)
  
  ../bin/analyseplugin:	analyseplugin.o load.o default.o
- 	$(CC) $(CFLAGS) $(LIBRARIES)					\
+ 	$(CC) $(CFLAGS) $(BINFLAGS)					\
  		-o ../bin/analyseplugin 				\
--		analyseplugin.o load.o default.o
-+		analyseplugin.o load.o default.o $(LDFLAGS)
+-		analyseplugin.o load.o default.o			\
++		analyseplugin.o load.o default.o $(LDFLAGS)		\
+ 		$(LIBRARIES)
  
  ../bin/listplugins:	listplugins.o search.o
- 	$(CC) $(CFLAGS) $(LIBRARIES)					\
+ 	$(CC) $(CFLAGS) $(BINFLAGS)					\
  		-o ../bin/listplugins	 				\
--		listplugins.o search.o
-+		listplugins.o search.o $(LDFLAGS)
+-		listplugins.o search.o					\
++		listplugins.o search.o $(LDFLAGS)			\
+ 		$(LIBRARIES)
  
  ###############################################################################
- #

--- a/srcpkgs/ladspa-sdk/template
+++ b/srcpkgs/ladspa-sdk/template
@@ -1,16 +1,16 @@
 # Template file for 'ladspa-sdk'
 pkgname=ladspa-sdk
-version=1.13
-revision=8
+version=1.15
+revision=1
 archs=noarch
-wrksrc=ladspa_sdk
+wrksrc="ladspa_sdk_${version}"
 makedepends="libsndfile-progs"
 short_desc="Linux Audio Developer's Simple Plugin API (LADSPA)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
+license="LGPL-2.1-or-later"
 homepage="http://www.ladspa.org/"
-license="LGPL-2.1"
-distfiles="${DEBIAN_SITE}/main/l/${pkgname}/${pkgname}_${version}.orig.tar.gz"
-checksum=b5ed3f4f253a0f6c1b7a1f4b8cf62376ca9f51d999650dd822650c43852d306b
+distfiles="http://www.ladspa.org/download/ladspa_sdk_${version}.tgz"
+checksum=4229959b09d20c88c8c86f4aa76427843011705df22d9c28b38359fd1829fded
 
 do_build() {
 	make CC=$CC CPP=$CXX LD=$LD -C src

--- a/srcpkgs/liblrdf/template
+++ b/srcpkgs/liblrdf/template
@@ -1,7 +1,7 @@
 # Template file for 'liblrdf'
 pkgname=liblrdf
 version=0.6.1
-revision=1
+revision=2
 wrksrc="LRDF-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"

--- a/srcpkgs/lmms/template
+++ b/srcpkgs/lmms/template
@@ -1,7 +1,7 @@
 # Template file for 'lmms'
 pkgname=lmms
 version=1.2.0rc7
-revision=2
+revision=3
 wrksrc="lmms-${version/r/-r}"
 _x11embed_commit=022b39a1d496d72eb3e5b5188e5559f66afca957
 _rpmalloc_version=1.3.1

--- a/srcpkgs/mlt/template
+++ b/srcpkgs/mlt/template
@@ -1,7 +1,7 @@
 # Template file for 'mlt'
 pkgname=mlt
 version=6.14.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-gpl --enable-gpl3 --disable-swfdec --without-kde
  --swig-languages=python"

--- a/srcpkgs/pvoc/template
+++ b/srcpkgs/pvoc/template
@@ -1,7 +1,7 @@
 # Template file for 'pvoc'
 pkgname=pvoc
 version=0.1.12
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=yes
 hostmakedepends="pkg-config"

--- a/srcpkgs/qtractor/template
+++ b/srcpkgs/qtractor/template
@@ -1,7 +1,7 @@
 # Template file for 'qtractor'
 pkgname=qtractor
 version=0.9.7
-revision=1
+revision=2
 wrksrc="qtractor-qtractor_${version//./_}"
 build_style=gnu-configure
 configure_args="--enable-debug"

--- a/srcpkgs/rosegarden/template
+++ b/srcpkgs/rosegarden/template
@@ -1,7 +1,7 @@
 # Template file for 'rosegarden'
 pkgname=rosegarden
 version=18.12
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config shared-mime-info"
 makedepends="qt5-devel alsa-lib-devel jack-devel ladspa-sdk liblrdf-devel dssi-devel

--- a/srcpkgs/rubberband/template
+++ b/srcpkgs/rubberband/template
@@ -1,7 +1,7 @@
 # Template file for 'rubberband'
 pkgname=rubberband
 version=1.8.2
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="ladspa-sdk libsamplerate-devel vamp-plugin-sdk-devel fftw-devel"

--- a/srcpkgs/tap-plugins/template
+++ b/srcpkgs/tap-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'tap-plugins'
 pkgname=tap-plugins
 version=1.0.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=yes
 makedepends="ladspa-sdk"

--- a/srcpkgs/whysynth/template
+++ b/srcpkgs/whysynth/template
@@ -1,7 +1,7 @@
 # Template file for 'whysynth'
 pkgname=whysynth
 version=20170701
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel dssi-devel liblo-devel ladspa-sdk alsa-lib-devel fftw-devel"


### PR DESCRIPTION
This is header only library. Should all dependents be rebuild?