### PR TITLE
efitools: restrict archs

### DIFF
--- a/srcpkgs/efitools/template
+++ b/srcpkgs/efitools/template
@@ -2,6 +2,7 @@
 pkgname=efitools
 version=1.9.2
 revision=1
+archs="x86_64* i686* arm* aarch64*"
 build_style=gnu-makefile
 hostmakedepends="perl-File-Slurp"
 makedepends="gnu-efi-libs libressl-devel"


### PR DESCRIPTION
UEFI is not available on anything but x86 and ARM.