### PR TITLE
mplayer: add patch to fix altivec usage on gcc 8.3

### DIFF
--- a/srcpkgs/mplayer/patches/altivec-gcc83.patch
+++ b/srcpkgs/mplayer/patches/altivec-gcc83.patch
@@ -1,0 +1,18 @@
+--- ffmpeg/libavutil/ppc/util_altivec.h
++++ ffmpeg/libavutil/ppc/util_altivec.h
+@@ -54,6 +54,15 @@
+ #if HAVE_ALTIVEC
+ #include <altivec.h>
+ 
++/* starting with gcc 8.3, the vector keyword no longer allows usage with
++ * typedefs (e.g. vector uint32_t), only with their respective basic types
++ * (e.g. vector unsigned int) - with __vector this still works and there
++ * is code relying on it
++ */
++#ifndef vector
++#define vector __vector
++#endif
++
+ // used to build registers permutation vectors (vcprm)
+ // the 's' are for words in the _s_econd vector
+ #define WORD_0 0x00,0x01,0x02,0x03


### PR DESCRIPTION
Mplayer contains ffmpeg 5.x which added some new code, breaking altivec builds by default. Ffmpeg itself is not broken because it is compiled with -std=c11, but mplayer does not follow this, so patch it in the internal copy.