### PR TITLE
icecat: allow membarrier in sandbox

### DIFF
--- a/srcpkgs/icecat/patches/fix-sandbox-membarrier.patch
+++ b/srcpkgs/icecat/patches/fix-sandbox-membarrier.patch
@@ -1,0 +1,52 @@
+allow usage of SYS_membarrier, needed since musl-1.1.22
+
+--- security/sandbox/linux/SandboxFilter.cpp
++++ security/sandbox/linux/SandboxFilter.cpp
+@@ -283,6 +283,8 @@
+       case __NR_set_tid_address:
+         return Allow();
+ #endif
++      case __NR_membarrier:
++        return Allow();
+ 
+         // prctl
+       case __NR_prctl: {
+
+--- security/sandbox/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
++++ security/sandbox/chromium/sandbox/linux/system_headers/arm_linux_syscalls.h
+@@ -1385,6 +1385,10 @@
+ #define __NR_memfd_create (__NR_SYSCALL_BASE+385)
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier (__NR_SYSCALL_BASE+389)
++#endif
++
+ // ARM private syscalls.
+ #if !defined(__ARM_NR_BASE)
+ #define __ARM_NR_BASE (__NR_SYSCALL_BASE + 0xF0000)
+
+--- security/sandbox/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
++++ security/sandbox/chromium/sandbox/linux/system_headers/x86_64_linux_syscalls.h
+@@ -1290,5 +1290,9 @@
+ #define __NR_memfd_create 319
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 324
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_64_LINUX_SYSCALLS_H_
+ 
+--- security/sandbox/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
++++ security/sandbox/chromium/sandbox/linux/system_headers/x86_32_linux_syscalls.h
+@@ -1490,5 +1490,9 @@
+ #define __NR_shutdown 373
+ #endif
+ 
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 375
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_X86_32_LINUX_SYSCALLS_H_
+ 

--- a/srcpkgs/icecat/patches/rust133.patch
+++ b/srcpkgs/icecat/patches/rust133.patch
@@ -1,0 +1,21 @@
+--- servo/components/style/lib.rs	2018-11-09 18:26:56.000000000 +0100
++++ servo/components/style/lib.rs	2019-04-23 23:12:18.536052865 +0200
+@@ -23,7 +23,6 @@
+ //! [cssparser]: ../cssparser/index.html
+ //! [selectors]: ../selectors/index.html
+ 
+-#![deny(missing_docs)]
+ 
+ extern crate app_units;
+ extern crate arrayvec;
+--- servo/components/style_traits/lib.rs	2018-11-09 18:26:55.000000000 +0100
++++ servo/components/style_traits/lib.rs	2019-04-23 23:11:20.637542457 +0200
+@@ -9,7 +9,7 @@
+ #![crate_name = "style_traits"]
+ #![crate_type = "rlib"]
+ 
+-#![deny(unsafe_code, missing_docs)]
++#![deny(unsafe_code)]
+ 
+ extern crate app_units;
+ #[macro_use] extern crate bitflags;

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -1,7 +1,7 @@
 # Template file for 'icecat'
 pkgname=icecat
 version=60.3.0
-revision=3
+revision=4
 short_desc="GNU version of the Firefox browser"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 homepage="https://www.gnu.org/software/${pkgname}/"


### PR DESCRIPTION
needed for musl-1.1.22,
also fix build with recent rust versions