### PR TITLE
qemu: Update version to 4.0.0

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,13 +1,13 @@
 # Template file for 'qemu'
 pkgname=qemu
-version=3.1.0
-revision=3
+version=4.0.0
+revision=1
 short_desc="Open Source Processor Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.qemu.org"
 distfiles="https://wiki.qemu.org/download/qemu-${version}.tar.bz2"
-checksum=98fee0c86b299ebaf08587ba8df1dc8bb7152708d62937a0631875d95cc8d921
+checksum=6d7f713f7400c8a636c770118957b13d6a7f72b0d2da4a925d10455d8e33af20
 nocross=https://api.travis-ci.org/jobs/210268003/log.txt
 
 nostrip=yes
@@ -17,19 +17,17 @@ makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
  libsasl-devel libglib-devel ncurses-devel libseccomp-devel nss-devel
  libcurl-devel xfsprogs-devel libcap-ng-devel libcap-devel vde2-devel usbredir-devel
  libbluetooth-devel libssh2-devel libusb-devel pulseaudio-devel libnfs-devel
- $(vopt_if sdl SDL-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if gtk3 "gtk+3-devel vte3-devel")
+ $(vopt_if sdl2 SDL2-devel) $(vopt_if gtk3 "gtk+3-devel vte3-devel")
  $(vopt_if spice spice-devel) $(vopt_if virgl virglrenderer-devel)
  $(vopt_if opengl 'libepoxy-devel libdrm-devel MesaLib-devel')
  $(vopt_if smartcard libcacard-devel)"
 
-build_options="gtk3 opengl sdl sdl2 spice virgl smartcard"
+build_options="gtk3 opengl sdl2 spice virgl smartcard"
 build_options_default="opengl gtk3 virgl smartcard sdl2"
-desc_option_sdl="Use SDL (1.x) video output"
-desc_option_sdl2="Use SDL (2.x) video output"
+desc_option_sdl2="Enable SDL (2.x) video output"
 desc_option_spice="Enable support for SPICE"
 desc_option_virgl="Enable support for VirGL (A Virtual 3D GPU renderer)"
 desc_option_smartcard="Enable smartcard support"
-vopt_conflict "sdl" "sdl2"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*|ppc64*) build_options_default+=" spice";;
@@ -53,7 +51,7 @@ do_configure() {
 
 	local want_sdl="--disable-sdl"
 	local audio_sdl=""
-	if [ "$build_option_sdl" ] || [ "$build_option_sdl2" ]; then
+	if [ "$build_option_sdl2" ]; then
 		want_sdl="--enable-sdl"
 		audio_sdl=",sdl"
 	fi
@@ -66,8 +64,6 @@ do_configure() {
 		--enable-pie --localstatedir=/var --datadir=/usr/lib \
 		$(vopt_enable virgl virglrenderer) $(vopt_enable opengl) $(vopt_enable spice) \
 		${want_sdl} \
-		$(vopt_if sdl "--with-sdlabi=1.2") \
-		$(vopt_if sdl2 "--with-sdlabi=2.0") \
 		$(vopt_enable smartcard) \
 		$(vopt_if gtk3 "--enable-gtk") ${args}
 }


### PR DESCRIPTION
SDL 2.0 is now the default option, with SDL 1.2 being dropped during development, hence the option being removed.