### PR TITLE
glm: update to 0.9.9.5.

### DIFF
--- a/srcpkgs/glm/template
+++ b/srcpkgs/glm/template
@@ -1,19 +1,18 @@
 # Template file for 'glm'
 pkgname=glm
-version=0.9.9.2
-reverts="0.9.9.3_1"
-revision=2
+version=0.9.9.5
+revision=1
 archs=noarch
 wrksrc=glm
 build_style=cmake
 configure_args="-DGLM_TEST_ENABLE=OFF"
 hostmakedepends="dos2unix unzip"
-short_desc="A C++ mathematics library for graphics programming"
+short_desc="C++ mathematics library for graphics programming"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="MIT"
 homepage="http://glm.g-truc.net"
 distfiles="https://github.com/g-truc/glm/releases/download/${version}/glm-${version}.zip"
-checksum=209b5943d393925e1a6ecb6734e7507b8f6add25e72a605b25d0d0d382e64fd4
+checksum=4fe34860ce69156f63eea6c3d84c91cadfc330353cf275ff394aef4e163cafee
 
 post_install() {
 	local f


### PR DESCRIPTION
0.9.9.3 was reverted because it caused kicad builds to fail. This was fixed in 0.9.9.4.