### PR TITLE
New package: ocrodjvu-0.11 (with dependency python-djvulibre-0.8.4)

### DIFF
--- a/srcpkgs/ocrodjvu/patches/fix-tesseract-ocr-executable-name.patch
+++ b/srcpkgs/ocrodjvu/patches/fix-tesseract-ocr-executable-name.patch
@@ -1,0 +1,11 @@
+--- lib/engines/tesseract.py
++++ lib/engines/tesseract.py
+@@ -111,7 +111,7 @@
+     image_format = image_io.TIFF
+     needs_utf8_fix = True
+ 
+-    executable = utils.property('tesseract')
++    executable = utils.property('tesseract-ocr')
+     extra_args = utils.property([], shlex.split)
+     use_hocr = utils.property(None, int)
+     fix_html = utils.property(0, int)

--- a/srcpkgs/ocrodjvu/template
+++ b/srcpkgs/ocrodjvu/template
@@ -1,0 +1,13 @@
+# Template file for 'ocrodjvu'
+pkgname=ocrodjvu
+version=0.11
+revision=1
+build_style=python2-module
+hostmakedepends="python"
+depends="python python-djvulibre python-lxml tesseract-ocr"
+short_desc="Wrapper for OCR systems, allowing OCR on DjVu"
+maintainer="B. Wilson <x@wilsonb.com>"
+license="GPL-2.0-or-later"
+homepage="http://jwilk.net/software/ocrodjvu"
+distfiles="https://github.com/jwilk/ocrodjvu/releases/download/${version}/ocrodjvu-${version}.tar.xz"
+checksum=c9eef66e0ed9f742b9e386381d92b89b412e07ebd625dc4023884637101e54f0

--- a/srcpkgs/python-djvulibre/template
+++ b/srcpkgs/python-djvulibre/template
@@ -1,0 +1,14 @@
+# Template file for 'python-djvulibre'
+pkgname=python-djvulibre
+version=0.8.4
+revision=1
+build_style=python2-module
+hostmakedepends="pkg-config python-Cython"
+makedepends="djvulibre-devel python-devel"
+depends="djvulibre python python-subprocess32"
+short_desc="Python bindings for the DjVuLibre library"
+maintainer="B. Wilson <x@wilsonb.com>"
+license="GPL-3.0-or-later"
+homepage="http://jwilk.net/software/python-djvulibre"
+distfiles="https://pypi.io/packages/source/p/python-djvulibre/python-djvulibre-${version}.tar.gz"
+checksum=6d7c84efa9ad7efc5fa6d94b7a6ca8201326cb95c7e62d6da566acfc115a647d


### PR DESCRIPTION
Void provides the `tesseract-ocr` binary, which upstream expects to be called `tesseract`. I've contacted upstream about this, but for now am just packaging with a dumb patch.