### PR TITLE
dbeaver: update to 6.0.3.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,15 +1,15 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=6.0.0
+version=6.0.3
 revision=1
-archs="i686 x86_64"
+archs="x86_64"
 hostmakedepends="apache-maven-bin"
 short_desc="Free Universal Database Tool"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://dbeaver.io"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz"
-checksum=b81206708799a26c8e461e72e188b110769ed8cb2be44fb537edb769e2680d9f
+checksum=d9cdaf470e913d84f549fce824dc86c5550ae31ee2b032301d4c87fe5b02babe
 nopie=true
 
 do_build() {
@@ -17,16 +17,8 @@ do_build() {
 }
 
 do_install() {
-	case $XBPS_TARGET_MACHINE in
-		x86_64*)
-			_target_dir=x86_64
-			;;
-		i686*)
-			_target_dir=x86
-			;;
-	esac
 	vmkdir /usr/lib
-	vcopy "product/standalone/target/products/org.jkiss.dbeaver.core.product/linux/gtk/${_target_dir}/dbeaver" /usr/lib/
+	vcopy "product/standalone/target/products/org.jkiss.dbeaver.core.product/linux/gtk/x86_64/dbeaver" /usr/lib/
 
 	vmkdir /usr/bin
 	ln -s /usr/lib/dbeaver/dbeaver ${DESTDIR}/usr/bin/dbeaver


### PR DESCRIPTION
@maxice8  and others. Not sure what the right thing to do here is. i686 support has been dropped upstream. If we update this package, will users on i686 get dropped unexpectedly, or will the old version remain in the i686 repos?
