### PR TITLE
libfilezilla: revert to 0.15.1

### DIFF
--- a/srcpkgs/libfilezilla/template
+++ b/srcpkgs/libfilezilla/template
@@ -1,7 +1,8 @@
 # Template file for 'libfilezilla'
 pkgname=libfilezilla
-version=0.16.0
-revision=1
+reverts="0.16.0_1"
+version=0.15.1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
@@ -11,7 +12,7 @@ maintainer="bra1nwave <brainwave@openmailbox.org>"
 license="GPL-2.0-or-later"
 homepage="https://lib.filezilla-project.org/"
 distfiles="https://download.filezilla-project.org/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=3b6c4be3c57ad5e6e9bcfd365222e95db7f52d2f6a165a9c93747f4aeb0ea7b9
+checksum=2048c4128f3bf37a2a4ece17c8bea5455f3d7414fe2e060afcf2a8b00a87f49f
 
 libfilezilla-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
0.16.0 is not ABI compatible and filezilla doesn't build against it.
Update to 0.16 when filezilla 3.42 is released

Fixes #11313