### PR TITLE
llvm6.0, llvm7, llvm8: generalize patches to use elfv2 on all ppc64

### DIFF
--- a/srcpkgs/llvm6.0/files/patches/llvm/llvm-002-musl-ppc64-elfv2.patch
+++ b/srcpkgs/llvm6.0/files/patches/llvm/llvm-002-musl-ppc64-elfv2.patch
@@ -1,43 +1,27 @@
-From 750d323a6060ad92c3d247f85d6555041f55b4a5 Mon Sep 17 00:00:00 2001
-From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
-Date: Thu, 4 Oct 2018 15:26:59 -0500
-Subject: [PATCH] Add support for powerpc64-*-linux-musl targets
+This patches LLVM to use ELFv2 on ppc64 uncoditionally unless overridden. We
+need this because unlike most distros we use ELFv2 for both glibc and musl
+on big endian ppc64.
 
-This patch ensures that 64-bit PowerPC musl targets use ELFv2 ABI on both
-endians.  It additionally adds a test that big endian PPC64 uses ELFv2 on
-musl.
----
- lib/Target/PowerPC/PPCTargetMachine.cpp | 4 ++++
- test/CodeGen/PowerPC/ppc64-elf-abi.ll   | 1 +
- 2 files changed, 5 insertions(+)
-
-diff --git a/lib/Target/PowerPC/PPCTargetMachine.cpp b/lib/Target/PowerPC/PPCTargetMachine.cpp
-index 34410393ef6..c583fba8cab 100644
 --- a/lib/Target/PowerPC/PPCTargetMachine.cpp
 +++ b/lib/Target/PowerPC/PPCTargetMachine.cpp
-@@ -199,6 +199,10 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+@@ -197,9 +197,9 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+ 
+   switch (TT.getArch()) {
    case Triple::ppc64le:
-     return PPCTargetMachine::PPC_ABI_ELFv2;
+-    return PPCTargetMachine::PPC_ABI_ELFv2;
    case Triple::ppc64:
-+    // musl uses ELFv2 ABI on both endians.
-+    if (TT.getEnvironment() == Triple::Musl)
-+      return PPCTargetMachine::PPC_ABI_ELFv2;
-+
-     return PPCTargetMachine::PPC_ABI_ELFv1;
+-    return PPCTargetMachine::PPC_ABI_ELFv1;
++    /* we use elfv2 by default for both endians and both libcs */
++    return PPCTargetMachine::PPC_ABI_ELFv2;
    default:
      return PPCTargetMachine::PPC_ABI_UNKNOWN;
-diff --git a/test/CodeGen/PowerPC/ppc64-elf-abi.ll b/test/CodeGen/PowerPC/ppc64-elf-abi.ll
-index 1e17930304b..aa594b37b47 100644
+   }
 --- a/test/CodeGen/PowerPC/ppc64-elf-abi.ll
 +++ b/test/CodeGen/PowerPC/ppc64-elf-abi.ll
-@@ -1,6 +1,7 @@
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv1
+@@ -1,4 +1,5 @@
+-; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv1
++; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv2
++; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-musl < %s | FileCheck %s -check-prefix=CHECK-ELFv2
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu -target-abi elfv1 < %s | FileCheck %s -check-prefix=CHECK-ELFv1
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu -target-abi elfv2 < %s | FileCheck %s -check-prefix=CHECK-ELFv2
-+; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-musl < %s | FileCheck %s -check-prefix=CHECK-ELFv2
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv2
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -target-abi elfv1 < %s | FileCheck %s -check-prefix=CHECK-ELFv1
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -target-abi elfv2 < %s | FileCheck %s -check-prefix=CHECK-ELFv2
--- 
-2.18.0
-

--- a/srcpkgs/llvm6.0/template
+++ b/srcpkgs/llvm6.0/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm6.0'
 pkgname=llvm6.0
 version=6.0.1
-revision=4
+revision=5
 wrksrc="llvm-${version}.src"
 lib32disabled=yes
 build_style=cmake

--- a/srcpkgs/llvm7/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
+++ b/srcpkgs/llvm7/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
@@ -1,13 +1,14 @@
---- clang/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:52:16.174867512 +0100
-+++ clang/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:56:25.040531791 +0100
-@@ -502,12 +502,12 @@
+--- a/lib/Driver/ToolChains/Linux.cpp
++++ b/lib/Driver/ToolChains/Linux.cpp
+@@ -590,12 +590,12 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      Loader = "ld.so.1";
      break;
    case llvm::Triple::ppc64:
 -    LibDir = "lib64";
 +    LibDir = "lib";
      Loader =
-         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+-        (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
++        (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
      break;
    case llvm::Triple::ppc64le:
 -    LibDir = "lib64";

--- a/srcpkgs/llvm7/files/patches/cfe/cfe-006-ppc64-musl-elfv2.patch
+++ b/srcpkgs/llvm7/files/patches/cfe/cfe-006-ppc64-musl-elfv2.patch
@@ -1,30 +1,26 @@
---- clang/lib/Basic/Targets/PPC.h
-+++ clang/lib/Basic/Targets/PPC.h
-@@ -358,7 +358,10 @@ public:
-       ABI = "elfv2";
+--- a/lib/Basic/Targets/PPC.h
++++ b/lib/Basic/Targets/PPC.h
+@@ -364,11 +364,10 @@ public:
+ 
+     if ((Triple.getArch() == llvm::Triple::ppc64le)) {
+       resetDataLayout("e-m:e-i64:64-n32:64");
+-      ABI = "elfv2";
      } else {
        resetDataLayout("E-m:e-i64:64-n32:64");
 -      ABI = "elfv1";
-+      if (Triple.getEnvironment() == llvm::Triple::Musl)
-+        ABI = "elfv2";
-+      else
-+        ABI = "elfv1";
      }
++    ABI = "elfv2";
  
      switch (getTriple().getOS()) {
-diff --git a/tools/clang/lib/Driver/ToolChains/Clang.cpp b/tools/clang/lib/Driver/ToolChains/Clang.cpp
-index 8e9c4c6a..40817ec3 100644
---- clang/lib/Driver/ToolChains/Clang.cpp
-+++ clang/lib/Driver/ToolChains/Clang.cpp
-@@ -1618,7 +1618,10 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
+     case llvm::Triple::FreeBSD:
+--- a/lib/Driver/ToolChains/Clang.cpp
++++ b/lib/Driver/ToolChains/Clang.cpp
+@@ -1745,7 +1745,7 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
          break;
        }
  
 -      ABIName = "elfv1";
-+      if (getToolChain().getTriple().getEnvironment() == llvm::Triple::Musl)
-+        ABIName = "elfv2";
-+      else
-+        ABIName = "elfv1";
++      ABIName = "elfv2";
        break;
      }
      case llvm::Triple::ppc64le:

--- a/srcpkgs/llvm7/files/patches/llvm/llvm-002-musl-ppc64-elfv2.patch
+++ b/srcpkgs/llvm7/files/patches/llvm/llvm-002-musl-ppc64-elfv2.patch
@@ -1,43 +1,27 @@
-From 750d323a6060ad92c3d247f85d6555041f55b4a5 Mon Sep 17 00:00:00 2001
-From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
-Date: Thu, 4 Oct 2018 15:26:59 -0500
-Subject: [PATCH] Add support for powerpc64-*-linux-musl targets
+This patches LLVM to use ELFv2 on ppc64 uncoditionally unless overridden. We
+need this because unlike most distros we use ELFv2 for both glibc and musl
+on big endian ppc64.
 
-This patch ensures that 64-bit PowerPC musl targets use ELFv2 ABI on both
-endians.  It additionally adds a test that big endian PPC64 uses ELFv2 on
-musl.
----
- lib/Target/PowerPC/PPCTargetMachine.cpp | 4 ++++
- test/CodeGen/PowerPC/ppc64-elf-abi.ll   | 1 +
- 2 files changed, 5 insertions(+)
-
-diff --git a/lib/Target/PowerPC/PPCTargetMachine.cpp b/lib/Target/PowerPC/PPCTargetMachine.cpp
-index 34410393ef6..c583fba8cab 100644
 --- a/lib/Target/PowerPC/PPCTargetMachine.cpp
 +++ b/lib/Target/PowerPC/PPCTargetMachine.cpp
-@@ -199,6 +199,10 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+@@ -197,9 +197,9 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+ 
+   switch (TT.getArch()) {
    case Triple::ppc64le:
-     return PPCTargetMachine::PPC_ABI_ELFv2;
+-    return PPCTargetMachine::PPC_ABI_ELFv2;
    case Triple::ppc64:
-+    // musl uses ELFv2 ABI on both endians.
-+    if (TT.getEnvironment() == Triple::Musl)
-+      return PPCTargetMachine::PPC_ABI_ELFv2;
-+
-     return PPCTargetMachine::PPC_ABI_ELFv1;
+-    return PPCTargetMachine::PPC_ABI_ELFv1;
++    /* we use elfv2 by default for both endians and both libcs */
++    return PPCTargetMachine::PPC_ABI_ELFv2;
    default:
      return PPCTargetMachine::PPC_ABI_UNKNOWN;
-diff --git a/test/CodeGen/PowerPC/ppc64-elf-abi.ll b/test/CodeGen/PowerPC/ppc64-elf-abi.ll
-index 1e17930304b..aa594b37b47 100644
+   }
 --- a/test/CodeGen/PowerPC/ppc64-elf-abi.ll
 +++ b/test/CodeGen/PowerPC/ppc64-elf-abi.ll
-@@ -1,6 +1,7 @@
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv1
+@@ -1,4 +1,5 @@
+-; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv1
++; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv2
++; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-musl < %s | FileCheck %s -check-prefix=CHECK-ELFv2
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu -target-abi elfv1 < %s | FileCheck %s -check-prefix=CHECK-ELFv1
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu -target-abi elfv2 < %s | FileCheck %s -check-prefix=CHECK-ELFv2
-+; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-musl < %s | FileCheck %s -check-prefix=CHECK-ELFv2
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv2
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -target-abi elfv1 < %s | FileCheck %s -check-prefix=CHECK-ELFv1
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -target-abi elfv2 < %s | FileCheck %s -check-prefix=CHECK-ELFv2
--- 
-2.18.0
-

--- a/srcpkgs/llvm7/template
+++ b/srcpkgs/llvm7/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm7'
 pkgname=llvm7
 version=7.0.1
-revision=6
+revision=7
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="

--- a/srcpkgs/llvm8/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-005-ppc64-dynamic-linker-path.patch
@@ -1,13 +1,14 @@
---- a/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:52:16.174867512 +0100
-+++ b/lib/Driver/ToolChains/Linux.cpp	2018-12-16 23:56:25.040531791 +0100
-@@ -502,12 +502,12 @@
+--- a/lib/Driver/ToolChains/Linux.cpp
++++ b/lib/Driver/ToolChains/Linux.cpp
+@@ -590,12 +590,12 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
      Loader = "ld.so.1";
      break;
    case llvm::Triple::ppc64:
 -    LibDir = "lib64";
 +    LibDir = "lib";
      Loader =
-         (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
+-        (tools::ppc::hasPPCAbiArg(Args, "elfv2")) ? "ld64.so.2" : "ld64.so.1";
++        (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
      break;
    case llvm::Triple::ppc64le:
 -    LibDir = "lib64";
@@ -15,4 +16,3 @@
      Loader =
          (tools::ppc::hasPPCAbiArg(Args, "elfv1")) ? "ld64.so.1" : "ld64.so.2";
      break;
-

--- a/srcpkgs/llvm8/files/patches/cfe/cfe-006-ppc64-musl-elfv2.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-006-ppc64-musl-elfv2.patch
@@ -1,30 +1,26 @@
 --- a/lib/Basic/Targets/PPC.h
 +++ b/lib/Basic/Targets/PPC.h
-@@ -358,7 +358,10 @@ public:
-       ABI = "elfv2";
+@@ -364,11 +364,10 @@ public:
+ 
+     if ((Triple.getArch() == llvm::Triple::ppc64le)) {
+       resetDataLayout("e-m:e-i64:64-n32:64");
+-      ABI = "elfv2";
      } else {
        resetDataLayout("E-m:e-i64:64-n32:64");
 -      ABI = "elfv1";
-+      if (Triple.getEnvironment() == llvm::Triple::Musl)
-+        ABI = "elfv2";
-+      else
-+        ABI = "elfv1";
      }
-
++    ABI = "elfv2";
+ 
      switch (getTriple().getOS()) {
-diff --git a/tools/clang/lib/Driver/ToolChains/Clang.cpp b/tools/clang/lib/Driver/ToolChains/Clang.cpp
-index 8e9c4c6a..40817ec3 100644
+     case llvm::Triple::FreeBSD:
 --- a/lib/Driver/ToolChains/Clang.cpp
 +++ b/lib/Driver/ToolChains/Clang.cpp
-@@ -1618,7 +1618,10 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
+@@ -1745,7 +1745,7 @@ void Clang::AddPPCTargetArgs(const ArgList &Args,
          break;
        }
-
+ 
 -      ABIName = "elfv1";
-+      if (getToolChain().getTriple().getEnvironment() == llvm::Triple::Musl)
-+        ABIName = "elfv2";
-+      else
-+        ABIName = "elfv1";
++      ABIName = "elfv2";
        break;
      }
      case llvm::Triple::ppc64le:

--- a/srcpkgs/llvm8/files/patches/llvm/llvm-002-musl-ppc64-elfv2.patch
+++ b/srcpkgs/llvm8/files/patches/llvm/llvm-002-musl-ppc64-elfv2.patch
@@ -1,43 +1,27 @@
-From 750d323a6060ad92c3d247f85d6555041f55b4a5 Mon Sep 17 00:00:00 2001
-From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
-Date: Thu, 4 Oct 2018 15:26:59 -0500
-Subject: [PATCH] Add support for powerpc64-*-linux-musl targets
+This patches LLVM to use ELFv2 on ppc64 uncoditionally unless overridden. We
+need this because unlike most distros we use ELFv2 for both glibc and musl
+on big endian ppc64.
 
-This patch ensures that 64-bit PowerPC musl targets use ELFv2 ABI on both
-endians.  It additionally adds a test that big endian PPC64 uses ELFv2 on
-musl.
----
- lib/Target/PowerPC/PPCTargetMachine.cpp | 4 ++++
- test/CodeGen/PowerPC/ppc64-elf-abi.ll   | 1 +
- 2 files changed, 5 insertions(+)
-
-diff --git a/lib/Target/PowerPC/PPCTargetMachine.cpp b/lib/Target/PowerPC/PPCTargetMachine.cpp
-index 34410393ef6..c583fba8cab 100644
 --- a/lib/Target/PowerPC/PPCTargetMachine.cpp
 +++ b/lib/Target/PowerPC/PPCTargetMachine.cpp
-@@ -199,6 +199,10 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+@@ -197,9 +197,9 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+ 
+   switch (TT.getArch()) {
    case Triple::ppc64le:
-     return PPCTargetMachine::PPC_ABI_ELFv2;
+-    return PPCTargetMachine::PPC_ABI_ELFv2;
    case Triple::ppc64:
-+    // musl uses ELFv2 ABI on both endians.
-+    if (TT.getEnvironment() == Triple::Musl)
-+      return PPCTargetMachine::PPC_ABI_ELFv2;
-+
-     return PPCTargetMachine::PPC_ABI_ELFv1;
+-    return PPCTargetMachine::PPC_ABI_ELFv1;
++    /* we use elfv2 by default for both endians and both libcs */
++    return PPCTargetMachine::PPC_ABI_ELFv2;
    default:
      return PPCTargetMachine::PPC_ABI_UNKNOWN;
-diff --git a/test/CodeGen/PowerPC/ppc64-elf-abi.ll b/test/CodeGen/PowerPC/ppc64-elf-abi.ll
-index 1e17930304b..aa594b37b47 100644
+   }
 --- a/test/CodeGen/PowerPC/ppc64-elf-abi.ll
 +++ b/test/CodeGen/PowerPC/ppc64-elf-abi.ll
-@@ -1,6 +1,7 @@
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv1
+@@ -1,4 +1,5 @@
+-; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv1
++; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv2
++; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-musl < %s | FileCheck %s -check-prefix=CHECK-ELFv2
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu -target-abi elfv1 < %s | FileCheck %s -check-prefix=CHECK-ELFv1
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-gnu -target-abi elfv2 < %s | FileCheck %s -check-prefix=CHECK-ELFv2
-+; RUN: llc -verify-machineinstrs -mtriple=powerpc64-unknown-linux-musl < %s | FileCheck %s -check-prefix=CHECK-ELFv2
  ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu < %s | FileCheck %s -check-prefix=CHECK-ELFv2
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -target-abi elfv1 < %s | FileCheck %s -check-prefix=CHECK-ELFv1
- ; RUN: llc -verify-machineinstrs -mtriple=powerpc64le-unknown-linux-gnu -target-abi elfv2 < %s | FileCheck %s -check-prefix=CHECK-ELFv2
--- 
-2.18.0
-

--- a/srcpkgs/llvm8/template
+++ b/srcpkgs/llvm8/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm8'
 pkgname=llvm8
 version=8.0.0
-revision=1
+revision=2
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="


### PR DESCRIPTION
Related to https://github.com/void-linux/void-packages/pull/11352, can be merged in either order. This changes the ppc64 patches to always use ELFv2 ABI regardless of libc and endianness. Most distributions use ELFv1 with glibc, so that's what llvm defaults to, we are legacy free so we can use the more modern/cleaner/simpler/better ABI; gcc has a `--with-abi=elfv2` configure option, llvm sadly does not.

These patches do respect the `-mabi` option in e.g. clang as well as explicit ABI setting in llvm API, so explicitly passing `-mabi=elfv1` can still be used to deal with e.g. compiling code for legacy chroots and so on.

This also bumps the revisions because LLVM is a cross-library/compiler and therefore may affect cross compiling to ppc64 from any host, including x86_64.

@pullmoll 