### PR TITLE
gobject-introspection: fix wrong ld library path in cross

### DIFF
--- a/srcpkgs/gobject-introspection/files/g-ir-scanner-wrapper
+++ b/srcpkgs/gobject-introspection/files/g-ir-scanner-wrapper
@@ -4,6 +4,8 @@
 if [ -n "$XBPS_CROSS_BASE" -a -n "$XBPS_TARGET_MACHINE" -a -n "$XBPS_VERSION" ]; then
 	# This prevents g-ir-scanner from writing cache data to $HOME
 	export GI_SCANNER_DISABLE_CACHE=1
+	# This prevents the native C compiler from using $XBPS_CROSS_BASE libraries
+	export GI_SCANNER_EXTRA_LD_LIBRARY_PATH=/usr/lib
 	
 	exec /usr/bin/g-ir-scanner.wrapped \
 				 --use-binary-wrapper=/usr/bin/g-ir-scanner-qemuwrapper \

--- a/srcpkgs/gobject-introspection/patches/0011-giscanner-ld-library-path.patch
+++ b/srcpkgs/gobject-introspection/patches/0011-giscanner-ld-library-path.patch
@@ -1,0 +1,40 @@
+This is a hack that, combined with g-ir-scanner-wrapper, allows us to put
+/usr/lib inside LD_LIBRARY_PATH before all the other paths that g-ir-scanner
+appends. This is very important, because if we don't put /usr/lib first, the
+cross base will be first and during certain circumstances (musl, cross-endian)
+the compiler will fail to execute.
+
+We cannot use another way to append it, because we don't want to put /usr/lib
+inside the library paths for scanning - we don't want the gi scanner to
+process any of these libs. We just want the native executables to run
+correctly.
+
+As for using the literal LD_LIBRARY_PATH inside the environment - the scanner
+will actually read it, but it will put it at the *end*, which does not help
+us.
+
+Ping 'q66 <daniel@octaforge.org>' for any questions.
+
+--- a/giscanner/ccompiler.py
++++ b/giscanner/ccompiler.py
+@@ -180,6 +180,7 @@ class CCompiler(object):
+ 
+         runtime_path_envvar = []
+         runtime_paths = []
++        extra_ld_libpath = 'GI_SCANNER_EXTRA_LD_LIBRARY_PATH'
+ 
+         if os.name == 'nt':
+             runtime_path_envvar = ['LIB', 'PATH']
+@@ -234,6 +235,12 @@ class CCompiler(object):
+             else:
+                 os.environ[envvar] = os.pathsep.join(runtime_paths)
+ 
++            # extra paths to prepend, for cross-compiling
++            if extra_ld_libpath in os.environ:
++                os.environ[envvar] = os.pathsep.join([
++                    os.environ[extra_ld_libpath], os.environ[envvar]
++                ])
++
+     def get_external_link_flags(self, args, libraries):
+         # An "external" link is where the library to be introspected
+         # is installed on the system; this case is used for the scanning

--- a/srcpkgs/gobject-introspection/template
+++ b/srcpkgs/gobject-introspection/template
@@ -1,7 +1,7 @@
 # Template file for 'gobject-introspection'
 pkgname=gobject-introspection
 version=1.60.0
-revision=2
+revision=3
 build_style=meson
 pycompile_dirs="usr/lib/${pkgname}/giscanner"
 hostmakedepends="flex pkg-config"


### PR DESCRIPTION
See comments in patch for further information. This solution is a bit hacky but I don't see any other way out.

It fixes cross.endian gir, there's a high chance that this also fixes gir for musl, that has to be tested. Either way, it prevents native binaries (here it's the C compiler, called from within the GI scanner) from attempting to use libraries from cross base (and failing) by providing them with native library path first.

@pullmoll @maxice8 