### PR TITLE
webkit2gtk: fix jit option usage

### DIFF
--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -48,8 +48,7 @@ desc_option_sampling_profiler="Toggle sampling profiler support (disabled on mus
 
 # JIT conflicts with sampling_profiler
 case "$XBPS_TARGET_MACHINE" in
-	x86_64-musl) build_options_default+=" jit" ;;
-	ppc*-musl|mips-musl|arm*-musl) ;;
+	ppc*|mips*|arm*) ;;
 	*-musl) build_options_default+=" jit" ;;
 	*) build_options_default+=" jit sampling_profiler" ;;
 esac


### PR DESCRIPTION
When enabling gir, the JIT option usage for webkit2gtk got altered (and broke ppc and stuff while at it), so restore the former behavior.

@pullmoll