### PR TITLE
qemu: add patches to fix build on ppc64(le)-musl

### DIFF
--- a/srcpkgs/qemu/patches/musl-ppc64-pt_nip.patch
+++ b/srcpkgs/qemu/patches/musl-ppc64-pt_nip.patch
@@ -1,0 +1,12 @@
+This include is necessary to get PT_NIP on musl.
+--- linux-user/host/ppc64/hostdep.h
++++ linux-user/host/ppc64/hostdep.h
+@@ -17,6 +17,8 @@
+ 
+ #ifndef __ASSEMBLER__
+ 
++#include <asm/ptrace.h>
++
+ /* These are defined by the safe-syscall.inc.S file */
+ extern char safe_syscall_start[];
+ extern char safe_syscall_end[];

--- a/srcpkgs/qemu/patches/musl-ppc64-pt_regs.patch
+++ b/srcpkgs/qemu/patches/musl-ppc64-pt_regs.patch
@@ -1,0 +1,16 @@
+On musl, the regs field in uc_mcontext is void * so it is necessary to
+cast it. The sys/user.h include is to get access to definition of pt_regs.
+--- accel/tcg/user-exec.c
++++ accel/tcg/user-exec.c
+@@ -285,9 +285,10 @@ int cpu_signal_handler(int host_signum, void *pinfo,
+  * From Wine
+  */
+ #ifdef linux
++#include <sys/user.h>
+ /* All Registers access - only for local access */
+ #define REG_sig(reg_name, context)              \
+-    ((context)->uc_mcontext.regs->reg_name)
++    (((struct pt_regs *)(context)->uc_mcontext.regs)->reg_name)
+ /* Gpr Registers access  */
+ #define GPR_sig(reg_num, context)              REG_sig(gpr[reg_num], context)
+ /* Program counter */


### PR DESCRIPTION
The musl headers are laid out differently, so it needs a couple workarounds to get access to all the definitions.

This also fixes qemu-user-static, and https://github.com/void-ppc64/void-packages/issues/9.

@pullmoll