### PR TITLE
dracut: add patch to fix a potential segfault

### DIFF
--- a/srcpkgs/dracut/patches/fix-dracut-install-segv.patch
+++ b/srcpkgs/dracut/patches/fix-dracut-install-segv.patch
@@ -1,0 +1,16 @@
+This fixes a segfault, see https://github.com/dracutdevs/dracut/pull/541
+
+Remove after update to 050.
+
+--- install/dracut-install.c
++++ install/dracut-install.c
+@@ -1243,6 +1243,9 @@ static int install_dependent_modules(struct kmod_list *modlist)
+                 mod = kmod_module_get_module(itr);
+                 path = kmod_module_get_path(mod);
+ 
++                if (path == NULL)
++                        continue;
++
+                 name = kmod_module_get_name(mod);
+                 if (arg_mod_filter_noname && (regexec(&mod_filter_noname, name, 0, NULL, 0) == 0)) {
+                         kmod_module_unref(mod);

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=048
-revision=4
+revision=5
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"


### PR DESCRIPTION
Without this patches dracut may segfault on certain platforms with certain kernel configurations. In this case, it segfaults on ppc64 big endian. Bump rev because it may happen anywhere.

Fixes https://github.com/void-ppc64/void-packages/issues/13