### PR TITLE
rust: add support for ppc64 target

### DIFF
--- a/srcpkgs/rust/files/patches/internal-llvm/llvm-002-musl-ppc64-elfv2.patch
+++ b/srcpkgs/rust/files/patches/internal-llvm/llvm-002-musl-ppc64-elfv2.patch
@@ -1,28 +1,18 @@
-From 750d323a6060ad92c3d247f85d6555041f55b4a5 Mon Sep 17 00:00:00 2001
-From: "A. Wilcox" <AWilcox@Wilcox-Tech.com>
-Date: Thu, 4 Oct 2018 15:26:59 -0500
-Subject: [PATCH] Add support for powerpc64-*-linux-musl targets
+This patches LLVM to use ELFv2 on ppc64 uncoditionally unless overridden. We
+need this because unlike most distros we use ELFv2 for both glibc and musl
+on big endian ppc64.
 
-This patch ensures that 64-bit PowerPC musl targets use ELFv2 ABI on both
-endians.  It additionally adds a test that big endian PPC64 uses ELFv2 on
-musl.
----
- lib/Target/PowerPC/PPCTargetMachine.cpp | 4 ++++
- test/CodeGen/PowerPC/ppc64-elf-abi.ll   | 1 +
- 2 files changed, 5 insertions(+)
-
-diff --git a/lib/Target/PowerPC/PPCTargetMachine.cpp b/lib/Target/PowerPC/PPCTargetMachine.cpp
-index 34410393ef6..c583fba8cab 100644
 --- a/lib/Target/PowerPC/PPCTargetMachine.cpp
 +++ b/lib/Target/PowerPC/PPCTargetMachine.cpp
-@@ -199,6 +199,10 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+@@ -197,9 +197,9 @@ static PPCTargetMachine::PPCABI computeTargetABI(const Triple &TT,
+ 
+   switch (TT.getArch()) {
    case Triple::ppc64le:
-     return PPCTargetMachine::PPC_ABI_ELFv2;
+-    return PPCTargetMachine::PPC_ABI_ELFv2;
    case Triple::ppc64:
-+    // musl uses ELFv2 ABI on both endians.
-+    if (TT.getEnvironment() == Triple::Musl)
-+      return PPCTargetMachine::PPC_ABI_ELFv2;
-+
-     return PPCTargetMachine::PPC_ABI_ELFv1;
+-    return PPCTargetMachine::PPC_ABI_ELFv1;
++    /* we use elfv2 by default for both endians and both libcs */
++    return PPCTargetMachine::PPC_ABI_ELFv2;
    default:
      return PPCTargetMachine::PPC_ABI_UNKNOWN;
+   }

--- a/srcpkgs/rust/patches/use-elfv2-everywhere.patch
+++ b/srcpkgs/rust/patches/use-elfv2-everywhere.patch
@@ -1,0 +1,35 @@
+This patches librustc_target so that ELFv2 is used everywhere, matching our
+LLVM. While this is not perfect (it does not allow rustc to compile legacy
+binaries), rustc never requests specific ABI from llvm in the first place,
+so at least match the environment we have.
+
+--- a/src/librustc_target/abi/call/powerpc64.rs
++++ b/src/librustc_target/abi/call/powerpc64.rs
+@@ -124,7 +124,7 @@ pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<'a, Ty>)
+     where Ty: TyLayoutMethods<'a, C> + Copy,
+           C: LayoutOf<Ty = Ty, TyLayout = TyLayout<'a, Ty>> + HasDataLayout + HasTargetSpec
+ {
+-    let abi = if cx.target_spec().target_env == "musl" {
++    let abi = if cx.target_spec().target_env == "musl" || cx.target_spec().target_env == "gnu" {
+         ELFv2
+     } else {
+         match cx.data_layout().endian {
+--- a/src/librustc_target/spec/powerpc64_unknown_linux_gnu.rs
++++ b/src/librustc_target/spec/powerpc64_unknown_linux_gnu.rs
+@@ -1,4 +1,4 @@
+-use crate::spec::{LinkerFlavor, Target, TargetResult, RelroLevel};
++use crate::spec::{LinkerFlavor, Target, TargetResult};
+ 
+ pub fn target() -> TargetResult {
+     let mut base = super::linux_base::opts();
+@@ -6,10 +6,6 @@ pub fn target() -> TargetResult {
+     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
+     base.max_atomic_width = Some(64);
+ 
+-    // ld.so in at least RHEL6 on ppc64 has a bug related to BIND_NOW, so only enable partial RELRO
+-    // for now. https://github.com/rust-lang/rust/pull/43170#issuecomment-315411474
+-    base.relro_level = RelroLevel::Partial;
+-
+     Ok(Target {
+         llvm_target: "powerpc64-unknown-linux-gnu".to_string(),
+         target_endian: "big".to_string(),

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -1,7 +1,7 @@
 # Template file for 'rust'
 pkgname=rust
 version=1.34.0
-revision=1
+revision=2
 _rust_dist_version=1.33.0
 _cargo_dist_version=0.33.0
 # NB. if you push any(!) new version, don't forget to put a build


### PR DESCRIPTION
This involves a few things. One is updating the internal-llvm patch to match what we have elsewhere, the other is updating librustc_target code to emit ELFv2 on glibc in our case. This is not handled perfectly (see comment) but it's best we can do for now.

Also bump, so that it gets rebuilt and cross-compiling works.

The actual ideal solution would be to come up with a new triple for glibc+elfv2, something like `powerpc64-unknown-linux-gnuelfv2` and make everything use it, but this is not something Void should do downstream, so stick with standard triple (requires the smallest amount of patching) and maybe migrate later (a fairly small amount of work once it exists)