### PR TITLE
xf86-video-mga: fix cross

### DIFF
--- a/srcpkgs/xf86-video-mga/patches/cross.patch
+++ b/srcpkgs/xf86-video-mga/patches/cross.patch
@@ -1,0 +1,44 @@
+Remove some checks that break cross.
+
+--- configure.ac	2019-04-30 17:00:37.796389608 +0200
++++ configure.ac	2019-04-30 17:01:44.933049215 +0200
+@@ -63,37 +63,14 @@
+               [EXA="$enableval"],
+               [EXA=yes])
+ 
+-# Store the list of server defined optional extensions in REQUIRED_MODULES
+-XORG_DRIVER_CHECK_EXT(RANDR, randrproto)
+-XORG_DRIVER_CHECK_EXT(RENDER, renderproto)
+-XORG_DRIVER_CHECK_EXT(XV, videoproto)
+-XORG_DRIVER_CHECK_EXT(DPMSExtension, xextproto)
+-
+ # Obtain compiler/linker options for the driver dependencies
+-PKG_CHECK_MODULES(XORG, [xorg-server >= 1.1.0 xproto fontsproto $REQUIRED_MODULES])
++PKG_CHECK_MODULES(XORG, [xorg-server >= 1.1.0 xproto fontsproto randrproto renderproto videoproto xextproto])
+ sdkdir=`$PKG_CONFIG --variable=sdkdir xorg-server`
+ 
+ # Checks for libraries.
+ 
+-if test "x$DRI" != xno; then
+-        AC_CHECK_FILE([${sdkdir}/dri.h],
+-                      [have_dri_h="yes"], [have_dri_h="no"])
+-        AC_CHECK_FILE([${sdkdir}/sarea.h],
+-                      [have_sarea_h="yes"], [have_sarea_h="no"])
+-        AC_CHECK_FILE([${sdkdir}/dristruct.h],
+-                      [have_dristruct_h="yes"], [have_dristruct_h="no"])
+-fi
+-
+ AC_MSG_CHECKING([whether to include DRI support])
+-if test "x$DRI" = xauto; then
+-        if test "x$have_dri_h" = xyes && \
+-           test "x$have_sarea_h" = xyes && \
+-           test "x$have_dristruct_h" = xyes; then
+-                DRI="yes"
+-        else
+-                DRI="no"
+-        fi
+-fi
++DRI="yes"
+ AC_MSG_RESULT([$DRI])
+ 
+ AM_CONDITIONAL(DRI, test "x$DRI" = xyes)

--- a/srcpkgs/xf86-video-mga/template
+++ b/srcpkgs/xf86-video-mga/template
@@ -7,7 +7,6 @@ build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config xorg-util-macros"
 makedepends="xorg-server-devel"
 depends="virtual?xserver-abi-video-24_1"
-nocross=yes
 short_desc="Xorg Matrox Graphics Adapter video driver"
 homepage="http://xorg.freedesktop.org"
 license="MIT"


### PR DESCRIPTION
This just replaces some configure.ac checks with assumptions that we always satisfy anyway.

@pullmoll