### PR TITLE
dnscrypt-proxy: update to 2.0.23.

### DIFF
--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,6 +1,6 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.0.22
+version=2.0.23
 revision=1
 build_style=go
 go_import_path=github.com/jedisct1/dnscrypt-proxy
@@ -10,8 +10,8 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="ISC"
 homepage="https://github.com/jedisct1/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/jedisct1/dnscrypt-proxy/master/ChangeLog"
-distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=ac8ad326b6da47bb1e515d29a354511a8dc9a5ebfcf4be816b6791532d02d564
+distfiles="https://github.com/jedisct1/dnscrypt-proxy/archive/${version}.tar.gz"
+checksum=d405a562b0d4b0101a11347c1647bb55351945d82d67565b396794babf296905
 conf_files="/etc/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 make_dirs="/var/log/dnscrypt-proxy 0750 dnscrypt_proxy dnscrypt_proxy"


### PR DESCRIPTION
* updated to latest version
* functionality tested on x86_64
* wrote out `${homepage}` while at it