### PR TITLE
neovim: update to 0.3.5.

### DIFF
--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,26 +1,17 @@
 # Template file for 'neovim'
 pkgname=neovim
-version=0.3.4
+version=0.3.5
 revision=1
 build_style=cmake
-configure_args="-DENABLE_JEMALLOC=0 -DUSE_BUNDLED_LIBTERMKEY=OFF"
-hostmakedepends="pkg-config gperf LuaJIT-devel lua51-lpeg lua51-mpack"
-makedepends="libtermkey-devel libuv-devel libvterm-devel msgpack-devel"
+configure_args="-DENABLE_JEMALLOC=0"
+hostmakedepends="pkg-config gperf LuaJIT lua51-lpeg lua51-mpack"
+makedepends="libtermkey-devel libuv-devel libvterm-devel msgpack-devel LuaJIT-devel"
 short_desc="Fork of Vim aiming to improve user experience, plugins and GUIs"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
-license="Apache-2.0, GPL-2.0-or-later"
+license="Apache-2.0, custom:Vim"
 homepage="https://neovim.io"
-distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=a641108bdebfaf319844ed46b1bf35d6f7c30ef5aeadeb29ba06e19c3274bc0e
-
-do_check() {
-	# requires downloading stuff from the outside and also adds the following deps
-	# libtool, automake, curl, unzip
-	:
-}
-
-# XXX: neovim needs host bin to generate helptags at build time.
-nocross=yes
+distfiles="https://github.com/neovim/neovim/archive/v${version}.tar.gz"
+checksum=b8b30043963133214f78901cb6361189c8f94e9f5f1b2493a7cedb4c323236d6
 
 alternatives="
  vi:vi:/usr/bin/nvim
@@ -29,3 +20,16 @@ alternatives="
  vi:view.1:/usr/share/man/man1/nvim.1
  vim:vim:/usr/bin/nvim
  vim:vim.1:/usr/share/man/man1/nvim.1"
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qemu-user-static"
+fi
+
+pre_configure() {
+	vsed -i runtime/CMakeLists.txt \
+		-e "s|\".*/bin/nvim|\${CMAKE_CROSSCOMPILING_EMULATOR} &|g"
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
* updated to latest version
* functionality tested on x86_64
* configure_args: removed `-DUSE_BUNDELED_LIBTERMKEY=OFF` as autoset by
  cmake when `libtermkey` is found on the system
* makedepends: links against luajit, so add to makedepends
* license: neovim's `LICENSE` states Apache-2.0 + VIM LICENSE, so fix
  accordingly and distribute
* do_check: removed as there is nothing done? Just `=> neovim-0.3.5_1: running do_check ...`
* fix cross: host was executing target's `build/bin/nvim` to generate
  helptags, so workaround via running the binary with `$CMAKE_CROSSCOMPILING_EMULATOR`
* template style: `alternatives` variable before buildphase-functions