### PR TITLE
rust: fix miscompilation of rustc on musl + enable vendor crates

### DIFF
--- a/srcpkgs/rust/patches/lzma-sys-cross-ldflags.patch
+++ b/srcpkgs/rust/patches/lzma-sys-cross-ldflags.patch
@@ -1,0 +1,11 @@
+This allows lzma-sys to build in a cross-compiling environment.
+--- rustc-1.33.0-src/vendor/lzma-sys/build.rs
++++ rustc-1.33.0-src/vendor/lzma-sys/build.rs
+@@ -101,6 +101,7 @@
+         }
+         cmd.env("CC", compiler.path())
+            .env("CFLAGS", cflags)
++           .env("LDFLAGS", "")
+            .current_dir(&dst.join("build"))
+            .arg(sanitize_sh(&src.join("configure")));
+         cmd.arg(format!("--prefix={}", sanitize_sh(&dst)));

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -1,7 +1,7 @@
 # Template file for 'rust'
 pkgname=rust
 version=1.34.0
-revision=2
+revision=3
 _rust_dist_version=1.33.0
 _cargo_dist_version=0.33.0
 # NB. if you push any(!) new version, don't forget to put a build
@@ -114,6 +114,13 @@ post_extract() {
 	fi
 }
 
+# we need this because cargo verifies checksums of all files in vendor
+# crates when it builds and gives us no way to override or update the
+# file sanely... so just clear out the file list
+_clear_vendor_checksums() {
+	sed -i 's/\("files":{\)[^}]*/\1/' vendor/$1/.cargo-checksum.json
+}
+
 post_patch() {
 	if [ "$build_option_internal_llvm" ]; then
 		# patches for Rust's bundled LLVM
@@ -133,6 +140,10 @@ post_patch() {
 	fi
 
 	sed -i /LD_LIBRARY_PATH/d src/bootstrap/bootstrap.py
+
+	# clear out all the checksum nonsense of patched vendor crates
+	_clear_vendor_checksums libc
+	_clear_vendor_checksums lzma-sys
 }
 
 do_configure() {
@@ -148,6 +159,7 @@ do_configure() {
 		--disable-rpath
 		--disable-docs
 		--disable-codegen-tests
+		--enable-vendor
 	"
 
 	if ! [ "$build_option_internal_llvm" ]; then
@@ -199,7 +211,7 @@ pre_build() {
 # of the cross host.
 # Unset LDFLAGS, otherwise cross builds to the same arch will fail
 do_build() {
-	env CFLAGS_${RUST_BUILD}="${CFLAGS_host}" LDFLAGS=''  make ${makejobs} ${make_build_args}
+	env CFLAGS_${RUST_BUILD}="${CFLAGS_host}" make ${makejobs} ${make_build_args}
 }
 
 do_install() {


### PR DESCRIPTION
This commit fixes several things.

1) It enables usage of vendor crates, making our patches actually do something (those for the vendor/ subdirectory anyway)
2) By extension, it enables dynamic linking of musl, which was not being done at all.
3) Removes the ugly LDFLAGS hack, which was causing miscompilation in cross environments, as it didn't pass the cross sysroot to search for libs in when linking. This resulted in a particularly bad miscompilation when cross-compiling from glibc to musl on the same architecture, as it would link against glibc's libc.a instead of musl's libc.a (not libc.so because the musl dynamic link patch was not being used), resulting in failures when actually compiling various projects. This hack is now replaced with properly patching the lzma-sys crate instead, which was the culprit previously when it comes to failures.

However, what I am not happy with: having to patch the sha256 hash of the patched files like this. If I don't patch them, cargo will complain. The reason I don't like it is 1) even though the patches are likely to remain the same, the checksums of those files will not, requiring updates every time we update 2) The line especially for lzma-sys is very long, resulting in a needlessly large diff. Any ideas about that?

@Cogitri @jnbr