### PR TITLE
skalibs: broken on ppc and mips

### DIFF
--- a/srcpkgs/skalibs/template
+++ b/srcpkgs/skalibs/template
@@ -3,6 +3,7 @@ pkgname=skalibs
 version=2.8.0.1
 revision=1
 _sysdepspkg=skaware-void-sysdeps
+archs="aarch64* armv7l* i686 x86_64*"
 build_style=configure
 configure_args="--libdir=/usr/lib --enable-static --enable-shared --enable-clock
  --enable-monotonic --enable-force-devr --datadir=/usr/share/$pkgname --libdir=/usr/lib


### PR DESCRIPTION
[skaware-void-sysdeps](https://github.com/CMB/skaware-void-sysdeps) only written for aarch64, armv7, i686 glibc and x86_64.