### PR TITLE
exiv2: Correct distfile location

### DIFF
--- a/srcpkgs/exiv2/template
+++ b/srcpkgs/exiv2/template
@@ -10,7 +10,7 @@ short_desc="Image metadata manipulation"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 license="GPL-2.0-or-later"
 homepage="http://www.exiv2.org"
-distfiles="http://www.exiv2.org/builds/exiv2-${version}-Source.tar.gz"
+distfiles="http://www.exiv2.org/releases/exiv2-${version}-Source.tar.gz"
 checksum=ee88bc81539b73c65010651785d094fad0b39760a424b3c16c17e1856cfef2d7
 
 exiv2-devel_package() {


### PR DESCRIPTION
Version 0.27.0 no longer latest version, hosted under "releases" directory.