### PR TITLE
libdmapsharing: disable tests

### DIFF
--- a/srcpkgs/libdmapsharing/template
+++ b/srcpkgs/libdmapsharing/template
@@ -1,13 +1,14 @@
 # Template file for 'libdmapsharing'
 pkgname=libdmapsharing
 version=2.9.39
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-mdns=avahi"
+build_helper=gir
+configure_args="--with-mdns=avahi --disable-tests"
 hostmakedepends="pkg-config glib-devel"
 makedepends="gtk+-devel avahi-glib-libs-devel libsoup-devel
  gst-plugins-base1-devel libgee08-devel"
-short_desc="A library that implements the DMAP family of protocols"
+short_desc="Library that implements the DMAP family of protocols"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="LGPL-2.1"
 homepage="http://www.flyn.org/projects/libdmapsharing/index.html"


### PR DESCRIPTION
These fail to build with libgee currently in the repository, so disable them.