### PR TITLE
gom: use python3

### DIFF
--- a/srcpkgs/gom/template
+++ b/srcpkgs/gom/template
@@ -1,14 +1,14 @@
 # Template file for 'gom'
 pkgname=gom
 version=0.3.3
-revision=1
+revision=2
 build_style=meson
 configure_args="-Denable-introspection=$(vopt_if gir true false)
  -Denable-gtk-doc=false"
 pycompile_module="gi"
 hostmakedepends="pkg-config"
 makedepends="sqlite-devel gettext-devel libglib-devel gdk-pixbuf-devel
- $(vopt_if gir 'gobject-introspection python-gobject-devel')"
+ $(vopt_if gir 'gobject-introspection python3-gobject-devel')"
 short_desc="GObject Data Mapper"
 maintainer="Juan RP <xtraeme@gmail.com>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
The build is broken otherwise (meson pulls in python3, which is registered first in alternatives, but the gobject bindings were installed for python2 and they couldn't be found afterwards).

Python 2 is getting phased out anyway, so switch.