### PR TITLE
skalibs: do not unconditionally set archs

### DIFF
--- a/srcpkgs/skalibs/template
+++ b/srcpkgs/skalibs/template
@@ -3,7 +3,6 @@ pkgname=skalibs
 version=2.8.0.1
 revision=1
 _sysdepspkg=skaware-void-sysdeps
-archs="aarch64* armv7l* i686 x86_64*"
 build_style=configure
 configure_args="--libdir=/usr/lib --enable-static --enable-shared --enable-clock
  --enable-monotonic --enable-force-devr --datadir=/usr/share/$pkgname --libdir=/usr/lib
@@ -21,6 +20,11 @@ if [ "$CROSS_BUILD" ]; then
 	distfiles+=" https://github.com/CMB/${_sysdepspkg}/archive/${version}.tar.gz"
 	checksum+=" 6d0f62109f22edfa1e8e0f1885bff705a2ce0c3588592692afbddeb6d691d7f7"
 	configure_args+=" --with-sysdeps=../${_sysdepspkg}-${version}/${XBPS_CROSS_TRIPLET}"
+
+	case "$XBPS_TARGET_MACHINE" in
+		aarch64*|armv6*|armv7l*|i686|x86_64*) ;;
+		*) nocross="Missing cross sysdeps" ;;
+	esac
 fi
 
 post_install() {


### PR DESCRIPTION
There is no need to break native builds too when they work perfectly fine. Also reenable armv6.

@stenstorp next time please mark things properly like this, I'm trying to get this right across the repo...