### PR TITLE
gcc: add patch to properly handle 64-bit long double for ppc*-musl

### DIFF
--- a/srcpkgs/cross-powerpc-linux-musl/files/0010-ldbl128-config.patch
+++ b/srcpkgs/cross-powerpc-linux-musl/files/0010-ldbl128-config.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/0010-ldbl128-config.patch

--- a/srcpkgs/cross-powerpc-linux-musl/files/libgcc-musl-ldbl128-config.patch
+++ b/srcpkgs/cross-powerpc-linux-musl/files/libgcc-musl-ldbl128-config.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/libgcc-musl-ldbl128-config.patch

--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=2
+revision=3
 
 short_desc="Cross toolchain for PowerPC (musl)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
@@ -88,6 +88,8 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 	_apply_patch -p0 ${FILESDIR}/no-stack_chk_fail_local.patch
+	_apply_patch -p0 ${FILESDIR}/0010-ldbl128-config.patch
+	_apply_patch -p0 ${FILESDIR}/libgcc-musl-ldbl128-config.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
 	msg_normal "Building cross gcc bootstrap\n"

--- a/srcpkgs/cross-powerpc64-linux-musl/files/libgcc-musl-ldbl128-config.patch
+++ b/srcpkgs/cross-powerpc64-linux-musl/files/libgcc-musl-ldbl128-config.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/libgcc-musl-ldbl128-config.patch

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=2
+revision=3
 short_desc="Cross toolchain for powerpc64 with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 	_apply_patch -p0 ${FILESDIR}/0010-ldbl128-config.patch
 	_apply_patch -p0 ${FILESDIR}/ppc64-pure64.patch
+	_apply_patch -p0 ${FILESDIR}/libgcc-musl-ldbl128-config.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h

--- a/srcpkgs/cross-powerpc64le-linux-musl/files/libgcc-musl-ldbl128-config.patch
+++ b/srcpkgs/cross-powerpc64le-linux-musl/files/libgcc-musl-ldbl128-config.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/libgcc-musl-ldbl128-config.patch

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=2
+revision=3
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -84,6 +84,7 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 	_apply_patch -p0 ${FILESDIR}/0010-ldbl128-config.patch
 	_apply_patch -p0 ${FILESDIR}/ppc64-pure64.patch
+	_apply_patch -p0 ${FILESDIR}/libgcc-musl-ldbl128-config.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h

--- a/srcpkgs/gcc/patches/libgcc-musl-ldbl128-config.patch
+++ b/srcpkgs/gcc/patches/libgcc-musl-ldbl128-config.patch
@@ -1,0 +1,138 @@
+From 330788a7acde436c1ee8fcb0c1fd657e6ffab8fd Mon Sep 17 00:00:00 2001
+From: q66 <daniel@octaforge.org>
+Date: Thu, 2 May 2019 18:58:29 +0200
+Subject: [PATCH] libgcc: do not build 128-bit long double runtime support for
+ musl
+
+Another patch was already disabling 128-bit long doubles for the
+compiler itself, this one additionally avoids building the runtime
+support for that.
+
+Musl does not support 128-bit long doubles, and building libgcc
+with 128-bit long double ABI was breaking things like ld.gold
+which refuses to link two objects with different FP ABI tags.
+---
+ libgcc/config.host              | 10 +++++++++-
+ libgcc/config/rs6000/ppc64-fp.c | 14 ++++++++++++++
+ libgcc/config/rs6000/t-musl     |  8 ++++++++
+ 3 files changed, 31 insertions(+), 1 deletion(-)
+ create mode 100644 libgcc/config/rs6000/t-musl
+
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 11b4aca..51ceef5 100644
+--- libgcc/config.host
++++ libgcc/config.host
+@@ -1071,8 +1071,16 @@ powerpc-*-rtems*)
+ 	extra_parts="$extra_parts crtbeginS.o crtendS.o crtbeginT.o ecrti.o ecrtn.o ncrti.o ncrtn.o"
+ 	;;
+ powerpc*-*-linux*)
+-	tmake_file="${tmake_file} rs6000/t-ppccomm rs6000/t-savresfgpr rs6000/t-crtstuff rs6000/t-linux t-dfprules rs6000/t-ppc64-fp t-slibgcc-libgcc"
++	tmake_file="${tmake_file} rs6000/t-ppccomm rs6000/t-savresfgpr rs6000/t-crtstuff t-dfprules rs6000/t-ppc64-fp t-slibgcc-libgcc"
+ 	tmake_file="${tmake_file} t-stack rs6000/t-stack-rs6000"
++	case ${host} in
++	powerpc*-*-linux-musl*)
++	  tmake_file="${tmake_file} rs6000/t-musl"
++	  ;;
++	*)
++	  tmake_file="${tmake_file} rs6000/t-linux"
++	  ;;
++	esac
+ 	case $ppc_fp_type in
+ 	64)
+ 		;;
+diff --git a/libgcc/config/rs6000/ppc64-fp.c b/libgcc/config/rs6000/ppc64-fp.c
+index faffc82..9f479ee 100644
+--- libgcc/config/rs6000/ppc64-fp.c
++++ libgcc/config/rs6000/ppc64-fp.c
+@@ -25,25 +25,34 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+ #if defined(__powerpc64__) || defined (__64BIT__) || defined(__ppc64__)
++#if __LDBL_MANT_DIG__ > __DBL_MANT_DIG__
+ #define TMODES
++#endif
+ #include "fp-bit.h"
+ 
++#ifdef TMODES
+ extern DItype __fixtfdi (TFtype);
++#endif
+ extern DItype __fixdfdi (DFtype);
+ extern DItype __fixsfdi (SFtype);
+ extern USItype __fixunsdfsi (DFtype);
+ extern USItype __fixunssfsi (SFtype);
++#ifdef TMODES
+ extern TFtype __floatditf (DItype);
+ extern TFtype __floatunditf (UDItype);
++#endif
+ extern DFtype __floatdidf (DItype);
+ extern DFtype __floatundidf (UDItype);
+ extern SFtype __floatdisf (DItype);
+ extern SFtype __floatundisf (UDItype);
++#ifdef TMODES
+ extern DItype __fixunstfdi (TFtype);
++#endif
+ 
+ static DItype local_fixunssfdi (SFtype);
+ static DItype local_fixunsdfdi (DFtype);
+ 
++#ifdef TMODES
+ DItype
+ __fixtfdi (TFtype a)
+ {
+@@ -51,6 +60,7 @@ __fixtfdi (TFtype a)
+     return - __fixunstfdi (-a);
+   return __fixunstfdi (a);
+ }
++#endif
+ 
+ DItype
+ __fixdfdi (DFtype a)
+@@ -86,6 +96,7 @@ __fixunssfsi (SFtype a)
+   return (SItype) a;
+ }
+ 
++#ifdef TMODES
+ TFtype
+ __floatditf (DItype u)
+ {
+@@ -109,6 +120,7 @@ __floatunditf (UDItype u)
+ 
+   return (TFtype) dh + (TFtype) dl;
+ }
++#endif
+ 
+ DFtype
+ __floatdidf (DItype u)
+@@ -183,6 +195,7 @@ __floatundisf (UDItype u)
+   return (SFtype) f;
+ }
+ 
++#ifdef TMODES
+ DItype
+ __fixunstfdi (TFtype a)
+ {
+@@ -206,6 +219,7 @@ __fixunstfdi (TFtype a)
+     v += (USItype) a;
+   return v;
+ }
++#endif
+ 
+ /* This version is needed to prevent recursion; fixunsdfdi in libgcc
+    calls fixdfdi, which in turn calls calls fixunsdfdi.  */
+diff --git a/libgcc/config/rs6000/t-musl b/libgcc/config/rs6000/t-musl
+new file mode 100644
+index 0000000..f261d8a
+--- /dev/null
++++ libgcc/config/rs6000/t-musl
+@@ -0,0 +1,8 @@
++# Overrides for musl; we want to avoid building all these implementations
++# required for quad-precision float handling as musl does not support that,
++# ibm-ldouble.c is added into the build by t-ppccomm
++
++HOST_LIBGCC2_CFLAGS += -mlong-double-64 -mno-minimal-toc
++
++# We do not want to build ibm-ldouble.c.
++LIB2ADD := $(filter-out %ibm-ldouble.c, $(LIB2ADD))
+-- 
+2.21.0
+


### PR DESCRIPTION
Musl requires gcc to be built with 64-bit long doubles as it does not support the quad precision long double format, which is implemented in software using two doubles.

This was already being patched, but it turns out libgcc is forcibly being built with 128-bit long doubles because of several glibc specific APIs it exposes. This wasn't causing any practical runtime issue, but it was causing problems when using e.g. the ld.gold linker to link, because it explicitly checks the ABI tag and libgcc was tagged as 128-bit long double.

This extra patch solves the problem by conditionally compiling libgcc with 64-bit long doubles (only on musl) and disabling the APIs that would have been affected (as they are for glibc only).
