### PR TITLE
sway: update to 1.1+rc1.

### DIFF
--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,19 +1,21 @@
 # Template file for 'sway'
 pkgname=sway
-version=1.0
+version=1.1+rc1
 revision=1
+_ver=1.1-rc1
+wrksrc=$pkgname-$_ver
 build_style=meson
 conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc git"
 makedepends="wlroots-devel wayland-devel wayland-protocols pcre-devel
  json-c-devel pango-devel cairo-devel gdk-pixbuf-devel"
-depends="xorg-server-xwayland"
+depends="xorg-server-xwayland swaybg"
 short_desc="Tiling Wayland compositor compatible with i3"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="MIT"
 homepage="https://swaywm.org"
-distfiles="https://github.com/swaywm/${pkgname}/archive/${version}.tar.gz"
-checksum=24dafd0f1e630e97a5dd47233841adf856b665e2321d6207acfe6b3002d1bc56
+distfiles="https://github.com/swaywm/${pkgname}/archive/${_ver}.tar.gz"
+checksum=b8d0eae2bcc7e350f2411830b5d0d9c02b266b8346d1f06c8de69df159b84512
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This is a release candidate, but package maintainers have not been instructed not to package this release as the developers did for the old ones.
It is up to you to decide if you want to add this version to void repositories (if the template is correct) or not ;)