### PR TITLE
wlroots: revert to 0.5.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3319,7 +3319,7 @@ libcodecore.so.0 libio.elementary.code-3.0_1
 libio.elementary.music-core.so.0 libio.elementary.music-5.0_1
 libpantheon-files-core.so.4 libio.elementary.files-4.1.4_1
 libpantheon-files-widgets.so.4 libio.elementary.files-4.1.4_1
-libwlroots.so.3 wlroots-0.6.0_1
+libwlroots.so.2 wlroots-0.5.0_1
 libbaseencode.so.1 libbaseencode-1.0.9_1
 libcotp.so.12 libcotp-1.2.1_1
 libunarr.so.1 libunarr-1.0.1_1

--- a/srcpkgs/wlroots/template
+++ b/srcpkgs/wlroots/template
@@ -1,7 +1,8 @@
 # Template file for 'wlroots'
 pkgname=wlroots
-version=0.6.0
-revision=1
+version=0.5.0
+reverts="0.6.0_1"
+revision=2
 build_style=meson
 configure_args="-Dlibcap=enabled -Dlogind=enabled -Dlogind-provider=elogind
  -Dxcb-errors=enabled -Dxcb-icccm=enabled -Dxwayland=enabled
@@ -11,13 +12,13 @@ makedepends="elogind-devel libcap-devel wayland-devel wayland-protocols
  MesaLib-devel libinput-devel libxkbcommon-devel libdrm-devel pixman-devel
  libxcb-devel xcb-util-cursor-devel xcb-util-devel xcb-util-image-devel
  xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel
- xcb-util-errors-devel xcb-util-xrm-devel freerdp-devel"
+ xcb-util-errors-devel xcb-util-xrm-devel"
 short_desc="Module Wayland compositor library"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="MIT"
 homepage="https://github.com/swaywm/wlroots"
 distfiles="https://github.com/swaywm/wlroots/archive/${version}.tar.gz"
-checksum=9cf3716f3683d800df8b150f256ff66dad65faf13a9d67c284f67a9444d28c70
+checksum=3c6d422aaa7ac09a1e4a88d93f07a4d6ef6c5e4d76c3422c240a5783265ed0e3
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This breaks shlibs for sway and sway itself does not build with wlroots 0.6.0, so revert.

@jnbr @Derriick