### PR TITLE
boost: add patch for context on ppc64

### DIFF
--- a/srcpkgs/boost/patches/ppc64-context.patch
+++ b/srcpkgs/boost/patches/ppc64-context.patch
@@ -1,0 +1,30 @@
+From 2354eca9b776a6739112833f64754108cc0d1dc5 Mon Sep 17 00:00:00 2001
+From: Shawn Anastasio <shawn@anastas.io>
+Date: Fri, 3 May 2019 20:18:11 -0500
+Subject: [PATCH] Fix ABI violation on ppc64 ELFv2, fixes #72
+
+The existing ontop_fcontext implementation for ppc64 ELFv2
+violates the ABI by not storing the callback entry address
+in %r12 before branching. This results in crashes on this
+platform.
+
+This commit addresses this and allows the context library
+to function as expected on ppc64 platforms using the ELFv2 ABI.
+---
+ src/asm/ontop_ppc64_sysv_elf_gas.S | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/asm/ontop_ppc64_sysv_elf_gas.S b/src/asm/ontop_ppc64_sysv_elf_gas.S
+index d54b16e7..cd97f456 100644
+--- libs/context/src/asm/ontop_ppc64_sysv_elf_gas.S
++++ libs/context/src/asm/ontop_ppc64_sysv_elf_gas.S
+@@ -174,6 +174,9 @@ ontop_fcontext:
+     # restore CTR
+     mtctr  %r5
+ 
++    # store cb entrypoint in %r12, used for TOC calculation
++    mr %r12, %r5
++
+     # copy transfer_t into ontop_fn arg registers
+     mr  %r3, %r7
+     # arg pointer already in %r4


### PR DESCRIPTION
This fixes the ontop_fcontext function of boost::context on ppc64.