### PR TITLE
docker: enable armv7 build

### DIFF
--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,7 +1,7 @@
 # Template file for 'docker'
 pkgname=docker
 version=18.09.5
-revision=1
+revision=2
 wrksrc="${pkgname}-ce-${version}"
 hostmakedepends="git go pkg-config curl cmake"
 makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel
@@ -19,7 +19,7 @@ depends+=" iptables xz git"
 nopie=yes
 nostrip=yes
 nocross=yes
-archs="x86_64* ppc64le*"
+archs="armv7l* x86_64* ppc64le*"
 system_groups="docker"
 
 _docker_components="tini proxy dockercli"


### PR DESCRIPTION
Hello!
Successfully built docker natively on raspberry pi 3 (had to add 1G swapfile)
docker is fully working (as far as i can tell)
