### PR TITLE
p11-kit: use system ca certificates as input for trust module

### DIFF
--- a/srcpkgs/p11-kit/template
+++ b/srcpkgs/p11-kit/template
@@ -1,9 +1,9 @@
 # Template file for 'p11-kit'
 pkgname=p11-kit
 version=0.23.15
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-module-path=/usr/lib/pkcs11 --without-trust-paths"
+configure_args="--with-module-path=/usr/lib/pkcs11"
 hostmakedepends="automake libtool pkg-config"
 makedepends="libtasn1-devel libffi-devel"
 short_desc="Provides a way to load and enumerate PKCS#11 modules"


### PR DESCRIPTION
To date p11-kit was built with `--without-trust-paths` which means that p11-kit was not feeded with the systems CAs and presented an empty store when queried.

This broke applications distributed via flatpak, which uses p11-kit to query the hosts available CAs and make them available inside the sandboxes.