### PR TITLE
qt: cross targets for ppc64, qt-webkit: fix build + ppc adjustments

### DIFF
--- a/srcpkgs/qt-webkit/template
+++ b/srcpkgs/qt-webkit/template
@@ -5,7 +5,7 @@ revision=7
 _qtver=4.8.7
 wrksrc="qtwebkit-${version}"
 create_wrksrc=yes
-hostmakedepends="automake libtool bison flex gperf ruby pkg-config qt-qmake"
+hostmakedepends="automake libtool bison flex gperf python ruby pkg-config qt-qmake"
 makedepends="MesaLib-devel libjpeg-turbo-devel qt-devel qt-designer-devel
  glib-devel fontconfig-devel gst-plugins-base1-devel sqlite-devel libXrender-devel"
 short_desc="Open source web browser engine (Qt4 port)"
@@ -50,7 +50,7 @@ do_build() {
 		opts+=" DEFINES+=ENABLE_JIT=0"
 		opts+=" DEFINES+=ENABLE_YARR_JIT=0"
 		;;
-	arm*|mips*)
+	arm*|mips*|ppc*)
 		# Disable JIT and assembler
 		opts+=" DEFINES+=ENABLE_JIT=0"
 		opts+=" DEFINES+=ENABLE_YARR_JIT=0"

--- a/srcpkgs/qt/template
+++ b/srcpkgs/qt/template
@@ -107,6 +107,22 @@ do_configure() {
 				_opts+=" -arch mips"
 				_spec="mipsel-linux-muslhf-c++"
 				;;
+			ppc64le)
+				_opts+=" -arch powerpc"
+				_spec="powerpc64le-linux-gnu-c++"
+				;;
+			ppc64le-musl)
+				_opts+=" -arch powerpc"
+				_spec="powerpc64le-linux-musl-c++"
+				;;
+			ppc64)
+				_opts+=" -arch powerpc"
+				_spec="powerpc64-linux-gnu-c++"
+				;;
+			ppc64-musl)
+				_opts+=" -arch powerpc"
+				_spec="powerpc64-linux-musl-c++"
+				;;
 			*-musl)
 				_opts+=" -arch arm"
 				_spec="${XBPS_TARGET_MACHINE}-linux-musl-c++"


### PR DESCRIPTION
These are the necessary changes for qt4 and qt4 webkit on ppc64.

Python is newly required for qt-webkit hostmakedepends, because a python script is run during build and this script must be run with python2 (registered as python in alternatives). Some change in a host dependency switched the python version to 3, which now breaks it.