### PR TITLE
netcdf: update to 4.7.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -72,7 +72,7 @@ libncurses.so.6 ncurses-libs-6.0_1 ignore
 libncurses.so.5 ncurses-libs-6.0_1 ignore
 libncursesw.so.6 ncurses-libs-5.8_1 ignore
 libncursesw.so.5 ncurses-libs-5.8_1 ignore
-libnetcdf.so.13 netcdf-4.6.0_2
+libnetcdf.so.15 netcdf-4.7.0_1
 libformw.so.5 ncurses-libs-5.9_13 ignore
 libformw.so.6 ncurses-libs-5.8_1 ignore
 libpanelw.so.5 ncurses-libs-5.9_13 ignore

--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -1,7 +1,7 @@
 # Template file for 'freecad'
 pkgname=freecad
 version=0.18.1
-revision=1
+revision=2
 wrksrc="FreeCAD-${version}"
 build_style=cmake
 

--- a/srcpkgs/netcdf/template
+++ b/srcpkgs/netcdf/template
@@ -1,6 +1,6 @@
 # Template file for 'netcdf'
 pkgname=netcdf
-version=4.6.2.1
+version=4.7.0
 revision=1
 wrksrc="netcdf-c-${version}"
 build_style=gnu-configure
@@ -12,7 +12,7 @@ maintainer="Hans Grob <woufrous@gmail.com>"
 license="NetCDF"
 homepage="https://www.unidata.ucar.edu/software/netcdf/"
 distfiles="https://github.com/Unidata/netcdf-c/archive/v${version}.tar.gz"
-checksum=8a62b2b5890fef10c1e32b266924f1974ac1c153358e111e764163097b3793b0
+checksum=26d03164074363b3911ed79b7cddd045c22adf5ebaf978943db11a1d9f15e9d3
 
 post_install() {
 	# Remove references to hardening -specs.

--- a/srcpkgs/vtk/template
+++ b/srcpkgs/vtk/template
@@ -1,7 +1,7 @@
 # Template file for 'vtk'
 pkgname=vtk
 version=8.2.0
-revision=1
+revision=2
 wrksrc=VTK-${version}
 build_style=cmake
 # vtk can be huge, especially with -DVTK_BUILD_ALL_MODULES=ON"


### PR DESCRIPTION
The 4.6.2.1 release actually got removed from github, so update to latest to unbreak.