### PR TITLE
base-system: Add Linux dependency on ppc

### DIFF
--- a/srcpkgs/base-system/template
+++ b/srcpkgs/base-system/template
@@ -2,7 +2,7 @@
 pkgname=base-system
 reverts="0.113_1"
 version=0.112
-revision=5
+revision=6
 build_style=meta
 short_desc="Void Linux base system meta package"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -23,5 +23,5 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc64*) depends+=" linux";;
+	i686*|x86_64*|ppc*) depends+=" linux";;
 esac


### PR DESCRIPTION
Now that all ppc variants have a kernel config, include linux in base-system.