### PR TITLE
gimp: build with libexecinfo on musl

### DIFF
--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -21,6 +21,13 @@ distfiles="https://download.gimp.org/pub/gimp/v${version%.*}/gimp-${version}.tar
 checksum=12d1f243265c7aee1f2c6e97883a5c90ddc0b19b4346cf822e24adbb6c998c77
 lib32disabled=yes
 
+case "$XBPS_TARGET_MACHINE" in
+	*-musl)
+		makedepends+=" libexecinfo-devel"
+		LDFLAGS+=" -lexecinfo"
+	;;
+esac
+
 pre_configure() {
 	NOCONFIGURE=1 autoreconf -fi
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Gimp unconditionally includes and uses execinfo.h in its app core library, which is used everywhere in gimp. If not installed, gimp will fail to compile. I'm actually not quite sure how it compiled for musl until now, but somehow it did.

See https://github.com/GNOME/gimp/blob/01f940990260146a860f6956ebd962b45b0fc961/app/core/gimpbacktrace-linux.c#L42