### PR TITLE
gcc + cross: remove default definition of __gnu_linux__ on ppc*-musl

### DIFF
--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=3
+revision=4
 
 short_desc="Cross toolchain for PowerPC (musl)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
@@ -91,6 +91,9 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/0010-ldbl128-config.patch
 	_apply_patch -p0 ${FILESDIR}/libgcc-musl-ldbl128-config.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
+
+	# REMOVE WITH 9.1
+	sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
 
 	msg_normal "Building cross gcc bootstrap\n"
 

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=3
+revision=4
 short_desc="Cross toolchain for powerpc64 with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -88,6 +88,9 @@ _gcc_bootstrap() {
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
+
+	# REMOVE WITH 9.1
+	sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
 
 	msg_normal "Building cross gcc bootstrap\n"
 

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=3
+revision=4
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -88,6 +88,9 @@ _gcc_bootstrap() {
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
+
+	# REMOVE WITH 9.1
+	sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
 
 	msg_normal "Building cross gcc bootstrap\n"
 

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -163,6 +163,12 @@ pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl) patch -p1 -i ${FILESDIR}/libgnarl-musl.patch ;;
 	esac
+	# REMOVE WITH 9.1
+	case "$XBPS_TARGET_MACHINE" in
+		ppc*-musl)
+			sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
+			;;
+	esac
 }
 do_configure() {
 	local _langs _args _hash


### PR DESCRIPTION
The ppc compilers on musl define the `__gnu_linux__` macro by default, while on other architectures they do not. 

Expected output:
```
$ gcc -dM -E - < /dev/null|grep gnu_linux
$
```
Output before patching:
```
$ gcc -dM -E - < /dev/null|grep gnu_linux
#define __gnu_linux__ 1
$
```

This breaks compilation of gimp and maybe other things. It is fixed in gcc 9.1, but the patch is a part of a bigger refactor that's too big to apply, so just do it conditionally like this, we can remove it once we update gcc.