### PR TITLE
notmuch: update to 0.28.4.

### DIFF
--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -1,6 +1,6 @@
 # Template file for 'notmuch'
 pkgname=notmuch
-version=0.28.3
+version=0.28.4
 revision=1
 hostmakedepends="perl pkg-config python-devel python3-Sphinx python3-devel"
 makedepends="bash-completion gmime3-devel talloc-devel xapian-core-devel"
@@ -9,7 +9,7 @@ maintainer="Jan S. <jan.schreib@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://notmuchmail.org"
 distfiles="https://notmuchmail.org/releases/notmuch-${version}.tar.gz"
-checksum=4e212d8b4ae30da04edb05d836dcdb569488ff6760706cecb882488eb1710eec
+checksum=bab1cabb0542ce2bd4b41a15b84a8d81c8dc3332162705ded6f311dd898656ca
 
 subpackages="libnotmuch libnotmuch-devel notmuch-mutt notmuch-python notmuch-python3"
 
@@ -87,7 +87,7 @@ notmuch-mutt_package() {
 }
 
 notmuch-python_package() {
-	depends="libnotmuch-devel>=${version}_${revision}"
+	depends="libnotmuch>=${version}_${revision}"
 	short_desc+=" - Python2 bindings"
 	pycompile_module="notmuch"
 	pkg_install() {
@@ -96,7 +96,7 @@ notmuch-python_package() {
 }
 
 notmuch-python3_package() {
-	depends="libnotmuch-devel>=${version}_${revision}"
+	depends="libnotmuch>=${version}_${revision}"
 	short_desc+=" - Python3 bindings"
 	pycompile_module="notmuch"
 	pkg_install() {


### PR DESCRIPTION
While we're at it, correct dependencies of notmuch-python:
it should depend on libnotmuch instead of libnotmuch-devel