### PR TITLE
x265: add options for altivec and assembly

### DIFF
--- a/srcpkgs/x265/template
+++ b/srcpkgs/x265/template
@@ -1,12 +1,11 @@
 # Template file for 'x265'
 pkgname=x265
 version=3.0
-revision=1
+revision=2
 wrksrc="x265_${version}"
 build_wrksrc=source
 build_style=cmake
 configure_args="-DENABLE_PIC=1"
-hostmakedepends="yasm"
 short_desc="Open Source H.265/HEVC video encoder"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -14,8 +13,33 @@ homepage="http://x265.org/"
 distfiles="https://bitbucket.org/multicoreware/x265/downloads/x265_${version}.tar.gz"
 checksum=c5b9fc260cabbc4a81561a448f4ce9cad7218272b4011feabc3a6b751b2f0662
 
+build_options="altivec assembly"
+
+desc_option_altivec="Enable AltiVec support on ppc64 (POWER8 and higher only)"
+desc_option_assembly="Enable assembly support on x86/ARM"
+
 case "$XBPS_TARGET_MACHINE" in
-	ppc64|ppc64-musl) configure_args+=" -DCPU_POWER8=OFF -DENABLE_ALTIVEC=OFF";;
+	ppc64le*) build_options_default="altivec" ;;
+	# on ARM, enabling it currently fails with undefined reference to
+	# x265::setupAssemblyPrimitives(x265::EncoderPrimitives&, int)
+	x86_64*|i686*) build_options_default="assembly" ;;
+	*) ;;
+esac
+
+if [ "$build_option_assembly" ]; then
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*|i686*) hostmakedepends+=" nasm" ;;
+		*) ;;
+	esac
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	ppc64*)
+		# altivec does not build without power8 being enabled
+		configure_args+=" -DENABLE_ALTIVEC=$(vopt_if altivec ON OFF)
+		 -DCPU_POWER8=$(vopt_if altivec ON OFF)"
+		;;
+	*) configure_args+=" -DENABLE_ASSEMBLY=$(vopt_if assembly ON OFF)" ;;
 esac
 
 pre_configure() {


### PR DESCRIPTION
This lets the user choose whether to build them in. Default to on for altivec on ppc64le (because that's always power8 or better) and off on ppc64 (because we support old hardware), assembly is on for ~~ARM and~~ x86 and off for everything else.