### PR TITLE
roswell: update to 19.4.10.98.

### DIFF
--- a/srcpkgs/roswell/template
+++ b/srcpkgs/roswell/template
@@ -1,6 +1,6 @@
 # Template file for 'roswell'
 pkgname=roswell
-version=18.10.10.95
+version=19.4.10.98
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake"
@@ -11,7 +11,7 @@ license="MIT"
 homepage="https://github.com/roswell/roswell"
 changelog="https://raw.githubusercontent.com/roswell/roswell/master/ChangeLog"
 distfiles="https://github.com/roswell/roswell/releases/download/v${version}/roswell_${version}.orig.tar.gz"
-checksum=9ad88ae0aed94feda679527f6ceb2732c39fd645921e91c048442be9874fff67
+checksum=5783431ef096840dd5696b448c76e66e8805e53bd7ac6fb572734e3ffd969649
 
 pre_configure() {
 	./bootstrap


### PR DESCRIPTION
This also fixes roswell/roswell#355, among other things.