### PR TITLE
Vulkan-ValidationLayers: update to 1.1.106

### DIFF
--- a/srcpkgs/Vulkan-ValidationLayers/template
+++ b/srcpkgs/Vulkan-ValidationLayers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-ValidationLayers'
 pkgname=Vulkan-ValidationLayers
-version=1.1.102
+version=1.1.106
 revision=1
 build_style=cmake
 configure_args="-DGLSLANG_INSTALL_DIR=/usr
@@ -13,4 +13,4 @@ maintainer="Colin Gillespie <colin@breavyn.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=27c3e4b16064f4125149a4932b8e348b3b5870d5a565c8c4a08c4ddc04684f56
+checksum=e095e7c23fe52098e966c056d3e9684d6b915f129d736556bc5a33e9574bd735


### PR DESCRIPTION
I tried to update it to 1.1.107 but it doesn't compile with the latest release of SPIRV-Tools.

Both vulkan-loader and Vulkan-Headers  build fine for version 1.1.107 but I don't know if it is okay to push only those to 1.1.107. If anyone has anything to say about this feel free to.