### PR TITLE
alsa stack: update to 1.1.9

### DIFF
--- a/srcpkgs/alsa-lib/template
+++ b/srcpkgs/alsa-lib/template
@@ -1,6 +1,6 @@
 # Template file for 'alsa-lib'
 pkgname=alsa-lib
-version=1.1.8
+version=1.1.9
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -9,7 +9,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://www.alsa-project.org"
 distfiles="ftp://ftp.alsa-project.org/pub/lib/${pkgname}-${version}.tar.bz2"
-checksum=3cdc3a93a6427a26d8efab4ada2152e64dd89140d981f6ffa003e85be707aedf
+checksum=488373aef5396682f3a411a6d064ae0ad196b9c96269d0bb912fbdeec94b994b
 
 alsa-lib-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/alsa-plugins/template
+++ b/srcpkgs/alsa-plugins/template
@@ -1,6 +1,6 @@
 # Template file for 'alsa-plugins'
 pkgname=alsa-plugins
-version=1.1.8
+version=1.1.9
 revision=1
 build_style=gnu-configure
 configure_args="--disable-maemo-plugin"
@@ -11,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.alsa-project.org"
 distfiles="ftp://ftp.alsa-project.org/pub/plugins/${pkgname}-${version}.tar.bz2"
-checksum=7f77df171685ccec918268477623a39db4d9f32d5dc5e76874ef2467a2405994
+checksum=161772303da521abbbf1d91f63b470c4791392d5728f2192a42d71292078f907
 
 post_install() {
 	rm -rfv ${DESTDIR}/etc/alsa/conf.d

--- a/srcpkgs/alsa-utils/template
+++ b/srcpkgs/alsa-utils/template
@@ -1,6 +1,6 @@
 # Template file for 'alsa-utils'
 pkgname=alsa-utils
-version=1.1.8
+version=1.1.9
 revision=1
 build_style=gnu-configure
 configure_args="--with-udev-rules-dir=/usr/lib/udev/rules.d --disable-alsaconf
@@ -14,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://www.alsa-project.org"
 distfiles="ftp://ftp.alsa-project.org/pub/utils/${pkgname}-${version}.tar.bz2"
-checksum=fd9bf528922b3829a91913b89a1858c58a0b24271a7b5f529923aa9ea12fa4cf
+checksum=5ddf2cbddb4bd1a4a2a6492a09c25898b08c3ad64893c3655be14194cf0a213a
 
 post_install() {
 	# Install required udev rules file.


### PR DESCRIPTION
Dist files don't like Travis for some reason. I was able to build x86_64 and a couple arms on both glibc/musl. I can only *really* test on glibc/x86_64, but it seems to be working fine.