### PR TITLE
keepassxc: restore build options and change maintainer

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -3,22 +3,41 @@ pkgname=keepassxc
 version=2.4.1
 revision=2
 build_style=cmake
-configure_args="-DWITH_TESTS=OFF -DWITH_XC_ALL=ON -DWITH_XC_KEESHARE_SECURE=ON"
-makedepends="qt5-tools-devel qt5-svg-devel libgcrypt-devel libargon2-devel qrencode-devel
- qt5-x11extras-devel libXtst-devel libykpers-devel libyubikey-devel libsodium-devel quazip-devel"
+configure_args="-DWITH_TESTS=OFF -DWITH_XC_UPDATECHECK=OFF
+ -DWITH_XC_AUTOTYPE=$(vopt_if autotype ON OFF)
+ -DWITH_XC_BROWSER=$(vopt_if browser ON OFF)
+ -DWITH_XC_KEESHARE_SECURE=$(vopt_if keeshare ON OFF)
+ -DWITH_XC_NETWORKING=$(vopt_if network ON OFF)
+ -DWITH_XC_SSHAGENT=$(vopt_if sshagent ON OFF)
+ -DWITH_XC_YUBIKEY=$(vopt_if yubikey ON OFF)"
+hostmakedepends="qt5-qmake qt5-host-tools"
+makedepends="qt5-tools-devel qt5-svg-devel libgcrypt-devel libargon2-devel
+ qrencode-devel
+ $(vopt_if autotype 'qt5-x11extras-devel libXtst-devel libXi-devel')
+ $(vopt_if browser libsodium-devel)
+ $(vopt_if keeshare quazip-devel)
+ $(vopt_if network libcurl-devel)
+ $(vopt_if yubikey 'libykpers-devel libyubikey-devel')"
 short_desc="KeePassXC is a cross-platform port of “Keepass Password Safe”"
-maintainer="ibrokemypie <ibrokemypie@bastardi.net>"
+maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,
  LGPL-3.0-or-later, Nokia-Qt-exception-1.1, MIT BSL-1.0"
 homepage="https://keepassxc.org/"
 distfiles="https://github.com/keepassxreboot/keepassxc/releases/download/${version}/keepassxc-${version}-src.tar.xz"
 checksum=0da97bd1279d1b9b06a63b9f723b43ab8c078b7f1203d6c13504fdd4735489ab
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-qmake qt5-host-tools"
-fi
+# https://github.com/keepassxreboot/keepassxc/blob/7bafe65d17e98348b0ff5fb46f117bdf05764cc6/CMakeLists.txt#L45
+build_options="browser keeshare network sshagent yubikey"
+desc_option_autotype="Include auto-type"
+desc_option_browser="Include browser integration with keepassxc-browser-plugin"
+desc_option_keeshare="Include sharing integration with KeeShare"
+desc_option_network="Include networking code (favicon download)"
+desc_option_sshagent="Include SSH agent support"
+desc_option_yubikey="Include YubiKey support"
+build_options_default="autotype browser keeshare sshagent yubikey"
 
 post_install() {
+	vlicense COPYING
 	vlicense LICENSE.BSD
 	vlicense LICENSE.MIT
 }


### PR DESCRIPTION
For reasons unclear to me, #10669 removed all build options.

Unfortunately, the old repository is gone now with all its issues and pullrequests, else i would have referenced an issue where discussion was held about which buildoptions should be default and that there is legitimate interest in being able to opt-out of certain features, given the security impact of this application.

@gspe 
@lemmi 