### PR TITLE
i2pd: update to 2.25.0.

### DIFF
--- a/srcpkgs/i2pd/files/i2pd/run
+++ b/srcpkgs/i2pd/files/i2pd/run
@@ -1,2 +1,4 @@
 #!/bin/sh
-exec chpst -u _i2pd:_i2pd i2pd --service 2>&1
+exec chpst -u _i2pd:_i2pd i2pd --service \
+	--conf=/etc/i2pd/i2pd.conf \
+	--tunconf=/etc/i2pd/tunnels.conf 2>&1

--- a/srcpkgs/i2pd/template
+++ b/srcpkgs/i2pd/template
@@ -1,35 +1,48 @@
 # Template file for 'i2pd'
 pkgname=i2pd
-version=2.24.0
+version=2.25.0
 revision=1
 build_style=gnu-makefile
 make_build_args="USE_UPNP=yes"
 makedepends="zlib-devel boost-devel libressl-devel miniupnpc-devel
  libatomic-devel"
-short_desc="I2P Daemon - a full-featured C++ implementation of I2P client"
+short_desc="Full-featured C++ implementation of I2P client"
 maintainer="Obosob <obosob@riseup.net>"
 license="BSD-3-Clause"
-homepage="http://i2pd.website/"
+homepage="https://i2pd.website/"
+changelog="https://raw.githubusercontent.com/PurpleI2P/i2pd/openssl/ChangeLog"
 distfiles="https://github.com/PurpleI2P/i2pd/archive/${version}.tar.gz"
-checksum=809b37100f0f176432b01ab6edee96dc62b0f65d5bf7531e008a87117e742566
-system_accounts="_i2pd"
+checksum=80486b51abbf082ca427c95a298f037a28504eb3c6c788a700273de34ae1bd6b
 disable_parallel_build=true
 
-make_dirs="/var/lib/i2pd 0755 _i2pd _i2pd"
+conf_files="
+ /etc/i2pd/i2pd.conf
+ /etc/i2pd/tunnels.conf"
+system_accounts="_i2pd"
+_i2pd_homedir="/var/lib/i2pd"
+make_dirs="/var/lib/i2pd 0700 _i2pd _i2pd"
 
 case "${XBPS_TARGET_MACHINE}" in
 	aarch64*|armv*|mips*) make_build_args+=" USE_AESNI=no USE_AVX=no" ;;
 esac
 
+pre_install() {
+	# Log errors to syslog
+	vsed -e "s/^# log = .*/log = syslog/" \
+		-e "s/^# loglevel = .*/loglevel = error/" \
+		-i contrib/i2pd.conf
+}
+
 do_install() {
 	vbin i2pd
 	vman debian/i2pd.1
-	vsconf contrib/i2pd.conf
-	vsconf contrib/tunnels.conf
-	vsconf contrib/subscriptions.txt
+	vinstall contrib/i2pd.conf 644 etc/i2pd
+	vinstall contrib/tunnels.conf 644 etc/i2pd
 	vlicense LICENSE
-}
-
-post_install() {
 	vsv i2pd
+	# Family, reseed and router certificates
+	vmkdir usr/share/i2pd
+	vcopy contrib/certificates usr/share/i2pd
+	vmkdir var/lib/i2pd
+	ln -s /usr/share/i2pd/certificates ${DESTDIR}/var/lib/i2pd/certificates
 }


### PR DESCRIPTION
* updated and tested (x86_64)
* stripped out non-descriptive part in short_desc
* https in homepage
* added changelog
* added `conf_files` and `_i2pd_homedir`
* restrict permissions in `/var/lib/i2pd` to `0700` (sensitive keymaterial)
* install bundled certs, mostly needed for reseeding