### PR TITLE
libtorrent-rasterbar: update to 1.1.13.

### DIFF
--- a/srcpkgs/libtorrent-rasterbar-examples
+++ b/srcpkgs/libtorrent-rasterbar-examples
@@ -1,0 +1,1 @@
+libtorrent-rasterbar

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,17 +1,17 @@
 # Template file for 'libtorrent-rasterbar'
 pkgname=libtorrent-rasterbar
-version=1.1.12
+version=1.1.13
 revision=1
 build_style=gnu-configure
-configure_args="--enable-python-binding --with-boost=${XBPS_CROSS_BASE}/usr"
+configure_args="--enable-examples --enable-python-binding --with-boost=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="automake pkg-config intltool libtool python-devel"
 makedepends="libressl-devel boost-devel geoip-devel python-devel"
 short_desc="C++ bittorrent library by Rasterbar Software"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
-distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent_${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
-checksum=a5937134edf3ca8c109403a47f5a5fc93f7b8dca4e97f1a629a8c84288bee7a7
+distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
+checksum=30040719858e3c06634764e0c1778738eb42ecd0b45e814afa746329a948ead7
 
 pre_configure() {
 	export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python2.7"
@@ -40,5 +40,12 @@ libtorrent-rasterbar-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.a"
+	}
+}
+
+libtorrent-rasterbar-examples_package() {
+	short_desc+=" - example binaries"
+	pkg_install() {
+		vmove usr/bin
 	}
 }


### PR DESCRIPTION
* updated and tested (x86_64)
* added `-examples` subpackage with some useful example binaries (I actually use them)