### PR TITLE
vsed: reduce number of digest call

### DIFF
--- a/common/environment/setup/vsed.sh
+++ b/common/environment/setup/vsed.sh
@@ -46,16 +46,16 @@ vsed() {
 
 	for rx in "${regexes[@]}"; do
 		for f in "${files[@]}"; do
-			shasums="$($XBPS_DIGEST_CMD "$f")"
+			olddigest="$($XBPS_DIGEST_CMD "$f")"
 
 			sed -i "$f" -e "$rx" || {
 				msg_red "$pkgver: vsed: sed call failed with regex \"$rx\" on file \"$f\"\n"
 				return 1
 			}
 
-			sha256sum="$($XBPS_DIGEST_CMD "$f")"
+			newdigest="$($XBPS_DIGEST_CMD "$f")"
 
-			if [ "$shasums" = "${sha256sum%% *}" ]; then
+			if [ "$olddigest" = "${newdigest%% *}" ]; then
 				msg_warn "$pkgver: vsed: regex \"$rx\" didn't change file \"$f\"\n"
 			fi
 		done

--- a/common/environment/setup/vsed.sh
+++ b/common/environment/setup/vsed.sh
@@ -47,6 +47,7 @@ vsed() {
 	for rx in "${regexes[@]}"; do
 		for f in "${files[@]}"; do
 			olddigest="$($XBPS_DIGEST_CMD "$f")"
+			olddigest="${olddigest%% *}"
 
 			sed -i "$f" -e "$rx" || {
 				msg_red "$pkgver: vsed: sed call failed with regex \"$rx\" on file \"$f\"\n"
@@ -54,8 +55,9 @@ vsed() {
 			}
 
 			newdigest="$($XBPS_DIGEST_CMD "$f")"
+			newdigest="${newdigest%% *}"
 
-			if [ "$olddigest" = "${newdigest%% *}" ]; then
+			if [ "$olddigest" = "$newdigest" ]; then
 				msg_warn "$pkgver: vsed: regex \"$rx\" didn't change file \"$f\"\n"
 			fi
 		done

--- a/common/environment/setup/vsed.sh
+++ b/common/environment/setup/vsed.sh
@@ -44,11 +44,11 @@ vsed() {
 		return 1
 	fi
 
-	for rx in "${regexes[@]}"; do
-		for f in "${files[@]}"; do
-			olddigest="$($XBPS_DIGEST_CMD "$f")"
-			olddigest="${olddigest%% *}"
+	for f in "${files[@]}"; do
+		olddigest="$($XBPS_DIGEST_CMD "$f")"
+		olddigest="${olddigest%% *}"
 
+		for rx in "${regexes[@]}"; do
 			sed -i "$f" -e "$rx" || {
 				msg_red "$pkgver: vsed: sed call failed with regex \"$rx\" on file \"$f\"\n"
 				return 1
@@ -60,6 +60,7 @@ vsed() {
 			if [ "$olddigest" = "$newdigest" ]; then
 				msg_warn "$pkgver: vsed: regex \"$rx\" didn't change file \"$f\"\n"
 			fi
+			olddigest="${newdigest}"
 		done
 	done
 }


### PR DESCRIPTION
This series try to reduce number of call to `XBPS_DIGEST_CMD` from:
`2 * nf * nr` to `nf * (nr +1)`
with:
- `nf` is number of files passed to `vsed`; and
- `nr` is number of regex passed to `vsed`