### PR TITLE
mariadb: Improve atomic detection

### DIFF
--- a/srcpkgs/mariadb/patches/c11_atomics.patch
+++ b/srcpkgs/mariadb/patches/c11_atomics.patch
@@ -1,0 +1,128 @@
+From: Debian MySQL Maintainers <pkg-mysql-maint@lists.alioth.debian.org>
+Date: Thu, 10 Aug 2017 20:40:29 +0200
+Subject: c11_atomics
+
+---
+ configure.cmake               | 23 +++++++++++++++++++++--
+ include/atomic/gcc_builtins.h | 15 +++++++++++++++
+ include/atomic/nolock.h       |  4 ++--
+ mysys/CMakeLists.txt          |  4 ++++
+ sql/CMakeLists.txt            |  4 ++++
+ 5 files changed, 46 insertions(+), 4 deletions(-)
+
+--- ./configure.cmake
++++ ./configure.cmake
+@@ -128,7 +128,7 @@ IF(UNIX)
+   ENDIF()
+   FIND_PACKAGE(Threads)
+ 
+-  SET(CMAKE_REQUIRED_LIBRARIES 
++  LIST(APPEND CMAKE_REQUIRED_LIBRARIES
+     ${LIBM} ${LIBNSL} ${LIBBIND} ${LIBCRYPT} ${LIBSOCKET} ${LIBDL} ${CMAKE_THREAD_LIBS_INIT} ${LIBRT} ${LIBEXECINFO})
+   # Need explicit pthread for gcc -fsanitize=address
+   IF(CMAKE_USE_PTHREADS_INIT AND CMAKE_C_FLAGS MATCHES "-fsanitize=")
+@@ -1038,7 +1038,26 @@ ELSEIF(NOT WITH_ATOMIC_OPS)
+     long long int *ptr= &var;
+     return (int)__atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+   }"
+-  HAVE_GCC_C11_ATOMICS)
++  HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC)
++  IF(HAVE_GCC_C11_ATOMICS_WITHOUT_LIBATOMIC)
++    SET(HAVE_GCC_C11_ATOMICS True)
++  ELSE()
++    SET(OLD_CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
++    LIST(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
++    CHECK_CXX_SOURCE_COMPILES("
++    int main()
++    {
++      long long int var= 1;
++      long long int *ptr= &var;
++      return (int)__atomic_load_n(ptr, __ATOMIC_SEQ_CST);
++    }"
++    HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
++    IF(HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
++      SET(HAVE_GCC_C11_ATOMICS True)
++    ELSE()
++      SET(CMAKE_REQUIRED_LIBRARIES ${OLD_CMAKE_REQUIRED_LIBRARIES})
++    ENDIF()
++  ENDIF()
+ ELSE()
+   MESSAGE(FATAL_ERROR "${WITH_ATOMIC_OPS} is not a valid value for WITH_ATOMIC_OPS!")
+ ENDIF()
+--- ./include/atomic/gcc_builtins.h
++++ ./include/atomic/gcc_builtins.h
+@@ -16,6 +16,7 @@
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+ 
++#if defined (HAVE_GCC_ATOMIC_BUILTINS)
+ #define make_atomic_add_body(S)                     \
+   v= __sync_fetch_and_add(a, v);
+ #define make_atomic_fas_body(S)                     \
+@@ -26,6 +27,20 @@
+   sav= __sync_val_compare_and_swap(a, cmp_val, set);\
+   if (!(ret= (sav == cmp_val))) *cmp= sav
+ 
++#elif defined(HAVE_GCC_C11_ATOMICS)
++
++#define make_atomic_add_body(S)                     \
++  v= __atomic_fetch_add(a, v, __ATOMIC_SEQ_CST)
++#define make_atomic_fas_body(S)                     \
++  v= __atomic_exchange_n(a, v, __ATOMIC_SEQ_CST)
++#define make_atomic_cas_body(S)                     \
++  int ## S sav;                                     \
++  ret= __atomic_compare_exchange_n(a, cmp, set,     \
++                                   0,               \
++                                   __ATOMIC_SEQ_CST,\
++                                   __ATOMIC_SEQ_CST);
++#endif
++
+ #ifdef MY_ATOMIC_MODE_DUMMY
+ #define make_atomic_load_body(S)   ret= *a
+ #define make_atomic_store_body(S)  *a= v
+--- ./include/atomic/nolock.h
++++ ./include/atomic/nolock.h
+@@ -17,7 +17,7 @@
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+ 
+ #if defined(__i386__) || defined(_MSC_VER) || defined(__x86_64__)   \
+-    || defined(HAVE_GCC_ATOMIC_BUILTINS) \
++    || defined(HAVE_GCC_ATOMIC_BUILTINS) || defined(HAVE_GCC_C11_ATOMICS) \
+     || defined(HAVE_SOLARIS_ATOMIC)
+ 
+ #  ifdef MY_ATOMIC_MODE_DUMMY
+@@ -41,7 +41,7 @@
+ #  elif __GNUC__
+ #    if defined(HAVE_SOLARIS_ATOMIC)
+ #      include "solaris.h"
+-#    elif defined(HAVE_GCC_ATOMIC_BUILTINS)
++#    elif defined(HAVE_GCC_ATOMIC_BUILTINS) || defined(HAVE_GCC_C11_ATOMICS)
+ #      include "gcc_builtins.h"
+ #    elif defined(__i386__) || defined(__x86_64__)
+ #      include "x86-gcc.h"
+--- ./mysys/CMakeLists.txt
++++ ./mysys/CMakeLists.txt
+@@ -79,6 +79,10 @@ IF(HAVE_BFD_H)
+   TARGET_LINK_LIBRARIES(mysys bfd)  
+ ENDIF(HAVE_BFD_H)
+ 
++IF(HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
++  TARGET_LINK_LIBRARIES(mysys atomic)
++ENDIF()
++
+ IF (WIN32)
+   TARGET_LINK_LIBRARIES(mysys IPHLPAPI)  
+ ENDIF(WIN32)
+--- ./sql/CMakeLists.txt
++++ ./sql/CMakeLists.txt
+@@ -165,6 +165,10 @@ TARGET_LINK_LIBRARIES(sql ${MYSQLD_STATI
+   ${SSL_LIBRARIES}
+   ${LIBSYSTEMD})
+ 
++IF(HAVE_GCC_C11_ATOMICS_WITH_LIBATOMIC)
++  TARGET_LINK_LIBRARIES(sql atomic)
++ENDIF()
++
+ IF(WIN32)
+   SET(MYSQLD_SOURCE main.cc nt_servc.cc message.rc)
+   TARGET_LINK_LIBRARIES(sql psapi)

--- a/srcpkgs/mariadb/template
+++ b/srcpkgs/mariadb/template
@@ -1,7 +1,7 @@
 # Template file for 'mariadb'
 pkgname=mariadb
 version=10.1.30
-revision=5
+revision=6
 build_style=cmake
 configure_args="-DMYSQL_DATADIR=/var/lib/mysql
  -DMYSQL_UNIX_ADDR=/run/mysqld/mysqld.sock -DDEFAULT_CHARSET=utf8
@@ -36,7 +36,7 @@ disable_parallel_build=yes
 CFLAGS="-w"
 
 case "$XBPS_TARGET_MACHINE" in
-	armv[56]*) LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -latomic"
+	armv[56]*|ppc|ppc-musl) LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -latomic"
 		hostmakedepends+=" libatomic-devel"
 		makedepends+=" libatomic-devel"
 		;;
@@ -44,7 +44,7 @@ esac
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in
-		armv[56]*) find -name CMakeLists.txt -exec sed -i "{}" \
+		armv[56]*|ppc|ppc-musl) find -name CMakeLists.txt -exec sed -i "{}" \
 				-e "/TARGET_LINK_LIBRARIES/s;); atomic);" \;
 			;;
 	esac


### PR DESCRIPTION
Fixes building on 32 bit ppc. Patch is adapted from the Debian package. Still fails on ppc-musl. Error:
```
[ 26%] Building CXX object storage/xtradb/CMakeFiles/xtradb.dir/api/api0api.cc.o
In file included from /builddir/mariadb-10.1.30/storage/xtradb/include/univ.i:641,
                 from /builddir/mariadb-10.1.30/storage/xtradb/api/api0api.cc:27:
/builddir/mariadb-10.1.30/storage/xtradb/include/ut0ut.h:89:10: fatal error: sys/platform/ppc.h: No such file or directory
 #include <sys/platform/ppc.h>
          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [storage/xtradb/CMakeFiles/xtradb.dir/build.make:63: storage/xtradb/CMakeFiles/xtradb.dir/api/api0api.cc.o] Error 1
```
I'd rather get that fixed before merging though.
[skip ci]