### PR TITLE
teeworlds: enable for all archs

### DIFF
--- a/srcpkgs/teeworlds/patches/portability.patch
+++ b/srcpkgs/teeworlds/patches/portability.patch
@@ -1,0 +1,23 @@
+From: Markus Koschany <apo@debian.org>
+Date: Sat, 27 Oct 2018 00:04:46 +0200
+Subject: portability
+
+Hopefully this prevents FTBFS on non-supported architectures.
+---
+ bam.lua | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/bam.lua b/bam.lua
+index f511fac..b23d501 100644
+--- bam.lua
++++ bam.lua
+@@ -191,9 +191,6 @@ function GenerateLinuxSettings(settings, conf, arch, compiler)
+ 		settings.link.flags:Add("-m64")
+ 	elseif arch == "armv7l" then
+ 		-- arm 32 bit
+-	else
+-		print("Unknown Architecture '" .. arch .. "'. Supported: x86, x86_64")
+-		os.exit(1)
+ 	end
+ 	settings.link.libs:Add("pthread")
+ 

--- a/srcpkgs/teeworlds/patches/zlib-cross.patch
+++ b/srcpkgs/teeworlds/patches/zlib-cross.patch
@@ -1,0 +1,32 @@
+Bam doesn't respect cflags when searching for libs/includes like this, so
+just assume we have zlib for the target (which we do) and link it. Other
+libs use pkg-config, so there is no problem for those.
+--- bam.lua
++++ bam.lua
+@@ -10,7 +10,6 @@ config:Add(OptCCompiler("compiler"))
+ config:Add(OptTestCompileC("stackprotector", "int main(){return 0;}", "-fstack-protector -fstack-protector-all"))
+ config:Add(OptTestCompileC("minmacosxsdk", "int main(){return 0;}", "-mmacosx-version-min=10.7 -isysroot /Developer/SDKs/MacOSX10.7.sdk"))
+ config:Add(OptTestCompileC("buildwithoutsseflag", "#include <immintrin.h>\nint main(){_mm_pause();return 0;}", ""))
+-config:Add(OptLibrary("zlib", "zlib.h", false))
+ config:Add(SDL.OptFind("sdl", true))
+ config:Add(FreeType.OptFind("freetype", true))
+ config:Finalize("config.lua")
+@@ -82,17 +81,8 @@ function GenerateCommonSettings(settings, conf, arch, compiler)
+ 		settings.cc.flags:Add("-Wall", "-fno-exceptions")
+ 	end
+ 
+-	-- Compile zlib if needed
+ 	local zlib = nil
+-	if config.zlib.value == 1 then
+-		settings.link.libs:Add("z")
+-		if config.zlib.include_path then
+-			settings.cc.includes:Add(config.zlib.include_path)
+-		end
+-	else
+-		settings.cc.includes:Add("src/engine/external/zlib")
+-		zlib = Compile(settings, Collect("src/engine/external/zlib/*.c"))
+-	end
++	settings.link.libs:Add("z")
+ 
+ 	local md5 = Compile(settings, Collect("src/engine/external/md5/*.c"))
+ 	local wavpack = Compile(settings, Collect("src/engine/external/wavpack/*.c"))

--- a/srcpkgs/teeworlds/template
+++ b/srcpkgs/teeworlds/template
@@ -1,8 +1,8 @@
 # Template file for 'teeworlds'
 pkgname=teeworlds
 version=0.7.3.1
-revision=1
-hostmakedepends="bam python"
+revision=2
+hostmakedepends="bam python pkg-config"
 makedepends="zlib-devel SDL2-devel glu-devel freetype-devel"
 short_desc="Retro multiplayer shooter"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -10,11 +10,16 @@ license="custom"
 homepage="https://www.teeworlds.com"
 distfiles="https://github.com/teeworlds/teeworlds/archive/${version}.tar.gz"
 checksum=62da301f20dfc20e2e480223dc1fc4ea5f9bfbfa6bc304c4c7732071a319ffd4
-nocross="Only supports i686 and x86_64"
 
-case "$XBPS_MACHINE" in
+case "$XBPS_TARGET_MACHINE" in
 	i686) _ARCH=x86;;
 	x86_64*) _ARCH=x86_64;;
+	ppc64*) _ARCH=ppc64;;
+	ppc*) _ARCH=ppc;;
+	armv7l*) _ARCH=armv7l;;
+	arm*) _ARCH=arm;;
+	aarch64*) _ARCH=aarch64;;
+	*) _ARCH=${XBPS_TARGET_MACHINE%%-musl};;
 esac
 
 do_configure() {


### PR DESCRIPTION
Tested and working perfectly fine on my `ppc64le`. Tested cross-compiling to `aarch64`.