### PR TITLE
youtube-dl: update to 2019.05.11.

### DIFF
--- a/srcpkgs/youtube-dl/template
+++ b/srcpkgs/youtube-dl/template
@@ -1,6 +1,6 @@
 # Template file for 'youtube-dl'
 pkgname=youtube-dl
-version=2019.04.30
+version=2019.05.11
 revision=1
 archs=noarch
 wrksrc="$pkgname"
@@ -10,11 +10,11 @@ hostmakedepends="python python3"
 depends="python"
 short_desc="CLI program to download videos from YouTube and other sites (Python2)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="Public Domain"
+license="Unlicense"
 homepage="https://rg3.github.io/youtube-dl/"
 changelog="https://raw.githubusercontent.com/rg3/youtube-dl/master/ChangeLog"
 distfiles="https://yt-dl.org/downloads/${version}/${pkgname}-${version}.tar.gz"
-checksum=e18f4291bd52e44f8587d28c3d0423edf95ab3f138d657b9845e213f6d5383e8
+checksum=4126221a6567c1c78dfa9d9abbf340bc5eb13e40963afca5150e72dc9e1447f8
 alternatives="youtube-dl:youtube-dl:/usr/bin/youtube-dl2"
 
 post_install() {


### PR DESCRIPTION
updated and fixed `license 'Public Domain' is not SPDX`