### PR TITLE
New packages: intellij-idea-ultimate-edition-2019.3.2

### DIFF
--- a/srcpkgs/intellij-idea-ultimate-edition/INSTALL.msg
+++ b/srcpkgs/intellij-idea-ultimate-edition/INSTALL.msg
@@ -1,0 +1,2 @@
+IntelliJ Ultimate has the following optional dependencies:
+	libdbusmenu-glib: For global menu support

--- a/srcpkgs/intellij-idea-ultimate-edition/template
+++ b/srcpkgs/intellij-idea-ultimate-edition/template
@@ -1,0 +1,71 @@
+# Template file for 'intellij-idea-ultimate-edition'
+pkgname=intellij-idea-ultimate-edition
+version=2019.3.2
+revision=1
+archs="i686 x86_64"
+wrksrc="idea-IU-193.6015.39"
+depends="giflib libXtst jetbrains-jdk-bin"
+short_desc="Most intelligent Java IDE"
+maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
+license="custom:Commercial"
+homepage="https://www.jetbrains.com/idea"
+distfiles="https://download.jetbrains.com/idea/ideaIU-${version}-no-jbr.tar.gz"
+checksum=1f0607e1425a492fe5569421ae684092267d78828a1f26b3e224f5f94e6b8f26
+repository=nonfree
+restricted=yes
+nopie=yes
+# JetBrains' tools are self-sufficient and while they include code that appears to be linked to libs from other packages, these libs are either included in the tool package, or the code works by looking for one of several supported libs.
+noverifyrdeps=yes
+
+post_extract() {
+	# Remove files for other OSes
+	rm -rf plugins/android/lib/libwebp/win
+	rm -rf plugins/android/lib/libwebp/mac
+	rm -rf plugins/maven/lib/maven3/lib/jansi-native/freebsd64
+	rm -rf plugins/maven/lib/maven3/lib/jansi-native/freebsd32
+
+	# Remove files for other CPU architectures
+	rm -rf bin/fsnotifier-arm
+	rm -rf lib/pty4j-native/linux/ppc64le
+
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64)
+			rm -rf bin/fsnotifier
+			rm -rf bin/idea.vmoptions
+			rm -rf bin/libyjpagent-linux.so
+			rm -rf plugins/android/lib/libwebp/linux/libwebp_jni.so
+			rm -rf lib/pty4j-native/linux/x86
+			;;
+		i686)
+			rm -rf bin/fsnotifier64
+			rm -rf bin/idea64.vmoptions
+			rm -rf bin/libyjpagent-linux64.so
+			rm -rf plugins/android/lib/libwebp/linux/libwebp_jni64.so
+			rm -rf lib/pty4j-native/linux/x86_64
+			;;
+	esac
+}
+
+do_install() {
+	TARGET_PATH="usr/lib/${pkgname}"
+	LICENSE_PATH="usr/share/licenses/${pkgname}"
+
+	vmkdir usr/bin
+	vmkdir ${TARGET_PATH}
+	vmkdir ${LICENSE_PATH}
+
+	# Ideally vlicense should be called here, but vcopy is more terse.
+	vcopy license/* ${LICENSE_PATH}
+
+	mkdir -p /usr/lib/jvm/jbrsdk
+	ln -sf /usr/lib/jvm/jbrsdk ${DESTDIR}/${TARGET_PATH}/jbr
+	vcopy bin ${TARGET_PATH}
+	vcopy help ${TARGET_PATH}
+	vcopy lib ${TARGET_PATH}
+	vcopy plugins ${TARGET_PATH}
+	vcopy redist ${TARGET_PATH}
+	vcopy product-info.json ${TARGET_PATH}
+	vcopy build.txt ${TARGET_PATH}
+
+	ln -sf /${TARGET_PATH}/bin/idea.sh ${DESTDIR}/usr/bin/idea-ultimate
+}

--- a/srcpkgs/intellij-idea-ultimate-edition/update
+++ b/srcpkgs/intellij-idea-ultimate-edition/update
@@ -1,0 +1,2 @@
+pattern="ideaIU-\K[\d.]+(?=-no-jbr\.tar)"
+site="https://data.services.jetbrains.com/products/releases?code=IIU%2CIIC&latest=true&type=release"


### PR DESCRIPTION
This based on the existing `intellij-idea-community-edition`.

I'm explicitly removing the JetBrains JDK and requiring JetBrains' custom JDK instead.