### PR TITLE
deadbeef: fix checksum, clean up template

### DIFF
--- a/srcpkgs/deadbeef/template
+++ b/srcpkgs/deadbeef/template
@@ -3,16 +3,13 @@ pkgname=deadbeef
 version=1.8.0
 revision=1
 build_style=gnu-configure
-configure_args="--disable-static --disable-oss
- $(vopt_if gtk3 '--enable-gtk3 --disable-gtk2' '--enable-gtk2 --disable-gtk3')"
-hostmakedepends="automake gettext-devel intltool libtool pkg-config sndio yasm
- $(vopt_if gtk3 glib-devel)"
+configure_args="--disable-oss $(vopt_if gtk3 --disable-gtk2 --disable-gtk3)"
+hostmakedepends="intltool pkg-config yasm $(vopt_if gtk3 glib-devel)"
 makedepends="
- libSM-devel alsa-lib-devel ffmpeg-devel libvorbis-devel libcurl-devel
- libjpeg-turbo-devel libpng-devel libmad-devel libflac-devel wavpack-devel
- libsndfile-devel libcdio-devel libcddb-devel dbus-devel glu-devel
- pulseaudio-devel faad2-devel libsamplerate-devel imlib2-devel jansson-devel
- mpg123-devel libzip-devel opusfile-devel sndio-devel
+ alsa-lib-devel dbus-devel faad2-devel ffmpeg-devel imlib2-devel jansson-devel
+ libcddb-devel libcdio-devel libcurl-devel libflac-devel libmad-devel
+ libpng-devel libsamplerate-devel libsndfile-devel libvorbis-devel libzip-devel
+ mpg123-devel opusfile-devel pulseaudio-devel sndio-devel wavpack-devel
  $(vopt_if gtk3 gtk+3-devel gtk+-devel)"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Ultimate Music Player for GNU/Linux"
@@ -20,7 +17,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="Zlib, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://deadbeef.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=8559e53e95bd85172d96bf9a8e7079dc36c16390110470ee1ea7b5d01c431608
+checksum=5b2d12f9a72c8bc21f88ae1acf9b1b6923a91977b9c06512f9fd424b6e318b96
 build_options="gtk3"
 build_options_default="gtk3"
 


### PR DESCRIPTION
- only file times had changed in the source tarball (2019-04-07)
- removed some unused build dependencies found using [this hook](https://gist.github.com/huglovefan/e87744efac57bab2496ed0d934bd5e8a)
- i checked and it produces the exact same package on x86_64-musl