### PR TITLE
nfs-utils: unbreak cross and disable static libs.

### DIFF
--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,13 +1,13 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
 version=2.3.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
  --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-svcgss
  --enable-uuid --enable-ipv6 --without-tcp-wrappers
  --with-tirpcinclude=$XBPS_CROSS_BASE/usr/include/tirpc
- --with-krb5=$XBPS_CROSS_BASE"
+ --with-krb5=$XBPS_CROSS_BASE --disable-static"
 short_desc="Network File System utilities"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -17,10 +17,10 @@ checksum=f68b34793831b05f1fd5760d6bdec92772c7684177586a99a61e7b444f336322
 patch_args="-Np1"
 replaces="rpcgen>=0"
 
-hostmakedepends="pkg-config libtirpc-devel"
+hostmakedepends="pkg-config libtirpc-devel rpcsvc-proto"
 makedepends="libblkid-devel libmount-devel libtirpc-devel
  libnfsidmap-devel keyutils-devel libevent-devel mit-krb5-devel
- device-mapper-devel libcap-devel sqlite-devel rpcsvc-proto"
+ device-mapper-devel libcap-devel sqlite-devel"
 depends="rpcbind"
 conf_files="/etc/exports /etc/idmapd.conf"
 make_dirs="
@@ -31,9 +31,10 @@ make_dirs="
 "
 
 pre_configure() {
+	vsed -i '/SUBDIRS =/s/locktest//' tools/Makefile.in
 	case "$XBPS_TARGET_MACHINE" in
 	*-musl)
-		sed -Ei -e 's/__res_querydomain/res_querydomain/g' configure*
+		vsed -i -e 's/__res_querydomain/res_querydomain/g' configure*
 	esac
 }
 


### PR DESCRIPTION
- unbreak cross by using rpcscv-proto from host and disabling tools/locktest.
- disable static libs because it's not expected that something links against it.