### PR TITLE
[DO NOT PACKAGE] New package: ulauncher

### DIFF
--- a/srcpkgs/ulauncher/template
+++ b/srcpkgs/ulauncher/template
@@ -1,0 +1,16 @@
+# Template file for 'ulauncher'
+pkgname=ulauncher
+version=5.2.0.r0
+revision=1
+wrksrc=${pkgname}
+build_style=python3-module
+pycompile_module="ulauncher"
+hostmakedepends="python3-distutils-extra intltool"
+depends="libappindicator>=12.10.0_2 libkeybinder3 python3-Levenshtein python3-dbus
+ python3-inotify python3-websocket-client python3-xdg webkit2gtk"
+short_desc="Linux application launcher with fuzzy search and extensions"
+maintainer="Alberto Pau <me@albertopau.com>"
+license="GPL-3.0-or-later"
+homepage="https://ulauncher.io/"
+distfiles="https://github.com/Ulauncher/Ulauncher/releases/download/${version}/${pkgname}_${version}.tar.gz"
+checksum=c492a692ec83e08cd7790a0e8966791b2de1c038ee56c7bc45dc6434ea9eeb7f


### PR DESCRIPTION
This is an updated version of [this template](https://github.com/void-linux/void-packages/issues/5532#issuecomment-447585459) since the issue mentioned there was fixed (in libappindicator 12.10.0_2)