### PR TITLE
enca: fix cross build

### DIFF
--- a/srcpkgs/enca/template
+++ b/srcpkgs/enca/template
@@ -10,15 +10,15 @@ hostmakedepends="pkg-config"
 makedepends="recode-devel"
 short_desc="Extremely Naive Charset Analyser and converter"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-homepage="http://cihar.com/software/enca/"
 license="GPL-2"
+homepage="http://cihar.com/software/enca/"
 distfiles="http://dl.cihar.com/enca/enca-${version}.tar.xz"
 checksum=3a487eca40b41021e2e4b7a6440b97d822e6532db5464471f572ecf77295e8b8
 
 pre_build() {
 	# make_hash must be built for the host.
 	cd tools
-	make CC=cc CFLAGS="$BUILD_CFLAGS -fPIE"
+	make CC=cc LDFLAGS="" CFLAGS="$BUILD_CFLAGS -fPIE"
 }
 
 libenca_package() {


### PR DESCRIPTION
Need this to get the cross-base library path out of the ldflags, so the host tools can build without attempting to link against bad libraries. This mostly applies when cross-compiling to "close" systems (like different libc, or different endianness).