### PR TITLE
New package: wl-clipboard-x11-5

### DIFF
--- a/srcpkgs/wl-clipboard-x11/template
+++ b/srcpkgs/wl-clipboard-x11/template
@@ -1,0 +1,13 @@
+# Template file for 'wl-clipboard-x11'
+pkgname=wl-clipboard-x11
+version=5
+revision=1
+build_style=gnu-makefile
+depends="wl-clipboard"
+short_desc="Use wl-clipboard as a drop-in replacement to X11 clipboard tools"
+maintainer="klardotsh <josh@klar.sh>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/brunelli/wl-clipboard-x11"
+distfiles="https://github.com/brunelli/wl-clipboard-x11/archive/v${version}.tar.gz"
+checksum=72ee2d932d93401e23fd5600ffd129cc4ef2f8686c84972bdd1c917ce31678bc
+alternatives="xclip:wl-clipboard-x11:/usr/bin/xclip xsel:wl-clipboard-x11:/usr/bin/xsel"

--- a/srcpkgs/xclip/template
+++ b/srcpkgs/xclip/template
@@ -1,16 +1,17 @@
 # Template file for 'xclip'
 pkgname=xclip
 version=0.13
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake"
 makedepends="libXmu-devel"
+short_desc="Command line interface to the X11 clipboard"
 maintainer="Steven R <dev@styez.com>"
 homepage="https://github.com/astrand/xclip"
 license="GPL-2"
-short_desc="Command line interface to the X11 clipboard"
 distfiles="https://github.com/astrand/xclip/archive/${version}.tar.gz"
 checksum=ca5b8804e3c910a66423a882d79bf3c9450b875ac8528791fb60ec9de667f758
+alternatives="xclip:xclip:/usr/bin/xclip"
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/xsel/template
+++ b/srcpkgs/xsel/template
@@ -1,7 +1,7 @@
 # Template file for 'xsel'
 pkgname=xsel
 version=1.2.0
-revision=4
+revision=5
 build_style="gnu-configure"
 makedepends="libXt-devel"
 short_desc="Command-line getting and setting the contents of the X selection"
@@ -10,3 +10,4 @@ license="custom"
 homepage="http://www.vergenet.net/~conrad/software/xsel/"
 distfiles="http://www.vergenet.net/~conrad/software/xsel/download/xsel-${version}.tar.gz"
 checksum=b927ce08dc82f4c30140223959b90cf65e1076f000ce95e520419ec32f5b141c
+alternatives="xsel:xsel:/usr/bin/xsel"


### PR DESCRIPTION
This is useful for syncing the X11 clipboard in Xwayland apps with the Wayland clipboard - this package in AUR form was crucial to my `sway` setup on Arch Linux, so it was a great candidate for learning Void packaging! :)

Upstream: https://github.com/brunelli/wl-clipboard-x11