### PR TITLE
toot: Add missing python3-wcwidth dependency

### DIFF
--- a/srcpkgs/toot/template
+++ b/srcpkgs/toot/template
@@ -1,12 +1,12 @@
 # Template file for 'toot'
 pkgname=toot
 version=0.21.0
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 pycompile_module="toot"
 hostmakedepends="python3-setuptools"
-depends="python3-BeautifulSoup4 python3-requests python3-setuptools"
+depends="python3-BeautifulSoup4 python3-requests python3-setuptools python3-wcwidth"
 short_desc="Mastodon CLI client"
 maintainer="Nathan Owens <ndowens04@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Resolves this DistributionNotFound exception on startup (at least on
`x86_64-musl`)

```
Traceback (most recent call last):
  File "/bin/toot", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3126, in <module>
    @_call_aside
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3110, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3139, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 581, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 898, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 784, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'wcwidth<2.0,>=0.1.7' distribution was not found and is required by toot
```