### PR TITLE
New package: wsjtx-2.0.1

### DIFF
--- a/srcpkgs/wsjtx/patches/cmake_hamlib_cross.patch
+++ b/srcpkgs/wsjtx/patches/cmake_hamlib_cross.patch
@@ -1,0 +1,22 @@
+--- CMakeLists.txt	2019-02-24 23:11:18.000000000 -0500
++++ CMakeLists.txt.fix	2019-05-19 00:43:03.724194227 -0400
+@@ -79,6 +79,10 @@
+ 
+ include (ExternalProject)
+ 
++if (DEFINED ENV{CROSS_BUILD})
++  get_filename_component(cross_triplet $ENV{XBPS_CROSS_BASE} NAME)
++  set (hamlib_cross "--host=${cross_triplet}")
++endif ()
+ 
+ #
+ # build and install hamlib locally so it can be referenced by the
+@@ -91,7 +95,7 @@
+   URL_HASH MD5=${hamlib_md5sum}
+   UPDATE_COMMAND ./bootstrap
+   PATCH_COMMAND ${PATCH_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/hamlib.patch
+-  CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-shared --enable-static --without-cxx-binding ${EXTRA_FLAGS} # LIBUSB_LIBS=${USB_LIBRARY}
++  CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-shared --enable-static --without-cxx-binding ${EXTRA_FLAGS} ${hamlib_cross} # LIBUSB_LIBS=${USB_LIBRARY}
+   BUILD_COMMAND $(MAKE) all V=1 # $(MAKE) is ExternalProject_Add() magic to do recursive make
+   INSTALL_COMMAND $(MAKE) install-strip V=1 DESTDIR=""
+   STEP_TARGETS update install

--- a/srcpkgs/wsjtx/template
+++ b/srcpkgs/wsjtx/template
@@ -1,14 +1,14 @@
 # Template file for 'wsjtx'
 pkgname=wsjtx
-version=2.0.1
+version=2.1.0
 revision=1
 build_style=cmake
 archs="i686 x86_64 x86_64-musl"
 hostmakedepends="git autoconf automake libtool gcc-fortran asciidoc ruby-asciidoctor qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds libgomp"
-makedepends="fftw-devel qt5-serialport-devel qt5-devel qt5-multimedia-devel libusb-devel libgomp-devel"
+makedepends="fftw-devel qt5-serialport-devel qt5-devel qt5-multimedia-devel libusb-devel libgomp-devel qt5-tools-devel"
 short_desc="WSJT-X weak-signal radio communication program"
 maintainer="Andy Cobaugh <andrew.cobaugh@gmail.com>"
 license="GPL-3.0"
 homepage="http://www.physics.princeton.edu/pulsar/K1JT/wsjtx.html"
 distfiles="http://www.physics.princeton.edu/pulsar/K1JT/wsjtx-${version}.tgz"
-checksum=18f18f93f7e0ecc631ff5f7e0002521c41b54322ea33e5d6ca3ab5144fe1a0cd
+checksum=9e6c5424b2c84534b9ae6b7cc8e014c9da6540a7c50df8f3b25636c09d87d411

--- a/srcpkgs/wsjtx/template
+++ b/srcpkgs/wsjtx/template
@@ -1,0 +1,14 @@
+# Template file for 'wsjtx'
+pkgname=wsjtx
+version=2.0.1
+revision=1
+build_style=cmake
+archs="i686 x86_64 x86_64-musl"
+hostmakedepends="git autoconf automake libtool gcc-fortran asciidoc ruby-asciidoctor qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds libgomp"
+makedepends="fftw-devel qt5-serialport-devel qt5-devel qt5-multimedia-devel libusb-devel libgomp-devel"
+short_desc="WSJT-X weak-signal radio communication program"
+maintainer="Andy Cobaugh <andrew.cobaugh@gmail.com>"
+license="GPL-3.0"
+homepage="http://www.physics.princeton.edu/pulsar/K1JT/wsjtx.html"
+distfiles="http://www.physics.princeton.edu/pulsar/K1JT/wsjtx-${version}.tgz"
+checksum=18f18f93f7e0ecc631ff5f7e0002521c41b54322ea33e5d6ca3ab5144fe1a0cd


### PR DESCRIPTION
Second attempt of #11790 

Also had to restrict which archs this builds on. The last build errored out on the non-intel archs: https://travis-ci.org/void-linux/void-packages/builds/534087066