### PR TITLE
New package: minimodem-0.24

### DIFF
--- a/srcpkgs/minimodem/template
+++ b/srcpkgs/minimodem/template
@@ -1,0 +1,13 @@
+# Template file for 'minimodem'
+pkgname=minimodem
+version=0.24
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="fftw-devel alsa-lib-devel libsndfile-devel pulseaudio-devel"
+short_desc="Generate or decode modem tones using various FSK protocols"
+maintainer="Nejc Bertoncelj <nejcbe@windowslive.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.whence.com/minimodem"
+distfiles="http://www.whence.com/minimodem/minimodem-${version}.tar.gz"
+checksum=f8cca4db8e3f284d67f843054d6bb4d88a3db5e77b26192410e41e9a06f4378e


### PR DESCRIPTION
I've checked the template with xlint and successfully compiled the program for x86_64, i686, aarch64 and armv7l. The post-install notice informs users about using minimodem without pulseaudio.