### PR TITLE
skalibs: update to 2.8.1.0

### DIFF
--- a/srcpkgs/skalibs/template
+++ b/srcpkgs/skalibs/template
@@ -1,6 +1,6 @@
 # Template file for 'skalibs'
 pkgname=skalibs
-version=2.8.0.1
+version=2.8.1.0
 revision=1
 _sysdepspkg=skaware-void-sysdeps
 build_style=configure
@@ -12,17 +12,17 @@ maintainer="bougyman <bougyman@voidlinux.org>"
 license="ISC"
 homepage="https://skarnet.org/software/skalibs/"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=47512e12c08c3b08a27367c63019f7f475c0427cf777aa27fc9ddcd16509b002
+checksum=431c6507b4a0f539b6463b4381b9b9153c86ad75fa3c6bfc9dc4722f00b166ba
 
 CFLAGS="-D_DEFAULT_SOURCE"
 
 if [ "$CROSS_BUILD" ]; then
 	distfiles+=" https://github.com/CMB/${_sysdepspkg}/archive/${version}.tar.gz"
-	checksum+=" 6d0f62109f22edfa1e8e0f1885bff705a2ce0c3588592692afbddeb6d691d7f7"
+	checksum+=" b5a56d24caeb731f9a8468fa61ab0e9ae139370609ef4acb36888e69bbe8d98d"
 	configure_args+=" --with-sysdeps=../${_sysdepspkg}-${version}/${XBPS_CROSS_TRIPLET}"
 
 	case "$XBPS_TARGET_MACHINE" in
-		aarch64*|armv6*|armv7l*|i686|x86_64*) ;;
+		aarch64*|armv6*|armv7l*|i686|x86_64*|ppc*) ;;
 		*) nocross="Missing cross sysdeps" ;;
 	esac
 fi


### PR DESCRIPTION
This also enables crossbuilds for ppc (32/64) as these are newly included in the sysdeps bundle.