### PR TITLE
consul: update to 1.5.0.

### DIFF
--- a/srcpkgs/consul/template
+++ b/srcpkgs/consul/template
@@ -1,12 +1,22 @@
 # Template file for 'consul'
 pkgname=consul
-version=1.4.4
+version=1.5.0
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/${pkgname}"
+_git_commit=34eff659dcc5503b6eb117733c9f7def63f01bad
+go_ldflags="-X ${go_import_path}/version.GitCommit=${_git_commit} -X ${go_import_path}/version.GitDescribe=v${version}"
+# consul has a vendor directory, but relies on replace statements in go.mod, so
+# force default non-vendor behavior.
+go_mod_mode=default
+hostmakedepends="git"
 short_desc="Distributed solution to connect and configure applications"
 maintainer="iaroki <iaroki@protonmail.com>"
 license="MPL-2.0"
 homepage="https://www.consul.io/"
-distfiles="https://github.com/hashicorp/consul/archive/v${version}.tar.gz"
-checksum=8bfb3be5c25cb20b7d8682582fa54969a4745794701efb967d37c06ab075dfe4
+distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
+checksum=3aec2a654efc56b9a5ec48561fac91074dfc6e9380f364fd4e82c121b5aeaf6d
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
- Fix version string from `consul version`.
- Add license (per manual, any non-GPL).