### PR TITLE
julia: update to 1.1.1

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,7 +1,7 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.1.0
-revision=2
+version=1.1.1
+revision=1
 archs="i686* x86_64* ppc64le*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc USE_SYSTEM_LLVM=0 USE_LLVM_SHLIB=1
@@ -22,10 +22,10 @@ maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=a62c40922a368e303051c007a32e616862340d6ae5f3fac851a9e1b7c7bed0a7
+checksum=3c5395dd3419ebb82d57bcc49dc729df3b225b9094e74376f8c649ee35ed79c2
 nocross=yes
 # Falsely detects dependency on libllvm
-skiprdeps=/usr/lib/libjulia.so.1.0
+skiprdeps=/usr/lib/libjulia.so.1.1
 
 case "$XBPS_TARGET_MACHINE" in
 *-musl)


### PR DESCRIPTION
[ci skip]

Built fine locally, and everything seems to be in order. `[ci skip]` is because building llvm.