### PR TITLE
julia: fix llvm6.0 dependency

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,7 +1,7 @@
 # Template file for 'julia'
 pkgname=julia
 version=1.1.1
-revision=1
+revision=2
 archs="i686* x86_64* ppc64le*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc USE_SYSTEM_LLVM=0 USE_LLVM_SHLIB=1
@@ -25,7 +25,7 @@ distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/juli
 checksum=3c5395dd3419ebb82d57bcc49dc729df3b225b9094e74376f8c649ee35ed79c2
 nocross=yes
 # Falsely detects dependency on libllvm
-skiprdeps=/usr/lib/libjulia.so.1.1
+skiprdeps="/usr/lib/libjulia.so.1.1 /usr/lib/julia/libllvmcalltest.so"
 
 case "$XBPS_TARGET_MACHINE" in
 *-musl)


### PR DESCRIPTION
[ci skip]

`/usr/lib/julia/libllvmcalltest.so` was pulling in libllvm6.0 as a dependency, and I didn't notice on first go-around in #11841. CI skip for building llvm. Don't know if there's a way to update the package's dependencies without rebuilding the whole thing?