### PR TITLE
llvm8: clang cross-compiling and musl fixes

### DIFF
--- a/srcpkgs/llvm8/files/patches/cfe/cfe-004-add-musl-triples.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-004-add-musl-triples.patch
@@ -1,65 +1,82 @@
 --- a/lib/Driver/ToolChains/Gnu.cpp.orig	2019-03-30 15:08:33.136000000 +0100
 +++ b/lib/Driver/ToolChains/Gnu.cpp	2019-03-30 15:10:24.666000000 +0100
-@@ -1871,7 +1871,7 @@
-   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
-   static const char *const AArch64Triples[] = {
-       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
--      "aarch64-suse-linux", "aarch64-linux-android"};
-+      "aarch64-suse-linux", "aarch64-linux-android", "aarch64-linux-musl"};
-   static const char *const AArch64beLibDirs[] = {"/lib"};
-   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
-                                                  "aarch64_be-linux-gnu"};
-@@ -1882,7 +1882,10 @@
-   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
-                                              "armv7hl-redhat-linux-gnueabi",
-                                              "armv6hl-suse-linux-gnueabi",
--                                             "armv7hl-suse-linux-gnueabi"};
-+                                             "armv7hl-suse-linux-gnueabi",
-+                                             "arm-linux-musleabihf",
-+                                             "armv7l-linux-musleabihf",
-+                                             "armv7l-linux-gnueabihf"};
-   static const char *const ARMebLibDirs[] = {"/lib"};
-   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi",
-                                              "armeb-linux-androideabi"};
-@@ -1896,7 +1899,8 @@
-       "x86_64-redhat-linux",    "x86_64-suse-linux",
-       "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
-       "x86_64-slackware-linux", "x86_64-unknown-linux",
--      "x86_64-amazon-linux",    "x86_64-linux-android"};
-+      "x86_64-amazon-linux",    "x86_64-linux-android",
-+      "x86_64-linux-musl"};
-   static const char *const X32LibDirs[] = {"/libx32"};
-   static const char *const X86LibDirs[] = {"/lib32", "/lib"};
-   static const char *const X86Triples[] = {
-@@ -1905,12 +1909,13 @@
-       "i586-redhat-linux",    "i386-redhat-linux",     "i586-suse-linux",
-       "i486-slackware-linux", "i686-montavista-linux", "i586-linux-gnu",
-       "i686-linux-android",   "i386-gnu",              "i486-gnu",
--      "i586-gnu",             "i686-gnu"};
-+      "i586-gnu",             "i686-gnu",              "i686-linux-musl"};
+@@ -2014,6 +2014,79 @@
+     return;
+   }
  
-   static const char *const MIPSLibDirs[] = {"/lib"};
-   static const char *const MIPSTriples[] = {
-       "mips-linux-gnu", "mips-mti-linux", "mips-mti-linux-gnu",
--      "mips-img-linux-gnu", "mipsisa32r6-linux-gnu"};
-+      "mips-img-linux-gnu", "mipsisa32r6-linux-gnu", "mips-linux-musl",
-+      "mipsel-linux-musl", "mipsel-linux-muslhf", "mips-linux-muslhf"};
-   static const char *const MIPSELLibDirs[] = {"/lib"};
-   static const char *const MIPSELTriples[] = {
-       "mipsel-linux-gnu", "mips-img-linux-gnu", "mipsisa32r6el-linux-gnu",
-@@ -1945,11 +1950,13 @@
-   static const char *const PPC64LibDirs[] = {"/lib64", "/lib"};
-   static const char *const PPC64Triples[] = {
-       "powerpc64-linux-gnu", "powerpc64-unknown-linux-gnu",
--      "powerpc64-suse-linux", "ppc64-redhat-linux"};
-+      "powerpc64-suse-linux", "ppc64-redhat-linux",
-+      "powerpc64-linux-musl"};
-   static const char *const PPC64LELibDirs[] = {"/lib64", "/lib"};
-   static const char *const PPC64LETriples[] = {
-       "powerpc64le-linux-gnu", "powerpc64le-unknown-linux-gnu",
--      "powerpc64le-suse-linux", "ppc64le-redhat-linux"};
-+      "powerpc64le-suse-linux", "ppc64le-redhat-linux",
-+      "powerpc64le-linux-musl"};
- 
-   static const char *const RISCV32LibDirs[] = {"/lib", "/lib32"};
-   static const char *const RISCVTriples[] = {"riscv32-unknown-linux-gnu",
++  if (TargetTriple.isMusl()) {
++    static const char *const AArch64MuslTriples[] = {"aarch64-linux-musl"};
++    static const char *const ARMHFMuslTriples[] = {
++        "arm-linux-musleabihf", "armv7l-linux-musleabihf",
++        "armv7l-linux-gnueabihf"
++    };
++    static const char *const ARMMuslTriples[] = {"arm-linux-musleabi"};
++    static const char *const X86_64MuslTriples[] = {"x86_64-linux-musl"};
++    static const char *const X86MuslTriples[] = {"i686-linux-musl"};
++    static const char *const MIPSMuslTriples[] = {
++        "mips-linux-musl", "mipsel-linux-musl",
++        "mipsel-linux-muslhf", "mips-linux-muslhf"
++    };
++    static const char *const PPCMuslTriples[] = {"powerpc-linux-musl"};
++    static const char *const PPC64MuslTriples[] = {"powerpc64-linux-musl"};
++    static const char *const PPC64LEMuslTriples[] = {"powerpc64le-linux-musl"};
++
++    switch (TargetTriple.getArch()) {
++    case llvm::Triple::aarch64:
++      LibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));
++      TripleAliases.append(begin(AArch64MuslTriples), end(AArch64MuslTriples));
++      BiarchLibDirs.append(begin(AArch64LibDirs), end(AArch64LibDirs));
++      BiarchTripleAliases.append(begin(AArch64MuslTriples), end(AArch64MuslTriples));
++      break;
++    case llvm::Triple::arm:
++      LibDirs.append(begin(ARMLibDirs), end(ARMLibDirs));
++      if (TargetTriple.getEnvironment() == llvm::Triple::MuslEABIHF) {
++        TripleAliases.append(begin(ARMHFMuslTriples), end(ARMHFMuslTriples));
++      } else {
++        TripleAliases.append(begin(ARMMuslTriples), end(ARMMuslTriples));
++      }
++      break;
++    case llvm::Triple::x86_64:
++      LibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
++      TripleAliases.append(begin(X86_64MuslTriples), end(X86_64MuslTriples));
++      BiarchLibDirs.append(begin(X86LibDirs), end(X86LibDirs));
++      BiarchTripleAliases.append(begin(X86MuslTriples), end(X86MuslTriples));
++      break;
++    case llvm::Triple::x86:
++      LibDirs.append(begin(X86LibDirs), end(X86LibDirs));
++      TripleAliases.append(begin(X86MuslTriples), end(X86MuslTriples));
++      BiarchLibDirs.append(begin(X86_64LibDirs), end(X86_64LibDirs));
++      BiarchTripleAliases.append(begin(X86_64MuslTriples), end(X86_64MuslTriples));
++      break;
++    case llvm::Triple::mips:
++      LibDirs.append(begin(MIPSLibDirs), end(MIPSLibDirs));
++      TripleAliases.append(begin(MIPSMuslTriples), end(MIPSMuslTriples));
++      break;
++    case llvm::Triple::ppc:
++      LibDirs.append(begin(PPCLibDirs), end(PPCLibDirs));
++      TripleAliases.append(begin(PPCMuslTriples), end(PPCMuslTriples));
++      BiarchLibDirs.append(begin(PPC64LibDirs), end(PPC64LibDirs));
++      BiarchTripleAliases.append(begin(PPC64MuslTriples), end(PPC64MuslTriples));
++      break;
++    case llvm::Triple::ppc64:
++      LibDirs.append(begin(PPC64LibDirs), end(PPC64LibDirs));
++      TripleAliases.append(begin(PPC64MuslTriples), end(PPC64MuslTriples));
++      BiarchLibDirs.append(begin(PPCLibDirs), end(PPCLibDirs));
++      BiarchTripleAliases.append(begin(PPCMuslTriples), end(PPCMuslTriples));
++      break;
++    case llvm::Triple::ppc64le:
++      LibDirs.append(begin(PPC64LELibDirs), end(PPC64LELibDirs));
++      TripleAliases.append(begin(PPC64LEMuslTriples), end(PPC64LEMuslTriples));
++      break;
++    default:
++      break;
++    }
++    TripleAliases.push_back(TargetTriple.str());
++    if (TargetTriple.str() != BiarchTriple.str())
++      BiarchTripleAliases.push_back(BiarchTriple.str());
++    return;
++  }
++
+   // Android targets should not use GNU/Linux tools or libraries.
+   if (TargetTriple.isAndroid()) {
+     static const char *const AArch64AndroidTriples[] = {

--- a/srcpkgs/llvm8/files/patches/cfe/cfe-007-ppc-musl-long-double-64.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-007-ppc-musl-long-double-64.patch
@@ -1,0 +1,38 @@
+We need this to ensure musl ppc targets use 64-bit long double, as our libgcc
+ships without the 128-bit long double runtime funcs enabled for musl and even
+if it did, the resulting binary would be incorrect.
+
+--- a/lib/Basic/Targets/PPC.h
++++ b/lib/Basic/Targets/PPC.h
+@@ -342,6 +342,15 @@ public:
+       break;
+     }
+ 
++    switch (getTriple().getEnvironment()) {
++    case llvm::Triple::Musl:
++      LongDoubleWidth = LongDoubleAlign = 64;
++      LongDoubleFormat = &llvm::APFloat::IEEEdouble();
++      break;
++    default:
++      break;
++    }
++
+     // PPC32 supports atomics up to 4 bytes.
+     MaxAtomicPromoteWidth = MaxAtomicInlineWidth = 32;
+   }
+@@ -378,6 +387,15 @@ public:
+       break;
+     }
+ 
++    switch (getTriple().getEnvironment()) {
++    case llvm::Triple::Musl:
++      LongDoubleWidth = LongDoubleAlign = 64;
++      LongDoubleFormat = &llvm::APFloat::IEEEdouble();
++      break;
++    default:
++      break;
++    }
++
+     // PPC64 supports atomics up to 8 bytes.
+     MaxAtomicPromoteWidth = MaxAtomicInlineWidth = 64;
+   }

--- a/srcpkgs/llvm8/files/patches/lldb/musl.patch
+++ b/srcpkgs/llvm8/files/patches/lldb/musl.patch
@@ -1,6 +1,6 @@
---- lldb/source/Plugins/Process/Linux/Procfs.h.orig
-+++ lldb/source/Plugins/Process/Linux/Procfs.h
-@@ -11,21 +11,6 @@
+--- a/source/Plugins/Process/Linux/Procfs.h
++++ b/source/Plugins/Process/Linux/Procfs.h
+@@ -11,21 +11,12 @@
  // sys/procfs.h on Android/Linux for all supported architectures.
  
  #include <sys/ptrace.h>
@@ -21,5 +21,11 @@
 -#endif // NT_FPREGSET
 -#endif
 -#else // __ANDROID__
++#if !defined(__GLIBC__) && defined(__powerpc__)
++#define pt_regs musl_pt_regs
++#include <sys/procfs.h>
++#undef pt_regs
++#else
  #include <sys/procfs.h>
 -#endif // __ANDROID__
++#endif

--- a/srcpkgs/llvm8/template
+++ b/srcpkgs/llvm8/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm8'
 pkgname=llvm8
 version=8.0.0
-revision=2
+revision=3
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="


### PR DESCRIPTION
This involves two things.

The first thing is fixing the patch that adds musl target triples into our clang; previously the patch wasn't correct, as it simply added the musl triples among the GNU triples, which, when cross compiling to musl targets, resulted in clang considering the GCC cross installations for glibc and same arch for linking the crt files; this resulted in broken builds. The new patch only considers musl triples for musl targets and glibc triples for glibc targets, so even if you have two cross-gccs installed in parallel for the same arch (one for musl and one for glibc) it will not pick the wrong ones.

The second thing is making clang use 64-bit long double for musl ppc targets correctly. Previously there was no logic for specifying this and that resulted in 128-bit long double using binaries emitted by clang for musl and ppc(64). With our specific gcc setup, that resulted in linking failures as the 128bit ldbl runtime funcs were not available, and even if they were, the results would be incorrect.

To verify the results:

```
q66@banana: /home/q66/void-packages$ clang --target=powerpc64-linux-musl --sysroot=/usr/powerpc64-linux-musl test.c -o test -v 2>&1|grep "GCC installation"
Found candidate GCC installation: /bin/../lib/gcc/powerpc64-linux-musl/8.3.0
Found candidate GCC installation: /bin/../lib64/gcc/powerpc64-linux-musl/8.3.0
Selected GCC installation: /bin/../lib64/gcc/powerpc64-linux-musl/8.3.0
q66@banana: /home/q66/void-packages$ file test
test: ELF 64-bit MSB pie executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-powerpc64.so.1, not stripped
q66@banana: /home/q66/void-packages$ clang --target=powerpc64-linux-gnu --sysroot=/usr/powerpc64-linux-gnu test.c -o test -v 2>&1|grep "GCC installation"
Found candidate GCC installation: /bin/../lib/gcc/powerpc64-linux-gnu/8.3.0
Found candidate GCC installation: /bin/../lib64/gcc/powerpc64-linux-gnu/8.3.0
Selected GCC installation: /bin/../lib64/gcc/powerpc64-linux-gnu/8.3.0
q66@banana: /home/q66/void-packages$ file test                                                                                                             
test: ELF 64-bit MSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), dynamically linked, interpreter /lib/ld64.so.2, for GNU/Linux 3.2.0, with debug_info, not stripped
```

Previously, both `gnu` and `musl` GCC installations were considered for `musl` builds, with `gnu` taking preference because it was first in the list.

This is not specific to ppc/it affects all targets we support.