### PR TITLE
musl, cross-powerpc-linux-musl: fix wchar_t with clang

### DIFF
--- a/srcpkgs/cross-powerpc-linux-musl/files/powerpc-wchar-t.patch
+++ b/srcpkgs/cross-powerpc-linux-musl/files/powerpc-wchar-t.patch
@@ -1,0 +1,1 @@
+../../musl/patches/powerpc-wchar-t.patch

--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=4
+revision=5
 
 short_desc="Cross toolchain for PowerPC (musl)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
@@ -153,6 +153,9 @@ _musl_build() {
 	[ -f ${wrksrc}/.musl_build_done ] && return 0
 
 	cd ${wrksrc}/musl-${_musl_version}
+
+	_apply_patch -p0 ${FILESDIR}/powerpc-wchar-t.patch
+
 	msg_normal "Building cross musl libc\n"
 
 	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \

--- a/srcpkgs/musl/patches/powerpc-wchar-t.patch
+++ b/srcpkgs/musl/patches/powerpc-wchar-t.patch
@@ -1,0 +1,19 @@
+Clang defines wchar_t as int, gcc as long on the target. They have the same
+size, but are different types. i386 already has this same change, do it for
+powerpc as well.
+
+--- arch/powerpc/bits/alltypes.h.in
++++ arch/powerpc/bits/alltypes.h.in
+@@ -6,8 +6,12 @@ TYPEDEF __builtin_va_list va_list;
+ TYPEDEF __builtin_va_list __isoc_va_list;
+ 
+ #ifndef __cplusplus
++#ifdef __WCHAR_TYPE__
++TYPEDEF __WCHAR_TYPE__ wchar_t;
++#else
+ TYPEDEF long wchar_t;
+ #endif
++#endif
+ 
+ TYPEDEF float float_t;
+ TYPEDEF double double_t;


### PR DESCRIPTION
See comment in patch.