### PR TITLE
rpi-userland: update to 20190501.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1259,7 +1259,7 @@ libvcsm.so rpi-userland-20170427_1
 libcontainers.so rpi-userland-20170427_1
 libbrcmWFC.so rpi-userland-20180103_1
 libdebug_sym.so rpi-userland-20180103_1
-libdtovl.s rpi-userland-20180103_1
+libdtovl.so rpi-userland-20180103_1
 liblockdev.so.1 lockdev-1.0.3_1
 libcec.so.4 libcec-4.0.2_1
 librump.so.0 netbsd-rumpkernel-20130321_1

--- a/srcpkgs/rpi-userland/template
+++ b/srcpkgs/rpi-userland/template
@@ -1,9 +1,9 @@
 # Template file for 'rpi-userland'
-_githash="e5803f2c986cbf8c919c60278b3231dcdf4271a6"
+_githash="517cdc30da167d81a485e7a994e02cec2390a269"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-userland
-version=20190114
+version=20190501
 revision=1
 wrksrc="userland-${_githash}"
 build_style=cmake
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/userland"
 distfiles="https://github.com/raspberrypi/userland/archive/${_githash}.tar.gz"
-checksum=9424ffa45ef888fb61483c63fd66532c1c648e071fea72c93762efbb3c2a8669
+checksum=f75b0e4f992313c6248c6e4e2229d59a49dd4153d67f23a05953dfc059b06e7f
 
 LDFLAGS="-Wl,--no-as-needed"
 archs="armv6l* armv7l*"


### PR DESCRIPTION
Fix typo in common/shlibs for libdtovl.so.