### PR TITLE
export XBPS_BINPKG_EXISTS rather than mark it as readonly

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -435,7 +435,7 @@ while getopts "$XBPS_OPTSTRING" opt; do
         1) export XBPS_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
         a) readonly XBPS_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
         C) readonly XBPS_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;
-        E) readonly XBPS_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
+        E) export XBPS_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
         f) readonly XBPS_BUILD_FORCEMODE=1; XBPS_OPTIONS+=" -f";;
         G) readonly XBPS_USE_GIT_REVS=1; XBPS_OPTIONS+=" -G";;
         g) readonly XBPS_DEBUG_PKGS=1; XBPS_OPTIONS+=" -g";;


### PR DESCRIPTION
srcpkg_get_version and srcpkg_get_pkgver require unsetting
XBPS_BINPKG_EXISTS to work properly (e.g. without it, some packages have
a trailing -).  Unfortunately, bash does not allow unsetting readonly
variables, which XBPS_BINPKG_EXISTS is exported as in xbps-src.

To resolve this problem, simply export XBPS_BINPKG_EXISTS as a normal
variable rather than marking it as readonly.  This addresses #11740.