### PR TITLE
nautilus: add required dependency: tracker

### DIFF
--- a/srcpkgs/nautilus/template
+++ b/srcpkgs/nautilus/template
@@ -1,7 +1,7 @@
 # Template file for 'nautilus'
 pkgname=nautilus
 version=3.32.1
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dtests=headless -Dintrospection=$(vopt_if gir true false)"
@@ -10,7 +10,7 @@ makedepends="exempi-devel gnome-autoar-devel gnome-desktop-devel gtk+3-devel
  libexif-devel libgexiv2-devel libglib-devel libnotify-devel libseccomp-devel
  libX11-devel libxml2-devel tracker-devel gst-plugins-base1-devel"
 depends="desktop-file-utils gsettings-desktop-schemas hicolor-icon-theme
- tracker-miners"
+ tracker-miners tracker"
 checkdepends="tracker"
 short_desc="GNOME file manager"
 maintainer="Rasmus Thomsen <oss@cogitri.dev>"


### PR DESCRIPTION
Without the `tracker` dep installed, nautilus cannot run and errors out with:
```
(org.gnome.Nautilus:23918): Tracker-ERROR **: 06:19:37.365: Unable to find default domain ontology rule /usr/share/tracker/domain-ontologies/default.rule
```