### PR TITLE
pulseaudio: fix broken alsa module

### DIFF
--- a/srcpkgs/pulseaudio/patches/fix-alsa-module.patch
+++ b/srcpkgs/pulseaudio/patches/fix-alsa-module.patch
@@ -1,0 +1,42 @@
+From b89d33bb182c42db5ad3987b0e91b7bf62f421e8 Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Sun, 21 Apr 2019 11:59:30 +0200
+Subject: [PATCH] alsa: Fix inclusion of use-case.h
+
+The recent change in ALSA upstream stripped -I$include/alsa path from
+pkgconfig.  We already fixed for this change in some places but still
+the code for UCM was overlooked, and this resulted in the unresolved
+symbols in alsa card module. Fix them as well.
+
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ configure.ac                | 2 +-
+ src/modules/alsa/alsa-ucm.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index c004bd70d..b44ed1595 100644
+--- configure.ac
++++ configure.ac
+@@ -826,7 +826,7 @@ AS_IF([test "x$enable_alsa" = "xyes" && test "x$HAVE_ALSA" = "x0"],
+ AS_IF([test "x$HAVE_ALSA" = "x1"],
+     [
+         save_CPPFLAGS="$CPPFLAGS"; CPPFLAGS="$CPPFLAGS $ASOUNDLIB_CFLAGS"
+-        AC_CHECK_HEADERS([use-case.h], HAVE_ALSA_UCM=1, HAVE_ALSA_UCM=0)
++        AC_CHECK_HEADERS([alsa/use-case.h], HAVE_ALSA_UCM=1, HAVE_ALSA_UCM=0)
+         CPPFLAGS="$save_CPPFLAGS"
+     ],
+     HAVE_ALSA_UCM=0)
+diff --git a/src/modules/alsa/alsa-ucm.h b/src/modules/alsa/alsa-ucm.h
+index 53abf3f90..c926f3cc3 100644
+--- src/modules/alsa/alsa-ucm.h
++++ src/modules/alsa/alsa-ucm.h
+@@ -23,7 +23,7 @@
+ ***/
+ 
+ #ifdef HAVE_ALSA_UCM
+-#include <use-case.h>
++#include <alsa/use-case.h>
+ #else
+ typedef void snd_use_case_mgr_t;
+ #endif

--- a/srcpkgs/pulseaudio/template
+++ b/srcpkgs/pulseaudio/template
@@ -1,7 +1,7 @@
 # Template file for 'pulseaudio'
 pkgname=pulseaudio
 version=12.2
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-oss-output --disable-oss-wrapper --disable-tcpwrap
  --enable-jack --disable-lirc --disable-hal-compat --disable-gconf --enable-orc
@@ -10,15 +10,16 @@ configure_args="--disable-oss-output --disable-oss-wrapper --disable-tcpwrap
  --disable-systemd-login --disable-systemd-daemon --disable-systemd-journal
  --enable-webrtc-aec --with-bash-completion-dir=/usr/share/bash-completion/completions
  --enable-bluez5-native-headset"
-hostmakedepends="automake gettext-devel intltool libtool orc-devel pkg-config"
+hostmakedepends="automake autoconf gettext-devel glib-devel intltool libtool
+ orc-devel pkg-config"
 makedepends="avahi-libs-devel eudev-libudev-devel fftw-devel jack-devel
-libSM-devel libXtst-devel libasyncns-devel libbluetooth-devel
-libcap-devel libcap-progs libglib-devel libltdl-devel libressl-devel
-libsndfile-devel libsoxr-devel orc-devel sbc-devel speex-devel tdb-devel
+ libSM-devel libXtst-devel libasyncns-devel libbluetooth-devel
+ libcap-devel libcap-progs libglib-devel libltdl-devel libressl-devel
+ libsndfile-devel libsoxr-devel orc-devel sbc-devel speex-devel tdb-devel
 webrtc-audio-processing-devel xcb-util-devel"
 depends="rtkit"
 conf_files="/etc/pulse/*"
-short_desc="A featureful, general-purpose sound server"
+short_desc="Featureful, general-purpose sound server"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/PulseAudio"
@@ -37,6 +38,10 @@ case "$XBPS_TARGET_MACHINE" in
 	# Disable neon optimizations for the arm* architectures
 	arm*) configure_args+=" --disable-neon-opt" ;;
 esac
+
+pre_configure() {
+	NOCONFIGURE=1 ./bootstrap.sh
+}
 
 post_install() {
 	rm -f ${DESTDIR}/etc/dbus-1/system.d/pulseaudio-system.conf


### PR DESCRIPTION
With some recent change in alsa upstream, the build stuff changed and pulseaudio stopped picking these up, which resulted in successful compilation but failed load of module-alsa-card.so, which resulted in a loss of sound.

Reference: https://lists.opensuse.org/opensuse-factory/2019-04/msg00293.html

Cherry-picking the appropriate fix from upstream fixed the module. Unfortunately, because of changed configure.ac, it is necessary to rebuild the autotools definitions, which made it pick up some extra host dependencies.