### PR TITLE
llvm8: fix triples patch for armv7l/gnu

### DIFF
--- a/srcpkgs/llvm8/files/patches/cfe/cfe-004-add-musl-triples.patch
+++ b/srcpkgs/llvm8/files/patches/cfe/cfe-004-add-musl-triples.patch
@@ -1,14 +1,23 @@
 --- a/lib/Driver/ToolChains/Gnu.cpp.orig	2019-03-30 15:08:33.136000000 +0100
 +++ b/lib/Driver/ToolChains/Gnu.cpp	2019-03-30 15:10:24.666000000 +0100
-@@ -2014,6 +2014,79 @@
+@@ -1882,7 +1882,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const ARMHFTriples[] = {"arm-linux-gnueabihf",
+                                              "armv7hl-redhat-linux-gnueabi",
+                                              "armv6hl-suse-linux-gnueabi",
+-                                             "armv7hl-suse-linux-gnueabi"};
++                                             "armv7hl-suse-linux-gnueabi",
++                                             "armv7l-linux-gnueabihf"};
+   static const char *const ARMebLibDirs[] = {"/lib"};
+   static const char *const ARMebTriples[] = {"armeb-linux-gnueabi",
+                                              "armeb-linux-androideabi"};
+@@ -2014,6 +2015,78 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
      return;
    }
  
 +  if (TargetTriple.isMusl()) {
 +    static const char *const AArch64MuslTriples[] = {"aarch64-linux-musl"};
 +    static const char *const ARMHFMuslTriples[] = {
-+        "arm-linux-musleabihf", "armv7l-linux-musleabihf",
-+        "armv7l-linux-gnueabihf"
++        "arm-linux-musleabihf", "armv7l-linux-musleabihf"
 +    };
 +    static const char *const ARMMuslTriples[] = {"arm-linux-musleabi"};
 +    static const char *const X86_64MuslTriples[] = {"x86_64-linux-musl"};

--- a/srcpkgs/llvm8/template
+++ b/srcpkgs/llvm8/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm8'
 pkgname=llvm8
 version=8.0.0
-revision=3
+revision=4
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="


### PR DESCRIPTION
This triple was originally added by the patch together with the musl ones, and I carried it over without noticing that it applies to gnu only. This makes cross-compiling with clang fail for armv7l-gnu (but not for anything else).