### PR TITLE
alacritty: fix icon naming and location

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,7 +1,7 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.3.2
-revision=2
+revision=3
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="freetype-devel fontconfig-devel"
@@ -19,7 +19,7 @@ post_install() {
 	vinstall extra/completions/_alacritty 644 usr/share/zsh/site-functions
 	vinstall extra/completions/alacritty.bash 644 usr/share/bash-completion/completions/alacritty
 	vinstall extra/completions/alacritty.fish 644 usr/share/fish/completions
-	vinstall extra/logo/alacritty-term.svg 644 usr/share/icons/hicolor/scalable/apps/Alacritty.svg
+	vinstall extra/logo/alacritty-term.svg 644 usr/share/icons/hicolor/scalable/apps Alacritty.svg
 	vinstall extra/alacritty.info 644 usr/share/terminfo/a
 	vman extra/alacritty.man alacritty.1
 	vsconf alacritty.yml


### PR DESCRIPTION
Previous commit (#11902) copied icon with its original name to a folder named "Alacritty.svg." Now the icon is properly renamed instead.