### PR TITLE
add php-zip

### DIFF
--- a/srcpkgs/php-zip/INSTALL.msg
+++ b/srcpkgs/php-zip/INSTALL.msg
@@ -1,0 +1,3 @@
+To enable the zip module add the following line to your php.ini:
+
+        extension=zip.so

--- a/srcpkgs/php-zip/template
+++ b/srcpkgs/php-zip/template
@@ -1,0 +1,24 @@
+# Template file for 'php-zip'
+pkgname=php-zip
+version=1.15.4
+revision=1
+wrksrc="zip-${version}"
+build_style=gnu-configure
+make_check_target=test
+hostmakedepends="autoconf pcre2-devel php-devel"
+makedepends="libzip-devel php-devel"
+depends="php"
+short_desc="Zip management extension for PHP"
+maintainer="fosslinux <fosslinux@aussies.space>"
+license="PHP-3.01"
+homepage="https://pecl.php.net/package/zip"
+distfiles="https://pecl.php.net/get/zip-${version}.tgz"
+checksum=0a32dd0e90f4b36e6d6acbcbe08d2eb033cde1dc6a8384b89d90631b05bbb099
+
+pre_configure() {
+	phpize
+}
+
+pre_install() {
+	make_install_args="INSTALL_ROOT=$DESTDIR"
+}


### PR DESCRIPTION
Add the PHP module `zip` to the repository, adapted from `php-acpu`. Needed for a nextcloud installation.