### PR TITLE
python-google-api-python-client: update to 1.7.9.

### DIFF
--- a/srcpkgs/python-google-api-python-client/template
+++ b/srcpkgs/python-google-api-python-client/template
@@ -1,6 +1,6 @@
 # Template file for 'python-google-api-python-client'
 pkgname=python-google-api-python-client
-version=1.7.8
+version=1.7.9
 revision=1
 archs=noarch
 wrksrc="${pkgname#*-}-${version}"
@@ -14,11 +14,12 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/google/google-api-python-client/"
 distfiles="${PYPI_SITE}/g/google-api-python-client/google-api-python-client-${version}.tar.gz"
-checksum=06907006ed5ce831018f03af3852d739c0b2489cdacfda6971bcc2075c762858
+checksum=048da0d68564380ee23b449e5a67d4666af1b3b536d2fb0a02cee1ad540fa5ec
 
 python3-google-api-python-client_package() {
 	archs=noarch
-	depends="python3-httplib2 python3-oauth2client python3-uritemplate python3-six"
+	depends="python3-httplib2 python3-google-auth
+	 python3-google-auth-httplib2 python3-uritemplate python3-six"
 	pycompile_module="apiclient googleapiclient"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {


### PR DESCRIPTION
Also updates the dependency list for the python3 package.