### PR TITLE
cargo: update to 0.36.0

### DIFF
--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,6 +1,6 @@
 # Template file for 'cargo'
 pkgname=cargo
-version=0.35.0
+version=0.36.0
 revision=1
 build_helper=rust
 hostmakedepends="rust python curl cmake pkg-config"
@@ -11,8 +11,8 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://crates.io/"
 distfiles="https://github.com/rust-lang/cargo/archive/${version}.tar.gz"
-checksum=59d27a00be827f30a26700240dc0651ded5e0ff035f6efb0319a0a0267fea22d
-_cargo_dist_version=0.33.0
+checksum=532a39ce9acc1436c5d33ce0643d050bc29183c46abe69934622c4f24f4c6831
+_cargo_dist_version=0.36.0
 build_options="static"
 
 if [ "$CROSS_BUILD" ]; then
@@ -22,39 +22,57 @@ else
 	case "$XBPS_MACHINE" in
 	x86_64-musl)
 		distfiles+="
-		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.xz"
+		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-x86_64-unknown-linux-musl.tar.gz"
 		checksum+="
-		 7d3e669dc5ddde7529ab0df2d0397648a679426fc56dd4c93d94f84fd68366d5"
+		 7a84d006688ffe9e292db59690e7fc99616d6d1a6d981affb93d121fca9e8bb5"
 		;;
 	x86_64)
 		distfiles+="
 		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-x86_64-unknown-linux-gnu.tar.gz"
 		checksum+="
-		 9dd7f79a0ab882ed7c892731514a4aed6435f7bc8a20381a8346b471c8a14209"
+		 77586f2fb5b6f6caef0cb6d3cc32a18559d4fcd6a6db4e75f4b3fb7adb050437"
 		;;
 	i686)
 		distfiles+="
 		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-i686-unknown-linux-gnu.tar.gz"
 		checksum+="
-		 163f46bd84ba6348dfe1ac3c10bc4730059f321791d2a7d4d4704fe8ddf8a755"
+		 6ef32560bfa7c85dee6ef932a5e35994457f3e05e2cf8979c19971b8a5b805e4"
 		;;
 	ppc64le)
 		distfiles+="
-		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64le-unknown-linux-gnu.tar.xz"
+		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-powerpc64le-unknown-linux-gnu.tar.gz"
 		checksum+="
-		 03ece4d677ad59f08a514eb90dd3bd6cad4399fbbaf3d0e916323fbce38e25d1"
+		 d196e4e506c89653c533e34c77fb5be7928a1667bca64a3fd866dd0d1aecfc6d"
 		;;
 	ppc64le-musl)
 		distfiles+="
 		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64le-unknown-linux-musl.tar.xz"
 		checksum+="
-		 801490f04eac96e883f56434747042c375aa3d210b224c2735e02a3a1eab95a0"
+		 9347f6c8b391e0142cda60988690f7bc9a877f8012ea2e71c35343a4cb9b7ee4"
+		;;
+	ppc64)
+		distfiles+="
+		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64-unknown-linux-gnu.tar.xz"
+		checksum+="
+		 512c69762fe2a18b6d9781186e77f76333f7ac179e76135cb85ba19e703afaca"
 		;;
 	ppc64-musl)
 		distfiles+="
 		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc64-unknown-linux-musl.tar.xz"
 		checksum+="
-		 ae90844974681c3ee85a855ae0ed27f06d22215e40f825f3b7ca705d8a7cfe7b"
+		 9b8cdacbb4859addfe63cf8ea1df9eb32343e25a18bef2a6422f990728d0e78a"
+		;;
+	ppc)
+		distfiles+="
+		 https://static.rust-lang.org/dist/cargo-${_cargo_dist_version}-powerpc-unknown-linux-gnu.tar.gz"
+		checksum+="
+		 821b4acd67c438b533436e1a57d11e9e267f6641493c9d49650ace657f59e106"
+		;;
+	ppc-musl)
+		distfiles+="
+		 https://alpha.de.repo.voidlinux.org/distfiles/cargo-${_cargo_dist_version}-powerpc-unknown-linux-musl.tar.xz"
+		checksum+="
+		 eee6637b48d9bbf6375a2de75e36b8670fae26d8da9c53a9890380b9a29d0bcf"
 		;;
 	esac
 fi
@@ -62,10 +80,7 @@ fi
 post_extract() {
 	if [ -z "$CROSS_BUILD" ]; then
 		mkdir -p target/snapshot
-		case "$XBPS_MACHINE" in
-			x86_64-musl|ppc64*) cp ../cargo cargo;;
-			*) cp ../cargo-${_cargo_dist_version}-${RUST_TARGET}/cargo/bin/cargo cargo;;
-		esac
+		cp ../cargo-${_cargo_dist_version}-${RUST_TARGET}/cargo/bin/cargo cargo
 	fi
 }
 


### PR DESCRIPTION
Should be merged after https://github.com/void-linux/void-packages/pull/11940 is merged and builders are done.

@jnbr @Gottox

**Changes:**

* new host support: `ppc64`, `ppc`, `ppc-musl`
* custom cargo distfiles now mimic the layout of official ones, so no need for a special `case`