### PR TITLE
grub: move font-unifont-bdf to hostmakedepends

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,10 +1,10 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.02
-revision=4
-hostmakedepends="flex freetype-devel"
+revision=5
+hostmakedepends="flex freetype-devel font-unifont-bdf"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
- liblzma-devel device-mapper-devel font-unifont-bdf fuse-devel"
+ liblzma-devel device-mapper-devel fuse-devel"
 depends="os-prober"
 conf_files="/etc/default/grub /etc/grub.d/*"
 short_desc="GRand Unified Bootloader 2"


### PR DESCRIPTION
Enables build-time grub-mkfont
Needed to create the files `ascii.pf2 euro.pf2 unicode.pf2` in the `/usr/share/grub` directory needed for `grub-install` when cross-compiling.