### PR TITLE
binutils: enable 64-bit bfd and x86_64 targets on i686 always

### DIFF
--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -1,7 +1,7 @@
 # Template file for 'binutils'
 pkgname=binutils
 version=2.32
-revision=1
+revision=2
 bootstrap=yes
 short_desc="GNU binary utilities"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -33,6 +33,8 @@ do_configure() {
 	fi
 	if [ "${XBPS_TARGET_MACHINE%-musl}" = "x86_64" ]; then
 		CONFIGFLAG+=" --enable-targets=x86_64-pep"
+	elif [ "${XBPS_TARGET_MACHINE%-musl}" = "i686" ]; then
+		CONFIGFLAG+=" --enable-64-bit-bfd --enable-targets=x86_64-linux-gnu,x86_64-pep"
 	fi
 	./configure --build=$XBPS_TRIPLET --prefix=/usr --enable-threads \
 		--enable-plugins --enable-secureplt --with-mmap \


### PR DESCRIPTION
Since binutils 2.30, this is necessary to allow building GRUB.