### PR TITLE
bc-gh: update to 2.0.0

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,6 +1,6 @@
 # Template file for 'bc-gh'
 pkgname=bc-gh
-version=1.2.8
+version=2.0.0
 revision=1
 wrksrc="bc-${version}"
 short_desc="Implementation of POSIX bc with GNU extensions"
@@ -8,7 +8,7 @@ maintainer="Gavin D. Howard <yzena.tech@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/gavinhoward/bc"
 distfiles="${homepage}/releases/download/${version}/bc-${version}.tar.xz"
-checksum=7318ab9d4f0755d9c5d6efdd293b5d261a464cac79dec9f32c5a940cbd0ff14f
+checksum=0ddfc78f6588d9c4d33334cb6862e6db96b2e499a8a650701e98de745e3f549e
 alternatives="
  bc:bc:/usr/bin/bc-gh
  dc:dc:/usr/bin/dc-gh"
@@ -21,7 +21,7 @@ do_build() {
 	make ${makejobs}
 }
 do_check() {
-	make test
+	make ${makejobs} test
 }
 do_install() {
 	# Note that make install is used because of a symlink.


### PR DESCRIPTION
This update brings extreme performance improvements, adds a few new features, and fixes a few subtle bugs. For more information, see the [release notes][1].

In this version, I also made the test run under multiple `make` jobs because I made the test suite able to do that.

[1]: https://github.com/gavinhoward/bc/releases/tag/2.0.0