### PR TITLE
handbrake: add atk-devel dependency

### DIFF
--- a/srcpkgs/handbrake/template
+++ b/srcpkgs/handbrake/template
@@ -16,7 +16,7 @@ makedepends="zlib-devel bzip2-devel libnotify-devel gtk+3-devel ncurses-devel
  fribidi-devel libass-devel fontconfig-devel libxml2-devel libogg-devel
  libdvdnav-devel libdvdread-devel libtheora-devel lame-devel jansson-devel
  libsamplerate-devel libbluray-devel librsvg-devel libvpx-devel ffmpeg-devel
- opus-devel speex-devel $(vopt_if nvenc nv-codec-headers)
+ opus-devel speex-devel atk-devel $(vopt_if nvenc nv-codec-headers)
  $(vopt_if fdk_aac fdk-aac-devel)"
 depends="gst-plugins-good1 desktop-file-utils hicolor-icon-theme"
 short_desc="Multithreaded video transcoder"


### PR DESCRIPTION
This dependency is necessary to compile.