### PR TITLE
python-dogpile.cache: add python-decorator as dep

### DIFF
--- a/srcpkgs/python-dogpile.cache/template
+++ b/srcpkgs/python-dogpile.cache/template
@@ -1,13 +1,13 @@
 # Template file for 'python-dogpile.cache'
 pkgname=python-dogpile.cache
 version=0.7.1
-revision=1
+revision=2
 archs=noarch
 wrksrc="dogpile.cache-${version}"
 build_style=python-module
 pycompile_module="dogpile"
 hostmakedepends="python-setuptools python3-setuptools"
-depends="python"
+depends="python python-decorator"
 short_desc="A caching front-end based on the Dogpile lock (Python2)"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="BSD-3-Clause"
@@ -22,7 +22,7 @@ post_install() {
 python3-dogpile.cache_package() {
 	archs=noarch
 	pycompile_module="dogpile"
-	depends="python3"
+	depends="python3 python3-decorator"
 	short_desc="${short_desc/Python2/Python3}"
 	alternatives="guessit:guessit:/usr/bin/guessit3"
 	pkg_install() {


### PR DESCRIPTION
Noticed that `python-dogpile.cache` did not have `python-decorator` as dep.

Thus, Usage of `subliminal` exits with error about not finding `python-decorator` which is needed by `python-dogpile.cache`.

Fixed and working.