### PR TITLE
base-system: Remove 32-bit Linux ppc dependency.

### DIFF
--- a/srcpkgs/base-system/template
+++ b/srcpkgs/base-system/template
@@ -2,7 +2,7 @@
 pkgname=base-system
 reverts="0.113_1"
 version=0.112
-revision=6
+revision=7
 build_style=meta
 short_desc="Void Linux base system meta package"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -23,5 +23,5 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc*) depends+=" linux";;
+	i686*|x86_64*|ppc64*) depends+=" linux";;
 esac


### PR DESCRIPTION
Some 32-bit PPC platforms do not use or conflict with the default kernel, such as the Wii, Wii U, APM-based devices, etc.