### PR TITLE
mate-menus: fix python bindings by setting python2 explicitly

### DIFF
--- a/srcpkgs/mate-menus/template
+++ b/srcpkgs/mate-menus/template
@@ -1,11 +1,12 @@
 # Template file for 'mate-menus'
 pkgname=mate-menus
 version=1.20.2
-revision=2
+revision=3
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static $(vopt_enable python)"
-hostmakedepends="pkg-config intltool itstool $(vopt_if gir gobject-introspection)"
+hostmakedepends="pkg-config intltool itstool $(vopt_if gir gobject-introspection)
+ $(vopt_if python python)"
 makedepends="libglib-devel $(vopt_if python python-devel)"
 short_desc="MATE menu specifications"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -16,6 +17,10 @@ checksum=e277df3b3072c2177277644a8c7b0191cc5c3779f1b8db99ef183734d4b4c4a3
 
 build_options="gir python"
 build_options_default="gir python"
+
+pre_configure() {
+	export PYTHON=/usr/bin/python2
+}
 
 mate-menus-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Previously added build_helper gir pulled in python3, so python now points to python3 during build but mate-menus needs python2.