### PR TITLE
hledger: update to 1.14.2

### DIFF
--- a/srcpkgs/hledger/template
+++ b/srcpkgs/hledger/template
@@ -1,18 +1,19 @@
 # Template file for 'hledger'
 pkgname=hledger
-version=1.10
+version=1.14.2
 revision=1
+wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=haskell-stack
-stackage="lts-12.0"
-nocross=yes # Can't yet cross compile Haskell
+stackage="lts-13.23"
+makedepends="zlib-devel ncurses-devel"
 short_desc="Simple, precise, plain text accounting"
 maintainer="Inokentiy Babushkin <twk@twki.de>"
 license="GPL-3.0-or-later"
-homepage="http://hledger.org/"
-makedepends="zlib-devel ncurses-devel"
-wrksrc="${pkgname}-${pkgname}-${version}"
+homepage="https://hledger.org/"
+changelog="https://hackage.haskell.org/package/hledger-1.14.2/changelog"
 distfiles="https://github.com/simonmichael/${pkgname}/archive/${pkgname}-${version}.tar.gz"
-checksum=460b7bfd91748abf1cd501471c983e99323f31f4b0bb43b02eab777ad465d8c2
+checksum=127edf1a8ca5b3c16e9163ec777909eb6f045f3ae3f0500ba7333074ff78c393
+nocross=yes # Can't yet cross compile Haskell
 nopie_files="/usr/bin/hledger"
 
 post_install() {


### PR DESCRIPTION
I need some help with this PR since I don't know the haskell package system. This package relies on `brick` but it isn't included in the latest stackage lts: `13.23`

The build quits with:
```zsh
Selected resolver: lts-13.23
Resolver 'lts-13.23' does not have all the packages to match your requirements.
    brick not found
        - hledger-ui requires >=0.23 && <0.47
    text-zipper not found
        - hledger-ui requires >=0.4
    Using package flags:
        - hledger-ui: threaded = True

This may be resolved by:
    - Using '--solver' to ask cabal-install to generate extra-deps, atop the chosen snapshot.
    - Using '--omit-packages to exclude mismatching package(s).
    - Using '--resolver' to specify a matching snapshot/resolver

=> ERROR: hledger-1.14.2_1: do_build: 'STACK_ROOT=$wrksrc/.stack stack init --system-ghc --force --resolver ${stackage}' exited with 1
=> ERROR:   in do_build() at common/build-style/haskell-stack.sh:18
```