### PR TITLE
mupdf: fix symlink

### DIFF
--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -1,7 +1,7 @@
 # Template file for 'mupdf'
 pkgname=mupdf
 version=1.15.0
-revision=1
+revision=2
 wrksrc="${pkgname}-${version}-source"
 hostmakedepends="pkg-config zlib-devel libcurl-devel freetype-devel
  libjpeg-turbo-devel jbig2dec-devel libXext-devel libXcursor-devel
@@ -41,7 +41,7 @@ do_build() {
 do_install() {
 	make USE_SYSTEM_LIBS=yes build=release prefix=${DESTDIR}/usr install
 
-	ln -rs ${DESTDIR}/usr/bin/mupdf-x11-curl ${DESTDIR}/usr/bin/mupdf
+	ln -rs ${DESTDIR}/usr/bin/mupdf-x11 ${DESTDIR}/usr/bin/mupdf
 
 	vinstall ${FILESDIR}/mupdf.xpm 644 usr/share/pixmaps
 	vinstall ${FILESDIR}/mupdf.desktop 644 usr/share/applications


### PR DESCRIPTION
Solve #12012.
Change symlink mupdf -> mupdf-x11-curl to mupdf -> mupdf-x11.