### PR TITLE
glibc: explicitly override xbps architecture on i686/ppc/arm

### DIFF
--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.29
-revision=5
+revision=6
 bootstrap=yes
 short_desc="GNU C library"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -171,6 +171,18 @@ do_install() {
 	rm -f ${DESTDIR}/usr/bin/z{dump,ic}
 
 	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
+
+	# Create xbps.d(5) arch override file for 32-bit architectures
+	# 32-bit userlands may be used with 64-bit kernels and then
+	# xbps will report an incorrect architecture by default
+	case "$XBPS_TARGET_MACHINE" in
+		i686|ppc|armv*)
+			vmkdir usr/share/xbps.d
+			echo "architecture=${XBPS_TARGET_MACHINE}" > \
+				${DESTDIR}/usr/share/xbps.d/arch-32bit.conf
+			;;
+		*) ;;
+	esac
 }
 
 glibc-devel_package() {


### PR DESCRIPTION
This is in order to fix xbps when running on 64-bit kernels with 32-bit userland style setups. Musl already does this in order to append the -musl suffix, so no fix there necessary.