### PR TITLE
gcc: enable secureplt for powerpc and remove redundant option

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -186,8 +186,8 @@ do_configure() {
 			_args+=" --with-arch=armv8-a"
 			sed -i '/m64=/s/lib64/lib/' gcc/config/aarch64/t-aarch64-linux
 			;;
-		ppc) _args+=" --with-cpu=powerpc --target=powerpc-linux-gnu";;
-		ppc-musl) _args+=" --with-cpu=powerpc --target=powerpc-linux-musl --disable-decimal-float --with-long-double=64";;
+		ppc) _args+=" --target=powerpc-linux-gnu --enable-secureplt";;
+		ppc-musl) _args+=" --target=powerpc-linux-musl --enable-secureplt --disable-decimal-float";;
 		ppc64le*) # use lib not lib64 by default
 			_args+=" --target=${_triplet} --with-abi=elfv2 --enable-secureplt --enable-targets=powerpcle-linux"
 			sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h


### PR DESCRIPTION
Secureplt is already matched in our crosstoolchains, it was just forgotten in the main template. Also remove the with-long-double option as it's already handled by one of our patches and is therefore redundant. Similarly, --with-cpu is also unnecessary.