### PR TITLE
gnupg2: update to 2.2.16.

### DIFF
--- a/srcpkgs/gnupg2/template
+++ b/srcpkgs/gnupg2/template
@@ -1,6 +1,6 @@
 # Template file for 'gnupg2'
 pkgname=gnupg2
-version=2.2.15
+version=2.2.16
 revision=1
 wrksrc="gnupg-${version}"
 build_style=gnu-configure
@@ -16,11 +16,10 @@ maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnupg.org/"
 distfiles="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2"
-checksum=cb8ce298d7b36558ffc48aec961b14c830ff1783eef7a623411188b5e0f5d454
+checksum=6cbe8d454bf5dc204621eed3016d721b66298fa95363395bb8eeceb1d2fd14cb
 
 pre_configure() {
-	sed -i '/^CFLAGS=$/d' configure
-	sed -i '/examples\/systemd-user/d' doc/Makefile.in
+	vsed -i '/examples\/systemd-user/d' doc/Makefile.in
 }
 
 post_install() {


### PR DESCRIPTION
`vsed: regex "/^CFLAGS=$/d" didn't change file "configure"`
Looking at `configure`, this `sed` doesn't seem to be needed anyway, so removed.