### PR TITLE
os-prober: fix the way scripts are installed for different archs

### DIFF
--- a/srcpkgs/os-prober/template
+++ b/srcpkgs/os-prober/template
@@ -1,7 +1,7 @@
 # Template file for 'os-prober'
 pkgname=os-prober
 version=1.77
-revision=1
+revision=2
 build_style=gnu-makefile
 make_dirs="/var/lib/os-prober 0755 root root"
 short_desc="Utility to detect other OSes on a set of drives"
@@ -10,6 +10,12 @@ license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/os-prober"
 distfiles="${DEBIAN_SITE}/main/o/${pkgname}/${pkgname}_${version}.tar.xz"
 checksum=8d8ea4afbe1aeef3c8b73f74a0fb37b06185e21a6abc78f80fc2160009cf705f
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*) _ARCH="x86";;
+	ppc*) _ARCH="powerpc";;
+	*) ;;
+esac
 
 do_install() {
 	vbin linux-boot-prober
@@ -20,7 +26,9 @@ do_install() {
 	for dir in os-probes os-probes/mounted os-probes/init linux-boot-probes linux-boot-probes/mounted; do
 		vmkdir usr/lib/${dir}
 		install -m755 -t ${DESTDIR}/usr/lib/${dir} ${dir}/common/*
-		[ -d ${dir}/x86 ] && cp -r ${dir}/x86/* ${DESTDIR}/usr/lib/${dir}
+		[ -n "$_ARCH" -a -d ${dir}/${_ARCH} ] && cp -r ${dir}/${_ARCH}/* ${DESTDIR}/usr/lib/${dir}
 	done
-	vinstall os-probes/mounted/powerpc/20macosx 755 usr/lib/os-probes/mounted
+	if [ -n "$_ARCH" -a "$_ARCH" = "x86" ]; then
+		vinstall os-probes/mounted/powerpc/20macosx 755 usr/lib/os-probes/mounted
+	fi
 }


### PR DESCRIPTION
The old way simply installed stuff for all as if they were x86, the new way follows what the Debian scripts do.