### PR TITLE
grub: patch out creation of OS X menu entries on non-x86

### DIFF
--- a/srcpkgs/grub/patches/os-prober-osx86.patch
+++ b/srcpkgs/grub/patches/os-prober-osx86.patch
@@ -1,0 +1,16 @@
+Patches OS X detection out of os-prober hook on non-x86 architectures. The
+menu entries generated for those are invalid for non-x86 Mac stuff.
+--- util/grub.d/30_os-prober.in
++++ util/grub.d/30_os-prober.in
+@@ -42,6 +42,11 @@ if [ -z "${OSPROBED}" ] ; then
+ fi
+ 
+ osx_entry() {
++    # GRUB won't load OS X outside of x86, no entry
++    case "x`uname -m`" in
++        xi?86|xx86_64) ;;
++        *) return ;;
++    esac
+     if [ x$2 = x32 ]; then
+         # TRANSLATORS: it refers to kernel architecture (32-bit)
+ 	bitstr="$(gettext "(32-bit)")"

--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,7 +1,7 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.02
-revision=5
+revision=6
 hostmakedepends="flex freetype-devel font-unifont-bdf"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel fuse-devel"


### PR DESCRIPTION
@pullmoll, can you test this on your Mac machine? It should do the right thing.