### PR TITLE
qt5-webkit: Fix building on ppc

### DIFF
--- a/srcpkgs/qt5-webkit/template
+++ b/srcpkgs/qt5-webkit/template
@@ -34,9 +34,14 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc64*)	# no JIT on ppc64 and other build workarounds
 		configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON"
 		;;
-	i686*) 	# try to reduce memory footprint when linking
+	i686*)  # try to reduce memory footprint when linking
 		nodebug=1
 		;;
+	ppc*)   # no JIT on ppc and need libatomic
+                configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON"
+                makedepends+=" libatomic-devel"
+                LIBS+=" -latomic"
+                ;;
 esac
 
 pre_configure() {


### PR DESCRIPTION
Cmake expects CMAKE_SYSTEM_PROCESSOR to be set to "ppc" when it should be "powerpc".
Also use -latomic and disable JIT.