### PR TITLE
ufetch: fix license to isc

### DIFF
--- a/srcpkgs/ufetch/template
+++ b/srcpkgs/ufetch/template
@@ -1,13 +1,13 @@
 # Template file for 'ufetch'
 pkgname=ufetch
 version=0.1
-revision=1
+revision=2
 archs=noarch
 wrksrc="ufetch-v${version}"
 depends="xbps coreutils ncurses"
 short_desc="Tiny system info for Void"
 maintainer="maxice8 <thinkabit.ukim@gmail.com>"
-license="MIT"
+license="ISC"
 homepage="https://gitlab.com/jschx/ufetch"
 distfiles="https://gitlab.com/jschx/ufetch/-/archive/v${version}/ufetch-v${version}.tar.gz"
 checksum=e4149fc8d0c75e431e99250e0cd2597ea389b488d8c9febc845eadd0f7b6e947


### PR DESCRIPTION
ufetch is licensed under ISC and not MIT, though it is pretty much the same, just shorter.