### PR TITLE
rebar3: update to 3.11.0.

### DIFF
--- a/srcpkgs/rebar3/template
+++ b/srcpkgs/rebar3/template
@@ -1,16 +1,16 @@
 # Template file for 'rebar3'
 pkgname=rebar3
-version=3.10.0
+version=3.11.0
 revision=1
 archs=noarch
 hostmakedepends=erlang
-depends=erlang
+depends="erlang>=22"
 short_desc="Erlang build tool to compile, test, and release applications"
 maintainer="Noel Cower <ncower@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.rebar3.org/"
 distfiles="https://github.com/erlang/rebar3/archive/${version}.tar.gz"
-checksum=656b4a0bd75f340173e67a33c92e4d422b5ccf054f93ba35a9d780b545ee827e
+checksum=d0f567bf5cfd60e16650b151a7caa24bf8164fb1c31359ce8b0452a683209421
 
 do_build() {
 	./bootstrap


### PR DESCRIPTION
Requires erlang>=22 now -- without this, if someone installs rebar3
while erlang is held on an earlier release, this breaks rebar3 (because
no forward compatibility).