### PR TITLE
build-style/cmake: powerpc->ppc for CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -16,7 +16,7 @@ do_configure() {
 			mips*) _CMAKE_SYSTEM_PROCESSOR=mips ;;
 			ppc64le*) _CMAKE_SYSTEM_PROCESSOR=ppc64le ;;
 			ppc64*) _CMAKE_SYSTEM_PROCESSOR=ppc64 ;;
-			ppc*) _CMAKE_SYSTEM_PROCESSOR=powerpc ;;
+			ppc*) _CMAKE_SYSTEM_PROCESSOR=ppc ;;
 			*) _CMAKE_SYSTEM_PROCESSOR=generic ;;
 		esac
 		if [ -x "${XBPS_CROSS_BASE}/usr/bin/wx-config-gtk3" ]; then


### PR DESCRIPTION
`ppc` is the correct name which cmake reports in a native ppc32 environment, therefore the cross toolchain definition is wrong.