### PR TITLE
New package: chirp-20190524

### DIFF
--- a/srcpkgs/chirp/template
+++ b/srcpkgs/chirp/template
@@ -1,0 +1,14 @@
+# Template file for 'chirp'
+pkgname=chirp
+version=20190524
+revision=1
+wrksrc="${pkgname}-daily-${version}"
+build_style=python2-module
+hostmakedepends="python-devel python-pyserial libxml2-python"
+makedepends="python-devel python-pyserial python-lxml pygtk-devel libxml2-python"
+short_desc="CHIRP is a free, open-source tool for programming your amateur radio"
+maintainer="Andy Cobaugh <andrew.cobaugh@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://chirp.danplanet.com"
+distfiles="https://trac.chirp.danplanet.com/chirp_daily/daily-${version}/chirp-daily-${version}.tar.gz"
+checksum=90246dbd9afa19579ee5aef1c8501d39f945bb87732ee60ee1dfda289ceb59cf


### PR DESCRIPTION
Is there a policy regarding naming/versioning of packages that are "daily" releases? This tool has no other style of release.