### PR TITLE
cargo: fix build

### DIFF
--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo'
 pkgname=cargo
 version=0.36.0
-revision=1
+revision=2
 build_helper=rust
 hostmakedepends="rust python curl cmake pkg-config"
 makedepends="libcurl-devel libgit2-devel"
@@ -100,6 +100,8 @@ do_build() {
 		cargo="./cargo"
 	fi
 
+	$cargo update
+	$cargo update --package libc --precise 0.2.55
 	$cargo build --release $(vopt_if static --features="all-static")
 }
 


### PR DESCRIPTION
build fails on musl with more recent versions of the libc crate