### PR TITLE
klavaro: distfile are no longer missing

### DIFF
--- a/srcpkgs/klavaro/template
+++ b/srcpkgs/klavaro/template
@@ -10,8 +10,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="http://klavaro.sourceforge.net/en/"
 distfiles="${SOURCEFORGE_SITE}/klavaro/klavaro-${version}.tar.bz2"
-checksum=a0802c32675b0267e09f41ef8635e9581ec86817218bc1d711f6090ec5b92c32
-broken="distfiles are gone"
+checksum=45c51f46afca3e3d948debed13271584ba569b461d15587b0c365f98479ee7ff
 
 post_install() {
 	rm ${DESTDIR}/usr/lib/*.{a,so}


### PR DESCRIPTION
Looks like 3.07 was reissued with [this change](https://sourceforge.net/p/klavaro/code/83/).

