### PR TITLE
travis/build.sh: use -jX in xbps-src.

### DIFF
--- a/common/travis/build.sh
+++ b/common/travis/build.sh
@@ -25,8 +25,13 @@ XBPS_SRCPKGDIR=/hostrepo/srcpkgs XBPS_MASTERDIR=/ chroot_prepare $1 || {
 
 PKGS=$(/hostrepo/xbps-src sort-dependencies $(cat /tmp/templates))
 
+NPROCS=1
+if [ -r /proc/cpuinfo ]; then
+        NPROCS=$(grep ^proc /proc/cpuinfo|wc -l)
+fi
+
 for pkg in ${PKGS}; do
-	/hostrepo/xbps-src -H "$HOME"/hostdir $arch pkg "$pkg"
+	/hostrepo/xbps-src -j$NPROCS -H "$HOME"/hostdir $arch pkg "$pkg"
 	[ $? -eq 1 ] && exit 1
 done
 


### PR DESCRIPTION
Do not rely on nproc(1) being available.

Signed-off-by: Juan RP <xtraeme@gmail.com>