### PR TITLE
networkmanager-dmenu: use python2 dependencies

### DIFF
--- a/srcpkgs/networkmanager-dmenu/template
+++ b/srcpkgs/networkmanager-dmenu/template
@@ -1,7 +1,7 @@
 # Template file for 'networkmanager-dmenu'
 pkgname=networkmanager-dmenu
 version=1.1
-revision=1
+revision=2
 archs=noarch
 conf_files="/etc/networkmanager_dmenu-config.ini"
 depends="NetworkManager python3-gobject"
@@ -11,6 +11,7 @@ license="MIT"
 homepage="https://github.com/firecat53/${pkgname}"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=279695b8833ec790cf0c00ec2eb36be09ca33a39aa9595578e2e3d2f644dd998
+python_version=3
 
 do_install() {
 	vmkdir usr/share/applications


### PR DESCRIPTION
networkmanager-dmenu is a python2 script, but the package currently depends on the python3 version of python-gobject. it should depend on the python2 version instead.