### PR TITLE
perl: update to 5.28.2.

### DIFF
--- a/srcpkgs/perl/template
+++ b/srcpkgs/perl/template
@@ -1,8 +1,8 @@
 # Template file for 'perl'
 pkgname=perl
-version=5.28.1
+version=5.28.2
 revision=1
-_perl_cross_version=1.2.1
+_perl_cross_version=1.3
 build_style=gnu-configure
 hostmakedepends="less"
 makedepends="zlib-devel bzip2-devel gdbm-devel db-devel"
@@ -13,9 +13,8 @@ license="Artistic-1.0-perl, GPL-1.0-or-later"
 homepage="https://www.perl.org"
 distfiles="https://www.cpan.org/src/5.0/perl-${version}.tar.gz
  https://github.com/arsv/perl-cross/releases/download/${_perl_cross_version}/perl-cross-${_perl_cross_version}.tar.gz"
-checksum="3ebf85fe65df2ee165b22596540b7d5d42f84d4b72d84834f74e2e0b8956c347
- 8b706bc688ddf71b62d649bde72f648669f18b37fe0c54ec6201142ca3943498"
-disable_parallel_build=yes
+checksum="aa95456dddb3eb1cc5475fed4e08f91876bea71fb636fba6399054dfbabed6c7
+ 49edea1ea2cd6c5c47386ca71beda8d150c748835781354dbe7f75b1df27e703"
 
 # Before updating this package to a new major version, run ${FILESDIR}/provides.pl
 # against ${wrksrc} to find the list of built in packages.


### PR DESCRIPTION
Use perl-cross-1.3, which supports perl<=5.30 and -jX.

Signed-off-by: Juan RP <xtraeme@gmail.com>