### PR TITLE
foliate: update to 1.1.1

### DIFF
--- a/srcpkgs/foliate/template
+++ b/srcpkgs/foliate/template
@@ -1,13 +1,13 @@
 # Template file for 'foliate'
 pkgname=foliate
-version=1.1.0
+version=1.1.1
 revision=1
 build_style=meson
-hostmakedepends="pkg-config gjs glib-devel meson ninja"
-depends="webkit2gtk libsoup"
+hostmakedepends="pkg-config gjs glib-devel ninja"
+depends="webkit2gtk libsoup gjs"
 short_desc="Simple and modern GTK eBook reader"
 maintainer="lorem <notloremipsum@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://johnfactotum.github.io/foliate/"
 distfiles="https://github.com/johnfactotum/${pkgname}/archive/${version}.tar.gz"
-checksum=adf62b26a64011789a26745dc8b2b095b18f9620a3834b92a5e1a7435a195927
+checksum=8adfb7beb0be197c11376ee5e6d927b7c033d603d6b762ad19f5414c5bf876e7


### PR DESCRIPTION
Also added gjs as a runtime dependency, was mistakenly overlooked in initial commit.