### PR TITLE
[NOMERGE] runit-void: update os-release information

### DIFF
--- a/srcpkgs/runit-void/files/os-release
+++ b/srcpkgs/runit-void/files/os-release
@@ -1,4 +1,4 @@
 NAME="void"
-ID="void"
-DISTRIB_ID="void"
-PRETTY_NAME="void"
+VERSION="rolling"
+ID="void_@arch@_@libc@"
+PRETTY_NAME="Void Linux (@arch@@float@ @libc@)"

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,13 +1,13 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20180623
-revision=2
+revision=3
 wrksrc="void-runit-${version}"
 build_style=gnu-makefile
-homepage="https://github.com/void-linux/void-runit"
 short_desc="Void Linux runit scripts"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="Public Domain"
+homepage="https://github.com/void-linux/void-runit"
 distfiles="https://github.com/void-linux/void-runit/archive/${version}.tar.gz"
 checksum=f71a070ac5e5af39fdaa0ffbd7404b607e503c2226cb49e98ac19e042283ff2c
 
@@ -27,10 +27,39 @@ make_dirs="
  /etc/zzz.d/resume 0755 root root"
 
 post_install() {
+	local arch="x86_64" libc="glibc" float
+
+	case "$XBPS_TARGET_MACHINE" in
+		*-musl) libc="musl";;
+		*) libc="glibc";;
+	esac
+
+	case "$XBPS_TARGET_MACHINE" in
+		i686*) arch="i686";;
+		x86_64*) arch="x86_64";;
+		aarch64*) arch="aarch64"; float="+neon";;
+		armv5*) arch="armv5tel"; float="+soft-float";;
+		armv6*) arch="armv6l"; float="+vfp";;
+		armv7*) arch="armv7l"; float="+neon";;
+		ppc64le*) arch="powerpc64le";;
+		ppc64*) arch="powerpc64";;
+		ppc*) arch="powerpc";;
+		mipselhf*) arch="mipsel"; float="+hard-float";;
+		mipsel*) arch="mipsel"; float="+soft-float";;
+		mipshf*) arch="mips"; float="+hard-float";;
+		mips*) arch="mips"; float="+soft-float";;
+	esac
+
+	sed ${FILESDIR}/os-release \
+		-e "s;@arch@;$arch;" \
+		-e "s;@float@;$float;" \
+		-e "s;@libc@;$libc;" \
+		> os-release
+
 	vmkdir usr/bin
 	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
 	vconf ${FILESDIR}/hostname
-	vconf ${FILESDIR}/os-release
+	vconf os-release
 	vconf ${FILESDIR}/locale.conf
 	vinstall ${FILESDIR}/apparmor 644 /etc/default/
 	vinstall ${FILESDIR}/09-apparmor.sh 644 /etc/runit/core-services/


### PR DESCRIPTION
The file /etc/os-release is used by e.g. os-prober (for grub) to extract
information for both, grub labels and user information.
For multiple boot partitions like glibc vs. musl libc, big vs. little
endian the user could not tell which partition contained which variant
because their names was always just "void".

This update creates an individual /etc/os-release containing information
about the libc (glibc or musl), the CPU architecture and endianness, and
the floating point options, if they are relevant.

The variable DISTRIB_ID is not defined in the description at:
https://www.freedesktop.org/software/systemd/man/os-release.html