### PR TITLE
mate-menus: update to 1.22.0.

### DIFF
--- a/srcpkgs/mate-menus/template
+++ b/srcpkgs/mate-menus/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-menus'
 pkgname=mate-menus
-version=1.20.2
-revision=3
+version=1.22.0
+revision=1
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static $(vopt_enable python)"
@@ -13,7 +13,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=e277df3b3072c2177277644a8c7b0191cc5c3779f1b8db99ef183734d4b4c4a3
+checksum=acec93a66154fdbd78404680fca5a99112085cb99d7c43022b010527dc9a6ad2
 
 build_options="gir python"
 build_options_default="gir python"


### PR DESCRIPTION
The soname didn't actually bump numerically, however, packages say they require the new version. Let me know if this is the correct procedure.