### PR TITLE
qemu: added default support to numa (CONFIG_NUMA = yes)

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=4.0.0
-revision=2
+revision=3
 short_desc="Open Source Processor Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
@@ -20,14 +20,15 @@ makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
  $(vopt_if sdl2 SDL2-devel) $(vopt_if gtk3 "gtk+3-devel vte3-devel")
  $(vopt_if spice spice-devel) $(vopt_if virgl virglrenderer-devel)
  $(vopt_if opengl 'libepoxy-devel libdrm-devel MesaLib-devel')
- $(vopt_if smartcard libcacard-devel)"
+ $(vopt_if smartcard libcacard-devel) $(vopt_if numa 'libnuma-devel')"
 
-build_options="gtk3 opengl sdl2 spice virgl smartcard"
-build_options_default="opengl gtk3 virgl smartcard sdl2"
+build_options="gtk3 opengl sdl2 spice virgl smartcard numa"
+build_options_default="opengl gtk3 virgl smartcard sdl2 numa"
 desc_option_sdl2="Enable SDL (2.x) video output"
 desc_option_spice="Enable support for SPICE"
 desc_option_virgl="Enable support for VirGL (A Virtual 3D GPU renderer)"
 desc_option_smartcard="Enable smartcard support"
+desc_option_numa="Enable support for host NUMA"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*|ppc64*) build_options_default+=" spice";;


### PR DESCRIPTION
Enables --numa in qemu configure and add it as a default. NUMA support
is required to set NUMA node binding of guest domains.