### PR TITLE
sharenix: update to 0.11.0a

### DIFF
--- a/srcpkgs/sharenix/template
+++ b/srcpkgs/sharenix/template
@@ -1,6 +1,6 @@
 # Template file for 'sharenix'
 pkgname=sharenix
-version=0.10.3a
+version=0.11.0a
 revision=1
 build_style=go
 go_import_path="github.com/Francesco149/sharenix"
@@ -11,7 +11,7 @@ maintainer="Franc[e]sco <lolisamurai@tfwno.gf>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Francesco149/sharenix"
 distfiles="https://github.com/Francesco149/sharenix/archive/${version}.tar.gz"
-checksum=cd344d0ac1cb956fbd8beedaaaa057bdc5c60c969c9dd92a08f575b7dc6db85b
+checksum=1b868305e38e496e43d0f126954e41999d619c1e7fa4c273b19faddb6f3b7a94
 
 post_install() {
 	vbin sharenix-section


### PR DESCRIPTION
Sharenix is a version behind in the repos right now, I've mostly done this to familiarize myself with github for future package submissions. But this sat out of date for awhile so i figured this would be my first one.