### PR TITLE
youtube-dl: add required dependency: phantomjs

### DIFF
--- a/srcpkgs/youtube-dl/template
+++ b/srcpkgs/youtube-dl/template
@@ -7,7 +7,7 @@ wrksrc="$pkgname"
 build_style=python-module
 pycompile_module="youtube_dl"
 hostmakedepends="python python3"
-depends="python"
+depends="python phantomjs"
 short_desc="CLI program to download videos from YouTube and other sites (Python2)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="Unlicense"
@@ -26,7 +26,7 @@ post_install() {
 
 python3-youtube-dl_package() {
 	archs=noarch
-	depends="python3"
+	depends="python3 phantomjs"
 	pycompile_module="youtube_dl"
 	alternatives="youtube-dl:youtube-dl:/usr/bin/youtube-dl3"
 	short_desc="${short_desc/2/3}"


### PR DESCRIPTION
Some links require `phantomjs` or it will error out with:
```
[ytdl_hook] ERROR: PhantomJS executable not found in PATH, download it from http://phantomjs.org
[ytdl_hook] youtube-dl failed: unexpected error ocurred
Failed to recognize file format.
```