### PR TITLE
[RFC] linux-firmware: add initramfs triggers

### DIFF
--- a/srcpkgs/linux-firmware/linux-firmware-amd.INSTALL
+++ b/srcpkgs/linux-firmware/linux-firmware-amd.INSTALL
@@ -1,0 +1,7 @@
+# Regenerate initramfs.
+case ${ACTION} in
+post)
+	echo "Regenerating initramfs, please wait..."
+	dracut -f -q --regenerate-all
+	;;
+esac

--- a/srcpkgs/linux-firmware/linux-firmware-amd.REMOVE
+++ b/srcpkgs/linux-firmware/linux-firmware-amd.REMOVE
@@ -1,0 +1,7 @@
+# Regenerate initramfs.
+case ${ACTION} in
+purge)
+	echo "Regenerating initramfs, please wait..."
+	dracut -f -q --regenerate-all
+	;;
+esac

--- a/srcpkgs/linux-firmware/linux-firmware-intel.INSTALL
+++ b/srcpkgs/linux-firmware/linux-firmware-intel.INSTALL
@@ -1,0 +1,1 @@
+linux-firmware-amd.INSTALL

--- a/srcpkgs/linux-firmware/linux-firmware-intel.REMOVE
+++ b/srcpkgs/linux-firmware/linux-firmware-intel.REMOVE
@@ -1,0 +1,1 @@
+linux-firmware-amd.REMOVE

--- a/srcpkgs/linux-firmware/linux-firmware-network.INSTALL
+++ b/srcpkgs/linux-firmware/linux-firmware-network.INSTALL
@@ -1,0 +1,1 @@
+linux-firmware-amd.INSTALL

--- a/srcpkgs/linux-firmware/linux-firmware-network.REMOVE
+++ b/srcpkgs/linux-firmware/linux-firmware-network.REMOVE
@@ -1,0 +1,1 @@
+linux-firmware-amd.REMOVE

--- a/srcpkgs/linux-firmware/linux-firmware-nvidia.INSTALL
+++ b/srcpkgs/linux-firmware/linux-firmware-nvidia.INSTALL
@@ -1,0 +1,1 @@
+linux-firmware-amd.INSTALL

--- a/srcpkgs/linux-firmware/linux-firmware-nvidia.REMOVE
+++ b/srcpkgs/linux-firmware/linux-firmware-nvidia.REMOVE
@@ -1,0 +1,1 @@
+linux-firmware-amd.REMOVE

--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
 version=20190514
-revision=1
+revision=2
 _githash=711d3297bac870af42088a467459a0634c1970ca
 archs=noarch
 wrksrc="${pkgname}-${_githash}"


### PR DESCRIPTION
This adds triggers to re-generate initramfs for every sub-package of `linux-firmware`.

The downside of that is that most users have probably all sub-packages installed, thus re-generating initramfs 4 times in a row. However, since it's plausible to only have a subset of these installed, it's more correct to always re-generate.