### PR TITLE
i3-gaps: disable sanitizers

### DIFF
--- a/srcpkgs/i3-gaps/template
+++ b/srcpkgs/i3-gaps/template
@@ -1,10 +1,10 @@
 # Template file for 'i3-gaps'
 pkgname=i3-gaps
 version=4.16.1
-revision=1
+revision=2
 wrksrc="i3-${version}"
 build_style=gnu-configure
-configure_args="--disable-builddir"
+configure_args="--disable-builddir --disable-sanitizers"
 conf_files="/etc/i3/config /etc/i3/config.keycodes"
 hostmakedepends="pkg-config perl git autoconf automake"
 makedepends="pcre-devel yajl-devel libxcb-devel libev-devel


### PR DESCRIPTION
This is supposed to fix a possible memory leak issue. Airblader [recommends it be disabled](https://github.com/Airblader/i3/wiki/Building-from-source#building) for production installations.