### PR TITLE
weechat: update to 2.5.

### DIFF
--- a/srcpkgs/weechat/template
+++ b/srcpkgs/weechat/template
@@ -1,13 +1,13 @@
 # Template file for 'weechat'
 pkgname=weechat
-version=2.4
+version=2.5
 revision=1
 build_style=cmake
 configure_args="-DENABLE_MAN=ON -DENABLE_ENCHANT=ON -DENABLE_PERL=ON
- -DENABLE_LUA=ON -DENABLE_RUBY=ON -DENABLE_RUBY=ON -DENABLE_ASPELL=ON
+ -DENABLE_LUA=ON -DENABLE_RUBY=ON -DENABLE_SPELL=ON
  -DPYTHON_EXECUTABLE=/usr/bin/python2.7
  -DPYTHON_LIBRARY=${XBPS_CROSS_BASE}/usr/lib/libpython2.7.so"
-hostmakedepends="asciidoc libgcrypt-devel pkg-config python tcl-devel"
+hostmakedepends="ruby-asciidoctor libgcrypt-devel pkg-config python tcl-devel"
 makedepends="enchant-devel gnutls-devel libcurl-devel lua-devel python-devel
  ruby-devel tcl-devel perl"
 depends="ca-certificates"
@@ -16,8 +16,8 @@ maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.weechat.org"
 changelog="https://raw.githubusercontent.com/weechat/weechat/master/ChangeLog.adoc"
-distfiles="${homepage}/files/src/${pkgname}-${version}.tar.bz2"
-checksum=61a6afe9849b96e99c1f3cde612d1748a03c807059dad459e3a6acbc5cf100fd
+distfiles="https://www.weechat.org/files/src/weechat-${version}.tar.xz"
+checksum=52c87775c3ff9714a62cfa5b7e13e2fa59bf32829fe083781c1d9c7f1c2d4c27
 lib32disabled=yes
 
 subpackages="weechat-aspell weechat-devel weechat-ruby weechat-python weechat-tcl weechat-lua weechat-perl"
@@ -33,7 +33,7 @@ if [ "$CROSS_BUILD" ]; then
 fi
 
 post_extract() {
-	sed -i '/pkg_search_module/s/ruby-2.2/ruby-2.9 ruby-2.8 ruby-2.7 ruby-2.6 ruby-2.5 ruby-2.4 ruby-2.3 &/' cmake/FindRuby.cmake
+	vsed -i '/pkg_search_module/s/ruby-2.2/ruby-2.9 ruby-2.8 ruby-2.7 ruby-2.6 ruby-2.5 ruby-2.4 ruby-2.3 &/' cmake/FindRuby.cmake
 }
 
 weechat-aspell_package() {
@@ -41,7 +41,7 @@ weechat-aspell_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - aspell/enchant plugin"
 	pkg_install() {
-		vmove usr/lib/weechat/plugins/aspell.so
+		vmove usr/lib/weechat/plugins/spell.so
 	}
 }
 weechat-devel_package() {


### PR DESCRIPTION
* updated and tested (x86_64)
* `-DENABLE_RUBY=ON` was defined twice so removed one
* `ruby-asciidoctor` is needed instead of `asciidoc` to actually generate man-pages
* switched to `.xz` tarball (smaller size)
* reflect upstream's rename of aspell -> spell