### PR TITLE
New Package: odin-0.10.0

### DIFF
--- a/srcpkgs/odin/template
+++ b/srcpkgs/odin/template
@@ -1,0 +1,28 @@
+# Template file for 'odin'
+pkgname=odin
+version=0.10.0
+revision=1
+archs="x86_64*"
+wrksrc="Odin-${version}"
+build_style="gnu-makefile"
+make_use_env=yes
+make_build_target="debug"
+hostmakedepends="pkg-config clang llvm"
+depends="clang llvm"
+short_desc="Fast, concise, readable, pragmatic and open programming language"
+maintainer="Logen Kain <logen@sudotask.com>"
+license="BSD-2-Clause"
+homepage="https://odin-lang.org"
+distfiles="https://github.com/odin-lang/Odin/archive/v${version}.tar.gz"
+checksum=04a1c9e8719281a598cac5e9cc3e5ca2316cc038a8b8f9ae43f514aba967c635
+nopie=yes
+
+do_install() {
+	vmkdir opt/odin
+	vmkdir usr/bin
+	vcopy "shared" opt/odin
+	vcopy "core" opt/odin
+	vcopy "odin" opt/odin
+	vlicense LICENSE
+	ln -s /opt/odin/odin ${DESTDIR}/usr/bin/odin
+}


### PR DESCRIPTION
Odin doesn't seem to have an installer yet and it requires the executable to be local to it's shared and core folders.

I could change it up so it only copies the binary and the two required folders, but odin is still early days so I figure I should leave it all there in case anyone wants to look at it.

EDIT:

Or if future updates requires something else to be kept local to the executable.