### PR TITLE
musl: backport recent ppc64 patches from musl upstream

### DIFF
--- a/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
+++ b/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
@@ -1,0 +1,1 @@
+../../musl/patches/ppc64-vrregset-t-fix-layout.patch

--- a/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
+++ b/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
@@ -1,0 +1,1 @@
+../../musl/patches/ppc64-vrregset-t-vrregs-fix.patch

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=4
+revision=5
 short_desc="Cross toolchain for powerpc64 with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -149,6 +149,10 @@ _musl_build() {
 	[ -f ${wrksrc}/.musl_build_done ] && return 0
 
 	cd ${wrksrc}/musl-${_musl_version}
+
+	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-fix-layout.patch
+	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-vrregs-fix.patch
+
 	msg_normal "Building cross musl libc\n"
 
 	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \

--- a/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
+++ b/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
@@ -1,0 +1,1 @@
+../../musl/patches/ppc64-vrregset-t-fix-layout.patch

--- a/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
+++ b/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
@@ -1,0 +1,1 @@
+../../musl/patches/ppc64-vrregset-t-vrregs-fix.patch

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.30
-revision=4
+revision=5
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -149,6 +149,10 @@ _musl_build() {
 	[ -f ${wrksrc}/.musl_build_done ] && return 0
 
 	cd ${wrksrc}/musl-${_musl_version}
+
+	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-fix-layout.patch
+	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-vrregs-fix.patch
+
 	msg_normal "Building cross musl libc\n"
 
 	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \

--- a/srcpkgs/musl/patches/ppc64-vrregset-t-fix-layout.patch
+++ b/srcpkgs/musl/patches/ppc64-vrregset-t-fix-layout.patch
@@ -1,0 +1,45 @@
+commit 3c59a868956636bc8adafb1b168d090897692532
+Author: Rich Felker <dalias@aerifal.cx>
+Date:   Wed May 22 15:17:12 2019 -0400
+
+    fix vrregset_t layout and member naming on powerpc64
+    
+    the mistaken layout seems to have been adapted from 32-bit powerpc,
+    where vscr and vrsave are packed into the same 128-bit slot in a way
+    that looks like it relies on non-overlapping-ness of the value bits in
+    big endian.
+    
+    the powerpc64 port accounted for the fact that the 64-bit ABI puts
+    each in its own 128-bit slot, but ordered them incorrectly (matching
+    the bit order used on the 32-bit ABI), and failed to account for vscr
+    being padded according to endianness so that it can be accessed via
+    vector moves.
+    
+    in addition to ABI layout, our definition used different logical
+    member layout/naming from glibc, where vscr is a structure to
+    facilitate access as a 32-bit word or a 128-bit vector. the
+    inconsistency here was unintentional, so fix it.
+
+diff --git a/arch/powerpc64/bits/signal.h b/arch/powerpc64/bits/signal.h
+index 34693a68..94c7a327 100644
+--- arch/powerpc64/bits/signal.h
++++ arch/powerpc64/bits/signal.h
+@@ -17,10 +17,14 @@ typedef struct {
+ 
+ typedef struct {
+ 	unsigned __int128 vrregs[32];
+-	unsigned _pad[3];
+-	unsigned vrsave;
+-	unsigned vscr;
+-	unsigned _pad2[3];
++	struct {
++#if __BIG_ENDIAN__
++		unsigned _pad[3], vscr_word;
++#else
++		unsigned vscr_word, _pad[3];
++#endif
++	} vscr;
++	unsigned vrsave, _pad[3];
+ } vrregset_t;
+ 
+ typedef struct sigcontext {

--- a/srcpkgs/musl/patches/ppc64-vrregset-t-vrregs-fix.patch
+++ b/srcpkgs/musl/patches/ppc64-vrregset-t-vrregs-fix.patch
@@ -1,0 +1,29 @@
+commit ac304227bb3ea1787d581f17d76a5f5f3abff51f
+Author: Rich Felker <dalias@aerifal.cx>
+Date:   Wed May 22 18:28:32 2019 -0400
+
+    make powerpc64 vrregset_t logical layout match expected API
+    
+    between v2 and v3 of the powerpc64 port patch, the change was made
+    from a 32x4 array of 32-bit unsigned ints for vrregs[] to a 32-element
+    array of __int128. this mismatches the API applications working with
+    mcontext_t expect from glibc, and seems to have been motivated by a
+    misinterpretation of a comment on how aarch64 did things as a
+    suggestion to do the same on powerpc64.
+
+diff --git a/arch/powerpc64/bits/signal.h b/arch/powerpc64/bits/signal.h
+index 94c7a327..2cc0604c 100644
+--- arch/powerpc64/bits/signal.h
++++ arch/powerpc64/bits/signal.h
+@@ -16,7 +16,10 @@ typedef struct {
+ } fpregset_t;
+ 
+ typedef struct {
+-	unsigned __int128 vrregs[32];
++#ifdef __GNUC__
++	__attribute__((__aligned__(16)))
++#endif
++	unsigned vrregs[32][4];
+ 	struct {
+ #if __BIG_ENDIAN__
+ 		unsigned _pad[3], vscr_word;

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -1,7 +1,7 @@
 # Template file for 'musl'.
 pkgname=musl
 version=1.1.22
-revision=2
+revision=3
 archs="*-musl"
 build_style=gnu-configure
 configure_args="--prefix=/usr --disable-gcc-wrapper"


### PR DESCRIPTION
these are necessary to fix build of libunwind on `ppc*-musl`, which will be PR'd later. They are also necessary for general correctness. Next musl release will automatically remove them.