### PR TITLE
libunwind: add patches for ppc*-musl

### DIFF
--- a/srcpkgs/libunwind/patches/ppc32-musl.patch
+++ b/srcpkgs/libunwind/patches/ppc32-musl.patch
@@ -1,0 +1,198 @@
+--- src/ppc32/Ginit.c
++++ src/ppc32/Ginit.c
+@@ -48,12 +48,12 @@ uc_addr (ucontext_t *uc, int reg)
+   void *addr;
+ 
+   if ((unsigned) (reg - UNW_PPC32_R0) < 32)
+-    addr = &uc->uc_mcontext.uc_regs->gregs[reg - UNW_PPC32_R0];
++    addr = &UC_REGS(*uc)->gregs[reg - UNW_PPC32_R0];
+ 
+   else
+   if ( ((unsigned) (reg - UNW_PPC32_F0) < 32) &&
+        ((unsigned) (reg - UNW_PPC32_F0) >= 0) )
+-    addr = &uc->uc_mcontext.uc_regs->fpregs.fpregs[reg - UNW_PPC32_F0];
++    addr = &UC_REGS(*uc)->fpregs.fpregs[reg - UNW_PPC32_F0];
+ 
+   else
+     {
+@@ -76,7 +76,7 @@ uc_addr (ucontext_t *uc, int reg)
+         default:
+           return NULL;
+         }
+-      addr = &uc->uc_mcontext.uc_regs->gregs[gregs_idx];
++      addr = &UC_REGS(*uc)->gregs[gregs_idx];
+     }
+   return addr;
+ }
+--- src/ppc32/ucontext_i.h
++++ src/ppc32/ucontext_i.h
+@@ -42,87 +42,93 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ //#define MQ_IDX                36
+ #define LINK_IDX        36
+ 
++#ifdef __GLIBC__
++#define UC_REGS(uctx) ((uctx).uc_mcontext.uc_regs)
++#else
++#define UC_REGS(uctx) ((uctx).uc_regs)
++#endif
++
+ /* These are dummy structures used only for obtaining the offsets of the
+    various structure members. */
+ static ucontext_t dmy_ctxt UNUSED;
+ 
+-#define UC_MCONTEXT_GREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[0] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[1] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[2] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[3] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[4] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[5] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[6] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[7] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[8] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[9] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[10] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[11] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[12] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[13] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[14] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[15] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[16] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[17] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[18] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[19] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[20] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[21] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[22] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[23] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[24] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[25] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[26] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[27] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[28] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[29] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[30] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[31] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R0 ((void *)&UC_REGS(dmy_ctxt)->gregs[0] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R1 ((void *)&UC_REGS(dmy_ctxt)->gregs[1] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R2 ((void *)&UC_REGS(dmy_ctxt)->gregs[2] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R3 ((void *)&UC_REGS(dmy_ctxt)->gregs[3] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R4 ((void *)&UC_REGS(dmy_ctxt)->gregs[4] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R5 ((void *)&UC_REGS(dmy_ctxt)->gregs[5] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R6 ((void *)&UC_REGS(dmy_ctxt)->gregs[6] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R7 ((void *)&UC_REGS(dmy_ctxt)->gregs[7] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R8 ((void *)&UC_REGS(dmy_ctxt)->gregs[8] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R9 ((void *)&UC_REGS(dmy_ctxt)->gregs[9] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R10 ((void *)&UC_REGS(dmy_ctxt)->gregs[10] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R11 ((void *)&UC_REGS(dmy_ctxt)->gregs[11] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R12 ((void *)&UC_REGS(dmy_ctxt)->gregs[12] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R13 ((void *)&UC_REGS(dmy_ctxt)->gregs[13] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R14 ((void *)&UC_REGS(dmy_ctxt)->gregs[14] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R15 ((void *)&UC_REGS(dmy_ctxt)->gregs[15] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R16 ((void *)&UC_REGS(dmy_ctxt)->gregs[16] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R17 ((void *)&UC_REGS(dmy_ctxt)->gregs[17] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R18 ((void *)&UC_REGS(dmy_ctxt)->gregs[18] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R19 ((void *)&UC_REGS(dmy_ctxt)->gregs[19] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R20 ((void *)&UC_REGS(dmy_ctxt)->gregs[20] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R21 ((void *)&UC_REGS(dmy_ctxt)->gregs[21] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R22 ((void *)&UC_REGS(dmy_ctxt)->gregs[22] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R23 ((void *)&UC_REGS(dmy_ctxt)->gregs[23] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R24 ((void *)&UC_REGS(dmy_ctxt)->gregs[24] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R25 ((void *)&UC_REGS(dmy_ctxt)->gregs[25] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R26 ((void *)&UC_REGS(dmy_ctxt)->gregs[26] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R27 ((void *)&UC_REGS(dmy_ctxt)->gregs[27] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R28 ((void *)&UC_REGS(dmy_ctxt)->gregs[28] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R29 ((void *)&UC_REGS(dmy_ctxt)->gregs[29] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R30 ((void *)&UC_REGS(dmy_ctxt)->gregs[30] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_R31 ((void *)&UC_REGS(dmy_ctxt)->gregs[31] - (void *)&dmy_ctxt)
+ 
+-#define UC_MCONTEXT_GREGS_MSR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[MSR_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_ORIG_GPR3 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[ORIG_GPR3_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_CTR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[CTR_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_LINK ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[LINK_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_XER ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[XER_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_CCR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[CCR_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_SOFTE ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[SOFTE_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_TRAP ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[TRAP_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_DAR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[DAR_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_DSISR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[DSISR_IDX] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_GREGS_RESULT ((void *)&dmy_ctxt.uc_mcontext.uc_regs->gregs[RESULT_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_MSR ((void *)&UC_REGS(dmy_ctxt)->gregs[MSR_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_ORIG_GPR3 ((void *)&UC_REGS(dmy_ctxt)->gregs[ORIG_GPR3_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_CTR ((void *)&UC_REGS(dmy_ctxt)->gregs[CTR_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_LINK ((void *)&UC_REGS(dmy_ctxt)->gregs[LINK_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_XER ((void *)&UC_REGS(dmy_ctxt)->gregs[XER_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_CCR ((void *)&UC_REGS(dmy_ctxt)->gregs[CCR_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_SOFTE ((void *)&UC_REGS(dmy_ctxt)->gregs[SOFTE_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_TRAP ((void *)&UC_REGS(dmy_ctxt)->gregs[TRAP_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_DAR ((void *)&UC_REGS(dmy_ctxt)->gregs[DAR_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_DSISR ((void *)&UC_REGS(dmy_ctxt)->gregs[DSISR_IDX] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_GREGS_RESULT ((void *)&UC_REGS(dmy_ctxt)->gregs[RESULT_IDX] - (void *)&dmy_ctxt)
+ 
+-#define UC_MCONTEXT_FREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[0] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[1] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[2] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[3] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[4] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[5] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[6] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[7] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[8] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[9] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[10] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[11] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[12] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[13] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[14] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[15] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[16] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[17] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[18] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[19] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[20] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[21] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[22] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[23] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[24] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[25] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[26] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[27] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[28] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[29] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[30] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[31] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_FPSCR ((void *)&dmy_ctxt.uc_mcontext.uc_regs->fpregs.fpregs[32] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R0 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[0] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R1 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[1] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R2 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[2] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R3 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[3] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R4 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[4] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R5 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[5] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R6 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[6] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R7 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[7] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R8 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[8] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R9 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[9] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R10 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[10] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R11 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[11] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R12 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[12] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R13 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[13] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R14 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[14] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R15 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[15] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R16 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[16] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R17 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[17] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R18 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[18] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R19 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[19] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R20 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[20] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R21 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[21] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R22 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[22] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R23 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[23] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R24 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[24] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R25 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[25] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R26 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[26] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R27 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[27] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R28 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[28] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R29 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[29] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R30 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[30] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R31 ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[31] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_FPSCR ((void *)&UC_REGS(dmy_ctxt)->fpregs.fpregs[32] - (void *)&dmy_ctxt)
+ 
+ #endif

--- a/srcpkgs/libunwind/patches/ppc64-musl.patch
+++ b/srcpkgs/libunwind/patches/ppc64-musl.patch
@@ -1,0 +1,114 @@
+--- src/ppc64/Ginit.c
++++ src/ppc64/Ginit.c
+@@ -51,7 +51,7 @@ uc_addr (ucontext_t *uc, int reg)
+     addr = &uc->uc_mcontext.gp_regs[reg - UNW_PPC64_R0];
+ 
+   else if ((unsigned) (reg - UNW_PPC64_F0) < 32)
+-    addr = &uc->uc_mcontext.fp_regs[reg - UNW_PPC64_F0];
++    addr = &(((double *)&uc->uc_mcontext.fp_regs)[reg - UNW_PPC64_F0]);
+ 
+   else if ((unsigned) (reg - UNW_PPC64_V0) < 32)
+     addr = (uc->uc_mcontext.v_regs == 0) ? NULL : &uc->uc_mcontext.v_regs->vrregs[reg - UNW_PPC64_V0][0];
+--- src/ppc64/ucontext_i.h
++++ src/ppc64/ucontext_i.h
+@@ -99,39 +99,39 @@ static vrregset_t dmy_vrregset;
+ #define UC_MCONTEXT_GREGS_DSISR ((void *)&dmy_ctxt.uc_mcontext.gp_regs[DSISR_IDX] - (void *)&dmy_ctxt)
+ #define UC_MCONTEXT_GREGS_RESULT ((void *)&dmy_ctxt.uc_mcontext.gp_regs[RESULT_IDX] - (void *)&dmy_ctxt)
+ 
+-#define UC_MCONTEXT_FREGS_R0 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[0] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R1 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[1] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R2 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[2] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R3 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[3] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R4 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[4] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R5 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[5] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R6 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[6] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R7 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[7] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R8 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[8] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R9 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[9] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R10 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[10] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R11 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[11] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R12 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[12] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R13 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[13] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R14 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[14] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R15 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[15] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R16 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[16] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R17 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[17] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R18 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[18] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R19 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[19] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R20 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[20] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R21 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[21] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R22 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[22] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R23 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[23] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R24 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[24] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R25 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[25] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R26 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[26] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R27 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[27] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R28 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[28] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R29 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[29] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R30 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[30] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_R31 ((void *)&dmy_ctxt.uc_mcontext.fp_regs[31] - (void *)&dmy_ctxt)
+-#define UC_MCONTEXT_FREGS_FPSCR ((void *)&dmy_ctxt.uc_mcontext.fp_regs[32] - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R0 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[0]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R1 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[1]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R2 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[2]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R3 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[3]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R4 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[4]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R5 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[5]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R6 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[6]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R7 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[7]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R8 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[8]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R9 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[9]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R10 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[10]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R11 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[11]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R12 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[12]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R13 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[13]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R14 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[14]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R15 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[15]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R16 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[16]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R17 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[17]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R18 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[18]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R19 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[19]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R20 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[20]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R21 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[21]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R22 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[22]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R23 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[23]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R24 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[24]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R25 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[25]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R26 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[26]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R27 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[27]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R28 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[28]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R29 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[29]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R30 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[30]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_R31 ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[31]) - (void *)&dmy_ctxt)
++#define UC_MCONTEXT_FREGS_FPSCR ((void *)&(((double *)&dmy_ctxt.uc_mcontext.fp_regs)[32]) - (void *)&dmy_ctxt)
+ 
+ #define UC_MCONTEXT_V_REGS ((void *)&dmy_ctxt.uc_mcontext.v_regs - (void *)&dmy_ctxt)
+ 
+--- src/ptrace/_UPT_internal.h
++++ src/ptrace/_UPT_internal.h
+@@ -37,7 +37,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ #include <sys/ptrace.h>
+ #endif
+ #ifdef HAVE_SYS_PROCFS_H
++#if !defined(__GLIBC__) && defined(__powerpc__)
++/* nasty hack to prevent conflict with asm/ptrace.h */
++#define pt_regs musl_pt_regs
+ #include <sys/procfs.h>
++#undef pt_regs
++#else
++#include <sys/procfs.h>
++#endif
+ #endif
+ 
+ #include <errno.h>
+--- src/ptrace/_UPT_reg_offset.c
++++ src/ptrace/_UPT_reg_offset.c
+@@ -32,6 +32,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+ # include <asm/ptrace_offsets.h>
+ #endif
+ 
++#include <asm/ptrace.h>
++
+ const int _UPT_reg_offset[UNW_REG_LAST + 1] =
+   {
+ #ifdef HAVE_ASM_PTRACE_OFFSETS_H

--- a/srcpkgs/libunwind/template
+++ b/srcpkgs/libunwind/template
@@ -12,10 +12,27 @@ homepage="https://www.nongnu.org/libunwind/"
 distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version/rc/-rc}.tar.gz"
 checksum=43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8
 
+# LDFLAGS is necessary because libunwind.so itself uses getcontext/setcontext
+case "$XBPS_TARGET_MACHINE" in
+	ppc*-musl) makedepends+=" libucontext-devel"; LDFLAGS=" -lucontext" ;;
+	*) ;;
+esac
+
 pre_configure() {
 	sed -i /SUBDIRS/s/tests// Makefile.am
 	# libunwind explicitly sets lib64 for ppc64 by default
 	sed -i /libdir/s/lib64/lib/ configure.ac
+
+	# unw_getcontext is just getcontext on ppc*, separate lib for musl
+	# it needs to be here because it's used directly in a macro in a
+	# public header, so things using libunwind need linkage against it
+	case "$XBPS_TARGET_MACHINE" in
+		ppc*-musl)
+			sed -i 's/\-lunwind/\-lunwind \-lucontext/' \
+			 src/unwind/libunwind.pc.in
+		;;
+	esac
+
 	autoreconf -fi
 }
 post_install() {
@@ -24,6 +41,12 @@ post_install() {
 
 libunwind-devel_package() {
 	depends="${sourcepkg}>=${version}"
+
+	case "$XBPS_TARGET_MACHINE" in
+		ppc*-musl) depends+=" libucontext-devel" ;;
+		*) ;;
+	esac
+
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
Requires https://github.com/void-linux/void-packages/pull/12359 first

This patches some internal bits to compile on ppc(64) with musl, where some structures have a different layout.