### PR TITLE
notmuch: update to 0.29.1

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -453,6 +453,10 @@ setup_pkg() {
     export LDFLAGS="$XBPS_LDFLAGS $XBPS_CROSS_LDFLAGS $LDFLAGS"
 
     export BUILD_CC="cc"
+    export BUILD_CXX="c++"
+    export BUILD_CPP="cpp"
+    export BUILD_FC="gfortran"
+    export BUILD_LD="ld"
     export BUILD_CFLAGS="$XBPS_CFLAGS"
     export BUILD_CXXFLAGS="$XBPS_CXXFLAGS"
     export BUILD_CPPFLAGS="$XBPS_CPPFLAGS"

--- a/srcpkgs/notmuch-ruby
+++ b/srcpkgs/notmuch-ruby
@@ -1,0 +1,1 @@
+notmuch

--- a/srcpkgs/notmuch/patches/cross.patch
+++ b/srcpkgs/notmuch/patches/cross.patch
@@ -1,6 +1,20 @@
---- configure.orig
-+++ configure
-@@ -370,7 +370,7 @@
+From 7bb539777d688acd5ca6081919047b60d47566d3 Mon Sep 17 00:00:00 2001
+From: Doan Tran Cong Danh <congdanhqx@gmail.com>
+Date: Mon, 10 Jun 2019 20:30:11 +0700
+Subject: [PATCH] configure: cross compile on Void Linux
+
+- Void Linux ships gmime linked against latest gpgme.
+- default Xapian backend is glass from version 1.4
+- cheat some test by running them on host environment
+---
+ configure | 73 +++----------------------------------------------------
+ 1 file changed, 4 insertions(+), 69 deletions(-)
+
+diff --git a/configure b/configure
+index 8b80f0e0..8e5fd4ce 100755
+--- a/configure
++++ b/configure
+@@ -380,7 +380,7 @@ int main(void) {
      return 0;
  }
  EOF
@@ -9,3 +23,98 @@
         && ./_libversion > _libversion.sh && . ./_libversion.sh
  then
      printf "OK.\n"
+@@ -478,13 +478,7 @@ int main(int argc, char** argv) {
+    Xapian::WritableDatabase db("test.db",Xapian::DB_CREATE_OR_OPEN);
+ }
+ EOF
+-    ${CXX} ${CXXFLAGS_for_sh} ${xapian_cxxflags} _default_backend.cc -o _default_backend ${xapian_ldflags}
+-    ./_default_backend
+-    if [ -f test.db/iamglass ]; then
+-	default_xapian_backend=glass
+-    else
+-	default_xapian_backend=chert
+-    fi
++    default_xapian_backend=glass
+     printf "%s\n" "${default_xapian_backend}";
+     rm -rf test.db _default_backend _default_backend.cc
+ fi
+@@ -499,66 +493,7 @@ if pkg-config --exists "gmime-3.0 > $GMIME_MINVER"; then
+     gmime_ldflags=$(pkg-config --libs gmime-3.0)
+ 
+     printf "Checking for GMime session key extraction support... "
+-
+-    cat > _check_session_keys.c <<EOF
+-#include <gmime/gmime.h>
+-#include <stdio.h>
+-
+-int main () {
+-    GError *error = NULL;
+-    GMimeParser *parser = NULL;
+-    GMimeMultipartEncrypted *body = NULL;
+-    GMimeDecryptResult *decrypt_result = NULL;
+-    GMimeObject *output = NULL;
+-
+-    g_mime_init ();
+-    parser = g_mime_parser_new ();
+-    g_mime_parser_init_with_stream (parser, g_mime_stream_file_open("test/corpora/crypto/basic-encrypted.eml", "r", &error));
+-    if (error) return !! fprintf (stderr, "failed to instantiate parser with test/corpora/crypto/basic-encrypted.eml\n");
+-
+-    body = GMIME_MULTIPART_ENCRYPTED(g_mime_message_get_mime_part (g_mime_parser_construct_message (parser, NULL)));
+-    if (body == NULL) return !!	fprintf (stderr, "did not find a multipart encrypted message\n");
+-
+-    output = g_mime_multipart_encrypted_decrypt (body, GMIME_DECRYPT_EXPORT_SESSION_KEY, NULL, &decrypt_result, &error);
+-    if (error || output == NULL) return !! fprintf (stderr, "decryption failed\n");
+-
+-    if (decrypt_result == NULL) return !! fprintf (stderr, "no GMimeDecryptResult found\n");
+-    if (decrypt_result->session_key == NULL) return !! fprintf (stderr, "GMimeDecryptResult has no session key\n");
+-
+-    printf ("%s\n", decrypt_result->session_key);
+-    return 0;
+-}
+-EOF
+-    if ! TEMP_GPG=$(mktemp -d); then
+-        printf 'No.\nCould not make tempdir for testing session-key support.\n'
+-        errors=$((errors + 1))
+-    elif ${CC} ${CFLAGS} ${gmime_cflags} _check_session_keys.c ${gmime_ldflags} -o _check_session_keys \
+-           && GNUPGHOME=${TEMP_GPG} gpg --batch --quiet --import < test/gnupg-secret-key.asc \
+-           && SESSION_KEY=$(GNUPGHOME=${TEMP_GPG} ./_check_session_keys) \
+-           && [ $SESSION_KEY = 9:0BACD64099D1468AB07C796F0C0AC4851948A658A15B34E803865E9FC635F2F5 ]
+-    then
+-        printf "OK.\n"
+-    else
+-        cat <<EOF
+-No.
+-*** Error: Could not extract session keys from encrypted message.
+-
+-This is likely due to your GMime having been built against a old
+-version of GPGME.
+-
+-Please try to rebuild your version of GMime against a more recent
+-version of GPGME (at least GPGME 1.8.0).
+-EOF
+-        if command -v gpgme-config >/dev/null; then
+-            printf 'Your current GPGME development version is: %s\n' "$(gpgme-config --version)"
+-        else
+-            printf 'You do not have the GPGME development libraries installed.\n'
+-        fi
+-        errors=$((errors + 1))
+-    fi
+-    if [ -n "$TEMP_GPG" -a -d "$TEMP_GPG" ]; then
+-        rm -rf "$TEMP_GPG"
+-    fi
++    printf "OK.\n"
+ else
+     have_gmime=0
+     printf "No.\n"
+@@ -581,7 +516,7 @@ else
+ fi
+ 
+ if ! pkg-config --exists zlib; then
+-  ${CC} -o compat/gen_zlib_pc "$srcdir"/compat/gen_zlib_pc.c >/dev/null 2>&1 &&
++  ${BUILD_CC} -o compat/gen_zlib_pc "$srcdir"/compat/gen_zlib_pc.c >/dev/null 2>&1 &&
+   compat/gen_zlib_pc > compat/zlib.pc &&
+   PKG_CONFIG_PATH="$PKG_CONFIG_PATH":compat &&
+   export PKG_CONFIG_PATH
+-- 
+2.22.0.rc1.479.gd8fdbe21b5
+

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -1,6 +1,6 @@
 # Template file for 'notmuch'
 pkgname=notmuch
-version=0.28.4
+version=0.29.1
 revision=1
 hostmakedepends="perl pkg-config python-devel python3-Sphinx python3-devel"
 makedepends="bash-completion gmime3-devel talloc-devel xapian-core-devel"
@@ -8,13 +8,15 @@ short_desc="Thread-based email index, search, and tagging"
 maintainer="Jan S. <jan.schreib@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://notmuchmail.org"
-distfiles="https://notmuchmail.org/releases/notmuch-${version}.tar.gz"
-checksum=bab1cabb0542ce2bd4b41a15b84a8d81c8dc3332162705ded6f311dd898656ca
+distfiles="https://notmuchmail.org/releases/notmuch-${version}.tar.xz"
+checksum=9846fc8e32d415cee41f6644581a4de7b0d2e6bc98e1ba86db918f061fcfe365
 
 subpackages="libnotmuch libnotmuch-devel notmuch-mutt notmuch-python notmuch-python3"
+patch_args=-Np1
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*|ppc64*)
+		hostmakedepends+=" desktop-file-utils"
 		makedepends+=" emacs"
 		subpackages+=" notmuch-emacs"
 		_args="--emacslispdir=/usr/share/emacs/site-lisp/notmuch
@@ -25,8 +27,6 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 do_configure() {
-	# fool the endianess test
-	sed -i 's|\(util_byte_order\)=.*|\1=1234|' configure
 	./configure --prefix=/usr \
 		--bashcompletiondir=/usr/share/bash-completion/completions \
 		--zshcompletiondir=/usr/share/zsh/site-functions ${_args}
@@ -71,7 +71,11 @@ notmuch-emacs_package() {
 	short_desc+=" - Emacs interface"
 	depends="${sourcepkg}-${version}_${revision} virtual?emacs"
 	pkg_install() {
+		vmove usr/bin/notmuch-emacs-mua
+		vmove usr/share/applications
 		vmove usr/share/emacs/site-lisp
+		vmove usr/share/info/notmuch-emacs*
+		vmove usr/share/man/man1/notmuch-emacs*
 	}
 }
 
@@ -87,6 +91,7 @@ notmuch-mutt_package() {
 }
 
 notmuch-python_package() {
+	archs=noarch
 	depends="libnotmuch>=${version}_${revision}"
 	short_desc+=" - Python2 bindings"
 	pycompile_module="notmuch"
@@ -96,6 +101,7 @@ notmuch-python_package() {
 }
 
 notmuch-python3_package() {
+	archs=noarch
 	depends="libnotmuch>=${version}_${revision}"
 	short_desc+=" - Python3 bindings"
 	pycompile_module="notmuch"

--- a/srcpkgs/notmuch/template
+++ b/srcpkgs/notmuch/template
@@ -26,6 +26,11 @@ case "$XBPS_TARGET_MACHINE" in
 	*) _args="--without-emacs";;
 esac
 
+if [ ! "$CROSS_BUILD" ]; then
+	makedepends+=" ruby-devel"
+	subpackages+=" notmuch-ruby"
+fi
+
 do_configure() {
 	./configure --prefix=/usr \
 		--bashcompletiondir=/usr/share/bash-completion/completions \
@@ -35,7 +40,6 @@ do_configure() {
 do_build() {
 	make ${makejobs} V=1
 	make -C contrib/notmuch-mutt
-	make -C bindings
 	cd bindings/python
 	python2 setup.py build --build-base=build-2
 	python3 setup.py build --build-base=build-3
@@ -43,11 +47,15 @@ do_build() {
 
 do_install() {
 	make DESTDIR=${DESTDIR} install
-	cd bindings/python
+	pushd bindings/python
 	python2 setup.py build --build-base=build-2 \
 		install --prefix=/usr --root=${DESTDIR}
 	python3 setup.py build --build-base=build-3 \
 		install --prefix=/usr --root=${DESTDIR}
+	popd
+	if [ ! "$CROSS_BUILD" ]; then
+		make DESTDIR=${DESTDIR} -C bindings/ruby install
+	fi
 }
 
 libnotmuch_package() {
@@ -107,5 +115,13 @@ notmuch-python3_package() {
 	pycompile_module="notmuch"
 	pkg_install() {
 		vmove ${py3_sitelib}
+	}
+}
+
+notmuch-ruby_package() {
+	depends="libnotmuch>=${version}_${revision} ruby"
+	short_desc+=" - Ruby bindings"
+	pkg_install() {
+		vmove usr/lib/ruby
 	}
 }


### PR DESCRIPTION
While we're at it, also:
- remove old sed for fooling endianess since it's not necessary anymore
- move emacs related file to notmuch-emacs
- mark notmuch-python{,3} as noarch