### PR TITLE
julia: drop ppc64le

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -2,7 +2,7 @@
 pkgname=julia
 version=1.1.1
 revision=2
-archs="i686* x86_64* ppc64le*"
+archs="i686* x86_64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc USE_SYSTEM_LLVM=0 USE_LLVM_SHLIB=1
  USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=1 USE_SYSTEM_LAPACK=1 USE_SYSTEM_GMP=1


### PR DESCRIPTION
This has been broken since 1.1.x and nobody seems to be fixing it, so drop. Other distros have done so already, and the fix seems to be non-trivial. Might reintroduce if it's fixed sometime.