### PR TITLE
mark some rust packages that use `ring` broken on ppc

### DIFF
--- a/srcpkgs/boringtun/template
+++ b/srcpkgs/boringtun/template
@@ -12,6 +12,7 @@ checksum=544c72fc482b636e7f6460bfee205adafc55de534067819e4e4914980f0d1350
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) broken="ioctl function signature differs on glibc and musl" ;;
+	ppc*) broken="ftbfs in ring" ;;
 esac
 
 post_install() {

--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -11,6 +11,10 @@ homepage="https://github.com/NLnetLabs/routinator"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=00d55fcfda6bee6311304415b77347e72e6f65f5f549c57c70876234f67cc0ab
 
+case "$XBPS_TARGET_MACHINE" in
+	ppc*) broken="ftbfs in ring" ;;
+esac
+
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/rust-sccache/template
+++ b/srcpkgs/rust-sccache/template
@@ -12,3 +12,7 @@ license="Apache-2.0"
 homepage="https://crates.io/crates/sccache"
 distfiles="https://static.crates.io/crates/sccache/sccache-${version}.crate"
 checksum=c1e914cab6496ac4ea3ef9e52b2a14661edd313ae3ecad8ce52f3a254aafcc1a
+
+case "$XBPS_TARGET_MACHINE" in
+	ppc*) broken="ftbfs in ring" ;;
+esac


### PR DESCRIPTION
These all use `ring` (directly or indirectly), a rust crypto library that only has platform specific assembly and no support for ppc platforms. I wrote WiP support for ppc* for that lib, so these are temporary, but it will probably take a while to upstream.