### PR TITLE
mark some templates broken

### DIFF
--- a/srcpkgs/Marker/template
+++ b/srcpkgs/Marker/template
@@ -13,3 +13,4 @@ license="GPL-3.0-or-later"
 homepage="https://fabiocolacio.github.io/Marker/"
 distfiles="https://github.com/fabiocolacio/Marker/releases/download/${version}/marker.zip"
 checksum=9038a2f8b976e6bfb199d14dbf60e7281b66e5ee94a6333ca48e89e63e6096ef
+broken="fails lint (ELF in /usr/share/com.github.fabiocolacio.marker/extensions/libscroll-extension.so)"

--- a/srcpkgs/antimicro/template
+++ b/srcpkgs/antimicro/template
@@ -12,6 +12,7 @@ license="GPL-3"
 homepage="https://github.com/AntiMicro/antimicro"
 distfiles="https://github.com/AntiMicro/antimicro/archive/${version}.tar.gz"
 checksum=ef309170612da805992f9194f1973bf38a3174a0856856afedab67f9d927a9ef
+broken="lots of undefined references during linkage"
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-tools-devel"

--- a/srcpkgs/boswars/template
+++ b/srcpkgs/boswars/template
@@ -12,6 +12,7 @@ license="GPL-2.0-or-later"
 homepage="http://boswars.org"
 distfiles="${homepage}/dist/releases/boswars-${version}-src.tar.gz"
 checksum=dc3718f531e9ea413cf37e1333b62a4c5e69f1405502d9c59b9e424635135e3e
+broken="fails lint (ELF in /usr/share)"
 
 post_extract() {
 	#png bugfix for version 2.7, https://savannah.nongnu.org/bugs/?39610

--- a/srcpkgs/cgit/template
+++ b/srcpkgs/cgit/template
@@ -14,6 +14,7 @@ distfiles="https://git.zx2c4.com/cgit/snapshot/cgit-${version}.tar.xz
  https://www.kernel.org/pub/software/scm/git/git-${_git_version}.tar.xz"
 checksum="3c547c146340fb16d4134326e7524bfb28ffa681284f1e3914bde1c27a9182bf
  8b40be383a603147ae29337136c00d1c634bdfdc169a30924a024596a7e30e92"
+broken="fails lint (ELF in /usr/share)"
 
 post_extract() {
 	rm -r git

--- a/srcpkgs/chatty/template
+++ b/srcpkgs/chatty/template
@@ -16,6 +16,7 @@ skip_extraction="chatty.png"
 checksum="
  0286f5987599cbca2862a286fdb89bb4371e6c64e849652a038546c489b68ef7
  8821ea5bca093b01ec244b80a76df95211aa2c151fc6320e0d3e98380108d904"
+broken="http://chatty.github.io/Chatty_icon_256x256.png is 404"
 
 do_build() {
 	gradle shadowJar


### PR DESCRIPTION
These generally suffer from lint failures (ELF in `/usr/share`), `antimicro` also fails to link with undefined references all over the place.