### PR TITLE
gnome-podcasts: broken with current rust (needs a release)

### DIFF
--- a/srcpkgs/gnome-podcasts/template
+++ b/srcpkgs/gnome-podcasts/template
@@ -14,6 +14,7 @@ homepage="https://wiki.gnome.org/Apps/Podcasts"
 distfiles="https://gitlab.gnome.org/World/podcasts/-/archive/${version}/podcasts-${version}.tar.gz"
 checksum=953c63e8184ca1f748418d8a8262d40eaa41047f81e2d2c874a3035d9d9d0e4a
 nocross="rustc cant be crosscompiled as of now"
+broken="broken rust code in release"
 
 export GETTEXT_BIN_DIR=/usr/bin
 export GETTEXT_LIB_DIR="${XBPS_CROSS_BASE}/usr/lib/gettext"


### PR DESCRIPTION
This has been broken because of broken rust code in a while, unfortunately they haven't made a release since.