### PR TITLE
mark some haskell packages broken because of stack

### DIFF
--- a/srcpkgs/amsynth/template
+++ b/srcpkgs/amsynth/template
@@ -12,3 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://amsynth.github.io/"
 distfiles="https://github.com/amsynth/${pkgname}/releases/download/release-${version}/${pkgname}-${version}.tar.bz2"
 checksum=c0d1e11be528366da543363e73363a4b9fd86f72e03d2d22adb3ec355fa61a80
+
+case "$XBPS_TARGET_MACHINE" in
+	ppc*) broken="broken pandoc" ;;
+esac

--- a/srcpkgs/cgrep/template
+++ b/srcpkgs/cgrep/template
@@ -14,3 +14,7 @@ distfiles="https://github.com/awgn/cgrep/archive/v${version}.tar.gz"
 checksum=1c623478e1b93a43eb1f151d20fa1096439a84b6ce7024bb9856f10c6ffeca59
 nopie_files="/usr/bin/cgrep"
 conflicts="codesearch"
+
+case "$XBPS_TARGET_MACHINE" in
+	ppc*) broken="broken stack" ;;
+esac

--- a/srcpkgs/pandoc/template
+++ b/srcpkgs/pandoc/template
@@ -25,6 +25,10 @@ nopie_files="
  /usr/bin/pandoc-citeproc
 "
 
+case "$XBPS_TARGET_MACHINE" in
+	ppc*) broken="broken stack" ;;
+esac
+
 post_extract() {
 	sed -i 's/tasty .*,/tasty,/' pandoc-*/pandoc.cabal
 	sed -i 's/zip-archive .*,/zip-archive,/' pandoc-*/pandoc.cabal


### PR DESCRIPTION
Stack currently does not work 100% on ppc, which means xbps-src cannot build these templates... this will be investigated and fixed later (apparently changes are needed in stack upstream), for now break.