### PR TITLE
pcsxr: update to 1.9.94

### DIFF
--- a/srcpkgs/pcsxr/patches/01_fix-i386-exec-stack.patch
+++ b/srcpkgs/pcsxr/patches/01_fix-i386-exec-stack.patch
@@ -1,0 +1,28 @@
+Description: Fix executable stack on i386
+ Fix is needed only for nasm >= 2.09, not tested on older versions.
+Author: Andrey Rahmatullin <wrar@wrar.name>
+Bug: http://pcsxr.codeplex.com/workitem/7915
+Last-Update: 2011-01-15
+
+--- a/plugins/dfxvideo/Makefile.am
++++ b/plugins/dfxvideo/Makefile.am
+@@ -4,7 +4,7 @@ SUFFIXES = .asm
+ 
+ .asm.lo:
+ 	$(LIBTOOL) --tag=CC --mode=compile \
+-	$(STRIP_FPIC) $(NASM) -f elf -d ELF -I${srcdir}/ $<
++	$(STRIP_FPIC) $(NASM) -f elf32 -d ELF -I${srcdir}/ $<
+ 
+ AM_CPPFLAGS = -DLOCALE_DIR=\"${datadir}/locale/\" \
+ 	-DDATADIR=\"${datadir}/psemu/\" \
+--- a/plugins/dfxvideo/i386.asm
++++ b/plugins/dfxvideo/i386.asm
+@@ -61,7 +61,7 @@ NEWSYM i386_shl10idiv
+ 	mov esp, ebp
+ 	pop ebp
+ 	ret
+-%ifidn __OUTPUT_FORMAT__,elf
++%ifidn __OUTPUT_FORMAT__,elf32
+ section .note.GNU-stack noalloc noexec nowrite progbits
+ %endif
+ 

--- a/srcpkgs/pcsxr/patches/02_disable-ppc-auto-dynarec.patch
+++ b/srcpkgs/pcsxr/patches/02_disable-ppc-auto-dynarec.patch
@@ -1,0 +1,17 @@
+Description: Do not enable dynarec on ppc when built with --enable-dynarec=auto
+ PowerPC dynarec code seems unsupported and not working.
+Author: Andrey Rahmatullin <wrar@wrar.name>
+Forwarded: not-needed
+Last-Update: 2012-03-03
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -220,8 +220,6 @@ if test "x$DYNARECSEL" = xauto; then
+ 		DYNARECSEL="x86"
+ 	elif expr x"$build_cpu" : 'xx86_64' > /dev/null; then
+ 		DYNARECSEL="x86_64"
+-	elif expr x"$build_cpu" : 'xpowerpc' > /dev/null; then
+-		DYNARECSEL="ppc"
+ 	fi
+ fi
+ 

--- a/srcpkgs/pcsxr/patches/05_format-security.patch
+++ b/srcpkgs/pcsxr/patches/05_format-security.patch
@@ -1,0 +1,25 @@
+Description: Fix multiple "format not a string literal" warnings
+Author: Andrey Rahmatullin <wrar@wrar.name>
+Forwarded: no
+Last-Update: 2012-06-15
+
+--- a/gui/GtkGui.c
++++ b/gui/GtkGui.c
+@@ -1114,7 +1114,7 @@ void SysErrorMessage(gchar *primary, gch
+ 				primary,
+ 				NULL);
+ 		gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(message_dialog),
+-				"s", secondary);
++				"%s", secondary);
+ 
+ 		gtk_dialog_run(GTK_DIALOG(message_dialog));
+ 		gtk_widget_destroy(message_dialog);
+@@ -1133,7 +1133,7 @@ void SysInfoMessage(gchar *primary, gcha
+ 				primary,
+ 				NULL);
+ 		gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(message_dialog),
+-				"s", secondary);
++				"%s", secondary);
+ 
+ 		gtk_dialog_run(GTK_DIALOG(message_dialog));
+ 		gtk_widget_destroy(message_dialog);

--- a/srcpkgs/pcsxr/patches/06_warnings.patch
+++ b/srcpkgs/pcsxr/patches/06_warnings.patch
@@ -1,0 +1,44 @@
+Description: Fix some compiler warnings caused by obviously incorrect code
+Author: James Cowgill <jcowgill@debian.org>
+Forwarded: no
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/plugins/dfinput/xkb.c
++++ b/plugins/dfinput/xkb.c
+@@ -46,10 +46,10 @@ void InitKeyboard() {
+     resumeScrSaver = 0;
+     if (g.cfg.PreventScrSaver) {
+         char buf[64];
+-        snprintf(buf, 64, "xdg-screensaver suspend 0x%x > /dev/null 2>&1", window);
++        snprintf(buf, 64, "xdg-screensaver suspend 0x%p > /dev/null 2>&1", window);
+         if (pclose(popen(buf, "r")) == 0) {
+             resumeScrSaver = 1;
+-            printf("Suspending Window ID 0x%x of activating screensaver.\n", window);
++            printf("Suspending Window ID 0x%p of activating screensaver.\n", window);
+         } else {
+             //resumeScrSaver = 0;
+             fprintf(stderr, "Failed to execute xdg-screensaver (maybe not installed?)\n");
+@@ -78,8 +78,8 @@ void DestroyKeyboard() {
+     // Enable screensaver if it was disabled - this could be in different place
+     if (resumeScrSaver) {
+         char buf[64];
+-        printf("Resuming Window ID 0x%x to activate screensaver.\n", window);
+-        snprintf(buf, 64, "xdg-screensaver resume 0x%x", window);
++        printf("Resuming Window ID 0x%p to activate screensaver.\n", window);
++        snprintf(buf, 64, "xdg-screensaver resume 0x%p", window);
+         FILE *phandle = popen(buf, "r");
+         pclose(phandle);
+     }
+--- a/plugins/dfsound/freeze.c
++++ b/plugins/dfsound/freeze.c
+@@ -217,8 +217,8 @@ void LoadStateUnknown(SPUFreeze_t * pF)
+    s_chan[i].bNew=0;
+    s_chan[i].bStop=0;
+    s_chan[i].ADSR.lVolume=0;
+-   s_chan[i].pLoop=(unsigned char *)((int)spuMemC+4096);
+-   s_chan[i].pStart=(unsigned char *)((int)spuMemC+4096);
++   s_chan[i].pLoop=(unsigned char *)(spuMemC+4096);
++   s_chan[i].pStart=(unsigned char *)(spuMemC+4096);
+    s_chan[i].iMute=0;
+    s_chan[i].iIrqDone=0;
+   }

--- a/srcpkgs/pcsxr/patches/10_cross.patch
+++ b/srcpkgs/pcsxr/patches/10_cross.patch
@@ -1,0 +1,21 @@
+Description: Fix cross building from x86 to non-x86
+ Caused by the dynamic recompiler selection confusing build and host
+ architectures.
+Author: Helmut Grohne <helmut@subdivi.de>
+Bug-Debian: https://bugs.debian.org/900917
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/configure.ac
++++ b/configure.ac
+@@ -216,9 +216,9 @@ else
+ fi
+ 
+ if test "x$DYNARECSEL" = xauto; then
+-	if expr x"$build_cpu" : 'xi.86' > /dev/null; then
++	if expr x"$host_cpu" : 'xi.86' > /dev/null; then
+ 		DYNARECSEL="x86"
+-	elif expr x"$build_cpu" : 'xx86_64' > /dev/null; then
++	elif expr x"$host_cpu" : 'xx86_64' > /dev/null; then
+ 		DYNARECSEL="x86_64"
+ 	fi
+ fi

--- a/srcpkgs/pcsxr/patches/cdriso-uncompress2-fix-mgorny.patch
+++ b/srcpkgs/pcsxr/patches/cdriso-uncompress2-fix-mgorny.patch
@@ -9,8 +9,8 @@ Subject: [PATCH] cdriso uncompress2 fix (mgorny);
 
 diff --git a/pcsxr/libpcsxcore/cdriso.c b/pcsxr/libpcsxcore/cdriso.c
 index 318f5ea7..4d6c3370 100644
---- libpcsxcore/cdriso.c
-+++ libpcsxcore/cdriso.c
+--- a/libpcsxcore/cdriso.c
++++ b/libpcsxcore/cdriso.c
 @@ -1219,7 +1219,7 @@ static int cdread_sub_mixed(FILE *f, unsigned int base, void *dest, int sector)
  	return ret;
  }

--- a/srcpkgs/pcsxr/patches/musl-fcntl_h.patch
+++ b/srcpkgs/pcsxr/patches/musl-fcntl_h.patch
@@ -1,5 +1,5 @@
---- plugins/dfinput/pad.c	2013-08-23 01:57:03.000000000 +0200
-+++ plugins/dfinput/pad.c	2015-11-02 11:08:45.328649386 +0100
+--- a/plugins/dfinput/pad.c	2013-08-23 01:57:03.000000000 +0200
++++ b/plugins/dfinput/pad.c	2015-11-02 11:08:45.328649386 +0100
 @@ -22,6 +22,7 @@
  #include <sys/file.h>
  #include <time.h>

--- a/srcpkgs/pcsxr/template
+++ b/srcpkgs/pcsxr/template
@@ -1,22 +1,21 @@
 # Template file for 'pcsxr'
 pkgname=pcsxr
-version=1.9.93
-revision=6
-lib32disabled=yes
+version=1.9.94
+revision=1
 wrksrc="${pkgname}"
 build_style=gnu-configure
 configure_args="--enable-libcdio --enable-opengl"
 hostmakedepends="pkg-config automake libtool intltool glib-devel gettext-devel nasm"
 makedepends="libXv-devel libXtst-devel libcdio-devel SDL-devel gtk+3-devel"
 depends="desktop-file-utils"
-short_desc="A Sony PlayStation (PSX) emulator based on the PCSX-df project"
+short_desc="Sony PlayStation (PSX) emulator based on the PCSX-df project"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://pcsxr.codeplex.com/"
-distfiles="https://sources.archlinux.org/other/community/pcsxr/pcsxr-${version}.tar.bz2"
-checksum=4d114bb8cd6a278d28c35020d62b928be4be7d6a1d45d7da3c808e4a4681fd9d
-
-nocross="https://build.voidlinux.org/builders/aarch64_builder/builds/7365/steps/shell_3/logs/stdio"
+distfiles="http://deb.debian.org/debian/pool/main/p/pcsxr/pcsxr_${version}.orig.tar.xz"
+checksum=8a366b68a7c236443aa75b422bea84b5115f8d8c23e5a78fd6951e643e90f660
+patch_args="-Np1"
+lib32disabled=yes
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
This switches distfiles source as the original does ńot have the new version. It also adds a bunch of patches, including fixes for ppc and so on, from Debian. Also trying enabling cross.