### PR TITLE
libretro-mupen64plus: update to 20190611

### DIFF
--- a/srcpkgs/libretro-mupen64plus-rpi/patches/rpi.patch
+++ b/srcpkgs/libretro-mupen64plus-rpi/patches/rpi.patch
@@ -1,0 +1,24 @@
+--- Makefile
++++ Makefile
+@@ -99,7 +99,7 @@ else ifneq (,$(findstring rpi,$(platform)))
+       GL_LIB := -lGLESv2
+    else
+       LLE = 0
+-      CPUFLAGS += -DVC
++      CPUFLAGS += -DVC -DGL_GLEXT_PROTOTYPES
+       GL_LIB := -L/opt/vc/lib -lbrcmGLESv2
+       EGL_LIB := -lbrcmEGL
+       INCFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos -I/opt/vc/include/interface/vcos/pthreads
+--- libretro-common/include/glsm/glsm.h
++++ libretro-common/include/glsm/glsm.h
+@@ -32,8 +32,8 @@
+ RETRO_BEGIN_DECLS
+ 
+ #ifdef HAVE_OPENGLES2
+-typedef GLfloat GLdouble;
+-typedef GLclampf GLclampd;
++typedef double GLdouble;
++typedef double GLclampd;
+ #endif
+ 
+ #if defined(HAVE_OPENGLES2)

--- a/srcpkgs/libretro-mupen64plus-rpi/patches/types.patch
+++ b/srcpkgs/libretro-mupen64plus-rpi/patches/types.patch
@@ -1,0 +1,29 @@
+This is needed to build on armv6/7 musl.
+--- mupen64plus-core/src/r4300/new_dynarec/new_dynarec.c
++++ mupen64plus-core/src/r4300/new_dynarec/new_dynarec.c
+@@ -25,12 +25,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#if defined(__APPLE__)
+ #include <sys/types.h> // needed for u_int, u_char, etc
+ 
+-#define MAP_ANONYMOUS MAP_ANON
+-#endif
+-
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+--- mupen64plus-core/src/r4300/new_dynarec/new_dynarec_64.c
++++ mupen64plus-core/src/r4300/new_dynarec/new_dynarec_64.c
+@@ -24,10 +24,7 @@
+ #include <string.h>
+ #include <assert.h>
+ 
+-#if defined(__APPLE__)
+ #include <sys/types.h> // needed for u_int, u_char, etc
+-#define MAP_ANONYMOUS MAP_ANON
+-#endif
+ 
+ #include "new_dynarec.h"
+ #include "main/main.h"

--- a/srcpkgs/libretro-mupen64plus-rpi/template
+++ b/srcpkgs/libretro-mupen64plus-rpi/template
@@ -1,0 +1,34 @@
+# Template file for 'libretro-mupen64plus-rpi'
+pkgname=libretro-mupen64plus-rpi
+version=20190611
+revision=1
+archs="armv6l* armv7l*"
+_gitrev=e64ef9d9f214e32341fb7cd9633260fbb44b2326
+wrksrc="mupen64plus-libretro-${_gitrev}"
+hostmakedepends="pkg-config unzip"
+makedepends="rpi-userland-devel zlib-devel"
+short_desc="Libretro port of Mupen64 Plus"
+maintainer="q66 <daniel@octaforge.org>"
+license="GPL-3.0-or-later"
+homepage="http://www.libretro.com/"
+distfiles="https://github.com/libretro/mupen64plus-libretro/archive/${_gitrev}.tar.gz"
+checksum=947abfb1d5ff34d6b22fecfb2df02bd3759fde3f4a0e5d238f65ec7e97d964d4
+conflicts="ĺibretro-mupen64plus>=0"
+
+do_build() {
+	local _args="ARCH=arm"
+
+	case "$XBPS_TARGET_MACHINE" in
+		armv6*) _args+=" platform=rpi";;
+		armv7*) _args+=" platform=rpi2";;
+	esac
+	install -d /opt/vc/lib
+	sed -i "s|-L/opt/vc/lib|-L${XBPS_CROSS_BASE}/opt/vc/lib -Wl,-R /opt/vc/lib|g" Makefile
+	sed -i 's|/opt/vc/include|${XBPS_CROSS_BASE}/opt/vc/include|g' Makefile
+
+	make CC=$CC ${_args} ${makejobs}
+}
+
+do_install() {
+	vinstall mupen64plus_libretro.so 755 usr/lib/libretro
+}

--- a/srcpkgs/libretro-mupen64plus/patches/gl-typedefs.patch
+++ b/srcpkgs/libretro-mupen64plus/patches/gl-typedefs.patch
@@ -1,0 +1,13 @@
+--- libretro-common/include/glsm/glsm.h
++++ libretro-common/include/glsm/glsm.h
+@@ -32,8 +32,8 @@
+ RETRO_BEGIN_DECLS
+ 
+ #ifdef HAVE_OPENGLES2
+-typedef GLfloat GLdouble;
+-typedef GLclampf GLclampd;
++typedef double GLdouble;
++typedef double GLclampd;
+ #endif
+ 
+ #if defined(HAVE_OPENGLES2)

--- a/srcpkgs/libretro-mupen64plus/patches/types.patch
+++ b/srcpkgs/libretro-mupen64plus/patches/types.patch
@@ -1,0 +1,29 @@
+This is needed to build on armv6/7 musl.
+--- mupen64plus-core/src/r4300/new_dynarec/new_dynarec.c
++++ mupen64plus-core/src/r4300/new_dynarec/new_dynarec.c
+@@ -25,12 +25,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#if defined(__APPLE__)
+ #include <sys/types.h> // needed for u_int, u_char, etc
+ 
+-#define MAP_ANONYMOUS MAP_ANON
+-#endif
+-
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+--- mupen64plus-core/src/r4300/new_dynarec/new_dynarec_64.c
++++ mupen64plus-core/src/r4300/new_dynarec/new_dynarec_64.c
+@@ -24,10 +24,7 @@
+ #include <string.h>
+ #include <assert.h>
+ 
+-#if defined(__APPLE__)
+ #include <sys/types.h> // needed for u_int, u_char, etc
+-#define MAP_ANONYMOUS MAP_ANON
+-#endif
+ 
+ #include "new_dynarec.h"
+ #include "main/main.h"

--- a/srcpkgs/libretro-mupen64plus/template
+++ b/srcpkgs/libretro-mupen64plus/template
@@ -1,40 +1,50 @@
 # Template file for 'libretro-mupen64plus'
 pkgname=libretro-mupen64plus
-version=20150204
+version=20190611
 revision=1
-wrksrc="mupen64plus-libretro-master"
-build_options="opengl rpi"
+_gitrev=e64ef9d9f214e32341fb7cd9633260fbb44b2326
+wrksrc="mupen64plus-libretro-${_gitrev}"
 hostmakedepends="pkg-config unzip"
-makedepends="$(vopt_if opengl MesaLib-devel) $(vopt_if rpi rpi-firmware)"
+makedepends="MesaLib-devel zlib-devel"
 short_desc="Libretro port of Mupen64 Plus"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.libretro.com/"
-distfiles="http://ftp.netbsd.org/pub/NetBSD/misc/jmcneill/retroarch/mupen64plus-libretro-${version}.zip"
-checksum=643379eaa840d632cd8fa046fc4858cc8ccd5a57ce5991771ab16f1ef675cee2
+distfiles="https://github.com/libretro/mupen64plus-libretro/archive/${_gitrev}.tar.gz"
+checksum=947abfb1d5ff34d6b22fecfb2df02bd3759fde3f4a0e5d238f65ec7e97d964d4
+conflicts="ĺibretro-mupen64plus-rpi>=0"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*)  build_options_default="opengl";;
-	armv[67]*) build_options_default="rpi";;
-	ppc*) broken="not supported in this release";;
+	i686*) hostmakedepends+=" nasm";;
+esac
+
+build_options="gles gles3"
+
+case "$XBPS_TARGET_MACHINE" in
+	armv*|aarch64*) build_options_default="gles";;
 esac
 
 do_build() {
 	local _args
 
+	# setting ARCH makes sure proper dynarec is selected
 	case "$XBPS_TARGET_MACHINE" in
-		i686*) _args="DYNAREC=x86";;
-		x86_64*) _args="DYNAREC=x86_64";;
-		arm*) _args="DYNAREC=arm";;
+		i686*) _args="ARCH=i686";;
+		arm*) _args="ARCH=arm";;
+		aarch64*) _args="ARCH=aarch64";;
+		x86_64*) _args="ARCH=x86_64";;
+		*) _args="ARCH=${XBPS_TARGET_MACHINE%-musl}";;
 	esac
-	if [ "$build_option_rpi" ]; then
-		install -d /opt/vc/lib
-		_args+=" platform=rpi"
-		sed -i "s|-L/opt/vc/lib|-L${XBPS_CROSS_BASE}/opt/vc/lib -Wl,-R /opt/vc/lib|g" Makefile
-		sed -i 's|/opt/vc/include|${XBPS_CROSS_BASE}/opt/vc/include|g' Makefile
+
+	if [ "$build_option_gles3" ]; then
+		_args+=" FORCE_GLES3=1"
+	elif [ "$builld_option_gles" ]; then
+		_args+=" FORCE_GLES=1"
 	fi
+
 	make CC=$CC ${_args} ${makejobs}
 }
+
 do_install() {
 	vinstall mupen64plus_libretro.so 755 usr/lib/libretro
 }

--- a/srcpkgs/libretro-mupen64plus/update
+++ b/srcpkgs/libretro-mupen64plus/update
@@ -1,1 +1,0 @@
-pkgname=mupen64plus-libretro


### PR DESCRIPTION
Our 2015something version is aging and I don't think it's worth it to do any more fixes on it, especially considering there have been many commits upstream since and updating also allows building on ppc platforms and so on. However, there are no releases, ever, so trying a github commit snapshot (dunno if that's the right thing to do, but it can't be worse than using a random netbsd distfile...)

I also wonder if the default `rpi` option for armv6/7 is right, as that will make it not work on anything but... rpi, which is not exactly a generic target, we have many different ones now. Maybe we should switch that to standard mesa opengl. Thoughts?

I tested cross-compiling to aarch64, but not the others. I'll let the CI handle that.