### PR TITLE
sway: added 'elogind' build option (default disabled).

### DIFF
--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,7 +1,7 @@
 # Template file for 'sway'
 pkgname=sway
 version=1.0
-revision=1
+revision=2
 build_style=meson
 conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc git"
@@ -14,9 +14,12 @@ license="MIT"
 homepage="https://swaywm.org"
 distfiles="https://github.com/swaywm/${pkgname}/archive/${version}.tar.gz"
 checksum=24dafd0f1e630e97a5dd47233841adf856b665e2321d6207acfe6b3002d1bc56
+build_options="elogind"
 
 post_install() {
 	vlicense LICENSE
-	# must be setuid without logind!
-	chmod u+s ${DESTDIR}/usr/bin/sway
+	if [ -z "$build_option_elogind" ]; then
+		# must be setuid without logind!
+		chmod u+s ${DESTDIR}/usr/bin/sway
+	fi
 }


### PR DESCRIPTION
If enabled the sway binary does not need to be setuid.

Signed-off-by: Juan RP <xtraeme@gmail.com>