### PR TITLE
vulkan-loader: update to 1.1.108

### DIFF
--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,7 +1,7 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
 _pkgname=Vulkan-Loader
-version=1.1.106
+version=1.1.108
 revision=1
 wrksrc="${_pkgname}-${version}"
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/v${version}.tar.gz"
-checksum=d48632a5459d21ee5d421cb6ef1611cc263d33cca3ef90d0f598f73d24dfc206
+checksum=16655a1dda5cf09c29e9e6261edac9bfca5953e774f8ef2418617fd1b0aecb29
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr"


### PR DESCRIPTION
Requires Vulkan-Headers-1.1.108. #12421 

---
Why is this package not called 'Vulkan-Loader' in the same vein as the Vulkan-{Headers,Tools,ValidationLayers}?