### PR TITLE
base-files: Mark /usr/lib/sysctl.d/10-void.conf as configuration file

### DIFF
--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.140
-revision=6
+revision=7
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
@@ -25,7 +25,8 @@ conf_files="
 	/etc/group
 	/etc/fstab
 	/etc/crypttab
-	/etc/nsswitch.conf"
+	/etc/nsswitch.conf
+	/usr/lib/sysctl.d/10-void.conf"
 
 replaces="base-directories>=0"
 # New system groups


### PR DESCRIPTION
The `10-void.conf` makes some modifications that can only be undone via rebooting, for example disabling kexec. However, I require kexec since I regularly use it on many of my servers to reboot them. If this file is not marked as a configuration file, it gets overridden on every update undoing all my changes inside. So I have to carefully check after each update, if the file got overridden before I reboot my machines. This is really annoying.