### PR TITLE
build-style/go: make do_install() really fail on errors.

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -41,7 +41,7 @@ do_build() {
 }
 
 do_install() {
-	for f in "$(find "${GOPATH}/bin" -type f -executable)"; do
+	for f in $(find "${GOPATH}/bin" -type f -executable); do
 		vbin "$f"
 	done
 }

--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -41,8 +41,7 @@ do_build() {
 }
 
 do_install() {
-	find "${GOPATH}/bin" -type f -executable | while read line
-	do
-		vbin "${line}"
+	for f in "$(find "${GOPATH}/bin" -type f -executable)"; do
+		vbin "$f"
 	done
 }


### PR DESCRIPTION
This fixes detection of some go packages (doctl) that are
simply empty because it couldn't find the binaries in $GOPATH/bin.

Still affected packages must be fixed, doctl being one of them.