### PR TITLE
cross-vpkg-dummy: differentiate between musl and glibc.

### DIFF
--- a/common/xbps-src/shutils/cross.sh
+++ b/common/xbps-src/shutils/cross.sh
@@ -28,12 +28,12 @@ prepare_cross_sysroot() {
     [ -z "$cross" -o "$cross" = "" ] && return 0
 
     # Check for cross-vpkg-dummy available for the target arch, otherwise build it.
-    pkg_available cross-vpkg-dummy $cross
+    pkg_available 'cross-vpkg-dummy>=0.30_1' $cross
     if [ $? -eq 0 ]; then
         $XBPS_LIBEXECDIR/build.sh cross-vpkg-dummy cross-vpkg-dummy pkg $cross init || return $?
     fi
 
-    check_installed_pkg cross-vpkg-dummy-0.17_1 $cross
+    check_installed_pkg cross-vpkg-dummy-0.30_1 $cross
     [ $? -eq 0 ] && return 0
 
     msg_normal "Installing $cross cross pkg: cross-vpkg-dummy ...\n"

--- a/srcpkgs/cross-vpkg-dummy/template
+++ b/srcpkgs/cross-vpkg-dummy/template
@@ -1,6 +1,6 @@
 # Template file for 'cross-vpkg-dummy'
 pkgname=cross-vpkg-dummy
-version=0.29
+version=0.30
 revision=1
 build_style=meta
 short_desc="Dummy meta-pkg for cross building packages with xbps-src"
@@ -9,10 +9,6 @@ license="Public domain"
 homepage="https://www.voidlinux.org/"
 
 depends="base-files>=0.126"
-
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) depends+=" musl-legacy-compat";;
-esac
 
 provides="
 	kernel-libc-headers-9999_1
@@ -28,10 +24,7 @@ provides="
 	libgomp-devel-9999_1
 	gcc-9999_1
 	gcc-fortran-9999_1
-	gcc-ada-9999_1
-	glibc-9999_1
-	glibc-devel-9999_1
-	musl-9999_1"
+	gcc-ada-9999_1"
 conflicts="
 	kernel-libc-headers>=0
 	binutils>=0
@@ -46,31 +39,29 @@ conflicts="
 	libgomp-devel>=0
 	gcc>=0
 	gcc-fortran>=0
-	gcc-ada>=0
-	glibc>=0
-	glibc-devel>=0
-	musl>=0"
+	gcc-ada>=0"
 shlib_provides="
-	libc.so
-	libc.so.6
-	libm.so.6
-	librt.so.1
-	libpthread.so.0
-	libcrypt.so.1
-	libdl.so.2
-	libresolv.so.2
-	libnsl.so.1
-	libutil.so.1
 	libgcc_s.so.1
 	libgnat-8.so
 	libgnarl-8.so
 	libgomp.so.1
 	libstdc++.so.6
-	libgfortran.so.5
-	ld.so.1
-	ld-linux.so.2
-	ld-linux.so.3
-	ld-linux-x86_64.so.2
-	ld-linux-armhf.so.3
-	ld-linux-aarch64.so.1
-	ld64.so.2"
+	libgfortran.so.5"
+
+case "$XBPS_TARGET_MACHINE" in
+*-musl) depends+=" musl-legacy-compat"
+	provides+=" musl-9999_1 musl-devel-9999_1"
+	conflicts+=" musl>=0"
+	shlib_provides+=" libc.so"
+	;;
+# glibc
+*)	provides+=" glibc-9999_1 glibc-devel-9999_1"
+	conflicts+=" glibc>=0"
+	shlib_provides+=" libc.so.6 libm.so.6 librt.so.1 libpthread.so.0"
+	shlib_provides+=" libcrypt.so.1 libdl.so.2 libresolv.so.2"
+	shlib_provides+=" libnsl.so.1 libutil.so.1"
+	shlib_provides+=" ld-linux.so.2 ld-linux.so.3 ld-linux-x86_64.so.2"
+	shlib_provides+=" ld-linux-armhf.so.3 ld-linux-aarch64.so.1"
+	shlib_provides+=" ld64.so.2 ld.so.1"
+	;;
+esac


### PR DESCRIPTION
A single pkg that provides musl and glibc and conflicts
with both, this is not a great idea.

Differentiate them to avoid issues like:

https://build.voidlinux.org/builders/armv6l-musl_builder/builds/19727/steps/shell_3/logs/stdio

Signed-off-by: Juan RP <xtraeme@gmail.com>