### PR TITLE
zbar: fix qt option handling

### DIFF
--- a/srcpkgs/zbar/template
+++ b/srcpkgs/zbar/template
@@ -1,20 +1,20 @@
 # Template file for 'zbar'
 pkgname=zbar
 version=0.10
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="ac_cv_header_wand_MagickWand_h=yes $(vopt_with qt) --with-gtk"
 hostmakedepends="automake pkg-config libtool gettext-devel python
  $(vopt_if qt 'qt5-qmake qt5-host-tools') glib-devel"
 makedepends="libmagick-devel libXv-devel pygtk-devel v4l-utils-devel
  $(vopt_if qt qt5-x11extras-devel)"
-short_desc="A barcode reading library and application"
+depends="libzbar-${version}_${revision}"
+short_desc="Barcode reading library and application"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="LGPL-2.1-or-later"
 homepage="https://zbar.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/zbar/${version}/${pkgname}-${version}.tar.bz2"
 checksum=234efb39dbbe5cef4189cc76f37afbe3cfcfb45ae52493bfe8e191318bdbadc6
-depends="libzbar-${version}_${revision}"
 
 build_options="qt"
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/zbar/template
+++ b/srcpkgs/zbar/template
@@ -3,7 +3,7 @@ pkgname=zbar
 version=0.10
 revision=7
 build_style=gnu-configure
-configure_args="ac_cv_header_wand_MagickWand_h=yes $(vopt_with qt qt5) --with-gtk"
+configure_args="ac_cv_header_wand_MagickWand_h=yes $(vopt_with qt) --with-gtk"
 hostmakedepends="automake pkg-config libtool gettext-devel python
  $(vopt_if qt 'qt5-qmake qt5-host-tools') glib-devel"
 makedepends="libmagick-devel libXv-devel pygtk-devel v4l-utils-devel


### PR DESCRIPTION
The option in configure is called qt not qt5.