### PR TITLE
gst-plugins-good1: add qt option

### DIFF
--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -6,17 +6,18 @@ wrksrc="${pkgname/1/}-${version}"
 lib32disabled=yes
 build_style=meson
 configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled
- -Dgtk3=$(vopt_if gtk3 enabled disabled)"
+ -Dgtk3=$(vopt_if gtk3 enabled disabled)
+ $(vopt_if qt '-Dqt5=enabled' '-Dqt5=disabled -Dexamples=disabled')"
 # XXX: libdv, dv1394 and shout2 modules.
-hostmakedepends="pkg-config intltool glib-devel qt5-qmake orc qt5-host-tools"
+hostmakedepends="pkg-config intltool glib-devel orc $(vopt_if qt 'qt5-qmake qt5-host-tools')"
 makedepends="
  libpng-devel libxml2-devel libgudev-devel libflac-devel
  libXdamage-devel aalib-devel libcaca-devel
  taglib-devel libsoup-gnome-devel gst-plugins-base1-devel
  pulseaudio-devel orc-devel libXv-devel wavpack-devel
  v4l-utils-devel jack-devel speex-devel libvpx-devel lame-devel
- mpg123-devel twolame-devel $(vopt_if gtk3 gtk+3-devel) qt5-devel
- qt5-declarative-devel  qt5-x11extras-devel qt5-wayland-devel"
+ mpg123-devel twolame-devel $(vopt_if gtk3 gtk+3-devel) $(vopt_if qt 'qt5-devel
+ qt5-declarative-devel  qt5-x11extras-devel qt5-wayland-devel')"
 depends="gst-plugins-base1>=${version}"
 short_desc="GStreamer set of well-maintained good plug-ins (1.x)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -25,5 +26,5 @@ homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
 checksum=654adef33380d604112f702c2927574cfc285e31307b79e584113858838bb0fd
 
-build_options="gtk3"
-build_options_default="gtk3"
+build_options="gtk3 qt"
+build_options_default="gtk3 qt"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,9 +1,8 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
 version=1.16.0
-revision=1
+revision=2
 wrksrc="${pkgname/1/}-${version}"
-lib32disabled=yes
 build_style=meson
 configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled
  -Dgtk3=$(vopt_if gtk3 enabled disabled)
@@ -25,6 +24,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
 checksum=654adef33380d604112f702c2927574cfc285e31307b79e584113858838bb0fd
+lib32disabled=yes
 
 build_options="gtk3 qt"
 build_options_default="gtk3 qt"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -5,7 +5,8 @@ revision=1
 wrksrc="${pkgname/1/}-${version}"
 lib32disabled=yes
 build_style=meson
-configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled"
+configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled
+ -Dgtk3=$(vopt_if gtk3 enabled disabled)"
 # XXX: libdv, dv1394 and shout2 modules.
 hostmakedepends="pkg-config intltool glib-devel qt5-qmake orc qt5-host-tools"
 makedepends="


### PR DESCRIPTION
With qt disabled examples also have to be disabled. Are they needed or could we just skip them all together regardless of qt option?

Also added explicit enable/disable for gtk3 for completeness. Should I just make another pull request for it? They kinda work together.