### PR TITLE
gnome-boxes: add tracker dependency

### DIFF
--- a/srcpkgs/gnome-boxes/template
+++ b/srcpkgs/gnome-boxes/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-boxes'
 pkgname=gnome-boxes
 version=3.32.0.2
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 # missing dependency: ovirt
@@ -11,7 +11,7 @@ makedepends="clutter-gtk-devel freerdp-devel gtk-vnc-devel libarchive-devel
  libglib-devel libgudev-devel libosinfo-devel libsecret-devel libsoup-devel
  libusb-devel libvirt-glib-devel libxml2-devel spice-gtk-devel spice-protocol
  tracker-devel vala-devel webkit2gtk-devel vte3-devel"
-depends="desktop-file-utils hicolor-icon-theme libosinfo libvirt-glib qemu"
+depends="desktop-file-utils hicolor-icon-theme libosinfo libvirt-glib qemu tracker"
 short_desc="GNOME 3 application to access remote or virtual systems"
 maintainer="Rasmus Thomsen <oss@cogitri.dev>"
 license="LGPL-2.0-or-later"


### PR DESCRIPTION
gnome-boxes doesn't run without it, at least not without the rest of gnome