### PR TITLE
mutt: remove alternative

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,7 +1,7 @@
 # Template file for 'mutt'
 pkgname=mutt
 version=1.12.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
  --enable-gpgme --with-regex --with-idn2 --with-ssl --with-sasl --enable-sidebar
@@ -20,31 +20,6 @@ changelog="http://mutt.org/relnotes/1.12"
 distfiles="http://ftp.mutt.org/pub/mutt/${pkgname}-${version}.tar.gz"
 checksum=01c565406ec4ffa85db90b45ece2260b25fac3646cc063bbc20a242c6ed4210c
 
-provides="mutt-0_1"
-# Begin alternatives:
-alternatives="
- mutt:mutt:/usr/bin/mutt-$pkgname
- mutt:pgpewrap:/usr/bin/pgpewrap-$pkgname
- mutt:flea:/usr/bin/flea-$pkgname
- mutt:muttbug:/usr/bin/muttbug-$pkgname
- mutt:smime_keys:/usr/bin/smime_keys-$pkgname
- mutt:flea:/usr/bin/flea-$pkgname
- mutt:muttbug:/usr/bin/muttbug-$pkgname
- mutt:mutt_pgpring:/usr/bin/mutt_pgpring-$pkgname
-
- mutt:pgpewrap.1:/usr/share/man/man1/pgpewrap-${pkgname}.1
- mutt:flea.1:/usr/share/man/man1/flea-${pkgname}.1
- mutt:mutt.1:/usr/share/man/man1/mutt-${pkgname}.1
- mutt:pgpring.1:/usr/share/man/man1/mutt_pgpring-${pkgname}.1
- mutt:muttbug.1:/usr/share/man/man1/muttbug-${pkgname}.1
- mutt:smime_keys.1:/usr/share/man/man1/smime_keys-${pkgname}.1
-
- mutt:mbox.5:/usr/share/man/man5/mbox-${pkgname}.5
- mutt:muttrc.5:/usr/share/man/man5/muttrc-${pkgname}.5
- mutt:mmdf.5:/usr/share/man/man5/mmdf-${pkgname}.5
-"
-# End alternatives
-
 pre_build() {
 	make CC="$BUILD_CC" CFLAGS="$BUILD_CFLAGS -fPIC" CPPFLAGS= mutt_md5
 	make CC="$BUILD_CC" CFLAGS="$BUILD_CFLAGS -fPIC" CPPFLAGS= -C doc
@@ -57,20 +32,4 @@ post_install() {
 	# move dist to examples dir
 	vsconf contrib/gpg.rc Muttrc.gpg.dist
 	mv "${DESTDIR}/etc/$pkgname/Muttrc.dist" "${DESTDIR}/usr/share/examples/${pkgname}"
-
-	# Allows alternatives to work
-	for manpage in "${DESTDIR}"/usr/share/man/man[15]/*; do
-		mv "$manpage" "${manpage%.*}-${pkgname}.${manpage##*.}"
-	done
-	for binary in "${DESTDIR}"/usr/bin/*; do
-		mv "$binary" "${binary}-${pkgname}"
-	done
 }
-
-# REMARKS:
-# Conf file is in a --sysconfdir=/etc/$pkgname/Muttrc and then alternatives to
-# /etc/Muttrc. In addition, a dependency on mime-types is broken by having
-# /etc/dir/ because mutt probably expects the mime information in the same
-# dir as sysconfdir. Thus a symlink is created to deal with this.
-# /etc/Muttrc is not currently in alternatives to prevent inadvertently
-# overwriting configuration.


### PR DESCRIPTION
We used to have mutt alternative, provided by neomutt.
However, from commit edb9bbd0f3, ("neomutt: update to 20171013.",
2017-10-17) neomutt is no longger mutt.

Drop this alternative, so users can have better autocomplete,
let's say by: man 5 mutt<tab> and we can have simpler template.

Signed-off-by: Doan Tran Cong Danh <congdanhqx@gmail.com>