### PR TITLE
New package: ddgtk-0.1

### DIFF
--- a/srcpkgs/ddgtk/template
+++ b/srcpkgs/ddgtk/template
@@ -1,0 +1,13 @@
+# Template file for 'ddgtk'
+pkgname=ddgtk
+version=0.1
+revision=1
+build_style=meson
+hostmakedepends="pkg-config glib glib-devel"
+depends="python3 python3-gobject gtk+3"
+short_desc="GUI frontend for dd to create bootable ISO images for Linux"
+maintainer="reback00 <reback00@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/gort818/ddgtk"
+distfiles="https://github.com/gort818/ddgtk/archive/${version}.tar.gz"
+checksum=0386336681b24d648cdce3daa0c2b83c77a69773296e97a8427b67cbd27531ed


### PR DESCRIPTION
[ddgtk](https://github.com/gort818/ddgtk) is a GUI version of the command line `dd`. It works similar to [unetbootin](https://unetbootin.github.io/) or [Etcher](https://www.balena.io/etcher/). It makes life so much easier!

<img src="https://i.imgur.com/mwcdr3dl.png" />

I use this tool after Etcher started showing annoying ads and stuff.
Hope it is useful.