### PR TITLE
icecat: set nodebug on i686

### DIFF
--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -32,7 +32,7 @@ esac
 CXXFLAGS="-Wno-class-memaccess -Wno-unused-function"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*) broken="https://build.voidlinux.org/builders/i686_builder/builds/18068/steps/shell_3/logs/stdio" ;;
+	i686*) nodebug=yes ;;
 esac
 
 post_extract() {


### PR DESCRIPTION
linker runs out of memory if debug is enabled