### PR TITLE
udisks2: update to 2.8.3.

### DIFF
--- a/common/travis/build.sh
+++ b/common/travis/build.sh
@@ -23,6 +23,8 @@ XBPS_SRCPKGDIR=/hostrepo/srcpkgs XBPS_MASTERDIR=/ chroot_prepare $1 || {
 	exit 1
 }
 
+# Two times due to updating xbps itself
+/hostrepo/xbps-src -H "$HOME"/hostdir bootstrap-update
 /hostrepo/xbps-src -H "$HOME"/hostdir bootstrap-update
 
 PKGS=$(/hostrepo/xbps-src sort-dependencies $(cat /tmp/templates))

--- a/srcpkgs/udisks2/template
+++ b/srcpkgs/udisks2/template
@@ -1,12 +1,12 @@
 # Template file for 'udisks2'
 pkgname=udisks2
-version=2.8.2
-revision=2
+version=2.8.3
+revision=1
 wrksrc="udisks-${version}"
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static --with-udevdir=/usr/lib/udev
- --enable-compile-warnings=minimum --enable-lvm2 --enable-btrfs
+ --enable-lvm2 --enable-btrfs --enable-bcache --enable-vdo
  --enable-lvmcache --enable-zram $(vopt_enable gir introspection)"
 hostmakedepends="docbook-xsl glib-devel libxslt pkg-config
  $(vopt_if gir 'gobject-introspection') polkit"
@@ -18,7 +18,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/udisks"
 changelog="https://raw.githubusercontent.com/storaged-project/udisks/master/NEWS"
 distfiles="https://github.com/storaged-project/udisks/releases/download/udisks-${version}/udisks-${version}.tar.bz2"
-checksum=3d233bc8ddac1b84338280e912ca31b613aadd1efca68a9717f818bb3b038bb6
+checksum=7b80a9a2a37caf3183dad7c5247740abd8b41cbd60c59f0853d8cbf3552cc6a0
 make_dirs="/var/lib/udisks2 0750 root root"
 conf_files="/etc/udisks2/udisks2.conf"
 


### PR DESCRIPTION
Enable support for bcache and vdo.