### PR TITLE
fuse-overlayfs: musl seems to work

### DIFF
--- a/srcpkgs/fuse-overlayfs/template
+++ b/srcpkgs/fuse-overlayfs/template
@@ -1,8 +1,7 @@
 # Template file for 'fuse-overlayfs'
 pkgname=fuse-overlayfs
 version=0.4
-revision=1
-archs="~*-musl"
+revision=2
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
 makedepends="fuse3-devel"


### PR DESCRIPTION
I built the package manually on `x86_64-musl` and ran it with multiple programs that used it, all without issue, so I decided to push change here.