### PR TITLE
hidapi: update to 0.9.0

### DIFF
--- a/srcpkgs/hidapi/template
+++ b/srcpkgs/hidapi/template
@@ -1,22 +1,20 @@
 # Template file for 'hidapi'
 pkgname=hidapi
-_distver=0.8.0
-_patchver=rc1
-version=${_distver}${_patchver}
-revision=2
-wrksrc="${pkgname}-${pkgname}-${_distver}-${_patchver}"
+version=0.9.0
+revision=1
+wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="eudev-libudev-devel libusb-devel"
-short_desc="A Simple library for communicating with USB and Bluetooth HID devices"
+short_desc="Simple library for communicating with USB and Bluetooth HID devices"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="http://www.signal11.us/oss/hidapi/"
-distfiles="https://github.com/signal11/hidapi/archive/hidapi-${_distver}-${_patchver}.tar.gz"
-checksum=3c147200bf48a04c1e927cd81589c5ddceff61e6dac137a605f6ac9793f4af61
+homepage="https://github.com/libusb/hidapi"
+distfiles="https://github.com/libusb/hidapi/archive/hidapi-${version}.tar.gz"
+checksum=630ee1834bdd5c5761ab079fd04f463a89585df8fcae51a7bfe4229b1e02a652
 
 pre_configure() {
-	NOCONFIGURE=1 ./bootstrap
+	./bootstrap
 }
 post_install() {
 	rm -r ${DESTDIR}/usr/share


### PR DESCRIPTION
PR should be fine this way I hope

The original author of hidapi (signal11) has been inactive for a long while now so the project has been forked under the libusb umbrella (https://github.com/libusb/hidapi) for development to continue there.