### PR TITLE
gpgme: update to 1.13.1, enable tests

### DIFF
--- a/srcpkgs/gpgme/template
+++ b/srcpkgs/gpgme/template
@@ -1,10 +1,9 @@
 # Template file for 'gpgme'
 pkgname=gpgme
-version=1.13.0
+version=1.13.1
 revision=1
 build_style=gnu-configure
-configure_args="--enable-fd-passing --disable-gpgconf-test
- --disable-gpg-test --disable-gpgsm-test
+configure_args="--enable-fd-passing
  --with-libgpg-error-prefix=$XBPS_CROSS_BASE/usr
  --with-libassuan-prefix=$XBPS_CROSS_BASE/usr"
 hostmakedepends="gnupg2 pkg-config qt5-host-tools qt5-qmake"
@@ -15,7 +14,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.gnupg.org/software/gpgme/index.html"
 distfiles="https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-${version}.tar.bz2"
-checksum=d4b23e47a9e784a63e029338cce0464a82ce0ae4af852886afda410f9e39c630
+checksum=c4e30b227682374c23cddc7fdb9324a99694d907e79242a25a4deeedb393be46
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) configure_args+=" ac_cv_sys_file_offset_bits=no";;
@@ -27,7 +26,8 @@ esac
 CXXFLAGS+=" -D_GLIBCXX_USE_C99_STDIO=1"
 
 post_extract() {
-	sed -i 's|GPG = gpg|GPG = gpg2|g' tests/gpg/Makefile.* \
+	vsed -i 's|GPG = gpg|GPG = gpg2|g' \
+		tests/gpg/Makefile.* tests/json/Makefile.* \
 		lang/qt/tests/Makefile.* lang/python/tests/Makefile.*
 }
 


### PR DESCRIPTION
The testsuite ran without issues here so I enabled it while updating to 1.13.1.