### PR TITLE
New package: cargo-edit-0.3.2

### DIFF
--- a/srcpkgs/cargo-edit/patches/0001-Cargo.toml-bump-version-to-0.3.2.patch
+++ b/srcpkgs/cargo-edit/patches/0001-Cargo.toml-bump-version-to-0.3.2.patch
@@ -1,0 +1,25 @@
+From 114cc7df87209eeb6ddd550113b1a6c7e439e803 Mon Sep 17 00:00:00 2001
+From: Andronik Ordian <write@reusable.software>
+Date: Tue, 4 Jun 2019 12:23:48 +0200
+Subject: [PATCH 1/2] [Cargo.toml] bump version to 0.3.2
+
+---
+ Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git Cargo.toml Cargo.toml
+index 93366811..7855ca03 100644
+--- Cargo.toml
++++ Cargo.toml
+@@ -25,7 +25,7 @@ license = "Apache-2.0/MIT"
+ name = "cargo-edit"
+ readme = "README.md"
+ repository = "https://github.com/killercup/cargo-edit"
+-version = "0.3.1"
++version = "0.3.2"
+ edition = "2018"
+ 
+ [[bin]]
+-- 
+2.22.0
+

--- a/srcpkgs/cargo-edit/patches/0002-Cargo.lock-update-to-0.3.2.patch
+++ b/srcpkgs/cargo-edit/patches/0002-Cargo.lock-update-to-0.3.2.patch
@@ -1,0 +1,25 @@
+From cbc392d33781e8259d3519648c4fbb344683548a Mon Sep 17 00:00:00 2001
+From: Andronik Ordian <write@reusable.software>
+Date: Tue, 4 Jun 2019 13:04:56 +0200
+Subject: [PATCH 2/2] [Cargo.lock] update to 0.3.2
+
+---
+ Cargo.lock | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git Cargo.lock Cargo.lock
+index 2dadd44c..f9977723 100644
+--- Cargo.lock
++++ Cargo.lock
+@@ -123,7 +123,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "cargo-edit"
+-version = "0.3.1"
++version = "0.3.2"
+ dependencies = [
+  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+-- 
+2.22.0
+

--- a/srcpkgs/cargo-edit/template
+++ b/srcpkgs/cargo-edit/template
@@ -1,0 +1,17 @@
+# Template file for 'cargo-edit'
+pkgname=cargo-edit
+version=0.3.2
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libressl-devel"
+short_desc="Utility for managing cargo dependencies from the command line"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://github.com/killercup/cargo-edit"
+distfiles="https://github.com/killercup/cargo-edit/archive/v${version}.tar.gz"
+checksum=5d239f596d67ee1ef8a71e93aa367ee40d4ae0cc9f45064105959a22727ecf95
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
The patches are required because upstream accidentally messed up the git tag (see https://github.com/killercup/cargo-edit/issues/313). They should be removed with the next update.