### PR TITLE
scrot: update to 1.0.

### DIFF
--- a/srcpkgs/scrot/template
+++ b/srcpkgs/scrot/template
@@ -1,18 +1,17 @@
 # Template file for 'scrot'
 pkgname=scrot
-version=0.9
+version=1.0
 revision=1
 build_style=gnu-configure
 make_install_args="docsdir=/usr/share/doc/scrot"
-hostmakedepends="automake"
-makedepends="libX11-devel giblib-devel imlib2-devel"
+hostmakedepends="automake autoconf-archive"
+makedepends="libX11-devel libXcursor-devel giblib-devel imlib2-devel"
 short_desc="Simple command-line screenshot utility for X"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="MIT"
-homepage="http://scrot.sourcearchive.com/"
-#distfiles="http://linuxbrit.co.uk/downloads/$pkgname-$version.tar.gz"
-distfiles="${DEBIAN_SITE}/main/s/${pkgname}/${pkgname}_${version}.orig.tar.gz"
-checksum=d9b6141c652f4c4c1a9d412d6d57d2045b515e70cd726e4787f5f066c837269e
+homepage="https://github.com/resurrecting-open-source-projects/scrot"
+distfiles="https://github.com/resurrecting-open-source-projects/scrot/archive/${version}.tar.gz"
+checksum=b926cda180ef55cab90d164ea0afa577cd24db8bc8821dc858b4a90d2a9fa09f
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
Scrot has been resurrected within the [resurrecting-open-source-projects](https://github.com/resurrecting-open-source-projects)
github-organization, so use this as upstream now.