### PR TITLE
[DO NOT MERGE] python3-ipython: add replaces python3-prompt_toolkit1.

### DIFF
--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
 version=7.5.0
-revision=1
+revision=2
 archs=noarch
 wrksrc="ipython-${version}"
 build_style=python3-module
@@ -16,6 +16,7 @@ license="BSD-3-Clause"
 homepage="https://ipython.org/"
 distfiles="${PYPI_SITE}/i/ipython/ipython-${version}.tar.gz"
 checksum=e840810029224b56cd0d9e7719dc3b39cf84d577f8ac686547c8ba7a06eeab26
+replaces="python3-prompt_toolkit1>=0"
 
 alternatives="
  ipython:ipython:/usr/bin/ipython3


### PR DESCRIPTION
This package was switched from `python3-prompt_toolkit1` to conflicting package 
`python3-prompt_toolkit2`.
Adding `replaces="python-prompt_toolkit1>=0"` allows to update systems with this package installed again.

fixes #12636