### PR TITLE
traceroute: change the provided alternative to an existing man page

### DIFF
--- a/srcpkgs/traceroute/template
+++ b/srcpkgs/traceroute/template
@@ -1,7 +1,7 @@
 # Template file for 'traceroute'
 pkgname=traceroute
 version=2.1.0
-revision=2
+revision=3
 short_desc="Traces the route taken by packets over an IPv4/IPv6 network"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2"
@@ -11,7 +11,7 @@ checksum=3669d22a34d3f38ed50caba18cd525ba55c5c00d5465f2d20d7472e5d81603b6
 
 alternatives="
  traceroute:traceroute:/usr/bin/linux-traceroute
- traceroute:traceroute.1:/usr/share/man/man1/linux-traceroute.1
+ traceroute:traceroute.8:/usr/share/man/man8/linux-traceroute.8
 "
 
 do_build() {


### PR DESCRIPTION
The package does not provide the linux-traceroute.1 file.