### PR TITLE
deadbeef: update to 1.8.1.

### DIFF
--- a/srcpkgs/deadbeef/template
+++ b/srcpkgs/deadbeef/template
@@ -1,7 +1,7 @@
 # Template file for 'deadbeef'
 pkgname=deadbeef
-version=1.8.0
-revision=2
+version=1.8.1
+revision=1
 build_style=gnu-configure
 configure_args="--disable-oss $(vopt_if gtk3 --disable-gtk2 --disable-gtk3)"
 hostmakedepends="intltool pkg-config yasm $(vopt_if gtk3 glib-devel)"
@@ -9,17 +9,19 @@ makedepends="
  alsa-lib-devel dbus-devel faad2-devel ffmpeg-devel imlib2-devel jansson-devel
  libcddb-devel libcdio-devel libcurl-devel libflac-devel libmad-devel
  libpng-devel libsamplerate-devel libsndfile-devel libvorbis-devel libzip-devel
- mpg123-devel opusfile-devel pulseaudio-devel sndio-devel wavpack-devel
+ mpg123-devel opusfile-devel pulseaudio-devel wavpack-devel
  $(vopt_if gtk3 gtk+3-devel gtk+-devel)"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Ultimate Music Player for GNU/Linux"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="Zlib, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://deadbeef.sourceforge.net"
+changelog="http://deadbeef.sourceforge.net/news0.html"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=5b2d12f9a72c8bc21f88ae1acf9b1b6923a91977b9c06512f9fd424b6e318b96
+checksum=f1d24019eeb5d8d659c60bb590fc9fd2b4b9a96c99cdabc781cf5378a5e41fb4
 build_options="gtk3"
 build_options_default="gtk3"
+LDFLAGS+=" -Wl,-z,stack-size=1048576"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
- sndio support was removed
- the template now has `changelog=`
- increasing the stack size using `LDFLAGS` seems to fix a crash on musl when a specific visualizer is enabled