### PR TITLE
vscode: update to 1.35.1.

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode'
 pkgname=vscode
-version=1.35.0
+version=1.35.1
 revision=1
 hostmakedepends="pkg-config python nodejs-lts yarn"
 makedepends="libxkbfile-devel libsecret-devel"
@@ -10,7 +10,7 @@ maintainer="shizonic <realtiaz@gmail.com>"
 license="MIT"
 homepage="https://code.visualstudio.com/"
 distfiles="https://github.com/Microsoft/vscode/archive/${version}.tar.gz"
-checksum=8bbf959691f6bc20e787c1aa26fb8331462e74f83e861fbe6632f2de6a1bb099
+checksum=6a5bab018f35727897140d410a3d0ebaa640d6c75ee8053a1cd5e02ece5714e9
 patch_args="-Np1"
 
 # Due to electron
@@ -21,8 +21,6 @@ nostrip_files="code-oss"
 # to successfully build vscode.  This sets it to 4GB, but
 # change this number if it still doesn't work for your system.
 _mem_limit="--max_old_space_size=4095"
-
-broken="https://build.voidlinux.org/builders/x86_64_builder/builds/18087/steps/shell_3/logs/stdio"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686)   broken="https://build.voidlinux.org/builders/i686_builder/builds/10486/steps/shell_3/logs/stdio"
@@ -37,6 +35,8 @@ pre_build() {
 
 do_build() {
 	export NODE_OPTIONS="${_mem_limit}"
+	# Remove once nodejs-lts >= 10; see node-gyp issue 1457.
+	export npm_config_build_v8_with_gn="false"
 	yarn install --ignore-engines --arch=${_ARCH}
 	yarn run gulp vscode-linux-${_ARCH}-min
 }


### PR DESCRIPTION
[ci skip]

Included is a fix for the current breakage (courtesy of https://github.com/nodejs/node-gyp/issues/1457#issuecomment-395490546).

I can also cross-build it for i686 on my machine. Can we see if it works again on the buildserver?