### PR TITLE
python-bottle: update to 0.12.17.

### DIFF
--- a/srcpkgs/python-bottle/template
+++ b/srcpkgs/python-bottle/template
@@ -1,6 +1,6 @@
 # Template file for 'python-bottle'
 pkgname=python-bottle
-version=0.12.16
+version=0.12.17
 revision=1
 archs=noarch
 wrksrc="bottle-${version}"
@@ -11,8 +11,8 @@ short_desc="Fast and simple WSGI-framework for small web-applications (Python2)"
 maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
 license="MIT"
 homepage="http://bottlepy.org"
-distfiles="https://github.com/bottlepy/bottle/archive/${version}.tar.gz"
-checksum=@71fc9dbf5159e2f37ae4a79dfa816538cb8ed7a6908f09e1086160055a2d0225
+distfiles="${PYPI_SITE}/b/bottle/bottle-${version}.tar.gz"
+checksum=e9eaa412a60cc3d42ceb42f58d15864d9ed1b92e9d630b8130c871c5bb16107c
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Fetch from PyPI now that the license is included there.