### PR TITLE
etc/defaults.conf: point to xbps-create for supported compression formats

### DIFF
--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -78,11 +78,8 @@ XBPS_SUCMD="sudo /bin/sh -c"
 #XBPS_DEBUG_PKGS=yes
 
 # [OPTIONAL]
-# Set the package compression format. Available formats:
-#  - gzip
-#  - bzip2
-#  - xz (default)
-#  - none (available since xbps-0.48)
+# Set the package compression format (defaults to xz). See xbps-create(1)
+# for the available formats.
 #
 #XBPS_PKG_COMPTYPE=none
 


### PR DESCRIPTION
Seems this didn't get updated in tandem with xbps 0.54.