### PR TITLE
apl: patch build on platforms with not enough ldbl range

### DIFF
--- a/srcpkgs/apl/patches/ppc.patch
+++ b/srcpkgs/apl/patches/ppc.patch
@@ -1,0 +1,43 @@
+This backports the relevant bit of svn revision 1177 to fix build on platforms
+where long double does not have extended range (larger than regular double),
+particularly PowerPC (32 and 64 bit).
+
+On those platforms, the build previously failed with:
+
+Tokenizer.cc:769:4: error: floating constant exceeds range of 'long double' [-Werror=overflow]
+    exp_0_9(1E30)
+    ^~~~~~~
+
+--- src/Tokenizer.cc
++++ src/Tokenizer.cc
+@@ -755,10 +755,10 @@
+        MAX_TOKENIZE_DIGITS = MAX_TOKENIZE_DIGITS_1 - 1   // excl. rounding digit
+      };
+ 
+-#define exp_0_9(x) x ## 0L, x ## 1L, x ## 2L, x ## 3L, x ## 4L,  \
+-                           x ## 5L, x ## 6L, x ## 7L, x ## 8L, x ## 9L, 
++#define exp_0_9(x) x ## 0, x ## 1, x ## 2, x ## 3, x ## 4,  \
++                           x ## 5, x ## 6, x ## 7, x ## 8, x ## 9,
+ 
+-static const long double expo_tab[310] = 
++static const long double expo_tab[309] = 
+ {
+    exp_0_9(1E)   exp_0_9(1E1)  exp_0_9(1E2)  exp_0_9(1E3)  exp_0_9(1E4)
+    exp_0_9(1E5)  exp_0_9(1E6)  exp_0_9(1E7)  exp_0_9(1E8)  exp_0_9(1E9)
+@@ -766,7 +766,7 @@
+    exp_0_9(1E15) exp_0_9(1E16) exp_0_9(1E17) exp_0_9(1E18) exp_0_9(1E19)
+    exp_0_9(1E20) exp_0_9(1E21) exp_0_9(1E22) exp_0_9(1E23) exp_0_9(1E24)
+    exp_0_9(1E25) exp_0_9(1E26) exp_0_9(1E27) exp_0_9(1E28) exp_0_9(1E29)
+-   exp_0_9(1E30)
++   1E300, 1E301, 1E302, 1E303, 1E304, 1E305, 1E306, 1E307, 1E308
+ };
+ 
+ static const long double nexpo_tab[310] = 
+@@ -960,6 +960,7 @@
+ 
+         if (expo > 0)
+            {
++             if (expo > 308)   return false;
+              if (negative)   flt_val = - v * expo_tab[expo];
+              else            flt_val =   v * expo_tab[expo];
+              return true;   // OK


### PR DESCRIPTION
~~Not every system has 80-bit or better extended range/precision long doubles, particularly ppc(64) uses either 128-bit long doubles implemented as a double pair (which has extended precision but not range) or just plain 64-bit that is the same as double (with musl which does not implement the 128-bit precision). On those systems, this patch pretty much reverts to the old code (i.e. before 1.8 update) which was not using precomputed tables.~~

@leahneukirchen 