### PR TITLE
harfbuzz: update to 2.5.2

### DIFF
--- a/srcpkgs/harfbuzz/template
+++ b/srcpkgs/harfbuzz/template
@@ -1,6 +1,6 @@
 # Template file for 'harfbuzz'
 pkgname=harfbuzz
-version=2.4.0
+version=2.5.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-glib --with-freetype --with-cairo --with-icu --with-graphite2"
@@ -11,8 +11,8 @@ maintainer="maxice8 <thinkabit.ukim@gmail.com>"
 license="MIT"
 homepage="http://www.freedesktop.org/wiki/Software/HarfBuzz/"
 changelog="https://raw.githubusercontent.com/harfbuzz/harfbuzz/master/NEWS"
-distfiles="${FREEDESKTOP_SITE}/harfbuzz/release/${pkgname}-${version}.tar.bz2"
-checksum=b470eff9dd5b596edf078596b46a1f83c179449f051a469430afc15869db336f
+distfiles="${FREEDESKTOP_SITE}/harfbuzz/release/${pkgname}-${version}.tar.xz"
+checksum=7c8fcf9a2bbe3df5ed9650060d89f9b7cfd40ec5729671447ace8b0505527e8b
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
The .bz2 is no longer available.