### PR TITLE
ibus-bamboo: update to 0.5.0

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.4.9
+version=0.5.0
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="4cfb282814216d7dc313f6a66b6a91a84a902b35d2cb1134df4e13a606036585"
+checksum="5a63a064221ca685b97fc770fadd4d62005315a391f29c95162b4322870db2e7"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
- Fix crash with Chromium ForwardKeyEvent api