### PR TITLE
py-spy: update to 0.1.11.

### DIFF
--- a/srcpkgs/py-spy/template
+++ b/srcpkgs/py-spy/template
@@ -1,20 +1,12 @@
 # Template file for 'py-spy'
 pkgname=py-spy
-version=0.1.10
+version=0.1.11
 revision=1
-hostmakedepends="cargo"
+build_style=cargo
 short_desc="Sampling profiler for Python programs"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/benfred/py-spy"
 distfiles="https://github.com/benfred/py-spy/archive/v${version}.tar.gz"
-checksum=ef9af58c5f08d408cb3f5a318ddf024db58f0aead158cade5171b97acaae1abc
-nocross=yes
-
-do_build() {
-	cargo build --release ${makejobs}
-}
-
-do_install() {
-	vbin target/release/${pkgname}
-}
+checksum=399a1be66414c2f1a3d57b20d1b219393e0dfd5370815b2c0d1406fa0886917e
+nocross="Could not compile remoteprocess"


### PR DESCRIPTION
and let `build_style=cargo` handle packaging.