### PR TITLE
telegram-desktop: add explicit dependency on libappindicator

### DIFF
--- a/srcpkgs/telegram-desktop/template
+++ b/srcpkgs/telegram-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'telegram-desktop'
 pkgname=telegram-desktop
 version=1.7.7
-revision=2
+revision=3
 _libtgvoip_commit=a19a0aff644127d8089f6a4ac18119ec5247dbd0
 _GSL_commit=d846fe50a3f0bb7767c7e087a05f4be95f4da0ec
 _variant_commit=550ac2f159ca883d360c196149b466955c77a573
@@ -19,7 +19,7 @@ makedepends="alsa-lib-devel ffmpeg-devel gtk+3-devel libappindicator-devel
  libdbusmenu-glib-devel libopenal-devel minizip-devel opus-devel xxHash-devel
  $(vopt_if pulseaudio 'pulseaudio-devel') qt5-devel range-v3 libva-devel
  rapidjson"
-depends="qt5-imageformats qt5>=5.11.3<5.11.4"
+depends="qt5-imageformats qt5>=5.11.3<5.11.4 libappindicator"
 short_desc="Telegram Desktop messaging app"
 maintainer="John <johnz@posteo.net>"
 license="GPL-3.0-or-later WITH OpenSSL"


### PR DESCRIPTION
I don't know why, but telegram-desktop doesn't depend on libappindicator, despite it presence in makedepeds.
![image](https://user-images.githubusercontent.com/4840430/60293985-077f4180-9929-11e9-80c3-b0cfde07dca7.png)
