### PR TITLE
eudev: adjust _UDEV_VERSION

### DIFF
--- a/srcpkgs/eudev/template
+++ b/srcpkgs/eudev/template
@@ -1,10 +1,10 @@
 # Template file for 'eudev'
 
-_UDEV_VERSION="220" # compatible udev version provided
+_UDEV_VERSION="228" # compatible udev version provided
 
 pkgname=eudev
 version=3.2.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-hwdb --enable-manpages --disable-introspection"
 hostmakedepends="automake libtool pkg-config gperf libxslt docbook-xsl"


### PR DESCRIPTION
With v3.2.8, UDEV_VERSION is now at 228:
```
$ udevadm version
228
```