### PR TITLE
gcc, cross-powerpc*-musl: remove some harmless but leftover sed

### DIFF
--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -93,9 +93,6 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/libgcc-musl-ldbl128-config.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 
-	# REMOVE WITH 9.1
-	sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
-
 	msg_normal "Building cross gcc bootstrap\n"
 
 	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -90,9 +90,6 @@ _gcc_bootstrap() {
 
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
 
-	# REMOVE WITH 9.1
-	sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
-
 	msg_normal "Building cross gcc bootstrap\n"
 
 	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -90,9 +90,6 @@ _gcc_bootstrap() {
 
 	sed -i 's/lib64/lib/' gcc/config/rs6000/linux64.h
 
-	# REMOVE WITH 9.1
-	sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
-
 	msg_normal "Building cross gcc bootstrap\n"
 
 	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -164,12 +164,6 @@ pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl) patch -p1 -i ${FILESDIR}/libgnarl-musl.patch ;;
 	esac
-	# REMOVE WITH 9.1
-	case "$XBPS_TARGET_MACHINE" in
-		ppc*-musl)
-			sed -i 's/ \-D__gnu_linux__//' gcc/config/rs6000/sysv4.h
-			;;
-	esac
 }
 do_configure() {
 	local _langs _args _hash


### PR DESCRIPTION
This was added in 8.3 to mitigate an incorrect macro being defined on musl. However, this code was reworked and fixed upstream in the meantime, so remove that. It's harmless because it doesn't match anything anymore, but better not keep it around.