### PR TITLE
teamspeak3: update to 3.3.0

### DIFF
--- a/srcpkgs/teamspeak3/template
+++ b/srcpkgs/teamspeak3/template
@@ -1,6 +1,6 @@
 # Template file for 'teamspeak3'
 pkgname=teamspeak3
-version=3.2.5
+version=3.3.0
 revision=1
 archs="i686 x86_64"
 wrksrc=teamspeak3
@@ -17,12 +17,12 @@ noverifyrdeps=yes
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_pkg="TeamSpeak3-Client-linux_amd64-${version}"
-	distfiles="http://dl.4players.de/ts/releases/${version}/${_pkg}.run"
-	checksum=fc29f1bc351a9e993a69c5134d3d7c48d3149f500f3b6d816a97a59b7c41f60c
+	distfiles="https://files.teamspeak-services.com/releases/client/${version}/${_pkg}.run"
+	checksum=0a8d31e59bb140fd3c9221286c75fb9a68fbf97530f88ab6f311932b5733488c
 elif [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	_pkg="TeamSpeak3-Client-linux_x86-${version}"
-	distfiles="http://dl.4players.de/ts/releases/${version}/${_pkg}.run"
-	checksum=6b34e0dce039259c7ed0aec6b15b157379d4690ffcaa6938fde18840f883c6f3
+	distfiles="https://files.teamspeak-services.com/releases/client/${version}/${_pkg}.run"
+	checksum=2506871bc4382a16086df41c469fd7a4445e644927d9eaca1e876f7b30659c12
 else
 	broken="No known upstream client for this architecture"
 fi
@@ -38,8 +38,8 @@ do_install() {
 	# Set proper permissions
 	find -type d | xargs chmod 755
 	find -type f | xargs chmod 644
-	find -name '*.so' | xargs chmod 755
-	chmod +x ts3client*
+	find -name '*.so*' | xargs chmod 755
+	chmod +x ts3client* package_inst QtWebEngineProcess
 
 	vmkdir "usr/lib/teamspeak3"
 	vcopy * "usr/lib/teamspeak3"


### PR DESCRIPTION
I intend to eventually cleanup the template on this in a future update,and I'm actually unsure if TS3 is still not redistributable, i'll look over the license as well. For now i left that there. Major change is just to the new download locations and the QtWebEngine stuff.