### PR TITLE
gcc: re-add patch to fix relocation errors in libgomp dependants

### DIFF
--- a/srcpkgs/gcc/patches/invalid_tls_model.patch
+++ b/srcpkgs/gcc/patches/invalid_tls_model.patch
@@ -1,0 +1,26 @@
+--- libgomp/configure.tgt	2018-11-08 18:13:04.000000000 +0100
++++ libgomp/configure.tgt	2019-06-29 20:06:31.972950350 +0200
+@@ -10,23 +10,6 @@
+ #  XCFLAGS		Add extra compile flags to use.
+ #  XLDFLAGS		Add extra link flags to use.
+ 
+-# Optimize TLS usage by avoiding the overhead of dynamic allocation.
+-if test $gcc_cv_have_tls = yes ; then
+-  case "${target}" in
+-
+-    *-*-k*bsd*-gnu*)
+-	;;
+-
+-    *-*-linux* | *-*-gnu*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=initial-exec -DUSING_INITIAL_EXEC_TLS"
+-	;;
+-
+-    *-*-rtems*)
+-	XCFLAGS="${XCFLAGS} -ftls-model=local-exec"
+-	;;
+-  esac
+-fi
+-
+ # Since we require POSIX threads, assume a POSIX system by default.
+ config_path="posix"
+ 

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.19
 
 pkgname=gcc
 version=${_minorver}.0
-revision=1
+revision=2
 short_desc="GNU Compiler Collection"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="http://gcc.gnu.org"


### PR DESCRIPTION
was previously added in 75fe6cb0497347aefead33b84a789897360a9116

It is needed at least for python3-Pillow on x86_64-musl