### PR TITLE
cross-powerpc*: bump version if necessary

### DIFF
--- a/srcpkgs/cross-powerpc-linux-gnu/template
+++ b/srcpkgs/cross-powerpc-linux-gnu/template
@@ -10,8 +10,8 @@ _archflags="-mcpu=powerpc -msecure-plt"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.30
-revision=3
+version=0.31
+revision=1
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
 homepage="http://www.voidlinux.org"

--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -11,8 +11,8 @@ _archflags="-mcpu=powerpc -msecure-plt"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.30
-revision=6
+version=0.31
+revision=1
 
 short_desc="Cross toolchain for PowerPC (musl)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -8,8 +8,8 @@ _triplet="powerpc64-linux-musl"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.30
-revision=5
+version=0.31
+revision=1
 short_desc="Cross toolchain for powerpc64 with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -8,8 +8,8 @@ _triplet="powerpc64le-linux-musl"
 _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
-version=0.30
-revision=5
+version=0.31
+revision=1
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"


### PR DESCRIPTION
Looks like these four were forgotten, therefore weren't properly rebuilt for gcc 9.1 - synchronize their versions with the other crosstoolchains.

@pullmoll