### PR TITLE
qemu{,-user-static}: fix mremap(2) errno codes

### DIFF
--- a/srcpkgs/qemu-user-static/template
+++ b/srcpkgs/qemu-user-static/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu-user-static'
 pkgname=qemu-user-static
 version=4.0.0
-revision=1
+revision=2
 wrksrc="qemu-${version}"
 hostmakedepends="pkg-config automake python"
 makedepends="dtc-devel libglib-static pixman-devel libuuid-devel"

--- a/srcpkgs/qemu/patches/mmap-mremap-efault.patch
+++ b/srcpkgs/qemu/patches/mmap-mremap-efault.patch
@@ -1,0 +1,41 @@
+Source: @pullmoll
+Upstream: no
+Reason: errno=EFAULT when the address passed to mremap(2) is not valid
+
+See Rich Felker's comment at https://www.openwall.com/lists/musl/2017/06/21/2 for
+why we need to return errno as described in man mremap(2) from qemu-user-static.
+Also speed up the loop when checking for increasing the mappings size to go
+in steps of TARGET_PAGE_SIZE and OR-in a check for the very last byte of the range.
+
+--- linux-user/mmap.c	2019-04-23 20:14:46.000000000 +0200
++++ linux-user/mmap.c	2019-06-30 16:31:26.545637450 +0200
+@@ -692,7 +692,7 @@
+     if (!guest_range_valid(old_addr, old_size) ||
+         ((flags & MREMAP_FIXED) &&
+          !guest_range_valid(new_addr, new_size))) {
+-        errno = ENOMEM;
++        errno = EFAULT;
+         return -1;
+     }
+ 
+@@ -728,9 +728,10 @@
+             abi_ulong addr;
+             for (addr = old_addr + old_size;
+                  addr < old_addr + new_size;
+-                 addr++) {
++                 addr += TARGET_PAGE_SIZE) {
+                 prot |= page_get_flags(addr);
+             }
++            prot |= page_get_flags(old_addr + new_size - 1);
+         }
+         if (prot == 0) {
+             host_addr = mremap(g2h(old_addr), old_size, new_size, flags);
+@@ -738,7 +739,7 @@
+                 mmap_reserve(old_addr + old_size, new_size - old_size);
+             }
+         } else {
+-            errno = ENOMEM;
++            errno = EFAULT;
+             host_addr = MAP_FAILED;
+         }
+         /* Check if address fits target address space */

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=4.0.0
-revision=3
+revision=4
 short_desc="Open Source Processor Emulator"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -36,14 +36,7 @@ CXXFLAGS="-Wno-expansion-to-defined"
 
 # Package build options
 build_options="gir wayland x11 jit sampling_profiler"
-build_options_default="wayland x11"
-
-case "$XBPS_TARGET_MACHINE" in
-	arm*-musl) # cross building hangs for hours in g-ir-scanner-qemuwrapper
-		broken="cross compiling from x86_64 to arm*-musl stalls the builders"
-		;;
-	*) build_options_default+=" gir"
-esac
+build_options_default="gir wayland x11"
 
 desc_option_jit="Enable JustInTime JS support"
 desc_option_sampling_profiler="Toggle sampling profiler support (disabled on musl)"


### PR DESCRIPTION
This fixes issue #11426 and we can build `webkit2gtk` for all targets.
Would be nice if someone can confirm my results, i.e. build `qemu-user-static` and cross build `webkit2gtk` for `armv6l-musl` and/or `armv7l-musl`.

Note: the patches are shared between `qemu` and `qemu-user-static`.
