### PR TITLE
libtool: patch the libtool script for native envs when cross

### DIFF
--- a/srcpkgs/libtool/template
+++ b/srcpkgs/libtool/template
@@ -1,15 +1,15 @@
-# Template build file for 'libtool'
+# Template file for 'libtool'
 pkgname=libtool
 version=2.4.6
-revision=2
+revision=3
+build_style=gnu-configure
 hostmakedepends="perl automake help2man"
 depends="tar sed"
-build_style=gnu-configure
-homepage="http://www.gnu.org/software/libtool"
-distfiles="${GNU_SITE}/libtool/$pkgname-$version.tar.xz"
 short_desc="Generic library support script"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2"
+homepage="http://www.gnu.org/software/libtool"
+distfiles="${GNU_SITE}/libtool/$pkgname-$version.tar.xz"
 checksum=7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f
 
 pre_configure() {
@@ -17,6 +17,41 @@ pre_configure() {
 	./bootstrap --force
 }
 
+post_install() {
+	local _canonical_host _host_os
+
+	# this is necessary, because when cross building, libtool will pick up
+	# the binary names of the crosstoolchain, which are prefixed with the
+	# short triplet (i.e. arch-linux-env instead of arch-unknown-linux-env)
+	# and those are not present in a real native environment; also the
+	# sysroot var will be set and cflags will include extra cross-related
+	# things that need to go; the target libtool script is meant to be used
+	# in native environments, not in cross environments, so patch the script
+	if [ "$CROSS_BUILD" ]; then
+		# e.g. AR="armv7l-linux-gnueabihf-ar" becomes AR="ar"
+		vsed -i -e "s,=\"${XBPS_CROSS_TRIPLET}\-,=\",g" \
+		 ${PKGDESTDIR}/usr/bin/libtool
+
+		# clear out any sysroot present
+		vsed -i -e "s,^lt_sysroot=.*,lt_sysroot=," \
+		 ${PKGDESTDIR}/usr/bin/libtool
+
+		# clear out sysroot include path
+		vsed -i -e "s,\-I${XBPS_CROSS_BASE}/usr/include,,g" \
+		 ${PKGDESTDIR}/usr/bin/libtool
+
+		# canonicalize host_alias, replace build(_alias,_os)
+		_canonical_host=$(grep "^host=" ${PKGDESTDIR}/usr/bin/libtool | sed 's/host=//')
+		_host_os=$(grep "^host_os=" ${PKGDESTDIR}/usr/bin/libtool | sed 's/host_os=//')
+		vsed -i \
+		 -e "s,^host_alias=.*,host_alias=${_canonical_host}," \
+		 -e "s,^host=.*,host=${_canonical_host}," \
+		 -e "s,^build_alias=.*,build_alias=${_canonical_host}," \
+		 -e "s,^build=.*,build=${_canonical_host}," \
+		 -e "s,^build_os=.*,build_os=${_host_os}," \
+		 ${PKGDESTDIR}/usr/bin/libtool
+	fi
+}
 
 libltdl-devel_package() {
 	depends="libltdl-${version}_${revision}"


### PR DESCRIPTION
When libtool is cross compiled, it introduces assumptions about the cross toolchain into the resulting /usr/bin/libtool script, which prevents the script from working when used on the target machine in a "native" environment.

The reason for this is primarily that the "short triplet" versions of the binutils tools do not exist in the target system, only in the crosstoolchain. Even if they did though, this would still be wrong.

This impacts some real packages, for example libtommath does not build when built natively in an environment for which libtool was cross compiled.