### PR TITLE
New package: azote-1.1.2

### DIFF
--- a/srcpkgs/azote/template
+++ b/srcpkgs/azote/template
@@ -1,0 +1,28 @@
+# Template file for 'azote'
+pkgname=azote
+version=1.1.1
+revision=1
+archs=noarch
+build_style=python3-module
+pycompile_module="azote"
+hostmakedepends="python3-setuptools"
+depends="python3>=3.5 python3-setuptools python3-gobject python3-Pillow gtk+3 feh xrandr wmctrl"
+short_desc="Wallpaper manager for Sway, i3 and some other WMs"
+maintainer="Piotr Miller <nwg.piotr@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/nwg-piotr/azote"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=f7c818b11d3add7af9388589fc6658b0121772acdf899a5ba4a275d082621a63
+
+do_install() {
+	python3 setup.py install --prefix=/usr --root=${DESTDIR} ${make_install_args}
+	vmkdir usr/bin
+	vmkdir usr/share/${pkgname}
+	vmkdir usr/share/applications
+
+	vcopy "dist/${pkgname}.svg" usr/share/${pkgname}
+	vcopy "dist/${pkgname}-void.sh" usr/share/${pkgname}
+	vcopy "dist/${pkgname}.desktop" usr/share/applications
+
+	ln -sf /usr/share/${pkgname}/${pkgname}-void.sh ${DESTDIR}/usr/bin/${pkgname}
+}

--- a/srcpkgs/azote/template
+++ b/srcpkgs/azote/template
@@ -1,6 +1,6 @@
 # Template file for 'azote'
 pkgname=azote
-version=1.1.1
+version=1.1.2
 revision=1
 archs=noarch
 build_style=python3-module
@@ -12,10 +12,9 @@ maintainer="Piotr Miller <nwg.piotr@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/nwg-piotr/azote"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=f7c818b11d3add7af9388589fc6658b0121772acdf899a5ba4a275d082621a63
+checksum=2caca782aa3b508c650dcdd44d49a183ac95282748edd6b960945c78986d6105
 
-do_install() {
-	python3 setup.py install --prefix=/usr --root=${DESTDIR} ${make_install_args}
+post_install() {
 	vmkdir usr/bin
 	vmkdir usr/share/${pkgname}
 	vmkdir usr/share/applications


### PR DESCRIPTION
Hi,
I was missing a wallpaper browser and setter on Sway, and it resulted in [this project](https://github.com/nwg-piotr/azote). It's a GTK+3 GUI to browse images, and set them with the `swaybg` command. For the program to work on other WMs, it's also capable of using `feh` as the background setter. I hope you'll like it, and the template is acceptable. :)