### PR TITLE
i2pd: update to 2.27.0.

### DIFF
--- a/srcpkgs/i2pd/template
+++ b/srcpkgs/i2pd/template
@@ -1,6 +1,6 @@
 # Template file for 'i2pd'
 pkgname=i2pd
-version=2.26.0
+version=2.27.0
 revision=1
 build_style=gnu-makefile
 make_build_args="USE_UPNP=yes"
@@ -12,7 +12,8 @@ license="BSD-3-Clause"
 homepage="https://i2pd.website/"
 changelog="https://raw.githubusercontent.com/PurpleI2P/i2pd/openssl/ChangeLog"
 distfiles="https://github.com/PurpleI2P/i2pd/archive/${version}.tar.gz"
-checksum=2ae18978c8796bb6b45bc8cfe4e1f25377e0cfc9fcf9f46054b09dc3384eef63
+checksum=46aa20760c85e3c5bf79229cd86b75a4c7e163271d400d0f104913d64cb8e093
+disable_parallel_build=yes
 
 conf_files="
  /etc/i2pd/i2pd.conf


### PR DESCRIPTION
Even though my local build ran fine, my fork's travis ran into a couple of issues with parallel building. So re-add `disable_parallel_build=yes`.