### PR TITLE
add patches to fix kernels on ppc64 BE with gcc9

### DIFF
--- a/srcpkgs/linux4.19/patches/ppc64-be-gcc91.patch
+++ b/srcpkgs/linux4.19/patches/ppc64-be-gcc91.patch
@@ -1,0 +1,28 @@
+Since gcc 9.1, adding `-mcall-aixdesc` to cflags makes it no longer define
+`__linux__`, which breaks compilation of the kernel in places where the macro
+is checked (which is multiple). This behavior is actually more correct than
+it was before, as `-mcall-aixdesc` is only meant to be used when compiling
+for AIX.
+
+However, it is not enough to just drop it and use `-mabi=elfv1`, as that
+results in a ton of undefined references all over the place when linking.
+So work around it until upstream sorts it out.
+
+--- a/arch/powerpc/Makefile
++++ b/arch/powerpc/Makefile
+@@ -96,6 +96,7 @@ endif
+ ifdef CONFIG_PPC64
+ cflags-$(CONFIG_CPU_BIG_ENDIAN)		+= $(call cc-option,-mabi=elfv1)
+ cflags-$(CONFIG_CPU_BIG_ENDIAN)		+= $(call cc-option,-mcall-aixdesc)
++cflags-$(CONFIG_CPU_BIG_ENDIAN)		+= -D__linux__
+ aflags-$(CONFIG_CPU_BIG_ENDIAN)		+= $(call cc-option,-mabi=elfv1)
+ aflags-$(CONFIG_CPU_LITTLE_ENDIAN)	+= -mabi=elfv2
+ endif
+@@ -151,6 +152,7 @@ AFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mabi=elfv2)
+ else
+ CFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mabi=elfv1)
+ CFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mcall-aixdesc)
++CFLAGS-$(CONFIG_PPC64)	+= -D__linux__
+ AFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mabi=elfv1)
+ endif
+ CFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mcmodel=medium,$(call cc-option,-mminimal-toc))

--- a/srcpkgs/linux5.1/patches/ppc64-be-gcc91.patch
+++ b/srcpkgs/linux5.1/patches/ppc64-be-gcc91.patch
@@ -1,0 +1,28 @@
+Since gcc 9.1, adding `-mcall-aixdesc` to cflags makes it no longer define
+`__linux__`, which breaks compilation of the kernel in places where the macro
+is checked (which is multiple). This behavior is actually more correct than
+it was before, as `-mcall-aixdesc` is only meant to be used when compiling
+for AIX.
+
+However, it is not enough to just drop it and use `-mabi=elfv1`, as that
+results in a ton of undefined references all over the place when linking.
+So work around it until upstream sorts it out.
+
+--- a/arch/powerpc/Makefile
++++ b/arch/powerpc/Makefile
+@@ -96,6 +96,7 @@ endif
+ ifdef CONFIG_PPC64
+ cflags-$(CONFIG_CPU_BIG_ENDIAN)		+= $(call cc-option,-mabi=elfv1)
+ cflags-$(CONFIG_CPU_BIG_ENDIAN)		+= $(call cc-option,-mcall-aixdesc)
++cflags-$(CONFIG_CPU_BIG_ENDIAN)		+= -D__linux__
+ aflags-$(CONFIG_CPU_BIG_ENDIAN)		+= $(call cc-option,-mabi=elfv1)
+ aflags-$(CONFIG_CPU_LITTLE_ENDIAN)	+= -mabi=elfv2
+ endif
+@@ -151,6 +152,7 @@ AFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mabi=elfv2)
+ else
+ CFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mabi=elfv1)
+ CFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mcall-aixdesc)
++CFLAGS-$(CONFIG_PPC64)	+= -D__linux__
+ AFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mabi=elfv1)
+ endif
+ CFLAGS-$(CONFIG_PPC64)	+= $(call cc-option,-mcmodel=medium,$(call cc-option,-mminimal-toc))


### PR DESCRIPTION
See the comment in the patches for rationale. This will be reported and hopefully fixed upstream, for now we need a workaround, this one is fortunately pretty simple.