### PR TITLE
bootchart2: conflict with bootchart

### DIFF
--- a/srcpkgs/bootchart2/template
+++ b/srcpkgs/bootchart2/template
@@ -1,7 +1,9 @@
 # Template file for 'bootchart2'
 pkgname=bootchart2
 version=0.14.8.20170531
-revision=1
+revision=2
+_gitrev=331ada031f1d65f6d934d918f896e1c708c64bf7
+wrksrc="bootchart-${_gitrev}"
 build_style=gnu-makefile
 make_install_args="EARLY_PREFIX=/usr"
 makedepends="python"
@@ -10,7 +12,6 @@ short_desc="Startup graphing tool"
 maintainer="Benjamin Hoffmeyer <hoffmeyer25@gmail.com>"
 license="GPL-2"
 homepage="https://github.com/xrmx/bootchart"
-_gitrev=331ada031f1d65f6d934d918f896e1c708c64bf7
 distfiles="https://github.com/xrmx/bootchart/archive/${_gitrev}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=a8140cc690bd7d08ab9c030325cb075e154b7545083036ffb65bda8d740d85b4
-wrksrc="bootchart-${_gitrev}"
+conflicts="bootchart>=0"


### PR DESCRIPTION
Both packages are sharing multiple files and should never be installed together.