### PR TITLE
flowblade: fix launch process

### DIFF
--- a/srcpkgs/flowblade/patches/00-add-bin-directories.patch
+++ b/srcpkgs/flowblade/patches/00-add-bin-directories.patch
@@ -1,0 +1,11 @@
+--- flowblade-trunk/flowblade	2019-02-04 02:29:07.000000000 -0700
++++ flowblade-trunk/flowblade	2019-07-06 17:48:47.295155396 -0600
+@@ -34,7 +34,7 @@ print "Launch script dir:", launch_dir
+ 
+ # Update sys.path to include modules
+ # When running on distro
+-if launch_dir == "/usr/bin":
++if launch_dir in {"/usr/bin", "/bin", "/usr/local/bin"}:
+     print "Running from installation..."
+     modules_path = "/usr/share/flowblade/Flowblade"
+     if not os.path.isdir(modules_path):

--- a/srcpkgs/flowblade/template
+++ b/srcpkgs/flowblade/template
@@ -1,7 +1,7 @@
 # Template file for 'flowblade'
 pkgname=flowblade
 version=2.0
-revision=1
+revision=2
 archs=noarch
 build_wrksrc=flowblade-trunk
 build_style=python2-module


### PR DESCRIPTION
Fix module path-checking to ensure that flowblade launches.

On systems where the flowblade executable is placed in /bin or /usr/local/bin, flowblade improperly detects module inclusion directories and fails to launch. This patch remedies that.

I did not submit this change upstream because development is temporarily suspended.

Thank you for any reply.