### PR TITLE
Revert "xbps-src/chroot.sh: sanitize PATH."

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -198,7 +198,7 @@ chroot_handler() {
         [ -n "$XBPS_BINPKG_EXISTS" ] && arg="$arg -E"
 
         action="$arg $action"
-        env -i -- PATH="/usr/bin" SHELL=/bin/sh \
+        env -i -- PATH="/usr/bin:$PATH" SHELL=/bin/sh \
             HOME=/tmp IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 \
             SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
             XBPS_ALLOW_CHROOT_BREAKOUT="$XBPS_ALLOW_CHROOT_BREAKOUT" \


### PR DESCRIPTION
This reverts commit e0e48d6f6a3e3975bd867d5ae9485ebfbb76a687.

This commit broke xbps-src on Distros with split bin sbin like Debian