### PR TITLE
python-parso: update to 0.5.0.

### DIFF
--- a/srcpkgs/python-parso/template
+++ b/srcpkgs/python-parso/template
@@ -1,6 +1,6 @@
 # Template file for 'python-parso'
 pkgname=python-parso
-version=0.4.0
+version=0.5.0
 revision=1
 archs=noarch
 wrksrc="parso-${version}"
@@ -13,7 +13,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="MIT"
 homepage="https://github.com/davidhalter/parso"
 distfiles="${PYPI_SITE}/p/parso/parso-${version}.tar.gz"
-checksum=2e9574cb12e7112a87253e14e2c380ce312060269d04bd018478a3c92ea9a376
+checksum=db5881df1643bf3e66c097bfd8935cf03eae73f4cb61ae4433c9ea4fb6613446
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
need for python-jedi 0.14.0