### PR TITLE
efibootmgr: add option to set partition number of EFI partition

### DIFF
--- a/srcpkgs/efibootmgr/files/efibootmgr-kernel-hook.confd
+++ b/srcpkgs/efibootmgr/files/efibootmgr-kernel-hook.confd
@@ -6,3 +6,5 @@ MODIFY_EFI_ENTRIES=0
 # OPTIONS="root=/dev/sda3 loglevel=4 slub_debug=P page_poison=1"
 # Disk where EFI Partition is.  Default is /dev/sda
 # DISK="/dev/sda"
+# Partition number of EFI Partition.  Default is 1
+# PART=1

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -18,6 +18,9 @@ args=""
 if [ "x${DISK}" != x ]; then
 	args="-d $DISK"
 fi
+if [ "x${PART}" != x ]; then
+	args="$args -p $PART"
+fi
 
 # get major version, e.g. "4.8" for "linux4.8"
 major_version=$(echo $PKGNAME | cut -c 6-)

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=17
-revision=2
+revision=3
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel popt-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"


### PR DESCRIPTION
This is useful when ESP is not the first partition, for instance if it
is added after some existing partitions during switch from BIOS to
UEFI boot.