### PR TITLE
firebird3: add patches to fix ppc64 builds and respect c(xx)flags

### DIFF
--- a/srcpkgs/firebird3/patches/Provide-sized-global-delete-operators-when-compiled.patch
+++ b/srcpkgs/firebird3/patches/Provide-sized-global-delete-operators-when-compiled.patch
@@ -1,0 +1,36 @@
+From: Michal Kubecek <mkubecek@suse.cz>
+Date: Mon, 25 Apr 2016 08:55:36 +0200
+Subject: Provide sized global delete operators when compiled in C++14 mode
+Patch-mainline: submitted
+Git-commit: 038f9fbf559e56032e4cb49eb7ce4c3ead23fda9
+References: bsc#964466 CORE-5099
+
+---
+ src/common/classes/alloc.h | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/common/classes/alloc.h b/src/common/classes/alloc.h
+index b1026ce2aac4..fda5bfebb0cc 100644
+--- a/src/common/classes/alloc.h
++++ b/src/common/classes/alloc.h
+@@ -331,6 +331,16 @@ inline void operator delete[](void* mem, Firebird::MemoryPool& pool ALLOC_PARAMS
+ 	MemoryPool::globalFree(mem);
+ }
+ 
++#if __cplusplus >= 201402L
++inline void operator delete(void* mem, std::size_t s ALLOC_PARAMS) throw()
++{
++	MemoryPool::globalFree(mem);
++}
++inline void operator delete[](void* mem, std::size_t s ALLOC_PARAMS) throw()
++{
++	MemoryPool::globalFree(mem);
++}
++#endif
+ #ifdef DEBUG_GDS_ALLOC
+ 
+ #ifdef __clang__
+-- 
+2.8.2
+
+

--- a/srcpkgs/firebird3/patches/cloop-honour-build-flags.patch
+++ b/srcpkgs/firebird3/patches/cloop-honour-build-flags.patch
@@ -1,0 +1,27 @@
+Description: make cloop build honor compiler/linker flags from the environment
+Author: Damyan Ivanov <dmn@debian.org>
+Forwarded: no
+
+--- a/extern/cloop/Makefile
++++ b/extern/cloop/Makefile
+@@ -6,7 +6,7 @@ TARGET	:= release
+ 
+ CC	:= gcc
+ CXX	:= g++
+-LD	:= $(CXX)
++LD	:= $(CXX) $(LDFLAGS)
+ 
+ SRC_DIR		:= src
+ BUILD_DIR	:= build
+@@ -27,8 +27,9 @@ SRCS_CPP := $(foreach sdir,$(SRC_DIRS),$
+ OBJS_C := $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRCS_C))
+ OBJS_CPP := $(patsubst $(SRC_DIR)/%.cpp,$(OBJ_DIR)/%.o,$(SRCS_CPP))
+ 
+-C_FLAGS := -ggdb -fPIC -MMD -MP -W -Wall -Wno-unused-parameter
+-CXX_FLAGS := $(C_FLAGS)
++COMMON_C_FLAGS := -ggdb -fPIC -MMD -MP -W -Wall -Wno-unused-parameter
++C_FLAGS := $(COMMON_C_FLAGS) $(CFLAGS) $(CPPFLAGS)
++CXX_FLAGS := $(COMMON_C_FLAGS) $(CXXFLAGS) $(CPPFLAGS)
+ FPC_FLAGS := -Mdelphi
+ 
+ ifeq ($(TARGET),release)

--- a/srcpkgs/firebird3/patches/honour-buildflags.patch
+++ b/srcpkgs/firebird3/patches/honour-buildflags.patch
@@ -1,0 +1,78 @@
+Description: improved support for build flags
+ The first change makes linking makeHeader use the same CPP/CXX/LD flags as the
+ rest of the sources.
+ The second change stops btyacc/Makefile from ignoring CFLAGS from the
+ environment.
+ The third change stops overriding CXXFLAGS
+ The result is using hardening flags from the environment when compiling and
+ linking.
+Author: Damyan Ivanov <dmn@debian.org>
+
+--- a/builds/posix/Makefile.in
++++ b/builds/posix/Makefile.in
+@@ -623,7 +623,7 @@ MAKE_HEADER_Src = $(addprefix $(SRC_ROOT
+ MAKE_HEADER_Bin = ./makeHeader
+ 
+ $(INCLUDE_DEST)/ibase.h: $(SRC_IBASE_ExtraFiles)
+-	$(STATICEXE_LINK) -o $(MAKE_HEADER_Bin) $(MAKE_HEADER_Src)
++	$(STATICEXE_LINK) $(EXE_LINK_OPTIONS) $(LINK_OPTS) $(CPPFLAGS) -o $(MAKE_HEADER_Bin) $(MAKE_HEADER_Src)
+ 	$(CP) $^ .
+ 	$(MAKE_HEADER_Bin) <ibase.h >$@
+ 	$(RM) -f ibase.h
+--- a/extern/btyacc/Makefile
++++ b/extern/btyacc/Makefile
+@@ -42,7 +42,7 @@ OTHERS	      = README README.BYACC \
+ all:		$(PROGRAM)
+ 
+ $(PROGRAM):     $(OBJS) $(LIBS)
+-		$(CC) $(LDFLAGS) -o $(PROGRAM) $(OBJS) $(LIBS)
++		$(CC) $(CFLAGS) $(LDFLAGS) -o $(PROGRAM) $(OBJS) $(LIBS)
+ 
+ clean:;		rm -f $(OBJS)
+ 
+--- a/builds/posix/make.defaults
++++ b/builds/posix/make.defaults
+@@ -166,8 +166,8 @@ LD =	@CXX@
+ 
+ LIB_LINK = $(CXX) $(GLOB_OPTIONS) $(CXXFLAGS)
+ STATICLIB_LINK = $(AR) crus
+-EXE_LINK = $(CXX) $(GLOB_OPTIONS) $(CXXFLAGS)
+-STATICEXE_LINK = $(CXX) $(GLOB_OPTIONS) $(CXXFLAGS)
++EXE_LINK = $(CXX) $(GLOB_OPTIONS) $(CXXFLAGS) $(LDFLAGS)
++STATICEXE_LINK = $(CXX) $(GLOB_OPTIONS) $(CXXFLAGS) $(LDFLAGS)
+ 
+ LINK_LIBS = @LIBS@
+ STATICLINK_LIBS = @LIBS@
+--- a/builds/posix/prefix.linux
++++ b/builds/posix/prefix.linux
+@@ -19,7 +19,7 @@
+ # 2 Oct 2002, Nickolay Samofatov - Major cleanup
+ 
+ COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -pipe -MMD -fPIC -fmessage-length=0 -fno-delete-null-pointer-checks
+-CXXFLAGS=-std=gnu++03
++CXXFLAGS+=-std=gnu++03
+ OPTIMIZE_FLAGS=-O3 -march=i586 -mtune=i686 -fno-omit-frame-pointer
+ WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable -Wno-narrowing
+ 
+--- a/builds/posix/prefix.linux_amd64
++++ b/builds/posix/prefix.linux_amd64
+@@ -19,7 +19,7 @@
+ # 2 Oct 2002, Nickolay Samofatov - Major cleanup
+ 
+ COMMON_FLAGS=-ggdb -DFB_SEND_FLAGS=MSG_NOSIGNAL -DLINUX -DAMD64 -pipe -MMD -fPIC -fmessage-length=0 -fno-delete-null-pointer-checks
+-CXXFLAGS=-std=gnu++03
++CXXFLAGS+=-std=gnu++03
+ OPTIMIZE_FLAGS=-O3 -fno-omit-frame-pointer
+ WARN_FLAGS=-Wall -Wno-switch -Wno-parentheses -Wno-unknown-pragmas -Wno-unused-variable -Wno-invalid-offsetof -Wno-narrowing -Wno-unused-local-typedefs
+ 
+--- a/builds/posix/prefix.linux_generic
++++ b/builds/posix/prefix.linux_generic
+@@ -19,7 +19,7 @@
+ # 2 Oct 2002, Nickolay Samofatov - Major cleanup
+ 
+ COMMON_FLAGS=-DLINUX -pipe -MMD -fPIC -DFB_SEND_FLAGS=MSG_NOSIGNAL -fno-delete-null-pointer-checks
+-CXXFLAGS=-std=gnu++03
++CXXFLAGS+=-std=gnu++03
+ 
+ PROD_FLAGS=-ggdb -O3 $(COMMON_FLAGS)
+ DEV_FLAGS=-ggdb -p -Wall -Wno-switch $(COMMON_FLAGS) -Wno-non-virtual-dtor

--- a/srcpkgs/firebird3/patches/musl-os_utils_h.patch
+++ b/srcpkgs/firebird3/patches/musl-os_utils_h.patch
@@ -1,5 +1,5 @@
---- src/common/os/os_utils.h	2016-04-14 16:07:29.000000000 +0200
-+++ src/common/os/os_utils.h	2019-02-15 02:22:49.698708718 +0100
+--- a/src/common/os/os_utils.h	2016-04-14 16:07:29.000000000 +0200
++++ b/src/common/os/os_utils.h	2019-02-15 02:22:49.698708718 +0100
 @@ -40,6 +40,7 @@
  #define mode_t int
  #define DEFAULT_OPEN_MODE (_S_IREAD | _S_IWRITE)

--- a/srcpkgs/firebird3/template
+++ b/srcpkgs/firebird3/template
@@ -1,7 +1,7 @@
 # Template file for 'firebird3'
 pkgname=firebird3
 version=3.0.4.33054
-revision=2
+revision=3
 _build=0
 _uver=${version//./_}
 wrksrc="Firebird-${version}-${_build}"
@@ -36,6 +36,10 @@ homepage="https://www.firebirdsql.org/en/start/"
 distfiles="https://github.com/FirebirdSQL/firebird/releases/download/R${_uver%_*}/Firebird-${version}-${_build}.tar.bz2"
 checksum=b208931d309029d05dbcd8f6c1b4fd9d21be1d60cee2ff29c08b5002db83756b
 replaces="firebird>=0"
+patch_args="-Np1"
+
+CFLAGS="-fno-strict-aliasing"
+CXXFLAGS="-fno-delete-null-pointer-checks"
 
 pre_configure() {
 	# Avoid errors telling we are not 'root' and


### PR DESCRIPTION
These are from Fedora. If I don't apply these, build fails on `ppc64le` with

```
make[3]: Entering directory '/builddir/Firebird-3.0.4.33054-0/gen'
rm -f metadata.fdb
/builddir/Firebird-3.0.4.33054-0/gen/Release/firebird/bin/isql -q -i /builddir/Firebird-3.0.4.33054-0/src/dbs/metadata.sql
rm -f msg.fdb
double free or corruption (out)
```

@pullmoll