### PR TITLE
tesseract-ocr: fix tessdata url

### DIFF
--- a/srcpkgs/tesseract-ocr/template
+++ b/srcpkgs/tesseract-ocr/template
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/tesseract-ocr/tesseract"
 distfiles="
  https://github.com/tesseract-ocr/tesseract/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz
- https://github.com/tesseract-ocr/tessdata/archive/${version}.tar.gz>tessdata-${_tessdataver}.tar.gz"
+ https://github.com/tesseract-ocr/tessdata/archive/${_tessdataver}.tar.gz>tessdata-${_tessdataver}.tar.gz"
 checksum="5c5ed5f1a76888dc57a83704f24ae02f8319849f5c4cf19d254296978a1a1961
  38c637d3a1763f6c3d32e8f1d979f045668676ec5feb8ee1869ee77cedd31b08"
 


### PR DESCRIPTION
did this ever build? if so, how?

@pullmoll