### PR TITLE
azote: update to 1.2.0

### DIFF
--- a/srcpkgs/azote/template
+++ b/srcpkgs/azote/template
@@ -1,18 +1,18 @@
 # Template file for 'azote'
 pkgname=azote
-version=1.1.2
+version=1.2.0
 revision=1
 archs=noarch
 build_style=python3-module
 pycompile_module="azote"
 hostmakedepends="python3-setuptools"
-depends="python3>=3.5 python3-setuptools python3-gobject python3-Pillow gtk+3 feh xrandr wmctrl"
+depends="python3>=3.5 python3-gobject python3-Pillow gtk+3 feh xrandr wmctrl"
 short_desc="Wallpaper manager for Sway, i3 and some other WMs"
 maintainer="Piotr Miller <nwg.piotr@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/nwg-piotr/azote"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=2caca782aa3b508c650dcdd44d49a183ac95282748edd6b960945c78986d6105
+checksum=2334817981da2b10c188d67d738fae57ff1e45e1288e28fd021d765a813f061e
 
 post_install() {
 	vmkdir usr/bin


### PR DESCRIPTION
I added some user-requested features and released Azote v1.2.0. 