### PR TITLE
enable sixel in xterm

### DIFF
--- a/srcpkgs/xterm/template
+++ b/srcpkgs/xterm/template
@@ -10,7 +10,7 @@ configure_args="--enable-wide-chars --enable-88-color --enable-broken-osc
  --with-app-defaults=/usr/share/X11/app-defaults --enable-i18n
  --disable-full-tgetent --disable-imake --enable-doublechars
  --enable-freetype --enable-tcap-query --enable-logging --enable-dabbrev
- --with-pkg-config=yes --enable-exec-xterm --with-utempter"
+ --with-pkg-config=yes --enable-exec-xterm --with-utempter --enable-sixel"
 hostmakedepends="pkg-config"
 makedepends="libXaw-devel libXft-devel libutempter-devel libxkbfile-devel
  ncurses-devel"


### PR DESCRIPTION
my friend wanted to use sixel on their void linux install but it didn't have sixel in xterm so ¯\\\_(ツ)_/¯