### PR TITLE
New package: rtl8822bu-dkms-20190427

### DIFF
--- a/srcpkgs/rtl8822bu-dkms/files/dkms.conf
+++ b/srcpkgs/rtl8822bu-dkms/files/dkms.conf
@@ -1,0 +1,11 @@
+PACKAGE_NAME="rtl8822bu"
+PACKAGE_VERSION="@VERSION@"
+BUILT_MODULE_NAME="88x2bu"
+PROCS_NUM=$(nproc)
+[ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
+MAKE="'make' -j$PROCS_NUM KVER=${kernelver} 
+KSRC=/lib/modules/${kernelver}/build"
+CLEAN="make clean"
+DEST_MODULE_LOCATION="/kernel/drivers/net/wireless"
+AUTOINSTALL="yes"
+REMAKE_INITRD=no

--- a/srcpkgs/rtl8822bu-dkms/template
+++ b/srcpkgs/rtl8822bu-dkms/template
@@ -1,0 +1,27 @@
+# Template file for 'rtl8822bu-dkms'
+pkgname=rtl8822bu-dkms
+version=20190427
+revision=1
+_gitrev=dbbf4f7c3527f1bff38054349f01a4a8438db0f4
+archs=noarch
+wrksrc="rtl8822bu-${_gitrev}"
+depends="dkms"
+short_desc="Realtek 8822BU USB WiFi driver (DKMS)"
+maintainer="Juan RP <xtraeme@voidlinux.org>"
+license="GPL-2.0-only"
+homepage="https://www.tp-link.com"
+distfiles="https://github.com/EntropicEffect/rtl8822bu/archive/${_gitrev}.tar.gz"
+checksum=96bd6dcf9a285fb7ebac7575bc1e8a28577c200dc1c7ec2abae4005181ef0de5
+dkms_modules="88x2bu ${version}"
+
+do_install() {
+	vmkdir /usr/src/88x2bu-${version}
+	vcopy "*" usr/src/88x2bu-${version}
+	vinstall ${FILESDIR}/dkms.conf 644 usr/src/88x2bu-${version}
+	sed -i -e "s/@VERSION@/${version}-${revision}/" ${PKGDESTDIR}/usr/src/88x2bu-${version}/dkms.conf
+
+	# modules-load.d(5) file.
+	vmkdir usr/lib/modules-load.d
+	echo "88x2bu" > ${DESTDIR}/usr/lib/modules-load.d/88x2bu.conf
+	chmod 644 ${DESTDIR}/usr/lib/modules-load.d/88x2bu.conf
+}


### PR DESCRIPTION
Driver for very popular usb Wi-Fi dongle TP-Link Archer T4U v3 and others