### PR TITLE
ibus-bamboo: update to 0.5.1

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.5.0
+version=0.5.1
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="5a63a064221ca685b97fc770fadd4d62005315a391f29c95162b4322870db2e7"
+checksum="58dcbc97e8e8546f1410747ebedf76ecba834755cc4e767df7d5a63cb049814a"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
- Fix dbus timeout, resolve [#18](https://github.com/BambooEngine/ibus-bamboo/issues/18)
- Add a new prop menu to disable input lookup table, thanks @viettuan1807
- Allow 'uowo' -> 'uo^' instead of 'u?oo'
- Allow 'linuxx' -> 'linux' instead of 'linu~x'