### PR TITLE
dstat: add missing python3-six dependency

### DIFF
--- a/srcpkgs/dstat/template
+++ b/srcpkgs/dstat/template
@@ -1,10 +1,10 @@
 # Template file for 'dstat'
 pkgname=dstat
 version=0.7.4
-revision=1
+revision=2
 archs=noarch
 makedepends="python3"
-depends="$makedepends"
+depends="python3-six"
 short_desc="Versatile tool for generating system resource statistics"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Fixes:
```
% dstat
Traceback (most recent call last):
  File "/usr/bin/dstat", line 32, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```