### PR TITLE
android-tools: enable cross-compiling

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -32,8 +32,6 @@ checksum="@dfaea8c40be4a8bbd1df513ab3516ff88e92430ee0fde399dd7e7e09ec21cd29
  @5c2fcb88154f9b6ffed8d24a069e4bad0a7aea1936be2ce18af972ad8762e09a
  @452e29d95f8da494896e3335931e928d9b7c94500a5793101bb19629cd7dea8c"
 
-nocross="error: requested alignment 64 is larger than 8 [-Werror=attributes]"
-
 do_extract() {
 	local tarball p
 	for p in ${distfiles}; do
@@ -51,11 +49,25 @@ pre_configure() {
 	mkdir -p boringssl/build
 	cd boringssl/build
 
+	# Don't check for CROSS_COMPILING, since i686 container/chroot inside
+	# x86_64 host will failed to build this.
+	if [ "${XBPS_TARGET_MACHINE}" = i686 ] && [ "$(uname -m)" = "x86_64" ]; then
+		boring_ssl_cmake_args="-DCMAKE_TOOLCHAIN_FILE=cross_boring_ssl.cmake"
+		cat > cross_boring_ssl.cmake <<-_EOF
+		SET(CMAKE_SYSTEM_NAME Linux)
+		SET(CMAKE_SYSTEM_VERSION 1)
+		SET(CMAKE_C_COMPILER   ${CC})
+		SET(CMAKE_CXX_COMPILER ${CXX})
+		SET(CMAKE_SYSTEM_PROCESSOR x86)
+		_EOF
+	fi
+
 	cmake -GNinja \
 		-DBUILD_SHARED_LIBS=FALSE \
 		-DCMAKE_BUILD_TYPE=RELEASE \
 		-DCMAKE_CXX_FLAGS="$CXXFLAGS" \
 		-DCMAKE_C_FLAGS="$CFLAGS" \
+		$boring_ssl_cmake_args \
 		..
 	ninja
 }


### PR DESCRIPTION
This also fix build problem on i686 container/chroot inside x86_64 host: https://github.com/void-linux/void-packages/pull/12834