### PR TITLE
azote: update to 1.2.0_2

### DIFF
--- a/srcpkgs/azote/template
+++ b/srcpkgs/azote/template
@@ -1,12 +1,12 @@
 # Template file for 'azote'
 pkgname=azote
 version=1.2.0
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 pycompile_module="azote"
 hostmakedepends="python3-setuptools"
-depends="python3>=3.5 python3-gobject python3-Pillow gtk+3 feh xrandr wmctrl"
+depends="python3>=3.5 python3-setuptools python3-gobject python3-Pillow gtk+3 feh xrandr wmctrl"
 short_desc="Wallpaper manager for Sway, i3 and some other WMs"
 maintainer="Piotr Miller <nwg.piotr@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
This restores dependency [mistakenly removed](https://github.com/nwg-piotr/azote/issues/32) in 1.2.0_1. 