### PR TITLE
gcc: import upstream patch for bug 90756

### DIFF
--- a/srcpkgs/cross-i686-linux-musl/files/bug90756.patch
+++ b/srcpkgs/cross-i686-linux-musl/files/bug90756.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/bug90756.patch

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -11,7 +11,7 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -88,6 +88,7 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/musl-ada.patch
 	_apply_patch -p1 ${FILESDIR}/libgnarl-musl.patch
 	_apply_patch -p0 ${FILESDIR}/invalid_tls_model.patch
+	_apply_patch -p0 ${FILESDIR}/bug90756.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 

--- a/srcpkgs/cross-i686-pc-linux-gnu/files/bug90756.patch
+++ b/srcpkgs/cross-i686-pc-linux-gnu/files/bug90756.patch
@@ -1,0 +1,1 @@
+../../gcc/patches/bug90756.patch

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -83,6 +83,7 @@ _gcc_bootstrap() {
 	_apply_patch -p0 ${FILESDIR}/fix-cxxflags-passing.patch
 	_apply_patch -p0 ${FILESDIR}/non-nullness.patch
 	_apply_patch -p0 ${FILESDIR}/no-stack_chk_fail_local.patch
+	_apply_patch -p0 ${FILESDIR}/bug90756.patch
 
 	msg_normal "Building cross gcc bootstrap\n"
 

--- a/srcpkgs/gcc/patches/bug90756.patch
+++ b/srcpkgs/gcc/patches/bug90756.patch
@@ -1,0 +1,23 @@
+Bug 90756 - [7/8/9 Regression] g++ ICE in convert_move, at expr.c:218 on i686 and s390x 
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90756
+
+--- gcc/explow.c	2019/07/04 02:39:58	273035
++++ gcc/explow.c	2019/07/04 04:49:22	273036
+@@ -892,16 +892,7 @@
+ 
+   tree type = TREE_TYPE (name);
+   int unsignedp = TYPE_UNSIGNED (type);
+-  machine_mode mode = TYPE_MODE (type);
+-
+-  /* Bypass TYPE_MODE when it maps vector modes to BLKmode.  */
+-  if (mode == BLKmode)
+-    {
+-      gcc_assert (VECTOR_TYPE_P (type));
+-      mode = type->type_common.mode;
+-    }
+-
+-  machine_mode pmode = promote_mode (type, mode, &unsignedp);
++  machine_mode pmode = promote_mode (type, TYPE_MODE (type), &unsignedp);
+   if (punsignedp)
+     *punsignedp = unsignedp;
+ 

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.19
 
 pkgname=gcc
 version=${_minorver}.0
-revision=2
+revision=3
 short_desc="GNU Compiler Collection"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="http://gcc.gnu.org"


### PR DESCRIPTION
This patch is necessary to build firefox 68 on i686.
Apparently only i686 and s390x are affected by this bug, so only patch the i686 cross tool chains.