### PR TITLE
chromium: depend on xdg-utils

### DIFF
--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -2,7 +2,7 @@
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
 version=75.0.3770.100
-revision=1
+revision=2
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
@@ -32,7 +32,7 @@ makedepends="libpng-devel gtk+-devel gtk+3-devel nss-devel pciutils-devel
  minizip-devel jsoncpp-devel zlib-devel libcap-devel libXdamage-devel
  re2-devel fontconfig-devel freetype-devel opus-devel
  ffmpeg-devel libva-devel"
-depends="libexif hwids desktop-file-utils hicolor-icon-theme"
+depends="libexif hwids desktop-file-utils hicolor-icon-theme xdg-utils"
 
 build_options_default="jumbo_build clang"
 


### PR DESCRIPTION
xdg-utils is needed to properly open files and directories in downloads.