### PR TITLE
[RFC] geda: remove -32bit makedepends

### DIFF
--- a/srcpkgs/geda/template
+++ b/srcpkgs/geda/template
@@ -1,7 +1,7 @@
 # Template file for 'geda'
 pkgname=geda
 version=1.8.2
-revision=7
+revision=8
 wrksrc="${pkgname}-gaf-${version}"
 build_style=gnu-configure
 configure_args="--with-sysroot=/${XBPS_CROSS_BASE}"
@@ -15,10 +15,6 @@ license="GPL-2.0-or-later"
 homepage="http://www.geda-project.org/"
 distfiles="http://ftp.geda-project.org/geda-gaf/stable/v${version%.*}/${version}/geda-gaf-${version}.tar.gz"
 checksum=bbf4773aef1b5a51a8d6f4c3fa288c047340cc62dd6e14d7928fcc6e4051b721
-
-if [ "${XBPS_ARCH}" = "x86_64" ]; then
-	hostmakedepends+=" glibc-devel-32bit"
-fi
 
 geda-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
@pullmoll This doesn't actually seem necessary to build it. This is related to the discussion at #12982 and #12990.