### PR TITLE
lighttpd: fix log and data directory owner

### DIFF
--- a/srcpkgs/lighttpd/template
+++ b/srcpkgs/lighttpd/template
@@ -1,7 +1,7 @@
 # Template file for 'lighttpd'
 pkgname=lighttpd
 version=1.4.54
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_bzip=true -Dwith_fam=false -Dwith_gdbm=true
  -Dwith_geoip=false -Dwith_krb5=true -Dwith_ldap=true -Dwith_libev=true
@@ -26,8 +26,8 @@ _lighttpd_homedir="/srv/www/${pkgname}"
 lib32disabled=yes
 
 make_dirs="
- /srv/www/lighttpd 0755 lighttpd lighttpd
- /var/log/lighttpd 0755 lighttpd lighttpd"
+ /srv/www/lighttpd 0755 _lighttpd _lighttpd
+ /var/log/lighttpd 0755 _lighttpd _lighttpd"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
The user name for the lighttpd service was changed to `_lighttpd` a while ago, but the log and data directories are still created for owner `lighttpd` in a fresh installation.