### PR TITLE
llvm8: correctly set clang-analyzer to be noarch

### DIFF
--- a/srcpkgs/llvm8/template
+++ b/srcpkgs/llvm8/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm8'.
 pkgname=llvm8
 version=8.0.0
-revision=5
+revision=6
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="
@@ -165,7 +165,7 @@ do_install() {
 }
 
 clang-analyzer_package() {
-	noarch=yes
+	archs=noarch
 	pycompile_dirs="usr/share/scan-view"
 	depends="clang-${version}_${revision} python"
 	short_desc+=" - A source code analysis framework"


### PR DESCRIPTION
[skip ci]