### PR TITLE
python-PyQt5: update to 5.13.0

### DIFF
--- a/srcpkgs/python-PyQt5-webengine
+++ b/srcpkgs/python-PyQt5-webengine
@@ -1,1 +1,0 @@
-python-PyQt5

--- a/srcpkgs/python-PyQt5-webengine/template
+++ b/srcpkgs/python-PyQt5-webengine/template
@@ -1,0 +1,90 @@
+# Template file for 'python-PyQt5'
+pkgname=python-PyQt5-webengine
+version=5.13.0
+revision=1
+lib32disabled=yes
+wrksrc="PyQtWebEngine_gpl-${version}"
+pycompile_module="PyQt5WebEngine"
+hostmakedepends="pkg-config qt5-qmake
+ qt5-declarative-devel qt5-webchannel-devel qt5-location-devel
+ python-devel python3-devel python-PyQt5-devel
+ qt5-webengine-devel"
+makedepends="${hostmakedepends/pkg-config/}"
+depends="python-PyQt5"
+short_desc="Python2 bindings for the Qt5 toolkit - webengine module"
+maintainer="Alessio Sergi <al3hex@gmail.com>"
+homepage="https://www.riverbankcomputing.com/software/pyqtwebengine/intro"
+license="GPL-3.0-only"
+distfiles="https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}/PyQtWebEngine_gpl-${version}.tar.gz"
+checksum=bb6cabcc454ed1394aedfb42eb35dbee3ca324cf582e8c0ca5e8c8af0b00e325
+
+pre_build() {
+	mkdir -p pyqt5-${py2_ver}
+	mv * pyqt5-${py2_ver} || true
+	cp -a pyqt5-${py2_ver} pyqt5-${py3_ver}
+	rm -rf pyqt5-${py2_ver}/pyuic/uic/port_v3
+	rm -rf pyqt5-${py3_ver}/pyuic/uic/port_v2
+}
+do_build() {
+	local _sysroot= _configuration= py_abiver= qt_version
+	for pyver in $py2_ver $py3_ver; do
+		if [ "$pyver" = "$py3_ver" ]; then
+			py_abiver="$py3_abiver"
+		fi
+
+		cd $wrksrc/pyqt5-$pyver
+		if [ "$CROSS_BUILD" ]; then
+			qt_version=$(qmake -query QT_VERSION)
+cat > pyqt5_${XBPS_CROSS_TRIPLET}.cfg <<EOF
+py_platform = linux
+py_inc_dir = %(sysroot)/usr/include/python%(py_major).%(py_minor)${py_abiver}
+py_pyshlib = python%(py_major).%(py_minor)${py_abiver}.so
+pyqt_disabled_features = PyQt_Desktop_OpenGL PyQt_qreal_double
+
+qt_shared = True
+
+[Qt ${qt_version}]
+pyqt_modules = QtWebEngine QtWebEngineCore QtWebEngineWidgets 
+EOF
+
+			_sysroot="--sysroot $XBPS_CROSS_BASE"
+			_configuration="--configuration $wrksrc/pyqt5-$pyver/pyqt5_${XBPS_CROSS_TRIPLET}.cfg"
+		fi
+
+		python${pyver} configure.py --no-dist-info $_sysroot $_configuration \
+			QMAKE_CC="${CC}" QMAKE_CFLAGS="${CFLAGS}" QMAKE_CXX="${CXX}" QMAKE_CXXFLAGS="${CXXFLAGS}" \
+			QMAKE_LINK="${CXX}" QMAKE_LINK_SHLIB="${CXX}" QMAKE_LFLAGS="${LDFLAGS}" QMAKE_STRIP=""
+		make ${makejobs}
+	done
+}
+do_install() {
+	# install python-pyqt5
+	make -C pyqt5-${py2_ver} DESTDIR=${DESTDIR} INSTALL_ROOT=${DESTDIR} install
+
+	# install python3-pyqt5
+	make -C pyqt5-${py3_ver} DESTDIR=${DESTDIR} INSTALL_ROOT=${DESTDIR} install
+}
+python-PyQt5-webengine_package() {
+	lib32disabled=yes
+	depends="${sourcepkg}-${version}_${revision}
+	 python-PyQt5-webchannel-${version}_${revision}"
+	pkg_install() {
+		vmove ${py2_sitelib}/PyQt5/QtWebEngine.so
+		vmove ${py2_sitelib}/PyQt5/QtWebEngineCore.so
+		vmove ${py2_sitelib}/PyQt5/QtWebEngineWidgets.so
+	}
+}
+python3-PyQt5-webengine_package() {
+	lib32disabled=yes
+	depends="python3-PyQt5-${version}_${revision}
+	 python3-PyQt5-webchannel-${version}_${revision}"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove ${py3_sitelib}/PyQt5/QtWebEngine.pyi
+		vmove ${py3_sitelib}/PyQt5/QtWebEngine.so
+		vmove ${py3_sitelib}/PyQt5/QtWebEngineCore.pyi
+		vmove ${py3_sitelib}/PyQt5/QtWebEngineCore.so
+		vmove ${py3_sitelib}/PyQt5/QtWebEngineWidgets.pyi
+		vmove ${py3_sitelib}/PyQt5/QtWebEngineWidgets.so
+	}
+}

--- a/srcpkgs/python-PyQt5-webengine/update
+++ b/srcpkgs/python-PyQt5-webengine/update
@@ -1,0 +1,1 @@
+pkgname="PyQtWebEngine_gpl"

--- a/srcpkgs/python-PyQt5/template
+++ b/srcpkgs/python-PyQt5/template
@@ -1,8 +1,8 @@
 # Template file for 'python-PyQt5'
 pkgname=python-PyQt5
-version=5.11.3
-revision=3
-_sipver=4.19.13
+version=5.13.0
+revision=1
+_sipver=4.19.18
 lib32disabled=yes
 wrksrc="PyQt5_gpl-${version}"
 pycompile_module="PyQt5"
@@ -10,7 +10,7 @@ hostmakedepends="pkg-config
  python-devel python3-devel python-sip-devel python3-sip-devel python-dbus-devel
  qt5-tools-devel qt5-connectivity-devel qt5-declarative-devel qt5-location-devel
  qt5-multimedia-devel qt5-sensors-devel qt5-serialport-devel qt5-svg-devel
- qt5-webchannel-devel qt5-webengine-devel qt5-webkit-devel qt5-websockets-devel
+ qt5-webchannel-devel qt5-webkit-devel qt5-websockets-devel
  qt5-x11extras-devel qt5-xmlpatterns-devel qt5-networkauth-devel pulseaudio-devel
  python-enum34"
 makedepends="${hostmakedepends/pkg-config/}"
@@ -19,8 +19,8 @@ short_desc="Python2 bindings for the Qt5 toolkit"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 homepage="https://riverbankcomputing.com/software/pyqt/intro"
 license="GPL-3.0-only"
-distfiles="${SOURCEFORGE_SITE}/pyqt/PyQt5_gpl-${version}.tar.gz"
-checksum=c9b57d15601d436faf35dacf8e0acefa220194829a653e771e80b189b3261073
+distfiles="https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/PyQt5_gpl-${version}.tar.gz"
+checksum=0cdbffe5135926527b61cc3692dd301cd0328dd87eeaf1313e610787c46faff9
 
 pre_build() {
 	mkdir -p pyqt5-${py2_ver}
@@ -54,8 +54,7 @@ pyqt_modules = QtCore QtGui QtHelp QtMultimedia
     QtSql QtSvg QtTest QtWebKit QtWebKitWidgets QtWidgets QtXml
     QtXmlPatterns QtDesigner QtDBus QtSensors QtSerialPort
     QtX11Extras QtBluetooth QtPositioning QtQuickWidgets QtWebSockets
-    QtWebChannel QtWebEngineWidgets QtLocation QtNfc QtWebEngineCore
-    QtWebEngine QtNetworkAuth
+    QtWebChannel QtLocation QtNfc QtNetworkAuth
 EOF
 
 			_sysroot="--sysroot $XBPS_CROSS_BASE"
@@ -240,17 +239,6 @@ python-PyQt5-webchannel_package() {
 		vmove ${py2_sitelib}/PyQt5/QtWebChannel.so
 	}
 }
-python-PyQt5-webengine_package() {
-	lib32disabled=yes
-	depends="${sourcepkg}-${version}_${revision}
-	 python-PyQt5-webchannel-${version}_${revision}"
-	short_desc+=" - webengine module"
-	pkg_install() {
-		vmove ${py2_sitelib}/PyQt5/QtWebEngine.so
-		vmove ${py2_sitelib}/PyQt5/QtWebEngineCore.so
-		vmove ${py2_sitelib}/PyQt5/QtWebEngineWidgets.so
-	}
-}
 python-PyQt5-webkit_package() {
 	lib32disabled=yes
 	depends="${sourcepkg}-${version}_${revision}"
@@ -424,20 +412,6 @@ python3-PyQt5-webchannel_package() {
 	pkg_install() {
 		vmove ${py3_sitelib}/PyQt5/QtWebChannel.pyi
 		vmove ${py3_sitelib}/PyQt5/QtWebChannel.so
-	}
-}
-python3-PyQt5-webengine_package() {
-	lib32disabled=yes
-	depends="python3-PyQt5-${version}_${revision}
-	 python3-PyQt5-webchannel-${version}_${revision}"
-	short_desc="${short_desc/Python2/Python3} - webengine module"
-	pkg_install() {
-		vmove ${py3_sitelib}/PyQt5/QtWebEngine.pyi
-		vmove ${py3_sitelib}/PyQt5/QtWebEngine.so
-		vmove ${py3_sitelib}/PyQt5/QtWebEngineCore.pyi
-		vmove ${py3_sitelib}/PyQt5/QtWebEngineCore.so
-		vmove ${py3_sitelib}/PyQt5/QtWebEngineWidgets.pyi
-		vmove ${py3_sitelib}/PyQt5/QtWebEngineWidgets.so
 	}
 }
 python3-PyQt5-webkit_package() {

--- a/srcpkgs/python3-PyQt5-webengine
+++ b/srcpkgs/python3-PyQt5-webengine
@@ -1,1 +1,1 @@
-python-PyQt5
+python-PyQt5-webengine

--- a/srcpkgs/sip/template
+++ b/srcpkgs/sip/template
@@ -1,7 +1,7 @@
 # Template file for 'sip'
 pkgname=sip
-version=4.19.13
-revision=3
+version=4.19.18
+revision=1
 wrksrc="sip-${version}"
 hostmakedepends="python-devel python3-devel"
 makedepends="${hostmakedepends}"
@@ -9,8 +9,8 @@ short_desc="Python extension module generator for C/C++ libraries"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="GPL-2.0-only, GPL-3.0-only, SIP"
 homepage="https://riverbankcomputing.com/software/sip/intro"
-distfiles="${SOURCEFORGE_SITE}/pyqt/sip/sip-${version}/sip-${version}.tar.gz"
-checksum=e353a7056599bf5fbd5d3ff9842a6ab2ea3cf4e0304a0f925ec5862907c0d15e
+distfiles="https://www.riverbankcomputing.com/static/Downloads/sip/${version}/sip-${version}.tar.gz"
+checksum=c0bd863800ed9b15dcad477c4017cdb73fa805c25908b0240564add74d697e1e
 
 pre_build() {
 	mkdir -p sip-${py2_ver}


### PR DESCRIPTION
- Update sip to 4.19.18

- Remove python-PyQt5-webengine from python-PyQt5 since upstream no longer includes it in PyQt5 bindings.

- Add new python-PyQt5-webengine template (based on previous python-PyQt5).

Tested by using qutebrowser with the updated python-PyQt5-webengine.