### PR TITLE
New package: jmtpfs-0.5

### DIFF
--- a/srcpkgs/jmtpfs/template
+++ b/srcpkgs/jmtpfs/template
@@ -1,0 +1,14 @@
+# Template file for 'jmtpfs'
+pkgname=jmtpfs
+version=0.5
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="libmtp-devel fuse-devel file-devel"
+short_desc="FUSE-based filesystem for accessing MTP devices"
+maintainer="Jorge Natz <jorgenatzdev@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/JasonFerrara/jmtpfs"
+changelog="https://github.com/JasonFerrara/jmtpfs/blob/master/ChangeLog"
+distfiles="https://github.com/JasonFerrara/${pkgname}/archive/v${version}.tar.gz"
+checksum=c0cacc4751c586a3b2b0fcd9c98dae4810a5d44f3eb9d2870868a15eeb696883


### PR DESCRIPTION
This is a utility for mounting mtp devices as FUSE filesystems.

I am not sure of how reliable a maintainer I would be. Should I designate a common maintainer with their permission, put myself anyway, or avoid submitting the package?

Thank you for any reply, and I apologize for anything I missed.