### PR TITLE
rpi-kernel: update to 4.19.58.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="8ea4810a9f2d0c510f6a8fd56805e82ac76904a3"
+_githash="246113692edbef9a438b31ab2dd0172a30ed5eb2"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.57
+version=4.19.58
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=c5390847b342376fa6146f17a504ddca7eeb2817c8a1ada28aca2d4106693af6
+checksum=47f9626324c16aae2318fc83fa96f16e4e75eaf18eccbe40302645d2d17d7834
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]