### PR TITLE
66: update to 0.2.0.2

### DIFF
--- a/srcpkgs/66/template
+++ b/srcpkgs/66/template
@@ -1,31 +1,45 @@
 # Template file for '66'
 pkgname=66
-version=0.1.0.1
+version=0.2.0.2
 revision=1
 wrksrc="66-v${version}"
 build_style=configure
 configure_args="--prefix=/usr
- --dynlibdir=/usr/lib
- --libdir=/usr/lib
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --with-lib=${XBPS_CROSS_BASE}/usr/lib"
-hostmakedepends="pkg-config"
-makedepends="oblibs-devel skalibs-devel execline-devel s6-devel s6-rc s6-portable-utils procps-ng-devel"
+hostmakedepends="pkg-config scdoc"
+makedepends="oblibs-devel skalibs-devel execline-devel s6-devel s6-rc procps-ng-devel"
 depends="s6-rc s6-portable-utils"
 short_desc="Helpers tools around s6-rc"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="http://web.obarun.org/software/"
 distfiles="https://framagit.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
-checksum=6633b7cf810aa3b59f84b567a57914f51247f7a96fca0879a2f8141b87bd674c
+checksum=98a0ba012f472b7e03657e3a063cca3e19bc1d4d4accae093fadaee74924b83b
+
+conf_files="/etc/66/init /etc/66/init.conf"
+make_dirs="
+/var/log/66 0755 root root
+/var/lib/66 0755 root root
+/usr/share/66/service 0755 root root
+/etc/66/service 0755 root root
+/etc/66/conf 0755 root root"
+
+
+pre_build() {
+	make man
+}
 
 post_install() {
 	local i
 	vlicense COPYING
-	for i in doc/*.html ; do
+	for i in doc/html/*.html ; do
 		vdoc $i
 	done
 	vdoc README
+	for i in doc/man/*.{1,5,8} ; do
+		vman $i
+	done
 }
 
 66-doc_package() {
@@ -34,6 +48,7 @@ post_install() {
 	depends="${sourcepkg}-${version}_${revision}"
 	pkg_install() {
 		vmove usr/share/doc
+		vmove usr/share/man
 	}
 }
 
@@ -42,6 +57,6 @@ post_install() {
 	depends="${sourcepkg}-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
-		vmove "usr/lib/*.a"
+		vmove usr/lib
 	}
 }


### PR DESCRIPTION
Is there a way to preserve empty dirs when packaging - other than creating a file in them post-install ?
```

=> WARNING: 66-0.2.0.2_1: removed empty dir: /var/log/66
=> WARNING: 66-0.2.0.2_1: removed empty dir: /var/lib/66
=> WARNING: 66-0.2.0.2_1: removed empty dir: /usr/share/66/service
=> WARNING: 66-0.2.0.2_1: removed empty dir: /etc/66/service
=> WARNING: 66-0.2.0.2_1: removed empty dir: /etc/66/conf
```
