### PR TITLE
higan: add a patch to prevent elfv2 ppc64(le) crashes

### DIFF
--- a/srcpkgs/higan/patches/ppc64-no-asm.patch
+++ b/srcpkgs/higan/patches/ppc64-no-asm.patch
@@ -1,0 +1,26 @@
+Higan's ppc code assumes big endian, so fall back to sjlj for that. ELFv2 big
+endian just needs a small patch to function.
+
+--- libco/libco.c
++++ libco/libco.c
+@@ -9,7 +9,7 @@
+     #include "amd64.c"
+   #elif defined(__arm__)
+     #include "arm.c"
+-  #elif defined(_ARCH_PPC)
++  #elif defined(_ARCH_PPC) && !defined(__LITTLE_ENDIAN__)
+     #include "ppc.c"
+   #elif defined(_WIN32)
+     #include "fiber.c"
+--- libco/ppc.c
++++ libco/ppc.c
+@@ -36,7 +36,8 @@ static thread_local cothread_t co_active_handle = 0;
+ 
+ /* whether function calls are indirect through a descriptor, or are directly to function */
+ #ifndef LIBCO_PPCDESC
+-  #if !_CALL_SYSV && (_CALL_AIX || _CALL_AIXDESC || LIBCO_PPC64)
++  #if !_CALL_SYSV && (_CALL_AIX || _CALL_AIXDESC || \
++      (LIBCO_PPC64 && (!defined(_CALL_ELF) || _CALL_ELF == 1)))
+     #define LIBCO_PPCDESC 1
+   #endif
+ #endif


### PR DESCRIPTION
I was able to load an SNES ROM without segfaulting after this.