### PR TITLE
android-tools: use upstream versioning

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -4,9 +4,11 @@ pkgname=android-tools
 #       of android used by android-tools. Check for diff with:
 #         curl -L http://git.io/vvC0Z | sh -s 5.0.2_r1 5.1.0_r1
 version=9.0.0r45
-revision=1
+revision=2
 archs="x86_64* i686*"
 _distver=${version/r/_r}
+#See https://android.googlesource.com/platform/development/+/refs/tags/android-${_distver}/sdk/plat_tools_source.prop_template
+_apiver="28.0.0 rc1"
 create_wrksrc=yes
 hostmakedepends="ruby cmake ninja perl go"
 makedepends="gtest-devel zlib-devel libressl-devel libusb-devel pcre2-devel"
@@ -44,7 +46,7 @@ do_extract() {
 }
 
 pre_configure() {
-	PKGVER=${_distver} ${FILESDIR}/generate_build.rb > build.ninja
+	PKGVER="${_apiver}-void-${version}_${revision}" ${FILESDIR}/generate_build.rb > build.ninja
 
 	mkdir -p boringssl/build
 	cd boringssl/build


### PR DESCRIPTION
resolves #13165

We should use the `platform-tools-*` tags at some later point, but it requires patching of the ruby script that currently builds this package.