### PR TITLE
python-PyQt5: fix cross build

### DIFF
--- a/srcpkgs/python-PyQt5/template
+++ b/srcpkgs/python-PyQt5/template
@@ -21,7 +21,6 @@ homepage="https://riverbankcomputing.com/software/pyqt/intro"
 license="GPL-3.0-only"
 distfiles="https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/PyQt5_gpl-${version}.tar.gz"
 checksum=0cdbffe5135926527b61cc3692dd301cd0328dd87eeaf1313e610787c46faff9
-nocross="https://build.voidlinux.org/builders/armv7l_builder/builds/18963/steps/shell_3/logs/stdio"
 
 pre_build() {
 	mkdir -p pyqt5-${py2_ver}
@@ -65,6 +64,12 @@ EOF
 		python${pyver} configure.py --confirm-license --assume-shared --no-dist-info $_sysroot $_configuration \
 			QMAKE_CC="${CC}" QMAKE_CFLAGS="${CFLAGS}" QMAKE_CXX="${CXX}" QMAKE_CXXFLAGS="${CXXFLAGS}" \
 			QMAKE_LINK="${CXX}" QMAKE_LINK_SHLIB="${CXX}" QMAKE_LFLAGS="${LDFLAGS}" QMAKE_STRIP=""
+
+		if [ "$CROSS_BUILD" ]; then
+			# Fix location of libraries
+			find . -name Makefile | xargs sed -i -E "s|(/usr/lib/libQt5[^ ]+so)|${XBPS_CROSS_BASE}\1|g"
+		fi
+
 		make ${makejobs}
 	done
 }


### PR DESCRIPTION
This fixes cross building by modifying the explicit library paths to Qt5 shared libraries to include the XBPS_CROSS_BASE.

Tested by cross building armv7l and armv7l-musl.

[ci skip]