### PR TITLE
lsof: update to 4.93.2

### DIFF
--- a/srcpkgs/lsof/template
+++ b/srcpkgs/lsof/template
@@ -1,24 +1,26 @@
 # Template file for 'lsof'
 pkgname=lsof
-version=4.91
+version=4.93.2
 revision=1
-wrksrc=lsof_${version}_src
 hostmakedepends="perl"
 short_desc="LiSt Open Files"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
-homepage="https://people.freebsd.org/~abe/"
 license="lsof"
-distfiles="https://fossies.org/linux/misc/lsof_${version}_src.tar.xz"
-checksum=84c8bba41a2f458edf92427ae5a3088d8010e8dbec7ce5bc58c709ede87ac3bf
+homepage="https://people.freebsd.org/~abe/"
+distfiles="https://fossies.org/linux/misc/lsof-${version}.tar.gz"
+checksum=3df912bd966fc24dc73ddea3e36a61d79270b21b085936a4caabca56e5b486a2
 
 do_build() {
 	sed "s|/\* #define\tHASSECURITY\t1 \*/|#define\tHASSECURITY\t1|" \
 		-i dialects/linux/machine.h
+	if [ "$CROSS_BUILD" ]; then
+		export LSOF_INCLUDE="${XBPS_CROSS_BASE}/usr/include"
+	fi
 	LSOF_CFGF="$CFLAGS" LSOF_CFGL="$LDFLAGS" ./Configure -n linux
 	make CC=$CC ${makejobs}
 }
 do_install() {
 	vbin lsof
-	vman lsof.8
+	vman Lsof.8
 	vlicense ${FILESDIR}/license.txt
 }


### PR DESCRIPTION
The distfile for 4.91 has been removed. Fix lint and cross issues while at it