### PR TITLE
[WIP] New package: signal-cli-0.10.5 (java)

### DIFF
--- a/srcpkgs/signal-cli/template
+++ b/srcpkgs/signal-cli/template
@@ -1,0 +1,39 @@
+# Template file for 'signal-cli'
+pkgname=signal-cli
+version=0.10.5
+revision=1
+hostmakedepends="asciidoc gradle openjdk17"
+#XXX: depends on https://github.com/signalapp/libsignal
+depends="virtual?java-runtime"
+short_desc="Commandline and dbus interface for libsignal-service-java"
+maintainer="Piraty <piraty1@inbox.ru>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/AsamK/signal-cli"
+distfiles="https://github.com/AsamK/signal-cli/archive/v${version}.tar.gz"
+checksum=36db3cf393c4f36e38560f33002a59a5efab4f8fe23a309c85be3da377826d6f
+
+do_build() {
+	gradle -v build
+	make ${makejobs} -C man
+}
+
+do_install() {
+	gradle installDist
+}
+
+post_install() {
+	vmkdir usr/lib/signal-cli
+	vcopy "build/install/signal-cli/lib/*" usr/lib/signal-cli
+
+	# wrapper: adapt search path to our custom location
+	vsed -i build/install/signal-cli/bin/signal-cli \
+		-e "s,^APP_HOME=.*,APP_HOME=/usr/lib/signal-cli/," \
+		-e "/^CLASSPATH/s,APP_HOME/lib,APP_HOME,g"
+
+	vbin build/install/signal-cli/bin/signal-cli
+	vman man/signal-cli.1
+}
+
+do_check() {
+	gradle check
+}


### PR DESCRIPTION
https://github.com/AsamK/signal-cli

Rudimentary Signal interface written in java for basic cli interactions, based on [libsignal-protocol-java](https://github.com/signalapp/libsignal-protocol-java/)

Unfortunately there doesn't seem to be anything useful based on [libsignal-protocol-c](https://github.com/signalapp/libsignal-protocol-c) yet.
I'm unsure if the package should better be named signal-cli-java instead?

Projects using it include (which i might look into packaging after some evaluation)
- https://github.com/isamert/scli
- https://github.com/TopView/signal-say

___

TODO
- [ ] mention external libraries' licenses
- [ ] fetch external libraries via `distfiles`? (see ghidra for reference)
- [ ] (optional) provide counterparts for the systemd servies (dbus related)