### PR TITLE
freecad: don't build against qt5-webkit-devel on musl target.

### DIFF
--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -1,7 +1,7 @@
 # Template file for 'freecad'
 pkgname=freecad
 version=0.18.2
-revision=1
+revision=2
 wrksrc="FreeCAD-${version}"
 build_style=cmake
 
@@ -20,6 +20,12 @@ makedepends="python3-devel boost-devel libxerces-c-devel zlib-devel occt-devel
  liblz4-devel libpyside2-python3-devel python3-matplotlib netcdf-devel
  jsoncpp-devel qt5-devel qt5-svg-devel qt5-tools-devel qt5-webkit-devel
  qt5-x11extras-devel coin3-doc glew-devel"
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) # SIGSEGV with musl, see https://github.com/void-linux/void-packages/issues/12595
+		makedepends=${makedepends/qt5-webkit-devel/}
+		;;
+esac
 
 # FreeCAD help: qt5/assistant with datas in SQLite format
 depends="python3-matplotlib python3-pyside2 qt5-plugin-sqlite python3-pivy"


### PR DESCRIPTION
workaround for https://github.com/void-linux/void-packages/issues/12595

[ci skip]