### PR TITLE
[wip] New package: lsd-0.15.1

### DIFF
--- a/srcpkgs/lsd/template
+++ b/srcpkgs/lsd/template
@@ -1,0 +1,12 @@
+# Template file for 'lsd'
+pkgname=lsd
+version=0.15.1
+revision=1
+build_style=cargo
+build_helper=rust
+short_desc="Next gen ls command"
+maintainer="mustaqim <mustaqim@pm.me>"
+license="Apache-2.0"
+homepage="https://github.com/Peltoche/lsd"
+distfiles="https://github.com/Peltoche/lsd/archive/${version}.tar.gz"
+checksum=849ad168171737ef1ca74b762b3d9fb885c936cb9a753eca07426886478ad2de


### PR DESCRIPTION
```zsh
error: process didn't exit successfully: `rustc -vV` (exit code: 1)
--- stdout
rustc 1.36.0
binary: rustc
commit-hash: unknown
commit-date: unknown
host: x86_64-unknown-linux-gnu
release: 1.36.0

--- stderr
error: couldn't load codegen backend "/usr/lib64/rustlib/x86_64-unknown-linux-gnu/codegen-backends/librustc_codegen_llvm-llvm.so": "/usr/lib/libstdc++.so.6: version `GLIBCXX_3.4.26\' not found (required by /usr/lib/libLLVM-8.so)"


=> ERROR: lsd-0.15.1_1: do_build: '${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}' exited with 101
=> ERROR:   in do_build() at common/build-style/cargo.sh:8
```

Hmm. Has this something to do with the rust library not linked against the same llvm? Or that it's not the same `libstdc++` version?

```zsh
$> strings /usr/lib/libstdc++.so.6 | grep GLIBCXX
GLIBCXX_3.4
GLIBCXX_3.4.1
GLIBCXX_3.4.2
GLIBCXX_3.4.3
GLIBCXX_3.4.4
GLIBCXX_3.4.5
GLIBCXX_3.4.6
GLIBCXX_3.4.7
GLIBCXX_3.4.8
GLIBCXX_3.4.9
GLIBCXX_3.4.10
GLIBCXX_3.4.11
GLIBCXX_3.4.12
GLIBCXX_3.4.13
GLIBCXX_3.4.14
GLIBCXX_3.4.15
GLIBCXX_3.4.16
GLIBCXX_3.4.17
GLIBCXX_3.4.18
GLIBCXX_3.4.19
GLIBCXX_3.4.20
GLIBCXX_3.4.21
GLIBCXX_3.4.22
GLIBCXX_3.4.23
GLIBCXX_3.4.24
GLIBCXX_3.4.25
GLIBCXX_3.4.26
GLIBCXX_DEBUG_MESSAGE_LENGTH

```