### PR TITLE
qutebrowser: update to 1.7.0.

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,6 +1,6 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
-version=1.6.3
+version=1.7.0
 revision=1
 archs=noarch
 build_style=python3-module
@@ -15,7 +15,7 @@ license="GPL-3.0-or-later"
 homepage="https://qutebrowser.org/"
 changelog="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/changelog.asciidoc"
 distfiles="https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/qutebrowser-${version}.tar.gz"
-checksum=1ed27f8bc7ce3e0d3d1d8687de5280d0be62c899154c773a22196cba49b02a7d
+checksum=f1f01b33669a9b08071997bb2642d46a1e5be9e293bdeb817d83db8dc5aad273
 
 pre_build() {
 	a2x -f manpage doc/qutebrowser.1.asciidoc
@@ -23,7 +23,7 @@ pre_build() {
 
 post_install() {
 	vman doc/qutebrowser.1
-	vinstall misc/qutebrowser.desktop 644 usr/share/applications
+	vinstall misc/org.qutebrowser.qutebrowser.desktop 644 usr/share/applications
 
 	vmkdir usr/share/qutebrowser
 	vcopy misc/userscripts usr/share/qutebrowser


### PR DESCRIPTION
* Runs fine so far on my x86_64.
* Note: Some users may encounter webengine segfaults especially on media-heavy sites because of [QTBUG-76913](https://bugreports.qt.io/browse/QTBUG-76913) (opened by qutebrowser's main dev), which will be resolved with Qt 5.13.1.