### PR TITLE
New package: la-capitaine-icon-theme-0.6.1

### DIFF
--- a/srcpkgs/la-capitaine-icon-theme/template
+++ b/srcpkgs/la-capitaine-icon-theme/template
@@ -1,0 +1,17 @@
+# Template file for 'la-capitaine-icon-theme'
+pkgname=la-capitaine-icon-theme
+version=0.6.1
+revision=1
+archs=noarch
+short_desc="Icon pack designed to integrate with most desktop environments"
+maintainer="linarcx <linarcx@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/keeferrourke/la-capitaine-icon-theme"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=9adb3123bf61464696400af43000b61de1825d2ce4b4ad4f21dd78091bd55e73
+
+do_install() {
+	vmkdir usr/share/icons
+	vmkdir usr/share/icons/La-Capitaine-Icon-Theme
+	vcopy ./* usr/share/icons/La-Capitaine-Icon-Theme
+}


### PR DESCRIPTION
An icon pack designed to integrate with most desktop environments. The set of icons takes inspiration from the latest iterations of macOS and Google's Material Design:

https://github.com/keeferrourke/la-capitaine-icon-theme
