### PR TITLE
New package: todoman-3.5.0

### DIFF
--- a/srcpkgs/todoman/template
+++ b/srcpkgs/todoman/template
@@ -1,0 +1,21 @@
+# Template file for 'todoman'
+pkgname=todoman
+version=3.5.0
+revision=1
+archs=noarch
+build_style=python3-module
+pycompile_module="todoman"
+hostmakedepends="python3-setuptools"
+depends="python3-icalendar python3-urwid python3-xdg python3-parsedatetime
+ python3-atomicwrites python3-click python3-configobj python3-click-log
+ python3-dateutil python3-tabulate python3-humanize"
+short_desc="Simple, standards-based, cli todo (aka: task) manager"
+maintainer="Eric Scheibler <email@eric-scheibler.de>"
+license="ISC"
+homepage="https://github.com/pimutils/todoman"
+distfiles="${PYPI_SITE}/t/todoman/todoman-${version}.tar.gz"
+checksum=89032887051b164527b90cfb947eb5162dd8b8bb64d9abf1e906b8c86f933814
+
+post_install() {
+	vlicense LICENCE
+}


### PR DESCRIPTION
Todoman is a simple, standards-based, cli todo (aka: task) manager. Todos are stored into icalendar files, which means you can sync them via CalDAV using, for example, vdirsyncer.

Todoman is now part of the pimutils project, and is hosted at GitHub.

https://todoman.readthedocs.io/en/stable/