### PR TITLE
vim: restore GUI for gvim-huge

### DIFF
--- a/srcpkgs/vim/template
+++ b/srcpkgs/vim/template
@@ -1,7 +1,7 @@
 # Template file for 'vim'
 pkgname=vim
 version=8.1.1729
-revision=1
+revision=2
 hostmakedepends="glib-devel pkg-config"
 makedepends="acl-devel gtk+3-devel libXt-devel lua-devel ncurses-devel
  perl python-devel python3-devel ruby-devel"
@@ -77,7 +77,7 @@ do_configure() {
 
 		cd $wrksrc/gvim-huge
 		./configure ${configure_args} ${args} \
-			--enable-gui=gtk2 --with-x --with-vim-name=gvim-huge \
+			--enable-gui=gtk3 --with-x --with-vim-name=gvim-huge \
 			--with-features=huge --enable-perlinterp --enable-pythoninterp \
 			--enable-rubyinterp --enable-luainterp --enable-terminal
 	fi


### PR DESCRIPTION
Fixes regression in #13276:
```
$ gvim-huge
E25: GUI cannot be used: Not enabled at compile time
```