### PR TITLE
freetype: enable subpixel rendering

### DIFF
--- a/srcpkgs/freetype/patches/enable-subpixel-rendering.patch
+++ b/srcpkgs/freetype/patches/enable-subpixel-rendering.patch
@@ -1,0 +1,11 @@
+--- include/freetype/config/ftoption.h
++++ include/freetype/config/ftoption.h
+@@ -126,7 +126,7 @@
+    * macro is not defined, FreeType offers alternative LCD rendering
+    * technology that produces excellent output without LCD filtering.
+    */
+-/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
++#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
+
+
+   /**************************************************************************

--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,7 +1,7 @@
 # Template file for 'freetype'
 pkgname=freetype
 version=2.10.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-freetype-config"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
This patch enables subpixel rendering (also called ClearType) for freetype.
While ClearType is patented by Microsoft, they joined the Open Source Initiative in 2017; since then Fedora also enabled it by default.