### PR TITLE
freetds: build with ODBC driver

### DIFF
--- a/srcpkgs/freetds/template
+++ b/srcpkgs/freetds/template
@@ -3,9 +3,10 @@ pkgname=freetds
 version=1.1.6
 revision=1
 build_style=gnu-configure
-configure_args="--sysconfdir=/etc/freetds"
+depends="unixodbc"
+configure_args="--sysconfdir=/etc/freetds --with-unixodbc=/usr"
 hostmakedepends="pkg-config"
-makedepends="readline-devel"
+makedepends="readline-devel unixodbc-devel"
 short_desc="Open source implementation of the Tabular Data Stream protocol"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="LGPL-2.0-or-later"


### PR DESCRIPTION
FreeTDS does not build with ODBC driver by default. Using unixodbc as driver manager.