### PR TITLE
prefer versioned .so files in libgssglue dependencies list

### DIFF
--- a/srcpkgs/libgssglue/files/gssapi_mech.conf
+++ b/srcpkgs/libgssglue/files/gssapi_mech.conf
@@ -15,7 +15,7 @@
 # library                               initialization function
 # ================================      ==========================
 # The MIT K5 gssapi library, use special function for initialization.
-/usr/lib/libgssapi_krb5.so		mechglue_internal_krb5_init
+/usr/lib/libgssapi_krb5.so.2		mechglue_internal_krb5_init
 #/usr/lib/libgssapi.so			mechglue_internal_krb5_init
 #
 # The SPKM3 gssapi library function.  Use the function spkm3_gss_initialize.

--- a/srcpkgs/libgssglue/template
+++ b/srcpkgs/libgssglue/template
@@ -1,7 +1,7 @@
 # Template file for 'libgssglue'
 pkgname=libgssglue
 version=0.4
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--disable-static"
 conf_files="/etc/gssapi_mech.conf"

--- a/srcpkgs/mit-krb5/template
+++ b/srcpkgs/mit-krb5/template
@@ -1,4 +1,6 @@
 # Template file for 'mit-krb5'
+# if there is a bump in .so version,
+# also update srcpkgs/libgssglue/files/gssapi_mech.conf
 pkgname=mit-krb5
 version=1.17
 revision=3


### PR DESCRIPTION
rdesktop requires /usr/lib/libgssapi_krb5.so,
that file should come with mit-krb5-libs instead of mit-krb5-devel.