### PR TITLE
cross-*-musl: rebuild for musl-1.1.23

### DIFF
--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=aarch64-linux-musl
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -23,7 +23,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=arm-linux-musleabi
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=arm-linux-musleabihf
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=armv7l-linux-musleabihf
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=i686-linux-musl
@@ -11,7 +11,7 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=3
+revision=4
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -23,7 +23,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=mips-linux-musl
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-mips-linux-muslhf/template
+++ b/srcpkgs/cross-mips-linux-muslhf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=mips-linux-muslhf
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 BE hardfloat target (musl)"
 maintainer="hipperson0 <hipperson0@gmail.com>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=mipsel-linux-musl
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=mipsel-linux-muslhf
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -24,7 +24,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes

--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=powerpc-linux-musl
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 
 short_desc="Cross toolchain for PowerPC (musl)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
@@ -27,7 +27,7 @@ checksum="
  0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3"
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa"
 
 lib32disabled=yes
 nocross=yes

--- a/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
+++ b/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
@@ -1,1 +1,0 @@
-../../musl/patches/ppc64-vrregset-t-fix-layout.patch

--- a/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
+++ b/srcpkgs/cross-powerpc64-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
@@ -1,1 +1,0 @@
-../../musl/patches/ppc64-vrregset-t-vrregs-fix.patch

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -1,7 +1,7 @@
 # Template file for 'cross-powerpc64-linux-musl'
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet="powerpc64-linux-musl"
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for powerpc64 with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -21,7 +21,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
@@ -148,10 +148,6 @@ _musl_build() {
 	[ -f ${wrksrc}/.musl_build_done ] && return 0
 
 	cd ${wrksrc}/musl-${_musl_version}
-
-	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-fix-layout.patch
-	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-vrregs-fix.patch
-
 	msg_normal "Building cross musl libc\n"
 
 	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \

--- a/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
+++ b/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-fix-layout.patch
@@ -1,1 +1,0 @@
-../../musl/patches/ppc64-vrregset-t-fix-layout.patch

--- a/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
+++ b/srcpkgs/cross-powerpc64le-linux-musl/files/ppc64-vrregset-t-vrregs-fix.patch
@@ -1,1 +1,0 @@
-../../musl/patches/ppc64-vrregset-t-vrregs-fix.patch

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -1,7 +1,7 @@
 # Template file for 'cross-powerpc64le-linux-musl'
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet="powerpc64le-linux-musl"
@@ -9,7 +9,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -21,7 +21,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes
@@ -148,10 +148,6 @@ _musl_build() {
 	[ -f ${wrksrc}/.musl_build_done ] && return 0
 
 	cd ${wrksrc}/musl-${_musl_version}
-
-	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-fix-layout.patch
-	_apply_patch -p0 ${FILESDIR}/ppc64-vrregset-t-vrregs-fix.patch
-
 	msg_normal "Building cross musl libc\n"
 
 	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -2,7 +2,7 @@
 #
 _binutils_version=2.32
 _gcc_version=9.1.0
-_musl_version=1.1.22
+_musl_version=1.1.23
 _linux_version=4.19
 
 _triplet=x86_64-linux-musl
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.31
-revision=2
+revision=3
 archs="i686* x86_64 ppc64le"
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -23,7 +23,7 @@ distfiles="
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
- 8b0941a48d2f980fd7036cfbd24aa1d414f03d9a0652ecbd5ec5c7ff1bee29e3
+ 8a0feb41cef26c97dde382c014e68b9bb335c094bbc1356f6edaaf6b79bd14aa
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
 
 lib32disabled=yes


### PR DESCRIPTION
This is both necessary to utilize changes in musl includes when buildings things as well as to fix build for `cross-powerpc64*-linux-musl` as the recent 1.1.23 update of musl removed patches that the crosstoolchains were using.