### PR TITLE
chatty: add .desktop file, take maintainership

### DIFF
--- a/srcpkgs/chatty/files/chatty.desktop
+++ b/srcpkgs/chatty/files/chatty.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Chatty
+Exec=/usr/bin/chatty
+Icon=chatty
+Terminal=false
+Type=Application
+Categories=Application;Network;
+Keywords=twitch;chat;

--- a/srcpkgs/chatty/template
+++ b/srcpkgs/chatty/template
@@ -1,12 +1,12 @@
 # Template file for 'chatty'
 pkgname=chatty
 version=0.9.7
-revision=1
+revision=2
 archs=noarch
 hostmakedepends="openjdk gradle"
 depends="virtual?java-runtime"
-short_desc="Chatty is a Twitch Chat Client for Desktop"
-maintainer="Phenethylamine <beta.phenylethylamine@gmail.com>"
+short_desc="Twitch Chat Client for Desktop"
+maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-3"
 homepage="http://chatty.github.io/"
 distfiles="https://github.com/chatty/chatty/archive/v${version}.tar.gz"
@@ -32,6 +32,7 @@ do_install() {
 	vbin $FILESDIR/${pkgname}
 
 	vinstall src/${pkgname}/gui/app_main_64.png 644 usr/share/pixmaps chatty.png
+	vinstall ${FILESDIR}/chatty.desktop 644 usr/share/applications
 
 	vlicense assets/LICENSE
 }


### PR DESCRIPTION
Add a desktop entry.

Also take maintainership. I use that package and the current maintainer is inactive for over a year now.