### PR TITLE
inkscape: fix extensions when python3 is default

### DIFF
--- a/srcpkgs/inkscape/patches/use-python2.patch
+++ b/srcpkgs/inkscape/patches/use-python2.patch
@@ -1,0 +1,11 @@
+--- src/extension/implementation/script.cpp.orig
++++ src/extension/implementation/script.cpp
+@@ -87,7 +87,7 @@
+ #ifdef WIN32
+         {"python", "python-interpreter", "pythonw" },
+ #else
+-        {"python", "python-interpreter", "python" },
++        {"python", "python-interpreter", "python2" },
+ #endif
+         {"ruby",   "ruby-interpreter",   "ruby"   },
+         {"shell",  "shell-interpreter",  "sh"     },

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.92.4
-revision=5
+revision=6
 wrksrc="${pkgname}-INKSCAPE_${version//./_}"
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
@@ -12,7 +12,7 @@ makedepends="popt-devel libpng-devel gsl-devel gc-devel gtkmm2-devel libxslt-dev
  lcms2-devel poppler-glib-devel boost-devel libmagick6-devel
  libvisio-devel libwpg-devel libcdr-devel dbus-glib-devel libgomp-devel
  potrace-devel cairomm-devel"
-depends="desktop-file-utils hicolor-icon-theme python-lxml"
+depends="desktop-file-utils hicolor-icon-theme python-lxml python-numpy python-scour"
 short_desc="Vector-based drawing program"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2, LGPL-2.1"


### PR DESCRIPTION
Also add missing python modules that some extensions rely on.

The issue is that `inkscape` just blindly calls `python` assuming its python2. Since `python2` is always `python2` on void, this is a decent temp fix until `inkscape` gets their python3 going. At that point, it'll probably have to be changed to always pick `python3` ... but that's fine.