### PR TITLE
pycharm-community: update to 2019.2

### DIFF
--- a/srcpkgs/pycharm-community/template
+++ b/srcpkgs/pycharm-community/template
@@ -1,6 +1,6 @@
 # Template file for 'pycharm-community'
 pkgname=pycharm-community
-version=2018.3.4
+version=2019.2
 revision=1
 archs="i686 x86_64"
 depends="virtual?java-environment giflib libXtst"
@@ -9,7 +9,7 @@ maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/pycharm/"
 distfiles="https://download-cf.jetbrains.com/python/${pkgname}-${version}.tar.gz"
-checksum=789bffb179f569cea9e867c04d52d1a05f587134759b188d21d4007127ff7f86
+checksum=632015cc40d6e4a874ab5cbab0430ec1962cd3c4a7ff5f083ce88242180f784b
 repository=nonfree
 nopie=yes
 
@@ -33,14 +33,16 @@ do_install() {
 	rm -vf ${DESTDIR}/usr/lib/pycharm/helpers/pydev/pydevd_attach_to_process/attach_*.dylib
 	rm -vf ${DESTDIR}/usr/lib/pycharm/helpers/pydev/third_party/wrapped_for_pydev/ctypes/_ctypes.dll
 
+	rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/ppc64le/libpty.so
+
 	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 		rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier
 		rm -vf ${DESTDIR}/usr/lib/pycharm/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
-		rm -vf ${DESTDIR}/usr/lib/pycharm/lib/libpty/linux/x86/libpty.so
+		rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86/libpty.so
 	else
 		rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier64
 		rm -vf ${DESTDIR}/usr/lib/pycharm/helpers/pydev/pydevd_attach_to_process/attach_linux_amd64.so
-		rm -vf ${DESTDIR}/usr/lib/pycharm/lib/libpty/linux/x86_64/libpty.so
+		rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86_64/libpty.so
 	fi
 
 	ln -sf /usr/lib/pycharm/bin/pycharm.sh ${DESTDIR}/usr/bin/pycharm


### PR DESCRIPTION
It seems like some stuff for ppc64le was added, though I can't test that, since openjdk won't cross-compile.