### PR TITLE
xbps-src: add XBPS_LIBC/XBPS_TARGET_LIBC

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -312,6 +312,18 @@ setup_pkg() {
         XBPS_CHECKVERS_XCMD="$XBPS_CHECKVERS_CMD"
     fi
 
+    if [ "${XBPS_MACHINE%-*}" = "${XBPS_MACHINE}" ]; then
+        export XBPS_LIBC="glibc"
+    else
+        export XBPS_LIBC="${XBPS_MACHINE#*-}"
+    fi
+
+    if [ "${XBPS_TARGET_MACHINE%-*}" = "${XBPS_TARGET_MACHINE}" ]; then
+        export XBPS_TARGET_LIBC="glibc"
+    else
+        export XBPS_TARGET_LIBC="${XBPS_TARGET_MACHINE#*-}"
+    fi
+
     export XBPS_INSTALL_XCMD XBPS_QUERY_XCMD XBPS_RECONFIGURE_XCMD \
         XBPS_REMOVE_XCMD XBPS_RINDEX_XCMD XBPS_UHELPER_XCMD
 


### PR DESCRIPTION
This can be used in template checks to remove the clunky case statements and pattern matching, as well as simplify normal ifs.

For example:

```
if [ "${XBPS_TARGET_MACHINE%-musl}" = "${XBPS_TARGET_MACHINE}" ]; then
    ... glibc specific ...
fi
```

or

```
case "$XBPS_TARGET_MACHINE" in
    *-musl) ;;
    *) ... glibc specific ...
esac
```

becomes a simple:

```
if [ "${XBPS_TARGET_LIBC}" = "glibc" ]; then
   ... glibc specific ...
fi
```

I've noticed these are common enough of patterns in our stuff to make this worthwhile. The implementation should be sound, I checked and there aren't any `uname` values with a dash in them.