### PR TITLE
rpi-kernel: update to 4.19.60.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="246113692edbef9a438b31ab2dd0172a30ed5eb2"
+_githash="20565c94ca877a099a3c9c5fa39a0380f3d16491"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.58
+version=4.19.60
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=47f9626324c16aae2318fc83fa96f16e4e75eaf18eccbe40302645d2d17d7834
+checksum=54e5ee55734b6a50a20c0588ab3dc7100ce5f411ccb5488bb2fe5cad7f7f99c3
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

Tested cross building for armv6l, armv7l, and aarch64.