### PR TITLE
iptables: split out an iptables-nft subpackage with nftables-based wrappers.

### DIFF
--- a/srcpkgs/iptables-nft
+++ b/srcpkgs/iptables-nft
@@ -1,0 +1,1 @@
+iptables

--- a/srcpkgs/iptables/template
+++ b/srcpkgs/iptables/template
@@ -1,7 +1,7 @@
 # Template file for 'iptables'
 pkgname=iptables
 version=1.8.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libipq --enable-shared --enable-devel --enable-bpf-compiler"
 hostmakedepends="pkg-config flex"
@@ -13,6 +13,13 @@ license="GPL-2.0-or-later"
 homepage="https://www.netfilter.org/"
 distfiles="https://www.netfilter.org/projects/iptables/files/iptables-${version}.tar.bz2"
 checksum=a23cac034181206b4545f4e7e730e76e08b5f3dd78771ba9645a6756de9cdd80
+	alternatives="
+		iptables:ip6tables:/usr/bin/xtables-legacy-multi
+		iptables:ip6tables-restore:/usr/bin/xtables-legacy-multi
+		iptables:ip6tables-save:/usr/bin/xtables-legacy-multi
+		iptables:iptables:/usr/bin/xtables-legacy-multi
+		iptables:iptables-restore:/usr/bin/xtables-legacy-multi
+		iptables:iptables-save:/usr/bin/xtables-legacy-multi"
 
 pre_build() {
 	rm include/linux/types.h
@@ -31,6 +38,9 @@ post_install() {
 		vinstall ${FILESDIR}/empty-${f}.rules 644 \
 			var/lib/iptables empty-${f}.rules
 	done
+	for i in ip{6,}tables{-save,-restore,} ; do
+		rm -f "usr/bin/${i}"
+	done
 }
 
 iptables-devel_package() {
@@ -42,4 +52,17 @@ iptables-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove usr/share/man/man3
 	}
+}
+
+iptables-nft_package() {
+	build_style=meta
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc="Iptables-compatible wrapper commands for nftables"
+	alternatives="
+		iptables:ip6tables:/usr/bin/xtables-nft-multi
+		iptables:ip6tables-restore:/usr/bin/xtables-nft-multi
+		iptables:ip6tables-save:/usr/bin/xtables-nft-multi
+		iptables:iptables:/usr/bin/xtables-nft-multi
+		iptables:iptables-restore:/usr/bin/xtables-nft-multi
+		iptables:iptables-save:/usr/bin/xtables-nft-multi"
 }


### PR DESCRIPTION
Possibly this could be useful for people who use iptables and want to run
docker on Void.  Docker tries to add firewall rules with iptables, but
mixing iptables and nftables is a bad idea.
In my brief experimentation, the nftables-based wrappers for iptables
solve that problem for me.