### PR TITLE
New package: Viber

### DIFF
--- a/srcpkgs/viber/template
+++ b/srcpkgs/viber/template
@@ -1,0 +1,36 @@
+# Template file for 'viber'
+pkgname=viber
+version=10.3.0
+revision=37
+archs="x86_64"
+build_style=fetch
+short_desc="Viber is a cross-platform VoIP and IM software application"
+license="viber"
+homepage="https://www.viber.com/"
+_openssl_version=1.0-1.0.2.s-1
+distfiles="https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb https://sgp.mirror.pkgbuild.com/core/os/x86_64/openssl-${_openssl_version}-x86_64.pkg.tar.xz"
+checksum="a5d7d99afc8c186643d1393152a4729c4fc805f4241896c2f004c721619efe7c 13c5b5c1a372cf9c481b2beb7e5fc607ccf52173d6075ae10281e4a3da179514"
+nocross=yes
+nostrip=yes
+repository=nonfree
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/viber.deb
+	unxz data.tar.xz
+	tar xopf data.tar
+	gunzip control.tar.gz
+	tar xopf control.tar
+	unxz -f ${XBPS_SRCDISTDIR}/${pkgname}-${version}/openssl-${_openssl_version}-x86_64.pkg.tar.xz --stdout > openssl.tar
+	mkdir openssl
+	tar xopf openssl.tar -C openssl
+}
+
+do_install() {
+	vcopy usr /
+	vcopy opt /
+	vbin preinst
+	vbin postinst
+	vcopy openssl/usr/lib/libssl.so.1.0.0 /opt/viber/lib/libssl.so
+	vcopy openssl/usr/lib/libcrypto.so.1.0.0 /opt/viber/lib/libcrypto.so
+}
+


### PR DESCRIPTION
New package: viber-10.3.0_37

It has a problem - it can't be versioned "https://download.cdn.viber.com/cdn/desktop/Linux/viber.deb" it does not have any parameters.
Does exist any way to disable "checksum" it is checks inside "preinst" script?