### PR TITLE
xfce4: add xfce-polkit as dependency

### DIFF
--- a/srcpkgs/xfce4/template
+++ b/srcpkgs/xfce4/template
@@ -1,7 +1,7 @@
-# Template file for 'xfce4'.
+# Template file for 'xfce4'
 pkgname=xfce4
 version=4.12.0
-revision=7
+revision=8
 build_style=meta
 depends="
 	xfce4-appfinder>=${version}
@@ -27,8 +27,9 @@ depends="
 	tumbler>=0.1.31
 	xdg-user-dirs-gtk
 	ConsoleKit2
-	upower"
-short_desc="The XFCE meta-package for Void Linux"
+	upower
+	xfce-polkit"
+short_desc="XFCE meta-package for Void Linux"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2, LGPL-2.1, BSD"
 homepage="https://xfce.org/"


### PR DESCRIPTION
Xfce needs a gui polkit helper, otherwise gui programs that ask for authentication cannot work. When something is launched from cli, the barebones cli helper is enough.