### PR TITLE
pyside-tools: remove package

### DIFF
--- a/srcpkgs/pyside-tools/INSTALL.msg
+++ b/srcpkgs/pyside-tools/INSTALL.msg
@@ -1,0 +1,1 @@
+pyside-tools is no longer provided by Void Linux, and will be fully removed from the repos on 2019-10-30

--- a/srcpkgs/pyside-tools/template
+++ b/srcpkgs/pyside-tools/template
@@ -1,18 +1,9 @@
 # Template file for 'pyside-tools'
 pkgname=pyside-tools
 version=0.2.15
-revision=1
-wrksrc="Tools-${version}"
-build_style=cmake
-
-# libshiboken-python-devel libpyside-python-devel has distinct conventions
-configure_args="-DPYTHON_SUFFIX=-python2.7 -DPYTHON_BASENAME=-python2.7"
-makedepends="libshiboken-python-devel libpyside-python-devel qt-devel"
-depends="python"
-pycompile_module="pysideuic"
-short_desc="LGPL-licensed Python2 bindings for the Qt4 toolkit"
-maintainer="yopito <pierre.bourgin@free.fr>"
-license="LGPL-2.1"
+revision=2
+archs=noarch
+build_style=meta
+short_desc="LGPL-licensed Python2 bindings for the Qt4 toolkit (removed package)"
+license="BSD-2-Clause"
 homepage="https://wiki.qt.io/"
-distfiles="https://github.com/PySide/Tools/archive/${version}.tar.gz"
-checksum=8a7fe786b19c5b2b4380aff0a9590b3129fad4a0f6f3df1f39593d79b01a9f74


### PR DESCRIPTION
Resolves #12844 
pyside-tools was broken when python-pyside was removed here: https://github.com/void-linux/void-packages/pull/11064

It looks like we do not intend to support these bindings, so removing this package is the correct solution.