### PR TITLE
llvm8: Move /usr/bin/wasm-ld into lld subpackage.

### DIFF
--- a/srcpkgs/llvm8/template
+++ b/srcpkgs/llvm8/template
@@ -1,7 +1,7 @@
-# Template file for 'llvm8'.
+# Template file for 'llvm8'
 pkgname=llvm8
 version=8.0.0
-revision=6
+revision=7
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="
@@ -223,6 +223,7 @@ lld_package() {
 	homepage="https://lld.llvm.org"
 	pkg_install() {
 		vmove usr/bin/lld*
+		vmove usr/bin/wasm-ld
 		vmove usr/bin/ld.lld*
 	}
 }


### PR DESCRIPTION
Fixes #12806 by moving the symlink into the subpackage.