### PR TITLE
rtl8812au-dkms: update module version to 5.2.20

### DIFF
--- a/srcpkgs/rtl8812au-dkms/template
+++ b/srcpkgs/rtl8812au-dkms/template
@@ -1,31 +1,29 @@
 # Template file for 'rtl8812au-dkms'
 pkgname=rtl8812au-dkms
-version=20190724
+version=20190731
 revision=1
-_gitrev=981899f422fb25a95218a146619c7cda3ed5297c
+_gitrev=6faa3eaf8916667cb7f4ab59923b3608e6ab7b18
 archs=noarch
-wrksrc="rtl8812AU_8821AU_linux-${_gitrev}"
+wrksrc="rtl8812au-${_gitrev}"
 depends="dkms"
 short_desc="Realtek 8812AU/8821AU USB WiFi driver (DKMS)"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://www.dlink.com"
-distfiles="https://github.com/abperiasamy/rtl8812AU_8821AU_linux/archive/${_gitrev}.tar.gz"
-checksum=9dfdf627043409bb7bc4e731fded5c7fcda060ebfea62ae9b47e96dfe3b7f58a
-dkms_modules="rtl8812au 4.3.14"
+distfiles="https://github.com/gordboy/rtl8812au/archive/${_gitrev}.tar.gz"
+checksum=dfe05443cd0c52f86a4457efcefcbf9789d4131eb2957907e85d49ee250d211d
+dkms_modules="rtl8812au 5.2.20"
 
 do_install() {
 	local modname=rtl8812au
-	local modver=4.3.14
+	local modver=5.2.20
 	local dest=/usr/src/${modname}-${modver}
 
 	vmkdir ${dest}
-	cp -r dkms.conf Kconfig Makefile.dkms Makefile platform core hal include os_dep ${DESTDIR}/${dest}
-	cp Makefile ${DESTDIR}/${dest}/Makefile
-	sed "s/#MODULE_VERSION#/${modver}/" dkms.conf > ${DESTDIR}/${dest}/dkms.conf
+	cp -r dkms.conf Kconfig Makefile platform core hal include os_dep ${DESTDIR}/${dest}
 
 	# modules-load.d(5) file.
 	vmkdir usr/lib/modules-load.d
-	echo "rtl8812au" > ${DESTDIR}/usr/lib/modules-load.d/${pkgname}.conf
+	echo "8812au" > ${DESTDIR}/usr/lib/modules-load.d/${pkgname}.conf
 	chmod 644 ${DESTDIR}/usr/lib/modules-load.d/${pkgname}.conf
 }


### PR DESCRIPTION
Change source repository to https://github.com/gordboy/rtl8812au which
provides newer version of the module.