### PR TITLE
scrcpy: Add post install message to scrcpy

### DIFF
--- a/srcpkgs/scrcpy/INSTALL.msg
+++ b/srcpkgs/scrcpy/INSTALL.msg
@@ -1,0 +1,6 @@
+If you encounter the following error:
+  adb: error: cannot stat '/usr/bin/scrcpy-server.jar': No such file or directory
+  ERROR: "adb push" returned with value 1
+
+Execute "export SCRCPY_SERVER_PATH=/usr/share/scrcpy/scrcpy-server-v1.9.jar"
+before executing scrcpy, or add it in your ~/.bashrc file.

--- a/srcpkgs/scrcpy/template
+++ b/srcpkgs/scrcpy/template
@@ -1,7 +1,7 @@
 # Template file for 'scrcpy'
 pkgname=scrcpy
 version=1.9
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dbuild_server=false
  -Doverride_server_path=/usr/share/scrcpy/scrcpy-server-v${version}.jar"


### PR DESCRIPTION
With the latest update to scrcpy, executing it would result in this error:
```
adb: error: cannot stat '/usr/bin/scrcpy-server.jar': No such file or directory
ERROR: "adb push" returned with value 1
```
It seems that override_server_path in the build argument is not working in this version. I added a post install message to show how to fix that.

I could change the install location of scrcpy-server.jar to /usr/bin as based on the documentation of scrcpy, it seems to use the directory where scrcpy is located.
