### PR TITLE
crystal: update to 0.30.0.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,16 +1,16 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.29.0
+version=0.30.0
 revision=1
 archs="x86_64* i686* aarch64* arm*"
-_shardsversion=0.8.1
-_bootstrapversion=0.29.0
+_shardsversion=0.9.0
+_bootstrapversion=0.30.0
 _bootstraprevision=1
-hostmakedepends="git llvm6.0"
+hostmakedepends="git llvm8"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
  libxml2-devel"
 depends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
- libxml2-devel gmp-devel libressl-devel llvm6.0 gcc pkg-config"
+ libxml2-devel gmp-devel libressl-devel llvm8 gcc pkg-config"
 checkdepends="readline-devel libyaml-devel gmp-devel libressl-devel"
 short_desc="Crystal Programming Language"
 maintainer="lvmbdv <ata.kuyumcu@protonmail.com>"
@@ -19,8 +19,8 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="c2265b2a904ded282751f59a3bd0367072058eee1cf51ebe0af03a572f8e19b9
- 75c74ab6acf2d5c59f61a7efd3bbc3c4b1d65217f910340cb818ebf5233207a5"
+checksum="fc884970089e382344540676a9c5aa4f369c9a0f45d1858e079b4ce26878164a
+ 90f230c87cc7b94ca845e6fe34f2523edcadb562d715daaf98603edfa2a94d65"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
 
@@ -32,11 +32,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" cad27db08542947e788e7c06fc00691c05ba678cedf20ecf9baa8cee741233f3"
+		checksum+=" 1995420a5d9146fd21322c96fe8bf87ddf73d5e0273b3c24c3c71d0e6f54cba2"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 0296df4824cadddadba0c052bd1fdc4ad1bdfe5758c688e7b1764ca163bca0db"
+		checksum+=" 81282e2fdaba77a31aeb682deac7cde545a72dfd0ad5b6554002b8fd861e9d3e"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"


### PR DESCRIPTION
- Crystal now [supports LLVM 7 and 8](https://github.com/crystal-lang/crystal/releases/tag/0.30.0)
- Compilation was tested with both i686 and x86_64
- Package was locally installed on x86_64, `crystal` and `shards` work good