### PR TITLE
New package: xdgmenumaker-1.5

### DIFF
--- a/srcpkgs/xdgmenumaker/patches/usr-local-deprecation-fix.patch
+++ b/srcpkgs/xdgmenumaker/patches/usr-local-deprecation-fix.patch
@@ -1,0 +1,6 @@
+diff -Naurp0 a/Makefile b/Makefile
+--- a/Makefile	2018-09-17 01:42:50.000000000 +0600
++++ b/Makefile	2019-07-29 17:36:09.563110157 +0600
+@@ -1 +1 @@
+-PREFIX ?= /usr/local
++PREFIX ?= /usr

--- a/srcpkgs/xdgmenumaker/template
+++ b/srcpkgs/xdgmenumaker/template
@@ -1,0 +1,21 @@
+# Template file for 'xdgmenumaker'
+pkgname=xdgmenumaker
+version=1.5
+revision=1
+hostmakedepends="make"
+depends="python3 python3-xdg pygtk python-gobject gobject-introspection"
+short_desc="Automatic menu generator for WMs, such as, fluxbox, icewm, jwm, pekwm"
+maintainer="reback00 <reback00@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/gapan/xdgmenumaker"
+distfiles="https://github.com/gapan/${pkgname}/archive/${version}.tar.gz"
+checksum=a8319db5998ea1c49e52f6d04aad40334daea8047840c6762b4e7f02082b0573
+patch_args="-Np1"
+
+do_build() {
+	make
+}
+
+do_install() {
+	make DESTDIR="${DESTDIR}" install
+}


### PR DESCRIPTION
`xdgmenumaker` is an automatic menu code generator for blackbox, compizboxmenu, fluxbox, icewm, jwm, pekwm and windowmaker. It creates application menu for lightweight WMs so that they don't have to be typed in manually.

Hope it's useful!