### PR TITLE
ibus-bamboo: update to 0.5.2

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.5.1
+version=0.5.2
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="58dcbc97e8e8546f1410747ebedf76ecba834755cc4e767df7d5a63cb049814a"
+checksum="f2c0763fc41b43059d8a399dde130a1f09af02e08067595262e1e9c0ed72f927"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
- Implement auto capitalize abbreviation feature
- Allow uoiwo -> uo^i instead of u?oio