### PR TITLE
rpi-kernel: update to 4.19.63.

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,9 +1,9 @@
 # Template file for 'rpi-firmware'
-_githash="d095b96ac33de9eb4b95539cb3261f35a3c74509"
+_githash="3822340923e5cddc772492386d82ba00f4275d62"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20190218
+version=20190801
 revision=1
 archs=noarch
 wrksrc="firmware-${_githash}"
@@ -12,7 +12,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=058c1c1411ef1830a9cf5faa29cada8dad89c2bc84ce1a449952ef56f8662fc0
+checksum=35a5b0a30cdc68aeeda355a506dc967bc5de5cf7fc94e90367d979bff0a0f0bb
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="20565c94ca877a099a3c9c5fa39a0380f3d16491"
+_githash="dee43611031fb719b1472e14d9e90e176284d98c"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.60
+version=4.19.63
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=54e5ee55734b6a50a20c0588ab3dc7100ce5f411ccb5488bb2fe5cad7f7f99c3
+checksum=608495b1e1f946cc2c96b9d4ec741613755e575bde7ad1adfea33df15eb5435b
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
Also update rpi-firmware.

Built for armv6l, armv7l, and aarch64.

Tested with armv6l and armv7l.