### PR TITLE
nodejs: ppc build fixes + generalize cross for all architectures

### DIFF
--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -32,12 +32,20 @@ replaces="iojs>=0"
 conflicts="nodejs-lts"
 provides="nodejs-runtime-0_1"
 
+if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
+	nocross="host and target must have the same pointer size"
+fi
+
+# v8 requires libatomic on ppc*/s390x/mips*
 case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		case "$XBPS_MACHINE" in
-			x86_64*|aarch64*)
-				nocross="Can't cross-compile to 32bit-host from 64bit-host";;
-		esac ;;
+	mips*|ppc*) makedepends+=" libatomic-devel" ;;
+	*) ;;
+esac
+
+# also need it on host when it's one of those archs
+case "$XBPS_MACHINE" in
+	mips*|ppc*) hostmakedepends+=" libatomic-devel" ;;
+	*) ;;
 esac
 
 do_configure() {
@@ -46,10 +54,23 @@ do_configure() {
 	export LD="$CXX"
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
+			arm*) _args="--dest-cpu=arm" ;;
 			aarch64*) _args="--dest-cpu=arm64" ;;
 			ppc64*) _args="--dest-cpu=ppc64" ;;
+			ppc*) _args="--dest-cpu=ppc" ;;
+			mipsel*) _args="--dest-cpu=mipsel" ;;
+			mips*) _args="--dest-cpu=mips" ;;
+			i686*) _args="--dest-cpu=x86" ;;
+			x86_64*) _args="--dest-cpu=x86_64" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
 		esac
+		# this is necessary - for example, normally compiling from ppc64le
+		# to ppc64 or from glibc to musl is considered non-cross-compiling
+		# by the build system, because it's technically the same architecture
+		#
+		# that results in the toolset built for target only, and attempting
+		# to execute it within the build system fails
+		_args+=" --cross-compiling"
 	fi
 	./configure --prefix=/usr --shared-zlib \
 		$(vopt_if icu --with-intl=system-icu) \


### PR DESCRIPTION
This generalizes the ugly cross-compiling checks for the new `XBPS_WORDSIZE` and `XBPS_TARGET_WORDSIZE`, also adds more `--dest-cpu` for all the architectures with cross-profiles we have, and fixes build for ppc/mips where libatomic is newly required (on both host and target).

@leahneukirchen 