### PR TITLE
dhcpcd: update to 8.0.2.

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,6 +1,6 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
-version=8.0.1
+version=8.0.2
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --rundir=/run"
@@ -11,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/dhcpcd"
 distfiles="https://roy.marples.name/downloads/dhcpcd/dhcpcd-${version}.tar.xz"
-checksum=031f4fbef5ad41b44714fec343ff5be898e3e3cd5e7c53d6ef3aaec43cdba931
+checksum=33a26ad561546cd2cfe1e6de6352a85df72b41c37def8c7eb00e90e57c627a5c
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
 


### PR DESCRIPTION
This should address the creation of a lot of `/tmp/dhcpcd-env-script-XXXXX` files as noted here:

https://www.reddit.com/r/voidlinux/comments/cmsq7y/is_your_dhcpcd_v80_filling_up_tmp_with/

According to the [ChangeLog](https://roy.marples.name/archives/dhcpcd-discuss/0002528.html)

> *  script: tmp files are removed for systems without open_memstream(3)
> *  configure: open_memstream(3) detected on recent glibc