### PR TITLE
xbps-src: generalize 32-bit masterdirs on 64-bit hosts

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -580,11 +580,29 @@ fi
 chroot_check
 check_native_arch
 
-# Reconfigure pkgs for 32bit on x86_64 and reexec itself.
-# XXX: how about 32bit userland on 64bit CPUs? (ppc, arm, etc).
+# test if to use linux32 for 32-bit masterdirs in 64-bit environments
+# x86_64, ppc64 (BE) and aarch64 are capable of this, others are not
+linux32_check() {
+    local hostarch="$1"
+    local tgtarch="$2"
+    case "$hostarch" in
+        x86_64*) if [[ "$tgtarch" == i686* ]]; then return 0; fi ;;
+        ppc64le*) return 1 ;;
+        ppc64*)
+            case "$tgtarch" in
+                ppc64*) return 1 ;;
+                ppc*) return 0 ;;
+            esac
+            ;;
+        aarch64*) if [[ "$tgtarch" == armv* ]]; then return 0; fi ;;
+    esac
+    return 1
+}
+
+# Reconfigure pkgs for 32bit on 64-bit systems and reexec itself.
 if [ -z "$XBPS_REINIT" -a -s $XBPS_MASTERDIR/.xbps_chroot_init ]; then
     export XBPS_ARCH=${XBPS_ARCH:-$(<$XBPS_MASTERDIR/.xbps_chroot_init)}
-    if [[ $XBPS_MACHINE == x86_64* ]] && [[ $XBPS_ARCH == i686* ]]; then
+    if linux32_check "$XBPS_MACHINE" "$XBPS_ARCH"; then
         # reconfigure pkgs via linux32
         linux32 xbps-reconfigure -r ${XBPS_MASTERDIR} -a &>/dev/null
         # reexec itself via linux32


### PR DESCRIPTION
Previously the check was hardcoded for i686 on x86_64. This can however also work for ppc64 (BE) running a ppc masterdir as well as aarch64 running armv* masterdirs.