### PR TITLE
keepassxc: added support for network and KeeShare by default

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -1,7 +1,7 @@
 # Template file for 'keepassxc'
 pkgname=keepassxc
 version=2.4.3
-revision=3
+revision=2
 build_style=cmake
 configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF
  -DWITH_XC_AUTOTYPE=$(vopt_if autotype ON OFF)
@@ -11,15 +11,13 @@ configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF
  -DWITH_XC_NETWORKING=$(vopt_if network ON OFF)
  -DWITH_XC_SSHAGENT=$(vopt_if sshagent ON OFF)
  -DWITH_XC_YUBIKEY=$(vopt_if yubikey ON OFF)"
-hostmakedepends="qt5-qmake qt5-host-tools"
+hostmakedepends="qt5-qmake qt5-host-tools m4"
 makedepends="qt5-tools-devel qt5-svg-devel libgcrypt-devel libargon2-devel
  qrencode-devel
  $(vopt_if autotype 'qt5-x11extras-devel libXtst-devel libXi-devel')
  $(vopt_if browser libsodium-devel)
  $(vopt_if keeshare quazip-devel)
- $(vopt_if network libcurl-devel)
- $(vopt_if yubikey 'libykpers-devel libyubikey-devel')
- $(vopt_if keyshare quazip-devel)"
+ $(vopt_if yubikey 'libykpers-devel libyubikey-devel')"
 short_desc="KeePassXC is a cross-platform port of “Keepass Password Safe”"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,

--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -1,11 +1,12 @@
 # Template file for 'keepassxc'
 pkgname=keepassxc
 version=2.4.3
-revision=1
+revision=3
 build_style=cmake
 configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF
  -DWITH_XC_AUTOTYPE=$(vopt_if autotype ON OFF)
  -DWITH_XC_BROWSER=$(vopt_if browser ON OFF)
+ -DWITH_XC_KEESHARE=$(vopt_if keeshare ON OFF)
  -DWITH_XC_KEESHARE_SECURE=$(vopt_if keeshare ON OFF)
  -DWITH_XC_NETWORKING=$(vopt_if network ON OFF)
  -DWITH_XC_SSHAGENT=$(vopt_if sshagent ON OFF)
@@ -17,7 +18,8 @@ makedepends="qt5-tools-devel qt5-svg-devel libgcrypt-devel libargon2-devel
  $(vopt_if browser libsodium-devel)
  $(vopt_if keeshare quazip-devel)
  $(vopt_if network libcurl-devel)
- $(vopt_if yubikey 'libykpers-devel libyubikey-devel')"
+ $(vopt_if yubikey 'libykpers-devel libyubikey-devel')
+ $(vopt_if keyshare quazip-devel)"
 short_desc="KeePassXC is a cross-platform port of “Keepass Password Safe”"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,
@@ -27,14 +29,14 @@ distfiles="https://github.com/keepassxreboot/keepassxc/releases/download/${versi
 checksum=d7c952192131047689c3f8fb7275df0e0dfbf2094a554dbbee9a6d6cfa8f2734
 
 # https://github.com/keepassxreboot/keepassxc/blob/a775031fe9471310e50232d1861d4991e2803aff/CMakeLists.txt#L46
-build_options="browser keeshare network sshagent yubikey"
+build_options="autotype browser keeshare network sshagent yubikey"
 desc_option_autotype="Include auto-type"
 desc_option_browser="Include browser integration with keepassxc-browser-plugin"
 desc_option_keeshare="Include sharing integration with KeeShare"
 desc_option_network="Include networking code (favicon download)"
 desc_option_sshagent="Include SSH agent support"
 desc_option_yubikey="Include YubiKey support"
-build_options_default="autotype browser keeshare sshagent yubikey"
+build_options_default="autotype browser keeshare network sshagent yubikey"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
I changed the default build_options to build with the Network and KeeShare support. Network allows a user to download key icons and KeeShare allows users to share subset of keys securely.