### PR TITLE
folks: explicitly disable building with LTO

### DIFF
--- a/srcpkgs/folks/template
+++ b/srcpkgs/folks/template
@@ -1,9 +1,9 @@
 # Template file for 'folks'
 pkgname=folks
 version=0.12.1
-revision=1
+revision=2
 build_style=meson
-configure_args="-Dlibsocialweb-backend=false $(vopt_bool vala vala)"
+configure_args="-Db_lto=false -Dlibsocialweb-backend=false $(vopt_bool vala vala)"
 hostmakedepends="pkg-config intltool glib-devel $(vopt_if vala vala)
  python $(vopt_if gir gobject-introspection)"
 makedepends="readline-devel telepathy-glib-devel zeitgeist-devel


### PR DESCRIPTION
Since version 0.12 libfolks is building with LTO (Link Time Optimizations)
by default. This leads to a several problems, e.g. Geary simply crashes
with segfault at startup.
Explicitly disable LTO during build to avoid such malfunction.

This matches the solutions from Arch Linux (https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/folks&id=484f2a1114d6756228b0383568447d1a9aa0df42) and Clear Linux  (https://github.com/clearlinux/distribution/issues/1013#issuecomment-514293511).
Geary seems to work now.