### PR TITLE
nodejs, nodejs-lts: disable asm for openssl on ppc64, add ppc32 patch

### DIFF
--- a/srcpkgs/nodejs-lts/patches/ppc32.patch
+++ b/srcpkgs/nodejs-lts/patches/ppc32.patch
@@ -1,0 +1,18 @@
+--- deps/v8/src/libsampler/sampler.cc
++++ deps/v8/src/libsampler/sampler.cc
+@@ -418,9 +418,15 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
+       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R31]);
+ #else
+   // Some C libraries, notably Musl, define the regs member as a void pointer
++  #if !V8_TARGET_ARCH_32_BIT
+   state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[32]);
+   state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[1]);
+   state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[31]);
++  #else
++  state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[32]);
++  state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[1]);
++  state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[31]);
++  #endif
+ #endif
+ #elif V8_HOST_ARCH_S390
+ #if V8_TARGET_ARCH_32_BIT

--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -36,6 +36,10 @@ do_configure() {
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}\n" ;;
 		esac
 	fi
+	# their pregenerated asm is for ELFv1...
+	case "$XBPS_TARGET_MACHINE" in
+		ppc64|ppc64-musl) _args+=" --openssl-no-asm" ;;
+	esac
 	./configure --prefix=/usr --shared-zlib \
 		$(vopt_if icu --with-intl=system-icu) \
 		$(vopt_if http_parser --shared-http-parser) \

--- a/srcpkgs/nodejs/patches/ppc32.patch
+++ b/srcpkgs/nodejs/patches/ppc32.patch
@@ -1,0 +1,18 @@
+--- deps/v8/src/libsampler/sampler.cc
++++ deps/v8/src/libsampler/sampler.cc
+@@ -418,9 +418,15 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
+       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R31]);
+ #else
+   // Some C libraries, notably Musl, define the regs member as a void pointer
++  #if !V8_TARGET_ARCH_32_BIT
+   state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[32]);
+   state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[1]);
+   state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[31]);
++  #else
++  state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[32]);
++  state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[1]);
++  state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[31]);
++  #endif
+ #endif
+ #elif V8_HOST_ARCH_S390
+ #if V8_TARGET_ARCH_32_BIT

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -72,6 +72,10 @@ do_configure() {
 		# to execute it within the build system fails
 		_args+=" --cross-compiling"
 	fi
+	# their pregenerated asm is for ELFv1...
+	case "$XBPS_TARGET_MACHINE" in
+		ppc64|ppc64-musl) _args+=" --openssl-no-asm" ;;
+	esac
 	./configure --prefix=/usr --shared-zlib \
 		$(vopt_if icu --with-intl=system-icu) \
 		$(vopt_if http_parser --shared-http-parser) \


### PR DESCRIPTION
The openssl asm disable is needed because nodejs ships pregenerated versions that are for ELFv1 on big endian, while we use ELFv2.