### PR TITLE
icu: use separate .dat file for data

### DIFF
--- a/srcpkgs/icu/template
+++ b/srcpkgs/icu/template
@@ -3,12 +3,14 @@
 #       next soname bump.
 pkgname=icu
 version=64.2
-revision=1
+revision=2
 wrksrc=icu
 build_wrksrc=source
 build_style=gnu-configure
+# use archive data instead of .so data for correct cross-compiling
+configure_args="--with-data-packaging=archive"
 hostmakedepends="pkg-config"
-short_desc="Robust and full-featured Unicode services"
+short_desc="Robust and fully-featured Unicode libraries"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="ICU"
 homepage="http://www.icu-project.org/"
@@ -18,6 +20,12 @@ checksum=627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --with-cross-build=${XBPS_BUILDDIR}/${wrksrc}/host-icu"
 fi
+
+# we will be managing icudata manually, because when cross-compiling for
+# another endianness the output data is broken... fortunately, we can use
+# icupkg to convert host-endianness data to target-endianness data
+_icu_dat="icudt${version%.*}"
+_icu_data="source/data/in"
 
 pre_configure() {
 
@@ -51,10 +59,36 @@ pre_configure() {
 	# probably other stuff breaks too, so let's just do it.
 	# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=653457
 	sed -e 's,-nostdlib,,g' -i ${wrksrc}/source/config/mh-linux
+
+	export CFLAGS="${CFLAGS} -DICU_DATA_DIR=\\\"/usr/share/icu/${version}\\\""
+	export CXXFLAGS="${CFLAGS} -DICU_DATA_DIR=\\\"/usr/share/icu/${version}\\\""
+
+	# makefile dependency bug: this directory needs to be created manually
+	mkdir -p ${wrksrc}/source/data/out/tmp
 }
 
 post_install() {
 	vlicense $wrksrc/LICENSE
+
+	# handled separately
+	rm -f ${DESTDIR}/usr/share/icu/${version}/${_icu_dat}${XBPS_TARGET_ENDIAN%e}.dat
+
+	# for little endian just use the file that's there
+	if [ "$XBPS_TARGET_ENDIAN" != "be" ]; then
+		return
+	fi
+
+	# for big endian, we need to convert the file that's there with icupkg
+	local _icupkg_path="${DESTDIR}/usr"
+	if [ "$CROSS_BUILD" ]; then
+		_icupkg_path="${wrksrc}/host-icu"
+	fi
+
+	rm -f ${wrksrc}/${_icu_data}/${_icu_dat}b.dat
+
+	LD_LIBRARY_PATH="${_icupkg_path}/lib" ${_icupkg_path}/bin/icupkg -tb \
+	 ${wrksrc}/${_icu_data}/${_icu_dat}l.dat \
+	 ${wrksrc}/${_icu_data}/${_icu_dat}b.dat
 }
 
 icu-devel_package() {
@@ -74,5 +108,11 @@ icu-libs_package() {
 	short_desc+=" - shared libs"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
+
+		# install data manually
+		vmkdir "usr/share/icu/${version}"
+		install -Dm644 \
+			${wrksrc}/${_icu_data}/${_icu_dat}${XBPS_TARGET_ENDIAN%e}.dat \
+			${PKGDESTDIR}/usr/share/icu/${version}
 	}
 }


### PR DESCRIPTION
This changes the build from using data embedded in `libicudata.so` to using a separate .dat file which is then loaded. The shared library itself remains there, but is much smaller (because of lack of embedded data) and loads the data separately.

This allows manipulation of this data using icu tools, and fixes cross-compiling from little endian to big endian architectures, as we can handle the endian conversion ourselves.

Testing needed by @leahneukirchen (on x86_64 etc) and @pullmoll (on ppc64 cross). I'm particularly curious about whether `mozjs52`/`mozjs60` works now when crosscompiled for ppc64 BE (when paired with https://github.com/void-linux/void-packages/pull/13580; it does work here).

This should not break ABI, but bump is needed because of the packaging changes.