### PR TITLE
rpi-kernel: update to 4.19.65.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="dee43611031fb719b1472e14d9e90e176284d98c"
+_githash="f1c1b67b26ed3cb789037d1c844d4105deaa3cfd"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.63
+version=4.19.65
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=608495b1e1f946cc2c96b9d4ec741613755e575bde7ad1adfea33df15eb5435b
+checksum=57a8cdd3840a69e33fd95524268d8a84ffc3fdf17669ce04618d5591c4d96b91
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

Built on armv6l, armv7l, and aarch64.

Tested on armv6l and armv7l.