### PR TITLE
cmake: update to 3.15.2

### DIFF
--- a/srcpkgs/cmake-gui/template
+++ b/srcpkgs/cmake-gui/template
@@ -1,6 +1,6 @@
 # Template file for 'cmake-gui'
 pkgname=cmake-gui
-version=3.14.5
+version=3.15.2
 revision=1
 wrksrc="cmake-${version}"
 build_style=configure
@@ -15,7 +15,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-3-Clause"
 homepage="https://www.cmake.org"
 distfiles="https://www.cmake.org/files/v${version%.*}/cmake-${version}.tar.gz"
-checksum=505ae49ebe3c63c595fa5f814975d8b72848447ee13b6613b0f8b96ebda18c06
+checksum=539088cb29a68e6d6a8fba5c00951e5e5b1a92c68fa38a83e1ed2f355933f768
 nocross=yes
 
 do_install() {

--- a/srcpkgs/cmake/template
+++ b/srcpkgs/cmake/template
@@ -1,6 +1,6 @@
 # Template file for 'cmake'
 pkgname=cmake
-version=3.14.5
+version=3.15.2
 revision=1
 build_style=configure
 make_check_target=test
@@ -11,7 +11,7 @@ maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-3-Clause"
 homepage="https://www.cmake.org"
 distfiles="https://www.cmake.org/files/v${version%.*}/${pkgname}-${version}.tar.gz"
-checksum=505ae49ebe3c63c595fa5f814975d8b72848447ee13b6613b0f8b96ebda18c06
+checksum=539088cb29a68e6d6a8fba5c00951e5e5b1a92c68fa38a83e1ed2f355933f768
 
 if [ "$CROSS_BUILD" ]; then
 	# XXX ugly :-)
@@ -31,6 +31,6 @@ fi
 post_install() {
 	rm -rf ${DESTDIR}/usr/share/doc/cmake
 	vlicense Copyright.txt
+	vlicense Utilities/KWIML/Copyright.txt KWIML-Copyright.txt
 	vlicense Utilities/cmzlib/Copyright.txt cmzlib-Copyright.txt
-	vlicense Utilities/cmcompress/Copyright.txt cmcompress-Copyright.txt
 }


### PR DESCRIPTION
This fixes a massive bug in qt5 automoc generation which would result various packages (like `lximage-qt`) failing to build on musl targets because cmake would silently skip some implicit include paths. Still not sure which commit exactly fixed it, I suspect it's this https://gitlab.kitware.com/cmake/cmake/commit/d88b38d05d5bc7528667ed4f86842ab8f7ff2ba2

Maybe it fixes other things too, dunno. I updated it because of said build failures.