### PR TITLE
nmap: make ncat an alternative for nc

### DIFF
--- a/srcpkgs/nmap/template
+++ b/srcpkgs/nmap/template
@@ -1,12 +1,8 @@
 # Template file for 'nmap'
 pkgname=nmap
 version=7.70
-revision=5
+revision=6
 build_style=gnu-configure
-build_options="lua"
-if [ -z "$CROSS_BUILD" ]; then
-	build_options_default="lua"
-fi
 configure_args="--without-ndiff --with-openssl --with-zenmap $(vopt_with lua liblua)"
 hostmakedepends="python"
 makedepends="libpcap-devel libressl-devel pcre-devel $(vopt_if lua lua52-devel)"
@@ -16,6 +12,14 @@ license="GPL-2.0-or-later"
 homepage="https://nmap.org"
 distfiles="https://nmap.org/dist/nmap-${version}.tar.bz2"
 checksum=847b068955f792f4cc247593aca6dc3dc4aae12976169873247488de147a6e18
+build_options="lua"
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default="lua"
+fi
+
+alternatives="
+	nc:nc:/usr/bin/ncat
+	nc:nc.1:/usr/share/man/man1/ncat.1"
 
 pre_check() {
 	# Disable zenmap tests


### PR DESCRIPTION
On RedHat systems (7+), `ncat` is used as an alternative for `nc`.  This makes `ncat` also an alternative to `nc` on Void Linux.

Also fix some xlint warnings.