### PR TITLE
gnome-podcasts: broken

### DIFF
--- a/srcpkgs/gnome-podcasts/template
+++ b/srcpkgs/gnome-podcasts/template
@@ -14,6 +14,7 @@ homepage="https://wiki.gnome.org/Apps/Podcasts"
 distfiles="https://gitlab.gnome.org/World/podcasts/-/archive/${version}/podcasts-${version}.tar.gz"
 checksum=953c63e8184ca1f748418d8a8262d40eaa41047f81e2d2c874a3035d9d9d0e4a
 nocross="rustc cant be crosscompiled as of now"
+broken="gettext-rs hash does not exists, if fixed build fails in gio 0.5.0"
 
 export GETTEXT_BIN_DIR=/usr/bin
 export GETTEXT_LIB_DIR="${XBPS_CROSS_BASE}/usr/lib/gettext"


### PR DESCRIPTION
This thing is once again broken.

The first problem is that it tries to use `gettext-rs` from a github hash that no longer exists. That can be patched with this:

```
--- Cargo.lock
+++ Cargo.lock
@@ -601,8 +601,8 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.4.1"
-source = "git+https://github.com/danigm/gettext-rs?branch=no-gettext#c514bbe52ef892e3c0689eb474c564949d15e145"
+version = "0.4.2"
+source = "git+https://github.com/danigm/gettext-rs?branch=no-gettext#61938b9f5f1d3bdc31f9839f53fabe5ccf136a78"
 dependencies = [
  "gettext-sys 0.19.8 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)",
  "locale_config 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -610,8 +610,8 @@ dependencies = [
 
 [[package]]
 name = "gettext-sys"
-version = "0.19.8"
-source = "git+https://github.com/danigm/gettext-rs?branch=no-gettext#c514bbe52ef892e3c0689eb474c564949d15e145"
+version = "0.19.9"
+source = "git+https://github.com/danigm/gettext-rs?branch=no-gettext#61938b9f5f1d3bdc31f9839f53fabe5ccf136a78"
 dependencies = [
  "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1586,7 +1586,7 @@ dependencies = [
  "fragile 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdk-pixbuf 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gettext-rs 0.4.1 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)",
+ "gettext-rs 0.4.2 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)",
  "gio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2541,8 +2541,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gdk-pixbuf 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc3aa730cb4df3de5d9fed59f43afdf9e5fb2d3d10bfcbd04cec031435ce87f5"
 "checksum gdk-pixbuf-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08284f16ce4d909b10d785a763ba190e222d2c1557b29908bf0a661e27a8ac3b"
 "checksum gdk-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "108548ebf5329b551f2b97ab356908d14627905abb74b936c3372de1535aee81"
-"checksum gettext-rs 0.4.1 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)" = "<none>"
-"checksum gettext-sys 0.19.8 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)" = "<none>"
+"checksum gettext-rs 0.4.2 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)" = "<none>"
+"checksum gettext-sys 0.19.9 (git+https://github.com/danigm/gettext-rs?branch=no-gettext)" = "<none>"
 "checksum gio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7aeedbcb85cc6a53f1928dbe6c015dc9a9b64a7e2fb7484d6f5d0d1d400e1db0"
 "checksum gio-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6975ada29f7924dc1c90b30ed3b32d777805a275556c05e420da4fbdc22eb250"
 "checksum glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740f7fda8dde5f5e3944dabdb4a73ac6094a8a7fdf0af377468e98ca93733e61"
```

But if you do that, it will fail to compile some Rust code in `gio-0.5.0`. If someone feels like patching this further, you can use the patch above and add to it, I CBA.