### PR TITLE
gnome-games: update to 3.33.90 (unbreaks build, enable cross)

### DIFF
--- a/srcpkgs/gnome-games/template
+++ b/srcpkgs/gnome-games/template
@@ -1,16 +1,15 @@
 # Template file for 'gnome-games'
 pkgname=gnome-games
-version=3.30.2
+version=3.33.90
 revision=1
 build_style=meson
 hostmakedepends="glib-devel pkg-config vala-devel"
 makedepends="libarchive-devel grilo-devel gtk+3-devel libglib-devel
  libmanette-devel librsvg-devel libsoup-devel libxml2-devel retro-gtk-devel
- sqlite-devel tracker-devel"
+ sqlite-devel tracker-devel libhandy-devel"
 short_desc="Browse and play your games"
 maintainer="Rasmus Thomsen <rasmus.thomsen@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Games"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=5607c4071d3b07809ec1a88deb52bb289c29b2f5fb91374e244ebe7f8dee31a1
-nocross="depends on libmanette, which hard depends on gobject-introspection"
+checksum=89faa9007be51ce5264675b94818ed5a4310bb02292fbc5ed850983fd9cc125d


### PR DESCRIPTION
Not sure if this crosses, so let's let the CI do its thing.