### PR TITLE
gtk-doc: add missing dependencies to unbreak usage

### DIFF
--- a/srcpkgs/gtk-doc/template
+++ b/srcpkgs/gtk-doc/template
@@ -1,13 +1,14 @@
 # Template file for 'gtk-doc'
 pkgname=gtk-doc
 version=1.30
-revision=1
+revision=2
 archs=noarch
 build_style=gnu-configure
 pycompile_version="$py3_ver"
 pycompile_dirs="usr/share/gtk-doc/python/gtkdoc"
 hostmakedepends="docbook-xml docbook-xsl itstool libxslt pkg-config python3"
-depends="docbook-xml docbook-xsl libxslt python3"
+depends="docbook-xml docbook-xsl libxslt python3-anytree
+ python3-Pygments python3-lxml"
 short_desc="Documentation tool for public library API"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, GFDL-1.1-or-later"

--- a/srcpkgs/python3-anytree/template
+++ b/srcpkgs/python3-anytree/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-anytree'
+pkgname=python3-anytree
+version=2.6.0
+revision=1
+archs=noarch
+wrksrc="anytree-${version}"
+build_style=python3-module
+pycompile_module="anytree"
+hostmakedepends="python3-setuptools"
+depends="python3-six"
+short_desc="Powerful and lightweight Python tree data structure"
+maintainer="q66 <daniel@octaforge.org>"
+license="Apache-2.0"
+homepage="https://github.com/c0fec0de/anytree"
+distfiles="${PYPI_SITE}/a/anytree/anytree-${version}.tar.gz"
+checksum=a221b6a603c3a5d5e417894dc48eaa8b1eab04056e1f5bb509bcfff0e7a47883


### PR DESCRIPTION
As it is it would fail to import some python modules. This also required packaging a new python module which we didn't have before.