### PR TITLE
git-revise: require python3-setuptools at runtime

### DIFF
--- a/srcpkgs/git-revise/template
+++ b/srcpkgs/git-revise/template
@@ -1,11 +1,11 @@
 # Template file for 'git-revise'
 pkgname=git-revise
 version=0.4.2
-revision=2
+revision=3
 build_style=python3-module
 pycompile_module="gitrevise"
 hostmakedepends="python3 python3-setuptools"
-depends="git"
+depends="git python3-setuptools"
 short_desc="Git subcommand to efficiently update, split, and rearrange commits"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"


### PR DESCRIPTION
Avoids
```
Traceback (most recent call last):
  File "/usr/bin/git-revise", line 6, in <module>
    from pkg_resources import load_entry_point
ModuleNotFoundError: No module named 'pkg_resources'
```