### PR TITLE
qca-qt5: patch out -ansi from CXXFLAGS

### DIFF
--- a/srcpkgs/qca-qt5/patches/ansi.patch
+++ b/srcpkgs/qca-qt5/patches/ansi.patch
@@ -1,0 +1,15 @@
+Not quite sure what the purpose of -ansi for C++ was meant to be, but it
+breaks build because it will make the compiler deactivate C++11 features
+that Qt relies on.
+
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -127,7 +127,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
+      endif()
+ 
+      set ( CMAKE_C_FLAGS     "${CMAKE_C_FLAGS} -Wno-long-long -ansi -Wundef -Werror-implicit-function-declaration -Wchar-subscripts -Wall -W -Wpointer-arith -Wwrite-strings -Wformat-security -Wmissing-format-attribute -fno-common")
+-     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor -Wno-long-long -ansi -Wundef -Wchar-subscripts -Wall -W -Wpointer-arith -Wwrite-strings -Wformat-security -fno-check-new -fno-common")
++     set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor -Wno-long-long -Wundef -Wchar-subscripts -Wall -W -Wpointer-arith -Wwrite-strings -Wformat-security -fno-check-new -fno-common")
+    endif (CMAKE_SYSTEM_NAME MATCHES Linux)
+ endif (CMAKE_COMPILER_IS_GNUCXX)
+ 

--- a/srcpkgs/qca-qt5/template
+++ b/srcpkgs/qca-qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qca-qt5'
 pkgname=qca-qt5
 version=2.1.3
-revision=7
+revision=8
 wrksrc="${pkgname%-*}-${version}"
 build_style=cmake
 configure_args="-DBUILD_TESTS=0 -DQCA_FEATURE_INSTALL_DIR=/usr/share/qca-qt5/mkspecs


### PR DESCRIPTION
This is completely wrong because -ansi when used with g++ disables C++11 features, which Qt relies on, resulting in megabytes of errors printed into the console. I'm not sure how this ever built but it's definitely not right.