### PR TITLE
cmake: workaround a race condition figuring out include paths

### DIFF
--- a/srcpkgs/cmake/patches/race.patch
+++ b/srcpkgs/cmake/patches/race.patch
@@ -1,0 +1,25 @@
+At very least under musl, cmake has some racey behavior.
+This workaround fixes that until a real fix is available.
+
+https://gitlab.kitware.com/cmake/cmake/issues/19590
+
+--- Modules/CMakeParseImplicitIncludeInfo.cmake
++++ Modules/CMakeParseImplicitIncludeInfo.cmake
+@@ -226,6 +226,17 @@ function(cmake_parse_implicit_include_info text lang dir_var log_var state_var)
+       get_filename_component(dir "${CMAKE_BINARY_DIR}/${CMAKE_MATCH_1}" ABSOLUTE)
+       list(APPEND implicit_dirs "${dir}")
+       string(APPEND log "  collapse relative include dir [${d}] ==> [${dir}]\n")
++    elseif("${d}" MATCHES [[^.* (/usr.*)$]])
++      # We've hit an unfortunate race where the output of something else prefixes
++      # our actual line... so perform a hacky workaround, at least until it's fixed
++      # https://gitlab.kitware.com/cmake/cmake/issues/19590
++      if(IS_ABSOLUTE "${CMAKE_MATCH_1}")
++        get_filename_component(dir "${CMAKE_MATCH_1}" ABSOLUTE)
++        list(APPEND implicit_dirs "${CMAKE_MATCH_1}")
++        string(APPEND log "  collapse include dir [${CMAKE_MATCH_1}] ==> [${dir}]\n")
++      else()
++        string(APPEND log "  skipping relative include dir [${d}]\n")
++      endif()
+     else()
+       string(APPEND log "  skipping relative include dir [${d}]\n")
+     endif()

--- a/srcpkgs/cmake/template
+++ b/srcpkgs/cmake/template
@@ -1,7 +1,7 @@
 # Template file for 'cmake'
 pkgname=cmake
 version=3.15.2
-revision=1
+revision=2
 build_style=configure
 make_check_target=test
 makedepends="expat-devel libarchive-devel libcurl-devel libuv-devel


### PR DESCRIPTION
This particularly affects musl installations, but the behavior is racey regardless of libc. Cmake uses verbose gcc output to figure out include and linker paths without taking care of it being racey, which sometimes results in paths being omitted.

This workaround does not break anything, in the worst theoretical case it introduces a false positive path, but the chance of that is very low; the chance of that path existing is even lower. So apply this until a real fix is found.