### PR TITLE
WIP: New package: cnping-afcc565771a37978eb0b54e185fa80482cdebe3a_1

### DIFF
--- a/srcpkgs/cnping/template
+++ b/srcpkgs/cnping/template
@@ -1,0 +1,22 @@
+# Template file for 'cnping'
+pkgname=cnping
+version=afcc565771a37978eb0b54e185fa80482cdebe3a
+revision=1
+hostmakedepends="gcc make libcap-progs"
+makedepends="libXinerama-devel"
+short_desc="Minimal Graphical IPV4 Ping Tool"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://github.com/cnlohr/cnping"
+distfiles="https://github.com/cnlohr/cnping/archive/${version}.tar.gz"
+checksum=9320ec8e1a982c538e217940c57ed894c16ad1363b2070c5a96d94564f2a9606
+
+do_build() {
+	make
+	setcap cap_net_raw=ep cnping
+}
+
+do_install() {
+	vbin cnping
+	vlicense LICENSE
+}


### PR DESCRIPTION
WIP because cnping doesn't have any tagged releases yet, so this PR is waiting for upstream to fix that.