### PR TITLE
protonmail-bridge: update to 1.1.6

### DIFF
--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,6 +1,6 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=1.1.4
+version=1.1.6
 revision=1
 archs="x86_64"
 build_style=fetch
@@ -9,7 +9,7 @@ maintainer="Rich G <rich@richgannon.net>"
 license="Proprietary"
 homepage="https://protonmail.com/bridge"
 distfiles="https://protonmail.com/download/beta/protonmail-bridge_${version}-1_amd64.deb"
-checksum=499fbb201dc8434ad8e3b401cd68373066065fed65dc2612568307e95b63e9d5
+checksum=e8878536d24964272aeb2521c51dbe861667be0f34c3337c3040b412b4a12ef5
 
 restricted=yes
 noverifyrdeps=yes


### PR DESCRIPTION
Confirmed working (local build; proprietary license still).