### PR TITLE
gitea: correct sed command in template

### DIFF
--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -1,7 +1,7 @@
 # Template file for 'gitea'
 pkgname=gitea
 version=1.9.0
-revision=1
+revision=2
 build_style=go
 go_import_path=code.gitea.io/gitea
 # This could be done with build options, but these are built in with the
@@ -59,7 +59,9 @@ pre_install() {
 		s:data/gitea.db:/var/lib/gitea/&:
 		s:indexers/issues.bleve:/var/lib/gitea/&:
 		s:data/avatars:/var/lib/gitea/&:
-		s:ROOT_PATH =:& /var/log/gitea:' custom/conf/app.ini.sample
+		s:SSH_ROOT_PATH =:& /var/lib/gitea:
+		s:STATIC_ROOT_PATH =:& /var/lib/gitea:
+		s:^ROOT_PATH =:& /var/log/gitea:' custom/conf/app.ini.sample
 }
 
 post_install() {


### PR DESCRIPTION
`sed` for `ROOT_PATH` was too greedy and made `(SSH|STATIC)_ROOT_PATH` to be `/var/log/gitea` which is wrong

```
$ bsdtar xOf ./hostdir/binpkgs/my-gitea/gitea-1.9.0_2.x86_64.xbps ./etc/gitea.conf \
     | grep ROOT_PATH
SSH_ROOT_PATH = /var/lib/gitea
STATIC_ROOT_PATH = /var/lib/gitea
ROOT_PATH = /var/log/gitea
; will be relative to ROOT_PATH
```