### PR TITLE
go: update to 1.12.8.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.12.7
+version=1.12.8
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=95e8447d6f04b8d6a62de1726defbb20ab203208ee167ed15f83d7978ce43b13
+checksum=11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898
 
 nostrip=yes
 noverifyrdeps=yes


### PR DESCRIPTION
This is a security release.