### PR TITLE
nomad: fix _git_commit.

### DIFF
--- a/srcpkgs/nomad/template
+++ b/srcpkgs/nomad/template
@@ -1,11 +1,11 @@
 # Template file for 'nomad'
 pkgname=nomad
 version=0.9.4
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/hashicorp/${pkgname}"
 go_build_tags="ui release"
-_git_commit=23c4597dbb6d1d46e020301b0f63db5cff80d3f0
+_git_commit=6c4863c5f61b0cdfb609927f6f67e17d90454197
 go_ldflags="-X ${go_import_path}/version.GitCommit=${_git_commit}"
 hostmakedepends="git"
 short_desc="Cluster scheduler designed to easily integrate into existing workflows"


### PR DESCRIPTION
Revision bumped because built output changes.

This should only be merged after #13654 to pick up security fixes without an extra rev bump.