### PR TITLE
consul: fix _git_commit.

### DIFF
--- a/srcpkgs/consul/template
+++ b/srcpkgs/consul/template
@@ -1,10 +1,10 @@
 # Template file for 'consul'
 pkgname=consul
 version=1.5.3
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/hashicorp/${pkgname}"
-_git_commit=34eff659dcc5503b6eb117733c9f7def63f01bad
+_git_commit=a42ded477cf4e5ac1a850b42ec5d25672cd2545d
 go_ldflags="-X ${go_import_path}/version.GitCommit=${_git_commit} -X ${go_import_path}/version.GitDescribe=v${version}"
 # consul has a vendor directory, but relies on replace statements in go.mod, so
 # force default non-vendor behavior.
@@ -15,7 +15,7 @@ maintainer="iaroki <iaroki@protonmail.com>"
 license="MPL-2.0"
 homepage="https://www.consul.io/"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=9a29ee11e12d75980016db0685ce7eb81a36a97c90d6bd23529a310f4e2dc02a
+checksum=f36f1e516346864a7a61b0917df0e82ef9a83eb792885f9f032cca99a594bc82
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Revision bumped because built output changes.

This should only be merged after #13654 to pick up security fixes without an extra rev bump.