### PR TITLE
DO NOT MERGE: vault: update to 1.2.1.

### DIFF
--- a/srcpkgs/vault/template
+++ b/srcpkgs/vault/template
@@ -1,18 +1,28 @@
 # Template file for 'vault'
 pkgname=vault
-version=1.2.0
+version=1.2.1
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/${pkgname}"
+go_build_tags="ui release"
+_git_commit=e16495da552c996068e05574cddf69875199f949
+go_ldflags="-X ${go_import_path}/sdk/version.GitCommit=${_git_commit}"
 conf_files="/etc/vault.hcl"
 make_dirs="/var/lib/vault 0700 _vault _vault"
+hostmakedepends="git nodejs-lts python yarn"
 short_desc="Tool for securely accessing secrets"
 maintainer="iaroki <iaroki@protonmail.com>"
 license="MPL-2.0"
 homepage="https://www.vaultproject.io/"
 distfiles="https://github.com/hashicorp/${pkgname}/archive/v${version}.tar.gz"
-checksum=9ec2b23d7f6fd16909dd409a15e0da52235ac4f0c7e1903e6cfb5de9308cab4d
+checksum=957aaca56be6ac8ac3bb9c0115a1156432ab96874dedfe20f04489694b617d7f
 system_accounts="_vault"
+
+pre_build() {
+	vsed -i Makefile -e "s@(find \. -name '\*\.go' | grep -v pb\.go | grep -v vendor)@(find . -name '*.go' | grep -v pb.go | grep -v vendor | grep -v ./_build-)@"
+	local depbin="${wrksrc}/_build-depbin"
+	GOOS= GOARCH= CGO_ENABLED=0 PATH="$depbin:$PATH" GOBIN="$depbin" make bootstrap ember-dist static-assets
+}
 
 post_install() {
 	vinstall ${FILESDIR}/vault.hcl 644 etc/


### PR DESCRIPTION
Adds support for building the UI. Due the yarn dependency, this may
restrict building on some architectures.

This should only be merged after #13654 to pick up security fixes without a rev bump.