### PR TITLE
nodejs-lts: readd ppc64 patch, fix cross for various platforms

### DIFF
--- a/srcpkgs/nodejs-lts/patches/ppc64.patch
+++ b/srcpkgs/nodejs-lts/patches/ppc64.patch
@@ -1,0 +1,41 @@
+Taken from Adélie Linux, fixes node on big endian ELFv2.
+--- deps/v8/src/ppc/assembler-ppc.h.old 2019-03-05 15:16:29.000000000 +0000
++++ deps/v8/src/ppc/assembler-ppc.h     2019-04-02 07:05:25.977213735 +0000
+@@ -48,7 +48,8 @@
+ #include "src/ppc/constants-ppc.h"
+ 
+ #if V8_HOST_ARCH_PPC && \
+-    (V8_OS_AIX || (V8_TARGET_ARCH_PPC64 && V8_TARGET_BIG_ENDIAN))
++    (V8_OS_AIX || (V8_TARGET_ARCH_PPC64 && \
++      (V8_TARGET_BIG_ENDIAN && (!defined(_CALL_ELF) || _CALL_ELF == 1))))
+ #define ABI_USES_FUNCTION_DESCRIPTORS 1
+ #else
+ #define ABI_USES_FUNCTION_DESCRIPTORS 0
+@@ -60,13 +61,15 @@
+ #define ABI_PASSES_HANDLES_IN_REGS 0
+ #endif
+ 
+-#if !V8_HOST_ARCH_PPC || !V8_TARGET_ARCH_PPC64 || V8_TARGET_LITTLE_ENDIAN
++#if !V8_HOST_ARCH_PPC || !V8_TARGET_ARCH_PPC64 || \
++    (V8_TARGET_LITTLE_ENDIAN || (defined(_CALL_ELF) && _CALL_ELF == 2))
+ #define ABI_RETURNS_OBJECT_PAIRS_IN_REGS 1
+ #else
+ #define ABI_RETURNS_OBJECT_PAIRS_IN_REGS 0
+ #endif
+ 
+-#if !V8_HOST_ARCH_PPC || (V8_TARGET_ARCH_PPC64 && V8_TARGET_LITTLE_ENDIAN)
++#if !V8_HOST_ARCH_PPC || (V8_TARGET_ARCH_PPC64 && \
++    (V8_TARGET_LITTLE_ENDIAN || (defined(_CALL_ELF) && _CALL_ELF == 2)))
+ #define ABI_CALL_VIA_IP 1
+ #else
+ #define ABI_CALL_VIA_IP 0
+@@ -220,7 +220,8 @@
+ // The following constants describe the stack frame linkage area as
+ // defined by the ABI.  Note that kNumRequiredStackFrameSlots must
+ // satisfy alignment requirements (rounding up if required).
+-#if V8_TARGET_ARCH_PPC64 && V8_TARGET_LITTLE_ENDIAN
++#if V8_TARGET_ARCH_PPC64 && (V8_TARGET_LITTLE_ENDIAN || \
++    defined(_CALL_ELF) && _CALL_ELF == 2)
+ // [0] back chain
+ // [1] condition register save area
+ // [2] link register save area

--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -32,15 +32,9 @@ replaces="iojs>=0"
 conflicts="nodejs"
 provides="nodejs-runtime-0_1"
 
-case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		case "$XBPS_MACHINE" in
-			x86_64*|aarch64*)
-				nocross="Can't cross-compile to 32bit-host from 64bit-host";;
-		esac ;;
-	ppc64le*) ;;
-	ppc64*) broken="Node is not supported on ppc64 BE Linux";;
-esac
+if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
+        nocross="host and target must have the same pointer size"
+fi
 
 do_configure() {
 	local _args
@@ -48,10 +42,17 @@ do_configure() {
 	export LD="$CXX"
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
-			aarch64*) _args="--dest-cpu=arm64 --without-snapshot" ;;
-			ppc64le*) _args="--dest-cpu=ppc64 --without-snapshot" ;;
+                        arm*) _args="--dest-cpu=arm" ;;
+                        aarch64*) _args="--dest-cpu=arm64" ;;
+                        ppc64*) _args="--dest-cpu=ppc64" ;;
+                        ppc*) _args="--dest-cpu=ppc" ;;
+                        mipsel*) _args="--dest-cpu=mipsel" ;;
+                        mips*) _args="--dest-cpu=mips" ;;
+                        i686*) _args="--dest-cpu=x86" ;;
+                        x86_64*) _args="--dest-cpu=x86_64" ;;
 			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
 		esac
+		_args+=" --without-snapshot"
 	fi
 	# their pregenerated asm is for ELFv1...
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Not sure why exactly this was removed, the patch didn't even fail to apply. While at it, clean up the template to properly utilize generic word size vars and define dest CPUs for various targets.