### PR TITLE
logrotate: ensure /etc/logrotate.d exists

### DIFF
--- a/srcpkgs/logrotate/template
+++ b/srcpkgs/logrotate/template
@@ -1,7 +1,7 @@
 # Template file for 'logrotate'
 pkgname=logrotate
 version=3.15.0
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="acl-devel popt-devel"
 conf_files="/etc/logrotate.conf"
@@ -11,6 +11,7 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/logrotate/logrotate"
 distfiles="${homepage}/releases/download/${version}/logrotate-${version}.tar.xz"
 checksum=313612c4776a305393454c874ef590d8acf84c9ffa648717731dfe902284ff8f
+make_dirs="/etc/logrotate.d 0755 root root"
 
 post_install() {
 	vconf ${FILESDIR}/logrotate.conf


### PR DESCRIPTION
Avoids an error message with the default `/etc/logrotate.conf` if no packages install a file in `/etc/logrotate.d`
```
error: cannot stat /etc/logrotate.d: No such file or directory
```