### PR TITLE
numactl: unrestrict archs

### DIFF
--- a/srcpkgs/numactl/template
+++ b/srcpkgs/numactl/template
@@ -2,7 +2,6 @@
 pkgname=numactl
 version=2.0.12
 revision=1
-archs="i686* x86_64* ppc64*"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="Simple NUMA policy support"


### PR DESCRIPTION
The source code is not arch specific and the NUMA subsystem in the kernel is not architecture specific either.