### PR TITLE
nodejs: broken on ppc32, nodejs-lts: fix on ppc32

### DIFF
--- a/srcpkgs/nodejs-lts/patches/ppc32.patch
+++ b/srcpkgs/nodejs-lts/patches/ppc32.patch
@@ -1,3 +1,28 @@
+--- configure.py
++++ configure.py
+@@ -848,7 +848,7 @@ def host_arch_cc():
+     '__MIPSEL__'  : 'mipsel',
+     '__mips__'    : 'mips',
+     '__PPC64__'   : 'ppc64',
+-    '__PPC__'     : 'ppc64',
++    '__PPC__'     : 'ppc',
+     '__x86_64__'  : 'x64',
+     '__s390__'    : 's390',
+     '__s390x__'   : 's390x',
+--- node.gyp
++++ node.gyp
+@@ -479,6 +479,11 @@
+       'msvs_disabled_warnings!': [4244],
+ 
+       'conditions': [
++        [ 'host_arch=="mips" or host_arch=="mipsel" or host_arch=="ppc"', {
++	  'link_settings': {
++	    'libraries': [ '-latomic' ],
++	  },
++	}],
+         [ 'node_code_cache_path!=""', {
+           'sources': [ '<(node_code_cache_path)' ]
+         }, {
 --- deps/v8/src/libsampler/sampler.cc
 +++ deps/v8/src/libsampler/sampler.cc
 @@ -418,9 +418,15 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {

--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -36,6 +36,12 @@ if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
         nocross="host and target must have the same pointer size"
 fi
 
+case "$XBPS_MACHINE" in
+	ppc64*) ;;
+	mips*|ppc*) hostmakedepends+=" libatomic-devel" ;;
+        *) ;;
+esac
+
 do_configure() {
 	local _args
 

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -36,6 +36,11 @@ if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
 	nocross="host and target must have the same pointer size"
 fi
 
+case "$XBPS_TARGET_MACHINE" in
+	ppc64*) ;;
+	ppc*) broken="Node 12.x does not support 32-bit ppc" ;;
+esac
+
 # v8 requires libatomic on ppc*/s390x/mips*
 case "$XBPS_TARGET_MACHINE" in
 	mips*|ppc*) makedepends+=" libatomic-devel" ;;


### PR DESCRIPTION
Node 12.x is broken on ppc32, with several bits of the codebase not compiling. This may and probably will be patched later, but for now marked broken. Node LTS (10.x) works fine on ppc32 but needs some relatively minor extra patching.