### PR TITLE
firefox*, thunderbird, icecat: broken on ppc32 and generalize nodebug, firefox: add some BE patches for 64-bit ppc

### DIFF
--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -30,16 +30,17 @@ conflicts="firefox>=0"
 build_options="alsa dbus gtk3 pulseaudio startup_notification xscreensaver sndio"
 build_options_default="alsa dbus gtk3 pulseaudio startup_notification xscreensaver sndio"
 
+if [ "$XBPS_WORDSIZE" -eq 32 ]; then
+	nodebug=yes
+fi
+
 case $XBPS_TARGET_MACHINE in
 	armv6*)
 		broken="required NEON extensions are not supported on armv6"
 		;;
-	i686*)
-		# /usr/bin/ld: failed to set dynamic section sizes: memory exhausted
-		nodebug=yes
-		;;
+	ppc64*) ;;
+	ppc*) broken="ftbfs in several places" ;;
 esac
-
 
 post_extract() {
 	case "$XBPS_TARGET_MACHINE" in
@@ -111,12 +112,10 @@ do_build() {
 		;;
 	esac
 
-	case "$XBPS_MACHINE" in
-		i686*)
+	if [ "$XBPS_WORDSIZE" -eq 32 ]; then
 		# ENOMEM
 		echo "ac_add_options --disable-debug-symbols" >>.mozconfig
-		;;
-	esac
+	fi
 
 	export LDFLAGS+=" -Wl,-rpath=/usr/lib/firefox"
 

--- a/srcpkgs/firefox/patches/disable-image-format-warning.patch
+++ b/srcpkgs/firefox/patches/disable-image-format-warning.patch
@@ -1,0 +1,15 @@
+Imported from Adélie. Firefox is prone to this warning on BE and
+it leads to huge .xsession-errors, and the warning is not very
+important or meaningful, so just disable it.
+
+--- gfx/2d/HelpersCairo.h
++++ gfx/2d/HelpersCairo.h
+@@ -147,7 +147,7 @@
+     case SurfaceFormat::R5G6B5_UINT16:
+       return CAIRO_FORMAT_RGB16_565;
+     default:
+-      gfxCriticalError() << "Unknown image format " << (int)format;
++      //gfxCriticalError() << "Unknown image format " << (int)format;
+       return CAIRO_FORMAT_ARGB32;
+   }
+ }

--- a/srcpkgs/firefox/patches/fix-i686-ppc-musl.patch
+++ b/srcpkgs/firefox/patches/fix-i686-ppc-musl.patch
@@ -1,0 +1,11 @@
+--- mozglue/misc/StackWalk.cpp	2017-04-11 04:13:21.000000000 +0200
++++ mozglue/misc/StackWalk.cpp	2017-11-29 15:23:07.218649970 +0100
+@@ -41,7 +41,7 @@
+ #define MOZ_STACKWALK_SUPPORTS_MACOSX 0
+ #endif
+ 
+-#if (defined(linux) && \
++#if defined(__GLIBC__) && (defined(linux) && \
+      ((defined(__GNUC__) && (defined(__i386) || defined(PPC))) || \
+       defined(HAVE__UNWIND_BACKTRACE)))
+ #define MOZ_STACKWALK_SUPPORTS_LINUX 1

--- a/srcpkgs/firefox/patches/yuv-be.patch
+++ b/srcpkgs/firefox/patches/yuv-be.patch
@@ -1,0 +1,48 @@
+# HG changeset patch
+# User A. Wilcox <AWilcox@Wilcox-Tech.com>
+# Date 1543674229 0
+#      Sat Dec 01 14:23:49 2018 +0000
+# Node ID 0309ff19e46b126c527e633518d7de8570442114
+# Parent  53107afbc21ec78e7ac46d37af212505f2032d5d
+Bug 1511604 - Swizzle YCbCr->RGB data on big-endian machines
+
+diff -r 53107afbc21e -r 0309ff19e46b gfx/ycbcr/YCbCrUtils.cpp
+--- gfx/ycbcr/YCbCrUtils.cpp	Wed Nov 07 04:50:21 2018 +0000
++++ gfx/ycbcr/YCbCrUtils.cpp	Sat Dec 01 14:23:49 2018 +0000
+@@ -3,7 +3,9 @@
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
++#include "mozilla/EndianUtils.h"
+ #include "gfx2DGlue.h"
++#include "mozilla/gfx/Swizzle.h"
+ 
+ #include "YCbCrUtils.h"
+ #include "yuv_convert.h"
+@@ -236,6 +238,13 @@
+                           yuvtype,
+                           srcData.mYUVColorSpace);
+   }
++#if MOZ_BIG_ENDIAN
++  // libyuv makes endian-correct result, which needs to be swapped to BGRX
++  if (aDestFormat != SurfaceFormat::R5G6B5_UINT16)
++    gfx::SwizzleData(aDestBuffer, aStride, gfx::SurfaceFormat::X8R8G8B8,
++                     aDestBuffer, aStride, gfx::SurfaceFormat::B8G8R8X8,
++                     srcData.mPicSize);
++#endif
+ }
+ 
+ void
+@@ -257,6 +266,12 @@
+                         aSrcStrideYA,
+                         aSrcStrideUV,
+                         aDstStrideARGB);
++#if MOZ_BIG_ENDIAN
++  // libyuv makes endian-correct result, which needs to be swapped to BGRA
++  gfx::SwizzleData(aDstARGB, aDstStrideARGB, gfx::SurfaceFormat::A8R8G8B8,
++                   aDstARGB, aDstStrideARGB, gfx::SurfaceFormat::B8G8R8A8,
++                   IntSize(aWidth, aHeight));
++#endif
+ }
+ 
+ } // namespace gfx

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -40,6 +40,8 @@ case $XBPS_TARGET_MACHINE in
 	armv6*)
 		broken="required NEON extensions are not supported on armv6"
 		;;
+	ppc64*) ;;
+	ppc*) broken="ftbfs in several places" ;;
 esac
 
 post_extract() {
@@ -112,12 +114,10 @@ do_build() {
 		;;
 	esac
 
-	case "$XBPS_MACHINE" in
-	i686*)
+	if [ "$XBPS_WORDSIZE" -eq 32 ]; then
 		# ENOMEM
 		echo "ac_add_options --disable-debug-symbols" >>.mozconfig
-		;;
-	esac
+	fi
 
 	export LDFLAGS+=" -Wl,-rpath=/usr/lib/firefox"
 

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -27,13 +27,15 @@ case $XBPS_TARGET_MACHINE in
 	armv6*)
 		broken="required NEON extensions are not supported on armv6"
 		;;
+	ppc64*) ;;
+	ppc*) broken="ftbfs in several places" ;;
 esac
 
 CXXFLAGS="-Wno-class-memaccess -Wno-unused-function"
 
-case "$XBPS_TARGET_MACHINE" in
-	i686*) nodebug=yes ;;
-esac
+if [ "$XBPS_WORDSIZE" -eq 32 ]; then
+	nodebug=yes
+fi
 
 post_extract() {
 	case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -30,9 +30,13 @@ depends="nss>=3.37.3 desktop-file-utils hicolor-icon-theme"
 build_options="alsa dbus pulseaudio startup_notification xscreensaver sndio wayland"
 build_options_default="alsa dbus pulseaudio startup_notification xscreensaver sndio wayland"
 
-case "$XBPS_TARGET_MACHINE" in
-	i686-musl) broken="mozglue/misc/StackWalk.cpp:851:2: error: #error Unsupported configuration";;
-	i686) nodebug=yes;;
+if [ "$XBPS_WORDSIZE" -eq 32 ]; then
+	nodebug=yes
+fi
+
+case $XBPS_TARGET_MACHINE in
+	ppc64*) ;;
+	ppc*) broken="ftbfs in several places" ;;
 esac
 
 post_extract() {


### PR DESCRIPTION
None of the Firefox related stuff currently builds on ppc32, so mark those broken. But, generalize the nodebug setting based on host wordsize instead of hardcoding for i686. Also, add patches to enhance Firefox functionality on big endian (for now only for 64-bit) as well as a preliminary patch for ppc-musl (also works for i686-musl) 

I will be looking into patching firefox for ppc32 later, but not now.