### PR TITLE
libvpx5: fix build on ppc32

### DIFF
--- a/srcpkgs/libvpx5/template
+++ b/srcpkgs/libvpx5/template
@@ -20,6 +20,12 @@ do_configure() {
 			armv7*) _cross="--target=armv7-linux-gcc";;
 			*) _cross="--target=generic-gnu";;
 		esac
+	else
+		# ppc32 is not a supported config, force generic-gnu
+		case "$XBPS_TARGET_MACHINE" in
+			ppc64*) ;;
+			ppc*) _cross="--target=generic-gnu";;
+		esac
 	fi
 	CFLAGS+=" -fPIC"
 


### PR DESCRIPTION
The build system recognizes the target as `powerpc-linux-gcc` but subsequently fails because it doesn't have that implemented. Force `generic-gnu` on those systems. Newer `libvpx` does not have the issue so only patch this one.