### PR TITLE
spice and spice-related things: fix brokenness

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -31,7 +31,7 @@ desc_option_smartcard="Enable smartcard support"
 desc_option_numa="Enable support for host NUMA"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc64*) build_options_default+=" spice";;
+	i686*|x86_64*|ppc64le*) build_options_default+=" spice";;
 	aarch64-musl) CFLAGS+=" -D_LINUX_SYSINFO_H";;
 esac
 

--- a/srcpkgs/spice-gtk/template
+++ b/srcpkgs/spice-gtk/template
@@ -1,7 +1,7 @@
 # Template file for 'spice-gtk'
 pkgname=spice-gtk
 version=0.37
-revision=3
+revision=4
 build_style=meson
 build_helper="gir"
 configure_args="-Dintrospection=$(vopt_if gir enabled disabled)
@@ -36,7 +36,8 @@ spice-gtk-devel_package() {
 	depends="gtk+3-devel pixman-devel libressl-devel opus-devel
 	 libva-devel libsasl-devel liblz4-devel usbredir-devel phodav-devel
 	 json-glib-devel gstreamer1-devel gst-plugins-base1-devel
-	 $(vopt_if gir libgirepository-devel) ${sourcepkg}-${version}_${revision}"
+	 spice-protocol $(vopt_if gir libgirepository-devel)
+	 ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/spice/template
+++ b/srcpkgs/spice/template
@@ -17,6 +17,10 @@ homepage="http://www.spice-space.org"
 distfiles="http://www.spice-space.org/download/releases/spice-${version}.tar.bz2"
 checksum=b203b3882e06f4c7249a3150d90c84e1a90490d41ead255a3d2cede46f4a29a7
 
+if [ "$XBPS_TARGET_ENDIAN" != "le" ]; then
+	broken="SPICE server only works on little endian architectures"
+fi
+
 post_extract() {
 	sed -i 's/armv6hl/arm/g' configure	# "detects" cpu from triplet.
 }

--- a/srcpkgs/vinagre/template
+++ b/srcpkgs/vinagre/template
@@ -1,13 +1,13 @@
 # Template file for 'vinagre'
 pkgname=vinagre
 version=3.22.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-schemas-compile --enable-compile-warnings=no"
 hostmakedepends="pkg-config intltool itstool glib gnome-doc-utils"
 makedepends="libxml2-devel libsecret-devel avahi-ui-libs-devel
- spice-devel avahi-glib-libs-devel telepathy-glib-devel vte3-devel
- gtk-vnc-devel openssh"
+ avahi-glib-libs-devel telepathy-glib-devel vte3-devel
+ spice-gtk-devel gtk-vnc-devel openssh"
 depends="openssh desktop-file-utils hicolor-icon-theme"
 short_desc="VNC client for the GNOME desktop"
 maintainer="Juan RP <xtraeme@voidlinux.org>"

--- a/srcpkgs/virt-viewer/template
+++ b/srcpkgs/virt-viewer/template
@@ -1,12 +1,11 @@
 # Template file for 'virt-viewer'
 pkgname=virt-viewer
 version=8.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-update-mimedb"
 hostmakedepends="glib-devel intltool pkg-config"
-makedepends="gtk-vnc-devel libvirt-glib-devel spice-devel spice-gtk-devel
- vte3-devel"
+makedepends="gtk-vnc-devel libvirt-glib-devel spice-gtk-devel vte3-devel"
 short_desc="Tool for displaying the graphical console of a virtual machine"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
1) For one, the SPICE server is not supported on big endian architectures.
2) Therefore, disable that, and disable it for BE in qemu as well.
3) Make sure `spice-gtk-devel` properly depends on the protocol headers, since it did not before; that made it useless alone (`pkg-config` would never detect it).
4) Then, remove `spice-devel` dependency from `vinagre` and `virt-viewer`, since neither of those requires a SPICE server, only the Gtk widget.
5) Bump revision on everything because SPICE wasn't previously properly built in `vinagre` or `virt-viewer` (because of the lack of `spice-protocol` installation), now it's actually detected and built.