### PR TITLE
kio-extras: remove unneeded dependencies

### DIFF
--- a/srcpkgs/kio-extras/template
+++ b/srcpkgs/kio-extras/template
@@ -8,8 +8,8 @@ hostmakedepends="extra-cmake-modules pkg-config gperf qt5-qmake qt5-host-tools
  python kdoctools kcoreaddons kio"
 makedepends="kdesignerplugin-devel kactivities5-devel kdelibs4support-devel
  kdnssd-devel khtml-devel kpty-devel exiv2-devel libmtp-devel
- libopenexr-devel samba-devel taglib-devel qt5-webengine-devel qt5-webchannel-devel
- qt5-location-devel syntax-highlighting-devel ksolid-devel"
+ syntax-highlighting-devel libopenexr-devel samba-devel taglib-devel
+ ksolid-devel"
 short_desc="Additional KIO components"
 maintainer="Denis Revin <denis.revin@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
@@ -20,7 +20,3 @@ checksum=b65cb37a5965782a9eaae80840fdd7e06505aece33cc6774510c65e1fea3f55b
 if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" libssh-devel"
 fi
-
-case "$XBPS_TARGET_MACHINE" in
-	arm*) broken="depends on qt5-webengine";;
-esac


### PR DESCRIPTION
kio-extras does not depend on webengine nor webchannel, they're not being checked, they make zero difference in the build.