### PR TITLE
python-pyasn1: update to 0.4.6.

### DIFF
--- a/srcpkgs/python-pyasn1/template
+++ b/srcpkgs/python-pyasn1/template
@@ -1,6 +1,6 @@
 # Template file for 'python-pyasn1'
 pkgname=python-pyasn1
-version=0.4.5
+version=0.4.6
 revision=1
 archs=noarch
 wrksrc="pyasn1-${version}"
@@ -10,10 +10,10 @@ hostmakedepends="python-setuptools python3-setuptools"
 depends="python"
 short_desc="ASN.1 library for Python2"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://github.com/etingof/pyasn1"
 license="BSD-2-Clause"
+homepage="https://github.com/etingof/pyasn1"
 distfiles="${PYPI_SITE}/p/pyasn1/pyasn1-${version}.tar.gz"
-checksum=da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7
+checksum=b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86
 
 post_install() {
 	vlicense LICENSE.rst


### PR DESCRIPTION
#13611 bumped the required version of this module. Both packages should probably be updated in tandem.