### PR TITLE
android-studio: update to 3.4.2.

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,23 +1,21 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=3.3.2
+version=3.4.2
 revision=1
 # _studio_build and _studio_rev are for downloading the zip from dl.google.com
 # https://developer.android.com/studio/#resources as of 2018-07-12
-_studio_build=182.5314842
+_studio_build=183.5692245
 _studio_rev=0
 archs="x86_64 i686"
 create_wrksrc=yes
-build_style=fetch
-hostmakedepends="unzip"
 depends="gtk+ libGL"
 short_desc="Official Android IDE"
 maintainer="Jordyn Carattini <onlinecloud1@gmail.com>"
 license="Apache-2.0"
 homepage="http://tools.android.com/"
 # changelog="https://developer.android.com/studio/releases/index.html"
-distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}.${_studio_rev}/android-studio-ide-${_studio_build}-linux.zip"
-checksum=8257d3eab61c3da088e26689888a13e53e210c109a4e775ed71158b4471bb06a
+distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}.${_studio_rev}/android-studio-ide-${_studio_build}-linux.tar.gz"
+checksum=35eb8c74837d1aab59229101fc91568a607ac04854a40209f7a0ba7ac0601924
 repository=nonfree
 nopie=yes
 nostrip=yes
@@ -32,18 +30,37 @@ skiprdeps="/opt/android-studio/plugins/android/resources/installer/arm64-v8a/ins
  /opt/android-studio/plugins/android/resources/perfa/x86_64/libperfa.so
  /opt/android-studio/plugins/android/resources/perfd/arm64-v8a/perfd
  /opt/android-studio/plugins/android/resources/perfd/armeabi-v7a/perfd
- /opt/android-studio/plugins/android/resources/perfd/x86/perfd"
+ /opt/android-studio/plugins/android/resources/perfd/x86/perfd
+ /opt/android-studio/plugins/android/resources/simpleperf/arm64-v8a/simpleperf
+ /opt/android-studio/plugins/android/resources/simpleperf/armeabi-v7a/simpleperf
+ /opt/android-studio/plugins/android/resources/simpleperf/x86/simpleperf
+ /opt/android-studio/plugins/android/resources/simpleperf/x86_64/simpleperf"
+
+do_extract() {
+	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}-ide-${_studio_build}-linux.tar.gz --strip-components=1 -C ${wrksrc}
+}
 
 do_install() {
-	unzip android-studio-ide-${_studio_build}-linux.zip
 	vmkdir opt/${pkgname}
-	vcopy android-studio/bin opt/${pkgname}/
-	vcopy android-studio/gradle opt/${pkgname}/
-	vcopy android-studio/lib opt/${pkgname}/
-	vcopy android-studio/jre opt/${pkgname}/
-	vcopy android-studio/plugins opt/${pkgname}/
+	vcopy bin opt/${pkgname}/
+	vcopy gradle opt/${pkgname}/
+	vcopy lib opt/${pkgname}/
+	vcopy jre opt/${pkgname}/
+	vcopy plugins opt/${pkgname}/
+	vcopy build.txt opt/${pkgname}/ # read as IDE version information
+	vcopy product-info.json opt/${pkgname}/
 	vmkdir usr/bin
 	ln -s /opt/android-studio/bin/studio.sh ${DESTDIR}/usr/bin/android-studio
+
+	# The version of host-side simpleperf bundled with Android Studio (as of 3.4.2) requires
+	# libncurses.so.5, which is not provided by Void Linux. However, as host-side simpleperf
+	# parsing is a fairly recent addition, we can just disable it...
+
+	rm -r ${DESTDIR}/opt/android-studio/plugins/android/resources/simpleperf/linux-x86
+	rm -r ${DESTDIR}/opt/android-studio/plugins/android/resources/simpleperf/linux-x86_64
+	echo "-Dprofiler.cpu.simpleperf.host=false" >> ${DESTDIR}/opt/android-studio/bin/studio.vmoptions
+	echo "-Dprofiler.cpu.simpleperf.host=false" >> ${DESTDIR}/opt/android-studio/bin/studio64.vmoptions
+
 	vinstall "${FILESDIR}/android-studio.desktop" 644 usr/share/applications/
 	chmod -R ugo+rX ${DESTDIR}/opt
 }


### PR DESCRIPTION
Continuation of https://github.com/void-linux/void-packages/pull/11219 - except this one installs properly and all functionality seems to work as intended.