### PR TITLE
edb-debugger: remove wrong CMAKE_INSTALL_LIBDIR

### DIFF
--- a/srcpkgs/edb-debugger/patches/include-limits.patch
+++ b/srcpkgs/edb-debugger/patches/include-limits.patch
@@ -1,0 +1,10 @@
+--- include/ByteShiftArray.h.orig	2019-08-16 23:27:51.186731499 +0200
++++ include/ByteShiftArray.h	2019-08-16 23:28:15.909729902 +0200
+@@ -22,6 +22,7 @@
+ #include "API.h"
+ #include <QVector>
+ #include <cstddef>
++#include <limits.h>
+ 
+ class EDB_EXPORT ByteShiftArray {
+ 	Q_DISABLE_COPY(ByteShiftArray)

--- a/srcpkgs/edb-debugger/template
+++ b/srcpkgs/edb-debugger/template
@@ -1,10 +1,9 @@
 # Template file for 'edb-debugger'
 pkgname=edb-debugger
 version=1.0.0
-revision=2
+revision=3
 archs="x86_64* i686*"
 build_style=cmake
-configure_args="-DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_INSTALL_LIBDIR=/usr/lib/"
 hostmakedepends='pkg-config'
 makedepends="capstone-devel graphviz-devel boost-devel qt5-devel qt5-xmlpatterns-devel qt5-svg-devel"
 short_desc="Cross platform x86/x86-64 debugger"


### PR DESCRIPTION
add patch to include limits.h for INT_MAX

fixes #13719