### PR TITLE
marco: update to 1.22.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1756,7 +1756,7 @@ libcblas.so.3 cblas-3.6.0_1
 liblapack.so.3 lapack-3.5.0_1
 libcinnamon-menu-3.so.0 cinnamon-menus-2.2.0_1
 libmate-desktop-2.so.17 mate-desktop-1.8.0_1
-libmarco-private.so.1 libmarco-1.14.0_1
+libmarco-private.so.2 libmarco-1.22.2_1
 libmate-menu.so.2 mate-menus-1.8.0_1
 libcaja-extension.so.1 libcaja-1.8.1_1
 libmatekbd.so.4 libmatekbd-1.8.0_1

--- a/srcpkgs/marco/patches/musl.patch
+++ b/srcpkgs/marco/patches/musl.patch
@@ -1,7 +1,6 @@
---- src/ui/theme.c.orig	2015-05-13 18:52:13.340057387 +0200
-+++ src/ui/theme.c	2015-05-13 18:55:30.469306867 +0200
-@@ -60,7 +60,8 @@
- #include <gtk/gtk.h>
+--- src/ui/theme.c.orig	2019-08-17 18:44:09.208980462 +0800
++++ src/ui/theme.c	2019-08-17 18:44:57.678662300 +0800
+@@ -62,6 +62,7 @@
  #include <string.h>
  #include <stdlib.h>
  #define __USE_XOPEN

--- a/srcpkgs/marco/template
+++ b/srcpkgs/marco/template
@@ -1,6 +1,6 @@
 # Template file for 'marco'
 pkgname=marco
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-startup-notification --disable-schemas-compile"
@@ -8,12 +8,12 @@ hostmakedepends="gdk-pixbuf-devel mate-common zenity"
 makedepends="libXt-devel libcanberra-devel libgtop-devel
  libnotify-devel mate-desktop-devel"
 depends="zenity"
-short_desc="window manager for MATE"
+short_desc="Window Manager for MATE"
 maintainer="Juan RP <xtraeme@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=4e20f5ea006142f3e5c8931e2b354e1838cb9291ba245825ea82fa6611def7c8
+checksum=3e73894cb244cee673aa555edfa2818ff166b15a9feea0a610d2272148e88769
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/mate-control-center/template
+++ b/srcpkgs/mate-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-control-center'
 pkgname=mate-control-center
 version=1.22.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --disable-update-mimedb"
 hostmakedepends="dbus-glib-devel desktop-file-utils glib-devel intltool itstool pkg-config"


### PR DESCRIPTION
My first PR into the Void Linux repository! This PR updates Marco to 1.22.2, bumps the SONAME and revbumps mate-control-center since it's dependent on marco & libmarco. Hopefully I didn't miss anything out.