### PR TITLE
elfutils: prevent build failure on musl

### DIFF
--- a/srcpkgs/elfutils/template
+++ b/srcpkgs/elfutils/template
@@ -13,7 +13,7 @@ homepage="https://sourceware.org/elfutils/"
 distfiles="https://sourceware.org/${pkgname}/ftp/${version}/${pkgname}-${version}.tar.bz2"
 checksum=eb5747c371b0af0f71e86215a5ebb88728533c3a104a43d4231963f308cd1023
 
-CFLAGS="-Wno-error"
+CFLAGS="-Wno-error -Wno-error=null-dereference"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" argp-standalone musl-fts-devel musl-obstack" ;;


### PR DESCRIPTION
Looks like `-Wno-error` alone does not cancel out explicit `-Werror=foo`.