### PR TITLE
xorg-server: change 'needs_root_rights' to 'auto' in Xwrapper.config

### DIFF
--- a/srcpkgs/xorg-server/files/Xwrapper.config
+++ b/srcpkgs/xorg-server/files/Xwrapper.config
@@ -1,1 +1,1 @@
-needs_root_rights = yes
+needs_root_rights = auto


### PR DESCRIPTION
It would allow Xorg.wrap to drop its root privileges if it detects that all cards support KMS. Fixes #13754 