### PR TITLE
lego: update to 3.0.2.

### DIFF
--- a/srcpkgs/lego/template
+++ b/srcpkgs/lego/template
@@ -1,16 +1,17 @@
 # Template file for 'lego'
 pkgname=lego
-version=2.7.2
+version=3.0.2
 revision=1
 build_style=go
-go_import_path="github.com/go-acme/${pkgname}"
+go_import_path="github.com/go-acme/${pkgname}/v3"
 go_package="${go_import_path}/cmd/${pkgname}"
+hostmakedepends="git"
 short_desc="Let's Encrypt client and ACME library written in Go"
 maintainer="Anachron <gith@cron.world>"
 license="MIT"
 homepage="https://go-acme.github.io/lego"
 distfiles="https://github.com/go-acme/lego/archive/v${version}.tar.gz"
-checksum=eb585fe8cd23671bea4b09c8f03d7a331f5b734aa652210f8cec897a6d6b8dbc
+checksum=a5389cc39f4fb70fb0f550436ddacb6d524ab6056815d2d2df0ecbfefa053a25
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Required as my DNS method is broken right now:
https://github.com/go-acme/lego/pull/940