### PR TITLE
xst: fix default Xresources TERM name

### DIFF
--- a/srcpkgs/xst/template
+++ b/srcpkgs/xst/template
@@ -1,7 +1,7 @@
 # Template file for 'xst'
 pkgname=xst
 version=0.7.2
-revision=2
+revision=3
 build_style=gnu-makefile
 make_use_env=compliant
 hostmakedepends="pkg-config"
@@ -21,6 +21,7 @@ do_install() {
 	vinstall doc/xst.info 644 usr/share/terminfo/x xst.terminfo
 	vdoc README.md README
 	vdoc doc/FAQ
+	vsed -i 's/st-256color/xst-256color/' doc/Xresources
 	vdoc doc/Xresources
 	vlicense doc/LICENSE
 }


### PR DESCRIPTION
Leaving it at the default `st-256color` glitches the font rendering. Is this the correct way to edit a source file?