### PR TITLE
libucontext: update to 0.9.0.

### DIFF
--- a/srcpkgs/libucontext/template
+++ b/srcpkgs/libucontext/template
@@ -1,14 +1,14 @@
 # Template file for 'libucontext'
 pkgname=libucontext
-version=0.1.3
+version=0.9.0
 revision=1
 archs="*-musl"
 short_desc="Compatibility layer providing ucontext functions"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 license="ISC"
-homepage="https://github.com/kaniini/libucontext"
-distfiles="https://distfiles.dereferenced.org/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=da530b2f4469f9adcef678b9c1bf07f2a66ea922251d9bcf13b691f09a08883e
+homepage="https://code.foxkit.us/adelie/libucontext"
+distfiles="https://distfiles.adelielinux.org/source/${pkgname}/${pkgname}-${version}.tar.xz"
+checksum=0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68
 
 case "${XBPS_TARGET_MACHINE}" in
 arm*)	export LIBUCONTEXT_ARCH="arm";;
@@ -19,7 +19,7 @@ esac
 
 do_build() {
 	case "${XBPS_TARGET_MACHINE}" in
-	i686*) sed -i arch/x86/startcontext.S -e "s;__i686.get_pc_thunk.bx;i686_get_pc_thunk_bx;g" ;;
+	i686*) vsed -i arch/x86/startcontext.S -e "s;__i686.get_pc_thunk.bx;i686_get_pc_thunk_bx;g" ;;
 	esac
 	make ARCH="${LIBUCONTEXT_ARCH}"
 }
@@ -41,5 +41,6 @@ libucontext-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
 	}
 }


### PR DESCRIPTION
https://adelie.blog/2019/04/28/libucontext-0-9-0-released/

> This is the first release of libucontext under the Adélie Linux umbrella, after its previous author [orphaned it](https://lists.alpinelinux.org/~alpine/devel/%3CCA%2BT2pCHBdVfzSiPVipiatJ4E7vPvD03d3KDEysEeJDuP-FO_NA%40mail.gmail.com%3E).