### PR TITLE
protonmail-bridge: update to 1.2.0

### DIFF
--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,6 +1,6 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=1.1.6
+version=1.2.0
 revision=1
 archs="x86_64"
 build_style=fetch
@@ -9,7 +9,7 @@ maintainer="Rich G <rich@richgannon.net>"
 license="Proprietary"
 homepage="https://protonmail.com/bridge"
 distfiles="https://protonmail.com/download/beta/protonmail-bridge_${version}-1_amd64.deb"
-checksum=e8878536d24964272aeb2521c51dbe861667be0f34c3337c3040b412b4a12ef5
+checksum=4150c290c681d2fe15e3e676aff13c413ea536c1a285c148fd532d34769c7bcb
 
 restricted=yes
 noverifyrdeps=yes


### PR DESCRIPTION
Tested working.  Still a proprietary license.