### PR TITLE
julia: update to 1.2.0

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,12 +1,12 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.1.1
-revision=2
+version=1.2.0
+revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc USE_SYSTEM_LLVM=0 USE_LLVM_SHLIB=1
  USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=1 USE_SYSTEM_LAPACK=1 USE_SYSTEM_GMP=1
- USE_SYSTEM_MPFR=1 USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBGIT2=1
+ USE_SYSTEM_MPFR=1 USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBGIT2=1 USE_BINARYBUILDER=0
  LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas
  LIBBLAS=-lopenblas LIBBLASNAME=libopenblas"
 make_install_args="$make_build_args"
@@ -22,10 +22,10 @@ maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=3c5395dd3419ebb82d57bcc49dc729df3b225b9094e74376f8c649ee35ed79c2
+checksum=2419b268fc5c3666dd9aeb554815fe7cf9e0e7265bc9b94a43957c31a68d9184
 nocross=yes
 # Falsely detects dependency on libllvm
-skiprdeps="/usr/lib/libjulia.so.1.1 /usr/lib/julia/libllvmcalltest.so"
+skiprdeps="/usr/lib/libjulia.so.1.2 /usr/lib/julia/libllvmcalltest.so"
 
 case "$XBPS_TARGET_MACHINE" in
 *-musl)


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/blob/release-1.2/NEWS.md for updates.

[ci skip] for llvm build

Additional make flag is to make sure the build doesn't pull in binary blobs as dependencies.

I have built and manually tested locally on x86-64 glibc.