### PR TITLE
deluge-web: fix added missing daemon argument

### DIFF
--- a/srcpkgs/deluge/files/deluge-web/run
+++ b/srcpkgs/deluge/files/deluge-web/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 sv check deluged >/dev/null || exit 1
-exec chpst -u deluge:deluge deluge-web 2>&1
+exec chpst -u deluge:deluge deluge-web -d 2>&1

--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,7 +1,7 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=2.0.3
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 pycompile_module="deluge"


### PR DESCRIPTION
A new daemon argument (-d) seems to have been added in a recent version of the deluge-web application. Without the argument the the deluge-web app is started but can't be controlled via runit (neither `sv stop` nor  `sv check` works).

For more information see:
https://forum.deluge-torrent.org/viewtopic.php?t=55379#p229789
https://deluge.readthedocs.io/en/latest/how-to/systemd-service.html#web-ui-deluge-web-service
 