### PR TITLE
iverilog: Updated to 10.3

### DIFF
--- a/srcpkgs/iverilog/template
+++ b/srcpkgs/iverilog/template
@@ -1,7 +1,7 @@
 # Template file for 'iverilog'
 pkgname=iverilog
-version=10.2
-revision=3
+version=10.3
+revision=1
 wrksrc="${pkgname}-${version/./_}"
 build_style=gnu-configure
 hostmakedepends="automake flex gperf"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://iverilog.icarus.com/"
 distfiles="https://github.com/steveicarus/iverilog/archive/v${version/./_}.tar.gz"
-checksum=f54d91821223c71c70f4735a1fb2af39c62efbccdeb9b0060ea1cf9c67647ee3
+checksum=4b884261645a73b37467242d6ae69264fdde2e7c4c15b245d902531efaaeb234
 
 nocross="draw_tt.exe: cannot execute binary file: Exec format error"
 


### PR DESCRIPTION
Updated iverilog from 10.2 to 10.3, a mandatory update since the time that passed by between 10.2 and 10.3 is almost 3 years.