### PR TITLE
libevent: update to 2.1.11.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -713,9 +713,11 @@ libsasl2.so.3 libsasl-2.1.26_1
 liblber-2.4.so.2 libldap-2.4.21_1
 libldap-2.4.so.2 libldap-2.4.21_1
 libldap_r-2.4.so.2 libldap-2.4.21_1
-libevent-2.1.so.6 libevent-2.1.8_1
-libevent_core-2.1.so.6 libevent-2.1.8_1
-libevent_pthreads-2.1.so.6 libevent-2.1.8_1
+libevent-2.1.so.7 libevent-2.1.11_1
+libevent_core-2.1.so.7 libevent-2.1.11_1
+libevent_extra-2.1.so.7 libevent-2.1.11_1
+libevent_pthreads-2.1.so.7 libevent-2.1.11_1
+libevent_openssl-2.1.so.7 libevent-2.1.11_1
 libSDL_mixer-1.2.so.0 SDL_mixer-1.2.11_1
 libapr-1.so.0 apr-1.4.2_1
 libaprutil-1.so.0 apr-util-1.3.9_1
@@ -2929,8 +2931,6 @@ libmirage.so.11 libmirage-3.1.0_1
 libwkhtmltox.so.0 libwkhtmltopdf-0.12.5_1
 libixml.so.10 libupnp1.8-1.8.2_1
 libupnp.so.13 libupnp1.8-1.8.4_1
-libevent_extra-2.1.so.6 libevent-2.1.8_3
-libevent_openssl-2.1.so.6 libevent-2.1.8_3
 libsysprof-3.so sysprof-3.34.0_1
 libsysprof-ui-3.so sysprof-3.34.0_1
 libmozjs-52.so mozjs52-52.3.0_1

--- a/srcpkgs/bitcoin/template
+++ b/srcpkgs/bitcoin/template
@@ -1,7 +1,7 @@
 # Template file for 'bitcoin'
 pkgname=bitcoin
 version=0.18.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-incompatible-bdb --disable-ccache --disable-static
  --enable-hardening --with-boost=${XBPS_CROSS_BASE}/usr"

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -2,7 +2,7 @@
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
 version=77.0.3865.120
-revision=1
+revision=2
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/coturn/template
+++ b/srcpkgs/coturn/template
@@ -1,7 +1,7 @@
 # Template file for 'coturn'
 pkgname=coturn
 version=4.5.1.1
-revision=2
+revision=3
 build_style=gnu-configure
 conf_files="/etc/turnserver.conf"
 makedepends="libressl-devel libevent-devel hiredis-devel sqlite-devel

--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,7 +1,7 @@
 # Template file for 'crystal'
 pkgname=crystal
 version=0.31.1
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
 _bootstrapversion=0.31.1

--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -4,9 +4,9 @@
 #
 pkgname=firefox-esr
 version=68.1.0
-revision=2
-build_helper="rust"
+revision=3
 wrksrc="firefox-${version}"
+build_helper="rust"
 short_desc="Mozilla Firefox web browser - Extended Support Release (ESR)"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="MPL-2.0, GPL-2.0-or-later, LGPL-2.1-or-later"
@@ -138,7 +138,7 @@ do_build() {
 
 	export MOZ_MAKE_FLAGS="${makejobs}"
 	export MOZ_NOSPAM=1
-        export MOZBUILD_STATE_PATH="${wrksrc}/mozbuild"
+	export MOZBUILD_STATE_PATH="${wrksrc}/mozbuild"
 
 	export AS=$CC
 

--- a/srcpkgs/firefox-i18n/template
+++ b/srcpkgs/firefox-i18n/template
@@ -3,10 +3,10 @@ pkgname=firefox-i18n
 version=69.0.3
 revision=1
 build_style=meta
-homepage="https://www.mozilla.org/firefox/"
 short_desc="Firefox language packs"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="MPL-2.0"
+homepage="https://www.mozilla.org/firefox/"
 
 create_wrksrc=yes
 

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -4,7 +4,7 @@
 #
 pkgname=firefox
 version=69.0.3
-revision=1
+revision=2
 build_helper="rust"
 short_desc="Mozilla Firefox web browser"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"

--- a/srcpkgs/freshplayerplugin/template
+++ b/srcpkgs/freshplayerplugin/template
@@ -1,7 +1,7 @@
 # Template file for 'freshplayerplugin'
 pkgname=freshplayerplugin
 version=0.3.9
-revision=3
+revision=4
 build_style=cmake
 hostmakedepends="pkg-config ragel"
 makedepends="libevent-devel libXcursor-devel alsa-lib-devel libXrandr-devel gtk+-devel

--- a/srcpkgs/fstrm/template
+++ b/srcpkgs/fstrm/template
@@ -1,7 +1,7 @@
 # Template file for 'fstrm'
 pkgname=fstrm
 version=0.5.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="libevent-devel"

--- a/srcpkgs/getdns/template
+++ b/srcpkgs/getdns/template
@@ -1,7 +1,7 @@
 # Template file for 'getdns'
 pkgname=getdns
 version=1.5.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-libev --with-libevent --with-libuv
  --with-ssl=${XBPS_CROSS_BASE}/usr"

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -1,7 +1,7 @@
 # Template file for 'icecat'
 pkgname=icecat
 version=60.7.0
-revision=2
+revision=3
 build_helper="rust"
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm
  cargo llvm clang rust cbindgen"

--- a/srcpkgs/libevent/patches/ddacaef59ab6808a0801007d0a681f2415af4871.patch
+++ b/srcpkgs/libevent/patches/ddacaef59ab6808a0801007d0a681f2415af4871.patch
@@ -1,0 +1,43 @@
+#upstream: yes
+
+From ddacaef59ab6808a0801007d0a681f2415af4871 Mon Sep 17 00:00:00 2001
+From: Azat Khuzhin <azat@libevent.org>
+Date: Thu, 29 Aug 2019 22:57:44 +0300
+Subject: [PATCH] Revert "Warn if forked from the event loop during
+ event_reinit()"
+
+Thinking about this more and realizing that this was a mistake, so
+should be reverted.
+
+In a nut shell I guess most of the apps calls event_reinit() from the
+loop (see [1] for example), and this should be totally fine (the bit
+with the signals [2] handled in event_reinit() gracefully)
+
+  [1]: https://archives.seul.org/libevent/users/Aug-2019/msg00009.html
+  [2]: https://github.com/libevent/libevent/pull/833#issuecomment-501834453
+
+This reverts commit 497ef904d544ac51de43934549dbeccce8e6e8f8.
+
+Reported-by: mikulas@twibright.com
+Backport-to: 2.1
+---
+ event.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/event.c b/event.c
+index 8cae318d1..ff4e79c84 100644
+--- event.c
++++ event.c
+@@ -1003,12 +1003,6 @@ event_reinit(struct event_base *base)
+ 
+ 	EVBASE_ACQUIRE_LOCK(base, th_base_lock);
+ 
+-	if (base->running_loop) {
+-		event_warnx("%s: forked from the event_loop.", __func__);
+-		res = -1;
+-		goto done;
+-	}
+-
+ 	evsel = base->evsel;
+ 
+ 	/* check if this event mechanism requires reinit on the backend */

--- a/srcpkgs/libevent/template
+++ b/srcpkgs/libevent/template
@@ -1,16 +1,16 @@
 # Template file for 'libevent'
 pkgname=libevent
-version=2.1.10
-revision=2
+version=2.1.11
+revision=1
 wrksrc="${pkgname}-${version}-stable"
 build_style=gnu-configure
 makedepends="libressl-devel"
 short_desc="Abstract asynchronous event notification library"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="BSD-3-Clause"
 homepage="http://libevent.org/"
-license="3-clause-BSD"
 distfiles="https://github.com/libevent/libevent/releases/download/release-${version}-stable/libevent-${version}-stable.tar.gz"
-checksum=e864af41a336bb11dab1a23f32993afe963c1f69618bd9292b89ecf6904845b0
+checksum=a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/litecoin/template
+++ b/srcpkgs/litecoin/template
@@ -1,7 +1,7 @@
 # Template file for 'litecoin'
 pkgname=litecoin
 version=0.16.3
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--with-incompatible-bdb --with-gui=qt5 --disable-static
  --disable-tests --with-libressl"

--- a/srcpkgs/memcached/template
+++ b/srcpkgs/memcached/template
@@ -1,7 +1,7 @@
 # Template file for 'memcached'
 pkgname=memcached
 version=1.5.16
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-seccomp"
 makedepends="libevent-devel libseccomp-devel"
@@ -24,4 +24,3 @@ memcached-devel_package() {
 		vmove usr/include
 	}
 }
-

--- a/srcpkgs/namecoin/template
+++ b/srcpkgs/namecoin/template
@@ -1,7 +1,7 @@
 # Template file for 'namecoin'
 pkgname=namecoin
 version=0.18.1
-revision=1
+revision=2
 wrksrc="${pkgname}-core-nc${version}"
 build_style=gnu-configure
 configure_args="--with-incompatible-bdb --disable-static

--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'nfs-utils'
 pkgname=nfs-utils
 version=2.3.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-statduser=nobody --enable-gss --enable-nfsv4
  --with-statedir=/var/lib/nfs --enable-libmount-mount --enable-svcgss

--- a/srcpkgs/nsd/template
+++ b/srcpkgs/nsd/template
@@ -1,7 +1,7 @@
 # Template file for 'nsd'
 pkgname=nsd
 version=4.2.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-ratelimit --enable-ratelimit-default-is-off
  --with-libevent=${XBPS_CROSS_BASE}/usr --with-ssl=${XBPS_CROSS_BASE}/usr"

--- a/srcpkgs/ntp/template
+++ b/srcpkgs/ntp/template
@@ -1,7 +1,7 @@
 # Template file for 'ntp'
 pkgname=ntp
 version=4.2.8p13
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-crypto --enable-linuxcap --enable-ipv6 --enable-ntp-signd
  --enable-all-clocks ol_cv_pthread_select_yields=yes"

--- a/srcpkgs/opensmtpd/template
+++ b/srcpkgs/opensmtpd/template
@@ -1,7 +1,7 @@
 # Template file for 'opensmtpd'
 pkgname=opensmtpd
 version=6.4.2p1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--sysconfdir=/etc/smtpd --sbindir=/usr/bin
  --with-path-socket=/run --with-path-pidfile=/run

--- a/srcpkgs/pgbouncer/template
+++ b/srcpkgs/pgbouncer/template
@@ -1,7 +1,7 @@
 # Template file for 'pgbouncer'
 pkgname=pgbouncer
 version=1.11.0
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libevent-devel"
 short_desc="Lightweight connection pooler for PostgreSQL"

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
 version=5.13.1
-revision=1
+revision=2
 wrksrc="qt-everywhere-src-${version}"
 build_style=gnu-configure
 hostmakedepends="cmake clang flex git glib-devel gperf ninja pkg-config

--- a/srcpkgs/redsocks/template
+++ b/srcpkgs/redsocks/template
@@ -1,9 +1,9 @@
 # Template file for 'redsocks'
 pkgname=redsocks
 version=0.5
-revision=3
-build_style=gnu-makefile
+revision=4
 wrksrc="${pkgname}-release-${version}"
+build_style=gnu-makefile
 makedepends="libevent-devel"
 short_desc="Transparent redirector of any TCP connection to a SOCKS or HTTP proxy"
 maintainer="cipr3s <cipr3s@gmx.com>"

--- a/srcpkgs/rspamd/template
+++ b/srcpkgs/rspamd/template
@@ -1,7 +1,7 @@
 # Template file for 'rspamd'
 pkgname=rspamd
 version=1.9.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DRSPAMD_USER=rspamd -DCONFDIR=/etc/rspamd
  -DDBDIR=/var/lib/rspamd"

--- a/srcpkgs/saldl/template
+++ b/srcpkgs/saldl/template
@@ -1,9 +1,9 @@
 # Template file for 'saldl'
 pkgname=saldl
 version=40
-revision=1
+revision=2
 build_style=waf
-configure_args="--saldl-version v${version}"
+configure_args="--saldl-version v${version} --no-werror"
 hostmakedepends="pkg-config asciidoc"
 makedepends="libevent-devel libcurl-devel"
 short_desc="CLI downloader optimized for speed and early preview"

--- a/srcpkgs/seafile-libclient/template
+++ b/srcpkgs/seafile-libclient/template
@@ -1,7 +1,7 @@
 # Template file for 'seafile-libclient'
 pkgname=seafile-libclient
 version=7.0.2
-revision=1
+revision=2
 _distname="${pkgname/-libclient/}"
 wrksrc="${_distname}-${version}"
 build_style=gnu-configure

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -4,7 +4,7 @@
 #
 pkgname=thunderbird
 version=68.1.0
-revision=1
+revision=2
 build_helper="rust"
 short_desc="Standalone Mail/News reader"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/tlsdate/template
+++ b/srcpkgs/tlsdate/template
@@ -1,7 +1,7 @@
 # Template file for 'tlsdate'
 pkgname=tlsdate
 version=0.0.13
-revision=13
+revision=14
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 configure_args="--with-polarssl=no ac_cv_func_clock_gettime=yes"

--- a/srcpkgs/tmate/template
+++ b/srcpkgs/tmate/template
@@ -1,7 +1,7 @@
 # Template file for 'tmate'
 pkgname=tmate
 version=2.2.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="libevent-devel libssh-devel msgpack-devel ncurses-devel"

--- a/srcpkgs/tmux/template
+++ b/srcpkgs/tmux/template
@@ -1,7 +1,7 @@
 # Template file for 'tmux'
 pkgname=tmux
 version=2.9a
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="libevent-devel ncurses-devel"
 short_desc="Terminal Multiplexer"

--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,7 +1,7 @@
 # Template file for 'tor'
 pkgname=tor
 version=0.4.1.6
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libevent-devel libseccomp-devel zlib-devel"
 depends="ca-certificates torsocks"

--- a/srcpkgs/transmission/template
+++ b/srcpkgs/transmission/template
@@ -1,14 +1,14 @@
 # Template file for 'transmission'
 pkgname=transmission
 version=2.94
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-nls --enable-cli --enable-daemon --enable-utp
  --without-systemd-daemon"
 hostmakedepends="intltool pkg-config"
 makedepends="dbus-glib-devel gtk+3-devel libcurl-devel libevent-devel
  qt5-tools-devel"
-short_desc="A fast, easy, and free BitTorrent client"
+short_desc="Fast, easy and free BitTorrent client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, GPL-2.0-or-later"
 homepage="https://www.transmissionbt.com"

--- a/srcpkgs/unbound/template
+++ b/srcpkgs/unbound/template
@@ -1,7 +1,7 @@
 # Template file for 'unbound'
 pkgname=unbound
 version=1.9.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-libevent --with-conf-file=/etc/unbound/unbound.conf
  --with-pidfile=/run/unbound.pid --with-ssl=${XBPS_CROSS_BASE}/usr

--- a/srcpkgs/zabbix/template
+++ b/srcpkgs/zabbix/template
@@ -1,7 +1,7 @@
 # Template file for 'zabbix'
 pkgname=zabbix
 version=4.2.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-libxml2 --with-gnutls --with-libcurl --with-net-snmp
  --with-mysql --enable-server --enable-ipv6 --with-ssh2 --enable-agent


### PR DESCRIPTION
what builds: all packages build, except

- [x] icecat ( fixed in #15221)
- [x] firefox-esr (fixed in #15402)
- [x] thunderbird (fixed in #15429)

what works: firefox, thunderbird, tmux, tor and qt work fine (tested on x86_64)