### PR TITLE
libqb: add to common/shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3496,3 +3496,4 @@ libde265.so.0 libde265-1.0.3_1
 libheif.so.1 libheif-1.4.0_1
 libuninameslist.so.1 libuninameslist-20190701_1
 libgambit.so.4 gambit-4.9.3_1
+libqb.so.0 libqb-1.0.5_1


### PR DESCRIPTION
IIUC this is needed to make `04-generate-runtime-deps.sh` pass if a new package uses libqb. I'm working on a package which uses `libqb` and it was failing with `UNKNOWN PKG PLEASE FIX!`.