### PR TITLE
New package: usbguard-0.7.5

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3500,3 +3500,4 @@ liblog4cpp.so.5 log4cpp-1.1.3_1
 libnuspell.so.2 libnuspell-2.3.0_1
 liblog4c.so.3 log4c-1.2.4_1
 libqb.so.0 libqb-1.0.5_1
+libusbguard.so.0 usbguard-0.7.5_1

--- a/srcpkgs/usbguard/files/usbguard/run
+++ b/srcpkgs/usbguard/files/usbguard/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec usbguard-daemon

--- a/srcpkgs/usbguard/patches/musl.patch
+++ b/srcpkgs/usbguard/patches/musl.patch
@@ -1,0 +1,84 @@
+--- src/CLI/usbguard.cpp.orig	2019-06-13 11:51:53.787863657 +0000
++++ src/CLI/usbguard.cpp	2019-08-23 01:52:34.233056882 +0000
+@@ -26,10 +26,8 @@
+ #include <map>
+ #include <iostream>
+ 
+-#ifndef _GNU_SOURCE
+-  #define _GNU_SOURCE
+-#endif
+-#include <cstring> /* GNU version of basename(3) */
++#include <cstring>
++#include <libgen.h>
+ 
+ #include "usbguard.hpp"
+ #include "usbguard-get-parameter.hpp"
+@@ -99,7 +97,7 @@
+ 
+   static int usbguard_cli(int argc, char* argv[])
+   {
+-    usbguard_arg0 = ::basename(argv[0]);
++    usbguard_arg0 = ::basename(strdup(argv[0]));
+ 
+     if (argc == 1) {
+       showTopLevelHelp();
+--- src/CLI/usbguard-rule-parser.cpp.orig	2019-06-13 11:51:53.783863704 +0000
++++ src/CLI/usbguard-rule-parser.cpp	2019-08-23 01:52:34.234056870 +0000
+@@ -24,10 +24,8 @@
+ #include "RuleParser.hpp"
+ 
+ #include <iostream>
+-#ifndef _GNU_SOURCE
+-  #define _GNU_SOURCE
+-#endif
+ #include <cstring>
++#include <libgen.h>
+ #include <fstream>
+ 
+ #include <getopt.h>
+@@ -43,8 +41,10 @@
+ 
+ static void showHelp(std::ostream& stream, const char* usbguard_arg0)
+ {
+-  stream << " Usage: " << ::basename(usbguard_arg0) << " [OPTIONS] <rule_spec>" << std::endl;
+-  stream << " Usage: " << ::basename(usbguard_arg0) << " [OPTIONS] -f <file>" << std::endl;
++  char *usbguard_arg0_copy = strdup(usbguard_arg0);
++  stream << " Usage: " << ::basename(usbguard_arg0_copy) << " [OPTIONS] <rule_spec>" << std::endl;
++  stream << " Usage: " << ::basename(usbguard_arg0_copy) << " [OPTIONS] -f <file>" << std::endl;
++  free(usbguard_arg0_copy);
+   stream << std::endl;
+   stream << " Options:" << std::endl;
+   stream << "  -f, --file       Interpret the argument as a path to a file that should be parsed." << std::endl;
+--- src/DBus/gdbus-server.cpp.orig	2019-06-28 08:45:27.616687137 +0000
++++ src/DBus/gdbus-server.cpp	2019-08-23 01:52:34.274056367 +0000
+@@ -23,6 +23,7 @@
+ #include <stdlib.h>
+ #include <iostream>
+ #include <getopt.h>
++#include <libgen.h>
+ #include "DBusBridge.hpp"
+ 
+ static usbguard::DBusBridge* dbus_bridge = nullptr;
+@@ -208,7 +209,9 @@
+ 
+ static void showHelp(std::ostream& stream)
+ {
+-  stream << " Usage: " << ::basename(usbguard_arg0) << " [OPTIONS]" << std::endl;
++  char *usbguard_arg0_copy = strdup(usbguard_arg0);
++  stream << " Usage: " << ::basename(usbguard_arg0_copy) << " [OPTIONS]" << std::endl;
++  free(usbguard_arg0_copy);
+   stream << std::endl;
+   stream << " Options:" << std::endl;
+   stream << "  -s, --system   Listen on the system bus." << std::endl;
+--- src/Library/public/usbguard/Exception.hpp.orig	2019-06-28 08:45:27.620687089 +0000
++++ src/Library/public/usbguard/Exception.hpp	2019-08-23 01:52:34.323055751 +0000
+@@ -116,7 +116,8 @@
+     static std::string reasonFromErrno(const int errno_value)
+     {
+       char buffer[1024];
+-      return std::string(strerror_r(errno_value, buffer, sizeof buffer));
++      strerror_r(errno_value, buffer, sizeof buffer);
++      return std::string(buffer);
+     }
+   };
+ 

--- a/srcpkgs/usbguard/template
+++ b/srcpkgs/usbguard/template
@@ -1,0 +1,20 @@
+# Template file for 'usbguard'
+pkgname=usbguard
+version=0.7.5
+revision=1
+build_style=gnu-configure
+configure_args="--with-crypto-library=sodium --with-bundled-catch --with-bundled-pegtl"
+conf_files="/etc/usbguard/*"
+make_dirs="/var/log/usbguard 0755 root root"
+hostmakedepends="automake libtool pkg-config asciidoc glib-devel protobuf"
+makedepends="libqb-devel libsodium-devel protobuf-devel dbus-glib-devel polkit-devel libcap-ng-devel libseccomp-devel"
+short_desc="Tool for whitelisting and blacklisting USB devices"
+maintainer="Philoponus Bindle <philoponus-bindle@protonmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://usbguard.github.io"
+distfiles="https://github.com/USBGuard/usbguard/releases/download/usbguard-$version/usbguard-$version.tar.gz"
+checksum=ab98091969bf4ea68d7a950997cd7af98ddac84558aa6dfe733e8fa0a936454a
+
+post_install() {
+	vsv usbguard
+}


### PR DESCRIPTION
This depends on #13877 as it links against libqb

On the dependencies:
 * `./configure` complains about the lack of a protobuf compiler if `protobuf` isn't on the `hostmakedepends`, but it also complains if `protobuf-devel` isn't in the `makedepends` as usbguard also still needs use the API directly and not just the CLI compiler, so that's why there is both deps.
 * `glib-devel` is needed for the tool `gdbus-codegen`, which is why it is on the `hostmakedepends`

lmk if there is anything else I should add or style things to change.

