### PR TITLE
New package: passphrase2pgp-0.1.0

### DIFF
--- a/srcpkgs/passphrase2pgp/template
+++ b/srcpkgs/passphrase2pgp/template
@@ -1,0 +1,13 @@
+# Template file for 'passphrase2pgp'
+pkgname=passphrase2pgp
+version=0.1.0
+revision=1
+build_style=go
+go_import_path="github.com/skeeto/passphrase2pgp"
+hostmakedepends="git"
+short_desc="Generate a PGP key from a passphrase"
+maintainer="Daniel Lewan <vision360.daniel@gmail.com>"
+license="Unlicense"
+homepage="https://github.com/skeeto/passphrase2pgp"
+distfiles="https://github.com/skeeto/passphrase2pgp/archive/v${version}.tar.gz"
+checksum=15d26a836d9df2fa6e487d7224e6ab7d6f51139211ceb77b8ecd8c594b86699a


### PR DESCRIPTION
> passphrase2pgp generates, in OpenPGP format, an EdDSA signing key and
Curve25519 encryption subkey entirely from a passphrase, essentially allowing
you to store a backup of your PGP keys in your brain.

https://nullprogram.com/blog/2019/07/10/