### PR TITLE
ibus-bamboo: update to 0.5.4

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.5.3
+version=0.5.4
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="8718418f5cb616808ca6827b0851ead83ee4660a981bcb9143edf0a5cf12e43a"
+checksum="3b945c58e5129081e1cc899f81edccf05c9f579fc429e1bdc8466469441d93cf"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
- Introduce "ForwardKeyEvent II" non-underline mode
- Disable X11 mouse grabbing