### PR TITLE
qt5-webkit: adopt, update snapshot, fixes, 32-bit debug support

### DIFF
--- a/srcpkgs/qt5-webkit/patches/ppc-llint.patch
+++ b/srcpkgs/qt5-webkit/patches/ppc-llint.patch
@@ -1,0 +1,32 @@
+This fixes JavaScriptCore on big endian systems (mainly ppc).
+
+Without the patch, attempting to run any JS results in
+a crash as the generated code was endian specific.
+
+--- Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
++++ Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+@@ -1500,13 +1500,13 @@ _llint_op_put_by_id:
+     loadp StructureChain::m_vector[t3], t3
+     assert(macro (ok) btpnz t3, ok end)
+ 
+-    loadp Structure::m_prototype[t2], t2
++    loadp Structure::m_prototype + PayloadOffset[t2], t2
+     btpz t2, .opPutByIdTransitionChainDone
+ .opPutByIdTransitionChainLoop:
+     loadp [t3], t1
+     bpneq t1, JSCell::m_structureID[t2], .opPutByIdSlow
+     addp 4, t3
+-    loadp Structure::m_prototype[t1], t2
++    loadp Structure::m_prototype + PayloadOffset[t1], t2
+     btpnz t2, .opPutByIdTransitionChainLoop
+ 
+ .opPutByIdTransitionChainDone:
+@@ -1984,7 +1984,7 @@ _llint_throw_from_slow_path_trampoline:
+     # When throwing from the interpreter (i.e. throwing from LLIntSlowPaths), so
+     # the throw target is not necessarily interpreted code, we come to here.
+     # This essentially emulates the JIT's throwing protocol.
+-    loadp Callee[cfr], t1
++    loadp Callee + PayloadOffset[cfr], t1
+     andp MarkedBlockMask, t1
+     loadp MarkedBlock::m_weakSet + WeakSet::m_vm[t1], t1
+     copyCalleeSavesToVMCalleeSavesBuffer(t1, t2)

--- a/srcpkgs/qt5-webkit/patches/reduce-exports.patch
+++ b/srcpkgs/qt5-webkit/patches/reduce-exports.patch
@@ -1,0 +1,27 @@
+Description: reduce the number of exported symbols in libQt5WebKit.so.5
+Author: Dmitry Shachnev <mitya57@debian.org>
+Forwarded: not-needed
+Last-Update: 2017-08-27
+
+--- Source/WTF/wtf/ExportMacros.h
++++ Source/WTF/wtf/ExportMacros.h
+@@ -56,7 +56,7 @@
+ 
+ #elif defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC__)
+ 
+-#define WTF_EXPORT_DECLARATION __attribute__((visibility("default")))
++#define WTF_EXPORT_DECLARATION
+ #define WTF_IMPORT_DECLARATION WTF_EXPORT_DECLARATION
+ #define WTF_HIDDEN_DECLARATION __attribute__((visibility("hidden")))
+ 
+--- Source/cmake/OptionsQt.cmake
++++ Source/cmake/OptionsQt.cmake
+@@ -658,6 +658,7 @@ if (COMPILER_IS_GCC_OR_CLANG AND UNIX)
+     if (NOT SHARED_CORE)
+         set(CMAKE_C_FLAGS "-fvisibility=hidden ${CMAKE_C_FLAGS}")
+         set(CMAKE_CXX_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden ${CMAKE_CXX_FLAGS}")
++        add_definitions(-DJS_NO_EXPORT)
+     endif ()
+ endif ()
+ 
+

--- a/srcpkgs/qt5-webkit/template
+++ b/srcpkgs/qt5-webkit/template
@@ -1,23 +1,30 @@
 # Template file for 'qt5-webkit'
 pkgname=qt5-webkit
 version=5.212.0
-revision=5
-_snap=1561566461
+revision=6
+_snap=1565895469
 _v=${version%.*}
 wrksrc="qtwebkit-everywhere-src-${_v}"
 build_style=cmake
-configure_args="-DPORT=Qt -DUSE_LD_GOLD=OFF"
+# some nasty stuff to prevent cmake from inducing buggy -O3 and default -g
+configure_args="-DPORT=Qt -DUSE_LD_GOLD=OFF
+ -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
+ -DCMAKE_CXX_FLAGS_DEBUG=-DNDEBUG
+ -DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-DNDEBUG
+ -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG
+ -DCMAKE_C_FLAGS_DEBUG=-DNDEBUG
+ -DCMAKE_C_FLAGS_RELWITHDEBINFO=-DNDEBUG"
 hostmakedepends="flex gperf perl pkg-config python qt5-qmake ruby"
 makedepends="libwebp-devel libxslt-devel libXcomposite-devel sqlite-devel
  libjpeg-turbo-devel gst-plugins-base1-devel qt5-declarative-devel
  qt5-location-devel qt5-sensors-devel qt5-webchannel-devel hyphen-devel
  ruby-devel"
 short_desc="Cross-platform application and UI framework (Qt5) - WebKit2 component"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="q66 <daniel@octaforge.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.qt.io/"
 distfiles="https://download.qt.io/snapshots/ci/qtwebkit/${_v}/${_snap}/src/submodules/qtwebkit-everywhere-src-${_v}.tar.xz"
-checksum=68eae85e7a12077b8004d7a039af065d68112e8e9ab95013f4e01527759fab9f
+checksum=607f0a13e05bbf831d86904d12ae464e7d46a15f0ceed2465487b53512948824
 
 CPPFLAGS="-I${XBPS_CROSS_BASE}/usr/include"
 CXXFLAGS="-fpermissive -Wno-class-memaccess"
@@ -27,27 +34,45 @@ if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DRUBY_CONFIG_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include/ruby-*"
 fi
 
-# reduce memory footprint when linking
-if [ "$XBPS_WORDSIZE" -eq 32 ]; then
-	nodebug=yes
-fi
-
+# only a few platform support JIT
 case "$XBPS_TARGET_MACHINE" in
-	armv6*)	# Need libatomic for __atomic_fetch_add_8 etc.
+	armv[67]*|aarch64*|i686*|x86_64*|mips*) ;;
+	*) configure_args+=" -DENABLE_JIT=OFF" ;;
+esac
+
+# some platforms need libatomic
+case "$XBPS_TARGET_MACHINE" in
+	ppc64*) ;;
+	armv6*|ppc*)
 		makedepends+=" libatomic-devel"
 		LIBS+=" -latomic"
 		;;
-	ppc64*)	# no JIT on ppc64 and other build workarounds
-		configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON"
-		;;
-	ppc*)   # no JIT on ppc and need libatomic
-		configure_args+=" -DENABLE_JIT=OFF -DUSE_SYSTEM_MALLOC=ON"
-		makedepends+=" libatomic-devel"
-		LIBS+=" -latomic"
-		;;
+	*) ;;
+esac
+
+# use system malloc on ppc64le (potential 64k page kernel)
+case "$XBPS_TARGET_MACHINE" in
+	ppc64le*) configure_args+=" -DUSE_SYSTEM_MALLOC=ON" ;;
+	*) ;;
 esac
 
 pre_configure() {
+	# work around large debug symbols on 32-bit hosts
+	if [ "$XBPS_WORDSIZE" = "32" ]; then
+		export CFLAGS="${CFLAGS/-g/-g1}"
+		export CXXFLAGS="${CXXFLAGS/-g/-g1}"
+		export LDFLAGS+=" -Wl,--no-keep-memory"
+	fi
+
+	# the above is not enough for 32-bit ppc and debug
+	case "$XBPS_TARGET_MACHINE" in
+		ppc64*) ;;
+		ppc*)
+			export CFLAGS="${CFLAGS/-O2/-Os}"
+			export CXXFLAGS="${CXXFLAGS/-O2/-Os}"
+			;;
+	esac
+
 	if [ "$CROSS_BUILD" ]; then
 		# XXX: disable failing check for private headers and assume they are available
 		sed -i Source/cmake/OptionsQt.cmake \


### PR DESCRIPTION
This also refactors the template, enables debug on 32-bit systems and fixes JavaScript on big endian (ppc/ppc64).