### PR TITLE
hydroxide: update to 0.2.7

### DIFF
--- a/srcpkgs/hydroxide/template
+++ b/srcpkgs/hydroxide/template
@@ -1,6 +1,6 @@
 # Template file for 'hydroxide'
 pkgname=hydroxide
-version=0.2.6
+version=0.2.7
 revision=1
 build_style=go
 go_import_path=github.com/emersion/hydroxide/cmd/hydroxide
@@ -10,9 +10,8 @@ maintainer="DirectorX <void.directorx@protonmail.com>"
 license="MIT"
 homepage="https://github.com/emersion/hydroxide"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=49b1cea513fd3c012dc1b09a60d19656fe7f12be647b4cbb25b36be580772b40
+checksum=99986a837bc0f107d8a323398654e20ad70968d3107da087f154ea9dc7580f22
 
 post_install() {
 	vlicense LICENSE
 }
-


### PR DESCRIPTION
previous versions are completely not working (at least on initialization) due to protonmail API change which this hydroxide update rectifies.