### PR TITLE
mutt: add cyrus-sasl-modules dep for smtp auth

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,7 +1,7 @@
 # Template file for 'mutt'
 pkgname=mutt
 version=1.12.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
  --enable-gpgme --with-regex --with-idn2 --with-ssl --with-sasl --enable-sidebar
@@ -11,7 +11,7 @@ conf_files="/etc/${pkgname}/Muttrc"
 hostmakedepends="libidn2-devel perl pkg-config"
 makedepends="gdbm-devel gpgme-devel libidn2-devel libressl-devel libsasl-devel
  ncurses-devel"
-depends="mime-types"
+depends="cyrus-sasl-modules mime-types"
 short_desc="Mutt Mail Client"
 maintainer="Jan S. <jan.schreib@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
would get no authenticators error message without cyrus-sasl-modules installed when trying to make outgoing smtp request.

found via varying online sources that this missing package is a culprit to this error on other distros.