### PR TITLE
python3-fonttools: update to 4.0.0

### DIFF
--- a/srcpkgs/python-fonttools/template
+++ b/srcpkgs/python-fonttools/template
@@ -1,11 +1,11 @@
 # Template file for 'python-fonttools'
 pkgname=python-fonttools
 version=3.44.0
-revision=1
+revision=2
 wrksrc="${pkgname#python-}-${version}"
-build_style=python-module
+build_style=python2-module
 pycompile_module="fonttools"
-hostmakedepends="python-devel python3-devel python-setuptools python3-setuptools"
+hostmakedepends="python-devel python-setuptools"
 makedepends="${hostmakedepends}"
 short_desc="Library to manipulate font files from Python2"
 maintainer="svenper <svenper@tuta.io>"
@@ -17,15 +17,4 @@ checksum=9dadbca88a5a841d821f6892fa9f4715ec03afd53980aaf4d61bd4be345b24ed
 post_install() {
 	vlicense LICENSE
 	vlicense LICENSE.external
-}
-
-python3-fonttools_package() {
-	pycompile_module="fonttools"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove "usr/lib/python3*"
-		vmove "usr/bin/*3"
-		vlicense LICENSE
-		vlicense LICENSE.external
-	}
 }

--- a/srcpkgs/python3-fonttools
+++ b/srcpkgs/python3-fonttools
@@ -1,1 +1,0 @@
-python-fonttools

--- a/srcpkgs/python3-fonttools/template
+++ b/srcpkgs/python3-fonttools/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-fonttools'
+pkgname=python3-fonttools
+version=4.0.0
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+pycompile_module="fonttools"
+hostmakedepends="python3-devel python3-setuptools"
+makedepends="${hostmakedepends}"
+short_desc="Library to manipulate font files from Python3"
+maintainer="svenper <svenper@tuta.io>"
+license="MIT, OFL-1.1, BSD-3-Clause"
+homepage="https://github.com/fonttools/fonttools"
+distfiles="https://github.com/fonttools/fonttools/archive/${version}.tar.gz"
+checksum=f854849ca51f8ac39b7627bb61142e33e833f4f1f6de882273d1011726819957
+
+post_install() {
+	vlicense LICENSE
+	vlicense LICENSE.external
+}


### PR DESCRIPTION
Python 2 support is dropped upstream.