### PR TITLE
libu2f-host: update to 1.1.10

### DIFF
--- a/srcpkgs/libu2f-host/template
+++ b/srcpkgs/libu2f-host/template
@@ -1,7 +1,7 @@
 # Template file for 'libu2f-host'
 pkgname=libu2f-host
-version=1.1.9
-revision=2
+version=1.1.10
+revision=1
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 configure_args="--with-openssl=yes --with-udevrulesdir=/usr/lib/udev/rules.d"
@@ -9,11 +9,11 @@ hostmakedepends="automake gengetopt libtool pkg-config"
 makedepends="hidapi-devel json-c-devel libressl-devel"
 short_desc="C library and tool that implements the host-side of the U2F protocol"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="LGPL-2.1-or-later, GPL-3-or-later"
+license="LGPL-2.1-or-later, GPL-3.0-or-later"
 homepage="https://developers.yubico.com/libu2f-host/"
 #changelog="https://raw.githubusercontent.com/Yubico/libu2f-host/master/NEWS"
 distfiles="https://github.com/Yubico/libu2f-host/archive/libu2f-host-${version}.tar.gz"
-checksum=f2d9ac7d0bb448d213a81aa3c2e97ae48b277144040c74b5c4f33d871338e93c
+checksum=45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303
 conf_files="/usr/lib/udev/rules.d/70-u2f.rules"
 
 pre_configure() {
@@ -21,7 +21,7 @@ pre_configure() {
 }
 
 post_install() {
-	vsed -e 's:TAG+="uaccess":TAG+="uaccess", MODE="0660", GROUP="users":' \
+	vsed -e 's:GROUP="plugdev":GROUP="users":' \
 		 -i ${DESTDIR}/usr/lib/udev/rules.d/70-u2f.rules
 }
 


### PR DESCRIPTION
Update to latest upstream version, with support for more devices, like SoloKey dongles.
~~Add the system group "plugdev" required by the included udev rules.~~
Fix udev rules patch in post_install.