### PR TITLE
New package: glfw-wayland-3.3

### DIFF
--- a/srcpkgs/glfw-wayland/template
+++ b/srcpkgs/glfw-wayland/template
@@ -1,0 +1,29 @@
+# Template file for 'glfw-wayland'
+pkgname=glfw-wayland
+version=3.3
+revision=1
+wrksrc=glfw-${version}
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=ON -DGLFW_USE_WAYLAND=ON"
+hostmakedepends="extra-cmake-modules pkg-config"
+makedepends="MesaLib-devel glu-devel wayland-devel wayland-protocols
+ libxkbcommon-devel"
+short_desc="Multi-platform library for creating windows with OpenGL contexts"
+maintainer="q66 <daniel@octaforge.org>"
+license="Zlib"
+homepage="http://www.glfw.org"
+distfiles="${SOURCEFORGE_SITE}/glfw/glfw-${version}.tar.bz2"
+checksum=32797630af0da94a1a05302bca0435eae352f593197a04670d797de2e492a5a5
+provides="glfw-${version}_${revision}"
+replaces="glfw>=0"
+
+if [ "$CROSS_BUILD" ]; then
+	# wayland-scanner
+	hostmakedepends+=" wayland-devel"
+fi
+
+do_install() {
+	vmkdir usr/lib
+	install -m755 ${wrksrc}/build/src/libglfw.so.${version} ${DESTDIR}/usr/lib/
+	ln -s libglfw.so.${version} ${DESTDIR}/usr/lib/libglfw.so.3
+}

--- a/srcpkgs/glfw/template
+++ b/srcpkgs/glfw/template
@@ -1,4 +1,5 @@
 # Template file for 'glfw'
+# update together with glfw-wayland
 pkgname=glfw
 version=3.3
 revision=1


### PR DESCRIPTION
This provides a wayland version of glfw, like other distros do. The devel files and stuff are shared, so this only installs the library. (glfw does not allow both choices at runtime yet, so a separate package is the only way to do it)