### PR TITLE
mplayer: runtime cpudetection is broken on ppc, disable altivec

### DIFF
--- a/srcpkgs/mplayer/template
+++ b/srcpkgs/mplayer/template
@@ -32,12 +32,11 @@ conf_files="
 do_configure() {
 	sed 's|-march=i486||g' -i configure
 
+	# we tried runtime cpudetection for ppc32 but stuff's broken
 	case "$XBPS_TARGET_MACHINE" in
-		i686*|x86_64*|ppc*) configure_args+=" --enable-vdpau --enable-runtime-cpudetection";;
+		i686*|x86_64*|ppc64*) configure_args+=" --enable-vdpau --enable-runtime-cpudetection";;
+		ppc*) configure_args+=" --enable-vdpau --disable-altivec";;
 	esac
-
-	# we enable runtime cpu detection for ppc, let the altivec bits build
-	export CFLAGS="${CFLAGS/-mno-altivec}"
 
 	./configure --prefix=/usr \
 		--disable-gui --disable-arts --disable-liblzo --disable-speex \


### PR DESCRIPTION
I tested this and it doesn't work (SIGILL). So disable altivec on ppc32 for now (it's already done in ffmpeg that way so I guess at least that's consistent). I might add it later as an option, or possibly figure out how to fix the CPU detection code.