### PR TITLE
rpi-kernel: update to 4.19.67

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,18 +1,18 @@
 # Template file for 'rpi-firmware'
-_githash="3822340923e5cddc772492386d82ba00f4275d62"
+_githash="7163480fff007dc98978899b556dcf06f8a462c8"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20190801
+version=20190823
 revision=1
 archs=noarch
 wrksrc="firmware-${_githash}"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Peter Bui <pbui@github.bx612.space>"
 license="BSD-3-Clause"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=35a5b0a30cdc68aeeda355a506dc967bc5de5cf7fc94e90367d979bff0a0f0bb
+checksum=012bc542157d03d19c52dfb2ff9e828905d1991a8b33420f1a2e3730040c167f
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,19 +5,19 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="fc5826fb999e0b32900d1f487e90c27a92010214"
+_githash="174fcab91765ef8fe3562c9858fb62f1a471c2d6"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.66
+version=4.19.67
 revision=1
 wrksrc="linux-${_githash}"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=cd8076d65788ad6e1719f29f3023ea6141c1727a330e1bbc947e3106b320bc2d
+checksum=006fd5539bda821d7c53cacb2e90498300dbf8551c7e1629873f74ab2aa31f99
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
- Built for armv6l, armv7l, aarch64.

- Tested on armv6l and armv7l.

- Also update rpi-firmware to 20190823.

- Take maintainership of both (currently orphaned).