### PR TITLE
pam_rundir: patch from branch next

### DIFF
--- a/srcpkgs/pam_rundir/patches/fix.patch
+++ b/srcpkgs/pam_rundir/patches/fix.patch
@@ -1,0 +1,40 @@
+--- pam_rundir.c	2015-09-23 12:57:53.000000000 -0400
++++ pam_rundir2.c	2019-08-24 13:17:11.241470935 -0400
+@@ -24,6 +24,8 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/file.h>
++#include <sys/prctl.h>
++#include <linux/securebits.h>
+ #include <string.h>
+ #include <pwd.h>
+ #include <fcntl.h>
+@@ -360,6 +362,7 @@
+         char file[sizeof (PARENT_DIR) + l + 2];
+         int fd;
+         int count = 0;
++        int secbits = -1;
+ 
+         print_filename (file, (int) pw->pw_uid, l);
+         fd = open_and_lock (file);
+@@ -396,6 +399,11 @@
+             goto done;
+         }
+ 
++        /* to bypass permission checks for mkdir, in case it isn't group
++         * writable */
++        secbits = prctl (PR_GET_SECUREBITS);
++        if (secbits != -1)
++            prctl (PR_SET_SECUREBITS, (unsigned long) secbits | SECBIT_NO_SETUID_FIXUP);
+         /* set euid so if we do create the dir, it is own by the user */
+         if (seteuid (pw->pw_uid) < 0)
+         {
+@@ -421,6 +429,8 @@
+         }
+ 
+ done:
++        if (secbits != -1)
++            prctl (PR_SET_SECUREBITS, (unsigned long) secbits);
+         close (fd); /* also unlocks */
+     }
+ 

--- a/srcpkgs/pam_rundir/template
+++ b/srcpkgs/pam_rundir/template
@@ -1,7 +1,7 @@
 # Template file for 'pam_rundir'
 pkgname=pam_rundir
 version=1.0.0
-revision=4
+revision=5
 build_style=configure
 configure_args="--prefix=/usr --with-parentdir=/run/user"
 makedepends="pam-devel"


### PR DESCRIPTION
Because of #4417, the old unsecure fix was removed. RIght now, this package is broken and simply does not work. The author issued a commit to fix the security concern. See https://github.com/jjk-jacky/pam_rundir/issues/3#issuecomment-437934718.