### PR TITLE
tty-clock: fix license in template

### DIFF
--- a/srcpkgs/tty-clock/template
+++ b/srcpkgs/tty-clock/template
@@ -1,12 +1,12 @@
 # Template file for 'tty-clock'
 pkgname=tty-clock
 version=2.3
-revision=1
+revision=2
 replaces="tty-clock-git>=0"
 makedepends="ncurses-devel"
 short_desc="Digital clock in ncurses"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+maintainer="Lugubris <lugubris@disroot.org>"
+license="BSD-3-Clause"
 homepage="https://github.com/xorg62/tty-clock"
 distfiles="https://github.com/xorg62/tty-clock/archive/v${version}.tar.gz"
 checksum=343e119858db7d5622a545e15a3bbfde65c107440700b62f9df0926db8f57984
@@ -18,4 +18,8 @@ do_build() {
 do_install() {
 	vbin tty-clock
 	vman tty-clock.1
+}
+
+post_install() {
+	vlicense LICENSE
 }


### PR DESCRIPTION
change from GPL-3 to BSD-3-Clause
-> https://github.com/xorg62/tty-clock/blob/master/LICENSE