### PR TITLE
tty-clock: fix travis ci warning

### DIFF
--- a/srcpkgs/tty-clock/template
+++ b/srcpkgs/tty-clock/template
@@ -2,7 +2,6 @@
 pkgname=tty-clock
 version=2.3
 revision=1
-replaces="tty-clock-git>=0"
 makedepends="ncurses-devel"
 short_desc="Digital clock in ncurses"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -10,6 +9,7 @@ license="GPL-3"
 homepage="https://github.com/xorg62/tty-clock"
 distfiles="https://github.com/xorg62/tty-clock/archive/v${version}.tar.gz"
 checksum=343e119858db7d5622a545e15a3bbfde65c107440700b62f9df0926db8f57984
+replaces="tty-clock-git>=0"
 
 do_build() {
 	make CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS -lncursesw"


### PR DESCRIPTION
travis-ci asked to place replaces= after checksum=
-> https://travis-ci.org/void-linux/void-packages/jobs/576259908