### PR TITLE
tty-clock: fix license

### DIFF
--- a/srcpkgs/tty-clock/template
+++ b/srcpkgs/tty-clock/template
@@ -1,15 +1,18 @@
 # Template file for 'tty-clock'
 pkgname=tty-clock
 version=2.3
-revision=1
+revision=2
 makedepends="ncurses-devel"
 short_desc="Digital clock in ncurses"
 maintainer="Lugubris <lugubris@disroot.org>"
-license="GPL-3"
+license="BSD-3-Clause"
 homepage="https://github.com/xorg62/tty-clock"
-distfiles="https://github.com/xorg62/tty-clock/archive/v${version}.tar.gz"
-checksum=343e119858db7d5622a545e15a3bbfde65c107440700b62f9df0926db8f57984
+distfiles="https://github.com/xorg62/tty-clock/archive/v${version}.tar.gz
+ https://raw.githubusercontent.com/xorg62/tty-clock/master/LICENSE"
+checksum="343e119858db7d5622a545e15a3bbfde65c107440700b62f9df0926db8f57984
+ 19b60b629c724d426ce56bfd8effefa03555c4bafd757e66063722c9178cc971"
 replaces="tty-clock-git>=0"
+skip_extraction="LICENSE"
 
 do_build() {
 	make CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS -lncursesw"
@@ -18,4 +21,8 @@ do_build() {
 do_install() {
 	vbin tty-clock
 	vman tty-clock.1
+}
+
+post_install() {
+	vlicense  ${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENSE
 }


### PR DESCRIPTION
change from GPL-3 to BSD-3-Clause
-> https://github.com/xorg62/tty-clock/blob/master/LICENSE