### PR TITLE
i3lock-color: fix pam configuration file

### DIFF
--- a/srcpkgs/i3lock-color/template
+++ b/srcpkgs/i3lock-color/template
@@ -1,7 +1,7 @@
 # Template file for 'i3lock-color'
 pkgname=i3lock-color
 version=2.12
-revision=1
+revision=2
 wrksrc="${pkgname}-${version}.c"
 build_style=gnu-configure
 hostmakedepends="pkg-config automake"
@@ -18,6 +18,10 @@ conflicts="i3lock"
 
 pre_configure() {
 	autoreconf -i
+}
+
+pre_build() {
+	vsed -i 's:login:system-auth:' pam/i3lock
 }
 
 post_install() {


### PR DESCRIPTION
pam_tally(i3lock:auth): Error opening /var/log/faillog for update

pam_tally doesn't have the necessary privileges to write to
/var/log/faillog.
Replace 'login' with 'system-auth' to fix the issue.

Fix taken from Gentoo.