### PR TITLE
 travis: set dist to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: bash
+dist: bionic
 
 git:
     depth: 200


### PR DESCRIPTION
Using a newer ubuntu version as base for travis allows qt5 packages to be successfully compiled for glibc architectures again.

Compare e.g.: https://travis-ci.org/void-linux/void-packages/builds/576460608 to https://travis-ci.com/Johnnynator/void-packages/builds/124499655