### PR TITLE
wireguard-tools: ensure /etc/wireguard exists

### DIFF
--- a/srcpkgs/wireguard/template
+++ b/srcpkgs/wireguard/template
@@ -1,7 +1,7 @@
 # Template file for 'wireguard'
 pkgname=wireguard
 version=0.0.20190702
-revision=1
+revision=2
 wrksrc="WireGuard-${version}"
 build_wrksrc="src/tools"
 build_style=gnu-makefile
@@ -28,6 +28,7 @@ post_install() {
 wireguard-tools_package() {
 	short_desc+=" - tools"
 	depends="openresolv"
+	make_dirs="/etc/wireguard 0700 root root"
 	pkg_install() {
 		vmove usr/bin/wg
 		vmove usr/bin/wg-quick


### PR DESCRIPTION
wg-quick expects config files in /etc/wireguard by default.
@leahneukirchen 