### PR TITLE
New package: font-VLGothic-20141206

### DIFF
--- a/srcpkgs/font-VLGothic/template
+++ b/srcpkgs/font-VLGothic/template
@@ -1,0 +1,26 @@
+# Template file for 'font-VLGothic'
+pkgname=font-VLGothic
+_pkgname=${pkgname#*-}
+version=20141206
+revision=1
+archs=noarch
+wrksrc=$_pkgname
+depends='font-util xbps-triggers'
+short_desc='Japanese TrueType fonts from Vine Linux'
+maintainer='Issam Maghni <me@concati.me>'
+license='custom'
+homepage='http://vlgothic.dicey.org'
+distfiles="https://jaist.dl.osdn.jp/${_pkgname,,}/62375/${_pkgname}-${version}.tar.xz"
+checksum=982040db2f9cb73d7c6ab7d9d163f2ed46d1180f330c9ba2fae303649bf8102d
+
+font_dirs='/usr/share/fonts/TTF'
+
+do_install() {
+	vmkdir ${font_dirs#*/}
+	for _i in *.ttf
+	do  vinstall $_i 644 ${font_dirs#*/}
+	done
+	vlicense LICENSE.en
+	vlicense LICENSE_E.mplus
+	vlicense README.sazanami
+}


### PR DESCRIPTION
Edit # 1: From [Arch’s Wiki](//wiki.archlinux.org/index.php/Fonts#Japanese),
> Default of Debian/Fedora/Vine Linux