### PR TITLE
NetworkManager: Enable support for IWD 

### DIFF
--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -12,6 +12,7 @@ configure_args="-Dpolkit_agent=true -Dsystemd_journal=false
  -Dpppd_plugin_dir=/usr/lib/pppd/2.4.7 -Dresolvconf=/usr/bin/resolvconf
  -Ddhclient=/usr/bin/dhclient -Dkernel_firmware_dir=/usr/lib/firmware
  -Ddnsmasq=/usr/bin/dnsmasq -Ddbus_conf_dir=/etc/dbus-1/system.d
+ -Diwd=true
  -Dudev_dir=/usr/lib/udev -Dintrospection=$(vopt_if gir true false)
  -Dvapi=$(vopt_if vala true false)
  -Dsession_tracking=$(vopt_if elogind elogind no)


### PR DESCRIPTION
It doesn't require any external dependencies for NetworkManager, so why not to enable it by default?