### PR TITLE
xbps-src: Actually unset subpkg functions

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -237,7 +237,7 @@ run_pkg_hooks() {
 unset_package_funcs() {
     local f
 
-    for f in "$(typeset -F)"; do
+    for f in $(typeset -F); do
         case "$f" in
         *_package)
             unset -f "$f"


### PR DESCRIPTION
When quoted, there is only one run of loop body. Found with shellcheck.