### PR TITLE
gnutls: always specify default trust store file

### DIFF
--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,10 +1,11 @@
 # Template file for 'gnutls'
 pkgname=gnutls
 version=3.6.9
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-zlib --disable-guile --disable-static
- --disable-valgrind-tests --disable-rpath"
+ --disable-valgrind-tests --disable-rpath
+ --with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt"
 hostmakedepends="gettext-devel pkg-config libtool"
 # add autogen when #6550 is solved
 makedepends="zlib-devel lzo-devel readline-devel libgpg-error-devel


### PR DESCRIPTION
Otherwise, gnutls will be set up incorrectly on cross systems. The reason is that the configure detects cross-compiling and defaults to empty path for those scenarios, while for actual native compilation it does autodetection. Force the path that we use in Void.

`configure.ac` reference:

```
dnl auto detect https://lists.gnu.org/archive/html/help-gnutls/2012-05/msg00004.html
AC_ARG_WITH([default-trust-store-file],
  [AS_HELP_STRING([--with-default-trust-store-file=FILE],
    [use the given file default trust store])], with_default_trust_store_file="$withval",
  [if test "$build" = "$host" && test x$with_default_trust_store_pkcs11 = x && test x$with_default_trust_store_dir = x && test x$have_macosx = x;then
  for i in \
    /etc/ssl/ca-bundle.pem \
    /etc/ssl/certs/ca-certificates.crt \
    /etc/pki/tls/cert.pem \
    /usr/local/share/certs/ca-root-nss.crt \
    /etc/ssl/cert.pem
    do
    if test -e "$i"; then
      with_default_trust_store_file="$i"
      break
    fi
  done
  fi]
)
```