### PR TITLE
rclone: update to 1.49.0.

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,17 +1,17 @@
 # Template file for 'rclone'
 pkgname=rclone
-version=1.48.0
+version=1.49.0
 revision=1
 wrksrc="rclone-v${version}"
 build_style=go
-go_import_path=github.com/ncw/rclone
+go_import_path=github.com/rclone/rclone
 hostmakedepends="git"
 short_desc="Rsync for cloud storage"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="MIT"
-homepage="https://rclone.org/downloads/"
-distfiles="https://github.com/ncw/rclone/releases/download/v${version}/rclone-v${version}.tar.gz"
-checksum=8cfed0b0e0c341c74d466d3ecc84e35e32666391d075445d50fe623035cd03e4
+homepage="https://rclone.org/"
+distfiles="https://github.com/rclone/rclone/releases/download/v${version}/rclone-v${version}.tar.gz"
+checksum=2a46cd1ce886a60715ecd9c9e2a699e2688689d846b81ffe379e625674aff10d
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
FWIW, rclone now has its own rclone/rclone repo (moved from the author's ncw/rclone)