### PR TITLE
links: update to 2.20

### DIFF
--- a/srcpkgs/links/template
+++ b/srcpkgs/links/template
@@ -1,7 +1,7 @@
 # Template file for 'links'
 pkgname=links
-version=2.19
-revision=2
+version=2.20
+revision=1
 build_style=gnu-configure
 configure_args="--with-ssl --enable-graphics"
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://links.twibright.com/"
 distfiles="http://links.twibright.com/download/links-${version}.tar.bz2"
-checksum=70758c7dd9bb70f045407900e0a90f1114947fce832c2f9bdefd5c0158089a0a
+checksum=3bddcd4cb2f7647e50e12a59d1c9bda61076f15cde5f5dca6288b58314e6902d
 
 post_install() {
 	mkdir -p ${DESTDIR}/usr/share/doc/


### PR DESCRIPTION
=== RELEASE 2.20 ===

Mon Aug 26 18:21:43 CEST 2019 mikulas:

        Security bug fixed: when links was connected to tor, it would send real
        dns requests outside the tor network when the displayed page contains
        <link rel="dns-prefetch" href="http://host.domain/">.

        This bug is present in links-2.15 to links-2.19.

        Found by Shi Tian <shitian@cock.li>