### PR TITLE
New package: nextcloud-client 2.6.0

### DIFF
--- a/srcpkgs/nextcloud-client-devel
+++ b/srcpkgs/nextcloud-client-devel
@@ -1,0 +1,1 @@
+nextcloud-client

--- a/srcpkgs/nextcloud-client-dolphin
+++ b/srcpkgs/nextcloud-client-dolphin
@@ -1,0 +1,1 @@
+nextcloud-client

--- a/srcpkgs/nextcloud-client/INSTALL.msg
+++ b/srcpkgs/nextcloud-client/INSTALL.msg
@@ -1,0 +1,2 @@
+NextCloud client end-to-end encryption (e2e) is currently unavailable
+(LibreSSL 2.9.2 does not provide EVP_PKEY_CTX_set_rsa_oaep_md primitive)

--- a/srcpkgs/nextcloud-client/patches/libressl-no-rsa_oaep_md.patch
+++ b/srcpkgs/nextcloud-client/patches/libressl-no-rsa_oaep_md.patch
@@ -1,0 +1,23 @@
+source: https://github.com/nextcloud/desktop/issues/738
+
+--- src/libsync/clientsideencryption.cpp.ORIG	2019-07-25 12:20:49.000000000 +0200
++++ src/libsync/clientsideencryption.cpp	2019-07-28 12:56:18.813514323 +0200
+@@ -35,6 +35,18 @@
+ 
+ #include "wordlist.h"
+ 
++/* libessl 2.92 does not provide EVP_PKEY_CTX_set_rsa_oaep_md
++ * So with LibreSSL EVP_PKEY_CTX_ctrl() should explicitly return an error 
++ * "operation not supported" when you try to use e2e
++ */
++#ifndef EVP_PKEY_CTX_set_rsa_oaep_md
++#define EVP_PKEY_CTRL_RSA_OAEP_MD       (EVP_PKEY_ALG_CTRL + 9)
++#define EVP_PKEY_CTRL_GET_RSA_OAEP_MD   (EVP_PKEY_ALG_CTRL + 11)
++#define EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) \
++        EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_RSA, EVP_PKEY_OP_TYPE_CRYPT,  \
++        EVP_PKEY_CTRL_RSA_OAEP_MD, 0, (void *)(md))
++#endif
++
+ QDebug operator<<(QDebug out, const std::string& str)
+ {
+     out << QString::fromStdString(str);

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,0 +1,54 @@
+# Template file for 'nextcloud-client'
+pkgname=nextcloud-client
+version=2.6.0
+revision=1
+wrksrc="desktop-${version}"
+build_style=cmake
+configure_args="-Wno-dev"
+hostmakedepends="pkg-config"
+makedepends="qt5-tools-devel qt5-webengine-devel qt5-declarative-devel
+ qt5-webchannel-devel qt5-location-devel qtkeychain-qt5-devel sqlite-devel
+ qt5-webkit-devel libcloudproviders-devel $(vopt_if dolphin 'extra-cmake-modules kio-devel')"
+conf_files="/etc/Nextcloud/sync-exclude.lst"
+short_desc="NextCloud Desktop client"
+maintainer="yopito <pierre.bourgin@free.fr>"
+license="GPL-2.0-or-later"
+homepage="https://nextcloud.com/clients/"
+distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
+checksum=7b3f3c14d2e44826a5183fd59a7412c6dd5ed00296873e35c566f75c14c3a3ea
+
+build_options="dolphin"
+desc_option_dolphin="Build KDE dolphin support"
+build_options_default="dolphin"
+
+case "$XBPS_TARGET_MACHINE" in
+	armv6*|armv7*) broken="qt5-tools-devel unavailable" ;;
+esac
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt5-qmake qt5-host-tools qt5-tools"
+	# provides desktoptojson
+	hostmakedepends+=" $(vopt_if dolphin 'kcoreaddons')"
+fi
+
+if [ $build_option_dolphin ]; then
+nextcloud-client-dolphin_package() {
+	short_desc+=" - KDE dolphin integration"
+	depends="nextcloud-client>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/lib/libnextclouddolphinpluginhelper.so
+		vmove usr/lib/qt5
+		vmove usr/share/kservices5
+	}
+}
+fi
+
+nextcloud-client-devel_package() {
+	depends="nextcloud-client>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/libnextcloudsync.so
+		vmove "usr/lib/nextcloud/*.so"
+	}
+}

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -22,7 +22,7 @@ desc_option_dolphin="Build KDE dolphin support"
 build_options_default="dolphin"
 
 case "$XBPS_TARGET_MACHINE" in
-	armv6*|armv7*) broken="qt5-tools-devel unavailable" ;;
+	arm*) broken="qt5-webengine-devel unavailable" ;;
 esac
 
 if [ "$CROSS_BUILD" ]; then
@@ -30,8 +30,8 @@ if [ "$CROSS_BUILD" ]; then
 	# provides desktoptojson
 	hostmakedepends+=" $(vopt_if dolphin 'kcoreaddons')"
 fi
+subpackages="$(vopt_if dolphin 'nextcloud-client-dolphin') nextcloud-client-devel"
 
-if [ $build_option_dolphin ]; then
 nextcloud-client-dolphin_package() {
 	short_desc+=" - KDE dolphin integration"
 	depends="nextcloud-client>=${version}_${revision}"
@@ -41,7 +41,6 @@ nextcloud-client-dolphin_package() {
 		vmove usr/share/kservices5
 	}
 }
-fi
 
 nextcloud-client-devel_package() {
 	depends="nextcloud-client>=${version}_${revision}"


### PR DESCRIPTION
* reuse various efforts on packaging it
* does NOT support Client Encryption (LibreSSL 2.9.2 limitation)
* [x] runtime usage ("it's working for me" (tm) )
* [x]  split with subpkg -devel, ...
* [x] crossbuild
* [x] KDE dolphin specific support