### PR TITLE
rakudo: fix wrong perl6 home path being compiled into binaries

### DIFF
--- a/srcpkgs/rakudo/patches/fix-perl6-home-dir.patch
+++ b/srcpkgs/rakudo/patches/fix-perl6-home-dir.patch
@@ -1,0 +1,26 @@
+diff --git src/main.nqp src/main.nqp
+index b53302759..bd9aeb5d5 100644
+--- src/main.nqp
++++ src/main.nqp
+@@ -33,7 +33,7 @@ my $install-dir := $execname eq ''
+ 
+ my $perl6-home := $comp.config<static_perl6_home>
+     // nqp::getenvhash()<PERL6_HOME>
+-    // $install-dir ~ '/share/perl6';
++    // $comp.config<libdir> ~ '/perl6';
+ if nqp::substr($perl6-home, nqp::chars($perl6-home) - 1) eq $sep {
+     $perl6-home := nqp::substr($perl6-home, 0, nqp::chars($perl6-home) - 1);
+ }
+diff --git tools/lib/NQP/Config/Rakudo.pm tools/lib/NQP/Config/Rakudo.pm
+index 90839c229..2819b60b6 100644
+--- tools/lib/NQP/Config/Rakudo.pm
++++ tools/lib/NQP/Config/Rakudo.pm
+@@ -347,7 +347,7 @@ sub configure_moar_backend {
+           );
+         $config->{static_perl6_home} =
+           File::Spec->rel2abs(
+-            File::Spec->catdir( $config->{prefix}, 'share', 'perl6' ) );
++            File::Spec->catdir( $config->{libdir}, 'perl6' ) );
+         $config->{static_nqp_home_define} =
+           '-DSTATIC_NQP_HOME='
+           . $self->c_escape_string( $config->{static_nqp_home} );

--- a/srcpkgs/rakudo/template
+++ b/srcpkgs/rakudo/template
@@ -1,7 +1,7 @@
 # Template file for 'rakudo'
 pkgname=rakudo
 version=2019.07.1
-revision=1
+revision=2
 build_style=configure
 make_check_target=test
 make_install_args="RAKUDO_LOG_PRECOMP=1 RAKUDO_RERESOLVE_DEPENDENCIES=0"
@@ -27,7 +27,7 @@ make_dirs="
  /usr/lib/perl6/vendor/sources 0755 root root"
 hostmakedepends="perl"
 makedepends="libatomic_ops-devel libffi-devel libtommath-devel libuv-devel nqp"
-depends="nqp-${version}_${revision}"
+depends="nqp>=${version}_1"
 short_desc="Production-ready, stable implementation of the Perl 6 language"
 maintainer="Ruslan <axetwe@gmail.com>"
 license="Artistic-2.0"


### PR DESCRIPTION
Rakudo expects it's home always to be `$PREFIX/share/perl6` even though setting `--libdir` changes that.

So running the current Perl 6 in xbps will crash because it expects `perl6.moarvm` to be in `/usr/share/perl6/runtime` even though on Void Linux it's in `/usr/lib/perl6/runtime`.

```
[docker:f33e5790e49e /]$ perl6
Unhandled exception: While looking for '/usr/share/perl6/runtime/perl6.moarvm': no such file or directory
```

This patch resolves said issue.

I will make an MR for upstream too