### PR TITLE
go: update to 1.12.9

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.12.8
+version=1.12.9
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=11ad2e2e31ff63fcf8a2bdffbe9bfa2e1845653358daed593c8c2d03453c9898
+checksum=ab0e56ed9c4732a653ed22e232652709afbf573e710f56a07f7fdeca578d62fc
 
 nostrip=yes
 noverifyrdeps=yes


### PR DESCRIPTION
Introduces fixes to the linker, and the os and math/big packages.