### PR TITLE
xdg-dbus-proxy: add missing patch for musl

### DIFF
--- a/srcpkgs/xdg-dbus-proxy/patches/musl-macros.patch
+++ b/srcpkgs/xdg-dbus-proxy/patches/musl-macros.patch
@@ -1,0 +1,15 @@
+--- config.h.in.orig
++++ config.h.in
+@@ -151,3 +151,12 @@
+ 
+ /* Define to 1 if you need to in order for `stat' and other things to work. */
+ #undef _POSIX_SOURCE
++
++#ifndef TEMP_FAILURE_RETRY
++#define TEMP_FAILURE_RETRY(expression) \
++  (__extension__                                                              \
++    ({ long int __result;                                                     \
++       do __result = (long int) (expression);                                 \
++       while (__result == -1L && errno == EINTR);                             \
++       __result; }))
++#endif


### PR DESCRIPTION
This is taken from the flatpak template, it's the same. I'm not sure how this previously built on musl, as musl does not have the macro.