### PR TITLE
dracut: adopt and add a module for PowerPC Mac fan control

### DIFF
--- a/srcpkgs/dracut/patches/ppc-mac-thermal.patch
+++ b/srcpkgs/dracut/patches/ppc-mac-thermal.patch
@@ -1,0 +1,144 @@
+From 3b146ac6c0397f4a73c7b4ee498bff4e98479066 Mon Sep 17 00:00:00 2001
+From: q66 <daniel@octaforge.org>
+Date: Mon, 22 Jul 2019 18:52:08 +0200
+Subject: [PATCH] modules.d: add a module for early fan control on PowerPC Macs
+
+The goal of this module is to enable automatic loading of the
+thermal/fan control modules on PowerPC based Macs, as on some
+modular kernel configurations this will not happen automatically
+which will result in the fans spinning up to 100% until they are
+manually loaded.
+
+This is especially a problem in live systems where it takes some
+time to boot up and the spin-up happens before the system even
+leaves initramfs.
+---
+ modules.d/90ppcmac/load-thermal.sh | 29 +++++++++++
+ modules.d/90ppcmac/module-setup.sh | 82 ++++++++++++++++++++++++++++++
+ 2 files changed, 111 insertions(+)
+ create mode 100644 modules.d/90ppcmac/load-thermal.sh
+ create mode 100644 modules.d/90ppcmac/module-setup.sh
+
+diff --git a/modules.d/90ppcmac/load-thermal.sh b/modules.d/90ppcmac/load-thermal.sh
+new file mode 100644
+index 000000000..1e548f052
+--- /dev/null
++++ modules.d/90ppcmac/load-thermal.sh
+@@ -0,0 +1,29 @@
++#!/bin/sh
++#
++# This hook attempts to load the appropriate thermal modules
++# for PowerPC Macs depending on the specific machine you have.
++
++[ -r /proc/cpuinfo ] || exit 0
++
++load_windfarm() {
++    local pm_model="$(sed -n '/model/p' /proc/cpuinfo)"
++    pm_model="${pm_model##*: }"
++
++    # load quietly and respect the blacklist
++    # this way if the modules are for some reason missing, it will
++    # still exit successfully and not affect the boot process
++    case "$pm_model" in
++        PowerMac3,6)             modprobe -b -q therm_windtunnel ;;
++        PowerMac7,2|PowerMac7,3) modprobe -b -q windfarm_pm72    ;;
++        PowerMac8,1|PowerMac8,2) modprobe -b -q windfarm_pm81    ;;
++        PowerMac9,1)             modprobe -b -q windfarm_pm91    ;;
++        PowerMac11,2)            modprobe -b -q windfarm_pm112   ;;
++        PowerMac12,1)            modprobe -b -q windfarm_pm121   ;;
++        RackMac3,1)              modprobe -b -q windfarm_rm31    ;;
++        *) ;;
++    esac
++
++    return 0
++}
++
++load_windfarm
+diff --git a/modules.d/90ppcmac/module-setup.sh b/modules.d/90ppcmac/module-setup.sh
+new file mode 100644
+index 000000000..59221ec4d
+--- /dev/null
++++ modules.d/90ppcmac/module-setup.sh
+@@ -0,0 +1,82 @@
++#!/bin/bash
++#
++# This module attempts to properly deal with thermal behavior on PowerPC
++# based Mac systems, by installing the model-appropriate (when hostonly)
++# or all (when not) fan control/thermal kernel modules and loading them
++# in a hook.
++#
++# While this is not strictly necessary for all kernels, particularly
++# modular kernels will not autoload those drivers, even once the full
++# system is up, which results in the fans spinning up to 100%; this is
++# particularly annoying on live systems, where the system takes a while
++# to load, so it's best to load the drivers early in initramfs stage.
++#
++# The behavior of this is inspired by the thermal hook in Debian's
++# initramfs-tools, but written for dracut specifically and updated
++# for modern kernels (2012+).
++
++# called by dracut
++check() {
++    local _arch="$(uname -m)"
++    # only for PowerPC Macs
++    [[ "$_arch" == ppc* && "$_arch" != ppc*le ]] || return 1
++    return 0
++}
++
++# called by dracut
++depends() {
++    return 0
++}
++
++# called by dracut
++installkernel() {
++    pmac_model() {
++        local pm_model="$(grep model /proc/cpuinfo)"
++        echo "${pm_model##*: }"
++    }
++
++    # only PowerMac3,6 has a module, special case
++    if [[ "$(uname -m)" == ppc ]]; then
++        if ! [[ $hostonly ]] || [[ "$(pmac_model)" == "PowerMac3,6" ]]; then
++            instmods therm_windtunnel
++        fi
++        return 0
++    fi
++
++    windfarm_modules() {
++        if ! [[ $hostonly ]]; then
++            # include all drivers when not hostonly
++            instmods \
++                windfarm_pm72 windfarm_pm81 windfarm_pm91 windfarm_pm112 \
++                windfarm_pm121 windfarm_rm31
++        else
++            # guess model specific module, then install the rest
++            case "$(pmac_model)" in
++                PowerMac7,2|PowerMac7,3) instmods windfarm_pm72  ;;
++                PowerMac8,1|PowerMac8,2) instmods windfarm_pm81  ;;
++                PowerMac9,1)             instmods windfarm_pm91  ;;
++                PowerMac11,2)            instmods windfarm_pm112 ;;
++                PowerMac12,1)            instmods windfarm_pm121 ;;
++                RackMac3,1)              instmods windfarm_rm31  ;;
++                # no match, so skip installation of the rest
++                *) return 1 ;;
++            esac
++        fi
++        return 0
++    }
++
++    # hostonly and didn't match a model; skip installing other modules
++    windfarm_modules || return 0
++    # these are all required by the assorted windfarm_pm*
++    instmods \
++        windfarm_core windfarm_cpufreq_clamp windfarm_pid \
++        windfarm_smu_controls windfarm_smu_sat windfarm_smu_sensors \
++        windfarm_fcu_controls windfarm_ad7417_sensor windfarm_max6690_sensor \
++        windfarm_lm75_sensor windfarm_lm87_sensor
++}
++
++# called by dracut
++install() {
++    # this will attempt to load the appropriate modules
++    inst_hook pre-udev 99 "$moddir/load-thermal.sh"
++}

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=049
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"
@@ -9,7 +9,7 @@ hostmakedepends="asciidoc pkg-config"
 makedepends="libkmod-devel"
 depends="bash coreutils cpio psmisc"
 short_desc="Low-level tool for generating an initramfs/initrd image"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="q66 <daniel@octaforge.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://www.kernel.org/pub/linux/utils/boot/dracut/dracut.html"
 distfiles="https://github.com/dracutdevs/dracut/archive/${version}.tar.gz"


### PR DESCRIPTION
I originally wanted to wait with this until upstream has reviewed this but PRs are piling up in upstream and nobody is looking at anything. The module has been tested by several users and confirmed to work fine (it's pretty much an adaptation of what `initramfs-tools` in Debian already had anyway). If it gets reviewed and merged in some form, this patch can be removed for next dracut release.

Also, adopt the template.