### PR TITLE
rsyslog: update build dependencies

### DIFF
--- a/srcpkgs/rsyslog/template
+++ b/srcpkgs/rsyslog/template
@@ -1,7 +1,7 @@
 # Template file for 'rsyslog'
 pkgname=rsyslog
 version=8.1904.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --enable-gnutls --enable-mysql
  --enable-pgsql --enable-imdiag --enable-imfile --enable-mail --enable-imptcp
@@ -10,7 +10,7 @@ configure_args="--sbindir=/usr/bin --enable-gnutls --enable-mysql
  --enable-pmaixforwardedfrom --enable-omuxsock --disable-generate-man-pages
  --enable-testbench"
 hostmakedepends="pkg-config postgresql-libs-devel"
-makedepends="gnutls-devel libcurl-devel libee-devel libfastjson-devel
+makedepends="gnutls-devel libcurl-devel libestr-devel libfastjson-devel
  liblogging-devel libmysqlclient-devel mit-krb5-devel postgresql-libs-devel"
 short_desc="Enhanced multi-threaded syslog daemon"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
libee (https://github.com/rsyslog/libee) is dead/archived code. rsyslog doesn't need to link against libee, but it does still need libestr-devel. 