### PR TITLE
python-parsing: update to 2.4.2.

### DIFF
--- a/srcpkgs/python-parsing/template
+++ b/srcpkgs/python-parsing/template
@@ -1,6 +1,6 @@
 # Template file for 'python-parsing'
 pkgname=python-parsing
-version=2.3.1
+version=2.4.2
 revision=1
 archs=noarch
 wrksrc="pyparsing-pyparsing_${version}"
@@ -14,12 +14,7 @@ license="MIT"
 homepage="https://github.com/pyparsing/pyparsing"
 changelog="https://github.com/pyparsing/pyparsing/raw/master/CHANGES"
 distfiles="https://github.com/pyparsing/pyparsing/archive/pyparsing_${version}.tar.gz"
-checksum=6b4146fb3eb6c4f5798b9f1d67b9609efa106276ac875c534695e55a34409f07
-
-do_check() {
-	python2 unitTests.py
-	python3 unitTests.py
-}
+checksum=fc079f975968ae21f82223ae2340a39e7182ea993631812ddb5978619ed5c456
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Now compatible with `python setup.py test`, so no custom `do_check()` needed anymore.