### PR TITLE
rpi-kernel: update to 4.19.69.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="d9a27b27450d9f81b567134f1c8b85401556ab5a"
+_githash="216324a8655b7256961a378893f290d7fa1eecc4"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.68
+version=4.19.69
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=9b8db859e0ae93ff222f462055e8c94ecbc8890d8a6f41d37f629959d7acb10d
+checksum=4ffe8201fcc298d22b338a4ada79e215b6bd364a7726a6ed62e473029ec80b1c
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

Built for armv6l, armv7l, and aarch64.

Tested on armv6l and armv7l.