### PR TITLE
audacious: enable Qt interface

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1151,6 +1151,7 @@ libguess.so.1 libguess-1.1_1
 libaudcore.so.5 audacious-3.9_1
 libaudgui.so.5 audacious-3.9_1
 libaudtag.so.3 audacious-3.8_1
+libaudqt.so.2 audacious-3.10.1_2
 libgstreamer-1.0.so.0 gstreamer1-1.0.0_1
 libgstbase-1.0.so.0 gstreamer1-1.0.0_1
 libgstcontroller-1.0.so.0 gstreamer1-1.0.0_1

--- a/srcpkgs/audacious-plugins/template
+++ b/srcpkgs/audacious-plugins/template
@@ -1,20 +1,27 @@
 # Template file for 'audacious-plugins'
 pkgname=audacious-plugins
 version=3.10.1
-revision=3
+revision=4
 build_style=gnu-configure
+configure_args="$(vopt_enable gtk) $(vopt_enable qt)"
 hostmakedepends="pkg-config"
 makedepends="audacious-devel alsa-lib-devel pulseaudio-devel jack-devel
  lame-devel libvorbis-devel libflac-devel mpg123-devel faad2-devel ffmpeg-devel
  libmodplug-devel fluidsynth-devel libcdio-paranoia-devel wavpack-devel libnotify-devel
- libcurl-devel libmtp-devel neon-devel libmms-devel gtk+-devel libxml2-devel
- libbs2b-devel libsoxr-devel libsidplayfp-devel"
+ libcurl-devel libmtp-devel neon-devel libmms-devel libxml2-devel
+ libbs2b-devel libsoxr-devel libsidplayfp-devel libcue-devel
+ $(vopt_if gtk gtk+-devel) $(vopt_if qt 'qt5-devel qt5-multimedia-devel')"
 short_desc="Plugins for the Audacious media player"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://audacious-media-player.org/"
 distfiles="https://distfiles.audacious-media-player.org/${pkgname}-${version}.tar.bz2"
 checksum=eec3177631f99729bf0e94223b627406cc648c70e6646e35613c7b55040a2642
+
+build_options="gtk qt"
+build_options_default="gtk"
+desc_option_gtk="Enable support for the GTK+2 GUI toolkit"
+vopt_conflict gtk qt
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/audacious/template
+++ b/srcpkgs/audacious/template
@@ -1,11 +1,12 @@
 # Template file for 'audacious'
 pkgname=audacious
 version=3.10.1
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--enable-thunar"
-hostmakedepends="pkg-config glib-devel"
-makedepends="libSM-devel gtk+-devel dbus-glib-devel libguess-devel"
+configure_args="$(vopt_enable gtk) $(vopt_enable qt)"
+hostmakedepends="pkg-config glib-devel $(vopt_if qt qt5-host-tools)"
+makedepends="libSM-devel dbus-glib-devel libguess-devel $(vopt_if gtk gtk+-devel)
+ $(vopt_if qt qt5-devel)"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Lightweight, advanced audio player focused on audio quality"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,6 +14,11 @@ license="BSD-2-Clause"
 homepage="https://audacious-media-player.org/"
 distfiles="https://distfiles.${pkgname}-media-player.org/${pkgname}-${version}.tar.bz2"
 checksum=8366e840bb3c9448c2cf0cf9a0800155b0bd7cc212a28ba44990c3d2289c6b93
+
+build_options="gtk qt"
+build_options_default="gtk"
+desc_option_gtk="Enable support for the GTK+2 GUI toolkit"
+vopt_conflict gtk qt
 
 post_install() {
 	vlicense COPYING
@@ -24,6 +30,6 @@ audacious-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
closes  https://github.com/void-linux/void-packages/issues/14171

Should I add a build option for Qt/GTK?