### PR TITLE
New package: termdown-1.16.0

### DIFF
--- a/srcpkgs/python3-pyfiglet/template
+++ b/srcpkgs/python3-pyfiglet/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-pyfiglet'
+pkgname=python3-pyfiglet
+version=0.8.0
+revision=1
+archs=noarch
+wrksrc="pyfiglet-${version}"
+build_style="python3-module"
+pycompile_module="pyfiglet"
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Implementation of figlet written in Python"
+maintainer="Illia Shestakov <ishestakov@airmail.cc>"
+license="MIT"
+homepage="https://github.com/pwaller/pyfiglet"
+distfiles="https://github.com/pwaller/pyfiglet/archive/v${version}.tar.gz"
+checksum=0331d8cd949b0def033fce08c9b1f62006b8d1e1dce578dd28fdb02ae0f827f1
+
+post_install() {
+	vlicense LICENSE
+	vdoc README
+}

--- a/srcpkgs/termdown/template
+++ b/srcpkgs/termdown/template
@@ -1,0 +1,15 @@
+# Template file for 'termdown'
+pkgname=termdown
+version=1.16.0
+revision=1
+archs=noarch
+build_style=python3-module
+pycompile_module="termdown.py"
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools python3-dateutil python3-click python3-pyfiglet"
+short_desc="Countdown timer and stopwatch in your terminal"
+maintainer="Illia Shestakov <ishestakov@airmail.cc>"
+license="GPL-3.0-only"
+homepage="https://github.com/trehn/termdown"
+distfiles="https://github.com/trehn/termdown/archive/${version}.tar.gz"
+checksum=bab26e830a6e3f7758e1daccb2580aec094a257f5631546aa0f66bc35c3a37bc


### PR DESCRIPTION
Also a python-pyfiglet, termdown's dependency, that is absent in repository

closes #14182