### PR TITLE
plata-theme: update to 0.8.9

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1756,7 +1756,7 @@ libcblas.so.3 cblas-3.6.0_1
 liblapack.so.3 lapack-3.5.0_1
 libcinnamon-menu-3.so.0 cinnamon-menus-2.2.0_1
 libmate-desktop-2.so.17 mate-desktop-1.8.0_1
-libmarco-private.so.1 libmarco-1.14.0_1
+libmarco-private.so.2 libmarco-1.22.2_1
 libmate-menu.so.2 mate-menus-1.8.0_1
 libcaja-extension.so.1 libcaja-1.8.1_1
 libmatekbd.so.4 libmatekbd-1.8.0_1

--- a/srcpkgs/marco/template
+++ b/srcpkgs/marco/template
@@ -1,19 +1,19 @@
 # Template file for 'marco'
 pkgname=marco
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-startup-notification --disable-schemas-compile"
 hostmakedepends="gdk-pixbuf-devel mate-common zenity"
 makedepends="libXt-devel libcanberra-devel libgtop-devel
- libnotify-devel mate-desktop-devel"
+ libnotify-devel mate-desktop-devel libXpresent-devel"
 depends="zenity"
-short_desc="window manager for MATE"
+short_desc="Window manager for MATE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=4e20f5ea006142f3e5c8931e2b354e1838cb9291ba245825ea82fa6611def7c8
+checksum=3e73894cb244cee673aa555edfa2818ff166b15a9feea0a610d2272148e88769
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh

--- a/srcpkgs/mate-control-center/template
+++ b/srcpkgs/mate-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-control-center'
 pkgname=mate-control-center
 version=1.22.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --disable-update-mimedb"
 hostmakedepends="dbus-glib-devel desktop-file-utils glib-devel intltool itstool pkg-config"

--- a/srcpkgs/plata-theme/INSTALL.msg
+++ b/srcpkgs/plata-theme/INSTALL.msg
@@ -1,0 +1,3 @@
+Plata-theme upstream recommends the Roboto font.
+You can obtain it by installing fonts-roboto-ttf or 
+google-fonts-ttf.

--- a/srcpkgs/plata-theme/template
+++ b/srcpkgs/plata-theme/template
@@ -1,6 +1,6 @@
 # Template file for 'plata-theme'
 pkgname=plata-theme
-version=0.8.0
+version=0.8.9
 revision=1
 archs=noarch
 build_style=gnu-configure
@@ -8,14 +8,13 @@ configure_args="--enable-parallel --enable-telegram"
 hostmakedepends="automake libtool pkg-config glib-devel libxml2 sassc inkscape
  parallel procps-ng zip"
 makedepends="libglib-devel gdk-pixbuf-devel gtk+-devel gtk+3-devel
- gtk2-engines gtk-engine-murrine"
-depends="fonts-roboto-ttf"
+ gtk2-engines gtk-engine-murrine libmarco-devel"
 short_desc="Gtk theme based on Material Design Refresh"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="CC-BY-SA-4.0, GPL-2.0-or-later"
 homepage="https://gitlab.com/tista500/plata-theme"
 distfiles="https://gitlab.com/tista500/plata-theme/-/archive/${version}/plata-theme-${version}.tar.gz"
-checksum=1ee6e49716fdf4ddafae61e5fafb4f9b2c66ee02abab200f9872556c037157f8
+checksum=f8eb0033eed93a3cecc0c2d8f9f81b206a158a2e0e2a02393a9d656cc691478d
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
- plata-theme needs marco >= 1.22.2
- marco-1.22.2 has new soname for libmarco-private and I added a dependency to libXpresent-devel (used by the compositor).
- mate-control-center is revbumped for the new libmarco-private  lib.