### PR TITLE
offlineimap: update to 7.3.0.

### DIFF
--- a/srcpkgs/offlineimap/template
+++ b/srcpkgs/offlineimap/template
@@ -1,19 +1,19 @@
 # Template file for 'offlineimap'
 pkgname=offlineimap
-version=7.2.4
+version=7.3.0
 revision=1
 archs=noarch
 build_style=python2-module
 pycompile_module="offlineimap"
-hostmakedepends="python-six asciidoc"
-depends="python-six"
+hostmakedepends="python-six python-rfc6555 asciidoc"
+depends="python-six python-rfc6555"
 short_desc="Powerful IMAP/Maildir synchronization and reader support"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Peter Bui <pbui@github.bx612.space>"
 license="GPL-2.0-or-later"
 homepage="http://offlineimap.org/"
 changelog="https://raw.githubusercontent.com/OfflineIMAP/offlineimap/master/Changelog.md"
 distfiles="https://github.com/OfflineIMAP/offlineimap/archive/v${version}.tar.gz"
-checksum=5b6590c82cd5f6cbfe09e89ce52622208f5d4b24e021fce7646204b417bd1d2e
+checksum=d8378e82e392c70f5c20cb08705687da30cd427f2bca539939311512777e6659
 
 post_install() {
 	make -C docs man

--- a/srcpkgs/python-rfc6555/template
+++ b/srcpkgs/python-rfc6555/template
@@ -1,0 +1,25 @@
+# Template file for 'python-rfc6555'
+pkgname=python-rfc6555
+version=0.0.0
+revision=1
+archs=noarch
+wrksrc="rfc6555-${version}"
+build_style=python-module
+pycompile_module="rfc6555"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-selectors2"
+short_desc="Python2 implementation of the Happy Eyeballs Algorithm"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="Apache-2.0"
+homepage="https://github.com/sethmlarson/rfc6555"
+distfiles="${PYPI_SITE}/r/rfc6555/rfc6555-${version}.tar.gz"
+checksum=191cbba0315b53654155321e56a93466f42cd0a474b4f341df4d03264dcb5217
+
+python3-rfc6555_package() {
+	archs=noarch
+	pycompile_module="rfc6555"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove usr/lib/python3*
+	}
+}

--- a/srcpkgs/python3-rfc6555
+++ b/srcpkgs/python3-rfc6555
@@ -1,0 +1,1 @@
+python-rfc6555


### PR DESCRIPTION
- Add new required package: python-rfc6555.

- Adopt package.