### PR TITLE
nomad: update to 0.9.5.

### DIFF
--- a/srcpkgs/nomad/template
+++ b/srcpkgs/nomad/template
@@ -1,7 +1,7 @@
 # Template file for 'nomad'
 pkgname=nomad
-version=0.9.4
-revision=2
+version=0.9.5
+revision=1
 build_style=go
 go_import_path="github.com/hashicorp/${pkgname}"
 go_build_tags="ui release"
@@ -13,7 +13,7 @@ maintainer="iaroki <iaroki@protonmail.com>"
 license="MPL-2.0"
 homepage="https://www.nomadproject.io/"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=46c7998a82a45e82db87b4f4575aa48dd3d5fc0acc9d69ac3536785622867058
+checksum=f5dcc802cd07756f169c24dda637fe32f8b2cb6c6bb71bb2b3f4d7f3def8223b
 patch_args="-Np1"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Security release for CVE-2019-14802, CVE-2019-14803.