### PR TITLE
*dm, util-linux, openssh: adjust PATH for usrmerge

### DIFF
--- a/srcpkgs/gdm/template
+++ b/srcpkgs/gdm/template
@@ -1,7 +1,7 @@
 # Template file for 'gdm'
 pkgname=gdm
 version=44.1
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="
@@ -10,6 +10,7 @@ configure_args="
  -Dplymouth=enabled -Dxauth-dir=/run/gdm -Dpid-file=/run/gdm/gdm.pid
  -Dsystemd-journal=false -Dinitial-vt=7 -Dwayland-support=true
  -Dselinux=disabled -Dlibaudit=disabled -Dgdm-xsession=true
+ -Ddefault-path=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
  -Dsystemdsystemunitdir=/usr/lib/systemd/system
  -Dsystemduserunitdir=/usr/lib/systemd/user"
 hostmakedepends="dconf gettext itstool pkg-config"

--- a/srcpkgs/lightdm/patches/1.32.0--adjust-PATH-for-usrmerge.patch
+++ b/srcpkgs/lightdm/patches/1.32.0--adjust-PATH-for-usrmerge.patch
@@ -1,0 +1,22 @@
+From 389d9e09217ee598674ff7d6df69563be51cbfe6 Mon Sep 17 00:00:00 2001
+From: Piotr Wójcik <chocimier@tlen.pl>
+Date: Sat, 1 Jul 2023 17:30:54 +0200
+Subject: adjust-PATH-for-usrmerge
+
+
+diff --git a/src/session-child.c b/src/session-child.c
+index 112daab..af28c48 100644
+--- a/src/session-child.c
++++ b/src/session-child.c
+@@ -394,7 +394,7 @@ session_child_run (int argc, char **argv)
+         else
+         {
+             /* Set POSIX variables */
+-            pam_putenv (pam_handle, "PATH=/usr/local/bin:/usr/bin:/bin");
++            pam_putenv (pam_handle, "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin");
+             pam_putenv (pam_handle, g_strdup_printf ("USER=%s", username));
+             pam_putenv (pam_handle, g_strdup_printf ("LOGNAME=%s", username));
+             pam_putenv (pam_handle, g_strdup_printf ("HOME=%s", user_get_home_directory (user)));
+-- 
+2.41.0
+

--- a/srcpkgs/lightdm/template
+++ b/srcpkgs/lightdm/template
@@ -1,7 +1,7 @@
 # Template file for 'lightdm'
 pkgname=lightdm
 version=1.32.0
-revision=2
+revision=3
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--sbindir=/usr/bin --with-greeter-session=lightdm-gtk-greeter

--- a/srcpkgs/linux-driver-management/template
+++ b/srcpkgs/linux-driver-management/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-driver-management'
 pkgname=linux-driver-management
 version=1.0.3
-revision=2
+revision=3
 # Tests require unpackaged umockdev
 # https://github.com/martinpitt/umockdev
 build_style=meson
@@ -22,6 +22,11 @@ if [ "$CROSS_BUILD" ]; then
 	# host needs glib-mkenums
 	hostmakedepends+=" glib-devel"
 fi
+
+post_install() {
+	mkdir -p ${DESTDIR}/usr/share/examples/sddm/scripts
+	mv ${DESTDIR}/usr/share/sddm/scripts/Xsetup ${DESTDIR}/usr/share/examples/sddm/scripts/Xsetup
+}
 
 linux-driver-management-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/lxdm/patches/default-PATH.patch
+++ b/srcpkgs/lxdm/patches/default-PATH.patch
@@ -1,0 +1,22 @@
+From e46c33735f81ca5607247fd0690ebbe9f1565708 Mon Sep 17 00:00:00 2001
+From: Piotr Wójcik <chocimier@tlen.pl>
+Date: Tue, 8 Oct 2019 19:32:15 +0200
+Subject: [PATCH] tweak default PATH
+
+
+diff --git a/src/lxdm.c b/src/lxdm.c
+index a37f051..8a0e6c6 100644
+--- a/src/lxdm.c
++++ b/src/lxdm.c
+@@ -1399,7 +1399,7 @@ void lxdm_do_login(struct passwd *pw, char *session, char *lang, char *option)
+ 	if( G_UNLIKELY(path) && path[0] ) /* if PATH is specified in config file */
+ 		env=g_environ_setenv(env, "PATH", path, TRUE); /* override current $PATH with config value */
+ 	else /* don't use the global env, they are bad for user */
+-		env=g_environ_setenv(env, "PATH", "/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin", TRUE); /* set proper default */
++		env=g_environ_setenv(env, "PATH", "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", TRUE); /* set proper default */
+ 	g_free(path);
+ 	/* optionally override $LANG, $LC_MESSAGES, and $LANGUAGE */
+ 	if( lang && lang[0] )
+-- 
+2.23.0
+

--- a/srcpkgs/lxdm/template
+++ b/srcpkgs/lxdm/template
@@ -1,7 +1,7 @@
 # Template file for 'lxdm'
 pkgname=lxdm
 version=0.5.3
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-consolekit --with-pam --enable-gtk3"
 hostmakedepends="automake gettext-devel libtool pkg-config intltool"
@@ -16,13 +16,13 @@ conf_files="
 	/etc/lxdm/Xsession
 	/etc/lxdm/lxdm.conf
 	/etc/pam.d/lxdm"
-system_groups="lxdm"
 short_desc="GUI login manager for LXDE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://lxde.org"
 distfiles="${SOURCEFORGE_SITE}/lxdm/lxdm-${version}.tar.xz"
 checksum=4891efee81c72a400cc6703e40aa76f3f3853833d048b72ec805da0f93567f2f
+system_groups="lxdm"
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,13 +1,14 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=9.3p1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
  --with-mantype=doc --without-rpath --with-xauth=/usr/bin/xauth
  --disable-strip --with-privsep-path=/var/chroot/ssh
- --with-default-path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ --with-default-path=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+ --with-superuser-path=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
  --with-pid-dir=/run --with-pam
  --with-libedit --with-Werror
  $(vopt_if ldns --with-ldns=$XBPS_CROSS_BASE/usr)

--- a/srcpkgs/sddm/patches/0.19.0--default-path.patch
+++ b/srcpkgs/sddm/patches/0.19.0--default-path.patch
@@ -1,0 +1,22 @@
+From 57d716be7cb0588538d89bb72113bec82adf9e52 Mon Sep 17 00:00:00 2001
+From: Piotr Wójcik <chocimier@tlen.pl>
+Date: Mon, 26 Jun 2023 23:15:05 +0200
+Subject: default-path
+
+
+diff --git a/src/common/Configuration.h b/src/common/Configuration.h
+index cf44a62..4c01c4a 100644
+--- a/src/common/Configuration.h
++++ b/src/common/Configuration.h
+@@ -82,7 +82,7 @@ namespace SDDM {
+         );
+ 
+         Section(Users,
+-            Entry(DefaultPath,         QString,     _S("/usr/local/bin:/usr/bin:/bin"),         _S("Default $PATH for logged in users"));
++            Entry(DefaultPath,         QString,     _S("/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin"), _S("Default $PATH for logged in users"));
+             Entry(MinimumUid,          int,         UID_MIN,                                    _S("Minimum user id for displayed users"));
+             Entry(MaximumUid,          int,         UID_MAX,                                    _S("Maximum user id for displayed users"));
+             Entry(HideUsers,           QStringList, QStringList(),                              _S("Comma-separated list of users that should not be listed"));
+-- 
+2.41.0
+

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -1,7 +1,7 @@
 # Template file for 'sddm'
 pkgname=sddm
 version=0.19.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DBUILD_MAN_PAGES=ON -DNO_SYSTEMD=ON -DUSE_ELOGIND=ON
  -DLOGIN_DEFS_PATH=${XBPS_SRCPKGDIR}/shadow/files/login.defs

--- a/srcpkgs/slim/patches/1.3.6--adjust-PATH-for-usrmerge.patch
+++ b/srcpkgs/slim/patches/1.3.6--adjust-PATH-for-usrmerge.patch
@@ -1,0 +1,34 @@
+From 0a96bb015d9dc30ff98cfc21256851cb2005cea1 Mon Sep 17 00:00:00 2001
+From: Piotr Wójcik <chocimier@tlen.pl>
+Date: Sat, 1 Jul 2023 17:28:17 +0200
+Subject: adjust-PATH-for-usrmerge
+
+
+diff --git a/cfg.cpp b/cfg.cpp
+index 02379f2..56a584b 100644
+--- a/cfg.cpp
++++ b/cfg.cpp
+@@ -29,7 +29,7 @@ Cfg::Cfg()
+ 	: currentSession(-1)
+ {
+ 	/* Configuration options */
+-	options.insert(option("default_path","/bin:/usr/bin:/usr/local/bin"));
++	options.insert(option("default_path","/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin"));
+ 	options.insert(option("default_xserver","/usr/bin/X"));
+ 	options.insert(option("xserver_arguments",""));
+ 	options.insert(option("numlock",""));
+diff --git a/slim.conf b/slim.conf
+index a8e2e1c..1c14ade 100644
+--- a/slim.conf
++++ b/slim.conf
+@@ -1,6 +1,6 @@
+ # Path, X server and arguments (if needed)
+ # Note: -xauth $authfile is automatically appended
+-default_path        /bin:/usr/bin:/usr/local/bin
++default_path        /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+ default_xserver     /usr/bin/X
+ #xserver_arguments   -dpi 75
+ 
+-- 
+2.41.0
+

--- a/srcpkgs/slim/template
+++ b/srcpkgs/slim/template
@@ -1,7 +1,7 @@
 # Template file for 'slim'
 pkgname=slim
 version=1.3.6
-revision=13
+revision=14
 build_style=cmake
 configure_args="-DUSE_CONSOLEKIT=no -DUSE_PAM=yes"
 conf_files="/etc/slim.conf /etc/pam.d/slim"

--- a/srcpkgs/util-linux-common/template
+++ b/srcpkgs/util-linux-common/template
@@ -2,7 +2,7 @@
 # Keep this package sync with util-linux
 pkgname=util-linux-common
 version=2.38.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--exec-prefix=\${prefix} --enable-libuuid --disable-makeinstall-chown
  --enable-libblkid --enable-fsck --disable-rpath --enable-fs-paths-extra=/usr/sbin:/usr/bin

--- a/srcpkgs/util-linux/patches/default-PATH.patch
+++ b/srcpkgs/util-linux/patches/default-PATH.patch
@@ -1,0 +1,37 @@
+From 52f81526dbbea59e5c8f6aee64db1a9c29509d58 Mon Sep 17 00:00:00 2001
+From: Piotr Wójcik <chocimier@tlen.pl>
+Date: Tue, 30 Mar 2021 22:58:45 +0200
+Subject: [PATCH] default-PATH
+
+
+diff --git a/include/pathnames.h b/include/pathnames.h
+index 3845d4c..984b4d8 100644
+--- a/include/pathnames.h
++++ b/include/pathnames.h
+@@ -19,20 +19,12 @@
+ /* DEFPATHs from <paths.h> don't include /usr/local */
+ #undef _PATH_DEFPATH
+ 
+-#ifdef USE_USRDIR_PATHS_ONLY
+-# define _PATH_DEFPATH	        "/usr/local/bin:/usr/bin"
+-#else
+-# define _PATH_DEFPATH	        "/usr/local/bin:/bin:/usr/bin"
+-#endif
++# define _PATH_DEFPATH	        "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin"
+ 
+ #undef _PATH_DEFPATH_ROOT
+ 
+-#ifdef USE_USRDIR_PATHS_ONLY
+-# define _PATH_DEFPATH_ROOT	"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+-#else
+-# define _PATH_DEFPATH_ROOT	"/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
+-#endif
+-
++# define _PATH_DEFPATH_ROOT	"/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin"
++	
+ #define	_PATH_HUSHLOGIN		".hushlogin"
+ #define	_PATH_HUSHLOGINS	"/etc/hushlogins"
+ 
+-- 
+2.31.0
+

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -2,7 +2,7 @@
 # Keep this package sync with util-linux-common
 pkgname=util-linux
 version=2.38.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--exec-prefix=\${prefix} --enable-libuuid --disable-makeinstall-chown
  --enable-libblkid --enable-fsck --disable-rpath --enable-fs-paths-extra=/usr/sbin:/usr/bin

--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,7 +1,7 @@
 # Template file for 'xdm'
 pkgname=xdm
 version=1.1.14
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp
@@ -23,6 +23,10 @@ license="MIT"
 homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/app/${pkgname}-${version}.tar.xz"
 checksum=3e9bf25636797ec9e595286dd6820ecc33901439f07705eaf608ecda012c3d5f
+
+pre_configure() {
+	export DEF_USER_PATH=/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+}
 
 post_install() {
 	vsv xdm


### PR DESCRIPTION
/bin is still added to PATH by /etc/profile, but after /usr/bin.
This makes `which` return real file instead of symlink.