### PR TITLE
New package: minecraft-launcher-2.1.5965

### DIFF
--- a/srcpkgs/minecraft-launcher/template
+++ b/srcpkgs/minecraft-launcher/template
@@ -1,0 +1,25 @@
+# Template file for 'minecraft-launcher'
+pkgname=minecraft-launcher
+version=2.1.5965
+revision=1
+archs=x86_64
+wrksrc=${pkgname}
+depends="virtual?java-runtime"
+short_desc="Launcher for the famous Minecraft game"
+maintainer="toluschr <toluschr@protonmail.com>"
+license="proprietary"
+homepage="https://www.minecraft.net/"
+distfiles="https://launcher.mojang.com/download/Minecraft.deb"
+checksum="76e5484363ae4a5fff39642116b8cd7bc9edae8bccd6af838ae23c16b94fa5d8"
+nopie=yes
+repository=nonfree
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/Minecraft.deb
+	tar xf data.tar.xz
+}
+
+do_install() {
+	vcopy usr /usr
+	vcopy opt /opt
+}


### PR DESCRIPTION
I know that there is an existing pull-request #14221, but I believe the official name is `minecraft-launcher` and I'd like to keep a legacy version as just `minecraft`.

I copied the `minecraft-launcher.desktop` and `minecraft-launcher.svg` from the official deb-package on the Minecraft website.