### PR TITLE
webkit2gtk: revert to 2.24.x and update to 2.24.4

### DIFF
--- a/srcpkgs/webkit2gtk/patches/fix-fast-memory-disabled.patch
+++ b/srcpkgs/webkit2gtk/patches/fix-fast-memory-disabled.patch
@@ -1,0 +1,14 @@
+--- Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp.orig	2017-09-14 10:03:40.908890971 +0200
++++ Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp	2017-09-14 10:04:17.084859537 +0200
+@@ -112,7 +112,11 @@ void unregisterCode(void* start, void* e
+ 
+ bool fastMemoryEnabled()
+ {
++#if ENABLE(WEBASSEMBLY_FAST_MEMORY)
+     return fastHandlerInstalled;
++#else
++    return false;
++#endif // ENABLE(WEBASSEMBLY_FAST_MEMORY)
+ }
+ 
+ void enableFastMemory()

--- a/srcpkgs/webkit2gtk/patches/fix-musl-javascriptcore.patch
+++ b/srcpkgs/webkit2gtk/patches/fix-musl-javascriptcore.patch
@@ -85,23 +85,23 @@ Updated for latest webkit2gtk.
      v(unsigned, jitMemoryReservationSize, 0, Normal, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)") \
 --- Source/ThirdParty/ANGLE/src/compiler/preprocessor/ExpressionParser.cpp
 +++ Source/ThirdParty/ANGLE/src/compiler/preprocessor/ExpressionParser.cpp
-@@ -728,7 +728,7 @@ int yydebug;
+@@ -836,7 +836,7 @@
  #if YYERROR_VERBOSE
  
- #    ifndef yystrlen
--#        if defined __GLIBC__ && defined _STRING_H
-+#        if defined __linux__ && defined _STRING_H
- #            define yystrlen strlen
- #        else
+ # ifndef yystrlen
+-#  if defined __GLIBC__ && defined _STRING_H
++#  if defined __linux__ && defined _STRING_H
+ #   define yystrlen strlen
+ #  else
  /* Return the length of YYSTR.  */
-@@ -743,7 +743,7 @@ static YYSIZE_T yystrlen(const char *yystr)
- #    endif
+@@ -852,7 +852,7 @@
+ # endif
  
- #    ifndef yystpcpy
--#        if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-+#        if defined __linux__ && defined _STRING_H && defined _GNU_SOURCE
- #            define yystpcpy stpcpy
- #        else
+ # ifndef yystpcpy
+-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
++#  if defined __linux__ && defined _STRING_H && defined _GNU_SOURCE
+ #   define yystpcpy stpcpy
+ #  else
  /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
 --- Source/WTF/wtf/Platform.h
 +++ Source/WTF/wtf/Platform.h

--- a/srcpkgs/webkit2gtk/patches/fix_armv6l.patch
+++ b/srcpkgs/webkit2gtk/patches/fix_armv6l.patch
@@ -1,0 +1,23 @@
+Fix code emitted for armv6l to not use movw/movt but ldr.
+See https://bugs.webkit.org/show_bug.cgi?id=131612
+and https://bugs.webkit.org/show_bug.cgi?id=141288
+
+--- Source/JavaScriptCore/offlineasm/arm.rb	2015-07-22 14:37:57.000000000 +0200
++++ Source/JavaScriptCore/offlineasm/arm.rb	2015-08-08 00:31:21.011824644 +0200
+@@ -473,8 +473,16 @@
+                 $asm.puts "mov #{armFlippedOperands(operands)}"
+             end
+         when "mvlbl"
++            if isARMv7 or isARMv7Traditional
+                 $asm.puts "movw #{operands[1].armOperand}, \#:lower16:#{operands[0].value}"
+                 $asm.puts "movt #{operands[1].armOperand}, \#:upper16:#{operands[0].value}"
++            else
++                $mvlbl_counter ||= 0
++                $mvlbl_counter += 1
++                const_label = "_mvlbl_const_label#{$mvlbl_counter}"
++                $asm.puts ".equ #{const_label}, (#{operands[0].value})"
++                $asm.puts "ldr  #{operands[1].armOperand}, =#{const_label}"
++            end
+         when "nop"
+             $asm.puts "nop"
+         when "bieq", "bpeq", "bbeq"

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,6 +1,7 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
-version=2.25.4
+reverts="2.25.4_1"
+version=2.24.4
 revision=1
 wrksrc="webkitgtk-${version}"
 build_style=cmake
@@ -15,7 +16,7 @@ configure_args="-DPORT=GTK -DUSE_LD_GOLD=OFF
  -DCMAKE_LINKER=${XBPS_CROSS_TRIPLET}-gcc
  -DRUBY_VERSION=2.6
  -DRUBY_CONFIG_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include/ruby-2.6.0
- -DENABLE_GTKDOC=OFF -DUSE_GSTREAMER_GL=OFF -DUSE_WPE_RENDERER=OFF
+ -DENABLE_GTKDOC=OFF -DUSE_GSTREAMER_GL=OFF
  -DENABLE_JIT=$(vopt_if jit ON OFF)
  -DENABLE_C_LOOP=$(vopt_if jit OFF ON)
  -DENABLE_INTROSPECTION=$(vopt_if gir ON OFF)
@@ -37,21 +38,15 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-2-Clause"
 homepage="https://webkitgtk.org/"
 distfiles="${homepage}/releases/webkitgtk-${version}.tar.xz"
-checksum=9361058c059402117995c779906f4a25232185ce7735663428fda9cf3c79f101
+checksum=8668b129c026624ec226a4cccf4995f9d26f3e88fc28ab75b0e965f3c32b7dd8
 
-build_options="gir wayland x11 bubblewrap jit sampling_profiler"
-build_options_default="gir wayland x11 bubblewrap"
+build_options="gir wayland x11 jit sampling_profiler"
+build_options_default="gir wayland x11"
 
-desc_option_bubblewrap="Enable bubblewrap sandbox"
 desc_option_jit="JavaScript JIT (Only some architectures)"
 desc_option_sampling_profiler="Sampling profiler support (JIT + glibc only)"
 
-# detection + runtime
-if [ "$build_option_bubblewrap" ]; then
-	hostmakedepends+=" bubblewrap xdg-dbus-proxy"
-	makedepends+=" libseccomp-devel"
-	depends+=" bubblewrap xdg-dbus-proxy"
-fi
+CXXFLAGS="-Wno-expansion-to-defined -Wno-redundant-move -Wno-deprecated-copy"
 
 # only a few platform support JIT
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Since the 2.25.x branch still appears to be problematic on some systems, revert to the 2.24.x branch for now. 2.24.3->2.24.4 would have been a necessary update either way as it fixes multiple CVEs.

But, keep most of the template changes made (debug for 32-bit, gold always off, fixed up musl jsc patch etc). Revert the bubblewrap stuff since 2.24.x is not sandboxed yet.

The 2.26 stable release appears to be coming fairly soon, so we will be unreverting this as soon as it does.

Please test at least on x86_64 + musl.

(revision is umbumped as the original update was from `2.24.3` and this is 2.24.4)