### PR TITLE
libvirt: fix control socket path

### DIFF
--- a/srcpkgs/libvirt/patches/socket-url-arguments.patch
+++ b/srcpkgs/libvirt/patches/socket-url-arguments.patch
@@ -1,0 +1,22 @@
+diff --git src/remote/remote_daemon.c src/remote/remote_daemon.c
+index 546328b24d..5d64397062 100644
+--- src/remote/remote_daemon.c
++++ src/remote/remote_daemon.c
+@@ -226,14 +226,14 @@ daemonUnixSocketPaths(struct daemonConfig *config,
+ 
+     if (config->unix_sock_dir) {
+         if (virAsprintf(sockfile, "%s/%s-sock",
+-                        SOCK_PREFIX, config->unix_sock_dir) < 0)
++                        config->unix_sock_dir, SOCK_PREFIX) < 0)
+             goto cleanup;
+ 
+         if (privileged) {
+             if (virAsprintf(rosockfile, "%s/%s-sock-ro",
+-                            SOCK_PREFIX, config->unix_sock_dir) < 0 ||
++                            config->unix_sock_dir, SOCK_PREFIX) < 0 ||
+                 virAsprintf(admsockfile, "%s/%s-admin-sock",
+-                            SOCK_PREFIX, config->unix_sock_dir) < 0)
++                            config->unix_sock_dir, SOCK_PREFIX) < 0)
+                 goto cleanup;
+         }
+     } else {

--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -1,7 +1,7 @@
 # Template file for 'libvirt'
 pkgname=libvirt
 version=5.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-hal --with-storage-lvm --with-qemu
  --with-qemu-user=libvirt --with-qemu-group=libvirt --without-netcf


### PR DESCRIPTION
If you use unix control sockets instead of TCP the path of the socket will be incorrectly build and you'll get errors like:

```
Failed to bind socket to 'libvirt//var/run/libvirt/-sock': No such file or directory
```

Included patch fixes that. is also send to upstream but idk how this ancient system of patches via mailing lists work tbh, so don't know if it came through