### PR TITLE
NetworkManager: Set elogind on by default.

### DIFF
--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager'
 pkgname=NetworkManager
 version=1.18.2
-revision=3
+revision=4
 build_style=meson
 build_helper="gir"
 configure_args="-Dpolkit_agent=true -Dsystemd_journal=false
@@ -53,7 +53,7 @@ esac
 
 # Package build options
 build_options="gir vala elogind"
-build_options_default="gir vala"
+build_options_default="gir vala elogind"
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
This causes network connections to be properly restarted on
suspend and resume of the system via elogind/desktops.