### PR TITLE
dnsmasq can be built with dnssec support in new nettle versions

### DIFF
--- a/srcpkgs/dnsmasq/patches/nettle35.patch
+++ b/srcpkgs/dnsmasq/patches/nettle35.patch
@@ -1,0 +1,42 @@
+From: Vladislav Grishenko <themiron@mail.ru>
+Date: Wed, 26 Jun 2019 15:27:11 +0000 (+0500)
+Subject: Fix build with libnettle 3.5
+X-Git-Url: http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commitdiff_plain;h=ab73a746a0d6fcac2e682c5548eeb87fb9c9c82e;hp=69bc94779c2f035a9fffdb5327a54c3aeca73ed5
+
+Fix build with libnettle 3.5
+---
+
+diff --git a/src/crypto.c b/src/crypto.c
+index ebb871e..fecc64a 100644
+--- src/crypto.c
++++ src/crypto.c
+@@ -275,6 +275,10 @@ static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len
+   static struct ecc_point *key_256 = NULL, *key_384 = NULL;
+   static mpz_t x, y;
+   static struct dsa_signature *sig_struct;
++#if NETTLE_VERSION_MAJOR == 3 && NETTLE_VERSION_MINOR < 4
++#define nettle_get_secp_256r1() (&nettle_secp_256r1)
++#define nettle_get_secp_384r1() (&nettle_secp_384r1)
++#endif
+
+   if (!sig_struct)
+     {
+@@ -294,7 +298,7 @@ static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len
+          if (!(key_256 = whine_malloc(sizeof(struct ecc_point))))
+            return 0;
+
+-         nettle_ecc_point_init(key_256, &nettle_secp_256r1);
++         nettle_ecc_point_init(key_256, nettle_get_secp_256r1());
+        }
+
+       key = key_256;
+@@ -307,7 +311,7 @@ static int dnsmasq_ecdsa_verify(struct blockdata *key_data, unsigned int key_len
+          if (!(key_384 = whine_malloc(sizeof(struct ecc_point))))
+            return 0;
+
+-         nettle_ecc_point_init(key_384, &nettle_secp_384r1);
++         nettle_ecc_point_init(key_384, nettle_get_secp_384r1());
+        }
+
+       key = key_384;
+


### PR DESCRIPTION
Added a patch which allows dnsmasq to be successfully compiled with new nettle versions, with different function names. 