### PR TITLE
rpi-kernel: update to 4.19.71.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="216324a8655b7256961a378893f290d7fa1eecc4"
+_githash="4a6e8b24948edd17cdb6f4fdebf1cac285b7c7a5"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.69
+version=4.19.71
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=4ffe8201fcc298d22b338a4ada79e215b6bd364a7726a6ed62e473029ec80b1c
+checksum=b89d582558c9bf69db80bead6c013b8f2470fc08feff407a9b284d0d60fd01a3
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built on armv6l, armv7l, and aarch64.
- Tested on armv6l and armv7l.