### PR TITLE
ibus-bamboo: update to 0.5.6

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.5.4
+version=0.5.6
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="3b945c58e5129081e1cc899f81edccf05c9f579fc429e1bdc8466469441d93cf"
+checksum="eaebd63b8e3a6c1be867b5a0e035483f3f7b40c418936269e4761fca71c7d770"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
0.5.5
- Improve some spell checking rules
- Fix an issue on chrome's address bar

0.5.6
- Fix golang 1.13 flag parsing in tests