### PR TITLE
dnscrypt-proxy: update to 2.0.27

### DIFF
--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,6 +1,6 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.0.26
+version=2.0.27
 revision=1
 build_style=go
 go_import_path=github.com/jedisct1/dnscrypt-proxy
@@ -11,7 +11,7 @@ license="ISC"
 homepage="https://github.com/jedisct1/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/jedisct1/dnscrypt-proxy/master/ChangeLog"
 distfiles="https://github.com/jedisct1/dnscrypt-proxy/archive/${version}.tar.gz"
-checksum=9bfae9b9c6655d3c3a40a1018d6c6cb8b67e2341c2f5efbf54461f0c1cf7ace6
+checksum=a501f44af39cb43e00489ef9e6678aa8adba2bc98f9042dd61ce60e9ad074d5a
 conf_files="/etc/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 make_dirs="/var/log/dnscrypt-proxy 0750 dnscrypt_proxy dnscrypt_proxy"


### PR DESCRIPTION
-> https://github.com/jedisct1/dnscrypt-proxy/issues/925