### PR TITLE
New package: gcn64tools-2.1.19

### DIFF
--- a/srcpkgs/gcn64tools/template
+++ b/srcpkgs/gcn64tools/template
@@ -1,0 +1,38 @@
+# Template file for 'gcn64tools'
+pkgname=gcn64tools
+_longname=raphnet-tech_adapter_manager
+version=2.1.23
+revision=1
+wrksrc=${_longname}-${version}
+build_wrksrc=src
+build_style=gnu-makefile
+make_use_env=false
+make_install_args="PREFIX=\${DESTDIR}/usr"
+hostmakedepends="pkg-config make glib-devel"
+makedepends="hidapi-devel gtk+3-devel libxml2 zlib-devel libglib-devel"
+depends="dfu-programmer"
+short_desc="Tools to manage Raphnet USB controller adapters"
+maintainer="Oliver Nutter <mrnoname1000@riseup.net>"
+license="GPL-3.0-or-later"
+homepage="https://www.raphnet-tech.com/products/adapter_manager/index.php"
+distfiles="https://www.raphnet-tech.com/downloads/${_longname}-${version}.tar.gz"
+checksum=066408ea8083140ed9f15758d4dd0c3d5b41afa3be26f7a9d47e608911cec8d8
+
+post_configure() {
+	vsed -i 's/^[[:space:]]*\(CC\)[[:space:]]*=\(.*\)$/\1?=\2/' "${wrksrc}/src/Makefile"
+}
+
+post_build() {
+	vsed -i 's|TAG+="uaccess"|MODE="0660", GROUP="users"|' "${wrksrc}/scripts/10-atmel-dfu.rules" "${wrksrc}/scripts/10-raphnet.rules"
+	# move comments to their own line
+	vsed -i 's|^\([^#]\+\)[[:space:]]*\(#.*\)$|\2\n\1|' "${wrksrc}/scripts/10-atmel-dfu.rules"
+}
+
+pre_install() {
+	vmkdir usr/bin
+}
+
+post_install() {
+	vinstall "${wrksrc}"/scripts/10-atmel-dfu.rules 644 usr/lib/udev/rules.d
+	vinstall "${wrksrc}"/scripts/10-raphnet.rules 644 usr/lib/udev/rules.d
+}

--- a/srcpkgs/gcn64tools/update
+++ b/srcpkgs/gcn64tools/update
@@ -1,0 +1,1 @@
+pattern="${_longname}-\K[\d.]+(?=.tar.gz)"


### PR DESCRIPTION
The program by default uses TAG+="uaccess" to get access to hidraw devices via udev, so I figured granting access to the users group would suffice.