### PR TITLE
nvidia: update to 430.40.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -147,7 +147,7 @@ libnvidia-glcore.so.346.47 nvidia340-libs-340.46_1 ignore
 libnvidia-glcore.so.390.87 nvidia390-libs-390.87_1 ignore
 libnvidia-glsi.so.346.72 nvidia-libs-346.72_1 ignore
 libnvidia-fatbinaryloader.so.390.116 nvidia390-libs-390.116_1 ignore
-libnvidia-fatbinaryloader.so.430.14 nvidia-libs-430.14_1 ignore
+libnvidia-fatbinaryloader.so.430.40 nvidia-libs-430.40_1 ignore
 libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
 librsvg-2.so.2 librsvg-2.26.0_1

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -3,8 +3,8 @@
 _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
-version=430.14
-revision=2
+version=430.40
+revision=1
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Proprietary NVIDIA license"
 homepage="http://www.nvidia.com"
@@ -23,7 +23,7 @@ build_options_default="glvnd"
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_pkg="NVIDIA-Linux-x86_64-${version}-no-compat32"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=0f583a277b1731cb8327510b75dba9cf7adf5c781247e4f48bcc9f358253278f
+	checksum=669ff38532ff05c78e1edc3c6df2055fd96437107f5919b6e5a774c3a495501b
 	subpackages="nvidia-gtklibs nvidia-dkms
 	 nvidia-opencl nvidia-libs"
 	depends="nvidia-libs-${version}_${revision}
@@ -32,7 +32,7 @@ if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 else
 	_pkg="NVIDIA-Linux-x86_64-${version}"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=00d46ffaf3e1e430081ddbd68b74cc361cd1328e8944224dfe69630dd8540f17
+	checksum=f700899f48ba711b7e1598014e8db9a93537d7baa3d6a64067ed08578387dfd7
 	subpackages="nvidia-libs"
 	depends="pkgconf"
 fi


### PR DESCRIPTION
this fixes compilation of dkms for 5.2.13 kernel.