### PR TITLE
python3-mpv: fix license issue, adopt

### DIFF
--- a/srcpkgs/python3-mpv/template
+++ b/srcpkgs/python3-mpv/template
@@ -9,8 +9,12 @@ pycompile_module="mpv.py"
 hostmakedepends="python3-setuptools"
 depends="python3 mpv"
 short_desc="Python3 interface to the MPV media player"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Lugubris <lugubris@disroot.org>"
 license="AGPL-3.0-or-later"
 homepage="https://github.com/jaseg/python-mpv"
 distfiles="https://github.com/jaseg/python-mpv/archive/v${version}.tar.gz"
 checksum=31ea56d1df50f42ec6ca232575a527483ed54967df867d143c47019636372c81
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
vlicense should be used for AGPL licenses