### PR TITLE
New package: fmtools

### DIFF
--- a/srcpkgs/fmtools/template
+++ b/srcpkgs/fmtools/template
@@ -1,0 +1,11 @@
+# Template file for 'fmtools'
+pkgname=fmtools
+version=2.0.7
+revision=1
+build_style=gnu-configure
+short_desc="Utility for adjusting the frequency and volume of FM radio cards"
+maintainer="Foxlet <foxlet@furcode.co>"
+license="GPL-2.0-only"
+homepage="https://benpfaff.org/fmtools/"
+distfiles="https://benpfaff.org/fmtools/fmtools-${version}.tar.gz"
+checksum=75174e07d8cde6d4a8a5d7bbaa3a3b0760a850e7f6840cb7c6246227b18f5a39


### PR DESCRIPTION
Present in Ubuntu repos, used for tuning PCIe radio cards.