### PR TITLE
cross-i686 compiler: keep sysroot /lib symlink

### DIFF
--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -12,7 +12,7 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=1
+revision=2
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -296,11 +296,10 @@ do_install() {
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a
 	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
+	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
 }
 
 cross-i686-linux-musl-libc_package() {

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -343,7 +343,7 @@ do_install() {
 	# Remove unnecessary stuff
 	rm -f ${DESTDIR}/usr/lib*/libiberty.a
 	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
+	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec


### PR DESCRIPTION
When packaging Firefox ESR 68.1.0 #14229 , and cross compile i686 from x86_64,
I received this complains:
> 0:06.67 DEBUG: | /usr/lib/gcc/i686-pc-linux-gnu/9.2.0/../../../../i686-pc-linux-gnu/bin/ld: cannot find /lib/libc.so.6 inside /usr/i686-pc-linux-gnu
> 0:06.67 DEBUG: | /usr/lib/gcc/i686-pc-linux-gnu/9.2.0/../../../../i686-pc-linux-gnu/bin/ld: cannot find /lib/ld-linux.so.2 inside /usr/i686-pc-linux-gnu

I didn't run into this complain when packaging aarch64 from x86_64,
I have a different problem when packaging ppc64le from x86_64
