### PR TITLE
kodi-rpi: Add PATH for firmware binaries

### DIFF
--- a/srcpkgs/kodi-rpi/files/xbmc-standalone/run
+++ b/srcpkgs/kodi-rpi/files/xbmc-standalone/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+PATH=$PATH:/opt/vc/bin
 exec chpst -P sudo LD_LIBRARY_PATH=/opt/vc/lib -u xbmc -- /usr/lib/kodi/kodi-rbpi --standalone

--- a/srcpkgs/kodi-rpi/template
+++ b/srcpkgs/kodi-rpi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi-rpi'
 pkgname=kodi-rpi
 version=18.4
-revision=1
+revision=2
 build_style=cmake
 _codename="Leia"
 wrksrc="xbmc-${version}-${_codename}"


### PR DESCRIPTION
Modfiy PATH variable to add raspberry's firmware tools.
This is needed for "Turn Off" screensaver, which uses vcgencmd
