### PR TITLE
pkgtop: update to 2.0.

### DIFF
--- a/srcpkgs/pkgtop/template
+++ b/srcpkgs/pkgtop/template
@@ -1,17 +1,17 @@
 # Template file for 'pkgtop'
 pkgname=pkgtop
-version=1.7
+version=2.0
 revision=1
 build_style=go
-go_import_path="github.com/keylo99/pkgtop"
+go_import_path="github.com/orhun/pkgtop"
 go_package="${go_import_path}/src"
 hostmakedepends="git"
 short_desc="Interactive package manager and resource monitor"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/keylo99/pkgtop"
-distfiles="https://github.com/keylo99/pkgtop/archive/${version}.tar.gz"
-checksum=3fc175dc241b7c171a34c5c99caa04840f2070f76033fb3624132faaacd0ee30
+homepage="https://github.com/orhun/pkgtop"
+distfiles="https://github.com/orhun/pkgtop/archive/${version}.tar.gz"
+checksum=0356155cea97e9a325a4c1fe99a1f6989bc2d7bf6ab1a9d34763bb832123f880
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/{src,pkgtop}


### PR DESCRIPTION
Package seems to have moved from https://github.com/keylo99/pkgtop to https://github.com/orhun/pkgtop