### PR TITLE
tectonic: remove hardcoded versions

### DIFF
--- a/srcpkgs/tectonic/template
+++ b/srcpkgs/tectonic/template
@@ -20,10 +20,10 @@ pre_build() {
 	# through 2.8.1, but a different version of OpenSSL was found. The build is now aborting
 	# due to this version mismatch.
 	# openssl 0.10.15
-	# error[E0432]: unresolved imports `ffi::SSLv23_method`, `ffi::DTLSv1_method`
-	# error[E0432]: unresolved imports `ffi::SSLEAY_VERSION`, `ffi::SSLEAY_CFLAGS`,
-	# `ffi::SSLEAY_BUILT_ON`, `ffi::SSLEAY_PLATFORM`, `ffi::SSLEAY_DIR`, `ffi::SSLeay`,
-	# `ffi::SSLeay_version`
+	# error[E0432]: unresolved imports ffi::SSLv23_method, ffi::DTLSv1_method
+	# error[E0432]: unresolved imports ffi::SSLEAY_VERSION, ffi::SSLEAY_CFLAGS,
+	# ffi::SSLEAY_BUILT_ON, ffi::SSLEAY_PLATFORM, ffi::SSLEAY_DIR, ffi::SSLeay,
+	# ffi::SSLeay_version
 	cargo update --package openssl --package openssl-sys
 }
 

--- a/srcpkgs/tectonic/template
+++ b/srcpkgs/tectonic/template
@@ -13,9 +13,18 @@ changelog="https://raw.githubusercontent.com/tectonic-typesetting/tectonic/maste
 distfiles="https://github.com/tectonic-typesetting/${pkgname}/archive/v${version}.tar.gz"
 checksum=e700dc691dfd092adfe098b716992136343ddfac5eaabb1e8cfae4e63f8454c7
 
+# REMOVE THIS SECTION ON NEXT VERSION
 pre_build() {
-	cargo update --package openssl-sys --precise 0.9.46
-	cargo update --package openssl --precise 0.10.22
+	# openssl-sys v0.9.39
+	# This crate is only compatible with OpenSSL 1.0.1 through 1.1.1, or LibreSSL 2.5
+	# through 2.8.1, but a different version of OpenSSL was found. The build is now aborting
+	# due to this version mismatch.
+	# openssl 0.10.15
+	# error[E0432]: unresolved imports `ffi::SSLv23_method`, `ffi::DTLSv1_method`
+	# error[E0432]: unresolved imports `ffi::SSLEAY_VERSION`, `ffi::SSLEAY_CFLAGS`,
+	# `ffi::SSLEAY_BUILT_ON`, `ffi::SSLEAY_PLATFORM`, `ffi::SSLEAY_DIR`, `ffi::SSLeay`,
+	# `ffi::SSLeay_version`
+	cargo update --package openssl --package openssl-sys
 }
 
 post_install() {


### PR DESCRIPTION
This way, we don’t need to change theses numbers at each breaking change from libressl,
because cargo will pick the latest openssl and openssl-sys.