### PR TITLE
dosbox: patch to support full mapping of joysticks

### DIFF
--- a/srcpkgs/dosbox/patches/fully-mappable-joystick.patch
+++ b/srcpkgs/dosbox/patches/fully-mappable-joystick.patch
@@ -1,0 +1,125 @@
+This patch by cfoesch allows mapping of up to 8 axes and 2 hat switches.
+The emulated joystick remains unchanged.
+Discussion: https://www.vogons.org/viewtopic.php?t=27452
+
+--- src/gui/sdl_mapper.cpp	2010-10-30 05:10:05.000000000 -0600
++++ src/gui/sdl_mapper.cpp	2011-02-14 09:29:43.251163300 -0700
+@@ -68,6 +68,8 @@
+ #define MAXACTIVE 16
+ #define MAXBUTTON 32
+ #define MAXBUTTON_CAP 16
++#define MAXAXIS 8
++#define MAXHAT 2
+
+ class CEvent;
+ class CHandlerEvent;
+@@ -521,10 +523,11 @@
+ };
+
+ #define MAX_VJOY_BUTTONS 8
++#define MAX_VJOY_AXES 8
+
+ static struct {
+ 	bool button_pressed[MAX_VJOY_BUTTONS];
+-	Bit16s axis_pos[8];
++	Bit16s axis_pos[MAX_VJOY_AXES];
+ 	bool hat_pressed[16];
+ } virtual_joysticks[2];
+
+@@ -615,8 +618,8 @@
+ 		if (_dummy) return;
+
+ 		// initialize binding lists and position data
+-		pos_axis_lists=new CBindList[4];
+-		neg_axis_lists=new CBindList[4];
++		pos_axis_lists=new CBindList[MAXAXIS];
++		neg_axis_lists=new CBindList[MAXAXIS];
+ 		button_lists=new CBindList[MAXBUTTON];
+ 		hat_lists=new CBindList[4];
+ 		Bitu i;
+@@ -625,7 +628,7 @@
+ 			old_button_state[i]=0;
+ 		}
+ 		for(i=0;i<16;i++) old_hat_state[i]=0;
+-		for (i=0; i<4; i++) {
++		for (i=0; i<MAXAXIS; i++) {
+ 			old_pos_axis_state[i]=false;
+ 			old_neg_axis_state[i]=false;
+ 		}
+@@ -643,8 +646,16 @@
+ 		}
+
+ 		axes=SDL_JoystickNumAxes(sdl_joystick);
+-		buttons=SDL_JoystickNumButtons(sdl_joystick);
++		if (axes > MAXAXIS) axes = MAXAXIS;
++		axes_cap=emulated_axes;
++		if (axes_cap>axes) axes_cap=axes;
++
+ 		hats=SDL_JoystickNumHats(sdl_joystick);
++		if (hats > MAXHAT) hats = MAXHAT;
++		hats_cap=emulated_hats;
++		if (hats_cap>hats) hats_cap=hats;
++
++		buttons=SDL_JoystickNumButtons(sdl_joystick);
+ 		button_wrap=buttons;
+ 		button_cap=buttons;
+ 		if (button_wrapping_enabled) {
+@@ -652,10 +663,7 @@
+ 			if (buttons>MAXBUTTON_CAP) button_cap = MAXBUTTON_CAP;
+ 		}
+ 		if (button_wrap > MAXBUTTON) button_wrap = MAXBUTTON;
+-		axes_cap=emulated_axes;
+-		if (axes_cap>axes) axes_cap=axes;
+-		hats_cap=emulated_hats;
+-		if (hats_cap>hats) hats_cap=hats;
++
+ 		LOG_MSG("Using joystick %s with %d axes, %d buttons and %d hat(s)",SDL_JoystickName(stick),axes,buttons,hats);
+ 	}
+ 	~CStickBindGroup() {
+@@ -688,7 +696,7 @@
+ 		if (event->type==SDL_JOYAXISMOTION) {
+ 			if (event->jaxis.which!=stick) return 0;
+ #if defined (REDUCE_JOYSTICK_POLLING)
+-			if (event->jaxis.axis>=emulated_axes) return 0;
++			if (event->jaxis.axis>=axes) return 0;
+ #endif
+ 			if (abs(event->jaxis.value)<25000) return 0;
+ 			return CreateAxisBind(event->jaxis.axis,event->jaxis.value>0);
+@@ -780,7 +788,7 @@
+ 			}
+ 		}
+
+-		for (i=0; i<axes_cap; i++) {
++		for (i=0; i<axes; i++) {
+ 			Sint16 caxis_pos=SDL_JoystickGetAxis(sdl_joystick,i);
+ 			/* activate bindings for joystick position */
+ 			if (caxis_pos>1) {
+@@ -812,7 +820,7 @@
+ 			}
+ 		}
+
+-		for (i=0; i<hats_cap; i++) {
++		for (i=0; i<hats; i++) {
+ 			Uint8 chat_state=SDL_JoystickGetHat(sdl_joystick,i);
+
+ 			/* activate binding if hat state has changed */
+@@ -838,7 +846,7 @@
+
+ private:
+ 	CBind * CreateAxisBind(Bitu axis,bool positive) {
+-		if (axis<emulated_axes) {
++		if (axis<axes) {
+ 			if (positive) return new CJAxisBind(&pos_axis_lists[axis],this,axis,positive);
+ 			else return new CJAxisBind(&neg_axis_lists[axis],this,axis,positive);
+ 		}
+@@ -877,8 +885,8 @@
+ 	char configname[10];
+ 	Bitu button_autofire[MAXBUTTON];
+ 	bool old_button_state[MAXBUTTON];
+-	bool old_pos_axis_state[16];
+-	bool old_neg_axis_state[16];
++	bool old_pos_axis_state[MAXAXIS];
++	bool old_neg_axis_state[MAXAXIS];
+ 	Uint8 old_hat_state[16];
+ 	bool is_dummy;
+ };

--- a/srcpkgs/dosbox/template
+++ b/srcpkgs/dosbox/template
@@ -1,7 +1,7 @@
 # Template file for 'dosbox'
 pkgname=dosbox
 version=0.74.3
-revision=1
+revision=2
 wrksrc=${pkgname}-0.74-3
 build_style=gnu-configure
 hostmakedepends="pkg-config"


### PR DESCRIPTION
Without this patch, dosbox is only able to use:
- either 2 joysticks/gamepads with 1 analog stick each (no hat switches/d-pads)
- or 1 joystick/gamepad with 1 analog stick and 1 hat switch/d-pad (with `joysticktype=fcs`)

This patch allows full mapping of 2 joysticks/gamepads with 2 analog sticks and 1 hat switch/d-pad, which means modern joysticks and gamepads can be fully used to play dos games in 2-player mode.

This patch is also used by Recalbox OS, see https://github.com/recalbox/recalbox-buildroot/blob/master/package/dosbox/dosbox-003-joystick-8axis.patch