### PR TITLE
dosbox: remove modification for libpng check

### DIFF
--- a/srcpkgs/dosbox/template
+++ b/srcpkgs/dosbox/template
@@ -13,9 +13,6 @@ homepage="http://www.dosbox.com"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${wrksrc}.tar.gz"
 checksum=c0d13dd7ed2ed363b68de615475781e891cd582e8162b5c3669137502222260a
 
-pre_configure() {
-	sed -i 's/png_check_sig/png_sig_cmp/' configure
-}
 post_install() {
 	vdoc README
 	vdoc docs/README.video
@@ -23,4 +20,3 @@ post_install() {
 	vinstall ${FILESDIR}/${pkgname}.png 644 usr/share/pixmaps
 	vinstall ${FILESDIR}/${pkgname}.desktop 644 usr/share/applications
 }
-


### PR DESCRIPTION
The `pre_configure` modification of the libpng check is no longer necessary, because the relevant bug has been resolved upstream, see https://sourceforge.net/p/dosbox/bugs/345/