### PR TITLE
linux5.2: update to 5.2.15.

### DIFF
--- a/srcpkgs/linux5.2/template
+++ b/srcpkgs/linux5.2/template
@@ -1,6 +1,6 @@
 # Template file for 'linux5.2'
 pkgname=linux5.2
-version=5.2.14
+version=5.2.15
 revision=1
 wrksrc="linux-${version}"
 short_desc="Linux kernel and modules (${version%.*} series)"
@@ -8,7 +8,7 @@ maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-only"
 homepage="https://www.kernel.org"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${version}.tar.xz"
-checksum=c64d36477fee6a864a734ec417407768e60040a13f144c33208fa9622fd0ce8c
+checksum=eb561009da8106b463b1e1a16ab0f75cdef564784f49177148f5f92c32380c4a
 patch_args="-Np1"
 
 nodebug=yes  # -dbg package is generated below manually


### PR DESCRIPTION
[skip ci]
fixes major btrfs fs corruption bug.