### PR TITLE
firefox-esr: enable debug symbols on all archs

### DIFF
--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -4,7 +4,7 @@
 #
 pkgname=firefox-esr
 version=68.1.0
-revision=1
+revision=2
 build_helper="rust"
 wrksrc="firefox-${version}"
 short_desc="Mozilla Firefox web browser - Extended Support Release (ESR)"
@@ -29,10 +29,6 @@ conflicts="firefox>=0"
 
 build_options="alsa dbus gtk3 pulseaudio startup_notification xscreensaver sndio"
 build_options_default="alsa dbus gtk3 pulseaudio startup_notification xscreensaver sndio"
-
-if [ "$XBPS_WORDSIZE" -eq 32 ]; then
-	nodebug=yes
-fi
 
 case $XBPS_TARGET_MACHINE in
 	armv6*)
@@ -112,9 +108,14 @@ do_build() {
 		;;
 	esac
 
-	if [ "$XBPS_WORDSIZE" -eq 32 ]; then
-		# ENOMEM
-		echo "ac_add_options --disable-debug-symbols" >>.mozconfig
+	# work around large debug symbols on 32-bit hosts
+	if [ "$XBPS_WORDSIZE" = "32" ]; then
+		export CFLAGS="${CFLAGS/-g/-g1}"
+		export CXXFLAGS="${CXXFLAGS/-g/-g1}"
+		export LDFLAGS+=" -Wl,--no-keep-memory"
+		# patch the rust debug level, this is hardcoded
+		sed -i "s/debug_info = '2'/debug_info = '1'/" \
+		build/moz.configure/toolchain.configure
 	fi
 
 	export LDFLAGS+=" -Wl,-rpath=/usr/lib/firefox"


### PR DESCRIPTION
Same as in main `firefox`.