### PR TITLE
rpi-kernel: update to 4.19.73.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="4a6e8b24948edd17cdb6f4fdebf1cac285b7c7a5"
+_githash="2b1731f8713e6695c32d140440bc92aa7a3cfd31"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.71
+version=4.19.73
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=b89d582558c9bf69db80bead6c013b8f2470fc08feff407a9b284d0d60fd01a3
+checksum=d86450dd78a781f0a34f21a199964b1a9ed333a0e52cb0bbaa71c608c2728fdb
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built on armv6l, armv7, and aarch64.

- Tested on armv6l and armv7l.