### PR TITLE
lsyncd: Fix run file, adopt the package

### DIFF
--- a/srcpkgs/lsyncd/files/lsyncd/log/run
+++ b/srcpkgs/lsyncd/files/lsyncd/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -t lsyncd -p 'daemon.info'

--- a/srcpkgs/lsyncd/files/lsyncd/run
+++ b/srcpkgs/lsyncd/files/lsyncd/run
@@ -1,4 +1,3 @@
 #!/bin/sh
 [ -r ./conf ] && . ./conf
-exec 1>&2
-exec lsyncd "${CONF_FILE:-'/etc/lsyncd/lsyncd.conf.lua'}"
+exec lsyncd -nodaemon "${CONF_FILE:-/etc/lsyncd/lsyncd.conf.lua}"

--- a/srcpkgs/lsyncd/template
+++ b/srcpkgs/lsyncd/template
@@ -1,14 +1,14 @@
 # Template file for 'lsyncd'
 pkgname=lsyncd
 version=2.2.3
-revision=1
+revision=2
 wrksrc="${pkgname}-release-${version}"
 build_style=cmake
 hostmakedepends="asciidoc lua"
 makedepends="lua-devel"
 depends="rsync"
 short_desc="Syncing Daemon that synchronizes local directories with remote targets"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/axkibe/lsyncd"
 distfiles="https://github.com/axkibe/lsyncd/archive/release-${version}.tar.gz"


### PR DESCRIPTION
The service file for lsyncd has been broken for a little while.

This also adds a logger service to lsyncd.
I don't think this will affect anyone's existing setup in a negative way. If their config file specified a log file to write the logs to, it will continue to do so. If they didn't configure a log file in the lsyncd config, they didn't get logs before. In that case, logs will now appear in their system logger if they have one installed.
