### PR TITLE
curl: update to 7.66.0.

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,10 +1,10 @@
 # Template file for 'curl'
 pkgname=curl
-version=7.65.3
+version=7.66.0
 revision=1
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
- $(vopt_with rtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnuts)
+ $(vopt_with rtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnutls)
  $(vopt_enable ldap ldaps) $(vopt_with ssh libssh2) $(vopt_with ssl)
  --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt --without-libidn2"
 hostmakedepends="groff perl pkg-config"
@@ -13,14 +13,14 @@ makedepends="nghttp2-devel zlib-devel $(vopt_if gnutls 'gnutls-devel')
  $(vopt_if rtmp 'librtmp-devel') $(vopt_if ssh 'libssh2-devel')
  $(vopt_if ssl 'libressl-devel')"
 depends="ca-certificates"
-checkdepends="python"
+checkdepends="python3"
 short_desc="Client that groks URLs"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://curl.haxx.se"
 changelog="https://curl.haxx.se/changes.html#${version//./_}"
 distfiles="${homepage}/download/${pkgname}-${version}.tar.bz2"
-checksum=0a855e83be482d7bc9ea00e05bdb1551a44966076762f9650959179c89fce509
+checksum=6618234e0235c420a21f4cb4c2dd0badde76e6139668739085a70c4e2fe7a141
 build_options="gnutls gssapi ldap rtmp ssh ssl"
 build_options_default="ssh ssl"
 vopt_conflict ssl gnutls
@@ -40,7 +40,7 @@ libcurl_package() {
 	shlib_provides="libcurl-gnutls.so.4"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
-		ln -sf libcurl.so.4.5.0 ${PKGDESTDIR}/usr/lib/libcurl-gnutls.so.4
+		ln -sf libcurl.so.4.6.0 ${PKGDESTDIR}/usr/lib/libcurl-gnutls.so.4
 	}
 }
 


### PR DESCRIPTION
Additionally:
* little typo in `$(vopt_with gnutls)`
* use python3 for the testsuite