### PR TITLE
python3-Telethon: update to 1.10.3.

### DIFF
--- a/srcpkgs/python3-Telethon/template
+++ b/srcpkgs/python3-Telethon/template
@@ -1,19 +1,19 @@
 # Template file for 'python3-Telethon'
 pkgname=python3-Telethon
-version=1.9.0
+version=1.10.3
 revision=1
 archs=noarch
 wrksrc="Telethon-${version}"
 build_style=python3-module
 pycompile_module="telethon telethon_generator"
 hostmakedepends="python3-setuptools"
-depends="python3-pyaes python3-rsa python3-async_generator"
+depends="python3-pyaes python3-rsa"
 short_desc="Pure Python3 Telegram client library"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 license="MIT"
 homepage="https://lonamiwebs.github.io/Telethon"
 distfiles="https://github.com/LonamiWebs/Telethon/archive/v${version}.tar.gz"
-checksum=3c0a37d6520234c731e6ee60546dd58730768c8ed7a08c78796ce07cede799bc
+checksum=5f1995c616a62fb24fb7dcc7172256d68a270e279e5e0f680efe997d7c275ee1
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Remove dependency on python3-async_generator