### PR TITLE
wps-office: update to 11.1.0.8865

### DIFF
--- a/srcpkgs/wps-office/template
+++ b/srcpkgs/wps-office/template
@@ -1,37 +1,50 @@
 # Template file for 'wps-office'
 pkgname=wps-office
-version=11.1.0.8722
+version=11.1.0.8865
 revision=1
 archs="x86_64"
 create_wrksrc=yes
 makedepends="rpmextract"
 short_desc="Linux office suite with similar appearance to MS Office"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
-license="Kingsoft WPS Community License"
-#Full license is at: http://wps-community.org/license.md (Not downloadable)
+license="custom:Kingsoft WPS Community License, custom:EULA"
 homepage="http://wps-community.org"
-checksum=e898a1edcb53bc7c0bd3361e225c8475fc84d54d937eea53e7ef030f12a1345e
+checksum="2b7d51dd56516fc5c89a9d4d145e4e201334b000f841d0520e33b0c4a199efe3
+ bd8e8a2f7142710bd3a86e2a978d6371e304dc1cbcf0712d94f21551647bb748"
 allow_unknown_shlibs=yes
 nodebug=yes
 restricted=yes
+skip_extraction="LICENSE_AGREEMENT_OF_KINGSOFT_OFFICE_FOR_LINUX_COMMUNITY.wps"
+
 
 #The programs themselves are PIE, but the error reporter isn't :/
 nopie=yes
 
-_disturl=http://kdl.cc.ksosoft.com/wps-community/download/8722
+_disturl=http://kdl.cc.ksosoft.com/wps-community/download/8865
 _distTar="${pkgname}-${version}-1.x86_64.rpm"
-distfiles="${_disturl}/${_distTar}"
+distfiles="${_disturl}/${_distTar}
+http://wps-community.org/download/licenses/LICENSE_AGREEMENT_OF_KINGSOFT_OFFICE_FOR_LINUX_COMMUNITY.wps"
+
 
 do_install() {
 	cp -R ${wrksrc}/* ${DESTDIR}
 }
 
 post_install() {
+
 	#Clean up:
 	#Delete everything under /etc. It contains cron, logrotate and autostart
 	# configuration for the update check and a seperate menu category for the
 	# wps programs that does not work.
 	rm -rf ${DESTDIR}/etc
+
 	#Delete postinst and prerm scripts
 	rm -rf ${DESTDIR}/opt/kingsoft/wps-office/INSTALL
+
+	# Install license and EULA
+	vlicense ${XBPS_SRCDISTDIR}/$pkgname-$version/LICENSE_AGREEMENT_OF_KINGSOFT_OFFICE_FOR_LINUX_COMMUNITY.wps
+	vlicense ${DESTDIR}/opt/kingsoft/wps-office/office6/mui/default/EULA_linux.txt
+
+	# Install privacy notice as documentation
+	vdoc ${DESTDIR}/opt/kingsoft/wps-office/office6/mui/default/Privacy_Linux.txt
 }


### PR DESCRIPTION
- wps-office has both a (downloadable) license and an EULA, license is in $FILESDIR and both of them are installed with vlicense.

- It also has a privacy notice, which is treated as documentation.

@the-maldridge : Please review the changes.