### PR TITLE
protontricks: update to 1.2.5

### DIFF
--- a/srcpkgs/protontricks/template
+++ b/srcpkgs/protontricks/template
@@ -1,6 +1,6 @@
 # Template file for 'protontricks'
 pkgname=protontricks
-version=1.2.4
+version=1.2.5
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -9,6 +9,6 @@ depends="python3-vdf winetricks"
 short_desc="Simple wrapper that does winetricks things for Proton enabled games"
 maintainer="Caleb JA <skywise@tutanota.de>"
 license="GPL-3.0-only"
-homepage="https://github.com/Matoking/${pkgname}"
+homepage="https://github.com/Matoking/protontricks"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=98316f553d40a01a1e62bb2a1a7ce94b35c1e62b7a1b29a3e07a509fad0503e1
+checksum=a37c8f6b57c6cad6daf726fbf6e90d8b110d0924ef948e1885aed73a2732f8fb


### PR DESCRIPTION
Update protontricks to 1.2.5 and use the package name instead of a variable for the homepage so the entry in void-updates.txt leads to the right place.