### PR TITLE
cri-tools: update to 1.16.0.

### DIFF
--- a/srcpkgs/cri-tools/template
+++ b/srcpkgs/cri-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'cri-tools'
 pkgname=cri-tools
-version=1.15.0
+version=1.16.0
 revision=1
 build_style=go
 go_import_path=github.com/kubernetes-sigs/cri-tools
@@ -9,8 +9,14 @@ maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://github.com/kubernetes-sigs/cri-tools"
 distfiles="https://github.com/kubernetes-sigs/cri-tools/archive/v${version}.tar.gz"
-checksum=7827777ffb085918ef454210ce158a464f1b7326eb339deb348cc8cd3aee2931
+checksum=4c382c3929f1536c36f3a6c8593ce49dd5b7831d3c0f9e41cd4f48163ec05b90
 
 do_build() {
 	make ${makejobs}
+}
+
+do_install() {
+	for bin in _output/*; do
+		vbin $bin
+	done
 }


### PR DESCRIPTION
Seems they've changed the place binaries show up.