### PR TITLE
systemsettings: dependencies fixed

### DIFF
--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,16 +1,16 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
 version=5.16.5
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules"
 makedepends="kcmutils-devel kdoctools khtml-devel kactivities5-stats-devel
  kirigami2-devel plasma-workspace-devel"
-depends="kirigami2 setxkbmap xrdb"
+depends="kirigami2 setxkbmap xrdb gsettings-desktop-schemas"
 short_desc="KDE System settings"
-maintainer="John <johnz@posteo.net>"
-license="GPL-2.0-or-later, GFDL-1.2"
+maintainer="k4leg <d0xi@inbox.ru>"
+license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://projects.kde.org/projects/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
 checksum=57944cf3f566cf5e25d5859f5716b2ad5dbd87de259f8d77efdfdd50a16fe1ec


### PR DESCRIPTION
Added dependency: gsettings-desktop-schemas.
Fixed license from GFDL-1.2 to GFDL-1.2-only.
If this dependency is missing (gsettings-desktop-schemas), the package crashes.
Departure Log: http://dpaste.com/1495W9R.
How to reproduce the problem:
We launch the package (systemsettings5), go to the section "Application Design" -> "Style of GNOME/GTK+ Programs" and try to change the GTK3 theme, a set of mouse cursors and "prefer a dark theme".
And this log shows the log of the package itself (systemsettings5) with this dependency: http://dpaste.com/3N42GFJ.