### PR TITLE
mate-screensaver: update to 1.22.1.

### DIFF
--- a/srcpkgs/mate-screensaver/template
+++ b/srcpkgs/mate-screensaver/template
@@ -1,18 +1,20 @@
 # Template file for 'mate-screensaver'
 pkgname=mate-screensaver
-version=1.22.0
-revision=2
+version=1.22.1
+revision=1
 build_style=gnu-configure
+configure_args="--without-console-kit"
 hostmakedepends="pkg-config intltool itstool glib-devel"
 makedepends="dbus-glib-devel libnotify-devel libXScrnSaver-devel
- libmatekbd-devel mate-menus-devel mate-desktop-devel pam-devel"
+ libmatekbd-devel mate-menus-devel mate-desktop-devel pam-devel
+elogind-devel"
 depends="mate-desktop mate-session-manager"
 short_desc="Screensaver for MATE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=5e0b043570dfc1904e9892956ec8377261f94ed541b7dafde22010a619f3dd9d
+checksum=6cef439cb9885df08769500b87df441a0777a6f08bd6f920fad92dfd75c19830
 
 post_install() {
 	vinstall ${FILESDIR}/${pkgname}.pam 644 etc/pam.d ${pkgname}


### PR DESCRIPTION
Switch from consolekit to elogind.

I disabled consolekit explicetly due to #ifdefs in gs-listener-dbus.c
No need to explicetly enable elogind in configure. Elogind ships a /usr/lib/pkgconfig/libsystemd.pc and a relevant simlinked include directory. Mate screen saver sources actually reuse the systemd #ifdef for elogind anyways.
This was tested by closing and opening laptop lid as well as "loginctl lock-session".