### PR TITLE
zoom: update to 3.0.291715.0908

### DIFF
--- a/srcpkgs/zoom/template
+++ b/srcpkgs/zoom/template
@@ -1,19 +1,20 @@
 # Template file for 'zoom'
 pkgname=zoom
-version=2.9.265650.0716
+version=3.0.291715.0908
 revision=1
 archs="x86_64"
 wrksrc=zoom
 create_wrksrc=yes
 short_desc="Video Conferencing and Web Conferencing Service"
 maintainer="Daniel Santana <daniel@santana.tech>"
-license="Proprietary"
+license="custom:Proprietary"
 homepage="https://zoom.us/"
 distfiles="https://zoom.us/client/${version}/zoom_x86_64.pkg.tar.xz"
-checksum=f9014967875c6e5f90968c11ed08846a24001f48191f6f860e5c95bbf58512e2
+checksum="73c614e523cc2f87c4461fd8e57e66855340a6fbcfdeef8d0e0592fef041e350"
 repository=nonfree
 restricted=yes
 nopie=yes
+
 
 do_install() {
 	vcopy opt .


### PR DESCRIPTION
Xlint cannot pass - there is no obvious license file in the tarball.