### PR TITLE
wayland-protocols: update to 1.18

### DIFF
--- a/srcpkgs/wayland-protocols/template
+++ b/srcpkgs/wayland-protocols/template
@@ -1,6 +1,6 @@
 # Template file for 'wayland-protocols'
 pkgname=wayland-protocols
-version=1.17
+version=1.18
 revision=1
 archs=noarch
 build_style=gnu-configure
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://wayland.freedesktop.org"
 distfiles="https://github.com/wayland-project/wayland-protocols/archive/${version}.tar.gz"
-checksum=f35e2e3e2b0fa71a7371e8330dcbcdedf933a9da631a326459298b4f4ba54035
+checksum=eccbd485a3e657a745c46ac84cef924e9279285ae21c1289657df9a715b1ac83
 
 pre_configure() {
 	export wayland_scanner=wayland-scanner


### PR DESCRIPTION
Mutter 3.34 (for PR #14640) requires wayland-protocols v1.18.