### PR TITLE
connman: patch segfault on musl

### DIFF
--- a/srcpkgs/connman/files/musl/freeaddrinfo.patch
+++ b/srcpkgs/connman/files/musl/freeaddrinfo.patch
@@ -1,0 +1,17 @@
+musl > 1.1.21 segfaults on null pointers to freeaddrinfo
+
+diff --git a/gweb/gweb.c b/gweb/gweb.c
+index 393afe0a..12fcb1d8 100644
+--- a/gweb/gweb.c
++++ b/gweb/gweb.c
+@@ -1274,7 +1274,8 @@ static bool is_ip_address(const char *host)
+ 	addr = NULL;
+ 
+ 	result = getaddrinfo(host, NULL, &hints, &addr);
+-	freeaddrinfo(addr);
++	if(!result)
++		freeaddrinfo(addr);
+ 
+ 	return result == 0;
+ }
+

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -1,7 +1,7 @@
 # Template file for 'connman'
 pkgname=connman
 version=1.37
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat


### PR DESCRIPTION
musl > 1.1.21 requires a non-null argument to freeaddrinfo. Fixed upstream so patch can be removed on next release.