### PR TITLE
[WIP] skalibs: update to 2.9.0.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2116,7 +2116,6 @@ libprocps.so.7 procps-ng-3.3.15_1
 libgegl-0.4.so.0 gegl-0.4.16_1
 libgegl-npd-0.4.so gegl-0.4.16_1
 libgegl-sc-0.4.so gegl-0.4.16_1
-libskarnet.so.2.8 skalibs-2.8.0.0_1
 libKF5BalooWidgets.so.5 baloo-widgets5-17.04.3_1
 libtidy.so.5 libtidy5-5.1.25_1
 libSDL2_gfx-1.0.so.0 SDL2_gfx-1.0.1_1
@@ -3510,3 +3509,4 @@ libdrumstick-rt.so.1 drumstick-1.1.2_1
 libnozzle.so.1 libnozzle1-1.11_2
 libmygpo-qt5.so.1 libmygpo-qt-1.1.0_1
 libluv.so.1 libluv-1.30.1.0_1
+libskarnet.so.2.9 skalibs-2.9.0.0_1

--- a/srcpkgs/execline/template
+++ b/srcpkgs/execline/template
@@ -1,6 +1,6 @@
 # Template file for 'execline'
 pkgname=execline
-version=2.5.1.0
+version=2.5.2.0
 revision=1
 build_style=configure
 makedepends="skalibs-devel"
@@ -13,7 +13,7 @@ license="ISC"
 homepage="https://skarnet.org/software/execline/"
 changelog="https://skarnet.org/software/execline/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=b1a756842947488404db8173bbae179d6e78b6ef551ec683acca540ecaf22677
+checksum=280bb633cbe96088193225729ad32d80493d68380a127e6bc1789aac64375e29
 
 CFLAGS="-fPIC"
 

--- a/srcpkgs/s6-rc/template
+++ b/srcpkgs/s6-rc/template
@@ -1,19 +1,19 @@
 # Template file for 's6-rc'
 pkgname=s6-rc
-version=0.5.0.0
-revision=6
+version=0.5.1.0
+revision=1
 build_style=configure
 configure_args="--prefix=/usr --libdir=/usr/lib --includedir=/usr/include
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --with-lib=${XBPS_CROSS_BASE}/usr/lib"
 makedepends="execline-devel skalibs-devel s6-devel"
-depends="s6>=2.8.0.0_1 execline>=2.5.1.0_1"
+depends="s6>=2.9.0.0_1 execline>=2.5.2.0_1"
 short_desc="Service manager of the s6 init system"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="ISC"
 homepage="https://skarnet.org/software/${pkgname}/"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=cb7f033965a6c1b6f500cbb7a2f3ecdf2310fbb18f79e7a2a384541413b9275d
+checksum=93c02d0b505c036c332e13769154d82c9e31e4dd99f3ba80aa97d377ca9ac11c
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/s6/template
+++ b/srcpkgs/s6/template
@@ -1,6 +1,6 @@
 # Template file for 's6'
 pkgname=s6
-version=2.8.0.1
+version=2.9.0.0
 revision=1
 build_style=configure
 makedepends="execline-devel skalibs-devel"
@@ -14,7 +14,7 @@ license="ISC"
 homepage="http://skarnet.org/software/s6/"
 changelog="https://skarnet.org/software/s6/upgrade.html"
 distfiles="http://skarnet.org/software/s6/s6-${version}.tar.gz"
-checksum=dbe08f5b76c15fa32a090779b88fb2de9a9a107c3ac8ce488931dd39aa1c31d8
+checksum=1cac59bf9ff7c011b189ae2def3c76b147c2c431b0a901029fcaf957a6d9a343
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" nsss-devel" configure_args+=" --enable-nsss" ;;

--- a/srcpkgs/skalibs/template
+++ b/srcpkgs/skalibs/template
@@ -1,30 +1,21 @@
 # Template file for 'skalibs'
 pkgname=skalibs
-version=2.8.1.0
+version=2.9.0.0
 revision=1
-_sysdepspkg=skaware-void-sysdeps
 build_style=configure
-configure_args="--libdir=/usr/lib --enable-static --enable-shared --enable-clock
- --enable-monotonic --enable-force-devr --datadir=/usr/share/$pkgname --libdir=/usr/lib
+configure_args="--libdir=/usr/lib --enable-static --enable-shared  --enable-force-devr --datadir=/usr/share/$pkgname --libdir=/usr/lib
  --bindir=/usr/bin --dynlibdir=/usr/lib"
 short_desc="General purpose libraries for building software from skarnet.org"
 maintainer="bougyman <bougyman@voidlinux.org>"
 license="ISC"
 homepage="https://skarnet.org/software/skalibs/"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=431c6507b4a0f539b6463b4381b9b9153c86ad75fa3c6bfc9dc4722f00b166ba
+checksum=f5604f9e5ebb436d3a8efa16a2c4133f7bd424d9f22aa88fe7a372f0153396fb
 
 CFLAGS="-D_DEFAULT_SOURCE"
 
 if [ "$CROSS_BUILD" ]; then
-	distfiles+=" https://github.com/CMB/${_sysdepspkg}/archive/${version}.tar.gz"
-	checksum+=" b5a56d24caeb731f9a8468fa61ab0e9ae139370609ef4acb36888e69bbe8d98d"
-	configure_args+=" --with-sysdeps=../${_sysdepspkg}-${version}/${XBPS_CROSS_TRIPLET}"
-
-	case "$XBPS_TARGET_MACHINE" in
-		aarch64*|armv6*|armv7l*|i686|x86_64*|ppc*) ;;
-		*) nocross="Missing cross sysdeps" ;;
-	esac
+	configure_args+=" --with-sysdep-devurandom=yes"
 fi
 
 post_install() {


### PR DESCRIPTION
Skalibs now supports autodetection of sysdeps for cross-compilation (with the exception of devurandom). I will update all revdeps in this PR.