### PR TITLE
s6-networking: update to 2.3.1.0

### DIFF
--- a/srcpkgs/s6-networking/template
+++ b/srcpkgs/s6-networking/template
@@ -1,7 +1,7 @@
 # Template file for 's6-networking'
 pkgname=s6-networking
-version=2.3.0.4
-revision=2
+version=2.3.1.0
+revision=1
 build_style=configure
 makedepends="execline-devel libressl-devel skalibs-devel s6-devel s6-dns-devel"
 configure_args="--libdir=/usr/lib --enable-ssl=libressl
@@ -13,7 +13,7 @@ license="ISC"
 homepage="https://skarnet.org/software/${pkgname}/"
 changelog="https://skarnet.org/software/s6-networking/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=0ae36a4adcf0000324d0cdb48767d7aa2b185a4e69105d3e7087a1cb2ab87802
+checksum=814fa3b70718d2423c742e920d31f64088272f7987c2cf7bebc86a63a75596b8
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" nsss-devel" configure_args+=" --enable-nsss" ;;


### PR DESCRIPTION
Depends on https://github.com/void-linux/void-packages/pull/14667 .