### PR TITLE
crystal: update to 0.31.0.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,10 +1,10 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.30.1
+version=0.31.0
 revision=1
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
-_bootstrapversion=0.30.1
+_bootstrapversion=0.31.0
 _bootstraprevision=1
 hostmakedepends="git llvm8"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -19,7 +19,7 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="0ffc00fa54929c2533bc0bcb89e0b001dd3abc470ccc87e3576047a5cdafc062
+checksum="483ffcdce30b98f89b8c6cf6e48c62652cd0450205f609e04721a37997c32486
  90f230c87cc7b94ca845e6fe34f2523edcadb562d715daaf98603edfa2a94d65"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -32,11 +32,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" aae60f90c809b480f069c6ae3f8ef54a8753dce5448ee34f1dda0e28c95955cc"
+		checksum+=" e0edff85da9375178f2e5c72845b6d3eb6abc1d9e32c9033451ae4c1fc0bf09a"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 62faf63ccf94b17b1d94d4166a4fadf2a4c36aac553c719bbf5a88e4bc0a586f"
+		checksum+=" a451e997378bc1230241b0e40023b8f0d754fd68943c5a8e77840d4fac0c5647"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"


### PR DESCRIPTION
- Compilation was locally tested with both i686 and x86_64
- Package was locally installed on x86_64, `crystal` and `shards` work good
- Issue with multi-threading: it is not possible to compile with the `-Dpreview_mt` flag. Investigating the [issue](https://github.com/crystal-lang/crystal/issues/8213) someone else had on Arch.

**Edit for Crystal developers:** Regarding multi-threading, a patch will be applied to Crystal in order to support new upstream functions from `gc`, instead of Crystal gc's custom ones. Eventually we will not patch boehm in our repositories, therefore it will be necessary to wait for a next `gc` release to be able to use multi-threading with Crystal.

**Edit 2:** In summary, `crystal` can be merged and multi-threading will be enabled in new releases of `crystal` and `gc`. For now, Crystal works well in single-threaded mode, as before.