### PR TITLE
Fix s6 rc

### DIFF
--- a/srcpkgs/66/template
+++ b/srcpkgs/66/template
@@ -18,7 +18,6 @@ homepage="http://web.obarun.org/software/"
 changelog="https://framagit.org/Obarun/66/raw/master/NEWS"
 distfiles="https://framagit.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
 checksum=9c3430ab291ec83e74faa05634614e1d851e2bc18fe173963d8fe5313c2dd337
-broken="https://build.voidlinux.org/builders/x86_64_builder/builds/20124/steps/shell_3/logs/stdio"
 
 conf_files="/etc/66/init /etc/66/init.conf"
 make_dirs="

--- a/srcpkgs/s6-rc/template
+++ b/srcpkgs/s6-rc/template
@@ -1,6 +1,6 @@
 # Template file for 's6-rc'
 pkgname=s6-rc
-version=0.5.0.0
+version=0.5.1.0
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --libdir=/usr/lib --includedir=/usr/include
@@ -14,7 +14,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-rc/"
 changelog="https://skarnet.org/software/s6-rc/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=cb7f033965a6c1b6f500cbb7a2f3ecdf2310fbb18f79e7a2a384541413b9275d
+checksum=93c02d0b505c036c332e13769154d82c9e31e4dd99f3ba80aa97d377ca9ac11c
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
@Hoshpak Looks like s6-rc wasn't updated correctly the other day.

```
--- a/srcpkgs/s6-rc/template
+++ b/srcpkgs/s6-rc/template
@@ -1,17 +1,18 @@
 # Template file for 's6-rc'
 pkgname=s6-rc
 version=0.5.0.0
-revision=6
+revision=1
```