### PR TITLE
pipewire: Add pipewire config to conf_files

### DIFF
--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,7 +1,7 @@
 # Template file for 'pipewire'
 pkgname=pipewire
 version=0.2.6
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dman=true -Dgstreamer=enabled -Ddocs=true -Dsystemd=false"
 hostmakedepends="doxygen graphviz pkg-config xmltoman"
@@ -14,6 +14,7 @@ homepage="https://pipewire.org/"
 changelog="https://raw.githubusercontent.com/PipeWire/pipewire/master/NEWS"
 distfiles="https://github.com/PipeWire/pipewire/archive/${version}.tar.gz"
 checksum=8592bcc2a83b078fee6cfb8560397cf2747346f28e88689197e780069b19cb17
+conf_files="/etc/pipewire/pipewire.conf"
 
 libpipewire_package() {
 	short_desc+=" - pipewire library"


### PR DESCRIPTION
```
$ sudo xbps-pkgdb -a  
ERROR: pipewire: hash mismatch for /etc/pipewire/pipewire.conf.
ERROR: pipewire: files check FAILED.
```