### PR TITLE
jenkins: update to 2.190.1

### DIFF
--- a/srcpkgs/jenkins/template
+++ b/srcpkgs/jenkins/template
@@ -1,6 +1,6 @@
 # Template file for 'jenkins'
 pkgname=jenkins
-version=2.176.3
+version=2.190.1
 revision=1
 build_style=fetch
 make_dirs="/var/lib/jenkins 0755 jenkins jenkins"
@@ -10,7 +10,7 @@ maintainer="Renato Aguiar <renato@renag.me>"
 license="MIT"
 homepage="https://jenkins.io/"
 distfiles="http://mirrors.jenkins.io/war-stable/${version}/jenkins.war"
-checksum=9406c7bee2bc473f77191ace951993f89922f927a0cd7efb658a4247d67b9aa3
+checksum=46fb1d25d9423fc66aadd648dc74b9772863a7fbbd89bfc14c873cd0c3436f05
 # Create 'jenkins' user
 system_accounts="jenkins"
 jenkins_homedir="/var/lib/jenkins"


### PR DESCRIPTION
As soon as my update got merged another LTS update came. Security fixes. There seems to be a change in symlink behaviour, but not huge. Otherwise only minor changes.

There is a non-major release with only the security updates, but this release is still the LTS branch.