### PR TITLE
kgpg: fix

### DIFF
--- a/srcpkgs/kgpg/template
+++ b/srcpkgs/kgpg/template
@@ -1,7 +1,7 @@
 # Template file for 'kgpg'
 pkgname=kgpg
 version=19.08.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules"
@@ -20,3 +20,7 @@ checksum=441a0bfa58df14bad87f5f446b89113dc20365424f6a87aec30125c9221815c5
 if [ "$CROSS_BUILD" ]; then
  hostmakedepends+=" qt5-qmake kcoreaddons-devel kdoctools kconfig"
 fi
+
+post_extract() {
+ sed -i "s/<default>gpg<\/default>/<default>gpg2<\/default>/g" ${XBPS_BUILDDIR}/${pkgname}-${version}/kgpg.kcfg
+}


### PR DESCRIPTION
As we know in Void Linux, there are two packages: gnupg & gnupg2. So, although the first time you launch kgpg, it gives you the opportunity to indicate where it is (gpg), but does not apply your actions, although it also indicates by default the correct path to gpg2.
Why not just add gnupg to the dependency, as it refers to /usr/bin/gpg? Because for some reason he does not want to work with him, he wants gnupg2.