### PR TITLE
mate-menus: update to 1.22.1.

### DIFF
--- a/srcpkgs/mate-menus/template
+++ b/srcpkgs/mate-menus/template
@@ -1,26 +1,22 @@
 # Template file for 'mate-menus'
 pkgname=mate-menus
-version=1.22.0
+version=1.22.1
 revision=1
 build_style=gnu-configure
 build_helper="gir"
-configure_args="--disable-static $(vopt_enable python)"
-hostmakedepends="pkg-config intltool itstool $(vopt_if gir gobject-introspection)
- $(vopt_if python python)"
-makedepends="libglib-devel $(vopt_if python python-devel)"
+configure_args="--disable-static"
+hostmakedepends="pkg-config intltool itstool
+ $(vopt_if gir gobject-introspection)"
+makedepends="libglib-devel"
 short_desc="MATE menu specifications"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=acec93a66154fdbd78404680fca5a99112085cb99d7c43022b010527dc9a6ad2
+checksum=800d26bdba7762660ec8513cf5bcc58ff173fa1ae96621b21d17e6e0ccf1064e
 
-build_options="gir python"
-build_options_default="gir python"
-
-pre_configure() {
-	export PYTHON=/usr/bin/python2
-}
+build_options="gir"
+build_options_default="gir"
 
 mate-menus-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Drop Python build option as it was dropped upstream.