### PR TITLE
New package: next-1.3.2

### DIFF
--- a/srcpkgs/next/template
+++ b/srcpkgs/next/template
@@ -1,0 +1,19 @@
+# Template file for 'next'
+pkgname=next
+version=1.3.2
+revision=1
+#create_wrksrc=yes
+#only_for_archs="i686 x86_64"
+build_style=gnu-makefile
+hostmakedepends="sbcl curl pkg-config"
+makedepends="webkit2gtk-devel libfixposix-devel libressl-devel"
+depends="sqlite xclip libfixposix-devel libressl-devel"
+short_desc="Keyboard-oriented, extensible web-browser"
+maintainer="0x0f0f0f <sudo-woodo3@protonmail.com>"
+license="BSD-3-Clause"
+homepage="https://next.atlas.engineer/"
+distfiles="https://github.com/atlas-engineer/next/archive/${version}.tar.gz"
+checksum=1c423f4af3b732f2b5bea74a571b17f51d416a7161cc0ad25574725612588593
+vlicense="LICENSE"
+nostrip=true
+nopie=true


### PR DESCRIPTION
I have included libfixposix-devel and libressl-devel in depends because of [atlas-engineer/next/issues/406](https://github.com/atlas-engineer/next/issues/406).