### PR TITLE
rpi-kernel: update to 4.19.75.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="2b1731f8713e6695c32d140440bc92aa7a3cfd31"
+_githash="6d8bf28fa4b1ca0a35c0cd1dcb267fb216daf720"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.73
+version=4.19.75
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=d86450dd78a781f0a34f21a199964b1a9ed333a0e52cb0bbaa71c608c2728fdb
+checksum=ccab02fd16a9450637c8f715f8037c02cd21a086c914d88b819e4b153cde873d
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Builds on armv6l, armv7l, and aarch64.
- Boots on armv6l and armv7l.