### PR TITLE
libGL: enable opencl on ppc, disable xa on ppc/aarch64

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,7 +1,7 @@
 # Template file for 'libGL'
 pkgname=libGL
 version=19.1.7
-revision=2
+revision=3
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dshared-glapi=true -Dgbm=true -Degl=true
@@ -44,19 +44,21 @@ ppc*)
 	configure_args+=" -Dgallium-drivers=r300,r600,radeonsi,swrast,nouveau,virgl"
 	configure_args+=" -Ddri-drivers=r100,r200,nouveau"
 	configure_args+=" -Dvulkan-drivers=amd"
-	configure_args+=" -Ddri3=true"
+	configure_args+=" -Dgallium-xa=false -Ddri3=true -Dgallium-opencl=icd"
 	# Explicitly control power8 feature usage, disable on BE
 	case "$XBPS_TARGET_MACHINE" in
 		ppc64le*) configure_args+=" -Dpower8=true";;
 		*) configure_args+=" -Dpower8=false";;
 	esac
 	hostmakedepends+=" clang"
+	makedepends+=" libclc-git"
 	subpackages+=" mesa-ati-dri mesa-nouveau-dri"
+	subpackages+=" mesa-opencl"
 	;;
 aarch64*)
 	configure_args+=" -Dgallium-drivers=nouveau,tegra,swrast,vc4"
 	configure_args+=" -Dvulkan-drivers= -Ddri-drivers="
-	configure_args+=" -Ddri3=true"
+	configure_args+=" -Dgallium-xa=false -Ddri3=true"
 	subpackages+=" mesa-tegra-dri mesa-nouveau-dri mesa-vc4-dri"
 	;;
 armv7l*)
@@ -181,13 +183,8 @@ mesa-ati-dri_package() {
 		vmove usr/lib/dri/r*
 		vmove "usr/share/vulkan/icd.d/radeon_icd*.json"
 		vmove "usr/lib/libvulkan_radeon.so"
-		case "$XBPS_TARGET_MACHINE" in
-			ppc*) ;;
-			*)
-				vmove "usr/lib/gallium-pipe/pipe_r[36]00.so"
-				vmove usr/lib/gallium-pipe/pipe_radeonsi.so
-			;;
-		esac
+		vmove "usr/lib/gallium-pipe/pipe_r[36]00.so"
+		vmove usr/lib/gallium-pipe/pipe_radeonsi.so
 	}
 }
 
@@ -209,7 +206,7 @@ mesa-nouveau-dri_package() {
 		vmove "usr/lib/xorg/modules/drivers/nouveau*"
 		vmove "usr/lib/dri/nouveau*"
 		case "$XBPS_TARGET_MACHINE" in
-			aarch64*|ppc*) ;;
+			aarch64*) ;;
 			*) vmove usr/lib/gallium-pipe/pipe_nouveau.so ;;
 		esac
 	}


### PR DESCRIPTION
The latter is necessary because otherwise it seems mesa will still build it by default and the library will leak into libGL itself.

OpenCL on ppc used not to build but it builds now.
