### PR TITLE
mate-tweak: update to 19.10.4

### DIFF
--- a/srcpkgs/mate-tweak/template
+++ b/srcpkgs/mate-tweak/template
@@ -1,14 +1,15 @@
 # Template file for 'mate-tweak'
 pkgname=mate-tweak
-version=18.10.2
+version=19.10.4
 revision=1
 archs=noarch
 build_style=python3-module
 hostmakedepends="intltool python3-distutils-extra python3-pbr python3-setuptools"
-depends="mate-panel python3-gobject python3-psutil python3-setproctitle"
+depends="mate-panel python3-gobject python3-psutil python3-setproctitle
+ python3-distro"
 short_desc="Tweak tool for MATE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ubuntu-mate/mate-tweak"
 distfiles="https://github.com/ubuntu-mate/mate-tweak/archive/${version}.tar.gz"
-checksum=1e5eea75339c1e45f3d643f7c0750fac1e1814958b1dd3f846f7a49faf1fabfb
+checksum=e4c3d75ce247ab9724ecbfbb3292dbadd523b01e06d435303f6da3af88b172a5

--- a/srcpkgs/python3-distro/template
+++ b/srcpkgs/python3-distro/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-distro'
+pkgname=python3-distro
+version=1.4.0
+revision=1
+wrksrc=distro-${version}
+build_style=python3-module
+pycompile_module="distro"
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel"
+depends="python3"
+short_desc="OS platform information API"
+maintainer="mobinmob <mobinmob@disroot.org>"
+license="Apache-2.0"
+homepage="https://github.com/nir0s/distro"
+distfiles="${PYPI_SITE}/d/distro/distro-${version}.tar.gz"
+checksum=362dde65d846d23baee4b5c058c8586f219b5a54be1cf5fc6ff55c4578392f57


### PR DESCRIPTION
The new release has a runtime dependency on the distro python module, so I include the new template.