### PR TITLE
mftrace: update to 1.2.20

### DIFF
--- a/srcpkgs/mftrace/patches/gf2pbm.1.patch
+++ b/srcpkgs/mftrace/patches/gf2pbm.1.patch
@@ -1,0 +1,11 @@
+--- GNUmakefile.in
++++ GNUmakefile.in
+@@ -14,7 +14,7 @@ CFLAGS += -I.
+ srcdir=@srcdir@
+ VPATH=$(srcdir)
+ NAME=mftrace
+-MANPAGES=mftrace.1 gf2pbm.1
++MANPAGES=mftrace.1
+ VERSION=@VERSION@
+ distdir=$(NAME)-$(VERSION)
+ prefix=@prefix@

--- a/srcpkgs/mftrace/template
+++ b/srcpkgs/mftrace/template
@@ -1,13 +1,13 @@
 # Template file for 'mftrace'
 pkgname=mftrace
-version=1.2.19
+version=1.2.20
 revision=1
 build_style=gnu-configure
-depends="python potrace"
-hostmakedepends="${depends}"
+hostmakedepends="python3 potrace"
+depends="${hostmakedepends}"
 short_desc="Trace a TeX bitmap font into PFA/PFB/TTF"
 maintainer="svenper <svenper@tuta.io>"
 license="GPL-2.0-or-later"
 homepage="http://lilypond.org/mftrace"
 distfiles="http://lilypond.org/downloads/sources/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=778126f4220aa31fc91fa8baafd26aaf8be9c5e8fed5c0e92a61de04d32bbdb5
+checksum=626b7a9945a768c086195ba392632a68d6af5ea24ef525dcd0a4a8b199ea5f6f


### PR DESCRIPTION
Patch Makefile that refers to gf2pbm.1 that doesn't exist.

Migrate package to python3:
https://github.com/hanwen/mftrace/commit/0ccbf933b27ff40b73d7e9de3c38a401a986edaf