### PR TITLE
rpi-firmware: use raspbian as source for wifi and bluetooth firmware

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -4,12 +4,12 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
 version=20190828
-revision=1
+revision=2
 archs=noarch
 wrksrc="firmware-${_githash}"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
 maintainer="Peter Bui <pbui@github.bx612.space>"
-license="BSD-3-Clause"
+license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
 checksum=7e988a93c27cc59c89fa5270455196a71516b4aa9668152f8e87d6b1448ea914
@@ -32,23 +32,26 @@ do_install() {
 	vinstall ${FILESDIR}/cmdline.txt 644 boot
 	vinstall ${FILESDIR}/config.txt 644 boot
 
+	$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/LICENCE.cypress
+	vlicense LICENCE.cypress
+
 	# Firmware for rpi3 b and zero wifi chip
 	for f in bin txt; do
-		$XBPS_FETCH_CMD https://archlinuxarm.org/builder/src/bcm43430/7.45.98.38/brcmfmac43430-sdio.${f}
+		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43430-sdio.${f}
 		vinstall brcmfmac43430-sdio.${f} 0644 usr/lib/firmware/brcm
 	done
 
 	# Firmware for rpi3 b and zero bluetooth chip
-	$XBPS_FETCH_CMD https://archlinuxarm.org/builder/src/bcm43430/BCM43430A1.hcd
+	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM43430A1.hcd
 	vinstall BCM43430A1.hcd 0644 usr/lib/firmware/brcm
 
 	# Firmware for rpi3 b+ wifi chip
 	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://archlinuxarm.org/builder/src/bcm43455/7.45.154/brcmfmac43455-sdio.${f}
+		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43455-sdio.${f}
 		vinstall brcmfmac43455-sdio.${f} 0644 usr/lib/firmware/brcm
 	done
 
 	# Firmware for rpi3 b+ bluetooth chip
-	$XBPS_FETCH_CMD https://archlinuxarm.org/builder/src/bcm43455/BCM4345C0.hcd
+	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM4345C0.hcd
 	vinstall BCM4345C0.hcd 0644 usr/lib/firmware/brcm
 }


### PR DESCRIPTION
This pull request changes the source for the WiFi and Bluetooth firmware to Raspbian. As the official Raspberry Pi distro, it receives the firmware directly from Cypress and always has the most recent versions. The changes over the current source:

brcmfmac43430-sdio.txt
- Improved brcmfmac BT coexistence parameters

BCM4345C0.hcd
- Restores the LEScan capability
- Enables BT 4.2 functionality