### PR TITLE
peek: update to 1.4.0.

### DIFF
--- a/srcpkgs/peek/template
+++ b/srcpkgs/peek/template
@@ -1,15 +1,14 @@
 # Template file for 'peek'
 pkgname=peek
-version=1.3.1
+version=1.4.0
 revision=1
-build_style=cmake
-configure_args="-DGSETTINGS_COMPILE=OFF"
+build_style=meson
 hostmakedepends="glib-devel libxml2 pkg-config txt2man vala"
 makedepends="gtk+3-devel libkeybinder3-devel"
 depends="gsettings-desktop-schemas"
-maintainer="Orphaned <orphan@voidlinux.org>"
 short_desc="Simple animated GIF screen recorder with an easy to use interface"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="GPL-3.0-or-later"
 homepage="https://github.com/phw/peek"
-license="GPL-3"
 distfiles="https://github.com/phw/peek/archive/${version}.tar.gz"
-checksum=8104b65b041858b7f7f482e1425f8f22d429524340ad341f95f08b08fe4e8602
+checksum=506c5797102629ff4a319c5fcc4eb6b771ffd680bb83ea07c1e5e8166000d605


### PR DESCRIPTION
- Switch to meson (upstream is deprecating cmake)
- Adopt package