### PR TITLE
qt5-styleplugins: bump git revision

### DIFF
--- a/srcpkgs/qt5-styleplugins/template
+++ b/srcpkgs/qt5-styleplugins/template
@@ -1,8 +1,8 @@
 # Template file for 'qt5-styleplugins'
 pkgname=qt5-styleplugins
 version=5.0.0
-revision=9
-_gitrev=600c296f4d429ffeb8203feb54efeacc2bbea0f7
+revision=10
+_gitrev=335dbece103e2cbf6c7cf819ab6672c2956b17b3
 wrksrc="qtstyleplugins-${_gitrev}"
 build_style=qmake
 hostmakedepends="pkg-config qt5-host-tools qt5-devel"
@@ -13,7 +13,7 @@ maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="LGPL-2.1-only, LGPL-3.0-only"
 homepage="https://github.com/qt/qtstyleplugins"
 distfiles="https://github.com/qt/qtstyleplugins/archive/${_gitrev}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=dbe1c03f00c6eadebc0ed9d5ec1eeb9129e8132c8574545dfa788f505c2dd9a3
+checksum=29ec24fa8df64be161ad06d0e5af3ba1a20bfe265004f5fe4ab9f5f3abf9a5ba
 
 # Cross builds fail with -fuse-ld=gold
 LDFLAGS="-Wl,-fuse-ld=bfd"


### PR DESCRIPTION
Ours is against an outdated one, there have been a few bug fixes for some annoying theme bugs since then. The repo is not very active (nothing since 2017), but fix anyway

@Johnnynator 