### PR TITLE
grub: grub.post: set ZPOOL_VDEV_NAME_PATH=YES

### DIFF
--- a/srcpkgs/grub/files/kernel.d/grub.post
+++ b/srcpkgs/grub/files/kernel.d/grub.post
@@ -7,6 +7,8 @@
 PKGNAME="$1"
 VERSION="$2"
 
+export ZPOOL_VDEV_NAME_PATH=YES
+
 if command -v grub-mkconfig >/dev/null 2>&1; then
 	if [ -d $ROOTDIR/boot/grub ]; then
 		grub-mkconfig -o $ROOTDIR/boot/grub/grub.cfg

--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,7 +1,7 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.04
-revision=1
+revision=2
 hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel fuse-devel"


### PR DESCRIPTION
Not setting this results in the output of 'zpool status' being
misparsed.

See https://github.com/zfsonlinux/grub/issues/5