### PR TITLE
rpi-kernel: enable build of kernel modules

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -41,76 +41,67 @@ mutable_files="
 	/usr/lib/modules/${_kernver}/modules.alias.bin
 	/usr/lib/modules/${_kernver}/modules.devname"
 
+_arch=
+case "$XBPS_TARGET_MACHINE" in
+	arm*) _arch=arm ;;
+	aarch64*) _arch=arm64 ;;
+esac
+_cross=
+if [ "$CROSS_BUILD" ]; then
+	_cross="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
+fi
+
 pre_configure() {
 	# Remove .git directory, otherwise scripts/setkernelversion.sh
 	# modifies KERNELRELEASE and appends + to it.
 	rm -rf .git
 }
 do_configure() {
-	if [ "$CROSS_BUILD" ]; then
-		_args="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
-	fi
+	local target defconfig
 
-	# Use upstream default configuration, no need to maintain ours.
+	# Use upstream's default configuration, no need to maintain ours.
 	case "$XBPS_TARGET_MACHINE" in
-	aarch64*)
-		echo "CONFIG_CONNECTOR=y" >> arch/arm64/configs/bcmrpi3_defconfig
-		echo "CONFIG_PROC_EVENTS=y" >> arch/arm64/configs/bcmrpi3_defconfig
-		echo "CONFIG_F2FS_FS_SECURITY=y" >> arch/arm64/configs/bcmrpi3_defconfig
-		echo "CONFIG_CGROUP_PIDS=y" >> arch/arm64/configs/bcmrpi3_defconfig
-		make ${makejobs} ${_args} ARCH=arm64 bcmrpi3_defconfig
-		;;
-	armv7l*)
-		echo "CONFIG_USER_NS=y" >> arch/arm/configs/bcm2709_defconfig
-		echo "CONFIG_CONNECTOR=y" >> arch/arm/configs/bcm2709_defconfig
-		echo "CONFIG_PROC_EVENTS=y" >> arch/arm/configs/bcm2709_defconfig
-		echo "CONFIG_F2FS_FS_SECURITY=y" >> arch/arm/configs/bcm2709_defconfig
-		echo "CONFIG_CGROUP_PIDS=y" >> arch/arm/configs/bcm2709_defconfig
-		make ${makejobs} ${_args} ARCH=arm bcm2709_defconfig
-		;;
-	armv6l*)
-		echo "CONFIG_USER_NS=y" >> arch/arm/configs/bcmrpi_defconfig
-		echo "CONFIG_CONNECTOR=y" >> arch/arm/configs/bcmrpi_defconfig
-		echo "CONFIG_PROC_EVENTS=y" >> arch/arm/configs/bcmrpi_defconfig
-		echo "CONFIG_F2FS_FS_SECURITY=y" >> arch/arm/configs/bcmrpi_defconfig
-		echo "CONFIG_CGROUP_PIDS=y" >> arch/arm/configs/bcmrpi_defconfig
-		make ${makejobs} ${_args} ARCH=arm bcmrpi_defconfig
-		;;
+		# RPi3
+		aarch64*)
+			target=bcmrpi3_defconfig
+			;;
+		# RPi2 / RPi3
+		armv7l*)
+			target=bcm2709_defconfig
+			;;
+		# RPi1
+		armv6l*)
+			target=bcmrpi_defconfig
+			;;
 	esac
+
+	defconfig="arch/${_arch}/configs/${target}"
+	echo "CONFIG_CONNECTOR=y" >> "$defconfig"
+	echo "CONFIG_PROC_EVENTS=y" >> "$defconfig"
+	echo "CONFIG_F2FS_FS_SECURITY=y" >> "$defconfig"
+	echo "CONFIG_CGROUP_PIDS=y" >> "$defconfig"
+
+	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
 
 	# Always use our revision to CONFIG_LOCALVERSION to match our pkg version.
-	sed -i -e "s|^\(CONFIG_LOCALVERSION=\).*|\1\"_${revision}\"|" .config
+	vsed -i -e "s|^\(CONFIG_LOCALVERSION=\).*|\1\"_${revision}\"|" .config
 }
 do_build() {
-	if [ "$CROSS_BUILD" ]; then
-		_args="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
-	fi
+	local target
 
 	case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		_arch=arm
-		_targets="zImage modules dtbs"
-		;;
-	aarch64*)
-		unset LDFLAGS
-		_arch=arm64
-		_targets="Image modules dtbs"
-		;;
+		arm*)
+			target="zImage modules dtbs"
+			;;
+		aarch64*)
+			target="Image modules dtbs"
+			;;
 	esac
 
-	make ${makejobs} ${_args} ARCH=${_arch} prepare
-	make ${makejobs} ${_args} ARCH=${_arch} ${_targets}
+	make ${makejobs} ${_cross} ARCH=${_arch} prepare
+	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
 }
 do_install() {
-	case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		_arch="arm"
-	;;
-	aarch64*)
-		_arch="arm64"
-	;;
-	esac
-
 	local hdrdest
 
 	# Run depmod after compressing modules.
@@ -173,14 +164,11 @@ do_install() {
 	cp Module.symvers ${hdrdest}
 	cp -a scripts ${hdrdest}
 
-	# fix permissions on scripts dir
-	chmod og-w -R ${hdrdest}/scripts
-
 	# copy arch includes for external modules
 	mkdir -p ${hdrdest}/arch/${_arch}
 	cp -a arch/${_arch}/include ${hdrdest}/arch/${_arch}
 
-	mkdir -p ${hdrdest}/arch/${arch}/kernel
+	mkdir -p ${hdrdest}/arch/${_arch}/kernel
 	cp arch/${_arch}/Makefile ${hdrdest}/arch/${_arch}
 	cp arch/${_arch}/kernel/asm-offsets.s ${hdrdest}/arch/${_arch}/kernel
 
@@ -207,10 +195,11 @@ do_install() {
 	done
 
 	# Remove unneeded architectures
-	for arch in alpha arc avr32 blackfin c6x cris frv h8300 \
-		hexagon ia64 m* n* p* s* um v850 x86 xtensa; do
-		rm -rf ${hdrdest}/arch/${arch}
-	done
+	# (save the correct one + Kconfig and delete all others)
+	mkdir -p arch-backup
+	cp ${hdrdest}/arch/${_arch} ${hdrdest}/arch/Kconfig arch-backup/
+	rm -rf ${hdrdest}/arch
+	mv arch-backup ${hdrdest}/arch
 
 	# Compress all modules with xz to save a few MBs.
 	msg_normal "$pkgver: compressing kernel modules with gzip, please wait...\n"

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -10,7 +10,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
 version=4.19.75
-revision=1
+revision=2
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
@@ -149,20 +149,39 @@ do_install() {
 	install -Dm644 Makefile ${hdrdest}/Makefile
 	install -Dm644 kernel/Makefile ${hdrdest}/kernel/Makefile
 	install -Dm644 .config ${hdrdest}/.config
+	for file in $(find . -name Kconfig\*); do
+		mkdir -p ${hdrdest}/$(dirname $file)
+		install -Dm644 $file ${hdrdest}/${file}
+	done
+	for file in $(find arch/${_arch} -name module.lds -o -name Kbuild.platforms -o -name Platform); do
+		mkdir -p ${hdrdest}/$(dirname $file)
+		install -Dm644 $file ${hdrdest}/${file}
+	done
 	mkdir -p ${hdrdest}/include
 
 	# Remove firmware stuff provided by the "linux-firmware" pkg.
 	rm -rf ${DESTDIR}/usr/lib/firmware
 
-	for i in acpi asm-generic config crypto drm generated linux math-emu \
-		media net pcmcia scsi sound trace uapi video xen; do
+	for i in acpi asm-generic clocksource config crypto drm generated linux \
+		math-emu media net pcmcia scsi sound trace uapi video xen; do
 		[ -d include/$i ] && cp -a include/$i ${hdrdest}/include
 	done
 
 	cd ${wrksrc}
+	# Remove helper binaries built for host,
+	# if generated files from the scripts/ directory need to be included,
+	# they need to be copied to ${hdrdest} before this step
+	if [ "$CROSS_BUILD" ]; then
+		make ${makejobs} ARCH=${_arch} _mrproper_scripts
+	fi
+
 	# Copy files necessary for later builds.
 	cp Module.symvers ${hdrdest}
 	cp -a scripts ${hdrdest}
+	mkdir -p ${hdrdest}/security/selinux
+	cp -a security/selinux/include ${hdrdest}/security/selinux
+	mkdir -p ${hdrdest}/tools/include
+	cp -a tools/include/tools ${hdrdest}/tools/include
 
 	# copy arch includes for external modules
 	mkdir -p ${hdrdest}/arch/${_arch}
@@ -171,6 +190,9 @@ do_install() {
 	mkdir -p ${hdrdest}/arch/${_arch}/kernel
 	cp arch/${_arch}/Makefile ${hdrdest}/arch/${_arch}
 	cp arch/${_arch}/kernel/asm-offsets.s ${hdrdest}/arch/${_arch}/kernel
+	if [ "$_arch" = "arm64" ] ; then
+		cp -a arch/${_arch}/kernel/vdso ${hdrdest}/arch/${_arch}/kernel/
+	fi
 
 	# Add md headers
 	mkdir -p ${hdrdest}/drivers/md
@@ -188,18 +210,15 @@ do_install() {
 	mkdir -p ${hdrdest}/include/config/dvb/
 	cp include/config/dvb/*.h ${hdrdest}/include/config/dvb/
 
-	# Copy in Kconfig files
-	for i in $(find . -name "Kconfig*"); do
-		mkdir -p ${hdrdest}/$(echo $i | sed 's|/Kconfig.*||')
-		cp $i ${hdrdest}/$i
-	done
-
 	# Remove unneeded architectures
 	# (save the correct one + Kconfig and delete all others)
 	mkdir -p arch-backup
-	cp ${hdrdest}/arch/${_arch} ${hdrdest}/arch/Kconfig arch-backup/
+	cp -r ${hdrdest}/arch/${_arch} ${hdrdest}/arch/Kconfig arch-backup/
 	rm -rf ${hdrdest}/arch
 	mv arch-backup ${hdrdest}/arch
+	# Keep arch/x86/ras/Kconfig as it is needed by drivers/ras/Kconfig
+	mkdir -p ${hdrdest}/arch/x86/ras
+	cp -a arch/x86/ras/Kconfig ${hdrdest}/arch/x86/ras/Kconfig
 
 	# Compress all modules with xz to save a few MBs.
 	msg_normal "$pkgver: compressing kernel modules with gzip, please wait...\n"

--- a/srcpkgs/xbps-triggers/files/dkms
+++ b/srcpkgs/xbps-triggers/files/dkms
@@ -72,7 +72,7 @@ add_modules() {
 		fi
 		if [ ! -f ${f}/build/scripts/basic/fixdep ] ; then
 			echo -n "Building scripts for kernel-${_kver}... "
-			make -C ${f}/build scripts &> ${f}/build/make.log
+			yes "" | make -C -j$(nproc) ${f}/build scripts > ${f}/build/make.log 2>&1
 			if [ $? -eq 0 ]; then
 				echo "done."
 			else

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
 version=0.113
-revision=1
+revision=2
 archs=noarch
 bootstrap=yes
 short_desc="The XBPS triggers for Void Linux"


### PR DESCRIPTION
Thanks to @marmeladema (#8480 ,  b5fa1bd9b6ec04c20bc1fe01540295200ef552d9) (and @Hoshpak for making me aware of this commit)

(I only run an rpi3 with aarch64, so my testing is limited)
- (cross)builds for: armv6l, armv7l and aarch64.
- Boots on: aarch64.
- Compiles dkms on: aarch64 (when rpi-kernel-headers is installed manually, which we should deal with later).

@pbui