### PR TITLE
crystal: update to 0.31.1.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,10 +1,10 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.31.0
+version=0.31.1
 revision=1
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
-_bootstrapversion=0.31.0
+_bootstrapversion=0.31.1
 _bootstraprevision=1
 hostmakedepends="git llvm8"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -19,7 +19,7 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="483ffcdce30b98f89b8c6cf6e48c62652cd0450205f609e04721a37997c32486
+checksum="b4a51164763b891572492e2445d3a69b462675184ea0ccf06fcc57a070f07b80
  90f230c87cc7b94ca845e6fe34f2523edcadb562d715daaf98603edfa2a94d65"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -32,11 +32,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" e0edff85da9375178f2e5c72845b6d3eb6abc1d9e32c9033451ae4c1fc0bf09a"
+		checksum+=" 308a5891322287852ba492e6e0dcc1484af361c189525349b6b98b531c551a65"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" a451e997378bc1230241b0e40023b8f0d754fd68943c5a8e77840d4fac0c5647"
+		checksum+=" 394bfe422bd2e74b6c5a99d31dcd873ec3f25c3f06834e1dd779efa2a36d3143"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"


### PR DESCRIPTION
- Compilation was locally tested with both i686 and x86_64
- Package was locally installed on x86_64, `crystal` and `shards` work good
- Issue with multi-threading: it is not possible to compile programs with the `-Dpreview_mt` flag. As said in #14688 a patch to `gc` is required for them to work, and we will eventually not bump this package until a new release which will contain this new feature.

**Note to Crystal developers:** If you really want to enable green threads support in the `gc` package, please use [this patch](https://gist.github.com/gcat432/2f7f000624c9333483e2a5b9abfba146) and compile `gc` (I did it using `xbps-src` using the same revision and force reinstalled it: it works without issue). Good luck!