### PR TITLE
nodejs: update to 12.10.0.

### DIFF
--- a/srcpkgs/nodejs/patches/ppc32.patch
+++ b/srcpkgs/nodejs/patches/ppc32.patch
@@ -1,17 +1,19 @@
---- deps/v8/src/libsampler/sampler.cc
+--- deps/v8/src/libsampler/sampler.cc.orig
 +++ deps/v8/src/libsampler/sampler.cc
-@@ -418,9 +418,15 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {
-       reinterpret_cast<void*>(ucontext->uc_mcontext.regs->gpr[PT_R31]);
+@@ -423,10 +423,17 @@
+   state->lr = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->link);
  #else
    // Some C libraries, notably Musl, define the regs member as a void pointer
 +  #if !V8_TARGET_ARCH_32_BIT
    state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[32]);
    state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[1]);
    state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[31]);
+   state->lr = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[36]);
 +  #else
 +  state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[32]);
 +  state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[1]);
 +  state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[31]);
++  state->lr = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[36]);
 +  #endif
  #endif
  #elif V8_HOST_ARCH_S390

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -1,6 +1,6 @@
 # Template file for 'nodejs'
 pkgname=nodejs
-version=12.8.0
+version=12.10.0
 revision=1
 wrksrc="node-v${version}"
 # Need these for host v8 for torque, see https://github.com/nodejs/node/pull/21079
@@ -17,7 +17,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://nodejs.org/"
 distfiles="${homepage}/dist/v${version}/node-v${version}.tar.gz"
-checksum=6f4e4ee7bcb52f782dce5a51d6951ff87151d9504be129d68d7aff469c0f7f36
+checksum=371a3e39f1a14adbd7b37dee57641075ccfa240bd990630ff213298f16ad49b4
 
 build_options="ssl libuv http_parser icu nghttp2 cares"
 desc_option_ssl="Enable shared libressl"


### PR DESCRIPTION
12.11 is out but has a broken upsteam tarball.

32-bit ppc please test, @q66.