### PR TITLE
python-tornado: update to 5.1.1.

### DIFF
--- a/srcpkgs/python-tornado/template
+++ b/srcpkgs/python-tornado/template
@@ -1,7 +1,7 @@
 # Template file for 'python-tornado'
 pkgname=python-tornado
-version=4.5.3
-revision=2
+version=5.1.1
+revision=1
 wrksrc="tornado-${version}"
 build_style=python-module
 pycompile_module="tornado"
@@ -10,10 +10,10 @@ makedepends="python-devel python3-devel"
 depends="ca-certificates python-singledispatch python-backports_abc"
 short_desc="Python2 web framework and asynchronous networking library"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="http://www.tornadoweb.org/"
 license="Apache-2.0"
+homepage="http://www.tornadoweb.org/"
 distfiles="${PYPI_SITE}/t/tornado/tornado-${version}.tar.gz"
-checksum=6d14e47eab0e15799cf3cdcc86b0b98279da68522caace2bd7ce644287685f0a
+checksum=4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409
 
 pre_build() {
 	# use system ca-certificates


### PR DESCRIPTION
5.1.1 is the last version that supports python2.x and python3.x both.