### PR TITLE
varnish: update to 6.3.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3514,3 +3514,4 @@ libnozzle.so.1 libnozzle1-1.11_2
 libmygpo-qt5.so.1 libmygpo-qt-1.1.0_1
 libluv.so.1 libluv-1.30.1.0_1
 libarmadillo.so.9 armadillo-9.700.2_1
+libvarnishapi.so.2 libvarnishapi-6.3.0_1

--- a/srcpkgs/libvarnishapi
+++ b/srcpkgs/libvarnishapi
@@ -1,0 +1,1 @@
+varnish

--- a/srcpkgs/libvarnishapi-devel
+++ b/srcpkgs/libvarnishapi-devel
@@ -1,0 +1,1 @@
+varnish

--- a/srcpkgs/varnish/INSTALL.msg
+++ b/srcpkgs/varnish/INSTALL.msg
@@ -1,1 +1,0 @@
-varnish is no longer provided by Void Linux, and will be fully removed from the repos on 2019/04/25

--- a/srcpkgs/varnish/files/varnishd/log/run
+++ b/srcpkgs/varnish/files/varnishd/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -t varnishd -p daemon.info

--- a/srcpkgs/varnish/files/varnishd/run
+++ b/srcpkgs/varnish/files/varnishd/run
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Default options
+VARNISH_ADDR=0.0.0.0:80
+VARNISH_MGMT_ADDR=localhost:6082
+VARNISH_CONFIG=/etc/varnish/default.vcl
+VARNISH_STORAGE=malloc,64M
+VARNISH_JAIL=unix,user=_varnish,workuser=_vcache
+VARNISH_OPTIONS=
+
+[ -r ./conf ] && . ./conf
+
+exec varnishd \
+  -F \
+  ${VARNISH_ADDR:+-a "$VARNISH_ADDR"} \
+  ${VARNISH_CONFIG:+-f "$VARNISH_CONFIG"} \
+  ${VARNISH_ADDR:+-T "$VARNISH_MGMT_ADDR"} \
+  ${VARNISH_STORAGE:+-s "$VARNISH_STORAGE"} \
+  ${VARNISH_JAIL:+-j "$VARNISH_JAIL"} \
+  ${VARNISH_OPTIONS}

--- a/srcpkgs/varnish/patches/musl.patch
+++ b/srcpkgs/varnish/patches/musl.patch
@@ -1,0 +1,22 @@
+--- include/vpf.h	2016-03-03 14:40:01.000000000 +0100
++++ include/vpf.h	2018-01-11 11:45:26.521900821 +0100
+@@ -30,6 +30,8 @@
+ #ifndef VPF_H_INCLUDED
+ #define VPF_H_INCLUDED
+ 
++#include <sys/types.h>
++
+ struct vpf_fh;
+ 
+ struct vpf_fh *VPF_Open(const char *path, mode_t mode, pid_t *pidptr);
+--- include/vsb.h	2017-11-14 14:39:22.000000000 +0100
++++ include/vsb.h	2018-01-11 11:48:15.505912873 +0100
+@@ -31,6 +31,8 @@
+ #ifndef VSB_H_INCLUDED
+ #define VSB_H_INCLUDED
+ 
++#include <sys/types.h>
++
+ /*
+  * Structure definition
+  */

--- a/srcpkgs/varnish/template
+++ b/srcpkgs/varnish/template
@@ -1,9 +1,66 @@
 # Template file for 'varnish'
 pkgname=varnish
-version=6.1.1
-revision=3
-archs=noarch
-build_style=meta
-short_desc="A fast caching HTTP reverse proxy (removed package)"
-license="metapackage"
+version=6.3.0
+revision=1
+build_style=gnu-configure
+configure_args="--cache-file=config.void --disable-static $(vopt_enable pcrejit pcre-jit)"
+hostmakedepends="pkg-config python3 python3-docutils python3-Sphinx"
+makedepends="pcre-devel readline-devel"
+short_desc="Fast caching HTTP reverse proxy"
+maintainer="Noel Cower <ncower@gmail.com>"
+license="BSD-2-Clause"
 homepage="https://varnish-cache.org/"
+distfiles="https://varnish-cache.org/_downloads/${pkgname}-${version}.tgz"
+checksum=95ccdec5f1dcba8b41d24e685b3f2379fbc6b9701d106cc78011d4d09a73947f
+lib32disabled=yes
+
+build_options="pcrejit"
+
+conf_files="/etc/varnish/default.vcl"
+make_dirs="/var/lib/varnish 0750 _varnish _varnish
+ /var/log/varnish 0750 _varnish _varnish"
+
+system_accounts="_varnish _vcache"
+_varnish_homedir="/var/lib/varnish"
+_vcache_pgroup="_varnish"
+
+if [ yes = "$(vopt_if pcrejit yes)" ]; then
+	# Don't permit cross builds if pcrejit is set.
+	nocross="Cannot run test program when cross compiling (PCRE_JIT)"
+elif [ "${XBPS_MACHINE%-musl}" != "${XBPS_TARGET_MACHINE%-musl}" ]; then
+	# Mark builds with different architectures as nocross.
+	nocross="Host and target architectures must be the same to run the program during build"
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl)
+		configure_args+=" --without-jemalloc"
+		makedepends+=" libexecinfo-devel"
+		;;
+	*)
+		makedepends+=" jemalloc-devel"
+		;;
+esac
+
+post_install() {
+	vinstall etc/example.vcl 644 etc/varnish default.vcl
+	vsv varnishd
+	vlicense LICENSE
+}
+
+libvarnishapi_package() {
+	short_desc+=" - API runtime library"
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+	}
+}
+libvarnishapi-devel_package() {
+	depends="libvarnishapi>=${version}_${revision}"
+	short_desc+=" - API development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove usr/share/man/man3
+	}
+}

--- a/srcpkgs/varnish/update
+++ b/srcpkgs/varnish/update
@@ -1,0 +1,1 @@
+site="https://varnish-cache.org/releases/index.html"


### PR DESCRIPTION
Adds Varnish back to packages.

  - Don't use jemalloc on -musl builds. This appears to be leading to
    the segfault described in the earlier broken= message for those.
    Noticed the segfault doesn't happen in Alpine's build, and the only
    major difference there is that they disable jemalloc (because they
    don't support it, but given that it's the only difference, it was
    worth disabling to get builds working).

    jemalloc remains enabled for glibc.

  - Disable pcrejit by default. There is a build option to turn it on,
    but this is disabled by default for cross builds. We could add
    a check for target machine == host machine and enable it on those
    by default if desired, but the build option may be easier. Could
    also hack around the config cache, but I'm less confident in JIT
    availability on ARM and such than I am basic socket definitions.

  - The package originally included a varnish-vcl-reload file in the
    files directory. This has been removed because it is, as far as
    I can tell, unused.

  - Rewrite run file. Old one doesn't work at all, no reason to
    preserve it.

  - Add _varnish and _vcache system users for default jail argument in
    run file. These share a system group.