### PR TITLE
unbound: update to 1.9.4.

### DIFF
--- a/srcpkgs/unbound/template
+++ b/srcpkgs/unbound/template
@@ -1,6 +1,6 @@
 # Template file for 'unbound'
 pkgname=unbound
-version=1.9.3
+version=1.9.4
 revision=1
 build_style=gnu-configure
 configure_args="--with-libevent --with-conf-file=/etc/unbound/unbound.conf
@@ -16,7 +16,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause"
 homepage="https://unbound.net/"
 distfiles="https://unbound.net/downloads/${pkgname}-${version}.tar.gz"
-checksum=1b55dd9170e4bfb327fb644de7bbf7f0541701149dff3adf1b63ffa785f16dfa
+checksum=3d3e25fb224025f0e732c7970e5676f53fd1764c16d6a01be073a13e42954bb0
 system_accounts="_unbound"
 
 post_install() {
@@ -37,4 +37,3 @@ unbound-devel_package() {
 		vmove usr/share/man/man3
 	}
 }
-


### PR DESCRIPTION
Fixes [CVE-2019-16866](https://nlnetlabs.nl/projects/unbound/security-advisories/#vulnerability-in-parsing-notify-queries)