### PR TITLE
jbig2dec: add patch to restore ABI compatibility

### DIFF
--- a/srcpkgs/jbig2dec/patches/2002_abi_compat.patch
+++ b/srcpkgs/jbig2dec/patches/2002_abi_compat.patch
@@ -1,0 +1,24 @@
+Description: Restore ABI compatibility
+Author: Julien Cristau <jcristau@debian.org>
+Source: https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=940605;filename=0001-Restore-ABI-compatibility-closes-940605.patch;msg=21
+Bug-Debian: https://bugs.debian.org/940605
+Forwarded: no
+Last-Update: 2019-09-19
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- jbig2.c
++++ jbig2.c
+@@ -99,6 +99,13 @@
+     return -1;
+ }
+
++#undef jbig2_ctx_new
++Jbig2Ctx *
++jbig2_ctx_new(Jbig2Allocator *allocator, Jbig2Options options, Jbig2GlobalCtx *global_ctx, Jbig2ErrorCallback error_callback, void *error_callback_data)
++{
++    return jbig2_ctx_new_imp((allocator), (options), (global_ctx), (error_callback), (error_callback_data), JBIG2_VERSION_MAJOR, JBIG2_VERSION_MINOR);
++}
++
+ Jbig2Ctx *
+ jbig2_ctx_new_imp(Jbig2Allocator *allocator, Jbig2Options options, Jbig2GlobalCtx *global_ctx, Jbig2ErrorCallback error_callback, void *error_callback_data, int jbig2_version_major, int jbig2_version_minor)
+ {

--- a/srcpkgs/jbig2dec/template
+++ b/srcpkgs/jbig2dec/template
@@ -1,7 +1,7 @@
 # Template file for 'jbig2dec'
 pkgname=jbig2dec
 version=0.17
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 makedepends="libpng-devel"


### PR DESCRIPTION
jbig2dec 0.17 breaks ABI resulting in
`mupdf: symbol lookup error: mupdf: undefined symbol: jbig2_ctx_new`
Debian bugreport: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=940605
Patch taken from Debian's Patch Tracker.