### PR TITLE
sqlite-replication: update to 3.29.0

### DIFF
--- a/srcpkgs/sqlite-replication/template
+++ b/srcpkgs/sqlite-replication/template
@@ -1,6 +1,6 @@
 # Template file for 'sqlite-replication'
 pkgname=sqlite-replication
-version=3.28.0
+version=3.29.0
 revision=1
 wrksrc="sqlite-version-${version}-replication3"
 build_style=gnu-configure
@@ -12,7 +12,7 @@ maintainer="Cameron Nemo <camerontnorman@gmail.com>"
 license="Public Domain"
 homepage="https://github.com/CanonicalLtd/sqlite"
 distfiles="${homepage}/archive/version-${version}+replication3.tar.gz"
-checksum=3e52fb92ef8f66ba640145941f05aabbffb4f422a0b9a42a97b6806e2c3c6812
+checksum=516ae04b7bef44b6de71fed99f41f1f11afc781495145c7bccf3c1e1073c37be
 replaces="sqlite>=3.8.11.1_3"
 provides="sqlite-${version}_${revision}"
 shlib_provides="libsqlite3.so"


### PR DESCRIPTION
This fixes an issue with lxd where sqlite-replication conflicts with
sqlite.  Special thanks to jsbronder in IRC for pointing this out.