### PR TITLE
sqlite-replication: use upstream manifest.

### DIFF
--- a/srcpkgs/sqlite-replication/template
+++ b/srcpkgs/sqlite-replication/template
@@ -1,10 +1,10 @@
 # Template file for 'sqlite-replication'
 pkgname=sqlite-replication
 version=3.29.0
-revision=1
+revision=2
 wrksrc="sqlite-version-${version}-replication3"
 build_style=gnu-configure
-configure_args="--enable-wal-replication --enable-threadsafe --enable-dynamic-extensions --enable-fts5"
+configure_args="--enable-replication --enable-threadsafe --enable-dynamic-extensions --enable-fts5"
 hostmakedepends="tcl"
 makedepends="libedit-devel"
 short_desc="Replication Enabled SQL Database Engine in a C Library"
@@ -26,9 +26,6 @@ CFLAGS+=" -DHAVE_FDATASYNC"
 disable_parallel_build=yes
 
 pre_configure() {
-	printf -- "D 2019-03-09T15:45:46\n" > manifest
-	printf -- "8250984a368079bb1838d48d99f8c1a6282e00bc" > manifest.uuid
-
 	sed -i -e 's/ -ltinfo//g' configure
 }
 


### PR DESCRIPTION
Previously, I was generating this manually
(it should be updated on each version bump)
Recently, Free included a generated manifest
for release commits.