### PR TITLE
New package: fake-hwclock-0.11

### DIFF
--- a/srcpkgs/fake-hwclock/files/fake-hwclock/finish
+++ b/srcpkgs/fake-hwclock/files/fake-hwclock/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec fake-hwclock save

--- a/srcpkgs/fake-hwclock/files/fake-hwclock/run
+++ b/srcpkgs/fake-hwclock/files/fake-hwclock/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+exec 1>&2
+[ -r /etc/default/fake-hwclock ] && . /etc/default/fake-hwclock
+fake-hwclock load $FORCE || exit 1
+exec chpst -b fake-hwclock pause

--- a/srcpkgs/fake-hwclock/patches/manpage.patch
+++ b/srcpkgs/fake-hwclock/patches/manpage.patch
@@ -1,0 +1,34 @@
+--- o.fake-hwclock.8	2019-10-03 01:19:44.542744670 -0400
++++ fake-hwclock.8	2019-10-03 01:21:03.241032055 -0400
+@@ -1,4 +1,4 @@
+-.TH FAKE-HWCLOCK 8 "1 October 2014" Debian
++.TH FAKE-HWCLOCK 8 "4 October 2019" Linux
+ .SH NAME
+ fake-hwclock \- Control fake hardware clock
+ .SH SYNOPSIS
+@@ -23,6 +23,11 @@
+ case, in which case it is possible to modify the init system
+ configuration to move things earlier/later as appropriate.
+
++This program was originally written for Debian, which uses an init system
++different from \fBrunit\fP. To add \fBfake-hwclock\fP as a service, the system
++administrator must link the directory \fI/etc/sv/fake-hwclock\fP to
++\fI/var/service\fP.
++
+ .SH DESCRIPTION
+ \fBfake-hwclock\fP sets and queries a fake "hardware clock" which stores the
+ time in a file. This program may be run by the system administrator
+@@ -47,11 +52,8 @@
+ \fB/etc/fake-hwclock.data\fR
+ The file used to store the time
+ .TP
+-\fB/etc/init.d/fake-hwclock\fR
+-The init script used to run fake-hwclock on startup and shutdown
+-.TP
+-\fB/lib/systemd/system/fake-hwclock.service\fR
+-systemd service used to run fake-hwclock on startup and shutdown
++\fB/etc/sv/fake-hwclock/\fR
++runit service used to run fake-hwclock on startup and shutdown
+ .TP
+ \fB/etc/default/fake-hwclock\fR
+ Settings file for the init script.

--- a/srcpkgs/fake-hwclock/template
+++ b/srcpkgs/fake-hwclock/template
@@ -1,0 +1,22 @@
+# Template file for 'fake-hwclock'
+pkgname=fake-hwclock
+version=0.11
+revision=1
+archs=noarch
+wrksrc=git
+short_desc="Save/restore system clock on machines without working RTC hardware"
+maintainer="Ivan Gonzalez Polanco <ivan14polanco@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://tracker.debian.org/pkg/fake-hwclock"
+distfiles="${DEBIAN_SITE}/main/f/${pkgname}/${pkgname}_${version}.tar.gz"
+checksum="58e29ff272a8e8b40ab972c49f82fd8fb6ef69a7fdde5f84292f800b53ea29ce"
+
+conf_files="/etc/default/fake-hwclock"
+
+do_install() {
+	vbin fake-hwclock
+	vinstall etc/default/fake-hwclock 644 etc/default
+	vinstall debian/fake-hwclock.cron.hourly 755 etc/cron.hourly fake-hwclock
+	vman fake-hwclock.8
+	vsv fake-hwclock
+}


### PR DESCRIPTION
Hello! I closed the previous pull request (#14985) and I'm making a new one
(sorry if it's wrong, I'm not used to pull requests) with some fixes so:
1. The template file now passes `xlint`'s test.
2. The service now behaves more like the systemd original one (that is, a
   "oneshot" service)

Thanks to maldridge, pulux, and bobertlo on IRC for their help and guidance!

Brief description of the package:

Save/restore system clock on machines without working RTC hardware.

Some machines don't have a working Real Time Clock (RTC) unit, or no driver for
said hardware. fake-hwclock is a simple set of scripts to save the kernel's
current clock periodically (including at shutdown) and restore it at boot so
that the system clock keeps at least close to the real time. This will stop
some of the problems that may be caused by a system believing it has travelled
in time back to 1970.

This is originally a Debian package, and as Debian uses systemd as it's init
and service manager, most of the init and service instructions were useless for
Void.

I took the liberty of adapting the scripts and patching the manpage with the
instructions to make fake-hwclock execute on boot and shutdown in Void Linux
(or at least distributions that use runit as init), all while being as
faithful to upstream as possible.
