### PR TITLE
k3s: add services, missing binaries.

### DIFF
--- a/srcpkgs/k3s/files/k3s-agent/log/run
+++ b/srcpkgs/k3s/files/k3s-agent/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -t k3s-agent

--- a/srcpkgs/k3s/files/k3s-agent/run
+++ b/srcpkgs/k3s/files/k3s-agent/run
@@ -1,0 +1,10 @@
+#!/bin/sh
+set --
+[ -r /etc/k3s/config ] && . /etc/k3s/config
+[ -r conf ] && . ./conf
+if [ 0 = $# ]; then
+  set -- \
+    ${K3S_SERVER:+--server="${K3S_SERVER}"} \
+    ${K3S_TOKEN:+--token="${K3S_TOKEN}"}
+fi
+exec k3s agent ${K3S_OPTIONS} ${K3S_AGENT_OPTIONS} "$@"

--- a/srcpkgs/k3s/files/k3s-server/log/run
+++ b/srcpkgs/k3s/files/k3s-server/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -t k3s-server

--- a/srcpkgs/k3s/files/k3s-server/run
+++ b/srcpkgs/k3s/files/k3s-server/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+set --
+[ -r /etc/k3s/config ] && . /etc/k3s/config
+[ -r ./conf ] && . ./conf
+exec k3s server ${K3S_OPTIONS} ${K3S_SERVER_OPTIONS} "$@"

--- a/srcpkgs/k3s/template
+++ b/srcpkgs/k3s/template
@@ -1,13 +1,65 @@
 # Template file for 'k3s'
 pkgname=k3s
 version=0.9.1
-revision=1
+revision=2
+create_wrksrc=yes
+build_wrksrc="${pkgname}-${version}"
 build_style=go
 go_import_path="github.com/rancher/k3s"
-hostmakedepends="git"
-short_desc="Kubernetes on sedatives"
+hostmakedepends="git pkg-config"
+makedepends="libseccomp-devel"
+short_desc="Lightweight Kubernetes"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
-homepage="https://github.com/rancher/k3s"
-distfiles="https://github.com/rancher/k3s/archive/v${version}.tar.gz"
-checksum=dee3ddfcdb61f292bcfe778d7677e436309511e15c6bbdd326ebec42ea41bbac
+homepage="https://k3s.io"
+# _traefik_* variables' values from scripts/download in source distfile
+_traefik_version="1.77.1"
+_traefik_file="traefik-${_traefik_version}.tgz"
+distfiles="https://${go_import_path}/archive/v${version}.tar.gz
+ https://kubernetes-charts.storage.googleapis.com/${_traefik_file}"
+checksum="dee3ddfcdb61f292bcfe778d7677e436309511e15c6bbdd326ebec42ea41bbac
+ 15dd78d136d7c9bae7144072052ef6cd12821ae081a7c085f145d834d96c5d5c"
+skip_extraction="${_traefik_file}"
+conflicts="kubernetes"
+
+_git_commit=755bd1c63bafe80f9b5fe8d4bba527f988625364
+
+pre_build() {
+	# Modify version.sh to use template variables' values.
+	vsed -i scripts/version.sh -e '
+		s@^COMMIT=.*@COMMIT='"${_git_commit}"'@;
+		s@^GIT_TAG=.*@GIT_TAG=v'"${version}"'@
+		'
+	# Remove -s (strip) and -w (no dwarf) linker arguments.
+	vsed -i scripts/build -e 's@-w -s@@'
+	# Remove BIN_SUFFIX, nullify GOARCH for go generate. The latter
+	# is needed because 'go run' will try to run binaries for the
+	# target given by GOOS/GOARCH. The -x prints what 'go generate'
+	# is executing. CGO_ENABLED is set to 0 because cross builds
+	# won't necessarily be able to handle 64-bit builds performed by
+	# 'go run'.
+	vsed -i scripts/package-cli -e '
+		s@BIN_SUFFIX="[^"]\+"@BIN_SUFFIX=""@;
+		s@^go generate$@CGO_ENABLED=0 GOARCH= & -x@;
+		s@-w -s@@g
+		'
+
+	# Recreate behavior of scripts/download minus downloading
+	# anything or having anything to do with busybox.
+	mkdir -p bin
+
+	mkdir -p build/static/charts
+	cp ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_traefik_file} build/static/charts/${_traefik_file}
+}
+
+do_build() {
+	scripts/build
+	scripts/package-cli
+}
+
+do_install() {
+	vbin dist/artifacts/k3s
+	vbin dist/artifacts/hyperkube
+	vsv k3s-server
+	vsv k3s-agent
+}


### PR DESCRIPTION
- Fix version string in 'k3s -v' output to match release builds.

- Adds the missing hyperkube binary. This conflicts with kubernetes, so
  it may be an issue for folks who want to install both k3s and
  kubernetes at the same time. Not sure who those folks are, but
  I guess it could be a subpackage too.

- Fixes k3s builds to include kubectl and crictl (previous revisions
  included the CLI commands in the usage output but could not be used).

- Add service files for k3s-agent and k3s-server.

- Fetch Traefik manifests for codegen bits of the build.

- Update short_desc to match k3s description.

- Set homepage to k3s.io.