### PR TITLE
New package: git-ftp-1.5.2

### DIFF
--- a/srcpkgs/git-ftp/template
+++ b/srcpkgs/git-ftp/template
@@ -1,0 +1,24 @@
+# Template file for 'git-ftp'
+pkgname=git-ftp
+version=1.5.2
+revision=1
+archs="noarch"
+makedepends="pandoc"
+depends="bash"
+short_desc="Uploads files GIT-style via FTP"
+maintainer="Nathan Owens <ndowens04@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://git-ftp.github.io/"
+distfiles="https://github.com/git-ftp/git-ftp/archive/$version.tar.gz"
+checksum=a6bf52f6f1d30c4d8f52fd0fbd61dc9f32e66099e3e9c4994bec65094305605b
+
+do_build() {
+	cd $wrksrc/man
+	pandoc -s -w man git-ftp.1.md -o ${wrksrc}/man/git-ftp.1
+}
+
+do_install() {
+	cd $wrksrc
+	vbin git-ftp
+	vman man/git-ftp.1
+}


### PR DESCRIPTION
Allows one to use GIT-style uploading of files through FTP.
I didn't use the included Makefile in src, as it did not respect make_install_args or even setting manually. 

