### PR TITLE
elogind: disable utmp for musl

### DIFF
--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,7 +1,7 @@
 # Template file for 'elogind'
 pkgname=elogind
 version=241.3
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
  -Drootlibexecdir=/usr/libexec/elogind -Dreboot-path=/usr/bin/reboot
@@ -19,6 +19,10 @@ homepage="https://github.com/elogind/elogind"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
 checksum=d6a465479c8a629d49ea9374f6199b0c60e7e42eade0fcd8265fc37085386365
 conf_files="/etc/elogind/logind.conf"
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	configure_args+=" -Dutmp=false"
+fi
 
 pre_check() {
 	# test-fs-util checks for /etc/machine-id/foo and expects ENOTDIR


### PR DESCRIPTION
Since musl only stubs out utmp, elogind emits this warning on startup:

    "elogind[1044]: Failed to set utmp path to /dev/null/utmp: Not supported"

This patch silences that warning by building elogind on musl without utmp log handling support.

I'm not sure if this is the best method of checking for musl and updating the configure line. This is my second void contribution. I grepped for other uses of `XBPS_TARGET_LIBC` as a guide.