### PR TITLE
llvm8, llvm9: secureplt patch fixes for ppc/ppc-musl

### DIFF
--- a/srcpkgs/llvm8/files/patches/llvm/llvm-003-secureplt.patch
+++ b/srcpkgs/llvm8/files/patches/llvm/llvm-003-secureplt.patch
@@ -1,10 +1,11 @@
-Partially taken from Adélie Linux, even-more-secure-plt.patch
---- a/lib/Target/PowerPC/PPCSubtarget.cpp
-+++ b/lib/Target/PowerPC/PPCSubtarget.cpp
+Taken from Adélie Linux.
+
+--- llvm/lib/Target/PowerPC/PPCSubtarget.cpp
++++ llvm/lib/Target/PowerPC/PPCSubtarget.cpp
 @@ -138,6 +138,10 @@ void PPCSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
    if (isDarwin())
      HasLazyResolverStubs = true;
- 
+
 +  // Force SecurePlt for all 32-bit Linux targets
 +  if (isTargetLinux() && !IsPPC64)
 +    SecurePlt = true;
@@ -12,22 +13,141 @@ Partially taken from Adélie Linux, even-more-secure-plt.patch
    if (HasSPE && IsPPC64)
      report_fatal_error( "SPE is only supported for 32-bit targets.\n", false);
    if (HasSPE && (HasAltivec || HasQPX || HasVSX || HasFPU))
---- a/lib/Target/PowerPC/PPCTargetMachine.cpp
-+++ b/lib/Target/PowerPC/PPCTargetMachine.cpp
-@@ -218,6 +218,10 @@ static Reloc::Model getEffectiveRelocModel(const Triple &TT,
-   if (TT.getArch() == Triple::ppc64)
-     return Reloc::PIC_;
+--- llvm/lib/Target/PowerPC/PPCISelLowering.cpp
++++ llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+@@ -2769,8 +2769,12 @@ SDValue PPCTargetLowering::LowerGlobalTLSAddress(SDValue Op,
+       SDValue GOTReg = DAG.getRegister(PPC::X2, MVT::i64);
+       GOTPtr = DAG.getNode(PPCISD::ADDIS_GOT_TPREL_HA, dl,
+                            PtrVT, GOTReg, TGA);
+-    } else
+-      GOTPtr = DAG.getNode(PPCISD::PPC32_GOT, dl, PtrVT);
++    } else {
++      if (isPositionIndependent())
++        GOTPtr = DAG.getNode(PPCISD::PPC32_PICGOT, dl, PtrVT);
++      else
++        GOTPtr = DAG.getNode(PPCISD::PPC32_GOT, dl, PtrVT);
++    }
+     SDValue TPOffset = DAG.getNode(PPCISD::LD_GOT_TPREL_L, dl,
+                                    PtrVT, TGA, GOTPtr);
+     return DAG.getNode(PPCISD::ADD_TLS, dl, PtrVT, TPOffset, TGATLS);
+@@ -4941,7 +4945,8 @@ PrepareCall(SelectionDAG &DAG, SDValue &Callee, SDValue &InFlag, SDValue &Chain,
+   if (auto *G = dyn_cast<GlobalAddressSDNode>(Callee))
+     GV = G->getGlobal();
+   bool Local = TM.shouldAssumeDSOLocal(*Mod, GV);
+-  bool UsePlt = !Local && Subtarget.isTargetELF() && !isPPC64;
++  bool UsePlt = !Local && Subtarget.isTargetELF() && !isPPC64 &&
++                TM.isPositionIndependent();
  
-+  // We force SecurePlt on 32-bit ppc linux which requires PIC
-+  if (TT.isOSLinux() && (TT.getArch() == Triple::ppc))
-+    return Reloc::PIC_;
-+
-   // Rest are static by default.
-   return Reloc::Static;
+   if (isFunctionGlobalAddress(Callee)) {
+     GlobalAddressSDNode *G = cast<GlobalAddressSDNode>(Callee);
+--- llvm/test/CodeGen/PowerPC/2008-10-28-f128-i32.ll
++++ llvm/test/CodeGen/PowerPC/2008-10-28-f128-i32.ll
+@@ -62,7 +62,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 328(1)
+ ; CHECK-NEXT:    fmr 1, 31
+ ; CHECK-NEXT:    fmr 2, 30
+-; CHECK-NEXT:    bl __gcc_qmul@PLT
++; CHECK-NEXT:    bl __gcc_qmul
+ ; CHECK-NEXT:    lis 3, 16864
+ ; CHECK-NEXT:    stfd 1, 280(1)
+ ; CHECK-NEXT:    fmr 29, 1
+@@ -84,7 +84,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 360(1)
+ ; CHECK-NEXT:    lfd 1, 352(1)
+ ; CHECK-NEXT:    lfd 2, 344(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    mffs 0
+ ; CHECK-NEXT:    mtfsb1 31
+ ; CHECK-NEXT:    lis 3, .LCPI0_1@ha
+@@ -117,7 +117,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:  .LBB0_5: # %bb1
+ ; CHECK-NEXT:    li 4, 0
+ ; CHECK-NEXT:    mr 3, 30
+-; CHECK-NEXT:    bl __floatditf@PLT
++; CHECK-NEXT:    bl __floatditf
+ ; CHECK-NEXT:    lis 3, 17392
+ ; CHECK-NEXT:    stfd 1, 208(1)
+ ; CHECK-NEXT:    fmr 29, 1
+@@ -140,7 +140,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 232(1)
+ ; CHECK-NEXT:    lfd 1, 224(1)
+ ; CHECK-NEXT:    lfd 2, 216(1)
+-; CHECK-NEXT:    bl __gcc_qadd@PLT
++; CHECK-NEXT:    bl __gcc_qadd
+ ; CHECK-NEXT:    blt 2, .LBB0_7
+ ; CHECK-NEXT:  # %bb.6: # %bb1
+ ; CHECK-NEXT:    fmr 2, 28
+@@ -163,7 +163,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    stw 3, 248(1)
+ ; CHECK-NEXT:    lfd 3, 256(1)
+ ; CHECK-NEXT:    lfd 4, 248(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    stfd 2, 176(1)
+ ; CHECK-NEXT:    fcmpu 0, 2, 27
+ ; CHECK-NEXT:    stfd 1, 168(1)
+@@ -205,7 +205,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 72(1)
+ ; CHECK-NEXT:    lfd 1, 64(1)
+ ; CHECK-NEXT:    lfd 2, 56(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    mffs 0
+ ; CHECK-NEXT:    mtfsb1 31
+ ; CHECK-NEXT:    lis 3, .LCPI0_2@ha
+@@ -260,7 +260,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 136(1)
+ ; CHECK-NEXT:    lfd 1, 128(1)
+ ; CHECK-NEXT:    lfd 2, 120(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    mffs 0
+ ; CHECK-NEXT:    mtfsb1 31
+ ; CHECK-NEXT:    lis 3, .LCPI0_0@ha
+--- llvm/test/CodeGen/PowerPC/2010-02-12-saveCR.ll
++++ llvm/test/CodeGen/PowerPC/2010-02-12-saveCR.ll
+@@ -11,7 +11,7 @@ entry:
+ ; CHECK-DAG: ori [[T2:[0-9]+]], [[T2]], 34492
+ ; CHECK-DAG: stwx [[T1]], 1, [[T2]]
+ ; CHECK-DAG: addi 3, 1, 28
+-; CHECK: bl bar@PLT
++; CHECK: bl bar
+   %x = alloca [100000 x i8]                       ; <[100000 x i8]*> [#uses=1]
+   %"alloca point" = bitcast i32 0 to i32          ; <i32> [#uses=0]
+   %x1 = bitcast [100000 x i8]* %x to i8*          ; <i8*> [#uses=1]
+--- llvm/test/CodeGen/PowerPC/available-externally.ll
++++ llvm/test/CodeGen/PowerPC/available-externally.ll
+@@ -14,7 +14,7 @@ target triple = "powerpc-unknown-linux-gnu"
+ define i32 @foo(i64 %x) nounwind {
+ entry:
+ ; STATIC: foo:
+-; STATIC: bl exact_log2@PLT
++; STATIC: bl exact_log2
+ ; STATIC: blr
+ 
+ ; PIC: foo:
+--- llvm/test/CodeGen/PowerPC/stubs.ll
++++ llvm/test/CodeGen/PowerPC/stubs.ll
+@@ -6,4 +6,4 @@ entry:
  }
-
---- a/lib/Target/PowerPC/InstPrinter/PPCInstPrinter.cpp
-+++ b/lib/Target/PowerPC/InstPrinter/PPCInstPrinter.cpp
+ 
+ ; CHECK: test1:
+-; CHECK: bl __floatditf@PLT
++; CHECK: bl __floatditf
+--- llvm/test/CodeGen/PowerPC/umulo-128-legalisation-lowering.ll
++++ llvm/test/CodeGen/PowerPC/umulo-128-legalisation-lowering.ll
+@@ -72,7 +72,7 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
+ ; PPC32-NEXT: mr 28, 9
+ ; PPC32-NEXT: mr 23, 6
+ ; PPC32-NEXT: mr 24, 5
+-; PPC32-NEXT: bl __multi3@PLT
++; PPC32-NEXT: bl __multi3
+ ; PPC32-NEXT: mr 7, 4
+ ; PPC32-NEXT: mullw 4, 24, 30
+ ; PPC32-NEXT: mullw 8, 29, 23
+--- llvm/lib/Target/PowerPC/InstPrinter/PPCInstPrinter.cpp
++++ llvm/lib/Target/PowerPC/InstPrinter/PPCInstPrinter.cpp
 @@ -442,13 +442,22 @@
    // On PPC64, VariantKind is VK_None, but on PPC32, it's VK_PLT, and it must
    // come at the _end_ of the expression.
@@ -55,8 +175,8 @@ Partially taken from Adélie Linux, even-more-secure-plt.patch
  }
  
  /// showRegistersWithPercentPrefix - Check if this register name should be
---- a/lib/Target/PowerPC/PPCAsmPrinter.cpp
-+++ b/lib/Target/PowerPC/PPCAsmPrinter.cpp
+--- llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
++++ llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
 @@ -487,8 +487,14 @@
    if (!Subtarget->isPPC64() && !Subtarget->isDarwin() &&
        isPositionIndependent())
@@ -73,8 +193,8 @@ Partially taken from Adélie Linux, even-more-secure-plt.patch
    const MachineOperand &MO = MI->getOperand(2);
    const GlobalValue *GValue = MO.getGlobal();
    MCSymbol *MOSymbol = getSymbol(GValue);
---- a/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
-+++ b/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+--- llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
++++ llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
 @@ -4054,7 +4054,20 @@
      if (trySETCC(N))
        return;

--- a/srcpkgs/llvm8/template
+++ b/srcpkgs/llvm8/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm8'
 pkgname=llvm8
 version=8.0.1
-revision=1
+revision=2
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="

--- a/srcpkgs/llvm9/files/patches/llvm/llvm-003-secureplt.patch
+++ b/srcpkgs/llvm9/files/patches/llvm/llvm-003-secureplt.patch
@@ -1,25 +1,130 @@
---- a/lib/Target/PowerPC/PPCSubtarget.cpp
-+++ b/lib/Target/PowerPC/PPCSubtarget.cpp
+--- llvm/lib/Target/PowerPC/PPCSubtarget.cpp
++++ llvm/lib/Target/PowerPC/PPCSubtarget.cpp
 @@ -145,8 +145,7 @@ void PPCSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
    if (isDarwin())
      HasLazyResolverStubs = true;
- 
+
 -  if (TargetTriple.isOSNetBSD() || TargetTriple.isOSOpenBSD() ||
 -      TargetTriple.isMusl())
 +  if (TargetTriple.isOSNetBSD() || TargetTriple.isOSOpenBSD() || isTargetLinux())
      SecurePlt = true;
- 
+
    if (HasSPE && IsPPC64)
---- a/lib/Target/PowerPC/PPCTargetMachine.cpp
-+++ b/lib/Target/PowerPC/PPCTargetMachine.cpp
-@@ -234,6 +234,10 @@ static Reloc::Model getEffectiveRelocModel(const Triple &TT,
-   if (TT.getArch() == Triple::ppc64)
-     return Reloc::PIC_;
+--- llvm/lib/Target/PowerPC/PPCISelLowering.cpp
++++ llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+@@ -4941,7 +4945,8 @@ PrepareCall(SelectionDAG &DAG, SDValue &Callee, SDValue &InFlag, SDValue &Chain,
+   if (auto *G = dyn_cast<GlobalAddressSDNode>(Callee))
+     GV = G->getGlobal();
+   bool Local = TM.shouldAssumeDSOLocal(*Mod, GV);
+-  bool UsePlt = !Local && Subtarget.isTargetELF() && !isPPC64;
++  bool UsePlt = !Local && Subtarget.isTargetELF() && !isPPC64 &&
++                TM.isPositionIndependent();
  
-+  // We force SecurePlt on 32-bit ppc linux which requires PIC
-+  if (TT.isOSLinux() && (TT.getArch() == Triple::ppc))
-+    return Reloc::PIC_;
-+
-   // Rest are static by default.
-   return Reloc::Static;
+   if (isFunctionGlobalAddress(Callee)) {
+     GlobalAddressSDNode *G = cast<GlobalAddressSDNode>(Callee);
+--- llvm/test/CodeGen/PowerPC/2008-10-28-f128-i32.ll
++++ llvm/test/CodeGen/PowerPC/2008-10-28-f128-i32.ll
+@@ -62,7 +62,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 328(1)
+ ; CHECK-NEXT:    fmr 1, 31
+ ; CHECK-NEXT:    fmr 2, 30
+-; CHECK-NEXT:    bl __gcc_qmul@PLT
++; CHECK-NEXT:    bl __gcc_qmul
+ ; CHECK-NEXT:    lis 3, 16864
+ ; CHECK-NEXT:    stfd 1, 280(1)
+ ; CHECK-NEXT:    fmr 29, 1
+@@ -84,7 +84,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 360(1)
+ ; CHECK-NEXT:    lfd 1, 352(1)
+ ; CHECK-NEXT:    lfd 2, 344(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    mffs 0
+ ; CHECK-NEXT:    mtfsb1 31
+ ; CHECK-NEXT:    lis 3, .LCPI0_1@ha
+@@ -117,7 +117,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:  .LBB0_5: # %bb1
+ ; CHECK-NEXT:    li 4, 0
+ ; CHECK-NEXT:    mr 3, 30
+-; CHECK-NEXT:    bl __floatditf@PLT
++; CHECK-NEXT:    bl __floatditf
+ ; CHECK-NEXT:    lis 3, 17392
+ ; CHECK-NEXT:    stfd 1, 208(1)
+ ; CHECK-NEXT:    fmr 29, 1
+@@ -140,7 +140,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 232(1)
+ ; CHECK-NEXT:    lfd 1, 224(1)
+ ; CHECK-NEXT:    lfd 2, 216(1)
+-; CHECK-NEXT:    bl __gcc_qadd@PLT
++; CHECK-NEXT:    bl __gcc_qadd
+ ; CHECK-NEXT:    blt 2, .LBB0_7
+ ; CHECK-NEXT:  # %bb.6: # %bb1
+ ; CHECK-NEXT:    fmr 2, 28
+@@ -163,7 +163,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    stw 3, 248(1)
+ ; CHECK-NEXT:    lfd 3, 256(1)
+ ; CHECK-NEXT:    lfd 4, 248(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    stfd 2, 176(1)
+ ; CHECK-NEXT:    fcmpu 0, 2, 27
+ ; CHECK-NEXT:    stfd 1, 168(1)
+@@ -205,7 +205,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 72(1)
+ ; CHECK-NEXT:    lfd 1, 64(1)
+ ; CHECK-NEXT:    lfd 2, 56(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    mffs 0
+ ; CHECK-NEXT:    mtfsb1 31
+ ; CHECK-NEXT:    lis 3, .LCPI0_2@ha
+@@ -260,7 +260,7 @@ define i64 @__fixunstfdi(ppc_fp128 %a) nounwind readnone {
+ ; CHECK-NEXT:    lfd 4, 136(1)
+ ; CHECK-NEXT:    lfd 1, 128(1)
+ ; CHECK-NEXT:    lfd 2, 120(1)
+-; CHECK-NEXT:    bl __gcc_qsub@PLT
++; CHECK-NEXT:    bl __gcc_qsub
+ ; CHECK-NEXT:    mffs 0
+ ; CHECK-NEXT:    mtfsb1 31
+ ; CHECK-NEXT:    lis 3, .LCPI0_0@ha
+--- llvm/test/CodeGen/PowerPC/2010-02-12-saveCR.ll
++++ llvm/test/CodeGen/PowerPC/2010-02-12-saveCR.ll
+@@ -11,7 +11,7 @@ entry:
+ ; CHECK-DAG: ori [[T2:[0-9]+]], [[T2]], 34492
+ ; CHECK-DAG: stwx [[T1]], 1, [[T2]]
+ ; CHECK-DAG: addi 3, 1, 28
+-; CHECK: bl bar@PLT
++; CHECK: bl bar
+   %x = alloca [100000 x i8]                       ; <[100000 x i8]*> [#uses=1]
+   %"alloca point" = bitcast i32 0 to i32          ; <i32> [#uses=0]
+   %x1 = bitcast [100000 x i8]* %x to i8*          ; <i8*> [#uses=1]
+--- llvm/test/CodeGen/PowerPC/available-externally.ll
++++ llvm/test/CodeGen/PowerPC/available-externally.ll
+@@ -14,7 +14,7 @@ target triple = "powerpc-unknown-linux-gnu"
+ define i32 @foo(i64 %x) nounwind {
+ entry:
+ ; STATIC: foo:
+-; STATIC: bl exact_log2@PLT
++; STATIC: bl exact_log2
+ ; STATIC: blr
+ 
+ ; PIC: foo:
+--- llvm/test/CodeGen/PowerPC/stubs.ll
++++ llvm/test/CodeGen/PowerPC/stubs.ll
+@@ -6,4 +6,4 @@ entry:
  }
+ 
+ ; CHECK: test1:
+-; CHECK: bl __floatditf@PLT
++; CHECK: bl __floatditf
+--- llvm/test/CodeGen/PowerPC/umulo-128-legalisation-lowering.ll
++++ llvm/test/CodeGen/PowerPC/umulo-128-legalisation-lowering.ll
+@@ -72,7 +72,7 @@ define { i128, i8 } @muloti_test(i128 %l, i128 %r) unnamed_addr #0 {
+ ; PPC32-NEXT: mr 28, 9
+ ; PPC32-NEXT: mr 23, 6
+ ; PPC32-NEXT: mr 24, 5
+-; PPC32-NEXT: bl __multi3@PLT
++; PPC32-NEXT: bl __multi3
+ ; PPC32-NEXT: mr 7, 4
+ ; PPC32-NEXT: mullw 4, 24, 30
+ ; PPC32-NEXT: mullw 8, 29, 23

--- a/srcpkgs/llvm9/template
+++ b/srcpkgs/llvm9/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm9'
 pkgname=llvm9
 version=9.0.0
-revision=1
+revision=2
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="


### PR DESCRIPTION
Bumps are necessary because this affects cross-compilers.

We need these patches in for the Rust 1.38 pull request to work correctly later. It's already confirmed to work on my side. The Rust PR will be using llvm8 because llvm9 generates broken executables on some targets with rust right now (regardless of how llvm9 is patched, so I already ruled this patchset out; it's an issue somewhere else) but llvm9 needs patching too (this potentially affects clang and so on), so do it at once.

@jnbr 