### PR TITLE
libqmatrixclient: update to 0.5.2.

### DIFF
--- a/srcpkgs/libqmatrixclient/template
+++ b/srcpkgs/libqmatrixclient/template
@@ -1,17 +1,18 @@
 # Template file for 'libqmatrixclient'
 pkgname=libqmatrixclient
-version=0.5.1.2
+version=0.5.2
 revision=1
+wrksrc="libQuotient-${version}"
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=1 -DQMATRIXCLIENT_INSTALL_EXAMPLE=0"
 hostmakedepends="qt5-qmake qt5-host-tools"
 makedepends="qt5-devel qt5-multimedia-devel"
-short_desc="Qt5 library to write cross-platfrom clients for Matrix"
+short_desc="Qt5 library to write cross-platform clients for Matrix"
 maintainer="Karol Kosek <krkkx@protonmail.com>"
 license="LGPL-2.1-or-later"
-homepage="https://matrix.org/docs/projects/sdk/libqmatrixclient.html"
-distfiles="https://github.com/QMatrixClient/libqmatrixclient/archive/${version}.tar.gz"
-checksum=c5de2aaef010a1d4d1d81c711bc983366d41c482487c828db3f0e6fa7a6e050d
+homepage="https://matrix.org/docs/projects/sdk/quotient"
+distfiles="https://github.com/quotient-im/libQuotient/archive/${version}.tar.gz"
+checksum=1848bc0af53ce42c2b1a1a4fdeccb054af1f9e0f765cadf609f62727ce23dfd2
 
 libqmatrixclient-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
0.5.x releases keep the previous library name, libQMatrixClient.