### PR TITLE
redis: update to 5.0.6.

### DIFF
--- a/srcpkgs/redis/template
+++ b/srcpkgs/redis/template
@@ -1,16 +1,16 @@
 # Template file for 'redis'
 pkgname=redis
-version=5.0.5
+version=5.0.6
 revision=1
 makedepends="jemalloc-devel libatomic-devel"
-checkdepends="tcl-devel"
+checkdepends="tcl-devel procps-ng"
 short_desc="Advanced key-value store"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://redis.io"
 changelog="https://raw.githubusercontent.com/antirez/redis/5.0/00-RELEASENOTES"
 distfiles="http://download.redis.io/releases/${pkgname}-${version}.tar.gz"
-checksum=2139009799d21d8ff94fc40b7f36ac46699b9e1254086299f8d3b223ca54a375
+checksum=6624841267e142c5d5d5be292d705f8fb6070677687c5aad1645421a936d22b3
 
 system_accounts="redis"
 redis_homedir="/var/lib/redis"


### PR DESCRIPTION
`procps-ng` needed for passing the testsuite