### PR TITLE
icecat: fix build

### DIFF
--- a/srcpkgs/icecat/patches/fix-gettid.patch
+++ b/srcpkgs/icecat/patches/fix-gettid.patch
@@ -1,3 +1,6 @@
+originally, the gettid wrapper was needed on glibc and musl,
+glibc-2.30 added a gettid function, so now it is only needed on musl
+
 --- tools/profiler/core/platform.h.orig
 +++ tools/profiler/core/platform.h
 @@ -56,7 +56,7 @@
@@ -5,7 +8,7 @@
  // We need a definition of gettid(), but glibc doesn't provide a
  // wrapper for it.
 -#if defined(__GLIBC__)
-+#if defined(__linux__)
++#if defined(__linux__) && !defined(__GLIBC__)
  #include <unistd.h>
  #include <sys/syscall.h>
  static inline pid_t gettid()

--- a/srcpkgs/icecat/patches/rust-cssparser.patch
+++ b/srcpkgs/icecat/patches/rust-cssparser.patch
@@ -1,0 +1,90 @@
+backport of:
+
+From 3c98d22c5de3b696bf1fde2b6c90069812312aa6 Mon Sep 17 00:00:00 2001
+From: Simon Sapin <simon.sapin@exyr.org>
+Date: Tue, 23 Apr 2019 13:47:25 +0200
+Subject: [PATCH] Fix a future-compat warning
+
+```
+warning[E0506]: cannot assign to `self.input.cached_token` because it is borrowed
+   --> src/parser.rs:591:17
+    |
+566 |     pub fn next_including_whitespace_and_comments(&mut self) -> Result<&Token<'i>, BasicParseError<'i>> {
+    |                                                   - let's call the lifetime of this reference `'1`
+...
+579 |             Some(ref cached_token)
+    |                  ---------------- borrow of `self.input.cached_token` occurs here
+...
+591 |                 self.input.cached_token = Some(CachedToken {
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `self.input.cached_token` occurs here
+...
+603 |         Ok(token)
+    |         --------- returning this value requires that `self.input.cached_token.0` is borrowed for `'1`
+    |
+    = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+    = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+```
+---
+ src/parser.rs | 50 +++++++++++++++++++++++++++-----------------------
+ 1 file changed, 27 insertions(+), 23 deletions(-)
+
+diff --git a/src/parser.rs b/src/parser.rs
+index 51f441e4..7cef117c 100644
+--- third_party/rust/cssparser/src/parser.rs
++++ third_party/rust/cssparser/src/parser.rs
+@@ -555,28 +555,34 @@
+         }
+ 
+         let token_start_position = self.input.tokenizer.position();
+-        let token;
+-        match self.input.cached_token {
+-            Some(ref cached_token)
+-            if cached_token.start_position == token_start_position => {
+-                self.input.tokenizer.reset(&cached_token.end_state);
+-                match cached_token.token {
+-                    Token::Function(ref name) => self.input.tokenizer.see_function(name),
+-                    _ => {}
+-                }
+-                token = &cached_token.token
++        let using_cached_token = self
++            .input
++            .cached_token
++            .as_ref()
++            .map_or(false, |cached_token| {
++                cached_token.start_position == token_start_position
++            });
++        let token = if using_cached_token {
++            let cached_token = self.input.cached_token.as_ref().unwrap();
++            self.input.tokenizer.reset(&cached_token.end_state);
++            match cached_token.token {
++                Token::Function(ref name) => self.input.tokenizer.see_function(name),
++                _ => {}
+             }
+-            _ => {
+-                let new_token = self.input.tokenizer.next()
+-                    .map_err(|()| self.new_basic_error(BasicParseErrorKind::EndOfInput))?;
+-                self.input.cached_token = Some(CachedToken {
+-                    token: new_token,
+-                    start_position: token_start_position,
+-                    end_state: self.input.tokenizer.state(),
+-                });
+-                token = self.input.cached_token_ref()
+-            }
+-        }
++            &cached_token.token
++        } else {
++            let new_token = self
++                .input
++                .tokenizer
++                .next()
++                .map_err(|()| self.new_basic_error(BasicParseErrorKind::EndOfInput))?;
++            self.input.cached_token = Some(CachedToken {
++                token: new_token,
++                start_position: token_start_position,
++                end_state: self.input.tokenizer.state(),
++            });
++            self.input.cached_token_ref()
++        };
+ 
+         if let Some(block_type) = BlockType::opening(token) {
+             self.at_start_of = Some(block_type);

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -37,6 +37,13 @@ if [ "$XBPS_WORDSIZE" -eq 32 ]; then
 	nodebug=yes
 fi
 
+# we need this because cargo verifies checksums of all files in vendor
+# crates when it builds and gives us no way to override or update the
+# file sanely... so just clear out the file list
+_clear_vendor_checksums() {
+	sed -i 's/\("files":{\)[^}]*/\1/' third_party/rust/$1/.cargo-checksum.json
+}
+
 post_extract() {
 	case "$XBPS_TARGET_MACHINE" in
 	*-musl)
@@ -51,6 +58,11 @@ post_extract() {
 	# Note: This is for Void Linux use ONLY.
 	echo -n "cd894504-7a2a-4263-abff-ff73ee89ffca" > mozilla-api-key
 }
+
+post_patch() {
+	_clear_vendor_checksums cssparser
+}
+
 do_build() {
 	local triplet
 	cp ${FILESDIR}/mozconfig .mozconfig


### PR DESCRIPTION
- the vendored version of cssparser fails to build with current rust
- glibc-2.30 introduced gettid as a function