### PR TITLE
gperftools: musl fixes, ppc fixes

### DIFF
--- a/srcpkgs/gperftools/patches/elf-mem-image-musl.patch
+++ b/srcpkgs/gperftools/patches/elf-mem-image-musl.patch
@@ -1,0 +1,13 @@
+This relies on link.h, which is present in musl as well as glibc.
+
+--- src/base/elf_mem_image.h
++++ src/base/elf_mem_image.h
+@@ -43,7 +43,7 @@
+ 
+ // Maybe one day we can rewrite this file not to require the elf
+ // symbol extensions in glibc, but for right now we need them.
+-#if defined(__ELF__) && defined(__GLIBC__) && !defined(__native_client__)
++#if defined(__ELF__) && !defined(__native_client__)
+ 
+ #define HAVE_ELF_MEM_IMAGE 1
+ 

--- a/srcpkgs/gperftools/patches/ppc-musl.patch
+++ b/srcpkgs/gperftools/patches/ppc-musl.patch
@@ -1,0 +1,76 @@
+Compatibility fixes for musl.
+
+--- m4/pc_from_ucontext.m4
++++ m4/pc_from_ucontext.m4
+@@ -31,6 +31,7 @@ AC_DEFUN([AC_PC_FROM_UCONTEXT],
+    pc_fields="$pc_fields uc_mcontext.gregs[[R15]]"     # Linux (arm old [untested])
+    pc_fields="$pc_fields uc_mcontext.arm_pc"           # Linux (arm arch 5)
+    pc_fields="$pc_fields uc_mcontext.gp_regs[[PT_NIP]]"  # Suse SLES 11 (ppc64)
++   pc_fields="$pc_fields uc_mcontext.gregs[[PT_NIP]]"
+    pc_fields="$pc_fields uc_mcontext.mc_eip"           # FreeBSD (i386)
+    pc_fields="$pc_fields uc_mcontext.mc_rip"           # FreeBSD (x86_64 [untested])
+    pc_fields="$pc_fields uc_mcontext.__gregs[[_REG_EIP]]"  # NetBSD (i386)
+@@ -55,7 +56,8 @@ AC_DEFUN([AC_PC_FROM_UCONTEXT],
+                         pc_field_found=true)
+        elif test "x$ac_cv_header_sys_ucontext_h" = xyes; then
+          AC_TRY_COMPILE([#define _GNU_SOURCE 1
+-                         #include <sys/ucontext.h>],
++                         #include <sys/ucontext.h>
++                         #include <asm/ptrace.h>],
+                         [ucontext_t u; return u.$pc_field == 0;],
+                         AC_DEFINE_UNQUOTED(PC_FROM_UCONTEXT, $pc_field,
+                                            How to access the PC from a struct ucontext)
+@@ -63,7 +65,8 @@ AC_DEFUN([AC_PC_FROM_UCONTEXT],
+                         pc_field_found=true)
+        elif test "x$ac_cv_header_ucontext_h" = xyes; then
+          AC_TRY_COMPILE([#define _GNU_SOURCE 1
+-                         #include <ucontext.h>],
++                         #include <ucontext.h>
++                         #include <asm/ptrace.h>],
+                         [ucontext_t u; return u.$pc_field == 0;],
+                         AC_DEFINE_UNQUOTED(PC_FROM_UCONTEXT, $pc_field,
+                                            How to access the PC from a struct ucontext)
+--- src/getpc.h
++++ src/getpc.h
+@@ -65,6 +65,9 @@
+ typedef ucontext ucontext_t;
+ #endif
+ 
++#if defined(__powerpc__) && !defined(PT_NIP)
++#define PT_NIP 32
++#endif
+ 
+ // Take the example where function Foo() calls function Bar().  For
+ // many architectures, Bar() is responsible for setting up and tearing
+--- src/stacktrace_powerpc-linux-inl.h
++++ src/stacktrace_powerpc-linux-inl.h
+@@ -186,7 +186,7 @@ static int GET_STACK_TRACE_OR_FRAMES {
+           ucontext_t uc;
+         // We don't care about the rest, since the IP value is at 'uc' field.
+         } *sigframe = reinterpret_cast<signal_frame_64*>(current);
+-        result[n] = (void*) sigframe->uc.uc_mcontext.gp_regs[PT_NIP];
++        result[n] = (void*) sigframe->uc.uc_mcontext.gp_regs[32];
+       }
+ #else
+       if (sigtramp32_vdso && (sigtramp32_vdso == current->return_addr)) {
+@@ -196,7 +196,7 @@ static int GET_STACK_TRACE_OR_FRAMES {
+           mcontext_t mctx;
+           // We don't care about the rest, since IP value is at 'mctx' field.
+         } *sigframe = reinterpret_cast<signal_frame_32*>(current);
+-        result[n] = (void*) sigframe->mctx.gregs[PT_NIP];
++        result[n] = (void*) sigframe->mctx.gregs[32];
+       } else if (sigtramp32_rt_vdso && (sigtramp32_rt_vdso == current->return_addr)) {
+         struct rt_signal_frame_32 {
+           char dummy[64 + 16];
+@@ -204,7 +204,11 @@ static int GET_STACK_TRACE_OR_FRAMES {
+           ucontext_t uc;
+           // We don't care about the rest, since IP value is at 'uc' field.A
+         } *sigframe = reinterpret_cast<rt_signal_frame_32*>(current);
++#if defined(__GLIBC__)
+         result[n] = (void*) sigframe->uc.uc_mcontext.uc_regs->gregs[PT_NIP];
++#else
++        result[n] = (void*) sigframe->uc.uc_mcontext.gregs[32];
++#endif
+       }
+ #endif
+ 

--- a/srcpkgs/gperftools/template
+++ b/srcpkgs/gperftools/template
@@ -1,8 +1,9 @@
 # Template file for 'gperftools'
 pkgname=gperftools
 version=2.7
-revision=2
+revision=3
 build_style=gnu-configure
+hostmakedepends="automake libtool"
 makedepends="libunwind-devel"
 checkdepends="perl"
 short_desc="Multi-threaded malloc() and performance analysis tools"
@@ -12,16 +13,31 @@ homepage="https://github.com/gperftools/gperftools"
 distfiles="https://github.com/${pkgname}/${pkgname}/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.gz"
 checksum=1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9
 
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	# needed by some newly enabled code
+	CXXFLAGS+=" -D__WORDSIZE=$XBPS_TARGET_WORDSIZE"
+	# needed on musl other than x86_64
+	if [ "$XBPS_TARGET_MACHINE" != "x86_64-musl" ]; then
+		makedepends+=" libucontext-devel"
+		LDFLAGS+=" -lucontext"
+	fi
+fi
+
 case "$XBPS_TARGET_MACHINE" in
 	arm*-musl|aarch64-musl)
+		# having libunwind in makedepends still causes failures...
 		makedepends="libucontext-devel"
-		LDFLAGS=" -lucontext"
-		configure_args="--disable-libunwind"
+		configure_args+=" --disable-libunwind"
+		;;
 esac
 
 post_extract() {
 	sed -i -e 's/__off64_t/off64_t/' \
 		src/base/linux_syscall_support.h src/malloc_hook_mmap_linux.h
+}
+
+pre_configure() {
+	autoreconf -fi
 }
 
 post_install() {


### PR DESCRIPTION
This allows some parts of the code that previously didn't build on musl to build. Additionally, it fixes build on musl ppc setups.