### PR TITLE
prometheus: update to 2.13.0

### DIFF
--- a/srcpkgs/prometheus/template
+++ b/srcpkgs/prometheus/template
@@ -1,6 +1,6 @@
 # Template file for 'prometheus'
 pkgname=prometheus
-version=2.12.0
+version=2.13.0
 revision=1
 build_style=go
 go_import_path="github.com/prometheus/prometheus"
@@ -15,14 +15,13 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://prometheus.io/"
 distfiles="https://github.com/prometheus/prometheus/archive/v${version}.tar.gz"
-checksum=9bd9ae6df02777a9ba3f6f544338865861decabd02054aa64975449bd6009e5a
+checksum=0a11ecc28989ad984af551a5426e9989aa1ca628fc2e875bb913af445ab38288
 
 system_accounts="_prometheus"
 
 make_dirs="/var/lib/prometheus 700 _prometheus _prometheus"
 
 post_install() {
-	vlicense LICENSE
 	vlicense NOTICE
 	vmkdir etc/prometheus
 	vmkdir usr/share/doc/prometheus


### PR DESCRIPTION
I removed the LICENSE because Apache does not need to be distributed, but included the NOTICE, because it references other licenses that do need attribution. Is this correct???