### PR TITLE
girara: update 0.3.3 and fix open

### DIFF
--- a/srcpkgs/girara/patches/xdg-open-to-gio-open.patch
+++ b/srcpkgs/girara/patches/xdg-open-to-gio-open.patch
@@ -1,0 +1,18 @@
++++ girara/utils.c
+@@ -68,7 +68,7 @@ girara_xdg_open_with_working_directory(const char* uri, const char* working_dire
+   }
+
+   /* g_spawn_async expects char** */
+-  char* argv[] = { g_strdup("xdg-open"), g_strdup(uri), NULL };
++  char* argv[] = { g_strdup("gio"), g_strdup("open"), g_strdup(uri), NULL };
+
+   GError* error = NULL;
+   const bool res = g_spawn_async(working_directory, argv, NULL, G_SPAWN_SEARCH_PATH, NULL,
+@@ -78,6 +78,7 @@ girara_xdg_open_with_working_directory(const char* uri, const char* working_dire
+     g_error_free(error);
+   }
+
++  g_free(argv[2]);
+   g_free(argv[1]);
+   g_free(argv[0]);
+

--- a/srcpkgs/girara/template
+++ b/srcpkgs/girara/template
@@ -1,6 +1,6 @@
 # Template file for 'girara'
 pkgname=girara
-version=0.3.2
+version=0.3.3
 revision=1
 build_style=meson
 configure_args="-Dnotify=auto -Dtests=disabled"
@@ -10,8 +10,8 @@ short_desc="A library implementing a user interface that focuses on minimalism"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="Zlib"
 homepage="https://pwmt.org/projects/girara/"
-distfiles="https://pwmt.org/projects/${pkgname}/download/${pkgname}-${version}.tar.xz"
-checksum=1700353a101f3c520f9b22e79d71ea5b268a9ec324796cf9e64775d96bb086cd
+distfiles="https://git.pwmt.org/pwmt/${pkgname}/-/archive/${version}/${pkgname}-${version}.tar.gz"
+checksum=4456ddd6f0420fa6f1677a4a8f438f0401c38c2521585db3ee42e339a730798f
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/girara/template
+++ b/srcpkgs/girara/template
@@ -6,7 +6,7 @@ build_style=meson
 configure_args="-Dnotify=auto -Dtests=disabled"
 hostmakedepends="pkg-config intltool doxygen glib-devel"
 makedepends="gtk+3-devel libnotify-devel libglib-devel json-c-devel"
-short_desc="A library implementing a user interface that focuses on minimalism"
+short_desc="Library implementing a user interface that focuses on minimalism"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="Zlib"
 homepage="https://pwmt.org/projects/girara/"


### PR DESCRIPTION
Because girara already depends on glib, I replaced `xdg-open` by `gio open` instead of adding yet another dependency.