### PR TITLE
04-create-xbps-medatada-scripts.sh: autogenerate pycompile_modules

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1438,9 +1438,10 @@ for example python3.4, those must also be added as host and target build depende
 The following variables may influence how the python packages are built and configured
 at post-install time:
 
-- `pycompile_module`: this variable expects the python modules that should be `byte-compiled`
-at post-install time. Python modules are those that are installed into the `site-packages`
-prefix: `usr/lib/pythonX.X/site-packages`. Multiple python modules may be specified separated
+- `pycompile_module`: By default, files and directories installed into
+`usr/lib/pythonX.X/site-packages`, excluding `*-info` and `*.so`, are byte-compiled
+at install time as python modules.  This variable expects subset of them that
+should be byte-compiled, if default is wrong.  Multiple python modules may be specified separated
 by blanks, Example: `pycompile_module="foo blah"`. If a python module installs a file into
 `site-packages` rather than a directory, use the name of the file, Example:
 `pycompile_module="fnord.py"`.

--- a/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
+++ b/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
@@ -260,6 +260,9 @@ _EOF
 	#
 	if [ -d ${PKGDESTDIR}/usr/lib/python* ]; then
 		pycompile_version="$(find ${PKGDESTDIR}/usr/lib/python* -prune -type d | grep -o '[[:digit:]]\.[[:digit:]]$')"
+		if [ -z "${pycompile_module}" ]; then
+			pycompile_module="$(find ${PKGDESTDIR}/usr/lib/python*/site-packages -mindepth 1 -maxdepth 1 '!' -name '*.egg-info' '!' -name '*.dist-info' '!' -name '*.so' '!' -name '*.pth' -printf '%f ')"
+		fi
 	fi
 
 	if [ -n "${pycompile_dirs}" -o -n "${pycompile_module}" ]; then


### PR DESCRIPTION
Setting pycompile_module in template will be no longer necessary.