### PR TITLE
jack: update to 1.9.13, adopt package

### DIFF
--- a/srcpkgs/jack/template
+++ b/srcpkgs/jack/template
@@ -1,33 +1,31 @@
 # Template file for 'jack'
 pkgname=jack
-version=1.9.12
-revision=12
+version=1.9.13
+revision=1
 wrksrc="jack2-${version}"
-# XXX libffado (firewire)
-hostmakedepends="pkg-config python"
-makedepends="opus-devel libsamplerate-devel readline-devel dbus-devel celt-devel"
-depends="python-dbus"
+build_style=waf3
+configure_args="--alsa --classic --dbus"
+hostmakedepends="pkg-config"
+makedepends="opus-devel libsamplerate-devel readline-devel dbus-devel celt-devel
+ $(vopt_if ffado libffado-devel)"
+depends="python3-dbus"
 short_desc="JACK Audio Connection Kit low-latency sound server (pro audio)"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2, LGPL-2.1"
-homepage="http://jackaudio.org/"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="https://jackaudio.org/"
 distfiles="https://github.com/jackaudio/jack2/archive/v${version}.tar.gz"
-checksum=deefe2f936dc32f59ad3cef7e37276c2035ef8a024ca92118f35c9a292272e33
+checksum=2a683eef63b608b292411d66482fd45aa7fa8dc004bed4184e06f9f9ca83c075
+python_version=3
+
+# Package build options
+build_options="ffado"
+desc_option_ffado="Enable support for FireWire audio devices"
 
 if [ -z "CROSS_BUILD" ]; then
 	makedepends+=" eigen"
 fi
 
-do_configure() {
-	python2 waf configure --prefix=/usr --alsa --classic --dbus
-}
-do_build() {
-	python2 waf build ${makejobs}
-}
-
-do_install() {
-	python2 waf install --destdir=${DESTDIR}
-
+post_install() {
 	# pam_limits(8) support
 	vinstall ${FILESDIR}/jack-limitsd.conf 644 etc/security/limits.d jack.conf
 	# audio group permissions for realtime


### PR DESCRIPTION
* basic functionality tested on x86_64
* use python3 (jack_control script is now python3 compatible)
* optional support for FireWire devices (libffado) added via `ffado` buildoption