### PR TITLE
texlive-bin: make the broken= actually work

### DIFF
--- a/srcpkgs/texlive-bin/template
+++ b/srcpkgs/texlive-bin/template
@@ -9,16 +9,17 @@ license="GPL-2"
 homepage="http://tug.org/texlive/"
 provides="texlive-${version}_${revision}"
 
+case "$XBPS_TARGET_MACHINE" in
+	i686) _tlarch=i386-linux;;
+	x86_64) _tlarch=x86_64-linux;;
+	x86_64-musl) _tlarch=x86_64-linuxmusl;;
+	arm*) _tlarch=armhf-linux;;
+	aarch64) _tlarch=aarch64-linux;;
+	*) broken="$XBPS_TARGET_MACHINE is not supported";;
+esac
+
 do_install() {
 	vmkdir etc/profile.d
-	case "$XBPS_TARGET_MACHINE" in
-		i686) tlarch=i386-linux;;
-		x86_64) tlarch=x86_64-linux;;
-		x86_64-musl) tlarch=x86_64-linuxmusl;;
-		arm*) tlarch=armhf-linux;;
-		aarch64) tlarch=aarch64-linux;;
-		*) broken="$XBPS_TARGET_MACHINE is not supported";;
-	esac
-	sed -e "s/@@ARCH@@/${tlarch}/; s/@@VERSION@@/${version}/" \
+	sed -e "s/@@ARCH@@/${_tlarch}/; s/@@VERSION@@/${version}/" \
 		${FILESDIR}/texlive.sh >${DESTDIR}/etc/profile.d/texlive.sh
 }


### PR DESCRIPTION
`xbps-src` will ignore it if it's stuffed in `do_install` like that.