### PR TITLE
vala-panel-appmenu: fix dependency typo

### DIFF
--- a/srcpkgs/vala-panel-appmenu/template
+++ b/srcpkgs/vala-panel-appmenu/template
@@ -1,7 +1,7 @@
 # Template file for 'vala-panel-appmenu'
 pkgname=vala-panel-appmenu
 version=0.7.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DENABLE_XFCE=ON -DENABLE_VALAPANEL=ON
  -DENABLE_MATE=ON -DENABLE_JAYATANA=OFF -DENABLE_APPMENU_GTK_MODULE=ON"
@@ -31,7 +31,7 @@ post_install() {
 appmenu-gtk-module-devel_package() {
 	short_desc="GTK module for exposing menus - development files"
 	depends="appmenu-gtk-module-${version}_${revision}
-	 appmenu-gkt3-module-${version}_${revision}"
+	 appmenu-gtk3-module-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig


### PR DESCRIPTION
I found a typo in the dependencies for the appmenu-gtk-module-devel package where a dependency was listed as "appmenu-gkt3-module" and am submitting a correction for it so the package may actually be installable.