### PR TITLE
nvidia390: fix libGL dependency conflict

### DIFF
--- a/srcpkgs/nvidia390/template
+++ b/srcpkgs/nvidia390/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GeForce 400, 500 series)"
 
 pkgname=nvidia390
 version=390.129
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="http://www.nvidia.com"
@@ -14,7 +14,8 @@ nopie=yes
 repository="nonfree"
 create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
-depends="nvidia390-gtklibs-${version}_${revision} nvidia390-dkms-${version}_${revision} pkg-config"
+depends="nvidia390-libs-${version}_${revision} nvidia390-gtklibs-${version}_${revision}
+ nvidia390-dkms-${version}_${revision} pkg-config"
 conflicts="catalyst>=0 xserver-abi-video>24_1"
 
 build_options="glvnd"


### PR DESCRIPTION
Trying to include the package `nvidia390` in a live image:
`sudo ./mklive.sh -a x86_64 -r https://alpha.de.repo.voidlinux.org/current/nonfree -p nvidia390`

Failed with:

> nvidia390-libs-390.129_1: collecting files...
ERROR: nvidia390-libs-390.129_1: file `/usr/lib/libEGL.so.1' already installed by package libEGL-19.1.7_3.
ERROR: nvidia390-libs-390.129_1: file `/usr/lib/libGL.so.1' already installed by package libGL-19.1.7_3.
ERROR: nvidia390-libs-390.129_1: file `/usr/lib/xorg/modules/extensions/libglx.so' already installed by package libGL-19.1.7_3.
Transaction failed! see above for errors.
ERROR: Failed to install base-system nvidia390

The reason is that `nvidia390-gtklibs` pulls in `cairo` which in turn installs the Mesa implementation of `libGL` (ignoring the `libGL` provided by Nvidia). I fixed this looking at how the `nvidia` template deals with it, I don't know if it's the optimal solution.