### PR TITLE
pelican: update to 4.1.3

### DIFF
--- a/srcpkgs/pelican/template
+++ b/srcpkgs/pelican/template
@@ -1,6 +1,6 @@
 # Template file for 'pelican'
 pkgname=pelican
-version=4.1.1
+version=4.1.3
 revision=1
 archs=noarch
 build_style=python2-module
@@ -15,7 +15,7 @@ license="AGPL-3.0-or-later"
 homepage="https://getpelican.com/"
 changelog="https://raw.githubusercontent.com/getpelican/pelican/${version}/docs/changelog.rst"
 distfiles="${PYPI_SITE}/p/pelican/pelican-${version}.tar.gz"
-checksum=77b71b4f0eba5d8e2aa7de6e1854659acc623f5bb74be7750ccbba1856c06bce
+checksum=cf0ed7342e5cf38559cd89f9daee52dc2697739eafd6b9fbd33b06e523bf4cce
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
builds on x86_64 and x86_64-musl, not tested elsewhere