### PR TITLE
New package: ibus-m17n-1.4.1

### DIFF
--- a/srcpkgs/ibus-m17n/INSTALL.msg
+++ b/srcpkgs/ibus-m17n/INSTALL.msg
@@ -1,0 +1,2 @@
+If the M17N languages don't appear in ibus-setup or GNOME Control Center
+run `ibus-daemon -xdr` or simply reboot.

--- a/srcpkgs/ibus-m17n/template
+++ b/srcpkgs/ibus-m17n/template
@@ -1,0 +1,19 @@
+# Template file for 'ibus-m17n'
+pkgname=ibus-m17n
+version=1.4.1
+revision=1
+build_style=gnu-configure
+configure_args="--prefix=/usr --libexecdir=/usr/lib/ibus"
+hostmakedepends="ibus m17n-db m17n-lib gnome-common xz pkg-config automake libtool gettext-devel"
+makedepends="ibus-devel m17n-lib-devel"
+depends="ibus m17n-db"
+short_desc="M17N engine for IBus"
+maintainer="reback00 <reback00@protonmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/ibus/ibus-m17n"
+distfiles="https://github.com/ibus/ibus-m17n/releases/download/${version}/ibus-m17n-${version}.tar.gz"
+checksum=5207f0b99bd17cae05251f96649dd26ec09f2feedb47dbe92a5128c7eeea4762
+
+pre_configure() {
+	autoreconf -fi
+}


### PR DESCRIPTION
[ibus-m17n](https://github.com/ibus/ibus-m17n) is a package for adding keyboard layouts
 for [Indic](https://fedoraproject.org/wiki/I18N/Indic) and other languages. Without this package those languages don't appear on `ibus-setup` or on GNOME Control Center. Other [distros](https://packages.debian.org/sid/ibus-m17n) [have](https://aur.archlinux.org/packages/ibus-m17n-git/) it [too](https://fedoraproject.org/wiki/I18N/IBus#IBus_Packages). So I hope it would be a wonderful addition to Void Linux. :)