### PR TITLE
xbps-src: (zap) correctly empty the masterdir

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -329,21 +329,9 @@ bootstrap_update() {
 }
 
 masterdir_zap() {
-    for f in bin boot builddir destdir dev etc home lib lib32 lib64 mnt \
-        opt proc root run sbin sys tmp usr var host media xbps \
-        void-packages .xbps_chroot_init .xbps_chroot_configured; do
-        if [ -d "$XBPS_MASTERDIR/$f" ]; then
-            echo "Removing directory $XBPS_MASTERDIR/$f ..."
-            rm -rf $XBPS_MASTERDIR/$f
-        elif [ -h "$XBPS_MASTERDIR/$f" ]; then
-            echo "Removing link $XBPS_MASTERDIR/$f ..."
-            rm -f $XBPS_MASTERDIR/$f
-        elif [ -f "$XBPS_MASTERDIR/$f" ]; then
-            echo "Removing file $XBPS_MASTERDIR/$f ..."
-            rm -f $XBPS_MASTERDIR/$f
-        fi
-    done
-    echo "$XBPS_MASTERDIR masterdir cleaned up."
+    rm -rf "$XBPS_MASTERDIR"
+    mkdir -p "$XBPS_MASTERDIR"
+    msg_normal "$XBPS_MASTERDIR masterdir cleaned up."
 }
 
 exit_func() {


### PR DESCRIPTION
Instead of relying on a potentially outdated list of files and dirs to
remove, just remove+recreate the whole masterdir.

This previously led to leftover .xbps* files, which broke subsequent
operations.

See: #14476