### PR TITLE
chromium: update to 77.0.3865.120.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=77.0.3865.90
+version=77.0.3865.120
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=f443503c88164f018ddb88247d2824431efcb863935ae476f4ada6218f41fdda
+checksum=07abdccd7c15f5abe68765c1162f2ab666b6478a4d578aa6351d5667cd983a48
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/patches/sandbox-sched_getparam.patch
+++ b/srcpkgs/chromium/patches/sandbox-sched_getparam.patch
@@ -1,0 +1,20 @@
+Allow SYS_sched_getparam and SYS_sched_getscheduler
+musl uses them for pthread_getschedparam()
+
+source: https://git.alpinelinux.org/aports/commit/community/chromium?id=54af9f8ac24f52d382c5758e2445bf0206eff40e
+
+--- services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc.orig	2019-10-08 21:03:18.253080425 +0200
++++ services/service_manager/sandbox/linux/bpf_renderer_policy_linux.cc	2019-10-08 21:04:19.648549718 +0200
+@@ -88,10 +88,10 @@
+     case __NR_sysinfo:
+     case __NR_times:
+     case __NR_uname:
+-      return Allow();
+-    case __NR_sched_getaffinity:
+     case __NR_sched_getparam:
+     case __NR_sched_getscheduler:
++      return Allow();
++    case __NR_sched_getaffinity:
+     case __NR_sched_setscheduler:
+       return sandbox::RestrictSchedTarget(GetPolicyPid(), sysno);
+     case __NR_prlimit64:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=77.0.3865.90
+version=77.0.3865.120
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=004cfdb1df74847bea8659bcaf8e039d51fe1101d42b6cf1c6cc346073fdefc3
+checksum=d792f9b09b1dcfd64e68f47a611c540dd1383dd9abd78ca1e06b2a7e2ff06af8
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
[ci skip]

- Built for i686, x86_64, x86_64-musl.
- Tested on x86_64.

Also, rolled in patch from #15268