### PR TITLE
hyperfine: update to 1.8.0.

### DIFF
--- a/srcpkgs/hyperfine/template
+++ b/srcpkgs/hyperfine/template
@@ -1,6 +1,6 @@
 # Template file for 'hyperfine'
 pkgname=hyperfine
-version=1.7.0
+version=1.8.0
 revision=1
 build_style=cargo
 short_desc="Command-line benchmarking tool"
@@ -9,8 +9,7 @@ license="MIT, Apache-2.0"
 homepage="https://github.com/sharkdp/hyperfine"
 changelog="https://github.com/sharkdp/hyperfine/releases"
 distfiles="https://github.com/sharkdp/hyperfine/archive/v${version}.tar.gz"
-checksum=d936aab473775e76c3a749828054e3f7d42e3909e8b0f56f99ecf6aa169a9bd3
-nocross="Multiple errors from rustc when cross-compiling."
+checksum=14de63b44eb4c2c5d6a6f9354acbcff350c9a2ba50b2397de5798c152cc2a029
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
cross seems to work again