### PR TITLE
bitlbee-facebook: depends on bitlbee

### DIFF
--- a/srcpkgs/bitlbee-facebook/template
+++ b/srcpkgs/bitlbee-facebook/template
@@ -1,10 +1,11 @@
 # Template file for 'bitlbee-facebook'
 pkgname=bitlbee-facebook
 version=1.2.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="libtool automake pkg-config glib-devel"
 makedepends="bitlbee-devel json-glib-devel"
+depends="bitlbee"
 short_desc="Facebook protocol plugin for BitlBee"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
bitlbee-facebook is a plugin of bitlbee, without bitlbee,
bitlbee-facebook couldn't work.

Add bitlbee to list of its dependencies.