### PR TITLE
common/build_dependencies.sh: don't ingore missing subpkgs in hostdeps

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -169,7 +169,7 @@ install_pkg_deps() {
                         break
                     fi
                 done
-                if [[ $found -eq 1 ]]; then
+                if [[ $found -eq 1 ]] && [[ -z "$cross" ]]; then
                     echo "   [host] ${_vpkg}: not found (subpkg, ignored)"
                 else
                     echo "   [host] ${_vpkg}: not found"


### PR DESCRIPTION
Currently missing hostmakedepends that are a subpkg are just ignored which leads to failing builds in theses cases if they are needed for cross compiling

e.g. https://build.voidlinux.org/builders/aarch64-musl_builder/builds/22678/steps/shell_3/logs/stdio