### PR TITLE
libreoffice: require libatomic on ppc32

### DIFF
--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -254,6 +254,11 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 esac
 
+case "$XBPS_TARGET_MACHINE" in
+	ppc64*) ;;
+	ppc*) makedepends+=" libatomic-devel";;
+esac
+
 CXXFLAGS+=" -DGLM_ENABLE_EXPERIMENTAL -DU_USING_ICU_NAMESPACE=1"
 
 # Move files listed in a <name>_list.txt into $PKGDESTDIR


### PR DESCRIPTION
It fails to link otherwise.