### PR TITLE
onionshare: update to 2.2.

### DIFF
--- a/srcpkgs/onionshare/template
+++ b/srcpkgs/onionshare/template
@@ -1,6 +1,6 @@
 # Template file for 'onionshare'
 pkgname=onionshare
-version=2.1
+version=2.2
 revision=1
 archs=noarch
 build_style=python3-module
@@ -12,13 +12,14 @@ depends="python3-cffi python3-chardet python3-click python3-cryptography
  python3-Jinja2 python3-MarkupSafe python3-pycparser python3-pycryptodome
  python3-PyQt5 python3-pysocks python3-requests python3-six python3-stem
  python3-urllib3 python3-Werkzeug python3-asn1crypto python3-altgraph
- python3-sip-PyQt5 python3-macholib python3-pefile python3-simplejson tor"
+ python3-sip-PyQt5 python3-macholib python3-pefile python3-simplejson tor
+ python3-Flask-HTTPAuth"
 short_desc="Share files anonymously and securely"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://onionshare.org/"
 distfiles="https://github.com/micahflee/onionshare/archive/v${version}.tar.gz"
-checksum=b412bc1e9d08deaa2805cfc9532b556928fa7b332d249189fb0887f27d587ddb
+checksum=7173863d7582b05aa8fd0d2207236e3cbbb38d854aad65e3b98ec5baad521fc2
 
 conf_files="/etc/apparmor.d/local/*"
 

--- a/srcpkgs/python3-Flask-HTTPAuth/template
+++ b/srcpkgs/python3-Flask-HTTPAuth/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-Flask-HTTPAuth'
+pkgname=python3-Flask-HTTPAuth
+version=3.3.0
+revision=1
+wrksrc=Flask-HTTPAuth-${version}
+build_style=python3-module
+pycompile_module="flask_httpauth.py"
+hostmakedepends="python3-setuptools"
+depends="python3-Flask"
+short_desc="Basic, Digest and Token HTTP authentication for Flask routes"
+maintainer="mobinmob <mobinmob@disroot.org>"
+license="MIT"
+homepage="https://github.com/miguelgrinberg/Flask-HTTPAuth"
+distfiles="${PYPI_SITE}/f/flask-httpauth/Flask-HTTPAuth-${version}.tar.gz"
+checksum=6ef8b761332e780f9ff74d5f9056c2616f52babc1998b01d9f361a1e439e61b9
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Flask-HTTPAuth is a dependency for the new version.