### PR TITLE
tau: update to 0.9.3

### DIFF
--- a/srcpkgs/tau/template
+++ b/srcpkgs/tau/template
@@ -1,6 +1,6 @@
 # Template file for 'tau'
 pkgname=tau
-version=0.9.2
+version=0.9.3
 revision=1
 build_style=meson
 build_helper=rust
@@ -11,8 +11,8 @@ short_desc="GTK frontend for the Xi text editor, written in Rust"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://gitlab.gnome.org/World/Tau"
-distfiles="https://gitlab.gnome.org/World/Tau/uploads/fdf09640e3837ad509f5c4b1da0c26e3/tau-${version}.tar.xz"
-checksum=e48db7356bf72d7082cab4ed09522e1d26eb682593881cf07b3a717160a0501d
+distfiles="https://gitlab.gnome.org/World/Tau/uploads/375ce054c0bc98e0c1a3e95fdcd4e46c/tau-${version}.tar.xz"
+checksum=e58b400e86fb7dd1a6610427732a6a360355e8f3b03712d518fb5438b6daae0b
 
 case $XBPS_MACHINE in
 	*-musl) broken="crashes rustc" ;;


### PR DESCRIPTION
Also enable on x86_64-musl again, where rustc should hopefully work w/ gtk-rs