### PR TITLE
libreoffice: fix soffice permissions

### DIFF
--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -515,6 +515,11 @@ do_configure() {
 do_build() {
 	make ${makejobs} ${make_build_args}
 	make ${makejobs} -C libreofficekit
+
+	# on some platforms (32-bit ppc at least), this single file has
+	# incorrect (non-executable) permissions, so fix it here
+	# only this file is affected and i have no idea why...
+	chmod 755 ${wrksrc}/instdir/program/soffice
 }
 
 do_install() {


### PR DESCRIPTION
This lone file for some reason can have incorrect non-executable permissions after build (it's a shell script). I have seen this on ppc32, but not anywhere else, and I haven't been able to figure out why. Fix it everywhere anyway.