### PR TITLE
retroarch: update to 1.7.9.2

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,6 +1,6 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.7.9
+version=1.7.9.2
 revision=1
 wrksrc="RetroArch-$version"
 build_style=configure
@@ -15,15 +15,16 @@ makedepends="zlib-devel libxml2-devel freetype-devel libxkbcommon-devel
  $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if jack jack-devel)
  $(vopt_if ffmpeg ffmpeg-devel) $(vopt_if sdl2 SDL2-devel)
  $(vopt_if x11 'libXext-devel libXinerama-devel libXv-devel libXxf86vm-devel')
- $(vopt_if vulkan 'vulkan-loader')"
+ $(vopt_if vulkan 'vulkan-loader')
+ $(vopt_if qt5 'qt5-devel')"
 depends="$(vopt_if vulkan 'vulkan-loader')"
 short_desc="Official reference frontend for the libretro API"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.libretro.com/"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=00d45a468023fbab8c023a81d4f26bca91bacb24ab24a7162079c26ff042c367
-build_options="ffmpeg opengl jack pulseaudio sdl2 x11 vulkan"
+checksum=1cb88c3e2e8a04a21e2e6a14b7b7a7eb2748d18e629e5e2063ca7a1a9a7dabb5
+build_options="ffmpeg opengl jack pulseaudio sdl2 x11 vulkan qt5"
 
 build_options_default="ffmpeg"
 


### PR DESCRIPTION
Added qt5 build option. Disabled as of now but feel free to enable it if you want.