### PR TITLE
New package: textadept-10.8

### DIFF
--- a/srcpkgs/textadept/template
+++ b/srcpkgs/textadept/template
@@ -1,0 +1,92 @@
+# Template file for 'textadept'
+pkgname=textadept
+version=10.8
+revision=1
+wrksrc="textadept-textadept_${version}"
+build_wrksrc="src"
+hostmakedepends="autoconf automake libtool wget unzip pkg-config glib-devel ncurses"
+makedepends="gtk+3-devel ncurses-devel"
+short_desc="Fast, minimalist, and extensible text editor for programmers"
+maintainer="reback00 <reback00@protonmail.com>"
+license="MIT"
+homepage="https://foicica.com/textadept/"
+# Note: The dependency urls and filenames must be checked and updated manually
+# for distfiles and skip_extraction variables on every new release (and
+# checksums updated accordingly). This is so that XBPS can cache them. Details:
+# https://github.com/void-linux/void-packages/pull/15627#issuecomment-549018252
+distfiles="https://github.com/rgieseke/textadept/archive/textadept_${version}.tar.gz
+ http://foicica.com/hg/scintilla/archive/99fa62b828ee.zip
+ http://www.lua.org/ftp/lua-5.3.5.tar.gz
+ http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz
+ http://github.com/keplerproject/luafilesystem/archive/v1_7_0_2.zip
+ http://foicica.com/hg/gtdialog/archive/db67f8a489e8.zip
+ http://invisible-mirror.net/archives/cdk/cdk-5.0-20150928.tgz
+ https://foicica.com/hg/bombay/archive/tip.zip>bombay.zip
+ http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.20.tar.gz"
+checksum="33d5c2eb36c93f48af2fa9fe6ae81ab2592b95af2fbe4f45144cd5b6d8a34ce0
+ 40ee221a1c7bd827c1d7fd0fa7f41a6fddaa9bdf15667fc492b1d91a77681d57
+ 0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac
+ 48d66576051b6c78388faad09b70493093264588fcd0f258ddaab1cdd4a15ffe
+ 9174ab891f1d392b42a587b2afb737f9565ecf8a860d2e5a2bff457858f58478
+ 508be36c3ae0de3cb3eeddad9b8cb5cf31ff4c6e8aa9acf72c4e72d94e8e1ee3
+ 028da75d5f777a1c4184f88e34918bd273bd83bbe3c959bc11710c4f0ea2e448
+ 4d1ae87bc817302127b250a5968bd05d3f1599e2b9eb785f339698db0bb9294f
+ 6c0d87c94ab9915e76ecd313baec08dedf3bd56de83743d9aa923a081935d2f5"
+skip_extraction="
+ 99fa62b828ee.zip
+ lua-5.3.5.tar.gz
+ lpeg-1.0.2.tar.gz
+ v1_7_0_2.zip
+ db67f8a489e8.zip
+ cdk-5.0-20150928.tgz
+ bombay.zip
+ libtermkey-0.20.tar.gz
+"
+
+post_extract() {
+	# We copy the downloaded dep files to src directory so that they are found
+	# and not downloaded again by the build process. This helps to utilize caching.
+	echo "${skip_extraction}" | while read archive ; do
+		if [ -f "${XBPS_SRCDISTDIR}/${sourcepkg}-${version}/${archive}" ]; then
+			cp "${XBPS_SRCDISTDIR}/${sourcepkg}-${version}/${archive}" \
+				"${wrksrc}/${build_wrksrc}/"
+		fi
+	done
+}
+
+pre_configure() {
+	# For cross builds
+	vsed -i \
+		-e 's/CC = /CC ?= /' \
+		-e 's/CFLAGS = /CFLAGS ?= /' \
+		-e 's/CXX = /CXX ?= /' \
+		-e 's/CXXFLAGS = /CXXFLAGS ?= /' Makefile
+	make deps
+}
+
+do_build() {
+	make ${makejobs} GTK3=1
+	make ${makejobs} curses
+}
+
+do_install() {
+	make PREFIX=/usr DESTDIR="${DESTDIR}" install
+	make curses PREFIX=/usr DESTDIR="${DESTDIR}" install
+
+	# Binaries in /usr/share/textadept are not allowed
+	# So we relocate to /usr/lib/textadept
+	mkdir -p "${DESTDIR}/usr/lib/"
+	mv "${DESTDIR}/usr/share/textadept" "${DESTDIR}/usr/lib/textadept"
+	ln -sf "/usr/lib/textadept/textadept" "${DESTDIR}/usr/bin/textadept"
+	ln -sf "/usr/lib/textadept/textadept-curses" \
+		"${DESTDIR}/usr/bin/textadept-curses"
+
+	# For icons
+	mkdir -p "${DESTDIR}/usr/share/pixmaps"
+	ln -s "/usr/lib/textadept/core/images/textadept.svg" \
+		"${DESTDIR}/usr/share/pixmaps/textadept.svg"
+	ln -s "/usr/lib/textadept/core/images/ta_48x48.png" \
+		"${DESTDIR}/usr/share/pixmaps/textadept.png"
+
+	vlicense ../LICENSE
+}


### PR DESCRIPTION
This is a resubmission of Textadept package. I [messed up](https://github.com/void-linux/void-packages/pull/15278#issuecomment-543545924) the old PR and it got closed automatically, so had to open a new one.

[Textadept](https://foicica.com/textadept/) is a very lightweight and fast text editor written in C. It is extensible with Lua. The project aims to keep the C code within 2000 lines but has standard functionalities of other text editors.
Hope it is useful.

EDIT: Updated for 10.8