### PR TITLE
gnome-characters: depends on gjs

### DIFF
--- a/srcpkgs/gnome-characters/template
+++ b/srcpkgs/gnome-characters/template
@@ -1,12 +1,12 @@
 # Template file for 'gnome-characters'
 pkgname=gnome-characters
 version=3.32.1
-revision=2
+revision=3
 build_style=meson
 build_helper="gir"
 hostmakedepends="gjs glib-devel itstool pkg-config"
 makedepends="gjs-devel libglib-devel gtk+3-devel libunistring-devel"
-depends="gnome-desktop"
+depends="gnome-desktop gjs"
 short_desc="Utility to find and insert unusual characters for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
It's not possible to run this package without gjs, because the gnome-characters command is a script that executes this dependency