### PR TITLE
New package: jetbrains-jdk-bin-11.0.5b569.2

### DIFF
--- a/srcpkgs/jetbrains-jdk-bin/template
+++ b/srcpkgs/jetbrains-jdk-bin/template
@@ -1,0 +1,34 @@
+# Template file for 'jetbrains-jdk-bin'
+pkgname=jetbrains-jdk-bin
+version=11.0.5b569.2
+revision=1
+archs="x86_64"
+wrksrc="jbrsdk"
+hostmakedepends="wget"
+short_desc="JetBrains Java 11 JDK"
+maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
+license="GPL-2.0-only, Classpath-exception-2.0"
+homepage="https://github.com/JetBrains/JetBrainsRuntime"
+_jdk_ver=${version%b*}
+_jdk_build=${version#*b}
+distfiles="https://dl.bintray.com/jetbrains/intellij-jbr/jbrsdk-${_jdk_ver//\./_}-linux-x64-b${_jdk_build}.tar.gz"
+checksum=008a98cf5e9205502211acdf61bb0d024e21f28fb33198798863ad90e4d1ecca
+# This JDK appears to link to libs that do not exist, but still continues to function well even in their absence.
+# Best guess is that they are optional. ¯\_(ツ)_/¯
+fetch_cmd="wget"
+noverifyrdeps=yes
+nopie=yes
+
+do_install() {
+	TARGET_PATH="usr/lib/jvm/jbrsdk"
+
+	vmkdir ${TARGET_PATH}
+
+	vcopy bin ${TARGET_PATH}
+	vcopy conf ${TARGET_PATH}
+	vcopy include ${TARGET_PATH}
+	vcopy jmods ${TARGET_PATH}
+	vcopy legal ${TARGET_PATH}
+	vcopy lib ${TARGET_PATH}
+	vcopy release ${TARGET_PATH}
+}

--- a/srcpkgs/jetbrains-jdk-bin/update
+++ b/srcpkgs/jetbrains-jdk-bin/update
@@ -1,0 +1,6 @@
+# NOTE: This does not check the jdk_ver part of the version (eg 11.0.4)
+# If it changes, this update check will not detect it, it will only detect the build number change.
+# It will be up to the maintainer to go hunt down the correct jdk version and update the template.
+_jdk_build=${version#*b}
+version=b${_jdk_build}
+pattern="jbrsdk-\d+_\d+_\d+-(?:linux-x64-)\Kb\d+\.\d+(?=\.tar\.gz</a>)"


### PR DESCRIPTION
Package name is `jetbrains-jdk-11`.
Version is `11.0.4 build 520.2`.
The `-11` is part of package name because there is also a JDK 8 by JetBrains.
If there is a way to publish multiple disjoint versions of a package by the same name, (eg a jetbrains-jdk v8 and a v11), I would appreciate a pointer so I could change the template here. 

The sources for this are available at the "homepage" location.
Ideally, we should build the sources to JetBrainsd JDK, however, I do not currently have the time to setup that build.
There is such a package in AUR in Arch Linux, it could be used as an example.

Once this is merged, I will also update PR #11736 to depend on this jdk.

