### PR TITLE
pass: add "x11" build option

### DIFF
--- a/srcpkgs/pass/template
+++ b/srcpkgs/pass/template
@@ -6,7 +6,7 @@ archs=noarch
 wrksrc="password-store-${version}"
 build_style=gnu-makefile
 make_install_args="WITH_BASHCOMP=yes WITH_ZSHCOMP=yes WITH_FISHCOMP=yes"
-depends="bash gnupg2 tree xclip"
+depends="bash gnupg2 tree $(vopt_if x11 xclip)"
 checkdepends="${depends} git"
 short_desc="Stores, retrieves, generates, and synchronizes passwords securely"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
@@ -15,6 +15,8 @@ homepage="http://www.passwordstore.org/"
 distfiles="http://git.zx2c4.com/password-store/snapshot/password-store-${version}.tar.xz"
 checksum=2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4
 make_check_target=test
+build_options="x11"
+build_options_default="x11"
 
 passmenu_package() {
 	short_desc="A dmenu-based interface to pass"


### PR DESCRIPTION
When "x11" option is disabled (enabled by default), "xclip" and
transitive dependencies on X libraries are not pulled by package
installation.

"xclip" still can be installed separately, though, to regain full
functionality.