### PR TITLE
rpi-kernel: enable IR device modules

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -10,7 +10,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
 version=4.19.79
-revision=1
+revision=2
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
@@ -80,6 +80,14 @@ do_configure() {
 	echo "CONFIG_PROC_EVENTS=y" >> "$defconfig"
 	echo "CONFIG_F2FS_FS_SECURITY=y" >> "$defconfig"
 	echo "CONFIG_CGROUP_PIDS=y" >> "$defconfig"
+	
+	# IR Remote Support
+	echo "CONFIG_RC_CORE=y" >> "$defconfig"
+	echo "CONFIG_LIRC=y" >> "$defconfig"
+	echo "CONFIG_RC_DECODERS=y" >> "$defconfig"
+	echo "CONFIG_RC_DEVICES=y" >> "$defconfig"
+	echo "CONFIG_IR_RC6_DECODER=m" >> "$defconfig"
+	echo "CONFIG_IR_MCEUSB=m" >> "$defconfig"
 
 	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
 


### PR DESCRIPTION
[skip ci]

`mceusb` and related modules aren't enabled in the kernel, preventing IR remotes from working.