### PR TITLE
runit-void: add hvc0 and hvsi0 agetty services + fix license

### DIFF
--- a/srcpkgs/runit-void/patches/7082410e3381937f5b42a609884666c44a63d269.patch
+++ b/srcpkgs/runit-void/patches/7082410e3381937f5b42a609884666c44a63d269.patch
@@ -1,0 +1,99 @@
+From 7082410e3381937f5b42a609884666c44a63d269 Mon Sep 17 00:00:00 2001
+From: q66 <daniel@octaforge.org>
+Date: Sun, 20 Oct 2019 22:27:01 +0200
+Subject: [PATCH] services: add agetty services for hvc0 and hvsi0
+
+These are used for virtual terminal/serial console on some
+hypervisors (Xen) as well as many POWER based machines (the
+OPAL firmware emulates these for serial as the OS has no
+physical access to that).
+---
+ services/agetty-hvc0/conf       | 3 +++
+ services/agetty-hvc0/finish     | 1 +
+ services/agetty-hvc0/run        | 1 +
+ services/agetty-hvc0/supervise  | 1 +
+ services/agetty-hvsi0/conf      | 8 ++++++++
+ services/agetty-hvsi0/finish    | 1 +
+ services/agetty-hvsi0/run       | 1 +
+ services/agetty-hvsi0/supervise | 1 +
+ 8 files changed, 17 insertions(+)
+ create mode 100644 services/agetty-hvc0/conf
+ create mode 120000 services/agetty-hvc0/finish
+ create mode 120000 services/agetty-hvc0/run
+ create mode 120000 services/agetty-hvc0/supervise
+ create mode 100644 services/agetty-hvsi0/conf
+ create mode 120000 services/agetty-hvsi0/finish
+ create mode 120000 services/agetty-hvsi0/run
+ create mode 120000 services/agetty-hvsi0/supervise
+
+diff --git a/services/agetty-hvc0/conf b/services/agetty-hvc0/conf
+new file mode 100644
+index 0000000..ecf4f1e
+--- /dev/null
++++ services/agetty-hvc0/conf
+@@ -0,0 +1,3 @@
++GETTY_ARGS="-L"
++BAUD_RATE=9600
++TERM_NAME=vt100
+diff --git a/services/agetty-hvc0/finish b/services/agetty-hvc0/finish
+new file mode 120000
+index 0000000..ad464cb
+--- /dev/null
++++ services/agetty-hvc0/finish
+@@ -0,0 +1 @@
++../agetty-generic/finish
+\ No newline at end of file
+diff --git a/services/agetty-hvc0/run b/services/agetty-hvc0/run
+new file mode 120000
+index 0000000..ffa62a5
+--- /dev/null
++++ services/agetty-hvc0/run
+@@ -0,0 +1 @@
++../agetty-serial/run
+\ No newline at end of file
+diff --git a/services/agetty-hvc0/supervise b/services/agetty-hvc0/supervise
+new file mode 120000
+index 0000000..665ccf0
+--- /dev/null
++++ services/agetty-hvc0/supervise
+@@ -0,0 +1 @@
++/run/runit/supervise.agetty-hvc0
+\ No newline at end of file
+diff --git a/services/agetty-hvsi0/conf b/services/agetty-hvsi0/conf
+new file mode 100644
+index 0000000..ec61b5f
+--- /dev/null
++++ services/agetty-hvsi0/conf
+@@ -0,0 +1,8 @@
++GETTY_ARGS="-L"
++if [ -x /sbin/agetty -o -x /bin/agetty ]; then
++	# util-linux specific settings
++	GETTY_ARGS="${GETTY_ARGS} -8"
++fi
++
++BAUD_RATE=19200
++TERM_NAME=vt100
+diff --git a/services/agetty-hvsi0/finish b/services/agetty-hvsi0/finish
+new file mode 120000
+index 0000000..ad464cb
+--- /dev/null
++++ services/agetty-hvsi0/finish
+@@ -0,0 +1 @@
++../agetty-generic/finish
+\ No newline at end of file
+diff --git a/services/agetty-hvsi0/run b/services/agetty-hvsi0/run
+new file mode 120000
+index 0000000..ffa62a5
+--- /dev/null
++++ services/agetty-hvsi0/run
+@@ -0,0 +1 @@
++../agetty-serial/run
+\ No newline at end of file
+diff --git a/services/agetty-hvsi0/supervise b/services/agetty-hvsi0/supervise
+new file mode 120000
+index 0000000..7dd4fb6
+--- /dev/null
++++ services/agetty-hvsi0/supervise
+@@ -0,0 +1 @@
++/run/runit/supervise.agetty-hvsi0
+\ No newline at end of file

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,13 +1,13 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20190906
-revision=1
+revision=2
 wrksrc="void-runit-${version}"
 build_style=gnu-makefile
-homepage="https://github.com/void-linux/void-runit"
 short_desc="Void Linux runit scripts"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="Public Domain"
+license="CC0-1.0"
+homepage="https://github.com/void-linux/void-runit"
 distfiles="https://github.com/void-linux/void-runit/archive/${version}.tar.gz"
 checksum=9e1027c07124ff4efad63bef74b9f1ae0659e43f9d4e7cfde996be271706570c
 


### PR DESCRIPTION
This backports from the `void-runit` repo. It just adds these two default services to scratch my (and other people's) itches.