### PR TITLE
rustup: update to 1.20.2.

### DIFF
--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,7 +1,7 @@
 # Template file for 'rustup'
 pkgname=rustup
-version=1.18.3
-revision=2
+version=1.20.2
+revision=1
 wrksrc="${pkgname}.rs-${version}"
 build_style=cargo
 configure_args="--features no-self-update --bin rustup-init"
@@ -12,10 +12,10 @@ maintainer="Daniel Lee Ramírez <dleeram@protonmail.com>"
 license="Apache-2.0, MIT"
 homepage="https://www.rustup.rs"
 distfiles="https://github.com/rust-lang-nursery/${pkgname}.rs/archive/${version}.tar.gz"
-checksum=9a2ae2c85bbbfc838b25d86d049bc677532950d78765725beabb8a61df1c2710
+checksum=4d47ef7468c615fd10fbb07a16c15754336263d7417ee1685dfbd6e3ec151084
 
 pre_build() {
-	cargo update --package openssl-sys --precise 0.9.46
+	cargo update --package openssl-sys --precise 0.9.52
 	cargo update --package openssl --precise 0.10.22
 }
 


### PR DESCRIPTION
Travis build succeeded on [my fork](https://travis-ci.org/Wychmire/void-packages/builds/601026991) and installs/updates toolchains properly on my local install.