### PR TITLE
glances: update to 3.1.3.

### DIFF
--- a/srcpkgs/glances/template
+++ b/srcpkgs/glances/template
@@ -1,9 +1,8 @@
 # Template file for 'glances'
 pkgname=glances
-version=3.1.2
+version=3.1.3
 revision=1
 archs=noarch
-wrksrc="Glances-${version}"
 build_style=python3-module
 pycompile_module="glances"
 hostmakedepends="python3-setuptools"
@@ -12,8 +11,8 @@ short_desc="Cross-platform curses-based monitoring tool"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/nicolargo/glances"
-distfiles="${PYPI_SITE}/G/Glances/Glances-${version}.tar.gz"
-checksum=733a30ee580d062759640a3ce9d7f5798b80c24e6dbf8f96269227bed7256894
+distfiles="https://github.com/nicolargo/glances/archive/v${version}.tar.gz"
+checksum=e3e8f9362b82c74427522e82501b47696945251035b35282f9ee4bc533996220
 
 post_install() {
 	vsconf conf/glances.conf


### PR DESCRIPTION
Fetch sources from github, the PYPI tarball now bundles and installs a lot of unneeded nodejs modules.