### PR TITLE
erlang: update to 22.1.4.

### DIFF
--- a/srcpkgs/erlang/template
+++ b/srcpkgs/erlang/template
@@ -1,6 +1,6 @@
 # Template file for 'erlang'
 pkgname=erlang
-version=22.1.3
+version=22.1.4
 revision=1
 create_wrksrc=yes
 build_wrksrc="otp-OTP-${version}"
@@ -15,7 +15,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Apache-2.0"
 homepage="http://www.erlang.org/"
 distfiles="https://github.com/erlang/otp/archive/OTP-${version}.tar.gz"
-checksum=53a828c1199a41cb54bd3bc6c2c49af977a8834e702c030a5ea34013a3fcacdd
+checksum=982e940c8c3313b1af27938655b4e90991d54bd6720b238c25438c16bc51699f
 
 build_options="x11"
 


### PR DESCRIPTION
CI skipped because the builds exceed Travis's timeout.