### PR TITLE
checkbashism: add notice to only bump version if necessary

### DIFF
--- a/srcpkgs/checkbashisms/template
+++ b/srcpkgs/checkbashisms/template
@@ -1,4 +1,6 @@
 # Template file for 'checkbashisms'
+# Not all upstream version bump is relevant to this script,
+# Please check before submit it to void-packages
 pkgname=checkbashisms
 version=2.19.7
 revision=1


### PR DESCRIPTION
Most of changes in Debian devscript is not relevant to the checkbashism.

The last change to checkbashism.pl was v2.19.6, and it was only code
formatting change.

The last meaningful changes to checkbashism.pl was v2.11.7, and it's
from 2012.

Add this notice so people won't make useless version bump to this script