### PR TITLE
rpi-kernel: update to 4.19.80.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,19 +5,19 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="047589b6dcd5dfd9673a995c5d36ec4073e578b5"
+_githash="3492a1b003494535eb1b17aa7f258469036b1de7"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.79
-revision=2
+version=4.19.80
+revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=f617730cd3a3ca35351259cc58105d95a4d106b8a2971386c81dab073c0fbd15
+checksum=41c64cab0192843512df8c6663f4021e594c29ff4c8087e9008a39170b25a4e3
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built on armv6l, armv7l, aarch64.
- Tested on armv6l and armv7l.