### PR TITLE
firefox esr 68.2.0

### DIFF
--- a/srcpkgs/firefox-esr-i18n/template
+++ b/srcpkgs/firefox-esr-i18n/template
@@ -1,6 +1,6 @@
 # Template file for 'firefox-esr-i18n'
 pkgname=firefox-esr-i18n
-version=68.1.0
+version=68.2.0
 revision=1
 build_style=meta
 homepage="https://www.mozilla.org/firefox/"

--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -3,8 +3,8 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/firefox-esr-i18n".
 #
 pkgname=firefox-esr
-version=68.1.0
-revision=3
+version=68.2.0
+revision=1
 wrksrc="firefox-${version}"
 build_helper="rust"
 short_desc="Mozilla Firefox web browser - Extended Support Release (ESR)"
@@ -12,7 +12,7 @@ maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="MPL-2.0, GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.mozilla.org/firefox/organizations/"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
-checksum=f56f5fa5a4744be0b9acf259cb991254d708a50b9a0a12d1d846ffa5a6c409ac
+checksum=85f1c2eaf68ebedcbc0b78a342f6d16ef0865dedd426a1bba94b75c85f716f38
 
 lib32disabled=yes
 hostmakedepends="autoconf213 unzip zip pkg-config perl python yasm
@@ -110,10 +110,6 @@ do_build() {
 	mkdir -p third_party/rust/libloading/.deps
 
 	case "$XBPS_TARGET_MACHINE" in
-	i686*)
-		export CFLAGS+=" -D_FILE_OFFSET_BITS=64"
-		export CXXFLAGS+=" -D_FILE_OFFSET_BITS=64"
-		;;
 	armv7*)
 		export CFLAGS+=" -mfpu=neon -Wno-psabi"
 		export CXXFLAGS+=" -mfpu=neon -Wno-psabi"


### PR DESCRIPTION
Built for:
- [x] x86_64
- [x] x86_64-musl
- [x] aarch64
- [x] aarch64-musl
- [x] i686
- [x] armv7hf
- [x] armv7hf-musl

Tested with:
- [x] x86_64
- [x] x86_64-musl

---
I'm trying to remove the conflict between firefox and firefox-esr