### PR TITLE
[WIP] xfce4-panel: update to 4.15.0.

### DIFF
--- a/srcpkgs/xfce4-panel/template
+++ b/srcpkgs/xfce4-panel/template
@@ -1,7 +1,7 @@
 # Template file for 'xfce4-panel'
 pkgname=xfce4-panel
-version=4.14.1
-revision=2
+version=4.15.0
+revision=1
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static --enable-gio-unix --enable-gtk3"
@@ -12,7 +12,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=9c3c78b49ddfac7d42a804e6a6ad9d22ad64ec60bbe17d8724bc52d3e3f6d114
+checksum=a4a8c9e2526f9006796aa37e9945a198aada3d53b7001ea176762eae70b9eb9f
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
This breaks the following packages due to:

```
unresolvable shlib `libxfce4panel-1.0.so.4'
```

- [ ] orage
- [ ] xfce4-notes-plugin
- [ ] xfce4-windowck-plugin