### PR TITLE
libGL: update to 19.2.2

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,6 +1,6 @@
 # Template file for 'libGL'
 pkgname=libGL
-version=19.2.1
+version=19.2.2
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
@@ -22,7 +22,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://www.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=4cc53ca1a8d12c6ff0e5ea44a5213c05c88447ab50d7e28bb350cd29199f01e9
+checksum=7e4f0e2678bfcf3b94f533078b514f37943378a4a8604e477c888ec8a2904394
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
Tested on musl under Wayland with Intel drivers.