### PR TITLE
chromium-widevine: update file structure for 78.0.3904.70

### DIFF
--- a/srcpkgs/chromium-widevine/INSTALL
+++ b/srcpkgs/chromium-widevine/INSTALL
@@ -9,9 +9,16 @@ post)
     # Things that have to happen no matter what
     cd $BUILD_DIR
     ar x $PKGNAME.deb
-    tar xf data.tar.xz --wildcards './opt/google/chrome/libwidevine*'
+    tar xf data.tar.xz --wildcards './opt/google/chrome/WidevineCdm/'
     cd -
-    mv $BUILD_DIR/opt/google/chrome/libwidevine* usr/lib/chromium
+    # Remove previous components
+    rm -fr /usr/lib/chromium/WidevineCdm /usr/lib/chromium/libwidevinecdm.so
+    # Move new components
+    mv $BUILD_DIR/opt/google/chrome/WidevineCdm /usr/lib/chromium/
+    ln -s /usr/lib/chromium/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so /usr/lib/chromium/libwidevinecdm.so
+    [ ! -d /usr/lib/chromium-dev ] && mkdir /usr/lib/chromium-dev
+    ln -s /usr/lib/chromium/WidevineCdm /usr/lib/chromium-dev/WidevineCdm
+    # Cleanup
     rm -r $BUILD_DIR
     ;;
 esac

--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -7,7 +7,7 @@ _channel="stable"
 
 pkgname=chromium-widevine
 version=78.0.3904.70
-revision=1
+revision=2
 archs="x86_64"
 create_wrksrc=yes
 short_desc="Browser plugin designed for the viewing of premium video content"


### PR DESCRIPTION
With the update to 78.0.3904.70, chromium now expects additional files
and a new file system layout for the widevine component.

This has been tested with Netflix and Amazon Prime.