### PR TITLE
New package: castget-2.0.1

### DIFF
--- a/srcpkgs/castget/template
+++ b/srcpkgs/castget/template
@@ -1,0 +1,13 @@
+# Template file for 'castget'
+pkgname=castget
+version=2.0.1
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="glib-devel libxml2-devel libcurl-devel id3lib-devel"
+short_desc="Simple command-line RSS enclosure downloader"
+maintainer="AN3223 <ethanr2048@gmail.com>"
+license="LGPL-2.1-or-later"
+homepage="https://castget.johndal.com/"
+distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
+checksum=438b5f7ec7e31a45ed3756630fe447f42015acda53ec09202f48628726b5e875


### PR DESCRIPTION
A simple, command-line based RSS enclosure downloader, primarily intended for automatic, unattended downloading of podcasts.