### PR TITLE
bluez-alsa: fix d-bus config file

### DIFF
--- a/srcpkgs/bluez-alsa/files/bluez_alsa.conf
+++ b/srcpkgs/bluez-alsa/files/bluez_alsa.conf
@@ -1,7 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  <policy user="_bluez_alsa">
-    <allow send_destination="org.bluez"/>
-  </policy>
-</busconfig>

--- a/srcpkgs/bluez-alsa/template
+++ b/srcpkgs/bluez-alsa/template
@@ -1,7 +1,7 @@
 # Template file for 'bluez-alsa'
 pkgname=bluez-alsa
 version=2.0.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-aac --disable-hcitop --enable-debug"
 hostmakedepends="pkg-config automake libtool"
@@ -21,7 +21,8 @@ pre_configure() {
 }
 
 post_install() {
-	vinstall ${FILESDIR}/bluez_alsa.conf 644 etc/dbus-1/system.d/
+	vsed -i ${DESTDIR}/etc/dbus-1/system.d/bluealsa.conf \
+		-e 's:user="root":user="_bluez_alsa":'
 
 	vlicense LICENSE
 	vsv bluez-alsa


### PR DESCRIPTION
bluez-alsa 2.0.0 is unable to start and produces the following error:
```
bluealsa: Couldn't acquire D-Bus name: org.bluealsa
```
This is caused by the Void provided D-Bus config file `/etc/dbus-1/system.d/bluez_alsa.conf`. It uses the incorrect D-Bus service name `org.bluez` instead of `org.bluealsa` that bluez-alsa 2.0.0 uses.

This pull request deletes the Void provided config file and instead relies on the upstream one (`/etc/dbus-1/system.d/bluealsa.conf`) that bluez-alsa 2.0.0 installs. It also fixes the upstream config file to work with the `bluez_alsa` user instead of `root`.