### PR TITLE
Clp: reenable everywhere and disable AVX2 usage on x86_64

### DIFF
--- a/srcpkgs/Clp/patches/disable-avx.patch
+++ b/srcpkgs/Clp/patches/disable-avx.patch
@@ -1,0 +1,46 @@
+This disables AVX2 usage on x86_64 (by defining NO_AVX_HARDWARE) as well as
+removes now-unused includes for AVX2/AVX512 instrinsics (the NEON header
+was never used in the first place and the way it's included is completely
+wrong anyway).
+
+We need it disabled on x86_64 because we're generic (and AVX is sandybridge
+and newer, but the enabled code was for haswell and newer), and on other
+arches it's disabled for obvious reasons.
+
+--- Clp/src/ClpPackedMatrix.cpp
++++ Clp/src/ClpPackedMatrix.cpp
+@@ -6749,11 +6749,6 @@ ClpPackedMatrix3::ClpPackedMatrix3()
+ }
+ #ifdef _MSC_VER
+ #include <intrin.h>
+-#elif defined(__arm__)
+-#include <arm_neon.h>
+-#else
+-#include <immintrin.h>
+-//#include <fmaintrin.h>
+ #endif
+ /* Constructor from copy. */
+ ClpPackedMatrix3::ClpPackedMatrix3(ClpSimplex *model, const CoinPackedMatrix *columnCopy)
+@@ -6777,7 +6772,7 @@ ClpPackedMatrix3::ClpPackedMatrix3(ClpSimplex *model, const CoinPackedMatrix *co
+ {
+   //#undef COIN_AVX2
+   //#define COIN_AVX2 8
+-  //#define NO_AVX_HARDWARE
++#define NO_AVX_HARDWARE
+ #ifndef COIN_AVX2
+ #define COIN_AVX2 4
+ #else
+--- Clp/src/ClpSimplexDual.cpp
++++ Clp/src/ClpSimplexDual.cpp
+@@ -3556,11 +3556,6 @@ void moveAndZero(clpTempInfo *info, int type, void *extra)
+ #endif
+ #ifdef _MSC_VER
+ #include <intrin.h>
+-#elif defined(__arm__)
+-#include <arm_neon.h>
+-#else
+-#include <immintrin.h>
+-//#include <fmaintrin.h>
+ #endif
+ int ClpSimplexDual::dualColumn0(const CoinIndexedVector *rowArray,
+   const CoinIndexedVector *columnArray,

--- a/srcpkgs/Clp/template
+++ b/srcpkgs/Clp/template
@@ -1,7 +1,7 @@
 # Template file for 'Clp'
 pkgname=Clp
 version=1.17.3
-revision=1
+revision=2
 build_style=gnu-configure
 depends="libClp>=${version}_${revision}"
 short_desc="COIN LP Solver"
@@ -10,10 +10,6 @@ license="EPL-1.0"
 homepage="http://projects.coin-or.org/Clp"
 distfiles="https://www.coin-or.org/Tarballs/${pkgname}/${pkgname}-${version}.tgz"
 checksum=a13bf54291ad503cf76f5f93f2643d2add4faa5d0e60ff2db902ef715c094573
-
-case "$XBPS_TARGET_MACHINE" in
-	aarch64*) broken="https://travis-ci.org/void-linux/void-packages/jobs/596999100"
-esac
 
 libClp-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
please, next time check for that kinda stuff before blindly bumping it (and it should receive a better review too) and marking stuff broken

we had haswell avx2 code enabled and that's unacceptable

@mobinmob @xtraeme