### PR TITLE
[TESTING] firefox: fix build for armv7hf-musl

### DIFF
--- a/srcpkgs/firefox/patches/musl-rust.configure.patch
+++ b/srcpkgs/firefox/patches/musl-rust.configure.patch
@@ -1,0 +1,26 @@
+--- build/moz.configure/rust.configure	2019-10-28 12:05:04.930404603 +0700
++++ build/moz.configure/rust.configure	2019-10-28 12:09:42.742338957 +0700
+@@ -297,11 +297,20 @@
+                     suffix = 'hf'
+                 else:
+                     suffix = ''
++
++                narrowed = []
+                 for p in prefixes:
+                     for c in candidates:
+-                        if c.rust_target.startswith('{}-'.format(p)) and \
+-                                c.rust_target.endswith(suffix):
+-                            return c.rust_target
++                        if c.rust_target.startswith('{}-'.format(p)):
++                            narrowed.append(c.rust_target)
++
++                for target in narrowed:
++                    if target.endswith(host_or_target.raw_os):
++                        return target
++
++                for target in narrowed:
++                    if target.endswith(suffix):
++                        return target
+ 
+             # See if we can narrow down on the exact alias
+             narrowed = [c for c in candidates if c.target.alias == host_or_target.alias]

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -32,7 +32,6 @@ build_options="alsa dbus pulseaudio startup_notification xscreensaver sndio wayl
 build_options_default="alsa dbus pulseaudio startup_notification xscreensaver sndio wayland"
 
 case $XBPS_TARGET_MACHINE in
-	armv7l-musl) broken="https://build.voidlinux.org/builders/armv7l-musl_builder/builds/21533/steps/shell_3/logs/stdio" ;;
 	armv6*)
 		broken="required NEON extensions are not supported on armv6"
 		;;


### PR DESCRIPTION
Built for:
- [x] armv7hf-musl
- [ ] armv7hf
- [x] x86_64
- [x] x86_64-musl
- [x] i686
- [ ] aarch64
- [ ] aarch64-musl

Tested with:
- [x] x86_64
- [x] x86_64-musl