### PR TITLE
Kernels: remove host objects from scripts/

### DIFF
--- a/srcpkgs/linux4.19/template
+++ b/srcpkgs/linux4.19/template
@@ -1,7 +1,7 @@
 # Template file for 'linux4.19'
 pkgname=linux4.19
 version=4.19.81
-revision=1
+revision=2
 wrksrc="linux-${version}"
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
@@ -182,6 +182,8 @@ do_install() {
 	# they need to be copied to ${hdrdest} before this step
 	if [ "$CROSS_BUILD" ]; then
 		make ${makejobs} ARCH=${subarch:-$arch} _mrproper_scripts
+		# remove host specific objects as well
+		find scripts -name '*.o' -delete
 	fi
 
 	# Copy files necessary for later builds, like nvidia and vmware

--- a/srcpkgs/linux5.3/template
+++ b/srcpkgs/linux5.3/template
@@ -1,7 +1,7 @@
 # Template file for 'linux5.3'
 pkgname=linux5.3
 version=5.3.7
-revision=1
+revision=2
 wrksrc="linux-${version}"
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Foxlet <foxlet@furcode.co>"
@@ -182,6 +182,8 @@ do_install() {
 	# they need to be copied to ${hdrdest} before this step
 	if [ "$CROSS_BUILD" ]; then
 		make ${makejobs} ARCH=${subarch:-$arch} _mrproper_scripts
+		# remove host specific objects as well
+		find scripts -name '*.o' -delete
 	fi
 
 	# Copy files necessary for later builds, like nvidia and vmware

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -10,7 +10,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
 version=4.19.80
-revision=1
+revision=2
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
@@ -181,6 +181,8 @@ do_install() {
 	# they need to be copied to ${hdrdest} before this step
 	if [ "$CROSS_BUILD" ]; then
 		make ${makejobs} ARCH=${_arch} _mrproper_scripts
+		# remove host specific objects as well
+		find scripts -name '*.o' -delete
 	fi
 
 	# Copy files necessary for later builds.


### PR DESCRIPTION
Shipping objects generated during cross-build makes no sense and breaks
"make scripts" on the targets on first dkms build