### PR TITLE
libtool: respect environment variables

### DIFF
--- a/srcpkgs/libtool/template
+++ b/srcpkgs/libtool/template
@@ -1,13 +1,13 @@
 # Template file for 'libtool'
 pkgname=libtool
 version=2.4.6
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="perl automake help2man"
 depends="tar sed"
 short_desc="Generic library support script"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.gnu.org/software/libtool"
 distfiles="${GNU_SITE}/libtool/$pkgname-$version.tar.xz"
 checksum=7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f
@@ -28,8 +28,8 @@ post_install() {
 	# things that need to go; the target libtool script is meant to be used
 	# in native environments, not in cross environments, so patch the script
 	if [ "$CROSS_BUILD" ]; then
-		# e.g. AR="armv7l-linux-gnueabihf-ar" becomes AR="ar"
-		vsed -i -e "s,=\"${XBPS_CROSS_TRIPLET}\-,=\",g" \
+		# e.g. AR="armv7l-linux-gnueabihf-ar" becomes AR="${AR:=ar}"
+		vsed -i -e "s,\([A-Z]\+\)=\"${XBPS_CROSS_TRIPLET}\-\(.*\)\",\1=\$\{\1:=\2\},g" \
 		 ${PKGDESTDIR}/usr/bin/libtool
 
 		# clear out any sysroot present


### PR DESCRIPTION
The /usr/bin/libtool script used to use cross tool-chains, when it was cross compiled.
This broke cross-built libtool for native builds and was changed in
653f4339274d162109af27c93a741264460f2da4 to native tool-chains.
Setting native tool-chains in libtools causes cross-builds which use libtool to fail.

Thus, change /usr/bin/libtool to use environment variables when defined and fall back to the native tool-chain otherwise.