### PR TITLE
New Package: RabbitMQ C-Client

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3519,3 +3519,4 @@ libluv.so.1 libluv-1.30.1.0_1
 libarmadillo.so.9 armadillo-9.700.2_1
 libvarnishapi.so.2 libvarnishapi-6.3.0_1
 libicns.so.1 libicns-0.8.1_1
+librabbitmq.so.4 rabbitmq-c-0.9.0_1

--- a/srcpkgs/rabbitmq-c-devel
+++ b/srcpkgs/rabbitmq-c-devel
@@ -1,0 +1,1 @@
+rabbitmq-c

--- a/srcpkgs/rabbitmq-c/template
+++ b/srcpkgs/rabbitmq-c/template
@@ -1,0 +1,28 @@
+# Template file for 'rabbitmq-c'
+pkgname=rabbitmq-c
+version=0.9.0
+revision=1
+build_style=cmake
+hostmakedepends="popt xmlto doxygen"
+makedepends="libressl-devel"
+short_desc="RabbitMQ C client"
+maintainer="Hans-J. Schmid <knock@myopendoor.de>"
+license="MIT"
+homepage="https://github.com/alanxz/rabbitmq-c"
+distfiles="https://github.com/alanxz/${pkgname}/archive/v${version}.tar.gz"
+checksum=316c0d156452b488124806911a62e0c2aa8a546d38fc8324719cd29aaa493024
+
+post_install() {
+	vlicense LICENSE-MIT
+}
+
+rabbitmq-c-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/*.a
+		vmove usr/lib/*.so
+	}
+}


### PR DESCRIPTION
I'm getting this message:

> WARNING: rabbitmq-c-0.9.0_1: librabbitmq.so.4 not found in common/shlibs!

Can I ignore it or do I have to manually add the new library to common/shlibs?