### PR TITLE
ImageMagick6: update to 6.9.10-69

### DIFF
--- a/srcpkgs/ImageMagick6/template
+++ b/srcpkgs/ImageMagick6/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick6'
 pkgname=ImageMagick6
 _majorver=6.9.10
-_patchver=68
+_patchver=69
 version="${_majorver}.${_patchver}"
 revision=1
 wrksrc="${pkgname}-${_majorver}-${_patchver}"
@@ -20,7 +20,7 @@ maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org/"
 distfiles="https://github.com/ImageMagick/ImageMagick6/archive/${_majorver}-${_patchver}.tar.gz"
-checksum=2caa3d8d1f65e733de30d1f537e57991ff3adb3edb5b60afa9cd0f6e0a20945f
+checksum=d5625ed92e593d8dc02cdbe87a8a83a0a5accf4c3f6aad9379c130c27582887b
 
 keep_libtool_archives=yes
 conf_files="/etc/ImageMagick-${_majorver%%.*}/*.xml"


### PR DESCRIPTION
Includes fixes for CVE-2019-17540
URL:https://security-tracker.debian.org/tracker/CVE-2019-17540