### PR TITLE
numactl: add devel file system link to support devel subpackage

### DIFF
--- a/srcpkgs/numactl-devel
+++ b/srcpkgs/numactl-devel
@@ -1,0 +1,1 @@
+numactl


### PR DESCRIPTION
devel subpackage already defined. Just the file system link is missing.