### PR TITLE
turbovnc: update to 2.2.3

### DIFF
--- a/srcpkgs/turbovnc/template
+++ b/srcpkgs/turbovnc/template
@@ -1,6 +1,6 @@
 # Template file for 'turbovnc'
 pkgname=turbovnc
-version=2.2.2
+version=2.2.3
 revision=1
 build_style=cmake
 configure_args="-DTJPEG_LIBRARY=/usr/lib/libturbojpeg.so -DTVNC_BUILDJAVA=0
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://virtualgl.org"
 distfiles="${SOURCEFORGE_SITE}/turbovnc/${pkgname}-${version}.tar.gz"
-checksum=7f1593a3db88dc800d0f82091252ca293b1980a28417b9834ce713eb7e0d09bc
+checksum=1c3de5abc66b3a2c45fb7ec6c75ddf54241153e5770f7d05ffd2dfef5d086981
 
 conf_files="/etc/*.conf"
 archs="i686* x86_64* ppc64*"


### PR DESCRIPTION
Includes fix for CVE-2019-15683