### PR TITLE
util-linux: compile with eudev

### DIFF
--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -1,9 +1,9 @@
 # Template file for 'util-linux'
 pkgname=util-linux
 version=2.34
-revision=2
+revision=3
 hostmakedepends="automake bison gettext-devel libtool pkg-config"
-makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel"
+makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel eudev-libudev-devel"
 checkdepends="ncurses" # Some tests require terminfo-entries
 short_desc="Miscellaneous linux utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -40,8 +40,7 @@ do_configure() {
 		--enable-fs-paths-extra=/usr/sbin:/usr/bin \
 		--enable-vipw --enable-newgrp --enable-chfn-chsh \
 		--with-systemdsystemunitdir=no \
-		--without-udev --without-python \
-		--enable-write
+		--without-python --enable-write
 }
 
 do_build() {
@@ -152,4 +151,3 @@ libsmartcols_package() {
 		vmove usr/lib/libsmartcols.so.*
 	}
 }
-


### PR DESCRIPTION
lsblk needs udev support to read LABEL, UUID and filesystem without root
permission.

eudev is already a dependency of base-voidstrap and base-system,
so most of people won't be effected by this new dependencies.

However, base-minimal depends on util-linux but not eudev.