### PR TITLE
chrony: fix wrong option in the default config.

### DIFF
--- a/srcpkgs/chrony/template
+++ b/srcpkgs/chrony/template
@@ -2,7 +2,7 @@
 # When Updating: Please confirm the upstream config still refers to make_dirs
 pkgname=chrony
 version=3.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-nss --enable-scfilter
  --with-sendmail=/usr/bin/sendmail"
@@ -29,12 +29,8 @@ alternatives="
  ntpd:ntpd:/etc/sv/chronyd"
 
 post_install() {
-	vconf examples/chrony.conf.example3 chrony.conf
-	# Modify default configuration so it works out-of-the-box
-	vsed -e 's,! pool pool.ntp.org iburst,pool pool.ntp.org iburst,' -i ${DESTDIR}/etc/chrony.conf
-	vsed -e 's,! rtcfile /var/lib/chrony/rtc,rtcfile /var/lib/chrony/rtc,' -i ${DESTDIR}/etc/chrony.conf
-	vsed -e 's,! makestep 1.0 3,makestep 1.0 3,' -i ${DESTDIR}/etc/chrony.conf
-	vsconf examples/chrony.conf.example1
+	vconf examples/chrony.conf.example1 chrony.conf
 	vsconf examples/chrony.conf.example2
+	vsconf examples/chrony.conf.example3
 	vsv chronyd
 }


### PR DESCRIPTION
The option rtcfile in the default config conflicts with runit's stage 3.
Chronyd in RTC mode takes control of /dev/rtc to measure RTC drift.
Stage 3 calls hwclock -w, which messes up chrony's drift calculation.
Furthermore the current chronyd runit service needs the -s option
to effectively use the RTC feature.

See for more info:
https://chrony.tuxfamily.org/faq.html#_i_want_to_use_code_chronyd_code_s_rtc_support_must_i_disable_code_hwclock_code

Switch rtcfile to the rtcsync option, to be consistent with stage 3.
Example config file 1 sets the right options that work out of the box.
So use that example file instead of editing the annotated one.
Example config file 3 will instead be installed to /usr/share/examples.