### PR TITLE
git: correct utf-16 and utf-32 conversion on musl

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
 version=2.23.0
-revision=1
+revision=2
 bootstrap=yes
 wrksrc="git-${version}"
 build_style=gnu-configure
@@ -26,7 +26,10 @@ else
 fi
 
 case "$XBPS_TARGET_MACHINE" in
-	*-musl) configure_args+=" ac_cv_fread_reads_directories=yes" ;;
+	*-musl)
+		configure_args+=" ac_cv_fread_reads_directories=yes"
+		make_build_args+=" ICONV_OMITS_BOM=Yes"
+		;;
 	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
 esac
 

--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,7 +1,7 @@
 # Template file for 'git'
 pkgname=git
 version=2.23.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2
  ac_cv_snprintf_returns_bogus=no"
@@ -13,7 +13,7 @@ makedepends="libglib-devel libcurl-devel libsecret-devel pcre2-devel tk-devel"
 # Required by https://
 depends="ca-certificates perl-Authen-SASL perl-MIME-tools perl-Net-SMTP-SSL"
 short_desc="Git Tree History Storage Tool"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
@@ -25,7 +25,10 @@ register_shell=/usr/bin/git-shell
 subpackages="git-cvs git-svn gitk git-gui git-all git-libsecret"
 
 case "$XBPS_TARGET_MACHINE" in
-	*-musl) configure_args+=" ac_cv_fread_reads_directories=yes" ;;
+	*-musl)
+		configure_args+=" ac_cv_fread_reads_directories=yes"
+		make_build_args+=" ICONV_OMITS_BOM=Yes"
+		;;
 	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
 esac
 


### PR DESCRIPTION
musl's iconv treats utf-{16,32} encoding as utf-{16,32}be,
without BOM, correctly according to POSIX.

However, most tools out there think differently.

Change the build flag for the musl system to fix it.

Together with my patch here:
https://github.com/git/git/commit/840c40cea11290d40fd455cc3b23d5793056f4d4

git's test: t0028 should be fine now.