### PR TITLE
remove cc alternative group

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.21
 
 pkgname=gcc
 version=${_minorver}.0
-revision=2
+revision=3
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"
@@ -30,7 +30,6 @@ nopie=yes
 lib32disabled=yes
 bootstrap=yes
 replaces="gcc-gcj<7.2.0 gcc-gcj-jdk-compat<7.2.0 libmpx>=0 libmpx-devel>=0"
-alternatives="cc:cc:/usr/bin/gcc"
 
 _have_gccgo=yes
 
@@ -364,6 +363,8 @@ do_install() {
 	ln -sfr ${DESTDIR}/usr/include/c++/${_minorver} \
 		${DESTDIR}/usr/include/c++/${version}
 
+	# cc symlink
+	ln -sfr ${DESTDIR}/usr/bin/gcc ${DESTDIR}/usr/bin/cc
 	# rpcgen wants /lib/cpp, make a symlink
 	ln -sfr ${DESTDIR}/usr/bin/cpp ${DESTDIR}/usr/lib/cpp
 

--- a/srcpkgs/llvm9/template
+++ b/srcpkgs/llvm9/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm9'
 pkgname=llvm9
 version=9.0.0
-revision=3
+revision=4
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="
@@ -216,7 +216,6 @@ clang_package() {
 		*) depends+=" glibc-devel";;
 	esac
 	short_desc+=" - C language family frontend"
-	alternatives="cc:cc:/usr/bin/clang"
 	homepage="https://clang.llvm.org/"
 	pkg_install() {
 		vmove usr/include/clang


### PR DESCRIPTION
The alternative group for cc keeps causing problems, mostly with dkms.
I think the benefit of keeping it isn't worth the trouble it causes.