### PR TITLE
thunderbird: add thunderbird-wayland start script.

### DIFF
--- a/srcpkgs/thunderbird/files/thunderbird-wayland
+++ b/srcpkgs/thunderbird/files/thunderbird-wayland
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec env MOZ_ENABLE_WAYLAND= /usr/lib/thunderbird/thunderbird "$@"

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -4,7 +4,7 @@
 #
 pkgname=thunderbird
 version=68.2.0
-revision=1
+revision=2
 build_helper="rust"
 short_desc="Standalone Mail/News reader"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -202,4 +202,6 @@ do_install() {
 
 	# https://bugzilla.mozilla.org/show_bug.cgi?id=658850
 	ln -sf thunderbird ${DESTDIR}/usr/lib/thunderbird/thunderbird-bin
+
+	vbin ${FILESDIR}/thunderbird-wayland
 }


### PR DESCRIPTION
Thunderbird equivalent for the firefox-wayland script in the firefox
package.