### PR TITLE
[WIP] New package: sysbench-1.0.18

### DIFF
--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -2,7 +2,7 @@
 pkgname=sysbench
 version=1.0.18
 revision=1
-build_style=gnu_configure
+build_style=gnu-configure
 configure_args="--prefix=/usr --with-pgsql"
 hostmakedepends="automake libtool pkg-config"
 makedepends="libaio-devel libmariadbclient-devel postgresql-libs-devel libressl-devel zlib-devel"

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -4,8 +4,8 @@ version=1.0.18
 revision=1
 build_style=gnu-configure
 configure_args="--prefix=/usr --with-pgsql"
-hostmakedepends="automake libtool pkg-config postgresql-libs"
-makedepends="libaio-devel libmariadbclient-devel libressl-devel zlib-devel"
+hostmakedepends="automake libtool pkg-config postgresql-libs-devel"
+makedepends="libaio-devel libmariadbclient-devel libressl-devel zlib-devel postgresql-libs-devel"
 short_desc="Scriptable multi-threaded benchmark tool"
 maintainer="Neel Chotai <neel@neelchotai.com>"
 license="GPL-2.0-only"

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -5,7 +5,8 @@ revision=1
 archs="i686 x86_64"
 build_style=configure
 configure_args="--prefix=/usr --with-pgsql"
-makedepends="make automake libtool pkg-config libaio-devel libmariadbclient-devel postgresql-libs-devel libressl-devel zlib-devel"
+hostmakedepends="make automake libtool pkg-config"
+makedepends="libaio-devel libmariadbclient-devel postgresql-libs-devel libressl-devel zlib-devel"
 short_desc="Scriptable multi-threaded benchmark tool"
 maintainer="Neel Chotai <neel@neelchotai.com>"
 license="GPL-2.0-only"

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -1,0 +1,18 @@
+# Template file for 'sysbench'
+pkgname=sysbench
+version=1.0.18
+revision=1
+archs="i686 x86_64"
+build_style=configure
+configure_args="--prefix=/usr --with-pgsql"
+makedepends="make automake libtool pkg-config libaio-devel libmariadbclient-devel postgresql-libs-devel libressl-devel zlib-devel"
+short_desc="Scriptable multi-threaded benchmark tool"
+maintainer="Neel Chotai <neel@neelchotai.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/akopytov/sysbench"
+distfiles="https://github.com/akopytov/sysbench/archive/${version}.tar.gz"
+checksum=c679b285e633c819d637bdafaeacc1bec13f37da5b3357c7e17d97a71bf28cb1
+
+pre_configure() {
+	./autogen.sh
+}

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -2,10 +2,9 @@
 pkgname=sysbench
 version=1.0.18
 revision=1
-archs="x86_64"
-build_style=configure
+build_style=gnu_configure
 configure_args="--prefix=/usr --with-pgsql"
-hostmakedepends="make automake libtool pkg-config"
+hostmakedepends="automake libtool pkg-config"
 makedepends="libaio-devel libmariadbclient-devel postgresql-libs-devel libressl-devel zlib-devel"
 short_desc="Scriptable multi-threaded benchmark tool"
 maintainer="Neel Chotai <neel@neelchotai.com>"

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -2,7 +2,7 @@
 pkgname=sysbench
 version=1.0.18
 revision=1
-archs="i686 x86_64"
+archs="x86_64"
 build_style=configure
 configure_args="--prefix=/usr --with-pgsql"
 hostmakedepends="make automake libtool pkg-config"

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -4,8 +4,8 @@ version=1.0.18
 revision=1
 build_style=gnu-configure
 configure_args="--prefix=/usr --with-pgsql"
-hostmakedepends="automake libtool pkg-config"
-makedepends="libaio-devel libmariadbclient-devel postgresql-libs-devel libressl-devel zlib-devel"
+hostmakedepends="automake libtool pkg-config postgresql-libs"
+makedepends="libaio-devel libmariadbclient-devel libressl-devel zlib-devel"
 short_desc="Scriptable multi-threaded benchmark tool"
 maintainer="Neel Chotai <neel@neelchotai.com>"
 license="GPL-2.0-only"


### PR DESCRIPTION
sysbench is a scriptable multi-threaded benchmark tool based on LuaJIT. It's often used for database benchmarks but can be used for non-database workloads like CPU, memory and thread benchmarks. The version I've submitted includes MySQL and PostgreSQL benchmarks, I'll also be submitting a template for a version without these.