### PR TITLE
New package: bsnes-112

### DIFF
--- a/srcpkgs/bsnes/template
+++ b/srcpkgs/bsnes/template
@@ -1,0 +1,16 @@
+# Template file for 'bsnes'
+pkgname=bsnes
+version=112
+revision=1
+build_wrksrc=bsnes
+build_style=gnu-makefile
+make_install_args='prefix=${DESTDIR}/usr'
+hostmakedepends="pkg-config"
+makedepends="SDL2-devel gtk+-devel gtksourceview2-devel libXv-devel libao-devel
+libopenal-devel libgomp-devel"
+short_desc="Super Nintendo / Super Famicom emulator"
+maintainer="<orphan@voidlinux.org>"
+license="GPL-3.0-only"
+homepage="https://bsnes.byuu.org/"
+distfiles="https://github.com/byuu/bsnes/archive/v${version}.tar.gz"
+checksum=fc8d113cc771bcf0a091ec549c28c9d41ff169e4ee5bed5b35e31a863f726fd8


### PR DESCRIPTION
It compiles and works fine on x86_64, and it compiles on i686 but I haven't run the application. I set the email as orphan in hopes that someone might want to test the package in i686 and maintain it. Musl is not compiled/tested at all.