### PR TITLE
WIP: ldc: update to 1.18.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1991,11 +1991,11 @@ libFcitxQt5WidgetsAddons.so.1 libfcitx-qt5-1.2.1_1
 libfcitx-qt5.so.0 libfcitx-qt5-0.1.3_1
 liblastfm.so.1 liblastfm-1.0.9_1
 liblastfm_fingerprint.so.1 liblastfm-1.0.9_1
-libdruntime-ldc-debug-shared.so.83 ldc-runtime-1.13.0_1
-libdruntime-ldc-shared.so.83 ldc-runtime-1.13.0_1
-libphobos2-ldc-shared.so.83 ldc-runtime-1.13.0_1
-libphobos2-ldc-debug-shared.so.83 ldc-runtime-1.13.0_1
-libldc-jit.so.83 ldc-runtime-1.13.0_1
+libdruntime-ldc-debug-shared.so.88 ldc-runtime-1.18.0_1
+libdruntime-ldc-shared.so.88 ldc-runtime-1.18.0_1
+libphobos2-ldc-shared.so.88 ldc-runtime-1.18.0_1
+libphobos2-ldc-debug-shared.so.88 ldc-runtime-1.18.0_1
+libldc-jit.so.88 ldc-runtime-1.18.0_1
 libmarblewidget-qt5.so.28 marble5-17.12.2_1
 libastro.so.2 marble5-17.12.2_1
 libparrot.so.6.9.0 parrot-6.9.0_1

--- a/srcpkgs/gtkd/template
+++ b/srcpkgs/gtkd/template
@@ -1,7 +1,7 @@
 # Template file for 'gtkd'
 pkgname=gtkd
 version=3.8.5
-revision=1
+revision=2
 wrksrc="GtkD-${version}"
 build_style=gnu-makefile
 make_build_args="LDFLAGS='-linker=bfd' DC=ldc2"

--- a/srcpkgs/ldc/template
+++ b/srcpkgs/ldc/template
@@ -1,7 +1,7 @@
 # Template file for 'ldc'
 pkgname=ldc
-version=1.13.0
-revision=2
+version=1.18.0
+revision=1
 wrksrc="ldc-${version}-src"
 build_style=cmake
 configure_args="-DINCLUDE_INSTALL_DIR=/usr/include/dlang/ldc -DBUILD_SHARED_LIBS=ON
@@ -16,7 +16,7 @@ license="BSD-3-Clause, BSL-1.0"
 homepage="https://wiki.dlang.org/LDC"
 changelog="https://raw.githubusercontent.com/ldc-developers/ldc/master/CHANGELOG.md"
 distfiles="https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc-${version}-src.tar.gz"
-checksum=4b2fd3eb90fb6debc0ae6d70406bc78fcb531a0f20806640e626d4822e87b2e0
+checksum=aa6b491a4d756942c471778724dbdc7e96026eba4d55720cd66574b9ce42155d
 nopie=yes
 nocross=yes
 

--- a/srcpkgs/tilix/template
+++ b/srcpkgs/tilix/template
@@ -1,7 +1,7 @@
 # Template file for 'tilix'
 pkgname=tilix
 version=1.9.3
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake gettext-devel gdk-pixbuf glib-devel ldc po4a pkg-config
  librsvg"


### PR DESCRIPTION
Tilix build is currently broken due to lack of https://github.com/gnunn1/tilix/pull/1733 within the latest release. I'll notify the maintainers and ask for a tagged release containing the fix.