### PR TITLE
git: keep build flag consistent in all stage

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
 version=2.23.0
-revision=2
+revision=3
 bootstrap=yes
 wrksrc="git-${version}"
 build_style=gnu-configure
@@ -9,8 +9,6 @@ configure_args="--without-curl --without-openssl
  --without-python --without-expat --without-tcltk
  ac_cv_lib_curl_curl_global_init=no ac_cv_lib_expat_XML_ParserCreate=no
  ac_cv_snprintf_returns_bogus=no"
-make_build_args="CC_LD_DYNPATH=-L"
-make_install_args="NO_INSTALL_HARDLINKS=1"
 makedepends="zlib-devel"
 short_desc="GIT Tree History Storage Tool -- for xbps-src use"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -28,10 +26,19 @@ fi
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)
 		configure_args+=" ac_cv_fread_reads_directories=yes"
-		make_build_args+=" ICONV_OMITS_BOM=Yes"
 		;;
 	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
 esac
+
+post_configure() {
+	cat <<-EOF >config.mak
+	CC_LD_DYNPATH=-L
+	NO_INSTALL_HARDLINKS=Yes
+	EOF
+	case "$XBPS_TARGET_MACHINE" in
+		*-musl) echo "ICONV_OMITS_BOM=Yes" >>config.mak ;;
+	esac
+}
 
 do_install() {
 	# remove unneeded stuff.

--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,12 +1,10 @@
 # Template file for 'git'
 pkgname=git
 version=2.23.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2
  ac_cv_snprintf_returns_bogus=no"
-make_install_args="NO_INSTALL_HARDLINKS=1 INSTALLDIRS=vendor
- perllibdir=/usr/share/perl5/vendor_perl"
 make_check_target=test
 hostmakedepends="asciidoc perl pkg-config tk xmlto"
 makedepends="libglib-devel libcurl-devel libsecret-devel pcre2-devel tk-devel"
@@ -27,10 +25,20 @@ subpackages="git-cvs git-svn gitk git-gui git-all git-libsecret"
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)
 		configure_args+=" ac_cv_fread_reads_directories=yes"
-		make_build_args+=" ICONV_OMITS_BOM=Yes"
 		;;
 	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
 esac
+
+post_configure() {
+	cat <<-EOF >config.mak
+	NO_INSTALL_HARDLINKS=Yes
+	INSTALLDIRS=vendor
+	perllibdir=/usr/share/perl5/vendor_perl
+	EOF
+	case "$XBPS_TARGET_MACHINE" in
+		*-musl) echo "ICONV_OMITS_BOM=Yes" >>config.mak ;;
+	esac
+}
 
 post_build() {
 	make ${makejobs} -C Documentation man


### PR DESCRIPTION
git build system will trigger a rebuild if it detects
if flags passed to make changed.

In commit 82a5337c07, ("git: correct utf-16 and utf-32 conversion on
musl", 2019-10-30) , we tried to correct the git-iconv interaction on
musl, but we forget to pass that flag into `make install'.

Hence, on do_install, git build system rebuild git without
ICONV_OMITS_BOM=Yes flag, thus produce faulty binary.

[Save that flag into config.mak][1] in order to keep it consistent across
build stage.

While we're at it, also move other make_*_args into config.mak

[1]: https://public-inbox.org/git/20191031181116.GC2133@sigill.intra.peff.net/

---

git make test isn't fully working in musl right now, so I couldn't find this earlier.

I'm proposing [a series of patch to git][2], if that series get merged,
we can run `./xbps-src check git` on musl. This mistake won't happen again.

[2]: https://public-inbox.org/git/20191101014006.GE30350@danh.dev/T/#re843bfd3d7b4e1592c6546e63d8c65ff57f564ef