### PR TITLE
mame: readd relevant part of ppc patch

### DIFF
--- a/srcpkgs/mame/patches/ppc-fixes.patch
+++ b/srcpkgs/mame/patches/ppc-fixes.patch
@@ -1,0 +1,15 @@
+--- makefile
++++ makefile
+@@ -394,6 +394,12 @@ BIGENDIAN := 1
+ endif
+ endif # BIGENDIAN
+ 
++# Work around an issue with long doubles on ppc (#3157)
++ifneq (,$(findstring ppc,$(UNAME)))
++ARCHOPTS_C += -mlong-double-64
++ARCHOPTS_CXX += -mlong-double-64
++endif
++
+ ifndef PYTHON_EXECUTABLE
+ PYTHON := python
+ else


### PR DESCRIPTION
We still need 64-bit long double.