### PR TITLE
MATE minor update.

### DIFF
--- a/srcpkgs/caja-extensions/template
+++ b/srcpkgs/caja-extensions/template
@@ -1,7 +1,7 @@
 # Template file for 'caja-extensions'
 pkgname=caja-extensions
 version=1.22.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-gksu"
 hostmakedepends="pkg-config intltool glib-devel"

--- a/srcpkgs/caja/template
+++ b/srcpkgs/caja/template
@@ -1,7 +1,7 @@
 # Template file for 'caja'
 pkgname=caja
 version=1.22.2
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static --disable-packagekit --disable-schemas-compile

--- a/srcpkgs/eom/template
+++ b/srcpkgs/eom/template
@@ -1,6 +1,6 @@
 # Template file for 'eom'
 pkgname=eom
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 build_helper="gir"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=64d73069ba4db8515a6c2c90fadba87e1c5cac67dd1e102b271f62e537ee970e
+checksum=3451efd64c7d26be4059c5f4163c190a4341a3023ca60c3405313cae08a7417d
 
 eom-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/libmateweather/template
+++ b/srcpkgs/libmateweather/template
@@ -1,6 +1,6 @@
 # Template file for 'libmateweather'
 pkgname=libmateweather
-version=1.22.0
+version=1.22.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-python
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=ca5cca359ed53fabef194884d76d93eafbc35eee8bcd951c5b8e5942397b2be6
+checksum=0386e31062dfb847f93fd2e46da51b67e80581f6d6b8e429fa061f56bd407ff8
 
 libmateweather-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/marco/template
+++ b/srcpkgs/marco/template
@@ -1,7 +1,7 @@
 # Template file for 'marco'
 pkgname=marco
 version=1.22.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-startup-notification --disable-schemas-compile"
 hostmakedepends="gdk-pixbuf-devel mate-common zenity"

--- a/srcpkgs/mate-applets/template
+++ b/srcpkgs/mate-applets/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-applets'
 pkgname=mate-applets
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-ipv6"
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=dd653d5f14772e0d962a096036f0a0576285912815fd4c8c5028478082a852a7
+checksum=0c47d69fdecda40231d021cb72594c479e01a4d4b7f49c9550731a9fe7cc62b0
 
 case "$XBPS_TARGET_MACHINE" in
 	i686|x86_64)

--- a/srcpkgs/mate-calc/template
+++ b/srcpkgs/mate-calc/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-calc'
 pkgname=mate-calc
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="glib-devel intltool itstool pkg-config"
@@ -10,4 +10,4 @@ maintainer="Álvaro Castillo <midgoon@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org/"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=8da209abc2d6f564effcb8963c97bfd2ba34dd1ac2ab9d455877e63f001f367e
+checksum=efe6818d0a89b5456246412ac3af2c9fea8b6c6a32226cfd26c8b1e6a17e44ab

--- a/srcpkgs/mate-common/template
+++ b/srcpkgs/mate-common/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-common'
 pkgname=mate-common
-version=1.22.0
+version=1.22.2
 revision=1
 archs=noarch
 build_style=gnu-configure
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2"
 homepage="http://mate-desktop.org"
 distfiles="http://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=3f19973a26ccff12834615c4fcc7414cef542ea648f391125e5cfdd8ec649c86
+checksum=ee7d873ad645962cf603fc632b96ec5968e4985dde06157229c3b08978c6a7f7

--- a/srcpkgs/mate-control-center/template
+++ b/srcpkgs/mate-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-control-center'
 pkgname=mate-control-center
-version=1.22.1
-revision=2
+version=1.22.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --disable-update-mimedb"
 hostmakedepends="dbus-glib-devel desktop-file-utils glib-devel intltool itstool pkg-config"
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=4015c830dfd29a454c1124226fc29db460b0ba373d78939aff70e9d9271f3c71
+checksum=f0c92c5ba17a764f1dac5aeccd2aa17b6271fb64c6a883cab0f8711357946df9
 
 post_install() {
 	rm -f ${DESTDIR}/usr/share/applications/mimeinfo.cache

--- a/srcpkgs/mate-desktop/template
+++ b/srcpkgs/mate-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-desktop'
 pkgname=mate-desktop
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 build_helper="gir"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=203be6a518a1c0f9afd077a977be939c11afe9f56c5dac58c69a958292c924c3
+checksum=906673d5de5e6814e73c4448b8cb67c5b86e90f9a72ae131eefbe2356eca85a3
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/mate-icon-theme/template
+++ b/srcpkgs/mate-icon-theme/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-icon-theme'
 pkgname=mate-icon-theme
-version=1.22.1
+version=1.22.2
 revision=1
 archs=noarch
 build_style=gnu-configure
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="CC-BY-SA-3.0"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=73448762d46612ebc3317ca50b677d96e6f45180384c6e0b89957092ebeac1de
+checksum=99b07fcd43921d67f2711396ea05bddc5142aba54236b54e92729a451d994b64
 
 post_install() {
 	rm -f ${DESTDIR}/usr/share/icons/mate/icon-theme.cache

--- a/srcpkgs/mate-media/template
+++ b/srcpkgs/mate-media/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-media'
 pkgname=mate-media
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=c27992695f006e83f5d8a9aa69ca59848cb49e1e126b47e8eb3ee4d79ab0e18d
+checksum=fca9d080e9491aa3bf204a31a488472c4bb7346a5e0f23bd4070ffbe70161855

--- a/srcpkgs/mate-menu/template
+++ b/srcpkgs/mate-menu/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-menu'
 pkgname=mate-menu
 version=18.04.3
-revision=1
+revision=2
 archs=noarch
 build_style=python2-module
 pycompile_module="mate_menu"

--- a/srcpkgs/mate-netbook/template
+++ b/srcpkgs/mate-netbook/template
@@ -1,13 +1,13 @@
 # Template file for 'mate-netbook'
 pkgname=mate-netbook
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool glib-devel"
 makedepends="libmate-panel-devel libXtst-devel libwnck-devel libfakekey-devel"
-short_desc="The MATE netbook extension"
+short_desc="MATE netbook extension"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=c4d4aa6f4957307dbad6488841e2e3e369ca7f7224703189877dafa99730c102
+checksum=5dc6376e447a5324d47ebf18532e67eb506fc171be577df41f4d687384d86854

--- a/srcpkgs/mate-notification-daemon/template
+++ b/srcpkgs/mate-notification-daemon/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-notification-daemon'
 pkgname=mate-notification-daemon
-version=1.22.0
+version=1.22.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=12bc6b95b517396642f25e060bbe3314db2ce9cf14ad3327f1b1950f3febe31b
+checksum=157cc581b4a0fd5bb475d9647c91aa826a8a05e69bf3df82e942e248521d1539

--- a/srcpkgs/mate-panel/template
+++ b/srcpkgs/mate-panel/template
@@ -1,7 +1,7 @@
 # Template file for 'mate-panel'
 pkgname=mate-panel
 version=1.22.2
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static --disable-schemas-compile

--- a/srcpkgs/mate-power-manager/template
+++ b/srcpkgs/mate-power-manager/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-power-manager'
 pkgname=mate-power-manager
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-schemas-compile"
@@ -13,4 +13,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=ba6647acea13852ac5bd2423dedbb68033eb056871ba58812c42074a08177a1b
+checksum=76d1ce28b812ba0fd118d5aa529538072cef1336ae76aea1832ecc00fc91f68a

--- a/srcpkgs/mate-screensaver/template
+++ b/srcpkgs/mate-screensaver/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-screensaver'
 pkgname=mate-screensaver
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--without-console-kit"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=6cef439cb9885df08769500b87df441a0777a6f08bd6f920fad92dfd75c19830
+checksum=8ba590f0a7a4f75d0e7625563fb9a8b8bd76a2f9e8105f32f148fb451e1208f9
 
 post_install() {
 	vinstall ${FILESDIR}/${pkgname}.pam 644 etc/pam.d ${pkgname}

--- a/srcpkgs/mate-session-manager/template
+++ b/srcpkgs/mate-session-manager/template
@@ -1,14 +1,14 @@
 # Template file for 'mate-session-manager'
 pkgname=mate-session-manager
-version=1.22.1
-revision=2
+version=1.22.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-elogind"
 hostmakedepends="pkg-config intltool glib-devel dbus-glib-devel elogind-devel"
 makedepends="gtk+3-devel dbus-glib-devel libSM-devel libXtst-devel"
-short_desc="The MATE Session Manager"
+short_desc="MATE Session Manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=2f1a68447a2ec30791e07865fd3747e367c3fffe8373d07ea948b0d759bca8c7
+checksum=a814b07cbd42920ab86fe77c40f3e1ce7118cbc5da3251b1eb2ab9aa974c0aec

--- a/srcpkgs/mate-settings-daemon/template
+++ b/srcpkgs/mate-settings-daemon/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-settings-daemon'
 pkgname=mate-settings-daemon
-version=1.22.0
+version=1.22.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --enable-polkit --enable-pulse"
@@ -9,12 +9,12 @@ makedepends="dbus-glib-devel libXt-devel libXxf86misc-devel libcanberra-devel
  libmatekbd-devel libmatemixer-devel libnotify-devel mate-desktop-devel nss-devel
  polkit-devel"
 depends="alsa-plugins-pulseaudio"
-short_desc="The MATE Settings daemon (pulseaudio)"
+short_desc="MATE Settings daemon (pulseaudio)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=d53f72d883bcc40d3c7d953aba4b14e8f9e9c80c7c559d840462369896d9257b
+checksum=37122a5aec96ebff25789be90e0a0f749eac096e8441babbbbe0c508be00bc45
 
 mate-settings-daemon-devel_package() {
 	depends="${sourcepkg}-${version}_${revision} dbus-glib-devel"

--- a/srcpkgs/mate-themes/template
+++ b/srcpkgs/mate-themes/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-themes'
 pkgname=mate-themes
-version=3.22.19
+version=3.22.20
 revision=1
 archs=noarch
 build_style=gnu-configure
@@ -13,4 +13,4 @@ license="LGPL-2.1-or-later"
 homepage="https://mate-desktop.org"
 changelog="https://raw.githubusercontent.com/mate-desktop/mate-themes/master/NEWS"
 distfiles="https://pub.mate-desktop.org/releases/themes/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=988b445079426edad15562b517d0297a946c7d2d239c43020c0d6990d1428bf9
+checksum=7d098cf524cf51c3a8f5ffc23adbe23cd11809c83d3de2a7aa82d97491836d30

--- a/srcpkgs/mate-user-guide/template
+++ b/srcpkgs/mate-user-guide/template
@@ -1,13 +1,13 @@
 # Template file for 'mate-user-guide'
 pkgname=mate-user-guide
-version=1.22.1
+version=1.22.3
 revision=1
 archs=noarch
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool itstool"
-short_desc="The MATE User Guide"
+short_desc="MATE User Guide"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GFDL-1.1-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=7a7738da71ae531839d4223c82a0f2c883946f0abab8755312adaa9d6173f40b
+checksum=5ab2746f365f7e140bb4066fb31965ee91362e0f314d3626064b2ddb7556687f

--- a/srcpkgs/mate-utils/template
+++ b/srcpkgs/mate-utils/template
@@ -1,6 +1,6 @@
 # Template file for 'mate-utils'
 pkgname=mate-utils
-version=1.22.1
+version=1.22.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=2f1f51d056f81a9896f2ab35097b913d536235bdbb3a2a7b4b4cd231baf1c81c
+checksum=594ea247edd45daf2068e790e390a5ff1c8d7b24ec4ad24fc948c2e047b5cec4
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
This PR brings mate components to the latest stable release (minor).
It breaks mate-menu (the one from ubuntu-mate) which is outdated, I will try to update it.