### PR TITLE
chromium: update to 78.0.3904.87.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,8 +6,8 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=78.0.3904.70
-revision=2
+version=78.0.3904.87
+revision=1
 archs="x86_64"
 create_wrksrc=yes
 short_desc="Browser plugin designed for the viewing of premium video content"
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=75d6063a5dc506662006eb3fde8c54342f3bc1422fa4d836650ae80f308a8f6f
+checksum=b8f00eee94d07b1665b85006fc3e06b5390c2a8970187dfd009a66c00f32e5f8
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=78.0.3904.70
+version=78.0.3904.87
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=ddc5794097d65ba19c1ae359c2057b08921e7b38b7afe9d5ec45f5e8b9a87462
+checksum=8df6ffca4087fc43e7d0443acc4f758399b248e96482705bd4fe7e88d239eb56
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
- Addresses CVE-2019-13721, CVE-2019-13720:

    https://chromereleases.googleblog.com/2019/10/stable-channel-update-for-desktop_31.html

- Built for x86_64, i686, x86_64.
- Tested on x86_64.