### PR TITLE
rpi-kernel: update to 4.19.81.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,19 +5,19 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="3492a1b003494535eb1b17aa7f258469036b1de7"
+_githash="bbdf44a11a065ebb2aa2ed5690b82287739b471d"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.80
-revision=2
+version=4.19.81
+revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=41c64cab0192843512df8c6663f4021e594c29ff4c8087e9008a39170b25a4e3
+checksum=b9ebdfc4622613e919d72089445ab715e2e438a31ecd1bdb357953bed0be1512
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built on armv6l, armv7l, aarch64.
- Tested on armv6l, armv7l.