### PR TITLE
polybar: update to 3.4.1.

### DIFF
--- a/srcpkgs/polybar/template
+++ b/srcpkgs/polybar/template
@@ -1,6 +1,6 @@
 # Template file for 'polybar'
 pkgname=polybar
-version=3.4.0
+version=3.4.1
 revision=1
 wrksrc="$pkgname"
 build_style=cmake
@@ -12,7 +12,7 @@ configure_args="
  -DENABLE_NETWORK=$(vopt_if network ON OFF)
  -DENABLE_PULSEAUDIO=$(vopt_if pulseaudio ON OFF)
  -DWITH_XCOMPOSITE=ON"
-hostmakedepends="pkg-config xcb-proto python"
+hostmakedepends="pkg-config xcb-proto python3"
 makedepends="cairo-devel xcb-util-image-devel xcb-util-wm-devel xcb-util-xrm-devel
  zlib-devel xcb-util-renderutil-devel xcb-util-cursor-devel libxcb-devel
  $(vopt_if alsa "alsa-lib-devel")
@@ -26,7 +26,7 @@ maintainer="Michael Carlberg <c@rlberg.se>"
 license="MIT"
 homepage="https://github.com/jaagr/polybar"
 distfiles="https://github.com/jaagr/polybar/releases/download/${version}/polybar-${version}.tar"
-checksum=69a098f22d7a72eb594030aff687801252b18520b097c12f5c7894a99c4bcd1b
+checksum=9e37fa48a1027881f14546f2b4f6ace4c91d09a20a293685f845da9cbaedc4eb
 
 build_options="alsa curl i3 mpd network pulseaudio"
 build_options_default="$build_options"


### PR DESCRIPTION
Upstream drops Python2 for Python3.