### PR TITLE
libdrm: update to 2.4.100

### DIFF
--- a/srcpkgs/libdrm/template
+++ b/srcpkgs/libdrm/template
@@ -1,6 +1,6 @@
 # Template file for 'libdrm'
 pkgname=libdrm
-version=2.4.99
+version=2.4.100
 revision=1
 wrksrc="drm-libdrm-${version}"
 build_style=meson
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://dri.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${version}/drm-libdrm-${version}.tar.gz"
-checksum=bb4121e6c0966053fa9fa29c066600a8f80fb71a2baadcce75b3c1f138cff479
+checksum=28d524e0ed8dfb064211e864c29799a1140aed1ff39d53fdecc6c9575a4835a8
 
 post_install() {
 	sed -n 9,25p < libsync.h > LICENSE


### PR DESCRIPTION
Built against a few packages that uses it and also ran radeontop fine