### PR TITLE
rpi-firmware: update to 20191101.

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,10 +1,10 @@
 # Template file for 'rpi-firmware'
-_githash="18bf532d97f73acd4b476429518e89f0e3d7007c"
+_githash="b79618b5db4e4e7c02f9ad9d3ada51713825313e"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20190828
-revision=2
+version=20191101
+revision=1
 archs=noarch
 wrksrc="firmware-${_githash}"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
@@ -12,7 +12,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=7e988a93c27cc59c89fa5270455196a71516b4aa9668152f8e87d6b1448ea914
+checksum=d7443e60d678fe8032683e91a348bdfbb7b8b8e251d73bbdf9fa86e7171dff1e
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 


### PR DESCRIPTION
[ci skip]

Tested on a RPI2 (armv6l) and RPI3 (armv7l).