### PR TITLE
xbps-src/shutils/cross.sh: error out if cross toolchain can't be compiled

### DIFF
--- a/common/xbps-src/shutils/cross.sh
+++ b/common/xbps-src/shutils/cross.sh
@@ -79,7 +79,7 @@ install_cross_pkg() {
     pkg_available cross-${XBPS_CROSS_TRIPLET}
     rval=$?
     if [ $rval -eq 0 ]; then
-        $XBPS_LIBEXECDIR/build.sh cross-${XBPS_CROSS_TRIPLET} cross-${XBPS_CROSS_TRIPLET} pkg || return $rval
+        $XBPS_LIBEXECDIR/build.sh cross-${XBPS_CROSS_TRIPLET} cross-${XBPS_CROSS_TRIPLET} pkg || return $?
     fi
 
     check_installed_pkg cross-${XBPS_CROSS_TRIPLET}-0.1_1


### PR DESCRIPTION
$rval was the return code of pkg_available and not of build.sh, since
pkg_available returns 0. because of this install_cross_pkg() would
always return 0 for success.

Can be easily tested by running something like `./xbps-src -m masterdir-musl pkg dash -a aarch64` before and afterwards.