### PR TITLE
rxvt-unicode: rebuild to fix perl issue

### DIFF
--- a/srcpkgs/rxvt-unicode/template
+++ b/srcpkgs/rxvt-unicode/template
@@ -1,7 +1,7 @@
 # Template file for 'rxvt-unicode'
 pkgname=rxvt-unicode
 version=9.22
-revision=11
+revision=12
 build_style=gnu-configure
 configure_args="
  --with-terminfo=/usr/share/terminfo --enable-256-color


### PR DESCRIPTION
Error on armv7l:
./rxvtperl.c: loadable library and perl binaries are mismatched (got handshake key 0x8d00080, needed 0x8e00080)