### PR TITLE
openjdk11: add bootstrap path for x86_64-musl and i686

### DIFF
--- a/srcpkgs/openjdk11/template
+++ b/srcpkgs/openjdk11/template
@@ -8,7 +8,7 @@ _openjdk_version="openjdk-${_java_ver}"
 
 pkgname=openjdk11
 version="${_java_ver}.${_java_min_ver}.${_java_sec_ver}+${_jdk_update}"
-revision=2
+revision=3
 wrksrc="jdk${_java_ver}u-jdk-${version}"
 build_style=gnu-configure
 configure_args="
@@ -25,9 +25,7 @@ configure_args="
  --with-vendor-name="Void"
  --with-vendor-url="https://voidlinux.org/"
  --with-vendor-bug-url="https://github.com/void-linux/void-packages/issues"
- --with-vendor-vm-bug-url="https://github.com/void-linux/void-packages/issues"
- --with-boot-jdk=/usr/lib/jvm/openjdk11-bin"
-
+ --with-vendor-vm-bug-url="https://github.com/void-linux/void-packages/issues""
 make_build_args="images $(vopt_if docs docs)"
 make_check_target="test-hotspot-gtest"
 hostmakedepends="pkg-config automake autoconf cpio unzip zip ca-certificates
@@ -55,71 +53,75 @@ esac
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" openjdk11"
 	configure_args+=" --with-boot-jdk=/usr/lib/jvm/openjdk11"
-else
+elif [ "$XBPS_ARCH" =  "x86_64-musl" ]; then
+	hostmakedepends+=" alsa-lib freetype giflib lcms libXi libXrender libXtst"
+	distfiles+=" https://alpha.de.repo.voidlinux.org/distfiles/openjdk-11.0.0.5+10-${XBPS_ARCH}.tar.gz"
+	checksum+=" 037520d9eb077628e137d638f3084689610e8a2fbc9efe50e10823dbac7897a4"
+	configure_args+=" --with-boot-jdk=${XBPS_BUILDDIR}/${wrksrc}/openjdk11"
+elif [ "$XBPS_ARCH" = "i686" ]; then
+	hostmakedepends+=" alsa-lib freetype giflib lcms libXi libXrender libXtst"
+	distfiles+=" https://alpha.de.repo.voidlinux.org/distfiles/openjdk-11.0.0.5+10-${XBPS_ARCH}.tar.gz"
+	checksum+=" 90f4f43431487c2560c5be5f5fac979b6e0ff34933eaef1c1e37cd4b0e8cfb63"
+	configure_args+=" --with-boot-jdk=${XBPS_BUILDDIR}/${wrksrc}/openjdk11"
+elif [ "$XBPS_ARCH" = "x86_64" ]; then
 	hostmakedepends+=" openjdk11-bin"
 	configure_args+=" --with-boot-jdk=/usr/lib/jvm/openjdk11-bin"
+else
+	broken="No suitable bootstrap binary found"
 fi
 
 alternatives="
  java:/usr/bin/java:/usr/lib/jvm/openjdk11/bin/java
  java:/usr/bin/jjs:/usr/lib/jvm/openjdk11/bin/jjs
  java:/usr/bin/keytool:/usr/lib/jvm/openjdk11/bin/keytool
- java:/usr/bin/orbd:/usr/lib/jvm/openjdk11/bin/orbd
  java:/usr/bin/pack200:/usr/lib/jvm/openjdk11/bin/pack200
- java:/usr/bin/policytool:/usr/lib/jvm/openjdk11/bin/policytool
  java:/usr/bin/rmid:/usr/lib/jvm/openjdk11/bin/rmid
  java:/usr/bin/rmiregistry:/usr/lib/jvm/openjdk11/bin/rmiregistry
- java:/usr/bin/servertool:/usr/lib/jvm/openjdk11/bin/servertool
- java:/usr/bin/tnameserv:/usr/lib/jvm/openjdk11/bin/tnameserv
  java:/usr/bin/unpack200:/usr/lib/jvm/openjdk11/bin/unpack200
 
- jdk:/usr/bin/appletviewer:/usr/lib/jvm/openjdk11/bin/appletviewer
- jdk:/usr/bin/extcheck:/usr/lib/jvm/openjdk11/bin/extcheck
- jdk:/usr/bin/idlj:/usr/lib/jvm/openjdk11/bin/idlj
+ jdk:/usr/bin/jaotc:/usr/lib/jvm/openjdk11/bin/jaotc
  jdk:/usr/bin/jar:/usr/lib/jvm/openjdk11/bin/jar
  jdk:/usr/bin/jarsigner:/usr/lib/jvm/openjdk11/bin/jarsigner
  jdk:/usr/bin/java:/usr/lib/jvm/openjdk11/bin/java
- jdk:/usr/bin/java-rmi.cgi:/usr/lib/jvm/openjdk11/bin/java-rmi.cgi
  jdk:/usr/bin/javac:/usr/lib/jvm/openjdk11/bin/javac
  jdk:/usr/bin/javadoc:/usr/lib/jvm/openjdk11/bin/javadoc
- jdk:/usr/bin/javah:/usr/lib/jvm/openjdk11/bin/javah
  jdk:/usr/bin/javap:/usr/lib/jvm/openjdk11/bin/javap
  jdk:/usr/bin/jcmd:/usr/lib/jvm/openjdk11/bin/jcmd
  jdk:/usr/bin/jconsole:/usr/lib/jvm/openjdk11/bin/jconsole
  jdk:/usr/bin/jdb:/usr/lib/jvm/openjdk11/bin/jdb
+ jdk:/usr/bin/jdeprscan:/usr/lib/jvm/openjdk11/bin/jdeprscan
  jdk:/usr/bin/jdeps:/usr/lib/jvm/openjdk11/bin/jdeps
- jdk:/usr/bin/jhat:/usr/lib/jvm/openjdk11/bin/jhat
+ jdk:/usr/bin/jhsdb:/usr/lib/jvm/openjdk11/bin/jhsdb
+ jdk:/usr/bin/jimage:/usr/lib/jvm/openjdk11/bin/jimage
  jdk:/usr/bin/jinfo:/usr/lib/jvm/openjdk11/bin/jinfo
  jdk:/usr/bin/jjs:/usr/lib/jvm/openjdk11/bin/jjs
+ jdk:/usr/bin/jlink:/usr/lib/jvm/openjdk11/bin/jlink
  jdk:/usr/bin/jmap:/usr/lib/jvm/openjdk11/bin/jmap
+ jdk:/usr/bin/jmod:/usr/lib/jvm/openjdk11/bin/jmod
  jdk:/usr/bin/jps:/usr/lib/jvm/openjdk11/bin/jps
  jdk:/usr/bin/jrunscript:/usr/lib/jvm/openjdk11/bin/jrunscript
- jdk:/usr/bin/jsadebugd:/usr/lib/jvm/openjdk11/bin/jsadebugd
+ jdk:/usr/bin/jshell:/usr/lib/jvm/openjdk11/bin/jshell
  jdk:/usr/bin/jstack:/usr/lib/jvm/openjdk11/bin/jstack
  jdk:/usr/bin/jstat:/usr/lib/jvm/openjdk11/bin/jstat
  jdk:/usr/bin/jstatd:/usr/lib/jvm/openjdk11/bin/jstatd
  jdk:/usr/bin/keytool:/usr/lib/jvm/openjdk11/bin/keytool
- jdk:/usr/bin/native2ascii:/usr/lib/jvm/openjdk11/bin/native2ascii
- jdk:/usr/bin/orbd:/usr/lib/jvm/openjdk11/bin/orbd
  jdk:/usr/bin/pack200:/usr/lib/jvm/openjdk11/bin/pack200
- jdk:/usr/bin/policytool:/usr/lib/jvm/openjdk11/bin/policytool
  jdk:/usr/bin/rmic:/usr/lib/jvm/openjdk11/bin/rmic
  jdk:/usr/bin/rmid:/usr/lib/jvm/openjdk11/bin/rmid
  jdk:/usr/bin/rmiregistry:/usr/lib/jvm/openjdk11/bin/rmiregistry
- jdk:/usr/bin/schemagen:/usr/lib/jvm/openjdk11/bin/schemagen
  jdk:/usr/bin/serialver:/usr/lib/jvm/openjdk11/bin/serialver
- jdk:/usr/bin/servertool:/usr/lib/jvm/openjdk11/bin/servertool
- jdk:/usr/bin/tnameserv:/usr/lib/jvm/openjdk11/bin/tnameserv
  jdk:/usr/bin/unpack200:/usr/lib/jvm/openjdk11/bin/unpack200
- jdk:/usr/bin/wsgen:/usr/lib/jvm/openjdk11/bin/wsgen
- jdk:/usr/bin/wsimport:/usr/lib/jvm/openjdk11/bin/wsimport
- jdk:/usr/bin/xjc:/usr/lib/jvm/openjdk11/bin/xjc
 "
 
 post_extract() {
 	chmod +x configure
 	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 		rm -r src/jdk.hotspot.agent
+	fi
+	if [ -z $CROSS_BUILD ]; then
+		if [ "$XBPS_ARCH" = "x86_64-musl" ] || [ "$XBPS_ARCH" = "i686" ]; then
+			mv ${wrksrc}/../openjdk11 ${wrksrc}/openjdk11
+		fi
 	fi
 }
 
@@ -153,6 +155,10 @@ post_install() {
 	mv ./ca/etc/pki/tls/java/cacerts ${DESTDIR}/usr/lib/jvm/openjdk${_java_ver}/lib/security/
 	chmod -R ugo+rw ./ca
 	rm -Rf ./ca
+	vmkdir etc/profile.d
+	cat >>${DESTDIR}/etc/profile.d/10_openjdk11.sh <<EOF
+export JAVA_HOME=\${JAVA_HOME=/usr/lib/jvm/openjdk${_java_ver}}
+EOF
 	vlicense ASSEMBLY_EXCEPTION
 	vlicense LICENSE
 }


### PR DESCRIPTION
Bootstrap binaries can just be cross compiled from glibc
`./xbps-src pkg openjdk11 -a x86_64-musl`. the tar ball just contains the `/usr/lib/jvm/openjdk11` directory.

https://void.johnnynator.dev/distfiles/