### PR TITLE
Git: Update to 2.24.0

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
-version=2.23.0
-revision=3
+version=2.24.0
+revision=1
 bootstrap=yes
 wrksrc="git-${version}"
 build_style=gnu-configure
@@ -15,7 +15,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=234fa05b6839e92dc300b2dd78c92ec9c0c8d439f65e1d430a7034f60af16067
+checksum=9f71d61973626d8b28c4cdf8e2484b4bf13870ed643fed982d68b2cfd754371b
 
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="perl"

--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,7 +1,7 @@
 # Template file for 'git'
 pkgname=git
-version=2.23.0
-revision=3
+version=2.24.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2
  ac_cv_snprintf_returns_bogus=no"
@@ -16,7 +16,7 @@ license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=234fa05b6839e92dc300b2dd78c92ec9c0c8d439f65e1d430a7034f60af16067
+checksum=9f71d61973626d8b28c4cdf8e2484b4bf13870ed643fed982d68b2cfd754371b
 replaces="git-perl>=0"
 register_shell=/usr/bin/git-shell
 
@@ -25,6 +25,7 @@ subpackages="git-cvs git-svn gitk git-gui git-all git-libsecret"
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)
 		configure_args+=" ac_cv_fread_reads_directories=yes"
+		export GIT_SKIP_TESTS='t3900'
 		;;
 	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
 esac
@@ -49,7 +50,7 @@ post_build() {
 }
 
 post_install() {
-	make NO_INSTALL_HARDLINKS=1 DESTDIR=${DESTDIR} install-doc
+	make DESTDIR=${DESTDIR} install-doc
 	vinstall contrib/completion/git-completion.bash 644 \
 		usr/share/bash-completion/completions git
 	vinstall contrib/completion/git-prompt.sh 644 usr/share/git


### PR DESCRIPTION
`./xbps check git` on x86_64-musl ran just fine by skipping t3900.


~But, it should be fine since I'm running its test daily.~ (written when test was running)