### PR TITLE
llvm9: add fixes for the powerpc backend (prepare for rust 1.39 switch to llvm9)

### DIFF
--- a/srcpkgs/llvm9/files/patches/llvm/llvm-005-ppc-lrint.patch
+++ b/srcpkgs/llvm9/files/patches/llvm/llvm-005-ppc-lrint.patch
@@ -1,0 +1,34 @@
+From 97e36260709c541044f30092b420238511e13e5b Mon Sep 17 00:00:00 2001
+From: Nemanja Ivanovic <nemanjai@ca.ibm.com>
+Date: Mon, 28 Oct 2019 16:08:30 -0500
+Subject: [PATCH] [PowerPC] Do not emit HW loop if the body contains calls to
+ lrint/lround
+
+These two intrinsics are lowered to calls so should prevent the formation of
+CTR loops. In a subsequent patch, we will handle all currently known intrinsics
+and prevent the formation of HW loops if any unknown intrinsics are encountered.
+
+Differential revision: https://reviews.llvm.org/D68841
+---
+ .../Target/PowerPC/PPCTargetTransformInfo.cpp |  4 +
+ llvm/test/CodeGen/PowerPC/pr43527.ll          | 75 +++++++++++++++++++
+ 2 files changed, 79 insertions(+)
+ create mode 100644 llvm/test/CodeGen/PowerPC/pr43527.ll
+
+diff --git a/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp b/llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
+index 53c2f0f88d14..ad37e435fa36 100644
+--- llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
++++ llvm/lib/Target/PowerPC/PPCTargetTransformInfo.cpp
+@@ -331,8 +331,12 @@ bool PPCTTIImpl::mightUseCTR(BasicBlock *BB,
+           case Intrinsic::ceil:               Opcode = ISD::FCEIL;      break;
+           case Intrinsic::trunc:              Opcode = ISD::FTRUNC;     break;
+           case Intrinsic::rint:               Opcode = ISD::FRINT;      break;
++          case Intrinsic::lrint:              Opcode = ISD::LRINT;      break;
++          case Intrinsic::llrint:             Opcode = ISD::LLRINT;     break;
+           case Intrinsic::nearbyint:          Opcode = ISD::FNEARBYINT; break;
+           case Intrinsic::round:              Opcode = ISD::FROUND;     break;
++          case Intrinsic::lround:             Opcode = ISD::LROUND;     break;
++          case Intrinsic::llround:            Opcode = ISD::LLROUND;    break;
+           case Intrinsic::minnum:             Opcode = ISD::FMINNUM;    break;
+           case Intrinsic::maxnum:             Opcode = ISD::FMAXNUM;    break;
+           case Intrinsic::umul_with_overflow: Opcode = ISD::UMULO;      break;

--- a/srcpkgs/llvm9/files/patches/llvm/llvm-006-ppc-bigpic.patch
+++ b/srcpkgs/llvm9/files/patches/llvm/llvm-006-ppc-bigpic.patch
@@ -1,0 +1,38 @@
+From f3dbdd49c06bfafc1d6138094cf42889c14d38b6 Mon Sep 17 00:00:00 2001
+From: Samuel Holland <samuel@sholland.org>
+Date: Sun, 3 Nov 2019 10:57:27 -0600
+Subject: [PATCH] [LLVM][PowerPC] Assume BigPIC if no PIC level is specified
+
+---
+ llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp  | 2 +-
+ llvm/lib/Target/PowerPC/PPCMCInstLower.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+index 269b84b4e8d..03246a5242c 100644
+--- llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
++++ llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+@@ -488,7 +488,7 @@ void PPCAsmPrinter::EmitTlsCall(const MachineInstr *MI,
+ 
+   // Add 32768 offset to the symbol so we follow up the latest GOT/PLT ABI.
+   if (Kind == MCSymbolRefExpr::VK_PLT && Subtarget->isSecurePlt() &&
+-      M->getPICLevel() == PICLevel::BigPIC)
++      M->getPICLevel() != PICLevel::SmallPIC)
+     TlsRef = MCBinaryExpr::createAdd(
+         TlsRef, MCConstantExpr::create(32768, OutContext), OutContext);
+   const MachineOperand &MO = MI->getOperand(2);
+diff --git a/llvm/lib/Target/PowerPC/PPCMCInstLower.cpp b/llvm/lib/Target/PowerPC/PPCMCInstLower.cpp
+index 027e6bd1ba0..ae461f4eea9 100644
+--- llvm/lib/Target/PowerPC/PPCMCInstLower.cpp
++++ llvm/lib/Target/PowerPC/PPCMCInstLower.cpp
+@@ -116,7 +116,7 @@ static MCOperand GetSymbolRef(const MachineOperand &MO, const MCSymbol *Symbol,
+   const MCExpr *Expr = MCSymbolRefExpr::create(Symbol, RefKind, Ctx);
+   // If -msecure-plt -fPIC, add 32768 to symbol.
+   if (Subtarget->isSecurePlt() && TM.isPositionIndependent() &&
+-      M->getPICLevel() == PICLevel::BigPIC &&
++      M->getPICLevel() != PICLevel::SmallPIC &&
+       MO.getTargetFlags() == PPCII::MO_PLT)
+     Expr =
+         MCBinaryExpr::createAdd(Expr, MCConstantExpr::create(32768, Ctx), Ctx);
+-- 
+2.23.0

--- a/srcpkgs/llvm9/template
+++ b/srcpkgs/llvm9/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm9'
 pkgname=llvm9
 version=9.0.0
-revision=2
+revision=3
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="


### PR DESCRIPTION
This fixes Rust with llvm9 on ppc32, so that we can finally switch to it (`llvm-006-bigpic.patch`) - previously it would emit wrong executables that segfault.

While at it, I'm adding an upstream backport that fixes incorrect codegen for certain things such as Chromium.