### PR TITLE
acmetool: update to 0.2.1

### DIFF
--- a/srcpkgs/acmetool/template
+++ b/srcpkgs/acmetool/template
@@ -1,8 +1,7 @@
 # Template file for 'acmetool'
 pkgname=acmetool
-version=0.0.67
-revision=6
-wrksrc="acme-${version}"
+version=0.2.1
+revision=1
 build_style=go
 go_import_path=github.com/hlandau/acme
 go_package="github.com/hlandau/acme/cmd/acmetool"
@@ -14,7 +13,7 @@ license="RILTS-based"
 homepage="https://hlandau.github.io/acme/"
 distfiles="https://github.com/hlandau/acme/archive/v${version}.tar.gz
  https://raw.githubusercontent.com/hlandau/rilts/master/licences/COPYING.MIT>COPYING"
-checksum="01f78340006539c62bb86250433d2f819ab529ccd9a0aa74e140ff0fee839073
+checksum="54acffe7381696ecdc829f65810897075d17c5600c077f431eda5e5244189a74
  fd80a26fbb3f644af1fa994134446702932968519797227e07a1368dea80f0bc"
 skip_extraction=COPYING
 


### PR DESCRIPTION
@Vaelatern As far as I can tell it works, I do not run a webserver, though I did run a temp one and it was trying to install the certs, but of course I have no domain tied to my temp server so install failed.