### PR TITLE
xf86-video-vmware: add libstdc++ to depends

### DIFF
--- a/srcpkgs/xf86-video-vmware/template
+++ b/srcpkgs/xf86-video-vmware/template
@@ -1,20 +1,20 @@
-# Template build file for 'xf86-video-vmware'
+# Template file for 'xf86-video-vmware'
 pkgname=xf86-video-vmware
 version=13.3.0
-revision=1
-lib32disabled=yes
+revision=2
 archs="i686* x86_64*"
 build_style=gnu-configure
 configure_args="--enable-vmwarectrl-client"
 hostmakedepends="pkg-config"
 makedepends="libdrm-devel MesaLib-devel xorg-server-devel"
-depends="virtual?xserver-abi-video-24_1 mesa-vmwgfx-dri"
+depends="virtual?xserver-abi-video-24_1 mesa-vmwgfx-dri libstdc++"
 short_desc="Modular Xorg VMware virtual video driver"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/driver/$pkgname-$version.tar.bz2"
 checksum=47971924659e51666a757269ad941a059ef5afe7a47b5101c174a6022ac4066c
+lib32disabled=yes
 
 LDFLAGS="-Wl,-z,lazy"
 


### PR DESCRIPTION
A Reddit user [found](https://www.reddit.com/r/voidlinux/comments/drqni6/need_help_about_xorg/) that X using `xf86-video-vmware` wouldn't start without manually installing the `libstdc++` package. This PR adds that package to `xf86-video-vmware`'s 'depends'.