### PR TITLE
gcc: backport omp false positive fix

### DIFF
--- a/srcpkgs/gcc/patches/omp.patch
+++ b/srcpkgs/gcc/patches/omp.patch
@@ -1,0 +1,17 @@
+Backport: https://gcc.gnu.org/viewcvs/gcc?view=revision&revision=276211
+
+This fixes potential failures with openmp and constants, such as
+
+error: ‘*.LC0’ not specified in enclosing ‘parallel’
+
+--- gcc/gimplify.c
++++ gcc/gimplify.c
+@@ -7132,6 +7132,8 @@
+   kind = lang_hooks.decls.omp_predetermined_sharing (decl);
+   if (kind != OMP_CLAUSE_DEFAULT_UNSPECIFIED)
+     default_kind = kind;
++  else if (VAR_P (decl) && TREE_STATIC (decl) && DECL_IN_CONSTANT_POOL (decl))
++    default_kind = OMP_CLAUSE_DEFAULT_SHARED;
+ 
+   switch (default_kind)
+     {

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.21
 
 pkgname=gcc
 version=${_minorver}.0
-revision=1
+revision=2
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"


### PR DESCRIPTION
This fixes gcc not marking constants emitted into assembly as shared which would result in strange build errors such as:

```
$ gcc -fopenmp test-openmp.c
test-openmp.c: In function ‘testfunc’:
test-openmp.c:10:15: error: ‘*.LC0’ not specified in enclosing ‘parallel’
   10 |         float k[3] = { 0.1f, 0.1f, 0.1f } ;
      |               ^
test-openmp.c:7:9: error: enclosing ‘parallel’
    7 | #pragma omp parallel for default(none) shared(f)
      |         ^~~
```

This happens only sometimes and not on all platforms and seems to mostly come down to luck.

Not bumping crosstoolchains for now, as that would be too intensive on the builders right now. If we encounter this somewhere we should bump cross as well.