### PR TITLE
rooster: update to 2.8.2

### DIFF
--- a/srcpkgs/rooster/template
+++ b/srcpkgs/rooster/template
@@ -1,7 +1,7 @@
 # Template file for 'rooster'
 pkgname=rooster
-version=2.8.0
-revision=2
+version=2.8.2
+revision=1
 build_style=cargo
 hostmakedepends="pkg-config python3"
 makedepends="libX11-devel libXmu-devel libressl-devel libsodium-devel"
@@ -10,11 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/conradkdotcom/rooster"
 distfiles="https://github.com/conradkdotcom/rooster/archive/v${version}.tar.gz"
-checksum=49647992eb48ef7df4ffee897aeb8f651e403c86d08c5dac92bb96547951a68a
-
-case "$XBPS_TARGET_MACHINE" in
-	aarch64*|ppc64*) broken="undefined reference to rust_crypto_util_fixed_time_eq_asm https://github.com/DaGenix/rust-crypto/issues/383" ;;
-esac
+checksum=73d62fde548cf13936db5918b67acc2d7590b44f99cc79811c144412f0a3102d
 
 pre_build() {
 	cargo update --package openssl-sys --precise 0.9.46


### PR DESCRIPTION
Unmark broken for aarch64 and ppc64

@q66 Can you test this on ppc64? aarch64 pkg'd fine, but I can't test it; if it now works on ppc64 then chance previous issue has been fixed.