### PR TITLE
python3-Telethon: update to 1.10.8.

### DIFF
--- a/srcpkgs/python3-Telethon/template
+++ b/srcpkgs/python3-Telethon/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Telethon'
 pkgname=python3-Telethon
-version=1.10.6
+version=1.10.8
 revision=1
 archs=noarch
 wrksrc="Telethon-${version}"
@@ -11,9 +11,9 @@ depends="python3-pyaes python3-rsa"
 short_desc="Pure Python3 Telegram client library"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 license="MIT"
-homepage="https://lonamiwebs.github.io/Telethon"
+homepage="https://github.com/LonamiWebs/Telethon"
 distfiles="https://github.com/LonamiWebs/Telethon/archive/v${version}.tar.gz"
-checksum=fdb86ae0eb5ffcab4e41fded937010a2f0e64a42082a476c7797958413d01ea6
+checksum=b53084720419de4cb451eb5eff299e557939a680ab4d36b25f0c3a137513b372
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Change homepage to GitHub page (more useful).