### PR TITLE
[RFC] etc/defaults.virtual: default to openjdk11

### DIFF
--- a/etc/defaults.virtual
+++ b/etc/defaults.virtual
@@ -21,8 +21,8 @@
 
 awk gawk
 emacs emacs
-java-environment openjdk
-java-runtime openjdk-jre
+java-environment openjdk11
+java-runtime openjdk11
 libudev eudev-libudev
 nodejs-runtime nodejs
 ntp-daemon chrony


### PR DESCRIPTION
Since, at least for now, `-jre` isn't split, this would set both `virtual?java-runtime` and `virtual?java-environment` to `openjdk11`. In the future, it could be split or the two `virtual?`'s could be merged.

The following packages have been tested to work with `openjdk11`.

- [ ] antlr3-bin
- [x] apache-ant
- [ ] apache-directory-studio-bin
- [ ] apache-fop
- [ ] apache-jmeter
- [ ] apache-maven
- [ ] apache-maven-bin
- [ ] apache-storm
- [ ] apache-tomcat
- [ ] ardor
- [ ] arduino
- [ ] chatty
- [ ] CLion
- [ ] clojure
- [ ] eclipse
- [ ] eclipse-ecj
- [ ] elasticsearch
- [X] freeplane
- [ ] GoLand
- [X] gradle
- [ ] intellij-idea-community-edition
- [ ] JAI
- [ ] java-commons-io
- [ ] jenkins
- [x] jmol
- [ ] kaitai-struct-compiler
- [ ] kickassembler
- [ ] leiningen
- [ ] lightzone
- [ ] marvin
- [ ] MultiMC
- [ ] nxt
- [ ] orientdb
- [X] plantuml
- [X] projectlibre
- [ ] pycharm-community
- [ ] RubyMine
- [ ] runelite-launcher
- [ ] sbt
- [ ] smali
- [ ] sugar
- [ ] SweetHome3D
- [ ] tuxguitar
- [ ] tvbrowser
- [ ] WebStorm
- [ ] zookeeper
