### PR TITLE
chromium: update to 78.0.3904.97

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=78.0.3904.87
+version=78.0.3904.97
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=b8f00eee94d07b1665b85006fc3e06b5390c2a8970187dfd009a66c00f32e5f8
+checksum=77c7627818630d73bedcfc0b38dde145d2554bea2d49616fe9b3cf8eb5f290db
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=78.0.3904.87
+version=78.0.3904.97
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=8df6ffca4087fc43e7d0443acc4f758399b248e96482705bd4fe7e88d239eb56
+checksum=d1f49ab9f4f973536166f587114553c21a29977bdc350dd407a89d34e22a9d07
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
Security fixes: 

https://chromereleases.googleblog.com/2019/11/stable-channel-update-for-desktop.html

- Built on x86_64, i686, x86_64-musl
- Tested on x86_64