### PR TITLE
dracut: dynamic link against libfts on musl

### DIFF
--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=049
-revision=3
+revision=4
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"
@@ -27,7 +27,7 @@ esac
 
 do_build() {
 	case "$XBPS_TARGET_MACHINE" in
-		*-musl) make ${makejobs} LDLIBS="${XBPS_CROSS_BASE}/usr/lib/libfts.a";;
+		*-musl) make ${makejobs} LDLIBS="-lfts" ;;
 	esac
 }
 


### PR DESCRIPTION
Static link against libfts is BSD-violation if we don't ship their
license.