### PR TITLE
libGL: update to 19.2.3

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,6 +1,6 @@
 # Template file for 'libGL'
 pkgname=libGL
-version=19.2.2
+version=19.2.3
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
@@ -22,7 +22,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://www.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=7e4f0e2678bfcf3b94f533078b514f37943378a4a8604e477c888ec8a2904394
+checksum=5ee6e42504fe41dcc9a6eba26982656a675b2550a640946f463927ed7f1c5047
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
Tested on musl, under Wayland and X, with Intel drivers.