### PR TITLE
libsigrok: install udev rules (+fix compilation with latest Doxygen)

### DIFF
--- a/srcpkgs/libsigrok/patches/fix_doxygen.patch
+++ b/srcpkgs/libsigrok/patches/fix_doxygen.patch
@@ -1,0 +1,33 @@
+From 2da97803e653b814db3a42b3b749953368932cb6 Mon Sep 17 00:00:00 2001
+From: Gerhard Sittig <gerhard.sittig@gmx.net>
+Date: Sun, 6 Oct 2019 10:08:09 +0200
+Subject: [PATCH 1/1] build: unbreak C++ binding compilation with newer Doxygen
+ (1.8.16)
+
+Doxygen version 1.8.16 introduced an issue which breaks the compilation
+of sigrok's C++ binding (https://github.com/doxygen/doxygen/issues/7190).
+Don't set the FILE_PATTERNS variable at all, instead of assigning an
+empty value. This resolves bug #1422.
+---
+ Doxyfile | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Doxyfile b/Doxyfile
+index 252e504e..76f410a0 100644
+--- a/Doxyfile
++++ b/Doxyfile
+@@ -763,7 +763,11 @@ INPUT_ENCODING         = UTF-8
+ # *.md, *.mm, *.dox, *.py, *.f90, *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf,
+ # *.qsf, *.as and *.js.
+ 
+-FILE_PATTERNS          =
++# BEWARE! DON'T set the variable to an empty value. Don't set the variable
++# at all instead. See https://github.com/doxygen/doxygen/issues/7190 and
++# https://sigrok.org/bugzilla/show_bug.cgi?id=1422 (can get reverted when
++# the Doxygen version which causes the issue no longer is used in the wild).
++## FILE_PATTERNS          =
+ 
+ # The RECURSIVE tag can be used to specify whether or not subdirectories should
+ # be searched for input files as well.
+-- 
+2.24.0.rc2

--- a/srcpkgs/libsigrok/template
+++ b/srcpkgs/libsigrok/template
@@ -1,7 +1,7 @@
 # Template file for 'libsigrok'
 pkgname=libsigrok
 version=0.5.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config doxygen python3"
 makedepends="glib-devel libzip-devel glibmm-devel libserialport-devel
@@ -12,10 +12,16 @@ license="GPL-3.0-or-later"
 homepage="https://sigrok.org/"
 distfiles="https://sigrok.org/download/source/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=e40fde7af98d29e922e9d3cbe0a6c0569889153fc31e47b8b1afe4d846292b9c
+patch_args="-Np1"
 
 case $XBPS_TARGET_MACHINE in
 	i686*|x86_64*|ppc64*) makedepends+=" libieee1284-devel";;
 esac
+
+post_install() {
+	vinstall contrib/60-libsigrok.rules 0644 /usr/lib/udev/rules.d
+	vinstall contrib/61-libsigrok-uaccess.rules 0644 /usr/lib/udev/rules.d
+}
 
 libsigrok-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"


### PR DESCRIPTION
This update also installs the udev rules provided by libsigrok. They are needed so non-root users can access (USB) devices supported by libsigrok.

The `fix_doxygen.patch` is needed because an update to Doxygen broke compilation. This fix is already included in the latest libsigrok sources but is not released yet.