### PR TITLE
Revert "util-linux: compile with eudev"

### DIFF
--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -1,9 +1,9 @@
 # Template file for 'util-linux'
 pkgname=util-linux
 version=2.34
-revision=3
+revision=4
 hostmakedepends="automake bison gettext-devel libtool pkg-config"
-makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel eudev-libudev-devel"
+makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel"
 checkdepends="ncurses" # Some tests require terminfo-entries
 short_desc="Miscellaneous linux utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -40,7 +40,8 @@ do_configure() {
 		--enable-fs-paths-extra=/usr/sbin:/usr/bin \
 		--enable-vipw --enable-newgrp --enable-chfn-chsh \
 		--with-systemdsystemunitdir=no \
-		--without-python --enable-write
+		--without-udev --without-python \
+		--enable-write
 }
 
 do_build() {


### PR DESCRIPTION
This reverts commit 66062de198c4ec37c78f05828fe5b7772819ac48.

xbps-src couldn't handle circular dependencies for now.