### PR TITLE
mm-common: update to 1.0.0

### DIFF
--- a/srcpkgs/gtkmm2/template
+++ b/srcpkgs/gtkmm2/template
@@ -1,16 +1,16 @@
 # Template file for 'gtkmm2'
 pkgname=gtkmm2
 version=2.24.5
-revision=3
+revision=4
 wrksrc="gtkmm-${version}"
 build_style=gnu-configure
 configure_args="--disable-static --disable-documentation"
-hostmakedepends="mm-common libtool pkg-config"
+hostmakedepends="automake mm-common libtool pkg-config"
 makedepends="gtk+-devel libsigc++-devel atkmm-devel pangomm-devel libXcursor-devel"
 short_desc="C++ bindings for The GTK+ toolkit (v2)"
-homepage="http://www.gtkmm.org/"
-license="LGPL-2.1"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-2.1-only"
+homepage="http://www.gtkmm.org/"
 distfiles="${GNOME_SITE}/gtkmm/${version%.*}/gtkmm-${version}.tar.xz"
 checksum=0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72
 

--- a/srcpkgs/mm-common/template
+++ b/srcpkgs/mm-common/template
@@ -1,14 +1,14 @@
 # Template file for 'mm-common'
 pkgname=mm-common
-version=0.9.12
+version=1.0.0
 revision=1
 archs=noarch
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="pkg-config intltool itstool"
-depends="automake libtool intltool pkg-config gtk-doc gettext-devel glib-devel yelp-tools"
+depends="gtk-doc gettext-devel glib-devel yelp-tools"
 short_desc="Common development macros for GTK+ C++"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gtkmm.org/en/"
 distfiles="http://download.gnome.org/sources/mm-common/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=ceffdcce1e5b52742884c233ec604bf6fded12eea9da077ce7a62c02c87e7c0b
+checksum=b97d9b041e5952486cab620b44ab09f6013a478f43b6699ae899b8a4da189cd4


### PR DESCRIPTION
When testing two packages that depends on mm-common, found gtkmm2 that fails to find autoreconf, so added missing dependency.