### PR TITLE
go: add a binary bootstrap package (1.12 series for now) and switch the compiler to it from 1.4

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -4,14 +4,13 @@ version=1.13.4
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
-hostmakedepends="go1.4-bootstrap"
+hostmakedepends="go1.12-bootstrap"
 short_desc="Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
 checksum=95dbeab442ee2746b9acf0934c8e2fc26414a0565c008631b04addb8c02e7624
-
 nostrip=yes
 noverifyrdeps=yes
 
@@ -21,8 +20,17 @@ case "${XBPS_TARGET_MACHINE}" in
 	mips*) _goarch=mips ;;
 	i686*) _goarch=386 ;;
 	x86_64*) _goarch=amd64 ;;
+	ppc64le*) _goarch=ppc64le ;;
+	ppc64*) broken="Upstream does not support ELFv2 for big endian ppc64";;
+	ppc*) broken="Upstream does not support 32-bit ppc";;
 	*) _goarch=${XBPS_TARGET_MACHINE} ;;
 esac
+
+if [ "$CROSS_BUILD" ]; then
+	if [ "${XBPS_MACHINE%%-musl}" = "${XBPS_TARGET_MACHINE%%-musl}" ]; then
+		broken="Cross-compiling to different libc is not supported"
+	fi
+fi
 
 do_build() {
 	unset GCC CC CXX LD CFLAGS
@@ -30,11 +38,9 @@ do_build() {
 	# dependency
 	unset CGO_CXXFLAGS CGO_CFLAGS CGO_ENABLED
 
-
-	export GOCACHE=off
+	export GOROOT_BOOTSTRAP="/usr/lib/go1.12"
 	export GOROOT=$PWD
 	export GOROOT_FINAL="/usr/lib/go"
-	export GOROOT_BOOTSTRAP="/usr/lib/go1.4"
 	export GOARCH=${_goarch}
 
 	cd "src"

--- a/srcpkgs/go1.12-bootstrap/INSTALL.msg
+++ b/srcpkgs/go1.12-bootstrap/INSTALL.msg
@@ -1,0 +1,4 @@
+This is a copy of the official Go language toolchain binaries as provided by
+the project on its download page. Please do keep in mind that it is almost
+definitely not what you want to use and exists purely for the purpose of
+bootstrapping the official compiler package (called simply 'go').

--- a/srcpkgs/go1.12-bootstrap/template
+++ b/srcpkgs/go1.12-bootstrap/template
@@ -1,0 +1,64 @@
+# Template file for 'go1.12-bootstrap'
+pkgname=go1.12-bootstrap
+version=1.12.13
+revision=1
+archs="x86_64* i686* armv[67]l* aarch64* ppc64le*"
+wrksrc="go"
+short_desc="Go 1.12 (bootstrap compiler)"
+maintainer="q66 <daniel@octaforge.org>"
+license="BSD-3-Clause"
+homepage="https://golang.org"
+nostrip=yes
+noverifyrdeps=yes
+nocross=yes
+lib32disabled=yes
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	depends+=" gcompat"
+	hostmakedepends+=" patchelf"
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*)
+		_dist_arch="amd64"
+		checksum="da036454cb3353f9f507f0ceed4048feac611065e4e1818b434365eb32ac9bdc"
+		;;
+	i686*)
+		_dist_arch="386"
+		checksum="fafcb585591557b7b16d9b22dec4654193d205cf444b1810ab2988f658585e23"
+		;;
+	arm*)
+		_dist_arch="armv6l"
+		checksum="bf061cc3d4951e07904496b5c3d6c82419309d24634835522d786673a3f5438f"
+		;;
+	aarch64*)
+		_dist_arch="arm64"
+		checksum="dcfcb3785292c98f7a75c2276169dfe2d445c19f8ffe1d40b3f7b8f59712d361"
+		;;
+	ppc64le*)
+		_dist_arch="ppc64le"
+		checksum="77056264abcf5444ed0d9ab7552552ae2145ca8fb6c39d33db3c735eaf3f42d2"
+		;;
+esac
+
+distfiles="https://dl.google.com/go/go${version}.linux-${_dist_arch}.tar.gz"
+
+post_build() {
+	[ "$XBPS_TARGET_LIBC" != "musl" ] && return 0
+
+	# we don't have lib64 compatibility path on musl 64-bit systems
+	# use patchelf to replace /lib64/<dynlinker> with /lib/<dynlinker>
+
+	local _interp=$(patchelf --print-interpreter ${wrksrc}/bin/go)
+
+	patchelf --set-interpreter ${_interp/lib64\//lib\/} ${wrksrc}/bin/go
+	patchelf --set-interpreter ${_interp/lib64\//lib\/} ${wrksrc}/bin/godoc
+}
+
+do_install() {
+	vmkdir usr/lib/go1.12
+	vcopy bin usr/lib/go1.12
+	vcopy src usr/lib/go1.12
+	vcopy pkg usr/lib/go1.12
+	vlicense LICENSE
+}


### PR DESCRIPTION
This adds a `go1.12-bootstrap` package newly used instead of `go1.4-bootstrap` to bootstrap the main Go compiler. The reason for this is to allow bootstrapping on platforms the ancient codebase does not support, particularly `ppc64le` and `aarch64`.

The new bootstrap package can technically run on all the targets that are in the intersection of what the official compiler supports and what Void supports.

~~There is a problem that the official binaries require glibc (just its dynamic linker, the libc itself and libpthread). In order to deal with that on musl, fetch a binary copy of glibc from Debian (which is reproducibly built, so it should be trustable) and patch the official binaries so that they use the newly bundled libc and dynamic linker. This allows the compiler to execute in a musl system, and build the proper target compiler (which will use the musl dynamic linker and libc, of course).~~

~~I chose the approach after evaluating all other choices, including `gcompat` and `gccgo`; in the end this was the only thing that truly and reliably worked.~~

I used gcompat to be able to run the compiler. In order for that to work, gcompat needs to be updated and patched, as in https://github.com/void-linux/void-packages/pull/16320. We still need to use patchelf to patch out the `lib64` requirement.

The second part of this patchset switches the `go` package to use the new 1.12 bootstrap. Since 1.12, `GOCACHE` must be not set when bootstrapping, so that line was removed. I also added new `broken` lines to disable the package on big endian PowerPC systems (ppc64 BE support uses incorrect ABI and requires POWER8 hardware, making it not safely distributable; 32-bit ppc was just never supported at all).

Additionally, I also added a `broken` when cross-building on the same architecture to a different libc (e.g. `x86_64` to `x86_64-musl`). This is because the build system does not account for this scenario and just does not cross build; this creates a package without failing but the contained compiler is just a compiler for the host system and will not function on the target. So at least until this problem is taken care of, disable it in order to not silently build broken packages.

If this is accepted, we can drop the `go1.4-bootstrap` package afterwards.

@the-maldridge @nilium 