### PR TITLE
cross-*-musl*: rebuild musl with PIC

### DIFF
--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -147,7 +147,7 @@ _musl_build() {
 
 	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \
 		AS="${_triplet}-as" RANLIB="${_triplet}-ranlib" \
-		CFLAGS="-Os -pipe ${_archflags}" \
+		CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -13,7 +13,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for ARMv5 TE target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -149,7 +149,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -13,7 +13,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -149,7 +149,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -13,7 +13,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -150,7 +150,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -12,7 +12,7 @@ _archflags="-march=i686"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for i686 target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -148,7 +148,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -144,7 +144,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-mips-linux-muslhf/template
+++ b/srcpkgs/cross-mips-linux-muslhf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 BE hardfloat target (musl)"
 maintainer="hipperson0 <hipperson0@gmail.com>"
 homepage="https://www.voidlinux.org/"
@@ -144,7 +144,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -144,7 +144,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -144,7 +144,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 
 short_desc="Cross toolchain for PowerPC (musl)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
@@ -158,7 +158,7 @@ _musl_build() {
 
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for powerpc64 with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -177,7 +177,7 @@ _libucontext_build() {
 
 	# it's ok if we're static only here
 	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
+		CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		make ARCH=ppc64 libucontext.a
 
 	cp libucontext.a ${_sysroot}/usr/lib

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 short_desc="Cross toolchain for powerpc64le with musl"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
@@ -160,7 +160,7 @@ _musl_build() {
 
 	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \
 		AS="${_triplet}-as" RANLIB="${_triplet}-ranlib" \
-		CFLAGS="-Os -pipe ${_archflags}" \
+		CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.32
-revision=2
+revision=3
 archs="i686* x86_64 ppc64le"
 short_desc="Cross toolchain for x86_64 with musl"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -152,7 +152,7 @@ _musl_build() {
 	cd ${wrksrc}/musl-${_musl_version}
 	msg_normal "Building cross musl libc\n"
 
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe ${_archflags}" \
+	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
 		./configure --prefix=/usr
 
 	make ${makejobs}


### PR DESCRIPTION
This is necessary because if musl is not built with PIC in the environment, things that need to link as static PIE when cross compiling will not build (notably https://github.com/void-linux/void-packages/pull/16320). The target musl is okay because the "final" gcc is built with `--enable-default-pie` but the cross musl is built with the bootstrap gcc.