### PR TITLE
ortp-devel: users of this library will depend on bctoolbox for builds

### DIFF
--- a/srcpkgs/ortp/template
+++ b/srcpkgs/ortp/template
@@ -1,7 +1,7 @@
 # Template file for 'ortp'
 pkgname=ortp
 version=1.0.2
-revision=3
+revision=4
 build_style=cmake
 configure_args="-DENABLE_STATIC=OFF"
 makedepends="bctoolbox-devel"
@@ -15,7 +15,7 @@ checksum=f8069cbb0c9679545e52d4080e07b4c2bea049f2571100332c90539490240d76
 CFLAGS="-Wno-stringop-truncation"
 
 ortp-devel_package() {
-	depends="ortp-${version}_${revision}"
+	depends="bctoolbox-devel ortp-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
It has a header file dependency:

  /usr/include/ortp/rtpsession.h:34:10: fatal error: bctoolbox/list.h: No such file or directory

I looked at SDL_ttf and followed the pattern for how it deals with
the same situation.