### PR TITLE
New package: trx

### DIFF
--- a/srcpkgs/trx/template
+++ b/srcpkgs/trx/template
@@ -1,0 +1,12 @@
+# Template file for 'trx'
+pkgname=trx
+version=0.5
+revision=1
+build_style=gnu-makefile
+makedepends="alsa-lib-devel ortp-devel opus-devel"
+short_desc="Realtime audio over IP"
+maintainer="Mark Hills <mark@xwax.org>"
+license="GPL-2.0-only"
+homepage="http://www.pogo.org.uk/~mark/trx"
+distfiles="http://www.pogo.org.uk/~mark/trx/releases/trx-${version}.tar.gz"
+checksum=c7c590c9401d9ef6687b950baa3ca6fd1567b2bbd5013b3283d2452b92624fca


### PR DESCRIPTION
trx is a simple toolset for broadcasting live audio from Linux. It sends and receives encoded audio over IP networks, via a soundcard or audio interface.

Homepage: https://www.pogo.org.uk/~mark/trx/