### PR TITLE
build-style/go: use glob instead of find

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -41,8 +41,9 @@ do_build() {
 }
 
 do_install() {
-	find "${GOPATH}/bin" -type f -executable | while read line
-	do
-		vbin "${line}"
+	for f in ${GOPATH}/bin/* ${GOPATH}/bin/**/*; do
+		if [ -f "$f" ] && [ -x "$f" ]; then
+			vbin "$f"
+		fi
 	done
 }

--- a/srcpkgs/doctl/template
+++ b/srcpkgs/doctl/template
@@ -1,17 +1,14 @@
 # Template file for 'doctl'
 pkgname=doctl
 version=1.21.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/digitalocean/doctl/cmd/doctl"
 go_build_tags="v${version}"
-go_get="yes"
-hostmakedepends="git"
+go_get="no"
 short_desc="Command line tool for DigitalOcean services"
 maintainer="Noah Huppert <contact@noahh.io>"
 license="Apache-2.0"
 homepage="https://github.com/digitalocean/doctl"
-
-post_install() {
-	       vlicense "$GOPATH/src/github.com/digitalocean/doctl/LICENSE.txt"
-}
+distfiles="https://github.com/digitalocean/doctl/archive/v${version}.tar.gz"
+checksum=8c1e60930e913ace562511b6a7ee8f0d3f4d08d4ba48148f26e12b6d2eb95f2b


### PR DESCRIPTION
Close #12442 

---
The second commit is more or less a showcase.
Anyway, cloning a whole repository for dist build isn't nice.