### PR TITLE
New package: swarm-0.5.2

### DIFF
--- a/srcpkgs/swarm/template
+++ b/srcpkgs/swarm/template
@@ -1,0 +1,13 @@
+# Template file for 'swarm'
+pkgname=swarm
+version=0.5.2
+revision=1
+build_style=go
+go_import_path=github.com/ethersphere/swarm
+go_package="${go_import_path}/cmd/swarm"
+short_desc="Censorship resistant storage and communication infrastructure"
+maintainer="Hoang Nguyen <hoang@wetrust.io>"
+license="GPL-3.0-only"
+homepage="https://swarm.ethereum.org"
+distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
+checksum=ff9b1f63039a62e808611503e999ae8392faa23f1306ff2cddc39ef5f0494da1


### PR DESCRIPTION
`swarm` was moved to a different repo. It was originally from `go-ethereum` until this PR https://github.com/void-linux/void-packages/pull/15662