### PR TITLE
sonic-visualiser: Fix build

### DIFF
--- a/srcpkgs/sonic-visualiser/patches/0001-Fix-header-file.patch
+++ b/srcpkgs/sonic-visualiser/patches/0001-Fix-header-file.patch
@@ -1,0 +1,12 @@
+diff --git a/svcore/base/RangeMapper.h b/svcore/base/RangeMapper.h
+index dd8ba94..4cdd924 100644
+--- svcore/base/RangeMapper.h
++++ svcore/base/RangeMapper.h
+ #ifndef SV_RANGE_MAPPER_H
+ #define SV_RANGE_MAPPER_H
+ 
+-#include <QString>
++#include <qt5/QtCore/qstring.h>
+ 
+ #include "Debug.h"
+ #include <map>

--- a/srcpkgs/sonic-visualiser/template
+++ b/srcpkgs/sonic-visualiser/template
@@ -1,7 +1,7 @@
 # Template file for 'sonic-visualiser'
 pkgname=sonic-visualiser
 version=4.0
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper=qmake
 hostmakedepends="pkg-config capnproto-devel"


### PR DESCRIPTION
<QString> points to "qstring.h"
which is not found, this corrects it