### PR TITLE
GCP-Guest-Environment: redirect sv check to /dev/null

### DIFF
--- a/srcpkgs/GCP-Guest-Environment/files/GCP-accounts/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-accounts/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sv check GCP-Guest-Initialization || exit 1
+sv check GCP-Guest-Initialization >/dev/null || exit 1
 
 while ! ping -c1 metadata.google.internal >/dev/null ; do
     sleep 5

--- a/srcpkgs/GCP-Guest-Environment/files/GCP-clock-skew/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-clock-skew/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sv check GCP-Guest-Initialization || exit 1
+sv check GCP-Guest-Initialization >/dev/null || exit 1
 
 while ! ping -c1 metadata.google.internal >/dev/null ; do
     sleep 5

--- a/srcpkgs/GCP-Guest-Environment/files/GCP-ip-forwarding/run
+++ b/srcpkgs/GCP-Guest-Environment/files/GCP-ip-forwarding/run
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sv check GCP-Guest-Initialization || exit 1
+sv check GCP-Guest-Initialization >/dev/null || exit 1
 
 while ! ping -c1 metadata.google.internal >/dev/null ; do
     sleep 5

--- a/srcpkgs/GCP-Guest-Environment/template
+++ b/srcpkgs/GCP-Guest-Environment/template
@@ -1,7 +1,7 @@
 # Template file for 'GCP-Guest-Environment'
 pkgname=GCP-Guest-Environment
 version=20190801
-revision=1
+revision=2
 archs=noarch
 wrksrc="compute-image-packages-${version}"
 build_wrksrc="packages/python-google-compute-engine"


### PR DESCRIPTION
Avoid spamming the tty/serial with sv messages.
The stdout for this command is not needed as it is used programmatically with the exit status

Fixes an issue with the serial console in the GCP Void build which should rebuilt after merging 