### PR TITLE
New package: openjdk7-bootstrap-7u221b02

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1788,6 +1788,12 @@ libawt_xawt.so openjdk11-11.0.5+10_1
 libjava.so openjdk11-11.0.5+10_1
 libjli.so openjdk11-11.0.5+10_1
 libjvm.so openjdk11-11.0.5+10_1
+libjawt.so openjdk7-bootstrap-7u221b02_1
+libawt.so openjdk7-bootstrap-7u221b02_1
+libawt_xawt.so openjdk7-bootstrap-7u221b02_1
+libjava.so openjdk7-bootstrap-7u221b02_1
+libjli.so openjdk7-bootstrap-7u221b02_1
+libjvm.so openjdk7-bootstrap-7u221b02_1
 libucl.so.5 libucl-0.8.1_1
 libhandle.so.1 xfsprogs-3.2.1_1
 libnfnetlink.so.0 libnfnetlink-1.0.1_1

--- a/srcpkgs/openjdk7-bootstrap/INSTALL.msg
+++ b/srcpkgs/openjdk7-bootstrap/INSTALL.msg
@@ -1,0 +1,4 @@
+This is a bootstrap compiler, which means it's not intended for ordinary usage
+but rather only to compile the toolchain. In this case, it's the OpenJDK 8
+toolchain, which needs OpenJDK 7 or newer to build itself. Please do not use
+this package as your Java implementation.

--- a/srcpkgs/openjdk7-bootstrap/files/dist_patches_glibc.txt
+++ b/srcpkgs/openjdk7-bootstrap/files/dist_patches_glibc.txt
@@ -1,0 +1,7 @@
+# Patch series passed to the IcedTea build system
+icedtea-pr64174.patch
+icedtea-jdk-execinfo.patch
+icedtea-jdk-fix-ipv6-init.patch
+icedtea-jdk-no-soname.patch
+icedtea-jdk-xattr.patch
+icedtea-cpio.patch

--- a/srcpkgs/openjdk7-bootstrap/files/dist_patches_musl.txt
+++ b/srcpkgs/openjdk7-bootstrap/files/dist_patches_musl.txt
@@ -1,0 +1,13 @@
+# Patch series passed to the IcedTea build system
+icedtea-pr64174.patch
+icedtea-hotspot-musl.patch
+icedtea-hotspot-musl-ppc.patch
+icedtea-hotspot-noagent-musl.patch
+icedtea-hotspot-uclibc-fixes.patch
+icedtea-jdk-fix-build.patch
+icedtea-jdk-execinfo.patch
+icedtea-jdk-fix-ipv6-init.patch
+icedtea-jdk-musl.patch
+icedtea-jdk-no-soname.patch
+icedtea-jdk-xattr.patch
+icedtea-cpio.patch

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-cpio.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-cpio.patch
@@ -1,0 +1,11 @@
+--- openjdk/jdk/make/common/shared/Defs-utils.gmk.orig
++++ openjdk/jdk/make/common/shared/Defs-utils.gmk
+@@ -104,7 +104,7 @@
+ COMM           = $(UTILS_USR_BIN_PATH)comm
+ COMPRESS       = $(UTILS_USR_BIN_PATH)compress
+ CP             = $(UTILS_COMMAND_PATH)cp
+-CPIO           = $(UTILS_COMMAND_PATH)cpio
++CPIO           = $(UTILS_USR_BIN_PATH)cpio
+ CUT            = $(UTILS_USR_BIN_PATH)cut
+ DATE           = $(UTILS_COMMAND_PATH)date
+ DF             = $(UTILS_COMMAND_PATH)df

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-musl-ppc.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-musl-ppc.patch
@@ -1,0 +1,22 @@
+--- openjdk.orig/hotspot/src/os_cpu/linux_ppc/vm/os_linux_ppc.cpp
++++ openjdk/hotspot/src/os_cpu/linux_ppc/vm/os_linux_ppc.cpp
+@@ -80,7 +80,7 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-
++# include <asm/ptrace.h>
+ 
+ address os::current_stack_pointer() {
+   intptr_t* csp;
+--- openjdk.orig/hotspot.orig/src/cpu/ppc/vm/macroAssembler_ppc.cpp
++++ openjdk/hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp
+@@ -46,6 +46,8 @@
+ #include "gc_implementation/g1/heapRegion.hpp"
+ #endif
+ 
++#include <asm/ptrace.h>
++
+ #ifdef PRODUCT
+ #define BLOCK_COMMENT(str) // nothing
+ #else

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-musl.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-musl.patch
@@ -1,0 +1,79 @@
+--- openjdk.orig/hotspot/src/os/linux/vm/jvm_linux.cpp
++++ openjdk/hotspot/src/os/linux/vm/jvm_linux.cpp
+@@ -154,7 +154,9 @@
+ #ifdef SIGSTKFLT
+   "STKFLT",     SIGSTKFLT,      /* Stack fault.  */
+ #endif
++#ifdef SIGCLD
+   "CLD",        SIGCLD,         /* Same as SIGCHLD (System V).  */
++#endif
+   "CHLD",       SIGCHLD,        /* Child status has changed (POSIX).  */
+   "CONT",       SIGCONT,        /* Continue (POSIX).  */
+   "STOP",       SIGSTOP,        /* Stop, unblockable (POSIX).  */
+--- openjdk.orig/hotspot/src/os/linux/vm/os_linux.inline.hpp
++++ openjdk/hotspot/src/os/linux/vm/os_linux.inline.hpp
+@@ -52,7 +52,7 @@
+ 
+ #include <unistd.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <netdb.h>
+ 
+ inline void* os::thread_local_storage_at(int index) {
+--- openjdk.orig/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
++++ openjdk/hotspot/src/os_cpu/linux_x86/vm/os_linux_x86.cpp
+@@ -73,7 +73,6 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
+ 
+ #ifdef AMD64
+ #define REG_SP REG_RSP
+@@ -533,6 +532,9 @@
+   ShouldNotReachHere();
+   return true; // Mute compiler
+ }
++
++#define _FPU_GETCW(cw) __asm__ __volatile__ ("fnstcw %0" : "=m" (*&cw))
++#define _FPU_SETCW(cw) __asm__ __volatile__ ("fldcw %0" : : "m" (*&cw))
+ 
+ void os::Linux::init_thread_fpu_state(void) {
+ #ifndef AMD64
+--- openjdk.orig/hotspot/src/os_cpu/linux_x86/vm/threadLS_linux_x86.hpp
++++ openjdk/hotspot/src/os_cpu/linux_x86/vm/threadLS_linux_x86.hpp
+@@ -32,7 +32,9 @@
+   // map stack pointer to thread pointer - see notes in threadLS_linux_x86.cpp
+   #define SP_BITLENGTH  32
+   #define PAGE_SHIFT    12
++  #ifndef PAGE_SIZE
+   #define PAGE_SIZE     (1UL << PAGE_SHIFT)
++  #endif
+   static Thread* _sp_map[1UL << (SP_BITLENGTH - PAGE_SHIFT)];
+ 
+ public:
+--- openjdk/hotspot/src/os_cpu/linux_aarch64/vm/os_linux_aarch64.cpp.orig
++++ openjdk/hotspot/src/os_cpu/linux_aarch64/vm/os_linux_aarch64.cpp
+@@ -76,7 +76,7 @@
+ # include <pwd.h>
+ # include <poll.h>
+ # include <ucontext.h>
+-# include <fpu_control.h>
++# include <linux/types.h>
+ 
+ #ifdef BUILTIN_SIM
+ #define REG_SP REG_RSP
+--- openjdk/hotspot/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp.orig
++++ openjdk/hotspot/src/cpu/aarch64/vm/sharedRuntime_aarch64.cpp
+@@ -194,10 +194,6 @@
+   return (r->reg2stack() + SharedRuntime::out_preserve_stack_slots()) * VMRegImpl::stack_slot_size;
+ }
+ 
+-template <class T> static const T& min (const T& a, const T& b) {
+-  return (a > b) ? b : a;
+-}
+-
+ // ---------------------------------------------------------------------------
+ // Read the array of BasicTypes from a signature, and compute where the
+ // arguments should go.  Values in the VMRegPair regs array refer to 4-byte

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-noagent-musl.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-noagent-musl.patch
@@ -1,0 +1,54 @@
+--- openjdk.orig/hotspot/make/linux/makefiles/defs.make
++++ openjdk/hotspot/make/linux/makefiles/defs.make
+@@ -327,6 +327,9 @@
+ 
+ # Serviceability Binaries
+ # No SA Support for PPC, IA64, ARM or zero
++# or if thread_db.h missing (musl)
++
++ifneq ($(wildcard /usr/include/thread_db.h),)
+ ADD_SA_BINARIES/x86   = $(EXPORT_JRE_LIB_ARCH_DIR)/libsaproc.$(LIBRARY_SUFFIX) \
+                         $(EXPORT_LIB_DIR)/sa-jdi.jar 
+ ADD_SA_BINARIES/sparc = $(EXPORT_JRE_LIB_ARCH_DIR)/libsaproc.$(LIBRARY_SUFFIX) \
+@@ -343,6 +346,10 @@
+       endif
+     endif
+   endif
++endif
++else
++ADD_SA_BINARIES/x86   =
++ADD_SA_BINARIES/sparc =
+ endif
+ ADD_SA_BINARIES/ppc   = 
+ ADD_SA_BINARIES/ppc64 = 
+--- openjdk.orig/hotspot/make/linux/makefiles/sa.make
++++ openjdk/hotspot/make/linux/makefiles/sa.make
+@@ -59,9 +59,11 @@
+ 
+ # if $(AGENT_DIR) does not exist, we don't build SA
+ # also, we don't build SA on Itanium or zero.
++# check for thread_db.h too (musl does not have it).
+ 
+ all: 
+-	if [ -d $(AGENT_DIR) -a "$(SRCARCH)" != "ia64" \
++	if [ -d $(AGENT_DIR) -a -f /usr/include/thread_db.h \
++             -a "$(SRCARCH)" != "ia64" \
+              -a "$(SRCARCH)" != "zero"  \
+              -a "$(SRCARCH)" != "aarch64" ] ; then \
+ 	   $(MAKE) -f sa.make $(GENERATED)/sa-jdi.jar; \
+--- openjdk.orig/hotspot/make/linux/makefiles/saproc.make
++++ openjdk/hotspot/make/linux/makefiles/saproc.make
+@@ -65,10 +65,13 @@
+ 
+ # if $(AGENT_DIR) does not exist, we don't build SA
+ # also, we don't build SA on Itanium or zero.
++# check for thread_db.h too (musl does not have it).
+ 
++ifneq ($(wildcard /usr/include/thread_db.h),)
+ ifneq ($(wildcard $(AGENT_DIR)),)
+ ifneq ($(filter-out ia64 zero aarch64,$(SRCARCH)),)
+   BUILDLIBSAPROC = $(LIBSAPROC)
++endif
+ endif
+ endif
+ 

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-uclibc-fixes.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-hotspot-uclibc-fixes.patch
@@ -1,0 +1,93 @@
+--- openjdk.orig/hotspot/src/os/linux/vm/os_linux.cpp
++++ openjdk/hotspot/src/os/linux/vm/os_linux.cpp
+@@ -112,7 +112,6 @@
+ # include <string.h>
+ # include <syscall.h>
+ # include <sys/sysinfo.h>
+-# include <gnu/libc-version.h>
+ # include <sys/ipc.h>
+ # include <sys/shm.h>
+ # include <link.h>
+@@ -632,6 +631,13 @@
+ // detecting pthread library
+ 
+ void os::Linux::libpthread_init() {
++#if 1
++  // Hard code Alpine Linux supported uclibc/musl compatible settings
++  os::Linux::set_glibc_version("glibc 2.9");
++  os::Linux::set_libpthread_version("NPTL");
++  os::Linux::set_is_NPTL();
++  os::Linux::set_is_floating_stack();
++#else
+   // Save glibc and pthread version strings. Note that _CS_GNU_LIBC_VERSION
+   // and _CS_GNU_LIBPTHREAD_VERSION are supported in glibc >= 2.3.2. Use a
+   // generic name for earlier versions.
+@@ -690,6 +696,7 @@
+   if (os::Linux::is_NPTL() || os::Linux::supports_variable_stack_size()) {
+      os::Linux::set_is_floating_stack();
+   }
++#endif
+ }
+ 
+ /////////////////////////////////////////////////////////////////////////////
+@@ -2951,11 +2958,7 @@
+ // If we are running with earlier version, which did not have symbol versions,
+ // we should use the base version.
+ void* os::Linux::libnuma_dlsym(void* handle, const char *name) {
+-  void *f = dlvsym(handle, name, "libnuma_1.1");
+-  if (f == NULL) {
+-    f = dlsym(handle, name);
+-  }
+-  return f;
++  return dlsym(handle, name);
+ }
+ 
+ bool os::Linux::libnuma_init() {
+@@ -5312,7 +5315,25 @@
+ // Linux doesn't yet have a (official) notion of processor sets,
+ // so just return the system wide load average.
+ int os::loadavg(double loadavg[], int nelem) {
++#ifdef __UCLIBC__
++	FILE *LOADAVG;
++	double avg[3] = { 0.0, 0.0, 0.0 };
++	int i, res = -1;;
++
++	if ((LOADAVG = fopen("/proc/loadavg", "r"))) {
++		fscanf(LOADAVG, "%lf %lf %lf", &avg[0], &avg[1], &avg[2]);
++		res = 0;
++		fclose(LOADAVG);
++	}
++
++	for (i = 0; (i < nelem) && (i < 3); i++) {
++		loadavg[i] = avg[i];
++	}
++
++	return res;
++#else
+   return ::getloadavg(loadavg, nelem);
++#endif
+ }
+ 
+ void os::pause() {
+--- openjdk.orig/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
++++ openjdk/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp
+@@ -253,7 +253,7 @@
+ #elif defined(__APPLE__)
+ inline int g_isnan(double f) { return isnan(f); }
+ #elif defined(LINUX) || defined(_ALLBSD_SOURCE)
+-inline int g_isnan(float  f) { return isnanf(f); }
++inline int g_isnan(float  f) { return isnan(f); }
+ inline int g_isnan(double f) { return isnan(f); }
+ #else
+ #error "missing platform-specific definition here"
+@@ -267,8 +267,8 @@
+ 
+ // Checking for finiteness
+ 
+-inline int g_isfinite(jfloat  f)                 { return finite(f); }
+-inline int g_isfinite(jdouble f)                 { return finite(f); }
++inline int g_isfinite(jfloat  f)                 { return isfinite(f); }
++inline int g_isfinite(jdouble f)                 { return isfinite(f); }
+ 
+ 
+ // Wide characters

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-execinfo.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-execinfo.patch
@@ -1,0 +1,40 @@
+--- openjdk.orig/jdk/src/solaris/native/sun/awt/awt_xembed_server.c
++++ openjdk/jdk/src/solaris/native/sun/awt/awt_xembed_server.c
+@@ -35,7 +35,7 @@
+ #include <X11/Xlib.h>
+ #include <X11/Xatom.h>
+ #include <Xm/MwmUtil.h>
+-#ifdef __linux__
++#if defined(__linux__) && defined(__GLIBC__) && ! defined(__UCLIBC__)
+ #include <execinfo.h>
+ #endif
+ #include <stdio.h>
+@@ -835,7 +835,7 @@
+     AWT_UNLOCK();
+ }
+ 
+-#ifdef __linux__
++#if defined(__linux__) && defined(__GLIBC__) && ! defined(__UCLIBC__)
+ void
+ print_stack (void)
+ {
+--- openjdk.orig/jdk/src/solaris/native/sun/xawt/XToolkit.c
++++ openjdk/jdk/src/solaris/native/sun/xawt/XToolkit.c
+@@ -27,7 +27,7 @@
+ #include <X11/Xutil.h>
+ #include <X11/Xos.h>
+ #include <X11/Xatom.h>
+-#ifdef __linux__
++#if defined(__linux__) && defined(__GLIBC__) && ! defined(__UCLIBC__)
+ #include <execinfo.h>
+ #endif
+ 
+@@ -689,7 +689,7 @@
+     return ret;
+ }
+ 
+-#ifdef __linux__
++#if defined(__linux__) && defined(__GLIBC__) && ! defined(__UCLIBC__)
+ void print_stack(void)
+ {
+   void *array[10];

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-fix-build.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-fix-build.patch
@@ -1,0 +1,56 @@
+Fixes three issues:
+ - so's should not be linked to -ljvm as dlopen(/abs/name) is
+   used by the launcher to load libjvm.so; it is thus not available
+   (musl/uclibc) ld.so to satisfy NEEDED dependency inserted by
+   -ljvm. Fix to not link against -ljvm, and disable -z defs so
+   undefined symbols are allowed in sos
+ - the previous makes ldd generate errors on unresolved symbols (musl)
+   remove it altogether as it's used for informative purposes only
+   (display things - not check anything useful)
+ - Don't delete the generated directory $(GENCSEXT), this can
+   confuse make in highly parallel builds with:
+   make[6]: *** INTERNAL: readdir: No such file or directory.  Stop.               
+   make[6]: Leaving directory '.../openjdk-boot/jdk/make/sun/nio/cs'     
+
+--- openjdk.orig/jdk/make/common/Defs-linux.gmk
++++ openjdk/jdk/make/common/Defs-linux.gmk
+@@ -350,7 +350,7 @@
+ 
+ EXTRA_LIBS += -lc
+ 
+-LDFLAGS_DEFS_OPTION  = -Xlinker -z -Xlinker defs
++LDFLAGS_DEFS_OPTION  =
+ LDFLAGS_COMMON  += $(LDFLAGS_DEFS_OPTION)
+ 
+ #
+@@ -407,7 +407,7 @@
+ # the library itself should not.
+ #
+ VM_NAME         = server
+-JVMLIB          = -L$(LIBDIR)/$(LIBARCH)/$(VM_NAME) -ljvm
++JVMLIB          =
+ JAVALIB         = -ljava $(JVMLIB)
+ 
+ #
+--- openjdk.orig/jdk/make/sun/nio/cs/Makefile
++++ openjdk/jdk/make/sun/nio/cs/Makefile
+@@ -107,7 +107,7 @@
+ 		$(GENCSDATASRC)/DoubleByte-X.java.template \
+ 		$(GENCSDATASRC)/extsbcs $(GENCSDATASRC)/dbcs
+ 	@$(prep-target)
+-	$(RM) -r $(GENCSEXT)
++	$(RM) -f "$(GENCSEXT)"/*
+ 	$(MKDIR) -p $(GENCSEXT)
+ 	$(BOOT_JAVA_CMD) -jar $(CHARSETMAPPING_JARFILE)	$(GENCSDATASRC) $(GENCSEXT) extsbcs
+ 	$(BOOT_JAVA_CMD) -jar $(CHARSETMAPPING_JARFILE) $(GENCSDATASRC) $(GENCSEXT) euctw \
+--- openjdk.orig/jdk/make/common/shared/Defs-linux.gmk
++++ openjdk/jdk/make/common/shared/Defs-linux.gmk
+@@ -207,8 +207,6 @@
+   if [ "`$(NM) -D -g --defined-only $1 | $(EGREP) 'SUNWprivate'`" = "" ] ; then \
+     $(ECHO) "$(MAPFILE_WARNING): File was not built with a mapfile: $1"; \
+   fi && \
+-  $(ECHO) "Library loads for: $1" && \
+-  $(LDD) $1 && \
+   $(ECHO) "RUNPATH for: $1" && \
+   ( $(READELF) -d $1 | $(EGREP) 'NEEDED|RUNPATH|RPATH' ) \
+ )

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-fix-ipv6-init.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-fix-ipv6-init.patch
@@ -1,0 +1,42 @@
+--- openjdk/jdk/src/solaris/native/java/net/net_util_md.c.orig
++++ openjdk/jdk/src/solaris/native/java/net/net_util_md.c
+@@ -561,7 +561,7 @@
+ 
+ static struct localinterface *localifs = 0;
+ static int localifsSize = 0;    /* size of array */
+-static int nifs = 0;            /* number of entries used in array */
++static int nifs = -1;            /* number of entries used in array */
+ 
+ /* not thread safe: make sure called once from one thread */
+ 
+@@ -573,6 +573,10 @@
+     int index, x1, x2, x3;
+     unsigned int u0,u1,u2,u3,u4,u5,u6,u7,u8,u9,ua,ub,uc,ud,ue,uf;
+ 
++    if (nifs >= 0)
++	return ;
++    nifs = 0;
++
+     if ((f = fopen("/proc/net/if_inet6", "r")) == NULL) {
+         return ;
+     }
+@@ -601,7 +605,7 @@
+             localifs = (struct localinterface *) realloc (
+                         localifs, sizeof (struct localinterface)* (localifsSize+5));
+             if (localifs == 0) {
+-                nifs = 0;
++                nifs = -1;
+                 fclose (f);
+                 return;
+             }
+@@ -624,9 +628,7 @@
+ static int getLocalScopeID (char *addr) {
+     struct localinterface *lif;
+     int i;
+-    if (localifs == 0) {
+-        initLocalIfs();
+-    }
++    initLocalIfs();
+     for (i=0, lif=localifs; i<nifs; i++, lif++) {
+         if (memcmp (addr, lif->localaddr, 16) == 0) {
+             return lif->index;

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-musl.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-musl.patch
@@ -1,0 +1,116 @@
+diff -ru openjdk.orig/jdk/src/share/native/com/sun/java/util/jar/pack/zip.cpp openjdk/jdk/src/share/native/com/sun/java/util/jar/pack/zip.cpp
+--- openjdk.orig/jdk/src/share/native/com/sun/java/util/jar/pack/zip.cpp	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/share/native/com/sun/java/util/jar/pack/zip.cpp	2014-07-15 07:19:52.186682096 +0000
+@@ -46,6 +46,8 @@
+ 
+ #include "zip.h"
+ 
++#define uchar unsigned char
++
+ #ifdef NO_ZLIB
+ 
+ inline bool jar::deflate_bytes(bytes& head, bytes& tail) {
+diff -ru openjdk.orig/jdk/src/share/native/com/sun/java/util/jar/pack/zip.h openjdk/jdk/src/share/native/com/sun/java/util/jar/pack/zip.h
+--- openjdk.orig/jdk/src/share/native/com/sun/java/util/jar/pack/zip.h	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/share/native/com/sun/java/util/jar/pack/zip.h	2014-07-15 07:19:52.186682096 +0000
+@@ -23,9 +23,7 @@
+  * questions.
+  */
+ 
+-#define ushort unsigned short
+-#define uint   unsigned int
+-#define uchar  unsigned char
++#include <sys/types.h>
+ 
+ struct unpacker;
+ 
+diff -ru openjdk.orig/jdk/src/share/native/sun/awt/medialib/mlib_types.h openjdk/jdk/src/share/native/sun/awt/medialib/mlib_types.h
+--- openjdk.orig/jdk/src/share/native/sun/awt/medialib/mlib_types.h	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/share/native/sun/awt/medialib/mlib_types.h	2014-07-15 07:19:52.186682096 +0000
+@@ -27,6 +27,7 @@
+ #ifndef MLIB_TYPES_H
+ #define MLIB_TYPES_H
+ 
++#include <stddef.h>			/* for NULL */
+ #include <limits.h>
+ #if defined(_MSC_VER)
+ #include <float.h>                      /* for FLT_MAX and DBL_MAX */
+diff -ru openjdk.orig/jdk/src/solaris/native/java/net/Inet4AddressImpl.c openjdk/jdk/src/solaris/native/java/net/Inet4AddressImpl.c
+--- openjdk.orig/jdk/src/solaris/native/java/net/Inet4AddressImpl.c	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/solaris/native/java/net/Inet4AddressImpl.c	2014-07-15 07:19:52.186682096 +0000
+@@ -47,7 +47,7 @@
+ 
+ #include "java_net_Inet4AddressImpl.h"
+ 
+-#if defined(__GLIBC__) || (defined(__FreeBSD__) && (__FreeBSD_version >= 601104))
++#if defined(__linux__) || (defined(__FreeBSD__) && (__FreeBSD_version >= 601104))
+ #define HAS_GLIBC_GETHOSTBY_R   1
+ #endif
+ 
+diff -ru openjdk.orig/jdk/src/solaris/native/java/net/NetworkInterface.c openjdk/jdk/src/solaris/native/java/net/NetworkInterface.c
+--- openjdk.orig/jdk/src/solaris/native/java/net/NetworkInterface.c	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/solaris/native/java/net/NetworkInterface.c	2014-07-15 07:19:52.186682096 +0000
+@@ -47,7 +47,6 @@
+ 
+ #ifdef __linux__
+ #include <sys/ioctl.h>
+-#include <bits/ioctls.h>
+ #include <sys/utsname.h>
+ #include <stdio.h>
+ #endif
+diff -ru openjdk.orig/jdk/src/solaris/native/java/net/PlainDatagramSocketImpl.c openjdk/jdk/src/solaris/native/java/net/PlainDatagramSocketImpl.c
+--- openjdk.orig/jdk/src/solaris/native/java/net/PlainDatagramSocketImpl.c	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/solaris/native/java/net/PlainDatagramSocketImpl.c	2014-07-15 07:19:52.190015524 +0000
+@@ -35,7 +35,6 @@
+ #endif
+ #ifdef __linux__
+ #include <unistd.h>
+-#include <sys/sysctl.h>
+ #include <sys/utsname.h>
+ #include <netinet/ip.h>
+ 
+diff -ru openjdk.orig/jdk/src/solaris/native/java/net/PlainSocketImpl.c openjdk/jdk/src/solaris/native/java/net/PlainSocketImpl.c
+--- openjdk.orig/jdk/src/solaris/native/java/net/PlainSocketImpl.c	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/solaris/native/java/net/PlainSocketImpl.c	2014-07-15 07:19:52.190015524 +0000
+@@ -43,7 +43,6 @@
+ #endif
+ #ifdef __linux__
+ #include <unistd.h>
+-#include <sys/sysctl.h>
+ #endif
+ 
+ #include "jvm.h"
+diff -ru openjdk.orig/jdk/src/solaris/native/java/net/linux_close.c openjdk/jdk/src/solaris/native/java/net/linux_close.c
+--- openjdk.orig/jdk/src/solaris/native/java/net/linux_close.c	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/solaris/native/java/net/linux_close.c	2014-07-15 07:22:17.609355950 +0000
+@@ -75,7 +75,7 @@
+ #ifdef _AIX
+ static int sigWakeup = (SIGRTMAX - 1);
+ #else
+-static int sigWakeup = (__SIGRTMAX - 2);
++static int sigWakeup;
+ #endif
+ 
+ /*
+@@ -148,6 +148,9 @@
+     /*
+      * Setup the signal handler
+      */
++#ifndef __AIX
++    sigWakeup = SIGRTMAX - 2;
++#endif
+     sa.sa_handler = sig_wakeup;
+     sa.sa_flags   = 0;
+     sigemptyset(&sa.sa_mask);
+diff -ru openjdk.orig/jdk/src/solaris/native/sun/nio/ch/NativeThread.c openjdk/jdk/src/solaris/native/sun/nio/ch/NativeThread.c
+--- openjdk.orig/jdk/src/solaris/native/sun/nio/ch/NativeThread.c	2014-06-12 20:14:44.000000000 +0000
++++ openjdk/jdk/src/solaris/native/sun/nio/ch/NativeThread.c	2014-07-15 07:19:52.190015524 +0000
+@@ -38,7 +38,7 @@
+ #include <sys/signal.h>
+ 
+ /* Also defined in src/solaris/native/java/net/linux_close.c */
+-#define INTERRUPT_SIGNAL (__SIGRTMAX - 2)
++#define INTERRUPT_SIGNAL (SIGRTMAX - 2)
+ 
+ static void
+ nullHandler(int sig)

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-no-soname.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-no-soname.patch
@@ -1,0 +1,12 @@
+--- ./openjdk/jdk/make/common/Defs-linux.gmk.orig
++++ ./openjdk/jdk/make/common/Defs-linux.gmk
+@@ -248,7 +248,9 @@
+ #
+ LDFLAGS_OPT     = -Xlinker -O1
+ LDFLAGS_COMMON += -L$(LIBDIR)/$(LIBARCH)
++ifdef LIBRARY
+ LDFLAGS_COMMON += -Wl,-soname=$(LIB_PREFIX)$(LIBRARY).$(LIBRARY_SUFFIX)
++endif
+ 
+ #
+ # -static-libgcc is a gcc-3 flag to statically link libgcc, gcc-2.9x always

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-xattr.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-jdk-xattr.patch
@@ -1,0 +1,11 @@
+--- openjdk.orig/jdk/src/solaris/native/sun/nio/fs/LinuxNativeDispatcher.c	2019-05-30 09:55:45.271164370 +0300
++++ openjdk/jdk/src/solaris/native/sun/nio/fs/LinuxNativeDispatcher.c	2019-05-30 09:56:01.000980599 +0300
+@@ -38,7 +38,7 @@
+ 
+ #ifdef COMPILE_AGAINST_SYSCALLS
+ #include <sys/types.h>
+-#include <attr/xattr.h>
++#include <sys/xattr.h>
+ #else
+ #include <syscalls_fp.h>
+ #endif

--- a/srcpkgs/openjdk7-bootstrap/files/icedtea-pr64174.patch
+++ b/srcpkgs/openjdk7-bootstrap/files/icedtea-pr64174.patch
@@ -1,0 +1,24 @@
+--- patches.orig/boot/pr64174.patch
++++ patches/boot/pr64174.patch
+@@ -1,8 +1,7 @@
+-diff -Nru openjdk-boot.orig/jdk/src/share/classes/java/util/CurrencyData.properties openjdk-boot/jdk/src/share/classes/java/util/CurrencyData.properties
+---- openjdk-boot.orig/jdk/src/share/classes/java/util/CurrencyData.properties	2014-12-04 15:09:06.030312835 +0000
+-+++ openjdk-boot/jdk/src/share/classes/java/util/CurrencyData.properties	2014-12-04 15:10:07.527160626 +0000
+-@@ -320,7 +320,7 @@
+- # LAO PEOPLE'S DEMOCRATIC REPUBLIC
++--- openjdk-boot.orig/jdk/src/share/classes/java/util/CurrencyData.properties
+++++ openjdk-boot/jdk/src/share/classes/java/util/CurrencyData.properties
++@@ -323,7 +323,7 @@
++ # LAO PEOPLE'S DEMOCRATIC REPUBLIC (THE)
+  LA=LAK
+  # LATVIA
+ -LV=LVL;2013-12-31-22-00-00;EUR
+@@ -10,7 +9,7 @@
+  # LEBANON
+  LB=LBP
+  # LESOTHO
+-@@ -332,7 +332,7 @@
++@@ -335,7 +335,7 @@
+  # LIECHTENSTEIN
+  LI=CHF
+  # LITHUANIA

--- a/srcpkgs/openjdk7-bootstrap/patches/fix-xattr-include.patch
+++ b/srcpkgs/openjdk7-bootstrap/patches/fix-xattr-include.patch
@@ -1,0 +1,13 @@
+--- icedtea-2.6.17.orig/acinclude.m4	2019-05-30 09:49:34.952140696 +0300
++++ icedtea-2.6.17/acinclude.m4	2019-05-30 09:50:28.231483929 +0300
+@@ -2271,8 +2271,8 @@
+     dnl Check for syscalls
+     AC_CHECK_FUNCS([openat64 fstatat64 fgetxattr fsetxattr fremovexattr flistxattr unlinkat renameat futimesat fdopendir epoll_create epoll_ctl epoll_wait],,
+       [AC_MSG_ERROR([Could not find required syscalls; check config.log and use --disable-compile-against-syscalls if necessary.])])
+-    AC_CHECK_HEADERS([sys/epoll.h attr/xattr.h],
+-      , [AC_MSG_ERROR([Could not find required system headers; install the appropriate files from glibc-headers, libc6-dev and/or libattr-devel, libattr1-dev or use --disable-compile-against-syscalls if necessary.])])
++    AC_CHECK_HEADERS([sys/epoll.h sys/xattr.h],
++      , [AC_MSG_ERROR([Could not find required system headers; install the appropriate files from glibc-headers or libc6-dev or use --disable-compile-against-syscalls if necessary.])])
+     ENABLE_SYSCALL_COMPILATION=true
+   fi
+   AM_CONDITIONAL(USE_SYSCALL_COMPILATION, test x"${ENABLE_SYSCALL_COMPILATION}" = "xtrue")

--- a/srcpkgs/openjdk7-bootstrap/template
+++ b/srcpkgs/openjdk7-bootstrap/template
@@ -1,0 +1,174 @@
+# Template file for 'openjdk7-bootstrap'
+# Adapted from openjdk7 from Alpine
+pkgname=openjdk7-bootstrap
+# 2.6.19 fails to build: https://github.com/alpinelinux/aports/pull/9813
+_icedtea_ver=2.6.18
+_java_ver=7
+_jdk_update=221
+_jdk_build=02
+_bootstrap_jdk_home="/usr/lib/jvm/java-1.5-gcj"
+_final_jdk_home="/usr/lib/jvm/java-1.7-openjdk"
+version="${_java_ver}u${_jdk_update}b${_jdk_build}"
+revision=1
+wrksrc=icedtea-${_icedtea_ver}
+build_style=gnu-configure
+configure_args="
+ --with-parallel-jobs=${XBPS_MAKEJOBS}
+ --disable-dependency-tracking
+ --disable-downloading
+ --disable-arm32-jit
+ --with-jdk-home=${_bootstrap_jdk_home}
+ --prefix=${_final_jdk_home}"
+make_build_target=icedtea-boot
+make_build_args="SHELL=/bin/bash"
+hostmakedepends="cpio unzip zip ca-certificates autoconf automake pkg-config
+ libxslt wget gcc6-gcj-jdk-compat"
+makedepends="nss-devel cups-devel libjpeg-turbo-devel giflib-devel libpng-devel
+ libXt-devel libXtst-devel libXp-devel libXrender-devel libXinerama-devel
+ libXcomposite-devel lcms2-devel zlib-devel alsa-lib-devel freetype-devel
+ fontconfig-devel gtk+-devel mit-krb5-devel pcsclite-devel lksctp-tools-devel"
+short_desc="OpenJDK 7 via IcedTea (bootstrap)"
+maintainer="q66 <daniel@octaforge.org>"
+license="GPL-2.0-or-later"
+homepage="https://icedtea.classpath.org/"
+lib32disabled=yes
+
+if [ -n "$XBPS_DEBUG_PKGS" ]; then
+	configure_args+=" --enable-native-debuginfo"
+else
+	configure_args+=" --disable-native-debuginfo"
+fi
+
+# using ccache causes ICEs with pregenerated headers
+export CCACHE_DISABLE=1
+
+_rhino_ver=1.7.7.2
+_ant_ver=1.9.11
+
+_drops_ver=$_icedtea_ver
+_drops_url=https://icedtea.classpath.org/download/drops/icedtea7/${_drops_ver}
+
+distfiles="
+ https://icedtea.classpath.org/download/source/icedtea-${_icedtea_ver}.tar.xz
+ ${_drops_url}/openjdk.tar.bz2>openjdk-${_drops_ver}.tar.bz2
+ ${_drops_url}/corba.tar.bz2>corba-${_drops_ver}.tar.bz2
+ ${_drops_url}/jaxp.tar.bz2>jaxp-${_drops_ver}.tar.bz2
+ ${_drops_url}/jaxws.tar.bz2>jaxws-${_drops_ver}.tar.bz2
+ ${_drops_url}/jdk.tar.bz2>jdk-${_drops_ver}.tar.bz2
+ ${_drops_url}/langtools.tar.bz2>langtools-${_drops_ver}.tar.bz2
+ ${_drops_url}/hotspot.tar.bz2>hotspot-${_drops_ver}.tar.bz2
+ https://archive.apache.org/dist/ant/binaries/apache-ant-${_ant_ver}-bin.tar.gz
+ https://github.com/mozilla/rhino/releases/download/Rhino${_rhino_ver//./_}_Release/rhino-${_rhino_ver}.zip"
+
+checksum="
+ af4031b21400d9194bce9aae4dceb012590f88fe8c51efcaa67de33eb7e6152f
+ da5fc1846ec80409ad5af870dbeb03d077b4add3ba54c0dde00414bea0376392
+ c115dfa1027c58b1b6444908e26b613c428661fb210e891c30e6a65e77208776
+ 632aa746ebfd8238c64226bf949d20cc2f1d1423eaabfd19897199b13b434e3c
+ 94fbcc00f3d89b9f3b940af5e7b469d1b945ca99e84b51a7abdadcde33a7be14
+ 57b5741ab0807fbc71f15efce11546d943baffeb5f5cf55ec16fed69634abc36
+ 915f492188b7b214e280532df061adc6c999f0d190ea5f1325bc70b77a2af4f0
+ 8ce20d0c5a16373fe7bea5437d91a513b861788bd24d79ac04e43e73cb82eb54
+ 54569cd31a01975ea6e6eb911e8ebd41016425c7ede2e3980d3feb42cc548bb1
+ b223595717dd360061b35aaa7e952271fcbbd6a763a78927283480227aaa0247"
+
+skip_extraction="
+ openjdk-${_drops_ver}.tar.bz2
+ corba-${_drops_ver}.tar.bz2
+ jaxp-${_drops_ver}.tar.bz2
+ jaxws-${_drops_ver}.tar.bz2
+ jdk-${_drops_ver}.tar.bz2
+ langtools-${_drops_ver}.tar.bz2
+ hotspot-${_drops_ver}.tar.bz2"
+
+shlib_provides="libawt.so libawt_xawt.so libjava.so libjli.so libjvm.so libjawt.so"
+patch_args="-Np1"
+nocross=yes
+
+post_extract() {
+	# ensure they're cleaned up
+	mv ../apache-ant-${_ant_ver} ${wrksrc}/apache-ant
+	mv ../rhino${_rhino_ver} ${wrksrc}/rhino
+
+	# distrib patches are relative to wrksrc
+	for patch in $(cat ${FILESDIR}/dist_patches_${XBPS_TARGET_LIBC}.txt); do
+		case "$patch" in
+			icedtea-*.patch) cp ${FILESDIR}/$patch ${wrksrc}
+		esac
+	done
+}
+
+# we need to set up these vars for both configure and build
+_setup_build_env() {
+	[ -n "$DISTRIBUTION_PATCHES" ] && return 0
+
+	export ALT_PARALLEL_COMPILE_JOBS=$XBPS_MAKEJOBS
+	export HOTSPOT_BUILD_JOBS=$XBPS_MAKEJOBS
+
+	export JAVA_HOME=${_bootstrap_jdk_home}
+	export PATH=$JAVA_HOME/bin:${wrksrc}/apache-ant/bin:$PATH
+
+	# force ELFv2 for ppc64 just in case
+	case "$XBPS_TARGET_MACHINE" in
+		ppc64*)
+			CFLAGS+=" -DABI_ELFv2"
+			CXXFLAGS+=" -DABI_ELFv2"
+			;;
+	esac
+
+	# from alpine: disable jvm-breaking optimizations and c++ std
+	export EXTRA_CPP_FLAGS="$CXXFLAGS -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-strict-overflow"
+	export EXTRA_CFLAGS="$CFLAGS -std=gnu++98 -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fno-strict-overflow"
+
+	local _patches=
+	for patch in $(cat ${FILESDIR}/dist_patches_${XBPS_TARGET_LIBC}.txt); do
+		case "$patch" in
+			icedtea-*.patch) _patches+=" $patch";;
+		esac
+	done
+
+	export DISTRIBUTION_PATCHES="$_patches"
+}
+
+pre_configure() {
+	./autogen.sh
+}
+
+do_configure() {
+	_setup_build_env
+
+	local _args=
+	local _src_prefix="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
+
+	_args+=" --with-rhino=${wrksrc}/rhino/lib/rhino-${_rhino_ver}.jar"
+	_args+=" --with-openjdk-src-zip=${_src_prefix}/openjdk-${_drops_ver}.tar.bz2"
+	_args+=" --with-hotspot-src-zip=${_src_prefix}/hotspot-${_drops_ver}.tar.bz2"
+	_args+=" --with-corba-src-zip=${_src_prefix}/corba-${_drops_ver}.tar.bz2"
+	_args+=" --with-jaxp-src-zip=${_src_prefix}/jaxp-${_drops_ver}.tar.bz2"
+	_args+=" --with-jaxws-src-zip=${_src_prefix}/jaxws-${_drops_ver}.tar.bz2"
+	_args+=" --with-jdk-src-zip=${_src_prefix}/jdk-${_drops_ver}.tar.bz2"
+	_args+=" --with-langtools-src-zip=${_src_prefix}/langtools-${_drops_ver}.tar.bz2"
+
+	./configure ${configure_args} ${_args}
+}
+
+pre_build() {
+	_setup_build_env
+}
+
+do_build() {
+	make -j1 ${make_build_args} ${make_build_target}
+}
+
+do_install() {
+	mkdir -p ${DESTDIR}/${_final_jdk_home}
+	cp -a ${wrksrc}/openjdk.build-boot/j2sdk-image/* ${DESTDIR}/${_final_jdk_home}
+	cp -a ${wrksrc}/openjdk.build-boot/include ${DESTDIR}/${_final_jdk_home}
+	rm -f ${DESTDIR}/${_final_jdk_home}/src.zip
+}
+
+post_install() {
+	rm -rf ${DESTDIR}/usr/lib/bin
+	vlicense ${DESTDIR}/${_final_jdk_home}/ASSEMBLY_EXCEPTION
+	vlicense ${DESTDIR}/${_final_jdk_home}/LICENSE
+}


### PR DESCRIPTION
This is a new toolchain used to bootstrap OpenJDK 8. It is itself bootstrapped using `gcj-6` (https://github.com/void-linux/void-packages/pull/16415), which lets us compile the whole chain from source without fetching foreign binaries.

Depends on https://github.com/void-linux/void-packages/pull/16415.

It is tested to build `openjdk` (version 8) from our repo without issues..