### PR TITLE
docker: Build for aarch64 as well

### DIFF
--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -19,7 +19,7 @@ depends+=" iptables xz git"
 nopie=yes
 nostrip=yes
 nocross=yes
-archs="armv7l* x86_64* ppc64le*"
+archs="aarch64* armv7l* x86_64* ppc64le*"
 system_groups="docker"
 
 _docker_components="tini proxy dockercli"


### PR DESCRIPTION
Docker can also be build for aarch64: Add this architecture

Signed-off-by: David Graeff <david.graeff@web.de>