### PR TITLE
libsass: update to 3.6.3.

### DIFF
--- a/srcpkgs/libsass/template
+++ b/srcpkgs/libsass/template
@@ -1,8 +1,7 @@
 # Template file for 'libsass'
 pkgname=libsass
-reverts="3.6.2_1"
-version=3.6.1
-revision=2
+version=3.6.3
+revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="C implementation of Sass CSS preprocessor"
@@ -10,7 +9,7 @@ maintainer="Gerardo Di Iorio <arete74@gmail.com>"
 license="MIT"
 homepage="http://www.sass-lang.com/libsass"
 distfiles="https://github.com/sass/${pkgname}/archive/${version}.tar.gz"
-checksum=18d6e866ba2430cccae2551f384aca253a84592c692ce7146550f1d4f273b7d7
+checksum=dadb470bb9141e91b437119d367654427180ed2b3d04b8000eab5b0ca47cd5bb
 
 pre_configure() {
 	NOCONFIGURE=1 autoreconf -fi


### PR DESCRIPTION
With this version build fine  sassc and  breeze-gtk 