### PR TITLE
rpi-kernel: update to 4.19.83.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="bbdf44a11a065ebb2aa2ed5690b82287739b471d"
+_githash="3c235dcfe80a7c7ba360219e4a3ecb256f294376"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.81
+version=4.19.83
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=b9ebdfc4622613e919d72089445ab715e2e438a31ecd1bdb357953bed0be1512
+checksum=23a222d8864107b296b3bf580106421899964af879bb7f1c440e875e565fd6f3
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built on armv6l, armv7l, and aarch64.

- Tested on armv6l and armv7l.