### PR TITLE
CLion: update to 2019.3.1

### DIFF
--- a/srcpkgs/CLion/INSTALL.msg
+++ b/srcpkgs/CLion/INSTALL.msg
@@ -8,4 +8,3 @@ CLion has the following optional dependencies:
 	python: Python 2 programming language support
 	python3: Python 3 programming language support
 	doxygen: Code documentation generation
-	libdbusmenu-glib: For global menu support

--- a/srcpkgs/CLion/template
+++ b/srcpkgs/CLion/template
@@ -1,19 +1,25 @@
 # Template file for 'CLion'
 pkgname=CLion
-version=2019.2.4
+version=2019.3.1
 revision=1
 archs="i686 x86_64"
 wrksrc="clion-${version}"
-depends="virtual?java-environment giflib libXtst"
+depends="jetbrains-jdk-bin giflib libXtst"
 short_desc="Smart cross-platform IDE for C and C++"
 maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="custom:Commercial"
 homepage="https://www.jetbrains.com/clion"
 distfiles="https://download.jetbrains.com/cpp/CLion-${version}.tar.gz"
-checksum=2d3b1820eef6d60aab4b9a12c7357280de6606f72cdc1c72d6449e3676f23030
+checksum=1c9bdeb55dda997a6cfce84ce2dbe2951f117709f9d37a3b65cfc2a68a359ecd
 repository=nonfree
 restricted=yes
 nopie=yes
+
+build_options="bundled_cmake bundled_gdb bundled_lldb"
+build_options_default="bundled_cmake bundled_gdb bundled_lldb"
+desc_option_bundled_cmake="Install bundled CMake"
+desc_option_bundled_gdb="Install bundled GDB"
+desc_option_bundled_lldb="Install bundled LLDB"
 
 post_extract() {
 	# Remove files for other CPU architectures
@@ -35,11 +41,15 @@ post_extract() {
 			;;
 	esac
 
-	# Remove JetBrains JDK
-	rm -rf jre64
-
-	# TODO: JetBrains' LLDB, GDB, and CMake can be made installable via separate subpackages
-	# bin/lldb bin/gdb bin/cmake
+	if [ ! "$build_option_bundled_cmake" ]; then
+		rm -rf bin/cmake
+	fi
+	if [ ! "$build_option_bundled_gdb" ]; then
+		rm -rf bin/gdb
+	fi
+	if [ ! "$build_option_bundled_lldb" ]; then
+		rm -rf bin/lldb
+	fi
 }
 
 do_install() {
@@ -53,6 +63,8 @@ do_install() {
 		vlicense $i
 	done
 
+	mkdir -p /usr/lib/jvm/jbrsdk
+	ln -sf /usr/lib/jvm/jbrsdk ${DESTDIR}/${TARGET_PATH}/jbr
 	vcopy bin ${TARGET_PATH}
 	vcopy help ${TARGET_PATH}
 	vcopy lib ${TARGET_PATH}


### PR DESCRIPTION
Additionally:
- add a dependency on `jetbrains-jdk-bin` to ensure the latest is always used.
- make installation of bundled `CMake`, `GDB`, and `LLDB` optional, add options, default to set.