### PR TITLE
python3-rss2email: update to 3.11.

### DIFF
--- a/srcpkgs/python3-rss2email/template
+++ b/srcpkgs/python3-rss2email/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-rss2email'
 pkgname=python3-rss2email
-version=3.10
+version=3.11
 revision=1
 archs=noarch
 wrksrc="rss2email-${version}"
@@ -8,9 +8,10 @@ build_style=python3-module
 pycompile_module="rss2email"
 hostmakedepends="python3-setuptools"
 depends="python3-feedparser python3-html2text"
+checkdepends="${depends} python3-BeautifulSoup4"
 short_desc="Forward RSS feeds to email (community edition)"
 maintainer="Anders Damsgaard <anders@adamsgaard.dk>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/rss2email/rss2email"
 distfiles="https://github.com/rss2email/rss2email/archive/v${version}.tar.gz"
-checksum=922b33f5bc3bce20568b977bff84dfdef3f1f7117fc70cc0b1bee7daa0e0acac
+checksum=ee2c7fc04afb0a8a4153f4c7e3f3bda91c358ec54740aeee9a30a93e28f80f4a


### PR DESCRIPTION
Relative to previous PR #15852, this PR has fixed commit history and added `checkdepends`. No output from `xlint`. Thank you @Chocimier.