### PR TITLE
libGL: update to 19.2.4

### DIFF
--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,6 +1,6 @@
 # Template file for 'libGL'
 pkgname=libGL
-version=19.2.3
+version=19.2.4
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
@@ -22,7 +22,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://www.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=5ee6e42504fe41dcc9a6eba26982656a675b2550a640946f463927ed7f1c5047
+checksum=09000a0f7dbbd82e193b81a8f1bf0c118eab7ca975c0329181968596e548e30f
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
> This is an emergency bugfix release, all users of 19.2.3 are recomended to upgrade immediately.