### PR TITLE
qt5-webengine: work around AdjustAddressSpaceLimit bug on musl

### DIFF
--- a/srcpkgs/qt5/patches/0101-disable-adjustaddressspacelimit-musl.patch
+++ b/srcpkgs/qt5/patches/0101-disable-adjustaddressspacelimit-musl.patch
@@ -1,0 +1,20 @@
+--- qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/page_allocator_internals_posix.h	2019-10-21 10:14:54.000000000 +0200
++++ qtwebengine/src/3rdparty/chromium/base/allocator/partition_allocator/page_allocator_internals_posix.h.patched	2019-11-15 07:04:36.673637152 +0100
+@@ -53,6 +53,9 @@
+ // Multiple guarded memory regions may exceed the process address space limit.
+ // This function will raise or lower the limit by |amount|.
+ bool AdjustAddressSpaceLimit(int64_t amount) {
++#if !defined(__GLIBC__)
++  return false;
++#else
+   struct rlimit old_rlimit;
+   if (getrlimit(RLIMIT_AS, &old_rlimit))
+     return false;
+@@ -62,6 +65,7 @@
+                                     old_rlimit.rlim_max};
+   // setrlimit will fail if limit > old_rlimit.rlim_max.
+   return setrlimit(RLIMIT_AS, &new_rlimit) == 0;
++#endif
+ }
+ 
+ // Current WASM guarded memory regions have 8 GiB of address space. There are

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
 version=5.13.2
-revision=2
+revision=3
 wrksrc="qt-everywhere-src-${version}"
 build_style=gnu-configure
 hostmakedepends="cmake clang flex git glib-devel gperf ninja pkg-config


### PR DESCRIPTION
The AdjustAddressSpaceLimit function crashes for some reason on musl when visiting certain websites (such as https://riot.im/app/).

This patch makes the function fail every time when not using glibc.