### PR TITLE
dnsmasq: let dnsmasq user own its dbus service

### DIFF
--- a/srcpkgs/dnsmasq/patches/dbus.patch
+++ b/srcpkgs/dnsmasq/patches/dbus.patch
@@ -1,0 +1,11 @@
+--- dbus/dnsmasq.conf.orig	2019-11-15 12:36:44.303440024 +0100
++++ dbus/dnsmasq.conf	2019-11-15 12:36:56.357452970 +0100
+@@ -2,7 +2,7 @@
+  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+ <busconfig>
+-	<policy user="root">
++	<policy user="dnsmasq">
+ 		<allow own="uk.org.thekelleys.dnsmasq"/>
+ 		<allow send_destination="uk.org.thekelleys.dnsmasq"/>
+ 	</policy>

--- a/srcpkgs/dnsmasq/template
+++ b/srcpkgs/dnsmasq/template
@@ -1,7 +1,7 @@
 # Template file for 'dnsmasq'
 pkgname=dnsmasq
 version=2.80
-revision=4
+revision=5
 conf_files="/etc/dnsmasq.conf"
 hostmakedepends="pkg-config"
 makedepends="dbus-devel libcap-devel libidn2-devel $(vopt_if dnssec nettle-devel)"


### PR DESCRIPTION
Not sure how this worked before.
The dnsmasq package is installed to be run as dnsmasq user
but its dbus config denies everyone except root.

Fix dbus config replacing root with dnsmasq.
Without this change, users observe a very frequent and annoying warning:

    dnsmasq[1086]: DBus error: Connection ":1.1" is not
    allowed to own the service "uk.org.thekelleys.dnsmasq" due to
    security policies in the configuration file