### PR TITLE
[WIP] [TEST] libGL, nvidia{,390}: use libglvnd

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -117,6 +117,13 @@ libpng16.so.16 libpng-1.6.2_1
 libXrender.so.1 libXrender-0.9.4_1
 libXrandr.so.2 libXrandr-1.3.0_1
 libGLU.so.1 glu-9.0.0_1
+libGLESv2.so.2 libglvnd-1.2.0_1
+libOpenGL.so.0 libglvnd-1.2.0_1
+libGLX.so.0 libglvnd-1.2.0_1
+libGLdispatch.so.0 libglvnd-1.2.0_1
+libGL.so.1 libglvnd-1.2.0_1
+libEGL.so.1 libglvnd-1.2.0_1
+libGLESv1_CM.so.1 libglvnd-1.2.0_1
 libEGL.so.1 libEGL-7.11_1
 libGLESv1_CM.so.1 libGLES-1.0_1
 libGLESv2.so.2 libGLES-1.0_1

--- a/srcpkgs/libGL/template
+++ b/srcpkgs/libGL/template
@@ -1,10 +1,10 @@
 # Template file for 'libGL'
 pkgname=libGL
 version=19.2.5
-revision=1
+revision=2
 wrksrc="mesa-${version}"
 build_style=meson
-configure_args="-Dshared-glapi=true -Dgbm=true -Degl=true
+configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
  -Dgallium-vdpau=true -Dgallium-xvmc=true -Dosmesa=gallium
  -Dgles1=true -Dgles2=true -Dgallium-va=true -Dlmsensors=true
  -Dplatforms=x11,drm,$(vopt_if wayland wayland,)surfaceless -Dllvm=true
@@ -15,7 +15,8 @@ makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel
  libXxf86vm-devel libatomic-devel libdrm-devel libffi-devel libva-devel
  libvdpau-devel libxshmfence-devel ncurses-devel talloc-devel zlib-devel
  $(vopt_if wayland 'wayland-devel wayland-protocols') llvm
- libsensors-devel libXrandr-devel"
+ libsensors-devel libXrandr-devel libglvnd-devel"
+depends="libglvnd"
 short_desc="Graphics library similar to SGI's OpenGL"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, LGPL-2.1-or-later"
@@ -99,6 +100,7 @@ esac
 
 case "$XBPS_TARGET_MACHINE" in
 	# Disable TLS with musl: https://bugs.freedesktop.org/show_bug.cgi?id=35268
+	# TODO: maybe this is handled by libglvnd now
 	*-musl) configure_args+=" -Duse-elf-tls=false";;
 	*) configure_args+=" -Dglx=dri";;
 esac
@@ -148,10 +150,8 @@ libEGL_package() {
 }
 
 libGLES_package() {
-	short_desc="Free implementation of the OpenGL|ES 1.x and 2.x API"
-	pkg_install() {
-		vmove "usr/lib/libGLES*.so.*"
-	}
+	build_style=meta
+	short_desc="Free implementation of the OpenGL|ES API (transitional dummy package)"
 }
 
 libOSMesa_package() {

--- a/srcpkgs/libglvnd-devel
+++ b/srcpkgs/libglvnd-devel
@@ -1,0 +1,1 @@
+libglvnd

--- a/srcpkgs/libglvnd/files/LICENSE
+++ b/srcpkgs/libglvnd/files/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2013, NVIDIA CORPORATION.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+unaltered in all copies or substantial portions of the Materials.
+Any additions, deletions, or changes to the original source files
+must be clearly indicated in accompanying documentation.
+
+If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the
+work of the Khronos Group."
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.

--- a/srcpkgs/libglvnd/template
+++ b/srcpkgs/libglvnd/template
@@ -1,0 +1,40 @@
+# Template file for 'libglvnd'
+pkgname=libglvnd
+version=1.2.0
+revision=1
+wrksrc="libglvnd-v${version}"
+build_style=gnu-configure
+hostmakedepends="autoconf libtool automake pkg-config python"
+makedepends="libXext-devel libX11-devel xorgproto"
+short_desc="GL Vendor-Neutral Dispatch library"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="MIT"
+homepage="https://gitlab.freedesktop.org/glvnd/libglvnd"
+distfiles="https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v${version}/libglvnd-v${version}.tar.gz"
+checksum=56510b6c73d69a6e577490ecc52471ff6e301f17b868afc395090c934eda2b6c
+
+conflicts="libGL<19.2.5_2 libEGL<19.2.5_2 libGLES<19.2.5_2 nvidia-libs<430.40_2 nvidia390-libs<390.132_2"
+
+# Disable TLS with musl: https://bugs.freedesktop.org/show_bug.cgi?id=35268
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) configure_args="--disable-tls"
+esac
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense ${FILESDIR}/LICENSE
+}
+
+libglvnd-devel_package() {
+	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	conflicts="MesaLib-devel<19.2.5_2"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=430.40
-revision=1
+revision=2
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Proprietary NVIDIA license"
 homepage="http://www.nvidia.com"
@@ -28,13 +28,13 @@ if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	 nvidia-opencl nvidia-libs"
 	depends="nvidia-libs-${version}_${revision}
 	 nvidia-gtklibs-${version}_${revision}
-	 nvidia-dkms-${version}_${revision} pkgconf"
+	 nvidia-dkms-${version}_${revision} pkgconf libglvnd"
 else
 	_pkg="NVIDIA-Linux-x86_64-${version}"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
 	checksum=f700899f48ba711b7e1598014e8db9a93537d7baa3d6a64067ed08578387dfd7
 	subpackages="nvidia-libs"
-	depends="pkgconf"
+	depends="pkgconf libglvnd"
 fi
 
 do_extract() {
@@ -174,12 +174,12 @@ do_install() {
 	# GLX client libs
 	if [ "${build_option_glvnd}" ]; then
 		# ----- Also provided by the libglvnd package (todo)
-		vinstall libGL.so.1.7.0 755 usr/lib
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
+#		vinstall libGL.so.1.7.0 755 usr/lib
+#		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
+#		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
 
-		vinstall libGLX.so.0 755 usr/lib
-		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
+#		vinstall libGLX.so.0 755 usr/lib
+#		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
 		# --------------------------------------------------
 
 		# Required for GLVND option
@@ -207,22 +207,22 @@ do_install() {
 	vinstall libnvidia-glvkspirv.so.${version} 755 usr/lib
 
 	# EGL
-	vinstall libOpenGL.so.0 755 usr/lib
-	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
+#	vinstall libOpenGL.so.0 755 usr/lib
+#	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
 
-	vinstall libGLdispatch.so.0 755 usr/lib
+#	vinstall libGLdispatch.so.0 755 usr/lib
 
-	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
+#	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
+#	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
+#	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
 
-	vinstall libGLESv2.so.2.1.0 755 usr/lib
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
+#	vinstall libGLESv2.so.2.1.0 755 usr/lib
+#	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
+#	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
 
-	vinstall libEGL.so.1.1.0 755 usr/lib
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
+#	vinstall libEGL.so.1.1.0 755 usr/lib
+#	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
+#	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
 
 	vinstall libEGL_nvidia.so.${version} 755 usr/lib
 	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/usr/lib/libEGL_nvidia.so.0
@@ -298,9 +298,7 @@ nvidia-gtklibs_package() {
 }
 nvidia-libs_package() {
 	short_desc="${_desc} - common libraries"
-	provides="libEGL-${version}_${revision}
-	 libGL-${version}_${revision} libGLES-${version}_${revision}"
-	replaces="libEGL>=0 libGL>=0 libGLES>=0"
+	conflicts="libGL<19.2.5_2 libEGL<19.2.5_2 libGLES<19.2.5_2"
 	pkg_install() {
 		vmove usr/lib
 	}

--- a/srcpkgs/nvidia390/template
+++ b/srcpkgs/nvidia390/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GeForce 400, 500 series)"
 
 pkgname=nvidia390
 version=390.132
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="http://www.nvidia.com"
@@ -15,7 +15,7 @@ repository="nonfree"
 create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
 depends="nvidia390-libs-${version}_${revision} nvidia390-gtklibs-${version}_${revision}
- nvidia390-dkms-${version}_${revision} pkg-config"
+ nvidia390-dkms-${version}_${revision} pkg-config libglvnd"
 conflicts="catalyst>=0 xserver-abi-video>24_1"
 
 build_options="glvnd"
@@ -55,17 +55,17 @@ do_install() {
 
 	# GLX extension module for X
 	vinstall libglx.so.${version} 755 usr/lib/xorg/modules/extensions
-	ln -sf libglx.so.${version} ${DESTDIR}/usr/lib/xorg/modules/extensions/libglx.so
+#	ln -sf libglx.so.${version} ${DESTDIR}/usr/lib/xorg/modules/extensions/libglx.so
 
 	# GLX client libs
 	if [ "${build_option_glvnd}" ]; then
 		# ----- Also provided by the libglvnd package (todo)
-		vinstall libGL.so.1.7.0 755 usr/lib
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
+#		vinstall libGL.so.1.7.0 755 usr/lib
+#		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
+#		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
 
-		vinstall libGLX.so.0 755 usr/lib
-		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
+#		vinstall libGLX.so.0 755 usr/lib
+#		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
 		# --------------------------------------------------
 
 		# Required for GLVND option
@@ -92,18 +92,18 @@ do_install() {
 
 	# EGL
 	# ----- Also provided by the libglvnd package (todo)
-	vinstall libOpenGL.so.0 755 usr/lib
-	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
+#	vinstall libOpenGL.so.0 755 usr/lib
+#	ln -sf libOpenGL.so.0 ${DESTDIR}/usr/lib/libOpenGL.so
 
-	vinstall libGLdispatch.so.0 755 usr/lib
+#	vinstall libGLdispatch.so.0 755 usr/lib
 
-	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
-	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
+#	vinstall libGLESv1_CM.so.1.2.0 755 usr/lib
+#	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so
+#	ln -sf libGLESv1_CM.so.1.2.0 ${DESTDIR}/usr/lib/libGLESv1_CM.so.1
 
-	vinstall libGLESv2.so.2.1.0 755 usr/lib
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
-	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
+#	vinstall libGLESv2.so.2.1.0 755 usr/lib
+#	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so
+#	ln -sf libGLESv2.so.2.1.0 ${DESTDIR}/usr/lib/libGLESv2.so.2
 
 	vinstall libnvidia-egl-wayland.so.1.0.2 755 usr/lib
 	ln -sf libnvidia-egl-wayland.so.1.0.2 ${DESTDIR}/usr/lib/libnvidia-egl-wayland.so.1
@@ -112,9 +112,9 @@ do_install() {
 	vinstall 10_nvidia_wayland.json 755 usr/share/egl/egl_external_platform.d
 	# --------------------------------------------------
 
-	vinstall libEGL.so.1.1.0 755 usr/lib
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
-	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
+#	vinstall libEGL.so.1.1.0 755 usr/lib
+#	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so
+#	ln -sf libEGL.so.1.1.0 ${DESTDIR}/usr/lib/libEGL.so.1
 
 	vinstall libEGL_nvidia.so.${version} 755 usr/lib
 	ln -sf libEGL_nvidia.so.${version} ${DESTDIR}/usr/lib/libEGL_nvidia.so.0
@@ -267,8 +267,7 @@ nvidia390-gtklibs_package() {
 }
 nvidia390-libs_package() {
 	short_desc="${_desc} - common libraries"
-	provides="libEGL-${version}_${revision} libGL-${version}_${revision} libGLES-${version}_${revision}"
-	replaces="libEGL>=0 libGL>=0 libGLES>=0"
+	conflicts="libGL<19.2.5_2 libEGL<19.2.5_2 libGLES<19.2.5_2"
 	pkg_install() {
 		vmove usr/lib
 	}


### PR DESCRIPTION
This requires extensive testing on all arches. I tested some GL applications on X and Wayland on `x86_64-musl`.
- once built, use `xi -u` to install the modified packages
- to rollback, run the attached script [revert-glvnd.txt](https://github.com/void-linux/void-packages/files/3854550/revert-glvnd.txt). Do not update your system before having rolled back.

This could break your system (rollback script could fail?), only try this if you know what you're doing or in a container/VM.
NOTE: tried to adapt the `nvidia{,390}` packages but do not have the hardware to test them
NOTE: travis builds succeeded (except license lint), disabling now

Some thoughts about how to handle the transition:
- ~~If the libraries provided by `libglvnd` are 100% compatible with those currently provided by mesa's `libGL` and friends (this should be the case, otherwise wouldn't have worked on my system), we don't need to rebuild all the packages that use GL. But a user that wants to use just nvidia cannot do that until all packages he wants to use are rebuilt so that they do not carry the mesa dependencies anymore~~ We must rebuild all the packages that require the libs provided by `libglvnd`.
- After putting the `libglvnd` libraries in `common/shlibs`, new packages that are built will have only `libglvnd` as a dependency, not the mesa stuff. How do we know which implementation (mesa vs nvidia) the user wants? Maybe we should force mesa as the default, and this is what I think e.g. Arch is doing. How to do so? Make glvnd depend on mesa? But what about users that want only nvidia?
POSSIBLE SOLUTION: let the user choose manually a GL implementation (or both for Optimus laptops) by himself, we should put this in the docs for the command line (minimal) install. And remember to explicitly add mesa when we make new graphical ISOs.

Also any other packages that currently conflict/replace `libGL` must be changed to conflict/replace `libglvnd` (e.g. `catalyst nvidia340 sunxi-mali`)