### PR TITLE
Signal-Desktop: update to 1.28.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=1.27.1
+version=1.28.0
 revision=1
 # Due to electron
 # 32-bit is not supported https://github.com/signalapp/Signal-Desktop/issues/1661
@@ -12,7 +12,7 @@ maintainer="Julio Galvan <juliogalvan@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=18c5c9f1a3684b4d0d49a9bb490c7e56417e464b29a06bf4cef36e2e5c523652
+checksum=f4fcce9d3bab0460fc115d0b0cb2a5eb6eafdc75906025ab7e9917ffb7db70a0
 nostrip_files="signal-desktop"
 
 pre_build() {


### PR DESCRIPTION
Finally a usable version. Loading does not take for ever anymore and it looks more polished.