### PR TITLE
i3-gaps: add missing man pages

### DIFF
--- a/srcpkgs/i3-gaps/template
+++ b/srcpkgs/i3-gaps/template
@@ -1,17 +1,17 @@
 # Template file for 'i3-gaps'
 pkgname=i3-gaps
 version=4.17.1
-revision=1
+revision=2
 wrksrc="i3-${version}"
 build_style=gnu-configure
-configure_args="--disable-builddir --disable-sanitizers"
-conf_files="/etc/i3/config /etc/i3/config.keycodes"
-hostmakedepends="pkg-config perl git autoconf automake"
+configure_args="--disable-builddir"
+hostmakedepends="pkg-config perl autoconf automake asciidoc pod2mdoc xmlto"
 makedepends="pcre-devel yajl-devel libxcb-devel libev-devel
  pango-devel startup-notification-devel libxkbcommon-devel
  xcb-util-keysyms-devel xcb-util-wm-devel xcb-util-cursor-devel
  xcb-util-xrm-devel"
 depends="perl-AnyEvent-I3"
+conf_files="/etc/i3/config /etc/i3/config.keycodes"
 short_desc="Improved tiling window manager - i3 fork with more features"
 maintainer="ian c. <ian@airmail.cc>"
 license="BSD-3-Clause"
@@ -43,4 +43,6 @@ pre_build() {
 post_install() {
 	rm -rf ${DESTDIR}/usr/include
 	vlicense LICENSE
+	vmkdir usr/share/man/man1
+	install -m644 man/*.1 ${DESTDIR}/usr/share/man/man1
 }


### PR DESCRIPTION
This adds build dependencies `asciidoc`, `pod2mdoc` and `xmlto`.  They are not needed for regular `i3` because the dist tarball already contains generated roff man pages, where `i3-gaps` is built from repository snapshot.

In the process I also removed `--disable-sanitizers` configure arg which is not neccesary as it is the default, removed unnecessary `git` build dependency and reordered some other variables to match the `i3` template.