### PR TITLE
eclipse-ecj: remove

### DIFF
--- a/srcpkgs/eclipse-ecj/INSTALL.msg
+++ b/srcpkgs/eclipse-ecj/INSTALL.msg
@@ -1,0 +1,1 @@
+eclipse-ecj is no longer provided by Void Linux, and will be fully removed from the repos on 2020-02-17

--- a/srcpkgs/eclipse-ecj/files/ecj1
+++ b/srcpkgs/eclipse-ecj/files/ecj1
@@ -1,4 +1,0 @@
-#!/usr/bin/bash
-gij -cp /usr/share/java/eclipse-ecj.jar 				\
-	org.eclipse.jdt.internal.compiler.batch.GCCMain 		\
-	${1+"$@"}

--- a/srcpkgs/eclipse-ecj/template
+++ b/srcpkgs/eclipse-ecj/template
@@ -1,18 +1,10 @@
-# Template build file for 'eclipse-ecj'.
+# Template file for 'eclipse-ecj'
 pkgname=eclipse-ecj
 version=4.9
-revision=2
+revision=3
 archs=noarch
-build_style=fetch
-depends="virtual?java-runtime"
-short_desc="A fork of the Eclipse Java bytecode compiler for GCJ"
+build_style=meta
+short_desc="Fork of the Eclipse Java bytecode compiler for GCJ (removed package)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="EPL"
 homepage="http://gcc.gnu.org/java/"
-checksum=9506e75b862f782213df61af67338eb7a23c35ff425d328affc65585477d34cd
-distfiles="http://mirrors.kernel.org/sources.redhat.com/java/ecj-${version}.jar"
-
-do_install() {
-	vinstall ecj-${version}.jar 644 usr/share/java ${pkgname}.jar
-	vbin ${FILESDIR}/ecj1
-}

--- a/srcpkgs/eclipse-ecj/update
+++ b/srcpkgs/eclipse-ecj/update
@@ -1,1 +1,0 @@
-pkgname=ecj


### PR DESCRIPTION
This has been unchanged since 2014 and it seems it originally existed to aid bootstrapping together with `gcj`, however it was useless as it run-depends on a java runtime in the first place - the `gcc6-gcj-ecj` package provided by `gcc6` now supplies this exact compiler, compiled with `gcj`, in binary form, used for bootstrap.

So we don't need this anymore, and never actually did.