### PR TITLE
go1.4-bootstrap: remove

### DIFF
--- a/srcpkgs/go1.4-bootstrap/INSTALL.msg
+++ b/srcpkgs/go1.4-bootstrap/INSTALL.msg
@@ -1,0 +1,1 @@
+go1.4-bootstrap is no longer provided by Void Linux, and will be fully removed from the repos on 2020-02-17

--- a/srcpkgs/go1.4-bootstrap/template
+++ b/srcpkgs/go1.4-bootstrap/template
@@ -1,46 +1,10 @@
 # Template file for 'go1.4-bootstrap'
 pkgname=go1.4-bootstrap
 version=20171003
-revision=1
-create_wrksrc=yes
-build_wrksrc="go"
-short_desc="Go 1.4 (bootstrap compiler)"
+revision=2
+archs=noarch
+build_style=meta
+short_desc="Go 1.4 (bootstrap compiler) (removed package)"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="https://golang.org"
-distfiles="https://dl.google.com/go/go1.4-bootstrap-${version}.tar.gz"
-checksum=f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52
-
-archs="x86_64* i686*"
-
-nostrip=yes
-noverifyrdeps=yes
-
-do_build() {
-	unset GCC CC CXX LD CFLAGS CXXFLAGS
-	# FIXME: work around leaking go build-style vars when built as a
-	# dependency
-	unset CGO_CXXFLAGS CGO_CFLAGS CGO_ENABLED
-
-	env > ENV.${XBPS_TARGET_MACHINE}
-	case "${XBPS_TARGET_MACHINE}" in
-		aarch64*) _goarch=arm64 ;;
-		arm*) _goarch=arm ;;
-		i686*) _goarch=386 ;;
-		x86_64*) _goarch=amd64 ;;
-		*) _goarch=${XBPS_TARGET_MACHINE} ;;
-	esac
-
-	export GOROOT="${PWD}"
-	export GOARCH="${_goarch}"
-	cd src
-	GOROOT_FINAL="/usr/lib/go1.4" ./make.bash
-}
-
-do_install() {
-	vmkdir usr/lib/go1.4
-	vcopy bin usr/lib/go1.4
-	vcopy src usr/lib/go1.4
-	vcopy pkg usr/lib/go1.4
-	vlicense LICENSE
-}

--- a/srcpkgs/go1.4-bootstrap/update
+++ b/srcpkgs/go1.4-bootstrap/update
@@ -1,1 +1,0 @@
-site="https://golang.org/doc/install/source"


### PR DESCRIPTION
The 1.4 bootstrap compiled has been made obsolete by https://github.com/void-linux/void-packages/pull/16287, so this is to be merged once that one has been merged.