### PR TITLE
iwd: update to 1.1.

### DIFF
--- a/srcpkgs/iwd/patches/musl-rawmemchr.patch
+++ b/srcpkgs/iwd/patches/musl-rawmemchr.patch
@@ -1,0 +1,14 @@
+--- src/wiphy.c.orig	2019-11-16 09:09:02.009699886 -0500
++++ src/wiphy.c	2019-11-16 09:25:25.188776792 -0500
+@@ -500,7 +500,11 @@
+ 
+ 	if (out_num)
+ 		*out_num =
++#if defined(__GLIBC__) 
+ 			(uint8_t *) rawmemchr(wiphy->supported_rates[band], 0) -
++#else
++			(uint8_t *) memchr(wiphy->supported_rates[band], 0, SIZE_MAX) -
++#endif
+ 			wiphy->supported_rates[band];
+ 
+ 	return wiphy->supported_rates[band];

--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,6 +1,6 @@
 # Template file for 'iwd'
 pkgname=iwd
-version=1.0
+version=1.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
@@ -14,7 +14,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="LGPL-2.1-or-later"
 homepage="https://iwd.wiki.kernel.org/"
 distfiles="${KERNEL_SITE}/network/wireless/iwd-${version}.tar.xz"
-checksum=7296812b3012b0689a8af879c6028fa9efa5b43b27ecf037355b38f7af1aa167
+checksum=7d58e1e0e81865cb85642f2bdc3e6c3b103d0f86c983021d2e9e113ec72b9598
 make_dirs="/var/lib/iwd 0600 root root
  /etc/iwd 755 root root"
 


### PR DESCRIPTION
Add patch for musl (does not have rawmemchr, so replace with memchr).

Tested with WPA2 and open networks.

Tested with eduroam.