### PR TITLE
dhcpcd: update to 8.1.2.

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,8 +1,7 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
-reverts="8.1.1_1"
-version=8.0.6
-revision=2
+version=8.1.2
+revision=1
 build_style=configure
 make_check_target=test
 configure_args="--prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --rundir=/run"
@@ -13,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://roy.marples.name/projects/dhcpcd"
 distfiles="https://roy.marples.name/downloads/dhcpcd/dhcpcd-${version}.tar.xz"
-checksum=66b50199ed83bf502af3fab9ac001b417f0fac7e69c92d97a9c41499cebabd4f
+checksum=cbd3e7ab1584a5a3a49d863376fa138e5fa388397a3e27d2b35bb81a2e8c35ad
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
 


### PR DESCRIPTION
Changelog: https://roy.marples.name/archives/dhcpcd-discuss/0002690.html

Includes fix for problem causing high CPU usage.

Appears to recover from suspend and resume just fine... no high CPU usage.... 

Update: after more usage, it appears to work fine.  I think it is good to go.