### PR TITLE
New package: qolibri-2.1.2

### DIFF
--- a/srcpkgs/qolibri/template
+++ b/srcpkgs/qolibri/template
@@ -1,0 +1,29 @@
+# Template file for 'qolibri'
+pkgname=qolibri
+version=2.1.2
+revision=1
+wrksrc="${pkgname}-${version}"
+build_style=cmake
+hostmakedepends="qt5-tools-devel"
+makedepends="libeb-devel qt5-declarative-devel qt5-devel qt5-location-devel
+ qt5-multimedia-devel qt5-tools-devel qt5-webchannel-devel qt5-webengine-devel
+ zlib-devel"
+short_desc="EPWING Dictionary/Book Viewer"
+maintainer="Matthias von Faber <mvf@gmx.eu>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/ludios/qolibri"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=796e426b9a35251756c53a70a377922d32df1f6e37c53f549066ba607aa65f97
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" qt5-host-tools qt5-qmake"
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	arm*) broken="qt5-webengine-devel unavailable" ;;
+esac
+
+post_install() {
+	vinstall ${wrksrc}/qolibri.desktop 644 usr/share/applications
+	vinstall ${wrksrc}/images/qolibri-128.png 644 usr/share/pixmaps qolibri.png
+}


### PR DESCRIPTION
32-bit ARM broken due to missing `qt5-webengine-devel` package.