### PR TITLE
refind: eliminate ed dependency

### DIFF
--- a/srcpkgs/refind/files/kernel.post-install
+++ b/srcpkgs/refind/files/kernel.post-install
@@ -19,21 +19,31 @@ zrefind_dir="${REFIND_CONF%/*}"
 mkdir -p "$zrefind_dir"
 touch "$REFIND_CONF"
 
+tmpfile=$(mktemp /tmp/refind.XXXXXXX)
+
 zefi_mountpoint=$(df -P "$REFIND_CONF" | awk 'NR==2{print $6}')
 zicon="${zrefind_dir#$zefi_mountpoint}/icons/os_void.png"
 
-mkedscript() {
-	zversion=$(echo $VERSION | sed 's/[.]/[.]/g')
-	zexpr='^menuentry "Void Linux '"$zversion"'" {$'
-	if grep -q "$zexpr" "$REFIND_CONF"; then
-		# Do not merge into /expr/,/}/d, it doesn't work
-		printf '%s\n' "/$zexpr/" '.,/}/d'
-	fi
-
-	cat <<EOF
-1
-/^menuentry /
-i
+zprocess() {
+	has_timeout=no
+	inserted=no
+	skipping=no
+	while IFS= read -r line; do
+		if [ $skipping = yes ]
+		then
+			if [ "x$line" = "x}" ]
+			then
+				skipping=no
+			fi
+			continue
+		elif [ "x${line#timeout[[:space:]]}" != "x${line}" ]
+		then
+			has_timeout=yes
+		elif [ "$inserted" = no ] &&
+			[ "x${line#menuentry }" != "x$line" ]
+		then
+			inserted=yes
+			cat <<EOF
 menuentry "Void Linux $VERSION" {
 	icon     $zicon
 	volume   "Void Linux"
@@ -41,14 +51,23 @@ menuentry "Void Linux $VERSION" {
 	initrd   /initramfs-$VERSION.img
 	options  "$OPTIONS"
 }
-.
 EOF
+		fi
 
-	if ! grep -q '^timeout ' "$REFIND_CONF"; then
-		printf '%s\n' 1i "timeout 20" .
+		if [ "x$line" = 'xmenuentry "Void Linux '"$VERSION"'" {' ]
+		then
+			skipping=yes
+		else
+			printf '%s\n' "$line"
+		fi
+	done
+	if [ $has_timeout = no ]
+	then
+		echo 'timeout 20'
 	fi
-	echo wq
 }
+zprocess <"$REFIND_CONF" >"$tmpfile"
 
-mkedscript | ed "$REFIND_CONF" >/dev/null
+mv "$tmpfile" "$REFIND_CONF"
+
 exit 0

--- a/srcpkgs/refind/files/kernel.post-remove
+++ b/srcpkgs/refind/files/kernel.post-remove
@@ -21,8 +21,4 @@ tmpfile=$(mktemp /tmp/refind.XXXXXXX)
 zversion=$(echo $VERSION | sed 's/[.]/[.]/g')
 sed "/^menuentry \"Void Linux $zversion\" [{]\$/,/[}]/d" "$REFIND_CONF" >"$tmpfile"
 
-if ! cmp -s "$REFIND_CONF" "$tmpfile"; then
-	mv "$tmpfile" "$REFIND_CONF"
-else
-	rm -f "$tmpfile"
-fi
+mv "$tmpfile" "$REFIND_CONF"

--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.11.4
-revision=2
+revision=3
 makedepends="gnu-efi-libs git"
 depends="bash dosfstools efibootmgr"
 short_desc="EFI boot manager utility"


### PR DESCRIPTION
post-install now depends on
- coreutils (df, mkdir, mktemp, mv, touch)
- awk

post-remove depends on:
- sed

---

Apparently #16251  is half-baked, this is a fix-up for that topic