### PR TITLE
yabasic: update to 2.85.0.

### DIFF
--- a/srcpkgs/yabasic/template
+++ b/srcpkgs/yabasic/template
@@ -1,19 +1,20 @@
 # Template file for 'yabasic'
 pkgname=yabasic
 reverts="2.769_1"
-version=2.84.3
+version=2.85.0
 revision=1
 build_style=gnu-configure
 makedepends="libXt-devel ncurses-devel libffi-devel"
 short_desc="Yet another Basic"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-3.0-or-later"
+license="MIT, GPL-3.0-or-later"
 homepage="https://2484.de/yabasic/"
 distfiles="https://2484.de/yabasic/download/yabasic-${version}.tar.gz"
-checksum=a78bfa48f9f7d3469ebbccdb4128f1618355b1dbf9d60eca679eb461da6bbbcd
+checksum=0598f25b4fa8320a1367d3ef46c95345df710434d10a6f647c5b4ad244be0ded
 
 do_install() {
 	vbin yabasic
 	vman yabasic.1
 	vdoc yabasic.htm
+	vlicense LICENSE
 }


### PR DESCRIPTION
Update, add MIT as a license (only config.sub and config.guess in the build system are GPL).