### PR TITLE
mdBook: update to 0.3.5.

### DIFF
--- a/srcpkgs/mdBook/template
+++ b/srcpkgs/mdBook/template
@@ -1,15 +1,15 @@
 # Template file for 'mdBook'
 pkgname=mdBook
-version=0.3.2
+version=0.3.5
 revision=1
 build_style=cargo
 short_desc="Create book from markdown files. Like Gitbook but implemented in Rust"
 maintainer="Huidong Hwang <hwangh95@gmail.com>"
 license="MPL-2.0"
-homepage="https://github.com/rust-lang-nursery/${pkgname}"
-changelog="https://raw.githubusercontent.com/rust-lang-nursery/mdBook/master/CHANGELOG.md"
-distfiles="https://github.com/rust-lang-nursery/${pkgname}/archive/v${version}.tar.gz"
-checksum=93caeeda86a4abf3b2da805ba1fc609a9f2803f9a37875ff30a87f1ead7c7c22
+homepage="https://github.com/rust-lang/mdBook"
+changelog="https://raw.githubusercontent.com/rust-lang/mdBook/master/CHANGELOG.md"
+distfiles="https://github.com/rust-lang/mdBook/archive/v${version}.tar.gz"
+checksum=73258ba3713004e06675ef2a1fbd3e7b48eb144db37c5ac1e2b96086b51a6e87
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
* Repo now lives under rust-lang.
* Tested by building void-docs.