### PR TITLE
krita: fix checksum + build on non-x86

### DIFF
--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -9,7 +9,7 @@ makedepends="karchive-devel kconfig-devel kwidgetsaddons-devel kcompletion-devel
  kcoreaddons-devel kguiaddons-devel ki18n-devel kitemmodels-devel kitemviews-devel
  kwindowsystem-devel kio-devel kcrash-devel qt5-svg-devel qt5-multimedia-devel
  boost-devel gsl-devel tiff-devel libjpeg-turbo-devel libraw-devel fftw-devel
- opencolorio-devel eigen vc exiv2-devel libXi-devel libopenexr-devel libgomp-devel
+ opencolorio-devel eigen exiv2-devel libXi-devel libopenexr-devel libgomp-devel
  poppler-qt5-devel giflib-devel python3-devel python3-sip-devel python3-PyQt5
  python-PyQt5-devel quazip-devel libheif-devel"
 short_desc="Painting and image editing program"
@@ -18,6 +18,12 @@ license="GPL-3.0-only"
 homepage="https://krita.org/"
 KDE_SITE="http://ftp5.gwdg.de/pub/linux/kde/stable/"
 distfiles="${KDE_SITE}/krita/${version}/krita-${version}.tar.gz"
-checksum=28218030edca9dfa1c7e255401ca6fc8fe0e5329f7611cfc196e35746d312086
+checksum=3ed29fd9d8e067def55e703fc55312815c21041d274727e228bdbe0478c09c3d
 nocross=yes
 replaces="calligra-krita>=0"
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*) makedepends+=" vc";;
+	ppc64*) ;;
+	armv6*|ppc*) makedepends+=" libatomic-devel";;
+esac


### PR DESCRIPTION
Having vc installed will make krita think there's arch-specific
optimizations for the given architecture, while they only have
them for x86. Do what e.g. Debian does and install it only when
on x86.