### PR TITLE
 rpi-kernel: update to 4.19.84.

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,9 +1,9 @@
 # Template file for 'rpi-firmware'
-_githash="b79618b5db4e4e7c02f9ad9d3ada51713825313e"
+_githash="68ec48189c5256b365c9232909180cb56c8820bc"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20191101
+version=20191118
 revision=1
 archs=noarch
 wrksrc="firmware-${_githash}"
@@ -12,7 +12,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=d7443e60d678fe8032683e91a348bdfbb7b8b8e251d73bbdf9fa86e7171dff1e
+checksum=ba24f9e64a9e85e54034454d01b9853fe8d4a91c4993fa1203d6bff99e227355
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="3c235dcfe80a7c7ba360219e4a3ecb256f294376"
+_githash="886bda7dfd4279fa9eef4345434ca83a347908bc"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.83
+version=4.19.84
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=23a222d8864107b296b3bf580106421899964af879bb7f1c440e875e565fd6f3
+checksum=56cbc2901edef5e0b158daee5f13335de300f88c917f3e8a4dc1ef294ce256bf
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
- Built for armv6l, armv7l, aarch64.

- Tested on armv6l, armv7l.

- Also update rpi-firmware.