### PR TITLE
python-Cheroot: add dependency on jaraco.functools

### DIFF
--- a/srcpkgs/python-Cheroot/template
+++ b/srcpkgs/python-Cheroot/template
@@ -1,14 +1,14 @@
 # Template file for 'python-Cheroot'
 pkgname=python-Cheroot
 version=8.2.1
-revision=1
+revision=2
 archs=noarch
 wrksrc="cheroot-${version}"
 build_style=python-module
 pycompile_module="cheroot"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python-setuptools python-six python-more-itertools
- python-backports.functools_lru_cache"
+ python-backports.functools_lru_cache python-jaraco.functools"
 short_desc="High-performance, pure-Python HTTP server (Python2)"
 maintainer="bra1nwave <brainwave@openmailbox.org>"
 license="BSD-3-Clause"
@@ -33,7 +33,8 @@ post_install() {
 python3-Cheroot_package() {
 	archs=noarch
 	pycompile_module="cheroot"
-	depends="python3-setuptools python3-six python3-more-itertools"
+	depends="python3-setuptools python3-six python3-more-itertools
+	 python3-jaraco.functools"
 	alternatives="cheroot:cheroot:/usr/bin/cheroot3"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {

--- a/srcpkgs/python-jaraco.functools/template
+++ b/srcpkgs/python-jaraco.functools/template
@@ -1,0 +1,32 @@
+# Template file for 'python-jaraco.functools'
+pkgname=python-jaraco.functools
+version=2.0
+revision=1
+archs=noarch
+wrksrc="jaraco.functools-${version}"
+build_style=python-module
+pycompile_module="jaraco.functools"
+hostmakedepends="python-setuptools python3-setuptools"
+depends="python-more-itertools python-backports.functools_lru_cache"
+short_desc="Additional functools in the spirit of Python2 stdlib's functools"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="MIT"
+homepage="https://github.com/jaraco/jaraco.functools"
+changelog="https://raw.githubusercontent.com/jaraco/jaraco.functools/${version}/CHANGES.rst"
+distfiles="${PYPI_SITE}/j/jaraco.functools/jaraco.functools-${version}.tar.gz"
+checksum=35ba944f52b1a7beee8843a5aa6752d1d5b79893eeb7770ea98be6b637bf9345
+
+post_install() {
+	vlicense LICENSE
+}
+
+python3-jaraco.functools_package() {
+	archs=noarch
+	pycompile_module="jaraco.functools"
+	depends="python3-more-itertools"
+	short_desc="${short_desc/Python2/Python3}"
+	pkg_install() {
+		vmove "usr/lib/python3*"
+		vlicense LICENSE
+	}
+}

--- a/srcpkgs/python3-jaraco.functools
+++ b/srcpkgs/python3-jaraco.functools
@@ -1,0 +1,1 @@
+python-jaraco.functools


### PR DESCRIPTION
It seems to be required since 7.0.0 and went by unnoticed.