### PR TITLE
libxml2: update to 2.9.10 / python: restore previous sysconfig CFLAGS handling

### DIFF
--- a/srcpkgs/libxml2-python/template
+++ b/srcpkgs/libxml2-python/template
@@ -1,7 +1,7 @@
 # Template file for 'libxml2-python'
 pkgname=libxml2-python
-version=2.9.9
-revision=3
+version=2.9.10
+revision=1
 wrksrc="${pkgname%-python}-${version}"
 build_wrksrc=python
 build_style=python-module
@@ -13,7 +13,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="http://www.xmlsoft.org/"
 distfiles="http://xmlsoft.org/sources/libxml2-${version}.tar.gz"
-checksum=94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871
+checksum=aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
 
 pre_build() {
 	sed "s:/usr/include:${XBPS_CROSS_BASE}/usr/include:" -i setup.py

--- a/srcpkgs/libxml2/template
+++ b/srcpkgs/libxml2/template
@@ -3,8 +3,8 @@
 # Please keep this in sync with "srcpkgs/libxml2-python"
 #
 pkgname=libxml2
-version=2.9.9
-revision=3
+version=2.9.10
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-threads --with-history --with-icu
  --without-python"
@@ -15,7 +15,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="http://www.xmlsoft.org/"
 distfiles="http://xmlsoft.org/sources/${pkgname}-${version}.tar.gz"
-checksum=94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871
+checksum=aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/libxslt/template
+++ b/srcpkgs/libxslt/template
@@ -1,7 +1,7 @@
 # Template file for 'libxslt'
 pkgname=libxslt
 version=1.1.34
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-dependency-tracking"
 hostmakedepends="libtool"

--- a/srcpkgs/python/patches/sysconfig.patch
+++ b/srcpkgs/python/patches/sysconfig.patch
@@ -1,0 +1,22 @@
+--- Lib/distutils/sysconfig.py	2019-10-19 20:38:44.000000000 +0200
++++ Lib/distutils/sysconfig.py	2019-03-02 19:17:42.000000000 +0100
+@@ -181,8 +171,8 @@
+                 _osx_support.customize_compiler(_config_vars)
+                 _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
+ 
+-        (cc, cxx, cflags, ccshared, ldshared, so_ext, ar, ar_flags) = \
+-            get_config_vars('CC', 'CXX', 'CFLAGS',
++        (cc, cxx, opt, cflags, ccshared, ldshared, so_ext, ar, ar_flags) = \
++            get_config_vars('CC', 'CXX', 'OPT', 'CFLAGS',
+                             'CCSHARED', 'LDSHARED', 'SO', 'AR',
+                             'ARFLAGS')
+ 
+@@ -206,7 +196,7 @@
+         if 'LDFLAGS' in os.environ:
+             ldshared = ldshared + ' ' + os.environ['LDFLAGS']
+         if 'CFLAGS' in os.environ:
+-            cflags = cflags + ' ' + os.environ['CFLAGS']
++            cflags = opt + ' ' + os.environ['CFLAGS']
+             ldshared = ldshared + ' ' + os.environ['CFLAGS']
+         if 'CPPFLAGS' in os.environ:
+             cpp = cpp + ' ' + os.environ['CPPFLAGS']

--- a/srcpkgs/python/template
+++ b/srcpkgs/python/template
@@ -4,7 +4,7 @@
 #
 pkgname=python
 version=2.7.17
-revision=1
+revision=2
 wrksrc="Python-${version}"
 pycompile_dirs="usr/lib/python2.7"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
The update to python 2.7.17 introduced a change which breaks cross-building all arch-dependent python packages. Previously, `CFLAGS` determined via `get_config_vars()` had been overwritten by environment `CFLAGS`, but now they’re appended. This leads to using host `CFLAGS` when cross-compiling and the build fails. The patch just restores the 2.7.16 behaviour.

With that, libxml2-python can be cross built again and libxml2 be updated.

Also rebuild libxslt, because `xslt-config` is broken. It uses `xml2-config`’s new option `--dynamic`, introduced in 2.9.10 and contains `xml2-config`’s usage message instead of the right flags.