### PR TITLE
dnscrypt-proxy: update to 2.0.33.

### DIFF
--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,17 +1,17 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
-version=2.0.31
+version=2.0.33
 revision=1
 build_style=go
-go_import_path=github.com/jedisct1/dnscrypt-proxy
+go_import_path=github.com/DNSCrypt/dnscrypt-proxy/dnscrypt-proxy
 go_package="${go_import_path}/dnscrypt-proxy"
 short_desc="DNS proxy that encrypts queries"
 maintainer="Lugubris <lugubris@disroot.org>"
 license="ISC"
-homepage="https://github.com/jedisct1/dnscrypt-proxy"
-changelog="https://raw.githubusercontent.com/jedisct1/dnscrypt-proxy/master/ChangeLog"
-distfiles="https://github.com/jedisct1/dnscrypt-proxy/archive/${version}.tar.gz"
-checksum=b5d17ae56856e5797b59d862bccb038ff891ac0bf159534e9a937b0f0cc35777
+homepage="https://github.com/DNSCrypt/dnscrypt-proxy"
+changelog="https://raw.githubusercontent.com/DNSCrypt/dnscrypt-proxy/master/ChangeLog"
+distfiles="https://github.com/DNSCrypt/dnscrypt-proxy/archive/${version}.tar.gz"
+checksum=9e62dd3dff59c283a0b8214d99925c1ca8855876992be1755b3eb6b3489194fd
 conf_files="/etc/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 make_dirs="/var/log/dnscrypt-proxy 0750 dnscrypt_proxy dnscrypt_proxy"


### PR DESCRIPTION
Now under its own github organization -> DNSCrypt.