### PR TITLE
New package: kubernetes-helm-0.6.0

### DIFF
--- a/srcpkgs/kubernetes-kind/template
+++ b/srcpkgs/kubernetes-kind/template
@@ -1,0 +1,13 @@
+# Template file for 'kubernetes-kind'
+pkgname=kubernetes-kind
+version=0.6.0
+revision=1
+wrksrc="kind-${version}"
+build_style=go
+go_import_path="sigs.k8s.io/kind"
+short_desc="Kind is a tool for running local Kubernetes clusters using Docker"
+maintainer="Andy Cobaugh <andrew.cobaugh@gmail.com>"
+license="Apache-2.0"
+homepage="https://kind.sigs.k8s.io/"
+distfiles="https://github.com/kubernetes-sigs/kind/archive/v${version}.tar.gz"
+checksum=966b5c9817850f958acf14496349276a8df6d6609adfdc41633a8b7bc73d5e5d


### PR DESCRIPTION
Followed the naming convention for the helm package, because `kind` by itself is kind of ambiguous.