### PR TITLE
bird: Add makedepend for libssh-devel

### DIFF
--- a/srcpkgs/bird/template
+++ b/srcpkgs/bird/template
@@ -1,19 +1,27 @@
 # Template file for 'bird'
 pkgname=bird
 version=2.0.7
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="flex autoconf"
-makedepends="ncurses-devel readline-devel"
+makedepends="ncurses-devel readline-devel libssh-devel"
 short_desc="BIRD Internet Routing Daemon"
 maintainer="Philipp Hirsch <itself@hanspolo.net>"
 license="GPL-2.0-or-later"
 homepage="https://bird.network.cz"
-distfiles="ftp://bird.network.cz/pub/bird/bird-${version}.tar.gz"
-checksum=631d2b58aebdbd651aaa3c68c3756c02ebfe5b1e60d307771ea909eeaa5b1066
+distfiles="https://gitlab.labs.nic.cz/labs/bird/-/archive/v${version}/bird-v${version}.tar.gz"
+checksum=d0c6aeaaef3217d6210261a49751fc662838b55fec92f576e20938917dbf89ab
 
 conf_files="/etc/bird.conf"
 system_accounts="_bird"
+
+post_extract() {
+	mv -v ${wrksrc/-/-v} $wrksrc
+}
+
+pre_configure() {
+	autoreconf
+}
 
 post_install() {
 	vsv bird


### PR DESCRIPTION
bird won't include support for the rpki router to router protocol
without libssh-devel