### PR TITLE
phpMyAdmin: update to 4.9.2

### DIFF
--- a/srcpkgs/phpMyAdmin/template
+++ b/srcpkgs/phpMyAdmin/template
@@ -1,6 +1,6 @@
 # Template file for 'phpMyAdmin'
 pkgname=phpMyAdmin
-version=4.9.0.1
+version=4.9.2
 revision=1
 archs=noarch
 wrksrc="phpMyAdmin-${version}-all-languages"
@@ -11,7 +11,7 @@ maintainer="Franc[e]sco <lolisamurai@tfwno.gf>"
 license="GPL-2.0-or-later"
 homepage="https://www.phpmyadmin.net"
 distfiles="https://files.phpmyadmin.net/phpMyAdmin/${version}/phpMyAdmin-${version}-all-languages.tar.xz"
-checksum=e3de59f913c095433c8f6466f8826dfde09b097cfac78b665ddef9ddc03b0ed6
+checksum=3bc3e37fefbdfcaf12fd59d6d7fdbf11ffcffe3e211155bf5b822b54a3c2043e
 
 do_install() {
 	vmkdir usr/share/webapps/


### PR DESCRIPTION
Update to 4.9.2, which includes fix for CVE-2019-18622

Signed-off-by: Nathan Owens <ndowens04@gmail.com>