### PR TITLE
reproducible: use SOURCE_DATE_EPOCH from template if set

### DIFF
--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -3,8 +3,10 @@
 if [ -n "$XBPS_USE_BUILD_MTIME" ]; then
 	unset SOURCE_DATE_EPOCH
 	return 0
-fi
-if [ -z "${SOURCE_DATE_EPOCH}" -a -n "$IN_CHROOT" ]; then
+elif [ -n "$SOURCE_DATE_EPOCH" ]; then
+	export SOURCE_DATE_EPOCH
+	return 0
+elif [ -z "${SOURCE_DATE_EPOCH}" -a -n "$IN_CHROOT" ]; then
 	if command -v chroot-git &>/dev/null; then
 		GIT_CMD=$(command -v chroot-git)
 	elif command -v git &>/dev/null; then


### PR DESCRIPTION
From commit a4a229cf64, (xbps-src: use HEAD commit time for
SOURCE_DATE_EPOCH, 2018-03-08), we're using commit time of HEAD
as SOURCE_DATE_EPOCH

Our distribution isn't reproducible anymore.
Because people will have a copy of our repository at some random time,
and they will build some random packages, those packages will be built
with the timestamp of the HEAD commit. But, our build bot will build
with the timestamp of another HEAD.

Let's take another route, ask people to put SOURCE_DATE_EPOCH directly
in the template, and uses that SOURCE_DATE_EPOCH instead.

This should work better even if minor details (maintainer,
hostmakedepends, etc...) changed.

Attach Unix timestamp instead of other time format (let's say ISO-8601),
because POSIX date doesn't provide portable option to convert them to
Unix timestamp.

xtools should be updated to support this, too.