### PR TITLE
ibus-bamboo: update to 0.6.2

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.6.0
+version=0.6.2
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="e50d22fec9a64694ba1db9bd0086c95021cf9e3af01f8ec73f26c3a7b14333a5"
+checksum="15fbee26a71d6c1dc0661cc29e00c12a116d93211e8097af914ab3e72549a774"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
0.6.2
- Fix some typing issues
- Reset buffer after pressing a key combination

0.6.1-1
- Hot fix issue with tab key on Google Sheets

0.6.1
- Clear buffer with focus changes
- Add wordaround for Google Spreadsheets, Goldendict, ..
- Use Tab key to expand macro