### PR TITLE
kmonad: Add permissions to uinput kernel module

### DIFF
--- a/srcpkgs/kmonad/files/60-kmonad.rules
+++ b/srcpkgs/kmonad/files/60-kmonad.rules
@@ -1,0 +1,1 @@
+KERNEL=="uinput", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"

--- a/srcpkgs/kmonad/template
+++ b/srcpkgs/kmonad/template
@@ -1,7 +1,7 @@
 # Template file for 'kmonad'
 pkgname=kmonad
 version=0.3.0
-revision=1
+revision=2
 build_style=haskell-stack
 stackage=lts-14.07
 short_desc="Keyboard remapping utility providing qmk-like functionality"
@@ -13,6 +13,7 @@ checksum="3f61c546d456354a15326558eb8025024ab3d51ef2f6ec761da5568e4473f7ec"
 nopie_files="/usr/bin/kmonad"
 nocross=yes
 
-post_install() {
-	    vlicense LICENSE
+do_install() {
+	vlicense LICENSE
+	vinstall ${FILESDIR}/60-kmonad.rules 644 usr/lib/udev/rules.d
 }


### PR DESCRIPTION
Adds permissions to the `input` group (as one would expect).  This is needed as `kmonad` reads keyboard input via `uinput`.