### PR TITLE
bc-gh: update to 2.3.1

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,6 +1,6 @@
 # Template file for 'bc-gh'
 pkgname=bc-gh
-version=2.3.0
+version=2.3.1
 revision=1
 wrksrc="bc-${version}"
 short_desc="Implementation of POSIX bc with GNU extensions"
@@ -8,7 +8,7 @@ maintainer="Gavin D. Howard <yzena.tech@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/gavinhoward/bc"
 distfiles="${homepage}/releases/download/${version}/bc-${version}.tar.xz"
-checksum=5a4d14721688ce0a2679fb02680fe8dc41574417f60647be3a125d53d5672f5d
+checksum=ecd66a326f348ce4e109df4ed06d9fe03a6fa5f22a6fe14aa577a393d2b08a32
 alternatives="
  bc:bc:/usr/bin/bc-gh
  dc:dc:/usr/bin/dc-gh"


### PR DESCRIPTION
This fixes a bug in comparison of negative numbers.