### PR TITLE
solaar: install udev rules

### DIFF
--- a/srcpkgs/Solaar/template
+++ b/srcpkgs/Solaar/template
@@ -1,7 +1,7 @@
 # Template file for 'Solaar'
 pkgname=Solaar
 version=1.0.1
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 pycompile_module="hidapi logitech_receiver solaar"
@@ -13,3 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://pwr-solaar.github.io/Solaar/"
 distfiles="https://github.com/pwr-Solaar/Solaar/archive/${version}.tar.gz"
 checksum=20f7c29610cc1d0a964052b6698c3e01f1703d08d621cbe7f9e45a9892632f13
+
+post_install() {
+	vinstall rules.d/42-logitech-unify-permissions.rules 644 usr/lib/udev/rules.d/
+}


### PR DESCRIPTION
Solaar requires installing udev rules so the application can access Logitech Unifying Receiver without requiring root. This PR installs the missing udev rules into `/usr/lib/udev/rules.d/`.