### PR TITLE
New package: pass-import-2.6

### DIFF
--- a/srcpkgs/pass-import/template
+++ b/srcpkgs/pass-import/template
@@ -1,0 +1,15 @@
+# Template file for 'pass-import'
+pkgname=pass-import
+version=2.6
+revision=1
+archs=noarch
+build_style=gnu-makefile
+make_install_args=BASHCOMPDIR=/usr/share/bash-completion/completions
+hostmakedepends="python3-setuptools python3-yaml"
+depends="pass>=1.7.0 python3-defusedxml"
+short_desc="Pass extension for importing data from most existing password managers"
+maintainer="Alan Brown <adbrown@rocketmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/roddhjav/pass-import"
+distfiles="https://github.com/roddhjav/pass-import/releases/download/v${version}/pass-import-${version}.tar.gz"
+checksum=19bddbbe3e43c15bedcc1df6eadf664e30bc04b2992809eb4d04f25a3d370ea8


### PR DESCRIPTION
I have found the pass-import extension useful for transferring my passwords from Gorilla and pwsafe