### PR TITLE
ytcc: update to 1.8.2

### DIFF
--- a/srcpkgs/ytcc/template
+++ b/srcpkgs/ytcc/template
@@ -1,18 +1,19 @@
 # Template file for 'ytcc'
 pkgname=ytcc
-version=1.8.1
+version=1.8.2
 revision=1
 archs=noarch
 build_style=python3-module
 pycompile_module="ytcc"
 hostmakedepends="python3-setuptools"
-depends="python3-SQLAlchemy python3-feedparser python3-lxml python3-youtube-dl"
+depends="python3-SQLAlchemy python3-feedparser python3-lxml python3-youtube-dl
+ mpv"
 short_desc="Cmdline tool to track your youtube channels"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/woefe/ytcc"
 distfiles="https://github.com/woefe/ytcc/archive/v${version}.tar.gz"
-checksum=e3c27a915182c5ee9314cb22ed19bd26847b4521c369d85a790408e0cdbd691e
+checksum=360db561bb0278b7f326fe3da9b012e738e1eceec9031c66b3749207f8091283
 
 post_install() {
 	vinstall completions/fish/ytcc.fish 0644 usr/share/fish/completions


### PR DESCRIPTION
Added mpv to depends as it is needed to play videos
when selecting video in ytcc

Signed-off-by: Nathan Owens <ndowens04@gmail.com>