### PR TITLE
python3-scikit-learn: update to 0.22

### DIFF
--- a/srcpkgs/python3-scikit-learn/template
+++ b/srcpkgs/python3-scikit-learn/template
@@ -1,19 +1,19 @@
 # Template file for 'python3-scikit-learn'
 pkgname=python3-scikit-learn
-version=0.20.4
+version=0.22
 revision=1
 wrksrc="scikit-learn-${version}"
 build_style=python3-module
 pycompile_module="sklearn"
 hostmakedepends="python3-setuptools python3-Cython"
-makedepends="python3-devel python3-numpy python3-scipy"
-depends="python3-numpy python3-scipy"
+makedepends="python3-devel python3-numpy python3-scipy python3-joblib"
+depends="python3-numpy python3-scipy python3-joblib"
 short_desc="Python3 modules for machine learning and data mining"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://scikit-learn.org/"
 distfiles="https://github.com/scikit-learn/scikit-learn/archive/${version}.tar.gz"
-checksum=1ec7a8dbf45fec730afaf6c783a797f9863fefc1225735ac4ce4706cc5857415
+checksum=6a495dbd5aac1f89d1ed51140fc41adb1f892293492b51b667eb5c40df1bde48
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
scikit-learn now requires joblib >= 0.11, I'll be making a pull request to add that package to the repository shortly.