### PR TITLE
PopCorn: add logging

### DIFF
--- a/srcpkgs/PopCorn/files/popcorn/log/run
+++ b/srcpkgs/PopCorn/files/popcorn/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -t popcorn

--- a/srcpkgs/PopCorn/files/popcorn/run
+++ b/srcpkgs/PopCorn/files/popcorn/run
@@ -5,5 +5,6 @@
 : ${SERVER:=popcorn.voidlinux.org}
 : ${PORT:=8001}
 
+exec 2>&1
 chpst -u _popcorn:_popcorn popcorn --server $SERVER --port $PORT
 exec chpst -u _popcorn:_popcorn snooze popcorn --server $SERVER --port $PORT

--- a/srcpkgs/PopCorn/template
+++ b/srcpkgs/PopCorn/template
@@ -1,7 +1,7 @@
 # Template file for 'PopCorn'
 pkgname=PopCorn
 version=0.4
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/the-maldridge/popcorn
 go_package="${go_import_path}/cmd/popcorn


### PR DESCRIPTION
This prevents PopCorn from printing warnings to tty1 because of a (not
yet) available network connection.
