### PR TITLE
chromium: update to 78.0.3904.108.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=78.0.3904.97
+version=78.0.3904.108
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=77c7627818630d73bedcfc0b38dde145d2554bea2d49616fe9b3cf8eb5f290db
+checksum=06ce37a4ae8bb93c35bf874681e12766f10bdedff96717f6a03fc84d60cbdace
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=78.0.3904.97
+version=78.0.3904.108
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=d1f49ab9f4f973536166f587114553c21a29977bdc350dd407a89d34e22a9d07
+checksum=f9c53839f306d2973de27723360024f7904101d426b9e7e9cdb56e8bcc775b0e
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
- Built for i686, x86_64, x86_64-musl.
- Tested on x86_64.
- Also update chromium-widevine.

