### PR TITLE
i3blocks: INSTALL.msg reflecting outsourcing of scripts

### DIFF
--- a/srcpkgs/i3blocks/INSTALL.msg
+++ b/srcpkgs/i3blocks/INSTALL.msg
@@ -1,5 +1,7 @@
-Some of the included scripts may use external tools which must be installed:
+Install package 'i3blocks-blocklets' for scripts.
+
+Some of these scripts may use external tools which must be installed, eg:
 	acpi: used by the battery script
 	lm_sensors: used by the temperature script
 	playerctl: used by the mediaplayer script
-	sysstat: used by the cpu_usage script
+	perl: used by the cpu_usage script

--- a/srcpkgs/i3blocks/template
+++ b/srcpkgs/i3blocks/template
@@ -1,7 +1,7 @@
 # Template file for 'i3blocks'
 pkgname=i3blocks
 version=1.5
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_args="SYSCONFDIR=/etc"
 hostmakedepends="autoconf automake pkg-config"


### PR DESCRIPTION
https://github.com/void-linux/void-packages/pull/16787 is needed for this package, because upstream outsourced former containing scripts.