### PR TITLE
cross-x86_64-w64-mingw32: update to 7.0.0

### DIFF
--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,18 +1,18 @@
 # Template file for 'cross-x86_64-w64-mingw32'
-_gcc_version=9.3.0
-_binutils_version=2.32
+_gcc_version=9.2.0
+_binutils_version=2.33.1
 _gmp_version=6.1.2
 _mpfr_version=4.0.1
 _mpc_version=1.1.0
-_isl_version=0.19
-_mingw_version=6.0.0
+_isl_version=0.21
+_mingw_version=7.0.0
 
 pkgname=cross-x86_64-w64-mingw32
 version=$_mingw_version
-revision=5
+revision=1
 archs="x86_64* i686*"
 create_wrksrc=yes
-hostmakedepends="flex perl python3 tar"
+hostmakedepends="flex perl"
 makedepends="zlib-devel"
 # it's ok to build with current's -devel packages
 # although it might break the package during compiler updates
@@ -23,20 +23,20 @@ maintainer="Aleksey Tulinov <aleksey.tulinov@gmail.com>"
 homepage="https://sourceforge.net/projects/mingw-w64/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, ZPL-2.1"
 distfiles="
- ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.bz2
+ ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
  ${GNU_SITE}/mpc/mpc-${_mpc_version}.tar.gz
- https://gmplib.org/download/gmp/gmp-${_gmp_version}.tar.xz
- http://www.mpfr.org/mpfr-${_mpfr_version}/mpfr-${_mpfr_version}.tar.xz
+ ${GNU_SITE}/gmp/gmp-${_gmp_version}.tar.xz
+ ${GNU_SITE}/mpfr/mpfr-${_mpfr_version}.tar.xz
  http://isl.gforge.inria.fr/isl-${_isl_version}.tar.bz2
  ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
-checksum="de38b15c902eb2725eac6af21183a5f34ea4634cb0bcef19612b50e5ed31072d
- 71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
+checksum="ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf
+ ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
  6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
  87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912
  67874a60826303ee2fb6affc6dc0ddd3e749e9bfcb4c8655e3953d0458a6e16e
- d59726f34f7852a081fbd3defd1ab2136f174110fc2e0c8d10bb122173fa9ed8
- 805e11101e26d7897fce7d49cbb140d7bac15f3e085a91e0001e80b2adaf48f0"
+ d18ca11f8ad1a39ab6d03d3dcb3365ab416720fcb65b42d69f34f51bf0a0e859
+ aa20dfff3596f08a7f427aab74315a6cb80c2b086b4a107ed35af02f9496b628"
 
 nopie=yes
 nodebug=yes
@@ -269,7 +269,7 @@ cross-x86_64-w64-mingw32-crt_package() {
 	# this subpackage exists to skip strip step on CRT files
 	nostrip=yes
 	noverifyrdeps=yes
-	noshlibsprovides=yes
+	noshlibprovides=yes
 	lib32disabled=yes
 	pkg_install() {
 		DESTDIR="$PKGDESTDIR" _install_crt "x86_64-w64-mingw32"
@@ -282,7 +282,7 @@ cross-i686-w64-mingw32_package() {
 	nopie=yes
 	nodebug=yes
 	noverifyrdeps=yes
-	noshlibsprovides=yes
+	noshlibprovides=yes
 	lib32disabled=yes
 	nostrip_files="libgcc.a libgcc_eh.a libgcc_s.a libgcov.a
 	 libatomic.a libatomic.dll.a libquadmath.a libquadmath.dll.a
@@ -299,7 +299,7 @@ cross-i686-w64-mingw32-crt_package() {
 	nodebug=yes
 	nostrip=yes
 	noverifyrdeps=yes
-	noshlibsprovides=yes
+	noshlibprovides=yes
 	lib32disabled=yes
 	pkg_install() {
 		DESTDIR="$PKGDESTDIR" _install_crt "i686-w64-mingw32"

--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,8 +1,8 @@
 # Template file for 'cross-x86_64-w64-mingw32'
-_gcc_version=9.2.0
+_gcc_version=9.3.0
 _binutils_version=2.33.1
 _gmp_version=6.1.2
-_mpfr_version=4.0.1
+_mpfr_version=4.0.2
 _mpc_version=1.1.0
 _isl_version=0.21
 _mingw_version=7.0.0
@@ -12,7 +12,7 @@ version=$_mingw_version
 revision=1
 archs="x86_64* i686*"
 create_wrksrc=yes
-hostmakedepends="flex perl"
+hostmakedepends="tar flex perl"
 makedepends="zlib-devel"
 # it's ok to build with current's -devel packages
 # although it might break the package during compiler updates
@@ -31,10 +31,10 @@ distfiles="
  http://isl.gforge.inria.fr/isl-${_isl_version}.tar.bz2
  ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
 checksum="ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf
- ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
+ 71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
  87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912
- 67874a60826303ee2fb6affc6dc0ddd3e749e9bfcb4c8655e3953d0458a6e16e
+ 1d3be708604eae0e42d578ba93b390c2a145f17743a744d8f3f8c2ad5855a38a
  d18ca11f8ad1a39ab6d03d3dcb3365ab416720fcb65b42d69f34f51bf0a0e859
  aa20dfff3596f08a7f427aab74315a6cb80c2b086b4a107ed35af02f9496b628"
 


### PR DESCRIPTION
Changes:

* Mingw-w64 7.0.0
* Fixed typo: `noshlibsprovides` -> `noshlibprovides`
* Links to GMP and MPFR now point to `${GNU_SITE}`. They seem to provide components on their site, except for ISL, checksums match, so for uniformity i changed links to `${GNU_SITE}`
* ISL version harmonized with `srcpkg/gcc/template` (0.21)
* binutils version harmonized with `srcpkg/binutils/template` (2.33.1)
* Removed host make dependency on `python3` (i don't know why it was there)