### PR TITLE
julia: update to 1.3.0

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,31 +1,35 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.2.0
+version=1.3.0
 revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
-make_build_args="prefix=/usr sysconfdir=/etc USE_SYSTEM_LLVM=0 USE_LLVM_SHLIB=1
- USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=1 USE_SYSTEM_LAPACK=1 USE_SYSTEM_GMP=1
- USE_SYSTEM_MPFR=1 USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBGIT2=1 USE_BINARYBUILDER=0
+make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
+ USE_LLVM_SHLIB=1 USE_BINARYBUILDER=0
+ USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBUNWIND=0 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_LIBM=0
+ USE_SYSTEM_DSFMT=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=1
+ USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
+ USE_SYSTEM_CURL=1 USE_SYSTEM_MPFR=1 USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_UTF8PROC=0
+ USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LAPACK=1
  LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas
  LIBBLAS=-lopenblas LIBBLASNAME=libopenblas"
 make_install_args="$make_build_args"
 make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
-hostmakedepends="perl cmake python"
+hostmakedepends="perl cmake python gcc-fortran patchelf"
 makedepends="openblas-devel pcre2-devel gmp-devel mpfr-devel libgit2-devel
- libcurl-devel libssh2-devel mbedtls-devel libatomic-devel"
-depends="pcre2 gmp mpfr libgit2 libcurl libssh2 mbedtls libatomic"
+ libcurl-devel libssh2-devel mbedtls-devel libatomic-devel zlib-devel p7zip"
+depends="pcre2 gmp mpfr libgit2 libcurl libssh2 mbedtls libatomic zlib p7zip"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=2419b268fc5c3666dd9aeb554815fe7cf9e0e7265bc9b94a43957c31a68d9184
+checksum=98c38f75eab1c16bde71509e8e3bdc941bc4686fe80dfc3c560f851c81e9e748
 nocross=yes
 # Falsely detects dependency on libllvm
-skiprdeps="/usr/lib/libjulia.so.1.2 /usr/lib/julia/libllvmcalltest.so"
+skiprdeps="/usr/lib/libjulia.so.1.3 /usr/lib/julia/libllvmcalltest.so"
 
 case "$XBPS_TARGET_MACHINE" in
 *-musl)


### PR DESCRIPTION
[ci skip] for building llvm. I have built/tested locally on x86_64 glibc.

I added in all the possible toggles for `USE_SYSTEM_X` since they seem to change around what's available there on a release-to-release basis. The big difference here is that this now uses the system zlib and p7zip. It's unclear to me if those are a new dependency or if they were simply bundled with Julia before with no option to unbundle.