### PR TITLE
librpcsecgss: mark broken on musl

### DIFF
--- a/srcpkgs/librpcsecgss/template
+++ b/srcpkgs/librpcsecgss/template
@@ -1,16 +1,24 @@
 # Template file for 'librpcsecgss'
 pkgname=librpcsecgss
 version=0.19
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libgssglue-devel"
 short_desc="Library for RPCSECGSS support"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="http://www.citi.umich.edu/projects/nfsv4/linux/"
 distfiles="$homepage/$pkgname/$pkgname-$version.tar.gz"
 checksum=0cafb86b67e5eb4c89e8abaaad9165298946bc164d258e8925fc6dc1fa913abd
+
+case "$XBPS_TARGET_LIBC" in
+	musl) broken="rpc/rpc.h header is not available on musl"
+esac
+
+post_install() {
+	vlicense COPYING
+}
 
 librpcsecgss-devel_package() {
 	depends="libgssglue-devel ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
librpcsecgss needs rpc/rpc.h which does not exist
on musl. Somewhat closes #12880

Signed-off-by: Nathan Owens <ndowens04@gmail.com>