### PR TITLE
libva-vdpau-driver: fix build

### DIFF
--- a/srcpkgs/libva-vdpau-driver/patches/CreateSurfaceFromV4L2Buf.patch
+++ b/srcpkgs/libva-vdpau-driver/patches/CreateSurfaceFromV4L2Buf.patch
@@ -1,0 +1,37 @@
+vdpau_video.c:927:1: error: conflicting types for 'vdpau_CreateSurfaceFromV4L2Buf'
+  927 | vdpau_CreateSurfaceFromV4L2Buf(
+      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In file included from vdpau_video.c:22:
+vdpau_video.h:274:1: note: previous declaration of 'vdpau_CreateSurfaceFromV4L2Buf' was here
+  274 | vdpau_CreateSurfaceFromV4L2Buf(
+      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+diff --git src/vdpau_video.c src/vdpau_video.c
+index 41d4573..937de19 100644
+--- src/vdpau_video.c
++++ src/vdpau_video.c
+@@ -927,8 +927,10 @@ VAStatus
+ vdpau_CreateSurfaceFromV4L2Buf(
+     VADriverContextP    ctx,
+     int                 v4l2_fd,
++/*
+     struct v4l2_format *v4l2_fmt,
+     struct v4l2_buffer *v4l2_buf,
++*/
+     VASurfaceID        *surface
+ )
+ {
+diff --git src/vdpau_video.h src/vdpau_video.h
+index 667a6d7..9ba654f 100644
+--- src/vdpau_video.h
++++ src/vdpau_video.h
+@@ -274,8 +274,10 @@ VAStatus
+ vdpau_CreateSurfaceFromV4L2Buf(
+     VADriverContextP    ctx,
+     int                 v4l2_fd,
++/*
+     struct v4l2_format *v4l2_fmt,
+     struct v4l2_buffer *v4l2_buf,
++*/
+     VASurfaceID        *surface
+ ) attribute_hidden;
+ 

--- a/srcpkgs/libva-vdpau-driver/template
+++ b/srcpkgs/libva-vdpau-driver/template
@@ -1,13 +1,13 @@
 # Template file for 'libva-vdpau-driver'
 pkgname=libva-vdpau-driver
 version=0.7.4
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libva-devel libvdpau-devel MesaLib-devel"
-short_desc="A VDPAU-based backend for VA-API"
+short_desc="VDPAU-based backend for VA-API"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://freedesktop.org/wiki/Software/vaapi"
 distfiles="${FREEDESKTOP_SITE}/vaapi/releases/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=155c1982f0ac3f5435ba20b221bcaa11be212c37db548cd1f2a030ffa17e9bb9


### PR DESCRIPTION
For some reason there is no `x86_64-musl` package of this. On rebuilding, it failed on all arches with error https://bbs.archlinux.org/viewtopic.php?pid=1855681#p1855681. Adding the suggested workaround makes it build.