### PR TITLE
nvidia: update to 440.36

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -3,10 +3,10 @@
 _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
-version=430.40
+version=440.36
 revision=1
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Proprietary NVIDIA license"
+license="custom:NVIDIA Proprietary"
 homepage="http://www.nvidia.com"
 
 archs="i686 x86_64"
@@ -16,14 +16,10 @@ create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
 conflicts="catalyst>=0 xserver-abi-video>24_1"
 
-build_options="glvnd"
-desc_option_glvnd="Add support for NVIDIA's GL Vendor Neutral Dispatch implementation"
-build_options_default="glvnd"
-
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_pkg="NVIDIA-Linux-x86_64-${version}-no-compat32"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=669ff38532ff05c78e1edc3c6df2055fd96437107f5919b6e5a774c3a495501b
+	checksum=1d25b67e70e59db0d0604a1ddbffbd3fe42cd6bd8184630b9807ac457f734eab
 	subpackages="nvidia-gtklibs nvidia-dkms
 	 nvidia-opencl nvidia-libs"
 	depends="nvidia-libs-${version}_${revision}
@@ -32,9 +28,10 @@ if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 else
 	_pkg="NVIDIA-Linux-x86_64-${version}"
 	distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-	checksum=f700899f48ba711b7e1598014e8db9a93537d7baa3d6a64067ed08578387dfd7
+	checksum=50086254101fc662c928194315b12d1fc773c3f21667d0091700ad1f79a36d59
 	subpackages="nvidia-libs"
 	depends="pkgconf"
+	build_style="meta"
 fi
 
 do_extract() {
@@ -42,12 +39,6 @@ do_extract() {
 	cd ${wrksrc}
 	./${_pkg}.run --extract-only
 	rm -f ${_pkg}.run
-}
-
-pre_install() {
-	cd ${_pkg}
-	cp nvidia_icd.json.template nvidia_icd.json
-	sed -i -e 's:__NV_VK_ICD__:libGLX_nvidia.so.0:g' nvidia_icd.json
 }
 
 do_install() {
@@ -64,8 +55,8 @@ do_install() {
 		ln -sf libglxserver_nvidia.so.${version} \
 			${DESTDIR}/usr/lib/xorg/modules/extensions/libglxserver_nvidia.so.1
 
-		vinstall libnvidia-egl-wayland.so.1.1.2 755 usr/lib
-		ln -sf libnvidia-egl-wayland.so.1.1.2 \
+		vinstall libnvidia-egl-wayland.so.1.1.4 755 usr/lib
+		ln -sf libnvidia-egl-wayland.so.1.1.4 \
 			${DESTDIR}/usr/lib/libnvidia-egl-wayland.so.1
 
 		vinstall 10_nvidia.json 755 usr/share/glvnd/egl_vendor.d
@@ -172,31 +163,19 @@ do_install() {
 	# Following libs are common between x86_64 and i686
 
 	# GLX client libs
-	if [ "${build_option_glvnd}" ]; then
-		# ----- Also provided by the libglvnd package (todo)
-		vinstall libGL.so.1.7.0 755 usr/lib
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
+	# ----- Also provided by the libglvnd package (todo)
+	vinstall libGL.so.1.7.0 755 usr/lib
+	ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so
+	ln -sf libGL.so.1.7.0 ${DESTDIR}/usr/lib/libGL.so.1
 
-		vinstall libGLX.so.0 755 usr/lib
-		ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
-		# --------------------------------------------------
+	vinstall libGLX.so.0 755 usr/lib
+	ln -sf libGLX.so.0 ${DESTDIR}/usr/lib/libGLX.so
+	# --------------------------------------------------
 
-		# Required for GLVND option
-		vinstall libGLX_nvidia.so.${version} 755 usr/lib
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
-	else
-		vinstall libGL.so.${version} 755 usr/lib
-		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so
-		ln -sf libGL.so.${version} ${DESTDIR}/usr/lib/libGL.so.1
-
-		# Not required for non-GLVND option but recommended
-		# more info: https://devtalk.nvidia.com/default/topic/915640/multiple-glx-client-libraries-in-the-nvidia-linux-driver-installer-package/
-		vinstall libGLX_nvidia.so.${version} 755 usr/lib
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
-		ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
-	fi
+	# Required for GLVND
+	vinstall libGLX_nvidia.so.${version} 755 usr/lib
+	ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_nvidia.so.0
+	ln -sf libGLX_nvidia.so.${version} ${DESTDIR}/usr/lib/libGLX_indirect.so.0
 
 	# OpenGL core library
 	vinstall libnvidia-glcore.so.${version} 755 usr/lib


### PR DESCRIPTION
Should close https://github.com/void-linux/void-packages/issues/16924

- Made `nvidia` use `build_style="meta"` for `i686` because there are no files to be packaged in the main package while we want the libraries in `nvidia-libs`. From https://devtalk.nvidia.com/default/topic/1032650/linux/unix-graphics-feature-deprecation-schedule/:
> The Linux-x86 and FreeBSD-x86 release packages, as well as support for 32-bit kernels in the Solaris package, are no longer provided starting with release 396.
- Removed `glvnd` option because not optional anymore:
> The release 430 series will be the last to support installing Linux OpenGL and EGL client libraries that do not use the GL Vendor Neutral Dispatch (GLVND) loader library.
- Removed `pre_install` section because now the vulkan icd file `nvidia_icd.json` already has `"library_path": "libGLX_nvidia.so.0"`

Previous attempt: https://github.com/void-linux/void-packages/pull/15849
Not tested (no hardware).