### PR TITLE
New package: qsudo-2019.11.29_1

### DIFF
--- a/srcpkgs/qsudo/template
+++ b/srcpkgs/qsudo/template
@@ -1,0 +1,19 @@
+# Template file for 'qsudo'
+pkgname=qsudo
+version=2019.11.29
+revision=1
+build_wrksrc="src-qt5"
+build_style=qmake
+hostmakedepends="qt5-host-tools qt5-qmake"
+makedepends="qt5-devel"
+depends="sudo"
+short_desc="Graphical sudo utility from Project Trident"
+maintainer="Ken Moore <ken@project-trident.org>"
+license="BSD-2-Clause"
+homepage="https://github.com/project-trident/qsudo"
+distfiles="https://github.com/project-trident/qsudo/archive/v${version}.tar.gz"
+checksum="0768f4dcc59dadb63b1803f6896b59d78f606224e223d2004ca5cba663a1c17b"
+
+post_install() {
+	vlicense ../LICENSE
+}


### PR DESCRIPTION
This is the drop-in graphical wrapper for "sudo" from Project Trident (originally written for TrueOS in 2016).

Sponsored by: Project Trident