### PR TITLE
shutils/bulk.sh: use XBPS_DISTDIR when running xbps-src

### DIFF
--- a/common/xbps-src/shutils/bulk.sh
+++ b/common/xbps-src/shutils/bulk.sh
@@ -35,7 +35,7 @@ bulk_sortdeps() {
     # Perform a topological sort of all pkgs but only with build dependencies
     # that are found in previous step.
     for pkg in ${pkgs}; do
-        _pkgs="$(./xbps-src show-build-deps $pkg 2>/dev/null)"
+        _pkgs="$($XBPS_DISTDIR/xbps-src show-build-deps $pkg 2>/dev/null)"
         found=0
         for x in ${_pkgs}; do
             _pkg=$(bulk_getlink $x)


### PR DESCRIPTION
This fixes a bug where Travis was not building packages in the correct order. It is due to `./xbps-src sort-dependencies` not working when invoked outside its directory, like Travis does. So this can also be reproduced locally by running the command from another directory (and removing the error silencing, don't know why it's there, does not affect command substitution). It will output lines like:
`/hostrepo/common/xbps-src/shutils/bulk.sh: line 38: ./xbps-src: No such file or directory`

I noticed this because one of my PRs was running out of time due to a dependency which was built twice.
Before the fix: https://travis-ci.org/void-linux/void-packages/builds/617373773
After the fix: https://travis-ci.org/st3r4g/void-packages/builds/618894144

Wondering if I should also remove the error silencing.