### PR TITLE
New package: pash-2.3.0

### DIFF
--- a/srcpkgs/pash/template
+++ b/srcpkgs/pash/template
@@ -1,0 +1,17 @@
+# Template file for 'pash'
+pkgname=pash
+version=2.3.0
+revision=1
+archs="noarch"
+depends="gnupg2"
+short_desc="Password manager using GPG written in POSIX sh"
+maintainer="Daniel Lewan <vision360.daniel@gmail.com>"
+license="MIT"
+homepage="https://github.com/dylanaraps/pash"
+distfiles="https://github.com/dylanaraps/pash/archive/${version}.tar.gz"
+checksum=7ee6a649d80350b8b52b1b7ad78d687775a3cc145fecbd3a75d34865c31dd7ef
+
+do_install() {
+	vbin pash
+	vlicense LICENSE.md
+}


### PR DESCRIPTION
https://github.com/dylanaraps/pash

Password manager written in POSIX sh compatible with pass

I made it depends on gpg2 but it works with gpg as well. I assume most people
use gpg2. I can add INSTALL script instead - it would warn user if neither
gpg nor gpg2 is installed. WDYT?