### PR TITLE
gcc: only build go for the final toolchain

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -239,7 +239,7 @@ do_configure() {
 		_args+=" --enable-fast-character"
 	fi
 
-	if [ "$_have_gccgo" = "yes" ]; then
+	if [ "$_have_gccgo" = "yes" -a -n "$CHROOT_READY" ]; then
 		_langs+=",go"
 	fi
 


### PR DESCRIPTION
The subpackages etc. are not defined when not CHROOT_READY, and it is not strictly necessary to have gccgo in the initial gcc, as it can be compiled without having an existing gccgo toolchain.