### PR TITLE
icewm: always makedepend on libXdamage-devel

### DIFF
--- a/srcpkgs/icewm/template
+++ b/srcpkgs/icewm/template
@@ -9,7 +9,7 @@ hostmakedepends="asciidoc gettext-devel libtool mkfontdir perl
  pkg-config"
 makedepends="libSM-devel libXft-devel libXinerama-devel libXpm-devel
  libXrandr-devel libao-devel librsvg-devel libsndfile-devel
- libXcomposite-devel fribidi-devel"
+ libXcomposite-devel libXdamage-devel fribidi-devel"
 depends="shared-mime-info"
 short_desc="Window Manager designed for speed, usability, and consistency"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -20,12 +20,6 @@ checksum=daa9c5b5850a26599f55d463ed250550c0309fd657cd20a5ac862976e7e8d3f9
 
 # No c++ warnings for 'One Defintion Rules' and make sure LTO goes ok
 CXXFLAGS="-Wno-odr -fno-strict-aliasing"
-
-
-if [ "$CROSS_BUILD" ]; then
-	makedepends+=" libXdamage-devel"
-fi
-
 
 pre_install() {
 	cp lib/IceWM.jpg build/lib/IceWM.jpg


### PR DESCRIPTION
The previous condition was just wrong - the reason it "worked" was that on x86_64 etc it's installed through cairo's enabled opengl backend (which pulls in mesa, which pulls in xdamage) while this is not enabled on 32-bit arm crosstargets.