### PR TITLE
New package: nebula-1.0.0

### DIFF
--- a/srcpkgs/nebula/files/nebula/log/run
+++ b/srcpkgs/nebula/files/nebula/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger --tag nebula --priority daemon.info

--- a/srcpkgs/nebula/files/nebula/run
+++ b/srcpkgs/nebula/files/nebula/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+NEBULA_CONFIG=/etc/nebula
+[ -r ./conf ] && . ./conf
+exec 2>&1
+exec nebula -config "${NEBULA_CONFIG}"

--- a/srcpkgs/nebula/template
+++ b/srcpkgs/nebula/template
@@ -1,0 +1,23 @@
+# Template file for 'nebula'
+pkgname=nebula
+version=1.0.0
+revision=1
+archs="aarch64* armv* x86_64*"
+build_style=go
+make_dirs="/etc/nebula 0750 root root"
+go_import_path=github.com/slackhq/nebula
+go_package="${go_import_path}/cmd/nebula ${go_import_path}/cmd/nebula-cert"
+go_ldflags="-X main.Build=${version}"
+hostmakedepends="git"
+short_desc="Scalable overlay networking tool"
+maintainer="Noel Cower <ncower@gmail.com>"
+license="MIT"
+homepage="https://github.com/slackhq/nebula"
+distfiles="https://github.com/slackhq/nebula/archive/v${version}.tar.gz"
+checksum=e0585ef37fae1f8db18cdea20648d4087e586b20ff0961ab7eac59a6c9bdafa2
+
+post_install() {
+	vlicense LICENSE
+	vsconf examples/config.yaml
+	vsv nebula
+}


### PR DESCRIPTION
Currently only supports x86_64, arm, and aarch64 targets (glibc and musl).

I'm working on patches for upstream to add i686 support, but that's not for this version. Would likely need to do the same for PowerPC support.

Related PR for i686 and PPC64 LE support: https://github.com/slackhq/nebula/pull/56