### PR TITLE
base-files: ship bin and lib symlinks

### DIFF
--- a/common/hooks/pre-pkg/99-pkglint.sh
+++ b/common/hooks/pre-pkg/99-pkglint.sh
@@ -7,19 +7,21 @@ hook() {
 	set +E
 
 	# Check for forbidden directories that are symlinks in void.
-	for f in bin sbin lib lib32; do
-		if [ -d ${PKGDESTDIR}/${f} ]; then
-			msg_red "${pkgver}: /${f} directory is not allowed, use /usr/${f}.\n"
+	for f in lib bin sbin lib64 lib32 usr/sbin usr/lib64; do
+		[ -e "${PKGDESTDIR}/${f}" ] || continue
+		if [ "${pkgname}" = "base-files" ]; then
+			if [ -L "${PKGDESTDIR}/${f}" ]; then
+				continue
+			fi
+			msg_red "${pkgver}: /${f} must be a symlink.\n"
+			error=1
+		else
+			msg_red "${pkgver}: /${f} must not exist.\n"
 			error=1
 		fi
 	done
-
-	if [ -d ${PKGDESTDIR}/usr/sbin ]; then
-		msg_red "${pkgver}: /usr/sbin directory is not allowed, use /usr/bin.\n"
-		error=1
-	fi
 	
-	for f in sys dev home root run var/run tmp usr/lib64 usr/local destdir; do
+	for f in sys dev home root run var/run tmp usr/local destdir; do
 		if [ -d ${PKGDESTDIR}/${f} ]; then
 			msg_red "${pkgver}: /${f} directory is not allowed, remove it!\n"
 			error=1

--- a/srcpkgs/base-files/INSTALL
+++ b/srcpkgs/base-files/INSTALL
@@ -32,35 +32,9 @@ make_system_dirs() {
 			install -d usr/local/share/man/man${d}
 	done
 
-	# Create /bin, /sbin and /lib symlinks to /usr.
-	for d in bin sbin lib; do
-		if [ ! -h "$d" -a -d "$d" ]; then
-			echo "/${d} must not be a directory, exiting!"
-			exit 1
-		fi
-		ln -sf usr/${d} .
-	done
-	# Create /usr/sbin symlink to /usr/bin.
-	[ ! -e usr/sbin ] && ln -sf bin usr/sbin
-
 	for d in empty log opt cache lib; do
 		[ ! -d var/${d} ] && install -d var/${d}
 	done
-
-	if [ "${ARCH}" = "x86_64" ] || [ "${ARCH}" = "ppc64le" ]; then
-		[ -L lib64 ] || ln -sf usr/lib lib64
-		cd usr
-		[ -L lib64 ] || ln -sf lib lib64
-		cd ..
-	fi
-	if [ "${ARCH}" = "x86_64" ]; then
-		install -d usr/lib32
-		[ -L lib32 ] || ln -sf usr/lib32 lib32
-	fi
-	if [ "${ARCH}" = "i686" ]; then
-		[ -L lib32 ] || ln -sf lib lib32
-		[ -L usr/lib32 ] || ln -sf lib usr/lib32
-	fi
 
 	# Create /var/run and /var/lock symlinks.
 	for d in run lock; do

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,12 +1,12 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.140
-revision=8
+revision=9
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
 maintainer="Enno Boland <orphan@voidlinux.org>"
-license="custom:Public domain"
+license="Public Domain"
 homepage="https://www.voidlinux.org"
 conf_files="
 	/etc/inputrc
@@ -32,11 +32,26 @@ replaces="base-directories>=0"
 system_groups="kvm:24"
 
 do_install() {
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-		vmkdir usr/lib
+	# Create bin and lib dirs and symlinks.
+	for d in bin lib; do
+		vmkdir "usr/${d}"
+		ln -snrf "${DESTDIR}/usr/${d}" "${DESTDIR}/${d}"
+	done
+	# Symlink sbin paths to /usr/bin.
+	for d in sbin usr/sbin; do
+		ln -snrf "${DESTDIR}/usr/bin" "${DESTDIR}/${d}"
+	done
+	# Symlink word-specific lib paths to /usr/lib.
+	for d in lib usr/lib; do
+		ln -snrf "${DESTDIR}/usr/lib" \
+			"${DESTDIR}/${d}${XBPS_TARGET_WORDSIZE}"
+	done
+	# Populate 32-bit lib files on 64-bit systems, for multilib.
+	if [ "${XBPS_TARGET_WORDSIZE}" = "64" ]; then
 		vmkdir usr/lib32
-		ln -s ../lib/locale ${DESTDIR}/usr/lib32/locale
-		vinstall ${FILESDIR}/ld.so.lib32.conf 644 etc/ld.so.conf.d lib32.conf
+		ln -snrf "${DESTDIR}/usr/lib32" "${DESTDIR}/lib32"
+		ln -sf ../lib/locale "${DESTDIR}/usr/lib32/locale"
+		vinstall "${FILESDIR}/ld.so.lib32.conf" 644 etc/ld.so.conf.d lib32.conf
 	fi
 
 	# Install misc config files.


### PR DESCRIPTION
Unanswered questions:

1. How does this interact with `common/hooks/{pre,post}-install/00-lib32.sh`
2. Some of the symlinks are a little funky, although not in a serious way (see below for xbps-query -f output):

```
/bin -> //usr/bin
/etc/mtab -> /proc/self/mounts
/lib -> //usr/lib
/lib32 -> //usr/lib32
/lib64 -> //lib
/sbin -> //bin
/usr/lib32/locale -> ../lib/locale
/usr/lib64 -> /usr/lib
/usr/sbin -> /usr/bin
```

Notice how the `/usr` links are fine, as is the mtab link. But the non-usr link targets have a double slash prefix.