### PR TITLE
k3s: update to 1.0.0.

### DIFF
--- a/srcpkgs/k3s/files/k3s-agent/run
+++ b/srcpkgs/k3s/files/k3s-agent/run
@@ -7,4 +7,5 @@ if [ 0 = $# ]; then
     ${K3S_SERVER:+--server="${K3S_SERVER}"} \
     ${K3S_TOKEN:+--token="${K3S_TOKEN}"}
 fi
+exec 2>&1
 exec k3s agent ${K3S_OPTIONS} ${K3S_AGENT_OPTIONS} "$@"

--- a/srcpkgs/k3s/files/k3s-server/run
+++ b/srcpkgs/k3s/files/k3s-server/run
@@ -2,4 +2,5 @@
 set --
 [ -r /etc/k3s/config ] && . /etc/k3s/config
 [ -r ./conf ] && . ./conf
+exec 2>&1
 exec k3s server ${K3S_OPTIONS} ${K3S_SERVER_OPTIONS} "$@"

--- a/srcpkgs/k3s/patches/0001-void-build.patch
+++ b/srcpkgs/k3s/patches/0001-void-build.patch
@@ -1,0 +1,98 @@
+From 3440b2daf5aa68b6c0f02bb043bf4e7fc1d2e35c Mon Sep 17 00:00:00 2001
+From: Noel Cower <ncower@gmail.com>
+Date: Mon, 28 Oct 2019 19:09:04 -0700
+Subject: [PATCH] Patch build and package-cli scripts for Void
+
+- Remove -w and -s linker flags.
+
+- Disable cgo and unset GOARCH when running go generate. (Breaks
+  execution of anything using 'go run' inside of a go:generate line.)
+
+- Replace git clone of plugins.git with a distfile so that its
+  SHA256SUM can be verified, similar to the traefik files. Adds a go
+  clean call to the end of the subshell since `rm -rf` on
+  a GOPATH/pkg/mod directory will fail (because everything is
+  read-only).
+
+- Nullify BIN_SUFFIX variable. This makes it needlessly hard to use
+  vinstall with binaries, so remove it.
+
+diff --git k3s-1.0.0/scripts/build k3s-1.0.0/scripts/build
+index 4341e3a3a1..431d024ac6 100755
+--- k3s-1.0.0/scripts/build
++++ k3s-1.0.0/scripts/build
+@@ -17,8 +17,7 @@ VERSIONFLAGS="
+     -X ${VENDOR_PREFIX}${PKG_CONTAINERD}/version.Version=${VERSION_CONTAINERD}
+     -X ${VENDOR_PREFIX}${PKG_CONTAINERD}/version.Package=${PKG_RANCHER_CONTAINERD}
+     -X ${VENDOR_PREFIX}${PKG_CRICTL}/pkg/version.Version=${VERSION_CRICTL}"
+-LDFLAGS="
+-    -w -s"
++LDFLAGS=""
+ STATIC="
+     -extldflags '-static'
+ "
+@@ -63,7 +62,7 @@ rm -f \
+ 
+ cleanup() {
+     exit_status=$?
+-    rm -rf $TMPDIR
++    go clean -modcache
+     exit ${exit_status}
+ }
+ 
+@@ -71,12 +70,11 @@ INSTALLBIN=$(pwd)/bin
+ if [ ! -x ${INSTALLBIN}/cni ]; then
+ (
+     echo Building cni
+-    TMPDIR=$(mktemp -d)
+     trap cleanup EXIT
+-    WORKDIR=$TMPDIR/src/github.com/containernetworking/plugins
+-    git clone -b $VERSION_CNIPLUGINS https://github.com/rancher/plugins.git $WORKDIR
+-    cd $WORKDIR
+-    GOPATH=$TMPDIR CGO_ENABLED=0 go build -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o $INSTALLBIN/cni
++    SRCDIR=
++    cd "$XBPS_BUILDDIR/k3s-${VERSION#v}/plugins-${VERSION_CNIPLUGINS#v}"
++    [ -r go.mod ] || go mod init github.com/containernetworking/plugins
++    CGO_ENABLED=0 go build -mod=vendor -tags "$TAGS" -ldflags "$LDFLAGS $STATIC" -o $INSTALLBIN/cni
+ )
+ fi
+ # echo Building agent
+@@ -95,7 +93,7 @@ ln -s containerd ./bin/ctr
+ # echo Building containerd
+ # CGO_ENABLED=0 go build -tags "$TAGS" -ldflags "$VERSIONFLAGS $LDFLAGS $STATIC" -o bin/containerd ./cmd/containerd/
+ echo Building runc
+-make EXTRA_LDFLAGS="-w -s" BUILDTAGS="apparmor seccomp" -C ./vendor/github.com/opencontainers/runc static
++make EXTRA_LDFLAGS="" BUILDTAGS="apparmor seccomp" -C ./vendor/github.com/opencontainers/runc static
+ cp -f ./vendor/github.com/opencontainers/runc/runc ./bin/runc
+ 
+ echo Building containerd-shim
+diff --git k3s-1.0.0/scripts/package-cli k3s-1.0.0/scripts/package-cli
+index 0aac10bb24..000f15f93e 100755
+--- k3s-1.0.0/scripts/package-cli
++++ k3s-1.0.0/scripts/package-cli
+@@ -40,20 +40,14 @@ HASH=$(sha256sum ./build/out/data.tar.gz | awk '{print $1}')
+ 
+ cp ./build/out/data.tar.gz ./build/data/${HASH}.tgz
+ 
+-BIN_SUFFIX="-${ARCH}"
+-if [ ${ARCH} = amd64 ]; then
+-    BIN_SUFFIX=""
+-elif [ ${ARCH} = arm ]; then
+-    BIN_SUFFIX="-armhf"
+-fi
++BIN_SUFFIX=""
+ 
+ CMD_NAME=dist/artifacts/k3s${BIN_SUFFIX}
+ 
+-go generate
++CGO_ENABLED=0 GOARCH= go generate -x
+ LDFLAGS="
+     -X github.com/rancher/k3s/pkg/version.Version=$VERSION
+     -X github.com/rancher/k3s/pkg/version.GitCommit=${COMMIT:0:8}
+-    -w -s
+ "
+ STATIC="-extldflags '-static'"
+ if [ "$DQLITE" = "true" ]; then
+-- 
+2.23.0
+

--- a/srcpkgs/k3s/template
+++ b/srcpkgs/k3s/template
@@ -1,13 +1,14 @@
 # Template file for 'k3s'
 pkgname=k3s
-version=0.9.1
-revision=2
+version=1.0.0
+revision=1
 create_wrksrc=yes
 build_wrksrc="${pkgname}-${version}"
 build_style=go
 go_import_path="github.com/rancher/k3s"
 hostmakedepends="git pkg-config"
 makedepends="libseccomp-devel"
+depends="ipset conntrack-tools"
 short_desc="Lightweight Kubernetes"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
@@ -15,40 +16,28 @@ homepage="https://k3s.io"
 # _traefik_* variables' values from scripts/download in source distfile
 _traefik_version="1.77.1"
 _traefik_file="traefik-${_traefik_version}.tgz"
+_plugins_version="0.7.6-k3s1"
+_plugins_file="v${_plugins_version}.tar.gz"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz
+ https://github.com/rancher/plugins/archive/${_plugins_file}
  https://kubernetes-charts.storage.googleapis.com/${_traefik_file}"
-checksum="dee3ddfcdb61f292bcfe778d7677e436309511e15c6bbdd326ebec42ea41bbac
+checksum="7b9222dcaa4bbc387dd6f38a653b7b2b09079987c19a399c6c4f3e5b3dc1d39c
+ 75e02aa09edcfb2b43d41cd576e24099e9bca21d80bda0dcdc3f98f2357f1363
  15dd78d136d7c9bae7144072052ef6cd12821ae081a7c085f145d834d96c5d5c"
 skip_extraction="${_traefik_file}"
-conflicts="kubernetes"
 
-_git_commit=755bd1c63bafe80f9b5fe8d4bba527f988625364
+_git_commit=18bd921cddee1e95cc03467a1b9636ddacd9d670
 
 pre_build() {
 	# Modify version.sh to use template variables' values.
 	vsed -i scripts/version.sh -e '
-		s@^COMMIT=.*@COMMIT='"${_git_commit}"'@;
+		s@^COMMIT=.*@COMMIT='"${_git_commit::10}"'@;
 		s@^GIT_TAG=.*@GIT_TAG=v'"${version}"'@
-		'
-	# Remove -s (strip) and -w (no dwarf) linker arguments.
-	vsed -i scripts/build -e 's@-w -s@@'
-	# Remove BIN_SUFFIX, nullify GOARCH for go generate. The latter
-	# is needed because 'go run' will try to run binaries for the
-	# target given by GOOS/GOARCH. The -x prints what 'go generate'
-	# is executing. CGO_ENABLED is set to 0 because cross builds
-	# won't necessarily be able to handle 64-bit builds performed by
-	# 'go run'.
-	vsed -i scripts/package-cli -e '
-		s@BIN_SUFFIX="[^"]\+"@BIN_SUFFIX=""@;
-		s@^go generate$@CGO_ENABLED=0 GOARCH= & -x@;
-		s@-w -s@@g
 		'
 
 	# Recreate behavior of scripts/download minus downloading
 	# anything or having anything to do with busybox.
-	mkdir -p bin
-
-	mkdir -p build/static/charts
+	mkdir -p etc bin build/static/charts
 	cp ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_traefik_file} build/static/charts/${_traefik_file}
 }
 
@@ -59,7 +48,6 @@ do_build() {
 
 do_install() {
 	vbin dist/artifacts/k3s
-	vbin dist/artifacts/hyperkube
 	vsv k3s-server
 	vsv k3s-agent
 }


### PR DESCRIPTION
Moves most vsed stuff into the given patch. Part of this is to force
reviewing it each time it doesn't apply cleanly (it probably won't most
of the time), the other is to stop cramming things into vsed, since
that's hackier than just patching the files.

0.10.x onward adds a dependency on ipset and conntrack-tools. Without
ipset, k3s will crash upon startup. Not having conntrack appears to be
a non-crashing error, but will result in error logs when deleting stale
service IPs.

This adds a new distfile, part of which motivated the patching, to
avoid running a direct 'git clone' of a repository in the build script.

Services now redirect stderr to stdout, as they probably weren't
capturing log output before.

hyperkube is no longer provided in k3s. As a result, k3s no longer
conflicts with kubernetes.

Have already tested this by upgrading my own cluster with these
changes.