### PR TITLE
Aegisub: use libatomic for ppc32/armv6l

### DIFF
--- a/srcpkgs/Aegisub/patches/libatomic.patch
+++ b/srcpkgs/Aegisub/patches/libatomic.patch
@@ -1,0 +1,35 @@
+--- Makefile.inc.in
++++ Makefile.inc.in
+@@ -8,6 +8,7 @@ HAVE_OSS        = @with_oss@
+ HAVE_PORTAUDIO  = @with_portaudio@
+ HAVE_FFMS2      = @with_ffms2@
+ HAVE_LIBPULSE   = @with_libpulse@
++HAVE_LIBATOMIC  = @with_libatomic@
+ 
+ ##############
+ # BUILD OUTPUT
+--- configure.ac
++++ configure.ac
+@@ -376,6 +376,9 @@ AGI_OPT_PKG(ffms2, [build without ffms2 A/V provider [auto]], [Enable FFMS2 supp
+ AGI_OPT_PKG(fftw3, [build without fftw support [auto]], [Enable fftw support])
+ AGI_OPT_PKG(hunspell, [build without hunspell spell-checking [auto]], [Enable Hunspell support])
+ 
++AC_ARG_WITH([libatomic], AS_HELP_STRING([--with-libatomic],[Use libatomic. [no]]))
++AC_SUBST(with_libatomic)
++
+ ######################################################
+ # Debugging support
+ ######################################################
+--- src/Makefile
++++ src/Makefile
+@@ -179,6 +179,10 @@ src_LIBS += $(LIBS_HUNSPELL)
+ src_OBJ += $(d)spellchecker_hunspell.o
+ endif
+ 
++ifeq (yes, $(HAVE_LIBATOMIC))
++src_LIBS += -latomic
++endif
++
+ #####################
+ # SOURCE-LEVEL CFLAGS
+ #####################

--- a/srcpkgs/Aegisub/template
+++ b/srcpkgs/Aegisub/template
@@ -28,6 +28,14 @@ desc_option_portaudio="Enable support for portaudio"
 LDFLAGS+=" -pthread"
 
 case "$XBPS_TARGET_MACHINE" in
+	ppc64*) ;;
+	armv6*|ppc*)
+		makedepends+="libatomic-devel"
+		configure_args+=" --with-libatomic"
+		;;
+esac
+
+case "$XBPS_TARGET_MACHINE" in
 	*musl) broken="segfaults on startup";;
 	armv7l*|armv6l*) broken="error: invalid conversion from 'const char**' to 'char**' [-fpermissive]"
 esac


### PR DESCRIPTION
Cannot be done via simple `LDFLAGS` as they're passed in the wrong order.