### PR TITLE
telepathy-mission-control: fix build by getting rid of epochs mess

### DIFF
--- a/srcpkgs/telepathy-mission-control/template
+++ b/srcpkgs/telepathy-mission-control/template
@@ -1,8 +1,9 @@
 # Template file for 'telepathy-mission-control'
 pkgname=telepathy-mission-control
-version=5:5.16.4
+reverts="5:5.16.4_1 5:5.16.1_2 5:5.16.1_1 5:5.16.0_2 5:5.16.0_1 5:5.15.1_1
+ 5:5.14.1_1 2:5.14.1_1 1:5.14.1_1"
+version=5.16.4
 revision=1
-wrksrc="${pkgname}-${version#*:}"
 build_style=gnu-configure
 configure_args="--disable-static --enable-gnome-keyring --disable-schemas-compile"
 hostmakedepends="pkg-config python-devel intltool libxslt glib-devel"
@@ -12,7 +13,7 @@ short_desc="Account manager and channel dispatcher for the Telepathy framework"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://telepathy.freedesktop.org"
-distfiles="${homepage}/releases/${pkgname}/${pkgname}-${version#*:}.tar.gz"
+distfiles="${homepage}/releases/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=9769ddac7ad8aad21f6db854016792162b57e6fa0b0aed8d823d76a71fe7e6cb
 
 telepathy-mission-control-devel_package() {

--- a/srcpkgs/telepathy-mission-control/update
+++ b/srcpkgs/telepathy-mission-control/update
@@ -1,2 +1,1 @@
-version="${version#*:}"
 ignore="*.9[0-9].*"


### PR DESCRIPTION
These were randomly bumped during the history of the package, and currently they don't even work because xbps-src doesn't know that a colon can be used in version number and fails to register them.

It's not needed anyway - just go back to a normal format and put every epoch'd version in git history into reverts (xbps considers those newer).