### PR TITLE
vapoursynth-mvtools: only for x86

### DIFF
--- a/srcpkgs/vapoursynth-mvtools/template
+++ b/srcpkgs/vapoursynth-mvtools/template
@@ -2,6 +2,7 @@
 pkgname=vapoursynth-mvtools
 version=21
 revision=1
+archs="x86_64* i686*"
 build_style=meson
 hostmakedepends="pkg-config libtool nasm"
 makedepends="fftw-devel vapoursynth-devel"
@@ -11,12 +12,6 @@ license="GPL-2"
 homepage="http://avisynth.org.ru/mvtools/mvtools2.html"
 distfiles="https://github.com/dubhater/vapoursynth-mvtools/archive/v${version}.tar.gz"
 checksum=dc267fce40dd8531a39b5f51075e92dd107f959edb8be567701ca7545ffd35c5
-
-case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		broken="https://build.voidlinux.org/builders/armv7l-musl_builder/builds/15031"
-		;;
-esac
 
 post_install() {
 	vdoc readme.rst


### PR DESCRIPTION
The code contains assembly as well as build system paths that are specifically x86 only.