### PR TITLE
telepathy-python: fix build (don't install errors.py twice)

### DIFF
--- a/srcpkgs/telepathy-python/template
+++ b/srcpkgs/telepathy-python/template
@@ -5,7 +5,7 @@ revision=7
 archs=noarch
 build_style=gnu-configure
 pycompile_module="telepathy"
-hostmakedepends="python libxslt"
+hostmakedepends="automake python libxslt"
 depends="python python-dbus"
 short_desc="Python libraries for use in Telepathy clients and connection managers"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,3 +13,7 @@ license="LGPL-2.1"
 homepage="http://telepathy.freedesktop.org"
 distfiles="http://telepathy.freedesktop.org/releases/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=244c0e1bf4bbd78ae298ea659fe10bf3a73738db550156767cc2477aedf72376
+
+pre_configure() {
+	autoreconf -if
+}


### PR DESCRIPTION
We have a patch for this but it wasn't being used as the autotools files weren't being regenerated.