### PR TITLE
netbsd-rumpkernel: restrict archs

### DIFF
--- a/srcpkgs/netbsd-rumpkernel/template
+++ b/srcpkgs/netbsd-rumpkernel/template
@@ -1,11 +1,12 @@
-# Template file for 'netbsd-rumpkernel'.
+# Template file for 'netbsd-rumpkernel'
 pkgname=netbsd-rumpkernel
 version=20140526
 revision=2
+archs="x86_64* i686*"
 wrksrc="buildrump.sh-${version}"
+hostmakedepends="git"
 short_desc="The NetBSD rump kernel"
 maintainer="Orphaned <orphan@voidlinux.org>"
-hostmakedepends="git"
 license="BSD"
 homepage="https://github.com/anttikantee/buildrump.sh"
 distfiles="https://github.com/rumpkernel/buildrump.sh/archive/v${version}.tar.gz"


### PR DESCRIPTION
I don't think this is tested on other archs at all, and e.g. does not support ppc64 ELFv2 ABI and possibly other specifics for various archs, so go with a safe set.