### PR TITLE
gtkimageview: switch source

### DIFF
--- a/srcpkgs/gtkimageview/template
+++ b/srcpkgs/gtkimageview/template
@@ -12,7 +12,7 @@ short_desc="Widget that provides a zoomable and panable view of a GdkPixbuf"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GTK/GtkImageView"
-distfiles="https://github.com/GNOME/gtkimageview/archive/${_githash}.tar.gz"
+distfiles="https://sources.voidlinux.org/${pkgname}-${version}/${_githash}.tar.gz"
 checksum=2d61c9957500e515419b2b3b0d9a3d5efb67a6a8384743926121dcd618a9ef35
 
 pre_build() {


### PR DESCRIPTION
The original location of this has been deleted and there isn't any other source. This should be phased out later with gtk2 but for now we still have things depending on this (e.g. `ufraw`). I think this is probably not ideal but the archive should be mirrored to our usual distfiles location, but I'll need someone to do this (@Gottox @the-maldridge @Duncaen)