### PR TITLE
List bootstrap dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ in the `srcpkgs` directory.
 The `bootstrap` packages are a set of packages required to build any available source package in a container. There are two methods to install the `bootstrap`:
 
  - `bootstrap`: all bootstrap packages will be built from scratch; additional utilities are required in the
-host system to allow building the `base-chroot` package: binutils, gcc, perl, texinfo, etc.
+host system to allow building the `base-chroot` package, on Void Linux host required packages are
+base-system, base-devel, git, gcc-ada, libada-devel, zlib-devel, gettext-devel, python3
 
  - `binary-bootstrap`: the bootstrap binary packages are downloaded via XBPS repositories.
 


### PR DESCRIPTION
This adds exhaustive list of void-linux packages which are necessary to run `./xbps-src -N bootstrap` on void linux host and also fixes one broken template i came upon while testing this.

At least #16097 can be closed, maybe also #13782 (I'll test that later).

As @q66 noted, it's probably not a good idea to list bootstrap as an alternative to binary-bootstrap and even first when binary-bootstrap is the absolutely preffered way to setup a masterdir.

It'd also be great to expand the documentation a bit and mention some pitfalls that come with bootstrap (something is written on the wiki, but I think it would be better to have with the rest of xbps-src documentation). I'd happily investigate and write this up, but I'd like someone with more authority to tell me in what way that would be desirable.