### PR TITLE
chroot-texinfo: fix path to automake config file

### DIFF
--- a/srcpkgs/chroot-texinfo/template
+++ b/srcpkgs/chroot-texinfo/template
@@ -17,7 +17,7 @@ distfiles="${GNU_SITE}/texinfo/texinfo-${version}.tar.lzma"
 checksum=6d28b0ceae866e3536142fc552e7a3bc9f84c8303119c25731b2478eef64c9e5
 
 do_configure() {
-	cp -f ${XBPS_CROSSPFDIR}/config.sub build-aux
+	cp -f ${XBPS_COMMONDIR}/environment/configure/automake/config.sub build-aux
 
 	./configure ${configure_args} --disable-nls
 }


### PR DESCRIPTION
file moved in 80b96a0ea0