### PR TITLE
telepathy-qt5: install python2 first

### DIFF
--- a/srcpkgs/telepathy-qt5/template
+++ b/srcpkgs/telepathy-qt5/template
@@ -1,4 +1,4 @@
-# Template file for 'telepathy-qt'
+# Template file for 'telepathy-qt5'
 pkgname=telepathy-qt5
 version=0.9.7
 revision=1
@@ -9,7 +9,7 @@ configure_args="
  -DENABLE_TESTS=OFF
  -DDESIRED_QT_VERSION=5
  -DQT_QMAKE_EXECUTABLE=/usr/bin/qmake-qt5"
-hostmakedepends="pkg-config"
+hostmakedepends="python pkg-config"
 makedepends="qt5-devel telepathy-farstream-devel telepathy-glib-devel gstreamer1-devel"
 short_desc="Qt5 bindings for the Telepathy D-Bus protocol"
 maintainer="Duncaen <duncaen@voidlinux.org>"


### PR DESCRIPTION
The buildsystem runs some python scripts and those seem to require python2. Meanwhile, python is already pulled in through some dep but it's python3. Make sure to install py2 first so the alternative is properly set.