### PR TITLE
amsynth: Add improvement patches

### DIFF
--- a/srcpkgs/amsynth/patches/0001-Fix-issue-of-static-initialization-order.patch
+++ b/srcpkgs/amsynth/patches/0001-Fix-issue-of-static-initialization-order.patch
@@ -1,0 +1,60 @@
+From aa3c555bbf27aa79cbfa811ee2c8cb5e125069b8 Mon Sep 17 00:00:00 2001
+From: JP Cimalando <jp-dev@inbox.ru>
+Date: Wed, 29 May 2019 20:57:35 +0200
+Subject: [PATCH 1/3] Fix issue of static initialization order
+
+The static variable _preset can be uninitialized when the library constructor
+runs. When it happens, the parameters and their names are not enumerated
+correctly in the DSSI descriptor.
+---
+ src/Preset.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git src/Preset.cpp src/Preset.cpp
+index 02bae49..b67dc81 100644
+--- src/Preset.cpp
++++ src/Preset.cpp
+@@ -223,10 +223,15 @@ void get_parameter_properties(int parameter_index, double *minimum, double *maxi
+ 
+ /* this implements the C API in controls.h */
+ 
+-static Preset _preset;
++static const Preset &_get_preset()
++{
++	static const Preset preset;
++	return preset;
++}
+ 
+ const char *parameter_name_from_index (int param_index)
+ {
++	const Preset &_preset = _get_preset();
+ 	if (param_index < 0 || param_index >= (int)_preset.ParameterCount())
+ 		return NULL;
+ 	static std::vector<std::string> names;
+@@ -239,6 +244,7 @@ const char *parameter_name_from_index (int param_index)
+ 
+ int parameter_index_from_name (const char *param_name)
+ {
++	const Preset &_preset = _get_preset();
+ 	for (unsigned i=0; i<_preset.ParameterCount(); i++) {
+ 		if (std::string(param_name) == _preset.getParameter(i).getName()) {
+ 			return i;
+@@ -249,6 +255,7 @@ int parameter_index_from_name (const char *param_name)
+ 
+ int parameter_get_display (int parameter_index, float parameter_value, char *buffer, size_t maxlen)
+ {
++	const Preset &_preset = _get_preset();
+ 	Parameter parameter = _preset.getParameter(parameter_index);
+ 	parameter.setValue(parameter_value);
+ 	float real_value = parameter.getControlValue();
+@@ -406,6 +413,7 @@ void Preset::setShouldIgnoreParameter(int parameter, bool ignore)
+ 
+ std::string Preset::getIgnoredParameterNames()
+ {
++	const Preset &_preset = _get_preset();
+ 	std::string names;
+ 	for (int i = 0; i < kAmsynthParameterCount; i++) {
+ 		if (shouldIgnoreParameter(i)) {
+-- 
+2.24.0
+

--- a/srcpkgs/amsynth/patches/0002-Fix-size-of-ALSA-audio-buffer.patch
+++ b/srcpkgs/amsynth/patches/0002-Fix-size-of-ALSA-audio-buffer.patch
@@ -1,0 +1,34 @@
+From 8d863e4bd86b1ae14ef1eb34b0b58a0609592353 Mon Sep 17 00:00:00 2001
+From: Nick Dowell <nick@nickdowell.com>
+Date: Fri, 26 Apr 2019 16:05:27 +0100
+Subject: [PATCH 2/3] Fix size of ALSA audio buffer
+
+---
+ src/drivers/ALSAAudioDriver.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git src/drivers/ALSAAudioDriver.cpp src/drivers/ALSAAudioDriver.cpp
+index f50e348..68ccf4c 100644
+--- src/drivers/ALSAAudioDriver.cpp
++++ src/drivers/ALSAAudioDriver.cpp
+@@ -1,7 +1,7 @@
+ /*
+  *  ALSAAudioDriver.cpp
+  *
+- *  Copyright (c) 2001-2015 Nick Dowell
++ *  Copyright (c) 2001-2019 Nick Dowell
+  *
+  *  This file is part of amsynth.
+  *
+@@ -112,7 +112,7 @@ ALSAAudioDriver::open()
+ 
+ 	_handle = pcm;
+ 	_channels = config.channels;
+-	_buffer = (short *)malloc(kMaxWriteFrames * sizeof(short));
++	_buffer = (short *)malloc(kMaxWriteFrames * _channels * sizeof(short));
+ 
+ 	config.current_audio_driver = "ALSA";
+ #ifdef ENABLE_REALTIME
+-- 
+2.24.0
+

--- a/srcpkgs/amsynth/patches/0003-Fix-a-segfault-when-trying-to-free-an-environment-va.patch
+++ b/srcpkgs/amsynth/patches/0003-Fix-a-segfault-when-trying-to-free-an-environment-va.patch
@@ -1,0 +1,27 @@
+From b0b2fd09f4b58fef8f189c1f09cc8857723b123c Mon Sep 17 00:00:00 2001
+From: Janne Junnila <janne.junnila@gmail.com>
+Date: Sun, 7 Jul 2019 10:06:07 +0200
+Subject: [PATCH 3/3] Fix a segfault when trying to free an environment
+ variable.
+
+---
+ src/GUI/editor_pane.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git src/GUI/editor_pane.c src/GUI/editor_pane.c
+index 090b80f..9332972 100644
+--- src/GUI/editor_pane.c
++++ src/GUI/editor_pane.c
+@@ -266,6 +266,9 @@ editor_pane_new (void *synthesizer, GtkAdjustment **adjustments, gboolean is_plu
+ 	gchar *skin_path = (gchar *)g_getenv ("AMSYNTH_SKIN");
+ 	if (skin_path == NULL) {
+ 		skin_path = g_build_filename (PKGDATADIR, "skins", "default", NULL);
++	} else {
++		// Copy the env var so that we don't segfault at free below
++		skin_path = g_strdup (skin_path);
+ 	}
+ 	
+ 	if (!g_file_test (skin_path, G_FILE_TEST_EXISTS)) {
+-- 
+2.24.0
+

--- a/srcpkgs/amsynth/template
+++ b/srcpkgs/amsynth/template
@@ -1,7 +1,7 @@
 # Template file for 'amsynth'
 pkgname=amsynth
 version=1.9.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pandoc intltool pkg-config"
 makedepends="dssi-devel ladspa-sdk gtk+-devel jack-devel alsa-lib-devel


### PR DESCRIPTION
Added patches to fix size of ALSA audio buffer,
static initialization order and a patch for a segfault

Signed-off-by: Nathan Owens <ndowens04@gmail.com>