### PR TITLE
0ad: restrict archs

### DIFF
--- a/srcpkgs/0ad-data/template
+++ b/srcpkgs/0ad-data/template
@@ -10,6 +10,12 @@ license="CC-BY-SA-3.0"
 homepage="https://play0ad.com"
 distfiles="https://releases.wildfiregames.com/0ad-${version}-alpha-unix-data.tar.xz"
 checksum=e11b4ade7ede954cbbdc1fe6e2e4b25ac6b8d5a644133b640ffc9b099338a713
+nocross=yes
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*|i686*|aarch64*|armv7l*|ppc64le*) ;;
+	*) broken="no base game available";;
+esac
 
 do_install() {
 	vmkdir usr/share/0ad/data

--- a/srcpkgs/0ad/template
+++ b/srcpkgs/0ad/template
@@ -2,6 +2,7 @@
 pkgname=0ad
 version=0.0.23b
 revision=3
+archs="x86_64* i686* aarch64* armv7l* ppc64le*"
 wrksrc="${pkgname}-${version}-alpha"
 hostmakedepends="pkg-config perl cmake python"
 makedepends="SDL2-devel boost-devel gloox-devel libcurl-devel libenet-devel


### PR DESCRIPTION
Code for other platforms is not provided in the tree. Big endian ppc64 is not supported (there are unhandled paths in it on which it errors).