### PR TITLE
dumb: unmark nocross

### DIFF
--- a/srcpkgs/dumb/template
+++ b/srcpkgs/dumb/template
@@ -9,11 +9,10 @@ hostmakedepends="ninja"
 makedepends="allegro4-devel"
 short_desc="IT, XM, S3M and MOD player library"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD"
+license="custom:DUMB"
 homepage="http://dumb.sourceforge.net/"
 distfiles="https://github.com/kode54/dumb/archive/${version}.tar.gz"
 checksum=99bfac926aeb8d476562303312d9f47fd05b43803050cd889b44da34a9b2a4f9
-nocross="gobject-introspection"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)


### PR DESCRIPTION
Correct License, it is not a BSD license

Signed-off-by: Nathan Owens <ndowens04@gmail.com>