### PR TITLE
bmon: Add patch for crash in certain conditions

### DIFF
--- a/srcpkgs/bmon/patches/Add_CTRL-N_CTRL-P.patch
+++ b/srcpkgs/bmon/patches/Add_CTRL-N_CTRL-P.patch
@@ -1,0 +1,35 @@
+From 5677863e61e2c115eb86613b09f636b84cf4ada3 Mon Sep 17 00:00:00 2001
+From: Alexis Hildebrandt <afh@surryhill.net>
+Date: Tue, 3 Oct 2017 00:00:07 +0200
+Subject: [PATCH] curses: Add CTRL-N/CTRL-P for next/previous element
+
+---
+ src/out_curses.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git src/out_curses.c src/out_curses.c
+index 51b6391..330e8f6 100644
+--- src/out_curses.c
++++ src/out_curses.c
+@@ -45,6 +45,8 @@ enum {
+ 	KEY_TOGGLE_DETAILS	= 'd',
+ 	KEY_TOGGLE_INFO		= 'i',
+ 	KEY_COLLECT_HISTORY	= 'h',
++	KEY_CTRL_N	= 14,
++	KEY_CTRL_P	= 16,
+ };
+ 
+ #define DETAILS_COLS		40
+@@ -1186,10 +1188,12 @@ static int handle_input(int ch)
+ 			return 1;
+ 
+ 		case KEY_DOWN:
++		case KEY_CTRL_N:
+ 			element_select_next();
+ 			return 1;
+ 
+ 		case KEY_UP:
++		case KEY_CTRL_P:
+ 			element_select_prev();
+ 			return 1;
+ 

--- a/srcpkgs/bmon/patches/out_curses.patch
+++ b/srcpkgs/bmon/patches/out_curses.patch
@@ -1,0 +1,52 @@
+From 341375179514bfd96f2d6001df15a4079631491b Mon Sep 17 00:00:00 2001
+From: Nachiketa Prachanda <nchkta@gmail.com>
+Date: Tue, 31 Jan 2017 12:08:48 -0800
+Subject: [PATCH] out_curses: use xcalloc instead of a fixed buffer
+
+In put_line(), replace the fixed onstack buffer with a xcalloc-ed buffer.
+This fixes a bmon crash with terminal size larger than 2048 bytes. The crash
+be reproduced with
+   $ stty cols 2100
+   $ bmon ....
+
+Signed-off-by: Nachiketa Prachanda <nchkta@gmail.com>
+---
+ src/out_curses.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git src/out_curses.c src/out_curses.c
+index 6d70ae3..e5317de 100644
+--- src/out_curses.c
++++ src/out_curses.c
+@@ -147,22 +147,24 @@ static char *float2str(double value, int width, int prec, char *buf, size_t len)
+ static void put_line(const char *fmt, ...)
+ {
+ 	va_list args;
+-	char buf[2048];
++	char *buf;
++	int len;
+ 	int x, y __unused__;
+ 
+-	memset(buf, 0, sizeof(buf));
+ 	getyx(stdscr, y, x);
+ 
++	len = cols - x;
++	buf = xcalloc(len+1, 1);
++
+ 	va_start(args, fmt);
+-	vsnprintf(buf, sizeof(buf), fmt, args);
++	vsnprintf(buf, len+1, fmt, args);
+ 	va_end(args);
+ 
+-	if (strlen(buf) > cols-x)
+-		buf[cols - x] = '\0';
+-	else
+-		memset(&buf[strlen(buf)], ' ', cols - strlen(buf)-x);
++	if (strlen(buf) < len)
++		memset(&buf[strlen(buf)], ' ', len - strlen(buf));
+ 
+ 	addstr(buf);
++	xfree(buf);
+ }
+ 
+ static void center_text(const char *fmt, ...)

--- a/srcpkgs/bmon/template
+++ b/srcpkgs/bmon/template
@@ -1,13 +1,13 @@
 # Template file for 'bmon'
 pkgname=bmon
 version=4.0
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="ncurses-devel libnl3-devel confuse-devel"
 short_desc="Bandwidth monitor and rate estimator"
 maintainer="Christian Neukirchen <chneukirchen@gmail.com>"
-license="BSD, MIT"
+license="BSD-2-Clause, MIT"
 homepage="http://github.com/tgraf/bmon/"
 distfiles="http://github.com/tgraf/${pkgname}/archive/v${version}.tar.gz"
 checksum=d5e503ff6b116c681ebf4d10e238604dde836dceb9c0008eb92416a96c87ca40


### PR DESCRIPTION
Added patch for crash if terminal is larger than 2048 bytes.
Also added patch for CTRL-N/CTRL-P for next/previous element.
While here, correct license format

Signed-off-by: Nathan Owens <ndowens04@gmail.com>