### PR TITLE
bochs: update to 2.6.10

### DIFF
--- a/srcpkgs/bochs/template
+++ b/srcpkgs/bochs/template
@@ -1,18 +1,18 @@
 # Template file for 'bochs'
-pkgname="bochs"
-version="2.6.9"
+pkgname=bochs
+version=2.6.10
 revision=1
 build_style=gnu-configure
-short_desc="Highly portable open source IA-32 (x86) PC emulator"
-maintainer="mid-kid <esteve.varela@gmail.com>"
-license="LGPL-2.1"
-homepage="http://bochs.sourceforge.net/"
+configure_args="--enable-debugger --enable-disasm --disable-readline"
 hostmakedepends="pkg-config"
 makedepends="libX11-devel libXrandr-devel gtk+-devel"
-configure_args="--enable-debugger --enable-disasm --disable-readline"
-disable_parallel_build=yes
+short_desc="Highly portable open source IA-32 (x86) PC emulator"
+maintainer="mid-kid <esteve.varela@gmail.com>"
+license="LGPL-2.1-only"
+homepage="http://bochs.sourceforge.net/"
 distfiles="$SOURCEFORGE_SITE/bochs/bochs-${version}.tar.gz"
-checksum=ee5b677fd9b1b9f484b5aeb4614f43df21993088c0c0571187f93acb0866e98c
+checksum=723f808b2c2ac6f886d90c4eb2000b8d075992661e6e47c8474e668e16e175b0
+disable_parallel_build=yes
 
 pre_build() {
 	sed -i 's/^LIBS = /LIBS = -lpthread/g' Makefile


### PR DESCRIPTION
Update to 2.6.10 correct order of variables

Signed-off-by: Nathan Owens <ndowens04@gmail.com>