### PR TITLE
go: update to 1.13.5; go12-bootstrap: update to 1.12.14.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.13.4
+version=1.13.5
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=95dbeab442ee2746b9acf0934c8e2fc26414a0565c008631b04addb8c02e7624
+checksum=27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff
 nostrip=yes
 noverifyrdeps=yes
 

--- a/srcpkgs/go1.12-bootstrap/template
+++ b/srcpkgs/go1.12-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'go1.12-bootstrap'
 pkgname=go1.12-bootstrap
-version=1.12.13
+version=1.12.14
 revision=1
 archs="x86_64* i686* armv[67]l* aarch64* ppc64le*"
 wrksrc="go"
@@ -21,23 +21,23 @@ fi
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*)
 		_dist_arch="amd64"
-		checksum="da036454cb3353f9f507f0ceed4048feac611065e4e1818b434365eb32ac9bdc"
+		checksum="925a1a9d8b31c2425d7313fe73d3342288968a66e26cd8bf1b6b5656f4603fcb"
 		;;
 	i686*)
 		_dist_arch="386"
-		checksum="fafcb585591557b7b16d9b22dec4654193d205cf444b1810ab2988f658585e23"
+		checksum="76dda90b4fc0410212094b433cfdc40c9802fba972427e95cbdec3c5b94fd7a6"
 		;;
 	arm*)
 		_dist_arch="armv6l"
-		checksum="bf061cc3d4951e07904496b5c3d6c82419309d24634835522d786673a3f5438f"
+		checksum="c7aa5562168b6eb3a4bb54af061d68bcb6b9ecae9d785f9a38255c107c986b73"
 		;;
 	aarch64*)
 		_dist_arch="arm64"
-		checksum="dcfcb3785292c98f7a75c2276169dfe2d445c19f8ffe1d40b3f7b8f59712d361"
+		checksum="1ab765f4cf74f05cfba40ddcea9160ca6cf9a57915036a559ca1691942862e7c"
 		;;
 	ppc64le*)
 		_dist_arch="ppc64le"
-		checksum="77056264abcf5444ed0d9ab7552552ae2145ca8fb6c39d33db3c735eaf3f42d2"
+		checksum="4e237b1357922e186337989914201e98bd9aed855f4034a5918476650484f83d"
 		;;
 esac
 


### PR DESCRIPTION
Combined update for Go and its bootstrap package. Can be split into different PRs if needed, but given that they're tied together, it didn't make much sense to do so.