### PR TITLE
libdwarf: Fix conflict with elfutils-devel

### DIFF
--- a/srcpkgs/libdwarf/template
+++ b/srcpkgs/libdwarf/template
@@ -1,9 +1,9 @@
 # Template file for 'libdwarf'
 pkgname=libdwarf
 version=20191104
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--prefix=/usr --enable-shared"
+configure_args="--enable-shared --enable-dwarfgen"
 makedepends="elfutils-devel"
 short_desc="DWARF Debugging Information Format Library"
 maintainer="John Regan <john@jrjrtech.com>"
@@ -13,24 +13,20 @@ distfiles="https://prevanders.net/${pkgname}-${version}.tar.gz"
 checksum=86119a9f7c409dc31e02d12c1b3906b1fce0dcb4db3d7e65ebe1bae585cf08f8
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" elfutils-devel"
-	make_cmd="make HOSTCC=cc HOSTCFLAGS=-I./ HOSTLDFLAGS="
-
-	pre_build() {
-		# Makefile doesn’t use $HOSTLDFLAGS when using $HOSTCC
-		sed -i -e 's|\$(HOSTCC) \$(HOSTCFLAGS) \$(LDFLAGS)|\$(HOSTCC) \$(HOSTCFLAGS) \$(HOSTLDFLAGS)|' Makefile
-	}
+	hostmakedepends="elfutils-devel"
 fi
 
 post_install() {
 	rm -rf ${PKGDESTDIR}/usr/share/libdwarf/libdwarf-devel
+	mkdir ${DESTDIR}/usr/include/libdwarf
+	mv ${DESTDIR}/usr/include/*.h ${DESTDIR}/usr/include/libdwarf
 }
 
 libdwarf-devel_package() {
 	short_desc+=" - development files"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
-		vmove usr/include
+		vmove "usr/include/libdwarf"
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.a"
 	}
@@ -40,7 +36,8 @@ libdwarf-doc_package() {
 	archs=noarch
 	short_desc+=" - documentation"
 	pkg_install() {
-		install -dm755 $PKGDESTDIR/usr/share/doc/${pkgname}
-		install -m644 README NEWS libdwarf/*.pdf $PKGDESTDIR/usr/share/doc/${pkgname}
+		for i in README NEWS libdwarf/*.pdf ; do
+			vdoc $i
+		done
 	}
 }


### PR DESCRIPTION
Just like Debian did to avoid conflict, move headers
to /usr/include/libdwarf
Closes #17130 

Signed-off-by: Nathan Owens <ndowens04@gmail.com>