### PR TITLE
bochs: fix build on BE

### DIFF
--- a/srcpkgs/bochs/patches/endian.patch
+++ b/srcpkgs/bochs/patches/endian.patch
@@ -1,0 +1,19 @@
+Some endian-conditional functions had incorrect signatures on BE hosts.
+
+--- bochs.h
++++ bochs.h
+@@ -627,12 +627,12 @@ BX_CPP_INLINE void WriteHostWordToLittleEndian(Bit16u *hostPtr, Bit16u nativeVar
+   *(hostPtr) = bx_bswap16(nativeVar16);
+ }
+ 
+-BX_CPP_INLINE void WriteHostDWordToLittleEndian(Bit8u *hostPtr, Bit32u nativeVar32)
++BX_CPP_INLINE void WriteHostDWordToLittleEndian(Bit32u *hostPtr, Bit32u nativeVar32)
+ {
+   *(hostPtr) = bx_bswap32(nativeVar32);
+ }
+ 
+-BX_CPP_INLINE void WriteHostQWordToLittleEndian(Bit8u *hostPtr, Bit64u nativeVar64)
++BX_CPP_INLINE void WriteHostQWordToLittleEndian(Bit64u *hostPtr, Bit64u nativeVar64)
+ {
+   *(hostPtr) = bx_bswap64(nativeVar64);
+ }


### PR DESCRIPTION
Some recent refactoring (conversions from macros to funcs) broke BE builds by having wrong types in signatures. The patch fixes that and has already been submitted upstream.