### PR TITLE
kicad: update to 5.1.5.

### DIFF
--- a/srcpkgs/kicad-footprints/template
+++ b/srcpkgs/kicad-footprints/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-footprints'
 pkgname=kicad-footprints
-version=5.1.3
+version=5.1.5
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-footprints/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=decdb0263caf9f09afb1be1ee0682cd4be120aa4605451542a1b5f46cbb8a67d
+checksum=c2bb5a126e49020134b75dc27d2ee4a9cd56cf300bb16c397ac580fd43339f76

--- a/srcpkgs/kicad-i18n/template
+++ b/srcpkgs/kicad-i18n/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-i18n'
 pkgname=kicad-i18n
-version=5.1.3
+version=5.1.5
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=3438dc35534f478e6328ba29f86468f976b4213159ea1d6cefe3bf3413e99090
+checksum=aec6902def684ffee62bb7d84edc167151d555ab743cc81b10053207b4e842a3

--- a/srcpkgs/kicad-library/template
+++ b/srcpkgs/kicad-library/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-library'
 pkgname=kicad-library
-version=5.1.3
+version=5.1.5
 revision=1
 build_style=meta
 depends="kicad-footprints>=${version} kicad-packages3D>=${version}

--- a/srcpkgs/kicad-packages3D/template
+++ b/srcpkgs/kicad-packages3D/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-packages3D'
 pkgname=kicad-packages3D
-version=5.1.3
+version=5.1.5
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-packages3D/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=2a772541154eaac6804ce6ade7ac8b1c4ee84c7a915b2f2a448e58586f5c9740
+checksum=b1c35e686865faf8a9b08d3843b188e90b4088f0b1e5f3f0393fac833a22a749

--- a/srcpkgs/kicad-symbols/template
+++ b/srcpkgs/kicad-symbols/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-symbols'
 pkgname=kicad-symbols
-version=5.1.3
+version=5.1.5
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-symbols/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=9fa8c747996518788c93ddab92e2e623db8b0b275de323bf018c062730e98778
+checksum=47abb25a88e8f2d9a623d21476bb7ee5a60f5e68e55dcf388842610f0bad7e06

--- a/srcpkgs/kicad-templates/template
+++ b/srcpkgs/kicad-templates/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-templates'
 pkgname=kicad-templates
-version=5.1.3
+version=5.1.5
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-templates/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=29b7f878ed414bce38a0913b53357f44f69e4c4cb5d3b90f7358b71c26a49964
+checksum=f08f857eee9b88cc89d1579c66046e01d752cf696d468d8ac2465066d379e406

--- a/srcpkgs/kicad/template
+++ b/srcpkgs/kicad/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad'
 pkgname=kicad
-version=5.1.3
+version=5.1.5
 revision=1
 build_style=cmake
 configure_args="-DKICAD_BUILD_VERSION=${version} -DKICAD_SCRIPTING=ON
@@ -17,7 +17,7 @@ maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://kicad-pcb.org"
 distfiles="https://launchpad.net/${pkgname}/${version%%.*}.0/${version}/+download/${pkgname}-${version}.tar.xz"
-checksum=724e338fccdcec30e644b96d569ea5e198d9de040a9b98a78a878782d136871d
+checksum=80625a1da876e1be683dc08268fe43fe67bb704e841e977431f7a82bdc096474
 build_options="spice"
 build_options_default="spice"
 


### PR DESCRIPTION
[ci skip]
Built locally on `x86_64{,-musl}` `armv7hf{,-musl}` `aarch64` as travis runs into timeouts.
Tested on `x86_64`.
@Hoshpak you merged a couple of commits of the maintainer. I don't know how to highlight them here, maybe you know how.