### PR TITLE
azote: update to 1.7.7

### DIFF
--- a/srcpkgs/azote/template
+++ b/srcpkgs/azote/template
@@ -1,18 +1,18 @@
 # Template file for 'azote'
 pkgname=azote
-version=1.7.4
+version=1.7.7
 revision=1
 archs=noarch
 build_style=python3-module
 pycompile_module="azote"
 hostmakedepends="python3-setuptools"
-depends="python3>=3.4 python3-setuptools python3-gobject python3-Pillow python3-send2trash gtk+3 feh xrandr grim slurp maim"
-short_desc="Wallpaper manager for Sway, i3 and some other WMs"
+depends="python3>=3.4 python3-setuptools python3-gobject python3-Pillow gtk+3 feh python3-send2trash xrandr grim slurp maim ImageMagick python3-yaml"
+short_desc="Wallpaper & color manager for Sway, i3 and other WMs"
 maintainer="Piotr Miller <nwg.piotr@gmail.com>"
 license="BSD-3-Clause, GPL-3.0-or-later"
 homepage="https://github.com/nwg-piotr/azote"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=617248a0506b78dd3f1f924b34b0b958e3af58a218e93918086f9294a453a3fd
+checksum=d1da9c8a0760e4a0e85fd5c77632d4f6763f779ac0852e706fc8fb8f286bc402
 
 post_install() {
 	vmkdir usr/bin


### PR DESCRIPTION
[v1.7.7](https://github.com/nwg-piotr/azote/releases/tag/v1.7.5)

- Added Image menu button: available in the top right thumbnail corner; turn on in preferences and use if the context menu not always appears on right mouse click (this may happen on Sway running with older gtk+ versions).

[v1.7.5](https://github.com/nwg-piotr/azote/releases/tag/v1.7.5)

- Color picker altered;
- Toolboxes for .Xresources and alacritty.yml added;
- Colour names dictionary added.