### PR TITLE
python3-astroid: update to 2.3.3.

### DIFF
--- a/srcpkgs/python-lazy-object-proxy/template
+++ b/srcpkgs/python-lazy-object-proxy/template
@@ -1,18 +1,18 @@
 # Template file for 'python-lazy-object-proxy'
 pkgname=python-lazy-object-proxy
-version=1.3.1
-revision=3
+version=1.4.3
+revision=1
 wrksrc="lazy-object-proxy-${version}"
 build_style=python-module
+pycompile_module="lazy_object_proxy"
 hostmakedepends="python-setuptools python3-setuptools"
 makedepends="python-devel python3-devel"
-pycompile_module="lazy_object_proxy"
 short_desc="Fast and thorough lazy object proxy (Python2)"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="BSD-2-Clause"
 homepage="https://github.com/ionelmc/python-lazy-object-proxy"
-license="2-clause-BSD"
 distfiles="${PYPI_SITE}/l/lazy-object-proxy/lazy-object-proxy-${version}.tar.gz"
-checksum=eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a
+checksum=f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python-wrapt/template
+++ b/srcpkgs/python-wrapt/template
@@ -1,18 +1,18 @@
 # Template file for 'python-wrapt'
 pkgname=python-wrapt
-version=1.10.11
-revision=3
+version=1.11.2
+revision=1
 wrksrc="wrapt-${version}"
 build_style=python-module
+pycompile_module="wrapt"
 hostmakedepends="python-setuptools python3-setuptools"
 makedepends="python-devel python3-devel"
-pycompile_module="wrapt"
 short_desc="Python2 module for decorators, wrappers and monkey patching"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="BSD-2-Clause"
 homepage="https://github.com/GrahamDumpleton/wrapt"
-license="2-clause-BSD"
 distfiles="${PYPI_SITE}/w/wrapt/wrapt-${version}.tar.gz"
-checksum=d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6
+checksum=565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-astroid/template
+++ b/srcpkgs/python3-astroid/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-astroid'
 pkgname=python3-astroid
-version=2.2.5
-revision=2
+version=2.3.3
+revision=1
 archs=noarch
 wrksrc="astroid-${version}"
 build_style=python3-module
@@ -9,12 +9,15 @@ pycompile_module="astroid"
 hostmakedepends="python3-setuptools"
 depends="python3-six python3-lazy-object-proxy python3-wrapt
  python3-typed-ast"
+checkdepends="$depends python3-attrs python3-pytest python3-wcwidth
+ python3-py python3-pluggy python3-more-itertools python3-importlib_metadata
+ python3-parsing python3-zipp"
 short_desc="Abstract syntax tree for Python3"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://github.com/PyCQA/astroid"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="https://github.com/PyCQA/astroid"
 distfiles="${PYPI_SITE}/a/astroid/astroid-${version}.tar.gz"
-checksum=6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4
+checksum=71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a
 
 post_install() {
 	# no tests


### PR DESCRIPTION
python3-astroid depends on python3-wrapt depends on python3-lazy-oobject