### PR TITLE
d-feet: noarch, fix runtime dependencies

### DIFF
--- a/srcpkgs/d-feet/template
+++ b/srcpkgs/d-feet/template
@@ -1,15 +1,16 @@
 # Template file for 'd-feet'
 pkgname=d-feet
 version=0.3.15
-revision=1
+revision=2
+archs=noarch
 build_style=meson
-maintainer="Enno Boland <gottox@voidlinux.org>"
+pycompile_module="dfeet"
 hostmakedepends="pkg-config intltool itstool python3-pycodestyle"
 makedepends="gtk+3-devel gobject-introspection"
-depends="python-gobject gir-freedesktop libwnck"
-pycompile_module="dfeet"
-license="GPL-2"
+depends="gtk+3 libwnck python3-gobject"
+short_desc="D-Bus debugger"
+maintainer="Enno Boland <gottox@voidlinux.org>"
+license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/action/show/Apps/DFeet"
-short_desc="A D-Bus debugger"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=1fff149ad01ccbd93c927f5733346a9122324b9d367da3adbf4f1a52e47dfdb1


### PR DESCRIPTION
Fixes:
```
$ d-feet
Traceback (most recent call last):
  File "/usr/bin/d-feet", line 43, in <module>
    import gi
ModuleNotFoundError: No module named 'gi'
```