### PR TITLE
cmus: use libatomic on ppc32 + unbreak on armv6l

### DIFF
--- a/srcpkgs/cmus/patches/pass-ldlibs.patch
+++ b/srcpkgs/cmus/patches/pass-ldlibs.patch
@@ -1,0 +1,24 @@
+Description: Pass LDLIBS to the linker
+ Needed to pass -latomic at the end so that we can fix a FTBFS on various
+ architectures.
+Author: Ryan Kavanagh <rak@debian.org>
+Origin: Debian
+Bug-Debian: http://bugs.debian.org/935678
+Forwarded: no
+Reviewed-by: Ryan Kavanagh <rak@debian.org>
+Last-Update: 2019-09-07
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: cmus/Makefile
+===================================================================
+--- Makefile	2019-09-07 10:02:00.152453147 -0400
++++ Makefile	2019-09-07 10:24:55.009937454 -0400
+@@ -22,7 +22,7 @@
+ FFMPEG_LIBS += $(shell pkg-config --libs libswresample)
+ 
+ CMUS_LIBS = $(PTHREAD_LIBS) $(NCURSES_LIBS) $(ICONV_LIBS) $(DL_LIBS) $(DISCID_LIBS) \
+-			-lm $(COMPAT_LIBS) $(LIBSYSTEMD_LIBS)
++			-lm $(COMPAT_LIBS) $(LIBSYSTEMD_LIBS) $(LDLIBS)
+ 
+ command_mode.o input.o main.o ui_curses.o op/pulse.lo: .version
+ command_mode.o input.o main.o ui_curses.o op/pulse.lo: CFLAGS += -DVERSION=\"$(VERSION)\"

--- a/srcpkgs/cmus/template
+++ b/srcpkgs/cmus/template
@@ -21,10 +21,9 @@ build_options_default="elogind"
 desc_option_elogind="Support MPRIS interface via elogind"
 
 case $XBPS_TARGET_MACHINE in
-	armv6*)
-		broken="needs libatomic workaround"
+	armv6*|ppc*)
 		makedepends+=" libatomic-devel"
-		LDFLAGS+=" -latomic"
+		export LDLIBS+=" -latomic"
 		;;
 esac
 


### PR DESCRIPTION
Giving this a CI run for cross.