### PR TITLE
containers.image: add dockerhub registry

### DIFF
--- a/srcpkgs/containers.image/patches/dockerhub.patch
+++ b/srcpkgs/containers.image/patches/dockerhub.patch
@@ -1,0 +1,11 @@
+--- registries.conf
++++ registries.conf
+@@ -9,7 +9,7 @@
+ # Registries to search for images that are not fully-qualified.
+ # i.e. foobar.com/my_image:latest vs my_image:latest
+ [registries.search]
+-registries = []
++registries = ['docker.io']
+ 
+ # Registries that do not use TLS when pulling images or uses self-signed
+ # certificates.


### PR DESCRIPTION
podman is almost useless without this line, so I think it should be installed with the package