### PR TITLE
hugo: add extended version build option

### DIFF
--- a/srcpkgs/hugo/template
+++ b/srcpkgs/hugo/template
@@ -4,6 +4,7 @@ version=0.60.1
 revision=1
 build_style=go
 go_import_path="github.com/gohugoio/${pkgname}"
+go_build_tags="$(vopt_if extended extended)"
 hostmakedepends="git"
 depends="$(vopt_if pygments python-Pygments)"
 short_desc="Fast & Modern Static Website Engine"
@@ -13,8 +14,9 @@ homepage="https://gohugo.io"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
 checksum=5c857cb27a4e1b43477f6775f2b2e870b937e9ebf32f52347ba7fdbde1ee50f7
 
-build_options="pygments"
+build_options="pygments extended"
 desc_option_pygments="Alternative syntax highlighter"
+desc_option_extended="SASS/SCSS build support for Hugo"
 
 post_install() {
 	vdoc README.md


### PR DESCRIPTION
Hi, first time contributor here :D
This enables the extended version of hugo to be built using xbps-src

Thanks for your work, void is awesome