### PR TITLE
xbps-src: account for nonfree repo with -E

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -306,7 +306,7 @@ get_subpkgs() {
 
 setup_pkg() {
     local pkg="$1" cross="$2" show_problems="$3"
-    local basepkg val _vars f dbgflags arch
+    local basepkg val _vars f dbgflags arch extrarepo
 
     [ -z "$pkg" ] && return 1
     basepkg=${pkg%-32bit}
@@ -455,7 +455,11 @@ setup_pkg() {
         arch="$XBPS_TARGET_MACHINE"
     fi
     if [ -n "$XBPS_BINPKG_EXISTS" ]; then
-        if [ "$($XBPS_QUERY_XCMD -i -R -ppkgver $pkgver 2>/dev/null)" = "$pkgver" ]; then
+        # nonfree packages need this otherwise they'll rebuild even with -E
+        if [ -n "$repository" ]; then
+            extrarepo=" --repository=$XBPS_REPOSITORY/$repository"
+        fi
+        if [ "$($XBPS_QUERY_XCMD $extrarepo -i -R -ppkgver $pkgver 2>/dev/null)" = "$pkgver" ]; then
             exit_and_cleanup
         fi
     fi


### PR DESCRIPTION
This makes sure nonfree packages don't get rebuilt when -E is passed to xbps-src.