### PR TITLE
vagrant: enable building for x86_64-musl

### DIFF
--- a/srcpkgs/vagrant/template
+++ b/srcpkgs/vagrant/template
@@ -1,8 +1,8 @@
 # Template file for 'vagrant'
 pkgname=vagrant
 version=2.2.6
-revision=1
-archs="i686 x86_64"
+revision=2
+archs="i686 x86_64*"
 hostmakedepends="ruby"
 makedepends="ruby-devel zlib-devel"
 depends="bsdtar curl openssh rsync"


### PR DESCRIPTION
Vagrant builds & works under musl (since it's a Ruby application), but `archs` only specify `i686 x86_64`. This PR simply change archs to use `x86_64*` so it builds under musl.