### PR TITLE
common/shlibs: add missing libglvnd libs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -151,6 +151,8 @@ libnvidia-fatbinaryloader.so.390.132 nvidia390-libs-390.132_1 ignore
 libnvidia-fatbinaryloader.so.430.40 nvidia-libs-430.40_1 ignore
 libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
+libOpenGL.so.0 libglvnd-1.3.0_1
+libGLX.so.0 libglvnd-1.3.0_1
 librsvg-2.so.2 librsvg-2.26.0_1
 libdbus-1.so.3 dbus-libs-1.2.10_1
 libdbus-glib-1.so.2 dbus-glib-0.80_1


### PR DESCRIPTION
These are linked against when using .pc files, cmake FindOpenGL and so on, so lots of things will now complain about shlibs being missing.

I found out about this when trying to build `SLADE`, but lots of other things are going to be affected.