### PR TITLE
monero: unbreak by using bundled rapidjson

### DIFF
--- a/srcpkgs/monero/template
+++ b/srcpkgs/monero/template
@@ -1,8 +1,10 @@
 # Template file for 'monero'
 pkgname=monero
 version=0.15.0.1
-revision=1
+revision=2
 _randomx_version="1.1.6"
+# the revision monero uses as a submodule for the specific version
+_rapidjson_gitrev="129d19ba7f496df5e33658527a7158c79b99c21c"
 build_style=cmake
 configure_args="-DBUILD_GUI_DEPS=ON -DHAVE_LIBRESSL=1"
 conf_files="/etc/monerod.conf"
@@ -12,16 +14,18 @@ make_dirs="
 hostmakedepends="pkg-config qt5-host-tools"
 makedepends="libressl-devel boost-devel libldns-devel libunwind-devel
  readline-devel unbound-devel miniupnpc-devel expat-devel
- cppzmq czmq-devel rapidjson libsodium-devel"
+ cppzmq czmq-devel libsodium-devel"
 short_desc="Private, secure, untraceable, decentralised digital currency"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="BSD-3-Clause"
 homepage="https://getmonero.org"
 distfiles="https://github.com/monero-project/monero/archive/v${version}.tar.gz
- https://github.com/tevador/RandomX/archive/v${_randomx_version}.tar.gz"
+ https://github.com/tevador/RandomX/archive/v${_randomx_version}.tar.gz
+ https://github.com/Tencent/rapidjson/archive/${_rapidjson_gitrev}.tar.gz"
 checksum="c4863d7e689d8f794d64e6236671f743fb478f782d259ce81ce805cd679500f8
- cf7946ff5f53401f24146e1472ec54f02338729147fdae091c831920acc390bb"
-skip_extraction="v${_randomx_version}.tar.gz}"
+ cf7946ff5f53401f24146e1472ec54f02338729147fdae091c831920acc390bb
+ 44b007d419ac21b6affec58991e865ee572346ead19b73cf1c3e4e11c7a81273"
+skip_extraction="v${_randomx_version}.tar.gz ${_rapidjson_gitrev}.tar.gz"
 system_accounts="monero"
 
 if [ "$CROSS_BUILD" ]; then
@@ -45,6 +49,8 @@ case "$XBPS_TARGET_MACHINE" in
 		makedepends+=" libatomic-devel"
 		CFLAGS+=" -latomic"
 	;;
+	ppc64le*) configure_args+=" -DARCH=ppc64le"
+	;;
 	ppc64*) configure_args+=" -DARCH=ppc64"
 	;;
 	ppc*) configure_arch+=" -DARCH=ppc"
@@ -62,6 +68,8 @@ esac
 post_extract() {
 	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/v${_randomx_version}.tar.gz \
 		--strip-components=1 -C ${wrksrc}/external/randomx
+	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_rapidjson_gitrev}.tar.gz \
+		--strip-components=1 -C ${wrksrc}/external/rapidjson
 }
 
 pre_configure() {


### PR DESCRIPTION
The `rapidjson` 1.1.0 we ship is too old (2016). Monero uses a newer version as a submodule in git. Using the older system version resulted in wallets not working, always reporting invalid password, at least on `ppc64le`.

Also use correct `ARCH` on `ppc64le`. (was found to be irrelevant later, but still)