### PR TITLE
cinnamon: add backport fix for cinnamon-settings crash

### DIFF
--- a/srcpkgs/cinnamon/patches/6e7ea0640ddb97d54febfbb76ac0e5cd0c0349d4.patch
+++ b/srcpkgs/cinnamon/patches/6e7ea0640ddb97d54febfbb76ac0e5cd0c0349d4.patch
@@ -1,0 +1,22 @@
+From 6e7ea0640ddb97d54febfbb76ac0e5cd0c0349d4 Mon Sep 17 00:00:00 2001
+From: Stephen Collins <scrivera64@gmail.com>
+Date: Sat, 14 Sep 2019 10:47:29 -0600
+Subject: [PATCH] cs_default.py: fix missing declaration causing crash when
+ desc not found (#8855)
+
+---
+ .../cinnamon/cinnamon-settings/modules/cs_default.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+index 85a90d6c2b..5c23e4da9c 100755
+--- files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
++++ files/usr/share/cinnamon/cinnamon-settings/modules/cs_default.py
+@@ -443,6 +443,7 @@ def acceptContentType(self, content_type):
+         return True
+ 
+     def getDescription(self, content_type):
++        description = None
+         for d in other_defs:
+             if content_type == d[DEF_CONTENT_TYPE]:
+                 s = d[DEF_LABEL]

--- a/srcpkgs/cinnamon/template
+++ b/srcpkgs/cinnamon/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon'
 pkgname=cinnamon
 version=4.2.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile
  --enable-compile-warnings=no --disable-gtk-doc"


### PR DESCRIPTION
See https://github.com/linuxmint/cinnamon/issues/8872

Also fixed in >=4.4.0, but I lack the time to do that update.