### PR TITLE
git: update to 2.24.1

### DIFF
--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,7 +1,7 @@
 # Template file for 'git'
 pkgname=git
-version=2.24.0
-revision=2
+version=2.24.1
+revision=1
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2
  ac_cv_snprintf_returns_bogus=no"
@@ -16,7 +16,7 @@ license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=9f71d61973626d8b28c4cdf8e2484b4bf13870ed643fed982d68b2cfd754371b
+checksum=723f24dce8fdd621a308b6187553fce7d5244205c065fe0a3aebd0b7c3f88562
 replaces="git-perl>=0"
 register_shell=/usr/bin/git-shell
 


### PR DESCRIPTION
Updated to 2.24.1 which has a fix
for CVE-2019-19604

Signed-off-by: Nathan Owens <ndowens04@gmail.com>