### PR TITLE
mpd: add cap_sys_nice to binary.

### DIFF
--- a/srcpkgs/mpd/INSTALL
+++ b/srcpkgs/mpd/INSTALL
@@ -1,0 +1,5 @@
+case "$ACTION" in
+post)
+	setcap 'cap_sys_nice=eip' usr/bin/mpd
+	;;
+esac

--- a/srcpkgs/mpd/template
+++ b/srcpkgs/mpd/template
@@ -1,7 +1,7 @@
 # Template file for 'mpd'
 pkgname=mpd
 version=0.21.16
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
  -Dsoundcloud=enabled -Dpipe=true -Dtwolame=enabled -Dbzip2=enabled
@@ -27,6 +27,7 @@ makedepends="avahi-glib-libs-devel boost-devel faad2-devel ffmpeg-devel
  $(vopt_if libao 'libao-devel') $(vopt_if mpcdec 'libmpcdec-devel')
  $(vopt_if pulseaudio 'pulseaudio-devel') $(vopt_if sndio 'sndio-devel')
  $(vopt_if wavpack 'wavpack-devel') $(vopt_if openal 'libopenal-devel')"
+depends="libcap-progs"
 short_desc="Flexible, powerful, server-side application for playing music"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
This patch adds a capability to the `mpd` binary, such that it is permitted (as a normal user) to create real-time threads for smooth playback on busy machines (such as a heavily used desktop.)

Signed-off-by: Joseph Benden <joe@benden.us>