### PR TITLE
libtorrent-rasterbar: update to 1.2.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1970,7 +1970,7 @@ libldns.so.3 libldns-1.7.1_1
 libopenjpeg.so.5 libopenjpeg-1.5.2_1
 liboping.so.0 liboping-1.8.0_1
 libloudmouth-1.so.0 loudmouth-1.4.3_1
-libtorrent-rasterbar.so.9 libtorrent-rasterbar-1.1.1_1
+libtorrent-rasterbar.so.10 libtorrent-rasterbar-1.2.2_1
 libcapstone.so.4 capstone-4.0_1
 libhavege.so.1 libhaveged-1.9.1_1
 libnih.so.1 libnih-1.0.3_1

--- a/srcpkgs/btfs/template
+++ b/srcpkgs/btfs/template
@@ -1,7 +1,7 @@
 # Template file for 'btfs'
 pkgname=btfs
 version=2.20
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="boost-devel fuse-devel libcurl-devel libtorrent-rasterbar-devel"

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,9 +1,11 @@
 # Template file for 'libtorrent-rasterbar'
 pkgname=libtorrent-rasterbar
-version=1.1.13
-revision=3
+version=1.2.2
+revision=1
 build_style=gnu-configure
-configure_args="--enable-examples --enable-python-binding --with-boost=${XBPS_CROSS_BASE}/usr --with-boost-python=boost_python36"
+configure_args="--enable-examples --enable-python-binding
+ --with-boost=${XBPS_CROSS_BASE}/usr
+ --with-boost-python=boost_python${py3_ver//./}"
 hostmakedepends="automake pkg-config intltool libtool python3-devel"
 makedepends="libressl-devel boost-devel geoip-devel python3-devel"
 short_desc="C++ bittorrent library by Rasterbar Software"
@@ -11,12 +13,20 @@ maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
 distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
-checksum=30040719858e3c06634764e0c1778738eb42ecd0b45e814afa746329a948ead7
+checksum=e579261d7f0acbe82e9b4ce703cb721627cb8075023f8a26405992f489bc6202
+
+case "$XBPS_TARGET_MACHINE" in
+	armv[56]*|mips*|ppc|ppc-musl)
+		makedepends+=" libatomic-devel"
+		LDFLAGS+=" -latomic"
+		;;
+esac
 
 pre_configure() {
-	export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python3.6m"
-	export PYTHON_CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python3.6m"
-	export PYTHON_EXTRA_LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -lpython3.6m"
+	local _py3_ver=${py3_ver}${py3_abiver}
+	export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python${_py3_ver}"
+	export PYTHON_CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python${_py3_ver}"
+	export PYTHON_EXTRA_LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${_py3_ver}"
 	autoreconf -fi
 }
 

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
 version=4.2.0
-revision=1
+revision=2
 create_wrksrc=yes
 build_style=qmake
 hostmakedepends="automake libtool pkg-config qt5-host-tools qt5-qmake qt5-tools"


### PR DESCRIPTION
* qbittorrent-4.2.0 now supports libtorrent-rasterbar 1.2.x (which was
  the only package blocking this update)
* Use `py3_ver` rather than hardcoding python36
* Tested this on x86_64, together with qbittorrent, btfs and deluge, which
  uses libtorrent's python3 binding.