### PR TITLE
common/rust.sh: set CARGO_HOME to /host/cargo

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -2,6 +2,7 @@
 # [build]
 # jobs = $XBPS_MAKEJOBS
 export CARGO_BUILD_JOBS="$XBPS_MAKEJOBS"
+export CARGO_HOME="/host/cargo"
 
 if [ "$CROSS_BUILD" ]; then
 	# Define equivalent of TOML config in environment


### PR DESCRIPTION
currently cargo chaches everything in /tmp/.cargo and is not shared
between masterdirs