### PR TITLE
New package: python3-py3dns-3.2.1

### DIFF
--- a/srcpkgs/python3-py3dns/template
+++ b/srcpkgs/python3-py3dns/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-py3dns'
+pkgname=python3-py3dns
+version=3.2.1
+revision=1
+archs="noarch"
+wrksrc="py3dns-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Python3 DNS library"
+maintainer="Nathan Owens <ndowens04@gmail.com>"
+license="CNRI-Python"
+homepage="https://launchpad.net/py3dns"
+distfiles="${PYPI_SITE}/p/py3dns/py3dns-${version}.tar.gz"
+checksum=1f07d4463e98d9859ce0280c3eaa57da670ad623f6d4d3285c67dca23d7045e4
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
New package is compatible with python3,
while the current python-pydns is not

Signed-off-by: Nathan Owens <ndowens04@gmail.com>