### PR TITLE
New package: intel-media-driver-19.3.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3704,3 +3704,4 @@ libtss2-tcti-mssim.so.0 tpm2-tss-2.3.1_1
 libtss2-tctildr.so.0 tpm2-tss-2.3.1_1
 libzfs.so.2 zfs-0.8.2_1
 libnvpair.so.1 zfs-0.8.2_1
+libigdgmm.so.12 intel-gmmlib-19.3.4_1

--- a/srcpkgs/intel-gmmlib-devel
+++ b/srcpkgs/intel-gmmlib-devel
@@ -1,0 +1,1 @@
+intel-gmmlib

--- a/srcpkgs/intel-gmmlib/template
+++ b/srcpkgs/intel-gmmlib/template
@@ -1,0 +1,29 @@
+# Template file for 'intel-gmmlib'
+pkgname=intel-gmmlib
+version=19.3.4
+revision=1
+archs="i686* x86_64*"
+wrksrc=gmmlib-intel-gmmlib-${version}
+build_style=cmake
+short_desc="Intel Graphics Memory Management Library"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="MIT"
+homepage="https://github.com/intel/gmmlib"
+distfiles="https://github.com/intel/gmmlib/archive/intel-gmmlib-${version}.tar.gz"
+checksum=5f08e36892db6bff8284913d9ab784f693d50e4ea1eb2ea6d2545e3dc6876b71
+
+lib32disabled=yes
+
+post_install() {
+	vlicense LICENSE.md
+}
+
+intel-gmmlib-devel_package() {
+	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/intel-media-driver-devel
+++ b/srcpkgs/intel-media-driver-devel
@@ -1,0 +1,1 @@
+intel-media-driver

--- a/srcpkgs/intel-media-driver/template
+++ b/srcpkgs/intel-media-driver/template
@@ -1,0 +1,35 @@
+# Template file for 'intel-media-driver'
+pkgname=intel-media-driver
+version=19.3.1
+revision=1
+archs="i686* x86_64*"
+wrksrc=media-driver-intel-media-${version}
+build_style=cmake
+configure_args="-DENABLE_NONFREE_KERNELS=$(vopt_if nonfree ON OFF)"
+hostmakedepends="pkg-config"
+makedepends="libva-devel libX11-devel intel-gmmlib-devel libpciaccess-devel"
+short_desc="Intel Media Driver for VAAPI (Broadwell+)"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="MIT, BSD-3-Clause"
+homepage="https://github.com/intel/media-driver"
+distfiles="https://github.com/intel/media-driver/archive/intel-media-${version}.tar.gz"
+checksum=637471705567cc20d88aab0fdb552f62c9b3c530512765436642a1ec9f36134c
+
+lib32disabled=yes
+
+build_options="nonfree"
+desc_option_nonfree="Enable nonfree kernels"
+
+post_install() {
+	vlicense LICENSE.md
+}
+
+intel-media-driver-devel_package() {
+	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
https://github.com/intel/media-driver
> The Intel(R) Media Driver for VAAPI is a new VA-API (Video Acceleration API) user mode driver supporting hardware accelerated decoding, encoding, and video post processing for GEN based graphics hardware.

This is a new `libva` backend for Broadwell+ GPUs. Also introduces a dependent library package. Is package naming fine? Other backends are currently called `libva-*`. I think this only makes sense on `i686* x86_64*` archs.
Tested on `x86_64-musl`