### PR TITLE
crystal: update to 0.32.0.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,10 +1,10 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.31.1
-revision=2
+version=0.32.0
+revision=1
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
-_bootstrapversion=0.31.1
+_bootstrapversion=0.32.0
 _bootstraprevision=1
 hostmakedepends="git llvm8"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -19,7 +19,7 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="b4a51164763b891572492e2445d3a69b462675184ea0ccf06fcc57a070f07b80
+checksum="c1705f6502e410ceff10ef4cafc859aadb2d0858a699311f923f7f6e7e8ce81a
  90f230c87cc7b94ca845e6fe34f2523edcadb562d715daaf98603edfa2a94d65"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -32,11 +32,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" 308a5891322287852ba492e6e0dcc1484af361c189525349b6b98b531c551a65"
+		checksum+=" 608db8d2a2296792022dad7a351ca96496e2565fbf16ac0172a66f6720d601eb"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 394bfe422bd2e74b6c5a99d31dcd873ec3f25c3f06834e1dd779efa2a36d3143"
+		checksum+=" 66de8a1554a21618521650cb51285048848f068fbec1fd6c4d9c0cd1bc67b75b"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"


### PR DESCRIPTION
- Compilation was locally tested with both i686 and x86_64
- Package was locally installed on x86_64, `crystal` and `shards` work good
- Issue with multi-threading: it is (still) not possible to compile programs with the `-Dpreview_mt` flag. See #14858