### PR TITLE
fiche: enable configuration via a conf file

### DIFF
--- a/srcpkgs/fiche/files/fiche/run
+++ b/srcpkgs/fiche/files/fiche/run
@@ -1,2 +1,4 @@
 #!/bin/sh
-exec chpst -u _fiche:_fiche fiche -d yourdomain.com -o /var/tmp/fiche -l /var/log/fiche/log
+[ -r ./conf ] && source ./conf
+
+exec chpst -u _fiche:_fiche fiche ${OPTS:--o /var/tmp/fiche -l /var/log/fiche/log -L 127.0.0.1}


### PR DESCRIPTION
`fiche` does not have any configuration file
and is configured through it's command line
arguments. As with other runscripts for similar
services sourcing an optional `conf` file for
those options is better than having to edit the
runscript.