### PR TITLE
mkvtoolnix: move mkvtoolnix-gui to separate package, build cross

### DIFF
--- a/srcpkgs/mkvtoolnix-gui
+++ b/srcpkgs/mkvtoolnix-gui
@@ -1,0 +1,1 @@
+mkvtoolnix

--- a/srcpkgs/mkvtoolnix/template
+++ b/srcpkgs/mkvtoolnix/template
@@ -1,11 +1,11 @@
 # Template file for 'mkvtoolnix'
 pkgname=mkvtoolnix
 version=41.0.0
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper=qmake
 configure_args="--with-docbook-xsl-root=/usr/share/xsl/docbook --enable-qt"
-hostmakedepends="autoconf docbook-xsl libxslt pkg-config ruby"
+hostmakedepends="autoconf docbook-xsl libxslt pkg-config qt5-tools-devel ruby"
 makedepends="boost-devel cmark-devel file-devel json-c++
  libflac-devel libmatroska-devel libvorbis-devel pugixml-devel
  qt5-multimedia-devel qt5-tools-devel"
@@ -29,4 +29,20 @@ do_build() {
 }
 do_install() {
 	rake DESTDIR=${DESTDIR} install
+}
+
+mkvtoolnix-gui_package() {
+	short_desc+=" - Qt GUI"
+	depends="${sourcepkg}-${version}_${revision}"
+	pkg_install() {
+		vmove usr/bin/mkvtoolnix-gui
+		vmove usr/share/applications
+		for file in "${DESTDIR}"/usr/share/icons/hicolor/*/apps/mkvtoolnix-gui.png; do
+			vmove "${file/${DESTDIR}\//}"
+		done
+		vmove usr/share/man/man1/mkvtoolnix-gui.1
+		vmove usr/share/metainfo
+		vmove usr/share/mime/packages
+		vmove usr/share/mkvtoolnix/sounds
+	}
 }


### PR DESCRIPTION
This moves `mkvtoolnix-gui` to its own package, saving >200 MB of installed deps when the GUI is not needed.

@pullmoll: Sorry if this makes the package somewhat more annoying to maintain. If you have better things to do, I'd be willing to adopt it.