### PR TITLE
nss: update to 3.48

### DIFF
--- a/srcpkgs/nspr/template
+++ b/srcpkgs/nspr/template
@@ -1,6 +1,6 @@
 # Template file for 'nspr'
 pkgname=nspr
-version=4.23
+version=4.24
 revision=1
 build_wrksrc=nspr
 build_style=gnu-configure
@@ -10,7 +10,7 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="http://www.mozilla.org/projects/nspr/"
 distfiles="${MOZILLA_SITE}/nspr/releases/v${version}/src/${pkgname}-${version}.tar.gz"
-checksum=4b9d821037faf5723da901515ed9cac8b23ef1ea3729022259777393453477a4
+checksum=90a59a0df6a11528749647fe18401cc7e03881e3e63c309f8c520ce06dd413d0
 
 do_configure() {
 	CFLAGS="$CFLAGS -D_PR_POLL_AVAILABLE -D_PR_HAVE_OFF64_T -D_PR_INET6 -D_PR_HAVE_INET_NTOP -D_PR_HAVE_GETHOSTBYNAME2 -D_PR_HAVE_GETADDRINFO -D_PR_INET6_PROBE"

--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -1,9 +1,9 @@
 # Template file for 'nss'
 
-_nsprver=4.23
+_nsprver=4.24
 
 pkgname=nss
-version=3.47.1
+version=3.48
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,11 +13,12 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=1ae3d1cb1de345b258788f2ef6b10a460068034c3fd64f42427a183d8342a6fb
+checksum=3f9c822a86a4e3e1bfe63e2ed0f922d8b7c2e0b7cafe36774b1c627970d0f8ac
 
 do_build() {
 	# Respect LDFLAGS
-	sed -e 's/\$(MKSHLIB) -o/\$(MKSHLIB) \$(LDFLAGS) -o/g' -i nss/coreconf/rules.mk
+	vsed -e 's/\$(MKSHLIB) -o/\$(MKSHLIB) \$(LDFLAGS) -o/g' \
+		-i nss/coreconf/rules.mk
 
 	export LIBRUNPATH=
 	export BUILD_OPT=1
@@ -25,6 +26,8 @@ do_build() {
 	export NSS_ENABLE_WERROR=0
 	export NSS_ENABLE_ECC=1
 	export FREEBL_NO_DEPEND=1
+	export NATIVE_CC="$BUILD_CC"
+	export NATIVE_FLAGS="$BUILD_CFLAGS"
 
 	case "$XBPS_MACHINE" in
 		aarch64*|x86_64*|ppc64*) _native_use64="USE_64=1";;
@@ -32,8 +35,7 @@ do_build() {
 
 	cd nss
 	# Build nsinstall for host.
-	make CC=$BUILD_CC LD=$BUILD_LD CFLAGS="$BUILD_CFLAGS" LDFLAGS="$BUILD_LDFLAGS" \
-		${_native_use64} -C coreconf
+	make LD=$BUILD_LD LDFLAGS="$BUILD_LDFLAGS" ${_native_use64} -C coreconf
 
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
@@ -65,6 +67,26 @@ do_build() {
 		make ${_native_use64} -C lib/dbm
 		make ${_native_use64}
 	fi
+}
+
+do_check() {
+	export LIBRUNPATH=
+	export BUILD_OPT=1
+	export NSS_USE_SYSTEM_SQLITE=1
+	export NSS_ENABLE_WERROR=0
+	export NSS_ENABLE_ECC=1
+	export FREEBL_NO_DEPEND=1
+	export NATIVE_CC="$BUILD_CC"
+	export NATIVE_FLAGS="$BUILD_CFLAGS"
+	# We couldn't run test in cross compile!
+	export NSPR_INCLUDE_DIR=/usr/include/nspr
+	export NSPR_LIB_DIR=/usr/lib
+	export XCFLAGS="${CFLAGS}"
+	case "$XBPS_MACHINE" in
+		aarch64*|x86_64*|ppc64*) _use_64="USE_64=1";;
+	esac
+	cd nss/tests
+	env $_use_64 HOST=localhost DOMSUF=localdomain ./all.sh
 }
 
 do_install() {


### PR DESCRIPTION
- also update nspr because nss 3.48 requires nspr 4.24
- [x] ./xbps-check -m x86_64 check nss
- [x] ./xbps-check -m x86_64-musl check nss
- [x] ./xbps-check -m i686 check nss
- [x] run with firefox on x86_64
- [x] run with firefox on x86_64-musl
- [x] run with firefox-esr on i686