### PR TITLE
base-files: install /usr/lib32 symlink on i686

### DIFF
--- a/common/hooks/post-install/00-lib32.sh
+++ b/common/hooks/post-install/00-lib32.sh
@@ -1,7 +1,8 @@
-# This hook removes the /usr/lib32 symlink on x86.
+# This hook removes the /usr/lib32 symlink on 32-bit systems.
 
 hook() {
-	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+	if [ "$XBPS_TARGET_WORDSIZE" = "32" ] && \
+	   [ "${pkgname}" != "base-files" ]; then
 		rm -f ${PKGDESTDIR}/usr/lib32
 	fi
 }

--- a/common/hooks/pre-install/00-lib32.sh
+++ b/common/hooks/pre-install/00-lib32.sh
@@ -1,7 +1,8 @@
-# This hook creates the /usr/lib32 symlink for x86.
+# This hook creates the /usr/lib32 symlink for 32-bit systems.
 
 hook() {
-	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+	if [ "$XBPS_TARGET_WORDSIZE" = "32" ] && \
+	   [ "${pkgname}" != "base-files" ]; then
 		vmkdir usr/lib
 		ln -sf lib ${PKGDESTDIR}/usr/lib32
 	fi

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.140
-revision=9
+revision=10
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
@xtraeme follow up to #17009 -- seems like i686 is missing `/usr/lib32 -> /usr/lib` without this. `binary-bootstrap i686` from x86_64 (and perhaps other arches) is broken without it.

Workaround: `ln -s lib /path/to/rootfs/usr/lib32`

Documented occurrences in the wild:

- https://www.reddit.com/r/voidlinux/comments/eapt4s/xbpssrc_error_after_installing_binarybootstrap/
- https://www.reddit.com/r/voidlinux/comments/e9xvbn/i686_rootfs_no_longer_usable/