### PR TITLE
WebStorm: update to 2019.3

### DIFF
--- a/srcpkgs/WebStorm/template
+++ b/srcpkgs/WebStorm/template
@@ -1,16 +1,16 @@
 # Template file for 'WebStorm'
 pkgname=WebStorm
-version=2019.2.3
+version=2019.3
 revision=1
 archs="i686 x86_64"
-wrksrc="WebStorm-192.6817.13"
-depends="virtual?java-environment"
+wrksrc="WebStorm-193.5233.80"
+depends="jetbrains-jdk-bin"
 short_desc="Smartest JavaScript IDE"
 maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="custom:Commercial"
 homepage="https://www.jetbrains.com/webstorm"
 distfiles="https://download.jetbrains.com/webstorm/WebStorm-${version}.tar.gz"
-checksum=af94c66c80508fe221d9ba2b294d3852d68db8bc293dd240e2638dd2c21a6c50
+checksum=63ffa9d500182909078356157dd4c7ee97abfc55c51bced45d71423c7230e593
 repository=nonfree
 restricted=yes
 nopie=yes
@@ -36,8 +36,6 @@ post_extract() {
 			rm -rf lib/pty4j-native/linux/x86_64
 			;;
 	esac
-
-	rm -rf jre64
 }
 
 do_install() {
@@ -51,6 +49,8 @@ do_install() {
 		vlicense $i
 	done
 
+	mkdir -p /usr/lib/jvm/jbrsdk
+	ln -sf /usr/lib/jvm/jbrsdk ${DESTDIR}/${TARGET_PATH}/jbr
 	vcopy bin ${TARGET_PATH}
 	vcopy help ${TARGET_PATH}
 	vcopy lib ${TARGET_PATH}


### PR DESCRIPTION
Update `WebStorm` to 2019.3
Additionally depend on JetBrains' Java runtime instead of any installed Java runtime.