### PR TITLE
rpi-kernel: update to 4.19.89.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="988cc7beacc150756c3fbe40646afcf8438b741b"
+_githash="edc6ef437bd690772d7a562adeea6c85daf11440"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.88
+version=4.19.89
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=d743a92b3d94973876dd7513044d4d8b119091ab8e66fcee3d0623e1c09d1d6d
+checksum=c96d9b6351b4876f5b1296decea8d3d71b06021abc22398df1bbd962a6ffc52a
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv7l.