### PR TITLE
New packages: libnvidia-container-1.0.5 and nvidia-container-runtime-…

### DIFF
--- a/srcpkgs/libnvidia-container/INSTALL
+++ b/srcpkgs/libnvidia-container/INSTALL
@@ -1,0 +1,8 @@
+# INSTALL
+case "$ACTION" in
+post)
+	# create symlink for the dynamic library
+	ln -s /usr/lib/libnvidia-container.so.1.0.5 /usr/lib/libnvidia-container.so 
+	ln -s /usr/lib/libnvidia-container.so.1.0.5 /usr/lib/libnvidia-container.so.1 
+	;;
+esac

--- a/srcpkgs/libnvidia-container/REMOVE
+++ b/srcpkgs/libnvidia-container/REMOVE
@@ -1,0 +1,10 @@
+#
+# This script remove the vlc plugins cache files.
+#
+
+case "${ACTION}" in
+post)
+	rm /usr/lib/libnvidia-container.so
+	rm /usr/lib/libnvidia-container.so.1
+	;;
+esac

--- a/srcpkgs/libnvidia-container/patches/fix_git_rev_unavail.patch
+++ b/srcpkgs/libnvidia-container/patches/fix_git_rev_unavail.patch
@@ -1,0 +1,10 @@
+--- mk/common.mk
++++ mk/common.mk
+@@ -21,7 +21,7 @@ DOCKER   ?= docker
+ UID      := $(shell id -u)
+ GID      := $(shell id -g)
+ DATE     := $(shell date -u --iso-8601=minutes)
+-REVISION := $(shell git rev-parse HEAD)
++REVISION := 0000000000000000000000000000000000000000
+ COMPILER := $(realpath $(shell which $(CC)))
+ PLATFORM ?= $(shell uname -m)

--- a/srcpkgs/libnvidia-container/patches/fix_makefile.patch
+++ b/srcpkgs/libnvidia-container/patches/fix_makefile.patch
@@ -1,0 +1,74 @@
+--- Makefile	2019-12-13 17:33:01.482513754 +0100
++++ Makefile	2019-12-13 17:33:01.482513754 +0100
+
+@@ -13,7 +13,7 @@
+
+ ##### Global definitions #####
+
+-export prefix      = /usr/local
++export prefix      = /usr
+ export exec_prefix = $(prefix)
+ export bindir      = $(exec_prefix)/bin
+ export libdir      = $(exec_prefix)/lib
+
+@@ -106,21 +106,22 @@
+ ##### Flags definitions #####
+
+ # Common flags
+-CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 $(CPPFLAGS)
+-CFLAGS   := -std=gnu11 -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fvisibility=hidden \
++CPPFLAGS := -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -fPIC $(CPPFLAGS)
++CFLAGS   := -std=gnu11 -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fvisibility=hidden -fPIC \
+             -Wall -Wextra -Wcast-align -Wpointer-arith -Wmissing-prototypes -Wnonnull \
+             -Wwrite-strings -Wlogical-op -Wformat=2 -Wmissing-format-attribute -Winit-self -Wshadow \
+             -Wstrict-prototypes -Wunreachable-code -Wconversion -Wsign-conversion \
+-            -Wno-unknown-warning-option -Wno-format-extra-args -Wno-gnu-alignof-expression $(CFLAGS)
++            -Wno-unknown-warning-option -Wno-format-extra-args -Wno-gnu-alignof-expression \
++            -I/usr/include/tirpc $(CFLAGS)
+ LDFLAGS  := -Wl,-zrelro -Wl,-znow -Wl,-zdefs -Wl,--gc-sections $(LDFLAGS)
+ LDLIBS   := $(LDLIBS)
+
+ # Library flags (recursively expanded to handle target-specific flags)
+-LIB_CPPFLAGS       = -DNV_LINUX -isystem $(DEPS_DIR)$(includedir) -include $(BUILD_DEFS)
++LIB_CPPFLAGS       = -fPIC -DNV_LINUX -isystem $(DEPS_DIR)$(includedir) -include $(BUILD_DEFS)
+ LIB_CFLAGS         = -fPIC
+ LIB_LDFLAGS        = -L$(DEPS_DIR)$(libdir) -shared -Wl,-soname=$(LIB_SONAME)
+ LIB_LDLIBS_STATIC  = -l:libnvidia-modprobe-utils.a
+-LIB_LDLIBS_SHARED  = -ldl -lcap
++LIB_LDLIBS_SHARED  = -ldl -lcap -ltirpc
+ ifeq ($(WITH_LIBELF), yes)
+ LIB_CPPFLAGS       += -DWITH_LIBELF
+ LIB_LDLIBS_SHARED  += -lelf
+
+@@ -149,6 +150,10 @@
+ BIN_LDFLAGS        = -L. -pie $(LDFLAGS) -Wl,-rpath='$$ORIGIN/../$$LIB'
+ BIN_LDLIBS         = -l:$(LIB_SHARED) -lcap $(LDLIBS)
+
++ifeq ($(WITH_TIRPC), yes)
++BIN_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
++endif
++
+ $(word 1,$(LIB_RPC_SRCS)): RPCGENFLAGS=-h
+ $(word 2,$(LIB_RPC_SRCS)): RPCGENFLAGS=-c
+ $(word 3,$(LIB_RPC_SRCS)): RPCGENFLAGS=-m
+
+@@ -215,15 +220,14 @@
+
+ static: $(LIB_STATIC)($(LIB_STATIC_OBJ))
+
+-deps: export DESTDIR:=$(DEPS_DIR)
+ deps: $(LIB_RPC_SRCS) $(BUILD_DEFS)
+ 	$(MKDIR) -p $(DEPS_DIR)
+-	$(MAKE) -f $(MAKE_DIR)/nvidia-modprobe.mk install
++	$(MAKE) -f $(MAKE_DIR)/nvidia-modprobe.mk DESTDIR=$(DEPS_DIR) install
+ ifeq ($(WITH_LIBELF), no)
+-	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk install
++	$(MAKE) -f $(MAKE_DIR)/elftoolchain.mk DESTDIR=$(DEPS_DIR) install
+ endif
+ ifeq ($(WITH_TIRPC), yes)
+-	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk install
++	$(MAKE) -f $(MAKE_DIR)/libtirpc.mk DESTDIR=$(DEPS_DIR) install
+ endif
+
+ install: all
+

--- a/srcpkgs/libnvidia-container/patches/fix_nvc.c.patch
+++ b/srcpkgs/libnvidia-container/patches/fix_nvc.c.patch
@@ -1,0 +1,20 @@
+--- src/nvc.c	2019-09-05 01:45:00.000000000 +0200
++++ src/nvc.c	2019-12-13 17:35:30.692519318 +0100
+@@ -189,13 +189,13 @@
+                 }
+
+                 log_info("loading kernel module nvidia");
+-                if (nvidia_modprobe(0, -1) == 0)
++                if (nvidia_modprobe(0) == 0)
+                         log_err("could not load kernel module nvidia");
+                 else {
+-                        if (nvidia_mknod(NV_CTL_DEVICE_MINOR, -1) == 0)
++                        if (nvidia_mknod(NV_CTL_DEVICE_MINOR) == 0)
+                                 log_err("could not create kernel module device node");
+                         for (int i = 0; i < (int)devs.num_matches; ++i) {
+-                                if (nvidia_mknod(i, -1) == 0)
++                                if (nvidia_mknod(i) == 0)
+                                         log_err("could not create kernel module device node");
+                         }
+                 }
+

--- a/srcpkgs/libnvidia-container/patches/fix_nvidia-modprobe.mk.patch
+++ b/srcpkgs/libnvidia-container/patches/fix_nvidia-modprobe.mk.patch
@@ -1,0 +1,22 @@
+--- mk/nvidia-modprobe.mk	2019-09-05 01:45:00.000000000 +0200
++++ mk/nvidia-modprobe.mk	2019-12-13 17:30:21.884507802 +0100
+
+@@ -6,7 +6,7 @@
+
+ ##### Source definitions #####
+
+-VERSION        := 396.51
++VERSION        := 440.44
+ PREFIX         := nvidia-modprobe-$(VERSION)
+ URL            := https://github.com/NVIDIA/nvidia-modprobe/archive/$(VERSION).tar.gz
+
+@@ -22,7 +22,7 @@
+ ##### Flags definitions #####
+
+ ARFLAGS  := -rU
+-CPPFLAGS := -D_FORTIFY_SOURCE=2 -DNV_LINUX
++CPPFLAGS := -D_FORTIFY_SOURCE=2 -DNV_LINUX -fPIC
+ CFLAGS   := -O2 -g -fdata-sections -ffunction-sections -fstack-protector -fno-strict-aliasing -fPIC
+
+ ##### Private rules #####
+

--- a/srcpkgs/libnvidia-container/template
+++ b/srcpkgs/libnvidia-container/template
@@ -1,0 +1,41 @@
+# Template file for 'libnvidia-container'
+pkgname=libnvidia-container
+version=1.0.5
+revision=1
+archs="x86_64"
+build_style=meta
+hostmakedepends="tar curl bmake groff m4 pkg-config"
+makedepends="rpcsvc-proto libcap-devel libseccomp-devel libtirpc-devel"
+short_desc="NVIDIA container runtime library"
+maintainer="Soroush <soroosh.haeri@me.com>"
+license="Apache-2.0"
+homepage="https://github.com/NVIDIA/libnvidia-container"
+distfiles="https://github.com/NVIDIA/libnvidia-container/archive/v${version}.tar.gz"
+checksum="b0b1a03f33ce7afdc06c432c7e100b17dc1723420293c27201c50bcb9b851e5a"
+
+do_build() {
+	make dist prefix=/usr
+}
+
+pre_install() {
+	cd dist
+	tar xvf ${pkgname}_${version}_${archs}.tar.xz
+}
+
+do_install() {
+	# install lib files
+	vinstall dist/${pkgname}_${version}/usr/lib/${pkgname}.a 644 /usr/lib/
+	vinstall dist/${pkgname}_${version}/usr/lib/${pkgname}.so.${version} 755 /usr/lib/
+	# create symlink
+	vinstall dist/${pkgname}_${version}/usr/lib/debug/usr/lib/${pkgname}.so.1 755  /usr/lib/debug/usr/lib/
+	vinstall dist/${pkgname}_${version}/usr/lib/pkgconfig/${pkgname}.pc 644 /usr/lib/pkgconfig/
+	# put docs in place
+	vdoc dist/${pkgname}_${version}/usr/share/doc/libnvidia-container-1.0.5/COPYING
+	vdoc dist/${pkgname}_${version}/usr/share/doc/libnvidia-container-1.0.5/COPYING.LESSER
+	vdoc dist/${pkgname}_${version}/usr/share/doc/libnvidia-container-1.0.5/LICENSE
+	vdoc dist/${pkgname}_${version}/usr/share/doc/libnvidia-container-1.0.5/NOTICE
+	# put binary in place
+	vbin dist/${pkgname}_${version}/usr/bin/nvidia-container-cli
+	# put includes
+	vinstall dist/${pkgname}_${version}/usr/include/nvc.h 644 /usr/include/
+}

--- a/srcpkgs/nvidia-container-runtime/INSTALL
+++ b/srcpkgs/nvidia-container-runtime/INSTALL
@@ -1,0 +1,7 @@
+# INSTALL
+case "$ACTION" in
+post)
+	# actions to execute if package is being installed.
+	ln -s /usr/bin/nvidia-container-toolkit /usr/bin/nvidia-container-runtime-hook
+	;;
+esac

--- a/srcpkgs/nvidia-container-runtime/REMOVE
+++ b/srcpkgs/nvidia-container-runtime/REMOVE
@@ -1,0 +1,9 @@
+#
+# This script remove the vlc plugins cache files.
+#
+
+case "${ACTION}" in
+post)
+	rm /usr/bin/nvidia-container-runtime-hook
+	;;
+esac

--- a/srcpkgs/nvidia-container-runtime/template
+++ b/srcpkgs/nvidia-container-runtime/template
@@ -1,0 +1,50 @@
+# Template file for 'nvidia-container-runtime'
+pkgname=nvidia-container-runtime
+version=3.1.4
+revision=1
+hostmakedepends="curl go git"
+makedepends="libseccomp-devel"
+depends="containerd runc libnvidia-container"
+short_desc="Modified version of runc adding a custom pre-start hook"
+maintainer="Soroush Haeri <soroosh.haeri@me.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/NVIDIA/nvidia-container-runtime/"
+distfiles="https://github.com/NVIDIA/nvidia-container-runtime/archive/v${version}.tar.gz"
+checksum="32bd9f49a1392253dccbfebc850b980b6d7cbd1b2621b06ced4fbe952c918038"
+
+pre_build() {
+	go get github.com/BurntSushi/toml
+	mkdir -p .gopath/src
+	ln -rTsf $PWD/runtime/src .gopath/src/${pkgname}
+	ln -rTsf $PWD/toolkit/nvidia-container-toolkit  .gopath/src/nvidia-container-toolkit
+	export GOPATH=$PWD/.gopath/
+}
+
+do_build() {
+	# Build the container runtime
+	go build \
+	  -buildmode=pie \
+	  -gcflags "all=-trimpath=${PWD}" \
+	  -asmflags "all=-trimpath=${PWD}" \
+	  "$pkgname"
+	# Build the container toolkit
+	go build \
+	  -buildmode=pie \
+	  -gcflags "all=-trimpath=${PWD}" \
+	  -asmflags "all=-trimpath=${PWD}" \
+	  nvidia-container-toolkit
+}
+
+do_install() {
+	vbin nvidia-container-runtime
+	vbin nvidia-container-toolkit
+}
+
+post_install() {
+	# Docker requires a nvidia-container-runtime-hook
+	echo [nvidia-container-runtime] > config.toml
+	echo debug = \"/var/log/nvidia-container-runtime\" >> config.toml
+	vmkdir /etc/nvidia-container-runtime 755
+	vinstall config.toml 755 /etc/nvidia-container-runtime
+	vlicense LICENSE
+}


### PR DESCRIPTION
…3.1.4

There are 2 packages added in order to enable using Nvidia devices in
containers. This has been tested with docker containers.
Two packages are included in one commit since the nvidia-container-runtime
package depends on libnvidia-container.

This commit resolves: #11084.
Even though the package requst is for the nvidia-docker
(https://github.com/NVIDIA/nvidia-docker) package,
as of Docker 19.03, docker recognize GPU devices, therefore, the nvidia-docker
library is not required anymore (https://github.com/NVIDIA/nvidia-docker).
Since the current version of docker on the void-packages is 19.03.5,
the nvidia-docker library would not be required to be included in the void packages.

libnvidia-container (https://github.com/NVIDIA/libnvidia-container) and
nvidia-container-runtime (https://github.com/NVIDIA/nvidia-container-runtime)
are required to be installed to add nvidia runtime to Docker.