### PR TITLE
python-smbc: Change to python3

### DIFF
--- a/srcpkgs/python-smbc/template
+++ b/srcpkgs/python-smbc/template
@@ -3,22 +3,10 @@ pkgname=python-smbc
 version=1.0.16
 revision=1
 wrksrc="pysmbc-${version}"
-build_style=python-module
-pycompile_module="smbc"
-hostmakedepends="pkg-config python-devel python3-devel python-setuptools
- python3-setuptools"
-makedepends="python-devel python3-devel samba-devel"
-short_desc="Python2 bindings for libsmbclient"
+build_style=meta
+short_desc="Python2 bindings for libsmbclient (Removed package)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/hamano/pysmbc"
 distfiles="${PYPI_SITE}/p/pysmbc/pysmbc-${version}.tar.bz2"
 checksum=62199b5cca02c05d5f3b9edbc9a864fb8a2cbe47a465c0b9461642eb3b6f5aca
-
-python3-smbc_package() {
-	pycompile_module="smbc"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-	}
-}

--- a/srcpkgs/python3-smbc
+++ b/srcpkgs/python3-smbc
@@ -1,1 +1,0 @@
-python-smbc

--- a/srcpkgs/python3-smbc/template
+++ b/srcpkgs/python3-smbc/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-smbc'
+pkgname=python3-smbc
+version=1.0.17
+revision=1
+wrksrc="pysmbc-${version}"
+build_style=python3-module
+pycompile_module="smbc"
+hostmakedepends="pkg-config python3-devel python3-setuptools"
+makedepends="python3-devel samba-devel"
+short_desc="Python3 bindings for libsmbclient"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/hamano/pysmbc"
+distfiles="${PYPI_SITE}/p/pysmbc/pysmbc-${version}.tar.bz2"
+checksum=1bc47dea9bb8d38b3a1793a8e98b97baac8f8b266db623e044434602fe236da4

--- a/srcpkgs/python3-smbc/update
+++ b/srcpkgs/python3-smbc/update
@@ -1,0 +1,1 @@
+pkgname="pysmbc"


### PR DESCRIPTION
Change python-smbc to meta, for removal.
Update python3-smbc to 1.0.17

Signed-off-by: Nathan Owens <ndowens04@gmail.com>