### PR TITLE
xorg-server: enable glamor/xwayland for armv7l

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=1.20.6
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb
@@ -34,7 +34,7 @@ build_options="elogind"
 desc_option_elogind="Rootless Xorg support with elogind"
 
 case "$XBPS_TARGET_MACHINE" in
-i686*|x86_64*|aarch64*|ppc*)
+i686*|x86_64*|aarch64*|ppc*|armv7l*)
 	# Enable glamor/dri/opengl/xwayland by default.
 	configure_args+=" -Dglamor=true -Ddri2=true -Ddri3=true -Dglx=true -Dxwayland=true"
 	replaces+=" glamor-egl>=0"


### PR DESCRIPTION
Raspberry Pi (32-bit) supports Glamor through the VC4 Mesa driver.

![](https://i.imgur.com/tAZmuYz.png)