### PR TITLE
openjdk8: update to 8u242b01

### DIFF
--- a/srcpkgs/openjdk8/template
+++ b/srcpkgs/openjdk8/template
@@ -3,8 +3,8 @@
 # TODO: make -headless versions
 # TODO: config files?
 _java_ver=8
-_jdk_update=232
-_jdk_build=09
+_jdk_update=242
+_jdk_build=01
 _main_ver=${_java_ver}u${_jdk_update}
 _final_jdk_home="usr/lib/jvm/java-1.8-openjdk"
 pkgname=openjdk8
@@ -52,14 +52,14 @@ distfiles="
  http://hg.openjdk.java.net/aarch64-port/jdk8u-shenandoah/langtools/archive/${_repo_ver}.tar.gz>langtools-${_repo_ver}.tar.gz
  http://hg.openjdk.java.net/aarch64-port/jdk8u-shenandoah/nashorn/archive/${_repo_ver}.tar.gz>nashorn-${_repo_ver}.tar.gz"
 
-checksum="9c08eb72cb3f46e8b03d4c4ef186dccbecb823e4eef3003e61fd9631bab825ec
- a8473d48ea87ee4213f24dfbf665bf5259ce31946ba128358666d11415a03c18
- 90a28984c1ae55ab18b8deab8c3459c47f03aaaac2d0fc50f36012b74007610d
- 98f75b028a07d0737c4d401ba1fd3ea7ecfbfe7fc914ff4fd218ac9e3ba5995e
- 3f8f8183c35b5343f10490cbecc477036c4032bda9584ce4e065a1d1ee877d3f
- 7426e95cde9dc816bd9d3ab44c8eea2a2dc97cb2e9905ec900d56b888e8b7def
- 376205b35a9d43e38808171b3be9e07c2211613f694c8be60af2e326905caab3
- 9cd16a9ed8feed26a485f6df296f4900cb6de6a70b50e5c6bb03198623d1773a"
+checksum="f251afdc71f252c4d2559f9d49cbce3128ffcba2185b5d3a0e7020d5d214bab7
+ 27590eaa48dcddaf9a8aa305333b5e619acede415f7a091afd9cca8fd69ccf85
+ af73a2b1a6bf2d59e5c2cb87253844c2969489f37ac6ad352c60599ea8a7e116
+ 7ecb436b63feceec86b0aefca3b95e2b03d08503a26233b0d5f09441826925db
+ 93bbcdfa489d4e5b68a7ccc5faf92ef74ea5ac5b2e3f93314158ea50624fd1c2
+ 6bd28277bb73c29d189c70ca2d61263e698406d89e54403c09f19a4e852a703a
+ 287d716a3f4ecd8a7c2e579a7514a0998c0164f544084cc90d8a476813663904
+ e272f22edc8f43c4c2dfcce6073b7689332a05014ead734dff24537a49e23682"
 
 build_options="docs"
 desc_option_docs="Build documentation"


### PR DESCRIPTION
Successfully built for
- [x] x86_64
- [x] x86_64-musl
- [x] i686
- [x] i686-musl
- [x] aarch64
- [x] aarch64-musl
- [x] armv7l
- [x] armv7l-musl
- [x] armv6l
- [x] armv6l-musl
- [x] armv5tel
- [x] armv5tel-musl
- [x] ppc
- [x] ppc-musl
- [x] ppc64
- [x] ppc64-musl
- [x] ppc64le
- [x] ppc64le-musl
[ci skip]