### PR TITLE
rpi-kernel: enable Steam HID driver

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -10,7 +10,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
 version=4.19.89
-revision=1
+revision=2
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
@@ -89,6 +89,9 @@ do_configure() {
 	echo "CONFIG_IR_RC6_DECODER=m" >> "$defconfig"
 	echo "CONFIG_IR_MCEUSB=m" >> "$defconfig"
 
+	# HID Controllers
+	echo "CONFIG_HID_STEAM=y" >> "$defconfig"
+	
 	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
 
 	# Always use our revision to CONFIG_LOCALVERSION to match our pkg version.


### PR DESCRIPTION
[skip ci]

Enable HID support for the Steam Controller and family (for X11, Kodi, and Steam Link apps).