### PR TITLE
ogmrip: remove gconf-devel from makedepends

### DIFF
--- a/srcpkgs/ogmrip/template
+++ b/srcpkgs/ogmrip/template
@@ -1,11 +1,11 @@
 # Template file for 'ogmrip'
 pkgname=ogmrip
 version=1.0.1
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="intltool pkg-config"
-makedepends="GConf-devel dbus-glib-devel enca-devel enchant2-devel lame-devel
+makedepends="dbus-glib-devel enca-devel enchant2-devel lame-devel
  libdvdread-devel libglade-devel libnotify-devel libtheora-devel mplayer
  vorbis-tools x264-devel xvidcore-devel"
 depends="desktop-file-utils mplayer vorbis-tools ogmtools mkvtoolnix tesseract-ocr"
@@ -22,7 +22,6 @@ pre_configure() {
 
 post_install() {
 	# Remove development stuff.
-	rm -r ${DESTDIR}/etc/gconf
 	rm -r ${DESTDIR}/usr/include
 	rm -r ${DESTDIR}/usr/lib/pkgconfig
 }


### PR DESCRIPTION
Remove gconf-devel from makedepends, as a step toward #17254

Signed-off-by: Nathan Owens <ndowens04@gmail.com>