### PR TITLE
vscode: remove GConf dependency

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,10 +1,10 @@
 # Template file for 'vscode'
 pkgname=vscode
 version=1.41.1
-revision=1
+revision=2
 hostmakedepends="pkg-config python nodejs-lts yarn"
 makedepends="libxkbfile-devel libsecret-devel"
-depends="GConf libXtst libxkbfile nss dejavu-fonts-ttf"
+depends="libXtst libxkbfile nss dejavu-fonts-ttf"
 short_desc="Microsoft Code for Linux"
 maintainer="shizonic <realtiaz@gmail.com>"
 license="MIT"


### PR DESCRIPTION
GConf is not needed and also a step toward #17254

Signed-off-by: Nathan Owens <ndowens04@gmail.com>