### PR TITLE
containerd: update to 1.3.2

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,11 +1,10 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=1.1.7
+version=1.3.2
 revision=1
 build_style=go
 go_import_path=github.com/containerd/containerd
 go_package="${go_import_path}/cmd/containerd
- ${go_import_path}/cmd/containerd-release
  ${go_import_path}/cmd/containerd-shim
  ${go_import_path}/cmd/ctr"
 go_ldflags="-X ${go_import_path}/version.Version=${version}
@@ -19,12 +18,12 @@ maintainer="Paul Knopf <pauldotknopf@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=4cbf55c85f5e6dd08afa13bf72cc426fba43eacb545f6b69c0fcb62acac900d8
+checksum=1ac07660f693aac0df48638090e1c528a056dbe19c4136bbe0c74fa865399b96
 make_dirs="/var/lib/containerd 0755 root root"
 
 post_build() {
 	# Build the man pages
-	for _i in ctr.1 containerd.1 config.toml.5 containerd-config.1 ; do
+	for _i in containerd-config.toml.5 containerd-config.1 ; do
 		go-md2man -in "docs/man/$_i.md" -out "docs/man/$_i"
 	done
 }
@@ -32,7 +31,7 @@ post_build() {
 post_install() {
 	vsv containerd
 
-	for _i in ctr.1 containerd.1 config.toml.5 containerd-config.1 ; do
+	for _i in containerd-config.toml.5 containerd-config.1 ; do
 		vman docs/man/$_i
 	done
 }


### PR DESCRIPTION
Is there a reason that this package is so far behind (+1000 commits since the last version), when Docker and runc are up-to-date?

I also don't know how to resolve this go build error:
```sh
#package github.com/containerd/containerd/cmd/containerd-release:
#/builddir/containerd-1.3.2/_build-containerd-xbps/src/github.com/containerd/containerd
#exists but
#/builddir/containerd-1.3.2/_build-containerd-xbps/src/github.com/containerd/containerd/.git
#does not - stale checkout?
```