### PR TITLE
zabbix: update to 4.4.4rc2

### DIFF
--- a/srcpkgs/zabbix/template
+++ b/srcpkgs/zabbix/template
@@ -1,7 +1,7 @@
 # Template file for 'zabbix'
 pkgname=zabbix
-version=4.2.1
-revision=3
+version=4.4.4rc2
+revision=1
 build_style=gnu-configure
 configure_args="--with-libxml2 --with-gnutls --with-libcurl --with-net-snmp
  --with-mysql --enable-server --enable-ipv6 --with-ssh2 --enable-agent
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.zabbix.com"
 changelog="https://www.zabbix.com/rn/rn${version}"
 distfiles="${SOURCEFORGE_SITE}/zabbix/zabbix-${version}.tar.gz"
-checksum=4915d52352163e40398ca9b56b8176ea369dfd475e291087c50a3d9ae2459076
+checksum=789fc736107d517703a7cb23cc12085472b1f5b0bde44611361b18ef7527db46
 conf_files="/etc/zabbix_server.conf"
 system_accounts="_zabbix_server"
 system_groups="_zabbix_server"


### PR DESCRIPTION
will fix frontend errors with php as described here https://support.zabbix.com/browse/ZBX-16751