### PR TITLE
[TESTERS NEEDED] empathy: update to 3.25.90.

### DIFF
--- a/srcpkgs/empathy/template
+++ b/srcpkgs/empathy/template
@@ -1,27 +1,33 @@
 # Template file for 'empathy'
 pkgname=empathy
-version=3.12.14
+version=3.25.90
 revision=1
-disable_parallel_build=yes
 build_style=gnu-configure
-configure_args="
- --enable-gst-1.0=yes --enable-gudev=yes --enable-spell=yes
+configure_args="--enable-gst-1.0=yes --enable-gudev=yes --enable-spell=yes
  --disable-schemas-compile --disable-static --enable-goa=no
  --enable-ubuntu-online-accounts=no --enable-geocode=yes
  --enable-location=yes --enable-nautilus-sendto=no --enable-map=yes"
 hostmakedepends="pkg-config intltool gnome-doc-utils itstool"
-makedepends="
- libcanberra-devel clutter-gst-devel clutter-gtk-devel
+makedepends="libcanberra-devel gst-plugins-bad1-devel clutter-gtk-devel
  telepathy-glib-devel telepathy-logger-devel libnotify-devel
  telepathy-farstream-devel telepathy-mission-control-devel
  evolution-data-server-devel geocode-glib-devel folks-devel
  webkit2gtk-devel libgudev-devel pulseaudio-devel cheese-devel
  enchant-devel NetworkManager-devel libchamplain-devel
  gnutls-devel gsettings-desktop-schemas-devel geoclue2-devel iso-codes"
-depends="gsettings-desktop-schemas>=3.12 iso-codes"
+depends="gsettings-desktop-schemas>=3.12 iso-codes telepathy-mission-control"
 short_desc="GNOME instant messaging client using the Telepathy framework"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
 homepage="http://live.gnome.org/Empathy"
-license="GPL-2"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
-checksum=7d86942ce97edd10ade0e6ae6a210d35e4d627fe4d223377d71fd1840bc6e3a3
+checksum=cc9289d0180e23e566fb4972562d9ebd2bba2f457d9fb954f6d4b0ea9903c16a
+
+if [ "$CROSS_BUILD" ] ; then
+	hostmakedepends+=" glib-devel geoclue2"
+fi
+
+pre_configure() {
+	# help libempathy find account-widgets headers
+	ln -s telepathy-account-widgets/tp-account-widgets .
+}


### PR DESCRIPTION
Upon startup, i get
```
Error contacting the Account Manager

There was an error while trying to connect to the Telepathy Account
Manager. The error was:

The name org.freedesktop.Telepathy.AccountManager was not provided by any .service files
```
I suspect the issue is rooted in missing dbus / elogind/consolekit session on my machine.

If anyone could test, I'd be happy.