### PR TITLE
pangox-compat: patch to fix build w/ pango-1.44.7

### DIFF
--- a/srcpkgs/pangox-compat/patches/pango-1.44.7.patch
+++ b/srcpkgs/pangox-compat/patches/pango-1.44.7.patch
@@ -1,0 +1,92 @@
+Source: @pullmoll
+Upstream: no
+Reason: get rid of calls to functions obsoleted / removed in pango-1.44.7
+
+--- basic-x.c	2012-08-28 01:19:32.000000000 +0200
++++ basic-x.c	2019-12-17 14:51:15.823014546 +0100
+@@ -558,7 +558,9 @@
+ 		    const char       *text,
+-		    gint              length,
++		    unsigned int      length,
+ 		    const PangoAnalysis *analysis,
+-		    PangoGlyphString *glyphs)
++		    PangoGlyphString *glyphs,
++		    const char       *paragraph_text,
++		    unsigned int      paragraph_length)
+ {
+   int n_chars;
+   int i;
+--- pangox-fontmap.c	2012-08-28 01:19:32.000000000 +0200
++++ pangox-fontmap.c	2019-12-17 14:54:51.107005962 +0100
+@@ -941,12 +941,9 @@
+ pango_x_font_map_read_aliases (PangoXFontMap *xfontmap)
+ {
+   char **files;
+-  char *files_str = pango_config_key_get ("PangoX/AliasFiles");
++  char *files_str = g_strdup ("~/.pangox_aliases:" SYSCONFDIR "/pango/pangox.aliases");
+   int n;
+ 
+-  if (!files_str)
+-    files_str = g_strdup ("~/.pangox_aliases:" SYSCONFDIR "/pango/pangox.aliases");
+-
+   files = pango_split_file_list (files_str);
+ 
+   n = 0;
+--- pangox.c	2012-08-28 01:19:32.000000000 +0200
++++ pangox.c	2019-12-17 14:54:49.846006012 +0100
+@@ -76,9 +76,6 @@
+ static PangoFontDescription *pango_x_font_describe          (PangoFont        *font);
+ static PangoCoverage *       pango_x_font_get_coverage      (PangoFont        *font,
+ 							     PangoLanguage    *language);
+-static PangoEngineShape *    pango_x_font_find_shaper       (PangoFont        *font,
+-							     PangoLanguage    *language,
+-							     guint32           ch);
+ static void                  pango_x_font_get_glyph_extents (PangoFont        *font,
+ 							     PangoGlyph        glyph,
+ 							     PangoRectangle   *ink_rect,
+@@ -279,7 +276,6 @@
+ 
+   font_class->describe = pango_x_font_describe;
+   font_class->get_coverage = pango_x_font_get_coverage;
+-  font_class->find_shaper = pango_x_font_find_shaper;
+   font_class->get_glyph_extents = pango_x_font_get_glyph_extents;
+   font_class->get_metrics = pango_x_font_get_metrics;
+   font_class->get_font_map = pango_x_font_get_font_map;
+@@ -980,7 +980,7 @@
+       xfont->metrics_by_lang = g_slist_prepend (xfont->metrics_by_lang, info);
+ 
+       info->sample_str = sample_str;
+-      metrics = pango_font_metrics_new ();
++      metrics = pango_font_metrics_ref (NULL);
+ 
+       get_font_metrics_from_string (font, language, sample_str, metrics);
+ 
+@@ -989,7 +989,7 @@
+       info->metrics = metrics;
+     }
+ 
+-  return pango_font_metrics_ref (info->metrics);
++  return info->metrics;
+ }
+ 
+ static PangoFontMap *
+@@ -1368,19 +1364,6 @@
+   return pango_x_face_get_coverage (xfont->xface, font, language);
+ }
+ 
+-static PangoEngineShape *
+-pango_x_font_find_shaper (PangoFont     *font G_GNUC_UNUSED,
+-			  PangoLanguage *language,
+-			  guint32        ch)
+-{
+-  PangoMap *shape_map = NULL;
+-  PangoScript script;
+-
+-  shape_map = pango_x_get_shaper_map (language);
+-  script = pango_script_for_unichar (ch);
+-  return (PangoEngineShape *)pango_map_get_engine (shape_map, script);
+-}
+-
+ /* Utility functions */
+ 
+ static XCharStruct *

--- a/srcpkgs/pangox-compat/template
+++ b/srcpkgs/pangox-compat/template
@@ -1,18 +1,18 @@
 # Template file for 'pangox-compat'
 pkgname=pangox-compat
 version=0.0.2
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="pango-devel"
-replaces="pango<1.32"
 short_desc="Library for layout and rendering of text (pangox compat library)"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-2.1-or-later"
 homepage="http://www.pango.org/"
-license="LGPL-2.1"
 distfiles="${GNOME_SITE}/${pkgname}/0.0/${pkgname}-${version}.tar.xz"
 checksum=552092b3b6c23f47f4beee05495d0f9a153781f62a1c4b7ec53857a37dfce046
+replaces="pango<1.32"
 
 pangox-compat-devel_package() {
 	depends="libX11-devel pango-devel>=1.31 ${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
This needs to be tested with packages depending on `pangox-compat-devel`.