### PR TITLE
python3-pipx: added missing dependency

### DIFF
--- a/srcpkgs/python3-pipx/template
+++ b/srcpkgs/python3-pipx/template
@@ -1,13 +1,12 @@
 # Template file for 'python3-pipx'
 pkgname=python3-pipx
 version=0.14.0.0
-revision=1
+revision=2
 archs=noarch
 wrksrc="pipx-${version}"
 build_style=python3-module
-pycompile_module="pipx"
 hostmakedepends="python3-setuptools"
-depends="python3-argcomplete python3-userpath"
+depends="python3-argcomplete python3-userpath python3-click"
 short_desc="Install and Run Python Applications in Isolated Environments"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"


### PR DESCRIPTION
Closes https://github.com/void-linux/void-packages/issues/17563.