### PR TITLE
New package: bukubrow-host-5.1.0

### DIFF
--- a/srcpkgs/bukubrow-host/template
+++ b/srcpkgs/bukubrow-host/template
@@ -1,0 +1,11 @@
+# Template file for 'bukubrow-host'
+pkgname=bukubrow-host
+version=5.1.0
+revision=1
+build_style=cargo
+short_desc="Host application for the Bukubrow WebExtension"
+maintainer="Ramdziana F Y <ramdzian@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/SamHH/bukubrow-host"
+distfiles="https://github.com/SamHH/bukubrow-host/archive/v${version}.tar.gz"
+checksum="986d024d9a83062404993e40572f9cdbc1607cce15a2fac627ccd75ec944a9fe"


### PR DESCRIPTION
Host application for Bukubrow webextension. So, we can manage Buku bookmarks from Firefox, Chromium, and Google Chrome.

Website: https://github.com/SamHH/bukubrow-host