### PR TITLE
protonmail-bridge: update to 1.2.4.

### DIFF
--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,15 +1,16 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=1.2.3
+version=1.2.4
 revision=1
 archs="x86_64"
 build_style=fetch
+depends="desktop-file-utils"
 short_desc="ProtonMail Bridge for use with E-mail software"
 maintainer="Rich G <rich@richgannon.net>"
-license="Proprietary"
+license="custom:Commercial"
 homepage="https://protonmail.com/bridge"
 distfiles="https://protonmail.com/download/beta/protonmail-bridge_${version}-1_amd64.deb"
-checksum=1c9393010c7025af4465d69f2a491153c8295c64fd9dd53c10ae1e8e55769906
+checksum=2b213c2c82204fe21347c011f5ab61634bcbc0b1600f92310cc948b76fc6c6da
 
 restricted=yes
 noverifyrdeps=yes
@@ -19,4 +20,5 @@ do_install() {
 	ar x protonmail-bridge_${version}-1_amd64.deb data.tar.xz
 	tar xpvf data.tar.xz
 	cp -r usr ${DESTDIR}
+	vlicense usr/lib/protonmail/bridge/LICENSE
 }


### PR DESCRIPTION
Updates ProtonMail-Bridge to the latest version, and fixing a couple of lint warnings.

Signed-off-by: Joseph Benden <joe@benden.us>