### PR TITLE
shadow: reduce the number of suid programs

### DIFF
--- a/srcpkgs/shadow/template
+++ b/srcpkgs/shadow/template
@@ -1,11 +1,11 @@
 # Template file for 'shadow'
 pkgname=shadow
 version=4.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-shared --disable-static
  --with-libpam --without-selinux --with-acl --with-attr
- --disable-nls --enable-subordinate-ids"
+ --disable-nls --enable-subordinate-ids --disable-account-tools-setuid"
 hostmakedepends="automake gettext-devel libtool"
 makedepends="acl-devel pam-devel"
 depends="pam"


### PR DESCRIPTION
The defaults for what programs contained in shadow have the setuid bit
has changed in version 4.7, when using pam most of those tools don't
need setuid bits so explicitly disable them.

References:
* https://github.com/shadow-maint/shadow/pull/199
* https://bugs.archlinux.org/task/64836
* https://bugs.gentoo.org/702252