### PR TITLE
pass: xclip should not be a hard dependency

### DIFF
--- a/srcpkgs/pass/template
+++ b/srcpkgs/pass/template
@@ -1,23 +1,23 @@
 # Template file for 'pass'
 pkgname=pass
 version=1.7.3
-revision=1
+revision=2
 archs=noarch
 wrksrc="password-store-${version}"
 build_style=gnu-makefile
 make_install_args="WITH_BASHCOMP=yes WITH_ZSHCOMP=yes WITH_FISHCOMP=yes"
-depends="bash gnupg2 tree xclip"
+make_check_target=test
+depends="bash gnupg2 tree"
 checkdepends="${depends} git"
 short_desc="Stores, retrieves, generates, and synchronizes passwords securely"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="GPL-2.0-or-later"
-homepage="http://www.passwordstore.org/"
-distfiles="http://git.zx2c4.com/password-store/snapshot/password-store-${version}.tar.xz"
+homepage="https://www.passwordstore.org"
+distfiles="https://git.zx2c4.com/password-store/snapshot/password-store-${version}.tar.xz"
 checksum=2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4
-make_check_target=test
 
 passmenu_package() {
-	short_desc="A dmenu-based interface to pass"
+	short_desc="Dmenu-based interface to pass"
 	depends="dmenu xdotool ${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vbin contrib/dmenu/passmenu


### PR DESCRIPTION
Xclip should not be a hard dependency because it assumes that you’re using X11, which is not always true (wayland).
Removing xclip does NOT break pass, it just removes a functionality:
```
/bin/pass: line 160: xclip: command not found
Error: Could not copy data to the clipboard
```