### PR TITLE
gmsh: Update to 4.5.0 ; Added build_option fltk

### DIFF
--- a/srcpkgs/gmsh/template
+++ b/srcpkgs/gmsh/template
@@ -1,33 +1,43 @@
 # Template file for 'gmsh'
 pkgname=gmsh
 version=4.4.1
-revision=2
+revision=3
 wrksrc="${pkgname}-${version}-source"
 build_style=cmake
 configure_args="-DENABLE_NUMPY=$(vopt_if numpy ON OFF)
- -DENABLE_ZIPPER=$(vopt_if zipper ON OFF) -DENABLE_HXT=$(vopt_if hxt ON OFF)"
-hostmakedepends="blas-devel lapack-devel SDL2-devel
- $(vopt_if mesh 'hdf5-devel fltk-devel') gmp-devel"
-depends="python blas-devel lapack-devel SDL2-devel
- $(vopt_if mesh 'hdf5-devel fltk-devel') gmp-devel"
+ -DENABLE_ZIPPER=$(vopt_if zipper ON OFF)
+ -DENABLE_HXT=$(vopt_if hxt ON OFF)
+ -DENABLE_FLTK=$(vopt_if fltk ON OFF)"
+hostmakedepends="blas-devel lapack-devel gmp-devel
+ $(vopt_if mesh 'hdf5-devel')
+ $(vopt_if fltk 'glu-devel fltk-devel')"
+depends="libgfortran python blas-devel lapack-devel
+ $(vopt_if mesh 'hdf5-devel')
+ $(vopt_if fltk 'glu-devel fltk-devel')"
 short_desc="Three-dimensional finite element mesh generator"
-maintainer="Nathan Owens <ndowens04@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gmsh.info"
 changelog="http://gmsh.info/CHANGELOG.txt"
 distfiles="https://gmsh.info/src/gmsh-${version}-source.tgz"
 checksum=853c6438fc4e4b765206e66a514b09182c56377bb4b73f1d0d26eda7eb8af0dc
 
-build_options="hxt mesh numpy zipper"
+build_options="hxt mesh numpy zipper fltk"
+desc_option_fltk="Enable FLTK GUI"
+desc_option_hxt="Enable HXT library"
+desc_option_mesh="Enable mesh support (Required for GUI and FLTK)"
+desc_option_numpy="Enable fullMatrix and numpy array conversion"
+desc_option_zipper="Enable zip file compression/decompression"
+
+# If fltk is enabled, mesh must be enabled
+if [ "$build_option_fltk" ]; then
+	build_options_default+=" mesh"
+fi
+
 # HXT and MESH only available on x86
 case "${XBPS_TARGET_MACHINE}" in
 	i686|x86_64) build_options_default="hxt mesh";;
 esac
-
-desc_option_hxt="Enable HXT library"
-desc_option_mesh="Enable mesh support (Required for GUI)"
-desc_option_numpy="Enable fullMatrix and numpy array conversion"
-desc_option_zipper="Enable zip file compression/decompression"
 
 post_install() {
 	rm -rf builddir/gmsh-$version-source/api


### PR DESCRIPTION
Add build_option fltk so by default a lot less dependencies are needed unless one wants to build
a fltk GUI. Also add libgfortran to depends as gmsh links
to the library. Closes: #17086

Signed-off-by: Nathan Owens <ndowens04@gmail.com>