### PR TITLE
openssh: restore upstream's default for PermitRootLogin

### DIFF
--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,7 +1,7 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=8.1p1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
@@ -53,12 +53,11 @@ post_install() {
 	vman contrib/ssh-copy-id.1
 	vlicense LICENCE
 
-	sed -i \
+	# configure to use PAM
+	vsed -i ${DESTDIR}/etc/ssh/sshd_config \
 		-e 's|^#\(UsePAM\) no|\1 yes|g' \
-		-e 's|^#\(PermitRootLogin\) .*|\1 yes|g' \
 		-e 's|^#\(ChallengeResponseAuthentication\) yes|\1 no|g' \
-		-e 's|^#\(PrintMotd\) yes|\1 no|g' \
-		${DESTDIR}/etc/ssh/sshd_config
+		-e 's|^#\(PrintMotd\) yes|\1 no|g'
 
 	vinstall ${FILESDIR}/sshd.pam 644 etc/pam.d sshd
 	vsv sshd


### PR DESCRIPTION
restore upstream's default for PermitRootLogin, which currently is 'prohibt-password'.

Should be discussed in conjunction with https://github.com/void-linux/void-mklive/pull/100.