### PR TITLE
.github/workflows: use notices, reformat message

### DIFF
--- a/.github/workflows/notify-irc.yaml
+++ b/.github/workflows/notify-irc.yaml
@@ -30,7 +30,7 @@ jobs:
           nickname: void-packages
           sasl_password: ${{ secrets.freenode_password_void_packages }}
           tls: true
-          message: "${{ github.actor }} ${{ github.event.action }} pull request #${{ github.event.pull_request.number }} “${{ github.event.pull_request.title }}”"
+          message: "${{ github.actor }} ${{ github.event.action }} pull request “${{ github.event.pull_request.title }}” ${{ github.event.pull_request.html_url }}"
       - name: irc issue
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'issues' && github.repository == 'void-linux/void-packages'
@@ -40,4 +40,4 @@ jobs:
           nickname: void-packages
           sasl_password: ${{ secrets.freenode_password_void_packages }}
           tls: true
-          message: "${{ github.actor }} ${{ github.event.action }} issue #${{ github.event.issue.number }} “${{ github.event.issue.title }}”"
+          message: "${{ github.actor }} ${{ github.event.action }} issue “${{ github.event.issue.title }}” ${{ github.event.issue.html_url }}"

--- a/.github/workflows/notify-irc.yaml
+++ b/.github/workflows/notify-irc.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   ircnotify:
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     steps:
       - name: irc push
         uses: rectalogic/notify-irc@v1

--- a/.github/workflows/notify-irc.yaml
+++ b/.github/workflows/notify-irc.yaml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: irc push
-        uses: rectalogic/notify-irc@v1
+        uses: Gottox/irc-message-action@master
         if: github.event_name == 'push' && github.repository == 'void-linux/void-packages'
         with:
           notice: true
@@ -23,7 +23,7 @@ jobs:
           tls: true
           message: "${{ github.actor }} pushed ${{ github.event.compare }}"
       - name: irc pull request
-        uses: rectalogic/notify-irc@v1
+        uses: Gottox/irc-message-action@master
         if: github.event_name == 'pull_request' && github.repository == 'void-linux/void-packages'
         with:
           notice: true
@@ -33,7 +33,7 @@ jobs:
           tls: true
           message: "${{ github.actor }} ${{ github.event.action }} pull request “${{ github.event.pull_request.title }}” ${{ github.event.pull_request.html_url }}"
       - name: irc issue
-        uses: rectalogic/notify-irc@v1
+        uses: Gottox/irc-message-action@master
         if: github.event_name == 'issues' && github.repository == 'void-linux/void-packages'
         with:
           notice: true

--- a/.github/workflows/notify-irc.yaml
+++ b/.github/workflows/notify-irc.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'push' && github.repository == 'void-linux/void-packages'
         with:
-          #notice: true
+          notice: true
           channel: "#xbps"
           nickname: void-packages
           sasl_password: ${{ secrets.freenode_password_void_packages }}
@@ -25,7 +25,7 @@ jobs:
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'pull_request' && github.repository == 'void-linux/void-packages'
         with:
-          #notice: true
+          notice: true
           channel: "#xbps"
           nickname: void-packages
           sasl_password: ${{ secrets.freenode_password_void_packages }}
@@ -35,7 +35,7 @@ jobs:
         uses: rectalogic/notify-irc@v1
         if: github.event_name == 'issues' && github.repository == 'void-linux/void-packages'
         with:
-          #notice: true
+          notice: true
           channel: "#xbps"
           nickname: void-packages
           sasl_password: ${{ secrets.freenode_password_void_packages }}


### PR DESCRIPTION
This PR changes the message behavior to send notices instead of privmsgs to the channel. Also it reformats the message to contain URLs to the issues and PRs instead of only the issue #.