### PR TITLE
atom: fix Fuzzy finder (git-utils), use system Git, upgrade to 1.44.0

### DIFF
--- a/srcpkgs/atom/patches/fixes.patch
+++ b/srcpkgs/atom/patches/fixes.patch
@@ -173,9 +173,6 @@ diff -Naurp0 a/src/main-process/atom-application.js b/src/main-process/atom-appl
 @@ -719 +719 @@ module.exports = class AtomApplication e
 -      path.join(process.resourcesPath, 'LICENSE.md')
 +      '/usr/share/licenses/atom/LICENSE.md'
-@@ -2050 +2050 @@ module.exports = class AtomApplication e
--    const args = [];
-+    const args = ['/usr/lib/atom/atom'];
 diff -Naurp0 a/src/workspace.js b/src/workspace.js
 --- a/src/workspace.js	2019-11-08 22:14:27.324474946 +0300
 +++ b/src/workspace.js	2019-11-08 22:15:49.853005612 +0300

--- a/srcpkgs/atom/patches/git-utils.patch
+++ b/srcpkgs/atom/patches/git-utils.patch
@@ -1,0 +1,23 @@
+diff -Naurp0 a/package.json b/package.json
+--- a/package.json	2019-12-13 22:07:42.000000000 +0300
++++ b/package.json	2019-12-19 13:26:20.083698872 +0300
+@@ -67 +67 @@
+-    "git-utils": "5.6.1",
++    "git-utils": "file:packages/git-utils",
+diff -Naurp0 a/package-lock.json b/package-lock.json
+--- a/package-lock.json	2019-12-13 22:07:42.000000000 +0300
++++ b/package-lock.json	2019-12-19 16:45:30.215685265 +0300
+@@ -3187,3 +3187 @@
+-      "version": "5.6.1",
+-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.1.tgz",
+-      "integrity": "sha512-wDF7vSbH940NupuMFC87As0x/VSke51P7xTnkdSlk96YN3tzOagXzBUNq5Nq16KOVuMSxcGj1l3qHF5VXl39Ng==",
++      "version": "file:packages/git-utils",
+@@ -5761 +5759 @@
+-        "git-utils": "^5.6.0",
++        "git-utils": "file:packages/git-utils",
+diff -Naurp0 a/packages/git-utils/binding.gyp b/packages/git-utils/binding.gyp
+--- a/packages/git-utils/binding.gyp	2019-06-20 18:40:36.000000000 +0300
++++ b/packages/git-utils/binding.gyp	2019-12-19 13:28:15.623981924 +0300
+@@ -164,0 +165,2 @@
++        'deps/libgit2/src/net.c',
++        'deps/libgit2/src/net.h',

--- a/srcpkgs/atom/patches/use-system-git.patch
+++ b/srcpkgs/atom/patches/use-system-git.patch
@@ -1,0 +1,51 @@
+diff -Naurp0 a/package.json b/package.json
+--- a/package.json	2019-12-13 22:07:42.000000000 +0300
++++ b/package.json	2019-12-19 17:00:25.029132872 +0300
+@@ -52,0 +53 @@
++    "dugite": "file:packages/dugite",
+diff -Naurp0 a/package-lock.json b/package-lock.json
+--- a/package-lock.json	2019-12-13 22:07:42.000000000 +0300
++++ b/package-lock.json	2019-12-19 16:44:18.175132282 +0300
+@@ -2530,3 +2530 @@
+-      "version": "1.87.5",
+-      "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.87.5.tgz",
+-      "integrity": "sha512-Rfl1pJ7SaIk8kW9knOGFvVl/aRWAL7RnESs/0GMUCay/yOtVejkrDGlK8JciN5dluJbIg/4bMp0KeK3HGuQqEQ==",
++      "version": "file:packages/dugite",
+@@ -3212 +3210 @@
+-        "dugite": "1.87.5",
++        "dugite": "file:packages/dugite",
+@@ -6992 +6990 @@
+-        "dugite": "^1.86.0",
++        "dugite": "file:packages/dugite",
+diff -Naurp0 a/packages/dugite/build/lib/git-environment.js b/packages/dugite/build/lib/git-environment.js
+--- a/packages/dugite/build/lib/git-environment.js	1985-10-26 11:15:00.000000000 +0300
++++ b/packages/dugite/build/lib/git-environment.js	2019-12-19 15:13:56.919818081 +0300
+@@ -4,12 +3,0 @@ const path = require("path");
+-function resolveEmbeddedGitDir() {
+-    if (process.platform === 'darwin' ||
+-        process.platform === 'linux' ||
+-        process.platform === 'android' ||
+-        process.platform === 'win32') {
+-        const s = path.sep;
+-        return path
+-            .resolve(__dirname, '..', '..', 'git')
+-            .replace(/[\\\/]app.asar[\\\/]/, `${s}app.asar.unpacked${s}`);
+-    }
+-    throw new Error('Git not supported on platform: ' + process.platform);
+-}
+@@ -27 +15 @@ function resolveGitDir() {
+-        return resolveEmbeddedGitDir();
++        return '/usr';
+@@ -108,7 +95,0 @@ function setupEnvironment(environmentVar
+-        if (!env.GIT_SSL_CAINFO && !env.LOCAL_GIT_DIRECTORY) {
+-            // use the SSL certificate bundle included in the distribution only
+-            // when using embedded Git and not providing your own bundle
+-            const distDir = resolveEmbeddedGitDir();
+-            const sslCABundle = `${distDir}/ssl/cacert.pem`;
+-            env.GIT_SSL_CAINFO = sslCABundle;
+-        }
+diff -Naurp0 a/packages/dugite/package.json b/packages/dugite/package.json
+--- a/packages/dugite/package.json	1985-10-26 11:15:00.000000000 +0300
++++ b/packages/dugite/package.json	2019-12-19 15:19:07.645889964 +0300
+@@ -16 +15,0 @@
+-    "postinstall": "node ./script/download-git.js",

--- a/srcpkgs/atom/template
+++ b/srcpkgs/atom/template
@@ -1,9 +1,9 @@
 # Template file for 'atom'
-_dugite_ver=1.87.6
+_dugite_ver=1.88.1
 _git_utils_ver=5.6.2
 pkgname=atom
-version=1.41.0
-revision=3
+version=1.44.0
+revision=1
 archs="x86_64"
 hostmakedepends="git pkg-config python-devel nodejs-lts-10 nodejs-lts-10-devel curl gtk+3
  libXtst libXScrnSaver nss python alsa-lib"
@@ -19,8 +19,8 @@ distfiles="
 	https://registry.npmjs.org/dugite/-/dugite-${_dugite_ver}.tgz
 	https://registry.npmjs.org/git-utils/-/git-utils-${_git_utils_ver}.tgz"
 checksum="
-	4a440909462c461cbec9b82b5f97bd21719a34f0ab59f2d859df85a40246c949
-	61cd7b32932788c70420cb64042d7056715c5e5c20f4df022e77cee034519c09
+	8d79697b0c969f22ee8dc2c1d27c608036e92deaf63574f8cd1509ea506eded9
+	ddb5479cc78cf863f05b1c35420d66dde55f2bfa66f30cd7bac484ffd5fd6782
 	b430ee53a09317df5b6677e5625950baefe840258f2e9d55cf4fc448c9d8576e"
 skip_extraction="
 	dugite-${_dugite_ver}.tgz
@@ -32,9 +32,9 @@ nostrip=yes
 
 post_extract() {
 	mkdir -p packages/dugite packages/git-utils
-	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/dugite-${_dugite_ver}.tgz \
+	bsdtar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/dugite-${_dugite_ver}.tgz \
 		--strip-components=1 -C packages/dugite
-	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/git-utils-${_git_utils_ver}.tgz \
+	bsdtar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/git-utils-${_git_utils_ver}.tgz \
 		--strip-components=1 -C packages/git-utils
 }
 

--- a/srcpkgs/atom/template
+++ b/srcpkgs/atom/template
@@ -1,31 +1,39 @@
 # Template file for 'atom'
+_dugite_ver=1.87.6
 _git_utils_ver=5.6.2
 pkgname=atom
 version=1.41.0
-revision=2
+revision=3
 archs="x86_64"
 hostmakedepends="git pkg-config python-devel nodejs-lts-10 nodejs-lts-10-devel curl gtk+3
  libXtst libXScrnSaver nss python alsa-lib"
 makedepends="python-devel GConf-devel libgnome-keyring-devel gtk+3-devel
  libX11-devel libxkbfile-devel libsecret-devel"
+depends="git"
 short_desc="Chrome-based text editor from Github"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://atom.io"
 distfiles="
 	https://github.com/atom/atom/archive/v${version}.tar.gz
+	https://registry.npmjs.org/dugite/-/dugite-${_dugite_ver}.tgz
 	https://registry.npmjs.org/git-utils/-/git-utils-${_git_utils_ver}.tgz"
 checksum="
 	4a440909462c461cbec9b82b5f97bd21719a34f0ab59f2d859df85a40246c949
+	61cd7b32932788c70420cb64042d7056715c5e5c20f4df022e77cee034519c09
 	b430ee53a09317df5b6677e5625950baefe840258f2e9d55cf4fc448c9d8576e"
-skip_extraction="git-utils-${_git_utils_ver}.tgz"
+skip_extraction="
+	dugite-${_dugite_ver}.tgz
+	git-utils-${_git_utils_ver}.tgz"
 shlib_provides="libGLESv2.so"
 patch_args="-Np1"
 nocross=yes
 nostrip=yes
 
 post_extract() {
-	mkdir -p packages/git-utils
+	mkdir -p packages/dugite packages/git-utils
+	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/dugite-${_dugite_ver}.tgz \
+		--strip-components=1 -C packages/dugite
 	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/git-utils-${_git_utils_ver}.tgz \
 		--strip-components=1 -C packages/git-utils
 }
@@ -42,9 +50,4 @@ do_build() {
 do_install() {
 	mv $DESTDIR/usr/libexec/applications $DESTDIR/usr/share
 	vlicense LICENSE.md
-}
-
-post_install() {
-	# Very hackish, git-imap-send is linked to openssl's libssl/libcrypto. Removing it allows it to package
-	rm $DESTDIR/usr/libexec/atom/resources/app.asar.unpacked/node_modules/dugite/git/libexec/git-core/git-imap-send
 }

--- a/srcpkgs/atom/template
+++ b/srcpkgs/atom/template
@@ -1,7 +1,8 @@
 # Template file for 'atom'
+_git_utils_ver=5.6.2
 pkgname=atom
 version=1.41.0
-revision=1
+revision=2
 archs="x86_64"
 hostmakedepends="git pkg-config python-devel nodejs-lts-10 nodejs-lts-10-devel curl gtk+3
  libXtst libXScrnSaver nss python alsa-lib"
@@ -11,12 +12,23 @@ short_desc="Chrome-based text editor from Github"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://atom.io"
-distfiles="https://github.com/atom/atom/archive/v${version}.tar.gz"
-checksum=4a440909462c461cbec9b82b5f97bd21719a34f0ab59f2d859df85a40246c949
+distfiles="
+	https://github.com/atom/atom/archive/v${version}.tar.gz
+	https://registry.npmjs.org/git-utils/-/git-utils-${_git_utils_ver}.tgz"
+checksum="
+	4a440909462c461cbec9b82b5f97bd21719a34f0ab59f2d859df85a40246c949
+	b430ee53a09317df5b6677e5625950baefe840258f2e9d55cf4fc448c9d8576e"
+skip_extraction="git-utils-${_git_utils_ver}.tgz"
 shlib_provides="libGLESv2.so"
 patch_args="-Np1"
 nocross=yes
 nostrip=yes
+
+post_extract() {
+	mkdir -p packages/git-utils
+	tar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/git-utils-${_git_utils_ver}.tgz \
+		--strip-components=1 -C packages/git-utils
+}
 
 pre_build() {
 	npm install -g gyp


### PR DESCRIPTION
This series fixes the bug with the Fuzzy finder (that has been already fixed across many distributions, but not in the "official" repository), switches Atom to system Git instead of shipped prebuilt copy and upgrades the package to the latest release of 1.44.0.

Tested on the latest Void Linux x86_64.