### PR TITLE
retroarch: unmark broken on aarch64

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -29,12 +29,11 @@ build_options="ffmpeg opengl jack pulseaudio sdl2 x11 vulkan qt5"
 build_options_default="ffmpeg"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc64*) build_options_default+=" opengl pulseaudio sdl2 x11 vulkan";;
-	armv[67]*) broken="https://build.voidlinux.org/builders/armv7l_builder/builds/19214/steps/shell_3/logs/stdio"
+	i686*|x86_64*|ppc64*|aarch64*) build_options_default+=" opengl pulseaudio sdl2 x11 vulkan";;
+	armv[67]*)
 		makedepends+=" rpi-userland-devel"
 		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib -lbcm_host"
 		;;
-	aarch64*) broken="https://build.voidlinux.org/builders/aarch64_builder/builds/21161/steps/shell_3/logs/stdio";;
 esac
 
 do_configure() {
@@ -46,7 +45,7 @@ do_configure() {
 	case "$XBPS_TARGET_MACHINE" in
 		i686*|x86_64*) configure_args+=" --enable-sse --enable-threads";;
 		ppc64*) configure_args+=" --enable-threads";;
-		aarch64*) configure_args+=" --enable-neon";;
+		aarch64*) configure_args+=" --disable-neon";;
 		armv6*) configure_args+=" --disable-neon"
 			CFLAGS+=" -I${XBPS_CROSS_BASE}/opt/vc/include"
 			LDFLAGS+=" -L${XBPS_CROSS_BASE}/opt/vc/lib -Wl,-R /opt/vc/lib";;


### PR DESCRIPTION
Unmark broken on aarch64 and disable neon, as it
gives __ARM_NEON__ is defined, but it's not

Signed-off-by: Nathan Owens <ndowens04@gmail.com>