### PR TITLE
chromium: update to 79.0.3945.88.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=79.0.3945.79
+version=79.0.3945.88
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=eb9dfc7bb27ca6373fd51e7a1daeac59cd6dd2600431861710bed160208bcf37
+checksum=9f2ec10cfc313de21ca7c7100b50e088df741cd20812e76890e3d840ac7584cc
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=79.0.3945.79
+version=79.0.3945.88
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=e1a7362d396b0f72e6ad8c1d53cae67db201e0eeaa2a96dbe9214d080925bcf3
+checksum=4f18171d2225502018fcafae860ce9329199bcd6a0e50f8d83de041afd723fc9
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
- Built for x86_64, i686, and x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine.