### PR TITLE
python3-cachetools: update to 4.0.0.

### DIFF
--- a/srcpkgs/python3-cachetools
+++ b/srcpkgs/python3-cachetools
@@ -1,1 +1,0 @@
-python-cachetools

--- a/srcpkgs/python3-cachetools/template
+++ b/srcpkgs/python3-cachetools/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-cachetools'
+pkgname=python3-cachetools
+version=4.0.0
+revision=1
+archs=noarch
+wrksrc="cachetools-${version}"
+build_style=python3-module
+pycompile_module="cachetools"
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Python3 extensible memoizing collections and decorators"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="MIT"
+homepage="https://github.com/tkem/cachetools/"
+distfiles="${PYPI_SITE}/c/cachetools/cachetools-${version}.tar.gz"
+checksum=9a52dd97a85f257f4e4127f15818e71a0c7899f121b34591fcc1173ea79a0198
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Upstream has dropped support for python2.