### PR TITLE
offlineimap: update to 7.3.2.

### DIFF
--- a/srcpkgs/offlineimap/template
+++ b/srcpkgs/offlineimap/template
@@ -1,6 +1,6 @@
 # Template file for 'offlineimap'
 pkgname=offlineimap
-version=7.3.0
+version=7.3.2
 revision=1
 archs=noarch
 build_style=python2-module
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="http://offlineimap.org/"
 changelog="https://raw.githubusercontent.com/OfflineIMAP/offlineimap/master/Changelog.md"
 distfiles="https://github.com/OfflineIMAP/offlineimap/archive/v${version}.tar.gz"
-checksum=d8378e82e392c70f5c20cb08705687da30cd427f2bca539939311512777e6659
+checksum=d47b564858c3e9fc7726ef58c9a4ee518d2958c5de3dcad6cd78b7cfe0a6bdef
 
 post_install() {
 	make -C docs man


### PR DESCRIPTION
Still doesn't support Python3.