### PR TITLE
ibus-bamboo: update to 0.6.3

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,6 +1,6 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.6.2
+version=0.6.3
 revision=1
 hostmakedepends="go"
 makedepends="libXtst-devel libX11-devel"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="15fbee26a71d6c1dc0661cc29e00c12a116d93211e8097af914ab3e72549a774"
+checksum="7bb80833e7a6509d2d3cae5c3203328442c27d8ea6f545784cfab39d8cf18a45"
 nocross="armv7l-linux-gnueabihf-gcc: error: unrecognized command line option '-m64'"
 _engine_dir="usr/share/ibus-bamboo/"
 _ibus_dir="usr/share/ibus"


### PR DESCRIPTION
Change log:
- Improve Telex 2 handling
- Backspace: Auto restore key strokes while typing
- Preedit: Add workaround for Google Spreadsheets
- Revert keyboard layout to default