### PR TITLE
spamassassin: update to 3.4.3

### DIFF
--- a/srcpkgs/spamassassin/patches/configure.patch
+++ b/srcpkgs/spamassassin/patches/configure.patch
@@ -1,0 +1,17 @@
+diff --git spamc/configure spamc/configure
+index d8e5dcf..3db5772 100755
+--- spamc/configure
++++ spamc/configure
+@@ -1737,10 +1737,10 @@ if test "$cross_compiling" != yes; then
+ 	{ { echo "$as_me:$LINENO: error: cannot run C compiled programs.
+ If you meant to cross compile, use \`--host'.
+ See \`config.log' for more details." >&5
+-echo "$as_me: error: cannot run C compiled programs.
++echo "$as_echo: cannot run C compiled programs.
+ If you meant to cross compile, use \`--host'.
+ See \`config.log' for more details." >&2;}
+-   { (exit 1); exit 1; }; }
++    }
+     fi
+   fi
+ fi

--- a/srcpkgs/spamassassin/template
+++ b/srcpkgs/spamassassin/template
@@ -2,22 +2,21 @@
 pkgname=spamassassin
 version=3.4.2
 revision=1
+wrksrc="Mail-SpamAssassin-${version}"
 build_style=perl-module
 # Missing optional dependencies:
 #  Mail::SPF, Geo::IP, Razor2, Encode::Detect, Net::Patricia
+hostmakedepends="$depends"
+makedepends="$depends"
 depends="curl gnupg perl perl-DBI perl-Digest-SHA1 perl-HTML-Parser
  perl-HTTP-Date perl-IO-Socket-INET6 perl-IO-Socket-SSL perl-LWP
  perl-Mail-DKIM perl-Net-DNS perl-NetAddr-IP"
-makedepends="$depends"
-hostmakedepends="$depends"
 short_desc="Tool that serves as a mail filter to identify Spam"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://spamassassin.apache.org/"
 distfiles="http://www.us.apache.org/dist/${pkgname}/source/Mail-SpamAssassin-${version}.tar.gz"
 checksum=8a1c139ee08f140d3d3fdf13e03d98cf68a5cae27a082c4a614d154565a3c34f
-wrksrc="Mail-SpamAssassin-${version}"
-nocross="https://build.voidlinux.org/builders/armv6l-musl_builder/builds/9678"
 conf_files="
  /etc/mail/spamassassin/v312.pre
  /etc/mail/spamassassin/v330.pre


### PR DESCRIPTION
Updated to 3.4.3 and fixed cross-compile
@Gottox This version also fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=946829#24


Signed-off-by: Nathan Owens <ndowens04@gmail.com>