### PR TITLE
libplacebo: update to 1.29.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3301,7 +3301,7 @@ libkid3-gui.so.3.8.0 kid3-3.8.0_1
 libcfitsio.so.3 cfitsio-3.450_1
 libapparmor.so.1 libapparmor-2.12.0_1
 libgsettings-qt.so.1 gsettings-qt-0.1+17.10.20170824_1
-libplacebo.so.21 libplacebo-1.21.0_1
+libplacebo.so.29 libplacebo-1.29.0_1
 libw2xc.so waifu2x-converter-cpp-5.2_1
 libnova-0.15.so.0 libnova-0.15.0_1
 libdtkcore.so.2 dtkcore-2.0.6_1

--- a/srcpkgs/libplacebo/template
+++ b/srcpkgs/libplacebo/template
@@ -1,7 +1,7 @@
 # Template file for 'libplacebo'
 pkgname=libplacebo
-version=1.21.0
-revision=2
+version=1.29.0
+revision=1
 build_style=meson
 configure_args="-Dvulkan=enabled -Dglslang=disabled -Dshaderc=enabled"
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/haasn/libplacebo"
 distfiles="https://github.com/haasn/libplacebo/archive/v${version}.tar.gz"
-checksum=09d78911a2c13c38b8913d29cf4d78c424d00aa998a84a8011e5db14477c72f8
+checksum=2866609a6a66f5a34da6065051821e958a6ede0583fe67ca76e3c6e39313b148
 
 libplacebo-devel_package() {
 	depends="libplacebo-${version}_${revision} vulkan-loader lcms2-devel"

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.30.0
-revision=3
+revision=4
 build_style=waf
 configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
  --enable-dvdnav --enable-dvdnav --enable-cdda --enable-libmpv-shared

--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -1,7 +1,7 @@
 # Template file for 'vlc'
 pkgname=vlc
 version=3.0.8
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--disable-gme --disable-libtar --enable-jack
  --enable-live555 --disable-fluidsynth --enable-dvdread


### PR DESCRIPTION
mpv works as expected, and I briefly tried vlc which seems ok, too.