### PR TITLE
Drop python3.8 backported package

### DIFF
--- a/srcpkgs/python-importlib_metadata
+++ b/srcpkgs/python-importlib_metadata
@@ -1,1 +1,0 @@
-python3-importlib_metadata

--- a/srcpkgs/python-importlib_metadata/template
+++ b/srcpkgs/python-importlib_metadata/template
@@ -1,13 +1,13 @@
-# Template file for 'python3-importlib_metadata'
-pkgname=python3-importlib_metadata
+# Template file for 'python-importlib_metadata'
+pkgname=python-importlib_metadata
 version=1.2.0
 revision=3
 archs=noarch
 wrksrc="importlib_metadata-${version}"
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools"
-depends="python3-zipp"
-checkdepends="${depends} python3-packaging"
+build_style=python2-module
+hostmakedepends="python-setuptools"
+depends="python-zipp"
+checkdepends="${depends}"
 short_desc="Read metadata from Python packages"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="Apache-2.0"
@@ -15,15 +15,3 @@ homepage="https://importlib-metadata.readthedocs.io/en/latest/"
 changelog="https://importlib-metadata.readthedocs.io/en/latest/changelog%20(links).html"
 distfiles="${PYPI_SITE}/i/importlib_metadata/importlib_metadata-${version}.tar.gz"
 checksum=41e688146d000891f32b1669e8573c57e39e5060e7f5f647aa617cd9a9568278
-
-do_check() {
-	python3 setup.py test
-}
-
-python-importlib_metadata_package() {
-	depends="python-zipp python-backports.configparser python-contextlib2"
-	short_desc="${short_desc/Python/Python 2/}"
-	pkg_install() {
-		vmove "usr/lib/python2.7"
-	}
-}

--- a/srcpkgs/python-zipp
+++ b/srcpkgs/python-zipp
@@ -1,1 +1,0 @@
-python3-zipp

--- a/srcpkgs/python-zipp/template
+++ b/srcpkgs/python-zipp/template
@@ -1,13 +1,12 @@
-# Template file for 'python3-zipp'
-pkgname=python3-zipp
+# Template file for 'python-zipp'
+pkgname=python-zipp
 version=0.6.0
 revision=2
 archs=noarch
 wrksrc="zipp-${version}"
-build_style=python-module
-pycompile_module="zipp.py"
-hostmakedepends="python-setuptools python3-setuptools"
-depends="python3"
+build_style=python2-module
+hostmakedepends="python-setuptools"
+depends="python"
 short_desc="Pathlib-compatible Zipfile object wrapper"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="MIT"
@@ -18,13 +17,4 @@ checksum=3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e
 
 post_install() {
 	vlicense LICENSE
-}
-
-python-zipp_package() {
-	depends=python
-	short_desc+=" - Python 2"
-	pkg_install() {
-		vmove "usr/lib/python2.7"
-		vlicense LICENSE
-	}
 }

--- a/srcpkgs/python3-astroid/template
+++ b/srcpkgs/python3-astroid/template
@@ -1,17 +1,15 @@
 # Template file for 'python3-astroid'
 pkgname=python3-astroid
 version=2.3.3
-revision=2
+revision=3
 archs=noarch
 wrksrc="astroid-${version}"
 build_style=python3-module
-pycompile_module="astroid"
 hostmakedepends="python3-setuptools"
 depends="python3-six python3-lazy-object-proxy python3-wrapt
  python3-typed-ast"
 checkdepends="$depends python3-attrs python3-pytest python3-wcwidth
- python3-py python3-pluggy python3-more-itertools python3-importlib_metadata
- python3-parsing python3-zipp"
+ python3-py python3-pluggy python3-more-itertools python3-parsing"
 short_desc="Abstract syntax tree for Python3"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"

--- a/srcpkgs/python3-pluggy/template
+++ b/srcpkgs/python3-pluggy/template
@@ -1,13 +1,12 @@
 # Template file for 'python3-pluggy'
 pkgname=python3-pluggy
 version=0.13.1
-revision=2
+revision=3
 archs=noarch
 wrksrc="pluggy-${version}"
 build_style=python3-module
-pycompile_module="pluggy"
 hostmakedepends="python3-setuptools"
-depends="python3-importlib_metadata"
+depends="python3"
 checkdepends="python3-pytest ${depends}"
 short_desc="Minimalist production ready plugin system (Python3)"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"

--- a/srcpkgs/python3-pytest/template
+++ b/srcpkgs/python3-pytest/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest'
 pkgname=python3-pytest
-version=5.3.2
-revision=3
+version=5.3.4
+revision=1
 archs=noarch
 wrksrc="${pkgname/python3-//}-${version}"
 build_style=python3-module
@@ -16,7 +16,7 @@ license="MIT"
 homepage="https://docs.pytest.org/en/latest/"
 changelog="https://docs.pytest.org/en/latest/changelog.html"
 distfiles="${PYPI_SITE}/p/pytest/pytest-${version}.tar.gz"
-checksum=6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa
+checksum=1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600
 alternatives="
  pytest:pytest:/usr/bin/pytest3
  pytest:py.test:/usr/bin/py.test3"

--- a/srcpkgs/python3-pytest/template
+++ b/srcpkgs/python3-pytest/template
@@ -1,14 +1,13 @@
 # Template file for 'python3-pytest'
 pkgname=python3-pytest
 version=5.3.2
-revision=2
+revision=3
 archs=noarch
 wrksrc="${pkgname/python3-//}-${version}"
 build_style=python3-module
-pycompile_module="_pytest pytest.py"
 hostmakedepends="python3-setuptools"
 depends="python3-py python3-packaging python3-attrs python3-more-itertools
- python3-atomicwrites python3-pluggy python3-importlib_metadata python3-wcwidth"
+ python3-atomicwrites python3-pluggy python3-wcwidth"
 checkdepends="$depends python3-argcomplete python3-hypothesis python3-mock
  python3-nose python3-requests python3-parsing tox"
 short_desc="Simple powerful testing with Python 3"
@@ -29,7 +28,7 @@ post_patch() {
 }
 
 do_check() {
-	tox -e py36
+	tox -e "py${py3_ver/./}"
 }
 
 post_install() {

--- a/srcpkgs/tox/template
+++ b/srcpkgs/tox/template
@@ -1,10 +1,10 @@
 # Template file for 'tox'
 pkgname=tox
 version=3.14.3
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-filelock python3-importlib_metadata python3-packaging
+depends="python3-filelock python3-packaging
  python3-pluggy python3-pytest python3-toml python3-virtualenv"
 checkdepends="${depends} python3-flaky python3-pathlib2"
 short_desc="Generic virtualenv management and test command line tool"


### PR DESCRIPTION
- zipp, importlib_metadata, mock are back-ported package.

- Drop them since we're in Python 3.8 now.

- ./xbps-src check passed