### PR TITLE
xsecurelock: Add mplayer/htpasswd support

### DIFF
--- a/srcpkgs/xsecurelock/template
+++ b/srcpkgs/xsecurelock/template
@@ -1,11 +1,14 @@
 # Template file for 'xsecurelock'
 pkgname=xsecurelock
 version=1.7.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-pam-service-name=system-local-login
- --with-xscreensaver=/usr/libexec/xscreensaver"
-hostmakedepends="pkg-config automake mpv xscreensaver"
+ --with-xscreensaver=/usr/libexec/xscreensaver
+ --with-mpv=/usr/bin/mpv
+ --with-mplayer=/usr/bin/mplayer
+ --with-htpasswd=/usr/bin/htpasswd"
+hostmakedepends="pkg-config automake"
 makedepends="libX11-devel libXcomposite-devel libXext-devel libXfixes-devel
  libXft-devel libXmu-devel libXrandr-devel libXScrnSaver-devel
  libXxf86misc-devel pam-devel"


### PR DESCRIPTION
Add as build dependencies allows the makefile to detect mpv/mplayer
location, and will then include them as optional runtime savers.