### PR TITLE
libva: set driver dir to /usr/lib32/dri on i686

### DIFF
--- a/srcpkgs/libva/template
+++ b/srcpkgs/libva/template
@@ -1,7 +1,7 @@
 # Template file for 'libva'
 pkgname=libva
 version=2.6.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_glx=no $(vopt_if wayland -Dwith_wayland=yes)
  -Dwith_egl=yes"
@@ -18,6 +18,10 @@ checksum=5566755739503ef53beafad7fd7e155e68039e9af78e051e27f1715a420a0952
 
 build_options="wayland"
 build_options_default="wayland"
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*) configure_args+=" -Ddriverdir=/usr/lib32/dri";;
+esac
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
If the libva i686 package is installed as a multilib package on x86_64,
it needs to load drivers from /usr/lib32/dri instead of /usr/lib/dri.