### PR TITLE
mesa: fix mesa-*-dri 32bit pkg generation

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=19.3.1
-revision=2
+revision=3
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
@@ -199,6 +199,7 @@ mesa-opencl_package() {
 mesa-dri_package() {
 	short_desc="Mesa DRI drivers"
 	depends="mesa-${version}_${revision}"
+	shlib_provides="libgallium_dri.so" # workaround for mesa-dri-32bit
 	nostrip_files="armada-drm_dri.so etnaviv_dri.so exynos_dri.so
 	 hx8357d_dri.so i915_dri.so i965_dri.so ili9225_dri.so ili9341_dri.so
 	 imx-drm_dri.so kgsl_dri.so kms_swrast_dri.so lima_dri.so meson_dri.so
@@ -218,6 +219,7 @@ mesa-dri_package() {
 
 mesa-vaapi_package() {
 	short_desc="Mesa VA-API drivers"
+	shlib_provides="libgallium_drv_video.so" # workaround for mesa-vaapi-32bit
 	nostrip_files="nouveau_drv_video.so r600_drv_video.so radeonsi_drv_video.so"
 	pkg_install() {
 		vmove "usr/lib/dri/*_drv_video.so"
@@ -228,7 +230,6 @@ mesa-vdpau_package() {
 	short_desc="Mesa VDPAU drivers"
 	nostrip_files="libvdpau_r300.so.1.0.0 libvdpau_r600.so.1.0.0
 	 libvdpau_radeonsi.so.1.0.0 libvdpau_nouveau.so.1.0.0"
-	noshlibprovides=yes # manually set them in case they are needed
 	pkg_install() {
 		vmove "usr/lib/vdpau/libvdpau_*"
 	}
@@ -237,7 +238,6 @@ mesa-vdpau_package() {
 mesa-XvMC_package() {
 	short_desc="Mesa XvMC drivers"
 	nostrip_files="libXvMCnouveau.so.1.0.0 libXvMCr600.so.1.0.0"
-	noshlibprovides=yes # manually set them in case they are needed
 	pkg_install() {
 		vmove "usr/lib/libXvMC*"
 	}
@@ -271,72 +271,84 @@ mesa-vulkan-overlay-layer_package() {
 
 mesa-ati-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for ATI GPUs (transitional dummy package)"
 	depends="mesa-dri mesa-vaapi mesa-vdpau mesa-XvMC mesa-vulkan-radeon"
 }
 
 mesa-etnaviv-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Vivante GPUs (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-freedreno-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Adreno GPUs (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-intel-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Intel GPUs (transitional dummy package)"
 	depends="mesa-dri mesa-vulkan-intel"
 }
 
 mesa-kmsro-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="KMS Render-only Mesa DRI drivers (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-lima-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Mali GPUs (Utgard) (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-nouveau-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for NVIDIA GPUs (transitional dummy package)"
 	depends="mesa-dri mesa-vaapi mesa-vdpau mesa-XvMC"
 }
 
 mesa-panfrost-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Mali GPUs (Midgard/Bifrost) (dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-tegra-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Tegra GPU (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-v3d-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Videocore VI GPU (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-vmwgfx-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for VMware (transitional dummy package)"
 	depends="mesa-dri"
 }
 
 mesa-vc4-dri_package() {
 	build_style=meta
+	lib32mode=full
 	short_desc="Mesa DRI drivers for Videocore IV GPU (transitional dummy package)"
 	depends="mesa-dri"
 }


### PR DESCRIPTION
User reported:
```
sudo xbps-install -Syu                                              
[*] Updating `https://alpha.de.repo.voidlinux.org/current/x86_64-repodata' ...
[*] Updating `https://alpha.de.repo.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
[*] Updating `https://alpha.de.repo.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating `https://alpha.de.repo.voidlinux.org/current/nonfree/x86_64-repodata' ...
libglapi-32bit-19.3.1_2 (update) breaks installed pkg `mesa-intel-dri-32bit-19.3.1_1'
mesa-32bit-19.3.1_2 (update) breaks installed pkg `mesa-intel-dri-32bit-19.3.1_1'
Transaction aborted due to unresolved dependencies.
exit 19
```
This is because mesa-intel-dri-32bit-19.3.1_**2** was not generated. This should fix it.