### PR TITLE
cross-arm-none-eabi*: update to 9.2, rework to include libgcc.a and libstdc++, newlib: build nano

### DIFF
--- a/srcpkgs/cross-arm-none-eabi-gcc/template
+++ b/srcpkgs/cross-arm-none-eabi-gcc/template
@@ -1,55 +1,13 @@
-# Template file for 'cross-${_triplet}-${_pkgname}'
+# Template file for 'cross-${_triplet}-gcc'
 _triplet=arm-none-eabi
 _pkgname=gcc
-pkgname=cross-${_triplet}-${_pkgname}
-version=9.1.0
+pkgname=cross-${_triplet}-gcc
+version=9.2.0
 revision=1
-wrksrc="${_pkgname}-${version}"
+wrksrc="gcc-${version}"
+build_wrksrc=build
 build_style=gnu-configure
-configure_args="
- --disable-decimal-float
- --disable-libffi
- --disable-libgomp
- --disable-libmudflap
- --disable-libquadmath
- --disable-libssp
- --disable-libstdcxx-pch
- --disable-nls
- --disable-shared
- --disable-threads
- --disable-tls
- --disable-werror
- --enable-__cxa_atexit
- --enable-c99
- --enable-gnu-indirect-function
- --enable-interwork
- --enable-languages=c,c++
- --enable-long-long
- --enable-multilib
- --enable-plugins
- --host=${XBPS_CROSS_TRIPLET}
- --libdir=/usr/lib
- --libexecdir=/usr/lib
- --prefix=/usr
- --target=${_triplet}
- --with-gmp
- --with-gnu-as
- --with-gnu-ld
- --with-headers=/usr/${_triplet}/include
- --with-host-libstdcxx='-static-libgcc'
- --with-isl
- --with-libelf
- --with-mpc
- --with-mpfr
- --with-multilib-list=rmprofile
- --with-native-system-header-dir=/include
- --with-newlib
- --with-python-dir=share/${_pkgname}-${_triplet}
- --with-sysroot=/usr/${_triplet}
- --with-system-zlib
-"
-make_build_target="all-gcc"
-make_install_target="install-gcc"
+make_build_args="INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0'"
 hostmakedepends="autoconf automake cross-arm-none-eabi-binutils bison flex perl"
 makedepends="gmp-devel isl15-devel libmpc-devel mpfr-devel zlib-devel"
 depends="cross-arm-none-eabi-binutils"
@@ -57,12 +15,72 @@ short_desc="GNU Compiler Collection"
 maintainer="Ivan Sokolov <ivan-p-sokolov@ya.ru>"
 license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://gcc.gnu.org"
-distfiles="${GNU_SITE}/${_pkgname}/${_pkgname}-${version}/${_pkgname}-${version}.tar.xz"
-checksum=79a66834e96a6050d8fe78db2c3b32fb285b230b855d0a66288235bc04b327a0
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
+checksum=ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
 alternatives="arm-none-eabi:/usr/bin/arm-none-eabi-cc:/usr/bin/arm-none-eabi-gcc"
 nocross=yes
 nopie=yes
+nostrip_files="libgcc.a libgcov.a"
+
+post_extract() {
+	mkdir -p build
+}
+
+pre_configure() {
+	export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+	export CXXFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+}
+
+do_configure() {
+	../configure \
+		--disable-decimal-float \
+		--disable-libffi \
+		--disable-libgomp \
+		--disable-libmudflap \
+		--disable-libquadmath \
+		--disable-libssp \
+		--disable-libstdcxx-pch \
+		--disable-libstdc__-v3 \
+		--disable-nls \
+		--disable-shared \
+		--disable-threads \
+		--disable-tls \
+		--disable-werror \
+		--enable-__cxa_atexit \
+		--enable-c99 \
+		--enable-gnu-indirect-function \
+		--enable-interwork \
+		--enable-languages=c,c++ \
+		--enable-long-long \
+		--enable-multilib \
+		--enable-plugins \
+		--host=${XBPS_CROSS_TRIPLET} \
+		--libdir=/usr/lib \
+		--libexecdir=/usr/lib \
+		--prefix=/usr \
+		--target=${_triplet} \
+		--with-gmp \
+		--with-gnu-as \
+		--with-gnu-ld \
+		--with-headers=/usr/${_triplet}/include \
+		--with-host-libstdcxx='-static-libgcc -Wl,-Bstatic,-lstdc++,-Bdynamic -lm' \
+		--with-isl \
+		--with-libelf \
+		--with-mpc \
+		--with-mpfr \
+		--with-multilib-list=rmprofile \
+		--with-native-system-header-dir=/include \
+		--with-newlib \
+		--with-python-dir=share/gcc-${_triplet} \
+		--with-sysroot=/usr/${_triplet} \
+		--with-system-zlib
+}
+
+pre_build() {
+	pre_configure
+}
 
 post_install() {
 	rm -fr ${DESTDIR}/usr/share/{info,man/man7}
+	rm -fr ${DESTDIR}/usr/lib/libcc1.*
 }

--- a/srcpkgs/cross-arm-none-eabi-libstdc++/template
+++ b/srcpkgs/cross-arm-none-eabi-libstdc++/template
@@ -1,0 +1,85 @@
+# Template file for 'cross-${_triplet}-libstdc++'
+_triplet=arm-none-eabi
+pkgname=cross-${_triplet}-libstdc++
+version=9.2.0
+revision=1
+wrksrc="gcc-${version}"
+# gnu-configure implicitly passes stuff we don't want
+build_style=configure
+configure_args="
+ --disable-libstdcxx-pch --disable-libstdcxx-threads
+ --disable-nls --disable-shared --disable-tls --disable-werror
+ --enable-multilib --host=${_triplet} --target=${_triplet}
+ --libdir=/usr/${_triplet}/lib --prefix=/usr/${_triplet}
+ --with-gnu-ld --with-gxx-include-dir=/usr/${_triplet}/include/${version}
+ --with-newlib --with-python-dir=share/gcc-${_triplet}"
+make_build_args="INHIBIT_LIBC_CFLAGS='-DUSE_TM_CLONE_REGISTRY=0'"
+hostmakedepends="autoconf automake cross-arm-none-eabi-binutils
+ cross-arm-none-eabi-gcc cross-arm-none-eabi-newlib bison flex perl"
+makedepends="gmp-devel isl15-devel libmpc-devel mpfr-devel zlib-devel"
+depends="cross-arm-none-eabi-gcc"
+short_desc="GNU Compiler Collection - Standard C++ Library"
+maintainer="q66 <daniel@octaforge.org>"
+license="GPL-3.0-or-later"
+homepage="https://gcc.gnu.org"
+distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
+checksum=ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
+nocross=yes
+nopie=yes
+nostrip=yes
+
+post_extract() {
+	mkdir -p build-{regular,nano}
+}
+
+do_configure() {
+	export CC=arm-none-eabi-gcc
+	export CXX=arm-none-eabi-g++
+	export CPP=arm-none-eabi-cpp
+	export AR=arm-none-eabi-ar
+	export AS=arm-none-eabi-as
+
+	pushd build-regular
+	export CFLAGS="-g -O2 -ffunction-sections -fdata-sections"
+	export CXXFLAGS="-g -O2 -ffunction-sections -fdata-sections"
+	../libstdc++-v3/configure ${configure_args}
+	popd
+
+	pushd build-nano
+	export CFLAGS="-g -Os -ffunction-sections -fdata-sections -fno-exceptions"
+	export CXXFLAGS="-g -Os -ffunction-sections -fdata-sections -fno-exceptions"
+	../libstdc++-v3/configure ${configure_args}
+	popd
+}
+
+do_build() {
+	unset CC CXX CPP AR AS CFLAGS CXXFLAGS
+
+	pushd build-regular
+	make ${makejobs} ${make_build_args}
+	popd
+
+	pushd build-nano
+	make ${makejobs} ${make_build_args}
+	popd
+}
+
+do_install() {
+	pushd build-regular
+	make DESTDIR=${DESTDIR} install
+	popd
+
+	pushd build-nano
+	mkdir -p dest-nano
+	make DESTDIR=$(pwd)/dest-nano install
+	# only install the static libs for nano, no headers
+	local multilibs=( $(${_triplet}-gcc -print-multi-lib 2>/dev/null) )
+	for multilib in "${multilibs[@]}"; do
+		local dir="${multilib%%;*}"
+		local from_dir=dest-nano/usr/${_triplet}/lib/${dir}
+		local to_dir=${DESTDIR}/usr/${_triplet}/lib/${dir}
+		cp -f ${from_dir}/libstdc++.a ${to_dir}/libstdc++_nano.a
+		cp -f ${from_dir}/libsupc++.a ${to_dir}/libsupc++_nano.a
+	done
+	popd
+}

--- a/srcpkgs/cross-arm-none-eabi-newlib/template
+++ b/srcpkgs/cross-arm-none-eabi-newlib/template
@@ -3,21 +3,14 @@ _triplet=arm-none-eabi
 _pkgname=newlib
 pkgname=cross-${_triplet}-${_pkgname}
 version=3.1.0.20181231
-revision=1
+revision=2
 wrksrc="${_pkgname}-${version}"
 build_style=gnu-configure
 configure_args="
- --disable-newlib-supplied-syscalls
- --disable-nls
- --enable-interwork
- --enable-newlib-io-long-long
- --enable-newlib-register-fini
- --host=${XBPS_CROSS_TRIPLET}
- --prefix=/usr
- --target=${_triplet}
- --with-gnu-as
- --with-gnu-ld
-"
+ --prefix=/usr --target=${_triplet} --host=${XBPS_CROSS_TRIPLET}
+ --with-gnu-as --with-gnu-ld --disable-nls
+ --disable-newlib-supplied-syscalls --enable-newlib-retargetable-locking
+ --enable-interwork"
 hostmakedepends="cross-arm-none-eabi-binutils cross-arm-none-eabi-gcc"
 short_desc="C library intended for use on embedded systems"
 maintainer="Ivan Sokolov <ivan-p-sokolov@ya.ru>"
@@ -26,3 +19,59 @@ homepage="https://www.sourceware.org/${_pkgname}/"
 distfiles="ftp://sources.redhat.com/pub/${_pkgname}/${_pkgname}-${version}.tar.gz"
 checksum=9e12fea7297648b114434033ed4458755afe7b9b6c7d58123389e82bd37681c0
 nostrip=yes
+
+post_extract() {
+	mkdir -p build-{newlib,nano}
+}
+
+do_configure() {
+	pushd build-newlib
+	export CFLAGS_FOR_TARGET="-g -O2 -ffunction-sections -fdata-sections"
+	../configure ${configure_args} \
+		--enable-newlib-io-long-long \
+		--enable-newlib-register-fini
+	popd
+
+	pushd build-nano
+	export CFLAGS_FOR_TARGET="-g -Os -ffunction-sections -fdata-sections"
+	../configure ${configure_args} \
+		--enable-newlib-reent-small \
+		--disable-newlib-fvwrite-in-streamio \
+		--disable-newlib-fseek-optimization \
+		--disable-newlib-wide-orient \
+		--enable-newlib-nano-malloc \
+		--disable-newlib-unbuf-stream-opt \
+		--enable-lite-exit \
+		--enable-newlib-global-atexit \
+		--enable-newlib-nano-formatted-io
+	popd
+}
+
+do_build() {
+	pushd build-newlib
+	make ${makejobs}
+	popd
+
+	pushd build-nano
+	make ${makejobs}
+	popd
+}
+
+do_install() {
+	pushd build-nano
+	make DESTDIR=${DESTDIR} install
+	find ${DESTDIR} -regex ".*/lib\(c\|g\|rdimon\)\.a" \
+		-exec rename .a _nano.a '{}' \;
+	install -d ${DESTDIR}/usr/${_triplet}/include/newlib-nano
+	install -m644 -t ${DESTDIR}/usr/${_triplet}/include/newlib-nano \
+		${DESTDIR}/usr/${_triplet}/include/newlib.h
+	popd
+
+	pushd build-newlib
+	make DESTDIR=${DESTDIR} install
+	popd
+}
+
+post_install() {
+	vlicense COPYING
+}

--- a/srcpkgs/cross-arm-none-eabi/template
+++ b/srcpkgs/cross-arm-none-eabi/template
@@ -1,10 +1,11 @@
 # Template file for 'cross-arm-none-eabi'
 _triplet=arm-none-eabi
 pkgname=cross-arm-none-eabi
-version=0.4
+version=0.5
 revision=1
 build_style=meta
-depends="cross-arm-none-eabi-binutils cross-arm-none-eabi-gcc cross-arm-none-eabi-newlib"
+depends="cross-arm-none-eabi-binutils cross-arm-none-eabi-gcc
+ cross-arm-none-eabi-libstdc++ cross-arm-none-eabi-newlib"
 short_desc="GNU cross bare metal toolchain"
 maintainer="Ivan Sokolov <ivan-p-sokolov@ya.ru>"
 license="metapackage"


### PR DESCRIPTION
For `cross-arm-none-eabi-gcc`:

I've reworked this to make it possible to include `libgcc.a`, rather than just the compiler itself. However, as `libstdc++` requires `newlib` to be built and present (which requires the gcc to build), skip building `libstdc++` at this stage. Instead, move it into a separate package.

I figured out the necessary changes mostly by reading the Arch pkgbuild.

For `cross-arm-none-eabi-libstdc++`:

As the gcc cannot include libstdc++ because of its newlib requirement, build it as a separate package. This is achieved by taking the gcc source tree, installing our previously built gcc as well as newlib (which was already packaged) and building libstdc++ on its own. I've successfully compiled things with this.

Two versions are provided, regular and nano. The nano version is built with -Os and no exceptions. You'd presumably use it with nano newlib.

For `cross-arm-none-eabi-newlib`:

We now build a nano variant.

@sirikid 