### PR TITLE
EternalTerminal: Remove manual compile flag

### DIFF
--- a/srcpkgs/EternalTerminal/patches/execinfo.patch
+++ b/srcpkgs/EternalTerminal/patches/execinfo.patch
@@ -1,22 +1,22 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index b277dff..9ee989c 100644
+index b277dff..ad24b56 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
-@@ -12,6 +12,12 @@ endif()
+@@ -125,6 +125,12 @@ include_directories(
+   ${UTEMPTER_INCLUDE_DIR}
+   )
  
- option(CODE_COVERAGE "Enable code coverage" OFF)
- option(DISABLE_CRASH_LOG "Disable installing easylogging crash handler" OFF)
-+option(ENABLE_EXECINFO "Enable execinfo support" OFF)
-+
-+if(ENABLE_EXECINFO)
-+	SET(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -lexecinfo")
-+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_EXECINFO")
++include(CheckIncludeFileCXX)
++check_include_file("execinfo.h" HAVE_EXECINFO_H)
++if (HAVE_EXECINFO_H)
++	add_definitions(-DHAVE_EXECINFO_H)
 +endif()
- 
- SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DET_VERSION='\"${PROJECT_VERSION}\"'")
- # For easylogging, disable default log file, enable crash log, ensure thread safe, and catch c++ exceptions
++
+ add_library(
+   et-lib
+   STATIC
 diff --git external_imported/easyloggingpp/src/easylogging++.cc external_imported/easyloggingpp/src/easylogging++.cc
-index d763ee7..1237d9c 100644
+index d763ee7..02e8b75 100644
 --- external_imported/easyloggingpp/src/easylogging++.cc
 +++ external_imported/easyloggingpp/src/easylogging++.cc
 @@ -2786,7 +2786,7 @@ std::ostream& operator<<(std::ostream& os, const StackTrace& st) {
@@ -24,24 +24,20 @@ index d763ee7..1237d9c 100644
  
  void StackTrace::generateNew(void) {
 -#if ELPP_STACKTRACE
-+#ifdef ENABLE_EXECINFO
++#ifdef HAVE_EXECINFO_H
    m_stack.clear();
    void* stack[kMaxStack];
    unsigned int size = backtrace(stack, kMaxStack);
 diff --git external_imported/easyloggingpp/src/easylogging++.h external_imported/easyloggingpp/src/easylogging++.h
-index 688d537..b4d754e 100644
+index 688d537..0b16966 100644
 --- external_imported/easyloggingpp/src/easylogging++.h
 +++ external_imported/easyloggingpp/src/easylogging++.h
-@@ -360,10 +360,10 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
+@@ -360,7 +360,7 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
  #      include <codecvt>
  #  endif // ELPP_OS_WINDOWS
  #endif  // defined(ELPP_UNICODE)
 -#if ELPP_STACKTRACE
-+#ifdef ENABLE_EXECINFO
++#ifdef HAVE_EXECINFO_H
  #   include <cxxabi.h>
  #   include <execinfo.h>
--#endif  // ELPP_STACKTRACE
-+#endif // ENABLE_EXECINFO
- #if ELPP_OS_ANDROID
- #   include <sys/system_properties.h>
- #endif  // ELPP_OS_ANDROID
+ #endif  // ELPP_STACKTRACE

--- a/srcpkgs/EternalTerminal/template
+++ b/srcpkgs/EternalTerminal/template
@@ -1,7 +1,7 @@
 # Template file for 'EternalTerminal'
 pkgname=EternalTerminal
 version=6.0.5
-revision=1
+revision=2
 wrksrc="${pkgname}-et-v${version}"
 build_style=cmake
 hostmakedepends="protobuf"
@@ -15,10 +15,6 @@ checksum=c029bb0f2d474e13428d0a88853d6596a929814f6ffaa6d2ef4ad436c0127d57
 system_accounts="_eternal"
 
 LDFLAGS="-lgflags"
-
-case "$XBPS_TARGET_LIBC" in
-	glibc) configure_args="-DENABLE_EXECINFO=ON";;
-esac
 
 post_install() {
 	vsv etserver


### PR DESCRIPTION
Re-edited CMakeLists.txt and sources to compile
with or without libexecinfo if system supports it
instead of using case to add or not add.

This is how I have the PR setup for both the ET upstream and
their vendor-ed dependency (easylogging)

Signed-off-by: Nathan Owens <ndowens04@gmail.com>