### PR TITLE
python3-Sphinx: update to 2.3.1, afew add Python 3.8 patch

### DIFF
--- a/srcpkgs/afew/patches/afew-python-3.8.patch
+++ b/srcpkgs/afew/patches/afew-python-3.8.patch
@@ -1,0 +1,8 @@
+--- afew/filters/__init__.py
++++ afew/filters/__init__.py
+@@ -6,4 +6,4 @@
+ 
+ __all__ = list(filename[:-3]
+                for filename in glob.glob1(os.path.dirname(__file__), '*.py')
+-               if filename is not '__init__.py')
++               if filename != '__init__.py')

--- a/srcpkgs/afew/template
+++ b/srcpkgs/afew/template
@@ -1,7 +1,7 @@
 # Template file for 'afew'
 pkgname=afew
 version=2.0.0
-revision=3
+revision=4
 archs=noarch
 build_style=python3-module
 pycompile_module="afew"

--- a/srcpkgs/python-Sphinx/template
+++ b/srcpkgs/python-Sphinx/template
@@ -4,13 +4,13 @@ version=1.8.5
 revision=2
 archs=noarch
 wrksrc="Sphinx-${version}"
-build_style=python-module
+build_style=python2-module
 pycompile_module="sphinx"
-hostmakedepends="python-setuptools python3-setuptools"
+hostmakedepends="python-setuptools"
 depends="python-setuptools python-docutils python-Jinja2 python-Pygments
  python-six python-Babel python-alabaster python-snowballstemmer python-imagesize
  python-requests python-packaging python-sphinxcontrib-websupport python-typing"
-short_desc="Python2 documentation generator"
+short_desc="Python 2 documentation generator"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-2-Clause"
 homepage="http://sphinx-doc.org/"
@@ -24,25 +24,9 @@ alternatives="
  sphinx:sphinx-quickstart:/usr/bin/sphinx-quickstart2"
 
 post_install() {
+	mv ${DESTDIR}/usr/bin/sphinx-apidoc ${DESTDIR}/usr/bin/sphinx-apidoc2
+	mv ${DESTDIR}/usr/bin/sphinx-autogen ${DESTDIR}/usr/bin/sphinx-autogen2
+	mv ${DESTDIR}/usr/bin/sphinx-build ${DESTDIR}/usr/bin/sphinx-build2
+	mv ${DESTDIR}/usr/bin/sphinx-quickstart ${DESTDIR}/usr/bin/sphinx-quickstart2
 	vlicense LICENSE
-}
-
-python3-Sphinx_package() {
-	alternatives="
-	 sphinx:sphinx-apidoc:/usr/bin/sphinx-apidoc3
-	 sphinx:sphinx-autogen:/usr/bin/sphinx-autogen3
-	 sphinx:sphinx-build:/usr/bin/sphinx-build3
-	 sphinx:sphinx-quickstart:/usr/bin/sphinx-quickstart3"
-	archs=noarch
-	depends="python3-setuptools python3-docutils python3-Jinja2 python3-Pygments
-	 python3-six python3-Babel python3-alabaster python3-snowballstemmer
-	 python3-imagesize python3-requests python3-packaging
-	 python3-sphinxcontrib-websupport"
-	pycompile_module="sphinx"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/bin/sphinx-*3
-		vmove usr/lib/python3*
-		vlicense LICENSE
-	}
 }

--- a/srcpkgs/python-Sphinx/update
+++ b/srcpkgs/python-Sphinx/update
@@ -1,1 +1,1 @@
-ignore="*a* *b*"
+ignore="2*"

--- a/srcpkgs/python3-Sphinx
+++ b/srcpkgs/python3-Sphinx
@@ -1,1 +1,0 @@
-python-Sphinx

--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -1,0 +1,34 @@
+# Template file for 'python3-Sphinx'
+pkgname=python3-Sphinx
+version=2.3.1
+revision=1
+archs=noarch
+wrksrc=Sphinx-${version}
+build_style=python3-module
+pycompile_module=sphinx
+hostmakedepends="python3-setuptools"
+depends="python3-Jinja2 python3-docutils python3-Pygments
+ python3-snowballstemmer python3-Babel python3-alabaster python3-imagesize
+ python3-requests python3-packaging python3-sphinxcontrib-applehelp
+ python3-sphinxcontrib-devhelp python3-sphinxcontrib-htmlhelp
+ python3-sphinxcontrib-jsmath python3-sphinxcontrib-qthelp
+ python3-sphinxcontrib-serializinghtml"
+short_desc="Python 3 documentation generator"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-3-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/S/Sphinx/Sphinx-${version}.tar.gz"
+checksum=e6e766b74f85f37a5f3e0773a1e1be8db3fcb799deb58ca6d18b70b0b44542a5
+alternatives="
+ sphinx:sphinx-apidoc:/usr/bin/sphinx-apidoc3
+ sphinx:sphinx-autogen:/usr/bin/sphinx-autogen3
+ sphinx:sphinx-build:/usr/bin/sphinx-build3
+ sphinx:sphinx-quickstart:/usr/bin/sphinx-quickstart3"
+
+post_install() {
+	mv ${DESTDIR}/usr/bin/sphinx-apidoc ${DESTDIR}/usr/bin/sphinx-apidoc3
+	mv ${DESTDIR}/usr/bin/sphinx-autogen ${DESTDIR}/usr/bin/sphinx-autogen3
+	mv ${DESTDIR}/usr/bin/sphinx-build ${DESTDIR}/usr/bin/sphinx-build3
+	mv ${DESTDIR}/usr/bin/sphinx-quickstart ${DESTDIR}/usr/bin/sphinx-quickstart3
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sphinxcontrib-applehelp/template
+++ b/srcpkgs/python3-sphinxcontrib-applehelp/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-sphinxcontrib-applehelp'
+pkgname=python3-sphinxcontrib-applehelp
+version=1.0.1
+revision=1
+archs=noarch
+wrksrc=sphinxcontrib-applehelp-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Sphinx extension which outputs Apple help book"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/s/sphinxcontrib-applehelp/sphinxcontrib-applehelp-${version}.tar.gz"
+checksum=edaa0ab2b2bc74403149cb0209d6775c96de797dfd5b5e2a71981309efab3897
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sphinxcontrib-devhelp/template
+++ b/srcpkgs/python3-sphinxcontrib-devhelp/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-sphinxcontrib-devhelp'
+pkgname=python3-sphinxcontrib-devhelp
+version=1.0.1
+revision=1
+archs=noarch
+wrksrc=sphinxcontrib-devhelp-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Sphinx extension which outputs Devhelp document"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/s/sphinxcontrib-devhelp/sphinxcontrib-devhelp-${version}.tar.gz"
+checksum=6c64b077937330a9128a4da74586e8c2130262f014689b4b89e2d08ee7294a34
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sphinxcontrib-htmlhelp/template
+++ b/srcpkgs/python3-sphinxcontrib-htmlhelp/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-sphinxcontrib-htmlhelp'
+pkgname=python3-sphinxcontrib-htmlhelp
+version=1.0.2
+revision=1
+archs=noarch
+wrksrc=sphinxcontrib-htmlhelp-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Sphinx extension which outputs HTML document"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/s/sphinxcontrib-htmlhelp/sphinxcontrib-htmlhelp-${version}.tar.gz"
+checksum=4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sphinxcontrib-jsmath/template
+++ b/srcpkgs/python3-sphinxcontrib-jsmath/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-sphinxcontrib-jsmath'
+pkgname=python3-sphinxcontrib-jsmath
+version=1.0.1
+revision=1
+archs=noarch
+wrksrc=sphinxcontrib-jsmath-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Sphinx extension which renders Math in HTML by Javascript"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/s/sphinxcontrib-jsmath/sphinxcontrib-jsmath-${version}.tar.gz"
+checksum=a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sphinxcontrib-qthelp/template
+++ b/srcpkgs/python3-sphinxcontrib-qthelp/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-sphinxcontrib-qthelp'
+pkgname=python3-sphinxcontrib-qthelp
+version=1.0.2
+revision=1
+archs=noarch
+wrksrc=sphinxcontrib-qthelp-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Sphinx extension which outputs QtHelp document"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/s/sphinxcontrib-qthelp/sphinxcontrib-qthelp-${version}.tar.gz"
+checksum=79465ce11ae5694ff165becda529a600c754f4bc459778778c7017374d4d406f
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sphinxcontrib-serializinghtml/template
+++ b/srcpkgs/python3-sphinxcontrib-serializinghtml/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-sphinxcontrib-serializinghtml'
+pkgname=python3-sphinxcontrib-serializinghtml
+version=1.1.3
+revision=1
+archs=noarch
+wrksrc=sphinxcontrib-serializinghtml-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Sphinx extension which outputs serialized HTML document"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://sphinx-doc.org"
+distfiles="${PYPI_SITE}/s/sphinxcontrib-serializinghtml/sphinxcontrib-serializinghtml-${version}.tar.gz"
+checksum=c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
- split out from python-Sphinx (2.x.x doesn't support python 2)
- despite their license looks like BSD-2-Clause, their README says it's a BSD-3-Clause
- python3-Sphinx doesn't depends on python3-setuptools (checked the code)
- afew docs couldn't be built with old Sphinx