### PR TITLE
tuimoji: add python3-setuptools to depends

### DIFF
--- a/srcpkgs/tuimoji/template
+++ b/srcpkgs/tuimoji/template
@@ -1,12 +1,12 @@
 # Template file for 'tuimoji'
 pkgname=tuimoji
 version=1.0.0
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 pycompile_module="tuimoji"
 hostmakedepends="python3-setuptools"
-depends="python3-urwid xclip"
+depends="python3-urwid xclip python3-setuptools"
 short_desc="Terminal based emoji chooser"
 maintainer="travankor <travankor@tuta.io>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
tuimoji needs python3-setuptools to run.
Closes: #17835

Signed-off-by: Nathan Owens <ndowens04@gmail.com>