### PR TITLE
python3-future: fix pycompile modules.

### DIFF
--- a/srcpkgs/python-future/template
+++ b/srcpkgs/python-future/template
@@ -1,7 +1,7 @@
 # Template file for 'python-future'
 pkgname=python-future
 version=0.17.1
-revision=2
+revision=3
 archs=noarch
 wrksrc="future-${version}"
 build_style=python-module
@@ -12,8 +12,8 @@ hostmakedepends="python-setuptools python3-setuptools"
 depends="python-setuptools"
 short_desc="Clean single-source support for Python 3 and 2 (Python2)"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://python-future.org/"
 license="MIT"
+homepage="https://python-future.org/"
 distfiles="${PYPI_SITE}/f/future/future-${version}.tar.gz"
 checksum=67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8
 
@@ -30,9 +30,7 @@ python3-future_package() {
 	 future:futurize:/usr/bin/futurize3
 	 future:pasteurize:/usr/bin/pasteurize3"
 	archs=noarch
-	pycompile_module="_dummy_thread _markupbase _thread builtins
-	 copyreg future html http libfuturize libpasteurize past queue reprlib
-	 socketserver tkinter winreg xmlrpc"
+	pycompile_module="future libfuturize libpasteurize past"
 	depends="python3-setuptools"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {


### PR DESCRIPTION
When I installing `python3-future-0.17.1_2`:
```
python3-future-0.17.1_2: configuring ...
Byte-compiling python3.8 code for module _dummy_thread...
Can't list 'usr/lib/python3.8/site-packages/_dummy_thread'
Can't list 'usr/lib/python3.8/site-packages/_dummy_thread'
Byte-compiling python3.8 code for module _markupbase...
Can't list 'usr/lib/python3.8/site-packages/_markupbase'
Can't list 'usr/lib/python3.8/site-packages/_markupbase'
Byte-compiling python3.8 code for module _thread...
Can't list 'usr/lib/python3.8/site-packages/_thread'
Can't list 'usr/lib/python3.8/site-packages/_thread'
Byte-compiling python3.8 code for module builtins...
Can't list 'usr/lib/python3.8/site-packages/builtins'
Can't list 'usr/lib/python3.8/site-packages/builtins'
Byte-compiling python3.8 code for module copyreg...
Can't list 'usr/lib/python3.8/site-packages/copyreg'
Can't list 'usr/lib/python3.8/site-packages/copyreg'
Byte-compiling python3.8 code for module future...
Byte-compiling python3.8 code for module html...
Can't list 'usr/lib/python3.8/site-packages/html'
Can't list 'usr/lib/python3.8/site-packages/html'
Byte-compiling python3.8 code for module http...
Can't list 'usr/lib/python3.8/site-packages/http'
Can't list 'usr/lib/python3.8/site-packages/http'
Byte-compiling python3.8 code for module libfuturize...
Byte-compiling python3.8 code for module libpasteurize...
Byte-compiling python3.8 code for module past...
Byte-compiling python3.8 code for module queue...
Can't list 'usr/lib/python3.8/site-packages/queue'
Can't list 'usr/lib/python3.8/site-packages/queue'
Byte-compiling python3.8 code for module reprlib...
Can't list 'usr/lib/python3.8/site-packages/reprlib'
Can't list 'usr/lib/python3.8/site-packages/reprlib'
Byte-compiling python3.8 code for module socketserver...
Can't list 'usr/lib/python3.8/site-packages/socketserver'
Can't list 'usr/lib/python3.8/site-packages/socketserver'
Byte-compiling python3.8 code for module tkinter...
Can't list 'usr/lib/python3.8/site-packages/tkinter'
Can't list 'usr/lib/python3.8/site-packages/tkinter'
Byte-compiling python3.8 code for module winreg...
Can't list 'usr/lib/python3.8/site-packages/winreg'
Can't list 'usr/lib/python3.8/site-packages/winreg'
Byte-compiling python3.8 code for module xmlrpc...
Can't list 'usr/lib/python3.8/site-packages/xmlrpc'
Can't list 'usr/lib/python3.8/site-packages/xmlrpc'
Updating ldconfig(8) cache...
python3-future-0.17.1_2: installed successfully.
```