### PR TITLE
libmysofa: update to 0.9

### DIFF
--- a/srcpkgs/libmysofa/template
+++ b/srcpkgs/libmysofa/template
@@ -1,6 +1,6 @@
 # Template file for 'libmysofa'
 pkgname=libmysofa
-version=0.8
+version=0.9
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTS=OFF"
@@ -11,7 +11,7 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/hoene/libmysofa"
 distfiles="https://github.com/hoene/libmysofa/archive/v${version}.tar.gz"
-checksum=0e0abb6ec6f5f09266325741d6ef218532187129f65d0bc6b21e155760dfb2ad
+checksum=9d8f8aec6d73209dadd1b33d436d397dbd3372ef8a8627081e0d28a8e7cc40d2
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Update to 0.9, which also includes fix for
CVE-2019-20016

Signed-off-by: Nathan Owens <ndowens04@gmail.com>