### PR TITLE
libredwg: update to 0.9.3.

### DIFF
--- a/srcpkgs/libredwg/template
+++ b/srcpkgs/libredwg/template
@@ -1,6 +1,6 @@
 # Template file for 'libredwg'
 pkgname=libredwg
-version=0.9.2
+version=0.9.3
 revision=1
 build_style=gnu-configure
 configure_args="--disable-bindings"
@@ -10,8 +10,8 @@ short_desc="Free library to handle DWG files"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/libredwg/"
-distfiles="$GNU_SITE/libredwg/libredwg-${version}.tar.xz"
-checksum=d4ba88bfd031a0901f6f3ad007ec87f5d9f328fb10d1bce2daf66315625d0364
+distfiles="https://github.com/LibreDWG/libredwg/releases/download/${version}/libredwg-${version}.tar.xz"
+checksum=db2dcc73d447397b23cbb556549b7a75f52a1513c0cfbebde3e786b53d97333b
 
 libredwg-tools_package() {
 	short_desc+=" - utilities"


### PR DESCRIPTION
Updated to 0.9.3
CVE fixed in this release:
2019-20009 2019-20010 2019-20011 2019-20012
2019-20013 2019-20014 2019-20015

Signed-off-by: Nathan Owens <ndowens04@gmail.com>