### PR TITLE
WIP: New package: cargo-prefetch-0.1.0

### DIFF
--- a/srcpkgs/cargo-prefetch/template
+++ b/srcpkgs/cargo-prefetch/template
@@ -1,0 +1,18 @@
+# Template file for 'cargo-prefetch'
+pkgname=cargo-prefetch
+version=0.1.0
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libressl-devel"
+short_desc="cargo subcommand to download popular crates"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT, Apache-2.0"
+homepage="https://github.com/ehuss/cargo-prefetch"
+distfiles="https://static.crates.io/crates/${pkgname}/${pkgname}-${version}.crate"
+checksum=482ab7c5d3fe41eaa3948a91de762339e9f9e286e8bead19301c2e723f7d5ebf
+
+pre_build() {
+	cargo update --package openssl-sys --precise 0.9.53
+	cargo update --package openssl --precise 0.10.26
+}


### PR DESCRIPTION
Currently upstream doesn't have git tags for the release,
and the source distributed via crates.io doesn't contain license files.