### PR TITLE
bumblebee: set correct MODPATH_NVIDIA after libglvnd switch

### DIFF
--- a/srcpkgs/bumblebee/template
+++ b/srcpkgs/bumblebee/template
@@ -1,13 +1,13 @@
 # Template file for 'bumblebee'
 pkgname=bumblebee
 version=3.2.1
-revision=7
+revision=8
 archs="i686 x86_64"
 build_style=gnu-configure
 configure_args="
  CONF_DRIVER_MODULE_NVIDIA=nvidia
  CONF_LDPATH_NVIDIA=/usr/lib
- CONF_MODPATH_NVIDIA=/usr/lib/xorg/modules
+ CONF_MODPATH_NVIDIA=/usr/lib/nvidia/xorg,/usr/lib/xorg/modules
  --with-udev-rules=/usr/lib/udev/rules.d/
  --without-pidfile"
 conf_files="


### PR DESCRIPTION
This simple change results in a working bumblebee setup in a `mesa`/`nvidia390` Optimus laptop. After the switch to `libglvnd`, `bumblebee` can be setup correctly because `nvidia390` doesn't attempt to replace `mesa` anymore. Enabling the `bumblebeed` service makes Xorg pick up Mesa's GLX by default, while apps run with `optirun` use NVIDIA's GL. Arch has an additional [patch](https://git.archlinux.org/svntogit/community.git/tree/trunk/0008-libglvnd.patch?h=packages/bumblebee) for `libglvnd` support which sets the __GLVND_DISALLOW_PATCHING env variable but I didn't find it necessary, maybe it's the result of a recent `libglvnd` update. If someone else finds that necessary, we can include it.
Tested on a Optimus laptop with `mesa`/`nvidia390` configuration (but should also work for `mesa`/`nvidia`, although NVIDIA's Prime Render Offload is a much better method performance-wise).