### PR TITLE
New Package: vsv@1.3.2

### DIFF
--- a/srcpkgs/vsv/template
+++ b/srcpkgs/vsv/template
@@ -1,0 +1,18 @@
+# Template file for 'vsv'
+pkgname=vsv
+version=1.3.2
+revision=1
+archs=noarch
+depends="bash coreutils psmisc"
+short_desc="Manage and view runit services"
+maintainer="Dave Eddy <dave@daveeddy.com>"
+license="MIT"
+homepage="https://github.com/bahamas10/vsv"
+distfiles="https://github.com/bahamas10/vsv/archive/v${version}.tar.gz"
+checksum=0f31850cdc676ae25c2524a4e7998a62785ff268b883d3f544c6fd93ddc0b5bc
+
+do_install() {
+	vbin vsv
+	vman man/vsv.8
+	vlicense LICENSE
+}


### PR DESCRIPTION
Summary
======

This adds [vsv](https://github.com/bahamas10/vsv) ([blog post intro](https://www.daveeddy.com/2018/09/20/vsv-void-service-manager/)).  This a bash wrapper around `sv` to add some fanciness to managing runit.

Personal Testimony
----------------------------

I install `vsv` almost immediately on every void installation I make... I'd recommend giving it a quick try if you haven't for nothing more than to just get a quick summary with a simple command:

![2020-01-01_21:24:55_2560x1440_scrot](https://user-images.githubusercontent.com/1205722/71649508-64472480-2cdd-11ea-9e1e-7b279a07173c.png)

Possible Issues
---------------------

1.  The name: I made it `vsv` to stand for `Void Service Manager`.  This is short-sighted at best as this can work on more than just Void - basically any OS that has runit and `sv` installed.  Also, this isn't an *official* Void sanctioned piece of software.  I haven't included `Void` in the name in the template and instead just left it as `vsv`... but I could see this potentially being an issue.
2. `vsv` is already used in this repo as one of the built in commands.  I don't think this is a huge issue since aliases and bash/sh functions will always be preferred over external commands, but just something to note.
3.  This doesn't meet the quality requirements in the contributing handbook - this software is not compiled.