### PR TITLE
New package: whipper-0.9.0

### DIFF
--- a/srcpkgs/python3-pycdio/template
+++ b/srcpkgs/python3-pycdio/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-pycdio'
+pkgname=python3-pycdio
+version=2.1.0
+revision=1
+wrksrc=pycdio-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools pkg-config swig"
+makedepends="libcdio-devel python3-devel"
+short_desc="Python OO interface to libcdio (CD Input and Control library)"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://www.gnu.org/software/libcdio"
+distfiles="${GNU_SITE}/libcdio/pycdio-${version}.tar.gz"
+checksum=d6d2e59d16339788835eed62ff75cfa38e7caa6f7e290dcc0d07f8ec30de6705

--- a/srcpkgs/whipper/patches/fix-failed-task-analyzetask.patch
+++ b/srcpkgs/whipper/patches/fix-failed-task-analyzetask.patch
@@ -1,0 +1,24 @@
+From 305678ec85568e9fdbc888078c11a1f7d4bc0100 Mon Sep 17 00:00:00 2001
+From: Merlijn Wajer <merlijn@wizzup.org>
+Date: Sat, 14 Dec 2019 18:16:30 +0800
+Subject: [PATCH] program/cdparanoia: fix failed() task of AnalyzeTask
+
+---
+ whipper/program/cdparanoia.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/whipper/program/cdparanoia.py b/whipper/program/cdparanoia.py
+index 636e6f5..f071674 100644
+--- a/whipper/program/cdparanoia.py
++++ b/whipper/program/cdparanoia.py
+@@ -603,7 +603,7 @@ class AnalyzeTask(ctask.PopenTask):
+     def failed(self):
+         # cdparanoia exits with return code 1 if it can't determine
+         # whether it can defeat the audio cache
+-        output = "".join(self._output)
++        output = "".join(o.decode() for o in self._output)
+         m = _WARNING_RE.search(output)
+         if m or _ABORTING_RE.search(output):
+             self.defeatsCache = False
+-- 
+2.17.1

--- a/srcpkgs/whipper/template
+++ b/srcpkgs/whipper/template
@@ -1,0 +1,23 @@
+# Template file for 'whipper'
+pkgname=whipper
+version=0.9.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="libsndfile-devel python3-devel"
+depends="libcdio-paranoia cdrdao python3-gobject python3-musicbrainzngs
+ python3-mutagen python3-requests python3-pycdio python3-discid
+ python3-ruamel.yaml flac sox"
+short_desc="Python CD-DA ripper preferring accuracy over speed"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/whipper-team/whipper"
+distfiles="https://github.com/whipper-team/whipper/archive/v${version}.tar.gz"
+checksum=3caceeec7ca73c8b73147884b0f8eeacbe66af52900021b564118b88d23afbd2
+
+patch_args="-Np1"
+
+pre_build() {
+# Temporary workaround for https://github.com/whipper-team/whipper/issues/428
+	echo "Version: ${version}" > PKG-INFO
+}


### PR DESCRIPTION
https://github.com/whipper-team/whipper

> Whipper is a Python 3 (3.5+) CD-DA ripper based on the morituri project (CDDA ripper for *nix systems aiming for accuracy over speed). It started just as a fork of morituri - which development seems to have halted - merging old ignored pull requests, improving it with bugfixes and new features. Nowadays whipper's codebase diverges significantly from morituri's one.

It was requested multiple times (#2201, #4182) but couldn't be packaged because it used python2 before current release.

Tested on `x86_64` (successfully ripped cd with default configuration).