### PR TITLE
julia: update to 1.3.1.

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,6 +1,6 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.3.0
+version=1.3.1
 revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
@@ -26,7 +26,7 @@ maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=98c38f75eab1c16bde71509e8e3bdc941bc4686fe80dfc3c560f851c81e9e748
+checksum=053908ec2706eb76cfdc998c077de123ecb1c60c945b4b5057aa3be19147b723
 nocross=yes
 # Falsely detects dependency on libllvm
 skiprdeps="/usr/lib/libjulia.so.1.3 /usr/lib/julia/libllvmcalltest.so"


### PR DESCRIPTION
[ci skip] for building llvm

Built and tested locally on AMD64 with glibc.