### PR TITLE
python-stem: update to 1.8.0

### DIFF
--- a/srcpkgs/python-stem/template
+++ b/srcpkgs/python-stem/template
@@ -1,7 +1,7 @@
 # Template file for 'python-stem'
 pkgname=python-stem
-version=1.7.1
-revision=2
+version=1.8.0
+revision=1
 archs=noarch
 wrksrc="stem-${version/b/}"
 build_style=python-module
@@ -10,11 +10,11 @@ hostmakedepends="python-devel python3-devel"
 depends="python-cryptography"
 short_desc="Python2 controller library for Tor"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="LGPL-3"
+license="LGPL-3.0-or-later"
 homepage="https://stem.torproject.org/"
 changelog="https://stem.torproject.org/change_log.html#version-1-7"
 distfiles="${PYPI_SITE}/s/stem/stem-${version}.tar.gz"
-checksum=c9eaf3116cb60c15995cbd3dec3a5cbc50e9bb6e062c4d6d42201e566f498ca2
+checksum=a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2
 alternatives="stem:tor-prompt:/usr/bin/tor-prompt2"
 
 python3-stem_package() {


### PR DESCRIPTION
nyx stopped working after my latest update. According to the following link, a newer python-stem is needed: https://bugs.archlinux.org/task/64647

Bumping python-stem to 1.8.0 makes nyx work on my system again.

The other utility depending on python-stem, onionshare, couldn't be tested with the new version since it crashes in the werkzeug package (it breaks in the same place with python-stem 1.7.1).