### PR TITLE
riot-desktop: update to v1.5.6 + Questions

### DIFF
--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=1.5.0
+version=1.5.6
 revision=1
 archs="i686 x86_64"
 wrksrc="riot-web-${version}"
@@ -12,7 +12,7 @@ maintainer="Bendodroid <bendodroid@icloud.com>"
 license="Apache-2.0"
 homepage="https://riot.im"
 distfiles="https://github.com/vector-im/riot-web/archive/v${version}.tar.gz"
-checksum=d4bfdf0ccd8eb1a6e6f2f52b5809e7719e7eea7096211c12563ae480fbcd341b
+checksum=81716845e53cca31ce3dc6ed42640ec56279b9171db2709e3f6f81b93c415a6a
 nocross=yes
 nostrip=yes
 shlib_provides="libGLVESv2.so"


### PR DESCRIPTION
Does what it says.

As I am currently not using VoidLinux actively on my main machine and still don't fully grasp the whole electron build process, I am looking for a new maintainer who is more familiar with yarn and that stuff. How do I indicate that?
And just out of interest, is anyone actually using riot-desktop on Void? Seeing the electron label here on github doesn't indicate high praise for electron in general among Void users.
And even though I didn't update for several versions, not one person complained via email, so I assume that nobody would miss the package. There's a flatpak and a snap anyway. So I guess it wouldn't be a big thing to remove the package entirely. One fewer electron app, yay.