### PR TITLE
emacs: add dbus build option

### DIFF
--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -27,7 +27,7 @@ nocross=yes
 nopie=yes
 
 # Package build options
-build_options="jpeg tiff gif png xpm svg xml imagemagick gnutls sound m17n"
+build_options="jpeg tiff gif png xpm svg xml imagemagick gnutls sound m17n dbus"
 desc_option_xpm="Enable support for XPM images"
 desc_option_sound="Enable support for sound"
 desc_option_m17n="Enable support for m17n multilingual text processing"
@@ -45,11 +45,11 @@ pre_configure() {
 
 do_configure() {
 	cd $wrksrc/nox
-	./configure --without-x --without-dbus ${configure_args}
+	./configure --without-x $(vopt_with dbus) ${configure_args}
 
 	cd $wrksrc/x11
 	./configure --with-x-toolkit=athena --without-toolkit-scroll-bars \
-		--without-dbus --without-gconf --without-gsettings \
+		$(vopt_with dbus) --without-gconf --without-gsettings \
 		${configure_args}
 
 	cd $wrksrc/gtk2


### PR DESCRIPTION
@leahneukirchen 

I use dbus on emacs without lockups, and use it for notifications as well. This will atleast give option to enable it if a user wanted, but not as default.