### PR TITLE
 editline: update to 1.17.0 

### DIFF
--- a/srcpkgs/editline/template
+++ b/srcpkgs/editline/template
@@ -1,6 +1,6 @@
 # Template file for 'editline'
 pkgname=editline
-version=1.16.1
+version=1.17.0
 revision=1
 build_style=gnu-configure
 short_desc="Minimal readline() replacement"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Spencer-94"
 homepage="http://troglobit.com/projects/editline/"
 distfiles="https://github.com/troglobit/editline/releases/download/${version}/editline-${version}.tar.xz"
-checksum=6518cc0d8241bcebc860432d1babc662a9ce0f5d6035649effe38b5bc9463f8c
+checksum=257fbf1f92eeb401d448f5a7f5e108416afd0f5979c5cbab2ea3010e0152ee93
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/share/doc


### PR DESCRIPTION
Bumped nix as there was a SONAME change, even though xbps didn't detect it. Upstream stated 1.0.1 -> 1.0.2. Verified by building old and new and there was a difference.