### PR TITLE
Fix the SDL2 gles stuff on arm*

### DIFF
--- a/srcpkgs/SDL2_image/template
+++ b/srcpkgs/SDL2_image/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2_image'
 pkgname=SDL2_image
 version=2.0.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-jpg-shared
  --disable-png-shared --disable-webp-shared --disable-tif-shared"
@@ -13,27 +13,6 @@ license="Zlib"
 homepage="http://www.libsdl.org/projects/SDL_image/"
 distfiles="http://www.libsdl.org/projects/SDL_image/release/${pkgname}-${version}.tar.gz"
 checksum=bdd5f6e026682f7d7e1be0b6051b209da2f402a2dd8bd1c4bd9c25ad263108d0
-
-# Package build options
-build_options="gles"
-
-case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		# Enable OpenGL/ES on rpi platforms
-		build_options_default="gles"
-		;;
-esac
-
-
-if [ "$build_option_gles" ]; then
-	case "$XBPS_TARGET_MACHINE" in
-	armv[67]*)
-		# RaspberryPi, use Videocore IV
-		makedepends+=" rpi-userland-devel"
-		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib -lbcm_host"
-		;;
-	esac
-fi
 
 post_install() {
 	vlicense COPYING.txt COPYING

--- a/srcpkgs/SDL2_mixer/template
+++ b/srcpkgs/SDL2_mixer/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2_mixer'
 pkgname=SDL2_mixer
 version=2.0.4
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel libvorbis-devel libmikmod-devel libflac-devel
@@ -15,27 +15,6 @@ homepage="http://www.libsdl.org/projects/SDL_mixer/"
 distfiles="http://www.libsdl.org/projects/SDL_mixer/release/${pkgname}-${version}.tar.gz"
 checksum=b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419
 
-# Package build options
-build_options="gles"
-
-case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		# Enable OpenGL/ES on rpi platforms
-		build_options_default="gles"
-		;;
-esac
-
-
-if [ "$build_option_gles" ]; then
-	case "$XBPS_TARGET_MACHINE" in
-	armv[67]*)
-		# RaspberryPi, use Videocore IV
-		makedepends+=" rpi-userland-devel"
-		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib -lbcm_host"
-		;;
-	esac
-fi
-
 pre_configure() {
 	sed -e "/CONFIG_FILE_ETC/s|/etc/timidity.cfg|/etc/timidity++/timidity.cfg|" \
 		-e "/DEFAULT_PATH/s|/etc/timidity|/etc/timidity++|" \
@@ -48,7 +27,7 @@ post_install() {
 }
 
 SDL2_mixer-devel_package() {
-	depends="SDL2-devel ${sourcepkg}>=${version}_${revision}"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/SDL2_net/template
+++ b/srcpkgs/SDL2_net/template
@@ -1,46 +1,24 @@
 # Template file for 'SDL2_net'
 pkgname=SDL2_net
 version=2.0.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel"
 short_desc="SDL2 networking module"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="https://www.libsdl.org/projects/SDL_net/"
 distfiles="https://www.libsdl.org/projects/SDL_net/release/${pkgname}-${version}.tar.gz"
 checksum=15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21
-
-# Package build options
-build_options="gles"
-
-case "$XBPS_TARGET_MACHINE" in
-	arm*)
-		# Enable OpenGL/ES on rpi platforms
-		build_options_default="gles"
-		;;
-esac
-
-
-if [ "$build_option_gles" ]; then
-	case "$XBPS_TARGET_MACHINE" in
-	armv[67]*)
-		# RaspberryPi, use Videocore IV
-		makedepends+=" rpi-userland-devel"
-		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib -lbcm_host"
-		;;
-	esac
-fi
-
 
 post_install() {
 	vlicense COPYING.txt
 }
 
 SDL2_net-devel_package() {
-	depends="SDL2-devel ${sourcepkg}>=${version}_${revision}"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/libwebp/template
+++ b/srcpkgs/libwebp/template
@@ -1,12 +1,12 @@
 # Template file for 'libwebp'
 pkgname=libwebp
 version=1.0.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-libwebpmux
  --enable-libwebpdemux --enable-libwebpdecoder"
 hostmakedepends="pkg-config"
-makedepends="giflib-devel libfreeglut-devel libpng-devel tiff-devel"
+makedepends="giflib-devel libpng-devel tiff-devel"
 short_desc="WebP image format"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
@@ -17,6 +17,7 @@ checksum=e20a07865c8697bba00aebccc6f54912d6bc333bb4d604e6b07491c1a226b34f
 case "$XBPS_TARGET_MACHINE" in
 	armv6*) configure_args+=" --disable-neon";;
 	armv7*) CFLAGS="-mfpu=neon";;
+	*) makedepends+=" libfreeglut-devel";;
 esac
 
 post_install() {

--- a/srcpkgs/rocksndiamonds/template
+++ b/srcpkgs/rocksndiamonds/template
@@ -1,7 +1,7 @@
 # Template file for 'rocksndiamonds'
 pkgname=rocksndiamonds
 version=4.1.4.0
-revision=2
+revision=1
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="SDL2_image-devel SDL2_mixer-devel SDL2_net-devel"

--- a/srcpkgs/rocksndiamonds/template
+++ b/srcpkgs/rocksndiamonds/template
@@ -1,7 +1,7 @@
 # Template file for 'rocksndiamonds'
 pkgname=rocksndiamonds
 version=4.1.4.0
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="SDL2_image-devel SDL2_mixer-devel SDL2_net-devel"
@@ -14,9 +14,6 @@ distfiles="http://www.artsoft.org/RELEASES/unix/${pkgname}/${pkgname}-${version}
 checksum=40658f923b9efa9116476abe8427fb65596b2015cf845dd83a4d8c3de1a32e5b
 
 LDFLAGS="-lz"
-case "$XBPS_TARGET_MACHINE" in
-	arm*) broken="https://build.voidlinux.org/builders/armv6l-musl_builder/builds/23388/steps/shell_3/logs/stdio";;
-esac
 
 do_build() {
 	CFLAGS+=" -DTARGET_SDL2"
@@ -24,7 +21,7 @@ do_build() {
 	CFLAGS+=" -DRW_GAME_DIR='\"/var/lib/${pkgname}\"'"
 	CFLAGS+=" $(sdl2-config --cflags)"
 	LDFLAGS+=" $(sdl2-config --libs) -lSDL2_image -lSDL2_mixer -lSDL2_net -lm"
-	make CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" sdl2
+	make ${makejobs} CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" sdl2
 }
 
 do_install() {


### PR DESCRIPTION
There's no need to propagate the gles settings from SDL2.

@pullmoll why did you add those? AFAIK only SDL2 is enough.