### PR TITLE
gdk-pixbuf: add shared-mime-info to depends

### DIFF
--- a/srcpkgs/gdk-pixbuf/template
+++ b/srcpkgs/gdk-pixbuf/template
@@ -1,7 +1,7 @@
 # Template file for 'gdk-pixbuf'
 pkgname=gdk-pixbuf
 version=2.40.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dgir=$(vopt_if gir true false) -Djasper=false
@@ -9,6 +9,7 @@ configure_args="-Dgir=$(vopt_if gir true false) -Djasper=false
 hostmakedepends="gettext-devel glib-devel pkg-config libxslt docbook-xsl"
 makedepends="libX11-devel libglib-devel libpng-devel tiff-devel
  shared-mime-info"
+depends="shared-mime-info"
 short_desc="Image loading library for The GTK+ toolkit (v2)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
I noticed because `sway` (or better, `swaybg`) was failing to show the wallpaper on a minimal install. The error was inside the library `gdk-pixbuf`. Installing `shared-mime-info` fixed the issue.