### PR TITLE
monero-gui: add missing dep qt5-xmlpatterns

### DIFF
--- a/srcpkgs/monero-gui/template
+++ b/srcpkgs/monero-gui/template
@@ -1,14 +1,14 @@
 # Template file for 'monero-gui'
 pkgname=monero-gui
 version=0.15.0.3
-revision=1
+revision=2
 build_style=qmake
 hostmakedepends="pkg-config qt5-tools qt5-qmake qt5-quickcontrols qt5-declarative-devel
  qt5-svg-devel"
 makedepends="boost-devel libatomic-devel libunwind-devel miniupnpc-devel monero-devel
 qt5-declarative-devel readline-devel unbound-devel libsodium-devel hidapi-devel
  qt5-svg-devel RandomX"
-depends="qt5-graphicaleffects qt5-quickcontrols qt5-quickcontrols2"
+depends="qt5-graphicaleffects qt5-quickcontrols qt5-quickcontrols2 qt5-xmlpatterns"
 short_desc="GUI for the core Monero implementation"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="BSD-3-Clause"


### PR DESCRIPTION
`qt5-xmlpatterns` is needed during runtime, otherwise the program exits with the following error message:

> 2020-01-06 23:28:27.251	W QQmlApplicationEngine failed to load component
> 2020-01-06 23:28:27.251	W qrc:/main.qml:1701 Type WizardLang unavailable
> 2020-01-06 23:28:27.251	W qrc:/wizard/WizardLang.qml:32 module "QtQuick.XmlListModel" is not installed
> 2020-01-06 23:28:27.251	E Error: no root objects