### PR TITLE
postgresql: update to 12.1

### DIFF
--- a/srcpkgs/postgresql/template
+++ b/srcpkgs/postgresql/template
@@ -1,6 +1,6 @@
 # Template file for 'postgresql'
 pkgname=postgresql
-version=9.6.16
+version=12.1
 revision=1
 build_style=gnu-configure
 make_build_target=world
@@ -17,7 +17,8 @@ maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="PostgreSQL"
 homepage="https://www.postgresql.org"
 distfiles="https://ftp.postgresql.org/pub/source/v${version}/${pkgname}-${version}.tar.bz2"
-checksum=5c6cba9cc0df70ba2b128c4a87d0babfce7c0e2b888f70a9c8485745f66b22e7
+checksum=a09bf3abbaf6763980d0f8acbb943b7629a8b20073de18d867aecdb7988483ed
+
 
 conf_files="
 	/etc/default/${pkgname}
@@ -76,7 +77,7 @@ postgresql-libs_package() {
 	pkg_install() {
 		vmove "usr/lib/*.so*"
 		for d in $(find ${DESTDIR}/usr/share/locale \
-		    -type f -name libpq5\*); do
+			-type f -name libpq5\*); do
 			mkdir -p ${PKGDESTDIR}/$(dirname ${d#${DESTDIR}})
 			mv ${d} ${PKGDESTDIR}/$(dirname ${d#${DESTDIR}})
 		done
@@ -137,14 +138,12 @@ postgresql-pltcl_package() {
 	depends="postgresql>=$version"
 	short_desc="PL/Tcl procedural language for PostgreSQL"
 	pkg_install() {
-		vmove "usr/bin/pltcl*"
 		vmove "usr/lib/postgresql/pltcl*"
 		for d in $(find ${DESTDIR}/usr/share/locale \
 		   -type f -name pltcl\*); do
 			mkdir -p ${PKGDESTDIR}/$(dirname ${d#${DESTDIR}})
 			mv ${d} ${PKGDESTDIR}/$(dirname ${d#${DESTDIR}})
 		done
-		vmove "usr/share/postgresql/*.pltcl"
 	}
 }
 
@@ -153,9 +152,8 @@ fi # !CROSS_BUILD
 postgresql-client_package() {
 	short_desc="Client frontends programs for PostgreSQL"
 	pkg_install() {
-		for f in clusterdb createdb createlang createuser dropdb droplang \
-			dropuser pg_dump pg_dumpall pg_isready pg_restore psql reindexdb \
-			vacuumdb; do
+		for f in clusterdb createdb createuser dropdb dropuser \
+			pg_dump pg_dumpall pg_isready pg_restore psql reindexdb vacuumdb; do
 			vmove usr/bin/${f}
 			vmove usr/share/man/man1/$(basename ${f}).1
 		done


### PR DESCRIPTION
[`createlang`](https://stackoverflow.com/questions/52107949/createlang-command-not-found-in-postgres#answer-52109145) and [`droplang`](https://www.postgresql.org/docs/9.6/app-droplang.html) has been deprecated since PostgreSQL 9.1

`plctcl` - Since `createlang` has been deprecated, `CREATE EXTENSION {pltcl,pltclu}` is needed to use it (I don't use this, so could someone please check if it's correct). See [here](https://www.postgresql.org/docs/10/pltcl-overview.html)

New versioning policy since [PostgreSQL 10](https://www.postgresql.org/support/versioning/)

[PostgreSQL 12 release notes](https://www.postgresql.org/docs/current/release-12.html)
[PostgreSQL 11 release notes](https://www.postgresql.org/docs/current/release-11.html)
[PostgreSQL 10 release notes](https://www.postgresql.org/docs/current/release-10.html)

Since more than 1 version has passed, `pg_upgrade` or `pg_dumpall` might be needed to be run on any DBs.