### PR TITLE
yubikey-manager: add semi-missing python3-setuptools dep

### DIFF
--- a/srcpkgs/yubikey-manager/template
+++ b/srcpkgs/yubikey-manager/template
@@ -1,12 +1,12 @@
 # Template file for 'yubikey-manager'
 pkgname=yubikey-manager
 version=3.1.0
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="libu2f-host python3-fido2 python3-openssl python3-usb python3-scard
-python3-click python3-cryptography python3-six pcsc-ccid"
+python3-click python3-cryptography python3-six pcsc-ccid python3-setuptools"
 short_desc="Library and CLI tools to configure YubiKey"
 maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="BSD-2-Clause"


### PR DESCRIPTION
The ultimately-installed `/usr/bin/ykman` has `from pkg_resources import
load_entry_point` towards the top, which is an import from `setuptools`.
On systems that don't already have that installed, `ykman` throws an
`ImportError` on launch.