### PR TITLE
git: correct ac_cv_fread_reads_directories on all platforms 

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,14 +1,14 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
 version=2.24.1
-revision=1
+revision=2
 bootstrap=yes
 wrksrc="git-${version}"
 build_style=gnu-configure
 configure_args="--without-curl --without-openssl
  --without-python --without-expat --without-tcltk
  ac_cv_lib_curl_curl_global_init=no ac_cv_lib_expat_XML_ParserCreate=no
- ac_cv_snprintf_returns_bogus=no"
+ ac_cv_snprintf_returns_bogus=no ac_cv_fread_reads_directories=yes"
 makedepends="zlib-devel"
 short_desc="GIT Tree History Storage Tool -- for xbps-src use"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -22,13 +22,6 @@ if [ "$CHROOT_READY" ]; then
 else
 	configure_args+=" --with-zlib=${XBPS_MASTERDIR}/usr"
 fi
-
-case "$XBPS_TARGET_MACHINE" in
-	*-musl)
-		configure_args+=" ac_cv_fread_reads_directories=yes"
-		;;
-	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
-esac
 
 post_configure() {
 	cat <<-EOF >config.mak

--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,17 +1,17 @@
 # Template file for 'git'
 pkgname=git
 version=2.24.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2
- ac_cv_snprintf_returns_bogus=no"
+ ac_cv_snprintf_returns_bogus=no ac_cv_fread_reads_directories=yes"
 make_check_target=test
 hostmakedepends="asciidoc gettext perl pkg-config tar tk xmlto"
 makedepends="libglib-devel libcurl-devel libsecret-devel pcre2-devel tk-devel"
 # Required by https://
 depends="ca-certificates perl-Authen-SASL perl-MIME-tools perl-Net-SMTP-SSL"
 short_desc="Git Tree History Storage Tool"
-maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
@@ -23,11 +23,7 @@ register_shell=/usr/bin/git-shell
 subpackages="git-cvs git-svn gitk git-gui git-all git-libsecret git-netrc"
 
 case "$XBPS_TARGET_MACHINE" in
-	*-musl)
-		configure_args+=" ac_cv_fread_reads_directories=yes"
-		export GIT_SKIP_TESTS='t3900'
-		;;
-	*) configure_args+=" ac_cv_fread_reads_directories=no" ;;
+	*-musl) export GIT_SKIP_TESTS='t3900' ;;
 esac
 
 post_configure() {


### PR DESCRIPTION
From commit bf8bba6, (git: correct ac_cv_fread_reads_directories on
musl, 2018-11-14), we've correctly set ac_cv_fread_reads_directories for
git linked with musl-libc variant.

Unfortunately, glibc also allows fopen on directory. But, I was obsessed
with musl-libc at the time, hence forgot to run the test for glibc.

Correct it.

---

Discovered this problem when I run check on v2.25.0.rc2 in preparation for the next release.