### PR TITLE
cheat: update to 3.2.2

### DIFF
--- a/srcpkgs/cheat/template
+++ b/srcpkgs/cheat/template
@@ -1,26 +1,20 @@
 # Template file for 'cheat'
 pkgname=cheat
-version=2.5.1
-revision=2
-build_style=python3-module
-pycompile_module="cheat"
-conf_files="/etc/cheat"
-hostmakedepends="python3"
-depends="python3-docopt python3-termcolor python3-Pygments"
+version=3.2.2
+revision=1
+build_style=go
+go_import_path="github.com/cheat/cheat/cmd/cheat"
 short_desc="Create and view interactive cheatsheets on the command-line"
 maintainer="bra1nwave <brainwave@openmailbox.org>"
-license="GPL-3.0-or-later, MIT"
+license="MIT"
 homepage="https://github.com/cheat/cheat"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=9ae44cfc79478a7ba604871f3253e176f2bf3e1a4e698c9466e58a39d279effd
+checksum=9a756b249ae9a9ea7beb2149a57a6556b145075e97c4c90b52ea6492334a5c7e
 
 post_install() {
-	vinstall cheat/autocompletion/cheat.bash 644 \
+	vinstall scripts/cheat-autocompletion.bash 644 \
 		usr/share/bash-completion/completions cheat
-	vinstall cheat/autocompletion/cheat.zsh 644 \
-		usr/share/zsh/site-functions _cheat
-	vinstall cheat/autocompletion/cheat.fish 644 \
+	vinstall scripts/cheat-autocompletion.fish 644 \
 		usr/share/fish/completions
-	vman man1/cheat.1.gz
-	vlicense licenses/mit.txt LICENSE
+	vlicense LICENSE.txt
 }


### PR DESCRIPTION
This package has been rewritten in go.
The manpage is no longer provided.
Cheatsheets are now in a separate repo.
The `conf` file is generated via command.