### PR TITLE
libtorrent-rasterbar: update to 1.2.3.

### DIFF
--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,7 +1,7 @@
 # Template file for 'libtorrent-rasterbar'
 pkgname=libtorrent-rasterbar
-version=1.2.2
-revision=3
+version=1.2.3
+revision=1
 build_style=gnu-configure
 configure_args="--enable-examples --enable-python-binding
  --with-boost=${XBPS_CROSS_BASE}/usr
@@ -13,7 +13,7 @@ maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
 distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
-checksum=e579261d7f0acbe82e9b4ce703cb721627cb8075023f8a26405992f489bc6202
+checksum=1582fdbbd0449bcfe4ffae2ccb9e5bf0577459a32bb25604e01accb847da1a2d
 
 case "$XBPS_TARGET_MACHINE" in
 	armv[56]*|mips*|ppc|ppc-musl)


### PR DESCRIPTION
Fixes buffer overflow, see qbittorrent/qBittorrent#11849