### PR TITLE
go: update to 1.13.6.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.13.5
+version=1.13.6
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff
+checksum=aae5be954bdc40bcf8006eb77e8d8a5dde412722bc8effcdaf9772620d06420c
 nostrip=yes
 noverifyrdeps=yes
 

--- a/srcpkgs/go1.12-bootstrap/template
+++ b/srcpkgs/go1.12-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'go1.12-bootstrap'
 pkgname=go1.12-bootstrap
-version=1.12.14
+version=1.12.15
 revision=1
 archs="x86_64* i686* armv[67]l* aarch64* ppc64le*"
 wrksrc="go"
@@ -21,23 +21,23 @@ fi
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*)
 		_dist_arch="amd64"
-		checksum="925a1a9d8b31c2425d7313fe73d3342288968a66e26cd8bf1b6b5656f4603fcb"
+		checksum="61068419f3d3fcd3cc415c352c4a93d6ae0e723ac18a22ac572b4904d78b5a4c"
 		;;
 	i686*)
 		_dist_arch="386"
-		checksum="76dda90b4fc0410212094b433cfdc40c9802fba972427e95cbdec3c5b94fd7a6"
+		checksum="608c9fb90b2b35f7b4e4b110a9c6919d8902311388c6309487b5f77aed9d2b74"
 		;;
 	arm*)
 		_dist_arch="armv6l"
-		checksum="c7aa5562168b6eb3a4bb54af061d68bcb6b9ecae9d785f9a38255c107c986b73"
+		checksum="3a36d168bf80c780694bf25d6cb2ed0dbb6d4bc29b1c82bb29e819d9dbe6347b"
 		;;
 	aarch64*)
 		_dist_arch="arm64"
-		checksum="1ab765f4cf74f05cfba40ddcea9160ca6cf9a57915036a559ca1691942862e7c"
+		checksum="cff1a28f0b207dd54230bf822cdcfbcc7cd411261a9366616a05a1fa1fbeedd3"
 		;;
 	ppc64le*)
 		_dist_arch="ppc64le"
-		checksum="4e237b1357922e186337989914201e98bd9aed855f4034a5918476650484f83d"
+		checksum="4fe9ce71a6cd9acd56f0e898dd87d95ed9bc83a6a5be0863e9b5b646e05eee05"
 		;;
 esac
 


### PR DESCRIPTION
Includes update to the bootstrap package to 1.12.15 since the two are tied together.