### PR TITLE
nginx: update to 1.17.7.

### DIFF
--- a/srcpkgs/nginx/template
+++ b/srcpkgs/nginx/template
@@ -1,7 +1,7 @@
 # Template file for 'nginx'
 pkgname=nginx
-version=1.16.1
-revision=2
+version=1.17.7
+revision=1
 build_style=gnu-makefile
 hostmakedepends="libressl-devel pcre-devel $(vopt_if geoip geoip-devel)"
 makedepends="${hostmakedepends}"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://nginx.org"
 distfiles="https://nginx.org/download/nginx-${version}.tar.gz"
-checksum=f11c2a6dd1d3515736f0324857957db2de98be862461b5a542a3ac6188dbe32b
+checksum=b62756842807e5693b794e5d0ae289bd8ae5b098e66538b2a91eb80f25c591ff
 
 # NOTE:
 # On update, the pregenerated header file for ARM may need synchronization.


### PR DESCRIPTION
Version 1.17.7 includes fix for CVE-2019-20372