### PR TITLE
rpi-kernel: update to 4.19.93.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,19 +5,19 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="edc6ef437bd690772d7a562adeea6c85daf11440"
+_githash="b4180819d3a119c56133d6a2d8301775bf6c60bb"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.89
-revision=2
+version=4.19.93
+revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=c96d9b6351b4876f5b1296decea8d3d71b06021abc22398df1bbd962a6ffc52a
+checksum=c401a6764d17bb2b33ae5f72fd0199608736c58eadd3d074c838ca2fa2c9e5dc
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.