### PR TITLE
New package: mopidy-mpd-3.0.0

### DIFF
--- a/srcpkgs/mopidy-mpd/template
+++ b/srcpkgs/mopidy-mpd/template
@@ -1,0 +1,17 @@
+# Template file for 'mopidy-mpd'
+pkgname=mopidy-mpd
+version=3.0.0
+revision=1
+archs=noarch
+wrksrc="Mopidy-MPD-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="mopidy python3-pykka python3-setuptools"
+checkdepends="${depends} python3-gobject python3-pytest"
+short_desc="Mopidy extension for controlling Mopidy from MPD clients"
+maintainer="Stacy Harper <contact@stacyharper.net>"
+license="Apache-2.0"
+homepage="http://www.mopidy.com"
+changelog="https://raw.githubusercontent.com/mopidy/mopidy-mpd/v${version}/CHANGELOG.rst"
+distfiles="${PYPI_SITE}/M/Mopidy-MPD/Mopidy-MPD-${version}.tar.gz"
+checksum=4c452e8ad8fbf13322b510cd48bc5bef5779d2ac8f39cd5e0ca2883248a4325f


### PR DESCRIPTION
Should I rename it to "Mopidy-MPD" as the python package name ?