### PR TITLE
mcpp: fix set_encoding() to understand C.UTF-8

### DIFF
--- a/srcpkgs/mcpp/patches/mbchar.patch
+++ b/srcpkgs/mcpp/patches/mbchar.patch
@@ -1,0 +1,29 @@
+Fix set_encoding() to understand C.UTF-8 and other
+locale names with != 5 characters before .
+
+--- src/mbchar.c	2008-03-08 11:06:13.000000000 -0200
++++ src/mbchar.c	2020-01-13 10:02:20.800174591 -0300
+@@ -366,6 +366,7 @@
+             = "Too long encoding name: %s%.0ld%.0s";    /* _E_  */
+     const char *    loc = "";
+     int     alias;
++    char   *dot;
+     char    norm[ NAMLEN];
+             /*
+              * Normalized name (removed 'xxxxx.', stripped '_', '-', '.'
+@@ -380,10 +381,11 @@
+             mcpp_fputc( '\n', ERR);
+         }
+     }
+-    strcpy( norm, name);
+-    if (norm[ 5] == '.')
+-        memmove( norm, norm + 5, strlen( norm + 5) + 1);
+-        /* Remove initial 'xxxxx.' as 'ja_JP.', 'en_US.' or any other   */
++    if ( dot = strchr( name, '.' ) )
++        /* Remove initial 'xxxxx.' as 'ja_JP.', 'en_US.', 'C.' or any other   */
++        strcpy( norm, dot+1);
++    else
++        strcpy( norm, name);
+     conv_case( norm, norm + strlen( norm), LOWER);
+     strip_bar( norm);
+ 

--- a/srcpkgs/mcpp/template
+++ b/srcpkgs/mcpp/template
@@ -1,7 +1,7 @@
 # Template file for 'mcpp'
 pkgname=mcpp
 version=2.7.2
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--enable-mcpplib"
 short_desc="Portable C preprocessor"


### PR DESCRIPTION
Function ```set_encoding()``` finds the encoding name by splitting a locale of the form ```en_US.UTF-8``` at the period, but only if the leading part is exactly 5 characters long.
```
$ LC_ALL=C.UTF-8 mcpp /dev/null
/dev/null:0: warning: Unknown encoding: C.UTF-8
    #line 1 "/dev/null"
```

This patch changes the behaviour to split at the first period instead.

This will also fix a warning in ```xrdb```:
```
$ LC_ALL=C.UTF-8 xrdb -merge /dev/null
/dev/null:0: warning: Unknown encoding: C.UTF-8
```