### PR TITLE
gtkmm: change version number to v3

### DIFF
--- a/srcpkgs/gtkmm/template
+++ b/srcpkgs/gtkmm/template
@@ -1,12 +1,12 @@
 # Template file for 'gtkmm'
 pkgname=gtkmm
 version=3.24.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-documentation"
 hostmakedepends="automake libtool pkg-config mm-common"
 makedepends="gtk+3-devel glibmm-devel atkmm-devel pangomm-devel"
-short_desc="C++ bindings for The GTK+ toolkit (v2)"
+short_desc="C++ bindings for The GTK+ toolkit (v3)"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gtkmm.org"


### PR DESCRIPTION
The short description for this package was wrong, as it was using v2 as
the version number.

Fixes #18290 