### PR TITLE
[RFC] SDL2: unify build options on all archs, don't enable rpi for arm*

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,7 +1,7 @@
 # Template file for 'SDL2'
 pkgname=SDL2
 version=2.0.10
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
  --enable-clock_gettime --disable-nas --disable-arts --disable-x11-shared
@@ -18,17 +18,11 @@ checksum=b4656c13a1f0d0023ae2f4a9cf08ec92fffb464e0f24238337784159b8b91d57
 
 # Package build options
 build_options="gles opengl pulseaudio sndio vulkan wayland x11"
+build_options_default="gles opengl pulseaudio sndio vulkan wayland x11"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc*)
-		build_options_default="gles opengl pulseaudio sndio vulkan wayland x11"
-		;;
-	aarch64*)
-		build_options_default="gles opengl pulseaudio sndio x11"
-		;;
 	arm*)
 		build_options+=" rpi"
-		build_options_default="rpi pulseaudio sndio x11"
 		;;
 esac
 
@@ -42,7 +36,6 @@ if [ "$build_option_gles" ]; then
 	configure_args+=" --enable-video-opengles"
 	# libGLESv2.so.2 is dynamically loaded with dlopen.
 	shlib_requires="libGLESv2.so.2"
-	depends+=" libGLES"
 else
 	configure_args+=" --disable-video-opengles"
 fi
@@ -58,7 +51,6 @@ fi
 if [ "$build_option_opengl" ]; then
 	# libGL.so.1 is dynamically loaded with dlopen.
 	shlib_requires+=" libGL.so.1"
-	depends+=" libGL"
 	configure_args+=" --enable-video-opengl"
 else
 	configure_args+=" --disable-video-opengl"


### PR DESCRIPTION
Currently `rpi-userland-devel` provides the some `pkgconfig` files as `libglvnd-devel`
```
/usr/lib/pkgconfig/glesv2.pc
/usr/lib/pkgconfig/egl.pc
```

Which makes it impossible to build something that depends on `SDL2-devel` and `libglvnd-devel`/`MesaLib-devel` since `rpi-userland-devel` will be pulled in.

Also if I'm not mistaken, the rpi build option is currently nevertheless broken. SDL2 only searches for `libGLESv2.so.2` if `--enable-video-rpi` is not set, and `rpi-userland` is only providing `libGLESv2.so`. The code of SDL does runtime checks whether it is a rpi so enabling it shouldn't break non rpi's. But everything should be less broken as the current state. So if anyone wanna fix the rpi build option feel free to do so.