### PR TITLE
vsv: update to v1.3.3

### DIFF
--- a/srcpkgs/vsv/template
+++ b/srcpkgs/vsv/template
@@ -1,6 +1,6 @@
 # Template file for 'vsv'
 pkgname=vsv
-version=1.3.2
+version=1.3.3
 revision=1
 archs=noarch
 depends="bash coreutils psmisc"
@@ -9,7 +9,7 @@ maintainer="Dave Eddy <dave@daveeddy.com>"
 license="MIT"
 homepage="https://github.com/bahamas10/vsv"
 distfiles="https://github.com/bahamas10/vsv/archive/v${version}.tar.gz"
-checksum=0f31850cdc676ae25c2524a4e7998a62785ff268b883d3f544c6fd93ddc0b5bc
+checksum=571bcb4bf46192a6519965743e4a2d4b2d761ca66269d0075822ada7258ea079
 
 do_install() {
 	vbin vsv


### PR DESCRIPTION
from the [changelog](https://github.com/bahamas10/vsv/blob/master/CHANGES.md)

`v1.3.3`
--------

- [#4](https://github.com/bahamas10/vsv/pull/4) Truncate command output to not overflow 17 characters
- [#6](https://github.com/bahamas10/vsv/issues/6) race condition when checking if a service is disabled