### PR TITLE
Bump to v0.10.9 release, fix URLs, add dependencies

### DIFF
--- a/srcpkgs/lua54-cassowary/template
+++ b/srcpkgs/lua54-cassowary/template
@@ -1,0 +1,65 @@
+# Template file for 'lua54-cassowary'
+pkgname=lua54-cassowary
+version=2.2
+revision=1
+create_wrksrc=yes
+hostmakedepends="lua51 lua52 lua53 lua54"
+makedepends="lua51-devel lua52-devel lua53-devel lua54-devel"
+depends="lua54"
+_desc="A Lua port of the cassowary constraint solver engine"
+short_desc="${_desc} (5.4.x)"
+maintainer=""
+license="MIT"
+homepage="https://github.com/sile-typesetter/cassowary.lua"
+distfiles="https://github.com/sile-typesetter/cassowary.lua/archive/v${version}.tar.gz"
+checksum=e2f7774b6883581491b8f2c9d1655b2136bc24d837a9e43f515590a766ec4afd
+
+post_extract() {
+	mv "cassowary.lua-v${version}" lua54
+	cp -a lua54 lua53
+	cp -a lua54 lua52
+	cp -a lua54 lua51
+}
+
+do_install() {
+	for x in lua54 lua53 lua52 lua51; do
+		vinstall "$x/cassowary/init.lua" 755 "usr/lib/lua/5.${x#lua5}"
+	done
+	vlicense lua54/LICENSE
+}
+
+lua54-cjson_package() {
+	depends="lua54"
+	short_desc="${_desc} (5.4.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.4
+		vlicense ${wrksrc}/lua54/LICENSE
+	}
+}
+
+lua53-cjson_package() {
+	depends="lua53"
+	short_desc="${_desc} (5.3.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.3
+		vlicense ${wrksrc}/lua53/LICENSE
+	}
+}
+
+lua52-cjson_package() {
+	depends="lua52"
+	short_desc="${_desc} (5.2.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.2
+		vlicense ${wrksrc}/lua52/LICENSE
+	}
+}
+
+lua51-cjson_package() {
+	depends="lua51"
+	short_desc="${_desc} (5.1.x)"
+	pkg_install() {
+		vmove usr/lib/lua/5.1
+		vlicense ${wrksrc}/lua51/LICENSE
+	}
+}

--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -1,23 +1,27 @@
 # Template file for 'sile'
 pkgname=sile
-version=0.9.5.1
-revision=4
+version=0.10.3
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
-makedepends="harfbuzz-devel lua51-devel lua51-lpeg lua51-luaexpat
- lua51-zlib lua51-luafilesystem lua51-luasocket lua51-luasec"
-depends="lua51-lpeg lua51-luaexpat lua51-zlib lua51-luafilesystem
- lua51-luasocket lua51-luasec"
+makedepends="fontconfig-devel harfbuzz-devel icu-devel lua51
+	lua51-cassowary lua51-cliargs lua51-cosmo lua51-epnf lua51-linenoise lua51-penlight
+	lua51-repl lua51-stdlib lua51-vstruct lua51-zlib lua51-bitlib lua51-lpeg
+	lua51-luasec lua51-zlib lua51-luaexpat lua51-luafilesystem lua51-luasocket"
+depends="fonts-sil-gentium lua51
+	lua51-cassowary lua51-cliargs lua51-cosmo lua51-epnf lua51-linenoise lua51-penlight
+	lua51-repl lua51-stdlib lua51-vstruct lua51-zlib lua51-bitlib lua51-lpeg
+	lua51-luasec lua51-zlib lua51-luaexpat lua51-luafilesystem lua51-luasocket"
 short_desc="Modern typesetting system inspired by TeX"
 maintainer="John <me@johnnynator.dev>"
 license="MIT"
-homepage="http://www.sile-typesetter.org/"
-distfiles="https://github.com/simoncozens/sile/releases/download/v${version}/sile-${version}.tar.bz2"
-checksum=60cdcc4509971973feab352dfc1a86217cc1fdb12d56823f04d863afef92003a
+homepage="https://www.sile-typesetter.org"
+distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}/sile-${version}.tar.bz2"
+checksum=d89d5ce7d2bf46fb062e5299ffd8b5d821dc3cb3462a0e7c1109edeee111d856
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" lua51 lua51-lpeg luaexpat lua51-zlib luafilesystem
-	 luasocket lua51-luasec"
+	hostmakedepends+=" lua51 lua51-lpeg luaexpat lua51-zlib lua51-luafilesystem
+	 lua51-luasocket lua51-luasec"
 fi
 
 post_install() {
@@ -27,6 +31,7 @@ post_install() {
 libtexpdf_package() {
 	short_desc="PDF library extracted from TeX's dvipdfmx"
 	pkg_install() {
+		# TODO: May not be necessary in v0.10.3
 		vmove "usr/lib/libtexpdf.so.*"
 	}
 }
@@ -36,6 +41,7 @@ libtexpdf-devel_package() {
 	depends="libtexpdf-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
+		# TODO: May not be necessary in v0.10.3
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.a"
 	}

--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -1,6 +1,6 @@
 # Template file for 'sile'
 pkgname=sile
-version=0.10.3
+version=0.10.9
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -17,7 +17,7 @@ maintainer="John <me@johnnynator.dev>"
 license="MIT"
 homepage="https://www.sile-typesetter.org"
 distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}/sile-${version}.tar.bz2"
-checksum=d89d5ce7d2bf46fb062e5299ffd8b5d821dc3cb3462a0e7c1109edeee111d856
+checksum=44eaaf286b059b46eb51f28ef813d149538b06f4541c1eb7fb6faef26d60a564
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" lua51 lua51-lpeg luaexpat lua51-zlib lua51-luafilesystem

--- a/srcpkgs/sile/template
+++ b/srcpkgs/sile/template
@@ -3,15 +3,17 @@ pkgname=sile
 version=0.10.9
 revision=1
 build_style=gnu-configure
+configure_args="--with-system-luarocks"
 hostmakedepends="pkg-config"
-makedepends="fontconfig-devel harfbuzz-devel icu-devel lua51
-	lua51-cassowary lua51-cliargs lua51-cosmo lua51-epnf lua51-linenoise lua51-penlight
-	lua51-repl lua51-stdlib lua51-vstruct lua51-zlib lua51-bitlib lua51-lpeg
-	lua51-luasec lua51-zlib lua51-luaexpat lua51-luafilesystem lua51-luasocket"
-depends="fonts-sil-gentium lua51
-	lua51-cassowary lua51-cliargs lua51-cosmo lua51-epnf lua51-linenoise lua51-penlight
-	lua51-repl lua51-stdlib lua51-vstruct lua51-zlib lua51-bitlib lua51-lpeg
-	lua51-luasec lua51-zlib lua51-luaexpat lua51-luafilesystem lua51-luasocket"
+makedepends="fontconfig-devel harfbuzz-devel icu-devel lua54 lua54-cassowary
+	lua54-cosmo lua54-linenoise lua54-lpeg lua54-zlib lua54-cliargs
+	lua54-luaepnf lua54-luaexpat lua54-luafilesystem lua54-repl lua54-luasec
+	lua54-luasocket lua54-penlight lua54-stdlib lua54-vstruct"
+depends="fonts-sil-gentium libtexpdf lua54 lua54-cassowary lua54-cosmo
+	lua54-linenoise lua54-lpeg lua54-zlib lua54-cliargs lua54-luaepnf
+	lua54-luaexpat lua54-luafilesystem lua54-repl lua54-luasec lua54-luasocket
+	lua54-penlight lua54-stdlib lua54-vstruct"
+checkdepends="poppler"
 short_desc="Modern typesetting system inspired by TeX"
 maintainer="John <me@johnnynator.dev>"
 license="MIT"
@@ -20,8 +22,8 @@ distfiles="https://github.com/sile-typesetter/sile/releases/download/v${version}
 checksum=44eaaf286b059b46eb51f28ef813d149538b06f4541c1eb7fb6faef26d60a564
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" lua51 lua51-lpeg luaexpat lua51-zlib lua51-luafilesystem
-	 lua51-luasocket lua51-luasec"
+	hostmakedepends+=" lua54 lua54-lpeg lua54-luaexpat lua54-zlib
+		lua54-luafilesystem lua54-luasocket lua54-luasec"
 fi
 
 post_install() {
@@ -31,7 +33,6 @@ post_install() {
 libtexpdf_package() {
 	short_desc="PDF library extracted from TeX's dvipdfmx"
 	pkg_install() {
-		# TODO: May not be necessary in v0.10.3
 		vmove "usr/lib/libtexpdf.so.*"
 	}
 }
@@ -41,8 +42,6 @@ libtexpdf-devel_package() {
 	depends="libtexpdf-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
-		# TODO: May not be necessary in v0.10.3
 		vmove "usr/lib/*.so"
-		vmove "usr/lib/*.a"
 	}
 }


### PR DESCRIPTION
- [x] Bump release
- [x] Update project URLs (moved to GitHub org since last release)
- [x] Update checksum
- [x] Add `--with-system-luarocks`. Note this is a new option since the last release, _not_ the default, but probably an option in keeping with Void Linux _MO_.
- [ ] Needs new packages for new dependencies not currently available:
    - [ ] lua-epnf
    - [x] lua-cassowary
    - [ ] lua-cosmo
    - [ ] lua-linenoise
    - [ ] lua-repl
    - [ ] lua-penlight
    - [ ] lua-vstruct
    - [ ] lua-stdlib
- [ ] Add documentation PDF as users manual
- [ ] Make sure (new) man page gets packaged

Some of these Lua packages that are missing were required by the previous version too (e.g. stdlib) so I'm not sure what's going on here.

If there is anything we can do upstream in SILE to make packaging easier let me know, I'm happy to facilitate a point release if 