### PR TITLE
nss: update to 3.49.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.24
 
 pkgname=nss
-version=3.48
+version=3.49
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,7 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=3f9c822a86a4e3e1bfe63e2ed0f922d8b7c2e0b7cafe36774b1c627970d0f8ac
+checksum=6738094dc4fd63061118a122bf3999a64fe8c7117fc52f6e81c2279181bde71d
 
 do_build() {
 	# Respect LDFLAGS


### PR DESCRIPTION
- Run firefox-esr with this nss on x86_64-musl for a while.
- xbps-src check passed for x86_64{,-musl}