### PR TITLE
vscode: remove telemetry

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,8 +1,8 @@
 # Template file for 'vscode'
 pkgname=vscode
 version=1.41.1
-revision=2
-hostmakedepends="pkg-config python nodejs-lts yarn"
+revision=3
+hostmakedepends="pkg-config python nodejs-lts yarn tar"
 makedepends="libxkbfile-devel libsecret-devel"
 depends="libXtst libxkbfile nss dejavu-fonts-ttf"
 short_desc="Microsoft Code for Linux"
@@ -31,6 +31,12 @@ esac
 pre_build() {
 	# Use yarn to install dependencies
 	echo "" > build/npm/preinstall.js
+
+	# redirect telemetry urls to 0.0.0.0
+	# src: vscodium/undo_telemetry.sh
+	_TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
+	_REPLACEMENT="s/$_TELEMETRY_URLS/0\.0\.0\.0/g"
+	grep -rl --exclude-dir=.git -E $_TELEMETRY_URLS | xargs sed -i -E $_REPLACEMENT
 }
 
 do_build() {


### PR DESCRIPTION
Adds a sed script from vscodium
https://github.com/VSCodium/vscodium/blob/f805d740bb77135aa36d77bda41318510978abc4/undo_telemetry.sh

AFAICT this is the only change sans rebranding vscodium does, so this
should address issue #10582

Also added `tar` in `hostmakedepends` because the vscode build script uses tar and this is way easier than trying to patch it to use bsdtar.