### PR TITLE
nss: update to 3.49.1

### DIFF
--- a/srcpkgs/nss/patches/arm32.patch
+++ b/srcpkgs/nss/patches/arm32.patch
@@ -1,0 +1,11 @@
+--- nss/lib/freebl/Makefile
++++ nss/lib/freebl/Makefile
+@@ -782,7 +782,7 @@
+ 
+ ifeq ($(CPU_ARCH),arm)
+ $(OBJDIR)/$(PROG_PREFIX)aes-armv8$(OBJ_SUFFIX): CFLAGS += -march=armv8-a -mfpu=crypto-neon-fp-armv8
+-$(OBJDIR)/$(PROG_PREFIX)gcm-arm32-neon$(OBJ_SUFFIX): CFLAGS += -mfpu=neon
++# -mfpu=neon will be set by template files for armv7
+ endif
+ ifeq ($(CPU_ARCH),aarch64)
+ $(OBJDIR)/$(PROG_PREFIX)aes-armv8$(OBJ_SUFFIX): CFLAGS += -march=armv8-a+crypto

--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.24
 
 pkgname=nss
-version=3.48
+version=3.49.1
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,7 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=3f9c822a86a4e3e1bfe63e2ed0f922d8b7c2e0b7cafe36774b1c627970d0f8ac
+checksum=d9aa42e49e02bb0dc0a2f164604cfc718e11a2a06ddb266cd676376ac21b026e
 
 do_build() {
 	# Respect LDFLAGS
@@ -39,8 +39,21 @@ do_build() {
 
 	if [ "$CROSS_BUILD" ]; then
 		case "$XBPS_TARGET_MACHINE" in
-			aarch64*) _ARCH="aarch64"; _target_use64="USE_64=1"; CFLAGS+=" -DNS_PTR_GT_32";;
-			ppc64*) _ARCH="ppc64"; _target_use64="USE_64=1"; CFLAGS+=" -DNS_PTR_GT_32";;
+			aarch64*)
+				_ARCH="aarch64"
+				_target_use64="USE_64=1"
+				CFLAGS+=" -DNS_PTR_GT_32"
+				;;
+			ppc64*)
+				_ARCH="ppc64"
+				_target_use64="USE_64=1"
+				CFLAGS+=" -DNS_PTR_GT_32"
+				;;
+			armv7*)
+				_ARCH="arm"
+				CFLAGS+=" -mfpu=neon"
+				CXXFLAGS+=" -mfpu=neon"
+				;;
 			arm*) _ARCH="arm";;
 			mips*) _ARCH="mips";;
 			ppc|ppc-musl) _ARCH="ppc";;


### PR DESCRIPTION
- I run 3.49 for a while, nss 3.49.1 is a small update over nss 3.49
- [x] ./xbps-src -m x86_64 check nss 
- [x] ./xbps-src -m x86_64-musl check nss 