### PR TITLE
New package: pam-gnupg-git-20191206

### DIFF
--- a/srcpkgs/pam-gnupg-git/template
+++ b/srcpkgs/pam-gnupg-git/template
@@ -1,0 +1,21 @@
+# Template file for 'pam-gnupg-git'
+pkgname=pam-gnupg-git
+version=20191206
+revision=1
+_githash=fbd75b720877e4cf94e852ce7e2b811feb330bb5
+wrksrc="pam-gnupg-${_githash}"
+build_style=gnu-configure
+configure_args="--with-moduledir=/usr/lib/security"
+hostmakedepends="automake libtool gnupg2"
+makedepends="pam-devel"
+depends="gnupg2"
+short_desc="PAM module to unlock GPG agent on login"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-3.0-only"
+homepage="https://github.com/cruegge/pam-gnupg"
+distfiles="${homepage}/archive/${_githash}.tar.gz"
+checksum=fe6d5874545832d9f0189f204571b19470bb090a3eac778732e5792b428cffa0
+
+pre_configure() {
+	sh autogen.sh
+}


### PR DESCRIPTION
This template adds support for the pam-gnupg PAM module, which presets key passphrases in gnupg2 to the PAM authentication passphrase. Configuring PAM to load for authentication after the pam_unix module and session management after any elogind or ConsoleKit2 modules will pass the user's password through gpg-connect-agent to preset the passphrase; as a side effect, gpg-agent will be launched if it is not already running.

The template references a specific git commit, which is not allowed according to CONTRIBUTING.md; I'm hoping an exception can be made because the module author has not published specific releases but the module is very useful.