### PR TITLE
rpi-kernel: update to 4.19.95.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="b4180819d3a119c56133d6a2d8301775bf6c60bb"
+_githash="798a72f0bbb1a06446b614516d76ff0c2ebaec9b"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.93
+version=4.19.95
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=c401a6764d17bb2b33ae5f72fd0199608736c58eadd3d074c838ca2fa2c9e5dc
+checksum=8c800ce213baae3a9b6b62943e50a4f34d31c9a233791d59e7726250db735868
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.