### PR TITLE
New package: zrep-1.8.0

### DIFF
--- a/srcpkgs/zrep/template
+++ b/srcpkgs/zrep/template
@@ -1,0 +1,20 @@
+# Template file for 'zrep'
+pkgname=zrep
+version=1.8.0
+revision=1
+archs=noarch
+build_style=fetch
+depends="ksh zfs"
+short_desc="Simple ZFS replication and failover script"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="custom:Proprietary"
+homepage="https://github.com/bolthole/${pkgname}"
+_zrep_root="https://raw.githubusercontent.com/bolthole/zrep/v${version}"
+distfiles="${_zrep_root}/${pkgname} ${_zrep_root}/LICENSE.txt"
+checksum="4f567de8505c5218d2cd624de9e3e4978cd26f6c66f7bab722959ec3a626f581
+ 5a5638d07535563a83a695ebbb4d2a592ce866281a076c4f9278007f70efb839"
+
+do_install() {
+	vbin zrep
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
zrep is a ksh script that allows local and remote (via SSH) replication of ZFS snapshots and a failover mode that will swap the roles of master and slave.