### PR TITLE
New package: zfs-prune-snapshots-1.1.0

### DIFF
--- a/srcpkgs/zfs-prune-snapshots/template
+++ b/srcpkgs/zfs-prune-snapshots/template
@@ -1,0 +1,19 @@
+# Template file for 'zfs-prune-snapshots'
+pkgname=zfs-prune-snapshots
+version=1.1.0
+revision=1
+archs="noarch"
+build_style=gnu-makefile
+hostmakedepends="make"
+depends="bash zfs"
+checkdepends="shellcheck"
+short_desc="Remove snapshots that match given criteria from one or more ZFS pools"
+maintainer="Andrew J. Hesford <ahesford@gleason.com>"
+license="MIT"
+homepage="https://github.com/bahamas10/${pkgname}"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=a9f2fb3c5230111db7622f70318219a37aa8d6bd3d7f894fee54e1ec00cdff2f
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
zfs-prune-snapshots is a bash script that deletes ZFS snapshots based on many criteria, providing pruning capabilities similar to those of zfs-auto-snapshot for arbitrary snapshots.