### PR TITLE
firejail: update to 0.9.62

### DIFF
--- a/srcpkgs/firejail/template
+++ b/srcpkgs/firejail/template
@@ -1,9 +1,10 @@
 # Template file for 'firejail'
 pkgname=firejail
-version=0.9.60
+version=0.9.62
 revision=1
 build_style=gnu-configure
 configure_args="--enable-apparmor"
+hostmakedepends="pkg-config"
 makedepends="libapparmor-devel"
 short_desc="SUID security sandbox program"
 maintainer="Duncaen <duncaen@voidlinux.org>"
@@ -11,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://firejail.wordpress.com"
 #changelog="https://raw.githubusercontent.com/netblue30/firejail/master/RELNOTES"
 distfiles="https://github.com/netblue30/firejail/archive/${version}.tar.gz"
-checksum=dd3059b19365c2c095b85e3f86737fdcaca0a05357680f0e377bebf07791bc70
+checksum=fcdc73f9a329394d3d38cab0f3724ccb08d165682a4451e9798d41882a7c031b
 conf_files="/etc/firejail/* /etc/apparmor.d/local/firejail-local"
 
 if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
Firejail 0.9.60 does not work with some modern AppImages (e.g. NextCloud), but 0.9.62 which was released about 20 dyas ago does.