### PR TITLE
chromium: update to 79.0.3945.130.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,8 +6,8 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=79.0.3945.117
-revision=2
+version=79.0.3945.130
+revision=1
 archs="x86_64"
 create_wrksrc=yes
 short_desc="Browser plugin designed for the viewing of premium video content"

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,15 +1,15 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=79.0.3945.117
-revision=2
+version=79.0.3945.130
+revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=4d960e8bd790cc1c8e7f0632790424957c4996a8a91b9d899eb572acec854ef1
+checksum=56193431ab9d1193773b133d86b419bfae8d8b9196eea253660895e0e8f87ba0
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
[ci skip]

- Built for x86_64, i686, x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine (version bump, but upstream contents did not change)