### PR TITLE
New package: void-release-keys-1

### DIFF
--- a/srcpkgs/void-release-keys/files/void-release-20191109.pub
+++ b/srcpkgs/void-release-keys/files/void-release-20191109.pub
@@ -1,0 +1,2 @@
+untrusted comment: This key is only valid for releases with date 20191109.
+RWSFkPfJ0Jkg3EIuGjZoCn1/GSChINr/WHdJcdAh1s0d5P+C+ejdCC64

--- a/srcpkgs/void-release-keys/template
+++ b/srcpkgs/void-release-keys/template
@@ -1,0 +1,15 @@
+# Template file for 'void-release-keys'
+pkgname=void-release-keys
+version=1
+revision=1
+archs=noarch
+short_desc="Void Linux Release Keys"
+maintainer="Void Release Engineering <releases@voidlinux.org>"
+license="Public domain"
+homepage="http://www.voidlinux.org"
+
+do_install() {
+	for _i in ${FILESDIR}/* ; do
+		vinstall $_i 644 etc/signify/
+	done
+}


### PR DESCRIPTION
This commit adds the initial signify key and allows bootstrapping trust via the existing key infrastructure used by xbps.  The key should be validated against the master in keybase by either @Duncaen or @Gottox.