### PR TITLE
emacs: Add tar to hostmakedepends

### DIFF
--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -7,7 +7,7 @@ configure_args="--with-file-notification=inotify --with-modules
  $(vopt_with jpeg) $(vopt_with tiff) $(vopt_with gif) $(vopt_with png)
  $(vopt_with xpm) $(vopt_with svg rsvg) $(vopt_with imagemagick)
  $(vopt_with xml xml2) $(vopt_with gnutls) $(vopt_with sound) $(vopt_with m17n m17n-flt)"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config tar"
 makedepends="ncurses-devel libXaw-devel gtk+-devel gtk+3-devel webkit2gtk-devel
  dbus-devel acl-devel
  $(vopt_if jpeg libjpeg-turbo-devel) $(vopt_if tiff tiff-devel)


### PR DESCRIPTION
Fails to build from without tar. This may not have been noticed
previously because a dependency likely requires tar during build, so it
just ends up being present.