### PR TITLE
intel-ucode: restore working firmware blob 06-55-04 to avoid reboot bug

### DIFF
--- a/srcpkgs/intel-ucode/template
+++ b/srcpkgs/intel-ucode/template
@@ -1,18 +1,27 @@
 # Template file for 'intel-ucode'
 pkgname=intel-ucode
 version=20191115
-revision=1
+revision=2
 archs="i686* x86_64*"
-wrksrc="Intel-Linux-Processor-Microcode-Data-Files-microcode-${version}"
+_wrksrc_base="Intel-Linux-Processor-Microcode-Data-Files-microcode"
+wrksrc="${_wrksrc_base}-${version}"
 short_desc="Microcode update files for Intel CPUs"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom: Proprietary"
 homepage="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files"
-distfiles="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/microcode-${version}.tar.gz"
-checksum=14b26d27be70774948b8cb582e298f5317263b8b8bb1fe8e41260eae54f531dc
+distfiles="${homepage}/archive/microcode-${version}.tar.gz
+ ${homepage}/archive/microcode-20190918.tar.gz"
+checksum="14b26d27be70774948b8cb582e298f5317263b8b8bb1fe8e41260eae54f531dc
+ 2b6b728d351764dfbf6a9763ac96ae7e04085f382a309fed3abc0118f094c943"
 repository=nonfree
 
 do_install() {
+	# Replace buggy 06-55-04 microcode with last known good version
+	_bad_ucode="intel-ucode/06-55-04"
+	rm "$_bad_ucode"
+	cp "../${_wrksrc_base}-20190918/$_bad_ucode" "$_bad_ucode"
+
+	# Rest of process continues as normal
 	vmkdir usr/lib/firmware/intel-ucode
 	vcopy "intel-ucode/*" usr/lib/firmware/intel-ucode
 	vmkdir usr/lib/dracut/dracut.conf.d


### PR DESCRIPTION
Firmware blob 06-55-04 in intel-ucode versions > 20190918 causes lockups when warm-rebooting certain Xeon and HEDT CPUs. ([Upstream issue](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/issues/21)) This PR replaces the affected blob with the last known good version.