### PR TITLE
vscode: tar missing as hostdependency

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -2,7 +2,7 @@
 pkgname=vscode
 version=1.41.1
 revision=2
-hostmakedepends="pkg-config python nodejs-lts yarn"
+hostmakedepends="pkg-config python nodejs-lts yarn tar"
 makedepends="libxkbfile-devel libsecret-devel"
 depends="libXtst libxkbfile nss dejavu-fonts-ttf"
 short_desc="Microsoft Code for Linux"


### PR DESCRIPTION
With the move to bsdtar, the file type inferrence for compressed archives differs, which breaks the build process. Adding tar to the hostdependencies fixes this problem.