### PR TITLE
zfs-auto-snapshot: crontab fixes

### DIFF
--- a/srcpkgs/zfs-auto-snapshot/template
+++ b/srcpkgs/zfs-auto-snapshot/template
@@ -1,16 +1,23 @@
 # Template file for 'zfs-auto-snapshot'
 pkgname=zfs-auto-snapshot
 version=1.2.4
-revision=1
+revision=2
+archs=noarch
 wrksrc="${pkgname}-upstream-${version}"
 build_style=gnu-makefile
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
-homepage="https://github.com/zfsonlinux/zfs-auto-snapshot"
 short_desc="ZFS automatic snapshot service"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-only"
+homepage="https://github.com/zfsonlinux/zfs-auto-snapshot"
 distfiles="${homepage}/archive/upstream/${version}.tar.gz"
 checksum=307f71f748cacf5149532891dc3174365a4494337d9cfc8e619d9038080f3e9b
-archs=noarch
+conf_files="/etc/cron.*/zfs-auto-snapshot"
+
+pre_install() {
+	# The "frequent" crontab contais a PATH= directive, which is not
+	# supported with the dcron package and is otherwise unnecessary
+	vsed -i 's/^PATH=/#PATH=/' etc/zfs-auto-snapshot.cron.frequent
+}
 
 post_install() {
 	mv ${DESTDIR}/usr/sbin ${DESTDIR}/usr/bin


### PR DESCRIPTION
The zfs-auto-snapshot package installs several crontab files. In this PR, these files are properly marked as conf_files because the user may wish to customize their behavior. Also, I comment out the PATH variable assignment in the etc/cron.d/zfs-auto-snapshot "frequent" file because such variable assignments are not supported in dcron. (In other crond alternatives, the variable assignment is meaningless, because the directories assigned are redundant with the system default.)