### PR TITLE
slack-desktop: add missing dependencies

### DIFF
--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -5,6 +5,7 @@ revision=1
 archs="x86_64"
 short_desc="Messaging app for teams"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
+hostmakedepends="tar xz"
 license="custom:Proprietary"
 homepage="https://slack.com/"
 distfiles="https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/${pkgname}-${version}-amd64.deb"


### PR DESCRIPTION
tar and xz are no longer in masterdir, so the conversion of this .deb package failed.