### PR TITLE
autofs: fix map locations in auto.master

### DIFF
--- a/srcpkgs/autofs/template
+++ b/srcpkgs/autofs/template
@@ -1,7 +1,7 @@
 # Template file for 'autofs'
 pkgname=autofs
 version=5.1.6
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_args="DONTSTRIP=1"
 configure_args="--with-libtirpc --with-mapdir=/etc/autofs --sbindir=/usr/bin"
@@ -33,6 +33,8 @@ pre_configure() {
 
 pre_build() {
 	unset STRIP
+	# Fix path for map files
+	vsed -i "s@/etc/@/etc/autofs/@g" samples/auto.master
 }
 
 post_install() {


### PR DESCRIPTION
The default auto.master looks for map files in /etc, but the package puts maps in /etc/autofs. This PR alters the default auto.master to look for maps in the right location.