### PR TITLE
cronie: support $OPTS and logging in service

### DIFF
--- a/srcpkgs/cronie/files/cronie/log/run
+++ b/srcpkgs/cronie/files/cronie/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -p cron.notice

--- a/srcpkgs/cronie/files/cronie/run
+++ b/srcpkgs/cronie/files/cronie/run
@@ -1,2 +1,3 @@
 #!/bin/sh
-exec cronie-crond -n 2>&1
+[ -r conf ] && . ./conf
+exec cronie-crond -n $OPTS 2>&1

--- a/srcpkgs/cronie/template
+++ b/srcpkgs/cronie/template
@@ -1,7 +1,7 @@
 # Template file for 'cronie'
 pkgname=cronie
 version=1.5.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-inotify --without-selinux --with-pam
  --enable-anacron --enable-pie --enable-relro"


### PR DESCRIPTION
This PR modifies the cronie package to support $OPTS definitions in the service conf file and adds a logger, both of which are consistent with the behavior of the dcron package.