### PR TITLE
Waybar: update to 0.9.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3705,3 +3705,4 @@ libnvpair.so.1 zfs-0.8.2_1
 libjsonnet.so.0 jsonnet-0.14.0_2
 libjsonnet++.so.0 jsonnet-0.14.0_2
 libigdgmm.so.11 intel-gmmlib-19.4.1_1
+libgtk-layer-shell.so.0 wf-shell-0.3_1

--- a/srcpkgs/Waybar/patches/Waybar-0.9.0-fix-building-with-libnl-option-enabled.patch
+++ b/srcpkgs/Waybar/patches/Waybar-0.9.0-fix-building-with-libnl-option-enabled.patch
@@ -1,0 +1,8 @@
+--- src/modules/network.cpp
++++ src/modules/network.cpp
+@@ -2,6 +2,7 @@
+ #include <spdlog/spdlog.h>
+ #include <sys/eventfd.h>
+ #include <fstream>
++#include <cassert>
+ #include "util/format.hpp"

--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,13 +1,14 @@
 # Template file for 'Waybar'
 pkgname=Waybar
-version=0.8.0
-revision=2
+version=0.9.0
+revision=1
 build_style=meson
 configure_args="-Dlibnl=$(vopt_if libnl enabled disabled)
  -Dpulseaudio=$(vopt_if pulseaudio enabled disabled)
- -Ddbusmenu-gtk=$(vopt_if dbusmenugtk enabled disabled)"
-hostmakedepends="pkg-config glib-devel wayland-devel sway"
-makedepends="libinput-devel wayland-devel wlroots-devel gtkmm-devel spdlog
+ -Ddbusmenu-gtk=$(vopt_if dbusmenugtk enabled disabled)
+ -Dsystemd=disabled"
+hostmakedepends="pkg-config glib-devel wayland-devel sway scdoc"
+makedepends="wf-shell libinput-devel wayland-devel wlroots-devel gtkmm-devel spdlog
  jsoncpp-devel libglib-devel libsigc++-devel fmt-devel
  $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if libnl libnl3-devel)
  $(vopt_if dbusmenugtk libdbusmenu-gtk3-devel)
@@ -18,7 +19,7 @@ license="MIT"
 homepage="https://github.com/Alexays/Waybar"
 changelog="https://github.com/Alexays/Waybar/releases"
 distfiles="https://github.com/Alexays/Waybar/archive/${version}.tar.gz"
-checksum=2de2f0cec243da0d9ff2255ceb9dac9d95e8be06d6ea13926fae460d72e4b8aa
+checksum=65e8397d5a8880cbb9172138e361b0d91f649bc99327d36945e38d1e5dbb157d
 
 build_options="libnl pulseaudio dbusmenugtk mpd"
 build_options_default="pulseaudio mpd"


### PR DESCRIPTION
I added new required dependencies: wf-shell and scdoc and also disabled the new meson build option "systemd" as Void Linux runs runit (it was enabled by default and the package couldn't be compiled).
Also I'm really sorry for closing the previous pull request by accident, I'm new to git.
#18428 can be closed now, right?