### PR TITLE
New package: volta-0.7.1

### DIFF
--- a/srcpkgs/volta/files/install.sh
+++ b/srcpkgs/volta/files/install.sh
@@ -1,0 +1,38 @@
+createDir() {
+    if [ ! -d "$1" ]; then
+        mkdir "$1"
+    fi
+}
+
+createSymlink() {
+    if [ ! -e "$2" ]; then
+        ln -s "$1" "$2"
+    fi
+}
+
+installProfile() {
+    if [ -e "$1" ]; then
+        isInstalled=$(grep "$2" "$1")
+        if [ -z "$isInstalled" ]; then
+            echo "" >> "$1"
+            echo "export VOLTA_HOME=\"$HOME/.volta\"" >> "$1"
+            echo "export PATH=\"$HOME/.volta/bin:\$PATH\"" >> "$1"
+            echo "source $2" >> "$1"
+        fi
+    fi
+}
+
+# Create directories
+createDir "$HOME/.volta"
+createDir "$HOME/.volta/bin"
+
+# Create symlinks
+createSymlink "/usr/bin/volta" "$HOME/.volta/volta"
+createSymlink "/usr/bin/volta-migrate" "$HOME/.volta/volta-migrate"
+createSymlink "/usr/bin/volta-shim" "$HOME/.volta/volta-shim"
+
+# Install profile
+installProfile "$HOME/.bashrc" "/etc/volta/load.bash"
+installProfile "$HOME/.cshrc" "/etc/volta/load.sh"
+installProfile "$HOME/.config/fish/config.fish" "/etc/volta/load.fish"
+installProfile "$HOME/.zshrc" "/etc/volta/load.sh"

--- a/srcpkgs/volta/template
+++ b/srcpkgs/volta/template
@@ -1,0 +1,36 @@
+# Template file for 'volta'
+pkgname=volta
+version=0.7.1
+revision=1
+archs="x86_64 i686"
+build_helper="rust"
+hostmakedepends="cargo pkg-config"
+makedepends="libressl-devel"
+short_desc="JavaScript tool version sync helper"
+maintainer="Alex Lohr <alex.lohr@logmein.com>"
+license="BSD-2-Clause"
+homepage="https://volta.sh/"
+distfiles="https://github.com/volta-cli/${pkgname}/archive/v${version}.tar.gz"
+checksum=e53a07e167bb64103f36901423f5a377a2ea89ecfdd7a1343e69d659f99f9c1b
+
+pre_build() {
+	cargo update --package openssl-sys --precise 0.9.53
+}
+
+do_build() {
+	cargo build --release --target ${RUST_TARGET}
+}
+
+do_install() {
+	vlicense LICENSE
+
+	vbin target/${RUST_TARGET}/release/volta
+	vbin target/${RUST_TARGET}/release/volta-shim
+	vbin target/${RUST_TARGET}/release/volta-migrate
+
+	vmkdir etc/volta 755
+	vinstall shell/unix/load.bash 755 etc/volta
+	vinstall shell/unix/load.sh 755 etc/volta
+	vinstall shell/unix/load.fish 755 etc/volta
+	vinstall ${FILESDIR}/install.sh 755 etc/volta
+}

--- a/srcpkgs/volta/update
+++ b/srcpkgs/volta/update
@@ -1,0 +1,2 @@
+site="https://github.com/volta-cli/volta/releases"
+pattern="\bv(\d+\.\d+\.\d+)\b"


### PR DESCRIPTION
Volta is a JavaScript utility version handling tool written in rust; unfortunately, binaries are only available for openssl, so it needs to be compiled for libressl. The original is supposed to be installed to a hidden directory, but since that does not fit into the workflow, I changed the installation to put the binaries into /usr/bin and the scripts into /etc/volta (where you can source them from your .bashrc or .zshrc).