### PR TITLE
pam-base: add support for pam-gnupg-git package

### DIFF
--- a/srcpkgs/pam-base/files/system-auth
+++ b/srcpkgs/pam-base/files/system-auth
@@ -3,6 +3,7 @@
 auth      required  pam_unix.so     try_first_pass nullok
 auth      optional  pam_permit.so
 auth      required  pam_env.so
+-auth     optional  pam_gnupg.so
 
 account   required  pam_unix.so
 account   optional  pam_permit.so

--- a/srcpkgs/pam-base/files/system-login
+++ b/srcpkgs/pam-base/files/system-login
@@ -18,4 +18,5 @@ session    optional   pam_mail.so          dir=/var/mail standard quiet
 -session   optional   pam_elogind.so
 -session   optional   pam_ck_connector.so  nox11
 session    required   pam_env.so
+-session   optional   pam_gnupg.so
 session    required   pam_lastlog.so       silent

--- a/srcpkgs/pam-base/template
+++ b/srcpkgs/pam-base/template
@@ -1,7 +1,7 @@
 # Template file for 'pam-base'
 pkgname=pam-base
 version=0.3
-revision=5
+revision=6
 archs=noarch
 short_desc="PAM base configuration files"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
Now that pam-gnupg-git has been merged, add (optional) support for the module in the pam-base configs.