### PR TITLE
New package: libopenmpt-0.4.11 & openmpt123

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -331,6 +331,7 @@ libglademm-2.4.so.1 libglademm-2.6.7_1
 libthunarx-3.so.0 Thunar-1.8.1_1
 libexif.so.12 libexif-0.6.17_1
 liboil-0.3.so.0 liboil-0.3.16_1
+libopenmpt.so.0 libopenmpt-0.4.11_1
 libogg.so.0 libogg-1.3.0_1
 libvorbis.so.0 libvorbis-1.2.1rc1_1
 libvorbisenc.so.2 libvorbis-1.2.1rc1_1

--- a/srcpkgs/libopenmpt-devel
+++ b/srcpkgs/libopenmpt-devel
@@ -1,0 +1,1 @@
+libopenmpt

--- a/srcpkgs/libopenmpt/template
+++ b/srcpkgs/libopenmpt/template
@@ -1,0 +1,51 @@
+# Template file for 'libopenmpt'
+pkgname=libopenmpt
+version=0.4.11
+revision=1
+wrksrc="libopenmpt-${version}+release.autotools"
+build_style=gnu-configure
+configure_args="$(vopt_with pulseaudio)
+ $(vopt_with sdl) $(vopt_with sdl2)
+ $(vopt_enable libopenmpt_modplug) $(vopt_enable libmodplug)"
+hostmakedepends="pkg-config"
+makedepends="zlib-devel mpg123-devel libogg-devel libvorbis-devel
+ portaudio-devel portaudio-cpp-devel libsndfile-devel libflac-devel
+ $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if sdl2 SDL2-devel)
+ $(vopt_if sdl SDL-devel)"
+short_desc="Cross-platform C & C++ library to decode tracked music files (modules)"
+maintainer="a dinosaur <nick@a-dinosaur.com>"
+license="BSD-3-Clause"
+homepage="https://lib.openmpt.org/libopenmpt/"
+distfiles="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz"
+checksum=260e92cc2f6af37113442bff2c75a3c36a09eba4078dc593203a0502f95d26bd
+conflicts="$(vopt_if libmodplug libmodplug)"
+
+post_install() {
+	vlicense LICENSE
+}
+
+# Package build options
+build_options="pulseaudio sdl2 sdl libopenmpt_modplug libmodplug"
+build_options_default="pulseaudio"
+vopt_conflict sdl2 sdl
+
+libopenmpt-devel_package() {
+	depends="${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/share/doc/libopenmpt/examples
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}
+
+openmpt123_package() {
+	depends="${sourcepkg}-${version}_${revision}"
+	short_desc="Cross-platform command-line or terminal based module file player"
+	pkg_install() {
+		vmove usr/bin/openmpt123
+		vmove usr/share/man/man1/openmpt123.1
+	}
+}

--- a/srcpkgs/openmpt123
+++ b/srcpkgs/openmpt123
@@ -1,0 +1,1 @@
+libopenmpt


### PR DESCRIPTION
Adds the OpenMPT music module replayer library + bundled mpg123 style command line player/decoder using it.

This is my first more complex package, so please let me know if there are any mistakes and I'll try to correct them.
Thanks.