### PR TITLE
nginx: add support for stream proxying

### DIFF
--- a/srcpkgs/nginx/files/ngx_auto_config.h.armv6l
+++ b/srcpkgs/nginx/files/ngx_auto_config.h.armv6l
@@ -1,7 +1,7 @@
-#define NGX_CONFIGURE " --prefix=/etc/nginx --conf-path=/etc/nginx/nginx.conf --sbin-path=/usr/bin/nginx --pid-path=/run/nginx.pid --lock-path=/var/lock/nginx.lock --user=nginx --group=nginx --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --http-client-body-temp-path=/var/tmp/nginx/client-body --http-proxy-temp-path=/var/tmp/nginx/proxy --http-fastcgi-temp-path=/var/tmp/nginx/fastcgi --http-scgi-temp-path=/var/tmp/nginx/scgi --http-uwsgi-temp-path=/var/tmp/nginx/uwsgi --with-mail --with-mail_ssl_module --with-pcre-jit --with-file-aio --with-http_gunzip_module --with-http_v2_module --with-http_dav_module --with-http_gzip_static_module --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-http_geoip_module"
+#define NGX_CONFIGURE " --prefix=/etc/nginx --conf-path=/etc/nginx/nginx.conf --sbin-path=/usr/bin/nginx --pid-path=/run/nginx.pid --lock-path=/var/lock/nginx.lock --user=nginx --group=nginx --http-log-path=/var/log/nginx/access.log --error-log-path=/var/log/nginx/error.log --http-client-body-temp-path=/var/tmp/nginx/client-body --http-proxy-temp-path=/var/tmp/nginx/proxy --http-fastcgi-temp-path=/var/tmp/nginx/fastcgi --http-scgi-temp-path=/var/tmp/nginx/scgi --http-uwsgi-temp-path=/var/tmp/nginx/uwsgi --with-mail --with-mail_ssl_module --with-pcre-jit --with-file-aio --with-http_gunzip_module --with-http_v2_module --with-http_dav_module --with-http_gzip_static_module --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-http_sub_module --with-http_geoip_module --with-stream --with-stream_realip_module --with-stream_ssl_module --with-stream_ssl_preread_module --with-stream_geoip_module"
 
 #ifndef NGX_COMPILER
-#define NGX_COMPILER  "gcc 8.2.0 (GCC) "
+#define NGX_COMPILER  "gcc 9.2.0 (GCC) "
 #endif
 
 
@@ -440,6 +440,16 @@
 
 #ifndef NGX_MAIL_SSL
 #define NGX_MAIL_SSL  1
+#endif
+
+
+#ifndef NGX_STREAM_SSL
+#define NGX_STREAM_SSL  1
+#endif
+
+
+#ifndef NGX_STREAM_UPSTREAM_ZONE
+#define NGX_STREAM_UPSTREAM_ZONE  1
 #endif
 
 

--- a/srcpkgs/nginx/template
+++ b/srcpkgs/nginx/template
@@ -1,8 +1,8 @@
 # Template file for 'nginx'
-reverts="1.17.7_1"
 pkgname=nginx
+reverts="1.17.7_1"
 version=1.16.1
-revision=3
+revision=4
 build_style=gnu-makefile
 hostmakedepends="libressl-devel pcre-devel $(vopt_if geoip geoip-devel)"
 makedepends="${hostmakedepends}"
@@ -32,8 +32,9 @@ make_dirs="/var/log/nginx 0750 root root
  /var/tmp 1777 root root
  /var/tmp/nginx 0750 nginx root"
 
-build_options="geoip"
-build_options_default="geoip"
+build_options="geoip stream"
+desc_option_stream="Enable support for stream proxies"
+build_options_default="geoip stream"
 
 do_configure() {
 	local cfgdir=/etc/nginx
@@ -43,6 +44,14 @@ do_configure() {
 		# fake configure run on host
 		unset CC CPP LD CFLAGS CPPFLAGS LDFLAGS
 	fi
+
+	local stream_modules="\
+		--with-stream \
+		--with-stream_realip_module \
+		--with-stream_ssl_module \
+		--with-stream_ssl_preread_module \
+		$(vopt_if geoip --with-stream_geoip_module) \
+	"
 
 	./configure --prefix=${cfgdir} \
 		--conf-path=${cfgdir}/nginx.conf \
@@ -67,7 +76,8 @@ do_configure() {
 		--with-http_ssl_module \
 		--with-http_stub_status_module \
 		--with-http_sub_module \
-		$(vopt_if geoip --with-http_geoip_module)
+		$(vopt_if geoip --with-http_geoip_module) \
+		$(vopt_if stream "$stream_modules")
 }
 
 pre_build() {


### PR DESCRIPTION
Nginx supports, with the "stream" family of modules, acting as a (reverse) proxy for arbitrary data streams. This PR adds a "stream" build option, enabled by default, that will configure nginx for stream proxying. Offloading encryption responsibilities to an nginx strem proxy represents a good use case for this feature.