### PR TITLE
sshguard: support dynamic firewall config and remove iptables dependency

### DIFF
--- a/srcpkgs/sshguard/files/sshguard-socklog/run
+++ b/srcpkgs/sshguard/files/sshguard-socklog/run
@@ -1,5 +1,14 @@
 #!/bin/sh
-sv check iptables >/dev/null || exit 1
-sv check socklog-unix >/dev/null || exit 1
 
-exec sshguard -l /var/log/socklog/secure/current -b 200:/var/db/sshguard/blacklist.db 2>&1
+# Defaults that mabe be overridden (or erased entirely) by configuration
+LOGFILE="${LOGFILE:-/var/log/socklog/secure/current}"
+BLACKLIST_SPEC="${BLACKLIST_SPEC:-200:/var/db/sshguard/blacklist.db}"
+
+# Allow the firewall and logger backends to be specified
+[ -f ./conf ] && . ./conf
+
+# If specified, add blacklist spec and log source to OPTS
+[ -n "$BLACKLIST_SPEC" ] && OPTS="-b $BLACKLIST_SPEC"
+[ -n "$LOGFILE" ] && OPTS="-l $LOGFILE $OPTS"
+
+exec sshguard $OPTS 2>&1

--- a/srcpkgs/sshguard/template
+++ b/srcpkgs/sshguard/template
@@ -1,10 +1,9 @@
 # Template file for 'sshguard'
 pkgname=sshguard
 version=2.4.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="flex"
-depends="iptables"
 short_desc="Protects networked hosts from brute force attacks"
 maintainer="Lodvær <lodvaer@gmail.com>"
 license="BSD-3-Clause"


### PR DESCRIPTION
sshguard uses iptables as an optional firewall backend, but also natively supports the nftables firewall. I removed the explicit iptables dependency from this package and added support for a "conf" file in the service (renamed to "sshguard" from "sshguard-socklog" because it is not inextricably linked to socklog) to allow the firewall and logger service dependencies to be dynamically changed. By default, the service still expects socklog-unix and iptables.

The rename will break /var/service links to the existing "sshguard-socklog", but the post-change behavior seems to make more sense.