### PR TITLE
passphrase2pgp: update to 1.0.0.

### DIFF
--- a/srcpkgs/passphrase2pgp/patches/version.patch
+++ b/srcpkgs/passphrase2pgp/patches/version.patch
@@ -1,0 +1,13 @@
+diff --git passphrase2pgp.go passphrase2pgp.go
+index 0afc4b..e47b97 100644
+--- passphrase2pgp.go
++++ passphrase2pgp.go
+@@ -33,7 +33,7 @@ const (
+ 	formatPGP = iota
+ 	formatSSH
+ 
+-	version = "0.1.0"
++	version = "1.0.0"
+ )
+ 
+ // Print the message like fmt.Printf() and then os.Exit(1).

--- a/srcpkgs/passphrase2pgp/template
+++ b/srcpkgs/passphrase2pgp/template
@@ -1,13 +1,13 @@
 # Template file for 'passphrase2pgp'
 pkgname=passphrase2pgp
-version=0.1.0
+version=1.0.0
 revision=1
 build_style=go
-go_import_path="github.com/skeeto/passphrase2pgp"
+go_import_path="nullprogram.com/x/passphrase2pgp"
 hostmakedepends="git"
 short_desc="Generate a PGP key from a passphrase"
 maintainer="Daniel Lewan <vision360.daniel@gmail.com>"
 license="Unlicense"
 homepage="https://github.com/skeeto/passphrase2pgp"
 distfiles="https://github.com/skeeto/passphrase2pgp/archive/v${version}.tar.gz"
-checksum=15d26a836d9df2fa6e487d7224e6ab7d6f51139211ceb77b8ecd8c594b86699a
+checksum=eebffea55028fb2416e6245fcb7f72c3a2db20b3e51fed281a4b7c146fb43267


### PR DESCRIPTION
Temporary patch, will be removed in next release