### PR TITLE
New package: runit-nftables-20200123

### DIFF
--- a/srcpkgs/runit-nftables/files/91-nftables.sh
+++ b/srcpkgs/runit-nftables/files/91-nftables.sh
@@ -1,0 +1,3 @@
+if [ -e /etc/nftables.conf ]; then
+  nft -f /etc/nftables.conf
+fi

--- a/srcpkgs/runit-nftables/template
+++ b/srcpkgs/runit-nftables/template
@@ -1,0 +1,14 @@
+# Template file for 'runit-nftables'
+pkgname=runit-nftables
+version=20200123
+revision=1
+archs=noarch
+depends="runit-void nftables"
+short_desc="Restore nftables rules on boot"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="Public Domain"
+homepage="https://www.voidlinux.org"
+
+do_install() {
+	vinstall ${FILESDIR}/91-nftables.sh 0644 etc/runit/core-services
+}


### PR DESCRIPTION
This package is analogous to runit-iptables, loading existing rules at /etc/nftables.conf (the file expected by the service installed by the nftables package) on boot.