### PR TITLE
New package: goimapnotify-2.0

### DIFF
--- a/srcpkgs/goimapnotify/template
+++ b/srcpkgs/goimapnotify/template
@@ -1,0 +1,15 @@
+# Template file for 'goimapnotify'
+pkgname=goimapnotify
+version=2.0
+revision=1
+build_style=go
+go_import_path="gitlab.com/shackra/goimapnotify"
+go_get="no"
+hostmakedepends="git"
+short_desc="Execute scripts on IMAP idle notifications (Go version)"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-3.0-only"
+homepage="https://gitlab.com/shackra/goimapnotify"
+changelog="https://gitlab.com/shackra/goimapnotify/blob/master/CHANGELOG.rst"
+distfiles="https://${go_import_path}/-/archive/${version}/${pkgname}-${version}.tar.gz"
+checksum=175734cdc3fad285479f4bbad761fe2a379f33e4919572efaf41c8107d249cd9


### PR DESCRIPTION
goimapnotify is a program to establish IDLE connections to at least one mailbox on an IMAP server and execute commands when message notifications are received.