### PR TITLE
plata-theme: update to 0.9.2. [ci skip]

### DIFF
--- a/srcpkgs/plata-theme/template
+++ b/srcpkgs/plata-theme/template
@@ -1,6 +1,6 @@
 # Template file for 'plata-theme'
 pkgname=plata-theme
-version=0.9.1
+version=0.9.2
 revision=1
 archs=noarch
 build_style=gnu-configure
@@ -14,7 +14,7 @@ maintainer="mobinmob <mobinmob@disroot.org>"
 license="CC-BY-SA-4.0, GPL-2.0-or-later"
 homepage="https://gitlab.com/tista500/plata-theme"
 distfiles="https://gitlab.com/tista500/plata-theme/-/archive/${version}/plata-theme-${version}.tar.gz"
-checksum=5a4510d880f20e945f561862712543e922072377262cd36f559cad44ea7b6a20
+checksum=9c5f10c2b2a4af819cebe94944ee3ab232ae049248137c93e72807f9abeafd92
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
[ci skip] because the build creates excessive output.