### PR TITLE
inetutils: fix the missing port number for whois

### DIFF
--- a/srcpkgs/inetutils/template
+++ b/srcpkgs/inetutils/template
@@ -1,13 +1,13 @@
 # Template file for 'inetutils'
 pkgname=inetutils
 version=1.9.4
-revision=10
+revision=11
 build_style=gnu-configure
 configure_args="--without-wrap --with-pam"
 makedepends="pam-devel readline-devel"
 short_desc="GNU network utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/inetutils"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.xz"
 checksum=849d96f136effdef69548a940e3e0ec0624fc0c81265296987986a0dd36ded37
@@ -29,9 +29,16 @@ esac
 depends="${subpackages}"
 
 pre_configure() {
-	sed -i 's|_GL_WARN_ON_USE (gets|//_GL_WARN_ON_USE (gets|' lib/stdio.in.h
+	vsed -i 's|_GL_WARN_ON_USE (gets|//_GL_WARN_ON_USE (gets|' lib/stdio.in.h
 	# Create a definition to allow the ifconfig program to build properly
 	echo '#define PATH_PROCNET_DEV "/proc/net/dev"' >> ifconfig/system/linux.h
+	# Use the standard name ("nicname") for the "whois" service.
+	vsed -i 's|port : "whois"|port : "nicname"|' whois/whois.c
+	# Changing the whois/whois.c triggers help2man invocation. This is not
+	# necessary because no option has changed. Moreover, launching help2man
+	# fails for the cross compilations. Let's make sure the build process
+	# is not triggered to run it then.
+	touch man/whois.1
 }
 post_install() {
 	# Keep just usr/share/info/inetutils.info.gz


### PR DESCRIPTION
Fixes issue 18445:
#18445

inetutils-whois consults the /etc/services provided by IANA to
determine the port number for the "whois" service. However, the
"whois" service is not listed in that file and when you run whois
you will end up with the following error:

> whois 4.2.2.4
  getaddrinfo: Servname not supported for ai_socktype

This patch makes use of "nicname" port which is the same number
(43) as a "whois" port and is listed in /etc/services.
Moreover, changing the whois/whois.c leads to invocation of
help2man. This is unnecessary, because no option has changed and
launching help2man during the cross compilation fails.

This fix wouldn't be possible without the help of great folks
at #voidlinux.