### PR TITLE
mesa: generate nostrip_files dynamically

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -200,16 +200,11 @@ mesa-dri_package() {
 	short_desc="Mesa DRI drivers"
 	depends="mesa-${version}_${revision}"
 	shlib_provides="libgallium_dri.so" # workaround for mesa-dri-32bit
-	nostrip_files="armada-drm_dri.so etnaviv_dri.so exynos_dri.so
-	 hx8357d_dri.so i915_dri.so i965_dri.so ili9225_dri.so ili9341_dri.so
-	 imx-drm_dri.so kgsl_dri.so kms_swrast_dri.so lima_dri.so meson_dri.so
-	 mi0283qt_dri.so msm_dri.so mxsfb-drm_dri.so nouveau_dri.so
-	 nouveau_vieux_dri.so panfrost_dri.so pl111_dri.so r200_dri.so
-	 r300_dri.so r600_dri.so radeon_dri.so radeonsi_dri.so repaper_dri.so
-	 rockchip_dri.so st7586_dri.so st7735r_dri.so stm_dri.so
-	 sun4i-drm_dri.so swrast_dri.so tegra_dri.so v3d_dri.so vc4_dri.so
-	 virtio_gpu_dri.so vmwgfx_dri.so"
 	pkg_install() {
+		# Only strip each megadriver once, via its master filename
+		nostrip_files=$(find "${DESTDIR}/usr/lib/xorg/modules/drivers" \
+		 ! -name 'libmesa_dri_drivers.so' ! -name 'libgallium_dri.so'  \
+		  -type f -printf '%f ')
 		vmove "usr/lib/xorg/modules/drivers";
 		if [ -d "$DESTDIR/usr/lib/gallium-pipe" ]; then
 			vmove "usr/lib/gallium-pipe/pipe_*.so"
@@ -220,25 +215,27 @@ mesa-dri_package() {
 mesa-vaapi_package() {
 	short_desc="Mesa VA-API drivers"
 	shlib_provides="libgallium_drv_video.so" # workaround for mesa-vaapi-32bit
-	nostrip_files="nouveau_drv_video.so r600_drv_video.so radeonsi_drv_video.so"
 	pkg_install() {
+		nostrip_files=$(find "${DESTDIR}/usr/lib/dri" \
+		 ! -name 'libgallium_drv_video.so' -type f -printf '%f ')
 		vmove "usr/lib/dri/*_drv_video.so"
 	}
 }
 
 mesa-vdpau_package() {
 	short_desc="Mesa VDPAU drivers"
-	nostrip_files="libvdpau_r300.so.1.0.0 libvdpau_r600.so.1.0.0
-	 libvdpau_radeonsi.so.1.0.0 libvdpau_nouveau.so.1.0.0"
 	pkg_install() {
+		nostrip_files=$(find "${DESTDIR}/usr/lib/vdpau" \
+		 ! -name 'libvdpau_gallium.so*' -type f -printf '%f ')
 		vmove "usr/lib/vdpau/libvdpau_*"
 	}
 }
 
 mesa-XvMC_package() {
 	short_desc="Mesa XvMC drivers"
-	nostrip_files="libXvMCnouveau.so.1.0.0 libXvMCr600.so.1.0.0"
 	pkg_install() {
+		nostrip_files=$(find "${DESTDIR}/usr/lib/libXvMC"* \
+		 ! -name 'libXvMCgallium.so' -type f -printf '%f ')
 		vmove "usr/lib/libXvMC*"
 	}
 }


### PR DESCRIPTION
This is functionally equivalent as before, but now the `nostrip_files` list is generated dynamically rather than hard-coded into the template. It has the benefit that one doesn't have to worry about forgetting to add new drivers to the list (which would break the debug stripping once again).