### PR TITLE
runc: update to 1.0.0rc10.

### DIFF
--- a/srcpkgs/runc/patches/nowhich.patch
+++ b/srcpkgs/runc/patches/nowhich.patch
@@ -1,0 +1,13 @@
+diff --git man/md2man-all.sh man/md2man-all.sh
+index f850ddf3..aae189da 100755
+--- man/md2man-all.sh
++++ man/md2man-all.sh
+@@ -9,7 +9,7 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+ 	pwd
+ }
+ 
+-if ! ( which go-md2man &>/dev/null ); then
++if ! ( command -v go-md2man &>/dev/null ); then
+ 	echo "To install man pages, please install 'go-md2man'."
+ 	exit 0
+ fi

--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,8 +1,8 @@
 # Template file for 'runc'
 pkgname=runc
 version=1.0.0
-revision=11
-_subver="rc9"
+revision=12
+_subver="rc10"
 _ver="$version-$_subver"
 wrksrc="$pkgname-$_ver"
 build_style=go
@@ -15,7 +15,7 @@ maintainer="Paul Knopf <pauldotknopf@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${_ver}/runc.tar.xz"
-checksum=2f1c7ebac67c779affe2bb4370bba44b08ed280144ba58c86219186e303832ba
+checksum=c823307ce8695af05381c5c25a92daacd6219c674d8bebaa0e1bff801c2b1f24
 
 post_build() {
 	make man


### PR DESCRIPTION
Fix CVE-2019-19921

See https://github.com/opencontainers/runc/issues/2197