### PR TITLE
slack-desktop: fix missing dependency

### DIFF
--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -4,6 +4,7 @@ version=4.2.0
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz"
+depends="xdg-utils"
 short_desc="Messaging app for teams"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="custom:Proprietary"


### PR DESCRIPTION
Without xdg-utils, the login will not work so slack basically becomes useless.