### PR TITLE
New package: libstdc++-doc-20140403

### DIFF
--- a/srcpkgs/libstdc++-doc/template
+++ b/srcpkgs/libstdc++-doc/template
@@ -1,0 +1,18 @@
+# Template file for 'libstdc++-doc'
+pkgname=libstdc++-doc
+version=20140403
+revision=1
+archs=noarch
+short_desc="A set of doxygen generated HTML documentation for the GNU Standard C++ Library"
+maintainer="Vars Bhat <emailvarsbhat@gmail.com>"
+license="GPL"
+homepage="http://gcc.gnu.org/libstdc++/"
+distfiles="https://gcc.gnu.org/pub/gcc/libstdc++/doxygen/libstdc++-api.${version}.man.tar.bz2"
+checksum="0f85315cfdb32c609d6bb64c76e855b6a625123f3c21d8b7d45332024e6ef138"
+wrksrc="libstdc++-api.20140403.man"
+
+
+do_install() {
+	vmkdir usr/share/man/man3
+	cp -rf ${wrksrc}/man3/*  ${DESTDIR}/usr/share/man/man3
+}


### PR DESCRIPTION
libstdc++-doc provides manpages for standard c++ library.