### PR TITLE
steam: add some missing runtime deps

### DIFF
--- a/srcpkgs/steam/template
+++ b/srcpkgs/steam/template
@@ -1,10 +1,11 @@
 # Template file for 'steam'
 pkgname=steam
 version=1.0.0.61
-revision=4
+revision=5
 archs="i686 x86_64"
 wrksrc=steam
-depends="zenity xz curl dbus freetype gdk-pixbuf hicolor-icon-theme desktop-file-utils liberation-fonts-ttf"
+depends="zenity xz curl dbus freetype gdk-pixbuf hicolor-icon-theme desktop-file-utils
+ liberation-fonts-ttf file tar bash coreutils"
 short_desc="Digital distribution client bootstrap package - Valve's steam client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom: Proprietary license"


### PR DESCRIPTION
Some of these are usually pulled in by `base-system`, some but not all are also in `base-minimal`.