### PR TITLE
inkscape: fix hostmakedepends

### DIFF
--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,13 +1,13 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=0.92.4
-revision=7
+revision=8
 wrksrc="${pkgname}-INKSCAPE_${version//./_}"
 build_style=gnu-configure
 configure_args="--enable-lcms --enable-poppler-cairo
  --without-gnome-vfs --disable-static --disable-strict-build"
-hostmakedepends="automake pkg-config libtool intltool gettext-devel
- glib-devel perl-XML-Parser which"
+hostmakedepends="automake autoconf pkg-config libtool intltool gettext-devel
+ glib-devel perl-XML-Parser tar xz which"
 makedepends="popt-devel libpng-devel gsl-devel gc-devel gtkmm2-devel libxslt-devel
  lcms2-devel poppler-glib-devel boost-devel libmagick6-devel
  libvisio-devel libwpg-devel libcdr-devel dbus-glib-devel libgomp-devel


### PR DESCRIPTION
Missing packages broke the build, fixed hostmakedepends brought it back.