### PR TITLE
open-vm-tools: update to 11.0.5. (add musl support)

### DIFF
--- a/srcpkgs/open-vm-tools/INSTALL.msg
+++ b/srcpkgs/open-vm-tools/INSTALL.msg
@@ -1,5 +1,0 @@
-Enable the vm-tools daemon by executing:
-
-ln -s /etc/sv/vmtoolsd /var/service/
-
-

--- a/srcpkgs/open-vm-tools/patches/0001-recognize-Void.patch
+++ b/srcpkgs/open-vm-tools/patches/0001-recognize-Void.patch
@@ -1,0 +1,24 @@
+#inspired by alpine
+#upstream: no
+
+--- open-vm-tools/lib/include/guest_os.h
++++ open-vm-tools/lib/include/guest_os.h
+@@ -241,6 +241,7 @@ Bool Gos_InSetArray(uint32 gos, const uint32 *set);
+ #define STR_OS_AMAZON_LINUX        "amazonlinux"
+ #define STR_OS_ANNVIX              "Annvix"
+ #define STR_OS_ARCH                "Arch"
++#define STR_OS_VOID                "Void Linux"
+ #define STR_OS_ARKLINUX            "Arklinux"
+ #define STR_OS_ASIANUX_3           "asianux3"
+ #define STR_OS_ASIANUX_4           "asianux4"
+--- open-vm-tools/lib/misc/hostinfoPosix.c
++++ open-vm-tools/lib/misc/hostinfoPosix.c
+@@ -902,6 +902,8 @@ HostinfoGetOSShortName(const char *distro,      // IN: full distro name
+ 
+       Str_Sprintf(distroShort, distroShortSize, "%s%d", STR_OS_AMAZON_LINUX,
+                   version);
++	} else if (strstr(distroLower, "void")) {
++		Str_Strcpy(distroShort, STR_OS_VOID, distroShortSize);
+    } else if (strstr(distroLower, "annvix")) {
+       Str_Strcpy(distroShort, STR_OS_ANNVIX, distroShortSize);
+    } else if (strstr(distroLower, "arch")) {

--- a/srcpkgs/open-vm-tools/patches/0002-disable-werror.patch
+++ b/srcpkgs/open-vm-tools/patches/0002-disable-werror.patch
@@ -1,5 +1,7 @@
---- configure.ac	2019-02-20 10:15:30.000000000 +0000
-+++ -	2019-08-01 02:24:35.995711725 +0000
+#upstream: no
+
+--- open-vm-tools/configure.ac
++++ open-vm-tools/configure.ac
 @@ -1218,7 +1218,7 @@
  
  ### General flags / actions

--- a/srcpkgs/open-vm-tools/patches/0003-Do-not-assume-that-linux-and-gnu-libc-are-the-same-t.patch
+++ b/srcpkgs/open-vm-tools/patches/0003-Do-not-assume-that-linux-and-gnu-libc-are-the-same-t.patch
@@ -1,0 +1,35 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+From 45ddb2ef1fe2e075831aae3ac37d6bde00260826 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Tue, 17 Nov 2015 10:39:01 +0000
+Subject: [PATCH 03/12] Do not assume that linux and gnu libc are the same
+ thing
+
+Use __GLIBC__ when testing for GNU libc specific things instead of
+assuming that __linux__ is GNU libc.
+
+This is needed for building with musl libc.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ open-vm-tools/lib/file/fileIOPosix.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/open-vm-tools/lib/file/fileIOPosix.c b/open-vm-tools/lib/file/fileIOPosix.c
+index 23108279..603ea28d 100644
+--- open-vm-tools/lib/file/fileIOPosix.c
++++ open-vm-tools/lib/file/fileIOPosix.c
+@@ -198,7 +198,7 @@ static AlignedPool alignedPool;
+  * are not available in any header file.
+  */
+ 
+-#if defined(__linux__) && !defined(__ANDROID__)
++#if defined(__linux__) && defined(__GLIBC__)
+    #if defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+       /*
+        * We want preadv/pwritev. But due to FOB=64, the symbols are -64.
+-- 
+2.19.1
+

--- a/srcpkgs/open-vm-tools/patches/0004-Use-configure-test-for-struct-timespec.patch
+++ b/srcpkgs/open-vm-tools/patches/0004-Use-configure-test-for-struct-timespec.patch
@@ -1,0 +1,51 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+From a7a78d7963d9dacb79fee1433fc092d67ea0748e Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 18 Nov 2015 09:03:00 +0000
+Subject: [PATCH 04/12] Use configure test for struct timespec
+
+Use the configure script to test for struct time spec instead of trying
+to keep track of what platforms has it.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ open-vm-tools/configure.ac           | 1 +
+ open-vm-tools/lib/include/hgfsUtil.h | 8 +-------
+ 2 files changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/open-vm-tools/configure.ac b/open-vm-tools/configure.ac
+index 367e4ff8..5dc0be2b 100644
+--- open-vm-tools/configure.ac
++++ open-vm-tools/configure.ac
+@@ -1208,6 +1208,7 @@ AC_TYPE_OFF_T
+ AC_TYPE_PID_T
+ AC_TYPE_SIZE_T
+ AC_CHECK_MEMBERS([struct stat.st_rdev])
++AC_CHECK_MEMBERS([struct timespec.tv_sec],[],[],[[#include <time.h>]])
+ AC_HEADER_TIME
+ AC_STRUCT_TM
+ AC_C_VOLATILE
+diff --git a/open-vm-tools/lib/include/hgfsUtil.h b/open-vm-tools/lib/include/hgfsUtil.h
+index 609f4c00..a3a022d4 100644
+--- open-vm-tools/lib/include/hgfsUtil.h
++++ open-vm-tools/lib/include/hgfsUtil.h
+@@ -53,13 +53,7 @@
+ #      include <time.h>
+ #   endif
+ #   include "vm_basic_types.h"
+-#   if !defined _STRUCT_TIMESPEC &&   \
+-       !defined _TIMESPEC_DECLARED && \
+-       !defined __timespec_defined && \
+-       !defined sun && \
+-       !defined __FreeBSD__ && \
+-       !__APPLE__ && \
+-       !defined _WIN32
++#   if !defined HAVE_STRUCT_TIMESPEC_TV_SEC
+ struct timespec {
+    time_t tv_sec;
+    long   tv_nsec;
+-- 
+2.19.1
+

--- a/srcpkgs/open-vm-tools/patches/0005-Fix-definition-of-ALLPERMS-and-ACCESSPERMS.patch
+++ b/srcpkgs/open-vm-tools/patches/0005-Fix-definition-of-ALLPERMS-and-ACCESSPERMS.patch
@@ -1,0 +1,64 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+From 2a53206a4d3a8a32acdd4ff2230fe6395f5e097c Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 18 Nov 2015 09:10:14 +0000
+Subject: [PATCH 05/12] Fix definition of ALLPERMS and ACCESSPERMS
+
+The ALLPERMS and ACCESSPERMS defines are not specified in POSIX so
+assume it is not there instead of testing for specific implementations.
+
+This is needed for musl libc.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ open-vm-tools/lib/hgfsServer/hgfsServerLinux.c      | 8 +++++---
+ open-vm-tools/services/plugins/dndcp/dnd/dndLinux.c | 3 +--
+ 2 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/open-vm-tools/lib/hgfsServer/hgfsServerLinux.c b/open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
+index f2b7ce67..0e6351a9 100644
+--- open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
++++ open-vm-tools/lib/hgfsServer/hgfsServerLinux.c
+@@ -105,11 +105,13 @@ typedef struct DirectoryEntry {
+ #endif
+ 
+ /*
+- * ALLPERMS (mode 07777) and ACCESSPERMS (mode 0777) are not defined in the
+- * Solaris version of <sys/stat.h>.
++ * ALLPERMS (mode 07777) and ACCESSPERMS (mode 0777) are not specified in
++ * POSIX.
+  */
+-#ifdef sun
++#ifndef ACCESSPERMS
+ #   define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
++#endif
++#ifndef ALLPERMS
+ #   define ALLPERMS (S_ISUID|S_ISGID|S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO)
+ #endif
+ 
+diff --git a/open-vm-tools/services/plugins/dndcp/dnd/dndLinux.c b/open-vm-tools/services/plugins/dndcp/dnd/dndLinux.c
+index 89133652..7e9c3a91 100644
+--- open-vm-tools/services/plugins/dndcp/dnd/dndLinux.c
++++ open-vm-tools/services/plugins/dndcp/dnd/dndLinux.c
+@@ -52,7 +52,7 @@
+ 
+ #define DND_ROOTDIR_PERMS     (S_IRWXU | S_IRWXG | S_IRWXO)
+ #define DND_STAGINGDIR_PERMS  (S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH)
+-#ifdef sun
++#ifndef ACCESSPERMS
+ #define ACCESSPERMS           (S_IRWXU | S_IRWXG | S_IRWXO)
+ #endif
+ #ifdef __ANDROID__
+@@ -61,7 +61,6 @@
+  */
+ #define NO_SETMNTENT
+ #define NO_ENDMNTENT
+-#define ACCESSPERMS           (S_IRWXU | S_IRWXG | S_IRWXO)
+ #endif
+ 
+ 
+-- 
+2.19.1
+

--- a/srcpkgs/open-vm-tools/patches/0006-Use-configure-to-test-for-feature-instead-of-platfor.patch
+++ b/srcpkgs/open-vm-tools/patches/0006-Use-configure-to-test-for-feature-instead-of-platfor.patch
@@ -1,0 +1,150 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+#adapted to match new open-vm-tools
+
+From 34a441d0a5de1d12e0710a66874ab3fe5112ec18 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 18 Nov 2015 10:05:07 +0000
+Subject: [PATCH 06/12] Use configure to test for feature instead of platform
+
+Test for various functions instead of trying to keep track of what
+platform and what version of the given platform has support for what.
+
+This should make it easier to port to currently unknown platforms and
+will solve the issue if a platform add support for a missing feature in
+the future.
+
+The features we test for are:
+- getifaddrs
+- getauxval
+- issetugid
+- __secure_getenv
+
+This is needed for musl libc.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ open-vm-tools/configure.ac               |  4 ++++
+ open-vm-tools/lib/misc/idLinux.c         | 30 +++++++++++-------------
+ open-vm-tools/lib/nicInfo/nicInfoPosix.c | 11 +++++----
+ 3 files changed, 24 insertions(+), 21 deletions(-)
+
+diff --git a/open-vm-tools/configure.ac b/open-vm-tools/configure.ac
+index 9aa95abb..941195c1 100644
+--- open-vm-tools/configure.ac
++++ open-vm-tools/configure.ac
+@@ -879,6 +879,7 @@ AC_CHECK_FUNCS(
+ 
+ AC_CHECK_FUNCS([ecvt])
+ AC_CHECK_FUNCS([fcvt])
++AC_CHECK_FUNCS([getifaddrs getauxval issetugid __secure_getenv])
+ 
+ AC_CHECK_FUNC([mkdtemp], [have_mkdtemp=yes])
+ 
+@@ -1088,9 +1089,12 @@ fi
+ ###
+ 
+ AC_CHECK_HEADERS([crypt.h])
++AC_CHECK_HEADERS([ifaddrs.h])
+ AC_CHECK_HEADERS([inttypes.h])
+ AC_CHECK_HEADERS([stdint.h])
+ AC_CHECK_HEADERS([stdlib.h])
++AC_CHECK_HEADERS([net/if.h])
++AC_CHECK_HEADERS([sys/auxv.h])
+ AC_CHECK_HEADERS([wchar.h])
+ AC_CHECK_HEADERS([sys/inttypes.h])
+ AC_CHECK_HEADERS([sys/io.h])
+diff --git a/open-vm-tools/lib/misc/idLinux.c b/open-vm-tools/lib/misc/idLinux.c
+index 1bb86f48..2116f2aa 100644
+--- open-vm-tools/lib/misc/idLinux.c
++++ open-vm-tools/lib/misc/idLinux.c
+@@ -27,12 +27,9 @@
+ #include <sys/syscall.h>
+ #include <string.h>
+ #include <unistd.h>
+-#ifdef __linux__
+-#if defined(__GLIBC__) && \
+-           (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 16))
++#ifdef HAVE_SYS_AUXV_H
+ #include <sys/auxv.h>
+ #endif
+-#endif
+ #ifdef __APPLE__
+ #include <sys/socket.h>
+ #include <TargetConditionals.h>
+@@ -1025,31 +1022,32 @@ Id_EndSuperUser(uid_t uid)  // IN:
+ static Bool
+ IdIsSetUGid(void)
+ {
+-#if defined(__ANDROID__)
+-   /* Android does not have a secure_getenv, so be conservative. */
+-   return TRUE;
+-#else
+    /*
+     * We use __secure_getenv, which returns NULL if the binary is
+-    * setuid or setgid. Alternatives include,
++    * setuid or setgid, when issetugid or getauxval(AT_SECURE) is not
++    * available. Alternatives include,
+     *
+-    *   a) getauxval(AT_SECURE); not available until glibc 2.16.
+-    *   b) __libc_enable_secure; may not be exported.
++    *   a) issetugid(); not (yet?) available in glibc.
++    *   b) getauxval(AT_SECURE); not available until glibc 2.16.
++    *   c) __libc_enable_secure; may not be exported.
+     *
+-    * Use (a) when we are based on glibc 2.16, or newer.
++    * Use (b) when we are based on glibc 2.16, or newer.
+     */
+ 
+-#if defined(__GLIBC__) && \
+-           (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 16))
++#if HAVE_ISSETUGID
++   return issetugid();
++#elif HAVE_GETAUXVAL
+    return getauxval(AT_SECURE) != 0;
+-#else
++#elif HAVE___SECURE_GETENV
+    static const char envName[] = "VMW_SETUGID_TEST";
+ 
+    if (setenv(envName, "1", TRUE) == -1) {
+       return TRUE; /* Conservative */
+    }
+    return __secure_getenv(envName) == NULL;
+-#endif
++#else
++   /* Android does not have a secure_getenv, so be conservative. */
++   return TRUE;
+ #endif
+ }
+ #endif
+diff --git a/open-vm-tools/lib/nicInfo/nicInfoPosix.c b/open-vm-tools/lib/nicInfo/nicInfoPosix.c
+index 3363f3ac..b343196b 100644
+--- open-vm-tools/lib/nicInfo/nicInfoPosix.c
++++ open-vm-tools/lib/nicInfo/nicInfoPosix.c
+@@ -35,9 +35,13 @@
+ #include <sys/stat.h>
+ #include <errno.h>
+ #include <limits.h>
+-#if defined(__FreeBSD__) || defined(__APPLE__)
++#if HAVE_SYS_SYSCTL_H
+ # include <sys/sysctl.h>
++#endif
++#if HAVE_IFADDRS_H
+ # include <ifaddrs.h>
++#endif
++#if HAVE_NET_IF_H
+ # include <net/if.h>
+ #endif
+ #ifndef NO_DNET
+@@ -494,10 +498,7 @@ GuestInfoGetNicInfo(unsigned int maxIPv4Routes,
+  *
+  ******************************************************************************
+  */
+-#if defined(__FreeBSD__) || \
+-    defined(__APPLE__) || \
+-    defined(USERWORLD) || \
+-    (defined(__linux__) && defined(NO_DNET))
++#if defined(NO_DNET) && defined(HAVE_GETIFADDRS)
+ 
+ char *
+ GuestInfoGetPrimaryIP(void)

--- a/srcpkgs/open-vm-tools/patches/0007-Use-configure-test-for-sys-stat.h-include.patch
+++ b/srcpkgs/open-vm-tools/patches/0007-Use-configure-test-for-sys-stat.h-include.patch
@@ -1,0 +1,31 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+From 114dede05e89a810021edc0ef75c0abb3310ad8f Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Wed, 18 Nov 2015 10:41:01 +0000
+Subject: [PATCH 07/12] Use configure test for sys/stat.h include
+
+This is needed for musl libc.
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+---
+ open-vm-tools/services/plugins/vix/vixTools.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/open-vm-tools/services/plugins/vix/vixTools.c b/open-vm-tools/services/plugins/vix/vixTools.c
+index e5273786..cabc4137 100644
+--- open-vm-tools/services/plugins/vix/vixTools.c
++++ open-vm-tools/services/plugins/vix/vixTools.c
+@@ -66,7 +66,7 @@
+ #include <unistd.h>
+ #endif
+ 
+-#if defined(sun) || defined(__FreeBSD__) || defined(__APPLE__)
++#ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
+ 
+-- 
+2.19.1
+

--- a/srcpkgs/open-vm-tools/patches/0010-use-posix-strerror_r-unless-gnu.patch
+++ b/srcpkgs/open-vm-tools/patches/0010-use-posix-strerror_r-unless-gnu.patch
@@ -1,0 +1,36 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+From 5dd2dbabd4c0535c44321c6c2303acff093c18c7 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Mon, 2 Jan 2017 14:39:27 +0000
+Subject: [PATCH 10/12] use posix strerror_r unless gnu
+
+---
+ open-vm-tools/lib/err/errPosix.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/open-vm-tools/lib/err/errPosix.c b/open-vm-tools/lib/err/errPosix.c
+index c81b4c13..a34e8190 100644
+--- open-vm-tools/lib/err/errPosix.c
++++ open-vm-tools/lib/err/errPosix.c
+@@ -63,11 +63,13 @@ ErrErrno2String(Err_Number errorNumber, // IN
+ {
+    char *p;
+ 
+-#if defined(__linux__) && !defined(__ANDROID__)
++#if defined(__GLIBC__)
+    p = strerror_r(errorNumber, buf, bufSize);
+ #else
+-   p = strerror(errorNumber);
+-#endif
++   if (strerror_r(errorNumber, buf, bufSize) != 0)
++      snprintf(buf, bufSize, "unknown error %i", errorNumber);
++   p = buf;
++#endif /* defined __GLIBC__ */
+    ASSERT(p != NULL);
+    return p;
+ }
+-- 
+2.19.1
+

--- a/srcpkgs/open-vm-tools/patches/0011-use-off64_t-instead-of-loff_t.patch
+++ b/srcpkgs/open-vm-tools/patches/0011-use-off64_t-instead-of-loff_t.patch
@@ -1,0 +1,113 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+From 099ef837922ee97c64651bc49c26022b7a97f816 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Mon, 2 Jan 2017 15:25:32 +0000
+Subject: [PATCH 11/12] use off64_t instead of loff_t
+
+---
+ open-vm-tools/vmhgfs-fuse/file.c   | 12 ++++++------
+ open-vm-tools/vmhgfs-fuse/fsutil.c |  2 +-
+ open-vm-tools/vmhgfs-fuse/fsutil.h |  8 ++------
+ 3 files changed, 9 insertions(+), 13 deletions(-)
+
+diff --git a/open-vm-tools/vmhgfs-fuse/file.c b/open-vm-tools/vmhgfs-fuse/file.c
+index 389ebba8..d22b66df 100644
+--- open-vm-tools/vmhgfs-fuse/file.c
++++ open-vm-tools/vmhgfs-fuse/file.c
+@@ -535,7 +535,7 @@ static int
+ HgfsDoRead(HgfsHandle handle,  // IN:  Handle for this file
+            char *buf,          // OUT: Buffer to copy data into
+            size_t count,       // IN:  Number of bytes to read
+-           loff_t offset)      // IN:  Offset at which to read
++           off64_t offset)      // IN:  Offset at which to read
+ {
+    HgfsReq *req;
+    HgfsOp opUsed;
+@@ -668,11 +668,11 @@ ssize_t
+ HgfsRead(struct fuse_file_info *fi,  // IN:  File info struct
+          char  *buf,                 // OUT: User buffer to copy data into
+          size_t count,               // IN:  Number of bytes to read
+-         loff_t offset)              // IN:  Offset at which to read
++         off64_t offset)              // IN:  Offset at which to read
+ {
+    int result = 0;
+    char *buffer = buf;
+-   loff_t curOffset = offset;
++   off64_t curOffset = offset;
+    size_t nextCount, remainingCount = count;
+ 
+    ASSERT(NULL != fi);
+@@ -729,7 +729,7 @@ static int
+ HgfsDoWrite(HgfsHandle handle,       // IN: Handle for the file
+             const char *buf,         // IN: Buffer containing data
+             size_t count,            // IN: Number of bytes to write
+-            loff_t offset)           // IN: Offset to begin writing at
++            off64_t offset)           // IN: Offset to begin writing at
+ {
+    HgfsReq *req;
+    int result = 0;
+@@ -853,11 +853,11 @@ ssize_t
+ HgfsWrite(struct fuse_file_info *fi,  // IN: File info structure
+          const char  *buf,            // OUT: User buffer to copy data into
+          size_t count,                // IN:  Number of bytes to read
+-         loff_t offset)               // IN:  Offset at which to read
++         off64_t offset)               // IN:  Offset at which to read
+ {
+    int result;
+    const char *buffer = buf;
+-   loff_t curOffset = offset;
++   off64_t curOffset = offset;
+    size_t nextCount, remainingCount = count;
+    ssize_t bytesWritten = 0;
+ 
+diff --git a/open-vm-tools/vmhgfs-fuse/fsutil.c b/open-vm-tools/vmhgfs-fuse/fsutil.c
+index 042c223c..c3d581d3 100644
+--- open-vm-tools/vmhgfs-fuse/fsutil.c
++++ open-vm-tools/vmhgfs-fuse/fsutil.c
+@@ -680,7 +680,7 @@ HgfsStatusConvertToLinux(HgfsStatus hgfsStatus) // IN: Status code to convert
+ unsigned long
+ HgfsCalcBlockSize(uint64 tsize)
+ {
+-   loff_t used = (tsize + 511) >> 9;
++   off64_t used = (tsize + 511) >> 9;
+    return (used > ULONG_MAX) ? ULONG_MAX : used;
+ }
+ 
+diff --git a/open-vm-tools/vmhgfs-fuse/fsutil.h b/open-vm-tools/vmhgfs-fuse/fsutil.h
+index 34b6d489..a75cff82 100644
+--- open-vm-tools/vmhgfs-fuse/fsutil.h
++++ open-vm-tools/vmhgfs-fuse/fsutil.h
+@@ -32,10 +32,6 @@
+ #include "hgfsProto.h"
+ #include <fuse.h>
+ 
+-#if defined(__FreeBSD__) || defined(__SOLARIS__) || defined(__APPLE__)
+-typedef long long loff_t;
+-#endif
+-
+ /*
+  * Struct used to pass around attributes.
+  * These aren't just the attributes seen in HgfsAttr[V2]; we add a filename
+@@ -73,7 +69,7 @@ ssize_t
+ HgfsWrite(struct fuse_file_info *fi,
+           const char  *buf,
+           size_t count,
+-          loff_t offset);
++          off64_t offset);
+ 
+ int
+ HgfsRename(const char* from, const char* to);
+@@ -93,7 +89,7 @@ ssize_t
+ HgfsRead(struct fuse_file_info *fi,
+          char  *buf,
+          size_t count,
+-         loff_t offset);
++         off64_t offset);
+ 
+ int
+ HgfsSetattr(const char* path,
+-- 
+2.19.1
+

--- a/srcpkgs/open-vm-tools/patches/1000-strerror_r.patch
+++ b/srcpkgs/open-vm-tools/patches/1000-strerror_r.patch
@@ -1,0 +1,16 @@
+#src: https://git.alpinelinux.org/aports/tree/community/open-vm-tools?id=6e0f65e51bfcd02c53bc2b78f46ed18af2dd7ea0
+#upstream: no
+
+diff --git a/open-vm-tools/vgauth/common/VGAuthLog.c b/open-vm-tools/vgauth/common/VGAuthLog.c
+index fb4261e..1b29536 100644
+--- open-vm-tools/vgauth/common/VGAuthLog.c
++++ open-vm-tools/vgauth/common/VGAuthLog.c
+@@ -210,7 +210,7 @@ LogErrorPosixCodeV(int code,
+    g_vsnprintf(buf, sizeof buf, fmt, args);
+    buf[sizeof buf - 1] = '\0';
+ 
+-#ifdef sun
++#if !defined(__GLIBC__)
+    strerror_r(code, errMsg, sizeof errMsg);
+    g_warning("[function %s, file %s, line %d], %s, [errno = %d], %s\n",
+              func, file, line, buf, code, errMsg);

--- a/srcpkgs/open-vm-tools/patches/1001-pr383-rename-poll-vm_poll.patch
+++ b/srcpkgs/open-vm-tools/patches/1001-pr383-rename-poll-vm_poll.patch
@@ -1,0 +1,127 @@
+#src: https://github.com/vmware/open-vm-tools/pull/383.patch
+#upstream: maybe soon
+
+From 821c7949d79ad8e06b20cb1238316fce56778607 Mon Sep 17 00:00:00 2001
+From: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+Date: Thu, 31 Oct 2019 17:06:10 +0100
+Subject: [PATCH] Rename poll.h into vm_poll.h to fix build failure on musl
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+musl libc redirects include of sys/poll.h to poll.h. But since poll.h is
+also a local header file, the musl libc header is never included. This
+leads to the following build failure:
+
+In file included from asyncsocket.c:73:0:
+.../host/i586-buildroot-linux-musl/sysroot/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
+ #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
+asyncsocket.c: In function ‘AsyncTCPSocketPollWork’:
+asyncsocket.c:2537:13: error: invalid use of undefined type ‘struct pollfd’
+          pfd[i].fd = asock[i]->fd;
+             ^
+asyncsocket.c:2537:13: error: dereferencing pointer to incomplete type ‘struct pollfd’
+asyncsocket.c:2538:13: error: invalid use of undefined type ‘struct pollfd’
+          pfd[i].events = read ? POLLIN : POLLOUT;
+             ^
+asyncsocket.c:2538:33: error: ‘POLLIN’ undeclared (first use in this function); did you mean ‘POLL_IN’?
+          pfd[i].events = read ? POLLIN : POLLOUT;
+
+So rename poll.h into vm_poll.h as suggested by srowe in
+https://github.com/vmware/open-vm-tools/issues/359#issuecomment-533529956
+
+Fixes:
+ - http://autobuild.buildroot.org/results/4f575ef42bbc4387a07e396205052b2da081c64d
+
+Fix #359
+
+Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
+---
+ open-vm-tools/lib/asyncsocket/asyncsocket.c     | 4 ++--
+ open-vm-tools/lib/hgfsServer/hgfsServer.c       | 2 +-
+ open-vm-tools/lib/include/asyncsocket.h         | 2 +-
+ open-vm-tools/lib/include/pollImpl.h            | 2 +-
+ open-vm-tools/lib/include/{poll.h => vm_poll.h} | 0
+ open-vm-tools/lib/rpcIn/rpcin.c                 | 2 +-
+ 6 files changed, 6 insertions(+), 6 deletions(-)
+ rename open-vm-tools/lib/include/{poll.h => vm_poll.h} (100%)
+
+diff --git lib/asyncsocket/asyncsocket.c lib/asyncsocket/asyncsocket.c
+index 102638cc9..01181a957 100644
+--- open-vm-tools/lib/asyncsocket/asyncsocket.c
++++ open-vm-tools/lib/asyncsocket/asyncsocket.c
+@@ -69,8 +69,8 @@
+ #else
+ #include <stddef.h>
+ #include <ctype.h>
++#include <poll.h>
+ #include <sys/types.h>
+-#include <sys/poll.h>
+ #include <sys/socket.h>
+ #include <sys/un.h>
+ #include <netdb.h>
+@@ -86,7 +86,7 @@
+ #include "random.h"
+ #include "asyncsocket.h"
+ #include "asyncSocketBase.h"
+-#include "poll.h"
++#include "vm_poll.h"
+ #include "log.h"
+ #include "err.h"
+ #include "hostinfo.h"
+diff --git lib/hgfsServer/hgfsServer.c lib/hgfsServer/hgfsServer.c
+index 462245511..fc6912860 100644
+--- open-vm-tools/lib/hgfsServer/hgfsServer.c
++++ open-vm-tools/lib/hgfsServer/hgfsServer.c
+@@ -48,7 +48,7 @@
+ #include "hgfsServerOplock.h"
+ #include "hgfsDirNotify.h"
+ #include "userlock.h"
+-#include "poll.h"
++#include "vm_poll.h"
+ #include "mutexRankLib.h"
+ #include "vm_basic_asm.h"
+ #include "unicodeOperations.h"
+diff --git lib/include/asyncsocket.h lib/include/asyncsocket.h
+index 95a5e4643..a4b4e5aae 100644
+--- open-vm-tools/lib/include/asyncsocket.h
++++ open-vm-tools/lib/include/asyncsocket.h
+@@ -164,7 +164,7 @@ typedef struct AsyncSocket AsyncSocket;
+  * Or the client can specify its favorite poll class and locking behavior.
+  * Use of IVmdbPoll is only supported for regular sockets and for Attach.
+  */
+-#include "poll.h"
++#include "vm_poll.h"
+ struct IVmdbPoll;
+ typedef struct AsyncSocketPollParams {
+    int flags;               /* Default 0, only POLL_FLAG_NO_BULL is valid */
+diff --git lib/include/pollImpl.h lib/include/pollImpl.h
+index 46442e556..8bc669970 100644
+--- open-vm-tools/lib/include/pollImpl.h
++++ open-vm-tools/lib/include/pollImpl.h
+@@ -44,7 +44,7 @@
+ #define INCLUDE_ALLOW_USERLEVEL
+ #include "includeCheck.h"
+ 
+-#include "poll.h"
++#include "vm_poll.h"
+ #include "vm_basic_asm.h"
+ 
+ #if defined(__cplusplus)
+diff --git open-vm-tools/lib/include/poll.h open-vm-tools/lib/include/vm_poll.h
+similarity index 100%
+rename from open-vm-tools/lib/include/poll.h
+rename to open-vm-tools/lib/include/vm_poll.h
+diff --git lib/rpcIn/rpcin.c lib/rpcIn/rpcin.c
+index 47a3380e4..660382c62 100644
+--- open-vm-tools/lib/rpcIn/rpcin.c
++++ open-vm-tools/lib/rpcIn/rpcin.c
+@@ -57,7 +57,7 @@
+ 
+ #if defined(VMTOOLS_USE_VSOCKET)
+ #  include <glib.h>
+-#  include "poll.h"
++#  include "vm_poll.h"
+ #  include "asyncsocket.h"
+ #  include "vmci_defs.h"
+ #include "dataMap.h"

--- a/srcpkgs/open-vm-tools/patches/1002-Fix-subdir-objects-configure-error.patch
+++ b/srcpkgs/open-vm-tools/patches/1002-Fix-subdir-objects-configure-error.patch
@@ -1,0 +1,27 @@
+#src: http://cgit.openembedded.org/meta-openembedded/tree/meta-oe/recipes-support/open-vm-tools/open-vm-tools?id=6642ae94227f7c3c91c1a58f00f99aeb9eb2393f
+#upstream: no
+
+From cf1284fda8fb22a2b27cb2ce7962f166166e74c3 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 13 Jun 2018 23:48:04 -0700
+Subject: [PATCH] Fix subdir objects configure error
+
+Fix build on musl while here
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ open-vm-tools/configure.ac | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/open-vm-tools/configure.ac b/open-vm-tools/configure.ac
+index 71e684bb..b76a7966 100644
+--- open-vm-tools/configure.ac
++++ open-vm-tools/configure.ac
+@@ -303,6 +303,7 @@ AC_ARG_ENABLE(
+    [],
+    [enable_resolutionkms="auto"])
+ 
++AM_INIT_AUTOMAKE([subdir-objects])
+ AM_INIT_AUTOMAKE
+ 
+ ###

--- a/srcpkgs/open-vm-tools/patches/2001-res_ninit-for-musl.patch
+++ b/srcpkgs/open-vm-tools/patches/2001-res_ninit-for-musl.patch
@@ -1,0 +1,39 @@
+#upstream: no
+--- open-vm-tools/lib/nicInfo/nicInfoPosix.c
++++ open-vm-tools/lib/nicInfo/nicInfoPosix.c
+@@ -66,6 +66,35 @@
+ #   include <net/if.h>
+ #endif
+ 
++
++#if !defined(__GLIBC__)
++/***************************************************************************
++ * Mimick GLIBC's res_ninit() and res_nclose() for musl libc
++ * Note: res_init() is actually deprecated according to
++ * http://docs.oracle.com/cd/E36784_01/html/E36875/res-nclose-3resolv.html
++ **************************************************************************/
++#include <string.h>
++
++static inline int res_ninit(res_state statp)
++{
++	int rc = res_init();
++	if (statp != &_res) {
++		memcpy(statp, &_res, sizeof(*statp));
++	}
++	return rc;
++}
++
++static inline int res_nclose(res_state statp)
++{
++	if (!statp)
++		return -1;
++	if (statp != &_res) {
++		memset(statp, 0, sizeof(*statp));
++	}
++	return 0;
++}
++#endif
++
+ /*
+  * resolver(3) and IPv6:
+  *

--- a/srcpkgs/open-vm-tools/template
+++ b/srcpkgs/open-vm-tools/template
@@ -1,28 +1,32 @@
 # Template file for 'open-vm-tools'
 pkgname=open-vm-tools
-version=11.0.1
+version=11.0.5
 revision=1
-_build=14773994
-archs="x86_64 i686"
-wrksrc="open-vm-tools-${version}-${_build}"
+archs="x86_64* i686*"
+wrksrc="open-vm-tools-stable-${version}"
+build_wrksrc="open-vm-tools"
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --with-udev-rules-dir=/usr/lib/udev/rules.d
  --without-xmlsecurity --without-kernel-modules
  $(vopt_with x11 x) $(vopt_with pam)"
-hostmakedepends="automake libtool pkg-config glib-devel"
-makedepends="fuse-devel glib-devel icu-devel libdnet-devel libmspack-devel
- libressl-devel libxerces-c-devel procps-ng-devel $(vopt_if pam 'pam-devel')
+hostmakedepends="automake autoconf libtool pkg-config glib-devel rpcgen"
+makedepends="fuse-devel glib-devel libmspack-devel libressl-devel libtirpc-devel
+ libxerces-c-devel procps-ng-devel $(vopt_if pam 'pam-devel')
  $(vopt_if x11 'gtkmm-devel libXtst-devel xmlsec1-devel')"
 short_desc="Open source implementation of VMware Tools"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-2.0-only, LGPL-2.1-only"
 homepage="https://github.com/vmware/open-vm-tools"
 changelog="https://github.com/vmware/open-vm-tools/blob/master/open-vm-tools/ChangeLog"
-distfiles="https://github.com/vmware/open-vm-tools/releases/download/stable-${version}/open-vm-tools-${version}-${_build}.tar.gz"
-checksum=8a707df98b6eb40195d7deaf09def5ef03c19c83ca418f8bf23c18405ebf2981
+distfiles="https://github.com/vmware/open-vm-tools/archive/stable-${version}.tar.gz"
+checksum=f4300d8ccf665a3ff435476bc372a3f189a98c2b830730608d4286226802bd97
 
 build_options="pam x11"
 build_options_default="pam x11"
+
+case "$XBPS_TARGET_MACHINE" in
+	*-musl) configure_args+=" --disable-glibc-check" ;; #yeah...
+esac
 
 pre_configure() {
 	autoreconf -vfi
@@ -33,7 +37,7 @@ post_install() {
 	rm ${DESTDIR}/sbin/mount.vmhgfs
 	rm -r ${DESTDIR}/sbin
 	# If X11 enabled, copy extra files
-	if [ $build_option_x11 ]; then
+	if [ "$build_option_x11" ]; then
 		vmkdir /etc/xdg/autostart
 		vinstall vmware-user-suid-wrapper/vmware-user.desktop 0644 /etc/xdg/autostart/
 		vbin scripts/common/vmware-xdg-detect-de


### PR DESCRIPTION
* build for musl as well / most patches are borrowed from alpine
* resolver compat copied from `srcpkgs/qt5/files/resolv_compat.h`
* build from sources instead of "build"-tarball
* drop dependencies `libdnet` and `icu`, as upstream disabled them for
linux builds (9f52cd, fcb7bb7)

tested on
* x86_64: works
* x86_64-musl: _not tested yet_
* i686: _not tested yet_