### PR TITLE
android-studio: add tar as a makedepends

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -8,6 +8,7 @@ _studio_build=191.6010548
 _studio_rev=0
 archs="x86_64 i686"
 create_wrksrc=yes
+hostmakedepends="tar"
 depends="gtk+ libGL"
 short_desc="Official Android IDE"
 maintainer="Jordyn Carattini <onlinecloud1@gmail.com>"


### PR DESCRIPTION
android-studio was updated to 3.5.3 in void-packages 2 months ago ( #17265). Although this change was merged and travis checks passed, when I ran `xbps-install -S android-studio`, I got version 3.3.2_1. When I tried to build 3.5.3 from void-packages using `./xbps-src pkg android-studio`, I found that tar was missing.

Adding tar as a makedepends fixes this issue.