### PR TITLE
snapcast: add logging

### DIFF
--- a/srcpkgs/snapcast/files/snapclient/log/run
+++ b/srcpkgs/snapcast/files/snapclient/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -t snapclient

--- a/srcpkgs/snapcast/files/snapclient/run
+++ b/srcpkgs/snapcast/files/snapclient/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-exec chpst -u _snapclient:audio snapclient ${OPTS}
+exec chpst -u _snapclient:audio snapclient ${OPTS} 2>&1

--- a/srcpkgs/snapcast/files/snapserver/log/run
+++ b/srcpkgs/snapcast/files/snapserver/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -t snapserver

--- a/srcpkgs/snapcast/files/snapserver/run
+++ b/srcpkgs/snapcast/files/snapserver/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-exec chpst -u _snapserver snapserver ${OPTS}
+exec chpst -u _snapserver snapserver ${OPTS} 2>&1

--- a/srcpkgs/snapcast/template
+++ b/srcpkgs/snapcast/template
@@ -1,7 +1,7 @@
 # Template file for 'snapcast'
 pkgname=snapcast
 version=0.18.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_WITH_TREMOR=OFF -DBUILD_WITH_AVAHI=$(vopt_if avahi ON OFF)"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
This pull request adds service logging to stop snapclient and snapserver from flooding tty1 with connection and stream messages.