### PR TITLE
elogind: update to 243.4.

### DIFF
--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -6,7 +6,7 @@ build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
  -Drootlibexecdir=/usr/libexec/elogind -Dreboot-path=/usr/bin/reboot
  -Dkexec-path=/usr/bin/kexec -Ddefault-hierarchy=legacy
- -Ddefault-kill-user-processes=false"
+ -Ddefault-kill-user-processes=false -Dman=true"
 hostmakedepends="docbook-xsl gettext-devel git gperf intltool libxslt m4
  pkg-config shadow glib-devel"
 makedepends="acl-devel eudev-libudev-devel gettext-devel libglib-devel libcap-devel

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,6 +1,6 @@
 # Template file for 'elogind'
 pkgname=elogind
-version=241.4
+version=243.4
 revision=1
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
@@ -17,8 +17,8 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://github.com/elogind/elogind"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=fb4d0f931d5fb11af5a4426b0198e85fabc83d604ee24427b26480164cddb7e1
-conf_files="/etc/elogind/logind.conf"
+checksum=f1098745863138e6270ea22e78a39baef9a0356b48246c5a53b34211992dc7db
+conf_files="/etc/elogind/*.conf"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	configure_args+=" -Dutmp=false"


### PR DESCRIPTION
Ok:                  177
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               3
Timeout:               0

Same output on glibc and musl.