### PR TITLE
re-enable pam authentication in opensmtpd

### DIFF
--- a/srcpkgs/opensmtpd/template
+++ b/srcpkgs/opensmtpd/template
@@ -8,6 +8,7 @@ configure_args="--sysconfdir=/etc/smtpd --sbindir=/usr/bin
  --with-mantype=doc --with-pie --with-table-db
  --with-path-CAfile=/etc/ssl/certs/ca-certificates.crt
  --with-maildir=/var/mail
+ --with-auth-pam=smtpd
  ac_cv_func_arc4random=yes
  ac_cv_func_arc4random_buf=yes
  ac_cv_func_arc4random_stir=no
@@ -18,7 +19,7 @@ configure_args="--sysconfdir=/etc/smtpd --sbindir=/usr/bin
  ac_cv_func_strlcat=no
  ac_cv_func_strlcpy=no"
 hostmakedepends="automake libtool pkg-config bison"
-makedepends="zlib-devel libressl-devel libevent-devel db-devel libasr-devel"
+makedepends="zlib-devel libressl-devel libevent-devel db-devel libasr-devel pam-devel"
 depends="ca-certificates"
 conf_files="/etc/smtpd/smtpd.conf /etc/smtpd/aliases"
 short_desc="Free implementation of the server-side SMTP protocol"


### PR DESCRIPTION
opensmtpd no longer enables pam auth by default (despite the ./configure script claiming so). This is quite the useful feature, so I'd love to see it enabled.