### PR TITLE
lumina: update to 1.6.0

### DIFF
--- a/srcpkgs/lumina/template
+++ b/srcpkgs/lumina/template
@@ -1,6 +1,6 @@
 # Template file for 'lumina'
 pkgname=lumina
-version=1.5.0
+version=1.6.0
 revision=1
 build_style=qmake
 configure_args="QT5LIBDIR=/usr/lib/qt5 L_ETCDIR=/etc"
@@ -8,13 +8,13 @@ hostmakedepends="qt5-host-tools"
 makedepends="qt5-devel qt5-x11extras-devel qt5-multimedia-devel qt5-svg-devel
  qt5-declarative-devel libXrender-devel libXcomposite-devel libXcursor-devel libXdamage-devel
  xcb-util-devel xcb-util-wm-devel xcb-util-image-devel pulseaudio-devel poppler-qt5-devel"
-depends="fluxbox numlockx xbacklight alsa-utils acpi xscreensaver oxygen-icons5"
+depends="fluxbox numlockx xbacklight alsa-utils acpi xscreensaver bsdtar qt5-svg qsudo"
 short_desc="Lumina Desktop Environment"
 maintainer="hipperson0 <hipperson0@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/lumina-desktop/lumina"
 distfiles="https://github.com/lumina-desktop/lumina/archive/v${version}.tar.gz"
-checksum=3dcf9844ba5ba912a1b4618a0f50e0170d8dc354c178b2c3b50f8a8e6b85400f
+checksum=f3512fca4d05e3cf3a6ac106f0f16c9618bda9fa546f1d23ffb0eab9a5ce7c8a
 replaces="lumina-git>=0"
 
 if [ -n "$CROSS_BUILD" ]; then


### PR DESCRIPTION
This brings a dedicated OS-interface for VoidLinux into Lumina.
This enabled system power options, audio/brightness controls, and more.
Also fixes a couple missing runtime dependencies (bsdtar for lumina-archiver, qt5-svg for icon support, and qsudo for the new power integrations).

Sponsored by: Project Trident