### PR TITLE
gitea: fix INSTALL script

### DIFF
--- a/srcpkgs/gitea/INSTALL
+++ b/srcpkgs/gitea/INSTALL
@@ -1,13 +1,5 @@
-case "$ACTION" in
-	post)
-		if [ "$UPDATE" = "yes" ] ; then
-			:
-		else
-			# This sets the secret key which would otherwise be
-			# distributed as a static packaged value
-			secret="$(tr -dc '[:alnum:]' < /dev/urandom | head -c32)"
-			sed -i "s!<SECRET_KEY>!$secret!" etc/gitea.conf
-		fi
-		chown _gitea:_gitea etc/gitea.conf
-		;;
+case "${ACTION}" in
+post)
+	chown _gitea:_gitea etc/gitea.conf
+	;;
 esac

--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -1,7 +1,7 @@
 # Template file for 'gitea'
 pkgname=gitea
 version=1.10.6
-revision=1
+revision=2
 build_style=go
 go_import_path=code.gitea.io/gitea
 # This could be done with build options, but these are built in with the


### PR DESCRIPTION
With current INSTALL sed process reveals generated secret key; it can be viewed by monitoring /proc or by using extrace.
Also sed pattern <SECRET_KEY> fails, since there no such substring in provided sample configuration.