### PR TITLE
go: update to 1.13.7.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.13.5
+version=1.13.7
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=27d356e2a0b30d9983b60a788cf225da5f914066b37a6b4f69d457ba55a626ff
+checksum=e4ad42cc5f5c19521fbbbde3680995f2546110b5c6aa2b48c3754ff7af9b41f4
 nostrip=yes
 noverifyrdeps=yes
 

--- a/srcpkgs/go1.12-bootstrap/template
+++ b/srcpkgs/go1.12-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'go1.12-bootstrap'
 pkgname=go1.12-bootstrap
-version=1.12.14
+version=1.12.16
 revision=1
 archs="x86_64* i686* armv[67]l* aarch64* ppc64le*"
 wrksrc="go"
@@ -21,23 +21,23 @@ fi
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*)
 		_dist_arch="amd64"
-		checksum="925a1a9d8b31c2425d7313fe73d3342288968a66e26cd8bf1b6b5656f4603fcb"
+		checksum="bf3a85d75658144c06ce986ba05e07ef08af4320089b74b1d41de3b0f340ea7e"
 		;;
 	i686*)
 		_dist_arch="386"
-		checksum="76dda90b4fc0410212094b433cfdc40c9802fba972427e95cbdec3c5b94fd7a6"
+		checksum="e6ebf5622203f2ceee138af16c765818bf65b74668d5e73c1da6491c3e890a88"
 		;;
 	arm*)
 		_dist_arch="armv6l"
-		checksum="c7aa5562168b6eb3a4bb54af061d68bcb6b9ecae9d785f9a38255c107c986b73"
+		checksum="2f77688eaf25d8ae58adc5164de0fc13d600705c2ebadc6e1138e5ce9ceadc41"
 		;;
 	aarch64*)
 		_dist_arch="arm64"
-		checksum="1ab765f4cf74f05cfba40ddcea9160ca6cf9a57915036a559ca1691942862e7c"
+		checksum="a01df310bfeffc67480982cf6ad50c9b83f9aaf4ac855d5e581b95eb727bb24c"
 		;;
 	ppc64le*)
 		_dist_arch="ppc64le"
-		checksum="4e237b1357922e186337989914201e98bd9aed855f4034a5918476650484f83d"
+		checksum="7c133932d1beae68a483dbac69bb0e1023fa08196ebee100594b79c0672ce67c"
 		;;
 esac
 


### PR DESCRIPTION
Updates bootstrap package as well.

This is a security release. It addresses CVE-2020-7919 and
CVE-2020-0601.