### PR TITLE
terraform: update to 0.12.20.

### DIFF
--- a/srcpkgs/terraform/template
+++ b/srcpkgs/terraform/template
@@ -1,6 +1,6 @@
 # Template file for 'terraform'
 pkgname=terraform
-version=0.12.19
+version=0.12.20
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/$pkgname"
@@ -9,4 +9,4 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MPL-2.0"
 homepage="https://www.terraform.io/"
 distfiles="https://$go_import_path/archive/v$version.tar.gz"
-checksum=bcc7a2d074a0d22cfa8daf0a604167b61b439d2769840909a47556c5644bda4d
+checksum=05415371bee3e00642c8ec93ab3183f7f3e60f33b8d345ba25173668ca41bab1


### PR DESCRIPTION
To ensure security fixes are part of the build, this should follow #18706.