### PR TITLE
[RFC] libglvnd: depend on mesa

### DIFF
--- a/srcpkgs/libglvnd-core-devel/template
+++ b/srcpkgs/libglvnd-core-devel/template
@@ -1,0 +1,24 @@
+# Template file for 'libglvnd-core-devel'
+pkgname=libglvnd-core-devel
+version=1.3.0
+revision=1
+wrksrc="libglvnd-v${version}"
+build_style=meson
+configure_args="-Dasm=disabled -Dx11=disabled -Degl=false -Dglx=disabled
+ -Dgles1=false -Dgles2=false -Dheaders=false"
+short_desc="GL Vendor-Neutral Dispatch library - core headers for vendors"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="custom:MIT-alike"
+homepage="https://gitlab.freedesktop.org/glvnd/libglvnd"
+distfiles="https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v${version}/libglvnd-v${version}.tar.gz"
+checksum=e336ac2340105c4f21412260e5b1db17a9ce1cef27aa708a63aed293c670c1b4
+
+conflicts="libglvnd libglvnd-devel"
+
+post_install() {
+	rm ${DESTDIR}/usr/lib/lib*.so*
+	rm ${DESTDIR}/usr/lib/pkgconfig/opengl.pc
+
+	grep -A 25 "Copyright (c) 2013, NVIDIA CORPORATION." README.md > LICENSE
+	vlicense LICENSE
+}

--- a/srcpkgs/libglvnd/template
+++ b/srcpkgs/libglvnd/template
@@ -1,11 +1,13 @@
 # Template file for 'libglvnd'
+# on updates,'libglvnd-core-devel' must also be updated
 pkgname=libglvnd
 version=1.3.0
-revision=1
+revision=2
 wrksrc="libglvnd-v${version}"
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libXext-devel libX11-devel xorgproto"
+depends="mesa"
 short_desc="GL Vendor-Neutral Dispatch library"
 maintainer="Stefano Ragni <st3r4g@protonmail.com>"
 license="custom:MIT-alike"
@@ -27,7 +29,7 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_install() {
-	$XBPS_FETCH_CMD "https://git.archlinux.org/svntogit/packages.git/plain/trunk/LICENSE?h=packages/libglvnd>LICENSE"
+	grep -A 25 "Copyright (c) 2013, NVIDIA CORPORATION." README.md > LICENSE
 	vlicense LICENSE
 }
 

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=19.3.3
-revision=1
+revision=2
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
@@ -16,8 +16,8 @@ makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel
  libXxf86vm-devel libatomic-devel libdrm-devel libffi-devel libva-devel
  libvdpau-devel libxshmfence-devel ncurses-devel talloc-devel zlib-devel
  $(vopt_if wayland 'wayland-devel wayland-protocols') llvm
- libsensors-devel libXrandr-devel libglvnd-devel"
-depends="libglvnd"
+ libsensors-devel libXrandr-devel libglvnd-core-devel"
+depends="mesa-dri-${version}_${revision}"
 short_desc="Graphics library similar to SGI's OpenGL"
 maintainer="Juan RP <xtraeme@gmail.com>"
 license="MIT, LGPL-2.1-or-later"
@@ -142,6 +142,8 @@ post_install() {
 }
 
 libglapi_package() {
+	# this is not a real dependency, just a hack for 32bit to allow the
+	# transition to libglvnd-32bit (e.g. for steam)
 	depends="libglvnd"
 	short_desc="Free implementation of the GL API - shared library"
 	pkg_install() {
@@ -198,7 +200,6 @@ mesa-opencl_package() {
 
 mesa-dri_package() {
 	short_desc="Mesa DRI drivers"
-	depends="mesa-${version}_${revision}"
 	shlib_provides="libgallium_dri.so" # workaround for mesa-dri-32bit
 	pkg_install() {
 		# Only strip each megadriver once, via its master filename


### PR DESCRIPTION
`libglvnd` doesn't currently install any OpenGL implementation, which makes GL unavailable ootb until the mesa drivers (package `mesa-dri`) are installed. This happens when installing `xorg-minimal` (which doesn't pull in the graphics drivers) or a Wayland compositor. Previously, `libGL` shipped the software rendering driver, so that GL was available (but not optimal), and users were expected to install the `mesa-...-dri` matching their GPU. Now that all dri drivers are in a single package, it is possible to provide hardware acceleration by default as soon as any program which links with GL is installed.
This PR modifies dependencies so that:
GL app -> libglvnd -> mesa -> mesa-dri

Caveats:

- Due to how xbps-src works (i.e. to avoid loops), a second libglvnd package must be introduced specifically to compile mesa (and kept in sync with the other one)
- xbps-src is not currently trying to build dependencies of subpackages. If it is changed to do so, loops will happen again as `libglvnd` appears as dependency in some subpackages (maybe those deps can be removed?)
- This will pull in the drivers also when building GL programs in chroot, which is unnecessary. Can it be avoided?

I initially thought about making `libglvnd` depend on a virtual `gl-vendor` which would be provided by `mesa` and `nvidia*`, but the nvidia packages required non-trivial modifications. Nvidia-only users can uninstall the mesa drivers via `ignorepkg` anyway.