### PR TITLE
gettext-devel: add xz to depends

### DIFF
--- a/srcpkgs/gettext/template
+++ b/srcpkgs/gettext/template
@@ -1,7 +1,7 @@
 # Template file for 'gettext'
 pkgname=gettext
 version=0.20.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-java --disable-native-java --disable-csharp
  --disable-libasprintf --enable-threads=posix --disable-rpath --without-emacs
@@ -45,7 +45,7 @@ gettext-devel-examples_package() {
 	}
 }
 gettext-devel_package() {
-	depends="gettext-libs>=${version}_${revision}"
+	depends="gettext-libs>=${version}_${revision} xz"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
/usr/bin/autopoint uses "tar xf" to extract /usr/share/gettext/archive.dir.tar.xz
if /usr/bin/tar is provided by GNU tar, xz is needed