### PR TITLE
android-studio: bump rev to recompile build

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,7 +1,7 @@
 # Template file for 'android-studio'
 pkgname=android-studio
 version=3.5.3
-revision=1
+revision=2
 # _studio_build and _studio_rev are for downloading the zip from dl.google.com
 # https://developer.android.com/studio/#resources as of 2018-07-12
 _studio_build=191.6010548


### PR DESCRIPTION
My original pull request ( #18625) added tar as a makedepends. However, since I didnt bump the revision, android studio was not rebuilt. This is evident by a `xbps-query -Rs android-studio` that still shows an android-studio < 3.5.3