### PR TITLE
ponyc: update to 0.33.2.

### DIFF
--- a/srcpkgs/ponyc/template
+++ b/srcpkgs/ponyc/template
@@ -1,18 +1,18 @@
 # Template file for 'ponyc'
 pkgname=ponyc
-version=0.32.0
+version=0.33.2
 revision=1
 archs="x86_64"
 build_style=gnu-makefile
-hostmakedepends="llvm7"
-makedepends="zlib-devel ncurses-devel libatomic-devel"
+hostmakedepends="llvm9 which"
+makedepends="zlib-devel ncurses-devel libatomic-devel libxml2-devel"
 depends="libatomic-devel"
 short_desc="OO, actor-model, capabilities-secure, high-performance language"
 maintainer="Brian Mitchell <brian@strmpnk.co>"
 license="BSD-2-Clause"
 homepage="https://ponylang.org/"
 distfiles="https://github.com/ponylang/ponyc/archive/${version}.tar.gz"
-checksum=e8e070164ca0e4e41e606bde617ccab9cc64aa3dca8c79293635a6fdbcabf454
+checksum=41ba573f16b4aecbcc39ec6d5b794185bf50e570b4a8f2cceef0a276e7fb50a3
 
 do_build() {
 	vsed -e 's/-Werror //' -i Makefile


### PR DESCRIPTION
Updated to LLVM 9 now that ponyc uses it.

Adds which as the makefile uses it regardless of whether LLVM_CONFIG is
set, resulting in an error because it cannot find an llvm-config.