### PR TITLE
pony-stable: update to 0.2.2.

### DIFF
--- a/srcpkgs/pony-stable/template
+++ b/srcpkgs/pony-stable/template
@@ -1,6 +1,6 @@
 # Template file for 'pony-stable'
 pkgname=pony-stable
-version=0.2.0
+version=0.2.2
 revision=1
 archs="x86_64"
 build_style=gnu-makefile
@@ -12,7 +12,7 @@ maintainer="Brian Mitchell <brian@strmpnk.co>"
 license="BSD-2-Clause"
 homepage="https://github.com/ponylang/pony-stable"
 distfiles="https://github.com/ponylang/pony-stable/archive/${version}.tar.gz"
-checksum=ed33a9523bc5eba7a9c738ede4e4dcef1755c485e6bfc0c58973c30908a1cb4d
+checksum=8fca5f0f600e695d648200a7492c5d8cea82581f4e4e138f0bb621911d9e4c13
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Not required, but should be merged after #18748 so that it benefits from the updated compiler.