### PR TITLE
xpra: create "xpra" system group on install

### DIFF
--- a/srcpkgs/xpra/template
+++ b/srcpkgs/xpra/template
@@ -1,7 +1,7 @@
 # Template file for 'xpra'
 pkgname=xpra
 version=3.0.5
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="pkg-config python3-Cython"
 makedepends="ffmpeg-devel libXcomposite-devel libXrandr-devel libXtst-devel
@@ -21,6 +21,8 @@ conf_files="
  /etc/xpra/xpra.conf
  /etc/xpra/xorg.conf
  /etc/xpra/conf.d/*"
+
+system_groups="xpra"
 
 if [ -z "$CROSS_BUILD" ]; then
 	depends+=" python3-PyOpenGL-accelerate"


### PR DESCRIPTION
Xpra installs a udev rule that relies on the existence of an "xpra" system group. This group should be created when the package is installed.