### PR TITLE
avahi: preserve default behavior for disallow-other-stacks

### DIFF
--- a/srcpkgs/avahi/template
+++ b/srcpkgs/avahi/template
@@ -1,7 +1,7 @@
 # Template file for 'avahi'
 pkgname=avahi
 version=0.7
-revision=8
+revision=9
 build_style=gnu-configure
 configure_args="--disable-qt3 --disable-qt4 --disable-mono --disable-monodoc
  --disable-doxygen-doc --enable-compat-libdns_sd --enable-compat-howl
@@ -42,8 +42,6 @@ post_extract() {
 }
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/python*
-	# Enable 'disallow_other_stacks' option by default.
-	sed -e 's,\#\(disallow-other-stacks\).*,\1=yes,' -i ${DESTDIR}/etc/avahi/avahi-daemon.conf
 	# Set 'enable-dbus=warn' option by default to not require dbus.
 	sed -e 's,\#\(enable-dbus\).*,\1=warn,' -i ${DESTDIR}/etc/avahi/avahi-daemon.conf
 	vsv avahi-daemon


### PR DESCRIPTION
The void package for avahi overrides the default configuration for disallow-other-stacks, which causes avahi-daemon to bind port 5353. This is "recommended" practice by the Avahi maintainers, but is disabled by default to "not annoy people". In particular, setting this to true breaks the hpaio SANE driver, which attempts to use its own mDNS stack to search for network-connected scanners.

To be consistent with default avahi behavior, this PR undoes the override.