### PR TITLE
Add hg.sr.ht to update_check.sh

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -55,7 +55,8 @@ update_check() {
               *kernel.org/pub/linux/kernel/*|\
               *cran.r-project.org/src/contrib*|\
               *rubygems.org*|\
-              *crates.io*)
+              *crates.io*|\
+              *hg.sr.ht*)
                 continue
                 ;;
             *)
@@ -135,6 +136,10 @@ update_check() {
             *crates.io*)
                 url="https://crates.io/api/v1/crates/${pkgname#rust-}"
                 rx='/crates/'${pkgname#rust-}'/\K[0-9.]*(?=/download)' ;;
+            *hg.sr.ht*)
+                hgsrhtname="$(printf %s "$url" | cut -d/ -f4,5)"
+                url="https://hg.sr.ht/$hgsrhtname/tags"
+                rx='/archive/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")';;
             esac
         fi
 


### PR DESCRIPTION
hg.sr.ht project pages are laid out quite closely to GitHubs format. We
can basically clone the check for GitHub to a new base URL of hg.sr.ht .

```
env XBPS_UPDATE_CHECK_VERBOSE=1 xcheckmypkgs 
... <truncated output> ...
checking: wofi
fetching https://hg.sr.ht/~scoopta/wofi/tags
already fetched https://hg.sr.ht/~scoopta/wofi/tags
found version 1.0
```