### PR TITLE
xbps-src: forbid use with root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ multiple utilities to accomplish this task:
  - `xbps-uchroot(1)` - XBPS utility that uses `namespaces` and must be `setgid` (part of xbps).
  - `proot(1)` - utility that implements chroot/bind mounts in user space, see https://proot-me.github.io/.
 
-> NOTE: you don't need to be `root` to use `xbps-src`, use your preferred chroot style as explained
-below.
+> NOTE: `xbps-src` does not allow building as root anymore. Use one of the chroot
+methods shown above.
 
-#### xbps-uunshare(1)
+### chroot methods
+
+#### xbps-uunshare(1) (default)
 
 This utility requires these Linux kernel options:
 

--- a/xbps-src
+++ b/xbps-src
@@ -421,6 +421,13 @@ fi
 # Read settings from config file
 [ -s "$XBPS_CONFIG_FILE" ] && . $XBPS_CONFIG_FILE &>/dev/null
 
+# Forbid root unless XBPS_ALLOW_CHROOT_BREAKOUT is set
+# (for travis CI).
+if [ -z "$IN_CHROOT" -a "$UID" -eq 0 -a -z "$XBPS_ALLOW_CHROOT_BREAKOUT" ]; then
+    echo "ERROR: xbps-src cannot be used as root." 1>&2
+    exit 1
+fi
+
 # if XBPS_MASTERDIR unset, defaults to $XBPS_DISTDIR/masterdir.
 : ${XBPS_MASTERDIR:=$XBPS_DISTDIR/masterdir}
 [ ! -d $XBPS_MASTERDIR ] &&  mkdir -p $XBPS_MASTERDIR


### PR DESCRIPTION
There's no reason to use xbps-src as root, and looks like
there's a lot of reports of this abuse.

Unless XBPS_ALLOW_CHROOT_BREAKOUT is set (travis),
using xbps-src as root now returns an error.