### PR TITLE
papirus-icon-theme: update to 20200201 [ci skip]

### DIFF
--- a/srcpkgs/papirus-icon-theme/template
+++ b/srcpkgs/papirus-icon-theme/template
@@ -1,6 +1,6 @@
 # Template file for 'papirus-icon-theme'
 pkgname=papirus-icon-theme
-version=20200102
+version=20200201
 revision=1
 archs=noarch
 short_desc="SVG icon theme for Linux, based on Paper Icon Set"
@@ -8,7 +8,7 @@ maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/PapirusDevelopmentTeam/papirus-icon-theme"
 distfiles="https://github.com/PapirusDevelopmentTeam/${pkgname}/archive/${version}.tar.gz"
-checksum=161353e1e3f14bdd28bf1a4a4dea6245cc3d9f56990f5d03092dc70876c97269
+checksum=f20c2b0b0ae6bb01859d62d1bc638e096d835389f64b978d0dc401eb467e00c3
 
 do_install() {
 	vmkdir usr/share/icons


### PR DESCRIPTION
[ci skip] = excessive output for the builders...