### PR TITLE
gedit: build with python3, fix cross

### DIFF
--- a/srcpkgs/gedit/template
+++ b/srcpkgs/gedit/template
@@ -1,17 +1,17 @@
 # Template file for 'gedit'
 pkgname=gedit
 version=3.34.1
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 pycompile_dirs="usr/lib/gedit/plugins"
 configure_args="-Dplugins=true -Dvapi=$(vopt_if vala true false)
  -Dintrospection=$(vopt_if gir true false)"
-hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf perl $(vopt_if vala vala)"
+hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf perl gettext
+ $(vopt_if vala vala)"
 makedepends="gsettings-desktop-schemas-devel gspell-devel gtksourceview4-devel
- libpeas-devel libsoup-devel $(vopt_if gir 'python-gobject-devel') gettext"
-depends="desktop-file-utils gsettings-desktop-schemas
- iso-codes"
+ libpeas-devel libsoup-devel $(vopt_if gir 'python3-gobject-devel')"
+depends="desktop-file-utils gsettings-desktop-schemas iso-codes"
 short_desc="Text editor for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -19,8 +19,7 @@ homepage="https://wiki.gnome.org/Apps/Gedit"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=ebf9ef4e19831699d26bb93ce029edfed65416d7c11147835fc370d73428d5c6
 shlib_provides="libgedit-3.14.so"
-
-nocross=yes
+pycompile_version=$py3_ver
 
 build_options="gir vala"
 build_options_default="gir vala"


### PR DESCRIPTION
gedit is being build with python 2 version of gobject,
gedit requires python3-gobject at runtime through libpeas (its dependencies).

Build gedit with python3-gobject to match it with runtime dependencies.