### PR TITLE
psmisc: update checksum

### DIFF
--- a/srcpkgs/psmisc/template
+++ b/srcpkgs/psmisc/template
@@ -9,4 +9,4 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.com/psmisc/psmisc"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=a4e93dde60ff5a3c1d4dfe61c73555f31cd523c67e2c7c5ada73c668bb448878
+checksum=41750e1a5abf7ed2647b094f58127c73dbce6876f77ba4e0a7e0995ae5c7279a


### PR DESCRIPTION
The psmisc tarball released at sourceforge keeps changing checksum every
so often. From the tarball timestamp, it appears that the translation
files have been updated and then presumably the tarball has been
recreated. Update checksum to reflect the latest one at sourceforge.