### PR TITLE
bsdtar: do not provide tar alternative

### DIFF
--- a/srcpkgs/libarchive/template
+++ b/srcpkgs/libarchive/template
@@ -1,7 +1,7 @@
 # Template file for 'libarchive'
 pkgname=libarchive
 version=3.4.1
-revision=2
+revision=3
 bootstrap=yes
 build_style=gnu-configure
 configure_args="$(vopt_enable acl) $(vopt_enable acl xattr)
@@ -28,7 +28,6 @@ post_install() {
 }
 
 bsdtar_package() {
-	alternatives="tar:tar:/usr/bin/bsdtar"
 	replaces="bsdcpio>=0"
 	short_desc="BSD utilities using libarchive"
 	pkg_install() {

--- a/srcpkgs/tar/template
+++ b/srcpkgs/tar/template
@@ -1,9 +1,9 @@
 # Template file for 'tar'
 pkgname=tar
 version=1.32
-revision=2
+revision=3
 build_style=gnu-configure
-configure_args="--program-prefix=g gl_cv_struct_dirent_d_ino=yes"
+configure_args="gl_cv_struct_dirent_d_ino=yes"
 makedepends="acl-devel"
 short_desc="GNU tape archiver with remote magnetic tape support"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -11,8 +11,6 @@ license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/tar/"
 distfiles="${GNU_SITE}/tar/${pkgname}-${version}.tar.xz"
 checksum=d0d3ae07f103323be809bc3eac0dcc386d52c5262499fe05511ac4788af1fdd8
-
-alternatives="tar:tar:/usr/bin/gtar"
 
 pre_configure() {
 	# chroot-style=ethereal


### PR DESCRIPTION
Alternative for tar was introduced to make switch from gnu tar to bsdtar in base-devel easier.

However, bsdtar has different interface than gnu tar, and with alternatives using gnu tar as tar is actually harder when it is needed.

There are also many user-used scripts assuming gnu tar, which are broken now. They should not be affected because of internal matters of packaging.