### PR TITLE
radicale2: add htpasswd as runtime dependency

### DIFF
--- a/srcpkgs/radicale2/template
+++ b/srcpkgs/radicale2/template
@@ -1,14 +1,13 @@
 # Template file for 'radicale2'
 pkgname=radicale2
 version=2.1.11
-revision=3
+revision=4
 archs=noarch
 wrksrc="Radicale-${version}"
 build_style=python3-module
-pycompile_module="radicale"
 hostmakedepends="python3 python3-setuptools"
 depends="python3-pam python3-requests python3-dulwich python3-vobject
- python3-dateutil python3-passlib python3-bcrypt"
+ python3-dateutil python3-passlib python3-bcrypt apache-htpasswd"
 # added passlib and bcrypt, since its seems to be the safest option.
 short_desc="Complete calendar and contact storing and manipulating solution"
 maintainer="teldra <teldra@rotce.de>"


### PR DESCRIPTION
htpasswd is needed to make safest passwords.