### PR TITLE
j: fix build with missing binaries (#18857)

### DIFF
--- a/srcpkgs/j/template
+++ b/srcpkgs/j/template
@@ -4,7 +4,7 @@ _vmaj=901
 _vmin=e
 _vrel=${_vmaj}-release${_vmin:+-}${_vmin}
 version=${_vmaj}.${_vmin}
-revision=2
+revision=3
 archs="aarch64* x86_64*"
 wrksrc="jsource-j${_vrel}"
 makedepends="libedit-devel libgomp-devel libomp-devel"
@@ -41,15 +41,24 @@ do_configure() {
 	         /jbuilder/s@unknown@${_jbuilder}@" \
 	     jsrc/jversion.h
 
+	# Remove version directory component from "~install" and "~user" paths
 	cp jlibrary/bin/profile.ijs jlibrary/bin/profile.ijs.new
 	vsed -i "/^install=./s@/usr/share/j/[0-9.]\+@${_jshare}@;
 	         /^user=./s@home,userx@home,'/${_juser}'@" \
 	     jlibrary/bin/profile.ijs.new
+
+	# The build scripts set compiler flags based on what they detect as the
+	# compiler (gcc vs clang). However, their detection scheme is fragile
+	# and breaks when using ccache. Thus we directly tell them that we are
+	# using gcc.
+	vsed -i '/^compiler/s/=.*/=gcc/' make2/build_jconsole.sh
+	vsed -i '/^compiler/s/=.*/=gcc/' make2/build_libj.sh
 }
 
 ##
 # Crossbuilds do not distinguish between AVX- and non-AVX targets, so instead
-# we build all applicable binaries.
+# we build all applicable binaries and install a wrapper script that executes
+# the correct one on the target machine.
 do_build() {
 	jplatform=${_jpl} j64x=${_jsz} make2/build_jconsole.sh
 	jplatform=${_jpl} j64x=${_jsz} make2/build_libj.sh


### PR DESCRIPTION
Upstreams's build scripts set compilation flags based on whether or not
gcc is detected. However, the detection scheme relies are path parsing
and breaks when using ccache.

Somehow this slipped passed CI. In particular see the broken build log:

https://build.voidlinux.org/builders/x86_64_builder/builds/22852/steps/shell_3/logs/stdio

The build phase stops when make exits with an error; however, this
failed to kill the build for some reason. Thus we end up with a package
containing none of the binaries that were supposed to build.

In particular, `do_make` failed because the upstream build scripts
*fallback* to assuming clang when gcc is not detected. Notice,
especially, the following lines in the build log:

    entering /builddir/jsource-j901-release-e/make2
    CC=cc
    compiler=/usr/bin/ccache

When using ccache, `cc` points to /usr/bin/ccache, which the build
scripts notice as not of the form `*gcc*`, thus assuming clang and
eventually leading to a broken package.