### PR TITLE
New package: libnpupnp-2.0.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1999,6 +1999,7 @@ libpolkit-qt5-core-1.so.1 polkit-qt5-0.112.0_1
 libfm-qt.so.6 libfm-qt-0.14.0_1
 libqtermwidget5.so.0 qtermwidget-0.6.0_1
 libnpth.so.0 npth-1.1_1
+libnpupnp.so.1 libnpupnp-2.0.1_1
 libglfw.so.3 glfw-3.0.4_1
 libusbmuxd.so.6 libusbmuxd-1.0.10_1
 libimobiledevice.so.6 libimobiledevice-1.2.0_1

--- a/srcpkgs/libnpupnp-devel
+++ b/srcpkgs/libnpupnp-devel
@@ -1,0 +1,1 @@
+libnpupnp

--- a/srcpkgs/libnpupnp/template
+++ b/srcpkgs/libnpupnp/template
@@ -1,0 +1,27 @@
+# Template file for 'libnpupnp'
+pkgname=libnpupnp
+version=2.0.1
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="expat-devel libcurl-devel libmicrohttpd-devel"
+short_desc="UPnP library based on libupnp, but extensively rewritten"
+maintainer="amak <amak.git@outlook.com>"
+license="BSD-3-Clause"
+homepage="https://www.lesbonscomptes.com/upmpdcli/libnpupnp.html"
+distfiles="https://www.lesbonscomptes.com/upmpdcli/downloads/libnpupnp-${version}.tar.gz"
+checksum=719d677bc5292440b481f249d90eee564f0d5677a0c876ff90f2b34df70f9734
+
+post_install() {
+	vlicense COPYING
+}
+
+libnpupnp-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
libnpupnp is a new UPnP library based on libupnp, but [extensively](https://www.lesbonscomptes.com/upmpdcli/libnpupnp.html) rewritten. It was created by the author of upmpdcli and libupnpp to replace libupnp usage in libupnpp.

This package is needed for libupnpp 0.18+.