### PR TITLE
New package: qmk-0.0.27

### DIFF
--- a/srcpkgs/python3-hjson/template
+++ b/srcpkgs/python3-hjson/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-hjson'
+pkgname=python3-hjson
+version=3.0.1
+revision=1
+archs=noarch
+wrksrc="hjson-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="User interface for JSON"
+maintainer="RinsedSloth <afernandezh@protonmail.com>"
+license="MIT"
+homepage="https://github.com/hjson/hjson-py"
+distfiles="${PYPI_SITE}/h/hjson/hjson-${version}.tar.gz"
+checksum=1d1727faa6aaef2973921877125a3ab7c5f6d34b93233179d01770f41fab51f9
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-yapf/template
+++ b/srcpkgs/python3-yapf/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-yapf'
+pkgname=python3-yapf
+version=0.29.0
+revision=1
+archs=noarch
+wrksrc="yapf-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Formatter for Python code"
+maintainer="RinsedSloth <afernandezh@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/google/yapf"
+distfiles="${PYPI_SITE}/y/yapf/yapf-${version}.tar.gz"
+checksum=712e23c468506bf12cadd10169f852572ecc61b266258422d45aaf4ad7ef43de

--- a/srcpkgs/qmk/template
+++ b/srcpkgs/qmk/template
@@ -1,0 +1,29 @@
+# Template file for 'qmk'
+pkgname=qmk
+version=0.0.27
+revision=1
+archs=noarch
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-appdirs
+ python3-argcomplete
+ python3-colorama
+ python3-hjson
+ python3-nose2
+ flake8
+ python3-yapf
+ dfu-programmer
+ avrdude
+ dfu-util
+ avr-gcc
+ cross-arm-none-eabi-gcc"
+short_desc="CLI tool for working with QMK firmware of mechanical keyboards"
+maintainer="RinsedSloth <afernandezh@protonmail.com>"
+license="MIT"
+homepage="https://github.com/qmk/qmk_cli"
+distfiles="${PYPI_SITE}/q/qmk/qmk-${version}.tar.gz"
+checksum=83828e56dbde30f3d257e10667aa62e63b90a8ff6d2397ab5cab4ae100c1fd74
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
CLI tool for managing the QMK firmware of compatible mechanical keyboards.

This pull request also adds two of its dependencies:
- Yapf, a python code formatter.
- Hjson a user interface for json.