### PR TITLE
lollypop: depend on gst-plugins-good1

### DIFF
--- a/srcpkgs/lollypop/template
+++ b/srcpkgs/lollypop/template
@@ -1,12 +1,12 @@
 # Template file for 'lollypop'
 pkgname=lollypop
 version=1.2.20
-revision=1
+revision=2
 archs=noarch
 build_style=meson
 hostmakedepends="cmake git glib-devel gobject-introspection intltool itstool pkg-config"
 makedepends="gtk+3-devel libsoup-devel python3-gobject-devel python3-devel"
-depends="dconf gst-libav libnotify libsecret python3-dbus python3-gobject
+depends="dconf gst-libav gst-plugins-good1 libnotify libsecret python3-dbus python3-gobject
  python3-pylast python3-youtube-dl python3-Pillow totem-pl-parser"
 short_desc="Music player for GNOME"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"


### PR DESCRIPTION
This commit adds a missing dependency for the GNOME Lollypop music player. It fixes Spotify and YouTube streaming not working at all.

(I got the following error)
```
[INFO] 2020-02-08 22:08:42 Track URI found by <lollypop.helper_web_youtube.YouTubeHelper object at 0x7ff5962fcca0>
[INFO] 2020-02-08 22:08:42 Player::_on_bus_error(): ../libs/gst/base/gstbasesrc.c(3072): gst_base_src_loop (): /GstPlayBin:player/GstURIDecodeBin:uridecodebin0/GstCurlHttpSrc:source:
streaming stopped, reason error (-5)
[ERROR] 2020-02-08 22:08:42 BinPlayer::__update_current_duration(): gst-stream-error-quark: Internal data stream error. (1)
```