### PR TITLE
udiskie: update to 2.1.0

### DIFF
--- a/srcpkgs/udiskie/template
+++ b/srcpkgs/udiskie/template
@@ -1,11 +1,10 @@
 # Template file for 'udiskie'
 pkgname=udiskie
-version=1.7.7
-revision=2
+version=2.1.0
+revision=1
 archs=noarch
 build_style=python3-module
-pycompile_module="udiskie"
-hostmakedepends="python3-setuptools python3-gobject"
+hostmakedepends="gettext python3-setuptools python3-gobject"
 depends="gtk+3 libnotify python3-docopt python3-gobject python3-keyutils
  python3-yaml udisks2"
 short_desc="Removable disk automounter using udisks"
@@ -13,7 +12,7 @@ maintainer="Matthias Fulz <mfulz@olznet.de>"
 license="MIT"
 homepage="https://github.com/coldfix/udiskie"
 distfiles="https://github.com/coldfix/udiskie/archive/${version}.tar.gz"
-checksum=dd6f01dd43ea377838834da99a12980fcd488f9de1bbbb19ad92687d8b9e94ba
+checksum=b55c6fc1061706716c1d094f1649a5f5928f2d0c1c38e17d896e85b0c7fef3dd
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Template may need to be altered, 1.7.7 (current version on Void) is the last version that supports Python 2.