### PR TITLE
lilypond: update to 2.19.84

### DIFF
--- a/srcpkgs/lilypond-doc/template
+++ b/srcpkgs/lilypond-doc/template
@@ -1,6 +1,6 @@
 # Template file for 'lilypond-doc'
 pkgname=lilypond-doc
-version=2.19.83.1
+version=2.19.84.1
 revision=1
 archs=noarch
 create_wrksrc=yes
@@ -9,11 +9,10 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="http://lilypond.org/"
 distfiles="http://lilypond.org/downloads/binaries/documentation/lilypond-${version%.*}-${version##*.}.documentation.tar.bz2"
-checksum=5ca48118b552b5ebf64dcc49d846d6cc23df6292bdea06216a0df1d083e2fc90
+checksum=d6007a1d2e6d4e63ab0fd072e7126274323d18cdbc4e62057946b7903eb7913f
 
 do_install() {
 	vmkdir usr
 	rm share/info/lilypond
 	mv share ${DESTDIR}/usr/
-	vlicense license/lilypond-doc
 }

--- a/srcpkgs/lilypond/template
+++ b/srcpkgs/lilypond/template
@@ -1,15 +1,15 @@
 # Template file for 'lilypond'
 pkgname=lilypond
-version=2.19.83
+version=2.19.84
 revision=1
-_tlversion=2018
+_tlversion=2019
 build_wrksrc="build"
 build_style="gnu-configure"
 configure_script="../configure"
 configure_args="--disable-documentation ac_cv_func_isinf=yes
  --with-texgyre-dir=/opt/texlive/${_tlversion}/texmf-dist/fonts/opentype/public/tex-gyre"
 hostmakedepends="autogen automake flex fontforge gettext gnupg guile1.8 pkg-config
- texlive-bin"
+ tar texinfo texlive-bin"
 makedepends="gc-devel guile1.8-devel libltdl-devel pango-devel python-devel"
 depends="python ghostscript"
 short_desc="Music engraving program"
@@ -17,7 +17,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="http://lilypond.org/"
 distfiles="http://lilypond.org/downloads/sources/v2.19/lilypond-${version}.tar.gz"
-checksum=96ba4f4b342d21057ad74d85d647aea7e47a5c24f895127c2b3553a252738fb3
+checksum=94dcc66447f24966f28eda72c79e1ec16143b8ea4a537cc9f97d017cc0c0dd11
 
 if [ -n "${CROSS_BUILD}" ]; then
 	# needs guile-config-1.8 and python-config
@@ -48,4 +48,3 @@ do_build() {
 	source /etc/profile.d/texlive.sh
 	make ${makejobs} ${make_build_args} ${make_build_target}
 }
-


### PR DESCRIPTION
Compiled for and tested on x86_64, x86_64-musl, i686, armv7l; no problems.
Packages also built sucessfully for aarch64 and armv6l.

Due to its ten thousand files lilypond-doc will exceed maximum log length, but I didn’t encounter any problem locally.