### PR TITLE
New package: opensmtpd-filter-senderscore-0.1.1_1

### DIFF
--- a/srcpkgs/opensmtpd-filter-senderscore/template
+++ b/srcpkgs/opensmtpd-filter-senderscore/template
@@ -1,0 +1,19 @@
+# Template file for 'opensmtpd-filter-senderscore'
+pkgname=opensmtpd-filter-senderscore
+version=0.1.1
+revision=1
+wrksrc="filter-senderscore-${version}"
+build_style=go
+go_import_path="github.com/poolpOrg/filter-senderscore"
+short_desc="Filter incoming mail based on sender reputation"
+maintainer="Lucas L. Treffenstädt <lucas@treffenstaedt.de>"
+license="ISC"
+homepage="https://github.com/poolpOrg/filter-senderscore"
+distfiles="https://github.com/poolpOrg/filter-senderscore/releases/download/${version}/filter-senderscore-${version}.tar.gz"
+checksum=a1e1b3106ea69218400e35c9c11e84702961b98a478b99fb329a52c954ec4b86
+
+do_install() {
+	vlicense LICENSE
+	vmkdir /usr/libexec/opensmtpd
+	vinstall $(find '_build-opensmtpd-filter-senderscore-xbps/bin' -name 'filter-senderscore') 0555 /usr/libexec/opensmtpd
+}


### PR DESCRIPTION
This nifty little package allows to filter incoming mail by the sending server's reputation.