### PR TITLE
New package: opensmtpd-filter-rspamd-0.1.5_1

### DIFF
--- a/srcpkgs/opensmtpd-filter-rspamd/template
+++ b/srcpkgs/opensmtpd-filter-rspamd/template
@@ -1,0 +1,19 @@
+# Template file for 'opensmtpd-filter-rspamd'
+pkgname=opensmtpd-filter-rspamd
+version=0.1.5
+revision=1
+wrksrc="filter-rspamd-${version}"
+build_style=go
+go_import_path="github.com/poolpOrg/filter-rspamd"
+short_desc="Filter incoming mail based on sender reputation"
+maintainer="Lucas L. Treffenstädt <lucas@treffenstaedt.de>"
+license="ISC"
+homepage="https://github.com/poolpOrg/filter-rspamd"
+distfiles="https://github.com/poolpOrg/filter-rspamd/releases/download/${version}/filter-rspamd-${version}.tar.gz"
+checksum=4458706e10cd3eb4716ec0229bfe390654e94261dac7f2650bed468570806b26
+
+do_install() {
+	vlicense LICENSE
+	vmkdir /usr/libexec/opensmtpd
+	vinstall $(find '_build-opensmtpd-filter-rspamd-xbps/bin' -name 'filter-rspamd') 0555 /usr/libexec/opensmtpd
+}


### PR DESCRIPTION
This package allows opensmtpd to use rspamd for spam filtering and dkim signing.