### PR TITLE
lxc: depend on wget

### DIFF
--- a/srcpkgs/lxc/template
+++ b/srcpkgs/lxc/template
@@ -3,14 +3,14 @@ _desc="Linux Containers"
 
 pkgname=lxc
 version=3.2.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-doc --enable-seccomp
  --enable-capabilities --enable-apparmor --with-distro=none
  --with-rootfs-path=/var/lxc/containers --with-log-path=/var/lxc/log"
 hostmakedepends="automake libtool pkg-config docbook2x"
 makedepends="libcap-devel libseccomp-devel gnutls-devel libapparmor-devel"
-depends="xz gnupg"
+depends="xz wget gnupg"
 short_desc="${_desc} - utilities"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://linuxcontainers.org"


### PR DESCRIPTION
After installation, lxc asked me to install wget.
I believe this can be considered a missing dependency, but I don't see this pull request being merged since lxc is orphaned anyways
```
ERROR: Missing required tool: wget
lxc-create: arch-packaging: lxccontainer.c: create_run_template: 1648 Failed to create container from template
lxc-create: arch-packaging: tools/lxc_create.c: main: 331 Failed to create container arch-packaging
```