### PR TITLE
dracut: remove psmisc dependency

### DIFF
--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,13 +1,13 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=049
-revision=4
+revision=5
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"
 hostmakedepends="asciidoc pkg-config"
 makedepends="libkmod-devel"
-depends="bash coreutils cpio eudev gzip kmod>=3.7 kpartx psmisc util-linux"
+depends="bash coreutils cpio eudev gzip kmod>=3.7 kpartx util-linux"
 short_desc="Low-level tool for generating an initramfs/initrd image"
 maintainer="q66 <daniel@octaforge.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"


### PR DESCRIPTION
None of the psmisc utils are used by dracut, so remove the dependency.