### PR TITLE
rsyslog: replace killall with pkill in logrotate script

### DIFF
--- a/srcpkgs/rsyslog/files/rsyslog.logrotate
+++ b/srcpkgs/rsyslog/files/rsyslog.logrotate
@@ -2,6 +2,6 @@
 	missingok
 	sharedscripts
 	postrotate
-		killall -HUP rsyslogd
+		pkill -HUP rsyslogd
 	endscript
 }

--- a/srcpkgs/rsyslog/template
+++ b/srcpkgs/rsyslog/template
@@ -1,7 +1,7 @@
 # Template file for 'rsyslog'
 pkgname=rsyslog
 version=8.2001.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --enable-gnutls --enable-mysql
  --enable-pgsql --enable-imdiag --enable-imfile --enable-mail --enable-imptcp


### PR DESCRIPTION
Avoid psmisc dependency by instead relying on the procps-ng pkill for
sending a HUP signal.