### PR TITLE
base-system: remove psmisc dependency

### DIFF
--- a/srcpkgs/base-system/template
+++ b/srcpkgs/base-system/template
@@ -1,19 +1,18 @@
 # Template file for 'base-system'
 pkgname=base-system
-reverts="0.113_1"
-version=0.112
-revision=6
+version=0.113
+revision=2
 build_style=meta
 short_desc="Void Linux base system meta package"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="Public domain"
+license="Public Domain"
 homepage="https://www.voidlinux.org"
 
 depends="
  base-files>=0.77 ncurses coreutils findutils diffutils libgcc
  dash bash grep gzip file sed gawk less util-linux which tar man-pages
  mdocml>=1.13.3 shadow e2fsprogs btrfs-progs xfsprogs f2fs-tools dosfstools
- psmisc procps-ng tzdata pciutils usbutils iana-etc openssh dhcpcd
+ procps-ng tzdata pciutils usbutils iana-etc openssh dhcpcd
  kbd iproute2 iputils iw wpa_supplicant xbps nvi sudo wifi-firmware
  void-artwork traceroute ethtool kmod acpid eudev runit-void"
 


### PR DESCRIPTION
None of the psmisc utils are needed for the base-system, remove the
dependency.