### PR TITLE
base-minimal: replace psmisc with procps-ng

### DIFF
--- a/srcpkgs/base-minimal/template
+++ b/srcpkgs/base-minimal/template
@@ -1,16 +1,16 @@
 # Template file for 'base-minimal'
 pkgname=base-minimal
-version=0.1
-revision=3
+version=0.2
+revision=1
 build_style=meta
-homepage="http://www.voidlinux.org/"
 short_desc="Void Linux base system meta with minimal tools"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="Public domain"
+license="Public Domain"
+homepage="https://www.voidlinux.org/"
 
 depends="
  base-files coreutils findutils diffutils dash grep gzip sed gawk
- util-linux which tar shadow psmisc iana-etc xbps nvi tzdata
+ util-linux which tar shadow procps-ng iana-etc xbps nvi tzdata
  runit-void"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
None of the psmisc utils are required for base, so remove the
dependency. At the same time, add procps-ng as a dep, since it includes
some fundamental utils (ps, pkill, free, ...).