### PR TITLE
base-voidstrap: remove psmisc dependency

### DIFF
--- a/srcpkgs/base-voidstrap/template
+++ b/srcpkgs/base-voidstrap/template
@@ -1,18 +1,18 @@
 # Template file for 'base-voidstrap'
 pkgname=base-voidstrap
-version=0.9
-revision=3
+version=0.10
+revision=1
 build_style=meta
-homepage="http://www.voidlinux.org/"
 short_desc="Void Linux base system meta package for containers/chroots"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="Public domain"
+license="Public Domain"
+homepage="https://www.voidlinux.org/"
 
 depends="
  base-files ncurses coreutils findutils diffutils
  dash bash grep gzip file sed gawk less util-linux which tar man-pages
  mdocml>=1.13.3 shadow e2fsprogs btrfs-progs xfsprogs f2fs-tools dosfstools kbd
- psmisc procps-ng tzdata pciutils iana-etc eudev runit-void openssh dhcpcd
+ procps-ng tzdata pciutils iana-etc eudev runit-void openssh dhcpcd
  iproute2 iputils iw xbps nvi sudo traceroute kmod"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
None of the psmisc utils are needed for base, remove the dependency.