### PR TITLE
Improved wrksrc variable documentation

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -506,7 +506,7 @@ For tarballs you can find the contents checksum by using the command
 `tar xf <tarball.ext> --to-stdout | sha256sum`.
 
 - `wrksrc` The directory name where the package sources are extracted, by default
-set to `${pkgname}-${version}`.
+set to `${pkgname}-${version}`. If the top level directory of a package's `distfile` is different from the default, `wrksrc` must be set to the top level directory name inside the archive.
 
 - `build_wrksrc` A directory relative to `${wrksrc}` that will be used when building the package.
 


### PR DESCRIPTION
As a new contributor the behavior of the `wrksrc` variable in package template files confused me and led to some confusing "cannot access wrksrc" errors when a package's `distfiles` are not named what `xbps-src` expects them to be by default.

This PR adds what I learned about `wrksrc` and how it ties to `distfiles` to the documentation.