### PR TITLE
teamspeak3: fix broken build

### DIFF
--- a/srcpkgs/teamspeak3/template
+++ b/srcpkgs/teamspeak3/template
@@ -5,6 +5,7 @@ revision=1
 archs="i686 x86_64"
 wrksrc=teamspeak3
 create_wrksrc=yes
+makedepends="tar"
 short_desc="Popular proprietary voice chat for gaming"
 maintainer="Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>"
 license="Proprietary"
@@ -29,8 +30,7 @@ fi
 
 do_extract() {
 	install -m755 ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_pkg}.run ${wrksrc}
-	cd ${wrksrc}
-	sh ./${_pkg}.run --tar -xf 2>/dev/null
+	sh ./${_pkg}.run --tar xf
 	rm -f ${_pkg}.run
 }
 


### PR DESCRIPTION
Today I tried to install `teamspeak3`, but the build failed.
The buildroot was empty after executing the run file.
It took me a bit to figure out, because `stderr` was redirected to `/dev/null`, but it seems that the `tar` dependency was missing