### PR TITLE
godot: fix incorrect icon and switch to system bullet library 

### DIFF
--- a/srcpkgs/godot/INSTALL.msg
+++ b/srcpkgs/godot/INSTALL.msg
@@ -1,4 +1,0 @@
-If you want to export your games, you should either
-install godot-templates or download it from
-godotengine.org . If godot-template should not be 
-available, just open an issue on GitHub.

--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,7 +1,7 @@
 # Template file for 'godot'
 pkgname=godot
 version=3.2
-revision=2
+revision=3
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 wrksrc="${pkgname}-${version}-stable"
 build_style=scons
@@ -10,7 +10,7 @@ build_style=scons
 # Use builtin bullet for now as it's too old in repos (needs 2.89)
 # Toggle to not use builtin once bullet has been updated
 make_build_args="platform=x11 tools=yes target=release_debug dev=no progress=no
- pulseaudio=no builtin_bullet=true builtin_libpng=false builtin_libvpx=false
+ pulseaudio=no builtin_bullet=false builtin_libpng=false builtin_libvpx=false
  builtin_libwebp=false builtin_libogg=false builtin_libtheora=false
  builtin_opus=false builtin_libvorbis=false builtin_enet=false
  builtin_zlib=false builtin_freetype=false builtin_mbedtls=false
@@ -45,7 +45,7 @@ pre_build() {
 do_install() {
 	vlicense LICENSE.txt
 	vinstall ${FILESDIR}/godot.desktop 644 /usr/share/applications/
-	vinstall ${wrksrc}/logo.png 644 /usr/share/pixmaps/ godot.png
+	vinstall ${wrksrc}/icon.png 644 /usr/share/pixmaps/ godot.png
 
 	case "$XBPS_TARGET_MACHINE" in
 		x86_64*|aarch64*|ppc64*) vbin bin/godot.x11.opt.tools.64 godot;;


### PR DESCRIPTION
changed the godot template to use the correct icon instead of the full logo

comparison:
![iconcomparison](https://user-images.githubusercontent.com/60516752/74111071-fae6eb00-4b91-11ea-8278-5b4a7308e83a.png)
