### PR TITLE
libupnpp: update to 0.18.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1430,7 +1430,7 @@ libgpaste.so.11 libgpaste-3.28.2_1
 libthreadutil.so.6 libupnp-1.6.18_1
 libixml.so.2 libupnp-1.6.18_1
 libupnp.so.6 libupnp-1.6.18_1
-libupnpp.so.8 libupnpp-0.17.2_1
+libupnpp.so.9 libupnpp-0.18.0_1
 libgeocode-glib.so.0 geocode-glib-3.10.0_1
 libzeitgeist-2.0.so.0 libzeitgeist2-0.9.14_1
 libpotrace.so.0 libpotrace-1.11_1

--- a/srcpkgs/libupnpp/template
+++ b/srcpkgs/libupnpp/template
@@ -1,16 +1,16 @@
 # Template file for 'libupnpp'
 pkgname=libupnpp
-version=0.17.2
+version=0.18.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
-makedepends="expat-devel libcurl-devel libupnp-devel"
-short_desc="C++ wrapper for libupnp"
+makedepends="expat-devel libcurl-devel libnpupnp-devel"
+short_desc="C++ wrapper for libnpupnp"
 maintainer="amak <amak.git@outlook.com>"
 license="LGPL-2.1-or-later"
 homepage="https://www.lesbonscomptes.com/upmpdcli"
 distfiles="https://www.lesbonscomptes.com/upmpdcli/downloads/libupnpp-${version}.tar.gz"
-checksum=5abaaf353a1e9c3482d61ef2627b650285d59f27c1ee60d35b8951952261374f
+checksum=c9659cd36ce70c43e9889a6c3a5eeb28e4f799580727826a6c7aef9bef6b6937
 
 libupnpp-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/upmpdcli/template
+++ b/srcpkgs/upmpdcli/template
@@ -1,10 +1,10 @@
 # Template file for 'upmpdcli'
 pkgname=upmpdcli
 version=1.4.6
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config tar"
-makedepends="jsoncpp-devel libmicrohttpd-devel libmpdclient-devel libupnp-devel libupnpp-devel"
+makedepends="jsoncpp-devel libmicrohttpd-devel libmpdclient-devel libupnpp-devel"
 short_desc="UPnP Media Renderer front-end for MPD"
 maintainer="amak <amak.git@outlook.com>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
libupnpp 0.18+ defaults to building with libnpupnp instead of libupnp. See https://www.lesbonscomptes.com/upmpdcli/libnpupnp.html