### PR TITLE
wrappers/uname: report correct machine type on ethereal

### DIFF
--- a/common/wrappers/uname.sh
+++ b/common/wrappers/uname.sh
@@ -2,5 +2,8 @@
 
 uname=$(/usr/bin/uname $@)
 rv=$?
-echo "$uname" | sed "s/\(^\| \)$(/usr/bin/uname -n)\($\| \)/\1void\2/"
+echo "$uname" |
+	sed "s/\(^\| \)$(/usr/bin/uname -n)\($\| \)/\1void\2/" |
+	sed "s/$(/usr/bin/uname -m)/${XBPS_ARCH%-musl}/"
+
 exit $rv


### PR DESCRIPTION
We're using Ethereal chroot style on Travis CI.

In that chroot style, `uname -m` reports x86_64 even if we're
bootstrapped with i686 systems.

Some i686 build that employ `uname -m` is failing on Travis CI,
e.g: https://travis-ci.org/void-linux/void-packages/jobs/648010517#L5787

Change `uname` output to make Travis Output meaningful for i686.