### PR TITLE
nvme-cli: remove systemd units

### DIFF
--- a/srcpkgs/nvme-cli/template
+++ b/srcpkgs/nvme-cli/template
@@ -1,7 +1,7 @@
 # Template file for 'nvme-cli'
 pkgname=nvme-cli
 version=1.9
-revision=2
+revision=3
 build_style=gnu-makefile
 # yeah, it must be 0 to enable
 make_build_args="LIBUUID=0"
@@ -18,9 +18,11 @@ checksum=d7c3d56f36f81c0933f7b7c3f90c4196be0fec758affc8062c525b6bc5ea65f5
 
 CFLAGS="-Wno-error -I."
 
-# these files are touch'd by install, remove so they don't get registered
-# by the package (which would subsequently cause trouble during removal)
 post_install() {
-	rm -f "${PKGDESTDIR}/etc/nvme/hostnqn"
-	rm -f "${PKGDESTDIR}/etc/nvme/hostid"
+	# these files are touch'd by install, remove so they aren't registered
+	# by the package (which would cause trouble during removal)
+	rm -f "${DESTDIR}/etc/nvme/hostnqn"
+	rm -f "${DESTDIR}/etc/nvme/hostid"
+	# no need for systemd files
+	rm -rf "${DESTDIR}/usr/lib/systemd"
 }


### PR DESCRIPTION
The nvme-cli package installs unit files in /usr/lib/systemd/system that are useless without systemd.