### PR TITLE
torbrowser-launcher: fix broken Apparmor integration.

### DIFF
--- a/srcpkgs/torbrowser-launcher/patches/apparmor.patch
+++ b/srcpkgs/torbrowser-launcher/patches/apparmor.patch
@@ -1,0 +1,21 @@
+From 0b78aea138daee5de1ba5fad126625f245134c6b Mon Sep 17 00:00:00 2001
+From: intrigeri <intrigeri@boum.org>
+Date: Mon, 9 Sep 2019 08:32:52 +0000
+Subject: [PATCH] AppArmor: allow new path for the Firefox 68 IPC
+
+---
+ apparmor/torbrowser.Browser.firefox | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/apparmor/torbrowser.Browser.firefox b/apparmor/torbrowser.Browser.firefox
+index f782f35..c6d8a26 100644
+--- apparmor/torbrowser.Browser.firefox
++++ apparmor/torbrowser.Browser.firefox
+@@ -105,6 +105,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
+ 
+   # Required for multiprocess Firefox (aka Electrolysis, i.e. e10s)
+   owner /{dev,run}/shm/org.chromium.* rw,
++  owner /dev/shm/org.mozilla.ipc.[0-9]*.[0-9]* rw, # for Chromium IPC
+ 
+   # Deny access to DRM nodes, that's granted by the X abstraction, which is
+   # sourced by the gnome abstraction, that we include.

--- a/srcpkgs/torbrowser-launcher/patches/sandbox.patch
+++ b/srcpkgs/torbrowser-launcher/patches/sandbox.patch
@@ -1,0 +1,35 @@
+From 73fc84bc3cfffef710a5bd96aeff681a7db6c350 Mon Sep 17 00:00:00 2001
+From: intrigeri <intrigeri@boum.org>
+Date: Mon, 9 Sep 2019 09:07:55 +0000
+Subject: [PATCH] AppArmor: Pass the environment to Firefox content processes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Without this, LD_LIBRARY_PATH is not passed to these processes, and then:
+
+ - Tor Browser cannot load libmozsandbox.so
+
+ - Tor Browser 9.0a6 does not start correctly:
+
+     /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.23' not
+     found (required by /usr/local/lib/tor-browser/libxul.so)
+
+   … while it should use its own copy of libstdc++.so.6.
+---
+ apparmor/torbrowser.Browser.firefox | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/apparmor/torbrowser.Browser.firefox b/apparmor/torbrowser.Browser.firefox
+index c6d8a26..42516b6 100644
+--- apparmor/torbrowser.Browser.firefox
++++ apparmor/torbrowser.Browser.firefox
+@@ -73,7 +73,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
+   owner @{torbrowser_home_dir}/TorBrowser/Tor/*.so.* mr,
+ 
+   # parent Firefox process when restarting after upgrade, Web Content processes
+-  owner @{torbrowser_firefox_executable} ixmr -> torbrowser_firefox,
++  owner @{torbrowser_firefox_executable} pxmr -> torbrowser_firefox,
+ 
+   /etc/mailcap r,
+   /etc/mime.types r,

--- a/srcpkgs/torbrowser-launcher/patches/updater.patch
+++ b/srcpkgs/torbrowser-launcher/patches/updater.patch
@@ -1,0 +1,21 @@
+From b8a13f96c22d668b5fb07da83e1b5ac399f471cb Mon Sep 17 00:00:00 2001
+From: intrigeri <intrigeri@boum.org>
+Date: Thu, 7 Nov 2019 07:47:27 +0000
+Subject: [PATCH] AppArmor: allow running the Firefox updater from its new path
+
+---
+ apparmor/torbrowser.Browser.firefox | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/apparmor/torbrowser.Browser.firefox b/apparmor/torbrowser.Browser.firefox
+index 42516b6..8d96043 100644
+--- apparmor/torbrowser.Browser.firefox
++++ apparmor/torbrowser.Browser.firefox
+@@ -63,6 +63,7 @@ profile torbrowser_firefox @{torbrowser_firefox_executable} {
+   owner @{torbrowser_home_dir}/firefox rix,
+   owner @{torbrowser_home_dir}/{,TorBrowser/UpdateInfo/}updates/[0-9]*/* rw,
+   owner @{torbrowser_home_dir}/{,TorBrowser/UpdateInfo/}updates/[0-9]*/{,MozUpdater/bgupdate/}updater ix,
++  owner @{torbrowser_home_dir}/updater ix,
+   owner @{torbrowser_home_dir}/TorBrowser/Data/Browser/.parentwritetest rw,
+   owner @{torbrowser_home_dir}/TorBrowser/Data/Browser/profiles.ini r,
+   owner @{torbrowser_home_dir}/TorBrowser/Data/Browser/profile.default/{,**} rwk,

--- a/srcpkgs/torbrowser-launcher/template
+++ b/srcpkgs/torbrowser-launcher/template
@@ -1,11 +1,10 @@
 # Template file for 'torbrowser-launcher'
 pkgname=torbrowser-launcher
 version=0.3.2
-revision=2
+revision=3
 archs="i686 x86_64" # limited by Tor Browser itself
 build_style=python3-module
-pycompile_module="torbrowser_launcher"
-hostmakedepends="python3-setuptools"
+hostmakedepends="gettext python3-setuptools"
 depends="python3-PyQt5 python3-gpg python3-requests python3-pysocks gnupg2 tor"
 short_desc="Securely download, verify and run Tor Browser"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"


### PR DESCRIPTION
Tor Browser shows a black screen with the previous Apparmor rules.