### PR TITLE
xbps-src: have cmdline arguments take precedence over config files

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -185,9 +185,11 @@ $(print_cross_targets)
 -N  Disable use of remote repositories to resolve dependencies.
 
 -o  <opt,~opt2,...>
-    Enable or disable (prefixed with ~) package build options. Note this overrides
-    options set via XBPS_PKG_OPTIONS from 'etc/conf'. This effectively has the same
-    effect than setting 'XBPS_PKG_OPTIONS_<pkgname>' in 'etc/conf'.
+    Enable or disable (prefixed with ~) package build options. If 'etc/conf'
+    already specifies some, it is merged. Keep in mind that these options
+    apply to all packages within the build, as in if a dependency needs to
+    be built, it will inherit these options.
+
     Supported options can be shown with the 'show-options' target.
 
 -r  <repo>
@@ -337,28 +339,31 @@ XBPS_OPTSTRING="1a:CEfgGhH:iIj:Lm:No:qQr:tV"
 # Preprocess arguments in order to allow options before and after XBPS_TARGET.
 eval set -- $(getopt "$XBPS_OPTSTRING" "$@");
 
+# Options are saved as XBPS_ARG_FOO instead of XBPS_FOO for now; this is
+# because configuration files may override those and we want arguments to
+# take precedence over configuration files
 while getopts "$XBPS_OPTSTRING" opt; do
     case $opt in
-        1) export XBPS_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
-        a) export XBPS_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
-        C) export XBPS_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;
-        E) export XBPS_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
-        f) export XBPS_BUILD_FORCEMODE=1; XBPS_OPTIONS+=" -f";;
-        G) export XBPS_USE_GIT_REVS=1; XBPS_OPTIONS+=" -G";;
-        g) export XBPS_DEBUG_PKGS=1; XBPS_OPTIONS+=" -g";;
-        H) export XBPS_HOSTDIR="$(readlink -f $OPTARG 2>/dev/null)"; XBPS_OPTIONS+=" -H $XBPS_HOSTDIR";;
+        1) XBPS_ARG_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
+        a) XBPS_ARG_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
+        C) XBPS_ARG_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;
+        E) XBPS_ARG_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
+        f) XBPS_ARG_BUILD_FORCEMODE=1; XBPS_OPTIONS+=" -f";;
+        G) XBPS_ARG_USE_GIT_REVS=1; XBPS_OPTIONS+=" -G";;
+        g) XBPS_ARG_DEBUG_PKGS=1; XBPS_OPTIONS+=" -g";;
+        H) XBPS_ARG_HOSTDIR="$OPTARG"; XBPS_OPTIONS+=" -H $OPTARG";;
         h) usage && exit 0;;
-        i) export XBPS_INFORMATIVE_RUN=1; XBPS_OPTIONS+=" -i";;
-        I) export XBPS_SKIP_DEPS=1; XBPS_OPTIONS+=" -I";;
-        j) export XBPS_MAKEJOBS="$OPTARG"; XBPS_OPTIONS+=" -j $OPTARG";;
+        i) XBPS_ARG_INFORMATIVE_RUN=1; XBPS_OPTIONS+=" -i";;
+        I) XBPS_ARG_SKIP_DEPS=1; XBPS_OPTIONS+=" -I";;
+        j) XBPS_ARG_MAKEJOBS="$OPTARG"; XBPS_OPTIONS+=" -j $OPTARG";;
         L) export NOCOLORS=1; XBPS_OPTIONS+=" -L";;
-        m) export XBPS_MASTERDIR=$(readlink -f $OPTARG 2>/dev/null); XBPS_OPTIONS+=" -m $XBPS_MASTERDIR";;
-        N) export XBPS_SKIP_REMOTEREPOS=1; XBPS_OPTIONS+=" -N";;
-        o) export XBPS_PKG_OPTIONS="$OPTARG"; XBPS_OPTIONS+=" -o $OPTARG";;
-        q) export XBPS_QUIET=1; XBPS_OPTIONS+=" -q";;
-        Q) export XBPS_CHECK_PKGS=1; XBPS_OPTIONS+=" -Q";;
-        r) export XBPS_ALT_REPOSITORY="$OPTARG"; XBPS_OPTIONS+=" -r $OPTARG";;
-        t) export XBPS_TEMP_MASTERDIR=1; XBPS_OPTIONS+=" -t -C";;
+        m) XBPS_ARG_MASTERDIR="$OPTARG"; XBPS_OPTIONS+=" -m $OPTARG";;
+        N) XBPS_ARG_SKIP_REMOTEREPOS=1; XBPS_OPTIONS+=" -N";;
+        o) XBPS_ARG_PKG_OPTIONS="$OPTARG"; XBPS_OPTIONS+=" -o $OPTARG";;
+        q) XBPS_ARG_QUIET=1; XBPS_OPTIONS+=" -q";;
+        Q) XBPS_ARG_CHECK_PKGS=1; XBPS_OPTIONS+=" -Q";;
+        r) XBPS_ARG_ALT_REPOSITORY="$OPTARG"; XBPS_OPTIONS+=" -r $OPTARG";;
+        t) XBPS_ARG_TEMP_MASTERDIR=1; XBPS_OPTIONS+=" -t -C";;
         V) echo "xbps-src-$XBPS_SRC_VERSION $(xbps-uhelper -V)" && exit 0;;
         --) shift; break;;
     esac
@@ -420,6 +425,48 @@ else
 fi
 # Read settings from config file
 [ -s "$XBPS_CONFIG_FILE" ] && . $XBPS_CONFIG_FILE &>/dev/null
+
+# Set options passed on command line, after configuration files have been read
+[ -n "$XBPS_ARG_BUILD_ONLY_ONE_PKG" ] && XBPS_BUILD_ONLY_ONE_PKG=yes
+[ -n "$XBPS_ARG_SKIP_REMOTEREPOS" ] && XBPS_SKIP_REMOTEREPOS=1
+[ -n "$XBPS_ARG_BUILD_FORCEMODE" ] && XBPS_BUILD_FORCEMODE=1
+[ -n "$XBPS_ARG_INFORMATIVE_RUN" ] && XBPS_INFORMATIVE_RUN=1
+[ -n "$XBPS_ARG_TEMP_MASTERDIR" ] && XBPS_TEMP_MASTERDIR=1
+[ -n "$XBPS_ARG_BINPKG_EXISTS" ] && XBPS_BINPKG_EXISTS=1
+[ -n "$XBPS_ARG_USE_GIT_REVS" ] && XBPS_USE_GIT_REVS=1
+[ -n "$XBPS_ARG_CHECK_PKGS" ] && XBPS_CHECK_PKGS=1
+[ -n "$XBPS_ARG_DEBUG_PKGS" ] && XBPS_DEBUG_PKGS=1
+[ -n "$XBPS_ARG_SKIP_DEPS" ] && XBPS_SKIP_DEPS=1
+[ -n "$XBPS_ARG_KEEP_ALL" ] && XBPS_KEEP_ALL=1
+[ -n "$XBPS_ARG_QUIET" ] && XBPS_QUIET=1
+[ -n "$XBPS_ARG_ALT_REPOSITORY" ] && XBPS_ALT_REPOSITORY="$XBPS_ARG_ALT_REPOSITORY"
+[ -n "$XBPS_ARG_CROSS_BUILD" ] && XBPS_CROSS_BUILD="$XBPS_ARG_CROSS_BUILD"
+[ -n "$XBPS_ARG_MAKEJOBS" ] && XBPS_MAKEJOBS="$XBPS_ARG_MAKEJOBS"
+
+export XBPS_BUILD_ONLY_ONE_PKG XBPS_SKIP_REMOTEREPOS XBPS_BUILD_FORCEMODE \
+       XBPS_INFORMATIVE_RUN XBPS_TEMP_MASTERDIR XBPS_BINPKG_EXISTS \
+       XBPS_USE_GIT_REVS XBPS_CHECK_PKGS XBPS_DEBUG_PKGS XBPS_SKIP_DEPS \
+       XBPS_KEEP_ALL XBPS_QUIET XBPS_ALT_REPOSITORY XBPS_CROSS_BUILD \
+       XBPS_MAKEJOBS
+
+# The masterdir/hostdir variables are forced and readonly in chroot
+if [ -z "$IN_CHROOT" ]; then
+    [ -n "$XBPS_ARG_MASTERDIR" ] && XBPS_MASTERDIR="$XBPS_ARG_MASTERDIR"
+    [ -n "$XBPS_ARG_HOSTDIR" ] && XBPS_HOSTDIR="$XBPS_ARG_HOSTDIR"
+
+    # Sanitize masterdir/hostdir once set for real (resolve links)
+    export XBPS_MASTERDIR="$(readlink -f $XBPS_MASTERDIR 2>/dev/null)"
+    export XBPS_HOSTDIR="$(readlink -f $XBPS_HOSTDIR 2>/dev/null)"
+fi
+
+# If pkg options were set in config(s), merge them with command line
+if [ -n "$XBPS_ARG_PKG_OPTIONS" ]; then
+    if [ -n "$XBPS_PKG_OPTIONS" ]; then
+        export XBPS_PKG_OPTIONS+=",$XBPS_ARG_PKG_OPTIONS"
+    else
+        export XBPS_PKG_OPTIONS="$XBPS_ARG_PKG_OPTIONS"
+    fi
+fi
 
 # Forbid root unless XBPS_ALLOW_CHROOT_BREAKOUT is set
 # (for travis CI).


### PR DESCRIPTION
This way we can e.g. have `XBPS_MAKEJOBS` set in config file while overriding it with `-j`.

This also notably changes some other semantics. Particularly:

1) Links in `hostdir`/`masterdir` are now always resolved regardless of how they are provided (via arg or via config)
2) The `-o` option for `xbps-src` specifying build options merges with whatever was previously specified in config file, instead of overriding. This makes more sense overall as options specified on command line
actually apply to every package built during that run.

This PR is in preparation for support for custom configurations via `-c configname`.