### PR TITLE
mozjs60: honors sysroot when used in cross-compile

### DIFF
--- a/srcpkgs/mozjs60/patches/0002-save-and-restore-non-volatile-x28-on-arm64.patch
+++ b/srcpkgs/mozjs60/patches/0002-save-and-restore-non-volatile-x28-on-arm64.patch
@@ -13,7 +13,7 @@ Applied-upstream: 61, commit: https://hg.mozilla.org/mozilla-central/rev/800abe6
 
 diff --git a/js/src/vm/UnboxedObject.cpp b/js/src/vm/UnboxedObject.cpp
 index 35ca20d7405f..1c20a1093d13 100644
---- ajs/src/vm/UnboxedObject.cpp
+--- a/js/src/vm/UnboxedObject.cpp
 +++ b/js/src/vm/UnboxedObject.cpp
 @@ -86,9 +86,16 @@ static const uintptr_t CLEAR_CONSTRUCTOR_CODE_TOKEN = 0x1;
  #endif

--- a/srcpkgs/mozjs60/patches/0012-mozjs60.pc-honor-sysroot.patch
+++ b/srcpkgs/mozjs60/patches/0012-mozjs60.pc-honor-sysroot.patch
@@ -1,0 +1,13 @@
+ js/src/build/js.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/js/src/build/js.pc.in b/js/src/build/js.pc.in
+index 2eae393..0a6fd5c 100644
+--- a/js/src/build/js.pc.in
++++ b/js/src/build/js.pc.in
+@@ -8,4 +8,4 @@ Description: The Mozilla library for JavaScript
+ Version: @MOZILLA_VERSION@
+ @PKGCONF_REQUIRES_PRIVATE@
+ Libs: -L${libdir} -l@JS_LIBRARY_NAME@
+-Cflags: -include ${includedir}/@JS_LIBRARY_NAME@/js/RequiredDefines.h -I${includedir}/@JS_LIBRARY_NAME@
++Cflags: -include ${pc_sysrootdir}${includedir}/@JS_LIBRARY_NAME@/js/RequiredDefines.h -I${includedir}/@JS_LIBRARY_NAME@

--- a/srcpkgs/mozjs60/template
+++ b/srcpkgs/mozjs60/template
@@ -1,12 +1,14 @@
 # Template file for 'mozjs60'
 pkgname=mozjs60
 version=60.8.0
-revision=2
+revision=3
 wrksrc="firefox-${version}"
 build_wrksrc=js/src
 build_style=gnu-configure
-hostmakedepends="perl python pkg-config automake autoconf213 autoconf-archive"
+hostmakedepends="perl python pkg-config automake autoconf213 autoconf-archive
+ which"
 makedepends="icu-devel libffi-devel nspr-devel python-devel readline-devel zlib-devel"
+depends="nspr>=4.19"
 short_desc="Mozilla JavaScript interpreter and library (60.x series)"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MPL-2.0"


### PR DESCRIPTION
Preparing for cross-compiling gnome stuffs.