### PR TITLE
mozjs52: honors sysroot when used in cross-compile

### DIFF
--- a/srcpkgs/mozjs52/patches/mozjs52.pc.patch
+++ b/srcpkgs/mozjs52/patches/mozjs52.pc.patch
@@ -1,0 +1,8 @@
+--- a/js/src/js.pc.in
++++ b/js/src/js.pc.in
+@@ -8,4 +8,4 @@ Description: The Mozilla library for JavaScript
+ Version: @MOZILLA_VERSION@
+ @PKGCONF_REQUIRES_PRIVATE@
+ Libs: -L${libdir} -l@JS_LIBRARY_NAME@
+-Cflags: -include ${includedir}/@JS_LIBRARY_NAME@/js/RequiredDefines.h -I${includedir}/@JS_LIBRARY_NAME@
++Cflags: -include ${pc_sysrootdir}${includedir}/@JS_LIBRARY_NAME@/js/RequiredDefines.h -I${includedir}/@JS_LIBRARY_NAME@

--- a/srcpkgs/mozjs52/template
+++ b/srcpkgs/mozjs52/template
@@ -1,16 +1,17 @@
 # Template file for 'mozjs52'
 pkgname=mozjs52
 version=52.9.0
-revision=4
+revision=5
 wrksrc="firefox-${version}esr"
 build_wrksrc="js/src"
 build_style=gnu-configure
 hostmakedepends="perl python pkg-config automake autoconf213 autoconf-archive which"
 makedepends="icu-devel libffi-devel nspr-devel zlib-devel readline-devel"
+depends="nspr>=4.13.1"
 short_desc="Mozilla JavaScript interpreter and library (52.x series)"
-homepage="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
-license="MPL-2.0"
 maintainer="Enno Boland <gottox@voidlinux.org>"
+license="MPL-2.0"
+homepage="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
 checksum=c01d09658c53c1b3a496e353a24dad03b26b81d3b1d099abc26a06f81c199dd6
 patch_args="-Np1"


### PR DESCRIPTION
From https://autotools.io/pkgconfig/cross-compiling.html

> To design a variable to contain a path that needs to be used at build
> time, such as the path where a generation script is, you can prefix it
> in the .pc file with the built-in variable ${pc_sysrootdir}.

Fixing broken cinnamon (mozjs52's only user) cross build.

---

I have a working cross-compile cinnamon at #18826 
But the big PR take too much time in Travis.

I have cinnamon 4.4 in testing, too.