### PR TITLE
caribou: switch to python3, split libcaribou

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3799,3 +3799,4 @@ libxmpp-vala.so.0 dino-0.1.0_1
 libqlite.so.0 dino-0.1.0_1
 libmpir.so.23 mpir-3.0.0_1
 libmpirxx.so.8 mpir-3.0.0_1
+libcaribou.so.0 libcaribou-0.4.21_3

--- a/srcpkgs/caribou/patches/autostart-set-nodisplay.patch
+++ b/srcpkgs/caribou/patches/autostart-set-nodisplay.patch
@@ -1,0 +1,21 @@
+From 286582f90fbbc9b3baa6b055bba1141cc30e6e94 Mon Sep 17 00:00:00 2001
+From: Jeremy Bicha <jbicha@ubuntu.com>
+Date: Thu, 12 Oct 2017 18:14:35 -0400
+Subject: autostart: Set NoDisplay=true
+
+https://bugzilla.gnome.org/show_bug.cgi?id=788906
+https://launchpad.net/bugs/1723266
+---
+ data/caribou-autostart.desktop.in.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/caribou-autostart.desktop.in.in b/data/caribou-autostart.desktop.in.in
+index 4bd1c03..bf73a94 100644
+--- a/data/caribou-autostart.desktop.in.in
++++ b/data/caribou-autostart.desktop.in.in
+@@ -5,4 +5,5 @@ Exec=@libexecdir@/caribou
+ AutostartCondition=GSettings org.gnome.desktop.a11y.applications screen-keyboard-enabled
+ X-GNOME-AutoRestart=true
+ #X-GNOME-Autostart-Phase=Initialization
++NoDisplay=true
+ OnlyShowIn=GNOME;Unity;

--- a/srcpkgs/caribou/patches/fix-font-property-in-style.css.patch
+++ b/srcpkgs/caribou/patches/fix-font-property-in-style.css.patch
@@ -1,0 +1,26 @@
+From 13df8b92ae89c796238e669ee6ef4447a42d6355 Mon Sep 17 00:00:00 2001
+From: Jeremy Bicha <jbicha@ubuntu.com>
+Date: Fri, 1 Dec 2017 12:11:35 -0500
+Subject: style.css: Fix failure to start in GNOME Flashback
+
+The order for 'font' properties matters
+https://developer.gnome.org/gtk3/stable/chap-css-properties.html
+
+https://bugzilla.gnome.org/show_bug.cgi?id=791001
+---
+ data/antler/style.css | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/antler/style.css b/data/antler/style.css
+index 5ab6f71..4d84904 100644
+--- a/data/antler/style.css
++++ b/data/antler/style.css
+@@ -13,7 +13,7 @@
+   border-width: 0px;
+   border-radius: 2px;
+   border-image: url("dark-key-border.svg") 2 2 2 2 repeat stretch;
+-  font: Sans 14px;
++  font: 14px Sans;
+   background-image: -gtk-gradient (linear,
+ 				     left top,
+ 				     left bottom,

--- a/srcpkgs/caribou/template
+++ b/srcpkgs/caribou/template
@@ -1,16 +1,16 @@
 # Template file for 'caribou'
 pkgname=caribou
 version=0.4.21
-revision=2
+revision=3
 build_style=gnu-configure
 build_helper="gir"
-pycompile_module="$pkgname"
-configure_args="--disable-schemas-compile --disable-static --disable-gtk2-module"
-hostmakedepends="pkg-config intltool gnome-doc-utils python-gobject-devel"
-makedepends="vala-devel libxklavier-devel libgee08-devel python-gobject-devel
+configure_args="--disable-schemas-compile --disable-static --disable-gtk2-module
+ PYTHON=/usr/bin/python3"
+hostmakedepends="pkg-config intltool gnome-doc-utils python3-gobject-devel"
+makedepends="vala-devel libxklavier-devel libgee08-devel python3-gobject-devel
  clutter-devel gtk+3-devel libXtst-devel gir-freedesktop"
-depends="python-gobject python-atspi python-dbus gir-freedesktop at-spi2-atk
- desktop-file-utils"
+depends="python3-gobject python3-atspi python3-dbus gir-freedesktop at-spi2-atk
+ desktop-file-utils libcaribou>=${version}_${revision}"
 short_desc="Alternative to the Gnome On-screen Keyboard"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-only"
@@ -18,11 +18,24 @@ homepage="https://wiki.gnome.org/Projects/Caribou"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=9c43d9f4bd30f4fea7f780d4e8b14f7589107c52e9cb6bd202bd0d1c2064de55
 lib32disabled=yes
+patch_args=-Np1
+
+libcaribou_package() {
+	lib32disabled=yes
+	short_desc+=" - library"
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+		vmove usr/share/caribou
+		vmove usr/lib/girepository-1.0
+		vmove "usr/lib/gtk*"
+		vmove "usr/lib/gnome-settings-daemon*"
+	}
+}
 
 caribou-devel_package() {
 	lib32disabled=yes
 	depends="libXtst-devel libgee08-devel libxklavier-devel gtk+3-devel
-	 libxml2-devel ${sourcepkg}>=${version}_${revision}"
+	 libxml2-devel libcaribou>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/cinnamon/template
+++ b/srcpkgs/cinnamon/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon'
 pkgname=cinnamon
 version=4.2.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile
  --enable-compile-warnings=no --disable-gtk-doc"
@@ -12,7 +12,7 @@ makedepends="cjs-devel clutter-gtk-devel cinnamon-menus-devel gstreamer1-devel
  startup-notification-devel pulseaudio-devel dbus-glib-devel GConf-devel
  libgnome-keyring-devel NetworkManager-devel libcroco-devel libsoup-devel
  cinnamon-desktop-devel"
-depends=" accountsservice caribou cinnamon-settings-daemon>=${version%.*}
+depends="accountsservice libcaribou cinnamon-settings-daemon>=${version%.*}
  cinnamon-session>=${version%.*} muffin>=${version%.*}
  cinnamon-control-center>=${version%.*} cinnamon-screensaver>=${version%.*}
  cinnamon-translations>=${version%.*} nemo>=${version%.*}

--- a/srcpkgs/libcaribou
+++ b/srcpkgs/libcaribou
@@ -1,0 +1,1 @@
+caribou


### PR DESCRIPTION
- caribou can run with python 3 just fine.

- cinnamon doesn't need all files from caribou for On Screen Keyboard.
  Split them out to drop unnecessary python dependencies.

- Fix broken stylesheet for antler-keyboard