### PR TITLE
r128gain: update to 1.0.1.

### DIFF
--- a/srcpkgs/python3-ffmpeg-python/template
+++ b/srcpkgs/python3-ffmpeg-python/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-ffmpeg-python'
+pkgname=python3-ffmpeg-python
+version=0.2.0
+revision=1
+archs=noarch
+wrksrc="ffmpeg-python-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="ffmpeg python3-future"
+checkdepends="$depends python3-pytest python3-pytest-mock"
+short_desc="Python bindings for FFmpeg - with complex filtering support"
+maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
+license="Apache-2.0"
+homepage="https://github.com/kkroening/ffmpeg-python"
+distfiles="https://github.com/kkroening/ffmpeg-python/archive/${version}.tar.gz"
+checksum="01b6b7640f00585a404194a358358bdf7f4050cedcd99f41416ac8b27222c9f1"

--- a/srcpkgs/r128gain/template
+++ b/srcpkgs/r128gain/template
@@ -1,15 +1,14 @@
 # Template file for 'r128gain'
 pkgname=r128gain
-version=0.9.3
-revision=2
+version=1.0.1
+revision=1
 build_style=python3-module
-pycompile_module="r128gain"
 hostmakedepends="python3-setuptools"
-depends="python3-crcmod python3-mutagen python3-tqdm ffmpeg"
+depends="python3-crcmod python3-ffmpeg-python python3-mutagen python3-tqdm"
 checkdepends="${depends} python3-requests sox"
 short_desc="Fast audio loudness scanner & tagger (ReplayGain v2 / R128)"
 maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/desbma/r128gain"
 distfiles="https://github.com/desbma/r128gain/archive/${version}.tar.gz"
-checksum=@ddbbc03a518827e8a7bb4a7c0b8241a858ee6eabf31015f099ae0bea0dd506a1
+checksum=2c82138abb5e2f1a5a973cb549fda674d6bf250038391e954b1920076c01a194


### PR DESCRIPTION
In case anyone wonders about it, the PyPI module packaged in `python3-ffmpeg-python` is indeed called `ffmpeg-python`, **not** `ffmpeg` (which is a different module).