### PR TITLE
xbps-src: add support for specifying custom configurations

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -148,6 +148,10 @@ Options:
 
 $(print_cross_targets)
 
+-c  <configuration>
+    If specified, etc/conf.<configuration> will be used as the primary config
+    file name; etc/conf will only be attempted if that does not exist.
+
 -C  Do not remove build directory, automatic dependencies and
     package destdir after successful install.
 
@@ -334,7 +338,7 @@ readonly XBPS_SRC_VERSION="113"
 export XBPS_MACHINE=$(xbps-uhelper -C /dev/null arch)
 
 XBPS_OPTIONS=
-XBPS_OPTSTRING="1a:CEfgGhH:iIj:Lm:No:qQr:tV"
+XBPS_OPTSTRING="1a:c:CEfgGhH:iIj:Lm:No:qQr:tV"
 
 # Preprocess arguments in order to allow options before and after XBPS_TARGET.
 eval set -- $(getopt "$XBPS_OPTSTRING" "$@");
@@ -346,6 +350,7 @@ while getopts "$XBPS_OPTSTRING" opt; do
     case $opt in
         1) XBPS_ARG_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
         a) XBPS_ARG_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
+        c) XBPS_ARG_CONFIG="$OPTARG"; XBPS_OPTIONS+=" -c $OPTARG";;
         C) XBPS_ARG_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;
         E) XBPS_ARG_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
         f) XBPS_ARG_BUILD_FORCEMODE=1; XBPS_OPTIONS+=" -f";;
@@ -415,8 +420,11 @@ else
     if [ -f $XBPS_DISTDIR/etc/defaults.conf ]; then
         . $XBPS_DISTDIR/etc/defaults.conf
     fi
-    if [ -s $XBPS_DISTDIR/etc/conf ]; then
-        # Read user configuration first...
+    if [ -n "$XBPS_ARG_CONFIG" -a -s $XBPS_DISTDIR/etc/conf.$XBPS_ARG_CONFIG ]; then
+        # If specified, read custom user configuration...
+        readonly XBPS_CONFIG_FILE=$XBPS_DISTDIR/etc/conf.$XBPS_ARG_CONFIG
+    elif [ -s $XBPS_DISTDIR/etc/conf ]; then
+        # ... otherwise read generic user configuration...
         readonly XBPS_CONFIG_FILE=$XBPS_DISTDIR/etc/conf
     elif [ -s $HOME/.xbps-src.conf ]; then
         # ... fallback to ~/.xbps-src.conf otherwise.


### PR DESCRIPTION
This is useful for example with multiple hostdirs/masterdirs when you want to have configuration files for each, specifying different flags without passing it on command line every time.