### PR TITLE
dbeaver: update to 6.3.4.

### DIFF
--- a/srcpkgs/apache-maven-bin/template
+++ b/srcpkgs/apache-maven-bin/template
@@ -1,9 +1,9 @@
 # Template file for 'apache-maven-bin'
 pkgname=apache-maven-bin
 version=3.3.9
-revision=1
+revision=2
 wrksrc=apache-maven-3.3.9
-depends="virtual?java-environment"
+depends="virtual?java-environment which"
 short_desc="A tool for building and managing Java-based projects"
 maintainer="Spencer H <spencernh77@gmail.com>"
 license="Apache-2.0"

--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,6 +1,6 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=6.2.5
+version=6.3.4
 revision=1
 archs="x86_64"
 hostmakedepends="apache-maven-bin"
@@ -9,7 +9,7 @@ maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://dbeaver.io"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz"
-checksum=0eb6686f7987198e88dfd7b3ec3080fc98daef82ff8baf22e348f39de5168365
+checksum=64c7122424209d00ea8e4c3dae643d63b5de5ed5a7585ff2f672cef8afb68ecf
 nopie=true
 
 do_build() {


### PR DESCRIPTION
This also adds a missing dependency to `apache-maven-bin`.