### PR TITLE
protonmail-bridge: update to 1.2.5.

### DIFF
--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,6 +1,6 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=1.2.4
+version=1.2.5
 revision=1
 archs="x86_64"
 build_style=fetch
@@ -10,7 +10,7 @@ maintainer="Rich G <rich@richgannon.net>"
 license="custom:Commercial"
 homepage="https://protonmail.com/bridge"
 distfiles="https://protonmail.com/download/beta/protonmail-bridge_${version}-1_amd64.deb"
-checksum=2b213c2c82204fe21347c011f5ab61634bcbc0b1600f92310cc948b76fc6c6da
+checksum=90f9d1e651eb0f973c476d71859471a3e6aa73d17742c3503084e6b16f8947e1
 
 restricted=yes
 noverifyrdeps=yes


### PR DESCRIPTION
This is a simple update to the software.

The resulting package works locally.