### PR TITLE
nvidia340: fix for newer kernels

### DIFF
--- a/srcpkgs/nvidia340/files/kernel-4.11.patch
+++ b/srcpkgs/nvidia340/files/kernel-4.11.patch
@@ -1,6 +1,6 @@
---- kernel/uvm/nvidia_uvm_lite.c	2017-09-27 13:50:46.334075042 +0200
-+++ kernel/uvm/nvidia_uvm_lite.c	2017-09-27 13:56:06.358041280 +0200
-@@ -818,7 +818,11 @@
+--- a/kernel/uvm/nvidia_uvm_lite.c
++++ b/kernel/uvm/nvidia_uvm_lite.c
+@@ -820,7 +820,11 @@ done:
  }
  
  #if defined(NV_VM_OPERATIONS_STRUCT_HAS_FAULT)
@@ -12,7 +12,7 @@
  {
  #if defined(NV_VM_FAULT_HAS_ADDRESS)
      unsigned long vaddr = vmf->address;
-@@ -828,7 +832,11 @@
+@@ -830,7 +834,11 @@ int _fault(struct vm_area_struct *vma, s
      struct page *page = NULL;
      int retval;
  
@@ -24,7 +24,7 @@
  
      vmf->page = page;
  
-@@ -866,7 +874,11 @@
+@@ -868,7 +876,11 @@ static struct vm_operations_struct uvmli
  // it's dealing with anonymous mapping (see handle_pte_fault).
  //
  #if defined(NV_VM_OPERATIONS_STRUCT_HAS_FAULT)

--- a/srcpkgs/nvidia340/files/kernel-5.0.patch
+++ b/srcpkgs/nvidia340/files/kernel-5.0.patch
@@ -1,6 +1,6 @@
---- kernel/uvm/nvidia_uvm_lite.c	2019-09-10 16:26:28.674315544 +0200
-+++ kernel/uvm/nvidia_uvm_lite.c	2019-09-10 16:28:05.224054277 +0200
-@@ -820,8 +830,10 @@
+--- a/kernel/uvm/nvidia_uvm_lite.c
++++ b/kernel/uvm/nvidia_uvm_lite.c
+@@ -822,8 +822,10 @@ done:
  #if defined(NV_VM_OPERATIONS_STRUCT_HAS_FAULT)
  #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
  int _fault(struct vm_area_struct *vma, struct vm_fault *vmf)
@@ -13,7 +13,7 @@
  #endif
  {
  #if defined(NV_VM_FAULT_HAS_ADDRESS)
-@@ -876,8 +888,10 @@
+@@ -878,8 +880,10 @@ static struct vm_operations_struct uvmli
  #if defined(NV_VM_OPERATIONS_STRUCT_HAS_FAULT)
  #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0)
  int _sigbus_fault(struct vm_area_struct *vma, struct vm_fault *vmf)

--- a/srcpkgs/nvidia340/files/usercopy.patch
+++ b/srcpkgs/nvidia340/files/usercopy.patch
@@ -1,0 +1,33 @@
+--- a/kernel/nv-linux.h
++++ b/kernel/nv-linux.h
+@@ -1190,7 +1190,8 @@ typedef void irqreturn_t;
+ #ifndef PCI_CAP_ID_EXP
+ #define PCI_CAP_ID_EXP 0x10
+ #endif
+-
++#define NV_KMEM_CACHE_CREATE_FULL_USERCOPY(name, size, align, flags, useroffset, usersize, ctor) \
++    kmem_cache_create_usercopy(name, size, align, flags, useroffset, usersize, ctor)
+ /*
+  * On Linux on PPC64LE enable basic support for Linux PCI error recovery (see
+  * Documentation/PCI/pci-error-recovery.txt). Currently RM only supports error
+@@ -1199,6 +1200,9 @@ typedef void irqreturn_t;
+ #if defined(NVCPU_PPC64LE)
+ #define NV_PCI_ERROR_RECOVERY
+ #define NV_PCI_ERS_BUFFER_SIZE  0x1000
++#define NV_KMEM_CACHE_CREATE_USERCOPY(name, type)    \
++    NV_KMEM_CACHE_CREATE_FULL_USERCOPY(name, sizeof(type), 0, 0, 0, sizeof(type), NULL)
++
+ #endif
+ 
+ /*
+--- a/kernel/nv.c
++++ b/kernel/nv.c
+@@ -752,7 +752,7 @@ int __init nvidia_init_module(void)
+     NV_SPIN_LOCK_INIT(&km_lock);
+ #endif
+ 
+-    NV_KMEM_CACHE_CREATE(nv_stack_t_cache, NV_STACK_CACHE_STR, nv_stack_t);
++    NV_KMEM_CACHE_CREATE_FULL_USERCOPY(nv_stack_t_cache, NV_STACK_CACHE_STR, nv_stack_t);
+     if (nv_stack_t_cache == NULL)
+     {
+         nv_printf(NV_DBG_ERRORS, "NVRM: stack cache allocation failed!\n");

--- a/srcpkgs/nvidia340/template
+++ b/srcpkgs/nvidia340/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GeForce 8, 9, 9M, 100, 100M, 200, 300 series)"
 
 pkgname=nvidia340
 version=340.108
-revision=1
+revision=2
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:NVIDIA proprietary"
 homepage="http://www.nvidia.com"
@@ -14,6 +14,7 @@ nopie=yes
 repository=nonfree
 create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
+hostmakedepends="tar"
 depends="${pkgname}-dkms-${version}_${revision} pkg-config"
 conflicts="catalyst>=0 xserver-abi-video>24_1"
 
@@ -40,8 +41,9 @@ do_extract() {
 
 do_patch() {
 	cd ${_pkg}
-	patch -p0 < ${FILESDIR}/kernel-4.11.patch
-	patch -p0 < ${FILESDIR}/kernel-5.0.patch
+	patch -p1 < ${FILESDIR}/kernel-4.11.patch
+	patch -p1 < ${FILESDIR}/kernel-5.0.patch
+	patch -p1 < ${FILESDIR}/usercopy.patch
 }
 
 do_install() {


### PR DESCRIPTION
- Applied a fix for crashes on newer kernels, caused by API changes.
- Added `tar` extraction dependency.
- Refreshed all patches.

For testing, it is working on my laptop.

Signed-off-by: Joseph Benden <joe@benden.us>