### PR TITLE
vscode: depends xdg-utils

### DIFF
--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,10 +1,10 @@
 # Template file for 'vscode'
 pkgname=vscode
 version=1.42.0
-revision=1
+revision=2
 hostmakedepends="pkg-config python nodejs-lts-10 yarn tar"
 makedepends="libxkbfile-devel libsecret-devel"
-depends="libXtst libxkbfile nss dejavu-fonts-ttf"
+depends="libXtst libxkbfile nss dejavu-fonts-ttf xdg-utils"
 short_desc="Microsoft Code for Linux"
 maintainer="shizonic <realtiaz@gmail.com>"
 license="MIT"


### PR DESCRIPTION
Follow link functionality
doesn't work without
xdg-utils