### PR TITLE
common/shlibs: mutter: add versioned soname to shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2901,9 +2901,13 @@ libemeraldengine.so.0 emerald-0.8.14_1
 libhangul.so.1 libhangul-0.1.0_1
 libmutter-5.so.0 mutter-3.34.1_1
 libmutter-clutter-5.so mutter-3.34.1_1
+libmutter-clutter-5.so.0 mutter-3.34.1_1
+libmutter-cogl-path-5.so mutter-3.34.1_1
 libmutter-cogl-path-5.so.0 mutter-3.34.1_1
 libmutter-cogl-5.so mutter-3.34.1_1
+libmutter-cogl-5.so.0 mutter-3.34.1_1
 libmutter-cogl-pango-5.so mutter-3.34.1_1
+libmutter-cogl-pango-5.so.0 mutter-3.34.1_1
 libgeoclue-2.so.0 geoclue2-2.4.4_1
 libgepub.so.0 libgepub-0.4_1
 libslopy.so.7.4 slop-7.4_1


### PR DESCRIPTION
- mutter generates shared-object with both API version, and SONAME
  version.
- We declared unversioned SONAME (with API version in template)
- gnome-shell requires versioned SONAME when packaging.

- Fix this problem by adding both versioned and unversioned SONAME to
  shlibs list

----

As in current state, gnome-shell is failed to be packaged