### PR TITLE
postgresql 12.2

### DIFF
--- a/srcpkgs/postgresql/template
+++ b/srcpkgs/postgresql/template
@@ -1,23 +1,23 @@
 # Template file for 'postgresql'
 pkgname=postgresql
-version=9.6.16
+version=12.2
 revision=1
 build_style=gnu-configure
 make_build_target=world
 configure_args="--with-openssl --with-python
  --with-pam --datadir=/usr/share/postgresql --enable-thread-safety
- --with-perl --with-tcl --without-ldap --without-gssapi --without-krb5
+ --with-perl --without-tcl --without-ldap --without-gssapi --without-krb5
  --without-bonjour --with-libxml --with-libxslt --disable-rpath
  --with-system-tzdata=/usr/share/zoneinfo --enable-nls --with-uuid=e2fs"
 hostmakedepends="docbook2x flex gettext openjade"
 makedepends="libfl-devel libressl-devel libuuid-devel libxslt-devel pam-devel perl
- python-devel readline-devel tcl-devel"
+ python3-devel readline-devel "
 short_desc="Sophisticated open-source Object-Relational DBMS"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="PostgreSQL"
 homepage="https://www.postgresql.org"
 distfiles="https://ftp.postgresql.org/pub/source/v${version}/${pkgname}-${version}.tar.bz2"
-checksum=5c6cba9cc0df70ba2b128c4a87d0babfce7c0e2b888f70a9c8485745f66b22e7
+checksum=ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de
 
 conf_files="
 	/etc/default/${pkgname}
@@ -133,27 +133,12 @@ postgresql-plpython_package() {
 	}
 }
 
-postgresql-pltcl_package() {
-	depends="postgresql>=$version"
-	short_desc="PL/Tcl procedural language for PostgreSQL"
-	pkg_install() {
-		vmove "usr/bin/pltcl*"
-		vmove "usr/lib/postgresql/pltcl*"
-		for d in $(find ${DESTDIR}/usr/share/locale \
-		   -type f -name pltcl\*); do
-			mkdir -p ${PKGDESTDIR}/$(dirname ${d#${DESTDIR}})
-			mv ${d} ${PKGDESTDIR}/$(dirname ${d#${DESTDIR}})
-		done
-		vmove "usr/share/postgresql/*.pltcl"
-	}
-}
-
 fi # !CROSS_BUILD
 
 postgresql-client_package() {
 	short_desc="Client frontends programs for PostgreSQL"
 	pkg_install() {
-		for f in clusterdb createdb createlang createuser dropdb droplang \
+		for f in createuser dropdb \
 			dropuser pg_dump pg_dumpall pg_isready pg_restore psql reindexdb \
 			vacuumdb; do
 			vmove usr/bin/${f}


### PR DESCRIPTION
i've just created a postgres 12.2 version (up from 9.6). I did drop Tcl support from the config, and haven't looked at postgis yet.
It runs fine on my computer (x86_64)

Let me know what you think please.

Removing clusterdb from the client package seemed necessary for the build. When you install postgresql itself, clusterdb is installed