### PR TITLE
go: update to 1.13.8

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.13.7
+version=1.13.8
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=e4ad42cc5f5c19521fbbbde3680995f2546110b5c6aa2b48c3754ff7af9b41f4
+checksum=b13bf04633d4d8cf53226ebeaace8d4d2fd07ae6fa676d0844a688339debec34
 nostrip=yes
 noverifyrdeps=yes
 

--- a/srcpkgs/go1.12-bootstrap/template
+++ b/srcpkgs/go1.12-bootstrap/template
@@ -1,6 +1,6 @@
 # Template file for 'go1.12-bootstrap'
 pkgname=go1.12-bootstrap
-version=1.12.16
+version=1.12.17
 revision=1
 archs="x86_64* i686* armv[67]l* aarch64* ppc64le*"
 wrksrc="go"
@@ -21,23 +21,23 @@ fi
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*)
 		_dist_arch="amd64"
-		checksum="bf3a85d75658144c06ce986ba05e07ef08af4320089b74b1d41de3b0f340ea7e"
+		checksum="a53dd476129d496047487bfd53d021dd17e0c96895865a0e7d0469ce3db8c8d2"
 		;;
 	i686*)
 		_dist_arch="386"
-		checksum="e6ebf5622203f2ceee138af16c765818bf65b74668d5e73c1da6491c3e890a88"
+		checksum="e33fc10c0486b02a019f120996d77792d8f19aae8bfdda97350a622a65d6b824"
 		;;
 	arm*)
 		_dist_arch="armv6l"
-		checksum="2f77688eaf25d8ae58adc5164de0fc13d600705c2ebadc6e1138e5ce9ceadc41"
+		checksum="a883c806fccb3eddb26da4a1a1f8536de863aee6807ed6c99606261877af7b99"
 		;;
 	aarch64*)
 		_dist_arch="arm64"
-		checksum="a01df310bfeffc67480982cf6ad50c9b83f9aaf4ac855d5e581b95eb727bb24c"
+		checksum="9d0819cce1451abdb090071880fe8771f16a3bcee71d6f6906023d17799574e2"
 		;;
 	ppc64le*)
 		_dist_arch="ppc64le"
-		checksum="7c133932d1beae68a483dbac69bb0e1023fa08196ebee100594b79c0672ce67c"
+		checksum="dca4df132da7579c352bccd9d6f4ecb8d8d61893a84b0feffcee2bb4246114a3"
 		;;
 esac
 


### PR DESCRIPTION
Includes updated bootstrap package.