### PR TITLE
docker: update to 19.03.6 and ensure runit logging works.

### DIFF
--- a/srcpkgs/docker/files/daemon.json
+++ b/srcpkgs/docker/files/daemon.json
@@ -1,0 +1,5 @@
+{
+	"log-driver": "local",
+	"storage-driver": "overlay2",
+	"dns": ["8.8.8.8", "8.8.4.4"]
+}

--- a/srcpkgs/docker/files/docker/run
+++ b/srcpkgs/docker/files/docker/run
@@ -5,4 +5,4 @@ mountpoint -q /sys/fs/cgroup/systemd || {
     mkdir -p /sys/fs/cgroup/systemd;
     mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
 }
-exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>/dev/null
+exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>&1

--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,9 +1,10 @@
 # Template file for 'docker'
 pkgname=docker
-version=19.03.5
+version=19.03.6
 revision=1
+conf_files="/etc/docker/daemon.json"
 wrksrc="${pkgname}-ce-${version}"
-hostmakedepends="git go pkg-config curl cmake"
+hostmakedepends="git go pkg-config curl cmake tar"
 makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel
  libapparmor-devel libltdl-devel"
 depends="containerd runc"
@@ -12,7 +13,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
 homepage="http://www.docker.io"
 distfiles="https://github.com/docker/docker-ce/archive/v${version}.tar.gz"
-checksum=d7948256e32bb4c104285d78e652ba9ead898c2e4dcee05f05ede2eaba719919
+checksum=805b586f5fbc5d236ac181068f7aa345bc5ec25d8f246e46e0f3ad55a69c63d5
 
 # These are required at run-time.
 depends+=" iptables xz git"
@@ -50,6 +51,8 @@ pre_build() {
 }
 
 do_install() {
+	vmkdir etc/docker
+	vinstall ${FILESDIR}/daemon.json 640 etc/docker daemon.json
 	vbin components/engine/bundles/dynbinary-daemon/dockerd dockerd
 	vbin components/cli/build/docker docker
 	vinstall components/cli/contrib/completion/bash/docker 644 usr/share/bash-completion/completions


### PR DESCRIPTION
This patch captures all Docker logging output and forwards to the runit logging system.

In order to accomplish this goal, both an update to the runit log service and a default Docker daemon configuration were needed. I believe the top line of the `daemon.json` is required; however, the other two lines are just plainly super useful - to the point of being desirable for inclusion as the default configuration...

Signed-off-by: Joseph Benden <joe@benden.us>