### PR TITLE
gnome-panel: split devel, build with zoneinfo, gnome-flashback: cross build

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -564,6 +564,7 @@ libpackagekit-glib2.so.18 PackageKit-1.1.12_1
 libpsl.so.5 libpsl-0.20.2_1
 libsoup-2.4.so.1 libsoup-2.34.0_1
 libsoup-gnome-2.4.so.1 libsoup-gnome-2.34.0_1
+libpanel-applet.so.3 gnome-panel-3.30.0_1
 libuninum.so.5 libuninum-2.7_1
 libunique-3.0.so.0 libunique-2.91.4_1
 libwebkit2gtk-4.0.so.37 webkit2gtk-2.6.2_1

--- a/srcpkgs/gnome-flashback/template
+++ b/srcpkgs/gnome-flashback/template
@@ -2,9 +2,10 @@
 pkgname=gnome-flashback
 version=3.34.1
 revision=1
+build_helper=gir
 build_style=gnu-configure
 configure_args="--enable-compile-warnings=minimum"
-hostmakedepends="pkg-config automake glib-devel"
+hostmakedepends="pkg-config automake glib-devel gettext"
 makedepends="gtk+3-devel gsettings-desktop-schemas-devel
  libglib-devel gdk-pixbuf-devel upower-devel ibus-devel polkit-devel
  pulseaudio-devel libcanberra-devel libxcb-devel libX11-devel pango-devel
@@ -17,4 +18,3 @@ license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeFlashback"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=ddba0c9661ad93b58ccbde267f6ecbc02da2c15f9d38d87d5504f4670c2fbc77
-nocross="gobject-introspection"

--- a/srcpkgs/gnome-panel-devel
+++ b/srcpkgs/gnome-panel-devel
@@ -1,0 +1,1 @@
+gnome-panel

--- a/srcpkgs/gnome-panel/template
+++ b/srcpkgs/gnome-panel/template
@@ -1,9 +1,10 @@
 # Template file for 'gnome-panel'
 pkgname=gnome-panel
 version=3.34.1
-revision=2
+revision=3
 build_style=gnu-configure
-hostmakedepends="gettext-devel glib-devel itstool pkg-config"
+configure_args="ax_cv_zoneinfo_tzdir=/usr/share/zoneinfo"
+hostmakedepends="gettext-devel glib-devel itstool pkg-config tzdata gettext"
 makedepends="cairo-devel dconf-devel elogind-devel evolution-data-server-devel
  gdm-devel gnome-desktop-devel gnome-menus-devel gtk+3-devel libglib-devel
  libgweather-devel libwnck-devel libXrandr-devel libX11-devel pango-devel
@@ -15,3 +16,14 @@ homepage="https://wiki.gnome.org/Projects/GnomePanel"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=a6bc0255252eeb4b964bcbe55fd7908b69f914c062c5ec8dff5ac0262d29b90d
 patch_args="-Np1"
+
+gnome-panel-devel_package() {
+	depends="glib-devel gtk+3-devel ${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove usr/share/gtk-doc
+	}
+}


### PR DESCRIPTION
gnome-panel was added back at 9b6b53deec, (New package:
gnome-panel-3.30.0, 2018-10-04)

And that version provided current shlib.