### PR TITLE
volta: update to 0.7.2

### DIFF
--- a/srcpkgs/volta/template
+++ b/srcpkgs/volta/template
@@ -1,6 +1,6 @@
 # Template file for 'volta'
 pkgname=volta
-version=0.7.1
+version=0.7.2
 revision=1
 archs="x86_64 i686" # Due to volta pulling pre-built binaries later. Evil.
 build_helper="rust"
@@ -11,7 +11,7 @@ maintainer="Alex Lohr <alex.lohr@logmein.com>"
 license="BSD-2-Clause"
 homepage="https://volta.sh/"
 distfiles="https://github.com/volta-cli/volta/archive/v${version}.tar.gz"
-checksum=e53a07e167bb64103f36901423f5a377a2ea89ecfdd7a1343e69d659f99f9c1b
+checksum=2401c17a7f5033598c85db79d9027f60f94b91b27f2d62f23370f88fada618b4
 
 pre_build() {
 	cargo update --package openssl-sys --precise 0.9.53

--- a/srcpkgs/volta/update
+++ b/srcpkgs/volta/update
@@ -1,2 +1,2 @@
 site="https://github.com/volta-cli/volta/releases"
-pattern="\bv(\d+\.\d+\.\d+)\b"
+pattern="\bv\K(\d+\.\d+\.\d+)\b"


### PR DESCRIPTION
update to version 0.7.2 and add the forgotten `\K` in the update pattern