### PR TITLE
crystal: update to 0.33.0.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,10 +1,10 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.32.1
+version=0.33.0
 revision=1
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
-_bootstrapversion=0.32.1
+_bootstrapversion=0.33.0
 _bootstraprevision=1
 hostmakedepends="which tar git llvm8 pkg-config"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -19,7 +19,7 @@ homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="66b62d0fb5bfa6547f285eb520f7fd0bc57bc994babf54cb8e7a61e613c79399
+checksum="88f08685f172e98f01f93f1a83fc3548c6d28df19a39c91859b167a796730289
  90f230c87cc7b94ca845e6fe34f2523edcadb562d715daaf98603edfa2a94d65"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -32,11 +32,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" 0c31fd8813e453b6aef77c5c5e502933d94bd8937878ae69d39b841e0fca97d7"
+		checksum+=" 9b9e078e9ba24fb97ee591d5f0a57c88cd018bd85ed6bdde9a30e5834b158128"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 3a56082403133684dc0c1326a2cefbea9544f91b39b23b64cf1034f6f3deee9f"
+		checksum+=" 7b5b4a9356993503b5c517be24d574d473abf2abc8b0dc5aff74bc93955ba187"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"
@@ -97,7 +97,6 @@ do_install() {
 	vcopy docs/* /usr/share/doc/crystal/api
 	vcopy src/* /usr/lib/crystal
 	vbin .build/crystal crystal
-	vlicense LICENSE
 	vman man/crystal.1
 	vbin shards/bin/shards
 	cp shards/LICENSE ${DESTDIR}/usr/share/licenses/shards


### PR DESCRIPTION
- Compilation was locally tested with both i686 and x86_64
- Package was locally installed on x86_64, `crystal` and `shards` work good
- Issue with multi-threading: it is (still) not possible to compile programs with the `-Dpreview_mt` flag. See #14858

I deleted the installation of the license because `xlint` complained with the following message:
```
template:100: license Apache-2.0 should not be installed
```