### PR TITLE
kmail: does not segfault on musl anymore

### DIFF
--- a/srcpkgs/kmail/template
+++ b/srcpkgs/kmail/template
@@ -16,7 +16,3 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="https://userbase.kde.org/KMail"
 distfiles="${KDE_SITE}/release-service/${version}/src/kmail-${version}.tar.xz"
 checksum=1168620b9571e29218332781cddd29e642cb05d3e186f6b294589e008a417025
-
-case $XBPS_TARGET_MACHINE in
-	*-musl) broken="segfaults on start";;
-esac


### PR DESCRIPTION
KMail builds and runs just fine on my x86_64-musl system.

I have not tested on i386/arm* because I've got a very poor internet connection at the moment…