### PR TITLE
minidlna: add runit logging

### DIFF
--- a/srcpkgs/minidlna/files/minidlnad/log/run
+++ b/srcpkgs/minidlna/files/minidlnad/log/run
@@ -1,0 +1,1 @@
+/usr/bin/vlogger

--- a/srcpkgs/minidlna/template
+++ b/srcpkgs/minidlna/template
@@ -1,14 +1,12 @@
 # Template file for 'minidlna'
 pkgname=minidlna
 version=1.2.1
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="
  --sbindir=/usr/bin
  --with-db-path=/var/db/minidlna
  --with-os-url=http://www.voidlinux.org"
-system_accounts="minidlna"
-minidlna_homedir="/var/lib/minidlna"
 conf_files="/etc/minidlna.conf"
 make_dirs="
  /var/lib/minidlna 0750 minidlna minidlna
@@ -22,6 +20,9 @@ license="BSD, GPL-2"
 homepage="http://minidlna.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=67388ba23ab0c7033557a32084804f796aa2a796db7bb2b770fb76ac2a742eec
+
+system_accounts="minidlna"
+minidlna_homedir="/var/lib/minidlna"
 
 post_install() {
 	vlicense LICENCE.miniupnpd # This one is BSD. COPYING is GPL-2


### PR DESCRIPTION
This patch introduces runit-based logging to the package.

Also fixed a few `xlint` complaints.

Signed-off-by: Joseph Benden <joe@benden.us>