### PR TITLE
add free version of master pdf editor

### DIFF
--- a/srcpkgs/master-pdf-editor-free/template
+++ b/srcpkgs/master-pdf-editor-free/template
@@ -1,0 +1,24 @@
+# Template file for 'master-pdf-editor-free'
+pkgname=master-pdf-editor-free
+version=4.3.89
+revision=1
+archs="x86_64"
+wrksrc="master-pdf-editor-4"
+depends="desktop-file-utils"
+short_desc="Multifunctional PDF Editor; the Old Watermark Free Version"
+maintainer="Uros Perisic <uros.m.perisic@gmail.com>"
+license="custom:Proprietary"
+homepage="https://code-industry.net/free-pdf-editor/"
+distfiles="https://code-industry.net/public/master-pdf-editor-${version}_qt5.amd64.tar.gz"
+checksum=ac77db75bcc5f2bce21d98a55c07176e15682b0abe5a83708c53d38721fdab4c
+nostrip=yes
+repository=nonfree
+
+do_install() {
+	vlicense license.txt
+	vinstall masterpdfeditor4.desktop 644 usr/share/applications
+	rm {license.txt,masterpdfeditor4.desktop}
+
+	vmkdir opt/master-pdf-editor-4
+	vcopy * opt/master-pdf-editor-4
+}

--- a/srcpkgs/master-pdf-editor-free/update
+++ b/srcpkgs/master-pdf-editor-free/update
@@ -1,0 +1,1 @@
+pattern="master-pdf-editor-\K[\d.]+(?=[-_]qt5.amd64\.tar\.)"


### PR DESCRIPTION
[This page](https://www.linuxuprising.com/2019/04/download-master-pdf-editor-4-for-linux.html) explains why this package is a useful addition. Basically version 5 is useless unless you want a watermark on every document you edit. But version 4 is free (as in beer) and less limited.

This is my first contribution, so please let me know if I made any mistakes :)