### PR TITLE
nvidia340: redo kernel patch

### DIFF
--- a/srcpkgs/nvidia340/files/kernel-5.5.patch
+++ b/srcpkgs/nvidia340/files/kernel-5.5.patch
@@ -1,0 +1,9 @@
+--- a/kernel/uvm/dkms.conf.fragment	2020-02-16 09:05:34.563363440 -0700
++++ b/kernel/uvm/dkms.conf.fragment	2020-02-16 09:06:02.720504874 -0700
+@@ -1,5 +1,5 @@
+ BUILT_MODULE_NAME[1]="${PACKAGE_NAME}-uvm"
+ BUILT_MODULE_LOCATION[1]="uvm/"
+ DEST_MODULE_LOCATION[1]="/kernel/drivers/video"
+-MAKE[0]+="; make -C uvm module KERNEL_UNAME=${kernelver} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/uvm"
++MAKE[0]+="; make -C uvm module KERNEL_UNAME=${kernelver} KBUILD_EXTMOD=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/uvm KBUILD_EXTRA_SYMBOLS=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build/Module.symvers"
+ CLEAN+="; make -C uvm clean"

--- a/srcpkgs/nvidia340/files/usercopy.patch
+++ b/srcpkgs/nvidia340/files/usercopy.patch
@@ -14,10 +14,10 @@
  #if defined(NVCPU_PPC64LE)
  #define NV_PCI_ERROR_RECOVERY
  #define NV_PCI_ERS_BUFFER_SIZE  0x1000
+ #endif
 +#define NV_KMEM_CACHE_CREATE_USERCOPY(name, type)    \
 +    NV_KMEM_CACHE_CREATE_FULL_USERCOPY(name, sizeof(type), 0, 0, 0, sizeof(type), NULL)
 +
- #endif
  
  /*
 --- a/kernel/nv.c
@@ -27,7 +27,7 @@
  #endif
  
 -    NV_KMEM_CACHE_CREATE(nv_stack_t_cache, NV_STACK_CACHE_STR, nv_stack_t);
-+    NV_KMEM_CACHE_CREATE_FULL_USERCOPY(nv_stack_t_cache, NV_STACK_CACHE_STR, nv_stack_t);
++    nv_stack_t_cache = NV_KMEM_CACHE_CREATE_USERCOPY(NV_STACK_CACHE_STR, nv_stack_t);
      if (nv_stack_t_cache == NULL)
      {
          nv_printf(NV_DBG_ERRORS, "NVRM: stack cache allocation failed!\n");

--- a/srcpkgs/nvidia340/template
+++ b/srcpkgs/nvidia340/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GeForce 8, 9, 9M, 100, 100M, 200, 300 series)"
 
 pkgname=nvidia340
 version=340.108
-revision=2
+revision=3
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:NVIDIA proprietary"
 homepage="http://www.nvidia.com"
@@ -44,6 +44,7 @@ do_patch() {
 	patch -p1 < ${FILESDIR}/kernel-4.11.patch
 	patch -p1 < ${FILESDIR}/kernel-5.0.patch
 	patch -p1 < ${FILESDIR}/usercopy.patch
+	patch -p1 < ${FILESDIR}/kernel-5.5.patch
 }
 
 do_install() {


### PR DESCRIPTION
Fixes: #19199 (nvidia340: broken with linux5.4)

Tested install against linux5.3 through linux5.5.