### PR TITLE
terminus-font: include 75-yes-terminus.conf and license

### DIFF
--- a/srcpkgs/terminus-font/template
+++ b/srcpkgs/terminus-font/template
@@ -1,18 +1,24 @@
 # Template file for 'terminus-font'
 pkgname=terminus-font
 version=4.48
-revision=1
+revision=2
 archs=noarch
-font_dirs="/usr/share/fonts/X11/misc"
 build_style=gnu-configure
 configure_args="--x11dir=${font_dirs}
  --psfdir=/usr/share/kbd/consolefonts"
 make_install_args="install install-pcf-8bit"
 hostmakedepends="python3 bdftopcf font-util"
 depends="font-util"
-short_desc="A clean, fixed width bitmap font"
+short_desc="Clean, fixed width bitmap font"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="OFL-1.1, GPL-2.0-or-later"
 homepage="http://terminus-font.sourceforge.net/"
-license="OFL-1.1, GPL-2"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=34799c8dd5cec7db8016b4a615820dfb43b395575afbb24fc17ee19c869c94af
+
+font_dirs="/usr/share/fonts/X11/misc"
+
+post_install() {
+	vlicense OFL.TXT OFL.txt
+	vinstall 75-yes-terminus.conf 644 etc/fonts/conf.avail
+}


### PR DESCRIPTION
If one enables `/usr/share/fontconfig/conf.avail/70-no-bitmaps.conf` (by symlinking into `/etc/fonts/conf.d`) then terminus font, being bitmap, becomes disabled.

The file `75-yes-terminus.conf` enables terminus font even when `70-no-bitmaps.conf` is enabled.