### PR TITLE
crystal: upgrade to llvm9

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,16 +1,16 @@
 # Template file for 'crystal'
 pkgname=crystal
 version=0.33.0
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
 _bootstrapversion=0.33.0
 _bootstraprevision=1
-hostmakedepends="which tar git llvm8 pkg-config"
+hostmakedepends="which tar git llvm9 pkg-config"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
  libxml2-devel"
 depends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
- libxml2-devel gmp-devel libressl-devel llvm8 gcc pkg-config"
+ libxml2-devel gmp-devel libressl-devel llvm9 gcc pkg-config"
 checkdepends="readline-devel libyaml-devel gmp-devel libressl-devel"
 short_desc="Crystal Programming Language"
 maintainer="lvmbdv <ata.kuyumcu@protonmail.com>"


### PR DESCRIPTION
LLVM9 support was not announced (due to having non-breaking changes). Arch has been building with LLVM9 since 0.31.1-4, [source](https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/crystal&id=33c30ed89d3a614862162d3e61085cc54c0e87b8).

Tested locally on x86_64 (both `crystal` and `shards`).

cc @gcat432 