### PR TITLE
docker: remove daemon.json configuration

### DIFF
--- a/srcpkgs/docker/files/daemon.json
+++ b/srcpkgs/docker/files/daemon.json
@@ -1,5 +1,0 @@
-{
-	"log-driver": "local",
-	"storage-driver": "overlay2",
-	"dns": ["8.8.8.8", "8.8.4.4"]
-}

--- a/srcpkgs/docker/files/docker/log/run
+++ b/srcpkgs/docker/files/docker/log/run
@@ -1,2 +1,1 @@
-#!/bin/sh
-exec logger -t docker
+/usr/bin/vlogger

--- a/srcpkgs/docker/template
+++ b/srcpkgs/docker/template
@@ -1,8 +1,7 @@
 # Template file for 'docker'
 pkgname=docker
 version=19.03.6
-revision=1
-conf_files="/etc/docker/daemon.json"
+revision=2
 wrksrc="${pkgname}-ce-${version}"
 hostmakedepends="git go pkg-config curl cmake tar"
 makedepends="libbtrfs-devel sqlite-devel device-mapper-devel libseccomp-devel
@@ -51,8 +50,6 @@ pre_build() {
 }
 
 do_install() {
-	vmkdir etc/docker
-	vinstall ${FILESDIR}/daemon.json 640 etc/docker daemon.json
 	vbin components/engine/bundles/dynbinary-daemon/dockerd dockerd
 	vbin components/cli/build/docker docker
 	vinstall components/cli/contrib/completion/bash/docker 644 usr/share/bash-completion/completions


### PR DESCRIPTION
While it would be nice to have a default working configuration, it causes too many problems for existing installations. At this time, it has been deemed best to undo the `daemon.json` configuration.

I've also opted to not go with the use of runit `conf`, as it causes the same set of problems. For more information, see #19115.

Fixes: #19202 (Latest docker update causes issues on btrfs)
Signed-off-by: Joseph Benden <joe@benden.us>