### PR TITLE
dante: enable preload support

### DIFF
--- a/srcpkgs/dante/template
+++ b/srcpkgs/dante/template
@@ -1,7 +1,7 @@
 # Template file for 'dante'
 pkgname=dante
 version=1.4.2
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="tar automake libtool"
 short_desc="SOCKS server and client"
@@ -10,6 +10,10 @@ license="MIT-CMU"
 homepage="http://www.inet.no/dante/index.html"
 distfiles="http://www.inet.no/dante/files/dante-${version}.tar.gz"
 checksum=4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7
+
+if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+	configure_args="--with-libc=libc.so.6"
+fi
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
Configure script does not detect preloading support unless file /etc/ld.so.cache exists.