### PR TITLE
hplip: add missing dependency also for hplip-gui

### DIFF
--- a/srcpkgs/hplip/template
+++ b/srcpkgs/hplip/template
@@ -1,7 +1,7 @@
 # Template file for 'hplip'
 pkgname=hplip
 version=3.19.12
-revision=3
+revision=4
 build_style=gnu-configure
 pycompile_dirs="usr/share/hplip"
 configure_args="
@@ -70,7 +70,7 @@ do_install() {
 
 hplip-gui_package() {
 	depends="python3-gobject python3-dbus desktop-file-utils
-	 foomatic-db foomatic-db-engine python3-PyQt5-dbus"
+	 foomatic-db foomatic-db-engine python3-distro python3-PyQt5-dbus"
 	short_desc+=" (with GUI)"
 	conflicts="hplip"
 	pkg_install() {


### PR DESCRIPTION
Commit dda0442eaef58e8cf71ea424fe0ab8eeb862529f added python3-distro
dependency, but only for main package hplip. hplip-gui should have it
too.