### PR TITLE
Deprecate WildMidi in favor of wildmidi and libwildmidi

### DIFF
--- a/srcpkgs/WildMidi/INSTALL.msg
+++ b/srcpkgs/WildMidi/INSTALL.msg
@@ -1,6 +1,3 @@
-For MIDI playing and sequencing, WildMidi requires a patchset (or sound fonts).
-
-The 'freepats' package provides a patchset compatible with TiMidity and WildMidi, as well as
-an example configuration file that can be copied to /etc/wildmidi/wildmidi.cfg
-
-Please refer to the wildmidi.cfg(5) manpage for more details.
+This package (WildMidi) was replaced by the wildmidi and libwildmidi packages.
+You can simply install those and uninstall this package.
+This package will be fully removed from the repos on 2020-4-20.

--- a/srcpkgs/WildMidi/template
+++ b/srcpkgs/WildMidi/template
@@ -1,24 +1,16 @@
 # Template file for 'WildMidi'
 pkgname=WildMidi
 version=0.4.3
-revision=1
+revision=2
 wrksrc="wildmidi-wildmidi-${version}"
-build_style=cmake
-makedepends="alsa-lib-devel libopenal-devel"
-short_desc="Core softsynth library that can be used with other applications"
+build_style=meta
+depends="wildmidi"
+short_desc="Core softsynth library and player (removed package)"
 maintainer="oreo639 <oreo6391@gmail.com>"
 license="GPL-3.0-or-later, LGPL-3.0-only"
 homepage="https://www.mindwerks.net/projects/wildmidi/"
-distfiles="https://github.com/Mindwerks/wildmidi/archive/wildmidi-${version}.tar.gz"
-checksum=498e5a96455bb4b91b37188ad6dcb070824e92c44f5ed452b90adbaec8eef3c5
 
 WildMidi-devel_package() {
+	depends="libwildmidi-devel"
 	short_desc+=" - development files"
-	depends="${makedepends} WildMidi>=${version}_${revision}"
-	pkg_install() {
-		vmove usr/include
-		vmove "usr/lib/*.so"
-		vmove usr/lib/pkgconfig
-		vmove usr/share/man/man3
-	}
 }

--- a/srcpkgs/wildmidi/template
+++ b/srcpkgs/wildmidi/template
@@ -1,20 +1,20 @@
 # Template file for 'wildmidi'
 pkgname=wildmidi
 version=0.4.3
-revision=3
+revision=4
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=cmake
 configure_args="-DWANT_ALSA=1 -DWANT_OSS=1 -DWANT_OPENAL=1"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel libopenal-devel"
 depends="libwildmidi"
-short_desc="Simple software midi player"
+short_desc="Simple software midi player and core softsinth library"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="GPL-3.0-or-later"
+license="GPL-3.0-or-later, LGPL-3.0-only"
 homepage="http://www.mindwerks.net/projects/wildmidi"
 distfiles="https://github.com/Mindwerks/${pkgname}/archive/${pkgname}-${version}.tar.gz"
 checksum=498e5a96455bb4b91b37188ad6dcb070824e92c44f5ed452b90adbaec8eef3c5
-replaces="WildMidi>=0"
+replaces="WildMidi>=0 WildMidi-devel>=0"
 
 post_install() {
 	vsed -i cfg/wildmidi.cfg -e "s;/usr/share/midi/freepats;/usr/share/freepats;"


### PR DESCRIPTION
The wildmidi package was created to replace WildMidi, but the WildMidi package was not removed, this may create confusion.

Now it will automatically install wildmidi if you have WildMidi installed.

Sorry I didn't notice this sooner.