### PR TITLE
mergerfs: orphan package.

### DIFF
--- a/srcpkgs/mergerfs/template
+++ b/srcpkgs/mergerfs/template
@@ -1,14 +1,14 @@
 # Template file for 'mergerfs'
 pkgname=mergerfs
 version=2.25.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="INTERNAL_FUSE=0"
 make_install_args="${make_build_args}"
-hostmakedepends="automake libtool pandoc pkg-config"
+hostmakedepends="automake libtool pandoc pkg-config which"
 makedepends="fuse-devel"
 short_desc="FUSE union filesystem"
-maintainer="Noel Cower <ncower@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://github.com/trapexit/mergerfs"
 distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.gz"


### PR DESCRIPTION
Abandoning the package since there's no sign that they'll stop using
a modified, internal fork of libfuse, and I don't intend to maintain
patches against something like that.