### PR TITLE
lapack: update to 3.9.0.

### DIFF
--- a/srcpkgs/lapack/patches/Restore-missing-prototypes-for-deprecated-LAPACK-fun.patch
+++ b/srcpkgs/lapack/patches/Restore-missing-prototypes-for-deprecated-LAPACK-fun.patch
@@ -1,0 +1,141 @@
+From 87536aa3c8bb0af00f66088fb6ac05d87509e011 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9bastien=20Villemot?= <sebastien@debian.org>
+Date: Sat, 23 Nov 2019 12:22:20 +0100
+Subject: [PATCH] Restore missing prototypes for deprecated LAPACK functions
+
+Some LAPACK functions prototypes were inadvertedly dropped in 3.9.0. As a
+consequence, LAPACKE has several unresolved symbols.
+
+Closes #365
+---
+ LAPACKE/include/lapack.h | 100 +++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 100 insertions(+)
+
+diff --git LAPACKE/include/lapack.h LAPACKE/include/lapack.h
+index 3f425325..5c131d84 100644
+--- LAPACKE/include/lapack.h
++++ LAPACKE/include/lapack.h
+@@ -1842,6 +1842,28 @@ void LAPACK_zgeqlf(
+     lapack_complex_double* work, lapack_int const* lwork,
+     lapack_int* info );
+ 
++#define LAPACK_sgeqpf LAPACK_GLOBAL(sgeqpf,SGEQPF)
++void LAPACK_sgeqpf( lapack_int* m, lapack_int* n, float* a, lapack_int* lda,
++                    lapack_int* jpvt, float* tau, float* work,
++                    lapack_int *info );
++
++#define LAPACK_dgeqpf LAPACK_GLOBAL(dgeqpf,DGEQPF)
++void LAPACK_dgeqpf( lapack_int* m, lapack_int* n, double* a, lapack_int* lda,
++                    lapack_int* jpvt, double* tau, double* work,
++                    lapack_int *info );
++
++#define LAPACK_cgeqpf LAPACK_GLOBAL(cgeqpf,CGEQPF)
++void LAPACK_cgeqpf( lapack_int* m, lapack_int* n, lapack_complex_float* a,
++                    lapack_int* lda, lapack_int* jpvt,
++                    lapack_complex_float* tau, lapack_complex_float* work,
++                    float* rwork, lapack_int *info );
++
++#define LAPACK_zgeqpf LAPACK_GLOBAL(zgeqpf,ZGEQPF)
++void LAPACK_zgeqpf( lapack_int* m, lapack_int* n, lapack_complex_double* a,
++                    lapack_int* lda, lapack_int* jpvt,
++                    lapack_complex_double* tau, lapack_complex_double* work,
++                    double* rwork, lapack_int *info );
++
+ #define LAPACK_cgeqp3 LAPACK_GLOBAL(cgeqp3,CGEQP3)
+ void LAPACK_cgeqp3(
+     lapack_int const* m, lapack_int const* n,
+@@ -3617,6 +3639,47 @@ void LAPACK_zggrqf(
+     lapack_complex_double* work, lapack_int const* lwork,
+     lapack_int* info );
+ 
++#define LAPACK_sggsvd LAPACK_GLOBAL(sggsvd,SGGSVD)
++lapack_int LAPACKE_sggsvd( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int n, lapack_int p,
++                           lapack_int* k, lapack_int* l, float* a,
++                           lapack_int lda, float* b, lapack_int ldb,
++                           float* alpha, float* beta, float* u, lapack_int ldu,
++                           float* v, lapack_int ldv, float* q, lapack_int ldq,
++                           lapack_int* iwork );
++
++#define LAPACK_dggsvd LAPACK_GLOBAL(dggsvd,DGGSVD)
++lapack_int LAPACKE_dggsvd( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int n, lapack_int p,
++                           lapack_int* k, lapack_int* l, double* a,
++                           lapack_int lda, double* b, lapack_int ldb,
++                           double* alpha, double* beta, double* u,
++                           lapack_int ldu, double* v, lapack_int ldv, double* q,
++                           lapack_int ldq, lapack_int* iwork );
++
++#define LAPACK_cggsvd LAPACK_GLOBAL(cggsvd,CGGSVD)
++lapack_int LAPACKE_cggsvd( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int n, lapack_int p,
++                           lapack_int* k, lapack_int* l,
++                           lapack_complex_float* a, lapack_int lda,
++                           lapack_complex_float* b, lapack_int ldb,
++                           float* alpha, float* beta, lapack_complex_float* u,
++                           lapack_int ldu, lapack_complex_float* v,
++                           lapack_int ldv, lapack_complex_float* q,
++                           lapack_int ldq, lapack_int* iwork );
++
++#define LAPACK_zggsvd LAPACK_GLOBAL(zggsvd,ZGGSVD)
++lapack_int LAPACKE_zggsvd( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int n, lapack_int p,
++                           lapack_int* k, lapack_int* l,
++                           lapack_complex_double* a, lapack_int lda,
++                           lapack_complex_double* b, lapack_int ldb,
++                           double* alpha, double* beta,
++                           lapack_complex_double* u, lapack_int ldu,
++                           lapack_complex_double* v, lapack_int ldv,
++                           lapack_complex_double* q, lapack_int ldq,
++                           lapack_int* iwork );
++
+ #define LAPACK_cggsvd3 LAPACK_GLOBAL(cggsvd3,CGGSVD3)
+ void LAPACK_cggsvd3(
+     char const* jobu, char const* jobv, char const* jobq,
+@@ -3679,6 +3742,43 @@ void LAPACK_zggsvd3(
+     lapack_int* iwork,
+     lapack_int* info );
+ 
++#define LAPACK_sggsvp LAPACK_GLOBAL(sggsvp,SGGSVP)
++lapack_int LAPACKE_sggsvp( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int p, lapack_int n, float* a,
++                           lapack_int lda, float* b, lapack_int ldb, float tola,
++                           float tolb, lapack_int* k, lapack_int* l, float* u,
++                           lapack_int ldu, float* v, lapack_int ldv, float* q,
++                           lapack_int ldq );
++
++#define LAPACK_dggsvp LAPACK_GLOBAL(dggsvp,DGGSVP)
++lapack_int LAPACKE_dggsvp( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int p, lapack_int n, double* a,
++                           lapack_int lda, double* b, lapack_int ldb,
++                           double tola, double tolb, lapack_int* k,
++                           lapack_int* l, double* u, lapack_int ldu, double* v,
++                           lapack_int ldv, double* q, lapack_int ldq );
++
++#define LAPACK_cggsvp LAPACK_GLOBAL(cggsvp,CGGSVP)
++lapack_int LAPACKE_cggsvp( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int p, lapack_int n,
++                           lapack_complex_float* a, lapack_int lda,
++                           lapack_complex_float* b, lapack_int ldb, float tola,
++                           float tolb, lapack_int* k, lapack_int* l,
++                           lapack_complex_float* u, lapack_int ldu,
++                           lapack_complex_float* v, lapack_int ldv,
++                           lapack_complex_float* q, lapack_int ldq );
++
++#define LAPACK_zggsvp LAPACK_GLOBAL(zggsvp,ZGGSVP)
++lapack_int LAPACKE_zggsvp( int matrix_layout, char jobu, char jobv, char jobq,
++                           lapack_int m, lapack_int p, lapack_int n,
++                           lapack_complex_double* a, lapack_int lda,
++                           lapack_complex_double* b, lapack_int ldb,
++                           double tola, double tolb, lapack_int* k,
++                           lapack_int* l, lapack_complex_double* u,
++                           lapack_int ldu, lapack_complex_double* v,
++                           lapack_int ldv, lapack_complex_double* q,
++                           lapack_int ldq );
++
+ #define LAPACK_cggsvp3 LAPACK_GLOBAL(cggsvp3,CGGSVP3)
+ void LAPACK_cggsvp3(
+     char const* jobu, char const* jobv, char const* jobq,
+-- 
+2.24.0
+

--- a/srcpkgs/lapack/patches/cmake-make-both-static-shared.patch
+++ b/srcpkgs/lapack/patches/cmake-make-both-static-shared.patch
@@ -1,6 +1,8 @@
---- BLAS/SRC/CMakeLists.txt.orig	2017-06-18 00:46:53.000000000 +0200
-+++ BLAS/SRC/CMakeLists.txt	2017-06-28 13:04:20.081282712 +0200
-@@ -98,9 +98,15 @@
+diff --git BLAS/SRC/CMakeLists.txt BLAS/SRC/CMakeLists.txt
+index 41c48043..e3776ecd 100644
+--- BLAS/SRC/CMakeLists.txt
++++ BLAS/SRC/CMakeLists.txt
+@@ -98,9 +98,15 @@ endif()
  list(REMOVE_DUPLICATES SOURCES)
  
  add_library(blas ${SOURCES})
@@ -16,9 +18,11 @@
 +  )
  lapack_install_library(blas)
 +lapack_install_library(blas_static)
---- CBLAS/src/CMakeLists.txt.orig	2017-11-13 05:15:54.000000000 +0100
-+++ CBLAS/src/CMakeLists.txt	2018-01-16 11:56:01.647337846 +0100
-@@ -114,15 +114,22 @@
+diff --git CBLAS/src/CMakeLists.txt CBLAS/src/CMakeLists.txt
+index 90e19f81..b97d64d7 100644
+--- CBLAS/src/CMakeLists.txt
++++ CBLAS/src/CMakeLists.txt
+@@ -114,15 +114,22 @@ endif()
  list(REMOVE_DUPLICATES SOURCES)
  
  add_library(cblas ${SOURCES})
@@ -41,9 +45,11 @@
 +target_link_libraries(cblas_static PRIVATE ${BLAS_LIBRARIES})
  lapack_install_library(cblas)
 +lapack_install_library(cblas_static)
---- LAPACKE/CMakeLists.txt.orig	2017-11-13 05:15:54.000000000 +0100
-+++ LAPACKE/CMakeLists.txt	2018-01-16 11:58:08.345344106 +0100
-@@ -54,12 +54,17 @@
+diff --git LAPACKE/CMakeLists.txt LAPACKE/CMakeLists.txt
+index 0589a74b..be63bba3 100644
+--- LAPACKE/CMakeLists.txt
++++ LAPACKE/CMakeLists.txt
+@@ -73,12 +73,17 @@ endif()
  list(APPEND SOURCES ${UTILS})
  
  add_library(lapacke ${SOURCES})
@@ -59,9 +65,9 @@
 +  OUTPUT_NAME lapacke
 +  )
  target_include_directories(lapacke PUBLIC
-   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
    $<INSTALL_INTERFACE:include>
-@@ -67,10 +72,13 @@
+@@ -90,10 +95,13 @@ endif()
  
  if(LAPACKE_WITH_TMG)
    target_link_libraries(lapacke PRIVATE tmglib)
@@ -72,12 +78,14 @@
  
  lapack_install_library(lapacke)
 +lapack_install_library(lapacke_static)
- install(FILES ${LAPACKE_INCLUDE} ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
- 
- if(BUILD_TESTING)
---- SRC/CMakeLists.txt.orig	2017-06-18 00:46:53.000000000 +0200
-+++ SRC/CMakeLists.txt	2017-06-28 13:24:03.571549842 +0200
-@@ -487,16 +487,23 @@
+ install(
+   FILES ${LAPACKE_INCLUDE} ${LAPACK_BINARY_DIR}/include/lapacke_mangling.h
+   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+diff --git SRC/CMakeLists.txt SRC/CMakeLists.txt
+index f19bdd30..7a9a0661 100644
+--- SRC/CMakeLists.txt
++++ SRC/CMakeLists.txt
+@@ -501,16 +501,23 @@ endif()
  list(REMOVE_DUPLICATES SOURCES)
  
  add_library(lapack ${SOURCES})
@@ -99,9 +107,9 @@
  target_link_libraries(lapack PRIVATE ${BLAS_LIBRARIES})
 +target_link_libraries(lapack_static PRIVATE ${BLAS_LIBRARIES})
  
- if (${CMAKE_BUILD_TYPE_UPPER} STREQUAL "COVERAGE")
+ if(_is_coverage_build)
    target_link_libraries(lapack PRIVATE gcov)
-@@ -504,3 +511,4 @@
+@@ -518,3 +525,4 @@ if(_is_coverage_build)
  endif()
  
  lapack_install_library(lapack)

--- a/srcpkgs/lapack/patches/cmake-make-cblas-lapacke-soname.patch
+++ b/srcpkgs/lapack/patches/cmake-make-cblas-lapacke-soname.patch
@@ -1,7 +1,9 @@
---- CBLAS/CMakeLists.txt.orig	2016-12-24 00:01:32.000000000 +0100
-+++ CBLAS/CMakeLists.txt	2017-01-26 15:24:38.039693320 +0100
-@@ -81,5 +81,11 @@
-   DESTINATION ${LIBRARY_DIR}/cmake/cblas-${LAPACK_VERSION}
+diff --git CBLAS/CMakeLists.txt CBLAS/CMakeLists.txt
+index 04c5ab79..8fa3b7d4 100644
+--- CBLAS/CMakeLists.txt
++++ CBLAS/CMakeLists.txt
+@@ -88,6 +88,12 @@ install(FILES
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cblas-${LAPACK_VERSION}
    )
  
 +set_target_properties(
@@ -11,11 +13,14 @@
 +  )
 +
  #install(EXPORT cblas-targets
- #  DESTINATION ${LIBRARY_DIR}/cmake/cblas-${LAPACK_VERSION})
---- LAPACKE/CMakeLists.txt.orig	2016-12-24 00:01:32.000000000 +0100
-+++ LAPACKE/CMakeLists.txt	2017-01-26 15:26:04.446690679 +0100
-@@ -81,5 +81,11 @@
-   DESTINATION ${LIBRARY_DIR}/cmake/lapacke-${LAPACK_VERSION}
+ #  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cblas-${LAPACK_VERSION}
+ #  COMPONENT Development
+diff --git LAPACKE/CMakeLists.txt LAPACKE/CMakeLists.txt
+index 0589a74b..adc87a3e 100644
+--- LAPACKE/CMakeLists.txt
++++ LAPACKE/CMakeLists.txt
+@@ -126,6 +126,12 @@ install(FILES
+   COMPONENT Development
    )
  
 +set_target_properties(
@@ -25,4 +30,5 @@
 +  )
 +
  install(EXPORT lapacke-targets
-   DESTINATION ${LIBRARY_DIR}/cmake/lapacke-${LAPACK_VERSION})
+   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lapacke-${LAPACK_VERSION}
+   COMPONENT Development

--- a/srcpkgs/lapack/template
+++ b/srcpkgs/lapack/template
@@ -1,17 +1,17 @@
-# Template file for 'lapack'.
+# Template file for 'lapack'
 pkgname=lapack
-version=3.8.0
-revision=2
+version=3.9.0
+revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DCMAKE_SKIP_RPATH=ON -DBUILD_TESTING=OFF
  -DCMAKE_VERBOSE_MAKEFILE=ON -DCBLAS=ON -DLAPACKE=ON -DBUILD_DEPRECATED=ON"
 hostmakedepends="gcc-fortran"
 short_desc="Linear Algebra PACKage"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="http://www.netlib.org/lapack/"
-license="3-clause-BSD"
-distfiles="http://www.netlib.org/lapack/lapack-${version}.tar.gz"
-checksum=deb22cc4a6120bff72621155a9917f485f96ef8319ac074a7afbc68aab88bcf6
+license="BSD-3-Clause"
+homepage="https://www.netlib.org/lapack/"
+distfiles="https://github.com/Reference-LAPACK/lapack/archive/v${version}.tar.gz"
+checksum=106087f1bb5f46afdfba7f569d0cbe23dacb9a07cd24733765a0e89dbe1ad573
 
 post_install() {
 	vlicense LICENSE
@@ -21,6 +21,7 @@ lapack-devel_package() {
 	depends="blas-devel-${version}_${revision} ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
+		vmove usr/include/lapack.h
 		vmove usr/lib/cmake/lapack-${version}
 		vmove usr/lib/pkgconfig/lapack.pc
 		vmove usr/lib/liblapack.a


### PR DESCRIPTION
* reapplied existing patches
* added a follow up patch from upstream which restores some missing
  prototypes for deprecated lapack functions (we build with BUILD_DEPRECATED=ON)
* official sources are now at github