### PR TITLE
gradle: update to 6.2.

### DIFF
--- a/srcpkgs/gradle/template
+++ b/srcpkgs/gradle/template
@@ -1,9 +1,8 @@
 # Template file for 'gradle'
 pkgname=gradle
-version=6.0.1
+version=6.2
 revision=1
 archs=noarch
-hostmakedepends="unzip"
 depends="virtual?java-environment"
 short_desc="Build system for Java/C/C++ software"
 maintainer="Adrian Siekierka <kontakt@asie.pl>"
@@ -11,12 +10,12 @@ license="Apache-2.0"
 homepage="https://gradle.org/"
 changelog="https://docs.gradle.org/${version}/release-notes.html"
 distfiles="https://services.gradle.org/distributions/gradle-${version}-bin.zip"
-checksum=d364b7098b9f2e58579a3603dc0a12a1991353ac58ed339316e6762b21efba44
+checksum=b93a5f30d01195ec201e240f029c8b42d59c24086b8d1864112c83558e23cf8a
 
 do_install() {
 	vmkdir "usr/lib/gradle"
 	sed ${FILESDIR}/gradle -e "s;@VERSION@;${version};" > gradle
 	vbin gradle
-	vdoc getting-started.html
+	vdoc README
 	mv lib ${DESTDIR}/usr/lib/gradle/
 }


### PR DESCRIPTION
gradle has more licenses beyond the Apache-2.0 mentioned in the template. There are all in the LICENSE file and they are mentioned in the NOTICE that comes with the distribution archive. Should I mention every single one? The LICENSE and NOTICE files should probably be installed with vlicense...