### PR TITLE
base-chroot-musl: update to 0.66.

### DIFF
--- a/srcpkgs/base-chroot-musl
+++ b/srcpkgs/base-chroot-musl
@@ -1,0 +1,1 @@
+base-chroot

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -19,3 +19,13 @@ depends+="
  patch sed findutils diffutils make gzip coreutils
  file bsdtar ccache xbps chroot-bash chroot-grep
  chroot-gawk chroot-distcc chroot-util-linux chroot-git"
+
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
+
+base-chroot-musl_package() {
+	build_style=meta
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - transitional dummy package"
+}
+
+fi # "$XBPS_TARGET_LIBC" = musl


### PR DESCRIPTION
This way bsdtar will reach musl travis without need to release new images.

`archs=` set on subpackage does not prevent it from being built.