### PR TITLE
refind: enable page_poison by default, rewrite hook

### DIFF
--- a/srcpkgs/refind/files/kernel.post-install
+++ b/srcpkgs/refind/files/kernel.post-install
@@ -13,7 +13,7 @@ if [ "z$UPDATE_REFIND_CONF" != "z1" ]; then
 fi
 
 # Default refind.conf
-REFIND_CONF="${REFIND_CONF:-/boot/EFI/refind/refind.conf}"
+: "${REFIND_CONF:=/boot/EFI/refind/refind.conf}"
 
 zrefind_dir="${REFIND_CONF%/*}"
 mkdir -p "$zrefind_dir"
@@ -23,27 +23,9 @@ tmpfile=$(mktemp /tmp/refind.XXXXXXX)
 
 zefi_mountpoint=$(df -P "$REFIND_CONF" | awk 'NR==2{print $6}')
 zicon="${zrefind_dir#$zefi_mountpoint}/icons/os_void.png"
+zversion=$(echo "$VERSION" | sed 's/[.]/[.]/g')
 
-zprocess() {
-	has_timeout=no
-	inserted=no
-	skipping=no
-	while IFS= read -r line; do
-		if [ $skipping = yes ]
-		then
-			if [ "x$line" = "x}" ]
-			then
-				skipping=no
-			fi
-			continue
-		elif [ "x${line#timeout[[:space:]]}" != "x${line}" ]
-		then
-			has_timeout=yes
-		elif [ "$inserted" = no ] &&
-			[ "x${line#menuentry }" != "x$line" ]
-		then
-			inserted=yes
-			cat <<EOF
+zentry=$(cat <<EOF
 menuentry "Void Linux $VERSION" {
 	icon     $zicon
 	volume   "Void Linux"
@@ -52,21 +34,20 @@ menuentry "Void Linux $VERSION" {
 	options  "$OPTIONS"
 }
 EOF
-		fi
+)
 
-		if [ "x$line" = 'xmenuentry "Void Linux '"$VERSION"'" {' ]
-		then
-			skipping=yes
-		else
-			printf '%s\n' "$line"
-		fi
-	done
-	if [ $has_timeout = no ]
-	then
-		echo 'timeout 20'
-	fi
-}
-zprocess <"$REFIND_CONF" >"$tmpfile"
+<"$REFIND_CONF" \
+sed "/^menuentry \"Void Linux $zversion\" [{]\$/,/[}]/d" |
+awk -v "entry=$zentry" '
+	/^timeout / {t=1}
+	/^menuentry / && !x {print entry; x=1}
+	1
+	END {
+		if (!x) {print entry}
+		if (!t) {print "timeout 20"}
+	}
+	' \
+>"$tmpfile"
 
 mv "$tmpfile" "$REFIND_CONF"
 

--- a/srcpkgs/refind/files/kernel.post-remove
+++ b/srcpkgs/refind/files/kernel.post-remove
@@ -13,7 +13,7 @@ if [ "z$UPDATE_REFIND_CONF" != "z1" ]; then
 fi
 
 # Default refind.conf
-REFIND_CONF="${REFIND_CONF:-/boot/EFI/refind/refind.conf}"
+: "${REFIND_CONF:=/boot/EFI/refind/refind.conf}"
 
 [ -f "$REFIND_CONF" ] || exit 0
 

--- a/srcpkgs/refind/files/refind-kernel-hook.conf
+++ b/srcpkgs/refind/files/refind-kernel-hook.conf
@@ -4,19 +4,19 @@
 UPDATE_REFIND_CONF=0
 
 # refind.conf location
-# It usually stay in
+# It usually stays in
 #
 # /boot/EFI/refind/refind.conf
 # 	if you use all default configuration and EFI partition mounted to /boot
 # /boot/efi/EFI/refind/refind.conf
 # 	if using default configuration and EFI partition mounted to /boot/efi
 # /boot/EFI/BOOT/refind.conf
-# 	if you run refind-install ==usedefault and EFI partition mounted to /boot
+# 	if you run refind-install --usedefault and EFI partition mounted to /boot
 # /boot/efi/EFI/BOOT/refind.conf
 # 	likewise, EFI mounted to /boot/efi
 # /efi/EFI/refind/refind.conf
-# /eif/EFI/BOOT/refind.conf
+# /efi/EFI/BOOT/refind.conf
 REFIND_CONF=/boot/EFI/refind/refind.conf
 
 # addition kernel cmdline
-OPTIONS="quiet"
+OPTIONS="quiet page_poison=1 loglevel=4 slub_debug=P"

--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.11.4
-revision=3
+revision=4
 makedepends="gnu-efi-libs git"
 depends="bash dosfstools efibootmgr"
 short_desc="EFI boot manager utility"


### PR DESCRIPTION
- both efibootmgr and grub enable page_poison by default.
  Let's enable it with refind, too
- The old post-install hook was written (by me, myself)
  was originally written in ed, and converted to ugly-and-lengthy
  while-read-echo sh.
  Both base-minimal, base-system, and base-chroot provides some kind
  of awk, let's rewrite it in awk.