### PR TITLE
pinebookpro-uboot: update to 0.0.20200212

### DIFF
--- a/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
+++ b/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
@@ -1,26 +1,32 @@
 #!/bin/sh
 
 kver=${2}
+uuid=$(cat /etc/fstab | awk '$2 == "/" { print $1 }' | sed 's/^UUID=//')
+dev=$(blkid -U "${uuid}")
+partuuid=$(blkid -o value -s PARTUUID "${dev}")
+bootpart=$(df -P /boot | tail -1 | awk '{ print $6 }')
+bootstrip() {
+    echo ${1} | sed "s,^${bootpart}/,/,"
+}
 
 cat > /boot/boot.txt <<EOF
 # MAC address (use spaces instead of colons)
 setenv macaddr da 19 c8 7a 6d f4
 
 part uuid \${devtype} \${devnum}:\${bootpart} uuid
-setenv bootargs console=ttyS2,1500000n8 root=PARTUUID=\${uuid} rw rootwait append video=eDP-1:1920x1080@60
+setenv bootargs console=tty1 root=PARTUUID=${partuuid} rw rootwait append video=eDP-1:1920x1080@60
 setenv fdtfile rockchip/rk3399-pinebook-pro.dtb
 
-if load \${devtype} \${devnum}:\${bootpart} \${kernel_addr_r} /boot/vmlinux-${kver}; then
-  if load \${devtype} \${devnum}:\${bootpart} \${fdt_addr_r} /boot/dtbs/dtbs-${kver}/\${fdtfile}; then
+if load \${devtype} \${devnum}:\${bootpart} \${kernel_addr_r} $(bootstrip /boot/vmlinux-${kver}); then
+  if load \${devtype} \${devnum}:\${bootpart} \${fdt_addr_r} $(bootstrip /boot/dtbs/dtbs-${kver}/\${fdtfile}); then
     fdt addr \${fdt_addr_r}
     fdt resize
     fdt set /ethernet@fe300000 local-mac-address "[\${macaddr}]"
-    if load \${devtype} \${devnum}:\${bootpart} \${ramdisk_addr_r} /boot/initramfs-${kver}.img; then
-      # This upstream Uboot doesn't support compresses cpio initrd, use kernel option to
-      # load initramfs
-      setenv bootargs \${bootargs} initrd=\${ramdisk_addr_r},20M ramdisk_size=10M
+    if load \${devtype} \${devnum}:\${bootpart} \${ramdisk_addr_r} $(bootstrip /boot/initramfs-${kver}.img); then
+      booti \${kernel_addr_r} \${ramdisk_addr_r}:\${filesize} \${fdt_addr_r};
+    else
+      booti \${kernel_addr_r} - \${fdt_addr_r};
     fi;
-    booti \${kernel_addr_r} - \${fdt_addr_r};
   fi;
 fi
 EOF

--- a/srcpkgs/pinebookpro-uboot/template
+++ b/srcpkgs/pinebookpro-uboot/template
@@ -1,7 +1,8 @@
 # Template file for 'pinebookpro-uboot'
 pkgname=pinebookpro-uboot
-version=20200212
-revision=2
+reverts=20200212_1
+version=0.0.20200212
+revision=1
 _commit_uboot=365495a329c8e92ca4c134562d091df71b75845e
 _commit_atf=22d12c4148c373932a7a81e5d1c59a767e143ac2
 archs="aarch64*"


### PR DESCRIPTION
- Add support for separate '/boot' partition

- Fix optional initramfs loading

- Redirect console output to display

(These changes will be needed to enable "full" disk encryption.)
