### PR TITLE
go-ipfs: update to 0.4.23

### DIFF
--- a/srcpkgs/go-ipfs/template
+++ b/srcpkgs/go-ipfs/template
@@ -1,9 +1,7 @@
 # Template file for 'go-ipfs'
 pkgname=go-ipfs
-version=0.4.21
+version=0.4.23
 revision=1
-create_wrksrc=yes
-build_wrksrc="${pkgname}-${version}"
 build_style=go
 go_import_path="github.com/ipfs/${pkgname}"
 go_package="${go_import_path}/cmd/ipfs"
@@ -11,11 +9,11 @@ hostmakedepends="git"
 depends="fs-repo-migrations>=1.3.0"
 short_desc="Global versioned P2P merkle DAG file system"
 maintainer="Christopher Brannon <chris@the-brannons.com>"
-license="MIT Apache-2.0"
+license="MIT, Apache-2.0"
 homepage="https://ipfs.io"
 changelog="https://github.com/ipfs/go-ipfs/blob/master/CHANGELOG.md"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=88d2208ee3468baa3966998bd3dcdaafe645640653a7a6b47ce2711464a46a5a
+checksum=21a7b7bfe822d5c6a64c4848eebd6f25f18ad4c94acdd0bbb56235c7c13d38c3
 broken="go-critic@v0.0.0-20181204210945-ee9bf5809ead: invalid pseudo-version"
 
 pre_build() {


### PR DESCRIPTION
Cross-compilation is still broken.