### PR TITLE
xpra: require python3-gobject as a runtime depdency

### DIFF
--- a/srcpkgs/xpra/template
+++ b/srcpkgs/xpra/template
@@ -1,13 +1,13 @@
 # Template file for 'xpra'
 pkgname=xpra
 version=3.0.5
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="pkg-config python3-Cython"
 makedepends="ffmpeg-devel libXcomposite-devel libXrandr-devel libXtst-devel
  libvpx-devel libwebp-devel libxkbfile-devel python3-gobject-devel x264-devel
  gtk+3-devel"
-depends="cups python3-Pillow python3-cups python3-dbus
+depends="cups python3-gobject python3-Pillow python3-cups python3-dbus
  python3-lz4 python3-paramiko python3-rencode xauth xf86-video-dummy
  xorg-server-xvfb"
 short_desc="Like screen(1) for X"


### PR DESCRIPTION
Xpra in client and server mode depends on the python3 'gi' module, provided by python3-gobject, even when it's not actually displaying anything.

```
xpra start --start=/home/zdykstra/Ripcord-0.4.22-x86_64.AppImage :110 --pulseaudio=no --daemon=no

X.Org X Server 1.20.7
X Protocol Version 11, Revision 0
Build Operating System: Linux Void
Current Operating System: Linux rethe 5.5.4_1 #1 SMP Sat Feb 15 06:25:56 UTC 2020 x86_64
Kernel command line: root=zfs:zroot/ROOT/void.2019.12.08 quiet loglevel=3
Build Date: 14 January 2020  02:00:55PM
 
Current version of pixman: 0.38.4
        Before reporting problems, check http://wiki.x.org
        to make sure that you have the latest version.
Markers: (--) probed, (**) from config file, (==) default setting,
        (++) from command line, (!!) notice, (II) informational,
        (WW) warning, (EE) error, (NI) not implemented, (??) unknown.
(++) Log file: "/run/user/1000/xpra/Xorg.:110.log", Time: Thu Feb 20 10:14:01 2020
(++) Using config file: "/etc/xpra/xorg.conf"
(==) Using system config directory "/usr/share/X11/xorg.conf.d"
xpra main error:
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/xpra/scripts/main.py", line 117, in main
    return run_mode(script_file, err, options, args, mode, defaults)
  File "/usr/lib/python3.8/site-packages/xpra/scripts/main.py", line 440, in run_mode
    return run_server(error_cb, options, mode, script_file, args, current_display)
  File "/usr/lib/python3.8/site-packages/xpra/scripts/server.py", line 340, in run_server
    return do_run_server(error_cb, opts, mode, xpra_file, extra_args, desktop_display)
  File "/usr/lib/python3.8/site-packages/xpra/scripts/server.py", line 776, in do_run_server
    from xpra.x11.gtk_x11.gdk_display_source import verify_gdk_display
  File "/usr/lib/python3.8/site-packages/xpra/x11/gtk_x11/gdk_display_source.py", line 11, in <module>
    from xpra.x11.gtk3 import gdk_display_source    #@UnresolvedImport, @Reimport
  File "xpra/x11/gtk3/gdk_display_source.pyx", line 40, in init xpra.x11.gtk3.gdk_display_source
ModuleNotFoundError: No module named 'gi'

```