### PR TITLE
rpm: define sharedstatedir

### DIFF
--- a/srcpkgs/rpm/template
+++ b/srcpkgs/rpm/template
@@ -1,10 +1,10 @@
 # Template file for 'rpm'
 pkgname=rpm
 version=4.15.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-lua --with-cap --with-acl --with-external-db
- --enable-python PYTHON=python3"
+ --enable-python PYTHON=python3 --sharedstatedir=/var/lib"
 hostmakedepends="automake gettext-devel libtool nss-devel pkg-config
  python3-setuptools"
 makedepends="binutils-devel db-devel elfutils-devel file-devel libarchive-devel


### PR DESCRIPTION
solved at least part of https://github.com/void-linux/void-packages/issues/19321

```
$ xuname ; rpm --version ; rpm --eval '%{_sharedstatedir}'
Void 5.4.10_2 x86_64 GenuineIntel notuptodate rrdFFFF
RPM version 4.15.1
/var/lib
```