### PR TITLE
Python3 pytest 5.3.5

### DIFF
--- a/srcpkgs/python3-elementpath/template
+++ b/srcpkgs/python3-elementpath/template
@@ -1,0 +1,30 @@
+# Template file for 'python3-elementpath'
+pkgname=python3-elementpath
+version=1.4.1
+revision=1
+archs=noarch
+wrksrc=elementpath-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-lxml python3-xmlschema"
+short_desc="XPath 1.0/2.0 parsers and selectors for ElementTree and lxml"
+maintainer="Đoàn Trần Công Danh <congdanhqx+sgn@gmail.com>"
+license="MIT"
+homepage="https://github.com/sissaschool/elementpath"
+distfiles="${PYPI_SITE}/e/elementpath/elementpath-${version}.tar.gz"
+checksum=b29f626d690cb6f3716a65867a456c54dd679ddce7249bb2af4f37d33b83035d
+
+post_patch() {
+	# locale handling in musl is NOT that ideal,
+	# those tests is broken on musl
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		vsed -i tests/test_xpath2_parser.py \
+			-e "/compare.*Strassen.* 1/d" \
+			-e "/with self\.assertRaises(locale\.Error)/,+3d"
+	fi
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pytest/template
+++ b/srcpkgs/python3-pytest/template
@@ -1,34 +1,37 @@
 # Template file for 'python3-pytest'
 pkgname=python3-pytest
-version=5.3.4
+version=5.3.5
 revision=1
 archs=noarch
-wrksrc="${pkgname/python3-//}-${version}"
+wrksrc="pytest-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-py python3-packaging python3-attrs python3-more-itertools
  python3-atomicwrites python3-pluggy python3-wcwidth"
 checkdepends="$depends python3-argcomplete python3-hypothesis python3-mock
- python3-nose python3-requests python3-parsing tox"
+ python3-nose python3-requests python3-parsing python3-xmlschema"
 short_desc="Simple powerful testing with Python 3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://docs.pytest.org/en/latest/"
 changelog="https://docs.pytest.org/en/latest/changelog.html"
 distfiles="${PYPI_SITE}/p/pytest/pytest-${version}.tar.gz"
-checksum=1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600
+checksum=0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d
 alternatives="
  pytest:pytest:/usr/bin/pytest3
  pytest:py.test:/usr/bin/py.test3"
 
 post_patch() {
-	sed -i setup.py \
+	vsed -i setup.py \
 		-e '/setup_requires=/d' \
 		-e "s|use_scm_version=.*|version=\"${version}\",|"
+	# This test depends on tox, and/or egg-info
+	# merely check pytest and py.test were generated
+	rm testing/test_entry_points.py
 }
 
 do_check() {
-	tox -e "py${py3_ver/./}"
+	PYTHONPATH=$(pwd)/build/lib python3 -m pytest
 }
 
 post_install() {

--- a/srcpkgs/python3-xmlschema/template
+++ b/srcpkgs/python3-xmlschema/template
@@ -1,0 +1,24 @@
+# Template file for 'python3-xmlschema'
+pkgname=python3-xmlschema
+version=1.1.1
+revision=1
+archs=noarch
+wrksrc=xmlschema-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-elementpath"
+checkdepends="python3-elementpath python3-lxml"
+short_desc="XML Schema validator and decoder for Python"
+maintainer="Đoàn Trần Công Danh <congdanhqx+sgn@gmail.com>"
+license="MIT"
+homepage="https://github.com/sissaschool/xmlschema"
+distfiles="${PYPI_SITE}/x/xmlschema/xmlschema-${version}.tar.gz"
+checksum=43d4d60b032ddbe484c562d65fcdba34e85d7c3ad59f2490795740b5a579c540
+
+do_check() {
+	PYTHONPATH=$(pwd)/build/lib python3 -m unittest
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
- xmlschema is required for check pytest
- elementpath is required for check xmlschema

- check has been run for i686-glibc, x86_64 (both glibc and musl)