### PR TITLE
betterlockscreen: patch to enable call to suspend with void.

### DIFF
--- a/srcpkgs/betterlockscreen/patches/zzz.patch
+++ b/srcpkgs/betterlockscreen/patches/zzz.patch
@@ -1,0 +1,10 @@
+--- a/betterlockscreen
++++ b/betterlockscreen
+@@ -422,6 +422,6 @@
+ 
+ # Activate lockscreen
+ [[ $runlock ]] && lockselect "$lockstyle" && \
+-	{ [[ $runsuspend ]] && systemctl suspend; }
++	{ [[ $runsuspend ]] && sleep 1s && sudo zzz; }
+ 
+ exit 0

--- a/srcpkgs/betterlockscreen/template
+++ b/srcpkgs/betterlockscreen/template
@@ -1,7 +1,7 @@
 # Template file for 'betterlockscreen'
 pkgname=betterlockscreen
 version=3.0.1
-revision=2
+revision=3
 archs=noarch
 depends="ImageMagick bash bc feh i3lock-color xdpyinfo xrandr xrdb"
 short_desc="Sweet looking lockscreen for linux system"
@@ -10,6 +10,7 @@ license="MIT"
 homepage="https://github.com/pavanjadhaw/betterlockscreen"
 distfiles="https://github.com/pavanjadhaw/betterlockscreen/archive/${version}.tar.gz"
 checksum=9b80af4b93e0b35bc916a584522ecf9eb39414c8010a2e4f2bb6941fdc5faf28
+patch_args="-Np1"
 
 do_install() {
 	vbin ${pkgname}


### PR DESCRIPTION
betterlockscreen assumes you are running systemd and therefore invokes
suspend using systemctl. With the patch you can now suspend on void.
The patch also adds a 1 second delay before suspending to make sure the screen
actually locks before suspending.