### PR TITLE
rpi-kernel: update to 4.19.105.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="b95085926057a72496595843384659a82b481c43"
+_githash="e645cec69367ba4b6daf63933f48661ab4b59ee1"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.102
+version=4.19.105
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=8b72b4858ff00fede8596f6a3bd076f9316b8597a018866911c2e148b57149d9
+checksum=bcc3ea5b5b3d6d10953f73e55c43bee8a1c1997826b0299c37c18b0095c18415
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.