### PR TITLE
elogind: update to 243.7.

### DIFF
--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,6 +1,6 @@
 # Template file for 'elogind'
 pkgname=elogind
-version=243.4
+version=243.7
 revision=1
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
@@ -17,7 +17,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://github.com/elogind/elogind"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=f1098745863138e6270ea22e78a39baef9a0356b48246c5a53b34211992dc7db
+checksum=519acd207c4c16b0b962a03090cc40bbdfe12f74e8ce5b32eabc9656a6537bf5
 conf_files="/etc/elogind/*.conf"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then


### PR DESCRIPTION
Ok:                  177
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               3
Timeout:               0

on x86_64-musl and i686-glibc