### PR TITLE
docker: Use OPTS="-s=overlay2" in case OPTS is not set

### DIFF
--- a/srcpkgs/docker/files/docker/run
+++ b/srcpkgs/docker/files/docker/run
@@ -5,4 +5,5 @@ mountpoint -q /sys/fs/cgroup/systemd || {
     mkdir -p /sys/fs/cgroup/systemd;
     mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
 }
+[ -n "$OPTS" ] || OPTS="-s=overlay2"
 exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>&1


### PR DESCRIPTION
- docker daemon requires the default storage driver set in case
  multiple graphdrivers are available
- message error by docker: the real problem was this: failed to start daemon: error
      initializing graphdriver: /var/lib/docker contains several valid
      graphdrivers: overlay2, btrfs; Please cleanup or explicitly choose
      storage driver (-s <DRIVER>)