### PR TITLE
pinebookpro-uboot: clean up kernel boot arguments

### DIFF
--- a/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
+++ b/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
@@ -14,7 +14,7 @@ cat > /boot/boot.txt <<EOF
 setenv macaddr da 19 c8 7a 6d f4
 
 part uuid \${devtype} \${devnum}:\${bootpart} uuid
-setenv bootargs console=tty1 root=PARTUUID=${partuuid} rw rootwait append video=eDP-1:1920x1080@60
+setenv bootargs console=ttyS2,1500000 console=tty1 root=PARTUUID=${partuuid} rootwait video=eDP-1:1920x1080@60 loglevel=4 slub_debug=P page_poison=1
 setenv fdtfile rockchip/rk3399-pinebook-pro.dtb
 
 if load \${devtype} \${devnum}:\${bootpart} \${kernel_addr_r} $(bootstrip /boot/vmlinux-${kver}); then

--- a/srcpkgs/pinebookpro-uboot/template
+++ b/srcpkgs/pinebookpro-uboot/template
@@ -2,7 +2,7 @@
 pkgname=pinebookpro-uboot
 reverts="20200212_1 20200212_2"
 version=0.0.20200212
-revision=2
+revision=3
 _commit_uboot=365495a329c8e92ca4c134562d091df71b75845e
 _commit_atf=22d12c4148c373932a7a81e5d1c59a767e143ac2
 archs="aarch64*"


### PR DESCRIPTION
- Add serial console output

- Add arguments from default grub configuration

- Remove unneeded arguments