### PR TITLE
Per-package compression

### DIFF
--- a/common/hooks/do-pkg/00-gen-pkg.sh
+++ b/common/hooks/do-pkg/00-gen-pkg.sh
@@ -54,6 +54,9 @@ genpkg() {
 	local _alternatives="$(echo $alternatives)"
 	local _tags="$(echo $tags)"
 	local _changelog="$(echo $changelog)"
+	local _comptype_pkg="XBPS_PKG_COMPTYPE_${pkgname//[^A-Za-z0-9_]/_}"
+	_comptype_pkg="${!_comptype_pkg}"
+	local _compression="${_comptype_pkg:-${XBPS_PKG_COMPTYPE:-xz}}"
 
 	msg_normal "Creating $binpkg for repository $pkgdir ...\n"
 
@@ -82,7 +85,7 @@ genpkg() {
 		--maintainer "${maintainer}" \
 		--desc "${desc}" \
 		--pkgver "${pkgver}" \
-		--compression ${XBPS_PKG_COMPTYPE:=xz} \
+		--compression ${_compression} \
 		--quiet \
 		${PKGDESTDIR}
 	rval=$?

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -162,8 +162,7 @@ set_build_options() {
     fi
 
     for f in ${build_options}; do
-        _pkgname=${pkgname//\-/\_}
-        _pkgname=${_pkgname//\+/\_}
+        _pkgname=${pkgname//[^A-Za-z0-9_]/_}
         eval pkgopts="\$XBPS_PKG_OPTIONS_${_pkgname}"
         if [ -z "$pkgopts" -o "$pkgopts" = "" ]; then
             pkgopts=${XBPS_PKG_OPTIONS}

--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -89,6 +89,13 @@ XBPS_SUCMD="sudo /bin/sh -c"
 #XBPS_PKG_COMPTYPE=none
 
 # [OPTIONAL]
+# Set the compression format for specific package. Value set on main package
+# isn't applied to subpackages. Characters other than A-Za-z0-9_ need to be
+# replaced by underscore. See xbps-create(1) for the available formats.
+#
+#XBPS_PKG_COMPTYPE_foo_data=none
+
+# [OPTIONAL]
 # Set the repository compression format (defaults to gzip/zlib). See xbps-rindex(1)
 # for the available formats.
 #


### PR DESCRIPTION
If index, xbps and dependencies are compressed as they are, planned migration to zstd can preserve compatibilty with old xbps.