### PR TITLE
python3-keyring: remove alternatives.

### DIFF
--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
 version=18.0.1
-revision=2
+revision=3
 archs=noarch
 wrksrc="keyring-${version}"
 build_style=python3-module
-pycompile_module="keyring"
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-SecretStorage python3-entrypoints"
 short_desc="Python interface to the system keyring service"
@@ -15,7 +14,6 @@ homepage="https://github.com/jaraco/keyring"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
 checksum=67d6cc0132bd77922725fae9f18366bb314fd8f95ff4d323a4df41890a96a838
-alternatives="keyring:keyring:/usr/bin/keyring2"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
python-keyring was removed and the /usr/bin package is broken.