### PR TITLE
nestopia: add missing gtk3/libao configure args

### DIFF
--- a/srcpkgs/nestopia/template
+++ b/srcpkgs/nestopia/template
@@ -1,8 +1,9 @@
 # Template file for 'nestopia'
 pkgname=nestopia
 version=1.50
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="--enable-gui --with-ao"
 hostmakedepends="autoconf-archive automake pkg-config"
 makedepends="SDL2-devel gtk+3-devel libao-devel libarchive-devel"
 depends="desktop-file-utils hicolor-icon-theme"


### PR DESCRIPTION
GTK3 and libao dependencies was included but wasn't enabled in the build.