### PR TITLE
font-sil-andika: include Andika New Basic

### DIFF
--- a/srcpkgs/font-sil-andika/template
+++ b/srcpkgs/font-sil-andika/template
@@ -1,7 +1,8 @@
 # Template file for 'font-sil-andika'
 pkgname=font-sil-andika
+_basic_version=5.500
 version=5.000
-revision=1
+revision=2
 archs=noarch
 wrksrc="Andika-${version}"
 hostmakedepends="unzip"
@@ -10,10 +11,21 @@ short_desc="Unicode-compliant sans serif font designed especially for literacy u
 maintainer="Ivan Sokolov <ivan-p-sokolov@ya.ru>"
 license="OFL-1.1"
 homepage="https://software.sil.org/andika/"
-distfiles="https://software.sil.org/downloads/r/andika/Andika-${version}.zip"
-checksum=604b7a1194be099bdf311ef76cbce086a054fa16d2b101cfaedcf527c63df507
+distfiles="https://software.sil.org/downloads/r/andika/Andika-${version}.zip
+ https://software.sil.org/downloads/r/andika/AndikaNewBasic-${_basic_version}.zip"
+checksum="604b7a1194be099bdf311ef76cbce086a054fa16d2b101cfaedcf527c63df507
+ 18308284a3e98cd7712d057742d8d6cd040a52ec0479a1dcf92d57815f8d368a"
 font_dirs="/usr/share/fonts/SIL"
+
+post_extract() {
+	mv     ${XBPS_BUILDDIR}/AndikaNewBasic-${_basic_version}/AndikaNewBasic-*.ttf ${XBPS_BUILDDIR}/Andika-${version}/
+	rm -rf ${XBPS_BUILDDIR}/AndikaNewBasic-${_basic_version}
+}
 
 do_install() {
 	vinstall Andika-R.ttf 644 ${font_dirs}
+	vinstall AndikaNewBasic-R.ttf 644 ${font_dirs}
+	vinstall AndikaNewBasic-I.ttf 644 ${font_dirs}
+	vinstall AndikaNewBasic-B.ttf 644 ${font_dirs}
+	vinstall AndikaNewBasic-BI.ttf 644 ${font_dirs}
 }


### PR DESCRIPTION
In a nutshell, the New Basic fonts are missing IPA characters, that are conventionally always set in the regular weight upright font anyway.

[Andika > Home > Support > FAQ:](http://software.sil.org/andika/support/faq/)

> ### What is the difference between Andika and Andika New Basic?
> *    Andika New Basic has all four faces: Regular, Bold, Italic and Bold-Italic.
> *    Andika has a more complete character set comparable to Charis SIL and Doulos SIL.
> *    Andika New Basic has a limited character set, supporting only the Basic Latin and Latin-1 Supplement Unicode ranges, plus a selection of the more commonly used extended Latin characters, with miscellaneous diacritical marks, symbols and punctuation.
> *    [Character Lists for Andika vs. Andika New Basic (Andika-only in yellow)](http://software.sil.org/wp-content/uploads/sites/19/2015/12/AndikaNewBasic-5.500_vs_Andika-5.000.pdf)