### PR TITLE
apache-kafka: fix build and update to 2.4.0.

### DIFF
--- a/srcpkgs/apache-kafka/template
+++ b/srcpkgs/apache-kafka/template
@@ -1,20 +1,19 @@
 # Template file for 'apache-kafka'
 pkgname=apache-kafka
-version=2.3.0
+version=2.4.0
 revision=1
 wrksrc="kafka-${version}-src"
-hostmakedepends="gradle"
+hostmakedepends="curl which tar openjdk8"
 depends="virtual?java-runtime"
 short_desc="Distributed Streaming Platform"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://kafka.apache.org"
 distfiles="http://apache.mirrors.ionfish.org/kafka/${version}/kafka-${version}-src.tgz"
-checksum=d32cbd619e1a7fb4deae2402fa1dce56d909af19ad690c82e2d495fb5c4cfdc0
-broken="https://build.voidlinux.org/builders/x86_64_builder/builds/23103/steps/shell_3/logs/stdio"
+checksum=d09efde300c1027e0289de1a1d2da093ecce6b182250e03f05215fb044f24f8b
 
 do_configure() {
-	gradle
+	./gradlew
 }
 
 do_build() {


### PR DESCRIPTION
This fixes the build for apache-kafka.

This is the only reference I could find to the build issue (http://mail-archives.apache.org/mod_mbox/kafka-users/201911.mbox/%3CCAD5tkZZasDw3fDg3Xh0ZGiF0dMpYm8kxDqDm7OdnAEb=s31RJQ@mail.gmail.com%3E)
