### PR TITLE
python-msgpack: update to 1.0.0

### DIFF
--- a/srcpkgs/python-msgpack/template
+++ b/srcpkgs/python-msgpack/template
@@ -1,10 +1,9 @@
 # Template file for 'python-msgpack'
 pkgname=python-msgpack
-version=0.6.2
-revision=2
+version=1.0.0
+revision=1
 wrksrc="msgpack-${version}"
 build_style=python-module
-pycompile_module="msgpack"
 hostmakedepends="python-setuptools python3-setuptools"
 makedepends="python-devel python3-devel"
 checkdepends="python3-pytest"
@@ -13,14 +12,13 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/msgpack/msgpack-python"
 distfiles="${PYPI_SITE}/m/msgpack/msgpack-${version}.tar.gz"
-checksum=ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830
+checksum=9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0
 
 do_check() {
 	python3 -m pytest
 }
 
 python3-msgpack_package() {
-	pycompile_module="msgpack"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*


### PR DESCRIPTION
The Neovim plugin Deoplete complains if python-msgpack isn't version 1.0.0, I'm not 100% sure this is a release because github's treating it like it's just a tag.