### PR TITLE
ssh-audit: update to 2.1.1

### DIFF
--- a/srcpkgs/ssh-audit/template
+++ b/srcpkgs/ssh-audit/template
@@ -1,20 +1,16 @@
 # Template file for 'ssh-audit'
 pkgname=ssh-audit
-version=1.7.0
+version=2.1.1
 revision=1
-_licver=22b671e15f0c8acdaed8594d0a8ae9f7c3303452
-build_style=fetch
 archs=noarch
-python_version=3
 depends="python3"
 short_desc="SSH server auditing"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="MIT"
-homepage="https://github.com/arthepsy/ssh-audit"
-distfiles="https://raw.githubusercontent.com/arthepsy/ssh-audit/v${version}/ssh-audit.py
- https://raw.githubusercontent.com/arthepsy/ssh-audit/${_licver}/LICENSE"
-checksum="a3ff0734e1c71b0830a1ff93de2a7bce5faaa8fa893d760966de50eac24d859b
- 8de5f3aaee4a896c62a5c3010954dbe13779b9ae07addcb0380873a9830c66e8"
+homepage="https://github.com/jtesta/ssh-audit"
+distfiles="https://github.com/jtesta/ssh-audit/archive/v${version}.tar.gz"
+checksum=e70d7dfb98fa4941f07424783a2f601c9e3920eb33da53997c13b9d7d2720dcb
+python_version=3
 
 do_install() {
 	vbin ssh-audit.py ssh-audit


### PR DESCRIPTION
The original maintainer disappeared, this fork continues development.
Issue on original repo asking if the project is still active: arthepsy/ssh-audit#42

@abenson