### PR TITLE
[WIP] fd: add completions

### DIFF
--- a/srcpkgs/fd/template
+++ b/srcpkgs/fd/template
@@ -9,8 +9,23 @@ license="Apache-2.0, MIT"
 homepage="https://github.com/sharkdp/fd"
 distfiles="https://github.com/sharkdp/fd/archive/v${version}.tar.gz"
 checksum=33570ba65e7f8b438746cb92bb9bc4a6030b482a0d50db37c830c4e315877537
+lib32disabled=yes
 
 post_install() {
 	vman doc/fd.1
 	vlicense LICENSE-MIT
+
+	local completion_dir
+	if [ "$CROSS_BUILD" ]; then
+		completion_dir="${wrksrc}/target/$XBPS_CROSS_RUST_TARGET/release/build/${pkgname}-*/out"
+	else
+		completion_dir="${wrksrc}/target/$XBPS_RUST_TARGET/release/build/${pkgname}-*/out"
+	fi
+
+	vmkdir usr/share/zsh/site-functions
+	vcopy "${$completion_dir}/_${pkgname}" usr/share/zsh/site-functions
+	vmkdir usr/share/bash-completion/completions
+	vcopy "${$completion_dir}/${pkgname}.bash" usr/share/bash-completion/completions
+	vmkdir usr/share/fish/completions
+	vcopy "${$completion_dir}/${pkgname}.fish" usr/share/fish/vendor_completions.d
 }


### PR DESCRIPTION
`fd` generates completion files for most shells during compilation, but the installation step doesn't add them to destdir.

~I may need some help with this, as the current template does install them (they show up in `masterdir/destdir/fd-7.4.0/` at the correct locations after `xbps-src install fd`), but they are still missing from the package after `xbps-src pkg`. I don't understand why.~ It was a caching issue...

As for using `vcopy` instead of `vinstall`, the path where the completion files are generated contains a hash. Maybe someone versed in rust's build system knows a better way than using a glob pattern.

I also noticed, that there is now a `/usr/.crates2.json` in the package, looking into it.