### PR TITLE
build-style/cargo.sh: also delete /usr/.crates2.json

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -19,5 +19,6 @@ do_install() {
 
 	${make_cmd} install --path . --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
 		--locked ${configure_args} ${make_install_args}
-	rm "${DESTDIR}"/usr/.crates.toml
+	rm -f "${DESTDIR}"/usr/.crates.toml
+	rm -f "${DESTDIR}"/usr/.crates2.json
 }


### PR DESCRIPTION
As I noticed in #19489, current cargo versions create a `/usr/.crates2.json` during install.
Also added `-f` switch, for when some cargo version doesn't produce both. Gentoo [handles then similarly](https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/cargo.eclass#n178).