### PR TITLE
urxvt-perls: update to 2.3

### DIFF
--- a/srcpkgs/urxvt-perls/template
+++ b/srcpkgs/urxvt-perls/template
@@ -1,7 +1,7 @@
 # Template file for 'urxvt-perls'
 pkgname=urxvt-perls
-version=2.2
-revision=4
+version=2.3
+revision=1
 archs=noarch
 depends="rxvt-unicode perl"
 short_desc="Perl extensions for the rxvt-unicode terminal emulator"
@@ -9,12 +9,11 @@ maintainer="nem <nem@posteo.net>"
 license="GPL-2.0-only"
 homepage="https://github.com/muennich/urxvt-perls"
 distfiles="https://github.com/muennich/urxvt-perls/archive/${version}.tar.gz"
-checksum=c184f9a188866fef333489323576e5d2808a1cbcdb5f69b9a0be5d5e1eff8b87
+checksum=a632e4867fe285eef3f2cd6db3fff18153eb1053b95c9218bc9963d7f9927442
 
 do_install() {
-	vlicense LICENSE
-	vinstall clipboard 644 usr/lib/urxvt/perl
+	vinstall deprecated/clipboard 644 usr/lib/urxvt/perl
 	vinstall keyboard-select 644 usr/lib/urxvt/perl
-	vinstall url-select 644 usr/lib/urxvt/perl
+	vinstall deprecated/url-select 644 usr/lib/urxvt/perl
 	vdoc README.md
 }


### PR DESCRIPTION
I'm not entirely sure this should be merged. Inclusion of deprecated files is a little messy but removing them risks breaking a lot of users' setups.