### PR TITLE
openssh: move openssh-sk-helper into subpkg.

### DIFF
--- a/srcpkgs/openssh-sk-helper
+++ b/srcpkgs/openssh-sk-helper
@@ -1,0 +1,1 @@
+openssh

--- a/srcpkgs/openssh/INSTALL.msg
+++ b/srcpkgs/openssh/INSTALL.msg
@@ -1,3 +1,4 @@
 CAUTION: After updating from OpenSSH <=8.1 to OpenSSH 8.2, the existing sshd
 will not allow new connections.  **Restart OpenSSH immediately** after this
 update to ensure you still can log in!
+Install 'openssh-sk-helper' to use FIDO authenticators on the client.

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,7 +1,7 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=8.2p1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
@@ -19,7 +19,7 @@ makedepends="libedit-devel pam-devel zlib-devel
  $(vopt_if gssapi 'mit-krb5-devel') $(vopt_if ldns 'libldns-devel')
  $(vopt_if ssl 'libressl-devel') $(vopt_if fido2 'libfido2-devel')"
 short_desc="OpenSSH free Secure Shell (SSH) client and server implementation"
-maintainer="Enno Boland <gottox@voidlinux.org>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-2-Clause, ISC"
 homepage="https://www.openssh.com"
 distfiles="https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/${pkgname}-${version}.tar.gz"
@@ -31,6 +31,10 @@ make_dirs="/var/chroot/ssh 0755 root root"
 build_options="fido2 gssapi ldns ssl"
 build_options_default="fido2 ldns ssl"
 desc_option_fido2="Enable support for FIDO2 USB tokens"
+
+if [ "$build_option_fido2" ]; then
+	subpackages+=" openssh-sk-helper"
+fi
 
 CFLAGS="-Wno-format-truncation -Wno-stringop-truncation"
 
@@ -63,4 +67,13 @@ post_install() {
 
 	vinstall ${FILESDIR}/sshd.pam 644 etc/pam.d sshd
 	vsv sshd
+}
+
+openssh-sk-helper_package() {
+	short_desc+=" - client support for FIDO authenticators"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/libexec/ssh-sk-helper
+		vmove usr/share/man/man8/ssh-sk-helper.8
+	}
 }


### PR DESCRIPTION
The libfido2 dependency is only needed for clients who want to use it.