### PR TITLE
xbps-src: correctly cleanup masterdir/tmp in the 'clean' target

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -734,9 +734,11 @@ case "$XBPS_TARGET" in
             fi
             msg_normal "xbps-src: cleaning up masterdir...\n"
             # Needed to remove Go Modules
-            [ -d $XBPS_MASTERDIR/builddir ] && chmod -R +wX $XBPS_MASTERDIR/builddir
-            rm -rf $XBPS_MASTERDIR/builddir $XBPS_MASTERDIR/destdir
-            rm -f $XBPS_MASTERDIR/tmp/* >/dev/null 2>&1
+            [ -d "$XBPS_BUILDDIR" ] && chmod -R +wX $XBPS_BUILDDIR
+            rm -rf \
+                $XBPS_BUILDDIR \
+                $XBPS_DESTDIR \
+                $XBPS_MASTERDIR/tmp/* $XBPS_MASTERDIR/tmp/.*
         else
             read_pkg
             if [ -n "$CHROOT_READY" -a -z "$IN_CHROOT" ]; then


### PR DESCRIPTION
465e481b70a forgot `rm -r` when cleaning /tmp. 
As a result, `xbps-src clean` returned 1 when directories were present in /tmp
because rm returned with an (suppressed) error.

Also use the global variables for builddir and destdir, to be more consistent.