### PR TITLE
perl-Clipboard: update to 0.22.

### DIFF
--- a/srcpkgs/perl-Clipboard/template
+++ b/srcpkgs/perl-Clipboard/template
@@ -1,16 +1,16 @@
-# Template build file for 'perl-Clipboard'.
+# Template file for 'perl-Clipboard'
 pkgname=perl-Clipboard
-version=0.13
+version=0.22
 revision=1
+archs=noarch
 wrksrc="Clipboard-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl"
 depends="perl"
 short_desc="Clipboard - Copy and paste with any OS"
-maintainer="Lukas Kropatschek <lukrop@hiddenbox.org>"
+maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
+license="Artistic-1.0-Perl"
 homepage="https://metacpan.org/release/Clipboard"
-license="Artistic, GPL-1"
-distfiles="${CPAN_SITE}/WebService/KING/Clipboard-${version}.tar.gz"
-checksum=eebf1c9cb2484be850abdae017147967cf47f8ccd99293771517674b0046ec8a
-archs=noarch
+distfiles="https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Clipboard-${version}.tar.gz"
+checksum=9fdb4dfc2e9bc2f3990b5b71649094dfe83aa12172c5a1809cf7e8b3be295ca7


### PR DESCRIPTION
Assuming maintainership of this package - the Void package was a year out of date, leading me to believe that the previous maintainer has abandoned it.