### PR TITLE
discord: Add SPDX Identifier

### DIFF
--- a/srcpkgs/discord/template
+++ b/srcpkgs/discord/template
@@ -1,6 +1,8 @@
 # Template file for 'discord'
 # Originally created by Benjamin Hoffmeyer, modified for stable Discord
 
+# SPDX-License-Identifier: proprietary
+
 pkgname=discord
 version=0.0.10
 revision=1


### PR DESCRIPTION
Pass Travis-CLI checks by setting SPDX-License-Identifier