### PR TITLE
crystal: fix completion files installation

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,7 +1,7 @@
 # Template file for 'crystal'
 pkgname=crystal
 version=0.33.0
-revision=2
+revision=3
 archs="x86_64* i686* aarch64* arm*"
 _shardsversion=0.9.0
 _bootstrapversion=0.33.0
@@ -87,12 +87,11 @@ do_install() {
 	vmkdir /usr/lib/crystal
 	vmkdir /usr/share/doc/crystal
 	vmkdir /usr/share/doc/crystal/api
-	vmkdir /usr/share/bash-completion/completions/crystal
-	vmkdir /usr/share/zsh/site-functions/_crystal
 	vmkdir /usr/share/licenses/shards
 
-	vcopy etc/completion.bash /usr/share/bash-completion/completions/crystal
-	vcopy etc/completion.zsh /usr/share/zsh/site-functions/_crystal
+	vinstall etc/completion.bash 644 \
+		usr/share/bash-completion/completions crystal
+	vinstall etc/completion.zsh 644 usr/share/zsh/site-functions _crystal
 	vcopy samples /usr/share/doc/crystal
 	vcopy docs/* /usr/share/doc/crystal/api
 	vcopy src/* /usr/lib/crystal


### PR DESCRIPTION
Attempt to fix issue #19559.

- Completion files were correctly installed from my local test.
- That's more or less how it is done in packages like `git` or `cargo`.