### PR TITLE
Fish completion

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,7 +1,7 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.4.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config python3"
 makedepends="freetype-devel fontconfig-devel libxcb-devel"
@@ -24,7 +24,7 @@ post_install() {
 	vinstall extra/logo/alacritty-term.svg 644 usr/share/pixmaps Alacritty.svg
 	vinstall extra/completions/alacritty.bash 644 usr/share/bash-completion/completions alacritty
 	vinstall extra/completions/_alacritty 644 usr/share/zsh/site-functions
-	vinstall extra/completions/alacritty.fish 644 usr/share/fish/completions
+	vinstall extra/completions/alacritty.fish 644 usr/share/fish/vendor_completions.d
 	vinstall extra/alacritty.info 644 usr/share/terminfo/a
 	vman extra/alacritty.man alacritty.1
 	vsconf alacritty.yml

--- a/srcpkgs/auto-auto-complete/patches/fish-completion-vendor.patch
+++ b/srcpkgs/auto-auto-complete/patches/fish-completion-vendor.patch
@@ -1,0 +1,34 @@
+#reason: fish-shell requires 3rd-party completion files to be installed to vendor_completions.d
+#upstream: https://github.com/maandree/auto-auto-complete/pull/7
+
+From 4dd203d77f65559931249c258ab2a1588798f6d6 Mon Sep 17 00:00:00 2001
+From: Piraty <piraty1@inbox.ru>
+Date: Tue, 25 Feb 2020 10:15:10 +0100
+Subject: [PATCH] install fish completion to vendor_completions.d
+
+As noted in the docs[1], third-party software vendors should install
+completion files into a different dir than upstream fish-shell to avoid
+conflicts.  Docs suggest `/usr/share/fish/vendor_completions.d`.
+
+This isn't an issue here (yet) but it conforms to the docs.
+
+[1] https://fishshell.com/docs/current/#where-to-put-completions
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d7e331d..6506628 100644
+--- Makefile
++++ Makefile
+@@ -188,8 +188,8 @@ install-zsh: bin/auto-auto-complete.zsh
+ 
+ .PHONY: install-fish
+ install-fish: bin/auto-auto-complete.fish
+-	install -dm755 -- "$(DESTDIR)$(DATADIR)/fish/completions"
+-	install -m644 $< -- "$(DESTDIR)$(DATADIR)/fish/completions/$(COMMAND).fish"
++	install -dm755 -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d"
++	install -m644 $< -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/$(COMMAND).fish"
+ 
+ 
+ # Uninstall rules

--- a/srcpkgs/auto-auto-complete/template
+++ b/srcpkgs/auto-auto-complete/template
@@ -1,14 +1,14 @@
 # Template file for 'auto-auto-complete'
 pkgname=auto-auto-complete
 version=7.2
-revision=3
-build_style=gnu-makefile
+revision=4
 archs=noarch
+build_style=gnu-makefile
 hostmakedepends="python3 texinfo"
 depends="python3"
 short_desc="Autogenerate shell auto-completion scripts"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/maandree/auto-auto-complete"
 distfiles="https://github.com/maandree/${pkgname}/archive/${version}.tar.gz"
 checksum=5e54025c6ef65dfff5ba976d23eb778a0936b0678763ebcd78359d460300301e

--- a/srcpkgs/avideo/template
+++ b/srcpkgs/avideo/template
@@ -1,16 +1,15 @@
 # Template file for 'avideo'
 pkgname=avideo
 version=2017.9.27
-revision=4
+revision=5
 archs=noarch
 wrksrc="avideo"
 build_style=python3-module
-pycompile_module="avideo"
 hostmakedepends="python3"
 depends="python3"
 short_desc="Libre video and audio downloader for GNU/Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://notabug.org/GPast/avideo"
 distfiles="https://notabug.org/GPast/avideo/raw/archive/${version}/avideo-${version}.tar.gz"
 checksum=474f9ae5f271d2f838e512cd6d02c631fb15e90b29949a6f8d2b0b13f13777bf
@@ -19,5 +18,5 @@ post_install() {
 	rm -rf ${DESTDIR}/usr/etc
 	vinstall avideo.bash-completion 644 usr/share/bash-completion/completions avideo
 	vinstall avideo.zsh 644 usr/share/zsh/site-functions _avideo
-	vinstall avideo.fish 644 usr/share/fish/completions avideo.fish
+	vinstall avideo.fish 644 usr/share/fish/vendor_completions.d
 }

--- a/srcpkgs/aws-vault/template
+++ b/srcpkgs/aws-vault/template
@@ -1,7 +1,7 @@
 # Template file for 'aws-vault'
 pkgname=aws-vault
 version=5.1.2
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/99designs/aws-vault
 short_desc="Vault for securely storing and accessing AWS credentials"
@@ -16,5 +16,5 @@ post_install() {
 
 	vinstall completions/zsh/_aws-vault 0644 usr/share/zsh/site-functions
 	vinstall completions/bash/aws-vault 0644 usr/share/bash-completion/completions
-	vinstall completions/fish/aws-vault.fish 0644 usr/share/fish/completions
+	vinstall completions/fish/aws-vault.fish 0644 usr/share/fish/vendor_completions.d
 }

--- a/srcpkgs/borg/template
+++ b/srcpkgs/borg/template
@@ -1,13 +1,12 @@
 # Template file for 'borg'
 pkgname=borg
 version=1.1.10
-revision=3
+revision=4
 wrksrc="borgbackup-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-devel libressl-devel"
 makedepends="${hostmakedepends/python3-setuptools/} acl-devel liblz4-devel libzstd-devel"
 depends="python3-llfuse python3-setuptools"
-pycompile_module="borg"
 short_desc="Deduplicating backup program with compression and encryption"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-3-Clause"
@@ -21,12 +20,13 @@ export BORG_LIBLZ4_PREFIX="${XBPS_CROSS_BASE}/usr"
 export BORG_LIBZSTD_PREFIX="${XBPS_CROSS_BASE}/usr"
 
 pre_build() {
-	sed -i setup.py \
+	vsed -i setup.py \
 		-e '/setup_requires=/d' \
 		-e '/use_scm_version=/,+2d' \
 		-e "/name=/ a\
 		version='${version}',"
 }
+
 post_install() {
 	vlicense LICENSE
 
@@ -36,7 +36,6 @@ post_install() {
 
 	cd scripts/shell_completions
 	vinstall bash/${pkgname} 644 usr/share/bash-completion/completions ${pkgname}
-	vinstall fish/${pkgname}.fish 644 usr/share/fish/completions ${pkgname}.fish
+	vinstall fish/${pkgname}.fish 644 usr/share/fish/vendor_completions.d
 	vinstall zsh/_${pkgname} 644 usr/share/zsh/site-functions _${pkgname}
-	cd ../..
 }

--- a/srcpkgs/cheat/template
+++ b/srcpkgs/cheat/template
@@ -1,7 +1,7 @@
 # Template file for 'cheat'
 pkgname=cheat
 version=3.6.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/cheat/cheat/cmd/cheat"
 short_desc="Create and view interactive cheatsheets on the command-line"
@@ -12,9 +12,7 @@ distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=8441c94d12b6a6f088818c8cabd91f75bc583bee3c66dac7a53851ae1032862f
 
 post_install() {
-	vinstall scripts/cheat.bash 644 \
-		usr/share/bash-completion/completions cheat
-	vinstall scripts/cheat.fish 644 \
-		usr/share/fish/completions
+	vinstall scripts/cheat.bash 644 usr/share/bash-completion/completions cheat
+	vinstall scripts/cheat.fish 644 usr/share/fish/vendor_completions.d
 	vlicense LICENSE.txt
 }

--- a/srcpkgs/googler/template
+++ b/srcpkgs/googler/template
@@ -1,7 +1,7 @@
 # Template file for 'googler'
 pkgname=googler
 version=4.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_target=disable-self-upgrade
 depends="python3 xsel xclip"
@@ -14,6 +14,6 @@ checksum=f72593ca2a3dccd7301c0fed55effd223cc38f6c21910bffbbfba1360c985cd3
 
 post_install() {
 	vinstall auto-completion/bash/googler-completion.bash 644 /usr/share/bash-completion/completions/googler
-	vinstall auto-completion/fish/googler.fish 644 /usr/share/fish/completions
+	vinstall auto-completion/fish/googler.fish 644 usr/share/fish/vendor_completions.d
 	vinstall auto-completion/zsh/_googler 644 /usr/share/zsh/site-functions
 }

--- a/srcpkgs/hub/template
+++ b/srcpkgs/hub/template
@@ -1,7 +1,7 @@
 # Template file for 'hub'
 pkgname=hub
 version=2.14.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/github/hub
 hostmakedepends="git groff"
@@ -46,5 +46,5 @@ post_install() {
 
 	vinstall etc/hub.zsh_completion 644 usr/share/zsh/site-functions _hub
 	vinstall etc/hub.bash_completion.sh 644 usr/share/bash-completion/completions hub
-	vinstall etc/hub.fish_completion 644 usr/share/fish/completions hub.fish
+	vinstall etc/hub.fish_completion 644 usr/share/fish/vendor_completions.d hub.fish
 }

--- a/srcpkgs/imgp/template
+++ b/srcpkgs/imgp/template
@@ -1,7 +1,7 @@
 # Template file for 'imgp'
 pkgname=imgp
 version=2.7
-revision=1
+revision=2
 archs=noarch
 build_style=gnu-makefile
 depends="python3-Pillow"
@@ -15,5 +15,5 @@ checksum=362f9fab7eaf4c53438e12f32477329c970bd7348181c243ffa30326e231acf7
 post_install() {
 	vinstall auto-completion/bash/imgp-completion.bash 644 usr/share/bash-completion/completions imgp
 	vinstall auto-completion/zsh/_imgp 644 usr/share/zsh/site-functions
-	vinstall auto-completion/fish/imgp.fish 644 usr/share/fish/completions
+	vinstall auto-completion/fish/imgp.fish 644 usr/share/fish/vendor_completions.d
 }

--- a/srcpkgs/kubetail/template
+++ b/srcpkgs/kubetail/template
@@ -1,7 +1,7 @@
 # Template file for 'kubetail'
 pkgname=kubetail
 version=1.6.10
-revision=1
+revision=2
 depends="bash"
 short_desc="Bash script to tail Kubernetes logs from multiple pods at the same time"
 maintainer="Frank Steinborn <steinex@nognu.de>"
@@ -13,6 +13,6 @@ checksum=9bb4ecd1d3a7b1e9627fc8b5117d1c7ff03f2ddea25252b250395e4ac4817b26
 do_install() {
 	vbin kubetail
 	vinstall completion/kubetail.bash 0644 usr/share/bash-completion/completions kubetail
-	vinstall completion/kubetail.fish 0644 usr/share/fish/completions/
+	vinstall completion/kubetail.fish 0644 usr/share/fish/vendor_completions.d
 	vinstall completion/kubetail.zsh 0644 usr/share/zsh/site-functions _kubetail
 }

--- a/srcpkgs/lf/template
+++ b/srcpkgs/lf/template
@@ -1,7 +1,7 @@
 # Template file for 'lf'
 pkgname=lf
 version=r13
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/gokcehan/${pkgname}"
 go_ldflags="-X main.gVersion=$version"
@@ -17,5 +17,5 @@ post_install() {
 	vlicense LICENSE
 	vsconf etc/lfrc.example lfrc
 	vman lf.1
-	vinstall etc/lf.fish 0644 usr/share/fish/completions
+	vinstall etc/lf.fish 0644 usr/share/fish/vendor_completions.d
 }

--- a/srcpkgs/nnn/template
+++ b/srcpkgs/nnn/template
@@ -1,7 +1,7 @@
 # Template file for 'nnn'
 pkgname=nnn
 version=3.0
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="ncurses-devel readline-devel"
@@ -19,7 +19,7 @@ post_install() {
 	vinstall misc/auto-completion/zsh/_nnn 644 \
 		usr/share/zsh/site-functions
 	vinstall misc/auto-completion/fish/nnn.fish 644 \
-		usr/share/fish/completions
+		usr/share/fish/vendor_completions.d
 
 	vlicense LICENSE
 }

--- a/srcpkgs/ponysay/patches/fish-completion-vendor.patch
+++ b/srcpkgs/ponysay/patches/fish-completion-vendor.patch
@@ -1,0 +1,30 @@
+# upstream: yes
+
+From dd922c09bbe5deb808152140679673e8dca3210d Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz@archlinux.org>
+Date: Tue, 21 Jan 2020 23:55:44 -0500
+Subject: [PATCH] fix incorrect install dir for fish completion
+
+fish completions should never be installed to share/fish/completions/ as
+that directory is reserved exclusively for completions shipped as part
+of the fish source code.
+
+Use the same vendor_completions.d/ directory which the default fish
+configuration uses.
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 17f12efd..5728a23f 100755
+--- setup.py
++++ setup.py
+@@ -28,7 +28,7 @@
+ commands = ['ponysay', 'ponythink', 'ponysay-tool']
+ 
+ shells = [('bash', '/usr/share/bash-completion/completions/ponysay', 'GNU Bash'),
+-          ('fish', '/usr/share/fish/completions/ponysay.fish', 'Friendly interactive shell'),
++          ('fish', '/usr/share/fish/vendor_completions.d/ponysay.fish', 'Friendly interactive shell'),
+           ('zsh', '/usr/share/zsh/site-functions/_ponysay', 'zsh')]
+ 
+ mansections = [('ponysay', '6'),

--- a/srcpkgs/ponysay/template
+++ b/srcpkgs/ponysay/template
@@ -1,14 +1,14 @@
 # Template file for 'ponysay'
 pkgname=ponysay
 version=3.0.3
-revision=2
+revision=3
 archs=noarch
 hostmakedepends="python3 texinfo"
 depends="python3"
 short_desc="Pony rewrite of cowsay"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-3"
-homepage="http://erkin.github.com/ponysay/"
+license="GPL-3.0-or-later"
+homepage="https://erkin.github.com/ponysay/"
 distfiles="https://github.com/erkin/${pkgname}/archive/${version}.tar.gz"
 checksum=c382d7f299fa63667d1a4469e1ffbf10b6813dcd29e861de6be55e56dc52b28a
 

--- a/srcpkgs/ripgrep/template
+++ b/srcpkgs/ripgrep/template
@@ -1,7 +1,7 @@
 # Template file for 'ripgrep'
 pkgname=ripgrep
 version=11.0.2
-revision=3
+revision=4
 build_style=cargo
 configure_args="--features=pcre2"
 hostmakedepends="asciidoc pkg-config"
@@ -21,4 +21,5 @@ post_install() {
 	cd "target/${RUST_TARGET}/release/build/ripgrep-"*/out
 	vman rg.1
 	vinstall rg.bash 0644 usr/share/bash-completion/completions rg
+	vinstall rg.fish 0644 usr/share/fish/vendor_completions.d
 }

--- a/srcpkgs/s/template
+++ b/srcpkgs/s/template
@@ -1,7 +1,7 @@
 # Template file for 's'
 pkgname=s
 version=0.5.14
-revision=2
+revision=3
 build_style=go
 go_import_path=github.com/zquestz/s
 hostmakedepends="git"
@@ -14,5 +14,5 @@ checksum=c32eedf6a4080cbe221c902cf7f63b1668b3927edfc448d963d69ed66c8ec2fb
 
 post_install() {
 	vlicense LICENSE
-	vinstall autocomplete/s.fish 644 usr/share/fish/completions
+	vinstall autocomplete/s.fish 644 usr/share/fish/vendor_completions.d
 }

--- a/srcpkgs/scrotty/patches/fish-completion-vendor.patch
+++ b/srcpkgs/scrotty/patches/fish-completion-vendor.patch
@@ -1,0 +1,20 @@
+#reason: fish-shell requires 3rd-party completion files to be installed to vendor_completions.d
+
+--- mk/shell.mk
++++ mk/shell.mk
+@@ -189,12 +189,12 @@
+ .PHONY: install-fish
+ install-fish: $(foreach F,$(_AUTO_COMPLETE),bin/$(F).fish-completion)
+ 	@$(PRINTF_INFO) '\e[00;01;31mINSTALL\e[34m %s\e[00m\n' "$@"
+-	$(Q)$(INSTALL_DIR) -- "$(DESTDIR)$(DATADIR)/fish/completions"
++	$(Q)$(INSTALL_DIR) -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d"
+ ifndef __SHELL_COMMAND
+-	$(Q)$(foreach F,$(_AUTO_COMPLETE),$(INSTALL_DATA) bin/$(F).fish-completion -- "$(DESTDIR)$(DATADIR)/fish/completions/$(F).fish" &&) $(TRUE)
++	$(Q)$(foreach F,$(_AUTO_COMPLETE),$(INSTALL_DATA) bin/$(F).fish-completion -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/$(F).fish" &&) $(TRUE)
+ endif
+ ifdef __SHELL_COMMAND
+-	$(Q)$(INSTALL_DATA) $^ -- "$(DESTDIR)$(DATADIR)/fish/completions/$(COMMAND).fish"
++	$(Q)$(INSTALL_DATA) $^ -- "$(DESTDIR)$(DATADIR)/fish/vendor_completions.d/$(COMMAND).fish"
+ endif
+ 	@$(ECHO_EMPTY)
+ 

--- a/srcpkgs/scrotty/template
+++ b/srcpkgs/scrotty/template
@@ -1,9 +1,9 @@
 # Template file for 'scrotty'
 pkgname=scrotty
 version=2.0
-revision=2
+revision=3
 build_style=gnu-configure
-hostmakedepends="pkg-config auto-auto-complete"
+hostmakedepends="auto-auto-complete gettext pkg-config texinfo"
 makedepends="libpng-devel"
 depends="ImageMagick"
 short_desc="Framebuffer screenshoter"

--- a/srcpkgs/task/template
+++ b/srcpkgs/task/template
@@ -1,7 +1,7 @@
 # Template file for 'task'
 pkgname=task
 version=2.5.1
-revision=4
+revision=5
 build_style=cmake
 makedepends="libuuid-devel gnutls-devel"
 short_desc="Command-line todo list manager"
@@ -14,6 +14,6 @@ checksum=d87bcee58106eb8a79b850e9abc153d98b79e00d50eade0d63917154984f2a15
 post_install() {
 	vinstall scripts/zsh/_task 644 usr/share/zsh/site-functions
 	vinstall scripts/bash/task.sh 644 usr/share/bash-completion/completions ${pkgname}
-	vinstall scripts/fish/task.fish 644 usr/share/fish/completions/
+	vinstall scripts/fish/task.fish 644 usr/share/fish/vendor_completions.d
 	vlicense LICENSE
 }

--- a/srcpkgs/youtube-dl/template
+++ b/srcpkgs/youtube-dl/template
@@ -1,12 +1,13 @@
 # Template file for 'youtube-dl'
 pkgname=youtube-dl
 version=2020.03.01
-revision=1
+revision=2
 archs=noarch
 wrksrc=youtube-dl
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools"
+checkdepends="flake8 python3-nose"
 short_desc="CLI program to download videos from YouTube and other sites"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="Unlicense"
@@ -15,11 +16,15 @@ changelog="https://raw.githubusercontent.com/ytdl-org/youtube-dl/master/ChangeLo
 distfiles="https://yt-dl.org/downloads/${version}/youtube-dl-${version}.tar.gz"
 checksum=5ca43f343738338cfdec47042de1569e5755b62d66af29950f48f5be2c001306
 
+do_check() {
+	PYTHON=/usr/bin/python3 make offlinetest
+}
+
 post_install() {
 	rm -rf ${DESTDIR}/usr/etc
 	vinstall youtube-dl.bash-completion 644 usr/share/bash-completion/completions youtube-dl
 	vinstall youtube-dl.zsh 644 usr/share/zsh/site-functions _youtube-dl
-	vinstall youtube-dl.fish 644 usr/share/fish/completions youtube-dl.fish
+	vinstall youtube-dl.fish 644 usr/share/fish/vendor_completions.d
 }
 
 python3-youtube-dl_package() {

--- a/srcpkgs/ytcc/template
+++ b/srcpkgs/ytcc/template
@@ -1,7 +1,7 @@
 # Template file for 'ytcc'
 pkgname=ytcc
 version=1.8.2
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools"
@@ -15,6 +15,6 @@ distfiles="https://github.com/woefe/ytcc/archive/v${version}.tar.gz"
 checksum=360db561bb0278b7f326fe3da9b012e738e1eceec9031c66b3749207f8091283
 
 post_install() {
-	vinstall completions/fish/ytcc.fish 0644 usr/share/fish/completions
+	vinstall completions/fish/ytcc.fish 0644 usr/share/fish/vendor_completions.d
 	vinstall completions/zsh/_ytcc 0644 usr/share/zsh/site-functions
 }

--- a/srcpkgs/zathura/patches/fish-completion-vendor.patch
+++ b/srcpkgs/zathura/patches/fish-completion-vendor.patch
@@ -1,0 +1,77 @@
+# upstream: yes
+
+From bf46e4de707f364082570f4818846f2944b0ccfa Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz@archlinux.org>
+Date: Tue, 21 Jan 2020 21:39:00 -0500
+Subject: [PATCH] Fix installation of bash/fish completions using pkg-config
+
+Both shells provide pkg-config files which declare their designated
+completionsdir. Use this as the primary source of truth.
+---
+ data/meson.build | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index c1e9231..557b630 100644
+--- data/meson.build
++++ data/meson.build
+@@ -70,6 +70,20 @@ fish_completion = configure_file(
+   configuration: conf_data
+ )
+ 
+-install_data(bash_completion, install_dir: join_paths(datadir, 'bash-completion', 'completions'))
++bash_comp = dependency('bash-completion', required: false)
++if bash_comp.found()
++  bash_compdir = bash_comp.get_pkgconfig_variable('completionsdir')
++else
++  bash_compdir = join_paths(datadir, 'bash-completion', 'completions')
++endif
++
++fish_comp = dependency('fish', required: false)
++if fish_comp.found()
++  fish_compdir = fish_comp.get_pkgconfig_variable('completionsdir')
++else
++  fish_compdir = join_paths(datadir, 'fish', 'completions')
++endif
++
++install_data(bash_completion, install_dir: bash_compdir)
+ install_data(zsh_completion, install_dir: join_paths(datadir, 'zsh', 'site-functions'))
+-install_data(fish_completion, install_dir: join_paths(datadir, 'fish', 'completions'))
++install_data(fish_completion, install_dir: fish_compdir)
+-- 
+2.25.0
+
+
+
+
+From d21d0406630eaf5e20d180524e6d396611e7243a Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz@archlinux.org>
+Date: Tue, 21 Jan 2020 21:39:26 -0500
+Subject: [PATCH] fish-completion: use the correct fallback directory
+
+fish completions should never be installed to share/fish/completions/ as
+that directory is reserved exclusively for completions shipped as part
+of the fish source code.
+
+Use the same vendor_completions.d/ directory which the default fish
+configuration uses.
+---
+ data/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index 557b630..4649160 100644
+--- data/meson.build
++++ data/meson.build
+@@ -81,7 +81,7 @@ fish_comp = dependency('fish', required: false)
+ if fish_comp.found()
+   fish_compdir = fish_comp.get_pkgconfig_variable('completionsdir')
+ else
+-  fish_compdir = join_paths(datadir, 'fish', 'completions')
++  fish_compdir = join_paths(datadir, 'fish', 'vendor_completions.d')
+ endif
+ 
+ install_data(bash_completion, install_dir: bash_compdir)
+-- 
+2.25.0
+

--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura'
 pkgname=zathura
 version=0.4.5
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsynctex=disabled -Dtests=disabled"
 hostmakedepends="pkg-config intltool python3-Sphinx desktop-file-utils


### PR DESCRIPTION
According to the [fish docs](https://fishshell.com/docs/current/#where-to-put-completions), third-party software should install to `/usr/share/fish/vendor_completions.d`.

See: #19413 (rustup: remove fish completion) as well

Some cleanups, fixes and xlints were performed along the way