### PR TITLE
New package: mstflint-4.13.3

### DIFF
--- a/srcpkgs/mstflint-devel
+++ b/srcpkgs/mstflint-devel
@@ -1,0 +1,1 @@
+mstflint

--- a/srcpkgs/mstflint/patches/musl.patch
+++ b/srcpkgs/mstflint/patches/musl.patch
@@ -1,0 +1,11 @@
+--- mtcr_ul/mtcr_ul_com.c.orig	2020-03-04 08:19:35.889730972 +0700
++++ mtcr_ul/mtcr_ul_com.c	2020-03-04 08:19:41.690743181 +0700
+@@ -76,7 +76,7 @@
+ 
+ #if CONFIG_ENABLE_MMAP
+ #include <sys/mman.h>
++#include <linux/pci.h>
+-#include <sys/pci.h>
+ #include <sys/ioctl.h>
+ #endif
+ 

--- a/srcpkgs/mstflint/template
+++ b/srcpkgs/mstflint/template
@@ -1,0 +1,26 @@
+# Template file for 'mstflint'
+pkgname=mstflint
+version=4.13.3r2
+revision=1
+_version=${version/r/-}
+wrksrc=mstflint-${version%r*}
+build_style=gnu-configure
+configure_args="--enable-cs --enable-fw-mgr --enable-xml2"
+makedepends="boost-devel libcurl-devel libibmad-devel liblzma-devel libxml2-devel zlib-devel"
+short_desc="Open source version of Mellanox Firmware Tools"
+maintainer="Rich Gannon <rich@richgannon.net>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/Mellanox/mstflint"
+distfiles="https://github.com/Mellanox/mstflint/releases/download/v${_version}/${pkgname}-${_version}.tar.gz"
+checksum=3abc918311fc07e4add7564879bd4a8def8ccfed40962f31682c75f2ee8a58d1
+
+CFLAGS="-Du_int8_t=uint8_t -Du_int16_t=uint16_t -Du_int32_t=uint32_t -Du_int64_t=uint64_t"
+
+mstflint-devel_package() {
+	depends="${pkgname}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+	}
+}


### PR DESCRIPTION
Package used to control Infiniband network cards, including firmware updates.

2 Issues:
   - Not sure how to properly handle the upstream versioning properly.
   - The packaging fails to identify that it needs boost_regex1.69.  How do I fix this?