### PR TITLE
yq: require python3-argcomplete as a runtime dependency

### DIFF
--- a/srcpkgs/yq/template
+++ b/srcpkgs/yq/template
@@ -1,12 +1,12 @@
 # Template file for 'yq'
 pkgname=yq
 version=2.10.0
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-yaml"
-depends="python3-setuptools python3-xmltodict python3-yaml python3-toml"
+depends="python3-setuptools python3-xmltodict python3-yaml python3-toml python3-argcomplete"
 checkdepends="jq python3-xmltodict python3-toml"
 short_desc="Command-line YAML processor written in Python that wraps around jq"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
Fixes #19568