### PR TITLE
dolphin: add missing build dependency

### DIFF
--- a/srcpkgs/dolphin/template
+++ b/srcpkgs/dolphin/template
@@ -7,7 +7,7 @@ configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules python3 qt5-qmake qt5-host-tools
  gettext kcoreaddons kconfig kdoctools"
 makedepends="baloo-widgets5-devel kcmutils-devel knewstuff-devel kactivities5-devel
- kinit-devel kparts-devel ksolid-devel"
+ kinit-devel kparts-devel ksolid-devel kcoreaddons-devel kio-devel ki18n-devel"
 depends="kio-extras"
 short_desc="KDE File manager"
 maintainer="John <johnz@posteo.net>"


### PR DESCRIPTION
Build fails without these dependencies