### PR TITLE
picard: update to 2.3.1

### DIFF
--- a/srcpkgs/picard/template
+++ b/srcpkgs/picard/template
@@ -1,13 +1,12 @@
 # Template file for 'picard'
 pkgname=picard
-version=2.2.3
-revision=2
+version=2.3.1
+revision=1
 archs=noarch
 wrksrc="${pkgname}-release-${version}"
 build_style=python3-module
 make_install_args="--disable-autoupdate"
-pycompile_module="picard"
-hostmakedepends="python3-setuptools"
+hostmakedepends="gettext python3-setuptools"
 makedepends="python3-devel"
 depends="python3-PyQt5 chromaprint python3-mutagen
  desktop-file-utils hicolor-icon-theme"
@@ -17,4 +16,4 @@ license="GPL-2.0-or-later"
 homepage="https://picard.musicbrainz.org/"
 changelog="https://picard.musicbrainz.org/changelog/"
 distfiles="http://ftp.musicbrainz.org/pub/musicbrainz/${pkgname}/${pkgname}-${version%.0}.tar.gz"
-checksum=920bc0ffc1b5ae395456698a133799aee06c66b4446f6a388a64046e07d8716b
+checksum=7466678a82f29d1376ab07370750d096fcc1305b8d8fe52f7729e3f7841b8e33


### PR DESCRIPTION
I tried building it `gettext-devel` instead of plain `gettext` as the makedepend but it won't compile because the process calls the `msgfmt` binary directly. If any changes are recommended, please let me know.