### PR TITLE
lutris: patch error caused by gtk+3 update

### DIFF
--- a/srcpkgs/lutris/patches/sort_new_with_model_fix.patch
+++ b/srcpkgs/lutris/patches/sort_new_with_model_fix.patch
@@ -1,0 +1,26 @@
+From 12a458db3c590c3f1972594e091a24cb4d65b610 Mon Sep 17 00:00:00 2001
+From: Mathieu Comandon <strycore@gmail.com>
+Date: Wed, 1 Jan 2020 12:47:55 -0800
+Subject: [PATCH] Support both sort_new_with_model and new_with_model
+
+---
+ lutris/gui/views/store.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/lutris/gui/views/store.py b/lutris/gui/views/store.py
+index 9e843e9e4..8fe5decf5 100644
+--- lutris/gui/views/store.py
++++ lutris/gui/views/store.py
+@@ -140,7 +140,11 @@ def __init__(
+         self.prevent_sort_update = False  # prevent recursion with signals
+         self.modelfilter = self.store.filter_new()
+         self.modelfilter.set_visible_func(self.filter_view)
+-        self.modelsort = Gtk.TreeModelSort.sort_new_with_model(self.modelfilter)
++        try:
++            self.modelsort = Gtk.TreeModelSort.sort_new_with_model(self.modelfilter)
++        except AttributeError:
++            # Apparently some API breaking changes on GTK minor versions.
++            self.modelsort = Gtk.TreeModelSort.new_with_model(self.modelfilter)
+         self.modelsort.connect("sort-column-changed", self.on_sort_column_changed)
+         self.modelsort.set_sort_func(sort_col, sort_func, sort_col)
+         self.sort_view(sort_key, sort_ascending)

--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,11 +1,10 @@
 # Template file for 'lutris'
 pkgname=lutris
 version=0.5.4
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 build_helper="gir"
-pycompile_module="$pkgname"
 hostmakedepends="python3-setuptools python3-gobject gtk+3-devel"
 depends="python3-dbus python3-gobject python3-yaml python3-evdev python3-Pillow
  pciutils cabextract gtk+3 xrandr unzip p7zip gnome-desktop python3-requests webkit2gtk"


### PR DESCRIPTION
Lutris isn't working since the latest .14 gtk+3 update. This patch from Arch Linux fixes it. 