### PR TITLE
linux5.5: linux5.5: fix wifi on intel 3168 devices

### DIFF
--- a/srcpkgs/linux5.5/patches/iwlwifi-mvm-3168.diff
+++ b/srcpkgs/linux5.5/patches/iwlwifi-mvm-3168.diff
@@ -1,0 +1,25 @@
+The logic for checking required NVM sections was recently fixed in
+commit b3f20e098293 ("iwlwifi: mvm: fix NVM check for 3168
+devices"). However, with that fixed the else is now taken for 3168
+devices and within the else clause there is a mandatory check for the
+PHY_SKU section. This causes the parsing to fail for 3168 devices.
+
+The PHY_SKU section is really only mandatory for the IWL_NVM_EXT
+layout (the phy_sku parameter of iwl_parse_nvm_data is only used when
+the NVM type is IWL_NVM_EXT). So this changes the PHY_SKU section
+check so that it's only mandatory for IWL_NVM_EXT.
+
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/nvm.c b/drivers/net/wireless/intel/iwlwifi/mvm/nvm.c
+index 46128a2a9c6e..e98ce380c7b9 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/nvm.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/nvm.c
+@@ -308,7 +308,8 @@ iwl_parse_nvm_sections(struct iwl_mvm *mvm)
+ 		}
+ 
+ 		/* PHY_SKU section is mandatory in B0 */
+-		if (!mvm->nvm_sections[NVM_SECTION_TYPE_PHY_SKU].data) {
++		if (mvm->trans->cfg->nvm_type == IWL_NVM_EXT &&
++		    !mvm->nvm_sections[NVM_SECTION_TYPE_PHY_SKU].data) {
+ 			IWL_ERR(mvm,
+ 				"Can't parse phy_sku in B0, empty sections\n");
+ 			return NULL;

--- a/srcpkgs/linux5.5/template
+++ b/srcpkgs/linux5.5/template
@@ -1,7 +1,7 @@
 # Template file for 'linux5.5'
 pkgname=linux5.5
 version=5.5.7
-revision=1
+revision=2
 wrksrc="linux-${version}"
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="Juan RP <xtraeme@gmail.com>"


### PR DESCRIPTION
This backports a patch to fix wifi support on intel 3168 (stone peak) wifi cards.
This patch was accepted into the wireless-drivers repo, but that repo has yet to be pulled into the upstream kernel, and probably won't until 5.7.