### PR TITLE
libepoxy-devel: depends on libglvnd-devel (fix gtk+3 broken build with ~wayland)

### DIFF
--- a/srcpkgs/libepoxy/template
+++ b/srcpkgs/libepoxy/template
@@ -1,7 +1,7 @@
 # Template file for 'libepoxy'
 pkgname=libepoxy
 version=1.5.4
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config xorg-util-macros"
 makedepends="MesaLib-devel"
@@ -19,7 +19,7 @@ post_install() {
 
 libepoxy-devel_package() {
 	short_desc+=" - development files"
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libglvnd-devel"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"


### PR DESCRIPTION
Fixing gtk+3 build errors with ~wayland

I build gtk+3 locally with ~wayland.