### PR TITLE
rpi-kernel: update to 4.19.106.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="e645cec69367ba4b6daf63933f48661ab4b59ee1"
+_githash="742cb761fa7f2a25e9fc57afd72deb0c47b0c864"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.105
+version=4.19.106
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=bcc3ea5b5b3d6d10953f73e55c43bee8a1c1997826b0299c37c18b0095c18415
+checksum=51ca9832bacceb5405d8e862b1559f6a16a2110b01586362a99855980c2a23e5
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.