### PR TITLE
Move to versioned pam-gnupg

### DIFF
--- a/srcpkgs/pam-gnupg-git/template
+++ b/srcpkgs/pam-gnupg-git/template
@@ -1,21 +1,10 @@
 # Template file for 'pam-gnupg-git'
 pkgname=pam-gnupg-git
-version=20191206
+version=20200214
 revision=1
-_githash=fbd75b720877e4cf94e852ce7e2b811feb330bb5
-wrksrc="pam-gnupg-${_githash}"
-build_style=gnu-configure
-configure_args="--with-moduledir=/usr/lib/security"
-hostmakedepends="automake libtool gnupg2"
-makedepends="pam-devel"
-depends="gnupg2"
-short_desc="PAM module to unlock GPG agent on login"
+build_style=meta
+depends="pam-gnupg"
+short_desc="PAM module to unlock GPG agent (transitional meta-package)"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="GPL-3.0-only"
-homepage="https://github.com/cruegge/pam-gnupg"
-distfiles="${homepage}/archive/${_githash}.tar.gz"
-checksum=fe6d5874545832d9f0189f204571b19470bb090a3eac778732e5792b428cffa0
-
-pre_configure() {
-	sh autogen.sh
-}
+homepage="https://www.voidlinux.org"

--- a/srcpkgs/pam-gnupg/template
+++ b/srcpkgs/pam-gnupg/template
@@ -1,0 +1,22 @@
+# Template file for 'pam-gnupg'
+pkgname=pam-gnupg
+# **NOTE** The pam-gnupg-git metapackage was created to migrate from date-based
+# versioning to release versioning. When this package is updated, pam-gnupg-git
+# should be updated or removed.
+version=0.1
+revision=1
+build_style=gnu-configure
+configure_args="--with-moduledir=/usr/lib/security"
+hostmakedepends="automake libtool gnupg2"
+makedepends="pam-devel"
+depends="gnupg2"
+short_desc="PAM module to unlock GPG agent"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-3.0-only"
+homepage="https://github.com/cruegge/pam-gnupg"
+distfiles="https://github.com/cruegge/pam-gnupg/archive/v${version}.tar.gz"
+checksum=b6e1a018185fb0ed467fa33e25998a9d666634da3828f8e4497e5d3739a59dc4
+
+pre_configure() {
+	sh autogen.sh
+}


### PR DESCRIPTION
This PR makes pam-gnupg-git a meta-package that depends on the new pam-gnupg package, which is a proper release version of the pam-gnupg module. The migration does not seem to work when pam-gnupg-git is a subpackage of pam-gnupg because the change from date-based versioning (20191206_1) to release versioning (0.1_1) is not properly ordered and XBPS will not recognize that the new meta-package is an upgrade to the earlier version.

The plan is to keep the pam-gnupg-git meta-package around for awhile---maybe until the next upstream release (I do not suspect that this is a popular package), then remove it and continue only with the new release-based package.