### PR TITLE
arandr: add missing python3 dependency

### DIFF
--- a/srcpkgs/arandr/template
+++ b/srcpkgs/arandr/template
@@ -1,14 +1,14 @@
 # Template file for 'arandr'
 pkgname=arandr
 version=0.1.10
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools python3-docutils"
-depends="python3-gobject xrandr"
+depends="python3-gobject xrandr python3"
 short_desc="Graphical frontend for XRandR"
 maintainer="mid-kid <esteve.varela@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://christian.amsuess.com/tools/arandr/"
 distfiles="http://christian.amsuess.com/tools/arandr/files/arandr-${version}.tar.gz"
 checksum=dbc8ac890da78e9c0ba3403a8932a925813bb8d62265276894e780ba2905b88c


### PR DESCRIPTION
Privately reported by fungalnet.