### PR TITLE
android-studio: update to 3.6.1.

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,10 +1,10 @@
 # Template file for 'android-studio'
 pkgname=android-studio
-version=3.5.3
+version=3.6.1
 revision=1
 # _studio_build and _studio_rev are for downloading the zip from dl.google.com
 # https://developer.android.com/studio/#resources as of 2018-07-12
-_studio_build=191.6010548
+_studio_build=192.6241897
 _studio_rev=0
 archs="x86_64 i686"
 create_wrksrc=yes
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="http://tools.android.com/"
 # changelog="https://developer.android.com/studio/releases/index.html"
 distfiles="https://dl.google.com/dl/android/studio/ide-zips/${version}.${_studio_rev}/android-studio-ide-${_studio_build}-linux.tar.gz"
-checksum=af630d40f276b0d169c6ac8c7663a989f562b0ac48a1d3f0d720f5b6472355db
+checksum=e754dc9db31a5c222f230683e3898dcab122dfe7bdb1c4174474112150989fd7
 repository=nonfree
 restricted=yes
 nopie=yes
@@ -77,7 +77,6 @@ do_install() {
 	# libncurses.so.5, which is not provided by Void Linux. However, as host-side simpleperf
 	# parsing is a fairly recent addition, we can just disable it...
 
-	rm -r ${DESTDIR}/opt/android-studio/plugins/android/resources/simpleperf/linux-x86
 	rm -r ${DESTDIR}/opt/android-studio/plugins/android/resources/simpleperf/linux-x86_64
 	echo "-Dprofiler.cpu.simpleperf.host=false" >> ${DESTDIR}/opt/android-studio/bin/studio.vmoptions
 	echo "-Dprofiler.cpu.simpleperf.host=false" >> ${DESTDIR}/opt/android-studio/bin/studio64.vmoptions


### PR DESCRIPTION
Update android studio.
Seems to work for my projects.

Also it looks like they stopped bundling 32bit version of simpleperf