### PR TITLE
python3-typing_extensions: update to 3.7.4.1

### DIFF
--- a/srcpkgs/python3-typing_extensions/template
+++ b/srcpkgs/python3-typing_extensions/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-typing_extensions'
 pkgname=python3-typing_extensions
-version=3.6.6
-revision=2
+version=3.7.4.1
+revision=1
 archs=noarch
 wrksrc="${pkgname#python3-}-${version}"
 build_style=python3-module
-pycompile_module="typing_extensions.py"
 hostmakedepends="python3-setuptools"
 depends="python3"
 short_desc="Backported and Experimental Type Hints for Python 3.5+"
@@ -13,4 +12,4 @@ maintainer="Denis Revin <denis.revin@gmail.com>"
 license="Python-2.0"
 homepage="https://github.com/python/typing"
 distfiles="${PYPI_SITE}/t/typing_extensions/typing_extensions-${version}.tar.gz"
-checksum=51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f
+checksum=091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2


### PR DESCRIPTION
- synapse-1.10.1 depends on >= 3.7.4
- also took advice from xlint