### PR TITLE
synapse: update to 1.11.0

### DIFF
--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -1,6 +1,6 @@
 # Template file for 'synapse'
 pkgname=synapse
-version=1.10.1
+version=1.11.0
 revision=1
 archs=noarch
 build_style=python3-module
@@ -19,9 +19,7 @@ maintainer="Pete <pete@port22.co.uk>"
 license="Apache-2.0"
 homepage="https://github.com/matrix-org/synapse"
 distfiles="https://github.com/matrix-org/synapse/archive/v${version}.tar.gz"
-checksum=43351bdee7e025c90f62c32795c610247db8d223d3a0dbdaa570796a78e05cee
-
-conf_files="/etc/synapse/log_config.yaml"
+checksum=4aacaa647cbc398ef2a8446273b9f449548b646aec615b9c8e60da9f98916523
 
 system_accounts="synapse"
 synapse_homedir="/var/lib/synapse"
@@ -31,7 +29,5 @@ make_dirs="
 	/etc/synapse 0755 synapse synapse"
 
 post_install() {
-	vinstall contrib/systemd/log_config.yaml 644 etc/synapse
-
 	vsv synapse
 }


### PR DESCRIPTION
also removed installation of a logging config file that assumed that systemd-journald was installed `generate-config` meintioned in INSTALL already creates a sensible logging configuration.