### PR TITLE
xq-api: update to 0.4.0.

### DIFF
--- a/srcpkgs/xq-api/template
+++ b/srcpkgs/xq-api/template
@@ -1,6 +1,6 @@
 # Template file for 'xq-api'
 pkgname=xq-api
-version=0.3.0
+version=0.4.0
 revision=1
 build_style=go
 go_import_path=go.spiff.io/xq-api
@@ -11,7 +11,7 @@ maintainer="Noel Cower <ncower@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/nilium/xq-api"
 distfiles="https://github.com/nilium/xq-api/archive/v${version}.tar.gz"
-checksum=2db5089928be8c809fb5df40b35351fb379912283eee54edcdb16f93e6d341ae
+checksum=0d03345899feb2094e662e6e1d0a4de09ebb82f4f2a474cdc48504059c837c6d
 system_accounts="_xqapi"
 _xqapi_homedir="/var/lib/xq-api"
 


### PR DESCRIPTION
Needed to support zstd-compressed repodata, since that change broke the
package search.