### PR TITLE
yggdrasil: add service changes from upstream systemd unit

### DIFF
--- a/srcpkgs/yggdrasil/files/yggdrasil/run
+++ b/srcpkgs/yggdrasil/files/yggdrasil/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+/usr/bin/modprobe tun
 if [ -f /etc/yggdrasil.conf ]; then
 	exec /usr/bin/yggdrasil --useconffile /etc/yggdrasil.conf 1>/dev/null
 else

--- a/srcpkgs/yggdrasil/files/yggdrasil/run
+++ b/srcpkgs/yggdrasil/files/yggdrasil/run
@@ -1,9 +1,9 @@
 #!/bin/sh
-/usr/bin/modprobe tun
+modprobe tun
 caps='-all,+NET_ADMIN,+NET_RAW'
-drop_caps="/usr/bin/setpriv --inh-caps $caps --bounding-set $caps"
+drop_caps="setpriv --inh-caps $caps --bounding-set $caps"
 if [ -f /etc/yggdrasil.conf ]; then
-	exec $drop_caps /usr/bin/yggdrasil --useconffile /etc/yggdrasil.conf 1>/dev/null
+	exec $drop_caps yggdrasil --useconffile /etc/yggdrasil.conf 1>/dev/null
 else
-	exec $drop_caps /usr/bin/yggdrasil --autoconf 1>/dev/null
+	exec $drop_caps yggdrasil --autoconf 1>/dev/null
 fi

--- a/srcpkgs/yggdrasil/files/yggdrasil/run
+++ b/srcpkgs/yggdrasil/files/yggdrasil/run
@@ -1,7 +1,9 @@
 #!/bin/sh
 /usr/bin/modprobe tun
+caps='-all,+NET_ADMIN,+NET_RAW'
+drop_caps="/usr/bin/setpriv --inh-caps $caps --bounding-set $caps"
 if [ -f /etc/yggdrasil.conf ]; then
-	exec /usr/bin/yggdrasil --useconffile /etc/yggdrasil.conf 1>/dev/null
+	exec $drop_caps /usr/bin/yggdrasil --useconffile /etc/yggdrasil.conf 1>/dev/null
 else
-	exec /usr/bin/yggdrasil --autoconf 1>/dev/null
+	exec $drop_caps /usr/bin/yggdrasil --autoconf 1>/dev/null
 fi

--- a/srcpkgs/yggdrasil/template
+++ b/srcpkgs/yggdrasil/template
@@ -1,7 +1,7 @@
 # Template file for 'yggdrasil'
 pkgname=yggdrasil
 version=0.3.14
-revision=1
+revision=2
 wrksrc="yggdrasil-go-${version}"
 build_style=go
 go_import_path=github.com/yggdrasil-network/yggdrasil-go

--- a/srcpkgs/yggdrasil/template
+++ b/srcpkgs/yggdrasil/template
@@ -6,6 +6,7 @@ wrksrc="yggdrasil-go-${version}"
 build_style=go
 go_import_path=github.com/yggdrasil-network/yggdrasil-go
 hostmakedepends="go git"
+depends=util-linux
 short_desc="Experiment in scalable routing as an encrypted IPv6 overlay network"
 maintainer="Jan Christian Gruenhage <jan.christian@gruenhage.xyz>"
 license="LGPL-3.0-only"


### PR DESCRIPTION
yggdrasil will fail to start if the `tun` kernel module is not loaded. Upstream modified their [service file](https://github.com/yggdrasil-network/yggdrasil-go/blob/4b16c325a3d90d97df208457bc35d499249f8146/contrib/systemd/yggdrasil.service) to first attempt to load the module before starting the service. They also opted to drop capabilities to CAP_NET_ADMIN and CAP_NET_RAW, which I saw fit to include.