### PR TITLE
New package: font-jetbrainsmono-ttf-1.0.6

### DIFF
--- a/srcpkgs/font-jetbrainsmono-ttf/template
+++ b/srcpkgs/font-jetbrainsmono-ttf/template
@@ -1,0 +1,23 @@
+# Template file for 'font-jetbrainsmono-ttf'
+# Template made by gcat432
+pkgname=font-jetbrainsmono-ttf
+version=1.0.6
+revision=1
+archs=noarch
+wrksrc="JetBrainsMono-${version}"
+short_desc="JetbrainsMono: Typeface font with ligatures for programming"
+maintainer="alferguet <afernandezh@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/JetBrains/JetBrainsMono"
+distfiles="https://github.com/JetBrains/JetBrainsMono/archive/v${version}.tar.gz"
+checksum=c2f3a7c063659d9d8414a1b8c38471723c2f3a97d24fdae32c450db7811ade02
+
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir usr/share/fonts/TTF
+	cd ttf
+	for f in *.ttf; do
+		vinstall $f 0644 /usr/share/fonts/TTF
+	done
+}


### PR DESCRIPTION
New free TrueType font with ligatures by the JetBrains team for their IDEs but also available standalone.

I needed to open the new pull request from #18671 because no longer have access to the old fork and some modifications were required asides from the update, made by @gcat432 . 