### PR TITLE
Remove v from the detected version match group

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -144,7 +144,7 @@ update_check() {
         fi
 
         rx=${pattern:-$rx}
-        rx=${rx:-'(?<!-)\b\Q'"$pkgname"'\E[-_]?((src|source)[-_])?\K([^-/_\s]*?\d[^-/_\s]*?)(?=(?:[-_.](?:src|source|orig))?\.(?:[jt]ar|shar|t[bglx]z|tbz2|zip))\b'}
+        rx=${rx:-'(?<!-)\b\Q'"$pkgname"'\E[-_]?((src|source)[-_])?v?\K([^-/_\s]*?\d[^-/_\s]*?)(?=(?:[-_.](?:src|source|orig))?\.(?:[jt]ar|shar|t[bglx]z|tbz2|zip))\b'}
 
         if [ "${fetchedurls[$url]}" ]; then
             if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then

--- a/srcpkgs/perl-Test-Trap/update
+++ b/srcpkgs/perl-Test-Trap/update
@@ -1,0 +1,1 @@
+pattern="${pkgname/perl-/}-\Kv[\d.]+(?=\.tar\.gz)"


### PR DESCRIPTION
The source archives for perl-Test-MockModule have a 'v' placed before the version string. This is throwing off the update-check utility:

```
./xbps-src update-check perl-Test-MockModule
perl-Test-MockModule-0.172.0 -> perl-Test-MockModule-v0.170.0
perl-Test-MockModule-0.172.0 -> perl-Test-MockModule-v0.171.0
perl-Test-MockModule-0.172.0 -> perl-Test-MockModule-v0.172.0
```
By making v an optional character before the version capture group, we can now return only decimals for a version. 

```
grep "^version=v" srcpkgs/*/template
srcpkgs/ci20-uboot/template:version=v2013.10
srcpkgs/odroid-u2-uboot/template:version=v2010.12
srcpkgs/perl-Test-Trap/template:version=v0.3.4
```

It looks like there are only three templates that explicitly have 'v' incorrectly embedded in their `version=` value. Both uboot templates are easily fixed. The perl-Test-Trap template is the opposite problem of perl-Test-MockModule, the 'v' should not be part of the version, but it does mean then that the update-check does correctly parse things. 

Fixing up the version value in these three templates won't be a problem, but I'm unsure how xbps will handle the version string changing or if it will impact people with the packages already installed. 

If it's simply adjusting the value / things that reference it, then revbumping each, I'll attach them as separate commits to this PR. 