### PR TITLE
New package: deadd-notification-center-1.7.2

### DIFF
--- a/srcpkgs/deadd-notification-center/patches/mirror.patch
+++ b/srcpkgs/deadd-notification-center/patches/mirror.patch
@@ -1,0 +1,31 @@
+diff -Np1 a/stack.yaml b/stack.yaml
+*** a/stack.yaml	2020-03-04 17:55:17.530246000 +0600
+--- b/stack.yaml	2020-03-04 22:38:18.133458418 +0600
+*************** extra-package-dbs: []
+*** 86,87 ****
+  # Allow a newer minor version of GHC than the snapshot specifies
+! # compiler-check: newer-minor
+\ No newline at end of file
+--- 86,107 ----
+  # Allow a newer minor version of GHC than the snapshot specifies
+! # compiler-check: newer-minor
+! 
+! # Alternative mirrors to fix s3.amazonaws.com connection issues
+! # Details: https://docs.haskellstack.org/en/stable/yaml_configuration/#package-indices
+! package-indices:
+! - download-prefix: https://hackage.haskell.org/
+!   hackage-security:
+!     keyids:
+!     - 0a5c7ea47cd1b15f01f5f51a33adda7e655bc0f0b0615baa8e271f4c3351e21d
+!     - 1ea9ba32c526d1cc91ab5e5bd364ec5e9e8cb67179a471872f6e26f0ae773d42
+!     - 280b10153a522681163658cb49f632cde3f38d768b736ddbc901d99a1a772833
+!     - 2a96b1889dc221c17296fcc2bb34b908ca9734376f0f361660200935916ef201
+!     - 2c6c3627bd6c982990239487f1abd02e08a02e6cf16edb105a8012d444d870c3
+!     - 51f0161b906011b52c6613376b1ae937670da69322113a246a09f807c62f6921
+!     - 772e9f4c7db33d251d5c6e357199c819e569d130857dc225549b40845ff0890d
+!     - aa315286e6ad281ad61182235533c41e806e5a787e0b6d1e7eef3f09d137d2e9
+!     - fe331502606802feac15e514d9b9ea83fee8b6ffef71335479a2e68d84adc6b0
+!     key-threshold: 3 # number of keys required
+! 
+!     # ignore expiration date, see https://github.com/commercialhaskell/stack/pull/4614
+!     ignore-expiry: true

--- a/srcpkgs/deadd-notification-center/template
+++ b/srcpkgs/deadd-notification-center/template
@@ -1,0 +1,35 @@
+# Template file for 'deadd-notification-center'
+pkgname=deadd-notification-center
+version=1.7.2
+revision=1
+archs="x86_64"
+wrksrc="linux_notification_center-${version}"
+create_wrksrc=yes
+build_style=gnu-makefile
+hostmakedepends="tar xz stack pkg-config cairo gobject-introspection"
+makedepends="pango-devel libxml2-devel gtk+3-devel glib-devel"
+depends="gobject-introspection gtk+3"
+short_desc="Notification daemon/center GUI for linux"
+maintainer="reback00 <reback00@protonmail.com>"
+license="BSD-3-Clause-Clear"
+homepage="https://github.com/phuhl/linux_notification_center"
+distfiles="https://github.com/phuhl/linux_notification_center/archive/${version}.tar.gz"
+checksum=f5359432d6e90ff65bb7b970bbe00561fc9765a3e9707be8ab0e5f8ca14ef10b
+patch_args="-Np1"
+nopie=yes
+
+do_extract() {
+	# To get rid of directory inside directory and have a clean structure
+	tar xf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${version}.tar.gz \
+		--strip-components=1 -C ${wrksrc}
+}
+
+pre_build() {
+	# Fix for "GHC bindist has not yet been added for OS key 'linux64-ncurses6'" error.
+	# Details: https://docs.haskellstack.org/en/stable/faq/#how-do-i-install-ghc-in-stack-when-it-fails-with-the-error-missing-ghc-bindist-for-linux64-ncurses6
+	ln -sf ../../usr/lib/libncursesw.so.6 ../../usr/lib/libtinfo.so.6
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
deadd is a feature rich GUI notification center with a notification daemon as featured in a recent [Brodie Robertson video](https://www.youtube.com/watch?v=jhp8Xb1190g). It can be configured to look like Win10 Notification Center.

Screenshots and info [here](https://github.com/phuhl/linux_notification_center).

Hope it's useful.

**EDIT:** `archs` is set to `x86_64` due to all sorts of errors in i686, such as `Unable to find installation URLs for OS key: linux32-tinfo6`, which requires something like `ncurses5-compat-libs` to be [ported](https://aur.archlinux.org/packages/aura-git/#comment-663743) from Arch. Any help is appreciated.