### PR TITLE
python3-humanize: update to 2.0.0.

### DIFF
--- a/srcpkgs/python3-humanize/template
+++ b/srcpkgs/python3-humanize/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-humanize'
 pkgname=python3-humanize
-version=1.0.0
+version=2.0.0
 revision=1
 archs=noarch
 wrksrc="humanize-${version}"
@@ -12,7 +12,18 @@ maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
 license="MIT"
 homepage="https://github.com/jmoiron/humanize"
 distfiles="${PYPI_SITE}/h/humanize/humanize-${version}.tar.gz"
-checksum=38ace9b66bcaeb7f8186b9dbf0b3448e00148e5b4fbaf726f96c789e52c3e741
+checksum=1766e8b82772abdf54a0b3620b14b21b36feba5160401838f97d18a4c58c7f71
+
+do_patch() {
+	# This line calls 'pkg_resources' and breaks testing due to a
+	# missing distribution (possibly because it expects the package
+	# to have already been installed).
+	sed -i "s/VERSION = .*$/VERSION = '${version}'/" src/humanize/__init__.py
+}
+
+do_check() {
+	PYTHONPATH="${PWD}/build/lib" python3 -m pytest
+}
 
 post_install() {
 	vlicense LICENCE


### PR DESCRIPTION
Only major change is dropping Python 2 support (which we never packaged, anyway).