### PR TITLE
New packages: tageditor, tagparser and c++utilities

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3859,3 +3859,4 @@ libbudgie-plugin.so.0 budgie-desktop-10.5.1_1
 libslirp.so.0 libslirp-4.2.0_1
 libqpdf.so.28 libqpdf-10.0.0_1
 libstk-4.6.1.so libstk-4.6.1_1
+libc++utilities.so.5 cpp-utilities-5.2.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3860,3 +3860,4 @@ libslirp.so.0 libslirp-4.2.0_1
 libqpdf.so.28 libqpdf-10.0.0_1
 libstk-4.6.1.so libstk-4.6.1_1
 libc++utilities.so.5 cpp-utilities-5.2.0_1
+libtagparser.so.9 tagparser-9.1.2_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3861,3 +3861,4 @@ libqpdf.so.28 libqpdf-10.0.0_1
 libstk-4.6.1.so libstk-4.6.1_1
 libc++utilities.so.5 cpp-utilities-5.2.0_1
 libtagparser.so.9 tagparser-9.1.2_1
+libqtutilities.so.6 qtutilities-6.0.4_1

--- a/srcpkgs/cpp-utilities-devel
+++ b/srcpkgs/cpp-utilities-devel
@@ -1,0 +1,1 @@
+cpp-utilities

--- a/srcpkgs/cpp-utilities/template
+++ b/srcpkgs/cpp-utilities/template
@@ -1,0 +1,35 @@
+# Template file for 'cpp-utilities'
+pkgname=cpp-utilities
+version=5.2.0
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS:BOOL=ON"
+short_desc="C++ library for argument parsing, IO, parsing and more"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-2.0-only"
+homepage="https://github.com/Martchus/cpp-utilities"
+distfiles="https://github.com/Martchus/${pkgname}/archive/v${version}.tar.gz"
+checksum=34b4ef7b8d5ce04ebb4ce685ce6a51656e7bd26f902796c2b4b904f54a97871f
+
+cpp-utilities-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+
+		# Rename cmake modules to fit with the rest of the system
+		vmkdir usr/lib/cmake
+		cmake_source="${DESTDIR}/usr/share/c++utilities/cmake"
+		cmake_dest="${PKGDESTDIR}/usr/lib/cmake/c++utilities"
+		mv "$cmake_source" "$cmake_dest"
+
+		# Update cmake configuration to point to new location
+		vsed -i "${cmake_dest}/c++utilitiesConfig.cmake" \
+			-e "s@share/c++utilities/cmake@lib/cmake/c++utilities@g"
+
+		# The rest of share is just development-related stuff
+		vmove usr/share/c++utilities
+	}
+}

--- a/srcpkgs/qtutilities-devel
+++ b/srcpkgs/qtutilities-devel
@@ -1,0 +1,1 @@
+qtutilities

--- a/srcpkgs/qtutilities/template
+++ b/srcpkgs/qtutilities/template
@@ -1,0 +1,34 @@
+# Template file for 'qtutilities'
+pkgname=qtutilities
+version=6.0.4
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS:BOOL=ON"
+hostmakedepends="qt5-qmake qt5-host-tools"
+makedepends="qt5-tools-devel cpp-utilities-devel"
+short_desc="Qt helper routines, including dialogs, widgets, and models"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-2.0-only"
+homepage="https://github.com/Martchus/qtutilities"
+distfiles="https://github.com/Martchus/${pkgname}/archive/v${version}.tar.gz"
+checksum=c5ffbeb96607212386077bad00818e0c21920e342e118a5f77e923d07018e20f
+
+qtutilities-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision} cpp-utilities-devel"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+
+		# Rename cmake modules to fit with the rest of the system
+		vmkdir usr/lib/cmake
+		cmake_source="${DESTDIR}/usr/share/${sourcepkg}/cmake"
+		cmake_dest="${PKGDESTDIR}/usr/lib/cmake/${sourcepkg}"
+		mv "$cmake_source" "$cmake_dest"
+
+		# Update cmake configuration to point to new location
+		vsed -i "${cmake_dest}/${sourcepkg}Config.cmake" \
+			-e "s@share/${sourcepkg}/cmake@lib/cmake/${sourcepkg}@g"
+	}
+}

--- a/srcpkgs/tageditor/template
+++ b/srcpkgs/tageditor/template
@@ -1,0 +1,72 @@
+# Template file for 'tageditor'
+pkgname=tageditor
+version=3.3.4
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS:BOOL=ON"
+makedepends="tagparser-devel cpp-utilities-devel"
+short_desc="Tag editor for AAC, ID3, Vorbis, Opus, FLAC and Matroska"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-2.0-only"
+homepage="https://github.com/Martchus/tageditor"
+distfiles="https://github.com/Martchus/${pkgname}/archive/v${version}.tar.gz"
+checksum=0874301bd7644a312d259d54a8b60366c0db80e5b1179c1039cad9905c95463d
+
+build_options="qt webengine webkit script"
+build_options_default="qt"
+
+desc_option_webengine="Enable support for qt5-webengine file views (requires qt)"
+desc_option_webkit="Enable support for qt5-webkit file views (requires qt)"
+desc_option_script="Enable support for qt5-script javascript (requires qt)"
+
+# Prefer qt5-webengine to qt5-webkit, if it can be built
+case "$XBPS_TARGET_MACHINE" in
+	# qt5-webengine not supported on these architectures
+	ppc|ppc-musl|armv5tel*);;
+	*) if [ "$XBPS_WORDSIZE" = "$XBPS_TARGET_WORDSIZE" ]; then
+		# webengine can be built only if word size matches
+		webview_backend="webengine"
+	fi;;
+esac
+build_options_default+=" ${webview_backend:-webkit}"
+
+vopt_conflict webengine webkit
+
+if [ "$build_option_qt" ]; then
+	hostmakedepends+=" qt5-host-tools qt5-qmake"
+	makedepends+=" qtutilities-devel qt5-tools-devel qt5-declarative-devel"
+
+	if [ "$build_option_webengine" ]; then
+		configure_args+=" -DWEBVIEW_PROVIDER=webengine"
+		makedepends+=" qt5-location-devel
+				qt5-webengine-devel qt5-webchannel-devel"
+	elif [ "$build_option_webkit" ]; then
+		configure_args+=" -DWEBVIEW_PROVIDER=webkit"
+		makedepends+=" qt5-webkit-devel"
+	else
+		configure_args+=" -DWEBVIEW_PROVIDER=none"
+	fi
+
+	if [ "$build_option_script" ]; then
+		configure_args+=" -DJS_PROVIDER=script"
+		makedepends+=" qt5-script-devel"
+	else
+		configure_args+=" -DJS_PROVIDER=qml"
+	fi
+else
+	configure_args+=" -DWIDGETS_GUI:BOOL=OFF -DQUICK_GUI:BOOL=OFF"
+fi
+
+pre_build() {
+	if [ -z "$build_option_qt" ]; then
+		vsed -i application/main.cpp -e "/^using namespace QtUtilities;$/s@^@//@"
+	fi
+}
+
+post_install() {
+	if [ -z "$build_option_qt" ]; then
+		rm -rf "${DESTDIR}/usr/share/metainfo"
+		rm -rf "${DESTDIR}/usr/share/icons"
+		rm -rf "${DESTDIR}/usr/share/applications"
+	fi
+}

--- a/srcpkgs/tagparser-devel
+++ b/srcpkgs/tagparser-devel
@@ -1,0 +1,1 @@
+tagparser

--- a/srcpkgs/tagparser/template
+++ b/srcpkgs/tagparser/template
@@ -1,0 +1,34 @@
+# Template file for 'tagparser'
+pkgname=tagparser
+version=9.1.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS:BOOL=ON"
+makedepends="cpp-utilities-devel zlib-devel"
+short_desc="C++ library for handling AAC, ID3, Vorbis, Opus, FLAC and Matroska tags"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="GPL-2.0-only"
+homepage="https://github.com/Martchus/tagparser"
+distfiles="https://github.com/Martchus/${pkgname}/archive/v${version}.tar.gz"
+checksum=234987086ac0dff279a3888b0e965294fdca6adb7412b063ea36f2cc564fbce2
+
+tagparser-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision} cpp-utilities-devel"
+
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+
+		# Rename cmake modules to fit with the rest of the system
+		vmkdir usr/lib/cmake
+		cmake_source="${DESTDIR}/usr/share/${sourcepkg}/cmake"
+		cmake_dest="${PKGDESTDIR}/usr/lib/cmake/${sourcepkg}"
+		mv "$cmake_source" "$cmake_dest"
+
+		# Update cmake configuration to point to new location
+		vsed -i "${cmake_dest}/${sourcepkg}Config.cmake" \
+			-e "s@share/${sourcepkg}/cmake@lib/cmake/${sourcepkg}@g"
+	}
+}


### PR DESCRIPTION
This PR introduces packages for `tageditor` and its dependencies, `tagparser` and `c++utilities`. `tageditor` is a utility to manipulate tags on audio and video files. This build enables an optional qt5 GUI but provides build options to package a CLI-only version to keep dependencies light.