### PR TITLE
kdevelop: don't depend on kde5-baseapps

### DIFF
--- a/srcpkgs/kdevelop/INSTALL.msg
+++ b/srcpkgs/kdevelop/INSTALL.msg
@@ -1,4 +1,5 @@
 Some optional packages may be installed for additional functionality:
 
-- kdevelop-python: python3 language and django project support
-- kdevelop-php   : PHP language support
+* kdevelop-python: python3 language and django project support
+* kdevelop-php   : PHP language support
+* cmake, git, cppcheck, indent (see kdevelop plugins)

--- a/srcpkgs/kdevelop/template
+++ b/srcpkgs/kdevelop/template
@@ -1,7 +1,7 @@
 # Template file for 'kdevelop'
 pkgname=kdevelop
 version=5.5.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools qt5-tools
  kcmutils kcoreaddons kdevelop-pg-qt plasma-framework gettext llvm tar which"
@@ -10,7 +10,8 @@ makedepends="apr-util-devel clang grantlee5-devel kcmutils-devel kdevelop-pg-qt
  ktexteditor-devel libkomparediff2-devel libksysguard-devel okteta-devel
  purpose-devel qt5-location-devel qt5-webchannel-devel subversion-devel
  $(vopt_if webengine 'qt5-webengine-devel' 'qt5-webkit-devel')"
-depends="cmake cppcheck git indent kde5-baseapps"
+# khelpcenter is required to display documentation
+depends="khelpcenter"
 short_desc="Integrated Development Environment for C++/C"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"


### PR DESCRIPTION
I was shocked to learn that kdevelop pulls all kde5-baseapps.

I say we adapt Void's minimal-by-default concept here, and users install dependencies as they need them.

@yopito: please approve