### PR TITLE
python3-Markdown: update to 3.2.1.

### DIFF
--- a/srcpkgs/python3-Markdown
+++ b/srcpkgs/python3-Markdown
@@ -1,1 +1,0 @@
-python-Markdown

--- a/srcpkgs/python3-Markdown/template
+++ b/srcpkgs/python3-Markdown/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-Markdown'
+pkgname=python3-Markdown
+version=3.2.1
+revision=1
+archs=noarch
+wrksrc="Markdown-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Python3 implementation of John Gruber's Markdown"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="BSD-3-Clause"
+homepage="https://github.com/waylan/Python-Markdown"
+distfiles="${PYPI_SITE}/M/Markdown/Markdown-${version}.tar.gz"
+checksum=90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902
+alternatives="markdown:markdown_py:/usr/bin/markdown_py3"
+
+post_install() {
+	vlicense LICENSE.md LICENSE
+}


### PR DESCRIPTION
Upstream has dropped support for Python 2.7:

    https://python-markdown.github.io/change_log/release-3.2/

Eventually, we will want to remove python-Markdown.