### PR TITLE
chromium: update to 80.0.3987.132.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=80.0.3987.122
+version=80.0.3987.132
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=eed37588679549e0b9cc4e5f658e068c4ed8cf48cb05cae8e47cdc8141fb374e
+checksum=681161c5f418c7fda572b1e0dc7df32983b94bc5cb5a7db31d7a92a33353b003
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=80.0.3987.122
+version=80.0.3987.132
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=48ebcbdcc20fa5864f1b0f0bf8163f8801ed59f82d13744f0303b497db412473
+checksum=2c0012059046a5a7e2bf6e9502f1898f1953226d63b724b82fc18226e285c201
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
[ci skip]

- Built for x86_64, x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine.