### PR TITLE
mesa: add iris

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=20.0.1
-revision=1
+revision=2
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
@@ -38,7 +38,7 @@ replaces="libGL>=10_1<19.2.5_2 libEGL>=10_1<19.2.5_2 libGLES>=10_1<19.2.5_2"
 case "$XBPS_TARGET_MACHINE" in
 i686*|x86_64*)
 	# Enable all x86 drivers.
-	configure_args+=" -Dgallium-drivers=r300,r600,radeonsi,svga,swrast,nouveau,virgl"
+	configure_args+=" -Dgallium-drivers=r300,r600,radeonsi,svga,swrast,nouveau,virgl,iris"
 	configure_args+=" -Ddri-drivers=i915,i965,r100,r200,nouveau"
 	configure_args+=" -Dgallium-xa=true -Ddri3=true -Dgallium-nine=true"
 	configure_args+=" -Dvulkan-drivers=intel,amd"


### PR DESCRIPTION
iris is new gallium driver for gen8 and newer intel gpus (should be default since mesa 20)