### PR TITLE
nss: update to 3.51.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.25
 
 pkgname=nss
-version=3.50
+version=3.51
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,7 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=185df319775243f5f5daa9d49b7f9cc5f2b389435be3247c3376579bee063ba7
+checksum=75348b3b3229362486c57a880db917da1f96ef4eb639dc9cc2ff17d72268459c
 
 do_build() {
 	local _native_use64 _target_use64


### PR DESCRIPTION
- run check with x86_64, x86_64-musl, i686
- run with firefox-esr on x86_64, and firefox on x86_64-musl