### PR TITLE
libgee08: update to 0.20.3.

### DIFF
--- a/srcpkgs/libgee08/template
+++ b/srcpkgs/libgee08/template
@@ -1,6 +1,6 @@
 # Template file for 'libgee08'
 pkgname=libgee08
-version=0.20.2
+version=0.20.3
 revision=1
 wrksrc="libgee-${version}"
 build_style=gnu-configure
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/Libgee"
 distfiles="${GNOME_SITE}/libgee/${version%.*}/libgee-${version}.tar.xz"
-checksum=9e035c4b755f46bfae70ba81cdcf8328b03f554373cec8c816e8b5680f85353c
+checksum=d0b5edefc88cbca5f1709d19fa62aef490922c6577a14ac4e7b085507911a5de
 
 # Package build options
 build_options="gir vala"


### PR DESCRIPTION
SO name didn't change, so I'm not revbumping dependent packages. Tested with a random program that depends on this - gitg - successfully.