### PR TITLE
nerd-fonts: fix font source

### DIFF
--- a/srcpkgs/nerd-fonts/template
+++ b/srcpkgs/nerd-fonts/template
@@ -1,64 +1,34 @@
 # Template file for 'nerd-fonts'
 pkgname=nerd-fonts
 version=2.1.0
-revision=1
+revision=2
 archs=noarch
-create_wrksrc=yes
-build_wrksrc=NerdFonts
 depends="font-util xbps-triggers nerd-fonts-ttf nerd-fonts-otf"
 short_desc="Iconic font aggregator, collection and patcher"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="MIT"
 homepage="https://nerdfonts.com"
-distfiles="https://gitlab.com/devopsdeluxe/nerd-fonts-aur/raw/v${version}/release/NerdFonts.tar.xz
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/LICENSE>LICENSE.txt
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_all.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_dev.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_fa.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_fae.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_iec.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_linux.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_material.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_oct.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_ple.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_pom.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_seti.sh
- https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v${version}/bin/scripts/lib/i_weather.sh"
-checksum="6e203ec84af9f55959141025a96ad3788c8edc7777b7dbcc1fafa600214c1213
- d2a29823384e9194a87936ccad495c764c2ef733b29bfa6f72a1d65803ce02e5
- 036361c808c84242b819ba24246f205b283ae51ba5d5d3304848f999a3ff0622
- 254f32ceca71d36afee8ddbcd2c98a5de06ab7d7579f03e693987501bef6476b
- f3d00c7188f9499911c8215483cb9b430fa1873f531fa57fd30ca20f0cad5314
- 09cfd8e5748c6401ee2bae24b95eb1c98cb7f7a4200c6337b741084612091b1c
- f0fe3eac3a979610153ca60611954cf4baba133e1268f395e2f61a8b800d26dd
- 3406824f07f7b92757d88356f9f3d89e2270eae0f2862205e7ed1eb8bd294eaf
- cddb161c6b4a3ec5f4e4d1723ebc9ce0bea6da572bbb940999a05eaf9ad52d74
- 67ab5c4bb0d4d057c4d6cd34075a8643f6f845977a2c57d56f05ac931b2f54f0
- d94a7c8ede808826258ed651f040bf4d3904fbf81c722692359b5ca5f30d6135
- 50be7ad9d955a05ba56badabde7992cf5277cc2ccb2348af3293a517bfaefe9d
- 3245d4859e7c4fe311e79599a406af84564c079d0ba5f36d3a458ee646ca5aac
- ced3b935d4f4a04e98da215862de6b6ab4282669fd20ff0b039c913b2f322dec"
+distfiles="https://github.com/ryanoasis/nerd-fonts/archive/v${version}.tar.gz"
+checksum="a084ca91a174b547bab4523507824c76aa91ebcf38f9256a4ffd181813f87bd8"
 
 do_install() {
 	vmkdir usr/share/fonts/NerdFonts/otf
 	vmkdir usr/share/fonts/NerdFonts/ttf
 	vmkdir usr/lib/NerdFonts
 
-	for otf in *.otf; do
-		vinstall "$otf" 644 usr/share/fonts/NerdFonts/otf
+	# get all patched fonts
+	find patched-fonts -name '*.otf' -exec install -Dm644 '{}' ${DESTDIR}/usr/share/fonts/NerdFonts/otf \;
+	find patched-fonts -name '*.ttf' -exec install -Dm644 '{}' ${DESTDIR}/usr/share/fonts/NerdFonts/ttf \;
+
+	# remove windows-compatible fonts
+	find ${DESTDIR}/usr/share/fonts/NerdFonts -name '*Windows Compatible.*tf' -delete
+
+	# install patching scripts
+	for sh in bin/scripts/lib/i_*.sh; do
+		vinstall $sh 744 usr/lib/NerdFonts
 	done
 
-	while read -r ttf; do
-		# This fails horribly due to some possible mangling
-		# vinstall "$tff" 644 usr/share/fonts/NerdFonts/ttf
-		install -m 644 "$ttf" ${DESTDIR}/usr/share/fonts/NerdFonts/ttf
-	done < <(find . -name '*.ttf')
-
-	while read -r sh; do
-		vinstall $sh 755 usr/lib/NerdFonts
-	done < <(find ../ -maxdepth 1 -name "i_*.sh")
-
-	vlicense ../LICENSE.txt
+	vlicense LICENSE
 }
 
 nerd-fonts-otf_package() {


### PR DESCRIPTION
(Paging @daniel-eys) This commit does not quite work yet, but it's a start in fixing the font source issue I created with the last nerd-fonts commit. Please do NOT merge this yet, even if it passes the builder tests. Attached is a log file showing the output of xbps-src attempting to package nerd-fonts using this template. I'm stumped as to what could be going  wrong.
[nerd-fonts.log](https://github.com/void-linux/void-packages/files/4306838/nerd-fonts.log)
