### PR TITLE
[WIP] Keybase 5.3

### DIFF
--- a/srcpkgs/keybase-desktop/template
+++ b/srcpkgs/keybase-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'keybase-desktop'
 pkgname=keybase-desktop
-version=5.2.1
+version=5.3.0
 revision=1
 wrksrc="client-${version}"
 hostmakedepends="git nodejs-lts yarn unzip"
@@ -10,7 +10,7 @@ maintainer="Dominic Monroe <monroef4@googlemail.com>"
 license="BSD-3-Clause"
 homepage="https://keybase.io"
 distfiles="https://github.com/keybase/client/archive/v${version}.tar.gz"
-checksum=209860c9b8c8e7d24b93b53afa2865aea543c2b83a3110f822d54b569f4deffe
+checksum=deec021a24e2f0d5e45818f818fc38e31a808c00644eb13b58237285e84f07ad
 nostrip_files="Keybase"
 
 case "${XBPS_TARGET_MACHINE}" in

--- a/srcpkgs/keybase/template
+++ b/srcpkgs/keybase/template
@@ -1,6 +1,6 @@
 # Template file for 'keybase'
 pkgname=keybase
-version=5.2.1
+version=5.3.0
 revision=1
 wrksrc="client-${version}"
 build_style=go
@@ -17,7 +17,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://keybase.io/"
 distfiles="https://github.com/keybase/client/archive/v${version}.tar.gz"
-checksum=209860c9b8c8e7d24b93b53afa2865aea543c2b83a3110f822d54b569f4deffe
+checksum=deec021a24e2f0d5e45818f818fc38e31a808c00644eb13b58237285e84f07ad
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
tested on x64, glibc, however, the following bug appears on my desktop: openbox + lxqt

> Note: On some Linux platforms, specifically with window managers like i3wm and others without support for StatusNotifier, the system tray icon will no longer appears, so if Keybase is minimized, it must be restarted to display it again, though it is running in the background. Two workarounds (in official Keybase packages) are running /opt/keybase/Keybase and with systemd, systemctl --user restart keybase.gui). We're working on a better UX around this experience.

@Vaelatern what's the appropriate remedy? Add INSTALL.msg ?