### PR TITLE
New package: epub2txt-2.01

### DIFF
--- a/srcpkgs/epub2txt/template
+++ b/srcpkgs/epub2txt/template
@@ -1,0 +1,12 @@
+# Template file for 'epub2txt'
+pkgname=epub2txt
+version=2.01
+revision=1
+wrksrc=epub2txt2-$version
+build_style=gnu-makefile
+short_desc="CLI utility for extracting text from EPUB documents"
+maintainer="Paper <paper@tilde.institute>"
+license="GPL-3.0-only"
+homepage="https://github.com/kevinboone/epub2txt2"
+distfiles="https://github.com/kevinboone/epub2txt2/archive/v$version.tar.gz"
+checksum=82c96c713c8a6e10d7b37e96db83a9d5f50fcb4b65034b4a1df1024776b6591f


### PR DESCRIPTION
should this be named epub2txt2 or epub2txt?