### PR TITLE
rpi-kernel: update to 4.19.108.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="742cb761fa7f2a25e9fc57afd72deb0c47b0c864"
+_githash="2fab54c74bf956951e61c6d4fe473995e8d07010"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.106
+version=4.19.108
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=51ca9832bacceb5405d8e862b1559f6a16a2110b01586362a99855980c2a23e5
+checksum=bc92c569bbdb53744dee458827c64119a16ee5267cdcba851e1832c3a174571c
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.