### PR TITLE
python3-acme: remove mock as dependency.

### DIFF
--- a/srcpkgs/python3-acme/patches/remove-mock.patch
+++ b/srcpkgs/python3-acme/patches/remove-mock.patch
@@ -1,0 +1,10 @@
+--- setup.py
++++ setup.py
+@@ -15,7 +15,6 @@
+     # 1.1.0+ is required to avoid the warnings described at
+     # https://github.com/certbot/josepy/issues/13.
+     'josepy>=1.1.0',
+-    'mock',
+     # Connection.set_tlsext_host_name (>=0.13)
+     'PyOpenSSL>=0.13.1',
+     'pyrfc3339',

--- a/srcpkgs/python3-acme/template
+++ b/srcpkgs/python3-acme/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-acme'
 pkgname=python3-acme
 version=1.3.0
-revision=1
+revision=2
 archs=noarch
 wrksrc="acme-${version}"
 build_style=python3-module


### PR DESCRIPTION
`certbot renew` failed for me with

```
Traceback (most recent call last):
  File "/usr/bin/certbot", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3251, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3234, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3263, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'mock' distribution was not found and is required by acme
```

this patch fixes that for me.  another solution would be to add `python3-mock` as dependency but since it's also patched out in `certbot` (see #17915) i thought this might be the way to go.