### PR TITLE
kmod: patch default output to /proc/self/fd/1

### DIFF
--- a/srcpkgs/kmod/patches/stdout.patch
+++ b/srcpkgs/kmod/patches/stdout.patch
@@ -1,0 +1,14 @@
+Use /proc/self/fd/1 instead of /dev/stdout, so we can use
+`kmod static-nodes` before udev is running.
+
+--- tools/static-nodes.c.orig
++++ tools/static-nodes.c
+@@ -156,7 +156,7 @@
+ {
+ 	struct utsname kernel;
+ 	char modules[PATH_MAX], buf[4096];
+-	const char *output = "/dev/stdout";
++	const char *output = "/proc/self/fd/1";
+ 	FILE *in = NULL, *out = NULL;
+ 	const struct static_nodes_format *format = &static_nodes_format_human;
+ 	int r, ret = EXIT_SUCCESS;

--- a/srcpkgs/kmod/template
+++ b/srcpkgs/kmod/template
@@ -1,7 +1,7 @@
 # Template file for 'kmod'
 pkgname=kmod
 version=27
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-zlib --with-xz"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
Fixes void-runit#38.