### PR TITLE
dante: rebuild for preload

### DIFF
--- a/srcpkgs/dante/template
+++ b/srcpkgs/dante/template
@@ -1,7 +1,7 @@
 # Template file for 'dante'
 pkgname=dante
 version=1.4.2
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="tar automake libtool"
 short_desc="SOCKS server and client"


### PR DESCRIPTION
using html filter in aerc returned this previously:
```
socksify: error: dante client not built with preloading support.
```
rebuilding dante solves it for me