### PR TITLE
facter: update to 3.14.9.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3846,5 +3846,4 @@ libOpenImageDenoise.so.0 openimagedenoise-1.1.0_1
 libblosc.so.1 c-blosc-1.17.1_1
 libopenvdb.so.7.0 openvdb-7.0.0_1
 libAlembic.so.1.7 alembic-1.7.12_1
-libfacter.so.3.14.8 facter-3.14.8_1
 libmodsecurity.so.3 modsecurity-3.0.4_1

--- a/srcpkgs/facter/template
+++ b/srcpkgs/facter/template
@@ -1,6 +1,6 @@
 # Template file for 'facter'
 pkgname=facter
-version=3.14.8
+version=3.14.9
 revision=1
 build_style=cmake
 configure_args="-DRUBY_CONFIG_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include
@@ -12,9 +12,9 @@ depends="net-tools ruby"
 short_desc="Collect and display system facts"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
-homepage="https://puppetlabs.com/facter"
+homepage="https://puppet.com/docs/puppet/latest/facter.html"
 distfiles="https://downloads.puppetlabs.com/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=ff6b5eb412bb7770c83a37a2f91451cec93e1f2d82b76506d94f52584619a3cb
+checksum=fcbc074c3032f6bc6b83053b3e75cd3936a98b2caa6abc5ce1b6abc49fef0856
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
I pulled the **.so** entry out of common/shlibs because nothing actually links against libfacter.so. I added it due to a previous xbps-src warning - but I've since learned that shlibs should be kept small, so unless something needs the library, don't add it to the file.