### PR TITLE
apparmor: fix dhcpcd profile

### DIFF
--- a/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
@@ -23,6 +23,8 @@ profile dhcpcd /{usr/,}bin/dhcpcd {
 
   /proc/*/net/if_inet6 r,
   /proc/sys/net/ipv{4,6}/conf/*/* rw,
+  /proc/sys/net/ipv{4,6}/neigh/*/retrans_time_ms w,
+  /proc/sys/net/ipv{4,6}/neigh/*/base_reachable_time_ms w,
 
   /{var/,}run/dhcpcd{-*,}.pid rwk,
   /{var/,}run/dhcpcd.sock rw,

--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
-# Template file for 'apparmor'.
+# Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.3
-revision=4
+revision=5
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure


### PR DESCRIPTION
Fixes "ipv6nd_applyra: Permission denied" after receiving a router advertisement.