### PR TITLE
llvm6.0: fix update file to filter out new versions

### DIFF
--- a/srcpkgs/llvm6.0/update
+++ b/srcpkgs/llvm6.0/update
@@ -1,3 +1,3 @@
 site=https://releases.llvm.org/
 pattern="'\K[\d\.]*(?=')"
-ignore="7.*"
+ignore="[!6]*"


### PR DESCRIPTION
I didn't revbump this, as the package doesn't actually need to be rebuilt. The update file just needed an update to remove false-positives for potential updates.  Will not revbumping this cause problems and/or is there some way to have the builders skip creating a new package for this merge?