### PR TITLE
WIP: Slant

### DIFF
--- a/srcpkgs/slant/template
+++ b/srcpkgs/slant/template
@@ -1,0 +1,26 @@
+# Template file for 'slant'
+pkgname=slant
+version=0.0.21
+revision=1
+build_style=configure
+configure_args="PREFIX=/usr MANDIR=/usr/share/man SBINDIR=/usr/bin"
+make_cmd="bmake"
+make_check_target="regress"
+hostmakedepends="bmake"
+makedepends="ksql kcgi libressl-devel ncurses-devel openradtool sqlbox zlib-devel"
+short_desc="Minimal open source system monitor for remote UNIX machines"
+maintainer="Anachron <gith@cron.world>"
+license="ISC"
+homepage="https://kristaps.bsd.lv/slant"
+distfiles="https://kristaps.bsd.lv/slant/snapshots/slant-${version}.tar.gz"
+checksum=69733d8b1cae1b6144a8a8f3e40615fee687512039f8fcc88b1bca73bf42ab08
+
+# /usr/bin/ld: slant-dns.o: in function 'dns_parse_url':
+# /builddir/slant-0.0.21/slant-dns.c:117: undefined reference to '__b64_ntop'
+pre_configure() {
+	vsed -i 's|$(LDADD_SLANT)|-lresolv $(LDADD_SLANT)|g' Makefile
+}
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/sqlbox/template
+++ b/srcpkgs/sqlbox/template
@@ -1,0 +1,21 @@
+# Template file for 'sqlbox'
+pkgname=sqlbox
+version=0.1.12
+revision=1
+wrksrc="sqlbox-VERSION_${version//./_}"
+build_style=configure
+configure_args="PREFIX=/usr MANDIR=/usr/share/man SBINDIR=/usr/bin"
+make_cmd="bmake"
+make_check_target="regress"
+hostmakedepends="bmake"
+makedepends="pkg-config sqlite-devel"
+short_desc="Secure database access library"
+maintainer="Anachron <gith@cron.world>"
+license="ISC"
+homepage="https://kristaps.bsd.lv/sqlbox"
+distfiles="https://github.com/kristapsdz/sqlbox/archive/VERSION_${version//./_}.tar.gz"
+checksum=c615829f6a76fdd0fbd4f048b42b40179f70af1eceab57b843d3fcf0dbe322a5
+
+post_install() {
+	vlicense LICENSE.md
+}


### PR DESCRIPTION
Closes #4376

Fails for now with

```
/usr/bin/ld: db.o: in function `db_trans_open':
/builddir/slant-0.0.21/db.c:175: undefined reference to `sqlbox_trans_deferred'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:173: undefined reference to `sqlbox_trans_immediate'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:171: undefined reference to `sqlbox_trans_exclusive'
/usr/bin/ld: db.o: in function `db_trans_rollback':
/builddir/slant-0.0.21/db.c:185: undefined reference to `sqlbox_trans_rollback'
/usr/bin/ld: db.o: in function `db_trans_commit':
/builddir/slant-0.0.21/db.c:194: undefined reference to `sqlbox_trans_commit'
/usr/bin/ld: db.o: in function `db_logging_data':
/builddir/slant-0.0.21/db.c:202: undefined reference to `sqlbox_msg_set_dat'
/usr/bin/ld: db.o: in function `db_open_logging':
/builddir/slant-0.0.21/db.c:245: undefined reference to `sqlbox_role_hier_alloc'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:251: undefined reference to `sqlbox_role_hier_sink'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:253: undefined reference to `sqlbox_role_hier_start'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:255: undefined reference to `sqlbox_role_hier_src'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:260: undefined reference to `sqlbox_role_hier_stmt'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:262: undefined reference to `sqlbox_role_hier_stmt'
/usr/bin/ld: /builddir/slant-0.0.21/db.c:264: undefined reference to `sqlbox_role_hier_stmt'
...
```