### PR TITLE
ponysay: apply patch for python3.8

### DIFF
--- a/srcpkgs/ponysay/patches/fix-do-not-compare-literal.patch
+++ b/srcpkgs/ponysay/patches/fix-do-not-compare-literal.patch
@@ -1,0 +1,36 @@
+From 69c23e3ae1e1e9e9f1ee3a06a706d755a4b1de48 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C3=93ZES=20=C3=81d=C3=A1m=20Istv=C3=A1n?=
+ <mozes.adam.istvan@pm.me>
+Date: Sat, 16 Nov 2019 09:58:28 +0100
+Subject: [PATCH] fix: do not compare literal with "is not"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Python3.8 issued the following warning on each ponysay invocation:
+
+/bin/ponysay/backend.py:294: SyntaxWarning: "is not" with a literal. Did you mean "!="?
+
+This has been corrected here.
+
+Signed-off-by: MÓZES Ádám István <mozes.adam.istvan@pm.me>
+---
+ src/backend.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/backend.py b/src/backend.py
+index 2cc539a5..82ff1496 100644
+--- a/src/backend.py
++++ b/src/backend.py
+@@ -291,7 +291,7 @@ class Backend():
+                         props = dollar[7:]
+                         if len(props) > 0:
+                             if ',' in props:
+-                                if props[0] is not ',':
++                                if props[0] != ',':
+                                     w = props[:props.index(',')]
+                                 h = int(props[props.index(',') + 1:])
+                             else:
+-- 
+2.25.1
+

--- a/srcpkgs/ponysay/template
+++ b/srcpkgs/ponysay/template
@@ -1,7 +1,7 @@
 # Template file for 'ponysay'
 pkgname=ponysay
 version=3.0.3
-revision=3
+revision=4
 archs=noarch
 hostmakedepends="python3 texinfo"
 depends="python3"
@@ -11,6 +11,7 @@ license="GPL-3.0-or-later"
 homepage="https://erkin.github.com/ponysay/"
 distfiles="https://github.com/erkin/${pkgname}/archive/${version}.tar.gz"
 checksum=c382d7f299fa63667d1a4469e1ffbf10b6813dcd29e861de6be55e56dc52b28a
+patch_args="-Np1"
 
 do_install() {
 	python3 setup.py --prefix=/usr --dest-dir=$DESTDIR \


### PR DESCRIPTION
This patch fixes the SyntaxWarning issue in python3.8.
See: https://github.com/erkin/ponysay/issues/295