### PR TITLE
font-iosevka: add slab-serif family

### DIFF
--- a/srcpkgs/font-iosevka/template
+++ b/srcpkgs/font-iosevka/template
@@ -1,7 +1,7 @@
 # Template file for 'font-iosevka'
 pkgname=font-iosevka
 version=2.3.3
-revision=1
+revision=2
 archs=noarch
 create_wrksrc=yes
 hostmakedepends="unzip"
@@ -11,9 +11,11 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="OFL-1.1"
 homepage="https://be5invis.github.io/Iosevka/"
 distfiles="https://raw.githubusercontent.com/be5invis/Iosevka/v${version}/LICENSE.md>LICENSE.txt
- https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip"
+ https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip
+ https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-slab-${version}.zip"
 checksum="ecfd74a1d6749bf509cee122870da0186bccfae446e3f6bc5faff253577ab000
- 619cefd74834c9277adf09b873a4fce6522d3f8e9241cfe15620c2f2662e7b4a"
+ 619cefd74834c9277adf09b873a4fce6522d3f8e9241cfe15620c2f2662e7b4a
+ 28e7560114ed4d21fef3fc32c4eed9638d2a1237ea7e529e0bccce89407c75e6"
 
 font_dirs="/usr/share/fonts/TTF"
 


### PR DESCRIPTION
The short description of package font-iosevka says "Slender monospace sans-serif and slab-serif typeface", but only the sans-serif family was included. This PR also adds the slab-serif family to the package