### PR TITLE
LGOGDownloader: update to 3.6.

### DIFF
--- a/srcpkgs/LGOGDownloader/template
+++ b/srcpkgs/LGOGDownloader/template
@@ -1,18 +1,18 @@
 # Template file for 'LGOGDownloader'
 pkgname=LGOGDownloader
-version=3.5
-revision=3
+version=3.6
+revision=1
 wrksrc="lgogdownloader-${version}"
 build_style=cmake
 hostmakedepends="pkg-config"
-makedepends="htmlcxx-devel tinyxml2-devel libcurl-devel liboauth-devel
- rhash-devel jsoncpp-devel boost-devel libressl-devel zlib-devel"
+makedepends="htmlcxx-devel tinyxml2-devel libcurl-devel rhash-devel
+ jsoncpp-devel boost-devel libressl-devel zlib-devel"
 short_desc="Open source downloader for GOG.com games that uses the GOG.com API"
 maintainer="RunningDroid <runningdroid@zoho.com>"
 license="WTFPL"
 homepage="https://github.com/Sude-/lgogdownloader"
 distfiles="https://github.com/Sude-/lgogdownloader/archive/v${version}.tar.gz"
-checksum=a7493f89e80796a4870d8fbc7996ff836b614a81af1471fc67025a4b194f28be
+checksum=01b6bea07431a7eea7f9aab73c6f3c19fc50f667f72246cf6093d0dd8d3d699b
 
 if [ -z "$CROSS_BUILD" ]; then
 	hostmakedepends+=" help2man"
@@ -21,9 +21,3 @@ fi
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 fi
-
-pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
-		sed -i 's/PRIVATE ${ZLIB_LIBRARIES}/\0\n  atomic/' CMakeLists.txt
-	fi
-}


### PR DESCRIPTION
Upstream checks for atomic support now.