### PR TITLE
ddpt: filter *r* source archives

### DIFF
--- a/srcpkgs/ddpt/update
+++ b/srcpkgs/ddpt/update
@@ -1,1 +1,1 @@
-ignore="*b*"
+ignore="*b* *r*"


### PR DESCRIPTION
```
XBPS_UPDATE_CHECK_VERBOSE=1 ./xbps-src update-check ddpt
using ddpt/update overrides
fetching http://sg.danny.cz/sg/ddpt.html
fetching http://sg.danny.cz/sg/p/
found version 0.90
found version 0.91
found version 0.91b1
ignored 0.91b1 due to *b*
found version 0.92
found version 0.93
found version 0.93b3r207
ignored 0.93b3r207 due to *b*
ignored 0.93b3r207 due to *r*
found version 0.93b6r221
ignored 0.93b6r221 due to *b*
ignored 0.93b6r221 due to *r*
found version 0.93b7r230
ignored 0.93b7r230 due to *b*
ignored 0.93b7r230 due to *r*
found version 0.93b8r236
ignored 0.93b8r236 due to *b*
ignored 0.93b8r236 due to *r*
found version 0.93b9r239
ignored 0.93b9r239 due to *b*
ignored 0.93b9r239 due to *r*
found version 0.94
found version 0.94exe
found version 0.95
found version 0.95b1r296
ignored 0.95b1r296 due to *b*
ignored 0.95b1r296 due to *r*
found version 0.95b2r302
ignored 0.95b2r302 due to *b*
ignored 0.95b2r302 due to *r*
found version 0.95b3r303
ignored 0.95b3r303 due to *b*
ignored 0.95b3r303 due to *r*
found version 0.96
found version 0.96b1r313
ignored 0.96b1r313 due to *b*
ignored 0.96b1r313 due to *r*
found version 0.96b2r317
ignored 0.96b2r317 due to *b*
ignored 0.96b2r317 due to *r*
found version 0.96b3r318
ignored 0.96b3r318 due to *b*
ignored 0.96b3r318 due to *r*
found version 0.96r358
ignored 0.96r358 due to *r*
found version 0.96r363
ignored 0.96r363 due to *r*
```
`0.96r363` was released 31-Jul-2018. Releases with r### seem to SVN revisions/tags.
