### PR TITLE
armadillo-devel: depend on armadillo

### DIFF
--- a/srcpkgs/armadillo/template
+++ b/srcpkgs/armadillo/template
@@ -1,7 +1,7 @@
 # Template file for 'armadillo'
 pkgname=armadillo
 version=9.700.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DDETECT_HDF5=$(vopt_if hdf5 ON OFF)"
 hostmakedepends="pkg-config openblas-devel"
@@ -20,7 +20,7 @@ if [ -z "$CROSS_BUILD" ]; then
 fi
 
 armadillo-devel_package() {
-	depends="${makedepends}"
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
installing `armadillo-devel` results in a broken symlink (`/usr/lib/libarmadillo.so` -> `/usr/lib/libarmadillo.so.9`)