### PR TITLE
lsscsi: filter false-positive source archive

### DIFF
--- a/srcpkgs/lsscsi/update
+++ b/srcpkgs/lsscsi/update
@@ -1,1 +1,1 @@
-ignore="*.*r*"
+ignore="*.*r* 030"


### PR DESCRIPTION
Another false positive for releases by this author. The 030 source archive was uploaded June 13, 2018, with 0.31 uploaded February 21, 2020.

`lsscsi-030.tgz	13-Jun-2018 05:41`

```
XBPS_UPDATE_CHECK_VERBOSE=1 ./xbps-src update-check lsscsi
using lsscsi/update overrides
fetching http://sg.danny.cz/scsi/lsscsi.html
fetching http://sg.danny.cz/scsi/
found version 0.02
found version 0.03
found version 0.04
found version 0.05
found version 0.06
found version 0.07
found version 0.08
found version 0.09
found version 0.10
found version 0.11
found version 0.12
found version 0.13
found version 0.14
found version 0.15
found version 0.16
found version 0.17
found version 0.18
found version 0.19
found version 0.20
found version 0.20beta
found version 0.21
found version 0.22
found version 0.23
found version 0.24
found version 0.24b1
found version 0.25
found version 0.25b1
found version 0.26
found version 0.26b2
found version 0.27
found version 0.27b1r107
ignored 0.27b1r107 due to *.*r*
found version 0.27b2r110
ignored 0.27b2r110 due to *.*r*
found version 0.27r99
ignored 0.27r99 due to *.*r*
found version 0.28
found version 0.28b1r115
ignored 0.28b1r115 due to *.*r*
found version 0.28b2r117
ignored 0.28b2r117 due to *.*r*
found version 0.28b3r119
ignored 0.28b3r119 due to *.*r*
found version 0.28b4r120
ignored 0.28b4r120 due to *.*r*
found version 0.29
found version 0.30
found version 0.30r147
ignored 0.30r147 due to *.*r*
found version 0.30r148
ignored 0.30r148 due to *.*r*
found version 0.30r149
ignored 0.30r149 due to *.*r*
found version 0.30r152
ignored 0.30r152 due to *.*r*
found version 0.30r153
ignored 0.30r153 due to *.*r*
found version 0.30r154
ignored 0.30r154 due to *.*r*
found version 0.31
found version 030
ignored 030 due to 030
```