### PR TITLE
lollypop: add missing runtime dep 'python3-BeautifulSoup4'

### DIFF
--- a/srcpkgs/lollypop/template
+++ b/srcpkgs/lollypop/template
@@ -1,13 +1,14 @@
 # Template file for 'lollypop'
 pkgname=lollypop
 version=1.2.25
-revision=1
+revision=2
 archs=noarch
 build_style=meson
 hostmakedepends="cmake git glib-devel gobject-introspection intltool itstool pkg-config"
 makedepends="gtk+3-devel libsoup-devel python3-gobject-devel python3-devel"
-depends="dconf gst-libav gst-plugins-good1 libnotify libsecret python3-dbus python3-gobject
- python3-pylast python3-youtube-dl python3-Pillow totem-pl-parser"
+depends="dconf gst-libav gst-plugins-good1 libnotify libsecret
+ python3-dbus python3-gobject python3-pylast python3-youtube-dl
+ python3-Pillow totem-pl-parser python3-BeautifulSoup4"
 short_desc="Music player for GNOME"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
fixes https://github.com/void-linux/void-packages/issues/20132