### PR TITLE
jetbrains-jdk-bin: add profile script to set 'IDEA_JDK'

### DIFF
--- a/srcpkgs/jetbrains-jdk-bin/template
+++ b/srcpkgs/jetbrains-jdk-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'jetbrains-jdk-bin'
 pkgname=jetbrains-jdk-bin
 version=11.0.6b770.9
-revision=1
+revision=2
 archs="x86_64"
 wrksrc="jbrsdk"
 hostmakedepends="wget"
@@ -31,4 +31,9 @@ do_install() {
 	vcopy legal ${TARGET_PATH}
 	vcopy lib ${TARGET_PATH}
 	vcopy release ${TARGET_PATH}
+
+	vmkdir etc/profile.d
+	cat > ${DESTDIR}/etc/profile.d/10_jbrsdk.sh <<EOF
+export IDEA_JDK=\${IDEA_JDK=/usr/lib/jvm/jbrsdk}
+EOF
 }


### PR DESCRIPTION
Hi!

I think it is reasonable for this package to configure `IDEA_JDK` to point to the newly installed JDK. This env var is picked up by IDEA (before checking `JAVA_HOME`), and I don't expect others to read it.

What do you think?