### PR TITLE
Marker: update to 2019.11.06.

### DIFF
--- a/srcpkgs/Marker/patches/0001-fix-version.patch
+++ b/srcpkgs/Marker/patches/0001-fix-version.patch
@@ -1,0 +1,11 @@
+# reason: upstream forgot to bump
+
+--- meson.build
++++ meson.build
+@@ -1,5 +1,5 @@
+ project('Marker', 'c',
+-  version : '2018.07.03',
++  version : '2019.11.06',
+   license : 'GPL3'
+ )
+ 

--- a/srcpkgs/Marker/template
+++ b/srcpkgs/Marker/template
@@ -1,16 +1,25 @@
 # Template file for 'Marker'
 pkgname=Marker
-version=2018.07.03
+version=2019.11.06
 revision=1
-wrksrc=marker
+wrksrc=Marker
 build_style=meson
-hostmakedepends="glib-devel pkg-config unzip"
+hostmakedepends="glib-devel pkg-config"
 makedepends="gtksourceview-devel gtkspell3-devel gtk+3-devel libglib-devel
  webkit2gtk-devel"
+depends="iso-codes"
 short_desc="A gtk3 markdown editor"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-3.0-or-later"
+license="GPL-3.0-or-later, BSD-3-Clause"
 homepage="https://fabiocolacio.github.io/Marker/"
-distfiles="https://github.com/fabiocolacio/Marker/releases/download/${version}/marker.zip"
-checksum=9038a2f8b976e6bfb199d14dbf60e7281b66e5ee94a6333ca48e89e63e6096ef
-broken="fails lint (ELF in /usr/share/com.github.fabiocolacio.marker/extensions/libscroll-extension.so)"
+distfiles="https://github.com/fabiocolacio/Marker/releases/download/${version}/${version}.tar.xz"
+checksum=a15ba19ddefd1de41f088716ff4a44c8409859a216856fb5970459d7632b71c9
+
+post_extract() {
+	# don't include bundled mathjax
+	rm -rf data/scripts/mathjax
+}
+
+post_install() {
+	rm ${DESTDIR}/usr/share/com.github.fabiocolacio.marker/extensions/libscroll-extension.so
+}


### PR DESCRIPTION
I did some testing with [mathjax](https://www.mathjax.org/#demo) and didn't find any issue with mathjax not being bundled nor installed (via xbps package `mathjax`), not sure how this works then. But it does