### PR TITLE
net-snmp: ignore rc and pre releases

### DIFF
--- a/srcpkgs/net-snmp/update
+++ b/srcpkgs/net-snmp/update
@@ -1,0 +1,1 @@
+ignore="*pre* *rc*"


### PR DESCRIPTION
Chipping away at the orphaned packages that have updates listed.  5.8 is the current/supported release according to http://www.net-snmp.org/download.html