### PR TITLE
cairo: fix CVE-2018-19876.

### DIFF
--- a/srcpkgs/cairo/patches/CVE-2018-19876.patch
+++ b/srcpkgs/cairo/patches/CVE-2018-19876.patch
@@ -1,0 +1,29 @@
+From 90e85c2493fdfa3551f202ff10282463f1e36645 Mon Sep 17 00:00:00 2001
+From: Carlos Garcia Campos <cgarcia@igalia.com>
+Date: Mon, 19 Nov 2018 12:33:07 +0100
+Subject: [PATCH] ft: Use FT_Done_MM_Var instead of free when available in
+ cairo_ft_apply_variations
+
+Fixes a crash when using freetype >= 2.9
+---
+ src/cairo-ft-font.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/cairo-ft-font.c b/src/cairo-ft-font.c
+index 325dd61b4..981973f78 100644
+--- a/src/cairo-ft-font.c
++++ b/src/cairo-ft-font.c
+@@ -2393,7 +2393,11 @@ skip:
+ done:
+         free (coords);
+         free (current_coords);
++#if HAVE_FT_DONE_MM_VAR
++        FT_Done_MM_Var (face->glyph->library, ft_mm_var);
++#else
+         free (ft_mm_var);
++#endif
+     }
+ }
+ 
+-- 
+2.18.1

--- a/srcpkgs/cairo/patches/freetype.patch
+++ b/srcpkgs/cairo/patches/freetype.patch
@@ -1,0 +1,55 @@
+From 12a5b7384f35d9a3f4c6b151fac4857444db3d6a Mon Sep 17 00:00:00 2001
+From: Nikolaus Waxweiler <madigens@gmail.com>
+Date: Sat, 10 Nov 2018 16:44:23 +0000
+Subject: [PATCH] Set default LCD filter to FreeType's default
+
+---
+ src/cairo-ft-font.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/cairo-ft-font.c b/src/cairo-ft-font.c
+index 325dd61b4..3c47dc12e 100644
+--- a/src/cairo-ft-font.c
++++ b/src/cairo-ft-font.c
+@@ -1404,7 +1404,7 @@ _render_glyph_outline (FT_Face                    face,
+ 		       cairo_image_surface_t	**surface)
+ {
+     int rgba = FC_RGBA_UNKNOWN;
+-    int lcd_filter = FT_LCD_FILTER_LEGACY;
++    int lcd_filter = FT_LCD_FILTER_DEFAULT;
+     FT_GlyphSlot glyphslot = face->glyph;
+     FT_Outline *outline = &glyphslot->outline;
+     FT_Bitmap bitmap;
+@@ -1439,13 +1439,13 @@ _render_glyph_outline (FT_Face                    face,
+ 	case CAIRO_LCD_FILTER_NONE:
+ 	    lcd_filter = FT_LCD_FILTER_NONE;
+ 	    break;
+-	case CAIRO_LCD_FILTER_DEFAULT:
+ 	case CAIRO_LCD_FILTER_INTRA_PIXEL:
+ 	    lcd_filter = FT_LCD_FILTER_LEGACY;
+ 	    break;
+ 	case CAIRO_LCD_FILTER_FIR3:
+ 	    lcd_filter = FT_LCD_FILTER_LIGHT;
+ 	    break;
++	case CAIRO_LCD_FILTER_DEFAULT:
+ 	case CAIRO_LCD_FILTER_FIR5:
+ 	    lcd_filter = FT_LCD_FILTER_DEFAULT;
+ 	    break;
+@@ -3416,7 +3416,6 @@ _cairo_ft_font_options_substitute (const cairo_font_options_t *options,
+ 	    case CAIRO_LCD_FILTER_NONE:
+ 		lcd_filter = FT_LCD_FILTER_NONE;
+ 		break;
+-	    case CAIRO_LCD_FILTER_DEFAULT:
+ 	    case CAIRO_LCD_FILTER_INTRA_PIXEL:
+ 		lcd_filter = FT_LCD_FILTER_LEGACY;
+ 		break;
+@@ -3424,6 +3423,7 @@ _cairo_ft_font_options_substitute (const cairo_font_options_t *options,
+ 		lcd_filter = FT_LCD_FILTER_LIGHT;
+ 		break;
+ 	    default:
++	    case CAIRO_LCD_FILTER_DEFAULT:
+ 	    case CAIRO_LCD_FILTER_FIR5:
+ 		lcd_filter = FT_LCD_FILTER_DEFAULT;
+ 		break;
+-- 
+2.19.1

--- a/srcpkgs/cairo/patches/memory-leak.patch
+++ b/srcpkgs/cairo/patches/memory-leak.patch
@@ -1,0 +1,55 @@
+From 79ad01724161502e8d9d2bd384ff1f0174e5df6e Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Thu, 30 May 2019 07:30:55 -0400
+Subject: [PATCH] Fix a thinko in composite_color_glyphs
+
+We can't just move around the contents of the
+passed-in string, we need to make a copy. This
+was showing up as memory corruption in pango.
+
+See https://gitlab.gnome.org/GNOME/pango/issues/346
+---
+ src/cairo-surface.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/cairo-surface.c b/src/cairo-surface.c
+index c30f84087..e112b660a 100644
+--- a/src/cairo-surface.c
++++ b/src/cairo-surface.c
+@@ -2820,6 +2820,7 @@ _cairo_surface_show_text_glyphs (cairo_surface_t	    *surface,
+ 				 const cairo_clip_t		*clip)
+ {
+     cairo_int_status_t status;
++    char *utf8_copy = NULL;
+ 
+     TRACE ((stderr, "%s\n", __FUNCTION__));
+     if (unlikely (surface->status))
+@@ -2847,6 +2848,10 @@ _cairo_surface_show_text_glyphs (cairo_surface_t	    *surface,
+     status = CAIRO_INT_STATUS_UNSUPPORTED;
+ 
+     if (_cairo_scaled_font_has_color_glyphs (scaled_font)) {
++        utf8_copy = malloc (sizeof (char) * utf8_len);
++        memcpy (utf8_copy, utf8, sizeof (char) * utf8_len);
++        utf8 = utf8_copy;
++
+         status = composite_color_glyphs (surface, op,
+                                          source,
+                                          (char *)utf8, &utf8_len,
+@@ -2861,6 +2866,8 @@ _cairo_surface_show_text_glyphs (cairo_surface_t	    *surface,
+         if (num_glyphs == 0)
+             goto DONE;
+     }
++    else
++      utf8_copy = NULL;
+ 
+     /* The logic here is duplicated in _cairo_analysis_surface show_glyphs and
+      * show_text_glyphs.  Keep in synch. */
+@@ -2918,6 +2925,9 @@ _cairo_surface_show_text_glyphs (cairo_surface_t	    *surface,
+ 	surface->serial++;
+     }
+ 
++    if (utf8_copy)
++        free (utf8_copy);
++
+     return _cairo_surface_set_error (surface, status);
+ }

--- a/srcpkgs/cairo/patches/musl-stacksize.patch
+++ b/srcpkgs/cairo/patches/musl-stacksize.patch
@@ -1,8 +1,8 @@
 Reduce the footprint of stack frame usage by turning
 some large(r) structures as `static __thread` instead.
 
---- src/cairo-rectangular-scan-converter.c	2015-10-27 22:04:21.000000000 +0100
-+++ src/cairo-rectangular-scan-converter.c	2016-05-07 04:25:26.640851782 +0200
+--- a/src/cairo-rectangular-scan-converter.c	2015-10-27 22:04:21.000000000 +0100
++++ b/src/cairo-rectangular-scan-converter.c	2016-05-07 04:25:26.640851782 +0200
 @@ -489,7 +489,7 @@
  	  cairo_span_renderer_t	*renderer,
  	  rectangle_t **rectangles)

--- a/srcpkgs/cairo/template
+++ b/srcpkgs/cairo/template
@@ -1,7 +1,7 @@
 # Template file for 'cairo'
 pkgname=cairo
 version=1.16.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-tee
  $(vopt_if opengl '--enable-gl --enable-egl')
@@ -16,6 +16,7 @@ license="LGPL-2.1-or-later, MPL-1.1"
 homepage="https://cairographics.org"
 distfiles="https://cairographics.org/releases/cairo-${version}.tar.xz"
 checksum=5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331
+patch_args="-Np1"
 
 # Package build options
 build_options="gles2 opengl"


### PR DESCRIPTION
Other backports from Fedora.