### PR TITLE
chromium: update to 80.0.3987.149.

### DIFF
--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=80.0.3987.132
+version=80.0.3987.149
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=2c0012059046a5a7e2bf6e9502f1898f1953226d63b724b82fc18226e285c201
+checksum=50bedde7932921e375b521ceab8989be134a8d937751847e9d9287f7e0a02c1e
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
[ci skip]

- Built for x86_64, x86_64-musl.
- Tested on x86_64.