### PR TITLE
New packages: python3-breathe and python3-pybind11

### DIFF
--- a/srcpkgs/python3-breathe/template
+++ b/srcpkgs/python3-breathe/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-breathe'
+pkgname=python3-breathe
+version=4.16.0
+revision=1
+archs=noarch
+wrksrc="breathe-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-Sphinx python3-docutils doxygen"
+short_desc="ReStructuredText and Sphinx bridge to Doxygen"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="BSD-3-Clause"
+homepage="https://github.com/michaeljones/breathe"
+distfiles="https://github.com/michaeljones/breathe/archive/v${version}.tar.gz"
+checksum=d042217288337609f528ee2dc1bf11b25208b4b7753120cc23fe6538074d01e8
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-pybind11/template
+++ b/srcpkgs/python3-pybind11/template
@@ -1,0 +1,31 @@
+# Template file for 'python3-pybind11'
+pkgname=python3-pybind11
+version=2.5.0
+revision=1
+archs=noarch
+wrksrc="pybind11-${version}"
+build_style=python3-module
+make_install_args="--install-headers=/usr/include/pybind11"
+hostmakedepends="python3-setuptools
+ python3-pytest python3-sphinx_rtd_theme python3-breathe"
+depends="python3-devel"
+short_desc="C++ header-only library to produce Python bindings"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="BSD-3-Clause"
+homepage="https://github.com/pybind/pybind11"
+distfiles="https://github.com/pybind/pybind11/archive/v${version}.tar.gz"
+checksum=97504db65640570f32d3fdf701c25a340c8643037c3b69aec469c10c93dc8504
+
+post_build() {
+	# Build the man page
+	make $makejobs -C docs man
+}
+
+post_install() {
+	vlicense LICENSE
+
+	# Copy the man page, but make it section 7
+	_manpage=docs/.build/man/pybind11.1
+	vsed -i ${_manpage} -e '/^\.TH/ s/"1"/"7"/'
+	vman ${_manpage} pybind11.7
+}


### PR DESCRIPTION
Pybind11 is a C++ header-only library that facilitates creation of Python bindings for C++ libraries. The man page for pybind11 is generated using the python3-breathe doxygen bridge.