### PR TITLE
gnome: Move cheese and epiphany to -apps

### DIFF
--- a/srcpkgs/gnome/template
+++ b/srcpkgs/gnome/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome'
 pkgname=gnome
 version=3.32.0
-revision=2
+revision=3
 build_style=meta
 short_desc="GNOME meta-package for Void Linux"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -17,7 +17,6 @@ depends="NetworkManager>=1.14.0_1
  cairomm>=1.12.2_2
  cantarell-fonts>=0.0.25
  caribou>=0.4.21
- cheese>=3.32.0
  chrome-gnome-shell>=10.0.0
  clutter>=1.26.2
  clutter-gst3>=3.0.24
@@ -25,7 +24,6 @@ depends="NetworkManager>=1.14.0_1
  cogl>=1.22.2
  dconf>=0.30.0
  eog>=3.32.0
- epiphany>=3.32.0
  evince>=3.32.0
  evolution-data-server>=3.32.0
  file-roller>=3.32.0
@@ -117,8 +115,10 @@ depends="NetworkManager>=1.14.0_1
  zenity>=3.32.0"
 
 _apps_depends="baobab>=3.32.0
+ cheese>=3.32.0
  dconf-editor>=3.32.0
  devhelp>=3.32.0
+ epiphany>=3.32.0
  evolution>=3.32.0
  ghex>=3.18.3
  gitg>=3.26.0


### PR DESCRIPTION
Other desktop environments like KDE or MATE don't add extra applications like `falkon` in the case of KDE or `mate-terminal` in the case of MATE. I think putting `epiphany` and `cheese` under the `-apps` package is a bit more coherent with the other DEs.