### PR TITLE
Update Vulkan to v1.2.135

### DIFF
--- a/srcpkgs/Vulkan-Headers/template
+++ b/srcpkgs/Vulkan-Headers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Headers'
 pkgname=Vulkan-Headers
-version=1.1.130
+version=1.2.135
 revision=1
 archs=noarch
 wrksrc="${pkgname}-${version}"
@@ -10,4 +10,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${version}.tar.gz"
-checksum=8300e8ddcb24b020f21107b2f249c1423d886187b6e909c11f4fde63cacd8da4
+checksum=cfca993d0ce6f33c669e78ee015fd49c65d3a998cd14e92e900a89380e41ae28

--- a/srcpkgs/Vulkan-Tools/template
+++ b/srcpkgs/Vulkan-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Tools'
 pkgname=Vulkan-Tools
-version=1.1.130
+version=1.2.135
 revision=1
 wrksrc="${pkgname}-${version}"
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=5de87f7c13ee2fcdd9c35c1ca9540c04c12900d6d6d77efa3426a4dcf931ec2a
+checksum=6b497194fb2e06e41a9ab8c404ea3c82cca1fc1e0c540ffcd2905b9bebef5e84
 
 build_options="cube"
 desc_option_cube="Build cube vulkan demo"

--- a/srcpkgs/Vulkan-ValidationLayers/template
+++ b/srcpkgs/Vulkan-ValidationLayers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-ValidationLayers'
 pkgname=Vulkan-ValidationLayers
-version=1.1.130
+version=1.2.133
 revision=1
 build_style=cmake
 configure_args="-C ${XBPS_CROSS_BASE}/tmp/helper.cmake
@@ -12,7 +12,7 @@ maintainer="Colin Gillespie <colin@breavyn.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=ef3a8decd315736612479f9e9b03dbac690722b663a9bf9d064ff227298d3a50
+checksum=f9a87f424960457d6798baa3c592b09a14e2f29533851dddb3fa8a110cf0ae8a
 
 pre_configure() {
 	# Fetch and compile "known good" versions of dependencies

--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,7 +1,7 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
 _pkgname=Vulkan-Loader
-version=1.1.130
+version=1.2.135
 revision=1
 wrksrc="${_pkgname}-${version}"
 build_style=cmake
@@ -14,4 +14,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/v${version}.tar.gz"
-checksum=4325b67ba8bfd4ba3d325a0f37340d0684806982be1cd9e2f40367d2688cb5f7
+checksum=9a45c9bfce00026f5c12d4b869f87f2708cb28be49f3cd6c5044c7f8121071b6


### PR DESCRIPTION
It hasn't been updated on Void since December, and newer games may expect later Vulkan versions.  
I'm still very new both to pull requesting in general and to xbps packaging, so please let me know if there's something I totally missed.