### PR TITLE
fscrypt: also include pam module in package 

### DIFF
--- a/srcpkgs/fscrypt/files/pam_config
+++ b/srcpkgs/fscrypt/files/pam_config
@@ -1,0 +1,1 @@
+auth required pam_unix.so

--- a/srcpkgs/fscrypt/template
+++ b/srcpkgs/fscrypt/template
@@ -1,14 +1,30 @@
 # Template file for 'fscrypt'
 pkgname=fscrypt
-version=0.2.6
+version=0.2.7
 revision=1
 build_style=go
 go_import_path=github.com/google/fscrypt
 go_package="${go_import_path}/cmd/fscrypt"
+hostmakedepends="m4"
 makedepends="pam-devel"
 short_desc="Tool for managing Linux filesystem encryption"
 maintainer="Andrea Brancaleoni <abc@pomel.me>"
 license="Apache-2.0"
 homepage="https://github.com/google/fscrypt"
 distfiles="https://github.com/google/fscrypt/archive/v${version}.tar.gz"
-checksum=bce54ebb716706150b759052665a29d01963d8df334ad9beb34105ce62d2de94
+checksum=08e7f1bb5481f5ee76a90d79b9d9e2632f167d43100438ba08bd637e2dfb0f22
+conf_files="/etc/pam.d/fscrypt"
+
+if [ "$XBPS_TARGET_WORDSIZE" = "32" ];
+then
+	broken="fscrypt can't be built for 32-bit targets"
+fi
+
+post_install() {
+	# build and install the PAM module
+	LDFLAGS= make PREFIX=/usr DESTDIR=${DESTDIR} install-pam
+	# remove Ubuntu specific pam-config files
+	rm -rf ${DESTDIR}/usr/share/pam-configs/
+	# add PAM config file
+	vinstall ${FILESDIR}/pam_config 644 etc/pam.d fscrypt
+}


### PR DESCRIPTION
The previous build style used for fscrypt, go, meant that the fscrypt PAM module, pam_fscrypt.so, wasn't included in the package. This makes PAM integration impossible if the user doesn't compile and install the module themselves.

The /etc/pam.d/fscrypt config file, which is supposed to be created by packagers to allow fscrypt to use the login password, wasn't included in the package either.

The INSTALL.msg file was added to let users know they'd still need to configure some things if they wanted a fully integrated setup. This configuration information is currently held in the Arch Wiki, where it's formatted a bit better than it is in the projects's github page. I felt it disnecessary to repeat the steps in the message, but I can copy them if you feel it's necessary, or add them to the Void Documentation.

I feel this build script has a few hacks, so I wanted to post it here to see if you have any ideas about what can be done to fix it (or if it's ok as it is).

* I added `nostrip` because it didn't build with `nopie`, and then failed during one of the lints.
* `make_install_args`: I couldn't understand what was going on with the original Makefile, but it didn't work unless I had it exactly like this. Anything I tried with setting `DESTDIR` to something made the whole thing go up in flames.
* `make_install_target`: installing only the library avoids having to remove the binary from DESTDIR, because otherwise it appears in the wrong place. The binary is then copied manually in `post_install`.
 
I don't know what Void's instace on this is, but this isn't a reproducible build. I had noticed it when traipsing through the Makefile, where the buildtime is passed as a "define" to the toolchain. The PKGBUILD used by Arch also adds a patch to make the build reproducible.