### PR TITLE
New package: wev-1.0.0

### DIFF
--- a/srcpkgs/wev/template
+++ b/srcpkgs/wev/template
@@ -1,0 +1,17 @@
+# Template file for 'wev'
+pkgname=wev
+version=1.0.0
+revision=1
+build_style=gnu-makefile
+hostmakedepends="wayland-devel pkg-config"
+makedepends="wayland-devel libxkbcommon-devel wayland-protocols"
+short_desc="Tool for debugging events on a Wayland, analagous to the X11 tool xev"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://git.sr.ht/~sircmpwn/wev"
+distfiles="https://git.sr.ht/~sircmpwn/wev/archive/${version}.tar.gz"
+checksum=6f004dedf3f5ce10d2fe3cd233d59912756d8a0af021214158d6ec54d66c9d6e
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This works just fine, but there's no git tags upstream so this is a date versioned package, based on the latest commit in master there.