### PR TITLE
u2f-hidraw-policy: enable building for musl

### DIFF
--- a/srcpkgs/u2f-hidraw-policy/template
+++ b/srcpkgs/u2f-hidraw-policy/template
@@ -1,7 +1,8 @@
 # Template file for 'u2f-hidraw-policy'
 pkgname=u2f-hidraw-policy
 version=1.0.2
-revision=1
+revision=2
+archs="i686 x86_64*"
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"


### PR DESCRIPTION
u2f-hidraw-policy builds & works under musl, but it's missing `archs` so this package is not available under musl. This package is required to get U2F key working.