### PR TITLE
plan9port: fix shebang of rc scripts

### DIFF
--- a/srcpkgs/plan9port/template
+++ b/srcpkgs/plan9port/template
@@ -1,11 +1,11 @@
 # Template file for 'plan9port'
 pkgname=plan9port
 version=20200222
-revision=1
+revision=2
 _githash=92aa0e13ad8cec37936998a66eb728bfca88d689
 archs="i686* x86_64* ppc*"
 wrksrc="${pkgname}-${_githash}"
-hostmakedepends="perl"
+hostmakedepends="perl which"
 makedepends="libX11-devel libXt-devel libXext-devel freetype-devel fontconfig-devel"
 short_desc="Port of many Plan 9 programs to Unix-like operating systems"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
If "which" is not included in hostmakedepends, some "command not found" errors are displayed while building.
Also, the shebang of rc scripts would be "#!/usr/local/plan9/bin/rc" instead of the correct "#!/usr/lib/plan9/bin/rc".