### PR TITLE
python-Twisted: update to 20.3.0.

### DIFF
--- a/srcpkgs/python-Twisted/template
+++ b/srcpkgs/python-Twisted/template
@@ -1,6 +1,6 @@
 # Template file for 'python-Twisted'
 pkgname=python-Twisted
-version=19.10.0
+version=20.3.0
 revision=1
 wrksrc="Twisted-${version}"
 build_style=python-module
@@ -15,7 +15,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="MIT"
 homepage="https://twistedmatrix.com/"
 distfiles="${PYPI_SITE}/T/Twisted/Twisted-${version}.tar.bz2"
-checksum=7394ba7f272ae722a74f3d969dcf599bc4ef093bc392038748a490f1724a515d
+checksum=d72c55b5d56e176563b91d11952d13b01af8725c623e498db5507b6614fc1e10
 
 alternatives="
  twisted:cftp:/usr/bin/cftp2


### PR DESCRIPTION
This fixes [CVE-2020-10108](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10108) and [CVE-2020-10109](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10109).