### PR TITLE
slirp4netns: update to 1.0.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3855,3 +3855,4 @@ libraven.so.0 budgie-desktop-10.5.1_1
 libbudgie-private.so.0 budgie-desktop-10.5.1_1
 libbudgietheme.so.0 budgie-desktop-10.5.1_1
 libbudgie-plugin.so.0 budgie-desktop-10.5.1_1
+libslirp.so.0 libslirp-4.2.0_1

--- a/srcpkgs/libslirp-devel
+++ b/srcpkgs/libslirp-devel
@@ -1,0 +1,1 @@
+libslirp

--- a/srcpkgs/libslirp/template
+++ b/srcpkgs/libslirp/template
@@ -1,0 +1,28 @@
+# Template file for 'libslirp'
+pkgname=libslirp
+version=4.2.0
+revision=1
+wrksrc="libslirp-v${version}"
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="libglib-devel"
+short_desc="User-mode networking library used by VMs and containers"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
+license="BSD-3-Clause"
+homepage="https://gitlab.freedesktop.org/slirp/libslirp"
+distfiles="https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${version}/libslirp-v${version}.tar.gz"
+checksum=8c088bb60952d18e615962a83bcd4f03fa0988d913bce9457fea9377e72ab9f3
+
+post_install() {
+	vlicense COPYRIGHT
+}
+
+libslirp-devel_package() {
+	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove usr/lib/*.so
+	}
+}

--- a/srcpkgs/slirp4netns/template
+++ b/srcpkgs/slirp4netns/template
@@ -1,16 +1,16 @@
 # Template file for 'slirp4netns'
 pkgname=slirp4netns
-version=0.4.3
+version=1.0.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
-makedepends="glib-devel libseccomp-devel libcap-devel"
+makedepends="libslirp-devel libseccomp-devel libcap-devel"
 short_desc="User-mode networking for unprivileged network namespaces"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/rootless-containers/slirp4netns"
 distfiles="https://github.com/rootless-containers/slirp4netns/archive/v${version}.tar.gz"
-checksum=d699bc28a031512ed4fe13ca5a812dbc00415a61d7444a41bac2da6b62f9c53a
+checksum=2b4e9b54144485865df29ccf94c2a5309f01e58c66a84e1b1779ec094e0b4be0
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
Draft for now, until slirp4netns 1.0 is released.