### PR TITLE
julia: update to 1.4.0.

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,35 +1,33 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.3.1
+version=1.4.0
 revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_LLVM_SHLIB=1 USE_BINARYBUILDER=0
  USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBUNWIND=0 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_LIBM=0
- USE_SYSTEM_DSFMT=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=1
+ USE_SYSTEM_DSFMT=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=0
  USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
  USE_SYSTEM_CURL=1 USE_SYSTEM_MPFR=1 USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_UTF8PROC=0
- USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LAPACK=1
- LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas
- LIBBLAS=-lopenblas LIBBLASNAME=libopenblas"
+ USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LAPACK=0"
 make_install_args="$make_build_args"
 make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
-hostmakedepends="perl cmake python gcc-fortran patchelf"
-makedepends="openblas-devel pcre2-devel gmp-devel mpfr-devel libgit2-devel
- libcurl-devel libssh2-devel mbedtls-devel libatomic-devel zlib-devel p7zip"
+hostmakedepends="perl cmake python gcc-fortran patchelf which tar xz"
+makedepends="pcre2-devel gmp-devel mpfr-devel libgit2-devel libcurl-devel
+ libssh2-devel mbedtls-devel libatomic-devel zlib-devel p7zip"
 depends="pcre2 gmp mpfr libgit2 libcurl libssh2 mbedtls libatomic zlib p7zip"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=053908ec2706eb76cfdc998c077de123ecb1c60c945b4b5057aa3be19147b723
+checksum=880c73a08296ce8d94ad9605149f2a2b2b028e7202a700ef725da899300b8be9
 nocross=yes
 # Falsely detects dependency on libllvm
-skiprdeps="/usr/lib/libjulia.so.1.3 /usr/lib/julia/libllvmcalltest.so"
+skiprdeps="/usr/lib/libjulia.so.1.4 /usr/lib/julia/libllvmcalltest.so"
 
 case "$XBPS_TARGET_MACHINE" in
 *-musl)
@@ -65,8 +63,11 @@ esac
 post_extract() {
 	sed -i '/^install:/s| \$(BUILDROOT)/doc.*||' Makefile
 }
+
 post_install() {
 	vlicense LICENSE.md
+	# Workaround https://github.com/JuliaLang/julia/issues/34264
+	vcopy usr/lib/libLLVM-8jl.so usr/lib/julia
 }
 
 julia-devel_package() {


### PR DESCRIPTION
This commit also changes julia from using the distributions openblas
to having julia vendor in its own version because julia by default
vendors openblas with 64-bit integers (ILP64). Some
packages (e.g. Arpack.jl) do not function correctly when openblas is
built using 32-bit integers. This change adds 28M to the
package-size.

https://github.com/JuliaLang/julia/blob/master/doc/build/distributing.md#notes-on-blas-and-lapack

[ci skip] for building llvm