### PR TITLE
wildmidi: fix default config

### DIFF
--- a/srcpkgs/wildmidi/files/wildmidi.cfg
+++ b/srcpkgs/wildmidi/files/wildmidi.cfg
@@ -1,0 +1,7 @@
+## wildmidi.cfg
+## This is used to set and configure GUS patchsets to be used with WildMidi
+## Please refer to the wildmidi.cfg(5) manpage for more details.
+
+## Load the patchset from freepats
+dir /usr/share/freepats
+source /etc/freepats/freepats.cfg

--- a/srcpkgs/wildmidi/template
+++ b/srcpkgs/wildmidi/template
@@ -1,7 +1,7 @@
 # Template file for 'wildmidi'
 pkgname=wildmidi
 version=0.4.3
-revision=4
+revision=5
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=cmake
 configure_args="-DWANT_ALSA=1 -DWANT_OSS=1 -DWANT_OPENAL=1"
@@ -17,8 +17,7 @@ checksum=498e5a96455bb4b91b37188ad6dcb070824e92c44f5ed452b90adbaec8eef3c5
 replaces="WildMidi>=0 WildMidi-devel>=0"
 
 post_install() {
-	vsed -i cfg/wildmidi.cfg -e "s;/usr/share/midi/freepats;/usr/share/freepats;"
-	vsconf cfg/wildmidi.cfg
+	vsconf ${FILESDIR}/wildmidi.cfg
 }
 
 libwildmidi_package() {
@@ -27,7 +26,7 @@ libwildmidi_package() {
 	conf_files="/etc/wildmidi/wildmidi.cfg"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
-		vinstall cfg/wildmidi.cfg 644 etc/wildmidi
+		vinstall ${FILESDIR}/wildmidi.cfg 644 etc/wildmidi
 	}
 }
 


### PR DESCRIPTION
The example config that ships with wildmidi is incomplete and doesn't contain all the patches in freepats, it would be better to just source the config that comes with the freepats package.