### PR TITLE
ghc: add build option "bindist"

### DIFF
--- a/srcpkgs/ghc/template
+++ b/srcpkgs/ghc/template
@@ -32,6 +32,16 @@ nopie_files="
  ${_bindir}/unlit
 "
 
+build_options="bindist"
+desc_option_bindist="Create a binary distribution"
+
+if [ "$build_option_bindist" ]; then
+	# Strip --with-system-libffi from configuration
+	configure_args=${configure_args/--with-system-libffi/}
+	# Required to make the binary distribution tarball
+	hostmakedepends+=" tar xz"
+fi
+
 pre_configure() {
 	export CONF_CC_OPTS_STAGE0=$CFLAGS_FOR_BUILD
 	export CONF_CC_OPTS_STAGE1=$CFLAGS
@@ -49,6 +59,14 @@ pre_configure() {
 post_install() {
 	sed -i 's#/usr/lib/ccache/bin/##g' ${DESTDIR}/usr/lib/ghc-${version%[!0-9]}/settings
 	vlicense LICENSE
+
+	if [ "$build_option_bindist" ]; then
+		msg_normal "Creating binary distribution for ${XBPS_TARGET_MACHINE}...\n"
+		make ${makejobs} binary-dist
+		dest="${XBPS_SRCDISTDIR}"/distfiles/ghc-${version}-void-linux-${XBPS_TARGET_LIBC}.tar.xz
+		install -d -m 0644 ghc-${version}-unknown-linux.tar.xz "${dest}"
+		msg_normal "Installed in ${dest}\n"
+	fi
 }
 
 ghc-doc_package() {


### PR DESCRIPTION
Setting the `bindist` option adapts the template to not only build
`ghc`, without using the system libffi, but also create a binary
distribution and install it in the source distfiles folder:
`${XBPS_SRCDISTDIR}/ghc-${version}-void-linux-${XBPS_TARGET_LIBC}.tar.xz`

Perhaps this can be incorporated in #20365
