### PR TITLE
jetbrains-jdk-bin: update to 11.0.6b795.3.

### DIFF
--- a/srcpkgs/jetbrains-jdk-bin/template
+++ b/srcpkgs/jetbrains-jdk-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'jetbrains-jdk-bin'
 pkgname=jetbrains-jdk-bin
-version=11.0.6b770.9
-revision=2
+version=11.0.6b795.3
+revision=1
 archs="x86_64"
 wrksrc="jbrsdk"
 hostmakedepends="wget"
@@ -12,8 +12,8 @@ homepage="https://github.com/JetBrains/JetBrainsRuntime"
 _jdk_ver=${version%b*}
 _jdk_build=${version#*b}
 distfiles="https://dl.bintray.com/jetbrains/intellij-jbr/jbrsdk-${_jdk_ver//\./_}-linux-x64-b${_jdk_build}.tar.gz"
-checksum=51c076fbb9a78daa503e67839add860a0b17820bd43597f14ef0a4ddfb3eb332
-# This JDK appears to link to libs that do not exist, but still continues to function well even in their absence.
+checksum=5005905002b6eb645fd80cc5eab4fa842727e846858444285e80e92b838ad866
+# This JDK appears to link to libs that do not exist, but functions well even in their absence.
 # Best guess is that they are optional. ¯\_(ツ)_/¯
 fetch_cmd="wget"
 noverifyrdeps=yes


### PR DESCRIPTION
Update to latest available.
While here, add JDK dir exports for other known JetBrains products.