### PR TITLE
CLion: update to 2019.3.5.

### DIFF
--- a/srcpkgs/CLion/template
+++ b/srcpkgs/CLion/template
@@ -1,6 +1,6 @@
 # Template file for 'CLion'
 pkgname=CLion
-version=2019.3.4
+version=2019.3.5
 revision=1
 archs="i686 x86_64"
 wrksrc="clion-${version}"
@@ -10,7 +10,7 @@ maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="custom:Commercial"
 homepage="https://www.jetbrains.com/clion"
 distfiles="https://download.jetbrains.com/cpp/CLion-${version}.tar.gz"
-checksum=adb76d1d5b13b5fae3e3953c953ee16f3342ef36af404fc2873b9dc9d2190d72
+checksum=f31efad95a4c43db59c1a069f9f2ebf5e44f8321262e9ba37edc4e8635b8b062
 repository=nonfree
 restricted=yes
 nopie=yes
@@ -65,8 +65,8 @@ do_install() {
 		vlicense $i
 	done
 
-	mkdir -p /usr/lib/jvm/jbrsdk
-	ln -sf /usr/lib/jvm/jbrsdk ${DESTDIR}/${TARGET_PATH}/jbr
+	local launcher_path="bin/clion.sh"
+	sed -i '1 s/$/\nCLION_JDK=${CLION_JDK:-${IDEA_JDK}}/' "${launcher_path}"
 	vcopy bin ${TARGET_PATH}
 	vcopy help ${TARGET_PATH}
 	vcopy lib ${TARGET_PATH}
@@ -74,5 +74,5 @@ do_install() {
 	vcopy product-info.json ${TARGET_PATH}
 	vcopy build.txt ${TARGET_PATH}
 
-	ln -sf /${TARGET_PATH}/bin/clion.sh ${DESTDIR}/usr/bin/${pkgname}
+	ln -sf "/${TARGET_PATH}/${launcher_path}" "${DESTDIR}/usr/bin/${pkgname}"
 }


### PR DESCRIPTION
Please merge only after #20384 is merged, as it defines the `CLION_JDK` env var necessary for CLion to work without the `jbr` dir symlink.