### PR TITLE
DataGrip: update to 2019.3.4.

### DIFF
--- a/srcpkgs/DataGrip/template
+++ b/srcpkgs/DataGrip/template
@@ -1,6 +1,6 @@
 # Template file for 'DataGrip'
 pkgname=DataGrip
-version=2019.3.3
+version=2019.3.4
 revision=1
 archs="i686 x86_64"
 wrksrc="DataGrip-${version}"
@@ -10,7 +10,7 @@ maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="custom:Commercial"
 homepage="https://www.jetbrains.com/datagrip"
 distfiles="https://download.jetbrains.com/datagrip/datagrip-${version}.tar.gz"
-checksum=307a298017cee716a6191a920170e8bdd68f895eba7eb5568998e1070c8f7e7d
+checksum=6409a7ed5b91d4b54adc03bb784e86ecde035b0c256aad66ab463d2d8288ebf9
 repository=nonfree
 restricted=yes
 nopie=yes
@@ -44,13 +44,13 @@ do_install() {
 		vlicense $i
 	done
 
-	mkdir -p /usr/lib/jvm/jbrsdk
-	ln -sf /usr/lib/jvm/jbrsdk ${DESTDIR}/${TARGET_PATH}/jbr
+	local launcher_path="bin/datagrip.sh"
+	sed -i '1 s/$/\nDATAGRIP_JDK=${DATAGRIP_JDK:-${IDEA_JDK}}/' "${launcher_path}"
 	vcopy bin ${TARGET_PATH}
 	vcopy lib ${TARGET_PATH}
 	vcopy plugins ${TARGET_PATH}
 	vcopy product-info.json ${TARGET_PATH}
 	vcopy build.txt ${TARGET_PATH}
 
-	ln -sf /${TARGET_PATH}/bin/datagrip.sh ${DESTDIR}/usr/bin/${pkgname}
+	ln -sf "/${TARGET_PATH}/${launcher_path}" "${DESTDIR}/usr/bin/${pkgname}"
 }


### PR DESCRIPTION
Please merge only after #20384 is merged, as it defines the `DATAGRIP_JDK` env var necessary for DataGrip to work without the `jbr` dir symlink.