### PR TITLE
New package: PhpStorm-2019.3.4

### DIFF
--- a/srcpkgs/PhpStorm/INSTALL.msg
+++ b/srcpkgs/PhpStorm/INSTALL.msg
@@ -1,0 +1,2 @@
+PhpStorm has the following optional dependencies:
+	libdbusmenu-glib: For global menu support

--- a/srcpkgs/PhpStorm/template
+++ b/srcpkgs/PhpStorm/template
@@ -1,0 +1,63 @@
+# Template file for 'PhpStorm'
+pkgname=PhpStorm
+version=2019.3.4
+revision=1
+archs="i686 x86_64"
+wrksrc="PhpStorm-193.6911.26"
+depends="jetbrains-jdk-bin"
+short_desc="Lightning-smart PHP IDE"
+maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
+license="custom:Commercial"
+homepage="https://www.jetbrains.com/phpstorm"
+distfiles="https://download.jetbrains.com/webide/PhpStorm-${version}.tar.gz"
+checksum=b564c25855f96a0d9eab715ae464472365e231bda591b52be988dfbe4d14b1af
+repository=nonfree
+restricted=yes
+nopie=yes
+# JetBrains' tools are self-sufficient and while they include code that appears to be linked to libs from other packages, these libs are either included in the tool package, or the code works by looking for one of several supported libs.
+noverifyrdeps=yes
+
+post_extract() {
+	# Remove files for other CPU architectures
+	rm -rf bin/fsnotifier-arm
+	rm -rf lib/pty4j-native/linux/ppc64le
+
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64)
+			rm -rf bin/fsnotifier
+			rm -rf bin/phpstorm.vmoptions
+			rm -rf bin/libyjpagent-linux.so
+			rm -rf lib/pty4j-native/linux/x86
+			;;
+		i686)
+			rm -rf bin/fsnotifier64
+			rm -rf bin/phpstorm64.vmoptions
+			rm -rf bin/libyjpagent-linux64.so
+			rm -rf lib/pty4j-native/linux/x86_64
+			;;
+	esac
+}
+
+do_install() {
+	TARGET_PATH="usr/lib/${pkgname}"
+
+	vmkdir usr/bin
+	vmkdir ${TARGET_PATH}
+
+	local i
+	for i in license/* ; do
+		vlicense $i
+	done
+
+	local launcher_path="bin/phpstorm.sh"
+	sed -i '1 s/$/\nPHPSTORM_JDK=${PHPSTORM_JDK:-${IDEA_JDK}}/' "${launcher_path}"
+
+	vcopy bin ${TARGET_PATH}
+	vcopy help ${TARGET_PATH}
+	vcopy lib ${TARGET_PATH}
+	vcopy plugins ${TARGET_PATH}
+	vcopy product-info.json ${TARGET_PATH}
+	vcopy build.txt ${TARGET_PATH}
+
+	ln -sf "/${TARGET_PATH}/${launcher_path}" "${DESTDIR}/usr/bin/${pkgname}"
+}

--- a/srcpkgs/PhpStorm/update
+++ b/srcpkgs/PhpStorm/update
@@ -1,0 +1,2 @@
+pattern="PhpStorm-\K[\d.]+(?=\.tar)"
+site="https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release"


### PR DESCRIPTION
This supercedes #12670.
Please merge only after #20384 is merged, as it defines the `PHPSTORM_JDK` env var necessary for PhpStorm to work without the `jbr` dir symlink.