### PR TITLE
budgie-desktop: add elogind dependency

### DIFF
--- a/srcpkgs/budgie-desktop/template
+++ b/srcpkgs/budgie-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'budgie-desktop'
 pkgname=budgie-desktop
 version=10.5.1
-revision=2
+revision=3
 build_style=meson
 build_helper=gir
 configure_args="-Dwith-gtk-doc=false -Dwith-desktop-icons=none"
@@ -9,7 +9,7 @@ hostmakedepends="pkg-config intltool vala glib-devel gobject-introspection sassc
 makedepends="alsa-lib-devel libnotify-devel accountsservice-devel libpeas-devel libwnck-devel
 mutter-devel ibus-devel gnome-desktop-devel pulseaudio-devel upower-devel gtk+3-devel polkit-devel
 gnome-bluetooth-devel gnome-menus-devel gnome-settings-daemon-devel vala libuuid-devel libupower-glib3"
-depends="gnome-session gnome-settings-daemon gnome-control-center"
+depends="gnome-session gnome-settings-daemon gnome-control-center elogind"
 short_desc="Modern desktop environment from the Solus Project"
 maintainer="Lorem <notloremipsum@protonmail.com>"
 license="GPL-2.0-only, LGPL-2.1-only"
@@ -28,7 +28,7 @@ budgie-desktop-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove usr/share/vala
-		vmove usr/lib/*.so
+		vmove "usr/lib/*.so"
 		vmove usr/share/gir-1.0
 	}
 }


### PR DESCRIPTION
Doesn't run if it isn't installed. Needs it for doing suspend and hibernation from the user-indicator applet.