### PR TITLE
New package: nautilus-python-1.2.3

### DIFF
--- a/srcpkgs/nautilus-python/template
+++ b/srcpkgs/nautilus-python/template
@@ -1,0 +1,17 @@
+# Template file for 'nautilus-python'
+pkgname=nautilus-python
+version=1.2.3
+revision=1
+archs=noarch
+build_style=gnu-configure
+configure_args="--enable-gtk-doc PYTHON=python3"
+hostmakedepends="automake libtool pkg-config which"
+makedepends="python3-devel python3-gobject-devel gtk-doc nautilus-devel"
+depends="nautilus python3-gobject"
+short_desc="Python bindings for the Nautilus extension framework"
+maintainer="Nafis <mnabid.25@outlook.com>"
+license="GPL-2.0-or-later"
+homepage="https://wiki.gnome.org/Projects/NautilusPython"
+distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
+checksum=073ce0297282259937ab473d189b97a04f42b97197c9292fc3bde9d135282098
+nocross="could not find Python headers"


### PR DESCRIPTION
If cross compiling, I get this error in configure: 
```
configure:9474: checking for headers required to compile python extensions
configure:9530: armv7l-linux-gnueabihf-cpp    -I/usr/include/python3.8 -I/usr/include/python3.8 conftest.c
In file included from /usr/include/python3.8/Python.h:63,
                 from conftest.c:23:
/usr/include/python3.8/pyport.h:726:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  726 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
```

**Added `nocross` flag as I'm stuck with this error now.** 

I've submitted an issue [here](https://gitlab.gnome.org/GNOME/nautilus-python/-/issues/11).