### PR TITLE
pipewire: update to 0.3.6

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3287,7 +3287,7 @@ libarcan_shmif_ext.so.0.11 arcan-0.5.4.3_1
 libarcan_shmif_server.so.0.11 arcan-0.5.4.3_1
 libarcan_tui.so.0.11 arcan-0.5.4.3_1
 liblwipv6.so.2 lwipv6-1.5a_1
-libpipewire-0.2.so.1 libpipewire-0.2.2_1
+libpipewire-0.3.so.0 libpipewire-0.3.6_1
 libvolk.so.2.2.1 volk-2.2.1_1
 libgnuradio-runtime.so.3.8.0 gnuradio-3.8.0.0_1
 libgnuradio-pmt.so.3.8.0 gnuradio-3.8.0.0_1
@@ -3516,6 +3516,18 @@ libcss_parser.so.0 htmlcxx-0.86_1
 libaom.so.0 libaom-1.0.0_1
 libre.so re-0.5.8_1
 libspandsp.so.2 spandsp-0.0.6_1
+libspa-alsa.so libspa-alsa-0.3.6_1
+libspa-audioconvert.so libspa-audioconvert-0.3.6_1
+libspa-audiomixer.so libspa-audiomixer-0.3.6_1
+libspa-bluez5.so libspa-bluetooth-0.3.6_1
+libspa-control.so libspa-control-0.3.6_1
+libspa-ffmpeg.so libspa-ffmpeg-0.3.6_1
+libspa-jack.so libspa-jack-0.3.6_1
+libspa-v4l2.so libspa-v4l2-0.3.6_1
+libspa-videoconvert.so libspa-videoconvert-0.3.6_1
+libspa-vulkan.so libspa-vulkan-0.3.6_1
+libspa-bluez5.so libspa-bluetooth-0.3.6_1
+libspa-ffmpeg.so libspa-ffmpeg-0.3.6_1
 librem.so rem-0.5.3_1
 libshp.so.1 shapelib-1.4.1_1
 libantlr3c.so libantlr3c-3.4_1

--- a/srcpkgs/alsa-pipewire
+++ b/srcpkgs/alsa-pipewire
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libjack-pipewire
+++ b/srcpkgs/libjack-pipewire
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libpulseaudio-pipewire
+++ b/srcpkgs/libpulseaudio-pipewire
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-alsa
+++ b/srcpkgs/libspa-alsa
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-audioconvert
+++ b/srcpkgs/libspa-audioconvert
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-audiomixer
+++ b/srcpkgs/libspa-audiomixer
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-control
+++ b/srcpkgs/libspa-control
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-jack
+++ b/srcpkgs/libspa-jack
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-v4l2
+++ b/srcpkgs/libspa-v4l2
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-videoconvert
+++ b/srcpkgs/libspa-videoconvert
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/libspa-vulkan
+++ b/srcpkgs/libspa-vulkan
@@ -1,0 +1,1 @@
+pipewire

--- a/srcpkgs/mutter/patches/pipewire-0.3.patch
+++ b/srcpkgs/mutter/patches/pipewire-0.3.patch
@@ -1,0 +1,521 @@
+Build mutter against pipewire-0.3, based on a patch at:
+https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1062
+--- meson.build
++++ meson.build
+@@ -50,7 +50,7 @@ libinput_req = '>= 1.7'
+ gbm_req = '>= 10.3'
+
+ # screen cast version requirements
+-libpipewire_req = '>= 0.2.5'
++libpipewire_req = '>= 0.3.0'
+
+ gnome = import('gnome')
+ pkg = import('pkgconfig')
+@@ -241,7 +241,7 @@ endif
+
+ have_remote_desktop = get_option('remote_desktop')
+ if have_remote_desktop
+-  libpipewire_dep = dependency('libpipewire-0.2', version: libpipewire_req)
++  libpipewire_dep = dependency('libpipewire-0.3', version: libpipewire_req)
+ endif
+
+ have_introspection = get_option('introspection')
+diff --git a/src/backends/meta-screen-cast-stream-src.c b/src/backends/meta-screen-cast-stream-src.c
+index 82c5cba436..ba1ce94a7e 100644
+--- src/backends/meta-screen-cast-stream-src.c
++++ src/backends/meta-screen-cast-stream-src.c
+@@ -29,6 +29,7 @@
+ #include <spa/param/props.h>
+ #include <spa/param/format-utils.h>
+ #include <spa/param/video/format-utils.h>
++#include <spa/utils/result.h>
+ #include <stdint.h>
+ #include <sys/mman.h>
+
+@@ -62,15 +63,6 @@ enum
+
+ static guint signals[N_SIGNALS];
+
+-typedef struct _MetaSpaType
+-{
+-  struct spa_type_media_type media_type;
+-  struct spa_type_media_subtype media_subtype;
+-  struct spa_type_format_video format_video;
+-  struct spa_type_video_format video_format;
+-  uint32_t meta_cursor;
+-} MetaSpaType;
+-
+ typedef struct _MetaPipeWireSource
+ {
+   GSource base;
+@@ -82,19 +74,19 @@ typedef struct _MetaScreenCastStreamSrcPrivate
+ {
+   MetaScreenCastStream *stream;
+
++  struct pw_context *pipewire_context;
+   struct pw_core *pipewire_core;
+-  struct pw_remote *pipewire_remote;
+-  struct pw_type *pipewire_type;
+   MetaPipeWireSource *pipewire_source;
+-  struct spa_hook pipewire_remote_listener;
++  struct spa_hook pipewire_core_listener;
+
+   gboolean is_enabled;
+
+   struct pw_stream *pipewire_stream;
+   struct spa_hook pipewire_stream_listener;
++  uint32_t node_id;
+
+-  MetaSpaType spa_type;
+   struct spa_video_info_raw video_format;
++  int video_stride;
+
+   uint64_t last_frame_timestamp_us;
+
+@@ -112,8 +104,6 @@ G_DEFINE_TYPE_WITH_CODE (MetaScreenCastStreamSrc,
+                                                 meta_screen_cast_stream_src_init_initable_iface)
+                          G_ADD_PRIVATE (MetaScreenCastStreamSrc))
+
+-#define PROP_RANGE(min, max) 2, (min), (max)
+-
+ static void
+ meta_screen_cast_stream_src_get_specs (MetaScreenCastStreamSrc *src,
+                                        int                     *width,
+@@ -286,9 +276,6 @@ meta_screen_cast_stream_src_set_empty_cursor_sprite_metadata (MetaScreenCastStre
+                                                               int                      x,
+                                                               int                      y)
+ {
+-  MetaScreenCastStreamSrcPrivate *priv =
+-    meta_screen_cast_stream_src_get_instance_private (src);
+-  MetaSpaType *spa_type = &priv->spa_type;
+   struct spa_meta_bitmap *spa_meta_bitmap;
+
+   spa_meta_cursor->id = 1;
+@@ -300,7 +287,7 @@ meta_screen_cast_stream_src_set_empty_cursor_sprite_metadata (MetaScreenCastStre
+   spa_meta_bitmap = SPA_MEMBER (spa_meta_cursor,
+                                 spa_meta_cursor->bitmap_offset,
+                                 struct spa_meta_bitmap);
+-  spa_meta_bitmap->format = spa_type->video_format.RGBA;
++  spa_meta_bitmap->format = SPA_VIDEO_FORMAT_RGBA;
+   spa_meta_bitmap->offset = sizeof (struct spa_meta_bitmap);
+
+   spa_meta_cursor->hotspot.x = 0;
+@@ -317,9 +304,6 @@ meta_screen_cast_stream_src_set_cursor_sprite_metadata (MetaScreenCastStreamSrc
+                                                         int                      y,
+                                                         float                    scale)
+ {
+-  MetaScreenCastStreamSrcPrivate *priv =
+-    meta_screen_cast_stream_src_get_instance_private (src);
+-  MetaSpaType *spa_type = &priv->spa_type;
+   CoglTexture *cursor_texture;
+   struct spa_meta_bitmap *spa_meta_bitmap;
+   int hotspot_x, hotspot_y;
+@@ -346,7 +330,7 @@ meta_screen_cast_stream_src_set_cursor_sprite_metadata (MetaScreenCastStreamSrc
+   spa_meta_bitmap = SPA_MEMBER (spa_meta_cursor,
+                                 spa_meta_cursor->bitmap_offset,
+                                 struct spa_meta_bitmap);
+-  spa_meta_bitmap->format = spa_type->video_format.RGBA;
++  spa_meta_bitmap->format = SPA_VIDEO_FORMAT_RGBA;
+   spa_meta_bitmap->offset = sizeof (struct spa_meta_bitmap);
+
+   meta_cursor_sprite_get_hotspot (cursor_sprite, &hotspot_x, &hotspot_y);
+@@ -382,12 +366,10 @@ static void
+ add_cursor_metadata (MetaScreenCastStreamSrc *src,
+                      struct spa_buffer       *spa_buffer)
+ {
+-  MetaScreenCastStreamSrcPrivate *priv =
+-    meta_screen_cast_stream_src_get_instance_private (src);
+-  MetaSpaType *spa_type = &priv->spa_type;
+   struct spa_meta_cursor *spa_meta_cursor;
+
+-  spa_meta_cursor = spa_buffer_find_meta (spa_buffer, spa_type->meta_cursor);
++  spa_meta_cursor = spa_buffer_find_meta_data (spa_buffer, SPA_META_Cursor,
++                                               sizeof (*spa_meta_cursor));
+   if (spa_meta_cursor)
+     meta_screen_cast_stream_src_set_cursor_metadata (src, spa_meta_cursor);
+ }
+@@ -447,14 +429,14 @@ meta_screen_cast_stream_src_maybe_record_frame (MetaScreenCastStreamSrc *src)
+     {
+       data = spa_buffer->datas[0].data;
+     }
+-  else if (spa_buffer->datas[0].type == priv->pipewire_type->data.MemFd)
++  else if (spa_buffer->datas[0].type == SPA_DATA_MemFd)
+     {
+       map = mmap (NULL, spa_buffer->datas[0].maxsize + spa_buffer->datas[0].mapoffset,
+                   PROT_READ | PROT_WRITE, MAP_SHARED,
+                   spa_buffer->datas[0].fd, 0);
+       if (map == MAP_FAILED)
+         {
+-          g_warning ("Failed to mmap pipewire stream buffer: %s\n",
++          g_warning ("Failed to mmap pipewire stream buffer: %s",
+                      strerror (errno));
+           return;
+         }
+@@ -469,28 +451,30 @@ meta_screen_cast_stream_src_maybe_record_frame (MetaScreenCastStreamSrc *src)
+
+   if (meta_screen_cast_stream_src_record_frame (src, data))
+     {
+-      struct spa_meta_video_crop *spa_meta_video_crop;
++      struct spa_meta_region *spa_meta_video_crop;
+
+       spa_buffer->datas[0].chunk->size = spa_buffer->datas[0].maxsize;
++      spa_buffer->datas[0].chunk->stride = priv->video_stride;
+
+       /* Update VideoCrop if needed */
+       spa_meta_video_crop =
+-        spa_buffer_find_meta (spa_buffer, priv->pipewire_type->meta.VideoCrop);
++        spa_buffer_find_meta_data (spa_buffer, SPA_META_VideoCrop,
++                                   sizeof (*spa_meta_video_crop));
+       if (spa_meta_video_crop)
+         {
+           if (meta_screen_cast_stream_src_get_videocrop (src, &crop_rect))
+             {
+-              spa_meta_video_crop->x = crop_rect.x;
+-              spa_meta_video_crop->y = crop_rect.y;
+-              spa_meta_video_crop->width = crop_rect.width;
+-              spa_meta_video_crop->height = crop_rect.height;
++              spa_meta_video_crop->region.position.x = crop_rect.x;
++              spa_meta_video_crop->region.position.y = crop_rect.y;
++              spa_meta_video_crop->region.size.width = crop_rect.width;
++              spa_meta_video_crop->region.size.height = crop_rect.height;
+             }
+           else
+             {
+-              spa_meta_video_crop->x = 0;
+-              spa_meta_video_crop->y = 0;
+-              spa_meta_video_crop->width = priv->stream_width;
+-              spa_meta_video_crop->height = priv->stream_height;
++              spa_meta_video_crop->region.position.x = 0;
++              spa_meta_video_crop->region.position.y = 0;
++              spa_meta_video_crop->region.size.width = priv->stream_width;
++              spa_meta_video_crop->region.size.height = priv->stream_height;
+             }
+         }
+     }
+@@ -555,7 +539,6 @@ on_stream_state_changed (void                 *data,
+   MetaScreenCastStreamSrc *src = data;
+   MetaScreenCastStreamSrcPrivate *priv =
+     meta_screen_cast_stream_src_get_instance_private (src);
+-  uint32_t node_id;
+
+   switch (state)
+     {
+@@ -563,14 +546,12 @@ on_stream_state_changed (void                 *data,
+       g_warning ("pipewire stream error: %s", error_message);
+       meta_screen_cast_stream_src_notify_closed (src);
+       break;
+-    case PW_STREAM_STATE_CONFIGURE:
+-      node_id = pw_stream_get_node_id (priv->pipewire_stream);
+-      g_signal_emit (src, signals[READY], 0, (unsigned int) node_id);
+-      break;
+-    case PW_STREAM_STATE_UNCONNECTED:
+-    case PW_STREAM_STATE_CONNECTING:
+-    case PW_STREAM_STATE_READY:
+     case PW_STREAM_STATE_PAUSED:
++      if (priv->node_id == SPA_ID_INVALID && priv->pipewire_stream)
++        {
++          priv->node_id = pw_stream_get_node_id (priv->pipewire_stream);
++          g_signal_emit (src, signals[READY], 0, (unsigned int) priv->node_id);
++        }
+       if (meta_screen_cast_stream_src_is_enabled (src))
+         meta_screen_cast_stream_src_disable (src);
+       break;
+@@ -578,68 +559,69 @@ on_stream_state_changed (void                 *data,
+       if (!meta_screen_cast_stream_src_is_enabled (src))
+         meta_screen_cast_stream_src_enable (src);
+       break;
++    case PW_STREAM_STATE_UNCONNECTED:
++    case PW_STREAM_STATE_CONNECTING:
++      break;
+     }
+ }
+
+ static void
+-on_stream_format_changed (void                 *data,
+-                          const struct spa_pod *format)
++on_stream_param_changed (void                 *data,
++                         uint32_t              id,
++                         const struct spa_pod *format)
+ {
+   MetaScreenCastStreamSrc *src = data;
+   MetaScreenCastStreamSrcPrivate *priv =
+     meta_screen_cast_stream_src_get_instance_private (src);
+-  struct pw_type *pipewire_type = priv->pipewire_type;
+   uint8_t params_buffer[1024];
+   int32_t width, height, stride, size;
+   struct spa_pod_builder pod_builder;
+   const struct spa_pod *params[3];
+   const int bpp = 4;
+
+-  if (!format)
+-    {
+-      pw_stream_finish_format (priv->pipewire_stream, 0, NULL, 0);
+-      return;
+-    }
++  if (!format || id != SPA_PARAM_Format)
++    return;
+
+   spa_format_video_raw_parse (format,
+-                              &priv->video_format,
+-                              &priv->spa_type.format_video);
++                              &priv->video_format);
+
+   width = priv->video_format.size.width;
+   height = priv->video_format.size.height;
+   stride = SPA_ROUND_UP_N (width * bpp, 4);
+   size = height * stride;
+
++  priv->video_stride = stride;
++
+   pod_builder = SPA_POD_BUILDER_INIT (params_buffer, sizeof (params_buffer));
+
+-  params[0] = spa_pod_builder_object (
++  params[0] = spa_pod_builder_add_object (
+     &pod_builder,
+-    pipewire_type->param.idBuffers, pipewire_type->param_buffers.Buffers,
+-    ":", pipewire_type->param_buffers.size, "i", size,
+-    ":", pipewire_type->param_buffers.stride, "i", stride,
+-    ":", pipewire_type->param_buffers.buffers, "iru", 16, PROP_RANGE (2, 16),
+-    ":", pipewire_type->param_buffers.align, "i", 16);
+-
+-  params[1] = spa_pod_builder_object (
++    SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
++    SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int (16, 2, 16),
++    SPA_PARAM_BUFFERS_blocks, SPA_POD_Int (1),
++    SPA_PARAM_BUFFERS_size, SPA_POD_Int (size),
++    SPA_PARAM_BUFFERS_stride, SPA_POD_Int (stride),
++    SPA_PARAM_BUFFERS_align, SPA_POD_Int (16));
++
++  params[1] = spa_pod_builder_add_object (
+     &pod_builder,
+-    pipewire_type->param.idMeta, pipewire_type->param_meta.Meta,
+-    ":", pipewire_type->param_meta.type, "I", pipewire_type->meta.VideoCrop,
+-    ":", pipewire_type->param_meta.size, "i", sizeof (struct spa_meta_video_crop));
++    SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
++    SPA_PARAM_META_type, SPA_POD_Id (SPA_META_VideoCrop),
++    SPA_PARAM_META_size, SPA_POD_Int (sizeof (struct spa_meta_region)));
+
+-  params[2] = spa_pod_builder_object (
++  params[2] = spa_pod_builder_add_object (
+     &pod_builder,
+-    pipewire_type->param.idMeta, pipewire_type->param_meta.Meta,
+-    ":", pipewire_type->param_meta.type, "I", priv->spa_type.meta_cursor,
+-    ":", pipewire_type->param_meta.size, "i", CURSOR_META_SIZE (64, 64));
++    SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta,
++    SPA_PARAM_META_type, SPA_POD_Id (SPA_META_Cursor),
++    SPA_PARAM_META_size, SPA_POD_Int (CURSOR_META_SIZE (64, 64)));
+
+-  pw_stream_finish_format (priv->pipewire_stream, 0,
+-                           params, G_N_ELEMENTS (params));
++  pw_stream_update_params (priv->pipewire_stream, params, G_N_ELEMENTS (params));
+ }
+
+ static const struct pw_stream_events stream_events = {
+   PW_VERSION_STREAM_EVENTS,
+   .state_changed = on_stream_state_changed,
+-  .format_changed = on_stream_format_changed,
++  .param_changed = on_stream_param_changed,
+ };
+
+ static struct pw_stream *
+@@ -652,8 +634,6 @@ create_pipewire_stream (MetaScreenCastStreamSrc  *src,
+   uint8_t buffer[1024];
+   struct spa_pod_builder pod_builder =
+     SPA_POD_BUILDER_INIT (buffer, sizeof (buffer));
+-  MetaSpaType *spa_type = &priv->spa_type;
+-  struct pw_type *pipewire_type = priv->pipewire_type;
+   float frame_rate;
+   MetaFraction frame_rate_fraction;
+   struct spa_fraction max_framerate;
+@@ -661,7 +641,9 @@ create_pipewire_stream (MetaScreenCastStreamSrc  *src,
+   const struct spa_pod *params[1];
+   int result;
+
+-  pipewire_stream = pw_stream_new (priv->pipewire_remote,
++  priv->node_id = SPA_ID_INVALID;
++
++  pipewire_stream = pw_stream_new (priv->pipewire_core,
+                                    "meta-screen-cast-src",
+                                    NULL);
+   if (!pipewire_stream)
+@@ -682,17 +664,17 @@ create_pipewire_stream (MetaScreenCastStreamSrc  *src,
+   max_framerate = SPA_FRACTION (frame_rate_fraction.num,
+                                 frame_rate_fraction.denom);
+
+-  params[0] = spa_pod_builder_object (
++  params[0] = spa_pod_builder_add_object (
+     &pod_builder,
+-    pipewire_type->param.idEnumFormat, pipewire_type->spa_format,
+-    "I", spa_type->media_type.video,
+-    "I", spa_type->media_subtype.raw,
+-    ":", spa_type->format_video.format, "I", spa_type->video_format.BGRx,
+-    ":", spa_type->format_video.size, "R", &SPA_RECTANGLE (priv->stream_width,
+-                                                           priv->stream_height),
+-    ":", spa_type->format_video.framerate, "F", &SPA_FRACTION (0, 1),
+-    ":", spa_type->format_video.max_framerate, "Fru", &max_framerate,
+-                                                      PROP_RANGE (&min_framerate,
++    SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
++    SPA_FORMAT_mediaType, SPA_POD_Id (SPA_MEDIA_TYPE_video),
++    SPA_FORMAT_mediaSubtype, SPA_POD_Id (SPA_MEDIA_SUBTYPE_raw),
++    SPA_FORMAT_VIDEO_format, SPA_POD_Id (SPA_VIDEO_FORMAT_BGRx),
++    SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle (&SPA_RECTANGLE (priv->stream_width,
++                                                              priv->stream_height)),
++    SPA_FORMAT_VIDEO_framerate, SPA_POD_Fraction (&SPA_FRACTION (0, 1)),
++    SPA_FORMAT_VIDEO_maxFramerate, SPA_POD_CHOICE_RANGE_Fraction (&max_framerate,
++                                                                  &min_framerate,
+                                                                   &max_framerate));
+
+   pw_stream_add_listener (pipewire_stream,
+@@ -702,7 +684,7 @@ create_pipewire_stream (MetaScreenCastStreamSrc  *src,
+
+   result = pw_stream_connect (pipewire_stream,
+                               PW_DIRECTION_OUTPUT,
+-                              NULL,
++                              SPA_ID_INVALID,
+                               (PW_STREAM_FLAG_DRIVER |
+                                PW_STREAM_FLAG_MAP_BUFFERS),
+                               params, G_N_ELEMENTS (params));
+@@ -717,40 +699,18 @@ create_pipewire_stream (MetaScreenCastStreamSrc  *src,
+ }
+
+ static void
+-on_state_changed (void                 *data,
+-                  enum pw_remote_state  old,
+-                  enum pw_remote_state  state,
+-                  const char           *error_message)
++on_core_error (void       *data,
++               uint32_t    id,
++	       int         seq,
++	       int         res,
++	       const char *message)
+ {
+   MetaScreenCastStreamSrc *src = data;
+-  MetaScreenCastStreamSrcPrivate *priv =
+-    meta_screen_cast_stream_src_get_instance_private (src);
+-  struct pw_stream *pipewire_stream;
+-  GError *error = NULL;
+
+-  switch (state)
+-    {
+-    case PW_REMOTE_STATE_ERROR:
+-      g_warning ("pipewire remote error: %s\n", error_message);
+-      meta_screen_cast_stream_src_notify_closed (src);
+-      break;
+-    case PW_REMOTE_STATE_CONNECTED:
+-      pipewire_stream = create_pipewire_stream (src, &error);
+-      if (!pipewire_stream)
+-        {
+-          g_warning ("Could not create pipewire stream: %s", error->message);
+-          g_error_free (error);
+-          meta_screen_cast_stream_src_notify_closed (src);
+-        }
+-      else
+-        {
+-          priv->pipewire_stream = pipewire_stream;
+-        }
+-      break;
+-    case PW_REMOTE_STATE_UNCONNECTED:
+-    case PW_REMOTE_STATE_CONNECTING:
+-      break;
+-    }
++  g_warning ("pipewire remote error: id:%u %s", id, message);
++
++  if (id == PW_ID_CORE && res == -EPIPE)
++    meta_screen_cast_stream_src_notify_closed (src);
+ }
+
+ static gboolean
+@@ -793,17 +753,6 @@ static GSourceFuncs pipewire_source_funcs =
+   pipewire_loop_source_finalize
+ };
+
+-static void
+-init_spa_type (MetaSpaType         *type,
+-               struct spa_type_map *map)
+-{
+-  spa_type_media_type_map (map, &type->media_type);
+-  spa_type_media_subtype_map (map, &type->media_subtype);
+-  spa_type_format_video_map (map, &type->format_video);
+-  spa_type_video_format_map (map, &type->video_format);
+-  type->meta_cursor = spa_type_map_get_id(map, SPA_TYPE_META__Cursor);
+-}
+-
+ static MetaPipeWireSource *
+ create_pipewire_source (void)
+ {
+@@ -829,9 +778,9 @@ create_pipewire_source (void)
+   return pipewire_source;
+ }
+
+-static const struct pw_remote_events remote_events = {
+-  PW_VERSION_REMOTE_EVENTS,
+-  .state_changed = on_state_changed,
++static const struct pw_core_events core_events = {
++  PW_VERSION_CORE_EVENTS,
++  .error = on_core_error,
+ };
+
+ static gboolean
+@@ -851,37 +800,31 @@ meta_screen_cast_stream_src_initable_init (GInitable     *initable,
+       return FALSE;
+     }
+
+-  priv->pipewire_core = pw_core_new (priv->pipewire_source->pipewire_loop,
+-                                     NULL);
+-  if (!priv->pipewire_core)
++  priv->pipewire_context = pw_context_new (priv->pipewire_source->pipewire_loop,
++                                           NULL, 0);
++  if (!priv->pipewire_context)
+     {
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Failed to create pipewire core");
++                   "Failed to create pipewire context");
+       return FALSE;
+     }
+
+-  priv->pipewire_remote = pw_remote_new (priv->pipewire_core, NULL, 0);
+-  if (!priv->pipewire_remote)
++  priv->pipewire_core = pw_context_connect (priv->pipewire_context, NULL, 0);
++  if (!priv->pipewire_core)
+     {
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Couldn't creat pipewire remote");
++                   "Couldn't connect pipewire context");
+       return FALSE;
+     }
+
+-  pw_remote_add_listener (priv->pipewire_remote,
+-                          &priv->pipewire_remote_listener,
+-                          &remote_events,
+-                          src);
++  pw_core_add_listener (priv->pipewire_core,
++                        &priv->pipewire_core_listener,
++                        &core_events,
++                        src);
+
+-  priv->pipewire_type = pw_core_get_type (priv->pipewire_core);
+-  init_spa_type (&priv->spa_type, priv->pipewire_type->map);
+-
+-  if (pw_remote_connect (priv->pipewire_remote) != 0)
+-    {
+-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Couldn't connect pipewire remote");
+-      return FALSE;
+-    }
++  priv->pipewire_stream = create_pipewire_stream (src, error);
++  if (!priv->pipewire_stream)
++    return FALSE;
+
+   return TRUE;
+ }
+@@ -912,8 +855,8 @@ meta_screen_cast_stream_src_finalize (GObject *object)
+     meta_screen_cast_stream_src_disable (src);
+
+   g_clear_pointer (&priv->pipewire_stream, pw_stream_destroy);
+-  g_clear_pointer (&priv->pipewire_remote, pw_remote_destroy);
+-  g_clear_pointer (&priv->pipewire_core, pw_core_destroy);
++  g_clear_pointer (&priv->pipewire_core, pw_core_disconnect);
++  g_clear_pointer (&priv->pipewire_context, pw_context_destroy);
+   g_source_destroy (&priv->pipewire_source->base);
+
+   G_OBJECT_CLASS (meta_screen_cast_stream_src_parent_class)->finalize (object);

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=3.34.1
-revision=2
+revision=3
 build_helper="gir"
 build_style=meson
 configure_args="-Degl_device=true -Dudev=true -Dnative_backend=true

--- a/srcpkgs/pipewire/patches/fix-neon-detection.patch
+++ b/srcpkgs/pipewire/patches/fix-neon-detection.patch
@@ -1,0 +1,55 @@
+Workaround for NEON detection for armv6l/armv7l
+https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/235
+
+diff --git meson.build meson.build
+index 29b4b892..0d048a1f 100644
+--- meson.build
++++ meson.build
+@@ -99,36 +99,16 @@ have_avx = cc.has_argument(avx_args)
+ have_avx2 = cc.has_argument(avx2_args)
+
+ have_neon = false
+-if host_machine.cpu_family() == 'aarch64'
+-  if cc.compiles('''
+-    #include <arm_neon.h>
+-    int main () {
+-      float *s;
+-      asm volatile(
+-	"      ld1 { v0.4s }, [%[s]], #16\n"
+-        "      fcvtzs v0.4s, v0.4s, #31\n"
+-	: [s] "+r" (s) : :);
+-    }
+-    ''',
+-    name : 'aarch64 Neon Support')
+-      neon_args = []
+-      have_neon = true
+-
+-  endif
+-elif cc.has_argument('-mfpu=neon')
+-  if cc.compiles('''
+-    #include <arm_neon.h>
+-    int main () {
+-      float *s;
+-      asm volatile(
+-        "      vld1.32 { q0 }, [%[s]]!\n"
+-        "      vcvt.s32.f32 q0, q0, #31\n"
+-	: [s] "+r" (s) : :);
+-    }
+-    ''',
+-    args: '-mfpu=neon',
+-    name : 'arm Neon Support')
+-      neon_args = ['-mfpu=neon']
+-      have_neon = true
++neon_args = []
++if host_machine.cpu_family() == 'arm' or host_machine.cpu_family() == 'aarch64'
++  if cc.compiles(
++'''
++#include <arm_neon.h>
++int32x4_t testfunc(int16_t *a, int16_t *b) {
++return vmull_s16(vld1_s16(a), vld1_s16(b));
++}
++''',
++   name : 'NEON support')
++    have_neon = true
+   endif
+ endif

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,26 +1,37 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.2.7
+version=0.3.6
 revision=1
 build_style=meson
-configure_args="-Dman=true -Dgstreamer=enabled -Ddocs=true -Dsystemd=false"
+configure_args="-Dman=true -Dgstreamer=true -Ddocs=true -Dsystemd=false
+ -Dbluez5=true -Dffmpeg=true -Dpipewire-alsa=true -Dpipewire-jack=true
+ -Dpipewire-pulseaudio=true"
 hostmakedepends="doxygen graphviz pkg-config xmltoman"
 makedepends="SDL2-devel ffmpeg-devel gst-plugins-base1-devel jack-devel
- sbc-devel v4l-utils-devel libva-devel"
+ sbc-devel v4l-utils-devel libva-devel libbluetooth-devel"
 short_desc="Server and user space API to deal with multimedia pipelines"
-maintainer="Orphaned <orphan@voidlinux.org>"
-#Next release will probably change to MIT, currently listed in master
-license="LGPL-2.1-only, GPL-2.0-only "
+maintainer="Kridsada Thanabulpong <sirn@ogsite.net>"
+license="MIT"
 homepage="https://pipewire.org/"
-changelog="https://raw.githubusercontent.com/PipeWire/pipewire/master/NEWS"
-distfiles="https://github.com/PipeWire/pipewire/archive/${version}.tar.gz"
-checksum=bfaa0f6ae6c0791e2e0b59234d399753bf24f1b33dbf587682363a8463dd8df1
+changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
+distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
+checksum=927301640f87d68e52f4480667977bc6f47186ee7877f7aa86ce9172ff144edc
 conf_files="/etc/pipewire/pipewire.conf"
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	LDFLAGS+=" -latomic"
+fi
+
+post_install() {
+	vlicense LICENSE
+}
 
 libpipewire_package() {
 	short_desc+=" - pipewire library"
 	pkg_install() {
-		vmove "usr/lib/libpipewire-0.2.so.*"
+		vmove "usr/lib/libpipewire-0.3.so.*"
+		vmove "usr/lib/pipewire-0.3/*.so"
 	}
 }
 
@@ -28,25 +39,81 @@ pipewire-devel_package() {
 	depends="libpipewire-${version}_${revision}"
 	short_desc+=" - pipewire and libspa development files"
 	pkg_install() {
-		vmove usr/include/pipewire
-		vmove usr/include/spa
-		vmove usr/lib/pkgconfig/libpipewire-0.2.pc
-		vmove usr/lib/pkgconfig/libspa-0.1.pc
-		vmove usr/lib/libpipewire-0.2.so
+		vmove usr/include/pipewire-0.3
+		vmove usr/include/spa-0.2
+		vmove usr/lib/pkgconfig/libpipewire-0.3.pc
+		vmove usr/lib/pkgconfig/libspa-0.2.pc
+		vmove usr/lib/libpipewire-0.3.so
 	}
 }
 
-libspa-ffmpeg_package() {
-	short_desc+=" - ffmpeg plugins"
+libspa-alsa_package() {
+	short_desc+=" - alsa plugins"
 	pkg_install() {
-		vmove usr/lib/spa/ffmpeg
+		vmove usr/lib/spa-0.2/alsa
+	}
+}
+
+libspa-audioconvert_package() {
+	short_desc+=" - audioconvert plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/audioconvert
+	}
+}
+
+libspa-audiomixer_package() {
+	short_desc+=" - audiomixer plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/audiomixer
 	}
 }
 
 libspa-bluetooth_package() {
 	short_desc+=" - bluetooth plugins"
 	pkg_install() {
-		vmove usr/lib/spa/bluez5
+		vmove usr/lib/spa-0.2/bluez5
+	}
+}
+
+libspa-control_package() {
+	short_desc+=" - control plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/control
+	}
+}
+
+libspa-ffmpeg_package() {
+	short_desc+=" - ffmpeg plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/ffmpeg
+	}
+}
+
+libspa-jack_package() {
+	short_desc+=" - jack plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/jack
+	}
+}
+
+libspa-v4l2_package() {
+	short_desc+=" - v4l2 plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/v4l2
+	}
+}
+
+libspa-videoconvert_package() {
+	short_desc+=" - videoconvert plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/videoconvert
+	}
+}
+
+libspa-vulkan_package() {
+	short_desc+=" - vulkan plugins"
+	pkg_install() {
+		vmove usr/lib/spa-0.2/vulkan
 	}
 }
 
@@ -54,6 +121,32 @@ gstreamer1-pipewire_package() {
 	short_desc+=" - gstreamer plugin"
 	pkg_install() {
 		vmove usr/lib/gstreamer-1.0
+	}
+}
+
+libpulseaudio-pipewire_package() {
+	depends="libpipewire-${version}_${revision}"
+	short_desc+=" - PulseAudio client library"
+	pkg_install() {
+		vmove usr/lib/pipewire-0.3/pulse
+		vmove usr/bin/pw-pulse
+	}
+}
+
+alsa-pipewire_package() {
+	depends="libpipewire-${version}_${revision}"
+	short_desc+=" - ALSA client library"
+	pkg_install() {
+		vmove usr/lib/alsa-lib
+	}
+}
+
+libjack-pipewire_package() {
+	depends="libpipewire-${version}_${revision}"
+	short_desc+=" - JACK client library"
+	pkg_install() {
+		vmove usr/lib/pipewire-0.3/jack
+		vmove usr/bin/pw-jack
 	}
 }
 

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,9 +1,10 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
 version=5.19.0
-revision=1
+revision=2
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons gettext"
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons gettext
+ pkg-config"
 makedepends="glib-devel kio-devel kwayland-devel libepoxy-devel pipewire-devel
  plasma-framework-devel kdeclarative-devel kirigami2-devel"
 short_desc="Backend implementation for xdg-desktop-portal that is using Qt/KF5"

--- a/srcpkgs/xdg-desktop-portal/patches/pipewire-0.3.patch
+++ b/srcpkgs/xdg-desktop-portal/patches/pipewire-0.3.patch
@@ -1,0 +1,551 @@
+From a38901e5e7f835efe7b7a06c55790c8c20bc91a2 Mon Sep 17 00:00:00 2001
+From: Wim Taymans <wtaymans@redhat.com>
+Date: Tue, 14 Jan 2020 09:37:09 +0100
+Subject: [PATCH] PipeWire: update to 0.3 API
+
+---
+ configure.ac      |   2 +-
+ src/camera.c      |  24 ++++----
+ src/pipewire.c    | 141 +++++++++++++---------------------------------
+ src/pipewire.h    |  10 ++--
+ src/screen-cast.c |  98 ++++++--------------------------
+ 5 files changed, 72 insertions(+), 203 deletions(-)
+
+diff --git configure.ac configure.ac
+index 89902fa..62d7960 100644
+--- configure.ac
++++ configure.ac
+@@ -97,7 +97,7 @@ AC_ARG_ENABLE(pipewire,
+ 	      [AS_HELP_STRING([--enable-pipewire],[Enable PipeWire support. Needed for screen cast portal])],
+ 	      enable_pipewire=$enableval, enable_pipewire=yes)
+ if test x$enable_pipewire = xyes ; then
+-	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.2 >= 0.2.6])
++	PKG_CHECK_MODULES(PIPEWIRE, [libpipewire-0.3 >= 0.2.90])
+ 	AC_DEFINE([HAVE_PIPEWIRE],[1], [Define to enable PipeWire support])
+ fi
+ AM_CONDITIONAL([HAVE_PIPEWIRE],[test "$enable_pipewire" = "yes"])
+diff --git src/camera.c src/camera.c
+index c2b392c..20fe3aa 100644
+--- src/camera.c
++++ src/camera.c
+@@ -141,7 +141,7 @@ open_pipewire_camera_remote (const char *app_id,
+                              GError **error)
+ {
+   PipeWireRemote *remote;
+-  struct spa_dict_item permission_items[1];
++  struct pw_permission permission_items[2];
+   struct pw_properties *pipewire_properties;
+ 
+   pipewire_properties =
+@@ -158,12 +158,12 @@ open_pipewire_camera_remote (const char *app_id,
+    * Hide all existing and future nodes by default. PipeWire will use the
+    * permission store to set up permissions.
+    */
+-  permission_items[0].key = PW_CORE_PROXY_PERMISSIONS_DEFAULT;
+-  permission_items[0].value = "---";
++  permission_items[0] = PW_PERMISSION_INIT (PW_ID_CORE, PW_PERM_RWX);
++  permission_items[1] = PW_PERMISSION_INIT (PW_ID_ANY, 0);
+ 
+-  pw_core_proxy_permissions (pw_remote_get_core_proxy (remote->remote),
+-                             &SPA_DICT_INIT (permission_items,
+-                                             G_N_ELEMENTS (permission_items)));
++  pw_client_update_permissions (pw_core_get_client(remote->core),
++                                G_N_ELEMENTS (permission_items),
++                                permission_items);
+ 
+   pipewire_remote_roundtrip (remote);
+ 
+@@ -219,7 +219,7 @@ handle_open_pipewire_remote (XdpCamera *object,
+     }
+ 
+   out_fd_list = g_unix_fd_list_new ();
+-  fd = pw_remote_steal_fd (remote->remote);
++  fd = pw_core_steal_fd (remote->core);
+   fd_id = g_unix_fd_list_append (out_fd_list, fd, &error);
+   close (fd);
+   pipewire_remote_destroy (remote);
+@@ -250,29 +250,28 @@ camera_iface_init (XdpCameraIface *iface)
+ static void
+ global_added_cb (PipeWireRemote *remote,
+                  uint32_t id,
+-                 uint32_t type,
++                 const char *type,
+                  const struct spa_dict *props,
+                  gpointer user_data)
+ {
+   Camera *camera = user_data;
+-  struct pw_type *core_type = pw_core_get_type (remote->core);
+   const struct spa_dict_item *media_class;
+   const struct spa_dict_item *media_role;
+ 
+-  if (type != core_type->node)
++  if (strcmp(type, PW_TYPE_INTERFACE_Node) != 0)
+     return;
+ 
+   if (!props)
+     return;
+ 
+-  media_class = spa_dict_lookup_item (props, "media.class");
++  media_class = spa_dict_lookup_item (props, PW_KEY_MEDIA_CLASS);
+   if (!media_class)
+     return;
+ 
+   if (g_strcmp0 (media_class->value, "Video/Source") != 0)
+     return;
+ 
+-  media_role = spa_dict_lookup_item (props, "media.role");
++  media_role = spa_dict_lookup_item (props, PW_KEY_MEDIA_ROLE);
+   if (!media_role)
+     return;
+ 
+@@ -342,6 +341,7 @@ create_pipewire_remote (Camera *camera,
+     }
+ 
+   pipewire_properties = pw_properties_new ("pipewire.access.portal.is_portal", "true",
++                                           "portal.monitor", "Camera",
+                                            NULL);
+   camera->pipewire_remote = pipewire_remote_new_sync (pipewire_properties,
+                                                       global_added_cb,
+diff --git src/pipewire.c src/pipewire.c
+index 793a378..162cd55 100644
+--- src/pipewire.c
++++ src/pipewire.c
+@@ -21,6 +21,7 @@
+ #include <errno.h>
+ #include <glib.h>
+ #include <pipewire/pipewire.h>
++#include <spa/utils/result.h>
+ 
+ #include "pipewire.h"
+ 
+@@ -36,27 +37,25 @@ static gboolean is_pipewire_initialized = FALSE;
+ static void
+ registry_event_global (void *user_data,
+                        uint32_t id,
+-                       uint32_t parent_id,
+                        uint32_t permissions,
+-                       uint32_t type,
++                       const char *type,
+                        uint32_t version,
+                        const struct spa_dict *props)
+ {
+   PipeWireRemote *remote = user_data;
+-  struct pw_type *core_type = pw_core_get_type (remote->core);
+   const struct spa_dict_item *factory_object_type;
+   PipeWireGlobal *global;
+ 
+   global = g_new0 (PipeWireGlobal, 1);
+   *global = (PipeWireGlobal) {
+-    .parent_id = parent_id,
++    .parent_id = id,
+   };
+ 
+   g_hash_table_insert (remote->globals, GINT_TO_POINTER (id), global);
+   if (remote->global_added_cb)
+     remote->global_added_cb (remote, id, type, props, remote->user_data);
+ 
+-  if (type != core_type->factory)
++  if (strcmp(type, PW_TYPE_INTERFACE_Factory) != 0)
+     return;
+ 
+   factory_object_type = spa_dict_lookup_item (props, "factory.type.name");
+@@ -81,8 +80,8 @@ registry_event_global_remove (void *user_data,
+   g_hash_table_remove (remote->globals, GINT_TO_POINTER (id));
+ }
+ 
+-static const struct pw_registry_proxy_events registry_events = {
+-  PW_VERSION_REGISTRY_PROXY_EVENTS,
++static const struct pw_registry_events registry_events = {
++  PW_VERSION_REGISTRY_EVENTS,
+   .global = registry_event_global,
+   .global_remove = registry_event_global_remove,
+ };
+@@ -90,7 +89,7 @@ static const struct pw_registry_proxy_events registry_events = {
+ void
+ pipewire_remote_roundtrip (PipeWireRemote *remote)
+ {
+-  pw_core_proxy_sync (remote->core_proxy, ++remote->sync_seq);
++  remote->sync_seq = pw_core_sync (remote->core, PW_ID_CORE, remote->sync_seq);
+   pw_main_loop_run (remote->loop);
+ }
+ 
+@@ -98,16 +97,13 @@ static gboolean
+ discover_node_factory_sync (PipeWireRemote *remote,
+                             GError **error)
+ {
+-  struct pw_type *core_type = pw_core_get_type (remote->core);
+-  struct pw_registry_proxy *registry_proxy;
++  struct pw_registry *registry;
+ 
+-  registry_proxy = pw_core_proxy_get_registry (remote->core_proxy,
+-                                               core_type->registry,
+-                                               PW_VERSION_REGISTRY, 0);
+-  pw_registry_proxy_add_listener (registry_proxy,
+-                                  &remote->registry_listener,
+-                                  &registry_events,
+-                                  remote);
++  registry = pw_core_get_registry (remote->core, PW_VERSION_REGISTRY, 0);
++  pw_registry_add_listener (registry,
++                            &remote->registry_listener,
++                            &registry_events,
++                            remote);
+ 
+   pipewire_remote_roundtrip (remote);
+ 
+@@ -122,59 +118,35 @@ discover_node_factory_sync (PipeWireRemote *remote,
+ }
+ 
+ static void
+-on_state_changed (void *user_data,
+-                  enum pw_remote_state old,
+-                  enum pw_remote_state state,
+-                  const char *error)
++core_event_error (void       *user_data,
++                  uint32_t    id,
++		  int         seq,
++		  int         res,
++		  const char *message)
+ {
+   PipeWireRemote *remote = user_data;
+ 
+-  switch (state)
++  if (id == PW_ID_CORE)
+     {
+-    case PW_REMOTE_STATE_ERROR:
+-      if (!remote->error)
+-        {
+-          g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                       "%s", error);
+-        }
++      g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
++                 "%s", message);
+       pw_main_loop_quit (remote->loop);
+-      break;
+-    case PW_REMOTE_STATE_UNCONNECTED:
+-      if (!remote->error)
+-        {
+-          g_set_error (&remote->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                       "Disconnected");
+-        }
+-      pw_main_loop_quit (remote->loop);
+-      break;
+-    case PW_REMOTE_STATE_CONNECTING:
+-      break;
+-    case PW_REMOTE_STATE_CONNECTED:
+-      pw_main_loop_quit (remote->loop);
+-      break;
+-    default:
+-      g_warning ("Unknown PipeWire state");
+-      break;
+     }
+ }
+ 
+-static const struct pw_remote_events remote_events = {
+-  PW_VERSION_REMOTE_EVENTS,
+-  .state_changed = on_state_changed,
+-};
+-
+ static void
+ core_event_done (void *user_data,
+-                 uint32_t seq)
++                 uint32_t id, int seq)
+ {
+   PipeWireRemote *remote = user_data;
+ 
+-  if (remote->sync_seq == seq)
++  if (id == PW_ID_CORE && remote->sync_seq == seq)
+     pw_main_loop_quit (remote->loop);
+ }
+ 
+-static const struct pw_core_proxy_events core_events = {
+-  PW_VERSION_CORE_PROXY_EVENTS,
++static const struct pw_core_events core_events = {
++  PW_VERSION_CORE_EVENTS,
++  .error = core_event_error,
+   .done = core_event_done,
+ };
+ 
+@@ -237,8 +209,8 @@ void
+ pipewire_remote_destroy (PipeWireRemote *remote)
+ {
+   g_clear_pointer (&remote->globals, g_hash_table_destroy);
+-  g_clear_pointer (&remote->remote, pw_remote_destroy);
+-  g_clear_pointer (&remote->core, pw_core_destroy);
++  g_clear_pointer (&remote->core, pw_core_disconnect);
++  g_clear_pointer (&remote->context, pw_context_destroy);
+   g_clear_pointer (&remote->loop, pw_main_loop_destroy);
+   g_clear_error (&remote->error);
+ 
+@@ -307,68 +279,31 @@ pipewire_remote_new_sync (struct pw_properties *pipewire_properties,
+       return NULL;
+     }
+ 
+-  remote->core = pw_core_new (pw_main_loop_get_loop (remote->loop), NULL);
+-  if (!remote->core)
++  remote->context = pw_context_new (pw_main_loop_get_loop (remote->loop), NULL, 0);
++  if (!remote->context)
+     {
+       pipewire_remote_destroy (remote);
+       pw_properties_free (pipewire_properties);
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Couldn't create PipeWire core");
++                   "Couldn't create PipeWire context");
+       return NULL;
+     }
+ 
+-  remote->remote = pw_remote_new (remote->core, pipewire_properties, 0);
+-  if (!remote->remote)
++  remote->core = pw_context_connect (remote->context, pipewire_properties, 0);
++  if (!remote->core)
+     {
+       pipewire_remote_destroy (remote);
+       g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Couldn't create PipeWire remote");
++                   "Couldn't connect to PipeWire");
+       return NULL;
+     }
+ 
+   remote->globals = g_hash_table_new_full (NULL, NULL, NULL, g_free);
+ 
+-  pw_remote_add_listener (remote->remote,
+-                          &remote->remote_listener,
+-                          &remote_events,
+-                          remote);
+-
+-  if (pw_remote_connect (remote->remote) != 0)
+-    {
+-      pipewire_remote_destroy (remote);
+-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Couldn't connect PipeWire remote");
+-      return NULL;
+-    }
+-
+-  pw_main_loop_run (remote->loop);
+-
+-  switch (pw_remote_get_state (remote->remote, NULL))
+-    {
+-    case PW_REMOTE_STATE_ERROR:
+-    case PW_REMOTE_STATE_UNCONNECTED:
+-      *error = g_steal_pointer (&remote->error);
+-      pipewire_remote_destroy (remote);
+-      return NULL;
+-    case PW_REMOTE_STATE_CONNECTING:
+-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "PipeWire loop stopped unexpectedly");
+-      pipewire_remote_destroy (remote);
+-      return NULL;
+-    case PW_REMOTE_STATE_CONNECTED:
+-      break;
+-    default:
+-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+-                   "Unexpected PipeWire state");
+-      pipewire_remote_destroy (remote);
+-      return NULL;
+-    }
+-
+-  remote->core_proxy = pw_remote_get_core_proxy (remote->remote);
+-  pw_core_proxy_add_listener (remote->core_proxy,
+-                              &remote->core_listener,
+-                              &core_events,
+-                              remote);
++  pw_core_add_listener (remote->core,
++                        &remote->core_listener,
++                        &core_events,
++                        remote);
+ 
+   if (!discover_node_factory_sync (remote, error))
+     {
+diff --git src/pipewire.h src/pipewire.h
+index 0f1bf54..bf48d5e 100644
+--- src/pipewire.h
++++ src/pipewire.h
+@@ -32,7 +32,7 @@ typedef struct _PipeWireGlobal
+ 
+ typedef void (* PipeWireGlobalAddedCallback) (PipeWireRemote *remote,
+                                               uint32_t id,
+-                                              uint32_t type,
++                                              const char *type,
+                                               const struct spa_dict *props,
+                                               gpointer user_data);
+ 
+@@ -43,13 +43,11 @@ typedef void (* PipeWireGlobalRemovedCallback) (PipeWireRemote *remote,
+ struct _PipeWireRemote
+ {
+   struct pw_main_loop *loop;
++  struct pw_context *context;
+   struct pw_core *core;
+-  struct pw_remote *remote;
+-  struct spa_hook remote_listener;
+-
+-  struct pw_core_proxy *core_proxy;
+   struct spa_hook core_listener;
+-  uint32_t sync_seq;
++
++  int sync_seq;
+ 
+   struct spa_hook registry_listener;
+ 
+diff --git src/screen-cast.c src/screen-cast.c
+index 7881ddc..1677050 100644
+--- src/screen-cast.c
++++ src/screen-cast.c
+@@ -31,10 +31,10 @@
+ #include "xdp-impl-dbus.h"
+ #include "xdp-utils.h"
+ 
+-#define PERMISSION_ITEM(item_key, item_value) \
+-  ((struct spa_dict_item) { \
+-    .key = item_key, \
+-    .value = item_value \
++#define PERMISSION_ITEM(item_id, item_permissions) \
++  ((struct pw_permission) { \
++    .id = item_id, \
++    .permissions = item_permissions \
+   })
+ 
+ typedef struct _ScreenCast ScreenCast;
+@@ -517,42 +517,9 @@ screen_cast_stream_get_pipewire_node_id (ScreenCastStream *stream)
+   return stream->id;
+ }
+ 
+-static void
+-append_parent_permissions (PipeWireRemote *remote,
+-                           GArray *permission_items,
+-                           GList **string_stash,
+-                           PipeWireGlobal *global,
+-                           const char *permission)
+-{
+-  PipeWireGlobal *parent;
+-  char *parent_permission_value;
+-
+-  if (global->parent_id == 0)
+-    return;
+-
+-  parent = g_hash_table_lookup (remote->globals, GINT_TO_POINTER (global->parent_id));
+-
+-  if (parent->permission_set)
+-    return;
+-  parent->permission_set = TRUE;
+-
+-  append_parent_permissions (remote, permission_items, string_stash,
+-                             parent, permission);
+-
+-  parent_permission_value = g_strdup_printf ("%u:%s",
+-                                             global->parent_id,
+-                                             permission);
+-  *string_stash = g_list_prepend (*string_stash, parent_permission_value);
+-
+-  g_array_append_val (permission_items,
+-                      PERMISSION_ITEM (PW_CORE_PROXY_PERMISSIONS_GLOBAL,
+-                                       parent_permission_value));
+-}
+-
+ static void
+ append_stream_permissions (PipeWireRemote *remote,
+                            GArray *permission_items,
+-                           GList **string_stash,
+                            GList *streams)
+ {
+   GList *l;
+@@ -561,21 +528,10 @@ append_stream_permissions (PipeWireRemote *remote,
+     {
+       ScreenCastStream *stream = l->data;
+       uint32_t stream_id;
+-      PipeWireGlobal *stream_global;
+-      char *stream_permission_value;
+ 
+       stream_id = screen_cast_stream_get_pipewire_node_id (stream);
+-      stream_global = g_hash_table_lookup (remote->globals,
+-                                           GINT_TO_POINTER (stream_id));
+-
+-      append_parent_permissions (remote, permission_items, string_stash,
+-                                 stream_global, "r--");
+-
+-      stream_permission_value = g_strdup_printf ("%u:rwx", stream_id);
+-      *string_stash = g_list_prepend (*string_stash, stream_permission_value);
+       g_array_append_val (permission_items,
+-                          PERMISSION_ITEM (PW_CORE_PROXY_PERMISSIONS_GLOBAL,
+-                                           stream_permission_value));
++                          PERMISSION_ITEM (stream_id, PW_PERM_RWX));
+     }
+ }
+ 
+@@ -587,9 +543,6 @@ open_pipewire_screen_cast_remote (const char *app_id,
+   struct pw_properties *pipewire_properties;
+   PipeWireRemote *remote;
+   g_autoptr(GArray) permission_items = NULL;
+-  char *node_factory_permission_string;
+-  GList *string_stash = NULL;
+-  struct spa_dict *permission_dict;
+   PipeWireGlobal *node_global;
+ 
+   pipewire_properties = pw_properties_new ("pipewire.access.portal.app_id", app_id,
+@@ -603,48 +556,31 @@ open_pipewire_screen_cast_remote (const char *app_id,
+ 
+   permission_items = g_array_new (FALSE, TRUE, sizeof (struct spa_dict_item));
+ 
+-  /*
+-   * Hide all existing and future nodes (except the ones we explicitly list below.
+-   */
+-  g_array_append_val (permission_items,
+-                      PERMISSION_ITEM (PW_CORE_PROXY_PERMISSIONS_EXISTING,
+-                                       "---"));
+-  g_array_append_val (permission_items,
+-                      PERMISSION_ITEM (PW_CORE_PROXY_PERMISSIONS_DEFAULT,
+-                                       "---"));
+-
+   /*
+    * PipeWire:Interface:Core
+    * Needs rwx to be able create the sink node using the create-object method
+    */
+   g_array_append_val (permission_items,
+-                      PERMISSION_ITEM (PW_CORE_PROXY_PERMISSIONS_GLOBAL,
+-                                       "0:rwx"));
++                      PERMISSION_ITEM (PW_ID_CORE, PW_PERM_RWX));
+ 
+   /*
+    * PipeWire:Interface:NodeFactory
+    * Needs r-- so it can be passed to create-object when creating the sink node.
+    */
+-  node_factory_permission_string = g_strdup_printf ("%d:r--",
+-                                                    remote->node_factory_id);
+-  string_stash = g_list_prepend (string_stash, node_factory_permission_string);
+   g_array_append_val (permission_items,
+-                      PERMISSION_ITEM (PW_CORE_PROXY_PERMISSIONS_GLOBAL,
+-                                       node_factory_permission_string));
+-  node_global = g_hash_table_lookup (remote->globals,
+-                                     GINT_TO_POINTER (remote->node_factory_id));
+-  append_parent_permissions (remote, permission_items, &string_stash,
+-                             node_global, "r--");
++                      PERMISSION_ITEM (remote->node_factory_id, PW_PERM_R));
+ 
+-  append_stream_permissions (remote, permission_items, &string_stash, streams);
++  append_stream_permissions (remote, permission_items, streams);
+ 
+-  permission_dict =
+-    &SPA_DICT_INIT ((struct spa_dict_item *) permission_items->data,
+-                    permission_items->len);
+-  pw_core_proxy_permissions (pw_remote_get_core_proxy (remote->remote),
+-                             permission_dict);
++  /*
++   * Hide all existing and future nodes (except the ones we explicitly list above).
++   */
++  g_array_append_val (permission_items,
++                      PERMISSION_ITEM (PW_ID_ANY, 0));
+ 
+-  g_list_free_full (string_stash, g_free);
++  pw_client_update_permissions (pw_core_get_client(remote->core),
++                                permission_items->len,
++                                (const struct pw_permission *)permission_items->data);
+ 
+   pipewire_remote_roundtrip (remote);
+ 
+@@ -943,7 +879,7 @@ handle_open_pipewire_remote (XdpScreenCast *object,
+     }
+ 
+   out_fd_list = g_unix_fd_list_new ();
+-  fd = pw_remote_steal_fd (remote->remote);
++  fd = pw_core_steal_fd (remote->core);
+   fd_id = g_unix_fd_list_append (out_fd_list, fd, &error);
+   close (fd);
+   pipewire_remote_destroy (remote);

--- a/srcpkgs/xdg-desktop-portal/template
+++ b/srcpkgs/xdg-desktop-portal/template
@@ -1,10 +1,10 @@
 # Template file for 'xdg-desktop-portal'
 pkgname=xdg-desktop-portal
 version=1.6.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-pipewire --enable-geoclue --disable-libportal"
-hostmakedepends="pkg-config glib-devel"
+hostmakedepends="automake libtool gettext-devel pkg-config glib-devel"
 makedepends="flatpak-devel fuse-devel pipewire-devel geoclue2-devel"
 short_desc="Portal frontend service for Flatpak"
 maintainer="Duncaen <duncaen@voidlinux.org>"
@@ -12,6 +12,10 @@ license="LGPL-2.1-or-later"
 homepage="https://github.com/flatpak/xdg-desktop-portal"
 distfiles="https://github.com/flatpak/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.xz"
 checksum=883c9c9a925e48af54812b5347f546dd776ec2e27076a83d5a8126af6bafb9da
+
+pre_configure() {
+	autoreconf -vfi
+}
 
 post_install() {
 	rm -rf "${DESTDIR}/usr/lib/systemd"


### PR DESCRIPTION
This PR updates `pipewire` to 0.3.6 and also updating/patching all packages that depends on it. 

* `xdg-desktop-portal` includes a patch backported from 1.7.0 to allow 1.6.0 to build against pipewire-0.3 (1.7.x is prerelease)
* `xdg-desktop-portal-kde` requires pkg-config to detect pipewire-0.3 because of include dir version suffix.
* `mutter` includes a patch backported from 3.35 to allow 3.34 to build against pipewire-0.3 (upgrading to >=3.35 also requires upgrading GNOME).