### PR TITLE
rpi-kernel: update to 4.19.113.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="2fab54c74bf956951e61c6d4fe473995e8d07010"
+_githash="4f2a4cc501c428c940549f39d5562e60404ac4f7"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.108
+version=4.19.113
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=bc92c569bbdb53744dee458827c64119a16ee5267cdcba851e1832c3a174571c
+checksum=97d835a853dcbc0016b26daa618ce7511b9fecb7c4628dcb56667234163d88eb
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.