### PR TITLE
rpi-firmware: update to 20200326.

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,10 +1,10 @@
 # Template file for 'rpi-firmware'
-_githash="68ec48189c5256b365c9232909180cb56c8820bc"
+_githash="5574077183389cd4c65077ba18b59144ed6ccd6d"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20191118
-revision=2
+version=20200326
+revision=1
 archs=noarch
 wrksrc="firmware-${_githash}"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
@@ -12,7 +12,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=ba24f9e64a9e85e54034454d01b9853fe8d4a91c4993fa1203d6bff99e227355
+checksum=0596505f529677906fed30e6c3c1d2387a5d287f668a719484e2f9d8a3059176
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 


### PR DESCRIPTION
[ci skip]