### PR TITLE
sdcc: update to 4.0.0 and update hostmakedepends

### DIFF
--- a/srcpkgs/sdcc/template
+++ b/srcpkgs/sdcc/template
@@ -1,16 +1,16 @@
 # Template file for 'sdcc'
 pkgname=sdcc
-version=3.9.0
+version=4.0.0
 revision=1
 archs="i686 x86_64*"
 build_style=gnu-configure
-hostmakedepends="flex bison gputils"
+hostmakedepends="automake flex bison gputils texinfo"
 makedepends="boost-devel zlib-devel"
 short_desc="Retargettable ANSI C compiler"
-maintainer="Leandro Vital <leavitals@gmail.com>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later"
 homepage="http://sdcc.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/sdcc/${pkgname}-src-${version}.tar.bz2"
-checksum=94ecae73faf7f3feee307f89dfe3cef2d7866293c7909ea05b3b33c88d67c036
-python_version=2 #unverified
+checksum=489180806fc20a3911ba4cf5ccaf1875b68910d7aed3f401bbd0695b0bef4e10
+python_version=3
 nostrip=yes


### PR DESCRIPTION
Automake and texinfo had to be added to hostmakedepends.

@maxice8 I'm tagging you here because you were the one responsible for the previous SDCC PRs.

EDIT: the builds timed out, which was predictable, if unfortunate.