### PR TITLE
go: add build_style=go to avoid code duplication

### DIFF
--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -2,7 +2,7 @@ hostmakedepends+=" go"
 nostrip=yes
 nopie=yes
 
-case "$XBPS_TARGET_MACHINE" in
+case "${XBPS_TARGET_MACHINE}" in
 	aarch64*) export GOARCH=arm64;;
 	armv6*) export GOARCH=arm; export GOARM=6;;
 	armv7*) export GOARCH=arm; export GOARM=7;;
@@ -10,6 +10,7 @@ case "$XBPS_TARGET_MACHINE" in
 	x86_64*) export GOARCH=amd64;;
 	ppc64le*) export GOARCH=ppc64le;;
 	ppc64*) export GOARCH=ppc64;;
+	ppc*) broken="Upstream does not support 32-bit ppc";;
 esac
 
 export GOPATH="${wrksrc}/_build-${pkgname}-xbps"

--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,9 +1,10 @@
 # Template file for 'go'
 pkgname=go
 version=1.14
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc=go
+build_style=go
 hostmakedepends="go1.12-bootstrap"
 short_desc="Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
@@ -11,26 +12,17 @@ license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
 checksum=6d643e46ad565058c7a39dac01144172ef9bd476521f42148be59249e4b74389
-nostrip=yes
 noverifyrdeps=yes
-
-case "${XBPS_TARGET_MACHINE}" in
-	aarch64*) _goarch=arm64 ;;
-	arm*) _goarch=arm ;;
-	mips*) _goarch=mips ;;
-	i686*) _goarch=386 ;;
-	x86_64*) _goarch=amd64 ;;
-	ppc64le*) _goarch=ppc64le ;;
-	ppc64*) _goarch=ppc64;;
-	ppc*) broken="Upstream does not support 32-bit ppc";;
-	*) _goarch=${XBPS_TARGET_MACHINE} ;;
-esac
 
 if [ "$CROSS_BUILD" ]; then
 	if [ "${XBPS_MACHINE%%-musl}" = "${XBPS_TARGET_MACHINE%%-musl}" ]; then
 		broken="Cross-compiling to different libc is not supported"
 	fi
 fi
+
+do_configure() {
+	:
+}
 
 do_build() {
 	unset GCC CC CXX LD CFLAGS


### PR DESCRIPTION
The GOARCH selection snippet was duplicated in the go build_style script
for environment variables and in the go template itself. Furthermore,
there were discrepancies between the two snippets, which have been
fixed.

This makes the go template leaner, and makes both cases more robust (changes to GOARCH selection can be done in a single place).