### PR TITLE
awesome: add build option jit

### DIFF
--- a/srcpkgs/awesome/template
+++ b/srcpkgs/awesome/template
@@ -1,17 +1,17 @@
 # Template file for 'awesome'
 pkgname=awesome
 version=4.3
-revision=6
+revision=7
 build_style=cmake
 build_helper="qemu"
 configure_args="-DSYSCONFDIR=/etc"
 conf_files="/etc/xdg/awesome/rc.lua"
-hostmakedepends="ruby-asciidoctor ImageMagick lua53-lgi lua53 pkg-config xmlto"
+hostmakedepends="ruby-asciidoctor ImageMagick pkg-config xmlto"
 makedepends="libxcb-devel pango-devel xcb-util-devel xcb-util-image-devel
  xcb-util-keysyms-devel xcb-util-wm-devel xcb-util-cursor-devel
- startup-notification-devel imlib2-devel lua53-lgi libxdg-basedir-devel
- gdk-pixbuf-devel lua53-devel dbus-devel libxkbcommon-devel xcb-util-xrm-devel"
-depends="dbus-x11 lua53-lgi>=0.7.2 pango"
+ startup-notification-devel imlib2-devel libxdg-basedir-devel
+ gdk-pixbuf-devel dbus-devel libxkbcommon-devel xcb-util-xrm-devel"
+depends="dbus-x11 pango"
 short_desc="Highly configurable, next gen framework window manager for X"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -19,9 +19,34 @@ homepage="http://awesomewm.org"
 distfiles="https://github.com/awesomeWM/awesome/releases/download/v${version}/awesome-${version}.tar.xz"
 checksum=78264d6f012350b371e339127aca485260bc0aa935eff578ba75ce1a00e11753
 
+build_options="jit"
+desc_option_jit="Use LuaJIT to build Awesome"
+
+if [ "$build_option_jit" ]; then
+	hostmakedepends+=" LuaJIT lua51-lgi"
+	makedepends+=" LuaJIT-devel lua51-lgi"
+	depends+=" lua51-lgi>=0.7.2"
+	configure_args+="
+		-DLUA_LIBRARY=$XBPS_CROSS_BASE/usr/lib/libluajit-5.1.so
+		-DLUA_INCLUDE_DIR=$XBPS_CROSS_BASE/usr/include/luajit-2.1"
+else
+	hostmakedepends+=" lua53 lua53-lgi"
+	makedepends+=" lua53-devel lua53-lgi"
+	depends+=" lua53-lgi>=0.7.2"
+fi
+
 pre_configure() {
 	# Russian manpages fail to build.
 	vsed -i -e "s|es fr de ru|es fr de|g" CMakeLists.txt
+
+	if [ "$build_option_jit" ]; then
+		# Use correct lua name
+		vsed -e "s|COMMAND lua\b|COMMAND luajit|" \
+			-i awesomeConfig.cmake \
+			-i tests/examples/CMakeLists.txt
+		vsed -e "s|LUA_COV_RUNNER lua\b|LUA_COV_RUNNER luajit|" \
+			-i tests/examples/CMakeLists.txt
+	fi
 }
 
 post_install() {


### PR DESCRIPTION
Enables users to build `awesome` with `LuaJIT`.

Change log:
- `lgi`: rename to `lua-lgi`, create alternative group `lgi`
- New package: `lua51-lgi` (dependencies for `awesome` running with `LuaJIT`)
- `./xbps-src pkg awesome -o jit`, this option is disabled by default.

Related/based on this PR: #16137 