### PR TITLE
New package: xsm-1.0.4

### DIFF
--- a/srcpkgs/xsm/template
+++ b/srcpkgs/xsm/template
@@ -1,0 +1,18 @@
+# Template file for 'xsm'
+pkgname=xsm
+version=1.0.4
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="libSM-devel libX11-devel libXt-devel libXaw-devel libICE-devel"
+depends="iceauth smproxy"
+short_desc="X Session Manager"
+maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
+license="MIT"
+homepage="http://xorg.freedesktop.org"
+distfiles="${XORG_SITE}/app/$pkgname-$version.tar.bz2"
+checksum=9934b6893a4e52cf7435368fc8d425c371b5e32d96e420ead30166eb82d64425
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
When using 'xdm' as a login manager, `/usr/lib/X11/xdm/Xsession` attempts to execute `/usr/bin/xsm` if ~/.xsession doesn't exist for the user logging in. This fails, and semi-silently breaks logins. Providing an `xsm` binary will at least let people log in. Once this is merged, I'll bump xdm to depend on it.

[xsm running](https://pastebin.stratumzero.date/u/p/f9197ae8c503c497b92e9e88573aeba0f0dae50b/stream)

By default, xsm wants to execute twm, but I purposefully left it off the depends list. It still does execute even without twm available - I'm not sure we want to force the installation of a window manager any time someone installs xdm.