### PR TITLE
New package: go-pie

### DIFF
--- a/srcpkgs/go-pie/patches/default-buildmode-pie.patch
+++ b/srcpkgs/go-pie/patches/default-buildmode-pie.patch
@@ -1,0 +1,12 @@
+diff go/src/cmd/go/internal/work/init.go go/src/cmd/go/internal/work/init.go
+--- go/src/cmd/go/internal/work/init.go
++++ go/src/cmd/go/internal/work/init.go
+@@ -131,7 +131,7 @@ func buildModeInit() {
+ 		ldBuildmode = "c-shared"
+ 	case "default":
+ 		switch cfg.Goos {
+-		case "android":
++		case "android", "linux":
+ 			codegenArg = "-shared"
+ 			ldBuildmode = "pie"
+ 		case "darwin":

--- a/srcpkgs/go-pie/template
+++ b/srcpkgs/go-pie/template
@@ -1,0 +1,80 @@
+# Template file for 'go-pie'
+pkgname=go-pie
+version=1.14
+revision=1
+create_wrksrc=yes
+build_wrksrc=go
+build_style=go
+hostmakedepends="go1.12-bootstrap"
+short_desc="Go Programming Language"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="BSD-3-Clause"
+homepage="http://golang.org/"
+distfiles="https://golang.org/dl/go${version}.src.tar.gz"
+checksum=6d643e46ad565058c7a39dac01144172ef9bd476521f42148be59249e4b74389
+conflicts="go"
+noverifyrdeps=yes
+
+if [ "$CROSS_BUILD" ]; then
+	if [ "${XBPS_MACHINE%%-musl}" = "${XBPS_TARGET_MACHINE%%-musl}" ]; then
+		broken="Cross-compiling to different libc is not supported"
+	fi
+fi
+
+do_configure() {
+	:
+}
+
+do_build() {
+	unset GCC CC CXX LD CFLAGS
+	# FIXME: work around leaking go build-style vars when built as a
+	# dependency
+	unset CGO_CXXFLAGS CGO_CFLAGS CGO_ENABLED
+
+	export GOROOT_BOOTSTRAP="/usr/lib/go1.12"
+	export GOROOT=$PWD
+	export GOROOT_FINAL="/usr/lib/go"
+	export GOARCH=${_goarch}
+
+	cd "src"
+
+	bash make.bash --no-clean -v
+}
+
+do_install() {
+	local bindir
+
+	if [ "$CROSS_BUILD" ]; then
+		bindir=bin/linux_${_goarch}
+	else
+		bindir=bin
+	fi
+
+	vmkdir usr/bin
+	vmkdir usr/lib/go
+	vmkdir usr/share/go
+	cp -d --preserve=all ${bindir}/* ${DESTDIR}/usr/bin || true
+	cp -a pkg src lib ${DESTDIR}/usr/lib/go
+	cp -r doc misc -t ${DESTDIR}/usr/share/go
+	ln -s /usr/share/go/doc ${DESTDIR}/usr/lib/go/doc
+
+	# This is to make go get code.google.com/p/go-tour/gotour and
+	# then running the gotour executable work out of the box.
+	#
+	# Also, /usr/bin is the place for system-wide executables,
+	# not /usr/lib/go/bin. Users should use different paths by
+	# setting the appropriate environment variables.
+	#
+	ln -sf /usr/bin ${DESTDIR}/usr/lib/go/bin
+
+	# <dominikh> sigh. well, someone fix the template and add
+	# a symlink, usr/lib/go/misc -> /usr/share/go/misc
+	ln -sfr ${DESTDIR}/usr/share/go/misc ${DESTDIR}/usr/lib/go/misc
+
+	rm -f ${DESTDIR}/usr/share/go/doc/articles/wiki/get.bin
+	rm -f ${DESTDIR}/usr/lib/go/pkg/tool/*/api
+	rm -rf ${DESTDIR}/usr/lib/go/pkg/bootstrap
+	rm -rf ${DESTDIR}/usr/lib/go/pkg/obj
+
+	vlicense LICENSE
+}

--- a/srcpkgs/go-pie/update
+++ b/srcpkgs/go-pie/update
@@ -1,0 +1,1 @@
+ignore="*beta* *rc*"


### PR DESCRIPTION
This package makes it possible to build Go binaries with PIE.

Both Arch Linux and Alpine already implement this feature. Arch has a package called go-pie that's used for most of their PKGBUILDs, while the only version of Go on Alpine is one capable of producing PIE binaries.

* On Arch: https://www.archlinux.org/packages/community/x86_64/go-pie/
* On Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/go

The patch used here is actually adapted from the one used by Arch, and if adopted can allow us to remove the nostrip flag from the go build_style.

I'm getting some weird build output, where it says

```
loadinternal: cannot find runtime/cgo
```

so I'm not completely certain that it's 100% complete. Building a program that uses cgo does work cleanly, so I'm not sure what it means.

It's referenced [in this issue](https://github.com/golang/go/issues/31544), but without any solution.