### PR TITLE
New package: trident-networkmgr-2020.03.29

### DIFF
--- a/srcpkgs/trident-networkmgr/template
+++ b/srcpkgs/trident-networkmgr/template
@@ -1,0 +1,20 @@
+# Template file for 'trident-networkmgr'
+pkgname=trident-networkmgr
+version=2020.03.29.1
+revision=1
+wrksrc="trident-utilities-${version}"
+build_wrksrc="src-qt5/networkmgr"
+build_style=qmake
+hostmakedepends="qt5-host-tools qt5-qmake"
+makedepends="qt5-devel"
+depends="qsudo"
+short_desc="Graphical network manager from Project Trident"
+maintainer="Ken Moore <ken@project-trident.org>"
+license="BSD-2-Clause"
+homepage="https://github.com/project-trident/trident-utilities"
+distfiles="https://github.com/project-trident/trident-utilities/archive/v${version}.tar.gz"
+checksum=87fc1b547f1da884dc9e9403914949e6f069ee5984484863d4f24c0b76189325
+
+post_install() {
+	vlicense ${wrksrc}/LICENSE
+}


### PR DESCRIPTION
This is a graphical front end for client-side operation of:
* dhcpcd
* wpa_supplicant
* resolvconf
* wireguard

Sponsored by: Project Trident