### PR TITLE
calibre: add missing runtime dep 'python-html2text'

### DIFF
--- a/srcpkgs/calibre/template
+++ b/srcpkgs/calibre/template
@@ -16,7 +16,7 @@ depends="desktop-file-utils optipng poppler-utils python-BeautifulSoup4
  python-PyQt5-webengine python-PyQt5-webchannel python-Pygments python-apsw
  python-css-parser python-cssselect python-dateutil python-dbus
  python-dnspython python-feedparser python-html5-parser python-mechanize
- python-msgpack python-netifaces python-psutil python-regex qt5-webengine"
+ python-msgpack python-netifaces python-psutil python-regex qt5-webengine python-html2text"
 short_desc="Ebook management application"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"
 license="GPL-3.0-only"


### PR DESCRIPTION
@bra1nwave 
```
Traceback (most recent call last):
  File "/usr/lib/calibre/calibre/ebooks/oeb/reader.py", line 171, in _manifest_prune_invalid
    item.data
  File "/usr/lib/calibre/calibre/ebooks/oeb/base.py", line 1043, in data
    data = self._parse_xhtml(data)
  File "/usr/lib/calibre/calibre/ebooks/oeb/base.py", line 960, in _parse_xhtml
    filename=fname, non_html_file_tags={'ncx'})
  File "/usr/lib/calibre/calibre/ebooks/oeb/parse_utils.py", line 203, in parse_html
    data = preprocessor(data)
  File "/usr/lib/calibre/calibre/ebooks/conversion/preprocess.py", line 602, in __call__
    html = pdf_markup.markup_chapters(html, totalwords, True)
  File "/usr/lib/calibre/calibre/ebooks/conversion/utils.py", line 334, in markup_chapters
    html = recurse_patterns(html, False)
  File "/usr/lib/calibre/calibre/ebooks/conversion/utils.py", line 329, in recurse_patterns
    html = chapdetect.sub(self.chapter_head, html)
  File "/usr/lib/calibre/calibre/ebooks/conversion/utils.py", line 63, in chapter_head
    txt_chap = delete_quotes.sub('', delete_whitespace.sub('\\g<c>', html2text(chap)))
  File "/usr/lib/calibre/calibre/utils/html2text.py", line 8, in html2text
    from html2text import HTML2Text
ImportError: No module named html2text
```