### PR TITLE
rtl8812au-dkms: update to 20200318

### DIFF
--- a/srcpkgs/rtl8812au-dkms/template
+++ b/srcpkgs/rtl8812au-dkms/template
@@ -1,23 +1,22 @@
 # Template file for 'rtl8812au-dkms'
 pkgname=rtl8812au-dkms
-version=20190903
+version=20200318
 revision=1
-_gitrev=30d47a0a3f43ccb19e8fd59fe93d74a955147bf2
+_modver=5.6.4.2
+_gitrev=49e98ff9bfdbe2ddce843808713de383132002e0
 archs=noarch
-wrksrc="rtl8812au-${_gitrev}"
+wrksrc="rtl8812au-${_modver}-${_gitrev}"
 depends="dkms"
 short_desc="Realtek 8812AU/8821AU USB WiFi driver (DKMS)"
 maintainer="Renato Aguiar <renato@renag.me>"
 license="GPL-2.0-only"
 homepage="http://www.dlink.com"
-distfiles="https://github.com/gordboy/rtl8812au/archive/${_gitrev}.tar.gz"
-checksum=8893cb02683d253efe6be5a2d1f9ccea778f03b1606043381eaa649e26e8b657
-dkms_modules="rtl8812au 5.2.20"
+distfiles="https://github.com/gordboy/rtl8812au-${_modver}/archive/${_gitrev}.tar.gz"
+checksum=75c8ba004b405f8bf8542c0e29f2ee5451ce572fecac41cb2ba01da5e0312952
+dkms_modules="rtl8812au ${_modver}"
 
 do_install() {
-	local modname=rtl8812au
-	local modver=5.2.20
-	local dest=/usr/src/${modname}-${modver}
+	local dest=/usr/src/rtl8812au-${_modver}
 
 	vmkdir ${dest}
 	cp -r dkms.conf Kconfig Makefile platform core hal include os_dep ${DESTDIR}/${dest}


### PR DESCRIPTION
Update to use new repository for upstream release that works with kernel 5.6