### PR TITLE
New package: scangearmp2-3.70

### DIFF
--- a/srcpkgs/scangearmp2/template
+++ b/srcpkgs/scangearmp2/template
@@ -1,0 +1,70 @@
+# Template file for 'scangearmp2'
+
+_upstreamversion="3.70-1"
+
+pkgname=scangearmp2
+version=3.70
+revision=1
+wrksrc=scangearmp2-source-${_upstreamversion}
+archs="i686 x86_64"
+repository=nonfree
+hostmakedepends="automake autoconf libtool"
+makedepends="glib-devel pkg-config gtk+-devel libusb-devel"
+depends="gtk+ libusb"
+short_desc="ScanGear MP GTK+ application for Canon PIXMA and CanoScan LiDE models"
+maintainer="Andrási István <isiandrasi@gmail.com>"
+license="custom:canon,GPL-2.0-or-later"
+homepage="https://www.canon-europe.com/support/consumer_products/products/fax__multifunctionals/inkjet/pixma_tr_series/pixma-tr4550.html?type=drivers&driverdetailid=tcm:128-1714905"
+distfiles="http://gdlp01.c-wss.com/gds/3/0100009933/01/scangearmp2-source-${_upstreamversion}.tar.gz"
+checksum=6d5c5b72d671bf8014260b060298e66e4b1fd1e1be475b5a7dbf4f9f9fc3edbc
+nocross="This software is provided by Canon and is only available for i686 and x86_64"
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64)
+		_arch=64
+		;;
+	i686)
+		_arch=32
+		;;
+	*)
+		_arch=0
+		;;
+esac
+
+pre_fetch() {
+	if [ "${_arch}" = "0" ]
+	then
+		echo "Unsupported architecture $XBPS_TARGET_MACHINE"
+		exit 1
+	fi
+}
+
+do_configure() {
+	( cd scangearmp2 && ./autogen.sh --prefix=/usr --enable-libpath=/usr/lib LDFLAGS="-L$(pwd)/../com/libs_bin${_arch}" )	
+}
+
+do_build() {
+	( cd scangearmp2 && make clean && make )	
+}
+
+do_install() {
+	( cd scangearmp2 && make install DESTDIR=${DESTDIR} )
+    
+	vmkdir /usr/lib
+	vcopy "com/libs_bin${_arch}/lib*" /usr/lib
+
+	vmkdir /usr/lib/bjlib
+	vinstall com/ini/canon_mfp2_net.ini 644 /usr/lib/bjlib
+
+	vmkdir /usr/lib/udev/rules.d
+	vcopy "scangearmp2/etc/*.rules" /usr/lib/udev/rules.d
+
+	vlicense doc/LICENSE-scangearmp-${version}EN.txt LICENSE.txt
+}
+
+post_install() {
+	if [ -x /bin/udevadm ]; then
+		/bin/udevadm control --reload-rules 2> /dev/null
+		/bin/udevadm trigger --action=add --subsystem-match=usb 2> /dev/null
+	fi
+}


### PR DESCRIPTION
This is the ScanGear application for Linux by Canon. I've tested it with my PIXMA TR4550.

I've created this package by copying and adjusting `cnijfilter2`.