### PR TITLE
libmicrodns: update to 0.1.2.

### DIFF
--- a/srcpkgs/libmicrodns/template
+++ b/srcpkgs/libmicrodns/template
@@ -1,18 +1,24 @@
 # Template file for 'libmicrodns'
 pkgname=libmicrodns
-version=0.1.0
+version=0.1.2
 revision=1
-build_style=gnu-configure
-hostmakedepends="autoconf automake libtool pkg-config"
+build_style=meson
+hostmakedepends="ninja"
 short_desc="Minimal mDNS resolver library"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="LGPL-2.1-only"
 homepage="https://github.com/videolabs/libmicrodns"
 distfiles="https://github.com/videolabs/libmicrodns/archive/${version}.tar.gz"
-checksum=aa16c9863962f54db991a0176ae75e60b9ab83f63c3b436806682c8a66443444
+checksum=2b4d733f9472e11b71d66208c025de2e1f4a1087814bdc1e12e1aa78aca670e5
 
-pre_configure() {
-	./bootstrap
+do_build() {
+	meson --prefix /usr --default-library both builddir
+	ninja -C builddir
+}
+
+do_install() {
+	export DESTDIR
+	ninja -C builddir install
 }
 
 libmicrodns-devel_package() {
@@ -23,6 +29,5 @@ libmicrodns-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
-		vmove usr/share
 	}
 }


### PR DESCRIPTION
The new library now uses meson instead of autotools.