### PR TITLE
coreutils: reenable statx() support on glibc

### DIFF
--- a/srcpkgs/coreutils/template
+++ b/srcpkgs/coreutils/template
@@ -1,7 +1,7 @@
 # Template file for 'coreutils'
 pkgname=coreutils
 version=8.32
-revision=3
+revision=4
 bootstrap=yes
 makedepends="gmp-devel acl-devel libcap-devel"
 short_desc="GNU core utilities"
@@ -51,9 +51,6 @@ do_configure() {
 	case "$XBPS_TARGET_MACHINE" in
 		# XXX syncfs() in src/sync.c expects a return value.
 		*-musl) configure_args+=" ac_cv_func_syncfs=no";;
-		# XXX disable statx(), needs glibc>=2.28 and linux>=4.11
-		# XXX seems to fail on travis always returning EACCES.
-		*) configure_args+=" ac_cv_func_statx=no";;
 	esac
 	#
 	# Do not install kill: provided by util-linux.


### PR DESCRIPTION
Commit 9cd29dcf7e had disabled statx support detection due to xbps
testing issues on travis with older kernels lacking statx support.

Reenable this, as after xbps commit a3a103a1 we are now running on a
newer travis environment with kernels recent enough to support this
syscall.