### PR TITLE
gnome-weather: update to 3.34.0. [ci skip]

### DIFF
--- a/srcpkgs/gnome-weather/template
+++ b/srcpkgs/gnome-weather/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-weather'
 pkgname=gnome-weather
-version=3.32.2
+version=3.34.0
 revision=1
 build_helper="gir"
 build_style=meson
-hostmakedepends="pkg-config itstool glib-devel gjs"
+hostmakedepends="gettext pkg-config itstool glib-devel gjs"
 makedepends="gtk+3-devel gjs-devel libgweather-devel geoclue2-devel"
 depends="desktop-file-utils gjs geoclue2 libgweather gnome-desktop"
 short_desc="Access current weather conditions and forecasts for GNOME"
@@ -12,5 +12,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Weather"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=1a25c325033a134f291481bb4aa00b5c9af6555daf5bc311e963e629976bdd49
+checksum=24867e21fcb92b81cd0cf09bbf8bc216ccc55d9a66ac21928b66c413f4efc3bc
 lib32disabled=yes


### PR DESCRIPTION
Travis build [timed out](https://travis-ci.org/github/void-linux/void-packages/builds/670535960?utm_source=github_status&utm_medium=notification) for `aarch64*` and `arm*` .