### PR TITLE
New package: fah-7.5.1

### DIFF
--- a/srcpkgs/fah/files/FAHClient/run
+++ b/srcpkgs/fah/files/FAHClient/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+OPTS=--run-as=_fah
+set -e
+[ -r config ] && . config
+cd /usr/libexec/_fah && exec /usr/bin/FAHClient $OPTS 2>&1

--- a/srcpkgs/fah/files/config.example
+++ b/srcpkgs/fah/files/config.example
@@ -1,0 +1,413 @@
+# This is an example of configuration options for FAHClient.
+# If you want to configure the services, put this file
+# or a list of OTPS+=" ..." in a file /etc/sv/FAHClient/config
+
+#    The number of client processing threads.
+#OPTS+=" --client-threads=6"
+
+#    The maximum cycle frequency in Hz of client threads.
+#OPTS+=" --cycle-rate=4"
+
+#    Run at most this many cycles. A value less than zero means run indefinitely.
+#OPTS+=" --cycles=1"
+
+#    The directory, relative to the current directory, where WU data and cores
+#    are stored.
+#OPTS+=" --data-directory=."
+
+#    Attempt to keep the system from sleeping when folding, unless on battery.
+#OPTS+=" --disable-sleep-when-active"
+
+#    The directory, relative to the current executable, where executables and
+#    dynamic libraries are located.
+#OPTS+=" --exec-directory=/usr/bin"
+
+#    Exit when all slots are paused.
+#OPTS+=" --exit-when-done"
+
+#    Start folding even if not configured.
+#OPTS+=" --fold-anon"
+
+#    Number of seconds of system idle time before enabling idle folding. Set to
+#    zero to ignore system idle time.
+#OPTS+=" --idle-seconds=300"
+
+#    Make an operating system specific call to open the Web Control in a browser
+#    once client is fully loaded
+#OPTS+=" --open-web-control=fals"
+
+#    Rotate the configuration file to a backup when saving would overwrite the
+#    previous configuration.
+#OPTS+=" --config-rotate=false"
+
+#    Put rotated configs in this directory.
+#OPTS+=" --config-rotate-dir=configs"
+
+#    The maximum number of rotated configuration files to keep. A value of zero
+#    will keep all configuration file backups.
+#OPTS+=" --config-rotate-max=16"
+
+#    The maximum number of errors before a slot is paused.
+#OPTS+=" --max-slot-errors=10"
+
+#    The maximum number of errors before a work unit is dumped.
+#OPTS+=" --max-unit-errors=5"
+
+#    Tell cores to checkpoint at least every # minutes.
+#OPTS+=" --checkpoint=15"
+
+#    The directory to store core files in.
+#OPTS+=" --core-dir=cores"
+
+#    Run this command on cores after they are downloaded. This option is useful
+#    for running Linux cores on BSD machines.
+#OPTS+=" --core-prep=coreprep"
+
+#    Set the core priority. Valid values are: idle or low
+#OPTS+=" --core-priority=idle"
+
+#    If true, try to lock core processes to a fixed CPU
+#OPTS+=" --cpu-affinity=false"
+
+#    The maximum percentage of the CPU a core should use. Not implemented by all
+#    cores.
+#OPTS+=" --cpu-usage=100"
+
+#    GPU usage as a percent from 10-100
+#OPTS+=" --gpu-usage=100"
+
+#    Tell cores to disable optimized assembly code.
+#OPTS+=" --no-assembly=false"
+
+#    The cause you prefer to support.
+#OPTS+=" --cause=ANY"
+
+#    The client subtype
+#OPTS+=" --client-subtype=LINUX"
+
+#    The client type. Can be 'normal', 'advanced' or 'beta'.
+#OPTS+=" --client-type=normal"
+
+#    CPU species.
+#OPTS+=" --cpu-species=X86_AMD"
+
+#    CPU type.
+#OPTS+=" --cpu-type=AMD64"
+
+#    How many CPUs a slot should use. <= 0 will use all the CPUs detected in the
+#    system.
+#OPTS+=" --cpus=-1"
+
+#    The CUDA device index of the GPU, counting starts from 0.
+#OPTS+=" --cuda-index=0"
+
+#    Disable reading visualization data.
+#OPTS+=" --disable-viz"
+
+#    Pass extra arguments to the core.
+#OPTS+=" --extra-core-args=<string>"
+
+#    Enable or disable auto-confiugration of GPU slots, requires appropriate
+#    hardware.
+#OPTS+=" --gpu=true"
+
+#    The index of the GPU as detected by the client. This index corresponds
+#    directly to the GPUs listed in the client's '--info' output.
+#OPTS+=" --gpu-index=0"
+
+#    Max size in bytes of a work unit packet. Can be small=5MiB, normal=25MiB,
+#    big=500MiB or a number.
+#OPTS+=" --max-packet-size=normal"
+
+#    Override memory, in bytes, reported to Folding@home.
+#OPTS+=" --memory=2147483648"
+
+#    The OpenCL device index of the GPU, counting starts from 0.
+#OPTS+=" --opencl-index=0"
+
+#    Operating system species.
+#OPTS+=" --os-species=UNKNOWN"
+
+#    Operating system type.
+#OPTS+=" --os-type=LINUX"
+
+#    Key for access to restricted testing projects.
+#OPTS+=" --project-key=0"
+
+#    Enable or disable auto-configuration of SMP slots, requires appropriate
+#    hardware.
+#OPTS+=" --smp=true"
+
+#    Set to false to disable the GUI. A GUI is not currently supported on all
+#    operating systems.
+#OPTS+=" --gui-enabled=true"
+
+#    Client addresses which are allowed to connect to this server. This option
+#    overrides IPs which are denied in the deny option. The pattern 0/0 matches
+#    all addresses.
+#OPTS+=" --allow=127.0.0.1"
+
+#    The maximum amount of time, in seconds, a connection can be idle before
+#    being dropped.
+#OPTS+=" --connection-timeout=60"
+
+#    Client address which are not allowed to connect to this server.
+#OPTS+=" --deny=0/0"
+
+#    A space separated list of server address and port pairs to listen on in the
+#    form <ip | hostname>[:<port>]
+#OPTS+=" --http-addresses=0:7396"
+
+#    A space separated list of secure server address and port pairs to listen on
+#    in the form <ip | hostname>[:<port>]
+#OPTS+=" --https-addresses=localhost:4443"
+
+#    The maximum amount of time, in seconds, a client can be connected to the
+#    server.
+#OPTS+=" --max-connect-time=900"
+
+#    Sets the maximum number of simultaneous connections.
+#OPTS+=" --max-connections=800"
+
+#    Sets the maximum length of a client request packet.
+#OPTS+=" --max-request-length=52428800"
+
+#    The minimum amount of time, in seconds, a client must be connected to the
+#    server before it can be dropped in favor or a new connection.
+#OPTS+=" --min-connect-time=300"
+
+#    The servers certificate file in PEM format.
+#OPTS+=" --certificate-file=fah-cert.pem"
+
+#    Supply a Certificate Revocation List. Overrides any internal CRL
+#OPTS+=" --certificate-file=fah-cert.crl"
+
+#    The servers private key file in PEM format.
+#OPTS+=" --private-key-file=fah-private.pem"
+
+#    Set log file.
+#OPTS+=" --log=log.txt"
+
+#    Print log messages with ANSI color coding.
+#OPTS+=" --log-color=false"
+
+#    Print carriage return and line feed at end of log lines.
+#OPTS+=" --log-crlf=false"
+
+#    Print date information with log entries.
+#OPTS+=" --log-date=false"
+
+#    Print date to log before new log entries if so many seconds have passed
+#    since the last date was printed.
+#OPTS+=" --log-date-periodically=21600"
+
+#    Print domain information with log entries.
+#OPTS+=" --log-domain=false"
+
+#    Set log levels by domain. Format is:
+#      <domain>[:i|d|t]:<level> ...
+#    Entries are separated by white-space and or commas.
+#      i - info
+#    For example: server:i:3 module:6
+#    Set 'server' domain info messages to level 3 and 'module' info messages to
+#    level 6. All other domains will follow the system wide log verbosity level.
+#    If <level> is negative it is relative to the system wide verbosity.
+#OPTS+=" --log-domain-levels=server:i:3 module:6"
+
+#    Enable log message headers.
+#OPTS+=" --log-header=false"
+
+#    Print level information with log entries.
+#OPTS+=" --log-level=false"
+
+#    Don't print 'INFO(#):' in header.
+#OPTS+=" --log-no-info-header=false"
+
+#    Redirect all output to log file. Implies !log-to-screen.
+#OPTS+=" --log-redirect=false"
+
+#    Rotate log files on each run.
+#OPTS+=" --log-rotate=false"
+
+#    Put rotated logs in this directory.
+#OPTS+=" --log-rotate-dir=logs"
+
+#    Maximum number of rotated logs to keep.
+#OPTS+=" --log-rotate-max=16"
+
+#    Print shortened level information with log entries.
+#OPTS+=" --log-short-level=false"
+
+#    Remove any leading directories and trailing file extensions from domains so
+#    that source code file names can be easily used as log domains.
+#OPTS+=" --log-simple-domains=false"
+
+#    Print id with log entries.
+#OPTS+=" --log-thread-id=false"
+
+#    Print thread prefixes, if set, with log entries.
+#OPTS+=" --log-thread-prefix=false"
+
+#    Print time information with log entries.
+#OPTS+=" --log-time=false"
+
+#    Log to screen.
+#OPTS+=" --log-to-screen=false"
+
+#    Truncate log file.
+#OPTS+=" --log-truncate=false"
+
+#    Set logging level for INFO messages.
+#OPTS+=" --verbosity=3"
+
+#    Set proxy for outgoing HTTP connections
+#OPTS+=" --proxy=127.0.0.1:3128"
+
+#    Enable proxy configuration
+#OPTS+=" --proxy-enable=false"
+
+#    Set password for proxy connections
+#OPTS+=" --proxy-pass=proxypass"
+
+#    Set user name for proxy connections
+#OPTS+=" --proxy-user=proxyuser"
+
+#    Disable 'daemon', 'fork', 'pid' and 'respawn' options. Also defaults
+#    'log-to-screen' to false. Used internally.
+#OPTS+=" --child=false"
+
+#    Short for --pid --service --respawn --log='' --fork
+#OPTS+=" --daemon=false"
+
+#    Run in background.
+#OPTS+=" --fork=false"
+
+#    Create PID file.
+#OPTS+=" --pid=true"
+
+#    Name of PID file.
+#OPTS+=" --pid-file='Folding@home Client.pid'"
+
+#    Set the process priority. Valid values are: idle, low, normal, high or
+#    realtime.
+#OPTS+=" --priority=normal"
+
+#    Run the application as a child process and respawn if it is killed or exits.
+#OPTS+=" --respawn=false"
+
+#    Run as specified user
+#OPTS+=" --run-as=_fah"
+
+#    Ignore user logout or hangup and interrupt signals
+#OPTS+=" --service=false"
+
+#    The address to which the command server should be bound.
+#OPTS+=" --command-address=0.0.0.0"
+
+#    IP address ranges that are allowed access to the command server with out a
+#    password if the 'password' option is set. These addresses will also have to
+#    be allowed IP based access.
+#OPTS+=" --command-allow-no-pass=127.0.0.1"
+
+#    IP address ranges that are not allowed access to the command server with out
+#    a password if the 'password' option is set. Overridden by
+#    command-allow-no-pass
+#OPTS+=" --command-deny-no-pass=0/0"
+
+#    Set to false to disable the command server.
+#OPTS+=" --command-enable"
+
+#    The port to which the command server should be bound.
+#OPTS+=" --command-port=36330"
+
+#    Evaluate the argument as a script.
+#OPTS+=" --eval=false"
+
+#    Set a command server password. Warning, setting a password disables the
+#    default IP address blocking.
+#OPTS+=" --password=fahPassWord"
+
+#    Run commands from a script file.
+#OPTS+=" --script=script.cmd"
+
+#    Only run slot when idle.
+#OPTS+=" --idle=false"
+
+#    The maximum amount of time to wait in seconds for a unit to exit on
+#    shutdown.
+#OPTS+=" --max-shutdown-wait=60"
+
+#    Pause the client or slot when the OS indicates the machine is running on
+#    battery power.
+#OPTS+=" --pause-on-battery=true"
+
+#    If true the slot will be started in a paused state.
+#OPTS+=" --pause-on-start"
+
+#    True if slot is paused.
+#OPTS+=" --paused=false"
+
+#    Set the client's power level. Valid values are 'light', 'medium' or 'full'.
+#    This setting affects the defaults of several other options such as 'cpus',
+#    'pause-on-battery', etc.
+#OPTS+=" --power=medium"
+
+#    The machine ID.
+#OPTS+=" --machine-id=0"
+
+#    Your passkey.
+#OPTS+=" --passkey=yourpass.key"
+
+#    Your team number.
+#OPTS+=" --team=0"
+
+#    Your user name.
+#OPTS+=" --user=Anonymous"
+
+#    Client addresses which are allowed to connect to this Web server. This
+#    option overrides IPs which are denied in the web-deny option. This option
+#    differs from the 'allow'/'deny' options in that clients that are not allowed
+#    are served an access denied page rather than simply dropping the connection.
+#    The value '0/0' matches all IPs.
+#OPTS+=" --web-allow=127.0.0.1"
+
+#    Client address which are not allowed to connect to this Web server.
+#OPTS+=" --web-deny=0/0"
+
+#    Set to false to disable the web server.
+#OPTS+=" --web-enable"
+
+#    The name of the session cookie.
+#OPTS+=" --session-cookie=fah_sid"
+
+#    The maximum session lifetime in seconds. Zero for unlimited session
+#    lifetime.
+#OPTS+=" --session-lifetime=86400"
+
+#    The max maximum amount of time in seconds since the last time a session was
+#    used before it timesout. Zero for no session timeout.
+#OPTS+=" --session-timeout=3600"
+
+#    Dump units if their deadline has passed.
+#OPTS+=" --dump-after-deadline=false"
+
+#    Maximum units per slot in the work queue.
+#OPTS+=" --max-queue=16"
+
+#    Process at most this number of units, then pause.
+#OPTS+=" --max-units=0"
+
+#    Pre-download the next work unit when the current one is this far along.
+#    Values less than 90 are not allowed.
+#OPTS+=" --next-unit-percentage=99"
+
+#    Attempt to detect stalled work units and restart them.
+#OPTS+=" --stall-detection-enabled=false"
+
+#    Minimum estimated percent work unit completion since last frame before a WU
+#    can be considered stalled, if zero the percentage is ignored.
+#OPTS+=" --stall-percent=5"
+
+#    Minimum time, in seconds, since last frame before a WU can be considered
+#    stalled.
+#OPTS+=" --stall-timeout=1800"

--- a/srcpkgs/fah/template
+++ b/srcpkgs/fah/template
@@ -1,0 +1,43 @@
+# Template file for 'fah'
+pkgname=fah
+version=7.5.1
+revision=1
+archs="x86_64"
+hostmakedepends="python"
+depends="python desktop-file-utils hicolor-icon-theme"
+short_desc="Folding@home distributed computation power for research"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="custom:Proprietary, GPL-2.0-only"
+homepage="https://foldingathome.org"
+distfiles="https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v${version%.*}/fahclient_${version}_amd64.deb
+ https://download.foldingathome.org/releases/public/release/fahcontrol/debian-stable-64bit/v${version%.*}/fahcontrol_${version}-1_all.deb
+ https://download.foldingathome.org/releases/public/release/fahviewer/debian-stable-64bit/v${version%.*}/fahviewer_${version}_amd64.deb"
+checksum="efe47061d328667259c1815b98bc6c37da339363fb8e9386673f6a96f4d37d26
+ c9d37823abe666923d903fbf4d7c6059cf8042a208954bc0044c9c5a6635b4d8
+ c87d331a35fc68d04427996aef05b275ca69dab3bef4087efaaf5e27e95d7b29"
+nostrip=yes
+repository="nonfree"
+restricted=yes
+system_accounts="_fah"
+_fah_homedir="/usr/libexec/_fah"
+_fah_descr="Folding@Home user"
+
+do_extract() {
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/fahclient_${version}_amd64.deb \
+		data.tar.xz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/fahcontrol_${version}-1_all.deb \
+		data.tar.xz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/fahviewer_${version}_amd64.deb \
+		data.tar.xz | bsdtar -x -f -
+}
+
+do_install() {
+	vmkdir usr
+	vcopy ${wrksrc}/usr/* usr
+	vsv FAHClient
+	mv -v ${DESTDIR}/usr/lib/python2.7/{dist,site}-packages
+	vlicense ${DESTDIR}/usr/share/doc/fahclient/copyright LICENSE.FAHClient
+	vlicense ${DESTDIR}/usr/share/doc/fahviewer/LICENSE LICENSE.FAHViewer
+	# Example file to modfiy or cut+paste from for /etc/sv/FAHClient/config
+	vsconf ${FILESDIR}/config.example
+}


### PR DESCRIPTION
Folding@Home debian packages collection which installs FAHClient service,
FAHControl, FAHCoreWrapper, and FAHViewer binaries.

The license of FAHClient does not allow redistribution thus set this
package to restricted.

I'm not sure if this is really required and whether I did it right, i.e. set `repo=nonfree` and `restricted=yes`.

This certainly needs a review because I'm quite unexperienced with `vsv` + `system_user` packages. I got it running locally as normal user but not yet as service with `--run-as=_fah` and the system user home `/var/lib/_fah`.

So far I can only tell the binaries basically work on Void x86_64.