### PR TITLE
gnome-documents: update to 3.34.0. [ci skip]

### DIFF
--- a/srcpkgs/gnome-documents/template
+++ b/srcpkgs/gnome-documents/template
@@ -1,10 +1,10 @@
 # Template file for 'gnome-documents'
 pkgname=gnome-documents
-version=3.32.0
-revision=3
+version=3.34.0
+revision=1
 build_helper="gir"
 build_style=meson
-hostmakedepends="docbook-xsl itstool pkg-config glib-devel libxslt gdk-pixbuf
+hostmakedepends="docbook-xsl gettext itstool pkg-config glib-devel libxslt gdk-pixbuf
  librsvg"
 makedepends="clutter-gtk-devel evince-devel gjs-devel gnome-desktop-devel
  libgdata-devel libgepub-devel librsvg-devel libzapojit-devel tracker-devel
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Documents"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=cc2060843e53b6db3372b806536f5df0bfc7abd3c0c35cb5021a3592d76f0dbf
+checksum=d8a90e84aef3a78fcaa91dc12a24a473a5778a47eb4c2354d0e35d558f29f0e2
 lib32disabled=yes
 
 build_options="gir"


### PR DESCRIPTION
Travis build [timed out](https://travis-ci.org/github/void-linux/void-packages/builds/670848786?utm_source=github_status&utm_medium=notification) for `aarch64*` and `arm*` .