### PR TITLE
gzdoom: added libopenal to depends

### DIFF
--- a/srcpkgs/gzdoom/template
+++ b/srcpkgs/gzdoom/template
@@ -1,14 +1,14 @@
 # Template file for 'gzdoom'
 pkgname=gzdoom
 version=4.2.4
-revision=1
+revision=2
 _tagdate=2019-07-09
 wrksrc="${pkgname}-g${version}"
 build_style=cmake
 configure_args="-DINSTALL_PK3_PATH=share/gzdoom"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel gtk+3-devel fluidsynth-devel libgme-devel libgomp-devel ppl-devel"
-depends="libfluidsynth gtk+3"
+depends="libfluidsynth gtk+3 libopenal"
 short_desc="Advanced Doom source port with OpenGL support"
 maintainer="Michael Straube <straubem@gmx.de>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
libopenal is needed to have sound output from GZDoom. Without libopenal GZDoom will not play sound, and provide the user with a "failed to init sound" message.