### PR TITLE
base-files: vkpurge: fix for empty /boot

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -29,6 +29,7 @@ list_kernels() {
 			kver=${k##*-}
 			case "$kver" in
 				"$running") ;;
+				"*") ;; # /boot isn't mounted -> no vmlinu[xz]
 				$pattern) printf "%s\n" "$kver" ;;
 			esac
 		done

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.140
-revision=12
+version=0.141
+revision=1
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
On system with empty /boot (example: /boot on external device and not
mounted:
* `vkpurge list` reports `*`, which is incorrect, and
* `vkpurge rm all` run `remove_kernel` for all file names in $PWD,
  this will normally harmless except when efibootmgr is used and some
  files with special name, let's say "V" "o" "i" "d" in $PWD, then,
  efibootmgr will remove all boot entries.

Fix it by checking for `vmlinu[xz]-*` explicitly.
A sane system shouldn't have that file.