### PR TITLE
New package: dot-0.1.4

### DIFF
--- a/srcpkgs/dot/template
+++ b/srcpkgs/dot/template
@@ -1,0 +1,17 @@
+# Template file for 'dot'
+pkgname=dot
+version=0.1.4
+revision=1
+build_style=cargo
+short_desc="Command-line tool for managing dotfiles, written in Rust"
+maintainer="Florian Warzecha <liketechnik@disroot.org>"
+license="MIT"
+homepage="https://github.com/ubnt-intrepid/dot"
+distfiles="https://github.com/ubnt-intrepid/dot/archive/v${version}.tar.gz"
+checksum="7f043f5a0e59b08f36c98e7117a65e5bbfdc927b0b55103e8de0cad5c94d6c1b"
+
+post_install() {
+	vdoc README.md
+	vlicense LICENSE
+	mv ${DESTDIR}/usr/bin/dot ${DESTDIR}/usr/bin/dot-rs
+}


### PR DESCRIPTION
`dot` is a command-line tool for managing dotfiles, written in Rust.
Homepage: https://github.com/ubnt-intrepid/dot