### PR TITLE
qt5-webengine: add missing alsa-lib-devel dependency [ci skip]

### DIFF
--- a/srcpkgs/qt5-webengine/template
+++ b/srcpkgs/qt5-webengine/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5-webengine'
 pkgname=qt5-webengine
 version=5.14.2
-revision=1
+revision=2
 wrksrc="qtwebengine-everywhere-src-${version}"
 archs="x86_64* i686* armv[67]* ppc64* aarch64*"
 build_style=qmake
@@ -18,7 +18,7 @@ makedepends="qt5-webchannel-devel qt5-location-devel qt5-tools-devel
  libwebp-devel opus-devel cups-devel nss-devel minizip-devel libxslt-devel
  libvpx-devel re2-devel libXtst-devel libXcursor-devel libXcomposite-devel
  jsoncpp-devel harfbuzz-devel lcms2-devel protobuf-devel pulseaudio-devel
- libXrandr-devel MesaLib-devel mit-krb5-devel"
+ libXrandr-devel MesaLib-devel mit-krb5-devel alsa-lib-devel"
 short_desc="Cross-platform application and UI framework (QT5) - WebEngine component"
 maintainer="John <johnz@posteo.net>"
 license="GPL-3.0-or-later, LGPL-3.0-or-later"


### PR DESCRIPTION
Restoring the alsa-lib-devel `makedepends` flag enables ALSA support in `qt5-webengine`. Skipping CI because the build will almost certainly time out.