### PR TITLE
mbedtls: revert to 2.16 LTS branch, update to 2.16.5

### DIFF
--- a/srcpkgs/mbedtls/template
+++ b/srcpkgs/mbedtls/template
@@ -1,6 +1,7 @@
 # Template file for 'mbedtls'
 pkgname=mbedtls
-version=2.17.0
+reverts="2.17.0_1"
+version=2.16.5
 revision=1
 wrksrc="mbedtls-mbedtls-${version}"
 build_style=cmake
@@ -12,7 +13,8 @@ license="Apache-2.0"
 homepage="https://tls.mbed.org/"
 changelog="https://raw.githubusercontent.com/ARMmbed/mbedtls/development/ChangeLog"
 distfiles="https://github.com/ARMmbed/mbedtls/archive/mbedtls-${version}.tar.gz"
-checksum=321a2c0220d9f75703e929c01dabba7b77da4cf2e39944897fc41d888bb1ef0d
+checksum=d8894abcaa23fe55d684ec73b2cd42cafe965eb162c993041fccfe68e3ef73c3
+
 
 pre_configure() {
 	sed -i include/mbedtls/config.h \
@@ -38,4 +40,3 @@ mbedtls-devel_package() {
 		vmove "usr/lib/*.so"
 	}
 }
-


### PR DESCRIPTION
https://tls.mbed.org/tech-updates/blog/announcing-lts-branch-mbedtls-2.16