### PR TITLE
gnome-music: update to 3.36.1.

### DIFF
--- a/srcpkgs/gnome-music/template
+++ b/srcpkgs/gnome-music/template
@@ -1,11 +1,10 @@
 # Template file for 'gnome-music'
 pkgname=gnome-music
-version=3.32.2
-revision=2
+version=3.36.1
+revision=1
 build_helper="gir"
 build_style=meson
-pycompile_module="gnomemusic"
-hostmakedepends="glib-devel itstool pkg-config"
+hostmakedepends="gettext glib-devel itstool pkg-config"
 makedepends="gnome-desktop-devel grilo-devel libmediaart-devel
  python3-gobject-devel python3-dbus tracker-devel gnome-online-accounts-devel
  libdazzle-devel grilo-plugins python3-cairo-devel"
@@ -16,5 +15,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Music"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=131a4b09983f7ee7f6ad6277bc2d5cf1b4a56484faf6357850357a355aa0c732
+checksum=7b80f630d158334935a8760296550cc91b50d604fa68b402fe5165b1531ec332
 lib32disabled=yes

--- a/srcpkgs/grilo/template
+++ b/srcpkgs/grilo/template
@@ -1,12 +1,12 @@
 # Template file for 'grilo'
 pkgname=grilo
-version=0.3.9
+version=0.3.12
 revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Denable-introspection=$(vopt_if gir true false)
  -Denable-vala=$(vopt_if gir true false) -Denable-gtk-doc=false"
-hostmakedepends="pkg-config glib-devel $(vopt_if vala vala)"
+hostmakedepends="gettext pkg-config glib-devel $(vopt_if vala vala)"
 makedepends="gtk+3-devel libxml2-devel libsoup-devel liboauth-devel
  totem-pl-parser-devel"
 short_desc="Framework focused on making media discovery and browsing easy"
@@ -14,7 +14,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/Grilo"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=730581cc62f2cfaadeac815760b80da8dcf3d08c454adad0d6128c930c5bcaf2
+checksum=dbfbd6082103288592af97568180b9cc81a336a274ed5160412f87675ec11a71
 
 # Package build options
 build_options="gir vala"


### PR DESCRIPTION
`gnome-music` needs `grilo >= 0.3.12` , so pushed them both.