### PR TITLE
Marker: update to 2020.04.04.

### DIFF
--- a/srcpkgs/Marker/patches/elf_files_in_lib.patch
+++ b/srcpkgs/Marker/patches/elf_files_in_lib.patch
@@ -1,0 +1,19 @@
+diff -ruN Marker/meson.build Marker1/meson.build
+--- Marker/meson.build	2019-11-06 14:44:46.000000000 +0200
++++ Marker1/meson.build	2019-12-06 22:39:56.434367811 +0200
+@@ -5,13 +5,14 @@
+
+ PREFIX = get_option('prefix')
+ DATA_DIR = join_paths(PREFIX, 'share')
++LIBS_DIR = join_paths(PREFIX, 'lib')
+ APP_DIR = join_paths(DATA_DIR, 'com.github.fabiocolacio.marker')
+ ICONS_DIR = join_paths(APP_DIR, 'icons')
+ STYLES_DIR = join_paths(APP_DIR, 'styles')
+ COMMON_DIR = join_paths(APP_DIR, 'common')
+ SCRIPTS_DIR = join_paths(APP_DIR, 'scripts')
+ HIGHLIGHT_STYLES_DIR = join_paths(join_paths(SCRIPTS_DIR, 'highlight'),'styles')
+-WEB_EXTENSIONS_DIRECTORY = join_paths(APP_DIR, 'extensions')
++WEB_EXTENSIONS_DIRECTORY = join_paths(LIBS_DIR, 'Marker.extensions')
+ APPDATA_DIR = join_paths(DATA_DIR, 'metainfo')
+ LOCALE_DIR = join_paths(PREFIX, get_option('localedir'))
+

--- a/srcpkgs/Marker/template
+++ b/srcpkgs/Marker/template
@@ -1,16 +1,26 @@
 # Template file for 'Marker'
 pkgname=Marker
-version=2018.07.03
+version=2020.04.04
 revision=1
 wrksrc=marker
 build_style=meson
-hostmakedepends="glib-devel pkg-config unzip"
+hostmakedepends="glib-devel pkg-config"
 makedepends="gtksourceview-devel gtkspell3-devel gtk+3-devel libglib-devel
  webkit2gtk-devel"
-short_desc="A gtk3 markdown editor"
+depends="iso-codes"
+short_desc="Gtk3 markdown editor"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-3.0-or-later"
+license="GPL-3.0-or-later, ISC"
 homepage="https://fabiocolacio.github.io/Marker/"
 distfiles="https://github.com/fabiocolacio/Marker/releases/download/${version}/marker.zip"
-checksum=9038a2f8b976e6bfb199d14dbf60e7281b66e5ee94a6333ca48e89e63e6096ef
-broken="fails lint (ELF in /usr/share/com.github.fabiocolacio.marker/extensions/libscroll-extension.so)"
+checksum=ca493e7e94f171c15f7ffc9f697ce265d3b4fdb20fae157601d091d89dd6fb40
+patch_args="-Np1"
+
+post_extract() {
+	# don't include bundled mathjax
+	rm -rf data/scripts/mathjax
+}
+
+post_install() {
+	vlicense src/scidown/LICENSE scidown.LICENSE
+}


### PR DESCRIPTION
Third update attempt (https://github.com/void-linux/void-packages/pull/17168 , https://github.com/void-linux/void-packages/pull/20181).
Built and tested on x86_64. Removing mathjax seems indeed to have no effect, so Ι followed what @Piraty did. I do not know what the binary plugin does, so I relocated it under /lib.