### PR TITLE
gedit: update to 3.36.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3589,7 +3589,7 @@ libqhttpengine.so.1 qhttpengine-1.0.1_1
 libqmdnsengine.so.0 qmdnsengine-0.1.0_1
 libyang.so.1 libyang-1.0r5_1
 libhtp.so.2 libhtp-0.5.30_1
-libgedit-3.14.so gedit-3.32.0_1
+libgedit-3.36.so gedit-3.36.1_1
 libchewing.so.3 libchewing-0.5.1_1
 libdwarves.so.1 pahole-1.12_1
 libdwarves_emit.so.1 pahole-1.12_1

--- a/srcpkgs/gedit-plugins/template
+++ b/srcpkgs/gedit-plugins/template
@@ -1,11 +1,10 @@
 # Template file for 'gedit-plugins'
 pkgname=gedit-plugins
-version=3.32.2
+version=3.36.2
 revision=1
-build_style=gnu-configure
-configure_args="--disable-schemas-compile --enable-python --enable-vala"
+build_style=meson
 pycompile_dirs="usr/lib/gedit/plugins"
-hostmakedepends="glib-devel itstool pkg-config vala appstream-glib python3-gobject
+hostmakedepends="gettext glib-devel itstool pkg-config vala appstream-glib python3-gobject
  gucharmap-devel vte3-devel"
 makedepends="gedit-devel gtksourceview4-devel gtk+3-devel libgit2-glib-devel
  libglib-devel libpeas-devel python-dbus-devel python3-devel zeitgeist-devel"
@@ -15,5 +14,5 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/action/show/Apps/Gedit/PluginsLists"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=1368338882c535297ab4f6677da40c3f7bea545464c04a9076ee2c0c38eabeff
+checksum=1151b955393f75b5ee59b51154fda4f1928f498fe986a5584d3cd440876a6af6
 pycompile_version="$py3_ver"

--- a/srcpkgs/gedit/template
+++ b/srcpkgs/gedit/template
@@ -1,7 +1,7 @@
 # Template file for 'gedit'
 pkgname=gedit
-version=3.34.1
-revision=2
+version=3.36.1
+revision=1
 build_helper="gir"
 build_style=meson
 pycompile_dirs="usr/lib/gedit/plugins"
@@ -10,15 +10,15 @@ configure_args="-Dplugins=true -Dvapi=$(vopt_if vala true false)
 hostmakedepends="itstool pkg-config glib-devel gdk-pixbuf perl gettext
  $(vopt_if vala vala)"
 makedepends="gsettings-desktop-schemas-devel gspell-devel gtksourceview4-devel
- libpeas-devel libsoup-devel $(vopt_if gir 'python3-gobject-devel')"
+ libpeas-devel libsoup-devel tepl-devel $(vopt_if gir 'python3-gobject-devel')"
 depends="desktop-file-utils gsettings-desktop-schemas iso-codes"
 short_desc="Text editor for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Gedit"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=ebf9ef4e19831699d26bb93ce029edfed65416d7c11147835fc370d73428d5c6
-shlib_provides="libgedit-3.14.so"
+checksum=6dc38eda227d1c368e039e9bff485d0bee9a49d5f9560c387ee08f5818a4e387
+shlib_provides="libgedit-3.36.so"
 pycompile_version=$py3_ver
 
 build_options="gir vala"

--- a/srcpkgs/tepl/template
+++ b/srcpkgs/tepl/template
@@ -1,7 +1,7 @@
 # Template file for 'tepl'
 pkgname=tepl
-version=4.2.0
-revision=3
+version=4.4.0
+revision=1
 build_style=gnu-configure
 build_helper="gir"
 configure_args="$(vopt_enable gir introspection)"
@@ -13,7 +13,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Projects/Tepl"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=8839d4428ecdd87fd5abc657ebbe5a9601a57262e9946845e47dec264e669ccd
+checksum=e6f6673a8a27e8f280725db8fbacec79b20676ae0558755239d15a9808faa256
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
`gedit` depends on `tepl >= 4.4`, pushed them both. 
(And updated `common/shlibs` too)