### PR TITLE
wf-shell: install wf-shell.ini.example

### DIFF
--- a/srcpkgs/wf-shell/template
+++ b/srcpkgs/wf-shell/template
@@ -1,7 +1,7 @@
 # Template file for 'wf-shell'
 pkgname=wf-shell
 version=0.4.0
-revision=2
+revision=3
 build_style=meson
 build_helper="gir"
 hostmakedepends="gobject-introspection pkg-config wayland-devel"
@@ -18,4 +18,5 @@ checksum="bc03e5232d72f69bf6ba634f688f5e896715d846b7b6344136e9eb88dd6a9aa0"
 
 post_install() {
 	vlicense LICENSE
+	vsconf wf-shell.ini.example
 }


### PR DESCRIPTION
Example configuration needs to be provided, missing currently.
This change installs `/usr/share/examples/wf-shell/wf-shell.ini.example` also.