### PR TITLE
New package: chez-exe-0.1.1

### DIFF
--- a/srcpkgs/chez-exe/template
+++ b/srcpkgs/chez-exe/template
@@ -1,0 +1,38 @@
+# Template file for 'chez-exe'
+pkgname=chez-exe
+version=0.1.1
+revision=1
+_chezversion=9.5.2
+archs="i686* x86_64* armv6l armv7l"
+build_style="gnu-makefile"
+hostmakedepends="chez-scheme"
+makedepends="libuuid-devel zlib-devel"
+depends="gcc"
+short_desc="Compile a chez-scheme program into a standalone executable"
+maintainer="rc-05 <rc23@email.it>"
+license="custom:chez-exe"
+homepage="https://github.com/rc-05/chez-exe"
+distfiles="https://github.com/rc-05/chez-exe/archive/${version}.tar.gz"
+checksum=82f66a41f054d08f36c8d8408d429a10faed2003483dbc1e3e1d3e699cca7319
+
+pre_build() {
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*)
+			${wrksrc}/gen-config.ss --prefix /usr --scheme /usr/bin/scheme --bootpath /usr/lib/csv${_chezversion}/ta6le -lz
+		;;
+		i686*)
+			${wrksrc}/gen-config.ss --prefix /usr --scheme /usr/bin/scheme --bootpath /usr/lib/csv${_chezversion}/ti3le -lz
+		;;
+		arm*)
+			${wrksrc}/gen-config.ss --prefix /usr --scheme /usr/bin/scheme --bootpath /usr/lib/csv${_chezversion}/arm32le -lz -m32
+		;;
+		*)
+			broken="Target platform not supported by ChezScheme"
+		;;
+	esac
+}
+
+post_install() {
+	vlicense LICENSE
+	vlicense NOTICE
+}


### PR DESCRIPTION
Utility for compiling chez-scheme programs into a standalone executable.