### PR TITLE
apparmor: fix dhcpcd profile for dhcpcd version 9

### DIFF
--- a/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
@@ -7,9 +7,15 @@ profile dhcpcd /{usr/,}bin/dhcpcd {
   #include <abstractions/nameservice>
 
   capability chown,
+  capability fowner,
+  capability fsetid,
+  capability kill,
   capability net_admin,
   capability net_raw,
+  capability setuid,
+  capability setgid,
   capability sys_admin,
+  capability sys_chroot,
 
   network packet dgram,
   network inet raw,
@@ -26,9 +32,10 @@ profile dhcpcd /{usr/,}bin/dhcpcd {
   /proc/sys/net/ipv{4,6}/neigh/*/retrans_time_ms w,
   /proc/sys/net/ipv{4,6}/neigh/*/base_reachable_time_ms w,
 
-  /{var/,}run/dhcpcd{-*,}.pid rwk,
-  /{var/,}run/dhcpcd.sock rw,
-  /{var/,}run/dhcpcd.unpriv.sock rw,
+  /{var/,}run/dhcpcd/ w,
+  /{var/,}run/dhcpcd/{,*.}pid rwk,
+  /{var/,}run/dhcpcd/{,*.}sock rw,
+  /{var/,}run/dhcpcd/unpriv.sock rw,
   /{var/,}run/udev/data/* r,
 
   /sys/devices/**/net/*/uevent r,

--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.4
-revision=1
+revision=2
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure


### PR DESCRIPTION
**edit**: this is fixed with the latest update of the dhcpcd package (thx duncaen).

------------

Some filename changes introduced by dhcpcd 9 seem unintended, like using
```
/run/pid
/run/sock
/run/unpriv.sock
```
instead of
```
/run/dhcpcd{-*,}.pid
/run/dhcpcd.sock
/run/dhcpcd.unpriv.sock
```
but the profile works for now.