### PR TITLE
swirc: update to 3.2.4.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.2.3
+version=3.2.4
 revision=1
 build_style=configure
 make_install_args="PREFIX=/usr"
@@ -12,7 +12,7 @@ maintainer="Markus Uhlin <markus.uhlin@bredband.net>"
 license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 distfiles="https://www.nifty-networks.net/swirc/releases/${pkgname}-${version}.tgz"
-checksum="52e273bbc9ea6384841947858d60cb740a65bd80d2257c7cab39d9a4eb919f06"
+checksum="c8c15eeb6cc768a1b96952314420fea60c942b4dad25f6318d28dd2f00a02bc9"
 
 post_configure() {
 	local _file="options.mk"


### PR DESCRIPTION
**swirc** 3.2.3 -> 3.2.4

[Full changelog](https://github.com/uhlin/swirc/blob/master/CHANGELOG.md#324---2020-04-08)
