### PR TITLE
crystal: update to 0.34.0.

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,10 +1,11 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.33.0
-revision=3
+version=0.34.0
+revision=1
 archs="x86_64* i686* aarch64* arm*"
-_shardsversion=0.9.0
-_bootstrapversion=0.33.0
+_shardsversion=0.10.0
+_molinilloversion=0.1.0
+_bootstrapversion=0.34.0
 _bootstraprevision=1
 hostmakedepends="which tar git llvm9 pkg-config"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -18,9 +19,11 @@ license="Apache-2.0"
 homepage="https://crystal-lang.org/"
 distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
- https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz"
-checksum="88f08685f172e98f01f93f1a83fc3548c6d28df19a39c91859b167a796730289
- 90f230c87cc7b94ca845e6fe34f2523edcadb562d715daaf98603edfa2a94d65"
+ https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz
+ https://github.com/crystal-lang/crystal-molinillo/archive/v${_molinilloversion}.tar.gz"
+checksum="973293ffbcfa4fb073f6a2f833b0ce5b82b72f7899427f39d7e5610ffc9029c8
+ 3aea420df959552d1866d473c878ab1ed0b58489c4c9881ef40a170cfb775459
+ 1ecc7a8bf52a3bfdc0134d4c58f1155ef204a22a3fed151ac2d4ba6a9e9e0a15"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
 
@@ -32,11 +35,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" 9b9e078e9ba24fb97ee591d5f0a57c88cd018bd85ed6bdde9a30e5834b158128"
+		checksum+=" 268ace9073ad073b56c07ac10e3f29927423a8b170d91420b0ca393fb02acfb1"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" 7b5b4a9356993503b5c517be24d574d473abf2abc8b0dc5aff74bc93955ba187"
+		checksum+=" e8962c91b6b739ac9738e03b24de907d64930d6129fbe54f9c81e0e029378006"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"
@@ -47,10 +50,12 @@ else
 fi
 
 do_extract() {
-	mkdir -p ${wrksrc}/{shards,$(vopt_if binary_bootstrap bootstrap)}
+	mkdir -p ${wrksrc}/{shards,shards/lib,shards/lib/molinillo,molinillo,$(vopt_if binary_bootstrap bootstrap)}
 
 	tar xfz ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${version}.tar.gz --strip-components=1 -C ${wrksrc}
 	tar xfz ${XBPS_SRCDISTDIR}/${pkgname}-${version}/v${_shardsversion}.tar.gz --strip-components=1 -C ${wrksrc}/shards
+	tar xfz ${XBPS_SRCDISTDIR}/${pkgname}-${version}/v${_molinilloversion}.tar.gz --strip-components=1 -C ${wrksrc}/molinillo
+	mv -f ${wrksrc}/molinillo/src/* ${wrksrc}/shards/lib/molinillo
 	if [ "$build_option_binary_bootstrap" ]; then
 		tar xf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-${XBPS_TARGET_MACHINE}.tar.gz \
 			--strip-components=1 -C ${wrksrc}/bootstrap


### PR DESCRIPTION
- Compilation was locally tested with both i686 and x86_64
- Package was locally installed on x86_64, `crystal` and `shards` work
- `shards` now requires the `molinillo` Crystal library to works. As this library cannot be installed using `shards` as we are effectively building `shards`, I decided to download it the same way as `shards`, to create a dedicated directory in `wrksrc` for it, then use `mv` to move the interesting files into `shards/lib`. I do not really know whether it is the right way to do it, but it works. If there is a better way, please tell me and I will try to make it work.
- Issue with multi-threading: it is (still) not possible to compile programs with the `-Dpreview_mt` flag. See #14858