### PR TITLE
postgresql: fix pg_config --*flags

### DIFF
--- a/srcpkgs/postgresql/files/pg_config.sh.in
+++ b/srcpkgs/postgresql/files/pg_config.sh.in
@@ -1,0 +1,139 @@
+#!/bin/sh
+# Released to Public Domain by Doan Tran Cong Danh
+
+sysroot="$(cd "${0%/*}" && cd ../.. && pwd)"
+
+BINDIR="$sysroot/usr/bin"
+DOCDIR="$sysroot/usr/share/doc/postgresql"
+HTMLDIR="$sysroot/usr/share/doc/postgresql"
+INCLUDEDIR="$sysroot/usr/include"
+PKGINCLUDEDIR="$sysroot/usr/include/postgresql"
+INCLUDEDIR_SERVER="$sysroot/usr/include/postgresql/server"
+LIBDIR="$sysroot/usr/lib"
+PKGLIBDIR="$sysroot/usr/lib/postgresql"
+LOCALEDIR="$sysroot/usr/share/locale"
+MANDIR="$sysroot/usr/share/man"
+SHAREDIR="$sysroot/usr/share/postgresql"
+SYSCONFDIR="$sysroot/etc/postgresql"
+PGXS="$sysroot/usr/lib/postgresql/pgxs/src/makefiles/pgxs.mk"
+
+CONFIGURE="@configure_args@"
+CC="@CC@"
+CPPFLAGS="@CPPFLAGS@"
+CFLAGS="@CFLAGS@"
+CFLAGS_SL="@CFLAGS_SL@"
+LDFLAGS="@LDFLAGS@"
+LDFLAGS_EX="@LDFLAGS_EX@"
+LDFLAGS_SL="@LDFLAGS_SL@"
+LIBS="@LIBS@"
+VERSION="PostgreSQL @VERSION@"
+
+if [ "$sysroot" != "/" ]; then
+	CPPFLAGS="$(echo "$CPPFLAGS" | sed "s,-I *\\(/usr/include\\),-I$sysroot\\1,g")"
+	CFLAGS="$(echo "$CFLAGS" | sed "s,-I *\\(/usr/include\\),-I$sysroot\\1,g")"
+	LDFLAGS="$(echo "$LDFLAGS" | sed "s,-L *\\(/usr/lib\\),-L$sysroot\\1,g")"
+fi
+
+usage() {
+	cat <<-EOF
+	$0 provides information about the installed version of PostgreSQL.
+
+	Usage:
+	  $0 [OPTION]...
+
+	Options:
+	  --bindir              show location of user executables
+	  --docdir              show location of documentation files
+	  --htmldir             show location of HTML documentation files
+	  --includedir          show location of C header files of the client interfaces
+	  --pkgincludedir       show location of other C header files
+	  --includedir-server   show location of C header files for the server
+	  --libdir              show location of object code libraries
+	  --pkglibdir           show location of dynamically loadable modules
+	  --localedir           show location of locale support files
+	  --mandir              show location of manual pages
+	  --sharedir            show location of architecture-independent support files
+	  --sysconfdir          show location of system-wide configuration files
+	  --pgxs                show location of extension makefile
+	  --configure           show options given to PostgreSQL was built
+	  --cc                  show CC value used when PostgreSQL was built
+	  --cppflags            show CPPFLAGS value used when PostgreSQL was built
+	  --cflags              show CFLAGS value used when PostgreSQL was built
+	  --cflags_sl           show CFLAGS_SL value used when PostgreSQL was built
+	  --ldflags             show LDFLAGS value used when PostgreSQL was built
+	  --ldflags_ex          show LDFLAGS_EX value used when PostgreSQL was built
+	  --ldflags_sl          show LDFLAGS_SL value used when PostgreSQL was built
+	  --libs                show LIBS value used when PostgreSQL was built
+	  --version             show the PostgreSQL version
+	  -?, --help            show this help, then exit
+
+	With no arguments, all known items are shown.
+
+	Report bugs to <pgsql-bugs@postgresql.org>.
+	EOF
+}
+
+if test $# -eq 0; then
+	cat <<-EOF
+	BINDIR = $BINDIR
+	DOCDIR = $DOCDIR
+	HTMLDIR = $HTMLDIR
+	INCLUDEDIR = $INCLUDEDIR
+	PKGINCLUDEDIR = $PKGINCLUDEDIR
+	INCLUDEDIR-SERVER = $INCLUDEDIR_SERVER
+	LIBDIR = $LIBDIR
+	PKGLIBDIR = $PKGLIBDIR
+	LOCALEDIR = $LOCALEDIR
+	MANDIR = $MANDIR
+	SHAREDIR = $SHAREDIR
+	SYSCONFDIR = $SYSCONFDIR
+	PGXS = $PGXS
+	CONFIGURE = $CONFIGURE
+	CC = $CC
+	CPPFLAGS = $CPPFLAGS
+	CFLAGS = $CFLAGS
+	CFLAGS_SL = $CFLAGS_SL
+	LDFLAGS = $LDFLAGS
+	LDFLAGS_EX = $LDFLAGS_EX
+	LDFLAGS_SL = $LDFLAGS_SL
+	LIBS = $LIBS
+	VERSION = $VERSION
+	EOF
+fi
+
+for arg
+do
+	if test "x$arg" = "x--help" || test "x$arg" = "x-?"; then
+		usage
+		exit 0
+	fi
+done
+
+for arg
+do
+	case "$arg" in
+	--bindir) echo "$BINDIR" ;;
+	--docdir) echo "$DOCDIR" ;;
+	--htmldir) echo "$HTMLDIR" ;;
+	--includedir) echo "$INCLUDEDIR" ;;
+	--pkgincludedir) echo "$PKGINCLUDEDIR" ;;
+	--includedir-server) echo "$INCLUDEDIR_SERVER" ;;
+	--libdir) echo "$LIBDIR" ;;
+	--pkglibdir) echo "$PKGLIBDIR" ;;
+	--localedir) echo "$LOCALEDIR" ;;
+	--mandir) echo "$MANDIR" ;;
+	--sharedir) echo "$SHAREDIR" ;;
+	--sysconfdir) echo "$SYSCONFDIR" ;;
+	--pgxs) echo "$PGXS" ;;
+	--configure) echo "$CONFIGURE" ;;
+	--cc) echo "$CC" ;;
+	--cppflags) echo "$CPPFLAGS" ;;
+	--cflags) echo "$CFLAGS" ;;
+	--cflags_sl) echo "$CFLAGS_SL" ;;
+	--ldflags) echo "$LDFLAGS" ;;
+	--ldflags_ex) echo "$LDFLAGS_EX" ;;
+	--ldflags_sl) echo "$LDFLAGS_SL" ;;
+	--libs) echo "$LIBS" ;;
+	--version) echo "$VERSION" ;;
+	esac
+done

--- a/srcpkgs/postgresql/patches/pg_config-cross-value.patch
+++ b/srcpkgs/postgresql/patches/pg_config-cross-value.patch
@@ -1,0 +1,46 @@
+Sources: Doan Tran Cong Danh
+Upstream: No
+	- First part needs to be rework in configure script to be usable
+	  upstream
+	- Second part would un-usable for Windows
+diff --git src/common/Makefile src/common/Makefile
+index ec04710..2af845f 100644
+--- src/common/Makefile
++++ src/common/Makefile
+@@ -22,11 +22,14 @@ include $(top_builddir)/src/Makefile.global
+ 
+ # don't include subdirectory-path-dependent -I and -L switches
+ STD_CPPFLAGS := $(filter-out -I$(top_srcdir)/src/include -I$(top_builddir)/src/include,$(CPPFLAGS))
++STD_CPPFLAGS := $(subst @XBPS_SYSROOT@,,$(STD_CPPFLAGS))
++STD_CFLAGS   := $(subst @XBPS_SYSROOT@,,$(CFLAGS))
+ STD_LDFLAGS := $(filter-out -L$(top_builddir)/src/common -L$(top_builddir)/src/port,$(LDFLAGS))
++STD_LDFLAGS := $(subst @XBPS_SYSROOT@,,$(STD_LDFLAGS))
+ override CPPFLAGS += -DVAL_CONFIGURE="\"$(configure_args)\""
+ override CPPFLAGS += -DVAL_CC="\"$(CC)\""
+ override CPPFLAGS += -DVAL_CPPFLAGS="\"$(STD_CPPFLAGS)\""
+-override CPPFLAGS += -DVAL_CFLAGS="\"$(CFLAGS)\""
++override CPPFLAGS += -DVAL_CFLAGS="\"$(STD_CFLAGS)\""
+ override CPPFLAGS += -DVAL_CFLAGS_SL="\"$(CFLAGS_SL)\""
+ override CPPFLAGS += -DVAL_LDFLAGS="\"$(STD_LDFLAGS)\""
+ override CPPFLAGS += -DVAL_LDFLAGS_EX="\"$(LDFLAGS_EX)\""
+@@ -44,7 +47,19 @@ OBJS_FRONTEND = $(OBJS_COMMON) fe_memutils.o restricted_token.o
+ 
+ OBJS_SRV = $(OBJS_COMMON:%.o=%_srv.o)
+ 
+-all: libpgcommon.a libpgcommon_srv.a
++all: libpgcommon.a libpgcommon_srv.a pg_config.sh
++
++pg_config.sh: pg_config.sh.in
++	sed -e "s/@configure_args@/$(subst /,\\/,$(configure_args))/" \
++		-e "s/@CC@/$(subst /,\\/,$(CC))/" \
++		-e "s/@CPPFLAGS@/$(subst /,\\/,$(STD_CPPFLAGS))/" \
++		-e "s/@CFLAGS@/$(subst /,\\/,$(STD_CFLAGS))/" \
++		-e "s/@CFLAGS_SL@/$(subst /,\\/,$(CFLAGS_SL))/" \
++		-e "s/@LDFLAGS@/$(subst /,\\/,$(STD_LDFLAGS))/" \
++		-e "s/@LDFLAGS_EX@/$(subst /,\\/,$(LDFLAGS_EX))/" \
++		-e "s/@LDFLAGS_SL@/$(subst /,\\/,$(LDFLAGS_SL))/" \
++		-e "s/@LIBS@/$(subst /,\\/,$(LIBS))/" \
++		$< >$@
+ 
+ # libpgcommon is needed by some contrib
+ install: all installdirs

--- a/srcpkgs/postgresql/template
+++ b/srcpkgs/postgresql/template
@@ -1,7 +1,7 @@
 # Template file for 'postgresql'
 pkgname=postgresql
 version=9.6.17
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_target=world
 configure_args="--with-openssl --with-python
@@ -35,6 +35,12 @@ if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --without-perl --without-python --without-tcl"
 fi
 
+post_patch() {
+	sed -e "s/@VERSION@/$version/" \
+		"$FILESDIR"/pg_config.sh.in >src/common/pg_config.sh.in
+	vsed -i -e "s,@XBPS_SYSROOT@,${XBPS_CROSS_BASE%/}," src/common/Makefile
+}
+
 pre_build() {
 	# http://www.postgresql.org/docs/9.3/static/docguide-toolsets.html
 	export SGML_CATALOG_FILES="/usr/share/sgml/openjade/catalog:/usr/share/sgml/iso8879/catalog:/usr/share/sgml/docbook/dsssl/modular/catalog:/usr/share/sgml/docbook/4.2/catalog"
@@ -58,6 +64,7 @@ post_install() {
 	vinstall ${FILESDIR}/${pkgname}.pam 644 etc/pam.d ${pkgname}
 	vinstall ${DESTDIR}/usr/share/${pkgname}/${pkgname}.conf.sample \
 		644 etc/${pkgname} ${pkgname}.conf
+	vbin src/common/pg_config.sh
 
 	sed -i 's/install_bin = .*/install_bin = install/g' \
 		${DESTDIR}/usr/lib/postgresql/pgxs/src/Makefile.global
@@ -91,6 +98,7 @@ postgresql-libs-devel_package() {
 			vmove usr/bin/${f}
 			vmove "usr/share/man/man1/$(basename ${f})*"
 		done
+		vmove usr/bin/pg_config.sh
 		vmove usr/include
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/pkgconfig/*"


### PR DESCRIPTION
Current `pg_config` reports flags included `$SYSROOT`,

	$ pg_config --cppflags
	-D_GNU_SOURCE -I/usr/aarch64-linux-musl/usr/include/libxml2

Fix the build system to remove it from $CPPFLAGS $CFLAGS $LDFLAGS.

Also ship a new pg_config.sh for cross-compiling other packages that
depends on postgresql.
That script was mostly translated from C code.

(Partial?) fix for #19642 