### PR TITLE
Clightd: add runit service

### DIFF
--- a/srcpkgs/Clightd/files/Clightd/log/run
+++ b/srcpkgs/Clightd/files/Clightd/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/bin/vlogger -t Clightd

--- a/srcpkgs/Clightd/files/Clightd/run
+++ b/srcpkgs/Clightd/files/Clightd/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sv check dbus >/dev/null || exit 1
+exec /usr/lib/clightd/clightd 2>&1

--- a/srcpkgs/Clightd/template
+++ b/srcpkgs/Clightd/template
@@ -1,7 +1,7 @@
 # Template file for 'Clightd'
 pkgname=Clightd
 version=4.0
-revision=2
+revision=3
 build_style=cmake
 cmake_builddir=build
 configure_args="-DENABLE_DDC=1 -DENABLE_GAMMA=1 -DENABLE_DPMS=1 -DENABLE_SCREEN=1"
@@ -17,4 +17,5 @@ checksum=b3b2c83d4deb3ebc75ee965d6640009794eec61160a20772932643a9864fb7ba
 
 post_install() {
 	vinstall Scripts/i2c_clightd.conf 644 /usr/lib/modules-load.d/
+	vsv Clightd
 }


### PR DESCRIPTION
This PR adds a runit service for the Clightd backlight management daemon. In the unmodified config, `dbus` will automatically start `clightd` on demand, but, once started, the daemon will never die. (When `dbus` dies, the Clightd daemon doesn't die with it, it just repeatedly complains about a missing bus.) By starting the daemon from runit, its lifetime can be managed with runit.