### PR TITLE
Kindd: remove unnecessary dependencies

### DIFF
--- a/srcpkgs/kindd/template
+++ b/srcpkgs/kindd/template
@@ -1,11 +1,12 @@
 # Template file for 'kindd'
 pkgname=kindd
 version=2.1.0
-revision=1
+revision=2
 build_style=cmake
-hostmakedepends="cmake pkg-config qt5-qmake qt5-host-tools"
-makedepends="qt5-devel qt5-declarative-devel qt5-quickcontrols2-devel qt5-svg-devel"
-depends="polkit-gnome qt5-quickcontrols qt5-quickcontrols2 qt5-graphicaleffects  qt5-declarative qt5-svg"
+hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
+makedepends="qt5-devel qt5-declarative-devel qt5-quickcontrols2-devel
+ qt5-svg-devel"
+depends="qt5-quickcontrols qt5-graphicaleffects qt5-svg"
 short_desc="Kindful dd, written by qt-quick"
 maintainer="linarcx <linarcx@gmail.com>"
 license="GPL-3.0-only"


### PR DESCRIPTION
1. Let users [decide](https://github.com/LinArcX/kindd/#polkit) which polkit-agent is appropriate for them.
2. Remove unnecessary runtime dependencies like:
`polkit-gnome` , `qt5-quickcontrols2`, `qt5-declarative`, `qt5-svg`