### PR TITLE
[TRACKING-upstream] go: enable PIE builds for Go executables

### DIFF
--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -4,15 +4,15 @@ if [ -z "$hostmakedepends" -o "${hostmakedepends##*gcc-go-tools*}" ]; then
 		archs="aarch64* armv[567]* i686* x86_64* ppc64le*"
 	fi
 	hostmakedepends+=" go"
-	nopie=yes
+	export GOFLAGS="-buildmode=pie"
 else
 	# gccgo compiler
 	if [ "$CROSS_BUILD" ]; then
 		# target compiler to use; otherwise it'll just call gccgo
 		export GCCGO="${XBPS_CROSS_TRIPLET}-gccgo"
 	fi
+	nostrip=yes
 fi
-nostrip=yes
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) export GOARCH=arm64;;


### PR DESCRIPTION
Fixed up version of #20450 

Both Arch Linux and Alpine already implement this feature. Arch has a package called go-pie that's used for most of their PKGBUILDs, while the only version of Go on Alpine is one capable of producing PIE binaries.

On Arch: https://www.archlinux.org/packages/community/x86_64/go-pie/
On Alpine: https://pkgs.alpinelinux.org/package/edge/community/x86_64/go
The patch used here is actually adapted from the one used by Arch, and if adopted can allow us to remove the nostrip flag from the go build_style.

I'm getting some weird build output, where it says

loadinternal: cannot find runtime/cgo
so I'm not completely certain that it's 100% complete. Building a program that uses cgo does work cleanly, so I'm not sure what it means.