### PR TITLE
rtl8822bu-dkms: update to 20200407.

### DIFF
--- a/srcpkgs/rtl8822bu-dkms/template
+++ b/srcpkgs/rtl8822bu-dkms/template
@@ -1,8 +1,8 @@
 # Template file for 'rtl8822bu-dkms'
 pkgname=rtl8822bu-dkms
-version=20190713
+version=20200407
 revision=1
-_gitrev=dea3bb8e631191ded1839c53fb266d80ef7e8ad3
+_gitrev=9438d453ec5b4878b7d4a2b4bcf87b37df09c3fb
 archs=noarch
 wrksrc="rtl8822bu-${_gitrev}"
 depends="dkms"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://www.tp-link.com"
 distfiles="https://github.com/EntropicEffect/rtl8822bu/archive/${_gitrev}.tar.gz"
-checksum=34474838558a8502edc9bcd1091c8911ec128d50aeda2f83173b36c1a592250c
+checksum=deaec219cc5921215523de6501966bcc3dd314e6e9a646161ee2deb5ce895662
 dkms_modules="88x2bu ${version}"
 
 do_install() {


### PR DESCRIPTION
This update should fix the crashes this module had when running with the Linux kernel 5.4 despite compiling and installing successfully (I have tested this). It should also allow compiling it with the 5.6 version (but I haven't tested this).