### PR TITLE
skopeo: update to 0.2.0.

### DIFF
--- a/srcpkgs/skopeo/template
+++ b/srcpkgs/skopeo/template
@@ -1,6 +1,6 @@
 # Template file for 'skopeo'
 pkgname=skopeo
-version=0.1.41
+version=0.2.0
 revision=1
 build_style=go
 go_import_path="github.com/containers/${pkgname}"
@@ -14,14 +14,16 @@ maintainer="Frank Steinborn <steinex@nognu.de>"
 license="Apache-2.0"
 homepage="https://github.com/containers/skopeo"
 distfiles="https://github.com/containers/${pkgname}/archive/v${version}.tar.gz"
-checksum=d9f4a0dcf4a43469768dbf16865d5bc98e5434fadd65af35051edb36767c9c70
+checksum=b58c54732932cdd89f760f30136317fc2fef6457d158fb1e5d4976aeabcb20f2
 make_dirs="/var/lib/atomic/sigstore 0755 root root"
 
 post_build() {
-	go-md2man -in docs/skopeo.1.md -out docs/skopeo.1
+	make docs
 }
 
 post_install() {
-	vman docs/skopeo.1
 	vinstall completions/bash/skopeo 644 usr/share/bash-completion/completions
+	for m in docs/*.1; do
+		vman "$m"
+	done
 }


### PR DESCRIPTION
Also build/install all of the manpages.