### PR TITLE
cheat: update to 3.9.0.

### DIFF
--- a/srcpkgs/cheat/template
+++ b/srcpkgs/cheat/template
@@ -1,6 +1,6 @@
 # Template file for 'cheat'
 pkgname=cheat
-version=3.8.0
+version=3.9.0
 revision=1
 build_style=go
 go_import_path="github.com/cheat/cheat/cmd/cheat"
@@ -9,7 +9,7 @@ maintainer="bra1nwave <bra1nwave@protonmail.com>"
 license="MIT"
 homepage="https://github.com/cheat/cheat"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=daa183b9328704bbd00fc423144ce29652b1750e895dbf9c99b131d98b7f01ec
+checksum=404081005628cccbbe576567cf3aa1e8d93c618230c9119ae74ce27366cddb1e
 
 post_install() {
 	vman doc/cheat.1


### PR DESCRIPTION
I will not add the zsh complete script for now because it conflicts with `zsh-completions`.
Someone has already created a [PR](https://github.com/zsh-users/zsh-completions/pull/700) to update the `_cheat` from `zsh-completions`.