### PR TITLE
nss: update to 3.51.1.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.25
 
 pkgname=nss
-version=3.51
+version=3.51.1
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,7 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=75348b3b3229362486c57a880db917da1f96ef4eb639dc9cc2ff17d72268459c
+checksum=085c5eaceef040eddea639e2e068e70f0e368f840327a678ef74ae3d6c15ca78
 
 do_build() {
 	local _native_use64 _target_use64


### PR DESCRIPTION
xbps-src check passed for x86_64 and i686.
Run with firefox for a day.