### PR TITLE
texlive2019-bin: use historic texlive repository

### DIFF
--- a/srcpkgs/texlive2019-bin/INSTALL
+++ b/srcpkgs/texlive2019-bin/INSTALL
@@ -5,10 +5,10 @@ post)
 		cd opt/texlive2019-installer
 		case "${ARCH}" in
 			x86_64-musl)
-			./install-tl -profile void.profile -force-platform x86_64-linuxmusl
+			./install-tl -profile void.profile -repository https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2019/tlnet-final/ -no-verify-downloads -force-platform x86_64-linuxmusl
 			;;
 			*)
-			./install-tl -profile void.profile
+			./install-tl -profile void.profile -repository https://ftp.tu-chemnitz.de/pub/tug/historic/systems/texlive/2019/tlnet-final/ -no-verify-downloads
 			;;
 		esac
 	esac

--- a/srcpkgs/texlive2019-bin/template
+++ b/srcpkgs/texlive2019-bin/template
@@ -1,7 +1,7 @@
-# Template file for 'texlive-bin'
+# Template file for 'texlive2019-bin'
 pkgname=texlive2019-bin
 version=2019
-revision=1
+revision=2
 archs="x86_64* i686 aarch64 arm*"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="http://tug.org/texlive/"


### PR DESCRIPTION
Currently a fresh texlive installation fails.

As texlive2020 has been released the default repository no longer
contains the 2019 version. Make the installer use the frozen
historic one.

Also the signing key seems to be expired so the installer fails. A workaround
is disabling the verification. However, not sure if this is a good idea, but I couldn’t
make it work otherwise.

This is likely a problem for the other historic texlive versions in Void’s repository, too, I didn’t test, however.

@leahneukirchen 