### PR TITLE
build-style/cargo.sh: don't use post_install() for leftover removal

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -20,9 +20,7 @@ do_install() {
 
 	${make_cmd} install --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
 		--locked ${configure_args} ${make_install_args}
-}
 
-post_install() {
 	rm -f "${DESTDIR}"/usr/.crates.toml
 	rm -f "${DESTDIR}"/usr/.crates2.json
 }


### PR DESCRIPTION
Looks like only the do_*() phases are overwritable by the template, so post_install() currently always uses the build_style defined one, ignoring the template.