### PR TITLE
rpi-kernel: update to 4.19.114.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="4f2a4cc501c428c940549f39d5562e60404ac4f7"
+_githash="e2efb9193948e20cd6e017a6331354b4028bf398"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.113
+version=4.19.114
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=97d835a853dcbc0016b26daa618ce7511b9fecb7c4628dcb56667234163d88eb
+checksum=223d8f71b2d94a75d20d1a0cf437ee155a2bd1ae43282d589484873f65a3c0d6
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.