### PR TITLE
New package: base16-builder-rust-0.1.1

### DIFF
--- a/srcpkgs/base16-builder-rust/template
+++ b/srcpkgs/base16-builder-rust/template
@@ -1,0 +1,17 @@
+# Template file for 'base16-builder-rust'
+pkgname=base16-builder-rust
+version=0.1.1
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libressl-devel"
+short_desc="Rust implementation of a base16 builder"
+maintainer="Anachron <gith@cron.world>"
+license="MIT"
+homepage="https://github.com/ilpianista/base16-builder-rust"
+distfiles="https://github.com/ilpianista/base16-builder-rust/archive/v${version}.tar.gz"
+checksum=09ff5fc67916fd6fbdb53170bf12ddfdc93151c16afe7d3ea02b652fa6048a63
+
+post_install() {
+	vlicense LICENSE.md
+}


### PR DESCRIPTION
Tested on `x86_64`.