### PR TITLE
php: Add cross compilation support

### DIFF
--- a/srcpkgs/php/patches/php-cross-config.patch
+++ b/srcpkgs/php/patches/php-cross-config.patch
@@ -1,0 +1,41 @@
+--- configure	2020-03-17 11:40:20.000000000 +0100
++++ configure	2020-04-12 19:51:57.216350534 +0200
+@@ -6374,10 +6374,12 @@ IFS="- /.
+     as_fn_error $? "Please note that Apache version >= 2.0.44 is required" "$LINENO" 5
+   fi
+ 
++  APXS_PREFIX='$(INSTALL_ROOT)'/usr
+   APXS_LIBEXECDIR='$(INSTALL_ROOT)'`$APXS -q LIBEXECDIR`
+   if test -z `$APXS -q SYSCONFDIR`; then
+     INSTALL_IT="\$(mkinstalldirs) '$APXS_LIBEXECDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
++                       -S PREFIX='$APXS_PREFIX' \
+                        -i -n php7"
+   else
+     APXS_SYSCONFDIR='$(INSTALL_ROOT)'`$APXS -q SYSCONFDIR`
+@@ -6385,6 +6387,7 @@ IFS="- /.
+                 \$(mkinstalldirs) '$APXS_SYSCONFDIR' && \
+                  $APXS -S LIBEXECDIR='$APXS_LIBEXECDIR' \
+                        -S SYSCONFDIR='$APXS_SYSCONFDIR' \
++                       -S PREFIX='$APXS_PREFIX' \
+                        -i -a -n php7"
+   fi
+ 
+@@ -57170,7 +57173,7 @@ $as_echo_n "checking for pg_config... "
+     fi
+   done
+ 
+-  if test -n "$PG_CONFIG"; then
++  if test -n "$PG_CONFIG" && test "x$cross_compiling" != "xyes"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PG_CONFIG" >&5
+ $as_echo "$PG_CONFIG" >&6; }
+     PGSQL_INCLUDE=`$PG_CONFIG --includedir`
+@@ -58821,7 +58824,7 @@ $as_echo_n "checking for pg_config... "
+     fi
+   done
+ 
+-  if test -n "$PG_CONFIG"; then
++  if test -n "$PG_CONFIG" && test "x$cross_compiling" != "xyes"; then
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PG_CONFIG" >&5
+ $as_echo "$PG_CONFIG" >&6; }
+     PGSQL_INCLUDE=`$PG_CONFIG --includedir`

--- a/srcpkgs/php/patches/php-pear-cross.patch
+++ b/srcpkgs/php/patches/php-pear-cross.patch
@@ -1,0 +1,23 @@
+--- pear/Makefile.frag	2020-03-17 11:40:21.000000000 +0100
++++ pear/Makefile.frag	2020-04-12 22:29:31.846943414 +0200
+@@ -8,9 +8,10 @@ FETCH = `which fetch 2>/dev/null`
+ PEAR_PREFIX = -dp a${program_prefix}
+ PEAR_SUFFIX = -ds a$(program_suffix)
+ PEAR_INSTALLER_URL = https://pear.php.net/install-pear-nozlib.phar
++PEAR_PHP ?= $(top_builddir)/sapi/cli/php
+ 
+ install-pear-installer: $(SAPI_CLI_PATH)
+-	@$(top_builddir)/sapi/cli/php $(PEAR_INSTALL_FLAGS) pear/install-pear-nozlib.phar -d "$(peardir)" -b "$(bindir)" ${PEAR_PREFIX} ${PEAR_SUFFIX}
++	@$(PEAR_PHP) $(PEAR_INSTALL_FLAGS) pear/install-pear-nozlib.phar -d "$(peardir)" -b "$(bindir)" ${PEAR_PREFIX} ${PEAR_SUFFIX}
+ 
+ install-pear:
+ 	@echo "Installing PEAR environment:      $(INSTALL_ROOT)$(peardir)/"
+@@ -23,7 +24,7 @@ install-pear:
+ 			elif test ! -z "$(FETCH)" && test -x "$(FETCH)"; then \
+ 				"$(FETCH)" -o $(builddir)/ "${PEAR_INSTALLER_URL}"; \
+ 			else \
+-				$(top_builddir)/sapi/cli/php -n $(srcdir)/fetch.php "${PEAR_INSTALLER_URL}" $(builddir)/install-pear-nozlib.phar; \
++				$(PEAR_PHP) -n $(srcdir)/fetch.php "${PEAR_INSTALLER_URL}" $(builddir)/install-pear-nozlib.phar; \
+ 			fi \
+ 		fi \
+ 	fi

--- a/srcpkgs/php/patches/php-phar-cross.patch
+++ b/srcpkgs/php/patches/php-phar-cross.patch
@@ -1,0 +1,29 @@
+--- ext/phar/Makefile.frag	2020-04-13 12:18:23.998801926 +0200
++++ ext/phar/Makefile.frag	2020-04-13 12:20:58.031795293 +0200
+@@ -8,12 +8,14 @@ $(srcdir)/phar_path_check.c: $(srcdir)/p
+ 
+ pharcmd: $(builddir)/phar.php $(builddir)/phar.phar
+ 
++PHAR_PHP ?= $(top_builddir)/$(SAPI_CLI_PATH)
++PHAR_PHP_MODULES ?= $(top_builddir)/modules
+ PHP_PHARCMD_SETTINGS = -n -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1' -d phar.readonly=0
+ PHP_PHARCMD_EXECUTABLE = ` \
+-	if test -x "$(top_builddir)/$(SAPI_CLI_PATH)"; then \
+-		$(top_srcdir)/build/shtool echo -n -- "$(top_builddir)/$(SAPI_CLI_PATH) -n"; \
++	if test -x "$(PHAR_PHP)"; then \
++		$(top_srcdir)/build/shtool echo -n -- "$(PHAR_PHP) -n"; \
+ 		if test "x$(PHP_MODULES)" != "x"; then \
+-		$(top_srcdir)/build/shtool echo -n -- " -d extension_dir=$(top_builddir)/modules"; \
++		$(top_srcdir)/build/shtool echo -n -- " -d extension_dir=$(PHAR_PHP_MODULES)"; \
+ 		for i in bz2 zlib phar; do \
+ 			if test -f "$(top_builddir)/modules/$$i.la"; then \
+ 				. $(top_builddir)/modules/$$i.la; $(top_srcdir)/build/shtool echo -n -- " -d extension=$$dlname"; \
+@@ -21,7 +23,7 @@ PHP_PHARCMD_EXECUTABLE = ` \
+ 		done; \
+ 		fi; \
+ 	else \
+-		$(top_srcdir)/build/shtool echo -n -- "$(PHP_EXECUTABLE)"; \
++		$(top_srcdir)/build/shtool echo -n -- "$(PHAR_PHP)"; \
+ 	fi;`
+ PHP_PHARCMD_BANG = `$(top_srcdir)/build/shtool echo -n -- "$(INSTALL_ROOT)$(bindir)/$(program_prefix)php$(program_suffix)$(EXEEXT)";`
+ 

--- a/srcpkgs/php/patches/php-phpize-sysroot-support.patch
+++ b/srcpkgs/php/patches/php-phpize-sysroot-support.patch
@@ -1,0 +1,28 @@
+--- scripts/phpize.m4	2020-03-17 11:40:21.000000000 +0100
++++ scripts/phpize.m4	2020-04-15 12:27:36.400466387 +0200
+@@ -44,6 +44,12 @@ PHP_ARG_WITH([libdir],
+   [lib],
+   [no])
+ 
++PHP_ARG_WITH([sysroot],,
++  [AS_HELP_STRING([--with-sysroot=NAME],
++    [System sysroot])],
++    [no],
++    [no])
++
+ PHP_RUNPATH_SWITCH
+ PHP_SHLIB_SUFFIX_NAMES
+ 
+@@ -58,7 +64,11 @@ dnl For BC.
+ PHP_CONFIG=$PHP_PHP_CONFIG
+ prefix=`$PHP_CONFIG --prefix 2>/dev/null`
+ phpincludedir=`$PHP_CONFIG --include-dir 2>/dev/null`
+-INCLUDES=`$PHP_CONFIG --includes 2>/dev/null`
++if test "x$PHP_SYSROOT" = xno; then :
++	INCLUDES=`$PHP_CONFIG --includes 2>/dev/null`
++else
++	INCLUDES=`$PHP_CONFIG --includes 2>/dev/null | sed "s#-I#-I$PHP_SYSROOT#g"`
++fi
+ EXTENSION_DIR=`$PHP_CONFIG --extension-dir 2>/dev/null`
+ PHP_EXECUTABLE=`$PHP_CONFIG --php-binary 2>/dev/null`
+ 

--- a/srcpkgs/php/template
+++ b/srcpkgs/php/template
@@ -1,7 +1,7 @@
 # Template file for 'php'
 pkgname=php
 version=7.4.4
-revision=2
+revision=3
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant-devel freetds-devel freetype-devel gdbm-devel
  gmp-devel libcurl-devel libjpeg-turbo-devel libmysqlclient-devel

--- a/srcpkgs/php/template
+++ b/srcpkgs/php/template
@@ -2,7 +2,7 @@
 pkgname=php
 version=7.4.4
 revision=2
-hostmakedepends="bison pkg-config"
+hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant-devel freetds-devel freetype-devel gdbm-devel
  gmp-devel libcurl-devel libjpeg-turbo-devel libmysqlclient-devel
  libsodium-devel libtidy5-devel libxslt-devel libzip-devel net-snmp-devel
@@ -17,11 +17,13 @@ checksum=1873c4cefdd3df9a78dcffb2198bba5c2f0464f55c9c960720c84df483fca74c
 
 conf_files="/etc/php/php.ini"
 
-# Needs (probably a lot of) work to make it cross compile
-nocross=https://build.voidlinux.org/builders/armv7l-musl_builder/builds/16307/steps/shell_3/logs/stdio
-
 lib32disabled=yes
 replaces="php-mcrypt<7.2.0"
+
+if [ -n "$CROSS_BUILD" ]; then
+	# php-pear needs php to build
+	hostmakedepends+=" php"
+fi
 
 do_build() {
 	local _phpconfig="--srcdir=.. \
@@ -59,18 +61,18 @@ do_build() {
 		--with-external-gd \
 		--with-zip=shared \
 		--with-ffi=shared \
-		--with-bz2=shared \
+		--with-bz2=shared,$XBPS_CROSS_BASE/usr/ \
 		--with-curl=shared \
-		--with-db4=/usr \
-		--with-enchant=shared,/usr \
-		--with-freetype-dir=/usr \
-		--with-gdbm \
+		--with-db4=$XBPS_CROSS_BASE/usr \
+		--with-enchant=shared,$XBPS_CROSS_BASE/usr \
+		--with-freetype-dir=$XBPS_CROSS_BASE/usr \
+		--with-gdbm=$XBPS_CROSS_BASE/usr \
 		--with-gettext=shared \
 		--with-gmp=shared \
 		--with-iconv=shared \
-		--with-icu-dir=/usr \
-		--with-jpeg-dir=/usr \
-		--with-ldap=shared \
+		--with-icu-dir=$XBPS_CROSS_BASE/usr \
+		--with-jpeg-dir=$XBPS_CROSS_BASE/usr \
+		--with-ldap=shared,$XBPS_CROSS_BASE/usr \
 		--with-ldap-sasl \
 		--with-libzip \
 		--with-sodium=shared \
@@ -78,55 +80,65 @@ do_build() {
 		--with-mysql-sock=/run/mysqld/mysqld.sock \
 		--with-mysqli=shared,mysqlnd \
 		--with-openssl=shared \
-		--with-pcre-regex=/usr \
+		--with-pcre-regex=$XBPS_CROSS_BASE/usr \
 		--with-pdo-mysql=shared,mysqlnd \
-		--with-pdo-odbc=shared,unixODBC,/usr \
-		--with-pdo-pgsql=shared \
-		--with-pdo-sqlite=shared,/usr \
-		--with-pgsql=shared \
-		--with-png-dir=/usr \
-		--with-readline \
-		--with-snmp=shared \
-		--with-sqlite3=shared,/usr \
-		--with-unixODBC=shared,/usr \
-		--with-xmlrpc=shared \
-		--with-xsl=shared \
-		--with-tidy=shared \
+		--with-pdo-odbc=shared,unixODBC,$XBPS_CROSS_BASE/usr \
+		--with-pdo-pgsql=shared,$XBPS_CROSS_BASE/usr \
+		--with-pdo-sqlite=shared,$XBPS_CROSS_BASE/usr \
+		--with-pgsql=shared,$XBPS_CROSS_BASE/usr \
+		--with-png-dir=$XBPS_CROSS_BASE/usr \
+		--with-readline=$XBPS_CROSS_BASE/usr \
+		--with-snmp=shared,$XBPS_CROSS_BASE/usr \
+		--with-sqlite3=shared,$XBPS_CROSS_BASE/usr \
+		--with-unixODBC=shared,$XBPS_CROSS_BASE/usr \
+		--with-xsl=shared,$XBPS_CROSS_BASE/usr \
+		--with-tidy=shared,$XBPS_CROSS_BASE/usr \
 		--with-zlib \
 		${configure_args} \
 		"
+	if [ -n "$CROSS_BUILD" ]; then
+		local _make_env="PHAR_PHP=/usr/bin/php PHAR_PHP_MODULES=/usr/lib/php/modules"
+	fi
 
 	EXTENSION_DIR=/usr/lib/php/modules
 	export EXTENSION_DIR
 	PEAR_INSTALLDIR=/usr/share/pear
 	export PEAR_INSTALLDIR
+	EXTRA_LIBS="-ldl"
+	export EXTRA_LIBS
 
 	# cgi,cli,embed,fcgi,fpm
 	mkdir -p build
 	cd build
 	ln -s ${wrksrc}/configure
 	./configure ${_phpconfig} \
+		--host=${XBPS_CROSS_TRIPLET} \
 		--enable-cgi \
 		--enable-fpm \
 		--with-fpm-user=http \
 		--with-fpm-group=http \
 		--enable-embed=shared \
 		${_phpextensions}
-	make ${makejobs}
+	make ${makejobs} ${_make_env}
 
 	# apache
 	# reuse the previous run; this will save us a lot of time
 	cp -a ${wrksrc}/build ${wrksrc}/build-apache
 	cd ${wrksrc}/build-apache
 	./configure ${_phpconfig} \
+		--host=${XBPS_CROSS_TRIPLET} \
 		--with-apxs2 \
 		${_phpextensions}
-	make ${makejobs}
+	make ${makejobs} ${_make_env}
 }
 
 do_install() {
 	cd ${wrksrc}/build
-	make INSTALL_ROOT=${DESTDIR} install-{modules,cli,build,headers,programs,pharcmd}
+	local _env="INSTALL_ROOT=${DESTDIR}"
+	if [ -n "$CROSS_BUILD" ]; then
+		_env+=" PHAR_PHP=/usr/bin/php"
+	fi
+	make ${_env} install-{modules,cli,build,headers,programs,pharcmd}
 
 	# install php.ini
 	vinstall ${wrksrc}/php.ini-production 644 etc/php php.ini
@@ -202,7 +214,11 @@ php-pear_package() {
 	conf_files="/etc/php/pear.conf"
 	pkg_install() {
 		cd ${wrksrc}/build
-		make install-pear INSTALL_ROOT=${PKGDESTDIR}
+		local _env="INSTALL_ROOT=${PKGDESTDIR}"
+		if [ -n "$CROSS_BUILD" ]; then
+			_env+=" PEAR_PHP=/usr/bin/php"
+		fi
+		make install-pear ${_env}
 		rm -rf ${PKGDESTDIR}/.{channels,depdb,depdblock,filemap,lock,registry}
 		rm -rf ${PKGDESTDIR}/usr/share/pear/.{channels,depdb,depdblock,filemap,lock,registry}
 	}


### PR DESCRIPTION
Support cross compilation by providing builddir path in configure and patching phar and pear makefiles to use host's php binary to install themselves. Therefore it also makes php a hostmakedepends when crosscompiling.