### PR TITLE
mtpaint: update to 3.49.26.

### DIFF
--- a/srcpkgs/mtpaint/template
+++ b/srcpkgs/mtpaint/template
@@ -1,18 +1,24 @@
 # Template file for 'mtpaint'
 pkgname=mtpaint
-version=3.49.23
+version=3.49.26
 revision=1
-_commit=3d675d0a8fd598d6dff8cac51940fb62e14f7b59
+_commit=60be9cc851dfd263381dde326cc8f955e0454c46
 wrksrc="mtPaint-${_commit}"
 build_style=configure
 configure_args="--prefix=/usr --mandir=/usr/share/man
-		imagick cflags GIF jpeg jp2 tiff lcms2 man"
+		imagick cflags GIF jpeg jp2 tiff lcms2 man
+		gtk3 webp"
 hostmakedepends="pkg-config"
-makedepends="giflib-devel gtk+-devel libmagick-devel libopenjpeg-devel"
+makedepends="giflib-devel gtk+3-devel libmagick-devel libopenjpeg-devel
+ libwebp-devel"
 depends="desktop-file-utils"
-short_desc="Simple GTK+2 painting program"
+short_desc="Simple GTK painting program"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://mtpaint.sourceforge.net/"
 distfiles="https://github.com/wjaguar/mtPaint/archive/${_commit}.tar.gz"
-checksum=8c086e83e4731de8437c3e3cb3bf84b2255696c59f15d3d0041bca03514f8fb3
+checksum=d17c6ab16050406ddf0ff38ddadfdda73115b805b6fecaecdee592e3b659a0eb
+
+post_install() {
+	vdoc doc/vcode.t2t
+}


### PR DESCRIPTION
- Use Gtk3.
- Enable webp support.
- Install documentation.