### PR TITLE
wpa_supplicant: add DRIVER option to runit service

### DIFF
--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/run
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ -r ./conf ]; then
 	. ./conf
-	: ${OPTS:=-M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} -s}
+	: ${OPTS:=-M -c ${CONF_FILE:-/etc/wpa_supplicant/wpa_supplicant.conf} ${WPA_INTERFACE:+-i ${WPA_INTERFACE}} ${DRIVER:+-D ${DRIVER}} -s}
 else
 	. ./auto
 	OPTS="${AUTO} -s"

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.9
-revision=1
+revision=2
 build_wrksrc="$pkgname"
 short_desc="WPA/WPA2/IEEE 802.1X Supplicant"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
On old hardware were `wext` is needed, there should be a way to configure `wpa_supplicant` without resorting to setting all options manually through `OPTS`.