### PR TITLE
python3-pillow-simd: update to 7.0.0.post3

### DIFF
--- a/srcpkgs/python3-pillow-simd/template
+++ b/srcpkgs/python3-pillow-simd/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-pillow-simd'
 pkgname=python3-pillow-simd
-version=5.3.0.post1
-revision=2
+version=7.0.0.post3
+revision=1
 archs="x86_64*"
 wrksrc="pillow-simd-${version}"
 build_style=python3-module
-pycompile_module="PIL"
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel libjpeg-turbo-devel libopenjpeg2-devel
  zlib-devel tiff-devel freetype-devel lcms2-devel libwebp-devel
@@ -14,10 +13,11 @@ short_desc="Python3 Imaging Library (PIL) fork (SIMD)"
 maintainer="mustaqim <mustaqim@pm.me>"
 license="custom: PIL"
 homepage="https://python-pillow.org/pillow-perf/"
-changelog="https://github.com/uploadcare/pillow-simd/compare/v5.2.0.post1...v5.3.0.post1"
+changelog="https://github.com/uploadcare/pillow-simd/blob/simd/master/CHANGES.SIMD.rst"
 distfiles="https://github.com/uploadcare/pillow-simd/archive/v${version}.tar.gz"
-checksum=ac135e962d1b335c393e2a31991cae41302cf248f42925a8defba284d2289cec
-conflicts="python-Pillow"
+checksum=9844b83312804a155fbdb5d4239578f4f1861f8a196ab8310992524484053b06
+replaces="python3-Pillow>=0"
+provides="python3-Pillow-${version}_${revision}"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
It's happened again :/

I switched to the `update_pillow_simd` branch, added its template and git committed the changes from the other branch (`update_ueberzug`) that I added but didn't commit. Is this default git behaviour?