### PR TITLE
xbps-src: break out of following cyclic dependencies

### DIFF
--- a/common/xbps-src/libexec/build.sh
+++ b/common/xbps-src/libexec/build.sh
@@ -26,6 +26,12 @@ for f in $XBPS_SHUTILSDIR/*.sh; do
     . $f
 done
 
+last="${XBPS_DEPENDS_CHAIN##*,}"
+case "$XBPS_DEPENDS_CHAIN" in
+    *,$last,*)
+        msg_error "Build-time cyclic dependency$last,${XBPS_DEPENDS_CHAIN##*,$last,} detected.\n"
+esac
+
 setup_pkg "$PKGNAME" $XBPS_CROSS_BUILD
 readonly SOURCEPKG="$sourcepkg"
 

--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -359,7 +359,7 @@ install_pkg_deps() {
         (
         curpkgdepname=$($XBPS_UHELPER_CMD getpkgname "$i" 2>/dev/null)
         setup_pkg $curpkgdepname
-        exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 \
+        exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 XBPS_DEPENDS_CHAIN="$XBPS_DEPENDS_CHAIN, $sourcepkg(host)" \
             $XBPS_LIBEXECDIR/build.sh $sourcepkg $pkg $target $cross_prepare || exit $?
         ) || exit $?
         host_binpkg_deps+=("$i")
@@ -372,7 +372,7 @@ install_pkg_deps() {
 
         curpkgdepname=$($XBPS_UHELPER_CMD getpkgname "$i" 2>/dev/null)
         setup_pkg $curpkgdepname $cross
-        exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 \
+        exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 XBPS_DEPENDS_CHAIN="$XBPS_DEPENDS_CHAIN, $sourcepkg(${cross:-host})" \
             $XBPS_LIBEXECDIR/build.sh $sourcepkg $pkg $target $cross $cross_prepare || exit $?
         ) || exit $?
         binpkg_deps+=("$i")
@@ -390,7 +390,7 @@ install_pkg_deps() {
             fi
         fi
         setup_pkg $curpkgdepname $cross
-        exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 \
+        exec env XBPS_DEPENDENCY=1 XBPS_BINPKG_EXISTS=1 XBPS_DEPENDS_CHAIN="$XBPS_DEPENDS_CHAIN, $sourcepkg(${cross:-host})" \
             $XBPS_LIBEXECDIR/build.sh $sourcepkg $pkg $target $cross $cross_prepare || exit $?
         ) || exit $?
     done


### PR DESCRIPTION
Exit with error instead of looping forever.

Cycles exist when building with XBPS_CHECK_PKGS, and there is no point to resolve cycle in such case. Also useful to find cycle introduced into regular build.