### PR TITLE
gnome-boxes: update to 3.36.2.

### DIFF
--- a/srcpkgs/gnome-boxes/template
+++ b/srcpkgs/gnome-boxes/template
@@ -1,12 +1,10 @@
 # Template file for 'gnome-boxes'
 pkgname=gnome-boxes
-version=3.32.1
+version=3.36.2
 revision=1
 build_helper="gir"
 build_style=meson
-# missing dependency: ovirt
-configure_args="-Dovirt=false"
-hostmakedepends="itstool pkg-config vala glib-devel"
+hostmakedepends="gettext itstool pkg-config vala glib-devel"
 makedepends="clutter-gtk-devel freerdp-devel gtk-vnc-devel libarchive-devel
  libglib-devel libgudev-devel libosinfo-devel libsecret-devel libsoup-devel
  libusb-devel libvirt-glib-devel libxml2-devel spice-gtk-devel spice-protocol
@@ -16,6 +14,6 @@ short_desc="GNOME 3 application to access remote or virtual systems"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Boxes"
-changelog="https://raw.githubusercontent.com/GNOME/gnome-boxes/gnome-3-32/NEWS"
+changelog="https://raw.githubusercontent.com/GNOME/gnome-boxes/gnome-3-36/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=84b2fa1632db0b1fe6e6e691cbe22e5c9880099b23124d96bc45933762ec3a95
+checksum=ea608e95b75b3c5417e23a1cfda2335a7232d2f0b763c7f3d4624a0ad3a71206

--- a/srcpkgs/libvirt-glib/template
+++ b/srcpkgs/libvirt-glib/template
@@ -1,7 +1,7 @@
 # Template file for 'libvirt-glib'
 pkgname=libvirt-glib
-version=2.0.0
-revision=3
+version=3.0.0
+revision=1
 build_helper="gir"
 build_style=gnu-configure
 configure_args="--disable-static $(vopt_enable gir introspection)
@@ -14,7 +14,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://libvirt.org"
 distfiles="http://libvirt.org/sources/glib/${pkgname}-${version}.tar.gz"
-checksum=94e8c410c67501303d3b32ca8ce2c36edf898511ec4de9b7f29cd35d274b3d6a
+checksum=7fff8ca9a2b723dbfd04223b1c7624251c8bf79eb57ec27362a7301b2dd9ebfe
 replaces="libvirt-glib-python>=0"
 
 build_options="gir vala"


### PR DESCRIPTION
needs `libvirt-glib >= 3.0.0`, updated. 