### PR TITLE
build-style/go: allow usage with gccgo compiler

### DIFF
--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -1,9 +1,18 @@
-if [ -z "$archs" ]; then
-	archs="aarch64* armv[567]* i686* x86_64* ppc64le*"
+if [ "${hostmakedepends##*gcc-go-tools*}" ]; then
+	# gc compiler
+	if [ -z "$archs" ]; then
+		archs="aarch64* armv[567]* i686* x86_64* ppc64le*"
+	fi
+	hostmakedepends+=" go"
+	nopie=yes
+else
+	# gccgo compiler
+	if [ "$CROSS_BUILD" ]; then
+		# target compiler to use; otherwise it'll just call gccgo
+		export GCCGO="${XBPS_CROSS_TRIPLET}-gccgo"
+	fi
 fi
-hostmakedepends+=" go"
 nostrip=yes
-nopie=yes
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) export GOARCH=arm64;;


### PR DESCRIPTION
This checks if `gcc-go-tools` have been specified in host deps and if so, use gccgo to build (`gcc-go-tools` conflicts with go).

Also, since gccgo is not a multi-compiler, we need to override `GCCGO` to get cross-builds. The gccgo for target is always installed, as it's a part of our cross-toolchains.

Basically, in summary, the behavior with this patch is:

1) Use `go` by default, always
2) If a template explicitly chooses to install `gcc-go-tools` in `hostmakedepends`, that indicates to the `build-style` that we're to build with gccgo (current behavior: conflicting packages will cause the build to fail)

Since `gcc-go-tools` provides the same regular `go` frontend as the main `go` package, the `build-style` will generally work OOTB, unchanged, and it respects `GOCACHE`, `GOARCH`, `GOOS` and so on. The only differences need to be:

1) No default `archs`; `gccgo` is available everywhere
2) No `nostrip`, since it's using a regular GNU toolchain with GCC backend, so it generates debug symbols same as usual
3) No `nopie`, as our `--enable-default-pie` for GCC applies here
4) The `GCCGO` variable needs to be set to point to the target's compiler, but otherwise `GOARCH` is still respected everywhere else, so it's handled outside the conditional block

## Usage

I have one place where I'd like to use this and that's `PopCorn`. It's a fairly trivial application and has been tested to work well under `gccgo` (I use it for stats reporting on big-endian architectures where the regular compiler doesn't exist and have been for months). To switch, we'd basically just do this:

```
--- a/srcpkgs/PopCorn/template
+++ b/srcpkgs/PopCorn/template
@@ -8,7 +8,7 @@ go_package="${go_import_path}/cmd/popcorn
  ${go_import_path}/cmd/popcornctl
  ${go_import_path}/cmd/statrepo
  ${go_import_path}/cmd/pqueryd"
-hostmakedepends="git"
+hostmakedepends="gcc-go-tools git"
 depends="snooze"
 short_desc="Package statistics system"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
```

With the `build-style` change, that just works.