### PR TITLE
riot-desktop: update to v1.5.15

### DIFF
--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,18 +1,18 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=1.5.7
+version=1.5.15
 revision=1
 archs="i686 x86_64"
 wrksrc="riot-web-${version}"
 conf_files="/etc/${pkgname}/config.json"
-hostmakedepends="git yarn"
+hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl"
 depends="c-ares ffmpeg gtk+3 http-parser libevent libxslt minizip nss re2 snappy"
 short_desc="Glossy Matrix collaboration client, desktop version"
-maintainer="Bendodroid <bendodroid@icloud.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://riot.im"
 distfiles="https://github.com/vector-im/riot-web/archive/v${version}.tar.gz"
-checksum=c11436a2fb77a3b9edc46053c4de6886a4652020e1220780a2c8863edecf5992
+checksum="3d5512f842fa436aef00b1b1f1c5ced4a4f1adc5cc1bcfddbc77573387f9cc42"
 nocross=yes
 nostrip=yes
 shlib_provides="libGLVESv2.so"
@@ -22,15 +22,30 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 pre_build() {
-	vsed -i package.json -e 's|-l --x64|-l --x64 --dir|'
-	yarn install --ignore-scripts
-	cd node_modules/matrix-js-sdk
-	yarn install --ignore-scripts
-	cd ../matrix-react-sdk
-	yarn install --ignore-scripts
+	# This section is borrowed from the Arch PKGBUILD
+	sed -i 's@https://riot.im/download/desktop/update/@null@g' electron_app/riot.im/config.json
+	sed -i 's/"target": "deb"/"target": "dir"/g' package.json
+	yarn install
+
+	# Add the matrix-seshat package (which is needed for search in E2E encrypted
+	# rooms) as well as the electron-build-env package, which gets used later to
+	# rebuild the native libraries against electron’s version of node.
+	# See here for more information:
+	# https://github.com/vector-im/riot-web/blob/develop/docs/native-node-modules.md#adding-seshat-for-search-in-e2e-encrypted-rooms
+	cd electron_app
+	yarn add matrix-seshat
+	yarn add electron-build-env
+	# Finally also enable the event indexing feature in the config.
+	sed -i 's/"features": {/"features": {\n        "feature_event_indexing": "enable",/' riot.im/config.json
 }
 
 do_build() {
+	# This is also borrowed from the Arch PKGBUILD
+	cd electron_app
+	# Recompile matrix-seshat
+	yarn run electron-build-env -- --electron 7 neon build matrix-seshat --release
+	cd ..
+	# Do the actual build
 	yarn build:electron:linux
 }
 


### PR DESCRIPTION
I'm no longer using Void Linux but was approached via Email to upgrade the package, so here it is. I'm marking this as orphaned since I don't plan to update this in the future.
Tested it in a xfce vm and even tray icon worked fine.