### PR TITLE
Build kde applications with python3

### DIFF
--- a/srcpkgs/akonadi-notes/template
+++ b/srcpkgs/akonadi-notes/template
@@ -3,7 +3,7 @@ pkgname=akonadi-notes
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules python qt5-qmake qt5-host-tools
+hostmakedepends="extra-cmake-modules python3 qt5-qmake qt5-host-tools
  gettext kcoreaddons"
 makedepends="kmime-devel akonadi5-devel"
 short_desc="Libraries and daemons to implement notes management in Akonadi"

--- a/srcpkgs/akonadi-search/template
+++ b/srcpkgs/akonadi-search/template
@@ -3,7 +3,7 @@ pkgname=akonadi-search
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python AppStream
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3 AppStream
  gettext kcoreaddons"
 makedepends="akonadi5-devel akonadi-mime-devel xapian-core-devel krunner-devel
  kcmutils-devel kcontacts-devel kcalendarcore-devel"

--- a/srcpkgs/grantleetheme/template
+++ b/srcpkgs/grantleetheme/template
@@ -4,7 +4,7 @@ version=19.12.3
 revision=1
 build_style=cmake
 configure_args="KDE_INSTALL_USE_QT_SYS_PATHS=TRUE"
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons"
 makedepends="grantlee5-devel ki18n-devel kiconthemes-devel knewstuff-devel"
 short_desc="Library for Grantlee theming support"

--- a/srcpkgs/kate5/template
+++ b/srcpkgs/kate5/template
@@ -18,5 +18,5 @@ checksum=f60b52e5a6a78920ac703a458f1eaf0ced02ffcd8b5f2d49de9a48674eeb007c
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-	hostmakedepends+=" kauth-devel kconfig-devel kcoreaddons-devel kpackage-devel kdoctools python qt5-host-tools qt5-qmake"
+	hostmakedepends+=" kauth-devel kconfig-devel kcoreaddons-devel kpackage-devel kdoctools python3 qt5-host-tools qt5-qmake"
 fi

--- a/srcpkgs/kcachegrind/template
+++ b/srcpkgs/kcachegrind/template
@@ -1,12 +1,12 @@
 # Template file for 'kcachegrind'
 pkgname=kcachegrind
 version=19.12.3
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kcoreaddons kdoctools
  pkg-config qt5-host-tools qt5-qmake"
 makedepends="kparts-devel qt5-devel"
-depends="python hicolor-icon-theme"
+depends="python3 hicolor-icon-theme"
 short_desc="Visualization of Performance Profiling Data"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-2.0-only, GFDL-1.2-only"

--- a/srcpkgs/kcalutils/template
+++ b/srcpkgs/kcalutils/template
@@ -3,7 +3,7 @@ pkgname=kcalutils
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons kconfig"
 makedepends="kcalendarcore-devel kidentitymanagement-devel"
 short_desc="The KDE calendar utility library"

--- a/srcpkgs/kdepim-apps-libs/template
+++ b/srcpkgs/kdepim-apps-libs/template
@@ -3,7 +3,7 @@ pkgname=kdepim-apps-libs
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons kconfig"
 makedepends="grantlee5-devel kcontacts-devel akonadi-contacts-devel libkleo-devel
  grantleetheme-devel libkdepim-devel pimcommon-devel"

--- a/srcpkgs/khelpcenter/template
+++ b/srcpkgs/khelpcenter/template
@@ -14,7 +14,7 @@ distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.
 checksum=526c89e46cace9e8afb4e748f9bbf0d105472a4cc4a6d8bb821e8b9b88ab0f73
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kconfig kdoctools python qt5-host-tools qt5-qmake"
+	hostmakedepends+=" kconfig kdoctools python3 qt5-host-tools qt5-qmake"
 	configure_args+=" -DXAPIAN_LIBRARIES=${XBPS_CROSS_BASE}/usr/lib/libxapian.so
 	 -DXAPIAN_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include -DXAPIAN_FOUND=TRUE"
 fi

--- a/srcpkgs/kimap/template
+++ b/srcpkgs/kimap/template
@@ -3,7 +3,7 @@ pkgname=kimap
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons"
 makedepends="kio-devel kmime-devel"
 short_desc="Job-based API for interacting with IMAP servers"

--- a/srcpkgs/kldap/template
+++ b/srcpkgs/kldap/template
@@ -3,7 +3,7 @@ pkgname=kldap
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons kdoctools"
 makedepends="kio-devel"
 short_desc="LDAP access API for KDE"

--- a/srcpkgs/kmail/template
+++ b/srcpkgs/kmail/template
@@ -3,7 +3,7 @@ pkgname=kmail
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules python qt5-host-tools qt5-qmake
+hostmakedepends="extra-cmake-modules python3 qt5-host-tools qt5-qmake
  gettext kdoctools kconfig kcoreaddons"
 makedepends="kcalutils-devel knotifyconfig-devel kontactinterface-devel
  kparts-devel ktnef-devel libkleo-devel libksieve-devel mailcommon-devel

--- a/srcpkgs/kmailtransport/template
+++ b/srcpkgs/kmailtransport/template
@@ -3,7 +3,7 @@ pkgname=kmailtransport
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons kconfig"
 makedepends="akonadi-mime-devel kcmutils-devel ksmtp-devel libkgapi-devel"
 short_desc="Mail Transport Service"

--- a/srcpkgs/kontactinterface/template
+++ b/srcpkgs/kontactinterface/template
@@ -3,7 +3,7 @@ pkgname=kontactinterface
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons"
 makedepends="kparts-devel"
 short_desc="Kontact Plugin Interface Library"

--- a/srcpkgs/ksmtp/template
+++ b/srcpkgs/ksmtp/template
@@ -3,7 +3,7 @@ pkgname=ksmtp
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons"
 makedepends="kmime-devel kio-devel"
 short_desc="Job-based library to send email through an SMTP server"

--- a/srcpkgs/ktnef/template
+++ b/srcpkgs/ktnef/template
@@ -3,7 +3,7 @@ pkgname=ktnef
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons"
 makedepends="kcalutils-devel kcontacts-devel"
 short_desc="API for handling TNEF data"

--- a/srcpkgs/libkleo/template
+++ b/srcpkgs/libkleo/template
@@ -3,7 +3,7 @@ pkgname=libkleo
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules python qt5-qmake qt5-host-tools
+hostmakedepends="extra-cmake-modules python3 qt5-qmake qt5-host-tools
  gettext kcoreaddons"
 makedepends="kitemmodels-devel kpimtextedit-devel gpgmeqt-devel gpgmepp-devel"
 short_desc="KDE PIM cryptographic library"

--- a/srcpkgs/libksieve/template
+++ b/srcpkgs/libksieve/template
@@ -3,7 +3,7 @@ pkgname=libksieve
 version=19.12.3
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools python3
  gettext kcoreaddons kdoctools kconfig"
 makedepends="kidentitymanagement-devel kmailtransport-devel pimcommon-devel
  qt5-webengine-devel qt5-webchannel-devel qt5-location-devel"

--- a/srcpkgs/mailcommon/template
+++ b/srcpkgs/mailcommon/template
@@ -4,7 +4,7 @@ version=19.12.3
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules kconfig libxslt qt5-qmake
- gettext qt5-host-tools python kgendesignerplugin"
+ gettext qt5-host-tools python3 kgendesignerplugin"
 makedepends="mailimporter-devel messagelib-devel kdesignerplugin-devel
  pimcommon-devel libkleo-devel qt5-multimedia-devel kcontacts-devel"
 short_desc="KDE PIM library providing support for mail applications"

--- a/srcpkgs/spectacle/template
+++ b/srcpkgs/spectacle/template
@@ -4,7 +4,7 @@ version=19.12.3
 revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules kdoctools python qt5-host-tools qt5-qmake
+hostmakedepends="extra-cmake-modules kdoctools python3 qt5-host-tools qt5-qmake
  gettext kcoreaddons"
 makedepends="kdeclarative-devel libkipi5-devel xcb-util-image-devel xcb-util-cursor-devel
  kwayland-devel purpose-devel knewstuff-devel"


### PR DESCRIPTION
Packages build with python 2 and 3 seem to differ only with generated ids in html help, therefore ok to switch.

Left usage of python2 in kig, because it cannot be built with version 3 yet.

@Johnnynator, comments?