### PR TITLE
perl-PerlIO-utf8-strict: rename to perl-PerlIO-utf8_strict

### DIFF
--- a/srcpkgs/biber/template
+++ b/srcpkgs/biber/template
@@ -1,7 +1,7 @@
 # Template file for 'biber'
 pkgname=biber
 version=2.14
-revision=2
+revision=3
 archs=noarch
 wrksrc="${pkgname}-${version}"
 build_style=perl-ModuleBuild
@@ -32,7 +32,7 @@ makedepends="
 	perl-Mozilla-CA
 	perl-namespace-autoclean
 	perl-Parse-RecDescent
-	perl-PerlIO-utf8-strict
+	perl-PerlIO-utf8_strict
 	perl-Regexp-Common
 	perl-Sort-Key
 	perl-Text-BibTeX

--- a/srcpkgs/perl-Mixin-Linewise/template
+++ b/srcpkgs/perl-Mixin-Linewise/template
@@ -1,11 +1,11 @@
 # Template file for 'perl-Mixin-Linewise'
 pkgname=perl-Mixin-Linewise
 version=0.108
-revision=1
+revision=2
 archs=noarch
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
-hostmakedepends="perl perl-PerlIO-utf8-strict perl-Sub-Exporter"
+hostmakedepends="perl perl-PerlIO-utf8_strict perl-Sub-Exporter"
 makedepends="$hostmakedepends"
 depends="$makedepends"
 short_desc="Mixin::Linewise - write your linewise code for handles; this does the rest"

--- a/srcpkgs/perl-PerlIO-utf8-strict/update
+++ b/srcpkgs/perl-PerlIO-utf8-strict/update
@@ -1,1 +1,0 @@
-pkgname=perl-PerlIO-utf8_strict

--- a/srcpkgs/perl-PerlIO-utf8_strict/template
+++ b/srcpkgs/perl-PerlIO-utf8_strict/template
@@ -1,8 +1,8 @@
-# Template file for 'perl-PerlIO-utf8-strict'
-pkgname=perl-PerlIO-utf8-strict
+# Template file for 'perl-PerlIO-utf8_strict'
+pkgname=perl-PerlIO-utf8_strict
 version=0.007
 revision=1
-wrksrc="PerlIO-utf8_strict-${version}"
+wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl perl-Test-Exception"
@@ -11,5 +11,7 @@ short_desc="PerlIO::utf8_strict - Fast and correct UTF-8 IO"
 maintainer="svenper <svenper@tuta.io>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/PerlIO-utf8_strict"
-distfiles="${CPAN_SITE}/PerlIO/PerlIO-utf8_strict-${version}.tar.gz"
+distfiles="${CPAN_SITE}/PerlIO/${pkgname/perl-/}-${version}.tar.gz"
 checksum=83a33f2fe046cb3ad6afc80790635a423e2c7c6854afacc6998cd46951cc81cb
+provides="perl-PerlIO-utf8-strict-${version}_${revision}"
+replaces="perl-PerlIO-utf8-strict>=0"


### PR DESCRIPTION
(final dash to underscore)
since #14005 was fixed