### PR TITLE
teamspeak3: update to 3.5.2.

### DIFF
--- a/srcpkgs/teamspeak3/template
+++ b/srcpkgs/teamspeak3/template
@@ -1,11 +1,11 @@
 # Template file for 'teamspeak3'
 pkgname=teamspeak3
-version=3.5.0
+version=3.5.2
 revision=1
 archs="i686 x86_64"
 wrksrc=teamspeak3
 create_wrksrc=yes
-makedepends="tar"
+hostmakedepends="tar"
 depends="glib bash grep freetype nss libXcomposite fontconfig glibc
  libxslt dbus-libs alsa-lib libXi libXcursor libXtst libXScrnSaver pciutils"
 short_desc="Popular proprietary voice chat for gaming"
@@ -21,11 +21,11 @@ noverifyrdeps=yes
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_pkg="TeamSpeak3-Client-linux_amd64-${version}"
 	distfiles="https://files.teamspeak-services.com/releases/client/${version}/${_pkg}.run"
-	checksum=17d53f116f38519d41749d5b07059e1791a533d0bcee052052b0b6b41f015912
+	checksum=d739fa78b41ef7b1423771ca237804981ffc7f14c4e620769cfa3fbc538aece8
 elif [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	_pkg="TeamSpeak3-Client-linux_x86-${version}"
 	distfiles="https://files.teamspeak-services.com/releases/client/${version}/${_pkg}.run"
-	checksum=6ed3a4255c4785437668748b5a8f39895678cd57133150c33302a94421c5ffeb
+	checksum=209375141ea0d0fc1d6dc7612cb621ba0df946e033a3b1140f3e8a5c8938d566
 else
 	broken="No known upstream client for this architecture"
 fi


### PR DESCRIPTION
32-bit might be failing to build. Had it happen once then build the second time(No idea why), but since this isn't a repo package i decided to push anyway.