### PR TITLE
neomutt: update to 20200417.

### DIFF
--- a/srcpkgs/neomutt/patches/00-bugfix-20200417.patch
+++ b/srcpkgs/neomutt/patches/00-bugfix-20200417.patch
@@ -1,0 +1,39 @@
+VOID PACKAGING NOTE: This was added to our release at upstream's request.
+Upstream released, found a bug, fixed it, and reached out to their downstream
+packagers to get this fix included.
+
+This is instead of breaking downstream packagers by moving the tag. We thank
+neomutt upstream for their attention to packaging this software.
+
+commit 9e7537caddb9c6adc720bb3322a7512cf51ab025 (HEAD -> master, origin/master, origin/HEAD)
+Author: Richard Russon <rich@flatcap.org>
+Date:   Fri Apr 17 15:36:58 2020 +0100
+
+    ensure OP_NULL is always first
+
+    A recent refactoring altered the ordering of the OPs when autocrypt was
+    enabled.  This mean that OP_NULL wasn't 0 any more.
+
+    Fixes: #2268
+
+diff --git a/opcodes.h b/opcodes.h
+index 701df71f8..3984d3a03 100644
+--- neomutt-20200417/opcodes.h
++++ neomutt-20200417/opcodes.h
+@@ -37,7 +37,6 @@
+ #endif
+
+ #define OPS_CORE(_fmt) \
+-  _fmt(OP_NULL,                           N_("null operation")) \
+   _fmt(OP_ATTACH_COLLAPSE,                N_("toggle display of subparts")) \
+   _fmt(OP_ATTACH_VIEW_MAILCAP,            N_("force viewing of attachment using mailcap")) \
+   _fmt(OP_ATTACH_VIEW_TEXT,               N_("view attachment as text")) \
+@@ -317,6 +316,7 @@
+   _fmt(OP_COMPOSE_SMIME_MENU,             N_("show S/MIME options")) \
+
+ #define OPS(_fmt) \
++  _fmt(OP_NULL,                           N_("null operation")) \
+   OPS_AUTOCRYPT(_fmt) \
+   OPS_CORE(_fmt) \
+   OPS_SIDEBAR(_fmt) \
+

--- a/srcpkgs/neomutt/template
+++ b/srcpkgs/neomutt/template
@@ -1,23 +1,29 @@
 # Template file for 'neomutt'
 pkgname=neomutt
-version=20200320
+version=20200417
 revision=1
 wrksrc="neomutt-${version}"
+create_wrksrc=true
+build_wrksrc="$wrksrc"
 build_style=configure
-configure_args="--ssl --gpgme --notmuch --gdbm --lua --sasl --zlib"
+configure_args="--ssl --gpgme --notmuch --gdbm --lua --sasl --zlib --tdb
+ --rocksdb --testing"
 make_check_target=test
 conf_files="/etc/neomuttrc"
 # neomutt needs either w3m/lynx/elinks to build manual.html
 hostmakedepends="docbook-xsl gettext libxslt perl tcl w3m"
 makedepends="aspell-devel gdbm-devel gettext-devel gpgme-devel libidn-devel
+ rocksdb-devel tdb-devel
  libnotmuch-devel libressl-devel libsasl-devel lua-devel zlib-devel"
 depends="mime-types"
 short_desc="Mutt with misc fixes and feature patches"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://neomutt.org/"
-distfiles="https://github.com/neomutt/neomutt/archive/${version}.tar.gz"
-checksum=69daf2e0633dee7e8bdba74ab714adfa70e8f078028b56d612228c2aa836aafa
+distfiles="https://github.com/neomutt/neomutt/archive/${version}.tar.gz
+ https://github.com/neomutt/neomutt-test-files/archive/1ee274e9ae1330fb901eb7b8275b3079d7869222.tar.gz"
+checksum="6ed358053ae17694b580f3b5b13eec9f00f5a7320e76fae6fba767607c40cc48
+ f7aeb9a70b213b1bbcdba629745fd345bde825c467453912f5cfd7f1d75418f5"
 
 # fix:
 if [ "${XBPS_CROSS_BASE}" ]; then
@@ -36,6 +42,19 @@ post_install() {
 	vsconf contrib/gpg.rc Muttrc.gpg.dist
 }
 
+pre_check() {
+	(
+	 cd ${wrksrc}/neomutt-test-files-1ee274e9ae1330fb901eb7b8275b3079d7869222/
+	 ./setup.sh
+	)
+	export NEOMUTT_TEST_DIR=${wrksrc}/neomutt-test-files-1ee274e9ae1330fb901eb7b8275b3079d7869222
+}
+
+post_check() {
+	# This is a file chmodded to 311 and can't be removed normally
+	chmod 777 ${wrksrc}/neomutt-test-files-1ee274e9ae1330fb901eb7b8275b3079d7869222/maildir/damson
+}
+
 # REMARKS:
 # Conf file is in a --sysconfdir=/etc/$pkgname/Muttrc and then alternatives to
 # /etc/Muttrc. In addition, a dependency on mime-types is broken by having
@@ -51,3 +70,8 @@ post_install() {
 # /etc/neomuttrc now exists, and there are no conflicts with regular mutt.
 # Due to this, an install.msg was added and all alternatives were removed.
 # Cross compiling was fixed in 20180323
+# 20200417 had some build changes, none referenced explicitly by our templates.
+# It also added a need for a special directory for unit tests, refered here by
+# commit hash (due to a lack of versioning)
+# Currently a shebang for keybase is rewritten to python2. That should be
+# fixed.


### PR DESCRIPTION
This does not work, 9 unit tests fail. Upstream tracking issue: https://github.com/neomutt/neomutt/issues/2273