### PR TITLE
New package: rpi-imager-1.4

### DIFF
--- a/srcpkgs/rpi-imager/template
+++ b/srcpkgs/rpi-imager/template
@@ -1,0 +1,14 @@
+# Template file for 'rpi-imager'
+pkgname=rpi-imager
+version=1.4
+revision=1
+build_style=cmake
+hostmakedepends="qt5-devel"
+makedepends="qt5-devel qt5-declarative-devel qt5-svg-devel qt5-tools-devel libcurl-devel libarchive-devel util-linux"
+depends="qt5-quickcontrols2 qt5-svg util-linux"
+short_desc="Raspberry Pi Imaging Utility"
+maintainer="Adam Gausmann <agausmann@fastmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/raspberrypi/rpi-imager"
+distfiles="https://github.com/raspberrypi/rpi-imager/archive/v${version}.tar.gz"
+checksum="f42359fca67a61fa37f0dfd0167749b7d758263b8501c07473d416542d78e004"


### PR DESCRIPTION
Raspberry Pi Imager, the [official tool](https://www.raspberrypi.org/blog/raspberry-pi-imager-imaging-utility/) for flashing Raspberry Pi images.

![2020-04-18-054646_686x440_scrot](https://user-images.githubusercontent.com/6611767/79635687-ee55b480-8137-11ea-9bd7-0bbe8809408b.png)

