### PR TITLE
make: inject make-4.3 fnmatch and glob

### DIFF
--- a/srcpkgs/make/template
+++ b/srcpkgs/make/template
@@ -4,17 +4,29 @@
 pkgname=make
 reverts="4.3_1"
 version=4.2.1
-revision=7
+revision=8
 bootstrap=yes
 build_style=gnu-configure
 configure_args="$(vopt_with guile)"
 hostmakedepends="$(vopt_if guile pkg-config)"
 makedepends="$(vopt_if guile 'gc-devel guile-devel')"
-short_desc="The GNU make system"
+short_desc="GNU make system"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/make"
-distfiles="${GNU_SITE}/make/${pkgname}-${version}.tar.bz2"
-checksum=d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589
+distfiles="${GNU_SITE}/make/${pkgname}-${version}.tar.bz2
+ ${GNU_SITE}/make/${pkgname}-4.3.tar.lz"
+checksum="d6e262bf3601b42d2b1e4ef8310029e1dcf20083c5446b4b7aa67081fdffc589
+ de1a441c4edf952521db30bfca80baae86a0ff1acd0a00402999344f04c45e82"
+skip_extraction="make-4.3.tar.lz"
 build_options=guile
 patch_args="-Np1"
+
+pre_configure() {
+	bsdtar xvpf $XBPS_SRCDISTDIR/$pkgname-$version/make-4.3.tar.lz \
+		make-4.3/lib/{fnmatch,glob}.*
+	cp -p make-4.3/lib/fnmatch.* glob/
+	cp -p make-4.3/lib/glob.* glob/
+	mv -v glob/fnmatch{.in,}.h
+	mv -v glob/glob{.in,}.h
+}


### PR DESCRIPTION
Use the faster and fixed(?) fnmatch and glob
implementations found in the make-4.3 archive.

Solves: #21089