### PR TITLE
New package: font-JetBrainsMono-ttf-1.0.5

### DIFF
--- a/srcpkgs/font-JetBrainsMono-ttf/template
+++ b/srcpkgs/font-JetBrainsMono-ttf/template
@@ -1,0 +1,20 @@
+# Template file for 'font-JetBrainsMono-ttf'
+pkgname=font-JetBrainsMono-ttf
+version=1.0.5
+revision=1
+archs=noarch
+wrksrc="JetBrainsMono-${version}"
+depends="font-util xbps-triggers"
+short_desc="Typeface for developers with code-specific ligatures"
+maintainer="maciozo <maciozo@maciozo.com>"
+license="Apache-2.0"
+homepage="https://www.jetbrains.com/lp/mono/"
+distfiles="https://github.com/JetBrains/JetBrainsMono/archive/v${version}.tar.gz"
+checksum=e902b830d6d3c2054493b0b1fe64d1d88600eda61794d9aa1d3ebb12ec9a5307
+
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir $font_dirs
+	vcopy ttf/ $font_dirs
+}


### PR DESCRIPTION
This is the font that is bundled in the 2020 versions of PyCharm (and probably other JetBrains IDEs). It's pretty cool :)

Is it alright that I've used vcopy instead of vinstall? I was just lazy and didn't want to manually add every ttf file.