### PR TITLE
dnsmap: update to 0.35.

### DIFF
--- a/srcpkgs/dnsmap/template
+++ b/srcpkgs/dnsmap/template
@@ -1,16 +1,17 @@
 # Template file for 'dnsmap'
 pkgname=dnsmap
-version=0.30
-revision=3
-build_style=gnu-makefile
-make_install_args="BINDIR=/usr/bin"
+version=0.35
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf automake"
 short_desc="Passive DNS network mapper a.k.a. subdomain bruteforcer"
 maintainer="Philipp Hirsch <itself@hanspolo.net>"
-license="GPL-2"
-homepage="https://dnsmap.googlecode.com"
-distfiles="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/dnsmap/${pkgname}-${version}.tar.gz"
-checksum=fcf03a7b269b51121920ac49f7d450241306cfff23c76f3da94b03792f6becbc
+license="GPL-2.0-or-later"
+homepage="https://github.com/resurrecting-open-source-projects/dnsmap"
+changelog="https://raw.githubusercontent.com/resurrecting-open-source-projects/dnsmap/master/ChangeLog"
+distfiles="https://github.com/resurrecting-open-source-projects/dnsmap/archive/${version}.tar.gz"
+checksum=6c8d28e461530721ed19314a6788f756a46c98356b5d66fa8b54294778c1f193
 
-post_extract() {
-	sed -i '/CC.*-o/s/$/ $(LDFLAGS)/' Makefile
+pre_configure() {
+	./autogen.sh
 }


### PR DESCRIPTION
dnsmap has been resurrected within the https://github.com/resurrecting-open-source-projects
github-organization, so use this as upstream now.