### PR TITLE
rpi-kernel: update to 4.19.115.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="e2efb9193948e20cd6e017a6331354b4028bf398"
+_githash="b13fc60b529fe9e4fee4a7a5caf73d582003abfa"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.114
+version=4.19.115
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=223d8f71b2d94a75d20d1a0cf437ee155a2bd1ae43282d589484873f65a3c0d6
+checksum=c0af88190562f9b08c2658a4cdca95ec592efc4a6146b9f21fbb90444231942a
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.