### PR TITLE
Make python3 default in XBPS environment and hooks

### DIFF
--- a/common/environment/setup/python.sh
+++ b/common/environment/setup/python.sh
@@ -2,8 +2,8 @@
 # Useful variables for determining Python version and paths.
 #
 
-# set version 2 as the default Python
-python_version="2"
+# set version 3 as the default Python
+python_version="3"
 
 py2_ver="2.7"
 py2_lib="/usr/lib/python${py2_ver}"

--- a/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
+++ b/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
@@ -266,7 +266,7 @@ _EOF
 	fi
 
 	if [ -n "${pycompile_dirs}" -o -n "${pycompile_module}" ]; then
-		echo "export pycompile_version=\"${pycompile_version:=2.7}\"" >>$tmpf
+		echo "export pycompile_version=\"${pycompile_version:=3.8}\"" >>$tmpf
 		if [ -n "${pycompile_dirs}" ]; then
 			echo "export pycompile_dirs=\"${pycompile_dirs}\"" >>$tmpf
 		fi

--- a/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
+++ b/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
@@ -4,7 +4,7 @@
 hook() {
 	local pyver= shebang= off=
 
-	: ${pyver:=2}
+	: ${pyver:=3}
 
 	if [ -d ${PKGDESTDIR}/usr/lib/python* ]; then
 		pyver="$(find ${PKGDESTDIR}/usr/lib/python* -prune -type d | grep -o '[[:digit:]]\.[[:digit:]]$')"


### PR DESCRIPTION
The `03-rewrite-python-shebang.sh` hook assumes `python2` by default, overriding only if `python_version` or `pycompile_version` are set, or the package installs some modules in `/usr/lib/python*`.

Not all packages that install Python scripts set these variables or install modules, so the shebang is forced to `python2` by default. Because `python2` is EOL, I think it is sensible to assume these packages are doing the right thing and targeting `python3` instead.