### PR TITLE
New package: 66-boot-0.1.2.1

### DIFF
--- a/srcpkgs/66-boot/INSTALL
+++ b/srcpkgs/66-boot/INSTALL
@@ -1,0 +1,10 @@
+if [ "$UPDATE" = "no" ]; then
+	case "${ACTION}" in
+	post)
+		66-tree -n boot
+		66-enable -t boot boot
+		66-tree -ncE default
+		66-enable -t default tty@tty1 tty@tty2 tty@tty3 tty@tty4
+		;;
+	esac
+fi

--- a/srcpkgs/66-boot/INSTALL.msg
+++ b/srcpkgs/66-boot/INSTALL.msg
@@ -1,0 +1,3 @@
+To boot with 66, simply add the argument `init=/usr/bin/66-bootstart' to your kernel commandline.
+
+The available service files are packaged in `66-services'.

--- a/srcpkgs/66-boot/REMOVE
+++ b/srcpkgs/66-boot/REMOVE
@@ -1,0 +1,6 @@
+case "${ACTION}" in
+	post)
+		66-tree -R boot
+		66-tree -R default
+		;;
+esac

--- a/srcpkgs/66-boot/files/66-bootstart
+++ b/srcpkgs/66-boot/files/66-bootstart
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+66-boot -b "Booting with 66-boot..." -m /run

--- a/srcpkgs/66-boot/files/tty@
+++ b/srcpkgs/66-boot/files/tty@
@@ -1,0 +1,12 @@
+[main]
+@type = classic
+@description = "Launch @I"
+@user = ( root )
+@options = ( env )
+
+[start]
+@build = auto
+@execute = ( execl-cmdline -s { agetty ${cmd_args} @I } )
+
+[environment]
+cmd_args=!-J 38400

--- a/srcpkgs/66-boot/template
+++ b/srcpkgs/66-boot/template
@@ -1,0 +1,24 @@
+# Template file for '66-boot'
+pkgname=66-boot
+_realpkgname=boot-66serv
+version=0.1.2.1
+revision=1
+archs="noarch"
+wrksrc=${_realpkgname}-v${version}
+build_style=gnu-configure
+makedepends="file"
+depends="s6 s6-rc s6-linux-utils s6-portable-utils 66 66-tools"
+short_desc="Stage 1 boot for 66"
+maintainer="Iskander Zemmouri <iskander.zemmouri@mailbox.org>"
+license="ISC"
+homepage="https://framagit.org/Obarun/boot-66serv"
+distfiles="https://framagit.org/Obarun/${_realpkgname}/-/archive/v${version}/${_realpkgname}-v${version}.tar.gz"
+checksum=508fb91de713664ba5244f5d50a9cde106ce03be63dad24e03bfa813f40af2ea
+conf_files="/etc/66/*.conf
+ /etc/66/rc.local"
+
+post_install() {
+	vinstall ${FILESDIR}/tty@ 644 usr/share/66/service/
+	vbin ${FILESDIR}/66-bootstart
+	vlicense LICENSE
+}


### PR DESCRIPTION
66-boot packages obarun's boot-66serv, which, as its author puts it, is a portable set of 66 services that can boot unix machines successfully. The packaging just helps with transitioning from runit to s6/66. The package in itself does not replace any of /bin/init, /bin/reboot, /bin/poweroff, etc... It merely installs another shell script that servces as init at /bin/66-bootstart which can be used with an alternative init=/bin/66-bootstart kernel command line argument. The user is left with the responsability to organize its machine as he sees fit and should find the shutdown, reboot and halt scripts in the /etc/66/ directory. Symbolic links to those scripts could be added to the package's INSTALL.
66-boot doesn't offer any service frontend files either (with the exception of tty@ which is necessary and the boot bundle directory which 66-boot's init binary (which is called by the 66-bootstart script) uses.
Another package named 66-services should package a compilation of possible 66 frontend service files for most daemons, as it seems rather difficult to put each daemon's frontend file in its corresponding package.
