### PR TITLE
New package: ddccontrol-0.4.4

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3960,3 +3960,4 @@ libvips-cpp.so.42 libvips-8.9.2_1
 libselinux.so.1 libselinux-3.0_1
 libsepol.so.1 libsepol-3.0_1
 libfrrcares.so.0 libfrr-7.3.1_1
+libddccontrol.so.0 ddccontrol-0.4.4_1

--- a/srcpkgs/ddccontrol-db/template
+++ b/srcpkgs/ddccontrol-db/template
@@ -1,0 +1,17 @@
+# Template file for 'ddccontrol-db'
+pkgname=ddccontrol-db
+version=20190825
+revision=1
+build_style=gnu-configure
+hostmakedepends="automake intltool libtool gettext-devel"
+makedepends="gettext-devel"
+short_desc="Database of monitor descriptors, used by ddccontrol"
+maintainer="zhengqunkoo <root@zhengqunkoo.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/ddccontrol/ddccontrol-db"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=e36a4eea37b35dfd03acb1fecd31fda686f1de17e0aab84a71df241b6df4d857
+
+pre_configure() {
+	./autogen.sh
+}

--- a/srcpkgs/ddccontrol/template
+++ b/srcpkgs/ddccontrol/template
@@ -1,0 +1,19 @@
+# Template file for 'ddccontrol'
+pkgname=ddccontrol
+version=0.4.4
+revision=1
+build_style=gnu-configure
+configure_args="--disable-gnome --sysconfdir=/etc --libexecdir=/usr/lib"
+hostmakedepends="automake intltool i2c-tools libtool tar"
+makedepends="gettext-devel libxml2-devel pciutils-devel"
+depends="ddccontrol-db"
+short_desc="Control monitor parameters, like brightness, contrast, RGB color levels"
+maintainer="zhengqunkoo <root@zhengqunkoo.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/ddccontrol/ddccontrol"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=aafbb16ac4f4edfe3fcc5feec1eb5729aaf86e3b0f31f9d707ba1406bb404817
+
+pre_configure() {
+	./autogen.sh
+}


### PR DESCRIPTION
Making of `gddccontrol` is disabled by `--disable-gnome`.