### PR TITLE
chromium: update to 81.0.4044.113.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=81.0.4044.92
+version=81.0.4044.113
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=e2b8dcb8aa9249b00c5f2cef5e755152a249b891bd38d7a0eb814375594ae8c5
+checksum=e3ee96e54bf085804dea671f8a8f29086aa2f43d5928470a2908c1c13375e72a
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=81.0.4044.92
+version=81.0.4044.113
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=a2cf3fd07a66330b189724cdcb4549ddac72705fba6adb33020bc6444efb1a44
+checksum=27cce807a91919211821c4d25be5be8ce48d362166615d4779e886ea0eef5d43
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
- Built for x86_64 and x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine.