### PR TITLE
wireshark-gtk: remove package

### DIFF
--- a/srcpkgs/wireshark-gtk
+++ b/srcpkgs/wireshark-gtk
@@ -1,1 +1,0 @@
-wireshark

--- a/srcpkgs/wireshark/INSTALL.msg
+++ b/srcpkgs/wireshark/INSTALL.msg
@@ -1,6 +1,3 @@
-The wireshark GTK interface is no longer provided by Void Linux,
-and it will be fully removed from the repos on 2019-06-09.
-
 To capture traffic, add your user to the 'wireshark' group.
 
     # usermod -aG wireshark <username>

--- a/srcpkgs/wireshark/template
+++ b/srcpkgs/wireshark/template
@@ -60,13 +60,6 @@ libwireshark-devel_package() {
 	}
 }
 
-wireshark-gtk_package() {
-	build_style=meta
-	archs=noarch
-	depends="${sourcepkg}>=${version}_${revision}"
-	short_desc+=" - GTK+ frontend (removed package)"
-}
-
 wireshark-qt_package() {
 	depends="${sourcepkg}>=${version}_${revision} desktop-file-utils"
 	short_desc+=" - Qt frontend"


### PR DESCRIPTION
Slated for removal in 2019.

Fixes #20308 