### PR TITLE
WIP: m4: Add texinfo dependency and fix xlint

### DIFF
--- a/srcpkgs/m4/template
+++ b/srcpkgs/m4/template
@@ -2,17 +2,18 @@
 pkgname=m4
 version=1.4.18
 revision=2
-patch_args="-Np1"
 bootstrap=yes
-replaces="chroot-m4>=0"
 build_style=gnu-configure
 configure_args="--enable-changeword --enable-threads"
+hostmakedepends="texinfo" # makeinfo
 short_desc="GNU version of UNIX m4 macro language processor"
-homepage="https://www.gnu.org/software/m4/"
-license="GPL-3.0-or-later"
 maintainer="Enno Boland <gottox@voidlinux.org>"
+license="GPL-3.0-or-later"
+homepage="https://www.gnu.org/software/m4/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=f2c1e86ca0a404ff281631bdc8377638992744b175afb806e25871a24a934e07
+replaces="chroot-m4>=0"
+patch_args="-Np1"
 
 pre_check() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
```
make[2]: Entering directory '/builddir/m4-1.4.18/doc'
  MAKEINFO m4.info
/builddir/m4-1.4.18/build-aux/missing: line 81: makeinfo: command not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <http://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <http://www.gnu.org/software/make/>
make[2]: *** [Makefile:1535: m4.info] Error 127
make[2]: Leaving directory '/builddir/m4-1.4.18/doc'
make[1]: *** [Makefile:1572: install-recursive] Error 1
make[1]: Leaving directory '/builddir/m4-1.4.18'
make: *** [Makefile:1867: install] Error 2
```