### PR TITLE
Manual.md: clean up vman

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -281,11 +281,11 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	converts gzipped (.gz) and bzipped (.bz2) manpages into plaintext.
 	Example mappings:
 
-	`foo.1` -> `${DESTDIR}/usr/share/man/man1/foo.1`
-	`foo.fr.1` -> `${DESTDIR}/usr/share/man/fr/man1/foo.1`
-	`foo.1p` -> `${DESTDIR}/usr/share/man/man1/foo.1p`
-	`foo.1.gz` -> `${DESTDIR}/usr/share/man/man1/foo.1`
-	`foo.1.bz2` -> `${DESTDIR}/usr/share/man/man1/foo.1`
+	`foo.1` -> `${DESTDIR}/usr/share/man/man1/foo.1`  
+	`foo.fr.1` -> `${DESTDIR}/usr/share/man/fr/man1/foo.1`  
+	`foo.1p` -> `${DESTDIR}/usr/share/man/man1/foo.1p`  
+	`foo.1.gz` -> `${DESTDIR}/usr/share/man/man1/foo.1`  
+	`foo.1.bz2` -> `${DESTDIR}/usr/share/man/man1/foo.1`  
 
 - *vdoc()* `vdoc <file> [<name>]`
 


### PR DESCRIPTION
each example on its own row (markdown: two spaces at the end of the row)