### PR TITLE
Manual.md: fix bullets in Development packages

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1396,14 +1396,14 @@ the appropriate `development` packages as dependencies.
 Development packages for the C and C++ languages usually `vmove` the
 following subset of files from the main package:
 
-    * Header files `usr/include`
-    * Static libraries `usr/lib/*.a`
-    * Shared library symbolic links `usr/lib/*.so`
-    * Cmake rules `usr/lib/cmake` `usr/share/cmake`
-    * Package config files `usr/lib/pkgconfig` `usr/share/pkgconfig`
-    * Autoconf macros `usr/share/aclocal`
-    * Gobject introspection XML files `usr/share/gir-1.0`
-    * Vala bindings `usr/share/vala`
+* Header files `usr/include`
+* Static libraries `usr/lib/*.a`
+* Shared library symbolic links `usr/lib/*.so`
+* Cmake rules `usr/lib/cmake` `usr/share/cmake`
+* Package config files `usr/lib/pkgconfig` `usr/share/pkgconfig`
+* Autoconf macros `usr/share/aclocal`
+* Gobject introspection XML files `usr/share/gir-1.0`
+* Vala bindings `usr/share/vala`
 
 <a id="pkgs_data"></a>
 ### Data packages


### PR DESCRIPTION
line-initial space made the markdown think it was code