### PR TITLE
ccl: update to 1.12.

### DIFF
--- a/srcpkgs/ccl/template
+++ b/srcpkgs/ccl/template
@@ -1,25 +1,36 @@
+# Template file for 'ccl'
 pkgname=ccl
-version=1.11.5
-revision=2
-wrksrc="ccl"
+version=1.12
+revision=1
 archs="i686* x86_64*"
-build_style=gnu-makefile
+create_wrksrc=yes
 hostmakedepends="m4"
 short_desc="Clozure Common Lisp interpreter and compiler"
-maintainer="Ankur Kothari <ankz.kothari@gmail.com>"
+maintainer="rc-05 <rc23@email.it>"
 license="Apache-2.0"
-homepage="http://ccl.clozure.com/"
-distfiles="https://github.com/Clozure/ccl/releases/download/v${version}/${pkgname}-${version}-linuxx86.tar.gz"
-checksum=b80850d8d6ca8662499975f1cd76bf51affdd29e2025796ddcff6576fe704143
+homepage="https://ccl.clozure.com/"
+distfiles="
+ https://github.com/Clozure/ccl/archive/v${version}.tar.gz
+ https://github.com/Clozure/ccl/releases/download/v${version}/linuxx86.tar.gz
+"
+checksum="
+ 774a06b4fb6dc4b51dfb26da8e1cc809c605e7706c12180805d1be6f2885bd52
+ 7fbdb04fb1b19f0307c517aa5ee329cb4a21ecc0a43afd1b77531e4594638796
+"
 nopie=1
 nostrip=1
 disable_parallel_build=1
+python_version=3
 
 case $XBPS_MACHINE in
 	x86_64*) _arch=64 ;;
 	i686*) broken="Build hangs forever" ;;
 	*) _arch='' ;;
 esac
+
+post_extract() {
+	mv ccl-${version}/* .
+}
 
 do_build() {
 	# recompile kernel, mandatory for musl
@@ -31,7 +42,6 @@ do_build() {
 }
 
 do_install() {
-
 	find . -type d -name .svn -exec rm -rf '{}' +
 	find . -name '*.o' -delete
 	find . -name '*.*fsl' -delete
@@ -58,6 +68,4 @@ EOF
 
 	vmkdir usr/share/examples/$pkgname
 	vcopy "examples/*" usr/share/examples/$pkgname
-
 }
-


### PR DESCRIPTION
Clozure-CL updated to latest [release](https://github.com/Clozure/ccl/releases).