### PR TITLE
New package: PikoPixel.app-1.0.b9e

### DIFF
--- a/srcpkgs/PikoPixel.app/template
+++ b/srcpkgs/PikoPixel.app/template
@@ -1,0 +1,30 @@
+# Template file for 'PikoPixel.app'
+pkgname=PikoPixel.app
+version=1.0.b9e
+revision=1
+wrksrc="PikoPixel.Sources.${version%.*}-${version##*.}"
+build_wrksrc=PikoPixel
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="gnustep-make gcc-objc tar which"
+makedepends="gnustep-base-devel gnustep-gui-devel"
+depends="gnustep-base gnustep-gui gnustep-back"
+short_desc="GNUstep application for drawing/editing pixel-art"
+maintainer="Kira Patton <roundduckman@protonmail.com>"
+license="AGPL-3.0-only"
+homepage="http://twilightedge.com/mac/pikopixel/"
+distfiles="http://twilightedge.com/downloads/PikoPixel.Sources.${version%.*}-${version##*.}.tar.gz"
+checksum=96977fc51343d294c7d7e76d8f1ac7aa82ae9da1d7d082dee6cee8035959afbe
+
+pre_build() {
+	source /usr/share/GNUstep/Makefiles/GNUstep.sh
+}
+
+pre_install() {
+	source /usr/share/GNUstep/Makefiles/GNUstep.sh
+}
+
+post_install() {
+	vinstall PikoPixel.app/Resources/PikoPixel.desktop 0755 /usr/share/applications/
+	vlicense ../LICENSE_agpl-3.0.txt
+}


### PR DESCRIPTION
This is a GNUstep-based app that's used to create pixel art. When I was looking for an open source art program to use after finding out I couldn't use aseprite and wanting to use something open source but still focused on pixel art anyways, I realized I could use this, but I always had trouble with it due to having to compile and run it manually, so I made my own package, with help from the irc chat.

I hope in the future I can port other packages too.