### PR TITLE
alacritty: fix missing libXi dependency

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,12 +1,12 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.4.2
-revision=2
+revision=3
 build_wrksrc="${pkgname}"
 build_style=cargo
 hostmakedepends="pkg-config python3"
 makedepends="freetype-devel fontconfig-devel libxcb-devel"
-depends="libXxf86vm ncurses alacritty-terminfo-${version}_${revision}"
+depends="libXi libXxf86vm ncurses alacritty-terminfo-${version}_${revision}"
 short_desc="Cross-platform, GPU-accelerated terminal emulator"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"


### PR DESCRIPTION
Addresses this Issue, which i have confirmed to be true.
https://github.com/void-linux/void-packages/issues/21158