### PR TITLE
megatools: update to 1.10.3 fixes #20820

### DIFF
--- a/srcpkgs/megatools/template
+++ b/srcpkgs/megatools/template
@@ -1,7 +1,7 @@
 # Template file for 'megatools'
 pkgname=megatools
-version=1.10.2
-revision=3
+version=1.10.3
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config asciidoc"
 makedepends="glib-networking gobject-introspection libressl-devel libcurl-devel fuse-devel libsodium-devel glib-devel"
@@ -10,7 +10,7 @@ maintainer="RunningDroid <runningdroid@zoho.com>"
 license="GPL-2.0-or-later"
 homepage="https://megatools.megous.com/"
 distfiles="${homepage}/builds/megatools-${version}.tar.gz"
-checksum=179e84c68e24696c171238a72bcfe5e28198e4c4e9f9043704f36e5c0b17c38a
+checksum=8dc1ca348633fd49de7eb832b323e8dc295f1c55aefb484d30e6475218558bdb
 
 post_install() {
 	vinstall contrib/bash-completion/megatools 644 usr/share/bash-completion/completions


### PR DESCRIPTION
Tested it on a few old links and they work with that update.

Quoting upstream:
> megatools 1.10.3 - 2020-04-15
> =============================
> 
> This is a bugfix release.
> 
> Fixes:
> - Add support for new format of mega.nz links (by Alberto Garcia)