### PR TITLE
Add glxinfo as a dependency to lutris

### DIFF
--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -7,7 +7,8 @@ build_style=python3-module
 build_helper="gir"
 hostmakedepends="python3-setuptools python3-gobject gtk+3-devel"
 depends="python3-dbus python3-gobject python3-yaml python3-evdev python3-Pillow
- pciutils cabextract gtk+3 xrandr unzip p7zip gnome-desktop python3-requests webkit2gtk"
+ pciutils cabextract gtk+3 xrandr unzip p7zip gnome-desktop python3-requests webkit2gtk
+ glxinfo"
 short_desc="Open gaming platform for managing games in a unified way"
 maintainer="Jan Wey. <janwey.git@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Without glxinfo installed, lutris will throw an exception and fail to open the preferences panel. The exception states that it cannot find glxinfo.