### PR TITLE
./xbps-src bootstrap fixes

### DIFF
--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -195,7 +195,6 @@ glibc-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.o"
-		vmove usr/share/info
 	}
 }
 glibc-locales_package() {

--- a/srcpkgs/m4/template
+++ b/srcpkgs/m4/template
@@ -14,6 +14,10 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=f2c1e86ca0a404ff281631bdc8377638992744b175afb806e25871a24a934e07
 
+pre_build() {
+    sed -i '1 i @documentencoding ISO-8859-1' doc/m4.texi
+}
+
 pre_check() {
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl* )

--- a/xbps-src
+++ b/xbps-src
@@ -394,7 +394,7 @@ umask 022
 #
 # Required utilities in host system for the bootstrap target.
 readonly REQHOST_UTILS_BOOTSTRAP="file objdump find make gawk bash sed gcc g++ gnat \
-    perl bsdtar gzip patch flock pkg-config"
+    perl bsdtar gzip patch flock pkg-config makeinfo"
 
 # Required utilities in host.
 readonly REQHOST_UTILS="xbps-install xbps-query xbps-rindex xbps-uhelper \


### PR DESCRIPTION
I found a few missing/broken things while testing `./xbps-src bootstrap`:

1. `bootstrap` requires texinfo on the host.
2. glibc doesn't contain usr/share/info.
3. m4 was broken.

Closes #21163 . Thanks to @rovenmaccorp