### PR TITLE
konversation: add missing build dependendencies

### DIFF
--- a/srcpkgs/konversation/template
+++ b/srcpkgs/konversation/template
@@ -3,8 +3,8 @@ pkgname=konversation
 version=1.7.5
 revision=2
 build_style=cmake
-hostmakedepends="extra-cmake-modules kconfig kdoctools python qt5-host-tools
- qt5-qmake"
+hostmakedepends="extra-cmake-modules kconfig kdoctools kcoreaddons
+ python qt5-host-tools qt5-qmake gettext"
 makedepends="kemoticons-devel kidletime-devel knotifyconfig-devel kparts-devel
  $(vopt_if qca 'qca-qt5-devel')"
 short_desc="User friendly IRC client for KDE"


### PR DESCRIPTION
Konversation failed to rebuild after the python_version behavior change. Looks like the template was missing some build dependencies. Those were added and it looks like it builds on armv7l and x86_64 now. I didn't bump the revision because it was bumped with the python_version change and has not been built since.