### PR TITLE
Revert "chroot-git: simplify and avoid gettext dependency."

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -5,8 +5,8 @@ revision=1
 bootstrap=yes
 wrksrc="git-${version}"
 build_style=gnu-configure
-configure_args="--with-zlib=$XBPS_MASTERDIR/usr --without-curl
- --without-openssl --without-python --without-expat --without-tcltk
+configure_args="--without-curl --without-openssl
+ --without-python --without-expat --without-tcltk
  ac_cv_lib_curl_curl_global_init=no ac_cv_lib_expat_XML_ParserCreate=no"
 makedepends="zlib-devel"
 short_desc="GIT Tree History Storage Tool -- for xbps-src use"
@@ -18,6 +18,8 @@ checksum=9ece0dcb07a5e0d7366a92b613b201cca11ae368ab7687041364b3e756e495d6
 
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="perl gettext tar"
+else
+	configure_args+=" --with-zlib=${XBPS_MASTERDIR}/usr"
 fi
 
 post_configure() {


### PR DESCRIPTION
This reverts commit aa1e576abe9b001879da67da2728e13d71be025d.
Fix cross-compile chroot-git.

@xtraeme 