### PR TITLE
python-gobject: update to 3.36.0

### DIFF
--- a/srcpkgs/python-gobject/template
+++ b/srcpkgs/python-gobject/template
@@ -1,12 +1,11 @@
 # Template file for 'python-gobject'
 pkgname=python-gobject
-version=3.32.2
-revision=2
+version=3.36.0
+revision=1
 wrksrc="pygobject-${version}"
 build_style=meson
 build_helper="gir"
 configure_args="-Dpython=python2.7"
-pycompile_module="gi pygtkcompat"
 hostmakedepends="pkg-config python"
 makedepends="libglib-devel python-cairo-devel python-devel"
 depends="gir-freedesktop python-cairo"
@@ -15,7 +14,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://pygobject.readthedocs.io/"
 distfiles="${GNOME_SITE}/pygobject/${version%.*}/pygobject-${version}.tar.xz"
-checksum=c39ca2a28364b57fa00549c6e836346031e6b886c3ceabfd8ab4b4fed0a83611
+checksum=8683d2dfb5baa9e501a9a64eeba5c2c1117eadb781ab1cd7a9d255834af6daef
 
 python-gobject-devel_package() {
 	depends="libgirepository-devel python-cairo-devel


### PR DESCRIPTION
Last release supporting python2.