### PR TITLE
docker: Fix runit service

### DIFF
--- a/srcpkgs/docker/files/docker/run
+++ b/srcpkgs/docker/files/docker/run
@@ -5,5 +5,5 @@ mountpoint -q /sys/fs/cgroup/systemd || {
     mkdir -p /sys/fs/cgroup/systemd;
     mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd;
 }
-[ -n "$OPTS" ] || OPTS="-s=overlay2"
+#[ -n "$OPTS" ] || OPTS="-s=overlay2"
 exec chpst -o 1048576 -p 1048576 dockerd $OPTS 2>&1


### PR DESCRIPTION
The "-s=overlay2" command line flag appears to prevent the service from starting.
Comment out this line in the service file for now.