### PR TITLE
xdm: add more conf_files

### DIFF
--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,14 +1,18 @@
 # Template file for 'xdm'
 pkgname=xdm
 version=1.1.12
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp
  --with-wtmp-file=/var/log/wtmp
  --with-xdmconfigdir=/etc/X11/xdm
  --with-pam"
-conf_files="/etc/pam.d/xdm"
+conf_files="/etc/pam.d/xdm
+ /etc/X11/xdm/Xaccess
+ /etc/X11/xdm/xdm-config
+ /etc/X11/xdm/Xresources
+ /etc/X11/xdm/Xservers"
 hostmakedepends="pkg-config"
 makedepends="pam-devel libXaw-devel"
 depends="sessreg xconsole xsm"


### PR DESCRIPTION
When configuring XDM for remote access, a number of the files in /etc/X11/xdm need to be modified to enable this support. Package upgrades should not overwrite changes to these files.