### PR TITLE
python3-hyper-h2: fix python3 depends

### DIFF
--- a/srcpkgs/python-hyper-h2/template
+++ b/srcpkgs/python-hyper-h2/template
@@ -1,11 +1,10 @@
 # Template file for 'python-hyper-h2'
 pkgname=python-hyper-h2
 version=3.1.1
-revision=2
+revision=3
 archs=noarch
 wrksrc="hyper-h2-${version}"
 build_style=python-module
-pycompile_module="h2"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python python-hpack python-hyperframe"
 short_desc="HTTP/2 State-Machine based protocol implementation(Python2)"
@@ -21,9 +20,8 @@ post_install() {
 
 python3-hyper-h2_package() {
 	archs=noarch
-	pycompile_module="h2"
 	short_desc="${short_desc/Python2/Python3}"
-	depends="${depends/python/python3}"
+	depends="python3 python3-hpack python3-hyperframe"
 	pkg_install() {
 		vmove "usr/lib/python3*"
 	}


### PR DESCRIPTION
fix #21252