### PR TITLE
alot: update to 0.9

### DIFF
--- a/srcpkgs/alot/patches/0001-Update-reference-to-envelope.body.patch
+++ b/srcpkgs/alot/patches/0001-Update-reference-to-envelope.body.patch
@@ -1,0 +1,25 @@
+From 28a4296c7f556c251d71d9502681980d46d9fa55 Mon Sep 17 00:00:00 2001
+From: Patrick Totzke <patricktotzke@gmail.com>
+Date: Sun, 16 Feb 2020 10:24:59 +0000
+Subject: [PATCH] Update reference to envelope.body
+
+which now should be body_txt as of e067ea2037c10224645f0cb7ab2e020772e612ac
+
+fixes #1468
+---
+ alot/commands/globals.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/alot/commands/globals.py b/alot/commands/globals.py
+index f9dc58120..aa1fd4368 100644
+--- a/alot/commands/globals.py
++++ b/alot/commands/globals.py
+@@ -869,7 +869,7 @@ async def _set_signature(self, ui):
+                     mimetype = helper.guess_mimetype(sigcontent)
+                     if mimetype.startswith('text'):
+                         sigcontent = helper.try_decode(sigcontent)
+-                        self.envelope.body += '\n' + sigcontent
++                        self.envelope.body_txt += '\n' + sigcontent
+             else:
+                 ui.notify('could not locate signature: %s' % sig,
+                           priority='error')

--- a/srcpkgs/alot/patches/0002-Fix-SyntaxWarning-is-with-a-literal.-from-Python-3.8.patch
+++ b/srcpkgs/alot/patches/0002-Fix-SyntaxWarning-is-with-a-literal.-from-Python-3.8.patch
@@ -1,0 +1,52 @@
+From 916b446317980e9794a02bfb79456da4fc2768a4 Mon Sep 17 00:00:00 2001
+From: Jordan Justen <jordan.l.justen@intel.com>
+Date: Thu, 9 Apr 2020 02:26:27 -0700
+Subject: [PATCH] Fix 'SyntaxWarning: "is" with a literal.' from Python 3.8
+
+alot/alot/widgets/ansi.py:84: SyntaxWarning: "is" with a literal. Did you mean "=="?
+  if code is 0:
+alot/alot/commands/envelope.py:762: SyntaxWarning: "is" with a literal. Did you mean "=="?
+  if self.action is "txt2html":
+alot/alot/commands/envelope.py:768: SyntaxWarning: "is" with a literal. Did you mean "=="?
+  elif self.action is "html2txt":
+
+Ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=955193
+Signed-off-by: Jordan Justen <jordan.l.justen@intel.com>
+---
+ alot/commands/envelope.py | 4 ++--
+ alot/widgets/ansi.py      | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/alot/commands/envelope.py b/alot/commands/envelope.py
+index 9c2fbbc54..ba0b4dbc9 100644
+--- a/alot/commands/envelope.py
++++ b/alot/commands/envelope.py
+@@ -759,13 +759,13 @@ def apply(self, ui):
+         ebuffer = ui.current_buffer
+         envelope = ebuffer.envelope
+ 
+-        if self.action is "txt2html":
++        if self.action == "txt2html":
+             fallbackcmd = settings.get('envelope_txt2html')
+             cmd = self.cmd or split_commandstring(fallbackcmd)
+             if cmd:
+                 envelope.body_html = self.convert(cmd, envelope.body_txt)
+ 
+-        elif self.action is "html2txt":
++        elif self.action == "html2txt":
+             fallbackcmd = settings.get('envelope_html2txt')
+             cmd = self.cmd or split_commandstring(fallbackcmd)
+             if cmd:
+diff --git a/alot/widgets/ansi.py b/alot/widgets/ansi.py
+index 97a4fb95c..4aaf28e7e 100644
+--- a/alot/widgets/ansi.py
++++ b/alot/widgets/ansi.py
+@@ -81,7 +81,7 @@ def parse_escapes_to_urwid(text, default_attr=None, default_attr_focus=None,
+             i = 0
+             while i < len(esc_code):
+                 code = esc_code[i]
+-                if code is 0:
++                if code == 0:
+                     attr.update({'bold': default_attr.bold,
+                                  'underline': default_attr.underline,
+                                  'standout': default_attr.standout})

--- a/srcpkgs/alot/template
+++ b/srcpkgs/alot/template
@@ -1,16 +1,25 @@
 # Template file for 'alot'
 pkgname=alot
-version=0.8.1
-revision=2
+version=0.9
+revision=1
 archs=noarch
 build_style=python3-module
-pycompile_module="alot"
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools python3-Sphinx"
 depends="python3-setuptools python3-Twisted notmuch-python3 python3-configobj
  python3-gpg python3-magic python3-urwidtrees"
+checkdepends="$depends gnupg2 procps-ng"
 short_desc="Terminal-based mail user agent based on the notmuch mail indexer"
 maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/pazz/alot"
 distfiles="https://github.com/pazz/${pkgname}/archive/${version}.tar.gz"
-checksum=823e2fae014c1036609068c6109042b676113a382eacbd04eb3dfa461ef53953
+checksum=64bfa2f550d775940348c93532bf5cbdde57b9fcec4bcf2447a72510d2add6cf
+patch_args="-Np1"
+
+post_build() {
+	make $makejobs -C docs man
+}
+
+post_install() {
+	vman docs/build/man/alot.1
+}


### PR DESCRIPTION
The `pycompile_module` was removed because it is autodetected.