### PR TITLE
06-strip-and-debug-pkgs.sh: ignore binaries for unknown machines

### DIFF
--- a/common/hooks/post-install/06-strip-and-debug-pkgs.sh
+++ b/common/hooks/post-install/06-strip-and-debug-pkgs.sh
@@ -70,6 +70,10 @@ hook() {
 			continue
 		fi
 
+		if [[ $(file -b "$f") =~ "no machine" ]]; then
+			continue
+		fi
+
 		fname=${f##*/}
 		for x in ${nostrip_files}; do
 			if [ "$x" = "$fname" ]; then


### PR DESCRIPTION
Because most likely these files are not executables, but some kind of bytecode. And strip doesn't know how to strip them anyway.