### PR TITLE
[WIP] New package: traverso-0.49.6

### DIFF
--- a/srcpkgs/traverso/patches/patch-src_core_Sheet.patch
+++ b/srcpkgs/traverso/patches/patch-src_core_Sheet.patch
@@ -1,0 +1,11 @@
+--- src/core/Sheet.cpp.orig	2019-05-16 08:08:50 UTC
++++ src/core/Sheet.cpp
+@@ -397,7 +397,7 @@ int Sheet::prepare_export(ExportSpecification* spec)
+ 		m_rendering = true;
+ 	}
+ 
+-	spec->startLocation = LONG_LONG_MAX;
++	spec->startLocation = LLONG_MAX;
+ 	spec->endLocation = TimeRef();
+ 
+ 	TimeRef endlocation, startlocation;

--- a/srcpkgs/traverso/template
+++ b/srcpkgs/traverso/template
@@ -1,0 +1,25 @@
+# Template file for 'traverso'
+pkgname=traverso
+version=0.49.6
+revision=1
+build_style=cmake
+configure_args="-DWANT_MP3_ENCODE=ON -DDETECT_HOST_CPU_FEATURES=OFF"
+hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
+makedepends="jack-devel wavpack-devel libvorbis-devel libflac-devel
+ libmad-devel lame-devel fftw-devel qt5-devel lilv-devel libsndfile-devel
+ libsamplerate-devel"
+depends="hicolor-icon-theme"
+short_desc="Digital Audio Workstation with an innovative user Interface"
+maintainer="Lorem <notloremipsum@protonmail.com>"
+license="GPL-2.0-or-later"
+homepage="http://traverso-daw.org/"
+distfiles="http://traverso-daw.org/traverso-${version}.tar.gz"
+checksum=f850b88cbb64529655514b7cfe01c56133e21929374b3e3b90813bc227eac789
+
+post_install() {
+	vdoc resources/help.text
+	vinstall resources/traverso.desktop 644 usr/share/applications
+	vinstall resources/x-traverso.xml 644 usr/share/mime/packages
+	vmkdir usr/share/icons/hicolor
+	cp -a resources/freedesktop/icons/* ${DESTDIR}/usr/share/icons/hicolor
+}


### PR DESCRIPTION
Closes #21298 
Need help in testing @leahneukirchen

Patch taken from [here](https://github.com/DragonFlyBSD/DPorts/blob/master/audio/traverso/files/patch-src_core_Sheet.cpp), it failed for armv7l-musl( the only arch I built for apart from x86_64) without it.