### PR TITLE
gst-plugins-bad1: rebuild against libdvdread-6.1.1

### DIFF
--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.16.2
-revision=4
+revision=5
 wrksrc="${pkgname/1/}-${version}"
 build_helper="gir"
 build_style=meson


### PR DESCRIPTION
Broke shlibs on my system for a while.