### PR TITLE
poppler: update homepage location

### DIFF
--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -16,7 +16,7 @@ makedepends="libpng-devel tiff-devel lcms2-devel libcurl-devel
 short_desc="PDF rendering library - Qt5 bindings"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, GPL-3.0-or-later"
-homepage="http://poppler.freedesktop.org"
+homepage="https://poppler.freedesktop.org"
 distfiles="${homepage}/poppler-${version}.tar.xz"
 checksum=4d3ca6b79bc13b8e24092e34f83ef5f387f3bb0bbd7359a6c078e09c696d104f
 

--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -16,7 +16,7 @@ makedepends="libpng-devel libglib-devel cairo-devel tiff-devel lcms2-devel
 short_desc="PDF rendering library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, GPL-3.0-or-later"
-homepage="http://poppler.freedesktop.org"
+homepage="https://poppler.freedesktop.org"
 distfiles="${homepage}/${pkgname}-${version}.tar.xz"
 checksum=4d3ca6b79bc13b8e24092e34f83ef5f387f3bb0bbd7359a6c078e09c696d104f
 


### PR DESCRIPTION
Now only works with https://, permanent redirect.