### PR TITLE
libslirp: update to 4.3.0.

### DIFF
--- a/srcpkgs/libslirp/template
+++ b/srcpkgs/libslirp/template
@@ -1,6 +1,6 @@
 # Template file for 'libslirp'
 pkgname=libslirp
-version=4.2.0
+version=4.3.0
 revision=1
 wrksrc="libslirp-v${version}"
 build_style=meson
@@ -10,8 +10,13 @@ short_desc="User-mode networking library used by VMs and containers"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="BSD-3-Clause"
 homepage="https://gitlab.freedesktop.org/slirp/libslirp"
+changelog="https://gitlab.freedesktop.org/slirp/libslirp/-/blob/master/CHANGELOG.md"
 distfiles="https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${version}/libslirp-v${version}.tar.gz"
-checksum=8c088bb60952d18e615962a83bcd4f03fa0988d913bce9457fea9377e72ab9f3
+checksum=4432667c0fadfd68a2779de351917d9a6c5cbacf0034dcc4de3194c39df980c4
+
+pre_configure() {
+	printf '%s\n' "${version}" > .tarball-version
+}
 
 post_install() {
 	vlicense COPYRIGHT


### PR DESCRIPTION
CVE-2020-1983