### PR TITLE
Add missing python_version=2 to packages the require it

### DIFF
--- a/srcpkgs/bleachbit/template
+++ b/srcpkgs/bleachbit/template
@@ -14,3 +14,4 @@ license="GPL-3.0-or-later"
 homepage="https://www.bleachbit.org/"
 distfiles="https://github.com/bleachbit/bleachbit/archive/v${version}.tar.gz"
 checksum=c0e25253781d768da4eacf56739bf547dc59f2fe212f44e464f4fcc1bc855e44
+python_version=2 #unverified

--- a/srcpkgs/bumblebee-status/template
+++ b/srcpkgs/bumblebee-status/template
@@ -11,6 +11,7 @@ license="MIT"
 homepage="https://github.com/tobi-wan-kenobi/bumblebee-status"
 distfiles="https://github.com/tobi-wan-kenobi/bumblebee-status/archive/v${version}.tar.gz"
 checksum=ba483f07f5726454aeaf929069bc82dce85be198b969b96c9bd8d85eab5a619c
+python_version=2 #unverified
 
 do_install() {
 	vmkdir usr/share/${pkgname}

--- a/srcpkgs/couchpotato/template
+++ b/srcpkgs/couchpotato/template
@@ -14,6 +14,7 @@ license="GPL-3.0-or-later"
 homepage="http://couchpota.to"
 distfiles="https://github.com/RuudBurger/CouchPotatoServer/archive/build/${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=f08f9c6ac02f66c6667f17ded1eea4c051a62bbcbadd2a8673394019878e92f7
+python_version=2 #unverified
 couchpotato_homedir="/var/lib/couchpotato"
 system_accounts="couchpotato"
 

--- a/srcpkgs/cross-arm-none-eabi-gdb/template
+++ b/srcpkgs/cross-arm-none-eabi-gdb/template
@@ -31,6 +31,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/${_pkgname}"
 distfiles="${GNU_SITE}/${_pkgname}/${_pkgname}-${version}.tar.xz"
 checksum=802f7ee309dcc547d65a68d61ebd6526762d26c3051f52caebe2189ac1ffd72e
+python_version=2 #unverified
 build_options="guile python"
 # don't enable guile and python interfaces until they are moved into
 # platform independent packages

--- a/srcpkgs/cycle/template
+++ b/srcpkgs/cycle/template
@@ -12,6 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/jose1711/cycle"
 distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=6ca5a8191653d435ed04968b91b4a52c8e0d3d90d31d2c008aba1e9edcc1adc9
+python_version=2 #unverified
 
 do_install() {
 	# Program

--- a/srcpkgs/eog-plugins/template
+++ b/srcpkgs/eog-plugins/template
@@ -2,13 +2,12 @@
 pkgname=eog-plugins
 version=3.26.5
 revision=1
-lib32disabled=yes
 build_style=gnu-configure
+pycompile_dirs="usr/lib/eog/plugins"
 hostmakedepends="pkg-config intltool"
 makedepends="eog-devel libgdata-devel
  libchamplain-devel libpeas-devel libexif-devel exempi-devel
  gsettings-desktop-schemas-devel gnome-desktop-devel librsvg-devel"
-pycompile_dirs="usr/lib/eog/plugins"
 depends="eog gsettings-desktop-schemas"
 short_desc="Eye of GNOME plugins"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -16,3 +15,5 @@ license="GPL-2.0-or-later"
 homepage="http://www.gnome.org"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=44968e09059272be038c00aaf9796b442a6cd68163a5cb08c98824492a9b5498
+python_version=2 #unverified
+lib32disabled=yes

--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -17,6 +17,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/gdb/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=699e0ec832fdd2f21c8266171ea5bf44024bd05164fdf064e4d10cc4cf0d1737
+python_version=3
 patch_args="-Np1"
 
 if [ "${CROSS_BUILD}" ]; then

--- a/srcpkgs/hugin/template
+++ b/srcpkgs/hugin/template
@@ -18,6 +18,7 @@ license="GPL-2.0-or-later"
 homepage="http://hugin.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}/${pkgname}-${version%.*}/${pkgname}-${version}.tar.bz2"
 checksum=8ba6bdfea246313f142f17f42e066c6888f51b72e4f8814b5e1c84ff56a95a3e
+python_version=3
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python3"

--- a/srcpkgs/menumaker/template
+++ b/srcpkgs/menumaker/template
@@ -14,6 +14,7 @@ license="BSD-2-Clause"
 homepage="http://menumaker.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=9d831adbaef2101d8b8d82e48d764c2c1a80a38e97dcf90740eb540e6db3f936
+python_version=2 #unverified
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/nemo/template
+++ b/srcpkgs/nemo/template
@@ -16,6 +16,7 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://developer.linuxmint.com/projects/cinnamon-projects.html/"
 distfiles="https://github.com/linuxmint/${pkgname}/archive/${version}.tar.gz"
 checksum=cda3b99c8275c57bb285f8718ef3e463349a8eebe97cc126b0daebffeb242c95
+python_version=2 #unverified
 
 
 do_check() {

--- a/srcpkgs/nitroshare/template
+++ b/srcpkgs/nitroshare/template
@@ -16,6 +16,7 @@ license="MIT"
 homepage="http://nitroshare.net"
 distfiles="https://github.com/nitroshare/nitroshare-desktop/archive/${version}.tar.gz"
 checksum=29874e5909c29211a3c9e13f8c0f49b901ec2996e5d60d80af80d2fb80c3d7ec
+python_version=2 #unverified
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools"

--- a/srcpkgs/qytdl/template
+++ b/srcpkgs/qytdl/template
@@ -12,6 +12,7 @@ license="GPL-3"
 homepage="http://www.someplacedumb.net/content/progs/#qytdl"
 distfiles="http://www.someplacedumb.net/content/progs/qytdl/qytdl-${version}.tar.gz"
 checksum=fe811fc7f91aa7c83aa381f754237df5be48e13be803accc08a1cd879aee630c
+python_version=3 #unverified
 
 do_install() {
 	make PREFIX=${DESTDIR}/usr install

--- a/srcpkgs/sabnzbd/template
+++ b/srcpkgs/sabnzbd/template
@@ -10,10 +10,11 @@ depends="par2cmdline python-cheetah python-configobj python-feedparser
 short_desc="Open Source Binary Newsreader written in Python"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-changelog="https://github.com/sabnzbd/sabnzbd/releases"
 homepage="https://sabnzbd.org/"
+changelog="https://github.com/sabnzbd/sabnzbd/releases"
 distfiles="https://github.com/sabnzbd/sabnzbd/releases/download/${version}/SABnzbd-${version}-src.tar.gz"
 checksum=f3ab6dffba914e6ddf88f1a755ec3ebaa95f0bdbec6f04b7bf0f90822249bb0c
+python_version=2 #unverified
 
 post_extract() {
 	rm -rf gntp sabnzbd/utils/{feedparser,configobj}.py

--- a/srcpkgs/sickbeard/template
+++ b/srcpkgs/sickbeard/template
@@ -12,6 +12,7 @@ license="GPL-3"
 homepage="http://sickbeard.com"
 distfiles="https://github.com/midgetspy/Sick-Beard/archive/build-${version}.tar.gz"
 checksum=eaf95ac78e065f6dd8128098158b38674479b721d95d937fe7adb892932e9101
+python_version=2 #unverified
 
 system_accounts="sickbeard"
 sickbeard_homedir="/var/lib/sickbeard"

--- a/srcpkgs/soundconverter/template
+++ b/srcpkgs/soundconverter/template
@@ -15,6 +15,7 @@ license="GPL-3.0-or-later"
 homepage="http://soundconverter.org/"
 distfiles="https://launchpad.net/${pkgname}/trunk/${version}/+download/${pkgname}-${version}.tar.xz"
 checksum=21d0b97bd4800a8e07840cf0ec035fa84a71a10c8cdadf5ea671880805aa68cb
+python_version=3
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" gtk+3-devel gstreamer1-devel"


### PR DESCRIPTION
This fixes #21323, where packages use `pycompile_dirs` without declaring `python_version` or installing packages to `/usr/lib/pythonX.Y` to allow automatic detection of the Python version.

Adding the `python_version` (and a few `xlint` fixes) will not change the build outputs, so I have not revbumped these templates and am skipping CI.