### PR TITLE
thttpd: unbreak

### DIFF
--- a/srcpkgs/thttpd/template
+++ b/srcpkgs/thttpd/template
@@ -1,7 +1,7 @@
 # Template file for 'thttpd'
 pkgname=thttpd
 version=2.29
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Tiny/turbo/throttling HTTP server"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -9,10 +9,9 @@ license="BSD-2-Clause"
 homepage="http://www.acme.com/software/thttpd/"
 distfiles="http://www.acme.com/software/thttpd/thttpd-${version}.tar.gz"
 checksum=99c09f47da326b1e7b5295c45549d2b65534dce27c44812cf7eef1441681a397
-broken="ELF in /usr/share"
 
 pre_configure() {
-	sed "s,-o bin -g bin,,g" -i Makefile.in
+	vsed -i Makefile.in -e "s,-o bin -g bin,,g"
 }
 
 do_build() {
@@ -25,7 +24,7 @@ do_install() {
 	vmkdir usr/share/man/man8
 
 	make WEBGROUP=$(whoami) \
-		WEBDIR=${DESTDIR}/usr/share/thttpd \
+		WEBDIR=${DESTDIR}/usr/libexec/thttpd \
 		BINDIR=${DESTDIR}/usr/bin \
 		MANDIR=${DESTDIR}/usr/share/man install
 


### PR DESCRIPTION
Place cgi-bin executables in /usr/libexec instead of /usr/share.