### PR TITLE
New Package: nodejs-static-v14.0.0

### DIFF
--- a/srcpkgs/nodejs-static-devel
+++ b/srcpkgs/nodejs-static-devel
@@ -1,0 +1,1 @@
+nodejs-static

--- a/srcpkgs/nodejs-static/patches/ppc32.patch
+++ b/srcpkgs/nodejs-static/patches/ppc32.patch
@@ -1,0 +1,20 @@
+--- deps/v8/src/libsampler/sampler.cc.orig
++++ deps/v8/src/libsampler/sampler.cc
+@@ -423,10 +423,17 @@
+   state->lr = reinterpret_cast<void*>(ucontext->uc_mcontext.regs->link);
+ #else
+   // Some C libraries, notably Musl, define the regs member as a void pointer
++  #if !V8_TARGET_ARCH_32_BIT
+   state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[32]);
+   state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[1]);
+   state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[31]);
+   state->lr = reinterpret_cast<void*>(ucontext->uc_mcontext.gp_regs[36]);
++  #else
++  state->pc = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[32]);
++  state->sp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[1]);
++  state->fp = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[31]);
++  state->lr = reinterpret_cast<void*>(ucontext->uc_mcontext.gregs[36]);
++  #endif
+ #endif
+ #elif V8_HOST_ARCH_S390
+ #if V8_TARGET_ARCH_32_BIT

--- a/srcpkgs/nodejs-static/template
+++ b/srcpkgs/nodejs-static/template
@@ -1,0 +1,88 @@
+# Template file for 'nodejs-static'
+pkgname=nodejs-static
+version=14.0.0
+revision=1
+wrksrc="node-v14.0.0"
+# Need these for host v8 for torque, see https://github.com/nodejs/node/pull/21079
+hostmakedepends="python3"
+makedepends="python3-devel which"
+short_desc="Evented I/O for V8 javascript"
+maintainer="Nathan Blair <engineer.nblair@gmail.com>"
+license="MIT"
+homepage="https://nodejs.org/"
+distfiles="${homepage}/dist/v${version}/node-v${version}.tar.gz"
+checksum=5ee2a8d3036a1652ec93bbd8b5812e0ae41e0450af729b14df4a27afc6f17cf8
+python_version=3 #unverified
+
+replaces="iojs>=0"
+conflicts="nodejs-lts nodejs-lts-10 nodejs-lts-12 nodejs"
+provides="nodejs-runtime-0_1"
+
+if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
+	nocross="host and target must have the same pointer size"
+fi
+
+case "$XBPS_TARGET_MACHINE" in
+	ppc64*) ;;
+	ppc*) broken="Node does not support 32-bit ppc" ;;
+esac
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
+if [ "$XBPS_NO_ATOMIC8" ]; then
+	hostmakedepends+=" libatomic-devel"
+fi
+
+do_configure() {
+	local _args
+
+	export LD="$CXX"
+	if [ "$CROSS_BUILD" ]; then
+		case "$XBPS_TARGET_MACHINE" in
+			arm*) _args="--dest-cpu=arm" ;;
+			aarch64*) _args="--dest-cpu=arm64" ;;
+			ppc64*) _args="--dest-cpu=ppc64" ;;
+			ppc*) _args="--dest-cpu=ppc" ;;
+			mipsel*) _args="--dest-cpu=mipsel" ;;
+			mips*) _args="--dest-cpu=mips" ;;
+			i686*) _args="--dest-cpu=x86" ;;
+			x86_64*) _args="--dest-cpu=x86_64" ;;
+			*) msg_error "$pkgver: cannot be cross compiled for ${XBPS_TARGET_MACHINE}.\n" ;;
+		esac
+		# this is necessary - for example, normally compiling from ppc64le
+		# to ppc64 or from glibc to musl is considered non-cross-compiling
+		# by the build system, because it's technically the same architecture
+		#
+		# that results in the toolset built for target only, and attempting
+		# to execute it within the build system fails
+		_args+=" --cross-compiling"
+	fi
+	# their pregenerated asm is for ELFv1...
+	case "$XBPS_TARGET_MACHINE" in
+		ppc64|ppc64-musl) _args+=" --openssl-no-asm" ;;
+	esac
+	./configure --prefix=/usr --fully-static ${_args}
+}
+
+do_build() {
+	if [ "$CROSS_BUILD" ]; then
+		make LD="$CXX" LDFLAGS+=-ldl -j4 PORTABLE=1 V=1
+	else
+		make LD="$CXX" LDFLAGS+=-ldl -j4 V=1
+	fi
+}
+
+do_install() {
+	make LD="$CXX" LDFLAGS+=-ldl DESTDIR="$DESTDIR" install
+  rm $DESTDIR/usr/include/node/openssl -rf
+	vlicense LICENSE
+}
+
+nodejs-static-devel_package() {
+	short_desc+=" (development files)"
+	conflicts="nodejs-devel nodejs-lts-devel nodejs-lts-10-devel nodejs-lts-12-devel"
+	pkg_install() {
+		vmove usr/include
+	}
+}

--- a/srcpkgs/nodejs-static/update
+++ b/srcpkgs/nodejs-static/update
@@ -1,0 +1,2 @@
+site=https://nodejs.org/dist
+pattern='v\K[\d.]+(?=\/)'


### PR DESCRIPTION
Added statically-compiled nodejs (v14.0.0)

This is mostly a copy-job from current `nodejs`, with shared
dependencies removed and the `--fully-static` configure flag set on
nodejs

This was done to circumvent some of the blocking dependency upgrades preventing `node` being upgraded past v13.2.0 (namely `icu`).

This could be a decent starting point for the `nodejs-lts`/`nodejs-lts-14`, or just as a decent `static`ally compiled nodejs alternative.

- Still includes `npm`
- Likely will only be available on `musl` as the libc from it can be statically linked, unless I'm misunderstanding something

All other nodejs configure flags are left as default for v14.0.0

Can't build on arm* - I'm using a 64-bit machine
arm64 isn't working either - getting this error when executing
`./xbps-src -a aarch64 pkg nodejs-static`
`ERROR: cross-aarch64-linux-gnu-0.33_2: cannot be built, it's currently broken;`

NOTE: This is my first contribution to the package repo. I apologize in advance if I missed anything in the CONTRIBUTING form about not submitting `static` binaries or missed a licensing issue somewhere. I was able to install it to my machine and ran a quick `node` testing suite I had handy; it did execute beautifully (`node` v14.0.0+ adds support for optional chaining and null coalescing so I was able to remove the `--harmony` flag I had to have set previously with `node v13.2.0`).

[ci skip]