### PR TITLE
kmonad: avoid overriding do_install() in build-style

### DIFF
--- a/srcpkgs/kmonad/template
+++ b/srcpkgs/kmonad/template
@@ -1,7 +1,7 @@
 # Template file for 'kmonad'
 pkgname=kmonad
 version=0.3.0
-revision=2
+revision=3
 build_style=haskell-stack
 stackage=lts-14.07
 short_desc="Keyboard remapping utility providing qmk-like functionality"
@@ -13,7 +13,7 @@ checksum="3f61c546d456354a15326558eb8025024ab3d51ef2f6ec761da5568e4473f7ec"
 nopie_files="/usr/bin/kmonad"
 nocross=yes
 
-do_install() {
+post_install() {
 	vlicense LICENSE
 	vinstall ${FILESDIR}/60-kmonad.rules 644 usr/lib/udev/rules.d
 }


### PR DESCRIPTION
An overrided `do_install()` means `/usr/bin/kmonad` is not installed.