### PR TITLE
base-system: Removed wifi dependencies

### DIFF
--- a/srcpkgs/base-system/template
+++ b/srcpkgs/base-system/template
@@ -13,8 +13,8 @@ depends="
  dash bash grep gzip file sed gawk less util-linux which tar man-pages
  mdocml>=1.13.3 shadow e2fsprogs btrfs-progs xfsprogs f2fs-tools dosfstools
  procps-ng tzdata pciutils usbutils iana-etc openssh dhcpcd
- kbd iproute2 iputils iw wpa_supplicant xbps nvi sudo wifi-firmware
- void-artwork traceroute ethtool kmod acpid eudev runit-void"
+ kbd iproute2 iputils iw xbps nvi sudo void-artwork traceroute
+ ethtool kmod acpid eudev runit-void"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) depends+=" musl";;


### PR DESCRIPTION
I use void on a Raspberry Pi, and it doesn't have WiFi. When trimming the system down to what I need, I always get stuck on a view `base-system` dependencies that would like to remove without using XBPS `-f` flag.

Here I suggest dropping the WiFi related packages, but would more generally like to start a conversation about dropping others too (`void-artwork`, `btrfs-progs`, `xfsprogs`, ...). 

I'm not familiar enough with the void system at large to know what the consequences would be. Just ignore and close this pull request if I'm opening some Pandora's box, that should just be ignored.