### PR TITLE
New package: libmsp430-3.15.0.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3977,3 +3977,4 @@ libselinux.so.1 libselinux-3.0_1
 libsepol.so.1 libsepol-3.0_1
 libfrrcares.so.0 libfrr-7.3.1_1
 libhugetlbfs.so.0 libhugetlbfs-2.22_1
+libmsp430.so libmsp430-3.15.0.1_1

--- a/srcpkgs/libmsp430/patches/hidapi.patch
+++ b/srcpkgs/libmsp430/patches/hidapi.patch
@@ -1,0 +1,48 @@
+diff --git DLL430_v3/src/TI/DLL430/HidUpdateManager.cpp DLL430_v3/src/TI/DLL430/HidUpdateManager.cpp
+index 5b74a2a..e1358df 100644
+--- DLL430_v3/src/TI/DLL430/HidUpdateManager.cpp
++++ DLL430_v3/src/TI/DLL430/HidUpdateManager.cpp
+@@ -38,7 +38,7 @@
+ #include <pch.h>
+ #include "HidUpdateManager.h"
+ 
+-#include <hidapi.h>
++#include <hidapi/hidapi.h>
+ 
+ #include <BSL430_DLL/Connections/MSPBSL_Connection5xxUSB.h>
+ #include <BSL430_DLL/MSPBSL_Factory.h>
+diff --git Makefile Makefile
+index a4cfbed..7c65736 100644
+--- Makefile
++++ Makefile
+@@ -55,7 +55,7 @@ ifeq ($(PLATFORM),Linux)
+ 	LIBS += -lusb-1.0
+ 	endif
+ 
+-	LIBS += -lusb-1.0 -lrt -lpthread
++	LIBS += -lusb-1.0 -lrt -lpthread -lhidapi-libusb
+ 
+ 	ifdef BOOST_DIR
+ 	INCLUDES += -I$(BOOST_DIR)
+@@ -66,7 +66,7 @@ ifeq ($(PLATFORM),Linux)
+ 	BSTATIC := -Wl,-Bstatic
+ 	BDYNAMIC := -Wl,-Bdynamic
+ 
+-	HIDOBJ := $(LIBTHIRD)/hid-libusb.o
++	HIDOBJ :=
+ else
+ 	CXX:= clang++
+ 
+diff --git ThirdParty/BSL430_DLL/BSL430_DLL/Physical_Interfaces/MSPBSL_PhysicalInterfaceUSB.h ThirdParty/BSL430_DLL/BSL430_DLL/Physical_Interfaces/MSPBSL_PhysicalInterfaceUSB.h
+index 37825c6..d1105ed 100644
+--- ThirdParty/BSL430_DLL/BSL430_DLL/Physical_Interfaces/MSPBSL_PhysicalInterfaceUSB.h
++++ ThirdParty/BSL430_DLL/BSL430_DLL/Physical_Interfaces/MSPBSL_PhysicalInterfaceUSB.h
+@@ -38,7 +38,7 @@
+ 
+ #pragma once
+ 
+-#include <hidapi.h>
++#include <hidapi/hidapi.h>
+ 
+ #include "MSPBSL_PhysicalInterface.h"
+ 

--- a/srcpkgs/libmsp430/template
+++ b/srcpkgs/libmsp430/template
@@ -1,0 +1,22 @@
+# Template file for 'libmsp430'
+pkgname=libmsp430
+version=3.15.0.1
+revision=1
+archs="x86_64 i686 x86_64-musl"
+create_wrksrc=yes
+makedepends="boost-devel hidapi-devel"
+short_desc="Static library & embedded firmware for MSP430 & MSP432 devices"
+maintainer="Eugen Zagorodniy <e.zagorodniy@gmail.com>"
+license=BSD-3-Clause
+homepage=https://www.ti.com/tool/MSPDS
+distfiles="http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPDS/3_15_0_000/export/MSPDebugStack_OS_Package_${version//./_}.zip"
+checksum=31f8f66ce9f9156bcb550adf3937ebf44ad7995bef2517f2b09e408be947c4c5
+
+do_build() {
+	make
+}
+
+do_install() {
+	vinstall $pkgname.so 755 /usr/lib
+	vlicense MSPDebugStackOpenSourcePackage_manifest.html
+}


### PR DESCRIPTION
Allows to use [mspdebug](https://github.com/void-linux/void-packages/tree/master/srcpkgs/mspdebug) with `tilib` driver, solving following error:

```
$ mspdebug tilib
MSPDebug version 0.25 - debugging tool for MSP430 MCUs
Copyright (C) 2009-2017 Daniel Beer <dlbeer@gmail.com>
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Chip info database from MSP430.dll v3.3.1.4 Copyright (C) 2013 TI, Inc.

tilib_api: can't find libmsp430.so: libmsp430.so: cannot open shared object file: No such file or directory
```