### PR TITLE
mesa: reorg driver config to be mostly feature based + fixes

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,14 +1,13 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=20.0.5
-revision=2
+revision=3
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
- -Dgallium-vdpau=true -Dgallium-xvmc=true -Dosmesa=gallium
- -Dgles1=true -Dgles2=true -Dgallium-va=true -Dlmsensors=true
- -Dplatforms=x11,drm,$(vopt_if wayland wayland),surfaceless -Dllvm=true
- -Db_lto=false"
+ -Dosmesa=gallium -Dgles1=true -Dgles2=true -Dglx=dri -Ddri3=true
+ -Dlmsensors=true -Dplatforms=x11,drm,$(vopt_if wayland wayland),surfaceless
+ -Dllvm=true -Db_lto=false"
 hostmakedepends="gettext flex libxml2-python llvm pkg-config
  python3-Mako $(vopt_if wayland 'wayland-protocols wayland-devel')
  glslang"
@@ -35,82 +34,142 @@ subpackages="libglapi libgbm libOSMesa"
 # Replace old mesa pkgs, superseded by libglvnd.
 replaces="libGL>=10_1<19.2.5_2 libEGL>=10_1<19.2.5_2 libGLES>=10_1<19.2.5_2"
 
+# Driver configuration
+# Check for correctness on major mesa version updates
+# Particularly, check if any new worthwhile drivers were added
+
+# swrast always present
+_gallium_drivers=" -Dgallium-drivers=swrast"
+_vulkan_drivers=" -Dvulkan-drivers="
+# legacy drivers only on x86 and ppc in general
+_dri_drivers=" -Ddri-drivers="
+
+# amd drivers only on x86 and ppc
+# this also enables clover opencl
 case "$XBPS_TARGET_MACHINE" in
-i686*|x86_64*)
-	# Enable all x86 drivers.
-	configure_args+=" -Dgallium-drivers=auto"
-	configure_args+=" -Ddri-drivers=auto"
-	configure_args+=" -Dgallium-xa=true -Ddri3=true -Dgallium-nine=true"
-	configure_args+=" -Dvulkan-drivers=auto"
-	configure_args+=" -Dgallium-opencl=icd"
-	configure_args+=" -Dvulkan-overlay-layer=true"
-	hostmakedepends+=" clang"
-	makedepends+=" libclc-git"
-	subpackages+=" libxatracker mesa-opencl mesa-dri mesa-vaapi mesa-vdpau"
-	subpackages+=" mesa-XvMC mesa-vulkan-intel mesa-vulkan-radeon mesa-vulkan-overlay-layer"
-	# Transitional dummy packages
-	subpackages+=" mesa-ati-dri mesa-intel-dri mesa-nouveau-dri mesa-vmwgfx-dri"
-	;;
-ppc*)
-	# Enable all ppc drivers.
-	configure_args+=" -Dgallium-drivers=r300,r600,radeonsi,swrast,nouveau,virgl"
-	configure_args+=" -Ddri-drivers=r100,r200,nouveau"
-	configure_args+=" -Dgallium-xa=false -Ddri3=true -Dgallium-opencl=icd"
-	configure_args+=" -Dvulkan-drivers=amd"
-	configure_args+=" -Dvulkan-overlay-layer=true"
-	# Explicitly control power8 feature usage, disable on BE
-	case "$XBPS_TARGET_MACHINE" in
-		ppc64le*) configure_args+=" -Dpower8=true";;
-		*) configure_args+=" -Dpower8=false";;
-	esac
-	hostmakedepends+=" clang"
-	makedepends+=" libclc-git"
-	subpackages+=" mesa-opencl mesa-dri mesa-vaapi mesa-vdpau mesa-XvMC mesa-vulkan-radeon"
-	subpackages+=" mesa-vulkan-overlay-layer"
-	# Transitional dummy packages
-	subpackages+=" mesa-ati-dri mesa-nouveau-dri"
-	;;
-aarch64*)
-	# Enable all ARM drivers
-	configure_args+=" -Dgallium-drivers=auto"
-	configure_args+=" -Dvulkan-drivers= -Ddri-drivers="
-	configure_args+=" -Dgallium-xa=false -Ddri3=true"
-	subpackages+=" mesa-dri mesa-vaapi mesa-vdpau mesa-XvMC"
-	# Transitional dummy packages
-	subpackages+=" mesa-kmsro-dri mesa-tegra-dri mesa-nouveau-dri mesa-v3d-dri mesa-vc4-dri"
-	subpackages+=" mesa-etnaviv-dri mesa-freedreno-dri mesa-lima-dri mesa-panfrost-dri"
-	;;
-armv[67]l*)
-	configure_args+=" -Dgallium-drivers=auto"
-	configure_args+=" -Dvulkan-drivers= -Ddri-drivers= -Dgallium-xvmc=false"
-	configure_args+=" -Dgallium-xa=false -Dgallium-vdpau=false -Dgallium-va=false"
-	subpackages+=" mesa-dri"
-	# Transitional dummy packages
-	subpackages+=" mesa-etnaviv-dri mesa-freedreno-dri mesa-kmsro-dri mesa-lima-dri mesa-panfrost-dri mesa-vc4-dri"
-	;;
-*)
-	# Enable swrast driver.
-	configure_args+=" -Dgallium-drivers=swrast"
-	configure_args+=" -Ddri-drivers= -Dvulkan-drivers= -Dgallium-va=false"
-	configure_args+=" -Dgallium-vdpau=false -Dgallium-xvmc=false"
-	configure_args+=" -Dgallium-xa=false"
-	subpackages+=" mesa-dri"
-	;;
+	i686*|x86_64*|ppc*) _have_amd=yes ;;
 esac
 
-# -devel must be the last one for proper order.
-subpackages+=" MesaLib-devel"
+# hardware video decoding on x86, ppc, aarch64
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*|ppc*|aarch64*) _have_hwdec=yes ;;
+esac
+
+# most platforms get nvidia and virgl
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*|ppc*|armv[67]*|aarch64*)
+		_have_nv=yes
+		_have_virgl=yes
+		;;
+esac
+
+# x86 additionally gets intel, vmware and gallium nine
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*)
+		_have_intel=yes
+		_have_vmware=yes
+		_have_nine=yes
+		;;
+esac
+
+if [ "$_have_amd" ]; then
+	# amd cards can use clover
+	_have_opencl=yes
+	_gallium_drivers+=",r300,r600,radeonsi"
+	_vulkan_drivers+=",amd"
+	_dri_drivers+=",r100,r200"
+	subpackages+=" mesa-vulkan-radeon"
+	# transitional dummy packages
+	subpackages+=" mesa-ati-dri"
+fi
+
+if [ "$_have_intel" ]; then
+	_gallium_drivers+=",iris"
+	_vulkan_drivers+=",intel"
+	_dri_drivers+=",i915,i965"
+	subpackages+=" mesa-vulkan-intel"
+	# transitional dummy packages
+	subpackages+=" mesa-intel-dri"
+fi
+
+if [ "$_have_nv" ]; then
+	_gallium_drivers+=",nouveau"
+	if [ "$_have_arm" ]; then
+		_gallium_drivers+=",tegra"
+		# transitional dummy packages
+		subpackages+=" mesa-tegra-dri"
+	else
+		_dri_drivers+=",nouveau"
+	fi
+	# transitional dummy packages
+	subpackages+=" mesa-nouveau-dri"
+fi
+
+if [ "$_have_arm" ]; then
+	_gallium_drivers+=",kmsro"
+	_gallium_drivers+=",v3d,vc4,freedreno,etnaviv,lima,panfrost"
+	# transitional dummy packages
+	subpackages+=" mesa-kmsro-dri mesa-v3d-dri mesa-vc4-dri"
+	subpackages+=" mesa-etnaviv-dri mesa-freedreno-dri"
+	subpackages+=" mesa-lima-dri mesa-panfrost-dri"
+fi
+
+if [ "$_have_virgl" ]; then
+	_gallium_drivers+=",virgl"
+fi
+
+if [ "$_have_nine" ]; then
+	configure_args+=" -Dgallium-nine=true"
+fi
+
+if [ "$_have_vmware" ]; then
+	_gallium_drivers+=",svga"
+	configure_args+=" -Dgallium-xa=true"
+	subpackages+=" libxatracker"
+	# transitional dummy packages
+	subpackages+=" mesa-vmwgfx-dri"
+else
+	configure_args+=" -Dgallium-xa=false"
+fi
+
+# enabled currently by amd drivers
+if [ "$_have_opencl" ]; then
+	hostmakedepends+=" clang"
+	makedepends+=" libclc-git"
+	subpackages+=" mesa-opencl"
+	configure_args+=" -Dgallium-opencl=icd"
+fi
+
+if [ "$_have_hwdec" ]; then
+	configure_args+=" -Dgallium-vdpau=true -Dgallium-va=true -Dgallium-xvmc=true"
+	subpackages+=" mesa-vaapi mesa-vdpau mesa-XvMC"
+else
+	configure_args+=" -Dgallium-vdpau=false -Dgallium-va=false -Dgallium-xvmc=false"
+fi
+
+configure_args+=" ${_gallium_drivers} ${_vulkan_drivers} ${_dri_drivers}"
+
+if [ "$_vulkan_drivers" ]; then
+	configure_args+=" -Dvulkan-overlay-layer=true"
+	subpackages+=" mesa-vulkan-overlay-layer"
+fi
+
+# must be the last one for proper order
+subpackages+=" mesa-dri MesaLib-devel"
+
+case "$XBPS_TARGET_MACHINE" in
+	ppc64le*) configure_args+=" -Dpower8=true" ;;
+	ppc*) configure_args+=" -Dpower8=false" ;;
+esac
 
 case "$XBPS_TARGET_MACHINE" in
 	i686) configure_args+=" -Ddri-drivers-path=/usr/lib32/xorg/modules/drivers";;
 	*) configure_args+=" -Ddri-drivers-path=/usr/lib/xorg/modules/drivers";;
 esac
 
-case "$XBPS_TARGET_MACHINE" in
-	# Disable TLS with musl: https://gitlab.freedesktop.org/mesa/mesa/issues/966
-	*-musl) configure_args+=" -Duse-elf-tls=false";;
-	*) configure_args+=" -Dglx=dri";;
-esac
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	configure_args+=" -Duse-elf-tls=false"
+fi
 
 post_configure() {
 	if [ "$CROSS_BUILD" ]; then
@@ -161,9 +220,9 @@ MesaLib-devel_package() {
 	 libdrm-devel libglvnd-devel
 	 libOSMesa>=${version}_${revision} libgbm>=${version}_${revision}
 	 mesa>=${version}_${revision}"
-	case "$XBPS_TARGET_MACHINE" in
-		i686*|x86_64*)  depends+=" libxatracker>=${version}_${revision}";;
-	esac
+	if [ "$_have_vmware" ]; then
+		depends+=" libxatracker>=${version}_${revision}"
+	fi
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
@@ -181,7 +240,7 @@ libxatracker_package() {
 
 mesa-opencl_package() {
 	short_desc="Mesa implementation of OpenCL (r600+ only)"
-	depends="libclc libOpenCL"
+	depends="libclc-git ocl-icd"
 	pkg_install() {
 		vmove etc/OpenCL
 		vmove "usr/lib/libMesaOpenCL.so.*"
@@ -262,7 +321,10 @@ mesa-ati-dri_package() {
 	build_style=meta
 	lib32mode=full
 	short_desc="Mesa DRI drivers for ATI GPUs (transitional dummy package)"
-	depends="mesa-dri mesa-vaapi mesa-vdpau mesa-XvMC mesa-vulkan-radeon"
+	depends="mesa-dri mesa-vulkan-radeon"
+	if [ "$_have_hwdec" ]; then
+		depends+=" mesa-vaapi mesa-vdpau mesa-XvMC"
+	fi
 }
 
 mesa-etnaviv-dri_package() {
@@ -304,7 +366,10 @@ mesa-nouveau-dri_package() {
 	build_style=meta
 	lib32mode=full
 	short_desc="Mesa DRI drivers for NVIDIA GPUs (transitional dummy package)"
-	depends="mesa-dri mesa-vaapi mesa-vdpau mesa-XvMC"
+	depends="mesa-dri"
+	if [ "$_have_hwdec" ]; then
+		depends+=" mesa-vaapi mesa-vdpau mesa-XvMC"
+	fi
 }
 
 mesa-panfrost-dri_package() {


### PR DESCRIPTION
This makes sure we can simply turn on features on/off per arch
in one place and then never explicitly check architecture again.
Also makes turning features on/off easy.

This also goes back to the manual driver list, so that we aren't
subject to mesa randomly turning things on/off.

Also, always enable dri3 and glx=dri, this seems to be the default
anyway, but be explicit about it; on the other hand, control
enablement of gallium-va and other hwdec stuff properly.

Also fix dependencies of mesa-opencl.

Just PRing this so travis can run.