### PR TITLE
gnome-epub-thumbnailer: update to 1.6 , fix license

### DIFF
--- a/srcpkgs/gnome-epub-thumbnailer/template
+++ b/srcpkgs/gnome-epub-thumbnailer/template
@@ -1,13 +1,13 @@
 # Template file for 'gnome-epub-thumbnailer'
 pkgname=gnome-epub-thumbnailer
-version=1.5
+version=1.6
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gdk-pixbuf-devel libarchive-devel libxml2-devel"
 short_desc="Thumbnailer for EPub and MOBI books"
 maintainer="Alif Rachmawadi <arch@subosito.com>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="https://git.gnome.org/browse/gnome-epub-thumbnailer"
 distfiles="${GNOME_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
-checksum=308210f5800219f64cae4828e59bb8e6e4c53b888048cf487221aeb4337d791a
+checksum=b502420d9b02ea0b0fc7986ef5a091a12b2286be14fed9e47594fe9fa0c5898e


### PR DESCRIPTION
Moved to #21382 .