### PR TITLE
gnome-terminal: update to 3.36.2.

### DIFF
--- a/srcpkgs/gnome-terminal/template
+++ b/srcpkgs/gnome-terminal/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-terminal'
 pkgname=gnome-terminal
-version=3.36.1.1
+version=3.36.2
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-nautilus-extension"
@@ -13,8 +13,8 @@ short_desc="GNOME terminal emulator application"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, GFDL-1.3-only"
 homepage="https://wiki.gnome.org/Apps/Terminal"
-distfiles="${GNOME_SITE}/${pkgname}/${version:0:4}/${pkgname}-${version}.tar.xz"
-checksum=f3d708a1e76d77c1c85b126f6e003220a15d4a46a50fd8070e1a3aabe678a376
+distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
+checksum=41d1b6a3dc97c066e294acdb7f36931e81668638dcc92ffa25bca3ddebacdf46
 lib32disabled=yes
 
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/vte3/template
+++ b/srcpkgs/vte3/template
@@ -1,6 +1,6 @@
 # Template file for 'vte3'
 pkgname=vte3
-version=0.60.1
+version=0.60.2
 revision=1
 wrksrc="vte-${version}"
 build_style=meson
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Terminal/VTE"
 distfiles="${GNOME_SITE}/vte/${version%.*}/vte-${version}.tar.xz"
-checksum=5e25807233f8a7e15204be7ff694bbcf6facbb0136092b5ba12584a7b70cf0c4
+checksum=35a0280e3f12feeb3096da05699191373c47a4a20c55cb7081e828e6015f8ca5
 
 # Suppress warnings as errors for NULL format strings (musl libc)
 CXXFLAGS="-Wno-error=format="


### PR DESCRIPTION
[ Moved to #21382 ]

needs `vte3 >=0.60.2`, updated.