### PR TITLE
cups-filters: update to 1.27.4.

### DIFF
--- a/srcpkgs/cups-filters/patches/disable-test-font-cross-compile-check.patch
+++ b/srcpkgs/cups-filters/patches/disable-test-font-cross-compile-check.patch
@@ -1,0 +1,11 @@
+--- configure.orig	2020-04-27 11:43:40.128998764 -0400
++++ configure	2020-04-27 11:44:53.843061000 -0400
+@@ -23628,8 +23628,6 @@
+ if eval \${$as_ac_File+:} false; then :
+   $as_echo_n "(cached) " >&6
+ else
+-  test "$cross_compiling" = yes &&
+-  as_fn_error $? "cannot check for file existence when cross compiling" "$LINENO" 5
+ if test -r ""$with_test_font_path""; then
+   eval "$as_ac_File=yes"
+ else

--- a/srcpkgs/cups-filters/template
+++ b/srcpkgs/cups-filters/template
@@ -1,24 +1,23 @@
 # Template file for 'cups-filters'
 pkgname=cups-filters
-version=1.27.2
-revision=2
+version=1.27.4
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-rcdir=no --enable-avahi
  --with-browseremoteprotocols=DNSSD,CUPS
  --with-test-font-path=/usr/share/fonts/TTF/DejaVuSans.ttf"
 hostmakedepends="ghostscript glib-devel mupdf-tools pkg-config poppler-utils
- liblouis"
+ liblouis dejavu-fonts-ttf"
 makedepends="avahi-glib-libs-devel cups-devel fontconfig-devel liblouis-devel
  ghostscript-devel lcms2-devel libqpdf-devel poppler-cpp-devel"
 depends="bc ghostscript libcups-filters-${version}_${revision} poppler-utils"
-checkdepends="dejavu-fonts-ttf"
 conf_files="/etc/cups/cups-browsed.conf"
 short_desc="OpenPrinting CUPS Filters"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, MIT"
 homepage="https://wiki.linuxfoundation.org/openprinting/cups-filters"
 distfiles="http://openprinting.org/download/cups-filters/${pkgname}-${version}.tar.xz"
-checksum=f7ad7ccda10340e468b9a45429baa54b84af8a170016cab89a3b5e404a97fa25
+checksum=0bc9df9c4ca0f41685c8d6de56fad40109798f567326fc4167d7edb2600f0b84
 
 lib32disabled=yes
 


### PR DESCRIPTION
dejavu-fonts-ttf is now a build dependency due to this upstream change:

    https://github.com/OpenPrinting/cups-filters/pull/214