### PR TITLE
opencl2-headers: bump version to agree with upstream numbering

### DIFF
--- a/srcpkgs/opencl2-headers/template
+++ b/srcpkgs/opencl2-headers/template
@@ -1,16 +1,14 @@
 # Template file for 'opencl2-headers'
 pkgname=opencl2-headers
-_openclver=2.2
-_distver=2020.03.13
-version="${_openclver}.20200313"
+version=2020.03.13
 revision=1
 archs=noarch
-wrksrc="OpenCL-Headers-${_distver}"
+wrksrc="OpenCL-Headers-${version}"
 short_desc="OpenCL 2.2 (Open Computing Language) header files"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/OpenCL-Headers"
-distfiles="${homepage}/archive/v${_distver}.tar.gz"
+distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476
 provides="opencl-headers-${version}_${revision}"
 replaces="opencl-headers>=0"


### PR DESCRIPTION
This does not change the package content, but it realigns package versioning to be compatible with upstream and prevents false detection of package updates.