### PR TITLE
python3-zeroconf: update to 0.26.0.

### DIFF
--- a/srcpkgs/python3-zeroconf/template
+++ b/srcpkgs/python3-zeroconf/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-zeroconf'
 pkgname=python3-zeroconf
-version=0.25.1
+version=0.26.0
 revision=1
 archs=noarch
 wrksrc="python-zeroconf-${version}"
@@ -12,4 +12,4 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/jstasiak/python-zeroconf"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=d32dbc683318e4534348d518011944467f641892574a757c19083ec6f8c25afb
+checksum=5f3bf8f1942ee9b3b5d3167e5eab096032b137f7379cd4af7cb830d8d62372ed


### PR DESCRIPTION
minor update, tested on x64, glibc