### PR TITLE
ncurses: add libtinfo.so

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -72,6 +72,7 @@ libncurses.so.6 ncurses-libs-6.0_1 ignore
 libncurses.so.5 ncurses-libs-6.0_1 ignore
 libncursesw.so.6 ncurses-libs-5.8_1 ignore
 libncursesw.so.5 ncurses-libs-5.8_1 ignore
+libtinfo.so.6 ncurses-libtinfo-libs-6.2_2
 libnetcdf.so.15 netcdf-4.7.0_1
 libformw.so.5 ncurses-libs-5.9_13 ignore
 libformw.so.6 ncurses-libs-5.8_1 ignore

--- a/srcpkgs/ncurses-libtinfo-devel
+++ b/srcpkgs/ncurses-libtinfo-devel
@@ -1,0 +1,1 @@
+ncurses

--- a/srcpkgs/ncurses-libtinfo-libs
+++ b/srcpkgs/ncurses-libtinfo-libs
@@ -1,0 +1,1 @@
+ncurses

--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template file for 'ncurses'
 pkgname=ncurses
 version=6.2
-revision=1
+revision=2
 bootstrap=yes
 configure_args="--enable-big-core"
 short_desc="System V Release 4.0 curses emulation library"
@@ -79,6 +79,16 @@ do_install() {
 	install -Dm755 lib/libncurses.so.${version} \
 		${DESTDIR}/usr/lib/libncurses.so.${version}
 
+	# Create libtinfo symlinks.
+	ln -sfr ${DESTDIR}/usr/lib/libncursesw.so \
+		${DESTDIR}/usr/lib/libtinfo.so
+	ln -sfr ${DESTDIR}/usr/lib/libncursesw.so.${version} \
+		${DESTDIR}/usr/lib/libtinfo.so.${version}
+	ln -sfr ${DESTDIR}/usr/lib/libtinfo.so.${version} \
+		${DESTDIR}/usr/lib/libtinfo.so.${version:0:1}
+	ln -sfr ${DESTDIR}/usr/lib/pkgconfig/ncursesw.pc \
+		${DESTDIR}/usr/lib/pkgconfig/tinfo.pc
+
 	# Create compat symlinks.
 	for f in ncurses form panel menu; do
 		ln -sfr ${DESTDIR}/usr/lib/lib${f}w.so.6 \
@@ -96,7 +106,10 @@ ncurses-libs_package() {
 	shlib_provides="libformw.so.5 libmenuw.so.5 libpanelw.so.5 libncursesw.so.5"
 	short_desc+=" -- shared libraries"
 	pkg_install() {
-		vmove "usr/lib/*.so.*"
+		vmove "usr/lib/libform*.so.*"
+		vmove "usr/lib/libmenu*.so.*"
+		vmove "usr/lib/libncurses*.so.*"
+		vmove "usr/lib/libpanel*.so.*"
 	}
 }
 ncurses-devel_package() {
@@ -105,9 +118,17 @@ ncurses-devel_package() {
 	pkg_install() {
 		vmove "usr/bin/ncurses*-config"
 		vmove usr/include
-		vmove usr/lib/pkgconfig
+		vmove usr/lib/pkgconfig/ncursesw.pc
+		vmove usr/lib/pkgconfig/formw.pc
+		vmove usr/lib/pkgconfig/menuw.pc
+		vmove usr/lib/pkgconfig/ncurses++w.pc
+		vmove usr/lib/pkgconfig/panelw.pc
 		vmove "usr/lib/*.a"
-		vmove "usr/lib/*.so"
+		vmove "usr/lib/libcurses*.so"
+		vmove "usr/lib/libform*.so"
+		vmove "usr/lib/libmenu*.so"
+		vmove "usr/lib/libncurses*.so"
+		vmove "usr/lib/libpanel*.so"
 		vmove usr/share/man/man3
 		vmove usr/share/man/man1/ncursesw6-config.1
 	}
@@ -128,5 +149,23 @@ ncurses-term_package() {
 	pkg_install() {
 		vmove usr/share/tabset
 		vmove usr/share/terminfo
+	}
+}
+
+ncurses-libtinfo-libs_package() {
+	depends="ncurses-libs-${version}_${revision}"
+	short_desc+=" - libtinfo.so symlink"
+	pkg_install() {
+		vmove "usr/lib/libtinfo*.so.*"
+	}
+}
+
+ncurses-libtinfo-devel_package() {
+	depends="ncurses-devel-${version}_${revision}"
+	depends+=" ncurses-libtinfo-libs-${version}_${revision}"
+	short_desc+=" - libtinfo.so symlink - development files"
+	pkg_install() {
+		vmove usr/lib/libtinfo.so
+		vmove "usr/lib/pkgconfig/tinfo.pc"
 	}
 }


### PR DESCRIPTION
This change add an extra library "libtinfo.so".
From the documentation:
    When building the ncurses library, organize this as two parts:  the
    curses library (libncurses) and the low-level terminfo library
    (libtinfo).  This is done to accommodate applications
    that use only
    the latter.  The terminfo library is about half
    the size of the total.
This is used by some programs, which will rather look at libtinfo, than
libncurses.

Stack, the Haskell build tool, uses this to determine what resolver it needs, and I can see multiple people have had problems with Stack not running out of the box, this should fix this, and also make Stack work with the latest version resolver version (A resolver is like a set of package versions including ghc, which is supposed to work together)