### PR TITLE
New package: ReDoomEd.app-0.92.1.b1

### DIFF
--- a/srcpkgs/ReDoomEd.app/template
+++ b/srcpkgs/ReDoomEd.app/template
@@ -1,0 +1,28 @@
+# Template file for 'ReDoomEd.app'
+pkgname=ReDoomEd.app
+version=0.92.1.b1
+revision=1
+wrksrc="ReDoomEd.Sources.${version%.*}-${version##*.}"
+build_wrksrc=ReDoomEd
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="gnustep-make gcc-objc"
+makedepends="gnustep-gui-devel gnustep-base-devel"
+short_desc="GNUstep-based port of id Software’s Doom map editor for NeXTSTEP"
+maintainer="Kira Patton <roundduckman@protonmail.com>"
+# see LICENSE.txt and https://doomwiki.org/wiki/Data_Utility_License for more info about license,
+# this is also why the package is considered restricted, due to fuzzy legality issues
+license="AGPL-3.0-or-later, custom:id-DUL, custom:unknown"
+homepage="http://twilightedge.com/mac/redoomed/"
+distfiles="http://twilightedge.com/downloads/ReDoomEd.Sources.${version%.*}-${version##*.}.tar.gz"
+checksum=256e4e63a6f109281673fd6fb1a11d3872aea6064ae8e104cd1238c9a7c21fa5
+repository=nonfree
+restricted=yes
+if [ -e /usr/share/GNUstep/Makefiles/GNUstep.sh ]; then
+ 	. /usr/share/GNUstep/Makefiles/GNUstep.sh
+fi
+
+post_install() {
+	vinstall ReDoomEd.app/Resources/ReDoomEd.desktop 0755 /usr/share/applications/
+	vlicense ../LICENSE.txt
+}


### PR DESCRIPTION
Another GNUstep program, this is used to create Doom levels. It's another historical Unix program, but was ported over by the same dev behind PikoPixel.

That said, a big issue, until John Romero responds, is that licensing is very fucked up so this will be treated as a restricted proprietary package like Google Chrome, even though source code has to be compiled like an open source program.