### PR TITLE
rpi-kernel: update to 4.19.118.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="b13fc60b529fe9e4fee4a7a5caf73d582003abfa"
+_githash="fe2c7bf4cad4641dfb6f12712755515ab15815ca"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.115
+version=4.19.118
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,8 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=c0af88190562f9b08c2658a4cdca95ec592efc4a6146b9f21fbb90444231942a
+checksum=ca458e01428927cc12e13e4ef0de219902feeba5fd7f6bcb5056ce33c4688e90
+python_version=2
 
 _kernver="${version}_${revision}"
 


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.