### PR TITLE
spotifyd: add build_options

### DIFF
--- a/srcpkgs/spotifyd/template
+++ b/srcpkgs/spotifyd/template
@@ -1,10 +1,12 @@
 # Template file for 'spotifyd'
 pkgname=spotifyd
 version=0.2.24
-revision=1
+revision=2
 build_style=cargo
+configure_args="--no-default-features"
 hostmakedepends="pkg-config"
-makedepends="alsa-lib-devel libressl-devel pulseaudio-devel dbus-devel"
+makedepends="libressl-devel $(vopt_if alsa alsa-lib-devel)
+$(vopt_if pulseaudio pulseaudio-devel) $(vopt_if dbus dbus-devel)"
 short_desc="Spotify client running as a UNIX daemon"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"
@@ -12,14 +14,21 @@ homepage="https://github.com/Spotifyd/spotifyd"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=d3763f4647217a8f98ee938b50e141d67a5f3d33e9378894fde2a92c9845ef80
 
+build_options="alsa pulseaudio dbus"
+build_options_default="alsa pulseaudio dbus"
+
+_features="$(vopt_if alsa 'alsa_backend,')"
+_features+="$(vopt_if pulseaudio 'pulseaudio_backend,')"
+_features+="$(vopt_if dbus 'dbus_mpris,dbus_keyring')"
+
+if [ "$_features" ]; then
+	echo $_features
+	configure_args="$configure_args --features $_features"
+fi
+
 case "$XBPS_TARGET_MACHINE" in
 	aarch64-musl) broken="https://travis-ci.org/void-linux/void-packages/jobs/636076091" ;;
 esac
 
 export CFLAGS_${RUST_BUILD//-/_}="${CFLAGS_host}"
 export CC_${RUST_BUILD//-/_}="${BUILD_CC}"
-
-pre_configure() {
-	vsed -e 's/default = \[/& "dbus", "dbus-tokio", "pulseaudio_backend", "keyring", /' \
-	 -i Cargo.toml
-}


### PR DESCRIPTION
Instead of manually altering the Cargo.toml file, we use the feature
flags available in cargo. There are three build options now:

- alsa: ALSA backend
- pulseaudio: Pulseaudio backend
- dbus: D-Bus functionality, both mpris and keyring

This also allows for a greater granularity when specifying dependencies.
All build options are selected as default, both to keep the package the
same as it was before (alsa and pulseaudio) and because the dependency
needed by the dbus option (dbus-libs) is required by pulseaudio already.

This commit allows builders to easily disable D-Bus functionality or
either audio backend without altering the template.

--

Removing the dbus option as a default one would be ok too.

I'd also like to leave the template as an idea for how to start implementing the feature flags straight into the cargo build style.

@abenson can you review this one, please?

Also, the aarch64-musl error still happens, unfortunately, but is supposed to have been fixed in a next version of the `nix` crate. So perhaps when there's a next release we can re-enable the package for that arch as well.