### PR TITLE
ipv6calc: enable external and GeoIP2 databases

### DIFF
--- a/srcpkgs/ipv6calc/patches/use-bash-for-scripts.patch
+++ b/srcpkgs/ipv6calc/patches/use-bash-for-scripts.patch
@@ -1,0 +1,16 @@
+--- tools/ipv6calc-update-registries.sh~	2019-10-11 07:15:53.000000000 +0200
++++ tools/ipv6calc-update-registries.sh	2020-04-28 20:56:41.367743447 +0200
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ #
+ # Project    : ipv6calc/databases/registries
+ # File       : update-registries.sh
+--- tools/ipv6calc-registries-check-run-create.sh~	2019-10-11 07:15:53.000000000 +0200
++++ tools/ipv6calc-registries-check-run-create.sh	2020-04-28 20:56:42.704763285 +0200
+@@ -1,4 +1,4 @@
+-#!/bin/sh
++#!/bin/bash
+ #
+ # Project    : ipv6calc/databases/ipv4-assignment
+ # File       : ipv6calc-registries-check-run-create.sh

--- a/srcpkgs/ipv6calc/template
+++ b/srcpkgs/ipv6calc/template
@@ -1,11 +1,11 @@
 # Template file for 'ipv6calc'
 pkgname=ipv6calc
 version=2.2.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--enable-geoip"
+configure_args="--enable-geoip --enable-mmdb --enable-external"
 hostmakedepends="perl"
-makedepends="geoip-devel"
+makedepends="geoip-devel libmaxminddb-devel db-devel"
 short_desc="Small utility to manipulate IPv6 addresses"
 maintainer="Lon Willett <xgit@lonw.net>"
 license="GPL-2.0-only"


### PR DESCRIPTION
Also fix tool scripts to use bash instead of sh