### PR TITLE
kmscon: patch build, add service files

### DIFF
--- a/srcpkgs/kmscon/files/kmscon/conf
+++ b/srcpkgs/kmscon/files/kmscon/conf
@@ -1,0 +1,11 @@
+# ensure there isn't an agetty or getty service in this tty
+TTY=2
+SWITCH_VT=0
+
+if [ "$SWITCH_VT" = 1 ] then
+	SWITCH_FLAG="--switchvt"
+else
+	SWITCH_FLAG="--no-switchvt"
+fi
+
+KMSCON_FLAGS="--vt=tty${TTY} ${SWITCH_FLAG}"

--- a/srcpkgs/kmscon/files/kmscon/run
+++ b/srcpkgs/kmscon/files/kmscon/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -r conf ] && . ./conf
+
+exec /usr/bin/kmscon ${KMSCON_FLAGS}

--- a/srcpkgs/kmscon/template
+++ b/srcpkgs/kmscon/template
@@ -1,7 +1,7 @@
 # Template file for 'kmscon'
 pkgname=kmscon
 version=8
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--disable-static --disable-multi-seat"
 hostmakedepends="pkg-config docbook-xsl xkeyboard-config"
@@ -25,4 +25,6 @@ post_install() {
 	# Remove devel files.
 	rm -rf ${DESTDIR}/usr/include
 	rm -rf ${DESTDIR}/usr/lib/pkgconfig
+
+	vsv kmscon
 }


### PR DESCRIPTION
- Simple patch, required an #include in one of the files.
- Created a service for kmscon, by default on TTY2.
- Fix xlint errors.

--

@q66 I know you said you'd like to remove the package. but I had already written the whole thing :p 

So this PR is for making a decision too:

- Keep the package, so make it better supported: patch so it can actually build, plus a service to make it usable.
- Remove the package, and be done with it.