### PR TITLE
New package: void-docs-2020.08.18.

### DIFF
--- a/srcpkgs/void-docs-browse
+++ b/srcpkgs/void-docs-browse
@@ -1,0 +1,1 @@
+void-docs

--- a/srcpkgs/void-docs/template
+++ b/srcpkgs/void-docs/template
@@ -1,0 +1,29 @@
+# Template file for 'void-docs'
+pkgname=void-docs
+version=2020.08.18
+revision=1
+archs=noarch
+hostmakedepends="mdBook fd pandoc texlive perl perl-JSON"
+short_desc="Documentation for Void Linux"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="CC-BY-SA-4.0"
+homepage="https://github.com/void-linux/void-docs"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=52b621a3d15ba4c5f5a33a6c1a27efa5bde9739334d277f22026bfd603f6f24b
+
+export PREFIX=/usr
+
+do_build() {
+	res/build.sh
+}
+
+do_install() {
+	export DESTDIR
+	res/install.sh
+}
+
+void-docs-browse_package() {
+	depends="${sourcepkg}>=${version}_${revision} fzf mdcat"
+	short-desc+=" - browsing utilities"
+	build_style=meta
+}


### PR DESCRIPTION
So, instead of having versions of void-docs tagged and used here, I thought it'd be better to just select a commit and roll with it. This is totally subject to change, though.

This package stores the docs inside `/usr/share/void-docs/`, for now. It'd be useful for inclusion inside the live images that void ships. In the case this is accepted, it would make sense to include a terminal markdown formatter as well (either mdcat or glow). I also think it would be interesting to inform the user that these pages exist, perhaps as a warning on the motd? I don't know how I'd go about including it.

This is WIP for now, but intends to close https://github.com/void-linux/void-docs/issues/214 !