### PR TITLE
go-ipfs: update to 0.5.0

### DIFF
--- a/srcpkgs/go-ipfs/template
+++ b/srcpkgs/go-ipfs/template
@@ -1,6 +1,6 @@
 # Template file for 'go-ipfs'
 pkgname=go-ipfs
-version=0.4.23
+version=0.5.0
 revision=1
 build_style=go
 go_import_path="github.com/ipfs/${pkgname}"
@@ -13,12 +13,11 @@ license="MIT, Apache-2.0"
 homepage="https://ipfs.io"
 changelog="https://github.com/ipfs/go-ipfs/blob/master/CHANGELOG.md"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=21a7b7bfe822d5c6a64c4848eebd6f25f18ad4c94acdd0bbb56235c7c13d38c3
+checksum=df74fe2331958cffde20daa22df25d671af8a29b9f41137c9ad320902fc39496
 
 pre_build() {
-	# Disable the dynamic plugin loader for now; breaks cross.
 	if [ "$CROSS_BUILD" ]; then
-		rm plugin/loader/load_linux.go
+		export CGO_ENABLED=0
 	fi
 }
 


### PR DESCRIPTION
Cross-compilation still appears to be broken; building without GCC seems to work.