### PR TITLE
Remove packages: ConsoleKit2 and cgmanager

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -275,7 +275,6 @@ libXdmcp.so.6 libXdmcp-1.0.2_1
 libpolkit-gobject-1.so.0 polkit-0.99_1
 libpolkit-agent-1.so.0 polkit-0.99_1
 libpolkit-backend-1.so.0 polkit-0.99_1
-libck-connector.so.0 ConsoleKit2-0.9.2_1
 libXt.so.6 libXt-1.0.5_1
 libXtst.so.6 libXtst-1.0.3_1
 libxkbfile.so.1 libxkbfile-1.0.5_1
@@ -2047,7 +2046,6 @@ libopencv_dnn_superres.so.4.2 libopencv4-4.2.0_1
 libopencv_dpm.so.4.2 libopencv4-4.2.0_1
 libopencv_phase_unwrapping.so.4.2 libopencv4-4.2.0_1
 libopencv_stereo.so.4.2 libopencv4-4.2.0_1
-libcgmanager.so.0 libcgmanager-0.33_1
 libuniconf.so.4.6 wvstreams-4.6.1_2
 libwvbase.so.4.6 wvstreams-4.6.1_1
 libwvutils.so.4.6 wvstreams-4.6.1_1


### PR DESCRIPTION
Both packages have already been removed, but their entries in shlibs
weren't. This commit fixes that.