### PR TITLE
trident-networkmgr: Update to 2020.04.30

### DIFF
--- a/srcpkgs/trident-networkmgr/template
+++ b/srcpkgs/trident-networkmgr/template
@@ -1,8 +1,8 @@
 # Template file for 'trident-networkmgr'
 pkgname=trident-networkmgr
-version=2020.03.29.1
+version=2020.04.30
 revision=1
-wrksrc="trident-utilities-${version}"
+wrksrc="trident-utilities-${version}.1"
 build_wrksrc="src-qt5/networkmgr"
 build_style=qmake
 hostmakedepends="qt5-host-tools qt5-qmake"
@@ -12,8 +12,8 @@ short_desc="Graphical network manager from Project Trident"
 maintainer="Ken Moore <ken@project-trident.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/project-trident/trident-utilities"
-distfiles="https://github.com/project-trident/trident-utilities/archive/v${version}.tar.gz"
-checksum=87fc1b547f1da884dc9e9403914949e6f069ee5984484863d4f24c0b76189325
+distfiles="https://github.com/project-trident/trident-utilities/archive/v${version}.1.tar.gz"
+checksum=386299bca804b4d3a0319d4e5343da859b633a5ec40280645d00e1157d4932bc
 
 post_install() {
 	vlicense ${wrksrc}/LICENSE


### PR DESCRIPTION
This tool is now considered "production ready" upstream.

Sponsored by: Project Trident