### PR TITLE
cryptsetup: update to 2.3.2.

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,6 +1,6 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.3.1
+version=2.3.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl $(vopt_enable pwquality)
@@ -9,14 +9,14 @@ make_check_args="-C tests"
 hostmakedepends="pkg-config"
 makedepends="device-mapper-devel json-c-devel libressl-devel popt-devel
  libargon2-devel $(vopt_if pwquality 'libpwquality-devel')"
-checkdepends="util-linux procps-ng"
+checkdepends="util-linux procps-ng which jq tar xz xxd"
 short_desc="Setup virtual encryption devices under Linux dm-crypt"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=92aba4d559a2cf7043faed92e0f22c5addea36bd63f8c039ba5a8f3a159fe7d2
+checksum=a89e13dff0798fd0280e801d5f0cc8cfdb2aa5b1929bec1b7322e13d3eca95fb
 subpackages="libcryptsetup cryptsetup-devel"
 
 build_options="pwquality"


### PR DESCRIPTION
* Tested on x86_64.
* Some more checkdepends were needed to ensure that really all non-root tests are run.