### PR TITLE
fwupd: update to 1.4.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3875,4 +3875,4 @@ libhidrd_item.so.0
 libhidrd_opt.so.0 hidrd-0.2.0_1
 libhidrd_strm.so.0 hidrd-0.2.0_1
 libhidrd_fmt.so.0 hidrd-0.2.0_1
-
+libjcat.so.1 libjcat-0.1.2_1

--- a/srcpkgs/fwupd/template
+++ b/srcpkgs/fwupd/template
@@ -1,7 +1,7 @@
 # Template file for 'fwupd'
 pkgname=fwupd
-version=1.3.9
-revision=2
+version=1.4.1
+revision=1
 build_style=meson
 build_helper="gir"
 # manpages fail to build
@@ -16,13 +16,13 @@ hostmakedepends="dejavu-fonts-ttf gnutls-tools help2man pkg-config gcab
 makedepends="libxmlb-devel cairo-devel colord-devel libarchive-devel
  gnutls-devel gpgme-devel json-glib-devel libgusb-devel polkit-devel
  sqlite-devel libsoup-devel gcab-devel pango-devel python3-gobject
- python3-Pillow elogind-devel tpm2-tss-devel"
+ python3-Pillow elogind-devel tpm2-tss-devel libjcat-devel"
 short_desc="Daemon to allow session software to update firmware"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/hughsie/fwupd"
 distfiles="https://github.com/hughsie/fwupd/archive/${version}.tar.gz"
-checksum=d96c6a8e194c5190137d3a01fb1b9c17926c6b00860542380a5719e38ca4911b
+checksum=39153ad966b5f05446ed359cefc3bd2705bef47d3991e3978dc30003775faa0b
 
 # no efi on non-efi platforms
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/libjcat-devel
+++ b/srcpkgs/libjcat-devel
@@ -1,0 +1,1 @@
+libjcat

--- a/srcpkgs/libjcat/template
+++ b/srcpkgs/libjcat/template
@@ -1,0 +1,32 @@
+# Template file for 'libjcat'
+pkgname=libjcat
+version=0.1.2
+revision=1
+build_style=meson
+build_helper="gir"
+hostmakedepends="gnutls-tools pkg-config vala"
+makedepends="json-glib-devel gnutls-devel gpgme-devel"
+short_desc="Library for reading and writing Jcat files"
+maintainer="marmeladema <xademax@gmail.com>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/hughsie/libjcat"
+distfiles="https://github.com/hughsie/libjcat/archive/${version}.tar.gz"
+checksum=b80a31a872d5612fa98ac0cfe483e4d33f5b02777427864ff5305bfd33a11aa0
+
+if [ -n "$XBPS_CROSS_BUILD" ]; then
+	configure_args="-Dman=false"
+else
+	hostmakedepends+=" help2man"
+fi
+
+libjcat-devel_package() {
+	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+		vmove usr/share/vala
+		vmove "usr/share/gir-*"
+	}
+}


### PR DESCRIPTION
Current version of `fwupd` stopped working. It fails with an error:
```
Failed to update metadata for lvfs: failed to set protocol: Invalid crypto engine
```

Upgrading to last version seems to fix the issue.