### PR TITLE
New package: iwyu-9.0.1_1

### DIFF
--- a/srcpkgs/iwyu/template
+++ b/srcpkgs/iwyu/template
@@ -1,0 +1,33 @@
+# Template file for 'iwyu'
+pkgname=iwyu
+version=9.0.1
+revision=1
+__version=( ${version//./ } )
+_major=${__version[0]}
+_minor=${__version[1]}
+build_style=cmake
+configure_args="
+ -DCMAKE_BUILD_TYPE=Release
+ -DCMAKE_PREFIX_PATH=/usr/lib/clang/${version}"
+hostmakedepends="git python3"
+makedepends="clang clang-tools-extra llvm9 python3-devel"
+depends="libllvm9>=${version} libllvm9<10.0.0"
+short_desc="Automatically determine headers used in your project"
+maintainer="Joseph Benden <joe@benden.us>"
+license="NCSA"
+homepage="https://include-what-you-use.org/"
+# necessary to override auto default
+python_version=3
+
+do_fetch() {
+	git clone --branch=clang_${_major}.${_minor} \
+		https://github.com/include-what-you-use/include-what-you-use.git \
+		$pkgname-$version
+}
+
+do_install() {
+	vlicense LICENSE.TXT
+
+	cd build
+	cmake -DCMAKE_INSTALL_PREFIX=${DESTDIR}/usr -P cmake_install.cmake
+}

--- a/srcpkgs/iwyu/update
+++ b/srcpkgs/iwyu/update
@@ -1,0 +1,2 @@
+site=https://releases.llvm.org/
+pattern="'\K[\d\.]*(?=')"


### PR DESCRIPTION
This is the developer tool `include-what-you-use` version 9.0.1 (paired against the packaged Clang/LLVM).

I have been locally using the package, without problems.

Signed-off-by: Joseph Benden <joe@benden.us>