### PR TITLE
New package: straw-viewer-0.0.5

### DIFF
--- a/srcpkgs/gtk-straw-viewer
+++ b/srcpkgs/gtk-straw-viewer
@@ -1,0 +1,1 @@
+straw-viewer

--- a/srcpkgs/straw-viewer/template
+++ b/srcpkgs/straw-viewer/template
@@ -1,0 +1,27 @@
+# Template file for 'straw-viewer'
+pkgname=straw-viewer
+version=0.0.5
+revision=1
+archs=noarch
+build_style=perl-ModuleBuild
+configure_args="--gtk"
+hostmakedepends="perl-Module-Build"
+makedepends="perl"
+depends="perl-Data-Dump perl-JSON perl-LWP-Protocol-https"
+short_desc="Search and stream from YouTube using the API of invidio.us"
+maintainer="Roberto Ricci <ricci@disroot.org>"
+license="Artistic-2.0"
+homepage="https://github.com/trizen/straw-viewer"
+changelog="https://github.com/trizen/straw-viewer/releases"
+distfiles="https://github.com/trizen/straw-viewer/archive/${version}.tar.gz"
+checksum=eab78a6bf5cdc12131823345080babdde5ec41d1a472df317b20a09ee58232f2
+
+gtk-straw-viewer_package() {
+	depends="${sourcepkg}-${version}_${revision} perl-Gtk3 perl-File-ShareDir"
+	short_desc="Gtk interface to search and stream YouTube using the API of invidio.us"
+	pkg_install() {
+		vmove usr/bin/gtk-straw-viewer
+		vmove "usr/share/perl5/vendor_perl/auto/share/dist/WWW-StrawViewer/gtk-*"
+		vmove usr/share/perl5/vendor_perl/auto/share/dist/WWW-StrawViewer/icons
+	}
+}


### PR DESCRIPTION
Fork of youtube-viewer, by the same author. Uses the API of invidio.us, so it does not need a YouTube API key.