### PR TITLE
printrun: add python-numpy dependency

### DIFF
--- a/srcpkgs/printrun/template
+++ b/srcpkgs/printrun/template
@@ -1,13 +1,12 @@
 # Template file for 'printrun'
 pkgname=printrun
 version=1.6.0
-revision=2
+revision=3
 archs=noarch
 wrksrc="Printrun-printrun-${version}"
 build_style=python2-module
-pycompile_module="printrun"
 hostmakedepends="python-setuptools python-pyserial"
-depends="python wxPython python-pyserial python-pyglet"
+depends="python wxPython python-pyserial python-pyglet python-numpy"
 short_desc="3D printing host suite"
 maintainer="Jasper Chan <jasperchan515@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
`plater` would not start without Python 2.7 `numpy` being installed.

```
ryan@void ~ $ plater
/usr/lib/python2.7/site-packages/wx-3.0-gtk2/wx/_core.py:16629: UserWarning: wxPython/wxWidgets
  warnings.warn("wxPython/wxWidgets release number mismatch")
Traceback (most recent call last):
  File "/bin/plater", line 23, in <module>
    from printrun.stlplater import StlPlater
  File "/usr/lib/python2.7/site-packages/printrun/stlplater.py", line 36, in <module>
    from printrun import stltool
  File "/usr/lib/python2.7/site-packages/printrun/stltool.py", line 23, in <module>
    import numpy
ImportError: No module named numpy
```