### PR TITLE
nss: update to 3.52.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.25
 
 pkgname=nss
-version=3.51.1
+version=3.52
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,7 @@ maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=085c5eaceef040eddea639e2e068e70f0e368f840327a678ef74ae3d6c15ca78
+checksum=0a0aeb0cdda65ddcb64f746223df58b150f6803f4bfa1a4e876bbe6f9c4c1561
 
 do_build() {
 	local _native_use64 _target_use64


### PR DESCRIPTION
@q66 Please have a check.

`./xbps-src check nss` passed for `x86_64`