### PR TITLE
R-cran-lubridate: update to 1.7.8

### DIFF
--- a/srcpkgs/R-cran-generics/template
+++ b/srcpkgs/R-cran-generics/template
@@ -1,0 +1,10 @@
+# Template file for 'R-cran-generics'
+pkgname=R-cran-generics
+version=0.0.2
+revision=1
+build_style=R-cran
+short_desc="Common generic S3 methods "
+maintainer="luhann <lukehannan@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/r-lib/generics"
+checksum=71b3d1b719ce89e71dd396ac8bc6aa5f1cd99bbbf03faff61dfbbee32fec6176

--- a/srcpkgs/R-cran-lubridate/template
+++ b/srcpkgs/R-cran-lubridate/template
@@ -1,12 +1,12 @@
 # Template file for 'R-cran-lubridate'
 pkgname=R-cran-lubridate
-version=1.7.4
-revision=2
+version=1.7.8
+revision=1
 build_style=R-cran
-depends+=" R-cran-stringr R-cran-Rcpp>=0.12.13"
-makedepends+=" R-cran-stringr R-cran-Rcpp"
+makedepends="R-cran-generics R-cran-Rcpp"
+depends="R-cran-generics R-cran-Rcpp>=0.12.13"
 short_desc="Make Dealing with Dates a Little Easier"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-or-later"
-homepage="https://github.com/hadley/lubridate"
-checksum=510ca87bd91631c395655ee5029b291e948b33df09e56f6be5839f43e3104891
+homepage="https://github.com/tidyverse/lubridate"
+checksum=3da19922fc373e113ecc58c4984955ba26da703edc9c991bd444b7077d4b553c


### PR DESCRIPTION
generics is necessary for R-cran-lubridate-1.7.8