### PR TITLE
New packages: caps2esc-0.1.3, interception-tools-0.1.1

### DIFF
--- a/srcpkgs/caps2esc/files/caps2esc.yaml
+++ b/srcpkgs/caps2esc/files/caps2esc.yaml
@@ -1,0 +1,5 @@
+- JOB: "intercept -g $DEVNODE | caps2esc | uinput -d $DEVNODE"
+  DEVICE:
+    EVENTS:
+      EV_KEY: [KEY_CAPSLOCK, KEY_ESC]
+

--- a/srcpkgs/caps2esc/files/caps2esc/run
+++ b/srcpkgs/caps2esc/files/caps2esc/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+sv check udevd >/dev/null || exit 1
+exec /usr/bin/nice -n -20 /usr/bin/udevmon -c /etc/caps2esc.yaml 

--- a/srcpkgs/caps2esc/template
+++ b/srcpkgs/caps2esc/template
@@ -1,0 +1,22 @@
+# Template file for 'caps2esc'
+pkgname=caps2esc
+version=0.1.3
+revision=1
+wrksrc="caps2esc-v0.1.3-bb09cd8d9a3f04463df55cb4ba63d2d4920e04a9"
+build_style=cmake
+configure_args="-DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release"
+depends="interception-tools"
+short_desc="Transforming the most useless key ever in the most useful one"
+maintainer="Casey Getz <clg0000@gmail.com>"
+license="MIT"
+homepage="https://gitlab.com/interception/linux/plugins/caps2esc"
+distfiles="https://gitlab.com/interception/linux/plugins/caps2esc/repository/archive.tar.gz?ref=v${version}>caps2esc-${version}.tar.gz"
+checksum="4055525a195afa8c12c2e7b3635d856bb88088383393aa48d370bacdc5b0dea4"
+
+conf_files="/etc/caps2esc.yaml"
+
+post_install() {
+	vlicense LICENSE.md
+	vinstall ${FILESDIR}/caps2esc.yaml 644 etc
+	vsv caps2esc
+}

--- a/srcpkgs/interception-tools/template
+++ b/srcpkgs/interception-tools/template
@@ -1,0 +1,15 @@
+# Template file for 'interception-tools'
+pkgname=interception-tools
+version=0.1.1
+revision=1
+wrksrc="tools-v0.1.1-92830567d8d86384fd42502aa0eb3de12584cdaf"
+build_style=cmake
+configure_args="-DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release"
+makedepends="eudev-libudev-devel libevdev-devel yaml-cpp-devel"
+depends="eudev-libudev libevdev yaml-cpp"
+short_desc="Minimal composable infrastructure on top of libudev and libevdev"
+maintainer="Casey Getz <clg0000@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.com/interception/linux/tools"
+distfiles="https://gitlab.com/interception/linux/tools/repository/archive.tar.gz?ref=v${version}>interception-tools-${version}.tar.gz"
+checksum="722017f78c21469ddc3f8ec151ce5522dc75c31762a82d445a0d53bfe1bde491"


### PR DESCRIPTION
Two new packages:
* interception-tools (adapted from https://aur.archlinux.org/packages/interception-tools/)
* caps2esc (adapted from https://aur.archlinux.org/packages/interception-caps2esc/)

A service is provided to run caps2esc using tools provided by interception-tools.