### PR TITLE
NetworkManager: add rules for policykit

### DIFF
--- a/srcpkgs/NetworkManager/files/50-org.freedesktop.NetworkManager.rules
+++ b/srcpkgs/NetworkManager/files/50-org.freedesktop.NetworkManager.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+	if (action.id.indexOf("org.freedesktop.NetworkManager.") == 0 && subject.isInGroup("network")) {
+		return polkit.Result.YES;
+	}
+});

--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager'
 pkgname=NetworkManager
 version=1.22.10
-revision=1
+revision=2
 build_style=meson
 build_helper="gir qemu"
 configure_args="-Dpolkit_agent=true -Dsystemd_journal=false
@@ -68,6 +68,8 @@ pre_configure() {
 
 post_install() {
 	vinstall ${FILESDIR}/${pkgname}.conf 644 etc/${pkgname}
+	vinstall ${FILESDIR}/50-org.freedesktop.NetworkManager.rules 644 \
+		/usr/share/polkit-1/rules.d
 	vsv ${pkgname}
 }
 


### PR DESCRIPTION
allows members of the group 'network' to access NetworkManager. Fixes https://github.com/void-linux/void-packages/issues/21578