### PR TITLE
connman: allow members of network group to control daemon via dbus

### DIFF
--- a/srcpkgs/connman/files/connmand.conf
+++ b/srcpkgs/connman/files/connmand.conf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy group="network">
+   <allow own="net.connman"/>
+   <allow send_destination="net.connman"/>
+   <allow send_interface="net.connman"/>
+  </policy>
+</busconfig>

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -1,7 +1,7 @@
 # Template file for 'connman'
 pkgname=connman
 version=1.38
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat
@@ -33,6 +33,7 @@ post_install() {
 	# Install the client connmanctl.
 	vbin client/connmanctl
 	vsv connmand
+	vinstall ${FILESDIR}/connmand.conf 755 usr/share/dbus-1/system.d/
 }
 
 connman-devel_package() {


### PR DESCRIPTION
The change enables users of the the network group to use every ui available for the connman daemon. I tested connman-gtk, connman-ncurses, connman-ui, econnman and cmst.
Configuration is based on the wiki article: https://wiki.voidlinux.org/Connman