### PR TITLE
aws-vault: update to 5.4.3

### DIFF
--- a/srcpkgs/aws-vault/template
+++ b/srcpkgs/aws-vault/template
@@ -1,15 +1,16 @@
 # Template file for 'aws-vault'
 pkgname=aws-vault
-version=5.3.2
+version=5.4.3
 revision=1
 build_style=go
 go_import_path=github.com/99designs/aws-vault
+go_ldflags="-X \"main.Version=${version}\" -s -w"
 short_desc="Vault for securely storing and accessing AWS credentials"
 maintainer="klardotsh <josh@klar.sh>"
 license="MIT"
 homepage="https://github.com/99designs/aws-vault"
 distfiles="https://github.com/99designs/aws-vault/archive/v${version}${_status}.tar.gz"
-checksum=6bca7d1bebf02e72714bfbfa162cbb38a33a48e4ea64dc2829626ff68a407a6a
+checksum=2174413fd5ea7eb2f7ee0bbc393667a1044800e108ab6b8300331ec15d9ed01a
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
this also fixes `aws-vault --version` by actually populating the version number (rather than falling back to the default, `dev`)