### PR TITLE
gcc: gcc-ada needs libada-devel [ci skip]

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.21
 
 pkgname=gcc
 version=${_minorver}.0
-revision=3
+revision=4
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"
@@ -138,7 +138,7 @@ esac
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" cross-${_triplet}"
 	if [ "$build_option_ada" ]; then
-		hostmakedepends+=" gcc-ada libada-devel"
+		hostmakedepends+=" gcc-ada"
 	fi
 fi
 
@@ -408,7 +408,7 @@ do_install() {
 
 gcc-ada_package() {
 	lib32disabled=yes
-	depends="gcc>=${_minorver} libada>=${_minorver}"
+	depends="gcc>=${_minorver} libada-devel>=${_minorver}"
 	short_desc+=" - Ada compiler frontend"
 	pkg_install() {
 		for f in gnat{,bind,chop,clean,find,kr,link,ls,make,name,prep,xref}; do


### PR DESCRIPTION
Closes #21642.