### PR TITLE
rust: import fix-memory-mf_exec-on-aarch64.patch from alpine

### DIFF
--- a/srcpkgs/rust/patches/fix-memory-mf_exec-on-aarch64.patch
+++ b/srcpkgs/rust/patches/fix-memory-mf_exec-on-aarch64.patch
@@ -1,0 +1,27 @@
+Source: https://git.alpinelinux.org/aports/tree/main/llvm9/fix-memory-mf_exec-on-aarch64.patch
+
+Fix failures in AllocationTests/MappedMemoryTest.* on aarch64:
+
+    Failing Tests (8):
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.AllocAndRelease/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.DuplicateNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.EnabledWrite/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.MultipleAllocAndRelease/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.SuccessiveNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.UnalignedNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.ZeroNear/3
+        LLVM-Unit :: Support/./SupportTests/AllocationTests/MappedMemoryTest.ZeroSizeNear/3
+
+Upstream-Issue: https://bugs.llvm.org/show_bug.cgi?id=14278#c10
+
+--- ./lib/Support/Unix/Memory.inc
++++ ./lib/Support/Unix/Memory.inc
+@@ -59,7 +59,7 @@
+     return PROT_READ | PROT_WRITE | PROT_EXEC;
+   case llvm::sys::Memory::MF_EXEC:
+ #if (defined(__FreeBSD__) || defined(__POWERPC__) || defined (__ppc__) || \
+-     defined(_POWER) || defined(_ARCH_PPC))
++     defined(_POWER) || defined(_ARCH_PPC) || (defined(__linux__) && defined(__aarch64__)))
+     // On PowerPC, having an executable page that has no read permission
+     // can have unintended consequences.  The function InvalidateInstruction-
+     // Cache uses instructions dcbf and icbi, both of which are treated by

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -5,7 +5,7 @@
 # See: https://github.com/rust-lang/core-team/issues/4
 pkgname=rust
 version=1.41.1
-revision=2
+revision=3
 _rust_dist_version=1.40.0
 _cargo_dist_version=0.41.0
 # Always make sure custom distfiles used for bootstrap are


### PR DESCRIPTION
addresses buildfail in #21577