### PR TITLE
R-cran-stringi: update to 1.4.6

### DIFF
--- a/srcpkgs/R-cran-stringi/template
+++ b/srcpkgs/R-cran-stringi/template
@@ -1,14 +1,14 @@
 # Template file for 'R-cran-stringi'
 pkgname=R-cran-stringi
-version=1.4.3
-revision=2
+version=1.4.6
+revision=1
 build_style=R-cran
 makedepends="pkg-config icu-devel"
 short_desc="Character String Processing Facilities"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="BSD-3-Clause"
 homepage="http://gagolewski.com/software/stringi/"
-checksum=13cecb396b700f81af38746e97b550a1d9fda377ca70c78f6cdfc770d33379ed
+checksum=633f67da5bd7bcb611764e4f478b0da050d22a715bbcbdd67aed0300dcef6fd6
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
The previous version no longer can be downloaded so it cannot be built.