### PR TITLE
common/shlibs: remove non-existent radare2 lib

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3141,7 +3141,6 @@ libkdeconnectinterfaces.so.1 kdeconnect-1.2_1
 libkdeconnectcore.so.1 kdeconnect-1.2_1
 libkpmcore.so.9 kpmcore-4.1.0_1
 libpkcs11-helper.so.1 pkcs11-helper-1.22_1
-libr2.so.2.5.0 radare2-2.5.0_1
 libr_core.so radare2-2.2.0_1
 libr_config.so radare2-2.2.0_1
 libr_cons.so radare2-2.2.0_1


### PR DESCRIPTION
The package no longer ships that lib.