### PR TITLE
nheko: add upstream patch; fix depends

### DIFF
--- a/srcpkgs/nheko/patches/fix_invites.patch
+++ b/srcpkgs/nheko/patches/fix_invites.patch
@@ -1,0 +1,14 @@
+Reason: Fix double percent encoding of invites
+Upstream: Taken from upstream commit https://github.com/Nheko-Reborn/nheko/commit/d94ac8 
+--- src/ChatPage.cpp.orig
++++ src/ChatPage.cpp
+@@ -1015,8 +1015,7 @@
+ void
+ ChatPage::joinRoom(const QString &room)
+ {
+-        // Percent escape the room ID
+-        const auto room_id = QUrl::toPercentEncoding(room).toStdString();
++        const auto room_id = room.toStdString();
+ 
+         http::client()->join_room(
+           room_id, [this, room_id](const nlohmann::json &, mtx::http::RequestErr err) {

--- a/srcpkgs/nheko/template
+++ b/srcpkgs/nheko/template
@@ -1,13 +1,14 @@
 # Template file for 'nheko'
 pkgname=nheko
 version=0.7.1
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="qt5-host-tools qt5-qmake pkg-config qt5-declarative"
 makedepends="qt5-multimedia-devel qt5-svg-devel qt5-tools-devel
  tweeny spdlog mtxclient-devel boost-devel cmark-devel olm-devel json-c++
  libsodium-devel lmdb++ qt5-declarative-devel qt5-quickcontrols2-devel"
-depends="hicolor-icon-theme qt5-quickcontrols2 qt5-graphicaleffects"
+depends="hicolor-icon-theme qt5-quickcontrols2 qt5-graphicaleffects
+ qt5-multimedia"
 short_desc="Desktop client for Matrix using Qt and C++14"
 maintainer="Lorem <notloremipsum@protonmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
- Added qt5-multimedia as a runtime dependency,
without it the chat pages would be blank.
- Added upstream patch to fix encoding of invite links.

Sorry for second bump regarding depends post last release, I will test runtime dependencies for packages more thoroughly in future.