### PR TITLE
chromium: update to 81.0.4044.138. 

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=81.0.4044.129
+version=81.0.4044.138
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=fe140112304b243240a5f6b287105fd5b7d6e48c6ff682194a62c8d08fd0ed5b
+checksum=9d13d41d79ce1f04d1f150b5d22fffd31779224cc7d8274f8479b06bcfe6846a
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=81.0.4044.129
+version=81.0.4044.138
 revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=ff74592f83ed91c082f746c6b0a3acf384bad91f170bd24548971c17f43046d3
+checksum=f478f28b8111cb70231df4c36e754d812ad7a94b7c844e9d0515345a71fd77a6
 
 lib32disabled=yes
 nodebug=yes


### PR DESCRIPTION
[ci skip]

- Built for x86_64, x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine.