### PR TITLE
libuv: update to 1.37.0

### DIFF
--- a/srcpkgs/libuv/template
+++ b/srcpkgs/libuv/template
@@ -1,6 +1,6 @@
 # Template file for 'libuv'
 pkgname=libuv
-version=1.35.0
+version=1.37.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
@@ -10,7 +10,7 @@ license="MIT, CC-BY-SA-4.0"
 homepage="https://libuv.org/"
 changelog="https://raw.githubusercontent.com/libuv/libuv/v1.x/ChangeLog"
 distfiles="https://github.com/libuv/libuv/archive/v${version}.tar.gz"
-checksum=ff84a26c79559e511f087aa67925c3b4e0f0aac60cd8039d4d38b292f208ff58
+checksum=7afa3c8a326b3eed02a9addb584ae7e995ae4d30516cad5e1e4af911931162a6
 
 LDFLAGS="-pthread"
 


### PR DESCRIPTION
The update seems to fix an issue with bind9 (named).