### PR TITLE
firefox: rebuild without system-nss

### DIFF
--- a/srcpkgs/firefox/files/mozconfig
+++ b/srcpkgs/firefox/files/mozconfig
@@ -1,8 +1,6 @@
 ac_add_options --prefix=/usr
 ac_add_options --libdir=/usr/lib
 
-ac_add_options --with-system-nspr
-ac_add_options --with-system-nss
 ac_add_options --with-system-bz2
 ac_add_options --with-system-jpeg
 ac_add_options --with-system-zlib

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -4,7 +4,7 @@
 #
 pkgname=firefox
 version=76.0
-revision=1
+revision=2
 build_helper="rust"
 short_desc="Mozilla Firefox web browser"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
@@ -17,7 +17,7 @@ lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python3 yasm rust cargo
  llvm clang nodejs-lts-10 cbindgen python nasm which tar"
-makedepends="nss-devel libjpeg-turbo-devel gtk+-devel gtk+3-devel icu-devel
+makedepends="libjpeg-turbo-devel gtk+-devel gtk+3-devel icu-devel
  pixman-devel libevent-devel libnotify-devel libvpx-devel
  libXrender-devel libXcomposite-devel libSM-devel libXt-devel rust-std
  libXdamage-devel freetype-devel $(vopt_if alsa alsa-lib-devel)
@@ -25,7 +25,7 @@ makedepends="nss-devel libjpeg-turbo-devel gtk+-devel gtk+3-devel icu-devel
  $(vopt_if startup_notification startup-notification-devel)
  $(vopt_if xscreensaver libXScrnSaver-devel)
  $(vopt_if sndio sndio-devel) $(vopt_if jack jack-devel)"
-depends="nss>=3.47.1 desktop-file-utils hicolor-icon-theme"
+depends="desktop-file-utils hicolor-icon-theme"
 conflicts="firefox-esr>=0"
 
 build_options="alsa jack dbus pulseaudio startup_notification xscreensaver sndio wayland"


### PR DESCRIPTION
building firefox-67.0 against nss-3.52 results in broken webrtc
disable system-nss as a workaround