### PR TITLE
riot-desktop: update to 1.6.0.

### DIFF
--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,65 +1,58 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=1.5.15
+version=1.6.0
 revision=1
 archs="i686 x86_64"
 wrksrc="riot-web-${version}"
 conf_files="/etc/${pkgname}/config.json"
-hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl"
-depends="c-ares ffmpeg gtk+3 http-parser libevent libxslt minizip nss re2 snappy"
+hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl libappindicator-devel libnotify-devel"
+depends="c-ares ffmpeg gtk+3 http-parser libevent libxslt minizip nss re2 snappy sqlcipher"
 short_desc="Glossy Matrix collaboration client, desktop version"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="projectmoon <projectmoon@agnos.is>"
 license="Apache-2.0"
 homepage="https://riot.im"
-distfiles="https://github.com/vector-im/riot-web/archive/v${version}.tar.gz"
-checksum="3d5512f842fa436aef00b1b1f1c5ced4a4f1adc5cc1bcfddbc77573387f9cc42"
+distfiles="https://github.com/vector-im/riot-desktop/archive/v${version}.tar.gz>riot-desktop.tar.gz https://github.com/vector-im/riot-web/archive/v${version}.tar.gz>riot-web.tar.gz"
+checksum="4b1befbabb1fc391d0a9a49125540903fa97d5bbad033bdaff377a018a244333 0e54adbda71e2d572f1ecdec3a6f07cb6379e5c9f8223bff19580d2e663f50c4"
 nocross=yes
 nostrip=yes
-shlib_provides="libGLVESv2.so"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="/void-packages/srcpkgs/riot-desktop/template: line 20:   390 Segmentation fault" ;;
 esac
 
 pre_build() {
-	# This section is borrowed from the Arch PKGBUILD
-	sed -i 's@https://riot.im/download/desktop/update/@null@g' electron_app/riot.im/config.json
-	sed -i 's/"target": "deb"/"target": "dir"/g' package.json
+	# Build dependencies for riot-web
 	yarn install
 
-	# Add the matrix-seshat package (which is needed for search in E2E encrypted
-	# rooms) as well as the electron-build-env package, which gets used later to
-	# rebuild the native libraries against electron’s version of node.
-	# See here for more information:
-	# https://github.com/vector-im/riot-web/blob/develop/docs/native-node-modules.md#adding-seshat-for-search-in-e2e-encrypted-rooms
-	cd electron_app
-	yarn add matrix-seshat
-	yarn add electron-build-env
-	# Finally also enable the event indexing feature in the config.
-	sed -i 's/"features": {/"features": {\n        "feature_event_indexing": "enable",/' riot.im/config.json
+	# Build dependencies and alterations for riot-desktop
+	cd ../riot-desktop-${version}
+	# Disable auto-updating.
+	sed -i 's@https://packages.riot.im/desktop/update/@null@g' riot.im/release/config.json
+	sed -i 's/"target": "deb"/"target": "dir"/g' package.json
+	yarn install
 }
 
 do_build() {
-	# This is also borrowed from the Arch PKGBUILD
-	cd electron_app
-	# Recompile matrix-seshat
-	yarn run electron-build-env -- --electron 7 neon build matrix-seshat --release
-	cd ..
-	# Do the actual build
-	yarn build:electron:linux
+	yarn build
+	cd ../riot-desktop-${version}
+	yarn run build:native
+	yarn run build
 }
 
 do_install() {
 	vmkdir usr/lib/riot-desktop
 	vmkdir etc/riot-desktop
-	vcopy electron_app/dist/linux-unpacked/* /usr/lib/riot-desktop
-	vinstall config.sample.json 664 /etc/riot-desktop/ config.json
-	ln -s /etc/riot-desktop/config.json $DESTDIR/usr/lib/riot-desktop/resources/webapp
+	vcopy ../riot-desktop-${version}/dist/linux-unpacked/* /usr/lib/riot-desktop
+	vinstall config.sample.json 644 /etc/riot-desktop/ config.json
+	vcopy webapp /usr/lib/riot-desktop/resources
+	ln -s /etc/riot-desktop/config.json $DESTDIR/usr/lib/riot-desktop/resources/webapp/config.json
+
 	vmkdir usr/bin
-	ln -s /usr/lib/riot-desktop/riot-web $DESTDIR/usr/bin/riot-desktop
+	ln -s /usr/lib/riot-desktop/riot-desktop $DESTDIR/usr/bin/riot-desktop
 	vinstall ${FILESDIR}/riot-desktop.desktop 644 /usr/share/applications/ riot-desktop.desktop
-	vinstall res/themes/riot/img/logos/riot-im-logo.svg 644 /usr/share/icons/hicolor/scalable/apps/ riot.svg
+	vinstall webapp/themes/riot/img/logos/riot-logo.svg 644 /usr/share/icons/hicolor/scalable/apps/ riot.svg
+
 	for i in 16 24 48 64 96 128 256 512; do
-		vinstall electron_app/build/icons/${i}x${i}.png 644 /usr/share/icons/hicolor/${i}x${i}/apps/ riot.png
+		vinstall ../riot-desktop-${version}/build/icons/${i}x${i}.png 644 /usr/share/icons/hicolor/${i}x${i}/apps/ riot.png
 	done
 }


### PR DESCRIPTION
Riot 1.6.0 came out ~2 days ago. This is a build for 1.6.0 following the new instructions posted here: https://github.com/vector-im/riot-desktop. This build also fixes the encrypted room search (version 1.5.15 has a syntax error in the build I think).

I am not exactly happy about this build downloading riot's source via yarn, although it does at least verify it with GPG. It uses a NodeJS script in the distfile to acquire riot-web's code for building. I would like a suggestion on how to improve this (unless it's okay by the Void maintainers, in which case, let's go crazy). It should be noted that the Riot developers plan to support fetching from arbitrary URLs in the future, but right now the script is required to download the riot-web source.

I think I will at least try to move the key and signature files to XBPS distfiles instead of letting yarn fetch them.

Edit: ^ having XBPS download the key files didn't really work.