### PR TITLE
bc-gh: update to 2.7.2

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,6 +1,6 @@
 # Template file for 'bc-gh'
 pkgname=bc-gh
-version=2.6.0
+version=2.7.2
 revision=1
 wrksrc="bc-${version}"
 short_desc="Implementation of POSIX bc with GNU extensions"
@@ -8,7 +8,7 @@ maintainer="Gavin D. Howard <yzena.tech@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/gavinhoward/bc"
 distfiles="${homepage}/releases/download/${version}/bc-${version}.tar.xz"
-checksum=2b9f08ee9db9ca8b1d3c159a5af5fed981fcd98899630add72d327083673eb80
+checksum=c017a6c0482cf7c4a2b31dae1f406028017a5e939d98dd6c78aa94ce3ecc8d38
 alternatives="
  bc:bc:/usr/bin/bc-gh
  bc:bc.1:/usr/share/man/man1/bc-gh.1


### PR DESCRIPTION
This release fixes a bug in an extension. In releases `2.7.0` and `2.7.1`, a pseudo-random number generator is added along with several locales.