### PR TITLE
New package: howl-0.6

### DIFF
--- a/srcpkgs/howl/template
+++ b/srcpkgs/howl/template
@@ -1,0 +1,21 @@
+# Template file for 'howl'
+pkgname=howl
+version=0.6
+revision=1
+build_wrksrc=src
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="pkg-config"
+makedepends="gtk+3-devel"
+short_desc="Lightweight and fully customizable general purpose editor"
+maintainer="reback00 <reback00@protonmail.com>"
+license="MIT"
+homepage="http://howl.io/"
+distfiles="https://github.com/howl-editor/howl/releases/download/${version}/howl-${version}.tgz"
+checksum=834b06e423d360c97197e7abec99b623fdc5ed3a0c39b88d6467e499074585e1
+python_version="3"
+nocross="https://travis-ci.org/github/void-linux/void-packages/jobs/684238158"
+
+post_install() {
+	vlicense ../LICENSE.md
+}


### PR DESCRIPTION
"Howl is a general purpose editor that aims to be both lightweight and fully customizable. It's built on top of the very fast LuaJIT runtime, uses Gtk for its interface, and can be extended in either Lua or Moonscript."

https://github.com/howl-editor/howl \
http://howl.io/

It's in the Arch Linux Community repo. Hope it's useful for Void users too.

It was requested [here](https://github.com/void-linux/void-packages/issues/21583).