### PR TITLE
libglvnd: Add missing shlib

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -153,6 +153,7 @@ libnvidia-fatbinaryloader.so.430.40 nvidia-libs-430.40_1 ignore
 libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
 libOpenGL.so.0 libglvnd-1.3.0_1
+libGLdispatch.so.0 libglvnd-1.3.1_1
 libGLX.so.0 libglvnd-1.3.0_1
 librsvg-2.so.2 librsvg-2.26.0_1
 libdbus-1.so.3 dbus-libs-1.2.10_1


### PR DESCRIPTION
`xlocate` reports that `libglvnd` provides `/usr/lib/libGLdispatch.so.0`.
There might also be others missing, but the package I was building required this one.