### PR TITLE
offlineimap: update to 7.3.3.

### DIFF
--- a/srcpkgs/offlineimap/template
+++ b/srcpkgs/offlineimap/template
@@ -1,19 +1,18 @@
 # Template file for 'offlineimap'
 pkgname=offlineimap
-version=7.3.2
+version=7.3.3
 revision=1
 archs=noarch
 build_style=python2-module
-pycompile_module="offlineimap"
 hostmakedepends="python-six python-rfc6555 asciidoc"
 depends="python-six python-rfc6555"
 short_desc="Powerful IMAP/Maildir synchronization and reader support"
-maintainer="Peter Bui <pbui@github.bx612.space>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://offlineimap.org/"
 changelog="https://raw.githubusercontent.com/OfflineIMAP/offlineimap/master/Changelog.md"
 distfiles="https://github.com/OfflineIMAP/offlineimap/archive/v${version}.tar.gz"
-checksum=d47b564858c3e9fc7726ef58c9a4ee518d2958c5de3dcad6cd78b7cfe0a6bdef
+checksum=bf1a777e63d2174eef0fe864ea577d843515b64d4f3a8630ad2d1b34a4afcaa6
 
 post_install() {
 	make -C docs man


### PR DESCRIPTION
Also orphan package (I have switched to mbsync so I can remove Python2 from systems).  Offlineimap currently does not have a roadmap to Python3 and may never make that transition.