### PR TITLE
fzf: install fzf.vim to Neovim plugin directory

### DIFF
--- a/srcpkgs/fzf/template
+++ b/srcpkgs/fzf/template
@@ -1,7 +1,7 @@
 # Template file for 'fzf'
 pkgname=fzf
 version=0.22.0
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/junegunn/fzf
 hostmakedepends="git"
@@ -22,7 +22,8 @@ post_install() {
 
 	sed -i -e 's#source ~/\.fzf\.bash; ##' shell/key-bindings.bash
 	vinstall plugin/fzf.vim 644 usr/share/vim/vimfiles/plugin
-	vinstall shell/completion.bash 644 usr/share/bash-completion/completions fzf
+	vinstall plugin/fzf.vim 644 usr/share/nvim/runtime/plugin
+	vinstall shell/completion.bash 644 usr/share/doc/fzf
 	vinstall shell/completion.zsh 644 usr/share/doc/fzf
 	vinstall shell/key-bindings.zsh 644 usr/share/doc/fzf
 	vinstall shell/key-bindings.bash 644 usr/share/doc/fzf


### PR DESCRIPTION
For Vim users, FZF works out of the box, but Neovim users have to
manually copy /usr/share/vim/vimfiles/plugin/fzf.vim to the proper
Neovim equivalent.