### PR TITLE
libucontext: switch upstream + update to 0.10

### DIFF
--- a/srcpkgs/libucontext/template
+++ b/srcpkgs/libucontext/template
@@ -1,19 +1,21 @@
 # Template file for 'libucontext'
 pkgname=libucontext
-version=0.9.0
+version=0.10
 revision=1
 archs="*-musl"
+wrksrc="${pkgname}-${pkgname}-${version}"
 short_desc="Compatibility layer providing ucontext functions"
-maintainer="Peter Bui <pbui@github.bx612.space>"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="ISC"
-homepage="https://code.foxkit.us/adelie/libucontext"
-distfiles="https://distfiles.adelielinux.org/source/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68
+homepage="https://github.com/kaniini/libucontext"
+distfiles="https://github.com/kaniini/libucontext/archive/${pkgname}-${version}.tar.gz"
+checksum=e77dee222a31d6ad66c7668ceab197ac683349ab943f66cfe8c324324778ac9f
 
 case "${XBPS_TARGET_MACHINE}" in
 arm*)	export LIBUCONTEXT_ARCH="arm";;
 i686*)	export LIBUCONTEXT_ARCH="x86";;
 ppc64*) export LIBUCONTEXT_ARCH="ppc64";;
+mips*)  export LIBUCONTEXT_ARCH="mips";;
 *)	export LIBUCONTEXT_ARCH="${XBPS_TARGET_MACHINE%%-musl}";;
 esac
 

--- a/srcpkgs/ruby/template
+++ b/srcpkgs/ruby/template
@@ -37,7 +37,7 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc64*) # Default is ucontext on BE, but ppc64le really just means ELFv2
 		configure_args+=" --with-coroutine=ppc64le"
 		;;
-	ppc-musl)
+	mips*-musl|ppc-musl)
 		_need_libucontext=yes
 		makedepends+=" libucontext-devel"
 		configure_args+=" LIBS=-lucontext"


### PR DESCRIPTION
New upstream (original source?) has updates to support `mips*` architectures.
This lets us build `ruby` and packages depending on it for `mips*` (e.g. `webkit2gtk`) again.
