### PR TITLE
llhttp: update to 2.0.5

### DIFF
--- a/srcpkgs/llhttp/template
+++ b/srcpkgs/llhttp/template
@@ -1,6 +1,6 @@
 # Template file for 'llhttp'
 pkgname=llhttp
-version=1.1.4
+version=2.0.5
 revision=1
 wrksrc="llhttp-release-v${version}"
 build_style=gnu-makefile
@@ -11,7 +11,7 @@ homepage="https://llhttp.org/"
 # _always_ use releases. Those have the C code generated, otherwise
 # we'd have a dep loop nodejs<->llhttp
 distfiles="https://github.com/nodejs/llhttp/archive/release/v${version}.tar.gz"
-checksum=eeb07e60a8f4113b110dd758756da3db69e4e2575b0407afb0a7755aef504dbb
+checksum=48f882f0b6cecc48aec8f81072ee4d80fe9a4b5e1bce009e3cf8aecbe5892c1a
 
 post_extract() {
 	# No need to pull in gyp for such a simple Makefile...


### PR DESCRIPTION
This is needed to update nodejs and nodejs-lts.