### PR TITLE
shared-mime-info: update to 2.0.

### DIFF
--- a/srcpkgs/shared-mime-info/template
+++ b/srcpkgs/shared-mime-info/template
@@ -1,15 +1,15 @@
 # Template file for 'shared-mime-info'
 pkgname=shared-mime-info
-version=1.15
+version=2.0
 revision=1
-build_style=gnu-configure
-configure_args="--disable-update-mimedb"
-hostmakedepends="pkg-config intltool itstool gettext-devel"
+build_style=meson
+configure_args="-Dupdate-mimedb=false"
+hostmakedepends="pkg-config intltool itstool gettext-devel xmlto"
 makedepends="libglib-devel libxml2-devel"
 short_desc="Core database of common types"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://freedesktop.org/Software/shared-mime-info"
-distfiles="https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/b27eb88e4155d8fccb8bb3cd12025d5b/shared-mime-info-${version}.tar.xz"
-checksum=f482b027437c99e53b81037a9843fccd549243fd52145d016e9c7174a4f5db90
+distfiles="https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/0440063a2e6823a4b1a6fb2f2af8350f/shared-mime-info-${version}.tar.xz"
+checksum=23c1cb7919f31cf97aeb5225548f75705f706aa5cc7d1c4c503364bcc8681e06
 disable_parallel_build=yes


### PR DESCRIPTION
- Upstream switches from gnu-configure to meson.
- Now requires xmlto to build.