### PR TITLE
util-linux: split libraries into separated template files

### DIFF
--- a/srcpkgs/libblkid
+++ b/srcpkgs/libblkid
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libblkid-devel
+++ b/srcpkgs/libblkid-devel
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libfdisk
+++ b/srcpkgs/libfdisk
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libfdisk-devel
+++ b/srcpkgs/libfdisk-devel
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libmount
+++ b/srcpkgs/libmount
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libmount-devel
+++ b/srcpkgs/libmount-devel
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libsmartcols
+++ b/srcpkgs/libsmartcols
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libsmartcols-devel
+++ b/srcpkgs/libsmartcols-devel
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libuuid
+++ b/srcpkgs/libuuid
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/libuuid-devel
+++ b/srcpkgs/libuuid-devel
@@ -1,1 +1,1 @@
-util-linux
+util-linux-libs

--- a/srcpkgs/util-linux-libs/patches/fix-musl.patch
+++ b/srcpkgs/util-linux-libs/patches/fix-musl.patch
@@ -1,0 +1,1 @@
+../../util-linux/patches/fix-musl.patch

--- a/srcpkgs/util-linux-libs/template
+++ b/srcpkgs/util-linux-libs/template
@@ -1,0 +1,151 @@
+# Template file for 'util-linux-libs'
+# Keep this package sync with util-linux
+pkgname=util-linux-libs
+version=2.35.1
+revision=2
+wrksrc="util-linux-$version"
+build_style=meta
+hostmakedepends="automake bison gettext-devel libtool pkg-config xz"
+makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel"
+depends="libfdisk libblkid libmount libsmartcols libuuid"
+checkdepends="ncurses" # Some tests require terminfo-entries
+short_desc="Miscellaneous linux utilities - meta libraries"
+maintainer="Enno Boland <gottox@voidlinux.org>"
+license="GPL-2.0-or-later"
+homepage="https://www.kernel.org/pub/linux/utils/util-linux/"
+distfiles="${KERNEL_SITE}/utils/util-linux/v2.35/util-linux-${version}.tar.xz"
+checksum=d9de3edd287366cd908e77677514b9387b22bc7b88f45b83e1922c3597f1d7f9
+
+pre_configure() {
+	local _cfgdir="$XBPS_COMMONDIR/environment/configure"
+	NOCONFIGURE=1 ./autogen.sh
+	for f in ./**/*config*.sub; do
+		if [ -f "$f" ]; then
+			cp -f "$_cfgdir/automake/config.sub" "$f"
+		fi
+	done
+	for f in ./**/*config*.guess; do
+		if [ -f "$f" ]; then
+			cp -f "$_cfgdir/automake/config.guess" "$f"
+		fi
+	done
+	# We want to keep basepkg as meta but we also needs below helper
+	unset build_style
+	. "$_cfgdir/gnu-configure-args.sh"
+}
+
+do_configure() {
+	./configure ${configure_args} \
+		--exec-prefix=/usr --libdir=/usr/lib \
+		--bindir=/usr/bin --sbindir=/usr/bin \
+		--enable-libuuid --disable-makeinstall-chown \
+		--enable-libblkid --enable-fsck --disable-rpath \
+		--enable-fs-paths-extra=/usr/sbin:/usr/bin \
+		--enable-vipw --enable-newgrp --enable-chfn-chsh \
+		--with-systemdsystemunitdir=no \
+		--without-udev --without-python \
+		--enable-write
+}
+
+do_build() {
+	make ${makejobs}
+}
+
+do_check() {
+	make -k check
+}
+
+do_install() {
+	make usrsbin_execdir=/usr/bin DESTDIR=${DESTDIR} install
+	# Those files will be provided by util-linux
+	rm -rf "$DESTDIR/usr/bin"
+	rm -rf "$DESTDIR/usr/share/man/man1"
+	rm -rf "$DESTDIR/usr/share/man/man5"
+	rm -rf "$DESTDIR/usr/share/man/man8"
+	rm -rf "$DESTDIR/usr/share/bash-completion"
+	rm -rf "$DESTDIR/usr/share/locale"
+	rm -rf "$DESTDIR/usr/share/doc/"
+}
+
+libfdisk_package() {
+	short_desc="Library for fdisk(8)"
+	pkg_install() {
+		vmove "usr/lib/libfdisk.so.*"
+	}
+}
+libfdisk-devel_package() {
+	depends="libblkid-devel-${version}_${revision} libfdisk-${version}_${revision}"
+	short_desc="Library for fdisk(8) - development files"
+	pkg_install() {
+		vmove usr/lib/libfdisk.a
+		vmove usr/lib/libfdisk.so
+		vmove "usr/lib/pkgconfig/*fdisk*"
+		vmove usr/include/libfdisk
+	}
+}
+libmount_package() {
+	short_desc="Library for mount(8)"
+	pkg_install() {
+		vmove "usr/lib/libmount.so.*"
+	}
+}
+libmount-devel_package() {
+	depends="libblkid-devel-${version}_${revision} libmount-${version}_${revision}"
+	short_desc="Library for mount(8) - development files"
+	pkg_install() {
+		vmove usr/lib/libmount.a
+		vmove usr/lib/libmount.so
+		vmove "usr/lib/pkgconfig/*mount*"
+		vmove usr/include/libmount
+	}
+}
+libblkid_package() {
+	short_desc="Library to handle device identification"
+	pkg_install() {
+		vmove "usr/lib/libblkid.so.*"
+	}
+}
+libblkid-devel_package() {
+	depends="zlib-devel libuuid-devel-${version}_${revision} libblkid-${version}_${revision}"
+	short_desc="Library to handle device identification - development files"
+	pkg_install() {
+		vmove usr/include/blkid
+		vmove usr/lib/libblkid.a
+		vmove usr/lib/libblkid.so
+		vmove usr/lib/pkgconfig/blkid.pc
+		vmove usr/share/man/man3/libblkid.3
+	}
+}
+libuuid_package() {
+	short_desc="UUID library"
+	pkg_install() {
+		vmove "usr/lib/libuuid.so.*"
+	}
+}
+libuuid-devel_package() {
+	depends="libuuid-${version}_${revision}"
+	short_desc="UUID library development files"
+	pkg_install() {
+		vmove usr/lib/libuuid.a
+		vmove usr/lib/libuuid.so
+		vmove usr/lib/pkgconfig
+		vmove usr/include/uuid
+		vmove usr/share/man/man3/uuid*
+	}
+}
+libsmartcols-devel_package() {
+	depends="libsmartcols>=${version}_${revision}"
+	short_desc="Table or Tree library from util-linux - development files"
+	pkg_install() {
+		vmove usr/lib/libsmartcols.a
+		vmove usr/lib/libsmartcols.so
+		vmove usr/include/libsmartcols
+		vmove usr/lib/pkgconfig/smartcols*
+	}
+}
+libsmartcols_package() {
+	short_desc="Table or Tree library from util-linux"
+	pkg_install() {
+		vmove usr/lib/libsmartcols.so.*
+	}
+}

--- a/srcpkgs/util-linux-libs/update
+++ b/srcpkgs/util-linux-libs/update
@@ -1,0 +1,2 @@
+site='https://github.com/karelzak/util-linux/releases'
+pattern='/archive/v\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -1,9 +1,12 @@
 # Template file for 'util-linux'
+# Keep this package sync with util-linux-libs
 pkgname=util-linux
 version=2.35.1
-revision=1
+revision=2
 hostmakedepends="automake bison gettext-devel libtool pkg-config xz"
-makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel"
+makedepends="libcap-ng-devel pam-devel readline-devel zlib-devel
+ eudev-libudev-devel"
+depends="util-linux-libs-${version}_${revision}"
 checkdepends="ncurses" # Some tests require terminfo-entries
 short_desc="Miscellaneous linux utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -40,7 +43,7 @@ do_configure() {
 		--enable-fs-paths-extra=/usr/sbin:/usr/bin \
 		--enable-vipw --enable-newgrp --enable-chfn-chsh \
 		--with-systemdsystemunitdir=no \
-		--without-udev --without-python \
+		--with-udev --without-python \
 		--enable-write
 }
 
@@ -68,87 +71,8 @@ do_install() {
 	vinstall $FILESDIR/common.pam 644 etc/pam.d chsh
 
 	vsv uuidd
-}
 
-libfdisk_package() {
-	short_desc="Library for fdisk(8)"
-	pkg_install() {
-		vmove "usr/lib/libfdisk.so.*"
-	}
-}
-libfdisk-devel_package() {
-	depends="libblkid-devel-${version}_${revision} libfdisk-${version}_${revision}"
-	short_desc="Library for fdisk(8) - development files"
-	pkg_install() {
-		vmove usr/lib/libfdisk.a
-		vmove usr/lib/libfdisk.so
-		vmove "usr/lib/pkgconfig/*fdisk*"
-		vmove usr/include/libfdisk
-	}
-}
-libmount_package() {
-	short_desc="Library for mount(8)"
-	pkg_install() {
-		vmove "usr/lib/libmount.so.*"
-	}
-}
-libmount-devel_package() {
-	depends="libblkid-devel-${version}_${revision} libmount-${version}_${revision}"
-	short_desc="Library for mount(8) - development files"
-	pkg_install() {
-		vmove usr/lib/libmount.a
-		vmove usr/lib/libmount.so
-		vmove "usr/lib/pkgconfig/*mount*"
-		vmove usr/include/libmount
-	}
-}
-libblkid_package() {
-	short_desc="Library to handle device identification"
-	pkg_install() {
-		vmove "usr/lib/libblkid.so.*"
-	}
-}
-libblkid-devel_package() {
-	depends="zlib-devel libuuid-devel-${version}_${revision} libblkid-${version}_${revision}"
-	short_desc="Library to handle device identification - development files"
-	pkg_install() {
-		vmove usr/include/blkid
-		vmove usr/lib/libblkid.a
-		vmove usr/lib/libblkid.so
-		vmove usr/lib/pkgconfig/blkid.pc
-		vmove usr/share/man/man3/libblkid.3
-	}
-}
-libuuid_package() {
-	short_desc="UUID library"
-	pkg_install() {
-		vmove "usr/lib/libuuid.so.*"
-	}
-}
-libuuid-devel_package() {
-	depends="libuuid-${version}_${revision}"
-	short_desc="UUID library development files"
-	pkg_install() {
-		vmove usr/lib/libuuid.a
-		vmove usr/lib/libuuid.so
-		vmove usr/lib/pkgconfig
-		vmove usr/include/uuid
-		vmove usr/share/man/man3/uuid*
-	}
-}
-libsmartcols-devel_package() {
-	depends="libsmartcols>=${version}_${revision}"
-	short_desc="Table or Tree library from util-linux - development files"
-	pkg_install() {
-		vmove usr/lib/libsmartcols.a
-		vmove usr/lib/libsmartcols.so
-		vmove usr/include/libsmartcols
-		vmove usr/lib/pkgconfig/smartcols*
-	}
-}
-libsmartcols_package() {
-	short_desc="Table or Tree library from util-linux"
-	pkg_install() {
-		vmove usr/lib/libsmartcols.so.*
-	}
+	rm -rf "$DESTDIR/usr/include"
+	rm -rf "$DESTDIR/usr/lib"
+	rm -rf "$DESTDIR/usr/share/man/man3"
 }


### PR DESCRIPTION
This is a rework of 66062de198 (util-linux: compile with eudev,
2019-10-30)

In order to support this command for unpriviledge users:

	lsblk -f

util-linux needs to be compile `--with-udev`.

However, eudev itself depends on `libblkid-devel` for building.

Break this dependency cycle by:
- compile `util-linux` `--without-udev` first, only keep its library,
this will be the `util-linux-libs` meta package
- compile eudev against that `util-linux` (`--without-udev`)
- compile util-linux binary against eudev, discard its libs

---
@Gottox : maintainer
@q66 : please check on PowerPC