### PR TITLE
bleachbit: update to 4.0.0.

### DIFF
--- a/srcpkgs/bleachbit/template
+++ b/srcpkgs/bleachbit/template
@@ -1,17 +1,17 @@
 # Template file for 'bleachbit'
 pkgname=bleachbit
-version=3.2.0
+version=4.0.0
 revision=1
 archs=noarch
 build_style=gnu-makefile
 pycompile_dirs="usr/share/bleachbit"
 make_install_args="prefix=/usr"
-hostmakedepends="python gettext"
-depends="python-gobject gtk+3 desktop-file-utils hicolor-icon-theme"
+hostmakedepends="python3 gettext"
+depends="python3-gobject python3-scandir gtk+3 desktop-file-utils hicolor-icon-theme"
 short_desc="Deletes unneeded files to free disk space and maintain privacy"
 maintainer="graysky <graysky@archlinux.us>"
 license="GPL-3.0-or-later"
 homepage="https://www.bleachbit.org/"
 distfiles="https://github.com/bleachbit/bleachbit/archive/v${version}.tar.gz"
-checksum=c0e25253781d768da4eacf56739bf547dc59f2fe212f44e464f4fcc1bc855e44
-python_version=2 #unverified
+checksum=5f7813b1ecda32647b1a31564b66f369fbd0d50d67924f256a0d414abc07501b
+python_version=3


### PR DESCRIPTION
- Use python3, now officially supported.
- Add python3-scandir to depends.