### PR TITLE
pass-import: update to 3.0.

### DIFF
--- a/srcpkgs/pass-import/template
+++ b/srcpkgs/pass-import/template
@@ -1,15 +1,15 @@
 # Template file for 'pass-import'
 pkgname=pass-import
-version=2.6
-revision=2
+version=3.0
+revision=1
 archs=noarch
 build_style=gnu-makefile
 make_install_args=BASHCOMPDIR=/usr/share/bash-completion/completions
 hostmakedepends="python3-setuptools python3-yaml"
-depends="pass>=1.7.0 python3-defusedxml"
+depends="pass>=1.7.0 python3-defusedxml python3-magic python3-cryptography python3-SecretStorage python3-pykeepass"
 short_desc="Pass extension for importing data from most existing password managers"
 maintainer="Alan Brown <adbrown@rocketmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/roddhjav/pass-import"
 distfiles="https://github.com/roddhjav/pass-import/releases/download/v${version}/pass-import-${version}.tar.gz"
-checksum=19bddbbe3e43c15bedcc1df6eadf664e30bc04b2992809eb4d04f25a3d370ea8
+checksum=14f6708df990b88c54b07e722686ed9e1a639300b33d2ff83dd87845e44779fc


### PR DESCRIPTION
This has now become a more general password importer hence the greater number of libraries it depends upon