### PR TITLE
New package: throttled-0.7

### DIFF
--- a/srcpkgs/throttled/files/lenovo_fix/run
+++ b/srcpkgs/throttled/files/lenovo_fix/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+PYTHONUNBUFFERED=1 exec python3 @PATH@/lenovo_fix/lenovo_fix.py

--- a/srcpkgs/throttled/patches/setup.py.patch
+++ b/srcpkgs/throttled/patches/setup.py.patch
@@ -1,0 +1,14 @@
+--- /dev/null
++++ setup.py
+@@ -0,0 +1,11 @@
++from setuptools import setup
++
++setup(
++    name='lenovo_fix',
++    version='@VERSION@',
++    description='Workaround for Intel throttling issues in Linux',
++    author='Francesco Palmarini',
++    author_email='palmarini@unive.it',
++    url='https://github.com/erpalma/throttled',
++    license='MIT',
++)

--- a/srcpkgs/throttled/template
+++ b/srcpkgs/throttled/template
@@ -1,0 +1,27 @@
+# Template file for 'throttled'
+pkgname=throttled
+version=0.7
+revision=1
+build_style=python3-module
+conf_files="/etc/lenovo_fix.conf"
+hostmakedepends="python3-setuptools"
+depends="python3-dbus python3-gobject"
+short_desc="Workaround for Intel throttling issues in Linux"
+maintainer="Dawid Potocki <dawid@dawidpotocki.com>"
+license="MIT"
+homepage="https://github.com/erpalma/throttled"
+distfiles="https://github.com/erpalma/throttled/archive/v${version}.tar.gz"
+checksum=64f139b3fd6f13381105f30ed4598faa69e59bfd613d26dfde29f46578b0b2a1
+
+pre_build() {
+	sed -i "s/@VERSION@/${version}/" setup.py
+}
+
+post_install() {
+	vinstall mmio.py 644 ${py3_sitelib}/lenovo_fix mmio.py
+	vinstall lenovo_fix.py 644 ${py3_sitelib}/lenovo_fix lenovo_fix.py
+	vconf etc/lenovo_fix.conf
+	vsv lenovo_fix
+	sed -i "s|@PATH@|${py3_sitelib}|" ${DESTDIR}/etc/sv/lenovo_fix/run
+	vlicense LICENSE
+}


### PR DESCRIPTION
Throttled is a program to fix throttling issues (https://old.reddit.com/r/thinkpad/comments/870u0a/t480s_linux_throttling_bug/) on some Intel laptops like

* Lenovo ThinkPad T480, T480s, X1C5, X1C6, T580, L480, T470, X280, Anniversary Edition 25, E590 w/ RX 550X, P43s, E480, E580
* Dell XPS 9365, 9370, Latitude 7390 2-in-1
* Microsoft Surface Book 2