### PR TITLE
zig: update to 0.6.0.

### DIFF
--- a/srcpkgs/zig/template
+++ b/srcpkgs/zig/template
@@ -1,26 +1,19 @@
 # Template file for 'zig'
 pkgname=zig
-version=0.5.0
+version=0.6.0
 revision=1
 archs="x86_64*"
 build_style=cmake
-configure_args="-DZIG_STATIC=FALSE"
-hostmakedepends="clang llvm9"
-makedepends="libxml2-devel ncurses-devel zlib-devel"
+makedepends="llvm10 lld-devel"
 short_desc="Programming language designed for robustness, optimality, and clarity"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MIT"
 homepage="https://ziglang.org/"
 distfiles="https://ziglang.org/download/${version}/zig-${version}.tar.xz"
-checksum=55ae16960f152bcb9cf98b4f8570902d0e559a141abf927f0d3555b7cc838a31
+checksum=5d167dc19354282dd35dd17b38e99e1763713b9be8a4ba9e9e69284e059e7204
 nopie=yes
 nocross=yes
 
-post_extract() {
-        # don't install build artefacts
-        vsed -i -e '/${ZIG_CPP_LIB_DIR}/d' CMakeLists.txt
-}
-
 post_install() {
-        vlicense LICENSE
+	vlicense LICENSE
 }


### PR DESCRIPTION
- Cleaned up the (host)makedepends, not sure why all this stuff was there.
- The `ZIG_STATIC` build options defaults to off, so dont set it.
- The cleanup preformed in post_extract() seems to no longer be needed.