### PR TITLE
rpi-kernel: update to 4.19.120.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="fe2c7bf4cad4641dfb6f12712755515ab15815ca"
+_githash="9da67d7329873623bd5c13fae5835d76d5be8806"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.118
+version=4.19.120
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=ca458e01428927cc12e13e4ef0de219902feeba5fd7f6bcb5056ce33c4688e90
+checksum=38c955458a8ce26409cbbf38cf0776a3dd2b496e4aee2acaf16388142948f5b0
 python_version=2
 
 _kernver="${version}_${revision}"


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.