### PR TITLE
libwacom: update to 1.3, remove some -devel deps

### DIFF
--- a/srcpkgs/libwacom/template
+++ b/srcpkgs/libwacom/template
@@ -1,6 +1,6 @@
 # Template file for 'libwacom'
 pkgname=libwacom
-version=1.2
+version=1.3
 revision=1
 build_style=meson
 build_helper="qemu"
@@ -13,14 +13,14 @@ license="MIT"
 homepage="https://github.com/linuxwacom/libwacom"
 changelog="https://raw.githubusercontent.com/linuxwacom/libwacom/master/NEWS"
 distfiles="https://github.com/linuxwacom/libwacom/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.bz2"
-checksum=c204cfdee2159d124a4f5ecc8970bbd72f9adf5ad7fd94b66798f93db1f863c3
+checksum=e19ce00fe1e074cc54ffd198dda6c6f1ec389e5c913134adc8795f2c5e63883c
 
 post_install() {
 	vlicense COPYING
 }
 
 libwacom-devel_package() {
-	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	depends="libgudev-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
`libwacom-devel` is pulling in `gtk+-devel` (unnecessarily imo), which has a big dependency tree. So I restricted `depends` to just the stuff listed in Requires.private from the .pc file.
Tested this by building `libinput`.
Pinging the previous updater @pullmoll 