### PR TITLE
New package: netrek-client-cow-3.3.1

### DIFF
--- a/srcpkgs/netrek-client-cow/template
+++ b/srcpkgs/netrek-client-cow/template
@@ -1,0 +1,30 @@
+# Template file for 'netrek-client-cow'
+pkgname=netrek-client-cow
+version=3.3.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="libtool automake"
+makedepends="libX11-devel imlib2-devel libXxf86vm-devel gmp-devel
+ SDL_mixer-devel SDL-devel libXpm-devel"
+short_desc="Netrek Client (C and X11)"
+maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
+license="MIT, custom:PublicDomain"
+homepage="https://www.netrek.org/"
+distfiles="https://www.netrek.org/files/COW/netrek-client-cow-${version}.tar.gz"
+checksum=cac219248d71033b62098c3da1ca6b4408974b22996da39eaba213b2253e6da3
+
+post_install() {
+	vlicense COPYING
+	vlicense copyright.h
+	vlicense copyright2.h
+	vmkdir usr/bin
+	ln -s ../games/netrek-client-cow ${DESTDIR}/usr/bin/netrek-client-cow
+}
+
+do_check() {
+	echo "Check stage is broken"
+}
+
+# REMARKS:
+# Source tracked at https://github.com/quozl/netrek-client-cow
+# Custom is a sort of public domain declaration


### PR DESCRIPTION
With some people being very bored, they might like having this packaged.

It doesn't build. Upstream is active.

The patch is changes between the packaged release and now, I filed a bug with upstream (but since it fails to build from source, that might have been premature). https://github.com/quozl/netrek-client-cow/issues/2