### PR TITLE
New package: intel-compute-runtime-20.21.16886

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3956,3 +3956,5 @@ libvips.so.42 libvips-8.9.2_1
 libvips-cpp.so.42 libvips-8.9.2_1
 libselinux.so.1 libselinux-3.0_1
 libsepol.so.1 libsepol-3.0_1
+libLLVMSPIRVLib.so.10 SPIRV-LLVM-Translator-10.0.0_1
+libopencl-clang.so.10 intel-opencl-clang-10.0.0.1_1

--- a/srcpkgs/SPIRV-LLVM-Translator-devel
+++ b/srcpkgs/SPIRV-LLVM-Translator-devel
@@ -1,0 +1,1 @@
+SPIRV-LLVM-Translator

--- a/srcpkgs/SPIRV-LLVM-Translator/template
+++ b/srcpkgs/SPIRV-LLVM-Translator/template
@@ -1,0 +1,29 @@
+# Template file for 'SPIRV-LLVM-Translator'
+pkgname=SPIRV-LLVM-Translator
+version=10.0.0
+revision=1
+archs="x86_64*"
+wrksrc=SPIRV-LLVM-Translator-${version}
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=ON"
+makedepends="clang-tools-extra llvm"
+short_desc="Library and tool for translation between LLVM IR and SPIR-V"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="NCSA"
+homepage="https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
+distfiles="https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/v${version}.tar.gz"
+checksum=7ccde52bac4c9ad967a362a3c5ec7261aa5b7b34d28cef0f3dec38d77c923049
+
+post_install() {
+	vlicense LICENSE.TXT
+}
+
+SPIRV-LLVM-Translator-devel_package() {
+	depends="${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/intel-compute-runtime/patches/musl-ioctl.patch
+++ b/srcpkgs/intel-compute-runtime/patches/musl-ioctl.patch
@@ -1,0 +1,14 @@
+--- opencl/test/unit_test/linux/mock_os_layer.h.orig	2020-05-12 23:23:47.438463587 +0200
++++ opencl/test/unit_test/linux/mock_os_layer.h	2020-05-12 23:26:38.282470463 +0200
+@@ -20,7 +20,11 @@
+ 
+ extern "C" {
+ int open(const char *pathname, int flags, ...);
++#ifdef __GLIBC__
+ int ioctl(int fd, unsigned long int request, ...) throw();
++#else
++int ioctl(int fd, int request, ...) throw();
++#endif
+ }
+ 
+ extern int (*c_open)(const char *pathname, int flags, ...);

--- a/srcpkgs/intel-compute-runtime/patches/musl-pthread_yield.patch
+++ b/srcpkgs/intel-compute-runtime/patches/musl-pthread_yield.patch
@@ -1,0 +1,20 @@
+--- opencl/test/unit_test/os_interface/linux/drm_gem_close_worker_tests.cpp.orig	2020-05-12 23:05:41.057419864 +0200
++++ opencl/test/unit_test/os_interface/linux/drm_gem_close_worker_tests.cpp	2020-05-12 23:06:01.992420706 +0200
+@@ -121,7 +121,7 @@
+ 
+     //wait for worker to complete or deadCnt drops
+     while (!worker->isEmpty() && (deadCnt-- > 0))
+-        pthread_yield(); //yield to another threads
++        sched_yield(); //yield to another threads
+ 
+     worker->close(false);
+ 
+@@ -142,7 +142,7 @@
+ 
+     //wait for worker to complete or deadCnt drops
+     while (!worker->isEmpty() && (deadCnt-- > 0))
+-        pthread_yield(); //yield to another threads
++        sched_yield(); //yield to another threads
+ 
+     //and check if GEM was closed
+     EXPECT_EQ(1, this->drmMock->gem_close_cnt.load());

--- a/srcpkgs/intel-compute-runtime/patches/musl-rtld-global.patch
+++ b/srcpkgs/intel-compute-runtime/patches/musl-rtld-global.patch
@@ -1,0 +1,11 @@
+--- shared/source/os_interface/linux/os_library_linux.cpp.orig	2020-05-12 21:02:19.995121993 +0200
++++ shared/source/os_interface/linux/os_library_linux.cpp	2020-05-12 21:03:20.426124425 +0200
+@@ -30,7 +30,7 @@
+         this->handle = dlopen(0, RTLD_LAZY);
+     } else {
+ #ifdef SANITIZER_BUILD
+-        constexpr auto dlopenFlag = RTLD_LAZY;
++        constexpr auto dlopenFlag = RTLD_LAZY | RTLD_GLOBAL;
+ #else
+         constexpr auto dlopenFlag = RTLD_LAZY | RTLD_DEEPBIND;
+ #endif

--- a/srcpkgs/intel-compute-runtime/patches/musl-select.patch
+++ b/srcpkgs/intel-compute-runtime/patches/musl-select.patch
@@ -1,0 +1,13 @@
+This macro conflicts with the select syscall. Since it isn't actually used, we
+just remove it.
+--- opencl/source/builtin_kernels_simulation/opencl_c.h.orig	2020-04-30 12:24:42.000000000 +0200
++++ opencl/source/builtin_kernels_simulation/opencl_c.h	2020-05-12 22:31:37.166337603 +0200
+@@ -220,8 +220,6 @@
+     (                               \
+         (type)var)
+ 
+-#define select(a, b, c) (c ? b : a)
+-
+ uint get_local_id(int dim);
+ uint get_global_id(int dim);
+ uint get_local_size(int dim);

--- a/srcpkgs/intel-compute-runtime/template
+++ b/srcpkgs/intel-compute-runtime/template
@@ -1,0 +1,29 @@
+# Template file for 'intel-compute-runtime'
+pkgname=intel-compute-runtime
+version=20.21.16886
+revision=1
+archs="x86_64*"
+wrksrc=compute-runtime-${version}
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="intel-gmmlib-devel intel-graphics-compiler-devel"
+depends="intel-graphics-compiler"
+short_desc="Intel Graphics Compute Runtime for OpenCL (Broadwell+)"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="MIT"
+homepage="https://github.com/intel/compute-runtime"
+distfiles="https://github.com/intel/compute-runtime/archive/${version}.tar.gz"
+checksum=7be4f46fb7e78e16ff37ba45035a20f4e8e492eece0d3d754bad173c4857a2a0
+
+if [ -z "${XBPS_CHECK_PKGS}" ]; then
+	configure_args+=" -DSKIP_UNIT_TESTS=1"
+fi
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	makedepends+=" libexecinfo-devel"
+	CXXFLAGS+=" -lexecinfo -DSANITIZER_BUILD"
+fi
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/intel-graphics-compiler-devel
+++ b/srcpkgs/intel-graphics-compiler-devel
@@ -1,0 +1,1 @@
+intel-graphics-compiler

--- a/srcpkgs/intel-graphics-compiler/patches/musl.patch
+++ b/srcpkgs/intel-graphics-compiler/patches/musl.patch
@@ -1,0 +1,21 @@
+--- inc/common/UFO/portable_compiler.h.orig	2020-05-13 11:41:37.725900359 +0200
++++ inc/common/UFO/portable_compiler.h	2020-05-13 11:42:26.407898739 +0200
+@@ -125,7 +125,7 @@
+ /* compile-time ASSERT */
+ 
+ #ifndef C_ASSERT
+-    #define __UNIQUENAME( a1, a2 )  __CONCAT( a1, a2 )
++    #define __UNIQUENAME( a1, a2 )  a1 ## a2
+     #define UNIQUENAME( __text )    __UNIQUENAME( __text, __COUNTER__ )
+ 
+ 
+--- visa/CISA.y.orig	2020-05-13 11:42:12.245899211 +0200
++++ visa/CISA.y	2020-05-13 11:42:26.410898739 +0200
+@@ -25,6 +25,7 @@
+ ======================= end_copyright_notice ==================================*/
+ 
+ %{
++#include <inttypes.h>
+ #include <stdio.h>
+ #include <math.h>
+ #include <string>

--- a/srcpkgs/intel-graphics-compiler/template
+++ b/srcpkgs/intel-graphics-compiler/template
@@ -1,0 +1,30 @@
+# Template file for 'intel-graphics-compiler'
+pkgname=intel-graphics-compiler
+version=1.0.4053
+revision=1
+archs="x86_64*"
+wrksrc=intel-graphics-compiler-igc-${version}
+build_style=cmake
+configure_args="-DIGC_PREFERRED_LLVM_VERSION='10.0.0' -Wno-dev"
+hostmakedepends="bison flex"
+makedepends="clang-tools-extra llvm intel-opencl-clang-devel"
+short_desc="Intel Graphics Compiler for OpenCL"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="MIT"
+homepage="https://github.com/intel/intel-graphics-compiler"
+distfiles="https://github.com/intel/intel-graphics-compiler/archive/igc-${version}.tar.gz"
+checksum=9117399688b02f7cee51fccbd0f140921377c8250563f65ae92a1e9ed1abd717
+
+post_install() {
+	vlicense LICENSE.md
+}
+
+intel-graphics-compiler-devel_package() {
+	depends="${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/intel-opencl-clang-devel
+++ b/srcpkgs/intel-opencl-clang-devel
@@ -1,0 +1,1 @@
+intel-opencl-clang

--- a/srcpkgs/intel-opencl-clang/template
+++ b/srcpkgs/intel-opencl-clang/template
@@ -1,0 +1,30 @@
+# Template file for 'intel-opencl-clang'
+pkgname=intel-opencl-clang
+version=10.0.0.1
+revision=1
+_version=${version%.*}-${version##*.}
+archs="x86_64*"
+wrksrc=opencl-clang-${_version}
+build_style=cmake
+makedepends="clang-tools-extra llvm SPIRV-LLVM-Translator-devel"
+short_desc="Wrapper library to compile OpenCL C kernels to SPIR-V modules"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="NCSA"
+homepage="https://github.com/intel/opencl-clang"
+distfiles="https://github.com/intel/opencl-clang/archive/v${_version}.tar.gz"
+checksum=815005b6fb7fd8fd2f08b9036035d3aa9543f5ce8464e41ef2f2ed08a816f507
+
+nocross="https://travis-ci.org/github/st3r4g/void-packages/jobs/686510849#L4390"
+
+post_install() {
+	vlicense LICENSE
+}
+
+intel-opencl-clang-devel_package() {
+	depends="${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
Closes #11364

Resumed the work I did some time ago, mainly updated the templates to use `llvm10`. Opening this as a draft for now because I remember musl requiring to be patched (I gave up back then), any help is welcome.

@ericonr 