### PR TITLE
musl-legacy-compat: add include guards to cdefs.h

### DIFF
--- a/srcpkgs/musl-legacy-compat/files/cdefs.h
+++ b/srcpkgs/musl-legacy-compat/files/cdefs.h
@@ -1,3 +1,6 @@
+#ifndef _SYS_CDEFS_H_
+#define _SYS_CDEFS_H_
+
 #warning usage of non-standard #include <sys/cdefs.h> is deprecated
 
 #undef __P
@@ -27,3 +30,5 @@
 
 #define __CONCAT(x,y)   x ## y
 #define __STRING(x)     #x
+
+#endif /* _SYS_CDEFS_H_ */

--- a/srcpkgs/musl-legacy-compat/template
+++ b/srcpkgs/musl-legacy-compat/template
@@ -1,7 +1,7 @@
 # Template file for 'musl-legacy-compat'
 pkgname=musl-legacy-compat
 version=0.3
-revision=3
+revision=4
 archs="*-musl"
 bootstrap=yes
 short_desc="Legacy compatibility headers for the musl libc"


### PR DESCRIPTION
The `cdefs.h` included in this package is missing include guards, breaking some software with sloppy includes that expects this file.

cc: @Gottox 