### PR TITLE
croc: fix go_import_path to fetch correct version

### DIFF
--- a/srcpkgs/croc/template
+++ b/srcpkgs/croc/template
@@ -1,9 +1,9 @@
 # Template file for 'croc'
 pkgname=croc
 version=8.0.10
-revision=1
+revision=2
 build_style=go
-go_import_path=github.com/schollz/croc/v6
+go_import_path=github.com/schollz/croc/v${version%%.*}
 hostmakedepends="git"
 short_desc="Easily and securely send things from one computer to another"
 maintainer="Benjamín Albiñana <benalb@gmail.com>"


### PR DESCRIPTION
The `go_import_path` for `croc` was hard-coded to download `v6` instead of the current `v8`, so version 6.4.10-073569f was packaged instead of `8.0.10-6dc44ec`. This PR fixes the `go_import_path` by using the major part of `version` to hopefully avoid this issue when the major number next jumps.

cc: @benalb 