### PR TITLE
New package: zoom-system-qt-5.0.403652.0509_1

### DIFF
--- a/srcpkgs/zoom/template
+++ b/srcpkgs/zoom/template
@@ -5,6 +5,7 @@ revision=1
 archs="x86_64"
 wrksrc=zoom
 create_wrksrc=yes
+depends="$(vopt_if systemqt 'qt5 qt5-graphicaleffects qt5-imageformats qt5-quickcontrols qt5-quickcontrols2 qt5-svg qt5-script qt5-declarative')"
 short_desc="Video Conferencing and Web Conferencing Service"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="custom:Proprietary"
@@ -16,6 +17,31 @@ noshlibprovides=yes
 noverifyrdeps=yes
 restricted=yes
 nopie=yes
+build_options="systemqt"
+desc_option_systemqt="Use system QT libraries"
+
+pre_install() {
+	if [ "${build_option_systemqt}" ]; then
+		rm -f opt/zoom/libQt5*.so{,.*}
+		rm -f opt/zoom/libicu*.so{,.*}
+
+		rm -rf opt/zoom/*integrations
+		rm -rf opt/zoom/audio
+		rm -rf opt/zoom/generic
+		rm -rf opt/zoom/iconengines
+		rm -rf opt/zoom/imageformats
+		rm -rf opt/zoom/platforms
+		rm -rf opt/zoom/platforminputcontexts
+		rm -rf opt/zoom/platformthemes
+		rm -rf opt/zoom/Qt{,GraphicalEffects,Qml,Quick,Quick.2}
+		rm -f opt/zoom/libmpg123.so
+		rm -f opt/zoom/libfaac1.so
+		rm -f opt/zoom/libturbojpeg.so{,.*}
+		rm -f opt/zoom/libquazip.so{,.*}
+
+		rm opt/zoom/qt.conf
+	fi
+}
 
 do_install() {
 	vcopy opt .


### PR DESCRIPTION
Add package for zoom using system libraries (modelled after https://aur.archlinux.org/packages/zoom-system-qt/). This adds e.g. wayland support and removes doubled and possibly outdated qt libraries. However, since this might break if zoom isn't updating to a close enough qt release, it's better to keep zoom with included qt around as well.