### PR TITLE
New package: minecraft-launcher-2.1.13829

### DIFF
--- a/srcpkgs/minecraft-launcher/template
+++ b/srcpkgs/minecraft-launcher/template
@@ -1,0 +1,28 @@
+# Template file for 'minecraft-launcher'
+pkgname=minecraft-launcher
+version=2.1.13829
+revision=1
+archs=noarch
+wrksrc="minecraft-launcher"
+depends="virtual?java-runtime GConf alsa-lib gtk+ libX11 libXScrnSaver libXtst libxcb nss xrandr"
+short_desc="Mojang's Electron launcher for Minecraft"
+maintainer="Matthew Treadwell <hewtreadwell@gmail.com>"
+license="custom:Minecraft"
+homepage="http://www.minecraft.net/"
+distfiles="https://launcher.mojang.com/download/Minecraft.tar.gz https://account.mojang.com/documents/minecraft_eula"
+checksum="e525c31bd6bacb7483929a674a5c8515a8ebb1b3f67ffd018f6f12a84f4e7051 a1487b03e88c43c7a33ed2f24328ae28767c17fca73d846193adc188b9e0ddc2"
+skip_extraction="minecraft_eula"
+repository=nonfree
+restricted=yes
+
+do_install() {
+	vmkdir /opt
+	vcopy "minecraft-launcher" "/opt/minecraft-launcher"
+	rm -rf "${DESTDIR}/opt/minecraft-launcher/lib/"
+	rm -rf "${DESTDIR}/opt/minecraft-launcher/include/"
+
+	vmkdir /usr/bin
+	ln -s "/opt/minecraft-launcher/minecraft-launcher" "${DESTDIR}/usr/bin/minecraft-launcher"
+
+	vlicense "${XBPS_SRCDISTDIR}/${pkgname}-${version}/minecraft_eula"
+}


### PR DESCRIPTION
Continuation of https://github.com/void-linux/void-packages/pull/14221 with the input from https://github.com/void-linux/void-packages/issues/13139. I'll close my old PR and start working on a minecraft-legacy package to replace the original, unmaintained minecraft package.