### PR TITLE
New package: minecraft-legacy-1.6.93

### DIFF
--- a/srcpkgs/minecraft-legacy/INSTALL.msg
+++ b/srcpkgs/minecraft-legacy/INSTALL.msg
@@ -1,0 +1,3 @@
+NOTE: This package may not be compatible with newest versions of
+      minecraft. Install minecraft-launcher to run the latest 
+      versions of minecraft.

--- a/srcpkgs/minecraft-legacy/files/minecraft-legacy
+++ b/srcpkgs/minecraft-legacy/files/minecraft-legacy
@@ -1,0 +1,4 @@
+#!/bin/sh
+JAR_PATH=/opt/minecraft-legacy/launcher.jar
+
+java -jar $JAR_PATH

--- a/srcpkgs/minecraft-legacy/template
+++ b/srcpkgs/minecraft-legacy/template
@@ -1,0 +1,25 @@
+# Template file for 'minecraft-legacy'
+pkgname=minecraft-legacy
+version=1.6.93
+revision=1
+archs=noarch
+wrksrc="minecraft-legacy"
+build_style=fetch
+depends="virtual?java-runtime wmname wget"
+short_desc="Legacy launcher for Minecraft (outdated)"
+maintainer="Matthew Treadwell <hewtreadwell@gmail.com>"
+license="custom:Minecraft"
+homepage="http://www.minecraft.net/"
+distfiles="https://launcher.mojang.com/v1/objects/eabbff5ff8e21250e33670924a0c5e38f47c840b/launcher.jar https://account.mojang.com/documents/minecraft_eula"
+checksum="d98de795667f666652e4d0f453708c51292cc326860f387ae8fdfc7cbaf33ca1 a1487b03e88c43c7a33ed2f24328ae28767c17fca73d846193adc188b9e0ddc2"
+repository=nonfree
+restricted=yes
+
+do_install() {
+	vmkdir /opt
+	vmkdir /opt/minecraft-legacy
+	vcopy "${XBPS_SRCDISTDIR}/${pkgname}-${version}/launcher.jar" "/opt/minecraft-legacy/"
+	vbin ${FILESDIR}/minecraft-legacy
+
+	vlicense "${XBPS_SRCDISTDIR}/${pkgname}-${version}/minecraft_eula"
+}


### PR DESCRIPTION
As discussed in https://github.com/void-linux/void-packages/issues/13139, this will replace the existing the minecraft package and has proper licensing and versioning. 