### PR TITLE
lua{,51,52}: move -devel alternatives to dedicated group

### DIFF
--- a/srcpkgs/lua/template
+++ b/srcpkgs/lua/template
@@ -1,13 +1,13 @@
 # Template file for 'lua'
 pkgname=lua
 version=5.3.5
-revision=2
+revision=3
 makedepends="ncurses-devel readline-devel"
 short_desc="Powerful, fast, lightweight, embeddable scripting language"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://www.lua.org"
-distfiles="http://www.lua.org/ftp/lua-${version}.tar.gz"
+homepage="https://www.lua.org"
+distfiles="https://www.lua.org/ftp/lua-${version}.tar.gz"
 checksum=0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac
 
 alternatives="
@@ -15,15 +15,6 @@ alternatives="
  lua:luac:/usr/bin/luac5.3
  lua:lua.1:/usr/share/man/man1/lua5.3.1
  lua:luac.1:/usr/share/man/man1/luac5.3.1
- lua:lua:/usr/include/lua5.3
- lua:/usr/include/lua.h:/usr/include/lua5.3/lua.h
- lua:/usr/include/luaconf.h:/usr/include/lua5.3/luaconf.h
- lua:/usr/include/lua.hpp:/usr/include/lua5.3/lua.hpp
- lua:/usr/include/lualib.h:/usr/include/lua5.3/lualib.h
- lua:/usr/include/lauxlib.h:/usr/include/lua5.3/lauxlib.h
- lua:lua.pc:/usr/lib/pkgconfig/lua5.3.pc
- lua:liblua.a:/usr/lib/liblua5.3.a
- lua:liblua.so:/usr/lib/liblua5.3.so
  lua:lua:/usr/share/doc/lua5.3
 "
 
@@ -71,6 +62,17 @@ do_install() {
 lua-devel_package() {
 	depends="${makedepends} lua>=${version}_${revision}"
 	short_desc+=" - development files"
+	alternatives="
+	 lua-devel:lua:/usr/include/lua5.3
+	 lua-devel:/usr/include/lua.h:/usr/include/lua5.3/lua.h
+	 lua-devel:/usr/include/luaconf.h:/usr/include/lua5.3/luaconf.h
+	 lua-devel:/usr/include/lua.hpp:/usr/include/lua5.3/lua.hpp
+	 lua-devel:/usr/include/lualib.h:/usr/include/lua5.3/lualib.h
+	 lua-devel:/usr/include/lauxlib.h:/usr/include/lua5.3/lauxlib.h
+	 lua-devel:lua.pc:/usr/lib/pkgconfig/lua5.3.pc
+	 lua-devel:liblua.a:/usr/lib/liblua5.3.a
+	 lua-devel:liblua.so:/usr/lib/liblua5.3.so
+	"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"

--- a/srcpkgs/lua51/template
+++ b/srcpkgs/lua51/template
@@ -1,14 +1,14 @@
 # Template file for 'lua51'
 pkgname=lua51
 version=5.1.5
-revision=8
+revision=9
 wrksrc="lua-${version}"
 makedepends="ncurses-devel readline-devel"
 short_desc="Powerful, fast, lightweight, embeddable scripting language (5.1.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="http://www.lua.org"
 license="MIT"
-distfiles="http://www.lua.org/ftp/lua-$version.tar.gz"
+homepage="https://www.lua.org"
+distfiles="https://www.lua.org/ftp/lua-$version.tar.gz"
 checksum=2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333
 
 alternatives="
@@ -16,15 +16,6 @@ alternatives="
  lua:luac:/usr/bin/luac5.1
  lua:lua.1:/usr/share/man/man1/lua5.1.1
  lua:luac.1:/usr/share/man/man1/luac5.1.1
- lua:lua:/usr/include/lua5.1
- lua:/usr/include/lua.h:/usr/include/lua5.1/lua.h
- lua:/usr/include/luaconf.h:/usr/include/lua5.1/luaconf.h
- lua:/usr/include/lua.hpp:/usr/include/lua5.1/lua.hpp
- lua:/usr/include/lualib.h:/usr/include/lua5.1/lualib.h
- lua:/usr/include/lauxlib.h:/usr/include/lua5.1/lauxlib.h
- lua:lua.pc:/usr/lib/pkgconfig/lua5.1.pc
- lua:liblua.a:/usr/lib/liblua5.1.a
- lua:liblua.so:/usr/lib/liblua5.1.so
  lua:lua:/usr/share/doc/lua5.1
 "
 
@@ -61,6 +52,17 @@ do_install() {
 lua51-devel_package() {
 	depends="ncurses-devel readline-devel>=6.3 lua51>=${version}_${revision}"
 	short_desc+=" - development files"
+	alternatives="
+	 lua-devel:lua:/usr/include/lua5.1
+	 lua-devel:/usr/include/lua.h:/usr/include/lua5.1/lua.h
+	 lua-devel:/usr/include/luaconf.h:/usr/include/lua5.1/luaconf.h
+	 lua-devel:/usr/include/lua.hpp:/usr/include/lua5.1/lua.hpp
+	 lua-devel:/usr/include/lualib.h:/usr/include/lua5.1/lualib.h
+	 lua-devel:/usr/include/lauxlib.h:/usr/include/lua5.1/lauxlib.h
+	 lua-devel:lua.pc:/usr/lib/pkgconfig/lua5.1.pc
+	 lua-devel:liblua.a:/usr/lib/liblua5.1.a
+	 lua-devel:liblua.so:/usr/lib/liblua5.1.so
+	"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"

--- a/srcpkgs/lua52/template
+++ b/srcpkgs/lua52/template
@@ -1,14 +1,14 @@
 # Template file for 'lua52'
 pkgname=lua52
 version=5.2.4
-revision=7
+revision=8
 wrksrc=lua-${version}
 makedepends="ncurses-devel readline-devel"
 short_desc="Powerful, fast, lightweight, embeddable scripting language (5.2.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="http://www.lua.org"
 license="MIT"
-distfiles="http://www.lua.org/ftp/lua-$version.tar.gz"
+homepage="https://www.lua.org"
+distfiles="https://www.lua.org/ftp/lua-$version.tar.gz"
 checksum=b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b
 
 alternatives="
@@ -16,15 +16,6 @@ alternatives="
  lua:luac:/usr/bin/luac5.2
  lua:lua.1:/usr/share/man/man1/lua5.2.1
  lua:luac.1:/usr/share/man/man1/luac5.2.1
- lua:lua:/usr/include/lua5.2
- lua:/usr/include/lua.h:/usr/include/lua5.2/lua.h
- lua:/usr/include/luaconf.h:/usr/include/lua5.2/luaconf.h
- lua:/usr/include/lua.hpp:/usr/include/lua5.2/lua.hpp
- lua:/usr/include/lualib.h:/usr/include/lua5.2/lualib.h
- lua:/usr/include/lauxlib.h:/usr/include/lua5.2/lauxlib.h
- lua:lua.pc:/usr/lib/pkgconfig/lua5.2.pc
- lua:liblua.a:/usr/lib/liblua5.2.a
- lua:liblua.so:/usr/lib/liblua5.2.so
  lua:lua:/usr/share/doc/lua5.2
 "
 
@@ -66,6 +57,17 @@ do_install() {
 lua52-devel_package() {
 	depends="${makedepends} lua52>=${version}_${revision}"
 	short_desc+=" - development files"
+	alternatives="
+	 lua-devel:lua:/usr/include/lua5.2
+	 lua-devel:/usr/include/lua.h:/usr/include/lua5.2/lua.h
+	 lua-devel:/usr/include/luaconf.h:/usr/include/lua5.2/luaconf.h
+	 lua-devel:/usr/include/lua.hpp:/usr/include/lua5.2/lua.hpp
+	 lua-devel:/usr/include/lualib.h:/usr/include/lua5.2/lualib.h
+	 lua-devel:/usr/include/lauxlib.h:/usr/include/lua5.2/lauxlib.h
+	 lua-devel:lua.pc:/usr/lib/pkgconfig/lua5.2.pc
+	 lua-devel:liblua.a:/usr/lib/liblua5.2.a
+	 lua-devel:liblua.so:/usr/lib/liblua5.2.so
+	"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"

--- a/srcpkgs/lua52/update
+++ b/srcpkgs/lua52/update
@@ -1,0 +1,1 @@
+pattern="lua-\K5.2[\d.]+(?=\.tar)"


### PR DESCRIPTION
The three lua packages all define alternatives that include headers and pkgconfig files; this results in broken links in `/usr` unless the `-devel` package for the selected lua alternative is also installed. I've moved the alternatives related to `-devel` subpackages into their own `lua-devel` alternatives group to avoid these broken symlinks, and to allow selection of a lua development environment that differs from the preferred lua execution environment.