### PR TITLE
[WIP] New package: icecream-1.3.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -987,6 +987,8 @@ liblilv-0.so.0 liblilv-0.14.4_1
 libsuil-0.so.0 suil-0.6.4_1
 libmcpp.so.0 libmcpp-2.7.2_1
 libjitterentropy.so.3 jitterentropy-3.0.0_1
+libicecc.so.0 icecream-1.3_1
+libjitterentropy.so.2 jitterentropy-2.2.0_1
 libkdecorations2.so.5 kdecoration-5.8.4_1
 libkdecorations2private.so.7 kdecoration-5.18.0_1
 libGlacier2.so.35 libIce-3.5.0_1

--- a/srcpkgs/icecream-devel
+++ b/srcpkgs/icecream-devel
@@ -1,0 +1,1 @@
+icecream

--- a/srcpkgs/icecream-sundae/patches/0001-FIX-compilation-on-macOS-addressed-code-review-comme.patch
+++ b/srcpkgs/icecream-sundae/patches/0001-FIX-compilation-on-macOS-addressed-code-review-comme.patch
@@ -1,0 +1,49 @@
+upstream: yes
+
+From 4c1cd11a34f26b2ec29170a4cd557ffd8b1c30e8 Mon Sep 17 00:00:00 2001
+From: Rene Meusel <rene@renemeusel.de>
+Date: Mon, 23 Sep 2019 22:19:51 +0200
+Subject: [PATCH] FIX: compilation on macOS (addressed code review comments)
+
+---
+ meson.build | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 9b17663..d6c4264 100644
+--- a/meson.build
++++ b/meson.build
+@@ -10,7 +10,9 @@ project('icecream-sundae', 'cpp',
+ 
+ icecc = dependency('icecc')
+ glib = dependency('glib-2.0')
++
+ ncurses = dependency('ncursesw')
++ncurses_cxxflag = '-DNCURSES_WIDECHAR'
+ 
+ cxx = meson.get_compiler('cpp')
+ 
+@@ -33,8 +35,8 @@ int main(int argc, char **argv)
+ if not cxx.links(code, dependencies: deps, name: 'libicecc links dynamically')
+     icecc = dependency('icecc', static: true)
+     liblzo2 = cxx.find_library('lzo2')
+-    libcapng = dependency('libcap-ng')
+-    deps += [libcapng, liblzo2]
++    libcapng = dependency('libcap-ng', required: false)
++    deps += [liblzo2, libcapng, libzstd]
+ endif
+ 
+ incdir = include_directories('src')
+@@ -64,7 +66,8 @@ icecream_sundae = executable('icecream-sundae',
+     ['src/main.cpp', 'src/draw.cpp', 'src/scheduler.cpp', 'src/simulator.cpp'],
+     include_directories: incdir,
+     dependencies: deps,
+-    install : true
++    install : true,
++    cpp_args: ncurses_cxxflag
+     )
+ 
+ install_data('icecream-sundae.desktop',
+-- 
+2.30.0
+

--- a/srcpkgs/icecream-sundae/patches/0002-Avoid-unnecessary-ncurses-clear-of-the-screen.patch
+++ b/srcpkgs/icecream-sundae/patches/0002-Avoid-unnecessary-ncurses-clear-of-the-screen.patch
@@ -1,0 +1,33 @@
+upstream: yes
+
+From c1324f186bc526aed7b3a63dfe514d34870548fb Mon Sep 17 00:00:00 2001
+From: Kevin Pulo <kev@pulo.com.au>
+Date: Tue, 19 Nov 2019 21:49:48 +1100
+Subject: [PATCH] Avoid unnecessary ncurses clear() of the screen.
+
+Instead, just erase() the screen, so that it can be drawn over again and
+then flushed at refresh() time.
+
+This fixes the problem where redraws in a slow terminal (eg. mosh or
+over a slow ssh link) sometimes render the cleared screen, causing a
+distracting visible "flash".
+---
+ src/draw.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/draw.cpp b/src/draw.cpp
+index 1ae1eb8..ec66a56 100644
+--- a/src/draw.cpp
++++ b/src/draw.cpp
+@@ -829,7 +829,7 @@ void NCursesInterface::doRender()
+ 
+ void NCursesInterface::doRedraw()
+ {
+-    clear();
++    erase();
+     doRender();
+     refresh();
+ }
+-- 
+2.30.0
+

--- a/srcpkgs/icecream-sundae/template
+++ b/srcpkgs/icecream-sundae/template
@@ -1,0 +1,14 @@
+# Template file for 'icecream-sundae'
+pkgname=icecream-sundae
+version=1.0.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="icecream-devel glib-devel ncurses-devel"
+short_desc="Commandline monitor for Icecream"
+maintainer="Piraty <piraty1@inbox.ru>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/JPEWdev/icecream-sundae"
+distfiles="https://github.com/JPEWdev/icecream-sundae/archive/v${version}.tar.gz"
+checksum=15c357664e47e255044bc4c4e7aaa4dfd911ee7282e2390b7770f2a14c02ae5e
+patch_args="-Np1"

--- a/srcpkgs/icecream/files/icecc-scheduler/run
+++ b/srcpkgs/icecream/files/icecc-scheduler/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+OPTS=
+[ -r ./conf ] && . ./conf
+exec icecc-scheduler --user-uid _icecc $OPTS

--- a/srcpkgs/icecream/files/iceccd/run
+++ b/srcpkgs/icecream/files/iceccd/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+OPTS=
+[ -r ./conf ] && . ./conf
+exec iceccd --user-uid _icecc $OPTS

--- a/srcpkgs/icecream/patches/dont-ignore-point-to-point-interfaces.patch
+++ b/srcpkgs/icecream/patches/dont-ignore-point-to-point-interfaces.patch
@@ -1,0 +1,55 @@
+src: https://github.com/icecc/icecream/pull/540
+
+From 772f402b26f42143aed4d15621b3f778928e3bb3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?T=C3=96R=C3=96K=20Attila?= <torokati44@gmail.com>
+Date: Sat, 20 Jun 2020 21:10:44 +0200
+Subject: [PATCH 1/2] services/comm: Don't ignore point-to-point interfaces,
+ instead use peer IP to broadcast.
+
+This should make icecream work across WireGuard connections.
+---
+ services/comm.cpp | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/services/comm.cpp b/services/comm.cpp
+index 364461fb..7d5e2a48 100644
+--- a/services/comm.cpp
++++ b/services/comm.cpp
+@@ -1473,8 +1473,8 @@ static int open_send_broadcast(int port, const char* buf, int size)
+                 continue;
+             }
+ 
+-            if ((addr->ifa_flags & IFF_POINTOPOINT) || !(addr->ifa_flags & IFF_BROADCAST)) {
+-                log_info() << "ignoring tunnels " << addr->ifa_name << " for broadcast" << endl;
++            if (!(addr->ifa_flags & IFF_BROADCAST) && !(addr->ifa_flags & IFF_POINTOPOINT)) {
++                log_info() << "ignoring " << addr->ifa_name << " - has no broadcast address, nor is it point-to-point" << endl;
+                 continue;
+             }
+         } else {
+@@ -1484,15 +1484,23 @@ static int open_send_broadcast(int port, const char* buf, int size)
+             }
+         }
+ 
+-        if (addr->ifa_broadaddr) {
++        sockaddr_in *broad_or_dst_addr = nullptr;
++
++        // both of these flags are never set at the same time
++        if (addr->ifa_flags & IFF_BROADCAST)
++            broad_or_dst_addr = (sockaddr_in *)addr->ifa_broadaddr;
++        if (addr->ifa_flags & IFF_POINTOPOINT)
++            broad_or_dst_addr = (sockaddr_in *)addr->ifa_dstaddr;
++
++        if (broad_or_dst_addr) {
+             log_info() << "broadcast "
+                        << addr->ifa_name << " "
+-                       << inet_ntoa(((sockaddr_in *)addr->ifa_broadaddr)->sin_addr)
++                       << inet_ntoa(broad_or_dst_addr->sin_addr)
+                        << endl;
+ 
+             remote_addr.sin_family = AF_INET;
+             remote_addr.sin_port = htons(port);
+-            remote_addr.sin_addr = ((sockaddr_in *)addr->ifa_broadaddr)->sin_addr;
++            remote_addr.sin_addr = broad_or_dst_addr->sin_addr;
+ 
+             if (sendto(ask_fd, buf, size, 0, (struct sockaddr *)&remote_addr,
+                        sizeof(remote_addr)) != size) {

--- a/srcpkgs/icecream/template
+++ b/srcpkgs/icecream/template
@@ -1,0 +1,46 @@
+# TODO
+# * system user obviously cannot chroot, which makes building in custom envs impossible. Add a second service `iceccd-root` that can?
+# * do we need anything else than the service's conf file? ... debian ships a full-blown conf file that pre-defines all cmdline args
+#
+# references:
+# 	* https://sources.debian.org/src/icecc/1.3.1-1/debian/
+# 	* https://src.fedoraproject.org/rpms/icecream/tree/master
+
+# Template file for 'icecream'
+pkgname=icecream
+version=1.3.1
+revision=1
+build_style=gnu-configure
+configure_args="--enable-shared"
+hostmakedepends="automake libtool docbook2x"
+makedepends="libcap-ng-devel lzo-devel libarchive-devel"
+short_desc="Distributed compiler with a central scheduler to share build load"
+maintainer="Piraty <piraty1@inbox.ru>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/icecc/icecream"
+distfiles="https://github.com/icecc/icecream/archive/${version}.tar.gz"
+checksum=9f45510fb2251d818baebcff19051c1cf059e48c6b830fb064a8379480159b9d
+patch_args="-Np1"
+
+system_accounts="_icecc"
+
+pre_configure() {
+	autoreconf -vfi
+}
+
+post_install() {
+	vsv iceccd
+	vsv icecc-scheduler
+}
+
+icecream-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.la"
+	}
+}

--- a/srcpkgs/icemon/template
+++ b/srcpkgs/icemon/template
@@ -1,0 +1,13 @@
+# Template file for 'icemon'
+pkgname=icemon
+version=3.3
+revision=1
+build_style=cmake
+hostmakedepends="docbook2x extra-cmake-modules pkg-config"
+makedepends="qt5-devel lzo-devel libcap-ng-devel icecream-devel libzstd-devel libarchive-devel"
+short_desc="Icecream GUI Monitor"
+maintainer="Piraty <piraty1@inbox.ru>"
+license="GPL-2.0-or-later"
+homepage="http://kfunk.org/tag/icemon/"
+distfiles="https://github.com/icecc/icemon/archive/v${version}.tar.gz"
+checksum=3caf14731313c99967f6e4e11ff261b061e4e3d0c7ef7565e89b12e0307814ca


### PR DESCRIPTION
### Intro
This PR brings distributed compiler icecc (https://github.com/icecc/icecream) to Void.

Unlike distcc it supports building on heterogeneous workers (by sending chroot archives to the workers), so my ultimate goal is to use it in xbps-src as an alternative to distcc.

### TODO
* [x] ~Naming of the package? `icecc` or `icecream`? [repology](https://repology.org/project/icecream/versions)~ icecream it is
* [ ] where should daemon's basedir be? [fedora](https://src.fedoraproject.org/rpms/icecream/tree/master) uses `/var/cache/icecc`
* [ ] other distros like [debian](https://sources.debian.org/src/icecc/1.3.1-1/debian/) [fedora](https://src.fedoraproject.org/rpms/icecream/blob/master/f/fedora-sysconfig.icecream) ship a custom icecc.conf that could be adopted for a more simple configuration of the services

### How to test
Required ports are mentioned in the project's [README](https://github.com/icecc/icecream#firewall)
1. on the remote machine: start the daemon: `iceccd -vvv`
1. on the local machine: start the scheduler: `icecc-scheduler -vvv` and a daemon
1. make sure scheduler connects to remote daemon
1. expand PATH to find the icecc symlinks 
```
export ICECC_DEBUG=debug
export PATH="/usr/libexec/icecc/bin:$PATH"
gcc -o helloworld helloworld.c
```
5. or invoke icecc directly
```
ICECC_DEBUG=debug icecc gcc -o helloworld helloworld.c
```