### PR TITLE
goimapnotify: fix update checking [ci skip]

### DIFF
--- a/srcpkgs/goimapnotify/update
+++ b/srcpkgs/goimapnotify/update
@@ -1,0 +1,2 @@
+site="https://gitlab.com/shackra/goimapnotify/-/tags/"
+pattern="goimapnotify-\K[\d.]*(?=\.tar\.gz)"


### PR DESCRIPTION
No need to rebuild pkg or test, I just want to be notified when update-check catches a new tagged release.