### PR TITLE
mesa: update to 20.0.7, remove ocl-icd from mesa-opencl deps

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -245,7 +245,7 @@ libxatracker_package() {
 
 mesa-opencl_package() {
 	short_desc="Mesa implementation of OpenCL (r600+ only)"
-	depends="libclc-git ocl-icd"
+	depends="libclc-git"
 	pkg_install() {
 		vmove etc/OpenCL
 		vmove "usr/lib/libMesaOpenCL.so.*"

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=20.0.6
-revision=2
+version=20.0.7
+revision=1
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
@@ -23,7 +23,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://www.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=30b5d8e9201a01a0e88e18bb79850e67b1d28443b34c4c5cacad4bd10f668b96
+checksum=fe6e258fe772c3cd2ac01741bf7408058c3ac02d66acff9a6e669bd72e3ea178
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
Closes #21899

~~didn't feel like revbumping just for this, mesa gets updated quite often~~
updated also