### PR TITLE
Waybar: update to 0.9.2

### DIFF
--- a/srcpkgs/Waybar/patches/Waybar-0.9.0-fix-building-with-libnl-option-enabled.patch
+++ b/srcpkgs/Waybar/patches/Waybar-0.9.0-fix-building-with-libnl-option-enabled.patch
@@ -1,8 +1,0 @@
---- src/modules/network.cpp
-+++ src/modules/network.cpp
-@@ -2,6 +2,7 @@
- #include <spdlog/spdlog.h>
- #include <sys/eventfd.h>
- #include <fstream>
-+#include <cassert>
- #include "util/format.hpp"

--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,43 +1,45 @@
 # Template file for 'Waybar'
 pkgname=Waybar
-version=0.9.0
+version=0.9.2
 revision=1
 build_style=meson
-configure_args="-Dlibnl=$(vopt_if libnl enabled disabled)
+configure_args="-Dgtk-layer-shell=enabled -Dlibudev=enabled -Dman-pages=enabled
+ -Dsystemd=disabled
+ -Dlibnl=$(vopt_if libnl enabled disabled)
  -Dpulseaudio=$(vopt_if pulseaudio enabled disabled)
  -Ddbusmenu-gtk=$(vopt_if dbusmenugtk enabled disabled)
- -Dsystemd=disabled"
-hostmakedepends="pkg-config glib-devel wayland-devel sway scdoc"
-makedepends="wf-shell libinput-devel wayland-devel wlroots-devel gtkmm-devel spdlog
+ -Dmpd=$(vopt_if mpd enabled disabled)"
+hostmakedepends="cmake pkg-config glib-devel wayland-devel scdoc
+ $(vopt_if dbusmenugtk gobject-introspection)"
+makedepends="libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
  gtk-layer-shell-devel jsoncpp-devel libglib-devel libsigc++-devel fmt-devel
- $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if libnl libnl3-devel)
+ $(vopt_if libnl libnl3-devel)
+ $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if dbusmenugtk libdbusmenu-gtk3-devel)
  $(vopt_if mpd libmpdclient-devel)"
 short_desc="Polybar-like Wayland Bar for Sway and Wlroots based compositors"
-maintainer="DirectorX <void.directorx@protonmail.com>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://github.com/Alexays/Waybar"
 changelog="https://github.com/Alexays/Waybar/releases"
-distfiles="https://github.com/Alexays/Waybar/archive/${version}.tar.gz"
-checksum=65e8397d5a8880cbb9172138e361b0d91f649bc99327d36945e38d1e5dbb157d
+# date library URLs and checksums taken from subprojects/date.wrap
+distfiles="https://github.com/Alexays/Waybar/archive/${version}.tar.gz
+ https://github.com/HowardHinnant/date/archive/v2.4.1.tar.gz
+ https://github.com/mesonbuild/hinnant-date/releases/download/2.4.1-1/hinnant-date.zip"
+checksum="9740662de19dd6126c23efb69c9dc7f9d918443543af12aee770de39d415bdf8
+ 98907d243397483bd7ad889bf6c66746db0d7d2a39cc9aacc041834c40b65b98
+ 2061673a6f8e6d63c3a40df4da58fa2b3de2835fd9b3e74649e8279599f3a8f6"
 
 build_options="libnl pulseaudio dbusmenugtk mpd"
-build_options_default="pulseaudio mpd"
+build_options_default="libnl pulseaudio dbusmenugtk mpd"
 
 desc_option_libnl="Enable libnl support for network related features"
 desc_option_dbusmenugtk="Enable support for tray"
 desc_option_mpd="Enable support for MPD"
 
-
-if [ -z "$CROSS_BUILD" ]; then
-	# Requires gobject introspection
-	build_options_default+=" dbusmenugtk"
-fi
-
-case "$XBPS_TARGET_MACHINE" in
-	*-musl) ;; # Has broken network headers on musl
-	*) build_options_default+=" libnl"
-esac
+pre_configure() {
+	cp -rv ../date-2.4.1 subprojects/
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Added dbusmenugtk option as default for all situations. libnl now works
for musl.

@DirectorX are you still using Void/having time to maintain this? I can maintain the package, if you'd like.