### PR TITLE
live555: update to 2020.05.15

### DIFF
--- a/srcpkgs/live555/template
+++ b/srcpkgs/live555/template
@@ -1,6 +1,6 @@
 # Template file for 'live555'
 pkgname=live555
-version=2020.04.12
+version=2020.05.15
 revision=1
 wrksrc=live
 build_style=gnu-makefile
@@ -9,8 +9,8 @@ short_desc="Set of C++ libraries for multimedia streaming"
 maintainer="Denis Revin <denis.revin@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="http://www.live555.com/liveMedia/"
-distfiles="http://www.live555.com/liveMedia/public/live.$version.tar.gz"
-checksum=3242622f606eb821435983a5e5065b0746d8d8c41f34bbf3552031858de0789a
+distfiles="http://www.live555.com/liveMedia/public/live.${version}.tar.gz"
+checksum=54bfa9bf10e979d742b687339595968c9b443afbb5f264682daa024c74756cb9
 
 if [ "$CROSS_BUILD" ]; then
 	CXXFLAGS="-I. -Iinclude -I../UsageEnvironment/include\


### PR DESCRIPTION
I wish live555 would stop deleting old versions from upstream distfiles.

I didn't revbump vlc because there is no shlib bump. I always get that wrong so please tell me if that is wrong.