### PR TITLE
bookworm: add missing dependencies

### DIFF
--- a/srcpkgs/bookworm/template
+++ b/srcpkgs/bookworm/template
@@ -1,17 +1,17 @@
 # Template file for 'bookworm'
 pkgname=bookworm
 version=1.1.2
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config glib-devel vala"
 makedepends="gtk+3-devel libgee08-devel granite-devel
  webkit2gtk-devel sqlite-devel poppler-glib-devel
  libxml2-devel glib-devel"
-depends="poppler"
+depends="poppler unzip unar"
 short_desc="Simple, focused eBook reader"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"
 homepage="https://babluboy.github.io/bookworm"
 distfiles="https://github.com/babluboy/${pkgname}/archive/${version}.tar.gz"
 checksum=6d27e55697debfa08f7cc15805413b74c94c55111cdf2d333b306228eccad824
-python_version=2 #unverified
+python_version=2 # Should be set to python3 when updated to version > 1.1.2


### PR DESCRIPTION
- `unzip` is needed for unpacking `epub` , `cbz` and `fb2` files.
- `unar` is needed for unpacking `cbr` files.

Edit: Should I python2 as a rundep for the time being? `mobi` files won't open if it ain't installed.

Upstream has added support for python 3 but there hasn't been a new release yet. So adding comment alongside `python_version` as a reminder.

Issue was reported on reddit: https://www.reddit.com/r/voidlinux/comments/gkjcue/bookworm/