### PR TITLE
libglvnd: remove excess devel deps, grep license

### DIFF
--- a/srcpkgs/libglvnd/template
+++ b/srcpkgs/libglvnd/template
@@ -1,7 +1,7 @@
 # Template file for 'libglvnd'
 pkgname=libglvnd
 version=1.3.1
-revision=1
+revision=2
 wrksrc="libglvnd-v${version}"
 build_style=meson
 hostmakedepends="pkg-config"
@@ -27,12 +27,12 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_install() {
-	$XBPS_FETCH_CMD "https://git.archlinux.org/svntogit/packages.git/plain/trunk/LICENSE?h=packages/libglvnd>LICENSE"
+	grep -A 25 "Copyright (c) 2013, NVIDIA CORPORATION." README.md > LICENSE
 	vlicense LICENSE
 }
 
 libglvnd-devel_package() {
-	depends="${makedepends} ${sourcepkg}-${version}_${revision}"
+	depends="libX11-devel ${sourcepkg}-${version}_${revision}"
 	conflicts="MesaLib-devel<19.2.5_2"
 	short_desc+=" - development files"
 	pkg_install() {


### PR DESCRIPTION
Tested building `glu` and `mesa`