### PR TITLE
python3-cloudscraper: update to 1.2.38; skip do_check

### DIFF
--- a/srcpkgs/python3-cloudscraper/template
+++ b/srcpkgs/python3-cloudscraper/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-cloudscraper'
 pkgname=python3-cloudscraper
-version=1.2.34
+version=1.2.38
 revision=1
 archs=noarch
 wrksrc=cloudscraper-${version}
@@ -12,7 +12,12 @@ maintainer="Lorem <notloremipsum@protonmail.com>"
 license="MIT"
 homepage="https://github.com/venomous/cloudscraper"
 distfiles="${PYPI_SITE}/c/cloudscraper/cloudscraper-${version}.tar.gz"
-checksum=50a131a9bfc1969b01d48eecb4ecc1acd92ee992be31c0bee4f1f31ac3cbae8f
+checksum=db295c5ca33f22ae058f317b07c6842a2b16d75c9e11e38d21395363d089692f
+
+do_check() {
+	# Needs unpackaged v8eval
+	:
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Needs unpackaged 'v8eval' to run tests