### PR TITLE
Komikku: update to 0.15.1

### DIFF
--- a/srcpkgs/Komikku/template
+++ b/srcpkgs/Komikku/template
@@ -1,6 +1,6 @@
 # Template file for 'Komikku'
 pkgname=Komikku
-version=0.15.0
+version=0.15.1
 revision=1
 archs=noarch
 wrksrc=Komikku-v${version}
@@ -16,4 +16,4 @@ maintainer="Lorem <notloremipsum@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/valos/Komikku"
 distfiles="${homepage}/-/archive/v${version}/Komikku-v${version}.tar.gz"
-checksum=4c56c9e22d201fbafbae1491c44f7a48a02d990897cf5562d17f9af6e5918ac8
+checksum=983641da25a6d3158e3fc248d450ec1219a22af014803e49a71a56736919feeb


### PR DESCRIPTION
Updates were being checked on https://gitlab.com/valos/Komikku/tags before which doesn't exist.