### PR TITLE
libbluray: enable building bdjava

### DIFF
--- a/srcpkgs/libbluray/template
+++ b/srcpkgs/libbluray/template
@@ -1,10 +1,10 @@
 # Template file for 'libbluray'
 pkgname=libbluray
 version=1.2.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--disable-static --disable-optimizations --disable-bdjava-jar"
-hostmakedepends="pkg-config"
+configure_args="--disable-static --disable-optimizations"
+hostmakedepends="pkg-config apache-ant openjdk8"
 makedepends="libxml2-devel fontconfig-devel"
 short_desc="Library to access Blu-Ray disks for video playback"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -12,6 +12,14 @@ license="LGPL-2.1-or-later"
 homepage="https://www.videolan.org/developers/libbluray.html"
 distfiles="https://download.videolan.org/pub/videolan/libbluray/${version}/libbluray-${version}.tar.bz2"
 checksum=cd41ea06fd2512a77ebf63872873641908ef81ce2fe4e4c842f6035a47696c11
+
+pre_build() {
+	export JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
+}
+
+pre_install() {
+	export JAVA_HOME="/usr/lib/jvm/java-1.8-openjdk"
+}
 
 libbluray-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Fixes #21641 

I'm assuming optimizations were disabled for some reason, we could consider re-enabling them. @DeepwaterCreations, if you could test this out? I'd like to know if it can work without Java installed, because it currently doesn't have Java as a hard dependency.