### PR TITLE
php: fix cross build

### DIFF
--- a/srcpkgs/php/template
+++ b/srcpkgs/php/template
@@ -1,7 +1,7 @@
 # Template file for 'php'
 pkgname=php
 version=7.4.6
-revision=1
+revision=2
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant-devel freetds-devel freetype-devel gdbm-devel
  gmp-devel libcurl-devel libjpeg-turbo-devel libmysqlclient-devel
@@ -23,6 +23,7 @@ replaces="php-mcrypt<7.2.0"
 if [ -n "$CROSS_BUILD" ]; then
 	# php-pear needs php to build
 	hostmakedepends+=" php"
+	CFLAGS+=" -DHAVE_LIBDL -DHAVE_DLOPEN -DHAVE_DLSYM"
 fi
 
 do_build() {


### PR DESCRIPTION
Dynamic loading of extensions was disabled,
because configure cannot determine if dlopen
is available (executes test program).
Override this test by using values taken
from a native build.

closes #21982 and closes #21852 

Did a short test run on armv7l, extensions are now found.
The short test one-liner from #21852
 `php -r 'new SQLite3("db");'` 
works, too.