### PR TITLE
bookworm: don't depend on unar

### DIFF
--- a/srcpkgs/bookworm/template
+++ b/srcpkgs/bookworm/template
@@ -1,13 +1,13 @@
 # Template file for 'bookworm'
 pkgname=bookworm
 version=1.1.2
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="pkg-config glib-devel vala"
 makedepends="gtk+3-devel libgee08-devel granite-devel
  webkit2gtk-devel sqlite-devel poppler-glib-devel
  libxml2-devel glib-devel"
-depends="poppler unzip unar"
+depends="poppler unzip"
 short_desc="Simple, focused eBook reader"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
unar is nocross and musl incompatible at the moment,
making it a hard dependency limits architectures.