### PR TITLE
python(3)-Flask-WTF: update to 0.14.3

### DIFF
--- a/srcpkgs/python-Flask-WTF/template
+++ b/srcpkgs/python-Flask-WTF/template
@@ -5,12 +5,11 @@ revision=1
 archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python-module
-pycompile_module="flask_wtf"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python-Flask python-WTForms"
 short_desc="Simple integration of Flask and WTForms (Python2)"
 maintainer="Eivind Uggedal <eivind@uggedal.com>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="https://github.com/lepture/flask-wtf"
 distfiles="${PYPI_SITE}/F/Flask-WTF/Flask-WTF-${version}.tar.gz"
 checksum=d417e3a0008b5ba583da1763e4db0f55a1269d9dd91dcc3eb3c026d3c5dbd720
@@ -21,7 +20,6 @@ post_install() {
 
 python3-Flask-WTF_package() {
 	archs=noarch
-	pycompile_module="flask_wtf"
 	depends="python3-Flask python3-WTForms"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {

--- a/srcpkgs/python-Flask-WTF/template
+++ b/srcpkgs/python-Flask-WTF/template
@@ -1,7 +1,7 @@
 # Template file for 'python-Flask-WTF'
 pkgname=python-Flask-WTF
-version=0.14.2
-revision=3
+version=0.14.3
+revision=1
 archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python-module
@@ -13,7 +13,7 @@ maintainer="Eivind Uggedal <eivind@uggedal.com>"
 license="3-clause-BSD"
 homepage="https://github.com/lepture/flask-wtf"
 distfiles="${PYPI_SITE}/F/Flask-WTF/Flask-WTF-${version}.tar.gz"
-checksum=5d14d55cfd35f613d99ee7cba0fc3fbbe63ba02f544d349158c14ca15561cc36
+checksum=d417e3a0008b5ba583da1763e4db0f55a1269d9dd91dcc3eb3c026d3c5dbd720
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Apparently werkzeug recently went 1.0 and removed some deprecated imports, which Flask-WTF [fixed](https://github.com/lepture/flask-wtf/commit/8b028994b68f5fffbf920770a0b4943a5225b282) and included in this release (from three months ago...). I only noticed because of the shiny new etesync-dav package!