### PR TITLE
postgresql: allow for proper shutdown

### DIFF
--- a/srcpkgs/postgresql/files/postgresql/control/t
+++ b/srcpkgs/postgresql/files/postgresql/control/t
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/kill -INT `/usr/bin/head -1 /run/runit/supervise.postgresql/pid`

--- a/srcpkgs/postgresql/template
+++ b/srcpkgs/postgresql/template
@@ -1,7 +1,7 @@
 # Template file for 'postgresql'
 pkgname=postgresql
 version=9.6.18
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_target=world
 configure_args="--with-openssl --with-python


### PR DESCRIPTION
runit sends TERM per default if it wants to down a service.
For postgres this means it will go into "smart shutdown mode" [1] and
wait until the last client disconnects and only then shut down. This
can lead to unproper termination of postgres, especially on
shutdowns/reboots.

This change overrides runits default beharviour by sending INT instead
so postgres will go into "fast shutdown mode" [1], which will make
postgres exit as promptly as possible.

[1] https://www.postgresql.org/docs/9.6/server-shutdown.html

cc @jnbr 