### PR TITLE
rpi-kernel: update to 4.19.122.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -5,11 +5,11 @@
 #
 #   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=224931
 
-_githash="9da67d7329873623bd5c13fae5835d76d5be8806"
+_githash="f0e620550b8b422fef4adcabb2d0e8e69f1fec75"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=4.19.120
+version=4.19.122
 revision=1
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
@@ -17,7 +17,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="The Linux kernel for Raspberry Pi (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=38c955458a8ce26409cbbf38cf0776a3dd2b496e4aee2acaf16388142948f5b0
+checksum=33601014b658e2257a51c9b474bd590f75193e11cf78ac200fa5e6dea0caf6d8
 python_version=2
 
 _kernver="${version}_${revision}"


### PR DESCRIPTION
[ci skip]

- Built for armv6l, armv7l, and aarch64.
- Tested on armv6l, armv7l.