### PR TITLE
source-highlight: correct reference to lesspipe.sh

### DIFF
--- a/srcpkgs/source-highlight/template
+++ b/srcpkgs/source-highlight/template
@@ -1,7 +1,7 @@
 # Template file for 'source-highlight'
 pkgname=source-highlight
 version=3.1.9
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-boost=${XBPS_CROSS_BASE}/usr
  --with-bash-completion=/usr/share/bash-completion/completions"
@@ -16,6 +16,11 @@ checksum=3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends="source-highlight"
 fi
+
+post_patch() {
+	# On Void, lesspipe is installed as lesspipe.sh
+	vsed -e 's/\blesspipe\b/&.sh/g' -i src/src-hilite-lesspipe.sh.in
+}
 
 post_configure() {
 	if [ "$CROSS_BUILD" ]; then


### PR DESCRIPTION
The script `src-hilite-lesspipe.sh` installed by `source-highlight` excpects to find an executable named `lesspipe` as a helper. The `lesspipe` package installs this helper as `lesspipe.sh`, so the `source-highlight` template has been modified to replace the `lesspipe` invocation with `lesspipe.sh`.