### PR TITLE
Update KiCad to 5.1.6

### DIFF
--- a/srcpkgs/kicad-doc/template
+++ b/srcpkgs/kicad-doc/template
@@ -1,0 +1,15 @@
+# Template file for 'kicad-doc'
+pkgname=kicad-doc
+version=5.1.6
+revision=1
+short_desc="KiCad documentation"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="GPL-3.0-or-later OR CC-BY-3.0"
+homepage="http://kicad-pcb.org"
+distfiles="https://kicad-downloads.s3.cern.ch/docs/${pkgname}-${version}.tar.gz"
+checksum=3abb7f96269d146023463edb0a5eaaeb73ff4f7b1b6948a5d97deeaf625aecd0
+
+do_install() {
+	vmkdir usr/
+	vcopy share/ usr/
+}

--- a/srcpkgs/kicad-footprints/template
+++ b/srcpkgs/kicad-footprints/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-footprints'
 pkgname=kicad-footprints
-version=5.1.5
+version=5.1.6
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-footprints/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=c2bb5a126e49020134b75dc27d2ee4a9cd56cf300bb16c397ac580fd43339f76
+checksum=a6585cac71aa100375b6e969cb43388749e5d77a54674569f3627aaaf38c6a2c

--- a/srcpkgs/kicad-i18n/template
+++ b/srcpkgs/kicad-i18n/template
@@ -1,14 +1,16 @@
 # Template file for 'kicad-i18n'
 pkgname=kicad-i18n
-version=5.1.5
+version=5.1.6
 revision=1
+_commit=5ad171ce5c8d90f4740517c2adecb310d8be51bd
 archs=noarch
+wrksrc="${pkgname}-${version}-${_commit}"
 build_style=cmake
 hostmakedepends="gettext"
 depends="kicad"
-short_desc="KiCAD localization files"
+short_desc="KiCad localization files"
 maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
-distfiles="https://github.com/kicad/${pkgname}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=aec6902def684ffee62bb7d84edc167151d555ab743cc81b10053207b4e842a3
+distfiles="https://gitlab.com/kicad/code/${pkgname}/-/archive/${version}/kicad-${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=c6f64f4c09286a6fb5834d72bcd6523aed7051d705fb110a52ba2af53f7a10fe

--- a/srcpkgs/kicad-library/template
+++ b/srcpkgs/kicad-library/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-library'
 pkgname=kicad-library
-version=5.1.5
+version=5.1.6
 revision=1
 build_style=meta
 depends="kicad-footprints>=${version} kicad-packages3D>=${version}

--- a/srcpkgs/kicad-packages3D/template
+++ b/srcpkgs/kicad-packages3D/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-packages3D'
 pkgname=kicad-packages3D
-version=5.1.5
+version=5.1.6
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-packages3D/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=b1c35e686865faf8a9b08d3843b188e90b4088f0b1e5f3f0393fac833a22a749
+checksum=c455712a9eacdbbabf3367977911152f2e616bf8f622962f0fd4f3c6ddd00038

--- a/srcpkgs/kicad-symbols/template
+++ b/srcpkgs/kicad-symbols/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-symbols'
 pkgname=kicad-symbols
-version=5.1.5
+version=5.1.6
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-symbols/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=47abb25a88e8f2d9a623d21476bb7ee5a60f5e68e55dcf388842610f0bad7e06
+checksum=c4cd711698aaa681693a733f80c371e140c2cd5809e3ee569320e843aac3325e

--- a/srcpkgs/kicad-templates/template
+++ b/srcpkgs/kicad-templates/template
@@ -1,6 +1,6 @@
 # Template file for 'kicad-templates'
 pkgname=kicad-templates
-version=5.1.5
+version=5.1.6
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,4 +10,4 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="CC-BY-SA-4.0"
 homepage="http://kicad-pcb.org"
 distfiles="https://github.com/kicad/kicad-templates/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=f08f857eee9b88cc89d1579c66046e01d752cf696d468d8ac2465066d379e406
+checksum=f970e889ed3c909691f8a2464831e117e0002cfb0d3b3558bf16f42fa04c55dc

--- a/srcpkgs/kicad/template
+++ b/srcpkgs/kicad/template
@@ -1,23 +1,23 @@
 # Template file for 'kicad'
 pkgname=kicad
-version=5.1.5
+version=5.1.6
 revision=1
 build_style=cmake
 configure_args="-DKICAD_BUILD_VERSION=${version} -DKICAD_SCRIPTING=ON
  -DKICAD_SCRIPTING_MODULES=ON -DKICAD_SCRIPTING_WXPYTHON=ON
  -DKICAD_SCRIPTING_ACTION_MENU=ON  -DBUILD_GITHUB_PLUGIN=ON -DKICAD_USE_OCE=OFF
- -DKICAD_SPICE=$(vopt_if spice ON OFF)"
-hostmakedepends="pkg-config swig wxWidgets-devel"
-makedepends="wxWidgets-devel wxPython-devel python-devel glew-devel cairo-devel
+ -DKICAD_USE_OCC=ON -DKICAD_SPICE=$(vopt_if spice ON OFF)"
+hostmakedepends="pkg-config swig wxWidgets-gtk3-devel"
+makedepends="wxWidgets-gtk3-devel wxPython-devel python-devel glew-devel cairo-devel
  libressl-devel boost-devel libcurl-devel glm occt-devel libgomp-devel
  $(vopt_if spice ngspice-devel)"
 depends="wxPython"
 short_desc="Electronic schematic and PCB design software"
-maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"
 homepage="http://kicad-pcb.org"
-distfiles="https://launchpad.net/${pkgname}/${version%%.*}.0/${version}/+download/${pkgname}-${version}.tar.xz"
-checksum=80625a1da876e1be683dc08268fe43fe67bb704e841e977431f7a82bdc096474
+distfiles="https://gitlab.com/kicad/code/${pkgname}/-/archive/${version}/kicad-${version}.tar.gz"
+checksum=ac1a15e25a7ff0aca4b6224bdb2d3298081b43bedfad79470339d53d5e72beb0
 build_options="spice"
 build_options_default="spice"
 


### PR DESCRIPTION
- Add OCC support

- Change tarball for some packages

- Add kicad-doc package

Closes #17844 and #17818

I'm test driving it locally for now, but if anyone has reviews lmk

Testing: built successfully for x86_64, aarch64 and armv7l.