### PR TITLE
python-pyQt5 fixes

### DIFF
--- a/srcpkgs/python-PyQt5/template
+++ b/srcpkgs/python-PyQt5/template
@@ -3,28 +3,27 @@ pkgname=python-PyQt5
 version=5.13.2
 revision=2
 _sipver=4.19.19
-lib32disabled=yes
 wrksrc="PyQt5-${version}"
-pycompile_module="PyQt5"
 hostmakedepends="pkg-config
- python-devel python3-devel python-sip-devel python3-sip-devel python-dbus-devel
- qt5-tools-devel qt5-connectivity-devel qt5-declarative-devel qt5-location-devel
- qt5-multimedia-devel qt5-sensors-devel qt5-serialport-devel qt5-svg-devel
- qt5-webchannel-devel qt5-webkit-devel qt5-websockets-devel
+ python-devel python3-devel python-sip-devel python3-sip-devel python-dbus-devel qt5
+ qt5-devel qt5-tools-devel qt5-connectivity-devel qt5-declarative-devel qt5-location-devel
+ qt5-multimedia-devel qt5-qmake qt5-sensors-devel qt5-serialport-devel
+ qt5-svg-devel qt5-webchannel-devel qt5-webkit-devel qt5-websockets-devel
  qt5-x11extras-devel qt5-xmlpatterns-devel qt5-networkauth-devel pulseaudio-devel
  python-enum34"
 makedepends="${hostmakedepends/pkg-config/}"
 depends="python-sip-PyQt5>=${_sipver} python-enum34"
 short_desc="Python2 bindings for the Qt5 toolkit"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://riverbankcomputing.com/software/pyqt/intro"
 license="GPL-3.0-only"
+homepage="https://riverbankcomputing.com/software/pyqt/intro"
 distfiles="https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/PyQt5-${version}.tar.gz"
 checksum=adc17c077bf233987b8e43ada87d1e0deca9bd71a13e5fd5fc377482ed69c827
+lib32disabled=yes
 
 pre_build() {
 	mkdir -p pyqt5-${py2_ver}
-	mv * pyqt5-${py2_ver} || true
+	mv * pyqt5-${py2_ver} 2>/dev/null || true
 	cp -a pyqt5-${py2_ver} pyqt5-${py3_ver}
 	rm -rf pyqt5-${py2_ver}/pyuic/uic/port_v3
 	rm -rf pyqt5-${py3_ver}/pyuic/uic/port_v2
@@ -50,11 +49,11 @@ qt_shared = True
 [Qt ${qt_version}]
 # _QOpenGLFunctions_ES2 doesn't work
 pyqt_modules = QtCore QtGui QtHelp QtMultimedia
-    QtMultimediaWidgets QtNetwork QtOpenGL QtPrintSupport QtQml QtQuick
-    QtSql QtSvg QtTest QtWebKit QtWebKitWidgets QtWidgets QtXml
-    QtXmlPatterns QtDesigner QtDBus QtSensors QtSerialPort
-    QtX11Extras QtBluetooth QtPositioning QtQuickWidgets QtWebSockets
-    QtWebChannel QtLocation QtNfc QtNetworkAuth
+ QtMultimediaWidgets QtNetwork QtOpenGL QtPrintSupport QtQml QtQuick
+ QtSql QtSvg QtTest QtWebKit QtWebKitWidgets QtWidgets QtXml
+ QtXmlPatterns QtDesigner QtDBus QtSensors QtSerialPort
+ QtX11Extras QtBluetooth QtPositioning QtQuickWidgets QtWebSockets
+ QtWebChannel QtLocation QtNfc QtNetworkAuth
 EOF
 
 			_sysroot="--sysroot $XBPS_CROSS_BASE"
@@ -97,7 +96,6 @@ python-PyQt5-devel-tools_package() {
 	 pyqt5:pylupdate5:/usr/bin/python2-pylupdate5
 	 pyqt5:pyrcc5:/usr/bin/python2-pyrcc5
 	 pyqt5:pyuic5:/usr/bin/python2-pyuic5"
-	pycompile_module="PyQt5"
 	pkg_install() {
 		vmove usr/bin/python2-*
 		vmove ${py2_sitelib}/PyQt5/pylupdate.so
@@ -114,7 +112,6 @@ python3-PyQt5-devel-tools_package() {
 	 pyqt5:pylupdate5:/usr/bin/python3-pylupdate5
 	 pyqt5:pyrcc5:/usr/bin/python3-pyrcc5
 	 pyqt5:pyuic5:/usr/bin/python3-pyuic5"
-	pycompile_module="PyQt5"
 	pkg_install() {
 		vmove usr/bin/python3-*
 		vmove ${py3_sitelib}/PyQt5/pylupdate.so
@@ -280,7 +277,6 @@ python-PyQt5-xmlpatterns_package() {
 }
 python3-PyQt5_package() {
 	lib32disabled=yes
-	pycompile_module="PyQt5"
 	depends="python3-sip-PyQt5>=${_sipver}"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {


### PR DESCRIPTION
1. It didn't build for me natively on x86_64 because `qmake` couldnt find `qt5` on the host. Hence, I added it to `hostmakedepends`. LMK if this is the wrong way to do it and it should be patched out instead.

2. There is a `mv` recursive move warning in pre_build that I silenced.

3. I made xlint happy.

Letting travis run, I only tested x86_64 here.