### PR TITLE
adobe-flash-plugin: upstream location has changed

### DIFF
--- a/srcpkgs/adobe-flash-plugin/template
+++ b/srcpkgs/adobe-flash-plugin/template
@@ -17,7 +17,7 @@ nopie=yes
 # The EULA file
 _eula="https://www.adobe.com/content/dam/Adobe/en/legal/licenses-terms/pdf/PlatformClients_PC_WWEULA-en_US-20150407_1357.pdf"
 _eulacksum=5a0a95eb4082b6db7182188ce119f3829184b238b0a91293322c2a51a2b41fc1
-_url=https://fpdownload.adobe.com/get/flashplayer/pdc/${version}
+_url=https://fpdownload.adobe.com/pub/flashplayer/pdc/${version}
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	distfiles="
 	 ${_url}/flash_player_npapi_linux.x86_64.tar.gz


### PR DESCRIPTION
Is now `/pub` not `/get`.