### PR TITLE
vpnd: update to 0.1.2.1

### DIFF
--- a/srcpkgs/vpnd/INSTALL.msg
+++ b/srcpkgs/vpnd/INSTALL.msg
@@ -1,2 +1,2 @@
-See the vpnd.conf file in /etc for customisation options
-(including different icons themes).
+- Has additional functionality when yad and notify-send(.sh) are installed
+* 0.1.2 breaking changes: reinstall yad for systray; new image paths in vpnd.conf

--- a/srcpkgs/vpnd/template
+++ b/srcpkgs/vpnd/template
@@ -1,15 +1,16 @@
 # Template file for 'vpnd'
 pkgname=vpnd
-version=0.1.1
+version=0.1.2.1
 revision=1
 archs=noarch
-depends="bash yad"
-short_desc="Systray notifier for Void Linux packages"
+depends="bash"
+conf_files="/etc/vpnd.conf"
+short_desc="Package update notifier daemon for Void Linux"
 maintainer="Benjamin Slade <slade@lambda-y.net>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/emacsomancer/vpnd"
 distfiles="https://gitlab.com/emacsomancer/vpnd/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=49e148766f1e0bdb4a48d58bd72448e72c977f4c326393d694ae0cce2b42f6f9
+checksum=a69066f28f3c65fad4718b35d9e75f7e5b82b85e0fb1f0cdbaea82eae259a69a
 
 do_install() {
 	vbin vpnd


### PR DESCRIPTION
*Breaking changes:*
- in vpnd.conf, icons are referenced _without_ the `icon:` prefix in the path
   - also new settings introduced
- `yad` removed from dependencies since notification option
  introduced (users who want systray icon should (re)install `yad`)

*Improvements:*
- optional notifications via notify-send(.sh)
- connectivity check (if ncat/nmap/curl are installed)
- ability to run w/o yad (if no systray is desired) via notify-send(.sh)
- fixes to formatting of `xbps` update output