### PR TITLE
Libselinux

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3889,3 +3889,4 @@ libjcat.so.1 libjcat-0.1.2_1
 libmatio.so.9 matio-1.5.17_2
 libvips.so.42 libvips-8.9.2_1
 libvips-cpp.so.42 libvips-8.9.2_1
+libselinux.so.1 libselinux-3.0_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3890,3 +3890,4 @@ libmatio.so.9 matio-1.5.17_2
 libvips.so.42 libvips-8.9.2_1
 libvips-cpp.so.42 libvips-8.9.2_1
 libselinux.so.1 libselinux-3.0_1
+libsepol.so.1 libsepol-3.0_1

--- a/srcpkgs/libselinux-devel
+++ b/srcpkgs/libselinux-devel
@@ -1,0 +1,1 @@
+libselinux

--- a/srcpkgs/libselinux/template
+++ b/srcpkgs/libselinux/template
@@ -1,0 +1,27 @@
+# Template file for 'libselinux'
+pkgname=libselinux
+version=3.0
+revision=1
+build_style=gnu-makefile
+make_install_args="SHLIBDIR=/usr/lib SBINDIR=/usr/bin"
+hostmakedepends="pkgconf python ruby xz swig"
+makedepends="libsepol-devel pcre-devel"
+depends="libsepol pcre"
+short_desc="SELinux library and simple utilities"
+maintainer="Anjandev Momi <anjan@momi.ca>"
+license="GPL-2.0-only"
+homepage="https://www.nsa.gov/what-we-do/research/selinux/"
+distfiles="https://github.com/SELinuxProject/selinux/releases/download/20191204/${pkgname}-${version}.tar.gz"
+checksum=2ea2b30f671dae9d6b1391cbe8fb2ce5d36a3ee4fb1cd3c32f0d933c31b82433
+
+libselinux-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove usr/share/man/man3
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}

--- a/srcpkgs/libsepol-devel
+++ b/srcpkgs/libsepol-devel
@@ -1,0 +1,1 @@
+libsepol

--- a/srcpkgs/libsepol/template
+++ b/srcpkgs/libsepol/template
@@ -1,0 +1,26 @@
+# Template file for 'libsepol'
+pkgname=libsepol
+version=3.0
+revision=1
+build_style=gnu-makefile
+make_install_args=SHLIBDIR=/usr/lib
+hostmakedepends="flex"
+depends="glibc"
+short_desc="SELinux binary policy manipulation library"
+maintainer="Anjandev Momi <anjan@momi.ca>"
+license="LGPL-2.1-or-later"
+homepage="http://userspace.selinuxproject.org"
+distfiles="https://github.com/SELinuxProject/selinux/releases/download/20191204/${pkgname}-${version}.tar.gz"
+checksum=5b7ae1881909f1048b06f7a0c364c5c8a86ec12e0ec76e740fe9595a6033eb79
+
+libsepol-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove usr/share/man/man3
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}


### PR DESCRIPTION
libselinux.so.1 is required for matlab according to: https://wiki.archlinux.org/index.php/MATLAB#Blackscreen_in_help_browser_and_livescripts

As such, Im trying to port this aur package: https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=libselinux

Unfortunately Im having trouble with including `libselinux.so.1` in my package as it says xbps-src is ignoring this file:

```
=> libselinux-3.0_1: running pre-pkg hook: 04-generate-runtime-deps ...
   SONAME: libselinux.so.1 <-> libselinux-3.0_1 (ignored)
```

shlibs are hard. Please let me know what I am doing wrong. Thank you.