### PR TITLE
timeshift: add missing psmisc dependency.

### DIFF
--- a/srcpkgs/timeshift/template
+++ b/srcpkgs/timeshift/template
@@ -1,12 +1,12 @@
 # Template file for 'timeshift'
 pkgname=timeshift
 version=20.03
-revision=1
+revision=2
 build_style=gnu-makefile
 conf_files="/etc/default/timeshift.json"
 hostmakedepends="gettext pkg-config vala which"
 makedepends="libgee08-devel json-glib-devel gtk+3-devel vte3-devel libgirepository-devel"
-depends="rsync"
+depends="rsync psmisc"
 short_desc="System restore tool"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
`timeshift` seems to depend on `fuser`, provided by `psmisc`.

cc: @abenson 