### PR TITLE
python3-pybind11: fix generation of man page

### DIFF
--- a/srcpkgs/python3-pybind11/patches/docs.patch
+++ b/srcpkgs/python3-pybind11/patches/docs.patch
@@ -1,0 +1,21 @@
+diff --git a/include/pybind11/pytypes.h b/include/pybind11/pytypes.h
+index 63cbf2e..519f839 100644
+--- include/pybind11/pytypes.h
++++ include/pybind11/pytypes.h
+@@ -980,6 +980,7 @@ public:
+         return std::string(buffer, (size_t) length);
+     }
+ };
++/// @} pytypes
+ 
+ inline bytes::bytes(const pybind11::str &s) {
+     object temp = s;
+@@ -1009,6 +1010,8 @@ inline str::str(const bytes& b) {
+     m_ptr = obj.release().ptr();
+ }
+ 
++/// \addtogroup pytypes
++/// @{
+ class none : public object {
+ public:
+     PYBIND11_OBJECT(none, object, detail::PyNone_Check)

--- a/srcpkgs/python3-pybind11/template
+++ b/srcpkgs/python3-pybind11/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pybind11'
 pkgname=python3-pybind11
 version=2.5.0
-revision=1
+revision=2
 archs=noarch
 wrksrc="pybind11-${version}"
 build_style=python3-module


### PR DESCRIPTION
pybind11 fails to build man pages with `python3-breathe>=4.17.0`; this patch fixes that.

cc: @q66 