### PR TITLE
font-iosevka: update to 3.0.1

### DIFF
--- a/srcpkgs/font-iosevka/template
+++ b/srcpkgs/font-iosevka/template
@@ -1,7 +1,7 @@
 # Template file for 'font-iosevka'
 pkgname=font-iosevka
-version=2.3.3
-revision=2
+version=3.0.1
+revision=1
 archs=noarch
 create_wrksrc=yes
 hostmakedepends="unzip"
@@ -13,9 +13,9 @@ homepage="https://be5invis.github.io/Iosevka/"
 distfiles="https://raw.githubusercontent.com/be5invis/Iosevka/v${version}/LICENSE.md>LICENSE.txt
  https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip
  https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-slab-${version}.zip"
-checksum="ecfd74a1d6749bf509cee122870da0186bccfae446e3f6bc5faff253577ab000
- 619cefd74834c9277adf09b873a4fce6522d3f8e9241cfe15620c2f2662e7b4a
- 28e7560114ed4d21fef3fc32c4eed9638d2a1237ea7e529e0bccce89407c75e6"
+checksum="e61c0988bb231a321f14cce1b119a468f279ea86826c32e943ab16dbf08c1ba9
+ 5e66198c71f5e4b6acb383faaf250af2251465342163b2d8ee2cb154995d844f
+ 25fdff0897aec4b855ee84dfcf7bcbd38cae89aec1779c3231f45e5782565981"
 
 font_dirs="/usr/share/fonts/TTF"
 


### PR DESCRIPTION
This PR updates the font-iosevka package to version 3.0.1
https://github.com/be5invis/Iosevka/releases/tag/v3.0.1