### PR TITLE
New package: b43-firmware, b43-firmware-classic

### DIFF
--- a/srcpkgs/b43-firmware-classic/INSTALL.msg
+++ b/srcpkgs/b43-firmware-classic/INSTALL.msg
@@ -1,0 +1,3 @@
+If you encounter any issues with this release, use b43-firmware.
+
+Problematic devices include: BCM4331

--- a/srcpkgs/b43-firmware-classic/template
+++ b/srcpkgs/b43-firmware-classic/template
@@ -1,0 +1,21 @@
+# Template file for 'b43-firmware-classic'
+pkgname=b43-firmware-classic
+version=5.100.138
+revision=1
+archs=noarch
+wrksrc="broadcom-wl-${version}"
+hostmakedepends="b43-fwcutter"
+short_desc="Firmware for Broadcom B43 wireless (trusted release)"
+maintainer="q66 <daniel@octaforge.org>"
+license="custom:proprietary"
+homepage="https://wireless.wiki.kernel.org/en/users/Drivers/b43"
+distfiles="http://www.lwfinger.com/b43-firmware/broadcom-wl-${version}.tar.bz2"
+checksum=f1e7067aac5b62b67b8b6e4c517990277804339ac16065eb13c731ff909ae46f
+conflicts="b43-firmware>=0"
+repository=nonfree
+restricted=yes
+
+do_install() {
+	vmkdir usr/lib/firmware
+	b43-fwcutter -w ${DESTDIR}/usr/lib/firmware linux/wl_apsta.o
+}

--- a/srcpkgs/b43-firmware/INSTALL.msg
+++ b/srcpkgs/b43-firmware/INSTALL.msg
@@ -1,0 +1,3 @@
+If you encounter any issues with this release, use b43-firmware-classic.
+
+Problematic devices include: BCM4306 rev.3, BCM4311, BCM4312 and BCM4318 rev.2

--- a/srcpkgs/b43-firmware/template
+++ b/srcpkgs/b43-firmware/template
@@ -1,0 +1,22 @@
+# Template file for 'b43-firmware'
+pkgname=b43-firmware
+version=6.30.163.46
+revision=1
+archs=noarch
+wrksrc="${pkgname}"
+create_wrksrc=yes
+hostmakedepends="b43-fwcutter"
+short_desc="Firmware for Broadcom B43 wireless (latest release)"
+maintainer="q66 <daniel@octaforge.org>"
+license="custom:proprietary"
+homepage="https://wireless.wiki.kernel.org/en/users/Drivers/b43"
+distfiles="http://www.lwfinger.com/${pkgname}/broadcom-wl-${version}.tar.bz2"
+checksum=a07c3b6b277833c7dbe61daa511f908cd66c5e2763eb7a0859abc36cd9335c2d
+conflicts="b43-firmware-classic>=0"
+repository=nonfree
+restricted=yes
+
+do_install() {
+	vmkdir usr/lib/firmware
+	b43-fwcutter -w ${DESTDIR}/usr/lib/firmware broadcom-wl-${version}.wl_apsta.o
+}


### PR DESCRIPTION
These are restricted templates (proprietary, non-redistributable) for broadcom b43 series wireless hardware (used in various laptops etc., notably Apple PowerPC and early Intel, but also others)

I haven't been able to find the license text.

Based on the Arch pkgbuilds and Gentoo ebuild.