### PR TITLE
apr and reverse-depends cross flags

### DIFF
--- a/srcpkgs/apache/template
+++ b/srcpkgs/apache/template
@@ -20,9 +20,7 @@ configure_args="--prefix= --sbindir=/usr/bin --enable-pie --enable-modules=all
  --enable-dav-lock --enable-vhost-alias --enable-imagemap --enable-so
  --enable-rewrite --enable-layout=XBPS --sysconfdir=/etc/${pkgname}
  --enable-mpms-shared=all --with-pcre=${XBPS_CROSS_BASE}/usr
- --with-z=${XBPS_CROSS_BASE}/usr
- --with-apr=${XBPS_CROSS_BASE}/usr/bin/apr-1-config
- --with-apr-util=${XBPS_CROSS_BASE}/usr/bin/apu-1-config"
+ --with-z=${XBPS_CROSS_BASE}/usr"
 conf_files="
 	/etc/${pkgname}/extra/*.conf
 	/etc/${pkgname}/httpd.conf
@@ -64,6 +62,13 @@ pre_configure() {
 		-i docs/conf/httpd.conf.in
 
 	cat ${FILESDIR}/xbps.layout >> config.layout
+	if [ "$CROSS_BUILD" ]; then
+		configure_args+=" --with-apr=$XBPS_WRAPPERDIR/apr-1-config
+		 --with-apr-util=$XBPS_WRAPPERDIR/apu-1-config"
+	else
+		configure_args+=" --with-apr=/usr/bin/apr-1-config
+		 --with-apr-util=/usr/bin/apu-1-config"
+	fi
 }
 
 post_configure() {

--- a/srcpkgs/apr-util/template
+++ b/srcpkgs/apr-util/template
@@ -4,7 +4,7 @@ version=1.6.1
 revision=8
 build_style=gnu-configure
 configure_args="
- --with-apr=${XBPS_CROSS_BASE}/usr/bin/apr-1-config --with-pgsql --with-ldap
+ --with-pgsql --with-ldap
  --with-expat=${XBPS_CROSS_BASE}/usr --with-gdbm=${XBPS_CROSS_BASE}/usr
  --with-sqlite3=${XBPS_CROSS_BASE}/usr --with-mysql=${XBPS_CROSS_BASE}/usr
  --with-berkeley-db=${XBPS_CROSS_BASE}/usr --with-odbc=${XBPS_CROSS_BASE}/usr
@@ -28,6 +28,11 @@ fi
 pre_configure() {
 	sed -i configure \
 		-e "s;^\(  APR_BUILD_DIR=\).*$;\1${XBPS_CROSS_BASE}/usr/share/apr-1/build;"
+	if [ "$CROSS_BUILD" ]; then
+		configure_args+=" --with-apr=${XBPS_WRAPPERDIR}/apr-1-config"
+	else
+		configure_args+=" --with-apr=/usr/bin/apr-1-config"
+	fi
 }
 
 post_configure() {

--- a/srcpkgs/apr/template
+++ b/srcpkgs/apr/template
@@ -1,7 +1,7 @@
 # Template file for 'apr'
 pkgname=apr
 version=1.7.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-installbuilddir=/usr/share/apr-1/build"
 makedepends="expat-devel libuuid-devel"
@@ -42,6 +42,14 @@ pre_build() {
 	fi
 }
 
+post_install() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i -e "s,$XBPS_CROSS_BASE,,g" \
+			"$DESTDIR/usr/bin/apr-1-config" \
+			"$DESTDIR/usr/share/apr-1/build/apr_rules.mk"
+	fi
+}
+
 apr-devel_package() {
 	depends="libtool libuuid-devel apr>=${version}_${revision}"
 	short_desc+=" - development files"
@@ -53,6 +61,6 @@ apr-devel_package() {
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.exp"
 		vmove usr/lib/pkgconfig
-		ln -sf /usr/bin/libtool ${PKGDESTDIR}/usr/share/apr-1/build/libtool
+		ln -sf ../../../bin/libtool "$PKGDESTDIR/usr/share/apr-1/build/"
 	}
 }

--- a/srcpkgs/subversion-kwallet-auth/template
+++ b/srcpkgs/subversion-kwallet-auth/template
@@ -44,8 +44,9 @@ pre_configure() {
 
 		# Use apr-1-config and apu-1-config wrappers
 		vsed -i config_vars.mk \
-			-e "s;/usr/bin/\(ap.-1-config\);${XBPS_WRAPPERDIR}/\1;g" \
-			-e "s;-I/usr/include;-I${XBPS_CROSS_BASE}/usr/include;g"
+			-e "/^APR_CONFIG/ s;=.*;= ${XBPS_WRAPPERDIR}/apr-1-config;" \
+			-e "/^APU_CONFIG/ s;=.*;= ${XBPS_WRAPPERDIR}/apu-1-config;" \
+			-e "s;\([I ]\)/usr/include;\1${XBPS_CROSS_BASE}/usr/include;g"
 
 		export PERL5LIB=${XBPS_STATEDIR}/perlprefix/${XBPS_TARGET_MACHINE}-linux
 		mkdir -p $PERL5LIB

--- a/srcpkgs/subversion/template
+++ b/srcpkgs/subversion/template
@@ -42,8 +42,9 @@ pre_configure() {
 
 		# Use apr-1-config and apu-1-config wrappers
 		vsed -i config_vars.mk \
-			-e "s;/usr/bin/\(ap.-1-config\);${XBPS_WRAPPERDIR}/\1;g" \
-			-e "s;-I/usr/include;-I${XBPS_CROSS_BASE}/usr/include;g"
+			-e "/^APR_CONFIG/ s;=.*;= ${XBPS_WRAPPERDIR}/apr-1-config;" \
+			-e "/^APU_CONFIG/ s;=.*;= ${XBPS_WRAPPERDIR}/apu-1-config;" \
+			-e "s;\([I ]\)/usr/include;\1${XBPS_CROSS_BASE}/usr/include;g"
 
 		export PERL5LIB=${XBPS_STATEDIR}/perlprefix/${XBPS_TARGET_MACHINE}-linux
 		mkdir -p $PERL5LIB


### PR DESCRIPTION
- remove cross cruft from `*-config` and `*.pc`
- correct cross flags for reverse dependencies if they're built fail.
- other reverse deps are being tested:
    - [x] serf
    - [x] log4cxx
    - [x] anjuta
    - [x] kdevelop
    - [x] subversion
    - [x] subversion-kwallet-auth
    - [x] apache


`libreoffice` isn't able cross-compile yet.