### PR TITLE
New package: cyrus-sasl-xoauth2-0.2.

### DIFF
--- a/srcpkgs/cyrus-sasl-xoauth2/template
+++ b/srcpkgs/cyrus-sasl-xoauth2/template
@@ -1,0 +1,21 @@
+# Template file for 'cyrus-sasl-xoauth2'
+pkgname=cyrus-sasl-xoauth2
+version=0.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="automake libtool"
+makedepends="libsasl-devel"
+short_desc="XOAUTH2 mechanism plugin for cyrus-sasl"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="MIT"
+homepage="https://github.com/moriyoshi/cyrus-sasl-xoauth2"
+distfiles="https://github.com/moriyoshi/cyrus-sasl-xoauth2/archive/v${version}.tar.gz"
+checksum=a62c26566098100d30aa254e4c1aa4309876b470f139e1019bb9032b6e2ee943
+
+pre_configure() {
+	./autogen.sh
+}
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
This allows one to utilize XOAUTH2 with `mbsync` and `msmtp`, which will be necessary for accessing Google mail servers in the near future.

There is a small patch needed with `isync` to take advantuage of this, but it is already upstream and should be in the next release.