### PR TITLE
update cgo to v0.6.1, fixed gopher URI parsing

### DIFF
--- a/srcpkgs/cgo/template
+++ b/srcpkgs/cgo/template
@@ -1,6 +1,6 @@
 # Template file for 'cgo'
 pkgname=cgo
-version=0.6.0
+version=0.6.1
 revision=1
 build_style=gnu-makefile
 short_desc="Terminal based gopher client"
@@ -8,7 +8,7 @@ maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="ISC"
 homepage="https://github.com/kieselsteini/cgo"
 distfiles="https://github.com/kieselsteini/cgo/archive/v${version}.tar.gz"
-checksum=25de0af911769f0b5a2b4234b281a140827e4b9355586b2b62410f087e37f677
+checksum=e95fad5ed682ea187afb5690e75eef3cff62dc0adf158e92db69cc9b45fae4d1
 
 pre_build() {
 	sed -i '/CC = cc/d' Makefile


### PR DESCRIPTION
- updated cgo version from 0.6.0 to version 0.6.1
- updated tarball checksum