### PR TITLE
chromium: enable pipewire webrtc backend

### DIFF
--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -2,7 +2,7 @@
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
 version=83.0.4103.61
-revision=1
+revision=2
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -31,7 +31,7 @@ makedepends="libpng-devel gtk+-devel gtk+3-devel nss-devel pciutils-devel
  libjpeg-turbo-devel libevent-devel json-c-devel harfbuzz-devel
  minizip-devel jsoncpp-devel zlib-devel libcap-devel libXdamage-devel
  re2-devel fontconfig-devel freetype-devel opus-devel
- ffmpeg-devel libva-devel python-setuptools"
+ ffmpeg-devel libva-devel python-setuptools pipewire-devel"
 depends="libexif hwids desktop-file-utils hicolor-icon-theme xdg-utils"
 
 build_options_default="clang"
@@ -164,8 +164,9 @@ do_configure() {
 		'enable_widevine=true'
 		'enable_hangout_services_extension=true'
 		'is_desktop_linux=true'
+		'rtc_use_pipewire=true'
 	)
-	
+
 	conf+=(
 		"use_vaapi=$(vopt_if vaapi true false)"
 	)


### PR DESCRIPTION
This allows for webrtc screensharing with, for example, https://github.com/emersion/xdg-desktop-portal-wlr to work.