### PR TITLE
qemu-user-static: statically link binaries.

### DIFF
--- a/srcpkgs/qemu-user-static/template
+++ b/srcpkgs/qemu-user-static/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu-user-static'
 pkgname=qemu-user-static
 version=5.0.0
-revision=1
+revision=2
 wrksrc="qemu-${version}"
 hostmakedepends="pkg-config automake python3"
 makedepends="dtc-devel libglib-static pixman-devel libuuid-devel"
@@ -87,7 +87,8 @@ do_configure() {
 	./configure --prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec \
 		--disable-kvm --disable-vnc-png \
 		--disable-virtfs --disable-fdt --disable-seccomp \
-		--enable-linux-user --disable-system
+		--enable-linux-user --disable-system \
+		--static
 }
 
 do_build() {


### PR DESCRIPTION
With the addition of '---static' to the configure stage, the resulting binaries are actually statically linked.

When running mkrootfs from void-mklive for an aarch64 target I ran into the exact problem described here: https://github.com/void-linux/void-mklive/issues/125

After recompiling the qemu-user-static package with this fix it started to work flawlessly and ldd also says that it is not a dynamic executable (which wasn't the case before).

I tested this on a x86_64-musl voidlinux installation.