### PR TITLE
python3-google-api-python-client: add missing dependency

### DIFF
--- a/srcpkgs/python3-google-api-core/template
+++ b/srcpkgs/python3-google-api-core/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-google-api-core'
+pkgname=python3-google-api-core
+version=1.17.0
+revision=1
+archs=noarch
+wrksrc="${pkgname#*-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-googleapis-common-protos python3-protobuf python3-google-auth
+ python3-requests python3-six python3-pytz"
+short_desc="Google API client core library for Python3"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="Apache-2.0"
+homepage="https://github.com/googleapis/python-api-core"
+distfiles="${PYPI_SITE}/g/google-api-core/google-api-core-${version}.tar.gz"
+checksum=e4082a0b479dc2dee2f8d7b80ea8b5d0184885b773caab15ab1836277a01d689

--- a/srcpkgs/python3-google-api-python-client/template
+++ b/srcpkgs/python3-google-api-python-client/template
@@ -1,13 +1,13 @@
 # Template file for 'python3-google-api-python-client'
 pkgname=python3-google-api-python-client
 version=1.8.3
-revision=1
+revision=2
 archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-setuptools"
+hostmakedepends="python3-setuptools"
 depends="python3-httplib2 python3-google-auth python3-google-auth-httplib2
- python3-uritemplate python3-six"
+ python3-google-api-core python3-uritemplate python3-six"
 short_desc="Google API client library for Python3"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"

--- a/srcpkgs/python3-googleapis-common-protos/template
+++ b/srcpkgs/python3-googleapis-common-protos/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-googleapis-common-protos'
+pkgname=python3-googleapis-common-protos
+version=1.51.0
+revision=1
+archs=noarch
+wrksrc="${pkgname#*-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-protobuf"
+short_desc="Common protobufs used in Google APIs (Python3)"
+maintainer="Peter Bui <pbui@github.bx612.space>"
+license="Apache-2.0"
+homepage="https://github.com/googleapis/googleapis"
+distfiles="${PYPI_SITE}/g/googleapis-common-protos/googleapis-common-protos-${version}.tar.gz"
+checksum=013c91704279119150e44ef770086fdbba158c1f978a6402167d47d5409e226e
+
+post_install() {
+	chmod -R +r ${py3_sitelib}
+}


### PR DESCRIPTION
Some of the common API modules were split out into a core library which is missing as a dependency.