### PR TITLE
travis/changed_templates: filter by git itself

### DIFF
--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -9,4 +9,7 @@ elif command -v git >/dev/null 2>&1; then
 fi
 
 /bin/echo -e '\x1b[32mChanged packages:\x1b[0m'
-$GIT_CMD diff --name-status FETCH_HEAD...HEAD | grep "^[AM].*srcpkgs/[^/]*/template$" | cut -d/ -f 2 | tee /tmp/templates | sed "s/^/  /" >&2
+$GIT_CMD diff-tree -r --no-renames --name-only --diff-filter=AM FETCH_HEAD HEAD -- 'srcpkgs/*/template' |
+	cut -d/ -f 2 |
+	tee /tmp/templates |
+	sed "s/^/  /" >&2


### PR DESCRIPTION
- Use plumbing git-diff-tree(1) instead of porcelain git-diff(1)
- Disable rename detection, gains some speed up and fix missing template
  with name-status Renamed and Copied.
- Use "--diff-filter" to filter by Git itself.
- Tell Git to only check 'srcpkgs/*/template', this glob will only look
  into template file inside direct sub-directory of srcpkgs
- With all of those options, we don't need a grep and a pipe

---
@Gottox you're the author of original script, this will speed up the script a bit.
I'll merge this in 2020-05-30 if nobody complains.