### PR TITLE
mariadb: fix cross-compile, fix license, fix xlint

### DIFF
--- a/srcpkgs/mariadb/template
+++ b/srcpkgs/mariadb/template
@@ -17,22 +17,23 @@ configure_args="-DMYSQL_DATADIR=/var/lib/mysql
  -DWITHOUT_EXAMPLE_STORAGE_ENGINE=1 -DWITHOUT_FEDERATED_STORAGE_ENGINE=1
  -DWITH_EXTRA_CHARSETS=complex -DWITH_LIBWRAP=OFF -DSTACK_DIRECTION=1
  -DWITHOUT_PBXT_STORAGE_ENGINE=1 -DWITH_INNOBASE_STORAGE_ENGINE=1"
-lib32disabled=yes
-hostmakedepends="perl bison ncurses-devel libressl-devel libatomic-devel"
+hostmakedepends="perl bison ncurses-devel libressl-devel libatomic-devel
+ pkg-config"
 makedepends="zlib-devel ncurses-devel libressl-devel readline-devel pcre-devel
  libatomic-devel"
 depends="mariadb-client"
+short_desc="Fast SQL database server, drop-in replacement for MySQL"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-only"
+homepage="https://mariadb.org/"
+distfiles="http://archive.mariadb.org/$pkgname-$version/source/$pkgname-$version.tar.gz"
+checksum=173a5e5a24819e0a469c3bd09b5c98491676c37c6095882a2ea34c5af0996c88
+lib32disabled=yes
 provides="mysql-${version}_${revision}"
 replaces="mysql>=0"
 conf_files="/etc/mysql/my.cnf"
 system_accounts="mysql"
 mysql_homedir="/var/lib/mysql"
-short_desc="Fast SQL database server, drop-in replacement for MySQL"
-maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="https://mariadb.org/"
-license="GPL-2"
-distfiles="http://archive.mariadb.org/$pkgname-$version/source/$pkgname-$version.tar.gz"
-checksum=173a5e5a24819e0a469c3bd09b5c98491676c37c6095882a2ea34c5af0996c88
 CFLAGS="-w"
 
 pre_configure() {
@@ -53,10 +54,15 @@ pre_configure() {
 
 pre_build() {
 	if [ "$CROSS_BUILD" ]; then
+		# CMake complains if those binaries ain't in build
 		cp bin.host/comp_err ${wrksrc}/extra
+		cp bin.host/comp_err ${wrksrc}/build/extra
 		cp bin.host/comp_sql ${wrksrc}/scripts
+		cp bin.host/comp_sql ${wrksrc}/build/scripts
 		cp bin.host/gen_lex_hash ${wrksrc}/sql
+		cp bin.host/gen_lex_hash ${wrksrc}/build/sql
 		cp bin.host/gen_lex_token ${wrksrc}/sql
+		cp bin.host/gen_lex_token ${wrksrc}/build/sql
 		export PATH=${PATH}:${wrksrc}/extra:${wrksrc}/scripts:${wrksrc}/sql
 	fi
 	export LD_LIBRARY_PATH=${wrksrc}/build/storage/tokudb/ft-index/portability


### PR DESCRIPTION
- I'm not sure if I should remove those copy to sourcedir
- without copy to builddir, cross build will fail
- change license to GPL-2.0-only
- noisy change because of xlint