### PR TITLE
arduino-cli: add gcompat dependency for musl

### DIFF
--- a/srcpkgs/arduino-cli/template
+++ b/srcpkgs/arduino-cli/template
@@ -1,7 +1,7 @@
 # Template file for 'arduino-cli'
 pkgname=arduino-cli
 version=0.10.0
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/arduino/arduino-cli
 short_desc="Arduino command line interface"
@@ -10,3 +10,8 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/arduino/arduino-cli"
 distfiles="https://github.com/arduino/arduino-cli/archive/${version}.tar.gz"
 checksum=165347f8eb7d34c669ef3cee42bede9faffd5f0bb7ae0ece16c806a6230e8790
+
+case "$XBPS_TARGET_MACHINE" in
+	# the downloaded toolchains use glibc, this allows them to work on musl
+	*-musl) depends+=" gcompat" ;;
+esac


### PR DESCRIPTION
This is necessary for musl systems, because the toolchains downloaded
by arduino-cli are built in glibc systems and require gcompat to work.

Suggested on #voidlinux