### PR TITLE
New packages: python3-aioinflux python3-ciso8601 (dependency)

### DIFF
--- a/srcpkgs/python3-aioinflux/template
+++ b/srcpkgs/python3-aioinflux/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-aioinflux'
+pkgname=python3-aioinflux
+version=0.9.0
+revision=1
+archs=noarch
+wrksrc="${pkgname#*-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-aiohttp python3-ciso8601"
+checkdepends="python3-devel python3-pandas ${depends}"
+short_desc="Asynchronous Python client for InfluxDB"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="MIT"
+homepage="https://github.com/gusutabopb/aioinflux"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=39554b2fe1fd99be07325ee728ba43e2f2a50af1542cc459324ffb924dad1c0a
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-ciso8601/template
+++ b/srcpkgs/python3-ciso8601/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-ciso8601'
+pkgname=python3-ciso8601
+version=2.1.3
+revision=1
+wrksrc="${pkgname#*-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel"
+depends="python3"
+short_desc="Fast ISO8601 date time parser for Python, written in C"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="MIT"
+homepage="https://github.com/closeio/ciso8601"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=4f27113e10622a3b86161c90bee80dc6f3ab8dcab9385092088db239e9fd94dc
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This supersedes #22201; `python-ciso8601` is a dependecy of `python3-aioinflux`, which provides an `asyncio` InfluxDB client.