### PR TITLE
pycharm-community: update to 2020.1.1.

### DIFF
--- a/srcpkgs/pycharm-community/template
+++ b/srcpkgs/pycharm-community/template
@@ -1,6 +1,6 @@
 # Template file for 'pycharm-community'
 pkgname=pycharm-community
-version=2020.1
+version=2020.1.1
 revision=1
 archs="i686 x86_64"
 depends="virtual?java-environment giflib libXtst"
@@ -9,9 +9,10 @@ maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/pycharm/"
 distfiles="https://download-cf.jetbrains.com/python/${pkgname}-${version}.tar.gz"
-checksum=1aa49fd01ec9020c288a583ac90e777df3ae5c5dfcf4cc73d93ac7be1284a9d1
+checksum=715a6a1fc1638078a36b5b45e36e3dbe1ce097aa974555023b4b3d957d00585c
 repository=nonfree
 nopie=yes
+python_version=3
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*) broken="/usr/lib/pycharm/bin/libdbm64.so: file format not recognized" ;;


### PR DESCRIPTION
Would be cool if python_version could be configured on a per-path basis, as it seems some shebangs are in "py2only/" directories and some are in "py3only/" directories, etc. - though I think the IDE might be taking care of that when launching the scripts.