### PR TITLE
nodejs*: set _LARGEFILE_SOURCE/_FILE_OFFSET_BITS=64

### DIFF
--- a/srcpkgs/nodejs-lts-10/template
+++ b/srcpkgs/nodejs-lts-10/template
@@ -43,6 +43,9 @@ if [ "$XBPS_NO_ATOMIC8" ]; then
 	hostmakedepends+=" libatomic-devel"
 fi
 
+CFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+CXXFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+
 do_configure() {
 	local _args
 

--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -49,6 +49,9 @@ if [ "$XBPS_NO_ATOMIC8" ]; then
 	hostmakedepends+=" libatomic-devel"
 fi
 
+CFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+CXXFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+
 do_configure() {
 	local _args
 

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -49,6 +49,9 @@ if [ "$XBPS_NO_ATOMIC8" ]; then
 	hostmakedepends+=" libatomic-devel"
 fi
 
+CFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+CXXFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"
+
 do_configure() {
 	local _args
 


### PR DESCRIPTION
This gets yarn (and probably some other programs) running again on i686
and probably also 32bit arm (untested, but nobody probably ever tested yarn there).

So far only verifided with nodejs