### PR TITLE
vpnd: update to 0.1.3

### DIFF
--- a/srcpkgs/mu/template
+++ b/srcpkgs/mu/template
@@ -1,6 +1,6 @@
 # Template file for 'mu'
 pkgname=mu
-version=1.4.6
+version=1.4.7
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config texinfo glib-devel"
@@ -10,8 +10,8 @@ short_desc="Emacs-based tool for dealing with e-mail stored in the Maildir-forma
 maintainer="Benjamin Slade <slade@jnanam.net>"
 license="GPL-3.0-or-later"
 homepage="https://www.djcbsoftware.nl/code/mu/"
-distfiles="https://github.com/djcb/mu/archive/${version}.tar.gz"
-checksum=8a6afd9f22a21499610bc07a19ea2c4dbe21cc8a2ce7924569346a5ae4b46199
+distfiles="https://github.com/djcb/${pkgname}/releases/download/1%2C4.7/${pkgname}-${version}.tar.xz"
+checksum=1556324b1bfa8ee080d23e3a3e9302ec9ee99a583679b43a03f24afb5cfa15a7
 
 if [ ! "$CROSS_BUILD" ]; then
 	subpackages="mu4e"

--- a/srcpkgs/vpnd/template
+++ b/srcpkgs/vpnd/template
@@ -1,6 +1,6 @@
 # Template file for 'vpnd'
 pkgname=vpnd
-version=0.1.2.1
+version=0.1.3
 revision=1
 archs=noarch
 depends="bash"
@@ -10,7 +10,7 @@ maintainer="Benjamin Slade <slade@lambda-y.net>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.com/emacsomancer/vpnd"
 distfiles="https://gitlab.com/emacsomancer/vpnd/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=a69066f28f3c65fad4718b35d9e75f7e5b82b85e0fb1f0cdbaea82eae259a69a
+checksum=1e06a2b969222b39071fd302e58e6ff13978def30d680c55649bd033e1ff41c7
 
 do_install() {
 	vbin vpnd


### PR DESCRIPTION
improve error handling, reduce redundant xbps calls, other

- simplify and improve handling of errors
- just call xbps-install -Munv once and store output
- kill any existing update process on left-click (so not have wait to recheck)
