### PR TITLE
python3-zeroconf: update to 0.26.2.

### DIFF
--- a/srcpkgs/python3-zeroconf/template
+++ b/srcpkgs/python3-zeroconf/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-zeroconf'
 pkgname=python3-zeroconf
-version=0.26.1
+version=0.26.2
 revision=1
 archs=noarch
 wrksrc="python-zeroconf-${version}"
@@ -12,4 +12,4 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/jstasiak/python-zeroconf"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=4ae4328f6b7721d24975000b0d0224d885093cd9b85055630dfdfd42734119f4
+checksum=b1f3327d861c272523b756a68031c0f980b53f657890e81fdf35b80fcf45697e


### PR DESCRIPTION
minor update
tested on x64, glibc