### PR TITLE
hyperfine: update to 1.10.0.

### DIFF
--- a/srcpkgs/hyperfine/template
+++ b/srcpkgs/hyperfine/template
@@ -1,6 +1,6 @@
 # Template file for 'hyperfine'
 pkgname=hyperfine
-version=1.9.0
+version=1.10.0
 revision=1
 build_style=cargo
 short_desc="Command-line benchmarking tool"
@@ -9,8 +9,14 @@ license="MIT, Apache-2.0"
 homepage="https://github.com/sharkdp/hyperfine"
 changelog="https://github.com/sharkdp/hyperfine/releases"
 distfiles="https://github.com/sharkdp/hyperfine/archive/v${version}.tar.gz"
-checksum=c2b1c6b6364b849acad43dc740c693f5b75a1a4649f24f43967a98c59ad9e9f7
+checksum=b949d6c1a78e9c1c5a7bb6c241fcd51d6faf00bba5719cc312f57b5b301cc854
 
 post_install() {
 	vlicense LICENSE-MIT
+	vman doc/hyperfine.1
+
+	cd "target/${RUST_TARGET}/release/build/hyperfine-"*/out
+	vinstall hyperfine.bash 644 usr/share/bash-completion/completions hyperfine
+	vinstall hyperfine.fish 644 usr/share/fish/vendor_completions.d
+	vinstall _hyperfine 644 usr/share/zsh/site-functions
 }


### PR DESCRIPTION
Also install manpage and shell completion files.