### PR TITLE
libetonyek: rebuild against mdds 1.5

### DIFF
--- a/srcpkgs/libetonyek/template
+++ b/srcpkgs/libetonyek/template
@@ -1,9 +1,9 @@
 # Template file for 'libetonyek'
 pkgname=libetonyek
 version=0.1.9
-revision=3
+revision=4
 build_style=gnu-configure
-configure_args="--with-mdds=1.4"
+configure_args="--with-mdds=1.5"
 hostmakedepends="pkg-config"
 makedepends="libxml2-devel boost-devel libcppunit-devel librevenge-devel
  glm mdds liblangtag-devel"

--- a/srcpkgs/mdds/template
+++ b/srcpkgs/mdds/template
@@ -1,4 +1,9 @@
 # Template file for 'mdds'
+#
+# WARNING: When this package is updated by a point version, libetonyek's
+# configure_args needs to be updated.
+#
+
 pkgname=mdds
 version=1.5.0
 revision=2


### PR DESCRIPTION
Add note to mdds template as it is not obvious to rebuild against it, it does not show up in `xrevshlib`.