### PR TITLE
xapps: update to 1.8.6...

### DIFF
--- a/srcpkgs/cinnamon-session/template
+++ b/srcpkgs/cinnamon-session/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon-session'
 pkgname=cinnamon-session
 version=4.6.0
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dgconf=false"

--- a/srcpkgs/nemo/template
+++ b/srcpkgs/nemo/template
@@ -1,7 +1,7 @@
 # Template file for 'nemo'
 pkgname=nemo
 version=4.6.1
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 pycompile_dirs="/usr/share/nemo/actions/myaction.py"
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://developer.linuxmint.com/projects/cinnamon-projects.html/"
 distfiles="https://github.com/linuxmint/${pkgname}/archive/${version}.tar.gz"
 checksum=be86ebdcd8f6f7ac2886d6791a7e037a0ec73598e4aac7fe1ccead50ceb0da50
-python_version=2 #unverified
+python_version=3
 
 
 do_check() {

--- a/srcpkgs/xapps/template
+++ b/srcpkgs/xapps/template
@@ -1,12 +1,12 @@
 # Template file for 'xapps'
 pkgname=xapps
-version=1.6.10
+version=1.8.6
 revision=1
 build_style=meson
 build_helper="gir"
-hostmakedepends="glib-devel gnome-common pkg-config vala python python3"
+hostmakedepends="glib-devel gnome-common pkg-config vala python3 gettext"
 makedepends="gettext-devel gobject-introspection libgnomekbd-devel
- python-gobject-devel"
+ python3-gobject-devel libdbusmenu-gtk3-devel"
 depends="gist inxi xfconf"
 short_desc="Cross-desktop libraries and common resources from Linux Mint"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later, LGPL-3.0-or-later"
 homepage="https://github.com/linuxmint/xapps"
 changelog="https://raw.githubusercontent.com/linuxmint/xapps/master/debian/changelog"
 distfiles="https://github.com/linuxmint/xapps/archive/${version}.tar.gz"
-checksum=4dd228a2165f1077f18d6fb3152bb77d365ffbb8ad883ed4dd9137886dd21377
+checksum=577a28bd8b02e6bdd52fcc1257d88ef738cdfc065fc5c8ed23554a002c4b0349
 
 xapps-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/xreader/template
+++ b/srcpkgs/xreader/template
@@ -1,7 +1,7 @@
 # Template file for 'xreader'
 pkgname=xreader
-version=2.4.0
-revision=2
+version=2.6.1
+revision=1
 build_style=meson
 build_helper="gir"
 configure_args="-Dintrospection=$(vopt_if gir true false) -Dthumbnailer=false"
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/linuxmint/xreader"
 distfiles="https://github.com/linuxmint/xreader/archive/${version}.tar.gz"
-checksum=d6c550434a89016f16780b146d102d6fda2eaa2a3005a5f22f8df7f188844d14
+checksum=39ce590b8dd21b67a6971eacf2711000423ff1b062387af0ed86043bab4369e0
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
- Drop python2 support. It is not used in the repo and and python3-xapps has dropped support already.
- Revbump nemo and cinnamon-session that use xapps-devel.
- Update xreader to latest version, it also uses xapps-devel.