### PR TITLE
automake: use makejobs instead of -j$(nproc)

### DIFF
--- a/srcpkgs/automake/template
+++ b/srcpkgs/automake/template
@@ -8,7 +8,7 @@ build_style=gnu-configure
 hostmakedepends="perl autoconf"
 checkdepends="cscope dejagnu emacs expect flex gettext-devel glib-devel libtool perl pkg-config
  sharutils texinfo vala lzip xz zip zstd"
-make_check_args="-j$(nproc)"
+make_check_args="${makejobs}"
 depends="${hostmakedepends}"
 short_desc="GNU Standards-compliant Makefile generator"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
@Piraty, was there any reason that nproc was used?