### PR TITLE
New package: waypipe-0.6.1

### DIFF
--- a/srcpkgs/waypipe/template
+++ b/srcpkgs/waypipe/template
@@ -1,0 +1,23 @@
+# Template file for 'waypipe'
+pkgname=waypipe
+version=0.6.1
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_style=meson
+# lto is off because it causes linking errors in armv6l and armv7l (due to NEON)
+configure_args="-Dwerror=false -Dwith_dmabuf=enabled -Dwith_lz4=enabled
+ -Dwith_zstd=enabled -Dwith_video=enabled -Dwith_vaapi=enabled -Db_lto=false"
+hostmakedepends="wayland-devel scdoc pkg-config"
+makedepends="wayland-protocols liblz4-devel libzstd-devel libva-devel
+ MesaLib-devel libdrm-devel ffmpeg-devel"
+depends="openssh"
+short_desc="Proxy for Wayland clients"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="MIT"
+homepage="https://gitlab.freedesktop.org/mstoeckl/waypipe"
+distfiles="https://gitlab.freedesktop.org/mstoeckl/waypipe/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=95114f0f4e52cbd8d054c3119265d9006c9f39550961dea58f72b984075d7bce
+
+post_install() {
+	vlicense COPYING LICENSE
+}


### PR DESCRIPTION
I've tested it, and it seems to be working fine between two x86_64 devices, one musl and one glibc. Worked between a headless armv6l-musl device and a x86_64 glibc as well.