### PR TITLE
New package: pcem-17

### DIFF
--- a/srcpkgs/pcem/template
+++ b/srcpkgs/pcem/template
@@ -1,0 +1,27 @@
+# Template file for 'pcem'
+pkgname=pcem
+version=17
+revision=1
+archs="i686* x86_64* armv7l* aarch64*"
+build_style=gnu-configure
+configure_args="--enable-release-build --enable-networking --enable-alsa"
+hostmakedepends="autoconf automake pkgconf"
+makedepends="SDL2-devel wxWidgets-devel libopenal-devel alsa-lib-devel"
+short_desc="Low-level x86 emulator targeting various IBM PC compatibles"
+maintainer="a dinosaur <nick@a-dinosaur.com>"
+license="GPL-2.0-or-later"
+homepage="https://pcem-emulator.co.uk"
+_distfile="PCemV${version}Linux.tar.gz"
+distfiles="https://pcem-emulator.co.uk/files/${_distfile}"
+checksum=5b24cb5ce886ed53232385f46594146ba3f7d7eecda90f82892b2dce1cb2f1a4
+
+do_extract() {
+	bsdtar -xf "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_distfile}" -C ${wrksrc}
+}
+
+post_install() {
+	vdoc README.md
+	vdoc readme.html
+	vdoc TESTED.md
+	vdoc tested.html
+}


### PR DESCRIPTION
PCem ~~v16~~ v17
http://pcem-emulator.co.uk/

Real BIOS ROM images placed in `~/.pcem/roms/` are required to boot, some freebies are available at the Downloads section of the PCem homepage.