### PR TITLE
transmission: build with cmake

### DIFF
--- a/srcpkgs/transmission/template
+++ b/srcpkgs/transmission/template
@@ -1,19 +1,19 @@
 # Template file for 'transmission'
 pkgname=transmission
 version=3.00
-revision=1
-build_style=gnu-configure
-configure_args="--enable-nls --enable-cli --enable-daemon --enable-utp
- --without-systemd-daemon"
-hostmakedepends="intltool pkg-config qt5-host-tools"
-makedepends="dbus-glib-devel gtk+3-devel libcurl-devel libevent-devel
+revision=2
+build_style=cmake
+configure_args="-DENABLE_CLI=ON"
+hostmakedepends="autoconf automake intltool libtool pkg-config qt5-host-tools qt5-qmake"
+makedepends="dbus-glib-devel glib-devel gtk+3-devel libcurl-devel libevent-devel
  qt5-tools-devel"
 short_desc="Fast, easy and free BitTorrent client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, GPL-2.0-or-later"
 homepage="https://www.transmissionbt.com"
-distfiles="https://github.com/transmission/transmission-releases/raw/master/${pkgname}-${version}.tar.xz"
-checksum=9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2
+distfiles="https://dev.gentoo.org/~floppym/dist/transmission-${version}.tar.xz"
+# distfiles="https://github.com/transmission/transmission-releases/raw/master/${pkgname}-${version}.tar.xz"
+checksum=825710fd4235d0727d4bdad439b30176d52263b264251ece0ba6fe449cbe8c6b
 
 # Create transmission system user/group
 system_accounts="transmission"
@@ -37,35 +37,6 @@ post_configure() {
 		 -e "/#include <inttypes.h>.*/i #include <stdio.h> /* off_t */"
 }
 
-do_build() {
-	make CXXFLAGS="${CXXFLAGS} -std=c++17" LDFLAGS="${LDFLAGS}" ${makejobs}
-	if [ -z "$CROSS_BUILD" ]; then
-		# Build the Qt frontend
-		cd qt
-		qmake-qt5 MOC=moc-qt5 QMAKE_CXXFLAGS="${CXXFLAGS}" QMAKE_LFLAGS="${LDFLAGS}" qtr.pro
-		lrelease-qt5 translations/*.ts
-		make ${makejobs} CXXFLAGS="${CXXFLAGS} -fPIC -std=c++17" LDFLAGS="${LDFLAGS}"
-	fi
-}
-
-do_install() {
-	# Install CLI tools, daemon and web client
-	for dir in cli daemon utils web; do
-		make -C ${dir} DESTDIR=${DESTDIR} install
-	done
-
-	# Install GTK+ frontend
-	make -C gtk DESTDIR=${DESTDIR} install
-	make -C po DESTDIR=${DESTDIR} install
-
-	if [ -z "$CROSS_BUILD" ]; then
-		# Install Qt frontend
-		make -C qt INSTALL_ROOT=${DESTDIR}/usr install
-		vmkdir usr/share/qt5/translations
-		vcopy qt/translations/*.qm usr/share/qt5/translations
-	fi
-}
-
 post_install() {
 	rm -f ${DESTDIR}/usr/share/${pkgname}/web/LICENSE
 	vsv transmission-daemon
@@ -78,10 +49,12 @@ transmission-qt_package() {
 	pkg_install() {
 		vmove usr/bin/transmission-qt
 		vmove usr/share/man/man1/transmission-qt.1
-		vmove usr/share/qt5/translations
-		sed -i '/Icon=/s/transmission/&-qt/' ${wrksrc}/qt/transmission-qt.desktop
+		vmove usr/share/transmission/translations
+		sed -i '/Icon=/s/transmission/&-qt/' ${DESTDIR}/usr/share/applications/transmission-qt.desktop
 		vinstall ${wrksrc}/qt/icons/transmission.png 644 usr/share/pixmaps transmission-qt.png
-		vinstall ${wrksrc}/qt/transmission-qt.desktop 644 usr/share/applications
+		vinstall ${wrksrc}/gtk/icons/hicolor_apps_scalable_transmission.svg \
+			644 usr/share/icons/hicolor/scalable/apps transmission-qt.svg
+		vmove usr/share/applications/transmission-qt.desktop
 	}
 }
 
@@ -92,8 +65,8 @@ transmission-gtk_package() {
 		vmove usr/bin/transmission-gtk
 		vmove usr/share/man/man1/transmission-gtk.1
 		vmove usr/share/icons/hicolor
-		vmove usr/share/applications
-		vmove usr/share/pixmaps
+		vmove usr/share/applications/transmission-gtk.desktop
+		vinstall ${wrksrc}/qt/icons/transmission.png 644 usr/share/pixmaps
 		# This install path seems to be used with musl libc
 		if [ -d ${DESTDIR}/usr/lib/locale ]; then
 			mv ${DESTDIR}/usr/lib/locale ${DESTDIR}/usr/share


### PR DESCRIPTION
- Updated template to use `build_style=cmake` instead of `gnu-configure`
- Fixed broken Qt translations  from previous revision

Right now the official tarball from [transmission/transmission-releases](https://github.com/transmission/transmission-releases) is broken as mentioned in [this issue](https://github.com/transmission/transmission/issues/1248). User @floppym has rolled their own tarball with [this fix](https://github.com/transmission/transmission/pull/1247) applied. I have used that tarball for now but hopefully we can revert to official tarballs for future versions.

Thanks a lot @floppym 