### PR TITLE
qmk: add cross-arm-none-eabi to dependencies

### DIFF
--- a/srcpkgs/qmk/template
+++ b/srcpkgs/qmk/template
@@ -16,7 +16,8 @@ depends="python3-appdirs
  avrdude
  dfu-util
  avr-gcc
- cross-arm-none-eabi-gcc"
+ cross-arm-none-eabi-gcc
+ cross-arm-none-eabi-newlib"
 short_desc="CLI tool for working with QMK firmware of mechanical keyboards"
 maintainer="RinsedSloth <afernandezh@protonmail.com>"
 license="MIT"


### PR DESCRIPTION
Fixes building at least planck/rev6 firmware, possibly other keyboards
with ARM based controllers.

Found out with help from Discord users Erovia and fauxpark on the qmk server.