### PR TITLE
qmk: change dependency to cross-arm-none-eabi

### DIFF
--- a/srcpkgs/qmk/template
+++ b/srcpkgs/qmk/template
@@ -1,7 +1,7 @@
 # Template file for 'qmk'
 pkgname=qmk
 version=0.0.34
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -16,7 +16,7 @@ depends="python3-appdirs
  avrdude
  dfu-util
  avr-gcc
- cross-arm-none-eabi-gcc"
+ cross-arm-none-eabi"
 short_desc="CLI tool for working with QMK firmware of mechanical keyboards"
 maintainer="RinsedSloth <afernandezh@protonmail.com>"
 license="MIT"


### PR DESCRIPTION
cross-arm-none-eabi pulls in both cross-arm-none-eabi-gcc and
cross-arm-none-eabi-newlib, and I found out the latter is also needed to build
at least planck/rev6 firmware, and likely other keyboards with ARM based
controllers.

Found out with help from Discord users @Erovia and @fauxpark on the qmk server.

Using cross-arm-none-eabi as dep to get -newlib suggested by @ericonr.