### PR TITLE
transmission: build with cmake

### DIFF
--- a/srcpkgs/transmission/patches/add-missing-files.patch
+++ b/srcpkgs/transmission/patches/add-missing-files.patch
@@ -1,0 +1,2462 @@
+diff --git libtransmission/subprocess-test.cmd libtransmission/subprocess-test.cmd
+new file mode 100644
+index 0000000..4d08d06
+--- /dev/null
++++ libtransmission/subprocess-test.cmd
+@@ -0,0 +1,48 @@
++@echo off
++setlocal EnableExtensions EnableDelayedExpansion
++
++set __argc=0
++for %%i in (%*) do (
++    set /a __argc+=1
++    set "__argv[!__argc!]=%%~i"
++)
++
++set "result_path=!__argv[1]!"
++set "test_action=!__argv[2]!"
++
++set "temp_result_path=%result_path%.tmp"
++>"%temp_result_path%" <nul set /p=
++
++if "%test_action%" == "--dump-args" goto dump_args
++if "%test_action%" == "--dump-env" goto dump_env
++if "%test_action%" == "--dump-cwd" goto dump_cwd
++
++exit /b 1
++
++:dump_args
++    for /l %%i in (3,1,%__argc%) do (
++        >>"%temp_result_path%" echo.!__argv[%%i]!
++    )
++    goto finish
++
++:dump_env
++    for /l %%i in (3,1,%__argc%) do (
++        >>"%temp_result_path%" call :dump_env_var "!__argv[%%i]!"
++    )
++    goto finish
++
++:dump_env_var
++    if defined %~1 (
++        echo.!%~1!
++    ) else (
++        echo.^<null^>
++    )
++    exit /b 0
++
++:dump_cwd
++    >>"%temp_result_path%" echo.%CD%
++    goto finish
++
++:finish
++    >nul move /y "%temp_result_path%" "%result_path%"
++    exit /b 0
+diff --git po/pt_PT.po po/pt_PT.po
+new file mode 100644
+index 0000000..d9346f8
+--- /dev/null
++++ po/pt_PT.po
+@@ -0,0 +1,2402 @@
++# SOME DESCRIPTIVE TITLE.
++# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
++# This file is distributed under the same license as the PACKAGE package.
++# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
++#
++# Translators:
++# Gonçalo Matos , 2017
++# String YM <inactive+StringYM@transifex.com>, 2017
++# Rui <xymarior@yandex.com>, 2019
++#
++#, fuzzy
++msgid ""
++msgstr ""
++"Project-Id-Version: PACKAGE VERSION\n"
++"Report-Msgid-Bugs-To: \n"
++"POT-Creation-Date: 2020-05-14 18:55+0300\n"
++"PO-Revision-Date: 2017-01-26 19:47+0000\n"
++"Last-Translator: Rui <xymarior@yandex.com>, 2019\n"
++"Language-Team: Portuguese (Portugal) (https://www.transifex.com/transmissionbt/teams/33778/pt_PT/)\n"
++"Language: pt_PT\n"
++"MIME-Version: 1.0\n"
++"Content-Type: text/plain; charset=UTF-8\n"
++"Content-Transfer-Encoding: 8bit\n"
++"Plural-Forms: nplurals=2; plural=(n != 1);\n"
++
++#: ../cli/cli.c:114 ../gtk/util.c:92 ../libtransmission/utils.c:1694
++msgid "None"
++msgstr "Nenhum"
++
++#: ../gtk/actions.c:31
++msgid "Sort by _Activity"
++msgstr "Ordernar por: _Atividade"
++
++#: ../gtk/actions.c:32
++msgid "Sort by _Name"
++msgstr "Ordenar por: _Nome"
++
++#: ../gtk/actions.c:33
++msgid "Sort by _Progress"
++msgstr "Ordenar por: _Progresso"
++
++#: ../gtk/actions.c:34
++msgid "Sort by _Queue"
++msgstr "Ordenar por: _Data"
++
++#: ../gtk/actions.c:35
++msgid "Sort by Rati_o"
++msgstr "Ordenar por: Percent_agem"
++
++#: ../gtk/actions.c:36
++msgid "Sort by Stat_e"
++msgstr "Ordenar por: _Estado"
++
++#: ../gtk/actions.c:37
++msgid "Sort by A_ge"
++msgstr "Ordenar por: A_ge"
++
++#: ../gtk/actions.c:38
++msgid "Sort by Time _Left"
++msgstr "Ordenar por: Time_Left"
++
++#: ../gtk/actions.c:39
++msgid "Sort by Si_ze"
++msgstr "Ordenar por: Si:ze"
++
++#: ../gtk/actions.c:53
++msgid "_Show Transmission"
++msgstr "_Mostrar o Transmission"
++
++#: ../gtk/actions.c:54
++msgid "Message _Log"
++msgstr "_Registo de Mensagens"
++
++#: ../gtk/actions.c:67
++msgid "Enable Alternative Speed _Limits"
++msgstr "Ativar _Limites de Velocidade Alternativos"
++
++#: ../gtk/actions.c:68
++msgid "_Compact View"
++msgstr "Vista _Compacta"
++
++#: ../gtk/actions.c:69
++msgid "Re_verse Sort Order"
++msgstr "In_verter Ordenação"
++
++#: ../gtk/actions.c:70
++msgid "_Filterbar"
++msgstr "Barra de _Filtros"
++
++#: ../gtk/actions.c:71
++msgid "_Statusbar"
++msgstr "Barra de E_stado"
++
++#: ../gtk/actions.c:72
++msgid "_Toolbar"
++msgstr "Barra de Ferramen_tas"
++
++#: ../gtk/actions.c:77
++msgid "_File"
++msgstr "_Ficheiro"
++
++#: ../gtk/actions.c:78
++msgid "_Torrent"
++msgstr "_Torrent"
++
++#: ../gtk/actions.c:79
++msgid "_View"
++msgstr "_Vista"
++
++#: ../gtk/actions.c:80
++msgid "_Sort Torrents By"
++msgstr "_Ordenar Torrents por:"
++
++#: ../gtk/actions.c:81
++msgid "_Queue"
++msgstr "F_ila"
++
++#: ../gtk/actions.c:82 ../gtk/details.c:2839
++msgid "_Edit"
++msgstr "_Editar"
++
++#: ../gtk/actions.c:83
++msgid "_Help"
++msgstr "_Ajuda"
++
++#: ../gtk/actions.c:84
++msgid "Copy _Magnet Link to Clipboard"
++msgstr "Copiar Link _Magnético"
++
++#: ../gtk/actions.c:85
++msgid "Open URL…"
++msgstr "Abrir URL…"
++
++#: ../gtk/actions.c:85
++msgid "Open _URL…"
++msgstr "Abrir _URL…"
++
++#: ../gtk/actions.c:86 ../gtk/actions.c:87
++msgid "Open a torrent"
++msgstr "Abrir um torrent"
++
++#: ../gtk/actions.c:88
++msgid "Start torrent"
++msgstr "_Iniciar Torrent"
++
++#: ../gtk/actions.c:88
++msgid "_Start"
++msgstr "_Iniciar"
++
++#: ../gtk/actions.c:89
++msgid "Start _Now"
++msgstr "Iniciar _Agora"
++
++#: ../gtk/actions.c:89
++msgid "Start torrent now"
++msgstr "Iniciar o torrent agora"
++
++#: ../gtk/actions.c:91
++msgid "_Statistics"
++msgstr "E_statísticas"
++
++#: ../gtk/actions.c:92
++msgid "_Donate"
++msgstr "_Doar"
++
++#: ../gtk/actions.c:93
++msgid "_Verify Local Data"
++msgstr "_Verificar Dados Locais"
++
++#: ../gtk/actions.c:94
++msgid "Pause torrent"
++msgstr "Pausar o Torrent"
++
++#: ../gtk/actions.c:94
++msgid "_Pause"
++msgstr "_Pausar"
++
++#: ../gtk/actions.c:95
++msgid "Pause all torrents"
++msgstr "Pausar todos os torrents"
++
++#: ../gtk/actions.c:95
++msgid "_Pause All"
++msgstr "Pausar tudo"
++
++#: ../gtk/actions.c:96
++msgid "Start all torrents"
++msgstr "Iniciar todos os Torrents"
++
++#: ../gtk/actions.c:96
++msgid "_Start All"
++msgstr "_Iniciar tudo"
++
++#: ../gtk/actions.c:97
++msgid "Set _Location…"
++msgstr "Definir _Localização…"
++
++#: ../gtk/actions.c:98
++msgid "Remove torrent"
++msgstr "Remover torrent"
++
++#: ../gtk/actions.c:99
++msgid "_Delete Files and Remove"
++msgstr "_Eliminar Ficheiros e Remover"
++
++#: ../gtk/actions.c:100
++msgid "Create a torrent"
++msgstr "Criar torrent"
++
++#: ../gtk/actions.c:100
++msgid "_New…"
++msgstr "_Novo"
++
++#: ../gtk/actions.c:101
++msgid "_Quit"
++msgstr "_Sair"
++
++#: ../gtk/actions.c:102
++msgid "Select _All"
++msgstr "Selecion_ar Tudo"
++
++#: ../gtk/actions.c:103
++msgid "Dese_lect All"
++msgstr "Desce_lecionar Tudo"
++
++#: ../gtk/actions.c:105
++msgid "Torrent properties"
++msgstr "Propriedades do torrent"
++
++#: ../gtk/actions.c:106
++msgid "Open Fold_er"
++msgstr "Abrir _Pasta"
++
++#: ../gtk/actions.c:108
++msgid "_Contents"
++msgstr "_Conteúdos"
++
++#: ../gtk/actions.c:109
++msgid "Ask Tracker for _More Peers"
++msgstr "Pedir ao rastreador _mais pares"
++
++#: ../gtk/actions.c:110
++msgid "Move to _Top"
++msgstr "Mover para o _Topo"
++
++#: ../gtk/actions.c:111
++msgid "Move _Up"
++msgstr "Mover para _Cima"
++
++#: ../gtk/actions.c:112
++msgid "Move _Down"
++msgstr "Mover para _Baixo"
++
++#: ../gtk/actions.c:113
++msgid "Move to _Bottom"
++msgstr "Mover para o _Fundo"
++
++#: ../gtk/actions.c:114
++msgid "Present Main Window"
++msgstr "Mostrar janela principal"
++
++#: ../gtk/details.c:486 ../gtk/details.c:497
++msgid "Use global settings"
++msgstr "Usar definições globais"
++
++#: ../gtk/details.c:487
++msgid "Seed regardless of ratio"
++msgstr "Semear independentemente do rácio"
++
++#: ../gtk/details.c:488
++msgid "Stop seeding at ratio:"
++msgstr "Parar de semear no rácio:"
++
++#: ../gtk/details.c:498
++msgid "Seed regardless of activity"
++msgstr "Semear independentemente da atividade"
++
++#: ../gtk/details.c:499
++msgid "Stop seeding if idle for N minutes:"
++msgstr "Parar de semear se inativo por N minutos:"
++
++#: ../gtk/details.c:517 ../gtk/tr-prefs.c:1253
++msgid "Speed"
++msgstr "Velocidade"
++
++#: ../gtk/details.c:519
++msgid "Honor global _limits"
++msgstr "Respeitar _limites globais"
++
++#: ../gtk/details.c:524
++#, c-format
++msgid "Limit _download speed (%s):"
++msgstr "Limitar velocidade de _descarregamento (%s):"
++
++#: ../gtk/details.c:537
++#, c-format
++msgid "Limit _upload speed (%s):"
++msgstr "Limitar velocidade de _envio (%s):"
++
++#: ../gtk/details.c:550 ../gtk/open-dialog.c:368
++msgid "Torrent _priority:"
++msgstr "_Prioridade do torrent:"
++
++#: ../gtk/details.c:554
++msgid "Seeding Limits"
++msgstr "Limites de Velocidade"
++
++#: ../gtk/details.c:564
++msgid "_Ratio:"
++msgstr "_Rácio:"
++
++#: ../gtk/details.c:573
++msgid "_Idle:"
++msgstr "_Inativo:"
++
++#: ../gtk/details.c:576
++msgid "Peer Connections"
++msgstr "Ligações a pares"
++
++#: ../gtk/details.c:579
++msgid "_Maximum peers:"
++msgstr "_Máximo de pares:"
++
++#: ../gtk/details.c:598 ../gtk/torrent-cell-renderer.c:195 ../libtransmission/verify.c:272
++msgid "Queued for verification"
++msgstr "Na fila para verificação"
++
++#: ../gtk/details.c:601
++msgid "Verifying local data"
++msgstr "A verificar dados locais"
++
++#: ../gtk/details.c:604 ../gtk/torrent-cell-renderer.c:199
++msgid "Queued for download"
++msgstr "Na fila para descarregar"
++
++#: ../gtk/details.c:607 ../gtk/filter.c:586
++msgctxt "Verb"
++msgid "Downloading"
++msgstr "A descarregar"
++
++#: ../gtk/details.c:610 ../gtk/torrent-cell-renderer.c:203
++msgid "Queued for seeding"
++msgstr "Na fila para semear"
++
++#: ../gtk/details.c:613 ../gtk/filter.c:587
++msgctxt "Verb"
++msgid "Seeding"
++msgstr "A semear"
++
++#: ../gtk/details.c:616 ../gtk/filter.c:589 ../gtk/torrent-cell-renderer.c:191
++msgid "Finished"
++msgstr "Terminado"
++
++#: ../gtk/details.c:616 ../gtk/filter.c:588 ../gtk/torrent-cell-renderer.c:191
++msgid "Paused"
++msgstr "Pausado"
++
++#: ../gtk/details.c:653 ../gtk/details.c:733
++msgid "N/A"
++msgstr "N/A"
++
++#: ../gtk/details.c:664 ../gtk/file-list.c:636
++msgid "Mixed"
++msgstr "Misturado"
++
++#: ../gtk/details.c:665
++msgid "No Torrents Selected"
++msgstr "Sem Torrents Selecionados"
++
++#: ../gtk/details.c:695
++msgid "Private to this tracker -- DHT and PEX disabled"
++msgstr "Privado para este rastreador - DHT e PEX desativados"
++
++#: ../gtk/details.c:695
++msgid "Public torrent"
++msgstr "Torrent público"
++
++#: ../gtk/details.c:739
++#, c-format
++msgid "Created by %1$s"
++msgstr "Criado por %1$s"
++
++#: ../gtk/details.c:743
++#, c-format
++msgid "Created on %1$s"
++msgstr "Criado em %1$s"
++
++#: ../gtk/details.c:747
++#, c-format
++msgid "Created by %1$s on %2$s"
++msgstr "Criado por %1$s em %2$s"
++
++#: ../gtk/details.c:877
++msgid "Unknown"
++msgstr "Desconhecido"
++
++#: ../gtk/details.c:919
++#, c-format
++msgid "%1$s (%2$'d piece @ %3$s)"
++msgid_plural "%1$s (%2$'d pieces @ %3$s)"
++msgstr[0] "%1$s (%2$'d pedaço @ %3$s)"
++msgstr[1] "%1$s (%2$'d pedaços @ %3$s)"
++
++#: ../gtk/details.c:925
++#, c-format
++msgid "%1$s (%2$'d piece)"
++msgid_plural "%1$s (%2$'d pieces)"
++msgstr[0] "%1$s (%2$'d pedaço)"
++msgstr[1] "%1$s (%2$'d pedaços)"
++
++#: ../gtk/details.c:969
++#, c-format
++msgid "%1$s (%2$s%%)"
++msgstr "%1$s (%2$s%%)"
++
++#: ../gtk/details.c:973
++#, c-format
++msgid "%1$s (%2$s%% of %3$s%% Available)"
++msgstr "%1$s (%2$s%% de %3$s%% Disponível)"
++
++#: ../gtk/details.c:977
++#, c-format
++msgid "%1$s (%2$s%% of %3$s%% Available); %4$s Unverified"
++msgstr "%1$s (%2$s%% de %3$s%% Disponível); %4$s Por verificar"
++
++#: ../gtk/details.c:1010
++#, c-format
++msgid "%1$s (+%2$s corrupt)"
++msgstr "%1$s (+%2$s corrompido)"
++
++#: ../gtk/details.c:1042
++#, c-format
++msgid "%s (Ratio: %s)"
++msgstr "%s (Rácio: %s)"
++
++#: ../gtk/details.c:1084
++msgid "No errors"
++msgstr "Sem erros"
++
++#: ../gtk/details.c:1108
++msgid "Never"
++msgstr "Nunca"
++
++#: ../gtk/details.c:1116
++msgid "Active now"
++msgstr "Ativo agora"
++
++#: ../gtk/details.c:1122
++#, c-format
++msgid "%1$s ago"
++msgstr "%1$s atrás"
++
++#: ../gtk/details.c:1145
++msgid "Activity"
++msgstr "Atividade"
++
++#: ../gtk/details.c:1150
++msgid "Torrent size:"
++msgstr "Tamanho do torrent:"
++
++#: ../gtk/details.c:1155
++msgid "Have:"
++msgstr "Tenho:"
++
++#: ../gtk/details.c:1160 ../gtk/stats.c:133 ../gtk/stats.c:158
++msgid "Uploaded:"
++msgstr "Enviado:"
++
++#: ../gtk/details.c:1165 ../gtk/stats.c:137 ../gtk/stats.c:162
++msgid "Downloaded:"
++msgstr "Descarregado:"
++
++#: ../gtk/details.c:1170
++msgid "State:"
++msgstr "Estado:"
++
++#: ../gtk/details.c:1175
++msgid "Running time:"
++msgstr "Tempo em execução:"
++
++#: ../gtk/details.c:1180
++msgid "Remaining time:"
++msgstr "Tempo restante:"
++
++#: ../gtk/details.c:1185
++msgid "Last activity:"
++msgstr "Última atividade:"
++
++#: ../gtk/details.c:1189
++msgid "Error:"
++msgstr "Erro:"
++
++#: ../gtk/details.c:1193
++msgid "Details"
++msgstr "Detalhes"
++
++#: ../gtk/details.c:1197
++msgid "Location:"
++msgstr "Localização:"
++
++#: ../gtk/details.c:1202
++msgid "Hash:"
++msgstr "Hash:"
++
++#: ../gtk/details.c:1208
++msgid "Privacy:"
++msgstr "Privacidade:"
++
++#: ../gtk/details.c:1213
++msgid "Origin:"
++msgstr "Origem:"
++
++#: ../gtk/details.c:1228
++msgid "Comment:"
++msgstr "Comentário:"
++
++#: ../gtk/details.c:1256
++msgid "Web Seeds"
++msgstr "Semeares da web"
++
++#: ../gtk/details.c:1260 ../gtk/details.c:1316
++msgid "Down"
++msgstr "Baixo"
++
++#: ../gtk/details.c:1312
++msgid "Address"
++msgstr "Endereço"
++
++#: ../gtk/details.c:1320
++msgid "Up"
++msgstr "Cima"
++
++#: ../gtk/details.c:1323
++msgid "Client"
++msgstr "Cliente"
++
++#: ../gtk/details.c:1326
++msgid "%"
++msgstr "%"
++
++#: ../gtk/details.c:1330
++msgid "Up Reqs"
++msgstr "Pedid. Env."
++
++#: ../gtk/details.c:1334
++msgid "Dn Reqs"
++msgstr "Pedid. Receb."
++
++#: ../gtk/details.c:1338
++msgid "Dn Blocks"
++msgstr "Blocos Receb."
++
++#: ../gtk/details.c:1342
++msgid "Up Blocks"
++msgstr "Blocos Env."
++
++#: ../gtk/details.c:1346
++msgid "We Cancelled"
++msgstr "Nós Concelamos"
++
++#: ../gtk/details.c:1350
++msgid "They Cancelled"
++msgstr "Eles Cancelaram"
++
++#: ../gtk/details.c:1353
++msgid "Flags"
++msgstr "Bandeiras"
++
++#: ../gtk/details.c:1770
++msgid "Optimistic unchoke"
++msgstr "Desestrangulamento otimista"
++
++#: ../gtk/details.c:1774
++msgid "Downloading from this peer"
++msgstr "A descarregar deste par"
++
++#: ../gtk/details.c:1778
++msgid "We would download from this peer if they would let us"
++msgstr "Descarregaríamos deste pare se ele permitisse"
++
++#: ../gtk/details.c:1782
++msgid "Uploading to peer"
++msgstr "A enviar para o par"
++
++#: ../gtk/details.c:1786
++msgid "We would upload to this peer if they asked"
++msgstr "Enviaríamos para este par se ele pedisse"
++
++#: ../gtk/details.c:1790
++msgid "Peer has unchoked us, but we're not interested"
++msgstr "O par destrangulou-nos, mas não estamos interessados"
++
++#: ../gtk/details.c:1794
++msgid "We unchoked this peer, but they're not interested"
++msgstr "Desestrangulamos este par, mas ele não está interessado"
++
++#: ../gtk/details.c:1798
++msgid "Encrypted connection"
++msgstr "Ligação encriptada"
++
++#: ../gtk/details.c:1802
++msgid "Peer was found through Peer Exchange (PEX)"
++msgstr "O par foi descoberto através da Trocar de Pares (PEX)"
++
++#: ../gtk/details.c:1806
++msgid "Peer was found through DHT"
++msgstr "O par foi encontrado através da Tabela Hash Distribuída (DHT)"
++
++#: ../gtk/details.c:1810
++msgid "Peer is an incoming connection"
++msgstr "O par é uma ligação a dar entrada"
++
++#: ../gtk/details.c:1814
++msgid "Peer is connected over µTP"
++msgstr "O par está ligado através de µTP"
++
++#: ../gtk/details.c:2082 ../gtk/details.c:2854
++msgid "Show _more details"
++msgstr "Mostrar _mais detalhes"
++
++#: ../gtk/details.c:2156
++#, c-format
++msgid "Got a list of %1$s%2$'d peers%3$s %4$s ago"
++msgstr "Obtida uma lista de %1$s%2$'d pares%3$s %4$s atrás"
++
++#: ../gtk/details.c:2161
++#, c-format
++msgid "Peer list request %1$stimed out%2$s %3$s ago; will retry"
++msgstr "O pedido de lista de pares %1$sexcedeu o tempo limite%2$s %3$s atrás; a tentar novamente"
++
++#: ../gtk/details.c:2166
++#, c-format
++msgid "Got an error %1$s\"%2$s\"%3$s %4$s ago"
++msgstr "Obtido um erro %1$s\"%2$s\"%3$s %4$s atrás"
++
++#: ../gtk/details.c:2175
++msgid "No updates scheduled"
++msgstr "Não há atualizações programadas"
++
++#: ../gtk/details.c:2181
++#, c-format
++msgid "Asking for more peers in %s"
++msgstr "A pedir mais pares em %s"
++
++#: ../gtk/details.c:2186
++msgid "Queued to ask for more peers"
++msgstr "Na fila para pedir por mais pares"
++
++#: ../gtk/details.c:2192
++#, c-format
++msgid "Asking for more peers now… <small>%s</small>"
++msgstr "A pedir agora por mais pares… <small>%s</small>"
++
++#: ../gtk/details.c:2205
++#, c-format
++msgid "Tracker had %s%'d seeders and %'d leechers%s %s ago"
++msgstr "O rastreador teve %s%'d semeadores e %'d sanguesugas%s %s atrás"
++
++#: ../gtk/details.c:2210
++#, c-format
++msgid "Got a scrape error \"%s%s%s\" %s ago"
++msgstr "Obtido um erro scrape \"%s%s%s\" %s atrás"
++
++#: ../gtk/details.c:2223
++#, c-format
++msgid "Asking for peer counts in %s"
++msgstr "A pedir a contagem de pares em %s"
++
++#: ../gtk/details.c:2228
++msgid "Queued to ask for peer counts"
++msgstr "Na fila para pedir a contagem de pares"
++
++#: ../gtk/details.c:2234
++#, c-format
++msgid "Asking for peer counts now… <small>%s</small>"
++msgstr "A pedir agora a contagem de pares… <small>%s</small>"
++
++#: ../gtk/details.c:2537
++msgid "List contains invalid URLs"
++msgstr "A lista contém URLs inválidos"
++
++#: ../gtk/details.c:2541 ../gtk/file-list.c:847
++msgid "Please correct the errors and try again."
++msgstr "Por favor corrija os erros e tente novamente."
++
++#: ../gtk/details.c:2603
++#, c-format
++msgid "%s - Edit Trackers"
++msgstr "%s - Editar Rastreadores"
++
++#: ../gtk/details.c:2610
++msgid "Tracker Announce URLs"
++msgstr "URLs de anúncios do rastreador"
++
++#: ../gtk/details.c:2613 ../gtk/makemeta-ui.c:493
++msgid ""
++"To add a backup URL, add it on the line after the primary URL.\n"
++"To add another primary URL, add it after a blank line."
++msgstr ""
++"Para adicionar um URL de cópia de segurança, aadicione-o à linha após o  URL principal.\n"
++"Para adicionar outro URL principal, adicione-o após uma linha vazia."
++
++#: ../gtk/details.c:2713
++#, c-format
++msgid "%s - Add Tracker"
++msgstr "%s - Adicionar Rastreador"
++
++#: ../gtk/details.c:2720
++msgid "Tracker"
++msgstr "Rastreador"
++
++#: ../gtk/details.c:2726
++msgid "_Announce URL:"
++msgstr "URL de _anúncios:"
++
++#: ../gtk/details.c:2810 ../gtk/details.c:2967
++msgid "Trackers"
++msgstr "Rastreadores"
++
++#: ../gtk/details.c:2834
++msgid "_Add"
++msgstr "_Adicionar"
++
++#: ../gtk/details.c:2845
++msgid "_Remove"
++msgstr "_Remover"
++
++#: ../gtk/details.c:2861
++msgid "Show _backup trackers"
++msgstr "Mostrar rastreadores na cópia de segurança"
++
++#: ../gtk/details.c:2959 ../gtk/msgwin.c:431
++msgid "Information"
++msgstr "Informação"
++
++#: ../gtk/details.c:2963
++msgid "Peers"
++msgstr "Pares"
++
++#: ../gtk/details.c:2972
++msgid "File listing not available for combined torrent properties"
++msgstr "Listagem de ficheiros não disponível para propriedades de torrents combinadas"
++
++#: ../gtk/details.c:2976 ../gtk/makemeta-ui.c:442
++msgid "Files"
++msgstr "Ficheiros"
++
++#: ../gtk/details.c:2980 ../gtk/tr-prefs.c:1164 ../gtk/tr-window.c:646
++msgid "Options"
++msgstr "Opções"
++
++#: ../gtk/details.c:3002
++#, c-format
++msgid "%s Properties"
++msgstr "%s Propriedades"
++
++#: ../gtk/details.c:3013
++#, c-format
++msgid "%'d Torrent Properties"
++msgstr "%'d Propriedades do Torrent"
++
++#: ../gtk/dialogs.c:100
++#, c-format
++msgid "Remove torrent?"
++msgid_plural "Remove %d torrents?"
++msgstr[0] "Remover torrent?"
++msgstr[1] "Remover %d torrents?"
++
++#: ../gtk/dialogs.c:104
++#, c-format
++msgid "Delete this torrent's downloaded files?"
++msgid_plural "Delete these %d torrents' downloaded files?"
++msgstr[0] "Eliminar este ficheiro torrent descarregado?"
++msgstr[1] "Eliminar estes %d ficheiros torrent descarregados?"
++
++#: ../gtk/dialogs.c:113
++msgid "Once removed, continuing the transfer will require the torrent file or magnet link."
++msgid_plural "Once removed, continuing the transfers will require the torrent files or magnet links."
++msgstr[0] "Após sere eliminado, para continuar o descarregamento será necessário o ficheiro torrent ou o link magnético."
++msgstr[1] "Após serem eliminados, para continuar o descarregamento serão necessários os ficheiros torrent ou os links magnéticos."
++
++#: ../gtk/dialogs.c:118
++msgid "This torrent has not finished downloading."
++msgid_plural "These torrents have not finished downloading."
++msgstr[0] "O descarregamento deste torrent ainda não terminou."
++msgstr[1] "O descarregamento destes torrents ainda não terminou."
++
++#: ../gtk/dialogs.c:123
++msgid "This torrent is connected to peers."
++msgid_plural "These torrents are connected to peers."
++msgstr[0] "Este torrent está conectado aos outros pares."
++msgstr[1] "Estes torrents estão conectados aos outros pares."
++
++#: ../gtk/dialogs.c:130
++msgid "One of these torrents is connected to peers."
++msgid_plural "Some of these torrents are connected to peers."
++msgstr[0] "Um destes torrents está conectado a outros pares."
++msgstr[1] "Alguns destes torrents estão conectados a outros pares."
++
++#: ../gtk/dialogs.c:141
++msgid "One of these torrents has not finished downloading."
++msgid_plural "Some of these torrents have not finished downloading."
++msgstr[0] "Um destes torrents ainda não terminou."
++msgstr[1] "Alguns destes torrents ainda não terminaram."
++
++#: ../gtk/file-list.c:624 ../gtk/util.c:520
++msgid "High"
++msgstr "Alta"
++
++#: ../gtk/file-list.c:628 ../gtk/util.c:521
++msgid "Normal"
++msgstr "Normal"
++
++#: ../gtk/file-list.c:632 ../gtk/util.c:522
++msgid "Low"
++msgstr "Baixa"
++
++#: ../gtk/file-list.c:845
++#, c-format
++msgid "Unable to rename file as \"%s\": %s"
++msgstr "Não foi possível alterar o nome do ficheiro para \"%s\": %s"
++
++#. add file column
++#: ../gtk/file-list.c:957 ../gtk/msgwin.c:289
++msgid "Name"
++msgstr "Nome"
++
++#. add "size" column
++#: ../gtk/file-list.c:973
++msgid "Size"
++msgstr "Tamanho"
++
++#. add "progress" column
++#: ../gtk/file-list.c:984
++msgid "Have"
++msgstr "Tenho"
++
++#. add "enabled" column
++#: ../gtk/file-list.c:997
++msgid "Download"
++msgstr "Descarregar"
++
++#. add priority column
++#: ../gtk/file-list.c:1012
++msgid "Priority"
++msgstr "Prioridade"
++
++#: ../gtk/filter.c:299 ../gtk/filter.c:583
++msgid "All"
++msgstr "Tudo"
++
++#: ../gtk/filter.c:585
++msgid "Active"
++msgstr "Ativo"
++
++#: ../gtk/filter.c:590
++msgctxt "Verb"
++msgid "Verifying"
++msgstr "A verificar"
++
++#: ../gtk/filter.c:591 ../gtk/msgwin.c:430 ../gtk/util.c:717
++msgid "Error"
++msgstr "Erro"
++
++#: ../gtk/filter.c:880
++msgid "_Show:"
++msgstr "_Mostrar:"
++
++#: ../gtk/filter.c:884
++#, c-format
++msgid "_Show %'d of:"
++msgstr "_Mostrar %'d de:"
++
++#: ../gtk/main.c:314
++#, c-format
++msgid "Error registering Transmission as a %s handler: %s"
++msgstr "Erro ao registar o Transmission como um manipulador de %s: %s"
++
++#: ../gtk/main.c:480
++#, c-format
++msgid "Got signal %d; trying to shut down cleanly. Do it again if it gets stuck."
++msgstr "Foi obtido o sinal de %d; a tentar desligar corretamente. Faça-o de novo caso fique bloqueado."
++
++#: ../gtk/main.c:616
++msgid "Where to look for configuration files"
++msgstr "Onde procurar por ficheiros de configuração"
++
++#: ../gtk/main.c:617
++msgid "Start with all torrents paused"
++msgstr "Iniciar com todos os torrents em pausa"
++
++#: ../gtk/main.c:618
++msgid "Start minimized in notification area"
++msgstr "Iniciar minimizado na área de notificações"
++
++#: ../gtk/main.c:619
++msgid "Show version number and exit"
++msgstr "Mostrar número da versão e sair"
++
++#: ../gtk/main.c:637 ../gtk/transmission-gtk.appdata.xml.in:11 ../gtk/transmission-gtk.desktop.in:3
++msgid "Transmission"
++msgstr "Transmission"
++
++#. parse the command line
++#: ../gtk/main.c:640
++msgid "[torrent files or urls]"
++msgstr "[ficheiros torrent ou urls]"
++
++#: ../gtk/main.c:647
++#, c-format
++msgid ""
++"%s\n"
++"Run '%s --help' to see a full list of available command line options.\n"
++msgstr ""
++"%s\n"
++"Execute '%s --help' para ver uma lista completa de opções de linha de comandos disponíveis.\n"
++
++#: ../gtk/main.c:746
++msgid "Transmission is a file sharing program. When you run a torrent, its data will be made available to others by means of upload. Any content you share is your sole responsibility."
++msgstr "O Transmission é um programa de partilha de ficheiros. Quando abre um torrent, os dados deste serão partilhados com outros utilizadores. Qualquer conteúdo que partilhe será de sua inteira responsabilidade."
++
++#: ../gtk/main.c:749
++msgid "I _Agree"
++msgstr "Eu _Concordo"
++
++#: ../gtk/main.c:980
++msgid "<b>Closing Connections</b>"
++msgstr "<b>A fechar ligações</b>"
++
++#: ../gtk/main.c:984
++msgid "Sending upload/download totals to tracker…"
++msgstr "A enviar o total de enviado/descarregado ao rastreador…"
++
++#: ../gtk/main.c:988
++msgid "_Quit Now"
++msgstr "_Sair Agora"
++
++#: ../gtk/main.c:1038
++msgid "Couldn't add corrupt torrent"
++msgid_plural "Couldn't add corrupt torrents"
++msgstr[0] "Não foi possível adicionar o torrent corrompido"
++msgstr[1] "Não foi possível adicionar torrents corrompidos"
++
++#: ../gtk/main.c:1044
++msgid "Couldn't add duplicate torrent"
++msgid_plural "Couldn't add duplicate torrents"
++msgstr[0] "Não foi possível adicionar o torrent duplicado"
++msgstr[1] "Não foi possível adicionar torrents duplicados"
++
++#: ../gtk/main.c:1363
++msgid "A fast and easy BitTorrent client"
++msgstr "Um cliente BitTorrent rápido e fácil de usar"
++
++#: ../gtk/main.c:1364
++msgid "Copyright (c) The Transmission Project"
++msgstr "Direitos de Autor (c) The Transmission Project"
++
++#. Translators: translate "translator-credits" as your name
++#. to have it appear in the credits in the "About"
++#. dialog
++#: ../gtk/main.c:1370
++msgid "translator-credits"
++msgstr ""
++"Gonçalo Matos (goncalomatos);\n"
++"Rui (xendez);\n"
++"StringYM;"
++
++#: ../gtk/makemeta-ui.c:70
++#, c-format
++msgid "Creating \"%s\""
++msgstr "A criar \"%s\""
++
++#: ../gtk/makemeta-ui.c:74
++#, c-format
++msgid "Created \"%s\"!"
++msgstr "Criado \"%s\"!"
++
++#: ../gtk/makemeta-ui.c:78
++#, c-format
++msgid "Error: invalid announce URL \"%s\""
++msgstr "Erro: URL de anúncio inválido \"%s\""
++
++#: ../gtk/makemeta-ui.c:82
++msgid "Cancelled"
++msgstr "Cancelado"
++
++#: ../gtk/makemeta-ui.c:86
++#, c-format
++msgid "Error reading \"%s\": %s"
++msgstr "Erro ao ler \"%s\": %s"
++
++#: ../gtk/makemeta-ui.c:90
++#, c-format
++msgid "Error writing \"%s\": %s"
++msgstr "Erro ao gravar \"%s\": %s"
++
++#. how much data we've scanned through to generate checksums
++#: ../gtk/makemeta-ui.c:113
++#, c-format
++msgid "Scanned %s"
++msgstr "%s processado"
++
++#: ../gtk/makemeta-ui.c:183 ../gtk/makemeta-ui.c:434
++msgid "New Torrent"
++msgstr "Novo Torrent"
++
++#: ../gtk/makemeta-ui.c:194
++msgid "Creating torrent…"
++msgstr "A criar o torrent…"
++
++#: ../gtk/makemeta-ui.c:304
++msgid "No source selected"
++msgstr "Nenhuma fonte selecionada"
++
++#: ../gtk/makemeta-ui.c:310
++#, c-format
++msgid "%1$s; %2$'d File"
++msgid_plural "%1$s; %2$'d Files"
++msgstr[0] "%1$s; %2$'d Ficheiro"
++msgstr[1] "%1$s; %2$'d Ficheiros"
++
++#: ../gtk/makemeta-ui.c:315
++#, c-format
++msgid "%1$'d Piece @ %2$s"
++msgid_plural "%1$'d Pieces @ %2$s"
++msgstr[0] "%1$'d Peça @ %2$s"
++msgstr[1] "%1$'d Peças @ %2$s"
++
++#: ../gtk/makemeta-ui.c:444
++msgid "Sa_ve to:"
++msgstr "Gra_var para:"
++
++#: ../gtk/makemeta-ui.c:450
++msgid "Source F_older:"
++msgstr "Pasta da f_onte:"
++
++#: ../gtk/makemeta-ui.c:462
++msgid "Source _File:"
++msgstr "_Ficheiro da fonte:"
++
++#: ../gtk/makemeta-ui.c:474
++msgid "<i>No source selected</i>"
++msgstr "<i>Nenhuma fonte selecionada</i>"
++
++#: ../gtk/makemeta-ui.c:478
++msgid "Properties"
++msgstr "Propriedades"
++
++#: ../gtk/makemeta-ui.c:480
++msgid "_Trackers:"
++msgstr "_Rastreadores:"
++
++#: ../gtk/makemeta-ui.c:500
++msgid "Co_mment:"
++msgstr "Co_mentário:"
++
++#: ../gtk/makemeta-ui.c:509
++msgid "_Private torrent"
++msgstr "Torrent _privado"
++
++#: ../gtk/msgwin.c:146
++#, c-format
++msgid "Couldn't save \"%s\""
++msgstr "Não foi possível gravar \"%s\""
++
++#: ../gtk/msgwin.c:209
++msgid "Save Log"
++msgstr "Gravar registo"
++
++#: ../gtk/msgwin.c:284
++msgid "Time"
++msgstr "Hora"
++
++#: ../gtk/msgwin.c:294
++msgid "Message"
++msgstr "Mensagem"
++
++#: ../gtk/msgwin.c:432
++msgid "Debug"
++msgstr "Depuração de erros"
++
++#: ../gtk/msgwin.c:457
++msgid "Message Log"
++msgstr "Registo de mensagens"
++
++#: ../gtk/msgwin.c:491
++msgid "Level"
++msgstr "Nível"
++
++#: ../gtk/notify.c:207
++msgid "Open File"
++msgstr "Abrir ficheiro"
++
++#: ../gtk/notify.c:212
++msgid "Open Folder"
++msgstr "Abrir pasta"
++
++#: ../gtk/notify.c:217
++msgid "Torrent Complete"
++msgstr "Torrent terminado"
++
++#: ../gtk/notify.c:233
++msgid "Torrent Added"
++msgstr "Torrent adicionado"
++
++#: ../gtk/open-dialog.c:256
++msgid "Torrent files"
++msgstr "Ficheiros de torrents"
++
++#: ../gtk/open-dialog.c:261
++msgid "All files"
++msgstr "Todos os ficheiros"
++
++#. make the dialog
++#: ../gtk/open-dialog.c:284
++msgid "Torrent Options"
++msgstr "Opções de torrents"
++
++#: ../gtk/open-dialog.c:301 ../gtk/tr-prefs.c:275
++msgid "Mo_ve .torrent file to the trash"
++msgstr "Mo_ver o ficheiro .torrent para o lixo"
++
++#: ../gtk/open-dialog.c:303
++msgid "_Start when added"
++msgstr "_Começar logo ao adicionar"
++
++#. "torrent file" row
++#: ../gtk/open-dialog.c:318
++msgid "_Torrent file:"
++msgstr "Ficheiro _torrent:"
++
++#: ../gtk/open-dialog.c:321
++msgid "Select Source File"
++msgstr "Selecionar ficheiro da fonte"
++
++#: ../gtk/open-dialog.c:331
++msgid "_Destination folder:"
++msgstr "Pasta de _destino:"
++
++#: ../gtk/open-dialog.c:334
++msgid "Select Destination Folder"
++msgstr "Selecione a pasta de destino"
++
++#: ../gtk/open-dialog.c:455
++msgid "Open a Torrent"
++msgstr "Abrir um torrent"
++
++#: ../gtk/open-dialog.c:466
++msgid "Show _options dialog"
++msgstr "Mostrar janela de _opções"
++
++#: ../gtk/open-dialog.c:518
++msgid "Open URL"
++msgstr "Abrir URL"
++
++#: ../gtk/open-dialog.c:524
++msgid "Open torrent from URL"
++msgstr "Abrir um torrent por URL"
++
++#: ../gtk/open-dialog.c:529
++msgid "_URL"
++msgstr "_URL"
++
++#: ../gtk/relocate.c:60
++#, c-format
++msgid "Moving \"%s\""
++msgstr "A mover \"1%s\""
++
++#: ../gtk/relocate.c:76
++msgid "Couldn't move torrent"
++msgstr "Não foi possível mover o torrent"
++
++#: ../gtk/relocate.c:111
++msgid "This may take a moment…"
++msgstr "Isto pode demorar um pouco…"
++
++#: ../gtk/relocate.c:139 ../gtk/relocate.c:153
++msgid "Set Torrent Location"
++msgstr "Definir a localização do torrent"
++
++#: ../gtk/relocate.c:146
++msgid "Location"
++msgstr "Localização"
++
++#: ../gtk/relocate.c:156
++msgid "Torrent _location:"
++msgstr "_Localização do torrent:"
++
++#: ../gtk/relocate.c:157
++msgid "_Move from the current folder"
++msgstr "_Mover da pasta atual"
++
++#: ../gtk/relocate.c:160
++msgid "Local data is _already there"
++msgstr "Os d_ados locais já estão lá"
++
++#: ../gtk/stats.c:69 ../gtk/stats.c:150
++#, c-format
++msgid "Started %'d time"
++msgid_plural "Started %'d times"
++msgstr[0] "Iniciado %'d vez"
++msgstr[1] "Iniciado %'d vezess"
++
++#: ../gtk/stats.c:91
++msgid "Reset your statistics?"
++msgstr "Limpar as suas estatísticas?"
++
++#: ../gtk/stats.c:92
++msgid "These statistics are for your information only. Resetting them doesn't affect the statistics logged by your BitTorrent trackers."
++msgstr "Estas estatísticas existem apenas para informação. Se as limpar isso não afetará as estatísticas registadas pelos rastreadores BitTorrent."
++
++#: ../gtk/stats.c:96 ../gtk/stats.c:123
++msgid "_Reset"
++msgstr "_Limpar"
++
++#: ../gtk/stats.c:123 ../gtk/tr-window.c:687
++msgid "Statistics"
++msgstr "Estatísticas"
++
++#: ../gtk/stats.c:129
++msgid "Current Session"
++msgstr "Sessão Atual"
++
++#: ../gtk/stats.c:141 ../gtk/stats.c:166
++msgid "Ratio:"
++msgstr "Rácio:"
++
++#: ../gtk/stats.c:145 ../gtk/stats.c:170
++msgid "Duration:"
++msgstr "Duração:"
++
++#: ../gtk/stats.c:149
++msgid "Total"
++msgstr "Total"
++
++#. %1$s is how much we've got,
++#. %2$s is how much we'll have when done,
++#. %3$s%% is a percentage of the two
++#: ../gtk/torrent-cell-renderer.c:59
++#, c-format
++msgid "%1$s of %2$s (%3$s%%)"
++msgstr "%1$s de %2$s (%3$s%%)"
++
++#. %1$s is how much we've got,
++#. %2$s is the torrent's total size,
++#. %3$s%% is a percentage of the two,
++#. %4$s is how much we've uploaded,
++#. %5$s is our upload-to-download ratio,
++#. %6$s is the ratio we want to reach before we stop uploading
++#: ../gtk/torrent-cell-renderer.c:75
++#, c-format
++msgid "%1$s of %2$s (%3$s%%), uploaded %4$s (Ratio: %5$s Goal: %6$s)"
++msgstr "%1$s de %2$s (%3$s%%), enviado %4$s (Rácio: %5$s Objetivo: %6$s)"
++
++#. %1$s is how much we've got,
++#. %2$s is the torrent's total size,
++#. %3$s%% is a percentage of the two,
++#. %4$s is how much we've uploaded,
++#. %5$s is our upload-to-download ratio
++#: ../gtk/torrent-cell-renderer.c:91
++#, c-format
++msgid "%1$s of %2$s (%3$s%%), uploaded %4$s (Ratio: %5$s)"
++msgstr "%1$s de %2$s (%3$s%%), enviado %4$s (Rácio: %5$s)"
++
++#. %1$s is the torrent's total size,
++#. %2$s is how much we've uploaded,
++#. %3$s is our upload-to-download ratio,
++#. %4$s is the ratio we want to reach before we stop uploading
++#: ../gtk/torrent-cell-renderer.c:108
++#, c-format
++msgid "%1$s, uploaded %2$s (Ratio: %3$s Goal: %4$s)"
++msgstr "%1$s, enviado %2$s (Rácio: %3$s Objetivo: %4$s)"
++
++#. %1$s is the torrent's total size,
++#. %2$s is how much we've uploaded,
++#. %3$s is our upload-to-download ratio
++#: ../gtk/torrent-cell-renderer.c:120
++#, c-format
++msgid "%1$s, uploaded %2$s (Ratio: %3$s)"
++msgstr "%1$s, enviado %2$s (Rácio: %3$s)"
++
++#: ../gtk/torrent-cell-renderer.c:135
++msgid "Remaining time unknown"
++msgstr "Tempo restante desconhecido"
++
++#. time remaining
++#: ../gtk/torrent-cell-renderer.c:142
++#, c-format
++msgid "%s remaining"
++msgstr "%s restante"
++
++#. down speed, down symbol, up speed, up symbol
++#: ../gtk/torrent-cell-renderer.c:162
++#, c-format
++msgid "%1$s %2$s  %3$s %4$s"
++msgstr "%1$s %2$s  %3$s %4$s"
++
++#. up speed, up symbol
++#: ../gtk/torrent-cell-renderer.c:171
++#, c-format
++msgid "%1$s  %2$s"
++msgstr "%1$s  %2$s"
++
++#: ../gtk/torrent-cell-renderer.c:175
++msgid "Stalled"
++msgstr "Paralisado"
++
++#: ../gtk/torrent-cell-renderer.c:207
++#, c-format
++msgid "Verifying local data (%.1f%% tested)"
++msgstr "A verificar dados locais (%.1f%% testados)"
++
++#: ../gtk/torrent-cell-renderer.c:236
++#, c-format
++msgid "Tracker gave a warning: \"%s\""
++msgstr "O rastreador forneceu um aviso: \"%s\""
++
++#: ../gtk/torrent-cell-renderer.c:237
++#, c-format
++msgid "Tracker gave an error: \"%s\""
++msgstr "O rastreador forneceu um erro: \"%s\""
++
++#: ../gtk/torrent-cell-renderer.c:238
++#, c-format
++msgid "Error: %s"
++msgstr "Erro: %s"
++
++#. Downloading metadata from 2 peer (s)(50% done)
++#: ../gtk/torrent-cell-renderer.c:262
++#, c-format
++msgid "Downloading metadata from %1$'d %2$s (%3$d%% done)"
++msgstr "A descarregar metadados de %1$'d %2$s (%3$d%% feito)"
++
++#: ../gtk/torrent-cell-renderer.c:263 ../gtk/torrent-cell-renderer.c:269 ../gtk/torrent-cell-renderer.c:282
++msgid "peer"
++msgid_plural "peers"
++msgstr[0] "par"
++msgstr[1] "pares"
++
++#. Downloading from 2 of 3 peer (s) and 2 webseed (s)
++#: ../gtk/torrent-cell-renderer.c:268
++#, c-format
++msgid "Downloading from %1$'d of %2$'d %3$s and %4$'d %5$s"
++msgstr "A descarregar de %1$'d de %2$'d %3$s e %4$'d %5$s"
++
++#: ../gtk/torrent-cell-renderer.c:270 ../gtk/torrent-cell-renderer.c:276
++msgid "web seed"
++msgid_plural "web seeds"
++msgstr[0] "semear da web"
++msgstr[1] "semeares da web"
++
++#. Downloading from 3 web seed (s)
++#: ../gtk/torrent-cell-renderer.c:275
++#, c-format
++msgid "Downloading from %1$'d %2$s"
++msgstr "A descarregar de %1$'d %2$s"
++
++#. Downloading from 2 of 3 peer (s)
++#: ../gtk/torrent-cell-renderer.c:281
++#, c-format
++msgid "Downloading from %1$'d of %2$'d %3$s"
++msgstr "A descarregar de %1$'d de %2$'d %3$s"
++
++#: ../gtk/torrent-cell-renderer.c:289
++#, c-format
++msgid "Seeding to %1$'d of %2$'d connected peer"
++msgid_plural "Seeding to %1$'d of %2$'d connected peers"
++msgstr[0] "A semear para %1$'d de %2$'d par conectado"
++msgstr[1] "A semear para %1$'d de %2$'d pares conectados"
++
++#: ../gtk/tr-core.c:1241
++#, c-format
++msgid "Couldn't read \"%s\": %s"
++msgstr "Não foi possível ler \"%s\": %s"
++
++#: ../gtk/tr-core.c:1337
++#, c-format
++msgid "Skipping unknown torrent \"%s\""
++msgstr "A ignorar o torrent desconhecido \"%s\""
++
++#: ../gtk/tr-core.c:1612
++msgid "Inhibiting desktop hibernation"
++msgstr "Impedir a hibernação"
++
++#: ../gtk/tr-core.c:1616
++#, c-format
++msgid "Couldn't inhibit desktop hibernation: %s"
++msgstr "Não foi possível impedir a hibernação: %s"
++
++#: ../gtk/tr-core.c:1649
++msgid "Allowing desktop hibernation"
++msgstr "Permitir hibernação"
++
++#: ../gtk/tr-icon.c:57
++msgid "Idle"
++msgstr "Inativo"
++
++#: ../gtk/tr-icon.c:80 ../gtk/tr-icon.c:102
++#, c-format
++msgid " (Limit: %s)"
++msgstr " (Limite: %s)"
++
++#. %1$s: current upload speed
++#. * %2$s: current upload limit, if any
++#. * %3$s: current download speed
++#. * %4$s: current download limit, if any
++#: ../gtk/tr-icon.c:109
++#, c-format
++msgid ""
++"Transmission\n"
++"Up: %1$s %2$s\n"
++"Down: %3$s %4$s"
++msgstr ""
++"Transmission\n"
++"Env: %1$s %2$s\n"
++"Rec: %3$s %4$s"
++
++#: ../gtk/tr-prefs.c:258
++msgctxt "Gerund"
++msgid "Adding"
++msgstr "A adicionar"
++
++#: ../gtk/tr-prefs.c:260
++msgid "Automatically add .torrent files _from:"
++msgstr "Adicionar automaticamente ficheiros .torrent _de:"
++
++#: ../gtk/tr-prefs.c:267
++msgid "Show the Torrent Options _dialog"
++msgstr "Mostrar a _janela de opções do torrent"
++
++#: ../gtk/tr-prefs.c:271
++msgid "_Start added torrents"
++msgstr "_Iniciar torrents adicionados"
++
++#: ../gtk/tr-prefs.c:280
++msgid "Save to _Location:"
++msgstr "Gravar na _localização:"
++
++#: ../gtk/tr-prefs.c:287
++msgid "Download Queue"
++msgstr "Fila de descarregamento"
++
++#: ../gtk/tr-prefs.c:289
++msgid "Ma_ximum active downloads:"
++msgstr "Número má_ximo de descarregamentos:"
++
++#: ../gtk/tr-prefs.c:293
++msgid "Downloads sharing data in the last _N minutes are active:"
++msgstr "Descarregamentos a partilharem dados nos últimos _X minutos estão ativos:"
++
++#: ../gtk/tr-prefs.c:298 ../libtransmission/torrent.c:2170
++msgid "Incomplete"
++msgstr "Imcompleto"
++
++#: ../gtk/tr-prefs.c:300
++msgid "Append \"._part\" to incomplete files' names"
++msgstr "Anexar \"._part\" ao nome dos ficheiros incompletos"
++
++#: ../gtk/tr-prefs.c:304
++msgid "Keep _incomplete torrents in:"
++msgstr "Manter os torrents incompletos em:"
++
++#: ../gtk/tr-prefs.c:311
++msgid "Call scrip_t when torrent is completed:"
++msgstr "Executar scrip_t quando um torrent terminar:"
++
++#: ../gtk/tr-prefs.c:334
++msgid "Limits"
++msgstr "Limites"
++
++#: ../gtk/tr-prefs.c:336
++msgid "Stop seeding at _ratio:"
++msgstr "Parar de semear no _rácio:"
++
++#: ../gtk/tr-prefs.c:343
++msgid "Stop seeding if idle for _N minutes:"
++msgstr "Parar de semear se estiver inativo por _X minutos:"
++
++#: ../gtk/tr-prefs.c:365 ../gtk/tr-prefs.c:1258
++msgid "Desktop"
++msgstr "Secretária"
++
++#: ../gtk/tr-prefs.c:367
++msgid "_Inhibit hibernation when torrents are active"
++msgstr "_Impedir a hibernação quando os torrents estão ativos"
++
++#: ../gtk/tr-prefs.c:371
++msgid "Show Transmission icon in the _notification area"
++msgstr "Mostrar o ícone do Transmission na área de notificações"
++
++#: ../gtk/tr-prefs.c:376
++msgid "Notification"
++msgstr "Notificação"
++
++#: ../gtk/tr-prefs.c:378
++msgid "Show a notification when torrents are a_dded"
++msgstr "Mostrar uma notificação quando são a_dicionados torrents"
++
++#: ../gtk/tr-prefs.c:382
++msgid "Show a notification when torrents _finish"
++msgstr "Mostrar uma notificação quando os torrents terminam"
++
++#: ../gtk/tr-prefs.c:386
++msgid "Play a _sound when torrents finish"
++msgstr "Reproduzir um _som quando os torrents terminam"
++
++#: ../gtk/tr-prefs.c:412
++#, c-format
++msgid "Blocklist contains %'d rule"
++msgid_plural "Blocklist contains %'d rules"
++msgstr[0] "A lista de bloqueios contém %'d regra"
++msgstr[1] "A lista de bloqueios contém %'d regras"
++
++#: ../gtk/tr-prefs.c:446
++#, c-format
++msgid "Blocklist has %'d rule."
++msgid_plural "Blocklist has %'d rules."
++msgstr[0] "A lista de bloqueios tem %'d regra."
++msgstr[1] "A lista de bloqueios tem %'d regras."
++
++#: ../gtk/tr-prefs.c:450
++msgid "<b>Unable to update.</b>"
++msgstr "<b>Não foi possível atualizar.</b>"
++
++#: ../gtk/tr-prefs.c:450
++msgid "<b>Update succeeded!</b>"
++msgstr "<b>Atualização bem sucedida!</b>"
++
++#: ../gtk/tr-prefs.c:461
++msgid "Update Blocklist"
++msgstr "Atualizar Lista de Bloqueios"
++
++#: ../gtk/tr-prefs.c:463
++msgid "Getting new blocklist…"
++msgstr "A obter a nova lista de bloqueios…"
++
++#: ../gtk/tr-prefs.c:488
++msgid "Allow encryption"
++msgstr "Permitir encriptação"
++
++#: ../gtk/tr-prefs.c:488
++msgid "Prefer encryption"
++msgstr "Preferir encriptação"
++
++#: ../gtk/tr-prefs.c:489
++msgid "Require encryption"
++msgstr "Usar apenas encriptação"
++
++#: ../gtk/tr-prefs.c:511 ../gtk/tr-prefs.c:1256
++msgid "Privacy"
++msgstr "Privacidade"
++
++#: ../gtk/tr-prefs.c:513
++msgid "_Encryption mode:"
++msgstr "Modo de _Encriptação:"
++
++#: ../gtk/tr-prefs.c:518
++msgid "Blocklist"
++msgstr "Lista de bloqueio"
++
++#: ../gtk/tr-prefs.c:520
++msgid "Enable _blocklist:"
++msgstr "Ativar lista de _bloqueio"
++
++#: ../gtk/tr-prefs.c:534
++msgid "_Update"
++msgstr "_Atualizar"
++
++#: ../gtk/tr-prefs.c:546
++msgid "Enable _automatic updates"
++msgstr "Ativar _atualizações automáticas"
++
++#: ../gtk/tr-prefs.c:747
++msgid "Remote Control"
++msgstr "Controlo Remoto"
++
++#. "enabled" checkbutton
++#: ../gtk/tr-prefs.c:750
++msgid "Allow _remote access"
++msgstr "Permitir acesso _remoto"
++
++#: ../gtk/tr-prefs.c:756
++msgid "_Open web client"
++msgstr "_Abrir cliente web"
++
++#: ../gtk/tr-prefs.c:765
++msgid "HTTP _port:"
++msgstr "_Porta HTTP:"
++
++#. require authentication
++#: ../gtk/tr-prefs.c:769
++msgid "Use _authentication"
++msgstr "Usar _autenticação"
++
++#. username
++#: ../gtk/tr-prefs.c:777
++msgid "_Username:"
++msgstr "_Nome de utilizador:"
++
++#. password
++#: ../gtk/tr-prefs.c:784
++msgid "Pass_word:"
++msgstr "Palavra-passe:"
++
++#. require authentication
++#: ../gtk/tr-prefs.c:792
++msgid "Only allow these IP a_ddresses:"
++msgstr "Permitir apenas estes en_dereços IP:"
++
++#: ../gtk/tr-prefs.c:816
++msgid "IP addresses may use wildcards, such as 192.168.*.*"
++msgstr "Os endereços IP podem ter caracteres-curinga, como por ex: 192.168.*.*"
++
++#: ../gtk/tr-prefs.c:835
++msgid "Addresses:"
++msgstr "Endereços:"
++
++#: ../gtk/tr-prefs.c:935
++msgid "Every Day"
++msgstr "Todos os dias"
++
++#: ../gtk/tr-prefs.c:936
++msgid "Weekdays"
++msgstr "Dias da semana"
++
++#: ../gtk/tr-prefs.c:937
++msgid "Weekends"
++msgstr "Fins de semana"
++
++#: ../gtk/tr-prefs.c:938
++msgid "Sunday"
++msgstr "Domingo"
++
++#: ../gtk/tr-prefs.c:939
++msgid "Monday"
++msgstr "Segunda-Feira"
++
++#: ../gtk/tr-prefs.c:940
++msgid "Tuesday"
++msgstr "Terça-Feira"
++
++#: ../gtk/tr-prefs.c:941
++msgid "Wednesday"
++msgstr "Quarta-Feira"
++
++#: ../gtk/tr-prefs.c:942
++msgid "Thursday"
++msgstr "Quinta-Feira"
++
++#: ../gtk/tr-prefs.c:943
++msgid "Friday"
++msgstr "Sexta-Feira"
++
++#: ../gtk/tr-prefs.c:944
++msgid "Saturday"
++msgstr "Sábado"
++
++#: ../gtk/tr-prefs.c:975
++msgid "Speed Limits"
++msgstr "Limites de Velocidade"
++
++#: ../gtk/tr-prefs.c:977
++#, c-format
++msgid "_Upload (%s):"
++msgstr "_Enviar (%s):"
++
++#: ../gtk/tr-prefs.c:984
++#, c-format
++msgid "_Download (%s):"
++msgstr "_Descarregar (%s):"
++
++#: ../gtk/tr-prefs.c:993
++msgid "Alternative Speed Limits"
++msgstr "Limites de velocidade alternativos"
++
++#: ../gtk/tr-prefs.c:1002
++msgid "Override normal speed limits manually or at scheduled times"
++msgstr "Ignorar limites de velocidade normal manualmente ou em horas programadas"
++
++#: ../gtk/tr-prefs.c:1009
++#, c-format
++msgid "U_pload (%s):"
++msgstr "_Enviar (%s):"
++
++#: ../gtk/tr-prefs.c:1013
++#, c-format
++msgid "Do_wnload (%s):"
++msgstr "_Descarregar (%s):"
++
++#: ../gtk/tr-prefs.c:1017
++msgid "_Scheduled times:"
++msgstr "_Horas programadas:"
++
++#: ../gtk/tr-prefs.c:1022
++msgid " _to "
++msgstr "_a"
++
++#: ../gtk/tr-prefs.c:1033
++msgid "_On days:"
++msgstr "_nos dias:"
++
++#: ../gtk/tr-prefs.c:1064 ../gtk/tr-prefs.c:1137 ../gtk/tr-prefs.c:1219
++msgid "Status unknown"
++msgstr "Estado desconhecido"
++
++#: ../gtk/tr-prefs.c:1090
++msgid "Port is <b>closed</b>"
++msgstr "A porta está <b>fechada</b>"
++
++#: ../gtk/tr-prefs.c:1090
++msgid "Port is <b>open</b>"
++msgstr "A porta está <b>aberta</b>"
++
++#: ../gtk/tr-prefs.c:1104
++msgid "<i>Testing TCP port…</i>"
++msgstr "<i>A testar a porta TCP…</i>"
++
++#: ../gtk/tr-prefs.c:1130
++msgid "Listening Port"
++msgstr "Porta de escuta"
++
++#: ../gtk/tr-prefs.c:1132
++msgid "_Port used for incoming connections:"
++msgstr "_Porta utilizada para entrada de ligações:"
++
++#: ../gtk/tr-prefs.c:1140
++msgid "Te_st Port"
++msgstr "Te_star Porta"
++
++#: ../gtk/tr-prefs.c:1147
++msgid "Pick a _random port every time Transmission is started"
++msgstr "Escolher uma porta _aleatória sempre que o Transmission for iniciado"
++
++#: ../gtk/tr-prefs.c:1151
++msgid "Use UPnP or NAT-PMP port _forwarding from my router"
++msgstr "Usar redirecionamento de portas UPnP ou NAT-PMP no meu router"
++
++#: ../gtk/tr-prefs.c:1156
++msgid "Peer Limits"
++msgstr "Limites de pares"
++
++#: ../gtk/tr-prefs.c:1159
++msgid "Maximum peers per _torrent:"
++msgstr "Máximo de pares por _torrent:"
++
++#: ../gtk/tr-prefs.c:1161
++msgid "Maximum peers _overall:"
++msgstr "Máximo _total de pares:"
++
++#: ../gtk/tr-prefs.c:1167
++msgid "Enable _uTP for peer communication"
++msgstr "Ativar _uTP para comunicação de pares"
++
++#: ../gtk/tr-prefs.c:1169
++msgid "uTP is a tool for reducing network congestion."
++msgstr "O uTP é uma ferramenta para reduzir o congestionamento na rede."
++
++#: ../gtk/tr-prefs.c:1174
++msgid "Use PE_X to find more peers"
++msgstr "Usar PE_X para encontrar mais pares"
++
++#: ../gtk/tr-prefs.c:1176
++msgid "PEX is a tool for exchanging peer lists with the peers you're connected to."
++msgstr "O PEX é uma ferramenta para trocar listas de pares com os pares aos quais está conectado."
++
++#: ../gtk/tr-prefs.c:1180
++msgid "Use _DHT to find more peers"
++msgstr "Usar o _DHT para encontrar mais pares"
++
++#: ../gtk/tr-prefs.c:1182
++msgid "DHT is a tool for finding peers without a tracker."
++msgstr "O DHT é uma ferramenta para encontrar pares sem um rastreador (tracker)."
++
++#: ../gtk/tr-prefs.c:1186
++msgid "Use _Local Peer Discovery to find more peers"
++msgstr "Usar _LPD para descobrir mais pares"
++
++#: ../gtk/tr-prefs.c:1188
++msgid "LPD is a tool for finding peers on your local network."
++msgstr "O LPD (descoberta local de pares) é uma ferramenta para encontrar pares na sua rede local."
++
++#: ../gtk/tr-prefs.c:1244
++msgid "Transmission Preferences"
++msgstr "Preferências do Transmission"
++
++#: ../gtk/tr-prefs.c:1254
++msgctxt "Gerund"
++msgid "Downloading"
++msgstr "Descarregar"
++
++#: ../gtk/tr-prefs.c:1255
++msgctxt "Gerund"
++msgid "Seeding"
++msgstr "Semear"
++
++#: ../gtk/tr-prefs.c:1257
++msgid "Network"
++msgstr "Rede"
++
++#: ../gtk/tr-prefs.c:1259
++msgid "Remote"
++msgstr "Remoto"
++
++#: ../gtk/tr-window.c:127
++msgid "Torrent"
++msgstr "Torrent"
++
++#: ../gtk/tr-window.c:227
++msgid "Total Ratio"
++msgstr "Rácio Total"
++
++#: ../gtk/tr-window.c:228
++msgid "Session Ratio"
++msgstr "Rácio da Sessão"
++
++#: ../gtk/tr-window.c:229
++msgid "Total Transfer"
++msgstr "Transferência Total"
++
++#: ../gtk/tr-window.c:230
++msgid "Session Transfer"
++msgstr "Transferência na Sessão"
++
++#: ../gtk/tr-window.c:255
++#, c-format
++msgid ""
++"Click to disable Alternative Speed Limits\n"
++" (%1$s down, %2$s up)"
++msgstr ""
++"Clique para desativar os limites de velocidade alternativos\n"
++" (%1$s rec, %2$s env)"
++
++#: ../gtk/tr-window.c:256
++#, c-format
++msgid ""
++"Click to enable Alternative Speed Limits\n"
++" (%1$s down, %2$s up)"
++msgstr ""
++"Clique para ativar os limites de velocidade alternativos\n"
++" (%1$s rec, %2$s env)"
++
++#: ../gtk/tr-window.c:310
++#, c-format
++msgid "Tracker will allow requests in %s"
++msgstr "O rastreador irá permitir pedidos dentro de %s"
++
++#: ../gtk/tr-window.c:380
++msgid "Unlimited"
++msgstr "Ilimitado"
++
++#: ../gtk/tr-window.c:451
++msgid "Seed Forever"
++msgstr "Semear para sempre"
++
++#: ../gtk/tr-window.c:489
++msgid "Limit Download Speed"
++msgstr "Limitar velocidade de descarregamento"
++
++#: ../gtk/tr-window.c:493
++msgid "Limit Upload Speed"
++msgstr "Limitar velocidade de envio"
++
++#: ../gtk/tr-window.c:500
++msgid "Stop Seeding at Ratio"
++msgstr "Parar de semear no rácio"
++
++#: ../gtk/tr-window.c:533
++#, c-format
++msgid "Stop at Ratio (%s)"
++msgstr "Parar no rácio (%s)"
++
++#: ../gtk/tr-window.c:761 ../gtk/tr-window.c:787
++#, c-format
++msgid "Ratio: %s"
++msgstr "Rácio: %s"
++
++#. Translators: "size|" is here for disambiguation. Please remove it from your translation.
++#. %1$s is the size of the data we've downloaded
++#. %2$s is the size of the data we've uploaded
++#: ../gtk/tr-window.c:771
++#, c-format
++msgid "Down: %1$s, Up: %2$s"
++msgstr "Receb: %1$s, Env: %2$s"
++
++#. Translators: "size|" is here for disambiguation. Please remove it from your translation.
++#. %1$s is the size of the data we've downloaded
++#. %2$s is the size of the data we've uploaded
++#: ../gtk/tr-window.c:781
++#, c-format
++msgid "size|Down: %1$s, Up: %2$s"
++msgstr "Receb: %1$s, Env: %2$s"
++
++#: ../gtk/transmission-gtk.appdata.xml.in:12 ../gtk/transmission-gtk.desktop.in:5
++msgid "Download and share files over BitTorrent"
++msgstr "Descarregar e partilhar ficheiros pelo BitTorrent"
++
++#. Translators: these are the application description paragraphs in the AppData file.
++#: ../gtk/transmission-gtk.appdata.xml.in:16
++msgid "BitTorrent is a peer-to-peer file-sharing protocol that is commonly used to distribute large amounts of data between multiple users."
++msgstr "O BitTorrent é um protocolo de partilha de ficheiros ponto-a-ponto que é comum utilizar para distribuir grandes quantidades de dados entre vários utilizadores."
++
++#: ../gtk/transmission-gtk.appdata.xml.in:20
++msgid "Transmission is a BitTorrent client with an easy-to-use frontend on top a cross-platform backend. Native frontends are available for OS X and Windows, as well as command line and web frontends."
++msgstr "O Transmission é um cliente BitTorrent com uma interface fácil de utilizar sobre um código multi-plataforma. Existem várias interfaces nativas para OS X e Windows, assim como em linha de comandos e baseado na web."
++
++#: ../gtk/transmission-gtk.appdata.xml.in:26
++msgid "Notable features of Transmission include support for Local Peer Discovery, encryption, DHT, µTP, PEX and Magnet Link."
++msgstr "O Transmission tem funcionalidaes notáveis como , descoberta de pares locais (LPD), encriptação, tabelas de hash distribuídas (DHT), protocolo de transporte micro (µTP), troca de pares (PEX) e links magnéticos."
++
++#: ../gtk/transmission-gtk.desktop.in:4
++msgid "BitTorrent Client"
++msgstr "Cliente BitTorrent"
++
++#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
++#: ../gtk/transmission-gtk.desktop.in:7
++msgid "torrents;downloading;uploading;share;sharing;"
++msgstr "torrents;descarregar;baixar;transferir;transferência;enviar;partilhar;partilha;"
++
++#: ../gtk/transmission-gtk.desktop.in:21
++msgid "Start Transmission with All Torrents Paused"
++msgstr "Iniciar o Transmission com todos os torrents em pausa"
++
++#: ../gtk/transmission-gtk.desktop.in:25
++msgid "Start Transmission Minimized"
++msgstr "Iniciar o Transmission minimizado"
++
++#: ../gtk/util.c:36
++msgid "KiB"
++msgstr "KiB"
++
++#: ../gtk/util.c:37
++msgid "MiB"
++msgstr "MiB"
++
++#: ../gtk/util.c:38
++msgid "GiB"
++msgstr "GiB"
++
++#: ../gtk/util.c:39
++msgid "TiB"
++msgstr "TiB"
++
++#: ../gtk/util.c:42
++msgid "kB"
++msgstr "kB"
++
++#: ../gtk/util.c:43
++msgid "MB"
++msgstr "MB"
++
++#: ../gtk/util.c:44
++msgid "GB"
++msgstr "GB"
++
++#: ../gtk/util.c:45
++msgid "TB"
++msgstr "TB"
++
++#: ../gtk/util.c:48
++msgid "kB/s"
++msgstr "kB/s"
++
++#: ../gtk/util.c:49
++msgid "MB/s"
++msgstr "MB/s"
++
++#: ../gtk/util.c:50
++msgid "GB/s"
++msgstr "GB/s"
++
++#: ../gtk/util.c:51
++msgid "TB/s"
++msgstr "TB/s"
++
++#: ../gtk/util.c:122
++#, c-format
++msgid "%'d day"
++msgid_plural "%'d days"
++msgstr[0] "%'d dia"
++msgstr[1] "%'d dias"
++
++#: ../gtk/util.c:123
++#, c-format
++msgid "%'d hour"
++msgid_plural "%'d hours"
++msgstr[0] "%'d hora"
++msgstr[1] "%'d horas"
++
++#: ../gtk/util.c:124
++#, c-format
++msgid "%'d minute"
++msgid_plural "%'d minutes"
++msgstr[0] "%'d minuto"
++msgstr[1] "%'d minutos"
++
++#: ../gtk/util.c:125
++#, c-format
++msgid "%'d second"
++msgid_plural "%'d seconds"
++msgstr[0] "%'d segundo"
++msgstr[1] "%'d segundos"
++
++#: ../gtk/util.c:258
++#, c-format
++msgid "The torrent file \"%s\" contains invalid data."
++msgstr "O ficheiro torrent \"%s\" contém dados inválidos."
++
++#: ../gtk/util.c:262
++#, c-format
++msgid "The torrent file \"%s\" is already in use by \"%s.\""
++msgstr "O ficheiro torrent \"%s\" está a ser utilizador pelo \"%s.\""
++
++#: ../gtk/util.c:267
++#, c-format
++msgid "The torrent file \"%s\" encountered an unknown error."
++msgstr "O ficheiro torrent \"%s\" encontrou um erro desconhecido."
++
++#: ../gtk/util.c:271
++msgid "Error opening torrent"
++msgstr "Erro ao abrir o torrent"
++
++#: ../gtk/util.c:594
++msgid "Unrecognized URL"
++msgstr "URL irreconhecido"
++
++#: ../gtk/util.c:596
++#, c-format
++msgid "Transmission doesn't know how to use \"%s\""
++msgstr "O Transmission não sabe como utilizar \"%s\""
++
++#: ../gtk/util.c:601
++#, c-format
++msgid "This magnet link appears to be intended for something other than BitTorrent. BitTorrent magnet links have a section containing \"%s\"."
++msgstr "Este link magnético parece ser para outra coisa que não o BitTorrent. Os links magnéticos BitTorrent têm uma secção com \"%s\"."
++
++#: ../gtk/util.c:723
++#, c-format
++msgid "%s free"
++msgstr "%s livre"
++
++#: ../libtransmission/announcer-http.c:221 ../libtransmission/announcer-http.c:389
++#, c-format
++msgid "Tracker gave HTTP response code %1$ld (%2$s)"
++msgstr "O rastreador forneceu o código HTTP de resposta %1$ld (%2$s)"
++
++#: ../libtransmission/announcer-udp.c:273 ../libtransmission/announcer-udp.c:423
++msgid "Unknown error"
++msgstr "Erro desconhecido"
++
++#: ../libtransmission/announcer-udp.c:513
++#, c-format
++msgid "DNS Lookup failed: %s"
++msgstr "Falhou a consulta de DNS: %s"
++
++#: ../libtransmission/announcer-udp.c:616
++msgid "Connection failed"
++msgstr "A ligação falhou"
++
++#: ../libtransmission/announcer.c:1150 ../libtransmission/announcer.c:1469
++msgid "Could not connect to tracker"
++msgstr "Não foi possível conectar ao rastreador"
++
++#: ../libtransmission/announcer.c:1154 ../libtransmission/announcer.c:1473
++msgid "Tracker did not respond"
++msgstr "O rastreador não respondeu"
++
++#: ../libtransmission/announcer.c:1218
++msgid "Success"
++msgstr "Sucesso"
++
++#: ../libtransmission/blocklist.c:63 ../libtransmission/blocklist.c:360 ../libtransmission/utils.c:258
++#, c-format
++msgid "Couldn't read \"%1$s\": %2$s"
++msgstr "Não foi possível ler \"%1$s\": %2$s"
++
++#: ../libtransmission/blocklist.c:103
++#, c-format
++msgid "Blocklist \"%s\" contains %zu entries"
++msgstr "A lista de bloqueios \"%s\" contém %zu entradas"
++
++#. don't try to display the actual lines - it causes issues
++#: ../libtransmission/blocklist.c:403
++#, c-format
++msgid "blocklist skipped invalid address at line %d"
++msgstr "a lista de bloqueios ignorou endereços inválidos na linha %d"
++
++#: ../libtransmission/blocklist.c:460 ../libtransmission/rpcimpl.c:1650 ../libtransmission/rpcimpl.c:1664 ../libtransmission/rpcimpl.c:1687 ../libtransmission/variant.c:1226
++#, c-format
++msgid "Couldn't save file \"%1$s\": %2$s"
++msgstr "Não foi possível gravar o ficheiro \"%1$s\": %2$s"
++
++#: ../libtransmission/blocklist.c:466
++#, c-format
++msgid "Blocklist \"%s\" updated with %zu entries"
++msgstr "A lista de bloqueios \"%s\" foi atualizada com %zu entradas"
++
++#: ../libtransmission/fdlimit.c:168
++#, c-format
++msgid "Couldn't get directory for \"%1$s\": %2$s"
++msgstr "Não foi possível obter o diretório de \"%1$s\": %2$s"
++
++#: ../libtransmission/fdlimit.c:174 ../libtransmission/file-posix.c:243
++#, c-format
++msgid "Couldn't create \"%1$s\": %2$s"
++msgstr "Não foi possível criar \"%1$s\": %2$s"
++
++#: ../libtransmission/fdlimit.c:195
++#, c-format
++msgid "Couldn't open \"%1$s\": %2$s"
++msgstr "Não foi possível abrir \"%1$s\": %2$s"
++
++#: ../libtransmission/fdlimit.c:207
++msgid "full"
++msgstr "cheio"
++
++#: ../libtransmission/fdlimit.c:212
++msgid "sparse"
++msgstr "escasso"
++
++#: ../libtransmission/fdlimit.c:219
++#, c-format
++msgid "Couldn't preallocate file \"%1$s\" (%2$s, size: %3$<PRIu64>): %4$s"
++msgstr "Não foi possível pré-alocar o ficheiro \"%1$s\" (%2$s, tamanho: %3$<PRIu64>): %4$s"
++
++#: ../libtransmission/fdlimit.c:224
++#, c-format
++msgid "Preallocated file \"%1$s\" (%2$s, size: %3$<PRIu64>)"
++msgstr "Ficheiro pré-alocado \"%1$s\" (%2$s, tamanho: %3$<PRIu64>)"
++
++#: ../libtransmission/fdlimit.c:235
++#, c-format
++msgid "Couldn't truncate \"%1$s\": %2$s"
++msgstr "Não foi possível truncar \"%1$s\": %2$s"
++
++#: ../libtransmission/fdlimit.c:553
++#, c-format
++msgid "Couldn't create socket: %s"
++msgstr "Não foi possível criar o socket: %s"
++
++#: ../libtransmission/file-posix.c:153
++#, c-format
++msgid "File \"%s\" is in the way"
++msgstr "O ficheiro \"%s\" está no caminho"
++
++#: ../libtransmission/makemeta.c:54
++#, c-format
++msgid "Torrent Creator is skipping file \"%s\": %s"
++msgstr "O criador de torrents está a ignorar o ficheiro \"%s\": %s"
++
++#: ../libtransmission/makemeta.c:209
++#, c-format
++msgid "Failed to set piece size to %s, leaving it at %s"
++msgstr "Não foi possível definir o tamanho das peças em %s, a utilizar %s"
++
++#: ../libtransmission/metainfo.c:759
++#, c-format
++msgid "Invalid metadata entry \"%s\""
++msgstr "Entrada de metadados inválidos \"%s\""
++
++#: ../libtransmission/natpmp.c:30
++msgid "Port Forwarding (NAT-PMP)"
++msgstr "Redirecionamento de portas (NAT-PMP)"
++
++#: ../libtransmission/natpmp.c:73
++#, c-format
++msgid "%s succeeded (%d)"
++msgstr "%s bem sucedido (%d)"
++
++#: ../libtransmission/natpmp.c:138
++#, c-format
++msgid "Found public address \"%s\""
++msgstr "Endereço público encontrado \"%s\""
++
++#: ../libtransmission/natpmp.c:173
++#, c-format
++msgid "no longer forwarding port %d"
++msgstr "já não está a redirecionar a porta %d"
++
++#: ../libtransmission/natpmp.c:222
++#, c-format
++msgid "Port %d forwarded successfully"
++msgstr "Porta %d redirecionada com sucesso"
++
++#: ../libtransmission/net.c:323
++#, c-format
++msgid "Couldn't set source address %s on %<PRIdMAX>: %s"
++msgstr "Não foi possível definir o endereço da fonte %s em %<PRIdMAX>: %s"
++
++#: ../libtransmission/net.c:339
++#, c-format
++msgid "Couldn't connect socket %<PRIdMAX> to %s, port %d (errno %d - %s)"
++msgstr "Não foi possível conectar o socket %<PRIdMAX> a %s, porta %d (errno %d - %s)"
++
++#: ../libtransmission/net.c:436
++msgid "Is another copy of Transmission already running?"
++msgstr "Está a ser executada outra instância do Transmission?"
++
++#: ../libtransmission/net.c:445
++#, c-format
++msgid "Couldn't bind port %d on %s: %s"
++msgstr "Não foi possível vincular a porta %d em %s: %s"
++
++#: ../libtransmission/net.c:449
++#, c-format
++msgid "Couldn't bind port %d on %s: %s (%s)"
++msgstr "Não foi possível vincular a porta %d em %s: %s (%s)"
++
++#: ../libtransmission/peer-msgs.c:2134
++#, c-format
++msgid "Please Verify Local Data! Piece #%zu is corrupt."
++msgstr "Por favor verifique os dados locais! A peça #%zu está corrompida."
++
++#: ../libtransmission/platform.c:472
++#, c-format
++msgid "Searching for web interface file \"%s\""
++msgstr "A procurar pelo ficheiro de interface web \"%s\""
++
++#: ../libtransmission/port-forwarding.c:29
++msgid "Port Forwarding"
++msgstr "Redirecionamento de portas"
++
++#: ../libtransmission/port-forwarding.c:57
++msgid "Starting"
++msgstr "A iniciar"
++
++#: ../libtransmission/port-forwarding.c:60
++msgid "Forwarded"
++msgstr "Redirecionado"
++
++#: ../libtransmission/port-forwarding.c:63
++msgid "Stopping"
++msgstr "A parar"
++
++#: ../libtransmission/port-forwarding.c:66
++msgid "Not forwarded"
++msgstr "Não redirecionado"
++
++#: ../libtransmission/port-forwarding.c:106 ../libtransmission/torrent.c:2302
++#, c-format
++msgid "State changed from \"%1$s\" to \"%2$s\""
++msgstr "Estado alterado de \"%1$s\" para \"%2$s\""
++
++#: ../libtransmission/port-forwarding.c:196
++msgid "Stopped"
++msgstr "Parado"
++
++#: ../libtransmission/rpc-server.c:1096
++#, c-format
++msgid "Couldn't find settings key \"%s\""
++msgstr "Não foi possível encontrar a chave de configurações \"%s\""
++
++#: ../libtransmission/rpc-server.c:1230
++#, c-format
++msgid "%s is not a valid address"
++msgstr "%s não é um endereço válido"
++
++#: ../libtransmission/rpc-server.c:1235
++#, c-format
++msgid "%s is not an IPv4 or IPv6 address. RPC listeners must be IPv4 or IPv6"
++msgstr "%s não é um endereço IPv4 nem IPv6. Os RPC listeners têm de ser IPv4 ou IPv6"
++
++#: ../libtransmission/rpc-server.c:1243
++#, c-format
++msgid "Serving RPC and Web requests on %s:%d%s"
++msgstr "A servir pedidos RPC e Web em %s:%d%s"
++
++#: ../libtransmission/rpc-server.c:1249
++msgid "Whitelist enabled"
++msgstr "Lista branca ativada"
++
++#: ../libtransmission/rpc-server.c:1254
++msgid "Password required"
++msgstr "Necessária palavra-passe"
++
++#: ../libtransmission/rpcimpl.c:1674
++#, c-format
++msgid "Error uncompressing blocklist: %s (%d)"
++msgstr "Erro ao descomprimir a lista de bloqueios: %s (%d)"
++
++#. first %s is the application name
++#. second %s is the version number
++#: ../libtransmission/session.c:769
++#, c-format
++msgid "%s %s started"
++msgstr "1%s 1%s iniciado"
++
++#: ../libtransmission/session.c:2170
++#, c-format
++msgid "Loaded %d torrents"
++msgstr "%d torrents carregados"
++
++#: ../libtransmission/torrent-magnet.c:310
++msgid "Magnet torrent's metadata is not usable"
++msgstr "Os metadados do torrent magnético não são utilizáveis"
++
++#: ../libtransmission/torrent.c:616
++#, c-format
++msgid "Tracker warning: \"%s\""
++msgstr "Aviso do rastreador: \"%s\""
++
++#: ../libtransmission/torrent.c:623
++#, c-format
++msgid "Tracker error: \"%s\""
++msgstr "Erro do rastreador: \"%s\""
++
++#: ../libtransmission/torrent.c:916
++msgid "No data found! Ensure your drives are connected or use \"Set Location\". To re-download, remove the torrent and re-add it."
++msgstr "Não foram encontrados dados. Certifique-se que as suas drives estão ligadas ou utiliza \"Definir Localização\". Para tornar a descarregar, remova o torrent e torne a adicioná-lo."
++
++#: ../libtransmission/torrent.c:1868
++msgid "Restarted manually -- disabling its seed ratio"
++msgstr "Reiniciado manualmente - a desativar o rácio de semear"
++
++#: ../libtransmission/torrent.c:2078
++msgid "Removing torrent"
++msgstr "A remover o torrent"
++
++#. Translators: this is a minor point that's safe to skip over, but FYI:
++#. "Complete" and "Done" are specific, different terms in Transmission:
++#. "Complete" means we've downloaded every file in the torrent.
++#. "Done" means we're done downloading the files we wanted, but NOT all
++#. that exist
++#: ../libtransmission/torrent.c:2164
++msgid "Done"
++msgstr "Feito"
++
++#: ../libtransmission/torrent.c:2167
++msgid "Complete"
++msgstr "Completo"
++
++#: ../libtransmission/torrent.c:3466
++#, c-format
++msgid "Piece %<PRIu32>, which was just downloaded, failed its checksum test"
++msgstr "A peça %<PRIu32>, que acabou de ser descarregada, falhou no teste de  soma de verificação (checksum)"
++
++#: ../libtransmission/upnp.c:29
++msgid "Port Forwarding (UPnP)"
++msgstr "Redirecionamento de portas (UPnP)"
++
++#: ../libtransmission/upnp.c:200
++#, c-format
++msgid "Found Internet Gateway Device \"%s\""
++msgstr "Foi encontrado o Internet Gateway Device \"%s\""
++
++#: ../libtransmission/upnp.c:201
++#, c-format
++msgid "Local Address is \"%s\""
++msgstr "O endereço local é \"%s\""
++
++#: ../libtransmission/upnp.c:228
++#, c-format
++msgid "Port %d isn't forwarded"
++msgstr "A porta %d não está a ser redirecionada"
++
++#: ../libtransmission/upnp.c:238
++#, c-format
++msgid "Stopping port forwarding through \"%s\", service \"%s\""
++msgstr "A parar o redirecionamento de portas por \"%s\", serviço \"%s\""
++
++#: ../libtransmission/upnp.c:275
++#, c-format
++msgid "Port forwarding through \"%s\", service \"%s\". (local address: %s:%d)"
++msgstr "A redirecionar portas por \"%s\", serviço \"%s\". (endereço local: %s:%d)"
++
++#: ../libtransmission/upnp.c:280
++msgid "Port forwarding successful!"
++msgstr "Redirecionamento de portas bem sucedido!"
++
++#: ../libtransmission/utils.c:270 ../libtransmission/utils.c:271
++msgid "Not a regular file"
++msgstr "Não é um ficheiro normal"
++
++#. did caller give us an uninitialized val?
++#: ../libtransmission/variant.c:926
++msgid "Invalid metadata"
++msgstr "metadados inválidos"
++
++#: ../libtransmission/variant.c:1211 ../libtransmission/variant.c:1235
++#, c-format
++msgid "Couldn't save temporary file \"%1$s\": %2$s"
++msgstr "Não foi possível gravar o ficheiro temporário \"%1$s\": %2$s"
++
++#: ../libtransmission/variant.c:1221
++#, c-format
++msgid "Saved \"%s\""
++msgstr "\"%s\" gravado"
++
++#: ../libtransmission/variant.c:1264
++msgid "Unable to parse file content"
++msgstr "Não foi possível processar o conteúdo do ficheiro"
++
++#: ../libtransmission/verify.c:220
++msgid "Verifying torrent"
++msgstr "A verificar o torrent"
++
++#, c-format
++#~ msgid "Server returned \"%1$ld %2$s\""
++#~ msgstr "O servidor devolveu \"%1$ld %2$s\""
++
++#, c-format
++#~ msgid "Error opening \"%s\""
++#~ msgstr "Erro ao abrir \"%s\""

--- a/srcpkgs/transmission/patches/fix-makefiles.patch
+++ b/srcpkgs/transmission/patches/fix-makefiles.patch
@@ -1,0 +1,62 @@
+From 642db5762b1f8e9d2bb8527b153b6c47d856cb9d Mon Sep 17 00:00:00 2001
+From: Mike Gelfand <mikedld@mikedld.com>
+Date: Sat, 23 May 2020 01:39:36 +0300
+Subject: [PATCH] Add missing files that fail build from tarball
+
+Fixes: #1246
+---
+ libtransmission/Makefile.am | 3 +++
+ macosx/Makefile.am          | 2 ++
+ po/LINGUAS                  | 1 +
+ third-party/Makefile.am     | 3 +++
+ 4 files changed, 9 insertions(+)
+
+diff --git a/libtransmission/Makefile.am b/libtransmission/Makefile.am
+index 0885fab0d..d9a61c12f 100644
+--- libtransmission/Makefile.am
++++ libtransmission/Makefile.am
+@@ -316,3 +316,6 @@ watchdir_generic_test_CPPFLAGS = -DWATCHDIR_TEST_FORCE_GENERIC $(AM_CPPFLAGS)
+ rename_test_SOURCES = rename-test.c $(TEST_SOURCES)
+ rename_test_LDADD = ${apps_ldadd}
+ rename_test_LDFLAGS = ${apps_ldflags}
++
++EXTRA_DIST = \
++  subprocess-test.cmd
+diff --git a/macosx/Makefile.am b/macosx/Makefile.am
+index 27abb77b6..5a6fec9ef 100644
+--- macosx/Makefile.am
++++ macosx/Makefile.am
+@@ -95,6 +95,8 @@ EXTRA_DIST = \
+     InfoTabButtonBack.m \
+     InfoTabButtonCell.h \
+     InfoTabButtonCell.m \
++    InfoTabMatrix.h \
++    InfoTabMatrix.m \
+     InfoTextField.h \
+     InfoTextField.m \
+     InfoActivityViewController.h \
+diff --git a/po/LINGUAS b/po/LINGUAS
+index 08629cd1b..6b3145a37 100644
+--- po/LINGUAS
++++ po/LINGUAS
+@@ -68,6 +68,7 @@ pa
+ pl
+ pt
+ pt_BR
++pt_PT
+ ro
+ ru
+ si
+diff --git a/third-party/Makefile.am b/third-party/Makefile.am
+index 9f66878d9..33df96d42 100644
+--- third-party/Makefile.am
++++ third-party/Makefile.am
+@@ -22,5 +22,8 @@ SUBDIRS = \
+   $(UTP_DIR)
+ 
+ EXTRA_DIST = \
++  curl \
++  libevent \
++  openssl \
+   macosx-libevent-config.h \
+   macosx-libevent-event-config.h

--- a/srcpkgs/transmission/template
+++ b/srcpkgs/transmission/template
@@ -1,11 +1,11 @@
 # Template file for 'transmission'
 pkgname=transmission
 version=3.00
-revision=1
-build_style=gnu-configure
-configure_args="--enable-nls --enable-cli --enable-daemon --enable-utp
- --without-systemd-daemon"
-hostmakedepends="intltool pkg-config qt5-host-tools"
+revision=2
+build_style=cmake
+configure_args="-DENABLE_CLI=ON"
+hostmakedepends="autoconf automake intltool glib-devel libtool pkg-config
+ qt5-host-tools qt5-qmake"
 makedepends="dbus-glib-devel gtk+3-devel libcurl-devel libevent-devel
  qt5-tools-devel"
 short_desc="Fast, easy and free BitTorrent client"
@@ -37,35 +37,6 @@ post_configure() {
 		 -e "/#include <inttypes.h>.*/i #include <stdio.h> /* off_t */"
 }
 
-do_build() {
-	make CXXFLAGS="${CXXFLAGS} -std=c++17" LDFLAGS="${LDFLAGS}" ${makejobs}
-	if [ -z "$CROSS_BUILD" ]; then
-		# Build the Qt frontend
-		cd qt
-		qmake-qt5 MOC=moc-qt5 QMAKE_CXXFLAGS="${CXXFLAGS}" QMAKE_LFLAGS="${LDFLAGS}" qtr.pro
-		lrelease-qt5 translations/*.ts
-		make ${makejobs} CXXFLAGS="${CXXFLAGS} -fPIC -std=c++17" LDFLAGS="${LDFLAGS}"
-	fi
-}
-
-do_install() {
-	# Install CLI tools, daemon and web client
-	for dir in cli daemon utils web; do
-		make -C ${dir} DESTDIR=${DESTDIR} install
-	done
-
-	# Install GTK+ frontend
-	make -C gtk DESTDIR=${DESTDIR} install
-	make -C po DESTDIR=${DESTDIR} install
-
-	if [ -z "$CROSS_BUILD" ]; then
-		# Install Qt frontend
-		make -C qt INSTALL_ROOT=${DESTDIR}/usr install
-		vmkdir usr/share/qt5/translations
-		vcopy qt/translations/*.qm usr/share/qt5/translations
-	fi
-}
-
 post_install() {
 	rm -f ${DESTDIR}/usr/share/${pkgname}/web/LICENSE
 	vsv transmission-daemon
@@ -78,10 +49,12 @@ transmission-qt_package() {
 	pkg_install() {
 		vmove usr/bin/transmission-qt
 		vmove usr/share/man/man1/transmission-qt.1
-		vmove usr/share/qt5/translations
-		sed -i '/Icon=/s/transmission/&-qt/' ${wrksrc}/qt/transmission-qt.desktop
+		vmove usr/share/transmission/translations
+		sed -i '/Icon=/s/transmission/&-qt/' ${DESTDIR}/usr/share/applications/transmission-qt.desktop
 		vinstall ${wrksrc}/qt/icons/transmission.png 644 usr/share/pixmaps transmission-qt.png
-		vinstall ${wrksrc}/qt/transmission-qt.desktop 644 usr/share/applications
+		vinstall ${wrksrc}/gtk/icons/hicolor_apps_scalable_transmission.svg \
+			644 usr/share/icons/hicolor/scalable/apps transmission-qt.svg
+		vmove usr/share/applications/transmission-qt.desktop
 	}
 }
 
@@ -92,8 +65,8 @@ transmission-gtk_package() {
 		vmove usr/bin/transmission-gtk
 		vmove usr/share/man/man1/transmission-gtk.1
 		vmove usr/share/icons/hicolor
-		vmove usr/share/applications
-		vmove usr/share/pixmaps
+		vmove usr/share/applications/transmission-gtk.desktop
+		vinstall ${wrksrc}/qt/icons/transmission.png 644 usr/share/pixmaps
 		# This install path seems to be used with musl libc
 		if [ -d ${DESTDIR}/usr/lib/locale ]; then
 			mv ${DESTDIR}/usr/lib/locale ${DESTDIR}/usr/share


### PR DESCRIPTION
Creating a second PR which fixes cross builds. Sorry for polluting the PR queue.

- Updated template to use `build_style=cmake` instead of `gnu-configure`. This is because upstream recommends building with `cmake` and localisation doesn't work with `gnu-configure`.
- Fixed broken Qt translations from previous revision

Right now the official tarball from [transmission/transmission-releases](https://github.com/transmission/transmission-releases) is broken as mentioned in [this issue](https://github.com/transmission/transmission/issues/1248). User @floppym has rolled their own tarball with [this fix](https://github.com/transmission/transmission/pull/1247) applied. I have used that tarball for now but hopefully we can revert to official tarballs for future versions.

Thanks a lot @floppym 