### PR TITLE
stack: update to 2.3.1

### DIFF
--- a/srcpkgs/stack/template
+++ b/srcpkgs/stack/template
@@ -1,6 +1,6 @@
 # Template file for 'stack'
 pkgname=stack
-version=2.3.0.1
+version=2.3.1
 revision=1
 _stackage="lts-15.4"
 hostmakedepends="cabal-install pkg-config unzip"
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://haskellstack.org"
 distfiles="https://github.com/commercialhaskell/${pkgname}/archive/v${version}.tar.gz
  https://www.stackage.org/${_stackage}/cabal.config>cabal.config-${_stackage}"
-checksum="a303a144dd3a37479e5b0fbf14d24e8d25d510bb038e413f14680ddb91036fd6
+checksum="6701ddfc6d0be0c2bf0f75c84375e41923c5617f04222c5e582e7011c7f8fb83
  4147e6738cf6ef38cfd48048ef0992fb00e786068592e359fdb804e3d9ed4781"
 skip_extraction="cabal.config-${_stackage}"
 nocross=yes
@@ -20,7 +20,7 @@ nopie_files="/usr/bin/stack"
 
 do_build() {
 	cp ${XBPS_SRCDISTDIR}/${pkgname}-${version}/cabal.config-${_stackage} cabal.config
-	HOME=$PWD cabal new-update
+	HOME=$PWD cabal update 'hackage.haskell.org,2020-04-29T20:25:58Z'
 	HOME=$PWD cabal new-build ${makejobs} --flag disable-git-info
 }
 


### PR DESCRIPTION
Using "cabal update 'hackage.haskell.org,2020-04-29T20:25:58Z'" to
stick to the successful build report on hackage. In this case:
https://hackage.haskell.org/package/stack-2.3.1/reports/1
[ci skip]