### PR TITLE
mbuffer: update to 20200505

### DIFF
--- a/srcpkgs/mbuffer/template
+++ b/srcpkgs/mbuffer/template
@@ -1,6 +1,6 @@
 # Template file for 'mbuffer'
 pkgname=mbuffer
-version=20191016
+version=20200505
 revision=1
 build_style=gnu-configure
 makedepends="libressl-devel"
@@ -9,5 +9,5 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.maier-komor.de/mbuffer.html"
 distfiles="http://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz"
-checksum=8dc210454765c18901074bc16e126c655135a486e73d69855caf74a157ddbe17
+checksum=cc046183149e51814c23b9f83fd748cc1625a88ee128651ea500aa7bd5f01f0b
 conf_files="/etc/mbuffer.rc"


### PR DESCRIPTION
2020505:
- configure fix for some powerpc toolchains
- update config.sub and config.guess
- added option to perform direct I/Os on temporary file