### PR TITLE
mixxx: add missing dependency speed-devel

### DIFF
--- a/srcpkgs/mixxx/template
+++ b/srcpkgs/mixxx/template
@@ -1,7 +1,7 @@
 # Template file for 'mixxx'
 pkgname=mixxx
 version=2.2.4
-revision=1
+revision=2
 wrksrc="mixxx-release-${version}"
 build_style=scons
 hostmakedepends="pkg-config protobuf"
@@ -10,7 +10,7 @@ makedepends="chromaprint-devel faad2-devel ffmpeg-devel fftw-devel glu-devel
  opusfile-devel portaudio-devel portmidi-devel protobuf-devel qt5-script-devel
  qt5-svg-devel qt5-xmlpatterns-devel rubberband-devel taglib-devel upower-devel
  vamp-plugin-sdk-devel lv2 lilv-devel qt5-x11extras-devel hidapi-devel
- libtheora-devel"
+ libtheora-devel speex-devel"
 depends="qt5-plugin-sqlite"
 short_desc="Open source digital DJing software that allows mixing music"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
without it, the build fails silently
fixes #22376