### PR TITLE
mesa: update to 20.1.1

### DIFF
--- a/srcpkgs/mesa/patches/musl.patch
+++ b/srcpkgs/mesa/patches/musl.patch
@@ -54,13 +54,3 @@
  
      if (first) {
          first = FALSE;
---- src/gallium/drivers/panfrost/pan_bo.h.orig	2020-03-06 08:37:26.810535178 +0100
-+++ src/gallium/drivers/panfrost/pan_bo.h	2020-03-06 08:38:00.290897294 +0100
-@@ -29,6 +29,7 @@
- #include <panfrost-misc.h>
- #include "pipe/p_state.h"
- #include "util/list.h"
-+#include <time.h>
- 
- struct panfrost_screen;
- 

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,6 +1,6 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=20.0.7
+version=20.1.1
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
@@ -23,7 +23,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://www.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=fe6e258fe772c3cd2ac01741bf7408058c3ac02d66acff9a6e669bd72e3ea178
+checksum=3ea6e46ea7881c656f7b4724639eaa4672d4e0e0b70869651e8f955ebae3d476
 
 build_options="wayland"
 build_options_default="wayland"
@@ -155,7 +155,7 @@ fi
 configure_args+=" ${_gallium_drivers} ${_vulkan_drivers} ${_dri_drivers}"
 
 if [ "$_have_vulkan" ]; then
-	configure_args+=" -Dvulkan-overlay-layer=true"
+	configure_args+=" -Dvulkan-device-select-layer=true -Dvulkan-overlay-layer=true"
 	subpackages+=" mesa-vulkan-overlay-layer"
 fi
 
@@ -228,11 +228,23 @@ MesaLib-devel_package() {
 	if [ "$_have_vmware" ]; then
 		depends+=" libxatracker>=${version}_${revision}"
 	fi
+	if [ "$_have_opencl" ]; then
+		depends+=" mesa-opencl>=${version}_${revision}"
+	fi
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.so"
+		vmove "usr/lib/lib{EGL,GLX}_mesa.so"
+		vmove usr/lib/libOSMesa.so
+		vmove usr/lib/libgbm.so
+		vmove usr/lib/libglapi.so
+		if [ "$_have_vmware" ]; then
+			vmove usr/lib/libxatracker.so
+		fi
+		if [ "$_have_opencl" ]; then
+			vmove usr/lib/libMesaOpenCL.so
+		fi
 	}
 }
 
@@ -317,6 +329,7 @@ mesa-vulkan-radeon_package() {
 mesa-vulkan-overlay-layer_package() {
 	short_desc="Vulkan layer to display information about the running application"
 	pkg_install() {
+		vmove usr/bin/mesa-overlay-control.py
 		vmove usr/lib/libVkLayer_MESA_overlay.so
 		vmove usr/share/vulkan/explicit_layer.d/VkLayer_MESA_overlay.json
 	}

--- a/srcpkgs/mesa/update
+++ b/srcpkgs/mesa/update
@@ -1,3 +1,2 @@
-pkgname="mesa"
-# libGL devs consider X.0.0 to be development releases
-ignore="*.*0*0"
+# mesa devs consider *.0 to be development releases
+ignore="*.0"


### PR DESCRIPTION
This is a development release, so do not merge yet.
I will undraft this once 20.1.1 comes out.
This is for testing purposes, and in preparation to 20.1.1 (which is likely this + minor fixes)
Testing on `x86_64-musl`, `sway`, Intel drivers