### PR TITLE
Ghc build for aarch64, aarch64-musl

### DIFF
--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -1,8 +1,8 @@
 # Template file for 'ghc-bin'
 pkgname=ghc-bin
 version=8.8.3
-revision=1
-archs="i686 x86_64* ppc64le"
+revision=2
+archs="i686 x86_64* ppc64le aarch64*"
 wrksrc="ghc-${version%[!0-9]}"
 hostmakedepends="ncurses perl libffi libnuma"
 depends="ncurses perl gcc libffi-devel gmp-devel"
@@ -31,6 +31,18 @@ ppc64le)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux.tar.xz"
 	checksum=0c8df56aa0177459894ba53375115ab76f8eed9f4b1018fae5c332bcc6b79cb4
 	;;
+aarch64)
+	# create with "make binary-dist"
+        depends+=" llvm"
+        distfiles="https://newstar.rinet.ru/~goga/void/ghc-${version}-aarch64-void-linux-glibc.tar.xz"
+        checksum=46bfdee5add70079c5700791aaddd958bf8630b7dad19aa09e79a612fe399c99
+        ;;
+aarch64-musl)
+	# create with "make binary-dist"
+        depends+=" llvm"
+        distfiles="https://newstar.rinet.ru/~goga/void/ghc-${version}-aarch64-void-linux-musl.tar.xz"
+        checksum=114ea7ddddec0b2fda06c2dbaff2cb1149b850ac17e052e5f5cb848297b06ed7
+        ;;
 esac
 
 do_configure() {

--- a/srcpkgs/ghc/template
+++ b/srcpkgs/ghc/template
@@ -2,7 +2,7 @@
 pkgname=ghc
 # Keep this synchronized with http://www.stackage.org/lts
 version=8.8.3
-revision=1
+revision=2
 wrksrc="ghc-${version%[!0-9]}"
 build_style=gnu-configure
 configure_args="--with-system-libffi"
@@ -38,6 +38,19 @@ desc_option_bindist="Create a binary distribution"
 # Recent safe to use tarball
 # GHC's bundled tarball is from 2017, buggy on some archs
 _ffi_rev=4d6d2866ae43e55325e8ee96561221804602cd7a
+
+case "$XBPS_TARGET_MACHINE" in
+aarch64)
+        hostmakedepends+=" llvm"
+        depends+=" llvm"
+        ;;
+aarch64-musl)
+        # does not work with gold
+        configure_args+=" --disable-ld-override"
+        hostmakedepends+=" llvm"
+        depends+=" llvm"
+        ;;
+esac
 
 if [ "$build_option_bindist" ]; then
 	# Strip --with-system-libffi from configuration


### PR DESCRIPTION
aarch64 binaries should probably be moved to a more appropriate place.