### PR TITLE
terraform: update to 0.12.26

### DIFF
--- a/srcpkgs/terraform/template
+++ b/srcpkgs/terraform/template
@@ -1,6 +1,6 @@
 # Template file for 'terraform'
 pkgname=terraform
-version=0.12.25
+version=0.12.26
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/$pkgname"
@@ -9,4 +9,4 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MPL-2.0"
 homepage="https://www.terraform.io/"
 distfiles="https://$go_import_path/archive/v$version.tar.gz"
-checksum=e4962e0ff928af9ba47e20976c2d9144020ef39930549c00bb79a9874759bf92
+checksum=4db5deb8c6a81956bf603196a1300aacbe80dd5716244ae20c2f9b3df571df4e


### PR DESCRIPTION
This PR updates `terraform` to v0.12.16
https://github.com/hashicorp/terraform/releases/tag/v0.12.26