### PR TITLE
ffmpeg: apply workaround for mesa vaapi bug

### DIFF
--- a/srcpkgs/ffmpeg/patches/workaround-mesa-readeon-vaapi-bug.patch
+++ b/srcpkgs/ffmpeg/patches/workaround-mesa-readeon-vaapi-bug.patch
@@ -1,0 +1,28 @@
+From 811d290844206fc73dc39c3e5b67d5d895baedf8 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Sat, 26 Jan 2019 19:48:35 +0100
+Subject: [PATCH] avcodec/vaapi_h264: skip decode if pic has no slices
+
+This fixes / workarounds https://bugs.freedesktop.org/show_bug.cgi?id=105368.
+It was hit frequently when watching h264 channels received via DVB-X.
+Corresponding kodi bug: https://github.com/xbmc/xbmc/issues/15704
+---
+ libavcodec/vaapi_h264.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libavcodec/vaapi_h264.c b/libavcodec/vaapi_h264.c
+index 5854587a255..f12fdc457a4 100644
+--- libavcodec/vaapi_h264.c
++++ libavcodec/vaapi_h264.c
+@@ -317,6 +317,11 @@ static int vaapi_h264_end_frame(AVCodecContext *avctx)
+     H264SliceContext *sl = &h->slice_ctx[0];
+     int ret;
+ 
++    if (pic->nb_slices == 0) {
++        ret = AVERROR_INVALIDDATA;
++        goto finish;
++    }
++
+     ret = ff_vaapi_decode_issue(avctx, pic);
+     if (ret < 0)
+         goto finish;

--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.2.3
-revision=1
+revision=2
 short_desc="Decoding, encoding and streaming software"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Works around https://bugs.freedesktop.org/show_bug.cgi?id=105368
which causes segfaults with vaapi with some radeon card.
The patch was written by the kodi developers and sent
upstream in http://ffmpeg.org/pipermail/ffmpeg-devel/2019-March/240862.html .