### PR TITLE
dkms: fix `make scripts` for crosscompiled kernels in kernel.d hook

### DIFF
--- a/srcpkgs/dkms/files/kernel.d/dkms.postinst
+++ b/srcpkgs/dkms/files/kernel.d/dkms.postinst
@@ -20,7 +20,7 @@ fi
 export IGNORE_CC_MISMATCH=1
 
 if [ ! -f /lib/modules/${VERSION}/build/scripts/basic/fixdep ] ; then
-	make -C /lib/modules/${VERSION}/build scripts
+	yes "" | make -j $(nproc) -C /lib/modules/${VERSION}/build scripts
 fi
 
 # Check available DKMS modules

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,7 +1,7 @@
 # Template file for 'dkms'
 pkgname=dkms
 version=2.8.1
-revision=1
+revision=2
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils linux-headers"
 short_desc="Dynamic Kernel Modules System"


### PR DESCRIPTION
* make use of all cores
* don't prompt during `make scripts`.

It was found that when building dkms on rpi using crosscompiled kernels
(which is the default), .config misses 'GCC_PLUGINS' so `make scripts`
prompts for it during update.

The same was applied already to xbps-triggers/dkms in 6dc2654685035825cec6deb528270cb85be08ce9 f609f7e76bcceef2d3db2e470ac60e548290e0fd