### PR TITLE
[RFC] john: make simd a build option, off by default

### DIFF
--- a/srcpkgs/john/template
+++ b/srcpkgs/john/template
@@ -1,12 +1,12 @@
 # Template file for 'john'
 pkgname=john
 version=1.9.0
-revision=1
+revision=2
 _jumbover=1
 wrksrc="${pkgname}-${version}-jumbo-${_jumbover}"
 build_wrksrc="src"
 build_style=gnu-configure
-configure_args="--with-systemwide"
+configure_args="--with-systemwide $(vopt_enable simd)"
 makedepends="libressl-devel gmp-devel libgomp-devel libpcap-devel bzip2-devel zlib-devel"
 short_desc="John the Ripper password cracker (jumbo-${_jumbover} patch included)"
 maintainer="Piraty <piraty1@inbox.ru>"
@@ -16,13 +16,7 @@ distfiles="$homepage/k/$pkgname-${version}-jumbo-${_jumbover}.tar.xz"
 checksum=f5d123f82983c53d8cc598e174394b074be7a77756f5fb5ed8515918c81e7f3b
 python_version=2 #unverified
 
-# the build system checks the host cpu for features, so when building on
-# a modern power9 system, it will attempt to shove in -mvsx and so on,
-# which breaks builds for 970 and 32-bit
-case "$XBPS_TARGET_MACHINE" in
-	ppc64le*) ;;
-	ppc*) configure_args+=" --disable-simd";;
-esac
+build_options="simd"
 
 pre_configure() {
 	unset CPP AS LD


### PR DESCRIPTION
This solves the problem of SIMD features being enabled and leaking in on all
architectures, not just ppc*. It is now provided as a build option if there
if is a want/need to enable these for custom builds.