### PR TITLE
vte3: update to 0.60.3.

### DIFF
--- a/srcpkgs/vte3/template
+++ b/srcpkgs/vte3/template
@@ -1,7 +1,7 @@
 # Template file for 'vte3'
 pkgname=vte3
-version=0.60.2
-revision=2
+version=0.60.3
+revision=1
 wrksrc="vte-${version}"
 build_style=meson
 build_helper="gir"
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Terminal/VTE"
 distfiles="${GNOME_SITE}/vte/${version%.*}/vte-${version}.tar.xz"
-checksum=35a0280e3f12feeb3096da05699191373c47a4a20c55cb7081e828e6015f8ca5
+checksum=feb76e1181a357d86112d447a08d127e2081438df76ece83243b18609dd9822a
 
 # Suppress warnings as errors for NULL format strings (musl libc)
 CXXFLAGS="-Wno-error=format="


### PR DESCRIPTION
Successfully built for: 
* `x86_64`
* `armv7l{,-musl}`
* `aarch64{,-musl}`