### PR TITLE
New package: gef-2020.06

### DIFF
--- a/srcpkgs/gef/template
+++ b/srcpkgs/gef/template
@@ -1,0 +1,20 @@
+# Template file for 'gef'
+pkgname=gef
+version=2020.06
+revision=1
+archs="noarch"
+pycompile_dirs="usr/share/gef"
+depends="keystone-python3 capstone-python3 unicorn-python3 python3-Ropper"
+short_desc="GDB Enhanced Features for exploit devs & reversers"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="MIT"
+homepage="https://gef.readthedocs.io/en/master/"
+distfiles="https://github.com/hugsy/gef/archive/${version}.tar.gz"
+checksum=334935986c681a346c1cb7944c1e4bbd52f7322f6427dfcba8a0185ff3c551c2
+python_version="3"
+
+do_install() {
+	vlicense LICENSE
+	vmkdir usr/share/gef
+	vcopy gef.py usr/share/gef
+}

--- a/srcpkgs/keystone-python3
+++ b/srcpkgs/keystone-python3
@@ -1,0 +1,1 @@
+keystone

--- a/srcpkgs/keystone/template
+++ b/srcpkgs/keystone/template
@@ -1,16 +1,21 @@
 # Template file for 'keystone'
 pkgname=keystone
-version=0.9.1
+version=0.9.2
 revision=1
 build_style=cmake
 configure_args='-DBUILD_SHARED_LIBS=ON -DLLVM_TARGETS_TO_BUILD=all'
-hostmakedepends="python"
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel"
 short_desc="Lightweight multi-platform, multi-architecture assembler framework"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.keystone-engine.org/"
 distfiles="https://github.com/keystone-engine/keystone/archive/${version}.tar.gz"
-checksum=e9d706cd0c19c49a6524b77db8158449b9c434b415fbf94a073968b68cf8a9f0
+checksum=c9b3a343ed3e05ee168d29daf89820aff9effb2c74c6803c2d9e21d55b5b7c24
+
+post_install() {
+	cd bindings/python && DESTDIR=${DESTDIR} make install3
+}
 
 keystone-devel_package() {
 	short_desc+=" - development files"
@@ -19,5 +24,13 @@ keystone-devel_package() {
 		vmove usr/include
 		vmove usr/lib/*.so
 		vmove usr/lib/pkgconfig
+	}
+}
+
+keystone-python3_package() {
+	short_desc+=" - Python3 bindings"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove "$py3_lib"
 	}
 }

--- a/srcpkgs/python3-Ropper/template
+++ b/srcpkgs/python3-Ropper/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-Ropper'
+pkgname=python3-Ropper
+version=1.13.5
+revision=1
+archs="noarch"
+wrksrc="Ropper-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="capstone-python3 python3-filebytes keystone-python3"
+short_desc="Find gadgets to build rop chains for different architectures"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://scoding.de/ropper/"
+distfiles="https://github.com/sashs/Ropper/archive/v${version}.tar.gz"
+checksum=b32329495645a6e0a8c1b2c4f4e330295a05b82eb8a5965051ad5c73e89bf371
+
+post_install() {
+	vlicense COPYING
+}

--- a/srcpkgs/python3-filebytes/template
+++ b/srcpkgs/python3-filebytes/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-filebytes'
+pkgname=python3-filebytes
+version=0.10.2
+revision=1
+archs="noarch"
+wrksrc="filebytes-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Library to read and edit ELF, PE, and other files"
+maintainer="Andrew Benson <abenson+void@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://scoding.de/filebytes-introduction"
+distfiles="https://github.com/sashs/filebytes/archive/v${version}.tar.gz"
+checksum=6a22a6cec9065c96143f7e3acb0acaffd5eb0d2419749361cb73e40d7e10c2d4
+
+post_install() {
+	vlicense COPYING
+}


### PR DESCRIPTION
1. I don't like that keystone python bindings require patching
2. I've already submitted an issue upstream to not use `-` in versions
3. Even if `gef` drops off this PR (understandable) the new packages and changes to existing packages are necessary for it.