### PR TITLE
New package: ngspice-bin-32

### DIFF
--- a/srcpkgs/ngspice-bin/template
+++ b/srcpkgs/ngspice-bin/template
@@ -1,0 +1,26 @@
+# Template file for 'ngspice-bin'
+pkgname=ngspice-bin
+version=32
+revision=1
+wrksrc=ngspice-${version}
+build_style=gnu-configure
+configure_args="--with-readline=yes --with-fftw3=yes --enable-xspice --enable-cider --disable-debug"
+hostmakedepends="bison byacc"
+makedepends="readline-devel libX11-devel libXaw-devel fftw-devel"
+short_desc="Mixed Mode Mixed Level Circuit Simulator based on Spice3F5 - executable"
+maintainer="Mohammad Amin Sameti <mamins1376@gmail.com>"
+license="BSD-3-Clause"
+homepage="http://ngspice.sourceforge.net"
+distfiles="${SOURCEFORGE_SITE}/ngspice/ng-spice-rework/${version}/ngspice-${version}.tar.gz"
+checksum=3cd90c4e94516d87c5b4d02a3a6405b1136b25d05c871d4fee1fd7c4c0d03ef2
+
+post_install() {
+	rm -f "${DESTDIR}/usr/bin/cmpp"
+	rm -f "${DESTDIR}/usr/share/man/man1/cmpp.1"
+
+	rm -rf "${DESTDIR}/usr/include"
+	rm -rf "${DESTDIR}/usr/lib/ngspice"
+	rm -rf "${DESTDIR}/usr/share/ngspice"
+
+	vlicense COPYING
+}


### PR DESCRIPTION
`ngspice` package itself only contains shared library version, and doesn't provide a way to execute ngspice scripts. This package compiles ngspice without `--with-ngshared` flag and contains only binary and it's manpage.

Original `ngspice` package is neither a dependency of this nor conflicts with.