### PR TITLE
keepassxc: fix dependency

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -14,9 +14,8 @@ configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF
  -DWITH_XC_YUBIKEY=$(vopt_if yubikey ON OFF)"
 hostmakedepends="qt5-qmake qt5-host-tools"
 makedepends="qt5-tools-devel qt5-svg-devel libgcrypt-devel libargon2-devel
- qrencode-devel readline-devel
+ qrencode-devel readline-devel libsodium-devel
  $(vopt_if autotype 'qt5-x11extras-devel libXtst-devel libXi-devel')
- $(vopt_if browser libsodium-devel)
  $(vopt_if keeshare quazip-devel)
  $(vopt_if yubikey 'libykpers-devel libyubikey-devel')"
 short_desc="KeePassXC is a cross-platform port of “Keepass Password Safe”"


### PR DESCRIPTION
KeepassXC fails to build without libsodium-devel when "browser" build option is not set.