### PR TITLE
mediainfo: split gui into mediainfo-gui subpackage

### DIFF
--- a/srcpkgs/mediainfo-gui
+++ b/srcpkgs/mediainfo-gui
@@ -1,0 +1,1 @@
+mediainfo

--- a/srcpkgs/mediainfo/template
+++ b/srcpkgs/mediainfo/template
@@ -1,27 +1,20 @@
 # Template file for 'mediainfo'
 pkgname=mediainfo
 version=20.03
-revision=1
+revision=2
 wrksrc=MediaInfo
 configure_args="--with-wx-config=wx-config-gtk3"
 hostmakedepends="automake libtool pkg-config"
-makedepends="libmediainfo-devel zlib-devel $(vopt_if GUI wxWidgets-gtk3-devel)"
-depends="$(vopt_if GUI 'desktop-file-utils hicolor-icon-theme')"
+makedepends="libmediainfo-devel zlib-devel wxWidgets-gtk3-devel"
 short_desc="Display technical and tag data for video and audio files"
 maintainer="John <johnz@posteo.net>"
 license="BSD-2-Clause"
 homepage="https://mediaarea.net/MediaInfo"
 distfiles="https://mediaarea.net/download/source/${pkgname}/${version}/${pkgname}_${version}.tar.xz"
 checksum=dc3ef8a2aea8d1bb101c679209de941d094141113acda42677c101c7bc853ab8
-replaces="mediainfo-gui>=0"
-
-build_options="CLI GUI"
-build_options_default="CLI GUI"
-desc_option_CLI="Build CLI version"
-desc_option_GUI="Build GUI version"
 
 do_configure() {
-	local targets="$(vopt_if CLI CLI) $(vopt_if GUI GUI)"
+	local targets="CLI GUI"
 
 	for d in $targets; do
 		cd $wrksrc/Project/GNU/$d
@@ -31,7 +24,7 @@ do_configure() {
 }
 
 do_build() {
-	local targets="$(vopt_if CLI CLI) $(vopt_if GUI GUI)"
+	local targets="CLI GUI"
 
 	for d in $targets; do
 		cd $wrksrc/Project/GNU/$d
@@ -40,7 +33,7 @@ do_build() {
 }
 
 do_install() {
-	local targets="$(vopt_if CLI CLI) $(vopt_if GUI GUI)"
+	local targets="CLI GUI"
 
 	for d in $targets; do
 		cd $wrksrc/Project/GNU/$d
@@ -48,12 +41,21 @@ do_install() {
 	done
 	vlicense ${wrksrc}/License.html
 
-	if [ "$build_option_GUI" ]; then
-		vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.svg 644 \
-			usr/share/icons/hicolor/scalable/apps mediainfo.svg
-		vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.png 644 \
-			usr/share/pixmaps mediainfo-gui.png
-		vinstall ${wrksrc}/Project/GNU/GUI/mediainfo-gui.desktop 644 \
-			usr/share/applications
-	fi
+	vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.svg 644 \
+		usr/share/icons/hicolor/scalable/apps mediainfo.svg
+	vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.png 644 \
+		usr/share/pixmaps mediainfo-gui.png
+	vinstall ${wrksrc}/Project/GNU/GUI/mediainfo-gui.desktop 644 \
+		usr/share/applications
+}
+
+mediainfo-gui_package() {
+	short_desc+=" - gtk user interface"
+	# GUI does not depend on CLI
+	depends="desktop-file-utils hicolor-icon-theme"
+
+	pkg_install() {
+		vmove /usr/bin/mediainfo-gui
+		vmove /usr/share
+	}
 }


### PR DESCRIPTION
Currently if you only want the CLI tool without pulling in the whole of GTK3 you need to build it yourself, so I split the 2 packages (just like I did with mp3info)