### PR TITLE
[RFC] shutils/bulk.sh: remove newlines from package list

### DIFF
--- a/common/xbps-src/shutils/bulk.sh
+++ b/common/xbps-src/shutils/bulk.sh
@@ -115,6 +115,6 @@ bulk_update() {
     if [ -n "$pkgs" -a -n "$args" ]; then
         echo
         msg_normal "xbps-src: updating your system, confirm to proceed...\n"
-        ${XBPS_SUCMD} "$XBPS_INSTALL_CMD $XBPS_INSTALL_ARGS -u ${pkgs}" || return 1
+        ${XBPS_SUCMD} "$XBPS_INSTALL_CMD $XBPS_INSTALL_ARGS -u ${pkgs//[$'\n']/ }" || return 1
     fi
 }


### PR DESCRIPTION
`xbps-checkvers` returns the package list one per line, which is fine until the update command is tried to be run. With the quotes, it effectively tries to run:

    xbps-install -u pkga
    pkgb

This removes the newlines so it works correctly.