### PR TITLE
julia: update to 1.4.2.

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,14 +1,14 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.4.1
-revision=2
+version=1.4.2
+revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_LLVM_SHLIB=1 USE_BINARYBUILDER=0
  USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBUNWIND=0 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_LIBM=0
  USE_SYSTEM_DSFMT=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=0
- USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
+ USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=0 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
  USE_SYSTEM_CURL=1 USE_SYSTEM_MPFR=1 USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_UTF8PROC=0
  USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LAPACK=0"
 make_install_args="$make_build_args"
@@ -16,15 +16,15 @@ make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
 hostmakedepends="perl cmake python gcc-fortran patchelf which tar xz"
-makedepends="pcre2-devel gmp-devel mpfr-devel libgit2-devel libcurl-devel
+makedepends="pcre2-devel gmp-devel mpfr-devel libcurl-devel
  libssh2-devel mbedtls-devel libatomic-devel zlib-devel p7zip"
-depends="pcre2 gmp mpfr libgit2 libcurl libssh2 mbedtls libatomic zlib p7zip"
+depends="pcre2 gmp mpfr libcurl libssh2 mbedtls libatomic zlib p7zip"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=b21585db55673ac0668c163678fcf2aad11eb7c64bb2aa03a43046115fab1553
+checksum=948c70801d5cce81eeb7f764b51b4bfbb2dc0b1b9effc2cb9fc8f8cf6c90a334
 nocross=yes
 # Falsely detects dependency on libllvm
 skiprdeps="/usr/lib/libjulia.so.1.4 /usr/lib/julia/libllvmcalltest.so"


### PR DESCRIPTION
[ci skip]

Changes julia to bundle its own copy of libgit2. Closes #21960. Julia
is currently binary-incompatible with the newer version of libgit2
shipped with void.

The libgit2 library adds 1.2M to the package size.