### PR TITLE
[WIP] New packages: proton-bridge-1.2.7 and dependency

### DIFF
--- a/srcpkgs/proton-bridge/patches/Makefile.patch
+++ b/srcpkgs/proton-bridge/patches/Makefile.patch
@@ -1,0 +1,184 @@
+--- proton-bridge-1.2.7-live.1/Makefile	2020-05-18 08:02:29.000000000 -0400
++++ "proton-bridge-1.2.7-live.1/Makefile copy"	2020-07-01 00:49:51.790962542 -0400
+@@ -23,14 +23,6 @@
+ ICO_FILES:=
+ EXE:=$(shell basename ${CURDIR})
+ 
+-ifeq "${GOOS}" "windows"
+-    EXE+=.exe
+-    ICO_FILES:=logo.ico icon.rc icon_windows.syso
+-endif
+-ifeq "${GOOS}" "darwin"
+-    DARWINAPP_CONTENTS:=${DEPLOY_DIR}/darwin/${EXE}.app/Contents
+-    EXE:=${EXE}.app/Contents/MacOS/${EXE}
+-endif
+ EXE_TARGET:=${DEPLOY_DIR}/${GOOS}/${EXE}
+ TGZ_TARGET:=bridge_${GOOS}_${REVISION}.tgz
+ 
+@@ -48,17 +40,6 @@
+ 	cp -pf ./LICENSE ${DEPLOY_DIR}/linux/
+ 	cp -pf ./Changelog.md ${DEPLOY_DIR}/linux/
+ 
+-${DEPLOY_DIR}/darwin: ${EXE_TARGET}
+-	cp ./internal/frontend/share/icons/Bridge.icns ${DARWINAPP_CONTENTS}/Resources/
+-	cp -r "utils/addcert.scpt" ${DARWINAPP_CONTENTS}/Resources/
+-	cp LICENSE ${DARWINAPP_CONTENTS}/Resources/
+-	rm -rf "${DARWINAPP_CONTENTS}/Frameworks/QtWebEngine.framework"
+-	rm -rf "${DARWINAPP_CONTENTS}/Frameworks/QtWebView.framework"
+-	rm -rf "${DARWINAPP_CONTENTS}/Frameworks/QtWebEngineCore.framework"
+-
+-${DEPLOY_DIR}/windows: ${EXE_TARGET}
+-	cp ./internal/frontend/share/icons/logo.ico ${DEPLOY_DIR}/windows/
+-	cp LICENSE ${DEPLOY_DIR}/windows/
+ 
+ ${EXE_TARGET}: check-has-go gofiles ${ICO_FILES} update-vendor
+ 	rm -rf deploy ${GOOS} ${DEPLOY_DIR}
+@@ -67,106 +48,21 @@
+ 	mv deploy cmd/Desktop-Bridge
+ 	rm -rf ${GOOS} main.go
+ 
+-logo.ico: ./internal/frontend/share/icons/logo.ico
+-	cp $^ .
+-icon.rc: ./internal/frontend/share/icon.rc
+-	cp $^ .
+-./internal/frontend/qt/icon_windows.syso: ./internal/frontend/share/icon.rc  logo.ico 
+-	windres $< $@
+-icon_windows.syso: ./internal/frontend/qt/icon_windows.syso
+-	cp $^ .
+-
+ 
+ ## Rules for therecipe/qt
+ .PHONY: prepare-vendor update-vendor
+-THERECIPE_QTVER:=$(shell grep "github.com/therecipe/qt " go.mod | sed -r 's;.* v[0-9\.]+-[0-9]+-([a-f0-9]*).*;\1;')
+ THERECIPE_ENV:=github.com/therecipe/env_${GOOS}_amd64_513
+ 
+-# vendor folder will be deleted by gomod hence we cache the big repo
+-# therecipe/env in order to download it only once
+-vendor-cache/${THERECIPE_ENV}:
+-	git clone https://${THERECIPE_ENV}.git vendor-cache/${THERECIPE_ENV}
+-
+-LINKCMD:=ln -sf ${CURDIR}/vendor-cache/${THERECIPE_ENV} vendor/${THERECIPE_ENV}
+-ifeq "${GOOS}" "windows"
+-    WINDIR:=$(subst /c/,c:\\,${CURDIR})/vendor-cache/${THERECIPE_ENV}
+-    LINKCMD:=cmd //c 'mklink $(subst /,\,vendor\${THERECIPE_ENV} ${WINDIR})'
+-endif
++LINKCMD:=ln -sf ${CURDIR}/../env_linux_amd64_513-e137a3934da63027a815b99feb2d27ca67af897b vendor/${THERECIPE_ENV}
+ 
+ prepare-vendor:
+-	go install -v -tags=no_env github.com/therecipe/qt/cmd/...
+ 	go mod vendor
+ 
+ # update-vendor is PHONY because we need to make sure that we always have updated vendor
+-update-vendor: vendor-cache/${THERECIPE_ENV} prepare-vendor
++update-vendor: prepare-vendor
++	$(shell ../env_linux_amd64_513-e137a3934da63027a815b99feb2d27ca67af897b/init.sh)
+ 	${LINKCMD}
+ 
+-
+-## Dev dependencies
+-.PHONY: install-devel-tools install-linter install-go-mod-outdated
+-LINTVER:="v1.23.6"
+-LINTSRC:="https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+-
+-install-dev-dependencies: install-devel-tools install-linter install-go-mod-outdated
+-
+-install-devel-tools: check-has-go
+-	go get -v github.com/golang/mock/gomock
+-	go get -v github.com/golang/mock/mockgen
+-	go get -v github.com/go-delve/delve
+-
+-install-linter: check-has-go
+-	curl -sfL $(LINTSRC) | sh -s -- -b $(shell go env GOPATH)/bin $(LINTVER)
+-
+-install-go-mod-outdated:
+-	which go-mod-outdated || go get -u github.com/psampaz/go-mod-outdated
+-
+-
+-## Checks, mocks and docs
+-.PHONY: check-has-go check-license test bench coverage mocks lint updates doc
+-check-has-go:
+-	@which go || (echo "Install Go-lang!" && exit 1)
+-
+-check-license:
+-	find . -not -path "./vendor/*" -not -name "*mock*.go" -regextype posix-egrep -regex ".*\.go|.*\.qml" -exec grep -L "Copyright (c) 2020 Proton Technologies AG" {} \;
+-
+-test: gofiles
+-	@# Listing packages manually to not run Qt folder (which needs to run qtsetup first) and integration tests.
+-	go test -coverprofile=/tmp/coverage.out -run=${TESTRUN} \
+-		./internal/api/... \
+-		./internal/bridge/... \
+-		./internal/events/... \
+-		./internal/frontend/autoconfig/... \
+-		./internal/frontend/cli/... \
+-		./internal/imap/... \
+-		./internal/preferences/... \
+-		./internal/smtp/... \
+-		./internal/store/... \
+-		./pkg/...
+-
+-bench:
+-	go test -run '^$$' -bench=. -memprofile bench_mem.pprof -cpuprofile bench_cpu.pprof ./internal/store
+-	go tool pprof -png -output bench_mem.png bench_mem.pprof
+-	go tool pprof -png -output bench_cpu.png bench_cpu.pprof
+-
+-coverage: test
+-	go tool cover -html=/tmp/coverage.out -o=coverage.html
+-
+-mocks:
+-	mockgen --package mocks github.com/ProtonMail/proton-bridge/internal/bridge Configer,PreferenceProvider,PanicHandler,PMAPIProvider,CredentialsStorer > internal/bridge/mocks/mocks.go
+-	mockgen --package mocks github.com/ProtonMail/proton-bridge/internal/store PanicHandler,BridgeUser > internal/store/mocks/mocks.go
+-	mockgen --package mocks github.com/ProtonMail/proton-bridge/pkg/listener Listener > internal/store/mocks/utils_mocks.go
+-
+-lint:
+-	which golangci-lint || $(MAKE) install-linter
+-	golangci-lint run ./...
+-
+-updates: install-go-mod-outdated
+-	# Uncomment the "-ci" to fail the job if something can be updated.
+-	go list -u -m -json all | go-mod-outdated -update -direct #-ci
+-
+-doc:
+-	godoc -http=:6060
+-
+ .PHONY: gofiles
+ # Following files are for the whole app so it makes sense to have them in bridge package.
+ # (Options like cmd or internal were considered and bridge package is the best place for them.)
+@@ -175,38 +71,3 @@
+ 	cd ./utils/ && ./credits.sh
+ ./internal/bridge/release_notes.go: ./utils/release-notes.sh ./release-notes/notes.txt ./release-notes/bugs.txt
+ 	cd ./utils/ && ./release-notes.sh
+-
+-
+-## Run and debug
+-.PHONY: run run-qt run-qt-cli run-nogui run-nogui-cli run-debug qmlpreview qt-fronted-clean clean
+-VERBOSITY?=debug-client
+-RUN_FLAGS:=-m -l=${VERBOSITY}
+-
+-run: run-nogui-cli
+-
+-run-qt: ${EXE_TARGET}
+-	PROTONMAIL_ENV=dev ./$< ${RUN_FLAGS} | tee last.log
+-run-qt-cli: ${EXE_TARGET}
+-	PROTONMAIL_ENV=dev ./$< ${RUN_FLAGS} -c
+-
+-run-nogui: clean-vendor gofiles
+-	PROTONMAIL_ENV=dev go run ${BUILD_FLAGS_NOGUI} cmd/Desktop-Bridge/main.go ${RUN_FLAGS} | tee last.log
+-run-nogui-cli: clean-vendor gofiles
+-	PROTONMAIL_ENV=dev go run ${BUILD_FLAGS_NOGUI} cmd/Desktop-Bridge/main.go ${RUN_FLAGS} -c
+-
+-run-debug:
+-	PROTONMAIL_ENV=dev dlv debug --build-flags "${BUILD_FLAGS_NOGUI}" cmd/Desktop-Bridge/main.go -- ${RUN_FLAGS}
+-
+-run-qml-preview:
+-	make -C internal/frontend/qt -f Makefile.local qmlpreview
+-
+-clean-frontend-qt:
+-	make -C internal/frontend/qt -f Makefile.local clean
+-
+-clean-vendor: clean-frontend-qt
+-	rm -rf ./vendor
+-
+-clean: clean-frontend-qt
+-	rm -rf vendor-cache
+-	rm -rf cmd/Desktop-Bridge/deploy
+-	rm -f build last.log mem.pprof

--- a/srcpkgs/proton-bridge/patches/init.sh.patch
+++ b/srcpkgs/proton-bridge/patches/init.sh.patch
@@ -1,0 +1,12 @@
+Change QT_ROOT to use system libraries.
+--- env_linux_amd64_513-e137a3934da63027a815b99feb2d27ca67af897b/init.sh	2019-06-25 20:03:07.000000000 -0400
++++ "env_linux_amd64_513-e137a3934da63027a815b99feb2d27ca67af897b/init copy.sh"	2020-07-01 00:43:03.372898161 -0400
+@@ -2,7 +2,7 @@
+ 
+ set -ev
+ 
+-QT_ROOT=/opt
++QT_ROOT=/usr/lib/qt5
+ QT_VERSION=5.13.0
+ 
+ rm -rf ./${QT_VERSION}

--- a/srcpkgs/proton-bridge/template
+++ b/srcpkgs/proton-bridge/template
@@ -1,0 +1,32 @@
+# Template file for 'proton-bridge'
+pkgname=proton-bridge
+version=1.2.7
+revision=1
+wrksrc="proton-bridge-${version}-live.1"
+create_wrksrc=yes
+build_wrksrc=${pkgname}-${version}-live.1
+_githash="e137a3934da63027a815b99feb2d27ca67af897b"
+build_style=gnu-makefile
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends="git go pkg-config qt5-go rsync tar which"
+makedepends="libsecret-devel libglvnd-devel"
+depends="gnome-keyring"
+short_desc="ProtonMail Bridge for e-mail clients"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://protonmail.com/bridge"
+distfiles="https://www.github.com/ProtonMail/proton-bridge/archive/v${version}-live.1.tar.gz
+ https://github.com/therecipe/env_linux_amd64_513/archive/${_githash}.tar.gz"
+checksum="5a4c19b769cd72097507de6840b79e56d37fa6a54cf7269d4fec28c05016ca45
+ 4b22aca118aabaf28da6ba39b5bf54c4a05e43fc354ce7682669dc4408b7d4fd"
+nostrip="yes"
+nopie="yes"
+
+do_install() {
+	vbin ./cmd/Desktop-Bridge/deploy/linux/${pkgname}-${version}-live.1 proton-bridge
+	vdoc ./doc/index.md
+	vdoc ./doc/bridge.md
+	vdoc ./doc/communication.md
+	vdoc ./doc/database.md
+	vdoc ./doc/encryption.md
+}

--- a/srcpkgs/qt5-go/template
+++ b/srcpkgs/qt5-go/template
@@ -1,0 +1,21 @@
+# Template file for 'qt5-go'
+pkgname=qt5-go
+version=0.0.2020.06.04
+revision=1
+_githash=b56356132618ecc7c0029f4262d4ac986afe1477
+wrksrc=qt-${_githash}
+build_style=go
+go_import_path=github.com/therecipe/qt/cmd/...
+go_build_tags="no_env"
+#make_dirs="/var/log/dir 0755 root root"
+makedepends="qt5-devel qt5-doc qt5-quickcontrols2-devel"
+short_desc="Qt5 bindings for the go language"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="LGPL-3.0-only"
+homepage="https://github.com/therecipe/qt"
+distfiles="https://github.com/therecipe/qt/archive/${_githash}.tar.gz"  # no official releases yet
+checksum=7d076486f590bfa8c3f6a248baa8f062b3f76fbc8ee7240dc3f760c795e3f700
+
+pre_fetch() {
+	export QT_PKG_CONFIG=true
+}


### PR DESCRIPTION
I'm trying to package [proton-bridge](https://github.com/ProtonMail/proton-bridge), but I'm running into some issues with the build process. Here's the relevant output from xbps-src:
```
make: qtdeploy: No such file or directory
make: *** [Makefile:66: cmd/Desktop-Bridge/deploy/linux/proton-bridge-1.2.7-live.1] Error 127
=> ERROR: proton-bridge-1.2.7_1: do_build: '${make_cmd} CC="$CC" CXX="$CXX" LD="$LD" AR="$AR" RANLIB="$RANLIB" CPP="$CPP" AS="$AS" OBJDUMP="$OBJDUMP" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" ${makejobs} ${make_build_args} ${make_build_target}' exited with 2
=> ERROR:   in do_build() at common/build-style/gnu-makefile.sh:9
```
I know that xlint throws up errors on this template as well, I thought I should fix those after solving the build errors. Any other suggestions for improvement are welcome as well!

As for `qtdeploy`, the best I can figure is that it's a tool provided by [this repository](https://github.com/therecipe/qt). Unfortunately, the repo has no releases, so the bindings and tools it provides can't be packaged. ericonr on IRC said that it might be possible to build without `qtdeploy`, but I haven't understood the Makefile well enough yet to figure out how to do that.