### PR TITLE
New package: snixembed-0.2.2

### DIFF
--- a/srcpkgs/snixembed/template
+++ b/srcpkgs/snixembed/template
@@ -1,0 +1,25 @@
+# Template file for 'snixembed'
+pkgname=snixembed
+version=0.2.2
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="pkg-config vala"
+makedepends="gtk+3-devel glib-devel libdbusmenu-gtk3-devel libdbusmenu-glib-devel vala-devel"
+short_desc="Proxy StatusNotifierItem systray API to XEmbed API"
+maintainer="projectmoon <projectmoon@agnos.is>"
+license="ISC"
+homepage="https://git.sr.ht/~steef/snixembed"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=91e654ced9c09f2c566afef2035894be6c99d18189a234a07b6c921427851a04
+
+pre_build() {
+	# Need to patch makefile with version because currently it
+	# assumes it's in a git repo.
+	vsed -i makefile -e 's/version.vala:.*/version.vala:/g'
+	vsed -i makefile -e 's/VERSION = .*$/VERSION = \\"'"${version}"'\\";\" > $@/g'
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
For proxying newer systray API to older XEmbed. Can fix issues like Riot 1.6+ not having a tray icon in window managers like i3.