### PR TITLE
blender: update to 2.83

### DIFF
--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -1,7 +1,7 @@
 # Template file for 'blender'
 pkgname=blender
-version=2.82
-revision=3
+version=2.83.0
+revision=1
 build_style="cmake"
 makedepends="
  libgomp-devel libpng-devel tiff-devel python3-devel glu-devel
@@ -15,8 +15,8 @@ short_desc="3D graphics creation suite"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.blender.org"
-distfiles="http://download.blender.org/source/${pkgname}-${version}.tar.xz"
-checksum=002adf2c51fc58a8941c87fc8e180bb1aacb73a0c223714f36d3d84da345fc65
+distfiles="https://download.blender.org/source/blender-${version}.tar.xz"
+checksum=14e2bc85e076b12ae94438ff3c1dd417eba642840ed32d7c979724a93aa93f1f
 patch_args="-Np1"
 
 python_version=3
@@ -54,8 +54,8 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 case "$XBPS_TARGET_MACHINE" in
-x86_64*)
-	# Enable Intel Open Image Denoise on x86_64
+x86_64)
+	# Intel(R) Open Image Denoise supports glibc 64-bit platforms only
 	makedepends+=" openimagedenoise-devel"
 	configure_args+=" -DWITH_OPENIMAGEDENOISE=ON"
 	;;


### PR DESCRIPTION
also fix openimagedenoise is just for glibc x86_64