### PR TITLE
openimagedenoise: update to 1.2.0

### DIFF
--- a/srcpkgs/openimagedenoise/template
+++ b/srcpkgs/openimagedenoise/template
@@ -1,18 +1,18 @@
 # Template file for 'openimagedenoise'
 pkgname=openimagedenoise
-version=1.1.0
+version=1.2.0
 revision=1
-archs="x86_64*"
+archs="x86_64"
 wrksrc=oidn-${version}
 build_style=cmake
-hostmakedepends="python3"
-makedepends="tbb-devel"
+hostmakedepends="python3 tbb-devel ispc"
+makedepends="openimageio-devel"
 short_desc="Intel(R) Open Image Denoise library"
 maintainer="teldra <teldra@rotce.de>"
 license="Apache-2.0"
 homepage="https://openimagedenoise.github.io"
 distfiles="https://github.com/OpenImageDenoise/oidn/releases/download/v${version}/oidn-${version}.src.tar.gz"
-checksum=4dd484abea8a0b3d12d346343fcb1ab7abef8f94318d8c537f69a20c2a75c4eb
+checksum=041f59758e79f4ea29a9b7a952f2c096426820678a5a713880b6d8a6519a75d0
 
 openimagedenoise-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Since version 1.2.0, OpenimageDenoise needs ispc, which is not available on x86_64-musl.