### PR TITLE
python3-pycares: correct dependencies

### DIFF
--- a/srcpkgs/python3-pycares/template
+++ b/srcpkgs/python3-pycares/template
@@ -5,8 +5,9 @@ revision=1
 wrksrc="pycares-${version}"
 build_style=python3-module
 # using bundled c-ares which is patched for TTL support
-hostmakedepends="python3-setuptools"
-makedepends="python3-devel python3-cffi libffi-devel"
+hostmakedepends="python3-setuptools python3-cffi"
+makedepends="python3-devel"
+depends="python3-cffi"
 short_desc="Python interface for c-ares"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="MIT"


### PR DESCRIPTION
Cross-compilation fails on the builders because `python3-cffi` is required on the host, not the target, to compile the shared object in this package. Also, `python3-cffi` should be a runtime dependency of all packages with `hostmakedepends=python3-cffi`, because the resulting modules pull in the Python `_cffi_backend` module at runtime.

cc: @sgn 