### PR TITLE
New package: libhugetlbfs-2.22

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3960,3 +3960,4 @@ libvips-cpp.so.42 libvips-8.9.2_1
 libselinux.so.1 libselinux-3.0_1
 libsepol.so.1 libsepol-3.0_1
 libfrrcares.so.0 libfrr-7.3.1_1
+libhugetlbfs.so.0 libhugetlbfs-2.22_1

--- a/srcpkgs/libhugetlbfs-devel
+++ b/srcpkgs/libhugetlbfs-devel
@@ -1,0 +1,1 @@
+libhugetlbfs

--- a/srcpkgs/libhugetlbfs-tools
+++ b/srcpkgs/libhugetlbfs-tools
@@ -1,0 +1,1 @@
+libhugetlbfs

--- a/srcpkgs/libhugetlbfs/patches/0001-Makefile-Fix-version-discovery.patch
+++ b/srcpkgs/libhugetlbfs/patches/0001-Makefile-Fix-version-discovery.patch
@@ -1,0 +1,43 @@
+From: Punit Agrawal <punitagrawal@gmail.com>
+Date: Sun, 3 Mar 2019 09:16:24 +0900
+Subject: Makefile: Fix version discovery
+
+Upstream uses git based discovery to generate versioning information
+for release tar balls. The invocation of the version generation script
+(localversion) doesn't work with packaging that lives in git
+repositories.
+
+Fix this by moving the relevant bits of versioning to the Makefile.
+---
+ Makefile | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 51e41f0..9b8c4ea 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,6 +23,8 @@ SOURCE = $(shell find . -maxdepth 1 ! -name version.h -a -name '*.[h]')
+ SOURCE += *.c *.lds Makefile
+ NODEPTARGETS=<version.h> <clean>
+ 
++REL_VERSION=2.22
++
+ INSTALL = install
+ 
+ LDFLAGS += -ldl
+@@ -266,11 +268,11 @@ $(OBJDIRS): %:
+ 	@mkdir -p $@
+ 
+ # <Version handling>
+-$(VERSION): always
++$(VERSION): FORCE
+ 	@$(VECHO) VERSION
+-	./localversion version $(SOURCE)
+-always:
+-# </Version handling>
++	printf "// %s\n" "${REL_VERSION}" > $@
++	printf "#define VERSION \"%s\"\n" "${REL_VERSION}" >> $@
++FORCE:
+ 
+ snapshot: $(VERSION)
+ 

--- a/srcpkgs/libhugetlbfs/patches/0002-Append-version-to-soname.patch
+++ b/srcpkgs/libhugetlbfs/patches/0002-Append-version-to-soname.patch
@@ -1,0 +1,34 @@
+From: Punit Agrawal <punitagrawal@gmail.com>
+Date: Sun, 3 Mar 2019 08:40:03 +0900
+Subject: Append version to soname
+
+---
+ Makefile | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index ba8e4a8..da318a6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -24,6 +24,7 @@ SOURCE += *.c *.lds Makefile
+ NODEPTARGETS=<version.h> <clean>
+ 
+ REL_VERSION=2.22
++SOVERSION=0
+ 
+ INSTALL = install
+ 
+@@ -308,11 +309,11 @@ obj64/libhugetlbfs.a: $(LIBOBJS64)
+ 
+ obj32/libhugetlbfs.so: $(LIBOBJS32)
+ 	@$(VECHO) LD32 "(shared)" $@
+-	$(CC32) $(LDFLAGS) -Wl,--version-script=version.lds -Wl,-soname,$(notdir $@) -shared -o $@ $^ $(LDLIBS)
++	$(CC32) $(LDFLAGS) -Wl,--version-script=version.lds -Wl,-soname,$(notdir $@).$(SOVERSION) -shared -o $@ $^ $(LDLIBS)
+ 
+ obj64/libhugetlbfs.so: $(LIBOBJS64)
+ 	@$(VECHO) LD64 "(shared)" $@
+-	$(CC64) $(LDFLAGS) -Wl,--version-script=version.lds -Wl,-soname,$(notdir $@) -shared -o $@ $^ $(LDLIBS)
++	$(CC64) $(LDFLAGS) -Wl,--version-script=version.lds -Wl,-soname,$(notdir $@).$(SOVERSION) -shared -o $@ $^ $(LDLIBS)
+ 
+ #obj32/libhugetlbfs_privutils.a: $(LIBPUOBJS:%=obj32/%)
+ #	@$(VECHO) AR32 $@

--- a/srcpkgs/libhugetlbfs/template
+++ b/srcpkgs/libhugetlbfs/template
@@ -1,0 +1,60 @@
+# Template file for 'libhugetlbfs'
+pkgname=libhugetlbfs
+version=2.22
+revision=1
+# fails to build on musl (relies on glibc specifics) + only for these archs
+archs="x86_64 i686 armv[67]l aarch64 ppc64le ppc64 ppc"
+build_style=gnu-makefile
+make_build_args="ARCH=${XBPS_TARGET_MACHINE%-*} LIB32=lib32 LIB64=lib BUILDTYPE=NATIVEONLY"
+make_install_args="${make_build_args}"
+short_desc="Library to deal with hugetlbfs"
+maintainer="q66 <daniel@octaforge.org>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/libhugetlbfs/libhugetlbfs"
+distfiles="https://github.com/${pkgname}/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.gz"
+checksum=94dca9ea2c527cd77bf28904094fe4708865a85122d416bfccc8f4b73b9a6785
+patch_args="-Np1"
+CFLAGS="-fPIC"
+
+do_check() {
+	# requires mounted hugetlbfs
+	:
+}
+
+post_extract() {
+	vsed -i 's,CUSTOM_LDSCRIPTS = yes,CUSTOM_LDSCRIPTS = no,' Makefile
+}
+
+post_install() {
+	# only needed with old binutils, and wrong for some of our setups
+	rm -rf ${DESTDIR}/usr/share/libhugetlbfs/ldscripts
+	# don't need this
+	rm -f ${DESTDIR}/usr/lib/libhugetlbfs_privutils.so
+	# soname
+	mv ${DESTDIR}/usr/lib/libhugetlbfs.so ${DESTDIR}/usr/lib/libhugetlbfs-${version}.so
+	ln -s libhugetlbfs-${version}.so ${DESTDIR}/usr/lib/libhugetlbfs.so.0
+	ln -s libhugetlbfs.so.0 ${DESTDIR}/usr/lib/libhugetlbfs.so
+	# ld
+	rm ${DESTDIR}/usr/share/${pkgname}/ld
+	mv ${DESTDIR}/usr/share/${pkgname}/ld.hugetlbfs ${DESTDIR}/usr/bin
+}
+
+libhugetlbfs-devel_package() {
+	depends="libhugetlbfs>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/libhugetlbfs.so
+		vmove usr/lib/libhugetlbfs.a
+		vmove usr/share/man/man3
+	}
+}
+
+libhugetlbfs-tools_package() {
+	short_desc="Tools to ease use of hugetlbfs"
+	pkg_install() {
+		vmove usr/bin
+		vmove usr/share/man/man1
+		vmove usr/share/man/man8
+	}
+}


### PR DESCRIPTION
Unfortunately not trivially patchable for musl (relies on some glibc specifics)

This is a bunch of tools + a library to deal with management of hugepage backings. Useful together with qemu, etc.

Putting this here to let travis do its thing.