### PR TITLE
riot-desktop: update to 1.6.3.

### DIFF
--- a/srcpkgs/riot-desktop/INSTALL.msg
+++ b/srcpkgs/riot-desktop/INSTALL.msg
@@ -1,0 +1,10 @@
+Since Riot 1.6, it uses Electron 8. This version of Electron has
+dropped support for the older XEmbed system tray API. If you are using
+a desktop or window manager that does not support StatusNotifierItems
+(i3, awesome, stalonetray, etc), you should install and configure
+snixembed:
+
+   xbps-install -S snixembed
+
+More instructions at: https://git.sr.ht/~steef/snixembed/
+

--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=1.6.2
+version=1.6.3
 revision=1
 archs="i686 x86_64"
 wrksrc="riot-web-${version}"
@@ -12,8 +12,8 @@ maintainer="projectmoon <projectmoon@agnos.is>"
 license="Apache-2.0"
 homepage="https://riot.im"
 distfiles="https://github.com/vector-im/riot-desktop/archive/v${version}.tar.gz>riot-desktop.tar.gz https://github.com/vector-im/riot-web/archive/v${version}.tar.gz>riot-web.tar.gz"
-checksum="509a2ac5376b25e6e88eb91d658aa38ca386533dcb84774fcf6918cfc6db822a
- 4f03f29ed15c1336f6582e4b04a37d9016e1dbeed0467b020ae380b78f39b874"
+checksum="2661db8e9e39f87e92ea37caeb9a96bb7c5bdea04ecb6db1bb096b913d80a5b8
+ 0334051674f11f05d0cc0bbc36424f9459a61a9f6cebea75c57b5c86c2d803db"
 nocross=yes
 nostrip=yes
 


### PR DESCRIPTION
This is a security update: https://blog.riot.im/developers-at-work/

Also added an `INSTALL.msg` about using snixembed on window managers that don't support StatusNotifierItems.