### PR TITLE
New package: bgpq3-0.1.35

### DIFF
--- a/srcpkgs/bgpq3/template
+++ b/srcpkgs/bgpq3/template
@@ -1,0 +1,17 @@
+# Template file for 'bgpq3'
+pkgname=bgpq3
+version=0.1.35
+revision=1
+build_style=gnu-configure
+short_desc="BGP filtering automation tool"
+maintainer="Adrian Pistol <vifino@tty.sh>"
+license="BSD-2-Clause"
+homepage="https://github.com/snar/bgpq3"
+distfiles="https://github.com/snar/bgpq3/archive/v${version}.tar.gz"
+checksum="571b99dc4186618ad3c77317eef2c20a8e601ce665a6b0f1ffca6e3d8d804cde"
+
+do_install() {
+	vbin bgpq3
+	vman bgpq3.8
+	vlicense COPYRIGHT
+}


### PR DESCRIPTION
This adds bgpq3's latest release. It allows generating prefix lists for BGP speaking devices.
I'll gladly maintain it. 