### PR TITLE
ffmpeg: enable JACK support

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.2.3
-revision=2
+revision=3
 short_desc="Decoding, encoding and streaming software"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="GPL-3.0-or-later"
@@ -66,7 +66,7 @@ do_configure() {
 		--enable-shared --enable-static --enable-libxcb \
 		$(vopt_enable pulseaudio libpulse) --enable-libfreetype --enable-libmodplug \
 		--enable-libspeex --enable-libcelt --enable-libass \
-		--enable-libopus --enable-librtmp  $(vopt_enable nvenc) \
+		--enable-libopus --enable-librtmp --enable-libjack  $(vopt_enable nvenc) \
 		$(vopt_if faac '--enable-nonfree --enable-libfaac') \
 		$(vopt_if fdk_aac '--enable-nonfree --enable-libfdk-aac') \
 		--disable-libopencore_amrnb --disable-libopencore_amrwb \


### PR DESCRIPTION
jack-devel was a makedepend already, but the configure argument hadn't
been set.

Retrying #22394 