### PR TITLE
musl-obstack: enable shared library

### DIFF
--- a/srcpkgs/musl-obstack/template
+++ b/srcpkgs/musl-obstack/template
@@ -1,10 +1,9 @@
 # Template file for 'musl-obstack'
 pkgname=musl-obstack
 version=1.1
-revision=3
+revision=4
 archs="*-musl"
 build_style=gnu-configure
-configure_args="--disable-shared"
 hostmakedepends="automake libtool"
 short_desc="Implementation of obstack for musl libc"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"


### PR DESCRIPTION
@pullmoll what do you think? I'm enabling it because I needed it for #22616, and I don't think there are any reasons for not building it.

That said, it could make sense now to split the package into a devel version as well, if we keep this change.