### PR TITLE
chromium: update to 83.0.4103.97.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=83.0.4103.61
+version=83.0.4103.97
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=adba3364137bfd377a590ba7256052f59faf34be6ff36e3d3d4ac467a60a51f2
+checksum=b32490fdb38db0ab0c35b07daab8bc1bfc27586dc3afb535e5f4e81e9f3f7f27
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,15 +1,15 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=83.0.4103.61
-revision=2
+version=83.0.4103.97
+revision=1
 archs="i686 x86_64*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=4961f20c4ee6a94490e823f1b1c4128147068f1ce9cfc509e81815f2101405bc
+checksum=12c405f61284cfc78f8c2b6600f3c1ae61a83b639c41087bb4f74fcaab036f83
 
 lib32disabled=yes
 nodebug=yes
@@ -165,7 +165,7 @@ do_configure() {
 		'enable_hangout_services_extension=true'
 		'is_desktop_linux=true'
 	)
-	
+
 	conf+=(
 		"use_vaapi=$(vopt_if vaapi true false)"
 	)
@@ -239,21 +239,31 @@ do_build() {
 do_install() {
 	vinstall out/Release/chrome 755 usr/lib/${pkgname} ${pkgname}
 	vinstall out/Release/chromedriver 755 usr/lib/${pkgname} chromedriver
+	vinstall out/Release/libEGL.so 755 usr/lib/${pkgname} libEGL.so
+	vinstall out/Release/libGLESv2.so 755 usr/lib/${pkgname} libGLESv2.so
 
-	cp out/Release/{*.pak,*.bin} ${DESTDIR}/usr/lib/chromium
-	cp -a out/Release/locales ${DESTDIR}/usr/lib/chromium
+	vcopy "out/Release/*.bin" usr/lib/chromium
+	vcopy "out/Release/*.pak" usr/lib/chromium
+
+	vmkdir usr/lib/chromium/locales
+	vcopy "out/Release/locales/*.pak" usr/lib/chromium/locales
+
+	vmkdir usr/lib/chromium/swiftshader
+	vcopy "out/Release/swiftshader/*.so" usr/lib/chromium/swiftshader
 
 	vinstall ${FILESDIR}/chromium.desktop 644 usr/share/applications
 
 	vinstall out/Release/icudtl.dat 0644 usr/lib/chromium
 
 	for size in 24 48 64 128 256; do
-		install -Dm644 "chrome/app/theme/chromium/product_logo_${size}.png" \
-		${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps/chromium.png
+		vinstall "chrome/app/theme/chromium/product_logo_${size}.png" \
+			644 \
+			usr/share/icons/hicolor/${size}x${size}/apps chromium.png
 	done
 	for size in 16 32; do
-		install -Dm644 "chrome/app/theme/default_100_percent/chromium/product_logo_${size}.png" \
-		${DESTDIR}/usr/share/icons/hicolor/${size}x${size}/apps/chromium.png
+		vinstall "chrome/app/theme/default_100_percent/chromium/product_logo_${size}.png" \
+			644 \
+			usr/share/icons/hicolor/${size}x${size}/apps chromium.png
 	done
 
 	vbin ${FILESDIR}/chromium.sh chromium


### PR DESCRIPTION
- Built for x86_64, x86_64-musl.
- Tested on x86_64.

- Add missing swiftshader libraries.
- Only copy *.pak locale files (don't need *.info).
- Use vcopy and vinstall instead of cp and install.

- Also update chromium-widevine.