### PR TITLE
font-iosevka: update to 3.1.1

### DIFF
--- a/srcpkgs/font-iosevka/template
+++ b/srcpkgs/font-iosevka/template
@@ -1,6 +1,6 @@
 # Template file for 'font-iosevka'
 pkgname=font-iosevka
-version=3.0.1
+version=3.1.1
 revision=1
 archs=noarch
 create_wrksrc=yes
@@ -14,8 +14,8 @@ distfiles="https://raw.githubusercontent.com/be5invis/Iosevka/v${version}/LICENS
  https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip
  https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-slab-${version}.zip"
 checksum="e61c0988bb231a321f14cce1b119a468f279ea86826c32e943ab16dbf08c1ba9
- 5e66198c71f5e4b6acb383faaf250af2251465342163b2d8ee2cb154995d844f
- 25fdff0897aec4b855ee84dfcf7bcbd38cae89aec1779c3231f45e5782565981"
+ 353b8e6fb8a3d28a8e359e83cc6c73cbbdd8fb4e77beed848d56b61c4276d3f6
+ f03f2d5d8456c9f744842b40b99b0bb6e12bb11f77bcfbbc5f4def5a028074d8"
 
 font_dirs="/usr/share/fonts/TTF"
 


### PR DESCRIPTION
This PR updates the package font-iosevka to version 3.1.1
https://github.com/be5invis/Iosevka/releases/tag/v3.1.1