### PR TITLE
borgmatic: add python3-requests to depends

### DIFF
--- a/srcpkgs/borgmatic/template
+++ b/srcpkgs/borgmatic/template
@@ -1,12 +1,12 @@
 # Template file for 'borgmatic'
 pkgname=borgmatic
 version=1.5.6
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="borg python3-setuptools python3-ruamel.yaml python3-pykwalify
- python3-colorama"
+ python3-colorama python3-requests"
 checkdepends="python3-ruamel.yaml python3-pytest python3-flexmock
  python3-pykwalify"
 short_desc="Wrapper script for the Borg backup software"


### PR DESCRIPTION
Adds necessary python3-requests as a dependency. Fails to run without, if you don't have it manually installed or via some other package's dependency.

Additionally noted as dependency here: https://github.com/witten/borgmatic/blob/795e18773b8cd1ef0b1b460e8fcd7b7a03fd3f97/setup.py#L34