### PR TITLE
dispcalGUI: add patch for error(3)

### DIFF
--- a/srcpkgs/dispcalGUI/patches/error.patch
+++ b/srcpkgs/dispcalGUI/patches/error.patch
@@ -1,0 +1,33 @@
+Reason: error(3) does not exist on musl, and on glibc the signature
+is (int, int, char*, ...) and not (char*, ...).
+Therefore the current code either results in garbled output or
+doesn't work at all. Replace it with a simple printf.
+
+---
+--- DisplayCAL/RealDisplaySizeMM.c	2018-07-25 16:47:01.000000000 +0200
++++ -	2020-06-07 22:27:10.984231905 +0200
+@@ -822,13 +822,13 @@
+ 						sprintf(desc1, "_ICC_PROFILE_%d",disps[ndisps]->uscreen);
+ 
+ 					if ((disps[ndisps]->icc_atom = XInternAtom(mydisplay, desc1, False)) == None)
+-						error("Unable to intern atom '%s'",desc1);
++						fprintf(stderr, "Unable to intern atom '%s'",desc1);
+ 
+ 					debugrr2((errout,"Root atom '%s'\n",desc1));
+ 
+ 					/* Create the atom of the output that may contain the associated ICC profile */
+ 					if ((disps[ndisps]->icc_out_atom = XInternAtom(mydisplay, "_ICC_PROFILE", False)) == None)
+-						error("Unable to intern atom '%s'","_ICC_PROFILE");
++						fprintf(stderr, "Unable to intern atom '%s'","_ICC_PROFILE");
+ 		
+ 					/* Grab the EDID from the output */
+ 					{
+@@ -993,7 +993,7 @@
+ 				sprintf(desc1, "_ICC_PROFILE_%d",disps[i]->uscreen);
+ 
+ 			if ((disps[i]->icc_atom = XInternAtom(mydisplay, desc1, False)) == None)
+-				error("Unable to intern atom '%s'",desc1);
++				fprintf(stderr, "Unable to intern atom '%s'",desc1);
+ 
+ 			/* See if we can locate the EDID of the monitor for this screen */
+ 			for (j = 0; j < 2; j++) { 

--- a/srcpkgs/dispcalGUI/template
+++ b/srcpkgs/dispcalGUI/template
@@ -1,7 +1,7 @@
 # Template file for 'dispcalGUI'
 pkgname=dispcalGUI
 version=3.8.9.3
-revision=1
+revision=2
 _name="DisplayCAL"
 wrksrc="${_name}-${version}"
 build_style=python2-module


### PR DESCRIPTION
Also if someone knows how to send a patch upstream, feel free to do so. (even the binaries inside the tarball link against the glibc error symbol, which is wrong)