### PR TITLE
mymcplus: add fix-glx-bad-context patch

### DIFF
--- a/srcpkgs/mymcplus/patches/fix-glx-bad-context.patch
+++ b/srcpkgs/mymcplus/patches/fix-glx-bad-context.patch
@@ -1,0 +1,11 @@
+Relax this attribute, otherwise GL context creation fails
+--- mymcplus/gui/icon_window.py.orig	2020-06-08 18:05:05.646326599 +0200
++++ mymcplus/gui/icon_window.py	2020-06-08 18:05:14.093326318 +0200
+@@ -121,7 +121,6 @@
+             glcanvas.WX_GL_RGBA,
+             glcanvas.WX_GL_DOUBLEBUFFER,
+             glcanvas.WX_GL_DEPTH_SIZE, 24,
+-            glcanvas.WX_GL_SAMPLES, 16
+         ]
+ 
+         self.sizer = wx.BoxSizer(wx.VERTICAL)

--- a/srcpkgs/mymcplus/template
+++ b/srcpkgs/mymcplus/template
@@ -1,7 +1,7 @@
 # Template file for 'mymcplus'
 pkgname=mymcplus
 version=3.0.2
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 pycompile_module="mymcplus"


### PR DESCRIPTION
The program was failing at startup with GLXBadContext for me and others before this.
Maybe it's not the proper fix but at least the program starts and I got it to display the 3D icon.