### PR TITLE
rhythmbox: optionalise brasero

### DIFF
--- a/srcpkgs/rhythmbox/template
+++ b/srcpkgs/rhythmbox/template
@@ -1,7 +1,7 @@
 # Template file for 'rhythmbox'
 pkgname=rhythmbox
 version=3.4.4
-revision=2
+revision=3
 build_style=gnu-configure
 build_helper=gir
 configure_args="--disable-static --with-gudev --without-hal
@@ -11,7 +11,7 @@ hostmakedepends="pkg-config intltool gnome-doc-utils itstool glib-devel
  $(vopt_if gir 'gobject-introspection vala')"
 makedepends="gtk+3-devel libsoup-gnome-devel totem-pl-parser-devel
  json-glib-devel libgudev-devel libdiscid-devel vala-devel
- libmtp-devel avahi-glib-libs-devel libpeas-devel brasero-devel
+ libmtp-devel avahi-glib-libs-devel libpeas-devel $(vopt_if brasero brasero-devel)
  libnotify-devel tdb-devel libsecret-devel libSM-devel grilo-devel
  gst-plugins-base1-devel clutter-gtk-devel python3-devel python-gobject-devel
  libdmapsharing-devel"
@@ -26,7 +26,8 @@ checksum=ee0eb0d7d7bdf696ac9471b19ff3bea3240d63b6cb8a134bf632054af8665d90
 python_version=3
 pycompile_dirs="/usr/lib/rhythmbox/plugins /usr/lib/rhythmbox/sample-plugins"
 
-build_options="gir"
+build_options="gir brasero"
+desc_option_brasero="Enable CD burning support"
 build_options_default="gir"
 
 pre_build() {


### PR DESCRIPTION
This PR adds a `build_option` for brasero and disables it by default. 

Note, `rhythmbox` from both [**Ubuntu**](https://packages.ubuntu.com/groovy/rhythmbox) and [**Debian**](https://packages.debian.org/sid/rhythmbox) repos doesn't have `brasero` as dependency. [**Arch Linux**](https://www.archlinux.org/packages/extra/x86_64/rhythmbox/) lists `brasero` as an optional dependency. But the one from Void repo pulls down `brasero` as hard dependency, which shouldn't be the case. 