### PR TITLE
ghostscript: fix cups build option.

### DIFF
--- a/srcpkgs/ghostscript/template
+++ b/srcpkgs/ghostscript/template
@@ -1,7 +1,7 @@
 # Template file for 'ghostscript'
 pkgname=ghostscript
 version=9.52
-revision=1
+revision=2
 short_desc="Interpreter for the PostScript language"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-or-later, CPL-1.0"
@@ -37,14 +37,14 @@ do_configure() {
 	# configure ghostscript
 	if [ "$CROSS_BUILD" ]; then
 		export CCAUX=cc CFLAGSAUX=${XBPS_CFLAGS}
+		export CUPSCONFIG=/usr/bin/cups-config
 	fi
 	./configure ${configure_args} --enable-dynamic --with-ijs \
 		--with-jbig2dec --with-omni --with-x --with-drivers=ALL \
 		--with-fontpath=/usr/share/fonts/Type1:/usr/share/fonts \
 		--enable-fontconfig --enable-freetype --enable-openjpeg \
 		--with-libpaper --without-luratech --without-omni \
-		--with-system-libtiff --disable-compile-inits \
-		$(vopt_if cups '' '--disable-cups')
+		--with-system-libtiff --disable-compile-inits $(vopt_enable cups)
 
 	# configure libijs
 	cd ijs


### PR DESCRIPTION
- Force --enable-cups so it fails without CUPS - it was instead
 compiling without CUPS support.
- Export CUPSCONFIG to fix cross compilation for CUPS.

Fixes #21662 