### PR TITLE
intel-ucode: update to 20200609, cleanup, claim maintainer

### DIFF
--- a/srcpkgs/intel-ucode/template
+++ b/srcpkgs/intel-ucode/template
@@ -1,27 +1,18 @@
 # Template file for 'intel-ucode'
 pkgname=intel-ucode
-version=20200508
+version=20200609
 revision=1
 archs="i686* x86_64*"
-_wrksrc_base="Intel-Linux-Processor-Microcode-Data-Files-microcode"
-wrksrc="${_wrksrc_base}-${version}"
+wrksrc="Intel-Linux-Processor-Microcode-Data-Files-microcode-${version}"
 short_desc="Microcode update files for Intel CPUs"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="custom: Proprietary"
 homepage="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files"
-distfiles="${homepage}/archive/microcode-${version}.tar.gz
- ${homepage}/archive/microcode-20190918.tar.gz"
-checksum="f5ed22de61be346fe28918eed196d052432e2af13a3d6eb5823d528ee9bbef81
- 2b6b728d351764dfbf6a9763ac96ae7e04085f382a309fed3abc0118f094c943"
+distfiles="${homepage}/archive/microcode-${version}.tar.gz"
+checksum=6c5295265abd03a7cdc815b85bff4f98387f813826a88935904bc2bbc783d5e4
 repository=nonfree
 
 do_install() {
-	# Replace buggy 06-55-04 microcode with last known good version
-	_bad_ucode="intel-ucode/06-55-04"
-	rm "$_bad_ucode"
-	cp "../${_wrksrc_base}-20190918/$_bad_ucode" "$_bad_ucode"
-
-	# Rest of process continues as normal
 	vmkdir usr/lib/firmware/intel-ucode
 	vcopy "intel-ucode/*" usr/lib/firmware/intel-ucode
 	vmkdir usr/lib/dracut/dracut.conf.d

--- a/srcpkgs/intel-ucode/update
+++ b/srcpkgs/intel-ucode/update
@@ -1,0 +1,1 @@
+pattern="microcode-\K[0-9]+(?=.tar)"


### PR DESCRIPTION
Looks like the buggy microcode issue is resolved, no need to fetch a known-good version anymore.