### PR TITLE
python3-pandas: rebuild for cross

### DIFF
--- a/srcpkgs/python3-pandas/template
+++ b/srcpkgs/python3-pandas/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pandas'
 pkgname=python3-pandas
 version=1.0.1
-revision=1
+revision=2
 wrksrc="pandas-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-Cython"
+hostmakedepends="python3-setuptools python3-Cython python3-numpy"
 makedepends="python3-devel python3-numpy python3-dateutil python3-pytz"
 depends="python3-numpy python3-dateutil python3-pytz"
 short_desc="Python3 data analysis library"


### PR DESCRIPTION
NumPy was in a nocross state last time pandas was built,
so pandas was only built for native arches.

Then for some reason it was pruned from the archives (?)
instead of being rebuilt.