### PR TITLE
python-pipenv: remove py3-only files from py2 package

### DIFF
--- a/srcpkgs/python-pipenv/template
+++ b/srcpkgs/python-pipenv/template
@@ -1,12 +1,11 @@
 # Template file for 'python-pipenv'
 pkgname=python-pipenv
 version=2020.6.2
-revision=1
+revision=2
 archs=noarch
 wrksrc="pipenv-${version}"
 build_style=python-module
 hostmakedepends="python-setuptools python3-setuptools"
-pycompile_module="pipenv"
 depends="python python-pip python-virtualenv python-virtualenv-clone"
 short_desc="Python Development Workflow for Humans"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -26,12 +25,16 @@ post_extract() {
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/python2*/site-packages/pipenv/patched/yaml3
 	vlicense LICENSE
+	# remove files only valid for Python 3
+	rm -f ${DESTDIR}/${py2_sitelib}/pipenv/vendor/importlib_resources/_py3.py
+	rm -f ${DESTDIR}/${py2_sitelib}/pipenv/vendor/jinja2/asyncsupport.py
+	rm -f ${DESTDIR}/${py2_sitelib}/pipenv/vendor/jinja2/asyncfilters.py
+	rm -f ${DESTDIR}/${py2_sitelib}/pipenv/vendor/pexpect/_async.py
 }
 
 python3-pipenv_package() {
 	archs=noarch
 	depends="python3 python3-pip python3-virtualenv python3-virtualenv-clone"
-	pycompile_module="pipenv"
 	short_desc="${short_desc/Python2/Python3}"
 	alternatives="
 	 pipenv:pipenv:/usr/bin/pipenv3


### PR DESCRIPTION
`pipenv` installs a few files in `$py2_sitelib` that are only valid for Python 3, so byte compilation during XBPS configuration of the package emits errors. Removing these files in the Python 2 package suppresses the errors.

Also removed `pycompile_module` to make `xlint` happy.

cc: @leahneukirchen 