### PR TITLE
travis/changed_templates: correct left tree-ish

### DIFF
--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -9,7 +9,9 @@ elif command -v git >/dev/null 2>&1; then
 fi
 
 /bin/echo -e '\x1b[32mChanged packages:\x1b[0m'
-$GIT_CMD diff-tree -r --no-renames --name-only --diff-filter=AM FETCH_HEAD HEAD -- 'srcpkgs/*/template' |
+$GIT_CMD diff-tree -r --no-renames --name-only --diff-filter=AM \
+	"$(git merge-base FETCH_HEAD HEAD)" HEAD \
+	-- 'srcpkgs/*/template' |
 	cut -d/ -f 2 |
 	tee /tmp/templates |
 	sed "s/^/  /" >&2


### PR DESCRIPTION
From b881f32687 (travis/changed_templates: filter by git itself,
2020-05-23), we replaced git-diff(1) with git-diff-tree(1).

The change wasn't equivalence, thought.
We used to compare between merge-base of FETCH_HEAD and HEAD.
From that commit, we compare FETCH_HEAD and HEAD instead.

Fix them by changing left tree-ish to the merge-base.