### PR TITLE
sdcc: enable cross and add nonfree build option.

### DIFF
--- a/srcpkgs/sdcc/template
+++ b/srcpkgs/sdcc/template
@@ -1,10 +1,11 @@
 # Template file for 'sdcc'
 pkgname=sdcc
 version=4.0.0
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="--enable-libgc $(vopt_enable nonfree non-free)"
 hostmakedepends="automake flex bison gputils texinfo"
-makedepends="boost-devel zlib-devel"
+makedepends="boost-devel zlib-devel gc-devel"
 short_desc="Retargettable ANSI C compiler"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later"
@@ -13,8 +14,20 @@ distfiles="${SOURCEFORGE_SITE}/sdcc/${pkgname}-src-${version}.tar.bz2"
 checksum=489180806fc20a3911ba4cf5ccaf1875b68910d7aed3f401bbd0695b0bef4e10
 python_version=3
 nostrip=yes
-nocross=yes
+
+build_options="nonfree"
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="code generator internal error"
 fi
+
+if [ "$CROSS_BUILD" ]; then
+	configure_args+=" --disable-device-lib"
+	hostmakedepends+=" sdcc"
+fi
+
+post_install() {
+	if [ "$CROSS_BUILD" ]; then
+		vcopy /usr/share/sdcc usr/share
+	fi
+}


### PR DESCRIPTION
- Enabling cross is done by disabling building the device libraries
during packaging.
- Some PIC headers and files are nonfree, so they shouldn't be
included in the free version.
- Add gc-devel for better memory behavior.

So, it doesn't automatically build a device lib if it needs one, which means it's a bit useless in this state (I think). Should we ship it in this state? The example I've found online for cross compiling uses the native builder to create the libraries and then copies that over.

https://github.com/ekawahyu/sdcc-CC2530/blob/master/sdcc-build-for-windows-from-osx.sh