### PR TITLE
Add vtargetrun (run executables with qemu) and vcompletion (install helper for shell completions);  use them in rustup and starship

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -337,6 +337,13 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	Note that vsed will call the sed command for every regex specified against
 	every file specified, in the order that they are given.
 
+- *vcompletion()* `<file> <shell> [<command>]`
+
+	Installs shell completion from `file` for `command`, in the correct location
+	and with the appropriate filename for `shell`. If `command` isn't specified,
+	it will default to `pkgname`. The `shell` argument can be one of `bash`,
+	`fish` or `zsh`.
+
 > Shell wildcards must be properly quoted, Example: `vmove "usr/lib/*.a"`.
 
 <a id="global_vars"></a>

--- a/Manual.md
+++ b/Manual.md
@@ -970,7 +970,9 @@ additional paths to be searched when linking target binaries to be introspected.
 - `qemu` sets additional variables for the `cmake` and `meson` build styles to allow
 executing cross-compiled binaries inside qemu.
 It sets `CMAKE_CROSSCOMPILING_EMULATOR` for cmake and `exe_wrapper` for meson
-to `qemu-<target_arch>-static` and `QEMU_LD_PREFIX` to `XBPS_CROSS_BASE`
+to `qemu-<target_arch>-static` and `QEMU_LD_PREFIX` to `XBPS_CROSS_BASE`.
+It also creates the `vtargetrun` function to wrap commands in a call to
+`qemu-<target_arch>-static` for the target architecture.
 
 - `qmake` creates the `qt.conf` configuration file (cf. `qmake` `build_style`)
 needed for cross builds and a qmake-wrapper to make `qmake` use this configuration.

--- a/common/build-helper/qemu.sh
+++ b/common/build-helper/qemu.sh
@@ -4,3 +4,11 @@ if [ "$CROSS_BUILD" ]; then
 		hostmakedepends+=" qemu-user-static"
 	fi
 fi
+
+vtargetrun() {
+	if [ "$CROSS_BUILD" ]; then
+		"/usr/bin/qemu-${XBPS_TARGET_QEMU_MACHINE}-static" "$@"
+	else
+		"$@"
+	fi
+}

--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -13,7 +13,7 @@ _noglob_helper() {
 }
 
 # Apply _noglob to v* commands
-for cmd in vinstall vcopy vmove vmkdir vbin vman vdoc vconf vsconf vlicense vsv; do
+for cmd in vinstall vcopy vcompletion vmove vmkdir vbin vman vdoc vconf vsconf vlicense vsv; do
        alias ${cmd}="set -f; _noglob_helper _${cmd}"
 done
 
@@ -257,4 +257,32 @@ _vmkdir() {
 	else
 		install -dm${mode} ${_destdir}/${dir}
 	fi
+}
+
+_vcompletion() {
+	local file="$1" shell="$2" cmd="${3:-${pkgname}}"
+	local _bash_completion_dir=usr/share/bash-completion/completions/
+	local _fish_completion_dir=usr/share/fish/vendor_completions.d/
+	local _zsh_completion_dir=usr/share/zsh/site-functions/
+
+	if [ -z "$DESTDIR" ]; then
+		msg_red "$pkgver: vcompletion: DESTDIR unset, can't continue...\n"
+		return 1
+	fi
+
+	if [ $# -lt 2 ]; then
+		msg_red "$pkgver: vcompletion: 2 arguments expected: <file> <shell>\n"
+		return 1
+	fi
+
+	if ! [ -f "$file" ]; then
+		msg_red "$pkgver: vcompletion: file $file doesn't exist\n"
+	fi
+
+	case "$shell" in
+		bash) vinstall "$file" 0644 $_bash_completion_dir "${cmd}" ;;
+		fish) vinstall "$file" 0644 $_fish_completion_dir "${cmd}.fish" ;;
+		zsh) vinstall "$file" 0644 $_zsh_completion_dir "_${cmd}" ;;
+		*) msg_red "$pkgver: vcompletion: unknown shell ${shell}" ;;
+	esac
 }

--- a/srcpkgs/rustup/template
+++ b/srcpkgs/rustup/template
@@ -1,8 +1,9 @@
 # Template file for 'rustup'
 pkgname=rustup
 version=1.22.1
-revision=1
+revision=2
 build_style=cargo
+build_helper=qemu
 configure_args="--features no-self-update --bin rustup-init"
 hostmakedepends="pkg-config"
 makedepends="libressl-devel zlib-devel libcurl-devel"
@@ -13,19 +14,25 @@ homepage="https://www.rustup.rs"
 distfiles="https://github.com/rust-lang/${pkgname}/archive/${version}.tar.gz"
 checksum=ad46cc624f318a9493aa62fc9612a450564fe20ba93c689e0ad856bff3c64c5b
 
+post_build() {
+	# rustup errors out because it doesn't know about armv6l-musl
+	if [ "$XBPS_TARGET_MACHINE" != armv6l-musl ]; then
+		RUSTUP="target/${RUST_TARGET}/release/rustup-init"
+		ln -sf "$RUSTUP" rustup
+		# generate shell completions
+		vtargetrun ./rustup completions zsh >rustup.zsh
+		vtargetrun ./rustup completions bash >rustup.bash
+		vtargetrun ./rustup completions fish >rustup.fish
+	fi
+}
+
 do_install() {
 	vbin target/${RUST_TARGET}/release/rustup-init
 
-	if ! [ "$CROSS_BUILD" ]; then
-		# generate shell completions
-		ln -s target/${RUST_TARGET}/release/rustup-init rustup
-		./rustup completions zsh > rustup.zsh
-		./rustup completions bash > rustup.bash
-		./rustup completions fish > rustup.fish
-
-		vinstall rustup.zsh 0644 usr/share/zsh/site-functions/ _rustup
-		vinstall rustup.bash 0644 usr/share/bash-completion/completions/ rustup
-		vinstall rustup.fish 0644 usr/share/fish/vendor_completions.d/
+	if [ "$XBPS_TARGET_MACHINE" != armv6l-musl ]; then
+		vcompletion rustup.bash bash
+		vcompletion rustup.fish fish
+		vcompletion rustup.zsh zsh
 	fi
 
 	vdoc README.md

--- a/srcpkgs/starship/template
+++ b/srcpkgs/starship/template
@@ -3,7 +3,7 @@ pkgname=starship
 version=0.44.0
 revision=1
 build_style=cargo
-build_helper="rust"
+build_helper=qemu
 hostmakedepends="pkg-config"
 makedepends="libgit2-devel"
 checkdepends="git"
@@ -14,9 +14,12 @@ homepage="https://starship.rs"
 distfiles="https://github.com/starship/starship/archive/v${version}.tar.gz"
 checksum=b002fa0e2b34ad59330a543461a51648751db4ae8d439d58065a3b9656772fe3
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qemu-user-static"
-fi
+post_build() {
+	STARSHIP="target/${RUST_TARGET}/release/starship"
+	vtargetrun ${STARSHIP} completions zsh  >starship.zsh
+	vtargetrun ${STARSHIP} completions bash >starship.bash
+	vtargetrun ${STARSHIP} completions fish >starship.fish
+}
 
 pre_check() {
 	[ -L target/debug ] && unlink target/debug
@@ -24,19 +27,9 @@ pre_check() {
 }
 
 post_install() {
-	STARSHIP="target/${RUST_TARGET}/release/starship"
-	if [ "$CROSS_BUILD" ]; then
-		export QEMU_LD_PREFIX=${XBPS_CROSS_BASE}
-		STARSHIP="/usr/bin/qemu-${XBPS_TARGET_QEMU_MACHINE}-static ${STARSHIP}"
-	fi
-
-	${STARSHIP} completions zsh  >starship.zsh
-	${STARSHIP} completions bash >starship.bash
-	${STARSHIP} completions fish >starship.fish
-
-	vinstall starship.zsh 0644 usr/share/zsh/site-functions/ _starship
-	vinstall starship.bash 0644 usr/share/bash-completion/completions/ starship
-	vinstall starship.fish 0644 usr/share/fish/vendor_completions.d/
+	vcompletion starship.bash bash
+	vcompletion starship.fish fish
+	vcompletion starship.zsh zsh
 
 	vlicense LICENSE
 }


### PR DESCRIPTION
Inspired by #22761 . Pinging @sgn 

Not revbumping because I don't think it's urgent. I could see the case for making this procedure part of the cargo build style, configurable with some variable like `clap_completions=yes`.

If you feel it adds too much complexity for little gain, I can close the PR.