### PR TITLE
pinebookpro-kernel: update to 5.7

### DIFF
--- a/srcpkgs/pinebookpro-kernel/template
+++ b/srcpkgs/pinebookpro-kernel/template
@@ -1,18 +1,18 @@
 # Template file for 'pinebookpro-kernel'
 pkgname=pinebookpro-kernel
-version=5.6.0
+version=5.7.0
 revision=1
-_commit=93293259039d6fc3a725961d42b4f11bfc3f5127
+archs="aarch64*"
+_commit=a8f4db8a726e5e4552e61333dcd9ea1ff35f39f9
 wrksrc="linux-pinebook-pro-${_commit}"
 short_desc="Linux kernel for Pinebook Pro (${version%.*} series)"
 maintainer="Renato Aguiar <renato@renatoaguiar.net>"
 license="GPL-2.0-only"
 homepage="https://www.kernel.org"
 distfiles="https://gitlab.manjaro.org/tsys/linux-pinebook-pro/-/archive/${_commit}/linux-pinebook-pro-${_commit}.tar.gz"
-checksum=61f59cd28fa560f939917f1c1315fecce0db4b1bf0a5b64296cd9aaee9f0adb1
+checksum=c76b54d62bdf58e40497846fe7cf236d9a923eeb7972c97d41a917329843268b
 patch_args="-Np1"
-
-archs="aarch64*"
+python_version=3
 
 nodebug=yes  # -dbg package is generated below manually
 nostrip=yes


### PR DESCRIPTION
python_version needs to be set, same as in the normal kernel package