### PR TITLE
blender: update to 2.83.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3933,7 +3933,7 @@ libtinyclipboard.so.1 tinyclipboard-16.01_1
 libcbor.so.0.7 libcbor-0.7.0_1
 libfido2.so.1 libfido2-1.3.0_1
 libjanet.so.1.9 janet-1.9.0_1
-libOpenImageDenoise.so.0 openimagedenoise-1.1.0_1
+libOpenImageDenoise.so.0 openimagedenoise-1.2.0_1
 libcbang0.so cbang-1.3.3_1
 libblosc.so.1 c-blosc-1.17.1_1
 libopenvdb.so.7.0 openvdb-7.0.0_1

--- a/srcpkgs/blender/patches/musl.patch
+++ b/srcpkgs/blender/patches/musl.patch
@@ -73,3 +73,18 @@ diff -ru blender-2.78.orig/source/creator/creator_signals.c blender-2.78a/source
      defined(__GLIBC__)
  #  include <malloc.h>
  #  define HAVE_MALLOC_STATS
+--- a/intern/libc_compat/libc_compat.c
++++ b/intern/libc_compat/libc_compat.c
+@@ -21,10 +21,10 @@
+  * incompatible with the system libraries that Blender is built on. To solve
+  * this we add a few -ffast-math symbols that can be missing. */
+ 
+-#ifdef __linux__
+ #  include <features.h>
+ #  include <math.h>
+ 
++#ifdef __GLIBC__
+ #  if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 31)
+ 
+ double __exp_finite(double x);
+ 

--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -1,7 +1,7 @@
 # Template file for 'blender'
 pkgname=blender
-version=2.82
-revision=3
+version=2.83.0
+revision=1
 build_style="cmake"
 makedepends="
  libgomp-devel libpng-devel tiff-devel python3-devel glu-devel
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.blender.org"
 distfiles="http://download.blender.org/source/${pkgname}-${version}.tar.xz"
-checksum=002adf2c51fc58a8941c87fc8e180bb1aacb73a0c223714f36d3d84da345fc65
+checksum=14e2bc85e076b12ae94438ff3c1dd417eba642840ed32d7c979724a93aa93f1f
 patch_args="-Np1"
 
 python_version=3

--- a/srcpkgs/ispc/template
+++ b/srcpkgs/ispc/template
@@ -2,10 +2,10 @@
 pkgname=ispc
 version=1.13.0
 revision=1
-archs="x86_64"
+archs="x86_64*"
 build_style=cmake
 configure_args="-DISPC_NO_DUMPS=ON -DARM_ENABLED=OFF"
-hostmakedepends="clang python3 m4 bison flex llvm"
+hostmakedepends="clang clang-tools-extra python3 m4 bison flex llvm"
 makedepends="ncurses-devel zlib-devel"
 short_desc="Compiler for high-performance SIMD programming on the CPU"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"

--- a/srcpkgs/openimagedenoise/patches/fix-build.patch
+++ b/srcpkgs/openimagedenoise/patches/fix-build.patch
@@ -1,0 +1,26 @@
+From e321d7c90a2c706a521a3afd8913af36b121dc9e Mon Sep 17 00:00:00 2001
+From: Attila Afra <attila.t.afra@intel.com>
+Date: Sat, 11 Apr 2020 22:53:30 +0300
+Subject: [PATCH] fixed compile error for future ISPC versions
+
+---
+ core/math.ih | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git core/math.ih core/math.ih
+index 37ee9629..353d6cfb 100644
+--- core/math.ih
++++ core/math.ih
+@@ -7,10 +7,12 @@
+ // Types
+ // -----------------------------------------------------------------------------
+ 
++#ifndef ISPC_UINT_IS_DEFINED
+ typedef unsigned int8  uint8;
+ typedef unsigned int16 uint16;
+ typedef unsigned int32 uint32;
+ typedef unsigned int64 uint64;
++#endif
+ 
+ // -----------------------------------------------------------------------------
+ // Constants

--- a/srcpkgs/openimagedenoise/patches/fix-sse-4.1-crash.patch
+++ b/srcpkgs/openimagedenoise/patches/fix-sse-4.1-crash.patch
@@ -1,0 +1,65 @@
+From 79ab63df9a2a0229af581050a59e0fdcdbae2e51 Mon Sep 17 00:00:00 2001
+From: Attila Afra <attila.t.afra@intel.com>
+Date: Tue, 9 Jun 2020 23:26:39 +0300
+Subject: [PATCH] fixed crash on pre-SSE4 CPUs when using some recent compilers
+ (e.g. GCC 10)
+
+---
+ cmake/oidn_dnnl.cmake     | 2 +-
+ cmake/oidn_platform.cmake | 5 -----
+ 2 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git cmake/oidn_dnnl.cmake cmake/oidn_dnnl.cmake
+index 42d1cf6..cbfb935 100644
+--- cmake/oidn_dnnl.cmake
++++ cmake/oidn_dnnl.cmake
+@@ -45,7 +45,7 @@ target_compile_definitions(dnnl_common
+     -DDNNL_ENABLE_CONCURRENT_EXEC
+ )
+ 
+-set(DNNL_COMPILE_OPTIONS ${OIDN_ISA_FLAGS_SSE41})
++set(DNNL_COMPILE_OPTIONS "")
+ if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+   # Correct 'jnl' macro/jit issue
+   list(APPEND DNNL_COMPILE_OPTIONS "/Qlong-double")
+diff --git cmake/oidn_platform.cmake cmake/oidn_platform.cmake
+index 10b8cae..5256da2 100644
+--- cmake/oidn_platform.cmake
++++ cmake/oidn_platform.cmake
+@@ -34,7 +34,6 @@ if(MSVC)
+     append(OIDN_C_CXX_FLAGS "/wd4244")
+   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+     append(OIDN_C_CXX_FLAGS "/MP")
+-    set(OIDN_ISA_FLAGS_SSE41 "-QxSSE4.1")
+     # Disable warning: option '/Qstd=c++11' is not valid for C compilations (CMake bug?)
+     append(OIDN_C_CXX_FLAGS "/Qwd10370")
+     # Disable diagnostic: loop was not vectorized with "simd"
+@@ -48,7 +47,6 @@ if(MSVC)
+     # Disable diagnostic: disabling user-directed function packaging (COMDATs)
+     append(OIDN_C_CXX_FLAGS "-Qdiag-disable:11031")
+   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(OIDN_ISA_FLAGS_SSE41 "-msse4.1")
+     # Disable warning: cannot vectorize some loops with #pragma omp simd
+     append(OIDN_C_CXX_FLAGS "-Wno-pass-failed")
+     # Disable warning: function is not needed and will not be emitted
+@@ -60,17 +58,14 @@ elseif(UNIX OR MINGW)
+   append(OIDN_C_CXX_FLAGS "-fvisibility=internal")
+   append(OIDN_CXX_FLAGS "-fvisibility-inlines-hidden")
+   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    set(OIDN_ISA_FLAGS_SSE41 "-msse4.1")
+     # Disable warning: cannot vectorize some loops with #pragma omp simd
+     append(OIDN_C_CXX_FLAGS "-Wno-pass-failed")
+     # Disable warning: function is not needed and will not be emitted
+     append(OIDN_C_CXX_FLAGS "-Wno-unneeded-internal-declaration")
+   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+-    set(OIDN_ISA_FLAGS_SSE41 "-msse4.1")
+     # Suppress warning on assumptions made regarding overflow (#146)
+     append(OIDN_C_CXX_FLAGS "-Wno-strict-overflow")
+   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+-    set(OIDN_ISA_FLAGS_SSE41 "-xSSE4.1")
+     # Disable optimizations in debug mode
+     append(OIDN_C_CXX_FLAGS_DEBUG "-O0")
+     # Workaround for ICC that produces error caused by pragma omp simd collapse(..)
+-- 
+2.27.0
+

--- a/srcpkgs/openimagedenoise/template
+++ b/srcpkgs/openimagedenoise/template
@@ -1,18 +1,18 @@
 # Template file for 'openimagedenoise'
 pkgname=openimagedenoise
-version=1.1.0
+version=1.2.0
 revision=1
 archs="x86_64*"
 wrksrc=oidn-${version}
 build_style=cmake
-hostmakedepends="python3"
+hostmakedepends="ispc python3"
 makedepends="tbb-devel"
 short_desc="Intel(R) Open Image Denoise library"
 maintainer="teldra <teldra@rotce.de>"
 license="Apache-2.0"
 homepage="https://openimagedenoise.github.io"
 distfiles="https://github.com/OpenImageDenoise/oidn/releases/download/v${version}/oidn-${version}.src.tar.gz"
-checksum=4dd484abea8a0b3d12d346343fcb1ab7abef8f94318d8c537f69a20c2a75c4eb
+checksum=041f59758e79f4ea29a9b7a952f2c096426820678a5a713880b6d8a6519a75d0
 
 openimagedenoise-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Smoke-tested on `x86_64`. Testers on other platforms and on CPUs without SSE 4.1 welcome.