### PR TITLE
youtube-viewer: fix gtk binaries spilling into the base package

### DIFF
--- a/srcpkgs/youtube-viewer/template
+++ b/srcpkgs/youtube-viewer/template
@@ -1,7 +1,7 @@
 # Template file for 'youtube-viewer'
 pkgname=youtube-viewer
 version=3.7.6
-revision=1
+revision=2
 archs=noarch
 build_style=perl-ModuleBuild
 configure_args="--gtk"
@@ -20,8 +20,8 @@ gtk-youtube-viewer_package() {
 	depends="${sourcepkg}-${version}_${revision} perl-Gtk2 perl-File-ShareDir"
 	short_desc="Gtk interface to search and stream videos from YouTube"
 	pkg_install() {
-		vmove usr/bin/gtk-youtube-viewer
-		vmove "usr/share/perl5/vendor_perl/auto/share/dist/WWW-YoutubeViewer/gtk-*"
+		vmove "usr/bin/gtk*-youtube-viewer"
+		vmove "usr/share/perl5/vendor_perl/auto/share/dist/WWW-YoutubeViewer/gtk*"
 		vmove usr/share/perl5/vendor_perl/auto/share/dist/WWW-YoutubeViewer/icons
 	}
 }


### PR DESCRIPTION
upstream seems to have changed some file names. there's now gtk2-* and gtk3-* glade files and binaries. `gtk-youtube-viewer` is just a launcher that auto detectes which gtk perl module is installed