### PR TITLE
Update checksum for a corrected release of zfsbootmenu

### DIFF
--- a/srcpkgs/zfsbootmenu/template
+++ b/srcpkgs/zfsbootmenu/template
@@ -1,7 +1,7 @@
 # Template file for 'zfsbootmenu'
 pkgname=zfsbootmenu
 version=1.1
-revision=1
+revision=2
 archs=noarch
 build_style=gnu-makefile
 conf_files="/etc/zfsbootmenu/config.ini"
@@ -11,7 +11,7 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="MIT"
 homepage="https://github.com/zdykstra/zfsbootmenu"
 distfiles="https://github.com/zdykstra/zfsbootmenu/archive/v${version}.tar.gz"
-checksum=d8cb5d263b53eab6f619eb27adb5572d3f616ab71ad51eaa2a0231b85079d77f
+checksum=4d22eff0fd504b04dbcd4464e5d6e36a016d58ac5db55fc71dae81fb67843b67
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
I missed a small change in the v1.1 release, so I re-tagged it and preserved the version. This corrects the checksum for the new archive.