### PR TITLE
Vulkan-*: update to 1.2.141 (and update required deps)

### DIFF
--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,13 +1,12 @@
 # Template file for 'SPIRV-Headers'
 pkgname=SPIRV-Headers
-version=1.5.1
-revision=2
-wrksrc="${pkgname}-${version}.corrected"
+version=1.5.3
+revision=1
 archs=noarch
 build_style=cmake
 short_desc="Machine-readable files for the SPIR-V Registry"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/KhronosGroup/SPIRV-Headers"
-distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/${version}.corrected.tar.gz"
-checksum=2b6a0ce1c02b9fe7b9ef727369168fe579e5256f1ea013993acdb8d8f06b7e89
+distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/${version}.tar.gz"
+checksum=eece8a9e147d37997d425d5d2eeb2e757ad25adc30d6651467094f3b18609b5a

--- a/srcpkgs/SPIRV-Tools/template
+++ b/srcpkgs/SPIRV-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-Tools'
 pkgname=SPIRV-Tools
-version=2020.1
+version=2020.3
 revision=1
 build_style=cmake
 configure_args="-DSPIRV_SKIP_TESTS=ON -DSPIRV_WERROR=OFF
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/SPIRV-Tools"
 distfiles="https://github.com/KhronosGroup/SPIRV-Tools/archive/v${version}.tar.gz"
-checksum=1eaa5e09c638d7113b60d825e6ce44406b35031be68db894a016b5faf45de568
+checksum=8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b
 
 SPIRV-Tools-devel_package() {
 	depends="SPIRV-Tools-${version}_${revision}"

--- a/srcpkgs/Vulkan-Headers/template
+++ b/srcpkgs/Vulkan-Headers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Headers'
 pkgname=Vulkan-Headers
-version=1.2.137
+version=1.2.141
 revision=1
 archs=noarch
 wrksrc="${pkgname}-${version}"
@@ -10,4 +10,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${version}.tar.gz"
-checksum=dcf378bab5e316b9aaf40d089945d04fbff5c9abeddf8e584a8439b2d1dbd30a
+checksum=328a4b04e5e9206db64c4da543e725be551c486b91bb4d74a253fc115f83b4c8

--- a/srcpkgs/Vulkan-Tools/template
+++ b/srcpkgs/Vulkan-Tools/template
@@ -1,11 +1,11 @@
 # Template file for 'Vulkan-Tools'
 pkgname=Vulkan-Tools
-version=1.2.137
+version=1.2.141
 revision=1
 wrksrc="${pkgname}-${version}"
 build_style=cmake
 configure_args="-DGLSLANG_INSTALL_DIR=/usr -DBUILD_CUBE=$(vopt_if cube ON OFF)
- -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr"
+ -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr -Wno-dev"
 hostmakedepends="python3 pkg-config $(vopt_if cube glslang)"
 makedepends="Vulkan-Headers vulkan-loader libxcb-devel libxkbcommon-devel
  wayland-devel libXrandr-devel"
@@ -14,7 +14,7 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=4b9e0aab8e873282a7163b3e9966928188c06697002f8f1ce0c567a06a1b5fda
+checksum=2570421840e18e97a596ffbbfdf0609e85e3450e48110ca6714a46f41a0a44b5
 
 build_options="cube"
 desc_option_cube="Build cube vulkan demo"

--- a/srcpkgs/Vulkan-ValidationLayers/template
+++ b/srcpkgs/Vulkan-ValidationLayers/template
@@ -1,21 +1,16 @@
 # Template file for 'Vulkan-ValidationLayers'
 pkgname=Vulkan-ValidationLayers
-version=1.2.137
+version=1.2.141
 revision=1
 build_style=cmake
-configure_args="-C ${XBPS_CROSS_BASE}/tmp/helper.cmake
- -DCMAKE_INSTALL_INCLUDEDIR=/usr/include/vulkan/ -DBUILD_LAYER_SUPPORT_FILES=ON"
-hostmakedepends="python3 git pkg-config"
-makedepends="libXrandr-devel wayland-devel"
+configure_args="-Wno-dev -DGLSLANG_INSTALL_DIR=${XBPS_CROSS_BASE}/usr
+ -DBUILD_LAYER_SUPPORT_FILES=ON"
+hostmakedepends="pkg-config"
+makedepends="Vulkan-Headers libXrandr-devel wayland-devel glslang-devel
+ SPIRV-Tools-devel SPIRV-Headers"
 short_desc="Khronos official Vulkan validation layers"
 maintainer="Colin Gillespie <colin@breavyn.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=54d9abf5faf0a554bbb88c82b81d44b98849018da33f25537f4a86ea1f25ba28
-
-pre_configure() {
-	# Fetch and compile "known good" versions of dependencies
-	./scripts/update_deps.py --dir=${XBPS_CROSS_BASE}/tmp
-	# NOTE: this directory won't be cleaned by xbps-src clean
-}
+checksum=3f2ebc5c0d69ead2031893f5c5da9bb4f328a90d30c1665a618a637a48d27ee0

--- a/srcpkgs/glslang/template
+++ b/srcpkgs/glslang/template
@@ -1,6 +1,6 @@
 # Template file for 'glslang'
 pkgname=glslang
-version=7.13.3496
+version=8.13.3743
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/KhronosGroup/glslang"
 distfiles="https://github.com/KhronosGroup/glslang/archive/${version}.tar.gz"
-checksum=170d1538a670af4cae300e875d7cda9744b1acee1ab7252ecf7c4004186bb922
+checksum=639ebec56f1a7402f2fa094469a5ddea1eceecfaf2e9efe361376a0f73a7ee2f
 
 post_install() {
 	sed -n '2,32p' < glslang/GenericCodeGen/CodeGen.cpp > LICENSE

--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,11 +1,12 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
 _pkgname=Vulkan-Loader
-version=1.2.137
+version=1.2.141
 revision=1
 wrksrc="${_pkgname}-${version}"
 build_style=cmake
-configure_args="-DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr -DBUILD_TESTS=OFF"
+configure_args="-Wno-dev -DVULKAN_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr
+ -DBUILD_TESTS=OFF"
 hostmakedepends="python3 pkg-config"
 makedepends="Vulkan-Headers libxcb-devel libxkbcommon-devel wayland-devel
  libXrandr-devel"
@@ -14,4 +15,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/v${version}.tar.gz"
-checksum=098a59996fcb32daeda6423fa3fb8a74cff532ec37b33235601ac06f0df00485
+checksum=0117afacc1f92c92c2b7c52839d2abacb0105480f54e0b93df25ae6b1e6d00d2


### PR DESCRIPTION
A notable change is that `Vulkan-ValidationLayers` can now build with the system wide dependencies provided by void packages. The workaround introduced in https://github.com/void-linux/void-packages/pull/16772 was very ugly, as it was fetching and compiling the dependencies (that are not so light) in `/tmp`