### PR TITLE
Fix imv and renameutils man page conflict

### DIFF
--- a/srcpkgs/imv/template
+++ b/srcpkgs/imv/template
@@ -1,7 +1,7 @@
 # Template file for 'imv'
 pkgname=imv
 version=4.1.0
-revision=2
+revision=3
 build_style=gnu-makefile
 hostmakedepends="asciidoc pkg-config"
 makedepends="cmocka-devel freeimage-devel glu-devel librsvg-devel libxkbcommon-devel
@@ -18,5 +18,8 @@ checksum=8c2f1baa4dce8bf1f6d1fb9dea8cf1da09fdf2c6de0f7030e91714df2ebcdf50
 conflicts="renameutils>=0"
 
 post_install() {
+	# copy the man page so it isn't clobbered by renameutils in man.voidlinux.org
+	vman "${DESTDIR}/usr/share/man/man1/imv.1" imv-x11.1
+	ln -s imv-x11.1 "${DESTDIR}/usr/share/man/man1/imv-wayland.1"
 	vlicense LICENSE
 }


### PR DESCRIPTION
Unfortunately the packages have the `imv` binary in common, so we can't make them not conflict at all. This fix is for man.voidlinux.org, instead.

Fixes #22856 