### PR TITLE
vivaldi: update to 3.1.1929.34.

### DIFF
--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -1,9 +1,10 @@
 # Template file for 'vivaldi'
 pkgname=vivaldi
-version=3.1.1929.29
+version=3.1.1929.34
 revision=1
 _release=1
 archs="i686 x86_64"
+hostmakedepends="curl python3-html2text python3-setuptools"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Advanced browser made with the power user in mind"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
@@ -17,13 +18,14 @@ nostrip=yes
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	_debarch=amd64
-	checksum=5413e091ceb7051bf0bfcfa4eb5af80af096d63702bbe220d5f35ad72cbf1c30
+	checksum=fa748302e5792198d26debf4fdb744e128598201bd9b91bf17edc1d16350aa73
 else
 	_debarch=i386
-	checksum=a1ad613d1d4b62f6b6860c9c2fee08abc7270ec1eac6b6acddbd7c1e7d6dc881
+	checksum=51f25a1b8a7a89b05579e5911ffba568f91f7e345b17f22f8db2f1a987ec9ad2
 fi
 
 distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_${_debarch}.deb"
+_licenseUrl="https://vivaldi.com/privacy/vivaldi-end-user-license-agreement/"
 
 do_extract() {
 	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/vivaldi-stable_${version}-${_release}_${_debarch}.deb
@@ -47,4 +49,11 @@ do_install() {
 		vinstall opt/vivaldi/product_logo_${res}.png 0644 \
 			usr/share/icons/hicolor/${res}x${res}/apps vivaldi.png
 	done
+}
+
+post_install() {
+	curl ${_licenseUrl} \
+		| sed -n '/main id="main"/,/\/main/p' \
+			| html2text > EULA.md
+	vlicense EULA.md
 }


### PR DESCRIPTION
Shipping the EULA from https://vivaldi.com/privacy/vivaldi-end-user-license-agreement/ with the package (that will silence `xlint`).

Stole the idea from `google-chrome`'s [template](https://github.com/void-linux/void-packages/blob/master/srcpkgs/google-chrome/template#L53) :stuck_out_tongue_winking_eye: