### PR TITLE
i3status-rust: add man page and changelog.

### DIFF
--- a/srcpkgs/i3status-rust/template
+++ b/srcpkgs/i3status-rust/template
@@ -1,7 +1,7 @@
 # Template file for 'i3status-rust'
 pkgname=i3status-rust
 version=0.14.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="dbus-devel pulseaudio-devel"
@@ -9,5 +9,10 @@ short_desc="Replacement for i3status, written in Rust"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/greshake/i3status-rust"
+changelog="https://raw.githubusercontent.com/greshake/i3status-rust/master/NEWS.md"
 distfiles="https://github.com/greshake/i3status-rust/archive/v${version}.tar.gz"
 checksum=bd22d28b8c3d35c93610b9f46a04fe49a92d62a466dbf0669ceb6b77943c5406
+
+post_install() {
+	vman man/i3status-rs.1
+}


### PR DESCRIPTION
I didn't revbump since it seems like they regularly release every 3 months.
Will change if requested.