### PR TITLE
New packages: ashuffle-3.5.1, abseil-cpp-20200225.2; gtest: update to 0.10.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1777,6 +1777,8 @@ libMrm.so.2 lesstif-0.95.2_1
 libUil.so.2 lesstif-0.95.2_1
 libgtest.so gtest-1.7.0_1
 libgtest_main.so gtest-1.7.0_1
+libgmock.so gtest-1.10.0_1
+libgmock_main.so gtest-1.10.0_1
 libxmlsec1-gcrypt.so.1 xmlsec1-1.2.20_2
 libxmlsec1-gnutls.so.1 xmlsec1-1.2.20_2
 libefivar.so.1 libefivar-31_1

--- a/srcpkgs/abseil-cpp/patches/fix-musl.patch
+++ b/srcpkgs/abseil-cpp/patches/fix-musl.patch
@@ -1,0 +1,13 @@
+diff --git absl/debugging/internal/stacktrace_config.h absl/debugging/internal/stacktrace_config.h
+index d4e8480..ee1ba54 100644
+--- absl/debugging/internal/stacktrace_config.h
++++ absl/debugging/internal/stacktrace_config.h
+@@ -40,7 +40,7 @@
+ # elif defined(__aarch64__)
+ #define ABSL_STACKTRACE_INL_HEADER \
+     "absl/debugging/internal/stacktrace_aarch64-inl.inc"
+-# elif defined(__arm__)
++# elif defined(__arm__) && defined(__GLIBC__)
+ // Note: When using glibc this may require -funwind-tables to function properly.
+ #define ABSL_STACKTRACE_INL_HEADER \
+   "absl/debugging/internal/stacktrace_generic-inl.inc"

--- a/srcpkgs/abseil-cpp/template
+++ b/srcpkgs/abseil-cpp/template
@@ -1,0 +1,14 @@
+# Template file for 'abseil-cpp'
+pkgname=abseil-cpp
+version=20200225.2
+revision=1
+build_style=cmake
+configure_args="-H. -DCMAKE_CXX_STANDARD=17 -DABSL_RUN_TESTS=ON
+ -DABSL_USE_GOOGLETEST_HEAD=ON"
+hostmakedepends="git"
+short_desc="Abseil Common Libraries (C++)"
+maintainer="Kartik Singh <kartik.ynwa@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/abseil/abseil-cpp"
+distfiles="https://github.com/abseil/abseil-cpp/archive/${version}.tar.gz"
+checksum="f41868f7a938605c92936230081175d1eae87f6ea2c248f41077c8f88316f111"

--- a/srcpkgs/ashuffle/patches/fix-type-warning.patch
+++ b/srcpkgs/ashuffle/patches/fix-type-warning.patch
@@ -1,0 +1,13 @@
+diff --git src/ashuffle.cc src/ashuffle.cc
+index 53f6bc0..5c222e4 100644
+--- src/ashuffle.cc
++++ src/ashuffle.cc
+@@ -159,7 +159,7 @@ void Loop(mpd::MPD *mpd, ShuffleChain *songs, const Options &options,
+             songs->Clear();
+             MPDLoader loader(mpd, options.ruleset);
+             loader.Load(songs);
+-            printf("Picking random songs out of a pool of %lu.\n", songs->Len());
++            printf("Picking random songs out of a pool of %lu.\n", (long unsigned int)songs->Len());
+         } else if (events.Has(MPD_IDLE_QUEUE) || events.Has(MPD_IDLE_PLAYER)) {
+             TryEnqueue(mpd, songs, options);
+         }

--- a/srcpkgs/ashuffle/template
+++ b/srcpkgs/ashuffle/template
@@ -1,0 +1,20 @@
+# Template file for 'ashuffle'
+pkgname=ashuffle
+version=3.5.2
+revision=1
+build_style=meson
+configure_args="--buildtype=release -Dtests=enabled -Dunsupported_use_system_absl=true
+ -Dunsupported_use_system_gtest=true"
+hostmakedepends="pkg-config"
+makedepends="libmpdclient-devel abseil-cpp gtest-devel"
+depends="libmpdclient"
+short_desc="Automatic library-wide shuffle for mpd"
+maintainer="Kartik Singh <kartik.ynwa@gmail.com>"
+license="MIT"
+homepage="https://github.com/Joshkunz/ashuffle"
+distfiles="https://github.com/joshkunz/ashuffle/archive/v${version}.tar.gz"
+checksum=febcdf6f27db1efee72c1b6e654a7095eaff8fea3bd3765c85f5467dfb19c93b
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/gtest/template
+++ b/srcpkgs/gtest/template
@@ -1,6 +1,6 @@
 # Template file for 'gtest'
 pkgname=gtest
-version=1.8.1
+version=1.10.0
 revision=1
 wrksrc="googletest-release-${version}"
 build_style=cmake
@@ -11,7 +11,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/google/googletest"
 distfiles="https://github.com/google/googletest/archive/release-${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+checksum=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
[ci_skip] [ci-skip]

Input on `configure_args` for `abseil-cpp` would be appreciated.