### PR TITLE
lvm2: include required symlinks in device-mapper pkg

### DIFF
--- a/srcpkgs/lvm2/template
+++ b/srcpkgs/lvm2/template
@@ -1,7 +1,7 @@
 # Template file for 'lvm2'
 pkgname=lvm2
 version=2.02.187
-revision=1
+revision=2
 wrksrc="LVM2.${version}"
 build_style=gnu-configure
 configure_args="--disable-selinux --enable-readline --enable-pkgconfig
@@ -60,7 +60,9 @@ device-mapper-devel_package() {
 		vmove usr/include/libdevmapper-event.h
 		vmove usr/include/lvm2cmd.h
 		vmove usr/lib/liblvm2cmd.so
-		vmove "usr/lib/libdevmapper*.so"
+		vmove "usr/lib/libdevmapper.so"
+		vmove "usr/lib/libdevmapper-event.so"
+		vmove "usr/lib/libdevmapper-event-lvm2.so"
 		case $XBPS_TARGET_MACHINE in
 			*-musl) vmove "usr/lib/*.a";;
 		esac
@@ -74,6 +76,7 @@ device-mapper_package() {
 		vmove "usr/lib/libdevmapper*.so.*"
 		vmove "usr/lib/liblvm2cmd.so.*"
 		vmove "usr/share/man/man8/dm*"
+		vmove usr/lib/libdevmapper-event-lvm2?*.so
 		vmove usr/lib/device-mapper
 		for f in 10-dm 13-dm-disk 95-dm-notify; do
 			vmove usr/lib/udev/rules.d/${f}.rules


### PR DESCRIPTION
Without these, monitoring raid1 LVs fails unless one installs `device-mapper-devel`. The log message is:
```
dmeventd libdevmapper-event-lvm2raid.so dlopen failed: libdevmapper-event-lvm2raid.so: cannot open shared object file: No such file or directory.
```

More details: the current `device-mapper` package includes:
```
/usr/lib/device-mapper/libdevmapper-event-lvm2mirror.so
/usr/lib/device-mapper/libdevmapper-event-lvm2raid.so
/usr/lib/device-mapper/libdevmapper-event-lvm2snapshot.so
/usr/lib/device-mapper/libdevmapper-event-lvm2thin.so
/usr/lib/device-mapper/libdevmapper-event-lvm2vdo.so
/usr/lib/libdevmapper-event-lvm2.so.2.02
/usr/lib/libdevmapper-event.so.1.02
/usr/lib/libdevmapper.so.1.02
/usr/lib/liblvm2cmd.so.2.02
```
while the current `device-mapper-devel` package includes:
```
/usr/lib/libdevmapper-event-lvm2.so -> /usr/lib/libdevmapper-event-lvm2.so.2.02
/usr/lib/libdevmapper-event-lvm2mirror.so -> /usr/lib/device-mapper/libdevmapper-event-lvm2mirror.so
/usr/lib/libdevmapper-event-lvm2raid.so -> /usr/lib/device-mapper/libdevmapper-event-lvm2raid.so
/usr/lib/libdevmapper-event-lvm2snapshot.so -> /usr/lib/device-mapper/libdevmapper-event-lvm2snapshot.so
/usr/lib/libdevmapper-event-lvm2thin.so -> /usr/lib/device-mapper/libdevmapper-event-lvm2thin.so
/usr/lib/libdevmapper-event-lvm2vdo.so -> /usr/lib/device-mapper/libdevmapper-event-lvm2vdo.so
/usr/lib/libdevmapper-event.so -> /usr/lib/libdevmapper-event.so.1.02
/usr/lib/libdevmapper.so -> /usr/lib/libdevmapper.so.1.02
/usr/lib/liblvm2cmd.so -> /usr/lib/liblvm2cmd.so.2.02
```

I claim all the symlinks for `libdevmapper-event-lvm2?*.so` should go into `device-mapper` pkg, which is what this PR does. Note the question mark, since I believe `libdevmapper-event-lvm2.so` should still go into `device-mapper-devel`.