### PR TITLE
dwarffortress: fix checksum of the main exec

### DIFF
--- a/srcpkgs/dwarffortress/template
+++ b/srcpkgs/dwarffortress/template
@@ -1,7 +1,7 @@
 # Template file for 'dwarffortress'
 pkgname=dwarffortress
 version=0.47.04
-revision=1
+revision=2
 _urlver=${version#*.}
 archs="x86_64"
 create_wrksrc=yes
@@ -13,11 +13,12 @@ homepage="http://www.bay12games.com/dwarves/"
 distfiles="http://www.bay12games.com/dwarves/df_${_urlver//./_}_linux.tar.bz2"
 checksum=1de5872bf3ac32906a0082129ec88d6879b6ac7059a3513607d628090b1328e6
 
+nostrip_files="Dwarf_Fortress"
 nopie="distfiles are precompiled as PIE"
 repository=nonfree
 
 do_patch() {
-	vsed -i df_linux/df -e "s;./libs/Dwarf_Fortress;LD_PRELOAD=/usr/lib/libstdc++.so.6 ./libs/Dwarf_Fortress;"
+	rm df_linux/libs/libstdc++.so.6
 }
 
 do_install() {


### PR DESCRIPTION
Some community tools as Dwarf Therapist or DFhacks uses the main exec md5 to determine the dwarf fortress version.

xbps-src lib strip step was changing this md5 causing impossibility for those tools to works.

I also removed the libstdc++.so.6 lib cause it is a cleaner way than force preload the os one in the start script.