### PR TITLE
python3-bokeh: update to 2.1.0.

### DIFF
--- a/srcpkgs/python3-bokeh/template
+++ b/srcpkgs/python3-bokeh/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-bokeh'
 pkgname=python3-bokeh
-version=2.0.2
+version=2.1.0
 revision=1
 archs=noarch
 wrksrc="${pkgname#*-}-${version}"
@@ -16,12 +16,9 @@ short_desc="Interactive data visualization in a browser, from Python"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/bokeh/bokeh"
+changelog="https://raw.githubusercontent.com/bokeh/bokeh/master/CHANGELOG"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=42d66cad60a52779fda0a321ca4453ec1e08ae31053c68ce82f1af874a5ef97b
-
-if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
-	broken="triggers segfault in npm"
-fi
+checksum=b4704a51c3a3b32710852f5eec31b4890c043e9db6c1247483c83a21c501d376
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
Looks like i686 works in the process, so unbreaking that.