### PR TITLE
[WIP] py-spy: update to 0.3.3.

### DIFF
--- a/srcpkgs/py-spy/template
+++ b/srcpkgs/py-spy/template
@@ -1,13 +1,14 @@
 # Template file for 'py-spy'
 pkgname=py-spy
-version=0.1.11
-# other archs can't compile remoteprocess
-archs="x86_64* i686*"
+version=0.3.11
 revision=1
 build_style=cargo
+makedepends="libunwind-devel"
+checkdepends="python3"
 short_desc="Sampling profiler for Python programs"
 maintainer="Wilson Birney <wpb@360scada.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/benfred/py-spy"
 distfiles="https://github.com/benfred/py-spy/archive/v${version}.tar.gz"
-checksum=399a1be66414c2f1a3d57b20d1b219393e0dfd5370815b2c0d1406fa0886917e
+checksum=094cfb80e2c099763453fc39cfa9c46cfa423afa858268c6a7bc0d867763b014
+make_check=extended


### PR DESCRIPTION
Trying to see if it works for other archs now. 

I get this error at least for `aarch64`:

    aarch64-linux-gnu-objdump: warning: /destdir/aarch64-linux-gnu/py-spy-0.3.3/usr/bin/py-spy: unsupported GNU_PROPERTY_TYPE (5) type: 0xc0000000

