### PR TITLE
xarchiver: rebuild against gtk3

### DIFF
--- a/srcpkgs/xarchiver/template
+++ b/srcpkgs/xarchiver/template
@@ -1,13 +1,13 @@
 # Template file for 'xarchiver'
 pkgname=xarchiver
 version=0.5.4.15
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--disable-doc"
+configure_args="--disable-doc --enable-gtk2=no"
 hostmakedepends="pkg-config intltool"
-makedepends="gtk+-devel"
+makedepends="gtk+3-devel"
 depends="xdg-utils desktop-file-utils hicolor-icon-theme"
-short_desc="GTK+2 lightweight desktop independent archive manager"
+short_desc="Lightweight desktop independent archive manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ib/xarchiver"


### PR DESCRIPTION
Gtk2 is not really supported by gnome anymore.\
Also, this fixes theming on KDE-Plasma.