### PR TITLE
New package: rsvd-user-1.0

### DIFF
--- a/srcpkgs/rsvd-user/template
+++ b/srcpkgs/rsvd-user/template
@@ -1,0 +1,17 @@
+# Template file for 'rsvd-user'
+pkgname=rsvd-user
+version=1.0
+revision=1
+make_dirs="/etc/rsvd-user 755 root root"
+depends="runit"
+short_desc="User runsvdir daemons framework"
+maintainer="danoloan10 <danoloan10@tutanota.com>"
+license="Public Domain"
+homepage="https://github.com/danoloan10/rsvd-user/"
+distfiles="https://github.com/danoloan10/rsvd-user/archive/v${version}.tar.gz"
+checksum=fc17a479fba95612c8bf3722ebe5b57a15430009694ca1bd7c3b7e0eb8dcc397
+
+do_install() {
+	vmkdir etc
+	vcopy etc/* etc
+}


### PR DESCRIPTION
This meta package enables per-user daemonization through `runsvdir`. When a user logs in, `runsvdir` is run on `$HOME/.cache/sv/`. Subsequent logins won't do anything. The provided service `logmon` (see `/etc/rsvd-user/logmon`) monitors when the user is not logged in anymore. 

To enable system-wide services that should be run in all user's sessions, they can be added in the `/etc/rsvd-user/` directory as one would do to enable a service on void.