### PR TITLE
fetchmail: fix and split fetchmailconf, update to python3, adopt

### DIFF
--- a/srcpkgs/fetchmail/template
+++ b/srcpkgs/fetchmail/template
@@ -1,15 +1,28 @@
 # Template file for 'fetchmail'
 pkgname=fetchmail
 version=6.4.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-ssl=${XBPS_CROSS_BASE}/usr"
-hostmakedepends="python-devel"
+hostmakedepends="python3"
 makedepends="libressl-devel"
-depends="python"
+depends="fetchmailconf"
 short_desc="Remote-mail retrieval utility"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="GPL-2.0-only"
 homepage="http://fetchmail.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=26cd936ece146e056cdf79a676a33738b4eab0a5ae2edf3fce5ba034721b09bd
+
+post_install() {
+	vsed -i -e 's,/usr/bin/python ,/usr/bin/python3 ,' "${DESTDIR}/usr/bin/fetchmailconf"
+}
+
+fetchmailconf_package() {
+	depends="python3-future python3-tkinter"
+	pkg_install() {
+		vmove usr/bin/fetchmailconf
+		vmove usr/share/man/man1/fetchmailconf.1
+		vmove "${py3_sitelib}"
+	}
+}

--- a/srcpkgs/fetchmailconf
+++ b/srcpkgs/fetchmailconf
@@ -1,0 +1,1 @@
+fetchmail


### PR DESCRIPTION
Idea of split is that dependencies of fetchmailconf are big in comparision to fetchmail itself, can be excluded from minimal installations with ignorepkg.