### PR TITLE
xbps-src: fix python shebang rewriting for itstool

### DIFF
--- a/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
+++ b/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
@@ -20,7 +20,7 @@ hook() {
 		while IFS= read -r -d '' file; do
 			[ ! -s "$file" ] && continue
 
-			pyinterp=$(sed -n -E -e 2q -e 's@^#!.*([[:space:]]|/)(python([0-9](\.[0-9]+)?)?)([[:space:]]+|$)@\2@p' "$file")
+			pyinterp=$(sed -n -E -e 2q -e 's@^#!.*([[:space:]]|/)(python([0-9](\.[0-9]+)?)?)([[:space:]]+.*|$)@\2@p' "$file")
 			[ -z "$pyinterp" ] && continue
 
 			pyver=${pyinterp#python}

--- a/srcpkgs/itstool/template
+++ b/srcpkgs/itstool/template
@@ -1,7 +1,7 @@
 # Template file for 'itstool'
 pkgname=itstool
 version=2.0.6
-revision=2
+revision=3
 archs=noarch
 build_style=gnu-configure
 configure_args="PYTHON=/usr/bin/python3"


### PR DESCRIPTION
User @fosslinux reported an issue with the python shebang in the `itstool` package caused by the recent change in version-detection behavior: the shebang `#!/usr/bin/python3 -s` is mistakenly changed to `#!/usr/bin/python3-s` (no space).

The hook has been changed so that all arguments following the python shebang are consumed by the match. This causes `#!/usr/bin/python3 -s` to be rewritten as `#!/usr/bin/python3`. While it would be nice to detect and preserve arguments, I haven't yet found a clean and robust way to do this.

The behavior in this PR is at least consistent with prior behavior (which always discarded additional arguments), while still preserving the improved version detection.

cc: @Chocimier 