### PR TITLE
Update brother-brscan3 package

### DIFF
--- a/srcpkgs/brother-brscan3/template
+++ b/srcpkgs/brother-brscan3/template
@@ -1,26 +1,29 @@
 # Template file for 'brother-brscan3'
 pkgname=brother-brscan3
-version=0.2.11
-revision=6
-maintainer="Carlo Dormeletti <carloDOTdormelettiATaliceDOTit>"
-homepage="http://support.brother.com/g/b/index.aspx"
-license="GPL-2"
-short_desc="Scanner driver for the brother DCP-197C printer/scanner"
+version=0.2.13
+revision=1
 archs="i686 x86_64"
-makedepends="sane-devel"
-depends="sane"
 create_wrksrc=yes
+hostmakedepends="tar"
+makedepends="sane-devel curl"
+depends="sane"
+short_desc="SANE scanner driver for brscan3-compatible Brother scanners"
+maintainer="Carlo Dormeletti <carlo.dormeletti@alice.it.invalid>"
+license="custom:BrotherEULA"
+homepage="http://support.brother.com/g/b/index.aspx"
 nopie=yes
+nodebug=yes
+_license_checksum=4ab8b9269a74377ee85458cc4dfbacfbf6d26665426572fe16f7102af214bd3c
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-	distfiles="http://download.brother.com/welcome/dlf006642/brscan3-${version}-5.amd64.deb"
-	checksum="cce23bd9481f0fb3856e6c1fecdb65d7b21d1efb74e1741ef6185fa952319beb"
-	debpkgid="5.amd64"
+	debpkgid="1.amd64"
+	distfiles="http://download.brother.com/welcome/dlf006642/brscan3-${version}-${debpkgid}.deb"
+	checksum="446adf531bf39032892e9504ce34b7bf889e0f8628c0732cebb3b83fafb327b8"
 	mylibdir="lib64"
 elif [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
-	distfiles="http://download.brother.com/welcome/dlf006641/brscan3-${version}-4.i386.deb"
-	checksum="3d2c8aace27a694c0984c6a1913fb2ebbd6cfd7a46bcdce3d54ae3693009d835"
-	debpkgid="4.i386"
+	debpkgid="1.i386"
+	distfiles="http://download.brother.com/welcome/dlf006641/brscan3-${version}-${debpkgid}.deb"
+	checksum="ad06665cac32035893f614d9305dabf73145af454f1aeb6b8b7c7fa2700fe2e6"
 	mylibdir="lib"
 fi
 
@@ -41,4 +44,22 @@ do_install() {
 	ln -sf /usr/lib/libbrscandec3.so.1.0.0 ${DESTDIR}/usr/lib/libbrscandec3.so
 	vmkdir /opt/Brother
 	vcopy "./usr/local/Brother/*" /opt/Brother/
+	vlicense LICENSE
+}
+
+post_extract() {
+	curl -sk https://support.brother.com/g/s/agreement/English_lpr/agree.html | \
+		sed -n \
+			-e 's,</\?p>,,' \
+			-e 's/\&quot;/"/g' \
+			-e 's, \?^M,,' \
+			-e 's,^[ \t]\+,,' \
+			-e '14,18p' \
+			-e '28,45p' \
+		> LICENSE
+
+	filesum="$(xbps-digest LICENSE)"
+	if [ "$filesum" != "$_license_checksum" ]; then
+		msg_error "SHA256 mismatch for LICENSE:\n$filesum\n"
+	fi
 }


### PR DESCRIPTION
Bump version to latest available binary blob from manufacturer.
Drop building debug package, libs are stripped at the source.
Make description like brscan4 package, since this package targets for
multiple Brother devices.
Avoid repetitions when assembling distfiles URL.