### PR TITLE
openconnect: update to 8.10.

### DIFF
--- a/srcpkgs/openconnect/template
+++ b/srcpkgs/openconnect/template
@@ -1,6 +1,6 @@
 # Template file for 'openconnect'
 pkgname=openconnect
-version=8.05
+version=8.10
 revision=1
 build_style=gnu-configure
 configure_args="--with-vpnc-script=/usr/libexec/vpnc-scripts/vpnc-script"
@@ -13,8 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="http://www.infradead.org/openconnect/"
 distfiles="ftp://ftp.infradead.org/pub/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=335c2952d0cb36822acb112eaaf5e3b4acffc6874985fb614fec0b76c4c12992
-python_version=2 #unverified
+checksum=30e64c6eca4be47bbf1d61f53dc003c6621213738d4ea7a35e5cf1ac2de9bab1
 
 openconnect-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Improved version detection for python shebangs makes `python_version` unnecessary, so remove that too.