### PR TITLE
nss: update to 3.53.1.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.25
 
 pkgname=nss
-version=3.53
+version=3.53.1
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=08d36dc1a56325f02e626626d4eeab9c4d126dbd99dfaf419b91d0a696f58917
+checksum=2dccde67079b25c4e95ac3121f11b2819c37cf8c48ca263a45d8f83f7a315316
 
 do_build() {
 	local _native_use64 _target_use64


### PR DESCRIPTION
- [x] `xbps-src check` on x86_64 (WIP)
- [x] `xbps-src check` on x86_64 on qemu `-cpu SandyBridge` (WIP)
- [x] `xbps-src check` on x86_64-musl
- [ ] manual testing
