### PR TITLE
zfs: trigger dracut on install and remove patch artifacts

### DIFF
--- a/srcpkgs/zfs/INSTALL
+++ b/srcpkgs/zfs/INSTALL
@@ -1,0 +1,13 @@
+case "${ACTION}" in
+post)
+	if [ -x usr/bin/dracut ]; then
+		# Include new modules in all initramfs instances when possible,
+		# as simultaneous updates of linux and zfs may trigger creation
+		# of images without modules and unable to boot from ZFS pools. 
+		#
+		# See https://github.com/void-linux/void-packages/issues/22817
+		echo "Regenerating initramfs, please wait..."
+		usr/bin/dracut -f -q --regenerate-all
+	fi
+	;;
+esac

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=0.8.4
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d
@@ -26,6 +26,9 @@ pre_configure() {
 	autoreconf -fi
 	# configure relies on bashism to redirect stdout/stderr when building tests
 	sed -i '1 s@^#!\s*/bin/sh$@#!/bin/bash@' configure
+
+	# Prevent patch artifacts from being installed
+	rm -f dkms.patch scripts/dkms.mkconf.orig
 	tar czf ../clean.tar.gz .
 }
 


### PR DESCRIPTION
These changes work around the reconfiguration ordering issue #22817 and remove the patch artifact in #22347. Note that there was an additional artifact, `dkms.mkconf.orig`, that is now gone as well.

cc: @Vaelatern 