### PR TITLE
xbps-src: fix do_clean

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -753,11 +753,12 @@ case "$XBPS_TARGET" in
             if [ -n "$CHROOT_READY" -a -z "$IN_CHROOT" ]; then
                 chroot_handler $XBPS_TARGET $XBPS_TARGET_PKG || exit $?
             else
-                remove_pkg_wrksrc
-                remove_pkg_statedir
                 if declare -f do_clean >/dev/null; then
                     run_func do_clean
                 fi
+                remove_pkg_autodeps
+                remove_pkg_wrksrc
+                remove_pkg_statedir
             fi
             remove_pkg $XBPS_CROSS_BUILD
         fi


### PR DESCRIPTION
It has to be run _before_ remove_pkg_statedir.

Fixes the following bug:
```
$ ./xbps-src extract zfs
...
$ ./xbps-src clean zfs
=> zfs-0.8.4_2: cleaning build directory...
=> zfs-0.8.4_2: running do_clean ...
mkfifo: cannot create fifo '/builddir/.xbps-zfs/zfs__0DLLrI5V.logpipe': No such file or directory
=> ERROR: zfs-0.8.4_2: do_clean: 'mkfifo "$logpipe"' exited with 1
=> ERROR:   in run_func() at common/xbps-src/shutils/common.sh:17
=> ERROR:   in main() at xbps-src:760
```