### PR TITLE
runelite-launcher: update to 2.1.3.

### DIFF
--- a/srcpkgs/runelite-launcher/template
+++ b/srcpkgs/runelite-launcher/template
@@ -1,6 +1,6 @@
 # Template file for 'runelite-launcher'
 pkgname=runelite-launcher
-version=1.6.2
+version=2.1.3
 revision=1
 archs=noarch
 wrksrc="launcher-${version}"
@@ -11,7 +11,7 @@ maintainer="Matteo Signer <matteo.signer@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://runelite.net"
 distfiles="https://github.com/runelite/launcher/archive/${version}.tar.gz"
-checksum=97c579a6a409eb9db8eca33061d7df71fade8e1ef4df3b245e3c90e2f01e6e1b
+checksum=164125d77eb67c936dff43da7d395fbb3a8d948312097cd4f0075ccca4beaf37
 
 do_build() {
 	mvn package


### PR DESCRIPTION
Despite the launcher auto-updating, this fixes the buggy gpu plugin for amdgpu using the mesa driver