### PR TITLE
kodi-18.7.1: Fix DPMS behaviour

### DIFF
--- a/srcpkgs/kodi/patches/fix-dpms.patch
+++ b/srcpkgs/kodi/patches/fix-dpms.patch
@@ -1,0 +1,24 @@
+diff --git a/xbmc/windowing/X11/WinSystemX11.cpp b/xbmc-18.7.1-Leia/xbmc/windowing/X11/WinSystemX11.cpp
+index 8b0c56579b..5db641efbd 100644
+--- a/xbmc/windowing/X11/WinSystemX11.cpp
++++ b/xbmc/windowing/X11/WinSystemX11.cpp
+@@ -26,6 +26,7 @@
+ #include "messaging/ApplicationMessenger.h"
+ #include <X11/Xatom.h>
+ #include <X11/extensions/Xrandr.h>
++#include "Application.h"
+ 
+ #include "WinEventsX11.h"
+ #include "input/InputManager.h"
+@@ -557,8 +558,10 @@ void CWinSystemX11::NotifyXRREvent()
+   {
+     UpdateResolutions();
+   }
+-
++  if (!g_application.IsDPMSActive())
++  {
+     RecreateWindow();
++  }
+ }
+ 
+ void CWinSystemX11::RecreateWindow()

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=18.7.1
-revision=1
+revision=2
 _codename="Leia"
 wrksrc="xbmc-${version}-${_codename}"
 build_style=cmake
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.kodi.tv"
 distfiles="https://github.com/xbmc/xbmc/archive/${version}-${_codename}.tar.gz"
 checksum=5cfec391bcd168bbd4f9d38a6c8ec93e42e040cf82cf6ebf23db5e86753816fb
-python_version=2 #unverified
+python_version=2
 patch_args="-Np1"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 


### PR DESCRIPTION
Change to only recreate window when dpms is being disabled due to it
not working when the window is recreated as it is going into powersaving
on the display.

without the patch if you wait for the screen to go into powersaving (takes 5mins) or if you use
```xset dpms force off``` it will turn back on every time after approximately 12secs, with the patch it behaves as expected and stays off

also verified that python2 is required, specifically python >= 2.7

after discussing the issue on the kodi freenode irc chatroom i was stuck listening to a 5minute rant on "ricer" distros like void/arch and that everyone should be using librelec as such i have not pushed this to upstream yet, however looking at the commit logs for this particular part of code it seems the intention was that the code should only be run when dpms is being disabled so this patch just changes it to the intended behaviour