### PR TITLE
gdb: avoid byte-compiling python2-only files

### DIFF
--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -1,9 +1,9 @@
 # Template file for 'gdb'
 pkgname=gdb
 version=9.2
-revision=1
+revision=2
 build_style=gnu-configure
-pycompile_dirs="/usr/share/gdb"
+pycompile_dirs="/usr/share/gdb/python"
 configure_args="--disable-werror --disable-nls --with-system-readline
  --with-system-gdbinit=/etc/gdb/gdbinit --with-system-zlib $(vopt_enable gdbserver)
  $(vopt_if static 'CFLAGS=-static CXXFLAGS=-static LDFLAGS=-static')


### PR DESCRIPTION
Almost all of the python "helpers" that ship with gdb are compatible with python3, but two files use old print syntax and are therefore not byte-compilable with python3: `/usr/share/gdb/system-gdbinit/elinos.py` and `/usr/share/gdb/system-gdbinit/wrs-linux.py`. These are environment initializers for ELinOS and WRS/Linux that are probably not useful on Void. In any case, if they are useful, users can install python2 manually to use them.

We shouldn't peg gdb to python2 just to make these two files byte-compilable at install time.