### PR TITLE
desktop-file-utils: update to 0.26.

### DIFF
--- a/srcpkgs/desktop-file-utils/template
+++ b/srcpkgs/desktop-file-utils/template
@@ -1,13 +1,14 @@
 # Template file for 'desktop-file-utils'
 pkgname=desktop-file-utils
-version=0.24
+version=0.26
 revision=1
-build_style=gnu-configure
+build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libglib-devel"
 short_desc="Utilities to manage desktop entries"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/desktop-file-utils"
+changelog="https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/raw/master/NEWS"
 distfiles="${FREEDESKTOP_SITE}/${pkgname}/releases/${pkgname}-${version}.tar.xz"
-checksum=a1de5da60cbdbe91e5c9c10ac9afee6c3deb019e0cee5fdb9a99dddc245f83d9
+checksum=b26dbde79ea72c8c84fb7f9d870ffd857381d049a86d25e0038c4cef4c747309


### PR DESCRIPTION
- Update to 0.26.
- Use meson - the autotools-based build system is deprecated since 0.25 and will be removed.