### PR TITLE
iwd: add ead service.

### DIFF
--- a/srcpkgs/iwd/files/ead/run
+++ b/srcpkgs/iwd/files/ead/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+[ -r ./conf ] && . conf
+exec /usr/libexec/ead "${OPTS}"

--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,7 +1,7 @@
 # Template file for 'iwd'
 pkgname=iwd
 version=1.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
  --enable-external-ell --enable-dbus-policy --enable-wired"
@@ -17,6 +17,7 @@ changelog="https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeL
 distfiles="${KERNEL_SITE}/network/wireless/${pkgname}-${version}.tar.xz"
 checksum=3c5074576f12a6f0f601aaa0f13863379ae4956f32d9d0937542025a4c136a8f
 make_dirs="/var/lib/iwd 0600 root root
+ /var/lib/ead 0600 root root
  /etc/iwd 755 root root"
 
 pre_configure() {
@@ -24,5 +25,6 @@ pre_configure() {
 }
 
 post_install() {
+	vsv ead
 	vsv iwd
 }


### PR DESCRIPTION
Service inspired by
https://git.kernel.org/pub/scm/network/wireless/iwd.git/tree/wired/ead.service.in

Fix #22589. 