### PR TITLE
nheko: rebuild against qt5-5.15.0

### DIFF
--- a/srcpkgs/nheko/template
+++ b/srcpkgs/nheko/template
@@ -1,7 +1,7 @@
 # Template file for 'nheko'
 pkgname=nheko
 version=0.7.2
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="qt5-host-tools qt5-qmake pkg-config qt5-declarative"
 makedepends="qt5-multimedia-devel qt5-svg-devel qt5-tools-devel


### PR DESCRIPTION
After qt5 update chat windows were blank and logs said.
```
[qml] [warning] qrc:/qml/TimelineView.qml: File was compiled ahead of time with an incompatible version of Qt and the original file cannot be found. Please recompile
````
Rebuilding against `qt5-5.15.0` fixed it.