### PR TITLE
urlwatch: update to 2.21

### DIFF
--- a/srcpkgs/urlwatch/template
+++ b/srcpkgs/urlwatch/template
@@ -1,23 +1,27 @@
 # Template file for 'urlwatch'
 pkgname=urlwatch
-version=2.17
-revision=2
+version=2.21
+revision=1
 archs=noarch
 build_style=python3-module
-pycompile_module="urlwatch"
 hostmakedepends="python3-setuptools"
 depends="python3-appdirs python3-keyring python3-minidb python3-requests
  python3-yaml python3-lxml python3-cssselect"
-checkdepends="python3-nose ${depends} python3-pycodestyle"
+# Check the Docs for optional packages:
+# https://urlwatch.readthedocs.io/en/latest/dependencies.html#optional-packages
+checkdepends="python3-pytest python3-pycodestyle python3-docutils
+ python3-Pygments ${depends}"
 short_desc="Tool for monitoring webpages for updates"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://thp.io/2008/urlwatch/"
 distfiles="${PYPI_SITE}/u/urlwatch/urlwatch-${version}.tar.gz"
-checksum=08f51c7ffe7489c0be7a6c54855e074da65131714e4b6c622e4cfb107ef7ea78
+checksum=c259e0169cc99114b54470d08a8312473159dfdbed1d712d1a222fd8a9d7291a
 
 do_check() {
-	nosetests3
+	# skip the tests that require python modules that aren't packaged
+	# (pdftotext & pytesseract)
+	pytest -k "not (pdf or ocr)" -v
 }
 
 post_install() {


### PR DESCRIPTION
It works fine as-is, but at least one feature is broken because it tries to import a python module that isn't packaged. I don't use that feature (beautify) but I'll look into packaging the missing modules.