### PR TITLE
kdeconnect: update to 20.04.2; depend on kirigami2

### DIFF
--- a/srcpkgs/kdeconnect/template
+++ b/srcpkgs/kdeconnect/template
@@ -1,7 +1,7 @@
 # Template file for 'kdeconnect'
 pkgname=kdeconnect
-version=20.04.0
-revision=2
+version=20.04.2
+revision=1
 wrksrc="kdeconnect-kde-${version}"
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-host-tools pkg-config
@@ -9,11 +9,11 @@ hostmakedepends="extra-cmake-modules qt5-host-tools pkg-config
 makedepends="kcmutils-devel qca-qt5-devel frameworkintegration-devel
  qt5-declarative-devel libfakekey-devel kwayland-devel
  qt5-multimedia-devel kpeoplevcard-devel kirigami2-devel pulseaudio-qt-devel"
-depends="kde-cli-tools qca-qt5-ossl fuse-sshfs"
+depends="kde-cli-tools qca-qt5-ossl fuse-sshfs kirigami2"
 short_desc="Multi-platform app that allows your devices to communicate"
 maintainer="Yuxuan Shui <yshuiv7@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/KDE/kdeconnect-kde"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-kde-${version}.tar.xz"
-checksum=6ca93ee5e6bbc93b04e58a4327a5c7d434f112fd5fc8c47624e4974ffa09501f
+checksum=37a606f243dcce42cdb84f5d27123845b6377e1f7043a618ad2f31b69653037b
 python_version=3


### PR DESCRIPTION
`kdeconnect` was failing to launch, citing:

```
QQmlApplicationEngine failed to load component
module "org.kde.kirigami" is not installed
```