### PR TITLE
grafana: create log dir

### DIFF
--- a/srcpkgs/grafana/template
+++ b/srcpkgs/grafana/template
@@ -1,7 +1,7 @@
 # Template file for 'grafana'
 pkgname=grafana
 version=7.0.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/grafana/grafana
 go_package="${go_import_path}/pkg/cmd/grafana-cli ${go_import_path}/pkg/cmd/grafana-server"
@@ -15,6 +15,7 @@ checksum=e11286c87c7ffe8f19d3631a4044d8d9e4378fcd5a512b2e9ee4c0f276b1b388
 
 system_accounts="_grafana"
 _grafana_homedir="/var/lib/grafana"
+make_dirs="/var/log/grafana 0750 _grafana _grafana"
 
 conf_files="/etc/grafana/grafana.ini"
 


### PR DESCRIPTION
`/var/log/grafana` is the default log path in the config and is used by the service if unchanged.