### PR TITLE
mdocml: backport patches for #9868

### DIFF
--- a/srcpkgs/mdocml/patches/fix.9868-1.patch
+++ b/srcpkgs/mdocml/patches/fix.9868-1.patch
@@ -1,0 +1,104 @@
+Log Message:
+-----------
+In man(1) mode, i.e. when asking for a single manual page by name,
+prefer file name matches over .Dt/.TH matches over first NAME matches
+over later NAME matches, but do not change the ordering for apropos(1) 
+nor for man -a.
+
+This reverts main.c rev. 1.310 and mansearch.h rev. 1.29
+and includes a partial revert of mansearch.c rev. 1.79.
+
+Regression reported by Lorenzo Beretta <loreb at github> 
+as part of https://github.com/void-linux/void-packages/issues/9868 .
+
+Modified Files:
+--------------
+    mandoc:
+        TODO
+        main.c
+        mansearch.c
+        mansearch.h
+
+Revision Data
+-------------
+Index: mansearch.c
+===================================================================
+RCS file: /home/cvs/mandoc/mandoc/mansearch.c,v
+retrieving revision 1.80
+retrieving revision 1.81
+diff -Lmansearch.c -Lmansearch.c -u -p -r1.80 -r1.81
+--- mansearch.c
++++ mansearch.c
+@@ -199,6 +199,7 @@ mansearch(const struct mansearch *search
+ 			}
+ 			mpage->names = buildnames(page);
+ 			mpage->output = buildoutput(outkey, page);
++			mpage->bits = search->firstmatch ? rp->bits : 0;
+ 			mpage->ipath = i;
+ 			mpage->sec = *page->sect - '0';
+ 			if (mpage->sec < 0 || mpage->sec > 9)
+@@ -294,8 +295,10 @@ manmerge_term(struct expr *e, struct oha
+ 				break;
+ 			slot = ohash_lookup_memory(htab,
+ 			    (char *)&res, sizeof(res.page), res.page);
+-			if ((rp = ohash_find(htab, slot)) != NULL)
++			if ((rp = ohash_find(htab, slot)) != NULL) {
++				rp->bits |= res.bits;
+ 				continue;
++			}
+ 			rp = mandoc_malloc(sizeof(*rp));
+ 			*rp = res;
+ 			ohash_insert(htab, slot, rp);
+@@ -408,7 +411,8 @@ manpage_compare(const void *vp1, const v
+ 
+ 	mp1 = vp1;
+ 	mp2 = vp2;
+-	if ((diff = mp1->sec - mp2->sec))
++	if ((diff = mp2->bits - mp1->bits) ||
++	    (diff = mp1->sec - mp2->sec))
+ 		return diff;
+ 
+ 	/* Fall back to alphabetic ordering of names. */
+Index: mansearch.h
+===================================================================
+RCS file: /home/cvs/mandoc/mandoc/mansearch.h,v
+retrieving revision 1.29
+retrieving revision 1.30
+diff -Lmansearch.h -Lmansearch.h -u -p -r1.29 -r1.30
+--- mansearch.h
++++ mansearch.h
+@@ -92,6 +92,7 @@ struct	manpage {
+ 	char		*file; /* to be prefixed by manpath */
+ 	char		*names; /* a list of names with sections */
+ 	char		*output; /* user-defined additional output */
++	uint64_t	 bits; /* name type mask */
+ 	size_t		 ipath; /* number of the manpath */
+ 	int		 sec; /* section number, 10 means invalid */
+ 	enum form	 form;
+Index: main.c
+===================================================================
+RCS file: /home/cvs/mandoc/mandoc/main.c,v
+retrieving revision 1.322
+retrieving revision 1.323
+diff -Lmain.c -Lmain.c -u -p -r1.322 -r1.323
+--- main.c
++++ main.c
+@@ -411,6 +411,7 @@ main(int argc, char *argv[])
+ 				res[sz].file = mandoc_strdup(argv[c]);
+ 				res[sz].names = NULL;
+ 				res[sz].output = NULL;
++				res[sz].bits = 0;
+ 				res[sz].ipath = SIZE_MAX;
+ 				res[sz].sec = 10;
+ 				res[sz].form = FORM_SRC;
+@@ -761,6 +762,7 @@ found:
+ 	page->file = file;
+ 	page->names = NULL;
+ 	page->output = NULL;
++	page->bits = NAME_FILE & NAME_MASK;
+ 	page->ipath = ipath;
+ 	page->sec = (*sec >= '1' && *sec <= '9') ? *sec - '1' + 1 : 10;
+ 	page->form = form;
+--
+ To unsubscribe send an email to source+unsubscribe@mandoc.bsd.lv
+

--- a/srcpkgs/mdocml/patches/fix.9868-2.patch
+++ b/srcpkgs/mdocml/patches/fix.9868-2.patch
@@ -1,0 +1,75 @@
+Log Message:
+-----------
+In man(1) mode with a specific section requested,
+try harder to find the best match.
+
+Use this order of preference:
+1. The section in both the directory name and the file name matches exactly.
+2. The section in the file name matches exactly.
+3. The section in the directory name matches exactly.
+4. Neither of them matches exactly.
+The latter can happen when mansearch() finds substring matches
+or when the second .Dt argument mismatches the dir and file names.
+
+Lorenzo Beretta <loreb at github> reported that this caused real 
+problems on Void Linux, like "man 3 readline" showing readline(3m).
+See https://github.com/void-linux/void-packages/issues/9868 for details.
+
+Modified Files:
+--------------
+    mandoc:
+        main.c
+
+Revision Data
+-------------
+Index: main.c
+===================================================================
+RCS file: /home/cvs/mandoc/mandoc/main.c,v
+retrieving revision 1.324
+retrieving revision 1.325
+diff -Lmain.c -Lmain.c -u -p -r1.324 -r1.325
+--- main.c
++++ main.c
+@@ -125,7 +125,7 @@ main(int argc, char *argv[])
+ 	char		*conf_file, *defpaths, *auxpaths;
+ 	char		*oarg, *tagarg;
+ 	unsigned char	*uc;
+-	size_t		 i, sz;
++	size_t		 i, sz, ssz;
+ 	int		 prio, best_prio;
+ 	enum outmode	 outmode;
+ 	int		 fd, startdir;
+@@ -434,7 +434,7 @@ main(int argc, char *argv[])
+ 
+ 		if (outmode == OUTMODE_ONE) {
+ 			argc = 1;
+-			best_prio = 20;
++			best_prio = 40;
+ 		} else if (outmode == OUTMODE_ALL)
+ 			argc = (int)sz;
+ 
+@@ -453,10 +453,21 @@ main(int argc, char *argv[])
+ 				sec = res[i].file;
+ 				sec += strcspn(sec, "123456789");
+ 				if (sec[0] == '\0')
+-					continue;
++					continue; /* No section at all. */
+ 				prio = sec_prios[sec[0] - '1'];
+-				if (sec[1] != '/')
+-					prio += 10;
++				if (search.sec != NULL) {
++					ssz = strlen(search.sec);
++					if (strncmp(sec, search.sec, ssz) == 0)
++						sec += ssz;
++				} else
++					sec++; /* Prefer without suffix. */
++				if (*sec != '/')
++					prio += 10; /* Wrong dir name. */
++				if (search.sec != NULL &&
++				    (strlen(sec) <= ssz  + 3 ||
++				     strcmp(sec + strlen(sec) - ssz,
++				      search.sec) != 0))
++					prio += 20; /* Wrong file ext. */
+ 				if (prio >= best_prio)
+ 					continue;
+ 				best_prio = prio;

--- a/srcpkgs/mdocml/patches/fix.9868-3.patch
+++ b/srcpkgs/mdocml/patches/fix.9868-3.patch
@@ -1,0 +1,67 @@
+Log Message:
+-----------
+Enter dangling .so links into the database, to avoid harassing 
+users of man(1) about running makewhatis(8), which won't help.
+Seeing the content of the broken .so request might even help
+users to figure out how to access the manual page they want.
+
+Fixing the last issue reported by Lorenzo Beretta <loreb at github>
+as part of https://github.com/void-linux/void-packages/issues/9868 .
+
+Modified Files:
+--------------
+    mandoc:
+        mandocdb.c
+
+Revision Data
+-------------
+Index: mandocdb.c
+===================================================================
+RCS file: /home/cvs/mandoc/mandoc/mandocdb.c,v
+retrieving revision 1.262
+retrieving revision 1.263
+diff -Lmandocdb.c -Lmandocdb.c -u -p -r1.262 -r1.263
+--- mandocdb.c
++++ mandocdb.c
+@@ -1,7 +1,7 @@
+ /*	$Id$ */
+ /*
+  * Copyright (c) 2011, 2012 Kristaps Dzonsons <kristaps@bsd.lv>
+- * Copyright (c) 2011-2018 Ingo Schwarze <schwarze@openbsd.org>
++ * Copyright (c) 2011-2019 Ingo Schwarze <schwarze@openbsd.org>
+  * Copyright (c) 2016 Ed Maste <emaste@freebsd.org>
+  *
+  * Permission to use, copy, modify, and distribute this software for any
+@@ -1186,9 +1186,11 @@ mpages_merge(struct dba *dba, struct mpa
+ 				mlink->next = mlink_dest->next;
+ 				mlink_dest->next = mpage->mlinks;
+ 				mpage->mlinks = NULL;
++				goto nextpage;
+ 			}
+-			goto nextpage;
+-		} else if (meta != NULL && meta->macroset == MACROSET_MDOC) {
++			meta->macroset = MACROSET_NONE;
++		}
++		if (meta != NULL && meta->macroset == MACROSET_MDOC) {
+ 			mpage->form = FORM_SRC;
+ 			mpage->sec = meta->msec;
+ 			mpage->sec = mandoc_strdup(
+@@ -1208,12 +1210,15 @@ mpages_merge(struct dba *dba, struct mpa
+ 		}
+ 
+ 		assert(mpage->desc == NULL);
+-		if (meta == NULL) {
+-			mpage->form = FORM_CAT;
++		if (meta == NULL || meta->sodest != NULL) {
+ 			mpage->sec = mandoc_strdup(mlink->dsec);
+ 			mpage->arch = mandoc_strdup(mlink->arch);
+ 			mpage->title = mandoc_strdup(mlink->name);
+-			parse_cat(mpage, fd);
++			if (meta == NULL) {
++				mpage->form = FORM_CAT;
++				parse_cat(mpage, fd);
++			} else
++				mpage->form = FORM_SRC;
+ 		} else if (meta->macroset == MACROSET_MDOC)
+ 			parse_mdoc(mpage, meta, meta->first);
+ 		else

--- a/srcpkgs/mdocml/template
+++ b/srcpkgs/mdocml/template
@@ -1,22 +1,22 @@
 # Template file for 'mdocml'
 pkgname=mdocml
 version=1.14.5
-revision=5
+revision=6
 wrksrc="mandoc-${version}"
 build_style=configure
 make_build_args="all man.cgi"
 make_check_target="regress"
 makedepends="less zlib-devel"
-checkdepends="perl"
 depends="less"
-provides="man-0_1"
+checkdepends="perl"
 conf_files="/etc/man.conf"
-short_desc="The mandoc UNIX manpage compiler toolset"
+short_desc="UNIX manpage compiler toolset (mandoc)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="ISC"
 homepage="http://mandoc.bsd.lv"
 distfiles="http://mandoc.bsd.lv/snapshots/mandoc-${version}.tar.gz"
 checksum=8219b42cb56fc07b2aa660574e6211ac38eefdbf21f41b698d3348793ba5d8f7
+provides="man-0_1"
 
 alternatives="
  man:man:/usr/bin/mandoc
@@ -30,28 +30,26 @@ post_extract() {
 	# use less(1)
 	sed -i 's,"more -s","less -s",g' main.c
 	sed -i 's,.Xr more,.Xr less,g' *.1
-	
 	sed -i 's/^CC=.*/CC=cc/' configure
 	cat ${FILESDIR}/void.css >>mandoc.css
 	cp ${FILESDIR}/cgi.h .
 }
 pre_configure() {
-	cat >configure.local <<EOF
-PREFIX=/usr
-SBINDIR=/usr/bin
-MANDIR=/usr/share/man
-OSNAME="Void Linux"
-BINM_SOELIM=mandoc-soelim
-MANM_ROFF="mandoc_roff"
-LDFLAGS="$LDFLAGS"
-CFLAGS="$CFLAGS"
-CC="$CC"
-HAVE_REWB_BSD=0
-EOF
+	cat >configure.local <<-EOF
+		PREFIX=/usr
+		SBINDIR=/usr/bin
+		MANDIR=/usr/share/man
+		OSNAME="Void Linux"
+		BINM_SOELIM=mandoc-soelim
+		MANM_ROFF="mandoc_roff"
+		LDFLAGS="$LDFLAGS"
+		CFLAGS="$CFLAGS"
+		CC="$CC"
+		HAVE_REWB_BSD=0
+	EOF
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl) echo 'UTF8_LOCALE="C.UTF-8"' >>configure.local;;
 	esac
-	
 }
 post_install() {
 	# Rename mans for alternatives


### PR DESCRIPTION
Fixes #9868 until a new upstream release.
Closes #13125.

It is important since some man pages are inaccessible without this.

For example: `man parallel` displays `moreutils_parallel.1` instead of `parallel.1`.

Also: `man vi` displays `nvi.1` instead of `vi.1` even when `vi` is the choosen alternative (this is less important since `man vim` works)

I took the patches verbatim from #9868, except I had to remove a hunk from the first patch for the file `TODO`.