### PR TITLE
build-style/cmake: s/Release/RelWithDebInfo/

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -43,7 +43,7 @@ _EOF
 		cmake_args+=" -DCMAKE_TOOLCHAIN_FILE=cross_${XBPS_CROSS_TRIPLET}.cmake"
 	fi
 	cmake_args+=" -DCMAKE_INSTALL_PREFIX=/usr"
-	cmake_args+=" -DCMAKE_BUILD_TYPE=Release"
+	cmake_args+=" -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 
 	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 		cmake_args+=" -DCMAKE_INSTALL_LIBDIR=lib32"


### PR DESCRIPTION
Release uses "-O3" which will overwrite our "-O2".

---

Requesting recent developers that touch cmake build-style.