### PR TITLE
fpc 3.2.0

### DIFF
--- a/srcpkgs/fpc-src/template
+++ b/srcpkgs/fpc-src/template
@@ -1,6 +1,6 @@
 # Template file for 'fpc-src'
 pkgname=fpc-src
-version=3.0.4
+version=3.2.0
 revision=1
 wrksrc="fpcbuild-${version}"
 short_desc="Source code for FreePascal compiler"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://www.freepascal.org"
 distfiles="ftp://ftp.freepascal.org/pub/fpc/dist/${version}/source/fpcbuild-${version}.tar.gz"
-checksum=f66514e6f2c2e4e1bccccb4d554c24b77682ed61c87811ae5dd210f421855e76
+checksum=f9b914eace989a023fb953da203dc0d973b44487568b4138c7d5b9613d7d6838
 nostrip=yes
 
 do_install() {

--- a/srcpkgs/fpc/template
+++ b/srcpkgs/fpc/template
@@ -1,7 +1,8 @@
 # Template file for 'fpc'
 pkgname=fpc
-version=3.0.4
-revision=2
+version=3.2.0
+revision=1
+archs="x86_64* i686*"
 create_wrksrc=yes
 build_wrksrc="${pkgname}build-${version}"
 conf_files="/etc/fpc.cfg /etc/fppkg.cfg"
@@ -9,24 +10,24 @@ hostmakedepends="rpmextract"
 makedepends="ncurses-devel zlib-devel expat-devel"
 short_desc="Free Pascal Compiler"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2, LGPL-2.1, FPC-FPR"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://freepascal.org/"
 distfiles="${SOURCEFORGE_SITE}/freepascal/Source/${version}/${pkgname}build-${version}.tar.gz"
-checksum=f66514e6f2c2e4e1bccccb4d554c24b77682ed61c87811ae5dd210f421855e76
+checksum=f9b914eace989a023fb953da203dc0d973b44487568b4138c7d5b9613d7d6838
 case "$XBPS_TARGET_MACHINE" in
 x86_64*)
 	distfiles+=" ${SOURCEFORGE_SITE}/freepascal/Linux/${version}/${pkgname}-${version}-1.x86_64.rpm"
-	checksum+=" c7b75f09174a502d8dd776fbfabcad3e4360494fd635445185159b21001d65f1"
+	checksum+=" 1f74e1ad3ced2dd67688fdb92edd42e73cdc31ef96056f8739449d70a9306f2c"
 	;;
 i686*)
 	distfiles+=" ${SOURCEFORGE_SITE}/freepascal/Linux/${version}/${pkgname}-${version}-1.i686.rpm"
-	checksum+=" a8f1ea31c63e8cd96dbdecf02af97311f14629babe58b4bd18ecfa094a13ad45"
+	checksum+=" 05c5600c9461362a08df100cf50ca125cb2b4d5bfe4da48cf8c144f2bf4617a2"
 	;;
 esac
 # TODO: figure out cross-build and how to unwrap the ARM .tar.
 nocross=yes
 nopie=yes
-archs="x86_64* i686*"
+noverifyrdeps=yes
 
 post_extract() {
 	# relative links needed
@@ -57,7 +58,6 @@ do_install() {
 	PATH=$DESTDIR/usr/bin:$PATH \
 		$DESTDIR/usr/lib/fpc/${version}/samplecfg \
 			$DESTDIR/usr/lib/fpc/${version} $DESTDIR/etc
-	sed -i "s,${DESTDIR},,g" $DESTDIR/etc/*.cfg $DESTDIR/etc/fppkg/* $DESTDIR/usr/lib/fpc/${version}/ide/text/*
+	sed -i "s,${DESTDIR},,g" $DESTDIR/etc/*.cfg $DESTDIR/etc/fppkg/default $DESTDIR/usr/lib/fpc/${version}/ide/text/*
 	vlicense fpcsrc/rtl/COPYING.FPC
 }
-

--- a/srcpkgs/hedgewars/patches/fpc-3.2.0.patch
+++ b/srcpkgs/hedgewars/patches/fpc-3.2.0.patch
@@ -1,0 +1,13 @@
+--- hedgewars/uWorld.pas
++++ hedgewars/uWorld.pas
+@@ -1168,8 +1168,8 @@ procedure RenderAttackBar();
+ procedure ShiftWorld(Dir: LongInt); inline;
+ begin
+     preShiftWorldDx:= WorldDx;
+-    WorldDx:= WorldDx + LongInt(Dir * LongInt(playWidth));
+-
++    Dir := Dir * LongInt(playWidth);
++    WorldDx:= WorldDx + Dir;
+ end;
+ 
+ procedure UnshiftWorld(); inline;

--- a/srcpkgs/hedgewars/patches/qt.patch
+++ b/srcpkgs/hedgewars/patches/qt.patch
@@ -1,0 +1,10 @@
+--- QTfrontend/ui/page/pagegamestats.cpp.orig
++++ QTfrontend/ui/page/pagegamestats.cpp
+@@ -22,6 +22,7 @@
+ #include <QGraphicsScene>
+ #include <QGroupBox>
+ #include <QSizePolicy>
++#include <QPainterPath>
+ 
+ #include "pagegamestats.h"
+ #include "team.h"

--- a/srcpkgs/hedgewars/template
+++ b/srcpkgs/hedgewars/template
@@ -1,7 +1,7 @@
 # Template file for 'hedgewars'
 pkgname=hedgewars
 version=1.0.0
-revision=1
+revision=2
 wrksrc="${pkgname}-src-${version}"
 build_style=cmake
 configure_args="-DNOSERVER=1 -DDATA_INSTALL_DIR=/usr/share/${pkgname}
@@ -37,7 +37,7 @@ case $XBPS_TARGET_MACHINE in
 esac
 
 if [ -n "$_use_c_engine" ]; then
-	hostmakedepends+=" glew-devel libatomic-devel ghc"
+	hostmakedepends+=" glew-devel libatomic-devel ghc clang"
 	configure_args+=" -DBUILD_ENGINE_C=1"
 	nopie_files+=" /usr/bin/hedgewars"
 fi
@@ -56,7 +56,6 @@ post_install() {
 
 hedgewars-data_package() {
 	short_desc+=" - data files"
-	archs=noarch
 	pkg_install() {
 		vmove usr/share/hedgewars/Data
 	}


### PR DESCRIPTION
Not merged as it breaks hedgewars:

```
...
uWorld.pas(1863,17) Note: Call to subroutine "procedure untint;" marked as inline is not inlined                                                                
uWorld.pas(1214,5) Fatal: Internal error 200306031                              
Fatal: Compilation aborted                                                      
Error: /usr/bin/ppcx64 returned an error exitcode                               
make[2]: *** [hedgewars/CMakeFiles/hwengine.dir/build.make:153: hedgewars/CMakeFiles/hwengine.dir/hwengine.o] Error 1            
```