### PR TITLE
cross compiler for glibc: ship gconv

### DIFF
--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=2
+revision=3
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="https://www.voidlinux.org/"
@@ -354,7 +354,6 @@ do_install() {
 	rm -rf ${DESTDIR}/usr/share
 	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 }
 

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -351,7 +351,6 @@ do_install() {
 	rm -rf ${DESTDIR}/usr/share
 	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 }
 

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -351,7 +351,6 @@ do_install() {
 	rm -rf ${DESTDIR}/usr/share
 	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 }
 

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=1
+revision=2
 short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -352,7 +352,6 @@ do_install() {
 	rm -rf ${DESTDIR}/usr/share
 	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 }
 

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -11,7 +11,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=3
+revision=4
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 homepage="https://www.voidlinux.org/"
@@ -351,7 +351,6 @@ do_install() {
 	rm -rf ${DESTDIR}/usr/share
 	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 }
 

--- a/srcpkgs/cross-powerpc-linux-gnu/template
+++ b/srcpkgs/cross-powerpc-linux-gnu/template
@@ -10,7 +10,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=2
+revision=3
 short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
 homepage="http://www.voidlinux.org"
@@ -352,7 +352,6 @@ do_install() {
 	rm -rf ${DESTDIR}/usr/share
 	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
 	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/lib/gconv
 	rm -f ${DESTDIR}/${_sysroot}/libexec
 }
 


### PR DESCRIPTION
- Some packages check for `iconv_open` to check if it works.
- The check in cmake/meson will be run in qemu-user-static
- Without gconv, the check will always fail.

