### PR TITLE
New package: horizon-1.2.0.

### DIFF
--- a/srcpkgs/horizon/template
+++ b/srcpkgs/horizon/template
@@ -1,0 +1,21 @@
+# Template file for 'horizon'
+pkgname=horizon
+version=1.2.1
+revision=1
+build_style=gnu-makefile
+make_build_args="GOLD="
+make_use_env=yes
+hostmakedepends="pkg-config glib-devel"
+makedepends="cairomm-devel librsvg-devel yaml-cpp-devel sqlite-devel boost-devel
+ glm libgit2-devel libcurl-devel occt-devel cppzmq libpodofo-devel libzip-devel
+ gtkmm-devel libepoxy-devel libsodium-devel"
+short_desc="Free EDA package"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="GPL-3.0-only"
+homepage="https://horizon-eda.org/"
+distfiles="https://github.com/horizon-eda/horizon/archive/v${version}.tar.gz"
+checksum=3c0d66afeec55cf7fffbb25a467f7aac1576a5f93fec1f461d7f8a3e20072365
+
+if [ "$CROSS_BUILD" ]; then
+	make_build_args+=" INC_OCE=-I$XBPS_CROSS_BASE/usr/include/opencascade"
+fi


### PR DESCRIPTION
This should wait for #22667, because it allows `occt` to be built for all archs.

Also, I don't know whether to name the package horizon or horizon-eda. The repo name is horizon, but most of the associated material uses horizon-eda, and that's the binary name as well.