### PR TITLE
common/environment/build: set CCACHE_BASEDIR to wrksrc

### DIFF
--- a/common/environment/build/ccache.sh
+++ b/common/environment/build/ccache.sh
@@ -1,0 +1,1 @@
+../configure/ccache.sh

--- a/common/environment/check/ccache.sh
+++ b/common/environment/check/ccache.sh
@@ -1,0 +1,1 @@
+../configure/ccache.sh

--- a/common/environment/configure/ccache.sh
+++ b/common/environment/configure/ccache.sh
@@ -1,0 +1,1 @@
+export CCACHE_BASEDIR="$wrksrc/$build_wrksrc"

--- a/common/environment/install/ccache.sh
+++ b/common/environment/install/ccache.sh
@@ -1,0 +1,1 @@
+../configure/ccache.sh

--- a/common/environment/patch/ccache.sh
+++ b/common/environment/patch/ccache.sh
@@ -1,0 +1,1 @@
+../configure/ccache.sh


### PR DESCRIPTION
this will rewrite total paths to be relative to CCACHE_BASEDIR before caching,
helps prevent cache misses due to changed wrksrc with build systems like cmake
that use total paths in their Makefiles