### PR TITLE
riot-desktop: update to 1.6.6.

### DIFF
--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,19 +1,20 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=1.6.5
+version=1.6.6
 revision=1
 archs="i686 x86_64"
 wrksrc="riot-web-${version}"
 conf_files="/etc/${pkgname}/config.json"
-hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl libappindicator-devel libnotify-devel"
+hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl libappindicator-devel libnotify-devel pkg-config"
+makedepends="libsecret-devel"
 depends="c-ares ffmpeg gtk+3 http-parser libevent libxslt minizip nss re2 snappy sqlcipher"
 short_desc="Glossy Matrix collaboration client, desktop version"
 maintainer="projectmoon <projectmoon@agnos.is>"
 license="Apache-2.0"
 homepage="https://riot.im"
 distfiles="https://github.com/vector-im/riot-desktop/archive/v${version}.tar.gz>riot-desktop.tar.gz https://github.com/vector-im/riot-web/archive/v${version}.tar.gz>riot-web.tar.gz"
-checksum="4083e541192701d4d77f640238580dcc97bf59656e57a42a67d20960c525d8c4
- fd9499b173a4372b8e62e947486e0b078f81d0ca1393a7673c068e2413138a2a"
+checksum="36f3ea87e5bf5234c3c2348517977b6a317f41e2f303dd63278db0668f7e899a
+ 59c85828a557be3504855e1566f98ef49e52fed95f6937935e88c9859968f0c2"
 nocross=yes
 nostrip=yes
 


### PR DESCRIPTION
New version requires adding pkg-config and libsecret-devel to the build process.