### PR TITLE
nvidia: add linux5.7 patch.

### DIFF
--- a/srcpkgs/nvidia/files/prime-run
+++ b/srcpkgs/nvidia/files/prime-run
@@ -1,0 +1,5 @@
+#!/bin/sh
+export __NV_PRIME_RENDER_OFFLOAD=1
+export __GLX_VENDOR_LIBRARY_NAME=nvidia
+export __VK_LAYER_NV_optimus=NVIDIA_only
+exec "$@"

--- a/srcpkgs/nvidia/patches/nvidia-kernel-5.7.patch
+++ b/srcpkgs/nvidia/patches/nvidia-kernel-5.7.patch
@@ -1,0 +1,24 @@
+Fix implicit declaration error when building DKMS module.
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 8f807a1..af29636 100755
+--- NVIDIA-Linux-x86_64-440.82/kernel/conftest.sh
++++ NVIDIA-Linux-x86_64-440.82/kernel/conftest.sh
+@@ -143,6 +143,7 @@ test_headers() {
+     FILES="$FILES video/nv_internal.h"
+     FILES="$FILES asm/book3s/64/hash-64k.h"
+     FILES="$FILES asm/set_memory.h"
++    FILES="$FILES asm/pgtable.h"
+     FILES="$FILES asm/prom.h"
+     FILES="$FILES asm/powernv.h"
+     FILES="$FILES asm/tlbflush.h"
+@@ -466,6 +467,9 @@ compile_test() {
+             # It does not exist on all architectures.
+             #
+             CODE="
++            #if defined(NV_ASM_PGTABLE_H_PRESENT)
++            #include <asm/pgtable.h>
++            #endif
+             #if defined(NV_ASM_SET_MEMORY_H_PRESENT)
+             #include <asm/set_memory.h>
+             #else

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=440.82
-revision=1
+revision=2
 maintainer="Juan RP <xtraeme@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com"
@@ -211,9 +211,12 @@ do_install() {
 		-e 's/__MAKEJOBS/-j$(nproc)/g' \
 		-i ${DESTDIR}/usr/src/nvidia-${version}/dkms.conf
 
+	# Xorg conf for PRIME
 	vmkdir /usr/share/X11/xorg.conf.d/
 	vinstall ${FILESDIR}/nvidia-drm-outputclass.conf 644 \
 		/usr/share/X11/xorg.conf.d 10-nvidia-drm-outputclass.conf
+
+	vbin ${FILESDIR}/prime-run
 
 	# Blacklist nouveau
 	vmkdir usr/lib/modprobe.d
@@ -238,6 +241,7 @@ nvidia-gtklibs_package() {
 		vmove "usr/lib/lib*gtk*.so*"
 	}
 }
+
 nvidia-libs-32bit_package() {
 	short_desc="${_desc} - common libraries (32bit)"
 	# manually set 32bit depends for libglvnd
@@ -247,6 +251,7 @@ nvidia-libs-32bit_package() {
 		vmove usr/lib32
 	}
 }
+
 nvidia-libs_package() {
 	short_desc="${_desc} - common libraries"
 	depends="libglvnd"
@@ -254,6 +259,7 @@ nvidia-libs_package() {
 		vmove usr/lib
 	}
 }
+
 nvidia-dkms_package() {
 	short_desc="${_desc} - DKMS kernel module"
 	dkms_modules="nvidia ${version}"
@@ -263,6 +269,7 @@ nvidia-dkms_package() {
 		vmove usr/lib/modprobe.d
 	}
 }
+
 nvidia-opencl_package() {
 	short_desc="${_desc} - OpenCL implementation"
 	depends="libOpenCL"


### PR DESCRIPTION
Building the DKMS module was failing due to a missing header. Patch
taken from Arch Linux.

Fixes #23128 