### PR TITLE
New package: wren-cli

### DIFF
--- a/srcpkgs/wren-cli/template
+++ b/srcpkgs/wren-cli/template
@@ -1,0 +1,28 @@
+# Template file for 'wren-cli'
+pkgname=wren-cli
+version=0.3.0
+revision=1
+build_wrksrc=projects/make
+build_style=gnu-makefile
+make_build_args="config=release_${XBPS_TARGET_WORDSIZE}bit"
+checkdepends="python3"
+short_desc="Small, class-based, concurrent scripting language - CLI"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="MIT"
+homepage="http://wren.io/cli"
+distfiles="https://github.com/wren-lang/wren-cli/archive/${version}.tar.gz"
+checksum=a498d2ccb9a723e7163b4530efbaec389cc13e6baaf935e16cbd052a739b7265
+
+post_patch() {
+	vsed -i -e 's/ -m64 / /;s/ -m32 / /;s/ -O3//' wren_cli.make
+}
+
+do_check() {
+	cd ../..
+	python3 util/test.py
+}
+
+do_install() {
+	vbin ${wrksrc}/bin/wren_cli wren
+	vlicense ${wrksrc}/LICENSE
+}


### PR DESCRIPTION
I'm having a couple issues with these templates. The first is that I can't seem to get the directories right when attempting to install files from the source archive. The second is that these packages have their 32 and 64 bit versions in the same release, you just select which one you want with arguments passed to `make`. Is there any way to set `make_build_args` based on the architecture that the package is being built for?