### PR TITLE
pulseaudio: use `flat-volumes = no` by default

### DIFF
--- a/srcpkgs/pulseaudio/template
+++ b/srcpkgs/pulseaudio/template
@@ -1,7 +1,7 @@
 # Template file for 'pulseaudio'
 pkgname=pulseaudio
 version=13.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-oss-output --disable-oss-wrapper --disable-tcpwrap
  --enable-jack --disable-lirc --disable-hal-compat --disable-gconf --enable-orc
@@ -24,7 +24,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/PulseAudio"
 distfiles="${FREEDESKTOP_SITE}/${pkgname}/releases/${pkgname}-${version}.tar.xz"
 checksum=961b23ca1acfd28f2bc87414c27bb40e12436efcf2158d29721b1e89f3f28057
-python_version=2 #unverified
+python_version=3
 system_groups="pulse-access"
 system_accounts="pulse"
 pulse_groups="audio"
@@ -45,6 +45,13 @@ esac
 post_install() {
 	rm -f ${DESTDIR}/etc/dbus-1/system.d/pulseaudio-system.conf
 	vsv pulseaudio
+
+	# Change the daemon's default configuration to "flat-volumes = no". This
+	# prevents the system volume jumping to high levels because of misbehaving
+	# applications.
+	vsed -e '/flat-volumes/iflat-volumes = no' \
+		-i "${DESTDIR}/etc/pulse/daemon.conf"
+
 }
 
 libpulseaudio_package() {


### PR DESCRIPTION
With this patch, the property `flat-volumes` defaults to `no`.

From `man pulse-daemon.conf`:
```
flat-volumes= Enable 'flat' volumes, i.e. where possible let the sink
volume equal the maximum of the volumes of the inputs connected to it.
Takes a boolean argument, defaults to yes.
```

`flat-volumes = yes`, Pulseaudio's upstream default, IMO is counter-intuitive. Most applications are not built around this feature, and the unintended consequence is that they end changing the system volume to 100% which is unpleasant.

Arch, Ubuntu, NixOS are some distros that I know of that default to `no`.

---

Also changed `python_version` to `3` since `/usr/bin/qpaeq` is Python 3 compatible.