### PR TITLE
pantalaimon: depend on python3-prompt_toolkit2.

### DIFF
--- a/srcpkgs/pantalaimon/template
+++ b/srcpkgs/pantalaimon/template
@@ -1,14 +1,15 @@
 # Template file for 'pantalaimon'
 pkgname=pantalaimon
 version=0.6.4
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-attrs python3-aiohttp python3-appdirs python3-click
  python3-keyring python3-logbook python3-peewee python3-janus
- python3-cachetools python3-prompt_toolkit python3-matrix-nio
+ python3-cachetools python3-prompt_toolkit2 python3-matrix-nio
  python3-dbus python3-gobject python3-pydbus python3-notify2"
+checkdepends="${depends}"
 short_desc="Proxy daemon for matrix.org clients supporting end-to-end encryption"
 maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
 license="Apache-2.0"


### PR DESCRIPTION
PR #15474 incorrectly specified python3-prompt_toolkit as a
dependency when pantalaimon requires version 2+.