### PR TITLE
dkms: fix post-install hook.

### DIFF
--- a/srcpkgs/dkms/files/kernel.d/dkms.postinst
+++ b/srcpkgs/dkms/files/kernel.d/dkms.postinst
@@ -40,6 +40,15 @@ for _mod_ in /var/lib/dkms/*; do
 	done
 done
 
+# This sections builds and install the available modules.
+#
+# If either building or installing a module fails, a warning is
+# printed and it is skipped, but the script still tries to build
+# the other modules.
+#
+# The list of available modules is in the form
+# [module1, modulever1, module2, modulever2, ...]
+#
 set -- ${DKMS_MODULES}
 while [ $# -ne 0 ]; do
 	module="$1"
@@ -50,39 +59,42 @@ while [ $# -ne 0 ]; do
 		# Check if the module is still there.
 		if [ ! -f usr/src/${module}-${modulever}/dkms.conf ]; then
 			echo "Skipping unexistent DKMS module: ${module}-${modulever}."
-			shift 2
-			continue
+			shift 2; continue
 		fi
 		# Build the module
 		echo -n "Building DKMS module: ${module}-${modulever}... "
 		dkms build -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
 		rval=$?
-		if [ $rval -eq 9 ]; then
-			echo "skipped!"
-			shift; shift
-			continue
-		elif [ $rval -eq 0 ]; then
+		# If the module was skipped or failed, go to the next module.
+		if [ $rval -eq 0 ]; then
 			echo "done."
+		elif [ $rval -eq 9 ]; then
+			echo "skipped!"
+			shift 2; continue
 		else
 			echo "FAILED!"
-			exit $?
+			shift 2; continue
 		fi
 		status=$(dkms status -m ${module} -v ${modulever} -k ${VERSION})
 	fi
 
-	#if the module is built (either pre-built or just now), install it
+	# If the module is built (either pre-built or just now), install it
 	if [ $(echo "$status"|grep -c ": built") -eq 1 ] &&
 	   [ $(echo "$status"|grep -c ": installed") -eq 0 ]; then
 		echo -n "Installing DKMS module: ${module}-${modulever}... "
-	        dkms install -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
-		if [ $? -eq 0 ]; then
+		dkms install -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
+		rval=$?
+		# If the module failed installation, go to the next module.
+		if [ $rval -eq 0 ]; then
 			echo "done."
 		else
 			echo "FAILED!"
-			exit $?
+			shift 2; continue
 		fi
 	fi
-	shift; shift
+
+	# Go to the next module - all steps for this module were successful.
+	shift 2
 done
 
 exit 0

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -2,7 +2,7 @@
 pkgname=dkms
 reverts="2.8.2_1"
 version=2.8.1
-revision=3
+revision=4
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils linux-headers"
 short_desc="Dynamic Kernel Modules System"


### PR DESCRIPTION
The hook exited when it encountered an error building a DKMS module,
leading it to not build the other modules. This fixes that issue, using
a similar logic to the one in the dkms xbps-trigger.

Fixes #23124.

Small style fixes included as well.