### PR TITLE
chroot.sh: reconfigure base-files inside chroot

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -31,7 +31,9 @@ install_base_chroot() {
 
 reconfigure_base_chroot() {
     local statefile="$XBPS_MASTERDIR/.xbps_chroot_configured"
-    local pkgs="glibc-locales ca-certificates"
+    # When binary-bootstrap glibc from musl host, getent failed to execute
+    # No directories is created
+    local pkgs="base-files glibc-locales ca-certificates"
     [ -z "$IN_CHROOT" -o -e $statefile ] && return 0
     # Reconfigure ca-certificates.
     msg_normal "xbps-src: reconfiguring base-chroot...\n"
@@ -113,7 +115,8 @@ chroot_prepare() {
         cp -f /usr/share/zoneinfo/UTC $XBPS_MASTERDIR/etc/localtime
     fi
 
-    for f in dev sys proc host boot; do
+    # mkstemp(3) requires /tmp
+    for f in dev sys proc host boot tmp; do
         [ ! -d $XBPS_MASTERDIR/$f ] && mkdir -p $XBPS_MASTERDIR/$f
     done
 


### PR DESCRIPTION
When binary-bootstrap a glibc chroot from musl host.
install(1) failed because chroot's getent(1) requires some glibc
specific symbols.

xbps-reconfigure(1) base-files agains inside chroot to correct it.
Before xbps-reconfigure(1) base-files, ensure that `/tmp` exists,
because base-files' INSTALL needs /tmp, too.

---

Reported by @ericonr in IRC. This area of code is recently touched by xtraeme.
If noone complains, I'll merge it very soon ;)