### PR TITLE
elogind: fix dbus dependency in service

### DIFF
--- a/srcpkgs/elogind/files/elogind/run
+++ b/srcpkgs/elogind/files/elogind/run
@@ -1,3 +1,4 @@
 #!/bin/sh
-sv check dbus >/dev/null || true
+# elogind doesn't work right if it starts before dbus
+sv check dbus >/dev/null || exit 1
 exec /usr/libexec/elogind/elogind.wrapper

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -2,7 +2,7 @@
 pkgname=elogind
 reverts="243.7_1"
 version=243.4
-revision=2
+revision=3
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
  -Drootlibexecdir=/usr/libexec/elogind -Dreboot-path=/usr/bin/reboot


### PR DESCRIPTION
The original `elogind` service script rendered a `dbus` check irrelevant, so `elogind` would start even if `dbus` was not running. This causes `elogind` to complain.