### PR TITLE
New package: nagios-4.4.6

### DIFF
--- a/srcpkgs/nagios/files/nagios/run
+++ b/srcpkgs/nagios/files/nagios/run
@@ -1,3 +1,2 @@
 #!/bin/sh
-chown -R _nagios:_nagios /var/nagios
 exec nagios /etc/nagios/nagios.cfg 2>&1

--- a/srcpkgs/nagios/files/nagios/run
+++ b/srcpkgs/nagios/files/nagios/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+chown -R _nagios:_nagios /var/nagios
+exec nagios /etc/nagios/nagios.cfg 2>&1

--- a/srcpkgs/nagios/template
+++ b/srcpkgs/nagios/template
@@ -10,37 +10,34 @@ _instdir="/usr/share/nagios"
 _bindir="/usr/bin"
 _vardir="/var/nagios"
 _confdir="/etc/nagios"
-_httpdconfdir="/etc/webapps/$pkgname/"
+_httpdconfdir="/etc/webapps/nagios/"
 _checkresultdir="/var/nagios/spool/checkresults"
 _cgibindir="/usr/libexec/nagios/cgi"
 
 configure_args="
-	--with-nagios-user=$_nagios_user
-	--with-nagios-group=$_nagios_group
-	--prefix=$_instdir
-	--bindir=$_bindir
-	--localstatedir=$_vardir
-	--sysconfdir=$_confdir
-	--with-httpd-conf=$_httpdconfdir
-	--with-checkresultdir=$_checkresultdir
-	--with-cgibindir=$_cgibindir
-	--enable-embedded-perl"
+ --with-nagios-user=$_nagios_user
+ --with-nagios-group=$_nagios_group
+ --prefix=$_instdir
+ --bindir=$_bindir
+ --localstatedir=$_vardir
+ --sysconfdir=$_confdir
+ --with-httpd-conf=$_httpdconfdir
+ --with-checkresultdir=$_checkresultdir
+ --with-cgibindir=$_cgibindir
+ --enable-embedded-perl"
 make_build_args="all"
-make_install_args="
-	prefix=$_instdir
-	BINDIR=$_bindir
-	LOGDIR=$_vardir
-	CFGDIR=$_confdir
-	HTTPD_CONF=$_httpdconfdir
-	CHECKRESULTDIR=$_checkresultdir
-	CGIDIR=$_cgibindir
-	install install-config"
+make_install_args="install install-config"
 
-makedepends="perl unzip"
-make_dirs="/etc/nagios 0775 _nagios _nagios"
+hostmakedepends="perl unzip"
+make_dirs="
+$_confdir 0775 _nagios _nagios
+$_vardir 0755 _nagios _nagios
+$_vardir/rw 0755 _nagios _nagios
+$_vardir/spool 0755 _nagios _nagios
+$_vardir/spool/checkresults 0755 _nagios _nagios"
 conf_files="/etc/nagios/nagios.cfg"
 
-short_desc="Nagios Core"
+short_desc="Nagios Core monitoring and alerting engine"
 maintainer="Dave Eddy <dave@daveeddy.com>"
 license="GPL-2.0-or-later"
 
@@ -52,10 +49,6 @@ checksum=ab0d5a52caf01e6f4dcd84252c4eb5df5a24f90bb7f951f03875eef54f5ab0f4
 system_accounts="${_nagios_user}"
 
 post_install() {
-	# these dirs are wiped away by the void post install hooks since they are empty
-	vmkdir "$_vardir/rw"
-	vmkdir "$_vardir/spool/check/results"
-
 	# nagios has these set as 770 by default
 	chmod 755 "$DESTDIR/$_bindir/nagios"
 	chmod 755 "$DESTDIR/$_bindir/nagiostats"

--- a/srcpkgs/nagios/template
+++ b/srcpkgs/nagios/template
@@ -1,0 +1,64 @@
+# Template file for 'nagios'
+pkgname=nagios
+version=4.4.6
+revision=1
+build_style=gnu-configure
+
+_nagios_user="_nagios"
+_nagios_group="_nagios"
+_instdir="/usr/share/nagios"
+_bindir="/usr/bin"
+_vardir="/var/nagios"
+_confdir="/etc/nagios"
+_httpdconfdir="/etc/webapps/$pkgname/"
+_checkresultdir="/var/nagios/spool/checkresults"
+_cgibindir="/usr/libexec/nagios/cgi"
+
+configure_args="
+	--with-nagios-user=$_nagios_user
+	--with-nagios-group=$_nagios_group
+	--prefix=$_instdir
+	--bindir=$_bindir
+	--localstatedir=$_vardir
+	--sysconfdir=$_confdir
+	--with-httpd-conf=$_httpdconfdir
+	--with-checkresultdir=$_checkresultdir
+	--with-cgibindir=$_cgibindir
+	--enable-embedded-perl"
+make_build_args="all"
+make_install_args="
+	prefix=$_instdir
+	BINDIR=$_bindir
+	LOGDIR=$_vardir
+	CFGDIR=$_confdir
+	HTTPD_CONF=$_httpdconfdir
+	CHECKRESULTDIR=$_checkresultdir
+	CGIDIR=$_cgibindir
+	install install-config"
+
+makedepends="perl unzip"
+make_dirs="/etc/nagios 0775 _nagios _nagios"
+conf_files="/etc/nagios/nagios.cfg"
+
+short_desc="Nagios Core"
+maintainer="Dave Eddy <dave@daveeddy.com>"
+license="GPL-2.0-or-later"
+
+homepage="https://github.com/NagiosEnterprises/nagioscore"
+changelog="${homepage}/blob/master/Changelog"
+distfiles="${homepage}/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.gz"
+
+checksum=ab0d5a52caf01e6f4dcd84252c4eb5df5a24f90bb7f951f03875eef54f5ab0f4
+system_accounts="${_nagios_user}"
+
+post_install() {
+	# these dirs are wiped away by the void post install hooks since they are empty
+	vmkdir "$_vardir/rw"
+	vmkdir "$_vardir/spool/check/results"
+
+	# nagios has these set as 770 by default
+	chmod 755 "$DESTDIR/$_bindir/nagios"
+	chmod 755 "$DESTDIR/$_bindir/nagiostats"
+
+	vsv nagios
+}

--- a/srcpkgs/nagios/template
+++ b/srcpkgs/nagios/template
@@ -6,6 +6,7 @@ build_style=gnu-configure
 
 _nagios_user="_nagios"
 _nagios_group="_nagios"
+_bindir="/usr/bin"
 _vardir="/var/nagios"
 _confdir="/etc/nagios"
 _webdir="/usr/share/nagios"

--- a/srcpkgs/nagios/template
+++ b/srcpkgs/nagios/template
@@ -6,35 +6,31 @@ build_style=gnu-configure
 
 _nagios_user="_nagios"
 _nagios_group="_nagios"
-_instdir="/usr/share/nagios"
-_bindir="/usr/bin"
 _vardir="/var/nagios"
 _confdir="/etc/nagios"
-_httpdconfdir="/etc/webapps/nagios/"
+_webdir="/usr/share/nagios"
 _checkresultdir="/var/nagios/spool/checkresults"
 _cgibindir="/usr/libexec/nagios/cgi"
 
 configure_args="
  --with-nagios-user=$_nagios_user
  --with-nagios-group=$_nagios_group
- --prefix=$_instdir
- --bindir=$_bindir
  --localstatedir=$_vardir
  --sysconfdir=$_confdir
  --with-httpd-conf=$_httpdconfdir
  --with-checkresultdir=$_checkresultdir
  --with-cgibindir=$_cgibindir
+ --with-webdir=$_webdir
  --enable-embedded-perl"
 make_build_args="all"
 make_install_args="install install-config"
 
 hostmakedepends="perl unzip"
 make_dirs="
-$_confdir 0775 _nagios _nagios
-$_vardir 0755 _nagios _nagios
-$_vardir/rw 0755 _nagios _nagios
-$_vardir/spool 0755 _nagios _nagios
-$_vardir/spool/checkresults 0755 _nagios _nagios"
+$_vardir 0770 _nagios _nagios
+$_vardir/rw 0770 _nagios _nagios
+$_vardir/spool 0770 _nagios _nagios
+$_vardir/spool/checkresults 0770 _nagios _nagios"
 conf_files="/etc/nagios/nagios.cfg"
 
 short_desc="Nagios Core monitoring and alerting engine"
@@ -49,7 +45,9 @@ checksum=ab0d5a52caf01e6f4dcd84252c4eb5df5a24f90bb7f951f03875eef54f5ab0f4
 system_accounts="${_nagios_user}"
 
 post_install() {
-	# nagios has these set as 770 by default
+	# nagios has these set as 770 by default (owner and group are both
+	# "root").  Leaving these as 770 and executing nagios as root results
+	# in an error.
 	chmod 755 "$DESTDIR/$_bindir/nagios"
 	chmod 755 "$DESTDIR/$_bindir/nagiostats"
 


### PR DESCRIPTION
`nrpe` and `monitoring-plugins` are already available as packages... this changes adds the nagios core itself into the set of available packages.

4.4.6 is the latest release available.

### Testing

I built the package and installed it with:

```
./xbps-src -f pkg nagios
xi nagios
```

I then enabled the service:

```
ln -s /etc/sv/nagios /var/service
```

And verified it was running with:

```
$ sudo cat /var/service/nagios/supervise/pid
30982
$ nagiostats 

Nagios Stats 4.4.6
Copyright (c) 2003-2008 Ethan Galstad (www.nagios.org)
Last Modified: 2020-04-28
License: GPL

CURRENT STATUS DATA
------------------------------------------------------
Status File:                            /var/nagios/status.dat
Status File Age:                        0d 0h 0m 3s
Status File Version:                    4.4.6

Program Running Time:                   0d 0h 0m 3s
Nagios PID:                             30982

```

Notice the PID in the `nagiostats` output matches the PID according to runit.