### PR TITLE
python3-zope.location: fix homepage url

### DIFF
--- a/srcpkgs/python3-zope.location/template
+++ b/srcpkgs/python3-zope.location/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-zope.location'
 pkgname=python3-zope.location
 version=4.2
-revision=2
+revision=3
 archs=noarch
 wrksrc="zope.location-${version}"
 build_style=python3-module
@@ -13,6 +13,6 @@ checkdepends="python3-zope.copy python3-zope.testrunner"
 short_desc="Zope location"
 maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="ZPL-2.1"
-homepage="https://github.com/zopefederation/zope.location"
+homepage="https://github.com/zopefoundation/zope.location"
 distfiles="${PYPI_SITE}/z/zope.location/zope.location-${version}.tar.gz"
 checksum=a720f9e3c8a51d5007ed6fcd47e1834df02671d85dbfd1062a0d808de8bf80ac


### PR DESCRIPTION
Revbump to update metadata in `xbps-query -S`