### PR TITLE
New package: libmali-rk-bifrost-g31-rxp0-gbm-r6p0.01rel0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -121,8 +121,11 @@ libGLU.so.1 glu-9.0.0_1
 libGL.so.1 libGL-7.11_1
 libEGL.so.1 libEGL-7.11_1
 libGLESv1_CM.so.1 libGLES-1.0_1
+libGLESv1_CM.so libmali-rk-bifrost-g31-rxp0-gbm-r6p0.01rel0_1
 libGLESv2.so.2 libGLES-1.0_1
+libGLESv2.so.2 libmali-rk-bifrost-g31-rxp0-gbm-r6p0.01rel0_1
 libEGL.so rpi-userland-0.0.0.0.20150907_1
+libEGL.so libmali-rk-bifrost-g31-rxp0-gbm-r6p0.01rel0_1
 libGLESv2.so rpi-userland-0.0.0.0.20150907_1
 libGLESv2.so atom-1.41.0_1
 libGLESv2.so opera-55.0.2994.37_2
@@ -133,6 +136,7 @@ libGLESv2.so wire-desktop-3.6.2885_1
 libGLESv2.so vscode-1.36.1_1
 libGLESv2.so Signal-Desktop-1.23.2_1
 libGLESv2.so slack-desktop-3.4.2_1
+libGLESv2.so libmali-rk-bifrost-g31-rxp0-gbm-r6p0.01rel0_1
 libbrcmEGL.so rpi-userland-20180103_2
 libbrcmGLESv2.so rpi-userland-20180103_2
 libbrcmOpenVG.so rpi-userland-20180103_2
@@ -153,6 +157,7 @@ libnvidia-fatbinaryloader.so.390.138 nvidia390-libs-390.138_1 ignore
 libnvidia-fatbinaryloader.so.430.40 nvidia-libs-430.40_1 ignore
 libglapi.so.0 libglapi-7.11_1
 libgbm.so.1 libgbm-9.0_1
+libgbm.so.1 libmali-rk-bifrost-g31-rxp0-gbm-r6p0.01rel0_1
 libOpenGL.so.0 libglvnd-1.3.0_1
 libGLX.so.0 libglvnd-1.3.0_1
 librsvg-2.so.2 librsvg-2.26.0_1

--- a/srcpkgs/libmali-rk-bifrost-g31-rxp0-gbm/files/50-mali.rules
+++ b/srcpkgs/libmali-rk-bifrost-g31-rxp0-gbm/files/50-mali.rules
@@ -1,0 +1,1 @@
+KERNEL=="mali0", MODE="0666", GROUP="video"

--- a/srcpkgs/libmali-rk-bifrost-g31-rxp0-gbm/files/libmali-bifrost.conf
+++ b/srcpkgs/libmali-rk-bifrost-g31-rxp0-gbm/files/libmali-bifrost.conf
@@ -1,0 +1,1 @@
+/usr/lib/mali

--- a/srcpkgs/libmali-rk-bifrost-g31-rxp0-gbm/template
+++ b/srcpkgs/libmali-rk-bifrost-g31-rxp0-gbm/template
@@ -1,0 +1,48 @@
+# Template file for 'libmali-rk-bifrost-g31-rxp0-gbm'
+pkgname=libmali-rk-bifrost-g31-rxp0-gbm
+version=r6p0.01rel0
+revision=1
+_gitrev=7fca6310eceb5b85062259ed8f4a5c1cf44fe773
+wrksrc="libmali-${_gitrev}"
+short_desc="Rockchip mali bifrost g31 gbm"
+maintainer="valadaa48 <valadaa48@gmx.com>"
+license="Unlicense"
+homepage="https://github.com/rockchip-linux/libmali"
+distfiles="https://github.com/rockchip-linux/libmali/archive/${_gitrev}.tar.gz"
+checksum=49fdd86cc046e109ecb610fc2bde6bdbe2c63cd5e2aaba6bcdc4f00add884ea3
+makedepends="libdrm"
+provides="libEGL-1.0_1 libGLES-1.0_1"
+replaces="libEGL>=0 libGLES>=0"
+shlib_provides="libEGL.so libgbm.so.1 libGLESv2.so libGLESv1_CM.so"
+archs="aarch64 armv7l*"
+
+do_install() {
+    local _lib _dir
+    _lib="libmali-bifrost-g31-rxp0-gbm.so"
+
+    case "$XBPS_TARGET_MACHINE" in
+        aarch64*) _dir="aarch64-linux-gnu";;
+        arm*) _dir="arm-linux-gnueabihf";;
+    esac
+
+    vinstall lib/${_dir}/${_lib} 755 usr/lib/mali
+
+    cd ${DESTDIR}/usr/lib/mali
+    ln -sf ${_lib} libEGL.so
+    ln -sf ${_lib} libEGL.so.1
+    ln -sf ${_lib} libEGL.so.1.0.0
+    ln -sf ${_lib} libEGL.so.1.1.0
+    ln -sf ${_lib} libGLESv1_CM.so
+    ln -sf ${_lib} libGLESv1_CM.so.1
+    ln -sf ${_lib} libGLESv1_CM.so.1.1.0
+    ln -sf ${_lib} libGLESv2.so
+    ln -sf ${_lib} libGLESv2.so.2
+    ln -sf ${_lib} libGLESv2.so.2.0.0
+    ln -sf ${_lib} libgbm.so.1
+    ln -sf ${_lib} libgbm.so
+    ln -sf ${_lib} libMali.so
+    ln -sf ${_lib} libmali.so
+
+    vinstall ${FILESDIR}/50-mali.rules 644 usr/lib/udev/rules.d
+    vinstall ${FILESDIR}/libmali-bifrost.conf 644 etc/ld.so.conf.d
+}


### PR DESCRIPTION
mali graphics drivers. This is somewhat of a tricky package as it includes files that conflict with mesa and other packages. Debian splits their packages so it's less of an issue for them. I based this off of  https://github.com/rockchip-linux/libmali/blob/master/debian/control.

Please let me know if specific changes around provides and shlibs are needed. I'm running this package on my device and it's working but I obviously want this package to be void compliant.