### PR TITLE
Add android udev rules package

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,11 +1,12 @@
 # Template file for 'android-tools'
 pkgname=android-tools
 version=29.0.6
-revision=1
+revision=2
 archs="armv* aarch64* x86_64* i686*"
 build_style=cmake
 hostmakedepends="perl go"
 makedepends="gtest-devel zlib-devel libressl-devel libusb-devel pcre2-devel"
+depends="android-udev-rules"
 short_desc="Android platform tools (adb and fastboot)"
 maintainer="John <johnz@posteo.net>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"

--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,0 +1,14 @@
+# Template file for 'android-udev-rules'
+pkgname=android-udev-rules
+version=20200613
+revision=1
+short_desc="Android udev rules list aimed to be the most comprehensive on the net"
+maintainer="Rien Maertens <rien.maertens@posteo.be>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/M0Rf30/android-udev-rules"
+distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
+checksum=8c7fad8cf97fe106f826f07aa9f033e9aa9ee69422b35dada6d9d2df878b5473
+
+do_install() {
+	vinstall 51-android.rules 644 usr/lib/udev/rules.d 51-android.rules
+}


### PR DESCRIPTION
This pr adds the [android-udev-rules](https://github.com/M0Rf30/android-udev-rules) package, an udev rules list for android devices.

If one installs the `android-tools` (the `adb` command), they will almost always want this installed too. So I've added this package as a dependency.