### PR TITLE
python3-scipy: update to 1.5.0; make cross compilation work

### DIFF
--- a/srcpkgs/python3-scipy/template
+++ b/srcpkgs/python3-scipy/template
@@ -1,13 +1,12 @@
 # Template file for 'python3-scipy'
 pkgname=python3-scipy
-version=1.3.2
-revision=2
+version=1.5.0
+revision=1
 wrksrc="scipy-${version}"
 build_style=python3-module
-pycompile_module="scipy"
 make_check_args="--force"
-hostmakedepends="python3-setuptools python3-Cython gcc-fortran"
-makedepends="python3-devel python3-numpy lapack-devel"
+hostmakedepends="python3-setuptools python3-Cython python3-numpy gcc-fortran"
+makedepends="python3-devel python3-numpy python3-pybind11 lapack-devel openblas-devel"
 depends="python3-numpy"
 checkdepends="python3-nose"
 short_desc="Scientific library for Python3"
@@ -15,11 +14,39 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://scipy.org/scipylib/"
 distfiles="https://github.com/scipy/scipy/releases/download/v${version}/scipy-${version}.tar.xz"
-checksum=1d2f09bcb6c4b66a65d9f49d21fa065f5396c940edac8285b87947b8d21b55f8
+checksum=23baeaa18803d12d1abdff3f5c148b1085c2dc4028c6b8efce652dde2119b41c
 
-nocross="https://build.voidlinux.org/builders/aarch64_builder/builds/24733/steps/shell_3/logs/stdio"
+if [ "$CROSS_BUILD" ]; then
+	# Make sure numpy is found for the target arch first
+	CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/include"
+	LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/lib"
 
-LDFLAGS+="-shared"
+	# Tell numpy.distutils where to find FORTRAN compilers
+	export F77="${FC}"
+	export F90="${FC}"
+fi
+
+LDFLAGS+=" -shared"
+
+pre_build() {
+	cat > site.cfg <<-EOF
+	[openblas]
+	libraries = openblas
+	EOF
+
+	if [ "$CROSS_BUILD" ]; then
+		# Make sure scipy knows how to find openblas
+		cat >> site.cfg <<-EOF
+		library_dirs = ${XBPS_CROSS_BASE}/usr/lib
+		include_dirs = ${XBPS_CROSS_BASE}/usr/include
+		runtime_library_dirs = ${XBPS_CROSS_BASE}/usr/lib
+		EOF
+
+		# numpy.distutils refuses to find the right linker for FORTRAN
+		# Link the cross compiler so the module will find it as gfortran
+		ln -sf "/usr/bin/${FC}" "${XBPS_WRAPPERDIR}/gfortran"
+	fi
+}
 
 post_install() {
 	rm ${DESTDIR}/${py3_sitelib}/scipy/*.txt

--- a/srcpkgs/python3-trimesh/template
+++ b/srcpkgs/python3-trimesh/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-trimesh'
 pkgname=python3-trimesh
-version=3.6.43
+version=3.7.4
 revision=1
 archs=noarch
 wrksrc="trimesh-${version}"
@@ -13,7 +13,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="MIT"
 homepage="https://trimsh.org/"
 distfiles="https://github.com/mikedh/trimesh/archive/${version}.tar.gz"
-checksum=b7614cf37723f2d1f11420253da0bd2bb0ec9fab6dc6afd3486d70780df2841d
+checksum=05818e5332337734fb1d0df706a80ea81398641f31274d51fef488cbd988f066
 
 post_install() {
 	vlicense LICENSE.md


### PR DESCRIPTION
The `numpy.distutils` build system used by `scipy` isn't very smart about cross-compiling FORTRAN, but I've managed to jump through hoops needed to get cross compilation to work.

This supersedes #22181.