### PR TITLE
nemo-fileroller: depend on file-roller; fix short_desc

### DIFF
--- a/srcpkgs/nemo-fileroller/template
+++ b/srcpkgs/nemo-fileroller/template
@@ -1,13 +1,14 @@
 # Template file for 'nemo-fileroller'
 pkgname=nemo-fileroller
 version=4.6.0
-revision=1
+revision=2
 wrksrc="nemo-extensions-${version}"
 build_wrksrc=nemo-fileroller
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="nemo-devel libglib-devel"
-short_desc="Extensions for the Nemo file manager"
+depends="file-roller"
+short_desc="Nemo file roller extension"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/linuxmint/nemo-extensions"


### PR DESCRIPTION
This package only adds entries to the context menu in Nemo,
`file-roller` provides compress and extract functionality.