### PR TITLE
build-style/cargo: pass config_args in do_check.

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -11,7 +11,8 @@ do_build() {
 do_check() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} test --release ${make_check_args}
+	${make_cmd} test --release --target ${RUST_TARGET} ${configure_args} \
+		${make_check_args}
 }
 
 do_install() {


### PR DESCRIPTION
Cargo rebuilds the package if the configure_args aren't the same, which
makes it test the wrong binary.