### PR TITLE
android-udev-rules: create adbusers group

### DIFF
--- a/srcpkgs/android-udev-rules/INSTALL.msg
+++ b/srcpkgs/android-udev-rules/INSTALL.msg
@@ -1,0 +1,3 @@
+To use adb, add your user to the 'adbusers' group.
+
+    # usermod -aG adbusers <username>

--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,13 +1,15 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
 version=20200613
-revision=1
+revision=2
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Rien Maertens <rien.maertens@posteo.be>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
 checksum=8c7fad8cf97fe106f826f07aa9f033e9aa9ee69422b35dada6d9d2df878b5473
+
+system_groups="adbusers"
 
 do_install() {
 	vinstall 51-android.rules 644 usr/lib/udev/rules.d 51-android.rules


### PR DESCRIPTION
If desired, I could also add a `post_install` function to run `udevadm control --reload`?