### PR TITLE
Add udev-rules.d-dir trigger to reload udev rules

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -56,6 +56,7 @@ packages for XBPS, the `Void Linux` native packaging system.
 		* [gtk-pixbuf-loaders](#triggers_gtk_pixbuf_loaders)
 		* [gtk3-immodules](#triggers_gtk3_immodules)
 		* [hwdb.d-dir](#triggers_hwdb.d_dir)
+		* [udev-rules.d-dir](#triggers_udev-rules.d_dir)
 		* [info-files](#triggers_info_files)
 		* [kernel-hooks](#triggers_kernel_hooks)
 		* [mimedb](#triggers_mimedb)
@@ -1764,6 +1765,16 @@ The hwdb.d-dir trigger is responsible for updating the hardware database.
 During installation and removal it runs `usr/bin/udevadm hwdb --root=. --update`.
 
 It is automatically added to packages that have `/usr/lib/udev/hwdb.d` present
+as a directory.
+
+<a id="triggers_udev-rules.d_dir"></a>
+#### udev-rules.d-dir
+
+The udev-rules.d-dir trigger is responsible for reloading udev rules.
+
+During installation and removal it runs `usr/bin/udevadm control --reload`.
+
+It is automatically added to packages that have `/usr/lib/udev/rules.d` present
 as a directory.
 
 <a id="triggers_info_files"></a>

--- a/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
+++ b/common/hooks/post-install/04-create-xbps-metadata-scripts.sh
@@ -150,6 +150,12 @@ _EOF
 		_add_trigger hwdb.d-dir
 	fi
 	#
+	# Handle files in udev rules directory
+	#
+	if [ -d "${PKGDESTDIR}/usr/lib/udev/rules.d" ]; then
+		_add_trigger udev-rules.d-dir
+	fi
+	#
 	# (Un)Register a shell in /etc/shells.
 	#
 	if [ -n "${register_shell}" ]; then

--- a/srcpkgs/xbps-triggers/files/udev-rules.d-dir
+++ b/srcpkgs/xbps-triggers/files/udev-rules.d-dir
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Reload udev rules
+#
+# Arguments:	$ACTION = [run/targets]
+#		$TARGET = [post-install/pre-remove]
+#		$PKGNAME
+#		$VERSION
+#		$UPDATE = [yes/no]
+#
+ACTION="$1"
+TARGET="$2"
+PKGNAME="$3"
+VERSION="$4"
+UPDATE="$5"
+
+udevadm=usr/bin/udevadm
+
+case "$ACTION" in
+targets)
+	echo "post-install pre-remove"
+	;;
+run)
+	if [ ! -x $udevadm ]; then
+		exit 0
+	fi
+
+	echo "Reloading udev rules  ..."
+	$udevadm control --reload || echo "Reloading failed, is udevd running?"
+	;;
+*)
+	exit 1
+	;;
+esac
+
+exit 0

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.114
+version=0.115
 revision=1
 archs=noarch
 bootstrap=yes


### PR DESCRIPTION
As discussed in #23307 and #23284, this adds a trigger which automatically runs `udevadm control --reload` when the udev rules change. This is basically a copy of the `hwdb.d-dir` trigger.