### PR TITLE
android-studio: fix skiprdeps

### DIFF
--- a/srcpkgs/android-studio/template
+++ b/srcpkgs/android-studio/template
@@ -1,7 +1,7 @@
 # Template file for 'android-studio'
 pkgname=android-studio
 version=4.0.0
-revision=1
+revision=2
 # _studio_build and _studio_rev are for downloading the zip from dl.google.com
 # https://developer.android.com/studio/#resources as of 2018-07-12
 _studio_build=193.6514223
@@ -49,10 +49,10 @@ skiprdeps="/opt/android-studio/plugins/android/resources/perfetto/x86_64/traced_
  /opt/android-studio/plugins/android/resources/installer/arm64-v8a/installer
  /opt/android-studio/plugins/android/resources/installer/test-installer
  /opt/android-studio/plugins/android/resources/installer/armeabi-v7a/installer
- /opt/android-studio/plugins/android/resources/transport/agent/arm64-v8a/libjvmtiagent.so
- /opt/android-studio/plugins/android/resources/transport/agent/armeabi-v7a/libjvmtiagent.so
- /opt/android-studio/plugins/android/resources/transport/agent/x86/libjvmtiagent.so
- /opt/android-studio/plugins/android/resources/transport/agent/x86_64/libjvmtiagent.so
+ /opt/android-studio/plugins/android/resources/transport/native/agent/arm64-v8a/libjvmtiagent.so
+ /opt/android-studio/plugins/android/resources/transport/native/agent/armeabi-v7a/libjvmtiagent.so
+ /opt/android-studio/plugins/android/resources/transport/native/agent/x86/libjvmtiagent.so
+ /opt/android-studio/plugins/android/resources/transport/native/agent/x86_64/libjvmtiagent.so
  /opt/android-studio/plugins/android/resources/transport/armeabi-v7a/transport
  /opt/android-studio/plugins/android/resources/transport/x86/transport
  /opt/android-studio/plugins/android/resources/transport/arm64-v8a/transport


### PR DESCRIPTION
Apparently in the new version of android studio, `libjvmtiagent.so` library was moved to the different location, but  `skiprdeps` were not updated, which caused [this issue](https://old.reddit.com/r/voidlinux/comments/hhulh9/help_missing_musl_im_trying_to_build/).