### PR TITLE
gjs: update to 1.65.3;  mozjs68: update to 68.10.0

### DIFF
--- a/srcpkgs/gjs/template
+++ b/srcpkgs/gjs/template
@@ -1,6 +1,6 @@
 # Template file for 'gjs'
 pkgname=gjs
-version=1.65.2
+version=1.65.3
 revision=1
 build_style=meson
 build_helper="gir qemu"
@@ -12,9 +12,9 @@ short_desc="Mozilla-based javascript bindings for the GNOME platform"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/action/show/Projects/Gjs"
-changelog="https://gitlab.gnome.org/GNOME/gjs/blob/gnome-3-30/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gjs/blob/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=a66edad8a5f10027f9b182d88af84b81f13e5ad5840319cfa747d66e77e0214f
+checksum=37f2e1b7bc2b8c141c045d30ef12ce1c2197c4bf133a767d490404933fcd3ea0
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/mozjs68/template
+++ b/srcpkgs/mozjs68/template
@@ -1,7 +1,7 @@
 # Template file for 'mozjs68'
 pkgname=mozjs68
-version=68.8.0
-revision=2
+version=68.10.0
+revision=1
 wrksrc="firefox-${version}"
 build_wrksrc=js/src
 build_style=gnu-configure
@@ -15,7 +15,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/js/"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
-checksum=fa5b2266d225878d4b35694678f79fd7e7a6d3c62759a40326129bd90f63e842
+checksum=2ec8c2627e46e80fc208584966a2ded7a0a9ff76b55ffccec0623b89b98ded2b
 patch_args="-Np1"
 CXXFLAGS="-Wno-class-memaccess"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"


### PR DESCRIPTION
When cross-building mozjs68, I get this warning: 
```
mozjs68-devel-68.10.0_1: running post-install hook: 99-pkglint-warn-cross-cruft ...

=> WARNING: /usr/bin/js68-config has cross cruft
```
Something to worry about?