### PR TITLE
python3-scikit-video: move deps to allow cross-compilation

### DIFF
--- a/srcpkgs/python3-scikit-video/template
+++ b/srcpkgs/python3-scikit-video/template
@@ -1,12 +1,11 @@
 # Template file for 'python3-scikit-video'
 pkgname=python3-scikit-video
 version=1.1.11
-revision=1
+revision=2
 wrksrc="scikit-video-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-makedepends="python3-devel python3-numpy python3-scipy python3-Pillow"
-depends="python3-numpy python3-scipy python3-Pillow"
+hostmakedepends="python3-setuptools python3-scipy python3-Pillow"
+depends="python3-scipy python3-Pillow"
 short_desc="Video processing in Python, which is modeled around scikit packages"
 maintainer="ash <bhat40436@gmail.com>"
 license="BSD-3-Clause"


### PR DESCRIPTION
This will prevent a failure on the cross-compiling builders.