### PR TITLE
qt5: get rid of EVP_CipherFinal warning

### DIFF
--- a/srcpkgs/qt5/patches/qtnetwork-5.15.0-libressl.patch
+++ b/srcpkgs/qt5/patches/qtnetwork-5.15.0-libressl.patch
@@ -338,3 +338,45 @@ index f35e0ba2..30097317 100644
 -- 
 2.25.0
 
+--- qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp	2020-05-11 10:15:08.000000000 +0200
++++ qtbase/src/network/ssl/qsslsocket_openssl_symbols.cpp	2020-07-01 17:06:34.471202351 +0200
+@@ -264,7 +264,7 @@
+ DEFINEFUNC5(int, EVP_CipherInit, EVP_CIPHER_CTX *ctx, ctx, const EVP_CIPHER *type, type, const unsigned char *key, key, const unsigned char *iv, iv, int enc, enc, return 0, return)
+ DEFINEFUNC6(int, EVP_CipherInit_ex, EVP_CIPHER_CTX *ctx, ctx, const EVP_CIPHER *cipher, cipher, ENGINE *impl, impl, const unsigned char *key, key, const unsigned char *iv, iv, int enc, enc, return 0, return)
+ DEFINEFUNC5(int, EVP_CipherUpdate, EVP_CIPHER_CTX *ctx, ctx, unsigned char *out, out, int *outl, outl, const unsigned char *in, in, int inl, inl, return 0, return)
+-DEFINEFUNC3(int, EVP_CipherFinal, EVP_CIPHER_CTX *ctx, ctx, unsigned char *out, out, int *outl, outl, return 0, return)
++DEFINEFUNC3(int, EVP_CipherFinal_ex, EVP_CIPHER_CTX *ctx, ctx, unsigned char *out, out, int *outl, outl, return 0, return)
+ DEFINEFUNC(const EVP_MD *, EVP_get_digestbyname, const char *name, name, return nullptr, return)
+ #ifndef OPENSSL_NO_DES
+ DEFINEFUNC(const EVP_CIPHER *, EVP_des_cbc, DUMMYARG, DUMMYARG, return nullptr, return)
+@@ -962,7 +962,7 @@
+     RESOLVEFUNC(EVP_CipherInit)
+     RESOLVEFUNC(EVP_CipherInit_ex)
+     RESOLVEFUNC(EVP_CipherUpdate)
+-    RESOLVEFUNC(EVP_CipherFinal)
++    RESOLVEFUNC(EVP_CipherFinal_ex)
+     RESOLVEFUNC(EVP_get_digestbyname)
+ #ifndef OPENSSL_NO_DES
+     RESOLVEFUNC(EVP_des_cbc)
+--- qtbase/src/network/ssl/qsslkey_openssl.cpp	2020-05-11 10:15:08.000000000 +0200
++++ qtbase/src/network/ssl/qsslkey_openssl.cpp	2020-07-01 17:58:44.674363835 +0200
+@@ -360,7 +360,7 @@
+     q_EVP_CipherUpdate(ctx,
+         reinterpret_cast<unsigned char *>(output.data()), &len,
+         reinterpret_cast<const unsigned char *>(data.constData()), data.size());
+-    q_EVP_CipherFinal(ctx,
++    q_EVP_CipherFinal_ex(ctx,
+         reinterpret_cast<unsigned char *>(output.data()) + len, &i);
+     len += i;
+ 
+--- qtbase/src/network/ssl/qsslsocket_openssl_symbols_p.h	2020-07-01 18:00:20.748368792 +0200
++++ qtbase/src/network/ssl/qsslsocket_openssl_symbols_p.h	2020-07-01 18:04:38.177382072 +0200
+@@ -429,7 +429,7 @@
+ int q_EVP_CipherInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type, const unsigned char *key, const unsigned char *iv, int enc);
+ int q_EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher, ENGINE *impl, const unsigned char *key, const unsigned char *iv, int enc);
+ int q_EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+-int q_EVP_CipherFinal(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
++int q_EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+ const EVP_MD *q_EVP_get_digestbyname(const char *name);
+ 
+ #ifndef OPENSSL_NO_DES

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
 version=5.15.0
-revision=1
+revision=2
 wrksrc="qt-everywhere-src-${version}"
 build_style=meta
 hostmakedepends="cmake clang flex perl glib-devel pkg-config


### PR DESCRIPTION
If EVP_CipherFinal is used, libressl always prints a linker warning:
/bin/ld: /usr/lib/libQt5Network.so: warning: EVP_CipherFinal is often misused,
         please use EVP_CipherFinal_ex and EVP_CIPHER_CTX_cleanup

Extend the qtnetwork-5.15.0-libressl.patch to replace EVP_CipherFinal()
with EVP_CipherFinal_ex() and add a call to EVP_CIPHER_CTX_cleanup(ctx).

[ci skip]