### PR TITLE
volumeicon: add libnotify patch.

### DIFF
--- a/srcpkgs/volumeicon/patches/notify.patch
+++ b/srcpkgs/volumeicon/patches/notify.patch
@@ -1,0 +1,22 @@
+From 78a9c23775ebe12d3f3be93c0798144a6e732d90 Mon Sep 17 00:00:00 2001
+From: John Lindgren <john.lindgren@aol.com>
+Date: Wed, 30 Dec 2015 20:50:46 -0500
+Subject: [PATCH] Add missing space in NOTIFY_CFLAGS.
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6ad78d5..c8b72bd 100644
+--- configure.ac
++++ configure.ac
+@@ -86,7 +86,7 @@ fi
+ if test "x${notify}" = xyes; then
+ # Check for libnotify
+ PKG_CHECK_MODULES([NOTIFY], [libnotify >= 0.5.0])
+-NOTIFY_CFLAGS+="-DCOMPILEWITH_NOTIFY"
++NOTIFY_CFLAGS+=" -DCOMPILEWITH_NOTIFY"
+ AC_SUBST(NOTIFY_CFLAGS)
+ AC_SUBST(NOTIFY_LIBS)
+ fi

--- a/srcpkgs/volumeicon/template
+++ b/srcpkgs/volumeicon/template
@@ -1,14 +1,20 @@
 # Template file for 'volumeicon'
 pkgname=volumeicon
 version=0.5.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-notify"
-hostmakedepends="pkg-config intltool"
-makedepends="alsa-lib-devel libnotify-devel gtk+3-devel"
+# automake, glib-devel and gettext-devel are needed for pre_configure
+hostmakedepends="pkg-config intltool automake glib-devel gettext-devel"
+makedepends="alsa-lib-devel libnotify-devel gtk+3-devel glib-devel gettext-devel"
 short_desc="Lightweight volume control that sits in your systray"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3"
 homepage="http://softwarebakery.com/maato/volumeicon.html"
 distfiles="http://softwarebakery.com/maato/files/volumeicon/volumeicon-${version}.tar.gz"
 checksum=24b8c1d0a81d708b201ce6e67301fc175d65588d892d01859f667b8db8a05da0
+
+# necessary because of notify patch
+pre_configure() {
+    autoreconf -fi
+}


### PR DESCRIPTION
Changes to the configure.ac file required new build time dependencies as well.

Fixes #23357 