### PR TITLE
opencv: update to 3.4.10.

### DIFF
--- a/srcpkgs/opencv/template
+++ b/srcpkgs/opencv/template
@@ -1,25 +1,40 @@
 # Template file for 'opencv'
 pkgname=opencv
-version=3.4.8
-revision=3
+version=3.4.10
+revision=1
 build_style=cmake
 configure_args="-DENABLE_PRECOMPILED_HEADERS=OFF -DWITH_OPENMP=ON
  -DWITH_OPENCL=ON -DENABLE_CXX11=ON -DOPENCV_SKIP_PYTHON_LOADER=ON
  -DOPENCV_PYTHON3_INSTALL_PATH=/${py3_sitelib}
  -DOPENCV_PYTHON_INSTALL_PATH=/${py2_sitelib}"
-hostmakedepends="pkg-config eigen"
+hostmakedepends="pkg-config eigen python-numpy python3-numpy"
 makedepends="ffmpeg-devel libpng-devel libjpeg-turbo-devel tiff-devel
  jasper-devel ocl-icd-devel libgomp-devel libopenexr-devel gtk+3-devel
- libgphoto2-devel gst-plugins-base1-devel openblas-devel"
+ libgphoto2-devel gst-plugins-base1-devel openblas-devel
+ python-numpy python3-numpy python-devel python3-devel"
 short_desc="Computer vision and machine learning software library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://opencv.org"
 distfiles="https://github.com/opencv/${pkgname}/archive/${version}.tar.gz"
-checksum=f0901648a1db3dc3af30e65082665921dbe998673137380450bdd91e8251b567
+checksum=1ed6f5b02a7baf14daca04817566e7c98ec668cec381e0edf534fa49f10f58a2
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
+fi
+
+if [ -z "$XBPS_CHECK_PKGS" ]; then
+	# opencv by default builds tests that only seem to be used in make check
+	configure_args+=" -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF"
+fi
+
+if [ "$CROSS_BUILD" ]; then
+	# Tell opencv where to find python and numpy
+	_npincdir="numpy/core/include"
+	configure_args+=" -DPYTHON2_INCLUDE_PATH=${XBPS_CROSS_BASE}/${py2_inc}
+	 -DPYTHON2_NUMPY_INCLUDE_DIRS=${XBPS_CROSS_BASE}/${py2_sitelib}/${_npincdir}
+	 -DPYTHON3_INCLUDE_PATH=${XBPS_CROSS_BASE}/${py3_inc}
+	 -DPYTHON3_NUMPY_INCLUDE_DIRS=${XBPS_CROSS_BASE}/${py3_sitelib}/${_npincdir}"
 fi
 
 post_install() {
@@ -44,24 +59,18 @@ libopencv-devel_package() {
 	}
 }
 
-if [ -z "$CROSS_BUILD" ]; then
-	# because python-numpy cannot be cross compiled
-	hostmakedepends+=" python-devel python3-devel"
-	makedepends+=" python-numpy python3-numpy"
-
-	libopencv-python_package() {
-		short_desc+=" - Python2 bindings"
-		depends="python-numpy"
-		pkg_install() {
-			vmove usr/lib/python2.7
-		}
+libopencv-python_package() {
+	short_desc+=" - Python2 bindings"
+	depends="python-numpy"
+	pkg_install() {
+		vmove usr/lib/python2.7
 	}
+}
 
-	libopencv-python3_package() {
-		short_desc+=" - Python3 bindings"
-		depends="python3-numpy"
-		pkg_install() {
-			vmove usr/lib/python3*
-		}
+libopencv-python3_package() {
+	short_desc+=" - Python3 bindings"
+	depends="python3-numpy"
+	pkg_install() {
+		vmove usr/lib/python3*
 	}
-fi
+}


### PR DESCRIPTION
This should also allow the Python module to cross build.

Separating from opencv4 PR #23371 so CI won't timeout.