### PR TITLE
riot-desktop: update to 1.6.8.

### DIFF
--- a/srcpkgs/riot-desktop/INSTALL.msg
+++ b/srcpkgs/riot-desktop/INSTALL.msg
@@ -1,10 +1,2 @@
-Since Riot 1.6, it uses Electron 8. This version of Electron has
-dropped support for the older XEmbed system tray API. If you are using
-a desktop or window manager that does not support StatusNotifierItems
-(i3, awesome, stalonetray, etc), you should install and configure
-snixembed:
-
-   xbps-install -S snixembed
-
-More instructions at: https://git.sr.ht/~steef/snixembed/
-
+Riot 1.6.8 has upgraded to Electron 9, with support for tray icons. It
+should no longer be necessary to use a package like snixembed.

--- a/srcpkgs/riot-desktop/template
+++ b/srcpkgs/riot-desktop/template
@@ -1,19 +1,20 @@
 # Template file for 'riot-desktop'
 pkgname=riot-desktop
-version=1.6.5
+version=1.6.8
 revision=1
 archs="i686 x86_64"
 wrksrc="riot-web-${version}"
 conf_files="/etc/${pkgname}/config.json"
-hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl libappindicator-devel libnotify-devel"
+hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl libappindicator-devel libnotify-devel pkg-config"
+makedepends="libsecret-devel"
 depends="c-ares ffmpeg gtk+3 http-parser libevent libxslt minizip nss re2 snappy sqlcipher"
 short_desc="Glossy Matrix collaboration client, desktop version"
 maintainer="projectmoon <projectmoon@agnos.is>"
 license="Apache-2.0"
 homepage="https://riot.im"
 distfiles="https://github.com/vector-im/riot-desktop/archive/v${version}.tar.gz>riot-desktop.tar.gz https://github.com/vector-im/riot-web/archive/v${version}.tar.gz>riot-web.tar.gz"
-checksum="4083e541192701d4d77f640238580dcc97bf59656e57a42a67d20960c525d8c4
- fd9499b173a4372b8e62e947486e0b078f81d0ca1393a7673c068e2413138a2a"
+checksum="fecf357e5326a4cf059b99c4478230d427686ae02072b8f8810ddfc623d69e85
+ c0481954e1dc523f78b25552017f8adbb192c1f869f62f8a4cc655dab32ee721"
 nocross=yes
 nostrip=yes
 


### PR DESCRIPTION
New package upgrades to Electron 9, which should restore built-in support for most system tray icons.