### PR TITLE
dkms: improvements to post-install hook: run depmod if necessary and better handle DKMS build/install failures

### DIFF
--- a/srcpkgs/dkms/files/kernel.d/dkms.postinst
+++ b/srcpkgs/dkms/files/kernel.d/dkms.postinst
@@ -40,49 +40,77 @@ for _mod_ in /var/lib/dkms/*; do
 	done
 done
 
+# This section builds and install the available modules.
+#
+# If either building or installing a module fails, a warning is
+# printed and it is skipped, but the script still tries to build
+# the other modules.
+#
+# The list of available modules is in the form
+# [module1, modulever1, module2, modulever2, ...]
+#
 set -- ${DKMS_MODULES}
-while [ $# -ne 0 ]; do
+while [ $# -gt 1 ]; do
 	module="$1"
-	modulever="$2"
+	shift
+	modulever="$1"
+	shift
+
+	# If adding a module, depmod is necessary unless dkms runs it
+	do_depmod="yes"
 
 	status=$(dkms status -m ${module} -v ${modulever} -k ${VERSION})
 	if [ $(echo "$status"|grep -c ": built") -eq 0 ]; then
 		# Check if the module is still there.
 		if [ ! -f usr/src/${module}-${modulever}/dkms.conf ]; then
-			echo "Skipping unexistent DKMS module: ${module}-${modulever}."
-			shift 2
+			echo "Skipping nonexistent DKMS module: ${module}-${modulever}."
 			continue
 		fi
 		# Build the module
 		echo -n "Building DKMS module: ${module}-${modulever}... "
 		dkms build -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
 		rval=$?
-		if [ $rval -eq 9 ]; then
-			echo "skipped!"
-			shift; shift
-			continue
-		elif [ $rval -eq 0 ]; then
+		# If the module was skipped or failed, go to the next module.
+		if [ $rval -eq 0 ]; then
 			echo "done."
+		elif [ $rval -eq 9 ]; then
+			echo "skipped!"
+			continue
 		else
 			echo "FAILED!"
-			exit $?
+			continue
 		fi
 		status=$(dkms status -m ${module} -v ${modulever} -k ${VERSION})
 	fi
 
-	#if the module is built (either pre-built or just now), install it
+	# If the module is built (either pre-built or just now), install it
 	if [ $(echo "$status"|grep -c ": built") -eq 1 ] &&
 	   [ $(echo "$status"|grep -c ": installed") -eq 0 ]; then
 		echo -n "Installing DKMS module: ${module}-${modulever}... "
-	        dkms install -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
-		if [ $? -eq 0 ]; then
+		dkms install -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
+		rval=$?
+		# If the module failed installation, go to the next module.
+		if [ $rval -eq 0 ]; then
+			# dkms runs depmod as part of the installation
+			unset do_depmod
 			echo "done."
 		else
 			echo "FAILED!"
-			exit $?
+			continue
 		fi
 	fi
-	shift; shift
 done
+
+if [ -n "$do_depmod" ]; then
+	echo -n "Generating kernel module dependency lists... "
+	depmod -a ${VERSION}
+	rval=$?
+	if [ $rval -eq 0 ]; then
+		echo "done."
+	else
+		echo "FAILED!"
+		exit $rval
+	fi
+fi
 
 exit 0

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -2,7 +2,7 @@
 pkgname=dkms
 reverts="2.8.2_1"
 version=2.8.1
-revision=3
+revision=4
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils linux-headers"
 short_desc="Dynamic Kernel Modules System"


### PR DESCRIPTION
Normally, `dkms install` will run depmod with each installed module to update module dependency lists. When force-reinstalling kernel packages, `dkms install` will not run because modules are already marked installed, but the kernel package will overwrite `modules.dep` and `modules.dep.bin` with packaged versions that do not include any modules installed by dkms. The kernel post-install hook now tracks whether depmod should be run and will do so if necessary.

To demonstrate the original problem:

1. Install `zfs` and enable the dracut zfs module with `add_dracutmodules+=" zfs "` in `dracut.conf` or a `.conf` file in `/etc/dracut.conf.d`.
2. Rerun `dracut`, e.g., with `xbps-reconfigure -f linuxX.Y` for an appropriate kernel package.
3. Confirm that `zfs.ko.gz` is in the newly generated initramfs.
4. Force-reinstall the kernel package: `xbps-install -f linuxX.Y`.
5. Confirm that `zfs.ko.gz` is *missing* from the newly generated initramfs.

With the changes in the hook, the force-installation of `linuxX.Y` should display `Generating kernel module dependency lists... done.` after "building" all DKMS modules (note: the modules were already built for the reinstalled kernel, so the `dkms build` run by the hook is basically a no-op). The resulting initramfs will contain `zfs.ko.gz` as expected.

Also, I propagated some return codes from `dkms` through the hook, which I believe was the original intention. (Before the fix, `exit $?` after an `echo` would generally always exit 0 because `echo` is unlikely to fail.)