### PR TITLE
torbrowser-launcher: add dbus-glib dependency

### DIFF
--- a/srcpkgs/torbrowser-launcher/template
+++ b/srcpkgs/torbrowser-launcher/template
@@ -1,11 +1,11 @@
 # Template file for 'torbrowser-launcher'
 pkgname=torbrowser-launcher
 version=0.3.2
-revision=3
+revision=4
 archs="i686 x86_64" # limited by Tor Browser itself
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools"
-depends="python3-PyQt5 python3-gpg python3-requests python3-pysocks gnupg2 tor"
+depends="python3-PyQt5 python3-gpg python3-requests python3-pysocks gnupg2 tor dbus-glib"
 short_desc="Securely download, verify and run Tor Browser"
 maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="MIT"


### PR DESCRIPTION
Without `dbus-glib`, Tor Browser Launcher gets stuck after a message saying:
```
Launching './Browser/start-tor-browser --detatch'...
```
Tested on `i3-gaps`.