### PR TITLE
gummiboot : patched to permit kernel cmdline parameter passing.

### DIFF
--- a/srcpkgs/gummiboot/patches/stub.patch
+++ b/srcpkgs/gummiboot/patches/stub.patch
@@ -1,0 +1,12 @@
+--- src/efi/stub.c	2015-03-12 00:50:35.000000000 +0100
++++ src/efi/stub.c	2020-07-06 12:32:55.985327487 +0200
+@@ -83,7 +83,7 @@
+         cmdline_len = szs[0];
+ 
+         /* if we are not in secure boot mode, accept a custom command line and replace the built-in one */
+-        if (!secure && loaded_image->LoadOptionsSize > 0) {
++        if ((!secure || cmdline_len == 0) && loaded_image->LoadOptionsSize > 0 && *(CHAR16 *)loaded_image->LoadOptions > 0x1F) {
+                 CHAR16 *options;
+                 CHAR8 *line;
+                 UINTN i;
+


### PR DESCRIPTION
The actual version doesn't work. See [here](https://github.com/systemd/systemd/blob/master/src/boot/efi/stub.c) at 66 line. Tested on my machine (Dell xps 9380)
