### PR TITLE
New package: ncspot-0.2.0

### DIFF
--- a/srcpkgs/ncspot/template
+++ b/srcpkgs/ncspot/template
@@ -1,0 +1,35 @@
+# Template file for 'ncspot'
+pkgname=ncspot
+version=0.2.0
+revision=1
+build_style=cargo
+configure_args="--no-default-features"
+hostmakedepends="pkg-config python3"
+makedepends="libressl-devel ncurses-devel $(vopt_if libxcb libxcb-devel)
+$(vopt_if dbus dbus-devel) $(vopt_if alsa alsa-lib-devel)
+$(vopt_if pulseaudio pulseaudio-devel)"
+short_desc="Cross-platform ncurses Spotify client written in Rust"
+maintainer="Rien Maertens <rien.maertens@posteo.be>"
+license="BSD-2-Clause"
+homepage="https://github.com/hrkfdn/ncspot/"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=876553020e53b8bbf7dac1ddf18f69115d622b302506ce5dc1c3bac1b59ef39b
+nocross="ncurses exec format error"
+
+build_options="libxcb dbus alsa pulseaudio"
+build_options_default="libxcb dbus alsa pulseaudio"
+desc_option_libxcb="Enable support for X clipboard access"
+
+_features="cursive/pancurses-backend"
+_features+="$(vopt_if libxcb ',share_clipboard')"
+_features+="$(vopt_if alsa ',alsa_backend')"
+_features+="$(vopt_if pulseaudio ',pulseaudio_backend')"
+_features+="$(vopt_if dbus ',mpris')"
+
+if [ "$_features" ]; then
+	configure_args+=" --features $_features"
+fi
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This packages [ncspot](https://github.com/hrkfdn/ncspot), a ncurses Spotify client.

It is currently built with a pulseaudio backend (default), but it can be configured to use alsa or portaudio. Is there a policy preferring an audio backend? Or should I create two (sub)packages: `ncspot-pulseaudio` and `ncspot-alsa`?