### PR TITLE
New package: vkBasalt-0.3.2.2_1

### DIFF
--- a/srcpkgs/vkBasalt/template
+++ b/srcpkgs/vkBasalt/template
@@ -1,0 +1,13 @@
+# Template file for 'vkBasalt'
+pkgname=vkBasalt
+version=0.3.2.2
+revision=1
+build_style=meson
+hostmakedepends="glslang pkg-config"
+makedepends="libX11-devel"
+short_desc="Vulkan post-processing layer"
+maintainer="xolophreny <lowranker@protonmail.com>"
+license="Zlib"
+homepage="https://github.com/DadSchoorse/vkBasalt"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=dd2c714b3569d5da0bc2f058d85cfc7683c8a9bc6d6255b80b3e968c902e1913


### PR DESCRIPTION
Cross-compilation for i686 fails because meson fails to find its sanity check results, native build works