### PR TITLE
openvpn: add mbedtls build option.

### DIFF
--- a/srcpkgs/openvpn/template
+++ b/srcpkgs/openvpn/template
@@ -1,12 +1,13 @@
 # Template file for 'openvpn'
 pkgname=openvpn
 version=2.4.9
-revision=2
+revision=3
 build_style=gnu-configure
-configure_args="--enable-pkcs11 --enable-iproute2 --disable-systemd"
+configure_args="$(vopt_enable pkcs11) --enable-iproute2 --disable-systemd
+ $(vopt_with mbedtls crypto-library=mbedtls)"
 hostmakedepends="iproute2 pkg-config"
-makedepends="libressl-devel lzo-devel pam-devel pkcs11-helper-devel
- cmocka-devel"
+makedepends="$(vopt_if mbedtls mbedtls-devel libressl-devel) lzo-devel pam-devel
+ $(vopt_if pkcs11 pkcs11-helper-devel) cmocka-devel"
 depends="iproute2"
 short_desc="Easy-to-use, robust, and highly configurable VPN"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -14,6 +15,12 @@ license="GPL-2.0-only"
 homepage="https://www.openvpn.net"
 distfiles="http://build.openvpn.net/downloads/releases/${pkgname}-${version}.tar.xz"
 checksum=641f3add8694b2ccc39fd4fd92554e4f089ad16a8db6d2b473ec284839a5ebe2
+
+build_options="mbedtls pkcs11"
+build_options_default="mbedtls"
+desc_option_mbedtls="Build with mbedtls support"
+desc_option_pkcs11="Enable support for PKCS#11"
+vopt_conflict mbedtls pkcs11
 
 post_install() {
 	vmkdir usr/share/examples/${pkgname}


### PR DESCRIPTION
Default to it since openvpn is broken with libressl-3.1.X.