### PR TITLE
python3-jupyter_console: tarball from github instead of pypi

### DIFF
--- a/srcpkgs/python3-jupyter_console/template
+++ b/srcpkgs/python3-jupyter_console/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-jupyter_console'
 pkgname=python3-jupyter_console
 version=6.1.0
-revision=1
+revision=2
 archs=noarch
 wrksrc="jupyter_console-${version}"
 build_style=python3-module
@@ -13,8 +13,9 @@ short_desc="Jupyter terminal console (Python3)"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/jupyter/jupyter_console"
-distfiles="${PYPI_SITE}/j/jupyter_console/jupyter_console-${version}.tar.gz"
-checksum=6f6ead433b0534909df789ea64f0a14cdf9b6b2360757756f08182be4b9e431b
+# pypi release of jupyter_console v6.1.0 does not include scripts dir
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=838c95c99ce52978e1660e7a30dd933dede158e2f4da1bc5fad1a8fad44570b7
 # alternatives will be a conflict
 conflicts="python-jupyter_console<=6.0.0_2"
 


### PR DESCRIPTION
The tarball on pypi does not include the scripts dir which is where
/usr/bin/jupyter-console is installed from. Earlier versions included
the scripts directory on pypi.

This was included in #20409 but not in #19967, which are similar PRs, but the latter was actually merged.