### PR TITLE
xbps-src: -p argument for showing more variables

### DIFF
--- a/common/xbps-src/shutils/show.sh
+++ b/common/xbps-src/shutils/show.sh
@@ -44,6 +44,21 @@ show_pkg() {
     for i in ${conflicts}; do
         [ -n "$i" ] && echo "conflicts:	$i"
     done
+    local OIFS="$IFS"
+    IFS=','
+    for var in $1; do
+        IFS=$OIFS
+        if [ ${var} != ${var/'*'} ]
+        then
+            var="${var/'*'}"
+            [ -n "${!var}" ] && echo "$var:	${!var//$'\n'/' '}"
+        else
+            for val in ${!var}; do
+                [ -n "$val" ] && echo "$var:	$val"
+            done
+        fi
+    done
+    IFS="$OIFS"
     [ -n "$long_desc" ] && echo "long_desc: $long_desc"
 
     return 0

--- a/xbps-src
+++ b/xbps-src
@@ -198,6 +198,11 @@ $(print_cross_targets)
 
     Supported options can be shown with the 'show-options' target.
 
+-p  <variable,variable2,...>
+    For show target, show specified variables in addition to default ones.
+    Variable is split and each word is printed in separate line by default.
+    In order to print the whole value in one line, append asterisk to variable name.
+
 -Q  Enable running the check stage.
 
 -q  Suppress informational output of xbps-src (build output is still printed).
@@ -346,7 +351,7 @@ readonly XBPS_SRC_VERSION="113"
 export XBPS_MACHINE=$(xbps-uhelper -C /dev/null arch)
 
 XBPS_OPTIONS=
-XBPS_OPTSTRING="1a:c:CEfgGhH:iIj:Lm:No:qQr:tV"
+XBPS_OPTSTRING="1a:c:CEfgGhH:iIj:Lm:No:p:qQr:tV"
 
 # Preprocess arguments in order to allow options before and after XBPS_TARGET.
 eval set -- $(getopt "$XBPS_OPTSTRING" "$@");
@@ -373,6 +378,7 @@ while getopts "$XBPS_OPTSTRING" opt; do
         m) XBPS_ARG_MASTERDIR="$OPTARG"; XBPS_OPTIONS+=" -m $OPTARG";;
         N) XBPS_ARG_SKIP_REMOTEREPOS=1; XBPS_OPTIONS+=" -N";;
         o) XBPS_ARG_PKG_OPTIONS="$OPTARG"; XBPS_OPTIONS+=" -o $OPTARG";;
+        p) XBPS_ARG_PRINT_VARIABLES="$OPTARG"; XBPS_OPTIONS+=" -p $OPTARG";;
         q) XBPS_ARG_QUIET=1; XBPS_OPTIONS+=" -q";;
         Q) XBPS_ARG_CHECK_PKGS=1; XBPS_OPTIONS+=" -Q";;
         r) XBPS_ARG_ALT_REPOSITORY="$OPTARG"; XBPS_OPTIONS+=" -r $OPTARG";;
@@ -457,6 +463,7 @@ fi
 [ -n "$XBPS_ARG_SKIP_DEPS" ] && XBPS_SKIP_DEPS=1
 [ -n "$XBPS_ARG_KEEP_ALL" ] && XBPS_KEEP_ALL=1
 [ -n "$XBPS_ARG_QUIET" ] && XBPS_QUIET=1
+[ -n "$XBPS_ARG_PRINT_VARIABLES" ] && XBPS_PRINT_VARIABLES="$XBPS_ARG_PRINT_VARIABLES"
 [ -n "$XBPS_ARG_ALT_REPOSITORY" ] && XBPS_ALT_REPOSITORY="$XBPS_ARG_ALT_REPOSITORY"
 [ -n "$XBPS_ARG_CROSS_BUILD" ] && XBPS_CROSS_BUILD="$XBPS_ARG_CROSS_BUILD"
 [ -n "$XBPS_ARG_MAKEJOBS" ] && XBPS_MAKEJOBS="$XBPS_ARG_MAKEJOBS"
@@ -465,7 +472,7 @@ export XBPS_BUILD_ONLY_ONE_PKG XBPS_SKIP_REMOTEREPOS XBPS_BUILD_FORCEMODE \
        XBPS_INFORMATIVE_RUN XBPS_TEMP_MASTERDIR XBPS_BINPKG_EXISTS \
        XBPS_USE_GIT_REVS XBPS_CHECK_PKGS XBPS_DEBUG_PKGS XBPS_SKIP_DEPS \
        XBPS_KEEP_ALL XBPS_QUIET XBPS_ALT_REPOSITORY XBPS_CROSS_BUILD \
-       XBPS_MAKEJOBS
+       XBPS_MAKEJOBS XBPS_PRINT_VARIABLES
 
 # The masterdir/hostdir variables are forced and readonly in chroot
 if [ -z "$IN_CHROOT" ]; then
@@ -804,7 +811,7 @@ case "$XBPS_TARGET" in
         ;;
     show)
         read_pkg ignore-problems
-        show_pkg
+        show_pkg $XBPS_PRINT_VARIABLES
         ;;
     show-avail)
         read_pkg &>/dev/null


### PR DESCRIPTION
I use this to know if package is restricted when bulk parsing templates. show-pkg-var and show-pkg-var-dump lacks distfiles, and calling xbps-src twice is too slow.