### PR TITLE
keybase: use hand-generated tarball

### DIFF
--- a/srcpkgs/keybase/template
+++ b/srcpkgs/keybase/template
@@ -2,7 +2,7 @@
 pkgname=keybase
 version=5.5.1
 revision=1
-wrksrc="client-${version}"
+wrksrc="client-v${version}"
 build_style=go
 go_import_path="github.com/keybase/client"
 go_package="${go_import_path}/go/keybase
@@ -16,8 +16,8 @@ short_desc="Client for keybase.io"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://keybase.io/"
-distfiles="https://github.com/keybase/client/archive/v${version}.tar.gz"
-checksum=a65dc4b62fc1299dd17da52ddd2484fa1dc1e7d2a4776c3a6e112ee020980b12
+distfiles="https://github.com/keybase/client/releases/download/v$version/keybase-v$version.tar.xz"
+checksum=a70abf39c68cef1effccf4b9b9b1ed2e9cad20ab4f6c4b66160b610eca1ec874
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
GitHub tarballs can be changed at anytime, which renders GitHub
auto-generated tarball invalid at sometime [1]

Use keybase manual generated tarball that is verified with their code
signing key [2]

[1] https://github.com/keybase/client/issues/10800
[2] https://keybase.io/docs/server_security/code_signing_key.asc

---

@Vaelatern 