### PR TITLE
python3-jupyter_console: revert to using tarball from pypi

### DIFF
--- a/srcpkgs/python3-jupyter_console/patches/setuptools.diff
+++ b/srcpkgs/python3-jupyter_console/patches/setuptools.diff
@@ -1,0 +1,11 @@
+--- setup.py
++++ setup.py
+@@ -51,7 +51,7 @@
+ import os
+ from glob import glob
+ 
+-from distutils.core import setup
++from setuptools import setup
+ 
+ pjoin = os.path.join
+ here = os.path.abspath(os.path.dirname(__file__))

--- a/srcpkgs/python3-jupyter_console/template
+++ b/srcpkgs/python3-jupyter_console/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-jupyter_console'
 pkgname=python3-jupyter_console
 version=6.1.0
-revision=2
+revision=3
 archs=noarch
 wrksrc="jupyter_console-${version}"
 build_style=python3-module
@@ -13,9 +13,8 @@ short_desc="Jupyter terminal console (Python3)"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/jupyter/jupyter_console"
-# pypi release of jupyter_console v6.1.0 does not include scripts dir
-distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=838c95c99ce52978e1660e7a30dd933dede158e2f4da1bc5fad1a8fad44570b7
+distfiles="${PYPI_SITE}/j/jupyter_console/jupyter_console-${version}.tar.gz"
+checksum=6f6ead433b0534909df789ea64f0a14cdf9b6b2360757756f08182be4b9e431b
 # alternatives will be a conflict
 conflicts="python-jupyter_console<=6.0.0_2"
 


### PR DESCRIPTION
This reverts #23446 and instead patches setup.py to use setuptools
instead of distutils which automatically generates the necessary
jupyter-console script.

@sgn