### PR TITLE
sylpheed: patch to use SNI

### DIFF
--- a/srcpkgs/sylpheed/patches/libsylph_ssl_c.patch
+++ b/srcpkgs/sylpheed/patches/libsylph_ssl_c.patch
@@ -1,0 +1,16 @@
+--- libsylph/ssl.c.orig
++++ libsylph/ssl.c
+@@ -258,6 +258,13 @@ gboolean ssl_init_socket_with_method(SockInfo *sockinf
+ 		return FALSE;
+ 	}
+ 
++#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
++	if (!SSL_set_tlsext_host_name(sockinfo->ssl, sockinfo->hostname)) {
++		g_warning("Error setting servername extension\n");
++		return FALSE;
++	}
++#endif
++
+ 	SSL_set_fd(sockinfo->ssl, sockinfo->sock);
+ 	while ((ret = SSL_connect(sockinfo->ssl)) != 1) {
+ 		err = SSL_get_error(sockinfo->ssl, ret);

--- a/srcpkgs/sylpheed/template
+++ b/srcpkgs/sylpheed/template
@@ -1,18 +1,18 @@
-# Template build file for 'sylpheed'.
+# Template file for 'sylpheed'
 pkgname=sylpheed
 version=3.7.0
-revision=5
-lib32disabled=yes
+revision=7
 build_style=gnu-configure
 configure_args="--disable-compface --disable-gtkspell --enable-ldap --with-gpgme-prefix=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="automake libtool pkg-config flex gettext-devel gtk+-devel gpgme-devel glib-devel"
 makedepends="libfl-devel zlib-devel libressl-devel gtk+-devel gpgme-devel libldap-devel"
 short_desc="GTK+ Lightweight and user-friendly e-mail client"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2, LGPL-2.1"
+license=" GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://sylpheed.sraoss.jp"
 distfiles="http://sylpheed.sraoss.jp/sylpheed/v${version%.*}/$pkgname-$version.tar.bz2"
 checksum=eb23e6bda2c02095dfb0130668cf7c75d1f256904e3a7337815b4da5cb72eb04
+lib32disabled=yes
 
 pre_configure() {
 	aclocal -I ac


### PR DESCRIPTION
Prior to this patch, sylpheed built against newer versions of LibreSSL could
not connect to IMAP server such as gmail's because it did not use SNI. This
patch from OpenBSD is a simple fix to implement it.

This fix is documented in the upstream bug tracker here: [https://sylpheed.sraoss.jp/redmine/issues/306](https://sylpheed.sraoss.jp/redmine/issues/306) and in the OpenBSD CVS here: [https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/mail/sylpheed/patches/patch-libsylph_ssl_c](https://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/mail/sylpheed/patches/patch-libsylph_ssl_c)

If there is anything I missed or anything I could have done better while contributing, please let me know. Thanks for any reply.