### PR TITLE
waypipe: update to 0.7.0.

### DIFF
--- a/srcpkgs/waypipe/INSTALL.msg
+++ b/srcpkgs/waypipe/INSTALL.msg
@@ -1,0 +1,2 @@
+CAUTION: Waypipe>=0.7.0 uses a new wire protocol, and won't work with
+previous versions.

--- a/srcpkgs/waypipe/template
+++ b/srcpkgs/waypipe/template
@@ -1,6 +1,6 @@
 # Template file for 'waypipe'
 pkgname=waypipe
-version=0.6.1
+version=0.7.0
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=meson
@@ -16,7 +16,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://gitlab.freedesktop.org/mstoeckl/waypipe"
 distfiles="https://gitlab.freedesktop.org/mstoeckl/waypipe/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
-checksum=95114f0f4e52cbd8d054c3119265d9006c9f39550961dea58f72b984075d7bce
+checksum=ce14508af422acc212b4eee6faae4c84e082abd8b3b85655bec36e942200b9fa
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
This is a breaking change in that it needs to be updated on both sides of the connection. Should I create an install msg to warn about this? It shouldn't be necessary, since if you try to launch it without updating one of the sides it errors out. Tested between two x86_64 musl devices.