### PR TITLE
blender: update to 2.83.3, enable alembic support

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3939,7 +3939,7 @@ libOpenImageDenoise.so.0 openimagedenoise-1.2.0_1
 libcbang0.so cbang-1.3.3_1
 libblosc.so.1 c-blosc-1.17.1_1
 libopenvdb.so.7.0 openvdb-7.0.0_1
-libAlembic.so.1.7 alembic-1.7.12_1
+libAlembic.so.1.7 alembic-1.7.13_1
 libmodsecurity.so.3 modsecurity-3.0.4_1
 libraven.so.0 budgie-desktop-10.5.1_1
 libbudgie-private.so.0 budgie-desktop-10.5.1_1

--- a/srcpkgs/alembic/template
+++ b/srcpkgs/alembic/template
@@ -1,17 +1,16 @@
 # Template file for 'alembic'
 pkgname=alembic
-version=1.7.12
+version=1.7.13
 revision=1
 build_style=cmake
-configure_args="-DALEMBIC_LIB_USES_TR1=1"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel ilmbase-devel libatomic-devel"
+makedepends="zlib-devel ilmbase-devel"
 short_desc="Open framework for storing and sharing scene data"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause, MIT"
 homepage="https://alembic.io"
 distfiles="https://github.com/alembic/alembic/archive/${version}.tar.gz"
-checksum=6c603b87c9a3eaa13618e577dd9ef5277018cdcd09ac82d3c196ad8bed6a1b48
+checksum=14a44a1d28d1a0736655e53fc529dd4d3993bf4d03535f66de9e634c9b47d441
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
@@ -20,6 +19,14 @@ esac
 
 if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" hdf5-devel"
+fi
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+
+	post_patch() {
+		printf '\ntarget_link_libraries(Alembic PRIVATE atomic)\n' >> lib/Alembic/CMakeLists.txt
+	}
 fi
 
 post_install() {

--- a/srcpkgs/blender/template
+++ b/srcpkgs/blender/template
@@ -1,6 +1,6 @@
 # Template file for 'blender'
 pkgname=blender
-version=2.83.0
+version=2.83.3
 revision=1
 build_style="cmake"
 makedepends="
@@ -9,14 +9,14 @@ makedepends="
  libsamplerate-devel ffmpeg-devel fftw-devel boost-devel pcre-devel llvm
  libopenexr-devel libopenjpeg2-devel libXi-devel openimageio-devel
  opencolorio-devel opencollada-devel python3-numpy libXrender-devel
- OpenSubdiv-devel tbb-devel libxml2-devel openvdb-devel"
+ OpenSubdiv-devel tbb-devel libxml2-devel openvdb-devel alembic-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="3D graphics creation suite"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.blender.org"
 distfiles="http://download.blender.org/source/${pkgname}-${version}.tar.xz"
-checksum=14e2bc85e076b12ae94438ff3c1dd417eba642840ed32d7c979724a93aa93f1f
+checksum=57400f66da3e1500d23f8864e7e4dca26f86abc8ad99dc10d97d4872973aa2a2
 patch_args="-Np1"
 
 python_version=3
@@ -40,6 +40,7 @@ configure_args="
 -DWITH_OPENCOLLADA=ON
 -DWITH_SYSTEM_GLEW=ON
 -DWITH_OPENVDB=ON
+-DWITH_ALEMBIC=ON
 -DWITH_BUILDINFO=OFF
 -DPYTHON_VERSION=$py3_ver
 -DPYTHON_LIBPATH=/usr/lib


### PR DESCRIPTION
Smoke-tested (export and import simple mesh) on x86_64. Fixes #23112