### PR TITLE
keepassxc: update to 2.6.0.

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -1,6 +1,6 @@
 # Template file for 'keepassxc'
 pkgname=keepassxc
-version=2.5.4
+version=2.6.0
 revision=1
 build_style=cmake
 configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF
@@ -12,7 +12,7 @@ configure_args="-DWITH_TESTS=ON -DWITH_XC_UPDATECHECK=OFF
  -DWITH_XC_NETWORKING=$(vopt_if network ON OFF)
  -DWITH_XC_SSHAGENT=$(vopt_if sshagent ON OFF)
  -DWITH_XC_YUBIKEY=$(vopt_if yubikey ON OFF)"
-hostmakedepends="qt5-qmake qt5-host-tools"
+hostmakedepends="qt5-qmake qt5-host-tools ruby-asciidoctor"
 makedepends="qt5-tools-devel qt5-svg-devel libgcrypt-devel libargon2-devel
  qrencode-devel readline-devel libsodium-devel
  $(vopt_if autotype 'qt5-x11extras-devel libXtst-devel libXi-devel')
@@ -25,7 +25,7 @@ license="GPL-3.0-or-later, BSD-3-Clause, CC0-1.0, LGPL-2.0-only, LGPL-2.1-only,
 homepage="https://keepassxc.org/"
 changelog="https://raw.githubusercontent.com/keepassxreboot/keepassxc/blob/${version}/CHANGELOG.md"
 distfiles="https://github.com/keepassxreboot/keepassxc/releases/download/${version}/keepassxc-${version}-src.tar.xz"
-checksum=a55e0801c318b02b1ac4e16e9b7a87ccfa7b039ea60d2c62610bd1bbbdd6cd4a
+checksum=d0d23d97a73ac1cbf59bfca2f5d1506ae36dfcd4fbfb4225efe19931f035fd3a
 
 # https://github.com/keepassxreboot/keepassxc/blob/a775031fe9471310e50232d1861d4991e2803aff/CMakeLists.txt#L46
 build_options="autotype browser fdosecrets keeshare network sshagent yubikey"


### PR DESCRIPTION
Built, installed. Tested unlocking a database and browser integration