### PR TITLE
godot: update to 3.2.2.

### DIFF
--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,6 +1,6 @@
 # Template file for 'godot'
 pkgname=godot
-version=3.2.1
+version=3.2.2
 revision=1
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 wrksrc="${pkgname}-${version}-stable"
@@ -27,7 +27,7 @@ maintainer="Nick Hahn <nick.hahn@hotmail.de>"
 license="MIT"
 homepage="https://www.godotengine.org/"
 distfiles="https://github.com/godotengine/${pkgname}/archive/${version}-stable.tar.gz"
-checksum=0f9635e5c014713340160d8bd0cbfc6d34a36d39402a84eaa0d8c5dee4d1c6f0
+checksum=9a071aba23fc912976203d35212a94207b7cb667c0b5353b3525f9b7e6899017
 nocross=https://build.voidlinux.org/builders/armv7l_builder/builds/6342/steps/shell_3/logs/stdio
 
 CFLAGS+=" -fPIE -fPIC"


### PR DESCRIPTION
Built and tested a few demo projects.

On x86_64 glibc