### PR TITLE
[RFC] New numpy build_helper to support cross compilation

### DIFF
--- a/common/build-helper/numpy.sh
+++ b/common/build-helper/numpy.sh
@@ -1,0 +1,36 @@
+#
+# numpy - build-helper for packages that compile against python3-numpy
+#
+# This build-helper makes sure packages can find python3-numpy libraries and
+# headers on the target architecture rather than the host, as well as making
+# sure the gfortran cross compiler is properly identified.
+
+# Even for cross compilation, numpy should be available on the host to ensure
+# that the host interpreter doesn't complain about missing deps
+if [[ $hostmakedepends != *"python3-numpy"* ]]; then
+	hostmakedepends+=" python3-numpy"
+fi
+
+if [ "$CROSS_BUILD" ]; then
+	if [[ $makedepends != *"python3-numpy"* ]]; then
+		makedepends+=" python3-numpy"
+	fi
+
+	# python3-setuptools finds numpy libs and headers on the host first;
+	# addding search paths up front allows the target to take priority
+	CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/include"
+	LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/lib"
+
+	# distutils from python3-numpy looks to environment variables F77 and
+	# F90 rather than the XBPS-set FC
+	export F77="${FC}"
+	export F90="${FC}"
+
+	# When compiling and linking FORTRAN, distutils from python3-numpy
+	# refuses respect any linker name except "gfortran"; symlink to the
+	# cross-compiler to that the right linker and compiler will be used
+	if _gfortran=$(command -v "${FC}"); then
+		ln -sf "${_gfortran}" "${XBPS_WRAPPERDIR}/gfortran"
+	fi
+	unset _gfortran
+fi

--- a/srcpkgs/python3-scipy/template
+++ b/srcpkgs/python3-scipy/template
@@ -1,13 +1,13 @@
 # Template file for 'python3-scipy'
 pkgname=python3-scipy
-version=1.5.0
+version=1.5.1
 revision=2
 wrksrc="scipy-${version}"
 build_style=python3-module
+build_helper="numpy"
 make_check_args="--force"
-hostmakedepends="gcc-fortran python3-setuptools
- python3-Cython python3-numpy python3-pybind11"
-makedepends="python3-devel python3-numpy python3-pybind11
+hostmakedepends="gcc-fortran python3-setuptools python3-Cython python3-pybind11"
+makedepends="python3-devel python3-pybind11
  $(vopt_if openblas openblas-devel lapack-devel)"
 depends="python3-numpy"
 checkdepends="python3-nose"
@@ -16,7 +16,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://scipy.org/scipylib/"
 distfiles="https://github.com/scipy/scipy/releases/download/v${version}/scipy-${version}.tar.xz"
-checksum=23baeaa18803d12d1abdff3f5c148b1085c2dc4028c6b8efce652dde2119b41c
+checksum=0728bd66a5251cfeff17a72280ae5a40ec14add217f94868d1415b3c469b610a
 
 build_options="openblas"
 desc_option_openblas="Enable support for openblas accelerated linear algebra"
@@ -29,25 +29,9 @@ case "$XBPS_TARGET_MACHINE" in
 	*) ;;
 esac
 
-if [ "$CROSS_BUILD" ]; then
-	# Make sure numpy is found for the target arch first
-	CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/include"
-	LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_sitelib}/numpy/core/lib"
-
-	# Tell numpy.distutils where to find FORTRAN compilers
-	export F77="${FC}"
-	export F90="${FC}"
-fi
-
 LDFLAGS+=" -shared"
 
 pre_build() {
-	if [ "$CROSS_BUILD" ]; then
-		# numpy.distutils refuses to find the right linker for FORTRAN
-		# Link the cross compiler so the module will find it as gfortran
-		ln -sf "/usr/bin/${FC}" "${XBPS_WRAPPERDIR}/gfortran"
-	fi
-
 	# Find the right linear algebra subroutines on the target arch
 	: > site.cfg
 	for _blaslib in $(vopt_if openblas openblas "lapack blas"); do


### PR DESCRIPTION
I plan on adding some packages that link against `python3-numpy` and require the same kinds of environment manipulations currently done in `python3-scipy` to support cross building. The new templates would be simplified if these manipulations were centralized in a build_helper, so here it is. `python3-scipy` has been reworked to take advantage of the new helper.