### PR TITLE
New package: wcm-0.4.0.

### DIFF
--- a/srcpkgs/wcm/template
+++ b/srcpkgs/wcm/template
@@ -1,0 +1,18 @@
+# Template file for 'wcm'
+pkgname=wcm
+version=0.4.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config wayland-devel"
+makedepends="wayfire wf-config-devel libevdev-devel libxml2-devel gtk+3-devel
+ wayland-protocols glm"
+short_desc="Wayfire Config Manager"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="MIT"
+homepage="https://wayfire.org/"
+distfiles="https://github.com/WayfireWM/wcm/archive/v${version}.tar.gz"
+checksum=8b03dbc9fad184c8e3277e8f5da68707148b3df9df6e042d848b80ee1c53b701
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This one's necessary for a proper Wayfire setup.