### PR TITLE
New package: ugdb-0.1.8.

### DIFF
--- a/srcpkgs/ugdb/template
+++ b/srcpkgs/ugdb/template
@@ -1,0 +1,15 @@
+# Template file for 'ugdb'
+pkgname=ugdb
+version=0.1.8
+revision=1
+build_style=cargo
+short_desc="Alternative TUI for gdb"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="MIT"
+homepage="https://github.com/ftilde/ugdb"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=000a0d1bcc848332d5786ca9c37fcba0ead5d5cf33b39ba7620fe3fd9e530b9c
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This will fail the first CI round for armv6l, just want to grab some links to explain why it's broken.