### PR TITLE
New package: old-ubuntu-human-theme-1.0.0

### DIFF
--- a/srcpkgs/old-ubuntu-human-theme/template
+++ b/srcpkgs/old-ubuntu-human-theme/template
@@ -1,0 +1,23 @@
+# Template file for 'old-ubuntu-human-theme'
+pkgname=old-ubuntu-human-theme
+version=1.0.0
+revision=1
+archs="noarch"
+build_style=fetch
+hostmakedepends="tar"
+depends="gtk-engine-murrine"
+short_desc="Old Ubuntu Human theme, for GTK 2.24 / 3.20-3.24 / 4.0"
+maintainer="rc-05 <rc23@email.it>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/luigifab/old-ubuntu-human-theme"
+distfiles="https://github.com/luigifab/${pkgname}/releases/download/v${version}/human-${version}.tar.gz"
+checksum="a2cab09164605cd98f9ac0edf1164fff6b66913c6d8dd80e8013a72cdf4bc454"
+
+do_install() {
+	tar --strip-components=1 --skip-old-files -xf human-${version}.tar.gz
+	vmkdir usr/share/themes
+	vcopy old-ubuntu-human usr/share/themes
+	vcopy old-ubuntu-human-blue usr/share/themes
+	vcopy old-ubuntu-human-green usr/share/themes
+	vcopy old-ubuntu-human-orange usr/share/themes
+}


### PR DESCRIPTION
Description from **[upstream](https://github.com/luigifab/old-ubuntu-human-theme)**:

The old Ubuntu Human theme, for GTK 2.24 / 3.20-3.24 / 4.0.
This is an adaptation of [Clearlooks-Phénix](https://github.com/jpfleury/clearlooks-phenix) theme, a GTK 3 port of old GTK 2 / GNOME 2 [Clearlooks](https://en.wikipedia.org/wiki/Clearlooks) style. This is also a continuation of [Human Quarny](https://www.mate-look.org/p/1013593/) theme.