### PR TITLE
qt5-webkit: add musl stacksize patch from webkit2gtk

### DIFF
--- a/srcpkgs/qt5-webkit/patches/jsc-musl.patch
+++ b/srcpkgs/qt5-webkit/patches/jsc-musl.patch
@@ -1,0 +1,32 @@
+--- Source/JavaScriptCore/runtime/Options.h	2020-04-14 00:51:51.000000000 +0200
++++ -	2020-07-11 18:53:50.372744315 +0200
+@@ -40,6 +40,16 @@
+ 
+ namespace JSC {
+ 
++#if defined(__GLIBC__)
++constexpr unsigned jscMaxPerThreadStack = 4 * MB;
++constexpr unsigned jscSoftReservedZoneSize = 128 * KB;
++constexpr unsigned jscReservedZoneSize = 64 * KB;
++#else
++constexpr unsigned jscMaxPerThreadStack = 80 * KB;
++constexpr unsigned jscSoftReservedZoneSize = 32 * KB;
++constexpr unsigned jscReservedZoneSize = 16 * KB;
++#endif
++
+ // How do JSC VM options work?
+ // ===========================
+ // The JSC_OPTIONS() macro below defines a list of all JSC options in use,
+@@ -112,9 +122,9 @@
+     \
+     v(bool, reportMustSucceedExecutableAllocations, false, nullptr) \
+     \
+-    v(unsigned, maxPerThreadStackUsage, 4 * MB, nullptr) \
+-    v(unsigned, reservedZoneSize, 128 * KB, nullptr) \
+-    v(unsigned, errorModeReservedZoneSize, 64 * KB, nullptr) \
++    v(unsigned, maxPerThreadStackUsage, jscMaxPerThreadStack, nullptr) \
++    v(unsigned, reservedZoneSize, jscSoftReservedZoneSize, nullptr) \
++    v(unsigned, errorModeReservedZoneSize, jscReservedZoneSize, nullptr) \
+     \
+     v(bool, crashIfCantAllocateJITMemory, false, nullptr) \
+     v(unsigned, jitMemoryReservationSize, 0, "Set this number to change the executable allocation size in ExecutableAllocatorFixedVMPool. (In bytes.)") \

--- a/srcpkgs/qt5-webkit/template
+++ b/srcpkgs/qt5-webkit/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5-webkit'
 pkgname=qt5-webkit
 version=5.212.0
-revision=10
+revision=11
 _snap=1586819898
 _v=${version%.*}
 wrksrc="qtwebkit-opensource-src-${_v}"


### PR DESCRIPTION
jsc on musl regulary fails without this patch:
> Fatal error compiling builtin function 'apply'

[ci skip]