### PR TITLE
gtk+3: update to 3.24.21.

### DIFF
--- a/srcpkgs/adwaita-icon-theme/template
+++ b/srcpkgs/adwaita-icon-theme/template
@@ -1,11 +1,10 @@
 # Template file for 'adwaita-icon-theme'
 pkgname=adwaita-icon-theme
 version=3.36.1
-revision=1
+revision=2
 archs=noarch
 build_style=gnu-configure
-configure_args="--enable-icon-mapping"
-hostmakedepends="pkg-config librsvg icon-naming-utils gtk-update-icon-cache"
+hostmakedepends="pkg-config"
 depends="librsvg"
 short_desc="Theme consisting of a set of icons for GTK+"
 maintainer="Enno Boland <gottox@voidlinux.org>"

--- a/srcpkgs/gtk+3/template
+++ b/srcpkgs/gtk+3/template
@@ -1,6 +1,6 @@
 # Template file for 'gtk+3'
 pkgname=gtk+3
-version=3.24.20
+version=3.24.21
 revision=1
 wrksrc="gtk+-${version}"
 build_style=gnu-configure
@@ -20,13 +20,14 @@ makedepends="at-spi2-atk-devel gdk-pixbuf-devel libepoxy-devel pango-devel
  $(vopt_if wayland 'libxkbcommon-devel wayland-devel wayland-protocols MesaLib-devel')
  $(vopt_if x11 'libXcursor-devel libXdamage-devel libXext-devel libXinerama-devel libXi-devel libXrandr-devel libXcomposite-devel')
  $(vopt_if cloudproviders 'libcloudproviders-devel')"
-depends="gtk-update-icon-cache shared-mime-info $(vopt_if x11 'dbus-x11')"
+depends="gtk-update-icon-cache adwaita-icon-theme
+ librsvg shared-mime-info $(vopt_if x11 'dbus-x11')"
 short_desc="GTK+ toolkit (v3)"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gtk.org/"
 distfiles="${GNOME_SITE}/gtk+/${version%.*}/gtk+-${version}.tar.xz"
-checksum=2dac69f716e8d04ba7a95091589e2baaec95dcace932cb15839163db479b1df3
+checksum=aeea6ae7cd35e83dfc7699be716519faefca346c62e784dd1a37d9df94c08f52
 
 # Package build options
 build_options="broadway colord cups gir cloudproviders wayland x11"

--- a/srcpkgs/librsvg/template
+++ b/srcpkgs/librsvg/template
@@ -1,7 +1,7 @@
 # Template file for 'librsvg'
 pkgname=librsvg
 # https://gitlab.gnome.org/GNOME/librsvg/-/issues/604
-version=2.48.6
+version=2.48.8
 revision=1
 build_style=gnu-configure
 build_helper="gir"
@@ -9,15 +9,14 @@ configure_args="--disable-static --host=${XBPS_TARGET_TRIPLET}
  $(vopt_enable gir introspection) $(vopt_enable vala)"
 hostmakedepends="cargo pkg-config python glib-devel
  gdk-pixbuf-devel $(vopt_if vala vala)"
-makedepends="cairo-devel freetype-devel gdk-pixbuf-devel gtk+3-devel
- libcroco-devel libglib-devel libxml2-devel pango-devel rust
- $(vopt_if vala vala)"
+makedepends="cairo-devel freetype-devel gdk-pixbuf-devel libcroco-devel
+ libglib-devel libxml2-devel pango-devel rust $(vopt_if vala vala)"
 short_desc="SVG library for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/LibRsvg"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=84ddd9447d392a307956826b40961790b9340a8e346285542a361dfc1f2e64cf
+checksum=f480a325bbdf26d1874eb6fb330ebc5920ba64e3e08de61931bb4506dfef2692
 
 # Package build options
 build_options="gir vala"


### PR DESCRIPTION
Also add dependency on `adwaita-icon-theme` because GTK applications will not display properly without at least some icon theme; see [void-docs PR #396](https://github.com/void-linux/void-docs/pull/396). The appropriate response is to pull in the default theme, then let users `ignorepkg` if they wish to replace it with something custom.

cc: @Gottox (maintainer) @flexibeast @ericonr 