### PR TITLE
ladspa-sdk: not all subpackages are noarch

### DIFF
--- a/srcpkgs/ladspa-sdk/template
+++ b/srcpkgs/ladspa-sdk/template
@@ -1,7 +1,7 @@
 # Template file for 'ladspa-sdk'
 pkgname=ladspa-sdk
 version=1.15
-revision=1
+revision=2
 archs=noarch
 wrksrc="ladspa_sdk_${version}"
 makedepends="libsndfile-progs"
@@ -36,6 +36,7 @@ ladspa-sdk-doc_package() {
 
 ladspa-sdk-example-plugins_package() {
 	short_desc+=" - Example plugins"
+	archs="*"
 	pkg_install() {
 		vmkdir usr/lib/ladspa
 		vcopy "${wrksrc}/plugins/*.so*" usr/lib/ladspa
@@ -44,6 +45,7 @@ ladspa-sdk-example-plugins_package() {
 
 ladspa-sdk-progs_package() {
 	short_desc+=" - Example programs"
+	archs="*"
 	pkg_install() {
 		vmkdir usr
 		vcopy ${wrksrc}/bin usr


### PR DESCRIPTION
The main package ladspa-sdk contains only a header file, but ladspa-sdk-example-plugins and ladspa-sdk-progs subpackages contain arch dependent binaries. Trying to load a plugin fails e.g. on i686.

I think the case where the main package is `noarch`, but some subpackages aren’t isn’t covered (yet) by xbps-src without having to add every available arch to the subpackage (which wouldn’t make sense, anyway). Or is it and I just don’t see it? :)
