### PR TITLE
Provide and use 'tex' virtual package

### DIFF
--- a/etc/defaults.virtual
+++ b/etc/defaults.virtual
@@ -30,7 +30,7 @@ phonon-backend phonon-backend-gstreamer
 phonon-qt5-backend phonon-qt5-backend-gstreamer
 rkt-stage1 rkt-stage1-coreos
 smtp-server opensmtpd
-texlive texlive-bin
+tex texlive
 xserver-abi-input xorg-server
 xserver-abi-video xorg-server
 libGL libglvnd

--- a/srcpkgs/lyx/template
+++ b/srcpkgs/lyx/template
@@ -1,18 +1,16 @@
 # Template file for 'lyx'
 pkgname=lyx
-version=2.3.5.1
+version=2.3.5.2
 revision=1
-wrksrc="${pkgname}-${version%.*}-${version##*.}"
 build_style=gnu-configure
 configure_args="--enable-qt5 --without-included-mythes --without-included-boost"
 hostmakedepends="pkg-config bc qt5-devel"
 makedepends="file-devel boost-devel mythes-devel enchant-devel qt5-svg-devel"
-depends="virtual?texlive GraphicsMagick python3"
+depends="virtual?tex GraphicsMagick python3"
 short_desc="Document Processor WYSIWYM Editor & Latex frontend"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.lyx.org/Home"
-#distfiles="ftp://ftp.lyx.org/pub/${pkgname}/stable/2.3.x/${pkgname}-${version}.tar.bz2"
-distfiles="https://fossies.org/linux/misc/lyx-${version}.tar.bz2"
-checksum=97a77ba9dc4002035e1e32855f42c0838bca6b8a159af0c727388304d26cdb67
+distfiles="https://ftp.lip6.fr/pub/lyx/stable/2.3.x/${pkgname}-${version}.tar.gz"
+checksum=63b75505d6fed264a7ed51f9ee3e4279c1d49a3960c06afe3c94f1c72bedea7e
 python_version=3

--- a/srcpkgs/python-pyx/template
+++ b/srcpkgs/python-pyx/template
@@ -1,13 +1,13 @@
 # Template file for 'python-pyx'
 pkgname=python-pyx
 version=0.12.1
-revision=3
+revision=4
 archs=noarch
 wrksrc="PyX-${version}"
 build_style=python2-module
 pycompile_module="pyx"
 hostmakedepends="python-setuptools"
-depends="python texlive-bin"
+depends="python virtual?tex"
 short_desc="Python library for the creation of PostScript and PDF files"
 maintainer="cipr3s <cipr3s@gmx.com>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/python3-pyx/template
+++ b/srcpkgs/python3-pyx/template
@@ -1,16 +1,15 @@
 # Template file for 'python3-pyx'
 pkgname=python3-pyx
-version=0.14.1
-revision=2
+version=0.15
+revision=1
 archs=noarch
 wrksrc="PyX-${version}"
 build_style=python3-module
-pycompile_module="pyx"
 hostmakedepends="python3-setuptools"
-depends="python3 texlive-bin"
+depends="python3 virtual?tex"
 short_desc="Python3 library for the creation of PostScript and PDF files"
 maintainer="cipr3s <cipr3s@gmx.com>"
-license="GPL-2"
-homepage="http://pyx.sourceforge.net"
+license="GPL-2.0-or-later"
+homepage="https://pyx-project.org"
 distfiles="${PYPI_SITE}/P/PyX/PyX-${version}.tar.gz"
-checksum=05d1b7fc813379d2c12fcb5bd0195cab522b5aabafac88f72913f1d47becd912
+checksum=0fc3b00c5e7fb6f4aefbf63b95f624297dde47700a82b8b5ad6ebb346b5e4977

--- a/srcpkgs/rubber/template
+++ b/srcpkgs/rubber/template
@@ -1,11 +1,11 @@
 # Template file for 'rubber'
 pkgname=rubber
 version=1.5.1
-revision=2
+revision=3
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3"
-depends="python3 texlive-bin"
+depends="python3 virtual?tex"
 pycompile_module="rubber"
 short_desc="LaTeX building tool"
 maintainer="Matteo Signer <matteo.signer@gmail.com>"

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20200406
-revision=1
+revision=2
 wrksrc="texlive-${version}-source"
 build_wrksrc="build"
 build_style=gnu-configure
@@ -72,6 +72,8 @@ makedepends="cairo-devel freetype-devel gd-devel graphite-devel gmp-devel
  poppler-devel pixman-devel libteckit-devel zlib-devel zziplib-devel
  libXaw-devel"
 depends="dialog ghostscript perl-Tk texlive-core xbps-triggers>=0.115_1"
+# Virtual package cares only about year part of version
+provides="tex-${version%${version#????}}_1"
 short_desc="TeX Live"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/texlive2014-bin/template
+++ b/srcpkgs/texlive2014-bin/template
@@ -1,12 +1,13 @@
 # Template file for 'texlive2014-bin'
 pkgname=texlive2014-bin
 version=2014
-revision=8
+revision=9
 archs="x86_64* i686 aarch64 arm*"
 create_wrksrc=yes
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+provides="tex-${version}_1"
 short_desc="TeX Live Binary distribution through tl-install"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2"

--- a/srcpkgs/texlive2016-bin/template
+++ b/srcpkgs/texlive2016-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-bin'
 pkgname=texlive2016-bin
 version=2016
-revision=2
+revision=3
 archs="x86_64* i686 aarch64 arm*"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="http://tug.org/texlive/"
@@ -10,6 +10,7 @@ short_desc="TeX Live Binary distribution through tl-install"
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+provides="tex-${version}_1"
 distfiles="ftp://ftp.tug.org/texlive/historic/${version}/install-tl-unx.tar.gz>${pkgname}-${version}-${revision}.tar.gz"
 checksum=a0559306f4ef1903b92c829a11177dcbf3b85ddb9c6b512a80791e2c543f7d95
 create_wrksrc=yes

--- a/srcpkgs/texlive2017-bin/template
+++ b/srcpkgs/texlive2017-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-bin'
 pkgname=texlive2017-bin
 version=2017
-revision=3
+revision=4
 archs="x86_64* i686 aarch64 arm*"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="http://tug.org/texlive/"
@@ -10,6 +10,7 @@ short_desc="TeX Live Binary distribution through tl-install"
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+provides="tex-${version}_1"
 distfiles="ftp://ftp.tug.org/texlive/historic/${version}/install-tl-unx.tar.gz>${pkgname}-${version}-${revision}.tar.gz"
 checksum=d4e07ed15dace1ea7fabe6d225ca45ba51f1cb7783e17850bc9fe3b890239d6d
 create_wrksrc=yes

--- a/srcpkgs/texlive2018-bin/template
+++ b/srcpkgs/texlive2018-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-bin'
 pkgname=texlive2018-bin
 version=2018
-revision=2
+revision=3
 archs="x86_64* i686 aarch64 arm*"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="http://tug.org/texlive/"
@@ -10,6 +10,7 @@ short_desc="TeX Live Binary distribution through tl-install"
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+provides="tex-${version}_1"
 distfiles="ftp://ftp.tug.org/texlive/historic/${version}/install-tl-unx.tar.gz>${pkgname}-${version}-${revision}.tar.gz"
 checksum=82c13110852af162c4c5ef1579fa2f4f51c2040850ec02fb7f97497da45eb446
 create_wrksrc=yes

--- a/srcpkgs/texlive2019-bin/template
+++ b/srcpkgs/texlive2019-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive2019-bin'
 pkgname=texlive2019-bin
 version=2019
-revision=2
+revision=3
 archs="x86_64* i686 aarch64 arm*"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="http://tug.org/texlive/"
@@ -10,6 +10,7 @@ short_desc="TeX Live Binary distribution through tl-install"
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+provides="tex-${version}_1"
 distfiles="ftp://ftp.tug.org/texlive/historic/${version}/install-tl-unx.tar.gz>${pkgname}-${version}-${revision}.tar.gz"
 checksum=44aa41b5783e345b7021387f19ac9637ff1ce5406a59754230c666642dfe7750
 create_wrksrc=yes

--- a/srcpkgs/texlive2020-bin/template
+++ b/srcpkgs/texlive2020-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-bin'
 pkgname=texlive2020-bin
 version=2020
-revision=1
+revision=2
 archs="x86_64* i686 aarch64 arm*"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 homepage="http://tug.org/texlive/"
@@ -10,6 +10,7 @@ short_desc="TeX Live Binary distribution through tl-install"
 depends="cairo pixman graphite gd poppler libsigsegv
  zziplib libpng libjpeg-turbo freetype icu harfbuzz wget perl
  ghostscript xz"
+provides="tex-${version}_1"
 distfiles="ftp://ftp.tug.org/texlive/historic/${version}/install-tl-unx.tar.gz>${pkgname}-${version}-${revision}.tar.gz"
 checksum=7c90a50e55533d57170cbc7c0370a010019946eb18570282948e1af6f809382d
 create_wrksrc=yes

--- a/srcpkgs/xournalpp/template
+++ b/srcpkgs/xournalpp/template
@@ -1,12 +1,12 @@
 # Template file for 'xournalpp'
 pkgname=xournalpp
 version=1.0.18
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config gettext"
 makedepends="libxml2-devel libcppunit-devel poppler-glib-devel gtk+3-devel
  portaudio-cpp-devel libsndfile-devel libzip-devel"
-depends="texlive-bin"
+depends="virtual?tex"
 short_desc="Handwriting Notetaking software with PDF annotation support"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
The `texlive` virtual package has been renamed `tex` to be more generic and avoid confusion with the new "native" `texlive` package, and `texlive` has been named the default provider for the new virtual.

Every `texlive*-bin` package provides `tex` with a version based on its own (which is the release year); the new `texlive` strips the month and day from its year to similarly provide `tex` with a version by year.

A few texlive dependents that are quick to build have been updated to depend on the new virtual, and I've bumped `python3-pyx` while I was at it.

This is really motivated by `xournalpp`, which is [ready to go](https://github.com/ahesford/void-packages/tree/xournalpp) with the new virtual, but I'm holding back because I want this to run through CI and I'm afraid `xournalpp` will time out.

This will also break `lyx` which currently depends on `virtual?texlive`, but that's also [ready to go](https://github.com/ahesford/void-packages/tree/lyx) with a new version bump. Again, including `lyx` here might overrun Travis time limits.

Seeking comments from @q66 and @fosslinux since they shepherded the new `texlive` as well as @leahneukirchen as `texlive*-bin` maintainer.