### PR TITLE
R-cran-scales: update to 1.1.1.

### DIFF
--- a/srcpkgs/R-cran-scales/template
+++ b/srcpkgs/R-cran-scales/template
@@ -1,19 +1,19 @@
 # Template file for 'R-cran-scales'
 pkgname=R-cran-scales
-version=1.1.0
+version=1.1.1
 revision=1
 build_style=R-cran
-makedepends=" R-cran-RColorBrewer R-cran-farver
- R-cran-munsell R-cran-labeling R-cran-Rcpp R-cran-R6
- R-cran-viridisLite R-cran-colorspace R-cran-lifecycle"
-depends="R-cran-RColorBrewer R-cran-farver
- R-cran-munsell>=0.2 R-cran-labeling R-cran-Rcpp R-cran-R6
- R-cran-viridisLite R-cran-colorspace R-cran-lifecycle"
+makedepends="R-cran-RColorBrewer R-cran-farver
+ R-cran-munsell R-cran-labeling R-cran-R6
+ R-cran-viridisLite R-cran-lifecycle"
+depends="R-cran-RColorBrewer R-cran-farver>=2.0.3
+ R-cran-munsell>=0.5 R-cran-labeling R-cran-R6
+ R-cran-viridisLite R-cran-lifecycle"
 short_desc="Scale Functions for Visualization"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="MIT"
 homepage="https://github.com/hadley/scales"
-checksum=1ee4a6fd1dbc5f52fe57dd8cce8caee4ce2fecb02d4e7d519e83f15aa45b2d03
+checksum=40b2b66522f1f314a20fd09426011b0cdc9d16b23ee2e765fe1930292dd03705
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Removed unneeded dependencies as well.