### PR TITLE
go: update to 1.14.6.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.14.4
+version=1.14.6
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=7011af3bbc2ac108d1b82ea8abb87b2e63f78844f0259be20cde4d42c5c40584
+checksum=73fc9d781815d411928eccb92bf20d5b4264797be69410eac854babe44c94c09
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
This also covers Go 1.14.5, which is a security release for CVE-2020-15586 (and one other that applies to Windows only).