### PR TITLE
[RFC] 11-pkglint-elf-in-usrshare: allow explicit setting of exceptions

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -141,7 +141,7 @@ to be accepted. New fonts are welcome if they provide value beyond
 aesthetics (e.g. they contain glyphs for a script missing in already
 packaged fonts).
 
-Browser forks, including those based on Chromium and Firefox, are generally not 
+Browser forks, including those based on Chromium and Firefox, are generally not
 accepted. Such forks require heavy patching, maintenance and hours of build time.
 
 <a id="buildphase"></a>
@@ -623,6 +623,12 @@ the `$DESTDIR` which will not be scanned for runtime dependencies. This may be u
 skip files which are not meant to be run or loaded on the host but are to be sent to some
 target device or emulation.
 
+- `ignore_elf_files` White space separated list of machine code files
+in /usr/share directory specified by absolute path, which are expected and allowed.
+
+- `ignore_elf_dirs` White space separated list of directories in /usr/share directory
+specified by absolute path, which are expected and allowed to contain machine code files.
+
 - `nocross` If set, cross compilation won't be allowed and will exit immediately.
 This should be set to a string describing why it fails, or a link to a travis
 buildlog demonstrating the failure.
@@ -950,7 +956,7 @@ Environment variables for a specific `build_style` can be declared in a filename
 matching the `build_style` name, Example:
 
     `common/environment/build-style/gnu-configure.sh`
-    
+
 - `texmf` For texmf zip/tarballs that need to go into /usr/share/texmf-dist. Includes
 duplicates handling.
 

--- a/common/hooks/post-install/11-pkglint-elf-in-usrshare.sh
+++ b/common/hooks/post-install/11-pkglint-elf-in-usrshare.sh
@@ -29,8 +29,9 @@ hook() {
         file="${f%:*}"
         file="${file#${PKGDESTDIR}}"
         case "${mime}" in
-            # Note application/x-executable is missing which is present in most Electron apps
-            application/x-sharedlib*|application/x-pie-executable*)
+            application/x-sharedlib*|\
+             application/x-pie-executable*|\
+             application/x-executable*)
                 if [[ ${ignore_elf_files} != *"${file}"* ]]; then
                     matches+=" ${file}"
                 fi

--- a/common/hooks/post-install/11-pkglint-elf-in-usrshare.sh
+++ b/common/hooks/post-install/11-pkglint-elf-in-usrshare.sh
@@ -2,12 +2,24 @@
 #
 # This hook executes the following tasks:
 #   - Looks on all packages for binary files being installed to /usr/share
+#   - Allows exceptions listed in $ignore_elf_files and $ignore_elf_dirs
 
 hook() {
-    local matches mime file
+    local matches mime file f prune_expr dir
 
     if [ ! -d ${PKGDESTDIR}/usr/share ]; then
         return 0
+    fi
+
+    if [ "${ignore_elf_dirs}" ]; then
+        for dir in ${ignore_elf_dirs}; do
+            if ! [ "${prune_expr}" ]; then
+                prune_expr="( -path ${PKGDESTDIR}${dir}"
+            else
+                prune_expr+=" -o -path ${PKGDESTDIR}${dir}"
+            fi
+        done
+        prune_expr+=" ) -prune -o "
     fi
 
     # Find all binaries in /usr/share and add them to the pool
@@ -15,13 +27,18 @@ hook() {
         mime="${f##*:}"
         mime="${mime// /}"
         file="${f%:*}"
+        file="${file#${PKGDESTDIR}}"
         case "${mime}" in
             # Note application/x-executable is missing which is present in most Electron apps
             application/x-sharedlib*|application/x-pie-executable*)
-                matches+=" ${file#$PKGDESTDIR}" ;;
+                if [[ ${ignore_elf_files} != *"${file}"* ]]; then
+                    matches+=" ${file}"
+                fi
+                ;;
         esac
-    done < <(find $PKGDESTDIR/usr/share -type f | file --mime-type --files-from -)
+    done < <(find $PKGDESTDIR/usr/share $prune_expr -type f | file --mime-type --files-from -)
 
+    # Check passed if no packages in pool
     if [ -z "$matches" ]; then
         return 0
     fi


### PR DESCRIPTION
This will allow to explicitely ignore files in the hook where it otherwise would create false positives like in the case of qemu.

@void-linux/pkg-committers