### PR TITLE
fortune-mod-anarchism: update to 1.4.0 and set archs=noarch

### DIFF
--- a/srcpkgs/fortune-mod-anarchism/template
+++ b/srcpkgs/fortune-mod-anarchism/template
@@ -1,7 +1,8 @@
 # Template file for 'fortune-mod-anarchism'
 pkgname=fortune-mod-anarchism
-version=1.3.1
+version=1.4.0
 revision=1
+archs=noarch
 wrksrc=blag-fortune
 build_style=gnu-makefile
 hostmakedepends="fortune-mod"
@@ -11,7 +12,7 @@ maintainer="Hazel Levine <rose.hazel@protonmail.ch>"
 license="Public Domain"
 homepage="https://notabug.org/PangolinTurtle/BLAG-fortune"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=5a2be2055872248f57091616b3f47aa0b7fd649bd6f892c770c9e22edbc07520
+checksum=5cfcd96b23f6ec3518d355ef1b53681321a9b7f85e5bdcc82d828d7a7bcd3a9e
 
 do_install() {
 	vmkdir usr/share/fortunes


### PR DESCRIPTION
Currently this package only available on `x86_64` and `x86_64-musl`, idk why it does not build for other architectures, but cross compile builds without any problem here.

`fortune-mod-void` and `fortune-mod-de` already has `archs=noarch` and this package should too.

@ralsei 