### PR TITLE
python3: update to 3.8.4

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1783,11 +1783,9 @@ libportaudio.so.2 portaudio-19.20140130_1
 libportaudiocpp.so.0 portaudio-cpp-19.20140130_1
 libdar.so.6000 libdar-2.6.6_1
 libdar64.so.6000 libdar-2.6.6_1
-libpython3.so python3-3.6.2_1
-libdar.so.5000 libdar-2.4.14_1
-libpython3.6m.so.1.0 python3-3.6.2_1
 libpython3.so python3-3.8.0_1
 libpython3.8.so.1.0 python3-3.8.0_1
+libdar.so.5000 libdar-2.4.14_1
 libbrscandec2.so.1 brother-brscan3-0.2.11_2
 libpyglib-2.0-python.so.0 python-gobject2-2.28.6_11
 libxmlrpc_server_abyss.so.3 xmlrpc-c-1.25.28_1

--- a/srcpkgs/python3-tkinter/template
+++ b/srcpkgs/python3-tkinter/template
@@ -1,13 +1,13 @@
 # Template file for 'python3-tkinter'
 #
-# THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/python3"; IT IS SPLITTED TO AVOID
-# A CYCLIC DEPENDENCY: python3 -> tk -> libX11 -> libxcb -> xcb-proto -> python3
+# THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/python3"; IT IS SPLIT TO AVOID A
+# CYCLIC DEPENDENCY: python3 -> tk -> libX11 -> libxcb -> xcb-proto -> python3
 #
 
 _desc="Python programming language"
 
 pkgname=python3-tkinter
-version=3.8.3
+version=3.8.4
 revision=1
 wrksrc="Python-${version}"
 pycompile_dirs="
@@ -22,7 +22,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.python.org"
 license="Python-2.0"
 distfiles="https://www.python.org/ftp/python/${version}/Python-${version}.tar.xz"
-checksum=dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864
+checksum=5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37
 
 pre_configure() {
 	# Ensure that internal copies of expat and libffi are not used.

--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -3,15 +3,15 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/python3-tkinter".
 #
 pkgname=python3
-version=3.8.3
-revision=2
+version=3.8.4
+revision=1
 wrksrc="Python-${version}"
 short_desc="Python programming language (${version%.*} series)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Python-2.0"
 homepage="https://www.python.org"
 distfiles="https://www.python.org/ftp/python/${version}/Python-${version}.tar.xz"
-checksum=dfab5ec723c218082fe3d5d7ae17ecbdebffa9a1aea4d64aa3a2ecdd2e795864
+checksum=5f41968a95afe9bc12192d7e6861aab31e80a46c46fa59d3d837def6a4cd4d37
 
 pycompile_dirs="usr/lib/python${version%.*}"
 hostmakedepends="pkgconf"


### PR DESCRIPTION
Also dropped outdated `python-3.6.2_1` lines from `common/shlibs`.