### PR TITLE
rpi-kernel: add support for LXD 4.2+.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -10,7 +10,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
 version=4.19.127
-revision=1
+revision=2
 wrksrc="linux-${_githash}"
 maintainer="Peter Bui <pbui@github.bx612.space>"
 homepage="http://www.kernel.org"
@@ -92,6 +92,9 @@ do_configure() {
 
 	# HID Controllers
 	echo "CONFIG_HID_STEAM=y" >> "$defconfig"
+
+	# LXD 4.2+ support
+	echo "CONFIG_BRIDGE_VLAN_FILTERING=y" >> "$defconfig"
 	
 	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
 


### PR DESCRIPTION
This is not enabled on any of the defconfigs by default, but is needed for LXD since 4.2.

@pbui Does this look sane to you?

Compiled for all archs and tested on rpi4 (aarch64) and rpi3 (aarch64, armv7l)

[ci skip]
