### PR TITLE
podman: update to 2.0.2.

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,10 +1,9 @@
 # Template file for 'podman'
 pkgname=podman
-version=2.0.1
+version=2.0.2
 revision=1
-wrksrc="libpod-${version}"
 build_style=go
-go_import_path="github.com/containers/libpod"
+go_import_path="github.com/containers/libpod/v2"
 go_package="${go_import_path}/cmd/podman"
 go_build_tags="seccomp apparmor containers_image_ostree_stub
  btrfs_noversion exclude_graphdriver_btrfs"
@@ -16,7 +15,7 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://podman.io/"
 distfiles="https://github.com/containers/libpod/archive/v${version}.tar.gz"
-checksum=bc151fbcb4890f3862124d5b2b272bd0152307e3945cb9cef4ba90f14a863d80
+checksum=5fee5873e00ecbbf8c47d5519d0f138e5a322716d8d2306f4e45ab71f0a079c6
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"


### PR DESCRIPTION
Fix the Go import path to use the v2 suffix (so that 2.x is being
built) and remove wrksrc.