### PR TITLE
qemu : fixed firmware path

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -82,6 +82,11 @@ do_install() {
 	# qemu-bridge-helper must be setuid for non privileged users.
 	chmod u+s ${DESTDIR}/usr/libexec/qemu-bridge-helper
 
+	#Symbolic link /usr/share/qemu/firmware -> /usr/lib/qemu/firmware
+	#to permit libvirtd to find the firmwares
+	vmkdir usr/share/qemu
+	ln -s /usr/lib/qemu/firmware ${DESTDIR}/usr/share/qemu/firmware
+
 	vsv qemu-ga
 }
 


### PR DESCRIPTION
Hi,
the actual qemu version is built wrong. 
When libvirt start, it searchs firmware in **/usr/share/qemu/firmware** but the firmwares are installed in **/usr/lib/qemu/firmware** because it has been set **--data-lib=/usr/lib**.
Deleting this setting , now libvirt works correctly and i can choice uefi firmware.
Before this was not possible.
Regards


