### PR TITLE
libressl: add assembly for aarch64, ppc*, extra assembly for arm

### DIFF
--- a/srcpkgs/libressl/template
+++ b/srcpkgs/libressl/template
@@ -1,12 +1,13 @@
 # Template file for 'libressl'
 pkgname=libressl
 version=3.1.3
-revision=1
+revision=2
 bootstrap=yes
 build_style=gnu-configure
+configure_args="$(vopt_enable asm)"
 short_desc="Version of the TLS/crypto stack forked from OpenSSL"
 maintainer="Juan RP <xtraeme@gmail.com>"
-license="OpenSSL-License, SSLeay-License, ISC"
+license="OpenSSL, ISC"
 #changelog="https://raw.githubusercontent.com/libressl-portable/portable/master/ChangeLog"
 homepage="http://www.libressl.org/"
 distfiles="http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${pkgname}-${version}.tar.gz"
@@ -14,20 +15,49 @@ checksum=c76b0316acf612ecb62f5cb014a20d972a663bd9e40abf952a86f3b998b69fa0
 provides="openssl-${version}_${revision}"
 replaces="openssl>=0"
 conf_files="/etc/ssl/openssl.cnf /etc/ssl/x509v3.cnf"
+_lssl_asm_ver="1.0.0"
 
-if [ "$XBPS_TARGET_MACHINE" = "i686-musl" ]; then
-	# XXX disable SSP
-	configure_args+=" --disable-hardening"
-elif [ "$XBPS_TARGET_MACHINE" = "armv5tel" ]; then
-	configure_args+=" --disable-asm"
+build_options="asm"
+desc_option_asm="Use platform assembly for faster crypto"
+
+if [ "$build_option_asm" ]; then
+	distfiles+=" https://github.com/q66/libressl-portable-asm/archive/v${_lssl_asm_ver}.tar.gz"
+	checksum+=" 2c261f263319ecd73497c2eadd990ccf8310f338e84a452305aca70d2269b298"
 fi
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends="automake libtool"
-	pre_configure() {
-		autoreconf -fi
-	}
+# only enable asm for full chroots by default
+# otherwise we'd be introducing an autotools dependency on the host
+if [ "$CHROOT_READY" ]; then
+	build_options_default="asm"
 fi
+
+case "$XBPS_TARGET_MACHINE" in
+	# disable ssp
+	i686-musl) configure_args+=" --disable-hardening";;
+	# on armv5 always disable asm as it's not supported
+	armv5*) configure_args+=" --disable-asm";;
+esac
+
+if [ "$CROSS_BUILD" -o "$build_option_asm" ]; then
+	_regen_build=yes
+fi
+
+if [ -n "$_regen_build" ]; then
+	hostmakedepends=" automake libtool"
+fi
+
+post_extract() {
+	[ -z "$build_option_asm" ] && return 0
+	mv ../libressl-portable-asm-${_lssl_asm_ver} .
+}
+
+pre_configure() {
+	[ -z "$_regen_build" ] && return 0
+	if [ "$build_option_asm" ]; then
+		./libressl-portable-asm-${_lssl_asm_ver}/patch_libressl.sh .
+	fi
+	autoreconf -if
+}
 
 post_install() {
 	# Use CA file from ca-certificates instead.


### PR DESCRIPTION
This yields significant speedups (20x) in some things (AES/ghash) on platforms with hardware crypto support (e.g. POWER8 and newer, and most aarch64) as well as enhances performance of assorted alogrithms by using optimized assembly implementations instead of portable fallbacks. E.g. on aarch64 https://gist.githubusercontent.com/q66/c75a46fc7d0c27eff21cc9d70639bf95/raw/dde1f60e304ef8f4a4049d41388d9c25e63b4a1e/gistfile1.txt

As it is now, libressl only supports asm for x86(_64) and to a limited degree, 32-bit ARM. The extra support was added by my project: https://github.com/q66/libressl-portable-asm

Everything was tested, test suite passes on all platforms, and benchmarks were run on relevant hardware, confirming the speedups.

I still think we should move back to OpenSSL, since there are many reasons to do so (even disregarding performance) and the performance is still better on it (as there are various algos that don't have optimized implementations under libressl at all) but this could be a decent stopgap solution, enabling at least basic things (like hardware AES on non-x86 systems).

Tested:

- [x] ppc64le
- [x] ppc64
- [x] ppc
- [x] armv7l
- [x] aarch64

Benchmarked:

- [x] ppc64le
- [x] ppc64
- [x] ppc
- [x] armv7l
- [x] aarch64

@void-linux/pkg-committers