### PR TITLE
xfce4: add elogind as dependency

### DIFF
--- a/srcpkgs/xfce4/template
+++ b/srcpkgs/xfce4/template
@@ -1,7 +1,7 @@
 # Template file for 'xfce4'
 pkgname=xfce4
 version=4.14.0
-revision=1
+revision=2
 build_style=meta
 depends="
 	xfce4-appfinder>=${version}
@@ -26,6 +26,7 @@ depends="
 	tumbler>=0.2.7
 	xdg-user-dirs-gtk
 	upower
+	elogind
 	xfce-polkit"
 short_desc="XFCE meta-package for Void Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
With the removal of ConsoleKit2, elogind is required for some session functionality as reported in #20245.