### PR TITLE
libwebp-devel: do not depend on libfreeglut-devel

### DIFF
--- a/srcpkgs/libwebp/template
+++ b/srcpkgs/libwebp/template
@@ -1,7 +1,7 @@
 # Template file for 'libwebp'
 pkgname=libwebp
 version=1.1.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --enable-libwebpmux
  --enable-libwebpdemux --enable-libwebpdecoder"
@@ -33,7 +33,7 @@ libwebp-tools_package() {
 }
 
 libwebp-devel_package() {
-	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	depends="${makedepends/libfreeglut-devel/} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
Although there is a (correct) makedepends on libfreeglut-devel, it is
only needed to compile the vwebp tool, so libwebp-devel should not
depend on it. This is very relevant since libfreeglut-devel deptree
includes a lot of unnecessary stuff (mesa, wayland, X libraries, etc.)