### PR TITLE
ncurses-libs: provide libncurses.so.{5,6}

### DIFF
--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template file for 'ncurses'
 pkgname=ncurses
 version=6.2
-revision=2
+revision=3
 bootstrap=yes
 configure_args="--enable-big-core"
 short_desc="System V Release 4.0 curses emulation library"
@@ -78,6 +78,8 @@ do_install() {
 	cd ${wrksrc}/ncurses-build
 	install -Dm755 lib/libncurses.so.${version} \
 		${DESTDIR}/usr/lib/libncurses.so.${version}
+	ln -sf libncurses.so.${version} ${DESTDIR}/usr/lib/libncurses.so.6
+	ln -sf libncurses.so.${version} ${DESTDIR}/usr/lib/libncurses.so.5
 
 	# Create libtinfo symlinks.
 	ln -sfr ${DESTDIR}/usr/lib/libncursesw.so \
@@ -107,7 +109,7 @@ do_install() {
 }
 
 ncurses-libs_package() {
-	shlib_provides="libformw.so.5 libmenuw.so.5 libpanelw.so.5 libncursesw.so.5"
+	shlib_provides="libformw.so.5 libmenuw.so.5 libpanelw.so.5 libncursesw.so.5 libncurses.so.5"
 	short_desc+=" -- shared libraries"
 	pkg_install() {
 		vmove "usr/lib/libform*.so.*"


### PR DESCRIPTION
For compatibility, provide symlinks

    /usr/lib/libncurses.so.5 -> /usr/lib/libncurses.so.6.2
    /usr/lib/libncurses.so.6 -> /usr/lib/libncurses.so.6.2