### PR TITLE
intel-media-driver: update to 20.2.0 (and deps)

### DIFF
--- a/srcpkgs/intel-gmmlib/template
+++ b/srcpkgs/intel-gmmlib/template
@@ -1,16 +1,17 @@
 # Template file for 'intel-gmmlib'
 pkgname=intel-gmmlib
-version=20.1.1
+version=20.2.2
 revision=1
 archs="i686* x86_64*"
 wrksrc=gmmlib-intel-gmmlib-${version}
 build_style=cmake
+configure_args="-Wno-dev"
 short_desc="Intel Graphics Memory Management Library"
 maintainer="Stefano Ragni <st3r4g@protonmail.com>"
 license="MIT"
 homepage="https://github.com/intel/gmmlib"
 distfiles="https://github.com/intel/gmmlib/archive/intel-gmmlib-${version}.tar.gz"
-checksum=821755657cf51f59d8f3f443c99e3ec9f28d897ff65c219c6a119e4acb5a2ac7
+checksum=b3dfb193549b7385d68d959b31fa4670fef69161ca808bc9268a213bffba84f2
 
 lib32disabled=yes
 

--- a/srcpkgs/intel-media-driver/template
+++ b/srcpkgs/intel-media-driver/template
@@ -1,11 +1,11 @@
 # Template file for 'intel-media-driver'
 pkgname=intel-media-driver
-version=20.1.1
+version=20.2.0
 revision=1
 archs="x86_64*"
 wrksrc=media-driver-intel-media-${version}
 build_style=cmake
-configure_args="-DENABLE_NONFREE_KERNELS=$(vopt_if nonfree ON OFF)"
+configure_args="-Wno-dev -DENABLE_NONFREE_KERNELS=$(vopt_if nonfree ON OFF)"
 hostmakedepends="pkg-config"
 makedepends="libva-devel libX11-devel intel-gmmlib-devel libpciaccess-devel"
 short_desc="Intel Media Driver for VAAPI (Broadwell+)"
@@ -13,7 +13,7 @@ maintainer="Stefano Ragni <st3r4g@protonmail.com>"
 license="MIT, BSD-3-Clause"
 homepage="https://github.com/intel/media-driver"
 distfiles="https://github.com/intel/media-driver/archive/intel-media-${version}.tar.gz"
-checksum=dbca37ba8383cd4d1f3e15fa906f03457ebdb5a118d2459d8f9cd477e0f3d4d4
+checksum=1cdd40517d9fee51e3760beea23d2a19c2d5fcb1d6a9ed2bc0af7318d0d3100f
 
 build_options="nonfree"
 desc_option_nonfree="Enable nonfree kernels"

--- a/srcpkgs/intel-media-driver/update
+++ b/srcpkgs/intel-media-driver/update
@@ -1,0 +1,1 @@
+pkgname=intel-media

--- a/srcpkgs/libva/template
+++ b/srcpkgs/libva/template
@@ -1,6 +1,6 @@
 # Template file for 'libva'
 pkgname=libva
-version=2.7.1
+version=2.8.0
 revision=1
 build_style=meson
 configure_args="-Dwith_glx=no $(vopt_if wayland -Dwith_wayland=yes)"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://01.org/linuxmedia/vaapi"
 changelog="https://raw.githubusercontent.com/intel/libva/master/NEWS"
 distfiles="https://github.com/intel/libva/archive/${version}.tar.gz"
-checksum=9a3167c9af8c0ce10c4a46791557f934457b78fcc625111dcefaa7f30b7eb289
+checksum=171bb8401930007945e87c765f22304e66e6e21c8a244a76389825dc2232671e
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
Tested on `x86_64-musl` with `mpv`

The lint script wrongly complains because it sees the word "nonfree"...