### PR TITLE
gummiboot: add configuration file.

### DIFF
--- a/srcpkgs/gummiboot/files/kernel.d/gummiboot.confd
+++ b/srcpkgs/gummiboot/files/kernel.d/gummiboot.confd
@@ -1,0 +1,2 @@
+# uncomment this line to disable the gummiboot hook
+#GUMMIBOOT_DISABLE=1

--- a/srcpkgs/gummiboot/files/kernel.d/gummiboot.post-install
+++ b/srcpkgs/gummiboot/files/kernel.d/gummiboot.post-install
@@ -7,6 +7,12 @@
 PKGNAME="$1"
 VERSION="$2"
 
+. "$ROOTDIR/etc/default/gummiboot"
+
+if [ "$GUMMIBOOT_DISABLE" ]; then
+	exit 0
+fi
+
 boot=$ROOTDIR/boot
 entries=$boot/loader/entries
 name=void-$VERSION

--- a/srcpkgs/gummiboot/template
+++ b/srcpkgs/gummiboot/template
@@ -1,9 +1,10 @@
 # Template file for 'gummiboot'
 pkgname=gummiboot
 version=48.1
-revision=3
+revision=4
 archs="i686* x86_64* aarch64*"
 build_style=gnu-configure
+conf_files="/etc/default/gummiboot"
 hostmakedepends="automake pkg-config libxslt docbook-xsl"
 makedepends="gnu-efi-libs liblzma-devel libblkid-devel"
 short_desc="Simple UEFI Boot Manager"
@@ -26,8 +27,10 @@ pre_configure() {
 }
 
 post_install() {
-	vinstall ${FILESDIR}/kernel.d/gummiboot.post-install 750 \
+	vinstall ${FILESDIR}/kernel.d/gummiboot.post-install 744 \
 		etc/kernel.d/post-install 50-gummiboot
-	vinstall ${FILESDIR}/kernel.d/gummiboot.post-remove 750 \
+	vinstall ${FILESDIR}/kernel.d/gummiboot.post-remove 744 \
 		etc/kernel.d/post-remove 50-gummiboot
+	vinstall ${FILESDIR}/kernel.d/gummiboot.confd 644 \
+		etc/default gummiboot
 }


### PR DESCRIPTION
This makes it possible to easily disable the gummiboot kernel hook.

Change hook permissions to 755 to allow them to be read by anyone.

@sgn