### PR TITLE
xtools: depend on spdx-licenses-list (for xlint)

### DIFF
--- a/srcpkgs/xtools/template
+++ b/srcpkgs/xtools/template
@@ -1,10 +1,10 @@
 # Template file for 'xtools'
 pkgname=xtools
 version=0.59
-revision=1
+revision=2
 archs="noarch"
 build_style=gnu-makefile
-depends="bash curl findutils git make xbps"
+depends="bash curl findutils git make spdx-licenses-list xbps"
 short_desc="Opinionated helpers for working with XBPS"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"


### PR DESCRIPTION
No more templates passing `xlint` locally, only to have Travis flag the license.