### PR TITLE
zfs: remove unused init scripts and add zed service

### DIFF
--- a/srcpkgs/zfs/files/zed/run
+++ b/srcpkgs/zfs/files/zed/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+[ -r conf ] && . conf
+exec zed -F $OPTS

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=0.8.4
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d
@@ -37,6 +37,8 @@ post_install() {
 	vlicense LICENSE
 	vlicense NOTICE
 
+	vsv zed
+
 	vmkdir usr/src/${pkgname}-${version}
 	tar xf ../clean.tar.gz -C ${DESTDIR}/usr/src/${pkgname}-${version}
 	scripts/dkms.mkconf -v ${version} -f ${DESTDIR}/usr/src/${pkgname}-${version}/dkms.conf -n zfs
@@ -44,8 +46,12 @@ post_install() {
 		-e 's/test "${PYTHON_VERSION:0:2}" = "2."/test "${PYTHON_VERSION##2.*}" = ""/' \
 		${DESTDIR}/usr/src/${pkgname}-${version}/configure # This is necessary because of https://github.com/zfsonlinux/zfs/issues/8827
 
+	# Remove init and service control pieces not used in Void
 	rm -rf ${DESTDIR}/usr/lib/systemd
 	rm -rf ${DESTDIR}/usr/share/initramfs-tools
+	rm -rf ${DESTDIR}/etc/init.d
+	rm -rf ${DESTDIR}/etc/default
+	rm -f ${DESTDIR}/etc/zfs/zfs-functions
 
 	# Contains ELF binaries. Remove it until upstream has a way to move this
 	# into /usr/libexec or similiar.


### PR DESCRIPTION
Small changes to:
1. Remove `/etc/init.d` scripts that aren't used in Void,
2. Remove `/etc/default/zfs` config script that isn't used, and
3. Add a service to run `zed`.

[edit: also remove `/etc/zfs/zfs-functions`]

@Vaelatern @zdykstra @ericonr