### PR TITLE
apache-storm: cleanup

### DIFF
--- a/srcpkgs/apache-storm/template
+++ b/srcpkgs/apache-storm/template
@@ -1,15 +1,16 @@
 # Template file for 'apache-storm'
 pkgname=apache-storm
 version=2.2.0
-revision=1
-depends="virtual?java-runtime python"
+revision=2
+archs=noarch
+depends="virtual?java-runtime python3 bash"
 short_desc="Distributed realtime computation system"
 maintainer="bougyman <bougyman@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://storm.apache.org/"
 distfiles="http://apache.osuosl.org/storm/apache-storm-${version}/apache-storm-${version}.tar.gz"
 checksum=f621163f349a8e85130bc3d2fbb34e3b08f9c039ccac5474f3724e47a3a38675
-python_version=2 #unverified
+python_version=3
 system_accounts="storm"
 storm_homedir="/var/lib/apache-storm"
 storm_shell="/bin/bash"
@@ -17,8 +18,8 @@ storm_descr="unprivileged user to run apache-storm java classes"
 
 do_install() {
 	vbin bin/storm
+	vbin bin/storm.py
 	vmkdir var/lib/apache-storm
-	# vcopy logback var/lib/apache-storm
 	vcopy public var/lib/apache-storm
 	vmkdir usr/lib/apache-storm
 	vcopy external usr/lib/apache-storm


### PR DESCRIPTION
* set noarch
* add missing storm.py (`/usr/bin/storm` bash script execs it)
* should be python3 compatible, judging from comments in storm.py
* remove commented vcopy

@pullmoll @bougyman @Kistelini