### PR TITLE
openjdk8: mips* support

### DIFF
--- a/srcpkgs/openjdk8/patches/104_mips-support.patch
+++ b/srcpkgs/openjdk8/patches/104_mips-support.patch
@@ -1,0 +1,69 @@
+# DP: Add support for zero architectures alpha, m68k, mips*, sh4
+
+Sourced from https://bazaar.launchpad.net/~openjdk/openjdk/openjdk8/view/head:/debian/patches/zero-architectures.diff
+
+--- openjdk/common/autoconf/platform.m4
++++ openjdk/common/autoconf/platform.m4
+@@ -54,6 +60,42 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_CPU
+       VAR_CPU_BITS=64
+       VAR_CPU_ENDIAN=little
+       ;;
++    mips)
++      VAR_CPU=mips
++      VAR_CPU_ARCH=mips
++      VAR_CPU_BITS=32
++      VAR_CPU_ENDIAN=big
++      ;;
++    mipsel)
++      VAR_CPU=mipsel
++      VAR_CPU_ARCH=mipsel
++      VAR_CPU_BITS=32
++      VAR_CPU_ENDIAN=little
++      ;;
++    mipsn32)
++      VAR_CPU=mipsn32
++      VAR_CPU_ARCH=mipsn32
++      VAR_CPU_BITS=32
++      VAR_CPU_ENDIAN=big
++      ;;
++    mipsn32el)
++      VAR_CPU=mipsn32el
++      VAR_CPU_ARCH=mipsn32el
++      VAR_CPU_BITS=32
++      VAR_CPU_ENDIAN=little
++      ;;
++    mips64)
++      VAR_CPU=mips64
++      VAR_CPU_ARCH=mips64
++      VAR_CPU_BITS=64
++      VAR_CPU_ENDIAN=big
++      ;;
++    mips64el)
++      VAR_CPU=mips64el
++      VAR_CPU_ARCH=mips64el
++      VAR_CPU_BITS=64
++      VAR_CPU_ENDIAN=little
++      ;;
+     powerpc)
+       VAR_CPU=ppc
+       VAR_CPU_ARCH=ppc
+@@ -373,6 +433,8 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS],
+ 
+   # ZERO_ARCHDEF is used to enable architecture-specific code
+   case "${OPENJDK_TARGET_CPU}" in
++    mips|mipsn32|mips64)  ZERO_ARCHDEF=MIPS ;;
++    mipsel|mipsn32el|mips64el)  ZERO_ARCHDEF=MIPSEL ;;
+     ppc)     ZERO_ARCHDEF=PPC32 ;;
+     ppc64)   ZERO_ARCHDEF=PPC64 ;;
+     s390*)   ZERO_ARCHDEF=S390  ;;
+--- openjdk/common/autoconf/flags.m4
++++ openjdk/common/autoconf/flags.m4
+@@ -827,6 +827,8 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAG
+     *)
+       ZERO_ARCHFLAG="${COMPILER_TARGET_BITS_FLAG}${OPENJDK_TARGET_CPU_BITS}"
+   esac
++  # use the default for the package builds
++  ZERO_ARCHFLAG=""
+   FLAGS_COMPILER_CHECK_ARGUMENTS([$ZERO_ARCHFLAG], [], [ZERO_ARCHFLAG=""])
+   AC_SUBST(ZERO_ARCHFLAG)
+ 

--- a/srcpkgs/openjdk8/template
+++ b/srcpkgs/openjdk8/template
@@ -67,7 +67,7 @@ desc_option_docs="Build documentation"
 # no hotspot JIT for arm32 and ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
-	arm*|ppc*) _use_zero=yes ;;
+	arm*|ppc*|mips*) _use_zero=yes ;;
 esac
 
 # specifically do not enable docs because with zero it takes hours
@@ -185,11 +185,17 @@ do_configure() {
 	CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=2/}
 	CXXFLAGS=${CXXFLAGS/-D_FORTIFY_SOURCE=2/}
 
-	# force ELFv2 for ppc64 just in case
 	case "$XBPS_TARGET_MACHINE" in
+		# force ELFv2 for ppc64 just in case
 		ppc64*)
 			CFLAGS+=" -DABI_ELFv2"
 			CXXFLAGS+=" -DABI_ELFv2"
+			;;
+		# with normal -O2 on mipshf there is a too-large jump which causes the
+		# assembler to fail. optimising for size means the jump is made smaller
+		mips*hf*)
+			CFLAGS+=" -Os"
+			CXXFLAGS+=" -Os"
 			;;
 	esac
 


### PR DESCRIPTION
Builds for all mips* platforms, using the zero backend. A mips port
properly is in process but has been "getting close to ready" for years
now, so we are using the much more tested zero backend.

mipshf had a branch jump error (mips hates super large branch jumps).
This is a known bug that is not going to be fixed very easily. To
workaround this, I reduced the jump by ~400 lines of assembly by
compiling with -Os, enough to make the jump close enough.

The mips support patch was taken from debian, I left mips64 in there because it might be useful in the future, we don't lose anything by having it there. (I debated putting the whole patch with all the extra archs in there, but it looked a bit unwieldy then)

cc @pullmoll recent committer and mips expert ;)
cc @Vaelatern maintainer

openjdk11 coming up