### PR TITLE
R-cran-ggplot2: update to 3.3.2.

### DIFF
--- a/srcpkgs/R-cran-callr/template
+++ b/srcpkgs/R-cran-callr/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-callr'
+pkgname=R-cran-callr
+version=3.4.3
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-processx R-cran-R6"
+depends="R-cran-processx R-cran-R6"
+short_desc="Call R from R"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/r-lib/callr"
+checksum=01b7277f20c1d662c6bebbfa2798d179922b36d4148b4298853579aeda0382b5
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-desc/template
+++ b/srcpkgs/R-cran-desc/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-desc'
+pkgname=R-cran-desc
+version=1.2.0
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-assertthat R-cran-crayon R-cran-R6 R-cran-rprojroot"
+depends="R-cran-assertthat R-cran-crayon R-cran-R6 R-cran-rprojroot"
+short_desc="Manipulate DESCRIPTION Files"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/r-lib/desc"
+checksum=e66fb5d4fc7974bc558abcdc107a1f258c9177a29dcfcf9164bc6b33dd08dae8
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-ggplot2/template
+++ b/srcpkgs/R-cran-ggplot2/template
@@ -1,20 +1,14 @@
 # Template file for 'R-cran-ggplot2'
 pkgname=R-cran-ggplot2
-version=3.2.1
+version=3.3.2
 revision=1
 build_style=R-cran
-makedepends="R-cran-digest R-cran-gtable R-cran-plyr
- R-cran-reshape2 R-cran-scales R-cran-tibble
- R-cran-lazyeval R-cran-withr"
-depends="R-cran-digest R-cran-gtable>=0.1.1 R-cran-plyr>=1.7.1
- R-cran-reshape2 R-cran-scales>=0.4.1 R-cran-tibble
- R-cran-lazyeval R-cran-withr>=2.0.0"
+makedepends="R-cran-digest R-cran-glue R-cran-gtable R-cran-isoband
+ R-cran-rlang R-cran-scales R-cran-tibble R-cran-withr"
+depends="R-cran-digest R-cran-glue R-cran-gtable R-cran-isoband
+ R-cran-rlang R-cran-scales R-cran-tibble R-cran-withr"
 short_desc="Create Elegant Data Visualisations Using the Grammar of Graphics"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-only"
 homepage="https://ggplot2.tidyverse.org/"
-checksum=e39114a90af69041645b0751ac469d8919c5a7e8cb044a3b56a0728623e65a56
-
-post_install() {
-	vlicense LICENSE
-}
+checksum=4dad281e6afb0202ebc8dbe9bd91ae93ab5c3b2aa10fad03078dd87f71595173

--- a/srcpkgs/R-cran-isoband/template
+++ b/srcpkgs/R-cran-isoband/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-isoband'
+pkgname=R-cran-isoband
+version=0.2.2
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-testthat"
+depends="R-cran-testthat"
+short_desc="Generate Isolines and Isobands from Regularly Spaced Elevation Grids"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/wilkelab/isoband"
+checksum=fd1bb33c547e1ace948212aacb12c7b1907fa3dbf1d417c236dbac4702788e10
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-pkgbuild/template
+++ b/srcpkgs/R-cran-pkgbuild/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-pkgbuild'
+pkgname=R-cran-pkgbuild
+version=1.1.0
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-callr R-cran-cli R-cran-crayon R-cran-desc
+ R-cran-prettyunits R-cran-R6 R-cran-rprojroot R-cran-withr"
+depends="R-cran-callr R-cran-cli R-cran-crayon R-cran-desc
+ R-cran-prettyunits R-cran-R6 R-cran-rprojroot R-cran-withr"
+short_desc="Find Tools Needed to Build R Packages"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/r-lib/pkgbuild"
+checksum=b39bfb7661fc53f88962e2380fa9ded2e323c6ad43ac6b582195c749b0ccabbd

--- a/srcpkgs/R-cran-pkgload/template
+++ b/srcpkgs/R-cran-pkgload/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-pkgload'
+pkgname=R-cran-pkgload
+version=1.1.0
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-cli R-cran-crayon R-cran-desc R-cran-pkgbuild
+ R-cran-rlang R-cran-rprojroot R-cran-rstudioapi R-cran-withr"
+depends="R-cran-cli R-cran-crayon R-cran-desc R-cran-pkgbuild
+ R-cran-rlang R-cran-rprojroot R-cran-rstudioapi R-cran-withr"
+short_desc="Simulate Package Installation and Attach"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/r-lib/pkgload"
+checksum=189d460dbba2b35fa15dd59ce832df252dfa654a5acee0c9a8471b4d70477b0d

--- a/srcpkgs/R-cran-praise/template
+++ b/srcpkgs/R-cran-praise/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-praise'
+pkgname=R-cran-praise
+version=1.0.0
+revision=1
+build_style=R-cran
+short_desc="Praise Users"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/rladies/praise"
+checksum=5c035e74fd05dfa59b03afe0d5f4c53fbf34144e175e90c53d09c6baedf5debd
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-prettyunits/template
+++ b/srcpkgs/R-cran-prettyunits/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-prettyunits'
+pkgname=R-cran-prettyunits
+version=1.1.1
+revision=1
+build_style=R-cran
+short_desc="Pretty, Human Readable Formatting of Quantities"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/gaborcsardi/prettyunits"
+checksum=9a199aa80c6d5e50fa977bc724d6e39dae1fc597a96413053609156ee7fb75c5
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-processx/template
+++ b/srcpkgs/R-cran-processx/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-processx'
+pkgname=R-cran-processx
+version=3.4.3
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-ps R-cran-R6"
+depends="R-cran-ps R-cran-R6"
+short_desc="Execute and Control System Processes"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/r-lib/processx"
+checksum=f247f2180f72e59f1e6d7149ddb44796698eb6be97cc8c479d5f488b65fcb01d
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-ps/template
+++ b/srcpkgs/R-cran-ps/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-ps'
+pkgname=R-cran-ps
+version=1.3.3
+revision=1
+build_style=R-cran
+short_desc="List, Query, Manipulate System Processes"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/r-lib/ps"
+checksum=03a45651538855be806e6dd9d731f101a6bbbd34162f887f9df69583f7fb20f4
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-rprojroot/template
+++ b/srcpkgs/R-cran-rprojroot/template
@@ -1,0 +1,12 @@
+# Template file for 'R-cran-rprojroot'
+pkgname=R-cran-rprojroot
+version=1.3r2
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-backports"
+depends="R-cran-backports"
+short_desc="Finding Files in Project Subdirectories"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/krlmlr/rprojroot"
+checksum=df5665834941d8b0e377a8810a04f98552201678300f168de5f58a587b73238b

--- a/srcpkgs/R-cran-rstudioapi/template
+++ b/srcpkgs/R-cran-rstudioapi/template
@@ -1,0 +1,14 @@
+# Template file for 'R-cran-rstudioapi'
+pkgname=R-cran-rstudioapi
+version=0.11
+revision=1
+build_style=R-cran
+short_desc="Safely Access the RStudio API"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="https://github.com/rstudio/rstudioapi"
+checksum=13e07fb7e2eba8cf1d885db2721901d676d219a1042d7ef5d166125e4905306b
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/R-cran-testthat/template
+++ b/srcpkgs/R-cran-testthat/template
@@ -1,0 +1,20 @@
+# Template file for 'R-cran-testthat'
+pkgname=R-cran-testthat
+version=2.3.2
+revision=1
+build_style=R-cran
+hostmakedepends="R-cran-cli R-cran-crayon R-cran-digest R-cran-ellipsis
+ R-cran-evaluate R-cran-magrittr R-cran-pkgload R-cran-praise R-cran-R6
+ R-cran-rlang R-cran-withr"
+depends="R-cran-cli R-cran-crayon R-cran-digest R-cran-ellipsis
+ R-cran-evaluate R-cran-magrittr R-cran-pkgload R-cran-praise R-cran-R6
+ R-cran-rlang R-cran-withr"
+short_desc="Unit Testing for R"
+maintainer="Luke Hannan <lukehannan@gmail.com>"
+license="MIT"
+homepage="http://testthat.r-lib.org"
+checksum=1a268d8df07f7cd8d282d03bb96ac2d96a24a95c9aa52f4cca5138a09dd8e06c
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
The latest version of R-cran-ggplot2 depends on the new package R-cran-isoband-0.2.2, all other new packages included are dependencies or sub-dependencies of R-cran-isoband-0.2.2. 

All packages built fine on x86_64.