### PR TITLE
akonadi5: enable tests.

### DIFF
--- a/srcpkgs/akonadi5/template
+++ b/srcpkgs/akonadi5/template
@@ -11,6 +11,7 @@ makedepends="qt5-devel qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql
  kdbusaddons-devel kiconthemes-devel kitemmodels-devel kio-devel sqlite-devel
  kaccounts-integration-devel libaccounts-qt5-devel qt5-tools-devel"
 depends="shared-mime-info"
+checkdepends="dbus ${depends}"
 short_desc="PIM layer providing an asynchronous API to access PIM data"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
@@ -44,7 +45,11 @@ pre_build() {
 }
 
 do_check() {
-	: # require dbus
+	# failing tests are disabled - sqlite tests hang on futex
+	cd build
+	QT_QPA_PLATFORM=offscreen CTEST_OUTPUT_ON_FAILURE=TRUE \
+		dbus-run-session ctest -E \
+		"(akonadixml-xmldocument|mimetypechecker|AkonadiControl-agenttype|.*sqlite.*)test"
 }
 
 akonadi5-devel_package() {


### PR DESCRIPTION
Tests require D-Bus, so it's necessary to run them with dbus-run-session.

@Chocimier it's hanging on all sqlite tests and failing the ones below: 

```
5 - akonadixml-xmldocumenttest (Failed)
42 - mimetypecheckertest (Failed)
95 - AkonadiControl-agenttypetest (Failed)
```

Perhaps @Johnnynator has some suggestion for it?