### PR TITLE
stepmania: update to 5.1.0-b2

### DIFF
--- a/srcpkgs/stepmania/template
+++ b/srcpkgs/stepmania/template
@@ -1,28 +1,33 @@
 # Template file for 'stepmania'
 pkgname=stepmania
-version=5.0.12
-revision=2
+version=5.1.0.b2
+revision=1
+# compilation errors with musl
+archs="i686 x86_64"
+wrksrc=${pkgname}-${version%.*}-${version##*.}
 build_style=cmake
 cmake_builddir="Build"
-hostmakedepends="nasm yasm pkg-config git"
+hostmakedepends="yasm pkg-config git"
 makedepends="libmad-devel libvorbis-devel pcre-devel libjpeg-turbo-devel
-alsa-lib-devel libXrandr-devel libva-devel glew-devel"
+ alsa-lib-devel libXrandr-devel libva-devel glew-devel pulseaudio-devel"
 short_desc="Advanced rhythm game"
-maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+maintainer="Jason Manley <jason@jasondavid.tv>"
 license="MIT"
 homepage="http://www.stepmania.com/"
-distfiles="https://github.com/stepmania/stepmania/archive/v${version}.tar.gz"
-checksum=df79bcadd69d4ed60cf560d45386ec275181343495ffd744c3ff8f73c83d4755
+distfiles="https://github.com/stepmania/stepmania/archive/v${version%.*}-${version##*.}.tar.gz"
+checksum=2e311df9b661ba287b046ce377eb0b41e426b73e169841df99fc9fe2baa89310
 
-# Upstream has stated that only x86 hardware can meed the performance
-# constraints and that musl is not supported due to interop issues
-# with Windows
-archs="i686 x86_64"
+post_patch() {
+	vsed -i 's/PULSE_FOUND/PULSEAUDIO_FOUND/g' ${wrksrc}/StepmaniaCore.cmake
+}
 
 post_install() {
+	for i in 16 22 24 32 36 48 64 72 96 128 192 256
+	do
+		vinstall icons/hicolor/${i}x${i}/apps/stepmania-ssc.png 644 \
+			usr/share/icons/hicolor/${i}x${i}/apps stepmania-ssc.png
+	done
+	vsed -i 's/Exec=stepmania/Exec=\/opt\/stepmania-5.1\/stepmania/g' stepmania.desktop
+	vinstall stepmania.desktop 644 usr/share/applications stepmania.desktop
 	vlicense Docs/Licenses.txt
-
-	mkdir -p ${DESTDIR}/usr/bin
-	cd ${DESTDIR}
-	ln -sf ../../opt/stepmania-5.0/stepmania usr/bin/
 }


### PR DESCRIPTION
The current version 5.0.12 results in an error "Fatal: crash from within the crash signal handler" upon running stepmania. From https://github.com/stepmania/stepmania/issues/1606 the suggested workaround is to use the 5.1 branch. The version 5.1-beta2 is technically a release that has been available for a long time. There are also 5.3 alpha releases, but this 5.1 I have tested to run.