### PR TITLE
tailscale: update to 0.100.0.

### DIFF
--- a/srcpkgs/tailscale/template
+++ b/srcpkgs/tailscale/template
@@ -1,7 +1,9 @@
 # Template file for 'tailscale'
 pkgname=tailscale
-version=0.99.1
+version=0.100.0
 revision=1
+_release=-153
+wrksrc="${pkgname}-${version}${_release}"
 build_style=go
 go_import_path="tailscale.com"
 go_package="tailscale.com/cmd/tailscale tailscale.com/cmd/tailscaled"
@@ -11,8 +13,8 @@ short_desc="Easy, secure, cross platform WireGuard, oauth2, and 2FA/SSO"
 maintainer="Noel Cower <ncower@nil.dev>"
 license="BSD-3-Clause"
 homepage="https://tailscale.com"
-distfiles="https://github.com/tailscale/tailscale/archive/v${version}.tar.gz"
-checksum=9d124c6ade7fe4bc599259ee77e21fa6c044828c87d4290020b2c9cce2371ba5
+distfiles="https://github.com/tailscale/tailscale/archive/v${version}${_release}.tar.gz"
+checksum=e055b72ea20d1288eae61fc0fd1a0108847891e651729d8b3cd318066633ed86
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Because tailscale uses a -$RELEASE suffix on versions and xbps-src
doesn't allow that, there's an additional _release variable that acts
as the release suffix for wrksrc and distfiles.