### PR TITLE
Revert "libseccomp: update to 2.5.0."

### DIFF
--- a/srcpkgs/libseccomp/template
+++ b/srcpkgs/libseccomp/template
@@ -1,15 +1,16 @@
 # Template file for 'libseccomp'
 pkgname=libseccomp
-version=2.5.0
-revision=1
+reverts="2.5.0_1"
+version=2.4.3
+revision=2
 build_style=gnu-configure
-hostmakedepends="automake gperf libtool"
+hostmakedepends="automake libtool"
 short_desc="High level interface to the Linux Kernel's seccomp filter"
 maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/seccomp/libseccomp/"
 distfiles="https://github.com/seccomp/${pkgname}/archive/v${version}.tar.gz"
-checksum=7720d01bb154afcc4e623434a577f181ea2a72585ef51a311ef56220e26723e6
+checksum=4d86f0bd0847795bf7f7bf6e44cb73edf4417d84f6d8848c23eda99b0c50fce6
 
 post_extract() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
This reverts commit aa21e5a7c0348f525735f2afb266a0301d2c8213.

According to https://github.com/seccomp/libseccomp/issues/273 libseccomp
v2.5.0 unintentionally refuses to allow multiple calls to seccomp_load,
which is a regression.

As a result, xwallpaper is inoperable:
https://github.com/stoeckmann/xwallpaper/issues/23