### PR TITLE
Gajim

### DIFF
--- a/srcpkgs/gajim/template
+++ b/srcpkgs/gajim/template
@@ -1,18 +1,18 @@
 # Template file for 'gajim'
 pkgname=gajim
-version=1.2.0
+version=1.2.1
 revision=1
 archs=noarch
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools"
 depends="python3-gobject python3-nbxmpp python3-pyasn1 python3-setuptools
  python3-precis-i18n python3-keyring python3-cssutils python3-packaging
- python3-css-parser"
+ python3-css-parser farstream"
 short_desc="Full featured Jabber/XMPP client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="https://www.gajim.org"
 #changelog="https://dev.gajim.org/gajim/gajim/raw/gajim-${version}/ChangeLog"
 distfiles="https://gajim.org/downloads/${version%.*}/gajim-${version}.tar.gz"
-checksum=fdd60e99ca374c28495a9313d1b162e9340bded98e952399e43af2a0ccfcd139
+checksum=c4faed4557296e4350bfea551c6743375dbaca3e1e7c5a3077321a10b10e8d1d
 nocross="gobject-introspection"

--- a/srcpkgs/python3-nbxmpp/template
+++ b/srcpkgs/python3-nbxmpp/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-nbxmpp'
 pkgname=python3-nbxmpp
-version=1.0.0
-revision=2
+version=1.0.1
+revision=1
 archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="https://python-nbxmpp.gajim.org/"
 #changelog="https://dev.gajim.org/gajim/python-nbxmpp/raw/master/ChangeLog"
 distfiles="${PYPI_SITE}/n/nbxmpp/nbxmpp-${version}.tar.gz"
-checksum=8b7e967bc1d0f1a1f7cf3395b6f5d70009ae5607ad9afb8de32ff92b661693ad
+checksum=ca60c9bd1527fbeac305df90c670f11f2fe79f1304dad1efa0315f7484a34d43
 
 python-nbxmpp_package() {
 	build_style=meta


### PR DESCRIPTION
- Update gajim.
- Update python3-nbxmpp (gajim needs the new version to function).
- Include farstream in the depends array for audio/video (reported and tested by a friend).