### PR TITLE
armadillo: remove absolute paths form headers

### DIFF
--- a/srcpkgs/armadillo/patches/9.700.2--include_dirs.patch
+++ b/srcpkgs/armadillo/patches/9.700.2--include_dirs.patch
@@ -1,0 +1,40 @@
+From a65f29c4cddccd22545746b077e6bd19d56e6bfb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Piotr=20W=C3=B3jcik?= <chocimier@tlen.pl>
+Date: Fri, 24 Jul 2020 23:07:44 +0200
+Subject: [PATCH] Absolute paths can't match both cross and native use
+
+
+diff --git include/armadillo_bits/config.hpp.cmake include/armadillo_bits/config.hpp.cmake
+index be42243..a285e35 100644
+--- include/armadillo_bits/config.hpp.cmake
++++ include/armadillo_bits/config.hpp.cmake
+@@ -50,7 +50,7 @@
+ #endif
+ 
+ #if !defined(ARMA_SUPERLU_INCLUDE_DIR)
+-#define ARMA_SUPERLU_INCLUDE_DIR ${ARMA_SUPERLU_INCLUDE_DIR}/
++#define ARMA_SUPERLU_INCLUDE_DIR ./
+ //// If you're using SuperLU and want to explicitly include the SuperLU headers,
+ //// uncomment the above define and specify the appropriate include directory.
+ //// Make sure the directory has a trailing /
+@@ -94,7 +94,7 @@
+ //// ARMA_BLAS_LONG, ARMA_BLAS_LONG_LONG, ARMA_USE_FORTRAN_HIDDEN_ARGS
+ 
+ #cmakedefine ARMA_USE_ATLAS
+-#define ARMA_ATLAS_INCLUDE_DIR ${ARMA_ATLAS_INCLUDE_DIR}/
++#define ARMA_ATLAS_INCLUDE_DIR ./
+ //// If you're using ATLAS and the compiler can't find cblas.h and/or clapack.h
+ //// uncomment the above define and specify the appropriate include directory.
+ //// Make sure the directory has a trailing /
+@@ -140,7 +140,7 @@
+   #undef  ARMA_USE_HDF5
+   #define ARMA_USE_HDF5
+   
+-  #define ARMA_HDF5_INCLUDE_DIR ${ARMA_HDF5_INCLUDE_DIR}/
++  #define ARMA_HDF5_INCLUDE_DIR ./
+ #endif
+ 
+ #if !defined(ARMA_MAT_PREALLOC)
+-- 
+2.27.0
+

--- a/srcpkgs/armadillo/template
+++ b/srcpkgs/armadillo/template
@@ -1,7 +1,7 @@
 # Template file for 'armadillo'
 pkgname=armadillo
 version=9.700.2
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DDETECT_HDF5=$(vopt_if hdf5 ON OFF)"
 hostmakedepends="pkg-config openblas-devel"


### PR DESCRIPTION
It was #define ARMA_SUPERLU_INCLUDE_DIR /usr/arm-linux-gnueabihf/usr/include/
before. Absolute paths can't match usage of same package in both
cross and native environment at same time, let alone expansion of
'linux' macro. As all headers are installed into standard location,
relative path works.
Not suitable to upstream.