### PR TITLE
New package: kstars

### DIFF
--- a/srcpkgs/Quaternion/template
+++ b/srcpkgs/Quaternion/template
@@ -6,7 +6,7 @@ build_style=cmake
 hostmakedepends="qt5-qmake qt5-host-tools"
 makedepends="qt5-declarative-devel qt5-quickcontrols qt5-tools-devel
  qt5-multimedia-devel libqmatrixclient-devel
- $(vopt_if qtkeychain 'qtkeychain-qt5-devel libsecret-devel')"
+ $(vopt_if qtkeychain qtkeychain-qt5-devel)"
 depends="qt5-quickcontrols"
 short_desc="Qt5-based IM client for the Matrix protocol"
 maintainer="Julio Galvan <juliogalvan@protonmail.com>"
@@ -17,3 +17,5 @@ checksum=7c04f62f6420af87c1df9e5e7f01250a1f4da33c9627e5f6e7f772e2f62864f0
 
 build_options="qtkeychain"
 build_options_default="qtkeychain"
+
+CXXFLAGS="-Wno-deprecated-declarations"

--- a/srcpkgs/chatterino2/template
+++ b/srcpkgs/chatterino2/template
@@ -11,7 +11,7 @@ hostmakedepends="qt5-qmake qt5-svg-devel qt5-multimedia-devel
  libcommuni-devel pkg-config"
 makedepends="qt5-svg-devel qt5-multimedia-devel
  boost-devel rapidjson libcommuni-devel websocketpp
- qtkeychain-qt5-devel libsecret-devel"
+ qtkeychain-qt5-devel"
 short_desc="Qt-based twitch chat client"
 maintainer="Franc[e]sco <lolisamurai@tfwno.gf>"
 license="MIT"

--- a/srcpkgs/kstars/template
+++ b/srcpkgs/kstars/template
@@ -1,0 +1,21 @@
+# Template file for 'kstars'
+pkgname=kstars
+version=3.4.3
+revision=1
+build_style=cmake
+hostmakedepends="kdoctools gettext qt5-host-tools qt5-qmake kcoreaddons
+ kconfig"
+makedepends="extra-cmake-modules eigen qt5-devel qt5-declarative-devel
+ qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite
+ qt5-plugin-tds qt5-svg-devel qt5-websockets-devel qt5-datavis3d-devel
+ cfitsio-devel  libnova-devel libraw-devel qtkeychain-qt5-devel
+ knotifyconfig-devel kauth-devel kconfig-devel kcrash-devel kdoctools-devel
+ kwidgetsaddons-devel knewstuff-devel ki18n-devel kio-devel kxmlgui-devel
+ kplotting-devel knotifications-devel"
+depends="xplanet"
+short_desc="Open source, cross-platform Astronomy Software by KDE"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="GPL-2.0-or-later"
+homepage="https://edu.kde.org/kstars/"
+distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
+checksum=c81119a85e9265991dd0fbfafdc6ba797bf3bedce64f4d5260511bafccebbe48

--- a/srcpkgs/qtkeychain-qt5/template
+++ b/srcpkgs/qtkeychain-qt5/template
@@ -1,7 +1,7 @@
-# Template file for 'qtkeychain'
+# Template file for 'qtkeychain-qt5'
 pkgname=qtkeychain-qt5
 version=0.9.1
-revision=1
+revision=2
 wrksrc="${pkgname%-*}-${version}"
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -22,7 +22,7 @@ post_install() {
 }
 
 qtkeychain-qt5-devel_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libsecret-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include

--- a/srcpkgs/tomahawk/template
+++ b/srcpkgs/tomahawk/template
@@ -1,15 +1,10 @@
 # Template file for 'tomahawk'
 pkgname=tomahawk
 version=0.8.4
-revision=20
+revision=21
 wrksrc=${pkgname}-${_commit}
-_commit=00f602e10203b76fc28b4615868c567e6bd4ced4
+_commit=90ec6f0dc701cba0533c66abdcb904e29f02a66f
 build_style=cmake
-build_options="upower hatchet kde xmpp"
-desc_option_hatchet="Enable support for http://hatchet.is"
-desc_option_kde="Enable support for KDE"
-desc_option_xmpp="Enable support for XMPP"
-build_options_default="xmpp upower"
 configure_args="-Wno-dev -DBUILD_RELEASE=ON \
  $(vopt_if hatchet '-DBUILD_HATCHET=ON' '-DBUILD_HATCHET=OFF') \
  -DBUILD_WITH_QT4=OFF \
@@ -21,7 +16,7 @@ hostmakedepends="pkg-config extra-cmake-modules"
 makedepends="Lucene++-devel attica-qt5-devel boost-devel gnutls-devel
  libechonest-qt5-devel liblastfm-qt5-devel phonon-qt5-devel qca-qt5-devel
  qt5-svg-devel qt5-tools-devel qt5-webkit-devel qtkeychain-qt5-devel
- quazip-devel sparsehash taglib-devel vlc-devel libsecret-devel
+ quazip-devel sparsehash taglib-devel vlc-devel
  $(vopt_if hatchet websocketpp) $(vopt_if xmpp jreen-devel)
  $(vopt_if kde telepathy-qt5-devel)"
 depends="virtual?phonon-qt5-backend qt5-plugin-sqlite $(vopt_if xmpp qca-qt5-ossl)"
@@ -30,7 +25,12 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://tomahawk-player.org/"
 distfiles="https://github.com/tomahawk-player/tomahawk/archive/${_commit}.tar.gz"
-checksum=f93d36b246944657dcef98ff71410db8630c53b5565dc283fb15f57e5b301f79
+checksum=3305a8221af1bfa51cbf5256abf8ab3824393b684ce428a3c46409cf5e1d3fce
+build_options="upower hatchet kde xmpp"
+desc_option_hatchet="Enable support for http://hatchet.is"
+desc_option_kde="Enable support for KDE"
+desc_option_xmpp="Enable support for XMPP"
+build_options_default="xmpp upower"
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-qmake"
@@ -43,6 +43,8 @@ fi
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 fi
+
+CXXFLAGS="-Wno-deprecated-declarations"
 
 tomahawk-devel_package() {
 	depends="tomahawk>=${version}_${revision}"


### PR DESCRIPTION
My first build errored out because it tried linking against `libsecret`, which wasn't available. Since `libsecret` is listed in `qtkeychain-qt5`'s cmake file, it should also be a dependency of `qtkeychain-qt5-devel`. This PR includes that fix and the removal of `libsecret-devel` from a few templates which don't need to be rebuilt.

Tested on x86_64-musl and built for armv7l-musl, since I'm not sure CI will manage to finish.