### PR TITLE
Use sndio as first preference in PortAudio, enable PortAudio for spotifyd

### DIFF
--- a/srcpkgs/portaudio/patches/sndio.patch
+++ b/srcpkgs/portaudio/patches/sndio.patch
@@ -20,7 +20,7 @@ index 5e1a764..2747f73 100644
  	src/hostapi/wdmks \
  	src/hostapi/wmme \
 diff --git configure.in configure.in
-index 13816fb..4c06d10 100644
+index 83c239a..db11d65 100644
 --- configure.in
 +++ configure.in
 @@ -24,6 +24,10 @@ AC_ARG_WITH(alsa,
@@ -59,7 +59,7 @@ index 13816fb..4c06d10 100644
          if [[ "$have_jack" = "yes" ] && [ "$with_jack" != "no" ]] ; then
             DLL_LIBS="$DLL_LIBS $JACK_LIBS"
             CFLAGS="$CFLAGS $JACK_CFLAGS"
-@@ -509,6 +524,7 @@ case "$target_os" in
+@@ -510,6 +525,7 @@ case "$target_os" in
          ;;
       *)
  	AC_MSG_RESULT([
@@ -68,7 +68,7 @@ index 13816fb..4c06d10 100644
    JACK ........................ $have_jack
  ])
 diff --git include/portaudio.h include/portaudio.h
-index 8a94aaf..f94d9c4 100644
+index 9c8a295..e535a02 100644
 --- include/portaudio.h
 +++ include/portaudio.h
 @@ -287,7 +287,8 @@ typedef enum PaHostApiTypeId
@@ -86,7 +86,7 @@ new file mode 100644
 index 0000000..725ef47
 --- /dev/null
 +++ src/hostapi/sndio/pa_sndio.c
-@@ -0,0 +1,765 @@
+@@ -0,0 +1,768 @@
 +/*
 + * Copyright (c) 2009 Alexandre Ratchov <alex@caoua.org>
 + *
@@ -775,6 +775,9 @@ index 0000000..725ef47
 +
 +	DPR("PaSndio_Initialize: initializing...\n");
 +
++	if ((hdl=sio_open(SIO_DEVANY, SIO_PLAY, 1)) == NULL)
++		return paNoError;
++	sio_close(hdl);
 +	/* unusable APIs should return paNoError and a NULL hostApi */
 +	*hostApi = NULL;
 +
@@ -853,7 +856,7 @@ index 0000000..725ef47
 +	return paNoError;
 +}
 diff --git src/os/unix/pa_unix_hostapis.c src/os/unix/pa_unix_hostapis.c
-index a9b4a05..c3fa2a3 100644
+index a9b4a05..f10ced1 100644
 --- src/os/unix/pa_unix_hostapis.c
 +++ src/os/unix/pa_unix_hostapis.c
 @@ -44,6 +44,7 @@
@@ -864,14 +867,17 @@ index a9b4a05..c3fa2a3 100644
  PaError PaOSS_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
  /* Added for IRIX, Pieter, oct 2, 2003: */
  PaError PaSGI_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiIndex index );
-@@ -79,6 +80,10 @@ PaUtilHostApiInitializer *paHostApiInitializers[] =
+@@ -57,6 +58,10 @@ PaError PaSkeleton_Initialize( PaUtilHostApiRepresentation **hostApi, PaHostApiI
  
- #endif  /* __linux__ */
- 
+ PaUtilHostApiInitializer *paHostApiInitializers[] =
+     {
 +#ifdef PA_USE_SNDIO
 +	    PaSndio_Initialize,
 +#endif
 +
- #if PA_USE_JACK
-         PaJack_Initialize,
- #endif
+ #ifdef __linux__
+ 
+ #if PA_USE_ALSA
+-- 
+2.27.0
+

--- a/srcpkgs/portaudio/template
+++ b/srcpkgs/portaudio/template
@@ -1,14 +1,14 @@
 # Template file for 'portaudio'
 pkgname=portaudio
 version=190600.20161030
-revision=4
+revision=5
 wrksrc=portaudio
 build_style=gnu-configure
 configure_args="--enable-cxx --with-jack $(vopt_enable sndio)"
 hostmakedepends="automake libtool pkg-config"
 makedepends="alsa-lib-devel jack-devel $(vopt_if sndio sndio-devel)"
 short_desc="Portable cross-platform audio I/O library"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="http://www.portaudio.com"
 distfiles="http://www.${pkgname}.com/archives/pa_stable_v${version%.*}_${version#*.}.tgz"

--- a/srcpkgs/spotifyd/template
+++ b/srcpkgs/spotifyd/template
@@ -1,12 +1,13 @@
 # Template file for 'spotifyd'
 pkgname=spotifyd
 version=0.2.24
-revision=3
+revision=4
 build_style=cargo
 configure_args="--no-default-features"
 hostmakedepends="pkg-config"
 makedepends="libressl-devel $(vopt_if alsa alsa-lib-devel)
-$(vopt_if pulseaudio pulseaudio-devel) $(vopt_if dbus dbus-devel)"
+ $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if portaudio portaudio-devel)
+ $(vopt_if dbus dbus-devel)"
 short_desc="Spotify client running as a UNIX daemon"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"
@@ -14,8 +15,9 @@ homepage="https://github.com/Spotifyd/spotifyd"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=d3763f4647217a8f98ee938b50e141d67a5f3d33e9378894fde2a92c9845ef80
 
-build_options="alsa pulseaudio dbus"
-build_options_default="alsa pulseaudio dbus"
+build_options="alsa pulseaudio portaudio dbus"
+desc_option_portaudio="Enable PortAudio backend"
+build_options_default="alsa pulseaudio portaudio dbus"
 
 export CFLAGS_${RUST_BUILD//-/_}="${CFLAGS_host}"
 export CC_${RUST_BUILD//-/_}="${BUILD_CC}"
@@ -23,6 +25,7 @@ export CC_${RUST_BUILD//-/_}="${BUILD_CC}"
 _features="$(vopt_if alsa ',alsa_backend')"
 _features+="$(vopt_if pulseaudio ',pulseaudio_backend')"
 _features+="$(vopt_if dbus ',dbus_mpris,dbus_keyring')"
+_features+="$(vopt_if portaudio ',portaudio_backend')"
 
 if [ "$_features" ]; then
 	configure_args+=" --features $_features"


### PR DESCRIPTION
If sndio isn't available, spotifyd, using the portaudio backend, falls back to ALSA cleanly. However, in the previous version, with sndio enabled, the portaudio backend simply didn't output anything. Therefore, I believe my change to the patch makes sense.

Enabling portaudio for spotifyd makes sense because it allows one to use sndio without requiring alsa-sndio.

@Johnnynator and @abenson 