### PR TITLE
New package: qwtplot3d-0.2.7+svn191+gcc7

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3975,3 +3975,4 @@ libtexlua53.so.5 texlive-LuaTeX-20200406_1
 libptexenc.so.1 texlive-20200406_1
 libdolphinvcs.so.5 dolphin-20.04.3_1
 libcglm.so.0 cglm-0.7.6_1
+libqwtplot3d.so.0 qwtplot3d-0.2.7+svn191+gcc7_1

--- a/srcpkgs/qwtplot3d-devel
+++ b/srcpkgs/qwtplot3d-devel
@@ -1,0 +1,1 @@
+qwtplot3d

--- a/srcpkgs/qwtplot3d/template
+++ b/srcpkgs/qwtplot3d/template
@@ -1,0 +1,36 @@
+# Template file for 'qwtplot3d'
+pkgname=qwtplot3d
+version=0.2.7+svn191+gcc7
+revision=1
+wrksrc="qwtplot3d-${version}.orig"
+build_style=qmake
+hostmakedepends="qt5-qmake qt5-host-tools"
+makedepends="qt5-devel glu-devel"
+short_desc="Qt/OpenGL-based C++ library, providing 3D-widgets for programmers"
+maintainer="gt7-void <gt7@mail.com>"
+license="custom:"
+homepage="http://qwtplot3d.sourceforge.net/"
+distfiles="${DEBIAN_SITE}/main/q/qwtplot3d/qwtplot3d_${version}.orig.tar.xz"
+checksum=e5fd4759d739c1f7ed9ec1b642f07550d4be66703e9caf980d9ae183f93fac9e
+
+post_extract() {
+	sed -i '/^CONFIG/ s/$/ shared_and_static build_all/' qwtplot3d.pro
+	sed -i '1s/^/#include <GL\/glu.h>\n/' include/qwt3d_openglhelper.h
+}
+
+do_install() {
+	vmkdir usr/lib
+	vcopy "lib/*.so.*" usr/lib
+	vlicense COPYING
+}
+
+qwtplot3d-devel_package() {
+	short_desc+=" - development files"
+	depends="qwtplot3d-${version}_${revision}"
+	pkg_install() {
+		vmkdir usr/lib
+		vcopy "lib/*.a lib/*.so" usr/lib
+		vmkdir usr/include/qwtplot3d
+		vcopy "include/*" usr/include/qwtplot3d
+	}
+}


### PR DESCRIPTION
Qt/OpenGL-based C++ library, providing 3D-widgets for programmers

http://qwtplot3d.sourceforge.net/

This is the exact version that has been in debian for ages, it also matches the version in arch (although they call it r259 the source code is exactly the same).

I built this because I thought it was needed for GoldenCheetah (#23839), in the end it's not required (maybe optional).