### PR TITLE
ncurses-libs: provide libncurses.so.5

### DIFF
--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template file for 'ncurses'
 pkgname=ncurses
 version=6.2
-revision=3
+revision=4
 bootstrap=yes
 configure_args="--enable-big-core"
 short_desc="System V Release 4.0 curses emulation library"
@@ -80,6 +80,9 @@ do_install() {
 		${DESTDIR}/usr/lib/libncurses.so.${version}
 	ln -sf libncurses.so.${version} \
 		${DESTDIR}/usr/lib/libncurses.so.${version:0:1}
+
+	# compatibility for binaries requiring libncurses.so.5
+	ln -sf libncurses.so.${version} ${DESTDIR}/usr/lib/libncurses.so.5
 
 	# Create libtinfo symlinks.
 	ln -sfr ${DESTDIR}/usr/lib/libncursesw.so \


### PR DESCRIPTION
@q66 can you please allow this symlink at least?

I state my case:

a. I need /usr/lib/libncurses.so.5 to run a binary (fwiw, megacli to manage a LSI raid controller -- unfortunately there's no other way to manage the raid arrays without rebooting to bios)

b. This binary runs without any problem with the symlink

c. I think this is expected since the ncurses 6 library is both API and ABI compatible with ncurses 5, according to its own documentation:

> This release is designed to be source-compatible with ncurses 5.0 through 6.1; providing extensions to the application binary interface (ABI). Although the source can still be configured to support the ncurses 5 ABI, the reason for the release is to reflect improvements to the ncurses 6 ABI and the supporting utility programs.

d. Someone else requested it on reddit (https://www.reddit.com/r/voidlinux/comments/hprhjp/where_to_download_libncursesso5/)

I'm not sure about all the other symlinks that https://github.com/void-linux/void-packages/commit/854828d619792969aef4315747c768a618434acd removed, an alternative would be to revert that one and apply https://github.com/void-linux/void-packages/pull/23660/commits/37f47318107975b56192a84fec9502b534628f4d from PR #23660 instead.