### PR TITLE
arduino-cli: update to 0.11.0.

### DIFF
--- a/srcpkgs/arduino-cli/template
+++ b/srcpkgs/arduino-cli/template
@@ -1,17 +1,31 @@
 # Template file for 'arduino-cli'
 pkgname=arduino-cli
-version=0.10.0
-revision=2
+version=0.11.0
+revision=1
+build_helper=qemu
 build_style=go
 go_import_path=github.com/arduino/arduino-cli
 short_desc="Arduino command line interface"
 maintainer="Jasper Chan <jasperchan515@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/arduino/arduino-cli"
-distfiles="https://github.com/arduino/arduino-cli/archive/${version}.tar.gz"
-checksum=165347f8eb7d34c669ef3cee42bede9faffd5f0bb7ae0ece16c806a6230e8790
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=5a9b7eec55c3ee7f54d8804fac00ceb78ad0697fd918f6fbae0bb61cb33d8b3e
 
 case "$XBPS_TARGET_MACHINE" in
 	# the downloaded toolchains use glibc, this allows them to work on musl
 	*-musl) depends+=" gcompat" ;;
 esac
+
+post_build() {
+	arduino_cli=$(find $GOPATH/bin -name arduino-cli)
+	vtargetrun $arduino_cli completion bash > arduino.bash
+	vtargetrun $arduino_cli completion fish > arduino.fish
+	vtargetrun $arduino_cli completion zsh > arduino.zsh
+}
+
+post_install() {
+	vcompletion arduino.bash bash
+	vcompletion arduino.fish fish
+	vcompletion arduino.zsh zsh
+}

--- a/srcpkgs/arduino-cli/update
+++ b/srcpkgs/arduino-cli/update
@@ -1,1 +1,0 @@
-pattern="/archive/\K[\d.]+(?=)"


### PR DESCRIPTION
This version added command line completions that must be generated at
build time.