### PR TITLE
sigil: update to 1.3.0

### DIFF
--- a/srcpkgs/sigil/template
+++ b/srcpkgs/sigil/template
@@ -1,6 +1,6 @@
 # Template file for 'sigil'
 pkgname=sigil
-version=1.2.0
+version=1.3.0
 revision=1
 wrksrc="Sigil-${version}"
 build_style=cmake
@@ -13,14 +13,14 @@ makedepends="zlib-devel qt5-tools-devel qt5-svg-devel
  qt5-declarative-devel qt5-location-devel qt5-webchannel-devel
  qt5-plugin-odbc qt5-plugin-mysql qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds
  boost-devel hunspell-devel python3-devel minizip-devel"
-depends="desktop-file-utils python3-lxml"
+depends="desktop-file-utils python3-lxml python3-css-parser"
 short_desc="Multi-platform EPUB ebook editor"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/Sigil-Ebook/Sigil"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=34c7c5c707375b561f00341509e59ae7036e893af06859ca8dbcebd5cf125758
-python_version=2 #unverified
+checksum=ac302328f0d0e0144e67bd4cbd7834650eb219f81a623f393271bf6f0686cc56
+python_version=3
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*) broken="depends on qt5-webengine";;


### PR DESCRIPTION
Previously all the files with `python2` in the shebang were in `/usr/share/sigil/python3lib/`. So changing the `python_version` shouldn't be a problem. In the time I have spent using this template, no issues have come up either.

`python3-css-parser` is required for CSS reformatting. The program throws an error if the package is not present.