### PR TITLE
xbps-src: enable C.UTF-8 locale on glibc masterdir

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -132,7 +132,10 @@ chroot_prepare() {
 
     # Prepare default locale: en_US.UTF-8.
     if [ -s ${XBPS_MASTERDIR}/etc/default/libc-locales ]; then
-        echo 'en_US.UTF-8 UTF-8' >> ${XBPS_MASTERDIR}/etc/default/libc-locales
+        printf '%s\n' \
+            'C.UTF-8 UTF-8' \
+            'en_US.UTF-8 UTF-8' \
+            >> ${XBPS_MASTERDIR}/etc/default/libc-locales
     fi
 
     touch -f $XBPS_MASTERDIR/.xbps_chroot_init


### PR DESCRIPTION
`util-linux` requires `C.UTF-8` for testing.

Since this is an important part of system,
enable `C.UTF-8' for checking `util-linux`.