### PR TITLE
dkms: update to 2.8.3.

### DIFF
--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,8 +1,7 @@
 # Template file for 'dkms'
 pkgname=dkms
-reverts="2.8.2_1"
-version=2.8.1
-revision=4
+version=2.8.3
+revision=1
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils linux-headers"
 short_desc="Dynamic Kernel Modules System"
@@ -10,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/dell/dkms"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=751e5dbc30a8cda26e379ff1940a80183145e77dab60914f160e037086177513
+checksum=0fcbb2691aa8231927b000edf3594d2798211c3944fd4a2a8b1864aa1c06eaaf
 
 if [ "$CROSS_BUILD" ]; then
 	depends+=" libressl-devel gmp-devel libada-devel libmpc-devel flex"
@@ -24,6 +23,6 @@ do_install() {
 	vinstall dkms.bash-completion 644 usr/share/bash-completion/completions dkms
 	vinstall dkms_framework.conf 644 etc/dkms framework.conf
 	# Kernel hooks.
-	vinstall ${FILESDIR}/kernel.d/dkms.postinst 750 etc/kernel.d/post-install 10-dkms
-	vinstall ${FILESDIR}/kernel.d/dkms.prerm 750 etc/kernel.d/pre-remove 10-dkms
+	vinstall ${FILESDIR}/kernel.d/dkms.postinst 754 etc/kernel.d/post-install 10-dkms
+	vinstall ${FILESDIR}/kernel.d/dkms.prerm 754 etc/kernel.d/pre-remove 10-dkms
 }


### PR DESCRIPTION
According to https://github.com/dell/dkms/releases, this fixes the issue
https://github.com/dell/dkms/issues/127 that led to reverting 2.8.2.

Works fine with zfs. @abenson please test with nvidia. Any other @void-linux/pkg-committers that use DKMS and don't mind testing, please let me know if there are any module build issues.

Also fixed permissions on kernel hooks. There is no reason the hooks shouldn't be readable by regular users.