### PR TITLE
rclone: update to 1.52.3.

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,10 +1,11 @@
 # Template file for 'rclone'
 pkgname=rclone
-version=1.52.1
+version=1.52.3
 revision=1
 wrksrc="rclone-v${version}"
 build_style=go
 go_import_path=github.com/rclone/rclone
+go_ldflags="-extldflags=-fuse-ld=bfd"
 hostmakedepends="git"
 short_desc="Rsync for cloud storage"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
@@ -12,8 +13,7 @@ license="MIT"
 homepage="https://rclone.org/"
 changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/changelog.md"
 distfiles="https://github.com/rclone/rclone/releases/download/v${version}/rclone-v${version}.tar.gz"
-checksum=a95fbac3768bc5fa563fff8305786f6cfddd3457deb570a3ada4c776f1a87553
-nocross="Problems with the dynamic linker: https://api.travis-ci.org/v3/job/613099406/log.txt"
+checksum=f4839e0153eee54615dba376a85be943ad0405300c3eea5d5e02b2c27ed7b0dd
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Fix cross by linking with bfd. Cross toolchains don't have gold available which caused the linker issues on arm.