### PR TITLE
New package: diskonaut-0.9.0

### DIFF
--- a/srcpkgs/diskonaut/template
+++ b/srcpkgs/diskonaut/template
@@ -1,0 +1,15 @@
+# Template file for 'diskonaut'
+pkgname=diskonaut
+version=0.9.0
+revision=1
+build_style=cargo
+short_desc="TUI disk space navigator written in rust"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="MIT"
+homepage="https://github.com/imsnif/diskonaut"
+distfiles="https://github.com/imsnif/diskonaut/archive/${version}.tar.gz"
+checksum=93564a195a62796f95eacc154ad10df8f1050c8a0b2e2e22a0612228c930c1f5
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
[diskonaut](https://github.com/imsnif/diskonaut) is a TUI disk space navigator written in Rust. It is currently available as a package for Arch, Fedora, CentOS, Gentoo, and NixOS.