### PR TITLE
fcft: update to 2.2.3.

### DIFF
--- a/srcpkgs/fcft/template
+++ b/srcpkgs/fcft/template
@@ -1,6 +1,6 @@
 # Template file for 'fcft'
 pkgname=fcft
-version=2.2.2
+version=2.2.3
 revision=1
 wrksrc=$pkgname
 build_style=meson
@@ -10,14 +10,11 @@ short_desc="Simple library for font loading and glyph rasterization"
 maintainer="Isaac Freund <ifreund@ifreund.xyz>"
 license="MIT"
 homepage="https://codeberg.org/dnkl/fcft"
-distfiles="${homepage}/archive/${version}.tar.gz
- ${homepage}/raw/branch/master/LICENSE"
-checksum="9bc54b5ccb637f6c8270697c886e3e86cb4ffb6042b1d4a32eaaee854fb0837d
- d534a23a31500a0ac958d9634b84f532bd73ff1aca1bb8f7debbcbebc16ff39a"
-skip_extraction=LICENSE
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=be6b44a84f798c15a4e903dd7579b7468b79c8928c73f4c29dd4d1b6e94bb4e2
 
 post_install() {
-	vlicense ${XBPS_SRCDISTDIR}/${pkgname}-${version}/LICENSE
+	vlicense LICENSE
 }
 
 fcft-devel_package() {
@@ -27,6 +24,10 @@ fcft-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+		vmove usr/share/doc
 		vmove usr/share/man/man3
+
+		# The license is already installed by the base package
+		rm ${PKGDESTDIR}/usr/share/doc/${sourcepkg}/LICENSE
 	}
 }


### PR DESCRIPTION
No need for any revbumps, this release is ABI compatible.