### PR TITLE
scryer-prolog: use system gmp

### DIFF
--- a/srcpkgs/scryer-prolog/template
+++ b/srcpkgs/scryer-prolog/template
@@ -1,24 +1,18 @@
 # Template file for 'scryer-prolog'
 pkgname=scryer-prolog
 version=0.8.123
-revision=1
-archs="~i686" # aggresive cpu detection
+revision=2
 build_style=cargo
 hostmakedepends="m4 pkg-config"
-depends="gmp"
+makedepends="gmp-devel mpfr-devel libmpc-devel"
 short_desc="Modern Prolog implementation written mostly in Rust"
 maintainer="Hans-J. Schmid <knock@myopendoor.de>"
 license="BSD-3-Clause"
 homepage="https://github.com/mthom/scryer-prolog"
 distfiles="https://github.com/mthom/scryer-prolog/archive/v${version}.tar.gz"
 checksum=4370bc2200e3e56d411326801219bc5fc37a422febdb6cd3548ed3f65b5a44aa
-
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	# XXX: Also should have GMP_MPFR_SYS_CACHE="" set somewhere https://crates.io/crates/gmp-mpfr-sys (we have ccache for that)
-	# We might also want to use system libs instead
-	# the runtime dep on gmp is incorrect right now, since gmp is statically linked
-	broken="https://build.voidlinux.org/builders/x86_64-musl_builder/builds/29779/steps/shell_3/logs/stdio"
-fi
+nocross="executes gmp header https://gitlab.com/tspiteri/gmp-mpfr-sys/-/blob/v1.2.2/build.rs#L1278"
+export CARGO_FEATURE_USE_SYSTEM_LIBS=1
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;


### PR DESCRIPTION
Previous cross-build packages are probably broken anyway.

cc @Johnnynator @mkohlhaas 