### PR TITLE
kdegraphics-thumbnailers: Add ffmpeg dependency

### DIFF
--- a/srcpkgs/kdegraphics-thumbnailers/template
+++ b/srcpkgs/kdegraphics-thumbnailers/template
@@ -1,11 +1,11 @@
 # Template file for 'kdegraphics-thumbnailers'
 pkgname=kdegraphics-thumbnailers
 version=20.04.3
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules kcoreaddons kconfig-devel pkg-config gettext"
 makedepends="qt5-devel kio-devel libkexiv25-devel"
-depends="ghostscript"
+depends="ffmpegthumbnailer ghostscript"
 short_desc="KDE Plasma 5 Thumbnailers for various graphics file formats"
 maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
This commit adds `ffmpegthumbnailer` as a dependency; this eases the process of enabling thumbnails in Dolphin.