### PR TITLE
[WIP] wireguard-dkms: Attempt to prevent install on linux>=5.6

### DIFF
--- a/srcpkgs/wireguard-dkms/template
+++ b/srcpkgs/wireguard-dkms/template
@@ -1,10 +1,11 @@
 # Template file for 'wireguard-dkms'
 pkgname=wireguard-dkms
 version=1.0.20200729
-revision=1
+revision=2
 wrksrc="wireguard-linux-compat-${version}"
 build_wrksrc="src"
 depends="dkms wireguard-tools perl"
+conflicts="linux>=5.6"
 short_desc="Fast, modern, secure VPN tunnel (DKMS module for Linux <= 5.5)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-only"


### PR DESCRIPTION
In [a recent issue I opened](https://github.com/void-linux/void-packages/issues/23790), I brought up that it was confusing whether or not wireguard-dkms was needed. The package's description now states that it's only for kernel versions 5.5 and lower, but I'd like to outright prevent someone from trying to install it on a kernel where it's not necessary. This is my attempt to do that.