### PR TITLE
[WIP] New package: teams-1.3.00.16851

### DIFF
--- a/srcpkgs/teams/template
+++ b/srcpkgs/teams/template
@@ -1,0 +1,32 @@
+# Template file for 'teams'
+pkgname=teams
+version=1.3.00.16851
+revision=1
+archs="x86_64"
+#build_style=fetch
+# depends = libasound2 (>= 1.0.16), libatk-bridge2.0-0 (>= 2.5.3), libatk1.0-0 (>= 1.12.4), libc6 (>= 2.17), libcairo2 (>= 1.10.0), libcups2 (>= 1.4.0), libexpat1 (>= 2.0.1), libgcc1 (>= 1:3.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.35.8), libgtk-3-0 (>= 3.10.0), libnspr4 (>= 2:4.9-2~), libnss3 (>= 2:3.22), libpango-1.0-0 (>= 1.14.0), libpangocairo-1.0-0 (>= 1.14.0), libuuid1 (>= 2.16), libx11-6 (>= 2:1.4.99.1), libx11-xcb1, libxcb1 (>= 1.6), libxcomposite1 (>= 1:0.3-1), libxcursor1 (>> 1.1.2), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxi6 (>= 2:1.2.99.4), libxrandr2 (>= 2:1.2.99.3), libxrender1, libxss1, libxtst6, apt-transport-https, libfontconfig1 (>= 2.11.0), libdbus-1-3 (>= 1.6.18), libstdc++6 (>= 4.8.1)
+depends="libsndfile alsa-lib atk glibc cairo libcups expat libgcc gdk-pixbuf glib gtk+3 nspr nss pango libuuid libX11 libxcb libXcomposite libXcursor libXdamage libXext libXfixes libXrender libXt libXtst fontconfig dbus libstdc++"
+short_desc="Microsoft Teams client for Linux"
+maintainer="Jason Manley <jason@jasondavid.tv>"
+license="custom:Microsoft"
+homepage="https://www.microsoft.com/teams"
+# way to get around this usage of amd64 vs x86_64 ? symlink amd64.sh in common/cross-profiles ?
+distfiles="https://packages.microsoft.com/repos/ms-teams/pool/main/t/${pkgname}/${pkgname}_${version}_amd64.deb"
+checksum=23838c8f8dea4960dce8bba559cd7ee3cdedc78ea7fdb226139b5b2204eee4d6
+repository=nonfree
+restricted=yes
+nostrip=yes
+
+do_extract() {
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}_${version}_amd64.deb
+	bsdtar -xf data.tar.xz
+}
+
+do_install() {
+	#vmkdir usr/share usr/bin
+	vbin usr/bin/teams 755 usr/bin/teams
+	vcopy usr/share/teams usr/share/
+	vinstall usr/share/applications/teams.desktop 644 usr/share/applications
+	vinstall usr/share/pixmaps/teams.png 644 usr/share/pixmaps
+	vlicense usr/share/teams/LICENSE
+}


### PR DESCRIPTION
Main error right now that has me stuck is ...
`=> teams-1.3.00.16851_1: running post-install hook: 11-pkglint-elf-in-usrshare ...
=> ERROR: teams-1.3.00.16851_1: ELF files found in /usr/share:
=> ERROR:    /usr/share/libEGL.so
=> ERROR:    /usr/share/teams
=> ERROR:    /usr/share/libGLESv2.so
=> ERROR:    /usr/share/libffmpeg.so
=> ERROR:    /usr/share/swiftshader/libEGL.so
=> ERROR:    /usr/share/swiftshader/libGLESv2.so
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/node-spellcheckr/build/Release/spellchecker.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/keytar3/build/Release/keytar.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/keytar4/build/Release/keytar.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/v8-profiler-next/build/Release/profiler.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/@msteams/node-locale-info-provider/build/Release/node-locale-info-provider.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/@msteams/electron-modules-package-utils/build/Release/package-utils.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/media-hid/build/Release/media-hid.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/slimcore/bin/slimcore.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/slimcore/bin/sharing-indicator.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/slimcore/bin/rect-overlay
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/keyboard-layout/build/Release/keyboard-layout-manager.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/native-utils/build/Release/native-utils.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/modern-osutils/build/Release/modern-osutils.node
=> ERROR:    /usr/share/resources/app.asar.unpacked/node_modules/@microsoft/fasttext-languagedetector/build/Release/fastText-languagedetector.node
=> ERROR: teams-1.3.00.16851_1: cannot continue with installation!`