### PR TITLE
perl-module: add perl to build depends

### DIFF
--- a/common/environment/build-style/perl-module.sh
+++ b/common/environment/build-style/perl-module.sh
@@ -1,1 +1,4 @@
+hostmakedepends+=" perl"
+makedepends+=" perl"
+depends+=" perl"
 lib32disabled=yes


### PR DESCRIPTION
There are 456 packages with a build style of `perl-module`. Of those, 455 have `perl` explicitly set for `$hostmakedepends` and 425 have `perl` set for `$makedepends`. 

I'm not sure it's reasonable to retroactively fix all of the templates using the `perl-module` build style, but future updates of templates can be cleaned up.