### PR TITLE
New package: r8125-dkms-9.003.05

### DIFF
--- a/srcpkgs/r8125-dkms/files/dkms.conf
+++ b/srcpkgs/r8125-dkms/files/dkms.conf
@@ -1,0 +1,12 @@
+PACKAGE_NAME="r8125"
+PACKAGE_VERSION="@VERSION@"
+BUILT_MODULE_NAME="r8125"
+
+AUTOINSTALL="yes"
+REMAKE_INITRD="no"
+
+MAKE="'make' -C $kernel_source_dir M=$dkms_tree/$PACKAGE_NAME/$PACKAGE_VERSION/build modules"
+MAKE="'make' -j$(nproc) KERNEL_UNAME=${kernelver} modules"
+CLEAN="make clean"
+
+DEST_MODULE_LOCATION="/kernel/drivers/net/ethernet/realtek"

--- a/srcpkgs/r8125-dkms/template
+++ b/srcpkgs/r8125-dkms/template
@@ -1,0 +1,27 @@
+# Template file for 'r8125-dkms'
+pkgname=r8125-dkms
+version=9.003.05
+revision=1
+_gitrev=34f17465e87f3237eb565cfa8fc5fb803f0c2402
+archs=noarch
+wrksrc="r8125-${version}"
+depends="dkms"
+short_desc="Realtek RTL8125 driver (DKMS)"
+maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
+license="GPL-2.0-only"
+homepage="https://www.realtek.com/"
+distfiles="https://github.com/ibmibmibm/r8125/archive/${version}.tar.gz"
+checksum=75196ec98afcefbb6706307104d32131a27abba24ac333633790264968d548d6
+dkms_modules="r8125 ${version}"
+
+do_install() {
+	vmkdir /usr/src/r8125-${version}
+	vcopy "src/*" usr/src/r8125-${version}
+	vinstall ${FILESDIR}/dkms.conf 644 usr/src/r8125-${version}
+	sed -i -e "s/@VERSION@/${version}-${revision}/" ${PKGDESTDIR}/usr/src/r8125-${version}/dkms.conf
+
+	# modules-load.d(5) file.
+	vmkdir usr/lib/modules-load.d
+	echo "r8125" > ${DESTDIR}/usr/lib/modules-load.d/r8125.conf
+	chmod 644 ${DESTDIR}/usr/lib/modules-load.d/r8125.conf
+}

--- a/srcpkgs/r8125-dkms/template
+++ b/srcpkgs/r8125-dkms/template
@@ -1,8 +1,8 @@
 # Template file for 'r8125-dkms'
 pkgname=r8125-dkms
-version=9.003.05
+version=9.004.01
 revision=1
-_gitrev=34f17465e87f3237eb565cfa8fc5fb803f0c2402
+_gitrev=e174fe9d2ccf5c64fc79e980683fd2bae8413c35
 archs=noarch
 wrksrc="r8125-${version}"
 depends="dkms"
@@ -10,8 +10,8 @@ short_desc="Realtek RTL8125 driver (DKMS)"
 maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
 license="GPL-2.0-only"
 homepage="https://www.realtek.com/"
-distfiles="https://github.com/ibmibmibm/r8125/archive/${version}.tar.gz"
-checksum=75196ec98afcefbb6706307104d32131a27abba24ac333633790264968d548d6
+distfiles="https://github.com/ibmibmibm/r8125/archive/${_gitrev}.tar.gz"
+checksum=10d96d19cbd6c2a251445de516788c4afb485c57bb9e8d4c96ec14fa56e2c324
 dkms_modules="r8125 ${version}"
 
 do_install() {


### PR DESCRIPTION
Verified locally on a [Gigabyte B550I AORUS PRO AX](https://www.gigabyte.com/Motherboard/B550I-AORUS-PRO-AX-rev-10).
Did not verify 2.5G functionality or performance because I do not have a 2.5G switch.