### PR TITLE
pa-applet: license identifier & notification only shows "pa-applet" fix

### DIFF
--- a/srcpkgs/pa-applet/patches/fix-volume-notification.patch
+++ b/srcpkgs/pa-applet/patches/fix-volume-notification.patch
@@ -1,0 +1,27 @@
+diff --git a/src/notifications.c b/src/notifications.c
+index f5ac1f8..e366a12 100644
+--- src/notifications.c
++++ src/notifications.c
+@@ -7,6 +7,7 @@
+  *
+  */
+ 
++#include <stdio.h>
+ #include <libnotify/notify.h>
+ 
+ #include "audio_status.h"
+@@ -73,7 +74,13 @@ void notifications_flash(void)
+     notify_notification_set_hint_int32(notification, "value", (gint)as->volume);
+ 
+     // Update the notification icon
+-    notify_notification_update(notification, PROGRAM_NAME, NULL, icon_name);
++    char vol_text[5];
++    if (as->muted) {
++      snprintf(vol_text, 5, "mute");
++    } else {
++      snprintf(vol_text, 5, "%3.0f%%", as->volume);
++    }
++    notify_notification_update(notification, PROGRAM_NAME, vol_text, icon_name);
+ 
+     // Show the notification
+     notify_notification_show(notification, NULL);

--- a/srcpkgs/pa-applet/template
+++ b/srcpkgs/pa-applet/template
@@ -1,7 +1,7 @@
 # Template file for 'pa-applet'
 pkgname=pa-applet
 version=0.0.0.20140304
-revision=1
+revision=2
 _commit=33b413b83234d457b9512219cf4c1020eb99a3de
 wrksrc="$pkgname-$_commit"
 build_style=gnu-configure
@@ -9,7 +9,7 @@ hostmakedepends="automake libtool pkg-config"
 makedepends="gtk+3-devel libnotify-devel libcanberra-devel pulseaudio-devel"
 short_desc="PulseAudio system tray applet with volume bar"
 maintainer="Alexander Mamay <alexander@mamay.su>"
-license="2-clause-BSD"
+license="BSD-2-Clause"
 homepage="https://github.com/fernandotcl/pa-applet"
 distfiles="$homepage/archive/$_commit.tar.gz"
 checksum=db30c04a6954e1d138c6bc80739dae80d667a0af151b015db503e48fb30b0b7a


### PR DESCRIPTION
Upstream doesn't seem to be maintained. I took this patch from one of the pull requests ([this one](https://github.com/fernandotcl/pa-applet/pull/24)).