### PR TITLE
font-manjari: got versioned release urls for archive from upstream

### DIFF
--- a/srcpkgs/font-manjari/template
+++ b/srcpkgs/font-manjari/template
@@ -1,7 +1,7 @@
 # Template file for 'font-manjari'
 pkgname=font-manjari
 version=1.810
-revision=2
+revision=3
 archs="noarch"
 create_wrksrc=yes
 depends="font-util"
@@ -9,15 +9,19 @@ short_desc="Malayalam font with smooth curves"
 maintainer="Ashish Kurian Thomas <a@aktsbot.in>"
 license="OFL-1.1"
 homepage="https://smc.org.in/fonts/manjari"
-distfiles="https://smc.org.in/downloads//fonts/manjari/manjari.zip
+distfiles="https://releases.smc.org.in/fonts/manjari/Version${version}/manjari-Version${version}.tar.gz
  https://gitlab.com/smc/fonts/manjari/-/raw/Version${version}/LICENSE.txt"
-checksum="ade6ba3006c0cbd01d90084d9a5119a22db996a603bf82b68d94fdcfed750cf2
+checksum="d90ca754850a2084f8435f3a885c52f200b08a4da5018f9a8291093a2c70c162
  94e69dddcfc87af561cad830b6afeb0d858634ae8aa649f8381891873fd6f591"
 font_dirs="/usr/share/fonts/TTF"
 
 do_install() {
-	for f in *.ttf; do
+	for f in ttf/*.ttf; do
 		vinstall $f 0644 usr/share/fonts/TTF
 	done
+
+	# install fontconfig file
+	vinstall 67-fonts-smc-manjari.conf 0644 etc/fonts/conf.avail/67-fonts-smc-manjari.conf
+
 	vlicense LICENSE.txt
 }

--- a/srcpkgs/font-manjari/update
+++ b/srcpkgs/font-manjari/update
@@ -1,0 +1,2 @@
+site="https://releases.smc.org.in/fonts/manjari/LATEST"
+pattern="manjari-Version\K[0-9.]+(?=.tar.gz)"


### PR DESCRIPTION
previous version of the package used an unversioned link from upstream,
that had frequent updates, which would break sha256sum check.