### PR TITLE
sv-netmount: redirect stdout when checking $NETWORK_MANAGER status

### DIFF
--- a/srcpkgs/sv-netmount/files/netmount/run
+++ b/srcpkgs/sv-netmount/files/netmount/run
@@ -3,7 +3,7 @@
 [ -r conf ] && . ./conf
 
 # Ensure the network manager is running
-[ -z "$NETWORK_MANAGER" ] || sv check "$NETWORK_MANAGER" 2> /dev/null || exit 1
+[ -z "$NETWORK_MANAGER" ] || sv check "$NETWORK_MANAGER" > /dev/null 2>&1 || exit 1
 
 # If it's running or not in used - rc.local - discover default gateway
 if [ -z "$GATEWAY" ]; then

--- a/srcpkgs/sv-netmount/template
+++ b/srcpkgs/sv-netmount/template
@@ -1,12 +1,12 @@
 # Template file for 'sv-netmount'
 pkgname=sv-netmount
 version=0.1
-revision=2
-short_desc="Service to mount/umount network filesystems from fstab"
-homepage="http://www.voidlinux.org/"
-maintainer="Olivier Mauras <olivier@mauras.ch>"
-license="GPL-2"
+revision=3
 build_style="meta"
+short_desc="Service to mount/umount network filesystems from fstab"
+maintainer="Olivier Mauras <olivier@mauras.ch>"
+license="GPL-2.0-or-later"
+homepage="http://www.voidlinux.org/"
 
 depends="runit"
 


### PR DESCRIPTION
This a quick and dirty solution to #23968 that just redirects stdout when checking the status of $NETWORK_MANAGER.