### PR TITLE
New package: dijo-0.2.3

### DIFF
--- a/srcpkgs/dijo/template
+++ b/srcpkgs/dijo/template
@@ -1,0 +1,16 @@
+# Template file for 'dijo'
+pkgname=dijo
+version=0.2.3
+revision=1
+build_style=cargo
+makedepends="ncurses-devel"
+short_desc="Scriptable, curses-based, digital habit tracker"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="MIT"
+homepage="https://github.com/NerdyPepper/dijo"
+distfiles="https://github.com/NerdyPepper/dijo/archive/v${version}.tar.gz"
+checksum=691178345abf9b07c751271b6b1a19e4182423294aaffa8b3a0973dc3e5805d3
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
[dijo](https://github.com/NerdyPepper/dijo) is a curses-based habit tracker that runs in your terminal. It is currently available via nixpkgs.