### PR TITLE
python3-matplotlib: depend on python3-Pillow

### DIFF
--- a/srcpkgs/python3-matplotlib/files/README.voidlinux
+++ b/srcpkgs/python3-matplotlib/files/README.voidlinux
@@ -9,8 +9,5 @@ For interactive graphics, install:
 
 The backend can be defined in $XDG_CONFIG_HOME/matplotlib/matplotlibrc
 
-Natively, matplotlib only supports PNG images. Install python3-Pillow
-to support more file formats.
-
 Matplotlib’s LaTeX support requires a working LaTeX installation and
 ghostscript.

--- a/srcpkgs/python3-matplotlib/template
+++ b/srcpkgs/python3-matplotlib/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-matplotlib'
 pkgname=python3-matplotlib
 version=3.3.0
-revision=1
+revision=2
 wrksrc="matplotlib-${version}"
 build_style=python3-module
 build_helper="numpy"
@@ -9,7 +9,8 @@ hostmakedepends="pkg-config python3-setuptools"
 # XXX use internal copy of agg, highly patched
 makedepends="python3-devel freetype-devel libpng-devel libqhull-devel"
 depends="python3-matplotlib-data>=${version}_${revision} python3-numpy
- python3-dateutil python3-parsing python3-cycler python3-kiwisolver"
+ python3-dateutil python3-parsing python3-cycler python3-kiwisolver
+ python3-Pillow"
 short_desc="Python3 2D/3D plotting library"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="custom:matplotlib, BSD-3-Clause, MIT"


### PR DESCRIPTION
Since 3.3, `import matplotlib.pyplot as plt` fails with:
```
ModuleNotFoundError: No module named 'PIL'
```
@ahesford 