### PR TITLE
[WIP] New package: ly-0.5.2

### DIFF
--- a/srcpkgs/ly/files/ly/conf
+++ b/srcpkgs/ly/files/ly/conf
@@ -1,0 +1,10 @@
+BAUD_RATE=38400
+TERM_NAME=linux
+# don't change the following value without also changing the "tty" value in /etc/ly/config.ini
+TTY=7
+
+if [ "${TTY}" = "1" ]; then
+	GETTY_ARGS="--noclear"
+fi
+
+[ -r /etc/locale.conf ] && . /etc/locale.conf

--- a/srcpkgs/ly/files/ly/finish
+++ b/srcpkgs/ly/files/ly/finish
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -r conf ] && . ./conf 
+
+exec utmpset -w "tty${TTY}"

--- a/srcpkgs/ly/files/ly/run
+++ b/srcpkgs/ly/files/ly/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -r conf ] && . ./conf
+
+LANG="$LANG" exec setsid agetty ${GETTY_ARGS} -nl /usr/bin/ly "tty${TTY}" "${BAUD_RATE}" "${TERM_NAME}"

--- a/srcpkgs/ly/patches/config.ini.patch
+++ b/srcpkgs/ly/patches/config.ini.patch
@@ -1,0 +1,13 @@
+Changes default TTY to 7
+--- ly-0.5.2/res/config.ini	2020-07-28 11:35:08.000000000 -0400
++++ "ly-0.5.2/res/config copy.ini"	2020-08-06 14:20:41.677126155 -0400
+@@ -79,7 +79,8 @@
+ #term_reset_cmd = /usr/bin/tput reset
+ 
+ # tty in use
+-#tty = 2
++# if you change this value, you must also change the "TTY" value in /etc/sv/ly/conf
++tty = 7
+ 
+ # wayland setup command
+ #wayland_cmd = /etc/ly/wsetup.sh

--- a/srcpkgs/ly/template
+++ b/srcpkgs/ly/template
@@ -1,0 +1,60 @@
+# Template file for 'ly'
+pkgname=ly
+version=0.5.2
+revision=1
+create_wrksrc=yes
+build_wrksrc=${pkgname}-${version}
+_argoat_githash=0eb7afae7a001094c9166a8959e021375707522c
+_testoasterror_githash=ee7c9d031d4632a6f381a6c174a38539bac04068
+_configator_githash=8cec1786196ae6f6a8b35e66181277457f2a2bb2
+_ctypes_githash=eb4b36559de8d17015f9416861ed085d06f5f5ed
+_dragonfail_githash=0a2492c6aab3ff64e182db894ce4d40b26799fbd
+_termbox_githash=23fff64470b0730959b39c70aa31fbddd776d9bc
+build_style=gnu-makefile
+conf_files="/etc/ly/config.ini"
+makedepends="ncurses-devel pam-devel xcb-util-devel libX11-devel"
+depends="pam util-linux xauth"
+short_desc="TUI (ncurses-like) display manager"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="WTFPL"
+homepage="https://github.com/nullgemm/ly"
+distfiles="https://github.com/nullgemm/ly/archive/v${version}.tar.gz
+ https://github.com/nullgemm/argoat/archive/${_argoat_githash}.tar.gz>argoat-${_argoat_githash}.tar.gz
+ https://github.com/nullgemm/testoasterror/archive/${_testoasterror_githash}.tar.gz>testoasterror-${_testoasterror_githash}.tar.gz
+ https://github.com/nullgemm/configator/archive/${_configator_githash}.tar.gz>configator-${_configator_githash}.tar.gz
+ https://raw.githubusercontent.com/nullgemm/ctypes/${_ctypes_githash}/ctypes.h>ctypes-${_ctypes_githash}.h
+ https://github.com/nullgemm/dragonfail/archive/${_dragonfail_githash}.tar.gz>dragonfail-${_dragonfail_githash}.tar.gz
+ https://github.com/nullgemm/termbox_next/archive/${_termbox_githash}.tar.gz>termbox_next-${_termbox_githash}.tar.gz"
+checksum="3460c2c8015add2946f9ff5d3e4bf051d7c07005698fe61279cedacd1283e010
+ 65b0b5d688f8538513f335795156441365b9cb319a28d2defbb29d81ea43a188
+ d627845bcece46499801bbef5b2ccf3e0bfe39493b52a16ae34478e54ab11bd6
+ 2067100f9779eceb5abefa9402ed56546314ca5ad6b3d5156d3e1eb46c853679
+ ef169974c68b548dc8ac83bd4714622775b024fab07dc2b7fe96e8e8f102dbab
+ d5cdd6d528a43c35d08e7fcac849370c07d949671ef592cfecb02b23ad3c4dad
+ 76d73183d2191e9e37285f39f2b1bd51f1dc2d991637902ff3c1aa35111b288d"
+skip_extraction="ctypes-${_ctypes_githash}.h"
+
+post_extract() {
+	mv argoat-${_argoat_githash}/* ${build_wrksrc}/sub/argoat/
+	mv testoasterror-${_testoasterror_githash}/* ${build_wrksrc}/sub/argoat/sub/testoasterror/
+	mv configator-${_configator_githash}/* ${build_wrksrc}/sub/configator/
+	mv $XBPS_SRCDISTDIR/$pkgname-$version/ctypes-${_ctypes_githash}.h ${build_wrksrc}/sub/ctypes/ctypes.h
+	mv dragonfail-${_dragonfail_githash}/* ${build_wrksrc}/sub/dragonfail/
+	mv termbox_next-${_termbox_githash}/* ${build_wrksrc}/sub/termbox_next/
+}
+
+pre_build() {
+	cd sub/argoat/sub/testoasterror
+	make
+	cd ../../
+	make
+	cd ../../
+	vsed -i makefile -e "s/^FLAGS+= -DGIT_VERSION_STRING=.*/FLAGS+= -DGIT_VERSION_STRING=\\\\\"${version}\\\\\"/g"
+	vsed -i makefile -e "s/^\t@/\t/g"
+	vsed -i sub/termbox_next/makefile -e "s/^\t@ar/\t@\$(AR)/g"
+}
+
+post_install() {
+	rm -f $DESTDIR/usr/lib/systemd/system/ly.service
+	vsv ly
+}


### PR DESCRIPTION
[ly](https://github.com/nullgemm/ly) is a simple TUI display manager. It recently had a new tagged release, and I thought this would be a good time to try to package it. This PR would resolve #13583 and would allow #13649 to be closed. The template is based almost entirely on [this template](https://github.com/ericonr/void-packages/commit/eadabab675acaff062d138a2607d5920b125bfde) by @ericonr, and the service files were taken from [a fork of ly made to work with Void](https://github.com/drozdowsky/ly-void/commit/b972fe48a143e709dc695ac8e2c83dc57cee279f). The patches make minor adjustments to make ly display on the standard TTY 7 and remove the systemD service.

ly is able to build properly on my machine; I'll soon see if it build properly through travis. The problem with this package is that it doesn't seem to work quite right after it starts running. I get PAM errors when attempting to log in using ly; you can see those errors in [this issue in the ly repository](https://github.com/nullgemm/ly/issues/216). My hunch is that the problem lies in [ly's PAM file](https://github.com/nullgemm/ly/blob/master/res/pam.d/ly). Does anyone know how to patch this to work properly?