### PR TITLE
New package: e16-1.0.22

### DIFF
--- a/srcpkgs/e16/template
+++ b/srcpkgs/e16/template
@@ -1,0 +1,24 @@
+# Template file for 'e16'
+pkgname=e16
+version=1.0.22
+revision=1
+build_style=gnu-configure
+configure_args="--sysconfdir=/etc --enable-sound=alsa"
+hostmakedepends="pkg-config tar"
+makedepends="pango-devel libXinerama-devel libXrandr-devel imlib2-devel libXcomposite-devel alsa-lib-devel libsndfile-devel"
+short_desc="Enlightenment DR16 window manager"
+maintainer="Brihadeesh <brihadeesh@protonmail.com>"
+license="BSD-2-Clause"
+homepage="https://www.enlightenment.org/e16"
+distfiles="$SOURCEFORGE_SITE/enlightenment/${pkgname}-${version}.tar.gz"
+checksum=b07d301a0a67ac020974afcbe779e1d48b376eab2e477fb189277c13b76d4a67
+
+post_install() {
+	# install gnome and kde session scripts
+	vbin "misc/Xclients.e16-gnome.sh" e16-gnome
+	vbin "misc/Xclients.e16-kde.sh" e16-kde
+
+	# licences for e16 and fonts(?)
+	vlicense COPYING
+	vlicense fonts/COPYRIGHT.Vera
+}


### PR DESCRIPTION
New package: e16-1.0.22 (enlightenment DR16 window manager; current release).

These lines in `post_install()` seem to have no purpose but the kde and gnome session scripts provided by e16 might be of use to some:

```
vbin "misc/Xclients.e16-gnome.sh" e16-gnome
vbin "misc/Xclients.e16-kde.sh" e16-kde
```
I'm also uncertain as to whether this is the right usage of the vbin function.

PS: this is like my first PR ever!!