### PR TITLE
NetworkManager-strongswan: update to 1.5.2.

### DIFF
--- a/srcpkgs/NetworkManager-strongswan/template
+++ b/srcpkgs/NetworkManager-strongswan/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager-strongswan'
 pkgname=NetworkManager-strongswan
-version=1.4.5
-revision=2
+version=1.5.2
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-more-warnings --without-libnm-glib
  --disable-more-warnings"
@@ -13,4 +13,4 @@ maintainer="Louis Dupré Bertoni <contact@louisdb.xyz>"
 license="GPL-2.0-or-later"
 homepage="https://www.strongswan.org/"
 distfiles="https://download.strongswan.org/NetworkManager/NetworkManager-strongswan-${version}.tar.bz2"
-checksum=343b68cbe32f65e2baa01b37716415e4360addc8c90209d45504b52b8864bd04
+checksum=c8452b952653881dcc2745f0ab460c061086215b297129212a743bd9e9f78169

--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,13 +1,12 @@
 # Template file for 'strongswan'
 pkgname=strongswan
 version=5.8.4
-revision=1
+revision=2
 build_style=gnu-configure
 # tpm support waits on libtss2
-configure_args="--disable-static --enable-blowfish --enable-curl
- --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5 --enable-led
- --enable-ha --enable-dhcp --enable-mediation --enable-soup --disable-des
- --enable-chapoly --enable-nm"
+configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
+ --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5 --enable-eap-identity --enable-eap-dynamic
+ --enable-led --enable-ha --enable-dhcp --enable-mediation --enable-soup --enable-chapoly --enable-nm"
 hostmakedepends="pkg-config flex bison python"
 makedepends="gmp-devel libsoup-devel libldns-devel unbound-devel libcurl-devel NetworkManager-devel"
 depends="iproute2 sqlite"


### PR DESCRIPTION
I also modified a bit the `strongswan` package because authentication with EAP MS-CHAPv2 was not working.