### PR TITLE
muffin: move *.gir and *.typelib files

### DIFF
--- a/srcpkgs/muffin/template
+++ b/srcpkgs/muffin/template
@@ -24,6 +24,13 @@ pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
 }
 
+post_install() {
+	vmkdir usr/lib/gir-1.0
+	mv ${DESTDIR}/usr/lib/muffin/*.gir ${DESTDIR}/usr/lib/gir-1.0
+	vmkdir usr/lib/girepository-1.0
+	mv ${DESTDIR}/usr/lib/muffin/*.typelib ${DESTDIR}/usr/lib/girepository-1.0
+}
+
 muffin-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
@@ -31,5 +38,6 @@ muffin-devel_package() {
 		vmove "usr/lib/*.so"
 		vmove usr/include
 		vmove usr/lib/pkgconfig
+		vmove usr/lib/gir-1.0
 	}
 }


### PR DESCRIPTION
Other packages have *.gir files in usr/lib/gir-1.0 and the
*.typelib files in usr/lib/girepository-1.0. The usr/lib/gir-1.0
directory should then be in the muffin-devel subpackage AFAICT.

This is in a try to fix the cinnamon cross build yet it isn't sufficient.