### PR TITLE
python-PyQt5: update to 5.15.0

### DIFF
--- a/srcpkgs/python-PyQt5-webengine/template
+++ b/srcpkgs/python-PyQt5-webengine/template
@@ -1,7 +1,7 @@
 # Template file for 'python-PyQt5-webengine'
 pkgname=python-PyQt5-webengine
-version=5.13.2
-revision=5
+version=5.15.0
+revision=1
 wrksrc="PyQtWebEngine-${version}"
 hostmakedepends="pkg-config qt5-qmake python python-PyQt5 python3-PyQt5"
 makedepends="qt5-declarative-devel qt5-webchannel-devel qt5-location-devel
@@ -11,8 +11,8 @@ short_desc="Python2 bindings for the Qt5 toolkit - webengine module"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="GPL-3.0-only"
 homepage="https://www.riverbankcomputing.com/software/pyqtwebengine/intro"
-distfiles="https://www.riverbankcomputing.com/static/Downloads/PyQtWebEngine/${version}/PyQtWebEngine-${version}.tar.gz"
-checksum=4264911b5847c75721d8c9c30af92e58a216bd25ceef37f7abf921005c1d45a9
+distfiles="${PYPI_SITE}/P/PyQtWebEngine/PyQtWebEngine-${version}.tar.gz"
+checksum=670812688e40bf75f70ddf01eadd897d231300318d3856b275bf8e7e0085bf75
 lib32disabled=yes
 nocross="configure script is broken for cross builds"
 

--- a/srcpkgs/python-PyQt5-webengine/update
+++ b/srcpkgs/python-PyQt5-webengine/update
@@ -1,1 +1,1 @@
-pkgname="PyQtWebEngine_gpl"
+pkgname="PyQtWebEngine"

--- a/srcpkgs/python-PyQt5/template
+++ b/srcpkgs/python-PyQt5/template
@@ -1,11 +1,9 @@
 # Template file for 'python-PyQt5'
 pkgname=python-PyQt5
-version=5.13.2
-revision=2
-_sipver=4.19.19
-lib32disabled=yes
+version=5.15.0
+revision=1
+_sipver=4.19.23
 wrksrc="PyQt5-${version}"
-pycompile_module="PyQt5"
 hostmakedepends="pkg-config
  python-devel python3-devel python-sip-devel python3-sip-devel python-dbus-devel
  qt5-tools-devel qt5-connectivity-devel qt5-declarative-devel qt5-location-devel
@@ -17,10 +15,11 @@ makedepends="${hostmakedepends/pkg-config/}"
 depends="python-sip-PyQt5>=${_sipver} python-enum34"
 short_desc="Python2 bindings for the Qt5 toolkit"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://riverbankcomputing.com/software/pyqt/intro"
 license="GPL-3.0-only"
-distfiles="https://www.riverbankcomputing.com/static/Downloads/PyQt5/${version}/PyQt5-${version}.tar.gz"
-checksum=adc17c077bf233987b8e43ada87d1e0deca9bd71a13e5fd5fc377482ed69c827
+homepage="https://riverbankcomputing.com/software/pyqt/intro"
+distfiles="${PYPI_SITE}/P/PyQt5/PyQt5-${version}.tar.gz"
+checksum=c6f75488ffd5365a65893bc64ea82a6957db126fbfe33654bcd43ae1c30c52f9
+lib32disabled=yes
 
 pre_build() {
 	mkdir -p pyqt5-${py2_ver}
@@ -97,7 +96,6 @@ python-PyQt5-devel-tools_package() {
 	 pyqt5:pylupdate5:/usr/bin/python2-pylupdate5
 	 pyqt5:pyrcc5:/usr/bin/python2-pyrcc5
 	 pyqt5:pyuic5:/usr/bin/python2-pyuic5"
-	pycompile_module="PyQt5"
 	pkg_install() {
 		vmove usr/bin/python2-*
 		vmove ${py2_sitelib}/PyQt5/pylupdate.so
@@ -114,7 +112,6 @@ python3-PyQt5-devel-tools_package() {
 	 pyqt5:pylupdate5:/usr/bin/python3-pylupdate5
 	 pyqt5:pyrcc5:/usr/bin/python3-pyrcc5
 	 pyqt5:pyuic5:/usr/bin/python3-pyuic5"
-	pycompile_module="PyQt5"
 	pkg_install() {
 		vmove usr/bin/python3-*
 		vmove ${py3_sitelib}/PyQt5/pylupdate.so
@@ -280,7 +277,6 @@ python-PyQt5-xmlpatterns_package() {
 }
 python3-PyQt5_package() {
 	lib32disabled=yes
-	pycompile_module="PyQt5"
 	depends="python3-sip-PyQt5>=${_sipver}"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {

--- a/srcpkgs/python-PyQt5/update
+++ b/srcpkgs/python-PyQt5/update
@@ -1,1 +1,1 @@
-pkgname="PyQt5_gpl"
+pkgname="PyQt5"

--- a/srcpkgs/sip/template
+++ b/srcpkgs/sip/template
@@ -1,7 +1,7 @@
 # Template file for 'sip'
 pkgname=sip
-version=4.19.19
-revision=2
+version=4.19.23
+revision=1
 hostmakedepends="python-devel python3-devel"
 makedepends="${hostmakedepends}"
 short_desc="Python extension module generator for C/C++ libraries"
@@ -9,7 +9,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="GPL-2.0-only, GPL-3.0-only, custom:SIP"
 homepage="https://riverbankcomputing.com/software/sip/intro"
 distfiles="https://www.riverbankcomputing.com/static/Downloads/sip/${version}/sip-${version}.tar.gz"
-checksum=5436b61a78f48c7e8078e93a6b59453ad33780f80c644e5f3af39f94be1ede44
+checksum=22ca9bcec5388114e40d4aafd7ccd0c4fe072297b628d0c5cdfa2f010c0bc7e7
 
 pre_build() {
 	mkdir -p sip-${py2_ver}
@@ -66,7 +66,6 @@ do_install() {
 python-sip_package() {
 	lib32disabled=yes
 	depends="${sourcepkg}-${version}_${revision} python"
-	pycompile_module="sipconfig.py"
 	short_desc="Python2 SIP bindings"
 	pkg_install() {
 		vmove ${py2_sitelib}/sip.so
@@ -76,7 +75,6 @@ python-sip_package() {
 }
 python-sip-devel_package() {
 	depends="python-sip-${version}_${revision}"
-	pycompile_module="sipdistutils.py"
 	short_desc="Python2 SIP bindings - development files"
 	pkg_install() {
 		vmove ${py2_inc}
@@ -86,7 +84,6 @@ python-sip-devel_package() {
 python3-sip_package() {
 	lib32disabled=yes
 	depends="${sourcepkg}-${version}_${revision} python3"
-	pycompile_module="sipconfig.py"
 	short_desc="Python3 SIP bindings"
 	pkg_install() {
 		vmove ${py3_sitelib}/sip.so
@@ -96,7 +93,6 @@ python3-sip_package() {
 }
 python3-sip-devel_package() {
 	depends="python3-sip-${version}_${revision}"
-	pycompile_module="sipdistutils.py"
 	short_desc="Python3 SIP bindings - development files"
 	pkg_install() {
 		vmove ${py3_inc}


### PR DESCRIPTION
requires: #23666 
also rebuild qutebrowser against python3-PyQt5 1.15.0
xlint will fail on python-PyQt5, because of indenting, but that's a false alarm