### PR TITLE
Improve consistency of relative paths in kernel hooks

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -39,10 +39,12 @@ list_kernels() {
 run_hooks() {
 	dir="$1"
 	kver="$2"
+
 	for d in /etc/kernel.d/"${dir}"/*; do
 		[ -x "$d" ] || continue
 		printf "Running %s kernel hook: %s...\n" "$dir" "${d##*/}"
-		"$d" kernel "$kver"
+		# Hooks assume they run from the root
+		(cd / && ROOTDIR=. "$d" kernel "$kver")
 	done
 }
 

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.141
-revision=1
+revision=2
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"

--- a/srcpkgs/dkms/files/kernel.d/dkms.postinst
+++ b/srcpkgs/dkms/files/kernel.d/dkms.postinst
@@ -8,7 +8,7 @@ PKGNAME="$1"
 VERSION="$2"
 ARCH=$(uname -m)
 
-if [ ! -x /usr/sbin/dkms ]; then
+if [ ! -x /usr/bin/dkms ]; then
 	exit 0
 fi
 
@@ -59,16 +59,16 @@ while [ $# -gt 1 ]; do
 	# If adding a module, depmod is necessary unless dkms runs it
 	do_depmod="yes"
 
-	status=$(dkms status -m ${module} -v ${modulever} -k ${VERSION})
+	status=$(/usr/bin/dkms status -m ${module} -v ${modulever} -k ${VERSION})
 	if [ $(echo "$status"|grep -c ": built") -eq 0 ]; then
 		# Check if the module is still there.
-		if [ ! -f usr/src/${module}-${modulever}/dkms.conf ]; then
+		if [ ! -f /usr/src/${module}-${modulever}/dkms.conf ]; then
 			echo "Skipping nonexistent DKMS module: ${module}-${modulever}."
 			continue
 		fi
 		# Build the module
 		echo -n "Building DKMS module: ${module}-${modulever}... "
-		dkms build -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
+		/usr/bin/dkms build -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
 		rval=$?
 		# If the module was skipped or failed, go to the next module.
 		if [ $rval -eq 0 ]; then
@@ -80,14 +80,14 @@ while [ $# -gt 1 ]; do
 			echo "FAILED!"
 			continue
 		fi
-		status=$(dkms status -m ${module} -v ${modulever} -k ${VERSION})
+		status=$(/usr/bin/dkms status -m ${module} -v ${modulever} -k ${VERSION})
 	fi
 
 	# If the module is built (either pre-built or just now), install it
 	if [ $(echo "$status"|grep -c ": built") -eq 1 ] &&
 	   [ $(echo "$status"|grep -c ": installed") -eq 0 ]; then
 		echo -n "Installing DKMS module: ${module}-${modulever}... "
-		dkms install -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
+		/usr/bin/dkms install -q -m ${module} -v ${modulever} -k ${VERSION} -a ${ARCH}
 		rval=$?
 		# If the module failed installation, go to the next module.
 		if [ $rval -eq 0 ]; then
@@ -101,16 +101,18 @@ while [ $# -gt 1 ]; do
 	fi
 done
 
-if [ -n "$do_depmod" ]; then
-	echo -n "Generating kernel module dependency lists... "
-	depmod -a ${VERSION}
-	rval=$?
-	if [ $rval -eq 0 ]; then
-		echo "done."
-	else
-		echo "FAILED!"
-		exit $rval
-	fi
+if [ -z "$do_depmod" ] || [ ! -x /usr/bin/depmod ]; then
+	exit 0
+fi
+
+echo -n "Generating kernel module dependency lists... "
+/usr/bin/depmod -a ${VERSION}
+rval=$?
+if [ $rval -eq 0 ]; then
+	echo "done."
+else
+	echo "FAILED!"
+	exit $rval
 fi
 
 exit 0

--- a/srcpkgs/dkms/files/kernel.d/dkms.prerm
+++ b/srcpkgs/dkms/files/kernel.d/dkms.prerm
@@ -4,14 +4,14 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ -x /usr/sbin/dkms ]; then
+if [ -x /usr/bin/dkms ]; then
 while read line; do
    name=`echo "$line" | awk '{print $1}' | sed 's/,$//'`
    vers=`echo "$line" | awk '{print $2}' | sed 's/,$//'`
    arch=`echo "$line" | awk '{print $4}' | sed 's/:$//'`
    echo "dkms: removing: $name $vers (${PKGNAME}-${VERSION}) ($arch)" >&2
-   dkms remove -q -m $name -v $vers -k ${VERSION} -a $arch
-done < <(dkms status -k ${VERSION} 2>/dev/null | grep ": installed")
+   /usr/bin/dkms remove -q -m $name -v $vers -k ${VERSION} -a $arch
+done < <(/usr/bin/dkms status -k ${VERSION} 2>/dev/null | grep ": installed")
 fi
 
 rmdir \

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,7 +1,7 @@
 # Template file for 'dkms'
 pkgname=dkms
 version=2.8.3
-revision=1
+revision=2
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils linux-headers"
 short_desc="Dynamic Kernel Modules System"

--- a/srcpkgs/dracut/files/kernel-hook-postinst
+++ b/srcpkgs/dracut/files/kernel-hook-postinst
@@ -7,9 +7,9 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ ! -x bin/dracut ]; then
+if [ ! -x usr/bin/dracut ]; then
 	exit 0
 fi
 
-dracut -q --force boot/initramfs-${VERSION}.img ${VERSION}
+usr/bin/dracut -q --force --sysroot . boot/initramfs-${VERSION}.img ${VERSION}
 exit $?

--- a/srcpkgs/dracut/files/kernel-hook-postrm
+++ b/srcpkgs/dracut/files/kernel-hook-postrm
@@ -7,7 +7,5 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ -f boot/initramfs-${VERSION}.img ]; then
-	rm -f boot/initramfs-${VERSION}.img
-fi
+rm -f boot/initramfs-${VERSION}.img
 exit $?

--- a/srcpkgs/dracut/files/kernel-uefi-hook-postinst
+++ b/srcpkgs/dracut/files/kernel-uefi-hook-postinst
@@ -12,12 +12,13 @@ if [ -z "${CREATE_UEFI_BUNDLES}" ]; then
 	exit 0
 fi
 
-if [ ! -x bin/dracut ]; then
+if [ ! -x usr/bin/dracut ]; then
 	exit 0
 fi
 
 mkdir -p ${UEFI_BUNDLE_DIR:=boot/efi/EFI/void}
 
-dracut -q --force ${KERNEL_CMDLINE:+--kernel-cmdline="${KERNEL_CMDLINE}"} ${DRACUT_OPTIONS} \
+usr/bin/dracut -q --force --sysroot . ${DRACUT_OPTIONS} \
+	${KERNEL_CMDLINE:+--kernel-cmdline="${KERNEL_CMDLINE}"} \
 	--uefi ${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi ${VERSION}
 exit $?

--- a/srcpkgs/dracut/files/kernel-uefi-hook-postrm
+++ b/srcpkgs/dracut/files/kernel-uefi-hook-postrm
@@ -11,7 +11,5 @@ VERSION="$2"
 
 : "${UEFI_BUNDLE_DIR:=boot/efi/EFI/void}"
 
-if [ -f "${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi" ]; then
-	rm -fv "${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi"
-fi
+rm -fv "${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi"
 exit $?

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=050
-revision=5
+revision=6
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"

--- a/srcpkgs/gummiboot/files/kernel.d/gummiboot.post-install
+++ b/srcpkgs/gummiboot/files/kernel.d/gummiboot.post-install
@@ -13,33 +13,33 @@ if [ "$GUMMIBOOT_DISABLE" ]; then
 	exit 0
 fi
 
-boot=$ROOTDIR/boot
-entries=$boot/loader/entries
-name=void-$VERSION
-entry=$entries/$name.conf
-options=$boot/loader/void-options.conf
-loader=$boot/loader/loader.conf
+boot="$ROOTDIR/boot"
+entries="$boot/loader/entries"
+name="void-$VERSION"
+entry="$entries/$name.conf"
+options="$boot/loader/void-options.conf"
+loader="$boot/loader/loader.conf"
 
-[ -d $boot ] || exit 0
+[ -d "$boot" ] || exit 0
 
-mkdir -p $entries
+mkdir -p "$entries"
 
-cat <<-EOF > $entry
+cat <<-EOF > "$entry"
 	title Void Linux
 	version $VERSION
 	linux /vmlinuz-$VERSION
 	initrd /initramfs-$VERSION.img
 EOF
 
-if [ -r $options ]; then
+if [ -r "$options" ]; then
 	# Add user provided options from /boot/loader/void-options.conf:
-	printf 'options %s\n' "$(cat $options | sed '/^#/d;/^$/d')" >> $entry
+	printf 'options %s\n' "$(cat "$options" | sed '/^#/d;/^$/d')" >> "$entry"
 fi
 
-if grep -q ^default $loader 2>/dev/null; then
+if grep -q ^default "$loader" 2>/dev/null; then
 	# Replace existing default entry with this entry:
-	sed -i "s/default.*/default $name/" $loader
+	sed -i "s/default.*/default $name/" "$loader"
 else
 	# Add this entry as the default:
-	printf 'default %s\n' $name >>$loader
+	printf 'default %s\n' $name >>"$loader"
 fi

--- a/srcpkgs/gummiboot/files/kernel.d/gummiboot.post-remove
+++ b/srcpkgs/gummiboot/files/kernel.d/gummiboot.post-remove
@@ -7,15 +7,15 @@
 PKGNAME="$1"
 VERSION="$2"
 
-boot=$ROOTDIR/boot
-entries=$boot/loader/entries
-name=void-$VERSION
-entry=$entries/$name.conf
-loader=$boot/loader/loader.conf
+boot="$ROOTDIR/boot"
+entries="$boot/loader/entries"
+name="void-$VERSION"
+entry="$entries/$name.conf"
+loader="$boot/loader/loader.conf"
 
-[ -d $boot ] || exit 0
+[ -d "$boot" ] || exit 0
 
-rm -f $entry
+rm -f "$entry"
 
 # No default entry if the removed entry was the default:
-sed -i "/^default $name\$/d" $loader
+[ -e "$loader" ] && sed -i "/^default $name\$/d" "$loader"

--- a/srcpkgs/gummiboot/template
+++ b/srcpkgs/gummiboot/template
@@ -1,7 +1,7 @@
 # Template file for 'gummiboot'
 pkgname=gummiboot
 version=48.1
-revision=5
+revision=6
 archs="i686* x86_64* aarch64*"
 build_style=gnu-configure
 conf_files="/etc/default/gummiboot"

--- a/srcpkgs/mkinitcpio/files/kernel-hook-postinst
+++ b/srcpkgs/mkinitcpio/files/kernel-hook-postinst
@@ -7,9 +7,9 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ ! -x bin/mkinitcpio ]; then
+if [ ! -x usr/bin/mkinitcpio ]; then
 	exit 0
 fi
 
-mkinitcpio -g boot/initramfs-${VERSION}.img -k ${VERSION}
+usr/bin/mkinitcpio -g boot/initramfs-${VERSION}.img -k ${VERSION}
 exit $?

--- a/srcpkgs/mkinitcpio/files/kernel-hook-postrm
+++ b/srcpkgs/mkinitcpio/files/kernel-hook-postrm
@@ -7,7 +7,5 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ -f /boot/initramfs-${VERSION}.img ]; then
-	rm -f /boot/initramfs-${VERSION}.img
-fi
+rm -f boot/initramfs-${VERSION}.img
 exit $?

--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=27
-revision=1
+revision=2
 archs=noarch
 build_style=gnu-makefile
 depends="busybox-static bsdtar bash"

--- a/srcpkgs/refind/files/kernel.post-install
+++ b/srcpkgs/refind/files/kernel.post-install
@@ -12,22 +12,18 @@ if [ "z$UPDATE_REFIND_CONF" != "z1" ]; then
 	exit 0;
 fi
 
-# Default refind.conf
-: "${REFIND_CONF:=/boot/EFI/refind/refind.conf}"
+: ${REFIND_CONF:=boot/EFI/refind/refind.conf}
+REFIND_CONF="${REFIND_CONF#/}"
 
-zrefind_dir="${REFIND_CONF%/*}"
-mkdir -p "$zrefind_dir"
+mkdir -p "${REFIND_CONF%/*}"
 touch "$REFIND_CONF"
 
 tmpfile=$(mktemp /tmp/refind.XXXXXXX)
 
-zefi_mountpoint=$(df -P "$REFIND_CONF" | awk 'NR==2{print $6}')
-zicon="${zrefind_dir#$zefi_mountpoint}/icons/os_void.png"
 zversion=$(echo "$VERSION" | sed 's/[.]/[.]/g')
 
 zentry=$(cat <<EOF
 menuentry "Void Linux $VERSION" {
-	icon     $zicon
 	volume   "Void Linux"
 	loader   /vmlinuz-$VERSION
 	initrd   /initramfs-$VERSION.img

--- a/srcpkgs/refind/files/kernel.post-remove
+++ b/srcpkgs/refind/files/kernel.post-remove
@@ -13,7 +13,9 @@ if [ "z$UPDATE_REFIND_CONF" != "z1" ]; then
 fi
 
 # Default refind.conf
-: "${REFIND_CONF:=/boot/EFI/refind/refind.conf}"
+: "${REFIND_CONF:=boot/EFI/refind/refind.conf}"
+# Make sure paths are relative
+REFIND_CONF="${REFIND_CONF#/}"
 
 [ -f "$REFIND_CONF" ] || exit 0
 

--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.12.0
-revision=1
+revision=2
 archs="x86_64* i686* aarch64*"
 makedepends="gnu-efi-libs"
 depends="bash dosfstools efibootmgr"

--- a/srcpkgs/sbsigntool/files/kernel.d/sbsigntool.post-install
+++ b/srcpkgs/sbsigntool/files/kernel.d/sbsigntool.post-install
@@ -9,7 +9,35 @@ PKGNAME="$1"
 VERSION="$2"
 
 msg() {
-	echo "EFI sbsign hook: $1"
+	echo "sbsigntool: $1"
+}
+
+do_sign() {
+	_kernel="$1"
+	if [ ! -f "$_kernel" ]; then
+		msg "$_kernel not found"
+		return 1
+	fi
+	# Ignore efi file signed with this key
+	if usr/bin/sbverify -c "$ROOTDIR/$EFI_CERT_FILE" "$_kernel" >/dev/null 2>&1; then
+		return 0
+	fi
+	if ! usr/bin/sbsign ${EFI_SIGN_ENGINE:+"--engine=$EFI_SIGN_ENGINE"} \
+		-k "$ROOTDIR/$EFI_KEY_FILE" -c "$ROOTDIR/$EFI_CERT_FILE" \
+		"$_kernel"
+	then
+		msg "failed to sign $_kernel"
+		return 1
+	fi
+	if ! usr/bin/sbverify -c "$ROOTDIR/$EFI_CERT_FILE" "$_kernel.signed"; then
+		msg "failed to verify the signature"
+		return 1
+	fi
+
+	if [ "x${EFI_KEEP_UNSIGNED}" = "x1" ]; then
+		mv -f "$_kernel" "$_kernel.unsigned"
+	fi
+	mv -f "$_kernel.signed" "$_kernel"
 }
 
 . "${ROOTDIR}/etc/default/sbsigntool-kernel-hook"
@@ -17,38 +45,18 @@ if [ "x${SBSIGN_EFI_KERNEL}" != x1 ]; then
 	exit 0
 fi
 
-if [ ! -f "${EFI_KEY_FILE}" ] || [ ! -f "${EFI_CERT_FILE}" ]; then
+if [ ! -f "$ROOTDIR/$EFI_KEY_FILE" ] || [ ! -f "$ROOTDIR/$EFI_CERT_FILE" ]; then
 	msg "key and/or certificate is not available"
 	exit 1
 fi
 
-key_stat=$(stat --dereference --format="%a %u" "${EFI_KEY_FILE}")
-
-# check if go=00 owner=0
-if [ "${key_stat}" = "${key_stat%00 0}" ]; then
-	msg "Please  chown root:root '${EFI_KEY_FILE}'"
-	msg "and     chmod go-rwx '${EFI_KEY_FILE}'"
+# All POSIX comformance ls should work
+if ! ls -Ll "$ROOTDIR/$EFI_KEY_FILE" "$ROOTDIR/$EFI_CERT_FILE" |
+	awk '$1 !~ /^-...------$/ || $3 != "root" { exit 1 }'
+then
+	msg "$EFI_KEY_FILE and $EFI_CERT_FILE must be owned by root."
+	msg "and not readable by other users."
 	exit 1
 fi
 
-# this part is completely untested
-options=""
-if [ "x${EFI_SIGN_ENGINE}" != x ]; then
-	options="--engine=${EFI_SIGN_ENGINE}"
-fi
-
-if ! sbsign $options -k "${EFI_KEY_FILE}" -c "${EFI_CERT_FILE}" \
-	"/boot/vmlinuz-${VERSION}"; then
-	msg "failed to sign kernel"
-	exit 1
-fi
-
-if ! sbverify -c "${EFI_CERT_FILE}" "/boot/vmlinuz-${VERSION}.signed"; then
-	msg "failed to verify the signature"
-	exit 1
-fi
-
-if [ "x${EFI_KEEP_UNSIGNED}" = "x1" ]; then
-	mv -f "/boot/vmlinuz-${VERSION}" "/boot/vmlinuz-${VERSION}.unsigned"
-fi
-mv -f "/boot/vmlinuz-${VERSION}.signed" "/boot/vmlinuz-${VERSION}"
+do_sign "boot/vmlinuz-$VERSION"

--- a/srcpkgs/sbsigntool/files/kernel.d/sbsigntool.post-remove
+++ b/srcpkgs/sbsigntool/files/kernel.d/sbsigntool.post-remove
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Kernel hook for sbsigntool.
+#
+# Arguments passed to this script: $1 pkgname, $2 version.
+#
+
+PKGNAME="$1"
+VERSION="$2"
+
+if [ -f "boot/vmlinuz-$VERSION.unsigned" ]; then
+	rm -f "boot/vmlinuz-${VERSION}.unsigned"
+fi

--- a/srcpkgs/sbsigntool/template
+++ b/srcpkgs/sbsigntool/template
@@ -1,7 +1,7 @@
 # Template file for 'sbsigntool'
 pkgname=sbsigntool
 version=0.9.4
-revision=2
+revision=3
 archs="x86_64* i686* aarch64* arm*"
 wrksrc=sbsigntools-$version
 build_style=gnu-configure
@@ -59,4 +59,6 @@ post_install() {
 	# and I'm not sure about their interaction
 	vinstall ${FILESDIR}/kernel.d/sbsigntool.post-install 744 \
 		etc/kernel.d/post-install 40-sbsigntool
+	vinstall ${FILESDIR}/kernel.d/sbsigntool.post-remove 744 \
+		etc/kernel.d/post-remove 40-sbsigntool
 }


### PR DESCRIPTION
Motivated by a breakage in the `dracut` removal hook as called from `vkpurge`, I cleaned up several packages that install kernel hooks to try to make their behavior more consistent. The XBPS trigger runs hooks from the target root directory with `ROOTDIR` set, so hooks should accommodate this if possible. `vkpurge` now changes to `/` and sets `ROOTDIR` to make sure any hooks it calls work as expected. It would be good to verify correct operation of all hooks after these changes, but `dkms` and `dracut` seem to be the most critical.

- [x] base-files
- [x] dkms
- [x] dracut
- [ ] gummiboot
- [ ] mkinitcpio
- [x] refind
- [x] sbsigntool

**Note 1**: `dracut` now uses `--sysroot .` to (hopefully) operate properly in a relative environment.

**Note 2**: `dkms` makes a lot of assumptions about running in the system root that are trickier to override, and the hook already made a lot of absolute path references, so I went all-in on absolute paths in the `dkms` hooks.

Affected maintainers: @Gottox @q66 @thypon @sgn
General interest: @ericonr @duncaen