### PR TITLE
tllist: update to 1.0.2.

### DIFF
--- a/srcpkgs/tllist/template
+++ b/srcpkgs/tllist/template
@@ -1,6 +1,6 @@
 # Template file for 'tllist'
 pkgname=tllist
-version=1.0.1
+version=1.0.2
 revision=1
 wrksrc=$pkgname
 build_style=meson
@@ -9,9 +9,9 @@ maintainer="Isaac Freund <ifreund@ifreund.xyz>"
 license="MIT"
 homepage="https://codeberg.org/dnkl/tllist"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=baa94259ee6a8cc9114cf59cf58395a7f6537d36909e8bed036f0da7457b6a0e
+checksum=8fe933e4614aed35aa6dfb6ab3105b2c2d6eb80a75bd3e93d4445ce6efd3dba0
 
 post_install() {
 	vlicense LICENSE
-	vdoc README.md
+	rm ${DESTDIR}/usr/share/doc/${pkgname}/LICENSE
 }


### PR DESCRIPTION
No code actually changed so no need for any rebuilds. Just a fix for the
license year and some changes in what meson installs.