### PR TITLE
julia: update to 1.5.0.

### DIFF
--- a/srcpkgs/julia/patches/36697.diff
+++ b/srcpkgs/julia/patches/36697.diff
@@ -1,0 +1,104 @@
+This patch was taken from <https://github.com/JuliaLang/julia/pull/36697>
+to workaround julia 1.5.0 not building correctly with musl libc.
+
+diff --git Make.inc Make.inc
+index e91461514463..21a0299318b5 100644
+--- Make.inc
++++ Make.inc
+@@ -940,17 +940,17 @@ LIBUNWIND:=
+ else
+ ifeq ($(USE_SYSTEM_LIBUNWIND), 1)
+ ifneq ($(OS),Darwin)
+-LIBUNWIND:=-lunwind-generic -lunwind
++LIBUNWIND:=-lunwind
+ # Only for linux since we want to use not yet released libunwind features
+ JCFLAGS+=-DSYSTEM_LIBUNWIND
+ JCPPFLAGS+=-DSYSTEM_LIBUNWIND
+ endif
+ else
+ ifeq ($(OS),Darwin)
+-LIBUNWIND:=$(build_libdir)/libosxunwind.a
++LIBUNWIND:=-losxunwind
+ JCPPFLAGS+=-DLIBOSXUNWIND
+ else
+-LIBUNWIND:=$(build_libdir)/libunwind-generic.a $(build_libdir)/libunwind.a
++LIBUNWIND:=-lunwind
+ endif
+ endif
+ endif
+@@ -1206,12 +1206,12 @@ OSLIBS += -lelf -lkvm -lrt -lpthread
+ OSLIBS += -lgcc_s
+ 
+ OSLIBS += -Wl,--export-dynamic -Wl,--version-script=$(JULIAHOME)/src/julia.expmap \
+-	$(NO_WHOLE_ARCHIVE) $(LIBUNWIND)
++	$(NO_WHOLE_ARCHIVE)
+ endif
+ 
+ ifeq ($(OS), Darwin)
+ SHLIB_EXT := dylib
+-OSLIBS += -framework CoreFoundation $(LIBUNWIND)
++OSLIBS += -framework CoreFoundation
+ WHOLE_ARCHIVE := -Xlinker -all_load
+ NO_WHOLE_ARCHIVE :=
+ JLDFLAGS :=
+diff --git Makefile Makefile
+index 96f58b9aec4e..23d1bd5208f7 100644
+--- Makefile
++++ Makefile
+@@ -181,6 +181,11 @@ endif
+ ifeq ($(USE_LLVM_SHLIB),1)
+ JL_PRIVATE_LIBS-$(USE_SYSTEM_LLVM) += libLLVM libLLVM-9jl
+ endif
++ifeq ($(OS),Darwin)
++JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBUNWIND) += libosxunwind
++else
++JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBUNWIND) += libunwind
++endif
+ 
+ ifeq ($(USE_SYSTEM_LIBM),0)
+ JL_PRIVATE_LIBS-$(USE_SYSTEM_OPENLIBM) += libopenlibm
+diff --git deps/Makefile deps/Makefile
+index e6a975ba1873..90e231f30e85 100644
+--- deps/Makefile
++++ deps/Makefile
+@@ -157,7 +157,11 @@ ifneq ($(OS), WINNT)
+ DEP_LIBS += libwhich
+ endif
+ 
+-DEP_LIBS_STAGED := $(filter-out suitesparse-wrapper osxunwind,$(DEP_LIBS)) # unlist targets that have not been converted to use the staged-install
++# unlist targets that have not been converted to use the staged-install
++DEP_LIBS_STAGED := $(filter-out suitesparse-wrapper,$(DEP_LIBS))
++ifneq ($(USE_BINARYBUILDER_LIBUNWIND),1)
++DEP_LIBS_STAGED := $(filter-out osxunwind,$(DEP_LIBS))
++endif
+ 
+ 
+ ## Common build target prefixes
+diff --git deps/unwind.mk deps/unwind.mk
+index f44917c28981..08d8990a720e 100644
+--- deps/unwind.mk
++++ deps/unwind.mk
+@@ -109,7 +109,7 @@ UNWIND_BB_NAME := LibUnwind.v$(UNWIND_VER)
+ 
+ $(eval $(call bb-install,unwind,UNWIND,false))
+ 
+-OSXUNWIND_BB_URL_BASE := https://github.com/JuliaPackaging/Yggdrasil/releases/download/LibOSXUnwind-$(OSXUNWIND_VER)-$(OSXUNWIND_BB_REL)
++OSXUNWIND_BB_URL_BASE := https://github.com/JuliaBinaryWrappers/LibOSXUnwind_jll.jl/releases/download/LibOSXUnwind-v$(OSXUNWIND_VER)+$(OSXUNWIND_BB_REL)
+ OSXUNWIND_BB_NAME := LibOSXUnwind.v$(OSXUNWIND_VER)
+ 
+ $(eval $(call bb-install,osxunwind,OSXUNWIND,false))
+diff --git src/Makefile src/Makefile
+index 3153c0178d0a..7d8db3740209 100644
+--- src/Makefile
++++ src/Makefile
+@@ -120,7 +120,7 @@ CLANG_LDFLAGS += -Wl,-undefined,dynamic_lookup
+ endif
+ 
+ 
+-COMMON_LIBS := -L$(build_shlibdir) -L$(build_libdir) $(LIBUV) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(LLVMLINK) $(OSLIBS) $(LIBUNWIND)
++COMMON_LIBS := -L$(build_shlibdir) -L$(build_libdir) $(LIBUV) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(LIBUNWIND) $(LLVMLINK) $(OSLIBS)
+ DEBUG_LIBS := $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp-debug.a $(WHOLE_ARCHIVE) $(BUILDDIR)/support/libsupport-debug.a $(COMMON_LIBS)
+ RELEASE_LIBS := $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp.a $(WHOLE_ARCHIVE) $(BUILDDIR)/support/libsupport.a $(COMMON_LIBS)
+ 
+
+

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -5,22 +5,20 @@ revision=1
 archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
- USE_BINARYBUILDER=0 USE_SYSTEM_LIBM=0 USE_SYSTEM_DSFMT=0
- USE_SYSTEM_LIBUV=0 USE_SYSTEM_SUITESPARSE=0
- USE_SYSTEM_LLVM=1 USE_SYSTEM_LIBUNWIND=1 USE_SYSTEM_PCRE=1
- USE_SYSTEM_GMP=1 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_MPFR=1
- USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_CURL=1
- USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1
- USE_SYSTEM_BLAS=1 USE_SYSTEM_LAPACK=1 USE_SYSTEM_UTF8PROC=1
+ USE_BINARYBUILDER=0 USE_SYSTEM_LIBM=0 USE_SYSTEM_DSFMT=0 USE_SYSTEM_LIBUV=0
+ USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_BLAS=0 USE_SYSTEM_LAPACK=0
+ USE_SYSTEM_LIBUNWIND=1 USE_SYSTEM_PCRE=1 USE_SYSTEM_GMP=1 USE_SYSTEM_PATCHELF=1
+ USE_SYSTEM_MPFR=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_CURL=1
+ USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_UTF8PROC=1
  UTF8PROC_INC='${XBPS_CROSS_BASE}/usr/include/libutf8proc'"
 make_install_args="$make_build_args"
 make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
-hostmakedepends="perl cmake python gcc-fortran patchelf which tar xz"
-makedepends="llvm10 p7zip pcre2-devel mpfr-devel libgit2-devel
- libcurl-devel libssh2-devel mbedtls-devel libatomic-devel zlib-devel
- libunwind-devel libutf8proc-devel blas-devel lapack-devel"
+hostmakedepends="pkg-config perl cmake python gcc-fortran patchelf which tar xz"
+makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel
+ libssh2-devel mbedtls-devel libatomic-devel zlib-devel libunwind-devel
+ libutf8proc-devel"
 # Julia provides vendored symlinks in /usr/lib/julia pointing to these libraries,
 # but none of the julia executables link to them so these deps can't be detected
 depends="libgit2 libcurl mpfr mbedtls libpcre2 libssh2"
@@ -39,7 +37,7 @@ i686*)
 	export CXXFLAGS="-march=pentium4"
 	export LDFLAGS="-Wl,--no-keep-memory"
 
-	make_build_args+=" MARCH=pentium4"
+	make_build_args+=" MARCH=pentium4 OPENBLAS_USE_THREAD=0"
 	;;
 x86_64*)
 	export M="x86-64"
@@ -70,6 +68,13 @@ post_extract() {
 
 post_install() {
 	vlicense LICENSE.md
+
+	# julia needlessly copies system libraries into a vendor directory
+	local _lib
+	for _lib in libgcc_s.so.1 libgfortran.so.5 libquadmath.so.0; do
+		rm -f "${DESTDIR}/usr/lib/julia/${_lib}"
+		ln -s "/usr/lib/${_lib}" "${DESTDIR}/usr/lib/julia"
+	done
 }
 
 julia-devel_package() {

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -6,7 +6,7 @@ archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_BINARYBUILDER=0 USE_SYSTEM_LIBM=0 USE_SYSTEM_DSFMT=0 USE_SYSTEM_LIBUV=0
- USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_BLAS=0 USE_SYSTEM_LAPACK=0
+ USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_LLVM=1 USE_SYSTEM_BLAS=0 USE_SYSTEM_LAPACK=0
  USE_SYSTEM_LIBUNWIND=1 USE_SYSTEM_PCRE=1 USE_SYSTEM_GMP=1 USE_SYSTEM_PATCHELF=1
  USE_SYSTEM_MPFR=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_CURL=1
  USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_UTF8PROC=1
@@ -18,7 +18,7 @@ conf_files="/etc/julia/startup.jl"
 hostmakedepends="pkg-config perl cmake python gcc-fortran patchelf which tar xz"
 makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel
  libssh2-devel mbedtls-devel libatomic-devel zlib-devel libunwind-devel
- libutf8proc-devel"
+ libutf8proc-devel llvm10"
 # Julia provides vendored symlinks in /usr/lib/julia pointing to these libraries,
 # but none of the julia executables link to them so these deps can't be detected
 depends="libgit2 libcurl mpfr mbedtls libpcre2 libssh2 p7zip"

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -2,66 +2,64 @@
 pkgname=julia
 version=1.5.0
 revision=1
-archs="i686* x86_64* armv7l aarch64"
+archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
- USE_LLVM_SHLIB=1 USE_BINARYBUILDER=0
- USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBUNWIND=0 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_LIBM=0
- USE_SYSTEM_DSFMT=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=0
- USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
- USE_SYSTEM_CURL=1 USE_SYSTEM_MPFR=1 USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_UTF8PROC=0
- USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LAPACK=0"
+ USE_BINARYBUILDER=0 USE_SYSTEM_LIBM=0 USE_SYSTEM_DSFMT=0
+ USE_SYSTEM_LIBUV=0 USE_SYSTEM_SUITESPARSE=0
+ USE_SYSTEM_LLVM=1 USE_SYSTEM_LIBUNWIND=1 USE_SYSTEM_PCRE=1
+ USE_SYSTEM_GMP=1 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_MPFR=1
+ USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_CURL=1
+ USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1
+ USE_SYSTEM_BLAS=1 USE_SYSTEM_LAPACK=1 USE_SYSTEM_UTF8PROC=1
+ UTF8PROC_INC='${XBPS_CROSS_BASE}/usr/include/libutf8proc'"
 make_install_args="$make_build_args"
 make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
 hostmakedepends="perl cmake python gcc-fortran patchelf which tar xz"
-makedepends="pcre2-devel gmp-devel libgit2-devel mpfr-devel libcurl-devel
- libssh2-devel mbedtls-devel libatomic-devel zlib-devel p7zip"
-depends="pcre2 gmp libgit2 mpfr libcurl libssh2 mbedtls libatomic zlib p7zip libstdc++"
+makedepends="llvm10 p7zip pcre2-devel mpfr-devel libgit2-devel
+ libcurl-devel libssh2-devel mbedtls-devel libatomic-devel zlib-devel
+ libunwind-devel libutf8proc-devel blas-devel lapack-devel"
+# Julia provides vendored symlinks in /usr/lib/julia pointing to these libraries,
+# but none of the julia executables link to them so these deps can't be detected
+depends="libgit2 libcurl mpfr mbedtls libpcre2 libssh2"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
 checksum=4a6ffadc8dd04ca0b7fdef6ae203d0af38185e57b78f7c0b972c4707354a6d1b
-nocross=yes
-noverifyrdeps="Julia vendors in libllvm, libgcc, libgfortran and libquadmath"
-
-case "$XBPS_TARGET_MACHINE" in
-*-musl)
-	depends+=" musl"
-	;;
-*)
-	depends+=" glibc"
-	;;
-esac
+nocross="build system is a mess"
 
 case "$XBPS_TARGET_MACHINE" in
 i686*)
 	export M="pentium4"
 	export CFLAGS="-march=pentium4"
 	export CXXFLAGS="-march=pentium4"
-	export LDFLAGS+=" -Wl,--no-keep-memory"
+	export LDFLAGS="-Wl,--no-keep-memory"
+
 	make_build_args+=" MARCH=pentium4"
-	make_build_args+=" OPENBLAS_USE_THREAD=0"
 	;;
 x86_64*)
 	export M="x86-64"
 	export CFLAGS="-march=x86-64"
 	export CXXFLAGS="-march=x86-64"
+
 	make_build_args+=" MARCH=x86-64"
 	;;
 armv7l*)
 	export M="armv7-a"
 	export CFLAGS="-march=armv7-a"
 	export CXXFLAGS="-march=armv7-a"
+
 	make_build_args+=" MARCH=armv7-a"
 	;;
 aarch64*)
 	export M="armv8-a"
 	export CFLAGS="-march=armv8-a"
 	export CXXFLAGS="-march=armv8-a"
+
 	make_build_args+=" MARCH=armv8-a"
 	;;
 esac

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -2,7 +2,7 @@
 pkgname=julia
 version=1.5.0
 revision=1
-archs="i686* x86_64*"
+archs="i686* x86_64* armv7l aarch64"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_LLVM_SHLIB=1 USE_BINARYBUILDER=0
@@ -31,17 +31,6 @@ noverifyrdeps="Julia vendors in libllvm, libgcc, libgfortran and libquadmath"
 case "$XBPS_TARGET_MACHINE" in
 *-musl)
 	depends+=" musl"
-	broken="fails to compile internal LLVM"
-	;;
-i686-musl)
-	makedepends+=" libexecinfo-devel"
-	depends+=" libexecinfo"
-	LDFLAGS="-lexecinfo -lc"
-	;;
-x86_64-musl)
-	makedepends+=" libexecinfo-devel"
-	depends+=" libexecinfo"
-	LDFLAGS="-lexecinfo"
 	;;
 *)
 	depends+=" glibc"
@@ -62,6 +51,18 @@ x86_64*)
 	export CFLAGS="-march=x86-64"
 	export CXXFLAGS="-march=x86-64"
 	make_build_args+=" MARCH=x86-64"
+	;;
+armv7l*)
+	export M="armv7-a"
+	export CFLAGS="-march=armv7-a"
+	export CXXFLAGS="-march=armv7-a"
+	make_build_args+=" MARCH=armv7-a"
+	;;
+aarch64*)
+	export M="armv8-a"
+	export CFLAGS="-march=armv8-a"
+	export CXXFLAGS="-march=armv8-a"
+	make_build_args+=" MARCH=armv8-a"
 	;;
 esac
 

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -21,7 +21,7 @@ makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel
  libutf8proc-devel"
 # Julia provides vendored symlinks in /usr/lib/julia pointing to these libraries,
 # but none of the julia executables link to them so these deps can't be detected
-depends="libgit2 libcurl mpfr mbedtls libpcre2 libssh2"
+depends="libgit2 libcurl mpfr mbedtls libpcre2 libssh2 p7zip"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,6 +1,6 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.4.2
+version=1.5.0
 revision=1
 archs="i686* x86_64*"
 build_style=gnu-makefile
@@ -8,7 +8,7 @@ make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_LLVM_SHLIB=1 USE_BINARYBUILDER=0
  USE_SYSTEM_LIBUV=0 USE_SYSTEM_LIBUNWIND=0 USE_SYSTEM_PATCHELF=1 USE_SYSTEM_LIBM=0
  USE_SYSTEM_DSFMT=0 USE_SYSTEM_LLVM=0 USE_SYSTEM_PCRE=1 USE_SYSTEM_BLAS=0
- USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=0 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
+ USE_SYSTEM_GMP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1
  USE_SYSTEM_CURL=1 USE_SYSTEM_MPFR=1 USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_UTF8PROC=0
  USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LAPACK=0"
 make_install_args="$make_build_args"
@@ -16,21 +16,21 @@ make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
 hostmakedepends="perl cmake python gcc-fortran patchelf which tar xz"
-makedepends="pcre2-devel gmp-devel mpfr-devel libcurl-devel
+makedepends="pcre2-devel gmp-devel libgit2-devel mpfr-devel libcurl-devel
  libssh2-devel mbedtls-devel libatomic-devel zlib-devel p7zip"
-depends="pcre2 gmp mpfr libcurl libssh2 mbedtls libatomic zlib p7zip"
+depends="pcre2 gmp libgit2 mpfr libcurl libssh2 mbedtls libatomic zlib p7zip libstdc++"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=948c70801d5cce81eeb7f764b51b4bfbb2dc0b1b9effc2cb9fc8f8cf6c90a334
+checksum=4a6ffadc8dd04ca0b7fdef6ae203d0af38185e57b78f7c0b972c4707354a6d1b
 nocross=yes
-# Falsely detects dependency on libllvm
-skiprdeps="/usr/lib/libjulia.so.1.4 /usr/lib/julia/libllvmcalltest.so"
+noverifyrdeps="Julia vendors in libllvm, libgcc, libgfortran and libquadmath"
 
 case "$XBPS_TARGET_MACHINE" in
 *-musl)
+	depends+=" musl"
 	broken="fails to compile internal LLVM"
 	;;
 i686-musl)
@@ -42,6 +42,9 @@ x86_64-musl)
 	makedepends+=" libexecinfo-devel"
 	depends+=" libexecinfo"
 	LDFLAGS="-lexecinfo"
+	;;
+*)
+	depends+=" glibc"
 	;;
 esac
 


### PR DESCRIPTION
The issues from <https://github.com/void-linux/void-packages/issues/21960> have been resolved, so system libgit2 is used instead of vendoring in dependency.

Switching from using skiprdeps to noverifyrdeps so that dependency
isn't falsely detected on libraries julia vendors
<https://github.com/void-linux/void-packages/issues/23997#issuecomment-667626936>.

[ci skip] because llvm takes too long to build.

Builds fine on my x86_64 glibc machine, and in principle we should be able to build julia on other supported architectures (armv7, aarch64, and x86_64-musl), but I don't have void installs to test that on.

EDIT: I successfully built in a x86_64-musl hostdir/masterdir using the current template.