### PR TITLE
go: update to 1.14.7.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.14.6
+version=1.14.7
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=73fc9d781815d411928eccb92bf20d5b4264797be69410eac854babe44c94c09
+checksum=064392433563660c73186991c0a315787688e7c38a561e26647686f89b6c30e3
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
This is a security release for CVE-2020-16845
(<https://golang.org/issue/40618>).