### PR TITLE
i3lock-color: update to 2.12.c.5

### DIFF
--- a/srcpkgs/i3lock-color/template
+++ b/srcpkgs/i3lock-color/template
@@ -1,8 +1,7 @@
 # Template file for 'i3lock-color'
 pkgname=i3lock-color
-version=2.12
-revision=2
-wrksrc="${pkgname}-${version}.c"
+version=2.12.c.5
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config automake"
 makedepends="libev-devel cairo-devel pam-devel libxkbcommon-devel xcb-util-devel
@@ -10,9 +9,9 @@ makedepends="libev-devel cairo-devel pam-devel libxkbcommon-devel xcb-util-devel
 short_desc="Screenlocker forked from i3lock with more features"
 maintainer="jtalowell <jtalowell@protonmail.com>"
 license="MIT"
-homepage="https://github.com/PandorasFox/i3lock-color"
-distfiles="https://github.com/PandorasFox/i3lock-color/archive/${version}.c.tar.gz"
-checksum=c2ba4cfa51fee3fd2cab439805d213d8614407d93cf8eecbd4e6fa5cb4c9b7a3
+homepage="https://github.com/Raymo111/i3lock-color"
+distfiles="https://github.com/Raymo111/i3lock-color/archive/${version}.tar.gz"
+checksum=62c9bdff2759186426b184ed45e4c1aae1dc3c582499d94da68d9b08662a96a9
 conf_files="/etc/pam.d/i3lock"
 conflicts="i3lock"
 


### PR DESCRIPTION
Updates `i3lock-color` to allow for 4-byte rgba colors and more features.

The maintainer of i3lock-color has also been changed to Raymo111, so the appropriate change has been reflected in the revised template file.

(Disclaimer: I'm still a little new to xbps templates, gently let me know if I did something wrong :))