### PR TITLE
salt: to 3001.1; python{,3}-pycryptodomex: new package

### DIFF
--- a/srcpkgs/python3-pycryptodomex/template
+++ b/srcpkgs/python3-pycryptodomex/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-pycryptodomex'
+pkgname=python3-pycryptodomex
+version=3.9.8
+revision=1
+wrksrc="pycryptodomex-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel"
+short_desc="Pycryptodome equivalent that installs to \`Cryptodome\` module"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="Public Domain, BSD-2-Clause"
+homepage="https://www.pycryptodome.org/"
+changelog="https://raw.githubusercontent.com/Legrandin/pycryptodome/master/Changelog.rst"
+distfiles="${PYPI_SITE}/p/pycryptodomex/pycryptodomex-${version}.tar.gz"
+checksum=48cc2cfc251f04a6142badeb666d1ff49ca6fdfc303fd72579f62b768aaa52b9
+
+post_install() {
+	vlicense LICENSE.rst
+}

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,21 +1,20 @@
 # Template file for 'salt'
 pkgname=salt
-version=3000.2
+version=3001.1
 revision=1
 archs=noarch
-build_style=python2-module
-pycompile_module="salt"
-hostmakedepends="python-devel python-setuptools"
-depends="python-yaml python-Jinja2 python-requests python-pyzmq
- python-M2Crypto python-tornado python-msgpack dmidecode pciutils
- python-psutil"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-yaml python3-Jinja2 python3-requests python3-pyzmq
+ python3-M2Crypto python3-tornado python3-msgpack dmidecode pciutils
+ python3-psutil python3-distro python3-pycryptodomex"
 short_desc="Remote execution system, and configuration manager"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="Apache-2.0"
 homepage="http://saltstack.org/"
 changelog="https://docs.saltstack.com/en/latest/topics/releases/${version}.html"
 distfiles="${PYPI_SITE}/s/salt/salt-${version}.tar.gz"
-checksum=0e33429d094a6109dfed955c4b1c638baee9641eca2f7609bbc4adad21c620d9
+checksum=e9ebb4d92fae8dabf21b8749dc126e4a4048bf8f613f5b1b851fe4b8226b5abc
 conf_files="
  /etc/salt/cloud.providers.d/digitalocean.conf
  /etc/salt/cloud.providers.d/vsphere.conf


### PR DESCRIPTION
@Vaelatern 

With saltstack/salt#55310 wrapped up, I figured I'd take a stab at updating our `salt` package. This _should_ also obsolete saltstack/salt#56551.

```
[ag@server~]# salt-master -V
Salt Version:
           Salt: 3001.1

Dependency Versions:
           cffi: 1.14.0
       cherrypy: Not Installed
       dateutil: Not Installed
      docker-py: 4.2.0
          gitdb: Not Installed
      gitpython: Not Installed
         Jinja2: 2.10.1
        libgit2: Not Installed
       M2Crypto: 0.35.2
           Mako: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 1.0.0
   mysql-python: Not Installed
      pycparser: 2.19
       pycrypto: Not Installed
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 3.8.4 (default, Jul 17 2020, 11:12:18)
   python-gnupg: Not Installed
         PyYAML: 5.3
          PyZMQ: 19.0.2
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.5.3
            ZMQ: 4.3.2

System Versions:
           dist: void rolling void
         locale: utf-8
        machine: x86_64
        release: 5.7.10_1
         system: Linux
        version: void rolling void
```