### PR TITLE
xen-hypervisor: fix install into /boot/boot

### DIFF
--- a/srcpkgs/xen/template
+++ b/srcpkgs/xen/template
@@ -1,7 +1,7 @@
 # Template file for 'xen'
 pkgname=xen
 version=4.10.4
-revision=3
+revision=4
 # grep -R IPXE_GIT_TAG src/xen-*/tools/firmware/etherboot
 _git_tag_ipxe=356f6c1b64d7a97746d1816cef8ca22bdd8d0b5d
 archs="x86_64*"
@@ -201,7 +201,7 @@ xen-hypervisor_package() {
 	short_desc="Xen Hypervisor"
 	nostrip_files="xen-syms-${version}"
 	pkg_install() {
-		vmove boot
+		vmove "boot/*"
 		vmove usr/lib/efi
 	}
 }


### PR DESCRIPTION
fix #17612
`[ci skip]` due to [exceeding](https://travis-ci.org/github/ashpooljh/void-packages/jobs/716090891#L29182) the maximum log length allowed by Travis.