### PR TITLE
xen: use makejobs in make install

### DIFF
--- a/srcpkgs/xen/template
+++ b/srcpkgs/xen/template
@@ -145,7 +145,7 @@ do_build() {
 do_install() {
 	rm -f ${XBPS_WRAPPERDIR}/strip
 	unset CC LD AR AS RANLIB CPP CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	make DESTDIR=${DESTDIR} NO_WERROR=1 install install-docs
+	make ${makejobs} DESTDIR=${DESTDIR} NO_WERROR=1 install install-docs
 
 	# Move example config files into correct directory.
 	vmkdir usr/share/examples/xen


### PR DESCRIPTION
It compiles something during `make install`, so use `${makejobs}` to allow speeding it up.