### PR TITLE
liburing: update to 0.7.0.

### DIFF
--- a/srcpkgs/liburing/template
+++ b/srcpkgs/liburing/template
@@ -1,16 +1,15 @@
 # Template file for 'liburing'
 pkgname=liburing
-version=0.2
+version=0.7
 revision=1
-archs="i686* x86_64* aarch64*"
 build_style=configure
 configure_args="--mandir=/usr/share/man"
 short_desc="Linux-native io_uring I/O access library"
 maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
 license="LGPL-2.1-only"
-homepage="http://git.kernel.dk/cgit/liburing/"
-distfiles="${homepage}/snapshot/${pkgname}-${version}.tar.xz"
-checksum=9e971105a376dc71feb76efe3e2a708e7da28b662edca77f8d230f000debde01
+homepage="http://git.kernel.dk/cgit/liburing"
+distfiles="${homepage}/snapshot/${pkgname}-${version}.tar.gz"
+checksum=05d0cf8493d573c76b11abfcf34aabc7153affebe17ff95f9ae88b0de062a59d
 
 liburing-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Add test target (currently broken), remove arch restrictions.

Closes #17702.