### PR TITLE
common/shlibs: add libHLSL.so

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3533,6 +3533,7 @@ libbelcard.so.1 belcard-1.0.2_1
 libshaderc_shared.so.1 shaderc-2018.0_1
 libglslang.so glslang-6.2.2596_1
 libSPIRV.so glslang-6.2.2596_1
+libHLSL.so glslang-8.13.3743_1
 libmaxminddb.so.0 libmaxminddb-1.3.2_1
 libmysqlpp.so.3 mysql++-3.2.5_1
 libKF5Syndication.so.5 syndication-5.50.0_1


### PR DESCRIPTION
glslang provides libHLSL.so but it's not in common/shlibs. It's needed by the retroarch package when building it with system glslang instead of the bundled version.