### PR TITLE
retroarch: update to 1.9.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3533,6 +3533,7 @@ libbelr.so.1 belr-0.1.3_1
 libbelcard.so.1 belcard-1.0.2_1
 libshaderc_shared.so.1 shaderc-2018.0_1
 libglslang.so glslang-6.2.2596_1
+libHLSL.so glslang-8.13.3743_1
 libSPIRV.so glslang-6.2.2596_1
 libmaxminddb.so.0 libmaxminddb-1.3.2_1
 libmysqlpp.so.3 mysql++-3.2.5_1

--- a/srcpkgs/retroarch/patches/conflicting-types.patch
+++ b/srcpkgs/retroarch/patches/conflicting-types.patch
@@ -1,0 +1,16 @@
+This patch has been merged upstream and shouldn't be needed for 1.9.1:
+https://github.com/libretro/RetroArch/pull/11171
+
+diff --git a/gfx/drivers_context/vc_egl_ctx.c b/gfx/drivers_context/vc_egl_ctx.c
+index 3c52edb96a..dba0e038f4 100644
+--- gfx/drivers_context/vc_egl_ctx.c
++++ gfx/drivers_context/vc_egl_ctx.c
+@@ -81,6 +81,8 @@ typedef struct
+ /* TODO/FIXME - static globals */
+ static enum gfx_ctx_api vc_api = GFX_CTX_NONE;
+ 
++static bool gfx_ctx_vc_bind_api(void *, enum gfx_ctx_api, unsigned, unsigned);
++
+ static INLINE bool gfx_ctx_vc_egl_query_extension(vc_ctx_data_t *vc, const char *ext)
+ {
+    const char *str = (const char*)eglQueryString(vc->egl.dpy, EGL_EXTENSIONS);

--- a/srcpkgs/retroarch/patches/musl-time_h.patch
+++ b/srcpkgs/retroarch/patches/musl-time_h.patch
@@ -1,0 +1,15 @@
+This patch has been merged upstream and shouldn't be needed for 1.9.1:
+https://github.com/libretro/RetroArch/pull/11170
+
+diff --git a/libretro-common/file/nbio/nbio_linux.c b/libretro-common/file/nbio/nbio_linux.c
+index 70e3a98..0c2d857 100644
+--- libretro-common/file/nbio/nbio_linux.c
++++ libretro-common/file/nbio/nbio_linux.c
+@@ -36,6 +36,7 @@
+ #include <fcntl.h>
+ #include <sys/syscall.h>
+ #include <linux/aio_abi.h>
++#include <time.h>
+ 
+ struct nbio_linux_t
+ {

--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,57 +1,96 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.8.4
+version=1.9.0
 revision=1
 wrksrc="RetroArch-$version"
 build_style=configure
-configure_args="--prefix=/usr --sysconfdir=/etc --enable-udev
- --enable-networking
- $(vopt_enable ffmpeg) $(vopt_enable jack) $(vopt_enable pulseaudio pulse)
- $(vopt_enable sdl2) $(vopt_enable x11) $(vopt_enable vulkan)"
+configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
+ --enable-udev --disable-builtinflac --disable-builtinglslang
+ --disable-builtinmbedtls --disable-builtinminiupnpc --disable-builtinzlib
+ $(vopt_enable ffmpeg) $(vopt_enable flac) $(vopt_enable glslang) $(vopt_enable jack)
+ $(vopt_enable miniupnpc) $(vopt_enable pulseaudio pulse) $(vopt_enable qt5 qt)
+ $(vopt_enable sdl2) $(vopt_enable vulkan) $(vopt_enable wayland) $(vopt_enable x11)"
 conf_files="/etc/retroarch.cfg"
-hostmakedepends="pkg-config python unzip"
-makedepends="zlib-devel libxml2-devel freetype-devel libxkbcommon-devel
- alsa-lib-devel eudev-libudev-devel $(vopt_if opengl MesaLib-devel)
- $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if jack jack-devel)
- $(vopt_if ffmpeg ffmpeg-devel) $(vopt_if sdl2 SDL2-devel)
- $(vopt_if x11 'libXext-devel libXinerama-devel libXv-devel libXxf86vm-devel')
- $(vopt_if vulkan 'vulkan-loader')
- $(vopt_if qt5 'qt5-devel')"
+hostmakedepends="pkg-config"
+makedepends="alsa-lib-devel eudev-libudev-devel freetype-devel libxkbcommon-devel
+ mbedtls-devel zlib-devel $(vopt_if ffmpeg ffmpeg-devel) $(vopt_if flac libflac-devel)
+ $(vopt_if glslang 'glslang-devel SPIRV-Tools-devel') $(vopt_if jack jack-devel)
+ $(vopt_if miniupnpc miniupnpc-devel) $(vopt_if pulseaudio pulseaudio-devel)
+ $(vopt_if qt5 qt5-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if vulkan vulkan-loader)
+ $(vopt_if x11 'libXext-devel libXinerama-devel libXv-devel libXxf86vm-devel')"
 depends="$(vopt_if vulkan 'vulkan-loader')"
 short_desc="Official reference frontend for the libretro API"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="http://www.libretro.com/"
+homepage="https://www.retroarch.com/"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=027e9eb243488da1b8532116eab2a79932fcf2dcb96bcc4be9a12b329a2a9c52
-build_options="ffmpeg opengl jack pulseaudio sdl2 x11 vulkan qt5"
+checksum=39d7ad9298c9487fb4848cd6a257c23a95ee85f83c75302f97bcc4797f154b6a
 
-build_options_default="ffmpeg"
+build_options="ffmpeg flac gles2 glslang jack miniupnpc opengl pulseaudio qt5 sdl2 vulkan wayland x11"
+build_options_default="ffmpeg flac gles2 glslang miniupnpc opengl pulseaudio sdl2 vulkan wayland x11"
 
-case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*|ppc64*|aarch64*) build_options_default+=" opengl pulseaudio sdl2 x11 vulkan";;
-	armv[67]*)
-		makedepends+=" rpi-userland-devel"
-		LDFLAGS="-L${XBPS_CROSS_BASE}/opt/vc/lib -lbcm_host"
-		;;
-esac
+desc_option_glslang="Enable support for GLSL shaders"
+desc_option_miniupnpc="Enable support for NAT traversal"
+
+if [ "$build_option_gles2" ]; then
+	configure_args+=" --enable-opengles --enable-opengles3"
+else
+	configure_args+=" --disable-opengles --disable-opengles3"
+fi
+
+if [ "$build_option_opengl" ]; then
+	if [ -z "$build_option_glslang" ]; then
+		msg_error "$pkgname: 'opengl' option requires 'glslang'.\n"
+	fi
+	configure_args+=" --enable-opengl_core"
+else
+	configure_args+=" --disable-opengl_core"
+fi
+
+if [ "$build_option_gles2" -o "$build_option_opengl" ]; then
+	configure_args+=" --enable-egl --enable-kms"
+	makedepends+=" MesaLib-devel"
+fi
+
+if [ "$build_option_qt5" ]; then
+	if [ "$CROSS_BUILD" ]; then
+		hostmakedepends+=" qt5-host-tools"
+	fi
+fi
+
+if [ "$build_option_vulkan" ]; then
+	if [ -z "$build_option_glslang" ]; then
+		msg_error "$pkgname: 'vulkan' option requires 'glslang'.\n"
+	fi
+fi
+
+if [ "$build_option_wayland" ]; then
+	if [ -z "$build_option_gles2" -a -z "$build_option_opengl" ]; then
+		msg_error "$pkgname: 'wayland' option requires 'gles2' or 'opengl'.\n"
+	fi
+	makedepends+=" wayland-devel wayland-protocols"
+	if [ "$CROSS_BUILD" ]; then
+		hostmakedepends+=" wayland-devel wayland-protocols"
+	fi
+fi
+
+if [ "$build_option_x11" ]; then
+	if [ -z "$build_option_gles2" -a -z "$build_option_opengl" ]; then
+		msg_error "$pkgname: 'x11' option requires 'gles2' or 'opengl'.\n"
+	fi
+fi
 
 do_configure() {
 	if [ "$CROSS_BUILD" ]; then
-		mkdir -p /opt/vc/lib
 		configure_args+=" --host=${XBPS_CROSS_TRIPLET}"
 	fi
 
 	case "$XBPS_TARGET_MACHINE" in
 		i686*|x86_64*) configure_args+=" --enable-sse --enable-threads";;
-		ppc64*) configure_args+=" --enable-threads";;
-		aarch64*) configure_args+=" --disable-neon";;
-		armv6*) configure_args+=" --disable-neon"
-			CFLAGS+=" -I${XBPS_CROSS_BASE}/opt/vc/include"
-			LDFLAGS+=" -L${XBPS_CROSS_BASE}/opt/vc/lib -Wl,-R /opt/vc/lib";;
-		armv7*) configure_args+=" --disable-neon --enable-threads"
-			CFLAGS+=" -I${XBPS_CROSS_BASE}/opt/vc/include"
-			LDFLAGS+=" -L${XBPS_CROSS_BASE}/opt/vc/lib -Wl,-R /opt/vc/lib";;
+		ppc*) configure_args+=" --enable-threads";;
+		aarch64*) configure_args+=" --disable-neon --enable-threads";;
+		armv7*) configure_args+=" --disable-neon --enable-threads";;
+		arm*) configure_args+=" --disable-neon";;
 	esac
 	./configure ${configure_args}
 }


### PR DESCRIPTION
- Use system flac, glslang, mbedtls, miniupnpc and zlib.
- Add `libHLSL.so` to `common/shlibs`. Needed when building with system glslang.
- Add patch for missing include on musl libc.
- Add patch for conflicting types build error.
- Add `flac`, `gles2`, `glslang`, `miniupnpc`, and `wayland` build options.
- Use common build options for all platforms.
- Remove `libxml2-devel` dependency. It was removed by upstream: https://github.com/libretro/RetroArch/pull/8486