### PR TITLE
xbps-src: fixed dangling binpkg lock on error

### DIFF
--- a/common/hooks/do-pkg/00-gen-pkg.sh
+++ b/common/hooks/do-pkg/00-gen-pkg.sh
@@ -23,6 +23,12 @@ genpkg() {
 		return 0
 	fi
 
+	# Lock binpkg
+	unlock_binpkg() {
+	    rm -f $pkgdir/${binpkg}.lock
+	}
+
+	trap unlock_binpkg ERR EXIT
 	touch -f $pkgdir/${binpkg}.lock
 
 	if [ ! -d $pkgdir ]; then
@@ -87,7 +93,9 @@ genpkg() {
 		${PKGDESTDIR}
 	rval=$?
 
+	# Unlock binpkg
 	rm -f $pkgdir/${binpkg}.lock
+	trap - ERR EXIT
 
 	if [ $rval -ne 0 ]; then
 		rm -f $pkgdir/$binpkg


### PR DESCRIPTION
Fixes #21020. 

Previously if a binpkg failed to be created due to [`xbps-create` falling over in `common/hooks/do-pkg/00-gen-pkg.sh`](https://github.com/void-linux/void-packages/blob/master/common/hooks/do-pkg/00-gen-pkg.sh#L63) it would leave a `hostdir/binpkgs/*.lock` file around.

This fix traps `ERR` and `EXIT` right before the lock file is created. If an error occurs it deletes the lock file. Right after the lock file is deleted it untraps `ERR` and `EXIT`.

There was an [`xbps-create` return value check in the source](https://github.com/void-linux/void-packages/blob/master/common/hooks/do-pkg/00-gen-pkg.sh#L88-L95). However I think the script is running with `set -e` which results in the failure of `xbps-create` exiting the process. Trapping `ERR` prevents the process from exiting.Trapping `EXIT` prevents the process from exiting if the user hits C-c during the `xbps-create` process.

**Before**  
Before these changes when a binpkg build failed due to `xbps-create` falling over it would look like so:

```
=> kernel-libc-headers-4.19.0_2: running do-pkg hook: 00-gen-pkg ...
=> Creating kernel-libc-headers-4.19.0_2.x86_64.xbps for repository /home/noah/documents/void-packages/hostdir/binpkgs ...
xbps-create: ERROR: Failed to open .xbps-pkg-XXX7c01am fd for writing: No such file or directory
[noah@ip-172-31-47-23 void-packages]$ => ERROR: kernel-libc-headers-4.19.0_2: do-pkg_00-gen-pkg: 'xbps-create ${_provides:+--provides "${_provides}"} ${_conflicts:+--conflicts "${_conflicts}"} ${_replaces:+--replaces "${_replaces}"} ${_reverts:+--reverts "${_reverts}"} ${_mutable_files:+--mutable-files "${_mutable_files}"} ${_deps:+--dependencies "${_deps}"} ${_conf_files:+--config-files "${_conf_files}"} ${PKG_BUILD_OPTIONS:+--build-options "${PKG_BUILD_OPTIONS}"} ${_gitrevs:+--source-revisions "${_gitrevs}"} ${_shprovides:+--shlib-provides "${_shprovides}"} ${_shrequires:+--shlib-requires "${_shrequires}"} ${_alternatives:+--alternatives "${_alternatives}"} ${_preserve:+--preserve} ${tags:+--tags "${tags}"} ${_changelog:+--changelog "${_changelog}"} ${XBPS_PKG_COMPTYPE:+--compression $XBPS_PKG_COMPTYPE} --architecture ${arch} --homepage "${homepage}" --license "${license}" --maintainer "${maintainer}" --desc "${desc}" --pkgver "${pkgver}" --quiet ${PKGDESTDIR}' exited with 1
=> ERROR:   in genpkg() at common/hooks/do-pkg/00-gen-pkg.sh:64
=> ERROR:   in hook() at common/hooks/do-pkg/00-gen-pkg.sh:121
=> ERROR:   in run_func() at common/xbps-src/shutils/common.sh:21
=> ERROR:   in run_pkg_hooks() at common/xbps-src/shutils/common.sh:232
=> ERROR:   in main() at common/xbps-src/libexec/xbps-src-dopkg.sh:44
```
(Note: The `xbps-create: ERROR: Failed to open .xbps-pkg-XXX...` error is not relevant, but was produced by `xbps-create` failing, how `xbps-src` handles this failure is the focus of the PR). 

When you tried to re-build any package which previously had a failed binpkg it would [spin forever trying to acquire the lock](https://github.com/void-linux/void-packages/blob/master/common/hooks/do-pkg/00-gen-pkg.sh#L15-L18):

```
./xbps-src pkg kernel-libc-headers
=> kernel-libc-headers-4.19.0_2: running do-pkg hook: 00-gen-pkg ...
=> WARNING: kernel-libc-headers-4.19.0_2: binpkg is being created, waiting for 1s...
=> WARNING: kernel-libc-headers-4.19.0_2: binpkg is being created, waiting for 1s...
=> WARNING: kernel-libc-headers-4.19.0_2: binpkg is being created, waiting for 1s...
=> WARNING: kernel-libc-headers-4.19.0_2: binpkg is being created, waiting for 1s...
...
```

**After**  

With the changes a binpkg build failing due to xbps-create appears as:

```
=> Creating kernel-libc-headers-4.19.0_2.x86_64.xbps for repository /home/noah/documents/void-packages/hostdir/binpkgs ...
xbps-create: ERROR: Failed to open .xbps-pkg-XXX316nSv fd for writing: No such file or directory
=> ERROR: Failed to created binary package: kernel-libc-headers-4.19.0_2.x86_64.xbps!
```

When you try to re-build any package with a previously failed binpkg the lock file does not exist. So the build will run normally. 