### PR TITLE
libsignal-protocol-c: change to shared library

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3981,3 +3981,4 @@ libaml.so.0 aml-0.1.0_1
 libneatvnc.so.0 neatvnc-0.2.0_1
 libtdjson.so.1.6.0 libtd-1.6.0_1
 libJudy.so.1 judy-1.0.5_1
+libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2

--- a/srcpkgs/dino/template
+++ b/srcpkgs/dino/template
@@ -1,20 +1,29 @@
 # Template file for 'dino'
 pkgname=dino
 version=0.1.0
-revision=3
+revision=4
 build_style=cmake
 configure_args="-GNinja -DDINO_PLUGIN_ENABLED_notification-sound=ON"
 make_cmd=ninja
 hostmakedepends="cmake ninja gettext unzip pkg-config vala glib-devel"
 makedepends="glib-devel qrencode-devel gtk+3-devel gpgme-devel
  libgee08-devel libgcrypt-devel libsoup-devel
- libsignal-protocol-c sqlite-devel libcanberra-devel"
+ libsignal-protocol-c-devel sqlite-devel libcanberra-devel"
 short_desc='Modern XMPP ("Jabber") Chat Client using GTK+/Vala'
 maintainer="Anjandev Momi <anjan@momi.ca>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/dino/dino"
 distfiles="https://github.com/dino/dino/archive/v${version}.tar.gz"
 checksum="202b7db322d85389b0bebc3c38976e7f7beaceddd1fc46b8123e50c6c7c07b8d"
+
+if [ "${XBPS_CHECK_PKGS}" ]; then
+	configure_args+=" -DBUILD_TESTS=ON"
+fi
+
+do_check() {
+	build/xmpp-vala-test
+	build/signal-protocol-vala-test
+}
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/include

--- a/srcpkgs/libsignal-protocol-c-devel
+++ b/srcpkgs/libsignal-protocol-c-devel
@@ -1,0 +1,1 @@
+libsignal-protocol-c

--- a/srcpkgs/libsignal-protocol-c/template
+++ b/srcpkgs/libsignal-protocol-c/template
@@ -1,9 +1,9 @@
 # Template file for 'libsignal-protocol-c'
 pkgname=libsignal-protocol-c
 version=2.3.3
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+configure_args="-DBUILD_SHARED_LIBS=ON"
 makedepends="libressl-devel"
 checkdepends="pkg-config check-devel"
 short_desc="Signal Protocol C Library"
@@ -16,3 +16,13 @@ checksum=c22e7690546e24d46210ca92dd808f17c3102e1344cd2f9a370136a96d22319d
 if [ "${XBPS_CHECK_PKGS}" ]; then
 	configure_args+=" -DBUILD_TESTING=1"
 fi
+
+libsignal-protocol-c-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/profanity/template
+++ b/srcpkgs/profanity/template
@@ -1,7 +1,7 @@
 # Template file for 'profanity'
 pkgname=profanity
 version=0.9.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="$(vopt_enable notify notifications) $(vopt_enable otr)
  $(vopt_enable pgp) $(vopt_enable python python-plugins) $(vopt_enable plugins)
@@ -12,7 +12,7 @@ makedepends="libcurl-devel libglib-devel libstrophe-devel readline-devel sqlite-
  $(vopt_if notify libnotify-devel) $(vopt_if otr 'libotr-devel libgcrypt-devel')
  $(vopt_if pgp gpgme-devel) $(vopt_if python python3-devel) $(vopt_if gtk gtk+-devel)
  $(vopt_if xscreensaver libXScrnSaver-devel)
- $(vopt_if omemo 'libsignal-protocol-c libgcrypt-devel')"
+ $(vopt_if omemo 'libsignal-protocol-c-devel libgcrypt-devel')"
 checkdepends="cmocka-devel"
 short_desc="Console based XMPP client"
 maintainer="Anthony Iliopoulos <ailiop@altatus.com>"


### PR DESCRIPTION
So things using `libsignal-protocol-c` (`profanity` and `dino`) link dynamically instead of statically.
@teldra