### PR TITLE
cross-vpkg-dummy: remove musl-legacy-compat.

### DIFF
--- a/srcpkgs/cross-vpkg-dummy/template
+++ b/srcpkgs/cross-vpkg-dummy/template
@@ -1,6 +1,6 @@
 # Template file for 'cross-vpkg-dummy'
 pkgname=cross-vpkg-dummy
-version=0.34
+version=0.35
 revision=1
 build_style=meta
 short_desc="Dummy meta-pkg for cross building packages with xbps-src"
@@ -60,8 +60,7 @@ shlib_provides="
 	libgfortran.so.5"
 
 case "$XBPS_TARGET_MACHINE" in
-*-musl) depends+=" musl-legacy-compat"
-	provides+=" musl-9999_1 musl-devel-9999_1"
+*-musl) provides+=" musl-9999_1 musl-devel-9999_1"
 	conflicts+=" musl>=0"
 	shlib_provides+=" libc.so"
 	;;


### PR DESCRIPTION
musl-legacy-compat was removed from base-chroot-musl in
75eca1b03e453d9e643b809550d5157717e46738, meaning that all templates
that depend on it had to add it as makedepends for native musl builds.
Therefore, for consistency, cross-vpkg-dummy shouldn't pull it either.

---

This template has a few stylistic issues and shouldn't pass xlint. Should I solve those?