### PR TITLE
conky: update to version 1.11.6

### DIFF
--- a/srcpkgs/conky/template
+++ b/srcpkgs/conky/template
@@ -1,7 +1,7 @@
 # Template file for 'conky'
 pkgname=conky
-version=1.11.5
-revision=3
+version=1.11.6
+revision=1
 build_style=cmake
 conf_files="/etc/conky/conky.conf /etc/conky/conky_no_x11.conf"
 configure_args="-DCMAKE_BUILD_TYPE=Release -DMAINTAINER_MODE=ON -DRELEASE=ON
@@ -18,7 +18,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause, GPL-3.0-or-later"
 homepage="https://github.com/brndnmtthws/conky"
 distfiles="https://github.com/brndnmtthws/conky/archive/v${version}.tar.gz"
-checksum=4cefdd92219a90934c28297e4ac7448a3f69d6aeec5d48c5763b23f6b214ef13
+checksum=e7c01e4910744851e05f85f0a0aab3f5068215b1af850515189ac40e7deeb26d
 
 post_install() {
 	vmkdir etc/conky


### PR DESCRIPTION
Conky version 1.11.5 has an annoying bug that displays negative RAM usage:
https://github.com/brndnmtthws/conky/issues/877

This is fixed in release 1.11.6 from 27th July 2020.

My first void contribution, hope this will do the trick ... !