### PR TITLE
xbps-triggers: silence warnings, unhelpful errors in texmf-dist

### DIFF
--- a/srcpkgs/xbps-triggers/files/texmf-dist
+++ b/srcpkgs/xbps-triggers/files/texmf-dist
@@ -16,6 +16,7 @@ UPDATE="$5"
 
 texhash=usr/bin/texhash
 fmtutil=usr/bin/fmtutil-sys
+optional_engines="luahbtex,luajithbtex,luajittex,luatex,xetex"
 
 case "$ACTION" in
 targets)
@@ -28,7 +29,8 @@ run)
 	fi
 	if [ -x ${fmtutil} ]; then
 		echo "Updating texmf-dist formats..."
-		${fmtutil} --all >/dev/null || true
+		${fmtutil} --no-error-if-no-engine="${optional_engines}" \
+			--quiet --all >/dev/null || true
 	fi
 	;;
 *)

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.115
+version=0.116
 revision=1
 archs=noarch
 bootstrap=yes


### PR DESCRIPTION
@fosslinux, please let me know if there's a compelling reason not to merge these changes. User `notreal--` on IRC has complained about [TeXLive configuration errors](https://pastebin.com/SDzvzmAM) when `texlive-minimal` is installed, and the warnings about missing inifiles spam the console.

The texmf-dist trigger produces warnings about missing inifiles that are suppressed by adding the `--quiet` command-line argument. However, this still leaves errors about missing engines when texlive package are installed without texlive-LuaTeX and texlive-XeTeX. The command-line option `--no-error-if-no-engine` is used to suppress these errors about missing optional components.