### PR TITLE
dracut: in kernel hooks, use binary from target root

### DIFF
--- a/srcpkgs/dracut/files/kernel-hook-postinst
+++ b/srcpkgs/dracut/files/kernel-hook-postinst
@@ -7,9 +7,8 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ ! -x bin/dracut ]; then
+if [ ! -x usr/bin/dracut ]; then
 	exit 0
 fi
 
-dracut -q --force boot/initramfs-${VERSION}.img ${VERSION}
-exit $?
+usr/bin/dracut -q --force boot/initramfs-${VERSION}.img ${VERSION}

--- a/srcpkgs/dracut/files/kernel-hook-postrm
+++ b/srcpkgs/dracut/files/kernel-hook-postrm
@@ -7,7 +7,4 @@
 PKGNAME="$1"
 VERSION="$2"
 
-if [ -f boot/initramfs-${VERSION}.img ]; then
-	rm -f boot/initramfs-${VERSION}.img
-fi
-exit $?
+rm -f boot/initramfs-${VERSION}.img

--- a/srcpkgs/dracut/files/kernel-uefi-hook-postinst
+++ b/srcpkgs/dracut/files/kernel-uefi-hook-postinst
@@ -12,12 +12,12 @@ if [ -z "${CREATE_UEFI_BUNDLES}" ]; then
 	exit 0
 fi
 
-if [ ! -x bin/dracut ]; then
+if [ ! -x usr/bin/dracut ]; then
 	exit 0
 fi
 
 mkdir -p ${UEFI_BUNDLE_DIR:=boot/efi/EFI/void}
 
-dracut -q --force ${KERNEL_CMDLINE:+--kernel-cmdline="${KERNEL_CMDLINE}"} ${DRACUT_OPTIONS} \
+usr/bin/dracut -q --force ${DRACUT_OPTIONS} \
+	${KERNEL_CMDLINE:+--kernel-cmdline="${KERNEL_CMDLINE}"} \
 	--uefi ${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi ${VERSION}
-exit $?

--- a/srcpkgs/dracut/files/kernel-uefi-hook-postrm
+++ b/srcpkgs/dracut/files/kernel-uefi-hook-postrm
@@ -11,7 +11,4 @@ VERSION="$2"
 
 : "${UEFI_BUNDLE_DIR:=boot/efi/EFI/void}"
 
-if [ -f "${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi" ]; then
-	rm -fv "${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi"
-fi
-exit $?
+rm -f "${UEFI_BUNDLE_DIR}/linux-${VERSION}.efi"

--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=050
-revision=7
+revision=8
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"


### PR DESCRIPTION
This restores some of the hook changes from the problematic `050_6` bump, but omits the `--sysroot` argument that caused the issues in the first place.

Verified on my local system, but I'd like to get another tester just in case.