### PR TITLE
zfs: add support for linux5.8

### DIFF
--- a/srcpkgs/zfs/patches/dkms.patch
+++ b/srcpkgs/zfs/patches/dkms.patch
@@ -2,11 +2,9 @@
 # Avoids recompiling ZFS userland utilities with DKMS rebuilds
 # Also short-circuits a useless test for Debian in the DKMS source
 
-diff --git a/scripts/dkms.mkconf b/scripts/dkms.mkconf
-index 88c289383..5a859a0e0 100755
---- scripts/dkms.mkconf
-+++ scripts/dkms.mkconf
-@@ -25,22 +25,7 @@ PACKAGE_CONFIG="${pkgcfg}"
+--- a/scripts/dkms.mkconf	2020-05-05 12:56:14.424687887 -0400
++++ b/scripts/dkms.mkconf	2020-08-12 10:20:16.673372895 -0400
+@@ -25,22 +25,7 @@
  PRE_BUILD="configure
    --prefix=/usr
    --with-config=kernel
@@ -28,10 +26,10 @@ index 88c289383..5a859a0e0 100755
 -  )
 +  --with-linux=\${kernel_source_dir}
    --with-linux-obj=\${kernel_source_dir}
-   --with-spl=\${source_tree}/spl-\${PACKAGE_VERSION}
-   --with-spl-obj=\${dkms_tree}/spl/\${PACKAGE_VERSION}/\${kernelver}/\${arch}
-@@ -78,7 +63,7 @@ POST_BUILD="scripts/dkms.postbuild
- BUILD_DEPENDS[0]="spl"
+   \$(
+     [[ -n \"\${ICP_ROOT}\" ]] && \\
+@@ -74,7 +59,7 @@
+ "
  AUTOINSTALL="yes"
  REMAKE_INITRD="no"
 -MAKE[0]="make"
@@ -39,6 +37,3 @@ index 88c289383..5a859a0e0 100755
  STRIP[0]="\$(
    [[ -r \${PACKAGE_CONFIG} ]] \\
    && source \${PACKAGE_CONFIG} \\
--- 
-2.19.1
-

--- a/srcpkgs/zfs/patches/linux58.patch
+++ b/srcpkgs/zfs/patches/linux58.patch
@@ -1,0 +1,119 @@
+diff -ur a/config/kernel.m4 b/config/kernel.m4
+--- a/config/kernel.m4	2020-05-05 12:56:29.709370875 -0400
++++ b/config/kernel.m4	2020-08-12 10:38:58.842672016 -0400
+@@ -45,6 +45,7 @@
+ 	ZFS_AC_KERNEL_SRC_SCHED
+ 	ZFS_AC_KERNEL_SRC_USLEEP_RANGE
+ 	ZFS_AC_KERNEL_SRC_KMEM_CACHE
++	ZFS_AC_KERNEL_SRC_VMALLOC_PAGE_KERNEL
+ 	ZFS_AC_KERNEL_SRC_WAIT
+ 	ZFS_AC_KERNEL_SRC_INODE_TIMES
+ 	ZFS_AC_KERNEL_SRC_INODE_LOCK
+@@ -163,6 +164,7 @@
+ 	ZFS_AC_KERNEL_SCHED
+ 	ZFS_AC_KERNEL_USLEEP_RANGE
+ 	ZFS_AC_KERNEL_KMEM_CACHE
++	ZFS_AC_KERNEL_VMALLOC_PAGE_KERNEL
+ 	ZFS_AC_KERNEL_WAIT
+ 	ZFS_AC_KERNEL_INODE_TIMES
+ 	ZFS_AC_KERNEL_INODE_LOCK
+@@ -894,3 +896,28 @@
+ 	    [test -f build/conftest/conftest.ko],
+ 	    [$3], [$4], [$5])
+ ])
++
++dnl #
++dnl # 5.8 API,
++dnl # __vmalloc PAGE_KERNEL removal
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_VMALLOC_PAGE_KERNEL], [
++	ZFS_LINUX_TEST_SRC([__vmalloc], [
++		#include <linux/mm.h>
++		#include <linux/vmalloc.h>
++	],[
++		void *p __attribute__ ((unused));
++
++		p = __vmalloc(0, GFP_KERNEL, PAGE_KERNEL);
++	])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_VMALLOC_PAGE_KERNEL], [
++	AC_MSG_CHECKING([whether __vmalloc(ptr, flags, pageflags) is available])
++	ZFS_LINUX_TEST_RESULT([__vmalloc], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_VMALLOC_PAGE_KERNEL, 1, [__vmalloc page flags exists])
++	],[
++		AC_MSG_RESULT(no)
++	])
++])
+diff -ur a/include/spl/sys/kmem.h b/include/spl/sys/kmem.h
+--- a/include/spl/sys/kmem.h	2020-05-05 12:56:29.717370676 -0400
++++ b/include/spl/sys/kmem.h	2020-08-12 10:41:20.253453058 -0400
+@@ -170,6 +170,15 @@
+ extern void spl_kmem_free(const void *ptr, size_t sz);
+ 
+ /*
++ * 5.8 API change, pgprot_t argument removed.
++ */
++#ifdef HAVE_VMALLOC_PAGE_KERNEL
++#define spl_vmalloc(size, flags) __vmalloc(size, flags, PAGE_KERNEL)
++#else
++#define spl_vmalloc(size, flags) __vmalloc(size, flags)
++#endif
++
++/*
+  * The following functions are only available for internal use.
+  */
+ extern void *spl_kmem_alloc_impl(size_t size, int flags, int node);
+diff -ur a/module/spl/spl-kmem-cache.c b/module/spl/spl-kmem-cache.c
+--- a/module/spl/spl-kmem-cache.c	2020-05-05 12:57:28.442960922 -0400
++++ b/module/spl/spl-kmem-cache.c	2020-08-12 10:38:58.843672014 -0400
+@@ -203,7 +203,7 @@
+ 		ASSERT(ISP2(size));
+ 		ptr = (void *)__get_free_pages(lflags, get_order(size));
+ 	} else {
+-		ptr = __vmalloc(size, lflags | __GFP_HIGHMEM, PAGE_KERNEL);
++		ptr = spl_vmalloc(size, lflags | __GFP_HIGHMEM);
+ 	}
+ 
+ 	/* Resulting allocated memory will be page aligned */
+@@ -1242,7 +1242,7 @@
+ 	 * allocation.
+ 	 *
+ 	 * However, this can't be applied to KVM_VMEM due to a bug that
+-	 * __vmalloc() doesn't honor gfp flags in page table allocation.
++	 * spl_vmalloc() doesn't honor gfp flags in page table allocation.
+ 	 */
+ 	if (!(skc->skc_flags & KMC_VMEM)) {
+ 		rc = __spl_cache_grow(skc, flags | KM_NOSLEEP);
+diff -ur a/module/spl/spl-kmem.c b/module/spl/spl-kmem.c
+--- a/module/spl/spl-kmem.c	2020-05-05 12:57:28.442960922 -0400
++++ b/module/spl/spl-kmem.c	2020-08-12 10:38:58.843672014 -0400
+@@ -172,7 +172,7 @@
+ 		 * kmem_zalloc() callers.
+ 		 *
+ 		 * For vmem_alloc() and vmem_zalloc() callers it is permissible
+-		 * to use __vmalloc().  However, in general use of __vmalloc()
++		 * to use spl_vmalloc().  However, in general use of spl_vmalloc()
+ 		 * is strongly discouraged because a global lock must be
+ 		 * acquired.  Contention on this lock can significantly
+ 		 * impact performance so frequently manipulating the virtual
+@@ -180,8 +180,7 @@
+ 		 */
+ 		if ((size > spl_kmem_alloc_max) || use_vmem) {
+ 			if (flags & KM_VMEM) {
+-				ptr = __vmalloc(size, lflags | __GFP_HIGHMEM,
+-				    PAGE_KERNEL);
++				ptr = spl_vmalloc(size, lflags | __GFP_HIGHMEM);
+ 			} else {
+ 				return (NULL);
+ 			}
+@@ -194,7 +193,7 @@
+ 
+ 		/*
+ 		 * For vmem_alloc() and vmem_zalloc() callers retry immediately
+-		 * using __vmalloc() which is unlikely to fail.
++		 * using spl_vmalloc() which is unlikely to fail.
+ 		 */
+ 		if ((flags & KM_VMEM) && (use_vmem == 0))  {
+ 			use_vmem = 1;

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=0.8.4
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d
@@ -16,19 +16,28 @@ homepage="https://zfsonlinux.org/"
 distfiles="https://github.com/zfsonlinux/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
 checksum=2b988f5777976f09d08083f6bebf6e67219c4c4c183c1f33033fb7e5e5eacafb
 
+patch_args="-Np1"
+
 replaces="spl<=0.7.13_1" # Because SPL was merged into zfs in 0.8.0
 
 dkms_modules="zfs ${version}"
 depends="dkms>=2.2.0.3_9 perl python3 bash"
 
+post_patch() {
+	# When collecting a "clean" tree for DKMS, don't leave patches in place
+	local _f
+	for _f in "${XBPS_SRCPKGDIR}/${pkgname}"/patches/*.patch; do
+		rm -f "${_f##*/}"
+	done
+}
+
 pre_configure() {
 	export CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/tirpc/"
 	autoreconf -fi
-	# configure relies on bashism to redirect stdout/stderr when building tests
-	sed -i '1 s@^#!\s*/bin/sh$@#!/bin/bash@' configure
 
-	# Prevent patch artifacts from being installed
-	rm -f dkms.patch scripts/dkms.mkconf.orig
+	# configure relies on bashism to redirect stdout/stderr when building tests
+	vsed -e '1 s@^#!\s*/bin/sh$@#!/bin/bash@' -i  configure
+
 	tar czf ../clean.tar.gz .
 }
 


### PR DESCRIPTION
Backport an upstream commit to support `__vmalloc` prototype change. Also clean up the `dkms.patch` to avoid `dkms.conf.orig` artifacts from an imperfect match and more intelligently prune patches from the build tree in preparation for packing `clean.tar.gz` for DKMS.

Build and run tested on `linux5.7` and `linux5.8`. There should be no issues with older kernel versions.

@Vaelatern @ericonr @zdykstra 