### PR TITLE
Remove noarch from aspell-*

### DIFF
--- a/srcpkgs/aspell-cs/template
+++ b/srcpkgs/aspell-cs/template
@@ -1,8 +1,7 @@
 # Template file for 'aspell-cs'
 pkgname=aspell-cs
 version=20040614.1
-revision=1
-archs=noarch
+revision=2
 wrksrc="aspell6-cs-${version/./-}"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-de/template
+++ b/srcpkgs/aspell-de/template
@@ -1,8 +1,7 @@
 # Template file for 'aspell-de'
 pkgname=aspell-de
 version=20161207.7.0
-revision=1
-archs=noarch
+revision=2
 wrksrc="aspell6-de-${version//./-}"
 build_style=configure
 hostmakedepends="aspell-devel which"
@@ -15,7 +14,6 @@ checksum=c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571
 
 words-de_package() {
 	short_desc="German dictionary word list"
-	archs=noarch
 	pkg_install() {
 		vmkdir usr/share/dict
 		precat *.cwl |

--- a/srcpkgs/aspell-el/template
+++ b/srcpkgs/aspell-el/template
@@ -1,9 +1,8 @@
 # Template file for 'aspell-el'
 pkgname=aspell-el
 version=0.08.0
-revision=1
+revision=2
 _distver="${version%.*}-${version##*.}"
-archs=noarch
 wrksrc="aspell6-el-${_distver}"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-en/template
+++ b/srcpkgs/aspell-en/template
@@ -1,8 +1,7 @@
 # Template file for 'aspell-en'
 pkgname=aspell-en
 version=2019.10.06
-revision=1
-archs=noarch
+revision=2
 wrksrc="aspell6-en-${version}-0"
 build_style=configure
 hostmakedepends="aspell-devel which"
@@ -15,7 +14,6 @@ checksum=24334b4daac6890a679084f4089e1ce7edbe33c442ace776fa693d8e334f51fd
 
 words-en_package() {
 	short_desc="English dictionary word list"
-	archs=noarch
 	pkg_install() {
 		vmkdir usr/share/dict
 		precat en-common.cwl en_US-wo_accents-only.cwl |

--- a/srcpkgs/aspell-fr/template
+++ b/srcpkgs/aspell-fr/template
@@ -1,16 +1,15 @@
 # Template file for 'aspell-fr'
 pkgname=aspell-fr
 version=0.50.3
-revision=2
-archs=noarch
+revision=3
 wrksrc="aspell-fr-0.50-3"
 build_style=configure
 hostmakedepends="aspell-devel which"
 makedepends="aspell-devel"
 depends="aspell"
 short_desc="French dictionary for aspell"
-homepage="http://aspell.net/"
-license="GPL-2"
 maintainer="7185 <7185@free.fr>"
+license="GPL-2.0-or-later"
+homepage="http://aspell.net/"
 distfiles="${GNU_SITE}/aspell/dict/fr/aspell-fr-0.50-3.tar.bz2"
 checksum=f9421047519d2af9a7a466e4336f6e6ea55206b356cd33c8bd18cb626bf2ce91

--- a/srcpkgs/aspell-pl/template
+++ b/srcpkgs/aspell-pl/template
@@ -1,14 +1,13 @@
 # Template file for 'aspell-pl'
 pkgname=aspell-pl
 version=20061121
-revision=1
-archs=noarch
+revision=2
 wrksrc="aspell6-pl-6.0_${version}-0"
 build_style=configure
 hostmakedepends="aspell-devel which"
 short_desc="Polish dictionary for aspell"
-homepage="http://aspell.net/"
-license="GPL-2"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
+license="GPL-2.0-or-later"
+homepage="http://aspell.net/"
 distfiles="${GNU_SITE}/aspell/dict/pl/aspell6-pl-6.0_${version}-0.tar.bz2"
 checksum=017741fcb70a885d718c534160c9de06b03cc72f352879bd106be165e024574d

--- a/srcpkgs/aspell-ru/template
+++ b/srcpkgs/aspell-ru/template
@@ -1,14 +1,13 @@
 # Template file for 'aspell-ru'
 pkgname=aspell-ru
 version=0.99f7
-revision=1
-archs=noarch
+revision=2
 wrksrc="aspell6-ru-${version}-1"
 build_style=configure
 hostmakedepends="aspell-devel which"
 short_desc="Russian dictionary for aspell"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://aspell.net/"
 distfiles="${GNU_SITE}/aspell/dict/ru/aspell6-ru-${version}-1.tar.bz2"
 checksum=5c29b6ccce57bc3f7c4fb0510d330446b9c769e59c92bdfede27333808b6e646


### PR DESCRIPTION
aspell dictionaries aren't architecture independent: the dictionary format depends on size_t, therefor it needs to be made architecture specific. This is why the dictionaries are stored in /usr/lib and not in /usr/share.

Without this fix, I get the following error on amd64 when running `aspell check -l fr`:

> Error: The file "/usr/lib/aspell-0.60/fr-40-only.rws" is not in the proper format. Incompatible hash function.

This fixes the aspell-fr package on amd64 and probably most 64bits architectures.

More information about this:

http://aspell.net/0.61/man-html/Using-32_002dBit-Dictionaries-on-a-64_002dBit-System.html