### PR TITLE
[RFC] Add _FORTIFY_SOURCE impl for musl.

### DIFF
--- a/common/environment/configure/hardening.sh
+++ b/common/environment/configure/hardening.sh
@@ -17,8 +17,8 @@ if [ -z "$nopie" ]; then
 		LDFLAGS="-specs=${_GCCSPECSDIR}/hardened-ld -Wl,-z,relro -Wl,-z,now ${LDFLAGS}"
 	else
 		# Enable FORITFY_SOURCE=2
-		CFLAGS="-fstack-clash-protection -D_FORTIFY_SOURCE=2 ${CFLAGS}"
-		CXXFLAGS="-fstack-clash-protection -D_FORTIFY_SOURCE=2 ${CXXFLAGS}"
+		CFLAGS="-fstack-clash-protection -D_FORTIFY_SOURCE=2 -isystem ${XBPS_CROSS_BASE}/usr/include/fortify ${CFLAGS}"
+		CXXFLAGS="-fstack-clash-protection -D_FORTIFY_SOURCE=2 -isystem ${XBPS_CROSS_BASE}/usr/include/fortify ${CXXFLAGS}"
 		LDFLAGS="-Wl,-z,relro -Wl,-z,now ${LDFLAGS}"
 	fi
 else

--- a/srcpkgs/fortify-headers/template
+++ b/srcpkgs/fortify-headers/template
@@ -1,0 +1,20 @@
+# Template file for 'fortify-headers'
+pkgname=fortify-headers
+version=1.1
+revision=1
+archs="*-musl"
+build_style=gnu-makefile
+short_desc="Standalone implementation of fortify source"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="ISC"
+homepage="https://git.2f30.org/fortify-headers/"
+distfiles="http://dl.2f30.org/releases/${pkgname}-${version}.tar.gz"
+checksum=6ba5d860a2d2ba4c3346924b93930c34856eafe148bdbdf271ecab8065201fb6
+
+do_build() {
+	:
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=3
+revision=4
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure
@@ -48,7 +48,7 @@ do_install() {
 }
 
 musl-devel_package() {
-	depends="kernel-libc-headers ${sourcepkg}-${version}_${revision}"
+	depends="kernel-libc-headers fortify-headers ${sourcepkg}-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
Using the `fortify-headers` impl from https://git.2f30.org/fortify-headers/file/README.html , which was recommended in https://wiki.musl-libc.org/open-issues.html#Substitute-for-%3Ccode%3E_FORTIFY_SOURCE%3C/code%3E .

Would definitely require extensive testing, I mostly want to know whether going through this testing is worth it.