### PR TITLE
aisleriot: update to 3.22.11.

### DIFF
--- a/srcpkgs/aisleriot/template
+++ b/srcpkgs/aisleriot/template
@@ -1,24 +1,22 @@
 # Template file for 'aisleriot'
 pkgname=aisleriot
-version=3.22.9
+version=3.22.11
 revision=1
-_pysol_cardsets=PySolFC-Cardsets
-_pysol_ver=2.0
-build_style=gnu-configure
-configure_args="--with-platform=gtk-only
- --with-pysol-card-theme-path=${XBPS_BUILDDIR}/${_pysol_cardsets}-${_pysol_ver}"
-hostmakedepends="desktop-file-utils glib-devel guile intltool itstool pkg-config"
-makedepends="gc-devel guile-devel libcanberra-devel librsvg-devel
- libatomic_ops-devel"
-depends="aisleriot-data guile"
+wrksrc="${pkgname}-${version}-08104246822df8286d3f0d7b30b697d644ddc656"
+build_style=meson
+# build requires assertions to be turned on -> n_debug=false
+configure_args="-Dtheme_pysol_path=/usr/share/PySolFC/cardsets -Dtheme_pysol=true
+ -Dtheme_kde=false -Db_ndebug=false"
+hostmakedepends="desktop-file-utils glib-devel guile intltool itstool pkg-config
+ pysolfc-cardsets"
+makedepends="guile-devel libcanberra-devel librsvg-devel libatomic_ops-devel"
+depends="aisleriot-data guile yelp"
 short_desc="GNOME solitaire card game"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Aisleriot"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz
- http://distfiles.voidlinux.de/${_pysol_cardsets}-${_pysol_ver}/${_pysol_cardsets}-${_pysol_ver}.tar.bz2"
-checksum="51f2ffe4dd4f23349b033fd87aab7bf433641285719503dd7e52b2c25982ed7b
- c388d6360191b3b7e463d84e5a64260c4e3ed36e791a85227d7e8923f3f47ca7"
+distfiles="https://gitlab.gnome.org/GNOME/${pkgname}/-/archive/${version}/${pgkname}-${version}.tar.gz"
+checksum=eed8edb267a9fa61651b1d3a22a83f51415a4e55d76d5ae737e18a9e9477016b
 
 aisleriot-data_package() {
 	short_desc+=" - data"


### PR DESCRIPTION
- Change build_style to meson
- Change distfile location
- Use pysol package instead of distfile

@pullmoll 

I could add `yelp` as a `depends` for browsing the include help docs. What do you think?