### PR TITLE
network-ups-tools: add warning about FHS violation

### DIFF
--- a/srcpkgs/network-ups-tools/template
+++ b/srcpkgs/network-ups-tools/template
@@ -4,6 +4,10 @@ version=2.7.4
 revision=9
 wrksrc="nut-${version}"
 build_style=gnu-configure
+# If you are updating/using this package, consider changing --with-drvpath to:
+#  --with-drvpath=/usr/libexec/nut
+# so that binaries are installed into /usr/libexec instead of /var.
+# Make sure to test afterward.
 configure_args="
  --sysconfdir=/etc/ups --without-doc --disable-static
  --datadir=/usr/share/ups --with-user=nut --with-group=nut --with-ssl


### PR DESCRIPTION
In Debian these are shipped in /lib/nut,
which is equivalent to /usr/libexec/nut on Void.

Binaries certainly do not belong in /var.