### PR TITLE
qemu: Add `qemuconf` to depends.

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=5.1.0
-revision=1
+revision=2
 short_desc="Open Source Processor Emulator"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
@@ -22,6 +22,7 @@ makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
  $(vopt_if opengl 'libepoxy-devel libdrm-devel MesaLib-devel')
  $(vopt_if iscsi 'libiscsi-devel')
  $(vopt_if smartcard libcacard-devel) $(vopt_if numa 'libnuma-devel')"
+depends="qemuconf"
 
 build_options="gtk3 opengl sdl2 spice virgl smartcard numa iscsi"
 build_options_default="opengl gtk3 virgl smartcard sdl2 numa iscsi"


### PR DESCRIPTION
The `qemu-generic` service provided by this package uses `qemuconf`, but the latter currently isn't listed in "depends".