### PR TITLE
libgme: update to 0.6.3.

### DIFF
--- a/srcpkgs/libgme/template
+++ b/srcpkgs/libgme/template
@@ -1,15 +1,17 @@
 # Template file for 'libgme'
 pkgname=libgme
-version=0.6.2
+version=0.6.3
 revision=1
 wrksrc="game-music-emu-${version}"
 build_style=cmake
+configure_args="-DENABLE_UBSAN=OFF"
+makedepends="zlib-devel SDL2-devel"
 short_desc="Video game music file emulation/playback library"
 maintainer="Pierre Allegraud <pierre.allegraud@crans.org>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="https://bitbucket.org/mpyne/game-music-emu/wiki/Home"
 distfiles="https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-${version}.tar.xz"
-checksum=5046cb471d422dbe948b5f5dd4e5552aaef52a0899c4b2688e5a68a556af7342
+checksum=aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
 
 libgme-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Also enables `zlib` for those programs that can use compression.