### PR TITLE
chromium: update to 84.0.4147.125.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=84.0.4147.105
+version=84.0.4147.125
 revision=1
 archs="x86_64"
 create_wrksrc=yes
@@ -17,7 +17,7 @@ depends="chromium binutils xz"
 homepage="https://www.google.com/chrome"
 repository=nonfree
 distfiles="https://dl.google.com/linux/direct/google-chrome-${_channel}_${_chromeVersion}_amd64.deb"
-checksum=dc7fa2ca2dccf482524dc2a343662859a22ad1fb33767447d7de6fcf6cc1dd7e
+checksum=1cb13f135c51a155dd86846457254ebea986a2b34e87b8236cc14df2e74e76b9
 
 do_extract() {
 	:

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=84.0.4147.105
+version=84.0.4147.125
 revision=1
 archs="i686* x86_64* aarch64* armv7l* ppc64le*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=caf4ebeb2a2333454c3067a2534aeecaab5029aa78fc0d8b27f79ad3b9c5ccac
+checksum=98439626cf2d8d3d8f9486d08a99cbc1e4981b3f3427a072d5eaaf6ded4daff5
 nocross=yes
 
 lib32disabled=yes


### PR DESCRIPTION
- Built for x86_64, x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine.