### PR TITLE
mlocate: revbump for aarch64-musl

### DIFF
--- a/srcpkgs/mlocate/template
+++ b/srcpkgs/mlocate/template
@@ -1,19 +1,19 @@
 # Template file for 'mlocate'
 pkgname=mlocate
 version=0.26
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--program-prefix=m --localstatedir=/var/lib"
 make_build_args="groupname=_mlocate"
 make_install_args="${make_build_args}"
-system_accounts="_mlocate"
 make_dirs="/var/lib/mlocate 0755 root root"
 short_desc="Implementation of locate/updatedb that reuses the database"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://pagure.io/mlocate"
-distfiles="http://releases.pagure.org/mlocate/${pkgname}-${version}.tar.xz"
+distfiles="https://releases.pagure.org/mlocate/${pkgname}-${version}.tar.xz"
 checksum=3063df79fe198fb9618e180c54baf3105b33d88fe602ff2d8570aaf944f1263e
+system_accounts="_mlocate"
 
 alternatives="
  locate:locate:/usr/bin/mlocate


### PR DESCRIPTION
aarch64-musl repository does not contain mlocate package, even though it builds fine