### PR TITLE
base-files: vkpurge: fix parameter expansion in list_kernels()

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -26,7 +26,7 @@ list_kernels() {
 			case "$installed" in
 				*"$k"*) continue ;;
 			esac
-			kver=${k##*-}
+			kver=${k#*-}
 			case "$kver" in
 				"$running") ;;
 				"*") ;; # /boot isn't mounted -> no vmlinu[xz]

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.141
-revision=2
+revision=3
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
This fixes next-kernels from having too much string of their versions
stripped.

Next-kernel versions have the format "vmlinu[xz]-<ver>-next-<date>".
Thus, the string was wrongly shortened to "<date>", instead of the
correct "<ver>-next-<date>".