### PR TITLE
texlive: make tlmgr work and split libsynctex

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3973,6 +3973,7 @@ libkpathsea.so.6 texlive-20200406_1
 libtexluajit.so.2 texlive-LuaTeX-20200406_1
 libtexlua53.so.5 texlive-LuaTeX-20200406_1
 libptexenc.so.1 texlive-20200406_1
+libsynctex.so.2 libsynctex-20200406_3
 libdolphinvcs.so.5 dolphin-20.04.3_1
 libcglm.so.0 cglm-0.7.6_1
 libfcft.so.3 fcft-2.2.2_1

--- a/srcpkgs/libsynctex
+++ b/srcpkgs/libsynctex
@@ -1,0 +1,1 @@
+texlive

--- a/srcpkgs/texlive/files/tlmgr
+++ b/srcpkgs/texlive/files/tlmgr
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/share/texmf-dist/scripts/texlive/tlmgr.pl "$@"

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -338,6 +338,13 @@ texlive-Xdvi_package() {
 	}
 }
 
+libsynctex_package() {
+	short_desc+=" - libsynctex"
+	pkg_install() {
+		vmove "usr/lib/libsynctex.so.*"
+	}
+}
+
 texlive-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20200406
-revision=2
+revision=3
 wrksrc="texlive-${version}-source"
 build_wrksrc="build"
 build_style=gnu-configure
@@ -72,8 +72,6 @@ makedepends="cairo-devel freetype-devel gd-devel graphite-devel gmp-devel
  poppler-devel pixman-devel libteckit-devel zlib-devel zziplib-devel
  libXaw-devel"
 depends="dialog ghostscript perl-Tk texlive-core xbps-triggers>=0.115_1"
-# Virtual package cares only about year part of version
-provides="tex-${version%${version#????}}_1"
 short_desc="TeX Live"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
@@ -81,6 +79,8 @@ homepage="https://www.tug.org/texlive/"
 distfiles="ftp://tug.org/texlive/historic/2020/texlive-${version}-source.tar.xz"
 checksum=e32f3d08cbbbcf21d8d3f96f2143b64a1f5e4cb01b06b761d6249c8785249078
 python_version=3
+# Virtual package cares only about year part of version
+provides="tex-${version%${version#????}}_1"
 
 if [ "$CROSS_BUILD" ] ; then
 	# Tangle is required for cross compile
@@ -252,6 +252,9 @@ post_install() {
 	done
 	ln -s eptex "${DESTDIR}/usr/bin/platex"
 	ln -s euptex "${DESTDIR}/usr/bin/uplatex"
+	# Create tlmgr smallscript
+	rm -f "${DESTDIR}/usr/bin/tlmgr"
+	vbin "${FILESDIR}/tlmgr"
 }
 
 texlive-XeTeX_package() {


### PR DESCRIPTION
tlmgr was attempting to lookup a relative path to /usr/bin, while it
expects to be in /usr/share/texmf-dist. Instead of symlinking it, create
a smallscript to run it from the correct location.