### PR TITLE
New package: xbpsvenv

### DIFF
--- a/srcpkgs/xbpsvenv/template
+++ b/srcpkgs/xbpsvenv/template
@@ -1,0 +1,20 @@
+# Template file for 'xbpsvenv'
+pkgname=xbpsvenv
+version=0.2.3
+revision=1
+short_desc="Convenient separated void-packages environments"
+maintainer="Noah Huppert <contact@noahh.io>"
+license="MIT"
+homepage="https://github.com/Noah-Huppert/xbpsvenv"
+distfiles="https://github.com/Noah-Huppert/xbpsvenv/archive/v${version}.tar.gz"
+checksum=706a12ec3f26b61849a2b3802e18c5cdac389c6f856258ecdb1eb667050758cf
+
+do_install() {
+	vlicense LICENSE
+
+	vmkdir usr/share/xbpsvenv 755
+	vcopy * usr/share/xbpsvenv
+
+	vmkdir usr/bin/
+	ln -s /usr/share/xbpsvenv/xbpsvenv ${DESTDIR}/usr/bin/xbpsvenv
+}


### PR DESCRIPTION
How to verify:

1. Install `xbpsvenv` package.
2. Run `xbpsvenv -h`. You should see help for the following sub-commands: `alias exec ls note pwd rm usectx workon`
3. Run `xbpsvenv ls` the line `Default  Workspace                   Alias  Notes` should print.

This will create the `$HOME/.local/share/xbpsvenv` directory. Uninstalling the package does not delete this directory since source code which the user works on is stored here.