### PR TITLE
Enable libsynctex for zathura

### DIFF
--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,13 +1,13 @@
 # Template file for 'zathura'
 pkgname=zathura
 version=0.4.6
-revision=1
+revision=2
 build_style=meson
-configure_args="-Dsynctex=disabled -Dtests=disabled"
+configure_args="-Dsynctex=enabled -Dtests=disabled"
 hostmakedepends="pkg-config intltool python3-Sphinx desktop-file-utils
  appstream-glib glib-devel librsvg-utils"
 makedepends="girara-devel sqlite-devel file-devel zlib-devel libseccomp-devel
- libglib-devel"
+ libglib-devel texlive-devel"
 short_desc="Highly customizable and functional document viewer"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="Zlib"


### PR DESCRIPTION
Depends on #24300 to avoid rebuilding texlive too many times. The texlive commit will be removed from here once that's merged.

Along with #24300, fixes #24013 .

@lemmi 