### PR TITLE
cross-aarch64-linux-musl: do not remove gcc's stddef.h

### DIFF
--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -12,7 +12,7 @@ _sysroot="/usr/${_triplet}"
 
 pkgname=cross-${_triplet}
 version=0.33
-revision=2
+revision=3
 short_desc="Cross toolchain for ARM64 LE target (musl)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
@@ -284,8 +284,7 @@ do_install() {
 	make DESTDIR=${DESTDIR}/${_sysroot} install
 
 	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/ \
-		${DESTDIR}/usr/lib/gcc/${_triplet}/*/include/stddef.h
+	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
 
 	# Make ld-musl.so symlinks relative.
 	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-aarch64.so.1

--- a/srcpkgs/pinebookpro-uboot/template
+++ b/srcpkgs/pinebookpro-uboot/template
@@ -20,9 +20,6 @@ do_fetch() {
 	git clone https://git.eno.space/pbp-uboot.git
 	cd pbp-uboot
 	git reset --hard ${_commit_uboot}
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-		touch include/stddef.h
-	fi
 
 	cd "${wrksrc}"
 	git clone https://github.com/ARM-software/arm-trusted-firmware.git

--- a/srcpkgs/u-boot-tools/template
+++ b/srcpkgs/u-boot-tools/template
@@ -20,7 +20,6 @@ if [ "$CROSS_BUILD" ]; then
 fi
 
 post_extract() {
-	touch include/stddef.h  # musl hack
 	vsed '1itypedef unsigned long ulong;' \
 		-i include/image.h \
 		-i include/env.h \
@@ -30,6 +29,12 @@ post_extract() {
 
 do_configure() {
 	make ${makejobs} ${make_build_args} tools-only_defconfig
+}
+
+do_check() {
+	# skip tests for now. requires some gymnastics to make the python scripts
+	# find libfdt. the most useful target appears to be "make tcheck"
+	: ;
 }
 
 do_install() {


### PR DESCRIPTION
224951e9dd7820f31ffce0fbe853e860bb37accc forgot to touch aarch64-musl,
possibly because it was added around that time.