### PR TITLE
base-files: modify kernel listing in vkpurge

### DIFF
--- a/srcpkgs/base-files/files/vkpurge
+++ b/srcpkgs/base-files/files/vkpurge
@@ -33,7 +33,7 @@ list_kernels() {
 				$pattern) printf "%s\n" "$kver" ;;
 			esac
 		done
-	done | sort -u
+	done | sort -uV
 }
 
 run_hooks() {


### PR DESCRIPTION
By default, kernel listing is not done by version, For example :

4.19.131_1
5.4.18_1
5.4.50_1
5.4.5_1
5.4.9_1
5.4.11_1

Using 'version-sort' option, it shows older versions before recent versions :
4.19.131_1
5.4.5_1
5.4.9_1
5.4.11_1
5.4.18_1
5.4.50_1