### PR TITLE
chroot-style/uchroot: add -t parameter to command.

### DIFF
--- a/common/chroot-style/uchroot.sh
+++ b/common/chroot-style/uchroot.sh
@@ -18,4 +18,4 @@ if [ -z "$MASTERDIR" -o -z "$DISTDIR" ]; then
 	exit 1
 fi
 
-exec xbps-uchroot $EXTRA_ARGS -b $DISTDIR:/void-packages ${HOSTDIR:+-b $HOSTDIR:/host} -- $MASTERDIR $CMD $@
+exec xbps-uchroot -t $EXTRA_ARGS -b $DISTDIR:/void-packages ${HOSTDIR:+-b $HOSTDIR:/host} -- $MASTERDIR $CMD $@


### PR DESCRIPTION
Without it, using xbps-src with overlay errors out with the message
below:

ERROR: failed to mount overlayfs on
/home/ericonr/void/void-packages/masterdir.XXXXdMemKO/masterdir (Invalid
argument)

---

I don't know if I'm the only one seeing this.