### PR TITLE
lcov: update to 1.15.

### DIFF
--- a/srcpkgs/lcov/template
+++ b/srcpkgs/lcov/template
@@ -1,6 +1,6 @@
 # Template file for 'lcov'
 pkgname=lcov
-version=1.14
+version=1.15
 revision=1
 build_style=gnu-makefile
 make_check_target=test
@@ -11,4 +11,4 @@ maintainer="Andre Klitzing <aklitzing@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="http://ltp.sourceforge.net/coverage/lcov.php"
 distfiles="https://github.com/linux-test-project/${pkgname}/archive/v${version}.tar.gz"
-checksum=f19eff1dcf5f40f4a57d959584acd318155873c43d723e25dd1b91636f94ca41
+checksum=d88b0718f59815862785ac379aed56974b9edd8037567347ae70081cd4a3542a


### PR DESCRIPTION
As of the GCC 9 series, lcov 1.14 and earlier are no longer compatible with GCC coverage data (lcov will not attempt to build reports). 1.15 fixes compatibility with newer GCC releases. I tested this with a medium-sized C++ project and got full coverage results in the report. More info https://github.com/linux-test-project/lcov/issues/58