### PR TITLE
playerctl: update to 2.2.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2244,7 +2244,6 @@ librom1394.so.0 libavc1394-0.5.4_1
 libavc1394.so.0 libavc1394-0.5.4_1
 libiec61883.so.0 libiec61883-1.2.0_1
 libffado.so.2 libffado-2.2.1_1
-libplayerctl-1.0.so.0 playerctl-0.4.2_1
 libkomparediff2.so.5 libkomparediff2-17.08.2_1
 libkompareinterface.so.5 kompare-17.08.2_1
 libkomparedialogpages.so.5 kompare-17.08.2_1

--- a/srcpkgs/playerctl/template
+++ b/srcpkgs/playerctl/template
@@ -1,6 +1,6 @@
 # Template file for 'playerctl'
 pkgname=playerctl
-version=2.1.1
+version=2.2.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -9,12 +9,12 @@ configure_args="-Dintrospection=$(vopt_if gir 'true' 'false')
 hostmakedepends="pkg-config glib-devel $(vopt_if doc gtk-doc)"
 makedepends="libglib-devel"
 short_desc="MPRIS command-line controller and library"
-maintainer="Duncaen <duncaen@voidlinux.org>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/acrisci/playerctl"
 changelog="https://github.com/altdesktop/playerctl/raw/master/CHANGELOG.md"
 distfiles="https://github.com/acrisci/playerctl/archive/v${version}.tar.gz"
-checksum=9eb810c1fd8e1afa5c76cecd34a2d22cc95e2029afe502025db8a38bce13e68d
+checksum=b431a693e815056964d084bcbf3813aee1cc9f92a4a3c1a7df9ae98d663efd03
 
 build_options="doc gir"
 desc_option_doc="Build documentation"  # fails :(


### PR DESCRIPTION
Remove from shlibs, since no package depends on it.

@Duncaen - I can adopt it, if you'd like.