### PR TITLE
fix dependency for synapse-1.19.0.

### DIFF
--- a/srcpkgs/python3-canonicaljson/template
+++ b/srcpkgs/python3-canonicaljson/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-canonicaljson'
 pkgname=python3-canonicaljson
-version=1.1.4
-revision=2
+version=1.3.0
+revision=1
 archs=noarch
 wrksrc="canonicaljson-${version}"
 build_style=python3-module
-pycompile_module="canonicaljson.py"
 hostmakedepends="python3-setuptools"
 depends="python3-simplejson>=3.6.5 python3-frozendict>=1.0 python3-six"
 short_desc="Canonical JSON"
@@ -13,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/matrix-org/python-canonicaljson"
 distfiles="${PYPI_SITE}/c/canonicaljson/canonicaljson-${version}.tar.gz"
-checksum=45bce530ff5fd0ca93703f71bfb66de740a894a3b5dd6122398c6d8f18539725
+checksum=b4763db06a2e8553293c5edaa4bda05605c3307179a7ddfb30273a24ac384b6c

--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -1,11 +1,11 @@
 # Template file for 'synapse'
 pkgname=synapse
 version=1.19.0
-revision=1
+revision=2
 archs=noarch
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-jsonschema python3-frozendict python3-canonicaljson
+depends="python3-jsonschema python3-frozendict python3-canonicaljson>=1.2.0
  python3-signedjson python3-pynacl python3-service_identity python3-Twisted
  python3-openssl python3-yaml python3-pyasn1 python3-pyasn1-modules
  python3-daemonize python3-bcrypt python3-Pillow python3-psutil


### PR DESCRIPTION
2994314a3f08152905ce80d78ad2f86eeda43fb3 broke synapse because the new version depended on a newer version of `canonicaljson`.  (please test before pushing.)  this version-bumps `canonicaljson` to the newest release and marks the version in `depends` in synapse.