### PR TITLE
[wip] common: disable creation of noarch packages.

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -711,8 +711,7 @@ used.
 - `fetch_cmd` Executable to be used to fetch URLs in `distfiles` during the `do_fetch` phase.
 
 - `archs` Whitespace separated list of architectures that a package can be
-built for, available architectures can be found under `common/cross-profiles`
-alongside the `noarch` value for packages that do not contain any machine code.
+built for, available architectures can be found under `common/cross-profiles`.
 In general, `archs` should only be set if the upstream software explicitly targets
 certain architectures or there is a compelling reason why the software should not be
 available on some supported architectures.
@@ -725,8 +724,6 @@ Examples:
 	archs="x86_64-musl ~*-musl"
 	# Default value (all arches)
 	archs="*"
-	# Packages that do not depend on architecture-specific objects
-	archs=noarch
 	```
 
 <a id="explain_depends"></a>
@@ -914,8 +911,8 @@ can be used to pass arguments during compilation. If your package does not make 
 extensions consider using the `gem` build style instead.
 
 - `gem` For packages that are installed using gems from [RubyGems](https://rubygems.org/).
-The gem command can be overridden by `gem_cmd`. `archs` is set to `noarch` unconditionally
-and `distfiles` is set by the build style if the template does not do so. If your gem
+The gem command can be overridden by `gem_cmd`. 
+`distfiles` is set by the build style if the template does not do so. If your gem
 provides extensions which must be compiled consider using the `gemspec` build style instead.
 
 - `ruby-module` For packages that are ruby modules and are installable via `ruby install.rb`.
@@ -1413,6 +1410,10 @@ destdir (`$DESTDIR`) to the `subpackage` destdir (`$PKGDESTDIR`).
 Subpackages are processed always in alphabetical order; To force a custom order,
 the `subpackages` variable can be declared with the wanted order.
 
+Please note that XBPS makes no distinction between normal packages, and data
+packages. Data packages, documentation packages and binary packages are all
+treated the same way.
+
 <a id="pkgs_development"></a>
 ### Development packages
 
@@ -1451,7 +1452,7 @@ type used to split architecture independent, big(ger) or huge amounts
 of data from a package's main and architecture dependent part. It is up
 to you to decide, if a `-data` subpackage makes sense for your package.
 This type is common for games (graphics, sound and music), part libraries (CAD)
-or card material (maps). Data subpackages are almost always `archs=noarch`.
+or card material (maps).
 The main package must then have `depends="${pkgname}-data-${version}_${revision}"`,
 possibly in addition to other, non-automatic depends.
 
@@ -1589,7 +1590,6 @@ The following variables influence how Haskell packages are built:
 Font packages are very straightforward to write, they are always set with the
 following variables:
 
-- `archs=noarch`: Font packages don't install arch specific files.
 - `depends="font-util"`: because they are required for regenerating the font
 cache during the install/removal of the package
 - `font_dirs`: which should be set to the directory where the package

--- a/common/hooks/do-pkg/00-gen-pkg.sh
+++ b/common/hooks/do-pkg/00-gen-pkg.sh
@@ -104,14 +104,12 @@ hook() {
 	local arch= binpkg= repo= _pkgver= _desc= _pkgn= _pkgv= _provides= \
 		_replaces= _reverts= f= found_dbg_subpkg=
 
-	if [ "${archs// /}" = "noarch" ]; then
-		arch=noarch
-	elif [ -n "$XBPS_TARGET_MACHINE" ]; then
+	if [ -n "$XBPS_TARGET_MACHINE" ]; then
 		arch=$XBPS_TARGET_MACHINE
 	else
 		arch=$XBPS_MACHINE
 	fi
-	if [ "${archs// /}" != "noarch" -a -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
+	if [ -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
 		arch=${XBPS_ARCH}
 	fi
 

--- a/common/hooks/post-install/06-strip-and-debug-pkgs.sh
+++ b/common/hooks/post-install/06-strip-and-debug-pkgs.sh
@@ -59,7 +59,7 @@ create_debug_pkg() {
 hook() {
 	local fname= x= f= _soname= STRIPCMD=
 
-	if [ -n "$nostrip" -o "${archs// /}" = "noarch" ]; then
+	if [ -n "$nostrip" ]; then
 		return 0
 	fi
 

--- a/common/hooks/post-pkg/00-register-pkg.sh
+++ b/common/hooks/post-pkg/00-register-pkg.sh
@@ -13,14 +13,12 @@ registerpkg() {
 hook() {
 	local arch= binpkg= pkgdir=
 
-	if [ "${archs// /}" = "noarch" ]; then
-		arch=noarch
-	elif [ -n "$XBPS_TARGET_MACHINE" ]; then
+	if [ -n "$XBPS_TARGET_MACHINE" ]; then
 		arch=$XBPS_TARGET_MACHINE
 	else
 		arch=$XBPS_MACHINE
 	fi
-	if [ "${archs// /}" != "noarch" -a -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
+	if [ -z "$XBPS_CROSS_BUILD" -a -n "$XBPS_ARCH" -a "$XBPS_ARCH" != "$XBPS_TARGET_MACHINE" ]; then
 		arch=${XBPS_ARCH}
 	fi
 	if [ -n "$repository" ]; then

--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -56,7 +56,7 @@ hook() {
 
     mapshlibs=$XBPS_COMMONDIR/shlibs
 
-    if [ "${archs// /}" = "noarch" -o -n "$noverifyrdeps" ]; then
+    if [ -n "$noverifyrdeps" ]; then
         store_pkgdestdir_rundeps
         return 0
     fi

--- a/common/hooks/pre-pkg/05-prepare-32bit.sh
+++ b/common/hooks/pre-pkg/05-prepare-32bit.sh
@@ -20,10 +20,6 @@ hook() {
 	if [ "$XBPS_TARGET_MACHINE" != "i686" ]; then
 		return
 	fi 
-	# Ignore noarch pkgs.
-	if [ "${archs// /}" = "noarch" ]; then
-		return
-	fi
 	if [ -z "$lib32mode" ]; then
 		# Library mode, copy only relevant files to new destdir.
 		#
@@ -104,13 +100,6 @@ hook() {
 			if [[ $pkgn =~ '-devel' ]]; then
 				echo "   RDEP: $f -> ${pkgn}-32bit${pkgv} (development)"
 				printf "${pkgn}-32bit${pkgv} " >> ${destdir32}/rdeps
-				continue
-			fi
-			# If dependency is noarch do not change it to 32bit.
-			_arch=$($XBPS_QUERY_CMD -R --property=architecture "$f")
-			if [ "${_arch}" = "noarch" ]; then
-				echo "   RDEP: $f -> ${pkgn}${pkgv} (noarch)"
-				printf "${pkgn}${pkgv} " >> ${destdir32}/rdeps
 				continue
 			fi
 			# If dependency does not have "shlib-provides" do not

--- a/common/hooks/pre-pkg/06-shlib-provides.sh
+++ b/common/hooks/pre-pkg/06-shlib-provides.sh
@@ -45,7 +45,7 @@ collect_sonames() {
 hook() {
 	local _destdir32=${XBPS_DESTDIR}/${pkgname}-32bit-${version}
 
-	if [ -z "$shlib_provides" -a "${archs// /}" = "noarch" -o -n "$noshlibprovides" ]; then
+	if [ -n "$noshlibprovides" ]; then
 		return 0
 	fi
 

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -395,7 +395,6 @@ setup_pkg() {
         source_file ${XBPS_SRCPKGDIR}/${basepkg}/template
     fi
 
-
     # Check if required vars weren't set.
     _vars="pkgname version short_desc revision homepage license"
     for f in ${_vars}; do
@@ -457,12 +456,7 @@ setup_pkg() {
     fi
     makejobs="-j$XBPS_MAKEJOBS"
 
-    # strip whitespaces to make "  noarch  " valid too.
-    if [ "${archs// /}" = "noarch" ]; then
-        arch="noarch"
-    else
-        arch="$XBPS_TARGET_MACHINE"
-    fi
+    arch="$XBPS_TARGET_MACHINE"
     if [ -n "$XBPS_BINPKG_EXISTS" ]; then
         local _binpkgver="$($XBPS_QUERY_XCMD -R -ppkgver $pkgver 2>/dev/null)"
         if [ "$_binpkgver" = "$pkgver" ]; then

--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -3,7 +3,7 @@
 check_pkg_arch() {
     local cross="$1" _arch f match nonegation
 
-    if [ -n "$archs" -a "${archs// /}" != "noarch" ]; then
+    if [ -n "$archs" ]; then
         if [ -n "$cross" ]; then
             _arch="$XBPS_TARGET_MACHINE"
         elif [ -n "$XBPS_ARCH" ]; then


### PR DESCRIPTION
This change disables the creation of noarch packages.

I believe that most package maintainers are of the same opinion that noarch causes far more problems than it solves. For some time on IRC there has been continued discussion about disabling it. This is what this PR attempts to achieve.

This still supports `archs=noarch` but IMO this is misleading if it dosen't actually create a package with the noarch arch. This is why I have made `archs=noarch` just mean `noarch=yes`. This is how I think all future packages should declare noarch: `noarch=yes`. I also considered `data_only=yes` or `arch_independent=yes` but I don't really like either of those.

The reason noarch even still exists is because it is a useful shorthand for `nodebug=yes`, `nostrip=yes`, etc etc.

The removed 32-bit block about noarch is useless because noarch already forces `noshlibprovides`.

NB: Right now, this is a MVP and still needs some more work.

Pinging @q66 @the-maldridge 