### PR TITLE
update barrier to 2.3.3

### DIFF
--- a/srcpkgs/barrier/template
+++ b/srcpkgs/barrier/template
@@ -1,7 +1,7 @@
 # Template file for 'barrier'
 pkgname=barrier
-version=2.3.2
-revision=2
+version=2.3.3
+revision=1
 build_style=cmake
 configure_args="-DBARRIER_REVISION=00000000 -DBARRIER_VERSION_STAGE=RELEASE"
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
@@ -11,8 +11,23 @@ short_desc="Open-source KVM software based on Synergy"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only"
 homepage="https://github.com/debauchee/barrier"
-distfiles="https://github.com/debauchee/barrier/archive/v${version}.tar.gz"
-checksum=6b92a70c5f4d625065842d133386982ec2ad1db2a809af47e46ab8ce2acd39b5
+_gmock_commit=7d33fee11ec480beae4c28ad09ca56d974140a72
+_gtest_commit=800f5422ac9d9e0ad59cd860a2ef3a679588acb4
+distfiles="https://github.com/debauchee/barrier/archive/v${version}.tar.gz
+ https://github.com/google/googlemock/archive/${_gmock_commit}.tar.gz
+ https://github.com/google/googletest/archive/${_gtest_commit}.tar.gz"
+checksum="259e75c150ca16d9db51870b026dc7aad56c410fa3d2f5fdccc19d4b6024bdc5
+ f4191fd64e8a961c06b7cc90a2bbf3774bd315254884675a900f8f34fc2c4c81
+ 57bc26ac31e1bc47a12e4ae99a0f6e17506ba10f0f82ae16aa52cc7cc215a3b0"
+
+pre_configure() {
+	# move submodule to proper location
+	rmdir ext/gmock
+	rmdir ext/gtest
+
+	mv -v ../googlemock-${_gmock_commit} ext/gmock
+	mv -v ../googletest-${_gtest_commit} ext/gtest
+}
 
 do_install() {
 	vbin build/bin/barrier


### PR DESCRIPTION
Upstream moved to a git submodule for gtest and gmock. I took https://github.com/void-linux/void-packages/blob/master/srcpkgs/wabt/template as an example how to download and move gtest to the proper location.

This works for me locally. Let me know if anything needs changing.