### PR TITLE
New package: squeekboard-1.9.3

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3980,3 +3980,4 @@ libfcft.so.3 fcft-2.2.2_1
 libaml.so.0 aml-0.1.0_1
 libneatvnc.so.0 neatvnc-0.2.0_1
 libtdjson.so.1.6.0 libtd-1.6.0_1
+libfeedback-0.0.so.0 feedbackd-0.0.0+git20200726_1

--- a/srcpkgs/feedbackd/template
+++ b/srcpkgs/feedbackd/template
@@ -1,0 +1,15 @@
+# Template file for 'feedbackd'
+pkgname=feedbackd
+version=0.0.0+git20200726
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_style=meson
+build_helper=gir
+hostmakedepends="pkg-config vala glib-devel"
+makedepends="gsound-devel json-glib-devel libgudev-devel"
+short_desc="Daemon to provide haptic (and later more) feedback on events"
+maintainer="John Sullivan <jsullivan@csumb.edu>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/feedbackd"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=e9632d1d1ef228bb7f6ca3d3d875806b2a5763b4def4e30e94acf0c7f3eb79ef

--- a/srcpkgs/squeekboard/template
+++ b/srcpkgs/squeekboard/template
@@ -1,0 +1,22 @@
+# Template file for 'squeekboard'
+pkgname=squeekboard
+version=1.9.3
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_style=meson
+build_helper=rust
+hostmakedepends="cargo pkg-config glib-devel wayland-devel"
+makedepends="rust gtk+3-devel feedbackd gnome-desktop-devel"
+short_desc="Onscreen keyboard for mobile devices - Used in GNOME Phosh"
+maintainer="John Sullivan <jsullivan@csumb.edu>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/squeekboard"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=b99e56faace3986bf752e08c104cea60ed896d514284840655033dd9457db824
+
+post_patch() {
+	[ -z "${CROSS_BUILD}" ] && return 0
+
+	vsed -i cargo_build.sh \
+		-e 's/\${BINARY_DIR}/${RUST_TARGET}\/debug/'
+}


### PR DESCRIPTION
#24072 will be the first port to a mobile phone, so some mobile graphical elements such as onscreen keyboards will be needed. Squeekboard is maintained by the Librem5 team at purism, and is the choice for most non-kde wayland environments such as wlroots compositors, GNOME 3 (Phosh), etc. It has been used extensively in postmarketos and the pinephone port of Archlinux ARM. 

I've tested it running inside sway on x86_64 and aarch64 cross-compiled. Basic typing and DBus/protocol activation both work.