### PR TITLE
discord: add update script

### DIFF
--- a/srcpkgs/discord/update
+++ b/srcpkgs/discord/update
@@ -1,0 +1,3 @@
+# sample response: {"name": "0.0.11", "pub_date": "2020-08-06T16:59:21"}
+site="https://discordapp.com/api/updates/stable?platform=linux"
+pattern="\"name\":\s*\"\K[\d.]+(?=\")"


### PR DESCRIPTION
This API endpoint is used by the app, and so should be stable.
The app also passes the version, but leaving it out seemingly doesn't cause problems.
ex request: https://discordapp.com/api/updates/stable?platform=linux&version=0.0.10