### PR TITLE
srcpkgs: don't append CFLAGS outside of funtions.

### DIFF
--- a/srcpkgs/arcan/template
+++ b/srcpkgs/arcan/template
@@ -27,7 +27,7 @@ fi
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
-	CFLAGS+=" -latomic"
+	CFLAGS="-latomic"
 fi
 
 build_options="tesseract"

--- a/srcpkgs/execline/template
+++ b/srcpkgs/execline/template
@@ -20,8 +20,8 @@ CFLAGS="-fPIC"
 build_options="static"
 
 if [ "$build_option_static" ]; then
-	CFLAGS+=" -static"
-	LDFLAGS+=" -static"
+	CFLAGS="-static"
+	LDFLAGS="-static"
 fi
 
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/fuse-sshfs/template
+++ b/srcpkgs/fuse-sshfs/template
@@ -18,7 +18,7 @@ checksum=6e7e86831f3066b356e7f16e22f1b8a8f177fda05146f6a5eb821c2fd0541c34
 
 case "${XBPS_TARGET_MACHINE}" in
 	i686|armv6l|armv7l)
-		CFLAGS+=" -D_FILE_OFFSET_BITS=64"
+		CFLAGS="-D_FILE_OFFSET_BITS=64"
 esac
 
 do_check() {

--- a/srcpkgs/gdb/template
+++ b/srcpkgs/gdb/template
@@ -22,8 +22,8 @@ patch_args="-Np1"
 
 if [ "${CROSS_BUILD}" ]; then
 	# Make python3.x detection work in cross builds
-	CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc}"
-	CXXFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc}"
+	CFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
+	CXXFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
 fi
 # Package build options
 build_options="gdbserver static python"

--- a/srcpkgs/musl-bootstrap/template
+++ b/srcpkgs/musl-bootstrap/template
@@ -16,7 +16,7 @@ distfiles="http://www.musl-libc.org/releases/musl-${version}.tar.gz"
 checksum=1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
 
 case "$XBPS_TARGET_MACHINE" in
-	ppc*) CFLAGS+=" -mlong-double-64";;
+	ppc*) CFLAGS="-mlong-double-64";;
 esac
 
 post_install() {

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -35,7 +35,7 @@ desc_option_iscsi="Enable support for iSCSI"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*|ppc64le*) build_options_default+=" spice";;
-	aarch64-musl) CFLAGS+=" -D_LINUX_SYSINFO_H";;
+	aarch64-musl) CFLAGS="-D_LINUX_SYSINFO_H";;
 esac
 
 pre_configure() {

--- a/srcpkgs/runit/template
+++ b/srcpkgs/runit/template
@@ -15,8 +15,8 @@ checksum=6fd0160cb0cf1207de4e66754b6d39750cff14bb0aa66ab49490992c0c47ba18
 build_options="static"
 
 if [ "$build_option_static" ]; then
-	CFLAGS+=" -static"
-	LDFLAGS+=" -static"
+	CFLAGS="-static"
+	LDFLAGS="-static"
 fi
 
 pre_build() {

--- a/srcpkgs/wxPython4/template
+++ b/srcpkgs/wxPython4/template
@@ -18,7 +18,7 @@ distfiles="${PYPI_SITE}/w/wxPython/wxPython-${version}.tar.gz"
 checksum=3be608bfdede3063678cc703453850ab0a018b82bafd5ee057302250b18f0233
 
 if [ "$CROSS_BUILD" ]; then
-	CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/python${py3_ver}"
+	CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python${py3_ver}"
 fi
 
 pre_build() {


### PR DESCRIPTION
Package templates are sourced multiple times during the build process,
which can lead to issues when defining variables like CFLAGS using
`CFLAGS+=`, since the contents will be added multiple times. This can
lead to a build command with `-static -static`, for example. Adding to
CFLAGS inside functions is safe, since functions are run only once.