### PR TITLE
s6-networking: add bearssl option, add devel deps.

### DIFF
--- a/srcpkgs/s6-networking/template
+++ b/srcpkgs/s6-networking/template
@@ -1,19 +1,27 @@
 # Template file for 's6-networking'
 pkgname=s6-networking
 version=2.3.1.2
-revision=2
+revision=3
 build_style=configure
-configure_args="--libdir=/usr/lib --enable-ssl=libressl
+configure_args="--libdir=/usr/lib $(vopt_if libressl --enable-ssl=libressl)
+ $(vopt_if bearssl --enable-ssl=bearssl)
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --with-lib=${XBPS_CROSS_BASE}/usr/lib --bindir=/usr/bin"
-makedepends="execline-devel libressl-devel skalibs-devel s6-devel s6-dns-devel"
+makedepends="execline-devel $(vopt_if libressl libressl-devel) skalibs-devel
+ s6-devel s6-dns-devel $(vopt_if bearssl bearssl-devel)"
 short_desc="Suite of small network utilities for Unix systems"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="ISC"
-homepage="https://skarnet.org/software/${pkgname}/"
+homepage="https://skarnet.org/software/s6-networking"
 changelog="https://skarnet.org/software/s6-networking/upgrade.html"
-distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
+distfiles="${homepage}/${pkgname}-${version}.tar.gz"
 checksum=d953dbfdf9020bb27e873328df1b644f8a7b6a3972a4288b1f20edeaf85b4980
+
+build_options="bearssl libressl"
+build_options_default="libressl"
+desc_option_bearssl="Use BearSSL as SSL library"
+desc_option_libressl="Use LibreSSL as SSL library"
+vopt_conflict bearssl libressl
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" nsss-devel" configure_args+=" --enable-nsss" ;;
@@ -35,6 +43,8 @@ s6-networking-doc_package() {
 }
 s6-networking-devel_package() {
 	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision} skalibs-devel
+	 $(vopt_if libressl libressl-devel) $(vopt_if bearssl bearssl-devel)"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"


### PR DESCRIPTION
s6-networking can also be built with BearSSL support, with full
functionality. The devel package for the chosen SSL library and
skalibs-devel are necessary for development with s6-networking
libraries, so they have been added as dependencies to the
s6-networking-devel.

Also xlint.