### PR TITLE
New package: rot8

### DIFF
--- a/srcpkgs/rot8/template
+++ b/srcpkgs/rot8/template
@@ -1,0 +1,15 @@
+# Template file for 'rot8'
+pkgname=rot8
+version=0.1.3
+revision=1
+build_style=cargo
+short_desc="Screen rotation daemon"
+maintainer="Harrison Thorne <harrisonthorne@protonmail.com>"
+license="MIT"
+homepage="https://github.com/efernau/rot8"
+distfiles="https://github.com/efernau/rot8/archive/v${version}.tar.gz"
+checksum=14b3e0073462de8a7a010d10485c841f81a3e6dfce90f6c8401fbbb4419f8125
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
`rot8` is a screen rotation daemon that works with Sway and X11.

[GitHub repo](https://github.com/efernau/rot8)

Sway itself [suggests using rot8](https://github.com/swaywm/sway/wiki#display-rotation) for automatic display rotation.