### PR TITLE
nss: update to 3.56

### DIFF
--- a/srcpkgs/nspr/template
+++ b/srcpkgs/nspr/template
@@ -1,6 +1,6 @@
 # Template file for 'nspr'
 pkgname=nspr
-version=4.27
+version=4.28
 revision=1
 build_wrksrc=nspr
 build_style=gnu-configure
@@ -10,7 +10,7 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="http://www.mozilla.org/projects/nspr/"
 distfiles="${MOZILLA_SITE}/nspr/releases/v${version}/src/${pkgname}-${version}.tar.gz"
-checksum=6d495192b6ab00a3c28db053492cf794329f7c0351a5728db198111a1816e89b
+checksum=63defc8e19a80b6f98fcc7d5a89e84ea703c0b50aa6bc13bf7ad071adf433b56
 
 do_configure() {
 	CFLAGS="$CFLAGS -D_PR_POLL_AVAILABLE -D_PR_HAVE_OFF64_T -D_PR_INET6 -D_PR_HAVE_INET_NTOP -D_PR_HAVE_GETHOSTBYNAME2 -D_PR_HAVE_GETADDRINFO -D_PR_INET6_PROBE"

--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -1,9 +1,9 @@
 # Template file for 'nss'
 
-_nsprver=4.27
+_nsprver=4.28
 
 pkgname=nss
-version=3.55
+version=3.56
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -13,7 +13,15 @@ maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.mozilla.org/projects/security/pki/nss"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=fc692e3db45a082ee6328cd989e795c171a00df9c518df090937f7604f850004
+checksum=f875e0e8ed3b5ce92d675be4a55aa25a8c1199789a4a01f69b5f2327e2048e9c
+
+export NS_USE_GCC=1
+export LIBRUNPATH=
+export BUILD_OPT=1
+export NSS_USE_SYSTEM_SQLITE=1
+export NSS_ENABLE_WERROR=0
+export NSS_ENABLE_ECC=1
+export FREEBL_NO_DEPEND=1
 
 do_build() {
 	local _native_use64 _target_use64
@@ -22,20 +30,11 @@ do_build() {
 	vsed -e 's/\$(MKSHLIB) -o/\$(MKSHLIB) \$(LDFLAGS) -o/g' \
 		-i nss/coreconf/rules.mk
 
-	export LIBRUNPATH=
-	export BUILD_OPT=1
-	export NSS_USE_SYSTEM_SQLITE=1
-	export NSS_ENABLE_WERROR=0
-	export NSS_ENABLE_ECC=1
-	export FREEBL_NO_DEPEND=1
 	export NATIVE_CC="$BUILD_CC"
 	export NATIVE_FLAGS="$BUILD_CFLAGS"
 
 	if [ "$XBPS_WORDSIZE" = "64" ]; then
 		_native_use64="USE_64=1"
-	fi
-	if [ "$XBPS_TARGET_WORDSIZE" = "64" ]; then
-		_target_use64="USE_64=1"
 	fi
 
 	# it's actually VSX, so disable on all BE ppc
@@ -49,14 +48,17 @@ do_build() {
 	make ${makejobs} LD=$BUILD_LD LDFLAGS="$BUILD_LDFLAGS" ${_native_use64} -C coreconf
 
 	if [ "$CROSS_BUILD" ]; then
+		if [ "$XBPS_TARGET_WORDSIZE" = "64" ]; then
+			CFLAGS+=" -DNS_PTR_GT_32"
+			_target_use64="USE_64=1"
+		fi
+
 		case "$XBPS_TARGET_MACHINE" in
-			aarch64*|ppc64*|x86_64*)
+			aarch64*|ppc*|x86_64*)
 				_ARCH="${XBPS_TARGET_MACHINE%-*}"
-				CFLAGS+=" -DNS_PTR_GT_32"
 				;;
 			arm*) _ARCH="arm";;
 			mips*) _ARCH="mips";;
-			ppc*) _ARCH="ppc";;
 			*) msg_error "$pkgver: unknown target machine\n";;
 		esac
 		# ... and then copy it to $wrksrc.
@@ -84,14 +86,6 @@ do_build() {
 
 do_check() {
 	local _use_64
-	export LIBRUNPATH=
-	export BUILD_OPT=1
-	export NSS_USE_SYSTEM_SQLITE=1
-	export NSS_ENABLE_WERROR=0
-	export NSS_ENABLE_ECC=1
-	export FREEBL_NO_DEPEND=1
-	export NATIVE_CC="$BUILD_CC"
-	export NATIVE_FLAGS="$BUILD_CFLAGS"
 	# We couldn't run test in cross compile!
 	export NSPR_INCLUDE_DIR=/usr/include/nspr
 	export NSPR_LIB_DIR=/usr/lib


### PR DESCRIPTION
`aarch64*` needs `export NS_USE_GCC=1` to use the correct code path.

* tested with x86_64 (glibc, musl, and glibc in sandy bridge), i686
* Will run another test with aarch64* in qemu-user-static