### PR TITLE
[RFC] xbps-src: allow JSON in update_check

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -161,7 +161,7 @@ update_check() {
         if [ -n "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
             echo "fetching $url" 1>&2
         fi
-        curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml' -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$url" |
+        curl -H 'Accept: text/html,application/xhtml+xml,application/xml,text/plain,application/rss+xml,application/json' -A "xbps-src-update-check/$XBPS_SRC_VERSION" --max-time 10 -Lsk "$url" |
             grep -Po -i "$rx"
         fetchedurls[$url]=yes
     done |

--- a/srcpkgs/python3-bokeh/update
+++ b/srcpkgs/python3-bokeh/update
@@ -1,0 +1,2 @@
+site="https://api.github.com/repos/bokeh/bokeh/tags"
+pattern='"name":\s*"\K[0-9.]+(?=")'


### PR DESCRIPTION
The `update_check` function restricts content types from sites that provide version lists. Adding `application/json` as an accepted type allows querying sites like

https://api.github.com/repos/<org\>/<repo\>/tags

which provide more complete listings of tags than the default locations that return HTML. This can be important for projects that provide a large number of prerelease tarballs, because they can flood the default tag or release pages and prevent proper version detection.

The `python3-bokeh` `update` definition takes advantage of this new capability to properly track versions.