### PR TITLE
66: update to 0.5.0.1.

### DIFF
--- a/srcpkgs/66/template
+++ b/srcpkgs/66/template
@@ -1,32 +1,28 @@
 # Template file for '66'
 pkgname=66
-version=0.5.0.0
-revision=3
+version=0.5.0.1
+revision=1
 wrksrc="66-v${version}"
 build_style=configure
 configure_args="--prefix=/usr
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --with-lib=${XBPS_CROSS_BASE}/usr/lib
- --with-s6-log-timestamp=iso"
+ --with-s6-log-timestamp=iso
+ --with-s6-log-user=_s6log"
 hostmakedepends="pkg-config lowdown"
 makedepends="oblibs-devel skalibs-devel execline-devel s6-devel
-s6-rc-devel procps-ng-devel"
-depends="s6-portable-utils"
+s6-rc-devel"
 short_desc="Small tools built around s6 and s6-rc programs"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="http://web.obarun.org/software/"
 changelog="https://framagit.org/Obarun/66/raw/master/NEWS.md"
 distfiles="https://framagit.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
-checksum=dd505d8d4355c33f4cdf79ad69b1fdc6aa9996cf9532116eea2e13ba7dac455a
+checksum=d4fc4bf08c41db2c3513ea3b806dcc41f11b2ff85064a5e801fa6054c05d2e69
 
 conf_files="/etc/66/init /etc/66/init.conf"
-make_dirs="
-/var/log/66 0755 root root
-/var/lib/66 0755 root root
-/usr/share/66/service 0755 root root
-/etc/66/service 0755 root root
-/etc/66/conf 0755 root root"
+
+system_accounts="_s6log"
 
 post_install() {
 	local i


### PR DESCRIPTION
This is minor bugfix release for 66.

Template changes:

1. A system account is created for the logger (`_s6log`).
2. `make_dirs` is removed.
3.  `makedepends` array is cleaned.

2&3 are based on recommendations by @Obarun. 