### PR TITLE
New package: R-cran-svglite-1.2.3.2

### DIFF
--- a/srcpkgs/R-cran-BH/template
+++ b/srcpkgs/R-cran-BH/template
@@ -1,0 +1,11 @@
+# Template file for 'R-cran-BH'
+pkgname=R-cran-BH
+version=1.72.0r3
+revision=1
+build_style=R-cran
+makedepends="boost-devel"
+short_desc="Boost C++ Header Files for R"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
+license="BSL-1.0"
+homepage="https://github.com/eddelbuettel/bh"
+checksum=888ec1a3316bb69e1ba749b08ba7e0903ebc4742e3a185de8d148c13cddac8ab

--- a/srcpkgs/R-cran-gdtools/template
+++ b/srcpkgs/R-cran-gdtools/template
@@ -1,0 +1,19 @@
+# Template file for 'R-cran-gdtools'
+pkgname=R-cran-gdtools
+version=0.2.2
+revision=1
+build_style=R-cran
+hostmakedepends="pkg-config"
+makedepends="R-cran-Rcpp R-cran-systemfonts cairo-devel freetype-devel"
+depends="R-cran-Rcpp>=0.12.12 R-cran-systemfonts>=0.1.1"
+short_desc="R utilities for graphical rendering"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/davidgohel/gdtools"
+checksum=4e629a3d30a87a6b4e2bbb42f298a821ef8264ca60f02285e17119066cfcd222
+
+pre_install() {
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		export PKG_CXXFLAGS+=" -D__MUSL__"
+	fi
+}

--- a/srcpkgs/R-cran-svglite/template
+++ b/srcpkgs/R-cran-svglite/template
@@ -1,0 +1,12 @@
+# Template file for 'R-cran-svglite'
+pkgname=R-cran-svglite
+version=1.2.3.2
+revision=1
+build_style=R-cran
+makedepends="R-cran-Rcpp R-cran-BH R-cran-gdtools"
+depends="R-cran-Rcpp R-cran-gdtools>=0.1.6"
+short_desc="Lightweight svg graphics device for R"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
+license="GPL-2.0-or-later"
+homepage="https://svglite.r-lib.org"
+checksum=25d60779cc81aac6d13499e4dc59fd46f013889a4c904d0404f4451ac95bc802

--- a/srcpkgs/R-cran-systemfonts/template
+++ b/srcpkgs/R-cran-systemfonts/template
@@ -1,0 +1,16 @@
+# Template file for 'R-cran-systemfonts'
+pkgname=R-cran-systemfonts
+version=0.2.3
+revision=1
+build_style=R-cran
+hostmakedepends="pkg-config"
+makedepends="fontconfig-devel freetype-devel"
+short_desc="System Native Font Handling in R"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
+license="MIT"
+homepage="https://github.com/r-lib/systemfonts"
+checksum=cb5251af974c488dee8331a771802cf69e0849f4ab650e26cbf497aa5c15c671
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Adds svglite R package and relevant dependencies.
These graphics packages pull in a lot of system deps,
so it is nice to have them in the Void repos.