### PR TITLE
Remove python-subliminal, python-stevedore

### DIFF
--- a/srcpkgs/python3-stevedore
+++ b/srcpkgs/python3-stevedore
@@ -1,1 +1,0 @@
-python-stevedore

--- a/srcpkgs/python3-stevedore/template
+++ b/srcpkgs/python3-stevedore/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-stevedore'
 pkgname=python3-stevedore
-version=1.30.1
-revision=2
+version=3.2.0
+revision=1
 archs=noarch
 wrksrc="stevedore-${version}"
 build_style=python3-module
-pycompile_module="stevedore"
 hostmakedepends="python3-setuptools python3-pbr"
 depends="python3-six"
 short_desc="Manage dynamic plugins for Python3 applications"
@@ -13,7 +12,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="Apache-2.0"
 homepage="https://git.openstack.org/cgit/openstack/stevedore"
 distfiles="${PYPI_SITE}/s/stevedore/stevedore-${version}.tar.gz"
-checksum=7be098ff53d87f23d798a7ce7ae5c31f094f3deb92ba18059b1aeb1ca9fec0a0
+checksum=38791aa5bed922b0a844513c5f9ed37774b68edc609e5ab8ab8d8fe0ce4315e5
 
 pre_build() {
 	# remove dependency on pbr; it's not a runtime dependency

--- a/srcpkgs/python3-stevedore/template
+++ b/srcpkgs/python3-stevedore/template
@@ -1,14 +1,14 @@
-# Template file for 'python-stevedore'
-pkgname=python-stevedore
+# Template file for 'python3-stevedore'
+pkgname=python3-stevedore
 version=1.30.1
 revision=2
 archs=noarch
 wrksrc="stevedore-${version}"
-build_style=python-module
+build_style=python3-module
 pycompile_module="stevedore"
-hostmakedepends="python-setuptools python3-setuptools python-pbr python3-pbr"
-depends="python-six"
-short_desc="Manage dynamic plugins for Python2 applications"
+hostmakedepends="python3-setuptools python3-pbr"
+depends="python3-six"
+short_desc="Manage dynamic plugins for Python3 applications"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="Apache-2.0"
 homepage="https://git.openstack.org/cgit/openstack/stevedore"
@@ -18,14 +18,4 @@ checksum=7be098ff53d87f23d798a7ce7ae5c31f094f3deb92ba18059b1aeb1ca9fec0a0
 pre_build() {
 	# remove dependency on pbr; it's not a runtime dependency
 	sed -i '/pbr/d' requirements.txt
-}
-
-python3-stevedore_package() {
-	archs=noarch
-	depends="python3-six"
-	pycompile_module="stevedore"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-	}
 }


### PR DESCRIPTION
Subliminal depends on stevedore>=3 and dogpile.cache, that do not work anymore with py2.