### PR TITLE
Revert "libtorrent-rasterbar: update to 1.2.9."

### DIFF
--- a/srcpkgs/btfs/template
+++ b/srcpkgs/btfs/template
@@ -1,7 +1,7 @@
 # Template file for 'btfs'
 pkgname=btfs
 version=2.22
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="boost-devel fuse-devel libcurl-devel libtorrent-rasterbar-devel"

--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,7 +1,7 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=2.0.3
-revision=6
+revision=7
 archs=noarch
 build_style=python3-module
 # TODO package python3-slimit to minify javascript

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,7 +1,9 @@
 # Template file for 'libtorrent-rasterbar'
+# Breaks ABI/API without changing soname, revbump all dependants
 pkgname=libtorrent-rasterbar
-version=1.2.9
-revision=1
+reverts="1.2.9_1"
+version=1.2.7
+revision=3
 build_style=gnu-configure
 configure_args="--enable-examples --enable-python-binding
  --with-boost=${XBPS_CROSS_BASE}/usr
@@ -12,8 +14,8 @@ short_desc="C++ bittorrent library by Rasterbar Software"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
-distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent-${version}/libtorrent-rasterbar-${version}.tar.gz"
-checksum=6c986225a1c2d9eb23c5b1ac0692d83208b721a05c968102a17ee3fde01bd709
+distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent_${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
+checksum=bc00069e65c0825cbe1eee5cdd26f94fcd9a621c4e7f791810b12fab64192f00
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
 version=4.2.5
-revision=2
+revision=3
 create_wrksrc=yes
 build_style=qmake
 hostmakedepends="automake libtool pkg-config qt5-host-tools qt5-qmake qt5-tools tar xz"


### PR DESCRIPTION
This reverts commit 216fdd4f1f998447fd8d2cb4ed22cc216b193fac.

Fixes #24512

@pullmoll 