### PR TITLE
New package: intermodal-0.1.10

### DIFF
--- a/srcpkgs/intermodal/template
+++ b/srcpkgs/intermodal/template
@@ -1,0 +1,11 @@
+# Template file for 'intermodal'
+pkgname=intermodal
+version=0.1.10
+revision=1
+build_style=cargo
+short_desc="User-friendly and featureful command-line BitTorrent metainfo utility"
+maintainer="Pika <pika@lasagna.dev>"
+license="CC0-1.0"
+homepage="https://github.com/casey/intermodal"
+distfiles="https://github.com/casey/intermodal/archive/v${version}.tar.gz"
+checksum=8bb3e4f549e5c4446543babd741fec0cd7c42da4d49eca3e98c5f7611ad59618


### PR DESCRIPTION
This PR adds [Intermodal](https://github.com/casey/intermodal), a user-friendly and featureful command-line BitTorrent metainfo utility.