### PR TITLE
cutter: Additionally load plugins from /usr/lib

### DIFF
--- a/srcpkgs/cutter/template
+++ b/srcpkgs/cutter/template
@@ -1,9 +1,10 @@
 # Template file for 'cutter'
 pkgname=cutter
 version=1.11.1
-revision=1
+revision=2
 build_wrksrc=src
 build_style=qmake
+configure_args="CUTTER_EXTRA_PLUGIN_DIRS=/usr/lib/RadareOrg/Cutter/plugins"
 hostmakedepends="pkg-config qt5-declarative-devel qt5-location-devel
  qt5-svg-devel qt5-tools-devel radare2"
 makedepends="capstone-devel python3-devel qt5-declarative-devel


### PR DESCRIPTION
Currently cutter only loads plugins from /usr/share and ~/.local, this makes it load them from /usr/lib aswell. See #24453 