### PR TITLE
[WIP] New package: shellcaster-1.0.1

### DIFF
--- a/srcpkgs/shellcaster/template
+++ b/srcpkgs/shellcaster/template
@@ -1,0 +1,19 @@
+# Template file for 'shellcaster'
+pkgname=shellcaster
+version=1.0.1
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libressl-devel ncurses-devel sqlite-devel"
+short_desc="Terminal-based podcast manager built in Rust"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://github.com/jeff-hughes/shellcaster"
+changelog="https://github.com/jeff-hughes/shellcaster/raw/master/CHANGELOG.md"
+distfiles="https://github.com/jeff-hughes/shellcaster/archive/v${version}.tar.gz"
+checksum=323945dc84bef27d09e57b831d2c0a0d4524c69b38d85f3be2701521b89dd9d1
+nocross="ncurses-rs tries to run a target executable on the host"
+
+post_install() {
+	vsconf config.toml
+}


### PR DESCRIPTION
Terminal-based podcast manager built in Rust

https://github.com/jeff-hughes/shellcaster

Unfortunately nocross because ncurses-rs's build.rs tries to run a target executable on the host.