### PR TITLE
New package: opencamlib-2019.07

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3981,6 +3981,7 @@ libtexlua53.so.5 texlive-LuaTeX-20200406_1
 libptexenc.so.1 texlive-20200406_1
 libsynctex.so.2 libsynctex-20200406_3
 libdolphinvcs.so.5 dolphin-20.04.3_1
+libocl.so.2019.07 opencamlib-2019.07_1
 libcglm.so.0 cglm-0.7.6_1
 libfcft.so.3 fcft-2.2.2_1
 libaml.so.0 aml-0.1.0_1

--- a/srcpkgs/opencamlib-devel
+++ b/srcpkgs/opencamlib-devel
@@ -1,0 +1,1 @@
+opencamlib/

--- a/srcpkgs/opencamlib-python3
+++ b/srcpkgs/opencamlib-python3
@@ -1,0 +1,1 @@
+opencamlib/

--- a/srcpkgs/opencamlib/template
+++ b/srcpkgs/opencamlib/template
@@ -1,0 +1,36 @@
+# Template file for 'opencamlib'
+pkgname=opencamlib
+version=2019.07
+revision=1
+build_style=cmake
+configure_args="-DBUILD_PY_LIB=ON -DUSE_PY_3=ON -DVERSION_STRING=${version}"
+hostmakedepends="python3"
+makedepends="python3-devel boost-devel libboost_program_options1.72 libgomp-devel"
+short_desc="Open source computer aided manufacturing algorithms library"
+maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
+license="LGPL-2.1-or-later"
+homepage="http://www.anderswallin.net/CAM"
+distfiles="https://github.com/aewallin/opencamlib/archive/${version}.tar.gz"
+checksum=e08ab50672e24b51d30938ac60a6caa38bd8f5fb5f8fa3375dec0e69031cb620
+
+subpackages="opencamlib-devel"
+# opencamlib-python3 cannot be cross compiled because of vtk-python3
+if [ -z "$CROSS_BUILD" ]; then
+	subpackages+=" opencamlib-python3"
+fi
+
+opencamlib-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+	}
+}
+
+opencamlib-python3_package() {
+	short_desc+=" - Python3 bindings"
+	depends="${sourcepkg}>=${version}_${revision} vtk-python3"
+	pkg_install() {
+		vmove "usr/lib/python3*"
+	}
+}


### PR DESCRIPTION
@Piraty the python bindings depend on vtk's python wrapper. How difficult would it be to enable that in vtk?