### PR TITLE
New packages: phoc-0.4.2 calls-0.1.7 purism-chatty-0.1.15

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3989,3 +3989,4 @@ libneatvnc.so.0 neatvnc-0.2.0_1
 libtdjson.so.1.6.0 libtd-1.6.0_1
 libJudy.so.1 judy-1.0.5_1
 libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2
+libfeedback-0.0.so.0 libfeedback-0.0.0+git20200707_1

--- a/srcpkgs/calls/template
+++ b/srcpkgs/calls/template
@@ -1,0 +1,17 @@
+# Template file for 'calls'
+pkgname=calls
+version=0.1.8
+revision=1
+wrksrc=${pkgname}-v${version}
+build_style=meson
+hostmakedepends="glib-devel gettext vala pkg-config wayland-devel
+ evolution-data-server-devel"
+makedepends="folks-devel libhandy-devel libpeas-devel gom-devel
+ ModemManager-devel libfeedback-devel"
+depends="NetworkManager ModemManager"
+short_desc="Phone call application"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/calls"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=58fd2c438fadec812a73181fd6b1a79478814bb10bf8153f3b79a4c6271078a9

--- a/srcpkgs/calls/update
+++ b/srcpkgs/calls/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/feedbackd/template
+++ b/srcpkgs/feedbackd/template
@@ -1,0 +1,37 @@
+# Template file for 'feedbackd'
+pkgname=feedbackd
+version=0.0.0+git20200726
+revision=1
+wrksrc=${pkgname}-v${version}
+build_style=meson
+build_helper=gir
+hostmakedepends="vala glib-devel pkg-config"
+makedepends="gsound-devel libgudev-devel json-glib-devel"
+depends="dbus"
+short_desc="Daemon to provide haptic feedback on events"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/feedbackd"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=e9632d1d1ef228bb7f6ca3d3d875806b2a5763b4def4e30e94acf0c7f3eb79ef
+
+post_install() {
+	vinstall debian/feedbackd.udev 0644 usr/lib/udev/rules.d 90-feedbackd.rules
+}
+
+libfeedback_package() {
+	short_desc+=" - shared libraries"
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+	}
+}
+
+libfeedback-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/feedbackd/update
+++ b/srcpkgs/feedbackd/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/kgx/template
+++ b/srcpkgs/kgx/template
@@ -1,0 +1,14 @@
+# Template file for 'kgx'
+pkgname=kgx
+version=0.2.1
+revision=1
+build_style=meson
+hostmakedepends="glib-devel pkg-config gettext"
+makedepends="vte3-devel gtk+3-devel libhandy-devel libgtop-devel"
+depends="dbus desktop-file-utils gsettings-desktop-schemas"
+short_desc="Minimal terminal for GNOME"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.gnome.org/ZanderBrown/kgx"
+distfiles="${homepage}/-/archive/${version}/kgx-${version}.tar.gz"
+checksum=70a814b0baf70049d5a20791d58a32e92661428d2deeeb56d91b81cc4dc5e81a

--- a/srcpkgs/libfeedback
+++ b/srcpkgs/libfeedback
@@ -1,0 +1,1 @@
+feedbackd

--- a/srcpkgs/libfeedback-devel
+++ b/srcpkgs/libfeedback-devel
@@ -1,0 +1,1 @@
+feedbackd

--- a/srcpkgs/megapixels/template
+++ b/srcpkgs/megapixels/template
@@ -1,0 +1,13 @@
+# Template file for 'megapixels'
+pkgname=megapixels
+version=0.8.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config glib-devel"
+makedepends="gtk+3-devel"
+short_desc="GTK+3 camera app for ARM devices"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://git.sr.ht/~martijnbraam/megapixels"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=af21a62c163d912bc8b9ace77701b0f8cc76e1d423c4e644e67fd8e92b645ba7

--- a/srcpkgs/megapixels/update
+++ b/srcpkgs/megapixels/update
@@ -1,0 +1,2 @@
+site="https://git.sr.ht/~martijnbraam/megapixels/refs"
+pattern='/archive/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/mobile-config-firefox/files/distro_links.html
+++ b/srcpkgs/mobile-config-firefox/files/distro_links.html
@@ -1,0 +1,5 @@
+<p class="distro-links">
+	<a href="https://voidlinux.org/">homepage</a> -
+	<a href="https://docs.voidlinux.org/">docs</a>
+	<a href="https://github.com/void-linux">repos</a>
+</p>

--- a/srcpkgs/mobile-config-firefox/template
+++ b/srcpkgs/mobile-config-firefox/template
@@ -1,0 +1,16 @@
+# Template file for 'mobile-config-firefox'
+pkgname=mobile-config-firefox
+version=1.0.1
+revision=1
+build_style=gnu-makefile
+make_install_args="DISTRO=VoidLinux"
+short_desc="Firefox tweaks for mobile and privacy"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.com/postmarketOS/mobile-config-firefox"
+distfiles="${homepage}/-/archive/${version}/${pkgname}-${version}.tar.gz"
+checksum=7dce837995956f6f224041853e005eecb3368cd3cbfec6fe3e8a3153747dd0a7
+
+post_extract() {
+	cp ${FILESDIR}/distro_links.html src/homepage
+}

--- a/srcpkgs/phoc/template
+++ b/srcpkgs/phoc/template
@@ -1,0 +1,16 @@
+# Template file for 'phoc'
+pkgname=phoc
+version=0.4.2
+revision=1
+wrksrc=${pkgname}-v${version}
+build_style=meson
+configure_args="-Dembed-wlroots=disabled"
+hostmakedepends="glib-devel pkg-config wayland-devel"
+makedepends="gnome-desktop-devel wlroots-devel"
+depends="mutter"
+short_desc="Wlroots based Phone compositor for the Phosh shell"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/phoc"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=bdb34644c7d49c953239c1e939bc5ee2bc26f6187b9d756b70b113d2734c712c

--- a/srcpkgs/phoc/update
+++ b/srcpkgs/phoc/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/phosh-desktop/files/000-gschema.override
+++ b/srcpkgs/phosh-desktop/files/000-gschema.override
@@ -1,0 +1,20 @@
+[org.gnome.desktop.background]
+picture-uri='file:///usr/share/backgrounds/gnome/LightWaves.jpg'
+
+[org.gnome.desktop.interface]
+clock-show-weekday=false
+clock-show-date=false
+
+[org.gnome.desktop.wm.preferences]
+button-layout='appmenu:'
+
+[org.gnome.Epiphany]
+search-engines=[('Search the Web', 'https://duckduckgo.com/?q=%s&t=epiphany', ''), ('DuckDuckGo', 'https://duckduckgo.com/?q=%s&t=epiphany', '!ddg'), ('Qwant', 'https://www.qwant.com/?q=%s', '!q')]
+
+[org.gnome.Epiphany.web]
+user-agent='Mozilla/5.0 (Linux; Android 10; Pixel) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36'
+
+
+[org.gnome.settings-daemon.plugins.power]
+sleep-inactive-ac-type='nothing'
+ambient-enabled=false

--- a/srcpkgs/phosh-desktop/files/01-phoc-scaling
+++ b/srcpkgs/phosh-desktop/files/01-phoc-scaling
@@ -1,0 +1,5 @@
+[sm/puri/phoc/application/firefox]
+scale-to-fit=false
+
+[sm/puri/phoc/application/org-gnome-maps]
+scale-to-fit=true

--- a/srcpkgs/phosh-desktop/template
+++ b/srcpkgs/phosh-desktop/template
@@ -1,0 +1,45 @@
+# Template file for 'phosh-desktop'
+pkgname=phosh-desktop
+version=0.1
+revision=1
+build_style=meta
+depends="
+ phosh
+ kgx
+ calls
+ megapixels
+ purism-chatty
+ iio-sensor-proxy
+ xdg-user-dirs
+ xdg-desktop-portal-gtk
+ gnome-backgrounds
+ gnome-color-manager
+ gnome-control-center
+ gnome-desktop
+ gnome-keyring
+ gnome-online-accounts
+ gnome-online-miners
+ gnome-calculator
+ gnome-calendar
+ gnome-clocks
+ gnome-contacts
+ gnome-maps
+ gnome-music
+ gnome-system-monitor
+ gedit
+ eog
+ evince
+ epiphany
+ evolution
+ gsettings-desktop-schemas
+ nautilus"
+
+short_desc="Phosh desktop environment metapackage"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://voidlinux.org"
+
+post_install() {
+	vinstall ${FILESDIR}/000-gschema.override 644 usr/share/glib-2.0/schemas 000-void.gschema.override
+	vinstall ${FILESDIR}/01-phoc-scaling 644 etc/dconf/db/void.d
+}

--- a/srcpkgs/phosh/files/phosh.desktop
+++ b/srcpkgs/phosh/files/phosh.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Phosh
+Name[en]=Phosh
+Comment=This session logs you into Phosh
+Comment[en]=This session logs in you into Phosh
+Exec=dbus-run-session /usr/bin/phosh
+TryExec=/usr/bin/phosh
+Icon=
+Type=Application
+X-DesktopNames=Phosh
+Keywords=launch;Phosh;desktop;session;

--- a/srcpkgs/phosh/files/sm.puri.OSK0.desktop
+++ b/srcpkgs/phosh/files/sm.puri.OSK0.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=On-screen keyboard
+Comment=Default on-screen keyboard
+Exec=/usr/bin/squeekboard
+Categories=GNOME;Core;
+OnlyShowIn=GNOME;
+NoDisplay=true
+X-GNOME-Autostart-Phase=Panel
+X-GNOME-Provides=inputmethod
+X-GNOME-Autostart-Notify=true
+X-GNOME-AutoRestart=true

--- a/srcpkgs/phosh/template
+++ b/srcpkgs/phosh/template
@@ -1,0 +1,22 @@
+# Template file for 'phosh'
+pkgname=phosh
+version=0.4.4
+revision=1
+build_style=meson
+hostmakedepends="phoc glib-devel gettext pkg-config wayland-devel"
+makedepends="libfeedback-devel gcr-devel gnome-desktop-devel pam-devel
+ polkit-devel pulseaudio-devel libsecret-devel libhandy1-devel
+ NetworkManager-devel upower-devel"
+depends="phoc squeekboard gnome-session gnome-settings-daemon elogind
+ xorg-server-xwayland cantarell-fonts font-adobe-source-code-pro"
+short_desc="Shell PoC for the Librem5"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/phosh"
+distfiles="https://repo.pureos.net/pureos/pool/main/p/phosh/phosh_$version.tar.xz"
+checksum=1b1161e23b22496027d7c93d75b1be54918402007c4128a1efb8adb3690f437d
+
+post_install() {
+	vcopy ${FILESDIR}/sm.puri.OSK0.desktop usr/share/applications
+	vcopy ${FILESDIR}/phosh.desktop usr/share/wayland-sessions
+}

--- a/srcpkgs/pinephone-wys/files/wys.desktop
+++ b/srcpkgs/pinephone-wys/files/wys.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Wys
+Comment=Daemon for managing PulseAudio for phone call audio
+Exec=/usr/bin/wys
+NoDisplay=true
+Terminal=false
+Type=Application
+StartupNotify=true
+X-GNOME-AutoRestart=true

--- a/srcpkgs/pinephone-wys/patches/0001-Simplify-daemon-to-only-switch-card-profiles.patch
+++ b/srcpkgs/pinephone-wys/patches/0001-Simplify-daemon-to-only-switch-card-profiles.patch
@@ -1,0 +1,906 @@
+From f66610d26395de15e3928cf4284573ca9cfabf26 Mon Sep 17 00:00:00 2001
+From: Arnaud Ferraris <arnaud.ferraris@collabora.com>
+Date: Fri, 6 Mar 2020 02:01:52 +0100
+Subject: [PATCH] Simplify daemon to only switch card profiles
+
+As a PoC for the PinePhone, we want to only switch card profiles:
+- when a call starts, use the "Voice Call" profile: audio is output on
+the earpiece, and the internal microphone is unmuted
+- when a call is terminated, switch back to the default "HiFi" profile,
+using the main speaker
+
+This should fully cover the most basic use-case. Headset will not work,
+and there is also no support for a "silent mode", but this is enough to
+demonstrate voice calls for the PinePhone.
+---
+diff --git meson.build meson.build
+index 5938cec..7516208 100644
+--- meson.build
++++ meson.build
+@@ -33,11 +33,6 @@ project (
+     ],
+ )
+ 
+-
+-libmchk_proj = subproject('libmachine-check')
+-libmchk_dep = libmchk_proj.get_variable('libmachine_check_dep')
+-
+-
+ app_name = meson.project_name()
+ 
+ prefix = get_option('prefix')
+@@ -63,14 +58,3 @@ config_data.set_quoted('DATADIR', full_datadir)
+ config_data.set_quoted('SYSCONFDIR', full_sysconfdir)
+ 
+ subdir('src')
+-
+-install_subdir (
+-  'machine-conf',
+-  install_dir : join_paths(datadir, app_name)
+-)
+-
+-install_subdir (
+-  'machine-check',
+-  install_dir : join_paths(datadir, 'machine-check', app_name),
+-  strip_directory : true
+-)
+diff --git src/main.c src/main.c
+index 587a5f3..4631a33 100644
+--- src/main.c
++++ src/main.c
+@@ -23,10 +23,8 @@
+  */
+ 
+ #include "wys-modem.h"
+-#include "wys-audio.h"
+ #include "util.h"
+ #include "config.h"
+-#include "mchk-machine-check.h"
+ 
+ #include <libmm-glib.h>
+ #include <glib.h>
+@@ -50,8 +48,6 @@ static GMainLoop *main_loop = NULL;
+ 
+ struct wys_data
+ {
+-  /** PulseAudio interface */
+-  WysAudio *audio;
+   /** ID for the D-Bus watch */
+   guint watch_id;
+   /** ModemManager object proxy */
+@@ -59,51 +55,112 @@ struct wys_data
+   /** Map of D-Bus object paths to WysModems */
+   GHashTable *modems;
+   /** How many modems have audio, in each direction */
+-  guint audio_count[2];
++  guint audio_count;
+ };
+ 
++static gboolean
++ugly_system (const gchar *cmd)
++{
++  gchar *out = NULL, *err = NULL;
++  gint status;
++  GError *error = NULL;
++  gboolean ok;
++
++  g_debug ("Executing command `%s'", cmd);
++
++  ok = g_spawn_command_line_sync
++    (cmd, &out, &err, &status, &error);
++
++  if (!ok)
++    {
++      g_warning ("Error spawning command `%s': %s'",
++                 cmd, error->message);
++      g_error_free (error);
++      return FALSE;
++    }
++
++  ok = g_spawn_check_exit_status (status, &error);
++  if (ok)
++    {
++      g_debug ("Command `%s' executed successfully"
++               "; stdout: `%s'; stderr: `%s'",
++               cmd, out, err);
++    }
++  else
++    {
++      g_warning ("Command `%s' failed: %s"
++                 "; stdout: `%s'; stderr: `%s'",
++                 cmd, error->message, out, err);
++      g_error_free (error);
++    }
++
++  g_free (out);
++  g_free (err);
++
++  return ok;
++}
++
++#define UGLY_CARD "alsa_card.platform-sound"
++
++static gboolean
++ugly_set_card_profile (const gchar *card,
++                       const gchar *profile)
++{
++  g_autofree gchar *cmd = NULL;
++
++  cmd = g_strdup_printf ("pactl set-card-profile '%s' '%s'", card, profile);
++
++  return ugly_system (cmd);
++}
++
++static gboolean
++ugly_set_voice_call (void)
++{
++  return ugly_set_card_profile (UGLY_CARD, "Voice Call");
++}
++
++static gboolean
++ugly_set_hifi (void)
++{
++  return ugly_set_card_profile (UGLY_CARD, "HiFi");
++}
+ 
+ static void
+ update_audio_count (struct wys_data *data,
+-                    WysDirection     direction,
+                     gint             delta)
+ {
+-  const guint old_count = data->audio_count[direction];
++  const guint old_count = data->audio_count;
+ 
+-  g_assert (delta >= 0 || data->audio_count[direction] > 0);
++  g_assert (delta >= 0 || data->audio_count > 0);
+ 
+-  data->audio_count[direction] += delta;
++  data->audio_count += delta;
+ 
+-  if (data->audio_count[direction] > 0 && old_count == 0)
++  if (data->audio_count > 0 && old_count == 0)
+     {
+-      g_debug ("Audio %s now present",
+-               wys_direction_get_description (direction));
+-      wys_audio_ensure_loopback (data->audio, direction);
++      g_message ("Audio now present");
++      ugly_set_voice_call ();
+     }
+-  else if (data->audio_count[direction] == 0 && old_count > 0)
++  else if (data->audio_count == 0 && old_count > 0)
+     {
+-      g_debug ("Audio %s now absent",
+-               wys_direction_get_description (direction));
+-      wys_audio_ensure_no_loopback (data->audio, direction);
++      g_message ("Audio now absent");
++      ugly_set_hifi ();
+     }
+ }
+ 
+ 
+ static void
+ audio_present_cb (struct wys_data *data,
+-                  WysDirection     direction,
+                   WysModem        *modem)
+ {
+-  update_audio_count (data, direction, +1);
++  update_audio_count (data, +1);
+ }
+ 
+ 
+ static void
+ audio_absent_cb (struct wys_data *data,
+-                 WysDirection     direction,
+                  WysModem        *modem)
+ {
+-  update_audio_count (data, direction, -1);
++  update_audio_count (data, -1);
+ }
+ 
+ 
+@@ -123,7 +180,7 @@ add_modem (struct wys_data *data,
+       return;
+     }
+ 
+-  g_debug ("Adding new voice-capable modem `%s'", path);
++  g_message ("Adding new voice-capable modem `%s'", path);
+ 
+   g_assert (MM_IS_OBJECT (object));
+   voice = mm_object_get_modem_voice (MM_OBJECT (object));
+@@ -153,7 +210,7 @@ interface_added_cb (struct wys_data *data,
+ 
+   info = g_dbus_interface_get_info (interface);
+ 
+-  g_debug ("ModemManager interface `%s' found on object `%s'",
++  g_message ("ModemManager interface `%s' found on object `%s'",
+            info->name,
+            g_dbus_object_get_object_path (object));
+ 
+@@ -184,7 +241,7 @@ interface_removed_cb (struct wys_data *data,
+   path = g_dbus_object_get_object_path (object);
+   info = g_dbus_interface_get_info (interface);
+ 
+-  g_debug ("ModemManager interface `%s' removed on object `%s'",
++  g_message ("ModemManager interface `%s' removed on object `%s'",
+            info->name, path);
+ 
+   if (g_strcmp0 (info->name, MM_DBUS_INTERFACE_MODEM_VOICE) == 0)
+@@ -229,7 +286,7 @@ void
+ object_added_cb (struct wys_data *data,
+                  GDBusObject     *object)
+ {
+-  g_debug ("ModemManager object `%s' added",
++  g_message ("ModemManager object `%s' added",
+            g_dbus_object_get_object_path (object));
+ 
+   add_mm_object (data, object);
+@@ -243,7 +300,7 @@ object_removed_cb (struct wys_data *data,
+   const gchar *path;
+ 
+   path = g_dbus_object_get_object_path (object);
+-  g_debug ("ModemManager object `%s' removed", path);
++  g_message ("ModemManager object `%s' removed", path);
+ 
+   remove_modem_object (data, path, object);
+ }
+@@ -286,7 +343,7 @@ mm_appeared_cb (GDBusConnection *connection,
+                 const gchar *name_owner,
+                 struct wys_data *data)
+ {
+-  g_debug ("ModemManager appeared on D-Bus");
++  g_message ("ModemManager appeared on D-Bus");
+ 
+   mm_manager_new (connection,
+                   G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_NONE,
+@@ -310,18 +367,14 @@ mm_vanished_cb (GDBusConnection *connection,
+                 const gchar *name,
+                 struct wys_data *data)
+ {
+-  g_debug ("ModemManager vanished from D-Bus");
++  g_message ("ModemManager vanished from D-Bus");
+   clear_dbus (data);
+ }
+ 
+ 
+ static void
+-set_up (struct wys_data *data,
+-        const gchar *codec,
+-        const gchar *modem)
++set_up (struct wys_data *data)
+ {
+-  data->audio = wys_audio_new (codec, modem);
+-
+   data->modems = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                         g_free, g_object_unref);
+ 
+@@ -333,7 +386,7 @@ set_up (struct wys_data *data,
+                       (GBusNameVanishedCallback)mm_vanished_cb,
+                       data, NULL);
+ 
+-  g_debug ("Watching for ModemManager");
++  g_message ("Watching for ModemManager");
+ }
+ 
+ 
+@@ -343,23 +396,19 @@ tear_down (struct wys_data *data)
+   clear_dbus (data);
+   g_bus_unwatch_name (data->watch_id);
+   g_hash_table_unref (data->modems);
+-  g_object_unref (G_OBJECT (data->audio));
+ }
+ 
+ 
+ static void
+-run (const gchar *codec,
+-     const gchar *modem)
++run (void)
+ {
+   struct wys_data data;
+ 
+   memset (&data, 0, sizeof (struct wys_data));
+-  set_up (&data, codec, modem);
++  set_up (&data);
+ 
+   main_loop = g_main_loop_new (NULL, FALSE);
+ 
+-  printf (APPLICATION_NAME " started with codec `%s', modem `%s'\n",
+-          codec, modem);
+   g_main_loop_run (main_loop);
+ 
+   g_main_loop_unref (main_loop);
+@@ -368,33 +417,6 @@ run (const gchar *codec,
+   tear_down (&data);
+ }
+ 
+-
+-static void
+-check_machine (const gchar *machine)
+-{
+-  gboolean ok, passed;
+-  GError *error = NULL;
+-
+-  ok = mchk_check_machine (APP_DATA_NAME,
+-                           machine,
+-                           &passed,
+-                           &error);
+-  if (!ok)
+-    {
+-      g_warning ("Error checking machine name against"
+-                 " whitelist/blacklist, continuing anyway");
+-      g_error_free (error);
+-    }
+-  else if (!passed)
+-    {
+-      g_message ("Machine name `%s' did not pass"
+-                 " whitelist/blacklist check, exiting",
+-                 machine);
+-      exit (EXIT_SUCCESS);
+-    }
+-}
+-
+-
+ static void
+ terminate (int signal)
+ {
+@@ -452,222 +452,18 @@ setup_signals ()
+ }
+ 
+ 
+-/** This function will close @fd */
+-static gchar *
+-read_machine_conf_file (const gchar *filename,
+-                        int          fd)
+-{
+-  GInputStream *unix_stream;
+-  GDataInputStream *data_stream;
+-  gboolean try_again;
+-  gchar *line;
+-  GError *error = NULL;
+-
+-  g_debug ("Reading machine configuration file `%s'", filename);
+-
+-  unix_stream = g_unix_input_stream_new (fd, TRUE);
+-  g_assert (unix_stream != NULL);
+-
+-  data_stream = g_data_input_stream_new (unix_stream);
+-  g_assert (data_stream != NULL);
+-  g_object_unref (unix_stream);
+-
+-  do
+-    {
+-      try_again = FALSE;
+-
+-      line = g_data_input_stream_read_line_utf8
+-        (data_stream, NULL, NULL, &error);
+-
+-      if (error)
+-        {
+-          g_warning ("Error reading from machine"
+-                     " configuration file `%s': %s",
+-                     filename, error->message);
+-          g_error_free (error);
+-        }
+-      else if (line)
+-        {
+-          g_strstrip (line);
+-
+-          // Skip comments and empty lines
+-          if (line[0] == '#' || line[0] == '\0')
+-            {
+-              g_free (line);
+-              try_again = TRUE;
+-            }
+-        }
+-    }
+-  while (try_again);
+-
+-  g_object_unref (data_stream);
+-  return line;
+-}
+-
+-
+-static gchar *
+-dir_machine_conf (const gchar *dir,
+-                  const gchar *machine,
+-                  const gchar *key)
+-{
+-  gchar *filename;
+-  int fd;
+-  gchar *value = NULL;
+-
+-  filename = g_build_filename (dir, APP_DATA_NAME,
+-                               "machine-conf",
+-                               machine, key, NULL);
+-
+-  g_debug ("Trying machine configuration file `%s'",
+-           filename);
+-
+-  fd = g_open (filename, O_RDONLY, 0);
+-  if (fd == -1)
+-    {
+-      if (errno != ENOENT)
+-        {
+-          // The error isn't that the file doesn't exist
+-          g_warning ("Error opening machine"
+-                     " configuration file `%s': %s",
+-                     filename, g_strerror (errno));
+-        }
+-    }
+-  else
+-    {
+-      value = read_machine_conf_file (filename, fd);
+-    }
+-
+-  g_free (filename);
+-  return value;
+-}
+-
+-
+-static gchar *
+-machine_conf (const gchar *machine,
+-              const gchar *key)
+-{
+-  gchar *value = NULL;
+-  const gchar * const *dirs, * const *dir;
+-
+-
+-#define try_dir(d)                                      \
+-  value = dir_machine_conf (d, machine, key);           \
+-  if (value)                                            \
+-    {                                                   \
+-      return value;                                     \
+-    }
+-
+-
+-  try_dir (g_get_user_config_dir ());
+-
+-  dirs = g_get_system_config_dirs ();
+-  for (dir = dirs; *dir; ++dir)
+-    {
+-      try_dir (*dir);
+-    }
+-
+-  try_dir (SYSCONFDIR);
+-  try_dir (DATADIR);
+-
+-  dirs = g_get_system_data_dirs ();
+-  for (dir = dirs; *dir; ++dir)
+-    {
+-      try_dir (*dir);
+-    }
+-
+-#undef try_dir
+-
+-  return NULL;
+-}
+-
+-
+-static void
+-ensure_alsa_card (const gchar  *machine,
+-                  const gchar  *var,
+-                  const gchar  *key,
+-                        gchar **name)
+-{
+-  const gchar *env;
+-
+-  if (*name)
+-    {
+-      return;
+-    }
+-
+-  env = g_getenv (var);
+-  if (env)
+-    {
+-      *name = g_strdup (env);
+-      return;
+-    }
+-
+-  if (machine)
+-    {
+-      *name = machine_conf (machine, key);
+-      if (*name)
+-        {
+-          return;
+-        }
+-    }
+-
+-  g_warning ("No %s specified with a machine configuration file"
+-             ", environment variable or command line option"
+-             "; refusing to run", key);
+-  exit (EXIT_SUCCESS);
+-}
+-
+-
+ int
+ main (int argc, char **argv)
+ {
+   GError *error = NULL;
+   GOptionContext *context;
+   gboolean ok;
+-  g_autofree gchar *codec = NULL;
+-  g_autofree gchar *modem = NULL;
+-  g_autofree gchar *machine = NULL;
+-
+-  GOptionEntry options[] =
+-    {
+-      { "codec", 'c', 0, G_OPTION_ARG_STRING, &codec, "Name of the codec's ALSA card", "NAME" },
+-      { "modem", 'm', 0, G_OPTION_ARG_STRING, &modem, "Name of the modem's ALSA card", "NAME" },
+-      { NULL }
+-    };
+ 
+   setlocale(LC_ALL, "");
+ 
+-  machine = mchk_read_machine (NULL);
+-  if (machine)
+-    {
+-      check_machine (machine);
+-    }
+-  else
+-    {
+-      g_warning ("Could not read machine name, continuing without machine check");
+-    }
+-
+-
+-  context = g_option_context_new ("- set up PulseAudio loopback for phone call audio");
+-  g_option_context_add_main_entries (context, options, NULL);
+-  ok = g_option_context_parse (context, &argc, &argv, &error);
+-  if (!ok)
+-    {
+-      g_print ("Error parsing options: %s\n", error->message);
+-    }
+-
+-
+-  if (machine)
+-    {
+-      /* Convert any directory separator characters to "_" */
+-      g_strdelimit (machine, G_DIR_SEPARATOR_S, '_');
+-    }
+-
+-  ensure_alsa_card (machine, "WYS_CODEC", "codec", &codec);
+-  ensure_alsa_card (machine, "WYS_MODEM", "modem", &modem);
+-
+   setup_signals ();
+ 
+-  run (codec, modem);
++  run ();
+ 
+   return 0;
+ }
+diff --git src/meson.build src/meson.build
+index 7b99235..a8a30d7 100644
+--- src/meson.build
++++ src/meson.build
+@@ -22,13 +22,10 @@
+ gnome = import('gnome')
+ 
+ wys_deps = [
+-  libmchk_dep,
+   dependency('gobject-2.0'),
+   dependency('gio-unix-2.0'),
+   dependency('ModemManager'),
+   dependency('mm-glib'),
+-  dependency('libpulse'),
+-  dependency('libpulse-mainloop-glib'),
+ ]
+ 
+ config_h = configure_file (
+@@ -36,20 +33,13 @@ config_h = configure_file (
+   configuration: config_data
+ )
+ 
+-wys_enum_headers = files(['wys-direction.h'])
+-wys_enum_sources = gnome.mkenums_simple('enum-types',
+-                                        sources : wys_enum_headers)
+-
+ executable (
+   'wys',
+   config_h,
+-  wys_enum_sources,
+   [
+     'main.c',
+     'util.h', 'util.c',
+-    'wys-direction.h', 'wys-direction.c',
+     'wys-modem.h', 'wys-modem.c',
+-    'wys-audio.h', 'wys-audio.c',
+   ],
+   dependencies : wys_deps,
+   include_directories : include_directories('..'),
+diff --git src/wys-modem.c src/wys-modem.c
+index 212f992..51a0575 100644
+--- src/wys-modem.c
++++ src/wys-modem.c
+@@ -24,18 +24,10 @@
+ 
+ 
+ #include "wys-modem.h"
+-#include "wys-direction.h"
+ #include "util.h"
+-#include "enum-types.h"
+ 
+ #include <glib/gi18n.h>
+ 
+-static const gchar * const WYS_MODEM_HAS_AUDIO[] =
+-  {
+-   [WYS_DIRECTION_FROM_NETWORK] = "wys-has-audio-from-network",
+-   [WYS_DIRECTION_TO_NETWORK]   = "wys-has-audio-to-network"
+-  };
+-
+ struct _WysModem
+ {
+   GObject parent_instance;
+@@ -43,8 +35,8 @@ struct _WysModem
+   MMModemVoice *voice;
+   /** Map of D-Bus object paths to MMCall objects */
+   GHashTable *calls;
+-  /** How many calls have audio, in each direction */
+-  guint audio_count[2];
++  /** How many calls have audio */
++  guint audio_count;
+ };
+ 
+ G_DEFINE_TYPE(WysModem, wys_modem, G_TYPE_OBJECT)
+@@ -65,15 +57,11 @@ static guint signals [SIGNAL_LAST_SIGNAL];
+ 
+ 
+ static gboolean
+-call_state_has_audio (WysDirection direction,
+-                      MMCallState  state)
++call_state_has_audio (MMCallState  state)
+ {
+   switch (state)
+     {
+     case MM_CALL_STATE_RINGING_OUT:
+-      return
+-        (direction == WYS_DIRECTION_FROM_NETWORK)
+-        ? TRUE : FALSE;
+     case MM_CALL_STATE_ACTIVE:
+       return TRUE;
+     default:
+@@ -84,39 +72,35 @@ call_state_has_audio (WysDirection direction,
+ 
+ static void
+ update_audio_count (WysModem     *self,
+-                    WysDirection  direction,
+                     gint          delta)
+ {
+-  const guint old_count = self->audio_count[direction];
++  const guint old_count = self->audio_count;
+ 
+-  g_assert (delta >= 0 || self->audio_count[direction] > 0);
++  g_assert (delta >= 0 || self->audio_count > 0);
+ 
+-  self->audio_count[direction] += delta;
++  self->audio_count += delta;
+ 
+-  if (self->audio_count[direction] > 0 && old_count == 0)
++  if (self->audio_count > 0 && old_count == 0)
+     {
+-      g_debug ("Modem `%s' audio %s now present",
+-               mm_modem_voice_get_path (self->voice),
+-               wys_direction_get_description (direction));
+-      g_signal_emit_by_name (self, "audio-present", direction);
++      g_message ("Modem `%s' audio now present",
++                 mm_modem_voice_get_path (self->voice));
++      g_signal_emit_by_name (self, "audio-present");
+     }
+-  else if (self->audio_count[direction] == 0 && old_count > 0)
++  else if (self->audio_count == 0 && old_count > 0)
+     {
+-      g_debug ("Modem `%s' audio now absent",
+-               mm_modem_voice_get_path (self->voice));
+-      g_signal_emit_by_name (self, "audio-absent", direction);
++      g_message ("Modem `%s' audio now absent",
++                 mm_modem_voice_get_path (self->voice));
++      g_signal_emit_by_name (self, "audio-absent");
+     }
+ }
+ 
+ 
+ static gboolean
+-get_call_has_audio (MMCall       *mm_call,
+-                    WysDirection  direction)
++get_call_has_audio (MMCall *mm_call)
+ {
+   gpointer data;
+ 
+-  data = g_object_get_data (G_OBJECT (mm_call),
+-                            WYS_MODEM_HAS_AUDIO[direction]);
++  data = g_object_get_data (G_OBJECT (mm_call), "audio-state");
+ 
+   return (gboolean)(GPOINTER_TO_UINT (data));
+ }
+@@ -124,42 +108,38 @@ get_call_has_audio (MMCall       *mm_call,
+ 
+ static void
+ set_call_has_audio (MMCall       *mm_call,
+-                    WysDirection  direction,
+                     gboolean      has_audio)
+ {
+   g_object_set_data (G_OBJECT (mm_call),
+-                     WYS_MODEM_HAS_AUDIO[direction],
++                     "audio-state",
+                      GUINT_TO_POINTER ((guint)has_audio));
+ }
+ 
+ 
+ static void
+-update_direction_state (WysModem     *self,
+-                        MMCall       *mm_call,
+-                        const gchar  *path,
+-                        WysDirection  direction,
+-                        MMCallState   old_state,
+-                        MMCallState   new_state)
++update_call_state (WysModem     *self,
++                   MMCall       *mm_call,
++                   const gchar  *path,
++                   MMCallState   old_state,
++                   MMCallState   new_state)
+ {
+-  gboolean had_audio  = call_state_has_audio (direction, old_state);
+-  gboolean have_audio = call_state_has_audio (direction, new_state);
++  gboolean had_audio  = call_state_has_audio (old_state);
++  gboolean have_audio = call_state_has_audio (new_state);
+ 
+   if (!had_audio && have_audio)
+     {
+-      g_debug ("Call `%s' gained audio %s", path,
+-               wys_direction_get_description (direction));
+-      update_audio_count (self, direction, +1);
++      g_message ("Call `%s' gained audio", path);
++      update_audio_count (self, +1);
+     }
+   else if (had_audio && !have_audio)
+     {
+-      g_debug ("Call `%s' lost audio %s", path,
+-               wys_direction_get_description (direction));
+-      update_audio_count (self, direction, -1);
++      g_message ("Call `%s' lost audio", path);
++      update_audio_count (self, -1);
+     }
+ 
+   if (had_audio != have_audio)
+     {
+-      set_call_has_audio (mm_call, direction, have_audio);
++      set_call_has_audio (mm_call, have_audio);
+     }
+ }
+ 
+@@ -174,34 +154,28 @@ call_state_changed_cb (MmGdbusCall       *mm_gdbus_call,
+   MMCall *mm_call = MM_CALL (mm_gdbus_call);
+   const gchar * path = mm_call_get_path (mm_call);
+ 
+-  g_debug ("Call `%s' state changed, new: %i, old: %i",
++  g_message ("Call `%s' state changed, new: %i, old: %i",
+            path, (int)new_state, (int)old_state);
+ 
+   // FIXME: deal with calls being put on hold (one call goes
+   // non-audio, another call goes audio after)
+ 
+-  update_direction_state (self, mm_call, path,
+-                          WYS_DIRECTION_FROM_NETWORK,
+-                          old_state, new_state);
+-  update_direction_state (self, mm_call, path,
+-                          WYS_DIRECTION_TO_NETWORK,
+-                          old_state, new_state);
++  update_call_state (self, mm_call, path, old_state, new_state);
+ }
+ 
+ 
+ static void
+-init_call_direction (WysModem     *self,
+-                     MMCall       *mm_call,
+-                     MMCallState   state,
+-                     WysDirection  direction)
++init_call_audio (WysModem     *self,
++                 MMCall       *mm_call,
++                 MMCallState   state)
+ {
+-  gboolean has_audio = call_state_has_audio (direction, state);
++  gboolean has_audio = call_state_has_audio (state);
+ 
+-  set_call_has_audio (mm_call, direction, has_audio);
++  set_call_has_audio (mm_call, has_audio);
+ 
+   if (has_audio)
+     {
+-      update_audio_count (self, direction, +1);
++      update_audio_count (self, +1);
+     }
+ }
+ 
+@@ -223,12 +197,9 @@ add_call (WysModem *self,
+                     self);
+ 
+   state = mm_call_get_state (mm_call);
+-  init_call_direction (self, mm_call, state,
+-                       WYS_DIRECTION_FROM_NETWORK);
+-  init_call_direction (self, mm_call, state,
+-                       WYS_DIRECTION_TO_NETWORK);
++  init_call_audio (self, mm_call, state);
+ 
+-  g_debug ("Call `%s' added, state: %i", path, (int)state);
++  g_message ("Call `%s' added, state: %i", path, (int)state);
+ }
+ 
+ 
+@@ -322,16 +293,14 @@ call_added_cb (MMModemVoice  *voice,
+ 
+ 
+ static void
+-clear_call_direction (WysModem     *self,
+-                      MMCall       *mm_call,
+-                      WysDirection  direction)
++clear_call_state (WysModem     *self,
++                  MMCall       *mm_call)
+ {
+-  gboolean has_audio =
+-    get_call_has_audio (mm_call, direction);
++  gboolean has_audio = get_call_has_audio (mm_call);
+ 
+   if (has_audio)
+     {
+-      update_audio_count (self, direction, -1);
++      update_audio_count (self, -1);
+     }
+ }
+ 
+@@ -343,7 +312,7 @@ call_deleted_cb (MMModemVoice *voice,
+ {
+   MMCall *mm_call;
+ 
+-  g_debug ("Removing call `%s'", path);
++  g_message ("Removing call `%s'", path);
+ 
+   mm_call = g_hash_table_lookup (self->calls, path);
+   if (!mm_call)
+@@ -352,14 +321,11 @@ call_deleted_cb (MMModemVoice *voice,
+       return;
+     }
+ 
+-  clear_call_direction (self, mm_call,
+-                        WYS_DIRECTION_FROM_NETWORK);
+-  clear_call_direction (self, mm_call,
+-                        WYS_DIRECTION_TO_NETWORK);
++  clear_call_state (self, mm_call);
+ 
+   g_hash_table_remove (self->calls, path);
+ 
+-  g_debug ("Call `%s' removed", path);
++  g_message ("Call `%s' removed", path);
+ }
+ 
+ 
+@@ -444,11 +410,9 @@ dispose (GObject *object)
+   if (g_hash_table_size (self->calls) > 0)
+     {
+       g_hash_table_remove_all (self->calls);
+-      if (self->audio_count[WYS_DIRECTION_FROM_NETWORK] > 0 ||
+-          self->audio_count[WYS_DIRECTION_TO_NETWORK] > 0)
++      if (self->audio_count > 0)
+         {
+-          self->audio_count[WYS_DIRECTION_FROM_NETWORK] =
+-            self->audio_count[WYS_DIRECTION_TO_NETWORK] = 0;
++          self->audio_count = 0;
+           g_signal_emit_by_name (self, "audio-absent");
+         }
+     }
+@@ -504,8 +468,7 @@ wys_modem_class_init (WysModemClass *klass)
+                   G_SIGNAL_RUN_LAST,
+                   0, NULL, NULL, NULL,
+                   G_TYPE_NONE,
+-                  1,
+-                  WYS_TYPE_DIRECTION);
++                  0);
+ 
+   /**
+    * WysModem::audio-absent:
+@@ -520,8 +483,7 @@ wys_modem_class_init (WysModemClass *klass)
+                   G_SIGNAL_RUN_LAST,
+                   0, NULL, NULL, NULL,
+                   G_TYPE_NONE,
+-                  1,
+-                  WYS_TYPE_DIRECTION);
++                  0);
+ }
+ 
+ 

--- a/srcpkgs/pinephone-wys/template
+++ b/srcpkgs/pinephone-wys/template
@@ -1,0 +1,19 @@
+# Template file for 'pinephone-wys'
+pkgname=pinephone-wys
+_pkgname=wys
+version=0.1.8
+revision=1
+wrksrc=${_pkgname}-v${version}
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="glib-devel pulseaudio-devel ModemManager-devel"
+short_desc="Daemon to bring up and take down PulseAudio for phone call audio"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/wys"
+distfiles="${homepage}/-/archive/v${version}/${_pkgname}-v${version}.tar.gz"
+checksum=07fd6d2ae9ea5d6187e1c99d5b0e5c1d9c74ba00f4869f4aae195cd8714ba375
+
+post_install() {
+	vinstall ${FILESDIR}/wys.desktop 644 etc/xdg/autostart
+}

--- a/srcpkgs/pinephone-wys/update
+++ b/srcpkgs/pinephone-wys/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${_pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$_pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/purism-chatty/template
+++ b/srcpkgs/purism-chatty/template
@@ -1,0 +1,22 @@
+# Template file for 'purism-chatty'
+pkgname=purism-chatty
+_pkgname=chatty
+version=0.1.16
+revision=1
+wrksrc=${_pkgname}-v${version}
+build_style=meson
+hostmakedepends="glib-devel pkg-config gettext"
+makedepends="libfeedback-devel libhandy-devel evolution-data-server-devel
+ libpurple libpurple-devel"
+short_desc="XMPP and SMS messaging via libpurple and Modemmanager"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/chatty"
+distfiles="${homepage}/-/archive/v${version}/${_pkgname}-v${version}.tar.gz"
+checksum=2eb565a60892eedc91779eafd83add583007fe9567e4bc270ff9c197854bba4b
+
+pre_configure() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i src/meson.build -e "s/purple_plugdir =.*/purple_plugdir = \'\/usr\/${XBPS_CROSS_TRIPLET}\/usr\/lib\/purple-2\'/g"
+	fi
+}

--- a/srcpkgs/purism-chatty/update
+++ b/srcpkgs/purism-chatty/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${_pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$_pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/purple-mm-sms/patches/0001-Support-meson.patch
+++ b/srcpkgs/purple-mm-sms/patches/0001-Support-meson.patch
@@ -1,0 +1,63 @@
+From 1c4896f15f63bb6719ece59b626fddf55b766a0e Mon Sep 17 00:00:00 2001
+From: Julio Galvan <julio-void@epazote.net>
+Date: Sat, 19 Sep 2020 21:32:19 -0700
+Subject: [PATCH] Support meson
+
+I am trying to package this library for voidlinux but it fails to
+crossbuild automatically. I thought that we could use this for now.
+---
+ meson.build | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+ create mode 100644 meson.build
+
+diff --git a/meson.build b/meson.build
+new file mode 100644
+index 0000000..8b6c90e
+--- /dev/null
++++ meson.build
+@@ -0,0 +1,42 @@
++project('purple-mm-sms', 'c',
++  version: '0.1.7',
++)
++
++cc = meson.get_compiler('c')
++
++purple = dependency('purple')
++mm = dependency('mm-glib')
++glib= dependency('glib-2.0', version: '>=2.50.0')
++
++purple_plugdir = purple.get_pkgconfig_variable('plugindir')
++
++mm_sms_headers = [
++  'mm-sms.h',
++  'itu-e212-iso.h',
++]
++
++mm_sms_sources = [
++  mm_sms_headers,
++  'mm-sms.c',
++]
++
++mm_sms_deps = [
++  purple,
++  mm,
++  glib,
++]
++
++mm_sms_shared = shared_library(
++  'mm-sms',
++  mm_sms_sources,
++         dependencies : mm_sms_deps,
++         name_prefix  : '',
++          install_dir : purple_plugdir,
++              install : true,
++)
++
++
++iconsdir = join_paths(get_option('datadir'), 'pixmaps', 'pidgin', 'protocols')
++foreach size: ['16', '22', '48']
++  install_data('icons/mm-sms-' + size + 'px.png', rename: 'mm-sms.png', install_dir: iconsdir + '/' + size)
++endforeach
+-- 
+2.28.0
+

--- a/srcpkgs/purple-mm-sms/template
+++ b/srcpkgs/purple-mm-sms/template
@@ -1,0 +1,14 @@
+# Template file for 'purple-mm-sms'
+pkgname=purple-mm-sms
+version=0.1.7
+revision=1
+wrksrc=${pkgname}-v${version}
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="ModemManager-devel libglib-devel libpurple-devel"
+short_desc="Purple SMS plugin using ModemManager"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/purple-mm-sms"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=123d71f40051e6afc59dc8f8fb6efef0524a99b377856d99d5e64d0b867ab2be

--- a/srcpkgs/purple-mm-sms/update
+++ b/srcpkgs/purple-mm-sms/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'

--- a/srcpkgs/squeekboard/template
+++ b/srcpkgs/squeekboard/template
@@ -1,0 +1,26 @@
+# Template file for 'squeekboard'
+pkgname=squeekboard
+version=1.9.3
+revision=1
+wrksrc=${pkgname}-v${version}
+build_style=meson
+build_helper=rust
+hostmakedepends="glib-devel gettext pkg-config cargo wayland-devel"
+makedepends="rust gtk+3-devel gnome-desktop-devel libfeedback-devel"
+depends="feedbackd"
+short_desc="Final Librem5 keyboard"
+maintainer="Julio Galvan <julio-void@epazote.net>"
+license="GPL-3.0-or-later"
+homepage="https://source.puri.sm/Librem5/squeekboard"
+distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=b99e56faace3986bf752e08c104cea60ed896d514284840655033dd9457db824
+
+pre_configure() {
+	if [ "$CROSS_BUILD" ]; then
+		vsed -i cargo_build.sh -e "s/-a ./-a ${XBPS_CROSS_RUST_TARGET}/g"
+	fi
+}
+
+post_install() {
+	chmod +x ${DESTDIR}/usr/bin/squeekboard-entry
+}

--- a/srcpkgs/squeekboard/update
+++ b/srcpkgs/squeekboard/update
@@ -1,0 +1,2 @@
+site="https://source.puri.sm/Librem5/${pkgname}/tags"
+pattern='/archive/[^/]+/\Q'"$pkgname"'\E-v?\K[\d\.]+(?=\.tar\.gz")'


### PR DESCRIPTION
Status of `phosh` on the PinePhone 1.2a

- [x] Shell
  - `phosh` `squeekboard` `phoc` `feedbackd` packaged
  - `phosh-desktop` (Should I rename it?, Does it need any additional dependencies?)
- [x] Calls (sound is bad)
  - `calls` `pinephone-wys` packaged
- [x] SMS (works) 
  -  `purism-chatty` `purple-mm-sms` packaged
- [x] Data (works)
- [ ] Camera (working on it)
  - `megapixels` packaged


The modem needs to be manually enabled every single time with `echo 1 > /sys/class/modem-power/modem-power/device/powered` (I could create a service for that).

You need to run this [script](https://gitlab.com/postmarketOS/pmaports/-/blob/master/device/community/device-pine64-pinephone/setup-modem.sh) at least one time for it to set up the modem with the right settings.

i am able to make calls with `calls` and `pinephone-wys`.  I am using the sound profiles from [here](https://gitlab.com/postmarketOS/pmaports/-/tree/master/device/community/device-pine64-pinephone/ucm) and `alsa-ucm-conf`(not yet packaged) but the sound is bad.

`purism-chatty` can't find `libjabber.so` and `mm-sms.so` that are inside `/usr/lib/purple-2`. I created symlinks from `/usr/lib/purple-2/{libjabber.so,mm-sms.so}` to `/usr/lib` Any suggestions on how to fix this?