### PR TITLE
[RFC] switch to functions for libc, atomic support, etc checks 

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -657,3 +657,14 @@ setup_pkg() {
         . $XBPS_BUILDHELPERDIR/${f}.sh
     done
 }
+
+xbps_target_libc() {
+    local libc="$1"
+    [ "$XBPS_TARGET_LIBC" = "$libc" ]
+    return $?
+}
+
+xbps_target_no_atomic8() {
+    [ "$XBPS_TARGET_NO_ATOMIC8" ]
+    return $?
+}

--- a/srcpkgs/Aegisub/template
+++ b/srcpkgs/Aegisub/template
@@ -27,7 +27,7 @@ desc_option_portaudio="Enable support for portaudio"
 
 LDFLAGS+=" -pthread"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+="libatomic-devel"
 	configure_args+=" --with-libatomic"
 fi

--- a/srcpkgs/CubicSDR/template
+++ b/srcpkgs/CubicSDR/template
@@ -18,7 +18,7 @@ checksum=5cb44c110fcbbb70a468b7fa402cf35f84d8901b3dd42d471a90ac3f5db00f4d
 build_options="alsa pulseaudio jack"
 build_options_default="alsa pulseaudio"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	configure_args+=" -DOTHER_LIBRARIES=atomic"
 fi

--- a/srcpkgs/EternalTerminal/template
+++ b/srcpkgs/EternalTerminal/template
@@ -16,12 +16,12 @@ system_accounts="_eternal"
 
 LDFLAGS="-lgflags"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 
 post_patch() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		# Use external libexecinfo
 		vsed -i CMakeLists.txt \
 			-e '/execinfo/!s/CORE_LIBRARIES util resolv/& execinfo/'

--- a/srcpkgs/FeedReader/template
+++ b/srcpkgs/FeedReader/template
@@ -14,13 +14,13 @@ homepage="https://jangernert.github.io/FeedReader/"
 distfiles="https://github.com/jangernert/${pkgname}/archive/v${version}.tar.gz"
 checksum=9f679cc08e5673e9e90541b0a0c4066990deacddfe2692f6611799d99bdf5b3e
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 	LDFLAGS+=" -lexecinfo"
 fi
 
 pre_configure() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		patch -Np0 -i ${FILESDIR}/fix-FeedServerMain_vala.patch
 	fi
 }

--- a/srcpkgs/FreeRADIUS/template
+++ b/srcpkgs/FreeRADIUS/template
@@ -16,7 +16,7 @@ nocross=yes # Not supported by upstream
 system_accounts="_freeradius"
 make_dirs="/etc/raddb 0750 _freeradius _freeradius"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/LGOGDownloader/template
+++ b/srcpkgs/LGOGDownloader/template
@@ -15,6 +15,6 @@ distfiles="https://github.com/Sude-/lgogdownloader/archive/v${version}.tar.gz"
 checksum=38e0c8cdff395d92754dda630bf6f3c64e45ae2b0cf696a47a299f879fefa9ac
 
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi

--- a/srcpkgs/QMPlay2/template
+++ b/srcpkgs/QMPlay2/template
@@ -17,7 +17,7 @@ changelog="https://raw.githubusercontent.com/zaps166/QMPlay2/master/ChangeLog"
 distfiles="https://github.com/zaps166/QMPlay2/releases/download/${version}/QMPlay2-src-${version}.tar.xz"
 checksum=0f71152708b4b217a9b62ea3690688bc6566812bfc94abf7d4cb6149cc12e3be
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
 fi

--- a/srcpkgs/RandomX/template
+++ b/srcpkgs/RandomX/template
@@ -10,7 +10,7 @@ homepage="https://github.com/tevador/RandomX"
 distfiles="https://github.com/tevador/RandomX/archive/v${version}.tar.gz"
 checksum=f982a12d18b1d260bef2a1d3c46ae4902975fbf63abb38ca6413c96d1778db3a
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	CFLAGS+=" -Wl,-latomic"
 	makedepends="libatomic-devel"
 fi

--- a/srcpkgs/ahoviewer/template
+++ b/srcpkgs/ahoviewer/template
@@ -17,12 +17,12 @@ distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=a14e32b4a8095c9f8b4b607c090a50cc8ac1076550e57b5a9303c54089068152
 nocross="https://travis-ci.org/void-linux/void-packages/jobs/490108528#L1022"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
 post_patch() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		echo "ahoviewer_LDADD += -latomic" >> src/Makefile.am
 	fi
 }

--- a/srcpkgs/akonadi5/template
+++ b/srcpkgs/akonadi5/template
@@ -23,12 +23,12 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-tools-devel qt5-devel kconfig kcoreaddons"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
 pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		vsed -e "s;^\(target_link_libraries(.*\);\1 atomic;" -i src/server/CMakeLists.txt
 	fi
 }

--- a/srcpkgs/alembic/template
+++ b/srcpkgs/alembic/template
@@ -21,7 +21,7 @@ if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" hdf5-devel"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 
 	post_patch() {

--- a/srcpkgs/aml/template
+++ b/srcpkgs/aml/template
@@ -11,7 +11,7 @@ homepage="https://github.com/any1/aml"
 distfiles="https://github.com/any1/aml/archive/v${version}.tar.gz"
 checksum=50341861e9bb4eaaf11731941c276ef22b78e0e3d9b1442f6cf683f1b8e08bff
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -13,7 +13,7 @@ homepage="http://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
 checksum=7fb1c127c36b0752657593838b6823743bf8e5730f9f8b0f7ba2c185424cf376
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -32,7 +32,7 @@ pre_configure() {
 		configure_args+=" ${boring_ssl_cmake_args}"
 	fi
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		sed -i vendor/CMakeLists.adb.txt \
 			-e "/target_link_libraries/s;$; atomic;"
 	fi

--- a/srcpkgs/anope/template
+++ b/srcpkgs/anope/template
@@ -20,7 +20,7 @@ make_dirs="
  /var/lib/anope 755 _anope _anope
  /var/log/anope 755 _anope _anope"
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" gettext-devel"
 	LDFLAGS="-lintl"
 fi

--- a/srcpkgs/apr-util/template
+++ b/srcpkgs/apr-util/template
@@ -20,7 +20,7 @@ homepage="http://apr.apache.org/"
 distfiles="http://www.apache.org/dist/apr/${pkgname}-${version}.tar.bz2"
 checksum=d3e12f7b6ad12687572a3a39475545a072608f4ba03a6ce8a3778f607dd0035b
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS="-latomic"
 fi

--- a/srcpkgs/apr/template
+++ b/srcpkgs/apr/template
@@ -24,7 +24,7 @@ if [ "$CROSS_BUILD" ]; then
 	configure_args+=" ac_cv_func_sem_open=sem_open"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS="-latomic"
 fi

--- a/srcpkgs/arcan/template
+++ b/srcpkgs/arcan/template
@@ -26,7 +26,7 @@ else
 fi
 
 CFLAGS="-fcommon"
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	CFLAGS="-latomic"
 fi

--- a/srcpkgs/audacity/template
+++ b/srcpkgs/audacity/template
@@ -24,7 +24,7 @@ case "$XBPS_TARGET_MACHINE" in
 	*) configure_args+=" --disable-sse" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS="-latomic"
 fi

--- a/srcpkgs/bacula-common/template
+++ b/srcpkgs/bacula-common/template
@@ -18,7 +18,7 @@ checksum=a40d04d2c48135972cecb6578405e835c4b9d798c0950017de0fad40ca94e8a0
 alternatives="bacula-db-backend:/usr/lib/libbaccats-${version}.so:/usr/lib/libbaccats-sqlite3-${version}.so"
 shlib_provides="libbaccats-${version}.so"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -21,7 +21,7 @@ depends+="
  chroot-bash chroot-grep chroot-gawk chroot-distcc
  chroot-util-linux chroot-git"
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 
 base-chroot-musl_package() {
 	build_style=meta

--- a/srcpkgs/bluez/template
+++ b/srcpkgs/bluez/template
@@ -20,7 +20,7 @@ system_groups="bluetooth"
 build_options="mesh nfc"
 patch_args="-Np1"
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/bsd-games/template
+++ b/srcpkgs/bsd-games/template
@@ -53,7 +53,7 @@ if [ "$XBPS_LIBC" = musl ]; then
 	hostmakedepends+=" musl-legacy-compat"
 fi
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/bsdunzip/template
+++ b/srcpkgs/bsdunzip/template
@@ -11,7 +11,7 @@ homepage="https://github.com/somasis/bsdunzip"
 distfiles="https://github.com/somasis/bsdunzip/archive/${version}.tar.gz"
 checksum=06c52c77fa518732665aa2daa73f364cd2470a5d47a83c9c79f86f207cf3ecc1
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/cairo-dock-plugins/template
+++ b/srcpkgs/cairo-dock-plugins/template
@@ -23,7 +23,7 @@ if [ "$CROSS_BUILD" ]; then
 fi
 
 CFLAGS="-fcommon"
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	CFLAGS+=" -D_GNU_SOURCE"
 fi
 

--- a/srcpkgs/ccls/template
+++ b/srcpkgs/ccls/template
@@ -13,12 +13,12 @@ distfiles="https://github.com/MaskRay/ccls/archive/${version}.tar.gz"
 checksum=83dd45120e9674319f91e4379013831e124c0858e050bbc3521e3f8aebe5c95b
 nocross="Clang cannot be installed as makedep"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
 post_extract() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		echo "target_link_libraries(ccls PRIVATE atomic)" >> CMakeLists.txt
 	fi
 }

--- a/srcpkgs/cereal/template
+++ b/srcpkgs/cereal/template
@@ -12,7 +12,7 @@ homepage="https://uscilab.github.io/cereal"
 distfiles="https://github.com/USCiLab/cereal/archive/v${version}.tar.gz"
 checksum=329ea3e3130b026c03a4acc50e168e7daff4e6e661bc6a7dfec0d77b570851d5
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"

--- a/srcpkgs/chatterino2/template
+++ b/srcpkgs/chatterino2/template
@@ -27,7 +27,7 @@ checksum="c017005d1098af9bddafaef013e8d1120cb805101125b3a20df2bd7dd413ccce
 196ebfe37e6cdf61eaa1650b570cd50fcf6d8fc4c0aa408ff540b017d71ec634
 2945e445ecaa183c8678f0c1c33cd0b6957ef2ac9218ac630cced31c147c0b11"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	configure_args+=" LIBS+=-latomic"
 fi

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -45,7 +45,7 @@ esac
 build_options_default="clang js_optimize vaapi pulseaudio"
 
 post_patch() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		for f in "${FILESDIR}"/musl-patches/*.patch; do
 			echo "Applying $f"
 			patch -Np0 -i "$f"

--- a/srcpkgs/clamav/template
+++ b/srcpkgs/clamav/template
@@ -28,7 +28,7 @@ CPPFLAGS="-Wno-unused-local-typedefs"
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --disable-mempool"
 fi
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-fts-devel"
 	LDFLAGS="-lfts"
 fi

--- a/srcpkgs/clens/template
+++ b/srcpkgs/clens/template
@@ -10,7 +10,7 @@ homepage="https://sourceforge.net/projects/clens/"
 distfiles="$SOURCEFORGE_SITE/clens/clens-${version}.tar.gz"
 checksum=064ac9954d38633e2cff6b696fd049dedc3e90b79acffbee1a87754bcf604267
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/cmus/template
+++ b/srcpkgs/cmus/template
@@ -20,7 +20,7 @@ build_options="elogind"
 build_options_default="elogind"
 desc_option_elogind="Support MPRIS interface via elogind"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	export LDLIBS+=" -latomic"
 fi

--- a/srcpkgs/corectrl/template
+++ b/srcpkgs/corectrl/template
@@ -17,7 +17,7 @@ distfiles="${homepage}/-/archive/v${version}/corectrl-v${version}.tar.gz"
 checksum=050f1b4f105615c26dcb23d09bbdadbc619c9b9782197cae482fb6921f5e3cf2
 patch_args="-Np1"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"

--- a/srcpkgs/cronie/template
+++ b/srcpkgs/cronie/template
@@ -33,12 +33,12 @@ alternatives="
  crond:crond.8:/usr/share/man/man8/cronie-crond.8
 "
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-obstack-devel"
 fi
 
 pre_configure() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		export LIBS="-lobstack"
 	fi
 }

--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -36,7 +36,7 @@ depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -39,7 +39,7 @@ depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -39,7 +39,7 @@ depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -39,7 +39,7 @@ depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -37,7 +37,7 @@ depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-powerpc-linux-gnu/template
+++ b/srcpkgs/cross-powerpc-linux-gnu/template
@@ -35,7 +35,7 @@ depends="${pkgname}-libc-${version}_${revision}"
 nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-powerpc64-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64-linux-gnu/template
@@ -35,7 +35,7 @@ nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-powerpc64le-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64le-linux-gnu/template
@@ -35,7 +35,7 @@ nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cross-x86_64-linux-gnu/template
+++ b/srcpkgs/cross-x86_64-linux-gnu/template
@@ -35,7 +35,7 @@ nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
  libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+if ! xbps_target_libc glibc; then
 	broken="glibc crosstoolchain only available on glibc"
 fi
 

--- a/srcpkgs/cwm/template
+++ b/srcpkgs/cwm/template
@@ -12,7 +12,7 @@ homepage="http://man.openbsd.org/cwm"
 distfiles="https://github.com/leahneukirchen/cwm/archive/v${version}.tar.gz"
 checksum=fdd3d5b4fe9b1b03e1fc270d3dd5a031218589a8e40170e8438d2b9c44a35f08
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/dante/template
+++ b/srcpkgs/dante/template
@@ -11,7 +11,7 @@ homepage="http://www.inet.no/dante/index.html"
 distfiles="http://www.inet.no/dante/files/dante-${version}.tar.gz"
 checksum=4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7
 
-if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+if xbps_target_libc glibc; then
 	configure_args="--with-libc=libc.so.6"
 fi
 

--- a/srcpkgs/deadbeef/template
+++ b/srcpkgs/deadbeef/template
@@ -24,7 +24,7 @@ build_options="gtk3"
 build_options_default="gtk3"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/dhcp/template
+++ b/srcpkgs/dhcp/template
@@ -12,7 +12,7 @@ homepage="https://www.isc.org/downloads/dhcp"
 distfiles="http://ftp.isc.org/isc/dhcp/${version/P/-P}/dhcp-${version/P/-P}.tar.gz"
 checksum=1a7ccd64a16e5e68f7b5e0f527fd07240a2892ea53fe245620f4f5f607004521
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -24,7 +24,7 @@ make_dirs="/var/lib/dhcp 0755 root root"
 CFLAGS="-fcommon"
 
 post_patch() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		vsed -i "/LIBATOMIC=/s/$/-latomic/" configure.ac
 	fi
 }

--- a/srcpkgs/dma/template
+++ b/srcpkgs/dma/template
@@ -17,7 +17,7 @@ system_accounts="mail"
 provides="smtp-server-0_1 smtp-forwarder-0_1"
 replaces="smtp-server>=0 smtp-forwarder>=0"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/drbd-utils/template
+++ b/srcpkgs/drbd-utils/template
@@ -30,7 +30,7 @@ distfiles="https://www.linbit.com/downloads/drbd/utils/${pkgname}-${version}.tar
 checksum=1102e2a2001a45685c2f4ce5cb14e5a8a099044f53389d38480b3a88f5db3fd1
 
 # XXX mirror which is reachable from musl builders
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	distfiles="https://distfiles.voidlinux.de/${pkgname}-${version}.tar.gz"
 fi
 

--- a/srcpkgs/electron7/template
+++ b/srcpkgs/electron7/template
@@ -126,7 +126,7 @@ post_patch() {
 		esac
 	done
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 	for x in $FILESDIR/musl-patches/*; do
 		case "${x##*/}" in
 			chromium*.patch)

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -21,7 +21,7 @@ distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
 checksum=f1098745863138e6270ea22e78a39baef9a0356b48246c5a53b34211992dc7db
 conf_files="/etc/elogind/*.conf"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" -Dutmp=false"
 fi
 

--- a/srcpkgs/encfs/template
+++ b/srcpkgs/encfs/template
@@ -18,7 +18,7 @@ if [ "$CROSS_BUILD" ]; then
 	configure_args="-DBUILD_UNIT_TESTS=0"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/fatsort/template
+++ b/srcpkgs/fatsort/template
@@ -13,6 +13,6 @@ homepage="https://fatsort.sourceforge.io/"
 distfiles="${SOURCEFORGE_SITE}/project/fatsort/fatsort-${version}.tar.xz"
 checksum=481c94ea08f6faaafe67594726d70fb3e3d5ac9672745f0034e55134ea5256fc
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	broken="most tests are failed"
 fi

--- a/srcpkgs/fdm/template
+++ b/srcpkgs/fdm/template
@@ -13,7 +13,7 @@ homepage="https://github.com/nicm/fdm"
 distfiles="https://github.com/nicm/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.gz"
 checksum=06b28cb6b792570bc61d7e29b13d2af46b92fea77e058b2b17e11e8f7ed0cea4
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/filezilla/template
+++ b/srcpkgs/filezilla/template
@@ -21,6 +21,6 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" wxWidgets-gtk3-devel xdg-utils"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi

--- a/srcpkgs/firebird3/template
+++ b/srcpkgs/firebird3/template
@@ -43,7 +43,7 @@ CXXFLAGS="-fno-delete-null-pointer-checks"
 
 pre_configure() {
 	# musl does not have gcrt1.o needed for -p
-	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	if xbps_target_libc musl; then
 		vsed -i -e '/FLAGS=/s/ \-p / /g' \
 			builds/posix/prefix.linux_powerpc* \
 			builds/posix/prefix.linux_arm* \

--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -36,7 +36,7 @@ case $XBPS_TARGET_MACHINE in
 	ppc*) broken="xptcall bitrot" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -90,7 +90,7 @@ do_build() {
 	ppc*) echo "ac_add_options --disable-webrtc" >>.mozconfig ;;
 	esac
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		export LDFLAGS+=" -latomic"
 	fi
 

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -36,7 +36,7 @@ case $XBPS_TARGET_MACHINE in
 	ppc*) broken="xptcall bitrot" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -91,7 +91,7 @@ do_build() {
 	ppc*) echo "ac_add_options --disable-webrtc" >>.mozconfig ;;
 	esac
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		export LDFLAGS+=" -latomic"
 	fi
 

--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -14,7 +14,7 @@ distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}
 checksum=d5b927203b5ca95da16f514969e2a91a537b2f75bec9b21a584c4cd1c7aa74ed
 register_shell="/bin/fish /usr/bin/fish"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/flacon/template
+++ b/srcpkgs/flacon/template
@@ -16,7 +16,7 @@ checksum=b6af83ed30697ed82369d3eefaf8fcceabea69fc86a1d6d1a5594cc5768bad7b
 
 post_extract() {
 	# no support for 64-bit atomics on these platforms in qt
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		vsed -i 's/QAtomicInteger<quint64>/QAtomicInteger<quint32>/' \
 			converter/splitter.cpp
 	fi

--- a/srcpkgs/flightgear/template
+++ b/srcpkgs/flightgear/template
@@ -33,7 +33,7 @@ fi
 # Suppress warnings regarding auto_ptr
 CXXFLAGS="-Wno-deprecated-declarations"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 	configure_args+=" -DCMAKE_EXE_LINKER_FLAGS=-lexecinfo"
 fi

--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -21,9 +21,9 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" libchamplain-devel"
 fi
 
-case "$XBPS_TARGET_LIBC" in
-	musl) makedepends+=" libexecinfo-devel"
-esac
+if xbps_target_libc musl; then
+	makedepends+=" libexecinfo-devel"
+fi
 
 post_install() {
 	rm -rv ${DESTDIR}/usr/share/doc/fotoxx/{changelog.gz,copyright,fotoxx.man} \

--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -36,7 +36,7 @@ homepage="https://freecadweb.org/"
 distfiles="https://github.com/FreeCAD/FreeCAD/archive/${version}.tar.gz"
 checksum=4e0cce447b31b8989a00cf68c49ae012ce8e5546a56c6e0874fbd8f7ddedffd2
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 

--- a/srcpkgs/freecell-solver/template
+++ b/srcpkgs/freecell-solver/template
@@ -16,7 +16,7 @@ changelog="https://fc-solve.shlomifish.org/docs/distro/NEWS.html"
 distfiles="https://fc-solve.shlomifish.org/downloads/fc-solve/freecell-solver-${version}.tar.xz"
 checksum=9f1a4c6d5c8ac54c6619b3b988efb5562d460cd048d33345e52a0c849fd0d9df
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/freedroidRPG/template
+++ b/srcpkgs/freedroidRPG/template
@@ -16,7 +16,7 @@ distfiles="http://ftp.osuosl.org/pub/freedroid/${pkgname}-${version%.*}/${pkgnam
 checksum=426df175034b12095e7498fd80c907e507667c960ee1da331d9e5566d1b09358
 python_version=2
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" --disable-backtrace"
 fi
 

--- a/srcpkgs/frr/template
+++ b/srcpkgs/frr/template
@@ -30,7 +30,7 @@ _frr_groups="_frrvty"
 _daemons="zebra staticd bgpd ospfd ospf6d ripd ripngd isisd pimd ldpd nhrpd
  eigrpd babeld sharpd pbrd bfdd fabricd"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/fswatch/template
+++ b/srcpkgs/fswatch/template
@@ -12,7 +12,7 @@ homepage="https://emcrisostomo.github.io/fswatch/"
 distfiles="https://github.com/emcrisostomo/fswatch/releases/download/${version}/fswatch-${version}.tar.gz"
 checksum=44d5707adc0e46d901ba95a5dc35c5cc282bd6f331fcf9dbf9fad4af0ed5b29d
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -82,7 +82,7 @@ fi
 if [ "$_have_gccgo" = "yes" ]; then
 	subpackages+=" gcc-go gcc-go-tools libgo-devel libgo"
 	# we need this for gcc-go on musl
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		makedepends+=" libucontext-devel"
 	fi
 fi
@@ -252,7 +252,7 @@ do_configure() {
 		_langs+=",go"
 	fi
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		_args+=" --disable-libsanitizer"
 		_args+=" --disable-symvers"
 		_args+=" libat_cv_have_ifunc=no"

--- a/srcpkgs/gcc6/template
+++ b/srcpkgs/gcc6/template
@@ -156,7 +156,7 @@ do_configure() {
 	_args+=" --disable-libmudflap"
 	_args+=" --disable-libssp"
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		_args+=" --disable-symvers"
 		_args+=" libat_cv_have_ifunc=no"
 	fi

--- a/srcpkgs/giada/template
+++ b/srcpkgs/giada/template
@@ -15,12 +15,12 @@ homepage="https://www.giadamusic.com/"
 distfiles="https://github.com/monocasual/giada/archive/v${version}.tar.gz"
 checksum=a2ee69e66bfb4504ce4f91e758315d42e6b83d7b8b0db2eb1d89ab245342f73c
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
 post_extract() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		vsed -e 's/\($(ldAdd)\)/\1 -latomic/g' -i Makefile.am
 	fi
 	vsed -e 's;deps/json/single_include/\(nlohmann/json.hpp\);\1;' -i \

--- a/srcpkgs/gmime/template
+++ b/srcpkgs/gmime/template
@@ -29,7 +29,7 @@ fi
 pre_build() {
 	if [ -z "$CROSS_BUILD" ]; then
 		:
-	elif [ "$XBPS_TARGET_LIBC" = musl ]; then
+	elif xbps_target_libc musl; then
 		cp ${FILESDIR}/musl-iconv-detect.h ${wrksrc}/iconv-detect.h
 	else
 		cp ${FILESDIR}/iconv-detect.h ${wrksrc}

--- a/srcpkgs/gmime3/template
+++ b/srcpkgs/gmime3/template
@@ -26,7 +26,7 @@ pre_configure() {
 
 	configure_args+=" ac_cv_have_iconv_detect_h=yes"
 
-	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	if xbps_target_libc musl; then
 		cp ${FILESDIR}/musl-iconv-detect.h ${wrksrc}/iconv-detect.h
 	else
 		cp ${FILESDIR}/iconv-detect.h ${wrksrc}/iconv-detect.h
@@ -34,7 +34,7 @@ pre_configure() {
 }
 
 do_check() {
-	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	if xbps_target_libc musl; then
 		make check VERBOSITY=-vv |
 		awk '
 			1

--- a/srcpkgs/gnunet/template
+++ b/srcpkgs/gnunet/template
@@ -36,7 +36,7 @@ desc_option_jansson="Enable support for jansson"
 desc_option_opus="Enable support for opus"
 desc_option_zbar="Enable support for zbar"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/go1.12-bootstrap/template
+++ b/srcpkgs/go1.12-bootstrap/template
@@ -13,7 +13,7 @@ noverifyrdeps=yes
 nocross=yes
 lib32disabled=yes
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	depends+=" gcompat"
 	hostmakedepends+=" patchelf"
 fi
@@ -44,7 +44,7 @@ esac
 distfiles="https://dl.google.com/go/go${version}.linux-${_dist_arch}.tar.gz"
 
 post_build() {
-	[ "$XBPS_TARGET_LIBC" != "musl" ] && return 0
+	xbps_target_libc glibc && return 0
 
 	# we don't have lib64 compatibility path on musl 64-bit systems
 	# use patchelf to replace /lib64/<dynlinker> with /lib/<dynlinker>

--- a/srcpkgs/goxel/template
+++ b/srcpkgs/goxel/template
@@ -13,7 +13,7 @@ homepage="https://guillaumechereau.github.io/goxel/"
 distfiles="https://github.com/guillaumechereau/goxel/archive/v${version}.tar.gz"
 checksum=af57197910788131441a537cc658a3397448d90552a0fd3bfe9992635e9d64d8
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -23,7 +23,7 @@ pre_build() {
 			-e "/conf = env.Configure()/ a env.Replace(CC = \"$CC\")" \
 			-e "/conf = env.Configure()/ a env.Replace(CXX = \"$CXX\")"
 	fi
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		vsed -i SConstruct \
 			-e "/conf = env.Configure()/ a env.Append(LIBS='atomic')"
 	fi

--- a/srcpkgs/gperftools/template
+++ b/srcpkgs/gperftools/template
@@ -13,7 +13,7 @@ homepage="https://github.com/gperftools/gperftools"
 distfiles="https://github.com/${pkgname}/${pkgname}/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.gz"
 checksum=1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	# needed by some newly enabled code
 	CXXFLAGS+=" -D__WORDSIZE=$XBPS_TARGET_WORDSIZE"
 	# needed on musl other than x86_64

--- a/srcpkgs/gpgme/template
+++ b/srcpkgs/gpgme/template
@@ -16,7 +16,7 @@ homepage="https://www.gnupg.org/software/gpgme/index.html"
 distfiles="https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-${version}.tar.bz2"
 checksum=cef1f710a6b0d28f5b44242713ad373702d1466dcbe512eb4e754d7f35cd4307
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" ac_cv_sys_file_offset_bits=no"
 elif [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	CFLAGS="-D_FILE_OFFSET_BITS=64 -DLARGEFILE_SOURCE=1"

--- a/srcpkgs/grpc/template
+++ b/srcpkgs/grpc/template
@@ -22,7 +22,7 @@ checksum="c2ab8a42a0d673c1acb596d276055adcc074c1116e427f118415da3e79e52969
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" grpc"   # need host grpc_cpp_plugin
 fi
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
 fi

--- a/srcpkgs/gtk-vnc/template
+++ b/srcpkgs/gtk-vnc/template
@@ -18,7 +18,7 @@ checksum=a81a1f1a79ad4618027628ffac27d3391524c063d9411c7a36a5ec3380e6c080
 build_options="gir"
 build_options_default="gir"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" -Dwith-coroutine=gthread"
 fi
 

--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -21,7 +21,7 @@ system_accounts="$pkgname"
 do_build() {
 	local target="linux-${XBPS_TARGET_LIBC}"
 	local atomic
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		atomic="-latomic"
 	fi
 	make ${makejobs} CC="$CC" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" EXTRA= \

--- a/srcpkgs/hfsprogs/template
+++ b/srcpkgs/hfsprogs/template
@@ -14,7 +14,7 @@ homepage="http://www.opensource.apple.com/"
 distfiles="http://cavan.codon.org.uk/~mjg59/diskdev_cmds/diskdev_cmds-${version}.tar.gz"
 checksum=b01b203a97f9a3bf36a027c13ddfc59292730552e62722d690d33bd5c24f5497
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/highlight/template
+++ b/srcpkgs/highlight/template
@@ -23,7 +23,7 @@ post_extract() {
 pre_build() {
 	# extra flags used during build of perl itself
 	local _ecflags=
-	if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+	if xbps_target_libc glibc; then
 		_ecflags="-D_FILE_OFFSET_BITS=64 -DLARGE_FILE_SUPPORT64"
 	fi
 	make -C extras/swig perl "CXX=$CXX -fPIC -lperl $CFLAGS $_ecflags $LDFLAGS"

--- a/srcpkgs/icecat/template
+++ b/srcpkgs/icecat/template
@@ -36,7 +36,7 @@ fi
 
 CXXFLAGS="-Wno-class-memaccess -Wno-unused-function"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 if [ "$XBPS_WORDSIZE" -eq 32 ]; then
@@ -98,7 +98,7 @@ do_build() {
 	ppc*) echo "ac_add_options --disable-webrtc" >>.mozconfig ;;
 	esac
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		export LDFLAGS+=" -latomic"
 	fi
 

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -19,7 +19,7 @@ checksum="673a1d8dfff4993917ac560d73ded4cab6edf8360cb97b99703658b14c03031f
  11d573e30d4b0c821e9c59a524c9f98b935dcfdad979066cc65fdf111cf116fe"
 python_version=3
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/jack_capture/template
+++ b/srcpkgs/jack_capture/template
@@ -13,7 +13,7 @@ distfiles="https://github.com/kmatheussen/${pkgname}/archive/${version}.tar.gz"
 checksum=21afb0257ed7437708cc9e5bec2f6299599461b7eec8bf66967d8ecadb0751de
 CFLAGS+=" -D__USE_GNU"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/kiwix-lib/template
+++ b/srcpkgs/kiwix-lib/template
@@ -14,7 +14,7 @@ changelog="https://github.com/kiwix/kiwix-lib/blob/${version}/ChangeLog"
 distfiles="https://github.com/kiwix/kiwix-lib/archive/${version}.tar.gz"
 checksum=b36500af589797e220d0a5fc551047f016c8914ac2d4b04666daef977aa0a4ce
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ] || [ "${XBPS_TARGET_MACHINE/-musl/}" = "armv7l" ]; then
+if xbps_target_no_atomic8 || [ "${XBPS_TARGET_MACHINE/-musl/}" = "armv7l" ]; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/kiwix-tools/template
+++ b/srcpkgs/kiwix-tools/template
@@ -13,7 +13,7 @@ changelog="https://github.com/kiwix/kiwix-tools/blob/${version}/Changelog"
 distfiles="https://github.com/kiwix/kiwix-tools/archive/${version}.tar.gz"
 checksum=86325ec31976d40357f08c520806cf223fa1b0a5edb02ad106c2a0d6746ca364
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ] || [ "${XBPS_TARGET_MACHINE/-musl/}" = "armv7l" ]; then
+if xbps_target_no_atomic8 || [ "${XBPS_TARGET_MACHINE/-musl/}" = "armv7l" ]; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/kjsembed/template
+++ b/srcpkgs/kjsembed/template
@@ -17,7 +17,7 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-qmake python kdoctools"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/kodi-addon-pvr-hts/template
+++ b/srcpkgs/kodi-addon-pvr-hts/template
@@ -14,6 +14,6 @@ distfiles="https://github.com/kodi-pvr/pvr.hts/archive/${version}-${_kodi_releas
 checksum=6958b91ca616554e4c068bc303c66388e9a2c3a68b5979d8918b4e0d7b6bb95c
 nocross="depends on kodi-platform"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi

--- a/srcpkgs/kore/template
+++ b/srcpkgs/kore/template
@@ -13,7 +13,7 @@ homepage="https://kore.io"
 distfiles="https://kore.io/releases/kore-${version}.tar.gz"
 checksum=c80d7a817883e631adf9eb5271b4ffa6ebb06c2e2fca40ce6c3c75638c08b67a
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -26,6 +26,6 @@ case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) makedepends+=" vc";;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi

--- a/srcpkgs/kross/template
+++ b/srcpkgs/kross/template
@@ -15,7 +15,7 @@ homepage="https://invent.kde.org/frameworks/kross"
 distfiles="${KDE_SITE}/frameworks/${version%.*}/portingAids/${pkgname}-${version}.tar.xz"
 checksum=aa27b434da981f64c40985a61ee041417667844c6077c9fb52456635be67546e
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -23,7 +23,7 @@ if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/libasr/template
+++ b/srcpkgs/libasr/template
@@ -12,7 +12,7 @@ homepage="https://www.opensmtpd.org/"
 distfiles="https://github.com/OpenSMTPD/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.gz"
 checksum=19fb6bed10d15c9775c8d008cd1130155917ae4e801c729fe85e6d88a545dab4
 
-if [ "$XBPS_TARGET_LIBC" != "musl" ]; then
+if xbps_target_libc glibc; then
 	CFLAGS="-DHAVE_RES_RANDOMID"
 fi
 

--- a/srcpkgs/libbitcoin-explorer/template
+++ b/srcpkgs/libbitcoin-explorer/template
@@ -19,7 +19,7 @@ distfiles="https://github.com/libbitcoin/libbitcoin-explorer/archive/v${version}
 checksum=e1b3fa2723465f7366a6e8c55e14df53106e90b82cc977db638c78f9bc5c47db
 conf_files="/etc/libbitcoin/bx.cfg"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS="-latomic"
 fi

--- a/srcpkgs/libfilezilla/template
+++ b/srcpkgs/libfilezilla/template
@@ -15,7 +15,7 @@ changelog="https://svn.filezilla-project.org/filezilla/libfilezilla/trunk/NEWS?v
 distfiles="https://download.filezilla-project.org/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=adeac127fbd1714b22c828cdd27fc6c92e09fd1abcc96684bf30535fb8226852
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/libgit2-glib/template
+++ b/srcpkgs/libgit2-glib/template
@@ -21,7 +21,7 @@ build_options_default="gir"
 CPPFLAGS="-UG_DISABLE_ASSERT"
 
 post_patch() {
-	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	if xbps_target_libc musl; then
 		vsed -i "s,TEST.*encoding.*,/* & */," tests/repository.c
 	fi
 }

--- a/srcpkgs/libglvnd/template
+++ b/srcpkgs/libglvnd/template
@@ -17,7 +17,7 @@ provides="libGL-7.11_1 libEGL-7.11_1 libGLES-7.11_1"
 replaces="libGL>=0 libEGL>=0 libGLES>=0"
 
 # Disable TLS with musl: https://bugs.freedesktop.org/show_bug.cgi?id=35268
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args="-Dtls=disabled"
 fi
 

--- a/srcpkgs/libkqueue/template
+++ b/srcpkgs/libkqueue/template
@@ -12,7 +12,7 @@ distfiles="https://github.com/mheily/libkqueue/archive/v${version}.tar.gz"
 checksum=6ef91fb9ffd0630e14ed7e551e64fbe14f1af84fed34f1972cdb703593b6ad1f
 CFLAGS="-Wno-error=format-truncation -Wno-error=stringop-overflow"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/libmilter/template
+++ b/srcpkgs/libmilter/template
@@ -13,7 +13,7 @@ distfiles="ftp://ftp.mirrorservice.org/sites/ftp.sendmail.org/pub/${_pkgname}/${
 checksum=24f94b5fd76705f15897a78932a5f2439a32b1a2fdc35769bb1a5f5d9b4db439
 wrksrc="${_pkgname}-${_version}"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/libogre/template
+++ b/srcpkgs/libogre/template
@@ -26,7 +26,7 @@ wrksrc=ogre-$version
 CXXFLAGS="-fcheck-new -fno-delete-null-pointer-checks -fno-lifetime-dse"
 
 pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		find -name CMakeLists.txt -exec sed -i "{}" \
 			-e "/target_link_libraries/s/)/ atomic)/" \;
 	fi

--- a/srcpkgs/libopenshot-audio/template
+++ b/srcpkgs/libopenshot-audio/template
@@ -15,7 +15,7 @@ checksum=937ff4f1c2dfb8ab5d56ad85beacaa29dfd5a79af0d9cf647386034fe9882309
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	CXXFLAGS+=" -latomic "
 fi

--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -257,7 +257,7 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 esac
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	# use shipped clucene, because CLucene/analysis/cjk/CJKAnalyzer.h
 	# is missing in the musl clucene-devel files
 	makedepends+=" libexecinfo-devel"
@@ -438,7 +438,7 @@ do_configure() {
 		-e "s|.1.gz|.1|g"
 	chmod +x bin/unpack-sources
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		vsed -i sal/Library_sal.mk -e "s;-ldl ;-lexecinfo &;"
 	fi
 

--- a/srcpkgs/libreoffice/template
+++ b/srcpkgs/libreoffice/template
@@ -263,7 +263,7 @@ if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/librpcsecgss/template
+++ b/srcpkgs/librpcsecgss/template
@@ -12,9 +12,9 @@ homepage="http://www.citi.umich.edu/projects/nfsv4/linux/"
 distfiles="$homepage/$pkgname/$pkgname-$version.tar.gz"
 checksum=0cafb86b67e5eb4c89e8abaaad9165298946bc164d258e8925fc6dc1fa913abd
 
-case "$XBPS_TARGET_LIBC" in
-	musl) broken="rpc/rpc.h header is not available on musl"
-esac
+if xbps_target_libc musl; then
+	broken="rpc/rpc.h header is not available on musl"
+fi
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/libselinux/template
+++ b/srcpkgs/libselinux/template
@@ -14,7 +14,7 @@ homepage="https://www.nsa.gov/what-we-do/research/selinux/"
 distfiles="https://github.com/SELinuxProject/selinux/releases/download/20191204/${pkgname}-${version}.tar.gz"
 checksum=2ea2b30f671dae9d6b1391cbe8fb2ce5d36a3ee4fb1cd3c32f0d933c31b82433
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-fts-devel"
 	export FTS_LDLIBS="-lfts"
 fi

--- a/srcpkgs/libtd/template
+++ b/srcpkgs/libtd/template
@@ -18,7 +18,7 @@ if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="Unsupported tl-schema version -1"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
 	makedepends+=" libatomic-devel"
 fi

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -17,7 +17,7 @@ homepage="https://libtorrent.org/"
 distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent_${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
 checksum=bc00069e65c0825cbe1eee5cdd26f94fcd9a621c4e7f791810b12fab64192f00
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/libvirt/template
+++ b/srcpkgs/libvirt/template
@@ -77,7 +77,7 @@ post_install() {
 	rm -rf ${DESTDIR}/var/log
 
 	# workaround for musl not providing an utmpx implementation
-	if [ "$XBPS_TARGET_LIBC" = "musl" ];
+	if xbps_target_libc musl;
 	then
 		echo "remember_owner = 0" >> ${DESTDIR}/etc/libvirt/qemu.conf
 	fi

--- a/srcpkgs/lnav/template
+++ b/srcpkgs/lnav/template
@@ -14,7 +14,7 @@ homepage="http://lnav.org/"
 distfiles="https://github.com/tstack/${pkgname}/archive/v${version}.tar.gz"
 checksum=5e5bfde95da71d9e00ec20b4a17d7f260ca90d23c86a47f8bc3fb98418aea6bc
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/ltrace/template
+++ b/srcpkgs/ltrace/template
@@ -17,7 +17,7 @@ checksum=4aecf69e4a33331aed1e50ce4907e73a98cbccc4835febc3473863474304d547
 CFLAGS="-Wno-error -D_GNU_SOURCE"
 
 pre_configure() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		sed -i '/HOST_OS/s/linux-uclibc/linux-musl/g' configure.ac
 		sed -i -e '/error.h/d' -e 's/error(1, errno/err(1/' \
 			read_config_file.c expr.c zero.c

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -165,7 +165,7 @@ case "$XBPS_TARGET_MACHINE" in
 	i686) configure_args+=" -Ddri-drivers-path=/usr/lib32/dri";;
 esac
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" -Duse-elf-tls=false"
 fi
 

--- a/srcpkgs/micropython/template
+++ b/srcpkgs/micropython/template
@@ -16,7 +16,7 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc*) broken="missing nlr_push" ;;
 esac
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/minidlna/template
+++ b/srcpkgs/minidlna/template
@@ -26,7 +26,7 @@ minidlna_homedir="/var/lib/minidlna"
 
 CFLAGS="-fcommon"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/minissdpd/template
+++ b/srcpkgs/minissdpd/template
@@ -13,7 +13,7 @@ checksum=dfd637b185731e1acb412a86faa9718eb93c04ca08280541a6d22d14d1fb890f
 
 CFLAGS="-D_GNU_SOURCE"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/miniupnpd/template
+++ b/srcpkgs/miniupnpd/template
@@ -17,7 +17,7 @@ homepage="http://miniupnp.free.fr"
 distfiles="http://miniupnp.free.fr/files/miniupnpd-${version}.tar.gz"
 checksum=950894779661197fe093855fda29a728f434b5756eb4fa6cb5f7b9bff7ffe0c1
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/mlt/template
+++ b/srcpkgs/mlt/template
@@ -22,7 +22,7 @@ checksum=ab211e27c06c0688f9cbe2d74dc0623624ef75ea4f94eea915cdc313196be2dd
 CFLAGS+=" -DHAVE_STRTOD_L=1 -DHAVE_LOCALE_H=1"
 CXXFLAGS+=" -DHAVE_STRTOD_L=1 -DHAVE_LOCALE_H=1"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/monero-gui/template
+++ b/srcpkgs/monero-gui/template
@@ -27,7 +27,7 @@ post_extract() {
 pre_configure() {
 	echo "var GUI_VERSION = \"${version}\"" > version.js
 	echo "var GUI_MONERO_VERSION = \"${version}\"" >> version.js
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		sed -i *.pro -e "s;-leasylogging;-leasylogging -latomic;"
 	fi
 }

--- a/srcpkgs/monero/template
+++ b/srcpkgs/monero/template
@@ -44,7 +44,7 @@ case "$XBPS_TARGET_MACHINE" in
 	*) configure_args+=" -DARCH=default" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	CFLAGS+=" -latomic"
 fi
@@ -61,7 +61,7 @@ post_extract() {
 }
 
 pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		sed -i CMakeLists.txt -e \
 			'/include(version.cmake)/i list(APPEND EXTRA_LIBRARIES libatomic.a)'
 	fi

--- a/srcpkgs/mozjs52/template
+++ b/srcpkgs/mozjs52/template
@@ -25,7 +25,7 @@ LDFLAGS="-fuse-ld=bfd"
 CFLAGS+=" -Wno-format-overflow"
 CXXFLAGS+=" -Wno-format-overflow"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/mozjs60/template
+++ b/srcpkgs/mozjs60/template
@@ -19,7 +19,7 @@ patch_args="-Np1"
 CXXFLAGS="-Wno-class-memaccess"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/mozjs68/template
+++ b/srcpkgs/mozjs68/template
@@ -20,7 +20,7 @@ patch_args="-Np1"
 CXXFLAGS="-Wno-class-memaccess"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/musikcube/template
+++ b/srcpkgs/musikcube/template
@@ -16,7 +16,7 @@ homepage="https://musikcube.com/"
 distfiles="https://github.com/clangen/musikcube/archive/${version}.tar.gz"
 checksum=e84e060acaab40266cc3d866f50f727c770c42273a5219fff5d6757186dbad21
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	configure_args+=" -DCMAKE_EXE_LINKER_FLAGS='-latomic'"
 fi

--- a/srcpkgs/namecoin/template
+++ b/srcpkgs/namecoin/template
@@ -16,7 +16,7 @@ homepage="https://namecoin.org"
 distfiles="https://github.com/namecoin/namecoin-core/archive/nc${version}.tar.gz"
 checksum=7117a0a0b8f48d49e4abf3577660f8a4eb9a4dea753281d19d9470725fc75d8e
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/netrek-client-cow/template
+++ b/srcpkgs/netrek-client-cow/template
@@ -14,7 +14,7 @@ distfiles="https://www.netrek.org/files/COW/netrek-client-cow-${version}.tar.gz"
 checksum=cac219248d71033b62098c3da1ca6b4408974b22996da39eaba213b2253e6da3
 nocross='./mkcflags compiled without HOSTCC'
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-fts-devel"
 	export LIBS+=" -lfts"
 fi

--- a/srcpkgs/nfs-utils/template
+++ b/srcpkgs/nfs-utils/template
@@ -31,7 +31,7 @@ make_dirs="
  /etc/exports.d			0750	root	root
 "
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/nix/template
+++ b/srcpkgs/nix/template
@@ -42,12 +42,12 @@ make_dirs="
 	/nix/var/nix/db 0755 root root
 	/nix/store 1775 root nixbld"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
 pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		echo "libexpr_LDFLAGS += -latomic" >> src/libexpr/local.mk
 		echo "libutil_LDFLAGS += -latomic" >> src/libutil/local.mk
 		echo "libstore_LDFLAGS += -latomic" >> src/libstore/local.mk

--- a/srcpkgs/nodejs-lts-10/template
+++ b/srcpkgs/nodejs-lts-10/template
@@ -36,7 +36,7 @@ if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
 	nocross="host and target must have the same pointer size"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 if [ "$XBPS_NO_ATOMIC8" ]; then

--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -42,7 +42,7 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc*) broken="Node 12.x does not support 32-bit ppc" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 if [ "$XBPS_NO_ATOMIC8" ]; then

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -42,7 +42,7 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc*) broken="Node 12.x does not support 32-bit ppc" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 if [ "$XBPS_NO_ATOMIC8" ]; then

--- a/srcpkgs/nsjail/template
+++ b/srcpkgs/nsjail/template
@@ -16,7 +16,7 @@ checksum="cfa66d3ed136b2e221752287b95e544915e8a6760aa866f023b604d14a374919
 
 archs="aarch64* armv5tel* armv6l* armv7l* x86_64*"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/nudoku/template
+++ b/srcpkgs/nudoku/template
@@ -12,7 +12,7 @@ homepage="https://github.com/jubalh/nudoku"
 distfiles="https://github.com/jubalh/${pkgname}/archive/${version}.tar.gz"
 checksum=44d3ec1ff34a010910ac7a92f6d84e8a7a4678a966999b7be27d224609ae54e1
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" --disable-nls"
 fi
 

--- a/srcpkgs/open-vm-tools/template
+++ b/srcpkgs/open-vm-tools/template
@@ -26,7 +26,7 @@ build_options_default="pam x11"
 
 CFLAGS="-fcommon"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	configure_args+=" --disable-glibc-check"
 fi
 

--- a/srcpkgs/openbsd-file/template
+++ b/srcpkgs/openbsd-file/template
@@ -15,7 +15,7 @@ checksum=f6bf601f513bd83038e343bbd93b7982f373669a2ffa76dc52d48fa7251515b2
 
 system_accounts="_file"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	CFLAGS="-DREG_STARTEND=0"
 	makedepends+=" musl-legacy-compat"
 fi

--- a/srcpkgs/opencv/template
+++ b/srcpkgs/opencv/template
@@ -19,7 +19,7 @@ homepage="https://opencv.org"
 distfiles="https://github.com/opencv/${pkgname}/archive/${version}.tar.gz"
 checksum=1ed6f5b02a7baf14daca04817566e7c98ec668cec381e0edf534fa49f10f58a2
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/opencv4/template
+++ b/srcpkgs/opencv4/template
@@ -25,7 +25,7 @@ distfiles="https://github.com/opencv/opencv/archive/${version}.tar.gz
 checksum="68bc40cbf47fdb8ee73dfaf0d9c6494cd095cf6294d99de445ab64cf853d278a
 	acb8e89c9e7d1174e63e40532125b60d248b00e517255a98a419d415228c6a55"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/openimageio/template
+++ b/srcpkgs/openimageio/template
@@ -23,7 +23,7 @@ case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) configure_args+=" -DUSE_SIMD=sse2" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -36,7 +36,7 @@ pre_build() {
 	# Replace -isystem with -I to avoid "#include_next <stdlib.h>" file not found
 	vsed -i src/cmake/compiler.cmake -e "s;-isystem;-I;g"
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		# Add libatomic to the targets
 		vsed -i src/libOpenImageIO/CMakeLists.txt \
 			-e "s;^\(target_link_libraries (OpenImageIO ${ZLIB_LIBRARIES}\));\1 atomic);"

--- a/srcpkgs/openjdk10-bootstrap/template
+++ b/srcpkgs/openjdk10-bootstrap/template
@@ -64,18 +64,18 @@ export CCACHE_DISABLE=1
 post_extract() {
 	chmod +x configure
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		rm -r src/jdk.hotspot.agent
 	fi
 }
 
 post_patch() {
-	[ "$XBPS_TARGET_LIBC" != "musl" ] && return 0
-
-	for f in ${FILESDIR}/musl_*.patch; do
-		echo "Applying $f"
-		patch -sNp1 -i "$f"
-	done
+	if xbps_target_libc musl; then
+		for f in ${FILESDIR}/musl_*.patch; do
+			echo "Applying $f"
+			patch -sNp1 -i "$f"
+		done
+	fi
 }
 
 do_configure() {

--- a/srcpkgs/openjdk11/template
+++ b/srcpkgs/openjdk11/template
@@ -63,9 +63,9 @@ if [ -n "$_use_zero" ]; then
 	esac
 fi
 
-case "$XBPS_TARGET_LIBC" in
-	glibc) build_options_default+=" docs";;
-esac
+if xbps_target_libc glibc; then
+	build_options_default+=" docs"
+fi
 
 if [ ! "$CROSS_BUILD" ]; then
 	hostmakedepends+=" openjdk10-bootstrap"
@@ -120,13 +120,13 @@ alternatives="
 
 post_extract() {
 	chmod +x configure
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		rm -r src/jdk.hotspot.agent
 	fi
 }
 
 post_patch() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		for f in "${FILESDIR}"/musl_patches/*.patch; do
 			echo "Applying $f"
 			patch -Np1 -i "$f"

--- a/srcpkgs/openjdk8/template
+++ b/srcpkgs/openjdk8/template
@@ -168,17 +168,17 @@ post_extract() {
 }
 
 post_patch() {
-	[ "$XBPS_TARGET_LIBC" != "musl" ] && return 0
+	if xbps_target_libc musl; then
+		for f in ${FILESDIR}/musl_*.patch; do
+			echo "Applying $f"
+			patch -sNp1 -i "$f"
+		done
 
-	for f in ${FILESDIR}/musl_*.patch; do
-		echo "Applying $f"
-		patch -sNp1 -i "$f"
-	done
-
-	# add cross prefix for thread_db.h check, fix cross from glibc to musl
-	sed -i "s,/usr/include/thread_db.h,${XBPS_CROSS_BASE}/usr/include/thread_db.h," \
-	 hotspot/make/linux/makefiles/defs.make hotspot/make/linux/makefiles/sa.make \
-	 hotspot/make/linux/makefiles/saproc.make
+		# add cross prefix for thread_db.h check, fix cross from glibc to musl
+		sed -i "s,/usr/include/thread_db.h,${XBPS_CROSS_BASE}/usr/include/thread_db.h," \
+		 hotspot/make/linux/makefiles/defs.make hotspot/make/linux/makefiles/sa.make \
+		 hotspot/make/linux/makefiles/saproc.make
+	fi
 }
 
 do_configure() {

--- a/srcpkgs/openjdk9-bootstrap/template
+++ b/srcpkgs/openjdk9-bootstrap/template
@@ -83,18 +83,18 @@ post_extract() {
 		mv ../${subrepo}-jdk-${_repo_ver} ${subrepo}
 	done
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		rm -r hotspot/src/jdk.hotspot.agent
 	fi
 }
 
 post_patch() {
-	[ "$XBPS_TARGET_LIBC" != "musl" ] && return 0
-
-	for f in ${FILESDIR}/musl_*.patch; do
-		echo "Applying $f"
-		patch -sNp1 -i "$f"
-	done
+	if xbps_target_libc musl; then
+		for f in ${FILESDIR}/musl_*.patch; do
+			echo "Applying $f"
+			patch -sNp1 -i "$f"
+		done
+	fi
 }
 
 do_configure() {

--- a/srcpkgs/openmw/template
+++ b/srcpkgs/openmw/template
@@ -20,7 +20,7 @@ if [ "$XBPS_TARGET_ENDIAN" != "le" ]; then
 	broken="https://gitlab.com/OpenMW/openmw/issues/564"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	broken="https://build.voidlinux.org/builders/armv6l_builder/builds/26346/steps/shell_3/logs/stdio"
 fi
 

--- a/srcpkgs/openvdb/template
+++ b/srcpkgs/openvdb/template
@@ -13,12 +13,12 @@ homepage="https://openvdb.org"
 distfiles="https://github.com/AcademySoftwareFoundation/openvdb/archive/v${version}.tar.gz"
 checksum=97bc8ae35ef7ccbf49a4e25cb73e8c2eccae6b235bac86f2150707efcd1e910d
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
 post_patch() {
-	[ "$XBPS_TARGET_NO_ATOMIC8" ] || return 0
+	xbps_target_no_atomic8 || return 0
 	vsed -i 's,ZLIB::ZLIB,ZLIB::ZLIB atomic,' openvdb/CMakeLists.txt
 }
 

--- a/srcpkgs/pacman/template
+++ b/srcpkgs/pacman/template
@@ -18,7 +18,7 @@ homepage="https://www.archlinux.org/pacman/"
 distfiles="https://sources.archlinux.org/other/pacman/pacman-${version}.tar.gz"
 checksum=bb201a9f2fb53c28d011f661d50028efce6eef2c1d2a36728bdd0130189349a0
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	do_check() {
 		: fakechroot is not available
 	}

--- a/srcpkgs/pam_ssh/template
+++ b/srcpkgs/pam_ssh/template
@@ -17,7 +17,7 @@ checksum=0c456f6a5c9e47ce6825ac50d467e7a797e14239b2b9a72bfeb2df0100f4af31
 
 CFLAGS="-fcommon"
 
-if [ "${XBPS_TARGET_LIBC}" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/paraview/template
+++ b/srcpkgs/paraview/template
@@ -37,7 +37,7 @@ CXXFLAGS="-D_GNU_SOURCE -fcommon"
 # qhelpgenerator: could not find a Qt installation of ''
 export QT_SELECT="5"
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then

--- a/srcpkgs/paraview/template
+++ b/srcpkgs/paraview/template
@@ -40,7 +40,7 @@ export QT_SELECT="5"
 if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -52,7 +52,7 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_extract() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		echo "target_link_libraries(vtkCommonDataModel PRIVATE atomic)" >> \
 			VTK/Common/DataModel/CMakeLists.txt
 	fi

--- a/srcpkgs/perl/template
+++ b/srcpkgs/perl/template
@@ -167,7 +167,7 @@ do_configure() {
 	LDFLAGS+=" -pthread"
 	export HOSTLDFLAGS+=" -pthread"
 
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		export HOSTCFLAGS+=" -D_GNU_SOURCE"
 		export CFLAGS+=" -DNO_POSIX_2008_LOCALE -D_GNU_SOURCE"
 	else

--- a/srcpkgs/pev/template
+++ b/srcpkgs/pev/template
@@ -19,7 +19,7 @@ homepage="http://pev.sourceforge.net/"
 distfiles="http://http.debian.net/debian/pool/main/p/pev/pev_${version}.orig.tar.gz"
 checksum=f68c8596f16d221d9a742812f6f728bcc739be90957bc1b00fbaa5943ffc5cfa
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -18,7 +18,7 @@ distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}
 checksum=927301640f87d68e52f4480667977bc6f47186ee7877f7aa86ce9172ff144edc
 conf_files="/etc/pipewire/pipewire.conf"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/planner/template
+++ b/srcpkgs/planner/template
@@ -18,7 +18,7 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" evolution-data-server-devel"
 fi
 pre_configure() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		# In musl libc there is no _NL_TIME_FIRST_WEEKDAY in langinfo.h
 		# thus replace Posix.NLTime.FIRST_WEEKDAY.to_string ().data[0];
 		# with 0; (sunday)

--- a/srcpkgs/ppp/template
+++ b/srcpkgs/ppp/template
@@ -28,7 +28,7 @@ conf_files="
 
 CFLAGS="-D_GNU_SOURCE"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/projectM/template
+++ b/srcpkgs/projectM/template
@@ -15,7 +15,7 @@ homepage="https://github.com/projectM-visualizer/projectm"
 distfiles="${homepage}/releases/download/v${version}/projectM-${version}.tar.gz"
 checksum=30af6d1c108efc19311a5636efbbedbe83d23905bb8472dd3fe4b07a21fb5fd3
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-fts-devel"
 	export LDFLAGS+=" -lfts"
 fi

--- a/srcpkgs/proot/template
+++ b/srcpkgs/proot/template
@@ -14,7 +14,7 @@ homepage="https://proot-me.github.io"
 distfiles="https://github.com/proot-me/PRoot/archive/v${version}.tar.gz"
 checksum=ce0a3baca8312613bd10f65bb436a3aaa28e1034f498a22c35ad0693600e01dd
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/protobuf24/template
+++ b/srcpkgs/protobuf24/template
@@ -24,7 +24,7 @@ if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --with-protoc=/usr/bin/protoc"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/python3-elementpath/template
+++ b/srcpkgs/python3-elementpath/template
@@ -18,7 +18,7 @@ checksum=5bbce8de94551c84eb8371dae8f0c7a3850385b1f9d8e9adf9c801bb7c722ffe
 post_patch() {
 	# locale handling in musl is NOT that ideal,
 	# those tests are broken on musl
-	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	if xbps_target_libc musl; then
 		vsed -i tests/test_xpath2_functions.py \
 			-e "/compare.*Strassen.* 1/d" \
 			-e "/with self\.assertRaises(locale\.Error)/,+3d"

--- a/srcpkgs/qpdf/template
+++ b/srcpkgs/qpdf/template
@@ -14,7 +14,7 @@ changelog="https://raw.githubusercontent.com/qpdf/qpdf/master/ChangeLog"
 distfiles="${homepage}/archive/release-qpdf-${version}.tar.gz"
 checksum=6bf21d71fc23b3dd0edf4699d4d68760402482cb8a96e7e36eae92914f931bca
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/qt5-webengine/template
+++ b/srcpkgs/qt5-webengine/template
@@ -34,7 +34,7 @@ if [ "$CROSS_BUILD" ]; then
 	 qt5-declarative-devel"
 fi
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/qt5-webengine/template
+++ b/srcpkgs/qt5-webengine/template
@@ -63,7 +63,7 @@ case "$XBPS_MACHINE" in
 	ppc64*) hostmakedepends+=" libatomic-devel"
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/qt5-webkit/template
+++ b/srcpkgs/qt5-webkit/template
@@ -41,7 +41,7 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 # some platforms need libatomic
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LIBS+=" -latomic"
 fi

--- a/srcpkgs/qtcreator/template
+++ b/srcpkgs/qtcreator/template
@@ -22,12 +22,12 @@ if [ "$CROSS_BUILD" ]; then
 	makedepends+=" clang llvm"
 fi
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 
 pre_configure() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		vsed -i src/plugins/qmldesigner/qmldesignerplugin.pro \
 			src/plugins/clangformat/clangformat.pro \
 			-e "/LIBS += /aLIBS += -L${XBPS_CROSS_BASE}/usr/lib -lexecinfo"

--- a/srcpkgs/qtox/template
+++ b/srcpkgs/qtox/template
@@ -24,6 +24,6 @@ checksum=23b60fc6d5ce5e45e7099ad606218d16203157ab87a2582377001d3241336aac
 build_options="snorenotify"
 build_options_default="snorenotify"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi

--- a/srcpkgs/remmina/template
+++ b/srcpkgs/remmina/template
@@ -22,6 +22,6 @@ changelog="https://gitlab.com/Remmina/Remmina/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/Remmina/Remmina/-/archive/v${version}/Remmina-v${version}.tar.bz2"
 checksum=7614d447dc588403aff2ff97b253f46c5f03a6347d024618e84490b8ab4cd87b
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi

--- a/srcpkgs/rocksdb/template
+++ b/srcpkgs/rocksdb/template
@@ -13,14 +13,14 @@ homepage="https://github.com/facebook/rocksdb"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=7fb6738263d3f2b360d7468cf2ebe333f3109f3ba1ff80115abd145d75287254
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 # Use the C++17 feature to align new
 CXXFLAGS="-faligned-new -Wno-error=deprecated-copy -Wno-error=pessimizing-move"
 
 pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		vsed -i CMakeLists.txt \
 			-e 's;target_link_libraries(${ROCKSDB_SHARED_LIB};& atomic;'
 	fi

--- a/srcpkgs/rott/template
+++ b/srcpkgs/rott/template
@@ -13,7 +13,7 @@ homepage="http://icculus.org/rott/"
 distfiles="${homepage}/releases/rott-${version}.tar.gz"
 checksum=102516e8c312f6b0bbf6c623e1f01cbfbbc314ace8adfe1f201d47b15bd927ff
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 	export LDLIBS="-lexecinfo"
 fi

--- a/srcpkgs/rsyslog/template
+++ b/srcpkgs/rsyslog/template
@@ -24,7 +24,7 @@ make_dirs="/etc/rsyslog.d 0755 root root"
 lib32disabled=yes
 disable_parallel_build=yes
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/ruby/template
+++ b/srcpkgs/ruby/template
@@ -49,7 +49,7 @@ if [ "$CROSS_BUILD" ]; then
 fi
 
 post_patch() {
-	[ "$XBPS_TARGET_LIBC" = "glibc" ] && return 0
+	xbps_target_libc glibc && return 0
 
 	echo "Patching out using binary gems for non-glibc..."
 	patch -sNp1 -i ${FILESDIR}/rubygems-avoid-platform-specific-gems.patch

--- a/srcpkgs/rvault/template
+++ b/srcpkgs/rvault/template
@@ -17,7 +17,7 @@ homepage="https://github.com/rmind/rvault"
 distfiles="https://github.com/rmind/rvault/archive/v${version}.tar.gz"
 checksum=0927017cab3d0f29cb9e6cd537405aa3c1bf302d1285cb7c16da656ba73aa1be
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -27,7 +27,7 @@ hostmakedepends="pkg-config perl python-devel"
 makedepends="readline-devel libcap-devel popt-devel e2fsprogs-devel mit-krb5-devel
  libldap-devel pam-devel acl-devel avahi-libs-devel tdb-devel talloc-devel cups-devel"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/siril/template
+++ b/srcpkgs/siril/template
@@ -15,7 +15,7 @@ homepage="https://www.siril.org/"
 distfiles="https://free-astro.org/download/${pkgname}-${version}.tar.bz2"
 checksum=9fb7f8a10630ea028137e8f213727519ae9916ea1d88cd8d0cc87f336d8d53b1
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 

--- a/srcpkgs/snapcast/template
+++ b/srcpkgs/snapcast/template
@@ -16,7 +16,7 @@ checksum=c7ce1094fa1231c66479bfd37a18f564805f632aaa42de99b52cb0f9f52a2c46
 
 build_options="avahi"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/sniproxy/template
+++ b/srcpkgs/sniproxy/template
@@ -16,7 +16,7 @@ conf_files="/etc/${pkgname}.conf"
 
 CFLAGS="-fcommon"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/sonic-visualiser/template
+++ b/srcpkgs/sonic-visualiser/template
@@ -17,7 +17,7 @@ changelog="https://code.soundsoftware.ac.uk/projects/sonic-visualiser/repository
 distfiles="https://code.soundsoftware.ac.uk/attachments/download/2717/${pkgname}-${version}.tar.gz"
 checksum=baf04e8987bfbd6a8591db0e23bd8da98a2cf7688b10e4b00ac7091def81e182
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -36,7 +36,7 @@ post_extract() {
 		 test-svcore-system.pro
 	fi
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		sed -i -e "s/^linux\*:LIBS +=.*/& -latomic/" config.pri.in
 	fi
 }

--- a/srcpkgs/squeak/template
+++ b/srcpkgs/squeak/template
@@ -17,7 +17,7 @@ distfiles="http://squeakvm.org/unix/release/Squeak-${version}-src.tar.gz"
 checksum=3db6d12ea223e5bc49f52af7f6f832e383a3a006a53bc8a87f6469e1af5dfc2e
 
 # a terrible hack around terrible code
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	CFLAGS+=" -D__NEED_struct__IO_FILE"
 fi
 

--- a/srcpkgs/squid/template
+++ b/srcpkgs/squid/template
@@ -68,7 +68,7 @@ distfiles="http://www.squid-cache.org/Versions/v4/squid-${version}.tar.xz"
 checksum=f42a03c8b3dc020722c88bf1a87da8cb0c087b2f66b41d8256c77ee1b527e317
 system_accounts="squid"
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/stockfish/template
+++ b/srcpkgs/stockfish/template
@@ -26,7 +26,7 @@ case $XBPS_TARGET_MACHINE in
 	ppc*) make_build_args+="ARCH=ppc-32" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS+=" -latomic"
 fi

--- a/srcpkgs/swi-prolog/template
+++ b/srcpkgs/swi-prolog/template
@@ -18,7 +18,7 @@ changelog="http://www.swi-prolog.org/ChangeLog?branch=stable"
 distfiles="http://www.swi-prolog.org/download/stable/src/swipl-${version}.tar.gz"
 checksum=331bc5093d72af0c9f18fc9ed83b88ef9ddec0c8d379e6c49fa43739c8bda2fb
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 	LDFLAGS="-latomic"
 fi

--- a/srcpkgs/swiften/template
+++ b/srcpkgs/swiften/template
@@ -12,7 +12,7 @@ homepage="http://swift.im/"
 distfiles="http://swift.im/git/swift/snapshot/swift-${version}.tar.bz2"
 checksum=2e48f081d337f471b4eba7c0c807a7b640216a76ed3568ced55abb5b927c7fd2
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/sysbench/template
+++ b/srcpkgs/sysbench/template
@@ -18,7 +18,7 @@ homepage="https://github.com/akopytov/sysbench"
 distfiles="https://github.com/akopytov/sysbench/archive/${version}.tar.gz"
 checksum=e8ee79b1f399b2d167e6a90de52ccc90e52408f7ade1b9b7135727efe181347f
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/tacacs/template
+++ b/srcpkgs/tacacs/template
@@ -16,7 +16,7 @@ python_version=2
 disable_parallel_build=yes
 
 pre_configure() {
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		patch -Np0 -i ${FILESDIR}/no-reap-child-test-no-nsl.patch
 	fi
 }

--- a/srcpkgs/tbb/template
+++ b/srcpkgs/tbb/template
@@ -45,7 +45,7 @@ post_extract() {
 
 	# alternative might be:
 	# https://git.alpinelinux.org/cgit/aports/tree/testing/libtbb/glibc-struct-mallinfo.patch
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	if xbps_target_libc musl; then
 		vsed -e "s@#define MALLOC_UNIXLIKE_OVERLOAD_ENABLED __linux__@@" \
 		  -i src/tbbmalloc/proxy.h
 	fi

--- a/srcpkgs/texi2mdoc/template
+++ b/srcpkgs/texi2mdoc/template
@@ -10,7 +10,7 @@ homepage="http://mdocml.bsd.lv/texi2mdoc"
 distfiles="http://mdocml.bsd.lv/texi2mdoc/snapshots/${pkgname}-${version}.tgz"
 checksum=7a45fd87c27cc8970a18db9ddddb2f09f18b8dd5152bf0ca377c3a5e7d304bfe
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/thrift/template
+++ b/srcpkgs/thrift/template
@@ -13,7 +13,7 @@ homepage="https://thrift.apache.org/"
 distfiles="http://www-us.apache.org/dist/thrift/${version}/thrift-${version}.tar.gz"
 checksum=7ad348b88033af46ce49148097afe354d513c1fca7c607b59c33ebb6064b5179
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -36,7 +36,7 @@ case $XBPS_TARGET_MACHINE in
 	ppc*) broken="xptcall bitrot" ;;
 esac
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 
@@ -89,7 +89,7 @@ do_build() {
 	ppc*) echo "ac_add_options --disable-webrtc" >>.mozconfig ;;
 	esac
 
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	if xbps_target_no_atomic8; then
 		export LDFLAGS+=" -latomic"
 	fi
 

--- a/srcpkgs/tomahawk/template
+++ b/srcpkgs/tomahawk/template
@@ -36,7 +36,7 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-qmake"
 fi
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/tomahawk/template
+++ b/srcpkgs/tomahawk/template
@@ -40,7 +40,7 @@ if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+if xbps_target_no_atomic8; then
 	makedepends+=" libatomic-devel"
 fi
 

--- a/srcpkgs/transmission/template
+++ b/srcpkgs/transmission/template
@@ -26,7 +26,7 @@ if [ -z "$CROSS_BUILD" ]; then
 	subpackages+=" transmission-qt"
 fi
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/trinity/template
+++ b/srcpkgs/trinity/template
@@ -17,7 +17,7 @@ if [ "$CROSS_BUILD" ]; then
 	export CROSS_COMPILE=${XBPS_TARGET_TRIPLET}
 fi
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	CFLAGS+=" -Dloff_t=off_t"
 fi
 

--- a/srcpkgs/ttyd/template
+++ b/srcpkgs/ttyd/template
@@ -13,7 +13,7 @@ homepage="https://tsl0922.github.io/ttyd/"
 distfiles="https://github.com/tsl0922/ttyd/archive/${version}.tar.gz"
 checksum=d14740bc82be0d0760dd0a3c97acbcbde490412a4edc61edabe46d311b068f83
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/vino/template
+++ b/srcpkgs/vino/template
@@ -16,6 +16,6 @@ homepage="https://wiki.gnome.org/action/show/Projects/Vino"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=2911c779b6a2c46e5bc8e5a0c94c2a4d5bd4a1ee7e35f2818702cb13d9d23bab
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi

--- a/srcpkgs/vtk/template
+++ b/srcpkgs/vtk/template
@@ -21,7 +21,7 @@ checksum=1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7
 
 nocross="hdf5 is nocross"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 	LDFLAGS="-lexecinfo"
 fi

--- a/srcpkgs/watchdog/template
+++ b/srcpkgs/watchdog/template
@@ -11,7 +11,7 @@ distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=b8e7c070e1b72aee2663bdc13b5cc39f76c9232669cfbb1ac0adc7275a3b019d
 conf_files="/etc/watchdog.conf"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	broken="nfsmount.h:9:10: fatal error: rpc/rpc.h: No such file or directory"
 fi
 

--- a/srcpkgs/wayfire/template
+++ b/srcpkgs/wayfire/template
@@ -18,7 +18,7 @@ checksum="24c1a2c963dac5af762f87cd024bc3dd736ec9a28a6735d357a05e8f6502e8aa
 
 build_options="elogind"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel"
 fi
 

--- a/srcpkgs/wayvnc/template
+++ b/srcpkgs/wayvnc/template
@@ -12,7 +12,7 @@ homepage="https://github.com/any1/wayvnc"
 distfiles="https://github.com/any1/wayvnc/archive/v${version}.tar.gz"
 checksum=a4ee6f49a821b326e89b2534048687330bc84ed3984499ab2cf39422517fb731
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -67,7 +67,7 @@ esac
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*|x86_64*)
 		build_options_default+=" jit"
-		if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+		if xbps_target_libc glibc; then
 			build_options_default+=" sampling_profiler"
 		elif [ "$build_option_sampling_profiler" ]; then
 			broken="sampling_profiler is only supported on glibc"

--- a/srcpkgs/widelands/template
+++ b/srcpkgs/widelands/template
@@ -20,7 +20,7 @@ checksum=601e0e4c6f91b3fb0ece2cd1b83ecfb02344a1b9194fbb70ef3f70e06994e357
 
 CXXFLAGS="-DU_USING_ICU_NAMESPACE=1"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" libexecinfo-devel gettext-devel"
 fi
 

--- a/srcpkgs/wmfs/template
+++ b/srcpkgs/wmfs/template
@@ -16,7 +16,7 @@ checksum=c28b7cec28a6e3f2bc38a136fb1773bab8ec8f48c69ebe25c24192f96e782d64
 
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2 -fcommon"
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/workrave/template
+++ b/srcpkgs/workrave/template
@@ -21,7 +21,7 @@ checksum=31a090b48c67c5a2ccb73fb56633f182fcc6d7aca5ec6376146671c72fda1444
 
 build_options="pulseaudio"
 
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
+if xbps_target_libc musl; then
 	makedepends+=" gettext-devel"
 	LDFLAGS="-lintl"
 fi

--- a/srcpkgs/xcb-util-xrm/template
+++ b/srcpkgs/xcb-util-xrm/template
@@ -12,7 +12,7 @@ homepage="https://github.com/Airblader/xcb-util-xrm"
 distfiles="https://github.com/Airblader/xcb-util-xrm/archive/v${version}.tar.gz"
 checksum=9d4a66c7366abb4840f6f822c613e1776c5898235358de728ba4554263fa0783
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-legacy-compat"
 fi
 

--- a/srcpkgs/yaz/template
+++ b/srcpkgs/yaz/template
@@ -15,10 +15,10 @@ homepage="https://www.indexdata.com/resources/software/yaz/"
 distfiles="http://ftp.indexdata.dk/pub/yaz/yaz-${version}.tar.gz"
 checksum=311bcb386d6327dfa22e0e442aea26d1be7c633eb664b9f70d982f072a130112
 
-case "$XBPS_TARGET_LIBC" in
-	musl) makedepends+=" libexecinfo-devel"
-		LDFLAGS+=" -lexecinfo" ;;
-esac
+if xbps_target_libc musl; then
+	makedepends+=" libexecinfo-devel"
+	LDFLAGS="-lexecinfo"
+fi
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/zeek/template
+++ b/srcpkgs/zeek/template
@@ -14,7 +14,7 @@ homepage="https://www.zeek.org"
 distfiles="https://old.zeek.org/downloads/zeek-${version}.tar.gz"
 checksum=af3ee5635140a54d305667983d38ea28f36457c9f2f8727e90ea3ef00b22c44f
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+if xbps_target_libc musl; then
 	makedepends+=" musl-fts-devel musl-legacy-compat"
 fi
 


### PR DESCRIPTION
- I just threw the functions in `shutils/common.sh`, they can certainly go elsewhere. They haven't undergone extensive testing at all.
- The packages with additional changes in the second commit (`xbps_target_libc`) should get their own commits.

Possible additions: `xbps_target_wordsize`, `xbps_host_target_wordsize_differ` (or something to that effect).