### PR TITLE
element-desktop: fix application icon grouping (StartupWMClass).

### DIFF
--- a/srcpkgs/element-desktop/files/element-desktop.desktop
+++ b/srcpkgs/element-desktop/files/element-desktop.desktop
@@ -5,6 +5,5 @@ Exec=element-desktop
 Terminal=false
 Type=Application
 Icon=element
-StartupWMClass="Element"
+StartupWMClass=element
 Categories=Network;InstantMessaging;Chat;IRCClient
-

--- a/srcpkgs/element-desktop/template
+++ b/srcpkgs/element-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'element-desktop'
 pkgname=element-desktop
 version=1.7.4
-revision=2
+revision=3
 wrksrc="element-web-${version}"
 conf_files="/etc/${pkgname}/config.json"
 hostmakedepends="git yarn nodejs rust cargo python sqlcipher-devel curl libappindicator-devel libnotify-devel pkg-config"


### PR DESCRIPTION
Small fix to the .desktop file to fix the WMClass so that Element appears properly on the taskbar. This appears to affect Gnome only. This changes the StartupWMClass to match that which is provided by the upstream code itself. Without this, you if you add Element to Gnome favorites (i.e. the taskbar), it will show up and then a second window will appear in the taskbar when you launch the application.