### PR TITLE
sndio: update to 1.7.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2176,7 +2176,7 @@ libKF5CddbWidgets.so.5 libkcddb-17.08.2_1
 libKF5Cddb.so.5 libkcddb-17.08.2_1
 libk3bdevice.so.7 k3b-17.08.2_1
 libk3blib.so.7 k3b-17.08.2_1
-libsndio.so.7.0 libsndio-1.4.0_1
+libsndio.so.7 libsndio-1.7.0_1
 libopenconnect.so.5 openconnect-7.05_1
 libusbredirparser.so.1 usbredir-0.7_1
 libusbredirhost.so.1 usbredir-0.7_1

--- a/srcpkgs/sndio/template
+++ b/srcpkgs/sndio/template
@@ -1,25 +1,42 @@
 # Template file for 'sndio'
 pkgname=sndio
-version=1.6.0
+version=1.7.0
 revision=1
 build_style=configure
-configure_args="--prefix=/usr"
+configure_args="--prefix=/usr --enable-alsa"
 makedepends="alsa-lib-devel"
 short_desc="Small audio and MIDI framework part of the OpenBSD project"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="archfan <ad-min@mailbox.org>"
 license="ISC"
+homepage="http://www.sndio.org/"
+distfiles="http://www.sndio.org/${pkgname}-${version}.tar.gz"
+checksum=dda4e3d0879423ed57923975ba74668cbb9299939cad579b0ac64a4b01535552
 system_accounts="sndiod"
 sndiod_descr="sndio daemon"
 sndiod_pgroup="audio"
-homepage="http://www.sndio.org/"
-distfiles="http://www.sndio.org/${pkgname}-${version}.tar.gz"
-checksum=99e0064ac11aceab24c73ed4630a31de401ff2f37689565b7b375682476f5bc1
+
+post_extract() {
+	# remove minor version from SONAME to avoid rebuilding
+	# packages, the minor version just added new symbols.
+	vsed -e '/-soname=/s/\.\\${MIN}//' -i configure
+}
 
 post_install() {
 	vsv sndiod
 	sed -n '/Copyright/,/PERFORMANCE/p' <sndiod/sndiod.c >LICENSE
 	vlicense LICENSE
+
+	# compatibility symlink, needed until the libsndio.so.7
+	# SONAME is used by everything.
+	ln -sf libsndio.so.7.1 libsndio.so.7.0
+	vcopy libsndio.so.7.0 usr/lib
+
+	# MAJOR SONAME to avoid rebuilds
+	ln -sf libsndio.so.7.1 libsndio.so.7
+	vcopy libsndio.so.7 usr/lib
+
 }
+
 
 libsndio_package() {
 	short_desc+=" -- library"


### PR DESCRIPTION
I've updated SNDIO to version 1.7.0 and enabled libbsd as it uses more recent libraries compared to bsd-compat/* from sndio. 

common/shlibs has been updated so a few packages have to be recompiled as well.


