### PR TITLE
xfce4-notifyd: update to 0.6.2.

### DIFF
--- a/srcpkgs/xfce4-notifyd/template
+++ b/srcpkgs/xfce4-notifyd/template
@@ -1,8 +1,9 @@
 # Template file for 'xfce4-notifyd'
 pkgname=xfce4-notifyd
-version=0.6.1
+version=0.6.2
 revision=1
 build_style=gnu-configure
+configure_args="--enable-dbus-start-daemon"
 hostmakedepends="pkg-config intltool glib-devel dbus-glib-devel"
 makedepends="libnotify-devel xfce4-panel-devel"
 depends="hicolor-icon-theme desktop-file-utils"
@@ -11,7 +12,7 @@ maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-2.0-or-later"
 homepage="https://goodies.xfce.org/projects/applications/xfce4-notifyd"
 distfiles="https://archive.xfce.org/src/apps/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=9b5274999c89bf296a7de03b375e8233eef37940b7444502130b92dfb6a089b4
+checksum=19ab84c6665c7819998f2269322d53f462c30963ce26042df23ae525e7d16545
 provides="notification-daemon-${version}_${revision}"
 replaces="notification-daemon>=0"
 


### PR DESCRIPTION
This update disabled autostart of xfce-notifyd via dbus by default, see: https://gitlab.xfce.org/apps/xfce4-notifyd/-/commit/e604b499353aae7759714dfe8c96b53f434a6f47

I think this is against POLA - if xfce4-notifyd is used outside of full XFCE, especially on wm's that don't honour XDG Autostart, people will wonder where their notification daemon has gone because it won't be started automatically anymore.

So i re-enabled dbus autostart via build options. Let me know if you think this is a bad idea.