### PR TITLE
PyInstaller: update to 4.0, fix bootstrap.

### DIFF
--- a/srcpkgs/PyInstaller/template
+++ b/srcpkgs/PyInstaller/template
@@ -1,14 +1,20 @@
 # Template file for 'PyInstaller'
 pkgname=PyInstaller
-version=3.6
+version=4.0
 revision=1
-archs=noarch
+wrksrc="pyinstaller-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
+makedepends="zlib-devel"
 depends="python3 python3-altgraph"
 short_desc="Bundles a Python application and dependencies into one package"
 maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="GPL-2.0-only"
 homepage="http://www.pyinstaller.org"
-distfiles="${PYPI_SITE}/P/PyInstaller/PyInstaller-${version}.tar.gz"
-checksum=3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7
+changelog="https://pyinstaller.readthedocs.io/en/v4.0/CHANGES.html"
+distfiles="https://github.com/pyinstaller/pyinstaller/releases/download/v${version}/pyinstaller-${version}.tar.gz"
+checksum=970beb07115761d5e4ec317c1351b712fd90ae7f23994db914c633281f99bab0
+
+post_extract() {
+	rm -rf PyInstaller/bootloader/*
+}


### PR DESCRIPTION
Updated to 4.0. 

The bootstrap binaries are coded in C and distributed pre-compiled
for x86_64 and i686. PyInstaller was noarch and using these bootstrap
binaries. This caused PyInstaller to essentially not work properly
for most packages on non-x86_64 and i686.

Recompile the bootstrap binaries and remove noarch.

Issue found in noarch rebuild.