### PR TITLE
ejabberd: update to 20.07

### DIFF
--- a/srcpkgs/ejabberd/template
+++ b/srcpkgs/ejabberd/template
@@ -1,7 +1,7 @@
 # Template file for 'ejabberd'
 pkgname=ejabberd
-version=20.02
-revision=2
+version=20.07
+revision=1
 build_style=gnu-configure
 configure_args="--enable-odbc --enable-mysql --enable-pgsql --enable-pam
  --enable-redis --enable-elixir $(vopt_enable sqlite)"
@@ -12,15 +12,13 @@ makedepends="libressl-devel libyaml-devel expat-devel zlib-devel pam-devel
 depends="erlang"
 short_desc="Robust and massively scalable XMPP platform"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://www.process-one.net/en/ejabberd/"
 distfiles="https://github.com/processone/ejabberd/archive/${version}.tar.gz"
-checksum=2e7f2fd0d137099de6d137794881200a70c2e4be7de8221fc6389b886fc16519
+checksum=7fd1142906a5f7d0345dc3d1363f94c62cc7d62088f5b2f3bd70dff4dca3bb41
 
 build_options="sqlite"
 build_options_default="sqlite"
-
-broken="Tries to link againt erl_interface-4.0, we only ship 3.13.2"
 
 if [ "$CROSS_BUILD" ]; then
 	makedepends+=" erlang"


### PR DESCRIPTION
We started shipping `erl_interface-4.0`, which means the package can be built (removing `broken`).

Tested on glibc x86_64 (two local [profanity](https://profanity-im.github.io/) clients sending messages to eachother).