### PR TITLE
New package: trident-automount-2020.09.02

### DIFF
--- a/srcpkgs/trident-automount/template
+++ b/srcpkgs/trident-automount/template
@@ -1,0 +1,22 @@
+# Template file for 'trident-automount'
+pkgname=trident-automount
+version=2020.09.02
+revision=1
+wrksrc="trident-utilities-${version}"
+build_wrksrc="src-go/automount"
+build_style=go
+go_import_path="github.com/project-trident/trident-automount"
+makedepends="go"
+depends="autofs"
+short_desc="Automounting daemon from Project Trident utilizing autofs"
+maintainer="Ken Moore <ken@project-trident.org>"
+license="BSD-2-Clause"
+homepage="https://github.com/project-trident/trident-utilities"
+distfiles="https://github.com/project-trident/trident-utilities/archive/v${version}.tar.gz"
+checksum=0bf0991c815b56b0143106e29ff2ab952416fd63d1810a6aa51fd95a0de4c48d
+
+post_install() {
+	vinstall sv/run 0755 /etc/sv/trident-automount
+	ln -s /run/runit/supervise.trident-automount $DESTDIR/etc/sv/trident-automount/supervise
+	vlicense ${wrksrc}/LICENSE
+}


### PR DESCRIPTION
This is a background service which monitors udev events for removable media and optical drives in order to create and maintain interaction shortcuts in the /media directory. This also configures and uses autofs for on-demand access to filesystems on removable devices.

Sponsored by: Project Trident