### PR TITLE
RFC: make vsv accept relative paths and target names

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -321,14 +321,18 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	`$DESTDIR`. The optional 2nd argument can be used to change the
 	`file name`. See [license](#var_license) for when to use it.
 
-- *vsv()* `vsv <service>`
+- *vsv()* `vsv <service> [target]`
 
-	Installs `service` from `${FILESDIR}` to /etc/sv. The service must
-	be a directory containing at least a run script. Note the `supervise`
-	symlink will be created automatically by `vsv` and that the run script
-	is automatically made executable by this function.
+	Installs `service` to `/etc/sv/target`. If `target` is not provided, the base
+	name of `service` will be used instead. The service must be a directory
+	containing at least a `run` script. If `service` contains a `/` character, it
+	is used as a source path without modification. Otherwise, `service` is
+	assumed to be a directory within `${FILESDIR}`. Note the `supervise` symlink
+	will be created automatically by `vsv` and that the run script is
+	automatically made executable by this function.
+
 	For further information on how to create a new service directory see
-	[The corresponding section the FAQ](http://smarden.org/runit/faq.html#create).
+	[the corresponding section the FAQ](http://smarden.org/runit/faq.html#create).
 
 - *vsed()* `vsed -i <file> -e <regex>`
 

--- a/srcpkgs/runit-swap/template
+++ b/srcpkgs/runit-swap/template
@@ -2,23 +2,19 @@
 pkgname=runit-swap
 version=2.0.0
 revision=1
+archs=noarch
 build_style=meta
 depends="runit bash util-linux>=2.26"
-hostmakedepends="git"
 short_desc="Script to manage swapspaces"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/thypon/runit-swap"
 conf_files="/etc/runit/swap.conf"
-archs=noarch
 distfiles="$homepage/archive/v$version.tar.gz"
 checksum=a66730777fb084564e7fae67f2017d775b757b6b6c0c319802f71bed2184e958
 
 do_install() {
 	vbin	runit-swap
+	vsv ./swap runit-swap
 	vinstall swap.conf 644 etc/runit
-
-	vinstall swap/run           755 etc/sv/runit-swap
-	vinstall swap/finish        755 etc/sv/runit-swap
-	ln -s /run/runit/supervise.runit-swap ${PKGDESTDIR}/etc/sv/runit-swap/supervise
 }

--- a/srcpkgs/trident-automount/template
+++ b/srcpkgs/trident-automount/template
@@ -16,7 +16,6 @@ distfiles="https://github.com/project-trident/trident-utilities/archive/v${versi
 checksum=0bf0991c815b56b0143106e29ff2ab952416fd63d1810a6aa51fd95a0de4c48d
 
 post_install() {
-	vinstall sv/run 0755 /etc/sv/trident-automount
-	ln -s /run/runit/supervise.trident-automount $DESTDIR/etc/sv/trident-automount/supervise
+	vsv ./sv trident-automount
 	vlicense ${wrksrc}/LICENSE
 }

--- a/srcpkgs/zramen/template
+++ b/srcpkgs/zramen/template
@@ -16,10 +16,5 @@ do_install() {
 	vbin zramen
 	vlicense UNLICENSE
 	vdoc README.md
-	vmkdir etc/sv
-	vcopy sv/zramen etc/sv
-	chmod 644 "${PKGDESTDIR}/etc/sv/zramen/conf"
-	chmod 755 "${PKGDESTDIR}/etc/sv/zramen/finish"
-	chmod 755 "${PKGDESTDIR}/etc/sv/zramen/run"
-	ln -s /run/runit/supervise.zramen "${PKGDESTDIR}/etc/sv/zramen/supervise"
+	vsv sv/zramen
 }


### PR DESCRIPTION
A few upstream packages include runit service directories, and installing them (if the installation process doesn't take care of it) requires manually building the service directory structure and copying files. This is what `vsv` does for services in `${FILESDIR}` in one shot.

The changes here allow specification of relative or absolute paths to services in the `$wrksrc` (anywhere, really), so constructs like `vsv ./my-svc` or `vsv ./path/to/my-svc` won't forcefully prepend `${FILESDIR}`. If there is no slash in the service path, `vsv` looks in `${FILESDIR}` like it always has. I don't see any templates that would be broken by this change, and the two changed here---`runit-swap` and `zramen`--- are slightly simplified with this change.

While I was at it, I also added an optional `target` argument, so upstream service directories can be renamed in one shot. `runit-swap` is a good example of this functionality, where the upstream `swap` service can be renamed to `runit-swap` in one pass with `vsv ./swap runit-swap`.