### PR TITLE
alsa-firmware: remove nocross, add ignore_elf_files

### DIFF
--- a/srcpkgs/alsa-firmware/template
+++ b/srcpkgs/alsa-firmware/template
@@ -1,8 +1,7 @@
 # Template file for 'alsa-firmware'
 pkgname=alsa-firmware
 version=1.2.1
-revision=1
-archs=noarch
+revision=2
 build_style=gnu-configure
 configure_args="--with-hotplug-dir=/usr/lib/firmware"
 short_desc="Advanced Linux Sound Architecture (ALSA) firmware"
@@ -11,8 +10,12 @@ license="GPL-2.0-only"
 homepage="http://www.alsa-project.org"
 distfiles="https://www.alsa-project.org/files/pub/firmware/${pkgname}-${version}.tar.bz2"
 checksum=aea27c571dbe02ede298cf9f637d8dfdb758e032e372c8d7e96ccb2b15fa08ab
-nocross=yes
 nostrip=yes
+ignore_elf_files="/usr/share/alsa/firmware/mixartloader/miXart8.elf"
+
+pre_configure() {
+	export CC="${BUILD_CC}" CFLAGS="${BUILD_CFLAGS}" LDFLAGS="${BUILD_LDFLAGS}"
+}
 
 post_install() {
 	# Removed to prevent any conflict with 'linux-firmware' package


### PR DESCRIPTION
alsa-firmware's only C files are internal generation utilities;
use the host cc to allow it to be cross.

There is an elf file that is required for one of the pieces of
firmware which needs to be located in /usr/share; add it to
ignore_elf_files.

This PR will be required for the nocross removal.