### PR TITLE
apache-jmeter: update to 5.3.

### DIFF
--- a/srcpkgs/apache-jmeter/template
+++ b/srcpkgs/apache-jmeter/template
@@ -1,43 +1,40 @@
 # Template file for 'apache-jmeter'
 pkgname=apache-jmeter
-version=5.1.1
-revision=2
-hostmakedepends="openjdk8 apache-ant"
+version=5.3
+revision=1
+hostmakedepends="openjdk8 gradle"
 depends="virtual?java-runtime"
 short_desc="Application to load test functional behavior and measure performance"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://jmeter.apache.org/"
-distfiles="http://apache.osuosl.org//jmeter/source/apache-jmeter-${version}_src.tgz"
-checksum=133fee3ccc300c759b5fbba4dd870db8e69aa0f72eca080fb37a8fb56c6caf6b
-broken="http://apache.osuosl.org//jmeter/source/apache-jmeter-5.1.1_src.tgz: Not Found"
-
-do_configure() {
-	ant download_jars
-}
+distfiles="http://apache.osuosl.org/jmeter/source/apache-jmeter-${version}_src.tgz"
+checksum=727d7c0cf2b72c0c3983c603a6700df7b797dbcbf19dcd7fa2aa457627324ff0
 
 do_build() {
-	ant install
+	# Tests fail -- they are too dependent on networking environment
+	gradle -PchecksumIgnore -x test createDist
 }
 
 do_install() {
-	rm -Rf src test build bin/testfiles
+	rm -rf build.gradle.kts buildSrc gradle* LICENSE licenses NOTICE \
+	 settings.gradle.kts *.md
 
-	vlicense LICENSE
-	vmkdir /usr/libexec/apache-jmeter
-	vcopy . /usr/libexec/apache-jmeter
+	vmkdir usr/share/doc/apache-jmeter
+	vcopy xdocs/* usr/share/doc/apache-jmeter
+	rm -rf xdocs
 
-	vmkdir /usr/bin
+	vmkdir usr/libexec/apache-jmeter
+	vcopy * usr/libexec/apache-jmeter
+
+	vmkdir usr/bin
 	ln -s /usr/libexec/apache-jmeter/bin/jmeter ${DESTDIR}/usr/bin/jmeter
 }
 
 apache-jmeter-doc_package() {
-	archs=noarch
 	short_desc+=" - documentation"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
-		vmove /usr/libexec/apache-jmeter/xdocs
-		vmove /usr/libexec/apache-jmeter/docs
-		vmove /usr/libexec/apache-jmeter/printable_docs
+		vmove usr/share/doc
 	}
 }


### PR DESCRIPTION
Upstream tarball no longer exists.

Move to supported gradle build.

Remove unnessecary files.

Required for noarch rebuild.