### PR TITLE
libpurple-skypeweb: update to 1.7

### DIFF
--- a/srcpkgs/libpurple-skypeweb/template
+++ b/srcpkgs/libpurple-skypeweb/template
@@ -1,15 +1,15 @@
 # Template file for 'libpurple-skypeweb'
 pkgname=libpurple-skypeweb
-version=1.5
+version=1.7
 revision=1
 wrksrc="skype4pidgin-${version}"
 build_wrksrc=skypeweb
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="libpurple-devel json-glib-devel"
-short_desc="A Skype plugin for libpurple - uses the Skype Web API"
+short_desc="Skype plugin for libpurple - uses the Skype Web API"
 maintainer="John Regan <john@jrjrtech.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/EionRobb/skype4pidgin"
 distfiles="https://github.com/EionRobb/skype4pidgin/archive/${version}.tar.gz"
-checksum=bb5fc550bff8f66f90a9ffacfc6bc2ed50fee86f4f500942aebc315d073f6e9d
+checksum=e504d4c4807a45aa6ab1c62509c2f31a97952bbf2f0501428fd32a885b2ad84e


### PR DESCRIPTION
Since August, the Skype login fails. Updating to version 1.7 fixes the issue.