### PR TITLE
crystal: update to 0.36.0

### DIFF
--- a/srcpkgs/crystal/template
+++ b/srcpkgs/crystal/template
@@ -1,11 +1,11 @@
 # Template file for 'crystal'
 pkgname=crystal
-version=0.34.0
-revision=2
+version=0.36.0
+revision=1
 archs="x86_64* i686* aarch64* arm*"
-_shardsversion=0.10.0
+_shardsversion=0.13.0
 _molinilloversion=0.1.0
-_bootstrapversion=0.34.0
+_bootstrapversion=0.36.0
 _bootstraprevision=1
 hostmakedepends="which tar git llvm10 pkg-config"
 makedepends="gc-devel libatomic_ops pcre-devel libevent-devel libyaml-devel
@@ -21,8 +21,8 @@ distfiles="
  https://github.com/crystal-lang/crystal/archive/${version}.tar.gz
  https://github.com/crystal-lang/shards/archive/v${_shardsversion}.tar.gz
  https://github.com/crystal-lang/crystal-molinillo/archive/v${_molinilloversion}.tar.gz"
-checksum="973293ffbcfa4fb073f6a2f833b0ce5b82b72f7899427f39d7e5610ffc9029c8
- 3aea420df959552d1866d473c878ab1ed0b58489c4c9881ef40a170cfb775459
+checksum="32ad927e78c4cc85e18136f70cfb9f1798edcc734de4d927b28f4de16c1456d3
+ 82a496aa450624afceab79bd9f7e6e1a43de41f61095512d08c3a3063c4da723
  1ecc7a8bf52a3bfdc0134d4c58f1155ef204a22a3fed151ac2d4ba6a9e9e0a15"
 nocross="FIXME: someone needs to sort out the llvm --cxxflags for cross building"
 _crystalflags="--release --no-debug --progress"
@@ -35,11 +35,11 @@ if [ "$build_option_binary_bootstrap" ]; then
 	case "$XBPS_MACHINE" in
 	x86_64)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-x86_64.tar.gz"
-		checksum+=" 268ace9073ad073b56c07ac10e3f29927423a8b170d91420b0ca393fb02acfb1"
+		checksum+=" 0d5eea55fd7e590a6afd2a6aecb1abf3b9caab2a8b1dea7d3cfdfe19714ed5c2"
 		;;
 	i686)
 		distfiles+=" https://github.com/crystal-lang/crystal/releases/download/${_bootstrapversion}/crystal-${_bootstrapversion}-${_bootstraprevision}-linux-i686.tar.gz"
-		checksum+=" e8962c91b6b739ac9738e03b24de907d64930d6129fbe54f9c81e0e029378006"
+		checksum+=" a87d7fc53ada13b3b0cb7ac41e57bb3eb73b140b6e143fc0966d964667bba0eb"
 		;;
 	*)
 		broken="cannot be built on $XBPS_MACHINE"


### PR DESCRIPTION
Tested locally on glibc x86_64 (`crystal` and `shards`).