### PR TITLE
OpenXcom: rebuild against yaml-cpp

### DIFF
--- a/srcpkgs/OpenXcom/template
+++ b/srcpkgs/OpenXcom/template
@@ -1,7 +1,7 @@
 # Template file for 'OpenXcom'
 pkgname=OpenXcom
 version=1.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-silent-rules --disable-werror"
 hostmakedepends="automake pkg-config xmlto"

--- a/srcpkgs/yaml-cpp/template
+++ b/srcpkgs/yaml-cpp/template
@@ -1,5 +1,7 @@
 # Template file for 'yaml-cpp'
 pkgname=yaml-cpp
+# yaml-cpp may break ABI even without changing the soname; when
+# updating, test dependants to determine if revbumps are needed
 version=0.6.3
 revision=1
 wrksrc="${pkgname}-${pkgname}-${version}"


### PR DESCRIPTION
Apparently yaml-cpp breaks ABI without bumping the soname.