### PR TITLE
apache-tomcat: update to 9.0.37.

### DIFF
--- a/srcpkgs/apache-tomcat/template
+++ b/srcpkgs/apache-tomcat/template
@@ -1,6 +1,6 @@
 # Template file for 'apache-tomcat'
 pkgname=apache-tomcat
-version=9.0.30
+version=9.0.37
 revision=1
 wrksrc="${pkgname}-${version}-src"
 hostmakedepends="openjdk8 apache-ant"
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://tomcat.apache.org"
 distfiles="http://mirrors.gigenet.com/apache/tomcat/tomcat-9/v${version}/src/${pkgname}-${version}-src.tar.gz"
-checksum=073bf0a56738d9bcb70c6065077495506b41dcea26731f0599c701efb90dc4ba
+checksum=1148357b8d38f571d2c69cc03341b6dabb3f70aad86e4dcd6c61deee751a936c
 
 system_accounts="tomcat"
 make_dirs="/usr/share/${pkgname}/webapps 0755 tomcat tomcat
@@ -28,7 +28,6 @@ post_build() {
 }
 
 do_install() {
-	vlicense LICENSE
 	mkdir -p ${DESTDIR}/usr/share/${pkgname}
 	cp -r output/build/* ${DESTDIR}/usr/share/${pkgname}
 
@@ -40,7 +39,6 @@ post_install() {
 }
 
 apache-tomcat-doc_package() {
-	archs=noarch
 	short_desc+=" - Documentation"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
@@ -49,7 +47,6 @@ apache-tomcat-doc_package() {
 }
 
 apache-tomcat-examples_package() {
-	archs=naorch
 	short_desc+=" - Examples"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
@@ -58,7 +55,6 @@ apache-tomcat-examples_package() {
 }
 
 apache-tomcat-manager_package() {
-	archs=noarch
 	short_desc+=" - Manager"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
@@ -67,7 +63,6 @@ apache-tomcat-manager_package() {
 }
 
 apache-tomcat-host-manager_package() {
-	archs=noarch
 	short_desc+=" - Host Manager"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {


### PR DESCRIPTION
Upstream tarball no longer exists for 9.0.30.

Required for noarch rebuild