### PR TITLE
boswars: move binary out of /usr/share.

### DIFF
--- a/srcpkgs/boswars/files/boswars
+++ b/srcpkgs/boswars/files/boswars
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/share/boswars/boswars -d /usr/share/boswars ${1+"$@"}
+exec /usr/libexec/boswars/boswars -d /usr/share/boswars ${1+"$@"}

--- a/srcpkgs/boswars/template
+++ b/srcpkgs/boswars/template
@@ -1,18 +1,18 @@
 # Template file for 'boswars'
 pkgname=boswars
 version=2.7
-revision=5
+revision=6
 wrksrc="${pkgname}-${version}-src"
 hostmakedepends="pkg-config libpng-progs python"
 makedepends="SDL-devel glu-devel libpng-devel libtheora-devel libvorbis-devel lua51-devel"
 depends="${pkgname}-data"
-short_desc="A futuristic real-time strategy game (RTS)"
+short_desc="Futuristic real-time strategy game (RTS)"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-2.0-or-later"
 homepage="http://boswars.org"
 distfiles="${homepage}/dist/releases/boswars-${version}-src.tar.gz"
 checksum=dc3718f531e9ea413cf37e1333b62a4c5e69f1405502d9c59b9e424635135e3e
-broken="fails lint (ELF in /usr/share)"
+python_version=2
 
 post_extract() {
 	#png bugfix for version 2.7, https://savannah.nongnu.org/bugs/?39610
@@ -37,8 +37,10 @@ do_build() {
 }
 
 do_install() {
+	vmkdir usr/libexec/boswars
+	vcopy fbuild/release/boswars usr/libexec/boswars/
+
 	vmkdir usr/share/boswars
-	vcopy fbuild/release/boswars usr/share/boswars/
 	vcopy campaigns usr/share/boswars/
 	vcopy doc usr/share/boswars/
 	vcopy graphics usr/share/boswars/
@@ -49,14 +51,15 @@ do_install() {
 	vcopy scripts usr/share/boswars/
 	vcopy sounds usr/share/boswars/
 	vcopy units usr/share/boswars/
+
 	vbin ${FILESDIR}/boswars
+
 	vinstall ${FILESDIR}/boswars.desktop 644 usr/share/applications/
 	vinstall ${FILESDIR}/boswars.png 644 usr/share/pixmaps/
 }
 
 boswars-data_package() {
 	short_desc+=" - data files"
-	archs=noarch
 	pkg_install() {
 		vmove usr/share/boswars/campaigns
 		vmove usr/share/boswars/doc


### PR DESCRIPTION
Fixes lint error. Has been tested.

Required for noarch rebuild.