### PR TITLE
haproxy: update to 2.2.2 and enable Prometheus support

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -27,6 +27,7 @@ do_build() {
 	make ${makejobs} CC="$CC" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" EXTRA= \
 		TARGET=$target USE_PCRE=1 USE_PCRE_JIT=1 USE_ZLIB=1 \
 		USE_OPENSSL=1 USE_LIBCRYPT=1 USE_GETADDRINFO=1 USE_LUA=1 \
+		EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o" \
 		ADDLIB="$atomic"
 }
 

--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.1.7
-revision=3
+version=2.2.2
+revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 makedepends="libatomic-devel libressl-devel lua53-devel pcre-devel"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
 distfiles="${homepage}/download/${version%.*}/src/${pkgname}-${version}.tar.gz"
-checksum=392e6cf18e75fe7e166102e8c4512942890a0b5ae738f6064faab4687f60a339
+checksum=391c705a46c6208a63a67ea842c6600146ca24618531570c89c7915b0c6a54d6
 
 haproxy_homedir="/var/lib/${pkgname}"
 make_dirs="$haproxy_homedir 0750 ${pkgname} ${pkgname}"


### PR DESCRIPTION
Update haproxy to 2.2.2 and enable Prometheus support to allow for configuring export of statistics.