### PR TITLE
eigen3.2: upstream moved, fixes, remove noarch.

### DIFF
--- a/srcpkgs/eigen3.2/template
+++ b/srcpkgs/eigen3.2/template
@@ -1,14 +1,13 @@
-# Template file for 'eigen'
+# Template file for 'eigen3.2'
 pkgname=eigen3.2
 version=3.2.10
-revision=2
-archs=noarch
-wrksrc="eigen-eigen-b9cd8366d4e8"
+revision=3
+wrksrc="eigen-${version}"
 build_style=cmake
 short_desc="C++ template library for linear algebra (version 3.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="MPL-2.0, GPL-3, LGPL-2.1"
+license="MPL-2.0"
 homepage="http://eigen.tuxfamily.org/"
-distfiles="http://bitbucket.org/eigen/eigen/get/${version}.tar.bz2"
-checksum=760e6656426fde71cc48586c971390816f456d30f0b5d7d4ad5274d8d2cb0a6d
+distfiles="https://gitlab.com/libeigen/eigen/-/archive/${version}/eigen-${version}.tar.bz2"
+checksum=1c982c9fa13422e885fcd82a140dbc6e5e6cd066deed38ba0b8051b70462e4d1
 conflicts="eigen>0"


### PR DESCRIPTION
- upstream has moved to gitlab
- fix some xlint warnings
- the only license is MPL
- remove noarch