### PR TITLE
New package: librtprocess-0.11.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3990,3 +3990,4 @@ libneatvnc.so.0 neatvnc-0.2.0_1
 libtdjson.so.1.6.0 libtd-1.6.0_1
 libJudy.so.1 judy-1.0.5_1
 libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2
+librtprocess.so.0 librtprocess-0.11.0_1

--- a/srcpkgs/librtprocess-devel
+++ b/srcpkgs/librtprocess-devel
@@ -1,0 +1,1 @@
+librtprocess

--- a/srcpkgs/librtprocess/template
+++ b/srcpkgs/librtprocess/template
@@ -1,0 +1,24 @@
+# Template file for 'librtprocess'
+pkgname=librtprocess
+version=0.11.0
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="libgomp-devel"
+short_desc="Image processing algorithms from RawTherapee"
+maintainer="Andreas Kempe <kempe@lysator.liu.se>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/CarVac/librtprocess"
+distfiles="https://github.com/CarVac/${pkgname}/archive/${version}.tar.gz"
+checksum=0a1691e6e90742644506a1123c716cdcfc28689adf461747843ab0440a837584
+
+librtprocess-devel_package() {
+	short_desc="Image processing algorithms from RawTherapee - development files"
+	depends="librtprocess>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/lib/librtprocess.so
+		vmove usr/include/rtprocess
+		vmove usr/lib/cmake/rtprocess
+		vmove usr/lib/pkgconfig/rtprocess.pc
+	}
+}


### PR DESCRIPTION
This package is a dependency for the Siril version bump found at https://github.com/void-linux/void-packages/pull/24678.