### PR TITLE
python3-google-api-python-client: update to 1.9.3.

### DIFF
--- a/srcpkgs/python3-cachetools/template
+++ b/srcpkgs/python3-cachetools/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-cachetools'
 pkgname=python3-cachetools
-version=4.1.0
+version=4.1.1
 revision=1
-archs=noarch
 wrksrc="cachetools-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +11,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="MIT"
 homepage="https://github.com/tkem/cachetools/"
 distfiles="${PYPI_SITE}/c/cachetools/cachetools-${version}.tar.gz"
-checksum=1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab
+checksum=bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-google-api-core/template
+++ b/srcpkgs/python3-google-api-core/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-google-api-core'
 pkgname=python3-google-api-core
-version=1.17.0
+version=1.22.2
 revision=1
-archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,7 +13,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/googleapis/python-api-core"
 distfiles="${PYPI_SITE}/g/google-api-core/google-api-core-${version}.tar.gz"
-checksum=e4082a0b479dc2dee2f8d7b80ea8b5d0184885b773caab15ab1836277a01d689
+checksum=779107f17e0fef8169c5239d56a8fbff03f9f72a3893c0c9e5842ec29dfedd54
 
 do_check() {
 	: all tests require grpc, which is optional dependencies.

--- a/srcpkgs/python3-google-api-python-client/template
+++ b/srcpkgs/python3-google-api-python-client/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-google-api-python-client'
 pkgname=python3-google-api-python-client
-version=1.8.4
+version=1.9.3
 revision=1
-archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,7 +13,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/googleapis/google-api-python-client"
 distfiles="${PYPI_SITE}/g/google-api-python-client/google-api-python-client-${version}.tar.gz"
-checksum=bbe212611fdc05364f3d20271cae53971bf4d485056e6c0d40748eddeeda9a19
+checksum=220349ce189a85229fc46875d467101318495a4a735c0ff2f165b9bdbc7511a0
 
 post_patch() {
 	# unittest2 is python2 thing.

--- a/srcpkgs/python3-google-auth-httplib2/template
+++ b/srcpkgs/python3-google-auth-httplib2/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-google-auth-httplib2'
 pkgname=python3-google-auth-httplib2
-version=0.0.3
-revision=4
-archs=noarch
+version=0.0.4
+revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-setuptools"
@@ -12,4 +11,4 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/GoogleCloudPlatform/google-auth-library-python3-httplib2"
 distfiles="${PYPI_SITE}/g/google-auth-httplib2/google-auth-httplib2-${version}.tar.gz"
-checksum=098fade613c25b4527b2c08fa42d11f3c2037dda8995d86de0745228e965d445
+checksum=8d092cc60fb16517b12057ec0bba9185a96e3b7169d86ae12eae98e645b7bc39

--- a/srcpkgs/python3-google-auth/template
+++ b/srcpkgs/python3-google-auth/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-google-auth'
 pkgname=python3-google-auth
-version=1.16.0
+version=1.21.1
 revision=1
-archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-setuptools"
@@ -12,4 +11,4 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/GoogleCloudPlatform/google-auth-library-python"
 distfiles="${PYPI_SITE}/g/google-auth/google-auth-${version}.tar.gz"
-checksum=1b3732b121917124adfe602de148ef5cba351792cf9527f99e6b61b84f74a7f5
+checksum=bcbd9f970e7144fe933908aa286d7a12c44b7deb6d78a76871f0377a29d09789

--- a/srcpkgs/python3-googleapis-common-protos/template
+++ b/srcpkgs/python3-googleapis-common-protos/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-googleapis-common-protos'
 pkgname=python3-googleapis-common-protos
-version=1.51.0
-revision=2
-archs=noarch
+version=1.52.0
+revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -13,7 +12,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/googleapis/googleapis"
 distfiles="${PYPI_SITE}/g/googleapis-common-protos/googleapis-common-protos-${version}.tar.gz"
-checksum=013c91704279119150e44ef770086fdbba158c1f978a6402167d47d5409e226e
+checksum=560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351
 
 post_install() {
 	chmod -R +r "${DESTDIR}/${py3_sitelib}"


### PR DESCRIPTION
Also update related packages and remove noarch.