### PR TITLE
pinebookpro-kernel: fix build w/ gcc10

### DIFF
--- a/srcpkgs/pinebookpro-kernel/patches/crypto_aegis_init_neon.patch
+++ b/srcpkgs/pinebookpro-kernel/patches/crypto_aegis_init_neon.patch
@@ -1,0 +1,33 @@
+--- a/crypto/aegis128-neon-inner.c	2020-09-05 19:09:33.377243984 +0200
++++ b/crypto/aegis128-neon-inner.c	2020-09-05 19:11:29.457249973 +0200
+@@ -131,23 +131,21 @@
+ 
+ void crypto_aegis128_init_neon(void *state, const void *key, const void *iv)
+ {
+-	static const uint8_t const0[] = {
++	static uint8_t const const0[] = {
+ 		0x00, 0x01, 0x01, 0x02, 0x03, 0x05, 0x08, 0x0d,
+ 		0x15, 0x22, 0x37, 0x59, 0x90, 0xe9, 0x79, 0x62,
+ 	};
+-	static const uint8_t const1[] = {
++	static uint8_t const const1[] = {
+ 		0xdb, 0x3d, 0x18, 0x55, 0x6d, 0xc2, 0x2f, 0xf1,
+ 		0x20, 0x11, 0x31, 0x42, 0x73, 0xb5, 0x28, 0xdd,
+ 	};
+ 	uint8x16_t k = vld1q_u8(key);
+ 	uint8x16_t kiv = k ^ vld1q_u8(iv);
+-	struct aegis128_state st = {{
+-		kiv,
+-		vld1q_u8(const1),
+-		vld1q_u8(const0),
+-		k ^ vld1q_u8(const0),
+-		k ^ vld1q_u8(const1),
+-	}};
++	uint8x16_t c0 = vld1q_u8(const0);
++	uint8x16_t c1 = vld1q_u8(const1);
++	uint8x16_t kc0 = k ^ c0;
++	uint8x16_t kc1 = k ^ c1;
++	struct aegis128_state st = { kiv, c1, c0, kc0, kc1 };
+ 	int i;
+ 
+ 	preload_sbox();


### PR DESCRIPTION
With gcc10 the patched piece of code does not compile when the XORs (^)
are done inside the initializer, so I added local variables for the
four initializers besides kiv.

The changes of `const uint8_t ...` to `uint8_t const ...` is just to match the [official docs for vld1q_u8()](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics?search=vld1q_u8)

[ci skip]