### PR TITLE
bind: include gss-api (required for new 'sssd')

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1052,11 +1052,11 @@ libtirpc.so.3 libtirpc-1.0.2_1
 librpcsecgss.so.3 librpcsecgss-0.19_1
 libnfsidmap.so.1 libnfsidmap-2.4.3_2
 libbind9.so.1600 bind-libs-9.16.2_1
-libdns.so.1605 bind-libs-9.16.5_1
+libdns.so.1607 bind-libs-9.16.7_1
 libirs.so.1601 bind-libs-9.16.3_1
 libisc.so.1606 bind-libs-9.16.6_1
 libisccc.so.1600 bind-libs-9.16.2_1
-libisccfg.so.1600 bind-libs-9.16.2_1
+libisccfg.so.1601 bind-libs-9.16.7_1
 libns.so.1604 bind-libs-9.16.5_1
 libplist.so.3 libplist-1.12_1
 libplist++.so.3 libplist++-1.12_1

--- a/srcpkgs/bind/template
+++ b/srcpkgs/bind/template
@@ -1,6 +1,6 @@
 # Template file for 'bind'
 pkgname=bind
-version=9.16.6
+version=9.16.7
 revision=1
 _fullver="${version}${_patchver:+-${_patchver}}"
 wrksrc="${pkgname}-${_fullver}"
@@ -8,13 +8,13 @@ build_style=gnu-configure
 configure_args="--disable-static --enable-threads --enable-largefile
  --with-libtool --enable-atomic --sysconfdir=/etc/named --enable-epoll
  --enable-ipv6 --with-randomdev=/dev/random --with-ecdsa=yes --with-eddsa=no
- --with-libtool --with-openssl=${XBPS_CROSS_BASE}/usr --without-gssapi
+ --with-libtool --with-openssl=${XBPS_CROSS_BASE}/usr --with-gssapi=/usr/bin
  --without-gost --enable-openssl-hash --with-readline --with-tuning=default
  --without-python --enable-fetchlimit --enable-sit
  --with-libidn2 $(vopt_enable seccomp)
  $(vopt_if geoip "--with-geoip=${XBPS_CROSS_BASE}/usr" "--without-geoip")"
 hostmakedepends="automake libtool perl pkg-config"
-makedepends="libressl-devel libxml2-devel libcap-devel readline-devel
+makedepends="libressl-devel libxml2-devel libcap-devel readline-devel mit-krb5-devel
  libatomic-devel libidn2-devel libuv-devel $(vopt_if geoip geoip-devel)
  $(vopt_if seccomp libseccomp-devel)"
 short_desc="Berkeley Internet Name Domain server"
@@ -23,7 +23,7 @@ license="MPL-2.0"
 homepage="https://www.isc.org/downloads/bind/"
 changelog="https://gitlab.isc.org/isc-projects/bind9/-/blob/v9_16/CHANGES"
 distfiles="https://ftp.isc.org/isc/bind9/${_fullver}/bind-${_fullver}.tar.xz"
-checksum=b567b0f3b47dd03b345a4848af7f2acdd3f5cea2bd804edd85d9ef50743571cb
+checksum=9f7d1812ebbd26a699f62b6fa8522d5dec57e4bf43af0042a0d60d39ed8314d1
 
 conf_files="/etc/named/named.conf"
 system_accounts="named"


### PR DESCRIPTION
Newer versions of `sssd` cannot be compiled without gss-api support in `bind`.