### PR TITLE
gtk+: add reminder to revbump gtk-layer-shell.

### DIFF
--- a/srcpkgs/gtk+3/template
+++ b/srcpkgs/gtk+3/template
@@ -1,4 +1,5 @@
 # Template file for 'gtk+3'
+# Revbump gtk-layer-shell when updating, otherwise it presents a warning message
 pkgname=gtk+3
 version=3.24.22
 revision=1


### PR DESCRIPTION
If gtk-layer-shell isn't revbumped, it has warning messages like:

  ** (waybar:449): WARNING **: 12:44:32.403: gtk-layer-shell was not
  compiled with support for GTK v3.24.22, program may crash