### PR TITLE
apparmor: update pulseaudio profile

### DIFF
--- a/srcpkgs/apparmor/files/profiles/usr.bin.pulseaudio
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.pulseaudio
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-/usr/bin/pulseaudio {
+profile pulseaudio /usr/bin/pulseaudio {
   #include <abstractions/base>
   #include <abstractions/audio>
   #include <abstractions/dbus-session>
@@ -23,6 +23,7 @@
 
   unix (connect, receive, send) type=stream peer=(addr="@/tmp/.ICE-unix/[0-9]*"),
   ptrace (read,trace) peer=@{profile_name},
+  signal (send) peer=pulseaudio//pulse-gsettings-helper,
 
   /usr/bin/pulseaudio mixr,
 
@@ -70,7 +71,7 @@
   /usr/share/applications/* r,
   /usr/share/pulseaudio/** r,
   /usr/lib/pulse-[1-9]*.[0-9]/modules/*.so mr,
-  /usr/lib/pulseaudio/pulse/gconf-helper Cx,
+  /usr/libexec/pulse/gsettings-helper Cx,
 
   owner /var/lib/gdm3/.config/pulse/ rw,
   owner /var/lib/gdm3/.config/pulse/* rw,
@@ -89,8 +90,7 @@
   /var/lib/pulse/*.tdb rw,
 
   owner @{PROC}/@{pid}/fd/ r,
-  owner @{PROC}/@{pid}/maps r,
-  owner @{PROC}/@{pid}/stat r,
+  owner @{PROC}/@{pid}/{maps,mountinfo,stat} r,
 
   owner /tmp/pulse-*/pid rwk,
   owner /tmp/pulse-*/native rwk,
@@ -105,10 +105,16 @@
   owner /tmp/.esd-@{pid}*/ rw,
   owner /tmp/.esd-@{pid}*/socket rw,
 
-  profile /usr/lib/pulseaudio/pulse/gconf-helper {
+  profile pulse-gsettings-helper /usr/libexec/pulse/gsettings-helper {
     #include <abstractions/base>
+    #include <abstractions/gnome>
+    #include <abstractions/dconf>
 
-    /usr/lib/pulseaudio/pulse/gconf-helper mr,
+    /usr/libexec/pulse/gsettings-helper mr,
+    owner /{,var/}run/user/*/dconf/user rw,
+    owner @{HOME}/.config/dconf/user rw,
+    owner @{PROC}/@{pid}/fd/ r,
+    signal (receive) peer=pulseaudio,
   }
 
   # Site-specific additions and overrides. See local/README for details.

--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.4
-revision=4
+revision=5
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure
@@ -26,7 +26,7 @@ fi
 post_patch() {
 	# Make.rules feeds some system headers to the C preprocessor to produce
 	# lists of capability and address-family names that, respectively,
-	# populate `parser/cap_names.h` and `parser/af_names.h`. The escaping
+	# populate 'parser/cap_names.h' and 'parser/af_names.h'. The escaping
 	# backslash in the '\#include" directives here is seen by the
 	# preprocessor, causing it to skip the system headers and produce empty
 	# files. Removing the backslash ensures correct behavior.


### PR DESCRIPTION
The pulseaudio profile was referring to the gconf helper, which has been
replaced with the gsettings-helper.