### PR TITLE
xbps-triggers:system-accounts: use grep to check for user/group existent

### DIFF
--- a/srcpkgs/xbps-triggers/files/system-accounts
+++ b/srcpkgs/xbps-triggers/files/system-accounts
@@ -19,6 +19,12 @@ export PATH="usr/sbin:usr/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 group_add() {
 	local _grname _gid use_gid
 
+	case "$1" in
+	*:*:*)	echo "Invalid system_groups specification"
+		exit 1
+		;;
+	esac
+
 	_grname="${1%:*}"
 	_gid="${1#*:}"
 
@@ -26,7 +32,7 @@ group_add() {
 		use_gid="gid ${_gid}"
 	fi
 
-	if ! getent group ${_grname} >/dev/null; then
+	if ! grep -q "^${_grname}:" etc/group >/dev/null; then
 		if [ -n "$use_gid" ]; then
 			groupadd -r ${_grname} -g ${_gid} >/dev/null 2>&1
 		else
@@ -59,9 +65,6 @@ run)
 	if [ -x sbin/groupadd -o -x bin/groupadd ]; then
 		GROUPADD=1
 	fi
-	if [ -x bin/getent -o -x sbin/getent ]; then
-		GETENT=1
-	fi
 	if [ -x bin/passwd -o -x sbin/passwd ]; then
 		PASSWD=1
 	fi
@@ -70,8 +73,8 @@ run)
 	post-install)
 		# System groups required by a package.
 		for grp in ${system_groups}; do
-			if [ -z "$GROUPADD" -a -z "$GETENT" ]; then
-				echo "WARNING: cannot create ${grp} system group (missing groupadd/getent)"
+			if [ -z "$GROUPADD" ]; then
+				echo "WARNING: cannot create ${grp} system group (missing groupadd)"
 				echo "The following group must be created manually: $grp"
 				continue
 			fi
@@ -80,6 +83,13 @@ run)
 
 		# System user/group required by a package.
 		for acct in ${system_accounts}; do
+
+			case "$acct" in
+			*:*:*)	echo "Invalid system_accounts specification"
+				exit 1
+				;;
+			esac
+
 			_uname="${acct%:*}"
 			_uid="${acct#*:}"
 
@@ -96,8 +106,8 @@ run)
 			[ "${_uid}" != "${_uname}" ] &&
 				use_id="-u ${_uid} -g ${pgroup:-${_uid}}"
 
-			if [ -z "$USERADD" -a -z "$GETENT" -a -z "$PASSWD" ]; then
-				echo "WARNING: cannot create ${acct} system user/group (missing useradd/getent/passwd)"
+			if [ -z "$USERADD" -a -z "$PASSWD" ]; then
+				echo "WARNING: cannot create ${acct} system user/group (missing useradd/passwd)"
 				echo "The following system account must be created:"
 				echo "   Account: ${uname:-${_uid}} (uid: '${_uid}')"
 				echo "   Description: '${descr}'"
@@ -109,7 +119,7 @@ run)
 
 			group_add ${pgroup:-${acct}}
 
-			if ! getent passwd ${_uname} >/dev/null; then
+			if ! grep -q "^${_uname}:" etc/passwd >/dev/null; then
 				useradd -c "$descr" -d "$homedir" -s "$shell" ${user_groups} \
 					${pgroup:+-N} ${use_id:=-g ${pgroup:-${_uname}}} -r ${_uname} && \
 					passwd -l ${_uname} >/dev/null 2>&1

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,8 +1,7 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
 version=0.116
-revision=1
-archs=noarch
+revision=2
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
In `system-accounts` triggers, we're using `getent(1)` to check whether
the username or group in question is existed before doing the heavy
lifting.

However, `getent(1)` will check the database in host system instead of our
rootfs, and by `PATH` manipulation logic, we prefer to use `usr/bin/getent`
inside our rootfs instead of host `getent(1)`.

This is usually not a problem since we mostly run `xbps-triggers` in
a real system instead of running from foreign system.

Except for `base-files` packages, which used to not have group `kvm`
pre-allocated. Thus, requires running this trigger, and lead to all sort
of problems:
- If host system is a musl-based linux system, with gcompat installed,
  and we're bootstrapping a glibc one, `getent(1)` will be executable,
  however, when `getent(1)` attempt to `dlopen(3)` other libraries,
  it'll run into failure.
- If host system doesn't have `kvm` group pre-allocated (bootstrapping
  from foreign distro), we attempt to run `groupadd(1)` on such system,
  thus failing with EPERM.

If we run into one of those cases, `xbps-reconfigure(1)` will stop
configuring `base-files`, not running `base-files`' `INSTALL` and leave
the system in half-baked state, without some requires files and
directories.

Switch to `grep(1)` to check for username and group existence,
since `passwd(5)` and `group(5)` is well-documented.