### PR TITLE
sof-firmware: fix symlinks

### DIFF
--- a/srcpkgs/sof-firmware/template
+++ b/srcpkgs/sof-firmware/template
@@ -1,7 +1,7 @@
 # Template file for 'sof-firmware'
 pkgname=sof-firmware
 version=1.5.1
-revision=1
+revision=2
 archs="i686* x86_64*"
 wrksrc=sof-bin-stable-v${version}
 short_desc="Sound Open Firmware and topology binaries"
@@ -22,12 +22,15 @@ do_install() {
 	for f in ${intel_path}/sof/v${version}/public-signed/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof/public-signed
 	done
-	for arc in {bdw,byt,cht,apl,cnl,icl}; do
+	for arc in {bdw,byt,cht}; do
 		ln -s sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
 	done
-	ln -s sof-apl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
-	ln -s sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
-	ln -s sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
+	for arc in {apl,cnl,icl}; do
+		ln -s intel-signed/sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
+	done
+	ln -s intel-signed/sof-apl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
+	ln -s intel-signed/sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
+	ln -s intel-signed/sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
 	for f in ${intel_path}/sof-tplg-v${version}/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof-tplg
 	done


### PR DESCRIPTION
Symlinks now point to .ri files in the intel-signed directory.