### PR TITLE
python-mistune: update to 2.0.0a5.

### DIFF
--- a/srcpkgs/python-mistune/template
+++ b/srcpkgs/python-mistune/template
@@ -1,28 +1,24 @@
 # Template file for 'python-mistune'
 pkgname=python-mistune
-version=0.8.4
-revision=2
-archs=noarch
+version=2.0.0a5
+revision=1
 wrksrc="mistune-${version}"
 build_style=python-module
-pycompile_module="mistune.py"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python"
-short_desc="The fastest markdown parser for Python2"
+short_desc="Markdown parser for Python"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://github.com/lepture/mistune"
 license="BSD-3-Clause"
-distfiles="${PYPI_SITE}/m/mistune/mistune-${version}.tar.gz"
-checksum=59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e
+homepage="https://github.com/lepture/mistune"
+distfiles="https://github.com/lepture/mistune/archive/v${version}.tar.gz"
+checksum=2ea34d73edeee177f37db0e64afd3be42f09f26a6baaf925912ba3e4dc546e59
 
 post_install() {
 	vlicense LICENSE
 }
 
 python3-mistune_package() {
-	archs=noarch
 	depends="python3"
-	pycompile_module="mistune.py"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*


### PR DESCRIPTION
Needed for packaging `md2gemini` (forthcoming). `md2gemini` needs a later version than 0.8.4, which is what's currently available on PyPi, so i'm using the latest release tagged in the `mistune` GH repo. `./xbps-src pkg` completes successfully. i've also fixed xlint errors, including changing the short_desc.

Finally, i've taken this opportunity to remove the `archs=noarch` lines.