### PR TITLE
New package: python3-md2gemini-1.6.0

### DIFF
--- a/srcpkgs/python3-md2gemini/template
+++ b/srcpkgs/python3-md2gemini/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-md2gemini'
+pkgname=python3-md2gemini
+version=1.6.0
+revision=1
+wrksrc="md2gemini-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-mistune"
+short_desc="Converter from Markdown to the Gemini text format"
+maintainer="Alexis <flexibeast@gmail.com>"
+license="LGPL-3.0-only"
+homepage="https://github.com/makeworld-the-better-one/md2gemini"
+distfiles="${PYPI_SITE}/m/md2gemini/md2gemini-${version}.tar.gz"
+checksum=7fa80b2aac5524c6513a261cb785f97003f31e4e1f3e76604fe4a18c675dfcff


### PR DESCRIPTION
Depends on #24798; using the template in that PR results in `./xbps-src pkg python3-md2gemini` completing successfully.

Distfile is fetched from GH, as i couldn't work out how to get the appropriate PyPi link ('appropriate' in the sense of "having the same URL format as in .e.g the `python3-ultrajson` template").