### PR TITLE
sndio: backport patch for sndioctl.

### DIFF
--- a/srcpkgs/sndio/patches/fflush.patch
+++ b/srcpkgs/sndio/patches/fflush.patch
@@ -1,0 +1,12 @@
+diff --git a/sndioctl/sndioctl.c b/sndioctl/sndioctl.c
+index 4c4a85a..71ae298 100644
+--- sndioctl/sndioctl.c
++++ sndioctl/sndioctl.c
+@@ -1014,6 +1014,7 @@ main(int argc, char **argv)
+                        perror("malloc");
+                        exit(1);
+                }
+                for (;;) {
++                       fflush(stdout);
+                        nfds = sioctl_pollfd(hdl, pfds, POLLIN);
+                        if (nfds == 0)

--- a/srcpkgs/sndio/template
+++ b/srcpkgs/sndio/template
@@ -1,7 +1,7 @@
 # Template file for 'sndio'
 pkgname=sndio
 version=1.7.0
-revision=2
+revision=3
 build_style=configure
 configure_args="--prefix=/usr"
 makedepends="alsa-lib-devel"


### PR DESCRIPTION
Fixes piped output.

@Duncaen 