### PR TITLE
castor: Rebuild to install icons and desktop file

### DIFF
--- a/srcpkgs/castor/template
+++ b/srcpkgs/castor/template
@@ -1,7 +1,7 @@
 # Template file for 'castor'
 pkgname=castor
 version=0.8.16
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="atk-devel pango-devel gdk-pixbuf-devel gtk+3-devel cairo-devel libressl-devel"
@@ -13,6 +13,6 @@ distfiles="https://git.sr.ht/~julienxx/castor/archive/${version}.tar.gz"
 checksum=50414f498c3b6232efb00e883043854517290b842e0501c1d1eccfaf78be9ae3
 
 post_install() {
-	make copy-data
+	make PREFIX="${PREFIX}" DESTDIR="${DESTDIR}" copy-data
 	vlicense LICENSE
 }


### PR DESCRIPTION
The current package in the repositories is missing all icons and the desktop file. They're present in a local build, so I'm revbumping to force a rebuild and confirm that the files are in the new package.