### PR TITLE
New package: zenpower-dkms-0.1.12

### DIFF
--- a/srcpkgs/zenpower3-dkms/template
+++ b/srcpkgs/zenpower3-dkms/template
@@ -1,0 +1,28 @@
+# Template file for 'zenpower3-dkms'
+pkgname=zenpower3-dkms
+_pkgname=${pkgname%-*}
+version=0.2.0
+revision=1
+archs="x86_64*"
+wrksrc="${_pkgname}-${version}"
+depends="dkms"
+short_desc="Linux kernel driver for reading sensors for AMD Zen family CPUs (DKMS)"
+maintainer="Anton Afanasyev <anton@doubleasoftware.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/Ta180m/zenpower3"
+distfiles="https://github.com/Ta180m/zenpower3/archive/v${version}.tar.gz"
+checksum=b206c1dfd8ea742a802126d012404d31ae62f2a23ae4723ea1c0f9f54581f6a3
+dkms_modules="${_pkgname} ${version}"
+
+do_install() {
+	vmkdir /usr/src/${_pkgname}-${version}
+	vcopy "./*" usr/src/${_pkgname}-${version}
+	vsed -i -e 's/@CFLGS@//' \
+		-e 's/@VERSION@/${version}-${revision}/' \
+		"${PKGDESTDIR}/usr/src/${_pkgname}-${version}/dkms.conf"
+
+	# modules-load.d(5) file.
+	vmkdir usr/lib/modules-load.d
+	echo "${_pkgname}" > ${DESTDIR}/usr/lib/modules-load.d/${_pkgname}.conf
+	chmod 644 ${DESTDIR}/usr/lib/modules-load.d/${_pkgname}.conf
+}


### PR DESCRIPTION
This adds a Linux kernel driver for reading sensors for AMD Zen family CPUs (as a DKMS module).
I did not write the code, merely the package template.

Verified on a [B550I AORUS PRO AX](https://www.gigabyte.com/Motherboard/B550I-AORUS-PRO-AX-rev-10) with a Ryzen 5 3600.

Without this module:
```zsh
% sensors
No sensors found!
Make sure you loaded all the kernel drivers you need.
Try sensors-detect to find out which these are.
```

With this module:
```zsh
% sensors
zenpower-pci-00c3
Adapter: PCI adapter
SVI2_Core:    +0.91 V
SVI2_SoC:     +1.09 V
Tdie:         +40.0°C  (high = +95.0°C)
Tctl:         +40.0°C
Tccd1:        +40.2°C
SVI2_P_Core:   5.45 W
SVI2_P_SoC:   11.91 W
SVI2_C_Core:  +5.27 A
SVI2_C_SoC:  +11.18 A
```