### PR TITLE
flite: revbump for alsa-libs compatibility

### DIFF
--- a/srcpkgs/flite/template
+++ b/srcpkgs/flite/template
@@ -1,7 +1,7 @@
 # Template file for 'flite'
 pkgname=flite
 version=2.1
-revision=1
+revision=2
 wrksrc="flite-${version}-release"
 build_style=gnu-configure
 configure_args="--enable-shared --with-audio=alsa"


### PR DESCRIPTION
I was seeing an undefined symbol (provided by alsa-libs) and a revbump
fixed it. Note this was on aarch64.