### PR TITLE
New package: jetbrains-mono-ttf-2.002

### DIFF
--- a/srcpkgs/jetbrains-mono-ttf/template
+++ b/srcpkgs/jetbrains-mono-ttf/template
@@ -1,0 +1,18 @@
+# Template file for 'jetbrains-mono-ttf'
+pkgname=jetbrains-mono-ttf
+version=2.002
+revision=1
+wrksrc="JetBrainsMono-${version}"
+depends="font-util"
+short_desc="Typeface made for developers. Monospace font created by JetBrains"
+maintainer="Wayne Van Son <waynevanson@gmail.com>"
+license="OFL-1.1"
+homepage="https://www.jetbrains.com/lp/mono/"
+distfiles="https://github.com/JetBrains/JetBrainsMono/archive/v${version}.tar.gz"
+checksum="e7cbd22401e2f08d46c3e13426f9238f7403500df9321d170e1681f4a07e9e7d"
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir /usr/share/fonts/TTF
+	find . -type f -name '*.ttf' -exec install -Dm644 '{}' ${DESTDIR}/usr/share/fonts/TTF \;
+}


### PR DESCRIPTION
I used `google-fonts-ttf` as a base template.

I built it on `x86_64`, `x86_64-musl`, `armv7l` and `aarm64`.