### PR TITLE
rpi-base: don't install snd_bcm2835.conf module file, move udev rules to separate file

### DIFF
--- a/srcpkgs/rpi-base/files/71-raspberrypi.rules
+++ b/srcpkgs/rpi-base/files/71-raspberrypi.rules
@@ -1,0 +1,4 @@
+# Fix permissions for the vchiq, vcio, vcsm devices.
+SUBSYSTEM=="vchiq", GROUP="video", MODE="0660"
+SUBSYSTEM=="bcm2708_vcio", GROUP="video", MODE="0660"
+SUBSYSTEM=="vc-sm", GROUP="video", MODE="0660"

--- a/srcpkgs/rpi-base/template
+++ b/srcpkgs/rpi-base/template
@@ -1,29 +1,14 @@
 # Template file for 'rpi-base'
 pkgname=rpi-base
-version=2.5
-revision=4
-homepage="http://www.voidlinux.org"
-short_desc="Void Linux RaspberryPi base files"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="Public Domain"
-
+version=2.6
+revision=1
 archs="armv6l* armv7l* aarch64*"
 depends="virtual?ntp-daemon rpi-firmware rpi-kernel"
+short_desc="Void Linux Raspberry Pi base files"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Public Domain"
+homepage="https://www.voidlinux.org"
 
 do_install() {
-	case "$XBPS_TARGET_MACHINE" in
-	armv6l*)
-		# Load the audio module by default on RPi.
-		vmkdir usr/lib/modules-load.d
-		echo snd-bcm2835 > ${DESTDIR}/usr/lib/modules-load.d/snd_bcm2835.conf
-		;;
-	esac
-	# Fix permissions for the vchiq, vcio, vcsm devices.
-	vmkdir usr/lib/udev/rules.d
-	echo 'SUBSYSTEM=="vchiq", GROUP="video", MODE="0660"' > \
-		${DESTDIR}/usr/lib/udev/rules.d/71-raspberrypi.rules
-	echo 'SUBSYSTEM=="bcm2708_vcio", GROUP="video", MODE="0660"' >> \
-		${DESTDIR}/usr/lib/udev/rules.d/71-raspberrypi.rules
-	echo 'SUBSYSTEM=="vc-sm", GROUP="video", MODE="0660"' >> \
-		${DESTDIR}/usr/lib/udev/rules.d/71-raspberrypi.rules
+	vinstall "${FILESDIR}/71-raspberrypi.rules" 644 usr/lib/udev/rules.d
 }

--- a/srcpkgs/rpi-firmware/files/config.txt
+++ b/srcpkgs/rpi-firmware/files/config.txt
@@ -81,3 +81,6 @@
 
 ## with fake kms
 #dtoverlay=vc4-fkms-v3d
+
+## Enable the BCM2835 audio driver
+#dtparam=audio=on

--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -4,7 +4,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
 version=20201123
-revision=3
+revision=4
 archs="armv6l* armv7l* aarch64*"
 wrksrc="firmware-${_githash}"
 provides="linux-firmware-broadcom-${version}_${revision}"


### PR DESCRIPTION
- Don't install the `snd_bcm2835.conf` module file. The current template only installs this file for `armv6l` (rpi 1, zero). RPi audio should instead be enabled via the device tree parameter `dtparam=audio=on` in `/boot/config.txt`. RPi audio is disabled by default.
- Move udev rules from template to `files/71-raspberrypi.rules` file.
- Fix xlint warnings.
- Add `dtparam=audio=on` to `rpi-frmware/files/config.txt`

Built for armv6l, armv7l, aarch64.
Tested on armv6l, armv7l.