### PR TITLE
DocBook-XSL: update to 1.79.2

### DIFF
--- a/srcpkgs/docbook-xsl-ns/patches/catalog-compat.patch
+++ b/srcpkgs/docbook-xsl-ns/patches/catalog-compat.patch
@@ -1,0 +1,22 @@
+From: Boyuan Yang <byang@debian.org>
+Date: Tue, 2 Jun 2020 22:11:52 -0400
+Subject: catalog.xml: Compatibility with 1.79.1 or earlier
+
+The docbook-xsl project changed the canonical URI since 1.79.2.
+Besides changes made in debian/*.xmlcatalogs files, this patch
+completes the support of the old URI so that existing software
+does not break with changed registered URI.
+
+Forwarded: not-needed
+Last-Update: 2020-06-02
+
+--- catalog.xml
++++ catalog.xml
+@@ -5,4 +5,7 @@
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl/current/" rewritePrefix="./"/>
+   <rewriteURI uriStartString="http://cdn.docbook.org/release/xsl/1.79.2/" rewritePrefix="./"/>
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl/1.79.2/" rewritePrefix="./"/>
++  <!-- Also support old URI of v1.79.1 or earlier -->
++  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl-ns/current/" rewritePrefix="./"/>
++  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl-ns/current/" rewritePrefix="./"/>
+ </catalog>

--- a/srcpkgs/docbook-xsl-ns/template
+++ b/srcpkgs/docbook-xsl-ns/template
@@ -1,16 +1,17 @@
 # Template file for 'docbook-xsl-ns'
 pkgname=docbook-xsl-ns
 # keep in sync with docbook-xsl
-version=1.79.1
+version=1.79.2
 revision=1
-archs=noarch
+# at v1.79.2, docbook-xsl-ns was renamed to just docbook-xsl
+wrksrc="docbook-xsl-${version}"
 depends="xmlcatmgr docbook-xml>=4.2"
 short_desc="Docbook XSL modular stylesheet"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
-homepage="http://docbook.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/docbook/${pkgname}-${version}.tar.bz2"
-checksum=36ca9026e05b8985baebd61a23af8ded8e2cf71cc3163b673159c9d78a7b0f9c
+homepage="https://docbook.org/"
+distfiles="https://github.com/docbook/xslt10-stylesheets/releases/download/release/${version}/${wrksrc}.tar.bz2"
+checksum=316524ea444e53208a2fb90eeb676af755da96e1417835ba5f5eb719c81fa371
 xml_entries="nextCatalog /usr/share/xsl-ns/docbook/catalog.xml --"
 
 do_install() {

--- a/srcpkgs/docbook-xsl/patches/0001_non-recursive_string_subst.patch
+++ b/srcpkgs/docbook-xsl/patches/0001_non-recursive_string_subst.patch
@@ -1,16 +1,20 @@
-Description: use EXSLT "replace" function when available
- A recursive implementation  of string.subst is problematic,
- long strings with many matches will cause stack overflows.
-Author: Peter De Wachter <pdewacht@gmail.com>
+From: Peter De Wachter <pdewacht@gmail.com>
+Date: Tue, 2 Jun 2020 09:10:39 -0400
+Subject: use EXSLT "replace" function when available
+
+A recursive implementation  of string.subst is problematic,
+long strings with many matches will cause stack overflows.
+
 Bug-Debian: https://bugs.debian.org/750593
 
 --- lib/lib.xsl
 +++ lib/lib.xsl
-@@ -10,7 +10,10 @@
+@@ -6,7 +6,11 @@
+ 
       This module implements DTD-independent functions
  
-      ******************************************************************** -->
--<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+-     ******************************************************************** --><xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
++     ******************************************************************** -->
 +<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 +                xmlns:str="http://exslt.org/strings"
 +                exclude-result-prefixes="str"
@@ -18,7 +22,7 @@ Bug-Debian: https://bugs.debian.org/750593
  
  <xsl:template name="dot.count">
    <!-- Returns the number of "." characters in a string -->
-@@ -56,6 +59,9 @@
+@@ -52,6 +56,9 @@
    <xsl:param name="replacement"/>
  
    <xsl:choose>

--- a/srcpkgs/docbook-xsl/patches/0002_docbook-xsl-mandir.patch
+++ b/srcpkgs/docbook-xsl/patches/0002_docbook-xsl-mandir.patch
@@ -1,0 +1,25 @@
+From: Michael Biebl <biebl@debian.org>
+Date: Wed, 7 Sep 2016 01:37:47 +0200
+Subject: Fix bad .so links in man pages
+
+Bug-Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=%23727251
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=831831
+
+--- manpages/other.xsl
++++ manpages/other.xsl
+@@ -558,7 +558,14 @@
+           <xsl:with-param name="message-prolog">Note: </xsl:with-param>
+           <xsl:with-param name="message-epilog"> (soelim stub)</xsl:with-param>
+           <xsl:with-param name="content">
+-            <xsl:value-of select="'.so '"/>
++            <xsl:choose>
++              <xsl:when test="$man.output.in.separate.dir = 0">
++              <xsl:value-of select="concat('.so man', $section, '/')"/>
++              </xsl:when>
++              <xsl:otherwise>
++              <xsl:value-of select="'.so '"/> <!-- added case -->
++              </xsl:otherwise>
++              </xsl:choose>
+             <xsl:variable name="full.filename">
+               <xsl:call-template name="make.adjusted.man.filename">
+                 <xsl:with-param name="name" select="$first.refname"/>

--- a/srcpkgs/docbook-xsl/patches/0003_catalog.xml-Compatibility-with-1.79.1-or-earlier.patch
+++ b/srcpkgs/docbook-xsl/patches/0003_catalog.xml-Compatibility-with-1.79.1-or-earlier.patch
@@ -1,0 +1,22 @@
+From: Boyuan Yang <byang@debian.org>
+Date: Tue, 2 Jun 2020 22:11:52 -0400
+Subject: catalog.xml: Compatibility with 1.79.1 or earlier
+
+The docbook-xsl project changed the canonical URI since 1.79.2.
+Besides changes made in debian/*.xmlcatalogs files, this patch
+completes the support of the old URI so that existing software
+does not break with changed registered URI.
+
+Forwarded: not-needed
+Last-Update: 2020-06-02
+
+--- catalog.xml
++++ catalog.xml
+@@ -5,4 +5,7 @@
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl-nons/current/" rewritePrefix="./"/>
+   <rewriteURI uriStartString="http://cdn.docbook.org/release/xsl-nons/1.79.2/" rewritePrefix="./"/>
+   <rewriteSystem systemIdStartString="http://cdn.docbook.org/release/xsl-nons/1.79.2/" rewritePrefix="./"/>
++  <!-- Also support old URI of v1.79.1 or earlier -->
++  <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
++  <rewriteSystem systemIdStartString="http://docbook.sourceforge.net/release/xsl/current/" rewritePrefix="./"/>
+ </catalog>

--- a/srcpkgs/docbook-xsl/template
+++ b/srcpkgs/docbook-xsl/template
@@ -1,17 +1,17 @@
 # Template file for 'docbook-xsl'
 pkgname=docbook-xsl
-reverts="1.79.2_1"
 # keep in sync with docbook-xsl-ns
-version=1.79.1
-revision=7
-archs=noarch
+version=1.79.2
+revision=2
+# at v1.79.2, docbook-xsl was renamed to docbook-xsl-nons
+wrksrc="${pkgname}-nons-${version}"
 depends="xmlcatmgr docbook-xml>=4.2"
 short_desc="Docbook XSL modular stylesheet"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
-homepage="http://docbook.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/docbook/${pkgname}-${version}.tar.bz2"
-checksum=725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968
+homepage="https://docbook.org/"
+distfiles="https://github.com/docbook/xslt10-stylesheets/releases/download/release/${version}/${wrksrc}.tar.bz2"
+checksum=ee8b9eca0b7a8f89075832a2da7534bce8c5478fc8fc2676f512d5d87d832102
 xml_entries="nextCatalog /usr/share/xsl/docbook/catalog.xml --"
 
 do_install() {


### PR DESCRIPTION
Updates the docbook-xsl packages (namespaced and non-namespaced) to 1.79.1.

Adds patches to maintain compatibility with the old sourceforge URIs (from Debian).

Adds another random Debian/Fedora patch, because it seemed sensible.

I adopted the non-namespaced package, since the two packages are meant to be updated in tandem and I maintain the namespaced package.

I tested building with one namespaced and one non-namespaced package (iputils and eudev). Further testing is advised, although we could always revert (again).