### PR TITLE
dhcpcd: make privsep a build option

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,10 +1,12 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
 version=9.2.0
-revision=1
+revision=2
 build_style=configure
 make_check_target=test
-configure_args="--prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --rundir=/run/dhcpcd --privsepuser=_dhcpcd"
+configure_args="
+ --prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --rundir=/run/dhcpcd
+ $(vopt_if privsep --privsepuser=_dhcpcd)"
 hostmakedepends="ntp pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="RFC2131 compliant DHCP client"
@@ -15,9 +17,12 @@ distfiles="https://roy.marples.name/downloads/dhcpcd/dhcpcd-${version}.tar.xz"
 checksum=fcb2d19672d445bbfd38678fdee4f556ef967a3ea6bd81092d10545df2cb9666
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
-# privsep
+
 system_accounts="_dhcpcd"
 _dhcpcd_homedir="/var/db/dhcpcd"
+
+build_options="privsep"
+build_options_default="privsep"
 
 post_install() {
 	vsv dhcpcd


### PR DESCRIPTION
Still forks away from the supervisor :/
But there is no huge process tree, just a launcher and master.