### PR TITLE
gotop: update to 4.0.1.

### DIFF
--- a/srcpkgs/gotop/template
+++ b/srcpkgs/gotop/template
@@ -1,16 +1,16 @@
 # Template file for 'gotop'
 pkgname=gotop
-version=3.0.0
+version=4.0.1
 revision=1
 build_style=go
-go_import_path=github.com/cjbassi/gotop
+go_import_path=github.com/xxxserxxx/gotop/cmd/gotop
 hostmakedepends="git"
 short_desc="Terminal based graphical activity monitor"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
-license="AGPL-3.0-or-later"
-homepage="https://github.com/cjbassi/gotop"
-distfiles="https://github.com/cjbassi/gotop/archive/${version}.tar.gz"
-checksum=d5147080bb6057f0bf0900b38438e89aa066959c845bdd4c84a9c9fe478b176f
+license="BSD-3-Clause"
+homepage="https://github.com/xxxserxxx/gotop"
+distfiles="https://github.com/xxxserxxx/gotop/archive/v${version}.tar.gz"
+checksum=38a34543ed828ed8cedd93049d9634c2e578390543d4068c19f0d0c20aaf7ba0
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Also, use a fork of the original project, which has been archived.