### PR TITLE
certbot: update to 1.8.0

### DIFF
--- a/srcpkgs/certbot/template
+++ b/srcpkgs/certbot/template
@@ -1,7 +1,7 @@
 # Template file for 'certbot'
 pkgname=certbot
-version=1.7.0
-revision=2
+version=1.8.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-acme python3-ConfigArgParse python3-configobj
@@ -15,7 +15,7 @@ maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot/certbot-${version}.tar.gz"
-checksum=10b95bb86fb8f1dbbd27558bb42454d5995cbdb45d6c00d961ebba2a4bdc4355
+checksum=4837c516af6543ccd10d70f1498a2113bbdf9ef9a05d3a18b1558b291a2953e4
 
 post_install() {
 	rm -rf ${DESTDIR}/${py3_sitelib}/certbot/tests

--- a/srcpkgs/python-cryptography/template
+++ b/srcpkgs/python-cryptography/template
@@ -1,7 +1,7 @@
 # Template file for 'python-cryptography'
 pkgname=python-cryptography
-version=2.8
-revision=3
+version=3.1
+revision=1
 wrksrc="cryptography-${version}"
 build_style=python-module
 hostmakedepends="python-setuptools python3-setuptools libressl-devel
@@ -21,7 +21,7 @@ license="BSD-3-Clause, Apache-2.0"
 homepage="https://github.com/pyca/cryptography"
 changelog="https://raw.githubusercontent.com/pyca/cryptography/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/c/cryptography/cryptography-${version}.tar.gz"
-checksum=3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651
+checksum=26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python-py/template
+++ b/srcpkgs/python-py/template
@@ -1,11 +1,9 @@
 # Template file for 'python-py'
 pkgname=python-py
-version=1.8.0
-revision=2
-archs=noarch
+version=1.9.0
+revision=1
 wrksrc="py-${version}"
 build_style=python-module
-pycompile_module="py"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python"
 checkdepends="python3-pytest"
@@ -15,7 +13,7 @@ license="MIT"
 homepage="https://github.com/pytest-dev/py"
 changelog="https://github.com/pytest-dev/py/raw/master/CHANGELOG"
 distfiles="${PYPI_SITE}/p/py/py-${version}.tar.gz"
-checksum=dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53
+checksum=9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342
 
 do_check() {
 	python3 -m pytest
@@ -26,9 +24,7 @@ post_install() {
 }
 
 python3-py_package() {
-	archs=noarch
 	depends="python3"
-	pycompile_module="py"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*

--- a/srcpkgs/python-pytz/template
+++ b/srcpkgs/python-pytz/template
@@ -1,11 +1,9 @@
 # Template file for 'python-pytz'
 pkgname=python-pytz
-version=2019.3
-revision=2
-archs=noarch
+version=2020.1
+revision=1
 wrksrc="pytz-${version}"
 build_style=python-module
-pycompile_module="pytz"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python tzdata"
 short_desc="Python2 timezone library"
@@ -13,7 +11,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="MIT"
 homepage="https://pythonhosted.org/pytz/"
 distfiles="${PYPI_SITE}/p/pytz/pytz-${version}.tar.gz"
-checksum=b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be
+checksum=c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048
 
 post_install() {
 	# use system tz database
@@ -25,9 +23,7 @@ post_install() {
 }
 
 python3-pytz_package() {
-	archs=noarch
 	depends="python3 tzdata"
-	pycompile_module="pytz"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*

--- a/srcpkgs/python-wcwidth/template
+++ b/srcpkgs/python-wcwidth/template
@@ -1,31 +1,27 @@
 # Template file for 'python-wcwidth'
 pkgname=python-wcwidth
-version=0.1.7
-revision=3
-archs=noarch
+version=0.2.5
+revision=1
 wrksrc="wcwidth-${version}"
 build_style=python-module
-pycompile_module="wcwidth"
 hostmakedepends="python-setuptools python3-setuptools"
 depends="python"
-short_desc="Measures number of terminal column cells of wide-character codes (Python2)"
+short_desc="Measures no. of terminal column cells of wide-character codes (Python2)"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
-homepage="https://github.com/jquast/wcwidth"
 license="MIT"
+homepage="https://github.com/jquast/wcwidth"
 distfiles="${PYPI_SITE}/w/wcwidth/wcwidth-${version}.tar.gz"
-checksum=3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e
+checksum=c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
 
 post_install() {
-	vlicense LICENSE.txt LICENSE
+	vlicense LICENSE
 }
 
 python3-wcwidth_package() {
-	archs=noarch
 	depends="python3"
-	pycompile_module="wcwidth"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*
-		vlicense LICENSE.txt LICENSE
+		vlicense LICENSE
 	}
 }

--- a/srcpkgs/python3-ConfigArgParse/template
+++ b/srcpkgs/python3-ConfigArgParse/template
@@ -1,11 +1,9 @@
 # Template file for 'python3-ConfigArgParse'
 pkgname=python3-ConfigArgParse
-version=1.1
+version=1.2.3
 revision=1
-archs=noarch
 wrksrc="ConfigArgParse-${version}"
 build_style=python3-module
-pycompile_module="configargparse.py"
 hostmakedepends="python3-setuptools"
 depends="python3"
 short_desc="Drop-in replacement for argparse"
@@ -13,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/bw2/ConfigArgParse"
 distfiles="${PYPI_SITE}/C/ConfigArgParse/ConfigArgParse-${version}.tar.gz"
-checksum=7971cdb14328baaada0f140832925de83ecee93ac5e67e587e3476fac283ad51
+checksum=edd17be986d5c1ba2e307150b8e5f5107aba125f3574dddd02c85d5cdcfd37dc
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-acme/template
+++ b/srcpkgs/python3-acme/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-acme'
 pkgname=python3-acme
-version=1.4.0
+version=1.8.0
 revision=1
-archs=noarch
 wrksrc="acme-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,4 +13,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/certbot/certbot"
 distfiles="${PYPI_SITE}/a/acme/acme-${version}.tar.gz"
-checksum=f12cb59762e0b833911b87e95cb16e85a162517ba4aa3440594bdf3b8126fc69
+checksum=ad8d067d14258d73ad2643439d9365913362308c04e66cc3010e39c868c5002d

--- a/srcpkgs/python3-josepy/template
+++ b/srcpkgs/python3-josepy/template
@@ -1,11 +1,9 @@
 # Template file for 'python3-josepy'
 pkgname=python3-josepy
-version=1.2.0
-revision=2
-archs=noarch
+version=1.4.0
+revision=1
 wrksrc="josepy-${version}"
 build_style=python3-module
-pycompile_module="josepy"
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography python3-openssl python3-setuptools python3-six"
 short_desc="JOSE protocol implementation in Python3"
@@ -13,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/certbot/josepy"
 distfiles="${PYPI_SITE}/j/josepy/josepy-${version}.tar.gz"
-checksum=9cec9a839fe9520f0420e4f38e7219525daccce4813296627436fe444cd002d3
+checksum=c37ff4b93606e6a452b72cdb992da5e0544be12912fac01b31ddbdd61f6d5bd0

--- a/srcpkgs/python3-more-itertools/template
+++ b/srcpkgs/python3-more-itertools/template
@@ -1,11 +1,9 @@
 # Template file for 'python3-more-itertools'
 pkgname=python3-more-itertools
-version=8.0.2
+version=8.5.0
 revision=1
-archs=noarch
 wrksrc="more-itertools-${version}"
 build_style=python3-module
-pycompile_module="more_itertools"
 hostmakedepends="python3-setuptools"
 depends="python3"
 short_desc="More Python3 routines for operating on itertables"
@@ -13,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/erikrose/more-itertools"
 distfiles="${PYPI_SITE}/m/more-itertools/more-itertools-${version}.tar.gz"
-checksum=b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d
+checksum=6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20
 
 do_check() {
 	python3 setup.py test

--- a/srcpkgs/python3-pytest/template
+++ b/srcpkgs/python3-pytest/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-pytest'
 pkgname=python3-pytest
-version=5.3.5
-revision=2
-archs=noarch
+version=6.0.2
+revision=1
 wrksrc="pytest-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -16,15 +15,12 @@ license="MIT"
 homepage="https://docs.pytest.org/en/latest/"
 changelog="https://docs.pytest.org/en/latest/changelog.html"
 distfiles="${PYPI_SITE}/p/pytest/pytest-${version}.tar.gz"
-checksum=0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d
+checksum=c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043
 alternatives="
  pytest:pytest:/usr/bin/pytest3
  pytest:py.test:/usr/bin/py.test3"
 
 post_patch() {
-	vsed -i setup.py \
-		-e '/setup_requires=/d' \
-		-e "s|use_scm_version=.*|version=\"${version}\",|"
 	# This test depends on tox, and/or egg-info
 	# merely check pytest and py.test were generated
 	rm testing/test_entry_points.py

--- a/srcpkgs/python3-zope.component/template
+++ b/srcpkgs/python3-zope.component/template
@@ -1,8 +1,7 @@
 # Template file for 'python3-zope.component'
 pkgname=python3-zope.component
-version=4.6.1
+version=4.6.2
 revision=1
-archs=noarch
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -13,7 +12,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="ZPL-2.1"
 homepage="https://www.zope.org"
 distfiles="${PYPI_SITE}/z/zope.component/zope.component-${version}.tar.gz"
-checksum=d9c7c27673d787faff8a83797ce34d6ebcae26a370e25bddb465ac2182766aca
+checksum=91628918218b3e6f6323de2a7b845e09ddc5cae131c034896c051b084bba3c92
 
 post_install() {
 	vlicense LICENSE.txt LICENSE


### PR DESCRIPTION
Current repo version is throwing an error because `python3-acme` is outdated. Plus many of the depends and checkdepends are outdated. Here's the log of another branch where I have updated all the dependencies:

```
df54cd33b2 (HEAD -> certbot-update) certbot: update to 1.8.0.
cfb41adfa5 python-cryptography: update to 3.1.
79993213e6 python-py: update to 1.9.0.
29779518c0 python-pytz: update to 2020.1.
a5ac7eb1b0 python-wcwidth: update to 0.2.5.
ab1783ad6b python3-ConfigArgParse: update to 1.2.3.
ad5b0d0c02 python3-acme: update to 1.8.0.
2292941c56 python3-josepy: update to 1.4.0.
69c9e936f5 python3-more-itertools: update to 8.5.0.
919c095e6c python3-pytest: update to 6.0.2.
361ee4a60f python3-zope.component: update to 4.6.2.
```

If filing a PR is advisable for these then let me know (and if I should do them together or separately). For now, this PR fixes the `certbot` error at lease.