### PR TITLE
qemu: install data files into the default directory

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,7 +1,7 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=5.1.0
-revision=2
+revision=3
 short_desc="Open Source Processor Emulator"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
@@ -23,6 +23,7 @@ makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
  $(vopt_if opengl 'libepoxy-devel libdrm-devel MesaLib-devel')
  $(vopt_if iscsi 'libiscsi-devel')
  $(vopt_if smartcard libcacard-devel) $(vopt_if numa 'libnuma-devel')"
+ignore_elf_dirs="/usr/share/qemu"
 
 build_options="gtk3 opengl sdl2 spice virgl smartcard numa iscsi"
 build_options_default="opengl gtk3 virgl smartcard sdl2 numa iscsi"
@@ -63,7 +64,7 @@ do_configure() {
 		--disable-xen --enable-tpm \
 		--enable-vhost-net --enable-vnc-png --enable-virtfs \
 		--enable-libusb --disable-glusterfs --enable-snappy --enable-usb-redir \
-		--enable-pie --localstatedir=/var --datadir=/usr/lib --enable-docs \
+		--enable-pie --localstatedir=/var --enable-docs \
 		$(vopt_enable virgl virglrenderer) $(vopt_enable opengl) $(vopt_enable spice) \
 		${want_sdl} \
 		$(vopt_enable smartcard) \


### PR DESCRIPTION
ignore foreign-arch elf files in /usr/share
fixes #23495
[skip ci]