### PR TITLE
pass: add xclip as a dependency.

### DIFF
--- a/srcpkgs/pass/template
+++ b/srcpkgs/pass/template
@@ -1,12 +1,11 @@
 # Template file for 'pass'
 pkgname=pass
 version=1.7.3
-revision=3
-archs=noarch
+revision=4
 wrksrc="password-store-${version}"
 build_style=gnu-makefile
 make_install_args="WITH_BASHCOMP=yes WITH_ZSHCOMP=yes WITH_FISHCOMP=yes"
-depends="bash gnupg2 tree which"
+depends="bash gnupg2 tree which xclip"
 checkdepends="gnupg2 tree which git"
 short_desc="Stores, retrieves, generates, and synchronizes passwords securely"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
This is required for proper operation of the -c function.

xclip dosen't pull in X along with it, so I believe this is OK
since it is a rather small package. Happy to not merge this though.

Also remove noarch.