### PR TITLE
dovecot: fix size of time_t for 64-bit cross.

### DIFF
--- a/srcpkgs/dovecot-plugin-pigeonhole/template
+++ b/srcpkgs/dovecot-plugin-pigeonhole/template
@@ -1,7 +1,7 @@
 # Template file for 'dovecot-plugin-pigeonhole'
 pkgname=dovecot-plugin-pigeonhole
 version=0.5.11
-revision=1
+revision=2
 wrksrc="dovecot-2.3-pigeonhole-${version}"
 build_style=gnu-configure
 configure_args="--prefix=/usr

--- a/srcpkgs/dovecot/template
+++ b/srcpkgs/dovecot/template
@@ -2,7 +2,7 @@
 # revbump dovecot-plugin-pigeonhole when updating dovecot!
 pkgname=dovecot
 version=2.3.11.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-moduledir=/usr/lib/dovecot/modules --with-sql=plugin
  --disable-static --with-pam --with-mysql --with-pgsql --with-lucene
@@ -22,14 +22,16 @@ distfiles="${homepage}/releases/2.3/${pkgname}-${version}.tar.gz"
 checksum=d3d9ea9010277f57eb5b9f4166a5d2ba539b172bd6d5a2b2529a6db524baafdc
 keep_libtool_archives=yes
 
-
 if [ "$CROSS_BUILD" ]; then
+	_tsize=${XBPS_TARGET_WORDSIZE}
+	# FIXME: remove for time64 rebuild
+	#[ "$XBPS_TARGET_LIBC" = "musl" ] && _tsize=64
 	configure_args+="
 		i_cv_epoll_works=yes
 		i_cv_inotify_works=yes
 		i_cv_posix_fallocate_works=yes
 		i_cv_signed_size_t=no
-		i_cv_gmtime_max_time_t=32
+		i_cv_gmtime_max_time_t=${_tsize}
 		i_cv_signed_time_t=yes
 		i_cv_mmap_plays_with_write=yes
 		i_cv_fd_passing=yes


### PR DESCRIPTION
configure_args hard coded the size of the time_t type, which means
64-bit cross compiled archs, such as aarch64, were using the wrong type.
For little-endian, it would just break 2038-proofness, but BE machines
could have bigger issues.

A comment and commented out code were added to prepare for musl's time64
update.