### PR TITLE
pinephone-kernel: update to 5.8.10.

### DIFF
--- a/srcpkgs/pinephone-kernel/files/config
+++ b/srcpkgs/pinephone-kernel/files/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.8.8 Kernel Configuration
+# Linux/arm64 5.8.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GCC) 9.3.0"
 CONFIG_CC_IS_GCC=y

--- a/srcpkgs/pinephone-kernel/template
+++ b/srcpkgs/pinephone-kernel/template
@@ -1,15 +1,15 @@
 # Template file for 'pinephone-kernel'
 pkgname=pinephone-kernel
-version=5.8.8
+version=5.8.10
 revision=1
-_commit=15c4dacda97d07b0d5c0cdd22d84c0a9552c376a
+_commit=b8647e317c32f64543c32465abb7b4651e6e3199
 wrksrc="linux-${_commit}"
 short_desc="Linux kernel and modules (${version%.*} series)"
 maintainer="John Sullivan <jsullivan@csumb.edu>"
 license="GPL-2.0-only"
 homepage="https://www.kernel.org"
 distfiles="https://github.com/megous/linux/archive/${_commit}.tar.gz"
-checksum=a5db03734af4d0c72c768396c69c4cb4c539d2a4733fc7f7cbfc8b2254e23e3a
+checksum=65c154fde37f38334ccd2038765954536f78a504ef4460a3021cb8e33f64de6a
 python_version=3
 patch_args="-Np1"
 


### PR DESCRIPTION
Merge mainline patch 5.8.10 (even-out with linux5.8 package)