### PR TITLE
brotli: add backport patch to address issue google/brotli#836

### DIFF
--- a/srcpkgs/brotli/patches/Revert-Add-runtime-linker-path-to-pkg-config-files.patch
+++ b/srcpkgs/brotli/patches/Revert-Add-runtime-linker-path-to-pkg-config-files.patch
@@ -1,0 +1,47 @@
+From 092446fafb4bfb81738853b7c7f76b293cd92a80 Mon Sep 17 00:00:00 2001
+From: Evgenii Kliuchnikov <eustas.ru@gmail.com>
+Date: Wed, 2 Sep 2020 10:49:49 +0200
+Subject: [PATCH] Revert "Add runtime linker path to pkg-config files (#740)"
+
+This reverts commit 31754d4ffce14153b5c2addf7a11019ec23f51c1.
+---
+ scripts/libbrotlicommon.pc.in | 2 +-
+ scripts/libbrotlidec.pc.in    | 2 +-
+ scripts/libbrotlienc.pc.in    | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/libbrotlicommon.pc.in b/scripts/libbrotlicommon.pc.in
+index 10ca969e..2a8cf7a3 100644
+--- a/scripts/libbrotlicommon.pc.in
++++ b/scripts/libbrotlicommon.pc.in
+@@ -7,5 +7,5 @@ Name: libbrotlicommon
+ URL: https://github.com/google/brotli
+ Description: Brotli common dictionary library
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -R${libdir} -lbrotlicommon
++Libs: -L${libdir} -lbrotlicommon
+ Cflags: -I${includedir}
+diff --git a/scripts/libbrotlidec.pc.in b/scripts/libbrotlidec.pc.in
+index e7c3124f..6f8ef2e4 100644
+--- a/scripts/libbrotlidec.pc.in
++++ b/scripts/libbrotlidec.pc.in
+@@ -7,6 +7,6 @@ Name: libbrotlidec
+ URL: https://github.com/google/brotli
+ Description: Brotli decoder library
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -R${libdir} -lbrotlidec
++Libs: -L${libdir} -lbrotlidec
+ Requires.private: libbrotlicommon >= 1.0.2
+ Cflags: -I${includedir}
+diff --git a/scripts/libbrotlienc.pc.in b/scripts/libbrotlienc.pc.in
+index 4dd0811b..2098afe2 100644
+--- a/scripts/libbrotlienc.pc.in
++++ b/scripts/libbrotlienc.pc.in
+@@ -7,6 +7,6 @@ Name: libbrotlienc
+ URL: https://github.com/google/brotli
+ Description: Brotli encoder library
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -R${libdir} -lbrotlienc
++Libs: -L${libdir} -lbrotlienc
+ Requires.private: libbrotlicommon >= 1.0.2
+ Cflags: -I${includedir}

--- a/srcpkgs/brotli/template
+++ b/srcpkgs/brotli/template
@@ -1,7 +1,7 @@
 # Template file for 'brotli'
 pkgname=brotli
 version=1.0.9
-revision=1
+revision=2
 build_style=cmake
 short_desc="Generic-purpose lossless compression algorithm"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -9,6 +9,7 @@ license="MIT"
 homepage="https://github.com/google/brotli"
 distfiles="https://github.com/google/${pkgname}/archive/v${version}.tar.gz"
 checksum=f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46
+patch_args="-p1"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
`brotli` has a fairly bad regression, breaking builds that depend on `brotli` and `pkg-config` (for example `libsoup` as I mentioned in #24260).

There's already a fix on master, which is where this patch came from, so this patch can be discarded whenever `brotli` does their next release.