### PR TITLE
python3-pure-protobuf: update to 2.0.1.

### DIFF
--- a/srcpkgs/python3-pure-protobuf/template
+++ b/srcpkgs/python3-pure-protobuf/template
@@ -1,21 +1,24 @@
 # Template file for 'python3-pure-protobuf'
 pkgname=python3-pure-protobuf
-version=2.0.0
-revision=2
-archs=noarch
+version=2.0.1
+revision=1
 wrksrc=protobuf-${version}
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
+checkdepends="python3-pytest"
 short_desc="Python implementation of Protocol Buffers data types"
 maintainer="Lorem <notloremipsum@protonmail.com>"
 license="MIT"
 homepage="https://github.com/eigenein/protobuf"
 changelog="https://github.com/eigenein/protobuf/blob/master/CHANGELOG.md"
 distfiles="https://github.com/eigenein/protobuf/archive/${version}.tar.gz"
-checksum=e1303e8ae29ce5e33254d49f93d896d04b040070f89e87232e33ecdfbb4ea6d9
+checksum=30fd2ccb075f00e5f24bbeee8434ff3edd8ebf7a02e3a8c665044fe196e4112d
+
+do_check() {
+	python3 -m pytest
+}
 
 post_install() {
-	rm -r ${DESTDIR}/${py3_sitelib}/tests
 	vlicense LICENSE
 }


### PR DESCRIPTION
Relevant changelog:

> exclude every test package when installing