### PR TITLE
upmpdcli: rebuild against libupnpp-0.19.4

### DIFF
--- a/srcpkgs/upmpdcli/template
+++ b/srcpkgs/upmpdcli/template
@@ -1,7 +1,7 @@
 # Template file for 'upmpdcli'
 pkgname=upmpdcli
 version=1.4.14
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config tar"
 makedepends="jsoncpp-devel libmicrohttpd-devel libmpdclient-devel libupnpp-devel"


### PR DESCRIPTION
libupnpp-0.19.4 SONAME didn't change but broke upmpdcli: `undefined symbol: _ZNK5UPnPP7LibUPnP12getInitErrorEv`