### PR TITLE
snapcast: fix man page and conf file installation

### DIFF
--- a/srcpkgs/snapcast/template
+++ b/srcpkgs/snapcast/template
@@ -1,9 +1,10 @@
 # Template file for 'snapcast'
 pkgname=snapcast
 version=0.21.0
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DBUILD_WITH_TREMOR=OFF -DBUILD_WITH_AVAHI=$(vopt_if avahi ON OFF)"
+configure_args="-DBUILD_WITH_TREMOR=OFF -DBUILD_WITH_AVAHI=$(vopt_if avahi ON OFF)
+ -DCMAKE_INSTALL_SYSCONFDIR=/etc"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel boost-devel expat-devel libflac-devel libsoxr-devel
  libvorbis-devel opus-devel $(vopt_if avahi avahi-libs-devel)"
@@ -34,8 +35,8 @@ snapclient_package() {
 	make_dirs="/var/lib/snapclient 0750 _snapclient _snapclient"
 
 	pkg_install() {
-		vmove /usr/bin/snapclient
-		vman client/snapclient.1
+		vmove usr/bin/snapclient
+		vmove usr/share/man/man1/snapclient.1
 		vsv snapclient
 	}
 }
@@ -50,9 +51,10 @@ snapserver_package() {
 	conf_files="/etc/snapserver.conf"
 
 	pkg_install() {
-		vmove /usr/bin/snapserver
-		vman server/snapserver.1
-		vconf server/etc/snapserver.conf
+		vmove usr/bin/snapserver
+		vmove usr/share/man/man1/snapserver.1
+		vmove usr/share/snapserver/snapweb
+		vmove etc/snapserver.conf
 		vsv snapserver
 	}
 }


### PR DESCRIPTION
Snapcast 0.21.0 added install targets for the man pages. This causes a file collision of the base and sub packages man pages.
```
# xbps-install snapserver
...
ERROR: snapserver-0.21.0_1: file `/usr/share/man/man1/snapserver.1' already installed by package snapcast-0.21.0_1.
Transaction failed! see above for errors.

# xbps-install snapclient
...
ERROR: snapclient-0.21.0_1: file `/usr/share/man/man1/snapclient.1' already installed by package snapcast-0.21.0_1.
Transaction failed! see above for errors.
```
An install target was also added for the conf file which results in it being installed by the base `snapcast` package in `/usr/etc/snapserver.conf`.