### PR TITLE
New package: bazel-3.5.0

### DIFF
--- a/srcpkgs/bazel/template
+++ b/srcpkgs/bazel/template
@@ -1,0 +1,23 @@
+# Template file for 'bazel'
+pkgname=bazel
+version=3.5.0
+revision=1
+archs="~*-musl"
+create_wrksrc="yes"
+hostmakedepends="gcc openjdk11 unzip which zip"
+makedepends="python3-devel"
+short_desc="Fast, scalable, multi-language and extensible build system"
+maintainer="Wayne Van Son <waynevanson@gmail.com>"
+license="Apache-2.0"
+homepage="https://www.bazel.build/"
+distfiles="https://github.com/bazelbuild/bazel/releases/download/${version}/bazel-${version}-dist.zip"
+checksum=334429059cf82e222ca8a9d9dbbd26f8e1eb308613463c2b8655dd4201b127ec
+nopie_files="/usr/bin/bazel"
+
+do_install() {
+	EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" ./compile.sh
+}
+
+post_install() {
+	vbin "${wrksrc}/output/bazel"
+}


### PR DESCRIPTION
I've strictly followed the instructions on the bazel site: https://docs.bazel.build/versions/3.5.0/install-compile-source.html#bootstrap-bazel

I'm unfamiliar with bazel and only want to use it so I can build something.
I'm sure someone more familiar will be able to help.

closes #24681 

A few questions:

- Should I be bootstrapping this? According to the instructions, that's what is I'm doing: https://docs.bazel.build/versions/3.5.0/install-compile-source.html#compiling-from-source
- The build doesn't work for any other archs besides `x86_64`. Any tips on getting this to work cross architecture?
