### PR TITLE
picard: update to 2.4.4

### DIFF
--- a/srcpkgs/picard/patches/remove-hidpi-scale-factor-rounding-policy.patch
+++ b/srcpkgs/picard/patches/remove-hidpi-scale-factor-rounding-policy.patch
@@ -1,0 +1,15 @@
+--- picard/tagger.py
++++ picard/tagger.py
+@@ -916,11 +916,6 @@ def main(localedir=None, autoupdate=True):
+     # Allow High DPI Support
+     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+-    # HighDpiScaleFactorRoundingPolicy is available since Qt 5.14. This is
+-    # required to support fractional scaling properly.
+-    if hasattr(QtGui.QGuiApplication, 'setHighDpiScaleFactorRoundingPolicy'):
+-        QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+-            QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
+ 
+     # Enable mnemonics on all platforms, even macOS
+     QtGui.qt_set_sequence_auto_mnemonic(True)
+

--- a/srcpkgs/picard/template
+++ b/srcpkgs/picard/template
@@ -1,19 +1,18 @@
 # Template file for 'picard'
 pkgname=picard
-version=2.3.2
+version=2.4.4
 revision=1
-archs=noarch
 wrksrc="${pkgname}-release-${version}"
 build_style=python3-module
 make_install_args="--disable-autoupdate"
 hostmakedepends="gettext python3-setuptools"
 makedepends="python3-devel"
-depends="python3-PyQt5 chromaprint python3-mutagen
- desktop-file-utils hicolor-icon-theme"
+depends="python3-PyQt5 python3-PyQt5-multimedia chromaprint python3-mutagen
+ desktop-file-utils hicolor-icon-theme python3-discid"
 short_desc="MusicBrainz's audio tagger"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://picard.musicbrainz.org/"
 changelog="https://picard.musicbrainz.org/changelog/"
 distfiles="http://ftp.musicbrainz.org/pub/musicbrainz/${pkgname}/${pkgname}-${version%.0}.tar.gz"
-checksum=a91d9f11f2e5a6a0c579e0749e3a3919694ddeef0f251c1dded32e9331b1b0b7
+checksum=3e6a1abb886c859a20c164bec76e65a90b6b8d5a0c303a39d1432a39483cb4b0


### PR DESCRIPTION
There's a issue open in relation to provided patch

https://tickets.metabrainz.org/browse/PICARD-1948

only result of patch is that your scaling will be rounded up or down to a integer (e.g. 110% = 100%, 150% = 200%) 