### PR TITLE
[NOMERGE] Update plasma 5.19.90 [ci skip]

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -471,6 +471,7 @@ libksignalplotter.so.9 libksysguard-5.18.90_1
 libksgrd.so.9 libksysguard-5.18.90_1
 libprocesscore.so.9 libksysguard-5.18.90_1
 liblsofui.so.9 libksysguard-5.18.90_1
+libKSysGuardFormatter.so.1 libksysguard-5.18.90_1
 libKSysGuardSensorFaces.so.1 libksysguard-5.18.90_1
 libKWaylandServer.so.5 kwayland-server-5.18.90_1
 libxenctrl.so.4.14 xen-libs-4.14.0_1

--- a/srcpkgs/bluedevil/template
+++ b/srcpkgs/bluedevil/template
@@ -1,6 +1,6 @@
 # Template file for 'bluedevil'
 pkgname=bluedevil
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,8 +11,8 @@ short_desc="KDE Bluetooth integration"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/bluedevil"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e857e3c73a3d6c08bb44506f35a8359b480e960d32ae189b9b5bddcbcf5ffe2d
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=7c6870fc5b23d9094d4fca7f1df2bf252410380fc3c6422c1ba9711866ecf5b8
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel"

--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze-gtk'
 pkgname=breeze-gtk
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules sassc python3 python3-cairo"
@@ -9,8 +9,8 @@ short_desc="A GTK Theme Built to Match KDE's Breeze"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/breeze-gtk"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=5213b2f6815e542cda6bf9ae153636285e178962c6a59ff9ab4fe5c07dc256c8
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=834e48b4adfcff2c1d05e283d5b6ff31c848037504d4061d119c33875db0c8a1
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-devel"

--- a/srcpkgs/breeze/template
+++ b/srcpkgs/breeze/template
@@ -1,6 +1,6 @@
 # Template file for 'breeze'
 pkgname=breeze
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,8 +13,8 @@ short_desc="Breeze visual style for the Plasma Desktop"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=61116665a534a0acd833f9bb499dbe983bb07088c0006988fbd929f60f0ff336
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=4103aa1301459cfbca28b65dc24446b170642d048f8a5e2bfef3c322f7373a49
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,6 +1,6 @@
 # Template file for 'kactivitymanagerd'
 pkgname=kactivitymanagerd
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,8 +11,8 @@ short_desc="Manage user's activities and track the usage patterns"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=eec1a0996812d89b98e93a3a2dec15527fd553c2c9c608ad7f1858f01749c3b0
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=9e9b72bf45333536fe04c7f2bce51e03ddb6805dd38132737752a9d6879519f2
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DRUN_RESULT_VAR=0"

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-cli-tools'
 pkgname=kde-cli-tools
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,8 +12,8 @@ short_desc="KDE CLI tools"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=07314832aee0b424451120e0aad59fdaab96ba713279dc1937cf36ef9b5389c7
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=75d879b805349c7206498d43192e37db4e47c15221fc07f3c5fedd95e76a9f3a
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kdoctools kcoreaddons python qt5-host-tools qt5-qmake"

--- a/srcpkgs/kde-gtk-config5/template
+++ b/srcpkgs/kde-gtk-config5/template
@@ -1,21 +1,21 @@
 # Template file for 'kde-gtk-config5'
 pkgname=kde-gtk-config5
-version=5.19.5
+version=5.19.90
 revision=1
 wrksrc="${pkgname%5}-${version}"
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules pkg-config qt5-qmake qt5-host-tools
- gettext"
+ gettext sassc"
 makedepends="kcmutils-devel knewstuff-devel gtk+-devel gtk+3-devel
- gsettings-desktop-schemas-devel"
+ gsettings-desktop-schemas-devel kdecoration-devel"
 depends="kde-cli-tools gsettings-desktop-schemas"
 short_desc="GTK2 and GTK3 Configurator for KDE"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=e9b79917994a18001691ce675d5f2e95367c872694d82540fb245ab6e57035a3
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname%5}-${version}.tar.xz"
+checksum=a12141f2323e3d676af41cbe42a45500911eb3b57cfcedae65a00112b8c34346
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kcoreaddons"

--- a/srcpkgs/kdecoration/template
+++ b/srcpkgs/kdecoration/template
@@ -1,6 +1,6 @@
 # Template file for 'kdecoration'
 pkgname=kdecoration
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,8 +10,8 @@ short_desc="KDE Plugin based library to create window decorations"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ce3ef7bb09405645699939cc3481d1fad67b1c5b758b64adfc4d81e5ffb1c85e
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=7adc209eeb5f2094474ee88647b048464e2227c8cace41008ba4352420122e1b
 
 kdecoration-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kdeplasma-addons5/template
+++ b/srcpkgs/kdeplasma-addons5/template
@@ -1,6 +1,6 @@
 # Template file for 'kdeplasma-addons5'
 pkgname=kdeplasma-addons5
-version=5.19.5
+version=5.19.90
 revision=1
 wrksrc="${pkgname%5}-${version}"
 build_style=cmake
@@ -13,8 +13,8 @@ short_desc="Various Plasma addons"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=659e10b553c7db1abd488f77c43a919046f5e7f29126972926afe1350f93ff23
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname%5}-${version}.tar.xz"
+checksum=2c11f4493e7179486372904f3a5aad0319596a79a483d381e15379936846f458
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/kgamma5/template
+++ b/srcpkgs/kgamma5/template
@@ -1,6 +1,6 @@
 # Template file for 'kgamma5'
 pkgname=kgamma5
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,8 +10,8 @@ short_desc="KDE gamma adjustiment app"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma5"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d6e70e2638c65283895ead3791957853553d02ee864b2f928c3b0df4611ca023
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=f76bafd2d4de723ba6c3a4b1a9f8753dc829d58cfbbc2415ccfe8cff5d375fee
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-devel kdoctools"

--- a/srcpkgs/khotkeys/template
+++ b/srcpkgs/khotkeys/template
@@ -1,6 +1,6 @@
 # Template file for 'khotkeys'
 pkgname=khotkeys
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,8 +11,8 @@ short_desc="KDE Hotkeys"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/khotkeys"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=568cb61eb385a3776d96b21aa77188377b02e56e3bf46f9d9ffddb83a9b31bda
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=e0098c7dedd06620e833eca1498210d211de7fffba61a70af7ba0353b0c20bf0
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,6 +1,6 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,8 +13,8 @@ short_desc="KDE Info Center"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2"
 homepage="https://invent.kde.org/plasma/kinfocenter"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ffae6f6fc311cedfac2b380dcbc9f15588952cbcd66b144f4ae717801cb2bc31
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=748bc4b3a79310a010c8396813d1f1b51f49f26ff2fd08a25433ef1d38d5419c
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel kdoctools-devel"

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,6 +1,6 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ short_desc="KDE Menu editor"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2"
 homepage="https://invent.kde.org/plasma/kmenuedit"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f4701c74c304d46f5146943aa297300fb38a9c3b1efad39d4fbf3238d49989f6
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=3fc418835ac1d4fe671a8a45fce61a38084dfc6fbae71d77382ac0c2ada52da4

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreen'
 pkgname=kscreen
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,8 +13,8 @@ short_desc="KDE screen management software"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=0d72c687a405358e6aa6b388a648134e8e9236b7ed60e36a31068960d07b56e8
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=72f01c6ffb3bf4e95aa167cfe62597c76ac9e8237e079e7f53785406bc9ccb2f
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,6 +1,6 @@
 # Template file for 'kscreenlocker'
 pkgname=kscreenlocker
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,8 +12,8 @@ short_desc="KDE Library and components for secure lock screen architecture"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b13b2081971db1347d6a77dec416725995ca20a5b7bf05f21c72a68e15d6a5b9
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=dd1fb3fc23fc3fe9e4834374f1c8f60190a73ee29eb098c58d66ec0f284f6344
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" wayland-devel"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,6 +1,6 @@
 # Template file for 'ksshaskpass'
 pkgname=ksshaskpass
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,5 +11,5 @@ short_desc="KDE ssh-add helper"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=51c7dbcc434fb993ae756ce6ef8bf7511033617cc3367478382e1490b6505bcc
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=e77a3711691b515ee0dc2f1260d50976e539186e15de3ff940792f04a56773a3

--- a/srcpkgs/ksysguard/template
+++ b/srcpkgs/ksysguard/template
@@ -1,6 +1,6 @@
 # Template file for 'ksysguard'
 pkgname=ksysguard
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ short_desc="KDE program to monitor various elements of your system"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2"
 homepage="https://invent.kde.org/plasma/ksysguard"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e1a66dc9750482ada19da5d3e9ec06893f859930f0e8e5a910a5751e9f267c47
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=b1b8a3db6cdfc0263589b7087bb3d0dd3e27673a5095ccc0ba5fe4dfbe25847d

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,6 +1,6 @@
 # Template file for 'kwallet-pam'
 pkgname=kwallet-pam
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 hostmakedepends="qt5-qmake qt5-host-tools extra-cmake-modules"
@@ -10,5 +10,5 @@ short_desc="KWallet PAM integration"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=788aed97654b82b3512870dbf2b0d0f521503631d094bba07a7eff1125a7916f
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=dc4a45284c807eefba6bc99ae7c756545519f1d2b6317d80b321f48994ab9d2d

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-integration'
 pkgname=kwayland-integration
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,5 +10,5 @@ short_desc="Integration plugins for Kwayland"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=6d1bed734cd256604736417846f891abad9bd7c2a45527fc6fc10560322c8a14
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=b97aafa2492005cdc7d05893290863666864967a0fc753407bf0473e114e4145

--- a/srcpkgs/kwayland-server/template
+++ b/srcpkgs/kwayland-server/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-server'
 pkgname=kwayland-server
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -11,8 +11,8 @@ short_desc="Wayland server components built on KDE Frameworks"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-server"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=50fd9c9f68fd514dfd1ad05e65c8767afa154a3eed792f335214eee188c8541a
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=5b43afa4a44e6fd2166ab070d26876bbd4979e60df08b72e0303d898a252a6aa
 
 kwayland-server-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,7 +1,7 @@
 # Template file for 'kwin'
 pkgname=kwin
-version=5.19.5
-revision=2
+version=5.19.90
+revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext breeze pkg-config"
@@ -15,8 +15,8 @@ short_desc="KDE Window manager"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=36afa37b773d31c0bcb8f4e32fa1f06cc33e15ad00e729ba36f120bbe034903b
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=a63c60f0be5f32e05b18337b5957e708560613d8ddc59dfe0baaef70e7d726dd
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-qmake qt5-host-tools kcoreaddons kconfig"

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,6 @@
 # Template file for 'kwrited'
 pkgname=kwrited
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,5 +10,5 @@ short_desc="KDE daemon listening for wall and write messages"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c934d9c85581db575da0559713f1c0bba0541749ea36a51f9cbce7454c2af4db
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=64195aca6af6e27c45611d5c37f4e2ddb72fcc9cdb2efdabbd6b474737881405

--- a/srcpkgs/libkscreen/template
+++ b/srcpkgs/libkscreen/template
@@ -1,6 +1,6 @@
 # Template file for 'libkscreen'
 pkgname=libkscreen
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,8 +10,8 @@ short_desc="KDE screen management software"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=11351cbed924264c6ccd8b95bd7fcaeed3477abb31e962894b0630ef41bdc165
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=e7932d1a4b091c90152b8fdf0c8d225293e08f6da16d67a2576385646864c093
 
 libkscreen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,6 +1,6 @@
 # Template file for 'libksysguard'
 pkgname=libksysguard
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kauth qt5-host-tools qt5-qmake"
@@ -10,8 +10,8 @@ short_desc="KDE libksysguard"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d8adb311dae1a699a3fd3fbdc9e6cdde037503ca303b70f12d33b985ee80a0cd
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=ea63d8e0cdba02b0e59ee395b0c98b7f50d99e89999f6ca7fe658ebc884790bc
 
 build_options="webengine"
 

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,6 +1,6 @@
 # Template file for 'milou'
 pkgname=milou
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,8 +11,8 @@ short_desc="KDE dedicated search application built on top of Baloo"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LPGL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=edc6e5c646a98f6f3eada802995c1308c84a5ae7aef467e9d4ce1deaf8a9040e
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=e2b5690dd077916a0853fe00a2114aa7ed009ff9bcf300e9b4377ba34b47adcf
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/oxygen/template
+++ b/srcpkgs/oxygen/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen'
 pkgname=oxygen
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ short_desc="Oxygen visual style for the Plasma Desktop"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4217d4da0f851d6e3fc25cdaa3f3123611e5e89d676ba33fa1c0fd02cddb0c35
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=02a835e8be263e7505452379ec776ec5a5d81f57d108cb1e88ec9b61c0376b1c

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-browser-integration'
 pkgname=plasma-browser-integration
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,8 +12,8 @@ short_desc="Integration of web browsers with the KDE Plasma 5 desktop"
 maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=29cb30b86f9f25857ba7e67bcb892e9a1dabfd4eec1767b0c4ca0a1400d61dcf
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=8159392459bbe093f926639ca1dc210bf0ec16f482ace1b49c5e35cff33e36c5
 
 if [ "${CROSS_BUILD}" ]; then
 	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-desktop'
 pkgname=plasma-desktop
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,8 +14,8 @@ short_desc="KDE Plasma Desktop"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c63e1c81edc438656f9159e235be31e3b1b11a3f8ecbe5b97b21fcc91eb71a70
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=b5b78212257b8d352b0c86a321dedba65fd05d85d5395ebec4e357331ade491e
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kconfig-devel kcoreaddons-devel kded

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-integration'
 pkgname=plasma-integration
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,5 +13,5 @@ short_desc="Theme integration plugins for the Plasma workspaces"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f7fdd854e78e366a310116ef190bd7bed42df15a059d8ad75b763cbcebfb6389
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=822ee25ffaa1c7aa800bb9341ac5715482ba1d5ec5cd06864228297d34d25b1d

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-nm'
 pkgname=plasma-nm
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,8 +14,8 @@ short_desc="NetworkManager Plasma applet"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=433fe0329bacaede666d4d0962c5dedf6b4449f7c7ad08870ae9554ad64f2bb9
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=04112594be85a7e911bb4ac7f085955ea9da26a9ec994ca139c386fa34eaf44f
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-pa'
 pkgname=plasma-pa
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,8 +12,8 @@ short_desc="PulseAudio Plasma applet"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b00eb9bc7c7bd35f3ae78f58522cea8d1dd86b9b20585dff83fb93ef64af91d8
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=42599c0a4c5a4acc0711957a89abc71d2b29c0f1b240a8461a410c4175277eec
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel"

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-sdk'
 pkgname=plasma-sdk
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,8 +12,8 @@ short_desc="Plasma development applications"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=8c434adbb6c68ce42581152269d7e0717f16362017290a96f2c5f1922930da20
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=f130ef26c56ac135907c8b781ed28b3ac9319b86cd07518d769fcd6bef9bfe6b
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-thunderbolt'
 pkgname=plasma-thunderbolt
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules kcoreaddons kcmutils
@@ -11,8 +11,8 @@ short_desc="Plasma integration for controlling Thunderbolt devices"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=959b4eb43b58d46895c94c94c082b28277ca197cdcaa25880800502ace6d0295
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=058f4f4d5f6e2884cdfafaa68c647af97f5efac32a4cfd1c758d3535801fa838
 
 do_check() {
 	: # Requires running dbus and bolt services

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-vault'
 pkgname=plasma-vault
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules kcoreaddons qt5-qmake qt5-host-tools
@@ -10,8 +10,8 @@ short_desc="Plasma applet and services for creating encrypted vaults"
 maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/KDE/plasma-vault"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7f81321f32f3784683fa7d9511dca9bfba70a7a9181a33e832d864c639b05204
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=0cc6f8603c72fe9abf2c49ad574b2740111be69cd5aeda3294eef99988961b87
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace-wallpapers'
 pkgname=plasma-workspace-wallpapers
-version=5.19.5
+version=5.19.90
 revision=1
 archs=noarch
 build_style=cmake
@@ -10,5 +10,5 @@ short_desc="KDE Plasma wallpapers"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4aeec36035356cca71c0966e9d7dbc7d9fca6be4c27abd990f0fa954a91374f9
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=b618168768b553dfc8cbddedc2968a0da79341b0658a5c4b1f38d60ab8050819

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,25 +1,25 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules iso-codes pkg-config kdoctools kcoreaddons
- gettext"
+ gettext plasma-wayland-protocols"
 makedepends="qt5-devel qt5-declarative-devel qt5-script-devel plasma-framework-devel
  krunner-devel kjsembed-devel knotifyconfig-devel kdesu-devel knewstuff-devel
  kcmutils-devel kidletime-devel kdelibs4support-devel libksysguard-devel
  baloo5-devel ktexteditor-devel kwin-devel libxcb-devel libXtst-devel
  libqalculate-devel prison-devel kholidays-devel ksolid-devel kpeople-devel
- libkscreen-devel kactivities5-stats-devel"
+ libkscreen-devel kactivities5-stats-devel pipewire-devel libXft-devel"
 depends="kactivitymanagerd kwin iso-codes milou plasma-integration
  kquickcharts qt5-wayland xorg-server-xwayland"
 short_desc="KDE Window manager"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=490329e08e63016edd696a9132bf80b76ef51dacf53308b865d2e27b67ce8127
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=8443749557af2f6288a144d3df46d3c0c271e7a9068fc46334faf7c3b6e2ab76
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,6 +1,6 @@
 # Template file for 'polkit-kde-agent'
 pkgname=polkit-kde-agent
-version=5.19.5
+version=5.19.90
 revision=1
 wrksrc="${pkgname}-1-${version}"
 build_style=cmake
@@ -12,5 +12,5 @@ short_desc="KDE PolKit auth agent"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=076129f450a82780f354d7ec18300094db3f7233cb52f4e57298b973750adb30
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-1-${version}.tar.xz"
+checksum=f264e25c9df2b2a90e05288c79990c42de1f153ca0aa0d726ad7ef8140d72712

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,6 +1,6 @@
 # Template file for 'powerdevil'
 pkgname=powerdevil
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ short_desc="Power consumption settings of a Plasma"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d15f013c50928097f6b719aca46ec2a93a997dcbb7584bcb09f18015cca8ac1a
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=a6bffc9145411f596aa28df4a470b078a11d8b4bb44c8dde800a98711ded274a

--- a/srcpkgs/prison/template
+++ b/srcpkgs/prison/template
@@ -1,10 +1,11 @@
 # Template file for 'prison'
 pkgname=prison
 version=5.74.0
-revision=1
+revision=2
 build_style=cmake
-hostmakedepends="kcoreaddons extra-cmake-modules qt5-tools"
-makedepends="qt5-devel libdmtx-devel qrencode-devel ecm-devel"
+hostmakedepends="kcoreaddons extra-cmake-modules qt5-tools doxygen qt5-declarative-devel"
+makedepends="qt5-devel libdmtx-devel qrencode-devel ecm-devel qt5-plugin-sqlite
+ qt5-declarative-devel"
 short_desc="Barcode API to produce QRCode barcodes and DataMatrix barcodes"
 maintainer="John <me@johnnynator.dev>"
 license="MIT"
@@ -30,5 +31,4 @@ prison-devel_package() {
 		vmove usr/lib/cmake
 		vmove "usr/lib/*.so"
 	}
-
 }

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,6 +1,6 @@
 # Template file for 'sddm-kcm'
 pkgname=sddm-kcm
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,5 +13,5 @@ short_desc="KDE Config Module for SDDM"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3ba2c6821fc847fca2cb8123748bf05cdd9c45557a0ecab5dc43a37a5ebde738
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=ab9e68985f1d94c1b8ae5c9ffbf737da1bc2b1297a83634bd4321beed23ba4fe

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,6 +1,6 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,8 +12,8 @@ short_desc="KDE System settings"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2"
 homepage="https://invent.kde.org/plasma/systemsettings"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ba8fdc2b8c861e7271bad7f6c5cdb92b0c2eee08ef81b86e28bba064259e2ff9
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=2d36c805137f6308b5ae0771ba08a92b77709981152de621be43ab08b38a63ca
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" python qt5-qmake qt5-host-tools kconfig

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
-version=5.19.5
+version=5.19.90
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons gettext
@@ -11,5 +11,5 @@ short_desc="Backend implementation for xdg-desktop-portal that is using Qt/KF5"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://phabricator.kde.org/source/xdg-desktop-portal-kde/"
-distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=055e7c379dc3e0edb8d87515468b8d16a70bd99765f269a211ce655eb3e1ea45
+distfiles="https://download.kde.org/unstable/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=b064e6111178bc787a370fe8668d68a58e438e85f08cc9cf78f2894e0e03bba3


### PR DESCRIPTION
This is just for people who want to try it out, and future reference, since `kde-gtk-config5`, `konsole`, `plasma-workspace` and `prison` needed a few minor changes to fully work apart from compiling.