### PR TITLE
haproxy: update to 2.2.4

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,17 +1,17 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.1.7
-revision=3
+version=2.2.4
+revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 makedepends="libatomic-devel libressl-devel lua53-devel pcre-devel"
 checkdepends="varnish"
 short_desc="Reliable, high performance TCP/HTTP load balancer"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
 distfiles="${homepage}/download/${version%.*}/src/${pkgname}-${version}.tar.gz"
-checksum=392e6cf18e75fe7e166102e8c4512942890a0b5ae738f6064faab4687f60a339
+checksum=87a4d9d4ff8dc3094cb61bbed4a8eed2c40b5ac47b9604daebaf036d7b541be2
 
 haproxy_homedir="/var/lib/${pkgname}"
 make_dirs="$haproxy_homedir 0750 ${pkgname} ${pkgname}"


### PR DESCRIPTION
Tested working.  This brings HAProxy to the latest LTS branch.