### PR TITLE
ffmpeg: Add support for webp codec

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.3.1
-revision=2
+revision=3
 short_desc="Decoding, encoding and streaming software"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="GPL-3.0-or-later"
@@ -22,11 +22,12 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  $(vopt_if v4l2 v4l-utils-devel) $(vopt_if faac faac-devel) $(vopt_if fdk_aac fdk-aac-devel)
  $(vopt_if vpx libvpx-devel) $(vopt_if aom libaom-devel)
  $(vopt_if nvenc nv-codec-headers) $(vopt_if sndio sndio-devel)
- $(vopt_if dav1d libdav1d-devel) $(vopt_if zimg zimg-devel)"
+ $(vopt_if dav1d libdav1d-devel) $(vopt_if zimg zimg-devel)
+ $(vopt_if webp libwebp-devel)"
 
 build_options="x265 v4l2 vaapi vdpau vpx faac fdk_aac aom nvenc sndio pulseaudio
- dav1d zimg"
-build_options_default="x265 v4l2 vpx aom sndio pulseaudio dav1d"
+ dav1d zimg webp"
+build_options_default="x265 v4l2 vpx aom sndio pulseaudio dav1d webp"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) build_options_default+=" vaapi vdpau nvenc";;
@@ -94,7 +95,8 @@ do_configure() {
 		$(vopt_enable aom libaom) $(vopt_enable vaapi) $(vopt_enable vdpau) \
 		--enable-libbs2b --enable-avresample --enable-libvidstab \
 		$(vopt_if dav1d '--enable-libdav1d') \
-		$(vopt_if zimg '--enable-libzimg')
+		$(vopt_if zimg '--enable-libzimg') \
+		$(vopt_if webp '--enable-libwebp')
 }
 do_build() {
 	rm ${XBPS_WRAPPERDIR}/strip


### PR DESCRIPTION
Adds dependency on `libwebp` with `--enable-libwebp`, behind enabled-by-default feature `webp`.