### PR TITLE
added dependencies for clipmenu

### DIFF
--- a/srcpkgs/clipmenu/template
+++ b/srcpkgs/clipmenu/template
@@ -1,9 +1,8 @@
 # Template file for 'clipmenu'
 pkgname=clipmenu
 version=6.1.0
-revision=1
-archs=noarch
-depends="bash dmenu"
+revision=2
+depends="bash dmenu clipnotify xsel"
 short_desc="Clipboard management using dmenu"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain"


### PR DESCRIPTION
I added some dependencies.
For example, without clipnotify I get an error.
These are the same dependencies as Arch Linux.