### PR TITLE
sddm: source ./conf

### DIFF
--- a/srcpkgs/sddm/files/sddm/run
+++ b/srcpkgs/sddm/files/sddm/run
@@ -12,4 +12,6 @@ fi
 # respect system locale
 [ -r /etc/locale.conf ] && . /etc/locale.conf && export LANG
 
+[ -f ./conf ] && . ./conf
+
 exec sddm 2>&1

--- a/srcpkgs/sddm/template
+++ b/srcpkgs/sddm/template
@@ -1,7 +1,7 @@
 # Template file for 'sddm'
 pkgname=sddm
 version=0.18.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_MAN_PAGES=1 -DNO_SYSTEMD=1 -DUSE_ELOGIND=1
  -DLOGIN_DEFS_PATH=${XBPS_SRCPKGDIR}/shadow/files/login.defs


### PR DESCRIPTION
E.g.: To set a different locale than systems locale.