### PR TITLE
yaboot: fix build w/ gcc10 and host i686/x86_64

### DIFF
--- a/srcpkgs/yaboot/patches/0003-build-system.patch
+++ b/srcpkgs/yaboot/patches/0003-build-system.patch
@@ -22,7 +22,7 @@ Also do not strip the binaries upon install, xbps-src will take care of that.
  # command used to get root (needed for tarball creation)
  GETROOT = fakeroot
  
-@@ -32,14 +32,17 @@ LD		:= $(CROSS)ld
+@@ -32,14 +32,18 @@ LD		:= $(CROSS)ld
  AS		:= $(CROSS)as
  OBJCOPY		:= $(CROSS)objcopy
  
@@ -39,10 +39,11 @@ Also do not strip the binaries upon install, xbps-src will take care of that.
  YBCFLAGS += -DKERNELADDR=$(KERNELADDR)
 -YBCFLAGS += -Werror -fdiagnostics-show-option
 +YBCFLAGS += -fgnu89-inline -fno-builtin-malloc -fno-stack-protector -no-pie
++YBCFLAGS += -fcommon
  YBCFLAGS += -I ./include
  YBCFLAGS += -fno-strict-aliasing
  
-@@ -69,12 +72,12 @@ LFLAGS = -Ttext $(TEXTADDR) -Bstatic -melf32ppclinux
+@@ -69,12 +72,13 @@ LFLAGS = -Ttext $(TEXTADDR) -Bstatic -melf32ppclinux
  
  # Libraries
  #
@@ -54,6 +55,7 @@ Also do not strip the binaries upon install, xbps-src will take care of that.
  UCFLAGS = -Os $(CFLAGS) -Wall -I/usr/include
 -UCFLAGS += -Werror -fdiagnostics-show-option
 +UCFLAGS += -fdiagnostics-show-option
++UCFLAGS += -fcommon
  
  # For compiling build-tools that run on the host.
  #

--- a/srcpkgs/yaboot/template
+++ b/srcpkgs/yaboot/template
@@ -59,6 +59,7 @@ _build_e2fsprogs() {
 		if [ -n "$_need_cross" -o -n "$CROSS_BUILD" ]; then
 			# using a crosscompiler, set up configure/compiler for that
 			_args+=" --host=${_need_cross:-$XBPS_CROSS_TRIPLET}"
+			_args+=" --build=$XBPS_TRIPLET"
 			_ecc="${_need_cross:-$XBPS_CROSS_TRIPLET}-gcc"
 			_ear="${_need_cross:-$XBPS_CROSS_TRIPLET}-ar"
 		fi


### PR DESCRIPTION
The -fcommon is required for gcc10 to build yaboot.
Adding --build=$XBPS_TRIPLET seems to be a good idea in any case
according to the autoconf manual, see the document at:
https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Hosts-and-Cross_002dCompilation.html

Still gives an error for me trying to build for ppc-musl using any
x86 host environment, be it glibc or musl libc.

More patches required or something else may be wrong?