### PR TITLE
grilo-plugins: build with tracker3.

### DIFF
--- a/srcpkgs/grilo-plugins/template
+++ b/srcpkgs/grilo-plugins/template
@@ -1,13 +1,13 @@
 # Template file for 'grilo-plugins'
 pkgname=grilo-plugins
 version=0.3.12
-revision=1
+revision=2
 build_style=meson
-hostmakedepends="pkg-config intltool itstool glib-devel gperf gnome-doc-utils"
+hostmakedepends="pkg-config intltool itstool glib-devel gperf gnome-doc-utils tracker3"
 # XXX missing plugins: fakemetadata.
 makedepends="grilo-devel gom-devel gupnp-av-devel json-glib-devel
  libquvi-devel rest-devel sqlite-devel libgcrypt-devel gmime-devel
- tracker-devel totem-pl-parser-devel libgdata-devel libmediaart-devel
+ tracker3-devel totem-pl-parser-devel libgdata-devel libmediaart-devel
  gstreamer1-devel libdmapsharing-devel lua53-devel gnome-online-accounts-devel
  avahi-glib-libs-devel"
 short_desc="Plugins for Grilo"


### PR DESCRIPTION
This fixes gnome-music not being able to launch.

Mentioned in #24997 

I could still launch `totem`, which is the other dependant of `grilo-plugins`, but I have no idea how to test for lost functionality. `grilo-plugin` can't be built with `tracker` and `tracker3` support simultaneously, so it could be necessary to ship a separate version for each version of tracker, I guess.

@q66 