### PR TITLE
enchant2: update to 2.2.11.

### DIFF
--- a/srcpkgs/enchant2/template
+++ b/srcpkgs/enchant2/template
@@ -1,19 +1,20 @@
 # Template file for 'enchant2'
 pkgname=enchant2
-version=2.2.10
+version=2.2.11
 revision=1
 wrksrc="enchant-${version}"
 build_style=gnu-configure
 make_build_args="pkgdatadir=/usr/share/enchant-2"
 make_install_args="$make_build_args"
 hostmakedepends="pkg-config"
-makedepends="libglib-devel hunspell-devel aspell-devel libvoikko-devel"
+makedepends="libglib-devel hunspell-devel aspell-devel libvoikko-devel
+ libnuspell-devel icu-devel boost-devel"
 short_desc="Generic spell checking library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://abiword.github.io/enchant/"
 distfiles="https://github.com/AbiWord/enchant/releases/download/v${version}/enchant-${version}.tar.gz"
-checksum=6a5b34c40647d8524b73a2b0d7104a6375504059ece61ae5ce459500d62cbdc3
+checksum=a29c5777c4e45fcac2595c15c49d6d2aa434fa5e7c993dff3f9f367b65fe472a
 
 enchant2-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Add support for `nuspell`. It was merged in main in the `2.2.8` update of `enchant2`.