### PR TITLE
pinephone: add support for modem setup and audio routing.

### DIFF
--- a/srcpkgs/pinephone-base/files/90-modem-eg25.rules
+++ b/srcpkgs/pinephone-base/files/90-modem-eg25.rules
@@ -1,5 +1,0 @@
-SUBSYSTEMS=="usb", ENV{.LOCAL_ifNum}="$attr{bInterfaceNumber}"
-
-SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="01", SYMLINK+="EG25.NMEA", MODE="0660"
-SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="02", SYMLINK+="EG25.AT", MODE="0660"
-SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="03", SYMLINK+="EG25.MODEM", MODE="0660"

--- a/srcpkgs/pinephone-base/template
+++ b/srcpkgs/pinephone-base/template
@@ -1,15 +1,11 @@
 # Template file for 'pinephone-base'
 pkgname=pinephone-base
-version=0.1
+version=0.2
 revision=1
 archs="aarch64*"
 build_style=meta
-depends="pinephone-kernel pinephone-uboot"
+depends="pinephone-kernel pinephone-uboot pinephone-utils"
 short_desc="Void Linux PinePhone platform package"
 maintainer="John Sullivan <jsullivan@csumb.edu>"
 license="Public Domain"
 homepage="https://www.voidlinux.org"
-
-do_install() {
-	vinstall "${FILESDIR}/90-modem-eg25.rules" 644 usr/lib/udev/rules.d
-}

--- a/srcpkgs/pinephone-utils/files/COPYING
+++ b/srcpkgs/pinephone-utils/files/COPYING
@@ -1,0 +1,6 @@
+Some files used in this package originate from postmarketOS, and are used with
+some modifications under the terms of the MIT license
+https://opensource.org/licenses/MIT
+
+see for sources:
+https://gitlab.com/postmarketOS/pmaports/-/tree/master/device/main/device-pine64-pinephone

--- a/srcpkgs/pinephone-utils/patches/vendor/modem-rules.patch
+++ b/srcpkgs/pinephone-utils/patches/vendor/modem-rules.patch
@@ -1,0 +1,8 @@
+--- device/main/device-pine64-pinephone/90-modem-eg25.rules	2021-01-27 07:11:44.000000000 -0800
++++ srcpkgs/pinephone-utils/files/90-modem-eg25.rules	2020-09-25 01:37:55.390496779 -0700
+@@ -3,5 +3,3 @@
+ SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="01", SYMLINK+="EG25.NMEA", MODE="0660"
+ SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="02", SYMLINK+="EG25.AT", MODE="0660"
+ SUBSYSTEMS=="usb", KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="03", SYMLINK+="EG25.MODEM", MODE="0660"
+-
+-ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="2c7c", ATTRS{idProduct}=="0125", ENV{.LOCAL_ifNum}=="02", RUN+="/usr/bin/pinephone_setup-modem '%E{DEVNAME}'"

--- a/srcpkgs/pinephone-utils/template
+++ b/srcpkgs/pinephone-utils/template
@@ -1,0 +1,34 @@
+# Template file for 'pinephone-utils'
+pkgname=pinephone-utils
+version=0.1
+revision=1
+archs="aarch64*"
+create_wrksrc=yes
+depends="alsa-ucm-conf"
+short_desc="Scripts/configs for managing pinephone hardware"
+maintainer="John Sullivan <jsullivan@csumb.edu>"
+license="MIT"
+homepage="https://postmarketos.org/"
+
+_commit_pmos=c48037d5ed307d865903ef3aecd302f1fa4417f8
+_pmos_device='device/main/device-pine64-pinephone'
+_pmos_checkout="pmaports-${_commit_pmos}-${_pmos_device//\//-}/${_pmos_device}"
+
+distfiles="https://gitlab.com/postmarketOS/pmaports/-/archive/${_commit_pmos}/pmaports-${_commit_pmos}.tar.gz?path=${_pmos_device}>pmos-scripts-${version}.tar.gz"
+checksum="d73200da438b6a5641ccd0e73f778cad07301c83b5bbf7286722c74a98675d2e"
+
+do_patch() {
+	patch "${_pmos_checkout}/90-modem-eg25.rules" -slNp1 -i "${PATCHESDIR}/vendor/modem-rules.patch"
+	vsed -i 's/postmarketOS/void/' "${_pmos_checkout}/setup-modem.sh"
+}
+
+do_install() {
+	vinstall "${_pmos_checkout}/90-modem-eg25.rules" 644 usr/lib/udev/rules.d
+	vinstall "${_pmos_checkout}/00_alsa_pinephone_dshare.conf" 644 etc/alsa/conf.d "00-alsa-pinephone-dshare.conf"
+	vbin "${_pmos_checkout}/setup-modem.sh" "pinephone_setup-modem"
+
+	vmkdir usr/share/alsa/ucm2
+	vcopy "${_pmos_checkout}/ucm" usr/share/alsa/ucm2/PinePhone
+
+	vlicense "${FILESDIR}/COPYING"
+}


### PR DESCRIPTION
This pull adds the necessary components for 4G modem usage, with the following use-cases in mind:

- Configure audio setup to and from modem
- Make and receive calls
- Send and read SMS
- Use mobile broadband/cellular data
- Wake-on-Modem (for calls and texts)

For now I've tested this with ModemManager+NetworkManager, but this also provides the groundwork for environments that use `ofono` (or just plain AT commands with `atinout` or `screen`, if you feel clever :^) )

To get started, you first need to run `pinephone_setup-modem` once as root to do the initial modem configuration. (chances are postmarketOS already did this if you booted the phone once, but this might need to be done again incase of potential data loss)

Some use-cases might require further configuration of software (eg specific to NetworkManager) but the setup script should do most of the needed work. Make sure modem is powered up by running `echo 1 > /sys/class/modem-power/modem-power/device/powered_blocking` Some examples of usage that I've tested below:

Read sms with `mmcli`
```sh
$ mmcli -s '/org/freedesktop/ModemManager1/SMS/2'
  -----------------------------------
  Content    |              number: '+5555555555'
             |                text: 'Test'
  -----------------------------------
  Properties |            PDU type: 'deliver'
             |               state: 'received'
             |             storage: 'me'
             |                smsc: '+919810051829'
             |           timestamp: '160808142935+05'
```

Sample script for answering calls, using ModemManager dbus interface. Audio is setup thru `alsaucm`
```sh
#!/bin/bash

MM_IFACE="org.freedesktop.ModemManager1"
MATCH_CALLS="type='signal',sender='${MM_IFACE}',interface='${MM_IFACE}.Modem.Voice',member='CallAdded'"

do_accept() {
	while read TYPE TIME SENDER HEADER
	do
		if [[ "$HEADER" = *"Modem.Voice"* ]]; then
			read TYPE _P OBJ
			OBJ=$(echo "${OBJ}" | tr -d '"')
			echo "Pickup ${OBJ}"

			alsaucm \
				open PinePhone \
				set _verb 'Voice Call' \
				set _enadev 'Mic' \
				set _enadev 'Earpiece'
			
			dbus-send \
				--system \
				--dest="${MM_IFACE}" \
				--print-reply \
				"${OBJ}" \
				"${MM_IFACE}.Call.Accept"
		else
			read
		fi
	done
}

dbus-monitor --system "${MATCH_CALLS}" | do_accept
```

Add a NetworkManager connection for LTE (sub `<operator_apn>` for your carrier's data APN)
```sh
$ nmcli c add type gsm ifname '*' con-name LTE apn <operator_apn>
```

For Wake-on-Modem: I tested by doing `loginctl suspend` from a sway session, then calling the phone. It wakes up within 2 rings.

fwiw: these examples are only good for making sure the hardware/software interface works. More work still needs to be done to get some telephony front-end software in the repo, like #24538 Sxmo also should work out-of-the box with the NetworkManager+ModemManager pair https://git.sr.ht/~mil/sxmo-docs