### PR TITLE
chromium: update to 85.0.4183.121.

### DIFF
--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=85.0.4183.83
+version=85.0.4183.121
 revision=1
 archs="x86_64"
 create_wrksrc=yes

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=85.0.4183.83
+version=85.0.4183.121
 revision=1
 archs="i686* x86_64* aarch64* armv7l* ppc64le*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=2064aa4502b87c025f2233b59d94e9e3d1c00bfeaf891e1d973687de5740e73b
+checksum=e018547e54566410fb365d9f3dae10037c30fca5debe6ba8baceef3ad3b03d28
 nocross=yes
 
 lib32disabled=yes


### PR DESCRIPTION
- Built for i686, x86_64, x86_64-musl.
- Tested on x86_64.

- Also bump chromium-widevine.