### PR TITLE
protonmail-bridge: update to 1.4.1.

### DIFF
--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,6 +1,6 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=1.3.3
+version=1.4.1
 revision=1
 archs="x86_64"
 build_style=fetch
@@ -10,7 +10,7 @@ maintainer="Rich G <rich@richgannon.net>"
 license="custom:Commercial"
 homepage="https://protonmail.com/bridge"
 distfiles="https://protonmail.com/download/beta/protonmail-bridge_${version}-1_amd64.deb"
-checksum=3a434001f7e5439021999d0e6739021a2a63a1804f1245cf6f42aac7b6b4c283
+checksum=d8e953cd0e720ba9131cf06aae9e23124814b5533a29c53f758a646e8eae80b8
 
 restricted=yes
 noverifyrdeps=yes


### PR DESCRIPTION
Update protonmail-bridge to 1.4.1 release.

Locally tested.

Signed-off-by: Joseph Benden <joe@benden.us>