### PR TITLE
New packages: packr2 and circleci-cli

### DIFF
--- a/srcpkgs/circleci-cli/template
+++ b/srcpkgs/circleci-cli/template
@@ -1,0 +1,29 @@
+# Template file for 'circleci-cli'
+pkgname=circleci-cli
+version=0.1.9578
+revision=1
+build_style=go
+go_import_path=github.com/CircleCI-Public/${pkgname}
+go_ldflags="-s -w -X github.com/CircleCI-Public/${pkgname}/version.Version=${version} -X github.com/CircleCI-Public/${pkgname}/version.Commit=cf6a918 -X github.com/CircleCI-Public/${pkgname}/version.packageManager=xbps"
+hostmakedepends="packr2"
+short_desc="Use CircleCI from the command line"
+maintainer="Gabriel Sanches <gabriel@gsr.dev>"
+license="MIT"
+homepage="https://circleci-public.github.io/circleci-cli/"
+distfiles="https://github.com/CircleCI-Public/${pkgname}/archive/v${version}.tar.gz"
+checksum=d5dac07d27d97ee41dced89cf2b36dfeea17906343b6a6a21c1d8c4ca34a78a0
+
+pre_build() {
+	packr2
+}
+
+post_build() {
+	packr2 clean
+}
+
+post_install() {
+	vlicense LICENSE
+
+	# Rename the binary according to CircleCI's own releases.
+	mv ${DESTDIR}/usr/bin/circleci{-cli,}
+}

--- a/srcpkgs/packr2/template
+++ b/srcpkgs/packr2/template
@@ -1,0 +1,18 @@
+# Template file for 'packr2'
+pkgname=packr2
+_pkgname=packr
+version=2.8.0
+revision=1
+wrksrc=${_pkgname}-${version}
+build_style=go
+go_import_path=github.com/gobuffalo/${_pkgname}/v2/packr2
+short_desc="Static files embedder for Go binaries"
+maintainer="Gabriel Sanches <gabriel@gsr.dev>"
+license="MIT"
+homepage="https://github.com/gobuffalo/packr"
+distfiles="https://github.com/gobuffalo/${_pkgname}/archive/v${version}.tar.gz"
+checksum=2cab1e8d60734af05d594346f8e4bffcef0ac2aea4895b08bd9f3c40fc24c639
+
+post_install() {
+	vlicense v2/LICENSE.txt
+}


### PR DESCRIPTION
I have also packaged `packr2` because it's a build dependency of `circleci-cli`, and might still be useful for Golang developers.