### PR TITLE
base-chroot-musl: remove

### DIFF
--- a/srcpkgs/base-chroot-musl
+++ b/srcpkgs/base-chroot-musl
@@ -1,1 +1,0 @@
-base-chroot

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -20,13 +20,3 @@ depends+="
  file bsdtar ccache xbps mpfr ncurses libreadline8
  chroot-bash chroot-grep chroot-gawk chroot-distcc
  chroot-util-linux chroot-git"
-
-if [ "$XBPS_TARGET_LIBC" = musl ]; then
-
-base-chroot-musl_package() {
-	build_style=meta
-	depends="${sourcepkg}>=${version}_${revision}"
-	short_desc+=" - transitional dummy package"
-}
-
-fi # "$XBPS_TARGET_LIBC" = musl


### PR DESCRIPTION
Remove as it was intended to keep CI going after unifying base-chroot. CI images was updated since.