### PR TITLE
libzip: update to 1.7.3.

### DIFF
--- a/srcpkgs/libzip/template
+++ b/srcpkgs/libzip/template
@@ -1,16 +1,16 @@
 # Template file for 'libzip'
 pkgname=libzip
-version=1.7.1
-revision=2
+version=1.7.3
+revision=1
 build_style=cmake
-hostmakedepends="perl groff"
-makedepends="bzip2-devel libressl-devel zlib-devel liblzma-devel"
+hostmakedepends="perl groff pkg-config"
+makedepends="bzip2-devel mbedtls-devel zlib-devel liblzma-devel"
 short_desc="C library for reading, creating, and modifying zip archives"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://libzip.org/"
 distfiles="https://libzip.org/download/libzip-${version}.tar.gz"
-checksum=b5957bff7eadfa76ec79c70a7c619729491ea62c384e2c9f5de1b34119dd3bce
+checksum=0e2276c550c5a310d4ebf3a2c3dfc43fb3b4602a072ff625842ad4f3238cb9cc
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Changed crypto lib dependency from libressl to mbedtls. libzip supports also gnutls and nettle.