### PR TITLE
[RFC] base-system: add nano to dependencies.

### DIFF
--- a/srcpkgs/base-system/template
+++ b/srcpkgs/base-system/template
@@ -1,7 +1,7 @@
 # Template file for 'base-system'
 pkgname=base-system
-version=0.113
-revision=2
+version=0.114
+revision=1
 build_style=meta
 short_desc="Void Linux base system meta package"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -14,7 +14,7 @@ depends="
  mdocml>=1.13.3 shadow e2fsprogs btrfs-progs xfsprogs f2fs-tools dosfstools
  procps-ng tzdata pciutils usbutils iana-etc openssh dhcpcd
  kbd iproute2 iputils iw wpa_supplicant xbps nvi sudo wifi-firmware
- void-artwork traceroute ethtool kmod acpid eudev runit-void"
+ void-artwork traceroute ethtool kmod acpid eudev runit-void nano"
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) depends+=" musl";;


### PR DESCRIPTION
`base-system` already depends on `libmagic` and `ncurses-libs`, which means this only costs the 500K of the `nano` package, which installed is 2M.

It makes for a better user experience nearly for free, since there are often times when one needs to change file contents before they can even connect to the internet and install another editor (edit `/etc/resolv.conf` manually or some weird wireless setup). `nano` is easier to use and way simpler for someone who isn't used to command line stuff, and there are also users who simply prefer it over modal editing. Adding it here instead of as one of the packages used to build live systems makes sense because someone performing a netinstall would be caught by surprise after their netinstall resulted in a system without nano.