### PR TITLE
python3-grako: fix permissions

### DIFF
--- a/srcpkgs/python3-grako/template
+++ b/srcpkgs/python3-grako/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-grako'
 pkgname=python3-grako
 version=3.99.9
-revision=5
+revision=6
 wrksrc="grako-$version"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython"
@@ -19,5 +19,7 @@ pre_build() {
 	sed -i '/setup_requires=/d' setup.py
 }
 post_install() {
+	# TODO: Find out why we need to change these permissions manually
+	chmod -R +r "${DESTDIR}/${py3_sitelib}"
 	vlicense LICENSE.txt
 }


### PR DESCRIPTION
@sgn 

chmod +r files in Python3 site-packages to make them world/other
readable.

Currently the files are installed with the following permissions:

```
ll /usr/lib/python3.8/site-packages/grako-3.99.9-py3.8.egg-info/
total 36K
-rw-r----- 1 root root  11K Sep 27 00:09 PKG-INFO
-rw-r----- 1 root root 3.1K Sep 27 00:09 SOURCES.txt
-rw-r----- 1 root root    1 Sep 27 00:09 dependency_links.txt
-rw-r----- 1 root root   38 Sep 27 00:09 entry_points.txt
-rw-r----- 1 root root    1 Sep 27 00:09 not-zip-safe
-rw-r----- 1 root root   22 Sep 27 00:09 requires.txt
-rw-r----- 1 root root    6 Sep 27 00:09 top_level.txt
```

This prevents programs such as `qutebrowser` from running.