### PR TITLE
libxkbcommon: update to 1.0.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1221,7 +1221,6 @@ libwayland-cursor.so.0 wayland-1.6.0_1
 libtomcrypt.so.1 libtomcrypt-1.18.0_1
 libHX.so.28 libHX-3.14_1
 libxkbcommon.so.0 libxkbcommon-0.2.0_1
-libxkbregistry.so.0 libxkbcommon-1.0.1_1
 libxkbcommon-x11.so.0 libxkbcommon-x11-0.4.2_1
 libgee-0.8.so.2 libgee08-0.8.2_1
 libnettle.so.8 nettle-3.6_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -1221,6 +1221,7 @@ libwayland-cursor.so.0 wayland-1.6.0_1
 libtomcrypt.so.1 libtomcrypt-1.18.0_1
 libHX.so.28 libHX-3.14_1
 libxkbcommon.so.0 libxkbcommon-0.2.0_1
+libxkbregistry.so.0 libxkbcommon-1.0.1_1
 libxkbcommon-x11.so.0 libxkbcommon-x11-0.4.2_1
 libgee-0.8.so.2 libgee08-0.8.2_1
 libnettle.so.8 nettle-3.6_1

--- a/srcpkgs/libxkbcommon-tools
+++ b/srcpkgs/libxkbcommon-tools
@@ -1,0 +1,1 @@
+libxkbcommon

--- a/srcpkgs/libxkbcommon/patches/remove-fuzzing.patch
+++ b/srcpkgs/libxkbcommon/patches/remove-fuzzing.patch
@@ -4,8 +4,8 @@ Reason: removes creation of fuzzing infrastructure which isn't included in the d
 
 --- meson.build
 +++ meson.build
-@@ -382,12 +382,6 @@ if get_option('enable-x11')
-     executable('test-x11comp', 'test/x11comp.c', dependencies: x11_test_dep)
+@@ -670,12 +670,6 @@
+     message('valgrind not found, disabling valgrind test setup')
  endif
  
 -
@@ -14,6 +14,6 @@ Reason: removes creation of fuzzing infrastructure which isn't included in the d
 -executable('fuzz-compose', 'fuzz/compose/target.c', dependencies: test_dep)
 -
 -
- # Demo programs.
- executable('rmlvo-to-kccgst', 'test/rmlvo-to-kccgst.c', dependencies: test_dep)
- executable('print-compiled-keymap', 'test/print-compiled-keymap.c', dependencies: test_dep)
+ # Benchmarks.
+ libxkbcommon_bench_internal = static_library(
+     'xkbcommon-bench-internal',

--- a/srcpkgs/libxkbcommon/template
+++ b/srcpkgs/libxkbcommon/template
@@ -1,19 +1,19 @@
 # Template file for 'libxkbcommon'
 pkgname=libxkbcommon
-version=0.10.0
+version=1.0.1
 revision=1
 wrksrc="${pkgname}-${pkgname#lib}-${version}"
 build_style=meson
 configure_args="-Denable-wayland=true -Denable-docs=false -Denable-x11=true"
 hostmakedepends="pkg-config bison wayland-protocols wayland-devel"
-makedepends="xkeyboard-config libxcb-devel wayland-devel wayland-protocols"
+makedepends="xkeyboard-config libxcb-devel libxml2-devel wayland-protocols wayland-devel"
 depends="xkeyboard-config"
 short_desc="Library to handle keyboard descriptions"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://xkbcommon.org/"
 distfiles="https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-${version}.tar.gz"
-checksum=9b4635cf5d9fc0fb9611ceec1780aafc0944299e9a29ab09c18ec2633923b9c3
+checksum=270e2ad4ce5699f633e49042114cb68a5697fa1ed45b65c1d96a833cfac20954
 
 pkg_install() {
 	vlicense LICENSE

--- a/srcpkgs/libxkbcommon/template
+++ b/srcpkgs/libxkbcommon/template
@@ -4,9 +4,10 @@ version=1.0.1
 revision=1
 wrksrc="${pkgname}-${pkgname#lib}-${version}"
 build_style=meson
-configure_args="-Denable-wayland=true -Denable-docs=false -Denable-x11=true"
+configure_args="-Denable-x11=true -Denable-docs=false
+ -Denable-wayland=true -Denable-xkbregistry=false"
 hostmakedepends="pkg-config bison wayland-protocols wayland-devel"
-makedepends="xkeyboard-config libxcb-devel libxml2-devel wayland-protocols wayland-devel"
+makedepends="xkeyboard-config libxcb-devel wayland-devel wayland-protocols"
 depends="xkeyboard-config"
 short_desc="Library to handle keyboard descriptions"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -15,7 +16,7 @@ homepage="https://xkbcommon.org/"
 distfiles="https://github.com/xkbcommon/libxkbcommon/archive/xkbcommon-${version}.tar.gz"
 checksum=270e2ad4ce5699f633e49042114cb68a5697fa1ed45b65c1d96a833cfac20954
 
-pkg_install() {
+post_install() {
 	vlicense LICENSE
 }
 
@@ -27,11 +28,21 @@ libxkbcommon-x11_package() {
 }
 
 libxkbcommon-devel_package() {
-	depends="libxcb-devel ${sourcepkg}-x11>=${version}_${revision} ${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}-x11>=${version}_${revision}
+	 ${sourcepkg}>=${version}_${revision} libxcb-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+	}
+}
+
+libxkbcommon-tools_package() {
+	short_desc+=" - utilities"
+	pkg_install() {
+		vmove usr/bin
+		vmove usr/libexec
+		vmove usr/share/man
 	}
 }


### PR DESCRIPTION
btw I saw this and added libxkbregistry.so.0 to shlibs

`=> WARNING: libxkbcommon-1.0.1_1: libxkbregistry.so.0 not found in common/shlibs!`

Questions:

1. ~~Are those shlibs usually added when there are new ones are found like this, or add only when it's actually needed?~~
`libxkbregistry.so.0` is located at `/usr/lib/libxkbregistry.so.0`, I've added it to common/shlibs

2. ~~Should I add `shlib_provides="libxkbcommon.so.0 libxkbregistry.so.0"` and `shlib_provides="libxkbcommon-x11.so.0"` to package template? I also added it for now, ask me to remove them if it's not supposed to be added~~
I will keep it as before, `shlib_provides` is not added in this commit.