### PR TITLE
packer: update to 1.6.3

### DIFF
--- a/srcpkgs/packer/template
+++ b/srcpkgs/packer/template
@@ -1,6 +1,6 @@
 # Template file for 'packer'
 pkgname=packer
-version=1.6.0
+version=1.6.3
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/packer"
@@ -9,9 +9,9 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MPL-2.0"
 homepage="http://www.packer.io"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=2a135643a837ad58df16e4acc3ac01ad32b61643722a6a027929bbd6baba9435
+checksum=6e92920cef2a30b231cb08cffc5410ff1b7e0921da0c6dea70cdb10684ed73ae
 replaces="packer-bin>=0"
 
 case "$XBPS_TARGET_MACHINE" in
-	i686*|arm*) broken="https://build.voidlinux.org/builders/i686_builder/builds/9375/steps/shell_3/logs/stdio";;
+	arm*) go_ldflags="-linkmode=external";;
 esac


### PR DESCRIPTION
Overflow issue on 32-bit platforms was fixed upstream:

- https://github.com/Azure/azure-sdk-for-go/issues/1993
- https://github.com/hashicorp/packer/pull/6479

arm issue is similar to https://github.com/golang/go/issues/30949, resolved by using system linker.