### PR TITLE
avrdude: build with FTDI support

### DIFF
--- a/srcpkgs/avrdude/template
+++ b/srcpkgs/avrdude/template
@@ -1,15 +1,15 @@
 # Template file for 'avrdude'
-pkgname="avrdude"
+pkgname=avrdude
 version=6.3
-revision=2
+revision=3
 build_style=gnu-configure
-short_desc="An utility to manipulate ROM and EEPROM of AVR microcontrollers"
+hostmakedepends="flex"
+makedepends="elfutils-devel libusb-devel libusb-compat-devel libftdi1-devel"
+depends="avr-libc"
+short_desc="Utility to manipulate ROM and EEPROM of AVR microcontrollers"
 maintainer="allan <mail@may.mooo.com>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.nongnu.org/avrdude/"
 distfiles="$NONGNU_SITE/$pkgname/${pkgname}-$version.tar.gz"
 checksum=0f9f731b6394ca7795b88359689a7fa1fba818c6e1d962513eb28da670e0a196
-hostmakedepends="flex"
-makedepends="elfutils-devel libusb-compat-devel"
-depends="avr-libc"
 conf_files="/etc/avrdude.conf"


### PR DESCRIPTION
A few days ago I've tried to use avrdude for FT2232 controller. But avrdude gave me an error about missing libftdi1. In fact the library was installed, but avrdude wasn't linked to it. So I fixed this problem.