### PR TITLE
pymol: enable for musl, fix byte-compilation.

### DIFF
--- a/srcpkgs/pymol/patches/musl.patch
+++ b/srcpkgs/pymol/patches/musl.patch
@@ -1,0 +1,13 @@
+diff --git a/ov/src/ov_types.h b/ov/src/ov_types.h
+index 6d2ad80..11d1589 100644
+--- ov/src/ov_types.h
++++ ov/src/ov_types.h
+@@ -19,6 +19,8 @@ extern "C" {
+ #include <windows.h>
+ #endif
+ 
++#include <cstddef>
++
+   /* automatically detect 64-bit machines */
+ 
+ #ifndef OV_32_BIT

--- a/srcpkgs/pymol/template
+++ b/srcpkgs/pymol/template
@@ -1,7 +1,7 @@
 # Template file for 'pymol'
 pkgname=pymol
 version=2.3.0
-revision=3
+revision=4
 wrksrc=${pkgname}-open-source-${version}
 build_style="python3-module"
 hostmakedepends="python3"
@@ -10,7 +10,7 @@ makedepends="msgpack-devel python3-numpy freetype-devel libfreeglut-devel glew-d
 depends="python3-numpy tcsh python3-pmw python3-tkinter python3-PyQt5"
 short_desc="PyMOL molecular visualization system"
 maintainer="Brenton Horne <brentonhorne77@gmail.com>"
-license="PyMOL"
+license="custom:PyMOL"
 homepage="https://pymol.org/"
 distfiles="https://github.com/schrodinger/pymol-open-source/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz
  https://c.fsdn.com/allura/p/${pkgname}/icon>${pkgname}.png"
@@ -18,16 +18,30 @@ checksum="62aa21fafd1db805c876f89466e47513809f8198395e1f00a5f5cc40d6f40ed0
  0ea81faaf336becc669a193777d0dca55475d303d1236b57df25cf67ff7c2bcd"
 skip_extraction="${pkgname}.png"
 
-case $XBPS_TARGET_MACHINE in
-	*-musl) broken="segfaults on start";;
-esac
+export PREFIX_PATH="${XBPS_CROSS_BASE}/usr"
+# PREFIX_PATH isn't used for the py3 include path
+CXXFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
 
-# TODO: make it use pkg-config, if possible
-CXXFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include/libxml2
- -I${XBPS_CROSS_BASE}/usr/include/freetype2"
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	makedepends+=" libexecinfo-devel"
+fi
+
+pre_configure() {
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		# execinfo is linked when building for freebsd, force it for linux with musl
+		vsed -e 's@sys.platform.startswith("freebsd")@True@' \
+			-i setup.py
+	fi
+}
 
 post_install() {
 	vlicense LICENSE
 	vinstall "${FILESDIR}/${pkgname}.desktop" 755 usr/share/applications
 	vinstall "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}.png" 644 usr/share/pixmaps
+
+	# these tests are written for python2
+	# LICENSE is vlicense'd
+	rm -r ${DESTDIR}/${py3_sitelib}/pymol/pymol_path/{test,LICENSE}
+
+	vlicense LICENSE
 }


### PR DESCRIPTION
It doesn't segfault anymore :D 

However, it's doing something weird in linking:

```
$ pymol
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/pymol/__init__.py", line 64, in <module>
    import pymol
  File "/usr/lib/python3.8/site-packages/pymol/__init__.py", line 580, in <module>
    import pymol._cmd
ImportError: Error relocating /usr/lib/python3.8/site-packages/pymol/_cmd.so: backtrace_symbols: symbol not found
$ LD_PRELOAD=/lib/libexecinfo.so.1 pymol
 PyMOL(TM) Molecular Graphics System, Version 2.3.0.
 Copyright (c) Schrodinger, LLC.
 All Rights Reserved.
[...]
```

It found the symbol while linking (I guess?) but it somehow wasn't recorded.

---

This is now fixed.