### PR TITLE
New package: gleam-0.11.2

### DIFF
--- a/srcpkgs/gleam/template
+++ b/srcpkgs/gleam/template
@@ -1,0 +1,14 @@
+# Template file for 'gleam'
+pkgname=gleam
+version=0.12.1
+revision=1
+build_style=cargo
+hostmakedepends="pkg-config"
+makedepends="libressl-devel"
+depends="libressl erlang rebar3"
+short_desc="Statically typed language for the Erlang VM"
+maintainer="Luna <luna@l4.pm>"
+license="Apache-2.0"
+homepage="https://github.com/gleam-lang/gleam"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=93797ef144f863120d305691913a21a3c42881c6cbc5a07bb2fe8336456e9aa8


### PR DESCRIPTION
Got successfull crossbuilds to `i686` and `armv7l`.

Tested on x86_64 glibc.