### PR TITLE
ripgrep: use system-provided libpcre2

### DIFF
--- a/srcpkgs/ripgrep/template
+++ b/srcpkgs/ripgrep/template
@@ -1,7 +1,7 @@
 # Template file for 'ripgrep'
 pkgname=ripgrep
 version=12.1.1
-revision=1
+revision=2
 build_style=cargo
 configure_args="--features=pcre2"
 hostmakedepends="ruby-asciidoctor pkg-config"
@@ -12,6 +12,9 @@ license="Unlicense, MIT"
 homepage="https://github.com/BurntSushi/ripgrep/"
 distfiles="https://github.com/BurntSushi/${pkgname}/archive/${version}.tar.gz"
 checksum=2513338d61a5c12c8fea18a0387b3e0651079ef9b31f306050b1f0aaa926271e
+
+# Dynamic linking to libpcre2 even on musl
+export PCRE2_SYS_STATIC=0
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
By default, for musl targets `libpcre2` is linked statically. This patch fixes this and reduces binary size by ~400 KiB for `x86_64-musl` target.
More info here: https://github.com/burntsushi/rust-pcre2/tree/HEAD/pcre2-sys#notes