### PR TITLE
common/build-helper/rust.sh: dynamic linking to libpcre2 on musl

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -38,3 +38,6 @@ export SODIUM_INC_DIR="${XBPS_CROSS_BASE}/usr/lib"
 
 # openssl-sys
 export OPENSSL_NO_VENDOR=1
+
+# pcre2-sys, only necessary for musl targets
+export PCRE2_SYS_STATIC=0

--- a/srcpkgs/ripgrep/template
+++ b/srcpkgs/ripgrep/template
@@ -1,7 +1,7 @@
 # Template file for 'ripgrep'
 pkgname=ripgrep
 version=12.1.1
-revision=1
+revision=2
 build_style=cargo
 configure_args="--features=pcre2"
 hostmakedepends="ruby-asciidoctor pkg-config"


### PR DESCRIPTION
By default, `pcre2-sys` crate use static linking on `musl` targets. This patch fixes such behavior and all Rust crates will automatically use system-provided `libpcre2` on musl.