### PR TITLE
zsh: use /etc/zsh/zprofile instead of /etc/profile, fix paths in docs

### DIFF
--- a/srcpkgs/zsh/files/zprofile
+++ b/srcpkgs/zsh/files/zprofile
@@ -1,0 +1,1 @@
+emulate sh -c 'source /etc/profile'

--- a/srcpkgs/zsh/template
+++ b/srcpkgs/zsh/template
@@ -1,13 +1,13 @@
 # Template file for 'zsh'
 pkgname=zsh
 version=5.8
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_target="all info"
 make_install_args="install.info"
 configure_args="--enable-etcdir=/etc/zsh --enable-zshenv=/etc/zsh/zshenv
  --enable-zlogin=/etc/zsh/zlogin --enable-zlogout=/etc/zsh/zlogout
- --enable-zprofile=/etc/profile --enable-zshrc=/etc/zsh/zshrc
+ --enable-zprofile=/etc/zsh/zprofile --enable-zshrc=/etc/zsh/zshrc
  --enable-maildir-support --enable-function-subdirs
  --enable-fndir=/usr/share/zsh/functions --with-term-lib=ncursesw
  --enable-scriptdir=/usr/share/zsh/scripts --enable-pcre
@@ -25,8 +25,9 @@ distfiles="http://www.zsh.org/pub/zsh-${version}.tar.xz"
 checksum=dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27
 register_shell="/bin/zsh /usr/bin/zsh"
 lib32disabled=yes
+conf_files="/etc/zsh/*"
 
-pre_configure() {
+post_patch() {
 	# Set correct keymap path
 	sed -i 's#/usr/share/keymaps#/usr/share/kbd/keymaps#g' \
 		Completion/Unix/Command/_loadkeys
@@ -36,9 +37,15 @@ pre_configure() {
 		rm -rf Completion/$_fpath
 		sed "s#\s*Completion/$_fpath/\*/\*##g" -i Src/Zle/complete.mdd
 	done
+
 	rm -f Completion/Linux/Command/_{pkgtool,rpmbuild,yast}
 	rm -f Completion/Unix/Command/_{notmuch,osc,systemd}
+
+	vsed -i -e 's,/etc/z,/etc/zsh/z,g' \
+		Doc/zsh.texi Doc/{zsh,zshall,zshoptions,zshmodules}.1
 }
+
 post_install() {
 	vlicense LICENCE
+	vinstall "${FILESDIR}/zprofile" 644 etc/zsh
 }


### PR DESCRIPTION
By default, upstream zsh prefers to use `/etc/zprofile` as a system configuration for login shells. We were overriding this to `/etc/profile`, which is not desirable because it forces bash/dash and zsh to use the same login profile configuration.

This PR moves the zsh profile config to `/etc/zsh/zprofile` (for consistency with other `/etc/zsh/*` configuration files) and, to minimize breakage for existing users, installs a default `zprofile` that just sources `/etc/profile` in sh emulation mode. Because this is a `conf_file`, users can now separate zsh configuration from bash/dash if they desire.

NB: because `/etc/zsh/zprofile` was not an allowed configuration path for prior zsh packages, I do not expect users to have this file, so the first package update should almost universally copy the new `zprofile` in the proper place and carry forward the `/etc/profile` behavior.

As a bonus, I updated the man and texinfo pages to point to the proper paths of these files, hopefully avoiding confusion in the future.

cc: @leahneukirchen @sgn