### PR TITLE
common/shlib: bump neatvnc shlib

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3987,7 +3987,7 @@ libocl.so.2019.07 opencamlib-2019.07_1
 libcglm.so.0 cglm-0.7.6_1
 libfcft.so.3 fcft-2.2.2_1
 libaml.so.0 aml-0.1.0_1
-libneatvnc.so.0 neatvnc-0.2.0_1
+libneatvnc.so.0 neatvnc-0.3.2_1
 libtdjson.so.1.6.0 libtd-1.6.0_1
 libJudy.so.1 judy-1.0.5_1
 libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2


### PR DESCRIPTION
Should've done this in my previous [pr](https://github.com/void-linux/void-packages/pull/25163)