### PR TITLE
bluez-alsa: update to 3.0.0

### DIFF
--- a/srcpkgs/bluez-alsa/template
+++ b/srcpkgs/bluez-alsa/template
@@ -1,10 +1,10 @@
 # Template file for 'bluez-alsa'
 pkgname=bluez-alsa
-version=2.1.0
+version=3.0.0
 revision=1
 build_style=gnu-configure
-configure_args="--enable-aac --disable-hcitop --enable-debug"
-hostmakedepends="pkg-config automake libtool"
+configure_args="--enable-aac --disable-hcitop --enable-debug --enable-manpages"
+hostmakedepends="pkg-config automake libtool pandoc"
 makedepends="alsa-lib-devel fdk-aac-devel libbluetooth-devel libglib-devel
  ortp-devel sbc-devel"
 short_desc="Bluetooth Audio ALSA Backend"
@@ -12,7 +12,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/Arkq/bluez-alsa"
 distfiles="https://github.com/Arkq/bluez-alsa/archive/v${version}.tar.gz"
-checksum=6459f70e47e70b4c04a85acf148381e6c8a2e86bd638aff21870afc6c14b85b0
+checksum=8b9bc36be922c10c6628ddf84b13dfadfeb3ab0bcf72bad842c66f3120abc6b2
 system_accounts="_bluez_alsa"
 _bluez_alsa_groups="audio"
 


### PR DESCRIPTION
- Add `pandoc` dependency for building man pages.