### PR TITLE
Update Waybar, fmt and revbump kodi (+ patch) + update jsoncpp and revbump more stuff

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1359,7 +1359,7 @@ libspeechd.so.2 speech-dispatcher-0.8_1
 libre2.so.7 re2-2020.06.01_1
 libminizip.so.1 minizip-1.2.7_1
 libsrtp2.so.1 libsrtp-2.1.0_1
-libjsoncpp.so.19 jsoncpp-1.8.3_1
+libjsoncpp.so.24 jsoncpp-1.9.4_1
 libesmtp.so.6 libesmtp-1.0.6_4
 libcaca.so.0 libcaca-0.99.beta18_3
 libcaca++.so.0 libcaca-0.99.beta18_3

--- a/common/shlibs
+++ b/common/shlibs
@@ -3577,7 +3577,7 @@ libcotp.so.12 libcotp-1.2.1_1
 libunarr.so.1 libunarr-1.0.1_1
 libretro-gtk-1.so.0 retro-gtk-1.0.0_1
 libmanette-0.2.so.0 libmanette-0.2.1_1
-libfmt.so.6 fmt-5.2.1_1
+libfmt.so.7 fmt-7.0.3_1
 libelementary-calendar.so.0 libio.elementary.calendar-4.2.3_1
 libolm.so.3 olm-3.0.0_1
 libcrypto.so.44 libcrypto44-2.8.2_1

--- a/srcpkgs/LGOGDownloader/template
+++ b/srcpkgs/LGOGDownloader/template
@@ -1,7 +1,7 @@
 # Template file for 'LGOGDownloader'
 pkgname=LGOGDownloader
 version=3.7
-revision=2
+revision=3
 wrksrc="lgogdownloader-${version}"
 build_style=cmake
 hostmakedepends="pkg-config"

--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,13 +1,13 @@
 # Template file for 'Waybar'
 pkgname=Waybar
-version=0.9.3
+version=0.9.4
 revision=1
 _date_version=3.0.0
 create_wrksrc=yes
 build_wrksrc=${pkgname}-${version}
 build_style=meson
 configure_args="-Dgtk-layer-shell=enabled -Dlibudev=enabled -Dman-pages=enabled
- -Dsystemd=disabled
+ -Dsystemd=disabled -Drfkill=enabled
  -Dlibnl=$(vopt_if libnl enabled disabled)
  -Dpulseaudio=$(vopt_if pulseaudio enabled disabled)
  -Ddbusmenu-gtk=$(vopt_if dbusmenugtk enabled disabled)
@@ -29,7 +29,7 @@ changelog="https://github.com/Alexays/Waybar/releases"
 distfiles="https://github.com/Alexays/Waybar/archive/${version}.tar.gz
  https://github.com/HowardHinnant/date/archive/v${_date_version}.tar.gz
  https://github.com/mesonbuild/hinnant-date/releases/download/${_date_version}-1/hinnant-date.zip"
-checksum="15cadd05c6a366fd99a92b0f149974c697902c4683c50e2af69f3e59571793e5
+checksum="d49c09ee253ca9cc9688d1b4d8602adc9bdae613b02e2fa1a2e7277ddc9e82e8
  87bba2eaf0ebc7ec539e5e62fc317cb80671a337c1fb1b84cb9e4d42c6dbebe3
  6ccaf70732d8bdbd1b6d5fdf3e1b935c23bf269bda12fdfd0e561276f63432fe"
 

--- a/srcpkgs/cmake-gui/template
+++ b/srcpkgs/cmake-gui/template
@@ -1,7 +1,7 @@
 # Template file for 'cmake-gui'
 pkgname=cmake-gui
 version=3.18.2
-revision=1
+revision=2
 wrksrc="cmake-${version}"
 build_style=cmake
 configure_args="

--- a/srcpkgs/fmt/template
+++ b/srcpkgs/fmt/template
@@ -1,6 +1,6 @@
 # Template file for 'fmt'
 pkgname=fmt
-version=6.2.1
+version=7.0.3
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DFMT_DOC=OFF -DFMT_TEST=OFF"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/fmtlib/fmt"
 distfiles="https://github.com/fmtlib/fmt/archive/${version}.tar.gz"
-checksum=5edf8b0f32135ad5fafb3064de26d063571e95e8ae46829c2f4f4b52696bbff0
+checksum=b4b51bc16288e2281cddc59c28f0b4f84fed58d016fb038273a09f05f8473297
 
 post_install() {
 	vlicense LICENSE.rst LICENSE

--- a/srcpkgs/jsoncpp/template
+++ b/srcpkgs/jsoncpp/template
@@ -1,7 +1,7 @@
 # Template build file for 'jsoncpp'.
 pkgname=jsoncpp
-version=1.8.4
-revision=2
+version=1.9.4
+revision=1
 build_style=cmake
 configure_args="-DBUILD_STATIC_LIBS=1 -DBUILD_SHARED_LIBS=1 -DJSONCPP_WITH_TESTS=0"
 short_desc="A JSON implementation in C++"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain, MIT"
 homepage="https://github.com/open-source-parsers/jsoncpp"
 distfiles="https://github.com/open-source-parsers/${pkgname}/archive/${version}.tar.gz"
-checksum=c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6
+checksum=e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999
 
 CXXFLAGS="-D_GLIBCXX_USE_C99_STDIO=1"
 

--- a/srcpkgs/kodi-rpi/template
+++ b/srcpkgs/kodi-rpi/template
@@ -1,6 +1,6 @@
 # Template file for 'kodi-rpi'
 pkgname=kodi-rpi
-version=18.7.1
+version=18.8
 revision=1
 _codename="Leia"
 wrksrc="xbmc-${version}-${_codename}"
@@ -10,9 +10,9 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.kodi.tv/"
 distfiles="https://github.com/xbmc/xbmc/archive/${version}-${_codename}.tar.gz"
-checksum=5cfec391bcd168bbd4f9d38a6c8ec93e42e040cf82cf6ebf23db5e86753816fb
+checksum=6deb28f725880b1ab6c5920b55ef1190a79b0684ffb30b6e13b199d23a0af296
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
-python_version=2 #unverified
+python_version=2
 patch_args="-Np1"
 
 nopie=yes

--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi'
 pkgname=kodi
 version=18.8
-revision=1
+revision=2
 _codename="Leia"
 wrksrc="xbmc-${version}-${_codename}"
 build_style=cmake
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.kodi.tv"
 distfiles="https://github.com/xbmc/xbmc/archive/${version}-${_codename}.tar.gz"
 checksum=6deb28f725880b1ab6c5920b55ef1190a79b0684ffb30b6e13b199d23a0af296
-python_version=2 #unverified
+python_version=2
 patch_args="-Np1"
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
 

--- a/srcpkgs/mkvtoolnix/template
+++ b/srcpkgs/mkvtoolnix/template
@@ -1,7 +1,7 @@
 # Template file for 'mkvtoolnix'
 pkgname=mkvtoolnix
 version=50.0.0
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper=qmake
 configure_args="--with-docbook-xsl-root=/usr/share/xsl/docbook --enable-qt

--- a/srcpkgs/polybar/template
+++ b/srcpkgs/polybar/template
@@ -1,7 +1,7 @@
 # Template file for 'polybar'
 pkgname=polybar
 version=3.4.3
-revision=1
+revision=2
 wrksrc="$pkgname"
 build_style=cmake
 configure_args="

--- a/srcpkgs/sysdig/template
+++ b/srcpkgs/sysdig/template
@@ -1,7 +1,7 @@
 # Template file for 'sysdig'
 pkgname=sysdig
 version=0.27.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DSYSDIG_VERSION=${version} -DUSE_BUNDLED_DEPS=OFF
  -DUSE_BUNDLED_B64=ON -DUSE_BUNDLED_JQ=ON -DBUILD_DRIVER=OFF

--- a/srcpkgs/upmpdcli/template
+++ b/srcpkgs/upmpdcli/template
@@ -1,7 +1,7 @@
 # Template file for 'upmpdcli'.
 pkgname=upmpdcli
 version=1.4.14
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config tar"
 makedepends="jsoncpp-devel libmicrohttpd-devel libmpdclient-devel libupnpp-devel"


### PR DESCRIPTION
Closes #23451

@Hoshpak please give ok on patch, otherwise I can just revbump.

Waybar built through `xbps-src` isn't dynamically linked against `libfmt.so`, I'm not sure why... *EDIT*: it's inlining and LTO magic.