### PR TITLE
python3-google-api-python-client: update to 1.12.3.

### DIFF
--- a/srcpkgs/python3-google-api-python-client/template
+++ b/srcpkgs/python3-google-api-python-client/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-google-api-python-client'
 pkgname=python3-google-api-python-client
-version=1.9.3
+version=1.12.3
 revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="Apache-2.0"
 homepage="https://github.com/googleapis/google-api-python-client"
 distfiles="${PYPI_SITE}/g/google-api-python-client/google-api-python-client-${version}.tar.gz"
-checksum=220349ce189a85229fc46875d467101318495a4a735c0ff2f165b9bdbc7511a0
+checksum=844ef76bda585ea0ea2d5e7f8f9a0eb10d6e2eba66c4fea0210ec7843941cb1a
 
 post_patch() {
 	# unittest2 is python2 thing.

--- a/srcpkgs/python3-httplib2/template
+++ b/srcpkgs/python3-httplib2/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-httplib2'
 pkgname=python3-httplib2
-version=0.14.0
-revision=4
+version=0.18.1
+revision=1
 create_wrksrc=yes
 build_wrksrc="httplib2-${version}"
 build_style=python3-module
@@ -14,7 +14,7 @@ homepage="https://github.com/httplib2/httplib2"
 changelog="https://raw.githubusercontent.com/httplib2/httplib2/master/CHANGELOG"
 distfiles="${PYPI_SITE}/h/httplib2/httplib2-${version}.tar.gz
  https://raw.githubusercontent.com/httplib2/httplib2/master/LICENSE>LICENSE.txt"
-checksum="34537dcdd5e0f2386d29e0e2c6d4a1703a3b982d34c198a5102e6e5d6194b107
+checksum="8af66c1c52c7ffe1aa5dc4bcd7c769885254b0756e6e69f953c7f0ab49a70ba3
  589eec38f72df2be203711d3b8cbece9b908c5e7ff00bc3cab7f63bae9e366b4"
 
 post_install() {


### PR DESCRIPTION
Also update python3-httplib to 0.18.1 since python3-google-api-python-client requires >= 0.15.0