### PR TITLE
lazarus: update to 2.0.10

### DIFF
--- a/srcpkgs/lazarus/template
+++ b/srcpkgs/lazarus/template
@@ -1,7 +1,9 @@
 # Template file for 'lazarus'
 pkgname=lazarus
-version=2.0.8
+version=2.0.10
 revision=1
+# For adding a revision suffix to version on the source tarball file
+_version_revision_suffix="-2"
 archs="x86_64 i686"
 wrksrc=lazarus
 hostmakedepends="fpc rsync"
@@ -11,8 +13,8 @@ short_desc="Delphi-like IDE for FreePascal"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, MPL-2.0, LGPL-2.0-or-later"
 homepage="http://www.lazarus.freepascal.org"
-distfiles="${SOURCEFORGE_SITE}/project/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${version}/lazarus-${version}.tar.gz"
-checksum=90b037280e5c63265bc25a63e6e78c9cb979fc4b45aa84606e3856b09ac791c5
+distfiles="${SOURCEFORGE_SITE}/project/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${version}/lazarus-${version}${_version_revision_suffix}.tar.gz"
+checksum=64d5626468dd24a3332b205f3abd0a581ab7de1b060a2d57e21864066cfd43b7
 nopie=yes
 lib32disabled=yes
 


### PR DESCRIPTION
The filename structure of the source tarball for 2.0.10 is different. A "-2" was added at the end as a revision number for 2.0.10. This was not the case for earlier 2.0.x versions.

`revision` variable is reserved for package revision. Can't add "-2" on `version` because xlint complains `version must not contain the characters : or -`. So had to add a `_version_revision_suffix` variable to fix this.