### PR TITLE
nicotine+: update to 2.1.2

### DIFF
--- a/srcpkgs/nicotine+/template
+++ b/srcpkgs/nicotine+/template
@@ -1,14 +1,14 @@
 # Template file for 'nicotine+'
 pkgname=nicotine+
-version=2.0.1
-revision=2
+version=2.1.2
+revision=1
 wrksrc="nicotine-plus-${version}"
 build_style=python3-module
-hostmakedepends="python3"
-depends="gtk+3 python3-gobject python3-miniupnpc python3-mutagen"
+hostmakedepends="python3-setuptools gettext"
+depends="gtk+3 python3-gobject python3-miniupnpc python3-pytaglib"
 short_desc="Soulseek music-sharing client written in Python"
 maintainer="doggone <doggone@airmail.cc>"
 license="GPL-3.0-or-later"
 homepage="https://nicotine-plus.org"
 distfiles="https://github.com/Nicotine-Plus/nicotine-plus/archive/${version}.tar.gz"
-checksum=229acf6e287e1c3ae7d07b04b85230c3fa2edc0c17298583e2f13dd986bbda5a
+checksum=3ed18ade97183c632836eb8e304a515fc19a35babb46cc6e6747bcfd8205dcdf

--- a/srcpkgs/python3-pytaglib/template
+++ b/srcpkgs/python3-pytaglib/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-pytaglib'
+pkgname=python3-pytaglib
+version=1.4.6
+revision=1
+wrksrc="pytaglib-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel taglib-devel"
+short_desc="Python bindings for the TagLib C++ library"
+maintainer="Stefano Ragni <st3r4g@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/supermihi/pytaglib"
+distfiles="https://github.com/supermihi/pytaglib/archive/v${version}.tar.gz"
+checksum=360b12d5b4c948cebf75acf86fac6b33a3f044eab6fcfe8949a1cd0f9c22bd25


### PR DESCRIPTION
Nicotine+ switched from `mutagen` to `pytaglib`. The latter is not in the repos yet.
I am not sure whether `GPL-3.0-only` or `GPL-3.0-or-later` is right for `pytaglib`

Tested on x86_64-musl