### PR TITLE
mpv: compile with uchardet

### DIFF
--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv'
 pkgname=mpv
 version=0.32.0
-revision=3
+revision=4
 build_style=waf3
 configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
  --enable-dvdnav --enable-cdda --enable-libmpv-shared
@@ -14,7 +14,7 @@ configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
 hostmakedepends="pkg-config python3-docutils perl $(vopt_if wayland wayland-devel)"
 makedepends="MesaLib-devel ffmpeg-devel harfbuzz-devel lcms2-devel libXv-devel
  libass-devel libbluray-devel libcdio-paranoia-devel libdvdnav-devel
- libguess-devel libuuid-devel libva-glx-devel rubberband-devel
+ libguess-devel libuuid-devel libva-glx-devel rubberband-devel uchardet-devel
  libarchive-devel $(vopt_if alsa alsa-lib-devel) $(vopt_if caca libcaca-devel)
  $(vopt_if jack jack-devel) $(vopt_if lua lua52-devel)
  $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if sdl2 SDL2-devel)


### PR DESCRIPTION
"If mpv was not compiled with uchardet, then utf-8 is the effective default."

non-utf8 subtitles are broken without this

ref: https://mpv.io/manual/stable/#subtitles