### PR TITLE
wayfire: add image build option, session file.

### DIFF
--- a/srcpkgs/wayfire/template
+++ b/srcpkgs/wayfire/template
@@ -1,11 +1,12 @@
 # Template file for 'wayfire'
 pkgname=wayfire
 version=0.5.0
-revision=1
+revision=2
 _utils_commit=f9b5eba437a04a0d1fb9f00a0fdb88c12b9f6b27
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
-makedepends="wf-config-devel wlroots-devel cairo-devel"
+makedepends="wf-config-devel wlroots-devel cairo-devel
+ $(vopt_if image 'libjpeg-turbo-devel libpng-devel')"
 depends="xorg-server-xwayland $(vopt_if elogind elogind)"
 short_desc="3D wayland compositor"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
@@ -16,7 +17,9 @@ distfiles="https://github.com/WayfireWM/wayfire/archive/${version}.tar.gz
 checksum="24c1a2c963dac5af762f87cd024bc3dd736ec9a28a6735d357a05e8f6502e8aa
  5c3e8bfefd74083a2548b6a95a070000cf73591bfe78335413da5c7fb82340cb"
 
-build_options="elogind"
+build_options="elogind image"
+build_options_default="image"
+desc_option_image="Enable JPEG and PNG support"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"
@@ -34,6 +37,7 @@ post_install() {
 	fi
 	vlicense LICENSE
 	vsconf wayfire.ini
+	vinstall wayfire.desktop 0644 usr/share/wayland-sessions
 }
 
 wayfire-devel_package() {


### PR DESCRIPTION
The session file used by display managers isn't installed by the build
system.

Closes #25260 