### PR TITLE
grub: remove noarch, build manpages.

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,8 +1,8 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.04
-revision=3
-hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf"
+revision=4
+hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf help2man"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel fuse-devel"
 depends="os-prober"
@@ -162,7 +162,6 @@ grub-utils_package() {
 	}
 }
 grub-x86_64-efi_package() {
-	archs=noarch
 	depends="grub>=$version dosfstools efibootmgr"
 	short_desc+=" - x86_64 EFI support"
 	pkg_install() {
@@ -170,7 +169,6 @@ grub-x86_64-efi_package() {
 	}
 }
 grub-i386-efi_package() {
-	archs=noarch
 	depends="grub>=$version dosfstools efibootmgr"
 	short_desc+=" - i386 EFI support"
 	pkg_install() {
@@ -178,7 +176,6 @@ grub-i386-efi_package() {
 	}
 }
 grub-i386-coreboot_package() {
-	archs=noarch
 	depends="grub>=$version"
 	short_desc+=" - i386 coreboot support"
 	pkg_install() {
@@ -200,7 +197,6 @@ grub-xen_package() {
 	}
 }
 grub-arm64-efi_package() {
-	archs=noarch
 	depends="grub>=$version dosfstools efibootmgr"
 	short_desc+=" - arm64 EFI support"
 	pkg_install() {
@@ -208,7 +204,6 @@ grub-arm64-efi_package() {
 	}
 }
 grub-powerpc-ieee1275_package() {
-	archs=noarch
 	depends="grub>=$version powerpc-utils"
 	short_desc+=" - powerpc Open Firmware support"
 	pkg_install() {


### PR DESCRIPTION
Requires help2man.

I think we should have grub man pages in man.voidlinux.org, because their documentation is kinda bad overall.