### PR TITLE
newsboat: update to 2.21.

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -1,7 +1,7 @@
 # Template file for 'newsboat'
 pkgname=newsboat
-version=2.19
-revision=2
+version=2.21
+revision=1
 build_style=configure
 build_helper="rust"
 configure_script="./config.sh"
@@ -16,7 +16,7 @@ license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"
 distfiles="https://newsboat.org/releases/${version}/newsboat-${version}.tar.xz"
-checksum=ba484c825bb903daf6d33d55126107b59e41111b455d368362208f1825403d1b
+checksum=0c46b3dd46bb578dd6dd4915db4cfdffb4352ab258f251080ad14655c75a9c31
 
 do_check() {
 	make test
@@ -25,7 +25,7 @@ do_check() {
 
 post_install() {
 	vlicense LICENSE
-	vsconf doc/example-bookmark-plugin.sh bookmark-plugin.sh
+	vsconf doc/examples/example-bookmark-plugin.sh bookmark-plugin.sh
 	mv "${DESTDIR}/usr/share/doc/newsboat/examples/config" \
 		"${DESTDIR}/usr/share/examples/newsboat"
 	vcopy contrib usr/share/examples/newsboat


### PR DESCRIPTION
Newsboat update to 2.21

Tested locally and functions.
Signed-off-by: Joseph Benden <joe@benden.us>