### PR TITLE
mpd: update to 0.22.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3992,3 +3992,4 @@ libJudy.so.1 judy-1.0.5_1
 libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2
 libSeExpr2Editor.so.3 seexpr-krita-3.4.4.0_1
 libSeExpr2.so.3 seexpr-krita-3.4.4.0_1
+liburing.so.1 liburing-0.7_1

--- a/srcpkgs/mpd/INSTALL
+++ b/srcpkgs/mpd/INSTALL
@@ -1,5 +1,5 @@
 case "$ACTION" in
 post)
-	setcap 'cap_sys_nice=eip' usr/bin/mpd
+	setcap 'cap_sys_nice,cap_ipc_lock=eip' usr/bin/mpd
 	;;
 esac

--- a/srcpkgs/mpd/files/mpd/run
+++ b/srcpkgs/mpd/files/mpd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
+[ -r conf ] && . ./conf
 install -d -m 0755 -o mpd -g mpd /run/mpd
-exec mpd --no-daemon
+exec mpd --no-daemon ${OPTS:-}

--- a/srcpkgs/mpd/template
+++ b/srcpkgs/mpd/template
@@ -1,6 +1,6 @@
 # Template file for 'mpd'
 pkgname=mpd
-version=0.21.26
+version=0.22.1
 revision=1
 build_style=meson
 configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
@@ -8,20 +8,22 @@ configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
  -Dzzip=enabled -Dsmbclient=disabled -Dsystemd=disabled -Dqobuz=disabled
  -Dchromaprint=disabled -Dsoxr=enabled -Dadplug=disabled
  -Dfluidsynth=disabled -Dgme=disabled -Dwildmidi=disabled -Dsidplay=disabled
- -Dshine=disabled -Ddocumentation=true -Daudiofile=enabled -Dtremor=disabled
- -Dsolaris_output=disabled
+ -Dshine=disabled -Ddocumentation=enabled -Daudiofile=enabled -Dtremor=disabled
+ -Dsolaris_output=disabled -Dhtml_manual=false -Dmanpages=true
  -Djack=$(vopt_if jack enabled disabled) -Dlame=$(vopt_if lame enabled disabled)
  -Dao=$(vopt_if libao enabled disabled) -Dmpcdec=$(vopt_if mpcdec enabled disabled)
  -Dsndio=$(vopt_if sndio enabled disabled) -Dpulse=$(vopt_if pulseaudio enabled disabled)
  -Dwavpack=$(vopt_if wavpack enabled disabled) -Dcdio_paranoia=$(vopt_if cdio enabled disabled)
- -Dopenal=$(vopt_if openal enabled disabled) -Dshout=$(vopt_if shoutcast enabled disabled)"
+ -Dopenal=$(vopt_if openal enabled disabled) -Dshout=$(vopt_if shoutcast enabled disabled)
+ -Dio_uring=$(vopt_if io_uring enabled disabled)"
 conf_files="/etc/mpd.conf"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config python3-Sphinx"
 makedepends="avahi-glib-libs-devel boost-devel faad2-devel ffmpeg-devel
  libcurl-devel libid3tag-devel libmad-devel libmikmod-devel libmms-devel
  libmodplug-devel libmpdclient-devel libnfs-devel libsamplerate-devel
  libsoup-devel libupnp1.8-devel mpg123-devel opus-devel yajl-devel
  zziplib-devel libsoxr-devel audiofile-devel twolame-devel
+ $(vopt_if io_uring 'liburing-devel')
  $(vopt_if cdio 'libcdio-paranoia-devel') $(vopt_if shoutcast 'libshout-devel')
  $(vopt_if jack 'jack-devel') $(vopt_if lame 'lame-devel')
  $(vopt_if libao 'libao-devel') $(vopt_if mpcdec 'libmpcdec-devel')
@@ -35,8 +37,9 @@ license="GPL-2.0-or-later"
 homepage="https://www.musicpd.org/"
 changelog="https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/v${version}/NEWS"
 distfiles="https://www.musicpd.org/download/mpd/${version%.*}/mpd-${version}.tar.xz"
-checksum=f9e68221c7a6829ec02f281eb313b2f24182020f5eb65ab22b337e6169ea4eea
+checksum=408464093d09c73ceecafc201defcbaba2193cb30ad0aaf1241459a410fecaf3
 LDFLAGS+=" -Wl,-z,stack-size=1048576"
+patch_args="-Np1"
 
 system_accounts="mpd"
 mpd_homedir="/var/lib/mpd"
@@ -47,19 +50,15 @@ make_dirs="
  /var/lib/mpd/playlists 0755 mpd mpd"
 
 # Package build options
-build_options="jack lame mpcdec pulseaudio libao wavpack sndio cdio openal shoutcast"
+build_options="jack lame mpcdec pulseaudio libao wavpack sndio cdio openal shoutcast io_uring"
 desc_option_cdio="Enable libcdio_paranoia input plugin"
 desc_option_openal="Enable OpenAL output plugin"
+desc_option_io_uring="Enable support for using liburing"
 build_options_default="jack pulseaudio libao sndio cdio shoutcast"
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtest=true"
 fi
-
-pre_configure() {
-	# We only want manpages
-	sed -n -e '1p' -i doc/meson.build
-}
 
 post_install() {
 	vconf doc/mpdconf.example mpd.conf


### PR DESCRIPTION
mpd update to 0.22; and addition to `common/shlibs` for `liburing`.

Tested locally and seems OK.

Signed-off-by: Joseph Benden <joe@benden.us>