### PR TITLE
virtualbox-ose: make vboxservice depend on dbus

### DIFF
--- a/srcpkgs/virtualbox-ose/files/vboxservice/run
+++ b/srcpkgs/virtualbox-ose/files/vboxservice/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+sv check dbus >/dev/null || exit 1
 exec VBoxService -f

--- a/srcpkgs/virtualbox-ose/template
+++ b/srcpkgs/virtualbox-ose/template
@@ -1,7 +1,7 @@
 # Template file for 'virtualbox-ose'
 pkgname=virtualbox-ose
 version=6.1.14
-revision=3
+revision=4
 wrksrc="VirtualBox-${version%*a}"
 short_desc="General-purpose full virtualizer for x86 hardware"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
vboxservice will give an error message if dbus is not started.
We should check that dbus is running before starting the
service.