### PR TITLE
ibus-bamboo: update to 0.6.7

### DIFF
--- a/srcpkgs/ibus-bamboo/template
+++ b/srcpkgs/ibus-bamboo/template
@@ -1,7 +1,7 @@
 # Template file for 'ibus-bamboo'
 pkgname=ibus-bamboo
-version=0.6.6
-revision=2
+version=0.6.7
+revision=1
 build_style=go
 makedepends="libXtst-devel libX11-devel"
 depends="ibus"
@@ -10,7 +10,7 @@ maintainer="ndgnuh <ndgnuh99@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/BambooEngine/ibus-bamboo"
 distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum="c51651bea965fe66ae89a2f08521ae1840ca5d89b57ab41472ba0ef9fdb9b60d"
+checksum="92d49fe232f241b3e62348c49883aed8a439f256bf6c39034270e069e6c34563"
 conf_files="/usr/share/ibus-bamboo/data/macro.tpl.txt"
 
 do_configure() {


### PR DESCRIPTION
- Boost typing speed upto 20ms/key in every mode
- Introduce default input mode options