### PR TITLE
python3-pyelftools: don't provides readelf alternatives

### DIFF
--- a/srcpkgs/python3-pyelftools/template
+++ b/srcpkgs/python3-pyelftools/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pyelftools'
 pkgname=python3-pyelftools
 version=0.25
-revision=4
+revision=5
 wrksrc="pyelftools-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ license="Public Domain"
 homepage="https://github.com/eliben/pyelftools"
 distfiles="${PYPI_SITE}/p/pyelftools/pyelftools-${version}.tar.gz"
 checksum=89c6da6f56280c37a5ff33468591ba9a124e17d71fe42de971818cbff46c1b24
-alternatives="pyelftools:readelf:/usr/bin/readelf.py3"
+alternatives="pyelftools:readelf.py:/usr/bin/readelf.py3"
 
 post_install() {
 	mv $DESTDIR/usr/bin/readelf.py $DESTDIR/usr/bin/readelf.py3


### PR DESCRIPTION
`/usr/bin/readelf` is provided by binutils.
This alternatives were incorrect from very begining.