### PR TITLE
mesa: update to 20.2.1

### DIFF
--- a/srcpkgs/mesa/patches/add-use-elf-tls.patch
+++ b/srcpkgs/mesa/patches/add-use-elf-tls.patch
@@ -9,10 +9,12 @@ index d228de0..972cd79 100644
  endif
  
  # Android uses emutls for versions <= P/28. For USE_ELF_TLS we need ELF TLS.
--if not ['windows', 'freebsd'].contains(host_machine.system()) and (not with_platform_android or get_option('platform-sdk-version') >= 29)
+ use_elf_tls = false
+-if not ['windows', 'freebsd', 'openbsd'].contains(host_machine.system()) and (not with_platform_android or get_option('platform-sdk-version') >= 29)
 +with_use_elf_tls = get_option('use-elf-tls')
-+if not ['windows', 'freebsd'].contains(host_machine.system()) and with_use_elf_tls and (not with_platform_android or get_option('platform-sdk-version') >= 29)
++if not ['windows', 'freebsd', 'openbsd'].contains(host_machine.system()) and with_use_elf_tls and (not with_platform_android or get_option('platform-sdk-version') >= 29)
    pre_args += '-DUSE_ELF_TLS'
+   use_elf_tls = true
  endif
 
 diff --git meson_options.txt meson_options.txt

--- a/srcpkgs/mesa/patches/musl.patch
+++ b/srcpkgs/mesa/patches/musl.patch
@@ -9,8 +9,8 @@
  #include "pipe/p_compiler.h"
  #include "pipe/p_state.h"
  
---- src/gallium/state_trackers/nine/threadpool.h.orig	2015-05-07 14:10:53.443337212 +0200
-+++ src/gallium/state_trackers/nine/threadpool.h	2015-05-07 14:11:04.210307653 +0200
+--- src/gallium/frontends/nine/threadpool.h.orig	2015-05-07 14:10:53.443337212 +0200
++++ src/gallium/frontends/nine/threadpool.h	2015-05-07 14:11:04.210307653 +0200
 @@ -24,6 +24,8 @@
  #ifndef _THREADPOOL_H_
  #define _THREADPOOL_H_
@@ -20,18 +20,16 @@
  #define MAXTHREADS 1
  
  struct threadpool {
---- src/util/rand_xor.c.orig	2017-06-20 00:38:57.199474067 +0200
-+++ src/util/rand_xor.c	2017-06-20 00:40:31.351279557 +0200
-@@ -23,7 +23,9 @@
-  */
- 
- #if defined(__linux__)
-+#include <sys/types.h>
- #include <sys/file.h>
-+#include <sys/stat.h>
+--- src/util/rand_xor.c.orig	2020-10-03 12:27:48.489024729 +0200
++++ src/util/rand_xor.c	2020-10-03 12:31:05.927113521 +0200
+@@ -28,6 +28,7 @@
+ #if defined(HAVE_GETRANDOM)
+ #include <sys/random.h>
+ #endif
++#include <sys/types.h>		/* size_t, ssize_t */
  #include <unistd.h>
  #include <fcntl.h>
- #else
+ #endif
 --- src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
 +++ src/amd/vulkan/winsys/amdgpu/radv_amdgpu_winsys.h
 @@ -28,6 +28,8 @@
@@ -43,8 +41,8 @@
  #include "radv_radeon_winsys.h"
  #include "ac_gpu_info.h"
  #include "addrlib/addrinterface.h"
---- src/gallium/state_trackers/nine/nine_debug.c.orig	2020-03-06 07:46:48.278918421 +0100
-+++ src/gallium/state_trackers/nine/nine_debug.c	2020-03-06 07:51:32.919964119 +0100
+--- src/gallium/frontends/nine/nine_debug.c.orig	2020-03-06 07:46:48.278918421 +0100
++++ src/gallium/frontends/nine/nine_debug.c	2020-03-06 07:51:32.919964119 +0100
 @@ -65,7 +65,7 @@ _nine_debug_printf( unsigned long flag,
  {
      static boolean first = TRUE;

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,6 +1,6 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=20.1.9
+version=20.2.1
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
@@ -23,7 +23,7 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=b251ca0769b722058986640d48f8457c596142cfbee1a83cba91b83391427382
+checksum=d1a46d9a3f291bc0e0374600bdcb59844fa3eafaa50398e472a36fc65fd0244a
 
 build_options="wayland"
 build_options_default="wayland"
@@ -146,6 +146,11 @@ else
 	configure_args+=" -Dgallium-vdpau=false -Dgallium-va=false -Dgallium-xvmc=false"
 fi
 
+# empty values introduced by leading comma are not allowed; the whole enumeration can be empty
+# _gallium_drivers is not affected by this problem
+_vulkan_drivers=${_vulkan_drivers/=,/=}
+_dri_drivers=${_dri_drivers/=,/=}
+
 configure_args+=" ${_gallium_drivers} ${_vulkan_drivers} ${_dri_drivers}"
 
 if [ "$_have_vulkan" ]; then
@@ -180,7 +185,7 @@ post_configure() {
 }
 
 post_install() {
-	vlicense docs/license.html
+	vlicense docs/license.rst
 	case "$XBPS_TARGET_MACHINE" in
 		i686*)
 			vsed -e 's#/usr/lib/#/usr/lib32/#g' \


### PR DESCRIPTION
This updates mesa to 20.2.0

Several things to keep in mind:
Announcement happened only on their mailing list https://lists.freedesktop.org/archives/mesa-announce/2020-September/000600.html
20.1.9 was released later but new games may still need 20.2.x to work.

I tested compiling musl and hope this does not cause run time problems for NVIDIA or Intel graphic cards.

The game Horizon Zero Dawn actually runs with 20.2.0 for me (on 20.1.9 and lower the game crashes during the intro or within seconds at the main menu.

I have checked this on one game so far. I'll test it on other games in the next hours (Radeon RX 590).
It would be nice if others would check it on their setups.

