### PR TITLE
gnome-desktop, gnome-shell, mutter: update to 3.38.1.

### DIFF
--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
-version=3.38.0
+version=3.38.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-desktop"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=089dbbe3c66fe5575659a4a385d5d4bbd99cf637034df317f21cf586b5dd6b90
+checksum=17903513fed60814e967512dd892751cb6a1d2716136232884bc65bd53cc3be0
 
 build_options="gir"
 build_options_default="gir"

--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
-version=3.38.0
+version=3.38.1
 revision=1
 build_style=meson
 build_helper=gir
@@ -21,7 +21,7 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeShell"
 changelog="https://raw.githubusercontent.com/GNOME/gnome-shell/gnome-3-30/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=c626403bc0875ee6da8c7a62ac0cee312badb523af073cb166125015a75a0a97
+checksum=b789e3296463c4cbfa329ad1724df38439c3e6d7537a01025cd8f2fec8c90bb4
 
 # needs X
 do_check() {

--- a/srcpkgs/mutter/patches/dont-pull-generated-headers.patch
+++ b/srcpkgs/mutter/patches/dont-pull-generated-headers.patch
@@ -1,0 +1,49 @@
+From ff379fb93ae2539bf9fae70ccc8e0351e5665fb0 Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Mon, 5 Oct 2020 12:13:07 +0200
+Subject: [PATCH] backend: Don't pull generated headers (indirectly)
+
+Use a typedef for MetaRemoteDesktop, so tests poking MetaBackend don't
+indirectly depend upon generated headers. This is arguably a code fix
+for a build system bug.
+
+https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1470
+
+Fixes: https://gitlab.gnome.org/GNOME/mutter/-/issues/1449
+(or something...)
+---
+ src/backends/meta-backend-private.h | 4 ----
+ src/backends/meta-backend-types.h   | 4 ++++
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git src/backends/meta-backend-private.h src/backends/meta-backend-private.h
+index 6d7d3ad758..5f4981fda5 100644
+--- src/backends/meta-backend-private.h
++++ src/backends/meta-backend-private.h
+@@ -42,10 +42,6 @@
+ #include "backends/meta-settings-private.h"
+ #include "core/util-private.h"
+ 
+-#ifdef HAVE_REMOTE_DESKTOP
+-#include "backends/meta-remote-desktop.h"
+-#endif
+-
+ #define DEFAULT_XKB_RULES_FILE "evdev"
+ #define DEFAULT_XKB_MODEL "pc105+inet"
+ 
+diff --git src/backends/meta-backend-types.h src/backends/meta-backend-types.h
+index 4753c07440..146a8c3d7c 100644
+--- src/backends/meta-backend-types.h
++++ src/backends/meta-backend-types.h
+@@ -59,4 +59,8 @@ typedef struct _MetaScreenCastStream MetaScreenCastStream;
+ 
+ typedef struct _MetaWaylandCompositor MetaWaylandCompositor;
+ 
++#ifdef HAVE_REMOTE_DESKTOP
++typedef struct _MetaRemoteDesktop MetaRemoteDesktop;
++#endif
++
+ #endif /* META_BACKEND_TYPE_H */
+-- 
+GitLab
+

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,6 +1,6 @@
 # Template file for 'mutter'
 pkgname=mutter
-version=3.38.0
+version=3.38.1
 revision=1
 build_helper="gir"
 build_style=meson
@@ -18,9 +18,16 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/Mutter/"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=058ed13d102085d3e9b6fa5564c66050a478c364a0cc55bc844fea3ddcd90eab
+checksum=e921570c9fdf63805dbd40aa21daa05504a1b9a21432d6119c54c17ee0217a33
 shlib_provides="libmutter-clutter-7.so libmutter-cogl-7.so
  libmutter-cogl-pango-7.so libmutter-cogl-path-7.so"
+
+case "$XBPS_MACHINE" in i686*)
+	pre_build() {
+		ninja ${makejobs} -C build src/meta-dbus-display-config.h
+	}
+;;
+esac
 
 # needs X
 do_check() {


### PR DESCRIPTION
### TODO:

- [x] mutter: fix build for `i686*`

<details>
<summary>
<b>
from <a href="https://travis-ci.org/github/void-linux/void-packages/jobs/733149209" target="_blank">old Travis log</a>:
</b>
</summary>

```
[188/863] Compiling C object src/tests/clutter/conform/timeline.p/.._.._clutter-test-utils.c.o
FAILED: src/tests/clutter/conform/timeline.p/.._.._clutter-test-utils.c.o 
cc -Isrc/tests/clutter/conform/timeline.p -Isrc/tests/clutter/conform -I../src/tests/clutter/conform -Iclutter -I../clutter -Iclutter/clutter -I../clutter/clutter -Icogl -I../cogl -Icogl/cogl -I../cogl/cogl -Isrc -I../src -I. -I.. -I/usr/include/atk-1.0 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/uuid -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/json-glib-1.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libwacom-1.0 -I/usr/include/gudev-1.0 -I/usr/include/graphene-1.0 -I/usr/lib/graphene-1.0/include -I/usr/include/gsettings-desktop-schemas -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib32/dbus-1.0/include -I/usr/include/gnome-desktop-3.0 -I/usr/include/gnome-settings-daemon-3.0 -I/usr/include/startup-notification-1.0 -I/usr/include/pipewire-0.3 -I/usr/include/spa-0.2 -I/usr/include/gobject-introspection-1.0 -I/usr/include/libdrm -I/usr/include/elogind -flto -fdiagnostics-color=always -DNDEBUG -pipe -D_FILE_OFFSET_BITS=64 -ffloat-store -D_GNU_SOURCE -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=i686 -O2 -pthread -D_REENTRANT -mfpmath=sse -msse -msse2 '-DG_LOG_DOMAIN="Clutter-Conform"' -DCOGL_DISABLE_DEPRECATION_WARNINGS '-DGETTEXT_PACKAGE="mutter"' -MD -MQ src/tests/clutter/conform/timeline.p/.._.._clutter-test-utils.c.o -MF src/tests/clutter/conform/timeline.p/.._.._clutter-test-utils.c.o.d -o src/tests/clutter/conform/timeline.p/.._.._clutter-test-utils.c.o -c ../src/tests/clutter-test-utils.c
In file included from ../src/backends/meta-backend-private.h:38,
                 from ../src/backends/x11/meta-backend-x11.h:31,
                 from ../src/backends/x11/nested/meta-backend-x11-nested.h:25,
                 from ../src/tests/clutter-test-utils.h:36,
                 from ../src/tests/clutter-test-utils.c:1:
../src/backends/meta-monitor-manager-private.h:38:10: fatal error: meta-dbus-display-config.h: No such file or directory
   38 | #include "meta-dbus-display-config.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[189/863] Compiling C object clutter/clutter/libmutter-clutter-7.so.0.0.0.p/clutter-canvas.c.o
ninja: build stopped: subcommand failed.
```

</details>