### PR TITLE
sx: update to 2.1.6.

### DIFF
--- a/srcpkgs/sx/template
+++ b/srcpkgs/sx/template
@@ -1,6 +1,6 @@
 # Template file for 'sx'
 pkgname=sx
-version=2.1.5
+version=2.1.6
 revision=1
 build_style=gnu-makefile
 depends="xorg-server xauth"
@@ -9,7 +9,7 @@ maintainer="mustaqim <mustaqim@pm.me>"
 license="MIT"
 homepage="https://github.com/Earnestly/sx"
 distfiles="https://github.com/Earnestly/sx/archive/${version}.tar.gz"
-checksum=f12a8312ac7f8393bbce07ef1371d38dd30f11be26912e9184e1e51ec606b4be
+checksum=85a3112cd9b25880685ce093da322e84f52534145e8b8db54551bd8964e3e66d
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
This release includes the fix for https://github.com/Earnestly/sx/issues/19 which I also experienced with dwm/2bwm