### PR TITLE
linux-tools: correct required modules for usbipd

### DIFF
--- a/srcpkgs/linux-tools/files/usbipd/run
+++ b/srcpkgs/linux-tools/files/usbipd/run
@@ -1,3 +1,4 @@
 #!/bin/sh
-modprobe -q usbip || exit 1
+modprobe -q usbip-host || exit 1
+modprobe -q vhci-hcd || exit 1
 exec usbipd

--- a/srcpkgs/linux-tools/template
+++ b/srcpkgs/linux-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-tools'
 pkgname=linux-tools
 version=5.4.42
-revision=1
+revision=2
 wrksrc="linux-${version}"
 build_style=meta
 hostmakedepends="asciidoc automake flex gettext libtool perl python3 xmlto"


### PR DESCRIPTION
the service file was last touched in 2014 so probably the module was refactored since then

it now needs `vhci-hcd` for attaching remote devices and `usbip-host` for exporting local ones

all linux versions packaged by void have these modules