### PR TITLE
[NOMERGE] lensfun: update to 0.3.95.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1735,7 +1735,7 @@ libIlmImfUtil-2_4.so.24 libopenexr-2.4.0_1
 libGraphicsMagick.so.3 libgraphicsmagick-1.3.19_1
 libGraphicsMagick++.so.12 libgraphicsmagick-1.3.22_1
 libGraphicsMagickWand.so.2 libgraphicsmagick-1.3.19_1
-liblensfun.so.1 lensfun-0.3.2_1
+liblensfun.so.2 lensfun-0.3.95_1
 libmitlm.so.1 mitlm-0.4.2_1
 libextractor.so.3 libextractor-1.1_1
 libextractor_common.so.1 libextractor-1.1_1

--- a/srcpkgs/lensfun/template
+++ b/srcpkgs/lensfun/template
@@ -1,17 +1,17 @@
 # Template file for 'lensfun'
 pkgname=lensfun
-version=0.3.2
-revision=2
+version=0.3.95
+revision=1
 build_style=cmake
 configure_args="-DINSTALL_HELPER_SCRIPTS=0"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="http://lensfun.sourceforge.net/"
+homepage="http://lensfun.github.io/"
 license="LGPL-3, CC-BY-SA-3.0"
 short_desc="Library for rectifying and simulating photographic lens distortions"
 hostmakedepends="pkg-config python"
 makedepends="libglib-devel"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
-checksum=ae8bcad46614ca47f5bda65b00af4a257a9564a61725df9c74cb260da544d331
+distfiles="https://github.com/lensfun/lensfun/archive/v${version}.tar.gz"
+checksum=82c29c833c1604c48ca3ab8a35e86b7189b8effac1b1476095c0529afb702808
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*);;


### PR DESCRIPTION
Builds on `x86_64`, can't test due to soname-bump. 