### PR TITLE
Add libQtWebkit.so.4 to common/shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -456,6 +456,7 @@ libQtSql.so.4 qt-4.5.3_1
 libQtDeclarative.so.4 qt-4.5.3_1
 libQtDesignerComponents.so.4 qt-designer-libs-4.7.8_13
 libQtDesigner.so.4 qt-designer-libs-4.7.8_13
+libQtWebKit.so.4 qt-webkit-2.3.4_7
 libsysfs.so.2 libsysfs-2.1.0_1
 libsensors.so.5 libsensors-3.5.0_1
 libcap-ng.so.0 libcap-ng-0.6.2_1


### PR DESCRIPTION
The commit message follows in the end. One remark that I have to make is that I am not 100% sure the line that I chose to add the entry is the best one.
```
When building a modified version of "goldendict" [1], I ended up
with this error:

  SONAME: libQtWebKit.so.4 <-> UNKNOWN PKG PLEASE FIX!

Here's the package added.

[1] modified "template" of "goldendict"
Because Qt5 webkit does not render right-to-left texts nicely, I
build my "goldendict" against Qt4; i.e. replace "qt5-webkit-devel"
with "qt-webkit-devel".
```