### PR TITLE
iverilog: update to 11.0.

### DIFF
--- a/srcpkgs/iverilog/template
+++ b/srcpkgs/iverilog/template
@@ -1,7 +1,7 @@
 # Template file for 'iverilog'
 pkgname=iverilog
-version=10.3
-revision=2
+version=11.0
+revision=1
 wrksrc="${pkgname}-${version/./_}"
 build_style=gnu-configure
 hostmakedepends="automake flex gperf"
@@ -11,12 +11,9 @@ maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://iverilog.icarus.com/"
 distfiles="https://github.com/steveicarus/iverilog/archive/v${version/./_}.tar.gz"
-checksum=4b884261645a73b37467242d6ae69264fdde2e7c4c15b245d902531efaaeb234
+checksum=6327fb900e66b46803d928b7ca439409a0dc32731d82143b20387be0833f1c95
 
 nocross="draw_tt.exe: cannot execute binary file: Exec format error"
-
-CFLAGS='-fcommon'
-CXXFLAGS='-fcommon -Wimplicit-fallthrough=0'
 
 pre_configure() {
 	sh ./autoconf.sh


### PR DESCRIPTION
Extra flags are not necessary anymore (verified it builds with `-fno-common`).