### PR TITLE
New package: isoimagewriter-0.8

### DIFF
--- a/srcpkgs/isoimagewriter/template
+++ b/srcpkgs/isoimagewriter/template
@@ -1,0 +1,16 @@
+# Template file for 'isoimagewriter'
+pkgname=isoimagewriter
+version=0.8
+revision=1
+archs="i686 x86_64"
+build_style=cmake
+hostmakedepends="python3 extra-cmake-modules kworkspace gettext"
+makedepends="qt5-devel kcoreaddons-devel ki18n-devel kwidgetsaddons-devel kiconthemes-devel gpgmepp-devel gpgmeqt-devel"
+depends="gpgmeqt kiconthemes"
+short_desc="Very simple GUI tool to write .iso files to USB flash drives"
+maintainer="reback00 <reback00@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://community.kde.org/ISOImageWriter"
+distfiles="https://download.kde.org/unstable/isoimagewriter/${version}/isoimagewriter-${version}.tar.xz"
+checksum=998d13364bf4c6f9a02483ccc1f7ee77ae27146c93109b9fa4ffca5abb290fe7
+python_version=3


### PR DESCRIPTION
**isoimagewriter** is a simple GUI application from KDE community that lets you write ISO image files to USB flash drives. Very easy to use and has friendly UI.

![isoimagewriter01](https://user-images.githubusercontent.com/51861250/95383567-2c74a980-090d-11eb-9948-67681fd18012.png)

![isoimagewriter02](https://user-images.githubusercontent.com/51861250/95383572-2da5d680-090d-11eb-9b70-d9bc8a53c865.png)

![isoimagewriter03](https://user-images.githubusercontent.com/51861250/95383573-2e3e6d00-090d-11eb-99b0-abc7c7ec4c5c.png)

[Project homepage](https://community.kde.org/ISOImageWriter)