### PR TITLE
celestia-glut: fixes + remove pangox-compat-devel.

### DIFF
--- a/srcpkgs/celestia-glut/template
+++ b/srcpkgs/celestia-glut/template
@@ -1,18 +1,19 @@
 # Template file for 'celestia-glut'
 pkgname=celestia-glut
 version=1.6.1
-revision=5
-short_desc="Free space simulation using GLUT"
-maintainer="Martin Riese <grauehaare@gmx.de>"
-license="GPL-2"
-homepage="http://www.shatters.net/celestia/"
-distfiles="${SOURCEFORGE_SITE}/celestia/celestia-${version}.tar.gz"
-checksum="d35570ccb9440fc0bd3e73eb9b4c3e8a4c25f3ae444a13d1175053fa16dc34c4"
+revision=6
+wrksrc="celestia-${version}"
 build_style=gnu-configure
 configure_args="--with-glut --with-lua --enable-theora --disable-static"
 hostmakedepends="pkg-config"
-makedepends="gtkglext-devel zlib-devel lua51-devel glu-devel libfreeglut-devel libjpeg-turbo-devel libpng-devel libtheora-devel pangox-compat-devel"
-wrksrc=celestia-${version}
+makedepends="gtkglext-devel zlib-devel lua51-devel glu-devel libfreeglut-devel
+ libjpeg-turbo-devel libpng-devel libtheora-devel"
+short_desc="Free space simulation using GLUT"
+maintainer="Martin Riese <grauehaare@gmx.de>"
+license="GPL-2.0-only"
+homepage="https://celestia.space"
+distfiles="${SOURCEFORGE_SITE}/celestia/celestia-${version}.tar.gz"
+checksum="d35570ccb9440fc0bd3e73eb9b4c3e8a4c25f3ae444a13d1175053fa16dc34c4"
 
 provides="celestia-${version}_${revision}"
 replaces="celestia>=0"


### PR DESCRIPTION
- celestia dosen't link against pangox-compat, this seems to be an
  old remnant.
- fix xlint warnings.
- move upstream homepage.
- revbump because of metadata.