### PR TITLE
celestia-gtk: fixes + remove pangox-compat-devel.

### DIFF
--- a/srcpkgs/celestia-gtk/template
+++ b/srcpkgs/celestia-gtk/template
@@ -1,19 +1,19 @@
 # Template file for 'celestia-gtk'
 pkgname=celestia-gtk
 version=1.6.1
-revision=4
-short_desc="Free space simulation using GTK"
-maintainer="Martin Riese <grauehaare@gmx.de>"
-license="GPL-2"
-homepage="http://www.shatters.net/celestia/"
-distfiles="${SOURCEFORGE_SITE}/celestia/celestia-${version}.tar.gz"
-checksum="d35570ccb9440fc0bd3e73eb9b4c3e8a4c25f3ae444a13d1175053fa16dc34c4"
+revision=5
+wrksrc="celestia-${version}"
 build_style=gnu-configure
 configure_args="--with-gtk --with-lua --enable-theora --disable-static"
 hostmakedepends="pkg-config"
-makedepends="gtkglext-devel zlib-devel lua51-devel glu-devel gtk+-devel libjpeg-turbo-devel
-libpng-devel libtheora-devel pangox-compat-devel"
-wrksrc=celestia-${version}
+makedepends="gtkglext-devel zlib-devel lua51-devel glu-devel gtk+-devel
+ libjpeg-turbo-devel libpng-devel libtheora-devel"
+short_desc="Free space simulation using GTK"
+maintainer="Martin Riese <grauehaare@gmx.de>"
+license="GPL-2.0-only"
+homepage="https://celestia.space"
+distfiles="${SOURCEFORGE_SITE}/celestia/celestia-${version}.tar.gz"
+checksum="d35570ccb9440fc0bd3e73eb9b4c3e8a4c25f3ae444a13d1175053fa16dc34c4"
 
 provides="celestia-${version}_${revision}"
 replaces="celestia>=0"


### PR DESCRIPTION
- similarly to celestia-glut dosen't link against pangox-compat.
- fix xlint warnings, move upstream homepage, make template neater.
- revbump for metadata.