### PR TITLE
cinnamon-session: remove pangox-compat + fix homepage.

### DIFF
--- a/srcpkgs/cinnamon-session/template
+++ b/srcpkgs/cinnamon-session/template
@@ -1,19 +1,19 @@
 # Template file for 'cinnamon-session'
 pkgname=cinnamon-session
 version=4.6.2
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dgconf=false"
 hostmakedepends="pkg-config gobject-introspection
  gettext-devel dbus-glib-devel glib-devel intltool xmlto"
 makedepends="gtk+3-devel dbus-devel json-glib-devel libSM-devel
- pangox-compat-devel cinnamon-desktop-devel libcanberra-devel upower-devel
+ cinnamon-desktop-devel libcanberra-devel upower-devel
  elogind-devel libXtst-devel xapps-devel"
 depends="cinnamon-desktop desktop-file-utils hicolor-icon-theme elogind"
 short_desc="Cinnamon session handler"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
-homepage="http://developer.linuxmint.com/projects/cinnamon-projects.html"
+homepage="https://linuxmint-developer-guide.readthedocs.io/en/latest/cinnamon.html#cinnamon-session"
 distfiles="https://github.com/linuxmint/${pkgname}/archive/${version}.tar.gz"
 checksum=0d4793d8fb828ce8ec6dbedc67a5d244e56d4182b83030d10029eadc0c6723e6


### PR DESCRIPTION
dosen't link against pangox-compat. important because currently
pangox-compat is FTBTS - cannot drop due to dumb gtkgl stuff.

homepage was dead link, revbump for metadata.