### PR TITLE
New package: puddletag-2.0.1

### DIFF
--- a/srcpkgs/puddletag/template
+++ b/srcpkgs/puddletag/template
@@ -1,0 +1,13 @@
+# Template file for 'puddletag'
+pkgname=puddletag
+version=2.0.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3 python3-configobj python3-mutagen python3-parsing python3-PyQt5 python3-PyQt5-svg"
+short_desc="Powerful, simple, audio tag editor for GNU/Linux "
+maintainer="Daniel Progrestian <progrestian@tuta.io>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/puddletag/puddletag"
+distfiles="https://github.com/puddletag/puddletag/releases/download/${version}/puddletag-${version}.tar.gz"
+checksum=f5c39b7168df34fb4e919d3f57660888f7a2218c6924979895e2b91ff9ba6a07


### PR DESCRIPTION
Package previously removed due to upstream quitting and depending on Python2 & PyQt4.
A new maintainer has picked up the project and ported it to Python3 & PyQt5.