### PR TITLE
cinnamon-settings-daemon: various template cleanups.

### DIFF
--- a/srcpkgs/cinnamon-settings-daemon/template
+++ b/srcpkgs/cinnamon-settings-daemon/template
@@ -1,10 +1,10 @@
 # Template file for 'cinnamon-settings-daemon'
 pkgname=cinnamon-settings-daemon
 version=4.6.4
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper=gir
-configure_args=" --disable-static --disable-schemas-compile"
+configure_args="--disable-static --disable-schemas-compile"
 hostmakedepends="dbus-glib-devel gettext-devel glib-devel gnome-common
  gobject-introspection intltool libtool pkg-config"
 makedepends="cinnamon-desktop-devel elogind-devel ibus-devel json-glib-devel
@@ -14,8 +14,7 @@ depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Cinnamon Settings Daemon"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
-homepage="http://developer.linuxmint.com/projects/cinnamon-projects.html/"
-changelog="https://raw.githubusercontent.com/linuxmint/cinnamon-settings-daemon/${version}/debian/changelog"
+homepage="https://linuxmint-developer-guide.readthedocs.io/en/latest/cinnamon.html#cinnamon-settings-daemon"
 distfiles="https://github.com/linuxmint/${pkgname}/archive/${version}.tar.gz"
 checksum=5c3d78c562f60cbd6348d1bbb3f7b0a98dbf0b483961b2f82f6b260b956d9db0
 


### PR DESCRIPTION
- fix the homepage.
- remove the changlog which is not kept up-to-date and is inconsistent
  between cinnamon templates AND upstream repos.
- other style fixes.