### PR TITLE
otter-browser: include "web browser" in short description

### DIFF
--- a/srcpkgs/otter-browser/template
+++ b/srcpkgs/otter-browser/template
@@ -7,7 +7,7 @@ makedepends="hunspell-devel libgcrypt-devel qt5-declarative-devel
  qt5-multimedia-devel qt5-svg-devel qt5-webkit-devel qt5-xmlpatterns-devel
  qt5-webchannel-devel qt5-location-devel"
 depends="qt5-plugin-sqlite"
-short_desc="Project aiming to recreate the best aspects of the classic Opera UI"
+short_desc="Web browser aiming to recreate the best aspects of the classic Opera UI"
 maintainer="GangstaCat <grumpy@keemail.me>"
 license="GPL-3.0-or-later"
 homepage="http://otter-browser.org"


### PR DESCRIPTION
Include "web browser" in the short description because that's what this package provides. This also ensures users can find the package via ``xbps-query -Rs "web browser"``.