### PR TITLE
qemu: enable debug package

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -1,15 +1,8 @@
 # Template file for 'qemu'
 pkgname=qemu
 version=5.1.0
-revision=3
-short_desc="Open Source Processor Emulator"
-maintainer="Helmut Pozimski <helmut@pozimski.eu>"
-license="GPL-2.0-or-later, LGPL-2.1-or-later"
-homepage="https://www.qemu.org"
-distfiles="https://wiki.qemu.org/download/qemu-${version}.tar.bz2"
-checksum=8314b6e5fcc7bf9fa3915d504de6586a69cba30ffa27cbe9ba85d2cb9987fb3a
-
-nostrip=yes
+revision=4
+build_style=configure
 hostmakedepends="gettext pkg-config perl python3 automake libtool flex
  python3-Sphinx texinfo"
 makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
@@ -23,7 +16,15 @@ makedepends="libpng-devel libjpeg-turbo-devel pixman-devel snappy-devel
  $(vopt_if opengl 'libepoxy-devel libdrm-devel MesaLib-devel')
  $(vopt_if iscsi 'libiscsi-devel')
  $(vopt_if smartcard libcacard-devel) $(vopt_if numa 'libnuma-devel')"
+short_desc="Open Source Processor Emulator"
+maintainer="Helmut Pozimski <helmut@pozimski.eu>"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.qemu.org"
+distfiles="https://wiki.qemu.org/download/qemu-${version}.tar.bz2"
+checksum=8314b6e5fcc7bf9fa3915d504de6586a69cba30ffa27cbe9ba85d2cb9987fb3a
 ignore_elf_dirs="/usr/share/qemu"
+nostrip_files="hppa-firmware.img openbios-ppc openbios-sparc32 openbios-sparc64
+ palcode-clipper s390-ccw.img s390-netboot.img u-boot.e500"
 
 build_options="gtk3 opengl sdl2 spice virgl smartcard numa iscsi"
 build_options_default="opengl gtk3 virgl smartcard sdl2 numa iscsi"
@@ -70,16 +71,8 @@ do_configure() {
 		$(vopt_enable smartcard) \
 		$(vopt_if gtk3 "--enable-gtk") ${args}
 }
-do_build() {
-	# Remove our strip(1) wrapper... E2BIG.
-	rm -f ${XBPS_WRAPPERDIR}/strip
 
-	make ${makejobs}
-}
 do_install() {
-	# Remove our strip(1) wrapper... E2BIG.
-	rm -f ${XBPS_WRAPPERDIR}/strip
-
 	vsed -i Makefile -e 's;dtc/%:;dtc/libfdt:;'
 
 	make DESTDIR=${DESTDIR} install


### PR DESCRIPTION
qemu package has had -dbg disabled for a long time (looks like an xtraeme anachronism), but the amount of space used by debuginfo is comparable to other large packages, so it seems reasonable to enable. This simplifies the template a little too.