### PR TITLE
gnubg: fix arm, cleanup template.

### DIFF
--- a/srcpkgs/gnubg/template
+++ b/srcpkgs/gnubg/template
@@ -1,29 +1,29 @@
 # Template file for 'gnubg'
 pkgname=gnubg
 version=1.06.002
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-cputest ax_cv_gcc_x86_cpuid_0x00000001=6000000"
-if [ "$XBPS_TARGET_MACHINE" = x86_64 ]; then
-	configure_args+=" --enable-simd=sse2"
-fi
-hostmakedepends="pkg-config python-devel gdk-pixbuf-devel"
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" ${pkgname}"
-fi
+hostmakedepends="pkg-config gdk-pixbuf-devel"
 makedepends="libcurl-devel libglib-devel gtk+-devel gtkglext-devel python-devel
  libcanberra-devel readline-devel readline sqlite-devel"
+depends="python"
 short_desc="GNU Backgammon game"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"
-homepage="http://www.gnubg.org"
-distfiles="http://www.gnubg.org/media/sources/$pkgname-release-$version-sources.tar.gz"
+homepage="https://www.gnu.org/software/gnubg"
+distfiles="${GNU_SITE}/${pkgname}/${pkgname}-release-${version}-sources.tar.gz"
 checksum=ce1b0b0c1900717cc598032a14cf8c0ee60faf24d84368b39922c0102983bc87
-LDFLAGS="-Wl,--no-as-needed -lm -lreadline"
+LDFLAGS+=" -Wl,--no-as-needed -lm -lreadline -lpython2.7 -I${XBPS_CROSS_BASE}/usr/include/python2.7"
+CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/python2.7"
 
-case "$XBPS_TARGET_MACHINE" in
-	arm*) broken="https://build.voidlinux.org/builders/armv7l_builder/builds/6536/steps/shell_3/logs/stdio" ;;
-esac
+if [ "$XBPS_TARGET_MACHINE" = x86_64 ]; then
+	configure_args+=" --enable-simd=sse2"
+fi
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" ${pkgname}"
+fi
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then
@@ -32,4 +32,3 @@ pre_configure() {
 		makebearoff -t 6x6 -f gnubg_ts0.bd
 	fi
 }
-


### PR DESCRIPTION
ARM was failing because it looks for python >=2.1.0. However, it
dosen't know that py3 exists and is very different. Hence, it tries
to use python 3.8 - which dosen't work. Setting CFLAGS and LDFLAGS
so that it uses python2.7 makes the build work.

Furthermore, python-devel in hostmakedepends confused it somewhat,
hence removed (it is not required), and python is required at runtime
(shlibs should pick that up, but it /is/ an explicit dependency
for scripting, and if the python package structure changes then
this is required).

Template cleanups:

- fix xlint warnings.
- move if statements below main variables.
- move the homepage to the new GNU location, gnubg.org is dead.
- move distfiles to working location.