### PR TITLE
swirc: update to 3.2.5.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,7 +1,7 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.2.4
-revision=2
+version=3.2.5
+revision=1
 build_style=configure
 make_install_args="PREFIX=/usr"
 hostmakedepends="pkg-config which"
@@ -12,7 +12,7 @@ maintainer="Markus Uhlin <markus.uhlin@bredband.net>"
 license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 distfiles="https://www.nifty-networks.net/swirc/releases/${pkgname}-${version}.tgz"
-checksum="c8c15eeb6cc768a1b96952314420fea60c942b4dad25f6318d28dd2f00a02bc9"
+checksum="79ff8ee8e08bbbc313b9abb0f2c1641395a903b5ea114b8223cdaa71ec880ee0"
 
 post_configure() {
 	local _file="options.mk"


### PR DESCRIPTION
New version of Swirc.
https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md
