### PR TITLE
projectM: fix GUI applications for cross.

### DIFF
--- a/srcpkgs/projectM/template
+++ b/srcpkgs/projectM/template
@@ -1,10 +1,13 @@
 # Template file for 'projectM'
 pkgname=projectM
 version=3.1.7
-revision=2
+revision=3
 build_style=gnu-configure
-configure_args="--datadir=/usr/libexec"
-hostmakedepends="pkg-config qt5-host-tools automake libtool which"
+build_helper=qmake
+configure_args="--datadir=/usr/libexec --enable-qt --enable-pulseaudio
+ --enable-jack --enable-sdl"
+hostmakedepends="pkg-config qt5-host-tools automake libtool which qt5-qmake
+ qt5-tools-devel"
 makedepends="pulseaudio-devel alsa-lib-devel glew-devel ftgl-devel libXext-devel
  SDL2-devel gtkglext-devel jack-devel qt5-tools-devel libvisual-devel glm
  MesaLib-devel glu-devel"
@@ -21,11 +24,9 @@ if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 fi
 
 post_install() {
-	if [ ! "$CROSS_BUILD" ]; then
-		# fix location of desktop files
-		# TODO: find out why these files aren't generated for the cross build
-		mv $DESTDIR/usr/libexec/{applications,icons} $DESTDIR/usr/share
-	fi
+	# fix location of desktop files
+	vmkdir usr/share
+	mv $DESTDIR/usr/libexec/{applications,icons} $DESTDIR/usr/share
 }
 
 projectM-devel_package() {


### PR DESCRIPTION
The template had a note:
`TODO: find out why these files aren't generated for the cross build`,
regarding the desktop files and icons that weren't being installed.
This was actually because the GUI application's weren't being built
at all! The build system could not find QT. Force enabling these
applications and doing qt shenanigans, including `build_helper=qmake`,
fixes these issues.