### PR TITLE
json-glib: update to 1.6.0

### DIFF
--- a/srcpkgs/json-glib/template
+++ b/srcpkgs/json-glib/template
@@ -1,22 +1,28 @@
 # Template file for 'json-glib'
 pkgname=json-glib
-version=1.4.4
-revision=3
+version=1.6.0
+revision=1
 build_style=meson
 build_helper="gir"
-configure_args="-Dintrospection=$(vopt_if gir true false)"
-hostmakedepends="pkg-config glib-devel"
+configure_args="-Dintrospection=$(vopt_if gir enabled disabled)
+ -Dgtk_doc=$(vopt_if gtk_doc enabled disabled)"
+hostmakedepends="pkg-config glib-devel $(vopt_if gtk_doc gtk-doc)"
 makedepends="libglib-devel"
 short_desc="JSON parser for GLib-based libraries and applications"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://live.gnome.org/JsonGlib"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=720c5f4379513dc11fd97dc75336eb0c0d3338c53128044d9fabec4374f4bc47
+checksum=0d7c67602c4161ea7070fab6c5823afd9bd7f7bc955f652a50d3753b08494e73
 
 # Package build options
-build_options="gir"
+build_options="gir gtk_doc"
 build_options_default="gir"
+desc_option_gtk_doc="Build GTK Documentation with gtk-doc"
+
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" gtk_doc"
+fi
 
 json-glib-devel_package() {
 	depends="libglib-devel ${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
By the way, should I update `common/shlibs` as well? Currently, the corresponding entry looks like this:
```
libjson-glib-1.0.so.0 json-glib-0.12.2_1
```