### PR TITLE
vba-m: make work on archs other than x86.

### DIFF
--- a/srcpkgs/vba-m/patches/x86-asm.patch
+++ b/srcpkgs/vba-m/patches/x86-asm.patch
@@ -1,0 +1,37 @@
+From af0de1c4b308ef8d9a081ecf407805b75a99d877 Mon Sep 17 00:00:00 2001
+From: Rafael Kitover <rkitover@gmail.com>
+Date: Fri, 4 Oct 2019 07:35:49 +0000
+Subject: [PATCH] xbrz: fix inline asm check
+
+Use correct cpp code to detect x86/amd64 architecture to use inline asm.
+
+Signed-off-by: Rafael Kitover <rkitover@gmail.com>
+---
+ src/filters/xBRZ/xbrz.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git src/filters/xBRZ/xbrz.cpp src/filters/xBRZ/xbrz.cpp
+index 36d70be26..13e6cdc13 100644
+--- src/filters/xBRZ/xbrz.cpp
++++ src/filters/xBRZ/xbrz.cpp
+@@ -66,17 +66,17 @@ uint32_t gradientARGB(uint32_t pixFront, uint32_t pixBack) //find intermediate c
+ 
+ inline double fastSqrt(double n)
+ {
+-#ifdef __GNUC__ || __clang__ || __MINGW64_VERSION_MAJOR || __MINGW32_MAJOR_VERSION
++#if (defined(__GNUC__) || defined(__clang__)) && (defined(__x86_64__) || defined(__i386__))
+     __asm__ ("fsqrt" : "+t" (n));
+     return n;
+-#elif _MSC_VER && _M_IX86
++#elif defined(_MSC_VER) && defined(_M_IX86)
+     // speeds up xBRZ by about 9% compared to std::sqrt which internally uses
+     // the same assembler instructions but adds some "fluff"
+     __asm {
+         fld n
+         fsqrt
+     }
+-#else // _MSC_VER && _M_X64 OR other platforms
++#else // defined(_MSC_VER) && defined(_M_X64) OR other platforms
+     // VisualStudio x86_64 does not allow inline ASM
+     return std::sqrt(n);
+ #endif

--- a/srcpkgs/vba-m/template
+++ b/srcpkgs/vba-m/template
@@ -2,12 +2,11 @@
 pkgname=vba-m
 reverts=1292_2
 version=2.1.4
-revision=3
-archs="x86_64* i686*"
+revision=4
 wrksrc="visualboyadvance-m-${version}"
 build_style=cmake
 configure_args="-DENABLE_GTK=TRUE -DENABLE_FFMPEG=TRUE -DENABLE_LINK=TRUE"
-hostmakedepends="gettext pkg-config unzip zip yasm wxWidgets-common-devel"
+hostmakedepends="gettext pkg-config unzip zip yasm wxWidgets-gtk3-devel"
 makedepends="zlib-devel libpng-devel MesaLib-devel libopenal-devel SDL2-devel
  gtkmm2-devel ffmpeg-devel gtk+3-devel
  SFML-devel wxWidgets-gtk3-devel libgomp-devel"
@@ -17,4 +16,3 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/visualboyadvance-m/visualboyadvance-m/"
 distfiles="https://github.com/visualboyadvance-m/visualboyadvance-m/archive/v${version}.tar.gz"
 checksum=8342e017212842de66b0d86bc7610c82349af2d4e59951d969a33fff956c39ba
-nocross=y


### PR DESCRIPTION
There was a block of inline asm that was for x86 only, a patch from
master fixed this months ago; chuck it in.

Also cross compiling to the ppc* family works now with the fixed
hostmakedepends.