### PR TITLE
kaitai-struct-compiler: drop noarch.

### DIFF
--- a/srcpkgs/kaitai-struct-compiler/template
+++ b/srcpkgs/kaitai-struct-compiler/template
@@ -1,13 +1,12 @@
 # Template file for 'kaitai-struct-compiler'
 pkgname=kaitai-struct-compiler
 version=0.8
-revision=1
-archs=noarch
+revision=2
 hostmakedepends="unzip"
 depends="virtual?java-environment"
 short_desc="Compiler for the Kaitai declarative binary format parsing language"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://kaitai.io"
 distfiles="https://bintray.com/kaitai-io/universal/download_file?file_path=${version}%2F${pkgname}-${version}.zip"
 checksum=545fc10e134db2901cad8817be1b440fca6f2bad8b92b2948ebe0647f3ffa2c9


### PR DESCRIPTION
Also rebuild to appear in musl repositories.