### PR TITLE
shutils/chroot.sh: fix syslog configuration.

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -127,9 +127,6 @@ chroot_prepare() {
     # Copy /etc/hosts from base-files.
     cp -f $XBPS_SRCPKGDIR/base-files/files/hosts $XBPS_MASTERDIR/etc
 
-    mkdir -p $XBPS_MASTERDIR/etc/xbps.d
-    echo "syslog=false" >> $XBPS_MASTERDIR/etc/xbps.d/00-xbps-src.conf
-
     # Prepare default locale: en_US.UTF-8.
     if [ -s ${XBPS_MASTERDIR}/etc/default/libc-locales ]; then
         printf '%s\n' \
@@ -264,6 +261,8 @@ chroot_sync_repodata() {
         fi
     fi
 
+    echo "syslog=false" > $confdir/00-xbps-src.conf
+
     # Copy host repos to the cross root.
     if [ -n "$XBPS_CROSS_BUILD" ]; then
         rm -rf $XBPS_MASTERDIR/$XBPS_CROSS_BASE/etc/xbps.d
@@ -287,6 +286,8 @@ chroot_sync_repodata() {
                     $crossconfdir/20-repository-remote.conf
             fi
         fi
+
+        echo "syslog=false" > $crossconfdir/00-xbps-src.conf
     fi
 
 


### PR DESCRIPTION
The file was created in chroot_prepare(), but the configuration
directory was being cleaned in chroot_sync_repodata(). This commit moves
the configuration to after the directories are created.

Fixes #25534