### PR TITLE
apparmor: fix capability list generation

### DIFF
--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=2.13.4
-revision=3
+revision=4
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure
@@ -22,6 +22,10 @@ patch_args="-Np1"
 if [ -z "$CROSS_BUILD" ]; then
 	configure_args="--with-perl --with-python"
 fi
+
+post_patch() {
+	vsed -i ${wrksrc}/common/Make.rules -e 's/\\#include </#include </'
+}
 
 pre_configure() {
 	autoreconf -if


### PR DESCRIPTION
The file `common/Make.rules` uses the C preprocessor to generate a list of capabilities and address families in some headers. For some reason, the makefile escapes the hash in `#include` statements, rendering them inoperable and making the generated headers empty. Removing the escape causes these files to be populated.

No idea why this appears to be a regression.

Fixes #25548.

@CameronNemo or @the-antz please confirm that this change results in a functioning apparmor installation.