### PR TITLE
asio: update to 1.18.0

### DIFF
--- a/srcpkgs/asio/template
+++ b/srcpkgs/asio/template
@@ -1,6 +1,6 @@
 # Template file for 'asio'
 pkgname=asio
-version=1.16.1
+version=1.18.0
 revision=1
 build_style=gnu-configure
 makedepends="boost-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSL-1.0"
 homepage="http://think-async.com/Asio/"
 distfiles="${SOURCEFORGE_SITE}/asio/asio-${version}.tar.bz2"
-checksum=e271db76dbbcda9835ed1c9c94deb2ba3f4589c3ebcaa71d99ac694b8d62638c
+checksum=9d539e7c09aa6394d512c433c5601c1f26dc4975f022ad7d5e8e57c3b635b370
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Note: vdrift works fine.

![screenshot](https://user-images.githubusercontent.com/22344340/95879550-02d0dd80-0d66-11eb-90ad-97440f560335.png)

