### PR TITLE
hplip: add patch to fix scanning

### DIFF
--- a/srcpkgs/hplip/patches/sane.patch
+++ b/srcpkgs/hplip/patches/sane.patch
@@ -1,0 +1,31 @@
+--- scan/sane.py.orig	2020-10-13 22:29:59.456276307 -0400
++++ scan/sane.py	2020-10-13 22:32:44.663586789 -0400
+@@ -378,14 +378,14 @@
+ 
+     def isScanActive(self):
+         if self.scan_thread is not None:
+-            return self.scan_thread.isAlive() and self.scan_thread.scan_active
++            return self.scan_thread.is_alive() and self.scan_thread.scan_active
+         else:
+             return False
+ 
+ 
+     def waitForScanDone(self):
+         if self.scan_thread is not None and \
+-            self.scan_thread.isAlive() and \
++            self.scan_thread.is_alive() and \
+             self.scan_thread.scan_active:
+ 
+             try:
+@@ -398,9 +398,9 @@
+         #time.sleep(0.5)
+         if self.scan_thread is not None:
+             while True:
+-                #print self.scan_thread.isAlive()
++                #print self.scan_thread.is_alive()
+                 #print self.scan_thread.scan_active
+-                if self.scan_thread.isAlive() and \
++                if self.scan_thread.is_alive() and \
+                     self.scan_thread.scan_active:
+                     return
+ 

--- a/srcpkgs/hplip/template
+++ b/srcpkgs/hplip/template
@@ -1,7 +1,7 @@
 # Template file for 'hplip'
 pkgname=hplip
 version=3.20.9
-revision=2
+revision=3
 build_style=gnu-configure
 pycompile_dirs="usr/share/hplip"
 configure_args="


### PR DESCRIPTION
This replaces the deprecated isAlive() method with is_alive().  This was
only made evident with the transition to Python 3.9.