### PR TITLE
python3-lazy-object-proxy: update to 1.5.1.

### DIFF
--- a/srcpkgs/python3-lazy-object-proxy/template
+++ b/srcpkgs/python3-lazy-object-proxy/template
@@ -1,21 +1,17 @@
 # Template file for 'python3-lazy-object-proxy'
 pkgname=python3-lazy-object-proxy
-version=1.4.3
-revision=4
+version=1.5.1
+revision=1
 wrksrc="lazy-object-proxy-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 makedepends="python3-devel"
 short_desc="Fast and thorough lazy object proxy (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/ionelmc/python-lazy-object-proxy"
 distfiles="${PYPI_SITE}/l/lazy-object-proxy/lazy-object-proxy-${version}.tar.gz"
-checksum=f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0
-
-post_patch() {
-	vsed -i '/setuptools_scm/d' setup.cfg
-}
+checksum=9723364577b79ad9958a68851fe2acb94da6fd25170c595516a8289e6a129043
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Also remove unnecessary post_patch which produced broken package (ie.
the egg version was set to 0.0.0 rather than the actual version causing
programs like pylint to break).