### PR TITLE
vdirsyncer: cherry pick Python 3.9 fixes.

### DIFF
--- a/srcpkgs/vdirsyncer/patches/0001-Update-usage-of-deprecated-method.patch
+++ b/srcpkgs/vdirsyncer/patches/0001-Update-usage-of-deprecated-method.patch
@@ -1,0 +1,19 @@
+Source: Upstream
+Upstream: Yes
+Reason: Python 3.9 compatibility fix.
+diff --git a/vdirsyncer/storage/dav.py b/vdirsyncer/storage/dav.py
+index 07d164f..a7e2422 100644
+--- vdirsyncer/storage/dav.py
++++ vdirsyncer/storage/dav.py
+@@ -124,7 +124,7 @@ def _merge_xml(items):
+         return None
+     rv = items[0]
+     for item in items[1:]:
+-        rv.extend(item.getiterator())
++        rv.extend(item.iter())
+     return rv
+ 
+ 
+-- 
+2.28.0
+

--- a/srcpkgs/vdirsyncer/template
+++ b/srcpkgs/vdirsyncer/template
@@ -1,7 +1,7 @@
 # Template file for 'vdirsyncer'
 pkgname=vdirsyncer
 version=0.16.8
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-atomicwrites python3-click python3-click-log


### PR DESCRIPTION
vdirsyncer uses the deprecared iter() method. Python 3.9 removed this method. Upstream has a fix (commit 7577fa21177442aacc2d86640ef28cebf1c4aaef), but has not spun a new release. This commit cherry-picks that commit and bumps the revision.