### PR TITLE
gcc: fix order of postdep_objects_CXX

### DIFF
--- a/srcpkgs/gcc/patches/fix-vtv-link-order.patch
+++ b/srcpkgs/gcc/patches/fix-vtv-link-order.patch
@@ -1,0 +1,20 @@
+put vtv_end.o in front of postdep_objects_CXX
+having it after crtendS.o leads to missing zero termination in eh_frame section
+
+This is in line with comment in libgcc/vtv_end.c:
+
+   When the GCC driver inserts vtv_start.o into the link line (just
+   after crtbegin.o) it also inserts vtv_end.o into the link line,
+   just before crtend.o.
+
+--- libstdc++-v3/configure
++++ libstdc++-v3/configure
+@@ -15443,7 +15443,7 @@
+ 
+ if test "$enable_vtable_verify" = yes; then
+   predep_objects_CXX="${predep_objects_CXX} ${glibcxx_builddir}/../libgcc/vtv_start.o"
+-  postdep_objects_CXX="${postdep_objects_CXX} ${glibcxx_builddir}/../libgcc/vtv_end.o"
++  postdep_objects_CXX="${glibcxx_builddir}/../libgcc/vtv_end.o ${postdep_objects_CXX}" 
+ fi
+ 
+ 

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.21
 
 pkgname=gcc
 version=${_minorver}.0
-revision=6
+revision=7
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"


### PR DESCRIPTION
make sure crt* objects come after anything else

fixes #25535

[ci skip]