### PR TITLE
common/build-style/meson.sh: set auto-features to auto.

### DIFF
--- a/common/build-style/meson.sh
+++ b/common/build-style/meson.sh
@@ -107,7 +107,7 @@ do_configure() {
 		--localstatedir=/var \
 		--sharedstatedir=/var/lib \
 		--buildtype=plain \
-		--auto-features=enabled \
+		--auto-features=auto \
 		--wrap-mode=nodownload \
 		-Db_lto=true -Db_ndebug=true \
 		-Db_staticpic=true \


### PR DESCRIPTION
This allows the build system to detect itself whether it should use
certain features, instead of defaulting to (potentially bad) enabled
status.

Features that aren't detected properly, be it because false positives or
negatives, should be explicitly called out in the templates.