### PR TITLE
korganizer: depends on sqlite

### DIFF
--- a/srcpkgs/korganizer/template
+++ b/srcpkgs/korganizer/template
@@ -1,12 +1,13 @@
 # Template file for 'korganizer'
 pkgname=korganizer
 version=20.08.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kdoctools
  kcoreaddons kconfig gettext"
 makedepends="akonadi-calendar-devel akonadi-notes-devel incidenceeditor-devel
  qt5-multimedia-devel kdepim-apps-libs-devel kholidays-devel kontactinterface-devel"
+depends="sqlite"
 short_desc="Calendar and scheduling Program"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
korganizer requires either mysql/mariadb/sqlite to be functional.
Considered that sqlite is very small and already pulled by nss (thus web
browser), python3, and gnupg2.

Let's make korganizer depends on sqlite.
Close #25252 