### PR TITLE
Fix versioning in python eggs

### DIFF
--- a/srcpkgs/afew/template
+++ b/srcpkgs/afew/template
@@ -1,9 +1,9 @@
 # Template file for 'afew'
 pkgname=afew
 version=3.0.1
-revision=2
+revision=3
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-Sphinx pkg-config"
+hostmakedepends="python3-setuptools_scm python3-Sphinx pkg-config"
 depends="notmuch-python3 python3-dkimpy python3-chardet notmuch"
 checkdepends="python3-pytest python3-freezegun $depends"
 short_desc="Initial tagging script for notmuch mail"
@@ -12,11 +12,6 @@ license="ISC"
 homepage="https://github.com/afewmail/afew"
 distfiles="${PYPI_SITE}/a/afew/afew-${version}.tar.gz"
 checksum=ce857fe1a3bc0982c1dac81aef66cacc148e4f9db06da720f869392af1c2ee72
-
-post_patch() {
-	# version is pre-generated
-	vsed -i -e "s/'setuptools_scm'//" setup.py
-}
 
 post_build() {
 	python3 setup.py build_sphinx -b man

--- a/srcpkgs/python3-Cheroot/template
+++ b/srcpkgs/python3-Cheroot/template
@@ -1,29 +1,27 @@
 # Template file for 'python3-Cheroot'
 pkgname=python3-Cheroot
-version=8.3.1
-revision=3
+version=8.4.5
+revision=1
 wrksrc="cheroot-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-six python3-more-itertools
- python3-jaraco.functools"
+hostmakedepends="python3-setuptools_scm"
+depends="python3-setuptools python3-six
+ python3-more-itertools python3-jaraco.functools"
 short_desc="High-performance, pure-Python HTTP server (Python3)"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/cherrypy/cheroot"
 changelog="https://github.com/cherrypy/cheroot/blob/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/c/cheroot/cheroot-${version}.tar.gz"
-checksum=7076d5845f64d729e4155ec2650ad24ee70209340d11b9e619a82e9210a579b8
-conflicts="python-Cheroot>=0"
+checksum=b6c18caf5f79cdae668c35fc8309fc88ea4a964cce9e2ca8504fab13bcf57301
+alternatives="cheroot:cheroot:/usr/bin/cheroot3"
 
-pre_build() {
-	vsed -i setup.cfg \
-		-e '/setuptools_scm/d' \
-		-e '/use_scm_version/d' \
-		-e "/name = /a\
-		version = ${version}"
+post_patch() {
+	# Don't need setuptools_scm_git_archive for the tarball
+	vsed -e '/setuptools_scm_git_archive/d' -i setup.cfg
 }
 
 post_install() {
+	mv "${DESTDIR}/usr/bin/cheroot" "${DESTDIR}/usr/bin/cheroot3"
 	vlicense LICENSE.md
 }

--- a/srcpkgs/python3-CherryPy/template
+++ b/srcpkgs/python3-CherryPy/template
@@ -1,12 +1,12 @@
 # Template file for 'python3-CherryPy'
 pkgname=python3-CherryPy
 version=18.6.0
-revision=2
+revision=3
 wrksrc="CherryPy-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-Cheroot python3-portend python3-zc.lockfile
- python3-jaraco.collections"
+hostmakedepends="python3-setuptools_scm"
+depends="python3-setuptools python3-Cheroot python3-portend
+ python3-zc.lockfile python3-jaraco.collections"
 short_desc="Object-oriented HTTP framework (Python3)"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"
 license="BSD-3-Clause"
@@ -15,12 +15,6 @@ changelog="https://raw.githubusercontent.com/cherrypy/cherrypy/master/CHANGES.rs
 distfiles="${PYPI_SITE}/C/CherryPy/CherryPy-${version}.tar.gz"
 checksum=56608edd831ad00991ae585625e0206ed61cf1a0850e4b2cc48489fb2308c499
 alternatives="cherrypy:cherryd:/usr/bin/cherryd3"
-
-pre_build() {
-	vsed -i setup.py \
-		-e '/setuptools_scm/d' \
-		-e "s|use_scm_version=True|version='${version}'|"
-}
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/cherryd{,3}

--- a/srcpkgs/python3-ansible-lint/template
+++ b/srcpkgs/python3-ansible-lint/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ansible-lint'
 pkgname=python3-ansible-lint
 version=4.3.5
-revision=1
+revision=2
 wrksrc="ansible-lint-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,12 +11,12 @@ maintainer="Joseph LaFreniere <joseph@lafreniere.xyz>"
 license="MIT"
 homepage="https://github.com/willthames/ansible-lint"
 changelog="https://raw.githubusercontent.com/willthames/ansible-lint/master/CHANGELOG.md"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=df5ffb79cbd76ab02bf6dd4b493502d6ba59fafb669d6f57f487251a6c955adc
+distfiles="${PYPI_SITE}/a/ansible-lint/ansible-lint-${version}.tar.gz"
+checksum=bec230cf5fcc4d976246d4170da3ae289715f99185529ca8bba4b3c173035656
 
 post_patch() {
-	vsed -i pyproject.toml -e '/setuptools_scm/d'
-	vsed -i setup.cfg -e '/setup_requires =/,/setuptools_scm_git_archive/d'
+	# scm versioning is broken in this release
+	vsed -e "/name =/a version = ${version}" -e "/setuptools_scm/d" -i setup.cfg
 }
 
 post_install() {

--- a/srcpkgs/python3-portend/template
+++ b/srcpkgs/python3-portend/template
@@ -1,24 +1,19 @@
 # Template file for 'python3-portend'
 pkgname=python3-portend
-version=2.5
-revision=4
+version=2.6
+revision=1
 wrksrc="portend-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-tempora"
 short_desc="TCP port monitoring utilities (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jaraco/portend"
 changelog="https://github.com/jaraco/portend/blob/master/CHANGES.rst"
-distfiles="https://github.com/jaraco/portend/archive/${version}.tar.gz"
-checksum=69fa3194739142b62bd6e44f0f0cb0828ddee521f4c7b4634abc5b5e9a54f85a
+distfiles="${PYPI_SITE}/p/portend/portend-${version}.tar.gz"
+checksum=600dd54175e17e9347e5f3d4217aa8bcf4bf4fa5ffbc4df034e5ec1ba7cdaff5
 
-pre_build() {
-	sed -i setup.py \
-		-e '/setuptools_scm/d' \
-		-e "s|use_scm_version=True|version='${version}'|"
-}
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-setuptools_scm/template
+++ b/srcpkgs/python3-setuptools_scm/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-setuptools_scm'
+pkgname=python3-setuptools_scm
+version=4.1.2
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools python3-wheel"
+short_desc="Manage Python package versions with SCM tags"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="MIT"
+homepage="https://github.com/pypa/setuptools_scm"
+distfiles="${PYPI_SITE}/s/setuptools_scm/setuptools_scm-${version}.tar.gz"
+checksum=a8994582e716ec690f33fec70cca0f85bd23ec974e3f783233e4879090a7faa8
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-tempora/template
+++ b/srcpkgs/python3-tempora/template
@@ -1,25 +1,20 @@
 # Template file for 'python3-tempora'
 pkgname=python3-tempora
-version=2.0.0
-revision=3
+version=4.0.0
+revision=1
 wrksrc="tempora-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm python3-toml"
 depends="python3-setuptools python3-six python3-pytz"
 short_desc="Objects and routines pertaining to date and time (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jaraco/tempora"
 distfiles="${PYPI_SITE}/t/tempora/tempora-${version}.tar.gz"
-checksum=f11df59b34b9a87d395cce031274f6ff3d2be2171dd1db32dff9ab1fcb5352fa
-conflicts="python-tempora>=0"
-
-pre_build() {
-	vsed -i setup.py \
-		 -e '/setuptools_scm/d' \
-		 -e "s|use_scm_version=True|version='${version}'|"
-}
+checksum=599a3a910b377f2b544c7b221582ecf4cb049b017c994b37f2b1a9ed1099716e
+alternatives="tempora:calc-prorate:/usr/bin/calc-prorate3"
 
 post_install() {
 	vlicense LICENSE
+	mv "${DESTDIR}/usr/bin/calc-prorate" "${DESTDIR}/usr/bin/calc-prorate3"
 }

--- a/srcpkgs/python3-ultrajson/template
+++ b/srcpkgs/python3-ultrajson/template
@@ -1,21 +1,17 @@
 # Template file for 'python3-ultrajson'
 pkgname=python3-ultrajson
-version=4.0.0
+version=4.0.1
 revision=1
 wrksrc="ujson-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 makedepends="python3-devel"
 short_desc="Ultra fast JSON encoder and decoder for Python"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/ultrajson/ultrajson"
 distfiles="${PYPI_SITE}/u/ujson/ujson-${version}.tar.gz"
-checksum=dba37ad41906d7f9ff52deeb729b9add7e305b94673b41979e9a6c5914083aa8
-
-post_patch() {
-	vsed -i setup.py -e 's/"setuptools_scm"//g'
-}
+checksum=26cf6241b36ff5ce4539ae687b6b02673109c5e3efc96148806a7873eaa229d3
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
Several python packages attempt to determine versioning using the `setuptools_scm` package and its plugin, `setuptools_scm_git_archive`. These dependencies have been packages and added to `hostmakedepends` for packages that previously attempted to either patch out (sometime incorrectly) the requirement or allow `setuptools` to download the egg at build time.

By doing this right, we ensure that the `egg-info` for each of the dependent packages is correctly versioned.