### PR TITLE
New package: dolphin-emu-beta-5.0.12716

### DIFF
--- a/srcpkgs/dolphin-emu-beta/template
+++ b/srcpkgs/dolphin-emu-beta/template
@@ -1,0 +1,21 @@
+# Template file for 'dolphin-emu-beta'
+pkgname=dolphin-emu-beta
+version=5.0.12716
+revision=1
+archs="x86_64*"
+_git_hash=31524288e3b2450eaefff8202c6d26c4ba3f7333
+wrksrc="dolphin-${_git_hash}"
+build_style=cmake
+configure_args="-DUSE_SHARED_ENET=ON"
+hostmakedepends="pkg-config"
+makedepends="
+ SFML-devel alsa-lib-devel eudev-libudev-devel ffmpeg-devel libXrandr-devel
+ libao-devel libbluetooth-devel libenet-devel libevdev-devel libglvnd-devel
+ libusb-devel lzo-devel mbedtls-devel miniupnpc-devel pulseaudio-devel qt5-devel
+ soundtouch-devel"
+short_desc="Gamecube / Wii / Triforce emulator"
+maintainer="sG4ZvHrf <oXPT62V7@disroot.org>"
+license="GPL-2.0-or-later"
+homepage="https://dolphin-emu.org"
+distfiles="https://github.com/dolphin-emu/dolphin/archive/${_git_hash}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=a7ce8390993b3309108dea8f23976b343d2d7cd527f3ded9ef4c2a0462c7f338


### PR DESCRIPTION
Closes #23328.

Template is based on [libclc](https://github.com/void-linux/void-packages/blob/master/srcpkgs/libclc-git/template)'s.

Worth reading:
- https://wiki.dolphin-emu.org/index.php?title=Building_Dolphin_on_Linux
- https://www.archlinux.org/packages/community/x86_64/dolphin-emu/