### PR TITLE
common/shlibs: add missing pango lib

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -92,6 +92,7 @@ libpangocairo-1.0.so.0 pango-1.24.0_1
 libpangoft2-1.0.so.0 pango-1.24.0_1
 libpangoxft-1.0.so.0 pango-xft-1.36.3_2
 libpango-1.0.so.0 pango-1.24.0_1
+libpangox-1.0.so.0 pango-1.24.0_1
 libcairo.so.2 cairo-1.8.6_1
 libcairo-gobject.so.2 cairo-1.8.6_1
 libcairo-script-interpreter.so.2 cairo-1.8.6_1


### PR DESCRIPTION
```libpangox-1.0.so.0``` was missing when I tried to build ```anydesk``` package.
Now it works without any problems.