### PR TITLE
libu2f-host is archived

### DIFF
--- a/srcpkgs/libfido2/template
+++ b/srcpkgs/libfido2/template
@@ -1,8 +1,9 @@
 # Template file for 'libfido2'
 pkgname=libfido2
 version=1.5.0
-revision=2
+revision=3
 build_style=cmake
+configure_args="-DUDEV_RULES_DIR=/usr/lib/udev/rules.d"
 hostmakedepends="pkg-config"
 makedepends="libcbor-devel libressl-devel eudev-libudev-devel"
 short_desc="Library for FIDO 2.0, including communication with a device over USB"
@@ -11,6 +12,9 @@ license="BSD-2-Clause"
 homepage="https://github.com/Yubico/libfido2"
 distfiles="https://github.com/Yubico/libfido2/archive/${version}.tar.gz"
 checksum=5990f923c9390fe1e6a00ba5d1d1f74030e7344b855e971d9fb7223e70ff3122
+# udev rules used to be shipped by libu2f-host
+conf_files="/usr/lib/udev/rules.d/70-u2f.rules"
+conflicts="libu2f-host<=1.1.10_3"
 
 CFLAGS="-Wno-type-limits"
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
@@ -25,6 +29,8 @@ pre_configure() {
 
 post_install() {
 	vlicense LICENSE
+	vsed -e 's/GROUP="plugdev"/GROUP="users"/' \
+		-i ${DESTDIR}/usr/lib/udev/rules.d/70-u2f.rules
 }
 
 libfido2-devel_package() {

--- a/srcpkgs/libu2f-host/template
+++ b/srcpkgs/libu2f-host/template
@@ -1,12 +1,13 @@
 # Template file for 'libu2f-host'
 pkgname=libu2f-host
 version=1.1.10
-revision=3
+revision=4
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
-configure_args="--with-openssl=yes --with-udevrulesdir=/usr/lib/udev/rules.d"
+configure_args="--with-openssl=yes"
 hostmakedepends="automake gengetopt libtool pkg-config"
 makedepends="hidapi-devel json-c-devel libressl-devel"
+depends="libfido2"
 short_desc="C library and tool that implements the host-side of the U2F protocol"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, GPL-3.0-or-later"
@@ -14,15 +15,9 @@ homepage="https://developers.yubico.com/libu2f-host/"
 #changelog="https://raw.githubusercontent.com/Yubico/libu2f-host/master/NEWS"
 distfiles="https://github.com/Yubico/libu2f-host/archive/libu2f-host-${version}.tar.gz"
 checksum=45937c6c04349f865d9f047d3a68cc50ea24e9085d18ac2c7d31fa38eb749303
-conf_files="/usr/lib/udev/rules.d/70-u2f.rules"
 
 pre_configure() {
 	autoreconf -fi
-}
-
-post_install() {
-	vsed -e 's:GROUP="plugdev":GROUP="users":' \
-		 -i ${DESTDIR}/usr/lib/udev/rules.d/70-u2f.rules
 }
 
 libu2f-host-devel_package() {

--- a/srcpkgs/pam-u2f/patches/musl.patch
+++ b/srcpkgs/pam-u2f/patches/musl.patch
@@ -1,0 +1,24 @@
+diff --git b64.c b64.c
+index 0649c1e..7788089 100644
+--- b64.c
++++ b64.c
+@@ -4,6 +4,7 @@
+ 
+ #include <openssl/bio.h>
+ #include <openssl/evp.h>
++#include <limits.h>
+ #include <stdint.h>
+ #include <string.h>
+ 
+diff --git util.c util.c
+index 3ec4e71..5989c6c 100644
+--- util.c
++++ util.c
+@@ -9,6 +9,7 @@
+ #include <openssl/ec.h>
+ #include <openssl/obj_mac.h>
+ 
++#include <limits.h>
+ #include <stdlib.h>
+ #include <fcntl.h>
+ #include <sys/stat.h>

--- a/srcpkgs/pam-u2f/template
+++ b/srcpkgs/pam-u2f/template
@@ -1,21 +1,20 @@
 # Template file for 'pam-u2f'
 pkgname=pam-u2f
-version=1.0.8
+version=1.1.0
 revision=1
 wrksrc="${pkgname/-/_}-${version}"
 build_style=gnu-configure
 configure_args="--with-pam-dir=/usr/lib/security"
-hostmakedepends="automake libtool pkg-config"
-makedepends="libu2f-host-devel libu2f-server-devel pam-devel"
+hostmakedepends="automake libtool pkg-config asciidoc"
+makedepends="libfido2-devel libressl-devel pam-devel"
 short_desc="Pluggable Authentication Module (PAM) for U2F"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://developers.yubico.com/pam-u2f/"
 #changelog="https://raw.githubusercontent.com/Yubico/pam-u2f/master/NEWS"
 distfiles="https://developers.yubico.com/pam-u2f/Releases/pam_u2f-${version}.tar.gz"
-checksum=52a203a6fab6160e06c1369ff104afed62007ca3ffbb40c297352232fa975c99
+checksum=0dc3bf96ebb69c6e398b5f8991493b37a8ce1af792948af71e694f695d5edc05
 
 post_install() {
 	vlicense COPYING
 }
-

--- a/srcpkgs/yubikey-manager/template
+++ b/srcpkgs/yubikey-manager/template
@@ -1,10 +1,10 @@
 # Template file for 'yubikey-manager'
 pkgname=yubikey-manager
 version=3.1.1
-revision=4
+revision=5
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="libu2f-host python3-fido2 python3-openssl python3-usb python3-pyscard
+depends="libfido2 python3-fido2 python3-openssl python3-usb python3-pyscard
  python3-click python3-cryptography python3-six pcsc-ccid python3-setuptools
  libykpers"
 checkdepends="$depends python3-pytest"


### PR DESCRIPTION
- libu2f-host is archived, and udev rules from libfido2 is more updated
- pam-u2f switched to libfido2 (tested by me on x86_64-musl)