### PR TITLE
jack: update to 1.9.16, add missing dependency

### DIFF
--- a/srcpkgs/jack/template
+++ b/srcpkgs/jack/template
@@ -1,12 +1,12 @@
 # Template file for 'jack'
 pkgname=jack
-version=1.9.14
+version=1.9.16
 revision=1
 wrksrc="jack2-${version}"
 build_style=waf3
 configure_args="--alsa --classic --dbus"
 hostmakedepends="pkg-config"
-makedepends="opus-devel libsamplerate-devel readline-devel dbus-devel celt-devel
+makedepends="opus-devel libsamplerate-devel readline-devel dbus-devel db-devel celt-devel
  $(vopt_if ffado libffado-devel)"
 depends="python3-dbus"
 short_desc="JACK Audio Connection Kit low-latency sound server (pro audio)"
@@ -14,7 +14,7 @@ maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://jackaudio.org/"
 distfiles="https://github.com/jackaudio/jack2/archive/v${version}.tar.gz"
-checksum=a20a32366780c0061fd58fbb5f09e514ea9b7ce6e53b080a44b11a558a83217c
+checksum=e176d04de94dcaa3f9d32ca1825091e1b938783a78c84e7466abd06af7637d37
 python_version=3
 
 # Package build options


### PR DESCRIPTION
`db-devel` is needed for jack metadata support https://github.com/falkTX/Carla/issues/1274#issuecomment-710136196