### PR TITLE
libguestfs: update update-libguestfs-appliance, fix license.

### DIFF
--- a/srcpkgs/libguestfs/files/update-libguestfs-appliance
+++ b/srcpkgs/libguestfs/files/update-libguestfs-appliance
@@ -17,8 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-VERSION=1.32.0
-SHA512SUM="202d0dde45612f9ef45cdb73cd4aeba6c75dcd52790e7f156b2ff404616887af4019e5bd061e3c6607f4f96ac136132c31d180dda31a71bfb31ade5da508b832"
+VERSION=1.40.1
+SHA512SUM="2d63b2ce8850929b42ddc91518b0e2b37d13e358be94bb54899da6c310afa308d708a3443b9f3b3aa3c46f4f2079036a6a4b34027788f183c17a20b68fcf4e6e"
 
 set -e
 umask 022

--- a/srcpkgs/libguestfs/template
+++ b/srcpkgs/libguestfs/template
@@ -1,7 +1,7 @@
 # Template file for 'libguestfs'
 pkgname=libguestfs
 version=1.42.0
-revision=3
+revision=4
 _version_short=${version%.*}
 build_style=gnu-configure
 make_install_args="INSTALLDIRS=vendor"
@@ -19,7 +19,7 @@ makedepends="ncurses-devel pcre-devel augeas-devel libxml2-devel gettext-devel f
  $(vopt_if php php-devel) $(vopt_if lua lua53-devel) $(vopt_if fuse fuse-devel)"
 short_desc="Access and modify virtual machine disk image"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2"
+license=" GPL-2.0-or-later"
 homepage="http://libguestfs.org"
 distfiles="http://libguestfs.org/download/${_version_short}-stable/${pkgname}-${version}.tar.gz"
 checksum=4fee192cf3aaa597f142afb21fa2d7f380fdabcf34d054e37090163e4a74f024
@@ -54,5 +54,6 @@ libguestfs-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
+		vmove usr/share/man/man3
 	}
 }


### PR DESCRIPTION
When doing something like "virt-filesystems -a void-rpi3-20191109.img" it fails with:

libguestfs: error: appliance closed the connection unexpectedly.
This usually means the libguestfs appliance crashed.

This update of the update-libguestfs-apliance script fix the problem.
