### PR TITLE
python3-numpy-stl: update to 2.12.0.

### DIFF
--- a/srcpkgs/python3-numpy-stl/template
+++ b/srcpkgs/python3-numpy-stl/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-numpy-stl'
 pkgname=python3-numpy-stl
-version=2.11.3
+version=2.12.0
 revision=1
 wrksrc="numpy-stl-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/WoLpH/numpy-stl/"
 distfiles="https://github.com/WoLpH/numpy-stl/archive/v${version}.tar.gz"
-checksum=c425c3cf7e3125fff2772a654202b29fb20ea47d43e194cb560acb1c59f8c724
+checksum=298ca92291a11eb26ea4b376c2bc47ea72542294299973c7600398bc0b41955f
 
 conflicts="python-numpy-stl>=0"
 


### PR DESCRIPTION
minor update
double-checked that it cross-builds