### PR TITLE
bubblewrap: use NetBSD realpath on musl 

### DIFF
--- a/srcpkgs/bubblewrap/patches/realpath-workaround.patch
+++ b/srcpkgs/bubblewrap/patches/realpath-workaround.patch
@@ -1,46 +1,249 @@
-add normpath(), originally written for xbps.
-diff --git bind-mount.c.orig bind-mount.c
-index 045fa0e..d05b540 100644
---- bind-mount.c.orig
-+++ bind-mount.c
-@@ -23,6 +23,28 @@
+--- /dev/null	2020-10-18 09:26:32.312745755 +0200
++++ LICENSE.realpath	2020-10-18 11:09:14.119929076 +0200
+@@ -0,0 +1,29 @@
++Copyright (c) 1989, 1991, 1993, 1995
++     The Regents of the University of California.  All rights reserved.
++
++This code is derived from software contributed to Berkeley by
++Jan-Simon Pendry.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions
++are met:
++1. Redistributions of source code must retain the above copyright
++   notice, this list of conditions and the following disclaimer.
++2. Redistributions in binary form must reproduce the above copyright
++   notice, this list of conditions and the following disclaimer in the
++   documentation and/or other materials provided with the distribution.
++3. Neither the name of the University nor the names of its contributors
++   may be used to endorse or promote products derived from this software
++   without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++SUCH DAMAGE.
+--- bind-mount.c	2018-09-26 14:55:17.000000000 +0200
++++ bind-mount.c	2020-10-18 11:08:37.822931452 +0200
+@@ -22,6 +22,198 @@
+ 
  #include "utils.h"
  #include "bind-mount.h"
- 
-+#ifndef __GLIBC__
-+static char *
-+normpath(char *path)
-+{
-+  char *seg = NULL, *p = NULL;
++#include <stdlib.h>
++#include <string.h>
++#include <limits.h>
++#include <unistd.h>
++#include <sys/stat.h>
++#include <errno.h>
++#include <fcntl.h>
++#include <sys/param.h>
 +
-+  for (p = path, seg = NULL; *p; p++) {
-+    if (strncmp(p, "/../", 4) == 0 || strncmp(p, "/..", 4) == 0) {
-+      memmove(seg ? seg : p, p+3, strlen(p+3) + 1);
-+      return normpath(path);
-+    } else if (strncmp(p, "/./", 3) == 0 || strncmp(p, "/.", 3) == 0) {
-+      memmove(p, p+2, strlen(p+2) + 1);
-+    } else if (strncmp(p, "//", 2) == 0 || strncmp(p, "/", 2) == 0) {
-+      memmove(p, p+1, strlen(p+1) + 1);
-+    }
-+    if (*p == '/')
-+      seg = p;
-+  }
-+  return path;
++#ifndef __GLIBC__
++/*
++ * Copyright (c) 1989, 1991, 1993, 1995
++ *      The Regents of the University of California.  All rights reserved.
++ *
++ * This code is derived from software contributed to Berkeley by
++ * Jan-Simon Pendry.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 3. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++char *realpath_int(const char *, char*);
++char *
++realpath_int(const char * path, char * resolved)
++{
++        struct stat sb;
++        int idx = 0, nlnk = 0;
++        const char *q;
++        char *p, wbuf[2][MAXPATHLEN], *fres;
++        size_t len;
++        ssize_t n;
++
++        /* POSIX sez we must test for this */
++        if (path == NULL) {
++                errno = EINVAL;
++                return NULL;
++        }
++
++        if (resolved == NULL) {
++                fres = resolved = malloc(MAXPATHLEN);
++                if (resolved == NULL)
++                        return NULL;
++        } else
++                fres = NULL;
++
++
++        /*
++         * Build real path one by one with paying an attention to .,
++         * .. and symbolic link.
++         */
++
++        /*
++         * `p' is where we'll put a new component with prepending
++         * a delimiter.
++         */
++        p = resolved;
++
++        if (*path == '\0') {
++                *p = '\0';
++                errno = ENOENT;
++                goto out;
++        }
++
++        /* If relative path, start from current working directory. */
++        if (*path != '/') {
++                /* check for resolved pointer to appease coverity */
++                if (resolved && getcwd(resolved, MAXPATHLEN) == NULL) {
++                        p[0] = '.';
++                        p[1] = '\0';
++                        goto out;
++                }
++                len = strlen(resolved);
++                if (len > 1)
++                        p += len;
++        }
++
++loop:
++        /* Skip any slash. */
++        while (*path == '/')
++                path++;
++
++        if (*path == '\0') {
++                if (p == resolved)
++                        *p++ = '/';
++                *p = '\0';
++                return resolved;
++        }
++
++        /* Find the end of this component. */
++        q = path;
++        do
++                q++;
++        while (*q != '/' && *q != '\0');
++
++        /* Test . or .. */
++        if (path[0] == '.') {
++                if (q - path == 1) {
++                        path = q;
++                        goto loop;
++                }
++                if (path[1] == '.' && q - path == 2) {
++                        /* Trim the last component. */
++                        if (p != resolved)
++                                while (*--p != '/')
++                                        continue;
++                        path = q;
++                        goto loop;
++                }
++        }
++
++        /* Append this component. */
++        if (p - resolved + 1 + q - path + 1 > MAXPATHLEN) {
++                errno = ENAMETOOLONG;
++                if (p == resolved)
++                        *p++ = '/';
++                *p = '\0';
++                goto out;
++        }
++        p[0] = '/';
++        memcpy(&p[1], path,
++            /* LINTED We know q > path. */
++            q - path);
++        p[1 + q - path] = '\0';
++
++        /*
++         * If this component is a symlink, toss it and prepend link
++         * target to unresolved path.
++         */
++        if (lstat(resolved, &sb) == -1)
++                goto out;
++
++        if (S_ISLNK(sb.st_mode)) {
++                if (nlnk++ >= MAXSYMLINKS) {
++                        errno = ELOOP;
++                        goto out;
++                }
++                n = readlink(resolved, wbuf[idx], sizeof(wbuf[0]) - 1);
++                if (n < 0)
++                        goto out;
++                if (n == 0) {
++                        errno = ENOENT;
++                        goto out;
++                }
++
++                /* Append unresolved path to link target and switch to it. */
++                if (n + (len = strlen(q)) + 1 > sizeof(wbuf[0])) {
++                        errno = ENAMETOOLONG;
++                        goto out;
++                }
++                memcpy(&wbuf[idx][n], q, len + 1);
++                path = wbuf[idx];
++                idx ^= 1;
++
++                /* If absolute symlink, start from root. */
++                if (*path == '/')
++                        p = resolved;
++                goto loop;
++        }
++        if (*q == '/' && !S_ISDIR(sb.st_mode)) {
++                errno = ENOTDIR;
++                goto out;
++        }
++
++        /* Advance both resolved and unresolved path. */
++        p += 1 + q - path;
++        path = q;
++        goto loop;
++out:
++        free(fres);
++        return NULL;
 +}
 +#endif
-+
+ 
  static char *
  skip_token (char *line, bool eat_whitespace)
- {
-@@ -397,7 +419,11 @@ bind_mount (int           proc_fd,
+@@ -395,9 +587,14 @@
+ 
+   /* The mount operation will resolve any symlinks in the destination
       path, so to find it in the mount table we need to do that too. */
-   resolved_dest = realpath (dest, NULL);
-   if (resolved_dest == NULL)
 +#ifdef __GLIBC__
-     return 2;
+   resolved_dest = realpath (dest, NULL);
+-  if (resolved_dest == NULL)
 +#else
-+    resolved_dest = normpath(strdup(dest));
++  resolved_dest = realpath_int (dest, NULL);
 +#endif
++  if (resolved_dest == NULL) {
+     return 2;
++  }
  
    mount_tab = parse_mountinfo (proc_fd, resolved_dest);
    if (mount_tab[0].mountpoint == NULL)

--- a/srcpkgs/bubblewrap/template
+++ b/srcpkgs/bubblewrap/template
@@ -1,7 +1,7 @@
 # Template file for 'bubblewrap'
 pkgname=bubblewrap
 version=0.4.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="libxslt docbook-xsl pkg-config"
 makedepends="libcap-devel"
@@ -11,3 +11,9 @@ license="LGPL-2.0-or-later"
 homepage="https://github.com/projectatomic/bubblewrap"
 distfiles="https://github.com/containers/bubblewrap/releases/download/v${version}/${pkgname}-${version}.tar.xz"
 checksum=b9c69b9b1c61a608f34325c8e1a495229bacf6e4a07cbb0c80cf7a814d7ccc03
+
+post_install() {
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		vlicense LICENSE.realpath
+	fi
+}


### PR DESCRIPTION
In some cases bubbewrap calls realpath without having /proc available,
but musl's realpath requires /proc.

@ericonr  