### PR TITLE
Manual.md: relax and clarify the "no sripts" policy

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -136,10 +136,11 @@ the Void packages system.
 1. Required: Another package either within the repository or pending inclusion
    requires the package.
 
-In particular, new themes and small shell scripts are highly unlikely
-to be accepted. New fonts are welcome if they provide value beyond
-aesthetics (e.g. they contain glyphs for a script missing in already
-packaged fonts).
+In particular, new themes are highly unlikely to be accepted. Simple shell
+scripts are unlikely to be accepted unless they provide considerable value to a
+broad user base. New fonts may be accepted if they provide value beyond
+aesthetics (e.g. they contain glyphs for a script missing in already packaged
+fonts).
 
 Browser forks, including those based on Chromium and Firefox, are generally not
 accepted. Such forks require heavy patching, maintenance and hours of build time.


### PR DESCRIPTION
I think our "no scripts" policy is too strict and precludes the inclusion of useful administrative tools. These are helpful to have packaged because it makes deploying new Void systems easier by keeping tools in one place. Based on a discussion in #xbps, I propose the following relaxed language that still gives us a reasonable justification for rejecting apparently useless scripts while admitting some more useful ones.