### PR TITLE
mellowplayer: update to 3.6.6.

### DIFF
--- a/srcpkgs/mellowplayer/template
+++ b/srcpkgs/mellowplayer/template
@@ -1,6 +1,6 @@
 # Template file for 'mellowplayer'
 pkgname=mellowplayer
-version=3.6.3
+version=3.6.6
 revision=1
 wrksrc="MellowPlayer-${version}"
 build_style=cmake
@@ -16,7 +16,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://colinduquesnoy.gitlab.io/MellowPlayer/"
 distfiles="https://gitlab.com/ColinDuquesnoy/MellowPlayer/-/archive/${version}/MellowPlayer-${version}.tar.bz2"
-checksum=f4f8f5e94a3d17b0d2ec8785ae1455991803e2c99a2781d56f1e253a73b41715
+checksum=17b8b25ca6b3d27b223f8be6ad80186ae5bd17ce762eb04ecd8b0e82e687b327
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools"


### PR DESCRIPTION
Closes https://github.com/void-linux/void-packages/issues/25415.