### PR TITLE
ccache: update to 4.0

### DIFF
--- a/common/environment/build-style/cmake.sh
+++ b/common/environment/build-style/cmake.sh
@@ -1,1 +1,3 @@
-hostmakedepends+=" cmake"
+if [ "$CHROOT_READY" ]; then
+	hostmakedepends+=" cmake"
+fi

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -1,7 +1,7 @@
 # Template file for 'base-chroot'
 pkgname=base-chroot
 version=0.66
-revision=3
+revision=4
 bootstrap=yes
 build_style=meta
 short_desc="Minimal set of packages required for chroot with xbps-src"
@@ -18,5 +18,5 @@ depends+="
  base-files binutils gcc gcc-ada libada-devel
  patch sed findutils diffutils make gzip coreutils
  file bsdtar ccache xbps mpfr ncurses libreadline8
- chroot-bash chroot-grep chroot-gawk chroot-distcc
- chroot-util-linux chroot-git"
+ chroot-bash chroot-grep chroot-gawk chroot-cmake
+ chroot-distcc chroot-util-linux chroot-git"

--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,11 +1,10 @@
 # Template file for 'ccache'
 pkgname=ccache
-version=3.7.12
+version=4.0
 revision=1
 bootstrap=yes
-build_style=gnu-configure
-make_check_args="CC=gcc"
-makedepends="zlib-devel"
+build_style=cmake
+makedepends="libzstd-devel zlib-devel"
 checkdepends="perl"
 short_desc="Fast C/C++ Compiler Cache"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -13,7 +12,18 @@ license="GPL-3.0-or-later"
 homepage="https://ccache.samba.org/"
 changelog="https://ccache.dev/releasenotes.html"
 distfiles="https://github.com/ccache/ccache/releases/download/v${version}/${pkgname}-${version}.tar.xz"
-checksum=a02f4e8360dc6618bc494ca35b0ae21cea080f804a4898eab1ad3fcd108eb400
+checksum=ac1b82fe0a5e39905945c4d68fcb24bd0f32344869faf647a1b8d31e544dcb88
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
+
+pre_configure() {
+	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+		vsed -i src/CMakeLists.txt \
+			-e "/add_library/a target_link_libraries(ccache_lib PRIVATE atomic)"
+	fi
+}
 
 post_install() {
 	vmkdir usr/lib/ccache/bin

--- a/srcpkgs/chroot-cmake/template
+++ b/srcpkgs/chroot-cmake/template
@@ -1,0 +1,44 @@
+# Template file for 'chroot-cmake'
+pkgname=chroot-cmake
+version=3.18.2
+revision=1
+wrksrc="${pkgname#chroot-}-${version}"
+bootstrap=yes
+build_style=configure
+configure_args="--prefix=/usr
+ --mandir=/share/man
+ --docdir=/share/doc/cmake
+ --no-system-curl
+ --system-expat
+ --no-system-jsoncpp
+ --system-zlib
+ --system-bzip2
+ --system-liblzma
+ --no-system-nghttp2
+ --system-zstd
+ --system-libarchive
+ --no-system-librhash
+ --no-system-libuv
+ ${XBPS_MAKEJOBS:+--parallel=$XBPS_MAKEJOBS}"
+makedepends="libarchive-devel expat-devel"
+short_desc="Cross-platform, open-source build system (chroot version)"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
+license="LGPL-2.1-or-later, BSD-3-Clause"
+homepage="https://www.cmake.org"
+distfiles="https://www.cmake.org/files/v${version%.*}/${pkgname#chroot-}-${version}.tar.gz"
+checksum=5d4e40fc775d3d828c72e5c45906b4d9b59003c9433ff1b36a1cb552bbd51d7e
+conflicts="cmake>=0"
+
+if [ "$CROSS_BUILD" ]; then
+	build_style=cmake
+	hostmakedepends="gcc-fortran"
+fi
+
+post_install() {
+	rm -rf ${DESTDIR}/usr/share/doc
+	rm -rf ${DESTDIR}/usr/share/cmake-${version%.*}/Help
+	# TODO: strip usr/share/cmake-${version%.*}/Modules/Compiler we don't need
+	vlicense Copyright.txt
+	vlicense Utilities/KWIML/Copyright.txt KWIML-Copyright.txt
+	vlicense Utilities/cmzlib/Copyright.txt cmzlib-Copyright.txt
+}

--- a/srcpkgs/cmake/template
+++ b/srcpkgs/cmake/template
@@ -1,7 +1,7 @@
 # Template file for 'cmake'
 pkgname=cmake
 version=3.18.2
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --mandir=/share/man --docdir=/share/doc/cmake
  --system-libs --no-system-jsoncpp ${XBPS_MAKEJOBS:+--parallel=$XBPS_MAKEJOBS}"
@@ -15,6 +15,7 @@ license="LGPL-2.1-or-later, BSD-3-Clause"
 homepage="https://www.cmake.org"
 distfiles="https://www.cmake.org/files/v${version%.*}/${pkgname}-${version}.tar.gz"
 checksum=5d4e40fc775d3d828c72e5c45906b4d9b59003c9433ff1b36a1cb552bbd51d7e
+conflicts="chroot-cmake>=0"
 
 if [ "$CROSS_BUILD" ]; then
 	# XXX ugly :-)

--- a/srcpkgs/expat/template
+++ b/srcpkgs/expat/template
@@ -1,7 +1,8 @@
 # Template file for 'expat'
 pkgname=expat
 version=2.2.10
-revision=1
+revision=2
+bootstrap=yes
 build_style=gnu-configure
 short_desc="XML parser library written in C"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
This release changes from using autoconf to cmake which is why
we need to remove the bootstrap=yes (N.B.: cmake is not bootstrap=yes).

I think we cannot turn `cmake` into a `bootstrap=yes` package.
Should we create a (legacy) chroot-ccache with a < 4.0 version?

There seems to be no way to build `ccache` >= 4.0 with just autoconf.