### PR TITLE
vdrift: remove unused dependency; minor fixes

### DIFF
--- a/srcpkgs/vdrift/template
+++ b/srcpkgs/vdrift/template
@@ -1,15 +1,15 @@
 # Template file for 'vdrift'
 pkgname=vdrift
 version=2014.10.20
-revision=9
+revision=10
 wrksrc="$pkgname"
 build_style=scons
 make_build_args="release=1 force_feedback=1 extbullet=1 datadir=share/${pkgname}"
 make_install_args="$make_build_args"
 hostmakedepends="gettext pkg-config"
-makedepends="asio libcurl-devel bullet-devel SDL2_image-devel glew-devel
+makedepends="libcurl-devel bullet-devel SDL2_image-devel glew-devel
  libvorbis-devel libarchive-devel MesaLib-devel"
-depends="vdrift-data-${version}_${revision}"
+depends="desktop-file-utils vdrift-data-${version}_${revision}"
 short_desc="Open source driving simulation made with drift racing in mind"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -35,7 +35,6 @@ post_install() {
 
 vdrift-data_package() {
 	short_desc+=" - data files"
-	archs=noarch
 	pkg_install() {
 		vmove usr/share/vdrift
 	}


### PR DESCRIPTION
vdrift does not require `asio`. I have no idea why this dependency was included.