### PR TITLE
freeplane: update to 1.8.8, remove noarch.

### DIFF
--- a/srcpkgs/freeplane/template
+++ b/srcpkgs/freeplane/template
@@ -1,8 +1,7 @@
 # Template file for 'freeplane'
 pkgname=freeplane
-version=1.8.7
+version=1.8.8
 revision=1
-archs=noarch
 hostmakedepends="apache-ant openjdk8 unzip gradle"
 depends="virtual?java-runtime"
 short_desc="Application for Mind Mapping, Knowledge Management, Project Management"
@@ -10,7 +9,7 @@ maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-or-later"
 homepage="http://freeplane.sourceforge.net/"
 distfiles="$SOURCEFORGE_SITE/$pkgname/$pkgname%20stable/${pkgname}_src-$version.tar.gz"
-checksum=3c65e4812f82b059d9b70a58b65c67d276181e3751cba38213363a1b4a47f98f
+checksum=e305910769f64c76ef5079714983f3161753f3b8801b1bd11df7e5fbb0c9ea6d
 
 make_dirs="
 /usr/share/freeplane/fwdir/condperm/ 755 root root


### PR DESCRIPTION
fixes ftbts.