### PR TITLE
common/shlibs: add shlibs for simavr

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3991,3 +3991,5 @@ libneatvnc.so.0 neatvnc-0.2.0_1
 libtdjson.so.1.6.0 libtd-1.6.0_1
 libJudy.so.1 judy-1.0.5_1
 libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2
+libsimavr.so.1 simavr-1.6_2
+libsimavrparts.so.1 simavr-1.6_2


### PR DESCRIPTION
Add missing shlib entries for `simavr`

Can someone explain why do we need to add shlibs manually?
How hard is to automate this process?