### PR TITLE
New package: simutron-1.0.1-SR2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3916,4 +3916,6 @@ libwinbind-client-samba4.so samba-libs-4.13.2_1
 libsixel.so.1 libsixel-1.8.6_1
 libpamtest.so.0 pam_wrapper-1.1.3_1
 libopenaptx.so.0 libopenaptx-0.2.0_1
+libsimavr.so.1 simavr-1.6_2
+libsimavrparts.so.1 simavr-1.6_2
 libsword-1.8.1.so libsword-1.8.1_6

--- a/srcpkgs/simutron/patches/remove-bitbang-from-firmware-c.patch
+++ b/srcpkgs/simutron/patches/remove-bitbang-from-firmware-c.patch
@@ -1,0 +1,13 @@
+--- plugins/avrmcu/plugin/firmware.c
++++ plugins/avrmcu/plugin/firmware.c
+@@ -118,10 +118,6 @@
+             case AVR_MMCU_TAG_SIMAVR_CONSOLE: {
+                 firmware->console_register_addr = src[0] | (src[1] << 8);
+             }	break;
+-			case AVR_MMCU_TAG_BITBANG: {
+-				firmware->bitbang_on_mask =
+-					src[0] | (src[1] << 8) | (src[2] << 16) | (src[3] << 24);
+-			}	break;
+         }
+         size -= next;
+         src += next - 2; // already incremented

--- a/srcpkgs/simutron/template
+++ b/srcpkgs/simutron/template
@@ -1,0 +1,24 @@
+# Template file for 'simutron'
+pkgname=simutron
+version=1.0.1
+revision=1
+_rev=SR2
+build_wrksrc=build
+build_style=qmake
+hostmakedepends="subversion qt5-qmake qt5-host-tools pkg-config"
+makedepends="simavr-devel qt5-devel"
+depends="libelf"
+short_desc="AVR simulator IDE"
+maintainer="Artur Sinila <opensource@logarithmus.dev>"
+license="GPL-3.0-only"
+homepage="https://sourceforge.net/projects/simutron/"
+nostrip_files="LCD20x4Test.elf"
+
+do_fetch() {
+	svn checkout "https://svn.code.sf.net/p/${pkgname}/code/branches/RB-${version}-${_rev}" "$wrksrc"
+}
+
+post_extract() {
+	rm share/simutron/examples/MENWIZ/LCD20x4Test/bin/Debug/LCD20x4Test.elf
+	rm share/simutron/examples/MENWIZ/LCD20x4Test/bin/Release/LCD20x4Test.elf
+}


### PR DESCRIPTION
Simulator for simple logic circuits and AVR microcontrollers (relies on `simavr` as a backend).
Requires https://github.com/void-linux/void-packages/pull/25741 to be merged.