### PR TITLE
gajim: rm update file

### DIFF
--- a/srcpkgs/gajim/update
+++ b/srcpkgs/gajim/update
@@ -1,1 +1,0 @@
-site="https://gajim.org/downloads.php?lang=en"


### PR DESCRIPTION
This file is unnecessary and, with this content, blocking update check.
No revbump or rebuild needed.

[ci-skip]