### PR TITLE
xbps-src/shutils/update_check.sh: add support for git.sr.ht

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -57,7 +57,8 @@ update_check() {
               *rubygems.org*|\
               *crates.io*|\
               *codeberg.org*|\
-              *hg.sr.ht*)
+              *hg.sr.ht*|\
+              *git.sr.ht*)
                 continue
                 ;;
             *)
@@ -144,6 +145,10 @@ update_check() {
             *hg.sr.ht*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
                 url="https://hg.sr.ht/$pkgurlname/tags"
+                rx='/archive/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")';;
+            *git.sr.ht*)
+                pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
+                url="https://git.sr.ht/$pkgurlname/refs"
                 rx='/archive/(v?|\Q'"$pkgname"'\E-)?\K[\d\.]+(?=\.tar\.gz")';;
             esac
         fi

--- a/srcpkgs/scdoc/update
+++ b/srcpkgs/scdoc/update
@@ -1,2 +1,0 @@
-site="https://git.sr.ht/%7Esircmpwn/scdoc/refs"
-pattern="scdoc/refs/\K[.\d]+(?=\")"

--- a/srcpkgs/snixembed/update
+++ b/srcpkgs/snixembed/update
@@ -1,2 +1,0 @@
-site="https://git.sr.ht/%7Esteef/snixembed/refs"
-pattern="snixembed/refs/\K[.\d]+(?=\")"


### PR DESCRIPTION
The code for `git.sr.ht` was almost identical to that of `hg.sr.ht`. The
main difference, aside from replacing `hg.sr.ht` in `url` with
`git.sr.ht`, was the endpoint of `url`. The `hg.sr.ht` url uses `tags`
whereas `git.sr.ht` uses `refs`.