### PR TITLE
speech-dispatcher: update to 0.10.1.

### DIFF
--- a/srcpkgs/speech-dispatcher/patches/0001-Fix-crash-with-python-3.9.patch
+++ b/srcpkgs/speech-dispatcher/patches/0001-Fix-crash-with-python-3.9.patch
@@ -1,0 +1,29 @@
+From 4fe066fefcbb28161b1053326867514a21f421b9 Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@gnome.org>
+Date: Fri, 11 Sep 2020 13:15:07 -0500
+Subject: [PATCH] Fix crash with python 3.9
+
+Thread.isAlive() was removed in python 3.9. Thread.is_alive() has been
+available since python 2.6, so let's use that.
+
+Fixes #402
+---
+ src/api/python/speechd/client.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/api/python/speechd/client.py b/src/api/python/speechd/client.py
+index ba7c0496..68200e2f 100644
+--- src/api/python/speechd/client.py
++++ src/api/python/speechd/client.py
+@@ -289,7 +289,7 @@ class _SSIP_Connection(object):
+         and return the triplet (code, msg, data)."""
+         # TODO: This check is dumb but seems to work.  The main thread
+         # hangs without it, when the Speech Dispatcher connection is lost.
+-        if not self._communication_thread.isAlive():
++        if not self._communication_thread.is_alive():
+             raise SSIPCommunicationError
+         self._ssip_reply_semaphore.acquire()
+         # The list is sorted, read the first item
+-- 
+2.28.0
+

--- a/srcpkgs/speech-dispatcher/template
+++ b/srcpkgs/speech-dispatcher/template
@@ -1,17 +1,20 @@
 # Template file for 'speech-dispatcher'
 pkgname=speech-dispatcher
-version=0.8.8
-revision=3
+version=0.10.1
+revision=1
+wrksrc="speechd-${version}"
 build_style=gnu-configure
-configure_args="--disable-static"
+# Disable support for sundry non-free TTS systems (said support causes
+# the pre-pkg step to fail on account of missing shlibs).
+configure_args="--disable-static --without-kali --without-ibmtts --without-baratinoo"
 short_desc="High-level device independent layer for speech synthesis interface"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2, LGPL-2.1, GFDL-1.2"
+license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
 homepage="http://devel.freebsoft.org/speechd"
-distfiles="http://devel.freebsoft.org/pub/projects/speechd/${pkgname}-${version}.tar.gz"
-checksum=3c2a89800d73403192b9d424a604f0e614c58db390428355a3b1c7c401986cf3
+distfiles="https://github.com/brailcom/speechd/archive/${version}.tar.gz"
+checksum=0c702d4acc4920818db3daa28ecf14004123b64514b4575c138874618835104c
 
-hostmakedepends="pkg-config intltool python3-devel texinfo"
+hostmakedepends="automake libtool gettext-devel pkg-config intltool python3-devel texinfo"
 makedepends="libltdl-devel glib-devel dotconf-devel libsndfile-devel libespeak-devel libao-devel python3-devel"
 depends="python3"
 conf_files="
@@ -20,6 +23,10 @@ conf_files="
  /etc/speech-dispatcher/*.conf"
 
 CFLAGS="-fcommon"
+
+pre_configure() {
+	autoreconf -fi
+}
 
 speech-dispatcher-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
Includes a patch pulled out of upstream's git repo that fixes a crash
under Python 3.9.