### PR TITLE
libsndfile: update checksum

### DIFF
--- a/srcpkgs/libsndfile/template
+++ b/srcpkgs/libsndfile/template
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://www.mega-nerd.com/libsndfile"
 distfiles="https://github.com/erikd/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.bz2"
-checksum=ec898634766595438142c76cf3bdd46b77305d4a295dd16b29d024122d7a4b3f
+checksum=9df273302c4fa160567f412e10cc4f76666b66281e7ba48370fb544e87e4611a
 
 libsndfile-progs_package() {
 	short_desc+=" - bundled cmdline apps"


### PR DESCRIPTION
[Note:](https://github.com/libsndfile/libsndfile/releases/tag/v1.0.30)
> libsndfile-1.0.30.tar.bz2 and libsndfile-1.0.30.tar.bz2.asc files were re-uploaded due to problems with incorrect line endings.
> Update the hashes if necessary. Sorry for the inconvenience.
