### PR TITLE
pandoc: unbreak i686 build

### DIFF
--- a/srcpkgs/pandoc/files/stack.yaml
+++ b/srcpkgs/pandoc/files/stack.yaml
@@ -34,6 +34,7 @@ extra-deps:
   - commonmark-0.1.0.1
   - commonmark-extensions-0.2.0.0
   - commonmark-pandoc-0.2.0.0
+  - unicode-transforms-0.3.7.1
 
 ghc-options:
    "$locals": -fhide-source-paths -Wno-missing-home-modules

--- a/srcpkgs/pandoc/template
+++ b/srcpkgs/pandoc/template
@@ -2,7 +2,7 @@
 pkgname=pandoc
 # Keep in sync with http://www.stackage.org/lts
 version=2.10.1
-revision=1
+revision=2
 _citeproc_version=0.17.0.1
 _sidenote_version=0.20.0
 _monad_gen_version=0.3.0.1
@@ -31,10 +31,6 @@ nopie_files="
  /usr/bin/pandoc-citeproc
  /usr/bin/pandoc-sidenote
 "
-
-case "$XBPS_TARGET_MACHINE" in
-	i686*) broken="https://build.voidlinux.org/builders/i686_builder/builds/28037/steps/shell_3/logs/stdio" ;;
-esac
 
 post_extract() {
 	sed -i 's/tasty .*,/tasty,/' pandoc-*/pandoc.cabal


### PR DESCRIPTION
As per composewell/unicode-transforms/issues/52 we simply need to update the version of `unicode-transforms` that pandoc depends on.