### PR TITLE
ansible: update to 2.10.1.

### DIFF
--- a/srcpkgs/ansible-base/template
+++ b/srcpkgs/ansible-base/template
@@ -1,0 +1,24 @@
+# Template file for 'ansible-base'
+pkgname=ansible-base
+version=2.10.2
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="${hostmakedepends} python3-cryptography python3-Jinja2 python3-paramiko
+ python3-yaml"
+checkdepends="python3-pytest"
+short_desc="Simple deployment, configuration management and execution framework"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="GPL-3.0-or-later"
+homepage="https://www.ansible.com/"
+distfiles="${PYPI_SITE}/a/ansible-base/ansible-base-${version}.tar.gz"
+checksum=c79fe108e13b286bad21734208624aaef9dabb49bb4211b13bc96d88829e22ab
+conflicts="ansible<2.10.1_1"
+
+post_install() {
+	vsconf examples/ansible.cfg
+	vsconf examples/hosts
+	for m in docs/man/man1/*.1; do
+		vman ${m}
+	done
+}

--- a/srcpkgs/ansible/template
+++ b/srcpkgs/ansible/template
@@ -1,23 +1,14 @@
 # Template file for 'ansible'
 pkgname=ansible
-version=2.9.13
-revision=2
+version=2.10.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="${hostmakedepends} python3-cryptography python3-Jinja2 python3-paramiko
- python3-yaml"
+depends="python3 ansible-base"
 checkdepends="python3-pytest"
 short_desc="Simple deployment, configuration management and execution framework"
-maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
-distfiles="https://releases.ansible.com/ansible/${pkgname}-${version}.tar.gz"
-checksum=3ab21588992fbfe9de3173aefd63da1267dc12892a60f5cfdc055fe19c549644
-
-post_install() {
-	vsconf examples/ansible.cfg
-	vsconf examples/hosts
-	for m in docs/man/man1/*.1; do
-		vman ${m}
-	done
-}
+distfiles="${PYPI_SITE}/a/ansible/ansible-${version}.tar.gz"
+checksum=75708c67e2ac926cea42856af72cbc9494bf8008197652f9609089f7b4c2515a


### PR DESCRIPTION
Ansible has been split into ansible-base and ansible, where ansible just contains modules and depends on ansible-base. There's still some warnings (both during build and install) I'd like to have someone with more python knowledge look over, but I've already deployed this on my workstation, works just fine.