### PR TITLE
salt: update to 3002

### DIFF
--- a/srcpkgs/salt/patches/ipv6addressscoped.patch
+++ b/srcpkgs/salt/patches/ipv6addressscoped.patch
@@ -1,0 +1,15 @@
+--- salt/_compat.py
++++ salt/_compat.py
+@@ -162,6 +162,9 @@ class IPv6AddressScoped(ipaddress.IPv6Address):
+         else:
+             self.__scope = None
+ 
++        # For compatibility with python3.9 ipaddress
++        self._scope_id = self.__scope
++
+         if sys.version_info.major == 2:
+             ipaddress._BaseAddress.__init__(self, address)
+             ipaddress._BaseV6.__init__(self, address)
+-- 
+2.29.0
+

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,7 +1,7 @@
 # Template file for 'salt'
 pkgname=salt
-version=3001.1
-revision=2
+version=3002
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-yaml python3-Jinja2 python3-requests python3-pyzmq
@@ -13,7 +13,7 @@ license="Apache-2.0"
 homepage="http://saltstack.org/"
 changelog="https://docs.saltstack.com/en/latest/topics/releases/${version}.html"
 distfiles="${PYPI_SITE}/s/salt/salt-${version}.tar.gz"
-checksum=e9ebb4d92fae8dabf21b8749dc126e4a4048bf8f613f5b1b851fe4b8226b5abc
+checksum=b622c9de9fde571db96bfd659a183bea553dd26e71cac85659387e937221aae6
 conf_files="
  /etc/salt/cloud.providers.d/digitalocean.conf
  /etc/salt/cloud.providers.d/vsphere.conf


### PR DESCRIPTION
Salt 3001 and 3002 would not work on Python 3.9 because the Salt team was using internal fields (`_underscore_prefixed`) from the Python standard library internally for Salt. When Python updated from 3.8 -> 3.9 some of those internal fields changed, so Salt broke. 

This PR updates Salt to version 3002 and includes [a patch by this lovely GitHub user](https://github.com/fepitre/salt/commit/4c5e18bfd092d9003d12c89131f787a57d54cf38) which fixes Salt's internal field issues.