### PR TITLE
tremc: add fix for python3.9

### DIFF
--- a/srcpkgs/tremc/patches/fix-python3.9.patch
+++ b/srcpkgs/tremc/patches/fix-python3.9.patch
@@ -1,0 +1,12 @@
+# upstream: yes
+--- tremc
++++ tremc
+@@ -438,7 +438,7 @@ class Transmission(object):
+                 # TAG_TORRENT_DETAILS, but just passing seems to help.(?)
+                 try:
+                     torrent_details = response['arguments']['torrents'][0]
+-                    torrent_details['pieces'] = base64.decodestring(bytes(torrent_details['pieces'], ENCODING))
++                    torrent_details['pieces'] = base64.decodebytes(bytes(torrent_details['pieces'], ENCODING))
+                     self.torrent_details_cache = torrent_details
+                     self.upgrade_peerlist()
+                 except IndexError:

--- a/srcpkgs/tremc/template
+++ b/srcpkgs/tremc/template
@@ -1,8 +1,7 @@
 # Template file for 'tremc'
 pkgname=tremc
 version=0.9.2
-revision=1
-archs=noarch
+revision=2
 build_style=gnu-makefile
 depends="python3"
 short_desc="Console client for the BitTorrent client Transmission"


### PR DESCRIPTION
base64.decodestring does not exist in python3 anymore. This fix is upstream, but no release was made yet.