### PR TITLE
dmd: update to 2.094.1

### DIFF
--- a/srcpkgs/dmd/files/musl.patch
+++ b/srcpkgs/dmd/files/musl.patch
@@ -1,0 +1,12 @@
+--- dmd/src/dmd/link.d
++++ dmd/src/dmd/link.d
+@@ -759,8 +759,7 @@
+             perror("unable to create pipe to linker");
+             return -1;
+         }
+-        // vfork instead of fork to avoid https://issues.dlang.org/show_bug.cgi?id=21089
+-        childpid = vfork();
++        childpid = fork();
+         if (childpid == 0)
+         {
+             // pipe linker stderr to fds[0]

--- a/srcpkgs/dmd/template
+++ b/srcpkgs/dmd/template
@@ -1,6 +1,6 @@
 # Template file for 'dmd'
 pkgname=dmd
-version=2.094.1
+version=2.095.0
 revision=1
 create_wrksrc=yes
 hostmakedepends="dmd2.091 which"
@@ -15,10 +15,10 @@ distfiles="
  https://github.com/dlang/druntime/archive/v${version}.tar.gz>druntime-${version}.tar.gz
  https://github.com/dlang/phobos/archive/v${version}.tar.gz>phobos-${version}.tar.gz
  http://downloads.dlang.org/releases/2.x/${version}/dmd.${version}.linux.tar.xz"
-checksum="63271e939dbe5c39e866074b97f53c515c2b9161fcae9bae1df3b38924b0098d
- 4bd91e438996363ec62f0b72392fa88f9d53ee73c51bea1c3be1ae97bd28d30c
- e84536c538f47247d4803a9d2163f32e4b1e03acac090fa195a77083147c556f
- 5208ef1babdb17bf63324d3fd439af774e4bb90d242d55c2471775deba3a399b"
+checksum="d8b54cdd885b86e2cc30ccb4ccc6923940b3bd79183b499889b86d34dd22621b
+ f8d6346aa13bdc6ff893eb9d9e5aa5e8ff5efe97dbfd92f7ecd8db8172d0c04a
+ f5c9606a988917a38b3b9a495c6da0d4e36b60beac8e805f6dea719d042d50d4
+ 02853f8a4988f55dab5daa1e0e9910ea91905b85bcaa7a5ffd83079147dc7d93"
 conf_files="/etc/dmd.conf"
 provides="d-compiler-${version}_${revision}"
 conflicts="dmd-bootstrap dmd2.081 dmd2.091"

--- a/srcpkgs/dmd/template
+++ b/srcpkgs/dmd/template
@@ -23,6 +23,7 @@ conf_files="/etc/dmd.conf"
 provides="d-compiler-${version}_${revision}"
 conflicts="dmd-bootstrap dmd2.081 dmd2.091"
 nopie=yes
+disable_parallel_build=yes
 LDFLAGS="-lpthread"
 
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/dmd/template
+++ b/srcpkgs/dmd/template
@@ -1,10 +1,10 @@
 # Template file for 'dmd'
 pkgname=dmd
-version=2.091.0
+version=2.094.1
 revision=1
 create_wrksrc=yes
-hostmakedepends="which"
-makedepends="dmd2.081 git"
+hostmakedepends="dmd2.091 which"
+makedepends="git"
 depends="libphobos>=${version} gcc"
 short_desc="Digital Mars D compiler"
 maintainer="streaks <assemblyislaw@gmail.com>"
@@ -15,13 +15,13 @@ distfiles="
  https://github.com/dlang/druntime/archive/v${version}.tar.gz>druntime-${version}.tar.gz
  https://github.com/dlang/phobos/archive/v${version}.tar.gz>phobos-${version}.tar.gz
  http://downloads.dlang.org/releases/2.x/${version}/dmd.${version}.linux.tar.xz"
-checksum="bcca38f4b80b51ae0a1955dc29e6cbfaa4d01d94869ddfcacf9292898c34343a
- cc8ba196b08cca04488d97d0e35c878f7351b7d8128aec90eaa312d2bd9a6af2
- df9f81eecda4366adc5ca9ed31a0b4474c248544b120ff6fa3f6cb45917d8769
- 6e4bd4ee73a553921cdca7e3e21768b842b18186d07c0b4898fbd13a359875c0"
+checksum="63271e939dbe5c39e866074b97f53c515c2b9161fcae9bae1df3b38924b0098d
+ 4bd91e438996363ec62f0b72392fa88f9d53ee73c51bea1c3be1ae97bd28d30c
+ e84536c538f47247d4803a9d2163f32e4b1e03acac090fa195a77083147c556f
+ 5208ef1babdb17bf63324d3fd439af774e4bb90d242d55c2471775deba3a399b"
 conf_files="/etc/dmd.conf"
 provides="d-compiler-${version}_${revision}"
-conflicts="dmd-bootstrap dmd2.081"
+conflicts="dmd-bootstrap dmd2.081 dmd2.091"
 nopie=yes
 LDFLAGS="-lpthread"
 
@@ -32,10 +32,15 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_extract() {
-	rm -rf dmd druntime phobos
 	mv dmd-${version} dmd
 	mv druntime-${version} druntime
 	mv phobos-${version} phobos
+}
+
+pre_configure() {
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		patch -p0 < ${FILESDIR}/musl.patch
+	fi
 }
 
 do_build() {

--- a/srcpkgs/dmd2.081/patches/backport-ld-exit.patch
+++ b/srcpkgs/dmd2.081/patches/backport-ld-exit.patch
@@ -1,0 +1,11 @@
+--- dmd/src/dmd/link.d
++++ dmd/src/dmd/link.d
+@@ -685,7 +685,7 @@ public int runLINK()
+             close(fds[0]);
+             execvp(argv[0], cast(char**)argv.tdata());
+             perror(argv[0]); // failed to execute
+-            return -1;
++            _exit(-1);
+         }
+         else if (childpid == -1)
+         {

--- a/srcpkgs/dmd2.081/template
+++ b/srcpkgs/dmd2.081/template
@@ -1,7 +1,7 @@
 # Template file for 'dmd2.081'
 pkgname=dmd2.081
 version=2.081.1
-revision=2
+revision=3
 create_wrksrc=yes
 hostmakedepends="which"
 makedepends="dmd-bootstrap"

--- a/srcpkgs/dmd2.091/files/dmd.conf
+++ b/srcpkgs/dmd2.091/files/dmd.conf
@@ -1,0 +1,2 @@
+[Environment]
+DFLAGS=-I/usr/include/d -I/usr/include/d/druntime/import -L-L/usr/lib -L-L/usr/lib -L--no-warn-search-mismatch -L--export-dynamic -fPIC

--- a/srcpkgs/dmd2.091/patches/backport-ld-exit.patch
+++ b/srcpkgs/dmd2.091/patches/backport-ld-exit.patch
@@ -1,0 +1,11 @@
+--- dmd/src/dmd/link.d
++++ dmd/src/dmd/link.d
+@@ -782,7 +782,7 @@ public int runLINK()
+             close(fds[0]);
+             execvp(argv[0], argv.tdata());
+             perror(argv[0]); // failed to execute
+-            return -1;
++            _exit(-1);
+         }
+         else if (childpid == -1)
+         {

--- a/srcpkgs/dmd2.091/template
+++ b/srcpkgs/dmd2.091/template
@@ -24,6 +24,7 @@ provides="d-compiler-${version}_${revision}"
 conflicts="dmd-bootstrap dmd2.081 libphobos2.081"
 nopie=yes
 nocross=yes
+disable_parallel_build=yes
 LDFLAGS="-lpthread"
 
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/dmd2.091/template
+++ b/srcpkgs/dmd2.091/template
@@ -1,0 +1,78 @@
+# Template file for 'dmd2.091'
+pkgname=dmd2.091
+version=2.091.0
+revision=1
+create_wrksrc=yes
+hostmakedepends="dmd2.081 which"
+makedepends="git"
+depends="gcc"
+short_desc="Digital Mars D compiler, 2.091"
+maintainer="Auri <me@aurieh.me>"
+license="BSL-1.0"
+homepage="http://www.digitalmars.com/d/2.0/"
+distfiles="
+ https://github.com/dlang/dmd/archive/v${version}.tar.gz>dmd-${version}.tar.gz
+ https://github.com/dlang/druntime/archive/v${version}.tar.gz>druntime-${version}.tar.gz
+ https://github.com/dlang/phobos/archive/v${version}.tar.gz>phobos-${version}.tar.gz
+ http://downloads.dlang.org/releases/2.x/${version}/dmd.${version}.linux.tar.xz"
+checksum="bcca38f4b80b51ae0a1955dc29e6cbfaa4d01d94869ddfcacf9292898c34343a
+ cc8ba196b08cca04488d97d0e35c878f7351b7d8128aec90eaa312d2bd9a6af2
+ df9f81eecda4366adc5ca9ed31a0b4474c248544b120ff6fa3f6cb45917d8769
+ 6e4bd4ee73a553921cdca7e3e21768b842b18186d07c0b4898fbd13a359875c0"
+conf_files="/etc/dmd.conf"
+provides="d-compiler-${version}_${revision}"
+conflicts="dmd-bootstrap dmd2.081 libphobos2.081"
+nopie=yes
+nocross=yes
+LDFLAGS="-lpthread"
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*) _archbits=64;;
+	i686) _archbits=32;;
+	*) broken="unsupported arch upstream";;
+esac
+
+post_extract() {
+	mv dmd-${version} dmd
+	mv druntime-${version} druntime
+	mv phobos-${version} phobos
+}
+
+do_build() {
+	local dmd
+
+	cd dmd
+	make ${makejobs} -f posix.mak MODEL=${_archbits} TARGET_CPU=X86 ENABLE_RELEASE=1 PIC=1
+	dmd=${wrksrc}/dmd/generated/linux/release/$_archbits/dmd
+
+	make ${makejobs} -C docs
+
+	cd ../druntime
+	make ${makejobs} -f posix.mak MODEL=${_archbits} DMD=$dmd ENABLE_RELEASE=1 PIC=1
+
+	cd ../phobos
+	make ${makejobs} -f posix.mak MODEL=${_archbits} DMD=$dmd ENABLE_RELEASE=1 PIC=1
+}
+
+do_install() {
+	cd dmd
+	vbin generated/linux/release/$_archbits/dmd
+	vinstall ${FILESDIR}/dmd.conf 644 etc
+
+	# note: dmd, druntime and phobos all share the same license
+	vlicense LICENSE.txt
+
+	vman generated/docs/man/man1/dmd.1
+	vman generated/docs/man/man5/dmd.conf.5
+
+	vmkdir usr/include/d
+
+	cd ../phobos
+	cp -r ./{*.d,etc,std} ${PKGDESTDIR}/usr/include/d
+	vinstall generated/linux/release/$_archbits/libphobos2.a 644 usr/lib libphobos2.a
+
+	cd ../druntime
+	vmkdir usr/include/d/druntime
+	cp -r import ${PKGDESTDIR}/usr/include/d/druntime
+	vinstall generated/linux/release/$_archbits/libdruntime.a 644 usr/lib libdruntime.a
+}


### PR DESCRIPTION
Also adds a new package, `dmd2.091`, which is required to bootstrap `2.094.1`, else the build fails with

```
Error: pointer cast from dmd.mtype.TypeTuple to immutable(void*)** is not supported at compile time
```
in `dmd/mtype.d`.