### PR TITLE
pinebookpro-kernel: add missing header files

### DIFF
--- a/srcpkgs/pinebookpro-kernel/template
+++ b/srcpkgs/pinebookpro-kernel/template
@@ -1,7 +1,7 @@
 # Template file for 'pinebookpro-kernel'
 pkgname=pinebookpro-kernel
 version=5.7.0
-revision=1
+revision=2
 archs="aarch64*"
 _commit=a8f4db8a726e5e4552e61333dcd9ea1ff35f39f9
 wrksrc="linux-pinebook-pro-${_commit}"
@@ -117,7 +117,7 @@ do_install() {
 	# Remove firmware stuff provided by the "linux-firmware" pkg.
 	rm -rf ${DESTDIR}/usr/lib/firmware
 
-	for i in acpi asm-generic clocksource config crypto drm generated linux \
+	for i in acpi asm-generic clocksource config crypto drm generated linux vdso \
 		math-emu media net pcmcia scsi sound trace uapi video xen dt-bindings; do
 		if [ -d include/$i ]; then
 			cp -a include/$i ${hdrdest}/include


### PR DESCRIPTION
The missing vdso header files prevented dkms from building zfs (and
probably other modules).

They're also included in the upstream 5.8 package https://github.com/void-linux/void-packages/blob/6d11ea5f69d561753a77854017e660a9deb8080d/srcpkgs/linux5.8/template#L182

I successfully cross compiled it on ppc64le (compiles successfully, result untested) and native on aarch64 (compiles successfully, result seems to work fine).
I'm currently building it on aarch64-musl but I'm not sure if that's relevant for a kernel package.