### PR TITLE
font-iosevka: update to 3.7.1

### DIFF
--- a/srcpkgs/font-iosevka/template
+++ b/srcpkgs/font-iosevka/template
@@ -1,6 +1,6 @@
 # Template file for 'font-iosevka'
 pkgname=font-iosevka
-version=3.6.2
+version=3.7.1
 revision=1
 create_wrksrc=yes
 depends="font-util"
@@ -12,8 +12,8 @@ distfiles="https://raw.githubusercontent.com/be5invis/Iosevka/v${version}/LICENS
  https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-${version}.zip
  https://github.com/be5invis/Iosevka/releases/download/v${version}/ttc-iosevka-slab-${version}.zip"
 checksum="e61c0988bb231a321f14cce1b119a468f279ea86826c32e943ab16dbf08c1ba9
- b108872310cd99fbeb3a13323acd62ef553f6873ce3de5e37ef1c9ae0792bfb1
- d99048a989bf82d38f015bfbc925256dd17ff4da43f96ee5b2b9fef2f9c819cb"
+ d9022b15e2a726a79bb154e8800bd650d0c6b8987c19c49ab698722b86334240
+ 41494ecca4888c06420e4fa0f6e2ff4f7ac15f0c01642455cb7c5be86fd979b1"
 
 font_dirs="/usr/share/fonts/TTF"
 


### PR DESCRIPTION
This PR update `font-iosevka` to v3.7.1: https://github.com/be5invis/Iosevka/releases/tag/v3.7.1