### PR TITLE
perl: set stack size for musl.

### DIFF
--- a/srcpkgs/perl/template
+++ b/srcpkgs/perl/template
@@ -1,7 +1,7 @@
 # Template file for 'perl'
 pkgname=perl
 version=5.30.3
-revision=1
+revision=2
 _perl_cross_version=1.3.1
 build_style=gnu-configure
 hostmakedepends="less"
@@ -10,7 +10,7 @@ depends="less"
 checkdepends="iana-etc perl-AnyEvent perl-Test-Pod procps-ng"
 short_desc="Practical Extraction and Report Language"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="Artistic-1.0-perl, GPL-1.0-or-later"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://www.perl.org"
 distfiles="https://www.cpan.org/src/5.0/perl-${version}.tar.gz
  https://github.com/arsv/perl-cross/releases/download/${_perl_cross_version}/perl-cross-${_perl_cross_version}.tar.gz"
@@ -164,7 +164,7 @@ do_configure() {
 		_args+=" --target=$XBPS_CROSS_TRIPLET"
 	fi
 
-	LDFLAGS+=" -pthread"
+	LDFLAGS+=" -Wl,-z,stack-size=2097152 -pthread"
 	export HOSTLDFLAGS+=" -pthread"
 
 	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then


### PR DESCRIPTION
Threaded perl programs can go over musl's default stack size, so setting
a bigger one in LDFLAGS is necessary to avoid segfaults. This segfault
was observed when using gscan2pdf to open an image.

@leahneukirchen 