### PR TITLE
ampache: update to 4.2.3

### DIFF
--- a/srcpkgs/ampache/template
+++ b/srcpkgs/ampache/template
@@ -1,8 +1,7 @@
 # Template file for 'ampache'
 pkgname=ampache
-version=3.9.0
+version=4.2.3
 revision=1
-archs=noarch
 create_wrksrc=yes
 hostmakedepends="unzip"
 depends="php mysql"
@@ -11,7 +10,7 @@ maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="AGPL-3.0-or-later"
 homepage="http://ampache.org"
 distfiles="https://github.com/ampache/ampache/releases/download/${version}/${pkgname}-${version}_all.zip"
-checksum=2c232e080eb9ea6c77cea7b078b89e94079f5629cfe7b1de578de92c1240b892
+checksum=26e5984d5582c0bd1789626c7b07ce86ada86d64e0e5549baac625236a36e5ad
 python_version=2
 
 do_install() {


### PR DESCRIPTION
Was tragically outdated with several CVEs to its name. This package is likely abandoned - I wouldn't mind taking ownership of it as I use the software myself.