### PR TITLE
fmt: update to 7.1.2.

### DIFF
--- a/srcpkgs/fmt/template
+++ b/srcpkgs/fmt/template
@@ -1,6 +1,6 @@
 # Template file for 'fmt'
 pkgname=fmt
-version=7.0.3
+version=7.1.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON -DFMT_DOC=OFF -DFMT_TEST=OFF"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/fmtlib/fmt"
 distfiles="https://github.com/fmtlib/fmt/archive/${version}.tar.gz"
-checksum=b4b51bc16288e2281cddc59c28f0b4f84fed58d016fb038273a09f05f8473297
+checksum=4119a1c34dff91631e1d0a3707428f764f1ea22fe3cd5e70af5b4ccd5513831c
 
 post_install() {
 	vlicense LICENSE.rst LICENSE


### PR DESCRIPTION
Waiting on https://github.com/fmtlib/fmt/issues/1961 , though I'm not 100% sure we were hit. Only kodi and mkvtoolnix are dynamically linked to fmt.