### PR TITLE
tzdata 2020d

### DIFF
--- a/srcpkgs/tzdata/template
+++ b/srcpkgs/tzdata/template
@@ -1,7 +1,7 @@
 # Template file for 'tzdata'
 pkgname=tzdata
-version=2020a
-revision=2
+version=2020d
+revision=1
 wrksrc=tzdata
 create_wrksrc=yes
 hostmakedepends="tzutils"
@@ -10,16 +10,16 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="Public Domain"
 homepage="http://www.iana.org/time-zones"
 distfiles="http://www.iana.org/time-zones/repository/releases/tzdata${version}.tar.gz"
-checksum=547161eca24d344e0b5f96aff6a76b454da295dc14ed4ca50c2355043fb899a2
+checksum=8d813957de363387696f05af8a8889afa282ab5016a764c701a20758d39cbaf3
 
 do_install() {
 	local timezones="africa antarctica asia australasia europe northamerica \
-		southamerica pacificnew etcetera backward systemv factory"
+		southamerica etcetera backward factory"
 
-	zic -y ./yearistype -d ${DESTDIR}/usr/share/zoneinfo ${timezones}
-	zic -y ./yearistype -d ${DESTDIR}/usr/share/zoneinfo/posix ${timezones}
-	zic -y ./yearistype -d ${DESTDIR}/usr/share/zoneinfo/right -L leapseconds ${timezones}
+	zic -b fat -d ${DESTDIR}/usr/share/zoneinfo ${timezones}
+	zic -b fat -d ${DESTDIR}/usr/share/zoneinfo/posix ${timezones}
+	zic -b fat -d ${DESTDIR}/usr/share/zoneinfo/right -L leapseconds ${timezones}
 
-	zic -y ./yearistype -d ${DESTDIR}/usr/share/zoneinfo -p America/New_York
+	zic -b fat -d ${DESTDIR}/usr/share/zoneinfo -p America/New_York
 	install -m444 -t ${DESTDIR}/usr/share/zoneinfo iso3166.tab zone1970.tab zone.tab
 }

--- a/srcpkgs/tzutils/template
+++ b/srcpkgs/tzutils/template
@@ -1,6 +1,6 @@
 # Template file for 'tzutils'
 pkgname=tzutils
-version=2020a
+version=2020d
 revision=1
 wrksrc="tz-${version}"
 short_desc="Time zone and daylight-saving time utilities"
@@ -8,7 +8,7 @@ maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
 license="Public Domain, BSD-3-Clause"
 homepage="https://www.iana.org/time-zones"
 distfiles="https://github.com/eggert/tz/archive/${version}.tar.gz"
-checksum=9d41f0789dfaa9f6793f25d483888e41871d40291e8369ee991496b49194b533
+checksum=6b9ec90e79593913f687e3af5d880eaa036bb0aafea9707682b0cbd00fadbb09
 
 do_build() {
 	make TZDIR=/usr/share/zoneinfo CC=$CC CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"


### PR DESCRIPTION
Use the (as of 2020b non-default) `fat` option, else Go parses DST wrong.