### PR TITLE
New package: avra-1.4.2

### DIFF
--- a/srcpkgs/avra/template
+++ b/srcpkgs/avra/template
@@ -1,0 +1,15 @@
+# Template file for 'avra'
+pkgname=avra
+version=1.4.2
+revision=1
+build_style=gnu-makefile
+short_desc="Assembler for the Atmel AVR microcontroller family"
+maintainer="Artur Sinila <opensource@logarithmus.dev>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/Ro5bert/avra"
+distfiles="https://github.com/Ro5bert/${pkgname}/archive/${version}.tar.gz"
+checksum=cc56837be973d1a102dc6936a0b7235a1d716c0f7cd053bf77e0620577cff986
+
+pre_build() {
+	CFLAGS="-DVERSION=\\\"$version\\\""
+}


### PR DESCRIPTION
Assembler for the Atmel AVR microcontroller family.
I had to explicitly specify commit hash, because 1.4.2 tag fails to build.
The author fixed it but didn't bump the version.