### PR TITLE
gpsim: remove #include "../config.h" from breakpoints.h to prevent errors about missing config.h

### DIFF
--- a/srcpkgs/gpsim/template
+++ b/srcpkgs/gpsim/template
@@ -1,7 +1,7 @@
 # Template file for 'gpsim'
 pkgname=gpsim
 version=0.31.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel popt-devel readline-devel"
@@ -13,7 +13,8 @@ distfiles="https://sourceforge.net/projects/gpsim/files/gpsim/${version}/gpsim-$
 checksum=110ee6be3a5d02b32803a91e480cbfc9d423ef72e0830703fc0bc97b9569923f
 
 pre_configure() {
-	vsed -i -e 's/#include "error.h"//' src/modules.cc
+	vsed -i src/modules.cc -e 's/#include "error.h"//'
+	vsed -i src/breakpoints.h -e 's/#include "\.\.\/config.h"//'
 }
 
 gpsim-devel_package() {
@@ -21,6 +22,7 @@ gpsim-devel_package() {
 	depends="gpsim-${version}_${revision} gtk+-devel popt-devel readline-devel"
 	pkg_install() {
 		vmove usr/include/gpsim
+		vmove usr/include/eXdbm
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 	}


### PR DESCRIPTION
When using `breakpoints.h` from `gpsim-devel` package, program fails to build due to missing `config.h` header.
AFAIK this header is generated automatically by `autotools` and exists only during the build process.

Another fix is installing `eXdbm` headers along with `gpsim`.