### PR TITLE
qt5-webengine: apply upstream backported nullptr patch

### DIFF
--- a/srcpkgs/qt5-webengine/patches/0200-nullptr-rtcpeerconnectionhandler.patch
+++ b/srcpkgs/qt5-webengine/patches/0200-nullptr-rtcpeerconnectionhandler.patch
@@ -1,0 +1,39 @@
+From 4e828b3bd2d410151dc2574d084bed631dac42ca Mon Sep 17 00:00:00 2001
+From: Daniel McArdle <dmcardle@chromium.org>
+Date: Thu, 16 Apr 2020 20:18:47 +0000
+Subject: [PATCH] [Backport] Fix for bug 1071327
+
+Manual backport of patch originally reviewed on
+https://chromium-review.googlesource.com/c/chromium/src/+/2153325:
+Avoid nullptr dereference in RTCPeerConnectionHandler
+
+Bug: 1071327
+Fixes: QTBUG-86752
+Change-Id: Icf4189905dc5c95854b5af4b3e5e25e0607dd39e
+Reviewed-by: Allan Sandfeld Jensen <allan.jensen@qt.io>
+---
+
+diff --git a/chromium/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc b/chromium/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+index 5a68327..371f25c 100644
+--- a/src/3rdparty/chromium/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
++++ b/src/3rdparty/chromium/third_party/blink/renderer/modules/peerconnection/rtc_peer_connection_handler.cc
+@@ -2319,7 +2319,8 @@
+ 
+ void RTCPeerConnectionHandler::OnModifySctpTransport(
+     blink::WebRTCSctpTransportSnapshot state) {
+-  client_->DidModifySctpTransport(state);
++  if (client_)
++    client_->DidModifySctpTransport(state);
+ }
+ 
+ void RTCPeerConnectionHandler::OnModifyTransceivers(
+@@ -2446,7 +2447,8 @@
+ }
+ 
+ void RTCPeerConnectionHandler::OnInterestingUsage(int usage_pattern) {
+-  client_->DidNoteInterestingUsage(usage_pattern);
++  if (client_)
++    client_->DidNoteInterestingUsage(usage_pattern);
+ }
+ 
+ webrtc::SessionDescriptionInterface*

--- a/srcpkgs/qt5-webengine/template
+++ b/srcpkgs/qt5-webengine/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5-webengine'
 pkgname=qt5-webengine
 version=5.15.1
-revision=1
+revision=2
 archs="x86_64* i686* armv[67]* ppc64* aarch64*"
 wrksrc="qtwebengine-everywhere-src-${version}"
 build_style=qmake


### PR DESCRIPTION
Refs qutebrowser/qutebrowser#5721, applies upstream patch https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/315691 which resolves renderer crashes in some WebRTC flows (it's especially bad in video calls, eg. Hangouts and Jitsi, where I routinely drop off the call by way of tab crashes every few minutes).