### PR TITLE
libass: update to 0.15.0

### DIFF
--- a/srcpkgs/libass/template
+++ b/srcpkgs/libass/template
@@ -1,6 +1,6 @@
 # Template build file for 'libass.
 pkgname=libass
-version=0.14.0
+version=0.15.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool yasm pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://github.com/libass/libass/"
 license="MIT"
 distfiles="https://github.com/libass/libass/archive/${version}.tar.gz"
-checksum=82e70ee1f9afe2e54ab4bf6510b83bb563fcb2af978f0f9da82e2dbc9ae0fd72
+checksum=232b1339c633e6a93c153cac7a483e536944921605f35fcbaedc661c62fb49ec
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
Pretty big release, patches a few low-severity vulnerabilities. https://github.com/libass/libass/releases/tag/0.15.0

Tested on: `x86_64`,  `i686`, `x86_64-musl`.

Was unable to test on `i686-musl` because building `m4` fails for whatever reason, will have to sort that out but no reason it shouldn't work.