### PR TITLE
python3-rsa: update to 4.6

### DIFF
--- a/srcpkgs/python3-rsa/template
+++ b/srcpkgs/python3-rsa/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-rsa'
 pkgname=python3-rsa
-version=4.0
-revision=4
+version=4.6
+revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,6 +11,6 @@ maintainer="Peter Bui <pnutzh4x0r@gmail.com>"
 license="Apache-2.0"
 homepage="https://stuvel.eu/rsa"
 distfiles="${PYPI_SITE}/r/rsa/rsa-${version}.tar.gz"
-checksum=1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487
+checksum=109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa
 
 conflicts="python-rsa>=0"


### PR DESCRIPTION
Resolves CVE-2020-13757 and drops Python 2.7 support, which is no big deal, since the only two packages (`python3-google-auth` and `python3-Telethon`) to depend on it both run on Python 3.