### PR TITLE
OpenRCT2: update to 0.3.2

### DIFF
--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -2,33 +2,41 @@
 # based on https://raw.githubusercontent.com/AluisioASG/void-packages/openrct2/srcpkgs/OpenRCT2/template
 # and https://github.com/void-linux/void-packages/issues/1014#issuecomment-417372421
 pkgname=OpenRCT2
-_objects_version=1.0.15
-_titles_version=0.1.2
-version=0.2.6
-revision=3
+_objects_version=1.0.18
+_titles_version=0.1.2c
+version=0.3.2
+revision=1
 build_style=cmake
-configure_args="$(vopt_if multiplayer "" "-DDISABLE_HTTP_TWITCH=1 -DDISABLE_NETWORK=1")"
+configure_args="
+ -DOPENRCT2_VERSION_TAG=${version}
+ -DDOWNLOAD_TITLE_SEQUENCES=0
+ -DDOWNLOAD_OBJECTS=0
+ $(vopt_if multiplayer '' '-DDISABLE_NETWORK=1')
+ $(vopt_if scripting '-DENABLE_SCRIPTING=1' '')"
 hostmakedepends="pkg-config unzip"
 makedepends="SDL2-devel fontconfig-devel freetype-devel libzip-devel
- libpng-devel speexdsp-devel jansson-devel icu-devel zlib-devel
- $(vopt_if multiplayer libcurl-devel) $(vopt_if multiplayer libressl-devel)"
+ libpng-devel speexdsp-devel jansson-devel icu-devel zlib-devel json-c++
+ $(vopt_if multiplayer 'libcurl-devel libressl-devel')
+ $(vopt_if scripting duktape-devel)"
 short_desc="Open source re-implementation of RollerCoaster Tycoon 2"
 maintainer="klardotsh <josh@klar.sh>"
 license="GPL-3.0-or-later"
 homepage="https://openrct2.io"
+# use title-sequences.zip to match CMakeLists instruction
 distfiles="https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz
  https://github.com/OpenRCT2/objects/releases/download/v${_objects_version}/objects.zip
- https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequence-v${_titles_version}.zip"
-checksum="0e05a709d3e07343cd72e4db4cb4f1a6d9956f8acf7da682d2a3940c3112776e
- 0171907a267c564071e587fc683bfe75f36b891a6769e0bd49a6fc46f2ae7ded
- dcb1648739b351e857e2d19fed1626bec561d5e9f4b49201568f42c475ee7e61"
-skip_extraction="objects.zip title-sequence-v${_titles_version}.zip"
+ https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequences.zip"
+checksum="66c1c7ae8c765397e324b1aac59907bd5197dbad88597133aaba8a9480627c36
+ bf8a28b7ccebaf58e4e9eb2540534632830534cf0b3f73677521dc555878c682
+ 5284333fa501270835b5f0cf420cb52155742335f5658d7889ea35d136b52517"
+skip_extraction="objects.zip title-sequences.zip"
 
 replaces="OpenRCT2-data>=0"
 
-build_options="multiplayer"
-build_options_default="multiplayer"
+build_options="multiplayer scripting"
+build_options_default="multiplayer scripting"
 desc_option_multiplayer="Enable multiplayer support"
+desc_option_scripting="Enable script / plugin support"
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="not yet implemented"
@@ -49,5 +57,7 @@ post_extract() {
 	_srcdir="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
 	mkdir -p data/object data/title
 	unzip -qd data/object "${_srcdir}/objects.zip"
-	unzip -qd data/title "${_srcdir}/title-sequence-v${_titles_version}.zip"
+	unzip -qd data/sequence "${_srcdir}/title-sequences.zip"
+
+	vsed -i CMakeLists.txt -e "s; -Werror;;"
 }

--- a/srcpkgs/json-c++/template
+++ b/srcpkgs/json-c++/template
@@ -1,9 +1,10 @@
 # Template file for 'json-c++'
 pkgname=json-c++
 version=3.9.1
-revision=1
+revision=2
 wrksrc="json-${version}"
 build_style=cmake
+configure_args="-DJSON_MultipleHeaders=ON"
 checkdepends="git"
 short_desc="JSON for modern C++"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"


### PR DESCRIPTION
Update to 0.3.1, the new title sequences directory, the scripting API, and all the other funsies that came in the new version.

I playtested this for a few minutes online on `x86_64-musl` and I see nothing obviously broken yet.