### PR TITLE
apparmor: update to 3.0.0

### DIFF
--- a/srcpkgs/apparmor/INSTALL.msg
+++ b/srcpkgs/apparmor/INSTALL.msg
@@ -1,2 +1,1 @@
-To ensure AppArmor is enabled upon reboot add 'apparmor=1 security=apparmor' to your grub CMDLINE and rebuild your grub config with 'grub-mkconfig -o /boot/grub/grub.cfg'.
-You'll also need to swith 'APPARMOR' setting in /etc/default/apparmor to your taste.
+To configure AppArmor properly, please refer to the Void Linux Handbook: https://docs.voidlinux.org/config/security/apparmor.html

--- a/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.dhcpcd
@@ -1,10 +1,12 @@
 # vim:syntax=apparmor
 
-#include <tunables/global>
+abi <abi/3.0>,
+
+include <tunables/global>
 
 profile dhcpcd /{usr/,}bin/dhcpcd {
-  #include <abstractions/base>
-  #include <abstractions/nameservice>
+  include <abstractions/base>
+  include <abstractions/nameservice>
 
   capability chown,
   capability fowner,
@@ -16,8 +18,10 @@ profile dhcpcd /{usr/,}bin/dhcpcd {
   capability setgid,
   capability sys_admin,
   capability sys_chroot,
+  capability bpf,
 
   network packet dgram,
+  network packet raw,
   network inet raw,
   network inet6 raw,
 
@@ -58,5 +62,5 @@ profile dhcpcd /{usr/,}bin/dhcpcd {
   owner @{PROC}/@{pid}/stat r,
 
   # Site-specific additions and overrides. See local/README for details.
-  #include <local/usr.bin.dhcpcd>
+  include if exists <local/usr.bin.dhcpcd>
 }

--- a/srcpkgs/apparmor/files/profiles/usr.bin.nginx
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.nginx
@@ -1,25 +1,23 @@
 # vim:syntax=apparmor
 
+abi <abi/3.0>,
+
 # NOTE: This profile will by default work with pfp-fpm on TCP sockets.
 # If you need to make use of php-fpm unix socket, add the following to local/usr.bin.nginx
 # /path/to/your/unix/socket rw,
 
-#include <tunables/global>
+include <tunables/global>
 
-/usr/bin/nginx {
-  #include <abstractions/base>
-  #include <abstractions/nameservice>
-  #include <abstractions/nis>
-  #include <abstractions/openssl>
+profile nginx /usr/bin/nginx {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/nis>
+  include <abstractions/openssl>
 
   capability setgid,
   capability setuid,
 
-  # XXX: Maybe switch to "/etc/nginx/** r," ?
-  /etc/nginx/*.conf r,
-  /etc/nginx/*_params r,
-  /etc/nginx/conf.d/* r,
-  /etc/nginx/mime.types r,
+  /etc/nginx/** r,
 
   /run/nginx.pid rw,
 
@@ -30,5 +28,5 @@
   /var/log/nginx/* w,
 
   # Site-specific additions and overrides. See local/README for details.
-  #include <local/usr.bin.nginx>
+  include if exists <local/usr.bin.nginx>
 }

--- a/srcpkgs/apparmor/files/profiles/usr.bin.php-fpm
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.php-fpm
@@ -1,22 +1,24 @@
 # vim:syntax=apparmor
 
+abi <abi/3.0>,
+
 # NOTE: This profile uses TCP sockets by default
 # If you wish for php-fpm to listen to unix socket,
 # add the following permission to local/usr.bin.php-fpm
 # /path/to/your/unix/socket w,
 
-#include <tunables/global>
+include <tunables/global>
 
 # This is PHP open_basedir where script can only be executed from.
 # /home, /tmp have been removed to not open permissions too widely
 # /usr/share/pear have been removed to have its own permission
 @{PHP_BASEDIRS} = /srv/www/ /var/www/ /usr/share/webapps/
 
-/usr/bin/php-fpm {
-  #include <abstractions/base>
-  #include <abstractions/nameservice>
-  #include <abstractions/openssl>
-  #include <abstractions/php>
+profile php-fpm /usr/bin/php-fpm {
+  include <abstractions/base>
+  include <abstractions/nameservice>
+  include <abstractions/openssl>
+  include <abstractions/php>
 
   capability setgid,
   capability setuid,
@@ -38,7 +40,6 @@
   /var/log/php-fpm.log w,
 
   # Site-specific additions and overrides. See local/README for details.
-  #include <local/usr.bin.php-fpm>
+  include if exists <local/usr.bin.php-fpm>
 
 }
-

--- a/srcpkgs/apparmor/files/profiles/usr.bin.pulseaudio
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.pulseaudio
@@ -1,12 +1,16 @@
-#include <tunables/global>
+# vim:syntax=apparmor
+
+abi <abi/3.0>,
+
+include <tunables/global>
 
 profile pulseaudio /usr/bin/pulseaudio {
-  #include <abstractions/base>
-  #include <abstractions/audio>
-  #include <abstractions/dbus-session>
-  #include <abstractions/dbus-strict>
-  #include <abstractions/nameservice>
-  #include <abstractions/X>
+  include <abstractions/base>
+  include <abstractions/audio>
+  include <abstractions/dbus-session>
+  include <abstractions/dbus-strict>
+  include <abstractions/nameservice>
+  include <abstractions/X>
 
   dbus send
        bus=system
@@ -67,11 +71,16 @@ profile pulseaudio /usr/bin/pulseaudio {
   /sys/devices/virtual/sound/**/uevent r,
 
   /usr/share/alsa/** r,
-  /usr/share/applications/ r,
-  /usr/share/applications/* r,
   /usr/share/pulseaudio/** r,
   /usr/lib/pulse-[1-9]*.[0-9]/modules/*.so mr,
   /usr/libexec/pulse/gsettings-helper Cx,
+
+  /usr/{,local/}share/applications/ r,
+  /usr/{,local/}share/applications/* r,
+  owner @{HOME}/.local/share/{,flatpak/exports/share/}applications/ r,
+  owner @{HOME}/.local/share/{,flatpak/exports/share/}applications/* r,
+  /var/lib/flatpak/exports/share/applications/ r,
+  /var/lib/flatpak/exports/share/applications/* r,
 
   owner /var/lib/gdm3/.config/pulse/ rw,
   owner /var/lib/gdm3/.config/pulse/* rw,
@@ -106,9 +115,9 @@ profile pulseaudio /usr/bin/pulseaudio {
   owner /tmp/.esd-@{pid}*/socket rw,
 
   profile pulse-gsettings-helper /usr/libexec/pulse/gsettings-helper {
-    #include <abstractions/base>
-    #include <abstractions/gnome>
-    #include <abstractions/dconf>
+    include <abstractions/base>
+    include <abstractions/gnome>
+    include <abstractions/dconf>
 
     /usr/libexec/pulse/gsettings-helper mr,
     owner /{,var/}run/user/*/dconf/user rw,
@@ -118,6 +127,6 @@ profile pulseaudio /usr/bin/pulseaudio {
   }
 
   # Site-specific additions and overrides. See local/README for details.
-  #include <local/usr.bin.pulseaudio>
+  include if exists <local/usr.bin.pulseaudio>
 }
 

--- a/srcpkgs/apparmor/files/profiles/usr.bin.uuidd
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.uuidd
@@ -1,10 +1,12 @@
 # vim:syntax=apparmor
 
-#include <tunables/global>
+abi <abi/3.0>,
 
-/usr/bin/uuidd {
-  #include <abstractions/base>
-  #include <abstractions/consoles>
+include <tunables/global>
+
+profile uuid /usr/bin/uuidd {
+  include <abstractions/base>
+  include <abstractions/consoles>
 
   network inet dgram,
 
@@ -13,5 +15,5 @@
   /run/uuidd/request rw,
 
   # Site-specific additions and overrides. See local/README for details.
-  #include <local/usr.bin.uuidd>
+  include if exists <local/usr.bin.uuidd>
 }

--- a/srcpkgs/apparmor/files/profiles/usr.bin.wpa_supplicant
+++ b/srcpkgs/apparmor/files/profiles/usr.bin.wpa_supplicant
@@ -1,8 +1,12 @@
-#include <tunables/global>
+# vim:syntax=apparmor
 
-/usr/bin/wpa_supplicant {
-  #include <abstractions/base>
-  #include <abstractions/dbus-strict>
+abi <abi/3.0>,
+
+include <tunables/global>
+
+profile wpa_supplicant /usr/bin/wpa_supplicant {
+  include <abstractions/base>
+  include <abstractions/dbus-strict>
 
   capability net_admin,
   capability net_raw,
@@ -45,5 +49,5 @@
        bus=system
        path=/fi/epitest/hostap/WPASupplicant/**,
 
-  #include <local/usr.bin.wpa_supplicant>
+  include if exists <local/usr.bin.wpa_supplicant>
 }

--- a/srcpkgs/apparmor/patches/correct_paths_logprofconf.patch
+++ b/srcpkgs/apparmor/patches/correct_paths_logprofconf.patch
@@ -1,5 +1,14 @@
+From 6f2649203d6bfc26b79f624b5b4625603923bccd Mon Sep 17 00:00:00 2001
+From: Paper <paper@tilde.institute>
+Date: Wed, 21 Oct 2020 10:20:47 +0200
+Subject: [PATCH] correct paths in logprof.conf
+
+---
+ utils/logprof.conf | 17 ++++++++---------
+ 1 file changed, 8 insertions(+), 9 deletions(-)
+
 diff --git a/utils/logprof.conf b/utils/logprof.conf
-index a3d7a31..296dd8b 100644
+index a778792..a9f7b79 100644
 --- a/utils/logprof.conf
 +++ b/utils/logprof.conf
 @@ -14,7 +14,7 @@
@@ -11,19 +20,42 @@ index a3d7a31..296dd8b 100644
    ldd = /usr/bin/ldd
    logger = /bin/logger /usr/bin/logger
  
-@@ -36,10 +36,10 @@
-   custom_includes =
+@@ -51,12 +51,10 @@
+   /bin/mount    = u
+   /usr/bin/mount = u
+   /etc/init.d/subdomain = u
+-  /sbin/cardmgr = u
+-  /usr/sbin/cardmgr = u
+-  /sbin/subdomain_parser = u
+-  /usr/sbin/subdomain_parser = u
+-  /usr/sbin/genprof = u
+-  /usr/sbin/logprof = u
++  /usr/bin/cardmgr = u
++  /usr/bin/subdomain_parser = u
++  /usr/bin/genprof = u
++  /usr/bin/logprof = u
+   /usr/lib/YaST2/servers_non_y2/ag_genprof = u
+   /usr/lib/YaST2/servers_non_y2/ag_logprof = u
  
+@@ -97,8 +95,7 @@
+   /usr/bin/sed  = icn
+   /bin/touch    = icn
+   /usr/bin/touch = icn
+-  /sbin/killall5 = icn
+-  /usr/sbin/killall5 = icn
++  /usr/bin/killall5 = icn
+   /usr/bin/find = icn
+   /usr/bin/killall = icn
+   /usr/bin/nice = icn
+@@ -112,6 +109,8 @@
+   /usr/bin/python3.5    = icn
+   /usr/bin/python3.6    = icn
+   /usr/bin/python3.7    = icn
++  /usr/bin/python3.8    = icn
++  /usr/bin/python3.9    = icn
+   /usr/bin/tr   = icn
  
--[repository]
--  distro         = ubuntu-intrepid
--  url            = http://apparmor.test.opensuse.org/backend/api
--  preferred_user = ubuntu
-+#[repository]
-+#  distro         = ubuntu-intrepid
-+#  url            = http://apparmor.test.opensuse.org/backend/api
-+#  preferred_user = ubuntu
- 
- [qualifiers]
-   # things will be painfully broken if bash has a profile
+ [required_hats]
+-- 
+2.29.0
 

--- a/srcpkgs/apparmor/patches/fix-musl.patch
+++ b/srcpkgs/apparmor/patches/fix-musl.patch
@@ -1,0 +1,24 @@
+diff --git a/binutils/aa_status.c b/binutils/aa_status.c
+index 78b0340..56ecac3 100644
+--- a/binutils/aa_status.c
++++ b/binutils/aa_status.c
+@@ -17,6 +17,7 @@
+ #include <errno.h>
+ #include <ctype.h>
+ #include <dirent.h>
++#include <limits.h>
+ 
+ #include <sys/apparmor.h>
+ #include <sys/apparmor_private.h>
+diff --git a/libraries/libapparmor/include/sys/apparmor.h b/libraries/libapparmor/include/sys/apparmor.h
+index 32892d0..dad7664 100644
+--- a/libraries/libapparmor/include/sys/apparmor.h
++++ b/libraries/libapparmor/include/sys/apparmor.h
+@@ -22,6 +22,7 @@
+ #include <stdint.h>
+ #include <unistd.h>
+ #include <sys/types.h>
++#include <sys/socket.h>
+ 
+ #ifdef __cplusplus
+ extern "C" {

--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
-version=2.13.4
-revision=6
+version=3.0.0
+revision=1
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure
@@ -16,22 +16,12 @@ maintainer="Olivier Mauras <olivier@mauras.ch>"
 license="GPL-2.0-only, LGPL-2.1-only"
 homepage="https://gitlab.com/apparmor/apparmor"
 distfiles="https://gitlab.com/apparmor/apparmor/-/archive/v${version}/apparmor-v${version}.tar.gz"
-checksum=4f45e5a5de59b72039c6cf218bb61cb4fc42eeb7f47ca109a58238896394a33b
+checksum=8c440ab1848e723483a8550ed2889e18f322e9d7ee9eb4e2e712152ea61da68f
 patch_args="-Np1"
 
 if [ -z "$CROSS_BUILD" ]; then
 	configure_args="--with-perl --with-python"
 fi
-
-post_patch() {
-	# Make.rules feeds some system headers to the C preprocessor to produce
-	# lists of capability and address-family names that, respectively,
-	# populate 'parser/cap_names.h' and 'parser/af_names.h'. The escaping
-	# backslash in the '\#include" directives here is seen by the
-	# preprocessor, causing it to skip the system headers and produce empty
-	# files. Removing the backslash ensures correct behavior.
-	vsed -i ${wrksrc}/common/Make.rules -e 's/\\#include </#include </'
-}
 
 pre_configure() {
 	autoreconf -if
@@ -40,14 +30,18 @@ pre_configure() {
 pre_build() {
 	# Replace release profiles with our own
 	cd ${wrksrc}
-
-	# Put in place our own profiles
 	cp ${FILESDIR}/profiles/* profiles/apparmor.d/
+
+	# use the correct syslog path
+	vsed -i utils/logprof.conf -e 's,logfiles = .*,logfiles = /var/log/socklog/kernel/current,'
 }
 
 post_build() {
 	cd ${wrksrc}
-	sed -i 's#$(DESTDIR)/sbin#$(DESTDIR)/usr/bin#g' parser/Makefile
+
+	# fix cross compilation
+	vsed -i parser/Makefile -e 's,cpp,$(CPP),'
+
 	make ${makejobs} -C binutils
 	make ${makejobs} -C utils
 	make ${makejobs} -C parser
@@ -56,27 +50,31 @@ post_build() {
 
 post_install() {
 	cd ${wrksrc}
-	make DESTDIR=${DESTDIR} install -C binutils
-	make DESTDIR=${DESTDIR} BINDIR=${DESTDIR}/usr/bin install -C utils
-	make DESTDIR=${DESTDIR} APPARMOR_BIN_PREFIX=${DESTDIR}/usr/lib/apparmor \
-		SBINDIR=${DESTDIR}/usr/bin USR_SBINDIR=${DESTDIR}/usr/bin install -C parser
-	make DESTDIR=${DESTDIR} install -C profiles
-
-	# Put Vim syntax in the correct place
-	mkdir -p ${DESTDIR}/usr/share/vim/vim80/syntax/
-	mv ${DESTDIR}/usr/share/apparmor/apparmor.vim ${DESTDIR}/usr/share/vim/vim80/syntax/
+	commonflags="DESTDIR=\"${DESTDIR}\" SBINDIR=\"${DESTDIR}/usr/bin\" USR_SBINDIR=\"${DESTDIR}/usr/bin\""
+	make $commonflags install -C binutils
+	make $commonflags \
+		BINDIR="${DESTDIR}/usr/bin" \
+		VIM_INSTALL_PATH="${DESTDIR}/usr/share/vim/vimfiles/syntax" \
+		install -C utils
+	make $commonflags \
+		APPARMOR_BIN_PREFIX="${DESTDIR}/usr/lib/apparmor" \
+		install -C parser
+	make DESTDIR="${DESTDIR}" install -C profiles
 
 	# requires perl bindings not generated when cross-compiling
 	if [ "$CROSS_BUILD" ]; then
 		rm -f ${DESTDIR}/usr/bin/aa-notify
 	fi
+
+	# we installed a custom conflicting profile
+	rm ${DESTDIR}/etc/apparmor.d/{,local/}php-fpm
 }
 
 apparmor-vim_package() {
 	short_desc+=" - Vim syntax"
 	depends="vim"
 	pkg_install() {
-		vmove usr/share/vim/vim80/syntax/apparmor.vim
+		vmove usr/share/vim/vimfiles/syntax/apparmor.vim
 		vmove usr/share/man/man5/apparmor.vim.5
 	}
 }


### PR DESCRIPTION
+ builds and works fine for x86_64-glibc

- [x] fix build on musl
- [x] check what happens with dhcpcd profile on kernels before 5.8 (bpf cap is 5.8+)