### PR TITLE
New packages: hunspell-pt_PT and hunspell-pt_PT-preao

### DIFF
--- a/srcpkgs/hunspell-pt_PT-preao/template
+++ b/srcpkgs/hunspell-pt_PT-preao/template
@@ -1,0 +1,16 @@
+# Template file for 'hunspell-pt_PT-preao'
+pkgname=hunspell-pt_PT-preao
+version=20201029
+revision=1
+short_desc="Portuguese dictionary for hunspell (prior to 1990 Orthographic Agreement)"
+maintainer="Luis Henriques <henrix@camandro.org>"
+license="GPL-2.0-only, LGPL-2.1-only, MPL-1.1"
+homepage="https://natura.di.uminho.pt/wiki/doku.php?id=dicionarios:main"
+distfiles="https://natura.di.uminho.pt/download/sources/Dictionaries/hunspell/${pkgname}-${version}.tar.gz"
+checksum=9427f1b21b9a3e8126fce62d008e6215b0b631498232ae567859d363351fbac4
+
+do_install() {
+	vinstall pt_PT-preao.aff 644 usr/share/hunspell
+	vinstall pt_PT-preao.dic 644 usr/share/hunspell
+	vdoc README_pt_PT.txt
+}

--- a/srcpkgs/hunspell-pt_PT/template
+++ b/srcpkgs/hunspell-pt_PT/template
@@ -1,0 +1,16 @@
+# Template file for 'hunspell-pt_PT'
+pkgname=hunspell-pt_PT
+version=20201029
+revision=1
+short_desc="Portuguese dictionary for hunspell"
+maintainer="Luis Henriques <henrix@camandro.org>"
+license="GPL-2.0-only, LGPL-2.1-only, MPL-1.1"
+homepage="https://natura.di.uminho.pt/wiki/doku.php?id=dicionarios:main"
+distfiles="https://natura.di.uminho.pt/download/sources/Dictionaries/hunspell/${pkgname}-${version}.tar.gz"
+checksum=711b2a2c755546cb341e5cf8ed70157fc4adaacc74b84e132c85b174d791c8db
+
+do_install() {
+	vinstall pt_PT.aff 644 usr/share/hunspell
+	vinstall pt_PT.dic 644 usr/share/hunspell
+	vdoc README_pt_PT.txt
+}


### PR DESCRIPTION
Two new packages containing the dictionaries for pt_PT.  These are the pre- (hunspell-pt_PT-preao) and post- (hunspell-pt_PT) 1990 Orthographic Agreement.
Since these two packages I related, I decided to create a single pull-request.  This is my 1st pull-request for the project, so maybe you prefer two separate requests.  Please let me know any problems with these packages.