### PR TITLE
cozy: added python3-pytz missing dep

### DIFF
--- a/srcpkgs/cozy/template
+++ b/srcpkgs/cozy/template
@@ -1,14 +1,15 @@
 # Template file for 'cozy'
 pkgname=cozy
 version=0.7.2
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="pkg-config glib-devel python3 python3-distro python3-peewee
  python3-mutagen python3-gobject-devel gettext"
 makedepends="glib-devel python3-distro python3-peewee python3-mutagen
  python3-gobject-devel"
 depends="python3 python3-peewee gst-libav gst-plugins-good1 gst1-python3
- python3-mutagen python3-distro python3-apsw python3-packaging"
+ python3-mutagen python3-distro python3-apsw python3-packaging python3-pytz
+ python3-requests python3-gobject"
 short_desc="Audio book player"
 maintainer="johannes <johannes.brechtmann@gmail.com>"
 license="GPL-3.0-only, LGPL-3.0-only"


### PR DESCRIPTION
There was a missing runtime dep with the cozy package.