### PR TITLE
highlight: update to 3.58.

### DIFF
--- a/srcpkgs/highlight/template
+++ b/srcpkgs/highlight/template
@@ -1,16 +1,16 @@
 # Template file for 'highlight'
 pkgname=highlight
-version=3.57
-revision=3
+version=3.58
+revision=1
 build_style=gnu-makefile
 hostmakedepends="pkg-config swig perl"
-makedepends="boost-devel lua53-devel perl"
+makedepends="boost-devel lua54-devel perl"
 short_desc="Fast and flexible source code highlighter (CLI version)"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.andre-simon.de/doku/highlight/en/highlight.php"
 distfiles="http://www.andre-simon.de/zip/${pkgname}-${version}.tar.bz2"
-checksum=f203f75e7e35ce381d0a13270bfdc9ee53fa965c39cc137a9927b9ff0e3be913
+checksum=df80251be1f83adfc58aaad589fd9a8f9a3866b0d89b9f3c81b1696f07db45f8
 conf_files="/etc/highlight/filetypes.conf"
 
 post_extract() {
@@ -30,7 +30,7 @@ pre_build() {
 }
 
 do_check() {
-	# No check target, fails spetarcularly when asked
+	# No check target, fails spectacularly when asked
 	:
 }
 


### PR DESCRIPTION
Builds on Lua 5.4 and fixes a typo in the template  
EDIT: No idea why those builds failed… I built it myself in a matter of minutes on my install (x86-64, glibc)