### PR TITLE
econnman: fix distfile location.

### DIFF
--- a/srcpkgs/econnman/template
+++ b/srcpkgs/econnman/template
@@ -1,10 +1,8 @@
 # Template file for 'econnman'
 pkgname=econnman
 version=1.1.0
-revision=5
-archs=noarch
-_gitrev=18e7be6bf80df6b86965ba93391b205339fc7267
-wrksrc=${pkgname}-${_gitrev}
+revision=6
+wrksrc="${pkgname}-${version%.*}"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config python3 efl-devel"
 makedepends="efl-devel python3-efl"
@@ -13,8 +11,8 @@ short_desc="Enlightenment ConnMan user interface"
 maintainer="q66 <daniel@octaforge.org>"
 license="LGPL-3.0-only"
 homepage="http://enlightenment.org"
-distfiles="https://git.enlightenment.org/apps/econnman.git/snapshot/econnman-${_gitrev}.tar.gz"
-checksum=6188accebac2bb52466794c685f042f9f2bcc7d5d77b2417b30458e2e7265282
+distfiles="http://download.enlightenment.org/rel/apps/econnman/econnman-${version%.*}.tar.xz"
+checksum=0cce87681fae7ca70f1e63cfe0ae65fdf17bc334727054317e25e3897619ed85
 python_version=3
 
 pre_configure() {


### PR DESCRIPTION
The upstream distfile location has moved, and has dropped the .0 from
the end, strip it off, the strip probably will need to be removed for
1.1.1 if that happens.