### PR TITLE
alot: patch mailcap rendering no content-type

### DIFF
--- a/srcpkgs/alot/patches/fix-mailcap-rendering-no-content-type.patch
+++ b/srcpkgs/alot/patches/fix-mailcap-rendering-no-content-type.patch
@@ -1,0 +1,65 @@
+From 0339a33818adc6fc33e83336f9eea289d5e7e893 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?M=C4=81rti=C5=86=C5=A1=20Ma=C4=8Ds?= <martins.macs@bi.lv>
+Date: Tue, 19 May 2020 13:48:17 +0300
+Subject: [PATCH] Fix mailcap rendering for e-mails without `Content-Type`
+ header
+
+`get_params()` returns `None` when the header is missing. Use `failobj`
+argument to mitigate that.
+
+Fixes #1512
+---
+ alot/db/utils.py            |  2 +-
+ tests/db/test_utils.py      | 10 ++++++++++
+ tests/static/mail/basic.eml |  5 +++++
+ 3 files changed, 16 insertions(+), 1 deletion(-)
+ create mode 100644 tests/static/mail/basic.eml
+
+diff --git a/alot/db/utils.py b/alot/db/utils.py
+index 27c85942..e55768b1 100644
+--- a/alot/db/utils.py
++++ b/alot/db/utils.py
+@@ -365,7 +365,7 @@ def render_part(part, field_key='copiousoutput'):
+             stdin = raw_payload
+ 
+         # read parameter, create handler command
+-        parms = tuple('='.join(p) for p in part.get_params())
++        parms = tuple('='.join(p) for p in part.get_params(failobj=[]))
+ 
+         # create and call external command
+         cmd = mailcap.subst(entry['view'], ctype,
+diff --git a/tests/db/test_utils.py b/tests/db/test_utils.py
+index 36ce77cf..40c2fb91 100644
+--- a/tests/db/test_utils.py
++++ b/tests/db/test_utils.py
+@@ -762,6 +762,16 @@ class TestExtractBodyPart(unittest.TestCase):
+ 
+         self.assertEqual(actual, expected)
+ 
++    @mock.patch('alot.db.utils.settings.mailcap_find_match',
++                mock.Mock(return_value=(None, {'view': 'cat'})))
++    def test_plaintext_mailcap_wo_content_type(self):
++        with open('tests/static/mail/basic.eml') as fp:
++            mail = email.message_from_file(fp,
++                    _class=email.message.EmailMessage)
++        body_part = utils.get_body_part(mail)
++        actual = utils.extract_body_part(body_part)
++        expected = 'test body\n'
++        self.assertEqual(actual, expected)
+ 
+ class TestRemoveCte(unittest.TestCase):
+ 
+diff --git a/tests/static/mail/basic.eml b/tests/static/mail/basic.eml
+new file mode 100644
+index 00000000..95f15693
+--- /dev/null
++++ b/tests/static/mail/basic.eml
+@@ -0,0 +1,5 @@
++From: me@localhost
++To: you@localhost
++Subject: test subject
++
++test body
+-- 
+2.29.2
+

--- a/srcpkgs/alot/template
+++ b/srcpkgs/alot/template
@@ -1,7 +1,7 @@
 # Template file for 'alot'
 pkgname=alot
 version=0.9.1
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Sphinx"
 depends="python3-setuptools python3-Twisted notmuch-python3 python3-configobj


### PR DESCRIPTION
Add a patch to fix a rendering problem with mails without _Content-Type_
header.

Patch is based on a bug already fixed in master branch of the `alot` project:

https://github.com/pazz/alot/pull/1513

I find it important because without it, there is no way to see any mail
sent via `git send-email` on projects with email-driven git workflows.
Apparently, `git send-email` doesn't add the aforementioned header.