### PR TITLE
mate-terminal: update to 1.24.1.

### DIFF
--- a/srcpkgs/mate-terminal/template
+++ b/srcpkgs/mate-terminal/template
@@ -1,14 +1,14 @@
 # Template file for 'mate-terminal'
 pkgname=mate-terminal
-version=1.24.0
+version=1.24.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="glib-devel intltool itstool pkg-config"
 makedepends="libSM-devel vte3-devel dconf-devel"
 depends="dbus mate-desktop"
 short_desc="MATE Terminal Emulator"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://mate-desktop.org"
 distfiles="https://pub.mate-desktop.org/releases/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=274d98e3646980b93366daa23ca72a91afc85a41bf1879dc7342f9b9aa1d8259
+checksum=550d38f223d21ab12d39b00af6cd75f083d3790c38d53051537df2ac6a87be62


### PR DESCRIPTION
built for all archs, tested on x86_64