### PR TITLE
sof-firmware: update to 1.6rc3; New package: alsa-ucm-conf-1.2.4

### DIFF
--- a/srcpkgs/alsa-ucm-conf/template
+++ b/srcpkgs/alsa-ucm-conf/template
@@ -1,0 +1,18 @@
+# Template file for 'alsa-ucm-conf'
+pkgname=alsa-ucm-conf
+version=1.2.4
+revision=1
+short_desc="ALSA Use Case Manager topology configurations"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/alsa-project/alsa-ucm-conf"
+distfiles="https://www.alsa-project.org/files/pub/lib/${pkgname}-${version}.tar.bz2"
+checksum=2c3b535c77dcb9aaf62a61f4f8324f1ab184162f105f7ec9ed1e37c742fcd340
+
+do_install() {
+	vdoc ucm2/README.md
+	rm ucm2/README.md
+	vmkdir usr/share/alsa
+	vcopy ucm2 usr/share/alsa
+	vlicense LICENSE
+}

--- a/srcpkgs/sof-firmware/template
+++ b/srcpkgs/sof-firmware/template
@@ -1,34 +1,40 @@
 # Template file for 'sof-firmware'
 pkgname=sof-firmware
-version=1.5.1
+version=1.6rc3
 revision=1
+_major=${version%rc*}
+_minor=${version#${_major}}
 archs="i686* x86_64*"
-wrksrc=sof-bin-stable-v${version}
+wrksrc="sof-bin-${_major}-${_minor}"
+depends="alsa-ucm-conf"
 short_desc="Sound Open Firmware and topology binaries"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://thesofproject.github.io/latest/index.html"
-distfiles="https://github.com/thesofproject/sof-bin/archive/stable-v${version}.tar.gz"
-checksum=270125fb621b9919de4190f53a86de5dc1163dcf839c349f4b22724a5a9c1fb1
+distfiles="https://github.com/thesofproject/sof-bin/archive/v${_major}-${_minor}.tar.gz"
+checksum=daefbeedfb26aa45ef73cc89d90f33dfb4c797244d40a00c8ac652ca3a5b4dce
 
 do_install() {
 	local intel_path="lib/firmware/intel"
-	for f in ${intel_path}/sof/v${version}/*.{ldc,ri}; do
+	for f in ${intel_path}/sof/v${_major}/*.{ldc,ri}; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof
 	done
-	for f in ${intel_path}/sof/v${version}/intel-signed/*; do
+	for f in ${intel_path}/sof/v${_major}/intel-signed/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof/intel-signed
 	done
-	for f in ${intel_path}/sof/v${version}/public-signed/*; do
+	for f in ${intel_path}/sof/v${_major}/public-signed/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof/public-signed
 	done
-	for arc in {bdw,byt,cht,apl,cnl,icl}; do
-		ln -s sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
+	for arc in {bdw,byt,cht}; do
+		ln -s sof-${arc}-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
 	done
-	ln -s sof-apl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
-	ln -s sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
-	ln -s sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
-	for f in ${intel_path}/sof-tplg-v${version}/*; do
+	for arc in {apl,cnl,icl}; do
+		ln -s intel-signed/sof-${arc}-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
+	done
+	ln -s intel-signed/sof-apl-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
+	ln -s intel-signed/sof-cnl-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
+	ln -s intel-signed/sof-cnl-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
+	for f in ${intel_path}/sof-tplg-v${_major}/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof-tplg
 	done
 	vlicense LICENCE.NXP


### PR DESCRIPTION
In addition to updating this package to version 1.6, this commit incorporates unmerged fixes proposed in #24776 and #24271. It also fixes a distfile error regarding pulling from a branch vs pulling from a commit. I would have pinned the distfile to a release tag, but unfortunately the sof-firmware project does not yet use those, though they are aware of the problem as shown by https://github.com/thesofproject/sof-bin/issues/21.

Closes #24776
Closes #24271
Closes #26419