### PR TITLE
mtpaint: update to 3.49.33,

### DIFF
--- a/srcpkgs/mtpaint/template
+++ b/srcpkgs/mtpaint/template
@@ -1,16 +1,16 @@
 # Template file for 'mtpaint'
 pkgname=mtpaint
-version=3.49.32
+version=3.49.33
 revision=1
-_commit=8dd4af91c61416a9d53bfd8135ef9a138020d993
+_commit=5272e2b1e773c8e02ac3506b2d3bde82ad946b21
 wrksrc="mtPaint-${_commit}"
 build_style=configure
 configure_args="--prefix=/usr --mandir=/usr/share/man
 		imagick cflags GIF jpeg jp2 tiff lcms2 man
-		gtk3 webp"
-hostmakedepends="pkg-config"
+		gtk3 webp intl release"
+hostmakedepends="pkg-config gettext"
 makedepends="giflib-devel gtk+3-devel libmagick-devel libopenjpeg-devel
- libwebp-devel"
+ libwebp-devel gettext-devel"
 depends="desktop-file-utils"
 short_desc="Simple GTK painting program"
 maintainer="mobinmob <mobinmob@disroot.org>"
@@ -18,8 +18,9 @@ license="GPL-3.0-or-later"
 homepage="http://mtpaint.sourceforge.net/"
 changelog="https://raw.githubusercontent.com/wjaguar/mtPaint/master/NEWS"
 distfiles="https://github.com/wjaguar/mtPaint/archive/${_commit}.tar.gz"
-checksum=e0bee4ce4a6158beb777a54b25746c237c35ae64b377e1ef086040626bd1d129
+checksum=1f61c7dd29c7b7ec46dfb8f31616114feea827e3dd91ce33a21ac2e319a186bc
 
 post_install() {
 	vdoc doc/vcode.t2t
+	cd "${DESTDIR}"/usr/bin && ln -s mtpaint mtv
 }


### PR DESCRIPTION
- enable release optimisations
- enable internationalisation
- add mtv symlink to mtpaint (simple file viewer, mtpaint -v).