### PR TITLE
libsndfile: use python3 when building

### DIFF
--- a/srcpkgs/libsndfile/template
+++ b/srcpkgs/libsndfile/template
@@ -3,13 +3,13 @@ pkgname=libsndfile
 version=1.0.30
 revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config python"
+hostmakedepends="pkg-config python3"
 makedepends="alsa-lib-devel libvorbis-devel libflac-devel sqlite-devel opus-devel"
 short_desc="C library for reading and writing files containing sampled sound"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
-homepage="http://www.mega-nerd.com/libsndfile"
-distfiles="https://github.com/erikd/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.bz2"
+homepage="https://libsndfile.github.io/libsndfile/"
+distfiles="https://github.com/libsndfile/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.bz2"
 checksum=9df273302c4fa160567f412e10cc4f76666b66281e7ba48370fb544e87e4611a
 
 libsndfile-progs_package() {


### PR DESCRIPTION
 - Use `python3` as it's compatible (see libsndfile/libsndfile#490)
 - Noticed the repository moved to its own organization. Update homepage and distfiles to keep it in sync.
   - The old `distfiles` url still redirects and the given `.tar.bz2` file from it has matching hashes, so `checksum` didn't update.