### PR TITLE
[RFC] ccache: remove bootstrap=y, build manpage, enable tests

### DIFF
--- a/srcpkgs/ccache/patches/build-and-install-man-page-by-default.patch
+++ b/srcpkgs/ccache/patches/build-and-install-man-page-by-default.patch
@@ -1,0 +1,32 @@
+upstream: yes
+
+From 294ff2face26448afa68e3ef7b68bf4898d6dc77 Mon Sep 17 00:00:00 2001
+From: Erik Flodin <erik@ejohansson.se>
+Date: Fri, 30 Oct 2020 10:23:08 +0100
+Subject: [PATCH] Build and install man page by default (#705)
+
+Fixes #684.
+---
+ doc/CMakeLists.txt | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index fb0f316..b5c9f24 100644
+--- doc/CMakeLists.txt
++++ doc/CMakeLists.txt
+@@ -58,7 +58,11 @@ else()
+       COMMAND ${A2X_EXE} --doctype manpage --format manpage MANUAL.xml
+       MAIN_DEPENDENCY MANUAL.xml
+     )
+-    add_custom_target(doc-man-page DEPENDS ccache.1)
++    add_custom_target(doc-man-page ALL DEPENDS ccache.1)
++    install(
++      FILES "${CMAKE_CURRENT_BINARY_DIR}/ccache.1"
++      DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
++    )
+     set(doc_files "${doc_files}" ccache.1)
+   endif()
+ 
+-- 
+2.29.2
+

--- a/srcpkgs/ccache/template
+++ b/srcpkgs/ccache/template
@@ -1,12 +1,10 @@
 # Template file for 'ccache'
 pkgname=ccache
 version=4.0
-revision=1
-bootstrap=yes
+revision=2
 build_style=cmake
-hostmakedepends="cmake-bootstrap"
+hostmakedepends="asciidoc cmake perl"
 makedepends="libzstd-devel zlib-devel"
-checkdepends="perl"
 short_desc="Fast C/C++ Compiler Cache"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -15,10 +13,20 @@ changelog="https://ccache.dev/releasenotes.html"
 distfiles="https://github.com/ccache/ccache/releases/download/v${version}/${pkgname}-${version}.tar.xz"
 checksum=ac1b82fe0a5e39905945c4d68fcb24bd0f32344869faf647a1b8d31e544dcb88
 
+if [ -n "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -DENABLE_TESTING=ON"
+else
+	configure_args+=" -DENABLE_TESTING=OFF"
+fi
+
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 	configure_args="-DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
 fi
+
+post_build() {
+	mv build/doc/Ccache.1 build/doc/ccache.1
+}
 
 post_install() {
 	vmkdir usr/lib/ccache/bin


### PR DESCRIPTION
#25753 bumped ccache to 4.0 and introduced cmake-bootstrap.

with ccache being `bootstrap=yes`, building manpage and tests is impossible, because building manpage requires [asciidoc](https://github.com/ccache/ccache/blob/v4.0/doc/CMakeLists.txt#L4) and [perl](https://github.com/ccache/ccache/blob/v4.0/doc/CMakeLists.txt#L52), and tests require ctest from the real cmake package which conflicts with the crippled cmake-bootsrap.


If this is considered to be merged, a few commits of #25753 should be reverted along