### PR TITLE
file: disable libseccomp explicitly on bootstrapping

### DIFF
--- a/srcpkgs/file/template
+++ b/srcpkgs/file/template
@@ -13,6 +13,14 @@ homepage="http://www.darwinsys.com/file/"
 distfiles="https://astron.com/pub/file/file-${version}.tar.gz"
 checksum=f05d286a76d9556243d0cb05814929c2ecf3a5ba07963f8f70bfaaa70517fad1
 
+if [ -z "$CHROOT_READY" ]; then
+	# libseccomp's default=auto
+	# and libseccomp is not bootstrap
+	# If we're bootstrap from host with libseccomp installed
+	# bootstrap will fail to install shlib required by file.
+	configure_args+=" --disable-libseccomp"
+fi
+
 if [ "$CROSS_BUILD" ]; then
 	# XXX cross compilation needs exactly the same version for the host
 	hostmakedepends="file"


### PR DESCRIPTION
To avoid autotools enable libseccomp on host with libseccomp installed.
Conditionally disable outside of chroot to allow future conditional
enable libseccomp in production.