### PR TITLE
protonmail-bridge: update to 1.4.4

### DIFF
--- a/srcpkgs/protonmail-bridge/template
+++ b/srcpkgs/protonmail-bridge/template
@@ -1,16 +1,16 @@
 # Template file for 'protonmail-bridge'
 pkgname=protonmail-bridge
-version=1.4.4
+version=1.5.7
 revision=1
 archs="x86_64"
 build_style=fetch
 depends="desktop-file-utils"
 short_desc="ProtonMail Bridge for use with E-mail software"
 maintainer="Rich G <rich@richgannon.net>"
-license="custom:Commercial"
+license="GPL-3.0-only"
 homepage="https://protonmail.com/bridge"
 distfiles="https://protonmail.com/download/beta/protonmail-bridge_${version}-1_amd64.deb"
-checksum=70938512bde6d6d072147ba593e40c67b70bc0e85fa976e656d6174309a80d22
+checksum=f81001677ceed9bd99efda768956f92bcee3dd4e218ca6d17878899df596bd66
 
 restricted=yes
 noverifyrdeps=yes
@@ -20,5 +20,4 @@ do_install() {
 	ar x protonmail-bridge_${version}-1_amd64.deb data.tar.xz
 	bsdtar xpvf data.tar.xz
 	cp -r usr ${DESTDIR}
-	vlicense usr/lib/protonmail/bridge/LICENSE
 }


### PR DESCRIPTION
Tested working on x86_64 glibc.

License changed to GPL v3 upstream.