### PR TITLE
New package: system76-dkms-1.0.9

### DIFF
--- a/srcpkgs/system76-dkms/template
+++ b/srcpkgs/system76-dkms/template
@@ -1,0 +1,24 @@
+# Template file for 'system76-dkms'
+pkgname=system76-dkms
+version=1.0.9
+revision=3
+archs="x86_64*"
+depends="dkms"
+short_desc="System76 laptop hotkey and fan control drivers"
+maintainer="Dr. Mike Murphy <mmurphy2@coastal.edu>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/pop-os/system76-dkms"
+distfiles="https://github.com/pop-os/${pkgname}/archive/${version}.tar.gz"
+checksum=66f455443a6d840506227ee108da6dd45c6142d1be114b534cdeb96ac5dcd9fd
+dkms_modules="system76 ${version}"
+
+post_extract() {
+	sed -i "s/#MODULE_VERSION#/${version}/" debian/system76-dkms.dkms
+}
+
+do_install() {
+	vmkdir usr/src/system76-${version}
+	vcopy "*.c" usr/src/system76-${version}
+	vcopy Makefile usr/src/system76-${version}
+	vcopy debian/system76-dkms.dkms usr/src/system76-${version}/dkms.conf
+}


### PR DESCRIPTION
Kernel driver for keyboard backlight and fan control on System76
branded laptops.