### PR TITLE
rock64-uboot: update to 2020.10

### DIFF
--- a/srcpkgs/atf-rk3328-bl31/template
+++ b/srcpkgs/atf-rk3328-bl31/template
@@ -1,6 +1,6 @@
 # Template file for 'atf-rk3328-bl31'
 pkgname=atf-rk3328-bl31
-version=2.3
+version=2.4
 revision=1
 archs="aarch64*"
 wrksrc="trusted-firmware-a-${version}"
@@ -9,7 +9,7 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="BSD-3-Clause"
 homepage="https://developer.trustedfirmware.org/dashboard/view/6/"
 distfiles="https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/snapshot/trusted-firmware-a-${version}.tar.gz"
-checksum=37f917922bcef181164908c470a2f941006791c0113d738c498d39d95d543b21
+checksum=bf3eb3617a74cddd7fb0e0eacbfe38c3258ee07d4c8ed730deef7a175cc3d55b
 nostrip=yes
 
 do_build() {

--- a/srcpkgs/rock64-uboot/template
+++ b/srcpkgs/rock64-uboot/template
@@ -1,6 +1,6 @@
 # Template file for 'rock64-uboot'
 pkgname=rock64-uboot
-version=2020.07
+version=2020.10
 revision=1
 archs="aarch64*"
 wrksrc="u-boot-${version}"
@@ -11,7 +11,7 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-or-later, BSD-3-Clause"
 homepage="https://www.denx.de/wiki/U-Boot/"
 distfiles="https://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2"
-checksum=c1f5bf9ee6bb6e648edbf19ce2ca9452f614b08a9f886f1a566aa42e8cf05f6a
+checksum=0d481bbdc05c0ee74908ec2f56a6daa53166cc6a78a0e4fac2ac5d025770a622
 
 do_configure() {
 	make rock64-rk3328_defconfig


### PR DESCRIPTION
Update U-Boot and TF-A for the Rock64.