### PR TITLE
Signal-Desktop: update to 1.37.2

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=1.34.5
+version=1.37.2
 revision=1
 # Due to electron
 # 32-bit is not supported https://github.com/signalapp/Signal-Desktop/issues/1661
@@ -12,7 +12,7 @@ maintainer="Julio Galvan <juliogalvan@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=7ece0d698ad9550802f02ad8718f3d6a70941dc453dfdd73556dead7802410d2
+checksum=26da47d05fd3a78609054224159a737ed3efb722719dee3797893006bdc61ac7
 nostrip_files="signal-desktop"
 
 pre_build() {


### PR DESCRIPTION
This package was really out of date & doesn't appear to have been touched by its listed maintainer since 2018/08/1, Orphan this maybe?