### PR TITLE
libwacom: update to 1.6.

### DIFF
--- a/srcpkgs/libwacom/template
+++ b/srcpkgs/libwacom/template
@@ -1,6 +1,6 @@
 # Template file for 'libwacom'
 pkgname=libwacom
-version=1.5
+version=1.6
 revision=1
 build_style=meson
 build_helper="qemu"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://github.com/linuxwacom/libwacom"
 changelog="https://raw.githubusercontent.com/linuxwacom/libwacom/master/NEWS"
 distfiles="https://github.com/linuxwacom/libwacom/releases/download/${pkgname}-${version}/${pkgname}-${version}.tar.bz2"
-checksum=6b349fb73c8edcf0288d17c49049648214924846b6a58914c2ed3477ff36d47b
+checksum=701cb23ee3f2ad4eb5183ef1421dfff3e5b7622e5d3bb6fcd599190a7d77aea8
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- aarch64 [x86_64]
- armv7l [x86_64]
- x86_64-musl [x86_64-musl]
- aarch64-musl [x86_64-musl]
- armv6l-musl [x86_64-musl]