### PR TITLE
mbuffer: update to 20200929

### DIFF
--- a/srcpkgs/mbuffer/template
+++ b/srcpkgs/mbuffer/template
@@ -1,7 +1,7 @@
 # Template file for 'mbuffer'
 pkgname=mbuffer
-version=20200505
-revision=2
+version=20200929
+revision=1
 build_style=gnu-configure
 makedepends="libressl-devel"
 short_desc="Buffer data streams with many additional functions"
@@ -9,5 +9,5 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
 homepage="http://www.maier-komor.de/mbuffer.html"
 distfiles="http://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz"
-checksum=cc046183149e51814c23b9f83fd748cc1625a88ee128651ea500aa7bd5f01f0b
+checksum=53a6e3c14e9a049f18a09840653dd84f18e7ec7560f2dcf2b61c0ab5f0ead4e8
 conf_files="/etc/mbuffer.rc"


### PR DESCRIPTION
- enhancement: added option --no-direct to disable use of O_DIRECT
- defaults: raised default TCP timeout to 10ms for WAN connections
- fix: leave TCP buffer size untouched if not set
- enhancement: add option to set TCP timeout
- performance optimization: use recv with MSG_WAITALL instead of read
- configure fix: look for objdump also with target prefix
- testing: make sure to use gtar for testing to avoid unexpected failures
- portability: NetBSD compatibility fix
- build enhancement: added dependency calculation for make
- build enhancement: automatic version string generation
