### PR TITLE
coreutils: fix tests

### DIFF
--- a/srcpkgs/coreutils/template
+++ b/srcpkgs/coreutils/template
@@ -91,16 +91,16 @@ do_check() {
 	local exeext_tests
 
 	# chgrp tests fail inside a chroot
-	sed -i '/tests\/chgrp/d' Makefile
+	vsed -i '/tests\/chgrp/d' Makefile
 
 	# Tests that fail due to being inside a chroot
 	exeext_tests="chown lchown fchownat"
 
-	# Tests that depend on the tests reemoved
+	# Tests that depend on the tests removed
 	exeext_tests+=" fchmodat fchdir"
 
 	for test in $exeext_tests ; do
-		sed -i "/test-$test\$(EXEEXT)/d" gnulib-tests/Makefile
+		vsed -i "s/test-$test\$(EXEEXT) //" gnulib-tests/Makefile
 	done
 
 	make check


### PR DESCRIPTION
try not to destroy the makefile while disabling tests
use vsed in do_check