### PR TITLE
New package: xdg-desktop-portal-wlr-0.1.0

### DIFF
--- a/srcpkgs/xdg-desktop-portal-wlr/template
+++ b/srcpkgs/xdg-desktop-portal-wlr/template
@@ -1,0 +1,18 @@
+# Template file for 'xdg-desktop-portal-wlr'
+pkgname=xdg-desktop-portal-wlr
+version=0.1.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config ninja"
+makedepends="elogind-devel wayland-devel wayland-protocols pipewire-devel"
+depends="xdg-desktop-portal"
+short_desc="Portal backend service for Flatpak using wlroots"
+maintainer="Artur Sinila <opensource@logarithmus.dev>"
+license="MIT"
+homepage="https://github.com/emersion/xdg-desktop-portal-wlr"
+distfiles="https://github.com/emersion/${pkgname}/archive/v${version}.tar.gz"
+checksum=69d67c236f4bd498323af509d44ec4a1b826da337f7ee64bbfbdb98bfda8e541
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Portal backend service for Flatpak using wlroots