### PR TITLE
chromium: update to 86.0.4240.183.

### DIFF
--- a/srcpkgs/chromium-widevine/INSTALL
+++ b/srcpkgs/chromium-widevine/INSTALL
@@ -1,6 +1,6 @@
 # INSTALL
 
-checksum=86a2dfca066f92e2017979b9608f61d82dccde7cad77c46d972312de7c8c5881
+checksum=c9d37f91449ea3563d518b13164c5aefb42d166d5aec91f9832948d335ee0de4
 _baseUrl="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable"
 _filename="google-chrome-stable_${VERSION%_*}-1_amd64.deb"
 DISTFILE="${_baseUrl}/${_filename}"

--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=86.0.4240.111
+version=86.0.4240.183
 revision=1
 archs="x86_64"
 create_wrksrc=yes

--- a/srcpkgs/chromium/patches/upstream-xproto-fix-underflow-in-Fp1616ToDouble.patch
+++ b/srcpkgs/chromium/patches/upstream-xproto-fix-underflow-in-Fp1616ToDouble.patch
@@ -1,0 +1,37 @@
+From 5ade494a9966c7a9675af86dc42aca62fb4d806d Mon Sep 17 00:00:00 2001
+From: Tom Anderson <thomasanderson@chromium.org>
+Date: Wed, 21 Oct 2020 22:02:35 +0000
+Subject: [PATCH] [XProto] Fix underflow in Fp1616ToDouble
+
+x11::Input::Fp1616 should be treated as a signed integer, otherwise
+-1 will underflow to 65535.  When dragging a scrollbar, this would
+cause the scrollbar to snap to the bottom when the cursor is dragged
+above the window's y=0 coordinate.  Verified that the issue is fixed
+after this CL.
+
+BUG=1139623,1136352
+R=sky
+
+Change-Id: Ie318006ceadde9b9ce3e267fb453ddeba0e81da0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2485620
+Auto-Submit: Thomas Anderson <thomasanderson@chromium.org>
+Commit-Queue: Scott Violet <sky@chromium.org>
+Reviewed-by: Scott Violet <sky@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#819538}
+---
+ ui/events/x/events_x_utils.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ui/events/x/events_x_utils.cc b/ui/events/x/events_x_utils.cc
+index 3010db5f40c..856dfb221e7 100644
+--- ui/events/x/events_x_utils.cc
++++ ui/events/x/events_x_utils.cc
+@@ -376,7 +376,7 @@ base::TimeTicks TimeTicksFromXEvent(const x11::Event& xev) {
+ 
+ // This is ported from libxi's FP1616toDBL in XExtInt.c
+ double Fp1616ToDouble(x11::Input::Fp1616 x) {
+-  auto x32 = static_cast<uint32_t>(x);
++  auto x32 = static_cast<int32_t>(x);
+   return x32 * 1.0 / (1 << 16);
+ }
+ 

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=86.0.4240.111
+version=86.0.4240.183
 revision=1
 archs="i686* x86_64* aarch64* armv7l* ppc64le*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=f27bdb02ebf3c48abe054c73f1ae57e22a22535ea34f5edf8693ab8432a7c717
+checksum=aa12c6665c33275f3edffb6f127f97f84fa0bb69c644b4b023d51d2d058a69bc
 nocross=yes
 
 lib32disabled=yes


### PR DESCRIPTION
- Built for x86_64, x86_64-musl, and i686.
- Tested on x86_64.

- Includes fixes for a few high CVEs:
  https://chromereleases.googleblog.com/2020/11/stable-channel-update-for-desktop.html

- Also update chromium-widevine