### PR TITLE
libcap: update to 2.45.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -202,6 +202,7 @@ libpam.so.0 pam-libs-1.1.6_3
 libpamc.so.0 pam-libs-1.1.6_3
 libpam_misc.so.0 pam-libs-1.1.6_3
 libcap.so.2 libcap-2.16_1
+libpsx.so.2 libcap-2.45_1
 liblzma.so.5 liblzma-5.0.0_1
 libuuid.so.1 libuuid-2.18_1
 libblkid.so.1 libblkid-2.18_1

--- a/srcpkgs/libcap/template
+++ b/srcpkgs/libcap/template
@@ -1,6 +1,6 @@
 # Template file for 'libcap'
 pkgname=libcap
-version=2.44
+version=2.45
 revision=1
 bootstrap=yes
 build_style=gnu-makefile
@@ -13,7 +13,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-2.0-only"
 homepage="http://sites.google.com/site/fullycapable/"
 distfiles="${KERNEL_SITE}/libs/security/linux-privs/libcap2/${pkgname}-${version}.tar.xz"
-checksum=92188359cd5be86e8e5bd3f6483ac6ce582264f912398937ef763def2205c8e1
+checksum=d66639f765c0e10557666b00f519caf0bd07a95f867dddaee131cd284fac3286
 
 if [ "$CROSS_BUILD" ]; then
 	make_build_args="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
@@ -33,6 +33,8 @@ libcap-devel_package() {
 		vmove usr/include
 		vmove usr/lib/libcap.a
 		vmove usr/lib/libcap.so
+		vmove usr/lib/libpsx.a
+		vmove usr/lib/libpsx.so
 		vmove usr/share/man/man3
 		vmove usr/lib/pkgconfig
 	}


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- aarch64 [x86_64]
- armv7l [x86_64]
- x86_64-musl [x86_64-musl]
- aarch64-musl [x86_64-musl]
- armv6l-musl [x86_64-musl]