### PR TITLE
libassuan: update to 2.5.4.

### DIFF
--- a/srcpkgs/libassuan/template
+++ b/srcpkgs/libassuan/template
@@ -1,7 +1,7 @@
 # Template file for 'libassuan'
 pkgname=libassuan
-version=2.5.3
-revision=2
+version=2.5.4
+revision=1
 build_style=gnu-configure
 configure_args="--with-libgpg-error-prefix=${XBPS_CROSS_BASE}/usr"
 makedepends="libgpg-error-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnupg.org/related_software/libassuan"
 distfiles="https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-${version}.tar.bz2"
-checksum=91bcb0403866b4e7c4bc1cc52ed4c364a9b5414b3994f718c70303f7f765e702
+checksum=c080ee96b3bd519edd696cfcebdecf19a3952189178db9887be713ccbcb5fbf0
 
 libassuan-devel_package() {
 	depends="libgpg-error-devel ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- aarch64 [x86_64]
- armv7l [x86_64]
- x86_64-musl [x86_64-musl]
- aarch64-musl [x86_64-musl]
- armv6l-musl [x86_64-musl]