### PR TITLE
surf: add "xprop" runtime dependency

### DIFF
--- a/srcpkgs/surf/template
+++ b/srcpkgs/surf/template
@@ -1,10 +1,11 @@
 # Template file for 'surf'
 pkgname=surf
 version=2.0
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="webkit2gtk-devel"
+depends="xprop"
 short_desc="Simple web browser based on WebKit/GTK+"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"


### PR DESCRIPTION
Without `xprop` visiting sites via Ctrl-g fails.