### PR TITLE
New package: musl-locales-0.git20201006

### DIFF
--- a/srcpkgs/musl-locales/template
+++ b/srcpkgs/musl-locales/template
@@ -1,0 +1,20 @@
+# Template file for 'musl-locales'
+pkgname=musl-locales
+version=0.git20201006
+revision=1
+_commit=1101fb2bcdd189cd9415b8bd1c775eb43527d25c
+archs="*-musl"
+wrksrc=${pkgname}-${_commit}
+build_style=cmake
+hostmakedepends="gettext"
+makedepends="gettext-devel"
+short_desc="Locale program for musl libc"
+maintainer="Artur Sinila <opensource@logarithmus.dev>"
+license="LGPL-3.0-only, MIT"
+homepage="https://gitlab.com/rilian-la-te/musl-locales"
+distfiles="${homepage}/-/archive/${_commit}/${pkgname}-${_commit}.tar.gz"
+checksum=a213ac888a20a224f27f73178ed707fa17e4106cde38598ab3fe7600709ea89c
+
+post_install() {
+	vlicense LICENSE.MIT
+}


### PR DESCRIPTION
Partial locale support for `musl`
Homepage: https://gitlab.com/rilian-la-te/musl-locales