### PR TITLE
heirloom-sh: allow Heirloom-specific profiles (patch)

### DIFF
--- a/srcpkgs/heirloom-sh/files/system-profile
+++ b/srcpkgs/heirloom-sh/files/system-profile
@@ -1,0 +1,6 @@
+# /etc/heirloom/profile
+
+# If this file is present, it is read in place of /etc/profile. A
+# ~/.heirloom_profile will take the place of ~/.profile. Otherwise,
+# initialization is as stated under "Invocation" in heirloom_sh(1).
+echo Sourcing /etc/heirloom/profile.

--- a/srcpkgs/heirloom-sh/files/user-profile
+++ b/srcpkgs/heirloom-sh/files/user-profile
@@ -1,0 +1,6 @@
+# $HOME/.heirloom_profile
+
+# If this file is present, it is read in place of ~/.profile. Also, an
+# /etc/heirloom/profile can take the place of /etc/profile. Otherwise,
+# initialization is as stated under "Invocation" in heirloom_sh(1).
+echo Sourcing ${HOME}/heirloom_profile.

--- a/srcpkgs/heirloom-sh/patches/allow-heirloom-specific-profiles-manpage-incl.patch
+++ b/srcpkgs/heirloom-sh/patches/allow-heirloom-specific-profiles-manpage-incl.patch
@@ -1,0 +1,97 @@
+From: Roarde <roarde@example.net>
+Date: Mon 02 Nov 2020 08:41:40 AM UTC
+Subject: [heirloom-sh] Allow Heirloom-specific profiles
+
+If /etc/heirloom/profile exists, read it instead of /etc/profile; same
+for an ~/.heirloom_profile and ~/.profile.
+
+_____
+
+diff -u ./defs.h ../new/defs.h
+--- ./defs.h	2005-07-03 19:25:46.000000000 +0000
++++ ../new/defs.h	2020-10-30 19:13:00.980629847 +0000
+@@ -461,7 +461,9 @@
+ /* prompting */
+ extern const char				stdprompt[];
+ extern const char				supprompt[];
++extern const char				hlprofile[];
+ extern const char				profile[];
++extern const char				syscfgdirs[];
+ extern const char				sysprofile[];
+ 
+ /* built in names */
+Common subdirectories: ./fakewchar and ../new/fakewchar
+diff -u ./main.c ../new/main.c
+--- ./main.c	2005-07-03 19:25:46.000000000 +0000
++++ ../new/main.c	2020-10-30 19:55:43.016599989 +0000
+@@ -268,14 +268,14 @@
+ 
+ #ifndef RES
+ 
+-			if ((input = pathopen(nullstr, sysprofile)) >= 0)
++			if ((input = pathopen(syscfgdirs, sysprofile)) >= 0)
+ 				exfile(rflag);		/* file exists */
+ 
+ #endif
+ 			/* user profile */
+ 
+-			if ((input = pathopen(homenod.namval, profile)) >= 0)
+-			{
++			if ((input = pathopen(homenod.namval, hlprofile)) >= 0 ||
++			    (input = pathopen(homenod.namval, profile)) >= 0) {
+ 				exfile(rflag);
+ 				flags &= ~ttyflg;
+ 			}
+diff -u ./msg.c ../new/msg.c
+--- ./msg.c	2005-07-03 19:25:46.000000000 +0000
++++ ../new/msg.c	2020-10-30 19:16:40.050891092 +0000
+@@ -151,8 +151,10 @@
+ const char	readmsg[]	= "> ";
+ const char	stdprompt[]	= "$ ";
+ const char	supprompt[]	= "# ";
++const char	hlprofile[]	= ".heirloom_profile";
+ const char	profile[]	= ".profile";
+-const char	sysprofile[]	= "/etc/profile";
++const char	syscfgdirs[]	= "/etc/heirloom:/etc";
++const char	sysprofile[]	= "profile";
+ 
+ /*
+  * tables
+diff -u ./sh.1 ../new/sh.1
+--- ./sh.1	2005-07-03 16:43:18.000000000 +0000
++++ ../new/sh.1	2020-11-02 06:08:36.273336949 +0000
+@@ -1442,12 +1442,17 @@
+ .SS "Invocation"
+ If the first character of argument zero is
+ .BR \- ,
+-commands are read from
++commands are read from the first of
++.B /etc/heirloom/profile
++or
+ .B /etc/profile
+-and
+-.BR \s-1$HOME\s0/.\|profile ,
+-if the respective file exists.
++which exists, if either, and then likewise from
++.B \s-1$HOME\s0/.\|heirloom_profile
++or
++.BR \s-1$HOME\s0/.\|profile .
+ Commands are then read as described below.
++.PD
++.PP
+ The following flags are interpreted by the shell
+ when it is invoked.
+ .PD 0
+@@ -1595,8 +1600,12 @@
+ .I wait
+ command (see above) recognizes job ids in its arguments.
+ .SH FILES
++/etc/heirloom/profile
++.br
+ /etc/profile
+ .br
++.RB $HOME/ . \^heirloom_profile
++.br
+ .RB $HOME/ . \^profile
+ .br
+ /tmp/sh*

--- a/srcpkgs/heirloom-sh/patches/allow-heirloom-specific-profiles.patch
+++ b/srcpkgs/heirloom-sh/patches/allow-heirloom-specific-profiles.patch
@@ -1,0 +1,59 @@
+From: Roarde <roarde@example.net>
+Date: Wed 04 Nov 2020 07:08:58 AM UTC
+Subject: [heirloom-sh] Allow Heirloom-specific profiles
+
+If /etc/heirloom/profile exists, read it instead of /etc/profile; same
+for an ~/.heirloom_profile and ~/.profile.
+
+_____
+
+diff -u ./defs.h ../new/defs.h
+--- ./defs.h	2005-07-03 19:25:46.000000000 +0000
++++ ../new/defs.h	2020-10-30 19:13:00.980629847 +0000
+@@ -461,7 +461,9 @@
+ /* prompting */
+ extern const char				stdprompt[];
+ extern const char				supprompt[];
++extern const char				hlprofile[];
+ extern const char				profile[];
++extern const char				syscfgdirs[];
+ extern const char				sysprofile[];
+ 
+ /* built in names */
+Common subdirectories: ./fakewchar and ../new/fakewchar
+diff -u ./main.c ../new/main.c
+--- ./main.c	2005-07-03 19:25:46.000000000 +0000
++++ ../new/main.c	2020-10-30 19:55:43.016599989 +0000
+@@ -268,14 +268,14 @@
+ 
+ #ifndef RES
+ 
+-			if ((input = pathopen(nullstr, sysprofile)) >= 0)
++			if ((input = pathopen(syscfgdirs, sysprofile)) >= 0)
+ 				exfile(rflag);		/* file exists */
+ 
+ #endif
+ 			/* user profile */
+ 
+-			if ((input = pathopen(homenod.namval, profile)) >= 0)
+-			{
++			if ((input = pathopen(homenod.namval, hlprofile)) >= 0 ||
++			    (input = pathopen(homenod.namval, profile)) >= 0) {
+ 				exfile(rflag);
+ 				flags &= ~ttyflg;
+ 			}
+diff -u ./msg.c ../new/msg.c
+--- ./msg.c	2005-07-03 19:25:46.000000000 +0000
++++ ../new/msg.c	2020-10-30 19:16:40.050891092 +0000
+@@ -151,8 +151,10 @@
+ const char	readmsg[]	= "> ";
+ const char	stdprompt[]	= "$ ";
+ const char	supprompt[]	= "# ";
++const char	hlprofile[]	= ".heirloom_profile";
+ const char	profile[]	= ".profile";
+-const char	sysprofile[]	= "/etc/profile";
++const char	syscfgdirs[]	= "/etc/heirloom:/etc";
++const char	sysprofile[]	= "profile";
+ 
+ /*
+  * tables

--- a/srcpkgs/heirloom-sh/patches/series
+++ b/srcpkgs/heirloom-sh/patches/series
@@ -1,0 +1,1 @@
+allow-heirloom-specific-profiles.patch

--- a/srcpkgs/heirloom-sh/template
+++ b/srcpkgs/heirloom-sh/template
@@ -1,14 +1,15 @@
 # Template file for 'heirloom-sh'
 pkgname=heirloom-sh
 version=050706
-revision=4
+revision=5
 short_desc="A portable variant of the traditional Unix shell"
 maintainer="allan <mail@may.mooo.com>"
-license="Caldera"
+license="CDDL-1.0, Caldera"
 homepage="http://heirloom.sourceforge.net/sh.html"
 distfiles="${SOURCEFORGE_SITE}/heirloom/${pkgname}/${version}/${pkgname}-${version}.tar.bz2"
 checksum=25fb8409e1eb75bb5da21ca32baf2d5eebcb8b84a1288d66e65763a125809e1d
-register_shell="/bin/heirloom-sh"
+conf_files="/etc/heirloom/profile /etc/skel/.heirloom_profile"
+register_shell="/usr/bin/heirloom-sh /bin/heirloom-sh"
 
 do_build() {
 	make CC=$CC CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" ${makejobs}
@@ -18,4 +19,6 @@ do_install() {
 	vman sh.1.out heirloom-sh.1
 	vlicense CALDERA.LICENSE
 	vlicense OPENSOLARIS.LICENSE
+	vinstall ${FILESDIR}/system-profile 0644 etc/heirloom profile
+	vinstall ${FILESDIR}/user-profile 0644 etc/skel .heirloom_profile
 }


### PR DESCRIPTION
Allows administrators to bypass a presumably modern `/etc/profile`, and whatever has been dropped into `/etc/profile.d/`, by providing an `/etc/heirloom/profile`. Users can do the same with `~/.heirloom_profile` for `~/.profile`. The present, traditional behavior is restored by removing those files.       
         
Originally prepared with a manual page edit, but the body of that text was last touched by Caldera before 1996. The echo lines and commentary in the profiles is enough documentation, and very easily removed by admins/users. I'll happily amend to documenting in the manpage, if that's wanted. In that case, probably will remove the *file* `/etc/skel/.heirloom_profile`, and shorten the commentary in the other to just 'See "Invocation" in heirloom-sh(1)'; also, just have the one patch and no `series` file that way.    
      
So far, only packaged and tested for i686.