### PR TITLE
occt: fix segfault in OSD_Host::InternetAddress

### DIFF
--- a/srcpkgs/occt/patches/fix-osd-host.patch
+++ b/srcpkgs/occt/patches/fix-osd-host.patch
@@ -1,0 +1,13 @@
+# gethostbyname returns a nullptr, because the host can't resolve itself
+
+--- src/OSD/OSD_Host.cxx
++++ src/OSD/OSD_Host.cxx
+@@ -124,7 +124,7 @@ TCollection_AsciiString OSD_Host::InternetAddress(){
+ 
+  host = HostName();
+  memcpy(&internet_address,
+-        gethostbyname(host.ToCString()),
++        gethostbyname("localhost"),
+         sizeof(struct hostent));
+ 
+  // Gets each bytes into integers

--- a/srcpkgs/occt/template
+++ b/srcpkgs/occt/template
@@ -1,7 +1,7 @@
 # Template file for 'occt'
 pkgname=occt
 version=7.4.0p1
-revision=1
+revision=2
 _gittag="V${version//./_}"
 wrksrc=occt-${_gittag}
 build_style=cmake


### PR DESCRIPTION
This fixes a rare segfault.