### PR TITLE
csminer-git: add v0.2.0 and librandomx-go-git

### DIFF
--- a/srcpkgs/csminer-git/files/correct-paths.patch
+++ b/srcpkgs/csminer-git/files/correct-paths.patch
@@ -1,0 +1,13 @@
+--- a/rx/rx.go
++++ b/rx/rx.go
+@@ -4,8 +4,8 @@
+ // Package rx provides Go access to various randomx library methods.
+ package rx
+ 
+-// #cgo CFLAGS: -std=c11 -D_GNU_SOURCE -m64 -O3 -I${SRCDIR}/../../rxlib/
+-// #cgo LDFLAGS: -L${SRCDIR}/../../rxlib/ -Wl,-rpath,$ORIGIN ${SRCDIR}/../../rxlib/rxlib.cpp.o -lrandomx -lstdc++ -lm
++// #cgo CFLAGS: -std=c11 -D_GNU_SOURCE -m64 -O3 -I$/usr/include/
++// #cgo LDFLAGS: -L/usr/lib/ -Wl,-rpath,$ORIGIN /usr/lib/rxlib.cpp.o -lrandomx -lstdc++ -lm
+ /*
+  #include <stdlib.h>
+  #include "rxlib.h"

--- a/srcpkgs/csminer-git/template
+++ b/srcpkgs/csminer-git/template
@@ -1,0 +1,43 @@
+# Template file for 'csminer'
+pkgname=csminer
+version=0.2.0
+revision=1
+short_desc="Easy-to-use CPU miner for Monero"
+maintainer="Kevin Crumb <kevcrumb@splitlinux.org>"
+license="GPL-3.0-or-later"
+homepage="https://cryptonote.social"
+#distfiles="https://cryptonote.social/static/csminer/csminer-${version}-linux.tgz"
+#checksum=f0ce530d82bae0dba8b488d885dc6fdfbb8219bd24e9298986db2ca9291b6c21
+#build_style=go
+#go_import_path="github.com/cryptonote-social/csminer"
+hostmakedepends="git go"
+makedepends="librandomx librandomx-go-git"
+#go_get=yes
+#create_wrksrc=yes
+
+
+do_fetch() {
+	git clone https://github.com/cryptonote-social/csminer csminer-${version}
+	cd csminer-${version} && git checkout 4eafaa9b65155747c856c57e5a4ed216212499d4
+}
+
+do_patch() {
+	cd rx && patch -i ${FILESDIR}/correct-paths.patch && cd ..
+}
+
+do_build() {
+	go get github.com/cryptonote-social/csminer/blockchain
+	go get github.com/cryptonote-social/csminer/crylog
+	go get github.com/cryptonote-social/csminer/stratum/client
+	go get github.com/godbus/dbus
+
+	mkdir -p /tmp/go/src/github.com/cryptonote-social/csminer/rx/../../rxlib/
+	cp /usr/lib/rxlib.cpp.o /tmp/go/src/github.com/cryptonote-social/csminer/rx/../../rxlib/
+	go get github.com/cryptonote-social/csminer/minerlib
+
+	cd linux && go build -a -buildmode=pie csminer.go
+}
+
+do_install() {
+	vinstall linux/csminer 755 usr/bin
+}

--- a/srcpkgs/librandomx-go-git/template
+++ b/srcpkgs/librandomx-go-git/template
@@ -1,0 +1,26 @@
+# Template file for 'librandomx-go-git'
+pkgname=librandomx-go-git
+version=1.1.8
+revision=4
+short_desc="Wrapper for working with RandomX from Go applications"
+maintainer="Kevin Crumb <kevcrumb@splitlinux.org>"
+license="BSD-3-Clause"
+homepage="https://github.com/cryptonote-social/RandomX"
+hostmakedepends="pkg-config git"
+
+do_fetch() {
+	git clone git://github.com/cryptonote-social/RandomX.git $wrksrc
+	cd $wrksrc
+	git reset --hard 0ff2e9af8c122df9f234e509c99bfa5fa33a9fa4
+}
+
+do_build() {
+	cd rxlib
+	CFLAGS="-std=c++11 -D_GNU_SOURCE -fPIC -I../src -O3"
+	c++ $CFLAGS -c rxlib.cpp -o rxlib.cpp.o
+}
+
+do_install() {
+	vinstall rxlib/rxlib.cpp.o 644 usr/lib/
+	vinstall rxlib/rxlib.h 644 usr/include/
+}


### PR DESCRIPTION
*csminer-git* contains binary of Monero mining software
*Not sure if using `-git` in the name is adequate since template hard-resets to a specific commit of the repo.*

*librandomx-go-git* allows miner to speak to library provided by librandomx package
