### PR TITLE
enchant2: update to 2.2.13.

### DIFF
--- a/srcpkgs/enchant2/template
+++ b/srcpkgs/enchant2/template
@@ -1,6 +1,6 @@
 # Template file for 'enchant2'
 pkgname=enchant2
-version=2.2.11
+version=2.2.13
 revision=1
 wrksrc="enchant-${version}"
 build_style=gnu-configure
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://abiword.github.io/enchant/"
 distfiles="https://github.com/AbiWord/enchant/releases/download/v${version}/enchant-${version}.tar.gz"
-checksum=a29c5777c4e45fcac2595c15c49d6d2aa434fa5e7c993dff3f9f367b65fe472a
+checksum=eab9f90d79039133660029616e2a684644bd524be5dc43340d4cfc3fb3c68a20
 
 enchant2-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- aarch64 [x86_64]
- armv7l [x86_64]
- x86_64-musl [x86_64-musl]
- aarch64-musl [x86_64-musl]
- armv6l-musl [x86_64-musl]