### PR TITLE
libdrm: update to 2.4.103.

### DIFF
--- a/srcpkgs/libdrm/template
+++ b/srcpkgs/libdrm/template
@@ -1,6 +1,6 @@
 # Template file for 'libdrm'
 pkgname=libdrm
-version=2.4.102
+version=2.4.103
 revision=1
 wrksrc="drm-libdrm-${version}"
 build_style=meson
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://dri.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${version}/drm-libdrm-${version}.tar.gz"
-checksum=22e7ec53227386fe7daf7c1e52a65d51f480100bb80c5628a35d87feb9b014a0
+checksum=9235bcbcaca43372151ce82af7c1f83aec5e6f371153cd7957a117f99098713f
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) configure_args+=" -Dvc4=true";;


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- aarch64 [x86_64]
- armv7l [x86_64]
- x86_64-musl [x86_64-musl]
- aarch64-musl [x86_64-musl]
- armv6l-musl [x86_64-musl]