### PR TITLE
hfsprogs: fix broken fsck.hfs.8 symlink

### DIFF
--- a/srcpkgs/hfsprogs/template
+++ b/srcpkgs/hfsprogs/template
@@ -3,7 +3,7 @@ pkgname=hfsprogs
 _distver=540.1
 _patchver=3
 version="${_distver}.linux${_patchver}"
-revision=6
+revision=7
 wrksrc="diskdev_cmds-${version}"
 hostmakedepends="clang"
 makedepends="libressl-devel libuuid-devel"
@@ -42,11 +42,11 @@ do_check() {
 do_install() {
 	vbin fsck_hfs.tproj/fsck_hfs fsck.hfs
 	vbin newfs_hfs.tproj/newfs_hfs mkfs.hfsplus
-	ln -s /usr/bin/fsck.hfs "${DESTDIR}"/usr/bin/fsck.hfsplus
+	ln -s fsck.hfs "${DESTDIR}"/usr/bin/fsck.hfsplus
 
-	vman fsck_hfs.tproj/fsck_hfs.8
-	vman newfs_hfs.tproj/newfs_hfs.8
-	ln -s fsck.hfs.8 "${DESTDIR}"/usr/share/man/man8/fsck.hfs.8
+	vman fsck_hfs.tproj/fsck_hfs.8 fsck.hfs.8
+	vman newfs_hfs.tproj/newfs_hfs.8 mkfs.hfsplus.8
+	ln -s fsck.hfs.8 "${DESTDIR}"/usr/share/man/man8/fsck.hfsplus.8
 
 	vlicense "${FILESDIR}"/APSL-2.0
 }


### PR DESCRIPTION
- Use `vman` second argument to change the man page file name. This fixes the broken `/usr/share/man/man8/fsck.hfs.8 -> fsck.hfs.8` symlink.
- Create `fsck.hfsplus.8` symlink to `fsck.hfs.8`.