### PR TITLE
libgusb: update to 0.3.5.

### DIFF
--- a/srcpkgs/libgusb/template
+++ b/srcpkgs/libgusb/template
@@ -1,6 +1,6 @@
 # Template file for 'libgusb'
 pkgname=libgusb
-version=0.3.4
+version=0.3.5
 revision=1
 build_style=meson
 build_helper="gir"
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://github.com/hughsie/libgusb"
 changelog="https://raw.githubusercontent.com/hughsie/libgusb/master/NEWS"
 distfiles="http://people.freedesktop.org/~hughsient/releases/${pkgname}-${version}.tar.xz"
-checksum=581fd24e12496654b9b2a0732f810b554dfd9212516c18c23586c0cd0b382e04
+checksum=5b2a00c6997cc4b0133c5a5748a2e616e9e7504626922105b62aadced78e65df
 
 build_options="gir vala"
 build_options_default="gir vala"


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- aarch64 [x86_64]
- armv7l [x86_64]
- x86_64-musl [x86_64-musl]
- aarch64-musl [x86_64-musl]
- armv6l-musl [x86_64-musl]