### PR TITLE
jrnl: add python3-packaging dependency

### DIFF
--- a/srcpkgs/jrnl/template
+++ b/srcpkgs/jrnl/template
@@ -1,12 +1,12 @@
 # Template file for 'jrnl'
 pkgname=jrnl
 version=2.4.5
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-ansiwrap python3-asteval python3-colorama python3-cryptography
  python3-dateutil python3-keyring python3-parsedatetime python3-passlib
- python3-pytz python3-tzlocal python3-xdg python3-yaml"
+ python3-pytz python3-tzlocal python3-xdg python3-yaml python3-packaging"
 short_desc="Simple journal application for your command line"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"


### PR DESCRIPTION
`jrnl` requires `python3-packaging` as of v2.4.5. Without it installed it will crash.

See the [changelog](https://github.com/jrnl-org/jrnl/blob/975e4ba7e25884f51fd93cc78e490c80ed8e19f7/CHANGELOG.md#v245-2020-07-31).
