### PR TITLE
New package: python-py-1.9.0

### DIFF
--- a/srcpkgs/python-py/template
+++ b/srcpkgs/python-py/template
@@ -1,0 +1,19 @@
+# Template file for 'python-py'
+pkgname=python-py
+version=1.9.0
+revision=2
+wrksrc="py-${version}"
+build_style=python2-module
+hostmakedepends="python-setuptools"
+depends="python"
+short_desc="Python development support library"
+maintainer="Johannes <johannes.brechtmann@gmail.com>"
+license="MIT"
+homepage="https://github.com/pytest-dev/py"
+changelog="https://github.com/pytest-dev/py/raw/master/CHANGELOG"
+distfiles="${PYPI_SITE}/p/py/py-${version}.tar.gz"
+checksum=9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Package was removed in 910ab2464e724fc8166e2151b75bb9b08211aad6 but python-pytest depends on it.
`revision=2` is on purpose to be higher than the removed version.
Uses a new template instead of sharing one with `python3-py` to avoid complications with setuptools vs setuptools_scm.