### PR TITLE
chronograf: update to 1.8.7

### DIFF
--- a/srcpkgs/chronograf/template
+++ b/srcpkgs/chronograf/template
@@ -1,6 +1,6 @@
 # Template file for 'chronograf'
 pkgname=chronograf
-version=1.7.14
+version=1.8.7
 revision=1
 build_style=go
 go_import_path="github.com/influxdata/${pkgname}"
@@ -9,10 +9,10 @@ go_ldflags="-X main.version=${version}"
 hostmakedepends="dep go-bindata nodejs-lts yarn python"
 short_desc="Open source monitoring and visualization UI for the TICK stack"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
-license="AGPL-3.0"
+license="AGPL-3.0-or-later"
 homepage="https://www.influxdata.com/time-series-platform/chronograf/"
 distfiles="https://github.com/influxdata/${pkgname}/archive/${version}.tar.gz"
-checksum=245479b691e2ad484717778562ce9e0c21b1d769e7d748335d1c5f41cd677d4c
+checksum=ccee19b4e0de69fc1109dea4fb71a14d2fb60077a7203307ffeb35033aff79e1
 
 system_accounts="_chronograf"
 _chronograf_homedir="/var/lib/${pkgname}"


### PR DESCRIPTION
The previous 1.7.14 no longer builds.