### PR TITLE
libsigrokdecode: add patch for python3.9

### DIFF
--- a/srcpkgs/libsigrokdecode/patches/0001-configure.ac-Add-support-for-Python-3.9.patch
+++ b/srcpkgs/libsigrokdecode/patches/0001-configure.ac-Add-support-for-Python-3.9.patch
@@ -1,0 +1,25 @@
+From 9b0ad5177bd692f7556a4756bdbd2da81d9c34ce Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dan=20Hor=C3=A1k?= <dan@danny.cz>
+Date: Tue, 4 Aug 2020 09:19:44 +0200
+Subject: [PATCH] configure.ac: Add support for Python 3.9.
+
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git configure.ac configure.ac
+index f9958b3..2917cb3 100644
+--- configure.ac
++++ configure.ac
+@@ -100,7 +100,7 @@ SR_PKG_CHECK_SUMMARY([srd_pkglibs_summary])
+ # first, since usually only that variant will add "-lpython3.8".
+ # https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build
+ SR_PKG_CHECK([python3], [SRD_PKGLIBS],
+-	[python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
++	[python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
+ AS_IF([test "x$sr_have_python3" = xno],
+ 	[AC_MSG_ERROR([Cannot find Python 3 development headers.])])
+ 
+-- 
+2.29.2
+

--- a/srcpkgs/libsigrokdecode/template
+++ b/srcpkgs/libsigrokdecode/template
@@ -1,9 +1,9 @@
 # Template file for 'libsigrokdecode'
 pkgname=libsigrokdecode
 version=0.5.3
-revision=2
+revision=3
 build_style=gnu-configure
-hostmakedepends="pkg-config python3"
+hostmakedepends="pkg-config python3 autoconf automake"
 makedepends="glib-devel python3-devel"
 checkdepends="check-devel"
 short_desc="C library provides basic API for running sigrok protocol decoders"
@@ -12,6 +12,10 @@ license="GPL-3.0-or-later"
 homepage="https://sigrok.org/"
 distfiles="https://sigrok.org/download/source/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=c50814aa6743cd8c4e88c84a0cdd8889d883c3be122289be90c63d7d67883fc0
+
+pre_configure() {
+	autoreconf
+}
 
 libsigrokdecode-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
without, libsigrokdecode does not link against libpython3.9