### PR TITLE
haproxy: update to 2.3.0.

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,6 +1,6 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.2.4
+version=2.3.0
 revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
@@ -12,7 +12,7 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
 distfiles="${homepage}/download/${version%.*}/src/${pkgname}-${version}.tar.gz"
-checksum=87a4d9d4ff8dc3094cb61bbed4a8eed2c40b5ac47b9604daebaf036d7b541be2
+checksum=08badc59e037883f788f2c8f3358fa3e351aeaee826fd8a719f1e6252aff78fc
 
 haproxy_homedir="/var/lib/${pkgname}"
 make_dirs="$haproxy_homedir 0750 ${pkgname} ${pkgname}"


### PR DESCRIPTION
Successfully built for ppc64le-glibc, cross-compiled for aarch64-glibc and x86_64-glibc. I'd like to also suggest the creation of `haproxy22` to continue tracking the LTS Haproxy 2.2 branch, which will be supported until 2025. Thoughts?