### PR TITLE
tpm2-tss: update to 3.0.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3907,7 +3907,7 @@ libgij.so.17 libgcj-6.5.0_1
 libtty.so.1 libtermrec-0.18_1
 libtss2-mu.so.0 tpm2-tss-2.3.1_1
 libtss2-esys.so.0 tpm2-tss-2.3.1_1
-libtss2-sys.so.0 tpm2-tss-2.3.1_1
+libtss2-sys.so.1 tpm2-tss-3.0.1_1
 libtss2-tcti-device.so.0 tpm2-tss-2.3.1_1
 libtss2-rc.so.0 tpm2-tss-2.3.1_1
 libtss2-tcti-mssim.so.0 tpm2-tss-2.3.1_1

--- a/srcpkgs/tpm2-tss/template
+++ b/srcpkgs/tpm2-tss/template
@@ -1,18 +1,19 @@
 # Template file for 'tpm2-tss'
 pkgname=tpm2-tss
-version=2.3.2
+version=3.0.1
 revision=1
 build_style=gnu-configure
-configure_args="--disable-weakcrypto --with-crypto=gcrypt"
+configure_args="--disable-weakcrypto --with-crypto=mbed
+ --disable-fapi"
 hostmakedepends="autoconf-archive automake libtool pkg-config
  doxygen libltdl-devel"
-makedepends="libltdl-devel libgcrypt-devel"
+makedepends="libltdl-devel mbedtls-devel"
 short_desc="OSS implementation of the TCG TPM2 Software Stack"
-maintainer="Nathan Owens <ndowens04@gmail.com>"
+maintainer="Nathan Owens <ndowens@artixlinux.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/tpm2-software/tpm2-tss"
 distfiles="https://github.com/tpm2-software/tpm2-tss/archive/${version}.tar.gz"
-checksum=fa027be1b44a5dfb87d90d96ba257b458ff54a38ab176bcfa1f276db1226de0b
+checksum=136131edb7198b28430beb2c4c7f244c1590b2217c4a9a80bc33dc2a547a9237
 
 system_accounts="_tss"
 


### PR DESCRIPTION
gcrypt has been removed as supported crypto backend; libressl is not supported upstream neither. Disable fapi as it needs to be compiled with openssl support.