### PR TITLE
wlroots: update to 0.12.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3565,7 +3565,7 @@ libcodecore.so.0 libio.elementary.code-3.0_1
 libio.elementary.music-core.so.0 libio.elementary.music-5.0_1
 libpantheon-files-core.so.4 libio.elementary.files-4.1.4_1
 libpantheon-files-widgets.so.4 libio.elementary.files-4.1.4_1
-libwlroots.so.6 wlroots-0.11.0_1
+libwlroots.so.7 wlroots-0.12.0_1
 libbaseencode.so.1 libbaseencode-1.0.9_1
 libcotp.so.12 libcotp-1.2.1_1
 libunarr.so.1 libunarr-1.0.1_1

--- a/srcpkgs/cage/INSTALL.msg
+++ b/srcpkgs/cage/INSTALL.msg
@@ -1,0 +1,6 @@
+Setting the SUID bit after install has been retired for all Wayland
+compositors. It is recommended that users use a session management daemon
+such as elogind or seatd and do not rely on compositors dropping privileges.
+
+All users who require this functionality will need to set the SUID bit manually
+after each update going forward.

--- a/srcpkgs/cage/template
+++ b/srcpkgs/cage/template
@@ -1,12 +1,12 @@
 # Template file for 'cage'
 pkgname=cage
 version=0.1.2.1
-revision=2
+revision=3
 build_style=meson
 configure_args="$(vopt_bool xwayland xwayland)"
 hostmakedepends="pkg-config wayland-devel scdoc"
 makedepends="wlroots-devel"
-depends="$(vopt_if xwayland xorg-server-xwayland) $(vopt_if elogind elogind)"
+depends="$(vopt_if xwayland xorg-server-xwayland)"
 short_desc="Kiosk compositor for Wayland"
 maintainer="Illia Shestakov <ishestakov@airmail.cc>"
 license="MIT"
@@ -14,14 +14,10 @@ homepage="https://www.hjdskes.nl/projects/cage/"
 distfiles="https://github.com/Hjdskes/cage/archive/v${version}.tar.gz"
 checksum=38a3e3968f00cc58fe1d9448e972cfac7d1efa30c48699f09032f264101a55ac
 
-build_options="elogind xwayland"
+build_options="xwayland"
 build_options_default="xwayland"
 desc_option_xwayland="Enable Xwayland support in cage"
 
 post_install() {
-	if [ -z "$build_option_elogind" ]; then
-		# must be setuid without logind!
-		chmod u+s ${DESTDIR}/usr/bin/cage
-	fi
 	vlicense LICENSE
 }

--- a/srcpkgs/hikari/INSTALL.msg
+++ b/srcpkgs/hikari/INSTALL.msg
@@ -1,0 +1,6 @@
+Setting the SUID bit after install has been retired for all Wayland
+compositors. It is recommended that users use a session management daemon
+such as elogind or seatd and do not rely on compositors dropping privileges.
+
+All users who require this functionality will need to set the SUID bit manually
+after each update going forward.

--- a/srcpkgs/hikari/template
+++ b/srcpkgs/hikari/template
@@ -1,13 +1,13 @@
 # Template file for 'hikari'
 pkgname=hikari
 version=2.2.2
-revision=1
+revision=2
 build_style=gnu-makefile
 make_cmd=bmake
 make_use_env=yes
 make_build_args="WITH_POSIX_C_SOURCE=YES WITH_XWAYLAND=YES
  WITH_SCREENCOPY=YES WITH_GAMMACONTROL=YES WITH_LAYERSHELL=YES ETC_PREFIX="
-make_install_args="ETC_PREFIX="
+make_install_args="ETC_PREFIX= WITHOUT_SUID=YES"
 hostmakedepends="bmake pkg-config wayland-devel"
 makedepends="wlroots-devel pango-devel cairo-devel pam-devel glib-devel libucl-devel"
 short_desc="Stacking Wayland compositor with tiling features"

--- a/srcpkgs/sway/INSTALL.msg
+++ b/srcpkgs/sway/INSTALL.msg
@@ -1,0 +1,6 @@
+Setting the SUID bit after install has been retired for all Wayland
+compositors. It is recommended that users use a session management daemon
+such as elogind or seatd and do not rely on compositors dropping privileges.
+
+All users who require this functionality will need to set the SUID bit manually
+after each update going forward.

--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,21 +1,19 @@
 # Template file for 'sway'
 pkgname=sway
-version=1.5
-revision=2
+version=1.5.1
+revision=1
 build_style=meson
 conf_files="/etc/sway/config"
 hostmakedepends="pkg-config wayland-devel scdoc git"
 makedepends="wlroots-devel pcre-devel json-c-devel pango-devel cairo-devel
  gdk-pixbuf-devel"
-depends="swaybg xorg-server-xwayland $(vopt_if elogind elogind)"
+depends="swaybg xorg-server-xwayland"
 short_desc="Tiling Wayland compositor compatible with i3"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://swaywm.org"
 distfiles="https://github.com/swaywm/${pkgname}/archive/${version}.tar.gz"
-checksum=c80644774d612d7d377093d4990061d36c36673862c06318a7b0e37fa47b0178
-
-build_options="elogind"
+checksum=095f983c9a5f80d761bc2fb19df8166839b9290124ccd47f3e74119a1335490f
 
 post_patch() {
 	vsed -e 's/werror=true/werror=false/g' -i meson.build
@@ -23,10 +21,6 @@ post_patch() {
 
 post_install() {
 	vlicense LICENSE
-	if [ -z "$build_option_elogind" ]; then
-		# must be setuid without logind!
-		chmod u+s ${DESTDIR}/usr/bin/sway
-	fi
 	vbin contrib/grimshot
 	vman contrib/grimshot.1
 }
@@ -34,7 +28,6 @@ post_install() {
 grimshot_package() {
 	short_desc="Helper for screenshots within sway"
 	depends="grim slurp sway wl-clipboard jq libnotify"
-	archs="noarch"
 	pkg_install() {
 		vmove usr/bin/grimshot
 		vmove usr/share/man/man1/grimshot.1

--- a/srcpkgs/wayfire-plugins-extra/template
+++ b/srcpkgs/wayfire-plugins-extra/template
@@ -1,6 +1,6 @@
 # Template file for 'wayfire-plugins-extra'
 pkgname=wayfire-plugins-extra
-version=0.5.0
+version=0.6.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
@@ -11,7 +11,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayfire.org/"
 distfiles="https://github.com/WayfireWM/wayfire-plugins-extra/archive/${version}.tar.gz"
-checksum=64c56ffa66df26a7cbee1af41c34ae123abe8252deeaf02687237688a8281a9e
+checksum=d1ac42c0b2d212a7523f2aeb63285ab8b95ffb6efd564bf27877310eeab1ab0e
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wayfire/INSTALL.msg
+++ b/srcpkgs/wayfire/INSTALL.msg
@@ -1,5 +1,6 @@
-Before running Wayfire, copy the default configuration file to your user:
+Setting the SUID bit after install has been retired for all Wayland
+compositors. It is recommended that users use a session management daemon
+such as elogind or seatd and do not rely on compositors dropping privileges.
 
-  cp /usr/share/examples/wayfire/wayfire.ini ~/.config/wayfire.ini
-
-You also probably want to install elogind, then restart your computer
+All users who require this functionality will need to set the SUID bit manually
+after each update going forward.

--- a/srcpkgs/wayfire/patches/fix_switcher.patch
+++ b/srcpkgs/wayfire/patches/fix_switcher.patch
@@ -1,0 +1,30 @@
+--- plugins/single_plugins/switcher.cpp	2020-11-18 15:30:44.970379825 +0100
++++ plugins/single_plugins/switcher.cpp	2020-11-18 15:30:31.068223026 +0100
+@@ -201,7 +201,8 @@ class WayfireSwitcher : public wf::plugi
+             active = true;
+ 
+             // grabs shouldn't fail if we could successfully activate plugin
+-            assert(grab_interface->grab());
++            auto grab = grab_interface->grab();
++            assert(grab);
+ 
+             focus_next(dir);
+             arrange();
+--- src/view/layer-shell.cpp	2020-11-18 15:30:44.970379825 +0100
++++ src/view/layer-shell.cpp	2020-11-18 15:30:40.404328323 +0100
+@@ -1,5 +1,6 @@
+ #include <algorithm>
+ #include <cstring>
++#include <cstdlib>
+ 
+ #include "xdg-shell.hpp"
+ #include "wayfire/core.hpp"
+@@ -69,7 +70,7 @@ wf::workspace_manager::anchored_edge anc
+         return wf::workspace_manager::ANCHORED_EDGE_RIGHT;
+     }
+ 
+-    assert(false);
++    abort();
+ }
+ 
+ struct wf_layer_shell_manager

--- a/srcpkgs/wayfire/template
+++ b/srcpkgs/wayfire/template
@@ -1,23 +1,26 @@
 # Template file for 'wayfire'
 pkgname=wayfire
-version=0.5.0
+version=0.6.0
 revision=2
-_utils_commit=f9b5eba437a04a0d1fb9f00a0fdb88c12b9f6b27
+_utils_commit=f45641beef46babdc8f1b8d18a924e72beaf8ee6
+_touch_commit=b1075c54a280f913edc26b9757262f4f9d6b62b0
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
 makedepends="wf-config-devel wlroots-devel cairo-devel
  $(vopt_if image 'libjpeg-turbo-devel libpng-devel')"
-depends="xorg-server-xwayland $(vopt_if elogind elogind)"
+depends="xorg-server-xwayland"
 short_desc="3D wayland compositor"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayfire.org"
 distfiles="https://github.com/WayfireWM/wayfire/archive/${version}.tar.gz
- https://github.com/WayfireWM/wf-utils/archive/${_utils_commit}.tar.gz"
-checksum="24c1a2c963dac5af762f87cd024bc3dd736ec9a28a6735d357a05e8f6502e8aa
- 5c3e8bfefd74083a2548b6a95a070000cf73591bfe78335413da5c7fb82340cb"
+ https://github.com/WayfireWM/wf-utils/archive/${_utils_commit}.tar.gz
+ https://github.com/WayfireWM/wf-touch/archive/${_touch_commit}.tar.gz"
+checksum="9c2bf92e6aecc9b800b87e4c086ff7a275393f7315501b8c39196baf9d245b33
+ d172f8c21e0bac01e4116cd957fb0159c5cb39ddfdce897beb0d9c753796d5f1
+ 2b22e03d3a522baeff5798f630ffe5aa95899fd3233b291527503af5fd3e30be"
 
-build_options="elogind image"
+build_options="image"
 build_options_default="image"
 desc_option_image="Enable JPEG and PNG support"
 
@@ -27,14 +30,12 @@ fi
 
 post_extract() {
 	rmdir subprojects/wf-utils
+	rmdir subprojects/wf-touch
 	mv ../wf-utils-${_utils_commit} subprojects/wf-utils
+	mv ../wf-touch-${_touch_commit} subprojects/wf-touch
 }
 
 post_install() {
-	if [ -z "$build_option_elogind" ]; then
-		# must be setuid without logind!
-		chmod u+s ${DESTDIR}/usr/bin/wayfire
-	fi
 	vlicense LICENSE
 	vsconf wayfire.ini
 	vinstall wayfire.desktop 0644 usr/share/wayland-sessions

--- a/srcpkgs/wcm/template
+++ b/srcpkgs/wcm/template
@@ -1,6 +1,6 @@
 # Template file for 'wcm'
 pkgname=wcm
-version=0.5.0
+version=0.6.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config wayland-devel"
@@ -10,7 +10,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayfire.org/"
 distfiles="https://github.com/WayfireWM/wcm/archive/v${version}.tar.gz"
-checksum=9cfcceefc838c8a0d547f5e40206901b282680da02a96490f756f7ad7da79341
+checksum=bfead0b617f46306ad3bc15b8e9c7e8f13996de6b5bdd3f2d18f066a9033740f
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wf-config/template
+++ b/srcpkgs/wf-config/template
@@ -1,6 +1,6 @@
 # Template file for 'wf-config'
 pkgname=wf-config
-version=0.5.0
+version=0.6.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Young Jin Park <youngjinpark20@gmail.com>"
 license="MIT"
 homepage="https://wayfire.org"
 distfiles="https://github.com/WayfireWM/wf-config/archive/${version}.tar.gz"
-checksum=bf690477ff0d8928ddeca6a278b9153a39ade1e13fd32cc6d04552db4d65cbf0
+checksum=73af6d803044d4e5907974ece019ae0d1b4020a057f6c27be0594fb70d86653b
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wf-shell/template
+++ b/srcpkgs/wf-shell/template
@@ -1,9 +1,10 @@
 # Template file for 'wf-shell'
 pkgname=wf-shell
-version=0.5.0
+version=0.6.1
 revision=1
 build_style=meson
 build_helper="gir"
+configure_args="-Dwayland-logout:implementation=c"
 hostmakedepends="gobject-introspection pkg-config wayland-devel"
 makedepends="alsa-lib-devel pulseaudio-devel gtkmm-devel wayfire-devel
  gtk+3-devel gtk-layer-shell-devel"
@@ -11,8 +12,8 @@ short_desc="Wayfire shell with GTK-based panel and background client"
 maintainer="Young Jin Park <youngjinpark20@gmail.com>"
 license="MIT"
 homepage="https://wayfire.org"
-distfiles="https://github.com/WayfireWM/wf-shell/releases/download/${version}/wf-shell-${version}.tar.xz"
-checksum=fa481e867784b94b08857ec7bd27bf43251490d5d50c1e834e7ea64d908792f0
+distfiles="https://github.com/WayfireWM/wf-shell/releases/download/v${version}/wf-shell-${version}.tar.xz"
+checksum=da8e5a16dde8f44966d41449452bcc7bc2466d5945324aca714ecc82827c884a
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wlroots/template
+++ b/srcpkgs/wlroots/template
@@ -1,13 +1,13 @@
 # Template file for 'wlroots'
 pkgname=wlroots
-version=0.11.0
-revision=2
+version=0.12.0
+revision=1
 build_style=meson
-configure_args="-Dlogind=enabled -Dlogind-provider=elogind
+configure_args="-Dlogind=disabled -Dlibseat=enabled
  -Dxcb-errors=enabled -Dxcb-icccm=enabled -Dxwayland=enabled
  -Dx11-backend=enabled -Dexamples=false"
 hostmakedepends="pkg-config wayland-devel"
-_devel_depends="MesaLib-devel elogind-devel eudev-libudev-devel libdrm-devel
+_devel_depends="MesaLib-devel libseat-devel eudev-libudev-devel libdrm-devel
  libinput-devel libxkbcommon-devel pixman-devel wayland-devel wayland-protocols
  xcb-util-errors-devel xcb-util-wm-devel"
 makedepends="${_devel_depends}
@@ -18,7 +18,7 @@ maintainer="Isaac Freund <ifreund@ifreund.xyz>"
 license="MIT"
 homepage="https://github.com/swaywm/wlroots"
 distfiles="https://github.com/swaywm/wlroots/archive/${version}.tar.gz"
-checksum=a7645e77229aab4942748c621be8bdb8b073d94f35f3e032b867246862bf2d01
+checksum=c9e9f4f6d2f526d0b2886daf3ec37e64831773059aa669fb98a88522a1626bdb
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/wofi/template
+++ b/srcpkgs/wofi/template
@@ -1,7 +1,7 @@
 # Template file for 'wofi'
 pkgname=wofi
-version=1.2.2
-revision=2
+version=1.2.3
+revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=meson
 hostmakedepends="pkg-config"
@@ -11,4 +11,4 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://hg.sr.ht/~scoopta/wofi"
 distfiles="https://hg.sr.ht/~scoopta/wofi/archive/v${version}.tar.gz"
-checksum=@4e5193fe7eb29d08ee0249aa1d6dbb343b9b1fe54b11abfeb06f7c2015270431
+checksum=@3ef3ff39eb6c72f20a70486a40f0060150044b701db84489f9773f309673f8e7


### PR DESCRIPTION
~~There have been some important changes to wlroots that add support for the seat management daemon seatd. Since~~
1. ~~seatd still isn't available in Void repos~~
2. ~~the issue can be approached differently, which will require some discussion~~

~~this PR only updates wlroots without dealing with any of this to get the new version to end users asap. The changes required to add support for seatd shall be added in a separate PR.~~