### PR TITLE
xf86-video-vesa: update to 2.5.0.

### DIFF
--- a/srcpkgs/xf86-video-vesa/template
+++ b/srcpkgs/xf86-video-vesa/template
@@ -1,7 +1,7 @@
 # Template file for 'xf86-video-vesa'
 pkgname=xf86-video-vesa
-version=2.4.0
-revision=2
+version=2.5.0
+revision=1
 archs="x86_64* i686*"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://xorg.freedesktop.org"
 distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.bz2"
-checksum=bf443c94d7bf6cd4e248f8a3147f4647be04dc4c80250d9405006263bbdee38c
+checksum=1f1624f3c73906801ad1bc98335a2cb5676a7a4d18e5374d9a1d18464e54c659
 lib32disabled=yes
 
 CFLAGS="-I$XBPS_CROSS_BASE/usr/include/xorg"


### PR DESCRIPTION
Built for: 
- x86_64 [x86_64]
- i686 [i686]
- x86_64-musl [x86_64-musl]