### PR TITLE
goodvibes: update to 0.6

### DIFF
--- a/srcpkgs/goodvibes/template
+++ b/srcpkgs/goodvibes/template
@@ -1,12 +1,12 @@
 # Template file for 'goodvibes'
 pkgname=goodvibes
-version=0.5.2
+version=0.6
 revision=1
 wrksrc="goodvibes-v${version}"
 build_style=meson
-hostmakedepends="appstream-glib desktop-file-utils glib-devel pkg-config gettext"
-makedepends="dconf-devel gst-plugins-base1-devel gtk+3-devel libkeybinder3-devel
- amtk-devel libsoup-devel"
+hostmakedepends="appstream-glib desktop-file-utils pkg-config gettext"
+makedepends="amtk-devel dconf-devel glib-devel gst-plugins-base1-devel
+ gtk+3-devel libkeybinder3-devel libsoup-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Light and simple internet radio player"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -14,4 +14,8 @@ license="GPL-3.0-or-later"
 homepage="https://gitlab.com/goodvibes/goodvibes"
 changelog="https://gitlab.com/goodvibes/goodvibes/raw/v${version}/NEWS"
 distfiles="https://gitlab.com/goodvibes/goodvibes/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
-checksum=bef8afaa129dbd95681cd8b8a05964aa3bbdab08fe7565709f0da81d3d11c5a6
+checksum=b3cb769ff2813e38ac5211be5af97a32f17b31ba48c0133d8a406005262f76a5
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends+=" glib-devel"
+fi


### PR DESCRIPTION
Reoder depedencies and only use glib-devel in hostmakedepends if cross-building