### PR TITLE
gst-plugins-good1: enable lib32

### DIFF
--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
 version=1.16.2
-revision=2
+revision=3
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
 configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled -Dqt5=enabled
@@ -24,7 +24,6 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
 checksum=40bb3bafda25c0b739c8fc36e48380fccf61c4d3f83747e97ac3f9b0171b1319
-lib32disabled=yes
 
 build_options="gtk3"
 build_options_default="gtk3"


### PR DESCRIPTION
Required by RPG Maker in wine to play vorbis files.
User still required to
export GST_PLUGIN_SYSTEM_PATH=/usr/lib/gstreamer-1.0:/usr/lib32/gstreamer-1.0