### PR TITLE
notify-send.sh: update to 1.1.

### DIFF
--- a/srcpkgs/notify-send.sh/template
+++ b/srcpkgs/notify-send.sh/template
@@ -1,6 +1,6 @@
 # Template file for 'notify-send.sh'
 pkgname=notify-send.sh
-version=1.0
+version=1.1
 revision=1
 depends="bash dbus glib"
 short_desc="Drop in replacement for libnotify and notify-send"
@@ -8,8 +8,9 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/vlevit/notify-send.sh"
 distfiles="https://github.com/vlevit/notify-send.sh/archive/v${version}.tar.gz"
-checksum=ec06365be9d66b2a2ec57f1867529a20c6b56f40c8c0379eb9af95eebb006b6b
+checksum=58460c5fc84ab4fa45d2de62a38e7d0a08af2c106327ce49a83a8dcbb91ba438
 
 do_install() {
 	vbin notify-send.sh
+	vbin notify-action.sh
 }


### PR DESCRIPTION
The current one (v1.0) in the void linux repo missing `notify-action.sh` this PR also adds it.

`notify-action.sh` is used for running commands when the user press a button on the notification `notify-send.sh` created.