### PR TITLE
fastd: update to 21

### DIFF
--- a/srcpkgs/fastd/template
+++ b/srcpkgs/fastd/template
@@ -1,17 +1,17 @@
 # Template file for 'fastd'
 pkgname=fastd
-version=18
-revision=5
-build_style=cmake
-hostmakedepends="pkg-config bison"
-makedepends="libuecc-devel libsodium-devel json-c-devel libcap-devel"
+version=21
+revision=1
+build_style=meson
+configure_args="-Db_lto=true -Dcipher_aes128-ctr=disabled"
+hostmakedepends="bison pkg-config"
+makedepends="json-c-devel libcap-devel libuecc-devel libsodium-devel"
 short_desc="Fast and Secure Tunneling Daemon"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="BSD"
+license="BSD-2-Clause"
 homepage="https://projects.universe-factory.net/projects/fastd"
-distfiles="https://git.universe-factory.net/fastd/snapshot/fastd-${version}.tar"
-checksum=dce99ee057f43e3d732a120fb0cb60acb3b86e8231d3dd64ab72fc1254c2491a
-configure_args="ENABLE_LTO=ON -DWITH_CIPHER_AES128_CTR_NACL=OFF"
+distfiles="https://github.com/NeoRaider/fastd/releases/download/v$version/fastd-$version.tar.xz"
+checksum=942f33bcd794bcb8e19da4c30c875bdfd4d0f1c24ec4dcdf51237791bbfb0d4c
 conf_files="
  /etc/fastd/secret.conf
  /etc/fastd/fastd.conf"


### PR DESCRIPTION
@Gottox this fixes https://nvd.nist.gov/vuln/detail/CVE-2020-27638 Seems service does run as checked ps -aux | grep fastd