### PR TITLE
git-lfs: update to 2.12.1

### DIFF
--- a/srcpkgs/git-lfs/template
+++ b/srcpkgs/git-lfs/template
@@ -1,6 +1,6 @@
 # Template file for 'git-lfs'
 pkgname=git-lfs
-version=2.12.0
+version=2.12.1
 revision=1
 build_style=go
 go_import_path="github.com/git-lfs/git-lfs"
@@ -10,7 +10,7 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MIT"
 homepage="https://git-lfs.github.com/"
 distfiles="https://github.com/git-lfs/${pkgname}/archive/v${version}.tar.gz"
-checksum=9971d91cd2b0dd34ccda41a3db97504bfdb4fbc23cc2ee4b6e3b9afea5643941
+checksum=2b2e70f1233f7efe9a010771510391a07527ec7c0af721ecf8edabac5d60f62b
 
 post_build() {
 	make man


### PR DESCRIPTION
Fixes CVE-2020-27955
@the-maldridge 