### PR TITLE
New package: watchexec-1.14.1

### DIFF
--- a/srcpkgs/watchexec/template
+++ b/srcpkgs/watchexec/template
@@ -1,0 +1,17 @@
+# Template file for 'watchexec'
+pkgname=watchexec
+version=1.14.1
+revision=1
+build_style=cargo
+short_desc="Executes commands in response to file modifications"
+maintainer="cptpcrd <cptpcrd.git@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/watchexec/watchexec"
+distfiles="https://github.com/watchexec/watchexec/archive/${version}.tar.gz"
+checksum=23ca90f1f070b0d30e821667c8b9deaf174d020373ea032e9e22f1a78adcfa1c
+
+post_install() {
+	vdoc README.md
+	vman doc/watchexec.1
+	vcompletion completions/zsh zsh
+}


### PR DESCRIPTION
Disclaimer: This is my 2nd new package, and my first Rust package. I based this off of [`bat`'s template](https://github.com/void-linux/void-packages/blob/master/srcpkgs/bat/template); I'm not sure if the `export`s in `pre_build` are strictly necessary.