### PR TITLE
chromium: update to 86.0.4240.193.

### DIFF
--- a/srcpkgs/chromium-widevine/INSTALL
+++ b/srcpkgs/chromium-widevine/INSTALL
@@ -1,6 +1,6 @@
 # INSTALL
 
-checksum=c9d37f91449ea3563d518b13164c5aefb42d166d5aec91f9832948d335ee0de4
+checksum=fc4a4717ddf9623eeb2ebd4cf0f3a845a20fab34bb2831af2a264507b6432ef4
 _baseUrl="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable"
 _filename="google-chrome-stable_${VERSION%_*}-1_amd64.deb"
 DISTFILE="${_baseUrl}/${_filename}"

--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=86.0.4240.183
+version=86.0.4240.193
 revision=1
 archs="x86_64"
 create_wrksrc=yes

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=86.0.4240.183
+version=86.0.4240.193
 revision=1
 archs="i686* x86_64* aarch64* armv7l* ppc64le*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=aa12c6665c33275f3edffb6f127f97f84fa0bb69c644b4b023d51d2d058a69bc
+checksum=203dd5097f5873cb4881e2e838034f0dac5ff13e7fafa286baf87937f8eca534
 nocross=yes
 
 lib32disabled=yes


### PR DESCRIPTION
- Built for x86_64, x86_64-musl.
- Tested on x86_64.

- Also update chromium-widevine.