### PR TITLE
s3cmd: backport Python 3.9 compatibility fix

### DIFF
--- a/srcpkgs/s3cmd/patches/python-3.9-compatibility.patch
+++ b/srcpkgs/s3cmd/patches/python-3.9-compatibility.patch
@@ -1,0 +1,54 @@
+# This patch has been already merged into `master`
+# and should be dropped after next release.
+# See https://github.com/s3tools/s3cmd/pull/1137
+
+From 328ced84fe688db5ef0385f5c763cd948087d81f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ond=C5=99ej=20Budai?= <obudai@redhat.com>
+Date: Fri, 2 Oct 2020 14:24:09 +0200
+Subject: [PATCH] fix compatibility with Python 3.9
+
+getchildren() method was removed from the ElementTree and Element classes in
+Python 3.9. See the release notes:
+
+https://docs.python.org/3.9/whatsnew/3.9.html#removed
+---
+ S3/Exceptions.py | 2 +-
+ S3/Utils.py      | 8 ++++----
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+--- S3/Exceptions.py
++++ S3/Exceptions.py
+@@ -127,7 +127,7 @@ def parse_error_xml(tree):
+         if not error_node.tag == "Error":
+             error_node = tree.find(".//Error")
+         if error_node is not None:
+-            for child in error_node.getchildren():
++            for child in error_node:
+                 if child.text != "":
+                     debug("ErrorXML: " + child.tag + ": " + repr(child.text))
+                     info[child.tag] = child.text
+--- S3/Utils.py
++++ S3/Utils.py
+@@ -65,9 +65,9 @@ def parseNodes(nodes):
+     retval = []
+     for node in nodes:
+         retval_item = {}
+-        for child in node.getchildren():
++        for child in node:
+             name = decode_from_s3(child.tag)
+-            if child.getchildren():
++            if len(child):
+                 retval_item[name] = parseNodes([child])
+             else:
+                 found_text = node.findtext(".//%s" % child.tag)
+@@ -124,8 +124,8 @@ def getListFromXml(xml, node):
+ 
+ def getDictFromTree(tree):
+     ret_dict = {}
+-    for child in tree.getchildren():
+-        if child.getchildren():
++    for child in tree:
++        if len(child):
+             ## Complex-type child. Recurse
+             content = getDictFromTree(child)
+         else:

--- a/srcpkgs/s3cmd/template
+++ b/srcpkgs/s3cmd/template
@@ -1,14 +1,14 @@
 # Template file for 's3cmd'
 pkgname=s3cmd
 version=2.1.0
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-dateutil"
 short_desc="Command line tool for Amazon S3"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
-#changelog="https://github.com/s3tools/s3cmd/raw/master/NEWS"
+changelog="https://github.com/s3tools/s3cmd/raw/master/NEWS"
 homepage="http://s3tools.org/s3cmd"
 distfiles="https://github.com/s3tools/${pkgname}/archive/v${version}.tar.gz"
 checksum=2293f775fde77201bf8e489f20516fd594168c77897168f129e5c1a2b33b7e37


### PR DESCRIPTION
https://github.com/s3tools/s3cmd/issues/1146 is fixed in `master` by https://github.com/s3tools/s3cmd/pull/1137. This PR adds corresponding patch.