### PR TITLE
pinebookpro-firmware: include clm_blob

### DIFF
--- a/srcpkgs/pinebookpro-firmware/template
+++ b/srcpkgs/pinebookpro-firmware/template
@@ -1,20 +1,36 @@
 # Template file for 'pinebookpro-firmware'
 pkgname=pinebookpro-firmware
 reverts=20200215_1
-version=0.0.20200215
+version=0.0.20201114
 revision=1
-_commit=58820c428d2ecae6aaf5e4f00997652b9479853a
+_rockchip_commit=72c91aa297a10140781e3f83419c077d4bf8890c
+_manjaro_commit=7074a2e21dd804e229eab1c031bc00246e9173e0
 archs="aarch64*"
-wrksrc="rkwifibt-${_commit}"
+create_wrksrc=yes
 short_desc="Firmware files for the Pinebook Pro"
 maintainer="Renato Aguiar <renato@renatoaguiar.net>"
 license="Apache-2.0"
 homepage="https://github.com/rockchip-linux/rkwifibt"
-distfiles="https://github.com/rockchip-linux/rkwifibt/archive/${_commit}.tar.gz"
-checksum=20161cf3011f57dc9912db7270be1a83e543a61ea8757c23eaf983542fb021e0
+distfiles="
+ https://github.com/rockchip-linux/rkwifibt/archive/${_rockchip_commit}.tar.gz
+ https://gitlab.manjaro.org/manjaro-arm/packages/community/ap6256-firmware/-/archive/${_manjaro_commit}/ap6256-firmware-${_manjaro_commit}.tar.gz"
+checksum="
+ f73a89b09cccb283b92911e978188987859c97cb78957ab1dbc2f169a0a5ec05
+ 190653595f0dbf564bf726bc0de3d3f06aa9a6fcd7743a9b3fdd5b3b233b6c6b"
 
 do_install() {
+	cd "${wrksrc}"
+	cd "ap6256-firmware-${_manjaro_commit}"
+	vinstall brcmfmac43456-sdio.clm_blob 644 usr/lib/firmware/brcm
+	cd ..
+	cd "rkwifibt-${_rockchip_commit}"
 	vinstall firmware/broadcom/AP6256/bt/BCM4345C5.hcd 644 usr/lib/firmware/brcm
 	vinstall firmware/broadcom/AP6256/wifi/fw_bcm43456c5_ag.bin 644 usr/lib/firmware/brcm brcmfmac43456-sdio.bin
-	vinstall firmware/broadcom/AP6256/wifi/nvram_ap6256.txt 644 usr/lib/firmware/brcm brcmfmac43456-sdio.pine64,pinebook-pro.txt
+	cp -f firmware/broadcom/AP6256/wifi/nvram_ap6256.txt .
+	vsed -i 's/ccode=DE/ccode=all/' nvram_ap6256.txt
+	vinstall nvram_ap6256.txt 644 usr/lib/firmware/brcm brcmfmac43456-sdio.txt
+	cd ..
+	for dev in pine64,pinebook-pro radxa,rockpi4b radxa,rockpi4c rockpro64-v2.1 rk3399-orangepi; do
+		ln -sf brcmfmac43456-sdio.txt "${DESTDIR}/usr/lib/firmware/brcm/brcmfmac43456-sdio.${dev}.txt"
+	done
 }


### PR DESCRIPTION
Ship the clm_blob so that the correct frequencies are used for the
relevant wireless jurisdiction. Otherwise, only limited frequences are
supported.