### PR TITLE
grafana: Create /var/log/grafana on install

### DIFF
--- a/srcpkgs/grafana/INSTALL
+++ b/srcpkgs/grafana/INSTALL
@@ -4,6 +4,8 @@ case "$ACTION" in
             :
         else
             chown _grafana:_grafana var/lib/grafana
+            vmkdir var/log/grafana
+            chown _grafana:_grafana var/log/grafana
         fi
         ;;
 esac


### PR DESCRIPTION
Directory is referenced in [`template`](https://github.com/Goorzhel/void-packages/blob/25102fb7685b04c1abf23456d3f78ce31c3094ce/srcpkgs/grafana/template#L49).

@the-maldridge 