### PR TITLE
New package: codemod-1.0.0

### DIFF
--- a/srcpkgs/codemod/template
+++ b/srcpkgs/codemod/template
@@ -1,0 +1,15 @@
+# Template file for 'codemod'
+pkgname=codemod
+version=1.0.0
+revision=1
+_commit=41d6eabad7b055a83923150efd5518813831c9a5
+wrksrc="${pkgname}-${_commit}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools"
+short_desc="Tool/Library to assist you with large-scale codebase refactors"
+maintainer="Sora Morimoto <sora@morimoto.io>"
+license="Apache-2.0"
+homepage="https://github.com/facebook/codemod"
+distfiles="${homepage}/archive/${_commit}.tar.gz"
+checksum=04f81c2791a1504e91721d2f8c81e0a0b23994b8b8f62a87bc129cf6295e0678


### PR DESCRIPTION
There is no release on GitHub that adheres to semantic versioning style, but the code says it's 1.0.0:
https://github.com/facebook/codemod/blob/41d6eabad7b055a83923150efd5518813831c9a5/setup.py#L15