### PR TITLE
clipgrab: update to 3.9.2

### DIFF
--- a/srcpkgs/clipgrab/template
+++ b/srcpkgs/clipgrab/template
@@ -1,10 +1,9 @@
 # Template file for 'clipgrab'
 pkgname=clipgrab
-version=3.8.15
+version=3.9.2
 revision=1
 build_style=qmake
 configure_args=clipgrab.pro
-hostmakedepends="qt5-qmake qt5-devel"
 makedepends="qt5-webengine-devel qt5-webchannel-devel
  qt5-location-devel qt5-devel qt5-quickcontrols2-devel
  qt5-declarative-devel"
@@ -14,12 +13,12 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://clipgrab.org"
 distfiles="https://download.clipgrab.org/clipgrab-${version}.tar.gz"
-checksum=769812558342ebf4dee0f1deb2fe2ea801278e9821d87ad8d639cec52144d7aa
+checksum=c5bfcb0f6c3bff52ea68c2b978812bcbd43718fd2bcd2dcad1d6a4c970be6cb2
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-location-devel qt5-quickcontrols2-devel
+	hostmakedepends=" qt5-location-devel qt5-quickcontrols2-devel
 	 qt5-declarative-devel qt5-webchannel-devel qt5-webengine-devel
-	 qt5-host-tools"
+	 qt5-host-tools qt5-devel"
 fi
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Compiles fine without qt5-qmake in hostmakedepends, since if CROSS_BUILD is being used already, move qt5-devel.