### PR TITLE
minetest: update to 5.3.0

### DIFF
--- a/srcpkgs/minetest/template
+++ b/srcpkgs/minetest/template
@@ -1,22 +1,30 @@
 # Template file for 'minetest'
 pkgname=minetest
-version=5.2.0
+version=5.3.0
 revision=1
 build_style=cmake
-configure_args="-DRUN_IN_PLACE=0 -DENABLE_GETTEXT=1 -DENABLE_FREETYPE=1 -DBUILD_SERVER=TRUE"
+configure_args="-DRUN_IN_PLACE=0 -DENABLE_GETTEXT=1 -DENABLE_FREETYPE=1
+ -DBUILD_SERVER=TRUE"
 hostmakedepends="pkg-config tar"
-makedepends="LuaJIT-devel MesaLib-devel freetype-devel gmp-devel irrlicht-devel
+makedepends="MesaLib-devel freetype-devel gmp-devel irrlicht-devel
  libcurl-devel libjpeg-turbo-devel libopenal-devel libvorbis-devel lua52-devel
  sqlite-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="InfiniMiner/Minecraft inspired game"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Nathan <ndowens@artixlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.minetest.net"
 distfiles="https://github.com/minetest/minetest/archive/${version}.tar.gz
  https://github.com/minetest/minetest_game/archive/${version}.tar.gz>minetest_game-${version}.tar.gz"
-checksum="4996c7c50a6600d0c7140680d4bd995cb9aae910f216b46373953b49d6b13a5d
- 0c49fd6e310de1aba2e8cb8ae72efe0e06bb6bc8d7c5efea23bc201b6a80ce94"
+checksum="65dc2049f24c93fa544500f310a61e289c1b8fa47bf60877b746a2c27a7238d6
+ 06c6c1d4b97af211dd0fa518a3e68a205f594e9816a4b2477e48d4d21d278e2d"
+
+# LuaJIT enabled causes PIE to
+# be broken/not-used on aarch64*
+case "$XBPS_TARGET_MACHINE" in
+	aarch64*) ;;
+	*) makedepends+=" LuaJIT-devel" ;;
+esac
 
 pre_install() {
 	# Install the minetest_game subgame.


### PR DESCRIPTION
Adopt
LuaJIT with aarch64* causes PIE breakage; disable use of
LuaJIT for aarc64* due to CMakeLists.txt setting here:
https://github.com/minetest/minetest/blob/97aefe9b81414fa560d1ff37a3060266ac9735a9/src/CMakeLists.txt#L755

If we remove that line, seems we will have issue
https://github.com/minetest/minetest/issues/10220

When LuaJIT isn't found, it uses bundled Lua
According to https://github.com/minetest/minetest/issues/9367 disabling LuaJIT allowed them to run the game fine as well.

Upstream PR that added linker flag to fix issues https://github.com/minetest/minetest/pull/9614