### PR TITLE
Fixed i2pd for older processors

### DIFF
--- a/srcpkgs/i2pd/template
+++ b/srcpkgs/i2pd/template
@@ -1,7 +1,7 @@
 # Template file for 'i2pd'
 pkgname=i2pd
 version=2.33.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="USE_UPNP=yes"
 makedepends="zlib-devel boost-devel libressl-devel miniupnpc-devel
@@ -24,7 +24,7 @@ make_dirs="/var/lib/i2pd 0700 _i2pd _i2pd"
 
 case "${XBPS_TARGET_MACHINE}" in
 	x86_64*|i686*) ;;
-	*) make_build_args+=" USE_AESNI=no USE_AVX=no" ;;
+	*) make_build_args+=" USE_AVX=no" ;;
 esac
 
 pre_install() {


### PR DESCRIPTION
Some processors have not the AES instructions set
(https://en.wikipedia.org/wiki/AES_instruction_set) and if you try to
run i2pd in a processor without that, it will simply give "Illegal instruction"

This can be fixed by removing the `USE_AESNI=1` make
flag. (https://i2pd.readthedocs.io/en/latest/devs/building/windows/#aes-ni)