### PR TITLE
influxdb: update to 1.8.3.

### DIFF
--- a/srcpkgs/influxdb/template
+++ b/srcpkgs/influxdb/template
@@ -1,6 +1,6 @@
 # Template file for 'influxdb'
 pkgname=influxdb
-version=1.7.9
+version=1.8.3
 revision=1
 build_style=go
 go_import_path=github.com/influxdata/influxdb
@@ -10,27 +10,28 @@ go_package="${go_import_path}/cmd/influx
  ${go_import_path}/cmd/influx_inspect
  ${go_import_path}/cmd/influx_stress"
 go_ldflags="-X main.version=${version}"
-hostmakedepends="dep"
+hostmakedepends="asciidoc xmlto"
 short_desc="Scalable datastore for metrics, events, and real-time analytics"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MIT"
 homepage="https://influxdata.com/time-series-platform/influxdb/"
 changelog="https://raw.githubusercontent.com/influxdata/influxdb/master/CHANGELOG.md"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=fad5107985395353a584978f6c0ad1fbd4f41ea71bdc9cf55a006cc9a88d2b61
+checksum=d8b89e324ed7343c1397124ac3cc68c405406faf74e7369e733611cada54656d
 
 system_accounts="_influxdb"
 _influxdb_homedir="/var/lib/influxdb"
 make_dirs="${_influxdb_homedir} 0755 _influxdb _influxdb"
 conf_files="/etc/${pkgname}/${pkgname}.conf"
 
-pre_build() {
-	cd $GOSRCPATH
-	dep ensure
+post_build() {
+	make -C man build
 }
 
 post_install() {
 	vlicense LICENSE
 	vsv ${pkgname}
 	vinstall etc/config.sample.toml 644 etc/${pkgname} ${pkgname}.conf
+
+	make -C man DESTDIR="${DESTDIR}/usr" install
 }


### PR DESCRIPTION
I believe `influxdb>=2.0` requires some manual intervention when upgrading from `<2.0`, so I'm not sure if we want to bump to `2.0` just yet. In the meantime, this is the latest `1.x` version.

I've also installed the man pages.

cc: @the-maldridge 