### PR TITLE
dhcpcd: make privsep a build option and disable it

### DIFF
--- a/srcpkgs/dhcpcd/template
+++ b/srcpkgs/dhcpcd/template
@@ -1,10 +1,12 @@
 # Template file for 'dhcpcd'
 pkgname=dhcpcd
 version=9.3.2
-revision=1
+revision=2
 build_style=configure
 make_check_target=test
-configure_args="--prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --rundir=/run/dhcpcd --privsepuser=_dhcpcd"
+configure_args="
+ --prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --rundir=/run/dhcpcd
+ $(vopt_if privsep --privsepuser=_dhcpcd)"
 hostmakedepends="ntp pkg-config"
 makedepends="eudev-libudev-devel"
 short_desc="RFC2131 compliant DHCP client"
@@ -15,9 +17,12 @@ distfiles="https://roy.marples.name/downloads/dhcpcd/dhcpcd-${version}.tar.xz"
 checksum=6d49af5e766a2515e6366e4f669663df04ecdf90a1a60ddb1d7a2feb4b5d2566
 lib32disabled=yes
 conf_files=/etc/dhcpcd.conf
-# privsep
+
 system_accounts="_dhcpcd"
 _dhcpcd_homedir="/var/db/dhcpcd"
+
+build_options="privsep"
+desc_option_privsep="Enable privilege separation mode for the daemon"
 
 post_install() {
 	vsv dhcpcd


### PR DESCRIPTION
dhcpcd's privsep is seccomp based and thus shits the bed on a whim (e.g.
different CPU architectures or upstream libc changes).

Disable it by default, but leave the option around if somebody really
needs it (hint: they can probably just use the AppArmor profile).

@Skirmisher care to test if this fixes the fork bomb?

@sgn