### PR TITLE
python3-bleach: update to 3.2.1

### DIFF
--- a/srcpkgs/python3-bleach/template
+++ b/srcpkgs/python3-bleach/template
@@ -1,15 +1,16 @@
 # Template file for 'python3-bleach'
 pkgname=python3-bleach
-version=3.1.1
-revision=3
+version=3.2.1
+revision=1
 wrksrc="bleach-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-six python3-webencodings"
+depends="python3-six python3-webencodings
+ python3-packaging"
 short_desc="Easy safelist-based HTML-sanitizing tool (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/mozilla/bleach"
 changelog="https://raw.githubusercontent.com/mozilla/bleach/master/CHANGES"
 distfiles="${PYPI_SITE}/b/bleach/bleach-${version}.tar.gz"
-checksum=aa8b870d0f46965bac2c073a93444636b0e1ca74e9777e34f03dd494b8a59d48
+checksum=52b5919b81842b1854196eaae5ca29679a2f2e378905c346d3ca8227c2c66080


### PR DESCRIPTION
Fixes CVE-2020-6816

Synapse seemed to run fine with this version and also tested against another python package that uses this as a checkdepend and tests ran fine.