### PR TITLE
New package: tree-sitter 0.17.3

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4045,3 +4045,4 @@ libutil-cmdline-samba4.so samba-libs-4.13.2_1
 libwinbind-client-samba4.so samba-libs-4.13.2_1
 libsixel.so.1 libsixel-1.8.6_1
 libpamtest.so.0 pam_wrapper-1.1.3_1
+libtree-sitter.so.0 tree-sitter-0.17.3_1

--- a/srcpkgs/tree-sitter-devel
+++ b/srcpkgs/tree-sitter-devel
@@ -1,0 +1,1 @@
+tree-sitter/

--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,0 +1,26 @@
+# Template file for 'tree-sitter'
+pkgname=tree-sitter
+version=0.17.3
+revision=1
+build_style=gnu-makefile
+short_desc="Parser generator tool and incremental parsing library"
+maintainer="Harrison Thorne <harrisonthorne@protonmail.com>"
+license="MIT"
+homepage="https://tree-sitter.github.io"
+distfiles="https://github.com/tree-sitter/${pkgname}/archive/${version}.tar.gz"
+checksum=a897e5c9a7ccb74271d9b20d59121d2d2e9de8b896c4d1cfaac0f8104c1ef9f8
+
+post_install() {
+	vlicense LICENSE
+}
+
+tree-sitter-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}


### PR DESCRIPTION
Neovim's upcoming 0.5 seems to have `tree-sitter` as a dependency. This pull request adds both `tree-sitter` and `tree-sitter-devel` packages.

Edit: ~~oops, I'll need to get rid of those other pesky commits~~ Done