### PR TITLE
gcc: remove wrong include-fxed/bits/statx.h header

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -8,7 +8,7 @@ _isl_version=0.21
 
 pkgname=gcc
 version=${_minorver}.0
-revision=7
+revision=8
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"
@@ -365,6 +365,10 @@ do_install() {
 	if [ -e ${DESTDIR}/usr/lib64 ]; then
 		rm -f ${DESTDIR}/usr/lib64
 	fi
+
+	# Remove "fixed" header
+	# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91085
+	rm -vf ${DESTDIR}/usr/lib/gcc/${_triplet}/${_minorver}/include-fixed/bits/statx.h
 
 	# Remove libffi stuff.
 	rm -f ${DESTDIR}/usr/lib/libffi*


### PR DESCRIPTION
This is needed, to be able to compile a new gcc with glibc-2.31+
