### PR TITLE
libcap-ng: update to 0.8.2.

### DIFF
--- a/srcpkgs/libcap-ng/template
+++ b/srcpkgs/libcap-ng/template
@@ -1,7 +1,7 @@
 # Template file for 'libcap-ng'
 pkgname=libcap-ng
-version=0.8
-revision=2
+version=0.8.2
+revision=1
 build_style=gnu-configure
 configure_args="--without-python --without-python3"
 short_desc="Alternate POSIX capabilities library"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://people.redhat.com/sgrubb/libcap-ng/"
 distfiles="http://people.redhat.com/sgrubb/$pkgname/$pkgname-$version.tar.gz"
-checksum=f14d23b60ae1465b032e4e8cbd4112006572c69a6017d55d5d3c6aad622a9e21
+checksum=52c083b77c2b0d8449dee141f9c3eba76e6d4c5ad44ef05df25891126cb85ae9
 
 subpackages="libcap-ng-devel libcap-ng-progs"
 


### PR DESCRIPTION
Adds more error checking for some functions, which can lead to unexpected failures. I know about https://github.com/stevegrubb/libcap-ng/issues/21 , at the moment.