### PR TITLE
qtkeychain-qt5: update to 0.11.1

### DIFF
--- a/srcpkgs/qtkeychain-qt5/INSTALL.msg
+++ b/srcpkgs/qtkeychain-qt5/INSTALL.msg
@@ -1,2 +1,2 @@
 To actually use qtkeychain-qt5 you need to either have kwallet or
-libgnome-keyring installed.
+gnome-keyring installed.

--- a/srcpkgs/qtkeychain-qt5/patches/use-kwallet-dbus-def.patch
+++ b/srcpkgs/qtkeychain-qt5/patches/use-kwallet-dbus-def.patch
@@ -1,0 +1,15 @@
+Use kwallet interface definition from the kwallet package,
+instead of using the out-of-date provided in qtkeychain package
+see https://github.com/frankosterfeld/qtkeychain/issues/172
+
+--- CMakeLists.txt.ORIG	2020-09-08 15:13:16.000000000 +0200
++++ CMakeLists.txt	2020-11-13 13:50:56.648621533 +0100
+@@ -169,7 +169,7 @@
+ 
+     add_definitions(-DKEYCHAIN_DBUS=1)
+     list(APPEND qtkeychain_SOURCES keychain_unix.cpp gnomekeyring.cpp libsecret.cpp plaintextstore.cpp)
+-    qt_add_dbus_interface(qtkeychain_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/org.kde.KWallet.xml kwallet_interface KWalletInterface)
++    qt_add_dbus_interface(qtkeychain_SOURCES /usr/share/dbus-1/interfaces/kf5_org.kde.KWallet.xml kwallet_interface KWalletInterface)
+     list(APPEND qtkeychain_LIBRARIES ${QTDBUS_LIBRARIES} )
+ endif()
+ 

--- a/srcpkgs/qtkeychain-qt5/template
+++ b/srcpkgs/qtkeychain-qt5/template
@@ -1,21 +1,26 @@
 # Template file for 'qtkeychain-qt5'
 pkgname=qtkeychain-qt5
-version=0.9.1
-revision=2
+version=0.11.1
+revision=1
 wrksrc="${pkgname%-*}-${version}"
 build_style=cmake
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config kwallet"
 makedepends="libsecret-devel qt5-tools-devel"
 short_desc="Platform-independent Qt5 API for storing passwords securely"
-maintainer="Duncaen <duncaen@voidlinux.org>"
+maintainer="yopito <pierre.bourgin@free.fr>"
 license="BSD-2-Clause"
 homepage="https://github.com/frankosterfeld/qtkeychain"
 distfiles="https://github.com/frankosterfeld/${pkgname%-*}/archive/v${version}.tar.gz"
-checksum=9c2762d9d0759a65cdb80106d547db83c6e9fdea66f1973c6e9014f867c6f28e
+checksum=77fc6841c1743d9e6bd499989481cd9239c21bc9bf0760d41a4f4068d2f0a49d
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-tools-devel"
 fi
+
+post_patch() {
+	# ensure it's not used (see dedicated patch)
+	rm org.kde.KWallet.xml
+}
 
 post_install() {
 	vlicense COPYING
@@ -28,5 +33,6 @@ qtkeychain-qt5-devel_package() {
 		vmove usr/include
 		vmove usr/lib/cmake
 		vmove usr/lib/*.so
+		vmove usr/lib/qt5/mkspecs
 	}
 }


### PR DESCRIPTION
* build is fine
* compared to 0.9.1: detect and launch correctly gnome-keyring if available (deprecated libgnome-keyring is uneeded)
* works with nextcloud client 3.0.2 for both GNOME keyring and kwallet5
