### PR TITLE
gcc-multilib: enable PIE and SSP.

### DIFF
--- a/srcpkgs/gcc-multilib/template
+++ b/srcpkgs/gcc-multilib/template
@@ -5,7 +5,7 @@ _majorver=9.3
 
 pkgname=gcc-multilib
 version=${_majorver}.0
-revision=1
+revision=2
 wrksrc="gcc-${version}"
 short_desc="GNU Compiler Collection (multilib files)"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -55,6 +55,8 @@ do_configure() {
 		--enable-lto \
 		--enable-linker-build-id \
 		--enable-gnu-unique-object \
+		--enable-default-pie \
+		--enable-default-ssp \
 		--enable-checking=release \
 		--disable-libstdcxx-pch \
 		--disable-target-libiberty \


### PR DESCRIPTION
Don't diverge from features of main gcc package.