### PR TITLE
slack-desktop: update to 4.11.1

### DIFF
--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'slack-desktop'
 pkgname=slack-desktop
-version=4.11.0
+version=4.11.1
 revision=1
 archs="x86_64"
 hostmakedepends="tar xz"
@@ -10,7 +10,7 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="custom:Proprietary"
 homepage="https://slack.com/"
 distfiles="https://slack-ssb-updates.global.ssl.fastly.net/linux_releases/${pkgname}-${version}-amd64.deb"
-checksum=ecfe313c75ceb01c8f142a90efa728a1009b5ade1bd7dd74b84fd05102ebccbe
+checksum=cf549741b6477cca74be04e56b96a8a9bfb02452ebd641d1c0aa286afb7883e4
 restricted=yes
 repository="nonfree"
 nopie=yes


### PR DESCRIPTION
Built package and tested working on amd64.