### PR TITLE
rclone: update to 1.53.3.

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,6 +1,6 @@
 # Template file for 'rclone'
 pkgname=rclone
-version=1.53.1
+version=1.53.3
 revision=1
 wrksrc="rclone-v${version}"
 build_style=go
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://rclone.org/"
 changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/changelog.md"
 distfiles="https://github.com/rclone/rclone/releases/download/v${version}/rclone-v${version}.tar.gz"
-checksum=d72d74a90a191fc0964705270ff59d58094e2bf4982f9fa0bc150f7296620caf
+checksum=f1e213bc6fb7c46f9a4cc8604ae0856718434bdafe07fa3ce449ae9a510a5763
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Fixes CVE-2020-28924.