### PR TITLE
New package: meli-0.6.2

### DIFF
--- a/srcpkgs/meli/patches/disable-lto.patch
+++ b/srcpkgs/meli/patches/disable-lto.patch
@@ -1,0 +1,12 @@
+--- Cargo.toml
++++ Cargo.toml
+@@ -64,9 +64,7 @@ quote = "^1.0"
+ proc-macro2 = "1.0.18"
+ 
+ [profile.release]
+-lto = "fat"
+ opt-level = "z"
+-debug = false
+ 
+ [workspace]
+ members = ["melib", "tools", ]

--- a/srcpkgs/meli/patches/fixes-for-32bit-systems.patch
+++ b/srcpkgs/meli/patches/fixes-for-32bit-systems.patch
@@ -1,0 +1,41 @@
+--- melib/src/backends/notmuch.rs
++++ melib/src/backends/notmuch.rs
+@@ -81,7 +81,7 @@ impl DbConnection {
+             call!(self.lib, notmuch_database_get_revision)(
+                 *self.inner.read().unwrap(),
+                 std::ptr::null_mut(),
+-            )
++            ) as u64
+         }
+     }
+ 
+--- melib/src/datetime.rs
++++ melib/src/datetime.rs
+@@ -69,8 +69,7 @@ extern "C" {
+ pub fn timestamp_to_string(timestamp: UnixTimestamp, fmt: Option<&str>) -> String {
+     let mut new_tm: ::libc::tm = unsafe { std::mem::zeroed() };
+     unsafe {
+-        let i: i64 = timestamp.try_into().unwrap_or(0);
+-        localtime_r(&i as *const i64, &mut new_tm as *mut ::libc::tm);
++        localtime_r(&(timestamp as ::libc::time_t), &mut new_tm);
+     }
+     let fmt = fmt
+         .map(CString::new)
+--- melib/src/lib.rs
++++ melib/src/lib.rs
+@@ -239,13 +239,13 @@ pub mod shellexpand {
+             let mut buf: Vec<u8> = Vec::with_capacity(BUF_SIZE);
+             let mut entries = SmallVec::new();
+             loop {
+-                let n: i64 = unsafe {
++                let n = unsafe {
+                     ::libc::syscall(
+                         ::libc::SYS_getdents64,
+                         dir.as_raw_fd(),
+                         buf.as_ptr(),
+                         BUF_SIZE - 256,
+-                    )
++                    ) as isize
+                 };
+                 if n < 0 {
+                     return SmallVec::new();

--- a/srcpkgs/meli/template
+++ b/srcpkgs/meli/template
@@ -1,0 +1,15 @@
+# Template file for 'meli'
+pkgname=meli
+version=0.6.2
+revision=1
+wrksrc=meli
+build_style=cargo
+configure_args="--features=cli-docs"
+hostmakedepends="pkg-config mdocml"
+makedepends="gpgme-devel dbus-devel sqlite-devel libnotmuch-devel libressl-devel pcre2-devel"
+short_desc="BSD/Linux terminal email client inspired by mutt"
+maintainer="Artur Sinila <opensource@logarithmus.dev>"
+license="GPL-3.0-or-later"
+homepage="https://meli.delivery/"
+distfiles="https://git.meli.delivery/meli/meli/archive/alpha-${version}.tar.gz"
+checksum=ae6651d11c5edd449e1a57729c792f5dc425fbc153fa180f9a6a6131d23a19fa


### PR DESCRIPTION
BSD/Linux terminal email client with support for multiple accounts and Maildir / mbox / notmuch / IMAP / JMAP.
See https://github.com/void-linux/void-packages/issues/26132
