### PR TITLE
cherrytree: update to 0.99.21

### DIFF
--- a/srcpkgs/cherrytree/template
+++ b/srcpkgs/cherrytree/template
@@ -1,25 +1,20 @@
 # Template file for 'cherrytree'
 pkgname=cherrytree
-version=0.38.9
+version=0.99.21
 revision=1
-archs=noarch
-build_style=python2-module
-pycompile_dirs="usr/share/cherrytree/modules"
-hostmakedepends="gettext python-devel desktop-file-utils"
-depends="pygtksourceview python-dbus python-enchant desktop-file-utils"
+build_style=cmake
+hostmakedepends="gettext pkg-config desktop-file-utils python3 glib-devel"
+makedepends="cpputest uchardet-devel libcurl-devel sqlite-devel
+ libxml++-devel gtksourceviewmm-devel gspell-devel gtkmm-devel"
+depends="desktop-file-utils"
+checkdepends="xvfb-run"
 short_desc="Hierarchial note taking application with syntax highlighting"
 maintainer="Logen K <logen@sudotask.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.giuspen.com/cherrytree/"
-distfiles="https://www.giuspen.com/software/${pkgname}-${version}.tar.xz"
-checksum=fc16669e81e7f981f1b51671171a55035febf2ea80e801c0dd7ff52763025475
-python_version=2
+distfiles="https://github.com/giuspen/cherrytree/archive/$version.tar.gz"
+checksum=5c180fdf5cbab43bc496a246ce952e7f39e84b2a7b4cabdb22773b9d4a415850
 
-post_install() {
-	# don’t install useless egg
-	rm -rf ${DESTDIR}/usr/lib/python*/site-packages
-
-	# remove old mime registration files
-	rm -rf ${DESTDIR}/usr/share/application-registry
-	rm -rf ${DESTDIR}/usr/share/mime-info
+do_check() {
+	xvfb-run make -C build test
 }


### PR DESCRIPTION
I haven't pushed an update since the runtime checks have become required. I'm not sure what to expect, but this is my result:

Running tests...
Test project /builddir/cherrytree_0.99.21/build
    Start 1: run_tests
1/1 Test #1: run_tests ........................***Failed    0.07 sec
Unable to init server: Could not connect: Connection refused

(run_tests:31504): Gtk-WARNING **: 10:39:54.094: cannot open display: 


0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.07 sec

The following tests FAILED:
	  1 - run_tests (Failed)
Errors while running CTest
make: *** [Makefile:171: test] Error 8
=> ERROR: cherrytree-0.99.21_1: do_check: 'CTEST_OUTPUT_ON_FAILURE=TRUE ${make_cmd} ${make_check_args} ${make_check_target}' exited with 2
=> ERROR:   in do_check() at common/build-style/cmake.sh:108
