### PR TITLE
pinebookpro-base: update to 0.3

### DIFF
--- a/srcpkgs/pinebookpro-base/files/10-pinebookpro.hwdb
+++ b/srcpkgs/pinebookpro-base/files/10-pinebookpro.hwdb
@@ -1,4 +1,4 @@
-evdev:input:b0003v258Ap001E*
+pinebookpro:keyboard
   KEYBOARD_KEY_700a5=brightnessdown
   KEYBOARD_KEY_700a6=brightnessup
   KEYBOARD_KEY_70066=sleep

--- a/srcpkgs/pinebookpro-base/files/60-pinebookpro.rules
+++ b/srcpkgs/pinebookpro-base/files/60-pinebookpro.rules
@@ -1,0 +1,7 @@
+ACTION=="remove", GOTO="pinebookpro_end"
+KERNEL!="event*", GOTO="pinebookpro_end"
+
+ENV{idVendor}=="258a", ENV{idProduct}=="001e", ENV{ID_INPUT_KEYBOARD}=="1", \
+  IMPORT{builtin}="hwdb 'pinebookpro:keyboard'", RUN{builtin}+="keyboard"
+
+LABEL="pinebookpro_end"

--- a/srcpkgs/pinebookpro-base/template
+++ b/srcpkgs/pinebookpro-base/template
@@ -1,6 +1,6 @@
 # Template file for 'pinebookpro-base'
 pkgname=pinebookpro-base
-version=0.2
+version=0.3
 revision=1
 archs="aarch64*"
 build_style=meta
@@ -9,8 +9,10 @@ short_desc="Void Linux Pinebook Pro platform package"
 maintainer="Renato Aguiar <renato@renatoaguiar.net>"
 license="Public Domain"
 homepage="https://www.voidlinux.org"
+mutable_files="/var/lib/alsa/asound.state"
 
 do_install() {
-	vinstall "${FILESDIR}/10-usb-kbd.hwdb" 644 usr/lib/udev/hwdb.d
+	vinstall "${FILESDIR}/60-pinebookpro.rules" 644 usr/lib/udev/rules.d
+	vinstall "${FILESDIR}/10-pinebookpro.hwdb" 644 usr/lib/udev/hwdb.d
 	vinstall "${FILESDIR}/asound.state" 644 var/lib/alsa
 }


### PR DESCRIPTION
Mark asound.state file as mutable.

Rename udev hwdb to denote pinebookpro specificity.

Rather than using an evdev hwdb match, set up a custom match via a udev
rule so that only the keyboard (and not other devices are matched).

Without the custom rule, lines like the following appear in dmesg:

udevd[...]: Error calling EVIOCSKEYCODE on device node [...]: Invalid argument