### PR TITLE
pelican: update to 4.5.1.

### DIFF
--- a/srcpkgs/pelican/template
+++ b/srcpkgs/pelican/template
@@ -1,9 +1,8 @@
 # Template file for 'pelican'
 pkgname=pelican
-version=4.2.0
-revision=3
+version=4.5.1
+revision=1
 build_style=python3-module
-pycompile_module="pelican"
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-feedgenerator python3-Jinja2 python3-Pygments
  python3-docutils python3-pytz python3-blinker python3-Unidecode python3-six
@@ -20,7 +19,7 @@ changelog="https://raw.githubusercontent.com/getpelican/pelican/${version}/docs/
 # We can live with it.
 # distfiles="${PYPI_SITE}/p/pelican/pelican-${version}.tar.gz"
 distfiles="https://github.com/getpelican/pelican/archive/${version}.tar.gz"
-checksum=4b0d4c9439217b49ace89f4f8b52c90e13fa283a786d7b12e2020a11f32f9a33
+checksum=b47c65f663bf6f2513b8ebc1f096e51f4d7865c17b36c370f83eadd80b6ba702
 
 post_extract() {
 	# This test is problematic,


### PR DESCRIPTION
Supersedes https://github.com/void-linux/void-packages/pull/25794 .