### PR TITLE
linux5.9: update to 5.9.11.

### DIFF
--- a/srcpkgs/linux5.9/template
+++ b/srcpkgs/linux5.9/template
@@ -1,6 +1,6 @@
 # Template file for 'linux5.9'
 pkgname=linux5.9
-version=5.9.8
+version=5.9.11
 revision=1
 wrksrc="linux-${version}"
 short_desc="Linux kernel and modules (${version%.*} series)"
@@ -8,7 +8,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-only"
 homepage="https://www.kernel.org"
 distfiles="https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${version}.tar.xz"
-checksum=7656733b316562662026ac82a7c0be41440e16bbf1bdc5447b119e34ff3b86a6
+checksum=5eb20a65a410669928f94b3975872e493fa6d0fe441c6a78b7564affa2a5d260
 python_version=3
 patch_args="-Np1"
 


### PR DESCRIPTION
This one should might have to wait a bit, seeing as 5.9.9 has reportedly been having network and filesytem issues, and 5.9.10 has very few changes added on top.

[ci skip]