### PR TITLE
.github/workflows/build: don't skip CI when PR is a draft.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: Build packages
     runs-on: ubuntu-18.04
-    if: "!github.event.pull_request.draft && !contains(github.event.pull_request.title, '[ci skip]') && !contains(github.event.pull_request.body, '[ci skip]')"
+    if: "!contains(github.event.pull_request.title, '[ci skip]') && !contains(github.event.pull_request.body, '[ci skip]')"
 
     container:
       image: 'voidlinux/masterdir-${{ matrix.config.bootstrap }}:20200607RC01'


### PR DESCRIPTION
When a PR is marked as ready for review (no longer a draft), CI isn't
re-run automatically, so no tests are run until the PR is updated. Even
trying to manually re-run the jobs doesn't fix this, since GH appears to
remember the PR state instead of using the current one.