### PR TITLE
rclone: fix musl cross builds.

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,7 +1,7 @@
 # Template file for 'rclone'
 pkgname=rclone
 version=1.53.3
-revision=1
+revision=2
 wrksrc="rclone-v${version}"
 build_style=go
 go_import_path=github.com/rclone/rclone
@@ -13,6 +13,15 @@ homepage="https://rclone.org/"
 changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/changelog.md"
 distfiles="https://github.com/rclone/rclone/releases/download/v${version}/rclone-v${version}.tar.gz"
 checksum=f1e213bc6fb7c46f9a4cc8604ae0856718434bdafe07fa3ce449ae9a510a5763
+
+pre_build() {
+	if [ "$CROSS_BUILD" ] && [ "$XBPS_TARGET_LIBC" = musl ]; then
+		# XXX: when cross building, the binary has a textrel, which segfaults when
+		# launched on musl
+		# FIXME: linkers for the musl toolchains should reject textrels entirely
+		export CGO_ENABLED=0
+	fi
+}
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
For some reason, the cross built binaries have a TEXTREL in their
dynamic section, which musl's runtime linker doesn't support at all,
causing a segfault at launch. Fix this by disabling CGO_ENABLED for now.

Fixes #26638 