### PR TITLE
libwebsockets-devel: add libressl-devel and libuv-devel to dependencies

### DIFF
--- a/srcpkgs/libwebsockets/template
+++ b/srcpkgs/libwebsockets/template
@@ -17,7 +17,7 @@ checksum=166d6e17cab64bfc10c2a71799c298284540a1fa63f6ea3de5caccb34502243c
 CFLAGS="-Wno-error"
 
 libwebsockets-devel_package() {
-	depends="libwebsockets>=${version}_${revision} libev-devel libcap-devel"
+	depends="libwebsockets>=${version}_${revision} libcap-devel libev-devel libressl-devel libuv-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/bin


### PR DESCRIPTION
libwebsockets.h depends on libressl and libuv header files due to
LWS_WITH_TLS=1 and LWS_WITH_LIBUV=1, so add them as dependencies.

Signed-off-by: Anthony Iliopoulos <ailiop@altatus.com>