### PR TITLE
igt-gpu-tools: fix segment fault on resolve_half_to_float

### DIFF
--- a/srcpkgs/igt-gpu-tools/patches/i-g-t-Fix-global-symbol-loading-failure-in-resolve-function.patch
+++ b/srcpkgs/igt-gpu-tools/patches/i-g-t-Fix-global-symbol-loading-failure-in-resolve-function.patch
@@ -1,0 +1,63 @@
+diff --git lib/igt_halffloat.c lib/igt_halffloat.c
+index 08ab05fc..e5e8a5bd 100644
+--- lib/igt_halffloat.c
++++ lib/igt_halffloat.c
+@@ -24,6 +24,19 @@
+ 
+ #include <assert.h>
+ #include <math.h>
++#include <stdbool.h>
++
++#ifdef HAVE_CPUID_H
++#include <cpuid.h>
++#else
++#define __get_cpuid_max(x, y) 0
++#define __cpuid(level, a, b, c, d) a = b = c = d = 0
++#define __cpuid_count(level, count, a, b, c, d) a = b = c = d = 0
++#endif
++
++#ifndef bit_F16C
++#define bit_F16C	(1 << 29)
++#endif
+ 
+ #include "igt_halffloat.h"
+ #include "igt_x86.h"
+@@ -182,6 +195,20 @@ static void half_to_float_f16c(const uint16_t *h, float *f, unsigned int num)
+ 
+ #pragma GCC pop_options
+ 
++static bool f16c_is_supported(void)
++{
++	unsigned max = __get_cpuid_max(0, NULL);
++	unsigned eax, ebx, ecx, edx;
++
++	if (max >= 1) {
++		__cpuid(1, eax, ebx, ecx, edx);
++
++		if (ecx & bit_F16C)
++			return true;
++	}
++	return false;
++}
++
+ static void float_to_half(const float *f, uint16_t *h, unsigned int num)
+ {
+ 	for (int i = 0; i < num; i++)
+@@ -196,7 +223,7 @@ static void half_to_float(const uint16_t *h, float *f, unsigned int num)
+ 
+ static void (*resolve_float_to_half(void))(const float *f, uint16_t *h, unsigned int num)
+ {
+-	if (igt_x86_features() & F16C)
++	if (f16c_is_supported())
+ 		return float_to_half_f16c;
+ 
+ 	return float_to_half;
+@@ -207,7 +234,7 @@ void igt_float_to_half(const float *f, uint16_t *h, unsigned int num)
+ 
+ static void (*resolve_half_to_float(void))(const uint16_t *h, float *f, unsigned int num)
+ {
+-	if (igt_x86_features() & F16C)
++	if (f16c_is_supported())
+ 		return half_to_float_f16c;
+ 
+ 	return half_to_float;

--- a/srcpkgs/igt-gpu-tools/template
+++ b/srcpkgs/igt-gpu-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'igt-gpu-tools'
 pkgname=igt-gpu-tools
 version=1.25
-revision=2
+revision=3
 build_style=meson
 configure_args="-Db_ndebug=false -Db_lto=false"
 # b_lto=true makes the build hang at a random point


### PR DESCRIPTION
This patch fix segment fault because the ifunc
resolver resolve_half_to_float() tries to call unbound global function
igt_x86_features().

Fix issue #26671

Signed-off-by: Tw <wei.tan@intel.com>