### PR TITLE
python3-codespell: update to 2.0.0

### DIFF
--- a/srcpkgs/python3-aspell/template
+++ b/srcpkgs/python3-aspell/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-aspell'
+pkgname=python3-aspell
+version=1.15
+revision=1
+wrksrc="aspell-python-$version"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel aspell-devel"
+depends="python3"
+short_desc="Python3 aspell binding"
+maintainer="Nathan Owens <ndowens@artixlinux.org>"
+license="BSD-3-Clause"
+homepage="http://github.com/WojciechMula/aspell-python"
+distfiles="https://github.com/WojciechMula/aspell-python/archive/$version.tar.gz"
+checksum=e1497eae8fbf35569520dc4c4f8bbd0bc7f349ce5b369c5067cd0f3a94bcb33d
+
+pre_configure() {
+	mv setup.3.py setup.py
+}
+
+do_check() {
+	: # No tests
+}

--- a/srcpkgs/python3-codespell/template
+++ b/srcpkgs/python3-codespell/template
@@ -1,15 +1,21 @@
 # Template file for 'python3-codespell'
 pkgname=python3-codespell
-version=1.17.1
+version=2.0.0
 revision=1
 wrksrc="codespell-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools"
+checkdepends="aspell-en python3-aspell python3-pytest-cov"
 short_desc="Checks code for common spelling mistakes (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/codespell-project/codespell"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=d9d90fdb223c3462cc3982f44c018bad873092ed7ac5b9efe23e1350fbe2d4c7
+checksum=f691d65ac0aa621698f68f0e98f3bcd5c4407c795ab510118130b593af2751b1
 conflicts="python-codespell>=0"
+
+pre_check() {
+	# Remove test that needs itself
+	vsed -i '/run_codespell/,/==4/d' codespell_lib/tests/test_basic.py
+}


### PR DESCRIPTION
python3-aspell source has no license file to "pet" lint