### PR TITLE
bctoolbox: update to 4.4.17

### DIFF
--- a/srcpkgs/bctoolbox/template
+++ b/srcpkgs/bctoolbox/template
@@ -1,6 +1,6 @@
 # Template file for 'bctoolbox'
 pkgname=bctoolbox
-version=4.4.9
+version=4.4.17
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTS=ON -DENABLE_TESTS_COMPONENT=OFF
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://gitlab.linphone.org/BC/public/bctoolbox"
 distfiles="https://gitlab.linphone.org/BC/public/bctoolbox/-/archive/${version}/bctoolbox-${version}.tar.gz"
-checksum=d96586b30999fd41d720150b52d334bbb5bbb419b8d5900a8a037f2617bf1d6b
+checksum=1364d5f42b5514546b9c6654c227804ff92cf9cf13fdc7cb6ca666e3bb5a7987
 
 bctoolbox-devel_package() {
 	depends="bctoolbox-${version}_${revision}"

--- a/srcpkgs/bzrtp/template
+++ b/srcpkgs/bzrtp/template
@@ -1,6 +1,6 @@
 # Template file for 'bzrtp'
 pkgname=bzrtp
-version=4.4.0
+version=4.4.17
 revision=1
 build_style=cmake
 configure_args="-DENABLE_TESTS=0 -DENABLE_STATIC=FALSE"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.linphone.org"
 distfiles="https://gitlab.linphone.org/BC/public/bzrtp/-/archive/${version}/bzrtp-${version}.tar.gz"
-checksum=5fc501c742f38661b5ac8904e6a66f530b07be93d7493663daab33f3d4ffdb6c
+checksum=8cfb6f8be7be64046982849aaa48020caf5c6f1ab9cd9422af6082dfd669267d
 
 bzrtp-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/mediastreamer/template
+++ b/srcpkgs/mediastreamer/template
@@ -1,9 +1,9 @@
 # Template file for 'mediastreamer'
 pkgname=mediastreamer
-version=4.4.0
-revision=2
-build_style=cmake
+version=4.4.17
+revision=1
 wrksrc="mediastreamer2-${version}"
+build_style=cmake
 configure_args="-DENABLE_STRICT=0 -DENABLE_UNIT_TESTS=0"
 hostmakedepends="python"
 makedepends="bzrtp-devel ffmpeg-devel glew-devel libXv-devel libsrtp-devel
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.linphone.org/technical-corner/mediastreamer2"
 distfiles="https://gitlab.linphone.org/BC/public/mediastreamer2/-/archive/${version}/mediastreamer2-${version}.tar.gz"
-checksum=f986fba8bb23db60441707c958e8d8cb41d56939b42ef4e47de1eeed62522eee
+checksum=4f67262621a93349651cfb0b51a2157623bf7758126d070e1c122bff58c7d5b4
 
 mediastreamer-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/ortp/template
+++ b/srcpkgs/ortp/template
@@ -1,6 +1,6 @@
 # Template file for 'ortp'
 pkgname=ortp
-version=4.4.0
+version=4.4.17
 revision=1
 build_style=cmake
 configure_args="-DENABLE_STATIC=OFF"
@@ -10,7 +10,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://www.linphone.org/technical-corner/ortp"
 distfiles="https://gitlab.linphone.org/BC/public/ortp/-/archive/${version}/ortp-${version}.tar.gz"
-checksum=684c6b5cfb7770b9764dbb360d355f15e583bf4e064e237095c7dbc29d4e49ee
+checksum=4368be03f7f1ec6a29ada80c1a962a4793964e1c58f4d9b9117e68332a401c93
 
 ortp-devel_package() {
 	depends="bctoolbox-devel ortp-${version}_${revision}"


### PR DESCRIPTION
@Johnnynator Most of these are your packages, but figured I'd update them along with bctoolbox since they depend on each other. If you could test linphone out. It runs with updates but I get no sound with linphone play, but I don't get audio with some other apps either.

I tried getting the newer linphone to build but was unable to and unsure why. At first it was unable to get 'git describe' version from bctoolbox cmake, which is strange as it isn't the git version. I got rid of the need to use that but there are undefind variable(s) afterward.