### PR TITLE
[NOMERGE] rmlint: backport bugfix #438.

### DIFF
--- a/srcpkgs/rmlint/patches/444.patch
+++ b/srcpkgs/rmlint/patches/444.patch
@@ -1,0 +1,23 @@
+From fc26e889e42602d96226514b65c33c06c47ecd99 Mon Sep 17 00:00:00 2001
+From: Chris Baker <ChrisBaker97@users.noreply.github.com>
+Date: Thu, 12 Nov 2020 13:54:17 -0500
+Subject: [PATCH] cfg.c: fix bug introduced in 2.10.0
+
+This reversion back to the code from version `2.9.0` addresses #438. Obviously there is some functionality here that's being implemented that I'm not familiar enough with the project to understand, but hopefully this gives someone a head start in trying to track down the bug, while still keeping the intended new behavior.
+---
+ lib/cfg.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/cfg.c b/lib/cfg.c
+index 92b02136..e46756e2 100644
+--- lib/cfg.c
++++ lib/cfg.c
+@@ -109,7 +109,7 @@ guint rm_cfg_add_path(RmCfg *cfg, bool is_prefd, const char *path) {
+     int rc = 0;
+ 
+ #if HAVE_FACCESSAT
+-    rc = faccessat(AT_FDCWD, path, R_OK, AT_EACCESS|AT_SYMLINK_NOFOLLOW);
++    rc = faccessat(AT_FDCWD, path, R_OK, AT_EACCESS);
+ #else
+     rc = access(path, R_OK);
+ #endif

--- a/srcpkgs/rmlint/template
+++ b/srcpkgs/rmlint/template
@@ -1,7 +1,7 @@
 # Template file for 'rmlint'
 pkgname=rmlint
 version=2.10.1
-revision=2
+revision=3
 build_style=scons
 hostmakedepends="pkg-config python3-Sphinx glib-devel"
 makedepends="libblkid-devel elfutils-devel json-glib-devel"


### PR DESCRIPTION
https://github.com/sahib/rmlint/issues/438
https://github.com/sahib/rmlint/pull/444