### PR TITLE
alacritty, st, dvtm: prevent ncurses-term from installing conflicting files

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,7 +1,7 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.5.0
-revision=2
+revision=3
 build_wrksrc="${pkgname}"
 build_style=cargo
 hostmakedepends="pkg-config python3"
@@ -28,7 +28,18 @@ post_install() {
 
 alacritty-terminfo_package() {
 	short_desc+=" - terminfo data"
+	depends="ncurses"
+
 	pkg_install() {
 		vmove usr/share/terminfo
+
+		# Avoid conflicts with ncurses-term
+		vmkdir usr/share/xbps.d
+		local _conflicts="${PKGDESTDIR}/usr/share/xbps.d/${pkgname}.conf"
+		cat > "$_conflicts" <<-EOF
+		noextract=/usr/share/terminfo/a/alacritty
+		noextract=/usr/share/terminfo/a/alacritty-direct
+		EOF
+		chmod 644 "$_conflicts"
 	}
 }

--- a/srcpkgs/dvtm/template
+++ b/srcpkgs/dvtm/template
@@ -1,7 +1,7 @@
 # Template file for 'dvtm'
 pkgname=dvtm
 version=0.15
-revision=2
+revision=3
 makedepends="ncurses-devel"
 depends="ncurses" # needs tic at post-install
 short_desc="Tiling window manager for the console"
@@ -16,8 +16,18 @@ do_build() {
 	sed -i 's,tic,/bin/true,g' Makefile
 	make CC=$CC V=1
 }
+
 do_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install
 	vlicense LICENSE
 	vinstall dvtm.info 644 usr/share/terminfo/d
+
+	# Avoid conflicts with ncurses-term
+	vmkdir usr/share/xbps.d
+	local _conflicts="${DESTDIR}/usr/share/xbps.d/${pkgname}.conf"
+	cat > "$_conflicts" <<-EOF
+	noextract=/usr/share/terminfo/d/dvtm
+	noextract=/usr/share/terminfo/d/dvtm-256color
+	EOF
+	chmod 644 "$_conflicts"
 }

--- a/srcpkgs/st/template
+++ b/srcpkgs/st/template
@@ -1,7 +1,7 @@
 # Template file for 'st'
 pkgname=st
 version=0.8.4
-revision=2
+revision=3
 build_style=gnu-makefile
 make_use_env=compliant
 hostmakedepends="pkg-config"
@@ -29,7 +29,20 @@ post_install() {
 
 st-terminfo_package() {
 	short_desc+=" - terminfo data"
+	depends="ncurses"
+
 	pkg_install() {
 		vmove usr/share/terminfo
+
+		# Avoid conflicts with ncurses-term
+		vmkdir usr/share/xbps.d
+		local _conflicts="${PKGDESTDIR}/usr/share/xbps.d/${pkgname}.conf"
+		cat > "$_conflicts" <<-EOF
+		noextract=/usr/share/terminfo/s/st
+		noextract=/usr/share/terminfo/s/st-256color
+		noextract=/usr/share/terminfo/s/stterm
+		noextract=/usr/share/terminfo/s/stterm-256color
+		EOF
+		chmod 644 "$_conflicts"
 	}
 }


### PR DESCRIPTION
This is an attempt to address file conflicts in Issue #26700 by adding `noextract` rules to packages that install specific terminfo definitions and then compile these at locations that conflict with files installed by `ncurses-term`. We should definitely prefer these specific versions when they are installed.

I'm not sure what `xbps<0.58` does when it encounters `noextract` definitions. This isn't the most elegant solution, but it may be the only workable solution we currently have to the conflicts here. Any other solution would seem to require knowledge in the `ncurses` template of specific templates that install conflicting files, which is uglier.