### PR TITLE
pam-base: update to 0.4, adopt.

### DIFF
--- a/srcpkgs/pam-base/INSTALL.msg
+++ b/srcpkgs/pam-base/INSTALL.msg
@@ -1,0 +1,5 @@
+WARNING: the default PAM configuration has changed. PAM 1.5.1
+will remove some deprecated modules, and this can break if you
+have custom configs. Please check that your PAM configuration
+in /etc/pam.d doesn't use the pam_tally, pam_tally2 or
+pam_lastlog (this last one only on musl systems) modules.

--- a/srcpkgs/pam-base/files/system-login
+++ b/srcpkgs/pam-base/files/system-login
@@ -1,6 +1,5 @@
 #%PAM-1.0
 
-auth       required   pam_tally.so         onerr=succeed file=/var/log/faillog
 auth       required   pam_shells.so
 auth       requisite  pam_nologin.so
 auth       include    system-auth
@@ -16,6 +15,4 @@ session    include    system-auth
 session    optional   pam_motd.so          motd=/etc/motd
 session    optional   pam_mail.so          dir=/var/mail standard quiet
 -session   optional   pam_elogind.so
--session   optional   pam_ck_connector.so  nox11
 session    required   pam_env.so
-session    required   pam_lastlog.so       silent

--- a/srcpkgs/pam-base/template
+++ b/srcpkgs/pam-base/template
@@ -1,10 +1,10 @@
 # Template file for 'pam-base'
 pkgname=pam-base
-version=0.3
-revision=6
+version=0.4
+revision=1
 short_desc="PAM base configuration files"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="custom:Public Domain"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="Public Domain"
 homepage="http://www.voidlinux.org"
 
 conf_files="


### PR DESCRIPTION
Remove pam_tally from system-login. The pam_tally module is deprecated
as of PAM 1.4.0 and was removed on PAM 1.5.0.

Make pam_lastlog optional, since it's no longer built on musl.

Fix license name.

Necessary for #25506 , still up for discussion. It might make sense to ship the INSTALL.msg from #25506 here as well, or a similar one.

@void-linux/pkg-committers 