### PR TITLE
pulseeffects: update to 4.8.4

### DIFF
--- a/srcpkgs/pulseeffects/template
+++ b/srcpkgs/pulseeffects/template
@@ -1,18 +1,19 @@
 # Template file for 'pulseeffects'
 pkgname=pulseeffects
-reverts="4.3.4_1"
-version=3.2.3
-revision=6
+version=4.8.4
+revision=1
 build_style=meson
-pycompile_module="PulseEffects PulseEffectsTest"
-hostmakedepends="pkg-config"
-makedepends="gsettings-desktop-schemas-devel gst-plugins-bad1-devel
- gtk+3-devel libbs2b-devel pulseaudio-devel python3-gobject-devel"
+hostmakedepends="itstool pkg-config gettext"
+makedepends="boost-devel glib-devel gsettings-desktop-schemas-devel
+ gst-plugins-bad1-devel gtkmm-devel libebur128-devel lilv-devel
+ pulseaudio-devel python3-gobject-devel sratom-devel
+ libsndfile-devel"
 depends="calf gsettings-desktop-schemas gst-plugins-bad1
- gst-plugins-good1 pulseaudio python3-gobject python3-numpy python3-scipy"
+ gst-plugins-good1 pulseaudio python3-gobject python3-scipy"
 short_desc="Sound effects for Pulseaudio applications"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/pulseeffects"
-distfiles="https://github.com/wwmm/pulseeffects/archive/v${version}.tar.gz"
-checksum=049a9d9c162a17790d392b7de9a0cc1397de32bd4324ae6490a45b96c92e5528
+distfiles="https://github.com/wwmm/pulseeffects/archive/${version}.tar.gz"
+checksum=12ba3205025d815a747b58636861594f7d1e43a578a5b0411f7794f4c12e5d86
+python_version=3


### PR DESCRIPTION
Looked at https://github.com/void-linux/void-packages/pull/2566 and I do not get the issue reported, the following is what I get and pulseeffects launches fine.
```
PULSEEFFECTS_DEBUG=1 pulseeffects

(pulseeffects:31375): Gtk-WARNING **: 19:05:36.812: Theme parsing error: gtk.css:2:33: Failed to import: Error opening file /home/ndowens/.config/gtk-3.0/window_decorations.css: No such file or directory

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.867: compressor plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.869: equalizer plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.878: maximizer plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.882: loudness plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.884: pitch plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.890: convolver plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.890: crystalizer plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.892: delay plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.897: compressor plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.897: equalizer plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.899: pitch plugin was not found!

(pulseeffects:31375): pulseeffects-WARNING **: 19:05:36.905: maximizer plugin was not found!

```