### PR TITLE
go-ethereum: update to 1.9.24.

### DIFF
--- a/srcpkgs/go-ethereum/template
+++ b/srcpkgs/go-ethereum/template
@@ -1,6 +1,6 @@
 # Template file for 'go-ethereum'
 pkgname=go-ethereum
-version=1.9.15
+version=1.9.24
 revision=1
 build_style=go
 go_import_path=github.com/ethereum/go-ethereum
@@ -17,7 +17,7 @@ maintainer="Hoang Nguyen <hoang@wetrust.io>"
 license="GPL-3.0-only"
 homepage="https://github.com/ethereum/go-ethereum"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=805b896f4055b8e1b7a295608e2135f93e45f75ce821eb07beaf2acd2e24acc8
+checksum=5e5d69dafc0c93af47fdc5fae782048b15a3a16ac722db39c9cda2eacdf21234
 
 geth_package() {
 	short_desc="Official Go implementation of the Ethereum protocol"

--- a/srcpkgs/go-ethereum/template
+++ b/srcpkgs/go-ethereum/template
@@ -10,7 +10,7 @@ go_package="${go_import_path}/cmd/abigen
  ${go_import_path}/cmd/geth
  ${go_import_path}/cmd/puppeth
  ${go_import_path}/cmd/rlpdump
- ${go_import_path}/cmd/wnode"
+ ${go_import_path}/cmd/clef"
 depends="geth"
 short_desc="Full suite of Go Ethereum utilities"
 maintainer="Hoang Nguyen <hoang@wetrust.io>"


### PR DESCRIPTION
Upstream has removed the wnode from the packages binaries https://github.com/ethereum/go-ethereum/commit/066c75531d5668366dc0cf9a8a2d9cb2addbc487