### PR TITLE
xbps-src: don't remove autodeps on `clean <pkg>`

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -756,7 +756,6 @@ case "$XBPS_TARGET" in
                 if declare -f do_clean >/dev/null; then
                     run_func do_clean
                 fi
-                remove_pkg_autodeps
                 remove_pkg_wrksrc
                 remove_pkg_statedir
             fi


### PR DESCRIPTION
previously, xbps-src clean foo didn't clean autodeps but only foo's builddir and destdir.
This is useful for clean rebuilds without re-installing all dependencies (if subsequent invocations add `-C`).

Fixes: 795429f1a44cb0b84e3af1197c68b880aae86098 (#23015)

___
it used to be like this:
* `xbps-src clean`: remove all dependencies (autodeps) and builddir/destdir
* `xbps-src clean <package>`: remove builddir/destdir for that package, leave dependencies installed.

xbps-src tells:
```
clean [pkgname]
    Removes auto dependencies, cleans up <masterdir>/builddir and <masterdir>/destdir.
    If <pkgname> argument is specified, package files from <masterdir>/destdir and its
    build directory in <masterdir>/buiddir are removed.
```

795429f (#23015) changed this without context and for no obvious reason.