### PR TITLE
w3m: fix all /usr/local reference, ships more docs

### DIFF
--- a/srcpkgs/w3m/template
+++ b/srcpkgs/w3m/template
@@ -1,13 +1,15 @@
 # Template file for 'w3m'
 pkgname=w3m
 version=0.5.3+git20200502
-revision=2
+revision=3
 wrksrc="${pkgname}-${version/+/-}"
 build_style=gnu-configure
 configure_args="--libexecdir=/usr/lib --enable-image=x11,fb
+ --with-nkf=/usr/bin/nkf
  --with-imagelib=imlib2 --with-termlib=ncurses --disable-w3mmailer"
-hostmakedepends="pkg-config gc-devel perl gettext"
-makedepends="zlib-devel ncurses-devel gc-devel libressl-devel imlib2-devel libX11-devel"
+hostmakedepends="pkg-config gc-devel perl gettext nkf"
+makedepends="zlib-devel ncurses-devel gc-devel libressl-devel imlib2-devel
+ libX11-devel"
 short_desc="Text-based Web browser and pager (with Debian patches)"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MIT"
@@ -17,6 +19,14 @@ distfiles="https://github.com/tats/w3m/archive/v$version.tar.gz"
 checksum=bfc3d076be414b76352fa487d67b0b2aa9e400aafe684e2eb66d668a1597141c
 
 LDFLAGS="-lX11"
+
+post_patch() {
+	rm -f Bonus/oldconfigure.sh
+	vsed -i -e 's,/usr/local/bin,/usr/bin,g' \
+		Bonus/makeref Bonus/scanhist.rb Bonus/html2latex \
+		scripts/w3mman/hlink.cgi
+	chmod +x Bonus/scanhist.rb Bonus/utf8.cgi
+}
 
 pre_build() {
 	# build host mktable
@@ -30,14 +40,24 @@ pre_build() {
 }
 
 post_install() {
-	vlicense ${wrksrc}/doc/README
+	local _file
+	vlicense doc/README
+	for _file in doc/HISTORY doc/README* doc/*.html
+	do
+		vdoc "$_file"
+	done
+	for _file in doc/keymap* doc/menu*
+	do
+		vsconf "$_file"
+	done
+	vcopy Bonus usr/share/examples/w3m/bonus
 }
 
 w3m-img_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - image display support"
 	pkg_install() {
-		vmove /usr/lib/w3m/w3mimgdisplay
-		vmove /usr/lib/w3m/xface2xpm
+		vmove usr/lib/w3m/w3mimgdisplay
+		vmove usr/share/doc/w3m/README.img
 	}
 }


### PR DESCRIPTION
A private email brought up that our w3m doesn't provides enough documentation like Debian's.
I think the argument of the person in question is worth considering.