### PR TITLE
Bibletime 3.0

### DIFF
--- a/srcpkgs/apache-fop/files/fop.conf
+++ b/srcpkgs/apache-fop/files/fop.conf
@@ -1,2 +1,2 @@
-FOP_OPTS="-Xmx512m"
+FOP_OPTS="-Xmx2g"
 FOP_HOME="/usr/share/fop"

--- a/srcpkgs/apache-fop/template
+++ b/srcpkgs/apache-fop/template
@@ -1,7 +1,7 @@
 # Template file for 'apache-fop'
 pkgname=apache-fop
 version=2.5
-revision=1
+revision=2
 wrksrc="fop-${version}"
 build_wrksrc="fop"
 hostmakedepends="openjdk8 apache-ant"

--- a/srcpkgs/bibletime/template
+++ b/srcpkgs/bibletime/template
@@ -3,30 +3,29 @@
 # NOTE: Docs have not been split out because otherwise the application fails
 # to start.
 pkgname=bibletime
-version=2.11.2
+version=3.0
 revision=1
 build_style=cmake
-hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
+configure_args="-DBT_DOCBOOK_XSL_HTML_CHUNK_XSL=/usr/share/xsl/docbook/html/chunk.xsl
+ -DBT_DOCBOOK_XSL_PDF_DOCBOOK_XSL=/usr/share/xsl/docbook/fo/docbook.xsl"
+hostmakedepends="pkg-config qt5-host-tools qt5-qmake apache-fop po4a
+ docbook-xsl docbook-xml libxslt"
 makedepends="clucene-devel libcurl-devel qt5-devel qt5-tools-devel
- qt5-svg-devel qt5-webkit-devel sword-devel zlib-devel"
+ qt5-svg-devel qt5-webkit-devel sword-devel zlib-devel qt5-declarative-devel"
 short_desc="Powerful cross platform Bible study tool"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
-homepage="http://bibletime.io"
+homepage="http://bibletime.info"
 distfiles="https://github.com/bibletime/bibletime/releases/download/v${version}/bibletime-${version}.tar.xz"
-checksum=d178197ce87c8211733409fb28fa6ed0220800bbf06944ebb8fe85bf78ddabe8
+checksum=d6beef62ad44b255e3dc4c5e89214bf01a0e85c9136073b0be12fca3d2b22622
 
-post_configure() {
-	# Workaround problem with qt5-host-tools path on some cross archs
-	if [ "$CROSS_BUILD" ]; then
-		find . -name build.make -exec \
-			sed -i "s:${XBPS_CROSS_BASE}/usr/lib/qt5/bin:/usr/lib/qt5/bin:" {} \;
-	fi
+pre_build() {
+	. /etc/profile.d/10_openjdk11.sh
 }
 
 pre_check() {
 	export QT_QPA_PLATFORM=offscreen
-	mkdir -p share/bibletime
-	cd share/bibletime
+	mkdir -p "share/bibletime"
+	cd "share/bibletime"
 	mkdir -p icons javascript license pics locale docs/handbook/en docs/howto/en display-templates
 }


### PR DESCRIPTION
The apache-fop commit has been included here because it is required to get bibletime to build one of the PDFs. I believe this is an acceptable change instead of changing fop.conf for bibletime because the PDFs are not very long or complex, so it would be common for people to need to change it anyway.

With this release, upstream has stopped distributing documentation in
release tarballs, instead we have to generate it. Hence, most of the new
dependencies are for this purpose.

The configure_args part is for detecting this in cross.

The hack for cross has been removed as this is actually a reccuring
issue with ppc cross that will be seperatly addressed, generally, for
all packages.

Tests are currently not working, @ericonr you looked at this before would you mind looking at it again and seeing if you can get it to work? I had a preliminary look, but couldn't make much sense of the weird QT path things... I don't really care about tests for this because they are "unsupported" by upstream.