### PR TITLE
foomatic-db + foomatic-db-nonfree fixes + bump

### DIFF
--- a/srcpkgs/foomatic-db-nonfree/template
+++ b/srcpkgs/foomatic-db-nonfree/template
@@ -1,22 +1,32 @@
 # Template file for 'foomatic-db-nonfree'
 # Note: update the version=<date> regularly like once/month.
 pkgname=foomatic-db-nonfree
-version=20200527
+version=20201129
 revision=1
-archs=noarch
 create_wrksrc=yes
 build_style=gnu-configure
-hostmakedepends="tar"
+hostmakedepends="tar xmlstarlet"
 short_desc="OpenPrinting printer support - nonfree database"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="nonfree"
+maintainer="fosslinux <fosslinux@aussies.space>"
+license="custom:Various Nonfree"
 homepage="https://wiki.linuxfoundation.org/openprinting/database/foomatic"
 repository="nonfree"
 
 do_fetch() {
-	$XBPS_FETCH_CMD https://www.openprinting.org/download/foomatic/$pkgname-current.tar.gz
+	$XBPS_FETCH_CMD https://www.openprinting.org/download/foomatic/${pkgname}-current.tar.gz
 }
+
 do_extract() {
-	tar xf ${XBPS_BUILDDIR}/${pkgname}-current.tar.gz \
+	bsdtar -xf ${XBPS_BUILDDIR}/${pkgname}-current.tar.gz \
 		--strip-components=1 -C ${wrksrc}
+}
+
+post_install() {
+	for i in db/source/driver/*.xml; do
+		if grep -q licensetext $i; then
+			xml sel -t -v '//driver/licensetext/en/text()' $i | sed "s/^ *//" \
+				> "LICENSE-$(basename $i .xml).txt"
+			vlicense "LICENSE-$(basename $i .xml).txt"
+		fi
+	done
 }

--- a/srcpkgs/foomatic-db/template
+++ b/srcpkgs/foomatic-db/template
@@ -1,21 +1,31 @@
 # Template file for 'foomatic-db'
 # Note: update the version=<date> regularly like once/month.
 pkgname=foomatic-db
-version=20180118
+version=20201129
 revision=1
-archs=noarch
+create_wrksrc=yes
 build_style=gnu-configure
-ceeate_wrksrc=yes
-hostmakedepends="tar"
+hostmakedepends="xmlstarlet tar"
 short_desc="OpenPrinting printer support - database"
-homepage="https://wiki.linuxfoundation.org/openprinting/database/foomatic"
-license="GPL-2, MIT"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later, MIT"
+homepage="https://wiki.linuxfoundation.org/openprinting/database/foomatic"
 
 do_fetch() {
-	$XBPS_FETCH_CMD https://www.openprinting.org/download/foomatic/$pkgname-4.0-current.tar.gz
+	$XBPS_FETCH_CMD https://www.openprinting.org/download/foomatic/${pkgname}-4.0-current.tar.gz
 }
+
 do_extract() {
-	tar xf ${XBPS_BUILDDIR}/${pkgname}-4.0-current.tar.gz \
+	bsdtar -xf ${XBPS_BUILDDIR}/${pkgname}-4.0-current.tar.gz \
 		--strip-components=1 -C ${wrksrc}
 }
+
+post_install() {
+	for i in db/source/driver/*.xml; do
+		if grep -q licensetext $i; then
+			xml sel -t -v '//driver/licensetext/en/text()' $i | sed "s/^ *//" \
+				> "LICENSE-$(basename $i .xml).txt"
+			vlicense "LICENSE-$(basename $i .xml).txt"
+		fi
+	done
+ }


### PR DESCRIPTION
- Bump both for new tarball.
- Install the various different licenses as well (notably MIT, but some have exceptions and the like, so install them all).
- Various other stylistic fixes.