### PR TITLE
libnma: replace libnm-gtk; revbump packages previously depending on libnm-gtk

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2982,7 +2982,6 @@ libczmq.so.4 czmq-4.0.1_1
 liblz.so.1 lzlib-1.8_1
 libelogind.so.0 libelogind-238.1_2
 libseat.so.1 libseat-0.3.0_1
-libnma.so.0 libnm-gtk-1.4.0_1
 libnma.so.0 libnma-1.8.30_1
 libgspell-1.so.2 gspell-1.8.0_1
 libotf.so.1 libotf-0.9.16_1

--- a/srcpkgs/NetworkManager-l2tp/template
+++ b/srcpkgs/NetworkManager-l2tp/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager-l2tp'
 pkgname=NetworkManager-l2tp
-version=1.8.2
-revision=2
+version=1.8.6
+revision=1
 build_style=gnu-configure
 configure_args="--runstatedir=/run"
 hostmakedepends="pkg-config intltool glib-devel"
@@ -13,7 +13,7 @@ maintainer="Douglas Kosovic <doug@uq.edu.au>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/nm-l2tp/NetworkManager-l2tp"
 distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=1d80986dc88951e298446833d314bab7af0a933e736960d6b3b025e6b7faca94
+checksum=e345263c440ef8f48bcd95661d7772ffdbdd65e37d0a3eca813a542a3357ac23
 
 # Automatically determine the pppd plugin dir location, but will need to
 # revbump this package whenever version of ppp package is updated.
@@ -21,8 +21,4 @@ do_configure() {
 	PPP_VERSION=$(awk '/VERSION/{print $3}' ${XBPS_CROSS_BASE}/usr/include/pppd/patchlevel.h)
 
 	./configure ${configure_args} --with-pppd-plugin-dir=/usr/lib/pppd/${PPP_VERSION}
-}
-
-post_install() {
-	mv $DESTDIR/etc/dbus-1 $DESTDIR/usr/share
 }

--- a/srcpkgs/NetworkManager-openvpn/template
+++ b/srcpkgs/NetworkManager-openvpn/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager-openvpn'
 pkgname=NetworkManager-openvpn
 version=1.8.12
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake gettext-devel glib-devel intltool libtool pkg-config"

--- a/srcpkgs/NetworkManager-pptp/template
+++ b/srcpkgs/NetworkManager-pptp/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager-pptp'
 pkgname=NetworkManager-pptp
 version=1.2.8
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--without-libnm-glib"
 hostmakedepends="pkg-config intltool glib-devel"

--- a/srcpkgs/NetworkManager-strongswan/template
+++ b/srcpkgs/NetworkManager-strongswan/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager-strongswan'
 pkgname=NetworkManager-strongswan
 version=1.5.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-more-warnings --without-libnm-glib
  --disable-more-warnings"

--- a/srcpkgs/NetworkManager-vpnc/template
+++ b/srcpkgs/NetworkManager-vpnc/template
@@ -1,7 +1,7 @@
 # Template file for 'NetworkManager-vpnc'
 pkgname=NetworkManager-vpnc
 version=1.2.6
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--localstatedir=/var --disable-static --without-libnm-glib"
 hostmakedepends="pkg-config intltool"

--- a/srcpkgs/cinnamon-control-center/template
+++ b/srcpkgs/cinnamon-control-center/template
@@ -1,7 +1,7 @@
 # Template file for 'cinnamon-control-center'
 pkgname=cinnamon-control-center
 version=4.6.2
-revision=2
+revision=3
 build_style=gnu-configure
 build_helper=gir
 configure_args="--disable-static --disable-update-mimedb --disable-systemd"
@@ -28,6 +28,7 @@ do_check() {
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
 }
+
 post_install() {
 	# Remove unused stuff
 	make -C shell DESTDIR="$DESTDIR" uninstall-binPROGRAMS uninstall-directoryDATA uninstall-uiDATA
@@ -41,6 +42,7 @@ libcinnamon-control-center_package() {
 		vmove "usr/lib/*.so.*"
 	}
 }
+
 cinnamon-control-center-devel_package() {
 	short_desc+=" - development files"
 	depends="libglib-devel gtk+3-devel lib${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/gnome-control-center/template
+++ b/srcpkgs/gnome-control-center/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-control-center'
 pkgname=gnome-control-center
-version=3.38.1
+version=3.38.2
 revision=1
 build_style=meson
 build_helper="gir"
@@ -24,7 +24,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-control-center"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=8d90006c610f6fccb3cddbcf413b1bc4137fb4977b901a3989420fe160082026
+checksum=1500e0ec0dbbb3f0b9289d084d6987b9430fe444872adbea5ca7fe0cd5f8476c
 
 build_options="cheese"
 build_options_default="cheese"

--- a/srcpkgs/gnome-initial-setup/template
+++ b/srcpkgs/gnome-initial-setup/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-initial-setup'
 pkgname=gnome-initial-setup
-version=3.38.1
+version=3.38.2
 revision=1
 build_style=meson
 configure_args="-Dsoftware-sources=disabled -Dparental_controls=disabled
@@ -18,4 +18,4 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Design/OS/InitialSetup"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=e55d4f4073998e0fb7b3dfcc470e2a4c7d950a96bedab15011b9084ebc813676
+checksum=aa5889274f8b0b6de6a0512b47742b82ac3400daec82dd4effe2eea27464a3b8

--- a/srcpkgs/libnma/template
+++ b/srcpkgs/libnma/template
@@ -1,7 +1,7 @@
 # Template file for 'libnma'
 pkgname=libnma
 version=1.8.30
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 hostmakedepends="gettext glib-devel gtk-doc pkg-config vala"
@@ -14,6 +14,7 @@ license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/libnma"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=da33e72a49e07d855d97a52aa9a8962a4c96f52b9168c4e0027117ad8ffdafb4
+replaces="libnm-gtk>=0"
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+="-Dgtk_doc=false"

--- a/srcpkgs/network-manager-applet/template
+++ b/srcpkgs/network-manager-applet/template
@@ -1,7 +1,7 @@
 # Template file for 'network-manager-applet'
 pkgname=network-manager-applet
 version=1.18.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dselinux=false"
 hostmakedepends="dbus-glib-devel glib-devel intltool pkg-config"

--- a/srcpkgs/switchboard-plug-network/template
+++ b/srcpkgs/switchboard-plug-network/template
@@ -1,6 +1,6 @@
 # Template file for 'switchboard-plug-network'
 pkgname=switchboard-plug-network
-version=2.3.2
+version=2.3.3
 revision=1
 build_style=meson
 hostmakedepends="pkg-config vala"
@@ -11,5 +11,5 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/elementary/switchboard-plug-network"
 distfiles="https://github.com/elementary/${pkgname}/archive/${version}.tar.gz"
-checksum=61c3803dccf68324afe7cb67094fd9dbcb874cae47284b9b131b9bd49971d9b8
+checksum=a2f29b3054c187f2be9688bb04b6800cf4c2d3dd74cdd4fa37626f0b2ac5df50
 nocross="https://travis-ci.org/github/void-linux/void-packages/builds/733837363"


### PR DESCRIPTION
This PR adds a "replaces" line to the `libnma` template and gets rid of the last line referencing `libnm-gtk` in `common/shlibs`. Additionally, it adds a runtime dependency on `libnma` to `network-manager-applet`.