### PR TITLE
openjdk: split to an metapackage

### DIFF
--- a/srcpkgs/openjdk
+++ b/srcpkgs/openjdk
@@ -1,1 +1,0 @@
-openjdk8

--- a/srcpkgs/openjdk-doc
+++ b/srcpkgs/openjdk-doc
@@ -1,1 +1,1 @@
-openjdk8
+openjdk

--- a/srcpkgs/openjdk-jre
+++ b/srcpkgs/openjdk-jre
@@ -1,1 +1,1 @@
-openjdk8
+openjdk

--- a/srcpkgs/openjdk-src
+++ b/srcpkgs/openjdk-src
@@ -1,1 +1,1 @@
-openjdk8
+openjdk

--- a/srcpkgs/openjdk/template
+++ b/srcpkgs/openjdk/template
@@ -1,0 +1,25 @@
+# Template file for 'openjdk'
+pkgname=openjdk
+version=8u999
+revision=1
+build_style=meta
+depends="openjdk${version%u*}"
+short_desc="OpenJDK Java Development Kit (meta)"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="metapackage"
+homepage="https://voidlinux.org"
+
+openjdk-jre_package() {
+	short_desc+=" - runtime components"
+	depends="openjdk${version%u*}-jre"
+}
+
+openjdk-src_package() {
+	short_desc+=" - source code"
+	depends="openjdk${version%u*}-src"
+}
+
+openjdk-doc_package() {
+	short_desc+=" - documentation"
+	depends="openjdk${version%u*}-doc"
+}

--- a/srcpkgs/openjdk8/template
+++ b/srcpkgs/openjdk8/template
@@ -284,31 +284,3 @@ openjdk8-doc_package() {
 		vmove ${_final_jdk_home}/man/man1
 	}
 }
-
-openjdk_package() {
-	archs=noarch
-	build_style=meta
-	depends="openjdk8>=${version}_${revision}"
-	short_desc+=" (transitional dummy package)"
-}
-
-openjdk-jre_package() {
-	archs=noarch
-	build_style=meta
-	depends="openjdk8-jre>=${version}_${revision}"
-	short_desc+=" - runtime components (transitional dummy package)"
-}
-
-openjdk-src_package() {
-	archs=noarch
-	build_style=meta
-	depends="openjdk8-src>=${version}_${revision}"
-	short_desc+=" - source code (transitional dummy package)"
-}
-
-openjdk-doc_package() {
-	archs=noarch
-	build_style=meta
-	depends="openjdk8-doc>=${version}_${revision}"
-	short_desc+=" - documentation (transitional dummy package)"
-}


### PR DESCRIPTION
- remove its noarch attribute without rebuilding openjdk8