### PR TITLE
python3-jsonschema: update to 3.2.0

### DIFF
--- a/srcpkgs/python3-jsonschema/template
+++ b/srcpkgs/python3-jsonschema/template
@@ -1,27 +1,25 @@
 # Template file for 'python3-jsonschema'
 pkgname=python3-jsonschema
 reverts="3.0.2_1"
-version=2.6.0
-revision=6
+version=3.2.0
+revision=1
 wrksrc="jsonschema-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools"
+depends="python3-setuptools python3-six python3-attrs python3-pyrsistent"
 short_desc="Implementation of JSON Schema for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/Julian/jsonschema"
+changelog="https://raw.githubusercontent.com/Julian/jsonschema/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/j/jsonschema/jsonschema-${version}.tar.gz"
-checksum=6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02
+checksum=c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
 conflicts="python-jsonschema>=0"
 
-pre_build() {
-	vsed -i setup.py \
-		-e '/setup_requires/d' \
-		-e '/vcversioner/d' \
-		-e "/name=/a\
-		version=\"${version}\","
+do_check() {
+	: # Disable tests due to it downloading several deps
 }
+
 post_install() {
 	vlicense COPYING LICENSE
 }

--- a/srcpkgs/python3-pyrsistent/template
+++ b/srcpkgs/python3-pyrsistent/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-pyrsistent'
+pkgname=python3-pyrsistent
+version=0.17.3
+revision=1
+wrksrc="pyrsistent-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel"
+depends="python3"
+short_desc="Python persistent immutable data structures"
+maintainer="Nathan Owens <ndowens@artixlinux.org>"
+license="MIT"
+homepage="https://github.com/tobgu/pyrsistent/"
+distfiles="${PYPI_SITE}/p/pyrsistent/pyrsistent-${version}.tar.gz"
+checksum=2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e
+
+do_check() {
+	: # Disable as it downloads many packages
+}
+
+post_install() {
+	vlicense LICENCE.mit LICENSE
+}


### PR DESCRIPTION
Add missing deps to packages that depends on python3-jsonschema; the simple method would have been to add python3-attrs and python3-pyrsistent to python3-jsonschema depends but decided not to do it this way. 

Tested anki, docker-compose, synapse and gns3-gui after changes and they launch fine. 
While testing, attaching fix for gns3-sever as upon launch gns3server gives certain version of aiohttp is needed @the-maldridge 