### PR TITLE
pipewire: update to 0.3.17

### DIFF
--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.3.12
+version=0.3.17
 revision=1
 build_style=meson
 configure_args="-Dman=true -Dgstreamer=true -Ddocs=true -Dsystemd=false
@@ -15,7 +15,7 @@ license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=98c71228aad2f8443e73a524106f32ca9a74e13c2bf55b65b1e06b72325892cd
+checksum=46d2f597506ef56b0be54498ab26b58bacdd7cae30f87f47836f1f717a0d05ac
 conf_files="/etc/pipewire/pipewire.conf"
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
@@ -138,6 +138,7 @@ alsa-pipewire_package() {
 	short_desc+=" - ALSA client library"
 	pkg_install() {
 		vmove usr/lib/alsa-lib
+		vmove usr/share/alsa/alsa.conf.d
 	}
 }
 


### PR DESCRIPTION
Basic instructions to have pipewire replace pulseaudio that worked on my system with this version:
https://gist.github.com/st3r4g/6c681a28b0403b3b02636f510ff68039