### PR TITLE
New package: python3-progressbar-3.53.1.

### DIFF
--- a/srcpkgs/python3-progressbar/template
+++ b/srcpkgs/python3-progressbar/template
@@ -1,0 +1,24 @@
+# Template file for 'python3-progressbar'
+pkgname=python3-progressbar
+version=3.53.1
+revision=1
+wrksrc="progressbar2-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3 python3-utils python3-six python3-sphinxcontrib"
+checkdepends="python3-flake8 python3-pytest python3-pytest-cov
+ python3-freezegun ${depends}"
+short_desc="Progress bar for Python"
+maintainer="fosslinux <fosslinux@aussies.space>"
+license="BSD-3-Clause"
+homepage="https://github.com/WoLpH/python-progressbar"
+distfiles="${homepage}/releases/download/v${version}/progressbar2-${version}.tar.gz"
+checksum=73224a2ba2f9a9e764bf9a4e63184cd294503c0d16e51ae90453f934b85bf937
+
+do_check() {
+	python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Required for use of diffoscope's progress function.