### PR TITLE
babl: update to 0.1.82

### DIFF
--- a/srcpkgs/babl/template
+++ b/srcpkgs/babl/template
@@ -1,11 +1,11 @@
 # Template file for 'babl'
 pkgname=babl
-version=0.1.78
+version=0.1.82
 revision=1
 build_style=meson
 build_helper=gir
-configure_args="-Dwith-docs=false"
-hostmakedepends="pkg-config vala-devel gobject-introspection"
+configure_args="-Dwith-docs=false -Denable-gir=true"
+hostmakedepends="pkg-config vala-devel"
 makedepends="lcms2-devel"
 short_desc="Dynamic pixel format translation library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -13,7 +13,7 @@ license="LGPL-3.0-only"
 homepage="http://gegl.org/babl/"
 changelog="https://raw.githubusercontent.com/GNOME/babl/master/NEWS"
 distfiles="https://download.gimp.org/pub/babl/${version%.*}/babl-${version}.tar.xz"
-checksum=17d5493633bff5585d9f375bc4df5925157cd1c70ccd7c22a635be75c172523a
+checksum=c62d93d4ad6774cb8e3231bbbc7f2e61e551e7242d78640d757505ee1a9fadc5
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*) ;;


### PR DESCRIPTION
@Gottox I tested this update against build of gegl-devel and it built fine even during cross-build.