### PR TITLE
gloobus-preview: correct dependencies

### DIFF
--- a/srcpkgs/gloobus-preview/template
+++ b/srcpkgs/gloobus-preview/template
@@ -1,17 +1,18 @@
 # Template file for 'gloobus-preview'
 pkgname=gloobus-preview
 version=2015.12.21
-revision=5
+revision=6
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config python3 gettext-devel xz"
-makedepends="gettext-devel boost-devel gtk+-devel gtk+3-devel gtksourceview-devel
- cairo-devel gstreamer1-devel gst-plugins-base1-devel gst-plugins-bad1-devel poppler-glib-devel
- libspectre-devel djvulibre-devel libgxps-devel freetype-devel glib-devel libX11-devel
- libarchive-devel"
-depends="python3 python-dbus gst-libav gst-plugins-good1 gst-plugins-bad1 gst-plugins-ugly1 ImageMagick p7zip tar unoconv unrar unzip"
-short_desc="A file previewer"
+makedepends="gettext-devel boost-devel gtk+3-devel gtksourceview-devel
+ cairo-devel gstreamer1-devel gst-plugins-base1-devel gst-plugins-bad1-devel
+ poppler-glib-devel libspectre-devel djvulibre-devel libgxps-devel
+ freetype-devel glib-devel libX11-devel libarchive-devel"
+depends="python3-dbus python3-gobject gst-libav gst-plugins-good1
+ gst-plugins-bad1 gst-plugins-ugly1 ImageMagick unoconv"
+short_desc="GNOME's extension to preview all kinds of file"
 maintainer="Antonio Malcolm <antonio@antoniomalcolm.com>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="https://github.com/antonio-malcolm/gloobus-preview"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=c43f1ed00ccc3603042abb78b871665ff6c6a89987d7f854b9b4254b7cf9d86c


### PR DESCRIPTION
- libarchive can support 7z, tar, rar, zip
- s/python-dbus/python3-dbus/
- unrar is nonfree