### PR TITLE
lurch: revert patch from #26757

### DIFF
--- a/srcpkgs/lurch/template
+++ b/srcpkgs/lurch/template
@@ -1,7 +1,7 @@
 # Template file for 'lurch'
 pkgname=lurch
 version=0.6.8
-revision=3
+revision=4
 build_style=gnu-makefile
 make_use_env=yes
 hostmakedepends="cmake pkg-config"
@@ -14,7 +14,3 @@ distfiles="https://github.com/gkdr/lurch/releases/download/v${version}/lurch-${v
 checksum=2e2447b5fe6b1ae4f08d8c79a2a846c70290685d6e338bf5ea8f59705bd2b19f
 
 LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib/purple-2"
-
-post_patch() {
-	vsed -e '/#define OMEMO_AES_GCM_IV_LENGTH/s/16/12/' -i lib/libomemo/src/libomemo.h
-}


### PR DESCRIPTION
The patch was erroneously applied after a github user claimed it to be
a security issue, and later it was determined that this user was going
around tricking various projects into applying their patch that had
been exlicitly declined by upstream (xsf/xeps#894).

There's probably a dialog to happen here around relative security of
accepting unverified patches in the name of 'security' but this is
neither the time nor the place.