### PR TITLE
containerd: update to 1.3.9

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,6 +1,6 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=1.3.7
+version=1.3.9
 revision=1
 build_style=go
 go_import_path=github.com/containerd/containerd
@@ -18,7 +18,7 @@ maintainer="Paul Knopf <pauldotknopf@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=d30d59e143697aa4f0960205b3f5ac59c573b332f20507740ef2dc0fb5ae8ded
+checksum=9244212589c84b12262769dca6fb985c0c680cb5259c8904b29c511d81fd62d0
 make_dirs="/var/lib/containerd 0755 root root"
 
 post_build() {


### PR DESCRIPTION
@pauldotknopf  

Tested using docker with a Ubuntu docker image fine.