### PR TITLE
expect: Fix the buffer overlow while logging

### DIFF
--- a/srcpkgs/expect/patches/0005-fix-buf-overflow-when-logging.patch
+++ b/srcpkgs/expect/patches/0005-fix-buf-overflow-when-logging.patch
@@ -1,0 +1,39 @@
+diff -up exp_log.c.orig exp_log.c
+--- exp_log.c.orig	2013-12-12 12:43:38.527854189 +0100
++++ exp_log.c	2013-12-12 12:49:26.866576387 +0100
+@@ -176,7 +176,7 @@ expStdoutLog TCL_VARARGS_DEF(int,arg1)
+ 
+     if ((!tsdPtr->logUser) && (!force_stdout) && (!tsdPtr->logAll)) return;
+ 
+-    (void) vsprintf(bigbuf,fmt,args);
++    (void) vsnprintf(bigbuf,sizeof(bigbuf),fmt,args);
+     expDiagWriteBytes(bigbuf,-1);
+     if (tsdPtr->logAll || (LOGUSER && tsdPtr->logChannel)) Tcl_WriteChars(tsdPtr->logChannel,bigbuf,-1);
+     if (LOGUSER) fprintf(stdout,"%s",bigbuf);
+@@ -222,7 +222,7 @@ expErrorLog TCL_VARARGS_DEF(char *,arg1)
+     va_list args;
+ 
+     fmt = TCL_VARARGS_START(char *,arg1,args);
+-    (void) vsprintf(bigbuf,fmt,args);
++    (void) vsnprintf(bigbuf,sizeof(bigbuf),fmt,args);
+ 
+     expDiagWriteChars(bigbuf,-1);
+     fprintf(stderr,"%s",bigbuf);
+@@ -264,7 +264,7 @@ expDiagLog TCL_VARARGS_DEF(char *,arg1)
+ 
+     fmt = TCL_VARARGS_START(char *,arg1,args);
+ 
+-    (void) vsprintf(bigbuf,fmt,args);
++    (void) vsnprintf(bigbuf,sizeof(bigbuf),fmt,args);
+ 
+     expDiagWriteBytes(bigbuf,-1);
+     if (tsdPtr->diagToStderr) {
+@@ -307,7 +307,7 @@ expPrintf TCL_VARARGS_DEF(char *,arg1)
+   int len, rc;
+ 
+   fmt = TCL_VARARGS_START(char *,arg1,args);
+-  len = vsprintf(bigbuf,arg1,args);
++  len = vsnprintf(bigbuf,sizeof(bigbuf),arg1,args);
+  retry:
+   rc = write(2,bigbuf,len);
+   if ((rc == -1) && (errno == EAGAIN)) goto retry;

--- a/srcpkgs/expect/template
+++ b/srcpkgs/expect/template
@@ -1,7 +1,7 @@
 # Template file for 'expect'
 pkgname=expect
 version=5.45.4
-revision=2
+revision=3
 wrksrc=${pkgname}${version}
 build_style=gnu-configure
 configure_args="expect_cv_wnohang_value=1"


### PR DESCRIPTION
There is a buffer overflow issue with "expect" when you run it
with "--debug" flag and the expected string is too big [1].

This patch was already proposed 7 years ago [2] but never found
its away upstream. Other distros also fix it locally [3]. It's
time we have it fixed in Void Linux as well.

[1] Bug 26986 - *** buffer overflow detected ***: expect terminated
https://sourceware.org/bugzilla/show_bug.cgi?id=26986

[2] Expect / Bugs / #95 buffer overflow in exp_log.c
https://sourceforge.net/p/expect/bugs/95/

[3] fedora fixing the overflow in expect
https://src.fedoraproject.org/rpms/expect/blob/master/f/expect-5.45-exp-log-buf-overflow.patch