### PR TITLE
xst: update to 0.8.4.

### DIFF
--- a/srcpkgs/xst/template
+++ b/srcpkgs/xst/template
@@ -1,27 +1,27 @@
 # Template file for 'xst'
 pkgname=xst
-version=0.7.2
-revision=3
+version=0.8.4
+revision=1
 build_style=gnu-makefile
 make_use_env=compliant
 hostmakedepends="pkg-config"
 makedepends="libXft-devel libXext-devel fontconfig-devel"
-depends="ncurses"
+depends="ncurses desktop-file-utils"
 short_desc="St fork with support for xresources"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Nathan <ndowens@artixlinux.org>"
 license="MIT"
 homepage="https://github.com/neeasade/xst"
 distfiles="https://github.com/neeasade/xst/archive/v${version}.tar.gz"
-checksum=5cea5a8bae643ff7df7f8322958065edece354c272c0f987b1dcadcdec689f9a
+checksum=0fb8dd47b018fe6b46a654b4d6bf69ab0785ae6fbb6a0965e38ad86382fec369
 
 do_install() {
 	vbin xst
-	vman doc/xst.1
+	vman st.1 xst.1
 
-	vinstall doc/xst.info 644 usr/share/terminfo/x xst.terminfo
-	vdoc README.md README
-	vdoc doc/FAQ
-	vsed -i 's/st-256color/xst-256color/' doc/Xresources
-	vdoc doc/Xresources
-	vlicense doc/LICENSE
+	vinstall st.info 644 usr/share/terminfo/x xst.terminfo
+	vdoc README
+	vdoc FAQ
+	vsed -i 's/st-256color/xst-256color/' .Xresources
+	vdoc .Xresources Xresources
+	vlicense LICENSE
 }


### PR DESCRIPTION
Adopt.
Renamed manpages and others from st to xst to avoid conflicts with st.