### PR TITLE
xf86-input-synaptics: fix build w/ musl-1.2.1

### DIFF
--- a/srcpkgs/xf86-input-synaptics/patches/fix-input_event-time.patch
+++ b/srcpkgs/xf86-input-synaptics/patches/fix-input_event-time.patch
@@ -1,0 +1,27 @@
+--- src/eventcomm.c	2018-05-29 05:18:45.000000000 +0200
++++ src/eventcomm.c	2020-12-01 21:27:55.746811502 +0100
+@@ -575,9 +575,12 @@
+         ev->type = EV_SYN;
+         ev->code = SYN_REPORT;
+         ev->value = 0;
+-        ev->time = last_event_time;
+-    } else if (ev->type == EV_SYN)
+-        last_event_time = ev->time;
++        ev->input_event_sec = last_event_time.tv_sec;
++        ev->input_event_usec = last_event_time.tv_usec;
++    } else if (ev->type == EV_SYN) {
++        last_event_time.tv_sec = ev->input_event_sec;
++        last_event_time.tv_usec = ev->input_event_usec;
++    }
+ 
+     return TRUE;
+ }
+@@ -725,7 +728,7 @@
+             case SYN_REPORT:
+                 hw->numFingers = count_fingers(pInfo, comm);
+                 if (proto_data->have_monotonic_clock)
+-                    hw->millis = 1000 * ev.time.tv_sec + ev.time.tv_usec / 1000;
++                    hw->millis = 1000 * ev.input_event_sec + ev.input_event_usec / 1000;
+                 else
+                     hw->millis = GetTimeInMillis();
+                 SynapticsCopyHwState(hwRet, hw);

--- a/srcpkgs/xf86-input-synaptics/template
+++ b/srcpkgs/xf86-input-synaptics/template
@@ -2,7 +2,6 @@
 pkgname=xf86-input-synaptics
 version=1.9.1
 revision=1
-lib32disabled=yes
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libX11-devel libXtst-devel libevdev-devel
@@ -14,6 +13,7 @@ license="MIT"
 homepage="http://www.x.org/"
 distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.bz2"
 checksum=7af83526eff1c76e8b9e1553b34245c203d029028d8044dd9dcf71eef1001576
+lib32disabled=yes
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Graceful transition to 64 bit time.