### PR TITLE
dkms: update to 2.8.4.

### DIFF
--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,7 +1,7 @@
 # Template file for 'dkms'
 pkgname=dkms
-version=2.8.3
-revision=3
+version=2.8.4
+revision=1
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils"
 short_desc="Dynamic Kernel Modules System"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/dell/dkms"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=0fcbb2691aa8231927b000edf3594d2798211c3944fd4a2a8b1864aa1c06eaaf
+checksum=540912bf0d845ac333f6971a3ccb80911c770a042af1b30ffbb9b420ac979af3
 
 case "$XBPS_TARGET_MACHINE" in
 	# Too many competing kernels for arm* to depend on linux-headers
@@ -26,7 +26,7 @@ do_install() {
 	vbin dkms
 	vman dkms.8
 	vinstall dkms_dbversion 644 var/lib/dkms
-	vinstall dkms.bash-completion 644 usr/share/bash-completion/completions dkms
+	vcompletion dkms.bash-completion bash dkms
 	vinstall dkms_framework.conf 644 etc/dkms framework.conf
 	# Kernel hooks.
 	vinstall ${FILESDIR}/kernel.d/dkms.postinst 754 etc/kernel.d/post-install 10-dkms


### PR DESCRIPTION
Tested locally with building zfs module. It built fine and removed fine.