### PR TITLE
treeline: update to 3.1.4

### DIFF
--- a/srcpkgs/treeline/template
+++ b/srcpkgs/treeline/template
@@ -1,7 +1,7 @@
 # Template file for 'treeline'
 pkgname=treeline
-version=3.1.3
-revision=2
+version=3.1.4
+revision=1
 wrksrc="TreeLine-${version}"
 pycompile_dirs="usr/share/treeline"
 hostmakedepends="python3"
@@ -11,7 +11,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-2.0-or-later"
 homepage="http://treeline.bellz.org/"
 distfiles="https://github.com/doug-101/TreeLine/archive/v${version}.tar.gz"
-checksum=420bd15fa9ef73ac66456d3a686b33c47f35b51d5ac51086568c8cc8e9dc50f2
+checksum=bc6918f7bc892ab00cfc9293236c2d03021d64a5b6190594501048f2590572ab
 python_version=3
 
 do_install() {


### PR DESCRIPTION
Fixes an incompatibility with Python 3.9, current version 3.8 crashes on startup.