### PR TITLE
rng-tools: fix configure to work with new jitterentropy library.

### DIFF
--- a/srcpkgs/rng-tools/patches/0004-configure-ac-jitterentropy-needs-pthread.patch
+++ b/srcpkgs/rng-tools/patches/0004-configure-ac-jitterentropy-needs-pthread.patch
@@ -1,0 +1,15 @@
+New jitterentropy library broke configure. This patch fixes it.
+
+Upstream patch: https://github.com/nhorman/rng-tools/commit/daff4e2dd9d3abb74829f41e72607681163bd309
+
+--- a/configure.ac	2020-12-03 20:59:11.086238518 +0100
++++ b/configure.ac	2020-12-03 21:00:40.978593727 +0100
+@@ -91,7 +91,7 @@
+ 		AC_SEARCH_LIBS(jent_version,jitterentropy,
+ 				[AM_CONDITIONAL([JITTER], [true])
+ 				AC_DEFINE([HAVE_JITTER],1,[Enable JITTER])],
+-				AC_MSG_NOTICE([No Jitterentropy library found]))
++				AC_MSG_NOTICE([No Jitterentropy library found]),-lpthread)
+ 	], [AC_MSG_NOTICE([Disabling JITTER entropy source])]
+ )
+ 

--- a/srcpkgs/rng-tools/template
+++ b/srcpkgs/rng-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'rng-tools'
 pkgname=rng-tools
 version=6.10
-revision=3
+revision=4
 wrksrc=${pkgname}-${version}
 build_style=gnu-configure
 configure_args="--sbindir=/usr/bin --without-pkcs11 --without-rtlsdr"


### PR DESCRIPTION
The recent update to the jitterentropy library broke rng-tools
configure. This patch fixes it. The source is the upstream commit:
https://github.com/nhorman/rng-tools/commit/daff4e2dd9d3abb74829f41e72607681163bd309.