### PR TITLE
rpi-firmware: update to 20201123.

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
 version=20200918
-revision=1
+revision=2
 depends="${pkgname}-amd-${version}_${revision} ${pkgname}-network-${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -11,6 +11,9 @@ distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmwa
 checksum=3cbb7f363dc63686b1c6e325ed679f6faa4715f17fa06be11b705456e1d5dcb9
 python_version=3
 nostrip=yes
+
+subpackages="rpi-firmware-network linux-firmware-amd linux-firmware-intel
+ linux-firmware-nvidia linux-firmware-network"
 
 do_install() {
 	vmkdir usr/lib/firmware
@@ -53,6 +56,7 @@ linux-firmware-nvidia_package() {
 
 linux-firmware-network_package() {
 	short_desc+=" - network"
+	depends="rpi-firmware-network"
 	nostrip=yes
 	pkg_install() {
 		vmove usr/lib/firmware/3com
@@ -73,5 +77,13 @@ linux-firmware-network_package() {
 		vmove usr/lib/firmware/ueagle-atm
 		vmove usr/lib/firmware/ti-connectivity
 		vmove usr/lib/firmware/dpaa2
+	}
+}
+
+rpi-firmware-network_package() {
+	short_desc+=" - Raspberry Pi"
+	nostrip=yes
+	pkg_install() {
+		vmove "usr/lib/firmware/brcm/brcmfmac434??-sdio.*"
 	}
 }

--- a/srcpkgs/rpi-firmware-network
+++ b/srcpkgs/rpi-firmware-network
@@ -1,0 +1,1 @@
+linux-firmware

--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,18 +1,19 @@
 # Template file for 'rpi-firmware'
-_githash="f293685f683c48b1872beeb38c2f7da1f46141a0"
+_githash="8f13114b9ea29bd004151d4a8afa500b2df721be"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20200819
-revision=2
+version=20201123
+revision=1
 archs="armv6l* armv7l* aarch64*"
 wrksrc="firmware-${_githash}"
+depends="rpi-firmware-network"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
-maintainer="Peter Bui <pbui@github.bx612.space>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=dd825e8ccbd524182f7e06c5301f2ed2f8a68200e80cf61b1095271dcfbe0e55
+checksum=f9be0cc177aae7dddaa0a2967d090ea33a95be9dd519d2eee3bc740af8ffb19e
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 nostrip=yes
@@ -36,21 +37,9 @@ do_install() {
 	$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/LICENCE.cypress
 	vlicense LICENCE.cypress
 
-	# Firmware for rpi3 b and zero wifi chip
-	for f in bin txt; do
-		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43430-sdio.${f}
-		vinstall brcmfmac43430-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
-
 	# Firmware for rpi3 b and zero bluetooth chip
 	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM43430A1.hcd
 	vinstall BCM43430A1.hcd 0644 usr/lib/firmware/brcm
-
-	# Firmware for rpi3 b+ wifi chip
-	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43455-sdio.${f}
-		vinstall brcmfmac43455-sdio.${f} 0644 usr/lib/firmware/brcm
-	done
 
 	# Firmware for rpi3 b+ bluetooth chip
 	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM4345C0.hcd


### PR DESCRIPTION
- Orphan package (suggest @Piraty takes it).

- linux-firmware-network now provides the necessary wifi blobs, so
  rpi-firmware no longer includes them and now depends on
  linux-firmware-network.

  Otherwise the two packages conflict with each other and prevents upgrading.

- I've tested on armv6l and armv7l with a RPI2 and RPI3 both builtin and external wireless devices.

@Piraty @sgn Per our discussion on IRC, I dropped the wifi blobs from this package and for now making it depend on linux-firmware-network.