### PR TITLE
qutebrowser: update to 1.14.1.

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -1,19 +1,19 @@
 # Template file for 'qutebrowser'
 pkgname=qutebrowser
-version=1.14.0
+version=1.14.1
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools asciidoc"
 depends="python3-PyQt5-quick python3-Jinja2 python3-Pygments python3-pyPEG2
  python3-yaml python3-attrs python3-PyQt5-opengl python3-PyQt5-sql
- qt5-plugin-sqlite"
+ qt5-plugin-sqlite python3-setuptools"
 short_desc="Keyboard-focused browser with a minimal GUI"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"
 homepage="https://qutebrowser.org/"
 changelog="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/changelog.asciidoc"
 distfiles="https://github.com/qutebrowser/qutebrowser/releases/download/v${version}/qutebrowser-${version}.tar.gz"
-checksum=76eb14097bab873ffae73bb4d017b4d22aa5c4604d45f0b9570dfaed4720374a
+checksum=554c145ff64b1a92d4f53e3c624aaad51baafb7cb5b469bc815ae2e0e1958796
 nostrip=yes
 
 build_options="webengine"


### PR DESCRIPTION
I also noticed qutebrowser does not run without python3-setuptools installed.