### PR TITLE
99-pkglint-subpkgs: simplify and correct

### DIFF
--- a/common/hooks/pre-pkg/99-pkglint-subpkgs.sh
+++ b/common/hooks/pre-pkg/99-pkglint-subpkgs.sh
@@ -18,21 +18,27 @@ hook() {
 
     subpkgs=$(get_subpkgs)
 
-    subpackages="${subpackages// /$'\n'}"
-
     # Sort the strings so they can be compare for equality
-    subpkgs="$(printf "%s\\n" "$subpkgs" | sort)"
-    subpackages="$(printf "%s\\n" "$subpackages" | sort)"
+    subpkgs="$(printf '%s\n' $subpkgs | sort)"
+    subpackages="$(printf '%s\n' $subpackages | sort)"
 
     if [ "$subpackages" = "$subpkgs" ]; then
         return 0
     fi
 
-    # XXX: Make the sed call work when subpackages has multiple lines
-    # this can be done with grep with perl regexp (-P) but chroot-grep
-    # is compiled without it
-    matches="$(sed -n 's/subpackages.*"\(.*\)"[^"]*$/\1/p' $XBPS_SRCPKGDIR/$pkgname/template \
-        | tr " " "\n" | sort)"
+    # sed supports comment but let's put them here
+    # 1: print everything between pairs of <""> in subpackages[+]?="..."
+    # 2: multiline subpackages="...\n..."
+    # 2.1: For any line in the middle, i.e. no <"> exists, print it
+    # 2.2: For the first line, print everything after <">
+    # 2.3: For last line, print everything before <">
+    matches="$(sed -n -e 's/subpackages.*"\(.*\)"[^"]*$/\1/p' \
+            -e '/subpackages[^"]*"[^"]*$/,/"/{
+                /"/!p
+                /subpackages/s/.*"//p
+                s/".*//p
+            }' $XBPS_SRCPKGDIR/$pkgname/template |
+        tr ' ' '\n' | sort)"
 
     for s in $subpkgs; do
         grep -q "^$s$" <<< "$matches" ||


### PR DESCRIPTION
As discussing in [1], on template with "subpackages" as multilines will
report false positive on some packages will never be built.

There're multiple problems here:

- expanded "subpackages" will have an empty line if it has a newline
  inside template
- "sed" expression couldn't work with multilines "subpackages"

Let's not quote "$subpkgs" and "$subpackages" in "printf" to let the
shell do expansion and trim the empty lines for us. And rewrite the
"sed" expression to work with multilines "subpackages"

[1]: https://github.com/void-linux/void-packages/pull/26939#issuecomment-739098547