### PR TITLE
Joplin

### DIFF
--- a/srcpkgs/joplin-cli/files/joplin-cli
+++ b/srcpkgs/joplin-cli/files/joplin-cli
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd /usr/libexec/joplin-cli/app-cli
+node app/main.js "$@"

--- a/srcpkgs/joplin-cli/template
+++ b/srcpkgs/joplin-cli/template
@@ -1,0 +1,69 @@
+# Template file for 'joplin-cli'
+pkgname=joplin-cli
+version=2.1.7
+revision=1
+wrksrc="joplin-${version}"
+hostmakedepends="nodejs git python3 pkg-config libvips-devel rsync"
+makedepends="libvips-devel libsecret-devel"
+depends="nodejs"
+short_desc="Open source note taking and to-do application - CLI version"
+maintainer="fosslinux <fosslinux@aussies.space>"
+license="MIT"
+homepage="https://joplinapp.org"
+distfiles="https://github.com/laurent22/joplin/archive/v${version}.tar.gz"
+checksum=b8d4fedb636d41d93718e51fcd99a5d889471db3f86002d9f3c1d90fc386f68c
+python_version=3
+make_check=extended # Some tests are broken (why?)
+
+if [ "$CROSS_BUILD" ]; then
+	export PKG_CONFIG_SYSROOT_DIR="$XBPS_CROSS_BASE"
+	export PKG_CONFIG_LIBDIR="$XBPS_CROSS_BASE/usr/lib/pkgconfig"
+	export PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR:$XBPS_CROSS_BASE/usr/share/pkgconfig"
+fi
+
+do_build() {
+	# Remove unused modules
+	rm -rf packages/{app-mobile,app-desktop,app-clipper,generator-joplin}
+
+	# Needed for cross to build
+	platform="linux"
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		platform="linuxmusl"
+	fi
+	local arch
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*) arch=x64 ;;
+		i686*) arch=ia32 ;;
+		*) # Dummy of arm; allows to be compiled from source
+			if [ "$XBPS_TARGET_WORDSIZE" = "64" ]; then
+				arch=arm64
+			else
+				arch=arm
+			fi ;;
+	esac
+	npm install ${XBPS_ALLOW_CHROOT_BREAKOUT:+--unsafe-perm} --build-from-source \
+		--platform="${platform}" --arch="${arch}"
+
+	cd packages
+	# https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=joplin-cli#n30
+	# Unsure why this is needed, but it is
+	for d in app-cli lib renderer tools; do
+		pushd "${d}"
+		mv node_modules/@joplin .
+		npm prune --production
+		mv @joplin node_modules/
+		popd
+	done
+}
+
+do_install() {
+	cd packages
+
+	vmkdir usr/libexec/joplin-cli
+	for d in app-cli fork-sax fork-htmlparser2 renderer lib tools; do
+		vcopy "${d}" usr/libexec/joplin-cli/
+	done
+
+	vbin "${FILESDIR}/joplin-cli"
+	vlicense ../LICENSE
+}

--- a/srcpkgs/joplin-desktop/files/joplin-desktop
+++ b/srcpkgs/joplin-desktop/files/joplin-desktop
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec electron10 /usr/libexec/joplin-desktop/resources/app.asar "$@"

--- a/srcpkgs/joplin-desktop/files/joplin.desktop
+++ b/srcpkgs/joplin-desktop/files/joplin.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Joplin
+Comment=Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
+Exec=/usr/bin/joplin-desktop
+Icon=/usr/libexec/joplin/resources/build/icons/128x128.png
+Terminal=false
+Type=Application
+Categories=Application;Office;

--- a/srcpkgs/joplin-desktop/patches/electron-ver.patch
+++ b/srcpkgs/joplin-desktop/patches/electron-ver.patch
@@ -1,0 +1,11 @@
+--- a/packages/app-desktop/package.json	2021-01-03 20:03:05.818525142 +1100
++++ b/packages/app-desktop/package.json	2021-01-03 20:04:24.352069708 +1100
+@@ -36,6 +36,8 @@
+     "afterAllArtifactBuild": "./generateSha512.js",
+     "asar": true,
+     "asarUnpack": "./node_modules/node-notifier/vendor/**",
++    "electronDist": "/usr/lib/electron10",
++    "electronVersion": "@ELECTRON_VER@",
+     "win": {
+       "rfc3161TimeStampServer": "http://timestamp.comodoca.com/rfc3161",
+       "icon": "../../Assets/ImageSources/Joplin.ico",

--- a/srcpkgs/joplin-desktop/template
+++ b/srcpkgs/joplin-desktop/template
@@ -1,0 +1,55 @@
+# Template file for 'joplin-desktop'
+pkgname=joplin-desktop
+version=2.1.7
+revision=1
+wrksrc="joplin-${version}"
+hostmakedepends="nodejs python3 pkg-config rsync git p7zip tar app-builder
+ squashfs-tools"
+makedepends="libvips-devel libsecret-devel electron10"
+depends="electron10"
+short_desc="Open source note taking and to-do application - Desktop version"
+maintainer="fosslinux <fosslinux@aussies.space>"
+license="MIT"
+homepage="https://joplinapp.org"
+distfiles="https://github.com/laurent22/joplin/archive/v${version}.tar.gz"
+checksum=b8d4fedb636d41d93718e51fcd99a5d889471db3f86002d9f3c1d90fc386f68c
+no_generic_pkgconfig_link=yes
+nopie_files="/usr/libexec/joplin-desktop/@joplinapp-desktop
+ /usr/libexec/joplin-desktop/chrome-sandbox"
+
+export USE_SYSTEM_7ZA="true"
+export USE_SYSTEM_APP_BUILDER="true"
+export USE_SYSTEM_MKSQUASHFS="true"
+
+if [ "$CROSS_BUILD" ]; then
+	export PKG_CONFIG_SYSROOT_DIR="$XBPS_CROSS_BASE"
+	export PKG_CONFIG_LIBDIR="$XBPS_CROSS_BASE/usr/lib/pkgconfig"
+	export PKG_CONFIG_PATH="$PKG_CONFIG_LIBDIR:$XBPS_CROSS_BASE/usr/share/pkgconfig"
+fi
+
+do_configure() {
+	# Remove unused modules
+	rm -rf packages/{app-mobile,app-cli,generator-joplin,app-clipper}
+	# Set electron version
+	sed -i "s/@ELECTRON_VER@/$(cat /usr/lib/electron10/version)/" packages/app-desktop/package.json
+}
+
+do_build() {
+	npm install ${XBPS_ALLOW_CHROOT_BREAKOUT:+--unsafe-perm} \
+		--build-from-source
+	cd packages/app-desktop
+	npm run dist
+}
+
+do_check() {
+	npm run test
+}
+
+do_install() {
+	vmkdir usr/libexec/joplin-desktop
+	rm -rf packages/app-desktop/dist/linux-*unpacked/resources/app.asar.unpacked/node_modules/7zip-bin-linux
+	vcopy packages/app-desktop/dist/linux-*unpacked/* usr/libexec/joplin-desktop/
+	vinstall "${FILESDIR}/joplin.desktop" 644 usr/share/applications/ joplin.desktop
+	vbin "${FILESDIR}/joplin-desktop"
+	vlicense LICENSE
+}


### PR DESCRIPTION
This PR adds the `joplin-desktop` and `joplin-cli` packages, containing the GUI and CLI versions of Joplin respectively. They are not distributed in the one package as they can and should be installed separately, they are separate applications.

Closes #19585