### PR TITLE
Go 1.4 bootstrap

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -4,7 +4,6 @@ version=1.15.5
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
-hostmakedepends="go1.12-bootstrap"
 short_desc="Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
@@ -24,6 +23,19 @@ case "${XBPS_TARGET_MACHINE}" in
 	*) broken="Unsupported architecture ${XBPS_TARGET_MACHINE}" ;;
 esac
 
+_src_bootstrap=0
+case "${XBPS_MACHINE}" in
+	aarch64*) _src_bootstrap=1 ;;
+	arm*) _src_bootstrap=1 ;;
+	i686*) _src_bootstrap=1 ;;
+	x86_64*) _src_bootstrap=1 ;;
+esac
+if [ "${_src_bootstrap}" = "1" ]; then
+	hostmakedepends="go1.4-bootstrap"
+else
+	hostmakedepends="go1.12-bootstrap"
+fi
+
 if [ "$CROSS_BUILD" ]; then
 	if [ "${XBPS_MACHINE%%-musl}" = "${XBPS_TARGET_MACHINE%%-musl}" ]; then
 		broken="Cross-compiling to different libc is not supported"
@@ -36,7 +48,11 @@ do_build() {
 	# dependency
 	unset CGO_CXXFLAGS CGO_CFLAGS CGO_ENABLED
 
-	export GOROOT_BOOTSTRAP="/usr/lib/go1.12"
+	if [ "${_src_bootstrap}" = "1" ]; then
+		export GOROOT_BOOTSTRAP="/usr/lib/go1.4"
+	else
+		export GOROOT_BOOTSTRAP="/usr/lib/go1.12"
+	fi
 	export GOROOT=$PWD
 	export GOROOT_FINAL="/usr/lib/go"
 	export GOARCH=${_goarch}

--- a/srcpkgs/go1.4-bootstrap/INSTALL.msg
+++ b/srcpkgs/go1.4-bootstrap/INSTALL.msg
@@ -1,0 +1,4 @@
+This is a copy of the official Go language toolchain binaries as provided by
+the project on its download page. Please do keep in mind that it is almost
+definitely not what you want to use and exists purely for the purpose of
+bootstrapping the official compiler package (called simply 'go').

--- a/srcpkgs/go1.4-bootstrap/template
+++ b/srcpkgs/go1.4-bootstrap/template
@@ -1,0 +1,39 @@
+# Template file for 'go1.4-bootstrap'
+pkgname=go1.4-bootstrap
+version=20171003
+revision=1
+archs="x86_64* i686* aarch64* armv[67]l*"
+wrksrc="go"
+short_desc="Go Programming Language 1.4 bootstrap package"
+maintainer="fosslinux <fosslinux@aussies.space>"
+license="BSD-3-Clause"
+homepage="https://golang.org/doc/install/source"
+distfiles="https://dl.google.com/go/go1.4-bootstrap-${version}.tar.gz"
+checksum=f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52
+nostrip=yes
+noverifyrdeps=yes
+
+case "${XBPS_TARGET_MACHINE}" in
+	aarch64*) GOARCH=arm64 ;;
+	arm*) GOARCH=arm ;;
+	i686*) GOARCH=386 ;;
+	x86_64*) GOARCH=amd64 ;;
+	*) broken="Unsupported architecture ${XBPS_TARGET_MACHINE}" ;;
+esac
+export GOARCH
+
+do_build() {
+	unset GCC CC CXX LD LDFLAGS
+	unset CGO_CXXFLAGS CGO_CFLAGS CGO_ENABLED
+
+	cd src
+	CGO_ENABLED=0 GOROOT="${PWD}" GOROOT_FINAL="/usr/lib/go1.4" ./make.bash
+}
+
+do_install() {
+	vmkdir usr/lib/go1.4
+	vcopy bin usr/lib/go1.4
+	vcopy src usr/lib/go1.4
+	vcopy pkg usr/lib/go1.4
+	vlicense LICENSE
+}


### PR DESCRIPTION
This PR reintroduces the C Go bootstrap for supported architectures, which was removed over a year ago.

**Why use the C Go bootstrap:**

- Allows Go to be bootstrapped without a pre-existing version of Go.
- Doesn't require gcompat on musl, which is often buggy.
- Allows for flexibility in the way the binaries are used in the bootstrap.
- https://bootstrappable.org

Furthermore, this doesn't drop any architecture support, as architectures that were not supported by Go 1.4 (namely, ppc) can still be bootstrapped via binaries.

@q66 Can you check this still works on ppc?
@the-maldridge maintainer

I have tested this for the official builder matrix.