### PR TITLE
pandoc: (WIP) Update to 2.11.2

### DIFF
--- a/srcpkgs/pandoc/template
+++ b/srcpkgs/pandoc/template
@@ -1,10 +1,10 @@
 # Template file for 'pandoc'
 pkgname=pandoc
 # Keep in sync with http://www.stackage.org/lts
-version=2.10.1
-revision=3
+version=2.11.2
+revision=1
 _citeproc_version=0.17.0.1
-_sidenote_version=0.20.0
+_sidenote_version=0.22.0
 _monad_gen_version=0.3.0.1
 create_wrksrc=yes
 build_style=haskell-stack
@@ -21,10 +21,11 @@ distfiles="http://hackage.haskell.org/package/${pkgname}-${version}/${pkgname}-$
  http://hackage.haskell.org/package/${pkgname}-citeproc-${_citeproc_version}/${pkgname}-citeproc-${_citeproc_version}.tar.gz
  https://github.com/jez/${pkgname}-sidenote/archive/${_sidenote_version}.tar.gz \
  https://hackage.haskell.org/package/monad-gen-${_monad_gen_version}/monad-gen-${_monad_gen_version}.tar.gz"
-checksum="938a4c9b0a7ed3de886c73af4052913b0ac9e4aa12b435bd2afd09670bd3229a
+checksum="cb0af254176870ca72f89170ae42fa9cf97b8c5ef4ea9bffca7f3d2e5bdde282
  f3e5ce3d1d21c27178f2fc69580750e3ce97fc5f962f2d01f7b6aa2e090c2342
- 34ee7f46d6472c04884b1dcb030d701a32b885d9b0d4307d2c0da327a359cb7a
- be8485023fce236b5b915f2f6074f7b0470a2040f84cdd137c5227f1b4c98465"
+ 7f3e2fd513670b2f613dd802e9486cc6c40383fb3699648a3e5f4cace8351660
+ be8485023fce236b5b915f2f6074f7b0470a2040f84cdd137c5227f1b4c98465
+"
 nocross=yes
 nopie_files="
  /usr/bin/pandoc


### PR DESCRIPTION
This update is currently failing with this error:

```
=> Using stack config in stack.yaml.
/builddir/pandoc-2.11.2/pandoc-2.10.1/: getDirectoryContents:openDirStream: does not exist (No such file or directory)
=> ERROR: pandoc-2.11.2_1: do_build: 'STACK_ROOT="$wrksrc/.stack" stack ${_stack_args} ${makejobs} build ${make_build_args}' exited with 1
=> ERROR:   in do_build() at common/build-style/haskell-stack.sh:27
```

Also, pandoc-citeproc is now deprecated in favor of [citeproc](http://hackage.haskell.org/package/citeproc). How do we go about incorporating this into the package repository?