### PR TITLE
python3-tweepy: update to 3.9.0.

### DIFF
--- a/srcpkgs/python3-tweepy/template
+++ b/srcpkgs/python3-tweepy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-tweepy'
 pkgname=python3-tweepy
-version=3.8.0
-revision=4
+version=3.9.0
+revision=1
 wrksrc="tweepy-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -10,14 +10,15 @@ short_desc="Twitter library for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/tweepy/tweepy"
-distfiles="${PYPI_SITE}/t/tweepy/tweepy-${version}.tar.gz
- https://raw.githubusercontent.com/tweepy/tweepy/v$version/LICENSE"
-checksum="8abd828ba51a85a2b5bb7373715d6d3bb32d18ac624e3a4db02e4ef8ab48316b
- bf9bc5b9dcb8421bb3c342bb7fd29194688e1262b50766bd71b21a07461e74b7"
-skip_extraction="LICENSE"
+distfiles="https://github.com/tweepy/tweepy/archive/v${version}.tar.gz"
+checksum=2b7ec06cc5d143396423a5eae16b198e69b93df2bc6044f1365270c805e940b7
+
+do_check() {
+	: # requires packages not provided by Void
+}
 
 post_install() {
-	vlicense $XBPS_SRCDISTDIR/$pkgname-$version/LICENSE
+	vlicense LICENSE
 	# remove examples from site-packages root
 	rm -rf ${DESTDIR}/usr/lib/python*/site-packages/examples
 }


### PR DESCRIPTION
Switched to GH for test and it includes license file by default.