### PR TITLE
Update GitHub Actions source to fix push notifications

### DIFF
--- a/.github/workflows/notify-issue.yaml
+++ b/.github/workflows/notify-issue.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           url: "${{ github.event.issue.html_url }}"
       - name: "Issue Notification"
-        uses: Gottox/irc-message-action@master
+        uses: Gottox/irc-message-action@main
         continue-on-error: true
         if: github.repository == 'void-linux/void-packages'
         with:

--- a/.github/workflows/notify-pr.yaml
+++ b/.github/workflows/notify-pr.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           url: "${{ github.event.pull_request.html_url }}"
       - name: "Pull Request Notification"
-        uses: Gottox/irc-message-action@master
+        uses: Gottox/irc-message-action@main
         continue-on-error: true
         if: github.repository == 'void-linux/void-packages'
         with:

--- a/.github/workflows/notify-push.yaml
+++ b/.github/workflows/notify-push.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           url: "${{ github.event.compare }}"
       - name: "Push Notification"
-        uses: Gottox/irc-message-action@master
+        uses: Gottox/irc-message-action@main
         continue-on-error: true
         if: github.repository == 'void-linux/void-packages'
         with:


### PR DESCRIPTION
While submitting a PR I noticed that the GitHub Workflows were failing.  The default branch has been renamed from `master` to `main` on the https://github.com/Gottox/irc-message-action repo.

This is the error from the workflow: 
```
Error: Unable to resolve action `Gottox/irc-message-action@master`, unable to find version `master`
```