### PR TITLE
linux: add dependencies to aarch64

### DIFF
--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,23 +1,23 @@
 # Template file for 'linux'
 pkgname=linux
 version=5.9
-revision=1
+revision=2
 build_style=meta
-homepage="http://www.voidlinux.org/"
-short_desc="The Linux kernel meta package"
+short_desc="Linux kernel meta package"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"
+homepage="http://www.voidlinux.org/"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)
 		depends="linux${version} linux-firmware-amd linux-firmware-intel linux-firmware-nvidia linux-firmware-network dracut"
 		_depends_headers="linux${version}-headers"
 		;;
-	ppc*)
+	ppc*|armv7l*|aarch64*)
 		depends="linux${version} linux-firmware-amd linux-firmware-nvidia linux-firmware-network dracut"
 		_depends_headers="linux${version}-headers"
 		;;
-	arm*|aarch64*)
+	arm*)
 		depends="linux${version}"
 		_depends_headers="linux${version}-headers"
 		;;


### PR DESCRIPTION
While setting up my Void installation I was confused at why an `initrd*.img` was not being generated, turns out `dracut` was not installed. This PR adds `dracut` as well as other firmware dependencies for an ARM/AArch64 install.