### PR TITLE
chroot.sh: export XBPS_ALT_REPOSITORY to chroot

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -180,6 +180,7 @@ chroot_handler() {
             SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
             XBPS_GIT_REVS="$XBPS_GIT_REVS" \
             XBPS_ALLOW_CHROOT_BREAKOUT="$XBPS_ALLOW_CHROOT_BREAKOUT" \
+            ${XBPS_ALT_REPOSITORY:+XBPS_ALT_REPOSITORY=$XBPS_ALT_REPOSITORY} \
             $XBPS_COMMONDIR/chroot-style/${XBPS_CHROOT_CMD:=uunshare}.sh \
             $XBPS_MASTERDIR $XBPS_DISTDIR "$XBPS_HOSTDIR" "$XBPS_CHROOT_CMD_ARGS" \
             /void-packages/xbps-src $XBPS_OPTIONS $action $pkg


### PR DESCRIPTION
Outside of chroot, we calcucate XBPS_ALT_REPOSITORY only to throw it
away and calculate it again inside chroot. Normally, this is not problem
except when we're working with a Git's worktree, in which case, we don't
have the access to original gitdir inside chroot.

Let's bring that value from outside of chroot into it.