### PR TITLE
nethack: fix SYSCF_FILE location

### DIFF
--- a/srcpkgs/nethack/INSTALL
+++ b/srcpkgs/nethack/INSTALL
@@ -2,6 +2,7 @@ case "${ACTION}" in
 post)
 	chown nethack:nethack usr/lib/nethack/nethack
 	chmod 02755 usr/lib/nethack/nethack
+	chmod 0644 etc/nethack/sysconf
 	touch var/games/nethack/logfile var/games/nethack/perm var/games/nethack/record var/games/nethack/xlogfile
 	chown nethack:nethack var/games/nethack var/games/nethack/*
 	chmod 0775 var/games/nethack

--- a/srcpkgs/nethack/patches/1-linux-hints.patch
+++ b/srcpkgs/nethack/patches/1-linux-hints.patch
@@ -1,0 +1,16 @@
+We move /usr/lib/nethack/sysconf to /etc/nethack/sysconf since
+this file is intended to be editable by root.
+
+diff --git sys/unix/hints/linux sys/unix/hints/linux
+index 8629150..9a4d722 100644
+--- sys/unix/hints/linux
++++ sys/unix/hints/linux
+@@ -23,7 +23,7 @@ POSTINSTALL=cp -n sys/unix/sysconf $(INSTDIR)/sysconf; $(CHOWN) $(GAMEUID) $(INS
+ CFLAGS=-g -O -I../include -DNOTPARMDECL
+ CFLAGS+=-DDLB
+ CFLAGS+=-DCOMPRESS=\"/bin/gzip\" -DCOMPRESS_EXTENSION=\".gz\"
+-CFLAGS+=-DSYSCF -DSYSCF_FILE=\"$(HACKDIR)/sysconf\" -DSECURE
++CFLAGS+=-DSYSCF -DSYSCF_FILE=\"/etc/nethack/sysconf\" -DSECURE
+ CFLAGS+=-DTIMED_DELAY
+ CFLAGS+=-DHACKDIR=\"$(HACKDIR)\"
+ CFLAGS+=-DDUMPLOG

--- a/srcpkgs/nethack/template
+++ b/srcpkgs/nethack/template
@@ -1,9 +1,12 @@
 # Template file for 'nethack'
 pkgname=nethack
 version=3.6.6
-revision=1
+revision=2
+wrksrc="NetHack-NetHack-${version}_Released"
+conf_files="/etc/nethack/sysconf"
 make_dirs="/var/games/nethack/save 0775 nethack nethack"
-hostmakedepends="ncurses-devel flex"
+hostmakedepends="flex"
+makedepends="ncurses-devel ncurses-libtinfo-devel"
 depends="gzip"
 short_desc="Exploring The Mazes of Menace"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -13,12 +16,6 @@ distfiles="https://www.nethack.org/download/${version}/nethack-${version//./}-sr
 checksum=cfde0c3ab6dd7c22ae82e1e5a59ab80152304eb23fb06e3129439271e5643ed2
 nocross=yes
 system_accounts="$pkgname"
-wrksrc="NetHack-NetHack-${version}_Released"
-
-post_extract() {
-	sed -i	-e '/COMPRESS/s/compress/gzip/g' \
-		-e '/COMPRESS_EXTENSION/s/\.Z/.gz/g' include/config.h
-}
 
 do_configure() {
 	sh sys/unix/setup.sh sys/unix/hints/linux
@@ -26,16 +23,15 @@ do_configure() {
 
 do_build() {
 	make all dungeon \
-		CC="$CC" LINK="$CC" LFLAGS="$LDFLAGS" \
-		LEX=flex WINTTYLIB=-lncurses \
-		CFLAGS="$CFLAGS -DLINUX -DTIMED_DELAY -DDLB \
-			-DSYSCF -DSYSCF_FILE='\"/usr/lib/nethack\"' \
-			-DHACKDIR='\"/var/games/nethack\"' -I../include"
+		CC="$CC" LINK="$CC" LFLAGS="$LDFLAGS" LEX=flex \
+		HACKDIR="/var/games/nethack"
 }
 
 do_install() {
 	vmkdir usr/share/man/man6
 	vmkdir var/games
+	vmkdir etc/nethack
+
 	make install manpages \
 		PREFIX=$DESTDIR \
 		SHELLDIR=$DESTDIR/usr/bin \
@@ -51,6 +47,7 @@ do_install() {
 
 	mv $DESTDIR/usr/lib/nethack/nhdat $DESTDIR/var/games/nethack
 	mv $DESTDIR/usr/lib/nethack/symbols $DESTDIR/var/games/nethack
+	mv $DESTDIR/usr/lib/nethack/sysconf $DESTDIR/etc/nethack
 	rm $DESTDIR/var/games/nethack/{logfile,perm,record,xlogfile}
 
 	sed -i	-e 's,^HACKDIR=.*,HACKDIR=/var/games/nethack,' \


### PR DESCRIPTION
I wasn't able to enter the wizard mode, not even as root, e.g. `sudo nethack -D -u wizard` just printed 
```
Entering explore/discovery mode instead
```
Then I found out that `SYSCF_FILE` in the template was pointing to the directory `/usr/lib/nethack` instead of the file itself `/usr/lib/nethack/sysconf`, and used `gdb` to verify that this had lead to `src/files.c:parse_conf_file` silently failing (parsing nothing) and `sysopt.wizards` ending up empty. Updating the `SYSCF_FILE` value fixed the issue, and now the sysconf file is read and I'm able to access the wizard mode.