### PR TITLE
curl: update to 7.74.0.

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,6 +1,6 @@
 # Template file for 'curl'
 pkgname=curl
-version=7.73.0
+version=7.74.0
 revision=1
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
@@ -21,7 +21,7 @@ license="MIT"
 homepage="https://curl.haxx.se"
 changelog="https://curl.haxx.se/changes.html#${version//./_}"
 distfiles="${homepage}/download/${pkgname}-${version}.tar.bz2"
-checksum=cf34fe0b07b800f1c01a499a6e8b2af548f6d0e044dca4a29d88a4bee146d131
+checksum=0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5
 patch_args="-Np1"
 build_options="gnutls gssapi ldap rtmp ssh ssl zstd"
 build_options_default="ssh ssl zstd"


### PR DESCRIPTION
Fixes include:

- CVE-2020-8286: Inferior OCSP verification
- CVE-2020-8285: FTP wildcard stack overflow
- CVE-2020-8284: trusting FTP PASV responses