### PR TITLE
snapper: add dbus dependency

### DIFF
--- a/srcpkgs/snapper/template
+++ b/srcpkgs/snapper/template
@@ -1,12 +1,12 @@
 # Template file for 'snapper'
 pkgname=snapper
 version=0.8.14
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-zypp --with-conf=/etc/conf.d"
 conf_files="/etc/conf.d/snapper"
 make_dirs="/etc/snapper/configs 0755 root root"
-hostmakedepends="automake dbus docbook-xsl libtool libxml2-devel libxslt
+hostmakedepends="automake docbook-xsl libtool libxml2-devel libxslt
  gettext pkg-config"
 makedepends="acl-devel boost-devel dbus-devel e2fsprogs-devel libbtrfs-devel
  libmount-devel libxml2-devel pam-devel"
@@ -55,7 +55,7 @@ libsnapper_package() {
 
 snapper-devel_package() {
 	short_desc+=" - development files"
-	depends="libsnapper>=${version}_${revision}"
+	depends="dbus libsnapper>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"

--- a/srcpkgs/snapper/template
+++ b/srcpkgs/snapper/template
@@ -6,7 +6,7 @@ build_style=gnu-configure
 configure_args="--disable-zypp --with-conf=/etc/conf.d"
 conf_files="/etc/conf.d/snapper"
 make_dirs="/etc/snapper/configs 0755 root root"
-hostmakedepends="automake docbook-xsl libtool libxml2-devel libxslt
+hostmakedepends="automake dbus docbook-xsl libtool libxml2-devel libxslt
  gettext pkg-config"
 makedepends="acl-devel boost-devel dbus-devel e2fsprogs-devel libbtrfs-devel
  libmount-devel libxml2-devel pam-devel"


### PR DESCRIPTION
Snapper requires dbus to work, as reported in #27047