### PR TITLE
python3-saml2: update to 6.4.1.

### DIFF
--- a/srcpkgs/python3-saml2/template
+++ b/srcpkgs/python3-saml2/template
@@ -1,15 +1,22 @@
 # Template file for 'python3-saml2'
 pkgname=python3-saml2
-version=5.0.0
-revision=2
+version=6.4.1
+revision=1
 wrksrc="pysaml2-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-cryptography python3-openssl python3-dateutil python3-pytz
  python3-requests python3-six python3-defusedxml"
+checkdepends="tox xmlsec1 xmlsec1-devel"
 short_desc="Python3 implementation of SAML Version 2 Standard"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/IdentityPython/pysaml2"
-distfiles="${PYPI_SITE}/p/pysaml2/pysaml2-${version}.tar.gz"
-checksum=deea75b252b5ead821f12ce01e9d88b0f6fbcde322c1595dcbb06f9660af0cc1
+distfiles="https://github.com/IdentityPython/pysaml2/archive/v${version}.tar.gz"
+checksum=341fe81e1fdff72e6082ba81645a9b75dab7482cf9b878f566d023311169f8c0
+
+do_check() {
+	# Remove un-used python versions
+	vsed -e '/py36/,/py38/d' -e '/pypy3/d' -i tox.ini
+	tox -c tox.ini
+}


### PR DESCRIPTION
This fixes byte-compiling upon install