### PR TITLE
tint2conf: remove conflicts

### DIFF
--- a/srcpkgs/tint2/template
+++ b/srcpkgs/tint2/template
@@ -1,7 +1,7 @@
 # Template file for 'tint2'
 pkgname=tint2
 version=16.7
-revision=2
+revision=3
 wrksrc="tint2-v${version}"
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=None"
@@ -20,7 +20,6 @@ checksum=ae2512355614014465f6aff36c98e2ed448998c44533157e4bace21c6c979f65
 tint2conf_package() {
 	short_desc+=" - configuration tools"
 	depends="tint2>=${version}_${revision}"
-	conflicts="tint2<=16.7_1"
 	pkg_install() {
 		vmove usr/bin/tint2conf
 		vmove usr/share/applications/tint2conf.desktop


### PR DESCRIPTION
tint2conf depends on tint2 >= its version, which means it will be never
installable with old version. Hence, conflicts is impossible.