### PR TITLE
supertux2: fix locale on musl, remove -data subpackage.

### DIFF
--- a/srcpkgs/supertux2-data
+++ b/srcpkgs/supertux2-data
@@ -1,1 +1,0 @@
-supertux2

--- a/srcpkgs/supertux2/patches/locale.patch
+++ b/srcpkgs/supertux2/patches/locale.patch
@@ -1,0 +1,36 @@
+commit 4380f504fbd51aa9ef7eb222b0bced481402fa7d
+Author: Érico Rolim <erico.erc@gmail.com>
+Date:   Wed Dec 9 16:22:22 2020 -0300
+
+    supertux/main: add try-catch for locale initialization.
+    
+    Fixes #1564.
+
+diff --git src/supertux/main.cpp src/supertux/main.cpp
+index ad5e3fde6..c33627e18 100644
+--- src/supertux/main.cpp
++++ src/supertux/main.cpp
+@@ -563,10 +563,19 @@ Main::run(int argc, char** argv)
+ 	_wfreopen(w_errpath.c_str(), L"a", stderr);
+ #endif
+ 
+-  // Create and install global locale
+-  std::locale::global(boost::locale::generator().generate(""));
+-  // Make boost.filesystem use it
+-  boost::filesystem::path::imbue(std::locale());
++  // Create and install global locale - this can fail on some setups:
++  // - with bad LANG values
++  // - targets where libstdc++ uses its generic locales code (https://gcc.gnu.org/legacy-ml/libstdc++/2003-02/msg00345.html)
++  try
++  {
++    std::locale::global(boost::locale::generator().generate(""));
++    // Make boost.filesystem use it
++    boost::filesystem::path::imbue(std::locale());
++  }
++  catch(const std::runtime_error& err)
++  {
++    std::cout << "Warning: " << err.what() << std::endl;
++  }
+ 
+   int result = 0;
+ 

--- a/srcpkgs/supertux2/template
+++ b/srcpkgs/supertux2/template
@@ -1,7 +1,7 @@
 # Template file for 'supertux2'
 pkgname=supertux2
 version=0.6.2
-revision=2
+revision=3
 wrksrc="SuperTux-v${version}-Source"
 build_style=cmake
 configure_args="
@@ -12,17 +12,10 @@ configure_args="
 hostmakedepends="pkg-config"
 makedepends="SDL2_image-devel boost-devel glew-devel libcurl-devel
  libopenal-devel libraqm-devel physfs-devel"
-depends="supertux2-data"
 short_desc="Side-scrolling platform game, milestone 2"
 maintainer="beefcurtains <beefcurtains@voidlinux.org>"
 license="GPL-3.0-or-later, GPL-2.0-or-later, CC-BY-SA-3.0, CC-BY-SA-4.0, CC-BY-3.0"
 homepage="https://supertux.github.io/"
 distfiles="https://github.com/SuperTux/supertux/releases/download/v${version}/SuperTux-v${version}-Source.tar.gz"
 checksum=26a9e56ea2d284148849f3239177d777dda5b675a10ab2d76ee65854c91ff598
-
-supertux2-data_package() {
-	short_desc+=" - data files"
-	pkg_install() {
-		vmove usr/share/supertux2
-	}
-}
+replaces="supertux2-data>=0"


### PR DESCRIPTION
Unless LANG was 'C', supertux2 would immediately abort when launched.

The data subpackage is no longer necessary.

Fixes #17687