### PR TITLE
gummiboot: WaitForKeyEx hanging patch

### DIFF
--- a/srcpkgs/gummiboot/patches/fix-waitforkey.patch
+++ b/srcpkgs/gummiboot/patches/fix-waitforkey.patch
@@ -1,0 +1,22 @@
+This patch fixes an issue where pressing any key within the gummiboot
+menu causes it to hang (though no issue occurs if no key is pressed).  The
+culprit appears to be the WaitForKeyEx function, which lacks support in certain
+UEFI implementations.  This fix is backported from the same issue found in
+systemd-boot (gummiboot's mainstream counterpart): see
+<https://github.com/systemd/systemd/issues/3632> and
+<https://github.com/systemd/systemd/pull/3735>.
+
+--- src/efi/console.c	2015-03-11 16:50:35.000000000 -0700
++++ src/efi/console.c	2020-12-09 15:41:19.837704801 -0800
+@@ -96,10 +96,7 @@
+ 
+         /* wait until key is pressed */
+         if (wait) {
+-                if (TextInputEx)
+-                        uefi_call_wrapper(BS->WaitForEvent, 3, 1, &TextInputEx->WaitForKeyEx, &index);
+-                else
+-                        uefi_call_wrapper(BS->WaitForEvent, 3, 1, &ST->ConIn->WaitForKey, &index);
++                uefi_call_wrapper(BS->WaitForEvent, 3, 1, &ST->ConIn->WaitForKey, &index);
+         }
+ 
+         if (TextInputEx) {

--- a/srcpkgs/gummiboot/template
+++ b/srcpkgs/gummiboot/template
@@ -1,7 +1,7 @@
 # Template file for 'gummiboot'
 pkgname=gummiboot
 version=48.1
-revision=6
+revision=7
 archs="i686* x86_64* aarch64*"
 build_style=gnu-configure
 conf_files="/etc/default/gummiboot"


### PR DESCRIPTION
I recently ran into a Gummiboot bug where pressing any key on boot causes the
boot menu to respond to that key (e.g. moves the highlighted entry if I press
down-arrow) but subsequently freeze (booting proceeds without issue if no key
is pressed andthe auto-timeout passes).  

I found a virtually identical issue on gummiboot's "parent/fork" project
systemd-boot (systemd/systemd#3632), with an alleged fix that has been merged
(systemd/systemd#3735), so I made this PR to backport that patch to gummiboot.
