### PR TITLE
mesa: doesn't use talloc anymore.

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -12,7 +12,7 @@ hostmakedepends="gettext flex llvm pkg-config python3-Mako glslang gzip
  $(vopt_if wayland 'wayland-protocols wayland-devel')"
 makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel
  libXxf86vm-devel libatomic-devel libdrm-devel libffi-devel libva-devel
- libvdpau-devel libxshmfence-devel ncurses-devel talloc-devel zlib-devel
+ libvdpau-devel libxshmfence-devel ncurses-devel zlib-devel
  $(vopt_if wayland 'wayland-devel wayland-protocols') llvm libsensors-devel
  libXrandr-devel libglvnd-devel libzstd-devel libxml2-devel lua53-devel
  libarchive-devel"


### PR DESCRIPTION
Remove talloc-devel from makedepends.