### PR TITLE
mumble: fix plugin path

### DIFF
--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,12 +1,12 @@
 # Template file for 'mumble'
 pkgname=mumble
 version=1.3.3
-revision=2
+revision=3
 build_style=qmake
 configure_args="CONFIG+=bundled-celt CONFIG+=no-bundled-opus CONFIG+=no-update
  CONFIG+=no-bundled-speex CONFIG+=no-g15 CONFIG+=no-xevie CONFIG+=pulseaudio
  $(vopt_if jack CONFIG+=jackaudio) CONFIG+=no-embed-qt-translations
- CONFIG+=no-oss CONFIG+=portaudio"
+ CONFIG+=no-oss CONFIG+=portaudio DEFINES+=PLUGIN_PATH=/usr/lib/mumble"
 hostmakedepends="Ice pkg-config protobuf qt5-host-tools qt5-qmake python3 which"
 makedepends="Ice-devel MesaLib-devel avahi-compat-libs-devel boost-devel
  libcap-devel libressl-devel libsndfile-devel opus-devel protobuf-devel


### PR DESCRIPTION
https://github.com/mumble-voip/mumble/blob/1.3.3/src/mumble/Plugins.cpp#L212-L220

Mumble was searching plugins in `/usr/bin/plugins/` because `MumbleApplication::applicationVersionRootPath()`(basically the `QCoreApplication::applicationDirPath()`) returns the path of the application executable.