### PR TITLE
synapse: update to 1.24.0.

### DIFF
--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -1,6 +1,6 @@
 # Template file for 'synapse'
 pkgname=synapse
-version=1.23.0
+version=1.24.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -19,7 +19,7 @@ license="Apache-2.0"
 homepage="https://github.com/matrix-org/synapse"
 changelog="https://raw.githubusercontent.com/matrix-org/synapse/develop/CHANGES.md"
 distfiles="https://github.com/matrix-org/synapse/archive/v${version}.tar.gz"
-checksum=afa86ea1332a52d09552ea5825567f910b304d4684692fa8325cefec105b2b4c
+checksum=d55a9b41432e3ca348b13d8e4b3ece6515b3e76a0f4062e8036ee1204842f53a
 
 system_accounts="synapse"
 synapse_homedir="/var/lib/synapse"


### PR DESCRIPTION
This fixes denial of service attack [CVE-2020-26257](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26257).