### PR TITLE
ninja: update to 1.10.2.

### DIFF
--- a/srcpkgs/ninja/template
+++ b/srcpkgs/ninja/template
@@ -1,19 +1,19 @@
 # Template file for 'ninja'
 pkgname=ninja
-version=1.10.1
+version=1.10.2
 revision=1
-hostmakedepends="python asciidoc"
+hostmakedepends="python3 asciidoc"
 short_desc="Small build system with a focus on speed"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://ninja-build.org/"
-distfiles="https://github.com/martine/ninja/archive/v${version}.tar.gz"
-checksum=a6b6f7ac360d4aabd54e299cc1d8fa7b234cd81b9401693da21221c62569a23e
+distfiles="https://github.com/ninja-build/ninja/archive/v${version}.tar.gz"
+checksum=ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed
 
 do_configure() {
 	# Skip rebuild with bootstrapped ninja until build phase:
 	vsed -e "s|subprocess.check_call(rebuild_args)|pass|" -i configure.py
-	python2 configure.py --bootstrap
+	python3 configure.py --bootstrap
 }
 
 do_build() {
@@ -22,7 +22,7 @@ do_build() {
 	else
 		HOST_CXXFLAGS="${CXXFLAGS}"
 	fi
-	CXXFLAGS="$HOST_CXXFLAGS" python2 configure.py
+	CXXFLAGS="$HOST_CXXFLAGS" python3 configure.py
 	asciidoc doc/manual.asciidoc
 }
 


### PR DESCRIPTION
- use python3 to build
- update distfile location (it redirected to ninja-build/ninja)