### PR TITLE
exec package-specific ntpd in runit scripts, not the default alternative

### DIFF
--- a/srcpkgs/busybox/files/busybox-ntpd/run
+++ b/srcpkgs/busybox/files/busybox-ntpd/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ntpd -nN -p pool.ntp.org
+exec busybox ntpd -nN -p pool.ntp.org

--- a/srcpkgs/busybox/template
+++ b/srcpkgs/busybox/template
@@ -1,7 +1,7 @@
 # Template file for 'busybox'
 pkgname=busybox
 version=1.31.1
-revision=2
+revision=3
 hostmakedepends="perl"
 checkdepends="zip"
 short_desc="Swiss Army Knife of Embedded Linux"

--- a/srcpkgs/ntp/files/isc-ntpd/run
+++ b/srcpkgs/ntp/files/isc-ntpd/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ntpd -g -u ntpd:ntpd -n >/dev/null 2>&1
+exec isc-ntpd -g -u ntpd:ntpd -n >/dev/null 2>&1

--- a/srcpkgs/ntp/template
+++ b/srcpkgs/ntp/template
@@ -1,7 +1,7 @@
 # Template file for 'ntp'
 pkgname=ntp
 version=4.2.8p15
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-crypto --enable-linuxcap --enable-ipv6 --enable-ntp-signd
  --enable-all-clocks ol_cv_pthread_select_yields=yes"

--- a/srcpkgs/openntpd/files/openntpd/run
+++ b/srcpkgs/openntpd/files/openntpd/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-exec ntpd -d ${OPTS:=-s} 2>&1
+exec openntpd -d ${OPTS:=-s} 2>&1

--- a/srcpkgs/openntpd/template
+++ b/srcpkgs/openntpd/template
@@ -1,7 +1,7 @@
 # Template file for 'openntpd'
 pkgname=openntpd
 version=6.2p3
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--with-privsep-user=${pkgname} --with-cacert=/etc/ssl/certs.pem"
 hostmakedepends="automake libtool"
@@ -9,7 +9,7 @@ makedepends="libressl-devel"
 depends="ca-certificates"
 short_desc="FREE, easy to use implementation of the Network Time Protocol"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD"
+license="ISC"
 homepage="http://openntpd.org/"
 distfiles="http://ftp.openbsd.org/pub/OpenBSD/OpenNTPD/${pkgname}-${version}.tar.gz"
 checksum=7b02691524197e01ba6b1b4b7595b33956e657ba6d5c4cf2fc20ea3f4914c13a


### PR DESCRIPTION
If the default alternative is executed, then it will only work if the package is the default for that group, which is not guaranteed.
I wonder why all the packages having this issue are NTP daemons.