### PR TITLE
xdm: update xdm.pam file with elogind support

### DIFF
--- a/srcpkgs/xdm/files/xdm.pam
+++ b/srcpkgs/xdm/files/xdm.pam
@@ -6,4 +6,4 @@ password	required	pam_unix.so
 session		required	pam_unix.so
 session		required	pam_limits.so
 session		required	pam_loginuid.so
-session        optional        pam_elogind.so
+session		optional	pam_elogind.so

--- a/srcpkgs/xdm/files/xdm.pam
+++ b/srcpkgs/xdm/files/xdm.pam
@@ -6,3 +6,4 @@ password	required	pam_unix.so
 session		required	pam_unix.so
 session		required	pam_limits.so
 session		required	pam_loginuid.so
+session        optional        pam_elogind.so

--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,7 +1,7 @@
 # Template file for 'xdm'
 pkgname=xdm
 version=1.1.12
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp


### PR DESCRIPTION
Add optional access to "pam_elogind.so" to prevent polkit agent malfunction in multiple Desktop Environments if started from xdm.