### PR TITLE
gimp: fix crashes on unpatched musl.

### DIFF
--- a/srcpkgs/gimp/patches/fix-segfault.patch
+++ b/srcpkgs/gimp/patches/fix-segfault.patch
@@ -1,0 +1,169 @@
+diff --git app/dialogs/dialogs.c app/dialogs/dialogs.c
+index 064f2c4..b17d82f 100644
+--- app/dialogs/dialogs.c
++++ app/dialogs/dialogs.c
+@@ -534,11 +534,15 @@ dialogs_init (Gimp            *gimp,
+                                      menu_factory);
+   gimp_dialog_factory_set_singleton (factory);
+ 
+-  for (i = 0; i < G_N_ELEMENTS (entries); i++)
++  for (i = 0; i < G_N_ELEMENTS (entries); i++) {
++    char *name, *blurb;
++    name = entries[i].name ? gettext(entries[i].name) : NULL;
++    blurb = entries[i].blurb ? gettext(entries[i].blurb) : NULL;
++
+     gimp_dialog_factory_register_entry (factory,
+                                         entries[i].identifier,
+-                                        gettext (entries[i].name),
+-                                        gettext (entries[i].blurb),
++                                        name,
++                                        blurb,
+                                         entries[i].icon_name,
+                                         entries[i].help_id,
+                                         entries[i].new_func,
+@@ -551,6 +555,7 @@ dialogs_init (Gimp            *gimp,
+                                         entries[i].hideable,
+                                         entries[i].image_window,
+                                         entries[i].dockable);
++  }
+ 
+   global_recent_docks = gimp_list_new (GIMP_TYPE_SESSION_INFO, FALSE);
+ }
+diff --git app/widgets/gimpactiongroup.c app/widgets/gimpactiongroup.c
+index 04bd1b6..12eff51 100644
+--- app/widgets/gimpactiongroup.c
++++ app/widgets/gimpactiongroup.c
+@@ -393,7 +393,7 @@ gimp_action_group_add_actions (GimpActionGroup       *group,
+   for (i = 0; i < n_entries; i++)
+     {
+       GimpAction  *action;
+-      const gchar *label;
++      const gchar *label   = NULL;
+       const gchar *tooltip = NULL;
+ 
+       if (! gimp_action_group_check_unique_action (group, entries[i].name))
+@@ -401,15 +401,18 @@ gimp_action_group_add_actions (GimpActionGroup       *group,
+ 
+       if (msg_context)
+         {
+-          label = g_dpgettext2 (NULL, msg_context, entries[i].label);
++          if (entries[i].label)
++            label = g_dpgettext2 (NULL, msg_context, entries[i].label);
+ 
+           if (entries[i].tooltip)
+             tooltip = g_dpgettext2 (NULL, msg_context, entries[i].tooltip);
+         }
+       else
+         {
+-          label   = gettext (entries[i].label);
+-          tooltip = gettext (entries[i].tooltip);
++          if (entries[i].label)
++            label   = gettext (entries[i].label);
++          if (entries[i].tooltip)
++            tooltip = gettext (entries[i].tooltip);
+         }
+ 
+       action = gimp_action_impl_new (entries[i].name, label, tooltip,
+@@ -450,15 +453,18 @@ gimp_action_group_add_toggle_actions (GimpActionGroup             *group,
+ 
+       if (msg_context)
+         {
+-          label = g_dpgettext2 (NULL, msg_context, entries[i].label);
++          if (entries[i].label)
++            label = g_dpgettext2 (NULL, msg_context, entries[i].label);
+ 
+           if (entries[i].tooltip)
+             tooltip = g_dpgettext2 (NULL, msg_context, entries[i].tooltip);
+         }
+       else
+         {
+-          label   = gettext (entries[i].label);
+-          tooltip = gettext (entries[i].tooltip);
++          if (entries[i].label)
++            label   = gettext (entries[i].label);
++          if (entries[i].tooltip)
++            tooltip = gettext (entries[i].tooltip);
+         }
+ 
+       action = gimp_toggle_action_new (entries[i].name, label, tooltip,
+@@ -504,17 +510,20 @@ gimp_action_group_add_radio_actions (GimpActionGroup            *group,
+       if (! gimp_action_group_check_unique_action (group, entries[i].name))
+         continue;
+ 
+-      if (msg_context)
++       if (msg_context)
+         {
+-          label = g_dpgettext2 (NULL, msg_context, entries[i].label);
++          if (entries[i].label)
++            label = g_dpgettext2 (NULL, msg_context, entries[i].label);
+ 
+           if (entries[i].tooltip)
+             tooltip = g_dpgettext2 (NULL, msg_context, entries[i].tooltip);
+         }
+       else
+         {
+-          label   = gettext (entries[i].label);
+-          tooltip = gettext (entries[i].tooltip);
++          if (entries[i].label)
++            label   = gettext (entries[i].label);
++          if (entries[i].tooltip)
++            tooltip = gettext (entries[i].tooltip);
+         }
+ 
+       action = gimp_radio_action_new (entries[i].name, label, tooltip,
+@@ -560,7 +569,7 @@ gimp_action_group_add_enum_actions (GimpActionGroup           *group,
+   for (i = 0; i < n_entries; i++)
+     {
+       GimpEnumAction *action;
+-      const gchar    *label;
++      const gchar    *label   = NULL;
+       const gchar    *tooltip = NULL;
+ 
+       if (! gimp_action_group_check_unique_action (group, entries[i].name))
+@@ -568,15 +577,18 @@ gimp_action_group_add_enum_actions (GimpActionGroup           *group,
+ 
+       if (msg_context)
+         {
+-          label = g_dpgettext2 (NULL, msg_context, entries[i].label);
++          if (entries[i].label)
++            label = g_dpgettext2 (NULL, msg_context, entries[i].label);
+ 
+           if (entries[i].tooltip)
+             tooltip = g_dpgettext2 (NULL, msg_context, entries[i].tooltip);
+         }
+       else
+         {
+-          label   = gettext (entries[i].label);
+-          tooltip = gettext (entries[i].tooltip);
++          if (entries[i].label)
++            label   = gettext (entries[i].label);
++          if (entries[i].tooltip)
++            tooltip = gettext (entries[i].tooltip);
+         }
+ 
+       action = gimp_enum_action_new (entries[i].name, label, tooltip,
+@@ -618,17 +630,20 @@ gimp_action_group_add_string_actions (GimpActionGroup             *group,
+       if (! gimp_action_group_check_unique_action (group, entries[i].name))
+         continue;
+ 
+-      if (msg_context)
++       if (msg_context)
+         {
+-          label = g_dpgettext2 (NULL, msg_context, entries[i].label);
++          if (entries[i].label)
++            label = g_dpgettext2 (NULL, msg_context, entries[i].label);
+ 
+           if (entries[i].tooltip)
+             tooltip = g_dpgettext2 (NULL, msg_context, entries[i].tooltip);
+         }
+       else
+         {
+-          label   = gettext (entries[i].label);
+-          tooltip = gettext (entries[i].tooltip);
++          if (entries[i].label)
++            label   = gettext (entries[i].label);
++          if (entries[i].tooltip)
++            tooltip = gettext (entries[i].tooltip);
+         }
+ 
+       action = gimp_string_action_new (entries[i].name, label, tooltip,

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,7 +1,7 @@
 # Template file for 'gimp'
 pkgname=gimp
 version=2.10.20
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool
  libtool pkg-config pygtk-devel perl-XML-Parser gtk-doc iso-codes"


### PR DESCRIPTION
GIMP depended on our mo_lookup patch for musl, which allows passing NULL
msgid to gettext functions. This patch fixes that.