### PR TITLE
rpi-firmware: provide and replace linux-firmware-broadcom

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -4,10 +4,11 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
 version=20201123
-revision=2
+revision=3
 archs="armv6l* armv7l* aarch64*"
 wrksrc="firmware-${_githash}"
-depends="linux-firmware-broadcom"
+provides="linux-firmware-broadcom-${version}_${revision}"
+replaces="linux-firmware-broadcom>=0"
 short_desc="Firmware files for the Raspberry Pi (git ${_gitshort})"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="BSD-3-Clause, custom:Cypress"
@@ -37,9 +38,21 @@ do_install() {
 	$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/LICENCE.cypress
 	vlicense LICENCE.cypress
 
+	# Firmware for rpi3 b and zero wifi chip
+	for f in bin txt; do
+		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43430-sdio.${f}
+		vinstall brcmfmac43430-sdio.${f} 0644 usr/lib/firmware/brcm
+	done
+
 	# Firmware for rpi3 b and zero bluetooth chip
 	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM43430A1.hcd
 	vinstall BCM43430A1.hcd 0644 usr/lib/firmware/brcm
+
+	# Firmware for rpi3 b+ wifi chip
+	for f in bin txt clm_blob; do
+		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43455-sdio.${f}
+		vinstall brcmfmac43455-sdio.${f} 0644 usr/lib/firmware/brcm
+	done
 
 	# Firmware for rpi3 b+ bluetooth chip
 	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM4345C0.hcd


### PR DESCRIPTION
As reported by amak79, the blobs provided by linux-firmware-broadcom are
not as up-to-date as those provided by the Raspberry Pi foundation nor
do they supply a blob for the Pi Zero.  Therefore, revert to packaging
the latest wifi blobs from RPi-Distro.

To resolve the conflict with the broadcom drivers, this package now
provides and replaces linux-firmware-broadcom.  This allows for
rpi-firmware and linux-firmware-network to coexist (just without the
non-Raspberry Pi broadcom drivers).  This should satisfy most use cases.