### PR TITLE
quilt: add missing patch dependency

### DIFF
--- a/srcpkgs/quilt/template
+++ b/srcpkgs/quilt/template
@@ -1,10 +1,11 @@
 # Template file for 'quilt'
 pkgname=quilt
 version=0.66
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-rpmbuild"
 hostmakedepends="perl"
+depends="patch"
 short_desc="Tool for Working with Many Patches"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-2.0-only"


### PR DESCRIPTION
`/usr/share/quilt/push: line 142: patch: command not found`