### PR TITLE
youtube-dl: update to 2020.12.14

### DIFF
--- a/srcpkgs/youtube-dl/template
+++ b/srcpkgs/youtube-dl/template
@@ -1,6 +1,6 @@
 # Template file for 'youtube-dl'
 pkgname=youtube-dl
-version=2020.12.09
+version=2020.12.14
 revision=1
 wrksrc="${pkgname}"
 build_style=python3-module
@@ -13,7 +13,7 @@ license="Unlicense"
 homepage="https://yt-dl.org"
 changelog="https://raw.githubusercontent.com/ytdl-org/youtube-dl/master/ChangeLog"
 distfiles="${homepage}/downloads/latest/${pkgname}-${version}.tar.gz"
-checksum=0ac76347bf455b4e80a026638f9406aa28df3d2b6e445c705ad43809808eb961
+checksum=9681a5a515cb44ef23c28bd77f6d79d531fdbc7325bdf4bbb7966260b7b64273
 
 do_check() {
 	PYTHON=/usr/bin/python3 make offlinetest


### PR DESCRIPTION
Core
* [extractor/common] Improve JSON-LD interaction statistic extraction (#23306)
* [downloader/hls] Delegate manifests with media initialization to ffmpeg
+ [extractor/common] Document duration meta field for playlists

Extractors
* [mdr] Bypass geo restriction
* [mdr] Improve extraction (#24346, #26873)
* [yandexmusic:album] Improve album title extraction (#27418)
* [eporner] Fix view count extraction and make optional (#23306)
+ [eporner] Extend URL regular expression
* [eporner] Fix hash extraction and extend _VALID_URL (#27396)
* [slideslive] Use m3u8 entry protocol for m3u8 formats (#27400)
* [twitcasting] Fix format extraction and improve info extraction (#24868)
* [linuxacademy] Fix authentication and extraction (#21129, #26223, #27402)
* [itv] Clean description from HTML tags (#27399)
* [vlive] Sort live formats (#27404)
* [hotstart] Fix and improve extraction
    * Fix format extraction (#26690)
    + Extract thumbnail URL (#16079, #20412)
    + Add support for country specific playlist URLs (#23496)
    * Select the last id in video URL (#26412)
+ [youtube] Add some invidious instances (#27373)

https://github.com/ytdl-org/youtube-dl/releases/tag/2020.12.14