### PR TITLE
libmilter: set explicit stack size.

### DIFF
--- a/srcpkgs/libmilter/patches/thread-stacksize.patch
+++ b/srcpkgs/libmilter/patches/thread-stacksize.patch
@@ -1,0 +1,42 @@
+Set default pthread stack size to 256 KB
+
+This patch tries to fix various crashes for applications depending on libmilter
+by setting the stack size for pthreads to 256 KB. The default stack size for
+musl libc is set to 80 KB whereas glibc has it set to 8 MB. This causes problems
+when a large amount of memory is allocated on the stack.
+
+For example, opendkim allocates blocks of 64 KB multiple times, which causes
+libmilter (and therefore opendkim) to crash. For now, a stack size of 256 KB
+looks sufficient and makes opendkim stop crashing.
+
+Fixes https://bugs.alpinelinux.org/issues/6360
+
+--- libmilter/libmilter.h
++++ libmilter/libmilter.h
+@@ -127,10 +127,10 @@
+ # define MI_SOCK_READ(s, b, l)	read(s, b, l)
+ # define MI_SOCK_READ_FAIL(x)	((x) < 0)
+ # define MI_SOCK_WRITE(s, b, l)	write(s, b, l)
+-
+-# define thread_create(ptid,wr,arg) pthread_create(ptid, NULL, wr, arg)
+ # define sthread_get_id()	pthread_self()
+
++extern int thread_create(pthread_t *ptid, void *(*wr) (void *), void *arg);
++
+ typedef pthread_mutex_t smutex_t;
+ # define smutex_init(mp)	(pthread_mutex_init(mp, NULL) == 0)
+ # define smutex_destroy(mp)	(pthread_mutex_destroy(mp) == 0)
+--- libmilter/main.c
++++ libmilter/main.c
+@@ -16,6 +16,12 @@
+ #include <fcntl.h>
+ #include <sys/stat.h>
+
++int thread_create(pthread_t *ptid, void *(*wr) (void *), void *arg) {
++	pthread_attr_t attr;
++	pthread_attr_init(&attr);
++	pthread_attr_setstacksize(&attr,256*1024);
++	return pthread_create(ptid, &attr, wr, arg);
++}
+
+ static smfiDesc_ptr smfi = NULL;

--- a/srcpkgs/libmilter/template
+++ b/srcpkgs/libmilter/template
@@ -1,9 +1,10 @@
 # Template file for 'libmilter'
 pkgname=libmilter
 version=1.0.2
-revision=3
+revision=4
 _pkgname=sendmail
 _version=8.15.2
+wrksrc="${_pkgname}-${_version}"
 hostmakedepends="m4"
 short_desc="Implementation of the sendmail Mail Filter API"
 maintainer="John Regan <john@jrjrtech.com>"
@@ -11,7 +12,6 @@ license="Sendmail"
 homepage="https://www.milter.org/developers/api/"
 distfiles="ftp://ftp.mirrorservice.org/sites/ftp.sendmail.org/pub/${_pkgname}/${_pkgname}.${_version}.tar.gz"
 checksum=24f94b5fd76705f15897a78932a5f2439a32b1a2fdc35769bb1a5f5d9b4db439
-wrksrc="${_pkgname}-${_version}"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"


### PR DESCRIPTION
Patch taken from alpine. libmilter stack overflows with musl's default
thread stack size.

Based on #27031 