### PR TITLE
polybar: update to 3.5.2.

### DIFF
--- a/srcpkgs/polybar/template
+++ b/srcpkgs/polybar/template
@@ -1,6 +1,6 @@
 # Template file for 'polybar'
 pkgname=polybar
-version=3.5.1
+version=3.5.2
 revision=1
 build_style=cmake
 configure_args="
@@ -25,7 +25,7 @@ maintainer="Michael Carlberg <c@rlberg.se>"
 license="MIT"
 homepage="https://github.com/jaagr/polybar"
 distfiles="https://github.com/jaagr/polybar/releases/download/${version}/polybar-${version}.tar.gz"
-checksum=d342fdb1d37a475f3460e00e82445a3f7be812961fec6e455b33277af3cda719
+checksum=e411d9c091d0d4b5e8fbb44969e45c537d8c45900ecb3e90c49a248b885fe110
 
 build_options="alsa curl i3 mpd network pulseaudio"
 build_options_default="$build_options"
@@ -49,11 +49,6 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES='-latomic'"
 fi
-
-post_extract() {
-	# Fixes compilation with musl
-	sed -i 's|strncpy(header->magic, g_i3_ipc_magic.c_str(),|memcpy(header->magic, g_i3_ipc_magic.c_str(),|g' lib/i3ipcpp/src/ipc-util.cpp
-}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Remove unneeded post_extract (tested cross-build).