### PR TITLE
i8kutils: add missing acpi, tcl dependencies

### DIFF
--- a/srcpkgs/i8kutils/template
+++ b/srcpkgs/i8kutils/template
@@ -1,10 +1,11 @@
 # Template file for 'i8kutils'
 pkgname=i8kutils
 version=1.43
-revision=2
+revision=3
 archs="x86_64* i686*"
 wrksrc="$pkgname"
 build_style=gnu-makefile
+depends="acpi tcl"
 short_desc="Fan control for certain Dell laptops"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
i8kmon is a tcl script and thus needs tcl to run.  It also calls acpi to read the battery status.