### PR TITLE
New package: ungoogled-chromium-67.0.3396.87-1

### DIFF
--- a/srcpkgs/ungoogled-chromium/template
+++ b/srcpkgs/ungoogled-chromium/template
@@ -1,0 +1,45 @@
+# Template file for 'ungoogled-chromium'
+pkgname=ungoogled-chromium
+version=67.0.3396.87
+revision=1
+short_desc="Lightweight approach to removing Google web service dependency"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/Eloston/ungoogled-chromium"
+distfiles="https://github.com/Eloston/ungoogled-chromium/archive/${version}-1.tar.gz"
+checksum=3c589087e163aa67a899b7f21b9a658ffed5e5944127b97028f183d677a81233
+
+hostmakedepends="python ninja clang"
+depends="libexif hwids desktop-file-utils hicolor-icon-theme xdg-utils"
+
+# Instructions from https://github.com/Eloston/ungoogled-chromium/blob/master/docs/building.md
+do_configure() {
+	# Ensure Chromium is downloaded
+	mkdir -p build/download_cache
+	./utils/downloads.py retrieve -c build/download_cache -i downloads.ini
+	./utils/downloads.py unpack -c build/download_cache -i downloads.ini -- build/src
+	# Prune binaries
+	./utils/prune_binaries.py build/src pruning.list
+	# Apply patches
+	./utils/patches.py apply build/src patches
+	# Substitute domains
+	./utils/domain_substitution.py apply -r domain_regex.list -f domain_substitution.list -c build/domsubcache.tar.gz build/src
+	# Build GN
+	mkdir -p build/src/out/Default
+	./build/src/tools/gn/bootstrap/bootstrap.py --skip-generate-buildfiles -j4 -o build/src/out/Default/
+}
+
+do_build() {
+	# mkdir -p build/src/out/Default
+	# NOTE: flags.gn contains only a subset of what is needed to run the build.
+	cp flags.gn build/src/out/Default/args.gn
+	# FIXME The below command is failing to download needed arch
+	./build/src/build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
+	./build/src/out/Default/gn gen build/src/out/Default --fail-on-unused-args
+	ninja -C build/src/out/Default chrome chromedriver chrome_sandbox
+}
+
+do_install() {
+	vinstall build/src/out/Default/chrome 755 usr/lib/${pkgname} ${pkgname}
+	vlicense LICENSE
+}


### PR DESCRIPTION
# Current issues
* Durring the `do_build()` process, the command `./build/src/build/linux/sysroot_scripts/install-sysroot.py --arch=amd64` is returning (on my local test build):
```
Installing Debian sid amd64 root image: /home/amber/.local/src/ungoogled-chromium/build/src/build/linux/debian_sid_amd64-sysroot
Downloading https://commondatastorage.9oo91eapis.qjz9zk/chrome-linux-sysroot/toolchain/5f64b417e1018dcf8fcc81dc2714e0f264b9b911/debian_sid_amd64_sysroot.tar.xz
Failed to download https://commondatastorage.9oo91eapis.qjz9zk/chrome-linux-sysroot/toolchain/5f64b417e1018dcf8fcc81dc2714e0f264b9b911/debian_sid_amd64_sysroot.tar.xz
```