### PR TITLE
elogind: update to 243.7.

### DIFF
--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,8 +1,7 @@
 # Template file for 'elogind'
 pkgname=elogind
-reverts="243.7_1"
-version=243.4
-revision=3
+version=243.7
+revision=2
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
  -Drootlibexecdir=/usr/libexec/elogind -Dreboot-path=/usr/bin/reboot
@@ -18,7 +17,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://github.com/elogind/elogind"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=f1098745863138e6270ea22e78a39baef9a0356b48246c5a53b34211992dc7db
+checksum=941fde1ffbdf51d61e47fcebc49e2fc2b1347fcf3b0522bfa9d65ad5da653e53
 conf_files="/etc/elogind/*.conf"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then


### PR DESCRIPTION
This was reverted in 93eb2fb2f548db67c6e295d690b8075449656509, but it appears to be fixed now.

Upstream has retagged 243.7 (https://github.com/elogind/elogind/releases/tag/v243.7) and it appears to be working (no issues with XDG_RUNTIME_DIR).  

This also fixes handling of sleep/resume hooks.