### PR TITLE
tlp: install elogind hooks to appropriate location

### DIFF
--- a/srcpkgs/tlp/template
+++ b/srcpkgs/tlp/template
@@ -1,7 +1,7 @@
 # Template file for 'tlp'
 pkgname=tlp
 version=1.3.1
-revision=2
+revision=3
 wrksrc="TLP-${version}"
 depends="hdparm bash iw util-linux ethtool perl"
 short_desc="Advanced power management tool for Linux"
@@ -20,7 +20,7 @@ do_install() {
 		TLP_SBIN=/usr/bin \
 		TLP_ULIB=/usr/lib/udev \
 		TLP_SHCPL=/usr/share/bash-completion/completions \
-		TLP_ELOD=/usr/lib/elogind/system-sleep \
+		TLP_ELOD=/usr/libexec/elogind/system-sleep \
 		TLP_WITH_SYSTEMD=0 \
 		install
 


### PR DESCRIPTION
On voidlinux, elogind looks for the hooks in /usr/libexec/elogind rather
than /usr/lib/elogind.