### PR TITLE
Vulkan: update to 1.2.162 (and deps)

### DIFF
--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,11 +1,11 @@
 # Template file for 'SPIRV-Headers'
 pkgname=SPIRV-Headers
-version=1.5.3
-revision=2
+version=1.5.4.raytracing.fixed
+revision=1
 build_style=cmake
 short_desc="Machine-readable files for the SPIR-V Registry"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/KhronosGroup/SPIRV-Headers"
 distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/${version}.tar.gz"
-checksum=eece8a9e147d37997d425d5d2eeb2e757ad25adc30d6651467094f3b18609b5a
+checksum=df2ad2520be4d95a479fa248921065885bbf435a658349a7fc164ad7b26b68c6

--- a/srcpkgs/SPIRV-Tools/template
+++ b/srcpkgs/SPIRV-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-Tools'
 pkgname=SPIRV-Tools
-version=2020.3
+version=2020.6
 revision=1
 build_style=cmake
 configure_args="-DSPIRV_SKIP_TESTS=ON -DSPIRV_WERROR=OFF
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/SPIRV-Tools"
 distfiles="https://github.com/KhronosGroup/SPIRV-Tools/archive/v${version}.tar.gz"
-checksum=8b538a1cb2a4275ef9617abcb047d54e8292f975ac1d93323d5dd1e19c85280b
+checksum=de2392682df8def7ac666a2a320cd475751badf4790b01c7391b7644ecb550a3
 
 SPIRV-Tools-devel_package() {
 	depends="SPIRV-Tools-${version}_${revision}"

--- a/srcpkgs/Vulkan-Headers/template
+++ b/srcpkgs/Vulkan-Headers/template
@@ -1,11 +1,11 @@
 # Template file for 'Vulkan-Headers'
 pkgname=Vulkan-Headers
-version=1.2.148
-revision=2
+version=1.2.162
+revision=1
 build_style=cmake
 short_desc="Vulkan header files"
 maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${version}.tar.gz"
-checksum=fecaa9af5f7c4d85abdbbe2a63d4b8ebdf48a532e992710ba204d5dfa7513866
+checksum=deab1a7a28ad3e0a7a0a1c4cd9c54758dce115a5f231b7205432d2bbbfb4d456

--- a/srcpkgs/Vulkan-Tools/template
+++ b/srcpkgs/Vulkan-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Tools'
 pkgname=Vulkan-Tools
-version=1.2.148
+version=1.2.162
 revision=1
 wrksrc="${pkgname}-${version}"
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=bb2e3c96d1785c3594e164be36c2183a899463554c05671eb5c8a3a5b5dab354
+checksum=98a3a00471da65df833b4ffeb1ab29ec1d169d5feab54270cf4cd8f50f82e682
 
 build_options="cube"
 desc_option_cube="Build cube vulkan demo"

--- a/srcpkgs/Vulkan-ValidationLayers/template
+++ b/srcpkgs/Vulkan-ValidationLayers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-ValidationLayers'
 pkgname=Vulkan-ValidationLayers
-version=1.2.148
+version=1.2.162
 revision=1
 build_style=cmake
 configure_args="-Wno-dev -DSPIRV_HEADERS_INSTALL_DIR=${XBPS_CROSS_BASE}/usr
@@ -13,4 +13,4 @@ maintainer="Colin Gillespie <colin@breavyn.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${pkgname}/archive/v${version}.tar.gz"
-checksum=da43a161e280cd7dce63a18e929efb586f08024d23b2ee205437f7949a8063fc
+checksum=83619b81a86e733383a71ea54f0f5e64e194bf596ee8ec4e36217bb0b29b8917

--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,7 +1,7 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
 _pkgname=Vulkan-Loader
-version=1.2.148
+version=1.2.162
 revision=1
 wrksrc="${_pkgname}-${version}"
 build_style=cmake
@@ -15,4 +15,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/${_pkgname}/archive/v${version}.tar.gz"
-checksum=8f4dca3d125965dcb4c4f19ff9dddae893b5f071d63cfd9e47658ccae2414843
+checksum=e582dce35051a34af82db2a8fcd38fbc5837b4506e76e6cda685dca02dee01c7


### PR DESCRIPTION
Updates all Vulkan packages to latest SDK version, which has **ray tracing** support.
It is necessary to update `SPIRV-Tools` and `SPIRV-Headers` too to build the new `Vulkan-ValidationLayers`.
Tested (on `x86-64`):
- `vkcube`
- compiling and running an application with validation layers

Supersedes  #25375