### PR TITLE
webkit2gtk: update to 2.30.4

### DIFF
--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,6 +1,6 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
-version=2.30.2
+version=2.30.4
 revision=1
 wrksrc="webkitgtk-${version}"
 build_style=cmake
@@ -39,7 +39,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-2-Clause"
 homepage="https://webkitgtk.org/"
 distfiles="${homepage}/releases/webkitgtk-${version}.tar.xz"
-checksum=c467e0bc2bc610c2570928e3fd63cedaadc4719cbf9b04aa99f79dd71ad5682a
+checksum=d595a37c5001ff787266b155e303a5f2e5b48a6d466f2714c2f30c11392f7b24
 
 build_options="gir wayland x11 bubblewrap jit sampling_profiler minibrowser"
 build_options_default="gir wayland x11 bubblewrap minibrowser"


### PR DESCRIPTION
Fixes CVE-2020-13543.

More at https://webkitgtk.org/security/WSA-2020-0009.html.

First PR here, take it easy on me, thanks!