### PR TITLE
broadcom-wl-dkms: add linux-5.9.patch

### DIFF
--- a/srcpkgs/broadcom-wl-dkms/patches/linux-5.9.patch
+++ b/srcpkgs/broadcom-wl-dkms/patches/linux-5.9.patch
@@ -1,0 +1,36 @@
+diff -u -r src/wl/sys/wl_cfg80211_hybrid.c src/wl/sys/wl_cfg80211_hybrid.c
+--- src/wl/sys/wl_cfg80211_hybrid.c	2015-09-18 22:47:30.000000000 +0000
++++ src/wl/sys/wl_cfg80211_hybrid.c	2020-10-12 21:20:05.200372484 +0000
+@@ -450,7 +450,7 @@
+ 	ifr.ifr_data = (caddr_t)&ioc;
+ 
+ 	fs = get_fs();
+-	set_fs(get_ds());
++	set_fs(KERNEL_DS);
+ #if defined(WL_USE_NETDEV_OPS)
+ 	err = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
+ #else
+diff -u -r src/wl/sys/wl_iw.c src/wl/sys/wl_iw.c
+--- src/wl/sys/wl_iw.c	2015-09-18 22:47:30.000000000 +0000
++++ src/wl/sys/wl_iw.c	2020-10-12 21:19:51.426836804 +0000
+@@ -117,7 +117,7 @@
+ 	ifr.ifr_data = (caddr_t) &ioc;
+ 
+ 	fs = get_fs();
+-	set_fs(get_ds());
++	set_fs(KERNEL_DS);
+ #if defined(WL_USE_NETDEV_OPS)
+ 	ret = dev->netdev_ops->ndo_do_ioctl(dev, &ifr, SIOCDEVPRIVATE);
+ #else
+diff -u -r src/wl/sys/wl_linux.c src/wl/sys/wl_linux.c
+--- src/wl/sys/wl_linux.c	2020-10-12 21:19:15.256305165 +0000
++++ src/wl/sys/wl_linux.c	2020-10-12 21:20:38.687530895 +0000
+@@ -1643,7 +1643,7 @@
+ 		goto done2;
+ 	}
+ 
+-	if (segment_eq(get_fs(), KERNEL_DS))
++	if (get_fs().seg == KERNEL_DS.seg)
+ 		buf = ioc.buf;
+ 
+ 	else if (ioc.buf) {

--- a/srcpkgs/broadcom-wl-dkms/template
+++ b/srcpkgs/broadcom-wl-dkms/template
@@ -2,7 +2,7 @@
 
 pkgname=broadcom-wl-dkms
 version=6.30.223.271
-revision=9
+revision=10
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:Proprietary Broadcom license"
 homepage="http://broadcom.com"


### PR DESCRIPTION
Linux 5.9 broke broadcom-wl-dkms.  Add patch[0] from archlinux package
to fix.

[0] https://raw.githubusercontent.com/archlinux/svntogit-community/packages/broadcom-wl-dkms/trunk/011-linux59.patch