### PR TITLE
rtl8812au-dkms: update to 20201214

### DIFF
--- a/srcpkgs/rtl8812au-dkms/template
+++ b/srcpkgs/rtl8812au-dkms/template
@@ -1,9 +1,9 @@
 # Template file for 'rtl8812au-dkms'
 pkgname=rtl8812au-dkms
-version=20200702
-revision=3
-_modver=5.6.4.2
-_gitrev=3110ad65d0f03532bd97b1017cae67ca86dd34f6
+version=20201214
+revision=1
+_modver=5.9.3.2
+_gitrev=b95e75064d6aa5b680049a3fe63b2131a3033e3e
 wrksrc="rtl8812au-${_modver}-${_gitrev}"
 depends="dkms"
 short_desc="Realtek 8812AU/8821AU USB WiFi driver (DKMS)"
@@ -11,7 +11,7 @@ maintainer="Renato Aguiar <renato@renag.me>"
 license="GPL-2.0-only"
 homepage="http://www.dlink.com"
 distfiles="https://github.com/gordboy/rtl8812au-${_modver}/archive/${_gitrev}.tar.gz"
-checksum=398c7524ba150a48c39204372425f4a7c8f84a58ef92e9cca400c3cc0518203f
+checksum=25047a16ed9d6682fc8605dedf28a45625c4c1bbd4124a3aa0a085cd0f4e9cb6
 dkms_modules="rtl8812au ${_modver}"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
New module version 5.9.3.2; includes fixes for 5.10 kernels.