### PR TITLE
mesa: update to 20.3.1.

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,19 +1,19 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=20.2.3
+version=20.3.1
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
  -Dosmesa=gallium -Dgles1=true -Dgles2=true -Dglx=dri -Ddri3=true
- -Dlmsensors=true -Dplatforms=x11,drm,$(vopt_if wayland wayland,)surfaceless
+ -Dlmsensors=true -Dplatforms=x11,wayland
  -Dllvm=true -Db_lto=false -Dcpp_std=gnu++14"
 hostmakedepends="gettext flex llvm pkg-config python3-Mako glslang gzip
- $(vopt_if wayland 'wayland-protocols wayland-devel')"
+ wayland-protocols wayland-devel"
 makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel
  libXxf86vm-devel libatomic-devel libdrm-devel libffi-devel libva-devel
  libvdpau-devel libxshmfence-devel ncurses-devel zlib-devel
- $(vopt_if wayland 'wayland-devel wayland-protocols') llvm libsensors-devel
+ wayland-devel wayland-protocols llvm libsensors-devel
  libXrandr-devel libglvnd-devel libzstd-devel libxml2-devel lua53-devel
  libarchive-devel"
 depends="libglvnd"
@@ -23,10 +23,8 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=ae1b240e11531df528d14dc214d2dc4d2b4f2e835c6230ba0b492b171eceb82b
+checksum=af751b49bb2ab0264d58c31e73d869e80333de02b2d1becc93f1b28c67aa780f
 
-build_options="wayland"
-build_options_default="wayland"
 
 # Set subpackages manually to set proper rdeps in 32bit pkgs.
 subpackages="libglapi libgbm libOSMesa"


### PR DESCRIPTION
removed drm and surfaceless from platforms since they're determined automatically now.