### PR TITLE
gnome-keyring: update to 3.36.0_2 + cifs-utils: update to 6.11_2

### DIFF
--- a/srcpkgs/cifs-utils/patches/libcap-ng-fix.patch
+++ b/srcpkgs/cifs-utils/patches/libcap-ng-fix.patch
@@ -1,0 +1,47 @@
+From fcef79bc705b70862326e1394dfe77295086bcbb Mon Sep 17 00:00:00 2001
+From: Jonas Witschel <diabonas@archlinux.org>
+Date: Sat, 21 Nov 2020 12:11:44 +0100
+Subject: [PATCH] mount.cifs: update the cap bounding set only when CAP_SETPCAP
+ is given
+
+libcap-ng 0.8.1 tightened the error checking on capng_apply, returning an error
+of -4 when trying to update the capability bounding set without having the
+CAP_SETPCAP capability to be able to do so. Previous versions of libcap-ng
+silently skipped updating the bounding set and only updated the normal
+CAPNG_SELECT_CAPS capabilities instead.
+
+Check beforehand whether we have CAP_SETPCAP, in which case we can use
+CAPNG_SELECT_BOTH to update both the normal capabilities and the bounding set.
+Otherwise, we can at least update the normal capabilities, but refrain from
+trying to update the bounding set to avoid getting an error.
+
+Signed-off-by: Jonas Witschel <diabonas@archlinux.org>
+---
+ mount.cifs.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git mount.cifs.c mount.cifs.c
+index 81bdbc8..2474e98 100644
+--- mount.cifs.c
++++ mount.cifs.c
+@@ -347,6 +347,8 @@ static int set_password(struct parsed_mount_info *parsed_info, const char *src)
+ static int
+ drop_capabilities(int parent)
+ {
++	capng_select_t set = CAPNG_SELECT_CAPS;
++
+ 	capng_setpid(getpid());
+ 	capng_clear(CAPNG_SELECT_BOTH);
+ 	if (parent) {
+@@ -364,7 +366,10 @@ drop_capabilities(int parent)
+ 			return EX_SYSERR;
+ 		}
+ 	}
+-	if (capng_apply(CAPNG_SELECT_BOTH)) {
++	if (capng_have_capability(CAPNG_EFFECTIVE, CAP_SETPCAP)) {
++		set = CAPNG_SELECT_BOTH;
++	}
++	if (capng_apply(set)) {
+ 		fprintf(stderr, "Unable to apply new capability set.\n");
+ 		return EX_SYSERR;
+ 	}

--- a/srcpkgs/cifs-utils/template
+++ b/srcpkgs/cifs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'cifs-utils'
 pkgname=cifs-utils
 version=6.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-systemd"
 make_install_args="ROOTSBINDIR=/usr/bin"

--- a/srcpkgs/gnome-keyring/patches/libcap-ng-fix.patch
+++ b/srcpkgs/gnome-keyring/patches/libcap-ng-fix.patch
@@ -1,0 +1,115 @@
+From ebc7bc9efacc17049e54da8d96a4a29943621113 Mon Sep 17 00:00:00 2001
+From: Steve Grubb <sgrubb@redhat.com>
+Date: Fri, 20 Nov 2020 11:52:14 -0500
+Subject: [PATCH] Update libcap-ng capability handling
+
+There is a change in libcap-ng-0.8.1 that causes gnome-keyring to not
+work correctly. The capng_apply function now returns an error if it
+cannot change the bounding set. Previously this was ignored. Which means
+now gnome-keyring exits when it shouldn't.
+
+The new patch adds troubleshooting info to the error messages. And it checks
+to see if we have CAP_SETPCAP. If we do not, then we cannot change the
+bounding set and just set capabilities. On the setuid side, it now drops
+the bounding set and clears any supplemental groups that may be left over
+as an accident.
+---
+ daemon/gkd-capability.c | 54 ++++++++++++++++++++++++++---------------
+ 1 file changed, 34 insertions(+), 20 deletions(-)
+
+diff --git daemon/gkd-capability.c daemon/gkd-capability.c
+index 9afe3039..6eb7ed75 100644
+--- daemon/gkd-capability.c
++++ daemon/gkd-capability.c
+@@ -1,7 +1,7 @@
+ /* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+ /* gkd-capability.c - the security-critical initial phase of the daemon
+  *
+- * Copyright (C) 2011 Steve Grubb
++ * Copyright (C) 2011,2020 Steve Grubb
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU Lesser General Public License as
+@@ -35,9 +35,10 @@
+ 
+ /* No logging, no gettext */
+ static void
+-early_error (const char *err_string)
++early_error (const char *err_string, int rc)
+ {
+-	fprintf (stderr, "gnome-keyring-daemon: %s, aborting\n", err_string);
++	fprintf (stderr, "gnome-keyring-daemon: %s - %d, aborting\n",
++		err_string, rc);
+ 	exit (1);
+ }
+ 
+@@ -64,6 +65,8 @@ void
+ gkd_capability_obtain_capability_and_drop_privileges (void)
+ {
+ #ifdef HAVE_LIBCAPNG
++	int rc;
++
+ 	capng_get_caps_process ();
+ 	switch (capng_have_capabilities (CAPNG_SELECT_CAPS))
+ 	{
+@@ -73,32 +76,43 @@ gkd_capability_obtain_capability_and_drop_privileges (void)
+ 			capng_update (CAPNG_ADD,
+ 					CAPNG_EFFECTIVE|CAPNG_PERMITTED,
+ 					CAP_IPC_LOCK);
+-			if (capng_change_id (getuid (), getgid (), 0))
+-				early_error ("failed dropping capabilities");
++			if ((rc = capng_change_id (getuid (), getgid (),
++						   CAPNG_DROP_SUPP_GRP|
++						   CAPNG_CLEAR_BOUNDING))) {
++				early_error ("failed dropping capabilities",
++					     rc);
++			}
+ 			break;
+ 		case CAPNG_FAIL:
+-			early_error ("error getting process capabilities");
++			early_error ("error getting process capabilities", 0);
+ 			break;
+ 		case CAPNG_NONE:
+-			early_warning ("insufficient process capabilities, insecure memory might get used");
++			early_warning ("no process capabilities, insecure memory might get used");
+ 			break;
+-		case CAPNG_PARTIAL: /* File system based capabilities */
+-			if (!capng_have_capability (CAPNG_EFFECTIVE, CAP_IPC_LOCK)) {
++		case CAPNG_PARTIAL: { /* File system based capabilities */
++			capng_select_t set = CAPNG_SELECT_CAPS;
++			if (!capng_have_capability (CAPNG_EFFECTIVE,
++							    CAP_IPC_LOCK)) {
+ 				early_warning ("insufficient process capabilities, insecure memory might get used");
+-				/* Drop all capabilities */
+-				capng_clear (CAPNG_SELECT_BOTH);
+-				capng_apply (CAPNG_SELECT_BOTH);
+-				break;
+ 			}
+ 
+-			/* Drop all capabilities except ipc_lock */
++			/* If we don't have CAP_SETPCAP, we can't update the
++			 * bounding set */
++			if (capng_have_capability (CAPNG_EFFECTIVE,
++								CAP_SETPCAP)) {
++				set = CAPNG_SELECT_BOTH;
++			}
++
++			 /* Drop all capabilities except ipc_lock */
+ 			capng_clear (CAPNG_SELECT_BOTH);
+-			if (capng_update (CAPNG_ADD,
+-					  CAPNG_EFFECTIVE|CAPNG_PERMITTED,
+-					  CAP_IPC_LOCK) != 0)
+-				early_error ("error dropping process capabilities");
+-			if (capng_apply (CAPNG_SELECT_BOTH) != 0)
+-				early_error ("error dropping process capabilities");
++			if ((rc = capng_update (CAPNG_ADD,
++						CAPNG_EFFECTIVE|CAPNG_PERMITTED,
++						CAP_IPC_LOCK)) != 0) {
++				early_error ("error updating process capabilities", rc);
++			}
++			if ((rc = capng_apply (set)) != 0) {
++				early_error ("error dropping process capabilities", rc);
++			}} /* Extra brace for local variable declaration */
+ 			break;
+ 	}
+ #endif /* HAVE_LIBCAPNG */

--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
 version=3.36.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile"
 hostmakedepends="autoconf docbook-xsl glib-devel intltool libtasn1-tools libxslt


### PR DESCRIPTION
The new libcap-ng 0.8.2 recently committed to master breaks these two packages. I pulled the commit patches from both project repos and bumped the revision on both packages.

Refer to:
https://github.com/void-linux/void-packages/issues/27216