### PR TITLE
gnome-keyring: fix libcap-ng usage

### DIFF
--- a/srcpkgs/gnome-keyring/patches/libcap-ng-fix.patch
+++ b/srcpkgs/gnome-keyring/patches/libcap-ng-fix.patch
@@ -1,0 +1,115 @@
+From ebc7bc9efacc17049e54da8d96a4a29943621113 Mon Sep 17 00:00:00 2001
+From: Steve Grubb <sgrubb@redhat.com>
+Date: Fri, 20 Nov 2020 11:52:14 -0500
+Subject: [PATCH] Update libcap-ng capability handling
+
+There is a change in libcap-ng-0.8.1 that causes gnome-keyring to not
+work correctly. The capng_apply function now returns an error if it
+cannot change the bounding set. Previously this was ignored. Which means
+now gnome-keyring exits when it shouldn't.
+
+The new patch adds troubleshooting info to the error messages. And it checks
+to see if we have CAP_SETPCAP. If we do not, then we cannot change the
+bounding set and just set capabilities. On the setuid side, it now drops
+the bounding set and clears any supplemental groups that may be left over
+as an accident.
+---
+ daemon/gkd-capability.c | 54 ++++++++++++++++++++++++++---------------
+ 1 file changed, 34 insertions(+), 20 deletions(-)
+
+diff --git daemon/gkd-capability.c daemon/gkd-capability.c
+index 9afe3039..6eb7ed75 100644
+--- daemon/gkd-capability.c
++++ daemon/gkd-capability.c
+@@ -1,7 +1,7 @@
+ /* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+ /* gkd-capability.c - the security-critical initial phase of the daemon
+  *
+- * Copyright (C) 2011 Steve Grubb
++ * Copyright (C) 2011,2020 Steve Grubb
+  *
+  * This program is free software; you can redistribute it and/or modify
+  * it under the terms of the GNU Lesser General Public License as
+@@ -35,9 +35,10 @@
+ 
+ /* No logging, no gettext */
+ static void
+-early_error (const char *err_string)
++early_error (const char *err_string, int rc)
+ {
+-	fprintf (stderr, "gnome-keyring-daemon: %s, aborting\n", err_string);
++	fprintf (stderr, "gnome-keyring-daemon: %s - %d, aborting\n",
++		err_string, rc);
+ 	exit (1);
+ }
+ 
+@@ -64,6 +65,8 @@ void
+ gkd_capability_obtain_capability_and_drop_privileges (void)
+ {
+ #ifdef HAVE_LIBCAPNG
++	int rc;
++
+ 	capng_get_caps_process ();
+ 	switch (capng_have_capabilities (CAPNG_SELECT_CAPS))
+ 	{
+@@ -73,32 +76,43 @@ gkd_capability_obtain_capability_and_drop_privileges (void)
+ 			capng_update (CAPNG_ADD,
+ 					CAPNG_EFFECTIVE|CAPNG_PERMITTED,
+ 					CAP_IPC_LOCK);
+-			if (capng_change_id (getuid (), getgid (), 0))
+-				early_error ("failed dropping capabilities");
++			if ((rc = capng_change_id (getuid (), getgid (),
++						   CAPNG_DROP_SUPP_GRP|
++						   CAPNG_CLEAR_BOUNDING))) {
++				early_error ("failed dropping capabilities",
++					     rc);
++			}
+ 			break;
+ 		case CAPNG_FAIL:
+-			early_error ("error getting process capabilities");
++			early_error ("error getting process capabilities", 0);
+ 			break;
+ 		case CAPNG_NONE:
+-			early_warning ("insufficient process capabilities, insecure memory might get used");
++			early_warning ("no process capabilities, insecure memory might get used");
+ 			break;
+-		case CAPNG_PARTIAL: /* File system based capabilities */
+-			if (!capng_have_capability (CAPNG_EFFECTIVE, CAP_IPC_LOCK)) {
++		case CAPNG_PARTIAL: { /* File system based capabilities */
++			capng_select_t set = CAPNG_SELECT_CAPS;
++			if (!capng_have_capability (CAPNG_EFFECTIVE,
++							    CAP_IPC_LOCK)) {
+ 				early_warning ("insufficient process capabilities, insecure memory might get used");
+-				/* Drop all capabilities */
+-				capng_clear (CAPNG_SELECT_BOTH);
+-				capng_apply (CAPNG_SELECT_BOTH);
+-				break;
+ 			}
+ 
+-			/* Drop all capabilities except ipc_lock */
++			/* If we don't have CAP_SETPCAP, we can't update the
++			 * bounding set */
++			if (capng_have_capability (CAPNG_EFFECTIVE,
++								CAP_SETPCAP)) {
++				set = CAPNG_SELECT_BOTH;
++			}
++
++			 /* Drop all capabilities except ipc_lock */
+ 			capng_clear (CAPNG_SELECT_BOTH);
+-			if (capng_update (CAPNG_ADD,
+-					  CAPNG_EFFECTIVE|CAPNG_PERMITTED,
+-					  CAP_IPC_LOCK) != 0)
+-				early_error ("error dropping process capabilities");
+-			if (capng_apply (CAPNG_SELECT_BOTH) != 0)
+-				early_error ("error dropping process capabilities");
++			if ((rc = capng_update (CAPNG_ADD,
++						CAPNG_EFFECTIVE|CAPNG_PERMITTED,
++						CAP_IPC_LOCK)) != 0) {
++				early_error ("error updating process capabilities", rc);
++			}
++			if ((rc = capng_apply (set)) != 0) {
++				early_error ("error dropping process capabilities", rc);
++			}} /* Extra brace for local variable declaration */
+ 			break;
+ 	}
+ #endif /* HAVE_LIBCAPNG */

--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
 version=3.36.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile"
 hostmakedepends="autoconf docbook-xsl glib-devel intltool libtasn1-tools libxslt


### PR DESCRIPTION
The new libcap-ng 0.8.2 recently committed to master breaks this package. I pulled the commit patch from the project repo and bumped the revision.

Refer to:
#27216