### PR TITLE
cifs-utils: fix mounting with new libcap-ng

### DIFF
--- a/srcpkgs/cifs-utils/patches/cifs.upall-setcap.patch
+++ b/srcpkgs/cifs-utils/patches/cifs.upall-setcap.patch
@@ -1,0 +1,51 @@
+From linux-cifs  Sat Nov 21 11:11:45 2020
+From: Jonas Witschel <diabonas () archlinux ! org>
+Date: Sat, 21 Nov 2020 11:11:45 +0000
+To: linux-cifs
+Subject: [PATCH 2/2] cifs.upall: update the cap bounding set only when CAP_SETPCAP is given
+Message-Id: <20201121111145.24975-3-diabonas () archlinux ! org>
+X-MARC-Message: https://marc.info/?l=linux-cifs&m=160595758021261
+
+libcap-ng 0.8.1 tightened the error checking on capng_apply, returning an error
+of -4 when trying to update the capability bounding set without having the
+CAP_SETPCAP capability to be able to do so. Previous versions of libcap-ng
+silently skipped updating the bounding set and only updated the normal
+CAPNG_SELECT_CAPS capabilities instead.
+
+Check beforehand whether we have CAP_SETPCAP, in which case we can use
+CAPNG_SELECT_BOTH to update both the normal capabilities and the bounding set.
+Otherwise, we can at least update the normal capabilities, but refrain from
+trying to update the bounding set to avoid getting an error.
+
+Signed-off-by: Jonas Witschel <diabonas@archlinux.org>
+---
+ cifs.upcall.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/cifs.upcall.c b/cifs.upcall.c
+index 1559434..af1a0b0 100644
+--- cifs.upcall.c
++++ cifs.upcall.c
+@@ -88,6 +88,8 @@ typedef enum _sectype {
+ static int
+ trim_capabilities(bool need_environ)
+ {
++	capng_select_t set = CAPNG_SELECT_CAPS;
++
+ 	capng_clear(CAPNG_SELECT_BOTH);
+ 
+ 	/* SETUID and SETGID to change uid, gid, and grouplist */
+@@ -105,7 +107,10 @@ trim_capabilities(bool need_environ)
+ 		return 1;
+ 	}
+ 
+-	if (capng_apply(CAPNG_SELECT_BOTH)) {
++	if (capng_have_capability(CAPNG_EFFECTIVE, CAP_SETPCAP)) {
++		set = CAPNG_SELECT_BOTH;
++	}
++	if (capng_apply(set)) {
+ 		syslog(LOG_ERR, "%s: Unable to apply capability set: %m\n", __func__);
+ 		return 1;
+ 	}
+-- 
+2.29.2

--- a/srcpkgs/cifs-utils/patches/mount.cifs-setcap.patch
+++ b/srcpkgs/cifs-utils/patches/mount.cifs-setcap.patch
@@ -1,0 +1,51 @@
+From linux-cifs  Sat Nov 21 11:11:44 2020
+From: Jonas Witschel <diabonas () archlinux ! org>
+Date: Sat, 21 Nov 2020 11:11:44 +0000
+To: linux-cifs
+Subject: [PATCH 1/2] mount.cifs: update the cap bounding set only when CAP_SETPCAP is given
+Message-Id: <20201121111145.24975-2-diabonas () archlinux ! org>
+X-MARC-Message: https://marc.info/?l=linux-cifs&m=160595758021264
+
+libcap-ng 0.8.1 tightened the error checking on capng_apply, returning an error
+of -4 when trying to update the capability bounding set without having the
+CAP_SETPCAP capability to be able to do so. Previous versions of libcap-ng
+silently skipped updating the bounding set and only updated the normal
+CAPNG_SELECT_CAPS capabilities instead.
+
+Check beforehand whether we have CAP_SETPCAP, in which case we can use
+CAPNG_SELECT_BOTH to update both the normal capabilities and the bounding set.
+Otherwise, we can at least update the normal capabilities, but refrain from
+trying to update the bounding set to avoid getting an error.
+
+Signed-off-by: Jonas Witschel <diabonas@archlinux.org>
+---
+ mount.cifs.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/mount.cifs.c b/mount.cifs.c
+index 4feb397..88b8b69 100644
+--- mount.cifs.c
++++ mount.cifs.c
+@@ -338,6 +338,8 @@ static int set_password(struct parsed_mount_info *parsed_info, const char *src)
+ static int
+ drop_capabilities(int parent)
+ {
++	capng_select_t set = CAPNG_SELECT_CAPS;
++
+ 	capng_setpid(getpid());
+ 	capng_clear(CAPNG_SELECT_BOTH);
+ 	if (parent) {
+@@ -355,7 +357,10 @@ drop_capabilities(int parent)
+ 			return EX_SYSERR;
+ 		}
+ 	}
+-	if (capng_apply(CAPNG_SELECT_BOTH)) {
++	if (capng_have_capability(CAPNG_EFFECTIVE, CAP_SETPCAP)) {
++		set = CAPNG_SELECT_BOTH;
++	}
++	if (capng_apply(set)) {
+ 		fprintf(stderr, "Unable to apply new capability set.\n");
+ 		return EX_SYSERR;
+ 	}
+-- 
+2.29.2

--- a/srcpkgs/cifs-utils/template
+++ b/srcpkgs/cifs-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'cifs-utils'
 pkgname=cifs-utils
 version=6.11
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-systemd"
 make_install_args="ROOTSBINDIR=/usr/bin"


### PR DESCRIPTION
This fixes the error "Unable to apply new capability set." when trying to mount cifs on an up-to-date system.