### PR TITLE
xst: fix terminfo and TERM name in Xresources

### DIFF
--- a/srcpkgs/xst/INSTALL
+++ b/srcpkgs/xst/INSTALL
@@ -1,5 +1,5 @@
 case "${ACTION}" in
 post)
-	tic -s usr/share/terminfo/x/xst.terminfo
+	tic -sx usr/share/terminfo/x/xst.terminfo
 	;;
 esac

--- a/srcpkgs/xst/template
+++ b/srcpkgs/xst/template
@@ -1,7 +1,7 @@
 # Template file for 'xst'
 pkgname=xst
 version=0.8.4.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_use_env=compliant
 hostmakedepends="pkg-config"
@@ -21,7 +21,6 @@ do_install() {
 	vinstall st.info 644 usr/share/terminfo/x xst.terminfo
 	vdoc README
 	vdoc FAQ
-	vsed -i 's/st-256color/xst-256color/' .Xresources
 	vdoc .Xresources Xresources
 	vlicense LICENSE
 }


### PR DESCRIPTION
Fixes "unknown capability" during terminfo generation and removes replacing TERM name in xresources since it is unneeded anymore.

The previous pull request is messed up by me because of lacking knowledge about git.

Please excuse me for such a move.