### PR TITLE
youtube-dl: move to versioned url.

### DIFF
--- a/srcpkgs/youtube-dl/template
+++ b/srcpkgs/youtube-dl/template
@@ -12,7 +12,7 @@ maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
 license="Unlicense"
 homepage="https://yt-dl.org"
 changelog="https://raw.githubusercontent.com/ytdl-org/youtube-dl/master/ChangeLog"
-distfiles="${homepage}/downloads/latest/${pkgname}-${version}.tar.gz"
+distfiles="${homepage}/downloads/${version}/${pkgname}-${version}.tar.gz"
 checksum=9681a5a515cb44ef23c28bd77f6d79d531fdbc7325bdf4bbb7966260b7b64273
 
 do_check() {


### PR DESCRIPTION
Otherwise links go out-of-date.