### PR TITLE
libucontext: update to 0.13.1

### DIFF
--- a/srcpkgs/libucontext/template
+++ b/srcpkgs/libucontext/template
@@ -1,15 +1,17 @@
 # Template file for 'libucontext'
 pkgname=libucontext
-version=0.11
+version=0.13.1
 revision=1
 archs="*-musl"
 wrksrc="${pkgname}-${pkgname}-${version}"
+make_build_args="all docs"
+hostmakedepends="scdoc"
 short_desc="Compatibility layer providing ucontext functions"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="ISC"
 homepage="https://github.com/kaniini/libucontext"
 distfiles="https://github.com/kaniini/libucontext/archive/${pkgname}-${version}.tar.gz"
-checksum=ec122a4bca8f75922082c4f4d81b09ff3e950906d7f5504e0bce367ec9a6fceb
+checksum=5d3517d12f1a605713cfb94c1ceda89e399bf534a4a85c9ff356cc329e12e4c1
 
 case "${XBPS_TARGET_MACHINE}" in
 arm*)	export LIBUCONTEXT_ARCH="arm";;
@@ -33,6 +35,7 @@ do_check() {
 
 do_install() {
 	make ARCH="${LIBUCONTEXT_ARCH}" DESTDIR="${DESTDIR}/usr" install
+	make ARCH="${LIBUCONTEXT_ARCH}" DESTDIR="${DESTDIR}" install_docs
 }
 
 post_install() {
@@ -45,5 +48,6 @@ libucontext-devel_package() {
 	pkg_install() {
 		vmove "usr/lib/*.so"
 		vmove "usr/lib/*.a"
+		vmove usr/share/man
 	}
 }


### PR DESCRIPTION
Adds man pages and fixes for RISC-V V64 support w/ musl.