### PR TITLE
New package: zerotier-one-1.6.2

### DIFF
--- a/srcpkgs/zerotier-one/files/zerotier/run
+++ b/srcpkgs/zerotier-one/files/zerotier/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec zerotier-one

--- a/srcpkgs/zerotier-one/patches/fix-cross.patch
+++ b/srcpkgs/zerotier-one/patches/fix-cross.patch
@@ -1,0 +1,59 @@
+--- make-linux.mk	2020-12-01 01:33:39.000000000 +0100
++++ make-linux.mk	2020-12-19 13:00:35.311711026 +0100
+@@ -144,6 +144,9 @@
+ ifeq ($(CC_MACH),ppc64el)
+ 	ZT_ARCHITECTURE=8
+ endif
++ifeq ($(CC_MACH),powerpc64)
++	ZT_ARCHITECTURE=8
++endif
+ ifeq ($(CC_MACH),e2k)
+ 	ZT_ARCHITECTURE=2
+ endif
+@@ -177,22 +180,22 @@
+ ifeq ($(CC_MACH),armv6)
+ 	ZT_ARCHITECTURE=3
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+-	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
++	ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+ endif
+ ifeq ($(CC_MACH),armv6l)
+ 	ZT_ARCHITECTURE=3
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+-	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
++	ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+ endif
+ ifeq ($(CC_MACH),armv6zk)
+ 	ZT_ARCHITECTURE=3
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+-	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
++	ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+ endif
+ ifeq ($(CC_MACH),armv6kz)
+ 	ZT_ARCHITECTURE=3
+ 	override DEFS+=-DZT_NO_TYPE_PUNNING
+-	ZT_USE_ARM32_NEON_ASM_CRYPTO=1
++	ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+ endif
+ ifeq ($(CC_MACH),armv7)
+ 	ZT_ARCHITECTURE=3
+@@ -275,19 +278,6 @@
+ 	override INCLUDES+=-I/usr/pgsql-10/include -Iext/hiredis-0.14.1/include/ -Iext/redis-plus-plus-1.1.1/install/centos8/include/sw/
+ endif
+ 
+-# ARM32 hell -- use conservative CFLAGS
+-ifeq ($(ZT_ARCHITECTURE),3)
+-	ifeq ($(shell if [ -e /usr/bin/dpkg ]; then dpkg --print-architecture; fi),armel)
+-		override CFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+-		override CXXFLAGS+=-march=armv5t -mfloat-abi=soft -msoft-float -mno-unaligned-access -marm
+-		ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+-	else
+-		override CFLAGS+=-march=armv5t -mno-unaligned-access -marm -fexceptions
+-		override CXXFLAGS+=-march=armv5t -mno-unaligned-access -marm -fexceptions
+-		ZT_USE_ARM32_NEON_ASM_CRYPTO=0
+-	endif
+-endif
+-
+ # Build faster crypto on some targets
+ ifeq ($(ZT_USE_X64_ASM_SALSA),1)
+ 	override DEFS+=-DZT_USE_X64_ASM_SALSA2012

--- a/srcpkgs/zerotier-one/template
+++ b/srcpkgs/zerotier-one/template
@@ -1,0 +1,24 @@
+# Template file for 'zerotier-one'
+pkgname=zerotier-one
+version=1.6.2
+revision=1
+wrksrc=ZeroTierOne-${version}
+build_style=gnu-makefile
+hostmakedepends="nodejs"
+makedepends="sqlite-devel"
+short_desc="Network Virtualization Everywhere"
+maintainer="Hadrian Węgrzynowski <hadrian@hawski.com>"
+license="custom:BPL-1.1"
+homepage="https://www.zerotier.com/"
+distfiles="https://github.com/zerotier/ZeroTierOne/archive/${version}.tar.gz"
+checksum=c8087b26c1191d36fda004b42cdfed31042cafd8586e49015586eef786f2c9a5
+repository=nonfree
+
+pre_install() {
+	sed -i 's/sbin/bin/g' make-linux.mk
+}
+
+post_install() {
+	vsv zerotier
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
It was removed around version 1.4.0. Now it also has a different, non-free, license. I can maintain it, as I use it quite a bit.