### PR TITLE
perl-DateTime-Format-Strptime: update to 1.78

### DIFF
--- a/srcpkgs/perl-DateTime-Format-Strptime/template
+++ b/srcpkgs/perl-DateTime-Format-Strptime/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-DateTime-Format-Strptime'
 pkgname=perl-DateTime-Format-Strptime
-version=1.77
-revision=2
+version=1.78
+revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -13,4 +13,4 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="Artistic-2.0"
 homepage="https://metacpan.org/release/DateTime-Format-Strptime"
 distfiles="${CPAN_SITE}/DateTime/${pkgname/perl-/}-$version.tar.gz"
-checksum=2fa43c838ecf5356f221a91a41c81dba22e7860c5474b4a61723259898173e4a
+checksum=5143cb8032301b49abef8b989cbfa7592e78db29b7b8c3b874bb0b9489e0d90f

--- a/srcpkgs/perl-DateTime-Locale/template
+++ b/srcpkgs/perl-DateTime-Locale/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-DateTime-Locale'
 pkgname=perl-DateTime-Locale
-version=1.28
-revision=2
+version=1.30
+revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl-File-ShareDir-Install"
@@ -17,4 +17,4 @@ license="Artistic-1.0-Perl, GPL-1.0-or-later"
 #changelog="http://cpansearch.perl.org/src/DROLSKY/DateTime-Locale-${version}/Changes"
 homepage="https://metacpan.org/release/DateTime-Locale"
 distfiles="${CPAN_SITE}/DateTime/${pkgname/perl-/}-${version}.tar.gz"
-checksum=6c604d8c5c9c2739b78e0538a402283b82b1df419e60bef20b04843e4584bade
+checksum=dd824794b3ce7c47de8e40d55e297677d9806eb6f9ebc1a5784342078b024e0a


### PR DESCRIPTION
Tests require perl-DateTime-Locale version 1.30 so I included this update here.