### PR TITLE
pipewire: update to 0.3.18

### DIFF
--- a/srcpkgs/libpulseaudio-pipewire
+++ b/srcpkgs/libpulseaudio-pipewire
@@ -1,1 +1,0 @@
-pipewire

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,22 +1,25 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.3.17
+version=0.3.18
 revision=1
 build_style=meson
 configure_args="-Dman=true -Dgstreamer=true -Ddocs=true -Dsystemd=false
  -Dbluez5=true -Dffmpeg=true -Dpipewire-alsa=true -Dpipewire-jack=true
- -Dpipewire-pulseaudio=true -Dudevrulesdir=/usr/lib/udev/rules.d"
+ -Dudevrulesdir=/usr/lib/udev/rules.d"
 hostmakedepends="doxygen graphviz pkg-config xmltoman"
 makedepends="SDL2-devel ffmpeg-devel gst-plugins-base1-devel jack-devel
  sbc-devel v4l-utils-devel libva-devel libbluetooth-devel"
+depends="libspa-alsa libspa-audioconvert libspa-audiomixer libspa-control"
 short_desc="Server and user space API to deal with multimedia pipelines"
 maintainer="Kridsada Thanabulpong <sirn@ogsite.net>"
 license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=46d2f597506ef56b0be54498ab26b58bacdd7cae30f87f47836f1f717a0d05ac
+checksum=a7317de8e54f57190a2e2fe5f469ed332b9a12151fade03bf984765a55e5e24b
 conf_files="/etc/pipewire/pipewire.conf"
+
+replaces="libpulseaudio-pipewire>=0"
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
@@ -121,15 +124,6 @@ gstreamer1-pipewire_package() {
 	short_desc+=" - gstreamer plugin"
 	pkg_install() {
 		vmove usr/lib/gstreamer-1.0
-	}
-}
-
-libpulseaudio-pipewire_package() {
-	depends="libpipewire-${version}_${revision}"
-	short_desc+=" - PulseAudio client library"
-	pkg_install() {
-		vmove usr/lib/pipewire-0.3/pulse
-		vmove usr/bin/pw-pulse
 	}
 }
 


### PR DESCRIPTION
* Add deps on core plugins (so that it works without having to manually install a bunch of non-obvious `libspa-`)
we may want to merge them in the main `pipewire` package, but we can do it later
* Remove libpulseaudio-pipewire (deprecated)

Tested briefly as pulse and jack replacement on `x86_64`