### PR TITLE
mesa: update to 20.3.1.

### DIFF
--- a/srcpkgs/libva/template
+++ b/srcpkgs/libva/template
@@ -1,7 +1,7 @@
 # Template file for 'libva'
 pkgname=libva
 version=2.9.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwith_glx=no $(vopt_if wayland -Dwith_wayland=yes)"
 hostmakedepends="pkg-config wayland-devel"
@@ -17,10 +17,6 @@ checksum=4e8640f65ad659332c5d24b7715703c95e820083ee11126c9cd051d418e3d9e0
 
 build_options="wayland"
 build_options_default="wayland"
-
-case "$XBPS_TARGET_MACHINE" in
-	i686*) configure_args+=" -Ddriverdir=/usr/lib32/dri";;
-esac
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,19 +1,19 @@
 # Template file for 'mesa'
 pkgname=mesa
-version=20.2.3
+version=20.3.1
 revision=1
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=true -Dgbm=true -Degl=true
  -Dosmesa=gallium -Dgles1=true -Dgles2=true -Dglx=dri -Ddri3=true
- -Dlmsensors=true -Dplatforms=x11,drm,$(vopt_if wayland wayland,)surfaceless
+ -Dlmsensors=true -Dplatforms=x11,wayland
  -Dllvm=true -Db_lto=false -Dcpp_std=gnu++14"
 hostmakedepends="gettext flex llvm pkg-config python3-Mako glslang gzip
- $(vopt_if wayland 'wayland-protocols wayland-devel')"
+ wayland-protocols wayland-devel"
 makedepends="elfutils-devel expat-devel libXdamage-devel libXvMC-devel
  libXxf86vm-devel libatomic-devel libdrm-devel libffi-devel libva-devel
  libvdpau-devel libxshmfence-devel ncurses-devel zlib-devel
- $(vopt_if wayland 'wayland-devel wayland-protocols') llvm libsensors-devel
+ wayland-devel wayland-protocols llvm libsensors-devel
  libXrandr-devel libglvnd-devel libzstd-devel libxml2-devel lua53-devel
  libarchive-devel"
 depends="libglvnd"
@@ -23,10 +23,11 @@ license="MIT, LGPL-2.1-or-later"
 homepage="https://www.mesa3d.org/"
 changelog="https://docs.mesa3d.org/relnotes/${version}.html"
 distfiles="https://mesa.freedesktop.org/archive/mesa-${version}.tar.xz"
-checksum=ae1b240e11531df528d14dc214d2dc4d2b4f2e835c6230ba0b492b171eceb82b
+checksum=af751b49bb2ab0264d58c31e73d869e80333de02b2d1becc93f1b28c67aa780f
 
-build_options="wayland"
-build_options_default="wayland"
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	configure_args+=" -Duse-elf-tls=false"
+fi
 
 # Set subpackages manually to set proper rdeps in 32bit pkgs.
 subpackages="libglapi libgbm libOSMesa"
@@ -166,14 +167,6 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc*) configure_args+=" -Dpower8=false" ;;
 esac
 
-case "$XBPS_TARGET_MACHINE" in
-	i686) configure_args+=" -Ddri-drivers-path=/usr/lib32/dri";;
-esac
-
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	configure_args+=" -Duse-elf-tls=false"
-fi
-
 post_configure() {
 	if [ "$CROSS_BUILD" ]; then
 		find -iname "*.ninja" -exec sed -i "{}" \
@@ -186,16 +179,40 @@ post_configure() {
 
 post_install() {
 	vlicense docs/license.rst
-	case "$XBPS_TARGET_MACHINE" in
-		i686*)
-			vsed -e 's#/usr/lib/#/usr/lib32/#g' \
-				-i ${DESTDIR}/usr/share/vulkan/icd.d/radeon_icd.i686.json \
-				-i ${DESTDIR}/usr/share/vulkan/icd.d/intel_icd.i686.json
-			;;
+
+	# ensure that each eligible architecture ships its multilib icd files
+	# in some cases, multiple counterpart architectures may exist (aarch64)
+	# this allows us to not have to ship these files in the current *-32bit packages
+	local arch=${XBPS_TARGET_MACHINE%-*}
+	local oarchs
+	local olibdir="/usr/lib32/"
+	if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
+		olibdir="/usr/lib64/"
+	fi
+	case "${arch}" in
+		aarch64) oarchs="armv6l armv7l";;
+		armv[67]l) oarchs="aarch64";;
+		x86_64) oarchs="i686";;
+		i686) oarchs="x86_64";;
+		ppc64le) oarchs="ppcle";;
+		ppc64) oarchs="ppc";;
+		ppcle) oarchs="ppc64le";;
+		ppc) oarchs="ppc64";;
+		*) ;; # no counterparts
 	esac
+	for oarch in $oarchs; do
+		for icd in ${DESTDIR}/usr/share/vulkan/icd.d/*_icd.${arch}.json; do
+			sed "s#/usr/lib${XBPS_TARGET_WORDSIZE}/#${olibdir}#g" \
+				${icd} > ${icd/.${arch}/.${oarch}}
+		done
+	done
 }
 
 libglapi_package() {
+	# this dependency is wrong, it was added as a hack to allow updating
+	# systems with libglapi-32bit after the switch to glvnd
+	# see 927f17347f9c646047c65312c8e8ce1ad88b7832
+	# it can be removed when glibc multilib (with *-32bit packages) is removed
 	depends="libglvnd"
 	short_desc="Free implementation of the GL API - shared library"
 	pkg_install() {
@@ -309,7 +326,6 @@ mesa-XvMC_package() {
 
 mesa-vulkan-intel_package() {
 	short_desc="Mesa Intel Vulkan driver"
-	lib32files="/usr/share/vulkan/icd.d/intel_icd.i686.json"
 	pkg_install() {
 		vmove "usr/share/vulkan/icd.d/intel_icd*.json"
 		vmove "usr/lib/libvulkan_intel.so"
@@ -318,7 +334,6 @@ mesa-vulkan-intel_package() {
 
 mesa-vulkan-radeon_package() {
 	short_desc="Mesa Radeon Vulkan driver"
-	lib32files="/usr/share/vulkan/icd.d/radeon_icd.i686.json"
 	pkg_install() {
 		vmove "usr/share/vulkan/icd.d/radeon_icd*.json"
 		vmove "usr/lib/libvulkan_radeon.so"

--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=1.20.10
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb


### PR DESCRIPTION
- removed drm and surfaceless from platforms since they're determined
automatically now.
- fix driver search path to use /usr/lib${wordsize}; see
https://github.com/void-linux/void-packages/pull/27269
- remove transitional dummy packages that only depend on mesa-dri

Closes: #27214 [via git-merge-pr]

I'm not sure if the issue here https://gitlab.freedesktop.org/mesa/mesa/-/issues/3989 matters for us.