### PR TITLE
nss: update to 3.60.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -3,7 +3,7 @@
 _nsprver=4.29
 
 pkgname=nss
-version=3.59
+version=3.60
 revision=1
 hostmakedepends="perl"
 makedepends="nspr-devel sqlite-devel zlib-devel"
@@ -11,9 +11,9 @@ depends="nspr>=${_nsprver}"
 short_desc="Mozilla Network Security Services"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MPL-2.0"
-homepage="https://www.mozilla.org/projects/security/pki/nss"
+homepage="https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS"
 distfiles="${MOZILLA_SITE}/security/nss/releases/NSS_${version//\./_}_RTM/src/nss-${version}.tar.gz"
-checksum=e6298174caa8527beacdc2858f77ed098d7047c1792846040e27e420fed0ce24
+checksum=84abd5575ab874c53ae511bd461e5d0868d1a1b384ee40753154cdd1d590fe3d
 
 export NS_USE_GCC=1
 export LIBRUNPATH=
@@ -27,7 +27,7 @@ do_build() {
 	local _native_use64 _target_use64
 
 	# Respect LDFLAGS
-	vsed -e 's/\$(MKSHLIB) -o/\$(MKSHLIB) \$(LDFLAGS) -o/g' \
+	vsed -e 's/[$](MKSHLIB) /&$(LDFLAGS) /g' \
 		-i nss/coreconf/rules.mk
 
 	export NATIVE_CC="$BUILD_CC"


### PR DESCRIPTION
@q66 Something is being changed for ppc:
```diff
diff --git a/nss/lib/freebl/Makefile b/nss/lib/freebl/Makefile
index 2851474..269e34c 100644
--- a/nss/lib/freebl/Makefile
+++ b/nss/lib/freebl/Makefile
@@ -293,9 +293,12 @@ ifeq ($(CPU_ARCH),arm)
 endif
 ifeq ($(CPU_ARCH),ppc)
     EXTRA_SRCS += gcm-ppc.c
-    ASFILES += sha512-p8.s
 ifdef USE_64
     DEFINES += -DNSS_NO_INIT_SUPPORT
+    PPC_ABI := $(shell $(CC) -dM -E - < /dev/null | awk '$$2 == "_CALL_ELF" {print $$3}')
+    ifeq ($(PPC_ABI),2)
+        ASFILES += sha512-p8.s
+    endif
 endif # USE_64
 endif # ppc
 endif # Linux
diff --git a/nss/lib/freebl/blinit.c b/nss/lib/freebl/blinit.c
index 2f2a476..82375fd 100644
--- a/nss/lib/freebl/blinit.c
+++ b/nss/lib/freebl/blinit.c
@@ -231,6 +231,15 @@ CheckARMSupport()
         arm_sha1_support_ = ID_AA64ISAR0_SHA1_VAL(isar0) >= ID_AA64ISAR0_SHA1_BASE;
         arm_sha2_support_ = ID_AA64ISAR0_SHA2_VAL(isar0) >= ID_AA64ISAR0_SHA2_BASE;
     }
+#elif defined(__ARM_FEATURE_CRYPTO)
+    /*
+     * Although no feature detection, default compiler option allows ARM
+     * Crypto Extension.
+     */
+    arm_aes_support_ = PR_TRUE;
+    arm_pmull_support_ = PR_TRUE;
+    arm_sha1_support_ = PR_TRUE;
+    arm_sha2_support_ = PR_TRUE;
 #endif
     /* aarch64 must support NEON. */
     arm_neon_support_ = PR_GetEnvSecure("NSS_DISABLE_ARM_NEON") == NULL;
```
harmless I think