### PR TITLE
fprint: update to 1.90.x

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1577,7 +1577,7 @@ libtcmalloc.so.4 gperftools-2.1_1
 libaio.so.1 libaio-0.3.109_1
 libofx.so.7 libofx-0.9.11_1
 libsigsegv.so.2 libsigsegv-2.10_2
-libfprint.so.0 libfprint-0.5.1_1
+libfprint-2.so.2 libfprint-1.90.6.1_1
 libwx_baseu_xml-3.0.so.0 wxWidgets-common-3.0.4_1
 libwx_baseu-3.0.so.0 wxWidgets-common-3.0.4_1
 libwx_gtk2_adv-3.0.so.0 wxWidgets-3.0.0_1
@@ -3985,6 +3985,8 @@ libneatvnc.so.0 neatvnc-0.3.2_1
 libtdjson.so.1.7.0 libtd-1.7.0_1
 libJudy.so.1 judy-1.0.5_1
 libsignal-protocol-c.so.2 libsignal-protocol-c-2.3.3_2
+libpamtest.so.0 pam_wrapper-1.1.3_1
+libpam_wrapper.so.0 pam_wrapper-1.1.3_1
 libSeExpr2Editor.so.3 seexpr-krita-3.4.4.0_1
 libSeExpr2.so.3 seexpr-krita-3.4.4.0_1
 liburing.so.1 liburing-0.7_1

--- a/srcpkgs/fprintd/template
+++ b/srcpkgs/fprintd/template
@@ -1,36 +1,26 @@
 # Template file for 'fprintd'
 pkgname=fprintd
-version=0.9.0
-revision=3
-wrksrc="fprintd-V_${version//./_}"
-build_style=gnu-configure
-configure_args="--sysconfdir=/etc/${pkgname} --disable-static --without-systemdsystemunitdir"
-conf_files="/etc/fprintd/fprintd.conf"
-hostmakedepends="autoconf automake dbus-glib-devel gettext-devel glib-devel gtk-doc intltool libtool m4 pkg-config"
-makedepends="dbus-devel dbus-glib-devel gettext-devel glib-devel libfprint-devel pam-devel polkit-devel"
+version=1.90.8
+revision=1
+wrksrc="fprintd-v${version}"
+build_style=meson
+configure_args="--sysconfdir=/etc/fprintd -Dman=true -Dgtk_doc=false
+-Dpam_modules_dir=/usr/lib/security -Dsystemd_system_unit_dir=/not-systemd"
+hostmakedepends="meson cmake dbus-glib-devel gettext-devel glib-devel intltool
+ pkg-config perl"
+makedepends="dbus-devel dbus-glib-devel gettext-devel glib-devel libxslt-devel
+ libfprint-devel pam-devel polkit-devel cairo-devel elogind-devel python3-cairo python3-dbus python3-dbusmock"
 short_desc="Daemon that provides fingerprint scanning functionality"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/fprint/"
-distfiles="https://gitlab.freedesktop.org/libfprint/fprintd/-/archive/V_${version//./_}/fprintd-V_${version//./_}.tar.bz2"
-checksum=3bfbf870a3c333a0a1f08287b2b8501c34fd347faac8c1d52bd0d64ab3474d8e
-lib32disabled=yes
+distfiles="https://gitlab.freedesktop.org/libfprint/fprintd/-/archive/v${version}/fprintd-v${version}.tar.bz2"
+checksum=7f39777b858142730ac89ffa41c0d2dc1a26a01535291f3f5f9b3adb2d28ffc9
 
-CFLAGS="-fcommon"
-
-pre_configure() {
-	glib-gettextize -c -f
-	gtkdocize --copy
-	intltoolize -c -f
-	libtoolize -c
-	aclocal
-	autoconf
-	autoheader
-	automake -a -c
+post_patch() {
+	vsed -i -e "/^systemd_dep *=/d" meson.build
 }
 
 post_install() {
-	mv $DESTDIR/etc/$pkgname/dbus-1 $DESTDIR/usr/share/dbus-1
-	vmkdir usr/share/dbus-1/system.d
-	mv $DESTDIR/usr/share/dbus-1/dbus-1/system.d/net.reactivated.Fprint.conf $DESTDIR/usr/share/dbus-1/system.d/
+	rm -rf $DESTDIR/not-systemd
 }

--- a/srcpkgs/libfprint/template
+++ b/srcpkgs/libfprint/template
@@ -1,19 +1,20 @@
 # Template file for 'libfprint'
 pkgname=libfprint
-version=1.0
+version=1.90.6
 revision=1
-wrksrc="libfprint-V_${version//./_}"
+wrksrc="libfprint-v${version}"
 build_style=meson
+build_helper=gir
 configure_args="-Dudev_rules=false -Dx11-examples=false -Dgtk-examples=false -Ddoc=false"
-hostmakedepends="pkg-config"
-makedepends="libusb-devel nss-devel glib-devel gdk-pixbuf-devel pixman-devel"
+hostmakedepends="pkg-config cmake glib-devel"
+makedepends="gobject-introspection libgusb-devel libusb-devel nss-devel glib-devel gdk-pixbuf-devel pixman-devel"
 short_desc="Support for consumer fingerprint reader devices"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/fprint/"
 changelog="https://gitlab.freedesktop.org/libfprint/libfprint/raw/master/NEWS"
-distfiles="https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/V_${version//./_}/libfprint-V_${version//./_}.tar.bz2"
-checksum=22777a1d202ef912395b94842ae6b531338c8d48a8a813616e846b1bc96c5ad9
+distfiles="https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v${version}/libfprint-v${version}.tar.bz2"
+checksum=ca6199ece086c0042d16ab432783ee989a733f27ecceeef2b48c075ceb503972
 
 post_install() {
 	vmkdir usr/lib/udev/rules.d

--- a/srcpkgs/pam_wrapper/template
+++ b/srcpkgs/pam_wrapper/template
@@ -1,0 +1,24 @@
+# Template file for 'pam_wrapper'
+pkgname=pam_wrapper
+version=1.1.3
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_BUILD_TYPE=None -DUNIT_TESTING=ON"
+hostmakedepends="cmake"
+makedepends="python3-devel pam-devel cmocka-devel"
+short_desc="Tool to test PAM applications and modules"
+maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://cwrap.org/pam_wrapper.html"
+distfiles="https://www.samba.org/ftp/cwrap/pam_wrapper-${version}.tar.gz"
+checksum=4feedd788c6fa36516f6d6060482cd86455998d72849eb5f539de48915bdc5f3
+lib32disabled=yes
+
+python3-pypamtest_package() {
+	lib32disabled=yes
+	short_desc+=" - Python 3 bindings"
+	depends="${sourcepkg}-${version}_${revision} python3"
+	pkg_install() {
+		vmove usr/lib/python*
+	}
+}

--- a/srcpkgs/python3-pypamtest
+++ b/srcpkgs/python3-pypamtest
@@ -1,0 +1,1 @@
+pam_wrapper


### PR DESCRIPTION
Builds successfully on x86_64. 
Tried building on aarch64, but it probably needs to be patched. I can't do that as I lack the experience/knowledge :/

fails with
`/usr/aarch64-linux-gnu/usr/bin/g-ir-scanner: line 10: /usr/bin/g-ir-scanner.wrapped: No such file or directory`

BTW this package hasn't been touched in a year.