### PR TITLE
sof-firmware: update to 1.6.1

### DIFF
--- a/srcpkgs/sof-firmware/template
+++ b/srcpkgs/sof-firmware/template
@@ -1,40 +1,38 @@
 # Template file for 'sof-firmware'
 pkgname=sof-firmware
-version=1.6rc3
+version=1.6.1
 revision=1
-_major=${version%rc*}
-_minor=${version#${_major}}
 archs="i686* x86_64*"
-wrksrc="sof-bin-${_major}-${_minor}"
+wrksrc="sof-bin-${version}"
 depends="alsa-ucm-conf"
 short_desc="Sound Open Firmware and topology binaries"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://thesofproject.github.io/latest/index.html"
-distfiles="https://github.com/thesofproject/sof-bin/archive/v${_major}-${_minor}.tar.gz"
-checksum=daefbeedfb26aa45ef73cc89d90f33dfb4c797244d40a00c8ac652ca3a5b4dce
+distfiles="https://github.com/thesofproject/sof-bin/archive/v${version}.tar.gz"
+checksum=587b320030bc84de1aacba5d86d89ba1a4f67201baf8b9b61bb885af60643bfb
 
 do_install() {
 	local intel_path="lib/firmware/intel"
-	for f in ${intel_path}/sof/v${_major}/*.{ldc,ri}; do
+	for f in ${intel_path}/sof/v${version}/*.{ldc,ri}; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof
 	done
-	for f in ${intel_path}/sof/v${_major}/intel-signed/*; do
+	for f in ${intel_path}/sof/v${version}/intel-signed/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof/intel-signed
 	done
-	for f in ${intel_path}/sof/v${_major}/public-signed/*; do
+	for f in ${intel_path}/sof/v${version}/public-signed/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof/public-signed
 	done
 	for arc in {bdw,byt,cht}; do
-		ln -s sof-${arc}-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
+		ln -s sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
 	done
 	for arc in {apl,cnl,icl}; do
-		ln -s intel-signed/sof-${arc}-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
+		ln -s intel-signed/sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
 	done
-	ln -s intel-signed/sof-apl-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
-	ln -s intel-signed/sof-cnl-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
-	ln -s intel-signed/sof-cnl-v${_major}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
-	for f in ${intel_path}/sof-tplg-v${_major}/*; do
+	ln -s intel-signed/sof-apl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
+	ln -s intel-signed/sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
+	ln -s intel-signed/sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
+	for f in ${intel_path}/sof-tplg-v${version}/*; do
 		vinstall ${f} 0644 /usr/${intel_path}/sof-tplg
 	done
 	vlicense LICENCE.NXP


### PR DESCRIPTION
In addition to updating to the newest stable version, this update uses sof-firmware's updated versioning scheme in which stable releases are actually stable.