### PR TITLE
New package: tiny-0.8.0

### DIFF
--- a/srcpkgs/tiny/template
+++ b/srcpkgs/tiny/template
@@ -1,0 +1,19 @@
+# Template file for 'tiny'
+pkgname=tiny
+version=0.8.0
+revision=1
+build_wrksrc="tiny"
+build_style=cargo
+configure_args="--no-default-features --features=desktop-notifications --features=tls-native"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel dbus-devel"
+short_desc="Tiny terminal IRC client"
+maintainer="eoli3n <jonathan.kirszling@runbox.com>"
+license="MIT"
+homepage="https://github.com/osa1/tiny"
+distfiles="https://github.com/osa1/tiny/archive/v${version}.tar.gz"
+checksum=acaf0b7c3515bdfd0c80b4a7274aec44d283025c6e40508e450525167f73e447
+
+post_install() {
+	vlicense ../LICENSE
+}


### PR DESCRIPTION
Closes https://github.com/void-linux/void-packages/issues/27180 and https://github.com/osa1/tiny/issues/286