### PR TITLE
enchant2: update to 2.2.14.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3741,7 +3741,7 @@ libheif.so.1 libheif-1.4.0_1
 libuninameslist.so.1 libuninameslist-20190701_1
 libgambit.so.4 gambit-4.9.3_1
 liblog4cpp.so.5 log4cpp-1.1.3_1
-libnuspell.so.3 libnuspell-3.0.0_1
+libnuspell.so.4 libnuspell-4.0.0_1
 liblog4c.so.3 log4c-1.2.4_1
 libqb.so.100 libqb-2.0.0_1
 libusbguard.so.0 usbguard-0.7.5_1

--- a/srcpkgs/enchant2/template
+++ b/srcpkgs/enchant2/template
@@ -1,20 +1,21 @@
 # Template file for 'enchant2'
 pkgname=enchant2
-version=2.2.13
+version=2.2.14
 revision=1
 wrksrc="enchant-${version}"
 build_style=gnu-configure
-make_build_args="pkgdatadir=/usr/share/enchant-2"
-make_install_args="$make_build_args"
+# tests need --enable-relocatable
+configure_args="--enable-relocatable"
 hostmakedepends="pkg-config"
 makedepends="libglib-devel hunspell-devel aspell-devel libvoikko-devel
  libnuspell-devel icu-devel boost-devel"
+checkdepends="unittest-cpp"
 short_desc="Generic spell checking library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://abiword.github.io/enchant/"
 distfiles="https://github.com/AbiWord/enchant/releases/download/v${version}/enchant-${version}.tar.gz"
-checksum=eab9f90d79039133660029616e2a684644bd524be5dc43340d4cfc3fb3c68a20
+checksum=bf7cc9a410b54c29648c7711dc8f210e7b13768508aaf43cc9c4527d5a9c7a8e
 
 enchant2-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/nuspell/template
+++ b/srcpkgs/nuspell/template
@@ -1,6 +1,6 @@
 # Template file for 'nuspell'
 pkgname=nuspell
-version=3.1.2
+version=4.2.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-3.0-or-later"
 homepage="https://nuspell.github.io/"
 distfiles="https://github.com/nuspell/nuspell/archive/v${version}.tar.gz"
-checksum=f59f8a27e97047f30659182f244daca8e05e052710c0ea5d845c2cb00f6c6eca
+checksum=01804d490bec517748ee49fa2f1249f4c99380c26335e32082cdaa02b5b2b4dc
 
 libnuspell_package() {
 	pkg_install() {


### PR DESCRIPTION
@Johnnynator Nuspell is yours, so asking for approval for it. enchant2 needs newer nuspell version to build.