### PR TITLE
common/hooks/{pre,post}-install: generalized libdir hook

### DIFF
--- a/common/hooks/post-install/00-lib32.sh
+++ b/common/hooks/post-install/00-lib32.sh
@@ -1,8 +1,0 @@
-# This hook removes the /usr/lib32 symlink on 32-bit systems.
-
-hook() {
-	if [ "$XBPS_TARGET_WORDSIZE" = "32" ] && \
-	   [ "${pkgname}" != "base-files" ]; then
-		rm -f ${PKGDESTDIR}/usr/lib32
-	fi
-}

--- a/common/hooks/post-install/00-libdir.sh
+++ b/common/hooks/post-install/00-libdir.sh
@@ -1,0 +1,7 @@
+# This hook removes the wordsize specific libdir symlink.
+
+hook() {
+	if [ "${pkgname}" != "base-files" ]; then
+		rm -f ${PKGDESTDIR}/usr/lib${XBPS_TARGET_WORDSIZE}
+	fi
+}

--- a/common/hooks/pre-install/00-lib32.sh
+++ b/common/hooks/pre-install/00-lib32.sh
@@ -1,9 +1,0 @@
-# This hook creates the /usr/lib32 symlink for 32-bit systems.
-
-hook() {
-	if [ "$XBPS_TARGET_WORDSIZE" = "32" ] && \
-	   [ "${pkgname}" != "base-files" ]; then
-		vmkdir usr/lib
-		ln -sf lib ${PKGDESTDIR}/usr/lib32
-	fi
-}

--- a/common/hooks/pre-install/00-libdir.sh
+++ b/common/hooks/pre-install/00-libdir.sh
@@ -1,0 +1,8 @@
+# This hook creates the wordsize specific libdir symlink.
+
+hook() {
+	if [ "${pkgname}" != "base-files" ]; then
+		vmkdir usr/lib
+		ln -sf lib ${PKGDESTDIR}/usr/lib${XBPS_TARGET_WORDSIZE}
+	fi
+}


### PR DESCRIPTION
this makes sure we don't have to worry about packages installing stuff in lib32/lib64, it will be automagically symlinked

if something is still left over for whatever reason, or if the opposite wordsize directory exists, that will be caught by pkglint

@Duncaen @ericonr @st3r4g