### PR TITLE
Aspell: force 32bit hash on all platforms

### DIFF
--- a/common/environment/configure/gnu-configure-args.sh
+++ b/common/environment/configure/gnu-configure-args.sh
@@ -4,8 +4,12 @@ if [ -n "$build_style" -a "$build_style" != "gnu-configure" ]; then
 	return 0
 fi
 
+# Store args from template so they can be included last and override
+# our defaults
+TEMPLATE_CONFIGURE_ARGS="${configure_args}"
+
 export configure_args="--prefix=/usr --sysconfdir=/etc --sbindir=/usr/bin --bindir=/usr/bin
- --mandir=/usr/share/man --infodir=/usr/share/info --localstatedir=/var ${configure_args}"
+ --mandir=/usr/share/man --infodir=/usr/share/info --localstatedir=/var"
 
 . ${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh
 export configure_args+=" --host=$XBPS_TRIPLET --build=$XBPS_TRIPLET"
@@ -29,11 +33,17 @@ esac
 
 # Cross compilation vars
 if [ -z "$CROSS_BUILD" ]; then
+	export configure_args+=" ${TEMPLATE_CONFIGURE_ARGS}"
+	unset TEMPLATE_CONFIGURE_ARGS
+
 	set +a
 	return 0
 fi
 
 export configure_args+=" --host=$XBPS_CROSS_TRIPLET --with-sysroot=$XBPS_CROSS_BASE --with-libtool-sysroot=$XBPS_CROSS_BASE "
+
+export configure_args+=" ${TEMPLATE_CONFIGURE_ARGS}"
+unset TEMPLATE_CONFIGURE_ARGS
 
 # Read autoconf cache variables for cross target (taken from OE).
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/aspell-cs/template
+++ b/srcpkgs/aspell-cs/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-cs'
 pkgname=aspell-cs
 version=20040614.1
-revision=2
+revision=3
 wrksrc="aspell6-cs-${version/./-}"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-de/template
+++ b/srcpkgs/aspell-de/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-de'
 pkgname=aspell-de
 version=20161207.7.0
-revision=2
+revision=3
 wrksrc="aspell6-de-${version//./-}"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-el/template
+++ b/srcpkgs/aspell-el/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-el'
 pkgname=aspell-el
 version=0.08.0
-revision=2
+revision=3
 _distver="${version%.*}-${version##*.}"
 wrksrc="aspell6-el-${_distver}"
 build_style=configure

--- a/srcpkgs/aspell-en/template
+++ b/srcpkgs/aspell-en/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-en'
 pkgname=aspell-en
 version=2020.12.07
-revision=1
+revision=2
 wrksrc="aspell6-en-${version}-0"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-fr/template
+++ b/srcpkgs/aspell-fr/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-fr'
 pkgname=aspell-fr
 version=0.50.3
-revision=3
+revision=4
 wrksrc="aspell-fr-0.50-3"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-pl/template
+++ b/srcpkgs/aspell-pl/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-pl'
 pkgname=aspell-pl
 version=20061121
-revision=2
+revision=3
 wrksrc="aspell6-pl-6.0_${version}-0"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell-ru/template
+++ b/srcpkgs/aspell-ru/template
@@ -1,7 +1,7 @@
 # Template file for 'aspell-ru'
 pkgname=aspell-ru
 version=0.99f7
-revision=3
+revision=4
 wrksrc="aspell6-ru-${version}-1"
 build_style=configure
 hostmakedepends="aspell-devel which"

--- a/srcpkgs/aspell/template
+++ b/srcpkgs/aspell/template
@@ -1,9 +1,16 @@
 # Template file for 'aspell'
 pkgname=aspell
 version=0.60.8
-revision=2
+revision=3
 build_style=gnu-configure
-configure_args="--enable-compile-in-filters"
+# we need to force aspell to use /usr/lib for data for two reasons:
+# - in multilib systems, it should use the native dicts instead of requiring
+#   that a dict be installed twice
+# - when cross compiling packages, it's aspell that determines where the dicts
+#   are to be installed; the build will error out if it tries to install the
+#   dictionaries into /usr/lib64 for 32-bit targets
+configure_args="--enable-compile-in-filters --enable-32-bit-hash-fun
+ --libdir=/usr/lib"
 hostmakedepends="automake libtool gettext-devel perl"
 makedepends="ncurses-devel"
 depends="perl"


### PR DESCRIPTION
See https://github.com/void-linux/void-packages/issues/16659

The other solutions are either

- an aspell-32bit-compat package to cross build for 32bit archs on 64bit host
- adding plumbing around all dictionary packages to use qemu (which will break next time someone adds a dictionary)

Since neither of those are great, I went with the simplest one.