### PR TITLE
cni-plugins: update to 0.9.0.

### DIFF
--- a/srcpkgs/cni-plugins/template
+++ b/srcpkgs/cni-plugins/template
@@ -1,6 +1,6 @@
 # Template file for 'cni-plugins'
 pkgname=cni-plugins
-version=0.8.7
+version=0.9.0
 revision=1
 wrksrc="plugins-${version}"
 build_style=go
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containernetworking/plugins"
 distfiles="https://github.com/containernetworking/plugins/archive/v${version}.tar.gz"
-checksum=de9fa170b4b6d38f6ff5287b313ddaf3c31f70bccb10e971ad59adadae22dd74
+checksum=54abd2fb7762943ff57832dfba19de12db09f0a0f8e69b31f1a2bb2baca395e7
 
 do_build() {
 	./build_linux.sh


### PR DESCRIPTION
Fairly uneventful release. There was a small behavior change on the host-device plugin.

https://github.com/containernetworking/plugins/releases/tag/v0.9.0