### PR TITLE
yosys: fix build generating files containing /usr/local

### DIFF
--- a/srcpkgs/yosys/template
+++ b/srcpkgs/yosys/template
@@ -1,9 +1,10 @@
 # Template file for 'yosys'
 pkgname=yosys
 version=0.9
-revision=2
+revision=3
 wrksrc=${pkgname}-${pkgname}-${version}
 build_style=gnu-makefile
+make_build_args="PREFIX=/usr"
 make_use_env=yes
 hostmakedepends="python3 bison flex pkg-config clang git tcl readline"
 makedepends="tcl-devel readline-devel libffi-devel"


### PR DESCRIPTION
Without this, yosys-config (and probably some other things) refer to /usr/local rather than /usr