### PR TITLE
xfce4-4.16

### DIFF
--- a/srcpkgs/Thunar/template
+++ b/srcpkgs/Thunar/template
@@ -1,6 +1,6 @@
 # Template file for 'Thunar'
 pkgname=Thunar
-version=1.8.16
+version=4.16.0
 revision=1
 wrksrc=thunar-${version}
 build_style=gnu-configure
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://docs.xfce.org/xfce/thunar/Start"
 changelog="https://raw.githubusercontent.com/xfce-mirror/thunar/master/NEWS"
 distfiles="https://archive.xfce.org/src/xfce/thunar/${version%.*}/thunar-${version}.tar.bz2"
-checksum=221338b1cbf14cbee2b9091f9b4e4f47cf6bc9513bbb113762da7ca4f8173c4c
+checksum=6277c448116a91ebfa564972645d8d79ef69864992a02bb164b7b13f98fdfd9b
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/systemd

--- a/srcpkgs/exo/template
+++ b/srcpkgs/exo/template
@@ -1,19 +1,18 @@
 # Template file for 'exo'
 pkgname=exo
-version=0.12.11
+version=4.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
-hostmakedepends="xfce4-dev-tools pkg-config intltool gettext-devel glib-devel perl-URI"
+hostmakedepends="xfce4-dev-tools pkg-config intltool gettext-devel glib-devel"
 makedepends="gtk+-devel libxfce4ui-devel"
-depends="hicolor-icon-theme desktop-file-utils perl-URI"
+depends="hicolor-icon-theme desktop-file-utils"
 short_desc="Extension library for the Xfce desktop environment"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/exo/${version%.*}/exo-${version}.tar.bz2"
-checksum=ec892519c08a67f3e0a1f0f8d43446e26871183e5aa6be7f82e214f388d1e5b6
-conf_files="/etc/xdg/xfce4/helpers.rc"
+checksum=1975b00eed9a8aa1f899eab2efaea593731c19138b83fdff2f13bdca5275bacc
 
 pre_configure() {
 	if [ "$CROSS_BUILD" ]; then
@@ -31,8 +30,6 @@ exo-devel_package() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-		vmove usr/bin/exo-csource
-		vmove usr/share/man/man1/exo-csource.1
 		vmove "usr/share/*doc"
 	}
 }

--- a/srcpkgs/garcon/template
+++ b/srcpkgs/garcon/template
@@ -1,6 +1,6 @@
 # Template file for 'garcon'
 pkgname=garcon
-version=0.7.0
+version=0.8.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/garcon/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=82c3b61b508011642b09e6fb01b1d3f22c4e4de0fc54a9244327d0ddb66b2423
+checksum=4811d89ee5bc48dbdeffd69fc3eec6c112bbf01fde98a9e848335b374a4aa1bb
 
 garcon-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} libxfce4ui-devel gtk+3-devel"

--- a/srcpkgs/libxfce4ui/template
+++ b/srcpkgs/libxfce4ui/template
@@ -1,7 +1,7 @@
 # Template file for 'libxfce4ui'
 pkgname=libxfce4ui
-version=4.14.1
-revision=5
+version=4.16.0
+revision=1
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-static"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=c449075eaeae4d1138d22eeed3d2ad7032b87fb8878eada9b770325bed87f2da
+checksum=8b06c9e94f4be88a9d87c47592411b6cbc32073e7af9cbd64c7b2924ec90ceaa
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/libxfce4util/template
+++ b/srcpkgs/libxfce4util/template
@@ -1,6 +1,6 @@
 # Template file for 'libxfce4util'
 pkgname=libxfce4util
-version=4.14.0
+version=4.16.0
 revision=1
 build_style=gnu-configure
 build_helper="gir"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=32ad79b7992ec3fd863e8ff2f03eebda8740363ef9d7d910a35963ac1c1a6324
+checksum=60598d745d1fc81ff5ad3cecc3a8d1b85990dd22023e7743f55abd87d8b55b83
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/mousepad/template
+++ b/srcpkgs/mousepad/template
@@ -1,6 +1,6 @@
 # Template file for 'mousepad'
 pkgname=mousepad
-version=0.5.0
+version=0.5.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="glib-devel intltool pkg-config"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/apps/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=10366d490cfc9b7f30400496d3fc0be7de8ad91a95d588b43ace0e464220708b
+checksum=3d2e277b1ae82dd0f0fa25e27169491fc38c2b70a9a624f2ea472604b317a582

--- a/srcpkgs/thunar-volman/template
+++ b/srcpkgs/thunar-volman/template
@@ -1,6 +1,6 @@
 # Template file for 'thunar-volman'
 pkgname=thunar-volman
-version=4.15.1
+version=4.16.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
@@ -12,4 +12,4 @@ license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 changelog="https://git.xfce.org/xfce/thunar-volman/plain/NEWS?h=${pkgname}-${version}"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=7528cd48d58467411cbcfeacb0e6ac24349952fc3d92d975d0e8fd341d43076b
+checksum=d2c0e719b242b7fd3db70bc6678a2df1abf2cfaa899b775a1591a5efa08a547d

--- a/srcpkgs/tumbler/template
+++ b/srcpkgs/tumbler/template
@@ -1,6 +1,6 @@
 # Template file for 'tumbler'
 pkgname=tumbler
-version=0.3.1
+version=4.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-gstreamer-thumbnailer"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=e4a30f3c0656b5b29fcd4a2450293f20f283a95b7fb0754a947c55427784c454
+checksum=9b0b7fed0c64041733d490b1b307297984629d0dd85369749617a8766850af66
 
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
 

--- a/srcpkgs/xfce4-appfinder/template
+++ b/srcpkgs/xfce4-appfinder/template
@@ -1,6 +1,6 @@
 # Template file for 'xfce4-appfinder'
 pkgname=xfce4-appfinder
-version=4.14.0
+version=4.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-gtk3"
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=7ec175d4954fceb2e76cbfbca76ac4a4f53fe799d097a14117e7de68e88a4d98
+checksum=37b92aaaeeec8220ed23163cf89321168d3b49e0c48b4c10f12dc4a21fdf0954

--- a/srcpkgs/xfce4-dev-tools/template
+++ b/srcpkgs/xfce4-dev-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'xfce4-dev-tools'
 pkgname=xfce4-dev-tools
-version=4.14.0
+version=4.16.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool gtk-doc intltool pkg-config"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=2c9eb8e0fe23e47dc31411a93b683fd1b7a49140e9163f0aab9e94a3d8a0b5fd
+checksum=f50b3070e66f3ebdf331744dd1ec5e1af5de333965d491e15ce05545e8eb4f04

--- a/srcpkgs/xfce4-panel/template
+++ b/srcpkgs/xfce4-panel/template
@@ -1,6 +1,6 @@
 # Template file for 'xfce4-panel'
 pkgname=xfce4-panel
-version=4.14.4
+version=4.16.0
 revision=1
 build_style=gnu-configure
 build_helper="gir"
@@ -8,11 +8,11 @@ configure_args="--disable-static --enable-gio-unix --enable-gtk3"
 hostmakedepends="xfce4-dev-tools pkg-config intltool gettext-devel glib-devel"
 makedepends="libwnck-devel libxfce4ui-devel xfconf-devel garcon-devel exo-devel"
 short_desc="Next generation panel for the XFCE desktop environment"
-maintainer="Peter Bui <pbui@github.bx612.space>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=8e5ea79412ba84cfada897ff309cbe2cd4aca16b9bd4f93df060229528576fd5
+checksum=5e979aeeb37d306d72858b1bc67448222ea7a68de01409055b846cd31f3cc53d
 
 # Package build options
 build_options="gir"

--- a/srcpkgs/xfce4-power-manager/patches/void.patch
+++ b/srcpkgs/xfce4-power-manager/patches/void.patch
@@ -14,9 +14,9 @@
  #define UP_BACKEND_SUSPEND_COMMAND	"/usr/sbin/zzz"
  #define UP_BACKEND_HIBERNATE_COMMAND "/usr/sbin/ZZZ"
  #endif
---- src/xfpm-suspend.c.orig	2019-08-13 12:19:21.476080088 +0200
-+++ src/xfpm-suspend.c	2019-08-13 12:20:59.699286887 +0200
-@@ -101,35 +101,6 @@ freebsd_supports_sleep_state (const gcha
+--- src/xfpm-suspend.c.orig	2020-12-22 20:56:08.139119371 -0500
++++ src/xfpm-suspend.c	2020-12-22 20:56:52.359241485 -0500
+@@ -105,40 +105,6 @@
  }
  #endif
  
@@ -24,49 +24,54 @@
 -static gboolean
 -linux_supports_sleep_state (const gchar *state)
 -{
--    gboolean ret = FALSE;
--    gchar *command;
--    GError *error = NULL;
--    gint exit_status;
+-  gboolean ret = FALSE;
+-  gchar *command;
+-  GError *error = NULL;
+-  gint exit_status;
 -
--    XFPM_DEBUG("entering");
+-  XFPM_DEBUG("entering");
 -
--    /* run script from pm-utils */
--    command = g_strdup_printf ("/usr/bin/pm-is-supported --%s", state);
--    g_debug ("executing command: %s", command);
--    ret = g_spawn_command_line_sync (command, NULL, NULL, &exit_status, &error);
--    if (!ret) {
--        g_warning ("failed to run script: %s", error->message);
--        g_error_free (error);
--        goto out;
+-  /* run script from pm-utils */
+-  command = g_strdup_printf ("/usr/bin/pm-is-supported --%s", state);
+-  g_debug ("executing command: %s", command);
+-  ret = g_spawn_command_line_sync (command, NULL, NULL, &exit_status, &error);
+-
+-  if (!ret) {
+-    if (error)
+-    {
+-      g_warning ("failed to run script: %s", error->message);
+-      g_error_free (error);
 -    }
--    ret = (WIFEXITED(exit_status) && (WEXITSTATUS(exit_status) == EXIT_SUCCESS));
+-    goto out;
+-  }
+-  ret = (WIFEXITED(exit_status) && (WEXITSTATUS(exit_status) == EXIT_SUCCESS));
 -
 -out:
--    g_free (command);
+-  g_free (command);
 -
--    return ret;
+-  return ret;
 -}
 -#endif
 -
- 
+-
  gboolean
  xfpm_suspend_can_suspend (void)
-@@ -139,7 +110,7 @@ xfpm_suspend_can_suspend (void)
-     return freebsd_supports_sleep_state ("S3");
+ {
+@@ -147,7 +113,7 @@
+   return freebsd_supports_sleep_state ("S3");
  #endif
  #ifdef BACKEND_TYPE_LINUX
--    return linux_supports_sleep_state ("suspend");
-+    return TRUE;
+-  return linux_supports_sleep_state ("suspend");
++  return TRUE;
  #endif
  #ifdef BACKEND_TYPE_OPENBSD
-     return TRUE;
-@@ -156,7 +127,7 @@ xfpm_suspend_can_hibernate (void)
-     return freebsd_supports_sleep_state ("S4");
+   return TRUE;
+@@ -164,7 +130,7 @@
+   return freebsd_supports_sleep_state ("S4");
  #endif
  #ifdef BACKEND_TYPE_LINUX
--    return linux_supports_sleep_state ("hibernate");
-+    return TRUE;
+-  return linux_supports_sleep_state ("hibernate");
++  return TRUE;
  #endif
  #ifdef BACKEND_TYPE_OPENBSD
-     return TRUE;
+   return TRUE;

--- a/srcpkgs/xfce4-power-manager/template
+++ b/srcpkgs/xfce4-power-manager/template
@@ -1,7 +1,6 @@
 # Template file for 'xfce4-power-manager'
 pkgname=xfce4-power-manager
-reverts=1.7.0_1
-version=1.6.6
+version=4.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
@@ -13,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=1b7bf0d3e8af69b10f7b6a518451e01fc7888e0d9d360bc33f6c89179bb6080b
+checksum=eb9c587c01b502fa45a32e7fc2aba98fa6d8391475133883654f77e562c43bf3

--- a/srcpkgs/xfce4-session/template
+++ b/srcpkgs/xfce4-session/template
@@ -1,6 +1,6 @@
 # Template file for 'xfce4-session'
 pkgname=xfce4-session
-version=4.14.2
+version=4.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --enable-polkit"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/$pkgname/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=fbe3a4a60c91589a2024ce12b2d2667625a8fedcbc90ef031831f56319f597af
+checksum=22f273f212481d71e0b5618c62710cd85f69aea74f5ea5c0093f7918b07d17b7
 
 post_install() {
 	# startxfce4 needs bash.

--- a/srcpkgs/xfce4-settings/template
+++ b/srcpkgs/xfce4-settings/template
@@ -1,6 +1,6 @@
 # Template file for 'xfce4-settings'
 pkgname=xfce4-settings
-version=4.14.3
+version=4.16.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-sound-settings --enable-pluggable-dialogs"
@@ -15,4 +15,4 @@ license="GPL-2.0-only"
 homepage="https://xfce.org/"
 changelog="https://raw.githubusercontent.com/xfce-mirror/xfce4-settings/xfce-4.14/NEWS"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=cab1a4d5351f9871533700523570f86f92bbe6e4055f44e5df950eb4b4f48bb3
+checksum=67a1404fc754c675c6431e22a8fe0e5d79644fdfadbfe25a4523d68e1442ddc2

--- a/srcpkgs/xfce4-terminal/template
+++ b/srcpkgs/xfce4-terminal/template
@@ -1,6 +1,6 @@
 # Template file for 'xfce4-terminal'
 pkgname=xfce4-terminal
-version=0.8.9.2
+version=0.8.10
 revision=1
 build_style=gnu-configure
 hostmakedepends="intltool pkg-config"
@@ -10,5 +10,5 @@ short_desc="Modern terminal emulator primarly for the Xfce desktop environment"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
-distfiles="https://archive.xfce.org/src/apps/${pkgname}/${version%.*.*}/${pkgname}-${version}.tar.bz2"
-checksum=9ba23bf86d350ef8a95d2dfb50bbd1bbb2144d82985a779ec28caf47faaeeeeb
+distfiles="https://archive.xfce.org/src/apps/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
+checksum=7a3337c198e01262a0412384823185753ac8a0345be1d6776a7e9bbbcbf33dc7

--- a/srcpkgs/xfce4/template
+++ b/srcpkgs/xfce4/template
@@ -1,7 +1,7 @@
 # Template file for 'xfce4'
 pkgname=xfce4
-version=4.14.0
-revision=2
+version=4.16.0
+revision=1
 build_style=meta
 depends="
 	xfce4-appfinder>=${version}
@@ -12,23 +12,23 @@ depends="
 	xfdesktop>=${version}
 	xfwm4>=${version}
 	xfwm4-themes>=4.10.0
-	xfce4-power-manager>=1.6.5
-	xfce4-terminal>=0.8.8
-	xfce4-taskmanager>=1.2.2
-	Thunar>=1.8.9
-	thunar-volman>=0.9.5
-	exo>=0.12.8
-	parole>=1.0.3
+	xfce4-power-manager>=${version}
+	xfce4-terminal>=0.8.10
+	xfce4-taskmanager>=1.2.3
+	Thunar>=${version}
+	thunar-volman>=${version}
+	exo>=${version}
+	parole>=1.0.5
 	ristretto>=0.10.0
-	mousepad>=0.4.1
-	xfce4-notifyd>=0.4.4
-	xfce4-screensaver>=0.1.4
-	tumbler>=0.2.7
+	mousepad>=0.5.1
+	xfce4-notifyd>=0.6.2
+	xfce4-screensaver>=0.1.11
+	tumbler>=${version}
 	xdg-user-dirs-gtk
 	upower
 	elogind
 	xfce-polkit"
 short_desc="XFCE meta-package for Void Linux"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2, LGPL-2.1, BSD"
+license="GPL-2.0-or-later"
 homepage="https://xfce.org/"

--- a/srcpkgs/xfconf/template
+++ b/srcpkgs/xfconf/template
@@ -1,23 +1,25 @@
 # Template file for 'xfconf'
 pkgname=xfconf
-version=4.14.4
+version=4.16.0
 revision=1
 build_helper=gir
 build_style=gnu-configure
-configure_args="--enable-gsettings-backend
- $(vopt_enable perl 'perl-bindings --with-perl-options=INSTALLDIRS=vendor')"
+configure_args="--enable-gsettings-backend"
 hostmakedepends="pkg-config intltool glib-devel vala-devel"
-makedepends="libxfce4util-devel vala-devel
-$(vopt_if perl 'perl-ExtUtils-Depends perl-ExtUtils-PkgConfig perl-Glib')"
+makedepends="libxfce4util-devel vala-devel"
+checkdepends="dbus xvfb-run"
 short_desc="Xfce hierarchical (tree-like) configuration system"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, LGPL-2.0-only"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/xfconf/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=cc37622eece51ed8905dfaad6f77b3c24662f41881545eb0142110f347ba5f73
-# XXX: perl bindings will be removed in >=4.15
-build_options="perl gir"
+checksum=652a119007c67d9ba6c0bc7a740c923d33f32d03dc76dfc7ba682584e72a5425
+build_options="gir"
 build_options_default="gir"
+
+do_check() {
+	dbus-run-session xvfb-run make check
+}
 
 xfconf-devel_package() {
 	depends="dbus-glib-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/xfdesktop/template
+++ b/srcpkgs/xfdesktop/template
@@ -1,6 +1,6 @@
 # Template file for 'xfdesktop'
 pkgname=xfdesktop
-version=4.14.3
+version=4.16.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool glib-devel Thunar-devel"
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/xfdesktop/${version%.*}/$pkgname-$version.tar.bz2"
-checksum=06d7d08f41a847f539e9aeb52ed715f960255dc1b2162a60e5f90661892a5793
+checksum=934ba5affecff21e62d9fac1dd50c50cd94b3a807fefa5f5bff59f3d6f155bae

--- a/srcpkgs/xfwm4/template
+++ b/srcpkgs/xfwm4/template
@@ -1,6 +1,6 @@
 # Template file for 'xfwm4'
 pkgname=xfwm4
-version=4.14.6
+version=4.16.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
@@ -13,4 +13,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/xfwm4/${version%.*}/xfwm4-${version}.tar.bz2"
-checksum=ac6fa8b09d34090fb9ad81d8b7fb0455a10eccf500396b644afa2b9c2444142f
+checksum=1e22eae1bbb66cebfd1753b0a5606e76ecbf6b09ce4cdfd732d093c936f1feb3


### PR DESCRIPTION
Updated core xfce4 packages to 4.16.0 as listed here: https://gitlab.xfce.org/xfce.  [ChangeLog](https://xfce.org/download/changelogs/4.16/)

Built and tested on x86_64.  Also built for x86_64-musl (but didn't test).