### PR TITLE
ckb-next: update to 0.4.3, default to use pulseaudio

### DIFF
--- a/srcpkgs/ckb-next/template
+++ b/srcpkgs/ckb-next/template
@@ -1,18 +1,22 @@
 # Template file for 'ckb-next'
 pkgname=ckb-next
-version=0.4.2
+version=0.4.3
 revision=1
 build_style=cmake
 configure_args="-DDISABLE_UPDATER=1 -DUDEV_RULE_DIRECTORY=/usr/lib/udev/rules.d"
-hostmakedepends="qt5-devel"
-makedepends="qt5-devel quazip-qt5-devel eudev-libudev-devel $(vopt_if pulseaudio pulseaudio-devel)"
+hostmakedepends="qt5-devel pkg-config"
+makedepends="eudev-libudev-devel libdbusmenu-qt5-devel qt5-devel
+ qt5-tools-devel qt5-x11extras-devel quazip-qt5-devel xcb-util-wm-devel
+ $(vopt_if pulseaudio pulseaudio-devel)"
+depends="$(vopt_if pulseaudio pulseaudio)"
 short_desc="Corsair RGB Driver for Linux"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ckb-next/ckb-next"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=75b6908d5590c293dee8258a83d4ebe206306d3df9f867596e953ef7c6a86440
+checksum=e4fbd14227ecc63fad9eaf705ca61defd7b44bcaa3ad29aae18cd8a69bbc9ef9
 build_options="pulseaudio"
+build_options_default="pulseaudio"
 desc_option_pulseaudio="Enable support for music visualizer animation"
 
 CFLAGS="-fcommon"


### PR DESCRIPTION
As upstream is deprecating optional dependencies, pulseaudio will most probably a hard dependency for the next release. As 0.4.3 is still builable without pulseaudio, I left the vopt's in for now, but defaulted pulseaudio to ON at this stage.

The vopt's will most probably removed with the update to 0.4.4.