### PR TITLE
New package: neochat-1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4040,3 +4040,4 @@ libndr-samba4.so samba-libs-4.13.2_1
 libsmb-transport-samba4.so samba-libs-4.13.2_1
 libutil-cmdline-samba4.so samba-libs-4.13.2_1
 libwinbind-client-samba4.so samba-libs-4.13.2_1
+libQuotient.so.0.6 libQuotient-0.6.2_1

--- a/srcpkgs/kquickimageeditor-devel
+++ b/srcpkgs/kquickimageeditor-devel
@@ -1,0 +1,1 @@
+kquickimageeditor

--- a/srcpkgs/kquickimageeditor/patches/Remove-werror.patch
+++ b/srcpkgs/kquickimageeditor/patches/Remove-werror.patch
@@ -1,0 +1,20 @@
+diff --git src/CMakeLists.txt src/CMakeLists.txt
+Source: https://invent.kde.org/libraries/kquickimageeditor/-/commit/c79657496326c10f81cf80a8c9a0e55bc2ba2798
+Issue: https://invent.kde.org/libraries/kquickimageeditor/-/issues/1
+---
+index 301c05e5efe557970b528b14f9d9c46911b0f684..99b0a8731b5cdc32ee2ccc7b9490152a815ebaed 100644
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -33,12 +33,6 @@ add_library(
+     ${sources} ${pluginData}
+ )
+ 
+-target_compile_options(
+-    kquickimageeditorplugin
+-    PRIVATE
+-        -Werror
+-)
+-
+ target_link_libraries(
+     kquickimageeditorplugin
+     PRIVATE

--- a/srcpkgs/kquickimageeditor/template
+++ b/srcpkgs/kquickimageeditor/template
@@ -1,0 +1,26 @@
+# Template file for 'kquickimageeditor'
+pkgname=kquickimageeditor
+version=0.1.2
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools"
+makedepends="qt5-declarative-devel"
+short_desc="QML image editing components"
+maintainer="Nathan Owens <ndowens@artixlinux.org>"
+license="LGPL-2.1-or-later, BSD-2-Clause, CC0-1.0"
+homepage="https://invent.kde.org/libraries/kquickimageeditor"
+distfiles="${KDE_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
+checksum=37d54981a1c7dbb48ca45a7df37b8871bf1751e4c0484eeaddc548804ee18a04
+
+post_install() {
+	vlicense LICENSES/BSD-2-Clause.txt
+}
+
+kquickimageeditor-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/lib/qt5/mkspecs
+		vmove usr/lib/cmake
+	}
+}

--- a/srcpkgs/libQuotient-devel
+++ b/srcpkgs/libQuotient-devel
@@ -1,0 +1,1 @@
+libQuotient

--- a/srcpkgs/libQuotient/template
+++ b/srcpkgs/libQuotient/template
@@ -1,0 +1,29 @@
+# Template file for 'libQuotient'
+pkgname=libQuotient
+version=0.6.2
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=1"
+hostmakedepends="qt5-qmake qt5-host-tools"
+makedepends="qt5-multimedia-devel"
+short_desc="Qt library to write cross-platform Matrix clients"
+maintainer="Nathan Owens <ndowens@artixlinux.org>"
+license="LGPL-2.1-or-later"
+homepage="https://matrix.org/docs/projects/sdk/quotient"
+distfiles="https://github.com/quotient-im/libQuotient/archive/$version/$pkgname-$version.tar.gz"
+checksum=afa9ee64327b9fdbf1d8514ec9b1374b797560b43315911211f723acf01ff317
+# libqmatrixclient was the old name,
+# until we can fully remove after
+# Quaternion has a new release
+conflicts="libqmatrixclient>=0"
+
+libQuotient-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/cmake
+		vmove usr/lib/pkgconfig
+	}
+}

--- a/srcpkgs/neochat/template
+++ b/srcpkgs/neochat/template
@@ -1,0 +1,21 @@
+# Template file for 'neochat'
+pkgname=neochat
+version=1.0
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules gettext pkg-config qt5-qmake
+ qt5-host-tools kcoreaddons kconfig"
+makedepends="cmark-devel qt5-declarative-devel qt5-devel qt5-multimedia-devel
+ qt5-quickcontrols2-devel qt5-svg-devel ki18n-devel kirigami2-devel
+ knotifications-devel kconfig-devel kcoreaddons-devel qtkeychain-qt5-devel
+ kdbusaddons-devel kquickimageeditor-devel libQuotient-devel"
+short_desc="Client for matrix from KDE"
+maintainer="Nathan Owens <ndowens@artixlinux.org>"
+license="GPL-3.0-only, GPL-3.0-or-later, GPL-2.0-or-later, BSD-2-Clause"
+homepage="https://apps.kde.org/en/neochat"
+distfiles="${KDE_SITE}/neochat/$version/neochat-$version.tar.xz"
+checksum=45231249f5af93d3cb56763a9aab1211f26916eedd7af732f9c945c58f8289c4
+
+post_install() {
+	vlicense LICENSES/BSD-2-Clause.txt
+}


### PR DESCRIPTION
libQuotient was renamed from libqmatrixclient. The current version of Quaternion looks for libqmatrixclient. Once new version of Quaternion is released we can remove libqmatrixclient. So add conflict with libqmatrixclient until then