### PR TITLE
void-docs: update to 2020.12.23.

### DIFF
--- a/srcpkgs/void-docs/template
+++ b/srcpkgs/void-docs/template
@@ -1,14 +1,14 @@
 # Template file for 'void-docs'
 pkgname=void-docs
-version=2020.08.18
-revision=3
-hostmakedepends="mdBook fd pandoc texlive perl perl-JSON"
+version=2020.12.23
+revision=1
+hostmakedepends="mdBook fd pandoc texlive perl perl-JSON librsvg-utils"
 short_desc="Documentation for Void Linux"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="CC-BY-SA-4.0"
 homepage="https://github.com/void-linux/void-docs"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=52b621a3d15ba4c5f5a33a6c1a27efa5bde9739334d277f22026bfd603f6f24b
+checksum=bc6f25392b14b3de33378fbfe84a93e4838cba21603cc9d742fd842ab32c4db5
 
 export PREFIX=/usr
 
@@ -22,7 +22,7 @@ do_install() {
 }
 
 void-docs-browse_package() {
-	depends="${sourcepkg}>=${version}_${revision} fzf mdcat"
+	depends="${sourcepkg}>=${version}_${revision} skim mdcat"
 	short_desc+=" - browsing utilities"
 	build_style=meta
 }


### PR DESCRIPTION
Use skim instead of fzf in void-docs-browse for better compatibility
across our supported architectures: rust is slightly more portable than
Go.