### PR TITLE
New package: font-vazir-code-1.1.2

### DIFF
--- a/srcpkgs/font-vazir-code/template
+++ b/srcpkgs/font-vazir-code/template
@@ -1,0 +1,22 @@
+# Template file for 'font-vazir-code'
+pkgname=font-vazir-code
+version=1.1.2
+revision=1
+create_wrksrc=yes
+depends="font-util"
+short_desc="Persian (farsi) monospaced font"
+maintainer="mkf <makefile@riseup.net>"
+license="Public Domain , custom:bitstream"
+homepage="https://github.com/rastikerdar/vazir-code-font"
+distfiles="https://github.com/rastikerdar/vazir-code-font/releases/download/v${version}/vazir-code-font-v${version}.zip"
+checksum=5c10819faef1d281db03703a82d498815b3d73b83badfa3100f9bbcd893b071e
+
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir usr/share/fonts/TTF
+	for f in ./*.ttf; do
+		vinstall "$f" 644 usr/share/fonts/TTF
+	done
+	vlicense LICENSE
+}


### PR DESCRIPTION
This font support of persian/farsi glyphes  in monospaced fonts, which is not found in other already added persian/farsi fonts.