### PR TITLE
crosstoolchain build-style

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -960,6 +960,16 @@ via `make_install_target`.
 via `configure_args`, the meson command can be overridden by `meson_cmd` and the location of
 the out of source build by `meson_builddir`
 
+- `void-cross` For cross-toolchain packages used to build Void systems. You will need to
+specify `cross_triplet` (corresponds to the target triplet specified in the cross profile
+for the target arch), `cross_linux_arch` (the architecture name in the Linux kernel source)
+and when building Go support for musl targets, also `cross_libucontext_arch` (see `libucontext`
+for available ones). Optionally, `cross_gcc_skip_go` can be specified. Individual subproject
+configure arguments can be specified via `cross_*_configure_args` where `*` is `binutils`,
+`gcc_bootstrap` (early gcc), `gcc` (final gcc), `glibc` (or `musl`), `configure_args` is
+additionally passed to both early and final `gcc`. You can also specify custom `CFLAGS`
+and `LDFLAGS` for the libc as `cross_(glibc|musl)_(cflags|ldflags)`.
+
 For packages that use the Python module build method (`setup.py` or
 [PEP 517](https://www.python.org/dev/peps/pep-0517/)), you can choose one of the following:
 

--- a/common/build-style/void-cross.sh
+++ b/common/build-style/void-cross.sh
@@ -1,0 +1,591 @@
+#
+# This helper is for void system crosstoolchain templates.
+#
+# Mandatory variables:
+#
+# - cross_triplet - the target triplet (e.g. aarch64-linux-gnu)
+# - cross_linux_arch - the source ARCH of the kernel (e.g. arm64)
+# - cross_libucontext_arch - only on musl without cross_gcc_skip_go
+#
+# Optional variables:
+#
+# - cross_gcc_skip_go - do not build gccgo support
+# - cross_binutils_configure_args
+# - cross_gcc_bootstrap_configure_args
+# - cross_gcc_configure_args
+# - cross_glibc_cflags
+# - cross_glibc_ldflags
+# - cross_glibc_configure_args
+# - cross_musl_cflags
+# - cross_musl_ldflags
+# - cross_musl_configure_args
+#
+# configure_args is passed to both bootstrap gcc and final gcc
+# if you need to pass some to one and not the other, use the
+# respective cross_ variables for final gcc and bootstrap gcc
+#
+
+_void_cross_apply_patch() {
+	local args="$1" pname="$(basename $2)"
+	if [ ! -f ".${pname}_done" ]; then
+		patch -N $args -i $2
+		touch .${pname}_done
+	fi
+}
+
+_void_cross_build_binutils() {
+	[ -f ${wrksrc}/.binutils_done ] && return 0
+
+	local ver=$1
+
+	msg_normal "Building binutils for ${cross_triplet}\n"
+
+	mkdir -p ${wrksrc}/binutils_build
+	cd ${wrksrc}/binutils_build
+
+	../binutils-${ver}/configure \
+		--prefix=/usr \
+		--sbindir=/usr/bin \
+		--libdir=/usr/lib \
+		--libexecdir=/usr/lib \
+		--target=${cross_triplet} \
+		--with-sysroot=/usr/${cross_triplet} \
+		--disable-nls \
+		--disable-shared \
+		--disable-multilib \
+		--disable-werror \
+		--disable-gold \
+		--with-system-zlib \
+		--enable-deterministic-archives \
+		--enable-default-hash-style=gnu \
+		${cross_binutils_configure_args}
+
+	make configure-host
+	make ${makejobs}
+
+	make install DESTDIR=${wrksrc}/build_root
+
+	touch ${wrksrc}/.binutils_done
+}
+
+_void_cross_build_bootstrap_gcc() {
+	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
+
+	local ver=$1
+
+	msg_normal "Patching GCC for ${cross_triplet}\n"
+
+	cd ${wrksrc}/gcc-${ver}
+	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
+		_void_cross_apply_patch -p0 "$f"
+	done
+	if [ -f ${wrksrc}/.musl_version ]; then
+		for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
+			_void_cross_apply_patch -p0 "$f"
+		done
+	fi
+	cd ..
+
+	msg_normal "Building bootstrap GCC for ${cross_triplet}\n"
+
+	mkdir -p gcc_bootstrap
+	cd gcc_bootstrap
+
+	local extra_args
+	if [ -f ${wrksrc}/.musl_version ]; then
+		extra_args+=" --with-newlib"
+		extra_args+=" --disable-symvers"
+		extra_args+=" libat_cv_have_ifunc=no"
+	else
+		extra_args+=" --without-headers"
+	fi
+
+	../gcc-${ver}/configure \
+		--prefix=/usr \
+		--sbindir=/usr/bin \
+		--libdir=/usr/lib \
+		--libexecdir=/usr/lib \
+		--target=${cross_triplet} \
+		--disable-nls \
+		--disable-multilib \
+		--disable-shared \
+		--disable-libquadmath \
+		--disable-decimal-float \
+		--disable-libgomp \
+		--disable-libmpx \
+		--disable-libmudflap \
+		--disable-libssp \
+		--disable-libitm \
+		--disable-libatomic \
+		--disable-threads \
+		--disable-sjlj-exceptions \
+		--enable-languages=c \
+		--with-gnu-ld \
+		--with-gnu-as \
+		${extra_args} \
+		${configure_args} \
+		${cross_gcc_bootstrap_configure_args}
+
+	make ${makejobs}
+	make install DESTDIR=${wrksrc}/build_root
+
+	local ptrs=$(${cross_triplet}-gcc -dM -E - < /dev/null | \
+		grep __SIZEOF_POINTER__)
+	local ws=${ptrs##* }
+
+	case ${ws} in
+		8) echo 64 > ${wrksrc}/.gcc_wordsize ;;
+		4) echo 32 > ${wrksrc}/.gcc_wordsize ;;
+		*) msg_error "Unknown word size: ${ws}\n" ;;
+	esac
+
+	touch ${wrksrc}/.gcc_bootstrap_done
+}
+
+_void_cross_build_kernel_headers() {
+	[ -f ${wrksrc}/.linux_headers_done ] && return 0
+
+	local ver=$1
+
+	msg_normal "Patching Linux headers for ${cross_triplet}\n"
+
+	cd ${wrksrc}/linux-${ver}
+	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
+		_void_cross_apply_patch -p0 $f
+	done
+	cd ..
+
+	msg_normal "Building Linux headers for ${cross_triplet}\n"
+
+	cd linux-${ver}
+
+	make ARCH=$cross_linux_arch headers_check
+	make ARCH=$cross_linux_arch \
+		INSTALL_HDR_PATH=${wrksrc}/build_root/usr/${cross_triplet}/usr \
+		headers_install
+
+	touch ${wrksrc}/.linux_headers_done
+}
+
+_void_cross_build_glibc_headers() {
+	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
+
+	local ver=$1
+	local tgt=$cross_triplet
+
+	msg_normal "Patching glibc for ${cross_triplet}\n"
+
+	cd ${wrksrc}/glibc-${ver}
+	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
+		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
+			_void_cross_apply_patch -p1 "$f"
+		done
+	fi
+	cd ..
+
+	msg_normal "Building glibc headers for ${cross_triplet}\n"
+
+	mkdir -p glibc_headers
+	cd glibc_headers
+
+	echo "libc_cv_forced_unwind=yes" > config.cache
+	echo "libc_cv_c_cleanup=yes" >> config.cache
+
+	# we don't need any custom args here, it's just headers
+	CC="${tgt}-gcc" CXX="${tgt}-g++" CPP="${tgt}-cpp" LD="${tgt}-ld" \
+	AS="${tgt}-as" NM="${tgt}-nm" CFLAGS="-pipe" CXXFLAGS="" CPPFLAGS="" \
+	LDFLAGS="" \
+	../glibc-${ver}/configure \
+		--prefix=/usr \
+		--host=${tgt} \
+		--with-headers=${wrksrc}/build_root/usr/${tgt}/usr/include \
+		--config-cache \
+		--enable-obsolete-rpc \
+		--enable-obsolete-nsl \
+		--enable-kernel=2.6.27 \
+		${cross_glibc_configure_args}
+
+	make -k install-headers cross_compiling=yes \
+		install_root=${wrksrc}/build_root/usr/${tgt}
+
+	touch ${wrksrc}/.glibc_headers_done
+}
+
+_void_cross_build_glibc() {
+	[ -f ${wrksrc}/.glibc_build_done ] && return 0
+
+	local ver=$1
+	local tgt=$cross_triplet
+
+	msg_normal "Building glibc for ${tgt}\n"
+
+	mkdir -p ${wrksrc}/glibc_build
+	cd ${wrksrc}/glibc_build
+
+	local ws=$(cat ${wrksrc}/.gcc_wordsize)
+
+	echo "slibdir=/usr/lib${ws}" > configparms
+
+	echo "libc_cv_forced_unwind=yes" > config.cache
+	echo "libc_cv_c_cleanup=yes" >> config.cache
+
+	CC="${tgt}-gcc" CXX="${tgt}-g++" CPP="${tgt}-cpp" LD="${tgt}-ld" \
+	AR="${tgt}-ar" AS="${tgt}-as" NM="${tgt}-nm" \
+	CFLAGS="-pipe ${cross_glibc_cflags}" \
+	CXXFLAGS="-pipe ${cross_glibc_cflags}" \
+	CPPFLAGS="${cross_glibc_cflags}" \
+	LDFLAGS="${cross_glibc_ldflags}" \
+	../glibc-${ver}/configure \
+		--prefix=/usr \
+		--libdir=/usr/lib${ws} \
+		--libexecdir=/usr/libexec \
+		--host=${tgt} \
+		--with-headers=${wrksrc}/build_root/usr/${tgt}/usr/include \
+		--config-cache \
+		--enable-obsolete-rpc \
+		--enable-obsolete-nsl \
+		--disable-profile \
+		--disable-werror \
+		--enable-kernel=2.6.27 \
+		${cross_glibc_configure_args}
+
+	make ${makejobs}
+	make install_root=${wrksrc}/build_root/usr/${tgt} install
+
+	touch ${wrksrc}/.glibc_build_done
+}
+
+_void_cross_build_musl() {
+	[ -f ${wrksrc}/.musl_build_done ] && return 0
+
+	local ver=$1
+	local tgt=$cross_triplet
+
+	msg_normal "Patching musl for ${tgt}\n"
+
+	cd ${wrksrc}/musl-${ver}
+	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
+		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
+			_void_cross_apply_patch -p0 "$f"
+		done
+	fi
+	cd ..
+
+	msg_normal "Building musl for ${tgt}\n"
+
+	mkdir -p musl_build
+	cd musl_build
+
+	CC="${tgt}-gcc" CXX="${tgt}-g++" CPP="${tgt}-cpp" LD="${tgt}-ld" \
+	AR="${tgt}-ar" AS="${tgt}-as" NM="${tgt}-nm" \
+	CFLAGS="-pipe -fPIC ${cross_musl_cflags}" \
+	CPPFLAGS="${cross_musl_cflags}" LDFLAGS="${cross_musl_ldflags}" \
+	../musl-${ver}/configure \
+		--prefix=/usr \
+		--host=${tgt} \
+		${cross_musl_configure_args}
+
+	make ${makejobs}
+	make DESTDIR=${wrksrc}/build_root/usr/${tgt} install
+
+	touch ${wrksrc}/.musl_build_done
+}
+
+_void_cross_build_libucontext() {
+	[ -n "$cross_gcc_skip_go" ] && return 0
+	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
+
+	local ver=$1
+
+	msg_normal "Building libucontext for ${cross_triplet}\n"
+
+	cd ${wrksrc}/libucontext-${ver}
+	# a terrible hack but seems to work for now
+	CC="${cross_triplet}-gcc" AS="${cross_triplet}-as" AR="${cross_triplet}-ar" \
+	CPPFLAGS="-pipe ${cross_musl_cflags} -g0 -Os -nostdinc -isystem ${wrksrc}/build_root/usr/${cross_triplet}/usr/include" \
+	make ARCH=${cross_libucontext_arch} libucontext.a
+
+	cp libucontext.a ${wrksrc}/build_root/usr/${cross_triplet}/usr/lib
+
+	touch ${wrksrc}/.libucontext_build_done
+}
+
+_void_cross_build_gcc() {
+	[ -f ${wrksrc}/.gcc_build_done ] && return 0
+
+	local ver=$1
+
+	msg_normal "Building gcc for ${cross_triplet}\n"
+
+	mkdir -p ${wrksrc}/gcc_build
+	cd ${wrksrc}/gcc_build
+
+	local langs="c,c++,fortran,objc,obj-c++,ada,lto"
+	if [ -z "$cross_gcc_skip_go" ]; then
+		langs+=",go"
+	fi
+
+	local extra_args
+	if [ -f ${wrksrc}/.musl_version ]; then
+		extra_args+=" --enable-libssp"
+		# otherwise glibc hosts get confused and use the gnu impl
+		extra_args+=" --enable-clocale=generic"
+		extra_args+=" --disable-symvers"
+		extra_args+=" --disable-gnu-unique-object"
+		extra_args+=" libat_cv_have_ifunc=no"
+	else
+		extra_args+=" --disable-libssp"
+		extra_args+=" --enable-gnu-unique-object"
+	fi
+
+	# note on --disable-libquadmath:
+	# on some platforms the library is actually necessary for the
+	# fortran frontend to build, but still disable it because it
+	# should not be in the resulting packages; it conflicts with
+	# the libquadmath you can install into the cross root
+	#
+	# platforms where this is a problem should explicitly force
+	# libquadmath to be on via cross_gcc_configure_args, the
+	# do_install in this build-style automatically removes it
+	#
+	../gcc-${ver}/configure \
+		--prefix=/usr \
+		--sbindir=/usr/bin \
+		--libdir=/usr/lib \
+		--libexecdir=/usr/lib \
+		--target=${cross_triplet} \
+		--with-sysroot=/usr/${cross_triplet} \
+		--with-build-sysroot=${wrksrc}/build_root/usr/${cross_triplet} \
+		--enable-languages=${langs} \
+		--disable-nls \
+		--disable-multilib \
+		--disable-sjlj-exceptions \
+		--disable-libquadmath \
+		--disable-libmudflap \
+		--disable-libitm \
+		--disable-libvtv \
+		--disable-libsanitizer \
+		--disable-libstdcxx-pch \
+		--enable-shared \
+		--enable-threads=posix \
+		--enable-__cxa_atexit \
+		--enable-linker-build-id \
+		--enable-libada \
+		--enable-lto \
+		--enable-default-pie \
+		--enable-default-ssp \
+		--with-gnu-ld \
+		--with-gnu-as \
+		--with-linker-hash-style=gnu \
+		${extra_args} \
+		${configure_args} \
+		${cross_gcc_configure_args}
+
+	make ${makejobs}
+
+	touch ${wrksrc}/.gcc_build_done
+}
+
+_void_cross_check_var() {
+	local var="cross_${1}"
+	if [ -z "${!var}" ]; then
+		msg_error "cross_${1} not defined in template"
+	fi
+}
+
+_void_cross_test_ver() {
+	local proj=$1
+	local noerr=$2
+	local ver cver
+	for p in ${proj}-*; do
+		cver=${p#${proj}-}
+		if [ -z "$noerr" -a -n "$ver" ]; then
+			msg_error "multiple versions of ${proj} found: ${ver}, ${cver}"
+		fi
+		ver=${cver}
+	done
+	if [ -d "${proj}-${ver}" ]; then
+		echo ${ver} > ${wrksrc}/.${proj}_version
+		return
+	fi
+	if [ -z "$noerr" ]; then
+		msg_error "project ${proj} not available for build\n"
+	fi
+}
+
+do_build() {
+	# Verify toolchain versions
+	cd ${wrksrc}
+
+	local binutils_ver linux_ver gcc_ver libc_ver libucontext_ver
+
+	_void_cross_test_ver binutils
+	_void_cross_test_ver linux
+	_void_cross_test_ver gcc
+
+	binutils_ver=$(cat .binutils_version)
+	linux_ver=$(cat .linux_version)
+	gcc_ver=$(cat .gcc_version)
+
+	_void_cross_test_ver musl noerr
+	if [ ! -f .musl_version ]; then
+		_void_cross_test_ver glibc
+		libc_ver=$(cat .glibc_version)
+	else
+		libc_ver=$(cat .musl_version)
+		if [ -z "$cross_gcc_skip_go" ]; then
+			_void_cross_test_ver libucontext
+			_void_cross_check_var libucontext_arch
+			libucontext_ver=$(cat .libucontext_version)
+		fi
+	fi
+
+	# Verify triplet
+	_void_cross_check_var triplet
+	_void_cross_check_var linux_arch
+
+	local sysroot="/usr/${cross_triplet}"
+
+	# Prepare environment
+	cd ${wrksrc}
+
+	# Core directories for the build root
+	mkdir -p build_root/usr/{bin,lib,include,share}
+	mkdir -p build_root/usr/${cross_triplet}/usr/{bin,lib,include,share}
+
+	# Host root uses host wordsize
+	ln -sf usr/lib build_root/lib
+	ln -sf usr/lib build_root/lib${XBPS_TARGET_WORDSIZE}
+	ln -sf lib build_root/usr/lib${XBPS_TARGET_WORDSIZE}
+
+	# Prepare target sysroot
+	ln -sf usr/lib build_root/${sysroot}/lib
+	ln -sf lib build_root/${sysroot}/usr/libexec
+
+	_void_cross_build_binutils ${binutils_ver}
+
+	# Prepare environment so we can use temporary prefix
+	local oldpath="$PATH"
+	local oldldlib="$LD_LIBRARY_PATH"
+
+	export PATH="${wrksrc}/build_root/usr/bin:$PATH"
+	export LD_LIBRARY_PATH="${wrksrc}/build_root/usr/lib:$PATH"
+
+	_void_cross_build_bootstrap_gcc ${gcc_ver}
+	_void_cross_build_kernel_headers ${linux_ver}
+
+	local ws=$(cat ${wrksrc}/.gcc_wordsize)
+
+	# Now that we know the target wordsize, prepare symlinks
+	ln -sf usr/lib ${wrksrc}/build_root/${sysroot}/lib${ws}
+	ln -sf lib ${wrksrc}/build_root/${sysroot}/usr/lib${ws}
+
+	if [ -f ${wrksrc}/.musl_version ]; then
+		_void_cross_build_musl ${libc_ver}
+		_void_cross_build_libucontext ${libucontext_ver}
+	else
+		_void_cross_build_glibc_headers ${libc_ver}
+		_void_cross_build_glibc ${libc_ver}
+	fi
+
+	_void_cross_build_gcc ${gcc_ver}
+
+	# restore this stuff in case later hooks depend on it
+	export PATH="$oldpath"
+	export LD_LIBRARY_PATH="$oldldlib"
+}
+
+do_install() {
+	# We need to be able to access binutils in the root
+	local oldpath="$PATH"
+	local oldldlib="$LD_LIBRARY_PATH"
+	export PATH="${wrksrc}/build_root/usr/bin:$PATH"
+	export LD_LIBRARY_PATH="${wrksrc}/build_root/usr/lib:$PATH"
+
+	local sysroot="/usr/${cross_triplet}"
+	local ws=$(cat ${wrksrc}/.gcc_wordsize)
+
+	# Core directories for the sysroot
+	#
+	# libexec is created for sysroot but not for dest, since in sysroot
+	# we configure glibc with separate libexec, elsewhere it's just lib
+	# and we want to delete the libexec from glibc afterwards to save space
+	mkdir -p ${DESTDIR}/${sysroot}/usr/{bin,lib,libexec,include,share}
+	# Sysroot base symlinks
+	ln -sf usr/lib ${DESTDIR}/${sysroot}/lib
+	ln -sf usr/lib ${DESTDIR}/${sysroot}/lib${ws}
+	ln -sf lib ${DESTDIR}/${sysroot}/usr/lib${ws}
+
+	# Install Linux headers
+	cd ${wrksrc}/linux-$(cat ${wrksrc}/.linux_version)
+	make ARCH=${cross_linux_arch} \
+		INSTALL_HDR_PATH=${DESTDIR}/${sysroot}/usr headers_install
+	rm -f $(find ${DESTDIR}/${sysroot}/usr/include \
+		-name .install -or -name ..install.cmd)
+	rm -rf ${DESTDIR}/${sysroot}/usr/include/drm
+
+	# Install binutils
+	cd ${wrksrc}/binutils_build
+	make install DESTDIR=${DESTDIR}
+
+	# Install final gcc
+	cd ${wrksrc}/gcc_build
+	make install DESTDIR=${DESTDIR}
+
+	# Move libcc1.so* to the sysroot
+	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${sysroot}/usr/lib
+
+	if [ -f ${wrksrc}/.musl_version ]; then
+		# Install musl
+		cd ${wrksrc}/musl_build
+		make DESTDIR=${DESTDIR}/${sysroot} install
+
+		# Remove useless headers
+		rm -rf ${DESTDIR}/usr/lib/gcc/${cross_triplet}/*/include-fixed
+
+		# Make ld-musl.so symlinks relative
+		for f in ${DESTDIR}/${sysroot}/usr/lib/ld-musl-*.so.*; do
+			ln -sf libc.so ${f}
+		done
+	else
+		# Install glibc
+		cd ${wrksrc}/glibc_build
+		make install_root=${DESTDIR}/${sysroot} install install-headers
+
+		# Remove bad header
+		rm -f ${DESTDIR}/usr/lib/gcc/${cross__triplet}/*/include-fixed/bits/statx.h
+	fi
+
+	local gcc_ver=$(cat ${wrksrc}/.gcc_version)
+
+	# Symlinks for gnarl and gnat shared libraries
+	local majorver=${gcc_ver%.*.*}
+	local adalib=usr/lib/gcc/${_triplet}/${gcc_ver}/adalib
+	mv ${DESTDIR}/${adalib}/libgnarl-${majorver}.so \
+		${DESTDIR}/${sysroot}/usr/lib
+	mv ${DESTDIR}/${adalib}/libgnat-${majorver}.so \
+		${DESTDIR}/${sysroot}/usr/lib
+	ln -sf libgnarl-${majorver}.so ${DESTDIR}/${sysroot}/usr/lib/libgnarl.so
+	ln -sf libgnat-${majorver}.so ${DESTDIR}/${sysroot}/usr/lib/libgnat.so
+	rm -vf ${DESTDIR}/${adalib}/libgna{rl,t}.so
+
+	# Remove unnecessary libatomic which is only built for gccgo
+	rm -rf ${DESTDIR}/${sysroot}/usr/lib/libatomic.*
+
+	# If libquadmath was forced (needed for gfortran on some platforms)
+	# then remove it because it conflicts with libquadmath package
+	rm -rf ${DESTDIR}/${sysroot}/usr/lib/libquadmath.*
+
+	# Remove leftover symlinks
+	rm -f ${DESTDIR}/usr/lib${XBPS_TARGET_WORDSIZE}
+	rm -f ${DESTDIR}/lib*
+	rm -f ${DESTDIR}/*bin
+	# Remove unnecessary stuff
+	rm -rf ${DESTDIR}/${sysroot}/{sbin,etc,var,libexec}
+	rm -rf ${DESTDIR}/${sysroot}/usr/{sbin,share,libexec}
+	rm -rf ${DESTDIR}/usr/share
+	rm -f ${DESTDIR}/usr/lib*/libiberty.a
+
+	export PATH="$oldpath"
+	export LD_LIBRARY_PATH="$oldldlib"
+}

--- a/common/environment/build-style/void-cross.sh
+++ b/common/environment/build-style/void-cross.sh
@@ -1,0 +1,13 @@
+lib32disabled=yes
+nopie=yes
+create_wrksrc=yes
+
+nostrip_files+=" libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
+ libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
+
+# glibc crosstoolchains not available on musl hosts yet
+if [ -z "$archs" -a "${cross_triplet/-musl}" = "${cross_triplet}" ]; then
+	if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
+		archs="~*-musl"
+	fi
+fi

--- a/srcpkgs/cross-aarch64-linux-gnu/template
+++ b/srcpkgs/cross-aarch64-linux-gnu/template
@@ -1,21 +1,21 @@
-# Template build file for 'cross-aarch64-linux-gnu'
-#
+# Template file for 'cross-aarch64-linux-gnu'
+_triplet=aarch64-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=aarch64-linux-gnu
-_archflags="-march=armv8-a"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--with-arch=armv8-a"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -25,349 +25,15 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
-
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=arm64
+cross_glibc_cflags="-O2 -march=armv8-a"
 
 if [ "$XBPS_TARGET_MACHINE" = "aarch64" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=arm64 headers_check
-	make ARCH=arm64 INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils\n"
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-gold"
-	_args+=" --with-system-zlib"
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_glibc_headers() {
-	local _args f
-
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-
-	_args="--prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib64" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" CXX="${_triplet}-g++" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-	export CFLAGS="-O1 -pipe ${_archflags}"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib64"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-profile"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" --disable-werror"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	export CC="gcc" CXX="g++" CFLAGS="-Os -pipe"
-	unset LD AS
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	unset LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for ARM64
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm64 INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-aarch64-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
@@ -376,6 +42,6 @@ cross-aarch64-linux-gnu-libc_package() {
 	noverifyrdeps=yes
 
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-aarch64-linux-musl/template
+++ b/srcpkgs/cross-aarch64-linux-musl/template
@@ -1,19 +1,19 @@
-# Template build file for 'cross-aarch64-linux-musl'
-#
+# Template file for 'cross-aarch64-linux-musl'
+_triplet=aarch64-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=aarch64-linux-musl
-_archflags="-march=armv8-a"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=4
-short_desc="Cross toolchain for ARM64 LE target (musl)"
+build_style=void-cross
+configure_args="--with-arch=armv8-a"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -28,297 +28,24 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
-
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_libucontext_arch=aarch64
+cross_linux_arch=arm64
+cross_musl_cflags="-O2 -march=armv8-a"
 
 if [ "$XBPS_TARGET_MACHINE" = "aarch64-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=arm64 headers_check
-	make ARCH=arm64 INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \
-		AS="${_triplet}-as" RANLIB="${_triplet}-ranlib" \
-		CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=aarch64 libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm64 INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl.so symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-aarch64.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/sbin
-}
 
 cross-aarch64-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noshlibprovides=yes
 	noverifyrdeps=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-arm-linux-gnueabi/template
+++ b/srcpkgs/cross-arm-linux-gnueabi/template
@@ -1,22 +1,21 @@
-# Template build file for 'cross-arm-linux-gnueabi'
-#
+# Template file for 'cross-arm-linux-gnueabi'
+_triplet=arm-linux-gnueabi
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=arm-linux-gnueabi
-_fpuflags="--with-arch=armv5te --without-fp --with-float=soft"
-_archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=2
-short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--with-arch=armv5te --with-float=soft"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.voidlinux.org/"
-license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1.0-or-later"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -26,346 +25,17 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=arm
+cross_binutils_configure_args="--without-fp"
+cross_glibc_configure_args="--without-fp"
+cross_glibc_cflags="-Os -march=armv5te -msoft-float -mfloat-abi=soft"
 
 if [ "$XBPS_TARGET_MACHINE" = "armv5tel" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=arm headers_check
-	make ARCH=arm INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils\n"
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_glibc_headers() {
-	local _args f
-
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-
-	_args="--prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib32" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-	export CFLAGS="-Os -pipe ${_archflags}"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib32"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --disable-profile"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-werror"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS CPP
-	export CC="gcc" CFLAGS="-Os -pipe"
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib32/, ${_sysroot}/lib32/,g;s, /usr/lib32/, ${_sysroot}/usr/lib32/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for MIPS
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
 
 cross-arm-linux-gnueabi-libc_package() {
 	short_desc+=" - glibc files"
@@ -374,6 +44,6 @@ cross-arm-linux-gnueabi-libc_package() {
 	noverifyrdeps=yes
 
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -1,22 +1,21 @@
-# Template build file for 'cross-arm-linux-gnueabihf'
-#
+# Template file for 'cross-arm-linux-gnueabihf'
+_triplet=arm-linux-gnueabihf
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=arm-linux-gnueabihf
-_fpuflags="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
-_archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=2
-short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.voidlinux.org/"
-license="Public Domain"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -26,346 +25,15 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=arm
+cross_glibc_cflags="-Os -march=armv6 -mfpu=vfp -mfloat-abi=hard"
 
 if [ "$XBPS_TARGET_MACHINE" = "armv6l" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=arm headers_check
-	make ARCH=arm INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils\n"
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_glibc_headers() {
-	local _args f
-
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-
-	_args="--prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib32" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-	export CFLAGS="-Os -pipe ${_archflags}"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib32"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --disable-profile"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-werror"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS CPP
-	export CC="gcc" CFLAGS="-Os -pipe"
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib32/, ${_sysroot}/lib32/,g;s, /usr/lib32/, ${_sysroot}/usr/lib32/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for MIPS
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
 
 cross-arm-linux-gnueabihf-libc_package() {
 	short_desc+=" - glibc files"
@@ -374,6 +42,6 @@ cross-arm-linux-gnueabihf-libc_package() {
 	noverifyrdeps=yes
 
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-arm-linux-musleabi/template
+++ b/srcpkgs/cross-arm-linux-musleabi/template
@@ -1,20 +1,19 @@
-# Template build file for 'cross-arm-linux-musleabi'
-#
+# Template file for 'cross-arm-linux-musleabi'
+_triplet=arm-linux-musleabi
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=arm-linux-musleabi
-_fpuflags="--with-arch=armv5te --without-fp --with-float=soft"
-_archflags="-march=armv5te -msoft-float -mfloat-abi=soft"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for ARMv5 TE target (musl)"
+build_style=void-cross
+configure_args="--with-arch=armv5te --with-float=soft"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -29,297 +28,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
+cross_triplet=${_triplet}
+cross_libucontext_arch=arm
+cross_linux_arch=arm
+cross_binutils_configure_args="--without-fp"
+cross_musl_cflags="-Os -march=armv5te -msoft-float -mfloat-abi=soft"
 
 if [ "$XBPS_TARGET_MACHINE" = "armv5tel-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=arm headers_check
-	make ARCH=arm INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=arm libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libquadmath"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-arm.so.1 symlink relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-arm.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
 
 cross-arm-linux-musleabi-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noshlibprovides=yes
 	noverifyrdeps=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-arm-linux-musleabihf/template
+++ b/srcpkgs/cross-arm-linux-musleabihf/template
@@ -1,20 +1,19 @@
-# Template build file for 'cross-arm-linux-musleabihf'
-#
+# Template file for 'cross-arm-linux-musleabihf'
+_triplet=arm-linux-musleabihf
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=arm-linux-musleabihf
-_fpuflags="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
-_archflags="-march=armv6 -mfpu=vfp -mfloat-abi=hard"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for ARMv6 LE Hard Float target (musl)"
+build_style=void-cross
+configure_args="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -29,296 +28,24 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
+cross_triplet=${_triplet}
+cross_libucontext_arch=arm
+cross_linux_arch=arm
+cross_musl_cflags="-Os -march=armv6 -mfpu=vfp -mfloat-abi=hard"
 
 if [ "$XBPS_TARGET_MACHINE" = "armv6l-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=arm headers_check
-	make ARCH=arm INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=arm libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-armhf.so.1 symlink relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-armhf.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
 
 cross-arm-linux-musleabihf-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noshlibprovides=yes
 	noverifyrdeps=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-armv7l-linux-gnueabihf/template
+++ b/srcpkgs/cross-armv7l-linux-gnueabihf/template
@@ -1,379 +1,47 @@
-# Template build file for 'cross-armv7l-linux-gnueabihf'
-#
+# Template file for 'cross-armv7l-linux-gnueabihf'
+_triplet=armv7l-linux-gnueabihf
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=armv7l-linux-gnueabihf
-_fpuflags="--with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard"
-_archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=2
-short_desc="GNU Cross toolchain for the ${_triplet} LE target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- http://ftp.gnu.org/gnu/glibc/glibc-${_glibc_version}.tar.xz
+ ${GNU_SITE}/glibc/glibc-${_glibc_version}.tar.xz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=arm
+cross_glibc_cflags="-O2 -march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 
 if [ "$XBPS_TARGET_MACHINE" = "armv7l" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=arm headers_check
-	make ARCH=arm INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils\n"
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_glibc_headers() {
-	local _args f
-
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-
-	_args="--prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib32" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-	export CFLAGS="-Os -pipe ${_archflags}"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib32"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --disable-profile"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-werror"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS CPP
-	export CC="gcc" CFLAGS="-Os -pipe"
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib32/, ${_sysroot}/lib32/,g;s, /usr/lib32/, ${_sysroot}/usr/lib32/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for MIPS
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
 
 cross-armv7l-linux-gnueabihf-libc_package() {
 	short_desc+=" - glibc files"
 	nostrip=yes
 	noshlibprovides=yes
 	noverifyrdeps=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-armv7l-linux-musleabihf/template
+++ b/srcpkgs/cross-armv7l-linux-musleabihf/template
@@ -1,20 +1,19 @@
-# Template build file for 'cross-armv7l-linux-musleabihf'
-#
+# Template file for 'cross-armv7l-linux-musleabihf'
+_triplet=armv7l-linux-musleabihf
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=armv7l-linux-musleabihf
-_fpuflags="--with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard"
-_archflags="-march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for ARMv7 LE Hard Float target (musl)"
+build_style=void-cross
+configure_args="--with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -29,299 +28,24 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
+cross_triplet=${_triplet}
+cross_libucontext_arch=arm
+cross_linux_arch=arm
+cross_musl_cflags="-O2 -march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard"
 
 if [ "$XBPS_TARGET_MACHINE" = "armv7l-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for ARM\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=arm headers_check
-	make ARCH=arm INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=arm libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=arm INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-armhf.so.1 symlink relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-armhf.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
 
 cross-armv7l-linux-musleabihf-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noshlibprovides=yes
 	noverifyrdeps=yes
-	pkg_install() {
-		vmove ${_sysroot}
 
+	pkg_install() {
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-i686-linux-musl/template
+++ b/srcpkgs/cross-i686-linux-musl/template
@@ -1,19 +1,18 @@
-# Template build file for 'cross-i686-linux-musl'
-#
+# Template file for 'cross-i686-linux-musl'
+_triplet=i686-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=i686-linux-musl
-_sysroot="/usr/${_triplet}"
-_archflags="-march=i686"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for i686 target (musl)"
+build_style=void-cross
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -28,295 +27,22 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
+
+cross_triplet=${_triplet}
+cross_libucontext_arch=x86
+cross_linux_arch=x86
+# explicitly enable for final gcc, as gfortran does not build without on x86
+cross_gcc_configure_args="--enable-libquadmath"
+cross_musl_cflags="-O2 -march=i686 -mtune=generic"
 
 if [ "$XBPS_TARGET_MACHINE" = "i686-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
 
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --prefix=/usr"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=x86 headers_check
-	make ARCH=x86 INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	vsed -i arch/x86/startcontext.S -e \
-	 "s;__i686.get_pc_thunk.bx;i686_get_pc_thunk_bx;g"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=x86 libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-libada"
-	_args+=" --enable-libquadmath"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers for x86
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=x86 INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-i386.so.1 symlink relative to cwd.
-	cd ${DESTDIR}/${_sysroot}/usr/lib
-	ln -sf libc.so ld-musl-i386.so.1
-
-	# Move files to /usr/lib (lib64).
-	if [ -d ${DESTDIR}/${_sysroot}/usr/lib64 ]; then
-		mv ${DESTDIR}/${_sysroot}/usr/lib64/* ${DESTDIR}/${_sysroot}/usr/lib/
-		rmdir ${DESTDIR}/${_sysroot}/usr/lib64
-	fi
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
+post_patch() {
+	vsed -i libucontext-${_libucontext_version}/arch/x86/startcontext.S \
+		-e "s;__i686.get_pc_thunk.bx;i686_get_pc_thunk_bx;g"
 }
 
 cross-i686-linux-musl-libc_package() {
@@ -324,7 +50,8 @@ cross-i686-linux-musl-libc_package() {
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-i686-pc-linux-gnu/template
+++ b/srcpkgs/cross-i686-pc-linux-gnu/template
@@ -1,21 +1,20 @@
-# Template build file for 'cross-i686-pc-linux-gnu'
-#
+# Template file for 'cross-i686-pc-linux-gnu'
+_triplet=i686-pc-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=i686-pc-linux-gnu
-_archflags="-march=i686 -mtune=generic"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=4
-short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
+build_style=void-cross
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -25,352 +24,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
 nocross=yes
-nopie=yes
-nodebug=yes
-lib32disabled=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=x86
+# explicitly enable for final gcc, as gfortran does not build without on x86
+cross_gcc_configure_args="--enable-libquadmath"
+cross_glibc_cflags="-O2 -Wno-error -march=i686 -mtune=generic"
 
 if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}/binutils-${_binutils_version}
-
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d ../binutils-build ] && mkdir ../binutils-build
-	cd ../binutils-build
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	# Fix https://build.voidlinux.org/builders/x86_64_builder/builds/24895/steps/shell_3/logs/stdio
-	export gcc_cv_libc_provides_ssp=yes
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for x86\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=x86 headers_check
-	make ARCH=x86 INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_glibc_headers() {
-	local _args f
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-	echo "libc_cv_ssp=no" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-
-	_args="--host=${_triplet}"
-	_args+=" --prefix=/usr"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib32" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-	echo "libc_cv_ssp=no" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp"
-	export CFLAGS="-O2 -pipe -Wno-error ${_archflags}"
-	_args="--host=${_triplet}"
-	_args+=" --prefix=/usr"
-	_args+=" --libdir=/usr/lib32"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" ${_fpuflags}"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS CPP
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib32/, ${_sysroot}/lib32/,g;s, /usr/lib32/, ${_sysroot}/usr/lib32/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-	_args="--target=${_triplet}"
-	_args+=" --target=${_triplet}"
-	_args+=" --prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-gnu-indirect-function"
-	_args+=" --enable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-	_args+=" ${_fpuflags}"
-
-	CC="gcc" CFLAGS="-O2 -pipe" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for x86.
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=x86 INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,lib,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
 
 cross-i686-pc-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-mips-linux-musl/template
+++ b/srcpkgs/cross-mips-linux-musl/template
@@ -1,296 +1,46 @@
-# Template build file for 'cross-mips-linux-musl'
-#
+# Template file for 'cross-mips-linux-musl'
+_triplet=mips-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
-
-_triplet=mips-linux-musl
-_fpuflags="--with-float=soft --without-fp"
-_archflags="-march=mips32r2 -msoft-float"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for MIPS32r2 BE softfloat target (musl)"
+build_style=void-cross
+configure_args="--with-arch=mips32r2 --with-float=soft
+ --with-linker-hash-style=sysv"
+hostmakedepends="tar gcc-objc flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ https://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=mips headers_check
-	make ARCH=mips INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libatomic"
-	_args+=" --enable-libssp"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=mips INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl.so symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips.so.1
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips-sf.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
+cross_triplet=${_triplet}
+cross_linux_arch=mips
+cross_gcc_skip_go=yes
+cross_binutils_configure_args="--without-fp --enable-default-hash-style=sysv"
+cross_musl_cflags="-Os -march=mips32r2 -msoft-float"
 
 cross-mips-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-mips-linux-muslhf/template
+++ b/srcpkgs/cross-mips-linux-muslhf/template
@@ -1,19 +1,19 @@
-# Template build file for 'cross-mips-linux-muslhf'
-#
+# Template file for 'cross-mips-linux-muslhf'
+_triplet=mips-linux-muslhf
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
-
-_triplet=mips-linux-muslhf
-_fpuflags="--with-float=hard --with-fp"
-_archflags="-march=mips32r2 -mhard-float"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for MIPS32r2 BE hardfloat target (musl)"
+build_style=void-cross
+configure_args="--with-arch=mips32r2 --with-float=hard
+ --with-linker-hash-style=sysv"
+hostmakedepends="tar gcc-objc flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="hipperson0 <hipperson0@gmail.com>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -26,270 +26,21 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=mips headers_check
-	make ARCH=mips INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libatomic"
-	_args+=" --enable-libssp"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=mips INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl.so symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mips.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
+cross_triplet=${_triplet}
+cross_linux_arch=mips
+cross_gcc_skip_go=yes
+cross_binutils_configure_args="--enable-default-hash-style=sysv"
+cross_musl_cflags="-Os -march=mips32r2 -mhard-float"
 
 cross-mips-linux-muslhf-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-mipsel-linux-musl/template
+++ b/srcpkgs/cross-mipsel-linux-musl/template
@@ -1,296 +1,46 @@
-# Template build file for 'cross-mipsel-linux-musl'
-#
+# Template file for 'cross-mipsel-linux-musl'
+_triplet=mipsel-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
-
-_triplet=mipsel-linux-musl
-_fpuflags="--with-float=soft --without-fp"
-_archflags="-march=mips32r2 -msoft-float"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for MIPS32r2 LE softfloat target (musl)"
+build_style=void-cross
+configure_args="--with-arch=mips32r2 --with-float=soft
+ --with-linker-hash-style=sysv"
+hostmakedepends="tar gcc-objc flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ https://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=mips headers_check
-	make ARCH=mips INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libatomic"
-	_args+=" --enable-libssp"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=mips INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl*.so.1 symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mipsel.so.1
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mipsel-sf.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
+cross_triplet=${_triplet}
+cross_linux_arch=mips
+cross_gcc_skip_go=yes
+cross_binutils_configure_args="--without-fp --enable-default-hash-style=sysv"
+cross_musl_cflags="-Os -march=mips32r2 -msoft-float"
 
 cross-mipsel-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-mipsel-linux-muslhf/template
+++ b/srcpkgs/cross-mipsel-linux-muslhf/template
@@ -1,295 +1,46 @@
-# Template build file for 'cross-mipsel-linux-muslhf'
-#
+# Template file for 'cross-mipsel-linux-muslhf'
+_triplet=mipsel-linux-muslhf
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
-
-_triplet=mipsel-linux-muslhf
-_fpuflags="--with-float=hard --with-fp"
-_archflags="-march=mips32r2 -mhard-float"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="Cross toolchain for MIPS32r2 LE hardfloat target (musl)"
+build_style=void-cross
+configure_args="--with-arch=mips32r2 --with-float=hard
+ --with-linker-hash-style=sysv"
+hostmakedepends="tar gcc-objc flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
- http://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
+ https://www.musl-libc.org/releases/musl-${_musl_version}.tar.gz
  ${KERNEL_SITE}/kernel/v4.x/linux-${_linux_version}.tar.xz"
 checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" ${_fpuflags}"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=mips headers_check
-	make ARCH=mips INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libatomic"
-	_args+=" --enable-libssp"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=mips INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl.so symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-mipsel.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
+cross_triplet=${_triplet}
+cross_linux_arch=mips
+cross_gcc_skip_go=yes
+cross_binutils_configure_args="--enable-default-hash-style=sysv"
+cross_musl_cflags="-Os -march=mips32r2 -mhard-float"
 
 cross-mipsel-linux-muslhf-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpc-linux-gnu/template
+++ b/srcpkgs/cross-powerpc-linux-gnu/template
@@ -1,19 +1,21 @@
 # Template file for 'cross-powerpc-linux-gnu'
+_triplet=powerpc-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=powerpc-linux-gnu
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=3
-short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
-homepage="http://www.voidlinux.org"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -23,348 +25,16 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=powerpc
+cross_binutils_configure_args="--enable-secureplt"
+cross_glibc_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppc" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for PowerPC\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils\n"
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-gold"
-	_args+=" --with-system-zlib"
-	_args+=" --enable-secureplt"
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-	_args+=" --enable-secureplt"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_glibc_headers() {
-	local _args f
-
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-
-	_args="--prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib32" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" CXX="${_triplet}-g++" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-	export CFLAGS="-O1 -pipe"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib32"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-profile"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" --disable-werror"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	export CC="gcc" CXX="g++" CFLAGS="-Os -pipe"
-	unset LD AS
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib32/, ${_sysroot}/lib32/,g;s, /usr/lib32/, ${_sysroot}/usr/lib32/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-	_args+=" --enable-secureplt"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	unset LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for powerpc
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-powerpc-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
@@ -373,6 +43,6 @@ cross-powerpc-linux-gnu-libc_package() {
 	noverifyrdeps=yes
 
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpc-linux-musl/template
+++ b/srcpkgs/cross-powerpc-linux-musl/template
@@ -1,21 +1,23 @@
 # Template file for 'cross-powerpc-linux-musl'
+_triplet=powerpc-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=powerpc-linux-musl
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=2
-
-short_desc="Cross toolchain for PowerPC (musl)"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify
+ --disable-decimal-float"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Thomas Batten <stenstorpmc@gmail.com>"
-homepage="http://www.voidlinux.org"
-license="GPL-3.0-or-later, GPL-2.0-only, MIT"
+homepage="https://www.voidlinux.org/"
+license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -27,298 +29,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
+cross_triplet=${_triplet}
+cross_libucontext_arch=ppc
+cross_linux_arch=powerpc
+cross_binutils_configure_args="--enable-secureplt"
+cross_musl_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppc-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" --enable-secureplt"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" --enable-secureplt"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe" \
-		make ARCH=ppc libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-libssp"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" --disable-decimal-float"
-	_args+=" --enable-secureplt"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl.so symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-powerpc.so.1
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-powerpc-sf.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
 
 cross-powerpc-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpc64-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64-linux-gnu/template
@@ -1,19 +1,22 @@
 # Template file for 'cross-powerpc64-linux-gnu'
+_triplet=powerpc64-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet="powerpc64-linux-gnu"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=1
-short_desc="GNU cross toolchain for the ${_triplet} targets (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify --with-abi=elfv2
+ --enable-targets=powerpc-linux"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -23,359 +26,24 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
-
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=powerpc
+cross_binutils_configure_args="--enable-secureplt"
+cross_glibc_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppc64" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpcle-linux"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-threads"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_glibc_headers() {
-	local _args f
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-
-	_args=" --prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib64" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" CXX="${_triplet}-g++" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-	export CFLAGS="-O2 -pipe"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib64"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-profile"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" --disable-werror"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/usr/lib/libc.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
-			-i ${_sysroot}/usr/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpcle-linux"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-shared"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-libquadmath"
-	_args+=" --disable-nls"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --disable-vtable-verify"
-	_args+=" --disable-sjlj-exceptions"
-
-	CC="gcc" CXX="g++" CFLAGS="-O2 -pipe" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	unset LDFLAGS
-	export CFLAGS="-Os -fPIC" CXXFLAGS="-Os -fPIC"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-powerpc64-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpc64-linux-musl/template
+++ b/srcpkgs/cross-powerpc64-linux-musl/template
@@ -1,17 +1,20 @@
 # Template file for 'cross-powerpc64-linux-musl'
+_triplet=powerpc64-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet="powerpc64-linux-musl"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=2
-short_desc="Cross toolchain for powerpc64 with musl"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify
+ --disable-decimal-float --with-abi=elfv2 --enable-targets=powerpc-linux"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -26,314 +29,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-        broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_libucontext_arch=ppc64
+cross_linux_arch=powerpc
+cross_binutils_configure_args="--enable-secureplt"
+cross_musl_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppc64-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-	export ac_cv_c_compiler_gnu=yes
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c"
-	_args+=" --enable-decimal-float=no"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpc-linux"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \
-		AS="${_triplet}-as" RANLIB="${_triplet}-ranlib" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		make ARCH=ppc64 libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-decimal-float=no"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpc-linux"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" --disable-vtable-verify"
-	_args+=" libat_cv_have_ifunc=no"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe -fPIC" CXXFLAGS="-Os -pipe -fPIC"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-powerpc64.so.1 symlink relative to cwd.
-	cd ${DESTDIR}/${_sysroot}/usr/lib
-	ln -sf libc.so ld-musl-powerpc64.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-powerpc64-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpc64le-linux-gnu/template
+++ b/srcpkgs/cross-powerpc64le-linux-gnu/template
@@ -1,19 +1,22 @@
 # Template file for 'cross-powerpc64le-linux-gnu'
+_triplet=powerpc64le-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet="powerpc64le-linux-gnu"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=1
-short_desc="GNU cross toolchain for the ${_triplet} targets (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify --with-abi=elfv2
+ --enable-targets=powerpcle-linux"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="q66 <daniel@octaforge.org>"
-homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -23,359 +26,26 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
-
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=powerpc
+cross_binutils_configure_args="--enable-secureplt"
+# explicitly enable for final gcc, gfortran does not build without on ppc64le
+cross_gcc_configure_args="--enable-libquadmath"
+cross_glibc_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppc64le" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpcle-linux"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-threads"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_glibc_headers() {
-	local _args f
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-
-	_args=" --prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib64" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" CXX="${_triplet}-g++" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-	export CFLAGS="-O2 -pipe"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib64"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-profile"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" --disable-werror"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/usr/lib/libc.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
-			-i ${_sysroot}/usr/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpcle-linux"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-shared"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-libquadmath"
-	_args+=" --disable-nls"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --disable-vtable-verify"
-	_args+=" --disable-sjlj-exceptions"
-
-	CC="gcc" CXX="g++" CFLAGS="-O2 -pipe" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	unset LDFLAGS
-	export CFLAGS="-Os -fPIC" CXXFLAGS="-Os -fPIC"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-powerpc64le-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpc64le-linux-musl/template
+++ b/srcpkgs/cross-powerpc64le-linux-musl/template
@@ -1,17 +1,20 @@
 # Template file for 'cross-powerpc64le-linux-musl'
+_triplet=powerpc64le-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet="powerpc64le-linux-musl"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=2
-short_desc="Cross toolchain for powerpc64le with musl"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify
+ --disable-decimal-float --with-abi=elfv2 --enable-targets=powerpcle-linux"
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="q66 <daniel@octaforge.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -26,314 +29,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_libucontext_arch=ppc64
+cross_linux_arch=powerpc
+cross_binutils_configure_args="--enable-secureplt"
+cross_musl_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppc64le-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-	export ac_cv_c_compiler_gnu=yes
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c"
-	_args+=" --enable-decimal-float=no"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpcle-linux"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" LD="${_triplet}-ld" AR="${_triplet}-ar" \
-		AS="${_triplet}-as" RANLIB="${_triplet}-ranlib" \
-		CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=ppc64 libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-abi=elfv2"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-decimal-float=no"
-	_args+=" --enable-secureplt"
-	_args+=" --enable-targets=powerpcle-linux"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" --disable-vtable-verify"
-	_args+=" libat_cv_have_ifunc=no"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe -fPIC" CXXFLAGS="-Os -pipe -fPIC"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-powerpc64le.so.1 symlink relative to cwd.
-	cd ${DESTDIR}/${_sysroot}/usr/lib
-	ln -sf libc.so ld-musl-powerpc64le.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-powerpc64le-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpcle-linux-gnu/template
+++ b/srcpkgs/cross-powerpcle-linux-gnu/template
@@ -1,20 +1,21 @@
 # Template file for 'cross-powerpcle-linux-gnu'
-# This is an experimental target for now and is subject to changes
+_triplet=powerpcle-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet=powerpcle-linux-gnu
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=1
-short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify"
+hostmakedepends="tar gcc-objc flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="q66 <daniel@octaforge.org>"
-homepage="http://www.voidlinux.org"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -24,348 +25,17 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-depends="${pkgname}-libc-${version}_${revision}"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=powerpc
+cross_gcc_skip_go=yes
+cross_binutils_configure_args="--enable-secureplt"
+cross_glibc_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppcle" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers for PowerPC\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils\n"
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-gold"
-	_args+=" --with-system-zlib"
-	_args+=" --enable-secureplt"
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-	_args+=" --enable-secureplt"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_glibc_headers() {
-	local _args f
-
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-
-	_args="--prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib32" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" CXX="${_triplet}-g++" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-	export CFLAGS="-O2 -pipe"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib32"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-profile"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" --disable-werror"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	export CC="gcc" CXX="g++" CFLAGS="-Os -pipe"
-	unset LD AS
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/lib/libc.so
-		sed -e "s, /lib32/, ${_sysroot}/lib32/,g;s, /usr/lib32/, ${_sysroot}/usr/lib32/,g" \
-			-i ${_sysroot}/lib/libc.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-long-longx"
-	_args+=" --enable-shared"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-libcilkrts"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libvtv"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --enable-libstdcxx-time"
-	_args+=" --with-linker-hash-style=gnu"
-	_args+=" --enable-secureplt"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	unset LDFLAGS
-	export CFLAGS="-Os" CXXFLAGS="-Os"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install linux API headers for powerpc
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{sbin,etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-powerpcle-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
@@ -374,6 +44,6 @@ cross-powerpcle-linux-gnu-libc_package() {
 	noverifyrdeps=yes
 
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-powerpcle-linux-musl/template
+++ b/srcpkgs/cross-powerpcle-linux-musl/template
@@ -1,20 +1,21 @@
 # Template file for 'cross-powerpcle-linux-musl'
-# This is an experimental target for now and is subject to changes
+_triplet=powerpcle-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
-
-_triplet=powerpcle-linux-musl
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=1
-
-short_desc="GNU Cross toolchain for the ${_triplet} target (binutils/gcc/glibc)"
+build_style=void-cross
+configure_args="--enable-secureplt --disable-vtable-verify
+ --disable-decimal-float"
+hostmakedepends="tar gcc-objc flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="q66 <daniel@octaforge.org>"
-homepage="http://www.voidlinux.org"
+homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
@@ -25,281 +26,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
 
-hostmakedepends="tar gcc-objc flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
+cross_triplet=${_triplet}
+cross_linux_arch=powerpc
+cross_gcc_skip_go=yes
+cross_binutils_configure_args="--enable-secureplt"
+cross_musl_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "ppcle-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" --enable-secureplt"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host && make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --with-newlib"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" --enable-secureplt"
-
-	CFLAGS="-O0 -g0" CXXFLAGS="-O0 -g0" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=powerpc headers_check
-	make ARCH=powerpc INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_gcc_build() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,fortran,lto"
-	_args+=" --enable-lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-libssp"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" --disable-decimal-float"
-	_args+=" --enable-secureplt"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe" CXXFLAGS="-Os -pipe"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib32
-	ln -sf usr/lib ${_sysroot}/lib32
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib32
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib32
-
-	# install linux API headers
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=powerpc INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed
-
-	# Make ld-musl.so symlinks relative.
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-powerpcle.so.1
-	ln -sf libc.so ${DESTDIR}/${_sysroot}/usr/lib/ld-musl-powerpcle-sf.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
 
 cross-powerpcle-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-x86_64-linux-gnu/template
+++ b/srcpkgs/cross-x86_64-linux-gnu/template
@@ -1,19 +1,20 @@
 # Template file for 'cross-x86_64-linux-gnu'
+_triplet=x86_64-linux-gnu
 _binutils_version=2.32
 _gcc_version=9.3.0
 _glibc_version=2.30
 _linux_version=4.19
-
-_triplet="x86_64-linux-gnu"
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=1
-short_desc="GNU cross toolchain for the ${_triplet} targets (binutils/gcc/glibc)"
+build_style=void-cross
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="q66 <daniel@octaforge.org>"
-homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.voidlinux.org/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -23,355 +24,25 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
  e2c4114e569afbe7edbc29131a43be833850ab9a459d81beb2588016d2bbb8af
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="isl15-devel libmpc-devel zlib-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_LIBC" != "glibc" ]; then
-	broken="glibc crosstoolchain only available on glibc"
-fi
-
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_linux_arch=x86
+# explicitly enable for final gcc, gfortran does not build without on x86
+cross_gcc_configure_args="--enable-libquadmath"
+cross_glibc_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --without-headers"
-	_args+=" --disable-nls"
-	_args+=" --disable-shared"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libssp"
-	_args+=" --disable-libitm"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-threads"
-	_args+=" --enable-languages=c"
-	_args+=" --disable-sjlj-exceptions"
-	_args+=" --disable-multilib"
-	_args+=" --with-gnu-ld"
-	_args+=" --with-gnu-as"
-
-	../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	make ARCH=x86 headers_check
-	make ARCH=x86 INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_glibc_headers() {
-	local _args f
-	[ -f ${wrksrc}/.glibc_headers_done ] && return 0
-
-	cd ${wrksrc}/glibc-${_glibc_version}
-	if [ -d "${XBPS_SRCPKGDIR}/glibc/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/glibc/patches/*.patch; do
-			_apply_patch -p1 "$f"
-		done
-	fi
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc headers\n"
-
-	[ ! -d glibc-headers ] && mkdir glibc-headers
-	cd glibc-headers
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-
-	_args=" --prefix=/usr"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --enable-kernel=2.6.27"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make -k install-headers cross_compiling=yes \
-		install_root=${_sysroot}
-
-	touch ${wrksrc}/.glibc_headers_done
-}
-
-_glibc_build() {
-	local _args
-	[ -f ${wrksrc}/.glibc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross glibc\n"
-
-	[ ! -d glibc-build ] && mkdir glibc-build
-	cd glibc-build
-
-	echo "slibdir=/usr/lib64" > configparms
-
-	echo "libc_cv_forced_unwind=yes" > config.cache
-	echo "libc_cv_c_cleanup=yes" >> config.cache
-
-	export CC="${_triplet}-gcc" CXX="${_triplet}-g++" LD="${_triplet}-ld" \
-		AS="${_triplet}-as" CPP="${_triplet}-cpp" \
-		NM="${_triplet}-nm"
-	export CFLAGS="-O2 -pipe"
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib64"
-	_args+=" --host=${_triplet}"
-	_args+=" --with-headers=${_sysroot}/usr/include"
-	_args+=" --config-cache"
-	_args+=" --enable-obsolete-rpc"
-	_args+=" --enable-obsolete-nsl"
-	_args+=" --disable-profile"
-	_args+=" --enable-kernel=2.6.27"
-	_args+=" --disable-werror"
-
-	../glibc-${_glibc_version}/configure ${_args}
-
-	make ${makejobs}
-	make install_root=${_sysroot} install
-
-	touch ${wrksrc}/.glibc_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	unset LD AS
-
-	# Make this link to target libs.
-	if [ ! -f .sed_subst_done ]; then
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/usr/lib/libc.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
-			-i ${_sysroot}/usr/lib/libc.so
-		sed -e "s, /lib/, ${_sysroot}/lib/,g;s, /usr/lib/, ${_sysroot}/usr/lib/,g" \
-			-i ${_sysroot}/usr/lib/libm.so
-		sed -e "s, /lib64/, ${_sysroot}/lib64/,g;s, /usr/lib64/, ${_sysroot}/usr/lib64/,g" \
-			-i ${_sysroot}/usr/lib/libm.so
-		touch .sed_subst_done
-	fi
-
-	_args="--prefix=/usr"
-	_args+=" --libdir=/usr/lib"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --with-gnu-as"
-	_args+=" --with-gnu-ld"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-linker-build-id"
-	_args+=" --enable-gnu-unique-object"
-	_args+=" --enable-shared"
-	_args+=" --enable-threads=posix"
-	_args+=" --enable-libquadmath"
-	_args+=" --disable-nls"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libstdcxx-pch"
-	_args+=" --disable-sjlj-exceptions"
-
-	CC="gcc" CXX="g++" CFLAGS="-O2 -pipe" \
-		../gcc-${_gcc_version}/configure ${_args}
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	unset LDFLAGS
-	export CFLAGS="-Os -fPIC" CXXFLAGS="-Os -fPIC"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_glibc_headers
-	_glibc_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers for x86
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=x86 INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install glibc for target
-	cd ${wrksrc}/glibc-build
-	make install_root=${DESTDIR}/${_sysroot} install install-headers
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
-
-do_clean() {
-	# Remove temporary stuff from masterdir
-	rm -rf ${_sysroot}
-	rm -f /usr/bin/${_triplet}*
-	rm -rf /usr/lib/gcc/${_triplet}
-	rm -rf /usr/libexec/gcc/${_triplet}
-}
 
 cross-x86_64-linux-gnu-libc_package() {
 	short_desc+=" - glibc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/cross-x86_64-linux-musl/template
+++ b/srcpkgs/cross-x86_64-linux-musl/template
@@ -1,18 +1,18 @@
 # Template file for 'cross-x86_64-linux-musl'
-#
+_triplet=x86_64-linux-musl
 _binutils_version=2.32
 _gcc_version=9.3.0
 _musl_version=1.1.24
 _linux_version=4.19
 _libucontext_version=0.9.0
-
-_triplet=x86_64-linux-musl
-_sysroot="/usr/${_triplet}"
-
 pkgname=cross-${_triplet}
 version=0.33
 revision=4
-short_desc="Cross toolchain for x86_64 with musl"
+build_style=void-cross
+hostmakedepends="tar gcc-objc gcc-go flex perl python3"
+makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
+depends="${pkgname}-libc-${version}_${revision}"
+short_desc="Void cross toolchain for ${_triplet}"
 maintainer="Orphaned <orphan@voidlinux.org>"
 homepage="https://www.voidlinux.org/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, MIT"
@@ -27,302 +27,26 @@ checksum="0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
  1370c9a812b2cf2a7d92802510cca0058cc37e66a7bedd70051f0a34015022a3
  0c68f5655528aed4f99dae71a5b259edc93239fa899e2df79c055275c21749a1
  0d53a415a307ef175153bbe60a572c940a922cb736ce13530b666e7ec2795d68"
-
-lib32disabled=yes
 nocross=yes
-nopie=yes
-nodebug=yes
-create_wrksrc=yes
-hostmakedepends="tar gcc-objc gcc-go flex perl python3"
-makedepends="zlib-devel gmp-devel mpfr-devel libmpc-devel isl15-devel"
-nostrip_files="libcaf_single.a libgcc.a libgcov.a libgcc_eh.a
- libgnarl_pic.a libgnarl.a libgnat_pic.a libgnat.a libgmem.a"
-depends="${pkgname}-libc-${version}_${revision}"
 
-if [ "$XBPS_TARGET_WORDSIZE" != "64" ]; then
-	broken="64-bit crosstoolchain only available on 64-bit host"
-fi
+cross_triplet=${_triplet}
+cross_libucontext_arch=x86_64
+cross_linux_arch=x86
+# explicitly enable for final gcc, gfortran does not build without on x86
+cross_gcc_configure_args="--enable-libquadmath"
+cross_musl_cflags="-O2"
 
 if [ "$XBPS_TARGET_MACHINE" = "x86_64-musl" ]; then
 	broken="Can't build crosstoolchain to itself"
 fi
-
-_apply_patch() {
-	local args="$1" pname="$(basename $2)"
-
-	if [ ! -f ".${pname}_done" ]; then
-		patch -N $args -i $2
-		touch .${pname}_done
-	fi
-}
-
-_binutils_build() {
-	local _args
-
-	[ -f ${wrksrc}/.binutils_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross binutils bootstrap\n"
-
-	[ ! -d binutils-build ] && mkdir binutils-build
-	cd binutils-build
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --disable-nls"
-	_args+=" --disable-multilib"
-	_args+=" --disable-werror"
-	_args+=" --disable-shared"
-	_args+=" --with-system-zlib"
-	_args+=" ${_fpuflags}"
-
-	../binutils-${_binutils_version}/configure ${_args}
-
-	make configure-host
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.binutils_build_done
-}
-
-_gcc_bootstrap() {
-	local _args
-
-	[ -f ${wrksrc}/.gcc_bootstrap_done ] && return 0
-
-	cd ${wrksrc}/gcc-${_gcc_version}
-	for f in ${XBPS_SRCPKGDIR}/gcc/patches/*.patch; do
-		_apply_patch -p0 "$f"
-	done
-	for f in ${XBPS_SRCPKGDIR}/gcc/files/*-musl.patch; do
-		_apply_patch -p1 "$f"
-	done
-
-	msg_normal "Building cross gcc bootstrap\n"
-
-	[ ! -d ../gcc-bootstrap ] && mkdir ../gcc-bootstrap
-	cd ../gcc-bootstrap
-	export ac_cv_c_compiler_gnu=yes
-
-	_args="--prefix=/usr"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c"
-	_args+=" --with-newlib"
-	_args+=" --disable-libssp"
-	_args+=" --disable-nls"
-	_args+=" --disable-libquadmath"
-	_args+=" --disable-threads"
-	_args+=" --disable-decimal-float"
-	_args+=" --disable-shared"
-	_args+=" --disable-libmudflap"
-	_args+=" --disable-libgomp"
-	_args+=" --disable-libatomic"
-	_args+=" --disable-symvers"
-	_args+=" --disable-libmpx"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-	find -name Makefile -exec sed -i "{}" -e "s;^CFLAGS.*;& -fPIC -D__WCHAR_TYPE__=int;" \;
-
-	make ${makejobs}
-	make install
-
-	touch ${wrksrc}/.gcc_bootstrap_done
-}
-
-_linux_headers() {
-	[ -f ${wrksrc}/.linux_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building Linux API headers\n"
-
-	cd linux-${_linux_version}
-
-	for f in ${XBPS_SRCPKGDIR}/kernel-libc-headers/patches/*.patch; do
-		_apply_patch -p0 $f
-	done
-
-	make ARCH=x86 headers_check
-	make ARCH=x86 INSTALL_HDR_PATH=${_sysroot}/usr headers_install
-
-	touch ${wrksrc}/.linux_build_done
-}
-
-_musl_build() {
-	[ -f ${wrksrc}/.musl_build_done ] && return 0
-
-	cd ${wrksrc}/musl-${_musl_version}
-	msg_normal "Building cross musl libc\n"
-
-	# Apply musl patches if there are any
-	if [ -d "${XBPS_SRCPKGDIR}/musl/patches" ]; then
-		for f in ${XBPS_SRCPKGDIR}/musl/patches/*.patch; do
-			_apply_patch -p0 "$f"
-		done
-	fi
-
-	CC="${_triplet}-gcc" CFLAGS="-Os -pipe -fPIC ${_archflags}" \
-		./configure --prefix=/usr
-
-	make ${makejobs}
-	make DESTDIR=${_sysroot} install
-
-	touch ${wrksrc}/.musl_build_done
-}
-
-_libucontext_build() {
-	[ -f ${wrksrc}/.libucontext_build_done ] && return 0
-
-	cd ${wrksrc}/libucontext-${_libucontext_version}
-	msg_normal "Building cross libucontext\n"
-
-	# it's ok if we're static only here
-	CC="${_triplet}-gcc" AR="${_triplet}-ar" AS="${_triplet}-as" \
-		CFLAGS="-Os -pipe ${_archflags}" \
-		make ARCH=x86_64 libucontext.a
-
-	cp libucontext.a ${_sysroot}/usr/lib
-
-	touch ${wrksrc}/.libucontext_build_done
-}
-
-_gcc_build() {
-	local _args
-	[ -f ${wrksrc}/.gcc_build_done ] && return 0
-
-	cd ${wrksrc}
-	msg_normal "Building cross gcc final\n"
-
-	[ ! -d gcc-build ] && mkdir gcc-build
-	cd gcc-build
-
-	_args="--prefix=/usr"
-	_args+=" --libexecdir=/usr/lib"
-	_args+=" --target=${_triplet}"
-	_args+=" --with-sysroot=${_sysroot}"
-	_args+=" --enable-languages=c,ada,c++,objc,obj-c++,go,fortran,lto"
-	_args+=" --enable-libada"
-	_args+=" --enable-lto"
-	_args+=" --enable-default-pie"
-	_args+=" --enable-default-ssp"
-	_args+=" --enable-libssp"
-	_args+=" --enable-libquadmath"
-	_args+=" --disable-libsanitizer"
-	_args+=" --disable-multilib"
-	_args+=" --disable-libmpx"
-	_args+=" --disable-libmudflap"
-	_args+=" --enable-shared"
-	_args+=" --disable-symvers"
-	_args+=" libat_cv_have_ifunc=no"
-	_args+=" ${_fpuflags}"
-
-	../gcc-${_gcc_version}/configure ${_args}
-	find -name Makefile -exec sed -i "{}" -e "s;^CFLAGS.*;& -fPIC -D__WCHAR_TYPE__=int;" \;
-
-	make ${makejobs}
-
-	touch ${wrksrc}/.gcc_build_done
-}
-
-do_build() {
-	# Ensure we use sane environment
-	unset CC CXX CPP LD AS AR RANLIB OBJDUMP READELF NM
-	unset CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
-	export CFLAGS="-Os -pipe -fPIC" CXXFLAGS="-Os -pipe -fPIC"
-
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${_sysroot}/usr/${f} ]; then
-			mkdir -p ${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${_sysroot}/${f} ]; then
-			ln -sfr ${_sysroot}/usr/${f} ${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${_sysroot}/usr/lib64
-	ln -sf usr/lib ${_sysroot}/lib64
-
-	_binutils_build
-	_gcc_bootstrap
-	_linux_headers
-	_musl_build
-	_libucontext_build
-	_gcc_build
-}
-
-do_install() {
-	for f in include lib libexec bin sbin; do
-		if [ ! -d ${DESTDIR}/${_sysroot}/usr/${f} ]; then
-			mkdir -p ${DESTDIR}/${_sysroot}/usr/${f}
-		fi
-		if [ ! -h ${DESTDIR}/${_sysroot}/${f} ]; then
-			ln -sfr ${DESTDIR}/${_sysroot}/usr/${f} \
-				${DESTDIR}/${_sysroot}/${f}
-		fi
-	done
-	ln -sf lib ${DESTDIR}/${_sysroot}/usr/lib64
-	ln -sf usr/lib ${DESTDIR}/${_sysroot}/lib64
-
-	# install linux API headers for x86
-	cd ${wrksrc}/linux-${_linux_version}
-	make ARCH=x86 INSTALL_HDR_PATH=${DESTDIR}/${_sysroot}/usr headers_install
-	rm -f $(find ${DESTDIR}/${_sysroot}/usr/include -name .install -or -name ..install.cmd)
-	rm -rf ${DESTDIR}/${_sysroot}/usr/include/drm
-
-	# install cross binutils
-	cd ${wrksrc}/binutils-build
-	make DESTDIR=${DESTDIR} install
-
-	# install cross gcc
-	cd ${wrksrc}/gcc-build
-	make DESTDIR=${DESTDIR} install
-
-	# move libcc1.so* to the sysroot
-	mv ${DESTDIR}/usr/lib/libcc1.so* ${DESTDIR}/${_sysroot}/usr/lib
-
-	# install musl libc for target
-	cd ${wrksrc}/musl-${_musl_version}
-	make DESTDIR=${DESTDIR}/${_sysroot} install
-
-	# Remove useless headers.
-	rm -rf ${DESTDIR}/usr/lib/gcc/${_triplet}/*/include-fixed/
-
-	# Make ld-musl-x86_64.so.1 symlink relative to cwd.
-	cd ${DESTDIR}/${_sysroot}/usr/lib
-	ln -sf libc.so ld-musl-x86_64.so.1
-
-	# symlinks for gnarl and gnat shared libraries
-	_majorver=${_gcc_version%.*.*}
-	_adalib=usr/lib/gcc/${_triplet}/${_gcc_version}/adalib
-	mv -v ${DESTDIR}/${_adalib}/libgnarl-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	mv -v ${DESTDIR}/${_adalib}/libgnat-${_majorver}.so ${DESTDIR}/${_sysroot}/usr/lib
-	ln -svf libgnarl-${_majorver}.so libgnarl.so
-	ln -svf libgnat-${_majorver}.so libgnat.so
-	rm -vf ${DESTDIR}/${_adalib}/libgna{rl,t}.so
-
-	# We need to build libatomic in target gcc as gccgo needs it to
-	# build... but it's not needed at runtime, so remove it from the
-	# destdir so it doesn't conflict with the libatomic package
-	rm -f ${DESTDIR}/${_sysroot}/usr/lib/libatomic.*
-
-	# Remove unnecessary stuff
-	rm -f ${DESTDIR}/usr/lib*/libiberty.a
-	rm -rf ${DESTDIR}/usr/share
-	rm -rf ${DESTDIR}/${_sysroot}/{etc,var}
-	rm -rf ${DESTDIR}/${_sysroot}/usr/{sbin,share,libexec}
-	rm -f ${DESTDIR}/${_sysroot}/libexec
-	rm -f ${DESTDIR}/${_sysroot}/lib/*.py
-	rm -f ${DESTDIR}/${_sysroot}/{sbin,lib}
-}
 
 cross-x86_64-linux-musl-libc_package() {
 	short_desc+=" - libc files"
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
+
 	pkg_install() {
-		vmove ${_sysroot}
+		vmove usr/${cross_triplet}
 	}
 }

--- a/srcpkgs/gcc/files/libgnarl-musl.patch
+++ b/srcpkgs/gcc/files/libgnarl-musl.patch
@@ -3,8 +3,8 @@ Upstream: Unknown
 Reason: Patch libgnarl to not use function missing from musl.
 
 diff -rup gcc-8.2.0/gcc/ada/libgnarl/s-osinte__linux.ads gcc-8.2.0-new/gcc/ada/libgnarl/s-osinte__linux.ads
---- gcc-8.2.0/gcc/ada/libgnarl/s-osinte__linux.ads	2018-01-11 00:55:25.000000000 -0800
-+++ gcc-8.2.0-new/gcc/ada/libgnarl/s-osinte__linux.ads	2018-11-01 16:16:23.372452951 -0700
+--- gcc/ada/libgnarl/s-osinte__linux.ads	2018-01-11 00:55:25.000000000 -0800
++++ gcc/ada/libgnarl/s-osinte__linux.ads	2018-11-01 16:16:23.372452951 -0700
 @@ -394,12 +394,6 @@ package System.OS_Interface is
     PTHREAD_RWLOCK_PREFER_WRITER_NP              : constant := 1;
     PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP : constant := 2;
@@ -31,8 +31,8 @@ diff -rup gcc-8.2.0/gcc/ada/libgnarl/s-osinte__linux.ads gcc-8.2.0-new/gcc/ada/l
        sched_priority : int;  --  scheduling priority
     end record;
 diff -rup gcc-8.2.0/gcc/ada/libgnarl/s-taprop__linux.adb gcc-8.2.0-new/gcc/ada/libgnarl/s-taprop__linux.adb
---- gcc-8.2.0/gcc/ada/libgnarl/s-taprop__linux.adb	2018-01-11 00:55:25.000000000 -0800
-+++ gcc-8.2.0-new/gcc/ada/libgnarl/s-taprop__linux.adb	2018-11-13 11:28:36.433964449 -0800
+--- gcc/ada/libgnarl/s-taprop__linux.adb	2018-01-11 00:55:25.000000000 -0800
++++ gcc/ada/libgnarl/s-taprop__linux.adb	2018-11-13 11:28:36.433964449 -0800
 @@ -202,9 +202,6 @@ package body System.Task_Primitives.Oper
     pragma Import
       (C, GNAT_pthread_condattr_setup, "__gnat_pthread_condattr_setup");

--- a/srcpkgs/gcc/files/libssp-musl.patch
+++ b/srcpkgs/gcc/files/libssp-musl.patch
@@ -2,8 +2,8 @@ First part taken from Alpine.
 
 Second part added to prevent gccgo from thinking it can -fsplit-stack on musl.
 
---- a/gcc/gcc.c
-+++ b/gcc/gcc.c
+--- gcc/gcc.c
++++ gcc/gcc.c
 @@ -876,9 +876,8 @@
  #endif
  
@@ -15,8 +15,8 @@ Second part added to prevent gccgo from thinking it can -fsplit-stack on musl.
  #else
  #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
  		       "|fstack-protector-strong|fstack-protector-explicit" \
---- a/gcc/config/i386/gnu-user-common.h
-+++ b/gcc/config/i386/gnu-user-common.h
+--- gcc/config/i386/gnu-user-common.h
++++ gcc/config/i386/gnu-user-common.h
 @@ -64,9 +64,3 @@ along with GCC; see the file COPYING3.  If not see
  
  /* Static stack checking is supported by means of probes.  */
@@ -27,8 +27,8 @@ Second part added to prevent gccgo from thinking it can -fsplit-stack on musl.
 -#if HAVE_GAS_CFI_PERSONALITY_DIRECTIVE
 -#define TARGET_CAN_SPLIT_STACK
 -#endif
---- a/gcc/config/i386/gnu.h
-+++ b/gcc/config/i386/gnu.h
+--- gcc/config/i386/gnu.h
++++ gcc/config/i386/gnu.h
 @@ -40,11 +40,6 @@ along with GCC.  If not, see <http://www.gnu.org/licenses/>.
  /* i386 glibc provides __stack_chk_guard in %gs:0x14.  */
  #define TARGET_THREAD_SSP_OFFSET        0x14

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -173,8 +173,8 @@ pre_configure() {
 	sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" {gcc,libiberty}/configure
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl)
-			patch -p1 -i ${FILESDIR}/libgnarl-musl.patch
-			patch -p1 -i ${FILESDIR}/libssp-musl.patch
+			patch -p0 -i ${FILESDIR}/libgnarl-musl.patch
+			patch -p0 -i ${FILESDIR}/libssp-musl.patch
 			patch -p0 -i ${FILESDIR}/gccgo-musl.patch
 			;;
 	esac


### PR DESCRIPTION
This introduces a build-style for system crosstoolchains. It only works, and will only work, for toolchains targeting Void and one of its standard libraries. The none targets and stuff like mingw are explicitly a non-goal, to reduce the amount of magic we have to do.

This has a bunch of advantages:

- crosstoolchain templates can now be small and simple
- crosstoolchains writen with this build-style will no longer mess up masterdirs like the existing ones do; you can safely build your stuff without `-t` and your `masterdir` will be pristine
- unification of options passed to `gcc`/libc/`binutils` configure, as much as possible
- reduced repeated boilerplate code between individual crosstoolchains
- `ccache` friendly
- easier upgrades, easier maintenance, etc

This is currently incomplete. These things are left to do:

- [x] Add musl support
- [x] Clean up the configure params, only keep the generic ones in the build-style, specific ones will go into individual crosstoolchains (this one is largely based on what the aarch64 one was doing)
- [x] 64-bit cross on 32-bit hosts is probably actually fine in general, we just need to enable it
- ~~Allow glibc crosstoolchains on musl~~ (this needs `glibc` 2.32 so it will be done later)

Toolchain rewrite TODO:

- [x] `cross-aarch64-linux-gnu`
- [x] `cross-aarch64-linux-musl`
- [x] `cross-arm-linux-gnueabi`
- [x] `cross-arm-linux-musleabi`
- [x] `cross-arm-linux-gnueabihf`
- [x] `cross-arm-linux-musleabihf`
- [x] `cross-armv7l-linux-gnueabihf`
- [x] `cross-armv7l-linux-musleabihf`
- [x] `cross-i686-pc-linux-gnu`
- [x] `cross-i686-linux-musl`
- [x] `cross-mips-linux-musl`
- [x] `cross-mips-linux-muslhf`
- [x] `cross-mipsel-linux-musl`
- [x] `cross-mipsel-linux-muslhf`
- [x] `cross-powerpc-linux-gnu`
- [x] `cross-powerpc-linux-musl`
- [x] `cross-powerpcle-linux-gnu`
- [x] `cross-powerpcle-linux-musl`
- [x] `cross-powerpc64-linux-gnu`
- [x] `cross-powerpc64-linux-musl`
- [x] `cross-powerpc64le-linux-gnu`
- [x] `cross-powerpc64le-linux-musl`
- [x] `cross-x86_64-linux-gnu`
- [x] `cross-x86_64-linux-musl`

For now, posting for input.

@Duncaen @leahneukirchen @pullmoll @ericonr @void-linux/pkg-committers 

[ci skip]