### PR TITLE
cherrytree: update to 0.99.27

### DIFF
--- a/srcpkgs/cherrytree/template
+++ b/srcpkgs/cherrytree/template
@@ -1,20 +1,18 @@
 # Template file for 'cherrytree'
 pkgname=cherrytree
-version=0.99.21
+version=0.99.27
 revision=1
 build_style=cmake
 hostmakedepends="gettext pkg-config desktop-file-utils python3 glib-devel"
 makedepends="cpputest uchardet-devel libcurl-devel sqlite-devel
  libxml++-devel gtksourceviewmm-devel gspell-devel gtkmm-devel"
 depends="desktop-file-utils"
-checkdepends="xvfb-run"
 short_desc="Hierarchial note taking application with syntax highlighting"
 maintainer="Logen K <logen@sudotask.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.giuspen.com/cherrytree/"
 distfiles="https://github.com/giuspen/cherrytree/archive/$version.tar.gz"
-checksum=5c180fdf5cbab43bc496a246ce952e7f39e84b2a7b4cabdb22773b9d4a415850
-
-do_check() {
-	xvfb-run make -C build test
-}
+checksum=fff13c6b764eaa952616308a53cb5bd863b37f913bd74891117b4da20ff29832
+configure_args+=" -DBUILD_GMOCK:BOOL='OFF'
+ -DBUILD_GTEST:BOOL='OFF'
+ -DBUILD_TESTING:BOOL='OFF'"


### PR DESCRIPTION
They decided to use gtest, which is fine, but it seems as though they expect gtest to be pulled in as a sub module, which, of course, ends up being an empty folder in the release tar ball. 

As seen here:

https://github.com/giuspen/cherrytree/tree/master/tests

If I pull in gtest, as it expects, it tests out properly, but I'm not sure how to do that properly for a void build, so I opted to disable the testing.

Always happy to learn better way to deal with things like this.