### PR TITLE
nx-libs, x2goclient and x2goserver

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3987,3 +3987,6 @@ libmariadb.so.3 libmariadbclient-10.5.9_1
 libmariadbd.so.19 libmariadbclient-10.5.9_1
 libinstpatch-1.0.so.2 libinstpatch-1.1.6_1
 libbasu.so.0 basu-0.2.0_1
+libXcomp.so.3 nx-libs-3.5.99.24_1
+libXcompshad.so.3 nx-libs-3.5.99.24_1
+libNX_X11.so.6 nx-libs-3.5.99.24_1

--- a/srcpkgs/nx-libs/patches/fix-musl-headers-x86.patch
+++ b/srcpkgs/nx-libs/patches/fix-musl-headers-x86.patch
@@ -1,0 +1,11 @@
+--- ./nx-X11/extras/Mesa/src/mesa/main/glheader.h.orig
++++ ./nx-X11/extras/Mesa/src/mesa/main/glheader.h
+@@ -62,7 +62,7 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+-#if defined(__linux__) && defined(__i386__)
++#if defined(__GLIBC__) && defined(__i386__)
+ #include <fpu_control.h>
+ #endif
+ #endif

--- a/srcpkgs/nx-libs/patches/xf86bigfont.patch
+++ b/srcpkgs/nx-libs/patches/xf86bigfont.patch
@@ -1,0 +1,10 @@
+--- nx-X11/programs/Xserver/Xext/xf86bigfont.c	2021-02-04 14:34:56.000000000 +0100
++++ -	2021-05-10 08:55:11.108944904 +0200
+@@ -45,7 +45,6 @@
+ /* Linux libc4 and libc5 only (because glibc doesn't include kernel headers):
+    Linux 2.0.x and 2.2.x define SHMLBA as PAGE_SIZE, but forget to define
+    PAGE_SIZE. It is defined in <asm/page.h>. */
+-#include <asm/page.h>
+ #include <limits.h>
+ #endif
+ #ifdef SVR4

--- a/srcpkgs/nx-libs/template
+++ b/srcpkgs/nx-libs/template
@@ -1,0 +1,62 @@
+# Template file for 'nx-libs'
+pkgname=nx-libs
+version=3.5.99.26
+revision=1
+build_style=gnu-configure
+make_build_args="CONFIGURE=echo IMAKE_DEFINES=-DUseTIRPC=YES"
+make_install_args="PREFIX=/usr"
+hostmakedepends="autoconf automake libtool pkg-config which imake xkbcomp gccmakedep"
+makedepends="xorgproto zlib-devel libjpeg-turbo-devel libpng-devel
+ libXext-devel libXdamage-devel libXrandr-devel libXtst-devel pixman-devel
+ libXfont2-devel libxml2-devel libXcomposite-devel libXinerama-devel
+ libtirpc-devel libXpm-devel font-util xkbcomp"
+short_desc="NX X11 protocol compression libraries"
+maintainer="eoli3n <jkirsz@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/ArcticaProject/nx-libs"
+distfiles="https://github.com/ArcticaProject/nx-libs/archive/$version/$pkgname-$version.tar.gz"
+checksum=3ce7ca4e6b57b3a2d7588b2d0f4009036d2566a8925ca2c62f08a8dc0df50357
+python_version=3
+nocross="imake attempts to run target executables on host"
+
+post_patch() {
+	# Replace hard-coded /usr/local ProjectRoot
+	vsed -e '/ProjectRoot/s,/usr/local,/usr,' -i nx-X11/config/cf/site.def
+	# Manually run autoreconf in pre_configure, disable in Makefile
+	vsed -e 's/autoreconf/echo &-disabled/' -i Makefile
+}
+
+pre_configure() {
+	# Create configure scripts for all subprojects
+	local _subdir
+	for _subdir in nxcomp nx-X11/lib nxcompshad nxproxy nxdialog; do
+		( cd ${_subdir} && autoreconf -vfsi )
+	done
+}
+
+do_configure() {
+	# Configure all subprojects in advance of build
+	local _subdir
+	for _subdir in nxcomp nxcompshad nxproxy nxdialog; do
+		( cd ${_subdir} && ./configure ${configure_args} )
+	done
+
+	# nx-X11 configure has an extra argument
+	( cd nx-X11/lib && ./configure ${configure_args} --disable-poll )
+}
+
+post_install() {
+	# Remove conflicting GL headers
+	rm -rf ${DESTDIR}/usr/include/GL
+}
+
+nx-libs-devel_install() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+	}
+}

--- a/srcpkgs/x2goclient/template
+++ b/srcpkgs/x2goclient/template
@@ -1,0 +1,20 @@
+# Template file for 'x2goclient'
+pkgname=x2goclient
+version=4.1.2.2
+revision=1
+build_style=gnu-makefile
+build_helper=qmake
+make_build_args="QMAKE_BINARY=qmake-qt5 LRELEASE_BINARY=lrelease-qt5"
+make_build_target="build_client build_man"
+make_install_args="$make_build_args"
+make_install_target="install_client install_man"
+hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
+makedepends="qt5-svg-devel qt5-x11extras-devel libldap-devel
+ libssh-devel libXpm-devel cups-devel"
+depends="nx-libs"
+short_desc="Graphical Qt5 client for X2Go"
+maintainer="eoli3n <jkirsz@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="http://www.x2go.org"
+distfiles="http://code.x2go.org/releases/source/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=c9953267c40fa67119ad96a73bacb1f266196da2059f0cdcd1b8d5199421d12a

--- a/srcpkgs/x2goserver/template
+++ b/srcpkgs/x2goserver/template
@@ -1,0 +1,28 @@
+# Template file for 'x2goserver'
+pkgname=x2goserver
+version=4.1.0.3
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config perl"
+makedepends="libssh2-devel"
+depends="perl perl-Config-Simple perl-DBI perl-Capture-Tiny perl-DBD-SQLite bash iproute2 makepasswd openssh lsof xauth perl-File-BaseDir nx-libs perl-File-Which"
+short_desc="Open source graphical Remote Desktop based on NX technology"
+maintainer="eoli3n <jkirsz@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="http://www.x2go.org"
+distfiles="http://code.x2go.org/releases/source/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=6776aaa354f5a44e349f0b3c176d4988c88a618c2edf46c98a37ae89c069dcd0
+system_groups="x2gouser"
+system_accounts="x2gouser"
+x2gouser_homedir="/var/lib/x2go"
+x2gouser_shell="/bin/false"
+
+post_extract() {
+	# Replace hard-coded /usr/sbin
+	for _file in x2goserver-printing/Makefile x2goserver/Makefile x2goserver-xsession/Makefile libx2go-server-db-perl/Makefile x2goserver-common/Makefile; do
+		vsed -e 's,/sbin,/bin,g' -i "$_file"
+	done
+	for _file in bin/x2golistdesktops bin/x2goresume-session bin/x2gostartagent sbin/x2gocleansessions; do
+		vsed -e 's,/usr/sbin,/usr/bin,g' -i x2goserver/"$_file"
+	done
+}


### PR DESCRIPTION
Closes https://github.com/void-linux/void-packages/issues/9779 and https://github.com/void-linux/void-packages/issues/2091

From https://github.com/renatoaguiar/void-packages/tree/x2goclient
Ping @renatoaguiar, I sent you a mail, if you want to be the maintainer, just ask.

# nx-libs
- [x] Changed license
- [x] Updated maintainer
- [x] Changed nx-libs source to https://github.com/ArcticaProject/nx-libs/
- [x] Updated to latest version
- [x] Set ``python_version``
- [x] Added libs to ``common/shlib``
- [x] Patch for musl, and bigfont
- [x] Disable cross compilation for the current version
- [x] Discussion to fix some limitations upstream in next versions : https://github.com/ArcticaProject/nx-libs/issues/975
  - Drop imake for automake: crossbuild for arm -> WIP https://github.com/ArcticaProject/nx-libs/pull/946
  - Patch mesa and bigfont: native musl builds -> WIP https://github.com/ArcticaProject/nx-libs/pull/976

The current version is ok to be merged.

# x2goclient
- [x] Changed license
- [x] Updated maintainer
- [x] Updated to latest version
- [ ] Disable cross compilation until nx-libs update ?
# x2goserver

- [x] Create template
- [x] Patch ``/usr/sbin`` references
- [ ] Init script for ``$PREFIX/bin/x2gocleansessions``
- [ ] Write runit service
- [ ] Disable cross compilation until nx-libs update ?

# Note
- https://git.alpinelinux.org/aports/tree/community/nx-libs/APKBUILD
- https://git.alpinelinux.org/aports/tree/community/x2goserver/APKBUILD