### PR TITLE
qjackctl: update to 0.9.0.

### DIFF
--- a/srcpkgs/qjackctl/template
+++ b/srcpkgs/qjackctl/template
@@ -1,6 +1,6 @@
 # Template file for 'qjackctl'
 pkgname=qjackctl
-version=0.6.3
+version=0.9.0
 revision=1
 build_style=gnu-configure
 build_helper=qmake
@@ -12,13 +12,9 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://qjackctl.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=9db46376cfacb2e2ee051312245f5f7c383c9f5a958c0e3d661b9bd2a9246b7d
+checksum=5196c5c01b7948c1a8ca37cd3198a7f0fe095a99a34a67086abd3466855b4abd
 
 if [ "${CROSS_BUILD}" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel qt5-x11extras-devel"
 	configure_args+=" ac_cv_path_ac_cv_qmake=${XBPS_WRAPPERDIR}/qmake"
 fi
-
-do_patch() {
-	vsed -i '21i#include <unistd.h> // gethostname()' src/qjackctl.cpp
-}


### PR DESCRIPTION
patch is obsolete since
https://sourceforge.net/p/qjackctl/code/ci/28bfd1e92c433aef9c65dfac801e7181bb1289eb/