### PR TITLE
noto-fonts-cjk: add 70-noto-fonts-cjk.conf

### DIFF
--- a/srcpkgs/noto-fonts-cjk/files/conf.avail
+++ b/srcpkgs/noto-fonts-cjk/files/conf.avail
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+    <match target="pattern">
+        <test name="lang">
+            <string>ja</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Serif CJK JP</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ko</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Serif CJK KR</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-cn</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK SC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-tw</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Serif CJK HK</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ja</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans CJK JP</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ko</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans CJK KR</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-cn</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK SC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-tw</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>sans-serif</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans CJK HK</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ja</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans Mono CJK JP</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>ko</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend">
+            <string>Noto Sans Mono CJK KR</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-cn</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK SC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-tw</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK TC</string>
+        </edit>
+    </match>
+
+    <match target="pattern">
+        <test name="lang">
+            <string>zh-hk</string>
+        </test>
+        <test name="family">
+            <string>monospace</string>
+        </test>
+        <edit name="family" mode="prepend" binding="strong">
+            <string>Noto Sans Mono CJK HK</string>
+        </edit>
+    </match>
+</fontconfig>

--- a/srcpkgs/noto-fonts-cjk/template
+++ b/srcpkgs/noto-fonts-cjk/template
@@ -1,7 +1,7 @@
 # Template file for 'noto-fonts-cjk'
 pkgname=noto-fonts-cjk
 version=20190416
-revision=2
+revision=3
 _githash=be6c059ac1587e556e2412b27f5155c8eb3ddbe6
 wrksrc="noto-cjk-${_githash}"
 depends="font-util"
@@ -17,5 +17,6 @@ font_dirs="/usr/share/fonts/noto"
 
 do_install() {
 	install -Dm644 Noto*.ttc -t ${DESTDIR}/usr/share/fonts/noto
+	vinstall ${FILESDIR}/conf.avail 644 etc/fonts/conf.avail 70-noto-fonts-cjk.conf
 	vlicense LICENSE
 }


### PR DESCRIPTION
Installs a configuration file to config.avail which sets the default font for Chinese, Japanese, and Korean to their corresponding Noto CJK variant. Would be useful for setting up Noto CJK as the default font for CJK languages.