### PR TITLE
containerd: Install runc shims

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,11 +1,13 @@
 # Template file for 'containerd'
 pkgname=containerd
 version=1.3.9
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/containerd/containerd
 go_package="${go_import_path}/cmd/containerd
  ${go_import_path}/cmd/containerd-shim
+ ${go_import_path}/cmd/containerd-shim-runc-v1
+ ${go_import_path}/cmd/containerd-shim-runc-v2
  ${go_import_path}/cmd/ctr"
 go_ldflags="-X ${go_import_path}/version.Version=${version}
  -X ${go_import_path}/version.Revision=UNSET"


### PR DESCRIPTION
The runc shims were not being installed.  I believe this change is all that is needed to get them installed properly.
I tested this by switching my Kubernetes install to use containerd runtime instead of docker.

cc @pauldotknopf