### PR TITLE
musl: fix ldd symlink for multilib systems.

### DIFF
--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -32,7 +32,7 @@ do_install() {
 	rm ${DESTDIR}/lib
 	# provide ldd
 	vmkdir usr/bin
-	ln -s /usr/lib/libc.so ${DESTDIR}/usr/bin/ldd
+	ln -s ../lib${XBPS_TARGET_WORDSIZE}/libc.so ${DESTDIR}/usr/bin/ldd
 	# additional utils from Alpine/NetBSD
 	vbin iconv
 	vbin getent


### PR DESCRIPTION
Also allows it to be called in any situation, not only when
/usr/lib/libc.so is indeed musl.

Not increasing revision, since this isn't an urgent fix.

@q66