### PR TITLE
xfce4-settings: use xrandr

### DIFF
--- a/srcpkgs/xfce4-settings/template
+++ b/srcpkgs/xfce4-settings/template
@@ -1,12 +1,12 @@
 # Template file for 'xfce4-settings'
 pkgname=xfce4-settings
 version=4.16.0
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--enable-sound-settings --enable-pluggable-dialogs"
+configure_args="--enable-sound-settings --enable-pluggable-dialogs --enable-xrandr"
 hostmakedepends="intltool pkg-config"
 makedepends="exo-devel garcon-devel libcanberra-devel libnotify-devel
- libxklavier-devel upower-devel"
+ libxklavier-devel upower-devel libXrandr-devel"
 depends="desktop-file-utils gnome-icon-theme"
 conf_files="/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml"
 short_desc="Xfce settings manager"


### PR DESCRIPTION
xfce4-display-settings now supports to scale the display with randr, something people with multi-monitor-setup with different resolutions (like me) will find incredibly helpful - and it's one of the major improvements of this package, so I think we should ship it as well.