### PR TITLE
WIP: Upcoming adblock feature in qutebrowser

### DIFF
--- a/srcpkgs/maturin/template
+++ b/srcpkgs/maturin/template
@@ -1,0 +1,21 @@
+# Template file for 'maturin'
+pkgname=maturin
+version=0.8.3
+revision=1
+#archs="i686 x86_64"
+wrksrc=maturin-$version
+build_style=cargo
+#configure_args=""
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends="python3-setuptools python3-toml cargo"
+makedepends=""
+depends=""
+short_desc="Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages"
+maintainer="Anjandev Momi <anjan@momi.ca>"
+license="Apache-2.0"
+homepage="https://github.com/PyO3/maturin"
+distfiles="https://github.com/PyO3/maturin/archive/v$version.tar.gz"
+checksum=8e18580bd4911b438331deee6a15cf755ccc425547fb26c027306b385845285e

--- a/srcpkgs/python3-adblock/template
+++ b/srcpkgs/python3-adblock/template
@@ -1,0 +1,28 @@
+# Template file for 'python3-adblock'
+pkgname=python3-adblock
+version=0.4.0
+revision=1
+#archs="i686 x86_64"
+#wrksrc=
+#create_wrksrc=yes
+build_style=python3-module
+#configure_args=""
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends="python3-setuptools python3-dephell cargo maturin pkg-config"
+makedepends="libressl-devel"
+depends="python3"
+short_desc="Python wrapper for Brave's adblocking library, which is written in Rust"
+maintainer="Anjandev Momi <anjan@momi.ca>"
+license="MIT"
+homepage="https://github.com/ArniDagur/python-adblock"
+distfiles="https://github.com/ArniDagur/python-adblock/archive/$version.tar.gz"
+wrksrc=python-adblock-$version
+checksum=49cf5bef7a637b9c08ddf6d2f68d11b522f341d2667ea9eb9ef584a59d130a92
+
+do_build() {
+    maturin build --release --strip
+    cargo build --release --locked --all-features --target-dir=.
+}

--- a/srcpkgs/python3-dephell/template
+++ b/srcpkgs/python3-dephell/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-dephell'
+pkgname=python3-dephell
+version=0.8.3
+revision=1
+build_style=python3-module
+#configure_args=""
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends="python3-setuptools"
+makedepends=""
+depends=""
+short_desc="Python project management"
+maintainer="Anjandev Momi <anjan@momi.ca>"
+license="MIT"
+homepage="https://dephell.org/"
+distfiles="https://github.com/dephell/dephell/archive/v.$version.tar.gz"
+checksum=d37fba0fb163831ba47bf94d140a56fa175251f1b80deba78ced4be10d92c8ae
+wrksrc=dephell-v.$version/


### PR DESCRIPTION
CC: @ericonr since he is the maintainer of qutebrowser

qutebrowser recently got proper adblock support:

https://github.com/qutebrowser/qutebrowser/pull/5317

But in order to use this, we need to package python3-adblock. I got to package python3-adblock's dependencies fine. There are still linting mistakes in those templates. I got to python3-adblock and got annoyed with rust so I stopped packaging.

Posting my work here so that it can be of use to others. Feel free to adopt this PR.