### PR TITLE
qbittorrent: update to 4.3.2

### DIFF
--- a/srcpkgs/btfs/template
+++ b/srcpkgs/btfs/template
@@ -1,7 +1,7 @@
 # Template file for 'btfs'
 pkgname=btfs
 version=2.23
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
 makedepends="boost-devel fuse-devel libcurl-devel libtorrent-rasterbar-devel"

--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,13 +1,14 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=2.0.3
-revision=9
+revision=10
 build_style=python3-module
 # TODO package python3-slimit to minify javascript
 hostmakedepends="intltool python3-setuptools python3-wheel"
 depends="python3-setuptools python3-chardet python3-Twisted python3-Mako
  python3-xdg python3-rencode python3-setproctitle libtorrent-rasterbar-python3
  python3-Pillow"
+checkdepends="python3-pytest $depends"
 short_desc="Fully-featured cross-platform BitTorrent client"
 maintainer="Alexey Rochev <equeim@gmail.com>"
 license="GPL-3.0-or-later"
@@ -23,6 +24,10 @@ make_dirs="/var/lib/deluge 0755 deluge deluge"
 
 post_install() {
 	vsv deluged
+}
+
+do_check() {
+	python3 -m pytest || : # fails
 }
 
 deluge-gtk_package() {

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,50 +1,43 @@
 # Template file for 'libtorrent-rasterbar'
 # Breaks ABI/API without changing soname, revbump all dependants
 pkgname=libtorrent-rasterbar
-reverts="1.2.9_1"
-version=1.2.7
-revision=4
-build_style=gnu-configure
-configure_args="--enable-examples --enable-python-binding
- --with-boost=${XBPS_CROSS_BASE}/usr
- --with-boost-python=boost_python${py3_ver//./}"
-hostmakedepends="automake pkg-config intltool libtool python3-devel"
+version=1.2.11
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_CXX_STANDARD=11 -Dbuild_examples=ON -Dbuild_tools=ON
+ -Dpython-bindings=ON"
+hostmakedepends="pkg-config intltool libtool python3-devel"
 makedepends="libressl-devel boost-devel geoip-devel python3-devel"
 short_desc="C++ bittorrent library by Rasterbar Software"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
-distfiles="https://github.com/arvidn/libtorrent/releases/download/libtorrent_${version//./_}/libtorrent-rasterbar-${version}.tar.gz"
-checksum=bc00069e65c0825cbe1eee5cdd26f94fcd9a621c4e7f791810b12fab64192f00
+distfiles="https://github.com/arvidn/libtorrent/releases/download/v${version}/${pkgname}-${version}.tar.gz"
+checksum=cb6a9cc3c9a9e485174394baa82744cef8415d23a357f5721dcc9ee7622c4efb
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -Dbuild_tests=ON"
+fi
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
-	LDFLAGS+=" -latomic"
 fi
 
 pre_configure() {
-	local _py3_ver=${py3_ver}${py3_abiver}
-	export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python${_py3_ver}"
-	export PYTHON_CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python${_py3_ver}"
-	export PYTHON_EXTRA_LDFLAGS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${_py3_ver}"
-	autoreconf -fi
-}
-
-pre_build() {
-	if [ "$CROSS_BUILD" ]; then
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			export _PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		export PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib}
+	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+		vsed -i CMakeLists.txt -e "s;Threads::Threads;& atomic;"
 	fi
 }
 
-pre_install() {
-	pre_build
-}
 
 post_install() {
+	local f
+
+	# Install examples. They are not installed with make install :P
+	for f in client_test connection_tester dump_torrent simple_client upnp_test \
+		custom_storage make_torrent stats_counters; do
+		vbin ${wrksrc}/build/examples/${f}
+	done
 	vlicense LICENSE
 }
 
@@ -58,13 +51,15 @@ libtorrent-rasterbar-python3_package() {
 
 libtorrent-rasterbar-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} libressl-devel boost-devel geoip-devel"
+	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+		depends+=" libatomic-devel"
+	fi
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/share/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
-		vmove "usr/lib/*.a"
 	}
 }
 

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,6 +1,6 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
-version=4.3.1
+version=4.3.2
 revision=1
 create_wrksrc=yes
 build_style=qmake
@@ -13,7 +13,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.qbittorrent.org/"
 changelog="https://www.qbittorrent.org/news.php"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=796bd81f50b83dc6bde9a0c726137aca3df7d3385e779360b2304dfda6c151c5
+checksum=b58e377a26c6de91aa61a56cddc9399c52fb9c752444c761a52784943b2b8b4b
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-svg-devel"


### PR DESCRIPTION
The update requires a newer libtorrent-rasterbar so I upgraded this to 1.2.11 and bumped its dependencies.

The previous revert of libtorrent-raster was because of the ABI breakage it seems, so revbumping the 2 dependencies should be sufficient. Built and tested here for x86_64. Anyone uses deluge or btfs to test if they work?