### PR TITLE
gimp: put locale data in /usr/share/locale.

### DIFF
--- a/srcpkgs/babl/template
+++ b/srcpkgs/babl/template
@@ -1,27 +1,19 @@
 # Template file for 'babl'
 pkgname=babl
-version=0.1.78
+version=0.1.84
 revision=1
 build_style=meson
 build_helper=gir
-configure_args="-Dwith-docs=false"
+configure_args="-Dwith-docs=false -Denable-gir=true"
 hostmakedepends="pkg-config vala-devel gobject-introspection"
-makedepends="lcms2-devel"
+makedepends="lcms2-devel vala-devel"
 short_desc="Dynamic pixel format translation library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-3.0-only"
 homepage="http://gegl.org/babl/"
 changelog="https://raw.githubusercontent.com/GNOME/babl/master/NEWS"
 distfiles="https://download.gimp.org/pub/babl/${version%.*}/babl-${version}.tar.xz"
-checksum=17d5493633bff5585d9f375bc4df5925157cd1c70ccd7c22a635be75c172523a
-
-case "$XBPS_TARGET_MACHINE" in
-	x86_64*|i686*) ;;
-	*)
-		configure_args+=" -Denable-sse=false -Denable-sse2=false
-		 -Denable-sse3=false -Denable-sse4_1=false -Denable-avx2=false
-		 -Denable-f16c=false -Denable-mmx=false";;
-esac
+checksum=e7e38b8441f77feb9dc8231cb434a86190a21f2f3692c281457e99d35e9c34ea
 
 babl-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/gegl/template
+++ b/srcpkgs/gegl/template
@@ -1,10 +1,10 @@
 # Template file for 'gegl'
 pkgname=gegl
-version=0.4.24
+version=0.4.28
 revision=1
 build_style=meson
 build_helper="gir"
-configure_args="-Ddocs=false -Dintrospection=$(vopt_if gir true false)
+configure_args="-Ddocs=false -Dintrospection=true
  -Dlibspiro=disabled -Dlibv4l=disabled -Dlibv4l2=disabled -Dlua=disabled
  -Dmrg=disabled -Dopenexr=disabled -Dsdl2=disabled -Dvapigen=disabled
  -Dlibav=disabled -Dumfpack=disabled"
@@ -18,10 +18,7 @@ license="GPL-3.0-only, LGPL-3.0-only"
 homepage="https://www.gimp.org"
 changelog="https://gitlab.gnome.org/GNOME/gegl/raw/master/docs/NEWS.txt"
 distfiles="https://download.gimp.org/pub/gegl/${version%.*}/gegl-${version}.tar.xz"
-checksum=7765499f27341b0d16032e665319cbc12876483ff6a944fcdf24a9c58e3e254a
-
-build_options="gir"
-build_options_default="gir"
+checksum=1d110d8577d54cca3b34239315bd37c57ccb27dd4355655074a2d2b3fd897900
 
 gegl-devel_package() {
 	depends="json-glib-devel babl-devel gegl>=${version}_${revision}"

--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -1,16 +1,17 @@
 # Template file for 'gimp'
 pkgname=gimp
-version=2.10.20
-revision=3
+version=2.10.22
+revision=1
 build_style=gnu-configure
-configure_args="--disable-check-update"
+configure_args="--disable-check-update --datadir=/usr/share"
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool
  libtool pkg-config pygtk-devel perl-XML-Parser gtk-doc iso-codes"
 makedepends="aalib-devel alsa-lib-devel babl-devel dbus-glib-devel gegl-devel
  ghostscript-devel jasper-devel lcms2-devel libXcursor-devel libXpm-devel
  libgexiv2-devel libgudev-devel libmng-devel libmypaint-devel
  libopenexr-devel librsvg-devel libwmf-devel mypaint-brushes1
- poppler-glib-devel pygtk-devel glib-networking libwebp-devel"
+ poppler-glib-devel pygtk-devel glib-networking libwebp-devel
+ libheif-devel libopenjpeg2-devel x265-devel"
 depends="desktop-file-utils hicolor-icon-theme iso-codes mypaint-brushes1"
 short_desc="GNU image manipulation program"
 conf_files="/etc/gimp/${version%%.*}.0/*"
@@ -18,7 +19,7 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-3.0-only"
 homepage="https://www.gimp.org"
 distfiles="https://download.gimp.org/pub/gimp/v${version%.*}/gimp-${version}.tar.bz2"
-checksum=e12f9f874b1a007c4277b60aa81e0b67330be7e6153e5749ead839b902fc7b3c
+checksum=2db84b57f3778d80b3466d7c21a21d22e315c7b062de2883cbaaeda9a0f618bb
 python_version=2
 lib32disabled=yes
 no_generic_pkgconfig_link=yes
@@ -28,6 +29,8 @@ pre_configure() {
 	if [ "$CROSS_BUILD" ]; then
 		vsed -i 's:^py_prefix=`:py_prefix='"$XBPS_CROSS_BASE"'`:' configure
 	fi
+	# don't allow configure to set DATADIRNAME=lib
+	vsed -i 's/DATADIRNAME=lib/DATADIRNAME=share/' configure
 }
 
 libgimp_package() {


### PR DESCRIPTION
Their gettext version check tries to link _nl_msg_cat_cntr, which is
available only in GNU gettext. This breaks when using musl's built-in
gettext impl, and leads to DATADIRNAME=lib being set, which is then used
to set gimplocaledir to /usr/lib/locale.