### PR TITLE
py-spy: update to 0.3.3.

### DIFF
--- a/srcpkgs/py-spy/patches/0001-add-missing-cargo-dep.patch
+++ b/srcpkgs/py-spy/patches/0001-add-missing-cargo-dep.patch
@@ -1,0 +1,26 @@
+From d19aa6776808fd2244eb5d93b36c2861de901816 Mon Sep 17 00:00:00 2001
+From: Nathan Owens <ndowens@artixlinux.org>
+Date: Mon, 28 Dec 2020 19:37:29 -0600
+Subject: [PATCH] add missing cargo dep
+
+---
+ Cargo.toml | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git Cargo.toml Cargo.toml
+index 7874f6e..6223445 100644
+--- Cargo.toml
++++ Cargo.toml
+@@ -33,7 +33,8 @@ serde_derive = "1.0"
+ serde_json = "1.0"
+ rand = "0.7"
+ rand_distr = "0.2"
+-remoteprocess = {version="0.3.4", features=["unwind"]}
++unwind = "0.4.0"
++remoteprocess = {version="0.4.0", features=["unwind"]}
+ 
+ [target.'cfg(unix)'.dependencies]
+ termios = "0.3.1"
+-- 
+2.29.2
+

--- a/srcpkgs/py-spy/template
+++ b/srcpkgs/py-spy/template
@@ -1,8 +1,6 @@
 # Template file for 'py-spy'
 pkgname=py-spy
-version=0.1.11
-# other archs can't compile remoteprocess
-archs="x86_64* i686*"
+version=0.3.3
 revision=1
 build_style=cargo
 short_desc="Sampling profiler for Python programs"
@@ -10,4 +8,4 @@ maintainer="Wilson Birney <wpb@360scada.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/benfred/py-spy"
 distfiles="https://github.com/benfred/py-spy/archive/v${version}.tar.gz"
-checksum=399a1be66414c2f1a3d57b20d1b219393e0dfd5370815b2c0d1406fa0886917e
+checksum=41454d3d9132da45c72f7574faaff65f40c757720293a277ffa5ec5a4b44f902


### PR DESCRIPTION
Remove limit of archs

Closes:#22932

Added makedepends="libunwind-devel" since it ends up linking against libunwind, submitted issue upstream https://github.com/benfred/py-spy/issues/334