### PR TITLE
fonttools: update to 4.18.2.

### DIFF
--- a/srcpkgs/fonttools/template
+++ b/srcpkgs/fonttools/template
@@ -1,6 +1,6 @@
 # Template file for 'fonttools'
 pkgname=fonttools
-version=4.17.1
+version=4.18.2
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -10,7 +10,7 @@ maintainer="svenper <svenper@tuta.io>"
 license="MIT, OFL-1.1, BSD-3-Clause"
 homepage="https://github.com/fonttools/fonttools"
 distfiles="https://github.com/fonttools/fonttools/archive/${version}.tar.gz"
-checksum=89e17920b2d5dce39fb538a4cc65c797a9bf604a481408a1a9a677e3e98f37a4
+checksum=db0a38a17061c65ae3d9e5a86d52e8fa2ecf4d474548d808d338a7f72cf08cff
 replaces="python-fonttools>=0 python3-fonttools>=0"
 provides="python-fonttools-${version}_${revision} python3-fonttools-${version}_${revision}"
 


### PR DESCRIPTION
Remove meta-package, should be enough time for people to have already moved to fonttools