### PR TITLE
Add the gopass utilities to the gopass package.

### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,9 +1,10 @@
 # Template file for 'gopass'
 pkgname=gopass
 version=1.10.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/gopasspw/gopass
+go_package="${go_import_path} ${go_import_path}/cmd/..."
 makedepends="gnupg2"
 depends="gnupg2 git"
 short_desc="Slightly more awesome standard unix password manager for teams"


### PR DESCRIPTION
Gopass as of (at least) 1.10 includes a few utility programs under the
cmd directory of the source distribution.  They should be built and
included in the gopass package.