### PR TITLE
libheif-devel: depends on libde265-devel

### DIFF
--- a/srcpkgs/libheif/template
+++ b/srcpkgs/libheif/template
@@ -1,7 +1,7 @@
 # Template file for 'libheif'
 pkgname=libheif
 version=1.10.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake autoconf pkg-config libtool"
 makedepends="libjpeg-turbo-devel libpng-devel libde265-devel"
@@ -18,7 +18,7 @@ pre_configure() {
 
 libheif-devel_package() {
 	short_desc+=" - development files"
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libde265-devel"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"


### PR DESCRIPTION
libde265 is required in its .pc-file