### PR TITLE
Texlive update

### DIFF
--- a/srcpkgs/texlive-basic/template
+++ b/srcpkgs/texlive-basic/template
@@ -1,15 +1,15 @@
 # Template file for 'texlive-basic'
 pkgname=texlive-basic
-version=2020
-revision=2
+version=2020.1
+revision=1
 build_style=meta
 depends="texlive>=20200406
  texlive-BibTeX>=20200406
  texlive-LuaTeX>=20200406
  texlive-dvi>=20200406
- texlive-core>=2020.55416
- texlive-latexextra>=2020.55418
- texlive-pictures>=2020.55342"
+ texlive-core>=2020.57066
+ texlive-latexextra>=2020.57067
+ texlive-pictures>=2020.57065"
 short_desc="TeX Live - Metapackage including some simple packages"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/texlive-bibtexextra/template
+++ b/srcpkgs/texlive-bibtexextra/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-bibtexextra'
 pkgname=texlive-bibtexextra
-version=2020.55376
-revision=2
+version=2020.56991
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Additional BibTeX styles and bibliography databases"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=f886188aa015f8450519a22cca61b7dc929bb206c90f5de8947a1a949f762f4a
+checksum=29ac4e1ab0447832a6847abf4a4f2a034ff4deae339fe9c118aef1bc95c02b49

--- a/srcpkgs/texlive-core/template
+++ b/srcpkgs/texlive-core/template
@@ -1,11 +1,11 @@
 # Template file for 'texlive-core'
 pkgname=texlive-core
-version=2020.55416
-revision=2
+version=2020.57066
+revision=1
 build_style="texmf"
 short_desc="TeX Live - core texmf distribution"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=8e025c2dfa4e19dcb6aa5e661874d2c2a158aa2e1a078c11a4ddd6347bd9db45
+checksum=b3280ddd2b2c8d41dba3784ba41b755e317e5352868015fe1f70a16b24f5dde9

--- a/srcpkgs/texlive-fontsextra/template
+++ b/srcpkgs/texlive-fontsextra/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-fontsextra'
 pkgname=texlive-fontsextra
-version=2020.55407
-revision=2
+version=2020.57042
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - All sorts of extra fonts"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=25e1060c699f09e02924bf27902b162d7af5a6cc2d0c898f83c09ca0928d9060
+checksum=88a46fc20ec4522bb825aad3b8792ad1494933b2dcbeee4e6b746e1a264352fb

--- a/srcpkgs/texlive-formatsextra/template
+++ b/srcpkgs/texlive-formatsextra/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-formatsextra'
 pkgname=texlive-formatsextra
-version=2020.54498
-revision=2
+version=2020.56699
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Collection of extra TeX 'formats'"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=897881410cc6144478c40cee45d976950a60bd5f86f798857d57501b3c2a4bf0
+checksum=ead7b2f6674f0db9b35db6ad89c13dead0831f7782999b7fdd921937ffec8352

--- a/srcpkgs/texlive-full/template
+++ b/srcpkgs/texlive-full/template
@@ -1,10 +1,10 @@
 # Template file for 'texlive-full'
 pkgname=texlive-full
-version=2020
-revision=2
+version=2020.1
+revision=1
 build_style=meta
-depends="texlive-most>=2020
- texlive-lang>=2020"
+depends="texlive-most>=2020.1
+ texlive-lang>=2020.1"
 short_desc="TeX Live - Metapackage including all packages"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/texlive-games/template
+++ b/srcpkgs/texlive-games/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-games'
 pkgname=texlive-games
-version=2020.55271
-revision=2
+version=2020.56833
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Typesetting board games"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=8fee7616c18bd8c53cdea108d2d17583b88ace4a97fe6d23f13d32c56397885b
+checksum=c11db61e7daf90f815a606df357da480479d300ebe7606179f67ca8c13fedc27

--- a/srcpkgs/texlive-humanities/template
+++ b/srcpkgs/texlive-humanities/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-humanities'
 pkgname=texlive-humanities
-version=2020.55389
-revision=2
+version=2020.57034
+revision=1
 build_style="texmf"
 depends="texlive-core texlive-latexextra texlive-pictures"
 short_desc="TeX Live - Packages for humanities, law, linguistics, etc"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=528bc27a2ba5410a76d4ab509b97d0ea87038fde1b65f4254fb0d94805c1f3e5
+checksum=9eecd63565d7ab550fa7f82f10f4f1bbb523c501e987c3eef051426e5927ed70

--- a/srcpkgs/texlive-lang/template
+++ b/srcpkgs/texlive-lang/template
@@ -1,15 +1,15 @@
 # Template file for 'texlive-lang'
 pkgname=texlive-lang
-version=2020
-revision=2
+version=2020.1
+revision=1
 build_style=meta
-depends="texlive-core>=2020.55416
- texlive-langchinese>=2020.55162
- texlive-langcyrillic>=2020.54594
- texlive-langextra>=2020.55417
- texlive-langgreek>=2020.54512
- texlive-langjapanese>=2020.55320
- texlive-langkorean>=2020.54519"
+depends="texlive-core>=2020.57066
+ texlive-langchinese>=2020.57044
+ texlive-langcyrillic>=2020.56674
+ texlive-langextra>=2020.56781
+ texlive-langgreek>=2020.56956
+ texlive-langjapanese>=2020.57025
+ texlive-langkorean>=2020.56915"
 short_desc="TeX Live - Metapackage including all languages"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/texlive-langchinese/template
+++ b/srcpkgs/texlive-langchinese/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-langchinese'
 pkgname=texlive-langchinese
-version=2020.55162
-revision=2
+version=2020.57044
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Fonts and macro packages for typesetting Chinese"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=4ed294a09e69ca853fd9a141103ad4d4f6282afc3dcc058e18415acfd71f8883
+checksum=635ff96a2373caca1c4b927ba54d6fd1bd3ee629dc9279be768021eb8fe1c93f

--- a/srcpkgs/texlive-langcyrillic/template
+++ b/srcpkgs/texlive-langcyrillic/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-langcyrillic'
 pkgname=texlive-langcyrillic
-version=2020.54594
-revision=2
+version=2020.56674
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Fonts and macro packages for typesetting Cyrillic text"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=42cb98a93a1cb9437691d24d4aae64360b260da036f874cb6644aa7bc8a47c67
+checksum=b20e99fd5a7f48e0024fc2e2bb2609d28eb9a74e5b2abee1843e680632833cf9

--- a/srcpkgs/texlive-langextra/template
+++ b/srcpkgs/texlive-langextra/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-langextra'
 pkgname=texlive-langextra
-version=2020.55417
-revision=2
+version=2020.56781
+revision=1
 build_style="texmf"
 depends="texlive-core texlive-latexextra"
 short_desc="TeX Live - Packages for a bunch of extra languages"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=b92cff8917d8f44071de42307c9f5d72d0be8999d789d1d407225d010f026ac9
+checksum=57b27be556189cb9a50ee5c724d4cce40cab2efdc3e253d8a4fb61c52d36860a

--- a/srcpkgs/texlive-langgreek/template
+++ b/srcpkgs/texlive-langgreek/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-langgreek'
 pkgname=texlive-langgreek
-version=2020.54512
-revision=2
+version=2020.56956
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Fonts and macro packages for typesetting Greek"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=72c7c9b7ab23df11edf2ec2430a97d8a45885316ccbcfa7bc62684b3f2e9188b
+checksum=9fac133578469c91572306a537c47ee6fdc661caf0f0dacba276af6a69fca465

--- a/srcpkgs/texlive-langjapanese/template
+++ b/srcpkgs/texlive-langjapanese/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-langjapanese'
 pkgname=texlive-langjapanese
-version=2020.55320
-revision=2
+version=2020.57025
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Fonts and macro packages for typesetting Japanese"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=2e2538c9c81ed69530ce78b1dd132eaa54832276e614d6907bafeec17a1c3a90
+checksum=8f358bde670e7afb8b1561382bc0c18797da97f0e2ea40c74b87a54fc32057c7

--- a/srcpkgs/texlive-langkorean/template
+++ b/srcpkgs/texlive-langkorean/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-langkorean'
 pkgname=texlive-langkorean
-version=2020.54519
-revision=2
+version=2020.56915
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Fonts and macro packages for typesetting Korean"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=dfc1e1434bbc10442009e9c3e28609ae45aeda96930df899d365eea38423f66e
+checksum=e767951038f076f9cdd76a7b5bad9598733ef3df098082d623511d9adffb1d1e

--- a/srcpkgs/texlive-latexextra/template
+++ b/srcpkgs/texlive-latexextra/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-latexextra'
 pkgname=texlive-latexextra
-version=2020.55418
-revision=2
+version=2020.57067
+revision=1
 build_style="texmf"
 depends="perl-File-Which python3-Pygments texlive-core texlive-pictures"
 short_desc="TeX Live - Collection of LaTeX addon packages"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=a2ee21a2a6f00def6bec620a85bb8116de97a16dcd98adaa308eb455fe0e7fcb
+checksum=6ab6ca702f7d956de9ee8fb9c78518da64c322472716c99780d9dfd9c158930f

--- a/srcpkgs/texlive-minimal/template
+++ b/srcpkgs/texlive-minimal/template
@@ -1,10 +1,10 @@
 # Template file for 'texlive-minimal'
 pkgname=texlive-minimal
-version=2020
-revision=2
+version=2020.1
+revision=1
 build_style=meta
 depends="texlive>=20200406
- texlive-core>=2020.55416"
+ texlive-core>=2020.57066"
 short_desc="TeX Live - Metapackage including minimal packages"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/texlive-most/template
+++ b/srcpkgs/texlive-most/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-most'
 pkgname=texlive-most
-version=2020
-revision=2
+version=2020.1
+revision=1
 build_style=meta
 depends="texlive>=20200406
  texlive-BibTeX>=20200406
@@ -11,18 +11,18 @@ depends="texlive>=20200406
  texlive-Xdvi>=20200406
  texlive-XeTeX>=20200406
  texlive-dvi>=20200406
- texlive-core>=2020.55416
- texlive-bibtexextra>=2020.55376
- texlive-fontsextra>=2020.55407
- texlive-formatsextra>=2020.54498
- texlive-games>=2020.55271
- texlive-humanities>=2020.55389
- texlive-latexextra>=2020.55418
- texlive-music>=2020.54758
- texlive-pictures>=2020.55342
- texlive-pstricks>=2020.55289
- texlive-publishers>=2020.55415
- texlive-science>=2020.55390"
+ texlive-core>=2020.57066
+ texlive-bibtexextra>=2020.56991
+ texlive-fontsextra>=2020.57042
+ texlive-formatsextra>=2020.56699
+ texlive-games>=2020.56833
+ texlive-humanities>=2020.57034
+ texlive-latexextra>=2020.57067
+ texlive-music>=2020.56473
+ texlive-pictures>=2020.57065
+ texlive-pstricks>=2020.56758
+ texlive-publishers>=2020.57058
+ texlive-science>=2020.57068"
 short_desc="TeX Live - Metapackage including most packages"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/texlive-music/template
+++ b/srcpkgs/texlive-music/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-music'
 pkgname=texlive-music
-version=2020.54758
-revision=2
+version=2020.56473
+revision=1
 build_style="texmf"
 depends="fontforge python3 texlive-core"
 short_desc="TeX Live - Music typesetting packages"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=47f418d851a0f838c08be406135ef338533e32cf0bc9c4ffefeaa0139973e8f1
+checksum=06caf29f5ef2e3881cde74963f70ffe75215359ae824ebae4f0599b24ca4458b

--- a/srcpkgs/texlive-pictures/template
+++ b/srcpkgs/texlive-pictures/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-pictures'
 pkgname=texlive-pictures
-version=2020.55342
-revision=2
+version=2020.57065
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Packages for drawing graphics"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=4bfd4a1cf0339151806ff7591c11d4b1868bc9ebf7f9b0f396193abbc3c7aec5
+checksum=4e9a720d65b4a2d15cb05591f817cc76dff57797485b075f356c1c1ff109bca5

--- a/srcpkgs/texlive-pstricks/template
+++ b/srcpkgs/texlive-pstricks/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-pstricks'
 pkgname=texlive-pstricks
-version=2020.55289
-revision=2
+version=2020.56758
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Additional PSTricks packages"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=be0eb4d24474a3af116af7d34af5b78f6cdc7aee6235ed4d63f1682dc2ef0cbc
+checksum=3c02a5733450544e8d38f66e6fa20055974a474e6184b293fe7d7003e891f6a1

--- a/srcpkgs/texlive-publishers/template
+++ b/srcpkgs/texlive-publishers/template
@@ -1,11 +1,11 @@
 # Template file for 'texlive-publishers'
 pkgname=texlive-publishers
-version=2020.55415
-revision=2
+version=2020.57058
+revision=1
 build_style="texmf"
 short_desc="TeX Live - Classes and packages for certain publishers"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=4d36cad1e18e5ad9b9866bba17c9288454f6d7b17a3ac144160ec4a5bce79176
+checksum=13a312f58913e168e68b6dc57ef93b099485537c99e5f6f588f5c98764abf069

--- a/srcpkgs/texlive-science/template
+++ b/srcpkgs/texlive-science/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive-science'
 pkgname=texlive-science
-version=2020.55390
-revision=2
+version=2020.57068
+revision=1
 build_style="texmf"
 depends="texlive-core"
 short_desc="TeX Live - Typesetting for mathematatics and science disciplines"
@@ -9,4 +9,4 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
 homepage="http://tug.org/texlive/"
 distfiles="https://sources.archlinux.org/other/texlive/${pkgname}-${version}-src.zip"
-checksum=c42294cd26e5a65585b27520e5a877539f88ba1583d5e1101c828a934225eea4
+checksum=ae3925dce04e315ee53cef15799c03a743bdf048313cf328a50b143ff9ace888


### PR DESCRIPTION
This is the first texlive update (well, texmf packge) update ever.

The metapackages have been updated to pull in the new versions of the packages.

The build_style do_check needs some further fixing. It was flawed on updates because it checked against every single version of the package in repositories. I fixed that in the first commit. However, there is another problem. All of the packages have to first be built and then check run for each package, otherwise it is checking against the outdated information on the other packages.

IMO, the best way to solve this would be to restrict the search to only the repository where the binpkgs are being generated. This means that some checks will be missed in CI but it will pass, and when it is updated on a local machine we can do the two pass:

1. `./xbps-src pkg texlive-blah` for each package
2. `./xbps-src check texlive-blah` for each package

Which is required anyway right now to check and for it to succeed.

@Chocimier thoughts on this above proposal, as you originally wrote the do_check.