### PR TITLE
freetype: clean XBPS_CROSS_TRIPLET reference in freetype-config

### DIFF
--- a/common/hooks/pre-configure/02-script-wrapper.sh
+++ b/common/hooks/pre-configure/02-script-wrapper.sh
@@ -175,6 +175,13 @@ install_cross_wrappers() {
 	done
 }
 
+link_wrapper() {
+	local wrapper="$1"
+	[ ! -x "${XBPS_CROSS_BASE}/usr/bin/${wrapper}" ] && return 0
+	[ -L "${XBPS_WRAPPERDIR}/${wrapper}" ] && return 0
+	ln -sf "${XBPS_CROSS_BASE}/usr/bin/${wrapper}" "${XBPS_WRAPPERDIR}"
+}
+
 hook() {
 	export PATH="$XBPS_WRAPPERDIR:$PATH"
 
@@ -186,9 +193,15 @@ hook() {
 	pkgconfig_wrapper
 	vapigen_wrapper
 	valac_wrapper
+
+	if [ -x /usr/bin/pkg-config ]; then
+		link_wrapper freetype-config
+	else
+		generic_wrapper freetype-config
+	fi
+
 	generic_wrapper icu-config
 	generic_wrapper libgcrypt-config
-	generic_wrapper freetype-config
 	generic_wrapper sdl-config
 	generic_wrapper sdl2-config
 	generic_wrapper gpgme-config

--- a/srcpkgs/SDL_ttf/template
+++ b/srcpkgs/SDL_ttf/template
@@ -1,19 +1,21 @@
 # Template file for 'SDL_ttf'
 pkgname=SDL_ttf
 version=2.0.11
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="freetype-devel SDL-devel libSM-devel"
 short_desc="Use TrueType fonts in your SDL applications"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="LGPL-2.1"
-homepage="http://www.libsdl.org/projects/${pkgname}"
+license="Zlib"
+homepage="http://www.libsdl.org/projects/SDL_ttf"
 distfiles="${homepage}/release/${pkgname}-${version}.tar.gz"
 checksum=724cd895ecf4da319a3ef164892b72078bd92632a5d812111261cde248ebcdb7
 
-CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
+post_install() {
+	vlicense COPYING
+}
 
 SDL_ttf-devel_package() {
 	depends="freetype-devel SDL-devel ${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/freetype/template
+++ b/srcpkgs/freetype/template
@@ -1,7 +1,7 @@
 # Template file for 'freetype'
 pkgname=freetype
 version=2.10.4
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-freetype-config"
 hostmakedepends="pkg-config"
@@ -12,6 +12,10 @@ license="GPL-2.0-or-later, FTL"
 homepage="https://www.freetype.org/"
 distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784
+
+post_patch() {
+	vsed -i -e "s/%PKG_CONFIG%/pkg-config/" builds/unix/freetype-config.in
+}
 
 post_install() {
 	vlicense docs/LICENSE.TXT

--- a/srcpkgs/libopenshot-audio/template
+++ b/srcpkgs/libopenshot-audio/template
@@ -13,8 +13,6 @@ homepage="https://github.com/OpenShot/libopenshot-audio"
 distfiles="https://github.com/OpenShot/libopenshot-audio/archive/v${version}.tar.gz"
 checksum=937ff4f1c2dfb8ab5d56ad85beacaa29dfd5a79af0d9cf647386034fe9882309
 
-CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
-
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 	CXXFLAGS+=" -latomic "

--- a/srcpkgs/slim/template
+++ b/srcpkgs/slim/template
@@ -3,8 +3,7 @@ pkgname=slim
 version=1.3.6
 revision=13
 build_style=cmake
-configure_args="-DUSE_CONSOLEKIT=no -DUSE_PAM=yes
- -DFREETYPE_INCLUDE_DIR_freetype2=${XBPS_CROSS_BASE}/usr/include/freetype2"
+configure_args="-DUSE_CONSOLEKIT=no -DUSE_PAM=yes"
 conf_files="/etc/slim.conf /etc/pam.d/slim"
 hostmakedepends="pkg-config"
 makedepends="libpng-devel freetype-devel libjpeg-turbo-devel libXrandr-devel
@@ -21,11 +20,8 @@ case "$XBPS_TARGET_MACHINE" in
 	*-musl) CXXFLAGS="-DNEEDS_BASENAME";;
 esac
 
-pre_configure() {
-	sed -i 's|set(LIBDIR "/lib")|set(LIBDIR "/usr/lib")|' CMakeLists.txt
-}
 post_install() {
 	vsv slim
 	vinstall ${FILESDIR}/slim.pam 644 etc/pam.d slim
-	rm -rf ${DESTDIR}/usr/lib/systemd
+	rm -rf ${DESTDIR}/lib/systemd
 }

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -172,16 +172,6 @@ post_patch() {
 	popd
 }
 
-pre_configure() {
-	if [ "$CROSS_BUILD" ] ; then
-		# For some reason, when cross-building, the configure script has this path
-		# for freetype2 include:
-		# /usr/x86_64-linux-musl/usr/x86_64-linux-musl/usr/include/freetype2.
-		# It shouldn't have two /usr/x86_64-linux-musl's, add it to CPPFLAGS.
-		CPPFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
-	fi
-}
-
 pre_build() {
 	if [ -n "$build_option_luajit" ] ; then
 		export HOST_CC="${_luajit_host_cc}"

--- a/srcpkgs/tumbler/template
+++ b/srcpkgs/tumbler/template
@@ -14,8 +14,6 @@ homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
 checksum=9b0b7fed0c64041733d490b1b307297984629d0dd85369749617a8766850af66
 
-CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/freetype2"
-
 tumbler-devel_package() {
 	depends="libglib-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"

--- a/srcpkgs/wmx/template
+++ b/srcpkgs/wmx/template
@@ -1,15 +1,14 @@
 # Template file for 'wmx'
 pkgname=wmx
 version=8
-revision=3
+revision=4
 build_style=gnu-configure
-make_build_args="LDFLAGS+=-lXft LDFLAGS+=-lfontconfig
- CXXFLAGS+=-I${XBPS_CROSS_BASE}/usr/include/freetype2"
-makedepends="libX11-devel libXext-devel libXmu-devel libXpm-devel freetype-devel
- libXft-devel fontconfig-devel libXcomposite-devel"
+hostmakedepends="pkg-config"
+makedepends="libX11-devel libXext-devel libXmu-devel libXpm-devel
+ freetype-devel libXft-devel fontconfig-devel libXcomposite-devel"
 short_desc="Simple window manager for X"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="BSD"
+license="BSD-2-Clause"
 homepage="http://www.all-day-breakfast.com/wmx"
 distfiles="http://www.all-day-breakfast.com/wmx/wmx-${version}.tar.gz"
 checksum=7316090e59fa8988219d6819e426870c6d8c0739818d77e8770e8108ddf0aedd
@@ -17,4 +16,8 @@ checksum=7316090e59fa8988219d6819e426870c6d8c0739818d77e8770e8108ddf0aedd
 do_install() {
 	vbin wmx
 	vinstall ${FILESDIR}/wmx.desktop 644 usr/share/xsessions
+	vlicense README
+	vlicense README.contrib
+	sed -ne '4,13p' Rotated.C >LICENSE.xvertext
+	vlicense LICENSE.xvertext
 }


### PR DESCRIPTION
* $XBPS_CROSS_TRIPLET-pkg-config is our wrapper not a real executable
* In a build that have both freetype-config and pkg-config,
  $XBPS_CROSS_BASE will be prepended twice with current system,
  let's fix it.