### PR TITLE
Waybar: update to 0.9.5.

### DIFF
--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,6 +1,6 @@
 # Template file for 'Waybar'
 pkgname=Waybar
-version=0.9.4
+version=0.9.5
 revision=1
 _date_version=3.0.0
 create_wrksrc=yes
@@ -11,7 +11,8 @@ configure_args="-Dgtk-layer-shell=enabled -Dlibudev=enabled -Dman-pages=enabled
  -Dlibnl=$(vopt_if libnl enabled disabled)
  -Dpulseaudio=$(vopt_if pulseaudio enabled disabled)
  -Ddbusmenu-gtk=$(vopt_if dbusmenugtk enabled disabled)
- -Dmpd=$(vopt_if mpd enabled disabled)"
+ -Dmpd=$(vopt_if mpd enabled disabled)
+ -Dsndio=$(vopt_if sndio enabled disabled)"
 hostmakedepends="cmake pkg-config glib-devel wayland-devel scdoc
  $(vopt_if dbusmenugtk gobject-introspection)"
 makedepends="libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
@@ -19,7 +20,8 @@ makedepends="libinput-devel wayland-devel gtkmm-devel spdlog eudev-libudev-devel
  $(vopt_if libnl libnl3-devel)
  $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if dbusmenugtk libdbusmenu-gtk3-devel)
- $(vopt_if mpd libmpdclient-devel)"
+ $(vopt_if mpd libmpdclient-devel)
+ $(vopt_if sndio sndio-devel)"
 short_desc="Polybar-like Wayland Bar for Sway and Wlroots based compositors"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
@@ -29,12 +31,12 @@ changelog="https://github.com/Alexays/Waybar/releases"
 distfiles="https://github.com/Alexays/Waybar/archive/${version}.tar.gz
  https://github.com/HowardHinnant/date/archive/v${_date_version}.tar.gz
  https://github.com/mesonbuild/hinnant-date/releases/download/${_date_version}-1/hinnant-date.zip"
-checksum="d49c09ee253ca9cc9688d1b4d8602adc9bdae613b02e2fa1a2e7277ddc9e82e8
+checksum="74d783d4da01c1c3a90a00968d74f47c2193a6952c3b2e0584cf3ddfa1ae4254
  87bba2eaf0ebc7ec539e5e62fc317cb80671a337c1fb1b84cb9e4d42c6dbebe3
  6ccaf70732d8bdbd1b6d5fdf3e1b935c23bf269bda12fdfd0e561276f63432fe"
 
-build_options="libnl pulseaudio dbusmenugtk mpd"
-build_options_default="libnl pulseaudio dbusmenugtk mpd"
+build_options="libnl pulseaudio dbusmenugtk mpd sndio"
+build_options_default="libnl pulseaudio dbusmenugtk mpd sndio"
 
 desc_option_libnl="Enable libnl support for network related features"
 desc_option_dbusmenugtk="Enable support for tray"


### PR DESCRIPTION
Add missing rfkill functionality and enable new sndio module.