### PR TITLE
foomatic-db{,-nonfree}: update to 20210104. 

### DIFF
--- a/srcpkgs/foomatic-db-nonfree/template
+++ b/srcpkgs/foomatic-db-nonfree/template
@@ -1,24 +1,25 @@
 # Template file for 'foomatic-db-nonfree'
-# Note: update the version=<date> regularly like once/month.
+# Update when there is a new commit at https://github.com/OpenPrinting/foomatic-db-nonfree.
 pkgname=foomatic-db-nonfree
-version=20201129
+version=20210104
 revision=1
-create_wrksrc=yes
+_commit=6ddae02ac89240c019f8b5026cfe70e30fd2b3db
+wrksrc="${pkgname}-${_commit}"
 build_style=gnu-configure
-hostmakedepends="tar xmlstarlet"
+hostmakedepends="tar xmlstarlet automake"
 short_desc="OpenPrinting printer support - nonfree database"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="custom:Various Nonfree"
 homepage="https://wiki.linuxfoundation.org/openprinting/database/foomatic"
+distfiles="https://github.com/OpenPrinting/foomatic-db-nonfree/archive/${_commit}.tar.gz"
+checksum=958c1067a24c37cb753ee2b4aeb9e8325629f4363ce9e108f1f6d0f828e5b7c5
 repository="nonfree"
 
-do_fetch() {
-	$XBPS_FETCH_CMD https://www.openprinting.org/download/foomatic/${pkgname}-current.tar.gz
-}
-
-do_extract() {
-	bsdtar -xf ${XBPS_BUILDDIR}/${pkgname}-current.tar.gz \
-		--strip-components=1 -C ${wrksrc}
+pre_configure() {
+	# From make_configure
+	aclocal
+	autoconf
+	sed -i "s=\#include \<xmlversion.h\>=\#include \<libxml/xmlversion.h\>=g" configure
 }
 
 post_install() {

--- a/srcpkgs/foomatic-db-nonfree/update
+++ b/srcpkgs/foomatic-db-nonfree/update
@@ -1,0 +1,3 @@
+site="https://github.com/OpenPrinting/foomatic-db-nonfree"
+version="${version:0:4}.${version:4:2}.${version:6:2}"
+pattern="relative-time datetime=\"\K\d{4}-\d{2}-\d{2}"

--- a/srcpkgs/foomatic-db/template
+++ b/srcpkgs/foomatic-db/template
@@ -1,23 +1,24 @@
 # Template file for 'foomatic-db'
-# Note: update the version=<date> regularly like once/month.
+# Update when there is a new commit at https://github.com/OpenPrinting/foomatic-db.
 pkgname=foomatic-db
-version=20201129
+version=20210104
 revision=1
-create_wrksrc=yes
+_commit=28466ef2f9f931f49816ed70c499001d1783f5cb
+wrksrc="${pkgname}-${_commit}"
 build_style=gnu-configure
-hostmakedepends="xmlstarlet tar"
+hostmakedepends="xmlstarlet tar automake"
 short_desc="OpenPrinting printer support - database"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, MIT"
 homepage="https://wiki.linuxfoundation.org/openprinting/database/foomatic"
+distfiles="https://github.com/OpenPrinting/foomatic-db/archive/${_commit}.tar.gz"
+checksum=eb412f7967300ae49bd22a886ecd478767828eff5da4d1e875c3409898265866
 
-do_fetch() {
-	$XBPS_FETCH_CMD https://www.openprinting.org/download/foomatic/${pkgname}-4.0-current.tar.gz
-}
-
-do_extract() {
-	bsdtar -xf ${XBPS_BUILDDIR}/${pkgname}-4.0-current.tar.gz \
-		--strip-components=1 -C ${wrksrc}
+pre_configure() {
+	# Taken from make_configure
+	aclocal
+	autoconf
+	sed -i "s=\#include \<xmlversion.h\>=\#include \<libxml/xmlversion.h\>=g" configure
 }
 
 post_install() {
@@ -28,4 +29,4 @@ post_install() {
 			vlicense "LICENSE-$(basename $i .xml).txt"
 		fi
 	done
- }
+}

--- a/srcpkgs/foomatic-db/update
+++ b/srcpkgs/foomatic-db/update
@@ -1,1 +1,3 @@
-pattern=$pkgname'-[\d.]+-\K[\d]+'
+site="https://github.com/OpenPrinting/foomatic-db"
+version="${version:0:4}.${version:4:2}.${version:6:2}"
+pattern="relative-time datetime=\"\K\d{4}-\d{2}-\d{2}"


### PR DESCRIPTION
These two packages are essentially non-versioned databases but need to be bumped every so often.