### PR TITLE
texlive: fix tlmgr.

### DIFF
--- a/srcpkgs/texlive/files/tlmgr
+++ b/srcpkgs/texlive/files/tlmgr
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/share/texmf-dist/scripts/texlive/tlmgr.pl "$@"
+exec /usr/share/texmf-dist/scripts/texlive/tlmgr.pl "$@"

--- a/srcpkgs/texlive/patches/tlmgr.patch
+++ b/srcpkgs/texlive/patches/tlmgr.patch
@@ -1,0 +1,113 @@
+Modified from Debian's tlmgr patch.
+Src: https://raw.githubusercontent.com/debian-tex/texlive-nonbin/9767c8ba4ea64d671eb98ddff550498cd2ac3d51/texlive-base/debian/patches/debian-tlmgr-usermode.
+
+Modifications:
+
+* Drop Debian specific wording.
+* Drop unnessecary manpage changes.
+* Change /usr/share path to what we use.
+
+Modified by fosslinux.
+
+--- texk/texlive/linked_scripts/texlive/tlmgr.pl
++++ texk/texlive/linked_scripts/texlive/tlmgr.pl
+@@ -21,7 +21,7 @@
+ $tlmgrversion = "$tlmgrrevision ($datrev)";
+ 
+ our $Master;
+-our $ismain;
++our $ismain = 1;
+ our $loadmediasrcerror;
+ our $packagelogfile;
+ our $packagelogged;
+@@ -41,50 +41,8 @@
+ 
+ BEGIN {
+   $^W = 1;
+-  $ismain = (__FILE__ eq $0);
+-  # WARNING
+-  # The only use anticipated for tlmgr.pl as library for the 2009 release
+-  # is the Windows w32client prototype script.
+-  # Unix-specific problems with use as library will probably go undetected.
+-
+-  # make subprograms (including kpsewhich) have the right path:
+-  my $kpsewhichname;
+-  if ($^O =~ /^MSWin/i) {
+-    # on w32 $0 and __FILE__ point directly to tlmgr.pl; they can be relative
+-    $Master = __FILE__;
+-    $Master =~ s!\\!/!g;
+-    $Master =~ s![^/]*$!../../..!
+-      unless ($Master =~ s!/texmf-dist/scripts/texlive/tlmgr\.pl$!!i);
+-    $bindir = "$Master/bin/win32";
+-    $kpsewhichname = "kpsewhich.exe";
+-    # path already set by wrapper batchfile
+-  } else {
+-    $Master = __FILE__;
+-    $Master =~ s,/*[^/]*$,,;
+-    if ($ismain) {
+-      $bindir = $Master;
+-      $Master = "$Master/../..";
+-    } else {
+-      # for the time being, this code will not be used or tested
+-      $Master = "$Master/../../..";
+-      # no code yet for $bindir; would have to detect platform
+-    }
+-    # make subprograms (including kpsewhich) have the right path:
+-    $ENV{"PATH"} = "$bindir:$ENV{PATH}";
+-    $kpsewhichname = "kpsewhich";
+-  }
+-  if (-r "$bindir/$kpsewhichname") {
+-    # if not in bootstrapping mode => kpsewhich exists, so use it to get $Master
+-    chomp($Master = `kpsewhich -var-value=SELFAUTOPARENT`);
+-  }
+-
+-  # if we have no directory in which to find our modules,
+-  # no point in going on.
+-  if (! $Master) {
+-    die ("Could not determine directory of tlmgr executable, "
+-         . "maybe shared library woes?\nCheck for error messages above");
+-  }
+-
++  
++  $Master = "/usr/share/texmf-dist";
+   $::installerdir = $Master;  # for config.guess et al., see TLUtils.pm
+ 
+   # make Perl find our packages first:
+@@ -621,6 +579,13 @@
+     tldie("$prg: Try --help if you need it.\n");
+   }
+ 
++  # automatically switch to user mode on Void, and warn
++  if (!$opts{"usermode"} && $action ne "init-usertree") {
++    $opts{"usermode"} = 1;
++    print "WARNING: switching to user mode!\n";
++    print "WARNING: normal mode unsupported on Void Linux.\n";
++  }
++
+   #
+   # the main tree we will be working on
+   $::maintree = $Master;
+@@ -6099,7 +6064,9 @@
+ # sets up the user tree for tlmgr in user mode
+ sub action_init_usertree {
+   # init_local_db but do not die if localtlpdb is not found!
+-  init_local_db(2);
++  # we don't ship tlpdb in the system, so don't even
++  # try to initialize it.
++  # init_local_db(2);
+   my $tlpdb = TeXLive::TLPDB->new;
+   my $usertree;
+   if ($opts{"usertree"}) {
+@@ -6739,7 +6706,11 @@
+     if ($should_i_die == 2) {
+       return undef;
+     } else {
+-      die("cannot setup TLPDB in $::maintree");
++      if ($opts{'usermode'}) {
++        die("$prg: user mode not initialized, please run `tlmgr init-usertree`\n");
++      } else {
++        die("cannot setup TLPDB in $::maintree");
++      }
+     }
+   }
+   # setup the programs, for w32 we need the shipped wget/xz etc, so we

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20200406
-revision=5
+revision=6
 wrksrc="texlive-${version}-source"
 build_wrksrc="build"
 build_style=gnu-configure


### PR DESCRIPTION
This PR adds a package texlive-tlpdb that is in the same vein as the foomatic-db* family, where there is no checksum as it packages a volatile database updated roughly daily that should be bumped regularly to ensure operation of tlmgr.

tlmgr requires the use of /usr/share/texmf-dist/tlpkg/texlive.tlpdb to
work correctly. We don't distribute this currently, but now we do, in
the package texlive-tlpdb. It is split out because it is very volatile
and we don't want to have to continously bump the full texlive package.

This finally! makes tlmgr work.