### PR TITLE
mdBook: update to 0.4.5.

### DIFF
--- a/srcpkgs/mdBook/template
+++ b/srcpkgs/mdBook/template
@@ -1,6 +1,6 @@
 # Template file for 'mdBook'
 pkgname=mdBook
-version=0.4.4
+version=0.4.5
 revision=1
 build_style=cargo
 short_desc="Create book from markdown files. Like Gitbook but implemented in Rust"
@@ -9,7 +9,7 @@ license="MPL-2.0"
 homepage="https://github.com/rust-lang/mdBook"
 changelog="https://raw.githubusercontent.com/rust-lang/mdBook/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/mdBook/archive/v${version}.tar.gz"
-checksum=eaf01085bd25e2efa07b561148afa5e3da3386e5f2c35b245961dc485562c154
+checksum=79fd98bddab8611cae9071aeb327edfcc67b4e449d5653d41d2ee5b04bee3afc
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Fixes CVE-2020-26297