### PR TITLE
slack-desktop: add -p to mkdir to avoid error

### DIFF
--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -24,7 +24,7 @@ do_install() {
 	vlicense usr/share/doc/slack-desktop/copyright
 	vinstall usr/share/applications/slack.desktop 644 usr/share/applications
 	vinstall usr/share/pixmaps/slack.png 644 usr/share/pixmaps
-	mkdir -p ${DESTDIR}/usr/{bin,lib}
+	mkdir ${DESTDIR}/usr/bin
 	vcopy usr/lib/slack usr/lib
 	ln -s ../lib/slack/slack ${DESTDIR}/usr/bin/slack
 }

--- a/srcpkgs/slack-desktop/template
+++ b/srcpkgs/slack-desktop/template
@@ -24,7 +24,7 @@ do_install() {
 	vlicense usr/share/doc/slack-desktop/copyright
 	vinstall usr/share/applications/slack.desktop 644 usr/share/applications
 	vinstall usr/share/pixmaps/slack.png 644 usr/share/pixmaps
-	mkdir ${DESTDIR}/usr/{bin,lib}
+	mkdir -p ${DESTDIR}/usr/{bin,lib}
 	vcopy usr/lib/slack usr/lib
 	ln -s ../lib/slack/slack ${DESTDIR}/usr/bin/slack
 }

--- a/srcpkgs/textadept/template
+++ b/srcpkgs/textadept/template
@@ -76,7 +76,6 @@ do_install() {
 
 	# Binaries in /usr/share/textadept are not allowed
 	# So we relocate to /usr/lib/textadept
-	mkdir -p "${DESTDIR}/usr/lib/"
 	mv "${DESTDIR}/usr/share/textadept" "${DESTDIR}/usr/lib/textadept"
 	ln -sf "/usr/lib/textadept/textadept" "${DESTDIR}/usr/bin/textadept"
 	ln -sf "/usr/lib/textadept/textadept-curses" \


### PR DESCRIPTION
I encountered this error when attempting to build slack-desktop locally. Unsure if there's a better fix, but it seems harmless.

```
=> slack-desktop-4.12.0_1: running do_install ...
mkdir: cannot create directory ‘/destdir//slack-desktop-4.12.0/usr/lib’: File exists
=> ERROR: slack-desktop-4.12.0_1: do_install: 'mkdir ${DESTDIR}/usr/{bin,lib}' exited with 1
=> ERROR:   in do_install() at srcpkgs/slack-desktop/template:27
```