### PR TITLE
nvidia390: add patches for linux5.9

### DIFF
--- a/srcpkgs/nvidia390/files/linux-5.9.x-x86_64.patch
+++ b/srcpkgs/nvidia390/files/linux-5.9.x-x86_64.patch
@@ -1,0 +1,58 @@
+Source: Mageia, http://sophie.zarb.org/rpms/eaff282f82f9fc9911151ebd234f25cc/files/7
+diff --git a/kernel/nvidia-uvm/nvidia-uvm.Kbuild b/kernel/nvidia-uvm/nvidia-uvm.Kbuild
+index 650c922..0c83fae 100644
+--- a/kernel/nvidia-uvm/nvidia-uvm.Kbuild
++++ b/kernel/nvidia-uvm/nvidia-uvm.Kbuild
+@@ -108,10 +108,11 @@ NV_CONFTEST_FUNCTION_COMPILE_TESTS += bitmap_clear
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += usleep_range
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += radix_tree_empty
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += radix_tree_replace_slot
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += do_gettimeofday
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += ktime_get_raw_ts64
++NV_CONFTEST_FUNCTION_COMPILE_TESTS += smp_read_barrier_depends
+ 
+ NV_CONFTEST_TYPE_COMPILE_TESTS += proc_dir_entry
+ NV_CONFTEST_TYPE_COMPILE_TESTS += irq_handler_t
+ NV_CONFTEST_TYPE_COMPILE_TESTS += outer_flush_all
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_operations_struct
+diff --git a/kernel/nvidia-uvm/uvm8_tools.c b/kernel/nvidia-uvm/uvm8_tools.c
+index 86dbb77..be865bc 100644
+--- a/kernel/nvidia-uvm/uvm8_tools.c
++++ b/kernel/nvidia-uvm/uvm8_tools.c
+@@ -188,11 +188,15 @@ static NV_STATUS tools_update_status(uvm_va_space_t *va_space);
+ 
+ static uvm_tools_event_tracker_t *tools_event_tracker(struct file *filp)
+ {
+     long event_tracker = atomic_long_read((atomic_long_t *)&filp->private_data);
+ 
++#if defined(NV_SMP_READ_BARRIER_DEPENDS_PRESENT)
+     smp_read_barrier_depends();
++#else
++    smp_rmb();
++#endif
+     return (uvm_tools_event_tracker_t *)event_tracker;
+ }
+ 
+ static bool tracker_is_queue(uvm_tools_event_tracker_t *event_tracker)
+ {
+diff --git a/kernel/nvidia-uvm/uvm8_va_range.h b/kernel/nvidia-uvm/uvm8_va_range.h
+index 8cae357..a74ad24 100644
+--- a/kernel/nvidia-uvm/uvm8_va_range.h
++++ b/kernel/nvidia-uvm/uvm8_va_range.h
+@@ -715,11 +715,15 @@ static uvm_va_block_t *uvm_va_range_block(uvm_va_range_t *va_range, size_t index
+     // Later accesses in this thread will read state out of block, potentially
+     // as soon as the block pointer is updated by another thread. We have to
+     // make sure that any initialization of this block by the creating thread is
+     // visible to later accesses in this thread, which requires a data
+     // dependency barrier.
++#if defined(NV_SMP_READ_BARRIER_DEPENDS_PRESENT)
+     smp_read_barrier_depends();
++#else
++    smp_mb();
++#endif
+     return block;
+ }
+ 
+ // Same as uvm_va_range_block except that the block is created if not already
+ // present in the array. If NV_OK is returned, the block has been allocated
+

--- a/srcpkgs/nvidia390/files/linux-5.9.x.patch
+++ b/srcpkgs/nvidia390/files/linux-5.9.x.patch
@@ -1,0 +1,427 @@
+Source: Mageia, http://sophie.zarb.org/rpms/eaff282f82f9fc9911151ebd234f25cc/files/8
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index 37c6841..23efe9e 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -159,12 +159,14 @@ static inline uid_t __kuid_val(kuid_t uid)
+ }
+ #endif
+ 
+ #if defined(NVCPU_X86_64) && !defined(HAVE_COMPAT_IOCTL)
+ #include <linux/syscalls.h>         /* sys_ioctl()                      */
++#if defined(NV_LINUX_IOCTL32_H_PRESENT)
+ #include <linux/ioctl32.h>          /* register_ioctl32_conversion()    */
+ #endif
++#endif
+ 
+ #if !defined(NV_FILE_OPERATIONS_HAS_IOCTL) && \
+   !defined(NV_FILE_OPERATIONS_HAS_UNLOCKED_IOCTL)
+ #error "struct file_operations compile test likely failed!"
+ #endif
+diff --git a/kernel/common/inc/nv-mm.h b/kernel/common/inc/nv-mm.h
+index 8df26f1..e791bb2 100644
+--- a/kernel/common/inc/nv-mm.h
++++ b/kernel/common/inc/nv-mm.h
+@@ -146,10 +146,15 @@ typedef int vm_fault_t;
+         #if defined(NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG)
+ 
+                return get_user_pages_remote(tsk, mm, start, nr_pages, flags,
+                                             pages, vmas, NULL);
+ 
++        #elif defined(NV_GET_USER_PAGES_REMOTE_REMOVED_TSK_ARG)
++
++               return get_user_pages_remote(mm, start, nr_pages, flags,
++                                            pages, vmas, NULL);
++
+         #else
+ 
+                return get_user_pages_remote(tsk, mm, start, nr_pages, flags,
+                                             pages, vmas);
+ 
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index cdb249c..54da233 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -132,10 +132,11 @@ test_headers() {
+     FILES="$FILES linux/sched/task_stack.h"
+     FILES="$FILES xen/ioemu.h"
+     FILES="$FILES linux/fence.h"
+     FILES="$FILES linux/ktime.h"
+     FILES="$FILES linux/dma-resv.h"
++    FILES="$FILES linux/ioctl32.h"
+ 
+     # Arch specific headers which need testing
+     FILES_ARCH="asm/book3s/64/hash-64k.h"
+     FILES_ARCH="$FILES_ARCH asm/set_memory.h"
+     FILES_ARCH="$FILES_ARCH asm/powernv.h"
+@@ -2449,10 +2450,69 @@ compile_test() {
+             }"
+ 
+             compile_check_conftest "$CODE" "NV_DRM_DRIVER_HAS_LEGACY_DEV_LIST" "" "types"
+         ;;
+ 
++        drm_driver_has_gem_free_object)
++            CODE="
++            #if defined(NV_DRM_DRMP_H_PRESENT)
++            #include <drm/drmP.h>
++            #endif
++
++            #if defined(NV_DRM_DRM_DRV_H_PRESENT)
++            #include <drm/drm_drv.h>
++            #endif
++
++            int conftest_drm_driver_has_gem_free_object(void) {
++                return offsetof(struct drm_driver, gem_free_object);
++            }"
++
++            compile_check_conftest "$CODE" "NV_DRM_DRIVER_HAS_GEM_FREE_OBJECT" "" "types"
++        ;;
++
++        drm_display_mode_has_vrefresh)
++            CODE="
++            #if defined(NV_DRM_DRMP_H_PRESENT)
++            #include <drm/drmP.h>
++            #endif
++
++            #if defined(NV_DRM_DRM_DRV_H_PRESENT)
++            #include <drm/drm_drv.h>
++            #endif
++
++            int conftest_drm_display_mode_has_vrefresh(void) {
++                return offsetof(struct drm_display_mode, vrefresh);
++            }"
++
++            compile_check_conftest "$CODE" "NV_DRM_DISPLAY_MODE_HAS_VREFRESH" "" "types"
++        ;;
++
++        drm_master_set_returns_int)
++            CODE="
++            #if defined(NV_DRM_DRMP_H_PRESENT)
++            #include <drm/drmP.h>
++            #endif
++
++            #if defined(NV_DRM_DRM_DRV_H_PRESENT)
++            #include <drm/drm_drv.h>
++            #endif
++
++            static int nv_master_set(struct drm_device *x, struct drm_file *y, bool z)
++            {
++                return 1;
++            }
++
++            int conftest_drm_master_set_returns_int(void) {
++                struct drm_driver nv_drm_driver;
++                nv_drm_driver.master_set = nv_master_set;
++
++                return nv_drm_driver.master_set(NULL, NULL, false);
++            }"
++
++            compile_check_conftest "$CODE" "NV_DRM_MASTER_SET_RETURNS_INT" "" "generic"
++        ;;
++
+         jiffies_to_timespec)
+             #
+             # Determine if jiffies_to_timespec() is present
+             #
+             # removed by commit 751addac78b6
+@@ -3138,10 +3198,33 @@ compile_test() {
+             else
+                 echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG" | append_conftest "functions"
+             fi
+             echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_WRITE_AND_FORCE_ARGS" | append_conftest "functions"
+ 
++            # conftest #4: check if get_user_pages_remote() has removed tsk argument
++
++            echo "$CONFTEST_PREAMBLE
++            #include <linux/mm.h>
++            long get_user_pages_remote(struct mm_struct *mm,
++                                       unsigned long start,
++                                       unsigned long nr_pages,
++                                       unsigned int gup_flags,
++                                       struct page **pages,
++                                       struct vm_area_struct **vmas,
++                                       int *locked) {
++                return 0;
++            }" > conftest$$.c
++
++            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
++            rm -f conftest$$.c
++
++            if [ -f conftest$$.o ]; then
++                echo "#define NV_GET_USER_PAGES_REMOTE_REMOVED_TSK_ARG" | append_conftest "functions"
++                rm -f conftest$$.o
++            else
++                echo "#undef NV_GET_USER_PAGES_REMOTE_REMOVED_TSK_ARG" | append_conftest "functions"
++            fi
+         ;;
+ 
+         usleep_range)
+             #
+             # Determine if the function usleep_range() is present.
+@@ -3227,10 +3310,25 @@ compile_test() {
+                 echo "#undef NV_DRM_GEM_OBJECT_LOOKUP_PRESENT" | append_conftest "functions"
+                 echo "#undef NV_DRM_GEM_OBJECT_LOOKUP_ARGUMENT_COUNT" | append_conftest "functions"
+             fi
+         ;;
+ 
++        drm_gem_object_put_unlocked)
++            CODE="
++            #if defined(NV_DRM_DRMP_H_PRESENT)
++            #include <drm/drmP.h>
++            #endif
++            #if defined(NV_DRM_DRM_GEM_H_PRESENT)
++            #include <drm/drm_gem.h>
++            #endif
++            int conftest_drm_gem_object_put_unlocked(void) {
++                drm_gem_object_put_unlocked();
++            }"
++
++            compile_check_conftest "$CODE" "NV_DRM_GEM_OBJECT_PUT_UNLOCKED_PRESENT" "" "functions"
++        ;;
++
+         drm_master_drop_has_from_release_arg)
+             #
+             # Determine if drm_driver::master_drop() has 'from_release' argument.
+             #
+             # Last argument 'bool from_release' has been removed by:
+@@ -4129,10 +4227,30 @@ compile_test() {
+             }"
+ 
+             compile_check_conftest "$CODE" "NV_PCI_DEV_HAS_SKIP_BUS_PM" "" "types"
+         ;;
+ 
++        smp_read_barrier_depends)
++            CODE="
++            #include <asm/barrier.h>
++            void conftest_smp_read_barrier_depends(void) {
++                smp_read_barrier_depends(0);
++            }"
++
++            compile_check_conftest "$CODE" "NV_SMP_READ_BARRIER_DEPENDS_PRESENT" "" "functions"
++        ;;
++
++        vga_tryget)
++            CODE="
++            #include <linux/vgaarb.h>
++            void conftest_vga_tryget(void) {
++                vga_tryget();
++            }"
++
++            compile_check_conftest "$CODE" "NV_VGA_TRYGET_PRESENT" "" "functions"
++        ;;
++
+     esac
+ }
+ 
+ case "$6" in
+     cc_sanity_check)
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index 17e377d..95e035b 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -464,20 +464,29 @@ static void nv_drm_unload(struct drm_device *dev)
+ }
+ #endif
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+ 
++#if defined(NV_DRM_MASTER_SET_RETURNS_INT)
+ static int nv_drm_master_set(struct drm_device *dev,
+                              struct drm_file *file_priv, bool from_open)
++#else
++static void nv_drm_master_set(struct drm_device *dev,
++                              struct drm_file *file_priv, bool from_open)
++#endif
+ {
+     struct nv_drm_device *nv_dev = to_nv_device(dev);
+ 
++#if defined(NV_DRM_MASTER_SET_RETURNS_INT)
+     if (!nvKms->grabOwnership(nv_dev->pDevice)) {
+         return -EINVAL;
+     }
+ 
+     return 0;
++#else
++    nvKms->grabOwnership(nv_dev->pDevice);
++#endif
+ }
+ 
+ #if defined(NV_DRM_MASTER_DROP_HAS_FROM_RELEASE_ARG)
+ static
+ void nv_drm_master_drop(struct drm_device *dev,
+@@ -675,11 +684,15 @@ static struct drm_driver nv_drm_driver = {
+ #if defined(NV_DRM_DRIVER_PRIME_FLAG_PRESENT)
+                                DRIVER_PRIME |
+ #endif
+                                DRIVER_GEM  | DRIVER_RENDER,
+ 
++#if defined(NV_DRM_DRIVER_HAS_GEM_FREE_OBJECT)
+     .gem_free_object        = nv_drm_gem_free,
++#else
++    .gem_free_object_unlocked = nv_drm_gem_free,
++#endif
+ 
+     .ioctls                 = nv_drm_ioctls,
+     .num_ioctls             = ARRAY_SIZE(nv_drm_ioctls),
+ 
+     .prime_handle_to_fd     = drm_gem_prime_handle_to_fd,
+diff --git a/kernel/nvidia-drm/nvidia-drm-gem.c b/kernel/nvidia-drm/nvidia-drm-gem.c
+index 37100ed..eb7b959 100644
+--- a/kernel/nvidia-drm/nvidia-drm-gem.c
++++ b/kernel/nvidia-drm/nvidia-drm-gem.c
+@@ -41,11 +41,13 @@
+ void nv_drm_gem_free(struct drm_gem_object *gem)
+ {
+     struct drm_device *dev = gem->dev;
+     struct nv_drm_gem_object *nv_gem = to_nv_gem_object(gem);
+ 
++#if !defined(NV_DRM_DRIVER_HAS_GEM_FREE_OBJECT)
+     WARN_ON(!mutex_is_locked(&dev->struct_mutex));
++#endif
+ 
+     /* Cleanup core gem object */
+ 
+     drm_gem_object_release(&nv_gem->base);
+ 
+diff --git a/kernel/nvidia-drm/nvidia-drm-gem.h b/kernel/nvidia-drm/nvidia-drm-gem.h
+index 5691a7a..7fc6f69 100644
+--- a/kernel/nvidia-drm/nvidia-drm-gem.h
++++ b/kernel/nvidia-drm/nvidia-drm-gem.h
+@@ -85,11 +85,15 @@ static inline struct nv_drm_gem_object *to_nv_gem_object(
+ 
+ static inline void
+ nv_drm_gem_object_unreference_unlocked(struct nv_drm_gem_object *nv_gem)
+ {
+ #if defined(NV_DRM_GEM_OBJECT_GET_PRESENT)
++#if defined(NV_DRM_GEM_OBJECT_PUT_UNLOCKED_PRESENT)
+     drm_gem_object_put_unlocked(&nv_gem->base);
++#else
++    drm_gem_object_put(&nv_gem->base);
++#endif
+ #else
+     drm_gem_object_unreference_unlocked(&nv_gem->base);
+ #endif
+ }
+ 
+@@ -136,11 +140,10 @@ void nv_drm_gem_object_init(struct nv_drm_device *nv_dev,
+     nv_dma_resv_init(&nv_gem->resv);
+ 
+ #if defined(NV_DRM_GEM_OBJECT_HAS_RESV)
+     nv_gem->base.resv = &nv_gem->resv;
+ #endif
+-
+ #endif
+ 
+     drm_gem_private_object_init(dev, &nv_gem->base, size);
+ }
+ 
+diff --git a/kernel/nvidia-drm/nvidia-drm-utils.c b/kernel/nvidia-drm/nvidia-drm-utils.c
+index 8cb2d5e..6460d4d 100644
+--- a/kernel/nvidia-drm/nvidia-drm-utils.c
++++ b/kernel/nvidia-drm/nvidia-drm-utils.c
+@@ -101,11 +101,13 @@ int nvkms_connector_type_to_drm_connector_type(NvKmsConnectorType type,
+ 
+ void
+ nvkms_display_mode_to_drm_mode(const struct NvKmsKapiDisplayMode *displayMode,
+                                struct drm_display_mode *mode)
+ {
++#if defined(NV_DRM_DISPLAY_MODE_HAS_VREFRESH)
+     mode->vrefresh    = (displayMode->timings.refreshRate + 500) / 1000; /* In Hz */
++#endif
+ 
+     mode->clock       = (displayMode->timings.pixelClockHz + 500) / 1000; /* In Hz */
+ 
+     mode->hdisplay    = displayMode->timings.hVisible;
+     mode->hsync_start = displayMode->timings.hSyncStart;
+@@ -187,11 +189,13 @@ bool drm_format_to_nvkms_format(u32 format,
+ }
+ 
+ void drm_mode_to_nvkms_display_mode(const struct drm_display_mode *src,
+                                     struct NvKmsKapiDisplayMode *dst)
+ {
++#if defined(NV_DRM_DISPLAY_MODE_HAS_VREFRESH)
+     dst->timings.refreshRate  = src->vrefresh * 1000;
++#endif
+ 
+     dst->timings.pixelClockHz = src->clock * 1000; /* In Hz */
+ 
+     dst->timings.hVisible   = src->hdisplay;
+     dst->timings.hSyncStart = src->hsync_start;
+diff --git a/kernel/nvidia-drm/nvidia-drm.Kbuild b/kernel/nvidia-drm/nvidia-drm.Kbuild
+index 4cfbbbc..d9dbab8 100644
+--- a/kernel/nvidia-drm/nvidia-drm.Kbuild
++++ b/kernel/nvidia-drm/nvidia-drm.Kbuild
+@@ -47,18 +47,20 @@ $(call ASSIGN_PER_OBJ_CFLAGS, $(NVIDIA_DRM_OBJECTS), $(NVIDIA_DRM_CFLAGS))
+ 
+ NV_OBJECTS_DEPEND_ON_CONFTEST += $(NVIDIA_DRM_OBJECTS)
+ 
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += drm_available
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += drm_atomic_available
++NV_CONFTEST_GENERIC_COMPILE_TESTS += drm_master_set_returns_int
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += is_export_symbol_gpl_refcount_inc
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += is_export_symbol_gpl_refcount_dec_and_test
+ 
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_dev_unref
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_reinit_primary_mode_group
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += get_user_pages_remote
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += get_user_pages
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_gem_object_lookup
++NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_gem_object_put_unlocked
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_atomic_state_ref_counting
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_driver_has_gem_prime_res_obj
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_atomic_helper_connector_dpms
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_connector_funcs_have_mode_in_name
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += vmf_insert_pfn
+@@ -70,10 +72,12 @@ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_connector_for_each_possible_encoder
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_bus_present
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_bus_has_bus_type
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_bus_has_get_irq
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_bus_has_get_name
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_legacy_dev_list
++NV_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_gem_free_object
++NV_CONFTEST_TYPE_COMPILE_TESTS += drm_display_mode_has_vrefresh
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_set_busid
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_crtc_state_has_connectors_changed
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_init_function_args
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_mode_connector_list_update_has_merge_type_bits_arg
+ NV_CONFTEST_TYPE_COMPILE_TESTS += drm_helper_mode_fill_fb_struct
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index f7f1def..8fb2161 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -49,12 +49,14 @@
+ #endif
+ 
+ 
+ #if NV_NEEDS_COMPAT_IOCTL_REGISTRATION
+ #include <linux/syscalls.h> /* sys_ioctl() */
++#if defined(NV_LINUX_IOCTL32_H_PRESENT)
+ #include <linux/ioctl32.h> /* register_ioctl32_conversion() */
+ #endif
++#endif
+ 
+ #define NVKMS_MAJOR_DEVICE_NUMBER 195
+ #define NVKMS_MINOR_DEVICE_NUMBER 254
+ 
+ #define NVKMS_LOG_PREFIX "nvidia-modeset: "
+diff --git a/kernel/nvidia/nv.c b/kernel/nvidia/nv.c
+index 15983f6..a7be80a 100644
+--- a/kernel/nvidia/nv.c
++++ b/kernel/nvidia/nv.c
+@@ -3870,11 +3870,15 @@ nvidia_probe
+ 
+     pci_set_master(dev);
+ 
+ #if defined(CONFIG_VGA_ARB) && !defined(NVCPU_PPC64LE)
+ #if defined(VGA_DEFAULT_DEVICE)
++#if defined(NV_VGA_TRYGET_PRESENT)
+     vga_tryget(VGA_DEFAULT_DEVICE, VGA_RSRC_LEGACY_MASK);
++#else
++    vga_get(VGA_DEFAULT_DEVICE, VGA_RSRC_LEGACY_MASK, 0);
++#endif
+ #endif
+     vga_set_legacy_decoding(dev, VGA_RSRC_NONE);
+ #endif
+ 
+     if (rm_get_cpu_type(sp, &nv_cpu_type) != NV_OK)
+

--- a/srcpkgs/nvidia390/template
+++ b/srcpkgs/nvidia390/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GeForce 400, 500 series)"
 
 pkgname=nvidia390
 version=390.138
-revision=2
+revision=3
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com"
@@ -43,6 +43,10 @@ pre_install() {
 	cp nvidia_icd.json.template nvidia_icd.json
 	sed -i -e 's:__NV_VK_ICD__:libGLX_nvidia.so.0:g' nvidia_icd.json
 	patch -Np1 < ${FILESDIR}/linux-5.8.x.patch
+	patch -Np1 < ${FILESDIR}/linux-5.9.x.patch
+	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
+		patch -Np1 < ${FILESDIR}/linux-5.9.x-x86_64.patch
+	fi
 }
 
 do_install() {


### PR DESCRIPTION
On i686, module builds in VM with few kernels, but wasn't runtime tested.
On x86_64, module builds and runs with few kernels.

Patches comes from Mageia.

cc @abenson, @pullmoll 