### PR TITLE
[RFC] add new libtls implementation

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1756,6 +1756,11 @@ libid3.so id3lib-3.8.3_1
 libid3-3.8.so.3 id3lib-3.8.3_1
 libgirara-gtk3.so.3 girara-0.2.8_1
 libjq.so.1 jq-devel-1.4_1
+libcrypto.so.43 libcrypto43-2.7.2_1
+libssl.so.45 libssl45-2.7.2_1
+libtls.so.17 libtls17-2.7.2_1
+libcrypto.so.1.1 libcrypto1.1-1.1.1f_1
+libssl.so.1.1 libssl1.1-1.1.1f_1
 libvamp-hostsdk.so.3 libvamp-plugin-sdk-2.2_6
 libportmidi.so portmidi-217_1
 libWildMidi.so.2 libwildmidi-0.4.3_1

--- a/srcpkgs/libcrypto1.1
+++ b/srcpkgs/libcrypto1.1
@@ -1,0 +1,1 @@
+openssl

--- a/srcpkgs/libretls-devel
+++ b/srcpkgs/libretls-devel
@@ -1,0 +1,1 @@
+libretls

--- a/srcpkgs/libretls/template
+++ b/srcpkgs/libretls/template
@@ -1,0 +1,24 @@
+# Template file for 'libretls'
+pkgname=libretls
+version=3.3.1
+revision=1
+build_style=gnu-configure
+hostmakedepnds="pkg-config"
+makedepends="openssl-devel"
+short_desc="Libtls for OpenSSL"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="ISC, 3-Clause-BSD, MIT"
+homepage="https://git.causal.agency/libretls"
+distfiles="https://causal.agency/libretls/libretls-${version}.tar.gz"
+checksum=f23a29ef321eff099b8fbabdecc3a3378cfb9eca24b2bf02062554e9779c4d33
+
+libretls-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/share/man/man3
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+	}
+}

--- a/srcpkgs/libssl1.1
+++ b/srcpkgs/libssl1.1
@@ -1,0 +1,1 @@
+openssl

--- a/srcpkgs/libtls-bearssl-devel
+++ b/srcpkgs/libtls-bearssl-devel
@@ -1,0 +1,1 @@
+libtls-bearssl

--- a/srcpkgs/libtls-bearssl/template
+++ b/srcpkgs/libtls-bearssl/template
@@ -1,0 +1,25 @@
+# Template file for 'libtls-bearssl'
+pkgname=libtls-bearssl
+version=0.3
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+hostmakedepends="bearssl-devel"
+short_desc="Libtls implemented on top of BearSSL"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="GPL-3.0-or-later"
+homepage="https://sr.ht/~mcf/libtls-bearssl"
+distfiles="https://github.com/michaelforney/libtls-bearssl/releases/download/${version}/libtls-bearssl-${version}.tar.gz"
+checksum=bcbcb423326c6ee41ae350788d4d50534632924ba8617fa170cc401be8d3a6e9
+
+libtls-bearssl-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/share/man/man3
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/openssl-c_rehash
+++ b/srcpkgs/openssl-c_rehash
@@ -1,0 +1,1 @@
+openssl

--- a/srcpkgs/openssl-devel
+++ b/srcpkgs/openssl-devel
@@ -1,0 +1,1 @@
+openssl

--- a/srcpkgs/openssl/patches/ppc-auxv.patch
+++ b/srcpkgs/openssl/patches/ppc-auxv.patch
@@ -1,0 +1,17 @@
+--- crypto/ppccap.c.old	2020-03-17 14:31:17.000000000 +0000
++++ crypto/ppccap.c	2020-03-30 06:32:25.943988524 +0000
+@@ -207,11 +207,9 @@
+         return 0;
+ }
+ 
+-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+-# if __GLIBC_PREREQ(2, 16)
+-#  include <sys/auxv.h>
+-#  define OSSL_IMPLEMENT_GETAUXVAL
+-# endif
++#if defined(__linux__)
++# include <sys/auxv.h>
++# define OSSL_IMPLEMENT_GETAUXVAL
+ #endif
+ 
+ /* I wish <sys/auxv.h> was universally available */

--- a/srcpkgs/openssl/patches/ppc64.patch
+++ b/srcpkgs/openssl/patches/ppc64.patch
@@ -1,0 +1,96 @@
+From 34ab13b7d8e3e723adb60be8142e38b7c9cd382a Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Sun, 5 May 2019 18:25:50 +0200
+Subject: [PATCH] crypto/perlasm/ppc-xlate.pl: add linux64v2 flavour
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is a big endian ELFv2 configuration. ELFv2 was already being
+used for little endian, and big endian was traditionally ELFv1
+but there are practical configurations that use ELFv2 with big
+endian nowadays (Adélie Linux, Void Linux, possibly Gentoo, etc.)
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/8883)
+---
+ crypto/perlasm/ppc-xlate.pl | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/crypto/perlasm/ppc-xlate.pl b/crypto/perlasm/ppc-xlate.pl
+index e52f2f6ea62..5fcd0526dff 100755
+--- crypto/perlasm/ppc-xlate.pl
++++ crypto/perlasm/ppc-xlate.pl
+@@ -49,7 +49,7 @@
+ 	/osx/		&& do { $name = "_$name";
+ 				last;
+ 			      };
+-	/linux.*(32|64le)/
++	/linux.*(32|64(le|v2))/
+ 			&& do {	$ret .= ".globl	$name";
+ 				if (!$$type) {
+ 				    $ret .= "\n.type	$name,\@function";
+@@ -80,7 +80,7 @@
+ };
+ my $text = sub {
+     my $ret = ($flavour =~ /aix/) ? ".csect\t.text[PR],7" : ".text";
+-    $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64le/);
++    $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64(le|v2)/);
+     $ret;
+ };
+ my $machine = sub {
+@@ -186,7 +186,7 @@
+ 
+ # Some ABIs specify vrsave, special-purpose register #256, as reserved
+ # for system use.
+-my $no_vrsave = ($flavour =~ /aix|linux64le/);
++my $no_vrsave = ($flavour =~ /aix|linux64(le|v2)/);
+ my $mtspr = sub {
+     my ($f,$idx,$ra) = @_;
+     if ($idx == 256 && $no_vrsave) {
+@@ -318,7 +318,7 @@ sub vfour {
+ 	if ($label) {
+ 	    my $xlated = ($GLOBALS{$label} or $label);
+ 	    print "$xlated:";
+-	    if ($flavour =~ /linux.*64le/) {
++	    if ($flavour =~ /linux.*64(le|v2)/) {
+ 		if ($TYPES{$label} =~ /function/) {
+ 		    printf "\n.localentry	%s,0\n",$xlated;
+ 		}
+
+From 098404128383ded87ba390dd74ecd9e2ffa6f530 Mon Sep 17 00:00:00 2001
+From: Andy Polyakov <appro@openssl.org>
+Date: Sun, 5 May 2019 18:30:55 +0200
+Subject: [PATCH] Configure: use ELFv2 ABI on some ppc64 big endian systems
+
+If _CALL_ELF is defined to be 2, it's an ELFv2 system.
+Conditionally switch to the v2 perlasm scheme.
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/8883)
+---
+ Configure | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/Configure b/Configure
+index 22082deb4c7..e303d98deb3 100755
+--- Configure
++++ Configure
+@@ -1402,8 +1402,15 @@
+ my %predefined_C = compiler_predefined($config{CROSS_COMPILE}.$config{CC});
+ my %predefined_CXX = $config{CXX}
+     ? compiler_predefined($config{CROSS_COMPILE}.$config{CXX})
+     : ();
+ 
++unless ($disabled{asm}) {
++    # big endian systems can use ELFv2 ABI
++    if ($target eq "linux-ppc64") {
++        $target{perlasm_scheme} = "linux64v2" if ($predefined_C{_CALL_ELF} == 2);
++    }
++}
++
+ # Check for makedepend capabilities.
+ if (!$disabled{makedepend}) {
+     if ($config{target} =~ /^(VC|vms)-/) {

--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,0 +1,88 @@
+# Template file for 'openssl'
+pkgname=openssl
+version=1.1.1g
+revision=1
+build_style=configure
+configure_script="./Configure"
+configure_args="--prefix=/usr --openssldir=/etc/ssl --libdir=lib shared
+ no-async no-comp no-idea no-mdc2 no-rc5 no-ec2m no-sm2 no-sm4 no-ssl2
+ no-ssl3 no-seed no-weak-ssl-ciphers -Wa,--noexecstack"
+make_cmd=make
+make_build_args='MAKEDEPPROG="$(CC)'
+make_check_target=test
+make_install_args="MANSUFFIX=ssl"
+short_desc="Toolkit for Secure Sockets Layer and Transport Layer Security"
+maintainer="John <johnz@posteo.net>"
+license="OpenSSL-License"
+homepage="https://www.openssl.org"
+distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
+checksum=ddb04774f1e32f0c49751e21b67216ac87852ceb056b75209af2443400636d46
+conf_files="/etc/ssl/openssl.cnf"
+conflicts="libressl<=3.0.2_2"
+
+alternatives="openssl:openssl:/usr/bin/openssl-openssl"
+
+if [ "$CHROOT_READY" ]; then
+	hostmakedepends="perl"
+fi
+
+case $XBPS_TARGET_MACHINE in
+	x86_64*) configure_args+=" enable-ec_nistp_64_gcc_128 linux-x86_64";;
+	i686*) configure_args+=" linux-elf";;
+	aarch64*) configure_args+=" linux-aarch64";;
+	ppc64le*) configure_args+=" linux-ppc64le";;
+	ppc64*) configure_args+=" linux-ppc64";;
+	ppc*) configure_args+=" linux-ppc";;
+	arm*) configure_args+=" linux-armv4";;
+	mips*) configure_args+=" linux-mips32 -mips32";;
+	*) broken="$XBPS_TARGET_MACHINE";;
+esac
+
+pre_configure() {
+	configure_args+=" ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+}
+
+pre_build() {
+	make ${makejobs} depend
+}
+
+post_install() {
+	mv ${DESTDIR}/usr/bin/openssl{,-openssl}
+}
+
+libcrypto1.1_package() {
+	short_desc+=" - crypto library"
+	pkg_install() {
+		vmove "usr/lib/libcrypto.so.*"
+		vmove usr/lib/engines-1.1
+	}
+}
+
+libssl1.1_package() {
+	short_desc+=" - SSL/TLS library"
+	pkg_install() {
+		vmove "usr/lib/libssl.so.*"
+	}
+}
+
+openssl-c_rehash_package() {
+	short_desc+=" - c_rehash utility"
+	depends="openssl perl"
+	pkg_install() {
+		vmove usr/bin/c_rehash
+	}
+}
+
+openssl-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	conflicts="libressl-devel>=0"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/share/man/man3
+		vmove usr/share/doc
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
Based on #21056 and some discussion in #20935 

@leahneukirchen has suggested an alternative that is building only `libtls` from LibreSSL instead. I haven't tried this one yet.( See https://github.com/libressl-portable/portable/commit/fe42a8011b25797afa48cf0359c7e2753b2ece5f )

My current propositions are:

- libretls from causal agency, who is the author of most of the software in our repos that depend on libtls
- libtls-bearssl, which is based on BearSSL instead of any sort of mix between LibreSSL/OpenSSL