### PR TITLE
s6-networking: switch to BearSSL as default.

### DIFF
--- a/srcpkgs/s6-networking/template
+++ b/srcpkgs/s6-networking/template
@@ -1,7 +1,7 @@
 # Template file for 's6-networking'
 pkgname=s6-networking
 version=2.3.2.0
-revision=1
+revision=2
 build_style=configure
 configure_args="--libdir=/usr/lib $(vopt_if libressl --enable-ssl=libressl)
  $(vopt_if bearssl --enable-ssl=bearssl)
@@ -18,7 +18,7 @@ distfiles="${homepage}/${pkgname}-${version}.tar.gz"
 checksum=bbe36a8460d90f3bff56c934811876186f7224ced5bdc15c2c96d49b4e917d12
 
 build_options="bearssl libressl"
-build_options_default="libressl"
+build_options_default="bearssl"
 desc_option_bearssl="Use BearSSL as SSL library"
 desc_option_libressl="Use LibreSSL as SSL library"
 vopt_conflict bearssl libressl


### PR DESCRIPTION
Generally preferred by upstream and will ease a transition to OpenSSL.

@lemmi any issue?