### PR TITLE
wine: Use MinGW to build WinPE DLLs

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,7 +1,7 @@
 # Template file for 'wine'
 pkgname=wine
 version=6.0rc5
-revision=1
+revision=2
 wrksrc=wine-${version/r/-r}
 build_style=gnu-configure
 configure_args="--bindir=/usr/libexec/wine"
@@ -11,6 +11,10 @@ license="LGPL-2.1-or-later"
 homepage="http://www.winehq.org/"
 distfiles="https://dl.winehq.org/wine/source/${version%r*}/wine-${version/r/-r}.tar.xz"
 checksum=f1f10a0aef4dcc9cf4ec67f0828fc1f7f364e2e8e7c2f027c253c8e2004bf451
+
+build_options="mingw"
+build_options_default="mingw"
+desc_option_mingw="Use the MinGW cross compiler to build WinPE DLLs"
 
 lib32mode=full
 archs="i686* x86_64*"
@@ -23,7 +27,8 @@ if [ "$XBPS_TARGET_MACHINE" = i686-musl ]; then
 	_nopie=yes
 fi
 
-hostmakedepends="pkg-config flex gettext"
+hostmakedepends="pkg-config flex gettext
+ $(vopt_if mingw "cross-${XBPS_TARGET_MACHINE%-musl}-w64-mingw32")"
 makedepends="gettext-devel lcms2-devel zlib-devel ncurses-devel
  glu-devel libSM-devel libXext-devel libX11-devel libXpm-devel
  libXinerama-devel libXcomposite-devel libXmu-devel libXxf86vm-devel


### PR DESCRIPTION
As of 5.x, Wine can now build DLLs in native WinPE format if the MinGW cross compiler is present. This is needed for some newer games to pass DRM/anti-cheat checks that validate the integrity of loaded system libraries.

See:

https://www.winehq.org/announce/5.0
https://bugs.winehq.org/show_bug.cgi?id=45349

I've split this out into a build option that's enabled by default.

This was built and tested on an x86_64 host, with 32-bit Wine tested as well. Games which would not launch on Void's Wine build are now functioning with this change (namely, World of Warcraft).