### PR TITLE
aws-vault: update go_import_path

### DIFF
--- a/srcpkgs/aws-vault/template
+++ b/srcpkgs/aws-vault/template
@@ -1,9 +1,9 @@
 # Template file for 'aws-vault'
 pkgname=aws-vault
 version=6.2.0
-revision=1
+revision=2
 build_style=go
-go_import_path=github.com/99designs/aws-vault
+go_import_path=github.com/99designs/aws-vault/v6
 go_ldflags="-X \"main.Version=${version}\" -s -w"
 short_desc="Vault for securely storing and accessing AWS credentials"
 maintainer="klardotsh <josh@klar.sh>"


### PR DESCRIPTION
Go package name has changed to github.com/99designs/aws-vault/v6

Fixes #27688.
