### PR TITLE
tcl: don't build unnecessary compatibility functions.

### DIFF
--- a/srcpkgs/tcl/template
+++ b/srcpkgs/tcl/template
@@ -1,13 +1,14 @@
 # Template file for 'tcl'
 pkgname=tcl
 version=8.6.10
-revision=2
+revision=3
 wrksrc="tcl${version}"
 build_wrksrc=unix
 build_style=gnu-configure
 configure_args="--enable-threads --without-tzdata --enable-man-symlinks
  --disable-static --disable-rpath --with-system-sqlite
- tcl_cv_strtod_unbroken=ok"
+ tcl_cv_strstr_unbroken=ok
+ tcl_cv_strtoul_unbroken=ok"
 makedepends="zlib-devel sqlite-devel"
 short_desc="TCL scripting language"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
./configure-time tests are incorrectly flagging some libc functions as
broken when cross-compiling.  Hard-code correct results of tests.
Without this patch, it seems that I cannot link some things (tclx)
against tcl on aarch64.
