### PR TITLE
balsa: replace enchant with gspell

### DIFF
--- a/srcpkgs/balsa/template
+++ b/srcpkgs/balsa/template
@@ -1,12 +1,12 @@
 # Template file for 'balsa'
 pkgname=balsa
 version=2.6.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-gnome --with-libsecret --with-gpgme --with-sqlite
- --with-html-widget=webkit2"
+ --with-html-widget=webkit2 --with-spell-checker=gspell"
 hostmakedepends="automake gettext-devel intltool pkg-config"
-makedepends="enchant-devel gmime3-devel gnutls-devel gpgme-devel iso-codes
+makedepends="gspell-devel gmime3-devel gnutls-devel gpgme-devel iso-codes
  libesmtp-devel libnotify-devel libsecret-devel webkit2gtk-devel libical-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Email client for GNOME"


### PR DESCRIPTION
It compile fine.
I don't use balsa so I haven't tested the spell check but I've tested gedit that use gspell as spell checker and it works fine, so balsa also should works fine.