### PR TITLE
[breaking] pipewire: update to 0.3.19

### DIFF
--- a/srcpkgs/pipewire/INSTALL.msg
+++ b/srcpkgs/pipewire/INSTALL.msg
@@ -1,0 +1,3 @@
+WARNING: pipewire>=0.3.19 changed the config file format. If
+you edited /etc/pipewire/pipewire.conf you must recreate it from
+/etc/pipewire/pipewire.conf.new-0.3.19_1 with your changes on top.

--- a/srcpkgs/pipewire/patches/ncursesw.patch
+++ b/srcpkgs/pipewire/patches/ncursesw.patch
@@ -1,0 +1,11 @@
+--- meson.build.orig	2021-01-05 18:40:24.345620177 +0100
++++ meson.build	2021-01-05 18:40:43.209619527 +0100
+@@ -325,7 +325,7 @@
+ pthread_lib = dependency('threads')
+ dbus_dep = dependency('dbus-1')
+ sdl_dep = dependency('sdl2', required : false)
+-ncurses_dep = dependency('ncurses', required : false)
++ncurses_dep = dependency('ncursesw', required : false)
+ sndfile_dep = dependency('sndfile', version : '>= 1.0.20', required : false)
+ 
+ if get_option('gstreamer')

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.3.18
+version=0.3.19
 revision=1
 build_style=meson
 configure_args="-Dman=true -Dgstreamer=true -Ddocs=true -Dsystemd=false
@@ -8,7 +8,7 @@ configure_args="-Dman=true -Dgstreamer=true -Ddocs=true -Dsystemd=false
  -Dudevrulesdir=/usr/lib/udev/rules.d"
 hostmakedepends="doxygen graphviz pkg-config xmltoman"
 makedepends="SDL2-devel ffmpeg-devel gst-plugins-base1-devel jack-devel
- sbc-devel v4l-utils-devel libva-devel libbluetooth-devel"
+ sbc-devel v4l-utils-devel libva-devel libbluetooth-devel ncurses-devel"
 depends="libspa-alsa libspa-audioconvert libspa-audiomixer libspa-control"
 short_desc="Server and user space API to deal with multimedia pipelines"
 maintainer="Kridsada Thanabulpong <sirn@ogsite.net>"
@@ -16,7 +16,7 @@ license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=a7317de8e54f57190a2e2fe5f469ed332b9a12151fade03bf984765a55e5e24b
+checksum=de2e757a57ff313362341f4b18b976c707d397d853c0cd2032975b76d0c540dc
 conf_files="/etc/pipewire/pipewire.conf"
 
 replaces="libpulseaudio-pipewire>=0"


### PR DESCRIPTION
> The config file format was changed to use the SPA JSON tokenizer. This makes it more flexible and extensible.

This requires manual intervention, as most have changed the config to launch pipewire-pulse. It is explained in the install msg.

This also adds ncurses makedep to build pw-top. But `meson.build` needs a patch to find our ncurses