### PR TITLE
lyx: update to 2.3.6.1 and replace old enchant

### DIFF
--- a/srcpkgs/lyx/template
+++ b/srcpkgs/lyx/template
@@ -1,16 +1,16 @@
 # Template file for 'lyx'
 pkgname=lyx
-version=2.3.6
+version=2.3.6.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-qt5 --without-included-mythes --without-included-boost"
 hostmakedepends="pkg-config bc qt5-devel"
-makedepends="file-devel boost-devel mythes-devel enchant-devel qt5-svg-devel"
+makedepends="file-devel boost-devel mythes-devel enchant2-devel qt5-svg-devel"
 depends="virtual?tex GraphicsMagick python3"
 short_desc="Document Processor WYSIWYM Editor & Latex frontend"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.lyx.org/Home"
 distfiles="https://ftp.lip6.fr/pub/lyx/stable/2.3.x/${pkgname}-${version}.tar.gz"
-checksum=6cd22594f2dc1e7c4860a97e3340513ab7a82899cd5e824bbaa2a147aa122932
+checksum=6d6f5458ebaac644cdfa35114d029e9ec57b4d930268d6d40bd9795d5c7e7929
 python_version=3


### PR DESCRIPTION
It compile fine.
I don't use lyx so I haven't tested the spell check but should works fine.