### PR TITLE
binutils 2.35.1

### DIFF
--- a/common/build-style/void-cross.sh
+++ b/common/build-style/void-cross.sh
@@ -38,6 +38,17 @@ _void_cross_build_binutils() {
 
 	local ver=$1
 
+	msg_normal "Patching binutils for ${cross_triplet}\n"
+
+	cd ${wrksrc}/binutils-${ver}
+	# enable when crosstoolchains are updated to latest binutils
+	#if [ -d "${XBPS_SRCPKGDIR}/binutils/patches" ]; then
+	#	for f in ${XBPS_SRCPKGDIR}/binutils/patches/*.patch; do
+	#		_void_cross_apply_patch -p1 "$f"
+	#	done
+	#fi
+	cd ..
+
 	msg_normal "Building binutils for ${cross_triplet}\n"
 
 	mkdir -p ${wrksrc}/binutils_build
@@ -55,9 +66,13 @@ _void_cross_build_binutils() {
 		--disable-multilib \
 		--disable-werror \
 		--disable-gold \
-		--with-system-zlib \
+		--enable-relro \
+		--enable-64-bit-bfd \
 		--enable-deterministic-archives \
 		--enable-default-hash-style=gnu \
+		--with-system-zlib \
+		--with-mmap \
+		--with-pic \
 		${cross_binutils_configure_args}
 
 	make configure-host

--- a/srcpkgs/binutils/patches/ppc64-revert-gnu-attributes.patch
+++ b/srcpkgs/binutils/patches/ppc64-revert-gnu-attributes.patch
@@ -1,0 +1,86 @@
+From b1faf99f3e546df2cd302bb1ad36a2078224fe8b Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Fri, 30 Oct 2020 16:59:48 -0600
+Subject: [PATCH] Revert "PR25882, .gnu.attributes are not checked for shared
+ libraries"
+
+This reverts commit a8acd6eeb6dc2cc5460ece90f90ebe36b56b20ba.
+---
+ bfd/ChangeLog     | 6 ------
+ bfd/elf32-tic6x.c | 3 ---
+ ld/ChangeLog      | 6 ------
+ ld/ldlang.c       | 9 ++++-----
+ 4 files changed, 4 insertions(+), 20 deletions(-)
+
+diff --git a/bfd/ChangeLog b/bfd/ChangeLog
+index 9fac12538a..b5461494e8 100644
+--- a/bfd/ChangeLog
++++ b/bfd/ChangeLog
+@@ -1422,12 +1422,6 @@
+ 	accessing root.u.def of symbols.  Also check root.u.def.section
+ 	is non-NULL.  Reverse tests so as to make the logic positive.
+ 
+-2020-05-01  Alan Modra  <amodra@gmail.com>
+-
+-	PR 25882
+-	* elf32-tic6x.c (elf32_tic6x_merge_attributes): Don't transfer
+-	Tag_ABI_PIC or Tag_ABI_PID from dynamic objects to the output.
+-
+ 2020-05-01  Alan Modra  <amodra@gmail.com>
+ 
+ 	PR 25882
+diff --git a/bfd/elf32-tic6x.c b/bfd/elf32-tic6x.c
+index b8b916bfd3..91bb6a10b1 100644
+--- a/bfd/elf32-tic6x.c
++++ b/bfd/elf32-tic6x.c
+@@ -3748,9 +3748,6 @@ elf32_tic6x_merge_attributes (bfd *ibfd, struct bfd_link_info *info)
+ 
+ 	case Tag_ABI_PIC:
+ 	case Tag_ABI_PID:
+-	  /* Don't transfer these tags from dynamic objects.  */
+-	  if ((ibfd->flags & DYNAMIC) != 0)
+-	    continue;
+ 	  if (out_attr[i].i > in_attr[i].i)
+ 	    out_attr[i].i = in_attr[i].i;
+ 	  break;
+diff --git a/ld/ChangeLog b/ld/ChangeLog
+index 4eec7d2977..b93452f70c 100644
+--- a/ld/ChangeLog
++++ b/ld/ChangeLog
+@@ -1319,12 +1319,6 @@
+ 	* testsuite/ld-aarch64/farcall-group.d: New test driver.
+ 	* testsuite/ld-aarch64/aarch64-elf.exp: Run the new test.
+ 
+-2020-05-01  Alan Modra  <amodra@gmail.com>
+-
+-	PR 25882
+-	* ldlang.c (lang_check): Call bfd_merge_private_bfd_data for
+-	shared libraries.
+-
+ 2020-05-01  Alan Modra  <amodra@gmail.com>
+ 
+ 	* po/BLD-POTFILES.in: Regenerate.
+diff --git a/ld/ldlang.c b/ld/ldlang.c
+index 9977195074..173d8ec349 100644
+--- a/ld/ldlang.c
++++ b/ld/ldlang.c
+@@ -6972,12 +6972,11 @@ lang_check (void)
+ 		   bfd_printable_name (input_bfd), input_bfd,
+ 		   bfd_printable_name (link_info.output_bfd));
+ 	}
+-
+-      /* If the input bfd has no contents, it shouldn't set the
+-	 private data of the output bfd.  */
+-      else if ((input_bfd->flags & DYNAMIC) != 0
+-	       || bfd_count_sections (input_bfd) != 0)
++      else if (bfd_count_sections (input_bfd))
+ 	{
++	  /* If the input bfd has no contents, it shouldn't set the
++	     private data of the output bfd.  */
++
+ 	  bfd_error_handler_type pfn = NULL;
+ 
+ 	  /* If we aren't supposed to warn about mismatched input
+-- 
+2.29.2
+

--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -1,14 +1,15 @@
 # Template file for 'binutils'
 pkgname=binutils
-version=2.34
-revision=2
+version=2.35.1
+revision=1
 bootstrap=yes
 short_desc="GNU binary utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/binutils/"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.xz"
-checksum=f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952
+checksum=3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607
+patch_args="-Np1"
 
 makedepends="zlib-devel"
 if [ "$CHROOT_READY" ]; then
@@ -30,72 +31,85 @@ _get_triplet() {
 }
 
 do_configure() {
-	local CONFIGFLAG="--build=$(_get_triplet)
-		--prefix=/usr
-		--enable-threads
-		--enable-plugins
-		--enable-secureplt
-		--with-mmap
-		--disable-shared
-		--enable-gold
-		--disable-werror
-		--enable-deterministic-archives
-		--enable-ld=default
-		--disable-nls"
+	local conf
+
 	if [ "$CHROOT_READY" ]; then
-		CONFIGFLAG+=" --with-debuginfod"
+		conf+=" --with-debuginfod"
 	else
-		CONFIGFLAG+=" --without-debuginfod"
-	fi
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-		CONFIGFLAG+=" --enable-64-bit-bfd --enable-multilib"
+		conf+=" --without-debuginfod"
 	fi
 	if [ "$CROSS_BUILD" ]; then
-		# Do not use configure_args nor build_style=gnu-configure,
-		# avoiding --with-sysroot to $XBPS_CROSS_BASE.
-		CONFIGFLAG+=" --host=$XBPS_CROSS_TRIPLET --with-build-sysroot=$XBPS_CROSS_BASE"
+		# we don't want --with-sysroot=${XBPS_CROSS_BASE} like gnu-configure
+		conf+=" --host=${XBPS_CROSS_TRIPLET} --with-build-sysroot=${XBPS_CROSS_BASE}"
 	fi
-	if [ "$XBPS_TARGET_MACHINE" = "mips-musl" -o "$XBPS_TARGET_MACHINE" = "mipsel-musl" ]; then
-		CONFIGFLAG+=" --with-float=soft --without-fp"
+
+	case "$XBPS_TARGET_MACHINE" in
+		ppc*)
+			conf+=" --enable-secureplt"
+			;;
+		x86_64*)
+			conf+=" --enable-targets=x86_64-pep"
+			;;
+		i686*)
+			conf+=" --enable-targets=x86_64-linux-gnu,x86_64-pep"
+			;;
+	esac
+
+	# enable multilib on x86_64 glibc
+	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
+		conf+=" --enable-multilib"
+	else
+		conf+=" --disable-multilib"
 	fi
-	if [ "${XBPS_TARGET_MACHINE%-musl}" = "x86_64" ]; then
-		CONFIGFLAG+=" --enable-targets=x86_64-pep"
-	elif [ "${XBPS_TARGET_MACHINE%-musl}" = "i686" ]; then
-		CONFIGFLAG+=" --enable-64-bit-bfd --enable-targets=x86_64-linux-gnu,x86_64-pep"
-	fi
-	./configure $CONFIGFLAG
+
+	# ensure softfloat on sf mips targets and set the default hash style
+	case "$XBPS_TARGET_MACHINE" in
+		mips*hf*) conf+=" --enable-default-hash-style=sysv" ;;
+		mips*) conf+=" --without-fp --enable-default-hash-style=sysv" ;;
+		*) conf+=" --enable-default-hash-style=gnu";;
+	esac
+
+	mkdir build && cd build
+	../configure --build=$(_get_triplet) \
+		--prefix=/usr \
+		--libdir=/usr/lib \
+		--mandir=/usr/share/man \
+		--infodir=/usr/share/info \
+		--disable-werror \
+		--disable-shared \
+		--disable-nls \
+		--enable-threads \
+		--enable-plugins \
+		--enable-relro \
+		--enable-gold \
+		--enable-deterministic-archives \
+		--enable-64-bit-bfd \
+		--enable-ld=default \
+		--with-system-zlib \
+		--with-mmap \
+		--with-pic \
+		$conf
 }
 
 do_build() {
-	make ${makejobs}
-
-	# Rebuild libiberty.a with -fPIC
-	cp -a libiberty libiberty-pic
-	make -C libiberty-pic clean
-	make CFLAGS="$CFLAGS -fPIC" -C libiberty-pic
-
-	# Rebuild libbfd.a with -fPIC
-	# hidden visability prevent 3rd party shared libraries exporting bfd non-stable API
-	cp -a bfd bfd-pic
-	make -C bfd-pic clean
-	make CFLAGS="$CFLAGS -fPIC -fvisibility=hidden" -C bfd-pic
-
-	# Rebuild libopcodes.a with -fPIC
-	cp -a opcodes opcodes-pic
-	make -C opcodes-pic clean
-	make CFLAGS="$CFLAGS -fPIC" -C opcodes-pic
+	cd ${wrksrc}/build && make ${makejobs}
 }
 
-# if you enable this later, keep it off for [ -z "$CHROOT_READY" ]
+# there is a testsuite now, but e.g. ifunc tests all fail on musl and
+# also there are other tests that fail on different targets for fairly
+# harmless reasons and it's just too much effort to fix it all
 do_check() {
-	# Seems like upstream forgot to include their new
-	# test-driver executable in their tarball...
-	:
+	[ "$CHROOT_READY" ] || return 0
+	: # cba for now
 }
 
 do_install() {
+	cd ${wrksrc}/build
+
 	local _triplet=$(_get_triplet)
 	make DESTDIR=${DESTDIR} tooldir=/usr install
+
+	cd ..
 
 	# Remove ld (hardlink) and make a symlink to ld.bfd.
 	rm -f ${DESTDIR}/usr/bin/ld
@@ -104,11 +118,6 @@ do_install() {
 	# Add some useful headers
 	vinstall include/libiberty.h 644 usr/include
  	vinstall include/demangle.h 644 usr/include
-
-	# install libraries rebuilt with -fPIC
-	vinstall libiberty-pic/libiberty.a 644 usr/lib
- 	vinstall bfd-pic/libbfd.a 644 usr/lib
- 	vinstall opcodes-pic/libopcodes.a 644 usr/lib
 
 	# Remove these symlinks, they are not ABI stable.
 	# Programs should compile static to the .a file.


### PR DESCRIPTION
we should probably merge this before https://github.com/void-linux/void-packages/pull/24258

I overhauled the template, and enabled (or made explicit) various options that are useful, including RELRO by default (other distros generally use this already). Our ancient PIC rebuild hack is now not needed thanks to `--with-pic`; universal options are now always used universally, and target specific options (e.g. secureplt) are target specific. Additionally, separate build directory is always used.

I tried enabling testsuite but especially on musl this is too much of a pain in the ass and not worth it. There are multiple tests we would have to patch out, even on glibc, and I don't think it's great to carry in a large number of patches just to get all this fragile mess fixed up. This is, however, not a new situation.

Also, the cross-toolchain build style has been updated to unify the binutils configure arguments a little. An omission is `--enable-threads`, which is only used by gold, which is disabled in crosstargets. I think it would be a good idea to disable it in binutils itself as well (it would seem upstream is considering deprecating it), but that's for another time.

Otherwise, I tested this on all ppc targets (32-bit, 64-bit, little endian, big endian, glibc, musl) and it seems to be working fine there (i'm currently building packages with it on my server). I also cross-compiled to `aarch64`, `aarch64-musl`, `armv7l` and `armv6l-musl`. Testing on x86(_64) by other people would be good before we merge this.