### PR TITLE
xen: update to 4.14.1.

### DIFF
--- a/srcpkgs/xen/files/stdint_local.h
+++ b/srcpkgs/xen/files/stdint_local.h
@@ -1,23 +1,20 @@
+/* Copied from Alpine Linux's aports repo: */
 /* 32 bit int types */
 #ifndef STDINT_LOCAL_H
 #define STDINT_LOCAL_H
-typedef signed char             int8_t;
-typedef short int               int16_t;
-typedef int                     int32_t;
-# if defined(__x86_64__)
-typedef long int                int64_t;
-#else
-typedef long long int           int64_t;
-#endif
+typedef	__INT8_TYPE__		int8_t;
+typedef __INT16_TYPE__		int16_t;
+typedef __INT32_TYPE__		int32_t;
+typedef __INT64_TYPE__		int64_t;
+typedef __INTPTR_TYPE__		intptr_t;
 
 /* Unsigned.  */
-typedef unsigned char           uint8_t;
-typedef unsigned short int      uint16_t;
-typedef unsigned int            uint32_t;
-# if defined(__x86_64__)
-typedef unsigned long int       uint64_t;
-#else
-typedef unsigned long long int  uint64_t;
-#endif
+typedef	__UINT8_TYPE__		uint8_t;
+typedef __UINT16_TYPE__		uint16_t;
+typedef __UINT32_TYPE__		uint32_t;
+typedef __UINT64_TYPE__		uint64_t;
+typedef __UINTPTR_TYPE__	uintptr_t;
 
+#define INTPTR_MAX	0x7fffffffffffffffL
+#define UINTPTR_MAX	0xffffffffffffffffUL
 #endif

--- a/srcpkgs/xen/patches/musl-hvmloader-fix-stdint.patch
+++ b/srcpkgs/xen/patches/musl-hvmloader-fix-stdint.patch
@@ -1,0 +1,190 @@
+(patch from Alpine Linux's aports repository)
+musl's stdint does not support gcc -m32 so we need to make sure that we
+don't use system's stdint.h. We ship a stdind_local.h and make sure that
+we use that instead
+
+https://bugs.alpinelinux.org/issues/3308
+
+diff --git a/tools/firmware/Rules.mk b/tools/firmware/Rules.mk
+index 26bbddc..efad58c 100644
+--- a/tools/firmware/Rules.mk
++++ b/tools/firmware/Rules.mk
+@@ -12,6 +12,7 @@ CFLAGS += -DNDEBUG
+ endif
+ 
+ CFLAGS += -Werror
++CFLAGS += -I$(XEN_ROOT)/tools/firmware
+ 
+ $(call cc-options-add,CFLAGS,CC,$(EMBEDDED_EXTRA_CFLAGS))
+ 
+diff --git a/tools/firmware/hvmloader/32bitbios_support.c b/tools/firmware/hvmloader/32bitbios_support.c
+index 1141350..0ba9d38 100644
+--- a/tools/firmware/hvmloader/32bitbios_support.c
++++ b/tools/firmware/hvmloader/32bitbios_support.c
+@@ -20,8 +20,8 @@
+  * this program; If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+-#include <inttypes.h>
+-#include <elf.h>
++#include <stdint_local.h>
++#include <elf_local.h>
+ #ifdef __sun__
+ #include <sys/machelf.h>
+ #endif
+diff --git a/tools/firmware/hvmloader/config.h b/tools/firmware/hvmloader/config.h
+index 844120b..8cb799f 100644
+--- a/tools/firmware/hvmloader/config.h
++++ b/tools/firmware/hvmloader/config.h
+@@ -1,7 +1,7 @@
+ #ifndef __HVMLOADER_CONFIG_H__
+ #define __HVMLOADER_CONFIG_H__
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <stdbool.h>
+ 
+ enum virtual_vga { VGA_none, VGA_std, VGA_cirrus, VGA_pt };
+diff --git a/tools/firmware/hvmloader/hypercall.h b/tools/firmware/hvmloader/hypercall.h
+index 5368c30..c57bc86 100644
+--- a/tools/firmware/hvmloader/hypercall.h
++++ b/tools/firmware/hvmloader/hypercall.h
+@@ -31,7 +31,7 @@
+ #ifndef __HVMLOADER_HYPERCALL_H__
+ #define __HVMLOADER_HYPERCALL_H__
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <xen/xen.h>
+ #include "config.h"
+ 
+diff --git a/tools/firmware/hvmloader/mp_tables.c b/tools/firmware/hvmloader/mp_tables.c
+index d207ecb..6dae38a 100644
+--- a/tools/firmware/hvmloader/mp_tables.c
++++ b/tools/firmware/hvmloader/mp_tables.c
+@@ -27,7 +27,7 @@
+  * this program; If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include "config.h"
+ 
+ /* number of non-processor MP table entries */
+diff --git a/tools/firmware/hvmloader/option_rom.h b/tools/firmware/hvmloader/option_rom.h
+index 0fefe08..66a93bc 100644
+--- a/tools/firmware/hvmloader/option_rom.h
++++ b/tools/firmware/hvmloader/option_rom.h
+@@ -1,7 +1,7 @@
+ #ifndef __HVMLOADER_OPTION_ROM_H__
+ #define __HVMLOADER_OPTION_ROM_H__
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ 
+ struct option_rom_header {
+     uint8_t signature[2]; /* "\x55\xaa" */
+diff --git a/tools/firmware/hvmloader/pir_types.h b/tools/firmware/hvmloader/pir_types.h
+index 9f9259c..7c004c8 100644
+--- a/tools/firmware/hvmloader/pir_types.h
++++ b/tools/firmware/hvmloader/pir_types.h
+@@ -23,7 +23,7 @@
+ #ifndef PIR_TYPES_H
+ #define PIR_TYPES_H
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ 
+ #define NR_PIR_SLOTS 6
+ 
+diff --git a/tools/firmware/hvmloader/smbios.c b/tools/firmware/hvmloader/smbios.c
+index 97a054e..e1646ee 100644
+--- a/tools/firmware/hvmloader/smbios.c
++++ b/tools/firmware/hvmloader/smbios.c
+@@ -19,7 +19,7 @@
+  * Authors: Andrew D. Ball <aball@us.ibm.com>
+  */
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <xen/xen.h>
+ #include <xen/version.h>
+ #include "smbios_types.h"
+diff --git a/tools/firmware/hvmloader/smbios_types.h b/tools/firmware/hvmloader/smbios_types.h
+index 7c648ec..6ea0dc8 100644
+--- a/tools/firmware/hvmloader/smbios_types.h
++++ b/tools/firmware/hvmloader/smbios_types.h
+@@ -25,7 +25,7 @@
+ #ifndef SMBIOS_TYPES_H
+ #define SMBIOS_TYPES_H
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ 
+ /* SMBIOS entry point -- must be written to a 16-bit aligned address
+    between 0xf0000 and 0xfffff. 
+diff --git a/tools/firmware/hvmloader/util.c b/tools/firmware/hvmloader/util.c
+index 7da144b..5a96608 100644
+--- a/tools/firmware/hvmloader/util.c
++++ b/tools/firmware/hvmloader/util.c
+@@ -24,7 +24,7 @@
+ #include "vnuma.h"
+ #include <acpi2_0.h>
+ #include <libacpi.h>
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <xen/xen.h>
+ #include <xen/memory.h>
+ #include <xen/sched.h>
+diff --git a/tools/firmware/hvmloader/util.h b/tools/firmware/hvmloader/util.h
+index 31889de..4f32283 100644
+--- a/tools/firmware/hvmloader/util.h
++++ b/tools/firmware/hvmloader/util.h
+@@ -2,7 +2,7 @@
+ #define __HVMLOADER_UTIL_H__
+ 
+ #include <stdarg.h>
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <stddef.h>
+ #include <stdbool.h>
+ #include <xen/xen.h>
+diff --git a/tools/firmware/rombios/32bit/pmm.c b/tools/firmware/rombios/32bit/pmm.c
+index 09fec42..133cab7 100644
+--- a/tools/firmware/rombios/32bit/pmm.c
++++ b/tools/firmware/rombios/32bit/pmm.c
+@@ -62,7 +62,7 @@
+  *     }
+  */
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <stddef.h>
+ #include "config.h"
+ #include "e820.h"
+diff --git a/tools/firmware/rombios/32bit/util.c b/tools/firmware/rombios/32bit/util.c
+index 6c1c480..52c5878 100644
+--- a/tools/firmware/rombios/32bit/util.c
++++ b/tools/firmware/rombios/32bit/util.c
+@@ -17,7 +17,7 @@
+  * this program; If not, see <http://www.gnu.org/licenses/>.
+  */
+ #include <stdarg.h>
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include "rombios_compat.h"
+ #include "util.h"
+ 
+diff --git a/tools/libacpi/acpi2_0.h b/tools/libacpi/acpi2_0.h
+index 2619ba3..c0498ca 100644
+--- a/tools/libacpi/acpi2_0.h
++++ b/tools/libacpi/acpi2_0.h
+@@ -14,7 +14,7 @@
+ #ifndef _ACPI_2_0_H_
+ #define _ACPI_2_0_H_
+ 
+-#include <stdint.h>
++#include <stdint_local.h>
+ #include <xen/xen.h>
+ #include <xen/hvm/ioreq.h>
+ 

--- a/srcpkgs/xen/template
+++ b/srcpkgs/xen/template
@@ -1,7 +1,7 @@
 # Template file for 'xen'
 pkgname=xen
-version=4.14.0
-revision=4
+version=4.14.1
+revision=1
 # grep -R IPXE_GIT_TAG src/xen-*/tools/firmware/etherboot
 _git_tag_ipxe=4bd064de239dab2426b31c9789a1f4d78087dc63
 # TODO: arm / aarch64
@@ -23,11 +23,21 @@ homepage="https://www.xenproject.org/"
 distfiles="
  https://downloads.xenproject.org/release/xen/${version}/${pkgname}-${version}.tar.gz
  https://github.com/ipxe/ipxe/archive/${_git_tag_ipxe}.tar.gz"
-checksum="
- 06839f68ea7620669dbe8b67861213223cc2a7d02ced61b56e5249c50e87f035
+checksum="cf0d7316ad674491f49b7ef0518cb1d906a2e3bfad639deef0ef2343b119ac0c
  4850691d6f196eaf4d6210f2de01383251b3ea1b928141da9ce28c0b06a90938"
 skip_extraction="${_git_tag_ipxe}.tar.gz"
 nopie=yes
+patch_args='-Np1'
+ignore_elf_dirs="/usr/share/xen/qemu /usr/share/qemu-xen/qemu"
+nostrip_files="
+ hppa-firmware.img
+ u-boot.e500
+ openbios-ppc
+ openbios-sparc32
+ openbios-sparc64
+ palcode-clipper
+ s390-ccw.img
+ s390-netboot.img"
 
 build_options="stubdom"
 build_options_default="stubdom"
@@ -90,19 +100,6 @@ conf_files="
  /etc/conf.d/xendomains
  /etc/conf.d/xencommons
  /etc/xen/xl.conf"
-nostrip_files="
- hppa-firmware.img
- u-boot.e500
- openbios-ppc
- openbios-sparc32
- openbios-sparc64
- palcode-clipper
- s390-ccw.img
- s390-netboot.img"
-ignore_elf_files="
- /usr/share/xen/qemu/openbios-ppc
- /usr/share/xen/qemu/openbios-sparc64
- /usr/share/xen/qemu/openbios-sparc32"
 
 post_extract() {
 	local _src="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
@@ -144,6 +141,7 @@ do_configure() {
 	# Silence a stream edit for dependencies
 	vsed -i Config.mk -e 's;sed ";@&;'
 	cp -a ${FILESDIR}/*.h ${wrksrc}/tools/firmware
+	cp -a ${FILESDIR}/stdint_local.h ${wrksrc}/tools/libxl/
 	rm -f ${XBPS_WRAPPERDIR}/strip
 	./autogen.sh
 	./configure ${configure_args}
@@ -168,9 +166,6 @@ do_install() {
 	# Remove useless stuff.
 	rm -rf ${DESTDIR}/etc/init.d ${DESTDIR}/usr/local
 	rm -f ${DESTDIR}/install.sh
-	if [ -d ${DESTDIR}/usr/lib64/efi ]; then
-		mv -v ${DESTDIR}/usr/lib64/efi ${DESTDIR}/usr/lib/
-	fi
 	rm -rf ${DESTDIR}/usr/lib64
 	rm -rf ${DESTDIR}/usr/bin/qemu-*-xen
 	rm -f ${DESTDIR}/boot/xen{,-4,-4.3}.gz
@@ -196,10 +191,6 @@ do_install() {
 	rm -f ${DESTDIR}/usr/share/doc/xen/html/man/xm.1.html
 	rm -f ${DESTDIR}/usr/share/doc/xen/html/man/{xmdomain.cfg,xend-config.sxp}.5.html
 	rm -f ${DESTDIR}/usr/share/examples/xen/xmexample*
-
-	# Move usr/share/qemu-xen/qemu to usr/libexec/qemu-xen/qemu
-	mkdir -p ${DESTDIR}/usr/libexec/qemu-xen
-	mv -v ${DESTDIR}/usr/{share,libexec}/qemu-xen/qemu
 
 	# runit services
 	vsv xen


### PR DESCRIPTION
Also:
* Split qemu data files into a xen-qemu-data package.  All of the
qemu-xen firmware belongs in /usr/share, not /usr/libexec, because it
is qemu data and not a host executable.
* Bring back a musl patch for hvmloader.  This came from Alpine Linux,
though we had it in the tree a long time ago.  Update stdint_local.h
with the version from Alpine.
