### PR TITLE
chromium: update to 87.0.4280.141.

### DIFF
--- a/srcpkgs/chromium-widevine/INSTALL
+++ b/srcpkgs/chromium-widevine/INSTALL
@@ -1,6 +1,6 @@
 # INSTALL
 
-checksum=4bc68502dc5e22d5c264b3fb5d0a1ecfdadc3ba21d945646d8d37de4b8a96e58
+checksum=b7edb7cd5c166bf3c0a1d245baa5924e242c3b81b97090468bec778f41f40373
 _baseUrl="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable"
 _filename="google-chrome-stable_${VERSION%_*}-1_amd64.deb"
 DISTFILE="${_baseUrl}/${_filename}"

--- a/srcpkgs/chromium-widevine/template
+++ b/srcpkgs/chromium-widevine/template
@@ -6,7 +6,7 @@ _chromeVersion="current"
 _channel="stable"
 
 pkgname=chromium-widevine
-version=87.0.4280.88
+version=87.0.4280.141
 revision=1
 archs="x86_64"
 create_wrksrc=yes

--- a/srcpkgs/chromium/template
+++ b/srcpkgs/chromium/template
@@ -1,7 +1,7 @@
 # Template file for 'chromium'
 pkgname=chromium
 # See http://www.chromium.org/developers/calendar for the latest version
-version=87.0.4280.88
+version=87.0.4280.141
 revision=1
 archs="i686* x86_64* aarch64* armv7l* ppc64le*"
 short_desc="Google's attempt at creating a safer, faster, and more stable browser"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.chromium.org/"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/${pkgname}-${version}.tar.xz"
-checksum=3e4645328735ef60db78d1a313efb3770a3edeaede90d076414df52f567a09c0
+checksum=147591d7fc21e1a173701d28bbf35baddb91e64dd96ec16d8eee9a5113403375
 nocross=yes
 
 lib32disabled=yes
@@ -223,12 +223,8 @@ do_configure() {
 		'use_lld=false'
 	)
 
-	# XXX: gold broken with musl and i686
-	case "${XBPS_TARGET_MACHINE}" in
-	*-musl) conf+=( 'use_gold=false' ) ;;
-	i686*) conf+=( 'use_gold=false' ) ;;
-	*) conf+=( 'use_gold=true' ) ;;
-	esac
+	# XXX: gold broken with musl, i686, and x86_64 so disable globally
+	conf+=( 'use_gold=false' )
 
 	# Always support proprietary codecs.
 	# Enable H.264 support in bundled ffmpeg.


### PR DESCRIPTION
[ci skip]

- Built for x86_64, x86_64-musl.
- Tested on x86_64.
- Update chromium-widevine as well.

Using gold to link produces a segfault during linking on x86_64, so I have disabled it (just like we have done for i686 and musl).

@ericonr @q66 @Johnnynator Please let me know if you know of a different solution for the gold linker.

