### PR TITLE
libvaladoc: depends on vala explicitly

### DIFF
--- a/srcpkgs/valadoc/template
+++ b/srcpkgs/valadoc/template
@@ -2,7 +2,7 @@
 pkgname=valadoc
 # Should be kept in sync with 'vala' (shared distfiles)
 version=0.50.0
-revision=2
+revision=3
 wrksrc="vala-${version}"
 build_style=gnu-configure
 configure_args="--with-cgraph=yes"
@@ -31,6 +31,7 @@ do_install() {
 
 libvaladoc_package() {
 	short_desc+=" - shared library"
+	depends="vala>=${version}"
 	pkg_install() {
 		vmove "usr/lib/libvaladoc-*.so.*"
 		vmove "usr/lib/valadoc-${version%.*}"


### PR DESCRIPTION
Otherwise, xbps-install complains about unresolved shlib.