### PR TITLE
New package: xmenu-4.5.5

### DIFF
--- a/srcpkgs/xmenu/template
+++ b/srcpkgs/xmenu/template
@@ -1,0 +1,20 @@
+# Template file for 'xmenu'
+pkgname=xmenu
+version=4.5.5
+revision=1
+build_style=gnu-makefile
+make_build_args="LOCALINC=$XBPS_CROSS_BASE/usr/include
+ LOCALLIB=$XBPS_CROSS_BASE/usr/lib
+ FREETYPEINC=$XBPS_CROSS_BASE/usr/include/freetype2
+ LDFLAGS+=\$(LIBS) CFLAGS+=\$(INCS)"
+makedepends="imlib2-devel libX11-devel libXft-devel libXinerama-devel"
+short_desc="X11 menu utility"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="MIT"
+homepage="https://github.com/phillbush/xmenu"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=13fda8068d3886a590365d19d6ff84f04c0a4c9a516d79569000514067b4e77b
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
# Current issues
When running `./xbps-src pkg xmenu`, it seems that it's looking for `ft2build.h`, even though `freetype-devel` isn't actually a dependency to build. Even when including `freetype-devel`, behaviour doesn't seem to change. It is specifically complaining about line 15: `#include <X11/Xft/Xft.h>`. I'm not too sure why it's complaining about not being able to find `ft2build.h`. The only dependency I included that the author seems to forget to mention is `libXinerama-devel` as on line 16 of `xmenu.c` it seems to call for it: `#include <X11/extensions/Xinerama.h>`. I am able to build and install the app from source successfully on my machine.