### PR TITLE
retroarch: add support for Neon SIMD on armv7l

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,7 +1,7 @@
 # Template file for 'retroarch'
 pkgname=retroarch
 version=1.9.0
-revision=1
+revision=2
 wrksrc="RetroArch-$version"
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
@@ -80,17 +80,32 @@ if [ "$build_option_x11" ]; then
 	fi
 fi
 
-do_configure() {
-	if [ "$CROSS_BUILD" ]; then
-		configure_args+=" --host=${XBPS_CROSS_TRIPLET}"
-	fi
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*)
+		configure_args+=" --enable-sse --enable-threads"
+		;;
+	ppc*)
+		configure_args+=" --enable-threads"
+		;;
+	aarch64*)
+		configure_args+=" --enable-threads"
+		;;
+	armv7*)
+		build_options+=" neon"
+		build_options_default+=" neon"
+		desc_option_neon="Enable support for ARM Neon SIMD extension"
 
-	case "$XBPS_TARGET_MACHINE" in
-		i686*|x86_64*) configure_args+=" --enable-sse --enable-threads";;
-		ppc*) configure_args+=" --enable-threads";;
-		aarch64*) configure_args+=" --disable-neon --enable-threads";;
-		armv7*) configure_args+=" --disable-neon --enable-threads";;
-		arm*) configure_args+=" --disable-neon";;
+		configure_args+=" --enable-threads $(vopt_enable neon)"
+
+		if [ "$build_option_neon" ]; then
+			CFLAGS+=" -mfpu=neon"
+		fi
+		;;
+	arm*)
+		configure_args+=" --disable-neon"
+		;;
 	esac
-	./configure ${configure_args}
-}
+
+if [ "$CROSS_BUILD" ]; then
+	configure_args+=" --host=${XBPS_CROSS_TRIPLET}"
+fi


### PR DESCRIPTION
`retroarch` is useless without "core" modules that provide emulation capabilities. For Linux on ARM, libretro provides precompiled modules for `armhf` and `armv7-neon-hf`. The `armhf` modules generally work in our `armv7l` build, but the `armv7-neon-hf` modules may offer better performance and---at least in the case of the `picodrive` Sega module---better functionality (I couldn't get the `armhf` version to run without crashing on a Raspberry Pi 3B+).

Since not every ARMv7 implementation supports Neon, this is a build option. However, because I believe Neon is commonly supported, it is enabled by default.