### PR TITLE
[WIP] New package: avldrums.lv2-0.4.1

### DIFF
--- a/srcpkgs/avldrums.lv2/template
+++ b/srcpkgs/avldrums.lv2/template
@@ -1,0 +1,17 @@
+# Template file for 'avldrums.lv2'
+pkgname=avldrums.lv2
+version=0.4.1
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config"
+makedepends="lv2 libglib-devel pango-devel cairo-devel MesaLib-devel glu-devel robtk"
+short_desc="Dedicated AVLDrumkits LV2 Plugin"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/x42/avldrums.lv2"
+distfiles="https://github.com/x42/avldrums.lv2/archive/v${version}.tar.gz"
+checksum=f72d553f48a2935bdfe7fd4b5f7756dc7f1ab2472f1f61331c88816e835f4da2
+
+do_configure() {
+	make submodules
+}

--- a/srcpkgs/robtk/template
+++ b/srcpkgs/robtk/template
@@ -1,0 +1,14 @@
+# Template file for 'robtk'
+pkgname=robtk
+version=0.7.1
+revision=1
+short_desc="Robin's LV2 UI ToolKit"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/x42/robtk"
+distfiles="https://github.com/x42/robtk/archive/v${version}.tar.gz"
+checksum=b2d3c3ff3a14e9f1e63711793d3342d95f53e18cbc83f2e51e6684a57a30367c
+
+do_install() {
+	make robtk.mk
+}


### PR DESCRIPTION
# Current Issues
The upstream Makefile states that `robtk is required` then provides a [link](https://github.com/x42/robtk). However, it's not that clear to me as to how one would go about installing robtk from the README. There is also no Makefile to go off of. This PR addresses [this](https://github.com/void-linux/void-packages/issues/27748).