### PR TITLE
starship: update to 0.48.0.

### DIFF
--- a/srcpkgs/starship/template
+++ b/srcpkgs/starship/template
@@ -1,18 +1,18 @@
 # Template file for 'starship'
 pkgname=starship
-version=0.46.2
+version=0.48.0
 revision=1
 build_style=cargo
 build_helper=qemu
 hostmakedepends="pkg-config"
 makedepends="libgit2-devel"
-checkdepends="git"
+checkdepends="git fish-shell"
 short_desc="Minimal, fast and customizable cross-shell prompt"
 maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
 license="ISC"
 homepage="https://starship.rs"
 distfiles="https://github.com/starship/starship/archive/v${version}.tar.gz"
-checksum=39301c8118239eda7b6d8dbcae498f28bfd901932e69003c249d99ee7989c1bb
+checksum=23e729ace48ec0bf6d8eff5f99003351463841f3b28fe453faceb62e6f99bae6
 
 post_build() {
 	STARSHIP="target/${RUST_TARGET}/release/starship"
@@ -21,9 +21,12 @@ post_build() {
 	vtargetrun ${STARSHIP} completions fish >starship.fish
 }
 
-pre_check() {
-	[ -L target/debug ] && unlink target/debug
-	ln -s release target/debug
+do_check() {
+	mkdir -p fake-home
+	local OLDHOME=$HOME
+	export HOME=$(pwd)/fake-home
+	cargo test -q --release --target ${RUST_TARGET}
+	export HOME=$OLDHOME
 }
 
 post_install() {


### PR DESCRIPTION
Some tests fail because `/` is world writable and `$HOME` is `/tmp` inside the the chroot. 