### PR TITLE
wine: Add wine-staging patchset as a (non-default) build option

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,20 +1,25 @@
 # Template file for 'wine'
 pkgname=wine
 version=6.0rc6
-revision=1
-wrksrc=wine-${version/r/-r}
+revision=2
+_pkgver=${version/r/-r}
+create_wrksrc=yes
+build_wrksrc=wine-${_pkgver}
 build_style=gnu-configure
 configure_args="--bindir=/usr/libexec/wine"
 short_desc="Run Microsoft Windows applications"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
 homepage="http://www.winehq.org/"
-distfiles="https://dl.winehq.org/wine/source/${version%r*}/wine-${version/r/-r}.tar.xz"
-checksum=e67a97f198c96b3a624b637902be39be68c6dc5540d5594513078cf89780e6c1
+distfiles="https://dl.winehq.org/wine/source/${version%r*}/wine-${_pkgver}.tar.xz
+ https://github.com/wine-staging/wine-staging/archive/v${_pkgver}.tar.gz"
+checksum="e67a97f198c96b3a624b637902be39be68c6dc5540d5594513078cf89780e6c1
+ 9ee8a6d9eefae3bca4a6550d5336edac96537e5da0c3669003d21f08b55cbd13"
 
-build_options="mingw"
+build_options="mingw staging"
 build_options_default="mingw"
 desc_option_mingw="Use the MinGW cross compiler to build WinPE DLLs"
+desc_option_staging="Apply the wine-staging patchset"
 
 lib32mode=full
 archs="i686* x86_64*"
@@ -28,7 +33,8 @@ if [ "$XBPS_TARGET_MACHINE" = i686-musl ]; then
 fi
 
 hostmakedepends="pkg-config flex gettext
- $(vopt_if mingw "cross-${XBPS_TARGET_MACHINE%-musl}-w64-mingw32")"
+ $(vopt_if mingw "cross-${XBPS_TARGET_MACHINE%-musl}-w64-mingw32")
+ $(vopt_if staging 'autoconf')"
 makedepends="gettext-devel lcms2-devel zlib-devel ncurses-devel
  glu-devel libSM-devel libXext-devel libX11-devel libXpm-devel
  libXinerama-devel libXcomposite-devel libXmu-devel libXxf86vm-devel
@@ -63,6 +69,12 @@ nopie_files="${_wine_libexec}/wine${_wine_suffix}"
 if [ "${_nopie}" = yes ]; then
 	nopie_files+=" ${_wine_libexec}/wineserver${_wineserver_suffix}"
 fi
+
+post_patch() {
+	if [ "${build_option_staging}" ]; then
+		"../wine-staging-${_pkgver}/patches/patchinstall.sh" --all
+	fi
+}
 
 pre_build() {
 	if [ "${_nopie}" = yes ]; then


### PR DESCRIPTION
Because staging is not release quality, this is introduced as a non-default build option. Because users expect a certain level of breakage and imperfection in Wine in general, I think it's still fine to introduce as an option, despite Void's policy against non-release software. Wine-staging is frequently required to make some applications/games work.

Open question of what to do if wine-staging lags a upstream wine release by a bit -- block package updates? But at least for the last several versions, wine-staging has tracked wine closely, lagging in their releases by no more than 1 day. 

Builds on x86_64 and i686. Tested on x86_64 with wine+wine-32bit multi. 

closes #27612