### PR TITLE
python3-numpy: Use OpenBLAS when available.

### DIFF
--- a/srcpkgs/python3-numpy/template
+++ b/srcpkgs/python3-numpy/template
@@ -1,11 +1,12 @@
 # Template file for 'python3-numpy'
 pkgname=python3-numpy
 version=1.19.5
-revision=1
+revision=2
 wrksrc="numpy-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython gcc-fortran"
-makedepends="python3-devel lapack-devel cblas-devel"
+makedepends="python3-devel
+ $(vopt_if openblas 'openblas-devel' 'lapack-devel cblas-devel')"
 depends="python3-setuptools"
 short_desc="Fast and sophisticated array facility to Python3"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"
@@ -15,6 +16,22 @@ distfiles="https://github.com/numpy/numpy/archive/v${version}.tar.gz"
 checksum=43fe3bcdf27a2eb27196a1d140385aeece71c8b1a6eda18d2c6365239e50c60f
 alternatives="numpy:f2py:/usr/bin/f2py3"
 
+build_options="openblas"
+desc_option_openblas="Enable support for openblas accelerated linear algebra"
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*|i686*|aarch64*|armv[67]*|ppc64*)
+		# Prefer accelerated routines where available
+		build_options_default="openblas"
+		;;
+	*) ;;
+esac
+
+LDFLAGS+=" -shared"
+
+# Tell numpy to build in parallel
+export NPY_NUM_BUILD_JOBS="${XBPS_MAKEJOBS}"
+
 post_patch() {
 	case "${XBPS_TARGET_MACHINE}" in
 		armv5tel-musl)
@@ -22,10 +39,25 @@ post_patch() {
 			patch -Np0 -i "${FILESDIR}/fenv-constants.patch"
 			;;
 	esac
+
+	if [ "$XBPS_TARGET_LIBC" = musl ] ; then
+		vsed -i 's|"backtrace",||' numpy/core/setup_common.py
+	fi
 }
 
 pre_build() {
 	make_build_args+=" ${makejobs}"
+	# Find the right linear algebra subroutines on the target arch
+	: > site.cfg
+	for _blaslib in $(vopt_if openblas openblas "lapack blas"); do
+		cat >> site.cfg <<-EOF
+		[$_blaslib]
+		libraries = ${_blaslib}
+		include_dirs = ${XBPS_CROSS_BASE}/usr/include
+		library_dirs = ${XBPS_CROSS_BASE}/usr/lib
+		runtime_library_dirs = ${XBPS_CROSS_BASE}/usr/lib
+		EOF
+	done
 }
 
 do_check() {


### PR DESCRIPTION
Just like `python3-scipy`, `python3-numpy` should use OpenBLAS when available and fall back to BLAS/LAPACK otherwise.