### PR TITLE
shutils/chroot.sh: move homedir to /tmp/fake-home.

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -88,7 +88,7 @@ PATH=/void-packages:/usr/bin
 
 exec env -i -- SHELL=/bin/sh PATH="\$PATH" DISTCC_HOSTS="\$XBPS_DISTCC_HOSTS" DISTCC_DIR="/host/distcc" \
     ${XBPS_ARCH+XBPS_ARCH=$XBPS_ARCH} ${XBPS_CHECK_PKGS+XBPS_CHECK_PKGS=$XBPS_CHECK_PKGS} \
-    CCACHE_DIR="/host/ccache" IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 TERM=linux HOME="/tmp" \
+    CCACHE_DIR="/host/ccache" IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 TERM=linux HOME="/tmp/fake-home" \
     PS1="[\u@$XBPS_MASTERDIR \W]$ " /bin/bash +h
 _EOF
 
@@ -119,7 +119,9 @@ chroot_prepare() {
 
     # Copy /etc/passwd and /etc/group from base-files.
     cp -f $XBPS_SRCPKGDIR/base-files/files/passwd $XBPS_MASTERDIR/etc
-    echo "$(whoami):x:$(id -u):$(id -g):$(whoami) user:/tmp:/bin/xbps-shell" \
+    mkdir -p $XBPS_MASTERDIR/tmp/fake-home
+    chown $(id -u):$(id -g) $XBPS_MASTERDIR/tmp/fake-home
+    echo "$(whoami):x:$(id -u):$(id -g):$(whoami) user:/tmp/fake-home:/bin/xbps-shell" \
         >> $XBPS_MASTERDIR/etc/passwd
     cp -f $XBPS_SRCPKGDIR/base-files/files/group $XBPS_MASTERDIR/etc
     echo "$(whoami):x:$(id -g):" >> $XBPS_MASTERDIR/etc/group
@@ -166,7 +168,7 @@ chroot_handler() {
         rv=$?
     else
         env -i -- PATH="/usr/bin:$PATH" SHELL=/bin/sh \
-            HOME=/tmp IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 \
+            HOME=/tmp/fake-home IN_CHROOT=1 LC_COLLATE=C LANG=en_US.UTF-8 \
             ${HTTP_PROXY:+HTTP_PROXY="${HTTP_PROXY}"} \
             ${HTTPS_PROXY:+HTTPS_PROXY="${HTTPS_PROXY}"} \
             ${FTP_PROXY:+FTP_PROXY="${FTP_PROXY}"} \

--- a/srcpkgs/pass/template
+++ b/srcpkgs/pass/template
@@ -15,7 +15,6 @@ distfiles="https://git.zx2c4.com/password-store/snapshot/password-store-${versio
 checksum=2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4
 
 do_check() {
-	mkdir -p fake-home
 	make test
 }
 

--- a/srcpkgs/pass/template
+++ b/srcpkgs/pass/template
@@ -16,7 +16,7 @@ checksum=2b6c65846ebace9a15a118503dcd31b6440949a30d3b5291dfb5b1615b99a3f4
 
 do_check() {
 	mkdir -p fake-home
-	HOME=$(pwd)/fake-home make test
+	make test
 }
 
 passmenu_package() {

--- a/srcpkgs/pygtk/template
+++ b/srcpkgs/pygtk/template
@@ -28,10 +28,7 @@ pre_configure() {
 }
 
 do_check() {
-	export HOME="$(mktemp -d)"
-	mkdir -p "$HOME/.local/share"
 	xvfb-run make check
-	rm -r "$HOME"
 }
 
 post_install() {

--- a/srcpkgs/starship/template
+++ b/srcpkgs/starship/template
@@ -22,11 +22,7 @@ post_build() {
 }
 
 do_check() {
-	mkdir -p fake-home
-	local OLDHOME=$HOME
-	export HOME=$(pwd)/fake-home
 	cargo test -q --release --target ${RUST_TARGET}
-	export HOME=$OLDHOME
 }
 
 post_install() {


### PR DESCRIPTION
starship tests fail if /tmp is $HOME because they create files inside /tmp and
compare the shortend path to an expected path. If /tmp is $HOME, starship
contracts it to ~ which does not match the expected value.
