### PR TITLE
New package: imlib2-heic-0.1.1

### DIFF
--- a/srcpkgs/imlib2-heic/template
+++ b/srcpkgs/imlib2-heic/template
@@ -1,0 +1,17 @@
+# Template file for 'imlib2-heic'
+pkgname=imlib2-heic
+version=0.1.1
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config"
+makedepends="imlib2-devel libheif-devel"
+short_desc="HEIC/HEIF decoder for imlib2"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/vi/imlib2-heic"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=8e7771903ef2e8718e17f228e7fcdb1aeb889e57c9d846b6708d45b6310a3856
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
Closes [this](https://github.com/void-linux/void-packages/issues/27597). [WIP] as I'm not too confident if I included the licenses correctly. `./xbps-src pkg imlib2-heic` passes locally on my end, hoping for the best ~