### PR TITLE
Skarnet packages new year 2021 release.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2304,7 +2304,7 @@ libgnunettransport.so.2 gnunet-0.12.2_1
 libgnunettransportapplication.so.0 gnunet-0.12.2_1
 libgnunettransportcore.so.0 gnunet-0.12.2_1
 libgnunettransportcommunicator.so.0 gnunet-0.12.2_1
-libskarnet.so.2.9 skalibs-2.9.0.0_1
+libskarnet.so.2.10 skalibs-2.10.0.1_1
 libKF5BalooWidgets.so.5 baloo-widgets5-17.04.3_1
 libtidy.so.5 libtidy5-5.1.25_1
 libSDL2_gfx-1.0.so.0 SDL2_gfx-1.0.1_1

--- a/srcpkgs/66-tools/template
+++ b/srcpkgs/66-tools/template
@@ -1,7 +1,7 @@
 # Template file for '66-tools'
 pkgname=66-tools
-version=0.0.6.2
-revision=2
+version=0.0.7.1
+revision=1
 wrksrc=${pkgname}-v${version}
 build_style=configure
 configure_args="--prefix=/usr
@@ -16,8 +16,8 @@ license="ISC"
 homepage="http://web.obarun.org/software/index.html"
 changelog="https://framagit.org/Obarun/66-tools/-/raw/master/NEWS.md"
 distfiles="https://framagit.org/Obarun/66-tools/-/archive/v${version}/66-tools-v${version}.tar.gz"
-checksum=2b9617cf4101cc1a9f4877358ab73dfaa7a7dd8ea5f20409205645784eaef121
+checksum=370fda8d10254bfece86cbeabf7b4d48d8b47e91bd57fe5bae12e18b5a032547
 
 post_install() {
-	vlicense COPYING
+	vlicense LICENSE
 }

--- a/srcpkgs/66/INSTALL.msg
+++ b/srcpkgs/66/INSTALL.msg
@@ -1,3 +1,4 @@
-CAUTION: upgrading 66 to a new major version may require manual intervention!
-You may need to run the `66-update` utility or otherwise update your trees.
-For details, refer to https://framagit.org/Obarun/66/raw/master/NEWS.md
+CAUTION: 66 v0.6.0.0 has changes to the way the log and env options
+are handled in the frontend service file. Please consult the 
+documentation and make the appropriate changes before restarting
+or enabling your services, especially complex module services.

--- a/srcpkgs/66/template
+++ b/srcpkgs/66/template
@@ -1,7 +1,7 @@
 # Template file for '66'
 pkgname=66
-version=0.5.1.1
-revision=2
+version=0.6.0.1
+revision=1
 wrksrc="66-v${version}"
 build_style=configure
 configure_args="--prefix=/usr
@@ -17,7 +17,7 @@ license="ISC"
 homepage="http://web.obarun.org/software/"
 changelog="https://framagit.org/Obarun/66/raw/master/NEWS.md"
 distfiles="https://framagit.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
-checksum=7a0db00186f1c2111d07cbcc082f769c806820607d7ba5f49e505abf06687e0c
+checksum=6267e6b51fa6a5c56ef10f385f89bbbf87dca51ff397be32a7dac161cbc25a9b
 
 conf_files="/etc/66/init /etc/66/init.conf"
 
@@ -25,7 +25,7 @@ system_accounts="_s6log"
 
 post_install() {
 	vdoc README.md
-	vlicense COPYING
+	vlicense LICENSE
 }
 
 66-doc_package() {

--- a/srcpkgs/execline/template
+++ b/srcpkgs/execline/template
@@ -1,6 +1,6 @@
 # Template file for 'execline'
 pkgname=execline
-version=2.6.1.1
+version=2.7.0.1
 revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --bindir=/usr/bin
@@ -8,12 +8,12 @@ configure_args="--libdir=/usr/lib --bindir=/usr/bin
  --with-lib=${XBPS_CROSS_BASE}/usr/lib"
 makedepends="skalibs-devel"
 short_desc="Non-interactive scripting language"
-maintainer="bougyman <bougyman@voidlinux.org>"
+maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="https://skarnet.org/software/execline/"
 changelog="https://skarnet.org/software/execline/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=394308f0349f962086a9695ca2bb5ef32cd38e5be6b7cec0b3d0cf35a2b2ba56
+checksum=cdf61164f97f764a06aba36986d549159df56f2d1a4b3bbf5467ee91ad8fdcdd
 
 CFLAGS="-fPIC"
 

--- a/srcpkgs/mdevd/template
+++ b/srcpkgs/mdevd/template
@@ -1,6 +1,6 @@
 # Template file for 'mdevd'
 pkgname=mdevd
-version=0.1.2.0
+version=0.1.3.0
 revision=1
 build_style=configure
 configure_args="--includedir=/usr/include --bindir=/usr/bin --libdir=/usr/lib
@@ -8,12 +8,12 @@ configure_args="--includedir=/usr/include --bindir=/usr/bin --libdir=/usr/lib
  --with-lib=${XBPS_CROSS_BASE}/usr/lib"
 makedepends="skalibs-devel"
 short_desc="Small mdev-compatible kernel hotplug daemon similar to udevd"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="https://skarnet.org/software/mdevd/"
 changelog="https://skarnet.org/software/mdevd/upgrade.html"
 distfiles="https://skarnet.org/software/mdevd/mdevd-${version}.tar.gz"
-checksum=952af443bc61b3694432f7799ba8182824083726872f47f45467c1a5b24796c1
+checksum=be89ab072c4de822a06e26579dcca10e85ae5fd5be23ba903415b4de8fe0fb6a
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)

--- a/srcpkgs/nsss/template
+++ b/srcpkgs/nsss/template
@@ -1,7 +1,7 @@
 # Template file for 'nsss'
 pkgname=nsss
-version=0.0.2.2
-revision=2
+version=0.1.0.0
+revision=1
 # Only available for musl
 archs="*-musl"
 build_style=configure
@@ -10,12 +10,12 @@ configure_args="--with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --bindir=/usr/bin --dynlibdir=/usr/lib --includedir=/usr/include/nsss"
 makedepends="skalibs-devel"
 short_desc="Minimal competing implementation of glibc's Name Switch Service"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="https://skarnet.org/software/nsss/"
 changelog="https://skarnet.org/software/nsss/upgrade.html"
 distfiles="https://skarnet.org/software/nsss/nsss-${version}.tar.gz"
-checksum=3345d76155b6a5d55b13b30cfecb0b9a21fd1264164f5f48b1c3eca57849a12a
+checksum=b88a389264a76893ef3ad9c086ea694f32b688ed22fb7480a2a172131c5f3d97
 
 do_check() {
 	: #checkdepends=s6, creates dependency cycle

--- a/srcpkgs/oblibs/template
+++ b/srcpkgs/oblibs/template
@@ -1,6 +1,6 @@
 # Template file for 'oblibs'
 pkgname=oblibs
-version=0.1.1.1
+version=0.1.2.0
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=configure
@@ -11,7 +11,7 @@ maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="https://framagit.org/Obarun/oblibs"
 distfiles="${homepage}/-/archive/v${version}/${pkgname}-v${version}.tar.bz2"
-checksum=7b19fab4c1e3926c6f5dad6cc7373f250ac4bf9a1541ac01737e169b46dc765a
+checksum=0009cbe48d786bca14e8e973a5092de5270713db1940d538f38d6dfaa9e75e0a
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/s6-dns/template
+++ b/srcpkgs/s6-dns/template
@@ -1,6 +1,6 @@
 # Template file for 's6-dns'
 pkgname=s6-dns
-version=2.3.3.0
+version=2.3.5.0
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --libdir=/usr/lib
@@ -12,7 +12,7 @@ maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="ISC"
 homepage="https://skarnet.org/software/s6-dns"
 distfiles="${homepage}/${pkgname}-${version}.tar.gz"
-checksum=2ac75918ff5eb4d6dabe33f7e55fa70cf3e6a9062ff87de5a35029ea22238716
+checksum=9f0b71c82cb51e9b7f998978d94c44e5e896fa60105f7233544db539572bb740
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/s6-linux-utils/template
+++ b/srcpkgs/s6-linux-utils/template
@@ -1,6 +1,6 @@
 # Template file for 's6-linux-utils'
 pkgname=s6-linux-utils
-version=2.5.1.3
+version=2.5.1.4
 revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --includedir=/usr/include
@@ -13,7 +13,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-linux-utils"
 changelog="https://skarnet.org/software/s6-linux-utils/upgrade.html"
 distfiles="${homepage}/${pkgname}-${version}.tar.gz"
-checksum=4471511c9ce995c5ac61e0714def5a05fcabe730ef0bb93a42b12ad5bf007b71
+checksum=d8ad8dcc8d805646b655971ddcaabcd50094d8347bd49d859ba2c51713fbfd09
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)

--- a/srcpkgs/s6-man-pages/template
+++ b/srcpkgs/s6-man-pages/template
@@ -1,0 +1,20 @@
+# Template file for 's6-man-pages'
+pkgname=s6-man-pages
+version=2.10.0.1.1
+revision=1
+build_style=gnu-makefile
+hostmakedepends="mdocml"
+short_desc="Ports of the HTML documentation for the s6 supervision suite to mdoc(7)"
+maintainer="mobinmob <mobinmob@disroot.org>"
+license="ISC"
+homepage="https://github.com/flexibeast/s6-man-pages"
+distfiles="https://github.com/flexibeast/s6-man-pages/archive/v${version}.tar.gz"
+checksum=de85efead2548166df4450286abbae4f9450dcff49e300ffba2b8e34a362078e
+
+
+do_install() {
+	vmkdir usr/share/man/man1
+	vmkdir usr/share/man/man7
+	make MANPATH="${DESTDIR}/usr/share/man"  install-man
+	vlicense LICENSE
+}

--- a/srcpkgs/s6-networking/template
+++ b/srcpkgs/s6-networking/template
@@ -1,7 +1,7 @@
 # Template file for 's6-networking'
 pkgname=s6-networking
-version=2.3.2.0
-revision=2
+version=2.4.0.0
+revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib $(vopt_if libressl --enable-ssl=libressl)
  $(vopt_if bearssl --enable-ssl=bearssl)
@@ -15,7 +15,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-networking"
 changelog="https://skarnet.org/software/s6-networking/upgrade.html"
 distfiles="${homepage}/${pkgname}-${version}.tar.gz"
-checksum=bbe36a8460d90f3bff56c934811876186f7224ced5bdc15c2c96d49b4e917d12
+checksum=f8fda2dd95286420e9a9254220a39dd724d4fe2cd24d6df2ebd3ca421d9f1efb
 
 build_options="bearssl libressl"
 build_options_default="bearssl"

--- a/srcpkgs/s6-portable-utils/template
+++ b/srcpkgs/s6-portable-utils/template
@@ -1,6 +1,6 @@
 # Template file for 's6-portable-utils'
 pkgname=s6-portable-utils
-version=2.2.3.0
+version=2.2.3.1
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --libdir=/usr/lib --includedir=/usr/include
@@ -13,7 +13,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-portable-utils/"
 changelog="https://skarnet.org/software/s6-portable-utils/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=29baab7ca8d5c97cb5f311f4ad359ecee4ed13249fb51e351f4bbc175de47f18
+checksum=43e68a9abec873b337baeee92075a1c2e22cdfffd595cb91475fdcb10b6441cf
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/s6-rc/template
+++ b/srcpkgs/s6-rc/template
@@ -1,6 +1,6 @@
 # Template file for 's6-rc'
 pkgname=s6-rc
-version=0.5.2.0
+version=0.5.2.1
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --libdir=/usr/lib --includedir=/usr/include
@@ -14,7 +14,7 @@ license="ISC"
 homepage="https://skarnet.org/software/s6-rc/"
 changelog="https://skarnet.org/software/s6-rc/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=1ab21a9bdde61b50e3d9deab867e01f808064dce653b0ebf8e5f5125d57cfee2
+checksum=2842fa55e2bddb65573d78d2c475c4a2f2b26b9258a18b457f8a0342e2fafa0a
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/s6/template
+++ b/srcpkgs/s6/template
@@ -1,7 +1,7 @@
 # Template file for 's6'
 pkgname=s6
-version=2.9.2.0
-revision=2
+version=2.10.0.1
+revision=1
 build_style=configure
 configure_args="--libdir=/usr/lib --bindir=/usr/bin
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
@@ -14,7 +14,7 @@ license="ISC"
 homepage="http://skarnet.org/software/s6/"
 changelog="https://skarnet.org/software/s6/upgrade.html"
 distfiles="http://skarnet.org/software/s6/s6-${version}.tar.gz"
-checksum=363db72af8fffba764b775c872b0749d052805b893b07888168f59a841e9dddd
+checksum=d0026f0fb4790febbd45f66bdcded54fab4a27ac2f579c075267a21154a0d1f5
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl)
@@ -31,7 +31,7 @@ post_install() {
 
 s6-doc_package() {
 	short_desc="Documentation for s6"
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} s6-man-pages"
 	pkg_install() {
 		vmove usr/share/doc
 	}

--- a/srcpkgs/skalibs/template
+++ b/srcpkgs/skalibs/template
@@ -1,8 +1,7 @@
 # Template file for 'skalibs'
 pkgname=skalibs
-version=2.9.3.0
+version=2.10.0.1
 revision=1
-_sysdepspkg=skaware-void-sysdeps
 build_style=configure
 configure_args="--libdir=/usr/lib --enable-static --enable-shared
  --enable-force-devr
@@ -10,12 +9,12 @@ configure_args="--libdir=/usr/lib --enable-static --enable-shared
  --bindir=/usr/bin --dynlibdir=/usr/lib
  --with-sysdep-devurandom=yes"
 short_desc="General purpose libraries for building software from skarnet.org"
-maintainer="bougyman <bougyman@voidlinux.org>"
+maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="https://skarnet.org/software/skalibs/"
 changelog="https://skarnet.org/software/skalibs/upgrade.html"
 distfiles="https://skarnet.org/software/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=f01a07049d384097864410f9251447ad899db0d17f82cd8ebc6b7000d7783b44
+checksum=4ffbae8fdcd5108916bbea8eb6f795106d2c3189039e331bcd4b8e00e9971cb2
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
This is a major release, especially for skalibs, s6 and execline.
`66` is not yet compatible with the changes in the above.
nsss can now probably be built and installed in a glibc system (the same goes for utmps https://github.com/void-linux/void-packages/pull/21869 ).
I would like to adopt skalibs and execline from @bougyman.

Interested parties: @duncaen @lemmi .