### PR TITLE
linux-firmware: use included Makefile.

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
 version=20201218
-revision=1
+revision=2
 depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -16,12 +16,14 @@ subpackages="linux-firmware-amd linux-firmware-broadcom
  linux-firmware-intel linux-firmware-nvidia linux-firmware-network"
 
 do_install() {
-	vmkdir usr/lib/firmware
-	vmkdir usr/share/licenses/${pkgname}
-	vcopy "*" usr/lib/firmware
-	rm -f ${DESTDIR}/usr/lib/firmware/{README*,configure,GPL*}
-	mv ${DESTDIR}/usr/lib/firmware/{LICEN*,WHENCE} \
-		${DESTDIR}/usr/share/licenses/${pkgname}
+	make install FIRMWAREDIR=/usr/lib/firmware DESTDIR=$DESTDIR
+
+	for _l in LICEN* WHENCE
+	do
+		vlicense "$_l"
+	done
+
+	# XXX: should some firmwares, like carl9170, be pruned?
 }
 
 linux-firmware-amd_package() {


### PR DESCRIPTION
Manually copying the files is error prone, leading to a lot of missing
symlinks (defined in the WHENCE file) as well as unnecessary content,
such as source code and some helper scripts. This commit fixes that.

Fixes #27682