### PR TITLE
vault: update to 1.6.1

### DIFF
--- a/srcpkgs/vault/template
+++ b/srcpkgs/vault/template
@@ -1,11 +1,11 @@
 # Template file for 'vault'
 pkgname=vault
-version=1.5.4
+version=1.6.1
 revision=1
 build_style=go
 go_import_path="github.com/hashicorp/${pkgname}"
 go_build_tags="release"
-_git_commit=e16495da552c996068e05574cddf69875199f949
+_git_commit=6d2db3f033e02e70202bef9ec896360062b88b03
 go_ldflags="-X ${go_import_path}/sdk/version.GitCommit=${_git_commit}"
 hostmakedepends="git"
 short_desc="Manage Secrets and Protect Sensitive Data"
@@ -13,10 +13,14 @@ maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="MPL-2.0"
 homepage="https://www.vaultproject.io/"
 distfiles="https://github.com/hashicorp/${pkgname}/archive/v${version}.tar.gz"
-checksum=99e3145a9b6f5ee6429b997f3e1f35f648d07c617ff6aef7041f91fcf34e1582
+checksum=fb5d96e682a48bfd421b13cdfffd710da0238dbded1988aab822dd5aae75b4c4
 system_accounts="_vault"
 make_dirs="/var/lib/vault 0700 _vault _vault
  /etc/vault 0700 root root"
+
+case "$XBPS_TARGET_MACHINE" in
+	arm*) go_ldflags="$go_ldflags -linkmode=external";;
+esac
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
@the-maldridge 

* Here are [the minor-version changes](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#160).
* For consistency's sake I matched `_git_commit` to `v1.6.1`'s hash. 

Sanity check:
```
$ ./xbps-src pkg vault
<...>
$ xi vault
<...>
$ vault version
Vault v1.6.1 (6d2db3f033e02e70202bef9ec896360062b88b03) (cgo)
$ vault server -dev &> /dev/null &
[1] 9125
$ export VAULT_ADDR='http://127.0.0.1:8200'
$ vault secrets enable -path=kv kv
Success! Enabled the kv secrets engine at: kv/
$ vault kv put kv/foo foo=bar
Success! Data written to: kv/foo
$ vault kv get kv/foo
=== Data ===
Key    Value
---    -----
foo    bar
```
Lemme know if there're any more tests you'd like me to run.