### PR TITLE
nmap: revert to 7.80 due to licensing issues

### DIFF
--- a/srcpkgs/nmap/template
+++ b/srcpkgs/nmap/template
@@ -1,17 +1,19 @@
 # Template file for 'nmap'
 pkgname=nmap
-version=7.91
-revision=1
+reverts="7.90_1 7.91_1"
+version=7.80
+revision=2
 build_style=gnu-configure
 configure_args="--without-ndiff --with-openssl --with-zenmap $(vopt_with lua liblua)"
 hostmakedepends="python"
-makedepends="libpcap-devel libressl-devel pcre-devel $(vopt_if lua lua53-devel)"
+makedepends="libpcap-devel libressl-devel libssh2-devel pcre-devel
+ $(vopt_if lua lua53-devel)"
 short_desc="Utility for network discovery and security auditing"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="custom:nmap"
 homepage="https://nmap.org"
 distfiles="https://nmap.org/dist/nmap-${version}.tar.bz2"
-checksum=18cc4b5070511c51eb243cdd2b0b30ff9b2c4dc4544c6312f75ce3a67a593300
+checksum=fcfa5a0e42099e12e4bf7a68ebe6fde05553383a682e816a7ec9256ab4773faa
 python_version=2
 
 build_options="lua"
@@ -22,7 +24,7 @@ alternatives="
 	nc:nc.1:/usr/share/man/man1/ncat.1"
 
 post_install() {
-	vlicense LICENSE
+	vlicense COPYING
 
 	# do not use bundled certificates, use only system ones
 	rm -f ${DESTDIR}/usr/share/ncat/ca-bundle.crt


### PR DESCRIPTION
nmap >= 7.90 is distributed under a modified license that many consider
problematic.

https://github.com/nmap/nmap/issues/2199
Gentoo bug: https://bugs.gentoo.org/749390
Debian bug: https://bugs.debian.org/972216
Guix discussion: https://lists.gnu.org/archive/html/guix-devel/2020-10/msg00227.html

Along, link against libssh2 instead of using the bundled version.