### PR TITLE
phpMyAdmin: update to 5.0.4, fix license

### DIFF
--- a/srcpkgs/phpMyAdmin/template
+++ b/srcpkgs/phpMyAdmin/template
@@ -1,16 +1,16 @@
 # Template file for 'phpMyAdmin'
 pkgname=phpMyAdmin
-version=5.0.2
-revision=2
+version=5.0.4
+revision=1
 wrksrc="phpMyAdmin-${version}-all-languages"
 conf_files="/etc/webapps/phpMyAdmin/config.inc.php"
 depends="php mysql"
 short_desc="Web interface for MySQL and MariaDB"
 maintainer="Franc[e]sco <lolisamurai@tfwno.gf>"
-license="GPL-2.0-or-later"
+license="GPL-2.0-only"
 homepage="https://www.phpmyadmin.net"
 distfiles="https://files.phpmyadmin.net/phpMyAdmin/${version}/phpMyAdmin-${version}-all-languages.tar.xz"
-checksum=cbcc78d1499308d9329950fcba2ebaa84c559a934fe54efc027d459d8e4161c8
+checksum=1578c1a08e594da4f4f62e676ccbdbd17784c3de769b094ba42c35bf05c057db
 
 do_install() {
 	vmkdir usr/share/webapps/


### PR DESCRIPTION
Closes [this](https://github.com/void-linux/void-packages/issues/27798).