### PR TITLE
New package: genie-1141

### DIFF
--- a/srcpkgs/genie/patches/no-git.diff
+++ b/srcpkgs/genie/patches/no-git.diff
@@ -1,0 +1,35 @@
+diff --git a/scripts/release.lua b/scripts/release.lua
+index d1173d5..a9d11d7 100644
+--- a/scripts/release.lua
++++ b/scripts/release.lua
+@@ -13,18 +13,18 @@ function dorelease()
+ 	end
+ 
+ 
+-	print("Updating version number...")
+-
+-	local f = io.popen("git rev-list --count HEAD")
+-	local rev = string.match(f:read("*a"), ".*%S")
+-	f:close()
+-	f = io.popen("git log --format=format:%H -1")
+-	local sha1 = f:read("*a")
+-	f:close()
+-	io.output("src/host/version.h")
+-	io.write("#define VERSION " ..rev .. "\n")
+-	io.write("#define VERSION_STR \"version " ..rev .. " (commit " .. sha1 .. ")\"\n")
+-	io.close()
++	--print("Updating version number...")
++
++	--local f = io.popen("git rev-list --count HEAD")
++	--local rev = string.match(f:read("*a"), ".*%S")
++	--f:close()
++	--f = io.popen("git log --format=format:%H -1")
++	--local sha1 = f:read("*a")
++	--f:close()
++	--io.output("src/host/version.h")
++	--io.write("#define VERSION " ..rev .. "\n")
++	--io.write("#define VERSION_STR \"version " ..rev .. " (commit " .. sha1 .. ")\"\n")
++	--io.close()
+ 
+ 
+ 	print("Updating embedded scripts...")

--- a/srcpkgs/genie/template
+++ b/srcpkgs/genie/template
@@ -1,0 +1,39 @@
+# Template file for 'genie'
+pkgname=genie
+version=1141
+revision=1
+_githash=44918162588e56512ddac6264b08ca6ba4e67468
+wrksrc="GENie-${_githash}"
+build_style="gnu-makefile"
+make_build_args="-C build/gmake.linux"
+short_desc="Project generator tool using Lua"
+maintainer="a dinosaur <nick@a-dinosaur.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/bkaradzic/GENie"
+distfiles="https://github.com/bkaradzic/GENie/archive/${_githash}.tar.gz"
+checksum=6dfc98dfeae0600c5c12a98156b2238effee5c1e2e09e8107477d9e5cfc7278d
+patch_args="-Np1"
+
+post_patch() {
+	# Unnecessary '-m64' only valid for x86_64, ppc64. Breaks 32-bit & ARM builds
+	# so remove it
+	vsed 's/-m64//' -i build/gmake.linux/genie.make scripts/genie.lua
+}
+
+do_configure() {
+	# A copy of GENie is built on the host to run the release script
+	# and ensure embeds & generated Makefiles are up to date
+	make ${makejobs} CC="${CC_host:-$CC}" CFLAGS="${XBPS_CFLAGS}" LDFLAGS="${XBPS_LDFLAGS}"
+	# Generate version.h without using Git
+	echo "#define VERSION ${version}" > src/host/version.h
+	echo "#define VERSION_STR \"version ${version} (commit ${_githash})\"" >> src/host/version.h
+	./bin/linux/genie release
+	make ${makejobs} -C build/gmake.linux clean
+}
+
+do_install() {
+	vbin bin/linux/genie
+	vdoc README.md
+	vdoc docs/scripting-reference.md
+	vlicense LICENSE
+}

--- a/srcpkgs/genie/update
+++ b/srcpkgs/genie/update
@@ -1,0 +1,2 @@
+site="https://github.com/bkaradzic/GENie"
+pattern='<code>version \K[0-9]+(?= \(commit [0-9a-z]+\))'


### PR DESCRIPTION
https://github.com/bkaradzic/GENie
Please excuse the Git, it's required by the pre-build configure scripts to set the version reported by `--version`. Upstream has an irritating way of designating the current stable release so something like this has to be done anyway.
I did my best to make sure the package builds & cross-compiles on every architecture xbps-src supports.