### PR TITLE
sof-firmware: use provided install script

### DIFF
--- a/srcpkgs/sof-firmware/template
+++ b/srcpkgs/sof-firmware/template
@@ -1,7 +1,7 @@
 # Template file for 'sof-firmware'
 pkgname=sof-firmware
 version=1.6.1
-revision=1
+revision=2
 archs="i686* x86_64*"
 wrksrc="sof-bin-${version}"
 depends="alsa-ucm-conf"
@@ -13,27 +13,11 @@ distfiles="https://github.com/thesofproject/sof-bin/archive/v${version}.tar.gz"
 checksum=587b320030bc84de1aacba5d86d89ba1a4f67201baf8b9b61bb885af60643bfb
 
 do_install() {
-	local intel_path="lib/firmware/intel"
-	for f in ${intel_path}/sof/v${version}/*.{ldc,ri}; do
-		vinstall ${f} 0644 /usr/${intel_path}/sof
-	done
-	for f in ${intel_path}/sof/v${version}/intel-signed/*; do
-		vinstall ${f} 0644 /usr/${intel_path}/sof/intel-signed
-	done
-	for f in ${intel_path}/sof/v${version}/public-signed/*; do
-		vinstall ${f} 0644 /usr/${intel_path}/sof/public-signed
-	done
-	for arc in {bdw,byt,cht}; do
-		ln -s sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
-	done
-	for arc in {apl,cnl,icl}; do
-		ln -s intel-signed/sof-${arc}-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-${arc}.ri
-	done
-	ln -s intel-signed/sof-apl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-glk.ri
-	ln -s intel-signed/sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cfl.ri
-	ln -s intel-signed/sof-cnl-v${version}.ri ${DESTDIR}/usr/${intel_path}/sof/sof-cml.ri
-	for f in ${intel_path}/sof-tplg-v${version}/*; do
-		vinstall ${f} 0644 /usr/${intel_path}/sof-tplg
-	done
 	vlicense LICENCE.NXP
+
+	export ROOT="${DESTDIR}/usr"
+	export SOF_VERSION="v${version}"
+
+	vmkdir usr/lib/firmware/intel
+	./go.sh
 }


### PR DESCRIPTION
**note** this message may be out of date due to commits being squashed. Refer to the latest commit message instad.

After hours of trying to find out why SOF (from repo) didn't like my
hardware, I tried installing the archive directly from
github.com/thesofproject/sof-bin/ instead. To my surprise, it worked!

Taking a closer look at the template, I realized that the firmware files
for my system weren't linked, causing the following errors on boot.

```
[   11.829580] sof-audio-pci 0000:00:1f.3: error: request firmware intel/sof/sof-tgl.ri failed err: -2
[   11.829709] sof-audio-pci 0000:00:1f.3: error: failed to load DSP firmware -2
[   11.830177] sof-audio-pci 0000:00:1f.3: error: sof_probe_work failed err: -2
```

**Note**
I have only tested this on Tiger Lake.