### PR TITLE
mpc-qt: fix ftbfs

### DIFF
--- a/srcpkgs/mpc-qt/template
+++ b/srcpkgs/mpc-qt/template
@@ -4,16 +4,21 @@ version=18.08
 revision=1
 build_style=qmake
 configure_args="MPCQT_VERSION=${version}"
-hostmakedepends="pkg-config qt5-qmake"
+hostmakedepends="pkg-config qt5-qmake qt5-x11extras-devel"
 makedepends="qt5-devel qt5-x11extras-devel mpv-devel"
 short_desc="Clone of Media Player Classic reimplemented in Qt"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/cmdrkotori/mpc-qt"
 #distfiles="${homepage}/archive/v${version}.tar.gz"
-distfiles="https://sources.voidlinux.org/mpc-qt-18.08/v18.08.tar.gz"
-checksum=c58fd90926773c9da8bdfc1a8e4dba0b95cbc58cee6db9981e8de94fd9534406
+# https://github.com/mpv-player/mpv/commit/575197ff8b0a0d8cd14f7ee78461c1d61d045d72
+distfiles="https://sources.voidlinux.org/mpc-qt-18.08/v18.08.tar.gz
+ https://raw.githubusercontent.com/mpv-player/mpv/2337fa4e0213993398d36cb3222633766d677dfd/libmpv/qthelper.hpp"
+checksum="c58fd90926773c9da8bdfc1a8e4dba0b95cbc58cee6db9981e8de94fd9534406
+ 86e1fcba6001829b7e23a856db84d01ebc76e63528f74064d7bc5705015a2684"
+skip_extraction="qthelper.hpp"
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-x11extras-devel"
-fi
+post_extract() {
+	mkdir -p mpv
+	cp $XBPS_SRCDISTDIR/mpc-qt-$version/qthelper.hpp mpv/
+}


### PR DESCRIPTION
Fetch the latest version of qthelper.hpp from mpv.
See https://github.com/mpv-player/mpv/commit/575197ff8b0a0d8cd14f7ee78461c1d61d045d72

---
Or just remove this package, I dun know