### PR TITLE
mesa-demos: fix DEMOS_DATA_DIR

### DIFF
--- a/srcpkgs/mesa-demos/template
+++ b/srcpkgs/mesa-demos/template
@@ -1,8 +1,9 @@
 # Template file for 'mesa-demos'
 pkgname=mesa-demos
 version=8.4.0
-revision=2
+revision=3
 build_style=gnu-configure
+configure_args="--with-system-data-files"
 hostmakedepends="pkg-config"
 makedepends="libXext-devel MesaLib-devel glu-devel glew-devel freetype-devel libfreeglut-devel"
 short_desc="Mesa 3D demos and tools"


### PR DESCRIPTION
This fixes an issue in which some programs for example `fire` would not start because of missing files.