### PR TITLE
Thunar: update to 4.16.2.

### DIFF
--- a/srcpkgs/Thunar/template
+++ b/srcpkgs/Thunar/template
@@ -1,6 +1,6 @@
 # Template file for 'Thunar'
 pkgname=Thunar
-version=4.16.1
+version=4.16.2
 revision=1
 wrksrc=thunar-${version}
 build_style=gnu-configure
@@ -17,7 +17,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://docs.xfce.org/xfce/thunar/Start"
 changelog="https://raw.githubusercontent.com/xfce-mirror/thunar/master/NEWS"
 distfiles="https://archive.xfce.org/src/xfce/thunar/${version%.*}/thunar-${version}.tar.bz2"
-checksum=da2d17d2cb69eb33768690b714cc232ed367cbd71eb9543aaa2a805d05dc3ce1
+checksum=67a90b98c436192f9aa6cd18a22a089e713007864aebfa65f36f121c86ba7add
 
 post_install() {
 	rm -rf ${DESTDIR}/usr/lib/systemd


### PR DESCRIPTION
Well, that is a first :D
```
ERROR: [reposync] failed to fetch file `https://alpha.de.repo.voidlinux.org/current/x86_64-repodata': Transient resolver failure
[*] Updating repository `https://alpha.de.repo.voidlinux.org/current/x86_64-repodata' ...
Package 'xbps' not found in repository pool.
Error: Process completed with exit code 2.
```