### PR TITLE
opendoas: set permissions during do_install.

### DIFF
--- a/srcpkgs/opendoas/INSTALL
+++ b/srcpkgs/opendoas/INSTALL
@@ -1,8 +1,0 @@
-#
-# This script sets up correct perms for usr/bin/doas.
-#
-case "${ACTION}" in
-post)
-	chmod 4111 usr/bin/doas
-	;;
-esac

--- a/srcpkgs/opendoas/template
+++ b/srcpkgs/opendoas/template
@@ -1,7 +1,7 @@
 # Template file for 'opendoas'
 pkgname=opendoas
 version=6.8
-revision=1
+revision=2
 wrksrc="OpenDoas-$version"
 build_style=configure
 configure_args="--prefix=/usr $(vopt_with 'pam') $(vopt_with 'timestamp')"
@@ -10,7 +10,7 @@ hostmakedepends="bison"
 makedepends="$(vopt_if 'pam' 'pam-devel')"
 short_desc="Portable OpenBSD doas to execute commands as another user"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="ISC, BSD-3-clause"
+license="ISC, BSD-3-Clause"
 homepage="https://github.com/Duncaen/OpenDoas"
 distfiles="https://github.com/Duncaen/OpenDoas/archive/v${version}.tar.gz"
 checksum=c53edc59a576cfe8ec8737230e7d0398842a5a8c925e25065463ab632a7eaba9
@@ -19,12 +19,10 @@ build_options="pam timestamp"
 build_options_default="pam timestamp"
 desc_option_timestamp="enable persistent auth using timestamps"
 
-
 pre_configure() {
 	cp ${FILESDIR}/doas.pam pam.d__doas__linux
 	vsed -i GNUmakefile \
-		-e '/chown ${BINOWN}:${BINGRP}/d' \
-		-e '/chmod ${BINMODE}/d'
+		-e '/chown ${BINOWN}:${BINGRP}/d'
 }
 
 post_install() {


### PR DESCRIPTION
- setting permissions in a INSTALL script makes the program unusable
between it being unpacked and the INSTALL script actually being run; for
users with other long running post-install steps, e.g. DKMS modules,
this can be a long time where an administrative tool can't be used.

- furthermore, any interruption of the post-install steps or a power
failure will have a much higher probability of leaving the user with a
non suid executable than if it had been set at install time.

- making the binary permissions 4111 isn't necessary; the binary can be
retrieved in multiple manners, so this doesn't offer any protection (and
the binary would be "unprotected" anyway while INSTALL hasn't run yet).
opendoas's makefile can chmod the executable, so we just stop removing the
chmod line from its makefile.

@Duncaen 