### PR TITLE
New package: haskell-language-server-1.0.0

### DIFF
--- a/srcpkgs/haskell-language-server/template
+++ b/srcpkgs/haskell-language-server/template
@@ -1,0 +1,25 @@
+# Template file for 'haskell-language-server'
+pkgname=haskell-language-server
+version=1.0.0
+revision=1
+# GHC only panics on i686
+# https://github.com/void-linux/void-packages/pull/27961/checks?check_run_id=2181519625#step:8:5936
+archs="~i686"
+build_style="haskell-stack"
+make_build_args="--stack-yaml stack-8.8.4.yaml"
+makedepends="ncurses-devel ncurses-libtinfo-devel icu-devel zlib-devel"
+short_desc="Integration of ghcide and haskell-ide-engine"
+maintainer="Wayne Van Son <waynevanson@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/haskell/haskell-language-server"
+distfiles="https://github.com/haskell/haskell-language-server/archive/${version}.tar.gz"
+checksum="14e28d6621d029f027fae44bc4a4ef62c869dab24ff01b88a2e51e6679cbff6c"
+nopie_files="
+ /usr/bin/haskell-language-server
+ /usr/bin/haskell-language-server-wrapper
+ /usr/bin/ghcide-bench
+ /usr/bin/ghcide
+ /usr/bin/ghcide-test-preprocessor
+ /usr/bin/test-server
+"
+nocross="Cannot yet cross compile with Haskell"


### PR DESCRIPTION
Hi Team,

This contains a few executables: haskell-language-server,  haskell-language-server-wrapper, ghcide, ghcide-test-preprocessor, ghcide-bench.

These were all made from running the `stack build` on the `wkrsrc` directory. 
Should these be packages as submodules? All the submodules seem to be requirements of the main module, haskell-laguage-server.