### PR TITLE
Signal-Desktop: update to 1.39.5

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=1.39.2
+version=1.39.5
 revision=1
 # Due to electron
 # 32-bit is not supported https://github.com/signalapp/Signal-Desktop/issues/1661
@@ -12,7 +12,7 @@ maintainer="Julio Galvan <juliogalvan@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=83da113eeaa13440cfa2af482aabf1352b1a98d3f219a8c9c9a55caa0e6266de
+checksum=f9f55c0195579b43712bf370b753337432eda4bcf89809d1c8f3deb0b4ee4400
 nostrip_files="signal-desktop"
 
 pre_build() {


### PR DESCRIPTION
Seems to help a little with the recent outages.