### PR TITLE
New package: ttf2pt1-3.4.4

### DIFF
--- a/srcpkgs/ttf2pt1/patches/001-makefile-config.patch
+++ b/srcpkgs/ttf2pt1/patches/001-makefile-config.patch
@@ -1,0 +1,248 @@
+--- Makefile
++++ Makefile
+@@ -1,21 +1,4 @@
+ 
+-# This file should be configured before running `make'.
+-# Uncomment or change the values that are relevant for your OS.
+-
+-# The preferred C compiler (by default use the OS-specific default value).
+-# For BSD/OS, FreeBSD, Linux (all flavors), NetBSD, OpenBSD the default
+-# compiler is GNU C. 
+-# (Note please the politically correct ordering by alphabet ! :-)
+-#
+-# Use GNU C even if it's not the default compiler
+-#
+-#CC=gcc
+-#
+-# Use the standard ANSI C compiler on HP-UX even if it's not default
+-#
+-#CC=c89
+-
+-#
+ # The system-dependent flags for the C compiler
+ #
+ # Default
+@@ -30,31 +13,21 @@ CFLAGS_SYS= -O
+ #
+ #CFLAGS_SYS= -O2 -D_GNU_SOURCE
+ #
+-# For GNU C on HP-UX/PA-RISC 1.1
+-#
+-#CFLAGS_SYS= -O2 -Wa,-w
+-#
+-# For the standard ANSI C on HP-UX
+-#
+-#CFLAGS_SYS= +O2 -D_HPUX_SOURCE
+ 
+ #
+ # The system-dependent libraries
+ #
+-# Defalut (for the BSD-style OSes)
++# Default (for the BSD-style OSes)
+ 
+ LIBS_SYS= -lm
+ 
+-# For SystemV (such as SCO, UnixWare, Solaris, but _NOT_ Linux or HP-UX)
+-#
+-#LIBS_SYS= -lm -lsocket
+ 
+ #
+-# The flags for C compiler for the FreeType-2 library (disabled by default). 
++# The flags for C compiler for the FreeType-2 library (disabled by default).
+ # This WON'T BUILD with FT2-beta8, use the FreeType release 2.0.4
+ # http://download.sourceforge.net/freetype/freetype-2.0.4.tar.gz
+ 
+-CFLAGS_FT= 
++CFLAGS_FT=
+ 
+ # To enable use of the FreeType-2 library
+ # (if the include and lib directory do not match your installation,
+@@ -62,7 +35,7 @@ CFLAGS_FT=
+ #
+ #CFLAGS_FT = -DUSE_FREETYPE -I/usr/local/include/freetype2 -I/usr/local/include
+ 
+-# 
++#
+ # The FreeType-2 library flags (disabled by default)
+ 
+ LIBS_FT=
+@@ -73,33 +46,6 @@ LIBS_FT=
+ #
+ #LIBS_FT= -L/usr/local/lib -lfreetype
+ 
+-#
+-# The flags for C compiler for the Autotrace library (disabled by default). 
+-# USE OF THIS FEATURE IS STRONGLY DISCOURAGED, THE BUILT-IN TRACING
+-# (AKA VECTORIZATION) PROVIDES MUCH BETTER RESULTS.
+-# The tested version is 0.29a (and the fonts produced with it are
+-# absolutely not usable).
+-# http://download.sourceforge.net/autotrace/autotrace-0.29.tar.gz
+-
+-CFLAGS_AT= 
+-
+-# To enable use of the Autotrace library
+-# (if the include and lib directory do not match your installation,
+-# modify them), also uncomment LIBS_AT
+-#
+-#CFLAGS_AT = -DUSE_AUTOTRACE -I/usr/local/include
+-
+-# 
+-# The Autotrace library flags (disabled by default)
+-
+-LIBS_AT=
+-
+-# To enable use of the Autotrace library
+-# (if the include and lib directory do not match your installation,
+-# modify them), also uncomment CFLAGS_AT
+-#
+-#LIBS_AT= -L/usr/local/lib -lautotrace
+-
+ #
+ # Preference of front-ends if multiple parsers match a file
+ # (by default the build-in front-end takes preference over FreeType)
+@@ -118,65 +64,28 @@ CFLAGS= $(CFLAGS_SYS) $(CFLAGS_FT) $(CFLAGS_AT) $(CFLAGS_PREF)
+ LIBS= $(LIBS_SYS) $(LIBS_FT) $(LIBS_AT)
+ 
+ # Installation-related stuff
+-# 
++#
+ # The base dir for installation and subdirs in it
+-INSTDIR = /usr/local
++INSTDIR = /usr
+ # for binaries
+ BINDIR = $(INSTDIR)/bin
+ # for binaries of little general interest
+-LIBXDIR = $(INSTDIR)/libexec/ttf2pt1
+ # for scripts, maps/encodings etc.
+-SHAREDIR = $(INSTDIR)/share/ttf2pt1
+-MANDIR = $(INSTDIR)/man
++SHAREDIR = $(INSTDIR)/share/examples/ttf2pt1
+ 
+-# owner and group of installed files
+-OWNER = root
+-GROUP = bin
+-
+-# After you have configured the Makefile, comment out the following
+-# definition:
+-warning: docs
+-	@echo >&2
+-	@echo "  You have to configure the Makefile before running make!" >&2
+-	@echo "(or if you are lazy and hope that it will work as is run \`make all')">&2
+-	@echo >&2
+-
+-DOCS=CHANGES README FONTS FONTS.hpux encodings/README other/README \
+-	app/X11/README app/netscape/README app/TeX/README
++DOCS=CHANGES FONTS encodings/README other/README \
++	app/TeX/README
+ 
+ SUBDIRS = app encodings maps scripts other
+ TXTFILES = README* FONTS* CHANGES* COPYRIGHT
+ 
+-MANS1=ttf2pt1.1 ttf2pt1_convert.1 ttf2pt1_x2gs.1
+-MANS=$(MANS1) $(MANS5)
+-
+-all:	t1asm ttf2pt1 docs mans rpm
++all:	t1asm ttf2pt1 docs
+ 
+ docs: $(DOCS)
+ 
+-mans: $(MANS) 
+-
+ clean:
+-	rm -f t1asm ttf2pt1 *.o app/RPM/Makefile app/RPM/*.spec *.core core.* core
++	rm -f t1asm ttf2pt1 *.o *.core core.* core
+ 	( cd other && make clean; )
+-	( cd app/netscape && make clean; )
+-
+-veryclean: clean
+-	rm -f $(DOCS) $(MANS)
+-
+-rpm: app/RPM/Makefile app/RPM/ttf2pt1.spec
+-
+-ttf2pt1.1: README.html
+-	scripts/html2man . . <README.html
+-
+-ttf2pt1_convert.1 ttf2pt1_x2gs.1: FONTS.html
+-	scripts/html2man . . <FONTS.html
+-
+-app/RPM/Makefile: Makefile
+-	sed 's/^CFLAGS_SYS.*=.*$$/CFLAGS_SYS= -O2 -D_GNU_SOURCE/;/warning:/,/^$$/s/^/#/' <Makefile >app/RPM/Makefile
+-
+-app/RPM/ttf2pt1.spec: app/RPM/ttf2pt1.spec.src version.h
+-	sed 's/^Version:.*/Version: '`grep TTF2PT1_VERSION version.h| cut -d\" -f2`'/' <app/RPM/ttf2pt1.spec.src  >$@
+ 
+ t1asm: t1asm.c
+ 	$(CC) $(CFLAGS) -o t1asm -DSTANDALONE t1asm.c $(LIBS)
+@@ -208,72 +117,15 @@ ttf2pt1:	ttf2pt1.o pt1.o runt1asm.o ttf.o ft.o bdf.o bitmap.o
+ CHANGES: CHANGES.html
+ 	scripts/unhtml <CHANGES.html >CHANGES
+ 
+-README: README.html
+-	scripts/unhtml <README.html >README
+-
+ encodings/README: encodings/README.html
+ 	scripts/unhtml <encodings/README.html >encodings/README
+ 
+ other/README: other/README.html
+ 	scripts/unhtml <other/README.html >other/README
+ 
+-app/X11/README: app/X11/README.html
+-	scripts/unhtml <app/X11/README.html >app/X11/README
+-
+-app/netscape/README: app/netscape/README.html
+-	scripts/unhtml <app/netscape/README.html >app/netscape/README
+-
+ app/TeX/README: app/TeX/README.html
+ 	scripts/unhtml <app/TeX/README.html >app/TeX/README
+ 
+ FONTS: FONTS.html
+ 	scripts/unhtml <FONTS.html >FONTS
+ 
+-FONTS.hpux: FONTS.hpux.html
+-	scripts/unhtml <FONTS.hpux.html >FONTS.hpux
+-
+-install: all
+-	scripts/inst_dir $(BINDIR) $(OWNER) $(GROUP) 0755
+-	scripts/inst_dir $(LIBXDIR) $(OWNER) $(GROUP) 0755
+-	scripts/inst_dir $(SHAREDIR) $(OWNER) $(GROUP) 0755
+-	scripts/inst_dir $(MANDIR)/man1 $(OWNER) $(GROUP) 0755
+-	scripts/inst_dir $(MANDIR)/man5 $(OWNER) $(GROUP) 0755
+-	cp -R $(TXTFILES) $(SUBDIRS) $(SHAREDIR)
+-	chown -R $(OWNER) $(SHAREDIR)
+-	chgrp -R $(GROUP) $(SHAREDIR)
+-	chmod -R go-w $(SHAREDIR)
+-	scripts/inst_file ttf2pt1 $(BINDIR)/ttf2pt1 $(OWNER) $(GROUP) 0755
+-	[ -f $(BINDIR)/t1asm ] || scripts/inst_file t1asm $(LIBXDIR)/t1asm $(OWNER) $(GROUP) 0755
+-	sed 's|^TTF2PT1_BINDIR=$$|TTF2PT1_BINDIR=$(BINDIR)|;\
+-		s|^TTF2PT1_LIBXDIR=$$|TTF2PT1_LIBXDIR=$(LIBXDIR)|;\
+-		s|^TTF2PT1_SHAREDIR=$$|TTF2PT1_SHAREDIR=$(SHAREDIR)|;' <scripts/convert >cvt.tmp
+-	scripts/inst_file cvt.tmp $(BINDIR)/ttf2pt1_convert $(OWNER) $(GROUP) 0755
+-	scripts/inst_file cvt.tmp $(SHAREDIR)/scripts/convert $(OWNER) $(GROUP) 0755
+-	rm cvt.tmp
+-	scripts/inst_file scripts/x2gs $(BINDIR)/ttf2pt1_x2gs $(OWNER) $(GROUP) 0755
+-	for i in $(MANS1); do { \
+-		sed 's|TTF2PT1_BINDIR|$(BINDIR)|;\
+-			s|TTF2PT1_LIBXDIR|$(LIBXDIR)|;\
+-			s|TTF2PT1_SHAREDIR|$(SHAREDIR)|;' <$$i >$(MANDIR)/man1/$$i \
+-		&& chown $(OWNER) $(MANDIR)/man1/$$i \
+-		&& chgrp $(GROUP) $(MANDIR)/man1/$$i \
+-		&& chmod 0644 $(MANDIR)/man1/$$i \
+-		|| exit 1; \
+-	} done
+-
+-uninstall:
+-	rm -f $(BINDIR)/ttf2pt1 $(BINDIR)/ttf2pt1_convert $(BINDIR)/ttf2pt1_x2gs
+-	rm -rf $(LIBXDIR)
+-	rm -rf $(SHAREDIR)
+-	for i in $(MANS1); do { \
+-		rm -f $(MANDIR)/man1/$$i $(MANDIR)/man1/$$i.gz; \
+-	} done
+-	
+-
+-# targets for automatic generation of releases and snapshots
+-
+-snapshot:
+-	scripts/mkrel snapshot
+-
+-release:
+-	scripts/mkrel release

--- a/srcpkgs/ttf2pt1/patches/002-fonts-html.patch
+++ b/srcpkgs/ttf2pt1/patches/002-fonts-html.patch
@@ -1,0 +1,265 @@
+--- FONTS.html
++++ FONTS.html
+@@ -52,11 +52,6 @@ fonts:
+ <ul>
+ <li> <A HREF="#X11">X11</A><br>
+ <li> <A HREF="#gs">Ghostscript</A><br>
+-<li> <A HREF="#win">MS Windows</A><br>
+-<li> <A HREF="#netscape">Netscape Navigator/Communicator</A><br>
+-<li> <A HREF="#rpm">Linux RPM package</A><br>
+-<li> <A HREF="#framemaker">FrameMaker</A><br>
+-<li> <A HREF="#soffice">StarOffice</A><br>
+ </ul>
+ </b><p>
+ 
+@@ -287,15 +282,9 @@ the result and the log file in <tt>DSTDIR</tt>.
+ 
+ Add the directory with newly converted fonts to the configuration
+ of X server or font server. For most of the systems this step is
+-very straightforward. For HP-UX it's rather tricky and poorly
+-documented, so the file <A HREF="FONTS.hpux.html">FONTS.hpux</A> gives a short description.
++very straightforward.
+ <p>
+ 
+-If you don't have the privileges of the root user, you still can
+-configure your private font server. Just use some non-standard
+-port number (see <A HREF="FONTS.hpux.html">FONTS.hpux</A> for an example, exept that you won't
+-need all the HP-related stuff on any other system).
+-<p>
+ <!-- =stop -->
+ 
+ <H4>
+@@ -308,52 +297,6 @@ Known Problems
+ <!-- ==head2 Known problems -->
+ 
+ <ul>
+-<li> One catch is that the X11 Type 1 font library has a rather low limit
+-  on the font size. Because of this the fonts with  more complicated
+-  outlines and the enabled hint substitution may not fit into
+-  this limit. The same applies to the fonts with very complicated
+-  outlines or with very many glyphs (especially the fonts with
+-  over 256 glyphs). So you will need to excercise caution with
+-  these options if you plan using these fonts with X11. Some vendors 
+-  such as HP provide the Type 1 implementation licensed from Adobe 
+-  which should have no such problem.
+-<p>
+-
+-  But there is a solution even for the generic X11. A patch located
+-  in the subdirectory `<tt>app/X11</tt>' fixes this problem as well
+-  as some other minor problems. Its description is provided in
+-  <A HREF="app/X11/README.html">app/X11/README</A>.
+-<p>
+-
+-  To fix the X11 font library, you have to get the X11 sources. I
+-  can recommend the ftp sites of the XFree86 project <A HREF="ftp://ftp.xfree86.org">ftp://ftp.xfree86.org</A>
+-  or of the Open Group <A HREF="ftp://ftp.x.org">ftp://ftp.x.org</A>. This patch was made on the sources
+-  of XFree86 so you may have better success with applying it to the
+-  XFree86 distribution. After you have got the sources, make sure
+-  that you can compile them. Then apply the patch as described.
+-  Make sure that it was applied properly. Compile the sources again
+-  (actually, you need only the fonts library, the fonts server, and
+-  possibly the X server). It would be prudent now to save your old
+-  font library, font server and, possibly, X server. Then install
+-  the new recently compiled versions of these files. Of course,
+-  if you know someone who already has compiled these files for the
+-  same OS as yours, you can just copy the binary fles from him.
+-<p>
+-
+-  Alas, building the X11 system from the source code is not the
+-  easiest thing in the world and if you have no experience it
+-  can be quite difficult. In this case just avoid the aforementioned
+-  features or check each converted font to make sure that it
+-  works properly.
+-<p>
+-
+-<li> The Type1 font library from the standard X11 distribution
+-  does not work on HP-UX (at least, up to 10.01). The font server
+-  supplied with HP-UX up to 10.01 is also broken. Starting from 
+-  HP-UX 10.20 (I don't know about 10.10) they supply a proprietary font 
+-  library and the converted fonts work fine with it, provided that
+-  they are configured properly (see the file <A HREF="FONTS.hpux.html">FONTS.hpux</A>).
+-<p>
+ 
+ <li> The <tt>fonts.scale</tt> files created by the older versions of the
+   <tt>ttf2pt1</tt> installation program (up to release 3.1) have conflicted 
+@@ -529,180 +472,6 @@ Alas, there is no visible solution of this problem yet.
+ <!-- ==back -->
+ <!-- =stop -->
+ 
+-<A NAME="win"></A>
+-<H3>
+-MS Windows
+-</H3>
+-<!
+-===========
+->
+-
+-<b>Ttf2pt1</b> can be built on Windows either with native compiler or in
+-POSIX emulation mode.
+-<p>
+-
+-Native MS Windows compilers require a different way to build the converter 
+-instead of the Makefile (their <tt>make</tt> programs commonly are quite weird
+-and limited in capabilities). An example of batch file <tt>winbuild.bat</tt> 
+-is provided for MS Visual C/C++. Probably it can be easily adapted for other 
+-32-bit Windows and DOS compilers. The important part is to define the 
+-preprocessor symbol WINDOWS during compilation.
+-<p>
+-
+-Cygnus <tt>make</tt> almost supports full Makefiles but not quite. Seems
+-like its POSIX support is also of the same quality "almost but not quite".
+-So another command file <tt>cygbuild.sh</tt> is provided for Cygnus GNU C, also 
+-with the preprocessor symbol WINDOWS defined. It is intended to be run from
+-the Cygnus BASH shell. To run the programs produced by the Cygnus compiler 
+-the Cygnus library file <tt>CYGWIN1.DLL</tt> should be copied first into 
+-<tt>C:\WINDOWS</tt>.
+-<p>
+-
+-To run the accompanying scripts Perl for Windows will be required as well as 
+-other tools from the Cygnus set.
+-<p>
+-
+-The Windows support was not particularly tested, so in case of problems with
+-building or running the converter please let us know.
+-<p>
+-
+-The pre-built code (possibly of an older version) of ttf2pt1 for MS Windows is
+-available from the GnuWin32 project from
+-
+-<A HREF="http://gnuwin32.sourceforge.net/packages/ttf2pt1.htm">http://gnuwin32.sourceforge.net/packages/ttf2pt1.htm</A>
+-<p>
+-
+-<A NAME="netscape"></a>
+-<H3>
+-Netscape Navigator/Communicator
+-</H3>
+-<!
+-===============================
+->
+-
+-Basically, the biggest problem with Netscape Navigator is that
+-it has built-in fixed PostScript font names and built-in fixed 
+-glyph tables for them. Oh, no, that's two! Let's start over: 
+-basically the two biggest problems of Netscape Navigator are 
+-that (one)it has built-in fixed PostScript font names and (two)
+-built-in fixed glyph tables for them and (three) it always
+-assumes that the fonts have ISOLatin1 encoding. OK, let's
+-start over again: basically the three biggest problems of Netscape 
+-Navigator are that (one) it has built-in fixed PostScript font names, 
+-(two) built-in fixed glyph tables for them and (three) it always
+-assumes that the fonts have ISOLatin1 encoding and (four) it
+-does not remember the scaled font size between the sessions.
+-You did not expect such a Spanish Inquisition, did you ? (<A HREF="#nsfn1">*</a>)
+-<p>
+-
+-Luckily, we have solutions for all of these problems. They are
+-located in the subdirectory `<tt>app/netscape</tt>' and described
+-in <A HREF="app/netscape/README.html">app/netscape/README</a>.
+-<p>
+-
+-<A NAME="nsfn1"></a>
+-&nbsp;&nbsp;-------<br>
+-&nbsp;&nbsp;<FONT SIZE=-1>*) See Monty Python's Flying Circus, episode 15</FONT></FONT>
+-<p>
+-
+-<FONT COLOR="#3333FF"><FONT SIZE=-1>*8*</FONT></FONT>
+-<H4>
+-Netscape and cyrillic fonts<br>
+-<!
+----------------------------
+->
+-(courtesy of Zvezdan Petkovic)
+-</H4>
+-
+-If you use TrueType fonts in your X, as I do, and you always get
+-KOI8-R encoded pages, then your Netscape does not recognise windows-1251
+-encoding.  Microsoft TrueType fonts simply declare all encodings they
+-can support including KOI8-R.  For some reason, KOI8-R always wins over
+-ISO-8859-5 in Netscape under X.  If you are reading other cyrillic
+-languages besides Russian, you might want to either erase KOI8-R entries
+-from the fonts.dir and fonts.scale files, or alternatively fix Netscape.
+-I put this line in my .Xdefaults.
+-<p>
+-
+-<blockquote><tt>
+-    Netscape*documentFonts.charset*koi8-r:               iso-8859-5
+-</tt></blockquote>
+-<p>
+-
+-Notice that you can still read Russian sites without trouble because
+-Netscape translates KOI8-R to ISO-8859-5 on the fly. I read both Russian
+-and Serbian sites with no trouble.
+-<p>
+-
+-<b>Note:</b> <i>If anybody knows the way to tell Netscape under Unix how to 
+-recognise {windows,ibm,cp}-1251 encoded fonts, I'd like to hear about that.</i>
+-<p>
+-
+-<A NAME="rpm"></a>
+-<H3>
+-Linux RPM package
+-</H3>
+-<!
+-=================
+->
+-
+-The spec file for the creation of a Linux RPM package is located in 
+-<tt>app/RPM</tt>. It has been contributed by Johan Vromans.  When 
+-<tt>make all</tt> is ran in the main directory it among the other 
+-things creates the version of itself adapted to Linux in <tt>app/RPM</tt>,
+-you may want to copy that version back to the main directory.
+-<p>
+-
+-<B>Warning:</B> Please note that the install section is incomplete, and 
+-the installed scripts won't work until the paths inside them
+-are corrected.
+-<p>
+-
+-<A NAME="framemaker"></a>
+-<H3>
+-FrameMaker
+-</H3>
+-<!
+-==========
+->
+-
+-The fonts and AFM files generated by the version 3.2 and higher 
+-should work with Framemaker without problems. The AFM files 
+-generated by the previous versions of the converter require a 
+-line added to them:
+-<p>
+-
+-&nbsp;&nbsp;<tt>EncodingScheme FontSpecific</tt>
+-<p>
+-
+-And the underscores in the font names of the font and AFM files 
+-generated by the older versions may need to be changed to dashes.
+-<p>
+-
+-<B>NOTE by Jason Baietto:</B> Ignore the directions in the Frame on-line docs 
+-that say to put a "serverdict begin 0 exitserver" line in the pfa files.  
+-Doing this caused both my printer and ghostscript to choke on the resulting
+-output from FrameMaker, so I would not advise doing this (though your
+-mileage may vary).
+-<p>
+-
+-<A NAME="soffice"></a>
+-<H3>
+-StarOffice
+-</H3>
+-<!
+-==========
+->
+-
+-StarOffice 5.1x has been reported to crash if the <tt>.afm</tt> file contains
+-spaces in the values of such statements as <b>Version</b>, <b>Weight</b> etc.
+-These spaces are permitted by the Adobe spec, so this is a problem of
+-StarOffice. The easiest way to fix these <tt>.afm</tt> files for StarOffice
+-is to remove spaces in these strings or remove these strings (in case if
+-they are optional) at all. This can be done automatically with a <tt>sed</tt>
+-script. It seems that StarOffice 5.2 has this problem fixed, so we decided to
+-spend no efforts on providing workarounds for 5.1 with <tt>ttf2pt1</tt>.
+-<p>
+ 
+ </BODY>
+ </HTML>

--- a/srcpkgs/ttf2pt1/patches/003-ttf2pt1-man-page-rewrite.patch
+++ b/srcpkgs/ttf2pt1/patches/003-ttf2pt1-man-page-rewrite.patch
@@ -1,0 +1,1414 @@
+--- ttf2pt1.1
++++ ttf2pt1.1
+@@ -1,205 +1,50 @@
+-.rn '' }`
+-''' $RCSfile$$Revision$$Date$
+-'''
+-''' $Log$
+-'''
+-.de Sh
+-.br
+-.if t .Sp
+-.ne 5
+-.PP
+-\fB\\$1\fR
+-.PP
+-..
+-.de Sp
+-.if t .sp .5v
+-.if n .sp
+-..
+-.de Ip
+-.br
+-.ie \\n(.$>=3 .ne \\$3
+-.el .ne 3
+-.IP "\\$1" \\$2
+-..
+-.de Vb
+-.ft CW
+-.nf
+-.ne \\$1
+-..
+-.de Ve
+-.ft R
+-
+-.fi
+-..
+-'''
+-'''
+-'''     Set up \*(-- to give an unbreakable dash;
+-'''     string Tr holds user defined translation string.
+-'''     Bell System Logo is used as a dummy character.
+-'''
+-.tr \(*W-|\(bv\*(Tr
+-.ie n \{\
+-.ds -- \(*W-
+-.ds PI pi
+-.if (\n(.H=4u)&(1m=24u) .ds -- \(*W\h'-12u'\(*W\h'-12u'-\" diablo 10 pitch
+-.if (\n(.H=4u)&(1m=20u) .ds -- \(*W\h'-12u'\(*W\h'-8u'-\" diablo 12 pitch
+-.ds L" ""
+-.ds R" ""
+-'''   \*(M", \*(S", \*(N" and \*(T" are the equivalent of
+-'''   \*(L" and \*(R", except that they are used on ".xx" lines,
+-'''   such as .IP and .SH, which do another additional levels of
+-'''   double-quote interpretation
+-.ds M" """
+-.ds S" """
+-.ds N" """""
+-.ds T" """""
+-.ds L' '
+-.ds R' '
+-.ds M' '
+-.ds S' '
+-.ds N' '
+-.ds T' '
+-'br\}
+-.el\{\
+-.ds -- \(em\|
+-.tr \*(Tr
+-.ds L" ``
+-.ds R" ''
+-.ds M" ``
+-.ds S" ''
+-.ds N" ``
+-.ds T" ''
+-.ds L' `
+-.ds R' '
+-.ds M' `
+-.ds S' '
+-.ds N' `
+-.ds T' '
+-.ds PI \(*p
+-'br\}
+-.\"	If the F register is turned on, we'll generate
+-.\"	index entries out stderr for the following things:
+-.\"		TH	Title 
+-.\"		SH	Header
+-.\"		Sh	Subsection 
+-.\"		Ip	Item
+-.\"		X<>	Xref  (embedded
+-.\"	Of course, you have to process the output yourself
+-.\"	in some meaninful fashion.
+-.if \nF \{
+-.de IX
+-.tm Index:\\$1\t\\n%\t"\\$2"
+-..
+-.nr % 0
+-.rr F
+-.\}
+-.TH TTF2PT1 1 "version 3.4.4" "December 31, 2003" "TTF2PT1 Font Converter"
+-.UC
+-.if n .hy 0
+-.if n .na
+-.ds C+ C\v'-.1v'\h'-1p'\s-2+\h'-1p'+\s0\v'.1v'\h'-1p'
+-.de CQ          \" put $1 in typewriter font
+-.ft CW
+-'if n "\c
+-'if t \\&\\$1\c
+-'if n \\&\\$1\c
+-'if n \&"
+-\\&\\$2 \\$3 \\$4 \\$5 \\$6 \\$7
+-'.ft R
+-..
+-.\" @(#)ms.acc 1.5 88/02/08 SMI; from UCB 4.2
+-.	\" AM - accent mark definitions
+-.bd B 3
+-.	\" fudge factors for nroff and troff
+-.if n \{\
+-.	ds #H 0
+-.	ds #V .8m
+-.	ds #F .3m
+-.	ds #[ \f1
+-.	ds #] \fP
+-.\}
+-.if t \{\
+-.	ds #H ((1u-(\\\\n(.fu%2u))*.13m)
+-.	ds #V .6m
+-.	ds #F 0
+-.	ds #[ \&
+-.	ds #] \&
+-.\}
+-.	\" simple accents for nroff and troff
+-.if n \{\
+-.	ds ' \&
+-.	ds ` \&
+-.	ds ^ \&
+-.	ds , \&
+-.	ds ~ ~
+-.	ds ? ?
+-.	ds ! !
+-.	ds /
+-.	ds q
+-.\}
+-.if t \{\
+-.	ds ' \\k:\h'-(\\n(.wu*8/10-\*(#H)'\'\h"|\\n:u"
+-.	ds ` \\k:\h'-(\\n(.wu*8/10-\*(#H)'\`\h'|\\n:u'
+-.	ds ^ \\k:\h'-(\\n(.wu*10/11-\*(#H)'^\h'|\\n:u'
+-.	ds , \\k:\h'-(\\n(.wu*8/10)',\h'|\\n:u'
+-.	ds ~ \\k:\h'-(\\n(.wu-\*(#H-.1m)'~\h'|\\n:u'
+-.	ds ? \s-2c\h'-\w'c'u*7/10'\u\h'\*(#H'\zi\d\s+2\h'\w'c'u*8/10'
+-.	ds ! \s-2\(or\s+2\h'-\w'\(or'u'\v'-.8m'.\v'.8m'
+-.	ds / \\k:\h'-(\\n(.wu*8/10-\*(#H)'\z\(sl\h'|\\n:u'
+-.	ds q o\h'-\w'o'u*8/10'\s-4\v'.4m'\z\(*i\v'-.4m'\s+4\h'\w'o'u*8/10'
+-.\}
+-.	\" troff and (daisy-wheel) nroff accents
+-.ds : \\k:\h'-(\\n(.wu*8/10-\*(#H+.1m+\*(#F)'\v'-\*(#V'\z.\h'.2m+\*(#F'.\h'|\\n:u'\v'\*(#V'
+-.ds 8 \h'\*(#H'\(*b\h'-\*(#H'
+-.ds v \\k:\h'-(\\n(.wu*9/10-\*(#H)'\v'-\*(#V'\*(#[\s-4v\s0\v'\*(#V'\h'|\\n:u'\*(#]
+-.ds _ \\k:\h'-(\\n(.wu*9/10-\*(#H+(\*(#F*2/3))'\v'-.4m'\z\(hy\v'.4m'\h'|\\n:u'
+-.ds . \\k:\h'-(\\n(.wu*8/10)'\v'\*(#V*4/10'\z.\v'-\*(#V*4/10'\h'|\\n:u'
+-.ds 3 \*(#[\v'.2m'\s-2\&3\s0\v'-.2m'\*(#]
+-.ds o \\k:\h'-(\\n(.wu+\w'\(de'u-\*(#H)/2u'\v'-.3n'\*(#[\z\(de\v'.3n'\h'|\\n:u'\*(#]
+-.ds d- \h'\*(#H'\(pd\h'-\w'~'u'\v'-.25m'\f2\(hy\fP\v'.25m'\h'-\*(#H'
+-.ds D- D\\k:\h'-\w'D'u'\v'-.11m'\z\(hy\v'.11m'\h'|\\n:u'
+-.ds th \*(#[\v'.3m'\s+1I\s-1\v'-.3m'\h'-(\w'I'u*2/3)'\s-1o\s+1\*(#]
+-.ds Th \*(#[\s+2I\s-2\h'-\w'I'u*3/5'\v'-.3m'o\v'.3m'\*(#]
+-.ds ae a\h'-(\w'a'u*4/10)'e
+-.ds Ae A\h'-(\w'A'u*4/10)'E
+-.ds oe o\h'-(\w'o'u*4/10)'e
+-.ds Oe O\h'-(\w'O'u*4/10)'E
+-.	\" corrections for vroff
+-.if v .ds ~ \\k:\h'-(\\n(.wu*9/10-\*(#H)'\s-2\u~\d\s+2\h'|\\n:u'
+-.if v .ds ^ \\k:\h'-(\\n(.wu*10/11-\*(#H)'\v'-.4m'^\v'.4m'\h'|\\n:u'
+-.	\" for low resolution devices (crt and lpr)
+-.if \n(.H>23 .if \n(.V>19 \
+-\{\
+-.	ds : e
+-.	ds 8 ss
+-.	ds v \h'-1'\o'\(aa\(ga'
+-.	ds _ \h'-1'^
+-.	ds . \h'-1'.
+-.	ds 3 3
+-.	ds o a
+-.	ds d- d\h'-1'\(ga
+-.	ds D- D\h'-1'\(hy
+-.	ds th \o'bp'
+-.	ds Th \o'LP'
+-.	ds ae ae
+-.	ds Ae AE
+-.	ds oe oe
+-.	ds Oe OE
+-.\}
+-.rm #[ #] #H #V #F C
+-.SH "NAME"
+-TTF2PT1 \- A True Type to PostScript Type 1 Font Converter 
+-.SH "SYNOPSIS"
+-\f(CWttf2pt1 \fI[-options] ttffont.ttf [Fontname]\fR\fR
+-.PP
++.\" TTF2PT1 1 "version 3.4.4" "December 31, 2003" "TTF2PT1 Font Converter"
++.Dd December 31, 2003
++.Dt TTF2PT1 1
++.Os
++.Sh NAME
++.Nm ttf2pt1
++.Nd A True Type to PostScript Type 1 Font Converter
++.Sh SYNOPSIS
++.Nm
++.Op Fl abeF
++.Op Fl d Ar suboptions
++.Op Fl G Ar suboptions
++.Op Fl l Ar language
++.Op Fl L Ar file
++.Op Fl m Ar type=value
++.Op Fl O Ar suboptions
++.Op Fl p Ar parser_name
++.Op Fl u Ar number
++.Op Fl v Ar size
++.Op Fl W Ar level
++.Bk
++.Ar ttffont.ttf Oo fontname Oc
++.Ek
++
+ or
+-.PP
+-\f(CWttf2pt1 \fI[-options] ttffont.ttf -\fR\fR
+-.SH "DESCRIPTION"
+-Ttf2pt1 is a font converter from the True Type format (and some other formats
++
++.Nm
++.Op Fl abeF
++.Op Fl d Ar suboptions
++.Op Fl G Ar suboptions
++.Op Fl l Ar language
++.Op Fl L Ar file
++.Op Fl m Ar type=value
++.Op Fl O Ar suboptions
++.Op Fl p Ar parser_name
++.Op Fl u Ar number
++.Op Fl v Ar size
++.Op Fl W Ar level
++.Ar ttffont.ttf
++.Op Fl
++
++.Sh DESCRIPTION
++.Nm
++is a font converter from the True Type format (and some other formats
+ supported by the FreeType library as well) to the Adobe Type1 format.
+-.PP
+-The versions 3.0 and later got rather extensive post-processing algorithm that 
++
++The versions 3.0 and later got rather extensive post-processing algorithm that
+ brings the converted fonts to the requirements of the Type1 standard, tries to
+ correct the rounding errors introduced during conversions and some simple
+ kinds of bugs that are typical for the public domain TTF fonts. It
+@@ -208,145 +53,237 @@ small sizes that are typical for the computer displays. But everything
+ has its price, and some of the optimizations may not work well for certain
+ fonts. That's why the options were added to the converter, to control
+ the performed optimizations.
+-.SH "OPTIONS"
+-The first variant creates the file \f(CWFontname.pfa\fR (or \f(CWFontname.pfb\fR if the 
+-option \*(L'\fB\-b\fR\*(R' was used) with the converted font and \f(CWFontname.afm\fR with the 
+-font metrics, the second one prints the font or another file (if the option
+-\&\*(R'\fB\-G\fR\*(R' was used) on the standard output from where it can be immediately
+-piped through some filter. If no \f(CWFontname\fR is specified for the first
+-variant, the name is generated from \f(CWttffont\fR by replacing the \f(CW.ttf\fR
++
++The first variant creates the file
++.Sq Fontname.pfa
++.Po or
++.Sq Fontname.pfb
++if the
++option
++.Fl b
++was used
++.Pc with the converted font and
++.Sq Fontname.afm
++with the
++font metrics, the second one prints the font or another file
++.Po if the option
++.Fl G
++was used
++.Pc on the standard output from where it can be immediately
++piped through some filter. If no
++.Ar Fontname
++is specified for the first
++variant, the name is generated from
++.Ar ttffont.ttf
++by replacing the
++.Sq .ttf
+ filename suffix.
+-.PP
+-Most of the time no options are neccessary (with a possible exception
+-of \*(L'\fB\-e\fR'). But if there are some troubles with the resulting font, they 
++
++Most of the time no options are neccessary
++.Po with a possible exception of
++.Fl e
++.Pc . But if there are some troubles with the resulting font, they
+ may be used to control the conversion.
+-The \fBoptions\fR are:
+-.Ip "\(bu" 2
+-\f(CW\fB-a\fR\fR \- Include all the glyphs from the source file into the converted
++The options are as follows:
++.Bl -tag
++.It Fl a
++Include all the glyphs from the source file into the converted
+ file. If this option is not specified then only the glyphs that have
+ been assigned some encoding are included, because the rest of glyphs
+-would be inaccessible anyway and would only consume the disk space. 
++would be inaccessible anyway and would only consume the disk space.
+ But some applications are clever enough to change the encoding on
+ the fly and thus use the other glyphs, in this case they could
+ benefit from using this option. But there is a catch: the X11 library
+ has rather low limit for the font size. Including more glyphs increases
+ the file size and thus increases the chance of hitting this limit.
+-See \f(CWapp/X11/README\fR for the description of a 
+-patch to X11 which fixes this problem.
+-.Ip "\(bu" 2
+-\f(CW\fB-b\fR\fR \- Encode the resulting font to produce a ready \f(CW.pfb\fR file.
+-.Ip "\(bu" 2
+-\f(CW\fB-d \fIsuboptions\fR\fR\fR \- Debugging options. The suboptions are:
+-.Sp
+-\f(CW\fBa\fR\fR \- Print out the absolute coordinates of dots in outlines. Such
+-a font can not be used by any program (that's why this option is
+-incompatible with \*(L'\fB\-e\fR') but it has proven to be a valuable debuging 
++.It Fl b
++Encode the resulting font to produce a ready
++.Sq .pfb
++file.
++.It Fl d Ar suboptions
++Debugging options. The suboptions are:
++.Bl -tag
++.It Ar a
++Print out the absolute coordinates of dots in outlines. Such
++a font can not be used by any program
++.Po that's why this option is
++incompatible with
++.Fl e
++.Pc but it has proven to be valuable debuging
+ information.
+-.Sp
+-\f(CW\fBr\fR\fR \- Do not reverse the direction of outlines. The \s-1TTF\s0 fonts have
++
++.It Ar r
++Do not reverse the direction of outlines. The TTF fonts have
+ the standard direction of outlines opposite to the Type1 fonts. So
+ they should be reversed during proper conversion. This option
+-may be used for debugging or to handle a \s-1TTF\s0 font with wrong
+-direction of outlines (possibly, converted in a broken way from
+-a Type1 font). The first signs of the wrong direction are the
+-letters like \*(L"P\*(R" or \*(L"B\*(R" without the unpainted \*(L"holes\*(R" inside.
+-.Ip "\(bu" 2
+-\f(CW\fB-e\fR\fR \- Assemble the resulting font to produce a ready \f(CW.pfa\fR file.
+-.Sp
++may be used for debugging or to handle a TTF font with wrong
++direction of outlines
++.Po
++possibly, converted in a broken way from
++a Type1 font
++.Pc. The first signs of the wrong direction are the
++letters like P or B without the unpainted holes inside.
++.El
++.It Fl e
++Assemble the resulting font to produce a ready
++.Sq .pfa
++file.
+ [ S.B.: Personally I don't think that this option is particularly useful.
+ The same result may be achieved by piping the unassembled data
+ through t1asm, the Type 1 assembler. And, anyways, it's good to
+-have the t1utils package handy. But Mark and many users think that 
++have the t1utils package handy. But Mark and many users think that
+ this functionality is good and it took not much time to add this option. ]
+-.Ip "\(bu" 2
+-\f(CW\fB-F\fR\fR \- Force the Unicode encoding: any type of \s-1MS\s0 encoding specified
++.It Fl F
++Force the Unicode encoding: any type of MS encoding specified
+ in the font is ignored and the font is treated like it has Unicode
+-encoding. \fB\s-1WARNING\s0:\fR this option is intended for buggy fonts
++encoding.
++.Sy WARNING:
++this option is intended for buggy fonts
+ which actually are in Unicode but are marked as something else. The
+ effect on the other fonts is unpredictable.
+-.Ip "\(bu" 2
+-\f(CW\fB-G \fIsuboptions\fR\fR\fR \- File generation options. The suboptions may be lowercase 
+-or uppercase, the lowercase ones disable the generation of particular 
+-files, the corresponding uppercase suboptions enable the generation of the 
+-same kind of files. If the result of ttf2pt1 is requested to be printed on
+-the standard output, the last enabling suboption of \fB\-G\fR determines
+-which file will be written to the standard output and the rest of files
+-will be discarded. For example, \fB\-G A\fR will request the \s-1AFM\s0 file.
++.It Fl G Ar suboptions
++File generation options. The suboptions may be lowercase
++or uppercase, the lowercase ones disable the generation of particular
++files, the corresponding uppercase suboptions enable the generation of the
++same kind of files. If the result of
++.Nm
++is requested to be printed on
++the standard output, the last enabling suboption of
++.Fl G
++determines which file will be written to the standard output and the rest of files
++will be discarded. For example,
++.Fl G Cm A
++will request the AFM file.
++
+ The suboptions to disable/enable the generation of the files are:
+-.Sp
+-\f(CW\fBf/F\fR\fR \- The font file. Depending on the other options this file
+-will have one of the suffixes \f(CW.t1a\fR, \f(CW.pfa\fR or \f(CW.pfb\fR. If the conversion result
+-is requested on the standard output ('\f(CW-\fR\*(R' is used as the output file name)
++.Bl -tag
++.It Ar f/F
++The font file. Depending on the other options this file
++will have one of the suffixes
++.Sq .t1a
++.Sq .pfa
++or
++.Sq .pfb
++\. If the conversion result is requested on the standard output
++.Po
++.Sq -
++is used as the output file name
++.Pc
+ then the font file will also be written there by default, if not overwritten
+-by another suboption of \fB\-G\fR.
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBa/A\fR\fR \- The Adobe font metrics file (\f(CW.afm\fR).
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBe/E\fR\fR \- The dvips encoding file (\f(CW.enc\fR).
+-\fBDefault: disabled\fR
+-.Ip "\(bu" 2
+-\f(CW\fB-l \fIlanguage\fR[+\fIargument\fR]\fR\fR \- Extract the fonts for the specified language from a
++by another suboption of
++.Fl G .
++.Sy Default: enabled
++.It Ar a/A
++The Adobe font metrics file
++.Pq .afm
++\.
++.Sy Default: enabled
++.It Ar e/E
++The dvips encoding file
++.Pq .enc
++\.
++.Sy Default: disabled
++.El
++.It Fl l Ar language Ns Op +argument
++Extract the fonts for the specified language from a
+ multi-language Unicode font. If this option is not used the converter
+-tries to guess the language by the values of the shell variable \s-1LANG\s0.
+-If it is not able to guess the language by \s-1LANG\s0 it tries all the
+-languages in the order they are listed. 
+-.Sp
++tries to guess the language by the values of the shell variable LANG.
++If it is not able to guess the language by LANG it tries all the
++languages in the order they are listed.
++
+ After the plus sign an optional argument for the language extractor
+ may be specified. The format of the argument is absolutely up to
+ the particular language converter. The primary purpose of the
+ argument is to support selection of planes for the multi-plane
+-Eastern encodings but it can also be used in any other way. The 
++Eastern encodings but it can also be used in any other way. The
+ language extractor may decide to add the plane name in some form
+-to the name of the resulting font. None of the currently supported 
++to the name of the resulting font. None of the currently supported
+ languages make any use of the argument yet.
+-.Sp
++
+ As of now the following languages are supported:
+-.Sp
+-\ \ \f(CWlatin1\fR \- for all the languages using the Latin-1 encoding
+-.Sp
+-\ \ \f(CWlatin2\fR \- for the Central European languages
+-.Sp
+-\ \ \f(CWlatin4\fR \- for the Baltic languages
+-.Sp
+-\ \ \f(CWlatin5\fR \- for the Turkish language
+-.Sp
+-\ \ \f(CWcyrillic\fR \- for the languages with Cyrillic alphabet
+-.Sp
+-\ \ \f(CWrussian\fR \- historic synonym for cyrillic
+-.Sp
+-\ \ \f(CWbulgarian\fR \- historic synonym for cyrillic
+-.Sp
+-\ \ \f(CWadobestd\fR \- for the AdobeStandard encoding used by TeX
+-.Sp
+-\ \ \f(CWplane+\fIargument\fR\fR \- to select one plane from a multi-byte encoding
+-.Sp
+-The argument of the \*(L"\f(CWplane\fR\*(R" language may be in one of three forms:
+-.Sp
+-\ \ \f(CWplane+\fBpid=\fR\fI<pid>\fR\fB,eid=\fR\fI<eid>\fR\fR
+-.Sp
+-\ \ \f(CWplane+\fBpid=\fR\fI<pid>\fR\fB,eid=\fR\fI<eid>\fR\fB,\fR\fI<plane_number>\fR\fR
+-.Sp
+-\ \ \f(CWplane+\fI<plane_number>\fR\fR
+-.Sp
+-Pid (\s-1TTF\s0 platform id) and eid (\s-1TTF\s0 encoding id) select a particular 
+-\s-1TTF\s0 encoding table in the original font. They are specified as decimal
++.Bl -inset
++.It latin1
++for all the languages using the Latin-1 encoding
++.It latin2
++for the Central European languages
++.It latin4
++for the Baltic languages
++.It latin5
++for the Turkish language
++.It cyrillic
++for the languages with Cyrillic alphabet
++.It russian
++historic synonym for cyrillic
++.It bulgarian
++historic synonym for cyrillic
++.It adobestd
++for the AdobeStandard encoding used by TeX
++.It plane Ns Ar +argument
++to select one plane from a multi-byte encoding
++.El
++
++The argument of the
++.Qq plane
++language may be in one of three forms:
++.Bl -inset
++.It plane+ Ns Sy pid= Ns Ao Ar pid Ac Ns Sy ,eid= Ns Ao Ar eid Ac No
++.It plane+ Ns Sy pid= Ns Ao Ar pid Ac Ns Sy ,eid= Ns Ao Ar eid Ac Ns Sy , Ns No Ns Ao Ar plane_number Ac No
++.It plane+ Ns Ao Ar plane_number Ac No
++.El
++
++.Ar pid
++.Po
++TTF platform id
++.Pc and
++.Ar eid
++.Po
++TTF encoding id
++.Pc
++select a particular TTF encoding table in the original font. They are specified as decimal
+ numbers. If this particular encoding table is not present in the font
+-file then the conversion fails. The native ("ttf") front-end parser supports
+-only pid=3 (Windows platform), the FreeType-based ("ft") front-end supports 
+-any platform. If pid/eid is not specified then the \s-1TTF\s0 encoding table is 
+-determined as usual: Unicode encoding if it's first or an 8-bit encoding
+-if not (and for an 8-bit encoding the plane number is silently ignored). 
++file then the conversion fails. The native
++.Po
++.Qo
++ttf
++.Qc
++.Pc
++front-end parser supports only pid=3 (Windows platform), the FreeType-based
++.Po
++.Qo
++ft
++.Qc
++.Pc
++front-end supports any platform. If
++.Ar pid
++/
++.Ar eid
++is not specified then the TTF encoding table is
++determined as usual: Unicode encoding if it
++.Ap
++s first or an 8-bit encoding
++if not
++.Po
++and for an 8-bit encoding the plane number is silently ignored
++.Pc .
+ To prevent the converter from falling back to an 8-bit encoding, specify
+ the Unicode pid/eid value explicitly.
+-.Sp
+-Plane_number is a hexadecimal (if starts with \*(L"\fB0x\fR") or decimal number.
+-It gives the values of upper bytes for which 256 characters will be 
++
++.Ar Plane_number
++is a hexadecimal
++.Po
++if starts with
++.Sy 0x
++.Pc
++or decimal number. It gives the values of upper bytes for which 256 characters will be
+ selected. If not specified, defaults to 0. It is also used as a font
+-name suffix (the leading \*(L"0x\*(R" is not included into the suffix).
+-.Sp
+-\fB\s-1NOTE\s0:\fR
++name suffix
++.Po
++the leading
++.Sy 0x
++is not included into the suffix
++.Pc .
++
++.Sy NOTE:
+ You may notice that the language names are not uniform: some are the
+ names of particular languages and some are names of encodings. This
+ is because of the different approaches. The original idea was to
+@@ -356,146 +293,190 @@ to generate the fonts in whatever final encodings are needed. This
+ would allow to pile together the Unicode fonts and the non-Unicode
+ Windows fonts for that language and let the program to sort them out
+ automatically. And then generate fonts in all the possible encodings
+-for that language. An example of this approach is the Russian language
+-support. But if there is no multiplicity of encodings used for some 
+-languages and if the non-Unicode fonts are not considered important 
++for that language.
++
++An example of this approach is the Russian language
++support. But if there is no multiplicity of encodings used for some
++languages and if the non-Unicode fonts are not considered important
+ by the users, another way would be simpler to implement: just provide
+ only one table for extraction of the target encoding from Unicode
+-and don't bother with the translation tables. The latin* \*(L"languages\*(R"
++and don't bother with the translation tables. The latin* languages
+ are examples of this approach. If somebody feels that he needs the
+ Type1 fonts both in Latin-* and Windows encodings he or she is absolutely
+ welcome to submit the code to implement it.
+-.Sp
+-\fB\s-1WARNING\s0:\fR
++
++.Sy WARNING:
+ Some of the glyphs included into the AdobeStandard encoding are not
+ included into the Unicode standard. The most typical examples of such
+-glyphs are ligatures like \*(L'fi\*(R', \*(L'fl\*(R' etc. Because of this the font 
++glyphs are ligatures like
++.Sq fi
++,
++.Sq fl
++etc. Because of this the font
+ designers may place them at various places. The converter tries to
+ do its best, if the glyphs have honest Adobe names and/or are
+ placed at the same codes as in the Microsoft fonts they will be
+-picked up. Otherwise a possible solution is to use the option \*(L'\fB\-L\fR\*(R'
+-with an external map. 
+-.Ip "\(bu" 2
+-\f(CW\fB-L \fIfile\fR[+[pid=\fI<pid>\fR,eid=\fI<eid>\fR,][\fIplane\fR]]\fR\fR \- Extract the fonts for the specified 
++picked up. Otherwise a possible solution is to use the option
++.Fl L
++with an external map.
++.It Fl L Ar file Ns Op + Ns Oo pid=<pid>,eid=<eid> Oc Ns Oo plane Oc
++Extract the fonts for the specified
+ language from a multi-language font using the map from this file. This is
+-rather like the option \*(L'\fB\-l\fR\*(R' but the encoding map is not 
++rather like the option
++.Fl l
++but the encoding map is not
+ compiled into the program, it's taken from that file, so it's
+-easy to edit. Examples of such files are provided in 
+-\f(CWmaps/adobe-standard-encoding.map\fR, \f(CWCP1250.map\fR. (\fB\s-1NOTE\s0:\fR
+-the \*(L'standard encoding\*(R' map does not include all the glyphs of the 
+-AdobeStandard encoding, it's provided only as an example.) The 
+-description of the supported map formats is in the file 
+-\f(CWmaps/unicode-sample.map\fR.
+-.Sp
+-Likewise to \*(L'\fB\-l\fR\*(R', an argument may be specified after the map file
+-name. But in this case the argument has fixed meaning: it selects the 
+-original \s-1TTF\s0 encoding table (the syntax is the same as in \*(L'\fB\-l plane\fR')
+-and/or a plane of the map file. The plane name also gets added after dash 
+-to the font name. The plane is a concept used in the Eastern fonts with big 
+-number of glyphs: one \s-1TTF\s0 font gets divided into multiple Type1 fonts, 
+-each containing one plane of up to 256 glyphs. But with a little 
+-creativity this concept may be used for other purposes of combining 
+-multiple translation maps into one file.  To extract multiple planes 
+-from a \s-1TTF\s0 font \f(CWttf2pt1\fR must be run multiple times, each time with 
++easy to edit. Examples of such files are provided in
++.Pa /usr/share/examples/ttf2ps1/maps .
++
++.Po
++.Sy NOTE:
++the
++.Sq standard encoding
++map does not include all the glyphs of the
++AdobeStandard encoding, it's provided only as an example.
++.Pc
++The
++description of the supported map formats is in the file
++.Pa /usr/share/examples/ttf2ps1/maps/unicode-sample.map .
++Likewise to
++.Fl l
++, an argument may be specified after the map file
++name. But in this case the argument has fixed meaning: it selects the
++original TTF encoding table
++.Po the syntax is the same as in
++.Fl l plane
++.Pc
++and/or a plane of the map file. The plane name also gets added after dash
++to the font name. The plane is a concept used in the Eastern fonts with big
++numbers of glyphs: one TTF font gets divided into multiple Type1 fonts,
++each containing one plane of up to 256 glyphs. But with a little
++creativity this concept may be used for other purposes of combining
++multiple translation maps into one file.  To extract multiple planes
++from a TTF font
++.Nm
++must be run multiple times, each time with
+ a different plane name specified.
+-.Sp
+-The default original \s-1TTF\s0 encoding table used for the option \*(L'\fB\-L\fR\*(R' is
+-Unicode. The map files may include directives to specify different original 
+-\s-1TTF\s0 encodings. However if the pid/eid pair is specified with
++
++The default original TTF encoding table used for the option
++.Fl L
++is
++Unicode. The map files may include directives to specify different original
++TTF encodings. However if the pid/eid pair is specified with
+ it overrides any original encoding specified in the map file.
+-.Ip "\(bu" 2
+-\f(CW\fB-m \fItype\fR=\fIvalue\fR\fR\fR \- Set maximal or minimal limits of resources.
++.It Fl m Ar type=value
++Set maximal or minimal limits of resources.
+ These limits control the the font generation by limiting the resources
+ that the font is permitted to require from the PostScript interpreter.
+ The currently supported types of limits are:
+-.Sp
+-\f(CW\fBh\fR\fR \- the maximal hint stack depth for the substituted hints. 
++.Bl -tag
++.It Ar h
++the maximal hint stack depth for the substituted hints.
+ The default value is 128, according to the limitation in X11. This seems to
+ be the lowest (and thus the safest) widespread value. To display the
+-hint stack depth required by each glyph in a \f(CW.t1a\fR file use the script
+-\f(CWscripts/cntstems.pl\fR.
+-.Ip "\(bu" 2
+-\f(CW\fB-O \fIsuboptions\fR\fR\fR \- Outline processing options. The suboptions
++hint stack depth required by each glyph in a
++.Sq .t1a
++file use the script
++.Pa /usr/share/examples/ttf2ps1/scripts/cntstems.pl .
++.El
++.It Fl O Ar suboptions
++Outline processing options. The suboptions
+ may be lowercase or uppercase, the lowercase ones disable the features,
+ the corresponding uppercase suboptions enable the same features.
+ The suboptions to disable/enable features are:
+-.Sp
+-\f(CW\fBb/B\fR\fR \- Guessing of the ForceBold parameter. This parameter helps
++.Bl -tag
++.It Ar b/B
++Guessing of the ForceBold parameter. This parameter helps
+ the Type1 engine to rasterize the bold fonts properly at small sizes.
+ But the algorithm used to guess the proper value of this flag makes
+ that guess based solely on the font name. In rare cases that may cause
+-errors, in these cases you may want to disable this guessing. 
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBh/H\fR\fR \- Autogeneration of hints. The really complex outlines
++errors, in these cases you may want to disable this guessing.
++.Sy Default: enabled
++.It Ar h/H
++Autogeneration of hints. The really complex outlines
+ may confuse the algorithm, so theoretically it may be useful
+ sometimes to disable them. Although up to now it seems that
+ even bad hints are better than no hints at all.
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBu/U\fR\fR \- Hint substitution. Hint substitution is a technique 
+-permitting generation of more detailed hints for the rasterizer. It allows 
+-to use different sets of hints for different parts of a glyph and change 
+-these sets as neccessary during rasterization (that's why \*(L"substituted").  
+-So it should improve the quality of the fonts rendered at small sizes.  
+-But there are two catches: First, the X11 library has rather low limit for 
+-the font size. More detailed hints increase the file size and thus increase 
++.Sy Default: enabled
++.It Ar u/U
++Hint substitution. Hint substitution is a technique
++permitting generation of more detailed hints for the rasterizer. It allows
++to use different sets of hints for different parts of a glyph and change
++these sets as neccessary during rasterization
++.Po
++that
++.Ap
++s why
++.Sq substituted
++.Pc .
++So it should improve the quality of the fonts rendered at small sizes.
++But there are two catches: First, the X11 library has rather low limit for
++the font size. More detailed hints increase the file size and thus increase
+ the chance of hitting this limit (that does not mean that you shall hit it
+-but you may if your fonts are particularly big). This is especially 
+-probable for Unicode fonts converted with option \*(L'\fB\-a\fR\*(R', so you may want to 
+-use \*(L'\fB\-a\fR\*(R' together with \*(L'\fB\-Ou\fR\*(R'. See \f(CWapp/X11/README\fR for the description of 
+-a patch to X11 which fixes this problem. Second, some rasterizers (again,
++but you may if your fonts are particularly big).
++Second, some rasterizers (again,
+ X11 is the typical example) have a limitation for total number of hints
+ used when drawing a glyph (also known as the hint stack depth). If that
+-stack overflows the glyph is ignored. Starting from version 3.22 \f(CWttf2pt1\fR
++stack overflows the glyph is ignored. Starting from version 3.22
++.Nm
+ uses algorithms to minimizing this depth, with the trade-off of slightly
+ bigger font files. The glyphs which still exceed the limit set by option
+-\&\*(R'\fB\-mh\fR\*(R' have all the substituted hints removed and only base hints left.
++.Fl mh
++have all the substituted hints removed and only base hints left.
+ The algorithms seem to have been refined far enough to make the fonts with
+-substituted hints look better than the fonts without them or at least the 
+-same. Still if the original fonts are not well-designed the detailed 
+-hinting may emphasize the defects of the design, such as non-even thickness 
+-of lines. So provided that you are not afraid of the X11 bug the best idea 
+-would be to generate a font with this feature and without it, then compare 
+-the results using the program \f(CWother/cmpf\fR (see the description 
+-in \f(CWother/README\fR) and decide which one looks better.
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBo/O\fR\fR \- Space optimization of the outlines\*(R' code. This kind of optimization
+-never hurts, and the only reason to disable this feature is for comparison 
+-of the generated fonts with the fonts generated by the previous versions of 
++substituted hints look better than the fonts without them or at least the
++same. Still if the original fonts are not well-designed the detailed
++hinting may emphasize the defects of the design, such as non-even thickness
++of lines. So provided that you are not afraid of the X11 bug the best idea
++would be to generate a font with this feature and without it, then compare
++the results using the program
++.Pa /usr/share/examples/ttf2ps1/other/cmpf
++.Po see the description in
++.Pa /usr/share/examples/ttf2ps1/other/README
++.Pc and decide which one looks better.
++.Sy Default: enabled
++.It Ar o/O
++Space optimization of the outlines code. This kind of optimization
++never hurts, and the only reason to disable this feature is for comparison
++of the generated fonts with the fonts generated by the previous versions of
+ converter. Well, it _almost_ never hurts. As it turned out there exist
+ some brain-damaged printers which don't understand it. Actually this
+-feature does not change the outlines at all. The Type 1 font manual 
++feature does not change the outlines at all. The Type 1 font manual
+ provides a set of redundant operators that make font description shorter,
+-such as \*(L'10 hlineto\*(R' instead of \*(L'0 10 rlineto\*(R' to describe a horizontal
+-line. This feature enables use of these operators.
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBs/S\fR\fR \- Smoothing of outlines. If the font is broken in some
+-way (even the ones that are not easily noticeable), such smoothing 
+-may break it further. So disabling this feature is the first thing to be 
++such as
++.Sq 10 hlineto
++instead of
++.Sq 0 10 rlineto
++to describe a horizontal line. This feature enables use of these operators.
++.Sy Default: enabled
++.It Ar s/S
++Smoothing of outlines. If the font is broken in some way
++.Pq even the ones that are not easily noticeable
++, such smoothing
++may break it further. So disabling this feature is the first thing to be
+ tried if some font looks odd. But with smoothing off the hint generation
+ algorithms may not work properly too.
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBt/T\fR\fR \- Auto-scaling to the 1000x1000 Type1 standard matrix. The
+-\s-1TTF\s0 fonts are described in terms of an arbitrary matrix up to
++.Sy Default: enabled
++.It Ar t/T
++Auto-scaling to the 1000x1000 Type1 standard matrix. The
++TTF fonts are described in terms of an arbitrary matrix up to
+ 4000x4000. The converted fonts must be scaled to conform to
+ the Type1 standard. But the scaling introduces additional rounding
+ errors, so it may be curious sometimes to look at the font in its
+ original scale.
+-\fBDefault: enabled\fR
+-.Sp
+-\f(CW\fBv/V\fR\fR \- Do vectorization on the bitmap fonts. Functionally
+-\*(L"vectorization\*(R" is the same thing as \*(L"autotracing\*(R", a different word is
+-used purely to differentiate it from the Autotrace library. It tries to
++.Sy Default: enabled
++.It Ar v/V
++Do vectorization on the bitmap fonts. Functionally
++.Qqvectorization
++is the same thing as
++.Qq autotracing
++, a different word is used purely to differentiate it from the Autotrace library. It tries to
+ produce nice smooth outlines from bitmaps. This feature is still a work
+ in progress though the results are already mostly decent.
+-\fBDefault: disabled\fR
+-.Sp
+-\f(CW\fBw/W\fR\fR \- Glyphs\*(R' width corection. This option is designed to be
+-used on broken fonts which specify too narrow widths for the 
++.Sy Default: disabled
++.It Ar w/W
++Glyphs' width corection. This option is designed to be
++used on broken fonts which specify too narrow widths for the
+ letters. You can tell that a font can benefit from this option
+ if you see that the characters are smashed together without
+ any whitespace between them. This option causes the converter
+@@ -507,67 +488,104 @@ will benefit from disabling this feature. You may want to convert
+ a font with and without this feature, compare the results and
+ select the better one. This feature may be used only on proportional
+ fonts, it has no effect on the fixed-width fonts.
+-\fBDefault: disabled\fR
+-.Sp
+-\f(CW\fBz/Z\fR\fR \- Use the Autotrace library on the bitmap fonts. The results 
+-are horrible and \fBthe use of this option is not recommended\fR. This option is 
+-present for experimental purposes. It may change or be removed in the
+-future. The working tracing can be achieved with option \f(CW\fB-OV\fR\fR.
+-\fBDefault: disabled\fR
+-.Ip "\(bu" 2
+-\f(CW\fB-p \fIparser_name\fR\fR\fR \- Use the specified front-end parser to read the font file.
++.Sy Default: disabled
++.It Ar z/Z
++Use the Autotrace library on the bitmap fonts. The results
++are horrible and
++.Sy the use of this option is not recommended.
++This option is present for experimental purposes. It may change or be removed in the
++future. The working tracing can be achieved with option
++.Fl OV .
++.Sy Default: disabled
++.El
++.It Fl p Ar parser_name
++Use the specified front-end parser to read the font file.
+ If this option is not used, ttf2pt1 selects the parser automatically based
+ on the suffix of the font file name, it uses the first parser in its
+ list that supports this font type. Now two parsers are supported:
+-.Sp
+-\ \ \f(CWttf\fR \- built-in parser for the ttf files (suffix \f(CW.ttf\fR)
+-.Sp
+-\ \ \f(CWbdf\fR \- built-in parser for the \s-1BDF\s0 files (suffix \f(CW.bdf\fR)
+-.Sp
+-\ \ \f(CWft\fR \- parser based on the FreeType-2 library (suffixes \f(CW.ttf\fR,
+-\&\f(CW.otf\fR, \f(CW.pfa\fR, \f(CW.pfb\fR)
+-.Sp
+-The parser \f(CWft\fR is \fB\s-1NOT\s0\fR linked in by default. See \f(CWMakefile\fR
+-for instructions how to enable it. We do no support this parser on
++.Bl -tag
++.It Ar ttf
++built-in parser for the ttf files
++.Po suffix
++.Sq .ttf
++.Pc
++.It Ar bdf
++built-in parser for the BDF files
++.Po suffix
++.Sq .bdf
++.Pc
++.Sp
++.It Ar ft
++parser based on the FreeType-2 library
++.Po suffixes
++.Sq .ttf
++,
++.Sq .otf
++,
++.Sq .pfa
++,
++.Sq .pfb
++.Pc
++.El
++The parser
++.Ar ft
++is
++.Sy NOT
++linked in by default. See
++.Sq Makefile
++for instructions how to enable it. We do not support this parser on
+ Windows: probably it will work but nobody tried and nobody knows how
+-to build it. 
+-.Sp
+-The conversion of the bitmap fonts (such as \s-1BDF\s0) is simplistic yet,
+-producing jagged outlines.  When converting such fonts, it might be 
+-a good idea to turn off the hint substitution (using option \fB\-Ou\fR) 
++to build it.
++
++The conversion of the bitmap fonts
++.Pq such as BDF
++is simplistic yet,
++producing jagged outlines. When converting such fonts, it might be
++a good idea to turn off the hint substitution
++.Po using option
++.Fl Ou
++.Pc
+ because the hints produced will be huge but not adding much to the
+ quality of the fonts.
+-.Ip "\(bu" 2
+-\f(CW\fB-u \fInumber\fR\fR\fR \- Mark the font with this value as its
++.It Fl u Ar number
++Mark the font with this value as its
+ UniqueID. The UniqueID is used by the printers with the hard disks
+ to cache the rasterized characters and thus significantly
+ speed-up the printing. Some of those printers just can't
+-store the fonts without UniqueID on their disk.The problem
+-is that the \s-1ID\s0 is supposed to be unique, as it name says. And
+-there is no easy way to create a guaranteed unique \s-1ID\s0. Adobe specifies
++store the fonts without UniqueID on their disk. The problem
++is that the ID is supposed to be unique, as it name says. And
++there is no easy way to create a guaranteed unique ID. Adobe specifies
+ the range 4000000-4999999 for private IDs but still it's difficult
+-to guarantee the uniqueness within it. So if you don't really need the 
+-UniqueID don't use it, it's optional. Luckily there are a few millions of 
+-possible IDs, so the chances of collision are rather low. 
+-If instead of the number a special value \*(L'\f(CW\fBA\fR\fR\*(R' is given
++to guarantee the uniqueness within it. So if you don't really need the
++UniqueID don't use it, it's optional. Luckily there are a few millions of
++possible IDs, so the chances of collision are rather low.
++If instead of the number a special value
++.Sq Sy A
++is given
+ then the converter generates the value of UniqueID automatically,
+-as a hash of the font name. (\fB\s-1NOTE\s0:\fR  in the version 3.22 the
++as a hash of the font name.
++.Po
++.Sy NOTE:
++in the version 3.22 the
+ algorithm for autogeneration of UniqueID was changed to fit the values
+-into the Adobe-spacified range. This means that if UniqueIDs were used 
+-then the printer's cache may need to be flushed before replacing the 
+-fonts converted by an old version with fonts converted by a newer version).
++into the Adobe-spacified range. This means that if UniqueIDs were used
++then the printer's cache may need to be flushed before replacing the
++fonts converted by an old version with fonts converted by a newer version
++.Pc .
+ A simple way to find if any of the fonts in a given directory have
+ duplicated UniqueIDs is to use the command:
+-.Sp
+-\f(CW\ \ cat *.pf[ab] | grep UniqueID | sort | uniq -c | grep -v ' 1 '\fR
+-.Sp
+-Or if you use \f(CWscripts/convert\fR it will do that for you automatically 
++.D1 cat *.pf[ab] | grep UniqueID | sort | uniq -c | grep -v ' 1 '
++Or if you use
++.Xr ttf2pt1_convert 1
++it will do that for you automatically
+ plus it will also give the exact list of files with duplicate UIDs.
+-.Ip "\(bu" 2
+-\f(CW\fB-v \fIsize\fR\fR\fR \- Re-scale the font to get the size of a typical uppercase
++.It Fl v Ar size
++Re-scale the font to get the size of a typical uppercase
+ letter somewhere around the specified size. Actually, it re-scales
+ the whole font to get the size of one language-dependent letter to be
+-at least of the specified size. Now this letter is \*(L"A\*(R" in all the
++at least of the specified size. Now this letter is
++.Qq A
++in all the
+ supported languages. The size is specified in the points of the
+ Type 1 coordinate grids, the maximal value is 1000. This is an
+ experimental option and should be used with caution. It tries to
+@@ -577,246 +595,184 @@ look out of scale. As of now the interesting values of size for
+ this option seem to be located mostly between 600 and 850. This
+ re-scaling may be quite useful but needs more experience to
+ understand the balance of its effects.
+-.Ip "\(bu" 2
+-\f(CW\fB-W \fIlevel\fR\fR\fR \- Select the verbosity level of the warnings.
++.It Fl W Ar level
++Select the verbosity level of the warnings.
+ Currently the levels from 0 to 4 are supported. Level 0 means no warnings
+ at all, level 4 means all the possible warnings. The default level is 3.
+ Other levels may be added in the future, so using the level number 99 is
+ recommended to get all the possible warnings. Going below level 2 is
+ not generally recommended because you may miss valuable information about
+ the problems with the fonts being converted.
+-.Ip "\(bu" 2
+-\fBObsolete option:\fR
+-\f(CW\fB-A\fR\fR \- Print the font metrics (.afm file) instead of the font on \s-1STDOUT\s0.
+-Use \fB\-\s-1GA\s0\fR instead.
+-.Ip "\(bu" 2
+-\fBVery obsolete option:\fR
+-.Sp
+-The algorithm that implemented the forced fixed width had major
+-flaws, so it was disabled. The code is still in the program and
+-some day it will be refined and returned back. Meanwhile the 
+-option name \*(L'\fB\-f\fR\*(R' was reused for another option. The old version was:
+-.Sp
+-\f(CW\fB-f\fR\fR \- Don't try to force the fixed width of font. Normally the converter
+-considers the fonts in which the glyph width deviates by not more
+-than 5% as buggy fixed width fonts and forces them to have really
+-fixed width. If this is undesirable, it can be disabled by this option.
+-.PP
+-The \f(CW.pfa\fR font format supposes that the description of the characters
++.El
++
++The
++.Sq .pfa
++font format supposes that the description of the characters
+ is binary encoded and encrypted. This converter does not encode or
+-encrypt the data by default, you have to specify the option \*(L'\fB\-e\fR\*(R'
+-or use the \f(CWt1asm\fR program to assemble (that means, encode and
+-encrypt) the font program. The \f(CWt1asm\fR program that is included with
+-the converter is actually a part of the \f(CWt1utils\fR package, rather old
+-version of which may be obtained from
+-.PP
+-http://ttf2pt1.sourceforge.net/t1utils.tar.gz
+-.PP
+-Note that \f(CWt1asm\fR from the old version of that package won't work properly
+-with the files generated by \f(CWttf2pt1\fR version 3.20 and later. Please use
+-\f(CWt1asm\fR packaged with \f(CWttf2pt1\fR or from the new version \f(CWt1utils\fR
+-instead. For a newer version of \f(CWt1utils\fR please look at
+-.PP
+-http://www.lcdf.org/~eddietwo/type/
+-.SH "EXAMPLES"
++encrypt the data by default, you have to specify the option
++.Fl e
++.Nm t1asm
++program to assemble
++.Pq that means, encode and encrypt
++the font program. The
++.Nm t1asm
++program that is included with
++the converter is actually a part of the
++.Nm t1utils
++package, rather old version of which may be obtained from
++
++.Lk http://ttf2pt1.sourceforge.net/t1utils.tar.gz
++
++Note that
++.Nm t1asm
++from the old version of that package won't work properly
++with the files generated by
++.Nm
++version 3.20 and later. Please use
++.Nm t1asm
++packaged with
++.Nm
++or from the new version
++.Nm t1utils
++instead. For a newer version of
++.Nm t1utils
++please look at
++
++.Lk http://www.lcdf.org/~eddietwo/type/
++
++.Sh EXAMPLES
+ So, the following command lines:
+-.PP
+-\f(CWttf2pt1 -e ttffont.ttf t1font\fR
+-.PP
+-\f(CWttf2pt1 ttffont.ttf - | t1asm >t1font.pfa\fR
+-.PP
+-represent two ways to get a working font. The benefit of the second form 
++
++.D1 ttf2pt1 -e ttffont.ttf t1font
++
++.D1 ttf2pt1 ttffont.ttf - | t1asm > t1font.pfa
++
++represent two ways to get a working font. The benefit of the second form
+ is that other filters may be applied to the font between the converter
+ and assembler.
+-.SH "FILES"
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_LIBXDIR/\s0t1asm
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR\s0/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/\s0scripts/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/\s0other/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/README\s0
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/FONTS\s0
+-.SH "SEE ALSO"
+-.Ip "\(bu" 4
+-the \fIttf2pt1_convert(1)\fR manpage
+-.Ip "\(bu" 4
+-the \fIttf2pt1_x2gs(1)\fR manpage
+-.Ip "\(bu" 4
+-the \fIt1asm(1)\fR manpage
+-.Ip "\(bu" 4
+-ttf2pt1-announce@lists.sourceforge.net
+-.Sp
+-The mailing list with announcements about ttf2pt1. It is a moderated mailing
+-with extremely low traffic. Everyone is encouraged to subscribe to keep in 
++.Sh FILES
++.Bl -tag
++.It Pa /usr/share/examples/ttf2ps1/*
++.It Pa /usr/share/examples/ttf2ps1/scripts/*
++.It Pa /usr/share/examples/ttf2ps1/other/*
++.It Pa /usr/share/examples/ttf2ps1/README
++.It Pa /usr/share/examples/ttf2ps1/FONTS
++.El
++.Sh SEE ALSO
++.Bl -tag
++.It Xr ttf2pt1_convert 1
++.It Xr ttf2pt1_x2gs 1
++.It Mt ttf2pt1-announce@lists.sourceforge.net
++The mailing list with announcements about
++.Nm .
++It is a moderated mailing
++with extremely low traffic. Everyone is encouraged to subscribe to keep in
+ touch with the current status of project. To subscribe use the Web interface
+-at http://lists.sourceforge.net/mailman/listinfo/ttf2pt1-announce.
+-If you have only e-mail access to the Net then send a subscribe request to 
+-the development mailing list ttf2pt1-devel@lists.sourceforge.net and somebody
+-will help you with subscription.
+-.Ip "\(bu" 4
+-ttf2pt1-devel@lists.sourceforge.net
+-.Sp
+-ttf2pt1-users@lists.sourceforge.net
+-.Sp
++at
++.Lk http://lists.sourceforge.net/mailman/listinfo/ttf2pt1-announce .
++If you have only e-mail access to the Net then send a subscribe request to
++the development mailing list
++.Mt ttf2pt1-devel@lists.sourceforge.net
++and somebody will help you with subscription.
++.It Mt ttf2pt1-devel@lists.sourceforge.net
++.It Mt ttf2pt1-users@lists.sourceforge.net
+ The ttf2pt1 mailing lists for development and users issues. They have not
+ that much traffic either. To subscribe use the Web interface at
+-http://lists.sourceforge.net/mailman/listinfo/ttf2pt1-devel
+-and http://lists.sourceforge.net/mailman/listinfo/ttf2pt1-users.
+-If you have only e-mail access to the Net then send a subscribe request to 
+-the development mailing list ttf2pt1-devel@lists.sourceforge.net and somebody
+-will help you with subscription.
+-.Ip "\(bu" 4
+-http://ttf2pt1.sourceforge.net
+-.Sp
++.Lk http://lists.sourceforge.net/mailman/listinfo/ttf2pt1-devel
++and
++.Lk http://lists.sourceforge.net/mailman/listinfo/ttf2pt1-users .
++If you have only e-mail access to the Net then send a subscribe request to
++the development mailing list
++.Mt ttf2pt1-devel@lists.sourceforge.net
++and somebody will help you with subscription.
++.It Lk http://ttf2pt1.sourceforge.net
+ The main page of the project.
+-.Sp
+-http://www.netspace.net.au/~mheath/ttf2pt1/
+-.Sp
++.It Lk http://www.netspace.net.au/~mheath/ttf2pt1/
+ The old main page of the project.
+-.SH "BUGS"
+-It seems that many Eastern fonts use features of the TTF format that are 
+-not supported by the ttf2pt1's built-in front-end parser. Because of
+-this for now we recommend using the FreeType-based parser (option
+-\&\*(R'\fB\-p ft\fR') with the \*(L"\f(CWplane\fR\*(R" language.
+-.Sh "Troubleshooting and bug reports"
+-Have problems with conversion of some font ? The converter dumps core ? Or your
+-printer refuses to understand the converted fonts ? Or some characters are 
+-missing ? Or some characters look strange ?
+-.PP
+-Send the bug reports to the ttf2pt1 development mailing list at
+-ttf2pt1-devel@lists.sourceforge.net.
+-.PP
++.Sh BUGS
++It seems that many Eastern fonts use features of the TTF format that are
++not supported by the
++.Nm
++.Ap
++s built-in front-end parser. Because of
++this for now we recommend using the FreeType-based parser
++.Po
++option
++.Fl p
++.Pc with the
++.Ar plane
++language.
++.Ss "Troubleshooting and bug reports"
++Have problems with conversion of some font? The converter dumps core? Or your
++printer refuses to understand the converted fonts? Or some characters are
++missing? Or some characters look strange?
++
++Send the bug reports to the
++.Nm
++development mailing list at
++.Lk ttf2pt1-devel@lists.sourceforge.net.
++
+ Try to collect more information about the problem and include it into
+ the bug report. (Of course, even better if you would provide a ready
+ fix, but just a detailed bug report is also good). Provide detailed
+ information about your problem, this will speed up the response greatly.
+-Don't just write \*(L"this font looks strange after conversion\*(R" but describe
++Don
++.Ap
++t just write
++.Dq this font looks strange after conversion
++but describe
+ what's exactly wrong with it: for example, what characters look wrong
+ and what exactly is wrong about their look. Providing a link to the
+ original font file would be also a good idea. Try to do a little
+ troublehooting and report its result. This not only would help with
+ the fix but may also give you a temporary work-around for the bug.
+-.PP
+-First, enable full warnings with option \*(L'\fB\-W99\fR\*(R', save them to
++
++First, enable full warnings with option
++.Fl W99
++, save them to
+ a file and read carefully. Sometimes the prolem is with a not implemented
+ feature which is reported in the warnings. Still, reporting about such
+ problems may be a good idea: some features were missed to cut corners,
+ in hope that no real font is using them. So a report about a font using
+ such a feature may motivate someone to implement it. Of course, you
+ may be the most motivated person: after all, you are the one wishing
+-to convert that font. ;\-) Seriously, the philosophy \*(L"scrath your own itch\*(R"
++to convert that font. ;\-) Seriously, the philosophy
++.Dq scratch your own itch
+ seems to be the strongest moving force behind the Open Source software.
+-.PP
++
+ The next step is playing with the options. This serves a dual purpose:
+ on one hand, it helps to localize the bug, on the other hand you may be
+ able to get a working version of the font for the meantime while the
+-bug is being fixed. The typical options to try out are: first \*(L'\fB\-Ou\fR\*(R', if
+-it does not help then \*(L'\fB\-Os\fR\*(R', then \*(L'\fB\-Oh\fR\*(R', then \*(L'\fB\-Oo\fR\*(R'.
++bug is being fixed. The typical options to try out are: first
++.FlOu
++, if it does not help then
++.Fl Os
++, then
++.Fl Oh
++, then
++.Fl Oo .
+ They are described in a bit more detail above. Try them one by one
+ and in combinations. See if with them the resulting fonts look better.
+-.PP
+-On some fonts ttf2pt1 just crashes. Commonly that happens because the
++
++On some fonts
++.Nm
++just crashes. Commonly that happens because the
+ font being converted is highly defective (although sometimes the bug
+-is in ttf2pt1 itself). In any case it should not crash, so the reports
++is in
++.Nm itself). In any case it should not crash, so the reports
+ about such cases will help to handle these defects properly in future.
+-.PP
+-We try to respond to the bug reports in a timely fashion but alas, this 
++
++We try to respond to the bug reports in a timely fashion but alas, this
+ may not always be possible, especially if the problem is complex.
+ This is a volunteer project and its resources are limited. Because
+ of this we would appreciate bug reports as detailed as possible,
+ and we would appreciate the ready fixes and contributions even more.
+-.SH "HISTORY"
++.Sh HISTORY
+ Based on ttf2pfa by Andrew Weeks, and help from Frank Siegert.
+-.PP
+-Modification by Mark Heath.
+-.PP
+-Further modification by Sergey Babkin.
+-.PP
+-The Type1 assembler by I. Lee Hetherington with modifications by 
+-Kai-Uwe Herbing.
+-
+-.rn }` ''
+-.IX Title "TTF2PT1 1"
+-.IX Name "TTF2PT1 - A True Type to PostScript Type 1 Font Converter"
+-
+-.IX Header "NAME"
+-
+-.IX Header "SYNOPSIS"
+-
+-.IX Header "DESCRIPTION"
+-
+-.IX Header "OPTIONS"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+ 
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "EXAMPLES"
+-
+-.IX Header "FILES"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "SEE ALSO"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "BUGS"
+-
+-.IX Subsection "Troubleshooting and bug reports"
++Modification by Mark Heath.
+ 
+-.IX Header "HISTORY"
++Further modification by Sergey Babkin.
+ 
++The Type1 assembler by I. Lee Hetherington with modifications by
++Kai-Uwe Herbing.

--- a/srcpkgs/ttf2pt1/patches/004-ttf2pt1_x2gs-man-page-rewrite.patch
+++ b/srcpkgs/ttf2pt1/patches/004-ttf2pt1_x2gs-man-page-rewrite.patch
@@ -1,0 +1,429 @@
+--- ttf2pt1_x2gs.1
++++ ttf2pt1_x2gs.1
+@@ -1,313 +1,128 @@
+-.rn '' }`
+-''' $RCSfile$$Revision$$Date$
+-'''
+-''' $Log$
+-'''
+-.de Sh
+-.br
+-.if t .Sp
+-.ne 5
+-.PP
+-\fB\\$1\fR
+-.PP
+-..
+-.de Sp
+-.if t .sp .5v
+-.if n .sp
+-..
+-.de Ip
+-.br
+-.ie \\n(.$>=3 .ne \\$3
+-.el .ne 3
+-.IP "\\$1" \\$2
+-..
+-.de Vb
+-.ft CW
+-.nf
+-.ne \\$1
+-..
+-.de Ve
+-.ft R
+-
+-.fi
+-..
+-'''
+-'''
+-'''     Set up \*(-- to give an unbreakable dash;
+-'''     string Tr holds user defined translation string.
+-'''     Bell System Logo is used as a dummy character.
+-'''
+-.tr \(*W-|\(bv\*(Tr
+-.ie n \{\
+-.ds -- \(*W-
+-.ds PI pi
+-.if (\n(.H=4u)&(1m=24u) .ds -- \(*W\h'-12u'\(*W\h'-12u'-\" diablo 10 pitch
+-.if (\n(.H=4u)&(1m=20u) .ds -- \(*W\h'-12u'\(*W\h'-8u'-\" diablo 12 pitch
+-.ds L" ""
+-.ds R" ""
+-'''   \*(M", \*(S", \*(N" and \*(T" are the equivalent of
+-'''   \*(L" and \*(R", except that they are used on ".xx" lines,
+-'''   such as .IP and .SH, which do another additional levels of
+-'''   double-quote interpretation
+-.ds M" """
+-.ds S" """
+-.ds N" """""
+-.ds T" """""
+-.ds L' '
+-.ds R' '
+-.ds M' '
+-.ds S' '
+-.ds N' '
+-.ds T' '
+-'br\}
+-.el\{\
+-.ds -- \(em\|
+-.tr \*(Tr
+-.ds L" ``
+-.ds R" ''
+-.ds M" ``
+-.ds S" ''
+-.ds N" ``
+-.ds T" ''
+-.ds L' `
+-.ds R' '
+-.ds M' `
+-.ds S' '
+-.ds N' `
+-.ds T' '
+-.ds PI \(*p
+-'br\}
+-.\"	If the F register is turned on, we'll generate
+-.\"	index entries out stderr for the following things:
+-.\"		TH	Title 
+-.\"		SH	Header
+-.\"		Sh	Subsection 
+-.\"		Ip	Item
+-.\"		X<>	Xref  (embedded
+-.\"	Of course, you have to process the output yourself
+-.\"	in some meaninful fashion.
+-.if \nF \{
+-.de IX
+-.tm Index:\\$1\t\\n%\t"\\$2"
+-..
+-.nr % 0
+-.rr F
+-.\}
+-.TH TTF2PT1_X2GS 1 "version 3.4.4" "December 31, 2003" "TTF2PT1 Font Converter"
+-.UC
+-.if n .hy 0
+-.if n .na
+-.ds C+ C\v'-.1v'\h'-1p'\s-2+\h'-1p'+\s0\v'.1v'\h'-1p'
+-.de CQ          \" put $1 in typewriter font
+-.ft CW
+-'if n "\c
+-'if t \\&\\$1\c
+-'if n \\&\\$1\c
+-'if n \&"
+-\\&\\$2 \\$3 \\$4 \\$5 \\$6 \\$7
+-'.ft R
+-..
+-.\" @(#)ms.acc 1.5 88/02/08 SMI; from UCB 4.2
+-.	\" AM - accent mark definitions
+-.bd B 3
+-.	\" fudge factors for nroff and troff
+-.if n \{\
+-.	ds #H 0
+-.	ds #V .8m
+-.	ds #F .3m
+-.	ds #[ \f1
+-.	ds #] \fP
+-.\}
+-.if t \{\
+-.	ds #H ((1u-(\\\\n(.fu%2u))*.13m)
+-.	ds #V .6m
+-.	ds #F 0
+-.	ds #[ \&
+-.	ds #] \&
+-.\}
+-.	\" simple accents for nroff and troff
+-.if n \{\
+-.	ds ' \&
+-.	ds ` \&
+-.	ds ^ \&
+-.	ds , \&
+-.	ds ~ ~
+-.	ds ? ?
+-.	ds ! !
+-.	ds /
+-.	ds q
+-.\}
+-.if t \{\
+-.	ds ' \\k:\h'-(\\n(.wu*8/10-\*(#H)'\'\h"|\\n:u"
+-.	ds ` \\k:\h'-(\\n(.wu*8/10-\*(#H)'\`\h'|\\n:u'
+-.	ds ^ \\k:\h'-(\\n(.wu*10/11-\*(#H)'^\h'|\\n:u'
+-.	ds , \\k:\h'-(\\n(.wu*8/10)',\h'|\\n:u'
+-.	ds ~ \\k:\h'-(\\n(.wu-\*(#H-.1m)'~\h'|\\n:u'
+-.	ds ? \s-2c\h'-\w'c'u*7/10'\u\h'\*(#H'\zi\d\s+2\h'\w'c'u*8/10'
+-.	ds ! \s-2\(or\s+2\h'-\w'\(or'u'\v'-.8m'.\v'.8m'
+-.	ds / \\k:\h'-(\\n(.wu*8/10-\*(#H)'\z\(sl\h'|\\n:u'
+-.	ds q o\h'-\w'o'u*8/10'\s-4\v'.4m'\z\(*i\v'-.4m'\s+4\h'\w'o'u*8/10'
+-.\}
+-.	\" troff and (daisy-wheel) nroff accents
+-.ds : \\k:\h'-(\\n(.wu*8/10-\*(#H+.1m+\*(#F)'\v'-\*(#V'\z.\h'.2m+\*(#F'.\h'|\\n:u'\v'\*(#V'
+-.ds 8 \h'\*(#H'\(*b\h'-\*(#H'
+-.ds v \\k:\h'-(\\n(.wu*9/10-\*(#H)'\v'-\*(#V'\*(#[\s-4v\s0\v'\*(#V'\h'|\\n:u'\*(#]
+-.ds _ \\k:\h'-(\\n(.wu*9/10-\*(#H+(\*(#F*2/3))'\v'-.4m'\z\(hy\v'.4m'\h'|\\n:u'
+-.ds . \\k:\h'-(\\n(.wu*8/10)'\v'\*(#V*4/10'\z.\v'-\*(#V*4/10'\h'|\\n:u'
+-.ds 3 \*(#[\v'.2m'\s-2\&3\s0\v'-.2m'\*(#]
+-.ds o \\k:\h'-(\\n(.wu+\w'\(de'u-\*(#H)/2u'\v'-.3n'\*(#[\z\(de\v'.3n'\h'|\\n:u'\*(#]
+-.ds d- \h'\*(#H'\(pd\h'-\w'~'u'\v'-.25m'\f2\(hy\fP\v'.25m'\h'-\*(#H'
+-.ds D- D\\k:\h'-\w'D'u'\v'-.11m'\z\(hy\v'.11m'\h'|\\n:u'
+-.ds th \*(#[\v'.3m'\s+1I\s-1\v'-.3m'\h'-(\w'I'u*2/3)'\s-1o\s+1\*(#]
+-.ds Th \*(#[\s+2I\s-2\h'-\w'I'u*3/5'\v'-.3m'o\v'.3m'\*(#]
+-.ds ae a\h'-(\w'a'u*4/10)'e
+-.ds Ae A\h'-(\w'A'u*4/10)'E
+-.ds oe o\h'-(\w'o'u*4/10)'e
+-.ds Oe O\h'-(\w'O'u*4/10)'E
+-.	\" corrections for vroff
+-.if v .ds ~ \\k:\h'-(\\n(.wu*9/10-\*(#H)'\s-2\u~\d\s+2\h'|\\n:u'
+-.if v .ds ^ \\k:\h'-(\\n(.wu*10/11-\*(#H)'\v'-.4m'^\v'.4m'\h'|\\n:u'
+-.	\" for low resolution devices (crt and lpr)
+-.if \n(.H>23 .if \n(.V>19 \
+-\{\
+-.	ds : e
+-.	ds 8 ss
+-.	ds v \h'-1'\o'\(aa\(ga'
+-.	ds _ \h'-1'^
+-.	ds . \h'-1'.
+-.	ds 3 3
+-.	ds o a
+-.	ds d- d\h'-1'\(ga
+-.	ds D- D\h'-1'\(hy
+-.	ds th \o'bp'
+-.	ds Th \o'LP'
+-.	ds ae ae
+-.	ds Ae AE
+-.	ds oe oe
+-.	ds Oe OE
+-.\}
+-.rm #[ #] #H #V #F C
+-.SH "NAME"
+-\fBttf2pt1_x2gs\fR \- font installer for Ghostscript
+-.SH "SYNOPSIS"
+-ttf2pt1_x2gs \fB[config-file]\fR
+-.SH "DESCRIPTION"
+-The fonts generated with \fBttf2pt1\fR work fine with Ghostscript by
+-themselves. The script `\fBx2gs\fR\*(R' (or `\fBttf2pt1_x2gs\fR\*(R' when installed
+-into a public directory, to avoid name conflicts with other
+-programs) links the font files from the X11 direcotry into the Ghostscript 
+-directory and automatically creates the description file (\f(CWFontmap\fR) 
++.\" TTF2PT1_X2GS 1 "version 3.4.4" "December 31, 2003" "TTF2PT1 Font Converter"
++
++.Dd December 31, 2003
++.Dt TTF2PT1_X2GS 1
++.Os
++.Sh NAME
++.Nm ttf2pt1_x2gs
++.Nd font installer for Ghostscript
++.Sh SYNOPSIS
++.Nm
++.Op Ar config-file
++.Sh DESCRIPTION
++The fonts generated with
++.Xr ttf2pt1 1
++work fine with Ghostscript by
++themselves. The script
++.Nm
++links the font files from the X11 direcotry into the Ghostscript
++directory and automatically creates the description file
++.Sq Fontmap
+ in Ghostscript format.
+-.PP
++
+ If the configuration file is not specified as an argument then the file
+-`\f(CWconvert.cfg\fR\*(R' in the current directory is used, just like the
+-`\f(CWconvert\fR\*(R' script does. Indeed, this configuration file is used for 
+-both scripts.
+-.PP
++.Pa ./convert.cfg
++is used, just like
++.Xr ttf2pt1_convert 1
++does. Indeed, this configuration file is used for both scripts.
++
+ The Ghostscript-related parameters in the configuration file are:
+-.PP
+-\fB\f(CWDSTDIR\fR\fR \- the X11 font directory used by `\f(CWx2gs\fR\*(R' as the
+-source of the fonts. This parameter is common with the X11 
++.Bl -tag
++.It Dv DSTDIR
++the X11 font directory used by
++.Nm
++as the source of the fonts. This parameter is common with the X11
+ configuration.
+-.PP
+-\fB\f(CWGSDIR\fR\fR \- the base directory of Ghostsript. If this
+-parameter is set to an empty string then `\f(CWconvert\fR\*(R' won't
+-call `\f(CWx2gs\fR\*(R'. So if you want to get only the X11 fonts
+-installed then set this parameter to an empty string. This 
+-directory may vary on various system, so please check your 
++.It Dv GSDIR
++the base directory of Ghostsript. If this
++parameter is set to an empty string then
++.Xr ttf2pt1_convert 1
++won't call
++.Nm .
++So if you want to get only the X11 fonts
++installed then set this parameter to an empty string. This
++directory may vary on various system, so please check your
+ system and set this value accordingly before running the script.
+-.PP
+-\fB\f(CWGSFONTDIR\fR\fR \- the font directory of Ghostscript. In the standard
+-Ghostscript installation it's a subdirectory of \f(CWGSDIR\fR 
++.It Dv GSFONTDIR
++the font directory of Ghostscript. In the standard
++Ghostscript installation it's a subdirectory of
++.Dv GSDIR
+ but some systems may use completely different directories.
+-.PP
+-\fB\f(CWGSCONFDIR\fR\fR \- the configuration subdirectory of Ghostscript
+-that contains the \f(CWFontmap\fR file.
+-.PP
+-\fB\f(CWINSTALLFONTMAP\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then 
+-install the entries for the new fonts right into the main 
+-\f(CWFontmap\fR file. Otherwise just leave the file \f(CWFontmap.ttf\fR 
++.It Dv GSCONFDIR
++the configuration subdirectory of Ghostscript
++that contains the
++.Sq Fontmap
++file.
++
++.It Dv INSTALLFONTMAP
++if the value is set to
++.Sy YES
++then install the entries for the new fonts right into the main
++.Sq Fontmap
++file. Otherwise just leave the file
++.Sq Fontmap.ttf
+ in the Ghostscript configuration directory.
+-.PP
+-After preparing the configuration file run the script. It symbolicaly links 
+-all the font files and creates the description file \f(CWFontmap.ttf\fR in 
+-\f(CWGSCONDFIR\fR. After that there are two choices. 
+-.PP
+-If the option \f(CWINSTALLFONTMAP\fR was set to \f(CWYES\fR then 
+-the font descriptions are also automatically installed into the
+-master \f(CWFontmap\fR file. The script is clever enough to
+-detect if it was run multiple times with the same directories
+-and if so it replaces the old \f(CWFontmap\fR entries with
+-the new ones instead of just accumulating all of them. You
++.El
++
++After preparing the configuration file run the script. It symbolicaly links
++all the font files and creates the description file
++.Sq Fontmap.ttf
++in
++.Sv GSCONDFIR .
++After that there are two choices:
++
++If the option
++.Dv INSTALLFONTMAP
++was set to
++.Sy YES
++then the font descriptions are also automatically installed into the master
++.Sq Fontmap
++file. The script is clever enough to detect if it was run multiple times
++with the same directories and if so it replaces the old
++.Sq Fontmap
++entries with the new ones instead of just accumulating all of them. You
+ may also run it multiple times for multiple X11 directories
+-and all the results will be properly collected in the \f(CWFontmap\fR.
++and all the results will be properly collected in the
++.Sq Fontmap .
+ But it's your responsibility to watch that the names of the
+ font files don't overlap. If the X11 font directory gets
+ renamed then you have to remove its font entries from the
+-\f(CWFontmap\fR and only after that re-run `\f(CWx2gs\fR\*(R'
+-for the new directory. 
+-.PP
+-On the other hand if the option \f(CWINSTALLFONTMAP\fR was set to 
+-\f(CWNO\fR then go to the \f(CWGSCONFDIR\fR directory and insert the 
+-contents of \f(CWFontmap.ttf\fR into the \f(CWFontmap\fR file
+-manually. This step may be left manual to make the installation
+-a little bit more safe. 
+-.PP
+-After that you may also want to redefine some of the aliases in 
+-\f(CWFontmap\fR to refer to the newly installed fonts.
++.Sq Fontmap
++and only after that re-run
++.Xr ttf2pt1_x2gs 1
++for the new directory.
++
++On the other hand if the option
++.Dv INSTALLFONTMAP
++was set to
++.Sy NO
++then go to the
++.Dv GSCONFDIR
++directory and insert the contents of
++.Sq Fontmap.ttf
++into the
++.Sq Fontmap
++file manually. This step may be left manual to make the installation
++a little bit more safe.
++
++After that you may also want to redefine some of the aliases in
++.Sq Fontmap
++to refer to the newly installed fonts.
+ But the redefinition of the aliases may be dangerous if the width of
+ characters in the new font will be different from the old font.
+ Alas, there is no visible solution of this problem yet.
+-.SH "FILES"
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/\s0scripts/convert.cfg.sample
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/\s0scripts/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/README\s0
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/FONTS\s0
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR\s0/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_BINDIR/\s0ttf2pt1
+-.SH "SEE ALSO"
+-.Ip "\(bu" 4
+-the \fIttf2pt1(1)\fR manpage
+-.Ip "\(bu" 4
+-the \fIttf2pt1_convert(1)\fR manpage
+-.Ip "\(bu" 4
+-the \fIt1asm(1)\fR manpage
+-
+-.rn }` ''
+-.IX Title "TTF2PT1_X2GS 1"
+-.IX Name "B<ttf2pt1_x2gs> - font installer for Ghostscript"
+-
+-.IX Header "NAME"
+-
+-.IX Header "SYNOPSIS"
+-
+-.IX Header "DESCRIPTION"
+-
+-.IX Header "FILES"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "SEE ALSO"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
++.Sh FILES
++.Bl -tag
++.It Pa /usr/share/examples/ttf2pt1/scripts/convert.cfg.sample
++.It Pa /usr/share/examples/ttf2pt1/scripts/*
++.It Pa /usr/share/examples/ttf2pt1/README
++.It Pa /usr/share/examples/ttf2pt1/FONTS
++.It Pa /usr/share/examples/ttf2pt1/*
++.It Pa /usr/bin/ttf2pt1
++.El
++.Sh SEE ALSO
++.Bl -tag
++.It Xr ttf2pt1 1
++.It ttf2pt1_convert 1
++.El
+ 

--- a/srcpkgs/ttf2pt1/patches/005-ttf2pt1_convert-man-page-rewrite.patch
+++ b/srcpkgs/ttf2pt1/patches/005-ttf2pt1_convert-man-page-rewrite.patch
@@ -1,0 +1,725 @@
+--- ttf2pt1_convert.1
++++ ttf2pt1_convert.1
+@@ -1,210 +1,33 @@
+-.rn '' }`
+-''' $RCSfile$$Revision$$Date$
+-'''
+-''' $Log$
+-'''
+-.de Sh
+-.br
+-.if t .Sp
+-.ne 5
+-.PP
+-\fB\\$1\fR
+-.PP
+-..
+-.de Sp
+-.if t .sp .5v
+-.if n .sp
+-..
+-.de Ip
+-.br
+-.ie \\n(.$>=3 .ne \\$3
+-.el .ne 3
+-.IP "\\$1" \\$2
+-..
+-.de Vb
+-.ft CW
+-.nf
+-.ne \\$1
+-..
+-.de Ve
+-.ft R
++.\" TTF2PT1_CONVERT 1 "version 3.4.4" "December 31, 2003" "TTF2PT1 Font Converter"
++.Dd December 31, 2003
++.Dt TTF2PT1_CONVERT 1
++.Os
++.Sh NAME
++.Nm ttf2pt1_convert
++.Nd convenience font conversion script
++.Sh SYNOPSIS
++.Nm
++.Op Ar config-file
++.Sh DESCRIPTION
++.Nm is the master conversion script provided with
++.Xr ttf2pt1 1 .
+ 
+-.fi
+-..
+-'''
+-'''
+-'''     Set up \*(-- to give an unbreakable dash;
+-'''     string Tr holds user defined translation string.
+-'''     Bell System Logo is used as a dummy character.
+-'''
+-.tr \(*W-|\(bv\*(Tr
+-.ie n \{\
+-.ds -- \(*W-
+-.ds PI pi
+-.if (\n(.H=4u)&(1m=24u) .ds -- \(*W\h'-12u'\(*W\h'-12u'-\" diablo 10 pitch
+-.if (\n(.H=4u)&(1m=20u) .ds -- \(*W\h'-12u'\(*W\h'-8u'-\" diablo 12 pitch
+-.ds L" ""
+-.ds R" ""
+-'''   \*(M", \*(S", \*(N" and \*(T" are the equivalent of
+-'''   \*(L" and \*(R", except that they are used on ".xx" lines,
+-'''   such as .IP and .SH, which do another additional levels of
+-'''   double-quote interpretation
+-.ds M" """
+-.ds S" """
+-.ds N" """""
+-.ds T" """""
+-.ds L' '
+-.ds R' '
+-.ds M' '
+-.ds S' '
+-.ds N' '
+-.ds T' '
+-'br\}
+-.el\{\
+-.ds -- \(em\|
+-.tr \*(Tr
+-.ds L" ``
+-.ds R" ''
+-.ds M" ``
+-.ds S" ''
+-.ds N" ``
+-.ds T" ''
+-.ds L' `
+-.ds R' '
+-.ds M' `
+-.ds S' '
+-.ds N' `
+-.ds T' '
+-.ds PI \(*p
+-'br\}
+-.\"	If the F register is turned on, we'll generate
+-.\"	index entries out stderr for the following things:
+-.\"		TH	Title 
+-.\"		SH	Header
+-.\"		Sh	Subsection 
+-.\"		Ip	Item
+-.\"		X<>	Xref  (embedded
+-.\"	Of course, you have to process the output yourself
+-.\"	in some meaninful fashion.
+-.if \nF \{
+-.de IX
+-.tm Index:\\$1\t\\n%\t"\\$2"
+-..
+-.nr % 0
+-.rr F
+-.\}
+-.TH TTF2PT1_CONVERT 1 "version 3.4.4" "December 31, 2003" "TTF2PT1 Font Converter"
+-.UC
+-.if n .hy 0
+-.if n .na
+-.ds C+ C\v'-.1v'\h'-1p'\s-2+\h'-1p'+\s0\v'.1v'\h'-1p'
+-.de CQ          \" put $1 in typewriter font
+-.ft CW
+-'if n "\c
+-'if t \\&\\$1\c
+-'if n \\&\\$1\c
+-'if n \&"
+-\\&\\$2 \\$3 \\$4 \\$5 \\$6 \\$7
+-'.ft R
+-..
+-.\" @(#)ms.acc 1.5 88/02/08 SMI; from UCB 4.2
+-.	\" AM - accent mark definitions
+-.bd B 3
+-.	\" fudge factors for nroff and troff
+-.if n \{\
+-.	ds #H 0
+-.	ds #V .8m
+-.	ds #F .3m
+-.	ds #[ \f1
+-.	ds #] \fP
+-.\}
+-.if t \{\
+-.	ds #H ((1u-(\\\\n(.fu%2u))*.13m)
+-.	ds #V .6m
+-.	ds #F 0
+-.	ds #[ \&
+-.	ds #] \&
+-.\}
+-.	\" simple accents for nroff and troff
+-.if n \{\
+-.	ds ' \&
+-.	ds ` \&
+-.	ds ^ \&
+-.	ds , \&
+-.	ds ~ ~
+-.	ds ? ?
+-.	ds ! !
+-.	ds /
+-.	ds q
+-.\}
+-.if t \{\
+-.	ds ' \\k:\h'-(\\n(.wu*8/10-\*(#H)'\'\h"|\\n:u"
+-.	ds ` \\k:\h'-(\\n(.wu*8/10-\*(#H)'\`\h'|\\n:u'
+-.	ds ^ \\k:\h'-(\\n(.wu*10/11-\*(#H)'^\h'|\\n:u'
+-.	ds , \\k:\h'-(\\n(.wu*8/10)',\h'|\\n:u'
+-.	ds ~ \\k:\h'-(\\n(.wu-\*(#H-.1m)'~\h'|\\n:u'
+-.	ds ? \s-2c\h'-\w'c'u*7/10'\u\h'\*(#H'\zi\d\s+2\h'\w'c'u*8/10'
+-.	ds ! \s-2\(or\s+2\h'-\w'\(or'u'\v'-.8m'.\v'.8m'
+-.	ds / \\k:\h'-(\\n(.wu*8/10-\*(#H)'\z\(sl\h'|\\n:u'
+-.	ds q o\h'-\w'o'u*8/10'\s-4\v'.4m'\z\(*i\v'-.4m'\s+4\h'\w'o'u*8/10'
+-.\}
+-.	\" troff and (daisy-wheel) nroff accents
+-.ds : \\k:\h'-(\\n(.wu*8/10-\*(#H+.1m+\*(#F)'\v'-\*(#V'\z.\h'.2m+\*(#F'.\h'|\\n:u'\v'\*(#V'
+-.ds 8 \h'\*(#H'\(*b\h'-\*(#H'
+-.ds v \\k:\h'-(\\n(.wu*9/10-\*(#H)'\v'-\*(#V'\*(#[\s-4v\s0\v'\*(#V'\h'|\\n:u'\*(#]
+-.ds _ \\k:\h'-(\\n(.wu*9/10-\*(#H+(\*(#F*2/3))'\v'-.4m'\z\(hy\v'.4m'\h'|\\n:u'
+-.ds . \\k:\h'-(\\n(.wu*8/10)'\v'\*(#V*4/10'\z.\v'-\*(#V*4/10'\h'|\\n:u'
+-.ds 3 \*(#[\v'.2m'\s-2\&3\s0\v'-.2m'\*(#]
+-.ds o \\k:\h'-(\\n(.wu+\w'\(de'u-\*(#H)/2u'\v'-.3n'\*(#[\z\(de\v'.3n'\h'|\\n:u'\*(#]
+-.ds d- \h'\*(#H'\(pd\h'-\w'~'u'\v'-.25m'\f2\(hy\fP\v'.25m'\h'-\*(#H'
+-.ds D- D\\k:\h'-\w'D'u'\v'-.11m'\z\(hy\v'.11m'\h'|\\n:u'
+-.ds th \*(#[\v'.3m'\s+1I\s-1\v'-.3m'\h'-(\w'I'u*2/3)'\s-1o\s+1\*(#]
+-.ds Th \*(#[\s+2I\s-2\h'-\w'I'u*3/5'\v'-.3m'o\v'.3m'\*(#]
+-.ds ae a\h'-(\w'a'u*4/10)'e
+-.ds Ae A\h'-(\w'A'u*4/10)'E
+-.ds oe o\h'-(\w'o'u*4/10)'e
+-.ds Oe O\h'-(\w'O'u*4/10)'E
+-.	\" corrections for vroff
+-.if v .ds ~ \\k:\h'-(\\n(.wu*9/10-\*(#H)'\s-2\u~\d\s+2\h'|\\n:u'
+-.if v .ds ^ \\k:\h'-(\\n(.wu*10/11-\*(#H)'\v'-.4m'^\v'.4m'\h'|\\n:u'
+-.	\" for low resolution devices (crt and lpr)
+-.if \n(.H>23 .if \n(.V>19 \
+-\{\
+-.	ds : e
+-.	ds 8 ss
+-.	ds v \h'-1'\o'\(aa\(ga'
+-.	ds _ \h'-1'^
+-.	ds . \h'-1'.
+-.	ds 3 3
+-.	ds o a
+-.	ds d- d\h'-1'\(ga
+-.	ds D- D\h'-1'\(hy
+-.	ds th \o'bp'
+-.	ds Th \o'LP'
+-.	ds ae ae
+-.	ds Ae AE
+-.	ds oe oe
+-.	ds Oe OE
+-.\}
+-.rm #[ #] #H #V #F C
+-.SH "NAME"
+-\fBttf2pt1_convert\fR \- convenience font conversion script
+-.SH "SYNOPSIS"
+-ttf2pt1_convert \fB[config-file]\fR
+-.SH "DESCRIPTION"
+-`\fBConvert\fR\*(R' is the master conversion script provided with ttf2pt1. 
+-When installed into a public directory it's named `\fBttf2pt1_convert\fR\*(R' 
+-to avoid name collisions with the other programs.
+-.PP
+ If the configuration file is not specified as an argument then the file
+-`\f(CWconvert.cfg\fR\*(R' in the current directory is used. This file contains
++.Pa ./convert.cfg
++is used. This file contains
+ a set of configuration variables. The distribution contains a sample file
+-file `\f(CWconvert.cfg.sample\fR\*(R'. Please copy it to `\f(CWconvert.cfg\fR\*(R',
++file
++.Pa /usr/share/examples/ttf2pt1/scripts/convert.cfg.sample .
++Please copy it to
++.PA ./convert.cfg ,
+ look inside it and change the configuration variables. The more stable
+ configuration variables, such as the path names of the scripts and
+-encoding files are located in `\f(CWconvert\fR\*(R' itself, they are
+-automatically updated when installing \fBttf2pt1\fR.
+-.PP
++encoding files are located in
++.Nm
++itself, they are
++automatically updated when installing
++.Xr ttf2pt1 1 .
++
+ Put all the TTF fonts you want to convert into some directory (this
+ may be just the directory that already contains all the Windows
+ fonts on a mounted FAT filesystem). If you have fonts in different
+@@ -213,294 +36,245 @@ into a separate directory. Up to 10 source directories are
+ supported. If you (in a rather unlikely case) have more source
+ directories then you can make two separate runs of the converter,
+ converting up to 10 directories at a time.
+-.PP
++
+ The variables in the configuration file are:
+-.Ip "\(bu" 2
+-\fB\f(CWSRCDIRS\fR\fR \- the list of directories (with absolute paths) with 
+-\s-1TTF\s0 fonts. Each line contains at least 3 fields: the name of the directory,
+-the language of the fonts in it (if you have fonts for different 
++.Bl -tag
++.It Dv SRCDIRS
++the list of directories (with absolute paths) with
++TTF fonts. Each line contains at least 3 fields: the name of the directory,
++the language of the fonts in it (if you have fonts for different
+ languages you have to put them into the separate directories) and the
+-encoding of the fonts. Again, if you have some of the \s-1TTF\s0 typefaces in 
+-one encoding, and some in another (say, \s-1CP\s0\-1251 and \s-1KOI\s0\-8), you have 
++encoding of the fonts. Again, if you have some of the TTF typefaces in
++one encoding, and some in another (say, CP-1251 and KOI-8), you have
+ to put them into the separate source directories. Some lines may contain
+ 4 fields. Then the fourth field is the name of the external map to
+ convert the Unicode fonts into the desirable encoding. This map is
+ used instead of the built-in map for the specified language.
+-.Sp
+-*8*
++
+ An interesting thing is that some languages have more than one
+ widely used character encodings. For example, the widely used
+-encodings for Russian are \s-1IBM\s0 \s-1CP\s0\-866 (\s-1MS\s0\-\s-1DOS\s0 and Unix), \s-1KOI\s0\-8
+-(Unix and \s-1VAX\s0, also the standard Internet encoding), \s-1IBM\s0 \s-1CP\s0\-1251 (\s-1MS\s0 Windows).
++encodings for Russian are IBM CP-866 (MS-DOS and Unix), KOI-8
++(Unix and VAX, also the standard Internet encoding), IBM CP-1251 (MS Windows).
+ That's why I have provided the means to generate the converted fonts
+-in more than one encoding. See the file encodings/\s-1README\s0 for 
+-details about the encoding tables. Actually, if you plan to use
++in more than one encoding. See the file
++.Pa /usr/share/examples/ttf2pt1/encodings/README
++for details about the encoding tables. Actually, if you plan to use
+ these fonts with Netscape Navigator better use the aliases
+ cp-866 instead of ibm-866 and windows-1251 instead of ibm-1251
+ because that's what Netscape wants.
+-.Ip "\(bu" 2
+-\fB\f(CWDSTDIR\fR\fR \- directory for the resulting Type1 fonts. Be careful!
++.It Dv DSTDIR
++directory for the resulting Type1 fonts. Be careful!
+ This directory gets completely wiped out before conversion,
+ so don't use any already existing directory for this purpose.
+-.Ip "\(bu" 2
+-\fB\f(CWDSTENC\fI{language}\fR\fR\fR \- the list of encodings in which the destination 
+-fonts will be generated for each language. Each font of that 
++.It Dv DSTENC Ns Ar language
++the list of encodings in which the destination
++fonts will be generated for each language. Each font of that
+ language will be generated in each of the specified
+ encodings. If you don't want any translation, just specify both
+-\f(CWSRCENC\fR and \f(CWDSTENC\fR as iso8859-1 (or if you want any other encoding
++.Dv SRCENC
++and
++.Dv DSTENC
++as iso8859-1
++.Po or if you want any other encoding
+ specified in the fonts.dir, copy the description of 8859-1 with
+-new name and use this new name for \f(CWSRCENC\fR and \f(CWDSTENC\fR).
+-.Ip "\(bu" 2
+-\fB\f(CWFOUNDRY\fR\fR \- the foundry name to be used in the fonts.dir file. I have
+-set it to `fromttf\*(R' to avoid name conflicts with any existing font for
++new name and use this new name for
++.Dv SRCENC
++and
++.Dv DSTENC
++.Pc .
++.It Dv FOUNDRY
++the foundry name to be used in the fonts.dir file. I have
++set it to
++.Sq fromttf
++to avoid name conflicts with any existing font for
+ sure. But this foundry name is not registered in X11 standards and
+ if you want to get the full standard compliance or have a font server
+-that enforces such a compliance, use `misc\*(R'.
+-.PP
++that enforces such a compliance, use
++.Sq misc
++\.
++.El
++
+ The next few parameters control the general behavior of the converter.
+ They default values are set to something reasonable.
+-.Ip "\(bu" 2
+-\fB\f(CWCORRECTWIDTH\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then use the 
+-converter option \f(CW\fB-w\fR\fR, otherwise don't use it. See the description of 
+-this option in the \s-1README\s0 file.
+-.Ip "\(bu" 2
+-\fB\f(CWREMOVET1A\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then after
+-conversion remove the un-encoded \f(CW.t1a\fR font files and the 
+-intermediate \f(CW.xpfa\fR font metric files.
+-.Ip "\(bu" 2
+-\fB\f(CWINSTALLFONTMAP\fR\fR \- a Ghostscript parameter, if the value is set to 
+-\fB\f(CWYES\fR\fR then install the entries for the new fonts
+-right into the main \f(CWFontmap\fR file. Otherwise just leave
+-the file \f(CWFontmap.ttf\fR in the Ghostscript configuration
+-directory.
+-.Ip "\(bu" 2
+-\fB\f(CWHINTSUBST\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR use the option
+-\f(CW\fB-H\fR\fR, otherwise don't use it. This option enables the
+-hint substitution technique. If you have not installed the X11 patch
+-described above, use this option with great caution. See further 
+-description of this option in the \s-1README\s0 file.
+-.Ip "\(bu" 2
+-\fB\f(CWENFORCEISO\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then
+-disguise the resulting fonts as the fonts in ISOLatin1 encoding. Historically
++.Bl -tag
++.It Dv CORRECTWIDTH
++.if the value is set to
++.Sy YES
++then use the converter option
++.Fl w ,
++otherwise don't use it.
++.It Dv REMOVET1A
++if the value is set to
++.Sy YES
++then after conversion remove the un-encoded
++.Sq .t1a font files and the intermediate
++.Sq .xpfa
++font metric files.
++.It Dv INSTALLFONTMAP
++a Ghostscript parameter, if the value is set to
++.Sy YES
++then install the entries for the new fonts
++right into the main
++.Sq Fontmap
++file. Otherwise just leave the file
++.Sq Fontmap.ttf
++in the Ghostscript configuration directory.
++.It HINTSUBST
++if the value is set to
++.Sy YES
++use the option
++.Fl H ,
++otherwise don't use it. This option enables the
++hint substitution technique.
++.It Dv ENFORCEISO
++if the value is set to
++.Sy YES
++then disguise the resulting fonts as the fonts in ISOLatin1 encoding. Historically
+ this was neccessary due to the way the installer scripts created the
+ X11 font configuration files. It is not neccessary any more for this
+ purpose. But if you plan to use these fonts with some other application
+ that expects ISOLatin1 encoding then better enable this option.
+-.Ip "\(bu" 2
+-\fB\f(CWALLGLYPHS\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then
+-include all the glyphs from the source fonts into the resulting fonts, even
+-if these glyphs are inaccessible. If it's set to \fB\f(CWNO\fR\fR then
+-include only the glyphs which have codes assigned to them. The glyphs
++.It Dv ALLGLYPHS
++if the value is set to
++.Sy YES
++then include all the glyphs from the source fonts into the resulting fonts, even
++if these glyphs are inaccessible. If it's set to
++.Sy NO
++then include only the glyphs which have codes assigned to them. The glyphs
+ without codes can not be used directly. But some clever programs,
+ such as the Type 1 library from XFree86 3.9 and higher can change
+-the encoding on the fly and use another set of glyphs. If you have not 
+-installed the X11 patch described above, use this option with great 
+-caution. See further description of the option option \f(CW\fB-a\fR\fR in the 
+-\s-1README\s0 file.
+-.Ip "\(bu" 2
+-\fB\f(CWGENUID\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then use
+-the option \f(CW\fB-uA\fR\fR of the converter to generate UniqueIDs for
+-the converted fonts. The standard X11 Type 1 library does not use
+-this \s-1ID\s0, so it may only be neccessary for the other applications.
++the encoding on the fly and use another set of glyphs.
++.It Dv GENUID
++if the value is set to
++.Sy YES
++then use the option
++.Fl uA
++of the converter to generate UniqueIDs for the converted fonts.
++The standard X11 Type 1 library does not use
++this ID, so it may only be neccessary for the other applications.
+ The script is clever enough to generate different UniqueID for the
+ same font converted to multiple encodings. Also after conversion it
+ checks all the fonts generacted during the session for duplicated
+ UniqueID and shows those. Still, this does not quarantee that these
+ UniqueIDs won't overlap with some other fonts. The UniqueIDs are
+ generated as hash values from the font names, so it's guaranteed
+-that if the `\f(CWconvert\fR\*(R' script runs multiple times it will
+-generate the same UniqueIDs during each run. See further description 
+-of this option in the \s-1README\s0 file.
+-.Ip "\(bu" 2
+-\fB\f(CWGENUID\fR\fR \- if the value is set to \fB\f(CWYES\fR\fR then create
+-the \f(CW.pfb\fR files, otherwise the \f(CW.pfa\fR files. The \f(CW.pfb\fR
++that if
++.Nm
++runs multiple times it will generate the same UniqueIDs during each run.
++.It Dv GENUID
++if the value is set to
++.Sy YES
++then create the
++.Sq .pfb
++files, otherwise create the
++.Sq .pfa
++files. The
++.Sq .pfb
+ files are more compact but contain binary data, so you may experience some
+ troubles when transferring them through the network.
+-.PP
++.El
+ The following parameters are used to locate the other scripts and
+-configuration files. By default the scripts do a bit of guessing for them:
+-they search in the \fBttf2pt1\fR installation directory if \fBttf2pt1\fR
+-was installed or otherwise suppose that you are running `\f(CWconvert\fR\*(R' with
+-`\f(CWscripts\fR\*(R' subdirectory being the current directory.
+-.Ip "\(bu" 2
+-\fB\f(CWENCDIR\fR\fR \- directory containing the descriptions of encodings
+-.Ip "\(bu" 2
+-\fB\f(CWMAPDIR\fR\fR \- directory containing the external map files
+-.PP
+-Besides that a few parameters are built into the `\f(CWconvert\fR\*(R' script itself.
+-You probably won't need to change them:
+-.Ip "\(bu" 2
+-\f(CW\fBT1ASM\fR\fR, \f(CW\fBTTF2PT1\fR\fR, \f(CW\fBTRANS\fR\fR, \f(CW\fBT1FDIR\fR\fR, \f(CW\fBFORCEISO\fR\fR \- paths to the other script
+-.PP
++configuration files.
++.Po These parameters are set to reasonable defaults on Void, and shouldn't need to be modified.
++.Pc
++By default the scripts do a bit of guessing for them:
++they search in the
++.Xr ttf2pt1 1
++installation directory
++.Po
++.Pa /usr/bin/
++.Pc if
++.Xr ttf2pt1 1
++was installed or otherwise suppose that you are running
++.Nm with
++.Pa /usr/share/examples/ttf2pt1/scripts
++subdirectory being the current directory.
++.Bl -tag
++.It ENCDIR
++directory containing the descriptions of encodings
++.It MAPDIR directory containing the external map files
++.El
++Besides that a few parameters are built into the
++.Nm convert
++script itself. You probably won't need to change them:
++.Bl -tag
++.It Dv T1ASM
++.It Dv TTF2PT1
++.It Dv TRANS
++.It Dv T1FDIR
++.It Dv FORCEISO
++paths to the other script
++.El
+ Also there are a few parameters controlling the installation of
+-fonts for Ghostscript. Please look at their description in the 
+-Ghostscript section of documentation or in the \fBttf2pt1_x2gs(1)\fR
+-manual page before running `\f(CWconvert\fR\*(R'. If these parameters are
+-set, `\f(CWconvert\fR\*(R' will call the `\f(CWx2gs\fR\*(R' script automatically
+-to install the newly converted fonts in Ghostscript.
+-.PP
+-After creating the configuration file run the `\f(CWconvert\fR\*(R' script. Look at
+-the result and the log file in \f(CWDSTDIR\fR.
+-.PP
++fonts for Ghostscript. Please look at their description in the
++Ghostscript section of documentation or in the
++.Xr ttf2pt1_x2gs 1
++manual page before running
++.Nm .
++If these parameters are set,
++.Nm
++will call the
++.Xr ttf2pt1_x2gs 1
++script automatically to install the newly converted fonts in Ghostscript.
++
++After creating the configuration file run the
++.Nm
++script. Look at the result and the log file in
++.Dv DSTDIR .
++
+ Add the directory with newly converted fonts to the configuration
+-of X server or font server. For most of the systems this step is
+-very straightforward. For \s-1HP\s0\-\s-1UX\s0 it's rather tricky and poorly
+-documented, so the file \s-1FONTS\s0.hpux gives a short description.
+-.PP
++of X server or font server.
++
+ If you don't have the privileges of the root user, you still can
+ configure your private font server. Just use some non-standard
+-port number (see \s-1FONTS\s0.hpux for an example, exept that you won't
+-need all the \s-1HP\s0\-related stuff on any other system).
+-.SH "FILES"
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/\s0scripts/convert.cfg.sample
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/\s0scripts/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/README\s0
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR/FONTS\s0
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_SHAREDIR\s0/*
+-.Ip "\(bu" 2
+-\s-1TTF2PT1_BINDIR/\s0ttf2pt1
+-.SH "SEE ALSO"
+-.Ip "\(bu" 4
+-the \fIttf2pt1(1)\fR manpage
+-.Ip "\(bu" 4
+-the \fIttf2pt1_x2gs(1)\fR manpage
+-.Ip "\(bu" 4
+-the \fIt1asm(1)\fR manpage
+-.SH "BUGS"
+-.Sh "Known problems"
+-.Ip "\(bu" 4
++port number.
++.Sh FILES
++.Bl -tag
++.It Pa /usr/share/examples/ttf2pt1/scripts/convert.cfg.sample
++.It Pa /usr/share/examples/ttf2pt1/scripts/*
++.It Pa /usr/share/examples/ttf2pt1/FONTS
++.It Pa /usr/share/examples/ttf2pt1/*
++.It Pa /usr/bin/ttf2pt1
++.El
++.Sh SEE ALSO
++.Bl -tag
++.It Xr ttf2pt1 1
++.It Xr ttf2pt1_x2gs 1
++.El
++.Sh BUGS
++.Ss Known problems
+ One catch is that the X11 Type 1 font library has a rather low limit
+ on the font size. Because of this the fonts with  more complicated
+ outlines and the enabled hint substitution may not fit into
+ this limit. The same applies to the fonts with very complicated
+ outlines or with very many glyphs (especially the fonts with
+ over 256 glyphs). So you will need to excercise caution with
+-these options if you plan using these fonts with X11. Some vendors 
+-such as \s-1HP\s0 provide the Type 1 implementation licensed from Adobe 
++these options if you plan using these fonts with X11. Some vendors
++such as HP provide the Type 1 implementation licensed from Adobe
+ which should have no such problem.
+-.Sp
+-But there is a solution even for the generic X11. A patch located
+-in the subdirectory `\f(CWapp/X11\fR\*(R' fixes this problem as well
+-as some other minor problems. Its description is provided in
+-app/X11/\s-1README\s0.
+-.Sp
+-To fix the X11 font library, you have to get the X11 sources. I
+-can recommend the ftp sites of the XFree86 project ftp://ftp.xfree86.org
+-or of the Open Group ftp://ftp.x.org. This patch was made on the sources
+-of XFree86 so you may have better success with applying it to the
+-XFree86 distribution. After you have got the sources, make sure
+-that you can compile them. Then apply the patch as described.
+-Make sure that it was applied properly. Compile the sources again
+-(actually, you need only the fonts library, the fonts server, and
+-possibly the X server). It would be prudent now to save your old
+-font library, font server and, possibly, X server. Then install
+-the new recently compiled versions of these files. Of course,
+-if you know someone who already has compiled these files for the
+-same \s-1OS\s0 as yours, you can just copy the binary fles from him.
+-.Sp
+-Alas, building the X11 system from the source code is not the
+-easiest thing in the world and if you have no experience it
+-can be quite difficult. In this case just avoid the aforementioned
+-features or check each converted font to make sure that it
+-works properly.
+-.Ip "\(bu" 4
+-The Type1 font library from the standard X11 distribution
+-does not work on \s-1HP\s0\-\s-1UX\s0 (at least, up to 10.01). The font server
+-supplied with \s-1HP\s0\-\s-1UX\s0 up to 10.01 is also broken. Starting from 
+-\s-1HP\s0\-\s-1UX\s0 10.20 (I don't know about 10.10) they supply a proprietary font 
+-library and the converted fonts work fine with it, provided that
+-they are configured properly (see the file \s-1FONTS\s0.hpux).
+-.Ip "\(bu" 4
+-The \f(CWfonts.scale\fR files created by the older versions of the
+-\f(CWttf2pt1\fR installation program (up to release 3.1) have conflicted 
+-with the language definitions of the \f(CWXfsft\fR font server and
+-parts of it included into XFree86. To overcome this incompatibility
+-the never versions creats the \f(CWfonts.scale\fR file describing all the
+-fonts as belonging to the \f(CWadobe-fontspecific\fR encoding and
+-the \f(CWfonts.alias\fR file with the proper names. The drawback of
+-this solution is that \f(CWxlsfonts\fR gives the list of twice more
+-fonts. But as a side effect the option \f(CW\fBENFORCEISO\fR\fR in
+-`\f(CWconvert.cfg\fR\*(R' is not required for X11 any more.
+-.Ip "\(bu" 4
+-The conversion script has no support for Eastern multi-plane fonts.
+-Contribution of such a support would be welcome.
+-
+-.rn }` ''
+-.IX Title "TTF2PT1_CONVERT 1"
+-.IX Name "B<ttf2pt1_convert> - convenience font conversion script"
+-
+-.IX Header "NAME"
+-
+-.IX Header "SYNOPSIS"
+-
+-.IX Header "DESCRIPTION"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+ 
+-.IX Item "\(bu"
++The
++.Sq fonts.scale
++files created by the older versions of the
++.Xr ttf2pt1 1
++installation program (up to release 3.1) have conflicted
++with the language definitions of the Xfsft
++font server and parts of it included into XFree86. To overcome this incompatibility
++the newer versions creats the
++.Sq fonts.scale
++file describing all the fonts as belonging to the
++.Sq adobe-fontspecific
++encoding and the
++.Sq fonts.alias
++file with the proper names. The drawback of
++this solution is that
++.Nm xlsfonts
++gives the list of twice more fonts. But as a side effect the option
++.Dv ENFORCEISO
++in
++.Pa convert.cfg
++is not required for X11 any more.
+ 
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "FILES"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "SEE ALSO"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Header "BUGS"
+-
+-.IX Subsection "Known problems"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
+-
+-.IX Item "\(bu"
++The conversion script has no support for Eastern multi-plane fonts.
++Contribution of such a support would be welcome.
+ 

--- a/srcpkgs/ttf2pt1/patches/006-scripts-diff.patch
+++ b/srcpkgs/ttf2pt1/patches/006-scripts-diff.patch
@@ -1,0 +1,28 @@
+--- scripts/convert
++++ scripts/convert
+@@ -41,9 +41,9 @@ fi
+ 
+ # these setting would be edited during installation
+ 
+-TTF2PT1_BINDIR=
+-TTF2PT1_LIBXDIR=
+-TTF2PT1_SHAREDIR=
++TTF2PT1_BINDIR=/usr/bin
++TTF2PT1_LIBXDIR=/usr/bin
++TTF2PT1_SHAREDIR=/usr/share/examples/ttf2pt1
+ 
+ [ -z "$TTF2PT1_BINDIR" ] && {
+ 	TTF2PT1_BINDIR=`pwd`/..
+@@ -70,10 +70,10 @@ TTF2PT1=$TTF2PT1_BINDIR/ttf2pt1
+ TRANS=$TTF2PT1_SHAREDIR/scripts/trans
+ T1FDIR=$TTF2PT1_SHAREDIR/scripts/t1fdir
+ FORCEISO=$TTF2PT1_SHAREDIR/scripts/forceiso
+-X2GS=$TTF2PT1_SHAREDIR/scripts/x2gs
++X2GS=$TTF2PT1_SHAREDIR/scripts/ttf2pt1_x2gs
+ SUFFIX="pfa"
+ 
+-MYSELF=convert
++MYSELF=ttf2pt1_convert
+ 
+ # include the configuration
+ 

--- a/srcpkgs/ttf2pt1/patches/007-getopt-include.patch
+++ b/srcpkgs/ttf2pt1/patches/007-getopt-include.patch
@@ -1,0 +1,14 @@
+--- t1asm.c
++++ t1asm.c
+@@ -45,10 +45,10 @@ static char portnotice[] =
+ 
+ #ifdef _MSDOS
+   #include <fcntl.h>
+-  #include <getopt.h>
+   #include <io.h>
+ #endif
+ #include <stdio.h>
++#include <getopt.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>

--- a/srcpkgs/ttf2pt1/template
+++ b/srcpkgs/ttf2pt1/template
@@ -1,0 +1,55 @@
+# Template file for 'ttf2pt1'
+pkgname=ttf2pt1
+version=3.4.4
+revision=1
+build_style="gnu-makefile"
+hostmakedepends="perl"
+makedepends="freetype-devel"
+depends="freetype"
+short_desc="Font converter from TTF to PS Type 1"
+maintainer="Stephen Walker-Weinshenker <sww1235@sww1235.net>"
+license="custom:unknown"
+homepage="https://sourceforge.net/projects/ttf2pt1/"
+distfiles="https://sourceforge.net/projects/ttf2pt1/files/ttf2pt1/${version}/ttf2pt1-${version}.tgz"
+checksum=ae926288be910073883b5c8a3b8fc168fde52b91199fdf13e92d72328945e1d0
+
+do_install() {
+
+	#makefile
+
+	make all
+
+	# install main binary.
+	vbin ttf2pt1
+	vbin t1asm
+
+
+	# install scripts
+	vsconf scripts/convert ttf2pt1_convert
+	vsconf scripts/x2gs ttf2pt1_x2gs
+	vsconf scripts/convert.cfg.sample
+	vsconf scripts/forceiso
+	vsconf scripts/frommap
+	vsconf scripts/t1fdir
+	vsconf scripts/trans
+
+
+	# install man pages
+	vman ttf2pt1.1
+	vman ttf2pt1_convert.1
+	vman ttf2pt1_x2gs.1
+
+	# install example files and extra scripts into
+	# /usr/share/examples/ttf2pt1
+	vsconf CHANGES
+	vsconf FONTS
+	vsconf app/TeX/README
+	vsconf other/README
+	vmkdir /usr/share/examples/ttf2pt1/encodings
+	vmkdir /usr/share/examples/ttf2pt1/maps
+	vcopy "encodings/*" /usr/share/examples/ttf2pt1/encodings
+	vcopy "maps/*" /usr/share/examples/ttf2pt1/maps
+
+	vlicense COPYRIGHT
+
+}


### PR DESCRIPTION
tool to convert TTF fonts to Adobe PS1 fonts. Allows for TTF font usage by tools like Enscript.

It hasn't been updated since 2003 (and still uses CVS for version control :vomiting_face: ), but is written in standard ANSI C, so I don't anticipate any breakage in the future. 

The MANPAGE patches are relatively critical, as they clean things up to match up with void filepath standards, and remove a bunch of outdated info related to void linux. They also convert the man pages into proper mdoc format, rather than raw nroff.

I wasn't sure where to put the two main scripts that are included with the tool. For now, I put them in `/usr/share/examples/ttf2pt1` along with most of the remainder of the included files in the package. If there is a better place to put them, please let me know, and I will update the pull request.