### PR TITLE
caribou: add fix for crash observed in cinammon-screensaver.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -896,7 +896,6 @@ liblcms2.so.2 lcms2-2.2_1
 libcolord.so.2 libcolord-1.1.7_1
 libcolordprivate.so.2 libcolord-1.1.7_1
 libcolorhug.so.2 libcolord-1.1.7_1
-libcaribou.so.0 caribou-0.4.0_1
 libgupnp-av-1.0.so.2 gupnp-av-0.10.0_1
 libgrilo-0.3.so.0 grilo-0.3.2_1
 libgrlnet-0.3.so.0 grilo-0.3.2_1

--- a/srcpkgs/caribou/patches/fix-crash.patch
+++ b/srcpkgs/caribou/patches/fix-crash.patch
@@ -1,0 +1,46 @@
+From d41c8e44b12222a290eaca16703406b113a630c6 Mon Sep 17 00:00:00 2001
+From: Michael Webster <miketwebster@gmail.com>
+Date: Tue, 12 Jan 2021 18:01:47 +0000
+Subject: [PATCH] xadapter.vala: Remove XkbKeyTypesMask and fields from
+ XKbChangeMap call.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This was originally a workaround for xFree86 4.3 - see:
+https://bugzilla.gnome.org/show_bug.cgi?id=673547
+​
+As of https://gitlab.freedesktop.org/xorg/xserver/-/commit/87c64fc5b0 this
+causes a BadLength error when attempting to use shifted characters.
+​
+Ref:
+https://www.x.org/releases/X11R7.7/doc/libX11/XKB/xkblib.html#Changing_Map_Components_in_the_Server
+---
+ libcaribou/xadapter.vala | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/libcaribou/xadapter.vala b/libcaribou/xadapter.vala
+index 22858b7..1da5a78 100644
+--- a/libcaribou/xadapter.vala
++++ b/libcaribou/xadapter.vala
+@@ -195,15 +195,10 @@ namespace Caribou {
+ 
+             Xkb.MapChanges changes = Xkb.MapChanges ();
+ 
+-            // We don't touch key types here but include the
+-            // information in XkbSetMap request to the server, because
+-            // some X servers need the information to check the sanity
+-            // of the keysyms change.
+-            changes.changed = (ushort) (Xkb.KeySymsMask | Xkb.KeyTypesMask);
++            changes.changed = (ushort) Xkb.KeySymsMask;
+             changes.first_key_sym = (char) this.reserved_keycode;
+             changes.num_key_syms = this.xkbdesc.map.key_sym_map[this.reserved_keycode].width;
+-            changes.first_type = 0;
+-            changes.num_types = this.xkbdesc.map.num_types;
++
+             Xkb.change_map (this.xdisplay, this.xkbdesc, changes);
+ 
+             this.xdisplay.flush ();
+-- 
+GitLab
+

--- a/srcpkgs/caribou/patches/fix-vala.patch
+++ b/srcpkgs/caribou/patches/fix-vala.patch
@@ -1,0 +1,16 @@
+Patch from
+https://github.com/archlinux/svntogit-packages/blob/bf8285526628664f46c1b790238c6e3555e51499/trunk/unicode_to_keyval-symbol-check.patch
+
+diff --git a/libcaribou/key-model.vala b/libcaribou/key-model.vala
+index 89015bc..e88342e 100644
+--- a/libcaribou/key-model.vala
++++ b/libcaribou/key-model.vala
+@@ -101,7 +101,7 @@ namespace Caribou {
+                     unichar uc;
+                     while (text.get_next_char (ref index, out uc)) {
+                         uint keyval = Gdk.unicode_to_keyval (uc);
+-                        if (keyval != uc | 0x01000000)
++                        if (keyval != (uc | 0x01000000))
+                             _keyvals += keyval;
+                     }
+                 } else {

--- a/srcpkgs/caribou/template
+++ b/srcpkgs/caribou/template
@@ -1,12 +1,12 @@
 # Template file for 'caribou'
 pkgname=caribou
 version=0.4.21
-revision=4
+revision=5
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-schemas-compile --disable-static --disable-gtk2-module
  PYTHON=/usr/bin/python3"
-hostmakedepends="pkg-config intltool python3-gobject-devel libxslt"
+hostmakedepends="pkg-config intltool python3-gobject-devel libxslt vala"
 makedepends="vala-devel libxklavier-devel libgee08-devel python3-gobject-devel
  clutter-devel gtk+3-devel libXtst-devel gir-freedesktop"
 depends="python3-gobject python3-atspi python3-dbus gir-freedesktop at-spi2-atk


### PR DESCRIPTION
https://github.com/linuxmint/cinnamon-screensaver/issues/354

Also clean wrong and repeated entry from shlibs.