### PR TITLE
New package: bsdgrep

### DIFF
--- a/srcpkgs/bsdgrep/template
+++ b/srcpkgs/bsdgrep/template
@@ -1,0 +1,14 @@
+# Template file for 'bsdgrep'
+pkgname=bsdgrep
+version=1.0.0
+revision=1
+build_style=gnu-makefile
+makedepends="bzip2-devel zlib-devel"
+short_desc="BSD grep from FreeBSD"
+maintainer="Martin Tournoij <martin@arp242.net>"
+license="BSD-2-Clause"
+homepage="https://github.com/arp242/bsdgrep"
+distfiles="https://github.com/arp242/bsdgrep/archive/v${version}.tar.gz"
+checksum=04e6be645eba6e50cc614d505dd7d53893573c6c6be577385695120cd7c5fe37
+provides="grep-${version}_${revision}"
+replaces="grep>=0"


### PR DESCRIPTION
This is "BSD grep" from the FreeBSD source tree, which is the default
grep in FreeBSD 13.

It should be pretty much a drop-in replacement for GNU grep, so I just
set it to replace/conflict with it. It installs a bunch of
commands/links, and I'm not sure if having them all as "bsd*grep*" and
updating alternatives is all that useful, but it could be done if people
feel strongly about this.