### PR TITLE
pinebookpro-kernel: overclock patch

### DIFF
--- a/srcpkgs/pinebookpro-kernel/patches/0009-overclock.patch
+++ b/srcpkgs/pinebookpro-kernel/patches/0009-overclock.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
+index 06d48338c836..60998c352b20 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
+@@ -12,7 +12,7 @@
+ #include <dt-bindings/usb/pd.h>
+ #include <dt-bindings/leds/common.h>
+ #include "rk3399.dtsi"
+-#include "rk3399-opp.dtsi"
++#include "rk3399-op1-opp.dtsi"
+ 
+ / {
+ 	model = "Pine64 Pinebook Pro";

--- a/srcpkgs/pinebookpro-kernel/template
+++ b/srcpkgs/pinebookpro-kernel/template
@@ -1,7 +1,7 @@
 # Template file for 'pinebookpro-kernel'
 pkgname=pinebookpro-kernel
 version=5.10.2
-revision=1
+revision=2
 archs="aarch64*"
 wrksrc="linux-${version}"
 short_desc="Linux kernel for Pinebook Pro"


### PR DESCRIPTION
Pinebook PRO uses the same OP1 RK3399 of many other chromebooks devices. 
These devices has been rated for 2.1Ghz max clock speed.
Use the OP1 profile already present in the kernel tree.

@ericonr @CameronNemo 