### PR TITLE
conky-cli: update to 1.11.6.

### DIFF
--- a/srcpkgs/conky-cli/template
+++ b/srcpkgs/conky-cli/template
@@ -1,7 +1,7 @@
 # Template file for 'conky-cli'
 pkgname=conky-cli
-version=1.11.5
-revision=3
+version=1.11.6
+revision=1
 wrksrc="${pkgname/-cli/}-${version}"
 build_style=cmake
 conf_files="/etc/conky/conky.conf /etc/conky/conky_no_x11.conf"
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause, GPL-3.0-or-later"
 homepage="https://github.com/brndnmtthws/conky"
 distfiles="https://github.com/brndnmtthws/conky/archive/v${version}.tar.gz"
-checksum=4cefdd92219a90934c28297e4ac7448a3f69d6aeec5d48c5763b23f6b214ef13
+checksum=e7c01e4910744851e05f85f0a0aab3f5068215b1af850515189ac40e7deeb26d
 
 provides="conky-${version}_${revision}"
 conflicts="conky>=0"


### PR DESCRIPTION
conky is already on this version since August 11, 2020 so it should work fine.

conky and conky-cli are more or less duplicates, just with different build options.
I would suggest to drop this package and realize it through `build_options` in conky. If not, we should leave a notice in both templates that the other one might also be affected by changes.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR
