### PR TITLE
keepassxc: enable fdosecrets by default

### DIFF
--- a/srcpkgs/keepassxc/template
+++ b/srcpkgs/keepassxc/template
@@ -36,7 +36,7 @@ desc_option_keeshare="Include sharing integration with KeeShare"
 desc_option_network="Include networking code (favicon download)"
 desc_option_sshagent="Include SSH agent support"
 desc_option_yubikey="Include YubiKey support"
-build_options_default="autotype browser keeshare network sshagent yubikey"
+build_options_default="autotype browser fdosecrets keeshare network sshagent yubikey"
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
This allows one to use `keepassxc` as a secrets storage via `libsecret`.

Note that `kwallet` is currently unusable from `qtkeychain` except in kde (#26774), so I'm looking for an alternative.

I checked that the package compiles, installs, and runs with this option enabled.

After configuration, it works ok with `owncloudclient`. I followed this guide https://avaldes.co/2020/01/28/secret-service-keepassxc.html to setup.
