### PR TITLE
base-files: fix mdns ordering in nsswitch.conf

### DIFF
--- a/srcpkgs/base-files/files/nsswitch.conf
+++ b/srcpkgs/base-files/files/nsswitch.conf
@@ -6,7 +6,7 @@ passwd: 	files
 group: 		files
 shadow: 	files
 
-hosts: 		files mdns mdns4_minimal mdns4 myhostname dns
+hosts: 		files mdns_minimal [NOTFOUND=return] dns mdns
 networks: 	files
 
 protocols: 	files

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.141
-revision=5
+revision=6
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
The current ordering of services for `hosts` in `nsswitch.conf` can lead to unreasonably long delays doing, *e.g.*, reverse DNS lookups when attempting to connect to a remote telnet host using the client in `inetutils-telnet` and `nss-mdns` is installed to allow Avahi to do mDNS lookups.

A snip from `strace telnet remotehost` shows the culprit:
```
socket(AF_UNIX, SOCK_STREAM, 0)         = 3
fcntl(3, F_GETFD)                       = 0
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
connect(3, {sa_family=AF_UNIX, sun_path="/var/run/avahi-daemon/socket"}, 110) = 0
fcntl(3, F_GETFL)                       = 0x2 (flags O_RDWR)
fstat(3, {st_mode=S_IFSOCK|0777, st_size=0, ...}) = 0
write(3, "RESOLVE-ADDRESS XX.YY.ZZ.TT\n", 31) = 31
read(3, "-15 Timeout reached\n", 4096)  = 20
close(3)                                = 0
```
where `XX.YY.ZZ.TT` is the public IPv4 address of my NAT router. The delay between the `RESOLVE-ADDRESS` write and the `-15 Timeout reached` response is several seconds, because Avahi is using `mdns` to attempt to resolve the address to a host.

Per [upstream documentation](https://github.com/lathiat/nss-mdns/blob/master/README.md) the `mdns{,4,6}_minimal` module short-circuits the lookup for anything but `.local` domains and link-local addresses, allowing fast failing unless the name is unlikely to be found in proper DNS. The `[NOTFOUND=return]` ensures that `.local` and link-local address lookups are authoritatively handled by mDNS (if `nss-mdns` is installed and Avahi enabled), preventing DNS queries that should never succeed anyway. The full module is recalled *after* DNS to allow custom domain configuration when a result is not available over regular DNS.

This at least eliminates the telnet connection delay.

The ordering agrees with the upstream example, except I use `mdns` instead of `mdns4` because, contrary to their observation that "most mDNS responders only register local IPv4 addresses via mDNS", Avahi and other modern hosts seem to register both IPv4 and IPv6 when IPv6 networking is enabled; the `mdns` modules handle both v4 and v6 lookups.

While I was making these changes, I noticed the `myhostname` NSS module no longer seems to exist, so I dropped that from the config as well.