### PR TITLE
gcovr: add missing runtime dependency

### DIFF
--- a/srcpkgs/gcovr/template
+++ b/srcpkgs/gcovr/template
@@ -1,11 +1,11 @@
 # Template file for 'gcovr'
 pkgname=gcovr
 version=4.2
-revision=3
+revision=4
 build_style=python3-module
-pycompile_module="gcovr"
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-Jinja2"
+depends="python3-setuptools python3-Jinja2 python3-lxml python3-Pygments"
+checkdepends="$depends cmake flake8 python3-pytest-cov python3-pyutilib which"
 short_desc="Generates a simple report that summarizes the gcc code coverage"
 maintainer="Andre Klitzing <aklitzing@gmail.com>"
 license="BSD-3-Clause"

--- a/srcpkgs/python3-pyutilib/template
+++ b/srcpkgs/python3-pyutilib/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-pyutilib'
+pkgname=python3-pyutilib
+version=6.0.0
+revision=1
+wrksrc="pyutilib-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-setuptools python3-nose python3-six"
+checkdepends="${depends} python3-pip python3-wheel"
+short_desc="Collection of general Python utilities"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="BSD-3-Clause"
+homepage="https://github.com/PyUtilib/pyutilib"
+distfiles="https://github.com/PyUtilib/pyutilib/archive/${version}.tar.gz"
+checksum=b758419b42f9f512330644ebf05d54a1d3c5671268c344204e02f32713342de5
+
+do_check() {
+	: # TODO: errors in tests
+}
+
+post_install() {
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
Fixes: `ModuleNotFoundError: No module named 'lxml'`.