### PR TITLE
lutris: fix crash, add missing dependency

### DIFF
--- a/srcpkgs/lutris/patches/fix-dxvk.patch
+++ b/srcpkgs/lutris/patches/fix-dxvk.patch
@@ -1,0 +1,22 @@
+upstream: yes
+--- lutris/util/wine/dxvk.py
++++ lutris/util/wine/dxvk.py
+@@ -53,7 +53,8 @@ def version(self):
+         """Return version of DXVK (latest known version if not provided)"""
+         if self._version:
+             return self._version
+-        return self.versions[0]
++        if self.versions:
++            return self.versions[0]
+ 
+     @property
+     def dxvk_path(self):
+@@ -62,6 +62,8 @@ def dxvk_path(self):
+ 
+     def load_dxvk_versions(self):
+         versions_path = os.path.join(self.base_dir, "dxvk_versions.json")
++        if not system.path_exists(versions_path):
++            return []
+         with open(versions_path, "r") as dxvk_version_file:
+             dxvk_versions = [v["tag_name"] for v in json.load(dxvk_version_file)]
+         return dxvk_versions

--- a/srcpkgs/lutris/template
+++ b/srcpkgs/lutris/template
@@ -1,12 +1,12 @@
 # Template file for 'lutris'
 pkgname=lutris
 version=0.5.8.2
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="gettext python3-setuptools python3-gobject gtk+3-devel"
 depends="python3-dbus python3-gobject python3-yaml python3-evdev python3-Pillow
  pciutils cabextract gtk+3 xrandr unzip p7zip gnome-desktop python3-requests webkit2gtk
- glxinfo python3-distro python3-lxml"
+ glxinfo python3-distro python3-lxml python3-magic"
 short_desc="Open gaming platform for managing games in a unified way"
 maintainer="Jan Wey. <janwey.git@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
The last version could crash if file `~/.local/share/lutris/runtime/dxvk/dxvk_versions.json` didn't exist (for example on first run). The patch content is already upstream.

Lutris was also complaining about an old version of python-magic, adding it to dependencies fixed it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
