### PR TITLE
gajim: add libsoup to dependencies.

### DIFF
--- a/srcpkgs/gajim/template
+++ b/srcpkgs/gajim/template
@@ -1,12 +1,12 @@
 # Template file for 'gajim'
 pkgname=gajim
 version=1.2.2
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools"
 depends="python3-gobject python3-nbxmpp python3-pyasn1 python3-setuptools
  python3-precis-i18n python3-keyring python3-cssutils python3-packaging
- python3-css-parser farstream python3-dbus"
+ python3-css-parser farstream python3-dbus libsoup"
 short_desc="Full featured Jabber/XMPP client"
 maintainer="teldra <teldra@rotce.de>"
 license="GPL-3.0-only"


### PR DESCRIPTION
Fixes https://github.com/void-linux/void-packages/issues/23424 by adding libsoup to dependencies.