### PR TITLE
webkit2gtk: build with enchant2 instead of enchant

### DIFF
--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,7 +1,7 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
 version=2.30.4
-revision=2
+revision=3
 wrksrc="webkitgtk-${version}"
 build_style=cmake
 build_helper="gir"
@@ -28,7 +28,7 @@ hostmakedepends="perl python pkg-config gperf flex ruby gettext glib-devel
  geoclue2 libharfbuzz $(vopt_if wayland wayland-devel)"
 makedepends="at-spi2-core-devel libjpeg-turbo-devel libpng-devel
  harfbuzz-devel gst-plugins-base1-devel gst-plugins-bad1-devel sqlite-devel
- libsoup-devel libxslt-devel gnutls-devel icu-devel enchant-devel
+ libsoup-devel libxslt-devel gnutls-devel icu-devel enchant2-devel
  dbus-glib-devel libwebp-devel gtk+-devel gtk+3-devel libgudev-devel
  libsecret-devel ruby-devel geoclue2-devel libnotify-devel hyphen-devel
  woff2-devel freetype-devel libopenjpeg2-devel libatomic-devel


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

