### PR TITLE
PrusaSlicer: update to 2.3.0.

### DIFF
--- a/srcpkgs/PrusaSlicer/patches/0002-Replace-get_current_thread_name-for-musl.patch
+++ b/srcpkgs/PrusaSlicer/patches/0002-Replace-get_current_thread_name-for-musl.patch
@@ -1,0 +1,30 @@
+--- src/libslic3r/Thread.cpp.orig	2021-01-24 13:50:00.469444149 +0100
++++ src/libslic3r/Thread.cpp	2021-01-24 13:51:17.109443201 +0100
+@@ -171,16 +171,27 @@ bool set_thread_name(boost::thread &thre
+ 	return true;
+ }
+ 
++#ifndef __GLIBC__
++thread_local char current_thread_name[16] = { 0 };
++#endif
++
+ bool set_current_thread_name(const char *thread_name)
+ {
++#ifndef __GLIBC__
++	strncpy(current_thread_name, thread_name, 15);
++#endif
+ 	pthread_setname_np(pthread_self(), thread_name);
+ 	return true;
+ }
+ 
+ std::optional<std::string> get_current_thread_name()
+ {
++#ifdef __GLIBC__
+ 	char buf[16];
+ 	return std::string(pthread_getname_np(pthread_self(), buf, 16) == 0 ? buf : "");
++#else
++	return std::string(current_thread_name);
++#endif
+ }
+ 
+ #endif

--- a/srcpkgs/PrusaSlicer/template
+++ b/srcpkgs/PrusaSlicer/template
@@ -1,21 +1,22 @@
 # Template file for 'PrusaSlicer'
 pkgname=PrusaSlicer
-version=2.2.0
-revision=4
+version=2.3.0
+revision=1
 wrksrc="PrusaSlicer-version_${version}"
 build_style=cmake
 build_helper="qemu"
-configure_args="-DSLIC3R_WX_STABLE=1 -DSLIC3R_FHS=1"
+configure_args="-DSLIC3R_WX_STABLE=1 -DSLIC3R_FHS=1 -DSLIC3R_GTK=3"
 hostmakedepends="pkg-config"
-makedepends="boost-devel tbb-devel libcurl-devel nlopt-devel gtest-devel
- wxWidgets-devel glu-devel libpng-devel glew-devel cereal openvdb-devel
- cgal-devel gmpxx-devel eigen"
+makedepends=" boost-devel cereal cgal-devel dbus-devel eigen glew-devel
+ glu-devel gmpxx-devel gtest-devel gtk+3-devel libcurl-devel libglib-devel
+ libpng-devel nlopt-devel openvdb-devel tbb-devel wxWidgets-devel
+ wxWidgets-gtk3-devel"
 short_desc="G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.)"
 maintainer="Jasper Chan <jasperchan515@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.prusa3d.com/prusaslicer/"
 distfiles="https://github.com/prusa3d/Prusaslicer/archive/version_${version}.tar.gz"
-checksum=e6e0c83bf92e448ec058fd3063b84caca69f58b8b419e48eace6e8ce534937c0
+checksum=cd3bac5e29b5441fc4690f28cd7b1064e97dc00207bbdc88f7bd7832308d6ca5
 nocross="https://build.voidlinux.org/builders/armv7l_builder/builds/25230/steps/shell_3/logs/stdio"
 
 Slic3rPE_package() {


### PR DESCRIPTION
* Update to 2.3.0
* Switch to GTK3, which is not officially supported, but works fine in daily usage.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
