### PR TITLE
allegro5: update to 5.2.6.0.

### DIFF
--- a/srcpkgs/allegro5/template
+++ b/srcpkgs/allegro5/template
@@ -1,7 +1,7 @@
 # Template file for 'allegro5'
 pkgname=allegro5
-version=5.2.5.0
-revision=2
+version=5.2.6.0
+revision=1
 wrksrc="allegro-${version}"
 build_style=cmake
 configure_args="-DWANT_DOCS=1 -DWANT_PHYSFS=1"
@@ -9,14 +9,14 @@ hostmakedepends="pkg-config"
 makedepends="zlib-devel alsa-lib-devel jack-devel libXpm-devel libXxf86vm-devel
  libXxf86dga-devel libXcursor-devel libvorbis-devel libpng-devel glu-devel
  libjpeg-turbo-devel libtheora-devel freetype-devel libflac-devel physfs-devel
- libopenal-devel gtk+-devel"
+ libopenal-devel gtk+-devel opus-devel opusfile-devel"
 depends="virtual?libGL"
 short_desc="Portable library mainly aimed at video game and multimedia programming"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="Allegro License (MIT alike)"
 homepage="https://liballeg.org/"
 distfiles="https://github.com/liballeg/allegro5/releases/download/${version}/allegro-${version}.tar.gz"
-checksum=59968da34a0353913868b8299aaff9520d19a3b0960c6406be8323a6ac9bb719
+checksum=5de8189ec051e1865f359654f86ec68e2a12a94edd00ad06d1106caa5ff27763
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
Bump version, and add opus/opusfile as makedepends to activate the opus allegro code.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-musl)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl (cross)
  - [x] armv7l (cross)
  - [x] armv6l-musl (cross)


Runtime tested on x86_64-musl, building a program against allegro that uses it regularly. Program works as normal. Program also uses opus files, those play as expected.