### PR TITLE
wine: fix faudio support

### DIFF
--- a/srcpkgs/FAudio/template
+++ b/srcpkgs/FAudio/template
@@ -1,10 +1,10 @@
 # Template file for 'FAudio'
 pkgname=FAudio
 version=20.11
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DGSTREAMER=ON -DSDL2_INCLUDE_DIRS=${XBPS_CROSS_BASE}/usr/include/SDL2
- -DSDL2_LIBRARIES=${XBPS_CROSS_BASE}/usr/lib"
+ -DSDL2_LIBRARIES=${XBPS_CROSS_BASE}/usr/lib/libSDL2.so"
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel gstreamer1-devel gst-plugins-base1-devel"
 short_desc="Accuracy-focused XAudio reimplementation for open platforms"

--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -1,7 +1,7 @@
 # Template file for 'wine'
 pkgname=wine
 version=6.0
-revision=1
+revision=2
 _pkgver=${version/r/-r}
 create_wrksrc=yes
 build_wrksrc=wine-${_pkgver}


### PR DESCRIPTION
Fix for these two issues:
wine - configure: libFAudio 64-bit development files not found, XAudio2 won't be supported.
faudio - WARNING: Target "FAudio" requests linking to directory "/usr/lib".  Targets may link only to libraries.  CMake is dropping the item.

Currently built faudio lib is broken due to missing link to libSDL2.

I only tested on x86_64 and wine seems to build correctly.
I wasn't able to cross-compile wine for i686.
