### PR TITLE
dante: fix runtime on musl.

### DIFF
--- a/srcpkgs/dante/template
+++ b/srcpkgs/dante/template
@@ -1,7 +1,7 @@
 # Template file for 'dante'
 pkgname=dante
 version=1.4.2
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="tar automake libtool"
 short_desc="SOCKS server and client"
@@ -13,6 +13,8 @@ checksum=4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7
 
 if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
 	configure_args="--with-libc=libc.so.6"
+else
+	configure_args="ac_cv_func_sched_setscheduler=no"
 fi
 
 pre_configure() {


### PR DESCRIPTION
musl implements the sched_{set,get}scheduler functions as stubs.
Unfortunately, dante fails if the functions are available but return an
error, which is always the case for musl. Force it to think setscheduler
isn't available (var appropriated from Alpine).

Fixes #28180

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
