### PR TITLE
vault: chown config dir to service user

### DIFF
--- a/srcpkgs/vault/template
+++ b/srcpkgs/vault/template
@@ -17,7 +17,7 @@ distfiles="https://github.com/hashicorp/vault/archive/v${version}.tar.gz"
 checksum=ff7fd9a1b33d19e3cb4743acd0139004e360bbffc04fa8e9598129530fc7118f
 system_accounts="_vault"
 make_dirs="/var/lib/vault 0700 _vault _vault
- /etc/vault 0700 root root"
+ /etc/vault 0750 root _vault"
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*) go_ldflags="$go_ldflags -linkmode=external";;


### PR DESCRIPTION
Dunno why I missed this before, but:
```
$ sudo -u _vault vault server -config=/etc/vault
Password:
error loading configuration from /etc/vault: open /etc/vault: permission denied
$ sudo chown _vault:_vault /etc/vault
$ sudo -u _vault vault server -config=/etc/vault
==> Vault server configuration:
<...>
```