### PR TITLE
common: fix exit status of uname wrapper

### DIFF
--- a/common/wrappers/uname.sh
+++ b/common/wrappers/uname.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 uname=$(/usr/bin/uname $@)
+rv=$?
 uname_m=$(/usr/bin/uname -m)
 arch=${XBPS_ARCH%-musl}
 # if XBPS_ARCH was reseted by `env -i` use original `/usr/bin/uname -m`
 : ${arch:=$uname_m}
-rv=$?
 echo "$uname" |
 	sed "s/\(^\| \)$(/usr/bin/uname -n)\($\| \)/\1void\2/" |
 	sed "s/$uname_m/$arch/"


### PR DESCRIPTION
On my attemp to fix i686 build on Travis long ago, I forgot to correct exit status.