### PR TITLE
grabc: update to 1.0.2

### DIFF
--- a/srcpkgs/grabc/template
+++ b/srcpkgs/grabc/template
@@ -1,20 +1,26 @@
 # Template file for 'grabc'
 pkgname=grabc
-version=1.1
+reverts=1.1_1
+version=1.0.2
 revision=1
-wrksrc="${pkgname}${version}"
+create_wrksrc=yes
+build_wrksrc="${pkgname}-${version}"
 build_style=gnu-makefile
 makedepends="libX11-devel"
 short_desc="Identify color of a pixel on the screen"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="GPL-2"
+license="MIT"
 homepage="http://www.muquit.com/muquit/software/grabc/grabc.html"
-distfiles="http://www.muquit.com/muquit/software/grabc/grabc${version}.tar.gz"
-checksum=f0492a8ea33b46a16bdb94644420f54724e31c4436e4cd77937a30b2de3bb00e
+# Remove the license file on next version bump as it will be included.
+distfiles="https://github.com/muquit/grabc/archive/v${version}.tar.gz
+ https://raw.githubusercontent.com/muquit/grabc/b9e4316/LICENSE.txt"
+checksum="a3e4d2e5b11ef63e8928a630418fc8dfe1327585adc48aef8d0f13b2d78d5ea0
+ 9691605fc9d14f0924faf49367189f9c5bc50e4872987b637b18db77960b1536"
 
 pre_build() {
-	sed -i -e 's|$(LIBS)|$(LDFLAGS) -lX11|' Makefile
+	vsed -e 's|/usr/local|/usr|' -i Makefile
 }
-do_install() {
-	vbin grabc
+
+post_install() {
+	vlicense ../LICENSE.txt
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

#### Some notes:
Old version number is from the tarball name, which appears to be a typo and should've been `1.0.1`, hence the revert. Let me know if this is the right approach to fix this.

~~xlint complains because the license changed from GPL2 to MIT, but there is no LICENSE or COPYING file to `vlicense`.~~