### PR TITLE
webkit2gtk: fix bwrap-libdir32.patch

### DIFF
--- a/srcpkgs/webkit2gtk/patches/bwrap-libdir32.patch
+++ b/srcpkgs/webkit2gtk/patches/bwrap-libdir32.patch
@@ -34,9 +34,9 @@ index 889388a..a7a75a8 100644
 -        "--ro-bind-try", "/lib64", "/lib64",
 -        "--ro-bind-try", "/usr/lib64", "/usr/lib64",
 -        "--ro-bind-try", "/usr/local/lib64", "/usr/local/lib64",
-+        "--ro-bind-try", "/lib" LIB_DIR_WS, "/lib" LIB_DIR_WS,
-+        "--ro-bind-try", "/usr/lib" LIB_DIR_WS, "/usr/lib" LIB_DIR_WS,
-+        "--ro-bind-try", "/usr/local/lib" LIB_DIR_WS, "/usr/local/lib" LIB_DIR_WS,
++        "--ro-bind-try", "/lib/" LIB_DIR_WS, "/lib/" LIB_DIR_WS,
++        "--ro-bind-try", "/usr/lib/" LIB_DIR_WS, "/usr/lib/" LIB_DIR_WS,
++        "--ro-bind-try", "/usr/local/lib/" LIB_DIR_WS, "/usr/local/lib/" LIB_DIR_WS,
  
          "--ro-bind-try", PKGLIBEXECDIR, PKGLIBEXECDIR,
      };

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -2,7 +2,7 @@
 # ping q66 before touching this
 pkgname=webkit2gtk
 version=2.30.4
-revision=4
+revision=5
 wrksrc="webkitgtk-${version}"
 build_style=cmake
 build_helper="gir"


### PR DESCRIPTION
The strings resulting from LIB_DIR_WS concatenation are missing a slash.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Not yet tested but I saw the wrong strings like `"/liblib64"` in an strace output.