### PR TITLE
librsvg: fix cross

### DIFF
--- a/srcpkgs/librsvg/template
+++ b/srcpkgs/librsvg/template
@@ -5,7 +5,7 @@ version=2.48.8
 revision=1
 build_style=gnu-configure
 build_helper="gir"
-configure_args="--disable-static --host=${XBPS_TARGET_TRIPLET}
+configure_args="--disable-static
  $(vopt_enable gir introspection) $(vopt_enable vala)"
 hostmakedepends="cargo pkg-config python glib-devel
  gdk-pixbuf-devel $(vopt_if vala vala)"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

Currently the package seems to fail to cross compile, I do not know why the `--host` was added to conf args in the first place.
```
configure: WARNING: unrecognized options: --with-libtool-sysroot
checking for a BSD-compatible install... /builddir/.xbps-librsvg/wrappers/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether UID '1000' is supported by ustar format... yes
checking whether GID '1000' is supported by ustar format... yes
checking how to create a ustar tar archive... none
checking whether make supports nested variables... (cached) yes
checking whether to enable maintainer-specific portions of Makefiles... yes
checking for a sed that does not truncate output... /usr/bin/sed
checking whether NLS is requested... yes
checking for msgfmt... no
checking for gmsgfmt... :
checking for xgettext... no
checking for msgmerge... no
checking whether make supports the include directive... yes (GNU style)
checking for gcc... aarch64-linux-gnu-gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... configure: error: in `/builddir/librsvg-2.48.8':
configure: error: cannot run C compiled programs.
If you meant to cross compile, use `--host'.
See `config.log' for more details
```


#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
- [x] I have not tested this yet

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [x] aarch64
  - [ ] armv7l
  - [ ] armv6l-musl
