### PR TITLE
sudo: update to 1.9.5p2.

### DIFF
--- a/srcpkgs/sudo/template
+++ b/srcpkgs/sudo/template
@@ -1,6 +1,6 @@
 # Template file for 'sudo'
 pkgname=sudo
-version=1.9.5p1
+version=1.9.5p2
 revision=1
 build_style=gnu-configure
 configure_args="--with-ignore-dot --with-insults=disabled --with-all-insults --with-env-editor
@@ -15,7 +15,7 @@ license="ISC"
 homepage="https://www.sudo.ws/"
 changelog="https://www.sudo.ws/repos/sudo/raw-file/tip/NEWS"
 distfiles="https://www.sudo.ws/dist/sudo-${version}.tar.gz"
-checksum=4dddf37c22653defada299e5681e0daef54bb6f5fc950f63997bb8eb966b7882
+checksum=539e2ef43c8a55026697fb0474ab6a925a11206b5aa58710cb42a0e1c81f0978
 conf_files="/etc/pam.d/sudo /etc/sudoers"
 lib32disabled=yes
 


### PR DESCRIPTION
Fixes CVE-2021-3156.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
