### PR TITLE
python3-setuptools: update to 52.0.0.

### DIFF
--- a/srcpkgs/duplicity/template
+++ b/srcpkgs/duplicity/template
@@ -1,9 +1,9 @@
 # Template file for 'duplicity'
 pkgname=duplicity
 version=0.8.18
-revision=1
+revision=2
 build_style=python3-module
-hostmakedepends="gettext python3-setuptools"
+hostmakedepends="gettext python3-setuptools_scm"
 makedepends="python3-devel librsync-devel"
 depends="python3-fasteners gnupg python3-future python3-urllib3"
 short_desc="Encrypted bandwidth-efficient backup using the rsync algorithm"

--- a/srcpkgs/fava/template
+++ b/srcpkgs/fava/template
@@ -1,9 +1,9 @@
 # Template file for 'fava'
 pkgname=fava
 version=1.17
-revision=1
+revision=2
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-Babel python3-Cheroot python3-Flask-Babel python3-Flask
  python3-Jinja2 beancount python3-click python3-markdown2 python3-ply
  python3-simplejson python3-Werkzeug python3-aiohttp"

--- a/srcpkgs/khard/template
+++ b/srcpkgs/khard/template
@@ -1,9 +1,9 @@
 # Template file for 'khard'
 pkgname=khard
 version=0.17.0
-revision=2
+revision=3
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-setuptools python3-atomicwrites python3-configobj
  python3-vobject python3-Unidecode python3-ruamel.yaml"
 short_desc="Command-line addressbook built around CardDAV"

--- a/srcpkgs/nagstamon/template
+++ b/srcpkgs/nagstamon/template
@@ -1,10 +1,9 @@
 # Template file for 'nagstamon'
 pkgname=nagstamon
 version=3.4.1
-revision=1
+revision=2
 wrksrc=Nagstamon
 build_style=python3-module
-pycompile_module="Nagstamon"
 hostmakedepends="python3-setuptools python3-keyring python3-psutil"
 depends="python3-BeautifulSoup4 python3-dbus python3-keyring python3-lxml
  python3-psutil python3-PyQt5-multimedia python3-PyQt5-svg python3-requests"
@@ -13,7 +12,7 @@ maintainer="Laszlo Dvornik <laulicus@zoho.com>"
 license="GPL-2.0-or-later"
 homepage="https://nagstamon.ifw-dresden.de"
 distfiles="https://nagstamon.ifw-dresden.de/files/stable/Nagstamon-${version}.tar.gz"
-checksum=2d26cf4d64a6e27fe55f1c5e5f042af511bcb09876ae16a456aee5800a98adea
+checksum=7a9611f40b08269bba4100ab2598ee089c7d0ebc6c4e9d7132689342f71150ec
 
 post_patch() {
 	# This relies on /etc/os-release, which doesn't exist without

--- a/srcpkgs/protontricks/template
+++ b/srcpkgs/protontricks/template
@@ -1,10 +1,9 @@
 # Template file for 'protontricks'
 pkgname=protontricks
 version=1.4.3
-revision=1
+revision=2
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-makedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-vdf winetricks"
 short_desc="Simple wrapper that does winetricks things for Proton enabled games"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/python-b2sdk/template
+++ b/srcpkgs/python-b2sdk/template
@@ -2,10 +2,10 @@
 # keep python-b2sdk name to revert this package
 pkgname=python-b2sdk
 version=1.3.0
-revision=1
+revision=2
 wrksrc="b2sdk-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-logfury python3-Arrow python3-requests python3-six"
 checkdepends="python3-pytest $depends python3-dateutil python3-nose
  python3-mock python3-tqdm python3-pyflakes"

--- a/srcpkgs/python-dateutil/template
+++ b/srcpkgs/python-dateutil/template
@@ -1,10 +1,9 @@
 # Template file for 'python-dateutil'
 pkgname=python-dateutil
 version=2.8.1
-revision=1
+revision=2
 build_style=python-module
-pycompile_module="dateutil"
-hostmakedepends="python-setuptools python3-setuptools"
+hostmakedepends="python-setuptools python3-setuptools_scm"
 depends="python-six tzdata"
 short_desc="Extensions to the standard Python2 datetime module"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
@@ -23,7 +22,6 @@ post_install() {
 
 python3-dateutil_package() {
 	depends="python3-six tzdata"
-	pycompile_module="dateutil"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*

--- a/srcpkgs/python3-Flask-User/template
+++ b/srcpkgs/python3-Flask-User/template
@@ -1,11 +1,12 @@
 # Template file for 'python3-Flask-User'
 pkgname=python3-Flask-User
 version=1.0.2.2
-revision=2
+revision=3
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-Flask python3-Flask-Login python3-Flask-WTF python3-Flask-SQLAlchemy python3-Flask-Mail python3-Flask-Babel"
+hostmakedepends="python3-setuptools python3-Flask-Login"
+depends="python3-Flask python3-Flask-Login python3-Flask-WTF
+ python3-Flask-SQLAlchemy python3-Flask-Mail python3-Flask-Babel"
 short_desc="User session management for Flask (Python3)"
 maintainer="pulux <pulux@pf4sh.de>"
 license="MIT"

--- a/srcpkgs/python3-PGPy/template
+++ b/srcpkgs/python3-PGPy/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-PGPy'
 pkgname=python3-PGPy
 version=0.5.3
-revision=1
+revision=2
 wrksrc=PGPy-${version}
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-makedepends="python3-devel"
+hostmakedepends="python3-setuptools python3-wheel"
+depends="python3-cryptography python3-pyasn1 python3-six"
 short_desc="Pretty Good Privacy for Python"
 maintainer="Anjandev Momi <anjan@momi.ca>"
 license="BSD-3-Clause"

--- a/srcpkgs/python3-aiohttp-sse-client/template
+++ b/srcpkgs/python3-aiohttp-sse-client/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-aiohttp-sse-client'
 pkgname=python3-aiohttp-sse-client
 version=0.2.0
-revision=1
+revision=2
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -13,3 +13,8 @@ license="Apache-2.0"
 homepage="https://github.com/rtfol/aiohttp-sse-client"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=7fe8f9af35cf9a97249562e81a35c2f86544ce388928223205021ab00c30edca
+
+post_patch() {
+	# Package does not *need* pytest-runner to build, and Void doesn't have it
+	vsed -e "/setup_requirements/s/['\"]pytest-runner['\"],*//" -i setup.py
+}

--- a/srcpkgs/python3-audioread/template
+++ b/srcpkgs/python3-audioread/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-audioread'
 pkgname=python3-audioread
 version=2.1.8
-revision=4
+revision=5
 wrksrc="audioread-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,6 +12,11 @@ license="MIT"
 homepage="https://github.com/sampsyo/audioread/"
 distfiles="${PYPI_SITE}/a/audioread/audioread-${version}.tar.gz"
 checksum=073904fabc842881e07bd3e4a5776623535562f70b1655b635d22886168dd168
+
+post_patch() {
+	# Build doesn't actually require pytest-runner and Void doesn't offer it
+	vsed -e '/pytest-runner/d' -i setup.py
+}
 
 post_install() {
 	sed -n '2,13p' decode.py > LICENSE

--- a/srcpkgs/python3-changelogs/template
+++ b/srcpkgs/python3-changelogs/template
@@ -1,20 +1,19 @@
 # Template file for 'python3-changelogs'
 pkgname=python3-changelogs
-version=0.14.0
-revision=3
+version=0.15.0
+revision=1
 wrksrc="changelogs-${version}"
 build_style=python3-module
-pycompile_module="changelogs"
 hostmakedepends="python3-setuptools"
-depends="python3-requests python3-lxml python3-packaging python3-validators
- python3-gitchangelog"
+depends="python3-requests python3-lxml python3-packaging
+ python3-validators python3-gitchangelog"
 short_desc="Changelog finder and parser for vendors like PyPi and npm"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/pyupio/changelogs"
 changelog="https://raw.githubusercontent.com/pyupio/changelogs/master/HISTORY.rst"
 distfiles="https://github.com/pyupio/changelogs/archive/${version}.tar.gz"
-checksum=90f5e631e580f928b732e3941a5ce26520ba53879bd95daab57018e01dbfabc7
+checksum=d2c14fd7c0847effe2f8eaebf33d77c7872c60f246aa592ca6906a1b32c02b9c
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-ffmpeg-python/template
+++ b/srcpkgs/python3-ffmpeg-python/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ffmpeg-python'
 pkgname=python3-ffmpeg-python
 version=0.2.0
-revision=2
+revision=3
 wrksrc="ffmpeg-python-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -13,3 +13,8 @@ license="Apache-2.0"
 homepage="https://github.com/kkroening/ffmpeg-python"
 distfiles="https://github.com/kkroening/ffmpeg-python/archive/${version}.tar.gz"
 checksum="01b6b7640f00585a404194a358358bdf7f4050cedcd99f41416ac8b27222c9f1"
+
+post_patch() {
+	# Build doesn't *need* pytest-runner and Void doesn't provide it
+	vsed -e '/pytest-runner/d' -i setup.py
+}

--- a/srcpkgs/python3-gitchangelog/patches/setup.cfg.patch
+++ b/srcpkgs/python3-gitchangelog/patches/setup.cfg.patch
@@ -1,0 +1,25 @@
+Make sure that setuptools_scm actually installs the module and entrypoint.
+
+--- setup.cfg	2021-01-28 10:10:54.291152917 -0500
++++ setup.cfg	2021-01-28 10:13:12.191007896 -0500
+@@ -61,3 +61,20 @@
+ tag_date = 0
+ tag_svn_revision = 0
+
++[options]
++packages = 
++	gitchangelog
++package_dir =
++	=src
++setup_requires =
++	setuptools
++	setuptools-scm
++
++[options.entry_points]
++console_scripts = 
++	gitchangelog = gitchangelog.gitchangelog:main
++
++[options.package_data]
++gitchangelog =
++	gitchangelog.rc.*
++	templates/**/*

--- a/srcpkgs/python3-gitchangelog/patches/setup.py.patch
+++ b/srcpkgs/python3-gitchangelog/patches/setup.py.patch
@@ -1,0 +1,25 @@
+The d2to1 package is defunct and not offered by Void; roughly equivalent
+functionality is provided by setuptools_scm, which is provided by Void. Drop
+the special d2to1 setup call to allow setuptools_scm to work properly.
+
+--- setup.py	2021-01-28 10:00:20.165871918 -0500
++++ setup.py	2021-01-28 10:01:07.760817952 -0500
+@@ -58,17 +58,4 @@
+ ## Normal d2to1 setup
+ ##
+ 
+-setup(
+-    setup_requires=['d2to1'],
+-    extras_require={
+-        'Mustache': ["pystache", ],
+-        'Mako': ["mako", ],
+-        'test': [
+-            "nose",
+-            "minimock",
+-            "mako",
+-            "pystache",
+-        ],
+-    },
+-    d2to1=True
+-)
++setup(use_scm_version=True)

--- a/srcpkgs/python3-gitchangelog/template
+++ b/srcpkgs/python3-gitchangelog/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-gitchangelog'
 pkgname=python3-gitchangelog
 version=3.0.4
-revision=3
+revision=4
 wrksrc="gitchangelog-${version}"
 build_style=python3-module
-pycompile_module="gitchangelog"
-hostmakedepends="python3-setuptools git"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-pystache python3-Mako"
 short_desc="Creates a changelog from git log history"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/python3-guessit/template
+++ b/srcpkgs/python3-guessit/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-guessit'
 pkgname=python3-guessit
 version=3.1.1
-revision=2
+revision=3
 wrksrc="guessit-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,3 +12,8 @@ license="LGPL-3.0-only"
 homepage="https://guessit.readthedocs.io/en/latest/"
 distfiles="${PYPI_SITE}/g/guessit/guessit-${version}.tar.gz"
 checksum=71c68c6d4e9d639eba6534a838468115ad20f4c5a688eae3079f0c08d605a3b0
+
+post_patch() {
+	# Package does not *need* pytest-runner to build, and Void doesn't have it
+	vsed -e "/setup_requires/s/['\"]pytest-runner['\"],*//" -i setup.py
+}

--- a/srcpkgs/python3-humanize/template
+++ b/srcpkgs/python3-humanize/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-humanize'
 pkgname=python3-humanize
 version=2.0.0
-revision=2
+revision=3
 wrksrc="humanize-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 checkdepends="python3-pytest python3-freezegun"
 short_desc="Python humanize utilities"
 maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"

--- a/srcpkgs/python3-irc/template
+++ b/srcpkgs/python3-irc/template
@@ -1,11 +1,10 @@
 # Template file for 'python3-irc'
 pkgname=python3-irc
 version=17.1
-revision=3
+revision=4
 wrksrc="irc-${version}"
 build_style=python3-module
-pycompile_module="irc"
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-six"
 short_desc="Full-featured Python IRC library for Python3"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"

--- a/srcpkgs/python3-jaraco.classes/template
+++ b/srcpkgs/python3-jaraco.classes/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-jaraco.classes'
 pkgname=python3-jaraco.classes
 version=3.1.0
-revision=2
+revision=3
 wrksrc="jaraco.classes-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-jaraco python3-more-itertools"
 short_desc="Utility functions for Python class constructs (Python3)"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"

--- a/srcpkgs/python3-jaraco.collections/template
+++ b/srcpkgs/python3-jaraco.collections/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-jaraco.collections'
 pkgname=python3-jaraco.collections
 version=3.0.0
-revision=2
+revision=3
 wrksrc="jaraco.collections-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-jaraco.classes python3-jaraco.text python3-six"
 short_desc="Collection of objects similar to stdlib by jaraco (Python3)"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"

--- a/srcpkgs/python3-jaraco.functools/template
+++ b/srcpkgs/python3-jaraco.functools/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-jaraco.functools'
 pkgname=python3-jaraco.functools
 version=3.0.1
-revision=2
+revision=3
 wrksrc="jaraco.functools-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm python3-toml python3-more-itertools"
 depends="python3-more-itertools python3-jaraco"
 checkdepends="${depends} python3-pytest python3-jaraco.classes"
 short_desc="Functools like those found in stdlib (Python3)"

--- a/srcpkgs/python3-jaraco.text/template
+++ b/srcpkgs/python3-jaraco.text/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-jaraco.text'
 pkgname=python3-jaraco.text
 version=3.2.0
-revision=2
+revision=3
 wrksrc="jaraco.text-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-jaraco.functools python3-six"
 short_desc="Module for text manipulation (Python3)"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"

--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
 version=21.2.1
-revision=2
+revision=3
 wrksrc="keyring-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm python3-toml"
 depends="python3-setuptools python3-SecretStorage python3-entrypoints"
 short_desc="Python interface to the system keyring service"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"

--- a/srcpkgs/python3-keyrings-alt/template
+++ b/srcpkgs/python3-keyrings-alt/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-keyrings-alt'
 pkgname=python3-keyrings-alt
 version=4.0.2
-revision=1
+revision=2
 wrksrc="keyrings.alt-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm python3-toml"
 depends="python3-keyring"
 checkdepends="${depends} python3-pytest"
 short_desc="Alternate keyring backend implementations"

--- a/srcpkgs/python3-keyutils/template
+++ b/srcpkgs/python3-keyutils/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-keyutils'
 pkgname=python3-keyutils
 version=0.6
-revision=4
+revision=5
 wrksrc=python-keyutils-$version
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,3 +12,8 @@ license="Apache-2.0"
 homepage="https://github.com/sassoftware/python-keyutils"
 distfiles="https://github.com/sassoftware/python-keyutils/archive/${version}.tar.gz"
 checksum=f69e6cadc50525dcb117714e440ee6579b0e5b7f12910b2bb2e910b236a2b18b
+
+post_patch() {
+	# Package does not *need* pytest-runner to build, and Void doesn't have it
+	vsed -e "/setup_requires/s/['\"]pytest-runner['\"],*//" -i setup.py
+}

--- a/srcpkgs/python3-marisa-trie/template
+++ b/srcpkgs/python3-marisa-trie/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-marisa-trie'
 pkgname=python3-marisa-trie
 version=0.7.5
-revision=5
+revision=6
 wrksrc="marisa-trie-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython"
@@ -13,6 +13,11 @@ homepage="https://github.com/pytries/marisa-trie"
 changelog="https://raw.githubusercontent.com/pytries/marisa-trie/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/m/marisa-trie/marisa-trie-${version}.tar.gz"
 checksum=c73bc25d868e8c4ea7aa7f1e19892db07bba2463351269b05340ccfa06eb2baf
+
+post_patch() {
+	# Package does not *need* pytest-runner to build, and Void doesn't have it
+	vsed -e "/setup_requires/s/['\"]pytest-runner['\"],*//" -i setup.py
+}
 
 pre_build() {
 	rm -f src/marisa_trie.cpp

--- a/srcpkgs/python3-numexpr/template
+++ b/srcpkgs/python3-numexpr/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-numexpr'
 pkgname=python3-numexpr
 version=2.7.2
-revision=1
+revision=2
 wrksrc="numexpr-${version}"
 build_style=python3-module
 build_helper=numpy
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/pydata/numexpr"
 distfiles="https://github.com/pydata/numexpr/archive/v${version}.tar.gz"
-checksum=c939f806c179e9fcb80100f3cd32a748d14a6101c29fb102cc77844549c88291
+checksum=7d1b3790103221feda07f4a93a4fa5c6654f46865197a677ca6f27eb5cb4e5ef
 
 post_install() {
 	vlicense LICENSE.txt

--- a/srcpkgs/python3-pluggy/template
+++ b/srcpkgs/python3-pluggy/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pluggy'
 pkgname=python3-pluggy
 version=0.13.1
-revision=5
+revision=6
 wrksrc="pluggy-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3"
 checkdepends="python3-pytest"
 short_desc="Minimalist production ready plugin system (Python3)"

--- a/srcpkgs/python3-portend/template
+++ b/srcpkgs/python3-portend/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-portend'
 pkgname=python3-portend
 version=2.7.0
-revision=1
+revision=2
 wrksrc="portend-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools_scm"
+hostmakedepends="python3-setuptools_scm python3-toml"
 depends="python3-tempora python3-jaraco.functools"
 short_desc="TCP port monitoring utilities (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/python3-pylast/template
+++ b/srcpkgs/python3-pylast/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pylast'
 pkgname=python3-pylast
 version=4.1.0
-revision=1
+revision=2
 wrksrc="pylast-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3"
 short_desc="Python3 interface to last.fm and libre.fm"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"

--- a/srcpkgs/python3-pysol_cards/template
+++ b/srcpkgs/python3-pysol_cards/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pysol_cards'
 pkgname=python3-pysol_cards
 version=0.10.1
-revision=2
+revision=3
 wrksrc="pysol_cards-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools python3-pbr"
 depends="python3-pbr python3-six"
 checkdepends="python3-appdirs python3-attrs python3-colorama python3-coverage
  python3-cryptography python3-dogpile.cache python3-future python3-jmespath

--- a/srcpkgs/python3-pytest-qt/template
+++ b/srcpkgs/python3-pytest-qt/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-pytest-qt'
 pkgname=python3-pytest-qt
 version=3.3.0
-revision=2
+revision=3
 wrksrc=pytest-qt-${version}
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-pytest"
 checkdepends="$depends python3-pyside2 python3-PyQt5 python3-pytest-xvfb
  xdpyinfo"

--- a/srcpkgs/python3-rebulk/template
+++ b/srcpkgs/python3-rebulk/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-rebulk'
 pkgname=python3-rebulk
 version=2.0.1
-revision=3
+revision=4
 wrksrc="rebulk-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,6 +12,11 @@ license="MIT"
 homepage="https://github.com/Toilal/rebulk"
 distfiles="${PYPI_SITE}/r/rebulk/rebulk-${version}.tar.gz"
 checksum=320ded3cc456347d828f95e9aa5f8bab77ac01943cad024c06012069fe19690a
+
+post_patch() {
+	# Package does not *need* pytest-runner to build, and Void doesn't have it
+	vsed -e "/setup_requires/s/['\"]pytest-runner['\"],*//" -i setup.py
+}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-setuptools/template
+++ b/srcpkgs/python3-setuptools/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-setuptools'
 pkgname=python3-setuptools
-version=51.3.3
+version=52.0.0
 revision=1
 wrksrc="setuptools-${version}"
 build_style=python3-module
@@ -14,8 +14,7 @@ license="MIT"
 homepage="https://github.com/pypa/setuptools"
 changelog="https://raw.githubusercontent.com/pypa/setuptools/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/s/setuptools/setuptools-${version}.tar.gz"
-checksum=127ec775c4772bfaf2050557b00c4be6e019e52dc2e171a3fb1cd474783a2497
-alternatives="setuptools:easy_install:/usr/bin/easy_install3"
+checksum=fb3a1ee622509550dbf1d419f241296169d7f09cb1eb5b1736f2f10965932b96
 provides="python3-distribute-${version}_1"
 replaces="python3-distribute>=0"
 
@@ -31,5 +30,4 @@ do_check() {
 
 post_install() {
 	vlicense LICENSE
-	mv ${PKGDESTDIR}/usr/bin/easy_install ${PKGDESTDIR}/usr/bin/easy_install3
 }

--- a/srcpkgs/python3-testtools/template
+++ b/srcpkgs/python3-testtools/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-testtools'
 pkgname=python3-testtools
 version=2.4.0
-revision=2
+revision=3
 wrksrc="testtools-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools python3-pbr"
 short_desc="Python3 standard library unit testing framework"
 maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="MIT"

--- a/srcpkgs/python3-treq/template
+++ b/srcpkgs/python3-treq/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-treq'
 pkgname=python3-treq
 version=20.3.0
-revision=2
+revision=3
 wrksrc="treq-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-incremental python3-requests>=2.1.0 python3-six
+hostmakedepends="python3-setuptools python3-incremental"
+depends="python3-incremental python3-requests python3-six
  python3-Twisted python3-attrs"
 short_desc="Requests-like API built on top of twisted.web's Agent"
 maintainer="Orphaned <orphan@voidlinux.org>"

--- a/srcpkgs/python3-zope.security/template
+++ b/srcpkgs/python3-zope.security/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-zope.security'
 pkgname=python3-zope.security
 version=5.1.1
-revision=2
+revision=3
 wrksrc="zope.security-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-distutils-extra"
+hostmakedepends="python3-setuptools python3-zope.proxy"
 makedepends="python3-devel"
 depends="python3-zope.component python3-zope.configuration python3-zope.testing
  python3-zope.testrunner python3-zope.location"

--- a/srcpkgs/rdiff-backup/template
+++ b/srcpkgs/rdiff-backup/template
@@ -1,11 +1,11 @@
 # Template file for 'rdiff-backup'
 pkgname=rdiff-backup
 version=2.0.5
-revision=2
+revision=3
 build_style=python3-module
-hostmakedepends="python3 python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 makedepends="python3-devel librsync-devel"
-depends="python3 python3-pyxattr"
+depends="python3-pyxattr"
 short_desc="Local/remote mirroring and incremental backups"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/terminator/template
+++ b/srcpkgs/terminator/template
@@ -1,7 +1,7 @@
 # Template file for 'terminator'
 pkgname=terminator
 version=2.0.1
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="intltool python3-setuptools"
 depends="desktop-file-utils gsettings-desktop-schemas libkeybinder3 libnotify
@@ -13,3 +13,8 @@ homepage="https://gnome-terminator.org"
 changelog="https://raw.githubusercontent.com/gnome-terminator/terminator/master/CHANGELOG.md"
 distfiles="https://github.com/gnome-terminator/terminator/releases/download/v$version/terminator-$version.tar.gz"
 checksum=e6a21ea18c48b9dcb8fac3b48fd90bc49768de13c2a749047c46a6e0f14abb24
+
+post_patch() {
+	# Package does not *need* pytest-runner to build, and Void doesn't have it
+	vsed -e '/pytest-runner/d' -i setup.py
+}

--- a/srcpkgs/todoman/template
+++ b/srcpkgs/todoman/template
@@ -1,9 +1,9 @@
 # Template file for 'todoman'
 pkgname=todoman
 version=3.8.0
-revision=2
+revision=3
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 depends="python3-icalendar python3-urwid python3-xdg python3-parsedatetime
  python3-atomicwrites python3-click-repl python3-configobj python3-click-log
  python3-dateutil python3-tabulate python3-humanize"

--- a/srcpkgs/whipper/template
+++ b/srcpkgs/whipper/template
@@ -1,9 +1,9 @@
 # Template file for 'whipper'
 pkgname=whipper
 version=0.9.0
-revision=2
+revision=3
 build_style=python3-module
-hostmakedepends="python3-setuptools"
+hostmakedepends="python3-setuptools_scm"
 makedepends="libsndfile-devel python3-devel"
 depends="libcdio-paranoia cdrdao python3-gobject python3-musicbrainzngs
  python3-mutagen python3-requests python3-pycdio python3-discid


### PR DESCRIPTION
This release drops `easy_install`, which will cause hard failures when building python-module or python3-module templates that do not specify all of their setup_requires dependencies in `hostmakedepends`. This is a good thing; before, setuptools would fetch setup dependencies on its own, negatively impacting the reproducibility of package builds.

Still, I am going to run through rebuilds of some (most? all?) of the `python3-*` packages to check for build-time breakage.