### PR TITLE
xbps-src: Clear subpkg data before printing subpkg

### DIFF
--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -354,7 +354,6 @@ rust-doc_package() {
 
 rust-std_package() {
 	short_desc+=" - standard library"
-	depends=""
 	pkg_install() {
 		vmove usr/lib/rustlib
 	}

--- a/xbps-src
+++ b/xbps-src
@@ -836,6 +836,7 @@ case "$XBPS_TARGET" in
         read_pkg ignore-problems
         for sub_name in $subpackages; do
             if [ $sub_name = $XBPS_TARGET_PKG ]; then
+                . ${XBPS_COMMONDIR}/environment/setup-subpkg/subpkg.sh
                 ${sub_name}_package
             fi
         done
@@ -859,6 +860,7 @@ case "$XBPS_TARGET" in
         read_pkg ignore-problems
         for sub_name in $subpackages; do
             if [ $sub_name = $XBPS_TARGET_PKG ]; then
+                . ${XBPS_COMMONDIR}/environment/setup-subpkg/subpkg.sh
                 ${sub_name}_package
             fi
         done
@@ -885,6 +887,34 @@ case "$XBPS_TARGET" in
                         printf "%s\n" "$(printf "${print_var% }" | tr -t '\n\r' ' ')"
                 fi # The trailing space gets stripped before printing anyway
         done
+        ;;
+    dbulk-dump)
+        read_pkg
+        for x in pkgname version revision; do
+            printf '%s: %s\n' "$x" "${!x}"
+        done
+        for x in hostmakedepends makedepends depends; do
+            arr=(${!x})
+            if [[ ${#arr} -gt 0 ]]; then
+                printf '%s:\n' "$x"
+                printf ' %s\n' "${arr[@]}"
+            fi
+        done
+        if [[ $subpackages ]]; then
+            printf 'subpackages:\n'
+            for x in ${subpackages}; do
+                . ${XBPS_COMMONDIR}/environment/setup-subpkg/subpkg.sh
+                ${x}_package
+                printf ' %s\n' "$x"
+                for x in depends; do
+                    arr=(${!x})
+                    if [[ ${#arr} -gt 0 ]]; then
+                        printf '  %s:\n' "$x"
+                        printf '   %s\n' "${arr[@]}"
+                    fi
+                done
+            done
+        fi
         ;;
     show-options)
         read_pkg ignore-problems


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
