### PR TITLE
mozjs78: fix homepage and don't append to *FLAGS in top level.

### DIFF
--- a/srcpkgs/mozjs78/template
+++ b/srcpkgs/mozjs78/template
@@ -14,13 +14,13 @@ depends="nspr>=4.19"
 short_desc="Mozilla JavaScript interpreter and library (78.x series)"
 maintainer="q66 <daniel@octaforge.org>"
 license="MPL-2.0"
-homepage="https://www.mozilla.org/js/"
+homepage="https://www.mozilla.org/firefox/"
 distfiles="${MOZILLA_SITE}/firefox/releases/${version}esr/source/firefox-${version}esr.source.tar.xz"
 checksum=965ccfcbb8c0aa97639911997c54be0fcf896fd388b03138952089af675ea918
 patch_args="-Np1"
 
-CXXFLAGS+=" -Wno-class-memaccess"
-LDFLAGS+=" -Wl,-z,stack-size=1048576"
+CXXFLAGS="-Wno-class-memaccess"
+LDFLAGS="-Wl,-z,stack-size=1048576"
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
