### PR TITLE
Update python3-aiohttp_socks to 0.5.5 and add dependencies

### DIFF
--- a/srcpkgs/python3-aiohttp_socks/template
+++ b/srcpkgs/python3-aiohttp_socks/template
@@ -1,15 +1,15 @@
 # Template file for 'python3-aiohttp_socks'
 pkgname=python3-aiohttp_socks
-version=0.2.2
-revision=3
+version=0.5.5
+revision=1
 wrksrc="aiohttp_socks-${version}"
 build_style=python3-module
-pycompile_module="aiohttp_socks"
 hostmakedepends="python3-setuptools"
-depends="python3-aiohttp"
+depends="python3-aiohttp python3-socks"
+checkdepends="python3-aiohttp python3-attrs python3-socks"
 short_desc="SOCKS proxy connector for aiohttp"
 maintainer="Christian Buschau <christian.buschau@mailbox.org>"
 license="Apache-2.0"
 homepage="https://github.com/romis2012/aiohttp-socks"
 distfiles="${PYPI_SITE}/a/aiohttp_socks/aiohttp_socks-${version}.tar.gz"
-checksum=eebd8939a7c3c1e3e7e1b2552c60039b4c65ef6b8b2351efcbdd98290538e310
+checksum=2eb2059756bde34c55bb429541cbf2eba3fd53e36ac80875b461221e2858b04a

--- a/srcpkgs/python3-curio/template
+++ b/srcpkgs/python3-curio/template
@@ -1,0 +1,25 @@
+# Template file for 'python3-curio'
+pkgname=python3-curio
+version=1.4
+revision=1
+wrksrc="curio-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Coroutine-based library for concurrent programming using async/await"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/dabeaz/curio"
+distfiles="${PYPI_SITE}/c/curio/curio-${version}.tar.gz"
+checksum=57edce81c837f3c2cf42fbb346dee26e537d1659e6605269fb13bd179e068744
+
+do_check() {
+	# CI container has different privileges than expected in test_errors()
+	# which leads to CI builds timing out on some arches.
+	PYTHONPATH=$(cd build/lib* && pwd) pytest -k 'not test_errors'
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-outcome/template
+++ b/srcpkgs/python3-outcome/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-outcome'
+pkgname=python3-outcome
+version=1.1.0
+revision=1
+wrksrc="outcome-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest python3-pytest-cov python3-pytest-asyncio"
+short_desc="Capture the outcome of Python function calls"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/python-trio/outcome"
+distfiles="${PYPI_SITE}/o/outcome/outcome-${version}.tar.gz"
+checksum=e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967
+
+do_check() {
+	PYTHONPATH=$(cd build/lib* && pwd) pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-sniffio/template
+++ b/srcpkgs/python3-sniffio/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-sniffio'
+pkgname=python3-sniffio
+version=1.2.0
+revision=1
+wrksrc="sniffio-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-pytest python3-pytest-cov python3-curio"
+short_desc="Sniff out which async library your code is running under"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/python-trio/sniffio"
+distfiles="${PYPI_SITE}/s/sniffio/sniffio-${version}.tar.gz"
+checksum=c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de
+
+do_check() {
+	PYTHONPATH=$(cd build/lib* && pwd) pytest
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-socks/template
+++ b/srcpkgs/python3-socks/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-socks'
+pkgname=python3-socks
+version=1.2.0
+revision=1
+wrksrc="python-socks-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+checkdepends="python3-async-timeout python3-curio python3-trio python3-attrs
+ python3-async_generator python3-sniffio python3-sortedcontainers
+ python3-outcome python3-idna"
+# Optional dependencies:
+# async-timeout >= 3.0.1
+# trio >= 0.16.0
+# curio >= 1.4
+short_desc="Core proxy client functionality for Python"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/romis2012/python-socks"
+distfiles="${PYPI_SITE}/p/python-socks/python-socks-${version}.tar.gz"
+checksum=3054a8afa984a35144198e00fed1144eeae3287cc231ac7db3908d32ab642cd4

--- a/srcpkgs/python3-trio/template
+++ b/srcpkgs/python3-trio/template
@@ -1,0 +1,31 @@
+# Template file for 'python3-trio'
+pkgname=python3-trio
+version=0.18.0
+revision=1
+wrksrc="trio-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-async_generator>=1.9 python3-attrs>=19.2.0 python3-idna
+ python3-outcome python3-sniffio python3-sortedcontainers"
+checkdepends="python3-pytest python3-pytest-cov python3-ipython python3-pylint
+ python3-jedi black python3-mypy python3-flake8
+ python3-async_generator>=1.9 python3-attrs>=19.2.0
+ python3-idna python3-outcome python3-sniffio python3-sortedcontainers"
+short_desc="Friendly Python library for async concurrency and I/O"
+maintainer="Arjan Mossel <arjanmossel@gmail.com>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/python-trio/trio"
+distfiles="${PYPI_SITE}/t/trio/trio-${version}.tar.gz"
+checksum=87a66ae61f27fe500c9024926a9ba482c07e1e0f56380b70a264d19c435ba076
+
+# Tests also need the following to be packaged:
+# pyOpenSSL https://pypi.org/project/pyOpenSSL/
+# trustme https://pypi.org/project/trustme/
+# astor https://pypi.org/project/astor/
+do_check() {
+	:
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x ] This ~~is~~ includes ~~a~~ new package**s** and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Overview
- Electrum 4 depends on a newer version of `aiohttp_socks` than is currently packaged ([electrum-4.0.9 update here](https://github.com/void-linux/void-packages/pull/28305)).
- `aiohttp_socks` >= 0.5.4 depends on `python-socks`, added as new package here.
- `python-socks` has optional dependencies on `python-curio` and `python-trio`; however these libraries are needed in order to pass `python-socks` tests, so they are also added as new packages here.
- `python-trio` depends on `sniffio` and `outcome` libraries, also added as new packages here.
- `python-trio` tests also depend on `pyOpenSSL`, `trustme`, and `astor` which are not available, so its tests are skipped for now.

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

Dependencies added:

    python3-socks-1.2.0
    python3-curio-1.4
    python3-trio-0.18.0
    python3-outcome-1.1.0
    python3-sniffio-1.2.0