### PR TITLE
hooks/pre-pkg/03-rewrite-python-shebang.sh: use grep -r instead of find.

### DIFF
--- a/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
+++ b/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
@@ -16,7 +16,7 @@ hook() {
 		default_shebang="#!/usr/bin/python${pyver%.*}"
 	fi
 
-	find "${PKGDESTDIR}" -type f -print0 | \
+	grep -rlIZ -m1 '^#!.*python' "${PKGDESTDIR}" |
 		while IFS= read -r -d '' file; do
 			[ ! -s "$file" ] && continue
 


### PR DESCRIPTION
This saves us one sed execution per file in the destdir, resulting
in a major speedup.

Grep will only consider text files and only look at the first line.
