### PR TITLE
[WIP] hooks/post-install: speed up 06-strip-and-debug-pkgs.sh.

### DIFF
--- a/common/hooks/post-install/06-strip-and-debug-pkgs.sh
+++ b/common/hooks/post-install/06-strip-and-debug-pkgs.sh
@@ -65,10 +65,10 @@ hook() {
 
 	STRIPCMD=/usr/bin/$STRIP
 
-	find ${PKGDESTDIR} -type f | while read f; do
-		if [[ $f =~ ^${PKGDESTDIR}/usr/lib/debug/ ]]; then
-			continue
-		fi
+	find ${PKGDESTDIR} \
+		\( -path ${PKGDESTDIR}/usr/share -o -path ${PKGDESTDIR}/usr/lib/debug \) -prune \
+		-false -o -type f |
+		while read f; do
 
 		fname=${f##*/}
 		for x in ${nostrip_files}; do


### PR DESCRIPTION
Files under /usr/share can't be stripped at all, since they shouldn't be
ELFs (if they are ELFs, they are unlikely to be ELFs for the target and
suitable for being stripped / debugged).

Since some big data packages have a lot of files /usr/share, this can
considerably speed up the hook, for no change in the package output.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
