### PR TITLE
wayland: update to 0.19.0, adopt.

### DIFF
--- a/srcpkgs/wayland/template
+++ b/srcpkgs/wayland/template
@@ -1,19 +1,18 @@
 # Template file for 'wayland'
 pkgname=wayland
-version=1.18.0
-revision=3
+version=1.19.0
+revision=1
 build_style=meson
-configure_args="-Ddocumentation=false"
+# "Tests must not be built with NDEBUG defined, they rely on assert()."
+configure_args="-Ddocumentation=false -Db_ndebug=false"
 hostmakedepends="flex pkg-config"
 makedepends="expat-devel libffi-devel libfl-devel libxml2-devel"
 short_desc="Wayland protocol compositor"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://wayland.freedesktop.org/"
 distfiles="https://wayland.freedesktop.org/releases/wayland-${version}.tar.xz"
-checksum=4675a79f091020817a98fd0484e7208c8762242266967f55a67776936c2e294d
-
-CFLAGS="-UNDEBUG"
+checksum=baccd902300d354581cd5ad3cc49daa4921d55fb416a5883e218750fef166d15
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" wayland-devel"


### PR DESCRIPTION
Also fix ndebug mode with meson options instead of CFLAGS.

I don't know why `-UNDEBUG` was initially added, though. In 0f7885c6d61c2814c98420e6791885c02280a981 it isn't explained.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me (though I haven't gone through extensive testing)
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
