### PR TITLE
librsvg: update to 2.50.3.

### DIFF
--- a/srcpkgs/librsvg/template
+++ b/srcpkgs/librsvg/template
@@ -1,7 +1,6 @@
 # Template file for 'librsvg'
 pkgname=librsvg
-# https://gitlab.gnome.org/GNOME/librsvg/-/issues/604
-version=2.48.8
+version=2.50.3
 revision=1
 build_style=gnu-configure
 build_helper="gir"
@@ -13,11 +12,14 @@ short_desc="SVG library for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/LibRsvg"
+# update changelog when release series changes
+changelog="https://gitlab.gnome.org/GNOME/librsvg/-/raw/librsvg-2.50/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=f480a325bbdf26d1874eb6fb330ebc5920ba64e3e08de61931bb4506dfef2692
+checksum=a4298a98e3a95fdd73c858c17d4dd018525fb09dbb13bbd668a0c2243989e958
 
 do_check() {
-	# reference files are for pango 1.44.x, we're on 1.42.x
+	# reference files are for specific pango and harfbuzz versions
+	# the test suite isn't designed to be run by distros
 	:
 }
 
@@ -29,12 +31,8 @@ librsvg-devel_package() {
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
 		vmove usr/share/gtk-doc
-		if [ "$build_option_gir" ]; then
-			vmove usr/share/gir-1.0
-		fi
-		if [ "$build_option_vala" ]; then
-			vmove usr/share/vala
-		fi
+		vmove usr/share/gir-1.0
+		vmove usr/share/vala
 	}
 }
 librsvg-utils_package() {


### PR DESCRIPTION
Remove outdated comments and re-enable checks.

Remove forgotten conditionals for vmoves. Would have built erroneous
packages.

@q66 want to test?

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
