### PR TITLE
dehydrated: update to 0.7.0.

### DIFF
--- a/srcpkgs/dehydrated/template
+++ b/srcpkgs/dehydrated/template
@@ -1,7 +1,7 @@
 # Template file for 'dehydrated'
 pkgname=dehydrated
-version=0.6.5
-revision=2
+version=0.7.0
+revision=1
 depends="curl"
 short_desc="Acme client implemented as a shell-script – just add water"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
@@ -9,7 +9,7 @@ license="MIT"
 homepage="https://dehydrated.io/"
 changelog="https://raw.githubusercontent.com/lukas2511/dehydrated/master/CHANGELOG"
 distfiles="https://github.com/lukas2511/dehydrated/releases/download/v${version}/dehydrated-${version}.tar.gz"
-checksum=10aabd0027450bc70a18e49acaca7a9697e0cfb92368d3e508b7a4d6d69bfa35
+checksum=1c5f12c2e57e64b1762803f82f0f7e767a72e65a6ce68e4d1ec197e61b9dc4f9
 conf_files="/etc/dehydrated/config
  /etc/dehydrated/domains.txt
  /etc/dehydrated/hook.sh"


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

This release fixes handling of ocsp with libressl.