### PR TITLE
ghdl: broken if no backend available

### DIFF
--- a/srcpkgs/ghdl/template
+++ b/srcpkgs/ghdl/template
@@ -20,17 +20,22 @@ checksum=3008616201cc3b0b596872e4ad59d8bc36e6ee3ff798bdce066828fbdad041e4
 nocross=yes
 patch_args="-Np1"
 
+if [ "$build_option_mcode" ]; then
+	depends="ghdl-mcode>=${version}_${revision}"
+elif [ "$build_option_llvm" ]; then
+	depends="ghdl-llvm>=${version}_${revision}"
+elif [ "$build_options_default" ]; then
+	# We don't want to see the broken message on the first pass.
+	# On the second pass, when build_options_default is set
+	# and no build_options have been set, mark broken.
+	broken="need a backend"
+fi
+
 build_options="llvm mcode"
 build_options_default="llvm"
 
 desc_option_llvm="Build the portable LLVM backend"
 desc_option_mcode="Build the x86-only mcode backend"
-
-if [ "$build_option_mcode" ]; then
-	depends=" ghdl-mcode>=${version}_${revision}"
-elif [ "$build_option_llvm" ]; then
-	depends=" ghdl-llvm>=${version}_${revision}"
-fi
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*)
@@ -42,15 +47,7 @@ case "$XBPS_TARGET_MACHINE" in
 		fi
 esac
 
-# get around xbps-src's broken 2-pass option eval
-unset subpackages
-
-if [ "$build_option_mcode" ]; then
-	subpackages+=" ghdl-mcode"
-fi
-
 if [ "$build_option_llvm" ]; then
-	subpackages+=" ghdl-llvm"
 	makedepends+=" llvm11"
 fi
 
@@ -123,18 +120,22 @@ do_check() {
 	done
 }
 
-ghdl-mcode_package() {
-	short_desc+=" - mcode backend"
-	pkg_install() {
-		vmove usr/bin/ghdl-mcode
-		vmove usr/lib/ghdl/mcode
+if [ "$build_option_mcode" ]; then
+	ghdl-mcode_package() {
+		short_desc+=" - mcode backend"
+		pkg_install() {
+			vmove usr/bin/ghdl-mcode
+			vmove usr/lib/ghdl/mcode
+		}
 	}
-}
+fi
 
-ghdl-llvm_package() {
-	short_desc+=" - LLVM backend"
-	pkg_install() {
-		vmove usr/bin/ghdl-llvm
-		vmove usr/lib/ghdl/llvm
+if [ "$build_option_llvm" ]; then
+	ghdl-llvm_package() {
+		short_desc+=" - LLVM backend"
+		pkg_install() {
+			vmove usr/bin/ghdl-llvm
+			vmove usr/lib/ghdl/llvm
+		}
 	}
-}
+fi


### PR DESCRIPTION
While we're at it, let xbps-src figure out which subpackages will be
built. I don't like `unset`.

---
@q66 feel free to revert the `subpackages` calculation part. Beside my dislike to unset, I think conditional definition of subpackages can reduce one warning :-p