### PR TITLE
bind: clean up outdated seccomp build option.

### DIFF
--- a/srcpkgs/bind/template
+++ b/srcpkgs/bind/template
@@ -1,7 +1,7 @@
 # Template file for 'bind'
 pkgname=bind
 version=9.16.7
-revision=1
+revision=2
 _fullver="${version}${_patchver:+-${_patchver}}"
 wrksrc="${pkgname}-${_fullver}"
 build_style=gnu-configure
@@ -11,12 +11,11 @@ configure_args="--disable-static --enable-threads --enable-largefile
  --with-libtool --with-openssl=${XBPS_CROSS_BASE}/usr --with-gssapi=/usr/bin
  --without-gost --enable-openssl-hash --with-readline --with-tuning=default
  --without-python --enable-fetchlimit --enable-sit
- --with-libidn2 $(vopt_enable seccomp)
+ --with-libidn2
  $(vopt_if geoip "--with-geoip=${XBPS_CROSS_BASE}/usr" "--without-geoip")"
 hostmakedepends="automake libtool perl pkg-config"
 makedepends="libressl-devel libxml2-devel libcap-devel readline-devel mit-krb5-devel
- libatomic-devel libidn2-devel libuv-devel $(vopt_if geoip geoip-devel)
- $(vopt_if seccomp libseccomp-devel)"
+ libatomic-devel libidn2-devel libuv-devel $(vopt_if geoip geoip-devel)"
 short_desc="Berkeley Internet Name Domain server"
 maintainer="Randy McCaskill <randy@mccaskill.us>"
 license="MPL-2.0"
@@ -31,12 +30,8 @@ named_descr="BIND DNS server"
 named_homedir="/var/named"
 make_dirs="/var/named 0770 root named"
 
-build_options="geoip seccomp"
+build_options="geoip"
 build_options_default="geoip"
-
-case "$XBPS_TARGET_MACHINE" in
-	x86_64*|i686*) build_options_default+=" seccomp";;
-esac
 
 do_check() {
 	# requires special network setup


### PR DESCRIPTION
Revbump to show updated options in package.

It also shows some more warnings:

```
Unrecognized options:
    --enable-threads, --enable-atomic, --enable-ipv6, --with-randomdev, --with-ecdsa, --with-eddsa, --without-gost, --enable-openssl-hash, --enable-fetchlimit, --enable-sit, --enable-seccomp, --with-geoip
```

The help output says geoip should be `--disable-geoip`, not what we are currently passing.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
