### PR TITLE
bind: fix named service.

### DIFF
--- a/srcpkgs/bind/files/named/log/run
+++ b/srcpkgs/bind/files/named/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -t named

--- a/srcpkgs/bind/files/named/run
+++ b/srcpkgs/bind/files/named/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+exec 2>&1
 mkdir -p /var/run/named || exit 1
 chown named:named /var/run/named || exit 1
-exec named -u named -f -c /etc/named/named.conf
+exec named -u named -g -c /etc/named/named.conf

--- a/srcpkgs/bind/template
+++ b/srcpkgs/bind/template
@@ -1,7 +1,7 @@
 # Template file for 'bind'
 pkgname=bind
 version=9.16.7
-revision=2
+revision=3
 _fullver="${version}${_patchver:+-${_patchver}}"
 wrksrc="${pkgname}-${_fullver}"
 build_style=gnu-configure


### PR DESCRIPTION
When used with the -f option, it can crash, likely due to a lack of
syslog. Using -g makes it work but still keeps it in the foreground, by
logging directly to stderr.

Fixes #18961.

Would appreciate confirmation from someone actively using named.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
