### PR TITLE
testdisk: Add missing ncurses-base dependency

### DIFF
--- a/srcpkgs/testdisk/template
+++ b/srcpkgs/testdisk/template
@@ -1,15 +1,15 @@
 # Template file for 'testdisk'
 pkgname=testdisk
 version=7.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--without-ewf --enable-sudo"
 makedepends="libjpeg-turbo-devel libuuid-devel e2fsprogs-devel
  ntfs-3g-devel ncurses-devel"
-depends="sudo"
+depends="sudo ncurses-base"
 short_desc="Powerful free data recovery software"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.cgsecurity.org/"
 distfiles="http://www.cgsecurity.org/$pkgname-$version.tar.bz2"
 checksum=1413c47569e48c5b22653b943d48136cb228abcbd6f03da109c4df63382190fe


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
