### PR TITLE
mymcplus: update to 3.0.4

### DIFF
--- a/srcpkgs/mymcplus/template
+++ b/srcpkgs/mymcplus/template
@@ -1,13 +1,14 @@
 # Template file for 'mymcplus'
 pkgname=mymcplus
-version=3.0.3
-revision=2
+version=3.0.4
+revision=1
+wrksrc=${pkgname}-v${version}
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="wxPython4 python3-PyOpenGL"
 short_desc="PlayStation 2 memory card manager"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/thestr4ng3r/mymcplus"
+homepage="https://git.sr.ht/~thestr4ng3r/mymcplus"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=9cbbe0162c19b386524f17db7613968cedea58d75fe3f6b307789d4953f6c71f
+checksum=f94b485f83590b59b87fa5fbe8311d1eb0f03490edb60fd64aadbdbea0588472


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)

This project moved to sourcehut so I've updated the links. Current version held in void-packages won't run under py3.9
I only tested the CLI portion of this program, I don't think the GUI works, but I think that is because wxPython is borked?

Edit: odd, CI logs seem to complain about the only two deps wxPython and pyOpenGL but I did not see this behavior when building locally
