### PR TITLE
[RFC] environment/configure/hardening: add -Werror=implicit.

### DIFF
--- a/common/build-style/gnu-configure.sh
+++ b/common/build-style/gnu-configure.sh
@@ -4,6 +4,8 @@
 do_configure() {
 	: ${configure_script:=./configure}
 
+	export CFLAGS="${CFLAGS/-Werror=implicit-function-declaration/}"
+	echo $CFLAGS
 	export lt_cv_sys_lib_dlsearch_path_spec="/usr/lib64 /usr/lib32 /usr/lib /lib /usr/local/lib"
 	${configure_script} ${configure_args}
 }

--- a/common/environment/configure/hardening.sh
+++ b/common/environment/configure/hardening.sh
@@ -28,3 +28,5 @@ else
 	FFLAGS="-fno-PIE ${FFLAGS}"
 	LDFLAGS="-no-pie ${LDFLAGS}"
 fi
+
+CFLAGS+=" -Werror=implicit-function-declaration"


### PR DESCRIPTION
Warnings for implicit function definitions should be errors, since they
can lead to issues down the line when the implicit type rules get things
wrong, especially with variadic functions.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
