### PR TITLE
New package: python3-adblock-0.4.2

### DIFF
--- a/common/build-helper/rust.sh
+++ b/common/build-helper/rust.sh
@@ -17,6 +17,12 @@ if [ "$CROSS_BUILD" ]; then
 	# [build]
 	# target = ${RUST_TARGET}
 	export CARGO_BUILD_TARGET="$RUST_TARGET"
+
+	# If cc-rs needs to build host binaries, it guesses the compiler and
+	# uses default (wrong) flags unless they are specified explicitly;
+	# innocuous flags are used here just to disable its defaults
+	export HOST_CC="gcc"
+	export HOST_CFLAGS="-O2"
 else
 	unset CARGO_BUILD_TARGET
 fi

--- a/srcpkgs/maturin/template
+++ b/srcpkgs/maturin/template
@@ -1,0 +1,36 @@
+# Template file for 'maturin'
+pkgname=maturin
+version=0.9.0
+revision=1
+build_style=cargo
+# Disable the 'rustls' feature, which leads to bad platform compatibility
+# The list of enabled features should be reconciled with each new release
+configure_args="--no-default-features --features auditwheel,log,upload,human-panic"
+hostmakedepends="python3-setuptools python3-toml"
+makedepends="libressl-devel"
+depends="python3-toml"
+short_desc="Build and publish crates as python packages"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/PyO3/maturin"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=22e8082a743e1dc11f5909b596f9053deb7dc1a56336003677381ba02cf67da8
+
+post_patch() {
+	# setup.py is broken, just use it for the pure python part
+	vsed -e 's/cmdclass.*/packages=["maturin"],/' -i setup.py
+}
+
+post_build() {
+	# python package is pure; the cross environment is not relevant
+	python3 setup.py build
+}
+
+do_check() {
+	echo "Tests use unstable features and fail to build; skipping"
+}
+
+post_install() {
+	vlicense license-mit LICENSE-MIT
+	python3 setup.py install --prefix=/usr --root=${DESTDIR}
+}

--- a/srcpkgs/python3-adblock/template
+++ b/srcpkgs/python3-adblock/template
@@ -1,0 +1,46 @@
+# Template file for 'python3-adblock'
+pkgname=python3-adblock
+version=0.4.2
+revision=1
+wrksrc="${pkgname/python3/python}-${version}"
+build_style=python3-pep517
+build_helper="rust"
+hostmakedepends="maturin pkg-config cargo libressl-devel"
+makedepends="libressl-devel python3-devel"
+depends="python3"
+checkdepends="python3-pytest"
+short_desc="Brave's adblock library in Python"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="Apache-2.0, MIT"
+homepage="https://github.com/ArniDagur/python-adblock"
+distfiles="${homepage}/archive/${version}.tar.gz"
+checksum=06de6074e6cfe889fc0383cc929a5a2306570251c14e51abbfcedd328b83e0e9
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*) broken="compiler throws SIGABRT on the psl crate" ;;
+esac
+
+if [ "$CROSS_BUILD" ]; then
+	makedepends+=" rust-std"
+	export PYO3_CROSS_LIB_DIR="${XBPS_CROSS_BASE}/usr/lib"
+	export PYO3_CROSS_INCLUDE_DIR="${XBPS_CROSS_BASE}/usr/include"
+fi
+
+do_build() {
+	maturin build -o . --release --target "${RUST_TARGET}" --manylinux off
+
+	# Drop platform specifiers from the wheel; pip will refuse to install,
+	# e.g., an armv7l wheel on an aarch64 system even if the masterdir is
+	# armv7l. The wheel is correct; no need for name compatibility checks.
+	mv adblock-${version}-*.whl adblock-${version}-py3-none-any.whl
+}
+
+pre_check() {
+	# Tests require the compiled extension
+	cp target/${RUST_TARGET}/release/libadblock.so adblock/adblock.so
+}
+
+post_install() {
+	vlicense LICENSE-MIT
+	chmod 755 ${DESTDIR}/${py3_sitelib}/adblock/*.so
+}


### PR DESCRIPTION
This supersedes #28380 and #27490.

Compiles natively on `x86_64*`, `aarch64` and `armv7l`. Works as expected on `x86_64` and `aarch64`. I haven't tried the other ARM architectures.

I can't figure out what happens with `openssl-sys` when cross-compiling; the flags passed to GCC include `-m64`, which are rejected by the ARM compilers. On `i686`, the build fails with SIGABRT when trying to build the `psl` crate. The `openssl-sys` issue appears even if I try using the built-in `cargo` build style rather than `maturin`, so this is some configuration problem that extends beyond `maturin`.

Any help fixing these issue would be appreciated. If we can't sort them out, `broken` on `i686` and `nocross` will be sufficient for now.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
