### PR TITLE
[RFC/POC] Support checks for signify signature inside xbps-src

### DIFF
--- a/common/signify-keys/mblaze.pub
+++ b/common/signify-keys/mblaze.pub
@@ -1,0 +1,2 @@
+untrusted comment: mblaze release key public key
+RWT/F+mCqnmHzj/+dB32aXOuZ+4Afcr3r6TOVHXGkRNCBExd3kS0tCnL

--- a/srcpkgs/base-chroot/template
+++ b/srcpkgs/base-chroot/template
@@ -1,7 +1,7 @@
 # Template file for 'base-chroot'
 pkgname=base-chroot
-version=0.66
-revision=3
+version=0.67
+revision=1
 bootstrap=yes
 build_style=meta
 short_desc="Minimal set of packages required for chroot with xbps-src"
@@ -19,4 +19,4 @@ depends+="
  patch sed findutils diffutils make gzip coreutils
  file bsdtar ccache xbps mpfr ncurses libreadline8
  chroot-bash chroot-grep chroot-gawk chroot-distcc
- chroot-util-linux chroot-git"
+ chroot-util-linux chroot-git outils"

--- a/srcpkgs/mblaze/template
+++ b/srcpkgs/mblaze/template
@@ -9,6 +9,8 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain, MIT"
 homepage="https://github.com/leahneukirchen/mblaze"
 distfiles="https://leahneukirchen.org/releases/${pkgname}-${version}.tar.gz"
+signify_sig="https://leahneukirchen.org/releases/${pkgname}-${version}.tar.gz.sig"
+signify_key="mblaze.pub"
 checksum=edd8cb86f667543e703dee58263b81c7e47744339d23ebbb6a43e75059ba93b1
 
 post_install() {

--- a/srcpkgs/mblaze/template
+++ b/srcpkgs/mblaze/template
@@ -3,6 +3,7 @@ pkgname=mblaze
 version=1.1
 revision=1
 build_style=gnu-makefile
+hostmakedepends="outils"
 checkdepends="perl"
 short_desc="Maildir-focused command line mail client"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

The idea was flown around on IRC and it tickled me. It's probably of very limited utility, but who knows, maybe the recent PGP crisis drive people towards signify :P 

It's very very simple, and only really supports a single distfile per template. Maybe it should loop through `signify_sigs` instead? I don't think things are being downloaded in the best place either.

I think this is unlikely to have much support, so other maintainers feel free to close the issue; if anyone thinks it's worth it, we can improve on it and potentially merge some day?

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
