### PR TITLE
anydesk: update to 6.1.0,

### DIFF
--- a/srcpkgs/anydesk/template
+++ b/srcpkgs/anydesk/template
@@ -1,8 +1,8 @@
 # Template file for 'anydesk'
 pkgname=anydesk
-version=6.0.1
-revision=3
-archs="i686 x86_64"
+version=6.1.0
+revision=1
+archs="x86_64"
 create_wrksrc=yes
 hostmakedepends="patchelf rpmextract w3m"
 short_desc="Fast remote desktop application"
@@ -13,12 +13,9 @@ homepage="https://anydesk.com/remote-desktop"
 nopie=yes
 restricted=yes
 
-distfiles="https://download.anydesk.com/linux/anydesk_$version-1_$XBPS_TARGET_MACHINE.rpm"
-if [ "${XBPS_TARGET_MACHINE}" = "x86_64" ] ; then
-	checksum=df029878486944bf0400e90746fe738eee0fc3f849e7f47f19d432fcb357c03e
-elif [ "${XBPS_TARGET_MACHINE}" = "i686" ]; then
-	checksum=b92a366a8233be44f556c81f274bdce3e527591987cc4c8d2b490fcd410305ed
-fi
+distfiles="https://download.anydesk.com/linux/anydesk_$version-1_x86_64.rpm"
+checksum=35772d898afa8cba0f410775fdd7e1e8e7b753130c906db94801895c0ea74754
+
 _eula_digest=f6386c15e187b6eac0ccd2564d3a873ae07d4b46a6b61dda13464caf5d54a319
 
 post_extract() {


### PR DESCRIPTION
- also drop i686 - upstream has ended support for 32bit.


#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
