### PR TITLE
libopenmpt: update to 0.5.5

### DIFF
--- a/srcpkgs/libopenmpt/template
+++ b/srcpkgs/libopenmpt/template
@@ -1,33 +1,31 @@
 # Template file for 'libopenmpt'
 pkgname=libopenmpt
-version=0.5.4
+version=0.5.5
 revision=1
 wrksrc="libopenmpt-${version}+release.autotools"
 build_style=gnu-configure
-configure_args="$(vopt_with pulseaudio)
- $(vopt_with sdl) $(vopt_with sdl2)
- $(vopt_enable libopenmpt_modplug) $(vopt_enable libmodplug)"
+configure_args="$(vopt_with pulseaudio) $(vopt_with sdl2)
+ $(vopt_with portaudio) $(vopt_with portaudio portaudiocpp)"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel mpg123-devel libogg-devel libvorbis-devel
- portaudio-devel portaudio-cpp-devel libsndfile-devel libflac-devel
+makedepends="zlib-devel libsndfile-devel
+ libflac-devel mpg123-devel libogg-devel libvorbis-devel
  $(vopt_if pulseaudio pulseaudio-devel) $(vopt_if sdl2 SDL2-devel)
- $(vopt_if sdl SDL-devel)"
+ $(vopt_if portaudio portaudio-cpp-devel)"
 short_desc="Cross-platform C & C++ library to decode tracked music files (modules)"
 maintainer="a dinosaur <nick@a-dinosaur.com>"
 license="BSD-3-Clause"
 homepage="https://lib.openmpt.org/libopenmpt/"
 distfiles="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${version}+release.autotools.tar.gz"
-checksum=f34d06b9daa7bca111625369e5bbc2e7c0e0e04737a439b0e6320811babcef40
-conflicts="$(vopt_if libmodplug libmodplug)"
+checksum=f1e01483ebf1a680d9ec030c9af20f5f2a5ac0f1e0642c18bd5593cfaa9ceb6b
 
 post_install() {
 	vlicense LICENSE
 }
 
 # Package build options
-build_options="pulseaudio sdl2 sdl libopenmpt_modplug libmodplug"
-build_options_default="pulseaudio"
-vopt_conflict sdl2 sdl
+build_options="pulseaudio sdl2 portaudio"
+build_options_default="pulseaudio sdl2 portaudio"
+desc_option_portaudio="Enable support for the PortAudio backend"
 
 libopenmpt-devel_package() {
 	depends="${sourcepkg}-${version}_${revision}"


### PR DESCRIPTION
- remove obsolete build options
- make PortAudio a build option
- build with SDL2 by default
- add option descriptions

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl
-->
