### PR TITLE
shlibs: remove libs from removed packages

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -56,8 +56,6 @@ libitm.so.1 libitm-4.7.3_1
 liblto_plugin.so.0 gcc-4.7.3_1
 libgcc_s.so.1 libgcc-4.4.0_1
 libgo.so.16 libgo-10.2.0_1
-libmpx.so.2 libmpx-6.2.1_1
-libmpxwrappers.so.2 libmpx-6.2.1_1
 libperl.so.5.32 perl-5.32.0_1
 libgmp.so.10 gmp-5.0.1_1
 libgmpxx.so.4 gmpxx-6.0.0_2
@@ -128,7 +126,6 @@ libbrcmGLESv2.so rpi-userland-20180103_2
 libbrcmOpenVG.so rpi-userland-20180103_2
 libwayland-egl.so.1 wayland-1.15.0_4
 libnvidia-ml.so.1 nvidia-libs-346.47_1 ignore
-libnvidia-ml.so.1 nvidia304-libs-304.00_1 ignore
 libnvidia-ml.so.1 nvidia390-libs-390.87_1 ignore
 libnvidia-tls.so.346.47 nvidia-libs-346.47_1 ignore
 libnvidia-glcore.so.346.47 nvidia-libs-346.47_1 ignore
@@ -314,7 +311,6 @@ libtiffxx.so.5 tiff-4.0.0_1
 libnotify.so.4 libnotify-0.7_1
 libexo-1.so.0 exo-0.7.3_1
 libexo-2.so.0 exo-0.12.0_1
-libvte.so.9 vte-0.20.1_1
 libglade-2.0.so.0 libglade-2.6.4_1
 libglademm-2.4.so.1 libglademm-2.6.7_1
 libthunarx-3.so.0 Thunar-1.8.1_1
@@ -430,26 +426,6 @@ libmpeg2.so.0 libmpeg2-0.5.1_1
 libmpeg2convert.so.0 libmpeg2-0.5.1_1
 libmng.so.2 libmng-2.0.2_1
 libQgpsmm.so.25 gpsd-qt-3.20_1
-libQtAssistantClient.so qt-4.5.3_1
-libQtXmlPatterns.so.4 qt-4.5.3_1
-libQtScriptTools.so.4 qt-4.5.3_1
-libQtCLucene.so.4 qt-4.5.3_1
-libQtMultimedia.so.4 qt-4.5.3_1
-libQtGui.so.4 qt-4.5.3_1
-libQtDBus.so.4 qt-4.5.3_1
-libQtNetwork.so.4 qt-4.5.3_1
-libQtOpenGL.so.4 qt-4.5.3_1
-libQtXml.so.4 qt-4.5.3_1
-libQtTest.so.4 qt-4.5.3_1
-libQt3Support.so.4 qt-4.5.3_1
-libQtSvg.so.4 qt-4.5.3_1
-libQtScript.so.4 qt-4.5.3_1
-libQtHelp.so.4 qt-4.5.3_1
-libQtCore.so.4 qt-4.5.3_1
-libQtSql.so.4 qt-4.5.3_1
-libQtDeclarative.so.4 qt-4.5.3_1
-libQtDesignerComponents.so.4 qt-designer-libs-4.7.8_13
-libQtDesigner.so.4 qt-designer-libs-4.7.8_13
 libsysfs.so.2 libsysfs-2.1.0_1
 libsensors.so.5 libsensors-3.5.0_1
 libcap-ng.so.0 libcap-ng-0.6.2_1
@@ -1025,7 +1001,6 @@ libnilfscleaner.so.0 libnilfs-2.1.0_1
 libchicken.so.11 libchicken-5.1.0_1
 libmdb.so.0 libmdb-0.5_1
 libmdbsql.so.0 libmdb-0.5_1
-libkeybinder.so.0 libkeybinder2-0.3.0_1
 libkmod.so.2 libkmod-5_1
 libestr.so.0 libestr-0.1.2_1
 libee.so.0 libee-0.3.2_1
@@ -1388,7 +1363,6 @@ libsolarus.so.1 solarus-1.6.2_1
 libsolarus-gui.so.1 solarus-1.6.2_1
 libplank.so.1 plank-0.11.0_1
 libssh.so.4 libssh-0.5.4_1
-libqjson.so.0 qjson-0.8.1_1
 libxcb-render-util.so.0 xcb-util-renderutil-0.3.8_1
 libKPimGAPIContacts.so.5 libkgapi-17.12.3_1
 libKPimGAPIBlogger.so.5 libkgapi-17.12.3_1
@@ -1782,9 +1756,6 @@ libid3.so id3lib-3.8.3_1
 libid3-3.8.so.3 id3lib-3.8.3_1
 libgirara-gtk3.so.3 girara-0.2.8_1
 libjq.so.1 jq-devel-1.4_1
-libcrypto.so.43 libcrypto43-2.7.2_1
-libssl.so.45 libssl45-2.7.2_1
-libtls.so.17 libtls17-2.7.2_1
 libvamp-hostsdk.so.3 libvamp-plugin-sdk-2.2_6
 libportmidi.so portmidi-217_1
 libWildMidi.so.2 libwildmidi-0.4.3_1
@@ -2098,7 +2069,6 @@ libopencv_stereo.so.4.3 libopencv4-4.3.0_1
 libopencv_rapid.so.4.3 libopencv4-4.3.0_1
 libopencv_intensity_transform.so.4.3 libopencv4-4.3.0_1
 libopencv_alphamat.so.4.3 libopencv4-4.3.0_1
-libcgmanager.so.0 libcgmanager-0.33_1
 libuniconf.so.4.6 wvstreams-4.6.1_2
 libwvbase.so.4.6 wvstreams-4.6.1_1
 libwvutils.so.4.6 wvstreams-4.6.1_1
@@ -2113,7 +2083,6 @@ libfcitx-core.so.0 libfcitx-4.2.8_1
 libfcitx-gclient.so.1 libfcitx-4.2.9.5_1
 libfcitx-utils.so.0 libfcitx-4.2.8_1
 libfcitx-config.so.4 libfcitx-4.2.8_1
-libfcitx-qt.so.0 libfcitx-qt-4.2.8_1
 libFcitxQt5DBusAddons.so.1 libfcitx-qt5-1.2.1_1
 libFcitxQt5WidgetsAddons.so.1 libfcitx-qt5-1.2.1_1
 libfcitx-qt5.so.0 libfcitx-qt5-0.1.3_1
@@ -2324,7 +2293,6 @@ libtbb.so.2 tbb-4.3_1
 libtbbmalloc_debug.so.2 tbb-4.3_1
 libembree.so.2 embree-2.5.1_1
 libgtkimageview.so.0 gtkimageview-1.6.4_1
-libgoocanvas.so.3 goocanvas1-1.0.0_1
 libgoocanvas-2.0.so.9 goocanvas-2.0.4_1
 libp8-platform.so.2 p8-platform-2.1.0.1_1
 libOIS.so.1.5.0 ois-1.5_1
@@ -2811,8 +2779,6 @@ libmono-btls-shared.so mono-5.2.0.215_1
 libxcb-xrm.so.0 xcb-util-xrm-1.0_1
 libinchi.so.0 openbabel-2.3.2_1
 libopenbabel.so.5 openbabel-2.4.1_1
-libavogadro.so.1 avogadro-1.2.0_1
-libavogadro_OpenQube.so.0 avogadro-1.2.0_1
 libcourier-unicode.so.4 courier-unicode-2.0_1
 libzstd.so.1 libzstd-1.0.0_1
 libudis86.so.0 udis86-1.7.2_4
@@ -3097,10 +3063,6 @@ libccext2-1.8.so.0 commoncpp2-1.8.1_1
 libucommon.so.8 ucommon-7.0.0_1
 libusecure.so.8 ucommon-7.0.0_1
 libcommoncpp.so.8 ucommon-7.0.0_1
-libmupdf.so.1.13.0 libmupdf-1.13.0_1
-libmupdfthird.so.1.13.0 libmupdf-1.13.0_1
-libmuthreads.so.1.13.0 libmupdf-1.13.0_1
-libmupkcs7.so.1.13.0 libmupdf-1.13.0_1
 libdatrie.so.1 libdatrie-0.2.10_1
 libthai.so.0 libthai-0.1.26_1
 libm17n-flt.so.0 m17n-lib-1.7.0_1
@@ -3383,7 +3345,6 @@ libvtkverdict-9.0.so.1 vtk-9.0.1_1
 libvolume_key.so.1 volume_key-0.3.9_1
 librand48_r.so.0 rand48_r-0.1_1
 libxxhash.so.0 libxxHash-0.6.5_2
-libfwup.so.1 libfwup-11_1
 libcapnp_c.so.0 c-capnproto-0.3_1
 libTKBin.so.7 occt-7.2.0p1_1
 libTKDraw.so.7 occt-7.2.0p1_1
@@ -3549,12 +3510,6 @@ libmanette-0.2.so.0 libmanette-0.2.1_1
 libfmt.so.7 fmt-7.0.3_1
 libelementary-calendar.so.0 libio.elementary.calendar-4.2.3_1
 libolm.so.3 olm-3.0.0_1
-libcrypto.so.44 libcrypto44-2.8.2_1
-libtls.so.18 libtls18-2.8.2_1
-libssl.so.46 libssl46-2.8.2_1
-libcrypto.so.45 libcrypto45-2.9.2_1
-libtls.so.19 libtls19-2.9.2_1
-libssl.so.47 libssl47-2.9.2_1
 libcrypto.so.46 libcrypto46-3.1.1_1
 libtls.so.20 libtls20-3.1.1_1
 libssl.so.48 libssl48-3.1.1_1
@@ -3900,7 +3855,6 @@ librdkafka++.so.1 librdkafka-1.3.0_1
 libco.so.0 libco-20_1
 libraft.so.0 raft-0.9.16_1
 libmdnsd.so.1 libmdnsd-0.9_1
-libPtex.so ptex-2.3.2_1
 libosdGPU.so.3.4.3 OpenSubdiv-3.4.3_1
 libosdCPU.so.3.4.3 OpenSubdiv-3.4.3_1
 libdino.so.0 dino-0.1.0_1


### PR DESCRIPTION
libEGL, libGL, libGLES left as they are virtuals now.

Fixes build of wps-office.