### PR TITLE
kops: update to 1.19.0

### DIFF
--- a/srcpkgs/kops/template
+++ b/srcpkgs/kops/template
@@ -1,7 +1,7 @@
 # Template file for 'kops'
 pkgname=kops
-version=1.15.1
-revision=1
+version=1.19.0
+revision=2
 archs="x86_64*"
 build_wrksrc=src/k8s.io/kops
 build_style=go
@@ -18,7 +18,7 @@ do_fetch() {
 	# process expects the directory to be a git repository
 	rm -rf $wrksrc
 	mkdir -p $wrksrc/src/k8s.io
-	git clone -b ${version} https://github.com/kubernetes/kops \
+	git clone -b v${version} https://github.com/kubernetes/kops \
 		$wrksrc/src/k8s.io/kops
 }
 


### PR DESCRIPTION
I had to change the checkout flow since they stopped publishing version related branches.

The new flow checks out the version tag.