### PR TITLE
[RFC] mumble: build umurmur without Ice rpc support

### DIFF
--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,14 +1,15 @@
 # Template file for 'mumble'
 pkgname=mumble
 version=1.3.3
-revision=4
+revision=5
 build_style=qmake
 configure_args="CONFIG+=bundled-celt CONFIG+=no-bundled-opus CONFIG+=no-update
  CONFIG+=no-bundled-speex CONFIG+=no-g15 CONFIG+=no-xevie CONFIG+=pulseaudio
  $(vopt_if jack CONFIG+=jackaudio) CONFIG+=no-embed-qt-translations
- CONFIG+=no-oss CONFIG+=portaudio DEFINES+=PLUGIN_PATH=/usr/lib/mumble"
-hostmakedepends="Ice pkg-config protobuf qt5-host-tools qt5-qmake python3 which"
-makedepends="Ice-devel MesaLib-devel avahi-compat-libs-devel boost-devel
+ CONFIG+=no-oss CONFIG+=portaudio CONFIG+=no-ice
+ DEFINES+=PLUGIN_PATH=/usr/lib/mumble"
+hostmakedepends="pkg-config protobuf qt5-host-tools qt5-qmake python3 which"
+makedepends="MesaLib-devel avahi-compat-libs-devel boost-devel
  libcap-devel libressl-devel libsndfile-devel opus-devel protobuf-devel
  pulseaudio-devel $(vopt_if jack jack-devel) qt5-devel qt5-svg-devel
  speech-dispatcher-devel speex-devel portaudio-devel"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
@Hoshpak  We currently use umurmur with an ancient Ice version from 2013 which nobody ever bothered to update, but a this old Ice version doesn't support recent OpenSSL versions.
I would propose to just drop Ice and build mumble without support for it.
If you would like to keep Ice support, than please update the package.

#### Have the results of the proposed changes been tested?
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
