### PR TITLE
plymouth: update to 0.9.5.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2751,10 +2751,6 @@ libTKXmlXCAF.so.11 oce-0.18_1
 libTKernel.so.11 oce-0.18_1
 libKF5CoreAddons.so.5 kcoreaddons-5.26.0_1
 librpmatch.so.0 musl-rpmatch-1.0_1
-libply.so.4 plymouth-0.9.2_1
-libply-splash-core.so.4 plymouth-0.9.2_1
-libply-splash-graphics.so.4 plymouth-0.9.2_1
-libply-boot-client.so.4 plymouth-0.9.2_1
 libmilter.so.1.0.2 libmilter-1.0.2_1
 libopendkim.so.10 opendkim-2.10.3_1
 libtevent.so.0 tevent-0.9.28_1

--- a/srcpkgs/plymouth/template
+++ b/srcpkgs/plymouth/template
@@ -1,15 +1,15 @@
 # Template file for 'plymouth'
 pkgname=plymouth
-version=0.9.4
-revision=2
+version=0.9.5
+revision=1
 build_style=gnu-configure
 configure_args="--with-system-root-install=no \
  --without-rhgb-compat-link --enable-systemd-integration=no \
- --enable-gdm-transition $(vopt_enable gtk3 gtk) $(vopt_enable pango) \
+ $(vopt_enable gtk3 gtk) $(vopt_enable pango) \
  --with-logo=/usr/share/void-artwork/void-transparent.png --localstatedir=/ \
  --disable-documentation"
 conf_files="/etc/plymouth/plymouthd.conf"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config gettext"
 makedepends="libdrm-devel libpng-devel void-artwork
  $(vopt_if gtk3 gtk+3-devel) $(vopt_if pango pango-devel)"
 depends="plymouth-data>=0"
@@ -18,7 +18,7 @@ maintainer="William OD <obirik2005@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/Plymouth/"
 distfiles="${FREEDESKTOP_SITE}/plymouth/releases/$pkgname-$version.tar.xz"
-checksum=4a197a4f1a05785d7453dd829b231352fb2d09171bd86c5ffaafbb2dd6791351
+checksum=ecae257f351d098340542a5bc06de029404c24dcee87e6ebb2abd5ef117fce86
 
 build_options="gtk3 pango"
 build_options_default="gtk3 pango"


### PR DESCRIPTION
`--enable-gdm-transition` was deprecated in 2012. `gettext` is now needed to translate the user visible strings.
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
