### PR TITLE
[NOMERGE] libgit2: update to 1.1.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1359,7 +1359,7 @@ libunwind-ppc64.so.8 libunwind-1.2.1_1
 libunwind-setjmp.so.0 libunwind-1.4_1
 libmicrohttpd.so.12 libmicrohttpd-0.9.48_1
 libmicrodns.so.0 libmicrodns-0.1.0_1
-libgit2.so.1.0 libgit2-1.0.0_1
+libgit2.so.1.1 libgit2-1.1.0_1
 libgit2-glib-1.0.so.0 libgit2-glib-0.23.4_1
 libagg.so.2 agg-2.5_1
 libzzip-0.so.13 zziplib-0.13.62_1

--- a/srcpkgs/libgit2/template
+++ b/srcpkgs/libgit2/template
@@ -1,7 +1,7 @@
 # Template file for 'libgit2'
 pkgname=libgit2
-version=1.0.1
-revision=2
+version=1.1.0
+revision=1
 build_style=cmake
 hostmakedepends="python3 git pkg-config"
 makedepends="zlib-devel libressl-devel http-parser-devel libssh2-devel"
@@ -10,7 +10,7 @@ maintainer="q66 <daniel@octaforge.org>"
 license="custom:GPL-2.0-or-later WITH GCC-exception-2.0"
 homepage="https://libgit2.org"
 distfiles="https://github.com/libgit2/libgit2/archive/v${version}.tar.gz"
-checksum=1775427a6098f441ddbaa5bd4e9b8a043c7401e450ed761e69a415530fea81d2
+checksum=41a6d5d740fd608674c7db8685685f45535323e73e784062cf000a633d420d1e
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Latest release from October, 2020, but it had some regressions regarding unaligned access, which I believe affect us.

See https://github.com/libgit2/libgit2/issues/5745

PR is open so hopefully anyone who searches for it is aware that it's not fully working right now. We could backport the specific patch for that issue, but I don't fully fancy it.

@q66 since your name is here :P