### PR TITLE
perl: fix provides version

### DIFF
--- a/srcpkgs/perl/files/update-perl-provides.pl
+++ b/srcpkgs/perl/files/update-perl-provides.pl
@@ -166,6 +166,8 @@ sub pkgspec
     #print STDOUT "2 dist $dist\n";
     $ver =~ tr/././s; # only one period at a time
     $ver =~ s/\A[.]|[.]\z//g; # shouldn't start or stop with a period
+    $ver =~ s/(\d)_(\d)/$1.$2/g; # retain 1.12 < 1.12_01 < 1.13 order in xbps ...
+    $ver =~ s/^([0-9.]+);/'$1';/; # ... then turn broken numeric literal into string
     $ver = eval $ver;
     my $rev = "_1";
     my $res = "perl-$dist-$ver" . $rev;

--- a/srcpkgs/perl/template
+++ b/srcpkgs/perl/template
@@ -1,7 +1,7 @@
 # Template file for 'perl'
 pkgname=perl
 version=5.32.1
-revision=1
+revision=2
 _perl_cross_version=1.3.5
 build_style=gnu-configure
 hostmakedepends="less"
@@ -32,11 +32,11 @@ provides="perl-Archive-Tar-2.36_1
  perl-Compress-Raw-Zlib-2.093_1
  perl-Config-Perl-V-0.32_1
  perl-DB_File-1.853_1
- perl-Data-Dumper-2.174_01_1
+ perl-Data-Dumper-2.174.01_1
  perl-Devel-PPPort-3.57_1
  perl-Devel-SelfStubber-1.06_1
- perl-Digest-1.17_01_1
- perl-Digest-MD5-2.55_01_1
+ perl-Digest-1.17.01_1
+ perl-Digest-MD5-2.55.01_1
  perl-Digest-SHA-6.02_1
  perl-Dumpvalue-1.21_1
  perl-Encode-3.06_1
@@ -66,19 +66,19 @@ provides="perl-Archive-Tar-2.36_1
  perl-IPC-SysV-2.07_1
  perl-JSON-PP-4.04_1
  perl-Locale-Maketext-1.29_1
- perl-Locale-Maketext-Simple-0.21_01_1
+ perl-Locale-Maketext-Simple-0.21.01_1
  perl-MIME-Base64-3.15_1
  perl-Math-BigInt-1.999818_1
  perl-Math-BigInt-FastCalc-0.5009_1
  perl-Math-BigRat-0.2614_1
- perl-Math-Complex-1.5901_1
- perl-Memoize-1.03_01_1
+ perl-Math-Complex-1.59.01_1
+ perl-Memoize-1.03.01_1
  perl-Module-CoreList-5.20210123_1
  perl-Module-Load-0.34_1
  perl-Module-Load-Conditional-0.70_1
  perl-Module-Loaded-0.08_1
  perl-Module-Metadata-1.000037_1
- perl-NEXT-0.67_01_1
+ perl-NEXT-0.67.01_1
  perl-Net-Ping-2.72_1
  perl-Params-Check-0.38_1
  perl-PathTools-3.78_1
@@ -89,7 +89,7 @@ provides="perl-Archive-Tar-2.36_1
  perl-Pod-Perldoc-3.2801_1
  perl-Pod-Simple-3.40_1
  perl-Pod-Usage-1.69_1
- perl-Safe-2.41_01_1
+ perl-Safe-2.41.01_1
  perl-Scalar-List-Utils-1.55_1
  perl-Search-Dict-1.07_1
  perl-SelfLoader-1.26_1
@@ -117,7 +117,7 @@ provides="perl-Archive-Tar-2.36_1
  perl-Unicode-Collate-1.27_1
  perl-Unicode-Normalize-1.27_1
  perl-Win32-0.53_1
- perl-Win32API-File-0.1203_01_1
+ perl-Win32API-File-0.1203.01_1
  perl-XSLoader-0.30_1
  perl-autodie-2.32_1
  perl-autouse-1.11_1


### PR DESCRIPTION
For purpose of version sorting, xbps interprets every number following
an underscore as revision, see mkcomponent in dewey.c.
Rewrite version with dot, so perl's float semantic is retained.