### PR TITLE
libXpresent: don't depend on xproto.

### DIFF
--- a/srcpkgs/libXpresent/template
+++ b/srcpkgs/libXpresent/template
@@ -1,7 +1,7 @@
 # Template file for 'libXpresent'
 pkgname=libXpresent
 version=1.0.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config xorg-util-macros"
 makedepends="libXfixes-devel libXrandr-devel"
@@ -14,7 +14,7 @@ checksum=92f1bdfb67ae2ffcdb25ad72c02cac5e4912dc9bc792858240df1d7f105946fa
 
 libXpresent-devel_package() {
 	depends="${sourcepkg}-${version}_${revision} libX11-devel libXext-devel
-	 libXfixes-devel libXrandr-devel xorgproto xproto"
+	 libXfixes-devel libXrandr-devel xorgproto"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
xproto is provided by xorgproto, so the dependency can be fullfilled at
install time, but it can fail when building the package. Depending on a
non-existent package is also entirely wrong, this was likely a leftover
from the xproto removal.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
