### PR TITLE
wofi: revert the old patch for musl

### DIFF
--- a/srcpkgs/wofi/patches/fix-mode-thread.patch
+++ b/srcpkgs/wofi/patches/fix-mode-thread.patch
@@ -1,0 +1,30 @@
+# HG changeset patch
+# User Scoopta <scoopta@scoopta.email>
+# Date 1601697276 25200
+#      Fri Oct 02 20:54:36 2020 -0700
+# Node ID 8a4a5e29ca9c1fb0a11ed9b329d275f5c02154a6
+# Parent  ac8dc17ab751b13b6d4ddcc1a1467e4beb8d7d26
+The mode thread will not be joined multiple times as this causes segfaults under musl
+
+--- src/wofi.c
++++ src/wofi.c
+@@ -103,6 +103,7 @@
+ static bool dynamic_lines;
+ static struct wl_list mode_list;
+ static pthread_t mode_thread;
++static bool has_joined_mode = false;
+
+ static struct map* keys;
+
+@@ -596,7 +597,10 @@
+ }
+
+ static gboolean insert_all_widgets(gpointer data) {
+-	pthread_join(mode_thread, NULL);
++	if(!has_joined_mode) {
++		pthread_join(mode_thread, NULL);
++		has_joined_mode = true;
++	}
+ 	struct wl_list* modes = data;
+ 	if(modes->prev == modes) {
+ 		return FALSE;

--- a/srcpkgs/wofi/template
+++ b/srcpkgs/wofi/template
@@ -1,7 +1,7 @@
 # Template file for 'wofi'
 pkgname=wofi
 version=1.2.4
-revision=1
+revision=2
 wrksrc="${pkgname}-v${version}"
 build_style=meson
 hostmakedepends="pkg-config"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

My fault to suggest deleting the patch in previous commit.
1.2.4 only fixes the version number, and doesn't include this patch (even though this patch is already upstreamed)