### PR TITLE
vboot-utils: Add update check

### DIFF
--- a/srcpkgs/vboot-utils/template
+++ b/srcpkgs/vboot-utils/template
@@ -8,7 +8,7 @@ hostmakedepends="pkg-config git"
 makedepends="libressl-devel libuuid-devel liblzma-devel libyaml-devel"
 short_desc="Verified boot kernel utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="BSD"
+license="BSD-3-Clause"
 homepage="https://chromium.googlesource.com/chromiumos/platform/vboot_reference.git"
 CFLAGS='-D_GNU_SOURCE -Wno-error -fcommon'
 

--- a/srcpkgs/vboot-utils/update
+++ b/srcpkgs/vboot-utils/update
@@ -1,0 +1,3 @@
+site="https://chromium.googlesource.com/chromiumos/platform/vboot_reference.git/+refs?format=TEXT"
+pattern='refs/heads/release-R\K[\d]+-[\d]+'
+version=${version//./-}


### PR DESCRIPTION
Adds an update check that parses the git revision.  Also removes the need to keep track of a separate git hash.  Resolves complaint surfaced in #28507, but does not actually update the package as I have no time nor resources to test the functionality of this package.