### PR TITLE
gthumb: fix to run on wlroots compositor

### DIFF
--- a/srcpkgs/gthumb/template
+++ b/srcpkgs/gthumb/template
@@ -1,7 +1,7 @@
 # Template file for 'gthumb'
 pkgname=gthumb
 version=3.10.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="gettext pkg-config itstool glib-devel"
 makedepends="webkit2gtk-devel json-glib-devel libsecret-devel librsvg-devel
@@ -23,6 +23,10 @@ desc_option_brasero="Enable burning discs"
 desc_option_clutter="Enable clutter (for slideshows)"
 desc_option_soup="Enable webservices"
 build_options_default="clutter gstreamer soup"
+
+post_configure() {
+	vsed -e 's:Exec=gthumb %U:Exec=env CLUTTER_BACKEND=gdk gthumb %U:' -i data/org.gnome.gThumb.desktop.in.in
+}
 
 gthumb-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

Actually gthumb doesn't run on wlroots based compositor.
After asking on #sway irc channel they told me that this is a `clutter` problem https://gitlab.gnome.org/GNOME/clutter/-/merge_requests/5 and for now as workaround I can run gthumb with this command `CLUTTER_BACKEND=gdk gthumb`
I've tested this with wayland compositor and with X11 and it works in both cases.

So this PR just add this environmental variable to the gthumb .desktop file, obvious this only works if gthumb is launched by menu/launcher of file manager not if it is run by terminal.
