### PR TITLE
samba: update to 4.13.4

### DIFF
--- a/srcpkgs/samba/files/nmbd/run
+++ b/srcpkgs/samba/files/nmbd/run
@@ -1,6 +1,10 @@
 #!/bin/sh
 
+exec 2>&1
+
+[ -r ./conf ] && . ./conf
+
 mkdir -p /run/samba
 mkdir -p /run/lock/samba
 
-exec nmbd -F -S
+exec nmbd -F ${OPTS:--S -d1}

--- a/srcpkgs/samba/files/smbd/run
+++ b/srcpkgs/samba/files/smbd/run
@@ -1,6 +1,10 @@
 #!/bin/sh
 
+exec 2>&1
+
+[ -r ./conf ] &&  . ./conf
+
 mkdir -p /run/samba
 mkdir -p /run/lock/samba
 
-exec smbd -F -S
+exec smbd -F ${OPTS:--S -d1}

--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,6 +1,6 @@
 # Template file for 'samba'
 pkgname=samba
-version=4.13.3
+version=4.13.4
 revision=1
 build_style=waf3
 build_helper="qemu"
@@ -27,7 +27,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.samba.org"
 distfiles="http://download.samba.org/pub/samba/stable/${pkgname}-${version}.tar.gz"
-checksum=c10585d43f33656fe4e1f9ff8bf40ea57d8d5b653521c1cc198fbf4922756541
+checksum=a1b34c63f7100cc8626902d80f335c7cb0b45d4707dd3c4b010f7a28ed615c78
 lib32disabled=yes
 conf_files="/etc/pam.d/samba /etc/samba/smb.conf"
 make_dirs="/etc/samba/private 0750 root root"

--- a/srcpkgs/talloc/template
+++ b/srcpkgs/talloc/template
@@ -1,7 +1,7 @@
 # Template file for 'talloc'
 pkgname=talloc
-version=2.3.1
-revision=2
+version=2.3.2
+revision=1
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://talloc.samba.org/"
 distfiles="http://samba.org/ftp/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=ef4822d2fdafd2be8e0cabc3ec3c806ae29b8268e932c5e9a4cd5585f37f9f77
+checksum=27a03ef99e384d779124df755deb229cd1761f945eca6d200e8cfd9bf5297bd7
 
 export PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config"
 


### PR DESCRIPTION
Relatively minor update, but I'd appreciate a bit of testing, especially from @Anachron and @wangp who had some issues on `armv7l` or `aarch64`.

There is a caveat: I tried building this update while running the `smbd` and `nmbd` services from the current `samba-4.13.3_1` package. The resulting 4.13.4_1 package produced a broken `smbd` which died on startup with the error
```
svcctl_init_winreg: Could not open SYSTEM\CurrentControlSet\Services - NT_STATUS_INVALID_HANDLE
regdb_close: decrementing refcount (1->0)
dcesrv_init_ep_server: Failed to init endpoint server 'svcctl': NT_STATUS_UNSUCCESSFUL
dcesrv_init: Failed to init DCE/RPC endpoint servers: NT_STATUS_UNSUCCESSFUL
main: Failed to setup RPC server: NT_STATUS_UNSUCCESSFUL
exit_daemon: daemon failed to start: Samba cannot setup ep pipe, error code 13
```
Code 13 looks like `EACCES`, but this is a [hard-coded number](https://gitlab.com/samba-team/samba/-/blob/master/source3/smbd/server.c#L2104) that is independent of the actual reason for failure.

After removing `samba`, `smbclient` and `samba-libs` (which also required removing `cifs-utils` and `vlc` on my system) and rebuilding the package, `smbd` worked as expected. I tried a third rebuild with `samba`, `smbclient` and `samba-libs` installed but the services not active. This also seemed to produce a working package.

It seems that the build process allows the host configuration to leak through some how, and when the old services are running, something causes `smbd` to break. If you have similar troubles, I recommend first stopping any `nmbd` and `smbd` and rebuilding; if that still fails, try removing `samba-libs` and any dependants.

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me

