### PR TITLE
dstat: patch to silence collections warnings

### DIFF
--- a/srcpkgs/dstat/patches/dstat.patch
+++ b/srcpkgs/dstat/patches/dstat.patch
@@ -1,0 +1,20 @@
+--- dstat.orig  2020-11-21 17:50:21.000000000 -0800
++++ dstat       2021-02-04 22:50:28.970723977 -0800
+@@ -19,7 +19,7 @@
+ from __future__ import absolute_import, division, generators, print_function
+ __metaclass__ = type
+ 
+-import collections
++import collections.abc
+ import fnmatch
+ import getopt
+ import getpass
+@@ -512,7 +512,7 @@
+                 scale = self.scales[i]
+             else:
+                 scale = self.scale
+-            if isinstance(self.val[name], collections.Sequence) and not isinstance(self.val[name], six.string_types):
++            if isinstance(self.val[name], collections.abc.Sequence) and not isinstance(self.val[name], six.string_types):
+                 line = line + cprintlist(self.val[name], ctype, self.width, scale)
+                 sep = theme['frame'] + char['colon']
+                 if i + 1 != len(self.vars):

--- a/srcpkgs/dstat/template
+++ b/srcpkgs/dstat/template
@@ -1,7 +1,7 @@
 # Template file for 'dstat'
 pkgname=dstat
 version=0.7.4
-revision=3
+revision=4
 makedepends="python3"
 depends="python3-six"
 short_desc="Versatile tool for generating system resource statistics"


### PR DESCRIPTION
Development on dstat is dead so whenever Python makes good on their
threat of removing direct access to collections.Sequence it will fail.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
