### PR TITLE
[WIP] New package: linux-steam-integration-0.7.3

### DIFF
--- a/srcpkgs/linux-steam-integration/template
+++ b/srcpkgs/linux-steam-integration/template
@@ -1,0 +1,19 @@
+# Template file for 'linux-steam-integration'
+pkgname=linux-steam-integration
+version=0.7.3
+revision=1
+archs="x86_64* i686*"
+build_style=meson
+configure_args="-Dwith-shim=co-exist
+ -Dwith-steam-binary=/usr/bin/steam
+ -Dwith-new-libcxx-abi=true
+ -Dwith-libressl-mode=native
+ -Dwith-frontend=true"
+hostmakedepends="pkg-config"
+makedepends="gtk+3-devel"
+short_desc="Helper for enabling better Steam integration on Linux"
+maintainer="xolophreny <xolophreny@protonmail.ch>"
+license="LGPL-2.1-only"
+homepage="https://github.com/clearlinux/linux-steam-integration"
+distfiles="${homepage}/releases/download/v${version}/${pkgname}-${version}.tar.xz"
+checksum="be8f391ad786c09aa74aec83dc9077adf0863f92f297a1d361dfd61ed1108d41"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

Closes #19282, caveats:

- Needs both 64-bit and 32-bit packages installed to work properly
- Couldn't test if `liblsi-intercept.so` and `liblsi-redirect.so` work at all for the following reason:
- Manually installing replacements for steam runtime components is a challenge, at some point I got stuck with lsi-steam crashing at launch without meaningful errors, and regular steam with STEAM_RUNTIME=0 not launching with
```
src/clientdll/appdatacache.cpp (2640) : Assertion Failed: !bSharedKVSymbols
src/clientdll/appdatacache.cpp (2640) : Assertion Failed: !bSharedKVSymbols
```
whatever that might mean. I'm not sure if lsi-steam crash is related to lsi-steam or steam itself, any help would be appreciated.

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
