### PR TITLE
qt5: clean $wrksrc leak on cross

### DIFF
--- a/common/build-style/qmake.sh
+++ b/common/build-style/qmake.sh
@@ -28,7 +28,7 @@ do_configure() {
 		mkdir -p "${wrksrc}/.target-spec/linux-g++"
 		cat > "${wrksrc}/.target-spec/linux-g++/qmake.conf" <<_EOF
 MAKEFILE_GENERATOR      = UNIX
-CONFIG                 += incremental
+CONFIG                 += incremental no_qt_rpath
 QMAKE_INCREMENTAL_STYLE = sublib
 
 include(/usr/lib/qt5/mkspecs/common/linux.conf)
@@ -58,7 +58,7 @@ _EOF
 		mkdir -p "${wrksrc}/.host-spec/linux-g++"
 		cat > "${wrksrc}/.host-spec/linux-g++/qmake.conf" <<_EOF
 MAKEFILE_GENERATOR      = UNIX
-CONFIG                 += incremental
+CONFIG                 += incremental no_qt_rpath
 QMAKE_INCREMENTAL_STYLE = sublib
 
 include(/usr/lib/qt5/mkspecs/common/linux.conf)

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
 version=5.15.2
-revision=1
+revision=2
 wrksrc="qt-everywhere-src-${version}"
 build_style=meta
 hostmakedepends="cmake clang flex perl glib-devel pkg-config
@@ -314,6 +314,7 @@ do_install() {
 		make -f Makefile.target ${makejobs}
 		ln -sf ../lib/qt5/bin/qmake ${PKGDESTDIR}/usr/bin/qmake-qt5
 		cp -ar ${wrksrc}/qtbase/mkspecs ${PKGDESTDIR}/usr/lib/qt5
+		_cleanup_wrksrc_leak
 
 		#
 		# Build qmldevtools for the target


### PR DESCRIPTION
I'm still building to see if this is enough.
Discovered when I'm trying to remove `qt5*-devel` from `hostmakedepends` for `python3-PyQt5`
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
[ci skip]