### PR TITLE
gdm: enable smooth transition with plymouth.

### DIFF
--- a/srcpkgs/gdm/template
+++ b/srcpkgs/gdm/template
@@ -1,19 +1,20 @@
 # Template file for 'gdm'
 pkgname=gdm
 version=3.38.2.1
-revision=2
+revision=3
 build_helper="gir"
 build_style=meson
 configure_args="
  -Ddefault-pam-config=arch -Dat-spi-registryd-dir=/usr/libexec
  -Dtcp-wrappers=false -Dscreenshot-dir=/var/lib/gdm/greeter
- -Dplymouth=disabled -Dxauth-dir=/run/gdm -Dpid-file=/run/gdm/gdm.pid
+ -Dplymouth=enabled -Dxauth-dir=/run/gdm -Dpid-file=/run/gdm/gdm.pid
  -Dsystemd-journal=false -Dinitial-vt=7 -Dwayland-support=true
  -Dselinux=disabled -Dlibaudit=disabled
  -Dsystemdsystemunitdir=/tmp -Dsystemduserunitdir=/tmp"
 hostmakedepends="dconf gettext itstool pkg-config"
 makedepends="accountsservice-devel elogind-devel gettext-devel glib-devel
- iso-codes libSM-devel libcanberra-devel nss-devel pam-devel upower-devel"
+ iso-codes libSM-devel libcanberra-devel nss-devel pam-devel upower-devel
+ plymouth-devel"
 depends="gnome-settings-daemon gnome-shell gnome-session gnome-themes-extra
  gsettings-desktop-schemas xorg-server xorg-server-xwayland xrdb"
 checkdepends="check-devel"


### PR DESCRIPTION
Support for smooth transition was disabled years ago, when `plymouth` wasn't in the Void repo. `gdm` checks whether `plymouth` can be pinged at run time so that no hard dependency is required.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
