### PR TITLE
libtool: revbump for the gcc update.

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -1,4 +1,6 @@
 # Template file for 'gcc'
+# Revbump libtool when updating gcc, since it hardcodes some internal compiler paths
+# which use the version number.
 _majorver=10
 _minorver=${_majorver}.2
 _patchver=${_minorver}.1

--- a/srcpkgs/libtool/template
+++ b/srcpkgs/libtool/template
@@ -1,7 +1,7 @@
 # Template file for 'libtool'
 pkgname=libtool
 version=2.4.6
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="texinfo perl automake help2man xz"
 depends="tar sed"


### PR DESCRIPTION
libtool hardcodes some internal gcc paths, which include the GCC version
information. Some applications can fail to build if these paths are
used. Revbumping libtool is enough for the recorded paths to be updated.

A proper solution is importing the fixes Debian applies:
https://salsa.debian.org/metux-guest/libtool/-/blob/ef64614b54a8da38fc4b4424639251fde9d135bf/debian/rules#L115

This is ugly as hell, but I don't want to do the work to import the debian workaround properly right now. But maybe I should :P 

Noticed when building https://sourceforge.net/projects/srecord/files/srecord/1.64/ , reported via IRC.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
