### PR TITLE
crda: update to 4.14

### DIFF
--- a/srcpkgs/crda/template
+++ b/srcpkgs/crda/template
@@ -1,9 +1,9 @@
 # Template file for 'crda'
 pkgname=crda
-version=3.18
-revision=5
+version=4.14
+revision=1
 _dbname=wireless-regdb
-_dbversion=2016.06.10
+_dbversion=2020.11.20
 _dbsrc="${XBPS_BUILDDIR}/${_dbname}-${_dbversion}/"
 hostmakedepends="libressl python python-M2Crypto pkg-config"
 makedepends="libnl-devel libgcrypt-devel"
@@ -11,10 +11,11 @@ depends="iw"
 short_desc="Central Regulatory Domain Agent for wireless networks"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="ISC"
-homepage="http://wireless.kernel.org/en/developers/Regulatory/CRDA"
-distfiles="https://kernel.org/pub/software/network/crda/${pkgname}-${version}.tar.xz https://www.kernel.org/pub/software/network/wireless-regdb/${_dbname}-${_dbversion}.tar.xz"
-checksum="43fcb9679f8b75ed87ad10944a506292def13e4afb194afa7aa921b01e8ecdbf
-cfedf1c3521b3c8f32602f25ed796e96e687c3441a00e7c050fedf7fd4f1b8b7"
+homepage="https://wireless.wiki.kernel.org/en/developers/regulatory/crda"
+distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/mcgrof/crda.git/snapshot/${pkgname}-${version}.tar.gz
+https://www.kernel.org/pub/software/network/wireless-regdb/${_dbname}-${_dbversion}.tar.xz"
+checksum="5a8f35bb8b27474f466b0e75d451ba917433d8aab1889678a64d9c4e72a8b8c2
+ b4164490d82ff7b0086e812ac42ab27baf57be24324d4c0ee1c5dd6ba27f2a52"
 conf_files="/etc/wireless-regdom.conf"
 
 build_options="wardrive"
@@ -29,22 +30,22 @@ post_extract() {
 do_build() {
 	CFLAGS+=" -Wno-unused-const-variable"
 	cd ${_dbsrc}
-	make
-	cp *.pem ${wrksrc}/pubkeys
+	cp *.pub.pem ${wrksrc}/pubkeys
 
 	cd ${wrksrc}
-
 	make CC="$CC" all_noverify
 }
 
 do_install() {
 	make DESTDIR="${DESTDIR}" SBINDIR="/usr/bin/" UDEV_RULE_DIR="/usr/lib/udev/rules.d/" install
-	vlicense LICENSE
+	vlicense LICENSE crda.LICENSE
 
 	cd ${_dbsrc}
-	vmkdir usr/lib/crda/
-	vinstall regulatory.bin 644 usr/lib/crda/
+	make DESTDIR="${DESTDIR}" FIRMWARE_PATH="/usr/lib/firmware" install
+	vlicense LICENSE wireless-regdb.LICENSE
+
 	vmkdir etc/conf.d/
+
 	for dom in $(grep ^country db.txt | cut -d' ' -f2 | sed 's|:||g'); do
 		echo "#WIRELESS_REGDOM=\"${dom}\"" >> ${DESTDIR}/etc/wireless-regdom.tmp
 	done
@@ -52,7 +53,7 @@ do_install() {
 	rm ${DESTDIR}/etc/wireless-regdom.tmp
 
 	vbin ${FILESDIR}/set-wireless-regdom
-	echo 'ACTION=="add" SUBSYSTEM=="module", DEVPATH=="/module/cfg80211", RUN+="/usr/bin/set-wireless-regdom"' >> ${DESTDIR}/usr/lib/udev/rules.d/85-regulatory.rules
+	echo 'ACTION=="add", SUBSYSTEM=="module", DEVPATH=="/module/cfg80211", RUN+="/usr/bin/set-wireless-regdom"' >> ${DESTDIR}/usr/lib/udev/rules.d/85-regulatory.rules
 
 	find ${DESTDIR} -type f -name \*.h -delete # No need for devel files, no package i know uses libreg.so
 }


### PR DESCRIPTION
crda: update to 4.14 #28580

* crda-4.14
* wireless-regdb-2020.12.20

fix error messages like

```
[    6.954196] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
[    6.954207] cfg80211: failed to load regulatory.db
```

registered also in the issue #2999 and

```
[    6.917367] cfg80211: Loading compiled-in X.509 certificates for regulatory database
[    6.920611] cfg80211: loaded regulatory.db is malformed or signature is missing/invalid
```

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
