### PR TITLE
common/00-libdir: only create lib{32,64} symlink if not exists

### DIFF
--- a/common/hooks/pre-install/00-libdir.sh
+++ b/common/hooks/pre-install/00-libdir.sh
@@ -1,7 +1,9 @@
 # This hook creates the wordsize specific libdir symlink.
 
 hook() {
-	if [ "${pkgname}" != "base-files" ]; then
+	if [ -L ${PKGDESTDIR}/usr/lib${XBPS_TARGET_WORDSIZE} ]; then
+		return 0
+	elif [ "${pkgname}" != "base-files" ]; then
 		vmkdir usr/lib
 		ln -sf lib ${PKGDESTDIR}/usr/lib${XBPS_TARGET_WORDSIZE}
 	fi


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
