### PR TITLE
xbps-src: create $XBPS_MASTERDIR/tmp in chroot_prepare

### DIFF
--- a/common/xbps-src/shutils/chroot.sh
+++ b/common/xbps-src/shutils/chroot.sh
@@ -119,7 +119,7 @@ chroot_prepare() {
         msg_warn "No local timezone configuration file created.\n"
     fi
 
-    for f in dev sys proc host boot; do
+    for f in dev sys tmp proc host boot; do
         [ ! -d $XBPS_MASTERDIR/$f ] && mkdir -p $XBPS_MASTERDIR/$f
     done
 


### PR DESCRIPTION
Missing $XBPS_MASTERDIR/tmp caused ca-certificates and glibc-locales to
fail in the reconfigure step of binary-bootstrap, since a call to mktemp
(which I couldn't locate in source though) assumed /tmp in the chroot
would be present already.

This issue was reproducible reliably for me on NixOS by doing something
like:

    rm -rf masterdir
    ./xbps-src binary-bootstrap

The workaround I found was:

    mkdir -p masterdir/tmp      # or alternatively ./xbps-src clean
                                # which also (re-)creates masterdir/tmp
    ./xbps-src binary-bootstrap

This workaround is now mirrored in chroot_prepare by ensuring that tmp
always exists.