### PR TITLE
firejail: update to 0.9.64.4.

### DIFF
--- a/srcpkgs/firejail/template
+++ b/srcpkgs/firejail/template
@@ -1,6 +1,6 @@
 # Template file for 'firejail'
 pkgname=firejail
-version=0.9.64.2
+version=0.9.64.4
 revision=1
 build_style=gnu-configure
 configure_args="--enable-apparmor"
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://firejail.wordpress.com"
 changelog="https://github.com/netblue30/firejail/raw/master/RELNOTES"
 distfiles="https://github.com/netblue30/firejail/archive/${version}.tar.gz"
-checksum=fa4113ccdf74694eeeb3d223017c1ade92bb104232df9340d30873816856f61c
+checksum=17a20c4c9f114aa8fdab467cecb60309f599ad08b4bbb3e751c992d98a95ac18
 conf_files="/etc/firejail/* /etc/apparmor.d/local/firejail-default"
 
 nocross=yes


### PR DESCRIPTION
Fixes a root privilege escalation bug by disabling the overlayfs
functionality completely.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

@Duncaen 

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
