### PR TITLE
python-cryptography: split python2 package

### DIFF
--- a/srcpkgs/python-cryptography/template
+++ b/srcpkgs/python-cryptography/template
@@ -1,42 +1,28 @@
 # Template file for 'python-cryptography'
 pkgname=python-cryptography
-version=3.3.1
+version=3.3.2
 revision=1
 wrksrc="cryptography-${version}"
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools libressl-devel
- python-enum34 python-ipaddress python-six python3-six
- python-cffi python3-cffi python-idna python3-idna"
-makedepends="libressl-devel python-devel python3-devel"
+build_style=python2-module
+hostmakedepends="python-setuptools libressl-devel python-enum34
+ python-ipaddress python-six python-cffi python-idna"
+makedepends="libressl-devel python-devel"
 depends="python-cffi python-six python-enum34 python-idna python-ipaddress"
 checkdepends="python-cryptography_vectors python-hypothesis python-pretend
- python-pytest python-pytz python-iso8601 python3-cryptography_vectors
- python3-hypothesis python3-pretend python3-pytest python3-pytz python3-iso8601
- ${depends}"
+ python-pytest python-pytz python-iso8601 ${depends}"
 short_desc="Python2 library that provides cryptographic recipes and primitives"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause, Apache-2.0"
 homepage="https://github.com/pyca/cryptography"
 changelog="https://raw.githubusercontent.com/pyca/cryptography/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/c/cryptography/cryptography-${version}.tar.gz"
-checksum=7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6
+checksum=5a60d3780149e13b7a6ff7ad6526b38846354d11a15e21068e57073e29e19bed
 
 do_check() {
-	PYTHONPATH="$(cd build-2.7/lib* && pwd)" python2.7 -m pytest tests
-	PYTHONPATH="$(cd build-${py3_ver}/lib* && pwd)" python${py3_ver} -m pytest tests
+	PYTHONPATH="$(cd build/lib* && pwd)" python2.7 -m pytest tests
 }
 
 post_install() {
 	vlicense LICENSE
 	vlicense LICENSE.BSD
-}
-
-python3-cryptography_package() {
-	depends="python3-cffi python3-six python3-idna"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-		vlicense LICENSE
-		vlicense LICENSE.BSD
-	}
 }

--- a/srcpkgs/python-cryptography/update
+++ b/srcpkgs/python-cryptography/update
@@ -1,0 +1,2 @@
+# cryptography >= 3.4 does not support Python 2
+pattern="cryptography-\K3\.3\.[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/python-cryptography_vectors/template
+++ b/srcpkgs/python-cryptography_vectors/template
@@ -1,27 +1,18 @@
 # Template file for 'python-cryptography_vectors'
 pkgname=python-cryptography_vectors
-version=3.3.1
+version=3.3.2
 revision=1
 wrksrc="cryptography_vectors-${version}"
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools"
+build_style=python2-module
+hostmakedepends="python-setuptools"
 short_desc="Test vectors for python-cryptography"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
 license="BSD-3-Clause, Apache-2.0"
 homepage="https://github.com/pyca/cryptography"
 distfiles="${PYPI_SITE}/c/cryptography_vectors/cryptography_vectors-${version}.tar.gz"
-checksum=03789c305dda8dccb4b8c9c019963a742469d88365abbc82e8e898ac478f5ca4
+checksum=8c9d5afada647a6c937c6392c975f204b540c31f25fd4acd925ec0e180be0afa
 
 post_install() {
 	vlicense LICENSE
 	vlicense LICENSE.BSD
-}
-
-python3-cryptography_vectors_package() {
-	short_desc="${short_desc/python/python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-		vlicense LICENSE
-		vlicense LICENSE.BSD
-	}
 }

--- a/srcpkgs/python-cryptography_vectors/update
+++ b/srcpkgs/python-cryptography_vectors/update
@@ -1,0 +1,2 @@
+# cryptography >= 3.4 does not support Python 2
+pattern="cryptography_vectors-\K3\.3\.[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/python3-cryptography
+++ b/srcpkgs/python3-cryptography
@@ -1,1 +1,0 @@
-python-cryptography

--- a/srcpkgs/python3-cryptography/template
+++ b/srcpkgs/python3-cryptography/template
@@ -1,0 +1,36 @@
+# Template file for 'python3-cryptography'
+pkgname=python3-cryptography
+version=3.4.4
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+build_helper="rust"
+hostmakedepends="python3-setuptools-rust python3-cffi cargo"
+makedepends="python3-devel libressl-devel"
+depends="python3-cffi"
+checkdepends="python3-pytest-subtests python3-pytz python3-iso8601
+ python3-cryptography_vectors python3-pretend python3-hypothesis $depends"
+short_desc="Python3 library that provides cryptographic recipes and primitives"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="BSD-3-Clause, Apache-2.0"
+homepage="https://github.com/pyca/cryptography"
+changelog="https://raw.githubusercontent.com/pyca/cryptography/master/CHANGELOG.rst"
+distfiles="${PYPI_SITE}/c/cryptography/cryptography-${version}.tar.gz"
+checksum=ee5e19f0856b6fbbdbab15c2787ca65d203801d2d65d0b8de6218f424206c848
+
+if [ "$CROSS_BUILD" ]; then
+	makedepends+=" rust-std"
+	export PYO3_CROSS_LIB_DIR="${XBPS_CROSS_BASE}/usr/lib"
+	export PYO3_CROSS_INCLUDE_DIR="${XBPS_CROSS_BASE}/usr/include"
+fi
+
+do_check() {
+	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest
+}
+
+post_install() {
+	vlicense LICENSE
+	vlicense LICENSE.BSD
+
+	chmod 755 ${DESTDIR}/${py3_sitelib}/cryptography/hazmat/bindings/*.so
+}

--- a/srcpkgs/python3-cryptography_vectors
+++ b/srcpkgs/python3-cryptography_vectors
@@ -1,1 +1,0 @@
-python-cryptography_vectors

--- a/srcpkgs/python3-cryptography_vectors/template
+++ b/srcpkgs/python3-cryptography_vectors/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-cryptography_vectors'
+pkgname=python3-cryptography_vectors
+version=3.4.4
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Test vectors for python3-cryptography"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="BSD-3-Clause, Apache-2.0"
+homepage="https://github.com/pyca/cryptography"
+distfiles="${PYPI_SITE}/c/cryptography_vectors/cryptography_vectors-${version}.tar.gz"
+checksum=b0b53e3eaac12c8d8a0d373b35b43813406e884fcdac3c30f358c40e9f77093a
+
+post_install() {
+	vlicense LICENSE
+	vlicense LICENSE.BSD
+}

--- a/srcpkgs/python3-pytest-subtests/template
+++ b/srcpkgs/python3-pytest-subtests/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-pytest-subtests'
+pkgname=python3-pytest-subtests
+version=0.4.0
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm"
+depends="python3-pytest"
+checkdepends="$depends"
+short_desc="Subtest fixture for python3-pytest"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="MIT"
+homepage="https://github.com/pytest-dev/pytest-subtests"
+distfiles="${PYPI_SITE}/p/pytest-subtests/pytest-subtests-${version}.tar.gz"
+checksum=8d9e2c1d1dce11f7b7d2c9d09202ebfc7757b7ff0cac9b72ad328edfe7ee037b
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-setuptools-rust/patches/preserve_rustflags.patch
+++ b/srcpkgs/python3-setuptools-rust/patches/preserve_rustflags.patch
@@ -1,0 +1,27 @@
+From cbd30fda8c6f7cc0d304728413f2cbf488da096b Mon Sep 17 00:00:00 2001
+From: "Andrew J. Hesford" <ajh@sideband.org>
+Date: Mon, 8 Feb 2021 12:58:58 -0500
+Subject: [PATCH] Augment, rather than replace, existing RUSTFLAGS when
+ building
+
+Some complex environments, like Void's cross-compilation environment,
+use RUSTFLAGS to control the behavior of rust compilation. Rather than
+overwriting RUSTFLAGS with custom flags, augment any existing RUSTFLAGS
+to preserve these environments.
+---
+ setuptools_rust/build.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git setuptools_rust/build.py setuptools_rust/build.py
+index 40d8e42..60eddfa 100644
+--- setuptools_rust/build.py
++++ setuptools_rust/build.py
+@@ -186,7 +186,7 @@ def build_extension(self, ext):
+             rustflags += " -C target-cpu=native"
+ 
+         if rustflags:
+-            env["RUSTFLAGS"] = rustflags
++            env["RUSTFLAGS"] = (env.get("RUSTFLAGS", "") + " " + rustflags).strip()
+ 
+         # Execute cargo
+         try:

--- a/srcpkgs/python3-setuptools-rust/template
+++ b/srcpkgs/python3-setuptools-rust/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-setuptools-rust'
+pkgname=python3-setuptools-rust
+version=0.11.6
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm python3-toml"
+depends="python3-semanticversion python3-toml python3-setuptools"
+short_desc="Setuptools plugin for Rust support"
+maintainer="Andrew J. Hesford <ajh@sideband.org>"
+license="MIT"
+homepage="https://github.com/PyO3/setuptools-rust"
+changelog="https://raw.githubusercontent.com/PyO3/setuptools-rust/master/CHANGELOG.md"
+distfiles="${PYPI_SITE}/s/setuptools-rust/setuptools-rust-${version}.tar.gz"
+checksum=a5b5954909cbc5d66b914ee6763f81fa2610916041c7266105a469f504a7c4ca
+
+do_check() {
+	echo "Tests have unpackaged dependencies; skipping"
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
If we wanted to, we could set CRYPTOGRAPHY_DONT_BUILD_RUST for "this release only" (which probably means this minor version only) and delay the `python3-setuptools_rust` addition. That would also prevent the installation of the no-op `cryptography.hazmat.bindings._rust` module. However, given that Rust is about to become a hard requirement for this package, we might as well just get it done with now.

The `python3-pytest-subtests` package is only required for checks in `python3-cryptography` but, given the importance of `cryptography`, I think it's worth ensuring that those tests pass.