### PR TITLE
Zim

### DIFF
--- a/srcpkgs/zim-tools/template
+++ b/srcpkgs/zim-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'zim-tools'
 pkgname=zim-tools
 version=1.2.1
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="libzim-devel xapian-core-devel icu-devel"

--- a/srcpkgs/zimwriterfs/template
+++ b/srcpkgs/zimwriterfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zimwriterfs'
 pkgname=zimwriterfs
 version=1.3.7
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
 makedepends="file-devel gumbo-parser-devel icu-devel libzim-devel


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

This kinda looks like an accidental ABI break, to be honest. If @Johnnynator prefers to fix `libzim` instead, it should be ok (we should almost certainly open an issue there, either way). This is a workaround.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
