### PR TITLE
libtorrent: don't depend on libcppunit in the resulting package.

### DIFF
--- a/srcpkgs/libtorrent/template
+++ b/srcpkgs/libtorrent/template
@@ -1,17 +1,19 @@
 # Template file for 'libtorrent'
 pkgname=libtorrent
 version=0.13.8
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-static --disable-debug --without-kqueue
  --enable-aligned --with-posix-fallocate"
 hostmakedepends="automake libtool pkg-config"
-makedepends="libcppunit-devel libressl-devel zlib-devel"
+makedepends="libressl-devel zlib-devel"
+# XXX: if built with XBPS_CHECK_PKGS, final binary will be dyn linked against libcppunit
+checkdepends="libcppunit-devel"
 short_desc="BitTorrent library written in C++"
 maintainer="Nathan Owens <ndowens04@gmail.com>"
 license="GPL-2.0-or-later"
-homepage="https://github.com/rakshasa/${pkgname}"
-distfiles="https://github.com/rakshasa/${pkgname}/archive/v${version}.tar.gz"
+homepage="https://github.com/rakshasa/libtorrent"
+distfiles="https://github.com/rakshasa/libtorrent/archive/v${version}.tar.gz"
 checksum=0f6c2e7ffd3a1723ab47fdac785ec40f85c0a5b5a42c1d002272205b988be722
 
 # https://github.com/rakshasa/rtorrent/issues/156


### PR DESCRIPTION
Probably some rebel linker options screwing things up and leaving
libcppunit as a required library in libtorrent. This isn't a proper fix,
because the final library doesn't use libcppunit symbols and
-Wl,--as-needed in LDFLAGS should have caught it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
