### PR TITLE
busybox: fix time64 patch.

### DIFF
--- a/srcpkgs/busybox/patches/time64.patch
+++ b/srcpkgs/busybox/patches/time64.patch
@@ -1,28 +1,38 @@
---- coreutils/date.c	2019-06-10 12:50:53.000000000 +0200
-+++ coreutils/date.c	2021-02-09 12:39:19.127054192 +0100
-@@ -274,7 +274,11 @@
+diff --git coreutils/date.c coreutils/date.c
+index 3414d38..6e12f36 100644
+--- coreutils/date.c
++++ coreutils/date.c
+@@ -272,9 +272,7 @@ int date_main(int argc UNUSED_PARAM, char **argv)
+ #endif
+ 	} else {
  #if ENABLE_FEATURE_DATE_NANO
- 		/* libc has incredibly messy way of doing this,
- 		 * typically requiring -lrt. We just skip all this mess */
-+#if defined(__NR_clock_gettime32)
-+		syscall(__NR_clock_gettime32, CLOCK_REALTIME, &ts);
-+#else
- 		syscall(__NR_clock_gettime, CLOCK_REALTIME, &ts);
-+#endif
+-		/* libc has incredibly messy way of doing this,
+-		 * typically requiring -lrt. We just skip all this mess */
+-		syscall(__NR_clock_gettime, CLOCK_REALTIME, &ts);
++		clock_gettime(CLOCK_REALTIME, &ts);
  #else
  		time(&ts.tv_sec);
  #endif
---- libbb/time.c	2019-06-10 12:50:53.000000000 +0200
-+++ libbb/time.c	2021-02-09 12:35:35.125037118 +0100
-@@ -257,7 +257,11 @@
-  * typically requiring -lrt. We just skip all this mess */
+diff --git libbb/time.c libbb/time.c
+index f9b8da0..600b60b 100644
+--- libbb/time.c
++++ libbb/time.c
+@@ -247,17 +247,10 @@ char* FAST_FUNC strftime_YYYYMMDDHHMMSS(char *buf, unsigned len, time_t *tp)
+ #if ENABLE_MONOTONIC_SYSCALL
+ 
+ #include <sys/syscall.h>
+-/* Old glibc (< 2.3.4) does not provide this constant. We use syscall
+- * directly so this definition is safe. */
+-#ifndef CLOCK_MONOTONIC
+-#define CLOCK_MONOTONIC 1
+-#endif
+ 
+-/* libc has incredibly messy way of doing this,
+- * typically requiring -lrt. We just skip all this mess */
  static void get_mono(struct timespec *ts)
  {
-+#if defined(__NR_clock_gettime32)
-+	if (syscall(__NR_clock_gettime32, CLOCK_MONOTONIC, ts))
-+#else
- 	if (syscall(__NR_clock_gettime, CLOCK_MONOTONIC, ts))
-+#endif
+-	if (syscall(__NR_clock_gettime, CLOCK_MONOTONIC, ts))
++	if (clock_gettime(CLOCK_MONOTONIC, ts))
  		bb_error_msg_and_die("clock_gettime(MONOTONIC) failed");
  }
  unsigned long long FAST_FUNC monotonic_ns(void)


### PR DESCRIPTION
The syscall name was changed explicitly so compilation broke instead of
allowing programs using the raw syscall to use the time64 struct
timespec with a syscall expecting the old one.

Since we have modern glibc and musl, we can just force clock_gettime
usage.

The previous patch also broke y2038 support.

Not revbumping, since c085deae94a6fbd3d113eaceaaee4f0f947e091d didn't
either.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
