### PR TITLE
acmetool: fix project homepage and license

### DIFF
--- a/srcpkgs/acmetool/template
+++ b/srcpkgs/acmetool/template
@@ -1,7 +1,7 @@
 # Template file for 'acmetool'
 pkgname=acmetool
 version=0.2.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/hlandau/acme
 go_package="github.com/hlandau/acme/cmd/acmetool"
@@ -9,8 +9,8 @@ hostmakedepends="git"
 makedepends="libcap-devel"
 short_desc="Tool to acquire certificates from ACME servers (such as Let's Encrypt)"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
-license="RILTS-based"
-homepage="https://hlandau.github.io/acme/"
+license="MIT"
+homepage="https://hlandau.github.io/acmetool/"
 distfiles="https://github.com/hlandau/acme/archive/v${version}.tar.gz
  https://raw.githubusercontent.com/hlandau/rilts/master/licences/COPYING.MIT>COPYING"
 checksum="54acffe7381696ecdc829f65810897075d17c5600c077f431eda5e5244189a74


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
Not particularly sexy but I noticed that the homepage= pointed to a non-existent place.
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
