### PR TITLE
rclone: fix builtin version string

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,17 +1,17 @@
 # Template file for 'rclone'
 pkgname=rclone
 version=1.54.0
-revision=1
+revision=2
 wrksrc="rclone-v${version}"
 build_style=go
 go_import_path=github.com/rclone/rclone
-go_ldflags="-extldflags=-fuse-ld=bfd"
+go_ldflags="-extldflags=-fuse-ld=bfd -X github.com/rclone/rclone/fs.Version=v${version}"
 short_desc="Rsync for cloud storage"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="MIT"
 homepage="https://rclone.org/"
 changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/changelog.md"
-distfiles="https://github.com/rclone/rclone/releases/download/v${version}/rclone-v${version}.tar.gz"
+distfiles="https://downloads.rclone.org/v${version}/rclone-v${version}.tar.gz"
 checksum=95f952dc059b842bd40338458b77657f7b5a1680c4ca837a3adcf83b63c8fda1
 
 pre_build() {
@@ -21,6 +21,10 @@ pre_build() {
 		# FIXME: linkers for the musl toolchains should reject textrels entirely
 		export CGO_ENABLED=0
 	fi
+}
+
+do_check() {
+	RCLONE_CONFIG="/notfound" go test ./...
 }
 
 post_install() {


### PR DESCRIPTION
Also:
- enable tests
- use official site for distfiles and changelog

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
