### PR TITLE
gstreamer1: add checkdepends

### DIFF
--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -12,6 +12,7 @@ hostmakedepends="gettext pkg-config flex python3 docbook-xsl glib-devel
  libcap-progs"
 makedepends="libxml2-devel libglib-devel gtk+3-devel libcap-devel libunwind-devel
  bash-completion"
+checkdepends="gsl-devel gmp-devel valgrind-devel"
 short_desc="Core GStreamer libraries and elements (1.x)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl
-->

I noticed when building the `gstreamer1` package with `xbps-src` that it warns about missing libraries:
![1612995217](https://user-images.githubusercontent.com/30329373/107582857-52f66a00-6bb7-11eb-884a-1cd5c5c497c3.png)
![1612995198](https://user-images.githubusercontent.com/30329373/107582864-54279700-6bb7-11eb-86ac-230a905bd63c.png)

Furthermore, I notice that the [PKGBUILD](https://github.com/archlinux/svntogit-packages/blob/packages/gstreamer/trunk/PKGBUILD) on Arch includes these libraries in their template. This might help with [this](https://github.com/void-linux/void-packages/issues/25852) issue. I notice that durring the build is says that pkg-config can't find gstreamer-1.0.pc in `PKG_CONFIG_PATH`. I used `xlocate gstreamer-1.0.pc` and tried adding, as a result:
```sh
export PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${DESTDIR}/usr/lib/pkgconfig"
```
as that is the directory where `gstreamer-1.0.pc` is located, but the same warning occurs.