### PR TITLE
python3-XlsxWriter: update to 1.3.7

### DIFF
--- a/srcpkgs/python3-XlsxWriter/template
+++ b/srcpkgs/python3-XlsxWriter/template
@@ -1,17 +1,16 @@
 # Template file for 'python3-XlsxWriter'
 pkgname=python3-XlsxWriter
-version=1.1.8
-revision=3
+version=1.3.7
+revision=1
 wrksrc="XlsxWriter-RELEASE_${version}"
 build_style=python3-module
-pycompile_module="XlsxWriter"
 hostmakedepends="python3-setuptools"
 short_desc="Python3 module for creating Excel XLSX files"
 maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://xlsxwriter.readthedocs.io/"
 distfiles="https://github.com/jmcnamara/XlsxWriter/archive/RELEASE_${version}.tar.gz"
-checksum=b9311ec075693be4c0bc6ebbe292bbdac21399f863cb0c4e55100a561d67a56d
+checksum=b08a1b30cde383cf3b09b50fa18fbfca28ec977e5df9ffab89f01a2ca93be2c1
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
Fixes `is` vs `==` logged Syntax Warnings.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl
-->
