### PR TITLE
Upgrade the Korn shell to the new upstream

### DIFF
--- a/srcpkgs/ksh/template
+++ b/srcpkgs/ksh/template
@@ -1,16 +1,15 @@
 # Template file for 'ksh'
 pkgname=ksh
-version=2020.0.0
-revision=1
-wrksrc="ast-${version}"
-build_style=meson
-configure_args="-Dbuild-api-tests=false -Dbuild-api-tests-only=true"
+version=1.0.0a
+revision=2
+_commit="37a18bab7173427ce045c9a67772cb98eb678cb7"
+wrksrc="${pkgname}-${_commit}"
 short_desc="AT&T's Korn shell (ksh93)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="EPL-1.0"
 homepage="http://www.kornshell.com/"
-distfiles="https://github.com/att/ast/archive/${version}.tar.gz"
-checksum=76597c96c4f94423b9225b5de50ea54be08d5bbaa1e0e594a7eec603bd60ecaf
+distfiles="https://github.com/ksh93/ksh/archive/${_commit}.tar.gz"
+checksum=2ec6700a3c1ef688409a9339acb745e72902717b9e719e7937cdcccaa140e16d
 nocross=yes
 
 register_shell="/bin/ksh"
@@ -19,30 +18,22 @@ alternatives="
  ksh:ksh.1:/usr/share/man/man1/ksh93.1
 "
 
-build_options="static"
-if [ "$build_option_static" ]; then
-	LDFLAGS+=" -static"
-fi
-
-case "$XBPS_TARGET_MACHINE" in
-*-musl)
-	makedepends+=" musl-fts-devel"
-esac
-
-post_extract() {
-	sed -i -e 's/= library/= static_library/'  \
-		-e 's/install: true/install: false/' src/lib/*/meson.build
-	sed -i 's/vpoi/void*/g' src/cmd/ksh93/include/name.h
-	if [ "$build_option_static" ]; then
-		# Drop tests that use .so
-		sed -i '/some tests/,$d' src/cmd/ksh93/meson.build
-		sed -i '/libsample_files/,$d' src/lib/libdll/meson.build
-	fi
+do_build() {
+	./bin/package make
 }
-post_install() {
-	mv ${DESTDIR}/usr/bin/ksh ${DESTDIR}/usr/bin/ksh93
-	mv ${DESTDIR}/usr/share/man/man1/ksh.1 ${DESTDIR}/usr/share/man/man1/ksh93.1
+
+do_check() {
+	script -e -c ./bin/shtests /dev/null
+}
+
+do_install() {
+	ARCH=$(./bin/package)
+	vmkdir usr/bin
+	mv arch/${ARCH}/bin/ksh ${DESTDIR}/usr/bin/ksh93
+	vmkdir usr/share/man/man1
+	mv arch/${ARCH}/man/man1/sh.1 ${DESTDIR}/usr/share/man/man1/ksh93.1
 	vmkdir usr/share/ksh
-	vcopy src/cmd/ksh93/fun usr/share/ksh/functions
-	vlicense LICENSE
+	vcopy arch/${ARCH}/fun usr/share/ksh/functions
+	rmdir ${DESTDIR}/usr/lib
+	vlicense LICENSE.md
 }


### PR DESCRIPTION
The Korn shell 2020 project has ground to a halt and AT&T has reverted its
changes due to numerous unfixed performance regressions and bugs. The new
Korn shell project at github.com/ksh93/ksh has restarted development with a
focus on bug fixing and preserving Korn shell functionality.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
