### PR TITLE
Link OptiX library after installing

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -209,8 +209,8 @@ do_install() {
 
 	# optix ray racing engine
 	vinstall libnvoptix.so.${version} 755 usr/lib
-	ln -sf libnvoptix.so.${version} ${DESTDIR}/${libdir}/libnvoptix.so
-	ln -sf libnvoptix.so.${version} ${DESTDIR}/${libdir}/libnvoptix.so.1
+	ln -sf libnvoptix.so.${version} /usr/lib/libnvoptix.so
+	ln -sf libnvoptix.so.${version} /usr/lib/libnvoptix.so.1
 
 	# dkms pkg
 	vmkdir usr/src/nvidia-${version}

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -209,6 +209,8 @@ do_install() {
 
 	# optix ray racing engine
 	vinstall libnvoptix.so.${version} 755 usr/lib
+	ln -sf libnvoptix.so.${version} ${DESTDIR}/${libdir}/libnvoptix.so
+	ln -sf libnvoptix.so.${version} ${DESTDIR}/${libdir}/libnvoptix.so.1
 
 	# dkms pkg
 	vmkdir usr/src/nvidia-${version}


### PR DESCRIPTION
This change allows applications that use OptiX (eg. Blender) to find and use the library.

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
