### PR TITLE
python3-pycryptodomex: update to 3.10.1.

### DIFF
--- a/srcpkgs/python3-pycryptodomex/template
+++ b/srcpkgs/python3-pycryptodomex/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pycryptodomex'
 pkgname=python3-pycryptodomex
-version=3.9.9
+version=3.10.1
 revision=1
 wrksrc="pycryptodomex-${version}"
 build_style=python3-module
@@ -12,7 +12,7 @@ license="Public Domain, BSD-2-Clause"
 homepage="https://www.pycryptodome.org/"
 changelog="https://raw.githubusercontent.com/Legrandin/pycryptodome/master/Changelog.rst"
 distfiles="${PYPI_SITE}/p/pycryptodomex/pycryptodomex-${version}.tar.gz"
-checksum=7b5b7c5896f8172ea0beb283f7f9428e0ab88ec248ce0a5b8c98d73e26267d51
+checksum=541cd3e3e252fb19a7b48f420b798b53483302b7fe4d9954c947605d0a263d62
 
 post_install() {
 	vlicense LICENSE.rst


### PR DESCRIPTION
N.B.: Support dropped for py2.6 and py3.4.
https://github.com/Legrandin/pycryptodome/blob/v3.10.1/Changelog.rst#breaks-in-compatibility

<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

```
ag@server ~ ❯ salt --versions-report | grep dome
  pycryptodome: 3.10.1
```

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl