### PR TITLE
rtkit: requires dbus and polkit

### DIFF
--- a/srcpkgs/rtkit/template
+++ b/srcpkgs/rtkit/template
@@ -1,10 +1,11 @@
 # Template file for 'rtkit'
 pkgname=rtkit
 version=0.13
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="dbus-devel libcap-devel"
+depends="dbus polkit"
 short_desc="Realtime Policy and Watchdog Daemon"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT, GPL-3.0-or-later"


### PR DESCRIPTION
See end of https://github.com/heftig/rtkit/blob/master/README

It doesn't work without them.