### PR TITLE
zsh-syntax-highlighting: add .plugin.zsh

### DIFF
--- a/srcpkgs/zsh-syntax-highlighting/template
+++ b/srcpkgs/zsh-syntax-highlighting/template
@@ -1,7 +1,7 @@
 # Template file for 'zsh-syntax-highlighting'
 pkgname=zsh-syntax-highlighting
 version=0.7.1
-revision=2
+revision=3
 depends="zsh"
 short_desc="Fish shell like syntax highlighting for Zsh"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -12,9 +12,6 @@ distfiles="${homepage}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=f5044266ee198468b1bcec881a56e6399e209657d6ed9fa6d21175bc76afdefa
 
 do_install() {
-	vinstall ${pkgname}.zsh 644 usr/share/zsh/plugins/${pkgname}
-	vinstall .version 644 usr/share/zsh/plugins/${pkgname}
-	vinstall .revision-hash 644 usr/share/zsh/plugins/${pkgname}
-	vcopy highlighters usr/share/zsh/plugins/${pkgname}
-	vlicense COPYING.md
+	make install SHARE_DIR=${DESTDIR}/usr/share/zsh/plugins/${pkgname} DOC_DIR=${DESTDIR}/usr/share/zsh/plugins/${pkgname}/doc
+	vinstall ${pkgname}.plugin.zsh 644 usr/share/zsh/plugins/${pkgname}
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
zsh-autosuggestions provides the zsh-autosuggestions.plugin.zsh file, this should provide its plugin file too.