### PR TITLE
audacious-plugins: Add glib-devel to build deps

### DIFF
--- a/srcpkgs/audacious-plugins/template
+++ b/srcpkgs/audacious-plugins/template
@@ -2,10 +2,10 @@
 #Keep in sync with audacious!
 pkgname=audacious-plugins
 version=4.1
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="$(vopt_enable gtk) $(vopt_enable qt)"
-hostmakedepends="gettext pkg-config"
+hostmakedepends="gettext pkg-config glib-devel"
 makedepends="audacious-devel alsa-lib-devel pulseaudio-devel jack-devel
  lame-devel libvorbis-devel libflac-devel mpg123-devel faad2-devel ffmpeg-devel
  libmodplug-devel fluidsynth-devel libcdio-paranoia-devel wavpack-devel libnotify-devel


### PR DESCRIPTION
This seems to be required to build the mpris2 plugin

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
