### PR TITLE
pulseaudio: remove rtkit dependency and update to 14.2

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -731,8 +731,8 @@ libasyncns.so.0 libasyncns-0.8_1
 libpulse.so.0 libpulseaudio-1.0_1
 libpulse-mainloop-glib.so.0 libpulseaudio-1.0_1
 libpulse-simple.so.0 libpulseaudio-1.0_1
-libpulsecommon-14.0.so libpulseaudio-14.0_1
-libpulsecore-14.0.so libpulseaudio-14.0_1
+libpulsecommon-14.2.so libpulseaudio-14.2_1
+libpulsecore-14.2.so libpulseaudio-14.2_1
 libprojectM.so.3 projectM-3.1.7_2
 liborc-0.4.so.0 orc-0.4.11_1
 liborc-test-0.4.so.0 orc-0.4.11_1

--- a/srcpkgs/pulseaudio-module-sndio/template
+++ b/srcpkgs/pulseaudio-module-sndio/template
@@ -1,7 +1,7 @@
 # Template file for 'pulseaudio-module-sndio'
 pkgname=pulseaudio-module-sndio
 version=13.0
-revision=2
+revision=3
 build_style=gnu-makefile
 make_use_env=yes
 hostmakedepends="pulseaudio pkg-config"

--- a/srcpkgs/pulseaudio/template
+++ b/srcpkgs/pulseaudio/template
@@ -1,8 +1,9 @@
 # Template file for 'pulseaudio'
 pkgname=pulseaudio
-version=14.0
-revision=3
+version=14.2
+revision=1
 build_style=meson
+# XXX: new version should be able to enable systemd functionality using elogind
 configure_args="-Djack=enabled -Dlirc=disabled -Dhal-compat=false -Dorc=enabled
  -Dgtk=disabled -Dsystemd=disabled -Dwebrtc-aec=enabled
  -Dbluez5=true -Dbluez5-ofono-headset=false -Dbluez5-native-headset=true
@@ -21,8 +22,11 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/PulseAudio"
 distfiles="${FREEDESKTOP_SITE}/${pkgname}/releases/${pkgname}-${version}.tar.xz"
-checksum=a834775d9382b055504e5ee7625dc50768daac29329531deb6597bf05e06c261
+checksum=75d3f7742c1ae449049a4c88900e454b8b350ecaa8c544f3488a2562a9ff66f1
 python_version=3
+# FIXME: core-util-test fails
+make_check=yes
+
 system_groups="pulse-access"
 system_accounts="pulse"
 pulse_groups="audio"


### PR DESCRIPTION
PulseAudio doesn't need rtkit available to work for basic usage, so
it's better to only pull it in when a user wants realtime (the error
messages should also be clear enough).

Since rtkit now pulls in a complex dependency in polkit, we can avoid
pulseaudio also pulling the whole thing in.

I have yet to test this throroughly. Basic functionality is fine.

@q66