### PR TITLE
libevdev: update to 1.11.0.

### DIFF
--- a/srcpkgs/libevdev/template
+++ b/srcpkgs/libevdev/template
@@ -1,6 +1,6 @@
 # Template file for 'libevdev'
 pkgname=libevdev
-version=1.9.1
+version=1.11.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-gcov"
@@ -11,7 +11,7 @@ maintainer="skmpz <dem.procopiou@gmail.com>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/libevdev/"
 distfiles="${FREEDESKTOP_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=f5603c48c5afd76b14df7a5124e0a94a102f8da0d45826192325069d1bbc7acb
+checksum=63f4ea1489858a109080e0b40bd43e4e0903a1e12ea888d581db8c495747c2d0
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
Should include a license fix, but we always had it at MIT.

Closes: #25921 [via git-merge-pr]

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
