### PR TITLE
gcc: don't throw exception on locales other than "C" on musl.

### DIFF
--- a/srcpkgs/gcc/patches/musl-generic-locale.patch
+++ b/srcpkgs/gcc/patches/musl-generic-locale.patch
@@ -1,0 +1,16 @@
+See
+https://inbox.vuxu.org/musl/551d3310-039f-23c4-608e-5e15e625f638@sholland.org/
+
+diff --git gcc-5.4.0/libstdc++-v3/config/locale/generic/c_locale.cc.orig gcc-5.4.0/libstdc++-v3/config/locale/generic/c_locale.cc
+--- libstdc++-v3/config/locale/generic/c_locale.cc.orig
++++ libstdc++-v3/config/locale/generic/c_locale.cc
+@@ -213,9 +213,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
+     // Currently, the generic model only supports the "C" locale.
+     // See http://gcc.gnu.org/ml/libstdc++/2003-02/msg00345.html
+     __cloc = 0;
+-    if (strcmp(__s, "C"))
+-      __throw_runtime_error(__N("locale::facet::_S_create_c_locale "
+-			    "name not valid"));
+   }
+ 
+   void

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -15,7 +15,7 @@ pkgname=gcc
 # it should be possible to switch back to stable with 10.3 or 11
 version=${_patchver}pre1
 wrksrc=gcc-${version/pre/_pre}
-revision=2
+revision=3
 short_desc="GNU Compiler Collection"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 homepage="http://gcc.gnu.org"


### PR DESCRIPTION
libtsdc++'s generic locale implementation is stuck in ~2003,
unfortunately, and just throws an exception if locales other than "C"
are used. Some applications catch this error, but they shouldn't have
to, so we will import a patch to disable the exception. It is a
workaround, and the best solution is adding a proper generic
implementation to libstdc++.

Fixes #18659

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
- [x] currently building and will test in a bit

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
