### PR TITLE
webkit2gtk: update to 2.30.5.

### DIFF
--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,8 +1,8 @@
 # Template file for 'webkit2gtk'
 # ping q66 before touching this
 pkgname=webkit2gtk
-version=2.30.4
-revision=5
+version=2.30.5
+revision=1
 wrksrc="webkitgtk-${version}"
 build_style=cmake
 build_helper="gir"
@@ -42,7 +42,7 @@ maintainer="q66 <daniel@octaforge.org>"
 license="LGPL-2.1-or-later, BSD-2-Clause"
 homepage="https://webkitgtk.org/"
 distfiles="${homepage}/releases/webkitgtk-${version}.tar.xz"
-checksum=d595a37c5001ff787266b155e303a5f2e5b48a6d466f2714c2f30c11392f7b24
+checksum=7d0dab08e3c5ae07bec80b2822ef42e952765d5724cac86eb23999bfed5a7f1f
 
 build_options="gir wayland x11 bubblewrap jit sampling_profiler minibrowser"
 build_options_default="gir wayland x11 bubblewrap minibrowser"


### PR DESCRIPTION
Fixes CVE-2020-13558.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR
- [ ] I'm still building this 

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
