### PR TITLE
66: clean default $PATH, change system-dir.

### DIFF
--- a/srcpkgs/66/INSTALL.msg
+++ b/srcpkgs/66/INSTALL.msg
@@ -1,4 +1,6 @@
-CAUTION: 66 v0.6.0.0 has changes to the way the log and env options
-are handled in the frontend service file. Please consult the 
-documentation and make the appropriate changes before restarting
-or enabling your services, especially complex module services.
+CAUTION: package revision 0.6.1.1_2 changes the default system-dir
+from /var/lib/66 to /etc/66/lib. The change requires user intervention.
+Users who upgrade from an earlier version should either copy the 
+contents of the old dir to the new one after installation, or re-create
+trees and re-enable services. That should be done before rebooting/halting
+the system.

--- a/srcpkgs/66/patches/e14021570c3037d716a1cb5d95eb06727d1745a5.diff
+++ b/srcpkgs/66/patches/e14021570c3037d716a1cb5d95eb06727d1745a5.diff
@@ -1,0 +1,47 @@
+diff --git a/src/66/66-inservice.c b/src/66/66-inservice.c
+index cfe5995e4fb861b749edca9a324f0207f26facc7..03fda5587df20e796300333c2db9d4847b1aa5b9 100644
+--- a/src/66/66-inservice.c
++++ b/src/66/66-inservice.c
+@@ -621,6 +621,7 @@ static void info_display_envfile(char const *field,ss_resolve_t *res)
+ 
+         FOREACH_SASTR(&list,pos) {
+ 
++            ssize_t upstream = 0 ;
+             sa.len = 0 ;
+             salink.len = newlen ;
+             if (!stralloc_cats(&salink,"/") ||
+@@ -630,8 +631,25 @@ static void info_display_envfile(char const *field,ss_resolve_t *res)
+             if (!file_readputsa_g(&sa,salink.s))
+                 log_dieusys(LOG_EXIT_SYS,"read environment file") ;
+ 
+-            if (NOFIELD) {
++            /** Remove warning message */
++            if (list.s[pos] == '.') {
++
++                char t[sa.len + 1] ;
++
++                upstream = str_contain(sa.s,"[ENDWARN]") ;
+ 
++                if (upstream == -1)
++                    log_die(LOG_EXIT_SYS,"invalid upstream configuration file! Do you have modified it? Tries to enable the service again.") ;
++
++                auto_strings(t,sa.s + upstream) ;
++
++                sa.len = 0 ;
++
++                if (!auto_stra(&sa,t))
++                    log_die_nomem("stralloc") ;
++            }
++
++            if (NOFIELD) {
+ 
+                 char *m = "environment variables from: " ;
+                 size_t mlen = strlen(m) ;
+@@ -640,6 +658,7 @@ static void info_display_envfile(char const *field,ss_resolve_t *res)
+                 if (!stralloc_inserts(&sa,0,msg) ||
+                 !stralloc_0(&sa))
+                     log_die_nomem("stralloc") ;
++
+             }
+ 
+             if (pos)

--- a/srcpkgs/66/template
+++ b/srcpkgs/66/template
@@ -1,14 +1,15 @@
 # Template file for '66'
 pkgname=66
 version=0.6.1.1
-revision=1
+revision=2
 wrksrc="66-v${version}"
 build_style=configure
 configure_args="--prefix=/usr
  --with-sysdeps=${XBPS_CROSS_BASE}/usr/lib/skalibs/sysdeps
  --with-lib=${XBPS_CROSS_BASE}/usr/lib
  --with-s6-log-timestamp=iso
- --with-s6-log-user=_s6log"
+ --with-s6-log-user=_s6log
+ --with-system-dir=/etc/66/lib"
 hostmakedepends="pkg-config lowdown"
 makedepends="oblibs-devel skalibs-devel execline-devel s6-devel s6-rc-devel"
 short_desc="Small tools built around s6 and s6-rc programs"
@@ -18,10 +19,18 @@ homepage="http://web.obarun.org/software/"
 changelog="https://framagit.org/Obarun/66/raw/master/NEWS.md"
 distfiles="https://framagit.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
 checksum=4f80d94851a8c26e9666ea0f274890fc3abb6185ca1fe9fd8e2ad71e27a2ade9
+patch_args=" -Np1"
 
-conf_files="/etc/66/init /etc/66/init.conf"
+conf_files="/etc/66/init.conf"
 
 system_accounts="_s6log"
+
+pre_configure() {
+
+	# Clean the default $PATH for service scripts
+	vsed -i "s@PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin@PATH=/usr/bin:/usr/sbin@" \
+	 "${wrksrc}/skel/init.conf"
+}
 
 post_install() {
 	vdoc README.md


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
There are two significant changes in the commit.

1.  The default $PATH 66 uses for the services  contains too many dirs. This reduces it to just /usr/bin:/usr/sbin, which is what runsvdir uses by default.
2. The default directory for the system-dir, which is where 66 stores the trees created and information about enabled services, is `/var/lib/66`. But 66 can be used to boot a system and /var may not be in the root filesystem or mounted early, so boot will fail. This update, changes service-dir to `/usr/lib/66`. Users that upgrade from an earlier version or revision should either copy the contents of the old system-dir to the new or create trees again and enable services.
@gspe @flexibeast @Obarun 