### PR TITLE
[RFC] [WIP] runit: respect SVDIR env variable in completion

### DIFF
--- a/srcpkgs/runit/files/_sv
+++ b/srcpkgs/runit/files/_sv
@@ -35,7 +35,11 @@ cmds)
         check
     ret=0;;
 args)
-    services=( /var/service/*(-/N:t) )
+    if [[ $BUFFER == sudo* ]] then
+	    services=( /var/service/*(-/N:t) )
+    else
+	    services=( ${SVDIR:-/var/service}/*(-/N:t) )
+    fi
     (( $#services )) && _values services $services && ret=0
     [[ $words[CURRENT] = */* ]] && _directories && ret=0
     ;;


### PR DESCRIPTION
Allows sv's completion to complete other service directories, e.g. for per-user services.
If the `$SVDIR` environment variable is set *and* `sv` isn't used with `sudo`, the completion is changed to complete services from `$SVDIR`. Otherwise behaviour is unchanged.

I currently have only implemented the change for `zsh`. In bash, the `sudo` completion modifies variables so that the completion of the following command doesn't "see" the `sudo` in the beginning. If there is interest in merging this, I'd check for a bash solution too.

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

[skip CI]
Does not change any compiled files