### PR TITLE
newsboat: update to 2.22.1.

### DIFF
--- a/srcpkgs/newsboat/template
+++ b/srcpkgs/newsboat/template
@@ -1,11 +1,12 @@
 # Template file for 'newsboat'
 pkgname=newsboat
-version=2.21
+version=2.22.1
 revision=1
 build_style=configure
 build_helper="rust"
 configure_script="./config.sh"
 make_install_args="prefix=/usr"
+make_check_target="ci-check"
 hostmakedepends="ruby-asciidoctor pkg-config cargo git gettext"
 makedepends="json-c-devel libcurl-devel libxml2-devel sqlite-devel stfl-devel
  rust-std"
@@ -16,11 +17,14 @@ license="MIT"
 homepage="https://newsboat.org/"
 changelog="https://raw.githubusercontent.com/newsboat/newsboat/master/CHANGELOG.md"
 distfiles="https://newsboat.org/releases/${version}/newsboat-${version}.tar.xz"
-checksum=0c46b3dd46bb578dd6dd4915db4cfdffb4352ab258f251080ad14655c75a9c31
+checksum=8920f41cc53776b67c0e85ad1696b0967f6ac248f3b8913d977942c15d75e690
 
-do_check() {
-	make test
-	(cd test && TERM=$TERM TMPDIR=/dev/shm ./test)
+# tests fail when run by superuser
+# they always fail on musl, see https://github.com/newsboat/newsboat/issues/1216
+make_check=extended
+
+pre_check() {
+	export TERM=$TERM
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

Tests fail on CI because they're run as superuser. I ran them locally and it worked fine.
Changed check target to `ci-check` which was introduced in 2.22 to run C++ *and* Rust tests.

closes #27902

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
