### PR TITLE
python3-grpcio: correct asm for boringssl

### DIFF
--- a/srcpkgs/python3-grpcio/template
+++ b/srcpkgs/python3-grpcio/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-grpcio'
 pkgname=python3-grpcio
 version=1.35.0
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* armv[67]* ppc64le*"
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
@@ -47,5 +47,5 @@ post_patch() {
 
 	vsed -i setup.py \
 		-e "s/asm_key = .*/asm_key = '${asm_key}'/" \
-		-e "s/if BUILD_WITH_BORING_SSL_ASM:/if False:/"
+		-e "s/if BUILD_WITH_BORING_SSL_ASM.*:/if False:/"
 }


### PR DESCRIPTION
The line was changed to:

	if BUILD_WITH_BORING_SSL_ASM and not BUILD_WITH_SYSTEM_OPENSSL:

---

I'm not sure if we should switch to use system's {open,libre}ssl instead of bundled boringssl.
Also `re2-devel`.