### PR TITLE
removed-packages: remove mozjs*.

### DIFF
--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,7 +1,7 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
 version=0.1
-revision=26
+revision=27
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
@@ -171,8 +171,6 @@ replaces="
  mdds0<=0.12.1_3
  mirrorbits<=0.5.1_1
  mongroup<=0.4.1_2
- mozjs52<=52.9.0_7
- mozjs60<=60.8.0_5
  mozjs68<=68.11.0_1
  orage<=4.12.1_7
  oce<=0.18.3_1


### PR DESCRIPTION
XBPS's self update phase is too eager, and ends up pulling in
removed-packages. This means that a library added to removed-packages,
which should be cleanly replaced during the update phase, since its
dependants will ether be removed or moved to another dependency, will
instead stop the installation due to shlib errors.

Fixes #28779.

@Chocimier @Duncaen 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl28779
-->
