### PR TITLE
go: update to 1.16

### DIFF
--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -39,6 +39,7 @@ export CGO_CPPFLAGS="$CPPFLAGS"
 export CGO_CXXFLAGS="$CXXFLAGS"
 export CGO_LDFLAGS="$LDFLAGS"
 export CGO_ENABLED=1
+export GO111MODULE=auto
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) export GOCACHE="${XBPS_HOSTDIR}/gocache-muslc" ;;
 	*)	export GOCACHE="${XBPS_HOSTDIR}/gocache-glibc" ;;

--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.15.9
+version=1.16.2
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -9,8 +9,9 @@ short_desc="Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://golang.org/"
+changelog="https://golang.org/doc/devel/release.html"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=90983b9c84a92417337dc1942ff066fc8b3a69733b8b5493fd0b9b9db1ead60f
+checksum=37ca14287a23cb8ba2ac3f5c3dd8adbc1f7a54b9701a57824bf19a0b271f83ea
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
Tested on x86_64-glibc.

~~According to the release notes, this version no more supports x87 on the 386 arch, but only SSE2 and softfloat. I think SSE2 was the default even in older releases.
Since Void's i686 port must not require SSE2, we should both export `GO386=softfloat` when building the compiler (if needed) and set it as the default for the package. I don't know how to do it however. Setting it in `do_build()` makes the build fail.~~

Also, `GO111MODULE` now defaults to `on` instead of `auto`. Should we provide an INSTALL.msg?

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
