### PR TITLE
gobuster: fix go_import_path.

### DIFF
--- a/srcpkgs/gobuster/template
+++ b/srcpkgs/gobuster/template
@@ -1,10 +1,9 @@
 # Template file for 'gobuster'
 pkgname=gobuster
 version=3.1.0
-revision=1
+revision=2
 build_style=go
-go_import_path=github.com/OJ/gobuster
-hostmakedepends="git"
+go_import_path=github.com/OJ/gobuster/v3
 short_desc="Directory, file and DNS busting tool"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="Apache-2.0"


### PR DESCRIPTION
This allows us to remove git from hostmakedepends, since it was only
being used to download v1 of gobuster in order to build that, instead of
building the current version.

Fixes #28846.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
