### PR TITLE
ncmpc: update to 0.45

### DIFF
--- a/srcpkgs/ncmpc/template
+++ b/srcpkgs/ncmpc/template
@@ -1,6 +1,6 @@
 # Template file for 'ncmpc'
 pkgname=ncmpc
-version=0.44
+version=0.45
 revision=1
 build_style=meson
 configure_args="-Dlirc=disabled"
@@ -12,7 +12,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.musicpd.org/clients/ncmpc/"
 changelog="https://raw.githubusercontent.com/MusicPlayerDaemon/ncmpc/master/NEWS"
 distfiles="https://www.musicpd.org/download/ncmpc/0/ncmpc-${version}.tar.xz"
-checksum=e9cf0ef9e052d55ec3e863f04724fd0cfe1a1e15e1c0017eed820906690eb58c
+checksum=17ff446447e002f2ed4342b7324263a830df7d76bcf177dce928f7d3a6f1f785
 
 post_install() {
 	vmkdir usr/share/examples/ncmpc


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
Ncmpc broke with the latest MPD update, a version bump is necessary to make it work again.