### PR TITLE
ctags: update to 5.9.20210214.0

### DIFF
--- a/srcpkgs/ctags/patches/0001-Strip-libiconv-dependant-tests.patch
+++ b/srcpkgs/ctags/patches/0001-Strip-libiconv-dependant-tests.patch
@@ -1,0 +1,195 @@
+From 0f18f8c8a27ea88d0637ab3d86394265abcbb8f9 Mon Sep 17 00:00:00 2001
+From: Reed Wade <reedwade@misterbanal.net>
+Date: Tue, 23 Feb 2021 09:12:01 +0100
+Subject: [PATCH] Strip libiconv dependant tests
+
+Signed-off-by: Reed Wade <reedwade@misterbanal.net>
+---
+ .../input-encoding-option.d/exit-expected.txt |  1 -
+ Tmain/input-encoding-option.d/input.java      |  4 ----
+ Tmain/input-encoding-option.d/input.js        |  1 -
+ Tmain/input-encoding-option.d/run.sh          | 22 -------------------
+ .../stderr-expected.txt                       |  0
+ .../stdout-expected.txt                       |  0
+ .../input-encoding-option.d/tags-expected.txt | 14 ------------
+ .../exit-expected.txt                         |  1 -
+ Tmain/output-encoding-option.d/input.java     |  4 ----
+ Tmain/output-encoding-option.d/input.js       |  1 -
+ Tmain/output-encoding-option.d/run.sh         | 21 ------------------
+ .../stderr-expected.txt                       |  0
+ .../stdout-expected.txt                       |  0
+ .../tags-expected.txt                         | 14 ------------
+ 14 files changed, 83 deletions(-)
+ delete mode 100644 Tmain/input-encoding-option.d/exit-expected.txt
+ delete mode 100644 Tmain/input-encoding-option.d/input.java
+ delete mode 100644 Tmain/input-encoding-option.d/input.js
+ delete mode 100644 Tmain/input-encoding-option.d/run.sh
+ delete mode 100644 Tmain/input-encoding-option.d/stderr-expected.txt
+ delete mode 100644 Tmain/input-encoding-option.d/stdout-expected.txt
+ delete mode 100644 Tmain/input-encoding-option.d/tags-expected.txt
+ delete mode 100644 Tmain/output-encoding-option.d/exit-expected.txt
+ delete mode 100644 Tmain/output-encoding-option.d/input.java
+ delete mode 100644 Tmain/output-encoding-option.d/input.js
+ delete mode 100644 Tmain/output-encoding-option.d/run.sh
+ delete mode 100644 Tmain/output-encoding-option.d/stderr-expected.txt
+ delete mode 100644 Tmain/output-encoding-option.d/stdout-expected.txt
+ delete mode 100644 Tmain/output-encoding-option.d/tags-expected.txt
+
+diff --git Tmain/input-encoding-option.d/exit-expected.txt Tmain/input-encoding-option.d/exit-expected.txt
+deleted file mode 100644
+index 573541ac..00000000
+--- Tmain/input-encoding-option.d/exit-expected.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-0
+diff --git Tmain/input-encoding-option.d/input.java Tmain/input-encoding-option.d/input.java
+deleted file mode 100644
+index f1ebd5d6..00000000
+--- Tmain/input-encoding-option.d/input.java
++++ /dev/null
+@@ -1,4 +0,0 @@
+-class Foo { // FooÉNÉâÉX
+-	public Foo() { // ÉRÉìÉXÉgÉâÉNÉ^
+-	}
+-}
+diff --git Tmain/input-encoding-option.d/input.js Tmain/input-encoding-option.d/input.js
+deleted file mode 100644
+index 8bfcd659..00000000
+--- Tmain/input-encoding-option.d/input.js
++++ /dev/null
+@@ -1 +0,0 @@
+-var a = 1; //  —øÙΩÈ¥¸≤Ω
+diff --git Tmain/input-encoding-option.d/run.sh Tmain/input-encoding-option.d/run.sh
+deleted file mode 100644
+index 16a5d21b..00000000
+--- Tmain/input-encoding-option.d/run.sh
++++ /dev/null
+@@ -1,22 +0,0 @@
+-#!/bin/sh
+-
+-# Copyright: 2015 Yasuhiro MATSUMOTO
+-# License: GPL-2
+-
+-CTAGS=$1
+-BUILDDIR=$2
+-
+-. ../utils.sh
+-
+-if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
+-  if ${CTAGS} --quiet --options=NONE \
+-	      --pseudo-tags=-TAG_PROC_CWD \
+-	      --input-encoding=utf-8 --input-encoding-java=cp932 --input-encoding-javascript=euc-jp \
+-	      -o ${BUILDDIR}/tags \
+-	      input.js input.java ; then
+-      remove_commit_id ${BUILDDIR}/tags
+-  fi
+-  exit $?
+-else
+-  skip "iconv feature is not available"
+-fi
+diff --git Tmain/input-encoding-option.d/stderr-expected.txt Tmain/input-encoding-option.d/stderr-expected.txt
+deleted file mode 100644
+index e69de29b..00000000
+diff --git Tmain/input-encoding-option.d/stdout-expected.txt Tmain/input-encoding-option.d/stdout-expected.txt
+deleted file mode 100644
+index e69de29b..00000000
+diff --git Tmain/input-encoding-option.d/tags-expected.txt Tmain/input-encoding-option.d/tags-expected.txt
+deleted file mode 100644
+index 07ddd7d6..00000000
+--- Tmain/input-encoding-option.d/tags-expected.txt
++++ /dev/null
+@@ -1,14 +0,0 @@
+-!_TAG_FILE_ENCODING	UTF-8	//
+-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
+-!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+-!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+-!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+-!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+-!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+-!_TAG_PROGRAM_VERSION	5.9.0	//
+-Foo	input.java	/^	public Foo() { \/\/ „Ç≥„É≥„Çπ„Éà„É©„ÇØ„Çø$/;"	m	class:Foo
+-Foo	input.java	/^class Foo { \/\/ Foo„ÇØ„É©„Çπ$/;"	c
+-a	input.js	/^var a = 1; \/\/ Â§âÊï∞ÂàùÊúüÂåñ$/;"	v
+diff --git Tmain/output-encoding-option.d/exit-expected.txt Tmain/output-encoding-option.d/exit-expected.txt
+deleted file mode 100644
+index 573541ac..00000000
+--- Tmain/output-encoding-option.d/exit-expected.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-0
+diff --git Tmain/output-encoding-option.d/input.java Tmain/output-encoding-option.d/input.java
+deleted file mode 100644
+index 234c5b20..00000000
+--- Tmain/output-encoding-option.d/input.java
++++ /dev/null
+@@ -1,4 +0,0 @@
+-class Foo { // Foo„ÇØ„É©„Çπ
+-	public Foo() { // „Ç≥„É≥„Çπ„Éà„É©„ÇØ„Çø
+-	}
+-}
+diff --git Tmain/output-encoding-option.d/input.js Tmain/output-encoding-option.d/input.js
+deleted file mode 100644
+index 8bfcd659..00000000
+--- Tmain/output-encoding-option.d/input.js
++++ /dev/null
+@@ -1 +0,0 @@
+-var a = 1; //  —øÙΩÈ¥¸≤Ω
+diff --git Tmain/output-encoding-option.d/run.sh Tmain/output-encoding-option.d/run.sh
+deleted file mode 100644
+index 0687e610..00000000
+--- Tmain/output-encoding-option.d/run.sh
++++ /dev/null
+@@ -1,21 +0,0 @@
+-#!/bin/sh
+-# Copyright: 2015 Yasuhiro MATSUMOTO
+-# License: GPL-2
+-
+-CTAGS=$1
+-BUILDDIR=$2
+-
+-. ../utils.sh
+-
+-if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
+-  if ${CTAGS}  --quiet --options=NONE \
+-	       --pseudo-tags=-TAG_PROC_CWD \
+-	       --output-encoding=cp932 --input-encoding=utf-8 --input-encoding-javascript=euc-jp \
+-	       -o ${BUILDDIR}/tags \
+-	       input.js input.java ; then
+-      remove_commit_id ${BUILDDIR}/tags
+-  fi
+-  exit $?
+-else
+-	skip "iconv feature is not available"
+-fi
+diff --git Tmain/output-encoding-option.d/stderr-expected.txt Tmain/output-encoding-option.d/stderr-expected.txt
+deleted file mode 100644
+index e69de29b..00000000
+diff --git Tmain/output-encoding-option.d/stdout-expected.txt Tmain/output-encoding-option.d/stdout-expected.txt
+deleted file mode 100644
+index e69de29b..00000000
+diff --git Tmain/output-encoding-option.d/tags-expected.txt Tmain/output-encoding-option.d/tags-expected.txt
+deleted file mode 100644
+index be3eae3f..00000000
+--- Tmain/output-encoding-option.d/tags-expected.txt
++++ /dev/null
+@@ -1,14 +0,0 @@
+-!_TAG_FILE_ENCODING	cp932	//
+-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
+-!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+-!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+-!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+-!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+-!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+-!_TAG_PROGRAM_VERSION	5.9.0	//
+-Foo	input.java	/^	public Foo() { \/\/ ÉRÉìÉXÉgÉâÉNÉ^$/;"	m	class:Foo
+-Foo	input.java	/^class Foo { \/\/ FooÉNÉâÉX$/;"	c
+-a	input.js	/^var a = 1; \/\/ ïœêîèâä˙âª$/;"	v
+-- 
+2.30.1
+

--- a/srcpkgs/ctags/template
+++ b/srcpkgs/ctags/template
@@ -1,14 +1,21 @@
 # Template file for 'ctags'
 pkgname=ctags
-version=5.8
-revision=7
+version=5.9.20210214.0
+revision=1
+wrksrc=ctags-p${version}
 build_style=gnu-configure
+hostmakedepends="pkg-config automake python3-docutils"
 short_desc="Generates an index file of language objects found in source files"
 maintainer="Jan S. <jan.schreib@gmail.com>"
-license="GPL-3"
-homepage="http://ctags.sourceforge.net/"
-distfiles="${SOURCEFORGE_SITE}/ctags/${version}/ctags-${version}.tar.gz"
-checksum=0e44b45dcabe969e0bbbb11e30c246f81abe5d32012db37395eb57d66e9e99c7
+license="GPL-2.0-only"
+homepage="https://ctags.io/"
+distfiles="https://github.com/universal-ctags/ctags/archive/p${version}.tar.gz"
+checksum=26d9efe481a57e81195878cdb0baca730a3c4d234b9a7c4f6bf2c8def42bf42b
+
+do_configure() {
+	./autogen.sh
+	./configure ${configure_args}
+}
 
 do_install() {
 	make prefix=${DESTDIR}/usr bindir=${DESTDIR}/usr/bin mandir=${DESTDIR}/usr/share/man install


### PR DESCRIPTION
This is an update of ctags using universal-ctags

#### General
- [x] This is a update package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I built this PR locally for my native architecture, (x86_64)

