### PR TITLE
common/build-style: remove go_get from Go style.

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -914,12 +914,11 @@ that do such things as append (`+=`) to variables, should have `make_use_env`
 set in the body of the template.
 
 - `go` For programs written in Go that follow the standard package
-  structure. The variable `go_import_path` must be set to the package's
-  import path, e.g. `github.com/github/hub` for the `hub` program. If
-  the variable `go_get` is set to `yes`, the package will be
-  downloaded with `go get`. Otherwise (the default) it's expected that
-  the distfile contains the package. In both cases, dependencies will
-  be downloaded with `go get`.
+structure. The variable `go_import_path` must be set to the package's
+import path, e.g. `github.com/github/hub` for the `hub` program. This
+information can be found in the `go.mod` file for modern Go projects.
+It's expected that the distfile contains the package, but dependencies
+will be downloaded with `go get`.
 
 - `meta` For `meta-packages`, i.e packages that only install local files or simply
 depend on additional packages. This build style does not install
@@ -1585,10 +1584,6 @@ The following template variables influence how Go packages are built:
   variable is required.
 - `go_package`: A space-separated list of import paths of the packages
   that should be built. Defaults to `go_import_path`.
-- `go_get`: If set to yes, the package specified via `go_import_path`
-  will be downloaded with `go get`. Otherwise, a distfile has to be
-  provided. This option should only be used with `-git` (or similar)
-  packages; using a versioned distfile is preferred.
 - `go_build_tags`: An optional, space-separated list of build tags to
   pass to Go.
 - `go_mod_mode`: The module download mode to use. May be `off` to ignore

--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -15,7 +15,7 @@ do_configure() {
 	if [ "${go_mod_mode}" != "off" ] && [ -f go.mod ]; then
 		# Skip GOPATH symlink for Go modules
 		msg_normal "Building $pkgname using Go modules.\n"
-	elif [ "${go_get}" != "yes" ]; then
+	else
 		mkdir -p ${GOSRCPATH%/*}/
 		ln -fs "$PWD" "${GOSRCPATH}"
 	fi

--- a/srcpkgs/doctl/template
+++ b/srcpkgs/doctl/template
@@ -5,7 +5,6 @@ revision=1
 build_style=go
 go_import_path="github.com/digitalocean/doctl/cmd/doctl"
 go_build_tags="v${version}"
-go_get="no"
 short_desc="Command line tool for DigitalOcean services"
 maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="Apache-2.0"

--- a/srcpkgs/goimapnotify/template
+++ b/srcpkgs/goimapnotify/template
@@ -4,7 +4,6 @@ version=2.0
 revision=1
 build_style=go
 go_import_path="gitlab.com/shackra/goimapnotify"
-go_get="no"
 hostmakedepends="git"
 short_desc="Execute scripts on IMAP idle notifications (Go version)"
 maintainer="Andrew J. Hesford <ajh@sideband.org>"


### PR DESCRIPTION
Fix Manual accordingly, and also fix indentation to be compatible with
nearby items.

The two packages which set this variable set it explicitly to "no", so
it wasn't relied upon. From its description, it was recommended only for
git packages, which by default don't fit Void's packaging guidelines.
Removing to avoid anyone coming to rely on it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
