### PR TITLE
common/build-style: check if go_import_path matches go.mod.

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -25,6 +25,11 @@ do_build() {
 	go_package=${go_package:-$go_import_path}
 	# Build using Go modules if there's a go.mod file
 	if [ "${go_mod_mode}" != "off" ] && [ -f go.mod ]; then
+		# Check if go_import_path matches module
+		if [ "module $go_import_path" != "$(head -n1 go.mod)" ]; then
+			msg_error "\"\$go_import_path\" doesn't match the one defined in go.mod!\n"
+		fi
+
 		if [ -z "${go_mod_mode}" ] && [ -d vendor ]; then
 			msg_normal "Using vendor dir for $pkgname Go dependencies.\n"
 			go_mod_mode=vendor


### PR DESCRIPTION
Without this check, calling `go install` with a wrong go_import_path
might end up downloading the source code for said package (using git,
for example), instead of building from the provided tarball. The first
line of go.mod should be "module $go_import_path" for Go to not try and
download source code instead of using what it has locally.

Fixes #27690.

I have yet to test if this catches mismatches correctly.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
