### PR TITLE
wxPython4: fix cross build.

### DIFF
--- a/srcpkgs/wxPython4/template
+++ b/srcpkgs/wxPython4/template
@@ -16,24 +16,21 @@ license="custom:wxWindows"
 homepage="http://www.wxpython.org/"
 distfiles="${PYPI_SITE}/w/wxPython/wxPython-${version}.tar.gz"
 checksum=3be608bfdede3063678cc703453850ab0a018b82bafd5ee057302250b18f0233
-# FIXME
-nocross="https://build.voidlinux.org/builders/armv7l-musl_builder/builds/31785/steps/shell_3/logs/stdio"
 
 if [ "$CROSS_BUILD" ]; then
-	CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/python${py3_ver}"
+	CFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
 fi
 
 pre_build() {
 	chmod -R go+rX $wrksrc
 	if [ "$CROSS_BUILD" ]; then
 		PYPREFIX="$XBPS_CROSS_BASE"
-		CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
 		LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
 		CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
 		LDSHARED="${CC} -shared $LDFLAGS"
 		env CC="$CC" LDSHARED="$LDSHARED" \
 			PYPREFIX="$PYPREFIX" CFLAGS="$CFLAGS" \
-			PYTHON_CONFIG="${XBPS_CROSS_BASE}/bin/python3-config" \
+			PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config" \
 			LDFLAGS="$LDFLAGS" python3 build.py build_py --use_syswx
 	else
 		python3 build.py build_py --use_syswx


### PR DESCRIPTION
The PYTHON_CONFIG path was using /bin/python3-config, but the cross
toolchains currently lack usrmerge. Since the canonical location is
/usr/bin anyway, switching to /usr/bin is 100% correct.

Since we are here, also clean up how CFLAGS are being set.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
