### PR TITLE
python3-pytest-mock: update to 3.5.1

### DIFF
--- a/srcpkgs/python3-pytest-mock/template
+++ b/srcpkgs/python3-pytest-mock/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pytest-mock'
 pkgname=python3-pytest-mock
-version=1.10.4
-revision=4
+version=3.5.1
+revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,10 +12,14 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/pytest-dev/pytest-mock/"
 distfiles="${PYPI_SITE}/p/pytest-mock/pytest-mock-${version}.tar.gz"
-checksum=5bf5771b1db93beac965a7347dc81c675ec4090cb841e49d9d34637a25c30568
+checksum=a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc
+
+# pytest-mock requires pytest-mock to be installed so it'll always fail during
+# packaging
+make_check=no
 
 pre_build() {
-	sed -i setup.py \
+	vsed -i setup.py \
 		-e '/setup_requires=/d' \
 		-e "s|use_scm_version=.*|version='${version}',|"
 }


### PR DESCRIPTION
Breaking changes:
drop deprecated mock alias to mocker
drop python 2.7 and 3.4 support

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
Updating some low-hanging fruit, I noted any breaking changes as documented.