### PR TITLE
cracklib: build without python.

### DIFF
--- a/srcpkgs/cracklib-python
+++ b/srcpkgs/cracklib-python
@@ -1,1 +1,0 @@
-cracklib

--- a/srcpkgs/cracklib/template
+++ b/srcpkgs/cracklib/template
@@ -1,11 +1,10 @@
 # Template file for 'cracklib'
 pkgname=cracklib
 version=2.9.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
-hostmakedepends="libtool automake gettext-devel python"
-makedepends="python-devel"
+hostmakedepends="libtool automake gettext-devel"
 short_desc="Password Checking Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
@@ -31,16 +30,6 @@ cracklib-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
-	}
-}
-
-cracklib-python_package() {
-	lib32disabled=yes
-	depends="python"
-	short_desc+=" - python bindings"
-	pycompile_module="cracklib.py"
-	pkg_install() {
-		vmove "usr/lib/python*"
 	}
 }
 

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -26,6 +26,7 @@ replaces="
  california<=0.4.0_4
  clamz<=0.5_4
  couchdb<=1.7.1_2
+ cracklib-python<=2.9.7_1
  ctpp2<=2.8.3_7
  ctpp2-devel<=2.8.3_7
  dht-node<=0.2.0_3


### PR DESCRIPTION
Doesn't seem to support python3, so remove python extension.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
