### PR TITLE
devhelp: gedit plugin depends on python3.

### DIFF
--- a/srcpkgs/devhelp/template
+++ b/srcpkgs/devhelp/template
@@ -1,7 +1,7 @@
 # Template file for 'devhelp'
 pkgname=devhelp
 version=3.38.0
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 hostmakedepends="gettext glib-devel itstool pkg-config"
@@ -33,7 +33,7 @@ devhelp-libs_package() {
 }
 devhelp-gedit-plugin_package() {
 	short_desc+=" - gedit plugin"
-	depends="devhelp gedit python"
+	depends="devhelp gedit python3"
 	pkg_install() {
 		vmove usr/lib/gedit
 	}


### PR DESCRIPTION
As seen in [1], the loader for this plugin is python3.

[1]
https://gitlab.gnome.org/GNOME/devhelp/-/blob/18f3d0d671540f3d2d6a5e1d5704681519420441/plugins/gedit-plugin/devhelp.plugin.desktop.in

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
