### PR TITLE
build-style/cmake: also fix -isystem for Ninja

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -67,8 +67,12 @@ _EOF
 	CFLAGS="${CFLAGS/ -pipe / }" CXXFLAGS="${CXXFLAGS/ -pipe / }" \
 		cmake ${cmake_args} ${configure_args} ${wrksrc}/${build_wrksrc}
 
-	# Replace -isystem with -I for Qt4 and Qt5 packages
-	find -name flags.make -exec sed -i "{}" -e"s;-isystem;-I;g" \;
+	# Replace -isystem with -I
+	if [ "$CMAKE_GENERATOR" = "Unix Makefiles" ]; then
+		find . -name flags.make -exec sed -i -e 's/-isystem/-I/g' +
+	elif [ "$CMAKE_GENERATOR" = Ninja ]; then
+		sed -i -e 's/-isystem/-I/g' build.ninja
+	fi
 }
 
 do_build() {

--- a/srcpkgs/gqrx/template
+++ b/srcpkgs/gqrx/template
@@ -5,7 +5,8 @@ revision=2
 build_style=cmake
 configure_args="$(vopt_if gr_audio -DLINUX_AUDIO_BACKEND=Gr-audio)
  $(vopt_if portaudio -DLINUX_AUDIO_BACKEND=Portaudio)"
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config qt5-qmake qt5-host-tools python3
+ gnuradio"
 makedepends="boost-devel gnuradio-devel gnuradio-osmosdr-devel
  pulseaudio-devel qt5-svg-devel log4cpp-devel mpir-devel volk-devel
  fftw-devel python3-devel alsa-lib-devel jack-devel gmpxx-devel


### PR DESCRIPTION
Discovered by cross-build failure of gnuradio-osmosdr.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
