### PR TITLE
libtool: stop put /usr/lib{32,64} into RPATH

### DIFF
--- a/common/build-style/gnu-configure.sh
+++ b/common/build-style/gnu-configure.sh
@@ -4,12 +4,14 @@
 do_configure() {
 	: ${configure_script:=./configure}
 
+	export lt_cv_sys_lib_dlsearch_path_spec="/usr/lib64 /usr/lib32 /usr/lib /lib /usr/local/lib"
 	${configure_script} ${configure_args}
 }
 
 do_build() {
 	: ${make_cmd:=make}
 
+	export lt_cv_sys_lib_dlsearch_path_spec="/usr/lib64 /usr/lib32 /usr/lib /lib /usr/local/lib"
 	${make_cmd} ${makejobs} ${make_build_args} ${make_build_target}
 }
 

--- a/srcpkgs/ttfautohint/template
+++ b/srcpkgs/ttfautohint/template
@@ -3,7 +3,8 @@ pkgname=ttfautohint
 version=1.8.3
 revision=1
 build_style=gnu-configure
-hostmakedepends="pkg-config"
+build_helper=qmake
+hostmakedepends="pkg-config qt5-host-tools qt5-qmake perl"
 makedepends="freetype-devel harfbuzz-devel qt5-devel"
 short_desc="Tools for automated hinting process and finely hand-hinting"
 maintainer="Renato Aguiar <renato@renag.me>"
@@ -11,7 +12,3 @@ license="GPL-2.0-only"
 homepage="https://www.freetype.org/ttfautohint/"
 distfiles="http://download.savannah.gnu.org/releases/freetype/ttfautohint-${version}.tar.gz"
 checksum=87bb4932571ad57536a7cc20b31fd15bc68cb5429977eb43d903fa61617cf87e
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-host-tools qt5-devel"
-fi


### PR DESCRIPTION
libtool will insert RPATH if $libdir not in sys_lib_dlsearch_path_spec.
libtool's configure will parse /etc/ld.so.conf for this value.

Without this change the original value is:

- glibc: /lib /usr/lib /usr/lib32 /usr/local/lib
- musl: /lib /usr/lib

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
