### PR TITLE
grub-btrfs-runit: use posix shell for the service

### DIFF
--- a/srcpkgs/grub-btrfs/files/grub-btrfs/run
+++ b/srcpkgs/grub-btrfs/files/grub-btrfs/run
@@ -5,7 +5,7 @@ exec 2>&1
 
 if [ -d "${SNAPSHOTS_PATH}" ]
 then
-	exec wendy ${OPTS} -m 960 -w "${SNAPSHOTS_PATH}" bash -c \
+	exec wendy ${OPTS} -m 960 -w "${SNAPSHOTS_PATH}" sh -c \
 	 'if [ -s "/boot/grub/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else update-grub; fi'
 else
   exit 1


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
Does this need revbump?