### PR TITLE
spotifyd: fix runtime crash.

### DIFF
--- a/srcpkgs/spotifyd/template
+++ b/srcpkgs/spotifyd/template
@@ -1,7 +1,7 @@
 # Template file for 'spotifyd'
 pkgname=spotifyd
 version=0.3.0
-revision=1
+revision=2
 build_style=cargo
 configure_args="--no-default-features"
 hostmakedepends="pkg-config"
@@ -34,6 +34,10 @@ fi
 case "$XBPS_TARGET_MACHINE" in
 	aarch64-musl) broken="https://travis-ci.org/void-linux/void-packages/jobs/636076091" ;;
 esac
+
+post_patch() {
+	vsed -e 's/"with-tremor"//' -i Cargo.toml
+}
 
 pre_build() {
 	cargo update --package openssl-sys --precise 0.9.58


### PR DESCRIPTION
Issue in unsafe code led to a runtime panic if compiled with Rust 1.48
or newer.

Relevant information: https://github.com/Spotifyd/spotifyd/issues/719

Fixes #28285

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
