### PR TITLE
enchant2: fix file conflict with enchant.

### DIFF
--- a/srcpkgs/enchant2/template
+++ b/srcpkgs/enchant2/template
@@ -1,9 +1,16 @@
 # Template file for 'enchant2'
 pkgname=enchant2
 version=2.2.15
-revision=1
+revision=2
 wrksrc="enchant-${version}"
 build_style=gnu-configure
+# so package doesn't conflict with enchant's /usr/share/enchant/enchant.ordering;
+# might be a bug in their build system that only this directory and/or file aren't
+# suffixed appropriately.
+# passing this in make is safe because this is the value used to define the macro
+# that their code uses to find enchant.ordering
+make_build_args="pkgdatadir=/usr/share/enchant-2"
+make_install_args="$make_build_args"
 # tests need --enable-relocatable
 configure_args="--enable-relocatable"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
Reverts a change made in 1d79784495195cff12559a53ff387f32e12a6dc8 that
removed the make args. Also add explanation for why the make arguments
are necessary.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
