### PR TITLE
xen: prevent unwanted service starts, support oxenstored in service.

### DIFF
--- a/srcpkgs/xen/files/xen.conf
+++ b/srcpkgs/xen/files/xen.conf
@@ -1,3 +1,4 @@
+xenfs
 xen-evtchn
 xen-gntdev
 xen-gntalloc

--- a/srcpkgs/xen/files/xen/run
+++ b/srcpkgs/xen/files/xen/run
@@ -1,5 +1,8 @@
 #!/bin/sh
+sv start xenconsoled > /dev/null || exit 1
 sv check xenconsoled >/dev/null || exit 1
-xenstore-write "/local/domain/0/domid" 0 || exit 1
-xenstore-write "/local/domain/0/name" "Domain-0" || exit 1
+if ! pgrep -f '^shim-xenconsoled' ; then
+    xenstore-write "/local/domain/0/domid" 0 || exit 1
+    xenstore-write "/local/domain/0/name" "Domain-0" || exit 1
+fi
 exec chpst -b xen pause

--- a/srcpkgs/xen/files/xenconsoled/check
+++ b/srcpkgs/xen/files/xenconsoled/check
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+exec > /dev/null
+exec 2>&1
+
+# Check for the faux xenconsoled first:
+pgrep -f '^shim-xenconsoled' && exit 0
+
+# There's not really a good way to check for xenconsoled being up.
+# The best I can come up with is to look at the open FDs, and if
+# hypervisor.log is open, then xenconsoled is almost certainly started
+# and ready to use.
+PID="$(pidof xenconsoled)" || exit 1
+expr "x${PID}" ':' 'x[0-9]\+$' > /dev/null || exit 1
+ls -l "/proc/${PID}/fd" 2>/dev/null |grep -q hypervisor.log

--- a/srcpkgs/xen/files/xenconsoled/log/run
+++ b/srcpkgs/xen/files/xenconsoled/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -p daemon.notice -t xenconsoled

--- a/srcpkgs/xen/files/xenconsoled/run
+++ b/srcpkgs/xen/files/xenconsoled/run
@@ -1,4 +1,12 @@
 #!/bin/sh
+exec 2>&1
+sv start xenstored >/dev/null || exit 1
 sv check xenstored >/dev/null || exit 1
+
+if pgrep -f '^shim-xenstored' ; then
+    # Not a Xen dom0; make this a no-op service.
+    exec chpst -b 'shim-xenconsoled' pause
+fi
+
 mkdir -p /var/log/xen/console
 exec xenconsoled -i --log=all

--- a/srcpkgs/xen/files/xenstored/check
+++ b/srcpkgs/xen/files/xenstored/check
@@ -1,0 +1,11 @@
+#!/bin/sh
+exec > /dev/null
+exec 2>&1
+
+# Check for faux xenstored first.  If it is, we aren't running under
+# a Xen dom0.  Consider xenstored started.
+pgrep -f '^shim-xenstored' && exit 0
+
+# The root key should always exist if xenstored is running, so we have
+# a simple test.
+/usr/bin/xenstore-exists /

--- a/srcpkgs/xen/files/xenstored/log/run
+++ b/srcpkgs/xen/files/xenstored/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -p daemon.notice -t xenstored

--- a/srcpkgs/xen/files/xenstored/run
+++ b/srcpkgs/xen/files/xenstored/run
@@ -1,7 +1,26 @@
 #!/bin/sh
+exec 2>&1
 [ ! -d /run/xen ] && mkdir -p /run/xen
-modprobe -q xen-evtchn xen-gnttalloc || exit 1
 mountpoint -q /proc/xen || mount -t xenfs xenfs /proc/xen
+# If not running in a Xen dom0, then this service is a no-op
+# and we can't start a real xenstored.
+grep -q control_d /proc/xen/capabilities || \
+    exec chpst -b \
+	 'shim-xenstored; see /etc/sv/xenstored/run to find out what this is' \
+	 pause
 mountpoint -q /var/lib/xenstored || mount -t tmpfs xenstored /var/lib/xenstored
-grep -q control_d /proc/xen/capabilities || exit 1
-exec xenstored --verbose --no-fork
+
+# shellcheck disable=SC1091
+[ -r conf ] && . ./conf
+XENSTORED="${XENSTORED:-xenstored}"
+case "$(basename "${XENSTORED}")" in
+    oxenstored)
+	XENSTORED_ARGS="${XENSTORED_ARGS:---no-fork}"
+	;;
+    *)
+	XENSTORED_ARGS="${XENSTORED_ARGS:---verbose --no-fork}"
+	;;
+esac
+
+# shellcheck disable=SC2086
+exec "${XENSTORED}" ${XENSTORED_ARGS}

--- a/srcpkgs/xen/patches/argp-standalone.patch
+++ b/srcpkgs/xen/patches/argp-standalone.patch
@@ -1,0 +1,15 @@
+Fix build with recent argp-standalone.
+I'll try and get this upstreamed so we don't have to carry it.
+
+diff -Nur xen-4.14.1.orig/tools/configure.ac xen-4.14.1/tools/configure.ac
+--- xen-4.14.1.orig/tools/configure.ac	2020-12-17 16:47:25.000000000 +0000
++++ xen-4.14.1/tools/configure.ac	2021-02-20 19:44:33.618002472 +0000
+@@ -426,7 +426,7 @@
+ AC_CHECK_LIB([iconv], [libiconv_open], [libiconv="y"], [libiconv="n"])
+ AC_SUBST(libiconv)
+ AC_CHECK_HEADER([argp.h], [
+-AC_CHECK_LIB([argp], [argp_usage], [argp_ldflags="-largp"])
++AC_CHECK_LIB([argp], [argp_parse], [argp_ldflags="-largp"])
+ ], [AC_MSG_ERROR([Could not find argp])])
+ AC_SUBST(argp_ldflags)
+ 

--- a/srcpkgs/xen/template
+++ b/srcpkgs/xen/template
@@ -1,7 +1,7 @@
 # Template file for 'xen'
 pkgname=xen
 version=4.14.1
-revision=2
+revision=3
 # grep -R IPXE_GIT_TAG src/xen-*/tools/firmware/etherboot
 _git_tag_ipxe=4bd064de239dab2426b31c9789a1f4d78087dc63
 # TODO: arm / aarch64


### PR DESCRIPTION
This is a rather convoluted fix for issue 18676.
We don't want to burn cycles and spam the user when the Xen services
are enabled and the system is not booted as a Xen dom0.  Booting a Xen
install into vanilla Linux without Xen is sometimes useful; that
experience should be more pleasant now.

Also, make the xenstored implementation selectable.  There are two
implementations shipped by Xen and in our Xen package:
the original one written in C (binary is just called xenstored) and
a newer one in ocaml (oxenstored).
oxenstored is -- IME -- more reliable.  Make it configurable in
./conf, but leave the default as-is.

Add a patch to fix failing to build from source on musl with newer
argp-standalone.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ x] I built this PR locally for my native architecture, (x86_64-musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
