### PR TITLE
opam: add dependency on bubblewrap.

### DIFF
--- a/srcpkgs/opam/template
+++ b/srcpkgs/opam/template
@@ -1,13 +1,13 @@
 # Template file for 'opam'
 pkgname=opam
 version=2.0.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/${pkgname}"
 make_build_args="lib-ext all"
 make_check_target="tests"
 makedepends="curl ncurses-devel ocaml ocaml-findlib tar"
-depends="curl patch unzip"
+depends="bubblewrap curl patch unzip"
 checkdepends="${depends} git rsync"
 short_desc="OCaml package manager"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
[chris@cmbvm ~]$ opam init
[NOTE] Will configure from built-in defaults.
Checking for available remotes: rsync and local, git.
  - you won't be able to use mercurial repositories unless you install
    the hg     command on your system.
  - you won't be able to use darcs repositories unless you install
    the darcs     command on your system.

[ERROR] Missing dependencies -- the following commands are required
for opam to         operate:
  - bwrap: Sandboxing tool bwrap was not found. You should install
    'bubblewrap'. See
    https://opam.ocaml.org/doc/FAQ.html#Why-does-opam-require-bwrap.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ x] I built this PR locally for my native architecture, (x86_64-musl)
- [ x] I built this PR locally for my native architecture, (x86_64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
