### PR TITLE
xbps-src: allow to run without git

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ See [Contributing](./CONTRIBUTING.md) for a general overview of how to contribut
 
 - GNU bash
 - xbps >= 0.56
+- git(1) - unless configured to not, see etc/defaults.conf
+- common POSIX utilities included by default in almost all UNIX systems
 - curl(1) - required by `xbps-src update-check`
+
+For bootstrapping additionally:
 - flock(1) - util-linux
 - bsdtar or GNU tar (in that order of preference)
 - install(1) - GNU coreutils
 - objcopy(1), objdump(1), strip(1): binutils
-- other common POSIX utilities included by default in almost all UNIX systems.
 
 `xbps-src` requires a utility to chroot and bind mount existing directories
 into a `masterdir` that is used as its main `chroot` directory. `xbps-src` supports

--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -2,7 +2,9 @@
 # only run this, if SOURCE_DATE_EPOCH isn't set.
 
 if [ -z "$XBPS_GIT_CMD" ]; then
-	msg_error "BUG: environment/setup: XBPS_GIT_CMD is not set\n"
+	if [ -z "$XBPS_USE_BUILD_MTIME" ] || [ -n "$XBPS_USE_GIT_REVS" ]; then
+		msg_error "BUG: environment/setup: XBPS_GIT_CMD is not set\n"
+	fi
 fi
 
 if [ -n "$XBPS_USE_BUILD_MTIME" ]; then

--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -132,7 +132,7 @@ XBPS_SUCMD="sudo /bin/sh -c"
 
 # [OPTIONAL]
 # Enable to use the standard mtime of files. Otherwise it will be rewritten to
-# the HEAD commit time.
+# the HEAD commit time. Requires git when disabled.
 #
 #XBPS_USE_BUILD_MTIME=yes
 

--- a/xbps-src
+++ b/xbps-src
@@ -513,7 +513,7 @@ if command -v chroot-git &>/dev/null; then
     export XBPS_GIT_CMD=$(command -v chroot-git)
 elif command -v git &>/dev/null; then
     export XBPS_GIT_CMD=$(command -v git)
-else
+elif [ -z "$XBPS_USE_BUILD_MTIME" ] || [ "$XBPS_USE_GIT_REVS" ]; then
     echo "neither chroot-git or git are available in your system!" 1>&2
     exit 1
 fi


### PR DESCRIPTION
This makes possible to binary-bootstrap and build packages
with only base-system using tarball of void-packages.