### PR TITLE
glyphy, libpipewire0.2: make devel depend on main package

### DIFF
--- a/srcpkgs/glyphy/template
+++ b/srcpkgs/glyphy/template
@@ -1,7 +1,7 @@
 # Template file for 'glyphy'
 pkgname=glyphy
 version=0.0.20190307
-revision=1
+revision=2
 _gitrev=bc2da506d23bdaf3eb0d95c9649a4591b4d912c7
 wrksrc="${pkgname}-${_gitrev}"
 build_style=gnu-configure
@@ -24,7 +24,7 @@ post_configure() {
 
 glyphy-devel_package() {
 	short_desc+=" - development files"
-	depends="${pkgname}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/*.so

--- a/srcpkgs/libpipewire0.2/template
+++ b/srcpkgs/libpipewire0.2/template
@@ -1,7 +1,7 @@
 # Template file for 'libpipewire0.2'
 pkgname=libpipewire0.2
 version=0.2.7
-revision=1
+revision=2
 wrksrc=pipewire-${version}
 build_style=meson
 configure_args="-Dgstreamer=disabled -Ddocs=false -Dsystemd=false"
@@ -26,7 +26,7 @@ post_install() {
 }
 
 libpipewire0.2-devel_package() {
-	depends="${pkgname}-${version}_${revision}"
+	depends="${sourcepkg}-${version}_${revision}"
 	short_desc+=" - pipewire and libspa development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
glyphy-devel is used by libreoffice, which seemed to be build without glyphy.
libpipewire0.2-devel is used by chromium. No idea if change will affect anything here.

One more package with that issue is gnunet, which will be updated separately.
<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
