### PR TITLE
portage: update to 3.0.15.

### DIFF
--- a/srcpkgs/portage/template
+++ b/srcpkgs/portage/template
@@ -1,6 +1,6 @@
 # Template file for 'portage'
 pkgname=portage
-version=3.0.14
+version=3.0.15
 revision=1
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="teldra <teldra@rotce.de>"
 license="GPL-2.0-only"
 homepage="https://wiki.gentoo.org/wiki/Portage"
 distfiles="https://github.com/gentoo/${pkgname}/archive/${pkgname}-${version}.tar.gz"
-checksum=59bebfa0aa1ff2ae3f27383f0b6c7f5d271050c080f6bfd3da86c2dcf7395aaf
+checksum=58779c9678112804b4fdd9107d3dad4141d6882d0035cde44e174be28f2d5898
 
 conf_files="
 	/etc/dispatch-conf.conf


### PR DESCRIPTION
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl
