### PR TITLE
common/gnu-configure-args: set exec_prefix to ${prefix}

### DIFF
--- a/common/environment/configure/gnu-configure-args.sh
+++ b/common/environment/configure/gnu-configure-args.sh
@@ -18,6 +18,7 @@ export configure_args+=" --host=$XBPS_TRIPLET --build=$XBPS_TRIPLET"
 # This is to make sure 32-bit and 64-bit libs can coexist when looking
 # up things (the opposite-libdir is always symlinked as libNN)
 export configure_args+=" --libdir=\${exec_prefix}/lib${XBPS_TARGET_WORDSIZE}"
+export configure_args+=" --exec-prefix=\${prefix}"
 
 _AUTOCONFCACHEDIR=${XBPS_COMMONDIR}/environment/configure/autoconf_cache
 

--- a/srcpkgs/openmpi/template
+++ b/srcpkgs/openmpi/template
@@ -1,11 +1,12 @@
 # Template file for 'openmpi'
 pkgname=openmpi
 version=4.1.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-ipv6 --with-hwloc=${XBPS_CROSS_BASE}/usr"
-hostmakedepends="gcc-fortran libgomp-devel perl"
-makedepends="libgfortran-devel libgomp-devel libhwloc-devel zlib-devel"
+hostmakedepends="gcc-fortran libgomp-devel perl pkg-config"
+makedepends="libgfortran-devel libgomp-devel libhwloc-devel zlib-devel
+ libevent-devel"
 conf_files="
  /etc/openmpi-default-hostfile
  /etc/openmpi-mca-params.conf
@@ -42,6 +43,8 @@ pre_configure() {
 
 post_install() {
 	vlicense LICENSE
+	# https://github.com/void-linux/void-packages/pull/28996#issuecomment-784255185
+	mv "${DESTDIR}/usr/lib/ompi_monitoring_prof.so" "${DESTDIR}/usr/lib/openmpi"
 }
 
 libopenmpi_package() {


### PR DESCRIPTION
autotools will pass its configure_args to subdir if required,
if we don't init exec_prefix, it will pass --libdir=NONE/lib{32,64} to
subdir configure.

---

Found when fixing openmpi

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
