### PR TITLE
cackey: remove rpath, fix cross build

### DIFF
--- a/srcpkgs/cackey/patches/no-rpath.patch
+++ b/srcpkgs/cackey/patches/no-rpath.patch
@@ -1,0 +1,14 @@
+Index: configure.ac
+===================================================================
+--- configure.ac.orig
++++ configure.ac
+@@ -212,9 +212,6 @@ fi
+ dnl Set version script, to limit the scope of symbols
+ DC_SETVERSIONSCRIPT(libcackey.vers, libcackey.syms)
+ 
+-dnl Upate LDFLAGS to include setting the run-time linker path to the same as our compile-time linker
+-DC_SYNC_RPATH
+-
+ dnl If we updated LIBOBJS, update SHLIBOBJS -- must be last.
+ DC_SYNC_SHLIBOBJS
+ 

--- a/srcpkgs/cackey/template
+++ b/srcpkgs/cackey/template
@@ -3,7 +3,8 @@ pkgname=cackey
 version=0.7.10
 revision=1
 build_style=gnu-configure
-makedepends="pcsclite-devel"
+hostmakedepends="automake"
+makedepends="pcsclite-devel zlib-devel"
 depends="pcsc-tools"
 short_desc="PKCS#11 provider library for using smart cards"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
@@ -11,6 +12,11 @@ license="MIT"
 homepage="http://www.rkeene.org/projects/info/wiki/161"
 distfiles="http://cackey.rkeene.org/download/$version/cackey-$version.tar.gz"
 checksum=e2074055bab8eb1c277bfa3355767c50f792d5b87bf41f9c0d1af0e77f311583
+CPPFLAGS="-I$XBPS_CROSS_BASE/usr/include/PCSC"
+
+pre_configure() {
+	autoreconf -fi
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
