### PR TITLE
Fix typo pupper -> puppet

### DIFF
--- a/srcpkgs/puppet/files/puppetmaster/run
+++ b/srcpkgs/puppet/files/puppetmaster/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-install -d -m0755 -o puppet -g pupper /run/puppet
+install -d -m0755 -o puppet -g puppet /run/puppet
 exec puppet master --no-daemonize

--- a/srcpkgs/puppet/template
+++ b/srcpkgs/puppet/template
@@ -1,7 +1,7 @@
 # Template file for 'puppet'
 pkgname=puppet
 version=6.16.0
-revision=2
+revision=3
 build_style=ruby-module
 hostmakedepends="ruby facter-devel hiera which"
 makedepends="facter-devel"


### PR DESCRIPTION
The current runit file for the puppetmaster service asserts a misnamed group, resulting in an error. This pull request fixes the issue.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
