### PR TITLE
straw-viewer: update to 0.1.3 and update some dependencies

### DIFF
--- a/srcpkgs/perl-File-Listing/template
+++ b/srcpkgs/perl-File-Listing/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-File-Listing'
 pkgname=perl-File-Listing
-version=6.11
+version=6.14
 revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/File-Listing"
 distfiles="${CPAN_SITE}/File/File-Listing-$version.tar.gz"
-checksum=c24c14ece10b949e1cb52d64bc28b42cbaebf87e00293a3f7500950d6be0bf6e
+checksum=15b3a4871e23164a36f226381b74d450af41f12cc94985f592a669fcac7b48ff

--- a/srcpkgs/perl-HTTP-Cookies/template
+++ b/srcpkgs/perl-HTTP-Cookies/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-HTTP-Cookies'
 pkgname=perl-HTTP-Cookies
-version=6.09
+version=6.10
 revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
@@ -12,4 +12,4 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="Artistic-1.0-Perl,  GPL-1.0-or-later"
 homepage="https://metacpan.org/release/HTTP-Cookies"
 distfiles="${CPAN_SITE}/HTTP/HTTP-Cookies-$version.tar.gz"
-checksum=903f017afaa5b78599cc90efc14ecccc8cc2ebfb636eb8c02f8f16ba861d1fe0
+checksum=e36f36633c5ce6b5e4b876ffcf74787cc5efe0736dd7f487bdd73c14f0bd7007

--- a/srcpkgs/perl-HTTP-Message/template
+++ b/srcpkgs/perl-HTTP-Message/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-HTTP-Message'
 pkgname=perl-HTTP-Message
-version=6.26
+version=6.28
 revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
@@ -13,4 +13,4 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/HTTP-Message"
 distfiles="${CPAN_SITE}/HTTP/HTTP-Message-$version.tar.gz"
-checksum=6ce6c359de75c3bb86696a390189b485ec93e3ffc55326b6d044fa900f1725e1
+checksum=04e3168f9576b48d45124ac681a574408ebb6fa8eb2dba6d3fe70c8f6704dbb8

--- a/srcpkgs/perl-JSON/template
+++ b/srcpkgs/perl-JSON/template
@@ -1,16 +1,16 @@
 # Template file for 'perl-JSON'
 pkgname=perl-JSON
-version=4.02
-revision=2
+version=4.03
+revision=1
 wrksrc="JSON-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="$hostmakedepends"
-checkdepends="perl-Test-Pod"
 depends="perl"
+checkdepends="perl-Test-Pod"
 short_desc="JSON (JavaScript Object Notation) encoder/decoder"
 maintainer="Steven R <dev@styez.com>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/JSON"
 distfiles="${CPAN_SITE}/JSON/JSON-${version}.tar.gz"
-checksum=444a88755a89ffa2a5424ab4ed1d11dca61808ebef57e81243424619a9e8627c
+checksum=e41f8761a5e7b9b27af26fe5780d44550d7a6a66bf3078e337d676d07a699941

--- a/srcpkgs/perl-Net-HTTP/template
+++ b/srcpkgs/perl-Net-HTTP/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-Net-HTTP'.
+# Template file for 'perl-Net-HTTP'
 pkgname=perl-Net-HTTP
-version=6.19
-revision=2
+version=6.20
+revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Net-HTTP"
 distfiles="${CPAN_SITE}/Net/Net-HTTP-${version}.tar.gz"
-checksum=52b76ec13959522cae64d965f15da3d99dcb445eddd85d2ce4e4f4df385b2fc4
+checksum=92527b2a24512961b8e3637c6216a057751e39b6fa751422ed181ff599779f1e

--- a/srcpkgs/perl-Term-ReadLine-Gnu/template
+++ b/srcpkgs/perl-Term-ReadLine-Gnu/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Term-ReadLine-Gnu'
 pkgname=perl-Term-ReadLine-Gnu
-version=1.36
-revision=3
+version=1.40
+revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl ncurses-devel readline-devel"
@@ -11,7 +11,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Term-ReadLine-Gnu"
 distfiles="${CPAN_SITE}/Term/${pkgname/perl-/}-${version}.tar.gz"
-checksum=9a08f7a4013c9b865541c10dbba1210779eb9128b961250b746d26702bab6925
+checksum=d3a6169aeb1f04f9f05853a4f1c3b26dd265f6f00b790024959cb8f395842774
 
 post_extract() {
 	vsed -i '/if.*guess_malloc_names/s/.*/if(my $extra_defs=""){/' Makefile.PL

--- a/srcpkgs/perl-URI/template
+++ b/srcpkgs/perl-URI/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-URI'
 pkgname=perl-URI
-version=5.05
+version=5.07
 revision=1
 wrksrc="URI-$version"
 build_style=perl-module
@@ -13,4 +13,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/URI"
 distfiles="${CPAN_SITE}/URI/URI-${version}.tar.gz"
-checksum=a5c113d2d02706d9fbdca6a86f290c5b05b2f86836d4e7fe1447f063261b79ec
+checksum=eeb6ed2ae212434e2021e29f7556f4024169421a5d8b001a89e65982944131ea

--- a/srcpkgs/straw-viewer/template
+++ b/srcpkgs/straw-viewer/template
@@ -1,6 +1,6 @@
 # Template file for 'straw-viewer'
 pkgname=straw-viewer
-version=0.1.2
+version=0.1.3
 revision=1
 build_style=perl-ModuleBuild
 configure_args="--gtk"
@@ -13,7 +13,7 @@ license="Artistic-2.0"
 homepage="https://github.com/trizen/straw-viewer"
 changelog="https://github.com/trizen/straw-viewer/releases"
 distfiles="https://github.com/trizen/straw-viewer/archive/${version}.tar.gz"
-checksum=4ce456143639a4ea88c21f20e37b9a9c19b15055d05c78bcf69a72be2b5a65b6
+checksum=e6afc6a87578a55b17666a79b813657daac93f78aaf810d1aa03fcb4a7354bf4
 
 gtk-straw-viewer_package() {
 	depends="${sourcepkg}-${version}_${revision} perl-Gtk3 perl-File-ShareDir"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
straw-viewer is now [deprecated](https://github.com/trizen/straw-viewer/releases) in favour of pipe-viewer (#29014 ). I'm not removing the package for the moment because the [commit](https://github.com/trizen/pipe-viewer/commit/17fb2136f3f3d8ee6dacac05beabcc15082f699d) which allows pipe-viewer to behave exactly as straw-viewer is not yet part of a release.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
