### PR TITLE
gnome-shell: enable screencast.

### DIFF
--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
 version=3.38.3
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dsystemd=false"
@@ -12,7 +12,7 @@ makedepends="at-spi2-atk evolution-data-server-devel folks-devel
  gnome-menus-devel gsettings-desktop-schemas-devel gstreamer1-devel gtk+3-devel
  ibus-devel json-glib-devel libcanberra-devel libcroco-devel libglib-devel
  libsecret-devel libsoup-devel libX11-devel libxml2-devel mutter-devel
- libnma-devel polkit-devel pulseaudio-devel
+ libnma-devel polkit-devel pulseaudio-devel pipewire-devel
  startup-notification-devel telepathy-logger-devel gnome-autoar-devel"
 depends="elogind glxinfo gnome-control-center gsettings-desktop-schemas upower"
 short_desc="GNOME core user interface"


### PR DESCRIPTION
pipewire-devel was missing as makedepends.

Fixes #28987.
Solution taken from same issue, kudos @maop:
https://build.opensuse.org/request/show/859147

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->