### PR TITLE
runc: update to 1.0.0_15 (rc93)

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,8 +1,8 @@
 # Template file for 'runc'
 pkgname=runc
 version=1.0.0
-revision=14
-_subver="rc92"
+revision=15
+_subver="rc93"
 _ver="$version-$_subver"
 wrksrc="$pkgname-$_ver"
 build_style=go
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${_ver}/runc.tar.xz"
-checksum=2f76b623b550588db98e2be72e74aae426f5d4cf736bd92afb91dd5586816daf
+checksum=70ee0fcf45b17f0da93dd4c4d174046a3584080dcc07c5468914d33d57c8202d
 
 post_build() {
 	make man


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR


Currently any docker containers with recent glibc are broken and won't really work (e.g. try invoking `pacman` on  `archlinux:latest`) latest runc fixed that