### PR TITLE
build-style/cmake: pass LIBS as CMAKE_*_STANDARD_LIBRARIES

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -65,7 +65,10 @@ _EOF
 	export CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
 	# Remove -pipe: https://gitlab.kitware.com/cmake/cmake/issues/19590
 	CFLAGS="-DNDEBUG ${CFLAGS/ -pipe / }" CXXFLAGS="-DNDEBUG ${CXXFLAGS/ -pipe / }" \
-		cmake ${cmake_args} ${configure_args} ${wrksrc}/${build_wrksrc}
+		cmake ${cmake_args} ${configure_args} \
+		${LIBS:+-DCMAKE_C_STANDARD_LIBRARIES="$LIBS"} \
+		${LIBS:+-DCMAKE_CXX_STANDARD_LIBRARIES="$LIBS"} \
+		${wrksrc}/${build_wrksrc}
 
 	# Replace -isystem with -I
 	if [ "$CMAKE_GENERATOR" = "Unix Makefiles" ]; then


### PR DESCRIPTION
Normally, we can add them into configure_args directly.
However, if we need to link with 2 or more libaries (e.g. -latomic
and -lexecinfo on armv6-musl), we have noway to do it properly:
- configure_args will be splited on whitespace
- cmake denies to recognise CMAKE_*_STANDARD_LIBRARIES as a list,
  hence denies to split on semicolon (";")

Let's pass LIBS as CMAKE_*_STANDARD_LIBRARIES instead.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
