### PR TITLE
mkinitcpio: update to 30.

### DIFF
--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,16 +1,16 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
-version=29
+version=30
 revision=1
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
-depends="busybox-static bsdtar bash"
+depends="busybox-static bsdtar bash zstd"
 short_desc="Next generation of initramfs creation"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-only"
 homepage="https://wiki.archlinux.org/index.php/Mkinitcpio"
 distfiles="https://sources.archlinux.org/other/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=0239ba7ae91d652472819457a5dd812c574ba37c3c3d9161e7742a63b85076c2
+checksum=c7725035a06d2ab6ef6e97601b69859d6061aec95c4551e2a1ad2e27d307258f
 
 conf_files="/etc/mkinitcpio.conf"
 


### PR DESCRIPTION
The only meaningful change is switch to zstd as default initrd image.
I'm tempted to not merge this one since I'm not sure all our kernels support zstd atm.