### PR TITLE
python3-pipx: add missing dependency

### DIFF
--- a/srcpkgs/python3-pipx/template
+++ b/srcpkgs/python3-pipx/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-pipx'
 pkgname=python3-pipx
 version=0.16.1.0
-revision=1
+revision=2
 wrksrc="pipx-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-argcomplete python3-userpath python3-setuptools python3-packaging"
+depends="python3-argcomplete python3-colorama python3-userpath python3-setuptools python3-packaging"
 short_desc="Install and Run Python Applications in Isolated Environments"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"


### PR DESCRIPTION
colorama is a new dependency in the 0.16.1.0 release of pipx (but wasn't added in the [commit](https://github.com/void-linux/void-packages/commit/a35dddca80d6b2497972171686834cd885ba9a1f) updating pipx earlier today) 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
