### PR TITLE
imv: enable HEIF & AVIF support

### DIFF
--- a/srcpkgs/imv/template
+++ b/srcpkgs/imv/template
@@ -1,10 +1,10 @@
 # Template file for 'imv'
 pkgname=imv
 version=4.2.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="asciidoc pkg-config cmake"
-makedepends="cmocka-devel freeimage-devel glu-devel librsvg-devel libxkbcommon-devel
+makedepends="cmocka-devel freeimage-devel glu-devel librsvg-devel libheif-devel libxkbcommon-devel
  pango-devel wayland-devel inih-devel"
 depends="desktop-file-utils"
 conf_files="/etc/imv_config"


### PR DESCRIPTION
`imv` supports HEIF & AVIF, but it has to be linked with `libheif` during build for it to work.