### PR TITLE
ImageMagick6: update to 6.9.12.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -340,7 +340,7 @@ libMagickWand-7.Q16HDRI.so.8 libmagick-7.0.10.37_1
 libMagick++-7.Q16HDRI.so.4 libmagick-7.0.9.1_1
 libMagickCore-6.Q16.so.7 libmagick6-6.9.11.61_1
 libMagickWand-6.Q16.so.7 libmagick6-6.9.11.61_1
-libMagick++-6.Q16.so.8 libmagick6-6.9.10.11_1
+libMagick++-6.Q16.so.9 libmagick6-6.9.12.1_1
 libltdl.so.7 libltdl-2.2.6_1
 libpoppler.so.102 libpoppler102-20.09.0_1
 libpoppler-glib.so.8 poppler-glib-0.18.2_1

--- a/srcpkgs/ImageMagick6/template
+++ b/srcpkgs/ImageMagick6/template
@@ -1,7 +1,7 @@
 # Template file for 'ImageMagick6'
 pkgname=ImageMagick6
-_majorver=6.9.11
-_patchver=61
+_majorver=6.9.12
+_patchver=1
 version="${_majorver}.${_patchver}"
 revision=1
 wrksrc="${pkgname}-${_majorver}-${_patchver}"
@@ -20,7 +20,7 @@ maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org/"
 distfiles="https://github.com/ImageMagick/ImageMagick6/archive/${_majorver}-${_patchver}.tar.gz"
-checksum=8621f619c5c9ce1bf7260c8fc8fa01a7414079cf7b0777a9b0a048a22c85647a
+checksum=9a799c054ff5925cbeb730624aa398562aac0550f30389ea5aadbeeda6007f95
 
 keep_libtool_archives=yes
 conf_files="/etc/ImageMagick-${_majorver%%.*}/*.xml"


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

No revbumps needed as there are no consumers of libMagick++-6.Q16.so.9