### PR TITLE
monkey: move libdir to /usr/lib{32,64}/monkey

### DIFF
--- a/srcpkgs/monkey/template
+++ b/srcpkgs/monkey/template
@@ -1,9 +1,10 @@
 # Template file for 'monkey'
 pkgname=monkey
 version=1.6.9
-revision=2
+revision=3
 build_style=configure
-configure_args="--prefix=/usr --sbindir=/usr/bin --libdir=/usr/lib
+configure_args="--prefix=/usr --sbindir=/usr/bin
+ --libdir=/usr/lib$XBPS_TARGET_WORDSIZE/$pkgname
  --sysconfdir=/etc/monkey/ --enable-plugins=mbedtls --malloc-libc
  --webroot=/srv/www/$pkgname --mandir=/usr/share/man --default-user=_monkey
  --pidfile=/var/run/monkey.pid --logdir=/var/log/monkey"
@@ -34,7 +35,7 @@ make_dirs="
 CFLAGS="-fcommon"
 
 case $XBPS_TARGET_MACHINE in
-	*-musl) configure_args+="--musl-mode --no-backtrace ";;
+	*-musl) configure_args+=" --musl-mode --no-backtrace ";;
 esac
 
 post_install() {
@@ -47,6 +48,5 @@ monkey-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
Those shared-objects are plugins for monkey,
its included debian rules also put them in /usr/lib/monkey.

While we're at it, fix --musl-mode argument.
(The actual code doesn't change if MUSL_CODE defined or not)

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
