### PR TITLE
browserpass: remove forced addon installation

### DIFF
--- a/srcpkgs/browserpass/template
+++ b/srcpkgs/browserpass/template
@@ -6,7 +6,7 @@ wrksrc="browserpass-native-${version}"
 build_style=go
 go_import_path=github.com/browserpass/browserpass-native
 hostmakedepends="git"
-short_desc="Browser extension for pass"
+short_desc="Native messaging host for browserpass
 maintainer="John <me@johnnynator.dev>"
 license="MIT"
 homepage="https://github.com/browserpass/browserpass-native"
@@ -20,14 +20,8 @@ post_build() {
 
 post_install() {
 	vlicense LICENSE
-
 	local targetname=com.github.browserpass.native.json
-
 	vinstall browser-files/firefox-host.json 644 usr/lib/mozilla/native-messaging-hosts $targetname
-
 	vinstall browser-files/chromium-host.json 644 etc/chromium/native-messaging-hosts $targetname
-	vinstall browser-files/chromium-policy.json 644 etc/chromium/policies/managed $targetname
-
 	vinstall browser-files/chromium-host.json 644 etc/opt/chrome/native-messaging-hosts $targetname
-	vinstall browser-files/chromium-policy.json 644 etc/opt/chrome/policies/managed $targetname
 }


### PR DESCRIPTION
browserpass package should not have forced managed addon installation. This extension should be packaged separately or installed manually.