### PR TITLE
caddy: upgrade to 2.4.3

### DIFF
--- a/srcpkgs/caddy/INSTALL.msg
+++ b/srcpkgs/caddy/INSTALL.msg
@@ -1,0 +1,3 @@
+WARNING: The config syntax has changed from caddy 1.x to 2.x
+
+Be sure to upgrade all your configuration files!

--- a/srcpkgs/caddy/files/caddy/run
+++ b/srcpkgs/caddy/files/caddy/run
@@ -2,7 +2,7 @@
 
 [ -r ./conf ] && . ./conf
 
-export CADDYPATH=/var/lib/caddy
+export HOME=/var/lib/caddy
 ulimit -n ${MAX_OPEN_FILES:-8192}
-cd /etc/caddy
-exec chpst -u caddy caddy
+
+exec chpst -u caddy caddy run --config ${CONFFILE:-/etc/caddy/Caddyfile}

--- a/srcpkgs/caddy/patches/fix_version_command.patch
+++ b/srcpkgs/caddy/patches/fix_version_command.patch
@@ -1,0 +1,17 @@
+--- a/caddy.go
++++ b/caddy.go
+@@ -712,14 +711,0 @@ func goModule(mod *debug.Module) *debug.Module {
+-	bi, ok := debug.ReadBuildInfo()
+-	if ok {
+-		mod.Path = bi.Main.Path
+-		// The recommended way to build Caddy involves
+-		// creating a separate main module, which
+-		// TODO: track related Go issue: https://github.com/golang/go/issues/29228
+-		// once that issue is fixed, we should just be able to use bi.Main... hopefully.
+-		for _, dep := range bi.Deps {
+-			if dep.Path == ImportPath {
+-				return dep
+-			}
+-		}
+-		return &bi.Main
+-	}

--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,28 +1,34 @@
 # Template file for 'caddy'
 pkgname=caddy
-version=1.0.5
+version=2.4.3
 revision=1
 build_style=go
-# XXX: use caddy/v2 when updating
-go_import_path=github.com/caddyserver/caddy
-go_package="${go_import_path}/caddy"
-hostmakedepends="git"
+go_import_path=github.com/caddyserver/caddy/v2
+go_package="${go_import_path}/cmd/caddy"
 short_desc="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 maintainer="Dominic Monroe <monroef4@googlemail.com>"
 license="Apache-2.0"
 homepage="https://caddyserver.com"
 distfiles="https://github.com/caddyserver/caddy/archive/v${version}.tar.gz"
-checksum=0e7dc07e4f61f9a00a4c962755098e19ebf8c8a8e0d72e311597ce021b7a2a5e
+checksum=10317b5ab7bee861631a8d94d13aeafb62e9665759271a6c65422a70d6584d6b
 
 system_accounts="caddy"
+caddy_homedir="/var/lib/caddy"
+caddy_descr="caddy daemon"
+
+conf_files="/etc/caddy/Caddyfile"
+
 make_dirs="
 	/etc/caddy 0700 caddy caddy
 	/var/lib/caddy 0700 caddy caddy"
 
-pre_build() {
-	vsed -e 's,var EnableTelemetry = true,var EnableTelemetry = false,g' -i caddy/caddymain/run.go
+post_extract() {
+	vsed -e "s,unknown,${version},g" -i ${wrksrc}/caddy.go
 }
 
 post_install() {
 	vsv caddy
+
+	printf "\n" > Caddyfile
+	vinstall Caddyfile 600 etc/caddy
 }


### PR DESCRIPTION
As there is currently a bug with go build info
(https://github.com/golang/go/issues/29228) a patch is needed to
fix printing the correct version number of the binary. Once the bug is
fixed, the patch can be dropped.

Fix for #22092

#### Have the results of the proposed changes been tested?
- [ x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
