### PR TITLE
rpi-kernel: split into rpi, rpi2, rpi3, add rpi4

### DIFF
--- a/srcpkgs/rpi-base/template
+++ b/srcpkgs/rpi-base/template
@@ -1,7 +1,7 @@
 # Template file for 'rpi-base'
 pkgname=rpi-base
 version=3.0
-revision=1
+revision=2
 archs="armv6l* armv7l* aarch64*"
 _base_depends="virtual?ntp-daemon rpi-firmware"
 depends="${_base_depends} rpi-kernel"
@@ -22,7 +22,7 @@ case "$XBPS_TARGET_MACHINE" in
 		subpackages="rpi2-base"
 		;;
 	aarch64*)
-		subpackages="rpi3-base"
+		subpackages="rpi3-base rpi4-base"
 		;;
 esac
 
@@ -55,6 +55,15 @@ rpi2-base_package() {
 rpi3-base_package() {
 	depends="${_base_depends} rpi3-kernel"
 	short_desc="Void Linux Raspberry Pi 3 base files"
+	pkg_install() {
+		vinstall "${FILESDIR}/71-raspberrypi.rules" 644 usr/lib/udev/rules.d
+	}
+}
+
+rpi4-base_package() {
+	depends="${_base_depends} rpi4-kernel"
+	short_desc="Void Linux Raspberry Pi 4 base files"
+	conflicts="rpi3-base"
 	pkg_install() {
 		vinstall "${FILESDIR}/71-raspberrypi.rules" 644 usr/lib/udev/rules.d
 	}

--- a/srcpkgs/rpi-base/template
+++ b/srcpkgs/rpi-base/template
@@ -1,9 +1,10 @@
 # Template file for 'rpi-base'
 pkgname=rpi-base
-version=2.6
+version=3.0
 revision=1
 archs="armv6l* armv7l* aarch64*"
-depends="virtual?ntp-daemon rpi-firmware rpi-kernel"
+_base_depends="virtual?ntp-daemon rpi-firmware"
+depends="${_base_depends} rpi-kernel"
 short_desc="Void Linux Raspberry Pi base files"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain"
@@ -11,4 +12,50 @@ homepage="https://www.voidlinux.org"
 
 do_install() {
 	vinstall "${FILESDIR}/71-raspberrypi.rules" 644 usr/lib/udev/rules.d
+}
+
+case "$XBPS_TARGET_MACHINE" in
+	armv6*)
+		subpackages=" "
+		;;
+	armv7*)
+		subpackages="rpi2-base"
+		;;
+	aarch64*)
+		subpackages="rpi3-base"
+		;;
+esac
+
+# support legacy systems (before rpi-kernel was split to rpi{,2,3})
+# archs != armv6* are emtpy meta packages to pull the new rpi${n}-base package
+case "$XBPS_TARGET_MACHINE" in
+	armv6*) : ;;
+	*)
+		build_style=meta
+		short_desc+=" (transitional dummy package)"
+
+	 	do_install() { : ; }
+
+		case "$XBPS_TARGET_MACHINE" in
+			armv7*) depends="rpi2-base" ;;
+			aarch64*) depends="rpi3-base" ;;
+		esac
+		;;
+esac
+
+rpi2-base_package() {
+	depends="${_base_depends} rpi2-kernel"
+	short_desc="Void Linux Raspberry Pi 2 base files"
+	pkg_install() {
+		vinstall "${FILESDIR}/71-raspberrypi.rules" 644 usr/lib/udev/rules.d
+	}
+}
+
+
+rpi3-base_package() {
+	depends="${_base_depends} rpi3-kernel"
+	short_desc="Void Linux Raspberry Pi 3 base files"
+	pkg_install() {
+		vinstall "${FILESDIR}/71-raspberrypi.rules" 644 usr/lib/udev/rules.d
+	}
 }

--- a/srcpkgs/rpi2-base
+++ b/srcpkgs/rpi2-base
@@ -1,0 +1,1 @@
+rpi-base

--- a/srcpkgs/rpi2-kernel-headers
+++ b/srcpkgs/rpi2-kernel-headers
@@ -1,0 +1,1 @@
+rpi2-kernel

--- a/srcpkgs/rpi2-kernel/template
+++ b/srcpkgs/rpi2-kernel/template
@@ -1,4 +1,4 @@
-# Template file for 'rpi-kernel'
+# Template file for 'rpi2-kernel'
 #
 # We track the latest Raspberry Pi LTS kernel as that is what is used in the
 # official Raspbian distribution. This is currently 5.4:
@@ -8,17 +8,17 @@
 _githash="76c49e60e742d0bebd798be972d67dd3fd007691"
 _gitshort="${_githash:0:7}"
 
-pkgname=rpi-kernel
+pkgname=rpi2-kernel
 version=5.4.83
 revision=2
-archs="armv6l*"
+archs="armv7l*"
 wrksrc="linux-${_githash}"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
 makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
-short_desc="Linux kernel for Raspberry Pi zero/1 (${version%.*} series [git ${_gitshort}])"
+short_desc="Linux kernel for Raspberry Pi 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
 checksum=4a98ea0d68c6e74d479789c12fc97619c872cb2607ae87a881a9491c1c3fbc35
 python_version=3
@@ -61,8 +61,8 @@ do_configure() {
 
 	# Use upstream's default configuration, no need to maintain ours.
 	case "$XBPS_TARGET_MACHINE" in
-		armv6l*)
-			target=bcmrpi_defconfig
+		armv7l*)
+			target=bcm2709_defconfig
 			;;
 	esac
 
@@ -120,7 +120,7 @@ do_install() {
 
 	# Generate kernel.img and install it to destdir.
 	vmkdir boot
-	cp arch/arm/boot/zImage ${DESTDIR}/boot/kernel.img
+	cp arch/arm/boot/zImage ${DESTDIR}/boot/kernel7.img
 
 	hdrdest=${DESTDIR}/usr/src/${sourcepkg}-headers-${_kernver}
 
@@ -221,7 +221,7 @@ do_install() {
 	depmod -b ${DESTDIR}/usr -F System.map ${_kernver}
 }
 
-rpi-kernel-headers_package() {
+rpi2-kernel-headers_package() {
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
@@ -231,34 +231,3 @@ rpi-kernel-headers_package() {
 		vmove usr/lib/modules/${_kernver}/build
 	}
 }
-
-
-# support legacy systems (before rpi-kernel was split to rpi{,2,3})
-# archs != armv6* are emtpy meta packages to pull the new rpi{$n}-kernel package
-archs+=" armv7l* aarch64*"
-case "$XBPS_TARGET_MACHINE" in
-	armv6*) : ;;
-	*)
-		build_style=meta
-		short_desc="Linux kernel for Raspberry Pi (transitional dummy package)"
-
-		pre_configure() { : ; }
-		do_configure() { : ; }
-		do_build() { : ; }
-		do_install() { : ; }
-
-		case "$XBPS_TARGET_MACHINE" in
-			armv7*) depends=rpi2-kernel ;;
-			aarch64*) depends=rpi3-kernel ;;
-		esac
-
-		rpi-kernel-headers_package() {
-			build_style=meta
-			short_desc="Linux kernel headers for Raspberry Pi (transitional dummy package)"
-			case "$XBPS_TARGET_MACHINE" in
-				armv7*) depends=rpi2-kernel-headers ;;
-				aarch64*) depends=rpi3-kernel-headers ;;
-			esac
-		}
-		;;
-esac

--- a/srcpkgs/rpi3-base
+++ b/srcpkgs/rpi3-base
@@ -1,0 +1,1 @@
+rpi-base

--- a/srcpkgs/rpi3-kernel-headers
+++ b/srcpkgs/rpi3-kernel-headers
@@ -1,0 +1,1 @@
+rpi3-kernel

--- a/srcpkgs/rpi3-kernel/template
+++ b/srcpkgs/rpi3-kernel/template
@@ -1,4 +1,4 @@
-# Template file for 'rpi-kernel'
+# Template file for 'rpi3-kernel'
 #
 # We track the latest Raspberry Pi LTS kernel as that is what is used in the
 # official Raspbian distribution. This is currently 5.4:
@@ -8,17 +8,17 @@
 _githash="76c49e60e742d0bebd798be972d67dd3fd007691"
 _gitshort="${_githash:0:7}"
 
-pkgname=rpi-kernel
+pkgname=rpi3-kernel
 version=5.4.83
 revision=2
-archs="armv6l*"
+archs="aarch64*"
 wrksrc="linux-${_githash}"
 hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
 makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
-short_desc="Linux kernel for Raspberry Pi zero/1 (${version%.*} series [git ${_gitshort}])"
+short_desc="Linux kernel for Raspberry Pi 3 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
 checksum=4a98ea0d68c6e74d479789c12fc97619c872cb2607ae87a881a9491c1c3fbc35
 python_version=3
@@ -61,8 +61,8 @@ do_configure() {
 
 	# Use upstream's default configuration, no need to maintain ours.
 	case "$XBPS_TARGET_MACHINE" in
-		armv6l*)
-			target=bcmrpi_defconfig
+		aarch64*)
+			target=bcmrpi3_defconfig
 			;;
 	esac
 
@@ -118,9 +118,12 @@ do_install() {
 	# Install device tree blobs
 	make ${makejobs} ARCH=${_arch} INSTALL_DTBS_PATH=${DESTDIR}/boot dtbs_install
 
+	# move dtb that ended up in /boot/broadcom
+	mv ${DESTDIR}/boot/broadcom/*dtb ${DESTDIR}/boot
+
 	# Generate kernel.img and install it to destdir.
 	vmkdir boot
-	cp arch/arm/boot/zImage ${DESTDIR}/boot/kernel.img
+	cp arch/arm64/boot/Image ${DESTDIR}/boot/kernel8.img
 
 	hdrdest=${DESTDIR}/usr/src/${sourcepkg}-headers-${_kernver}
 
@@ -221,7 +224,7 @@ do_install() {
 	depmod -b ${DESTDIR}/usr -F System.map ${_kernver}
 }
 
-rpi-kernel-headers_package() {
+rpi3-kernel-headers_package() {
 	nostrip=yes
 	noverifyrdeps=yes
 	noshlibprovides=yes
@@ -231,34 +234,3 @@ rpi-kernel-headers_package() {
 		vmove usr/lib/modules/${_kernver}/build
 	}
 }
-
-
-# support legacy systems (before rpi-kernel was split to rpi{,2,3})
-# archs != armv6* are emtpy meta packages to pull the new rpi{$n}-kernel package
-archs+=" armv7l* aarch64*"
-case "$XBPS_TARGET_MACHINE" in
-	armv6*) : ;;
-	*)
-		build_style=meta
-		short_desc="Linux kernel for Raspberry Pi (transitional dummy package)"
-
-		pre_configure() { : ; }
-		do_configure() { : ; }
-		do_build() { : ; }
-		do_install() { : ; }
-
-		case "$XBPS_TARGET_MACHINE" in
-			armv7*) depends=rpi2-kernel ;;
-			aarch64*) depends=rpi3-kernel ;;
-		esac
-
-		rpi-kernel-headers_package() {
-			build_style=meta
-			short_desc="Linux kernel headers for Raspberry Pi (transitional dummy package)"
-			case "$XBPS_TARGET_MACHINE" in
-				armv7*) depends=rpi2-kernel-headers ;;
-				aarch64*) depends=rpi3-kernel-headers ;;
-			esac
-		}
-		;;
-esac

--- a/srcpkgs/rpi4-base
+++ b/srcpkgs/rpi4-base
@@ -1,0 +1,1 @@
+rpi-base

--- a/srcpkgs/rpi4-kernel-headers
+++ b/srcpkgs/rpi4-kernel-headers
@@ -1,0 +1,1 @@
+rpi4-kernel

--- a/srcpkgs/rpi4-kernel/template
+++ b/srcpkgs/rpi4-kernel/template
@@ -21,7 +21,7 @@ license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 4 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
 checksum=4a98ea0d68c6e74d479789c12fc97619c872cb2607ae87a881a9491c1c3fbc35
-python_version=2
+python_version=3
 conflicts=rpi3-kernel
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi4-kernel/template
+++ b/srcpkgs/rpi4-kernel/template
@@ -1,0 +1,237 @@
+# Template file for 'rpi4-kernel'
+#
+# We track the latest Raspberry Pi LTS kernel as that is what is used in the
+# official Raspbian distribution. This is currently 5.4:
+#
+#   https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=269769
+
+_githash="76c49e60e742d0bebd798be972d67dd3fd007691"
+_gitshort="${_githash:0:7}"
+
+pkgname=rpi4-kernel
+version=5.4.83
+revision=1
+archs="aarch64*"
+wrksrc="linux-${_githash}"
+hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
+makedepends="ncurses-devel"
+maintainer="Piraty <piraty1@inbox.ru>"
+homepage="http://www.kernel.org"
+license="GPL-2.0-only"
+short_desc="Linux kernel for Raspberry Pi 4 (${version%.*} series [git ${_gitshort}])"
+distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
+checksum=4a98ea0d68c6e74d479789c12fc97619c872cb2607ae87a881a9491c1c3fbc35
+python_version=2
+conflicts=rpi3-kernel
+
+_kernver="${version}_${revision}"
+
+nodebug=yes
+nostrip=yes
+noverifyrdeps=yes
+noshlibprovides=yes
+
+triggers="kernel-hooks"
+# These files could be modified when an external module is built.
+mutable_files="
+	/usr/lib/modules/${_kernver}/modules.dep
+	/usr/lib/modules/${_kernver}/modules.dep.bin
+	/usr/lib/modules/${_kernver}/modules.symbols
+	/usr/lib/modules/${_kernver}/modules.symbols.bin
+	/usr/lib/modules/${_kernver}/modules.alias
+	/usr/lib/modules/${_kernver}/modules.alias.bin
+	/usr/lib/modules/${_kernver}/modules.devname"
+
+_arch=
+case "$XBPS_TARGET_MACHINE" in
+	arm*) _arch=arm ;;
+	aarch64*) _arch=arm64 ;;
+esac
+_cross=
+if [ "$CROSS_BUILD" ]; then
+	_cross="CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"
+fi
+
+pre_configure() {
+	# Remove .git directory, otherwise scripts/setkernelversion.sh
+	# modifies KERNELRELEASE and appends + to it.
+	rm -rf .git
+}
+do_configure() {
+	local target defconfig
+
+	# Use upstream's default configuration, no need to maintain ours.
+	case "$XBPS_TARGET_MACHINE" in
+		aarch64*)
+			target=bcm2711_defconfig
+			;;
+	esac
+
+	defconfig="arch/${_arch}/configs/${target}"
+	echo "CONFIG_CONNECTOR=y" >> "$defconfig"
+	echo "CONFIG_PROC_EVENTS=y" >> "$defconfig"
+	echo "CONFIG_F2FS_FS_SECURITY=y" >> "$defconfig"
+	echo "CONFIG_CGROUP_PIDS=y" >> "$defconfig"
+
+	# IR Remote Support
+	echo "CONFIG_RC_CORE=y" >> "$defconfig"
+	echo "CONFIG_LIRC=y" >> "$defconfig"
+	echo "CONFIG_RC_DECODERS=y" >> "$defconfig"
+	echo "CONFIG_RC_DEVICES=y" >> "$defconfig"
+	echo "CONFIG_IR_RC6_DECODER=m" >> "$defconfig"
+	echo "CONFIG_IR_MCEUSB=m" >> "$defconfig"
+
+	# HID Controllers
+	echo "CONFIG_HID_STEAM=y" >> "$defconfig"
+
+	# LXD 4.2+ support
+	echo "CONFIG_BRIDGE_VLAN_FILTERING=y" >> "$defconfig"
+
+	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
+
+	# Always use our revision to CONFIG_LOCALVERSION to match our pkg version.
+	vsed -i -e "s|^\(CONFIG_LOCALVERSION=\).*|\1\"_${revision}\"|" .config
+}
+do_build() {
+	local target
+
+	case "$XBPS_TARGET_MACHINE" in
+		arm*)
+			target="zImage modules dtbs"
+			;;
+		aarch64*)
+			target="Image modules dtbs"
+			;;
+	esac
+
+	make ${makejobs} ${_cross} ARCH=${_arch} prepare
+	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
+}
+do_install() {
+	local hdrdest
+
+	# Run depmod after compressing modules.
+	sed -i '2iexit 0' scripts/depmod.sh
+
+	# Install kernel, firmware and modules
+	make ${makejobs} ARCH=${_arch} INSTALL_MOD_PATH=${DESTDIR} modules_install
+
+	# Install device tree blobs
+	make ${makejobs} ARCH=${_arch} INSTALL_DTBS_PATH=${DESTDIR}/boot dtbs_install
+
+	# move dtb that ended up in /boot/broadcom
+	mv ${DESTDIR}/boot/broadcom/*dtb ${DESTDIR}/boot
+
+	# Generate kernel.img and install it to destdir.
+	vmkdir boot
+	cp arch/arm64/boot/Image ${DESTDIR}/boot/kernel8.img
+
+	hdrdest=${DESTDIR}/usr/src/${sourcepkg}-headers-${_kernver}
+
+	# Switch to /usr.
+	vmkdir usr
+	mv ${DESTDIR}/lib ${DESTDIR}/usr
+
+	cd ${DESTDIR}/usr/lib/modules/${_kernver}
+	rm -f source build
+	ln -sf ../../../src/${sourcepkg}-headers-${_kernver} build
+
+	cd ${wrksrc}
+	# Install required headers to build external modules
+	install -Dm644 Makefile ${hdrdest}/Makefile
+	install -Dm644 kernel/Makefile ${hdrdest}/kernel/Makefile
+	install -Dm644 .config ${hdrdest}/.config
+	for file in $(find . -name Kconfig\*); do
+		mkdir -p ${hdrdest}/$(dirname $file)
+		install -Dm644 $file ${hdrdest}/${file}
+	done
+	for file in $(find arch/${_arch} -name module.lds -o -name Kbuild.platforms -o -name Platform); do
+		mkdir -p ${hdrdest}/$(dirname $file)
+		install -Dm644 $file ${hdrdest}/${file}
+	done
+	mkdir -p ${hdrdest}/include
+
+	# Remove firmware stuff provided by the "linux-firmware" pkg.
+	rm -rf ${DESTDIR}/usr/lib/firmware
+
+	for i in acpi asm-generic clocksource config crypto drm generated linux \
+		math-emu media net pcmcia scsi sound trace uapi video xen; do
+		[ -d include/$i ] && cp -a include/$i ${hdrdest}/include
+	done
+
+	cd ${wrksrc}
+	# Remove helper binaries built for host,
+	# if generated files from the scripts/ directory need to be included,
+	# they need to be copied to ${hdrdest} before this step
+	if [ "$CROSS_BUILD" ]; then
+		make ${makejobs} ARCH=${_arch} _mrproper_scripts
+		# remove host specific objects as well
+		find scripts -name '*.o' -delete
+	fi
+
+	# Copy files necessary for later builds.
+	cp Module.symvers ${hdrdest}
+	cp -a scripts ${hdrdest}
+	mkdir -p ${hdrdest}/security/selinux
+	cp -a security/selinux/include ${hdrdest}/security/selinux
+	mkdir -p ${hdrdest}/tools/include
+	cp -a tools/include/tools ${hdrdest}/tools/include
+	if [ -d "arch/${_arch}/tools" ]; then
+		cp -a arch/${_arch}/tools ${hdrdest}/arch/${_arch}
+	fi
+
+	# copy arch includes for external modules
+	mkdir -p ${hdrdest}/arch/${_arch}
+	cp -a arch/${_arch}/include ${hdrdest}/arch/${_arch}
+
+	mkdir -p ${hdrdest}/arch/${_arch}/kernel
+	cp arch/${_arch}/Makefile ${hdrdest}/arch/${_arch}
+	cp arch/${_arch}/kernel/asm-offsets.s ${hdrdest}/arch/${_arch}/kernel
+	if [ "$_arch" = "arm64" ] ; then
+		cp -a arch/${_arch}/kernel/vdso ${hdrdest}/arch/${_arch}/kernel/
+	fi
+
+	# Add md headers
+	mkdir -p ${hdrdest}/drivers/md
+	cp drivers/md/*.h ${hdrdest}/drivers/md
+
+	# Add inotify.h
+	mkdir -p ${hdrdest}/include/linux
+	cp include/linux/inotify.h ${hdrdest}/include/linux
+
+	# Add wireless headers
+	mkdir -p ${hdrdest}/net/mac80211/
+	cp net/mac80211/*.h ${hdrdest}/net/mac80211
+
+	# add dvb headers for external modules
+	mkdir -p ${hdrdest}/include/config/dvb/
+	cp include/config/dvb/*.h ${hdrdest}/include/config/dvb/
+
+	# Remove unneeded architectures
+	# (save the correct one + Kconfig and delete all others)
+	mkdir -p arch-backup
+	cp -r ${hdrdest}/arch/${_arch} ${hdrdest}/arch/Kconfig arch-backup/
+	rm -rf ${hdrdest}/arch
+	mv arch-backup ${hdrdest}/arch
+	# Keep arch/x86/ras/Kconfig as it is needed by drivers/ras/Kconfig
+	mkdir -p ${hdrdest}/arch/x86/ras
+	cp -a arch/x86/ras/Kconfig ${hdrdest}/arch/x86/ras/Kconfig
+
+	# Compress all modules with xz to save a few MBs.
+	msg_normal "$pkgver: compressing kernel modules with gzip, please wait...\n"
+	find ${DESTDIR} -name '*.ko' | xargs -n1 -P0 gzip -9
+
+	# ... and run depmod again.
+	depmod -b ${DESTDIR}/usr -F System.map ${_kernver}
+}
+
+rpi4-kernel-headers_package() {
+	nostrip=yes
+	noverifyrdeps=yes
+	noshlibprovides=yes
+	short_desc="${short_desc/kernel/kernel headers}"
+	pkg_install() {
+		vmove usr/src
+		vmove usr/lib/modules/${_kernver}/build
+	}
+}


### PR DESCRIPTION
This is my second approach to the rpi4 problem (first try: https://github.com/void-linux/void-packages/pull/26000)

The problem is: how to not break existing systems while having a consistent naming scheme for rpi-kernel / rpi-base.

As ~demanded~ suggested by @the-maldridge , `rpi-kernel` continues to provide the kernel for rpi0/rpi1 and becomes a meta package that pulls `rpi{2,3}-kernel` (based on target arch) so legacy pull the new update systems.
This may be optional though and we could require users to manually install the new kernel package, possibly posting a new post on the website for that.

To support legacy systems, rpi-base is split into rpiN-base which all ship the same udev rule and depend on the respective kernel. This (still) allows to have a single entry-point to raspberry related packages.

I performed (offline) testing of the package transition process, seems fine. Script [here](https://gist.github.com/Piraty/2b0bd709c58ca2e8dd2240cc5b1141c9)


### How to
1. checkout this branch
2. build one of `rpi4-base` (aarch64*) or `rpi-base` (`armv6*`, `armv7l*` or `aarch64*`)
3. update your pi with the new packages or build fresh images: see https://github.com/void-linux/void-mklive/pull/153

---

@pbui @Duncaen @ahesford 