### PR TITLE
drop slub_debug/page_poison from bootloaders

### DIFF
--- a/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
+++ b/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
@@ -14,7 +14,7 @@ cat > /boot/boot.txt <<EOF
 setenv macaddr da 19 c8 7a 6d f4
 
 part uuid \${devtype} \${devnum}:\${bootpart} uuid
-setenv bootargs console=ttyS2,1500000 console=tty1 root=PARTUUID=${partuuid} rootwait video=eDP-1:1920x1080@60 loglevel=4 slub_debug=P page_poison=1
+setenv bootargs console=ttyS2,1500000 console=tty1 root=PARTUUID=${partuuid} rootwait video=eDP-1:1920x1080@60 loglevel=4
 setenv fdtfile rockchip/rk3399-pinebook-pro.dtb
 
 if load \${devtype} \${devnum}:\${bootpart} \${kernel_addr_r} $(bootstrip /boot/vmlinux-${kver}); then

--- a/srcpkgs/pinebookpro-uboot/template
+++ b/srcpkgs/pinebookpro-uboot/template
@@ -2,7 +2,7 @@
 pkgname=pinebookpro-uboot
 reverts="20200212_1 20200212_2"
 version=0.0.20200212
-revision=3
+revision=4
 _commit_uboot=365495a329c8e92ca4c134562d091df71b75845e
 _commit_atf=22d12c4148c373932a7a81e5d1c59a767e143ac2
 archs="aarch64*"

--- a/srcpkgs/pinephone-uboot/files/uboot.default
+++ b/srcpkgs/pinephone-uboot/files/uboot.default
@@ -8,4 +8,4 @@
 ROCKER_ARGS=yes
 
 # Regular cmdline for configured kernel
-CMDLINE="console=tty0 console=ttyS0,115200 rootwait loglevel=4 slub_debug=P page_poison=1"
+CMDLINE="console=tty0 console=ttyS0,115200 rootwait loglevel=4"

--- a/srcpkgs/pinephone-uboot/template
+++ b/srcpkgs/pinephone-uboot/template
@@ -1,7 +1,7 @@
 # Template file for 'pinephone-uboot'
 pkgname=pinephone-uboot
 version=0.0.20200917
-revision=2
+revision=3
 archs="aarch64*"
 create_wrksrc=yes
 hostmakedepends="flex cross-or1k-none-elf-gcc dtc python3 python3-devel bc swig"


### PR DESCRIPTION
These are kernel hardening options introduced into Void in 2016. On most modern hardware they have a small performance hit, on older hardware they can have a significant performance hit. In kernel 5.3, new options were introduced, `init_on_alloc` and `init_on_free`. There are also kernel options to make these default.

The new defaults have been toggled in kernels 5.4, 5.10 and 5.11 in bd0d33eec0bd774d8cc62e32689b6fbfda517179. I explicitly did not enable `init_on_free` since that has a much bigger performance penalty, even on current-day hardware.

The only "drawback" of these changes is that people using old kernels will not get these options anymore. OTOH, the new behavior is much better in other ways (it has less of an impact, it's enabled in kernels rather than default configs so any changes to it will propagate to all users unconditionally, etc). And also, there isn't any other mainstream distribution that was using these options in the first place, for a reason, as far as I can tell.

People on kernels 4.4, 4.9, 4.14 and 4.19 who really care can update it themselves. But since older kernels tend to be associated with older hardware, they'll probably want to keep the options off in the first place.

What troubles me more is that even if I merge this PR, it will not propagate to existing users who have modified their `/etc/default/grub`, so they will need to change those files themselves. The new default kernel options are not incompatible with the old options, but people will likely want to remove them anyway. So we should probably put information about this in the documentation, too.

[ci skip]

Anyway, waiting with merging this until the affected kernels have been rebuilt (i.e. for their next version bump).