### PR TITLE
pari: add to checkdepends and common/shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3924,3 +3924,4 @@ libsimavr.so.1 simavr-1.6_2
 libsimavrparts.so.1 simavr-1.6_2
 libsword-1.8.1.so libsword-1.8.1_6
 libtree-sitter.so.0 tree-sitter-0.18.2_1
+libpari-gmp.so.7 pari-2.13.0_1

--- a/srcpkgs/pari/template
+++ b/srcpkgs/pari/template
@@ -10,6 +10,7 @@ make_build_target=all
 make_check_target=test-all
 hostmakedepends="perl texlive"
 makedepends="gmp-devel readline-devel $(vopt_if x11 libX11-devel)"
+checkdepends="pari-elldata pari-seadata pari-galdata pari-galpol"
 short_desc="Fast computations library in number theory"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
- Some tests depend on data packages, add them to checkdepends.
- libpari-gmp.so.7 was missing in common/shlibs

No revbump since these changes don't affect compilation.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
