### PR TITLE
.github/workflows: add CI run to lock closed threads.

### DIFF
--- a/.github/workflows/lockthreads.yml
+++ b/.github/workflows/lockthreads.yml
@@ -1,0 +1,14 @@
+name: 'Lock threads'
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          pr-lock-inactive-days: '90'


### PR DESCRIPTION
Closed PRs and issues will be locked after 90 days of inactivity, to
avoid comments on old inactive threads and encourage people to create
new ones, which will receive the proper attention.

Inspired by hook from fish-shell:
https://github.com/fish-shell/fish-shell/blob/a36dbad3b82c36352c6cf9d4bbdc58c7bd46e18a/.github/workflows/lockthreads.yml

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
