### PR TITLE
mDNSResponder: update to 1310.80.1.

### DIFF
--- a/srcpkgs/mDNSResponder/patches/Clients-dns-sd.c.patch
+++ b/srcpkgs/mDNSResponder/patches/Clients-dns-sd.c.patch
@@ -1,0 +1,16 @@
+--- Clients/dns-sd.c.orig	2021-01-26 20:47:47 UTC
++++ Clients/dns-sd.c
+@@ -58,11 +58,13 @@
+ //#define TEST_NEW_CLIENTSTUB 1
+ 
+ #include <ctype.h>
++#include <stdarg.h>         // For va_list
+ #include <stdio.h>          // For stdout, stderr
+ #include <stdlib.h>         // For exit()
+ #include <string.h>         // For strlen(), strcpy()
+ #include <errno.h>          // For errno, EINTR
+ #include <time.h>
++#include <sys/param.h>      // For MIN
+ #include <sys/types.h>      // For u_char
+ #ifdef APPLE_OSX_mDNSResponder
+ #include <inttypes.h>       // For PRId64

--- a/srcpkgs/mDNSResponder/template
+++ b/srcpkgs/mDNSResponder/template
@@ -1,6 +1,6 @@
 # Template file for 'mDNSResponder'
 pkgname=mDNSResponder
-version=878.260.1
+version=1310.80.1
 revision=1
 hostmakedepends="flex byacc"
 short_desc="Implements the Bonjour/Zeroconf protocol"
@@ -8,7 +8,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0, BSD-3-Clause"
 homepage="https://opensource.apple.com/"
 distfiles="https://opensource.apple.com/tarballs/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=3cc71582e8eee469c2de8ecae1d769e7f32b3468dfb7f2ca77f1dee1f30a7d1e
+checksum=097662447e1535573484697861d9f50eceaf2c52ec2742e451ee6ffe9bbf3e75
 
 conf_files="/etc/nss_mdns.conf"
 conflicts="nss-mdns>=0"


### PR DESCRIPTION
Updated to latest upstream release, added patch courtesy of FreeBSD ports.
Both resolving and publishing mdns works as expected, at least on x86_64.
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
