### PR TITLE
pipewire: update to 0.3.23

### DIFF
--- a/srcpkgs/pipewire/patches/autostart-media-session.patch
+++ b/srcpkgs/pipewire/patches/autostart-media-session.patch
@@ -1,0 +1,11 @@
+--- src/daemon/pipewire.conf.in.orig	2021-03-04 16:54:52.950015583 +0100
++++ src/daemon/pipewire.conf.in	2021-03-04 16:55:13.766016281 +0100
+@@ -203,7 +203,7 @@
+     # but it is better to start it as a systemd service.
+     # Run the session manager with -h for options.
+     #
+-    @comment@"@media_session_path@" = { args = "" }
++    "@media_session_path@" = { args = "" }
+     #
+     # You can optionally start the pulseaudio-server here as well
+     # but it is better to start it as a systemd service.

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.3.22
+version=0.3.23
 revision=1
 build_style=meson
 configure_args="-Dman=true -Dgstreamer=true -Ddocs=true -Dsystemd=false
@@ -18,7 +18,7 @@ license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=5db2caf41af79cd9e343d07a3804c63b8b243c1d74e926181058e29771d4b691
+checksum=e9a9030032ba8f3b6f9e300dbf755ab439340cd4cbeb3e1bba6f1a18d2c9da92
 conf_files="/etc/pipewire/pipewire.conf"
 
 replaces="libpulseaudio-pipewire>=0"


### PR DESCRIPTION
In 0.3.23 the config does not autostart pipewire-media-session anymore, which is essential for everything, from audio to screen-sharing. It's not easy to start externally in a script since it needs the pipewire socket up, and void doesn't have a mechanism to ensure it (systemd socket activation). So let's "uncomment the comment" to keep the current behavior.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
