### PR TITLE
Remove libintl dependency from some packages

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -176,11 +176,10 @@ libxfce4panel-2.0.so.4 libxfce4panel-4.12.0_1
 libgdbm.so.6 gdbm-1.16_1
 libgdbm_compat.so.4 gdbm-1.10_1_1
 libintl.so.8 gettext-libs-0.19.2_1
-libgnuintl.so.8 gettext-libs-0.19.2_1
-libgettextlib-0.21.so gettext-libs-0.21_1
-libgettextsrc-0.21.so gettext-libs-0.21_1
-libgettextpo.so.0 gettext-libs-0.17_1
-libtextstyle.so.0 gettext-libs-0.20.1_1
+libgettextlib-0.21.so gettext-0.21_3
+libgettextsrc-0.21.so gettext-0.21_3
+libtextstyle.so.0 gettext-0.21_3
+libgettextpo.so.0 gettext-0.21_3
 libattr.so.1 attr-2.4.43_1
 libacl.so.1 acl-2.2.47_1
 libpython2.7.so.1.0 python-2.7.18_3

--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,11 +1,11 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
 version=3.2.1
-revision=1
+revision=2
 wrksrc="fish-${version}"
 build_style=cmake
 hostmakedepends="gettext"
-makedepends="ncurses-devel pcre2-devel gettext-devel"
+makedepends="ncurses-devel pcre2-devel"
 depends="groff"
 checkdepends="python3-pexpect procps-ng"
 short_desc="User friendly shell intended mostly for interactive use"
@@ -15,6 +15,8 @@ homepage="https://fishshell.com/"
 distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.xz"
 checksum=d8e49f4090d3778df17dd825e4a2a80192015682423cd9dd02b6675d65c3af5b
 register_shell="/bin/fish /usr/bin/fish"
+# tests don't work as root
+make_check=extended
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"

--- a/srcpkgs/gettext-devel-tools
+++ b/srcpkgs/gettext-devel-tools
@@ -1,0 +1,1 @@
+gettext

--- a/srcpkgs/gettext/patches/musl-realpath.patch
+++ b/srcpkgs/gettext/patches/musl-realpath.patch
@@ -1,0 +1,41 @@
+https://gitlab.alpinelinux.org/alpine/aports/-/issues/12295
+This patch is necessary only with musl after 1.2.2
+
+----
+test-canonicalize.c:339: assertion 'strcmp (result1, "/") == 0' failed
+Aborted (core dumped)
+FAIL test-canonicalize (exit status: 134)
+----
+
+diff --git a/gettext-tools/gnulib-tests/test-canonicalize-lgpl.c b/gettext-tools/gnulib-tests/test-canonicalize-lgpl.c
+index ff82981..17842e8 100644
+--- a/gettext-tools/gnulib-tests/test-canonicalize-lgpl.c
++++ b/gettext-tools/gnulib-tests/test-canonicalize-lgpl.c
+@@ -208,8 +208,8 @@ main (void)
+ #ifndef __MVS__
+     if (SAME_INODE (st1, st2))
+       {
+-        ASSERT (strcmp (result1, "/") == 0);
+-        ASSERT (strcmp (result2, "/") == 0);
++        ASSERT (strcmp (result1, "/") == 0 || strcmp (result1, "//") == 0);
++        ASSERT (strcmp (result2, "/") == 0 || strcmp (result2, "//") == 0);
+       }
+     else
+ #endif
+--- a/gettext-tools/gnulib-tests/test-canonicalize.c
++++ b/gettext-tools/gnulib-tests/test-canonicalize.c
+@@ -336,10 +336,10 @@
+     ASSERT (stat ("//", &st2) == 0);
+     if (SAME_INODE (st1, st2))
+       {
+-        ASSERT (strcmp (result1, "/") == 0);
+-        ASSERT (strcmp (result2, "/") == 0);
+-        ASSERT (strcmp (result3, "/") == 0);
+-        ASSERT (strcmp (result4, "/") == 0);
++        ASSERT (strcmp (result1, "/") == 0 || strcmp (result1, "//") == 0);
++        ASSERT (strcmp (result2, "/") == 0 || strcmp (result2, "//") == 0);
++        ASSERT (strcmp (result3, "/") == 0 || strcmp (result3, "//") == 0);
++        ASSERT (strcmp (result4, "/") == 0 || strcmp (result4, "//") == 0);
+       }
+     else
+       {

--- a/srcpkgs/gettext/patches/musl-unsupported-iconv-encoding.patch
+++ b/srcpkgs/gettext/patches/musl-unsupported-iconv-encoding.patch
@@ -1,0 +1,44 @@
+As upstream notes:
+
+# Note: This test fails on Linux with musl libc versions that don't support
+# the BIG5 encoding in 'iconv'.
+
+diff --git a/gettext-tools/tests/msgconv-2 b/gettext-tools/tests/msgconv-2
+index d286cda..d96c487 100755
+--- a/gettext-tools/tests/msgconv-2
++++ b/gettext-tools/tests/msgconv-2
+@@ -7,6 +7,8 @@
+ # Note: This test fails on Linux with musl libc versions that don't support
+ # the BIG5 encoding in 'iconv'.
+ 
++Exit 77
++
+ cat <<\EOF > mco-test2.po
+ # Chinese translation for GNU gettext messages.
+ #
+diff --git a/gettext-tools/tests/msgmerge-compendium-6 b/gettext-tools/tests/msgmerge-compendium-6
+index 0afbe1e..1b2fe6b 100755
+--- a/gettext-tools/tests/msgmerge-compendium-6
++++ b/gettext-tools/tests/msgmerge-compendium-6
+@@ -10,6 +10,8 @@
+ # Note: This test fails on Linux with musl libc versions that don't support
+ # the EUC-KR encoding in 'iconv'.
+ 
++Exit 77
++
+ : ${MSGCONV=msgconv}
+ ${MSGCONV} --to-code=UTF-8 -o mm-ko.utf-8.pot "$wabs_srcdir"/mm-ko.ascii.pot
+ 
+diff --git a/gettext-tools/tests/xgettext-python-3 b/gettext-tools/tests/xgettext-python-3
+index ca0926d..2c49fd7 100755
+--- a/gettext-tools/tests/xgettext-python-3
++++ b/gettext-tools/tests/xgettext-python-3
+@@ -6,6 +6,8 @@
+ # Note: This test fails on Linux with musl libc versions that don't support
+ # the EUC-JP encoding in 'iconv'.
+ 
++Exit 77
++
+ cat <<\EOF > xg-py-3a.py
+ #!/usr/bin/env python
+ # TRANSLATORS: Franè´Æois Pinard is a hero.

--- a/srcpkgs/gettext/template
+++ b/srcpkgs/gettext/template
@@ -1,7 +1,7 @@
 # Template file for 'gettext'
 pkgname=gettext
 version=0.21
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--disable-java --disable-native-java --disable-csharp
  --disable-libasprintf --enable-threads=posix --disable-rpath --without-emacs
@@ -22,11 +22,20 @@ homepage="https://www.gnu.org/software/gettext/"
 changelog="https://git.savannah.gnu.org/cgit/gettext.git/plain/NEWS"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=c77d0da3102aec9c07f43671e60611ebff89a996ef159497ce8e59d075786b12
+patch_args=-Np1
 
-case "$XBPS_TARGET_MACHINE" in
+subpackages="gettext-devel-examples gettext-devel gettext-devel-tools"
+unset _intl_lib
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	# force libintl
-	*-musl) configure_args+=" --with-included-gettext";;
-esac
+	configure_args+=" --with-included-gettext"
+	subpackages+=" gettext-libs"
+	_intl_lib=intl
+else
+	# on glibc, old gettext-libs conflicts with gettext
+	replaces="gettext-libs>=0"
+	conflicts="gettext-libs>=0"
+fi
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" automake libtool"
@@ -35,10 +44,9 @@ if [ "$CROSS_BUILD" ]; then
 	}
 fi
 
-
 post_install() {
-	# Fix conflict with musl.
-	if [ -e ${DESTDIR}/usr/include/libintl.h ]; then
+	# don't overwrite musl's header
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
 		vmkdir usr/include/gettext
 		mv ${DESTDIR}/usr/include/libintl.h ${DESTDIR}/usr/include/gettext/libintl.h
 	fi
@@ -50,22 +58,42 @@ gettext-devel-examples_package() {
 		vmove usr/share/doc/gettext
 	}
 }
+
 gettext-devel_package() {
-	depends="gettext-libs>=${version}_${revision} xz tar"
+	depends="${sourcepkg}>=${version}_${revision}
+	 gettext-devel-tools>=${version}_${revision} xz tar"
+	if [ -n "${_intl_lib}" ]; then
+		depends+=" gettext-libs>=${version}_${revision}"
+	fi
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/*.a
-		vmove usr/share/aclocal
+		vmove "usr/lib/*.a"
+		# libgettext{lib,src}-$version.so need to be in the main package
+		for _lib in ${_intl_lib} gettextlib gettextpo gettextsrc textstyle
+		do
+			vmove "usr/lib/lib${_lib}.so"
+		done
 		vmove usr/share/gettext
 		vmove usr/share/man/man3
-		vmove usr/bin/autopoint
-		vmove usr/bin/gettextize
 	}
 }
+
+gettext-devel-tools_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development tools"
+	pkg_install() {
+		vmove usr/share/aclocal
+		vmove usr/bin/autopoint
+		vmove usr/bin/gettextize
+		vmove usr/share/man/man1/autopoint.1
+		vmove usr/share/man/man1/gettextize.1
+	}
+}
+
 gettext-libs_package() {
 	short_desc+=" - shared libraries"
 	pkg_install() {
-		vmove usr/lib/*.so*
+		vmove "usr/lib/libintl.so.*"
 	}
 }

--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,13 +1,15 @@
 # Template file for 'gnutls'
 pkgname=gnutls
 version=3.6.15
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-zlib --disable-guile --disable-static
  --disable-valgrind-tests --disable-rpath
  --with-default-trust-store-file=/etc/ssl/certs/ca-certificates.crt
  --with-trousers-lib=${XBPS_CROSS_BASE}/usr/lib"
-hostmakedepends="automake gettext-devel libtool pkg-config which"
+hostmakedepends="gettext libtool pkg-config which"
+# for autoreconf
+#hostmakedepends+=" gettext-devel-tools automake"
 makedepends="zlib-devel lzo-devel readline-devel libgpg-error-devel
  libtasn1-devel libgcrypt-devel p11-kit-devel nettle-devel libidn2-devel
  libunistring-devel unbound-devel trousers-devel"
@@ -18,10 +20,6 @@ license="GPL-3.0-only, LGPL-2.1-or-later"
 homepage="https://gnutls.org"
 distfiles="https://www.gnupg.org/ftp/gcrypt/gnutls/v${version%.*}/gnutls-${version}.tar.xz"
 checksum=0ea8c3283de8d8335d7ae338ef27c53a916f15f382753b174c18b45ffd481558
-
-pre_configure() {
-	autoreconf -vfi
-}
 
 pre_check() {
 	# same as $PASS in tests/cert-tests/certtool

--- a/srcpkgs/gtranslator/template
+++ b/srcpkgs/gtranslator/template
@@ -1,7 +1,7 @@
 # Template file for 'gtranslator'
 pkgname=gtranslator
 version=3.38.0
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="gettext pkg-config glib-devel itstool"
 makedepends="gettext-devel libglib-devel libdazzle-devel libsoup-devel

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,13 +1,13 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=1.0.2
-revision=1
+revision=2
 wrksrc="inkscape-${version}_2021-01-15_e86c870879"
 build_style=cmake
 # builds executables then runs checks
 # FIXME: some tests still fail on musl
 make_check_target=check
-hostmakedepends="automake pkg-config libtool intltool gettext-devel
+hostmakedepends="automake pkg-config libtool intltool gettext
  glib-devel perl-XML-Parser tar which xz"
 makedepends="harfbuzz-devel libsoup-devel gsl-devel pango-devel
  double-conversion-devel gc-devel libwpd-devel libcdr-devel libvisio-devel

--- a/srcpkgs/weechat/template
+++ b/srcpkgs/weechat/template
@@ -1,12 +1,13 @@
 # Template file for 'weechat'
 pkgname=weechat
 version=3.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DENABLE_MAN=ON -DENABLE_PERL=ON
  -DENABLE_LUA=ON -DENABLE_RUBY=ON -DENABLE_SPELL=ON
  -DENABLE_GUILE=OFF -DENABLE_PHP=OFF -DENABLE_JAVASCRIPT=OFF"
-hostmakedepends="ruby-asciidoctor libgcrypt-devel pkg-config python3 tcl-devel"
+hostmakedepends="ruby-asciidoctor libgcrypt-devel pkg-config python3 tcl-devel
+ gettext"
 makedepends="aspell-devel gnutls-devel libcurl-devel lua53-devel ncurses-devel
  perl python3-devel ruby-devel tcl-devel"
 depends="ca-certificates"


### PR DESCRIPTION
The initial commit explains most of the situation. Basically remove unnecessary / useless libintl dependency from some musl packages, where possible. Starting with packages I use myself and can test, would appreciate testing from others as well.