### PR TITLE
diffoscope: remove rpm-python3 dependency.

### DIFF
--- a/srcpkgs/diffoscope/template
+++ b/srcpkgs/diffoscope/template
@@ -1,15 +1,14 @@
 # Template file for 'diffoscope'
 pkgname=diffoscope
 version=167
-revision=1
+revision=2
 build_style=python3-module
 # file 5.39 causes errors there, see https://bugs.astron.com/view.php?id=170
 make_check_args="-k not((test_wasm)and((test_identification)or(test_no_differences)))"
 hostmakedepends="python3-setuptools"
 depends="python3-magic python3-libarchive-c python3-setuptools
  python3-argcomplete binwalk python3-defusedxml python3-distro
- python3-jsondiff python3-PyPDF2 python3-pyxattr rpm-python3
- python3-tlsh"
+ python3-jsondiff python3-PyPDF2 python3-pyxattr python3-tlsh"
 checkdepends="${depends} python3-pytest"
 short_desc="In-depth comparison of files, archives, and directories"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"


### PR DESCRIPTION
Unnecessary for local usage with most of the objects Void users deal
with, and it can detect that the library isn't available at runtime.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

@Chocimier I can carry a local `ignorepkg` if you don't like this patch, but I think it makes more sense like this.