### PR TITLE
ninja: also install plain text manual.

### DIFF
--- a/srcpkgs/ninja/template
+++ b/srcpkgs/ninja/template
@@ -1,7 +1,7 @@
 # Template file for 'ninja'
 pkgname=ninja
 version=1.10.2
-revision=1
+revision=2
 hostmakedepends="python3 asciidoc"
 short_desc="Small build system with a focus on speed"
 maintainer="Duncaen <duncaen@voidlinux.org>"
@@ -34,6 +34,7 @@ do_check() {
 do_install() {
 	vbin ninja
 	vdoc doc/manual.html
+	vdoc doc/manual.asciidoc
 	vinstall misc/bash-completion 644 usr/share/bash-completion/completions ninja
 	vinstall misc/zsh-completion 644 usr/share/zsh/site-functions _ninja
 }


### PR DESCRIPTION
Not generating a manpage because it fails with:
    asciidoc: FAILED: manual.asciidoc: line 3: missing backend conf file: manpage.conf

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
