### PR TITLE
fzf: cleanup post_install()

### DIFF
--- a/srcpkgs/fzf/template
+++ b/srcpkgs/fzf/template
@@ -1,7 +1,7 @@
 # Template file for 'fzf'
 pkgname=fzf
 version=0.26.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/junegunn/fzf"
 hostmakedepends="git"
@@ -18,14 +18,19 @@ post_install() {
 	cd ${wrksrc}
 	vbin bin/fzf-tmux
 	vman man/man1/fzf.1
+	vman man/man1/fzf-tmux.1
 	vlicense LICENSE
 
-	sed -i -e 's#source ~/\.fzf\.bash; ##' shell/key-bindings.bash
 	vinstall plugin/fzf.vim 644 usr/share/vim/vimfiles/plugin
+	vinstall doc/fzf.txt 644 usr/share/vim/vimfiles/doc
+
 	vinstall plugin/fzf.vim 644 usr/share/nvim/runtime/plugin
-	vinstall shell/completion.bash 644 usr/share/doc/fzf
-	vinstall shell/completion.zsh 644 usr/share/doc/fzf
-	vinstall shell/key-bindings.zsh 644 usr/share/doc/fzf
-	vinstall shell/key-bindings.bash 644 usr/share/doc/fzf
-	vinstall shell/key-bindings.fish 644 usr/share/doc/fzf
+	vinstall doc/fzf.txt 644 usr/share/nvim/runtime/doc
+
+	vcompletion shell/completion.bash bash
+	vcompletion shell/completion.zsh zsh
+
+	vinstall shell/key-bindings.zsh 644 usr/share/fzf
+	vinstall shell/key-bindings.bash 644 usr/share/fzf
+	vinstall shell/key-bindings.fish 644 usr/share/fish/vendor_functions.d fzf_key_bindings.fish
 }


### PR DESCRIPTION
Added missing manpage for fzf-tmux, removed unused sed line, installed completion by default.