### PR TITLE
monero-gui: fix cross.

### DIFF
--- a/srcpkgs/monero-gui/template
+++ b/srcpkgs/monero-gui/template
@@ -35,8 +35,6 @@ checksum="3a924b4e08b557d93337a0c05826a9fa95e5cf8c503aff0ecb3676be45db1d14
 skip_extraction="monero-${version}.tar.gz ${_rapidjson_gitrev}.tar.gz ${_supercop_gitrev}.tar.gz v${_randomx_version}.tar.gz
  ${_quirc_gitrev}.tar.gz"
 
-nocross="https://build.voidlinux.org/builders/armv7l_builder/builds/31154/steps/shell_3/logs/stdio"
-
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 	CFLAGS+=" -latomic"
@@ -57,8 +55,6 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc*) configure_args+=" -DARCH=ppc"     ;;
 	*) configure_args+=" -DARCH=default" ;;
 esac
-
-
 
 post_extract() {
 	bsdtar xzf ${XBPS_SRCDISTDIR}/${pkgname}-${version}/monero-${_monero_version}.tar.gz --strip-components 1 -C monero
@@ -95,7 +91,7 @@ pre_build() {
 		# but is not included in the binary package. It thus needs to be
 		# built for the host
 		CC=${CC_host} CFLAGS="${XBPS_CFLAGS}" LDFLAGS="${XBPS_LDFLAGS}" \
-			make -C build/monero ${makejobs} generate_translations_header
+			ninja -C build ${makejobs} generate_translations_header
 
 	fi
 	make ${makejobs} -C src/zxcvbn-c


### PR DESCRIPTION
Upstream had moved to ninja so generate_translation_headers was not
being generated properly in the makefiles. Moving to ninja for the
building command solves this issue.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
