### PR TITLE
New package: loki-2.1.0

### DIFF
--- a/srcpkgs/loki/template
+++ b/srcpkgs/loki/template
@@ -1,0 +1,15 @@
+# Template file for 'loki'
+pkgname=loki
+version=2.1.0
+revision=1
+build_style=go
+go_import_path="github.com/grafana/loki"
+go_package="${go_import_path}/cmd/loki
+ ${go_import_path}/cmd/logcli
+ ${go_import_path}/cmd/loki-canary"
+short_desc="Like Prometheus, but for logs"
+maintainer="Michael Aldridge <aldridge.mac@gmail.com>"
+license="Apache-2.0"
+homepage="https://grafana.com/oss/loki/"
+distfiles="https://github.com/grafana/loki/archive/v$version.tar.gz"
+checksum=ceccc4e42a7158ca0bc49903a3fbe31c8cd55f85f50bac8a8bba9843b4f8cd6f


### PR DESCRIPTION
- [x] This is actively part of fleet infrastructure, and is running right now.