### PR TITLE
xbps: Remove untracked virtualpkgs file

### DIFF
--- a/srcpkgs/xbps/template
+++ b/srcpkgs/xbps/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps'
 pkgname=xbps
 version=0.59.1
-revision=4
+revision=5
 bootstrap=yes
 build_style=configure
 short_desc="XBPS package system utilities"
@@ -48,6 +48,8 @@ post_install() {
 
 	vlicense LICENSE
 	vlicense LICENSE.3RDPARTY
+
+	echo "" > ${DESTDIR}/usr/share/xbps.d/void-virtualpkgs.conf
 }
 
 libxbps_package() {


### PR DESCRIPTION
```
02:57 <heliocat> duncaen: someone should update base-packages to remove /usr/share/xbps.d/void-virtualpackages.conf
02:58 <heliocat> void-mklive/installer.sh is what's copying that file for some people and it's going to have broken a whole lot of folks
```