### PR TITLE
mumble: add portaudio build option

### DIFF
--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,17 +1,18 @@
 # Template file for 'mumble'
 pkgname=mumble
 version=1.3.4
-revision=4
+revision=5
 build_style=qmake
 configure_args="CONFIG+=bundled-celt CONFIG+=no-bundled-opus CONFIG+=no-update
  CONFIG+=no-bundled-speex CONFIG+=no-g15 CONFIG+=no-xevie CONFIG+=pulseaudio
  $(vopt_if jack CONFIG+=jackaudio) CONFIG+=no-embed-qt-translations
- CONFIG+=no-oss CONFIG+=portaudio DEFINES+=PLUGIN_PATH=/usr/lib/mumble"
+ CONFIG+=no-oss $(vopt_if portaudio CONFIG+=portaudio)
+ DEFINES+=PLUGIN_PATH=/usr/lib/mumble"
 hostmakedepends="Ice pkg-config protobuf qt5-host-tools qt5-qmake python3 which"
 makedepends="Ice-devel MesaLib-devel avahi-compat-libs-devel boost-devel
  libcap-devel openssl-devel libsndfile-devel opus-devel protobuf-devel
  pulseaudio-devel $(vopt_if jack jack-devel) qt5-devel qt5-svg-devel
- speech-dispatcher-devel speex-devel portaudio-devel"
+ speech-dispatcher-devel speex-devel $(vopt_if portaudio portaudio-devel)"
 depends="desktop-file-utils qt5-plugin-sqlite"
 short_desc="Open source, low-latency, high quality voice chat for gaming"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
@@ -20,8 +21,8 @@ homepage="http://mumble.sourceforge.net/"
 distfiles="https://github.com/mumble-voip/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.gz"
 checksum=615f4ebfc3385d945163f369efd3e910c8b6d0f025797a7eed541515fccb6093
 
-build_options="jack"
-desc_option_jack="Enable support for the JACK sound server"
+build_options="jack portaudio"
+build_options_default="jack portaudio"
 
 do_install() {
 	vlicense LICENSE


### PR DESCRIPTION
jack option is already described

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
