### PR TITLE
Move Python 2 to Active State cPython

### DIFF
--- a/srcpkgs/python-tkinter/template
+++ b/srcpkgs/python-tkinter/template
@@ -7,19 +7,19 @@
 _desc="Interpreted, interactive, object-oriented programming language"
 
 pkgname=python-tkinter
-version=2.7.18
-revision=3
-wrksrc="Python-${version}"
+version=2.7.18.4
+revision=1
+wrksrc="cpython-${version}"
 pycompile_dirs="usr/lib/python2.7/lib-tk"
 hostmakedepends="pkg-config"
 makedepends="libffi-devel readline-devel gdbm-devel openssl-devel expat-devel
  sqlite-devel bzip2-devel zlib-devel tk-devel"
 short_desc="${_desc} - GUI toolkit for Python2"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Python-2.0"
 homepage="https://www.python.org"
-distfiles="https://www.python.org/ftp/python/${version}/Python-${version}.tar.xz"
-checksum=b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43
+distfiles="https://github.com/ActiveState/cpython/archive/v${version}.tar.gz"
+checksum=003a4fbd03fa0dbb3cf88d894c40311ef30dd17b2aa85291c3136393148b1362
 
 pre_configure() {
 	# Ensure that internal copies of expat, libffi and zlib are not used.

--- a/srcpkgs/python/template
+++ b/srcpkgs/python/template
@@ -3,20 +3,20 @@
 # THIS PKG MUST BE SYNCHRONIZED WITH "srcpkgs/python-tkinter".
 #
 pkgname=python
-version=2.7.18
-revision=3
-wrksrc="Python-${version}"
+version=2.7.18.4
+revision=1
+wrksrc="cpython-${version}"
 pycompile_dirs="usr/lib/python2.7"
 hostmakedepends="pkg-config"
 makedepends="libffi-devel readline-devel gdbm-devel openssl-devel expat-devel
  sqlite-devel bzip2-devel zlib-devel"
 depends="ca-certificates"
 short_desc="Interpreted, interactive, object-oriented programming language"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Python-2.0"
 homepage="https://www.python.org"
-distfiles="https://www.python.org/ftp/python/${version}/Python-${version}.tar.xz"
-checksum=b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43
+distfiles="https://github.com/ActiveState/cpython/archive/v${version}.tar.gz"
+checksum=003a4fbd03fa0dbb3cf88d894c40311ef30dd17b2aa85291c3136393148b1362
 
 alternatives="
  python:idle:/usr/bin/idle2.7
@@ -85,13 +85,13 @@ post_install() {
 	rm -r ${DESTDIR}/usr/lib/python2.7/lib2to3/tests
 	# Remove references to the install(1) wrapper.
 	vsed -e "s,${XBPS_WRAPPERDIR},/usr/bin,g" -i \
-		${DESTDIR}/usr/lib/python${version%.*}/_sysconfigdata.py \
-		${DESTDIR}/usr/lib/python${version%.*}/config/Makefile
+		${DESTDIR}/usr/lib/python${version%.*.*}/_sysconfigdata.py \
+		${DESTDIR}/usr/lib/python${version%.*.*}/config/Makefile
 	if [ "$CROSS_BUILD" ]; then
 		# Remove references to cross toolchain.
 		vsed -i "s/$XBPS_CROSS_TRIPLET-//g" \
-			${DESTDIR}/usr/lib/python${version%.*}/_sysconfigdata.py \
-			${DESTDIR}/usr/lib/python${version%.*}/config/Makefile
+			${DESTDIR}/usr/lib/python${version%.*.*}/_sysconfigdata.py \
+			${DESTDIR}/usr/lib/python${version%.*.*}/config/Makefile
 	fi
 }
 

--- a/srcpkgs/python/update
+++ b/srcpkgs/python/update
@@ -1,2 +1,1 @@
-site="https://www.python.org/ftp/python/"
-pattern='"\K2\.[\d.]+(?=/")'
+pattern='v\K2\.7\.[\d.]*\d'


### PR DESCRIPTION
ActiveState is running a branch of cPython that has a bunch of security fixes, at
https://github.com/ActiveState/cpython/

This is very convenient to use for our python package, so let's do it.