### PR TITLE
pueue: update to 0.12.0

### DIFF
--- a/srcpkgs/pueue/template
+++ b/srcpkgs/pueue/template
@@ -1,20 +1,31 @@
 # Template file for 'pueue'
 pkgname=pueue
-version=0.10.2
+version=0.12.0
 revision=1
 build_style=cargo
+build_helper="qemu"
 short_desc="Command-line tool for managing long-running tasks"
 maintainer="crater2150 <void@qwertyuiop.de>"
 license="MIT"
 homepage="https://github.com/Nukesor/pueue"
 distfiles="https://github.com/Nukesor/pueue/archive/v${version}.tar.gz"
-checksum=dbd333079df9249609f6a01d7c96175ec9d74f9d621688b95ec755134b7fa1f5
+checksum=9c3930380120bf8479caa55236fb9fdbbad5bfe3d41c0729a667c777cbc856e2
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;
 	*) broken="ftbfs in ring" ;;
 esac
 
+post_build() {
+	for shell in bash fish zsh; do
+		vtargetrun target/${RUST_TARGET}/release/pueue completions $shell .
+	done
+}
+
 post_install() {
 	vlicense LICENSE
+
+	vcompletion _pueue zsh pueue
+	vcompletion pueue.bash bash pueue
+	vcompletion pueue.fish fish pueue
 }


### PR DESCRIPTION
I bundled the completion files, which are generated by running `pueue completions`. Please let me know if there's a good way to run this step from the template (`pueue` is a binary, so I didn't know how to call it without breaking cross-building).

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl