### PR TITLE
git: update to 2.30.2.

### DIFF
--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,7 +1,7 @@
 # Template file for 'git'
 pkgname=git
-version=2.30.1
-revision=2
+version=2.30.2
+revision=1
 build_style=gnu-configure
 configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2"
 hostmakedepends="asciidoc gettext perl pkg-config tar tk xmlto"
@@ -14,7 +14,7 @@ license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=f988a8a095089978dab2932af4edb22b4d7d67d67b81aaa1986fa29ef45d9467
+checksum=41f7d90c71f9476cd387673fcb10ce09ccbed67332436a4cc58d7af32c355faa
 replaces="git-perl>=0"
 register_shell=/usr/bin/git-shell
 python_version=3


### PR DESCRIPTION
Fixes CVE-2021-21300.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
