### PR TITLE
xorriso: update to 1.5.4.pl02

### DIFF
--- a/srcpkgs/xorriso/template
+++ b/srcpkgs/xorriso/template
@@ -1,12 +1,13 @@
 # Template file for 'xorriso'
 pkgname=xorriso
-version=1.5.3
+version=1.5.4.pl02
 revision=1
+wrksrc="${pkgname}-${version%.pl*}"
 build_style=gnu-configure
 makedepends="zlib-devel bzip2-devel readline-devel acl-devel"
 short_desc="ISO 9660 Rock Ridge Filesystem Manipulator"
 maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/xorriso"
-distfiles="https://www.gnu.org/software/xorriso/xorriso-${version}.tar.gz"
-checksum=bb8db9274caecd44993e8242e6acff4298b3508b83ac3c51c9fd970b9e765adc
+distfiles="${GNU_SITE}/xorriso/xorriso-${version}.tar.gz"
+checksum=3ec7393d4a9dcbf5f74309c28a415f55227ec62770b95ae993ac8d7a3b152972


### PR DESCRIPTION
- use GNU_SITE for downloads

@ailiop-git

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
