### PR TITLE
pango: update to 1.48.3

### DIFF
--- a/srcpkgs/pango/template
+++ b/srcpkgs/pango/template
@@ -1,18 +1,20 @@
 # Template file for 'pango'
 pkgname=pango
-version=1.48.0
-revision=2
+version=1.48.3
+revision=1
 build_style=meson
 build_helper=gir
 configure_args="-Dintrospection=$(vopt_if gir enabled disabled)"
 hostmakedepends="glib-devel help2man pkg-config"
 makedepends="fribidi-devel harfbuzz-devel libXft-devel libthai-devel"
+checkdepends="liberation-fonts-ttf cantarell-fonts"
 short_desc="Library for layout and rendering of text"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.pango.org/"
+changelog="https://gitlab.gnome.org/GNOME/pango/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/pango/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=391f26f3341c2d7053e0fb26a956bd42360dadd825efe7088b1e9340a65e74e6
+checksum=36ea145c82217c8efc954d02aa577391b1d9a5da205e0aef7ffe0461349b4b46
 
 # Package build options
 build_options="gir"
@@ -26,7 +28,7 @@ post_install() {
 pango-xft_package() {
 	short_desc+=" - X font rendering"
 	pkg_install() {
-		vmove usr/lib/libpangoxft*.so.*
+		vmove "usr/lib/libpangoxft*.so.*"
 		if [ "$build_option_gir" ]; then
 			vmove usr/lib/girepository-1.0/PangoXft-1.0.typelib
 		fi


### PR DESCRIPTION
[Help] Two issues I'm unable to find a solution for:
1. /usr/include/features.h:397:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]

2. Package pango/fc.pc was not found in the pkg-config search path.
Dunno they disappear for the arch I what to build??

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [X] armv7l
  - [ ] armv6l-musl
-->
