### PR TITLE
nushell: update to 0.28.0

### DIFF
--- a/srcpkgs/nushell/template
+++ b/srcpkgs/nushell/template
@@ -1,7 +1,7 @@
 # Template file for 'nushell'
 pkgname=nushell
-version=0.27.1
-revision=3
+version=0.28.0
+revision=1
 build_style=cargo
 configure_args="--features=extra"
 hostmakedepends="pkg-config python3 libgit2-devel"
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://www.nushell.sh/"
 changelog="https://www.nushell.sh/blog/"
 distfiles="https://github.com/nushell/nushell/archive/${version}.tar.gz"
-checksum=bd153a95ea15446bb61a9e0292adc165ee0dd3a586298e77a0041597d68bc04e
+checksum=aa6769f614a031ad33738064030d1c0d9ab500b2b0924adca71edacb1bd1d85d
 register_shell="/usr/bin/nu"
 # all tests fail with argument --target
 make_check=no


### PR DESCRIPTION
`decimal` has a new update 2.1.0. But we have to wait for `bson` to
update `decimal` version, and then wait for `nushell` to update `bson`
version :)
So keep the `post_patch()` for now. We probably can remove it in the next
release.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
