### PR TITLE
libwaylandpp: fix shlibs

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3966,3 +3966,7 @@ libsimavrparts.so.1 simavr-1.6_2
 libsword-1.8.1.so libsword-1.8.1_6
 libpari-gmp.so.7 pari-2.13.0_1
 libtree-sitter.so.0 tree-sitter-0.19.0_1
+libwayland-client++.so.0 libwaylandpp-0.2.8_1
+libwayland-cursor++.so.0 libwaylandpp-0.2.8_1
+libwayland-egl++.so.0 libwaylandpp-0.2.8_1
+libwayland-client-extra++.so.0 libwaylandpp-0.2.8_1


### PR DESCRIPTION
While working on the kodi 19 update, I encountered an issue with libwaylandpp libraries not being written in the shlibs file.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
