### PR TITLE
cyrus-sasl-modules: remove dependency to main package

### DIFF
--- a/srcpkgs/cyrus-sasl/template
+++ b/srcpkgs/cyrus-sasl/template
@@ -1,7 +1,7 @@
 # Template file for 'cyrus-sasl'
 pkgname=cyrus-sasl
 version=2.1.27
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--disable-static --enable-shared --enable-checkapop
  --enable-cram --enable-digest --disable-otp --disable-srp
@@ -39,7 +39,6 @@ post_install() {
 }
 
 cyrus-sasl-modules-ldap_package() {
-	depends="cyrus-sasl>=${version}_${revision}"
 	short_desc="Cyrus SASL - pluggable authentication modules (LDAP)"
 	pkg_install() {
 		vmove "usr/lib/sasl2/libldapdb.*"
@@ -47,7 +46,6 @@ cyrus-sasl-modules-ldap_package() {
 }
 
 cyrus-sasl-modules-sql_package() {
-	depends="cyrus-sasl>=${version}_${revision}"
 	short_desc="Cyrus SASL - pluggable authentication modules (SQL)"
 	pkg_install() {
 		vmove "usr/lib/sasl2/libsql.*"
@@ -55,7 +53,6 @@ cyrus-sasl-modules-sql_package() {
 }
 
 cyrus-sasl-modules-gssapi_package() {
-	depends="cyrus-sasl>=${version}_${revision}"
 	short_desc="Cyrus SASL - pluggable authentication modules (GSSAPI)"
 	pkg_install() {
 		vmove "usr/lib/sasl2/libgssapi*"
@@ -63,7 +60,6 @@ cyrus-sasl-modules-gssapi_package() {
 }
 
 cyrus-sasl-modules_package() {
-	depends="cyrus-sasl>=${version}_${revision}"
 	short_desc="Cyrus SASL - pluggable authentication modules"
 	pkg_install() {
 		vmove usr/lib/sasl2


### PR DESCRIPTION
The various sasl modules do not dependent on any of the tools and
daemons that are included in the main cyrus-sasl package. Drop the
dependency.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
