### PR TITLE
xbps-src: simplify dbulk-dump output

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -32,19 +32,18 @@ setup_pkg_depends() {
             if [ -z "$foo" ]; then
                 msg_error "$pkgver: failed to resolve virtual dependency for '$j' (missing from etc/virtual)\n"
             fi
-            _deps+="$foo "
+            [[ $out ]] && echo "$foo"
         else
             foo="$($XBPS_UHELPER_CMD getpkgdepname ${_depname} 2>/dev/null)"
             if [ -z "$foo" ]; then
                 foo="$($XBPS_UHELPER_CMD getpkgname ${_depname} 2>/dev/null)"
                 [ -z "$foo" ] && foo="${_depname}"
             fi
-            _deps+="$foo "
+            [[ $out ]] && echo "$foo"
         fi
         run_depends+="${_depname} "
     done
 
-    [[ $out && $_deps ]] && echo "$_deps"
     return 0
 }
 

--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -21,7 +21,7 @@ check_pkg_arch() {
             esac
         done
         if [ -z "$nonegation" -a -n "$match" ] || [ -n "$nonegation" -a -z "$match" ]; then
-            msg_red "$pkgname: this package cannot be built for ${_arch}.\n"
+            msg_red "${pkgname}-${version}_${revision}: this package cannot be built for ${_arch}.\n"
             exit 2
         fi
     fi

--- a/xbps-src
+++ b/xbps-src
@@ -891,33 +891,28 @@ case "$XBPS_TARGET" in
         ;;
     dbulk-dump)
         read_pkg
+        check_pkg_arch "$XBPS_CROSS_BUILD"
         for x in pkgname version revision; do
             printf '%s: %s\n' "$x" "${!x}"
         done
         for x in bootstrap; do
             [[ ${!x} ]] && printf '%s: %s\n' "$x" "${!x}"
         done
-        for x in hostmakedepends makedepends depends; do
+        for x in hostmakedepends makedepends; do
             arr=(${!x})
             if [[ ${#arr} -gt 0 ]]; then
                 printf '%s:\n' "$x"
                 printf ' %s\n' "${arr[@]}"
             fi
         done
+        _cleandeps=$(setup_pkg_depends "" 1 1 | { grep -vF "$(printf "%s\n" $pkgname $subpackages)" || :; } | sort -u) || exit 1
+        if [[ $_cleandeps ]]; then
+                printf 'depends:\n'
+                printf ' %s\n' $_cleandeps
+        fi
         if [[ $subpackages ]]; then
             printf 'subpackages:\n'
-            for x in ${subpackages}; do
-                . ${XBPS_COMMONDIR}/environment/setup-subpkg/subpkg.sh
-                ${x}_package
-                printf ' %s\n' "$x"
-                for x in depends; do
-                    arr=(${!x})
-                    if [[ ${#arr} -gt 0 ]]; then
-                        printf '  %s:\n' "$x"
-                        printf '   %s\n' "${arr[@]}"
-                    fi
-                done
-            done
+            printf ' %s\n' $subpackages
         fi
         ;;
     show-options)


### PR DESCRIPTION
* List dependencies of subpackages as part of the source packages
  dependencies, knowing the subpackage they are coming from does
  not matter to a build scheduler as long as xbps-src requires
  those to exist in the same way to main depends= have to exist.
* Resolve virtual? packages through existing means in xbps-src to
  avoid duplicating and possibly diverting from xbps-src's
  behaviour in tools that use dbulk-dump.
* Filter out dependencies on the template itself from sub packages,
  this matches the xbps-src behaviour and there is no need to
  have to duplicate logic for this into the scheduling tool.
* Error out on archs= restrictions as we do already on broken=
  and nocross=, there shouldn't be the need to discover archs=
  restrictions when attempting to build the package.