### PR TITLE
[WIP] occt: update to 7.5.0.

### DIFF
--- a/srcpkgs/occt/patches/fix-cmake-regex.patch
+++ b/srcpkgs/occt/patches/fix-cmake-regex.patch
@@ -3,7 +3,7 @@
 
 --- adm/templates/OpenCASCADEConfig.cmake.in	2019-01-27 00:18:42.763819658 -0500
 +++ adm/templates/OpenCASCADEConfig.cmake.in	2019-01-27 23:40:32.872489521 -0500
-@@ -26,7 +26,7 @@
+@@ -27,7 +27,7 @@
  if (OpenCASCADE_INSTALL_PREFIX MATCHES "/cmake$")
    get_filename_component (OpenCASCADE_INSTALL_PREFIX "${OpenCASCADE_INSTALL_PREFIX}" PATH)
  endif()

--- a/srcpkgs/occt/patches/musl-fenv.patch
+++ b/srcpkgs/occt/patches/musl-fenv.patch
@@ -11,8 +11,8 @@ non-posix functions fegetexcept(3) and feenableexcept(3).
  
  #include <signal.h>
  
--#if !defined(__ANDROID__) && !defined(__QNX__)
-+#if !defined(__ANDROID__) && !defined(__QNX__) && defined(__GLIBC__)
+-#if !defined(__ANDROID__) && !defined(__QNX__) && !defined(__EMSCRIPTEN__)
++#if !defined(__ANDROID__) && !defined(__QNX__) && !defined(__EMSCRIPTEN__) && defined(__GLIBC__)
    #include <sys/signal.h>
  #endif
  

--- a/srcpkgs/occt/patches/musl-mallinfo.patch
+++ b/srcpkgs/occt/patches/musl-mallinfo.patch
@@ -2,16 +2,17 @@ In musl libc there is no struct mallinfo and no function mallinf()
 
 --- src/OSD/OSD_MemInfo.cxx.orig
 +++ src/OSD/OSD_MemInfo.cxx
-@@ -147,8 +147,12 @@
+
+@@ -182,8 +182,12 @@
+ #elif (defined(__linux__) || defined(__linux))
+   if (IsActive (MemHeapUsage))
+   {
++    #if defined(__GLIBC__)
+     const struct mallinfo aMI = mallinfo();
+     myCounters[MemHeapUsage] = aMI.uordblks;
++    #else /* XXX not yet coded */
++    myCounters[MemHeapUsage] = 0;
++    #endif
    }
-   aFile.close();
  
-+  #if defined(__GLIBC__)
-   struct mallinfo aMI = mallinfo();
-   myCounters[MemHeapUsage] = aMI.uordblks;
-+  #else /* XXX not yet coded */
-+  myCounters[MemHeapUsage] = 0;
-+  #endif
- 
- #elif (defined(__APPLE__))
-   struct task_basic_info aTaskInfo;
+   if (!IsActive (MemVirtual)

--- a/srcpkgs/occt/template
+++ b/srcpkgs/occt/template
@@ -1,9 +1,9 @@
 # Template file for 'occt'
 pkgname=occt
-version=7.4.0p1
-revision=2
-_gittag="V${version//./_}"
-wrksrc=occt-${_gittag}
+version=7.5.0
+revision=1
+_ver="${version//./_}"
+wrksrc=OCCT-${_ver}
 build_style=cmake
 configure_args="-DUSE_FREEIMAGE=ON -DUSE_TBB=ON -DUSE_GL2PS=ON -DUSE_VTK=OFF
  -DINSTALL_SAMPLES=ON"
@@ -11,12 +11,10 @@ makedepends="freetype-devel glu-devel freeimage-devel gl2ps-devel tbb-devel
  tcl-devel tk-devel"
 short_desc="OpenCASCADE Technology - library for CAD/CAM/CAE applications"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="LGPL-2.1-only"
+license="custom:LGPL-2.1-only-with-exceptions"
 homepage="https://www.opencascade.com"
-# distfile: use git instead of official tarball, which requires registration
-# see https://www.opencascade.com/content/packaging-again-debian
-distfiles="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/${_gittag};sf=tgz>occt-${_gittag}.tar.gz"
-checksum=e00fedc221560fda31653c23a8f3d0eda78095c87519f338d4f4088e2ee9a9c0
+distfiles="https://github.com/Open-Cascade-SAS/OCCT/archive/V${_ver}.tar.gz"
+checksum=dbe1d62a9317ad1516bd4575293d9aab2dc20206ca7a60a7705c9a3b77dc59c9
 conflicts="oce>=0"
 
 post_install() {

--- a/srcpkgs/occt/update
+++ b/srcpkgs/occt/update
@@ -1,2 +1,0 @@
-site="https://git.dev.opencascade.org/gitweb/?p=occt.git;a=tags"
-pattern=">V\K[\d_p]+(?=</a>)"


### PR DESCRIPTION
ping @Piraty 

- I need to fix patches
- occt dev is now mirrored on github, I think that's a better download location
- right now, the regular git repo is down:
https://old.opencascade.com/content/scheduled-maintenance-starting-march-2-2021