### PR TITLE
llvm11: update to 11.1.0.

### DIFF
--- a/srcpkgs/llvm11/template
+++ b/srcpkgs/llvm11/template
@@ -32,10 +32,6 @@ python_version=3
 
 _lldb_enable=yes
 
-if [ "$CROSS_BUILD" ]; then
-	_lldb_enable=no
-fi
-
 case "$XBPS_TARGET_MACHINE" in
 	ppc64le*) ;;
 	ppc*) _lldb_enable=no ;;
@@ -100,11 +96,11 @@ pre_configure() {
 		mkdir -p build/HOST && pushd build/HOST
 		CC="$BUILD_CC" CXX="$BUILD_CXX" CFLAGS="$BUILD_CFLAGS" \
 			CXXFLAGS="$BUILD_CXXFLAGS" LDFLAGS="$BUILD_LDFLAGS" \
-			cmake ../.. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang
-		make ${makejobs} -C utils/TableGen
-		make ${makejobs} -C tools/clang/utils/TableGen
+			cmake ../.. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;lldb"
+		make ${makejobs} llvm-tblgen clang-tblgen lldb-tblgen
 		configure_args+=" -DLLVM_TABLEGEN=$PWD/bin/llvm-tblgen"
 		configure_args+=" -DCLANG_TABLEGEN=$PWD/bin/clang-tblgen"
+		configure_args+=" -DLLDB_TABLEGEN=$PWD/bin/lldb-tblgen"
 		popd
 	fi
 

--- a/srcpkgs/llvm11/template
+++ b/srcpkgs/llvm11/template
@@ -1,18 +1,23 @@
 # Template file for 'llvm11'
 pkgname=llvm11
-version=11.0.0
+version=11.1.0
 revision=1
-wrksrc="llvm-${version}.src"
+wrksrc="llvm-project-${version}.src"
+build_wrksrc=llvm
 build_style=cmake
 configure_args="
- -DCMAKE_BUILD_TYPE=Release
+ -DENABLE_LINKER_BUILD_ID=ON
+ -DLLDB_USE_SYSTEM_SIX=ON
  -DLLVM_INSTALL_UTILS=ON
+ -DLLVM_BUILD_DOCS=ON
  -DLLVM_BUILD_LLVM_DYLIB=ON
  -DLLVM_LINK_LLVM_DYLIB=ON
  -DLLVM_ENABLE_RTTI=ON
  -DLLVM_ENABLE_FFI=ON
  -DLLVM_BINUTILS_INCDIR=/usr/include"
-hostmakedepends="groff perl python3 zlib-devel libffi-devel swig"
+# TODO: configure_args+=" -DLLVM_ENABLE_SPHINX=ON"
+_projects="clang clang-tools-extra compiler-rt lld lldb"
+hostmakedepends="groff perl python3 python3-Sphinx zlib-devel libffi-devel swig"
 makedepends="python3-devel zlib-devel libffi-devel libedit-devel
  libxml2-devel binutils-devel libatomic-devel"
 depends="libllvm11"
@@ -20,20 +25,8 @@ short_desc="Low Level Virtual Machine"
 maintainer="q66 <daniel@octaforce.org>"
 license="NCSA"
 homepage="https://www.llvm.org"
-distfiles="
- https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/llvm-${version}.src.tar.xz
- https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/lldb-${version}.src.tar.xz
- https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/lld-${version}.src.tar.xz
- https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/clang-${version}.src.tar.xz
- https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/clang-tools-extra-${version}.src.tar.xz
- https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/compiler-rt-${version}.src.tar.xz"
-checksum="
- 913f68c898dfb4a03b397c5e11c6a2f39d0f22ed7665c9cefa87a34423a72469
- 8570c09f57399e21e0eea0dcd66ae0231d47eafc7a04d6fe5c4951b13c4d2c72
- efe7be4a7b7cdc6f3bcf222827c6f837439e6e656d12d6c885d5c8a80ff4fd1c
- 0f96acace1e8326b39f220ba19e055ba99b0ab21c2475042dbc6a482649c5209
- fed318f75d560d0e0ae728e2fb8abce71e9d0c60dd120c9baac118522ce76c09
- 374aff82ff573a449f9aabbd330a5d0a441181c535a3599996127378112db234"
+distfiles="https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/llvm-project-${version}.src.tar.xz"
+checksum="74d2529159fd118c3eac6f90107b5611bccc6f647fdea104024183e8d5e25831"
 lib32disabled=yes
 python_version=3
 
@@ -55,80 +48,39 @@ if [ "$_lldb_enable" = "yes" ]; then
 fi
 subpackages+=" lld lld-devel"
 
+_apply_patches() {
+	local project=$1
+
+	for i in ${FILESDIR}/patches/${project}/*.patch; do
+		msg_normal "Applying ${i/${FILESDIR}\//} to ${project}\n"
+		patch -sNp1 -d ${wrksrc}/${project} -i ${i}
+	done
+}
+
 post_patch() {
-	# patches
-	cd ${XBPS_BUILDDIR}/llvm-${version}.src
-	for i in ${FILESDIR}/patches/llvm/llvm-*.patch; do
-		msg_normal "Applying $i to llvm\n"
-		patch -sNp1 -i ${i}
-	done
-
-	cd ${XBPS_BUILDDIR}/clang-${version}.src
-	for i in ${FILESDIR}/patches/clang/clang-*.patch; do
-		msg_normal "Applying $i to clang\n"
-		patch -sNp1 -i ${i}
-	done
-
-	cd ${XBPS_BUILDDIR}/lld-${version}.src
-	for i in ${FILESDIR}/patches/lld/lld-*.patch; do
-		msg_normal "Applying $i to lld\n"
-		patch -sNp1 -i ${i}
+	for project in llvm clang lld lldb; do
+		_apply_patches ${project}
 	done
 
 	case "$XBPS_TARGET_MACHINE" in
 	armv5*)
-		cd ${XBPS_BUILDDIR}/compiler-rt-${version}.src
-		for i in ${FILESDIR}/patches/compiler-rt/compiler-rt-*.patch; do
-			msg_normal "Applying $i to compiler-rt\n"
-			patch -sNp1 -i ${i}
-		done
-		;;
+		_apply_patches compiler-rt ;;
 	esac
 
-	if [ "$_lldb_enable" = "yes" ]; then
-		cd ${XBPS_BUILDDIR}/lldb-${version}.src
-		for i in ${FILESDIR}/patches/lldb/*.patch; do
-			msg_normal "Applying $i to lldb\n"
-			patch -sNp1 -i ${i}
-		done
-		case "$XBPS_TARGET_MACHINE" in
-			*-musl) sed -i 's|__ptrace_request|int|g' source/Plugins/Process/Linux/NativeProcessLinux.cpp ;;
-		esac
-	fi
+	case "$XBPS_TARGET_MACHINE" in
+		*-musl) sed -i 's|__ptrace_request|int|g' ${wrksrc}/lldb/source/Plugins/Process/Linux/NativeProcessLinux.cpp
+			;;
+	esac
 
-	# Move clang files into the llvm source.
-	if [ -d ${XBPS_BUILDDIR}/clang-${version}.src ]; then
-		mv ${XBPS_BUILDDIR}/clang-${version}.src ${wrksrc}/tools/clang
-	fi
-	# Move clang-tools-extra files into llvm source.
-	if [ -d ${XBPS_BUILDDIR}/clang-tools-extra-${version}.src ]; then
-		mv ${XBPS_BUILDDIR}/clang-tools-extra-${version}.src ${wrksrc}/tools/clang/tools/extra
-	fi
-	# Move lld files into the llvm source.
-	if [ -d ${XBPS_BUILDDIR}/lld-${version}.src ]; then
-		mv ${XBPS_BUILDDIR}/lld-${version}.src ${wrksrc}/tools/lld
-	fi
-	# Move lldb files into the llvm source.
-	if [ -d ${XBPS_BUILDDIR}/lldb-${version}.src ]; then
-		if [ "$_lldb_enable" = "yes" ]; then
-			mv ${XBPS_BUILDDIR}/lldb-${version}.src ${wrksrc}/tools/lldb
-		else
-			rm -rf ${XBPS_BUILDDIR}/lldb-${version}.src
-		fi
-	fi
-	# Move compiler-rt files into the llvm source.
-	if [ -d ${XBPS_BUILDDIR}/compiler-rt-${version}.src ]; then
-		mv ${XBPS_BUILDDIR}/compiler-rt-${version}.src ${wrksrc}/projects/compiler-rt
-	fi
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl)
 			# Disable sanitizers
-			sed -i 's/set(COMPILER_RT_HAS_SANITIZER_COMMON TRUE)/set(COMPILER_RT_HAS_SANITIZER_COMMON FALSE)/' ${wrksrc}/projects/compiler-rt/cmake/config-ix.cmake
+			sed -i 's/set(COMPILER_RT_HAS_SANITIZER_COMMON TRUE)/set(COMPILER_RT_HAS_SANITIZER_COMMON FALSE)/' ${wrksrc}/compiler-rt/cmake/config-ix.cmake
 			;;
 	esac
 
 	# update config.guess for better platform detection
-	cp $XBPS_COMMONDIR/environment/configure/automake/config.guess ${wrksrc}/cmake
+	cp $XBPS_COMMONDIR/environment/configure/automake/config.guess ${wrksrc}/llvm/cmake
 }
 
 pre_configure() {
@@ -145,16 +97,19 @@ pre_configure() {
 
 	if [ "$CROSS_BUILD" ]; then
 		msg_normal "Building host tblgen\n"
-		mkdir -p build/HOST
-		cd build/HOST
+		mkdir -p build/HOST && pushd build/HOST
 		CC="$BUILD_CC" CXX="$BUILD_CXX" CFLAGS="$BUILD_CFLAGS" \
 			CXXFLAGS="$BUILD_CXXFLAGS" LDFLAGS="$BUILD_LDFLAGS" \
-			cmake ../.. -DCMAKE_BUILD_TYPE=Release
+			cmake ../.. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS=clang
 		make ${makejobs} -C utils/TableGen
 		make ${makejobs} -C tools/clang/utils/TableGen
-		configure_args+=" -DLLVM_TABLEGEN=${wrksrc}/build/HOST/bin/llvm-tblgen"
-		configure_args+=" -DCLANG_TABLEGEN=${wrksrc}/build/HOST/bin/clang-tblgen"
-		cd ../..
+		configure_args+=" -DLLVM_TABLEGEN=$PWD/bin/llvm-tblgen"
+		configure_args+=" -DCLANG_TABLEGEN=$PWD/bin/clang-tblgen"
+		popd
+	fi
+
+	if [ "$_lldb_enable" != "yes" ]; then
+		_projects=${_projects/lldb/}
 	fi
 
 	case "$XBPS_TARGET_MACHINE" in
@@ -169,7 +124,7 @@ pre_configure() {
 	esac
 	configure_args+=" -DLLVM_TARGET_ARCH=${_arch}"
 	configure_args+=" -DLLVM_HOST_TRIPLE=${XBPS_CROSS_TRIPLET:-$XBPS_TRIPLET}"
-	configure_args+=" -DLLVM_DEFAULT_TARGET_TRIPLE=${XBPS_CROSS_TRIPLET:-$XBPS_TRIPLET}"
+	configure_args+=" -DLLVM_ENABLE_PROJECTS=${_projects// /\;}"
 }
 
 do_install() {
@@ -177,9 +132,6 @@ do_install() {
 
 	cd build
 	cmake -DCMAKE_INSTALL_PREFIX=${DESTDIR}/usr -P cmake_install.cmake
-
-	# Fix permissions of static libs
-	chmod -x ${DESTDIR}/usr/lib/*.a
 
 	# Required for multilib.
 	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
@@ -298,8 +250,6 @@ lldb_package() {
 		vmove usr/bin/*lldb*
 		vmove usr/lib/liblldb*so.*
 		vmove /usr/lib/python*
-		# Depend on python3-six instead of conflicting
-		rm ${PKGDESTDIR}/usr/lib/python3*/site-packages/six.py
 	}
 }
 

--- a/srcpkgs/llvm11/update
+++ b/srcpkgs/llvm11/update
@@ -1,2 +1,3 @@
-site=https://releases.llvm.org/
-pattern="'\K[\d\.]*(?=')"
+site="https://github.com/llvm/llvm-project/releases"
+pattern="llvmorg-\K(\d+.){2}\d+(-rc\d+)?"
+ignore="*-rc*"


### PR DESCRIPTION
Also:
- Clean up template.
- Update `srcpkgs/llvm11/update` due to #29429.

Fixes: #28609.
Fixes: #17935.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
- [x] I built this PR locally for my native architecture, x86_64-musl
- [x] I built this PR locally for these architectures (TODO):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
  - [ ] ppc-musl
  - [ ] ppc
  - [ ] ppcle-musl
  - [ ] ppcle
  - [ ] ppc64-musl
  - [ ] ppc64
  - [ ] ppc64le-musl
  - [ ] ppc64le

Currently, the documentation fails to build:
```
[2824/5792] Generating man Sphinx documentation for clang-tools into "/builddir/llvm-project-11.1.0.src/llvm/build/tools/clang/tools/extra/docs/man"
FAILED: tools/clang/tools/extra/docs/CMakeFiles/docs-clang-tools-man 
cd /builddir/llvm-project-11.1.0.src/llvm/build/tools/clang/tools/extra/docs && /usr/bin/sphinx-build -b man -d /builddir/llvm-project-11.1.0.src/llvm/build/tools/clang/tools/extra/docs/_doctrees-clang-tools-man -q -t builder-man -W /builddir/llvm-project-11.1.0.src/clang-tools-extra/docs /builddir/llvm-project-11.1.0.src/llvm/build/tools/clang/tools/extra/docs/man

Warning, treated as error:
/builddir/llvm-project-11.1.0.src/clang-tools-extra/docs/clang-tidy/Integrations.rst::"table cell spanning" not supported
```

### List of packages to rebuild:
H = hostmakedepends, M = makedepends, C = checkdepends:
- [ ] 0ad: H=*clang*
- [ ] afl: H=*clang*,*llvm*
- [ ] ardour: H=*clang*
- [ ] bat: H=*clang*,*llvm*
- [ ] bcc: M=*clang*,*clang-tools-extra*,*lld-devel*,*llvm*
- [ ] beignet: H=*clang*,*llvm*
- [ ] blender: M=*llvm*
- [ ] bpftrace: M=*clang*,*clang-tools-extra*,*llvm*
- [ ] ccls: H=*clang-tools-extra* M=*clang-tools-extra*,*llvm*
- [ ] chromium: H=*clang*
- [ ] clazy: M=*clang*,*llvm* D=*clang*
- [ ] codelite: H=*clang* M=*lldb-devel*
- [ ] deadbeef: H=*clang*
- [ ] discord-ptb: D=*libcxx*
- [ ] discord: D=*libcxx*
- [ ] electron10: H=*clang*
- [ ] electron9: H=*clang*
- [ ] faust: H=*llvm* M=*llvm-libunwind-devel*
- [ ] firefox-esr: H=*llvm*,*clang*
- [ ] firefox: H=*llvm*,*clang*
- [ ] ghdl: M=*llvm11*
- [ ] gnome-builder: H=*llvm* M=*clang*
- [ ] godot: H=*clang*
- [ ] hedgewars: H=*clang*
- [ ] hfsprogs: H=*clang*
- [ ] include-what-you-use: M=*clang*,*clang-tools-extra*,*llvm*
- [ ] ispc: H=*clang*,*clang-tools-extra*,*llvm*
- [ ] juCi++: M=*clang*
- [ ] kdevelop: H=*llvm* M=*clang*
- [ ] ldc: H=*llvm11*
- [ ] mesa: H=*llvm* clang M=*clang*,*libclc* D=*libclc*
- [ ] meson: C=*clang*,*llvm*
- [ ] mozjs78: H=*llvm*,*clang*
- [ ] multitail: H=*clang-analyzer*
- [ ] pijul: H=*clang*
- [ ] qt5-doc: H=*clang*
- [ ] qt5: H=*clang*
- [ ] qtcreator: H,M=*clang*,*llvm*
- [ ] qv4l2: H=*clang*
- [ ] rdedup: H=*clang*
- [ ] rtags: H=*clang* M=*llvm*
- [ ] rust: H=*llvm11* M=*llvm11*
- [ ] shiboken2: M=*clang* D=*clang*
- [ ] thunderbird: H=*llvm*,*clang*
- [ ] zig: M=*clang*,*llvm11*,*lld-devel*

[ci skip]