### PR TITLE
.github/workflows: Pull masterdirs from ghcr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
     if: "!contains(github.event.pull_request.title, '[ci skip]') && !contains(github.event.pull_request.body, '[ci skip]')"
 
     container:
-      image: 'voidlinux/masterdir-${{ matrix.config.bootstrap }}:20200607RC01'
+      image: 'ghcr.io/void-linux/xbps-src-masterdir:20210313rc01-${{ matrix.config.bootstrap }}'
       env:
         PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
         ARCH: '${{ matrix.config.arch }}'


### PR DESCRIPTION
The new masterdirs are significantly updated, and additionally are hosted within GHCR, which should dramatically improve cache and pull performance.  These are after the libressl => openssl cutover so it should also save us a lot of build time in the setup phase because the chroot won't be installing that one update over and over.