### PR TITLE
cups: update to 2.3.3op2.

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,6 +1,6 @@
 # Template file for 'cups'
 pkgname=cups
-version=2.3.3
+version=2.3.3op2
 revision=1
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
@@ -14,9 +14,9 @@ depends="xdg-utils"
 short_desc="Common Unix Printing System"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
-homepage="https://www.cups.org/"
-distfiles="https://github.com/apple/cups/releases/download/v${version}/cups-${version}-source.tar.gz"
-checksum=261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee
+homepage="https://github.com/OpenPrinting/cups"
+distfiles="https://github.com/OpenPrinting/cups/releases/download/v${version}/cups-${version}-source.tar.gz"
+checksum=deb3575bbe79c0ae963402787f265bfcf8d804a71fc2c94318a74efec86f96df
 
 conf_files="/etc/pam.d/cups /etc/cups/*.conf /etc/xinetd.d/cups-lpd"
 make_dirs="

--- a/srcpkgs/cups/update
+++ b/srcpkgs/cups/update
@@ -1,2 +1,2 @@
-site=https://github.com/apple/cups/releases
+site=https://github.com/OpenPrinting/cups/releases
 ignore="*b* *rc*"


### PR DESCRIPTION
Switch to the latest openprinting release, available at https://github.com/OpenPrinting/cups.
This has fixed a lot of issues around ipp-everywhere printers for me, but may need a little more testing with different setups.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
