### PR TITLE
hledger: update to 1.21

### DIFF
--- a/srcpkgs/hledger/template
+++ b/srcpkgs/hledger/template
@@ -1,6 +1,6 @@
 # Template file for 'hledger'
 pkgname=hledger
-version=1.20.4
+version=1.21
 revision=1
 build_style=haskell-stack
 makedepends="zlib-devel ncurses-devel"
@@ -10,15 +10,12 @@ license="GPL-3.0-or-later"
 homepage="http://hledger.org/"
 changelog="https://hackage.haskell.org/package/hledger-${version}/changelog"
 distfiles="https://github.com/simonmichael/${pkgname}/archive/${version}.tar.gz"
-checksum=1213854ee7cf94913652706139b4c7f619af4394f5e70856b859f3c0ed07b2a4
+checksum=55a83947852ff088b244447ae0d0d96b8902d867b9b0773ebd1dab2e64e98ecd
 nopie_files="/usr/bin/hledger"
 nocross=yes # Can't yet cross compile Haskell
 
 post_install() {
 	vman hledger/hledger.1
-	for manpage in hledger-lib/*.5; do
-		vman $manpage
-	done
 }
 
 hledger-ui_package() {


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
- [X] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

#### Remarks
Removed installation of .5 man pages, since they have been removed upstream in https://github.com/simonmichael/hledger/commit/a7e9e9ac0ecb29a57a2e543c313a5f79b921d6de
