### PR TITLE
runit-void: update to 20210314.

### DIFF
--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,6 +1,6 @@
 # Template file for 'runit-void'
 pkgname=runit-void
-version=20200720
+version=20210314
 revision=1
 wrksrc="void-runit-${version}"
 build_style=gnu-makefile
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="CC0-1.0"
 homepage="https://github.com/void-linux/void-runit"
 distfiles="https://github.com/void-linux/void-runit/archive/${version}.tar.gz"
-checksum=706ed491315bd75b4b4ca07bc04af97369f8ef8820e9fa1931dae6939ea2e2db
+checksum=9ac95a14b5e1aedfcf0b093b8992b08316448ac1afb7fd26501ac43c4ebf3847
 
 depends="virtual?awk procps-ng runit"
 conf_files="


### PR DESCRIPTION
Fixes since last tag:
* core-services/00-pseudofs
  - Configurable v1/v2/hybrid cgroup mounts
* core-services/03-filesystems
  - Respect auto-activation when activating LVM devices
  - Load any needed encryption keys when mounting ZFS datasets
* vlogger(8)
  - Behave like logger(1) when arvg[0] is "logger"
  - Pass empty tag to /etc/vlogger when tag is NULL
  - Default to daemon.notice if linked as runit log service
* halt(8)
  - Relax argv[0] comparisons when determining behavior
* services/agetty-generic
  - Use `chpst -P` to avoid backgrounding session leaders
* modules-load
  - Use global substitution to replace all commas in /proc/cmdline
* Documentation fixes