### PR TITLE
efibootmgr: fix post-remove kernel hook

### DIFF
--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-remove
@@ -18,4 +18,4 @@ major_version=$(echo $PKGNAME | cut -c 6-)
 hexnum=$(efibootmgr | grep "Void Linux with kernel ${major_version}" | cut -c "5-8")
 
 # delete it
-efibootmgr -Bq -b $hexnum
+[ "$hexnum" ] && efibootmgr -Bq -b $hexnum

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=17
-revision=5
+revision=6
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel popt-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"


### PR DESCRIPTION
Don't attempt to delete nonexistent UEFI entries from previous kernel versions.
Fixes #13133

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
