### PR TITLE
mbuffer: fix use-after-free.

### DIFF
--- a/srcpkgs/mbuffer/patches/0001-mbuffer-don-t-cancel-ReaderThr.patch
+++ b/srcpkgs/mbuffer/patches/0001-mbuffer-don-t-cancel-ReaderThr.patch
@@ -1,0 +1,33 @@
+Subject: [PATCH] mbuffer: don't cancel ReaderThr.
+
+joinSenders is called after ReaderThr has been joined, which makes the
+pthread_cancel call in cancelAll undefined behavior and a case of
+use-after-free. Since the thread will already have been joined in main
+by the time joinSenders is called, there is no need to cancel it, so
+that call can simply be removed.
+
+Furthermore, we don't have to account for situations where pthread_join
+can fail, because this program doesn't generate them. If there were
+other threads which tried to join readerThr at the same time, a
+successful pthread_join call should also set Status=0, so pthread_cancel
+isn't called. However, that isn't necessary.
+---
+ mbuffer.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/mbuffer.c b/mbuffer.c
+index 79c997f..6e65277 100644
+--- a/mbuffer.c
++++ b/mbuffer.c
+@@ -166,8 +166,6 @@ static void cancelAll(void)
+ 			d->result = "canceled";
+ 		d = d->next;
+ 	} while (d);
+-	if (Status)
+-		(void) pthread_cancel(ReaderThr);
+ }
+ 
+ 
+-- 
+2.30.2
+

--- a/srcpkgs/mbuffer/template
+++ b/srcpkgs/mbuffer/template
@@ -1,7 +1,7 @@
 # Template file for 'mbuffer'
 pkgname=mbuffer
 version=20210209
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="openssl-devel"
 checkdepends="tar"
@@ -11,4 +11,5 @@ license="GPL-3.0-or-later"
 homepage="https://www.maier-komor.de/mbuffer.html"
 distfiles="https://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz"
 checksum=e81f2788e2621f20f848181ef2cb19ac6d12328691437f301574b253fd899a0c
+patch_args=-Np1
 conf_files="/etc/mbuffer.rc"


### PR DESCRIPTION
Fixes segfault on musl when killed with SIGINT.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
