### PR TITLE
Cross compile (missing) kodi addons

### DIFF
--- a/srcpkgs/kodi-addon-peripheral-joystick/template
+++ b/srcpkgs/kodi-addon-peripheral-joystick/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi-addon-peripheral-joystick'
 pkgname=kodi-addon-peripheral-joystick
 version=1.7.1
-revision=1
+revision=2
 _kodi_release="Matrix"
 wrksrc="peripheral.joystick-${version}-${_kodi_release}"
 build_style=cmake
@@ -13,4 +13,8 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/xbmc/peripheral.joystick"
 distfiles="https://github.com/xbmc/peripheral.joystick/archive/${version}-${_kodi_release}.tar.gz"
 checksum=4dc63c6c5bdad25881eeba800765d97c53b2583addf28e71bbcd67775452ecdb
-nocross="depends on kodi-platform"
+
+if [ -n "${CROSS_BUILD}" ]; then
+	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"
+	configure_args+=" -DKODI_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include/kodi"
+fi

--- a/srcpkgs/kodi-binary-addons/template
+++ b/srcpkgs/kodi-binary-addons/template
@@ -1,14 +1,13 @@
 # Template file for 'kodi-binary-addons'
 pkgname=kodi-binary-addons
-version=18.6
-revision=2
+version=19.0
+revision=1
 build_style=meta
 depends="kodi-addon-pvr-zattoo kodi-addon-game-libretro
  kodi-addon-peripheral-joystick kodi-addon-inputstream-rtmp
  kodi-addon-inputstream-adaptive kodi-addon-pvr-hts kodi-addon-pvr-iptvsimple
- kodi-addon-vfs-rar"
+ kodi-addon-vfs-sftp kodi-addon-vfs-rar"
 short_desc="Meta-package for binary kodi addons"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="metapackage"
+license="Public Domain"
 homepage="https://kodi.tv"
-nocross="addons can't be cross-compiled yet"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
