### PR TITLE
kodi: enable cross compilation for 32bit arm architectures

### DIFF
--- a/srcpkgs/kodi/template
+++ b/srcpkgs/kodi/template
@@ -42,7 +42,7 @@ fi
 
 lib32disabled=yes
 archs="i686* x86_64* aarch64*
- ppc64*"
+ ppc64* armv6l* armv7l*"
 
 hostmakedepends="
  automake libtool pkg-config gperf cmake gettext zip unzip nasm yasm python3-devel
@@ -60,7 +60,7 @@ makedepends="
  giflib-devel libxslt-devel gnutls-devel libssh-devel libmicrohttpd-devel
  libcec-devel dcadec-devel flatbuffers-devel fmt-devel lcms2-devel
  libfstrcmp-devel rapidjson libcdio-paranoia spdlog libwaylandpp-devel
- libinput-devel libdav1d-devel gtest-devel"
+ libinput-devel libdav1d-devel gtest-devel python3-devel"
 
 # The following dependencies are dlopen(3)ed.
 depends="libbluray libmad libvorbis libcurl libflac libmodplug libass libmpeg2
@@ -81,12 +81,6 @@ _gtest_filter+=":TestWebServer.CanGetRangedFileRangeFirstSecond"
 _gtest_filter+=":TestWebServer.CanGetRangedFileRangeFirstSecondLast"
 
 case "$XBPS_TARGET_MACHINE" in
-	aarch64*)
-		hostmakedepends+=" libmariadbclient-devel SDL2_image-devel lzo-devel"
-		hostmakedepends+=" libwaylandpp-devel"
-		makedepends+=" python3-devel ffmpeg-devel"
-		configure_args+=" -DENABLE_VAAPI=OFF"
-		;;
 	i686)
 		# Additionaly disable these tests on i686 architecutre
 		# https://github.com/void-linux/void-packages/commit/3c0332ab330e30a2c280de2258ed9bf60a9c2e09/checks/2101961301/logs
@@ -98,6 +92,15 @@ esac
 
 if [ -z "$CROSS_BUILD" ]; then
 	make_build_target+=" kodi-test"
+else
+	hostmakedepends+=" libmariadbclient-devel SDL2_image-devel lzo-devel
+	 libwaylandpp-devel"
+fi
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	configure_args+=" -DCMAKE_EXE_LINKER_FLAGS=-latomic"
+	LDFLAGS+=" -latomic"
 fi
 
 pre_configure() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
