### PR TITLE
serd: disable test coverage

### DIFF
--- a/srcpkgs/serd/template
+++ b/srcpkgs/serd/template
@@ -11,7 +11,7 @@ distfiles="http://download.drobilla.net/${pkgname}-${version}.tar.bz2"
 checksum=affa80deec78921f86335e6fc3f18b80aefecf424f6a5755e9f2fa0eb0710edf
 
 if [ "${XBPS_CHECK_PKGS}" ]; then
-	configure_args+=" --test"
+	configure_args+=" --test --no-coverage"
 fi
 
 do_check() {


### PR DESCRIPTION
just a small change to get rid of these error messages during check :)
```
Failed to run lcov to clear old coverage data ([Errno 2] No such file or directory: 'lcov')
...
Failed to run lcov to generate coverage report (%s)
```

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
