### PR TITLE
xfce4-time-out-plugin: update to 1.1.2.

### DIFF
--- a/srcpkgs/xfce4-time-out-plugin/template
+++ b/srcpkgs/xfce4-time-out-plugin/template
@@ -1,7 +1,7 @@
 # Template file for 'xfce4-time-out-plugin'
 pkgname=xfce4-time-out-plugin
-version=1.1.1
-revision=2
+version=1.1.2
+revision=1
 build_style=gnu-configure
 configure_args="--with-locales-dir=/usr/share/locale"
 hostmakedepends="pkg-config intltool"
@@ -12,4 +12,4 @@ license="GPL-2.0-or-later"
 homepage="https://goodies.xfce.org/projects/panel-plugins/xfce4-time-out-plugin"
 changelog="https://gitlab.xfce.org/panel-plugins/xfce4-time-out-plugin/-/raw/master/NEWS"
 distfiles="https://archive.xfce.org/src/panel-plugins/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=194dbeb8751d8aaedf3850a7a9c770f09d32316a99683cde34d7d0fc5bdba31d
+checksum=3dd8eba694ff3ba5c25bd7f5cd70dc22175fb2c0a759213f05ab8f0e629d82d4


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
