### PR TITLE
btrfs-progs: update to 5.11

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1452,6 +1452,7 @@ libvlc_pulse.so.0 libvlc-3.0.2_1
 libvlc_xcb_events.so.0 libvlc-3.0.2_1
 libcmocka.so.0 cmocka-1.1.1_1
 libbtrfs.so.0 libbtrfs-3.12_1
+libreiserfscore.so.0 reiserfsprogs-3.6.27_3
 libbtrfsutil.so.1 libbtrfsutil-5.4_1
 libecore_audio.so.1 efl-1.25.1_2
 libecore_con.so.1 efl-1.25.1_2

--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,33 +1,35 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=5.9
+version=5.12.1
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=gnu-configure
 make_check_target=test
 configure_args="--disable-backtrace --disable-python"
 hostmakedepends="asciidoc pkg-config xmlto"
-makedepends="acl-devel e2fsprogs-devel libzstd-devel lzo-devel"
-checkdepends="acl-progs e2fsprogs tar xz which eudev"
+makedepends="acl-devel libzstd-devel lzo-devel libblkid-devel libuuid-devel
+ $(vopt_if e2fs 'e2fsprogs-devel') $(vopt_if reiserfs 'reiserfsprogs')
+ zlib-devel"
 short_desc="Btrfs filesystem utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only, LGPL-3.0-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/${pkgname}/${pkgname}-v${version}.tar.xz"
-checksum=b89358a665ad753ecbdff11d2be77d230d2b197bb3c7e0eb739fb979c087a791
+checksum=950846fea454fb4b1c39f0fa454983644572df91df5c06047b335bf2d5473759
+# Most of the tests depend on `mount` and `fallocate` commands, which are not
+# presented in chroot-util-linux
+make_check=no
+
+build_options="reiserfs e2fs"
+build_options_default="e2fs"
+desc_option_reiserfs="Enable support for converting reiserfs disk to btrfs"
+desc_option_e2fs="Enable support for converting ext2/3/4 disk to btrfs"
 
 pre_build() {
 	if [ $CROSS_BUILD ]; then
 		${BUILD_CC} ${BUILD_CFLAGS} kernel-lib/mktables.c -o mktables
 	fi
-}
-
-pre_check() {
-	# Requires losetup which is part of util-linux, but even with it installed it fails
-	rm -rf -- tests/mkfs-tests/017-small-backing-size-thin-provision-device
-	# Requires fallocate from util-linux
-	rm -rf -- tests/fsck-tests/025-file-extents
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

Taken over and closes #28153
Why do we disable Python bindings for `libbtrfsutil`?
I gave up half way through cherry-picking tests to disable :) Most of them fail without `mount` command from util-linux.
Welcome other for battle test.

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
