### PR TITLE
jamulus: update to 3.7.0

### DIFF
--- a/srcpkgs/jamulus/template
+++ b/srcpkgs/jamulus/template
@@ -1,6 +1,6 @@
 # Template file for 'jamulus'
 pkgname=jamulus
-version=3.6.2
+version=3.7.0
 revision=1
 _version=r${version//./_}
 wrksrc=${pkgname}-${_version}
@@ -13,4 +13,4 @@ maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://jamulus.io"
 distfiles="https://github.com/corrados/jamulus/archive/${_version}.tar.gz"
-checksum=6bea992f0e4b6a9d08104f8ad9d42b630d523da258e201f70418cecda1c11dac
+checksum=4c7469f29d23725216529f936136d2e7eee68139610f4a7016e01655426e216e


### PR DESCRIPTION
Update to the 3.7.0 release [here](https://github.com/jamulussoftware/jamulus/releases/tag/r3_7_0)