### PR TITLE
monkey: fix the runit service.

### DIFF
--- a/srcpkgs/monkey/files/monkey/run
+++ b/srcpkgs/monkey/files/monkey/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec chpst -u monkey:monkey monkey
+exec monkey

--- a/srcpkgs/monkey/template
+++ b/srcpkgs/monkey/template
@@ -1,7 +1,7 @@
 # Template file for 'monkey'
 pkgname=monkey
 version=1.6.9
-revision=3
+revision=4
 build_style=configure
 configure_args="--prefix=/usr --sbindir=/usr/bin
  --libdir=/usr/lib$XBPS_TARGET_WORDSIZE/$pkgname


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

`monkey` drops privileges to the default user which is defined in the configure stage correctly as `_monkey`. The chpst invocation uses the wrong user/group (`monkey`), is not needed and fails consistently.



<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
