### PR TITLE
mediainfo: split cli

### DIFF
--- a/srcpkgs/mediainfo-cli
+++ b/srcpkgs/mediainfo-cli
@@ -1,0 +1,1 @@
+mediainfo

--- a/srcpkgs/mediainfo/template
+++ b/srcpkgs/mediainfo/template
@@ -1,12 +1,12 @@
 # Template file for 'mediainfo'
 pkgname=mediainfo
 version=20.09
-revision=1
+revision=2
 wrksrc=MediaInfo
 configure_args="--with-wx-config=wx-config-gtk3"
 hostmakedepends="automake libtool pkg-config"
-makedepends="libmediainfo-devel zlib-devel $(vopt_if GUI wxWidgets-gtk3-devel)"
-depends="$(vopt_if GUI 'desktop-file-utils hicolor-icon-theme')"
+makedepends="libmediainfo-devel zlib-devel wxWidgets-gtk3-devel"
+depends="desktop-file-utils hicolor-icon-theme mediainfo-cli"
 short_desc="Display technical and tag data for video and audio files"
 maintainer="John <me@johnnynator.dev>"
 license="BSD-2-Clause"
@@ -15,15 +15,8 @@ distfiles="https://mediaarea.net/download/source/${pkgname}/${version}/${pkgname
 checksum=39327ef83caa38a96114d1b90654012b9ef727538fe82c37dd67aea2cf4f0f67
 replaces="mediainfo-gui>=0"
 
-build_options="CLI GUI"
-build_options_default="CLI GUI"
-desc_option_CLI="Build CLI version"
-desc_option_GUI="Build GUI version"
-
 do_configure() {
-	local targets="$(vopt_if CLI CLI) $(vopt_if GUI GUI)"
-
-	for d in $targets; do
+	for d in CLI GUI; do
 		cd $wrksrc/Project/GNU/$d
 		autoreconf -fi
 		./configure ${configure_args}
@@ -31,29 +24,29 @@ do_configure() {
 }
 
 do_build() {
-	local targets="$(vopt_if CLI CLI) $(vopt_if GUI GUI)"
-
-	for d in $targets; do
+	for d in CLI GUI; do
 		cd $wrksrc/Project/GNU/$d
 		make ${makejobs}
 	done
 }
 
 do_install() {
-	local targets="$(vopt_if CLI CLI) $(vopt_if GUI GUI)"
+	cd $wrksrc/Project/GNU/GUI
+	make DESTDIR="${DESTDIR}" install
 
-	for d in $targets; do
-		cd $wrksrc/Project/GNU/$d
-		make DESTDIR="${DESTDIR}" install
-	done
-	vlicense ${wrksrc}/License.html
+	vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.svg 644 \
+		usr/share/icons/hicolor/scalable/apps mediainfo.svg
+	vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.png 644 \
+		usr/share/pixmaps mediainfo-gui.png
+	vinstall ${wrksrc}/Project/GNU/GUI/mediainfo-gui.desktop 644 \
+		usr/share/applications
+}
 
-	if [ "$build_option_GUI" ]; then
-		vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.svg 644 \
-			usr/share/icons/hicolor/scalable/apps mediainfo.svg
-		vinstall ${wrksrc}/Source/Resource/Image/MediaInfo.png 644 \
-			usr/share/pixmaps mediainfo-gui.png
-		vinstall ${wrksrc}/Project/GNU/GUI/mediainfo-gui.desktop 644 \
-			usr/share/applications
-	fi
+mediainfo-cli_package() {
+	short_desc+=" - CLI"
+	pkg_install() {
+		cd ${wrksrc}/Project/GNU/CLI
+		make DESTDIR="${PKGDESTDIR}" install
+		vlicense ${wrksrc}/License.html
+	}
 }


### PR DESCRIPTION
Yes, GUI doesn't depend on CLI.
However, I think noone really care about 99KB executable.

Close #29578
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
