### PR TITLE
New package: kleopatra:20.12.3

### DIFF
--- a/srcpkgs/kleopatra/INSTALL.msg
+++ b/srcpkgs/kleopatra/INSTALL.msg
@@ -1,0 +1,11 @@
+Kleopatra is using pinentry for entering passphrases.
+To avoid errors for key-generation, please install one of the following dependencies:
+
+	pinentry-qt (For QT - used by KDE desktops)
+	pinentry-gnome (Gnome)
+	pinentry-gtk2 (For GTK2 desktops)
+
+You have to set it as as default pinentry, for example:
+	echo "pinentry-program /usr/bin/pinentry-qt" > ~/.gnupg/gpg-agent.conf
+
+LogOut and LogIn your user again.

--- a/srcpkgs/kleopatra/template
+++ b/srcpkgs/kleopatra/template
@@ -1,0 +1,20 @@
+# Template file for 'kleopatra'
+pkgname=kleopatra
+version=20.12.3
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules kdoctools qt5-qmake qt5-host-tools kcoreaddons gettext kconfig"
+makedepends="kcmutils-devel AppStream kitemmodels-devel gpgmeqt-devel libkleo-devel kmime-devel"
+depends="gnupg2"
+checkdepends="dbus gnupg2"
+short_desc="Certificate Manager and Unified Crypto GUI"
+maintainer="Justin Jagieniak <justin@jagieniak.net>"
+license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-or-later"
+homepage="https://www.kde.org/applications/utilities/kleopatra/"
+distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
+checksum="bf30f99bc6abd44d512ca8c53a7e81af625db72547a33df5c581101d787feaa0"
+
+do_check() {
+	QT_QPA_PLATFORM=offscreen CTEST_OUTPUT_ON_FAILURE=TRUE \
+		dbus-run-session ninja -C build test
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86-64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

-----------------

- [x] I had an issue with pinentry-qt. I had to insert into `~/.gnupg/gpg-agent.conf` following line:
` pinentry-program /usr/bin/pinentry-qt `

Otherwise kleopatra will throw errors in generating keys. Maybe this can be solved somehow.
According to the packager-README.md of the source files kleopatra doesn't work with pinentry-curses. But VoidLinux is using pinentry-curses per default, so this has to be changed for kleopatra.