### PR TITLE
[wip] pari: add config options

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3963,7 +3963,8 @@ libopenaptx.so.0 libopenaptx-0.2.0_1
 libsimavr.so.1 simavr-1.6_2
 libsimavrparts.so.1 simavr-1.6_2
 libsword-1.8.1.so libsword-1.8.1_6
-libpari-gmp.so.7 pari-2.13.0_1
+libpari-gmp.so.7 pari-2.13.1_2
+libpari-gmp-tls.so.7 pari-2.13.1_2
 libtree-sitter.so.0 tree-sitter-0.19.0_1
 libwayland-client++.so.0 libwaylandpp-0.2.8_1
 libwayland-cursor++.so.0 libwaylandpp-0.2.8_1

--- a/srcpkgs/giac/patches/malloc.patch
+++ b/srcpkgs/giac/patches/malloc.patch
@@ -1,11 +1,11 @@
 --- src/History.cc.orig	2017-10-02 10:23:46.000000000 +0200
 +++ src/History.cc	2017-11-14 15:42:12.119849965 +0100
-@@ -3828,7 +3828,7 @@
+@@ -4352,7 +4352,7 @@
        // mode_s += "Time: ";
        // double t=double(clock());
        // mode_s += xcas::print_DOUBLE_(t/CLOCKS_PER_SEC);
--#ifdef HAVE_MALLOC_H //
-+#if defined HAVE_MALLOC_H && defined __GLIBC__ //
+-#if defined(HAVE_MALLOC_H) && !defined(__MINGW_H)
++#if defined(HAVE_MALLOC_H) && !defined(__MINGW_H) && defined(__GLIBC__)
        struct mallinfo mem=mallinfo();
        double memd=mem.arena+mem.hblkhd;
        mode_s +=xcas::print_DOUBLE_(memd/1048576);

--- a/srcpkgs/giac/template
+++ b/srcpkgs/giac/template
@@ -1,9 +1,10 @@
 # Template file for 'giac'
 pkgname=giac
-version=1.5.0.87
-revision=4
+version=1.7.0.1
+revision=1
 wrksrc="giac-${version%.*}"
 build_style=gnu-configure
+configure_args="--disable-micropy --disable-quickjs"
 makedepends="fltk-devel gmp-devel gsl-devel lapack-devel
  libjpeg-turbo-devel libpng-devel readline-devel mpfr-devel pari-devel"
 depends="desktop-file-utils hicolor-icon-theme"
@@ -12,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www-fourier.ujf-grenoble.fr/~parisse/giac.html"
 distfiles="https://www-fourier.ujf-grenoble.fr/~parisse/debian/dists/stable/main/source/giac_${version%.*}-${version##*.}.tar.gz"
-checksum=bbd6f0aafe373de3c9ed53d21878224e847359fdd9a7cdf9e9096e7c960f10b4
+checksum=385d4192f4217c0edd5884a02761a6d29f63fba50d6628c0775951a1be322269
 
 # need more than 4*65536 stack, see try_parse() in gen.cc line 11812
 LDFLAGS="-Wl,-z,stack-size=2097152"

--- a/srcpkgs/pari/template
+++ b/srcpkgs/pari/template
@@ -1,11 +1,11 @@
 # Template file for 'pari'
 pkgname=pari
 version=2.13.1
-revision=1
+revision=2
 build_style=configure
 build_helper=qemu
 configure_script=./Configure
-configure_args="--prefix=/usr"
+configure_args="--prefix=/usr --with-readline --mt=pthread --with-gmp"
 make_build_target=all
 make_check_target=test-all
 hostmakedepends="perl texlive"
@@ -19,6 +19,8 @@ checksum=81ecf7d70ccdaae230165cff627c9ce2ec297b8f22f9f40742279d85f86dfcb1
 
 build_options="x11"
 build_options_default="x11"
+# reduce speed losses under pthread
+CFLAGS=-flto
 
 post_patch() {
 	# sse2 is not available on all i686


### PR DESCRIPTION
This is such that pari is usable when building sagemath, which requires pthread.

Note: pthread also sets --enable-tls (build the thread-safe version of the library). This tends to slow down the shared library libpari.so by about 25%, so it is suggested to use the static library libpari.a instead. How do I do that?
Arch Linux has `export CFLAGS+=' -flto'`, Alpine has `export CFLAGS="$CFLAGS -flto" # reduce speed losses under pthread`.