### PR TITLE
caerbannog: add missing python3-gpg dependency

### DIFF
--- a/srcpkgs/caerbannog/template
+++ b/srcpkgs/caerbannog/template
@@ -1,10 +1,10 @@
 # Template file for 'caerbannog'
 pkgname=caerbannog
 version=0.3
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="glib-devel"
-depends="libhandy1 libnotify python3-anytree python3-gobject python3-fuzzyfinder"
+depends="libhandy1 libnotify python3-anytree python3-gpg python3-gobject python3-fuzzyfinder"
 short_desc="Frontend for password-store"
 maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
ping maintainer @Piraty 

also, this package isn't in binary repositories for some reason, so this will trigger a build