### PR TITLE
split xwayland from xorg-server

### DIFF
--- a/srcpkgs/xorg-server-common
+++ b/srcpkgs/xorg-server-common
@@ -1,0 +1,1 @@
+xorg-server

--- a/srcpkgs/xorg-server-xwayland
+++ b/srcpkgs/xorg-server-xwayland
@@ -1,1 +1,0 @@
-xorg-server

--- a/srcpkgs/xorg-server-xwayland/template
+++ b/srcpkgs/xorg-server-xwayland/template
@@ -1,0 +1,27 @@
+# Template file for 'xorg-server-xwayland'
+pkgname=xorg-server-xwayland
+version=21.1.1
+revision=1
+wrksrc="xserver-xwayland-$version"
+build_style=meson
+configure_args="-Dipv6=true -Dxvfb=false -Dxdmcp=false -Dxcsecurity=true
+ -Ddri3=true -Dxwayland_eglstream=false -Dglamor=true -Dxkb_dir=/usr/share/X11/xkb
+ -Dxkb_output_dir=/var/lib/xkb"
+hostmakedepends="pkg-config wayland-devel"
+makedepends="nettle-devel libepoxy-devel font-util libXfont2-devel pixman-devel
+ libxkbfile-devel dbus-devel wayland-devel wayland-protocols libtirpc-devel
+ MesaLib-devel libxcb-devel"
+depends="xorg-server-common"
+short_desc="Nested X server that runs as a wayland client"
+maintainer="Paper <paper@tilde.institute>"
+license="MIT"
+homepage="https://xorg.freedesktop.org"
+distfiles="https://gitlab.freedesktop.org/xorg/xserver/-/archive/xwayland-$version/xserver-xwayland-$version.tar.gz"
+checksum=f93c8a92d1f8eabde40713c7af01200a9040b3b73eafba54589732dac0a937fe
+
+post_install() {
+	# protocol.txt is provided by xorg-server-common
+	rm ${DESTDIR}/usr/lib/xorg/protocol.txt
+	rm ${DESTDIR}/usr/share/man/man1/Xserver.1
+	vlicense COPYING
+}

--- a/srcpkgs/xorg-server-xwayland/update
+++ b/srcpkgs/xorg-server-xwayland/update
@@ -1,0 +1,1 @@
+pkgname=xserver-xwayland

--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=1.20.11
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb
@@ -9,16 +9,16 @@ configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Ddmx=true -Dlinux_acpi=true -Dlinux_apm=false -Dsuid_wrapper=true
  -Dxcsecurity=true -Dsystemd_logind=$(vopt_if elogind true false)
  -Dos_vendor=Void -Dglamor=true -Ddri2=true -Ddri3=true -Dglx=true
- -Dxwayland=true"
-hostmakedepends="pkg-config wayland-devel xkbcomp flex"
+ -Dxwayland=false"
+hostmakedepends="pkg-config xkbcomp flex"
 makedepends="MesaLib-devel libXaw-devel libXfont-devel libXfont2-devel
  libXrender-devel libXres-devel libXtst-devel libXv-devel libXxf86dga-devel
  libdmx-devel libepoxy-devel openssl-devel libtirpc-devel libxkbfile-devel
- libxkbui-devel pixman-devel wayland-devel wayland-protocols
- xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel
- xcb-util-wm-devel xkbcomp nettle-devel $(vopt_if elogind 'dbus-devel')"
+ libxkbui-devel pixman-devel xcb-util-image-devel xcb-util-keysyms-devel
+ xcb-util-renderutil-devel xcb-util-wm-devel xkbcomp nettle-devel
+ $(vopt_if elogind 'dbus-devel')"
 # See hw/xfree86/common/xf86Module.h. Only care for the major version.
-depends="xkeyboard-config $(vopt_if elogind 'elogind')"
+depends="xkeyboard-config $(vopt_if elogind 'elogind') xorg-server-common"
 checkdepends="xkeyboard-config"
 short_desc="X11 server from X.org"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -77,13 +77,6 @@ xorg-server-xdmx_package() {
 	}
 }
 
-xorg-server-xwayland_package() {
-	short_desc="Nested X server that runs as a wayland client"
-	pkg_install() {
-		vmove usr/bin/Xwayland
-	}
-}
-
 xorg-server-xnest_package() {
 	short_desc="Nested X server that runs as an X application"
 	pkg_install() {
@@ -106,6 +99,13 @@ xorg-server-xvfb_package() {
 	pkg_install() {
 		vmove usr/bin/Xvfb
 		vmove usr/share/man/man1/Xvfb.1
+	}
+}
+
+xorg-server-common_package() {
+	short_desc+="- common files"
+	pkg_install() {
+		vmove usr/lib/xorg/protocol.txt
 	}
 }
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
xwayland releases were recently split from xorg releases. This PR works well on my system, but some parts should be improved.

@leahneukirchen you are the maintainer of xorg-server, do you want to maintain xwayland too? or @ericonr? (maintainer of wayland)

TODO:
- [x] fiigure out `depends=`
- [x] solve file conflict with xorg-server (`/usr/lib/xorg/protocol.txt`)