### PR TITLE
NetAuth Suite: Update everything to the latest versions.

### DIFF
--- a/srcpkgs/NetAuth-ldap/template
+++ b/srcpkgs/NetAuth-ldap/template
@@ -1,6 +1,6 @@
 # Template file for 'NetAuth-ldap'
 pkgname=NetAuth-ldap
-version=0.2.0
+version=0.2.3
 revision=1
 wrksrc=ldap-$version
 build_style=go
@@ -12,7 +12,7 @@ maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://www.netauth.org/ecosystem/ldap"
 distfiles="https://github.com/netauth/ldap/archive/v$version.tar.gz"
-checksum=581b60475e940efff673edd3a0fb5ab34fef28f4872fc51a0720013f2004c2f0
+checksum=1d75f23197ea869207e8895cfaadde2c536f279eb26ddb8256642f5babece7e7
 system_accounts="_netauth_ldap"
 
 post_install() {

--- a/srcpkgs/NetAuth-localizer/template
+++ b/srcpkgs/NetAuth-localizer/template
@@ -1,6 +1,6 @@
 # Template file for 'NetAuth-localizer'
 pkgname=NetAuth-localizer
-version=0.1.1
+version=0.1.3
 revision=1
 wrksrc=localizer-$version
 build_style=go
@@ -13,7 +13,7 @@ maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://netauth.org/ecosystem/localizer"
 distfiles="https://github.com/netauth/localizer/archive/v$version.tar.gz"
-checksum=8a7f7b57f7bdb751f9a6b482603b0207577ae54c1e79cb0f7dd8e96730fbdb84
+checksum=63c4d462f90e03b8f4e225afe8cd064fdb54cf1d646c8ec4ff2452dbe2ad55f5
 
 do_check() {
 	go test -v ./...

--- a/srcpkgs/NetAuth-nsscache/template
+++ b/srcpkgs/NetAuth-nsscache/template
@@ -1,6 +1,6 @@
 # Template file for 'NetAuth-nsscache'
 pkgname=NetAuth-nsscache
-version=0.6.3
+version=0.6.5
 revision=1
 wrksrc="nsscache-$version"
 build_style=go
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://netauth.org"
 distfiles="https://github.com/NetAuth/nsscache/archive/v$version.tar.gz"
-checksum=9e29b188166318e1d3aa4a2ddc00501c4419699ed812f34ea1fb73303f4fedfd
+checksum=d5e558d552009d59e5b433a9b96dac7db378412ccebb9dee95216a7a58eab2aa
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/NetAuth-pam-helper/template
+++ b/srcpkgs/NetAuth-pam-helper/template
@@ -1,14 +1,18 @@
 # Template file for 'NetAuth-pam-helper'
 pkgname=NetAuth-pam-helper
-version=0.1.3
+version=0.1.5
 revision=1
 wrksrc=pam-helper-$version
 build_style=go
 go_import_path="github.com/netauth/pam-helper"
 hostmakedepends="git"
-short_desc="A helper executable to use with pam_exec"
-maintainer="Michael Aldridge <maldridge@VoidLinux.org>"
+short_desc="Helper executable to use with pam_exec"
+maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://www.github.com/netauth/pam-helper"
 distfiles="$homepage/archive/v$version.tar.gz"
-checksum=d9b14782a52604a0fc19ffe5164aad5e1580e3bdb015fda0c4b58acdb38049ae
+checksum=1f4fd5e914e6a423ba51911c89b105736b595a2328946e298a31e9dc144d1998
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/NetAuth/template
+++ b/srcpkgs/NetAuth/template
@@ -1,7 +1,7 @@
 # Template file for 'NetAuth'
 pkgname=NetAuth
-version=0.3.4
-revision=5
+version=0.4.1
+revision=1
 wrksrc=netauth-$version
 build_style="go"
 go_import_path="github.com/netauth/netauth"
@@ -9,11 +9,11 @@ go_package="${go_import_path}/cmd/netauth
  ${go_import_path}/cmd/netauthd"
 hostmakedepends="git"
 short_desc="Network authentication and identity system"
-maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://netauth.org"
 distfiles="https://github.com/NetAuth/NetAuth/archive/v$version.tar.gz"
-checksum=76811411d4ebd00876e553b4eb9c912c16ee5ebc5c6aaeab922e233275f56a94
+checksum=0d68df48faa114a96c3e636fbfbd558fbac1f24f59f383be1449eec3a8101a4d
 
 do_check() {
 	go test -v ./...

--- a/srcpkgs/NetKeys/template
+++ b/srcpkgs/NetKeys/template
@@ -1,6 +1,6 @@
 # Template file for 'NetKeys'
 pkgname=NetKeys
-version=0.5.3
+version=0.5.5
 revision=1
 wrksrc=netkeys-$version
 build_style=go
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://netauth.org"
 distfiles="https://github.com/NetAuth/NetKeys/archive/v$version.tar.gz"
-checksum=c7cdcc54a41501c3a40f114aa873668bb78c6ff2bd73c7a1c8c2295a968fc453
+checksum=1a82b2d415b77a63bd1cf7b2f79db454aea11811f268166dc004b75f38b9a791
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/pam_netauth/template
+++ b/srcpkgs/pam_netauth/template
@@ -1,6 +1,6 @@
 # Template file for 'pam_netauth'
 pkgname=pam_netauth
-version=0.3.3
+version=0.3.5
 revision=1
 build_style=go
 go_import_path="github.com/netauth/pam_netauth"
@@ -11,7 +11,7 @@ maintainer="Michael Aldridge <maldridge@netauth.org>"
 license="MIT"
 homepage="https://netauth.org"
 distfiles="https://github.com/NetAuth/pam_netauth/archive/v$version.tar.gz"
-checksum=974bec19c5c50181e72c3cc1ab3089a5d37a753a7147d432dc7d44caa7dfd9f6
+checksum=50e206ee9b542831e1f62e40817e6238d218c5dc95f6e854a9f4267c1e7a3341
 
 do_build() {
 	go build -x -o pam_netauth.so -buildmode=c-shared -ldflags "${go_ldflags}" ${go_import_path}


### PR DESCRIPTION
In draft state until certificates and keys are copied into the right locations to be visible after the switch since they will be resolved relative to the config file, not the data dir.  This removes the need for the data-dir to be present on non-server hosts.