### PR TITLE
openblas: choose generic target for x86 and x86_64.

### DIFF
--- a/srcpkgs/openblas/template
+++ b/srcpkgs/openblas/template
@@ -1,7 +1,7 @@
 # Template file for 'openblas'
 pkgname=openblas
 version=0.3.13
-revision=2
+revision=3
 wrksrc="OpenBLAS-${version}"
 build_style=gnu-makefile
 make_build_args=" HOSTCC=gcc USE_OPENMP=1"
@@ -20,8 +20,8 @@ case "${XBPS_TARGET_MACHINE}" in
 	armv6*) make_build_args+=" TARGET=ARMV6" ;;
 	armv7*) make_build_args+=" TARGET=ARMV7" ;;
 	aarch64*) make_build_args+=" TARGET=ARMV8 DYNAMIC_ARCH=1" ;;
-	i686*) make_build_args+=" BINARY=32 DYNAMIC_ARCH=1" ;;
-	x86_64*) make_build_args+=" BINARY=64 DYNAMIC_ARCH=1" ;;
+	i686*) make_build_args+=" BINARY=32 TARGET=GENERIC DYNAMIC_ARCH=1" ;;
+	x86_64*) make_build_args+=" BINARY=64 TARGET=GENERIC DYNAMIC_ARCH=1" ;;
 	ppc64le*) make_build_args+=" TARGET=POWER8 DYNAMIC_ARCH=1" ;;
 	ppc64*) make_build_args+=" TARGET=PPC970MP" ;; # dynamic arch broken for <power6
 	ppc*) make_build_args+=" TARGET=PPCG4" ;;


### PR DESCRIPTION
The current template uses DYNAMIC_ARCH=1 to get multiple versions of some
functions to support different cpus. However, it will pick up the cpu it was
compiled in as a minimum requirement for the common code.

Adding TARGET=GENERIC fixes this, now the common code is compiled for a generic cpu.

See #29604 and https://github.com/xianyi/OpenBLAS/issues/3139.

<!-- Mark items with [x] where applicable -->


#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
