### PR TITLE
gopass: update to 1.12.4

### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,6 +1,6 @@
 # Template file for 'gopass'
 pkgname=gopass
-version=1.12.0
+version=1.12.4
 revision=1
 build_style=go
 build_helper=qemu
@@ -14,19 +14,13 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/v${version}.tar.gz"
-checksum=73b7c5c8367e664d85871fba88f4fa806ef0fb75047c767a72b8516dea6f64b3
-
-post_build() {
-	gopass=$(find $GOPATH/bin -name gopass)
-	for shell in bash fish zsh; do
-		vtargetrun $gopass completion $shell > completion.$shell
-	done
-}
+checksum=1e3d7ad389a8462256ff7e439de1fbed8012c38ec33bded63b11af74f0525279
 
 post_install() {
 	vlicense LICENSE
+	vman gopass.1
 
 	for shell in bash fish zsh; do
-		vcompletion completion.$shell $shell
+		vcompletion $shell.completion $shell
 	done
 }


### PR DESCRIPTION
The shell completion files are now part of the source tarball and doesn't need to be generated.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR