### PR TITLE
mupen64plus: update to 2.5.9

### DIFF
--- a/srcpkgs/mupen64plus/template
+++ b/srcpkgs/mupen64plus/template
@@ -1,18 +1,19 @@
 # Template file for 'mupen64plus'
 pkgname=mupen64plus
-version=2.5
-revision=13
+version=2.5.9
+revision=1
+nocross="yes"
 wrksrc="mupen64plus-bundle-src-${version}"
-hostmakedepends="pkg-config which"
+hostmakedepends="pkg-config which nasm"
 makedepends="boost-devel SDL2-devel speexdsp-devel freetype-devel glu-devel libpng-devel libsamplerate-devel"
 depends="desktop-file-utils"
-short_desc="A Nintendo64 Emulator"
+short_desc="Nintendo64 Emulator"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="http://www.mupen64plus.org"
 distfiles="https://github.com/mupen64plus/mupen64plus-core/releases/download/${version}/${pkgname}-bundle-src-${version}.tar.gz"
-checksum=9c75b9d826f2d24666175f723a97369b3a6ee159b307f7cc876bbb4facdbba66
-archs="i686* x86_64*"
+checksum=d5243ddc00388ee2e538b3826a78a719dec2bd5da54ac6f3344fed861fb141a8
+nopie=yes
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86-64, libc)

#### Comments
2.5 was wobbling walls and textures in Mario64
Not sure if `nopie` is an issue, first time I've had to add that.

2.5 was from 2015, 2.5.9 is from 2019

edit:
updated linting
no clue on gpl spdx specifics