### PR TITLE
New package: haunt-0.2.4

### DIFF
--- a/srcpkgs/guile-commonmark/template
+++ b/srcpkgs/guile-commonmark/template
@@ -1,0 +1,14 @@
+# Template file for 'guile-commonmark'
+pkgname=guile-commonmark
+version=0.1.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="guile pkg-config"
+makedepends="guile-devel"
+depends="guile"
+short_desc="Guile library for parsing CommonMark"
+maintainer="aliasless <aliasless@quasivoid.net>"
+license="LGPL-3.0-or-later"
+homepage="https://github.com/OrangeShark/guile-commonmark"
+distfiles="https://github.com/OrangeShark/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.gz"
+checksum="56d518ece5e5d94c1b24943366149e9cb0f6abdb24044c049c6c0ea563d3999e"

--- a/srcpkgs/guile-reader/template
+++ b/srcpkgs/guile-reader/template
@@ -1,0 +1,14 @@
+# Template file for 'guile-reader'
+pkgname=guile-reader
+version=0.6.3
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config guile gperf"
+makedepends="lightning guile-devel"
+depends="guile"
+short_desc="Guile-Reader is a simple framework for building readers for GNU Guile"
+maintainer="aliasless <aliasless@quasivoid.net>"
+license="GPL-3.0-or-later"
+homepage="https://www.nongnu.org/guile-reader/"
+distfiles="${NONGNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum="38c2b444eadbb8c0cab78d90a44ec3ebff42bd410c5b84a91018cee7eb64d2bb"

--- a/srcpkgs/haunt/template
+++ b/srcpkgs/haunt/template
@@ -1,0 +1,18 @@
+# Template file for 'haunt'
+pkgname=haunt
+version=0.2.4
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config autoconf automake guile"
+makedepends="guile-devel guile-commonmark guile-reader"
+depends="guile"
+short_desc="Haunt is a simple, functional, hackable static site generator"
+maintainer="aliasless <aliasless@quasivoid.net>"
+license="GPL-3.0-or-later"
+homepage="https://dthompson.us/projects/haunt.html"
+distfiles="https://files.dthompson.us/haunt/${pkgname}-${version}.tar.gz"
+checksum="cce9080a0eca9892613d63ed2514f70bdb180753a2835c4bb603cd19ed27df14"
+
+pre_configure() {
+	autoreconf -fi
+}

--- a/srcpkgs/lightning/template
+++ b/srcpkgs/lightning/template
@@ -1,0 +1,12 @@
+# Template file for 'lightning'
+pkgname=lightning
+version=2.1.3
+revision=1
+build_style=gnu-configure
+depends="zlib"
+short_desc="Library that generates assembly language code at run-time"
+maintainer="aliasless <aliasless@quasivoid.net>"
+license="GPL-3.0-or-later"
+homepage="https://www.gnu.org/software/lightning/"
+distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum="ed856b866dc6f68678dc1151579118fab1c65fad687cf847fc2d94ca045efdc9"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

Building guile-reader appears to fail on non-native architectures. I do not understand why, whether it can be fixed in the template or if its an upstream bug. There appears to have been some mailing list discussion about this some years ago [here](https://lists.gnu.org/archive/html/guile-reader-devel/2017-11/threads.html). Advice is appreciated.
```
checking for scm_take_u8vector... no
configure: error: You need Guile 1.8.x or higher.
=> ERROR: guile-reader-0.6.3_1: do_configure: '${configure_script} ${configure_args}' exited with 1
=> ERROR:   in do_configure() at common/build-style/gnu-configure.sh:8
```