### PR TITLE
python3-pgzero: update to 1.2.1.

### DIFF
--- a/srcpkgs/python3-pgzero/template
+++ b/srcpkgs/python3-pgzero/template
@@ -1,10 +1,9 @@
 # Template file for 'python3-pgzero'
 pkgname=python3-pgzero
-version=1.2
-revision=3
+version=1.2.1
+revision=1
 wrksrc="pgzero-${version}"
 build_style=python3-module
-pycompile_module="pgzero pgzrun.py"
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-pygame python3-numpy"
 short_desc="Zero-boilerplate games programming framework based on Pygame (Python3)"
@@ -12,4 +11,5 @@ maintainer="Peter Bui <pbui@github.bx612.space>"
 license="LGPL-3.0-or-later"
 homepage="https://pygame-zero.readthedocs.io/en/stable/"
 distfiles="${PYPI_SITE}/p/pgzero/pgzero-${version}.tar.gz"
-checksum=91e641d545c6235a24719dea0fd83c8429e92a8b5ab1756bef145128e8db9017
+checksum=8cadc020f028cbac3e0cbd3bb9311a1c045f1deedac7917ff433f986c38e6106
+make_check=no # Tests require video device

--- a/srcpkgs/python3-pygame/template
+++ b/srcpkgs/python3-pygame/template
@@ -1,24 +1,19 @@
 # Template file for 'python3-pygame'
 pkgname=python3-pygame
-version=1.9.6
-revision=4
+version=2.0.1
+revision=1
 wrksrc="pygame-${version}"
 build_style=python3-module
 make_build_args="cython"
 hostmakedepends="pkg-config python3-setuptools python3-Cython
- SDL_mixer-devel SDL_image-devel SDL_ttf-devel libjpeg-turbo-devel portmidi-devel"
-makedepends="python3-devel SDL_mixer-devel SDL_image-devel
- SDL_ttf-devel libjpeg-turbo-devel portmidi-devel"
+ SDL2_mixer-devel SDL2_image-devel SDL2_ttf-devel libjpeg-turbo-devel portmidi-devel"
+makedepends="python3-devel SDL2_mixer-devel SDL2_image-devel
+ SDL2_ttf-devel libjpeg-turbo-devel portmidi-devel"
 short_desc="Collection of Python modules for writing games (Python3)"
 maintainer="Archaeme <normandy@firemail.cc>"
 license="LGPL-2.1-or-later"
 homepage="https://www.pygame.org/"
 distfiles="${PYPI_SITE}/p/pygame/pygame-${version}.tar.gz"
-checksum=301c6428c0880ecd4a9e3951b80e539c33863b6ff356a443db1758de4f297957
+checksum=8b1e7b63f47aafcdd8849933b206778747ef1802bd3d526aca45ed77141e4001
 
 export PORTMIDI_INC_PORTTIME=1
-
-pre_build() {
-	# Remove the C source to re-cythonize, which avoids some API changes
-	rm src_c/pypm.c src_c/_sdl2/{sdl2,audio,video}.c
-}


### PR DESCRIPTION
Also update related dependency **python3-pygame** to 2.0.0.  This now uses **SDL2** rather than **SDL**.  The only package that depends on **python3-pygame** appears to be **pysolfc** and I have tested that it still runs with this update to **python3-pygame**.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
