### PR TITLE
tectonic: update to 0.4.1.

### DIFF
--- a/srcpkgs/tectonic/template
+++ b/srcpkgs/tectonic/template
@@ -1,7 +1,7 @@
 # Template file for 'tectonic'
 pkgname=tectonic
-version=0.3.3
-revision=2
+version=0.4.1
+revision=1
 wrksrc="tectonic-tectonic-${version}"
 build_style=cargo
 hostmakedepends="pkg-config"
@@ -11,7 +11,7 @@ maintainer="Chinmay Pai <chinmaydpai@gmail.com>"
 license="MIT"
 homepage="https://tectonic-typesetting.github.io"
 distfiles="https://github.com/tectonic-typesetting/tectonic/archive/tectonic@${version}.tar.gz"
-checksum=c0aa60186f2e7f37af67dafbdccfc7a99ca5ce084651d8fcabe7561b941dcb97
+checksum=5a2c910f822d59ddaf9d32a0e5f7f34ce30f44e4129513b3a0c50425cf48ac8f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Test failure on i686 reported upstream:
https://github.com/tectonic-typesetting/tectonic/issues/749

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Closes #27969