### PR TITLE
Linting pass 1 of many for SPDX errors, covers all packages starting with digits and a

### DIFF
--- a/srcpkgs/9base/template
+++ b/srcpkgs/9base/template
@@ -1,7 +1,7 @@
-# Template file for '9base'.
+# Template file for '9base'
 pkgname=9base
 version=6.0.20190911
-revision=1
+revision=2
 _githash=63916da7bd6d73d9a405ce83fc4ca34845667cce
 wrksrc="9base-${_githash}"
 build_style=gnu-makefile
@@ -9,10 +9,10 @@ build_style=gnu-makefile
 hostmakedepends="byacc"
 short_desc="Revived minimalist port of Plan 9 userland to Unix"
 maintainer='Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>'
-license="custom"
+license="MIT, custom:LPL-1.02 with exceptions"
 homepage="http://git.suckless.org/9base"
 # Checked out from http://git.suckless.org/9base/ and created tarball with 'git archive'.
-distfiles="https://distfiles.voidlinux.de/9base-${_githash}.tar.gz"
+distfiles="https://sources.voidlinux.org/9base-${version}/9base-${_githash}.tar.gz"
 checksum=bb8cd1e0060824914839fd090353971862a1025ae4b8ea5d1e99618ddd1b160f
 conflicts="plan9port"
 provides="plan9port-20160418_4"

--- a/srcpkgs/aalib/template
+++ b/srcpkgs/aalib/template
@@ -1,14 +1,14 @@
 # Template file for 'aalib'
 pkgname=aalib
 version=1.4rc5
-revision=1
+revision=2
 wrksrc="aalib-1.4.0"
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="Portable ASCII art GFX library"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-2.0-or-later"
 homepage="http://aa-project.sourceforge.net/aalib/"
-license="LGPL-2"
 distfiles="${SOURCEFORGE_SITE}/aa-project/${pkgname}-${version}.tar.gz"
 checksum=fbddda9230cf6ee2a4f5706b4b11e2190ae45f5eda1f0409dc4f99b35e0a70ee
 

--- a/srcpkgs/abook/template
+++ b/srcpkgs/abook/template
@@ -1,14 +1,14 @@
 # Template file for 'abook'
 pkgname=abook
 version=0.6.1
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake libtool gettext gettext-devel tar"
 makedepends="ncurses-devel readline-devel"
-maintainer="Philipp Hirsch <itself@hanspolo.net>"
-license="GPL-2"
-homepage="http://abook.sourceforge.net/"
 short_desc="Text-based addressbook designed to use with mutt mail client"
+maintainer="Philipp Hirsch <itself@hanspolo.net>"
+license="GPL-2.0-or-later"
+homepage="http://abook.sourceforge.net/"
 distfiles="http://abook.sourceforge.net/devel/${pkgname}-${version}.tar.gz"
 checksum=f0a90df8694fb34685ecdd45d97db28b88046c15c95e7b0700596028bd8bc0f9
 

--- a/srcpkgs/abootimg/template
+++ b/srcpkgs/abootimg/template
@@ -1,14 +1,14 @@
 # Template file for 'abootimg'
 pkgname=abootimg
 version=0.6.20160512
-revision=1
+revision=2
 _commit="1ebeb393252ab5aeed62e34bc439b6728444f06e"
-build_style=gnu-makefile
 wrksrc="abootimg-$_commit-$_commit"
+build_style=gnu-makefile
 makedepends="libblkid-devel"
 short_desc="Manipulate Android Boot Images"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://gitorious.org/ac100/abootimg"
 distfiles="https://gitlab.com/ajs124/abootimg/repository/archive.tar.gz?ref=$_commit>archive.tar.gz"
 checksum=36efff208101a8d04cc84085849cda3300cea71f062c8d425c534e5f85f6cc3f

--- a/srcpkgs/advancecomp/template
+++ b/srcpkgs/advancecomp/template
@@ -1,12 +1,12 @@
 # Template file for 'advancecomp'
 pkgname=advancecomp
 version=2.1
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="zlib-devel"
-short_desc="A collection of recompression utilities for ZIP/PNG/GZ"
+short_desc="Command-line recompression utilities for ZIP/PNG/GZ"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.advancemame.it/comp-readme.html"
 distfiles="https://github.com/amadvance/${pkgname}/releases/download/v${version}/${pkgname}-${version}.tar.gz"
 checksum=3ac0875e86a8517011976f04107186d5c60d434954078bc502ee731480933eb8

--- a/srcpkgs/airspy/template
+++ b/srcpkgs/airspy/template
@@ -1,7 +1,7 @@
 # Template file for 'airspy'
 pkgname=airspy
 version=1.0.9
-revision=1
+revision=2
 wrksrc=airspyone_host-${version}
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -9,7 +9,7 @@ makedepends="libusb-devel"
 _desc="Tiny and efficient software defined radio (SDR)"
 short_desc="${_desc} - tools"
 maintainer="bra1nwave <brainwave@openmailbox.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://airspy.com/"
 distfiles="https://github.com/airspy/airspyone_host/archive/v${version}.tar.gz"
 checksum=967ef256596d4527b81f007f77b91caec3e9f5ab148a8fec436a703db85234cc

--- a/srcpkgs/aldo/template
+++ b/srcpkgs/aldo/template
@@ -1,12 +1,12 @@
 # Template file for 'aldo'
 pkgname=aldo
 version=0.7.7
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libao-devel"
 short_desc="Morse code learning tool with four training methods"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.nongnu.org/aldo/"
 distfiles="${NONGNU_SITE}/aldo/aldo-${version}.tar.bz2"
 checksum=f1b8849d09267fff3c1f5122097d90fec261291f51b1e075f37fad8f1b7d9f92

--- a/srcpkgs/an/template
+++ b/srcpkgs/an/template
@@ -1,13 +1,13 @@
 # Template file for 'an'
 pkgname=an
 version=1.2
-revision=6
+revision=7
 build_style=gnu-makefile
 makedepends="icu-devel"
 depends="words-en"
 short_desc="Very fast anagram generator"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/an"
 distfiles="${DEBIAN_SITE}/main/a/an/an_${version}.orig.tar.xz"
 checksum=b925d57d80bd0d83b755f5b8d78e6d5bf05eb059ec84a7d8fbb77b18c73b17a5

--- a/srcpkgs/aoeui/template
+++ b/srcpkgs/aoeui/template
@@ -1,14 +1,14 @@
 # Template file for 'aoeui'
 pkgname=aoeui
 version=1.7
-revision=6
+revision=7
 _githash=4e5dee93ebbaf5bd7bd7da80ce34b2eef196cd08
 wrksrc="${pkgname}-${_githash}"
 build_style=gnu-makefile
 hostmakedepends="m4"
 short_desc="Lightweight UNIX-friendly text editor"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="https://github.com/pklausler/aoeui"
 distfiles="https://github.com/pklausler/aoeui/archive/${_githash}.tar.gz"
 checksum=3b06c7950b0fcbdfe57e78de8cb9b9d7af141932459a32d72a029f96839d667f

--- a/srcpkgs/armagetronad/template
+++ b/srcpkgs/armagetronad/template
@@ -1,7 +1,7 @@
 # Template file for 'armagetronad'
 pkgname=armagetronad
 version=0.2.8.3.5
-revision=1
+revision=2
 build_style=gnu-configure
 conf_files="/etc/games/${pkgname}/*.cfg
  /etc/games/${pkgname}/*.srv"
@@ -11,11 +11,11 @@ makedepends="libX11-devel libxml2-devel libICE-devel libpng-devel glu-devel
  libjpeg-turbo-devel SDL_image-devel SDL_mixer-devel"
 short_desc="3D Lightcycle game from the movie Tron with advanced capabilities"
 maintainer="Toyam Cox <Vaelatern@gmail.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://armagetronad.org"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.src.tar.bz2"
 checksum=1dc3962fc77f4fd64a795ff4e3c02518e2a79bb57f9ed599ba43eff8eb51d2ef
-python_version=2 #unverified
+python_version=2
 
 do_configure() {
 	mkdir build_dedicated

--- a/srcpkgs/arpwatch/template
+++ b/srcpkgs/arpwatch/template
@@ -1,12 +1,12 @@
 # Template file for 'arpwatch'
 pkgname=arpwatch
 version=2.1a15
-revision=2
+revision=3
 build_style=gnu-configure
 makedepends="libpcap-devel"
 short_desc="Ethernet/FDDI station activity monitor"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="BSD"
+license="BSD-3-Clause-LBNL"
 homepage="ftp://ftp.ee.lbl.gov"
 distfiles="ftp://ftp.ee.lbl.gov/$pkgname-$version.tar.gz"
 checksum=c1df9737e208a96a61fa92ddad83f4b4d9be66f8992f3c917e9edf4b05ff5898

--- a/srcpkgs/ascii/template
+++ b/srcpkgs/ascii/template
@@ -1,10 +1,10 @@
 # Template file for 'ascii'
 pkgname=ascii
 version=3.18
-revision=1
+revision=2
 short_desc="List ASCII idiomatic names and octal/decimal code-point forms"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD"
+license="BSD-2-Clause"
 homepage="http://www.catb.org/~esr/ascii"
 distfiles="http://www.catb.org/~esr/ascii/ascii-${version}.tar.gz"
 checksum=728422d5f4da61a37a17b4364d06708e543297de0a5f70305243236d80df072d

--- a/srcpkgs/assimp/template
+++ b/srcpkgs/assimp/template
@@ -1,18 +1,18 @@
 # Template file for 'assimp'
 pkgname=assimp
 version=5.0.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DASSIMP_BUILD_SAMPLES=OFF"
 hostmakedepends="pkg-config"
 makedepends="boost-devel libgomp-devel devil-devel minizip-devel zziplib-devel"
+depends="libassimp>=${version}_${revision}"
 short_desc="Import library for various well-known 3D model formats"
 maintainer="Jürgen Buchmüller <pullmoll@t-online.de>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="http://assimp.sourceforge.net/"
 distfiles="https://github.com/assimp/assimp/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
 checksum=11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc
-depends="libassimp>=${version}_${revision}"
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/at/template
+++ b/srcpkgs/at/template
@@ -1,21 +1,21 @@
 # Template file for 'at'
 pkgname=at
 version=3.1.23
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-jobdir=/var/spool/atd --with-atspool=/var/spool/atd
  --sbindir=/usr/bin --with-daemon_username=at --with-daemon_groupname=at
  SENDMAIL=/usr/sbin/sendmail"
-disable_parallel_build=yes
 hostmakedepends="flex"
 makedepends="pam-devel libfl-devel"
 depends="virtual?smtp-server"
 short_desc="Run commands at a specified time"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://packages.qa.debian.org/a/at.html"
 distfiles="${DEBIAN_SITE}/main/a/${pkgname}/${pkgname}_${version}.orig.tar.gz"
 checksum=97450aa954aaa8a70218cc8e61a33df9fee9f86527e9f861de302fb7a3c81710
+disable_parallel_build=yes
 
 conf_files="/etc/at.deny"
 system_accounts="at"

--- a/srcpkgs/liba52/patches/disable-globals-test.patch
+++ b/srcpkgs/liba52/patches/disable-globals-test.patch
@@ -1,0 +1,17 @@
+Description: Disable globals test
+ The tests makes sense during development to check for erroneously added global
+ symbols, but on a packing level we will catch the using symbols file. So we
+ disable the test. Especially since the test is not able to handle -fPIE as
+ default.
+Author: Sebastian Ramacher <sramacher@debian.org>
+Forwarded: not-needed
+Last-Update: 2017-02-04
+
+--- test/Makefile.am
++++ test/Makefile.am
+@@ -3,4 +3,4 @@ compare_SOURCES = compare.c
+ compare_LDADD = -lm
+ 
+ EXTRA_DIST = regression tests compile globals
+-TESTS = regression compile globals
++TESTS = regression compile

--- a/srcpkgs/liba52/template
+++ b/srcpkgs/liba52/template
@@ -1,14 +1,14 @@
 # Template file for 'liba52'
 pkgname=liba52
 version=0.7.4
-revision=8
+revision=9
 wrksrc="a52dec-${version}"
 build_style=gnu-configure
 configure_args="--enable-shared"
 hostmakedepends="automake libtool"
 short_desc="Free ATSC A/52 stream decoder"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://liba52.sourceforge.net/"
 distfiles="http://liba52.sourceforge.net/files/a52dec-${version}.tar.gz"
 checksum=a21d724ab3b3933330194353687df82c475b5dfb997513eef4c25de6c865ec33


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
