### PR TITLE
openssl 1.1.1k

### DIFF
--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -14,7 +14,7 @@ make_check_target=test
 make_install_args="MANSUFFIX=ssl"
 short_desc="Toolkit for Secure Sockets Layer and Transport Layer Security"
 maintainer="John <johnz@posteo.net>"
-license="OpenSSL-License"
+license="OpenSSL"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
 checksum=892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5

--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,7 +1,7 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=1.1.1j
-revision=2
+version=1.1.1k
+revision=1
 bootstrap=yes
 build_style=configure
 configure_script="./Configure"
@@ -17,7 +17,7 @@ maintainer="John <johnz@posteo.net>"
 license="OpenSSL-License"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
-checksum=aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
+checksum=892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
Fixes CVE-2021-3450 and CVE-2021-3449