### PR TITLE
[BUGFIX] rust-sccache: update to 0.2.15, enable feature=dist-server for x86_64*

### DIFF
--- a/srcpkgs/rust-sccache/template
+++ b/srcpkgs/rust-sccache/template
@@ -1,23 +1,30 @@
 # Template file for 'rust-sccache'
 pkgname=rust-sccache
-version=0.2.13
-revision=3
+version=0.2.15
+revision=1
 wrksrc="${pkgname/rust-/}-${version}"
 build_style=cargo
+# test_rust_cargo: tests/test-crate directory exists in v0.2.15 tag on github,
+# but is strangely missing from v0.2.15 on crates.io
+make_check_args="-- --skip test_rust_cargo"
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"
-short_desc="Sccache is a ccache-like tool"
+checkdepends="cargo"
+short_desc="Ccache-like tool for Rust, C/C++ & more"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://crates.io/crates/sccache"
 distfiles="https://static.crates.io/crates/sccache/sccache-${version}.crate"
-checksum=34b8eaab25eb467e9796c2f3ad7524c8548bf3afed962a922dd0b40ed2472ef7
+checksum=cd1b19d56224beccdbf3fcc1fac1b21d58ddad64eed7fc1288db84d227bcebf7
 
 case "$XBPS_TARGET_MACHINE" in
-	x86_64*|i686*|arm*|aarch64*) ;;
+	x86_64*) configure_args+=" --features dist-server" ;;
+	i686*|arm*|aarch64*) ;;
 	*) broken="ftbfs in ring" ;;
 esac
 
-pre_build() {
-	cargo update --package openssl-sys --precise 0.9.58
-}
+# test_sccache_command will fail if gcc/clang is actually a ccache wrapper
+# requires fixing in upstream
+if [ -n "$XBPS_CCACHE" ]; then
+	make_check_args+=" --skip test_sccache_command"
+fi


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
