### PR TITLE
julia: update to 1.6.0.

### DIFF
--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,38 +1,39 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.5.3
-revision=2
+version=1.6.0
+revision=1
 archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_BINARYBUILDER=0 USE_SYSTEM_LIBM=0 USE_SYSTEM_DSFMT=0 USE_SYSTEM_LIBUV=0
  USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_BLAS=0 USE_SYSTEM_LAPACK=0 USE_SYSTEM_LLVM=1
  USE_SYSTEM_LIBUNWIND=1 USE_SYSTEM_PCRE=1 USE_SYSTEM_GMP=1 USE_SYSTEM_PATCHELF=1
- USE_SYSTEM_MPFR=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_CURL=1
- USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1 USE_SYSTEM_UTF8PROC=1
+ USE_SYSTEM_MPFR=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_NGHTTP2=1
+ USE_SYSTEM_CURL=1 USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1
+ USE_SYSTEM_UTF8PROC=1
  UTF8PROC_INC='${XBPS_CROSS_BASE}/usr/include/libutf8proc'"
 make_install_args="$make_build_args"
 make_check_args="$make_build_args"
 make_check_target=testall
 conf_files="/etc/julia/startup.jl"
 hostmakedepends="pkg-config perl cmake python gcc-fortran patchelf which tar xz"
-makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel
+makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel nghttp2-devel
  libssh2-devel mbedtls-devel libatomic-devel zlib-devel libunwind-devel
- libutf8proc-devel llvm10"
+ libutf8proc-devel llvm11"
 # Julia provides vendored symlinks in /usr/lib/julia pointing to these libraries,
 # but none of the julia executables link to them so these are not auto-detected
-depends="libgit2 libcurl mpfr mbedtls libpcre2 libssh2 libquadmath p7zip"
+depends="libgit2 libcurl mpfr mbedtls libatomic libpcre2 libssh2 nghttp2 libquadmath libssp p7zip"
 short_desc="High-level, high-performance dynamic programming language"
 maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=fb69337ca037576758547c7eed9ae8f153a9c052318327b6b7f1917408c14d91
+checksum=1b05f42c9368bc2349c47363b7ddc175a2da3cd162d52b6e24c4f5d4d6e1232c
 nocross="build system is a mess"
 # Targets for the vendored symlinks mentioned above
 shlib_requires="libgit2.so.1.0 libcurl.so.4 libmpfr.so.6 libgmp.so.10
  libmbedcrypto.so.3 libmbedtls.so.12 libmbedx509.so.0 libpcre2-8.so.0
- libssh2.so.1 libquadmath.so.0"
+ libssh2.so.1 libquadmath.so.0 libnghttp2.so.14 libatomic.so.1 libssp.so.0"
 
 case "$XBPS_TARGET_MACHINE" in
 i686*)
@@ -85,8 +86,8 @@ post_install() {
 
 	# julia needlessly copies system libraries into a vendor directory
 	local _lib
-	for _lib in libgcc_s.so.1 libgfortran.so.5 libquadmath.so.0; do
-		rm -f "${DESTDIR}/usr/lib/julia/${_lib}"
+	for _lib in libgcc_s.so.1 libgfortran.so.5 libquadmath.so.0 libatomic.so.1 libstdc++.so.6 libssp.so.0; do
+		rm "${DESTDIR}/usr/lib/julia/${_lib}"
 		ln -s "/usr/lib/${_lib}" "${DESTDIR}/usr/lib/julia"
 	done
 }


### PR DESCRIPTION
Built successfully and appears to be working fine on x86_64 glibc. Test suite doesn't pass and hasn't been passing unless you build julia using all vendored (and heavily patched) dependencies (including llvm).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
