### PR TITLE
linux5.4: Disable VFIO on arm*

### DIFF
--- a/srcpkgs/linux5.4/files/arm-dotconfig
+++ b/srcpkgs/linux5.4/files/arm-dotconfig
@@ -5957,6 +5957,7 @@ CONFIG_VIRTIO_MENU=y
 CONFIG_VIRTIO_BALLOON=m
 CONFIG_VIRTIO_INPUT=m
 # CONFIG_VIRTIO_MMIO is not set
+# CONFIG_VFIO is not set
 
 #
 # Microsoft Hyper-V guest support


### PR DESCRIPTION
hardware virtualization is unlikely on 32-bit arm targets, but if needed we can always turn it back on.