### PR TITLE
cmusfm: fix license - split from PR 29785 because the test pass is super slow

### DIFF
--- a/srcpkgs/cmusfm/template
+++ b/srcpkgs/cmusfm/template
@@ -1,14 +1,14 @@
 # Template file for 'cmusfm'
 pkgname=cmusfm
 version=0.3.3
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--enable-libnotify"
 hostmakedepends="automake pkg-config"
 makedepends="libcurl-devel libnotify-devel"
 short_desc="Last.fm scrobbler for cmus"
 maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/Arkq/cmusfm"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=9d9fa7df01c3dd7eecd72656e61494acc3b0111c07ddb18be0ad233110833b63


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
