### PR TITLE
gnome-desktop: fix thumbnail generation on musl systems.

### DIFF
--- a/srcpkgs/gnome-desktop/patches/thumbnail-bwrap-musl.patch
+++ b/srcpkgs/gnome-desktop/patches/thumbnail-bwrap-musl.patch
@@ -1,0 +1,13 @@
+diff --git libgnome-desktop/gnome-desktop-thumbnail-script.c libgnome-desktop/gnome-desktop-thumbnail-script.c
+index cfbbad0..efad40b 100644
+--- libgnome-desktop/gnome-desktop-thumbnail-script.c
++++ libgnome-desktop/gnome-desktop-thumbnail-script.c
+@@ -532,7 +532,7 @@ add_bwrap (GPtrArray   *array,
+   add_args (array,
+ 	    "bwrap",
+ 	    "--ro-bind", "/usr", "/usr",
+-	    "--ro-bind", "/etc/ld.so.cache", "/etc/ld.so.cache",
++	    "--ro-bind-try", "/etc/ld.so.cache", "/etc/ld.so.cache",
+ 	    NULL);
+ 
+   /* These directories might be symlinks into /usr/... */

--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
 version=3.38.4
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dgnome_distributor=VoidLinux -Dudev=enabled -Dsystemd=disabled


### PR DESCRIPTION
/etc/ld.so.cache doesn't exist on musl systems, which makes the bwrap
command fail. Users will have to remove the "failed generation" cache
from ~/.cache/thumbnails/fail/ for nautilus to reattempt thumbnail
generation of previously visited directories.

Fixes #29767.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
