### PR TITLE
py3status: update to 3.35.

### DIFF
--- a/srcpkgs/py3status/template
+++ b/srcpkgs/py3status/template
@@ -1,6 +1,6 @@
 # Template file for 'py3status'
 pkgname=py3status
-version=3.34
+version=3.35
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,7 +11,7 @@ maintainer="teldra <teldra@rotce.de>"
 license="BSD-3-Clause"
 homepage="https://github.com/ultrabug/py3status"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=f1234e72cda0a792c3d71da3de3a3752ed3462b62793f6a1204372234a5d2521
+checksum=8069e35ff7dead4feecdd714b6c36985c4dbfd2cc133ff0ae6d190e99549f55b
 
 do_check() {
 	python3 -m pytest


### PR DESCRIPTION
- [x] I generally don't use the affected packages but briefly tested this PR

- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl

