### PR TITLE
flint: change name to flint-checker

### DIFF
--- a/srcpkgs/flint-checker/template
+++ b/srcpkgs/flint-checker/template
@@ -1,16 +1,18 @@
-# Template file for 'flint'
-pkgname=flint
+# Template file for 'flint-checker'
+pkgname=flint-checker
 version=0.1.0
-revision=9
+revision=10
+wrksrc=flint-${version}
 build_style=go
+go_import_path="github.com/pengwynn/flint"
 hostmakedepends="git"
 short_desc="Check your project for common sources of contributor friction"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="MIT"
-go_import_path="github.com/pengwynn/flint"
 homepage="https://github.com/pengwynn/flint"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=ec865ec5cad191c7fc9c7c6d5007754372696a708825627383913367f3ef8b7f
+replaces="flint<=${version}_${revision}"
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,7 +1,7 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
 version=0.1
-revision=38
+revision=39
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
@@ -61,6 +61,7 @@ replaces="
  electron7<=7.3.3_1
  enventor<=1.0.0_2
  epstopdf<=2.27_3
+ flint<=0.1.0_9
  fontmatrix<=0.6.0.20171228_2
  gegl3<=0.3.28_2
  gens-gs<=2.16.7_2


### PR DESCRIPTION
This conforms to the name used by other distros, see [Repology](https://repology.org/project/flint-checker/versions) and it allows to create in the future a package `flint` to be used for math, http://flintlib.org again as in all other distros.