### PR TITLE
djvulibre: fix checksum

### DIFF
--- a/srcpkgs/djvulibre/template
+++ b/srcpkgs/djvulibre/template
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://djvu.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/djvu/$pkgname-$version.tar.gz"
-checksum=82e392a9cccfee94fa604126c67f06dbc43ed5f9f0905d15b6c8164f83ed5655
+checksum=fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
Not sure why the checksum changed.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, x86_64-musl
- [x] I built this PR locally for these architectures:
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
