### PR TITLE
libofx: update to 0.10.1 and revbump

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1563,7 +1563,7 @@ libcheck.so.0 check-0.9.12_1
 liblxc.so.1 liblxc-4.0.6_2
 libtcmalloc.so.4 gperftools-2.1_1
 libaio.so.1 libaio-0.3.109_1
-libofx.so.7 libofx-0.9.11_1
+libofx.so.7 libofx-0.10.1_1
 libsigsegv.so.2 libsigsegv-2.10_2
 libfprint.so.0 libfprint0-1.0_1
 libfprint-2.so.2 libfprint-1.90.7_1

--- a/srcpkgs/gnucash/template
+++ b/srcpkgs/gnucash/template
@@ -1,7 +1,7 @@
 # Template file for 'gnucash'
 pkgname=gnucash
 version=4.4
-revision=1
+revision=2
 wrksrc="${pkgname}-${version%b}"
 build_style=cmake
 make_check_target=check

--- a/srcpkgs/homebank/template
+++ b/srcpkgs/homebank/template
@@ -1,7 +1,7 @@
 # Template file for 'homebank'
 pkgname=homebank
 version=5.5.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="intltool pkg-config"
 makedepends="libofx-devel librsvg-devel gtk+3-devel libsoup-devel"

--- a/srcpkgs/kmymoney/template
+++ b/srcpkgs/kmymoney/template
@@ -1,7 +1,7 @@
 # Template file for 'kmymoney'
 pkgname=kmymoney
 version=5.1.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson
  -DBUILD_TESTING=OFF"

--- a/srcpkgs/libofx/template
+++ b/srcpkgs/libofx/template
@@ -1,18 +1,19 @@
 # Template file for 'libofx'
 pkgname=libofx
-version=0.9.15
+version=0.10.1
 revision=1
 build_style="gnu-configure"
 configure_args="--with-opensp-includes=${XBPS_CROSS_BASE}/usr/include/OpenSP
  --with-opensp-libs=${XBPS_CROSS_BASE}/usr/lib"
 hostmakedepends="pkg-config"
 makedepends="opensp-devel libcurl-devel libxml++-devel"
-short_desc="Parser and an API designed to allow applications to very easily support OFX command responses"
+short_desc="OFX banking protocol abstraction library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://libofx.sourceforge.net"
+changelog="https://raw.githubusercontent.com/libofx/libofx/master/NEWS"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname/$pkgname-$version.tar.gz"
-checksum=e95c14e09fc37b331af3ef4ef7bea29eb8564a06982959fbd4bca7e331816144
+checksum=3bcc2c86b23dc11315a8ce0c9f20cc504fdc6147ea3a0385cb3e05768279c64d
 
 libofx-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Changes since version 0.9.15: [...0.10.1](https://github.com/libofx/libofx/compare/0.9.15...0.10.1) (just for reference).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
- [x] I built this PR locally for my native architecture, x86_64-musl
- [x] I built this PR locally for these architectures:
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
