### PR TITLE
goatcounter: update to 2.0.0

### DIFF
--- a/srcpkgs/goatcounter/template
+++ b/srcpkgs/goatcounter/template
@@ -1,13 +1,15 @@
 # Template file for 'goatcounter'
 pkgname=goatcounter
-version=1.2.0
+version=2.0.0
 revision=1
 build_style=go
 go_import_path=zgo.at/goatcounter
 go_package="${go_import_path}/cmd/goatcounter"
+go_ldflags="-X zgo.at/goatcounter.Version=${version}"
+depends="tzdata"
 short_desc="Easy web analytics without tracking of personal data"
-maintainer="Anjandev Momi <anjan@momi.ca>"
+maintainer="Martin Tournoij <martin@arp242.net>"
 license="EUPL-1.2"
 homepage="https://www.goatcounter.com/"
 distfiles="https://github.com/zgoat/goatcounter/archive/v${version}.tar.gz"
-checksum=505f8c5848bb368e18c0a041fcbeb87f540813a7455d9a67cdce5a5f25d799e7
+checksum=bca27f65a302482ae018e9d7c5449c4e91aec11a4eea2f62cfe2ed8743a9b241


### PR DESCRIPTION
This also correctly sets the version so that "goatcounter version" shows the
expected result instead of just "dev", and adds a dependency on tzdata.

I've also taken the liberty of setting myself as the maintainer; I'm the
upstream author and a Void user as well. I accidentally discovered there's a
Void package last week when doing some license analysis on void-packages 😅
The current 1.2.0 is pretty outdated, so I don't expect @anjandev will mind?

Fixes: #22087

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
