### PR TITLE
plan9port: update to 20210324

### DIFF
--- a/srcpkgs/plan9port/template
+++ b/srcpkgs/plan9port/template
@@ -1,22 +1,19 @@
 # Template file for 'plan9port'
 pkgname=plan9port
-version=20200927
-revision=2
-_githash=291f7411783bf6871b253f3b15ce691eea7a257e
+version=20210324
+revision=1
+_githash=88a87fadae6629932d9c160f53ad5d79775f8f94
 wrksrc="${pkgname}-${_githash}"
 hostmakedepends="perl which"
 makedepends="libX11-devel libXt-devel libXext-devel freetype-devel fontconfig-devel"
 short_desc="Port of many Plan 9 programs to Unix-like operating systems"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="LPL-1.02"
+license="MIT, bzip2-1.0.6, Public Domain, custom:Bigelow & Holmes,
+ custom:Bigelow & Holmes Inc and URW++ GmbH, custom:Bitstream Vera Fonts"
 homepage="https://9fans.github.io/plan9port/"
 distfiles="https://github.com/9fans/plan9port/archive/${_githash}.tar.gz"
-checksum=4db90ed7859066d26a424ebde38b318bb6030ad9209cdbfb4f5fb32fb486a659
+checksum=d4b873a094035024fe54282a7fdd652255b73b51c4fd78ae7701746d1e3e8f38
 nocross=yes
-
-if [[ $XBPS_TARGET_MACHINE == *-musl ]]; then
-	makedepends+=" libucontext-devel"
-fi
 
 CFLAGS="-fcommon"
 
@@ -32,23 +29,26 @@ post_extract() {
 	sed -i "s,/usr/local/plan9,/usr/lib/plan9,g" \
 		 $(grep -lr /usr/local/plan9)
 }
+
 do_build() {
 	CFLAGS+=' -D_DEFAULT_SOURCE'
 	echo "CFLAGS='$CFLAGS'" >LOCAL.config
 	echo "LDFLAGS='$LDFLAGS'" >>LOCAL.config
 	vsed -e 's/-O2/$CFLAGS/' -i bin/9c
-	if [[ $XBPS_TARGET_MACHINE == *-musl ]]; then
-		# add libucontext to extralibs under linux
-		vsed -e '/^\textralibs=.*-lpthread"$/s/"$/ -lucontext"/' -i bin/9l
-	fi
 
-	./INSTALL
+	NPROC=$XBPS_MAKEJOBS ./INSTALL
 }
+
 do_install() {
 	xargs -a lib/moveplan9.files -d'\n' sed -i "s#$wrksrc#/usr/lib/plan9#"
 
 	vinstall $FILESDIR/plan9.sh 644 etc/profile.d
 	vlicense LICENSE
+	vlicense src/cmd/bzip2/LICENSE LICENSE.bzip2
+	vlicense postscript/font/dejavu/LICENSE.dejavu
+	vlicense postscript/font/luxi/COPYRIGHT.BH
+	sed '1d' font/luc/NOTICE > NOTICE.BH
+	vlicense NOTICE.BH
 
 	vmkdir usr/lib
 	cp -a $wrksrc $DESTDIR/usr/lib/plan9


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

Also built on:
x86_64-musl
i686-glibc

WIth commit https://github.com/9fans/plan9port/commit/18571208068d5fe2f0bf7b4e980525a7f577c503 ucontext is no
longer required. Whist it builds for musl and should work I cannot test it.
