### PR TITLE
linux-firmware: move cypress firmware to linux-firmware-broadcom.

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
 version=20210315
-revision=1
+revision=2
 depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
@@ -45,6 +45,9 @@ linux-firmware-broadcom_package() {
 	pkg_install() {
 		vmove usr/lib/firmware/brcm
 		vmove usr/share/licenses/linux-firmware/LICENCE.broadcom_bcm43xx
+		# firmware/brcm contains multiple symlinks to ../cypress/
+		vmove usr/lib/firmware/cypress
+		vmove usr/share/licenses/linux-firmware/LICENCE.cypress
 	}
 }
 


### PR DESCRIPTION
Many people, including those using our linux package, will only have
linux-firmware-network installed, not linux-firmware; therefore, many
symlinks from the linux-firmware-broadcom package (pulled in by
linux-firmware-network) would be broken, because the cypress files were
in linux-firmware.

Reported by Stas over email.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
