### PR TITLE
python3-pikepdf: update to 2.10.0.

### DIFF
--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pikepdf'
 pkgname=python3-pikepdf
-version=2.9.2
+version=2.10.0
 revision=1
 wrksrc="pikepdf-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="Philipp David <pd@3b.pm>"
 license="MPL-2.0"
 homepage="https://github.com/pikepdf/pikepdf"
 distfiles="${PYPI_SITE}/p/pikepdf/pikepdf-${version}.tar.gz"
-checksum=7dd6bad55da7b41b37f678058fa586b73d9052f46aa0ba78ad7b1bc61e854088
+checksum=7a804515942049f846d548d3b817317f8136e06938737ff64b79c82d61908e27
 
 pre_build() {
 	vsed -i "s/__version__.*/__version__ = '${version}'/g" setup.py


### PR DESCRIPTION
Bumped to latest upstream release, this one fixes a security issue: https://github.com/pikepdf/pikepdf/blob/master/docs/release_notes.rst#v2100

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
