### PR TITLE
Update podman, buildah, crun

### DIFF
--- a/srcpkgs/buildah/template
+++ b/srcpkgs/buildah/template
@@ -1,6 +1,6 @@
 # Template file for 'buildah'
 pkgname=buildah
-version=1.19.6
+version=1.20.0
 revision=1
 build_style=go
 go_import_path=github.com/containers/buildah
@@ -9,14 +9,14 @@ go_build_tags=containers_image_ostree_stub
 hostmakedepends="pkg-config go-md2man"
 makedepends="libostree-devel libbtrfs-devel device-mapper-devel gpgme-devel
  libassuan-devel libseccomp-devel"
-depends="runc containers.image"
+depends="crun containers.image"
 short_desc="Dockerfile compatible OCI image building tool"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containers/buildah"
 changelog="https://github.com/containers/buildah/blob/master/CHANGELOG.md"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=4f2e737521691abddfff7eaf6d7a7137db019c842de61d68054ccc2a6587c2fd
+checksum=6af8fd6ad6fdb515f4f806105c8fe3e4ceda63eaea6e33e3c7ac7b272fe61797
 
 post_build() {
 	make -C docs GOMD2MAN=go-md2man

--- a/srcpkgs/crun/template
+++ b/srcpkgs/crun/template
@@ -1,7 +1,7 @@
 # Template file for 'crun'
 pkgname=crun
-version=0.16
-revision=2
+version=0.19
+revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd"
 hostmakedepends="pkg-config libtool python3 $(vopt_if man go-md2man)"
@@ -11,7 +11,7 @@ maintainer="Imran Khan <imrankhan@teknik.io>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/containers/crun"
 distfiles="https://github.com/containers/crun/releases/download/${version}/crun-${version}.tar.gz"
-checksum=fba02fe03dbb83570d4d00e0268e6c3b8ff5e7472e24c183ed8644ea208336dc
+checksum=8065b73ae37ccfb960915fa10051e2bf27850d1c2c69ffeb9eec17c6f198d1c9
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" argp-standalone"

--- a/srcpkgs/podman/INSTALL.msg
+++ b/srcpkgs/podman/INSTALL.msg
@@ -1,21 +1,15 @@
 `fuse-overlayfs` has been added as a runtime dependency to podman.
 podman will now prefer this storage driver to the `vfs` fallback driver.
+If you have existing containers that rely on the `vfs` driver, podman
+will display an error and refuse any further operation.
 
 To switch to the new storage driver, podman has to be reset:
 
     # podman system reset
 
-To keep the `vfs` driver, add this to `/etc/containers/storage.conf`
-or `~/.config/containers/storage.conf`:
+To instead keep using the `vfs` driver, add
 
     [storage]
     driver="vfs"
 
-Otherwise podman will display an error and refuse any further operation.
-
-Additionally the `btrfs` storage driver has been enabled. This driver is also
-available for rootless operation. Reset podman and add the following to your
-`storage.conf` to switch to this driver:
-
-    [storage]
-    driver="btrfs"
+to `/etc/containers/storage.conf` or `~/.config/containers/storage.conf`.

--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,20 +1,20 @@
 # Template file for 'podman'
 pkgname=podman
-version=3.0.1
-revision=3
+version=3.1.0
+revision=1
 build_style=go
-go_import_path="github.com/containers/podman/v2"
+go_import_path="github.com/containers/podman/v3"
 go_package="${go_import_path}/cmd/podman"
 go_build_tags="seccomp apparmor containers_image_ostree_stub"
 hostmakedepends="pkg-config go-md2man"
 makedepends="gpgme-devel libseccomp-devel device-mapper-devel libbtrfs-devel"
-depends="runc conmon cni-plugins slirp4netns containers.image fuse-overlayfs"
+depends="crun conmon cni-plugins slirp4netns containers.image fuse-overlayfs"
 short_desc="Simple management tool for containers and images"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://podman.io/"
 distfiles="https://github.com/containers/libpod/archive/v${version}.tar.gz"
-checksum=259e682d6e90595573fe8880e0252cc8b08c813e19408b911c43383a6edd6852
+checksum=60031aa620cbfab641ffef9cb4e68240a0383c23ffd0276938684e98794bb5db
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"


### PR DESCRIPTION
In addition to the update, I've moved `podman` and `buildah` from `runc` to `crun`. `crun` is produced by the same organization and advertises better speed and lower memory footprint. More importantly, with `void-runit` supporting cgroupsv2-only `CGROUP_MODE=unified` mounts (see `/etc/rc.conf`), `podman` does not work out of the box with `runc` but works just fine with `crun`. In fact, when `crun` is installed alongside `runc`, `buildah` prefers `crun`.

I don't know whether `runc` can be made to work with the unified cgroupsv2 mount or whether there are any potential breakages if `runc` is replaced with `crun`.

@CameronNemo @kartikynwa @lemmi 

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR