### PR TITLE
uim: disable non-utf-8 anthy backend

### DIFF
--- a/srcpkgs/uim/template
+++ b/srcpkgs/uim/template
@@ -1,12 +1,12 @@
 # Template file for 'uim'
 pkgname=uim
 version=1.8.8
-revision=4
+revision=5
 build_style=gnu-configure
 build_helper=qmake
 configure_args="--enable-pref --enable-fep --with-gtk2 --with-gtk3
- --with-libgcroots=installed
- --with-qt5 --with-qt5-immodule --with-x --with-anthy-utf8 --with-skk"
+ --with-libgcroots=installed --with-qt5 --with-qt5-immodule --with-x
+ --with-anthy-utf8 --without-anthy --with-skk"
 hostmakedepends="pkg-config intltool qt5-host-tools qt5-qmake automake
  libtool gettext-devel"
 makedepends="gtk+-devel gtk+3-devel qt5-devel ncurses-devel anthy-devel


### PR DESCRIPTION
After the recent upgrade of anthy to 0.4 in [https://github.com/void-linux/void-packages/commit/700c49292eccc0cd96372e45027e2a929229e060](https://github.com/void-linux/void-packages/commit/700c49292eccc0cd96372e45027e2a929229e060), the anthy input method in uim will no longer work with the anthy available in the repository, instead requiring the anthy-utf8 input method to interface and convert kanji correctly. In order to prevent broken configurations, this change disables the build of the old anthy input method.

In order to avoid installing the new build of uim-anthy when the old anthy is present, I set uim-anthy to conflict with older versions of anthy that use EUC-JP instead of UTF-8. If there is a better way of ensuring this is not installed in a way that introduces incompatibility, I would very much like to know.

Thank you for reading this and for any reply.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
