### PR TITLE
fpc: Add ppc64le support.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3974,3 +3974,4 @@ libmd.so.0 libmd-1.0.3_1
 libldacBT_abr.so.2 ldacBT-2.0.2.3_1
 libldacBT_enc.so.2 ldacBT-2.0.2.3_1
 libgumbo.so.1 gumbo-parser-0.10.1_2
+libpas2jlib.so fpc-3.2.0_1

--- a/srcpkgs/fpc/template
+++ b/srcpkgs/fpc/template
@@ -2,12 +2,12 @@
 pkgname=fpc
 version=3.2.0
 revision=1
-archs="x86_64* i686*"
+archs="x86_64* i686* ppc64le"
 create_wrksrc=yes
 build_wrksrc="${pkgname}build-${version}"
 conf_files="/etc/fpc.cfg /etc/fppkg.cfg"
 hostmakedepends="rpmextract"
-makedepends="ncurses-devel zlib-devel expat-devel"
+makedepends="ncurses-devel zlib-devel expat-devel bsdtar"
 short_desc="Free Pascal Compiler"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
@@ -23,6 +23,9 @@ i686*)
 	distfiles+=" ${SOURCEFORGE_SITE}/freepascal/Linux/${version}/${pkgname}-${version}-1.i686.rpm"
 	checksum+=" 05c5600c9461362a08df100cf50ca125cb2b4d5bfe4da48cf8c144f2bf4617a2"
 	;;
+ppc64le*)
+	distfiles+=" ${SOURCEFORGE_SITE}/freepascal/Linux/${version}/${pkgname}-${version}.powerpc64le-linux.tar"
+	checksum+=" 9bf59ae3d336f0de4624c63e4e892ea95de4be2ca66182d185defc50b69b65f3"
 esac
 # TODO: figure out cross-build and how to unwrap the ARM .tar.
 nocross=yes
@@ -30,9 +33,25 @@ nopie=yes
 noverifyrdeps=yes
 
 post_extract() {
-	# relative links needed
-	ln -sf ../lib64/fpc/${version}/ppcx64 usr/bin
-	ln -sf ../lib/fpc/${version}/ppc386 usr/bin
+	# extract recursive tar files or otherwise post-process.
+	case "$XBPS_TARGET_MACHINE" in
+	ppc64le*)
+		mkdir ${wrksrc}/usr
+		cd ${wrksrc}/${pkgname}-${version}.powerpc64-linux
+		for f in $(bsdtar -tf binary.powerpc64-linux.tar)
+		do
+			bsdtar -xOf binary.powerpc64-linux.tar $f | bsdtar -C ${wrksrc}/usr -xzf -
+		done
+		cd ${wrksrc}
+		ln -sf ../lib/fpc/${version}/ppcppc64 usr/bin
+		;;
+	x86_64* | i686*)
+		# relative links needed
+		ln -sf ../lib64/fpc/${version}/ppcx64 usr/bin
+		ln -sf ../lib/fpc/${version}/ppc386 usr/bin
+		;;
+	esac
+
 
 	# tweak PT_INTERP for musl targets
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ppc64le-libc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

Details: Ran test suite. There are a small number of failures (36 of 7k+). The tests that fail are the same ones that the bootstrap compiler fails, so I'm fairly sure that no additional failures are introduced by this packaging template.
