### PR TITLE
icewm: update to 2.3.1.

### DIFF
--- a/srcpkgs/icewm/template
+++ b/srcpkgs/icewm/template
@@ -1,8 +1,9 @@
 # Template file for 'icewm'
 pkgname=icewm
-version=2.2.1
+version=2.3.1
 revision=1
 build_style=cmake
+make_cmd=make
 configure_args="-DENABLE_LTO=ON -DCONFIG_LIBRSVG=ON -DENABLE_ALSA=ON
  -DCONFIG_XPM=ON -DCONFIG_LIBJPEG=ON -DCFGDIR=/etc/icewm"
 hostmakedepends="asciidoc gettext-devel libtool mkfontdir perl
@@ -16,9 +17,12 @@ maintainer="Glaulher <glaulher.developer@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://ice-wm.org/"
 distfiles="https://github.com/ice-wm/icewm/archive/${version}.tar.gz"
-checksum=199a37a395e8788b4c2eeb73c46248654d785b2862b89bb5b01709eb33968dc8
+checksum=b44136a519fc2c5b8077879d1d13f2375646ff1580f3db54dd418dfc3b98e5fe
 # broken tests
 make_check=no
+
+# Ninja build files generation fails
+export CMAKE_GENERATOR="Unix Makefiles"
 
 # No c++ warnings for 'One Defintion Rules' and make sure LTO goes ok
 CXXFLAGS="-Wno-odr -fno-strict-aliasing"


### PR DESCRIPTION
CMAKE_GENERATOR and make_cmd are adjusted to create and use a makefile and make.

```
Linting srcpkgs/icewm/template...
srcpkgs/icewm/template:25: custom variables should use _ prefix: CMAKE_GENERATOR="Unix Makefiles"
```
`xlint` is wrong here.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
