### PR TITLE
build-style/void-cross.sh: fix leftover _triplet variable

### DIFF
--- a/common/build-style/void-cross.sh
+++ b/common/build-style/void-cross.sh
@@ -607,7 +607,7 @@ do_install() {
 		${DESTDIR}/${sysroot}/usr/include/c++/${gcc_patch}
 
 	# Symlinks for gnarl and gnat shared libraries
-	local adalib=usr/lib/gcc/${_triplet}/${gcc_patch}/adalib
+	local adalib=usr/lib/gcc/${tgt}/${gcc_patch}/adalib
 	mv ${DESTDIR}/${adalib}/libgnarl-${gcc_major}.so \
 		${DESTDIR}/${sysroot}/usr/lib
 	mv ${DESTDIR}/${adalib}/libgnat-${gcc_major}.so \


### PR DESCRIPTION
One instance of `_triplet` was forgotten in https://github.com/void-linux/void-packages/commit/1088eba15b1921472270aff3666b800c42df2b5d

@q66 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
