### PR TITLE
exa: update to 0.10.0

### DIFF
--- a/srcpkgs/exa/template
+++ b/srcpkgs/exa/template
@@ -1,21 +1,30 @@
 # Template file for 'exa'
 pkgname=exa
-version=0.9.0
-revision=2
+version=0.10.0
+revision=1
 build_style=cargo
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config libgit2-devel"
 makedepends="libgit2-devel"
 short_desc="Modern replacement for ls"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="FollieHiyuki <folliekazetani@protonmail.com>"
 license="MIT"
 homepage="https://the.exa.website/"
-distfiles="https://github.com/ogham/exa/archive/v${version}.tar.gz"
-checksum=@facbe3b234f403e1e1919f28f009f1733a0fbbbb11f0bc2ba89ac3eba11bc5e8
+distfiles="https://github.com/ogham/exa/archive/v${version}.tar.gz
+ https://github.com/ogham/exa/releases/download/v${version}/exa-accoutrements-v${version}.zip"
+checksum="27420f7b805941988399d63f388be4f6077eee94a505bf01c2fb0e7d15cbf78d
+ c1ab340af63e64bc3fd854c03f6161aa240a533e928688036a7d4544aecabc05"
+
+post_extract() {
+	mkdir -p accoutrements
+	mv ../man accoutrements/
+	mv ../completions accoutrements/
+}
 
 post_install() {
-	vman contrib/man/exa.1
-	vcompletion contrib/completions.bash bash
-	vcompletion contrib/completions.fish fish
-	vcompletion contrib/completions.zsh zsh
+	vman accoutrements/man/exa.1
+	vman accoutrements/man/exa_colors.5
+	vcompletion completions/completions.bash bash
+	vcompletion completions/completions.fish fish
+	vcompletion completions/completions.zsh zsh
 	vlicense LICENCE
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Upstream uses markdown for the man pages and convert them into plain text with `pandoc`. I don't know a convenient way to install them.
Another option is to pull the pre-compiled man pages from their release.
