### PR TITLE
gatling: update to 0.16, fix lint

### DIFF
--- a/srcpkgs/gatling/patches/gatling.c.patch
+++ b/srcpkgs/gatling/patches/gatling.c.patch
@@ -1,0 +1,12 @@
+# patch gatling.c to use capability headers from the kernel instead of libcap
+--- gatling.c.orig	2021-04-04 21:51:17.641001871 +0000
++++ gatling.c	2021-04-04 21:51:49.798095616 +0000
+@@ -62,7 +62,7 @@
+ 
+ #ifdef __linux__
+ #include <sys/auxv.h>
+-#include <sys/capability.h>
++#include <linux/capability.h>
+ #endif
+ 
+ char serverroot[1024];

--- a/srcpkgs/gatling/template
+++ b/srcpkgs/gatling/template
@@ -1,17 +1,17 @@
 # Template file for 'gatling'
 pkgname=gatling
-version=0.15
-revision=10
+version=0.16
+revision=1
 build_style=gnu-makefile
+make_build_target="gatling dl getlinks"
+make_install_args="prefix=/usr MANDIR=/usr/share/man"
 makedepends="libowfat openssl-devel zlib-devel"
 short_desc="High performance web server"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-2"
-homepage="http://www.fefe.de/$pkgname/"
+license="GPL-2.0-only"
+homepage="http://www.fefe.de/gatling"
 distfiles="https://www.fefe.de/gatling/$pkgname-$version.tar.xz"
-checksum=6fa329d0ced0c80deb8dde5460e9d9e984bee94f265043d7fdec0e253dce9aa4
-make_build_target="gatling dl getlinks"
-make_install_args="prefix=/usr MANDIR=/usr/share/man"
+checksum=5f96438ee201d7f1f6c2e0849ff273b196bdc7493f29a719ce8ed08c8be6365b
 
 CFLAGS="-std=c99 -I${XBPS_CROSS_BASE}/usr/include/libowfat -fcommon"
 
@@ -24,4 +24,3 @@ pre_build() {
 pre_install() {
 	vmkdir usr/share/man/man1
 }
-


### PR DESCRIPTION
Gatling 0.16 grew a header dependency on capability.h. However, it
doesn't appear to actually use anything from libcap so until that
changes, patch gatling.c to use linux/capability.h (from
kernel-libc-headers) instead of sys/capability.h (from libcap-devel).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

