### PR TITLE
julia: stop hardcoding mbedtls sonames.

### DIFF
--- a/srcpkgs/julia/patches/julia-hardcoded-libs.patch
+++ b/srcpkgs/julia/patches/julia-hardcoded-libs.patch
@@ -1,0 +1,43 @@
+diff --git a/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl b/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
+index a7ca666b23..b84a42f4e7 100644
+--- a/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
++++ b/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
+@@ -31,9 +31,9 @@ elseif Sys.isapple()
+     const libmbedtls = "@rpath/libmbedtls.13.dylib"
+     const libmbedx509 = "@rpath/libmbedx509.1.dylib"
+ else
+-    const libmbedcrypto = "libmbedcrypto.so.5"
+-    const libmbedtls = "libmbedtls.so.13"
+-    const libmbedx509 = "libmbedx509.so.1"
++    const libmbedcrypto = "libmbedcrypto.so"
++    const libmbedtls = "libmbedtls.so"
++    const libmbedx509 = "libmbedx509.so"
+ end
+ 
+ function __init__()
+diff --git a/stdlib/libLLVM_jll/src/libLLVM_jll.jl b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+index fa45e754e5..b51812e3a8 100644
+--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
++++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+@@ -23,7 +23,7 @@ if Sys.iswindows()
+ elseif Sys.isapple()
+     const libLLVM = "@rpath/libLLVM.dylib"
+ else
+-    const libLLVM = "libLLVM-11jl.so"
++    const libLLVM = "libLLVM.so"
+ end
+ 
+ function __init__()
+diff --git a/stdlib/nghttp2_jll/src/nghttp2_jll.jl b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+index 8b98c76ac5..77ad9e3800 100644
+--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
++++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+@@ -22,7 +22,7 @@ if Sys.iswindows()
+ elseif Sys.isapple()
+     const libnghttp2 = "@rpath/libnghttp2.14.dylib"
+ else
+-    const libnghttp2 = "libnghttp2.so.14"
++    const libnghttp2 = "libnghttp2.so"
+ end
+ 
+ function __init__()

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,7 +1,7 @@
 # Template file for 'julia'
 pkgname=julia
 version=1.6.0
-revision=1
+revision=2
 archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
@@ -15,6 +15,7 @@ make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
 make_install_args="$make_build_args"
 make_check_args="$make_build_args"
 make_check_target=testall
+patch_args=-Np1
 conf_files="/etc/julia/startup.jl"
 hostmakedepends="pkg-config perl cmake python gcc-fortran patchelf which tar xz"
 makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel nghttp2-devel


### PR DESCRIPTION
When julia 1.6.0 vendors in mbedtls, it uses v2.26.0 which provides a
different set of sonames than the version provided by Void. We need to
patch where the library sonames are hardcoded to allow julia to properly
call into libraries provided by mbedtls.

Closes #29964

See <https://github.com/julialang/julia/issues/40198> for the upstream
bug.

This patch is directly copied from Arch Linux.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
