### PR TITLE
python3-pip: add pip3 symlink.

### DIFF
--- a/srcpkgs/python3-pip/template
+++ b/srcpkgs/python3-pip/template
@@ -13,11 +13,10 @@ homepage="https://pip.pypa.io/"
 changelog="https://raw.githubusercontent.com/pypa/pip/master/NEWS.rst"
 distfiles="${PYPI_SITE}/p/pip/pip-${version}.tar.gz"
 checksum=99bbde183ec5ec037318e774b0d8ae0a64352fe53b2c7fd630be1d07e94f41e5
-
-do_check() {
-	: tests have unpackaged dependencies
-}
+# tests have unpackaged dependencies
+make_check=no
 
 post_install() {
 	vlicense LICENSE.txt
+	ln -s pip $DESTDIR/usr/bin/pip3
 }


### PR DESCRIPTION
Going from [1], also provide a Python 3 specific pip3 command.

[1] https://www.python.org/dev/peps/pep-0394/

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
