### PR TITLE
build-helper/qmake: fix {C,CXX,LD}FLAGS

### DIFF
--- a/common/build-helper/qmake.sh
+++ b/common/build-helper/qmake.sh
@@ -65,14 +65,36 @@ _EOF
 	# create the qmake-wrapper here because it only
 	# makes sense together with the qmake build-helper
 	# and not to interfere with e.g. the qmake build-style
+	#
+	# XXX: Intentionally quote {C,CXX,LD}FLAGS here but not in native.
+	# - Cross Build:
+	#   + base flags will be picked up from QMAKE_{C,CXX,LD}FLAGS
+	#   + hardening flags will be picked up from environment variables
+	# - Native Build:
+	#   + hardening flags will be picked up first (Makefile, qt.conf?)
+	#   + base flags will be picked up from QMAKE_{C,CXX,LD}FLAGS
+	# Maybe there're better workaround, I don't know.
         cat > "${XBPS_WRAPPERDIR}/qmake" <<_EOF
 #!/bin/sh
-exec /usr/lib/qt5/bin/qmake "\$@" -qtconf "${XBPS_WRAPPERDIR}/qt.conf"
+exec /usr/lib/qt5/bin/qmake "\$@" -qtconf "${XBPS_WRAPPERDIR}/qt.conf" \\
+	QMAKE_CFLAGS+="\${CFLAGS}" \\
+	QMAKE_CXXFLAGS+="\${CXXFLAGS}" \\
+	QMAKE_LFLAGS+="\${LDFLAGS}"
 _EOF
 else
         cat > "${XBPS_WRAPPERDIR}/qmake" <<_EOF
 #!/bin/sh
-exec /usr/lib/qt5/bin/qmake "\$@" CONFIG+=no_qt_rpath
+exec /usr/lib/qt5/bin/qmake \
+	"\$@" \
+	PREFIX=/usr \
+	QT_INSTALL_PREFIX=/usr \
+	LIB=/usr/lib \
+	QMAKE_CC=$CC QMAKE_CXX=$CXX \
+	QMAKE_LINK=$CXX QMAKE_LINK_C=$CC \
+	QMAKE_CFLAGS+="${CFLAGS}" \
+	QMAKE_CXXFLAGS+="${CXXFLAGS}" \
+	QMAKE_LFLAGS+="${LDFLAGS}" \
+	CONFIG+=no_qt_rpath
 _EOF
 fi
 chmod 755 ${XBPS_WRAPPERDIR}/qmake

--- a/srcpkgs/abGate/template
+++ b/srcpkgs/abGate/template
@@ -11,10 +11,6 @@ short_desc="LV2 Noise Gate plugin"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
 homepage="http://abgate.sourceforge.net/"
-distfiles="https://github.com/antanasbruzas/abGate/archive/v${version}.tar.gz>${pkgname}-${versiont}.tar.gz"
+distfiles="https://github.com/antanasbruzas/abGate/archive/v${version}.tar.gz"
 checksum=ebee1cc545b088bf6e5989c114e7e34fa9f21ac7fdb1eee3fd067bcf98703b86
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-devel"
-fi
 CXXFLAGS="-fPIC"

--- a/srcpkgs/djview/template
+++ b/srcpkgs/djview/template
@@ -1,11 +1,11 @@
 # Template file for 'djview'
 pkgname=djview
 version=4.12
-revision=2
+revision=3
 wrksrc="djview4-${version}"
 build_style=gnu-configure
 build_helper=qmake
-configure_args="QMAKE=qmake-qt5 ac_cv_path_QMAKE=${XBPS_WRAPPERDIR}/qmake-qt5"
+configure_args="ac_cv_path_QMAKE=${XBPS_WRAPPERDIR}/qmake-qt5"
 hostmakedepends="automake pkg-config qt5-host-tools qt5-qmake libtool"
 makedepends="qt5-devel djvulibre-devel libxkbcommon-devel libSM-devel libXt-devel"
 short_desc="Portable DjVu viewer and browser plugin"

--- a/srcpkgs/qjackctl/template
+++ b/srcpkgs/qjackctl/template
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://qjackctl.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=ca443646daae21c13a6bec11160fe15639ea19c919d4a5607b1d1918dddd60bc
+checksum=867c088ed819f61d2eb1e550d4bb8f6330d8f247ab99843a584d81825f1a5d24
 
 build_options="jack_session"
 build_options_default="jack_session"

--- a/srcpkgs/smplayer/template
+++ b/srcpkgs/smplayer/template
@@ -1,7 +1,7 @@
 # Template file for 'smplayer'
 pkgname=smplayer
 version=21.1.0
-revision=1
+revision=2
 build_style=gnu-makefile
 build_helper=qmake
 hostmakedepends="qt5-host-tools qt5-tools qt5-script-devel tar"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
- recoll will be submitted in #30086, together with libxslt
- PyQt5 will be updated soon.
- gmic build is broken, even with latest version, with or without this change.