### PR TITLE
OpenRCT2: update to 0.3.3, tweak template

### DIFF
--- a/srcpkgs/OpenRCT2/INSTALL.msg
+++ b/srcpkgs/OpenRCT2/INSTALL.msg
@@ -1,5 +1,0 @@
-You must install a package that provides either the zenity or kdialog binaries:
-
-- zenity
-- qarma
-- kdialog

--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -2,32 +2,36 @@
 # based on https://raw.githubusercontent.com/AluisioASG/void-packages/openrct2/srcpkgs/OpenRCT2/template
 # and https://github.com/void-linux/void-packages/issues/1014#issuecomment-417372421
 pkgname=OpenRCT2
-_objects_version=1.0.18
+_objects_version=1.0.21
 _titles_version=0.1.2c
-version=0.3.2
-revision=3
+version=0.3.3
+revision=1
 build_style=cmake
 configure_args="
  -DOPENRCT2_VERSION_TAG=${version}
  -DDOWNLOAD_TITLE_SEQUENCES=0
  -DDOWNLOAD_OBJECTS=0
+ -DDISABLE_DISCORD_RPC=1
+ -DDISABLE_GOOGLE_BENCHMARK=1
  $(vopt_if multiplayer '' '-DDISABLE_NETWORK=1')
  $(vopt_if scripting '-DENABLE_SCRIPTING=1' '')"
+make_build_target="all g2"
 hostmakedepends="pkg-config unzip"
 makedepends="SDL2-devel fontconfig-devel freetype-devel libzip-devel
- libpng-devel speexdsp-devel jansson-devel icu-devel zlib-devel json-c++
+ libpng-devel speexdsp-devel icu-devel zlib-devel json-c++
  $(vopt_if multiplayer 'libcurl-devel openssl-devel')
  $(vopt_if scripting duktape-devel)"
+depends="zenity"
 short_desc="Open source re-implementation of RollerCoaster Tycoon 2"
 maintainer="klardotsh <josh@klar.sh>"
-license="GPL-3.0-or-later"
+license="GPL-3.0-or-later, CC-BY-SA-4.0"
 homepage="https://openrct2.io"
 # use title-sequences.zip to match CMakeLists instruction
 distfiles="https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz
  https://github.com/OpenRCT2/objects/releases/download/v${_objects_version}/objects.zip
  https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequences.zip"
-checksum="66c1c7ae8c765397e324b1aac59907bd5197dbad88597133aaba8a9480627c36
- bf8a28b7ccebaf58e4e9eb2540534632830534cf0b3f73677521dc555878c682
+checksum="71f9d1ae8477e1e9881a6f9759bddac71346e8ba42238d22514ae3d872b54fd2
+ b081f885311f9afebc41d9dd4a68b7db4cf736eb815c04e307e1a426f08cfa35
  5284333fa501270835b5f0cf420cb52155742335f5658d7889ea35d136b52517"
 skip_extraction="objects.zip title-sequences.zip"
 
@@ -55,7 +59,6 @@ pre_configure() {
 
 post_extract() {
 	_srcdir="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
-	mkdir -p data/object data/title
 	unzip -qd data/object "${_srcdir}/objects.zip"
 	unzip -qd data/sequence "${_srcdir}/title-sequences.zip"
 


### PR DESCRIPTION
- Add CC-BY-SA-4.0 license declaration (see <https://github.com/OpenRCT2/title-sequences/issues/3>)
- Remove unused `jansson-devel` makedep
- Explicitly disable unused dependency options when configuring
- Add missing make target `g2` (packs some data into a file, was previously being invoked as a dependency of `install`)
- Remove useless and incorrect mkdir line from `post_extract`
- Remove INSTALL.msg, add explicit zenity dep instead

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR