### PR TITLE
MultiMC: added qt5-svg as dependency for proper rendering of icons

### DIFF
--- a/srcpkgs/MultiMC/template
+++ b/srcpkgs/MultiMC/template
@@ -1,7 +1,7 @@
 # Template file for 'MultiMC'
 pkgname=MultiMC
 version=0.6.12
-revision=1
+revision=2
 wrksrc="${pkgname}5-${version}"
 _commithashnbt="4b305bbd2ac0e7a26987baf7949a484a87b474d4"
 _nbtversion="multimc-0.6.1"
@@ -10,7 +10,7 @@ build_style=cmake
 configure_args='-DMultiMC_BUILD_PLATFORM=Void -DMultiMC_LAYOUT=lin-system'
 hostmakedepends="openjdk8 xxd git qt5-qmake qt5-host-tools tar"
 makedepends="qt5-devel qt5-x11extras-devel qt5-svg-devel gtk+-devel"
-depends="virtual?java-environment"
+depends="virtual?java-environment qt5-svg"
 short_desc="Instanced Minecraft client"
 maintainer="Henry Naguski <henry@nilsu.org>"
 license="Apache-2.0"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
