### PR TITLE
New package: rtl8192eu-dkms-2022.12.29

### DIFF
--- a/srcpkgs/rtl8192eu-dkms/template
+++ b/srcpkgs/rtl8192eu-dkms/template
@@ -1,0 +1,26 @@
+# Template file for 'rtl8192eu-dkms'
+pkgname=rtl8192eu-dkms
+version=2022.12.29
+revision=1
+_gitrev=865656c3a1d1aee8c4ba459ce7608756d17c712f
+wrksrc="rtl8192eu-linux-driver-${_gitrev}"
+depends="dkms bc"
+short_desc="Realtek 8192EU USB WiFi driver (DKMS)"
+maintainer="Phicem <phicem@gmx.com>"
+license="GPL-2.0-only"
+homepage="https://github.com/clnhub/rtl8192eu-linux"
+distfiles="https://github.com/clnhub/rtl8192eu-linux/archive/${_gitrev}.tar.gz"
+checksum=72d1d97c6d2038885e5666f3271609b4dcbe45633c19a5606dc59745ff8ab543
+dkms_modules="rtl8192eu ${version}"
+
+do_install() {
+	local dest=/usr/src/rtl8192eu-${_modver}
+
+	vmkdir ${dest}
+	cp -r dkms.conf Kconfig Makefile platform core hal include os_dep ${DESTDIR}/${dest}
+
+	# modules-load.d(5) file.
+	vmkdir usr/lib/modules-load.d
+	echo "8192eu" > ${DESTDIR}/usr/lib/modules-load.d/${pkgname}.conf
+	chmod 644 ${DESTDIR}/usr/lib/modules-load.d/${pkgname}.conf
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### Purpose of this package

This package is necessary for using some versions of TP-Link TL-WN823N (because in-kernel rtl8xxxx module does not work properly for those devices).

#### Quality requirement
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements)
  --> The source repository does not provide releases

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
  On a x86_64 (glibc) system, with TP-Link TL-WN823N v2/v3

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
