### PR TITLE
xbps-src: Add remove-obsoletes command

### DIFF
--- a/common/xbps-src/shutils/remove_obsoletes.sh
+++ b/common/xbps-src/shutils/remove_obsoletes.sh
@@ -1,0 +1,6 @@
+remove_obsoletes () {
+    for repo in $XBPS_HOSTDIR/binpkgs $XBPS_HOSTDIR/binpkgs/debug $XBPS_HOSTDIR/binpkgs/nonfree $XBPS_HOSTDIR/binpkgs/multilib/  $XBPS_HOSTDIR/binpkgs/multilib/nonfree ; do
+        msg_normal "Cleaning $repo\n"
+        XBPS_ARCH=${XBPS_CROSS_TARGET:-$XBPS_MACHINE} $XBPS_RINDEX_CMD -r $repo
+    done
+}

--- a/xbps-src
+++ b/xbps-src
@@ -78,6 +78,9 @@ remove <pkgname>
 remove-autodeps
     Removes all package dependencies that were installed automatically.
 
+remove-obsoletes
+    Remove all obsolete packages from default repositories as detected by xbps-rindex.
+
 purge-distfiles
     Removes all obsolete distfiles in <hostdir>/sources.
 
@@ -798,6 +801,9 @@ case "$XBPS_TARGET" in
     remove|remove-destdir)
         read_pkg
         remove_pkg $XBPS_CROSS_BUILD
+        ;;
+    remove-obsoletes)
+        remove_obsoletes
         ;;
     list)
         $XBPS_QUERY_CMD -l


### PR DESCRIPTION
This cleans more than it probably should since it will clean several layers of nesting.  We could enable globstar and iterate over everything it finds, but I'm not particularly keen on this.

Open to changes on this, looking for feedback.