### PR TITLE
fotoxx: update to 21.40, add dcraw as runtime dependency.

### DIFF
--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -1,19 +1,19 @@
 # Template file for 'fotoxx'
 pkgname=fotoxx
-version=20.19
+version=21.40
 revision=1
 wrksrc=fotoxx
 build_style=gnu-makefile
 make_use_env=yes
 hostmakedepends="pkg-config"
 makedepends="libchamplain-devel libraw-devel"
-depends="desktop-file-utils exiftool xdg-utils"
+depends="desktop-file-utils exiftool xdg-utils dcraw"
 short_desc="Free open source program for image editing and collection management"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.kornelix.net/fotoxx/fotoxx.html"
 distfiles="https://www.kornelix.net/downloads/downloads/fotoxx-${version}.tar.gz"
-checksum=4c9216d4612641151ca75e3f6fd74521a8dcfbb0a14d765b73d2ff62eed37a3e
+checksum=0c16597053ce8e186fb8163839f4f4ed44548bf00e43e88951f4346a9dbbb620
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/champlain-0.12"
 
@@ -24,8 +24,3 @@ fi
 case "$XBPS_TARGET_LIBC" in
 	musl) makedepends+=" libexecinfo-devel"
 esac
-
-post_install() {
-	rm -rv ${DESTDIR}/usr/share/doc/fotoxx/{changelog.gz,copyright,fotoxx.man} \
-		  ${DESTDIR}/usr/share/appdata
-}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
