### PR TITLE
budgie-desktop: add patch from upstream

### DIFF
--- a/srcpkgs/budgie-desktop/patches/fix-budgie-desktop-settings-crash.patch
+++ b/srcpkgs/budgie-desktop/patches/fix-budgie-desktop-settings-crash.patch
@@ -1,0 +1,65 @@
+From: Joshua Strobl <joshua@streambits.io>
+Date: Mon, 12 Apr 2021 06:14:04 +0300
+Subject: [PATCH] Support moved font anti-aliasing and hinting in GSD 40. Fixes
+ #2121.
+
+---
+ src/panel/meson.build                  |  4 ++++
+ src/panel/settings/settings_fonts.vala | 11 ++++++++++-
+ 2 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git src/panel/meson.build src/panel/meson.build
+index ee610868..5451c278 100644
+--- src/panel/meson.build
++++ src/panel/meson.build
+@@ -72,6 +72,10 @@ budgie_panel_vala_args = [
+         '--gresources=' + gresource,
+ ]
+ 
++if dep_gsd.version().version_compare('>=40.0')
++    budgie_panel_vala_args += ['-D', 'HAVE_GSD_40']
++endif
++
+ budgie_panel_c_args = [
+     '-DWNCK_I_KNOW_THIS_IS_UNSTABLE'
+ ]
+diff --git src/panel/settings/settings_fonts.vala src/panel/settings/settings_fonts.vala
+index fc17622f..f750b926 100644
+--- src/panel/settings/settings_fonts.vala
++++ src/panel/settings/settings_fonts.vala
+@@ -24,7 +24,10 @@ namespace Budgie {
+ 
+ 		private Settings ui_settings;
+ 		private Settings wm_settings;
++
++#if !HAVE_GSD_40
+ 		private Settings x_settings;
++#endif
+ 
+ 		public FontPage() {
+ 			Object(group: SETTINGS_GROUP_APPEARANCE,
+@@ -135,14 +138,20 @@ namespace Budgie {
+ 			/* Hook up settings */
+ 			ui_settings = new Settings("org.gnome.desktop.interface");
+ 			wm_settings = new Settings("org.gnome.desktop.wm.preferences");
+-			x_settings = new Settings("org.gnome.settings-daemon.plugins.xsettings");
+ 			ui_settings.bind("document-font-name", fontbutton_document, "font-name", SettingsBindFlags.DEFAULT);
+ 			ui_settings.bind("font-name", fontbutton_interface, "font-name", SettingsBindFlags.DEFAULT);
+ 			ui_settings.bind("monospace-font-name", fontbutton_monospace, "font-name", SettingsBindFlags.DEFAULT);
+ 			wm_settings.bind("titlebar-font", fontbutton_title, "font-name", SettingsBindFlags.DEFAULT);
+ 			ui_settings.bind("text-scaling-factor", spinbutton_scaling, "value", SettingsBindFlags.DEFAULT);
++
++#if HAVE_GSD_40
++			ui_settings.bind("font-antialiasing", combobox_antialias, "active-id", SettingsBindFlags.DEFAULT);
++			ui_settings.bind("font-hinting", combobox_hinting, "active-id", SettingsBindFlags.DEFAULT);
++#else
++			x_settings = new Settings("org.gnome.settings-daemon.plugins.xsettings");
+ 			x_settings.bind("hinting", combobox_hinting, "active-id", SettingsBindFlags.DEFAULT);
+ 			x_settings.bind("antialiasing", combobox_antialias, "active-id", SettingsBindFlags.DEFAULT);
++#endif
+ 		}
+ 	}
+ }
+-- 
+2.31.1
+

--- a/srcpkgs/budgie-desktop/template
+++ b/srcpkgs/budgie-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'budgie-desktop'
 pkgname=budgie-desktop
 version=10.5.2
-revision=2
+revision=3
 build_style=meson
 build_helper=gir
 configure_args="-Dwith-gtk-doc=false"


### PR DESCRIPTION
 fixes crash when launching budgie-desktop-settings
 while gnome-settings-daemon version >=40.0 is installed.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
