### PR TITLE
OpenRCT2: fix build type

### DIFF
--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -5,7 +5,7 @@ pkgname=OpenRCT2
 _objects_version=1.0.21
 _titles_version=0.1.2c
 version=0.3.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="
  -DOPENRCT2_VERSION_TAG=${version}
@@ -37,6 +37,8 @@ skip_extraction="objects.zip title-sequences.zip"
 
 replaces="OpenRCT2-data>=0"
 
+CXXFLAGS="-DNDEBUG"
+
 build_options="multiplayer scripting"
 build_options_default="multiplayer scripting"
 desc_option_multiplayer="Enable multiplayer support"
@@ -48,7 +50,7 @@ fi
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" OpenRCT2"
-	CXXFLAGS="-DHAVE_IMMINTRIN_H=false -DSDL_DISABLE_IMMINTRIN_H=1"
+	CXXFLAGS+=" -DHAVE_IMMINTRIN_H=false -DSDL_DISABLE_IMMINTRIN_H=1"
 fi
 
 pre_configure() {


### PR DESCRIPTION
By default it produces a debug build, which crashes on assertions insetad of discarding them.

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR