### PR TITLE
man-pages: don't remove xattr syscall pages

### DIFF
--- a/srcpkgs/man-pages/template
+++ b/srcpkgs/man-pages/template
@@ -1,7 +1,7 @@
 # Template file for 'man-pages'
 pkgname=man-pages
 version=5.11
-revision=1
+revision=2
 short_desc="Linux Documentation Project (LDP) manual pages"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -34,9 +34,6 @@ do_install() {
 	# mdocml
 	rm -f man7/man.7
 	rm -f man7/mdoc.7
-	# attr-devel
-	rm -f man5/attr.5
-	rm -f man2/*xattr.2
 	# openssl-devel
 	mv man3/rand.3 man3/glibc-rand.3
 	mv man3/err.3 man3/glibc-err.3


### PR DESCRIPTION
Those are not longer provided by attr-devel, and this prevents the xattr
family of syscall man-pages from getting included in the man-pages devel
package.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
