### PR TITLE
glibc: restore debug symbols

### DIFF
--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.32
-revision=1
+revision=2
 bootstrap=yes
 short_desc="GNU C library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -20,36 +20,17 @@ nostrip_files="
 	POSIX_V7_ILP32_OFFBIG
 	POSIX_V6_LP64_OFF64
 	POSIX_V7_LP64_OFF64
-	XBS5_LP64_OFF64
-	ld-${version}.so
-	libdl-${version}.so
-	libanl-${version}.so
-	libcidn-${version}.so
-	libresolv-${version}.so
-	libcrypt-${version}.so
-	libpthread-${version}.so
-	libm-${version}.so
-	libutil-${version}.so
-	libthread_db-1.0.so
-	librt-${version}.so
-	libnsl-${version}.so
-	libc-${version}.so
-	libBrokenLocale-${version}.so
-	libnss_compat-${version}.so
-	libnss_db-${version}.so
-	libnss_dns-${version}.so
-	libnss_files-${version}.so
-	libnss_hesiod-${version}.so
-	libnss_nisplus-${version}.so
-	libnss_nis-${version}.so"
+	XBS5_LP64_OFF64"
 
 conf_files="
 	/etc/rpc
 	/etc/gai.conf
 	/etc/ld.so.conf"
+
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="bison perl python3 texinfo"
 fi
+
 makedepends="kernel-libc-headers"
 lib32files="/usr/lib/gconv/gconv-modules"
 lib32symlinks="ld-linux.so.2"
@@ -118,6 +99,7 @@ do_build() {
 	cd build
 	make ${makejobs}
 }
+
 do_install() {
 	vlicense LICENSES
 	# Create DESTDIR/etc/ld.so.conf
@@ -192,6 +174,7 @@ glibc-devel_package() {
 		fi
 	}
 }
+
 glibc-locales_package() {
 	conf_files="/etc/default/libc-locales"
 	short_desc+=" - locale data files"


### PR DESCRIPTION
commit b5a52cc50a13 ("glibc: do not strip shlibs to make valgrind work
ootb.") had added the main glibc shared libraries in the nostrip list so
that valgrind could work out of the box. As mentioned in that commit
message, this had the side-effect of making the glibc-dbg package lack
the debug symbols for all those libraries.

Restore all glibc debug symbol generation by removing all those shared
libraries from the nostrip list, so that symbolic debugging of glibc is
made possible.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
