### PR TITLE
Omnibus linting pass for SPDX warnings - most packages starting with H

### DIFF
--- a/srcpkgs/hans/template
+++ b/srcpkgs/hans/template
@@ -1,10 +1,10 @@
 # Template file for 'hans'
 pkgname=hans
 version=1.0
-revision=1
+revision=2
 short_desc="ICMP tunneling software"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://code.gerade.org/hans/"
 distfiles="https://github.com/friedrich/$pkgname/archive/v$version.tar.gz"
 checksum=53090083d440466e573b35f2eeab0b4b0dcd3e6290f797c999b4f5a0b5caaba2

--- a/srcpkgs/hdf5/template
+++ b/srcpkgs/hdf5/template
@@ -1,14 +1,14 @@
 # Template file for 'hdf5'
 pkgname=hdf5
 version=1.10.5
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-cxx --enable-fortran"
 hostmakedepends="gcc-fortran"
 makedepends="zlib-devel"
 short_desc="Data model, library, and file format for storing and managing data"
 maintainer="pulux <pulux@pf4sh.de>"
-license="custom"
+license="custom:BSD-3-Clause-LBNL-alike"
 homepage="https://hdfgroup.org"
 distfiles="https://www.hdfgroup.org/ftp/HDF5/current/src/hdf5-${version}.tar.gz"
 checksum=6d4ce8bf902a97b050f6f491f4268634e252a63dadd6656a1a9be5b7b7726fa8

--- a/srcpkgs/hex2hcd/template
+++ b/srcpkgs/hex2hcd/template
@@ -1,12 +1,12 @@
 # Template file for 'hex2hcd'
 pkgname=hex2hcd
 version=2016.02.21
-revision=2
+revision=3
 build_style=gnu-makefile
 short_desc="Convert *.hex firmware files to *.hcd format"
 maintainer="Antonio Malcolm <antonio@antoniomalcolm.com>"
+license="GPL-2.0-or-later"
 homepage="https://github.com/antonio-malcolm/hex2hcd"
-license="GPL-2"
 distfiles="${homepage}/archive/${version}.tar.gz"
 checksum=45cab33daa404c6e66979abea975f11cb5705152c7723a2a16391f5fd1ba847b
 conflicts="bluez" # /usr/bin/hex2hcd

--- a/srcpkgs/heyu/template
+++ b/srcpkgs/heyu/template
@@ -1,13 +1,13 @@
 # Template file for 'heyu'
 pkgname=heyu
 version=2.10.1
-revision=2
+revision=3
 build_style=configure
 configure_script="./Configure"
 configure_args="linux"
 short_desc="X10 automation for Linux"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.heyu.org"
 distfiles="https://github.com/HeyuX10Automation/heyu/archive/v${version}.tar.gz"
 checksum=621a20f45eef62070b3f95ad17ecbc3e7e1f7352d25dac86093ff6938b606baa

--- a/srcpkgs/hnb/template
+++ b/srcpkgs/hnb/template
@@ -1,11 +1,11 @@
 # Template file for 'hnb'
 pkgname=hnb
 version=1.9.17
-revision=2
+revision=3
 makedepends="ncurses-devel"
-short_desc="A curses program to structure many kinds of data in one place"
+short_desc="Curses program to structure many kinds of data in one place"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://hnb.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/hnb/hnb/${version}/hnb-${version}.tar.gz"
 checksum=c233c00aaef5b7fb93759d7888c885f99f40aec689a7f3e0d5d8b5797bf80cd4

--- a/srcpkgs/httpry/template
+++ b/srcpkgs/httpry/template
@@ -1,19 +1,19 @@
 # Template file for 'httpry'
 pkgname=httpry
 version=0.1.8
-revision=1
+revision=2
+wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-makefile
 makedepends="libpcap-devel"
 short_desc="HTTP logging and information retrieval tool"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
+license="GPL-2.0-only"
 homepage="http://dumpsterventures.com/jason/httpry/"
-license="GPL-2"
 distfiles="https://github.com/jbittel/${pkgname}/archive/${pkgname}-${version}.tar.gz"
 checksum=b3bcbec3fc6b72342022e940de184729d9cdecb30aa754a2c994073447468cf0
-wrksrc="${pkgname}-${pkgname}-${version}"
 
 post_extract() {
-	sed -i -e'/^CC /d' \
+	vsed -i -e'/^CC /d' \
 		-e 's/^CCFLAGS .*/CCFLAGS=$(CFLAGS) $(LDFLAGS)/' Makefile
 }
 

--- a/srcpkgs/httrack/template
+++ b/srcpkgs/httrack/template
@@ -1,16 +1,16 @@
 # Template file for 'httrack'
 pkgname=httrack
 version=3.49.2
-revision=7
+revision=8
 build_style=gnu-configure
 configure_args="--disable-static --with-zlib=${XBPS_CROSS_BASE}/usr"
-short_desc="A free and easy-to-use offline browser utility"
+makedepends="zlib-devel openssl-devel"
+short_desc="Free and easy-to-use offline browser utility"
 maintainer="mid-kid <esteve.varela@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="http://www.httrack.com"
 distfiles="http://mirror.httrack.com/httrack-${version}.tar.gz"
 checksum=3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025
-makedepends="zlib-devel openssl-devel"
 
 httrack-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/hyphen/template
+++ b/srcpkgs/hyphen/template
@@ -1,15 +1,19 @@
-# Template file for 'altlinuxHyph'
+# Template file for 'hyphen'
 pkgname=hyphen
 version=2.8.8
-revision=2
+revision=3
 build_style=gnu-configure
-short_desc="ALTLinux hyphenation library"
 hostmakedepends="perl"
+short_desc="ALTLinux hyphenation library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-3"
+license="GPL-2.0-or-later, LGPL-2.1-or-later, MPL-1.1"
 homepage="http://sourceforge.net/projects/hunspell/files/Hyphen"
 distfiles="${SOURCEFORGE_SITE}/hunspell/$pkgname-$version.tar.gz"
 checksum=304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705
+
+post_install() {
+	vlicense COPYING
+}
 
 hyphen-tools_package() {
 	depends="hyphen>=${version}_${revision}"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_6)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
