### PR TITLE
growlight: patch to work with notcurses v2.2.6.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3887,9 +3887,9 @@ liburing.so.2 liburing-2.0_1
 libbson-1.0.so.0 libbson-1.17.4_2
 libsonic.so.0 libsonic-0.2.0_1
 libtickit.so.3 libtickit-0.4.1_1
-libnotcurses.so.2 notcurses-2.0.4_1
-libnotcurses-core.so.2 notcurses-2.1.7_1
-libnotcurses++.so.2 notcurses-2.0.4_1
+libnotcurses.so.2 notcurses-2.2.6_1
+libnotcurses-core.so.2 notcurses-2.2.6_1
+libnotcurses++.so.2 notcurses-2.2.6_1
 libevemu.so.3 evemu-2.7.0_1
 libantilib.so.1 libantimicrox-3.1.2_1
 libinih.so.0 inih-52_1

--- a/srcpkgs/growlight/patches/1bfbad3daf23276167e28dedb73dcd1af4c9f826.diff
+++ b/srcpkgs/growlight/patches/1bfbad3daf23276167e28dedb73dcd1af4c9f826.diff
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d85c10..4c1ad5f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,7 +34,7 @@ add_compile_options(-Wall -Wextra -W -Wshadow -Wformat -fexceptions)
+ find_package(PkgConfig REQUIRED)
+ find_package(Threads)
+ set_package_properties(Threads PROPERTIES TYPE REQUIRED)
+-find_package(Notcurses 2.1.8 CONFIG)
++find_package(Notcurses 2.2.6 CONFIG)
+ set_package_properties(Notcurses PROPERTIES TYPE REQUIRED)
+ pkg_check_modules(LIBATASMART REQUIRED libatasmart>=0.19)
+ pkg_check_modules(LIBBLKID REQUIRED blkid>=2.20.1)
+diff --git a/README.md b/README.md
+index c8ef069..ec250d2 100644
+--- a/README.md
++++ b/README.md
+@@ -22,7 +22,7 @@ Dependencies:
+  - libcryptsetup 2.1.5+
+  - libdevmapper 1.02.74+
+  - libnettle 3.5.1+
+- - libnotcurses 2.1.8+
++ - libnotcurses 2.2.6+
+  - libpci 3.1.9+
+  - libpciaccess 0.13.1+
+  - libreadline 8.0+
+diff --git a/src/notcurses/notcurses.c b/src/notcurses/notcurses.c
+index 1eaf143..a56a9d3 100644
+--- a/src/notcurses/notcurses.c
++++ b/src/notcurses/notcurses.c
+@@ -622,10 +622,10 @@ cmvwhline(struct ncplane* nc, int y, int x, const char* ch, int n){
+   }
+   c.channels = ncplane_channels(nc);
+   if(ncplane_hline(nc, &c, n) != n){
+-    cell_release(nc, &c);
++    nccell_release(nc, &c);
+     return -1;
+   }
+-  cell_release(nc, &c);
++  nccell_release(nc, &c);
+   return 0;
+ }
+ 

--- a/srcpkgs/growlight/template
+++ b/srcpkgs/growlight/template
@@ -1,7 +1,7 @@
 # Template file for 'growlight'
 pkgname=growlight
 version=1.2.32
-revision=1
+revision=2
 build_style=cmake
 configure_args="$(vopt_bool zfs USE_LIBZFS) $(vopt_bool man USE_PANDOC)"
 hostmakedepends="pkg-config $(vopt_if man pandoc)"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
