### PR TITLE
fluidsynth: update to 2.2.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -957,7 +957,7 @@ libfftw3l_omp.so.3 libfftw-3.3.5_1
 libfftw3f_threads.so.3 libfftw-3.3_1
 libfftw3f.so.3 libfftw-3.3_1
 libfftw3f_omp.so.3 libfftw-3.3.5_1
-libfluidsynth.so.2 libfluidsynth-2.1.1_1
+libfluidsynth.so.3 libfluidsynth-2.2.0_1
 liblo.so.7 liblo-0.26_1
 libvamp-sdk.so.2 libvamp-plugin-sdk-2.2_1
 librubberband.so.2 librubberband-1.6.0_1

--- a/srcpkgs/Carla/template
+++ b/srcpkgs/Carla/template
@@ -1,7 +1,7 @@
 # Template file for 'Carla'
 pkgname=Carla
 version=2.1
-revision=2
+revision=3
 archs="x86_64* i686* aarch64* arm*"
 build_style=gnu-makefile
 pycompile_dirs="usr/share/carla"

--- a/srcpkgs/SLADE/template
+++ b/srcpkgs/SLADE/template
@@ -1,7 +1,7 @@
 # Template file for 'SLADE'
 pkgname=SLADE
 version=3.1.12a
-revision=4
+revision=5
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 hostmakedepends="pkg-config p7zip which"

--- a/srcpkgs/alure/template
+++ b/srcpkgs/alure/template
@@ -1,7 +1,7 @@
 # Template file for 'alure'
 pkgname=alure
 version=1.2
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DMODPLUG=ON -DDYNLOAD=OFF"
 hostmakedepends="pkg-config"

--- a/srcpkgs/ardour/template
+++ b/srcpkgs/ardour/template
@@ -1,7 +1,7 @@
 # Template file for 'ardour'
 pkgname=ardour
 version=6.6
-revision=1
+revision=2
 _commit="e4e21f4d073ab00b1a0bb6ff6ca49f28b02fd68a"
 build_style=waf3
 configure_args="--cxx11 --no-phone-home --with-backends=jack,alsa,dummy
@@ -18,6 +18,8 @@ short_desc="Professional-grade digital audio workstation"
 maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="GPL-2.0-or-later"
 homepage="http://ardour.org"
+
+CXXFLAGS="-fpermissive"
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*)  configure_args+=" --dist-target=x86_64" ;;

--- a/srcpkgs/audacious-plugins/template
+++ b/srcpkgs/audacious-plugins/template
@@ -2,7 +2,7 @@
 #Keep in sync with audacious!
 pkgname=audacious-plugins
 version=4.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="$(vopt_enable gtk) $(vopt_enable qt)"
 hostmakedepends="gettext pkg-config glib-devel"

--- a/srcpkgs/calf/template
+++ b/srcpkgs/calf/template
@@ -1,7 +1,7 @@
 # Template file for 'calf'
 pkgname=calf
 version=0.90.3
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-experimental"
 hostmakedepends="automake libtool pkg-config"

--- a/srcpkgs/csound/template
+++ b/srcpkgs/csound/template
@@ -1,7 +1,7 @@
 # Template file for 'csound'
 pkgname=csound
 version=6.15.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="
  -DLUA_MODULE_INSTALL_DIR=${XBPS_CROSS_BASE}/usr/lib/lua/5.1

--- a/srcpkgs/fluidsynth/template
+++ b/srcpkgs/fluidsynth/template
@@ -1,6 +1,6 @@
 # Template file for 'fluidsynth'
 pkgname=fluidsynth
-version=2.1.8
+version=2.2.0
 revision=1
 build_style=cmake
 make_check_target=check
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://www.fluidsynth.org/"
 distfiles="https://github.com/FluidSynth/fluidsynth/archive/v${version}.tar.gz"
-checksum=a254efceff5d99f8d658d12d25318317f37307e6df852ec9baeb7da173496967
+checksum=928fb16f307507485bd1d9b010dafba8c747bce5de2ba47ab1705944c87013b6
 
 libfluidsynth_package() {
 	short_desc+=" - runtime library"

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.18.4
-revision=2
+revision=3
 wrksrc="${pkgname/1/}-${version}"
 build_helper="gir"
 build_style=meson

--- a/srcpkgs/lmms/template
+++ b/srcpkgs/lmms/template
@@ -1,7 +1,7 @@
 # Template file for 'lmms'
 pkgname=lmms
 version=1.2.2
-revision=1
+revision=2
 archs="~armv6*"
 wrksrc=${pkgname}
 build_style=cmake

--- a/srcpkgs/prboom-plus/template
+++ b/srcpkgs/prboom-plus/template
@@ -1,7 +1,7 @@
 # Template file for 'prboom-plus'
 pkgname=prboom-plus
 version=2.5.1.4
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-cpu-opt --disable-dogs"
 hostmakedepends="pcre-devel fluidsynth-devel libmad-devel SDL_mixer-devel SDL_net-devel

--- a/srcpkgs/qsynth/template
+++ b/srcpkgs/qsynth/template
@@ -1,7 +1,7 @@
 # Template file for 'qsynth'
 pkgname=qsynth
 version=0.9.2
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper=qmake
 hostmakedepends="pkg-config qt5-tools"

--- a/srcpkgs/residualvm/template
+++ b/srcpkgs/residualvm/template
@@ -1,7 +1,7 @@
 # Template file for 'residualvm'
 pkgname=residualvm
 version=0.3.1
-revision=4
+revision=5
 build_style=configure
 configure_args="--prefix=/usr --enable-all-engines --enable-release
  --enable-flac --enable-faad --enable-fluidsynth $(vopt_enable sndio)"
@@ -11,7 +11,7 @@ makedepends="SDL2-devel libvorbis-devel libmad-devel libjpeg-turbo-devel
  glew-devel libflac-devel fluidsynth-devel faad2-devel $(vopt_if sndio sndio-devel)"
 short_desc="Cross-platform 3D game interpreter"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD, ISC, MIT, Zlib"
+license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, BSD-3-Clause, ISC, MIT, Zlib"
 homepage="https://www.residualvm.org/"
 distfiles="https://www.residualvm.org/downloads/release/${version}/residualvm-${version}-sources.tar.bz2"
 checksum=f50c83bbc55a8121eefc279e83982b6ec590e608e145b7f750006619dd0bf9e9
@@ -41,4 +41,7 @@ post_install() {
 	# move licenses to the right place
 	vmkdir usr/share/licenses/residualvm
 	mv ${DESTDIR}/usr/share/doc/residualvm/COPYING* ${DESTDIR}/usr/share/licenses/residualvm/
+	vlicense COPYING.BSD
+	vlicense COPYING.ISC
+	vlicense COPYING.MIT
 }

--- a/srcpkgs/scummvm/patches/fluidsynth-2.2.0.diff
+++ b/srcpkgs/scummvm/patches/fluidsynth-2.2.0.diff
@@ -1,0 +1,25 @@
+--- audio/softsynth/fluidsynth.cpp
++++ audio/softsynth/fluidsynth.cpp
+@@ -144,11 +144,11 @@
+ 	return p;
+ }
+ 
+-static int SoundFontMemLoader_read(void *buf, int count, void *handle) {
++static int SoundFontMemLoader_read(void *buf, fluid_long_long_t count, void *handle) {
+ 	return ((Common::SeekableReadStream *) handle)->read(buf, count) == (uint32)count ? FLUID_OK : FLUID_FAILED;
+ }
+ 
+-static int SoundFontMemLoader_seek(void *handle, long offset, int origin) {
++static int SoundFontMemLoader_seek(void *handle, fluid_long_long_t offset, int origin) {
+ 	return ((Common::SeekableReadStream *) handle)->seek(offset, origin) ? FLUID_OK : FLUID_FAILED;
+ }
+ 
+@@ -157,7 +157,7 @@
+ 	return FLUID_OK;
+ }
+ 
+-static long SoundFontMemLoader_tell(void *handle) {
++static fluid_long_long_t SoundFontMemLoader_tell(void *handle) {
+ 	return ((Common::SeekableReadStream *) handle)->pos();
+ }
+ #endif

--- a/srcpkgs/scummvm/template
+++ b/srcpkgs/scummvm/template
@@ -1,7 +1,7 @@
 # Template file for 'scummvm'
 pkgname=scummvm
 version=2.2.0
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr --enable-release-mode
  --with-sdl-prefix=${XBPS_CROSS_BASE}/usr"
@@ -14,7 +14,7 @@ short_desc="Free implementation of LucasArts' SCUMM interpreter"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://www.scummvm.org/"
-distfiles="https://www.scummvm.org/frs/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
+distfiles="https://downloads.scummvm.org/frs/${pkgname}/${version}/${pkgname}-${version}.tar.xz"
 checksum=1469657e593bd8acbcfac0b839b086f640ebf120633e93f116cab652b5b27387
 
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/tuxguitar/template
+++ b/srcpkgs/tuxguitar/template
@@ -1,7 +1,7 @@
 # Template file for 'tuxguitar'
 pkgname=tuxguitar
 version=1.5.4
-revision=1
+revision=2
 wrksrc="${pkgname}-${version}-src"
 hostmakedepends="apache-maven openjdk8"
 makedepends="alsa-lib-devel fluidsynth-devel jack-devel"


### PR DESCRIPTION
I did not test each of the rebuilt packages, but they all compile successfully.

`ardour` requires `-fpermissive` even without updating fluidsynth.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
