### PR TITLE
[RFC] screen: don't enable multiuser mode by default.

### DIFF
--- a/srcpkgs/screen/template
+++ b/srcpkgs/screen/template
@@ -1,7 +1,7 @@
 # Template file for 'screen'
 pkgname=screen
 version=4.8.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-sys-screenrc=/etc/screenrc --enable-pam
  --enable-colors256 --enable-rxvt_osc --enable-telnet
@@ -15,10 +15,14 @@ homepage="http://www.gnu.org/s/screen/"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=6e11b13d8489925fde25dfb0935bf6ed71f9eb47eff233a181e078fde5655aa1
 
+build_options="multiuser"
+
 post_install() {
 	vinstall etc/etcscreenrc 0644 etc screenrc
 	vinstall etc/screenrc 0644 etc/skel .screenrc
 	vinstall ${FILESDIR}/screen 0644 etc/pam.d
 
-	chmod 4755 ${DESTDIR}/usr/bin/screen-${version}
+	if [ "$build_option_multiuser" ]; then
+		chmod 4755 ${DESTDIR}/usr/bin/screen-${version}
+	fi
 }


### PR DESCRIPTION
This requires that the screen binary be suid.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
