### PR TITLE
ocs-url: added qt5-quickcontrols as a dependency

### DIFF
--- a/srcpkgs/ocs-url/template
+++ b/srcpkgs/ocs-url/template
@@ -1,11 +1,12 @@
 # Template file for 'ocs-url'
 pkgname=ocs-url
 version=3.1.0
-revision=1
+revision=2
 wrksrc="ocs-url-release-${version}"
 build_style="qmake"
 hostmakedepends="qt5-qmake kdeclarative-devel qt5-svg-devel qt5-declarative-devel"
 makedepends="qt5-svg-devel kdeclarative-devel qt5-declarative-devel"
+depends="qt5-quickcontrols"
 short_desc="Install helper program for OpenCollaborationServices (ocs://)"
 maintainer="ThatGeekyWeeb <thatgeekyweeb@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
there is a runtime error of 
```
QQmlApplicationEngine failed to load component
qrc:/qml/main.qml:3:1: module "QtQuick.Controls" is not installed
```
caused by this package missing  
said error prevents the installation of any ocs-url package, as ocs-url simply does nothing at all after displaying the error message..

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
