### PR TITLE
nginx: configure with --with-compat for dynamic module support

### DIFF
--- a/srcpkgs/nginx/template
+++ b/srcpkgs/nginx/template
@@ -1,7 +1,7 @@
 # Template file for 'nginx'
 pkgname=nginx
 version=1.18.0
-revision=5
+revision=6
 build_style=gnu-makefile
 hostmakedepends="openssl-devel pcre-devel $(vopt_if geoip geoip-devel)"
 makedepends="${hostmakedepends}"
@@ -55,6 +55,7 @@ do_configure() {
 
 	./configure --prefix=${cfgdir} \
 		--conf-path=${cfgdir}/nginx.conf \
+		--with-compat \
 		--sbin-path=/usr/bin/nginx \
 		--pid-path=/run/nginx.pid \
 		--lock-path=/var/lock/nginx.lock \


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!--
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [X] armv7l
  - [ ] armv6l-musl
-->

This change is required for dynamic modules to work, as mentioned in [this tutorial](https://www.nginx.com/blog/compiling-dynamic-modules-nginx-plus/):
"`--with-compat` ... creates a standard build environment supported by both NGINX Open Source and NGINX Plus."