### PR TITLE
zita-njbridge: update to 0.4.8

### DIFF
--- a/srcpkgs/zita-njbridge/template
+++ b/srcpkgs/zita-njbridge/template
@@ -1,6 +1,6 @@
 # Template file for 'zita-njbridge'
 pkgname=zita-njbridge
-version=0.4.4
+version=0.4.8
 revision=1
 build_wrksrc="source"
 build_style=gnu-makefile
@@ -10,4 +10,4 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later"
 homepage="https://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="https://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
-checksum=12bdcf6b2e3fcfecd30e0b57ad43e095196fb47b4d9392ebc10f5c28dbd719d1
+checksum=101176a0bd407cab7bffd326e8d6886c1b65b212bc33f2efb97b03f926c47907


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes <s>on a regular basis</s> and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

tested on x86_64 and x86_64-musl

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
