### PR TITLE
libluv: update to 1.41.0.0.

### DIFF
--- a/srcpkgs/libluv/template
+++ b/srcpkgs/libluv/template
@@ -1,6 +1,6 @@
 # Template file for 'libluv'
 pkgname=libluv
-version=1.36.0.0
+version=1.41.0.0
 revision=1
 _distver="${version%.*}-${version##*.}"
 wrksrc=luv-${_distver}
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://github.com/luvit/luv"
 distfiles="https://github.com/luvit/luv/releases/download/${_distver}/luv-${_distver}.tar.gz
 			https://raw.githubusercontent.com/luvit/luv/${_distver}/libluv.pc.in"
-checksum="f2e7eb372574f25c6978c1dc74280d22efdcd7df2dda4a286c7fe7dceda26445
+checksum="4018f293d71c2d75757b64fcdacf982729c9dc8b0bf8eda4015a8818a5a29321
  be2a4909c724e09a50de42b1caa3c82c1b1afee8b80abf20c6944f1df1c7fd0e"
 skip_extraction="libluv.pc.in"
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
`libluv` is a dependency of `neovim`, it's only used by that package.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 

- [X] I built this PR locally for my native architecture, x86_64-glibc
- [ ] I built this PR locally for these architectures:
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl