### PR TITLE
gst-plugins-ugly1: Fix not building 32bit package

### DIFF
--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
 version=1.18.4
-revision=1
+revision=2
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
 configure_args="-Damrnb=disabled -Damrwbdec=disabled -Dsidplay=disabled"
@@ -17,4 +17,3 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
 checksum=218df0ce0d31e8ca9cdeb01a3b0c573172cc9c21bb3d41811c7820145623d13c
-lib32disabled=yes


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
  - [x] i686 (cross)

I didn't test any arm or others, but they should work fine because all this changes is the ability to build 32bit packages which I did test.