### PR TITLE
base-files: disable unprivileged eBPF by default.

### DIFF
--- a/srcpkgs/base-files/files/bpf.conf
+++ b/srcpkgs/base-files/files/bpf.conf
@@ -1,0 +1,2 @@
+# Block unprivileged use of eBPF
+kernel.unprivileged_bpf_disabled=1

--- a/srcpkgs/base-files/files/sysctl.conf
+++ b/srcpkgs/base-files/files/sysctl.conf
@@ -2,7 +2,7 @@
 # User-alterable options are in 10-void-user.conf.
 
 # Append the PID to the core filename
-kernel.core_uses_pid = 1
+kernel.core_uses_pid=1
 
 # Enable hard and soft link protection
 fs.protected_hardlinks=1

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,6 +1,6 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.141
+version=0.142
 revision=11
 bootstrap=yes
 depends="xbps-triggers"
@@ -75,6 +75,7 @@ do_install() {
 	# sysctl(8) files
 	vinstall ${FILESDIR}/sysctl.conf 644 usr/lib/sysctl.d 10-void.conf
 	vinstall ${FILESDIR}/sysctl-user.conf 644 usr/lib/sysctl.d 10-void-user.conf
+	vinstall ${FILESDIR}/bpf.conf 644 usr/lib/sysctl.d 20-bpf.conf
 
 	# Install common licenses, from Debian.
 	vmkdir usr/share/licenses


### PR DESCRIPTION
eBPF allowed a fair amount of local privilege escalation in
the past, disallow it for ordinary users by default.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
