### PR TITLE
kmod: fix license

### DIFF
--- a/srcpkgs/kmod/template
+++ b/srcpkgs/kmod/template
@@ -1,7 +1,7 @@
 # Template file for 'kmod'
 pkgname=kmod
 version=27
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-zlib --with-xz"
 hostmakedepends="pkg-config"
@@ -13,7 +13,7 @@ make_dirs="
  /usr/lib/modprobe.d 0755 root root"
 short_desc="Linux kernel module handling"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-2.0-only"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
 distfiles="${KERNEL_SITE}/utils/kernel/kmod/kmod-${version}.tar.xz"
 checksum=c1d3fbf16ca24b95f334c1de1b46f17bbe5a10b0e81e72668bdc922ebffbbc0c


### PR DESCRIPTION
From the `README` file in the `wrksrc` for `kmod`:
```
License:
        LGPLv2.1+ for libkmod, testsuite and helper libraries
        GPLv2+ for tools/*
```
The `+` is meant to mean that one can redistribute it under a later version of the respective license (e.g. `GPLv2+ -> GPL-2.0-or-later`).