### PR TITLE
python3: remove obsolete --with-threads configure option

### DIFF
--- a/srcpkgs/python3-tkinter/template
+++ b/srcpkgs/python3-tkinter/template
@@ -47,7 +47,7 @@ do_configure() {
 	fi
 	./configure ${configure_args} ${_args} \
 		--enable-shared --enable-ipv6 --enable-loadable-sqlite-extensions \
-		--with-threads --with-computed-gotos --with-dbmliborder=gdbm:ndbm \
+		--with-computed-gotos --with-dbmliborder=gdbm:ndbm \
 		--with-system-expat --with-system-ffi --without-ensurepip
 }
 

--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -48,7 +48,7 @@ do_configure() {
 	fi
 	./configure ${configure_args} ${_args} \
 		--enable-shared --enable-ipv6 --enable-loadable-sqlite-extensions \
-		--with-threads --with-computed-gotos --with-dbmliborder=gdbm:ndbm \
+		--with-computed-gotos --with-dbmliborder=gdbm:ndbm \
 		--with-system-expat --with-system-ffi --without-ensurepip
 }
 


### PR DESCRIPTION
Thread-less builds became unsupported in upstream commit a6a4dc816d68
("bpo-31370: Remove support for threads-less builds (#3385)"), and as
such this config option has been unrecognized since python3.7.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
