### PR TITLE
wireshark: update to 3.4.5.

### DIFF
--- a/srcpkgs/wireshark/template
+++ b/srcpkgs/wireshark/template
@@ -1,6 +1,6 @@
 # Template file for 'wireshark'
 pkgname=wireshark
-version=3.4.2
+version=3.4.5
 revision=1
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=None"
@@ -17,7 +17,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.wireshark.org"
 distfiles="https://www.wireshark.org/download/src/${pkgname}-${version}.tar.xz"
-checksum=de9868729e426a469baabd8d444240d84fa5445020e92c842dd19afd0d47a4c4
+checksum=de1aafd100a1e1207c850d180e97dd91ab8da0f5eb6beec545f725cdb145d333
 system_groups="wireshark"
 
 CFLAGS="-DNDEBUG -I${XBPS_CROSS_BASE}/usr/include/lua5.2"
@@ -30,7 +30,7 @@ post_patch() {
 }
 
 pre_check() {
-	make ${makejobs} -C build test-programs
+	ninja -C build test-programs
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

Switch to ninja (our default cmake generator) in `pre_check()` otherwise I get
```
make: *** No rule to make target 'test-programs'.  Stop.
```

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!--
#### Does it build and run successfully?
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
