### PR TITLE
dolphin-plugins: update to 21.04.0

### DIFF
--- a/srcpkgs/dolphin-plugins/template
+++ b/srcpkgs/dolphin-plugins/template
@@ -1,6 +1,6 @@
 # Template file for 'dolphin-plugins'
 pkgname=dolphin-plugins
-version=20.12.3
+version=21.04.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext qt5-qmake qt5-host-tools kcoreaddons kconfig"
@@ -10,4 +10,4 @@ maintainer="Domenico Panella <pandom79@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://kde.org/applications/en/system/org.kde.dolphin_plugins"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=fcb2ca9acf2ef3b7aaa8d5bf66920fc79983952cda7223416d172802ad9a5e80
+checksum=9fb395bfc62b726a4feae87b89d97294262cdadbeadf69706d7f314b1ff488d2


### PR DESCRIPTION
Dolphin and dolphin-plugins packages always have to be at the same version.
Currently, dolphin crashes if an older dolphin-plugins version is installed.
