### PR TITLE
rust-analyzer: update to 2021.04.20, rust: update to 1.51, cargo: update to 0.51.0

### DIFF
--- a/srcpkgs/cargo/template
+++ b/srcpkgs/cargo/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo'
 pkgname=cargo
-version=0.49.0
-revision=2
+version=0.51.0
+revision=1
 wrksrc="cargo-${version}"
 build_helper=rust
 hostmakedepends="rust python3 curl cmake pkg-config zlib-devel"
@@ -21,14 +21,14 @@ desc_option_bindist="Generate a tarball for bootstrap"
 # rust upstream no longer ships cargo-versioned tarballs
 # need to use the corresponding rust version instead
 _bootstrap_url="https://static.rust-lang.org/dist"
-_cargo_dist_version="1.48.0"
+_cargo_dist_version="1.51.0"
 
 case "$XBPS_MACHINE" in
 	x86_64*|i686|ppc64le) ;;
 	ppc*)
 		# custom bootstrap tarballs still use cargo versioning, so override
 		_bootstrap_url="https://alpha.de.repo.voidlinux.org/distfiles"
-		_cargo_dist_version="0.49.0"
+		_cargo_dist_version="0.51.0"
 		;;
 esac
 

--- a/srcpkgs/rust-analyzer/template
+++ b/srcpkgs/rust-analyzer/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-analyzer'
 pkgname=rust-analyzer
-version=2021.03.08
+version=2021.04.20
 revision=1
 _ver=${version//./-}
 wrksrc="${pkgname}-${_ver}"
@@ -11,7 +11,7 @@ maintainer="Gabriel Sanches <gabriel@gsr.dev>"
 license="Apache-2.0, MIT"
 homepage="https://rust-analyzer.github.io/"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/${_ver}.tar.gz"
-checksum=75d810a4b3fd08d8d0948186f077b754ab9a2a02af3d3c6947e0baa58576e43d
+checksum=f22fdc42fd72ab67cb32a4ed2d01e8d5e68fe30b3ed04f2c4029c5a7cbe99739
 
 export RUST_ANALYZER_REV=${_ver}
 

--- a/srcpkgs/rust-analyzer/update
+++ b/srcpkgs/rust-analyzer/update
@@ -1,0 +1,3 @@
+site=https://github.com/rust-analyzer/rust-analyzer/tags
+version=${version//./-}
+pattern="/archive/refs/tags/\K[\d\-]+(?=\.tar\.gz)"

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -8,9 +8,9 @@
 # uploaded to https://alpha.de.repo.voidlinux.org/distfiles/
 #
 pkgname=rust
-version=1.48.0
+version=1.51.0
 revision=1
-_rust_dist_version=1.48.0
+_rust_dist_version=1.51.0
 wrksrc="rustc-${version}-src"
 hostmakedepends="cmake curl pkg-config python3 tar"
 makedepends="libffi-devel ncurses-devel libxml2-devel zlib-devel llvm11"
@@ -20,7 +20,10 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT, Apache-2.0"
 homepage="https://www.rust-lang.org/"
 distfiles="https://static.rust-lang.org/dist/rustc-${version}-src.tar.gz"
-checksum="0e763e6db47d5d6f91583284d2f989eacc49b84794d1443355b85c58d67ae43b"
+checksum="7a6b9bafc8b3d81bbc566e7c0d1f17c9f499fd22b95142f7ea3a8e4d1f9eb847
+ 
+ 
+ "
 lib32disabled=yes
 patch_args="-Np1"
 
@@ -38,7 +41,7 @@ case "$XBPS_MACHINE" in
 	ppc*)
 		# custom bootstrap tarballs still use cargo versioning, so override
 		_bootstrap_url="https://alpha.de.repo.voidlinux.org/distfiles"
-		_cargo_dist_version="0.49.0"
+		_cargo_dist_version="0.51.0"
 		;;
 esac
 
@@ -49,11 +52,11 @@ distfiles+=" ${_bootstrap_url}/cargo-${_cargo_dist_version}-${RUST_BUILD}.tar.xz
 case "$XBPS_MACHINE" in
 	i686)
 		checksum+="
-		 1eab76df91e87198632605752d0dd66f3d84b502cbd1f982f6db3d0d8d943cdb"
+		 706417391b73a2f8fd90fe664d2dc4003cd623eabcd7805eebcefe56011965a7"
 		;;
 	x86_64)
 		checksum+="
-		 b11d595581e2580c069b5039214e1031a0e4f87ff6490ac39f92f77857e37055"
+		 2c557e448c145ed773baae0d6533449947bb130f8f8a2a0876d08f55b74a313f"
 		;;
 	x86_64-musl)
 		checksum+="
@@ -109,8 +112,8 @@ else
 			;;
 		x86_64)
 			checksum+="
-			 fc4d292a52cbb6b84fb9f065d0d7596064a9b957381d639d5a750d6e2bf02483
-			 1c00a6a0dabbf6290728b09f9307d9fa6cc985487f727075c68acd4a600ef3f8"
+			 feef13f6cd5072f30e2c121b7775d7ac5316998fcf03b68b2537684f3a7fe24a
+			 1199ba8351bb88166050c0fb15a55a23b20b6ead098d7637aaca53b91c5e68ca"
 			;;
 		x86_64-musl)
 			checksum+="


### PR DESCRIPTION
It seems that Void uses outdated version of Rust without const generics, that's why new `rust-analyzer` fails to compile.
I suggest updating `rust`, `cargo` & `rust-analyzer`. Unfortunately, I can't do it since `rust`'s package `template` file instructs `xbps-src` to download bootstrap `rustc`, `rust-std` & `cargo` from https://alpha.de.repo.voidlinux.org/distfiles/, and this URL contains `rust-1.48` only. I guess only Void members can add `rust-1.51`

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
