### PR TITLE
hugo: enable `extended` option by default

### DIFF
--- a/srcpkgs/hugo/template
+++ b/srcpkgs/hugo/template
@@ -1,12 +1,11 @@
 # Template file for 'hugo'
 pkgname=hugo
 version=0.82.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/gohugoio/hugo"
 go_build_tags="$(vopt_if extended extended)"
-hostmakedepends="git"
-depends="$(vopt_if pygments python-Pygments)"
+depends="$(vopt_if pygments python3-Pygments)"
 short_desc="Fast & Modern Static Website Engine"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"
@@ -15,6 +14,7 @@ distfiles="https://github.com/gohugoio/hugo/archive/v${version}.tar.gz"
 checksum=3190ae848fdb1a04339c233faab5934c422d85cf85ea3b0c0b5a842239c84e75
 
 build_options="pygments extended"
+build_options_default="extended"
 desc_option_pygments="Alternative syntax highlighter"
 desc_option_extended="SASS/SCSS build support for Hugo"
 


### PR DESCRIPTION
Sass support is nice to have even though most people might not
use it.
Also fix to use the right `Pygments` package name and
remove `git` in hostmakedepends.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
