### PR TITLE
pulseaudio: split pulseaudio-utils, document optional dependency python3-PyQt5-dbus

### DIFF
--- a/srcpkgs/pulseaudio-utils
+++ b/srcpkgs/pulseaudio-utils
@@ -1,0 +1,1 @@
+pulseaudio

--- a/srcpkgs/pulseaudio/files/README.voidlinux
+++ b/srcpkgs/pulseaudio/files/README.voidlinux
@@ -1,3 +1,7 @@
 The system service `/etc/sv/pulseaudio` provided by the pulseaudio package is
 only needed in rare cases and should be avoided in most setups for performance
 and security reasons.
+
+Optional dependencies:
+
+* `python3-PyQt5-dbus` for running `qpaeq`

--- a/srcpkgs/pulseaudio/template
+++ b/srcpkgs/pulseaudio/template
@@ -1,7 +1,7 @@
 # Template file for 'pulseaudio'
 pkgname=pulseaudio
 version=14.2
-revision=3
+revision=4
 build_style=meson
 # XXX: new version should be able to enable systemd functionality using elogind
 configure_args="-Djack=enabled -Dlirc=disabled -Dhal-compat=false -Dorc=enabled
@@ -15,7 +15,7 @@ makedepends="$(vopt_if avahi avahi-libs-devel) eudev-libudev-devel fftw-devel ja
  libcap-devel libcap-progs libglib-devel libltdl-devel openssl-devel
  libsndfile-devel libsoxr-devel orc-devel sbc-devel speex-devel tdb-devel
  webrtc-audio-processing-devel xcb-util-devel check-devel"
-depends="rtkit"
+depends="pulseaudio-utils>=${version}_${revision} rtkit"
 conf_files="/etc/pulse/*"
 short_desc="Featureful, general-purpose sound server"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -74,5 +74,19 @@ pulseaudio-devel_package() {
 		vmove usr/lib/libpulse-simple.so
 		vmove usr/lib/libpulse-mainloop-glib.so
 		vmove usr/share/vala
+	}
+}
+
+pulseaudio-utils_package() {
+	short_desc+=" - utilities"
+	pkg_install() {
+		for b in pacat pacmd pactl padsp pamon paplay parec \
+				 parecord pasuspender pax11publish; do
+			vmove usr/bin/$b
+			vmove usr/share/man/man1/${b}.1
+		done
+		vmove usr/bin/pa-info
+		vmove usr/share/bash-completion
+		vmove usr/share/zsh
 	}
 }


### PR DESCRIPTION
Split pulseaudio utilities from the main `pulseaudio` package, useful
for `pipewire-pulse`.

Closes #29576
Closes #29405

One question: Should the `bash` and `zsh` completions be split into `-utils`? Without it, only installing `-utils` and trying to autocomplete will result in errors like `zsh: _pulseaudio: function definition file not found`

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl (crossbuild)
  - [ ] armv7l
  - [ ] armv6l-musl
