### PR TITLE
Use system libuv in nodejs and nodejs-lts, fix nodejs-lts-10 build on armv6l

### DIFF
--- a/srcpkgs/http-parser/patches/cve_2020_8287.patch
+++ b/srcpkgs/http-parser/patches/cve_2020_8287.patch
@@ -1,0 +1,56 @@
+Upstream: no
+Patch from NodeJS's vendored version:
+https://github.com/nodejs/node/commit/fc70ce08f5818a286fb5899a1bc3aff5965a745e
+
+--- http_parser.c
++++ http_parser.c
+@@ -1344,6 +1344,13 @@ size_t http_parser_execute (http_parser *parser,
+               } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
+                 parser->header_state = h_transfer_encoding;
+                 parser->uses_transfer_encoding = 1;
++
++                /* Multiple `Transfer-Encoding` headers should be treated as
++                 * one, but with values separate by a comma.
++                 *
++                 * See: https://tools.ietf.org/html/rfc7230#section-3.2.2
++                 */
++                parser->flags &= ~F_CHUNKED;
+               }
+               break;
+ 
+--- test.c
++++ test.c
+@@ -2154,6 +2154,32 @@ const struct message responses[] =
+   ,.body= "2\r\nOK\r\n0\r\n\r\n"
+   ,.num_chunks_complete= 0
+   }
++#define HTTP_200_DUPLICATE_TE_NOT_LAST_CHUNKED 30
++, {.name= "HTTP 200 response with `chunked` and duplicate Transfer-Encoding"
++  ,.type= HTTP_RESPONSE
++  ,.raw= "HTTP/1.1 200 OK\r\n"
++         "Transfer-Encoding: chunked\r\n"
++         "Transfer-Encoding: identity\r\n"
++         "\r\n"
++         "2\r\n"
++         "OK\r\n"
++         "0\r\n"
++         "\r\n"
++  ,.should_keep_alive= FALSE
++  ,.message_complete_on_eof= TRUE
++  ,.http_major= 1
++  ,.http_minor= 1
++  ,.status_code= 200
++  ,.response_status= "OK"
++  ,.content_length= -1
++  ,.num_headers= 2
++  ,.headers=
++    { { "Transfer-Encoding", "chunked" }
++    , { "Transfer-Encoding", "identity" }
++    }
++  ,.body= "2\r\nOK\r\n0\r\n\r\n"
++  ,.num_chunks_complete= 0
++  }
+ };
+ 
+ /* strnlen() is a POSIX.2008 addition. Can't rely on it being available so
+

--- a/srcpkgs/http-parser/template
+++ b/srcpkgs/http-parser/template
@@ -1,15 +1,18 @@
 # Template file for 'http-parser'
 pkgname=http-parser
-version=2.9.4
+# 2.9.4, plus upstream commits through ec8b5ee, plus fc70ce0 from nodejs/node
+version=2.9.4.20201223
 revision=1
+_githash=ec8b5ee63f0e51191ea43bb0c6eac7bfbff3141d
+wrksrc="${pkgname}-${_githash}"
 build_style=gnu-makefile
 make_build_target=library
 short_desc="HTTP request/response parser for c"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
-homepage="https://github.com/joyent/http-parser"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=467b9e30fd0979ee301065e70f637d525c28193449e1b13fbcb1b1fab3ad224f
+homepage="https://github.com/nodejs/http-parser"
+distfiles="${homepage}/archive/${_githash}.tar.gz"
+checksum=765a21444322ea2476ca1e3cfeb74d280eeb37f4713cf52d2bf398dabf6e4128
 
 pre_install() {
 	vmkdir usr/lib/pkgconfig

--- a/srcpkgs/nodejs-lts-10/patches/atomic8.patch
+++ b/srcpkgs/nodejs-lts-10/patches/atomic8.patch
@@ -1,0 +1,14 @@
+--- node.gyp
++++ node.gyp
+@@ -479,6 +479,11 @@
+       'msvs_disabled_warnings!': [4244],
+ 
+       'conditions': [
++        [ 'target_arch=="mips" or target_arch=="mipsel" or target_arch=="ppc" or target_arch=="arm"', {
++	  'link_settings': {
++	    'libraries': [ '-latomic' ],
++	  },
++	}],
+         [ 'node_code_cache_path!=""', {
+           'sources': [ '<(node_code_cache_path)' ]
+         }, {

--- a/srcpkgs/nodejs-lts-10/patches/ppc32.patch
+++ b/srcpkgs/nodejs-lts-10/patches/ppc32.patch
@@ -9,20 +9,6 @@
      '__x86_64__'  : 'x64',
      '__s390__'    : 's390',
      '__s390x__'   : 's390x',
---- node.gyp
-+++ node.gyp
-@@ -479,6 +479,11 @@
-       'msvs_disabled_warnings!': [4244],
- 
-       'conditions': [
-+        [ 'host_arch=="mips" or host_arch=="mipsel" or host_arch=="ppc"', {
-+	  'link_settings': {
-+	    'libraries': [ '-latomic' ],
-+	  },
-+	}],
-         [ 'node_code_cache_path!=""', {
-           'sources': [ '<(node_code_cache_path)' ]
-         }, {
 --- deps/v8/src/libsampler/sampler.cc
 +++ deps/v8/src/libsampler/sampler.cc
 @@ -418,9 +418,15 @@ void SignalHandler::FillRegisterState(void* context, RegisterState* state) {

--- a/srcpkgs/nodejs-lts-10/template
+++ b/srcpkgs/nodejs-lts-10/template
@@ -1,14 +1,16 @@
 # Template file for 'nodejs-lts-10'
 pkgname=nodejs-lts-10
 version=10.24.0
-revision=1
+revision=2
 wrksrc="node-v${version}"
-hostmakedepends="pkg-config python zlib-devel which $(vopt_if icu icu-devel)
- $(vopt_if ssl openssl-devel) $(vopt_if libuv libuv-devel)
+# atomic8.patch will pull in -latomic even for some architectures
+# not covered by XBPS_TARGET_NO_ATOMIC8.
+hostmakedepends="pkg-config python which zlib-devel libatomic-devel
+ $(vopt_if icu icu-devel) $(vopt_if ssl openssl-devel) $(vopt_if libuv libuv-devel)
  $(vopt_if http_parser http-parser-devel) $(vopt_if nghttp2 nghttp2-devel)
  $(vopt_if cares c-ares-devel)"
-makedepends="zlib-devel python-devel $(vopt_if icu icu-devel)
- $(vopt_if ssl openssl-devel) $(vopt_if libuv libuv-devel)
+makedepends="libatomic-devel zlib-devel python-devel
+ $(vopt_if icu icu-devel) $(vopt_if ssl openssl-devel) $(vopt_if libuv libuv-devel)
  $(vopt_if http_parser http-parser-devel) $(vopt_if nghttp2 nghttp2-devel)
  $(vopt_if cares c-ares-devel)"
 checkdepends="procps-ng"
@@ -18,7 +20,7 @@ license="MIT"
 homepage="https://nodejs.org/"
 distfiles="${homepage}/download/release/v${version}/node-v${version}.tar.xz"
 checksum=158273af66f891b2fca90aec7336c42f7574f467affad02c14e80ca163cb3acc
-python_version=2 #unverified
+python_version=3
 
 build_options="ssl libuv http_parser icu nghttp2 cares"
 desc_option_ssl="Enable shared openssl"
@@ -35,13 +37,6 @@ provides="nodejs-runtime-0_1"
 
 if [ "$XBPS_WORDSIZE" -ne "$XBPS_TARGET_WORDSIZE" ]; then
 	nocross="host and target must have the same pointer size"
-fi
-
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
-	makedepends+=" libatomic-devel"
-fi
-if [ "$XBPS_NO_ATOMIC8" ]; then
-	hostmakedepends+=" libatomic-devel"
 fi
 
 CFLAGS="-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64"

--- a/srcpkgs/nodejs-lts/patches/shared-uv.patch
+++ b/srcpkgs/nodejs-lts/patches/shared-uv.patch
@@ -1,0 +1,25 @@
+--- deps/uvwasi/uvwasi.gyp.orig
++++ deps/uvwasi/uvwasi.gyp
+@@ -18,9 +18,6 @@
+         'src/wasi_rights.c',
+         'src/wasi_serdes.c',
+       ],
+-      'dependencies': [
+-        '../uv/uv.gyp:libuv',
+-      ],
+       'direct_dependent_settings': {
+         'include_dirs': ['include']
+       },
+@@ -31,6 +28,12 @@
+             '_POSIX_C_SOURCE=200112',
+           ],
+         }],
++        [ 'node_shared_libuv=="false"', {
++          'dependencies': [ '../uv/uv.gyp:libuv' ],
++        }],
++        [ 'node_shared_libuv=="true"', {
++          'libraries': [ '-luv' ],
++        }]
+       ],
+     }
+   ]

--- a/srcpkgs/nodejs-lts/template
+++ b/srcpkgs/nodejs-lts/template
@@ -1,7 +1,7 @@
 # Template file for 'nodejs-lts'
 pkgname=nodejs-lts
 version=12.21.0
-revision=1
+revision=2
 wrksrc="node-v${version}"
 # Need these for host v8 for torque, see https://github.com/nodejs/node/pull/21079
 hostmakedepends="pkg-config python libatomic-devel zlib-devel which

--- a/srcpkgs/nodejs/patches/shared-uv.patch
+++ b/srcpkgs/nodejs/patches/shared-uv.patch
@@ -16,7 +16,7 @@
          }],
 +        [ 'node_shared_libuv=="false"', {
 +          'dependencies': [ '../uv/uv.gyp:libuv' ],
-+        }]
++        }],
 +        [ 'node_shared_libuv=="true"', {
 +          'libraries': [ '-luv' ],
 +        }]

--- a/srcpkgs/nodejs/template
+++ b/srcpkgs/nodejs/template
@@ -1,7 +1,7 @@
 # Template file for 'nodejs'
 pkgname=nodejs
 version=14.16.0
-revision=1
+revision=2
 wrksrc="node-v${version}"
 # Need these for host v8 for torque, see https://github.com/nodejs/node/pull/21079
 hostmakedepends="which pkg-config python3 libatomic-devel zlib-devel


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

This addresses #29034. I've verified that the libuv changes cause the `node` binary to depend on `libuv.so` and that it doesn't cause any (additional) test failures on my machine, and I've checked that `nodejs-lts-10` at least compiles on armv6l (don't have any test hardware).

The changes to `nodejs-lts-10` will link with `-latomic` on any `arm` architecture, not just ones where `XBPS_TARGET_NO_ATOMIC8` is set, but I did check and the resulting binary doesn't depend on libatomic on (say) armv7l where it's not needed. I think this is the best I can do without finding a way to pass `XBPS_TARGET_NO_ATOMIC8` into node-gyp.

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
