### PR TITLE
coin3: fix cmake support for crossbuild

### DIFF
--- a/srcpkgs/coin3/template
+++ b/srcpkgs/coin3/template
@@ -1,10 +1,10 @@
 # Template file for 'coin3'
 pkgname=coin3
 version=4.0.0
-revision=1
+revision=2
 wrksrc="coin-Coin-${version}"
 build_style=cmake
-configure_args="-DCMAKE_INSTALL_INCLUDEDIR=/usr/include/Coin3
+configure_args="-DCMAKE_INSTALL_INCLUDEDIR=include/Coin3
  -DCOIN_BUILD_TESTS=OFF -DCOIN_BUILD_DOCUMENTATION=ON"
 hostmakedepends="doxygen graphviz"
 makedepends="boost-devel glu-devel"


### PR DESCRIPTION
CMAKE_INSTALL_INCLUDEDIR must be a relative path. This way, generated
coin-export.cmake will compute include path at runtime against installed path,
that is fine for crossbuild.
If full path is provided, generated coin-export.cmake use directly this full
path, that is wrong with of crossbuild usage.

Fine to crossbuild python3-pivy 0.6.6 (PR to come)

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
