### PR TITLE
orientdb: update to 3.1.11

### DIFF
--- a/srcpkgs/orientdb/template
+++ b/srcpkgs/orientdb/template
@@ -1,18 +1,17 @@
 # Template file for 'orientdb'
 pkgname=orientdb
-version=2.2.29
-revision=2
+version=3.1.11
+revision=1
 archs="i686 x86_64"
 conf_files="/etc/${pkgname}/*"
-wrksrc="${pkgname}-community-${version}"
 depends="virtual?java-runtime"
 short_desc="Distributed Graph Database"
 maintainer="bougyman <bougyman@rubyists.com>"
 license="Apache-2.0"
-patch_args="-p1"
-homepage="http://orientdb.com"
-distfiles="http://www.orientdb.com/download.php?email=unknown@unknown.com&file=orientdb-community-${version}.tar.gz&os=linux>orientdb-community-${version}.tar.gz"
-checksum=0e4f5d5150afcfb509dcafd6dced587d70f521dab4e27980e30c76c69be78ea9
+homepage="https://orientdb.org"
+distfiles="https://s3.us-east-2.amazonaws.com/orientdb3/releases/${version}/orientdb-${version}.tar.gz"
+checksum=73830279a5587de17ea4f5864598a0829bb03212d6cd36d185fe126a46086236
+patch_args="-Np1"
 system_accounts="orientdb"
 
 do_install() {

--- a/srcpkgs/orientdb/update
+++ b/srcpkgs/orientdb/update
@@ -1,2 +1,2 @@
-site="https://orientdb.com/releases/"
-pattern="OrientDB v \K[\d\.]+"
+site="https://orientdb.org/download/"
+pattern="OrientDB \K[\d\.]+"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

Updated to version 3.1.11 and template / update files fixed to point to the new upstream host per #30041.

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
