### PR TITLE
budgie-screensaver: build with elogind support

### DIFF
--- a/srcpkgs/budgie-screensaver/template
+++ b/srcpkgs/budgie-screensaver/template
@@ -1,11 +1,11 @@
 # Template file for 'budgie-screensaver'
 pkgname=budgie-screensaver
 version=4.0
-revision=1
+revision=2
 wrksrc=budgie-screensaver-v${version}
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool glib"
-makedepends="gnome-desktop-devel dbus-glib-devel pam-devel"
+makedepends="gnome-desktop-devel dbus-glib-devel pam-devel elogind-devel"
 short_desc="Fork of GNOME Screensaver for Budgie 10"
 maintainer="Lorem <notloremipsum@protonmail.com>"
 license="GPL-2.0-only"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
Among other things, this is needed to ensure that screen locks before going to sleep. For me, that was not working when suspended by button or lid closing.
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
