### PR TITLE
Omnibus lint pass for SPDX errors, most packages starting with I

### DIFF
--- a/srcpkgs/iat/template
+++ b/srcpkgs/iat/template
@@ -1,15 +1,17 @@
 # Template file for 'iat'
 pkgname=iat
 version=0.1.7
-revision=3
+revision=4
 build_style=gnu-configure
-short_desc="A tool for detecting the structure of many types of CD/DVD image"
+short_desc="Tool for detecting the structure of many types of CD/DVD image"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-3"
+license="custom:GPL-2.0-or-later-with-BSD-attribution-requirement"
 homepage="http://sourceforge.net/projects/iat.berlios/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}.berlios/${pkgname}-${version}.tar.gz"
 checksum=b25d57fde28a02b2d87cd49fd1478b039adbd836351879a654fea14c27764b21
 
 post_install() {
+	sed '2,34p;d' src/main.c > LICENSE
+	vlicense LICENSE
 	rm -rf ${DESTDIR}/usr/include
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

