### PR TITLE
Omnibus lint pass for SPDX issues, most packages starting with "J"

### DIFF
--- a/srcpkgs/jbigkit/template
+++ b/srcpkgs/jbigkit/template
@@ -1,14 +1,14 @@
 # Template file for 'jbigkit'
 pkgname=jbigkit
 version=2.2
-revision=1
+revision=2
 wrksrc="${pkgname}-shared-${version}"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 checkdepends="check-devel"
 short_desc="Data compression library/utilities for bi-level high-resolution images"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
-license="GPL-3"
+license="GPL-2.0-only"
 homepage="http://www.cl.cam.ac.uk/~mgk25/jbigkit"
 distfiles="https://github.com/void-linux/jbigkit-shared/archive/v${version}.tar.gz"
 checksum=5cccbfb3bd7daf224a244ce0578dbcf706e4f39962426ceede873262b29b9931

--- a/srcpkgs/jeti-filemanager/template
+++ b/srcpkgs/jeti-filemanager/template
@@ -1,12 +1,12 @@
 # Template file for 'jeti-filemanager'
 pkgname=jeti-filemanager
 version=2.0.1
-revision=2
+revision=3
 build_style=gnu-makefile
 makedepends="ncurses-devel"
 short_desc="Total Commander filemanager ncurses clone"
 maintainer="Harri Leino <mr.leino@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="https://github.com/mrshampoo/jeti-filemanager/"
 distfiles="https://github.com/mrshampoo/jeti-filemanager/archive/${version}.tar.gz"
 checksum=4da4ddee8fe6774b91ea473810d6c6898777c9bbcb8816996d72095dc0e18691

--- a/srcpkgs/jnettop/template
+++ b/srcpkgs/jnettop/template
@@ -1,7 +1,7 @@
 # Template file for 'jnettop'
 pkgname=jnettop
 version=0.13.0
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc="${pkgname}-${version}"
 build_style=gnu-configure
@@ -9,7 +9,7 @@ hostmakedepends="pkg-config"
 makedepends="glib-devel libpcap-devel ncurses-devel"
 short_desc="View hosts/ports taking up the most network traffic"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/net/jnettop"
 distfiles="${DEBIAN_SITE}/main/j/${pkgname}/${pkgname}_${version}.orig.tar.gz
  ${DEBIAN_SITE}/main/j/${pkgname}/${pkgname}_${version}-1.debian.tar.gz"

--- a/srcpkgs/joe/template
+++ b/srcpkgs/joe/template
@@ -1,7 +1,7 @@
 # Template file for 'joe'
 pkgname=joe
 version=4.6
-revision=1
+revision=2
 build_style=gnu-configure
 conf_files="
 	/etc/joe/ftyperc
@@ -13,10 +13,10 @@ conf_files="
 	/etc/joe/rjoerc
 	/etc/joe/shell.csh
 	/etc/joe/shell.sh"
-short_desc="The world-famous Wordstar like text editor"
+short_desc="World-famous Wordstar like text editor"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-2"
-conflicts="jupp>=0"
+license="GPL-2.0-or-later"
 homepage="http://joe-editor.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/joe-editor/JOE%20sources/joe-${version}/joe-${version}.tar.gz"
 checksum=495a0a61f26404070fe8a719d80406dc7f337623788e445b92a9f6de512ab9de
+conflicts="jupp>=0"

--- a/srcpkgs/john/template
+++ b/srcpkgs/john/template
@@ -1,7 +1,7 @@
 # Template file for 'john'
 pkgname=john
 version=1.9.0
-revision=4
+revision=5
 _jumbover=1
 wrksrc="${pkgname}-${version}-jumbo-${_jumbover}"
 build_wrksrc="src"
@@ -10,11 +10,11 @@ configure_args="--with-systemwide $(vopt_enable simd)"
 makedepends="openssl-devel gmp-devel libgomp-devel libpcap-devel bzip2-devel zlib-devel"
 short_desc="John the Ripper password cracker (jumbo-${_jumbover} patch included)"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="GPL-2.0-or-later with OpenSSL-exception"
+license="custom:GPL-2.0-or-later with OpenSSL-exception"
 homepage="https://www.openwall.com/john/"
 distfiles="$homepage/k/$pkgname-${version}-jumbo-${_jumbover}.tar.xz"
 checksum=f5d123f82983c53d8cc598e174394b074be7a77756f5fb5ed8515918c81e7f3b
-python_version=2 #unverified
+python_version=3
 
 build_options="simd"
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

