### PR TITLE
sway: restore support for gtk-primary-selection

### DIFF
--- a/srcpkgs/sway/patches/primary_selection.diff
+++ b/srcpkgs/sway/patches/primary_selection.diff
@@ -1,0 +1,25 @@
+Sway 1.6 removed support for gtk-primary-selection, but some
+programs (e.g. Firefox ESR 78) still rely on it.
+Since wlroots will drop it in version 0.14, we can restore
+this feature on sway.
+https://github.com/swaywm/sway/pull/5788
+https://github.com/swaywm/wlroots/issues/2421
+https://github.com/swaywm/wlroots/pull/2460
+--- sway/server.c
++++ sway/server.c
+@@ -15,6 +15,7 @@
+ #include <wlr/types/wlr_data_control_v1.h>
+ #include <wlr/types/wlr_export_dmabuf_v1.h>
+ #include <wlr/types/wlr_gamma_control_v1.h>
++#include <wlr/types/wlr_gtk_primary_selection.h>
+ #include <wlr/types/wlr_idle.h>
+ #include <wlr/types/wlr_layer_shell_v1.h>
+ #include <wlr/types/wlr_pointer_constraints_v1.h>
+@@ -75,6 +76,7 @@ bool server_init(struct sway_server *server) {
+ 		wlr_data_device_manager_create(server->wl_display);
+ 
+ 	wlr_gamma_control_manager_v1_create(server->wl_display);
++	wlr_gtk_primary_selection_device_manager_create(server->wl_display);
+ 
+ 	server->new_output.notify = handle_new_output;
+ 	wl_signal_add(&server->backend->events.new_output, &server->new_output);

--- a/srcpkgs/sway/template
+++ b/srcpkgs/sway/template
@@ -1,7 +1,7 @@
 # Template file for 'sway'
 pkgname=sway
 version=1.6
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dwerror=false -Db_ndebug=false"
 conf_files="/etc/sway/config"


### PR DESCRIPTION
This reverts https://github.com/swaywm/sway/commit/5ad3990a6c9beae44392e1962223623c0a4e3fa9 and fixes clipboard issues with Firefox ESR 78.

See https://github.com/swaywm/sway/issues/6169, https://github.com/swaywm/sway/pull/5788, https://github.com/swaywm/wlroots/issues/2421.

The issue should only affect GTK versions older than 3.24.24, but apparenty Firefox 78 (and maybe others) is affected even if we have a more recent GTK.
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
