### PR TITLE
Build mozilla stuff with nodejs-lts instead of nodejs-lts-10

### DIFF
--- a/srcpkgs/firefox-esr/template
+++ b/srcpkgs/firefox-esr/template
@@ -8,7 +8,7 @@ revision=1
 wrksrc="firefox-${version}"
 build_helper="rust qemu"
 hostmakedepends="autoconf213 unzip zip pkg-config perl python3 yasm rust cargo
- llvm clang nodejs-lts-10 cbindgen python nasm which tar"
+ llvm clang nodejs-lts cbindgen python nasm which tar"
 makedepends="nss-devel libjpeg-turbo-devel gtk+-devel gtk+3-devel icu-devel
  pixman-devel libevent-devel libnotify-devel libvpx-devel
  libXrender-devel libXcomposite-devel libSM-devel libXt-devel rust-std

--- a/srcpkgs/firefox/template
+++ b/srcpkgs/firefox/template
@@ -16,7 +16,7 @@ checksum=6b50dbfb393f843e4401e23965a1d8f7fd44b5a7628d95138294094094eee297
 lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python3 yasm rust cargo
- llvm clang nodejs-lts-10 cbindgen python nasm which tar"
+ llvm clang nodejs-lts cbindgen python nasm which tar"
 makedepends="nss-devel libjpeg-turbo-devel gtk+-devel gtk+3-devel icu-devel
  pixman-devel libevent-devel libnotify-devel libvpx-devel
  libXrender-devel libXcomposite-devel libSM-devel libXt-devel rust-std

--- a/srcpkgs/thunderbird/template
+++ b/srcpkgs/thunderbird/template
@@ -16,7 +16,7 @@ checksum=65d79a557027a3b52cc672ab9aea8da7131e6373f94657d03f6d6b9c7b36fb45
 lib32disabled=yes
 
 hostmakedepends="autoconf213 unzip zip pkg-config perl python3 yasm rust cargo
- llvm clang nodejs-lts-10 cbindgen python nasm which tar"
+ llvm clang nodejs-lts cbindgen python nasm which tar"
 makedepends="nss-devel libjpeg-turbo-devel gtk+-devel gtk+3-devel icu-devel
  pixman-devel libevent-devel libnotify-devel libvpx-devel
  libXrender-devel libXcomposite-devel libSM-devel libXt-devel rust-std


### PR DESCRIPTION
I have tested thunderbird built with it, works fine.

From https://github.com/ericonr/void-packages/pull/4, https://github.com/ericonr/void-packages/pull/3 and https://github.com/ericonr/void-packages/pull/2 we can see that the others also build correctly (aarch64 just OOM's as usual).

This is in the interest of killing `nodejs-lts-10`, seeing as it only has a few more days until EOL.

[ci skip]