### PR TITLE
0ad: disable generation of -32bit package.

### DIFF
--- a/srcpkgs/0ad/template
+++ b/srcpkgs/0ad/template
@@ -1,7 +1,7 @@
 # Template file for '0ad'
 pkgname=0ad
 version=0.0.24b
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* armv7l* ppc64le*"
 wrksrc="${pkgname}-${version}-alpha"
 hostmakedepends="pkg-config perl cmake python3 rust cargo yasm tar clang"
@@ -16,6 +16,7 @@ homepage="https://play0ad.com"
 distfiles="https://releases.wildfiregames.com/${pkgname}-${version}-alpha-unix-build.tar.xz"
 checksum=325c23c9b6bfc16eb636af6a7a7bdaadbf19214b6eed0422d74cc0090bf137a8
 nocross="uses bundled third-party libraries that do not cross-compile"
+lib32disabled=yes
 
 CXXFLAGS="-fpermissive"
 # Use BFD linker to avoid erroneous detection of llvm pr8927 with *-musl


### PR DESCRIPTION
The resulting 0ad-32bit package only contains internal libraries used by
the game.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
