### PR TITLE
python3-ipython: fix broken matplotlib_inline import

### DIFF
--- a/srcpkgs/python3-ipython/patches/mpl_inline_fix.patch
+++ b/srcpkgs/python3-ipython/patches/mpl_inline_fix.patch
@@ -1,0 +1,12 @@
+diff --git IPython/core/pylabtools.py IPython/core/pylabtools.py
+index c71b0cdb6..bb815956e 100644
+--- IPython/core/pylabtools.py
++++ IPython/core/pylabtools.py
+@@ -383,6 +383,6 @@ def configure_inline_support(shell, backend):
+         stacklevel=2,
+     )
+ 
+-    from matplotlib_inline.backend_inline import configure_inline_support_orig
++    from matplotlib_inline.backend_inline import configure_inline_support as configure_inline_support_orig
+ 
+     configure_inline_support_orig(shell, backend)

--- a/srcpkgs/python3-ipython/template
+++ b/srcpkgs/python3-ipython/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-ipython'
 pkgname=python3-ipython
 version=7.23.0
-revision=1
+revision=2
 wrksrc="ipython-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"


### PR DESCRIPTION
Looks like the upstream restructuring introduced a bug. Awaiting either upstream acknowledgment or downstream confirmation that this fix is sufficient.

Issue report: https://www.reddit.com/r/voidlinux/comments/n2nxyd/matplotlib_inline_broken_after_most_recent_update/
Proposed upstream fix: https://github.com/ipython/ipython/pull/12940