### PR TITLE
retroarch: update to 1.9.2

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,13 +1,12 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.9.1
+version=1.9.2
 revision=1
 wrksrc="RetroArch-$version"
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
  --enable-udev --disable-builtinflac --disable-builtinglslang
  --disable-builtinmbedtls --disable-builtinminiupnpc --disable-builtinzlib
- --disable-git_version
  $(vopt_enable ffmpeg) $(vopt_enable flac) $(vopt_enable glslang) $(vopt_enable jack)
  $(vopt_enable miniupnpc) $(vopt_enable pulseaudio pulse) $(vopt_enable qt5 qt)
  $(vopt_enable sdl2) $(vopt_enable vulkan) $(vopt_enable wayland) $(vopt_enable x11)"
@@ -25,7 +24,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.retroarch.com/"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=153f7057cecd22441904f557302d50f969d199c4b6ff263bfe87d9cf4a9bab75
+checksum=782b1d15ac20b5b629e9e520bbfd8f0a4e00bf1bbeb10189f811770b68b610cf
 
 build_options="ffmpeg flac gles2 glslang jack miniupnpc neon opengl pulseaudio qt5 sdl2 vulkan wayland x11"
 build_options_default="ffmpeg flac gles2 glslang miniupnpc opengl pulseaudio sdl2 vulkan wayland x11"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

The `--disable-git_version` configure option was added in 1.9.1, but has been [reverted](https://github.com/libretro/RetroArch/commit/cbec423413b85202131b69c0a314a6c29335e135) in 1.9.2.