### PR TITLE
Enable MSCHAPv2 with StrongSwan.

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,12 +1,12 @@
 # Template file for 'strongswan'
 pkgname=strongswan
 version=5.8.4
-revision=1
+revision=2
 build_style=gnu-configure
 # tpm support waits on libtss2
-configure_args="--disable-static --enable-blowfish --enable-curl
- --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5 --enable-led
- --enable-ha --enable-dhcp --enable-mediation --enable-soup --disable-des
+configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
+ --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5 --enable-eap-identity --enable-eap-dynamic
+ --enable-led --enable-ha --enable-dhcp --enable-mediation --enable-soup --disable-des
  --enable-chapoly --enable-nm"
 hostmakedepends="pkg-config flex bison python"
 makedepends="gmp-devel libsoup-devel libldns-devel unbound-devel libcurl-devel NetworkManager-devel"


### PR DESCRIPTION
StrongSwan on Void currently has issues with EAP-MSCHAPv2 in different ways.

(1) eap-identity needs to be enabled in order for config files with `eap_identity=%any` and similar lines to work (you essentially end up with `EAP_NAK` when `EAP_IDENTITY` is requested);
(2) eap-mschapv2 requires `md4` to be enabled as a plugin
(3) eap-dynamic **might** be required on some setups, so this pull request enables it to avoid issues in the future.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl

I have **not tested** if it runs on any of the cross builds, I simply tested that it indeed does build.