### PR TITLE
ansible-base: add python3-packaging as a runtime dependency

### DIFF
--- a/srcpkgs/ansible-base/template
+++ b/srcpkgs/ansible-base/template
@@ -1,11 +1,11 @@
 # Template file for 'ansible-base'
 pkgname=ansible-base
 version=2.10.8
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="${hostmakedepends} python3-cryptography python3-Jinja2 python3-paramiko
- python3-yaml"
+ python3-yaml python3-packaging"
 short_desc="Simple deployment, configuration management and execution framework"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Running the current ansible package results in a warning:

"[WARNING]: packaging Python module unavailable; unable to validate collection Ansible version requirements"

A simple web search leads to the Ansible developers stating that
python3-packaging is a dependency for ansible-base[1], and this commit
adds it.

[1]: https://github.com/ansible/ansible/issues/72117


#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR


#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl

