### PR TITLE
hfsprogs: fix distfile

### DIFF
--- a/srcpkgs/hfsprogs/template
+++ b/srcpkgs/hfsprogs/template
@@ -2,6 +2,7 @@
 pkgname=hfsprogs
 _distver=540.1
 _patchver=3
+_md5sum=0435afc389b919027b69616ad1b05709
 version="${_distver}.linux${_patchver}"
 revision=8
 wrksrc="diskdev_cmds-${version}"
@@ -10,8 +11,8 @@ makedepends="openssl-devel libuuid-devel"
 short_desc="Apple's mkfs and fsck for HFS and HFS+ file systems"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="APSL-2.0"
-homepage="http://www.opensource.apple.com/"
-distfiles="http://cavan.codon.org.uk/~mjg59/diskdev_cmds/diskdev_cmds-${version}.tar.gz"
+homepage="https://www.opensource.apple.com/"
+distfiles="https://src.fedoraproject.org/repo/pkgs/hfsplus-tools/diskdev_cmds-${version}.tar.gz/${_md5sum}/diskdev_cmds-${version}.tar.gz"
 checksum=b01b203a97f9a3bf36a027c13ddfc59292730552e62722d690d33bd5c24f5497
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

The current distfile source is dead. Arch Linux [switched](https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=hfsprogs&id=771ca78d224417ace4eb999e147dcf0d7484d65d) to using Fedora as the source. This commit does the same.