### PR TITLE
Omnibus lint pass for SPDX errors - most packages starting with K

### DIFF
--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,7 +1,7 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
 version=5.21.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt5-host-tools qt5-qmake"
@@ -11,7 +11,7 @@ makedepends="kdoctools plasma-framework-devel kdesignerplugin-devel kcmutils-dev
 depends="hwids"
 short_desc="KDE Info Center"
 maintainer="John <me@johnnynator.dev>"
-license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2"
+license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
 checksum=3e5c3fed0156f3464bb30ebb9e0822c4141d71802dfa8995961f84c548771394

--- a/srcpkgs/klystrack/template
+++ b/srcpkgs/klystrack/template
@@ -1,14 +1,14 @@
 # Template file for 'klystrack'
 pkgname=klystrack
 version=1.7.3
-revision=1
+revision=2
 _klystronsha=f5114db4de299ece73852becbef56d7d461bf421
 create_wrksrc=yes
 hostmakedepends="SDL2-devel"
 makedepends="SDL2_image-devel SDL2_mixer-devel"
 short_desc="Chiptune music tracker"
 maintainer="allan <mail@may.mooo.com>"
-license="BSD"
+license="MIT"
 homepage="http://kometbomb.github.io/klystrack/"
 distfiles="https://github.com/kometbomb/klystrack/archive/${version}.tar.gz
  https://github.com/kometbomb/klystron/archive/${_klystronsha}.tar.gz"
@@ -45,5 +45,5 @@ do_install() {
 	vcopy key usr/lib/klystrack
 	vmkdir usr/share/examples/klystrack
 	vcopy examples usr/share/examples/klystrack
-	vlicense linux/copyright
+	vlicense doc/LICENSE
 }

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,7 +1,7 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
 version=5.21.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules kdoctools qt5-qmake qt5-host-tools
@@ -10,7 +10,7 @@ makedepends="kdelibs4support-devel kdesignerplugin-devel kdoctools"
 depends="khotkeys"
 short_desc="KDE Menu editor"
 maintainer="John <me@johnnynator.dev>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
 checksum=d022bb6486663fd1db8b627794be5eb557fa0daa45b27bb69d834fa84494b8c2

--- a/srcpkgs/ksysguard/template
+++ b/srcpkgs/ksysguard/template
@@ -1,7 +1,7 @@
 # Template file for 'ksysguard'
 pkgname=ksysguard
 version=5.21.4
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules kdoctools qt5-qmake qt5-host-tools
@@ -11,7 +11,7 @@ makedepends="knewstuff-devel libksysguard-devel kinit-devel libsensors-devel
 depends="hicolor-icon-theme lm_sensors"
 short_desc="KDE program to monitor various elements of your system"
 maintainer="John <me@johnnynator.dev>"
-license="GPL-2.0-or-later, GFDL-1.2"
+license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/ksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
 checksum=cd1482653c35c5e04e6940346836fcd0655c213fc191da30685cb10cd05ae582

--- a/srcpkgs/ktoblzcheck/template
+++ b/srcpkgs/ktoblzcheck/template
@@ -1,17 +1,21 @@
 # Template file for 'ktoblzcheck'
 pkgname=ktoblzcheck
 version=1.53
-revision=1
+revision=2
+build_style=cmake
+configure_args="-DENABLE_BANKDATA_DOWNLOAD=NO"
 hostmakedepends="pkg-config python"
 makedepends="python-devel"
-build_style=cmake
-maintainer="Enno Boland <gottox@voidlinux.org>"
-license="LGPL-2.1"
-homepage="http://ktoblzcheck.sourceforge.net"
 short_desc="Tool for verification of account numbers and bank codes"
+maintainer="Enno Boland <gottox@voidlinux.org>"
+license="LGPL-2.1-or-later"
+homepage="http://ktoblzcheck.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=18b9118556fe83240f468f770641d2578f4ff613cdcf0a209fb73079ccb70c55
-configure_args="-DENABLE_BANKDATA_DOWNLOAD=NO"
+
+post_patch() {
+	vsed -i src/python/test_ktoblzcheck.py -e 's/Postbank Ndl der DB Privat- und Firmenkundenbank/Postbank Ndl der Deutsche Bank/'
+}
 
 ktoblzcheck-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
