### PR TITLE
binutils: remove dependency to binutils-doc

### DIFF
--- a/srcpkgs/binutils/template
+++ b/srcpkgs/binutils/template
@@ -17,7 +17,6 @@ if [ "$CHROOT_READY" ]; then
 	hostmakedepends="flex perl texinfo"
 	makedepends+=" elfutils-devel"
 	checkdepends="bc"
-	depends="binutils-doc"
 	subpackages+=" binutils-devel"
 fi
 


### PR DESCRIPTION
The binutils main package doesn't depend on the info files contained in
the documentation package. Remove it from being a dependency similar to
any other package whose documentation is split off into a subpackage.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
