### PR TITLE
tor: fix Failing because we run out of file handles

### DIFF
--- a/srcpkgs/tor/files/tor/run
+++ b/srcpkgs/tor/files/tor/run
@@ -1,3 +1,4 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
+ulimit -n ${MAX_OPEN_FILES:-8192}
 exec tor ${OPTS:=--quiet} --runasdaemon 0 2>&1

--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,7 +1,7 @@
 # Template file for 'tor'
 pkgname=tor
 version=0.4.5.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-zstd"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
```
May  5 00:31:43 Tor[857]: Failing because we have 4063 connections already. Please read doc/TUNING for guidance.
```

Still does not build on musl but works for me, pinging @daniel-eys 


<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
