### PR TITLE
mlocate : add updatedb.conf

### DIFF
--- a/srcpkgs/mlocate/files/updatedb.conf
+++ b/srcpkgs/mlocate/files/updatedb.conf
@@ -1,0 +1,4 @@
+PRUNE_BIND_MOUNTS = "yes"
+PRUNEFS = "9p afs anon_inodefs auto autofs bdev binfmt_misc cgroup cifs coda configfs cpuset cramfs debugfs devpts devtmpfs ecryptfs exofs ftpfs fuse fuse.encfs fuse.sshfs fusectl gfs gfs2 hugetlbfs inotifyfs iso9660 jffs2 lustre mqueue ncpfs nfs nfs4 nfsd pipefs proc ramfs rootfs rpc_pipefs securityfs selinuxfs sfs shfs smbfs sockfs sshfs sysfs tmpfs ubifs udf usbfs vboxsf"
+PRUNENAMES = ".git .hg .svn .snapshots"
+PRUNEPATHS = "/afs /media /mnt /net /sfs /tmp /udev /var/cache /var/lock /var/run /var/spool /var/tmp"

--- a/srcpkgs/mlocate/template
+++ b/srcpkgs/mlocate/template
@@ -27,4 +27,5 @@ post_install() {
 	vinstall ${FILESDIR}/mupdatedb.cron-daily 744 etc/cron.daily mupdatedb
 	# rename for compatibility with findutils.
 	mv ${DESTDIR}/usr/share/man/man8/mupdatedb.8 ${DESTDIR}/usr/share/man/man1/mupdatedb.1
+	vinstall ${FILESDIR}/updatedb.conf 744 etc/
 }


### PR DESCRIPTION
This configuration file allow us to filter the resources 
which have to indexed and to avoid slowdowns too.
The snapshots are just an example.