### PR TITLE
julia: update to 1.6.1.

### DIFF
--- a/srcpkgs/julia/patches/julia-hardcoded-libs.patch
+++ b/srcpkgs/julia/patches/julia-hardcoded-libs.patch
@@ -1,0 +1,43 @@
+diff --git a/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl b/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
+index a7ca666b23..b84a42f4e7 100644
+--- a/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
++++ b/stdlib/MbedTLS_jll/src/MbedTLS_jll.jl
+@@ -31,9 +31,9 @@ elseif Sys.isapple()
+     const libmbedtls = "@rpath/libmbedtls.13.dylib"
+     const libmbedx509 = "@rpath/libmbedx509.1.dylib"
+ else
+-    const libmbedcrypto = "libmbedcrypto.so.5"
+-    const libmbedtls = "libmbedtls.so.13"
+-    const libmbedx509 = "libmbedx509.so.1"
++    const libmbedcrypto = "libmbedcrypto.so"
++    const libmbedtls = "libmbedtls.so"
++    const libmbedx509 = "libmbedx509.so"
+ end
+ 
+ function __init__()
+diff --git a/stdlib/libLLVM_jll/src/libLLVM_jll.jl b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+index fa45e754e5..b51812e3a8 100644
+--- a/stdlib/libLLVM_jll/src/libLLVM_jll.jl
++++ b/stdlib/libLLVM_jll/src/libLLVM_jll.jl
+@@ -23,7 +23,7 @@ if Sys.iswindows()
+ elseif Sys.isapple()
+     const libLLVM = "@rpath/libLLVM.dylib"
+ else
+-    const libLLVM = "libLLVM-11jl.so"
++    const libLLVM = "libLLVM.so"
+ end
+ 
+ function __init__()
+diff --git a/stdlib/nghttp2_jll/src/nghttp2_jll.jl b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+index 8b98c76ac5..77ad9e3800 100644
+--- a/stdlib/nghttp2_jll/src/nghttp2_jll.jl
++++ b/stdlib/nghttp2_jll/src/nghttp2_jll.jl
+@@ -22,7 +22,7 @@ if Sys.iswindows()
+ elseif Sys.isapple()
+     const libnghttp2 = "@rpath/libnghttp2.14.dylib"
+ else
+-    const libnghttp2 = "libnghttp2.so.14"
++    const libnghttp2 = "libnghttp2.so"
+ end
+ 
+ function __init__()

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,12 +1,12 @@
 # Template file for 'julia'
 pkgname=julia
-version=1.6.0
+version=1.6.1
 revision=1
 archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
  USE_BINARYBUILDER=0 USE_SYSTEM_LIBM=0 USE_SYSTEM_DSFMT=0 USE_SYSTEM_LIBUV=0
- USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_BLAS=0 USE_SYSTEM_LAPACK=0 USE_SYSTEM_LLVM=1
+ USE_SYSTEM_SUITESPARSE=0 USE_SYSTEM_BLAS=0 USE_SYSTEM_LAPACK=0 USE_SYSTEM_LLVM=0
  USE_SYSTEM_LIBUNWIND=1 USE_SYSTEM_PCRE=1 USE_SYSTEM_GMP=1 USE_SYSTEM_PATCHELF=1
  USE_SYSTEM_MPFR=1 USE_SYSTEM_MBEDTLS=1 USE_SYSTEM_LIBSSH2=1 USE_SYSTEM_NGHTTP2=1
  USE_SYSTEM_CURL=1 USE_SYSTEM_ZLIB=1 USE_SYSTEM_P7ZIP=1 USE_SYSTEM_LIBGIT2=1
@@ -19,7 +19,7 @@ conf_files="/etc/julia/startup.jl"
 hostmakedepends="pkg-config perl cmake python gcc-fortran patchelf which tar xz"
 makedepends="p7zip pcre2-devel mpfr-devel libgit2-devel libcurl-devel nghttp2-devel
  libssh2-devel mbedtls-devel libatomic-devel zlib-devel libunwind-devel
- libutf8proc-devel llvm11"
+ libutf8proc-devel"
 # Julia provides vendored symlinks in /usr/lib/julia pointing to these libraries,
 # but none of the julia executables link to them so these are not auto-detected
 depends="libgit2 libcurl mpfr mbedtls libatomic libpcre2 libssh2 nghttp2 libquadmath libssp p7zip"
@@ -28,8 +28,11 @@ maintainer="Adam Beckmeyer <adam_git@thebeckmeyers.xyz>"
 license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
-checksum=1b05f42c9368bc2349c47363b7ddc175a2da3cd162d52b6e24c4f5d4d6e1232c
+checksum=71d8e40611361370654e8934c407b2dec04944cf3917c5ecb6482d6b85ed767f
+patch_args=-Np1
 nocross="build system is a mess"
+# Avoid pulling in llvm as a dependency for "libLLVM-11.so"
+skiprdeps="/usr/lib/julia/libjulia-internal.so.1.6 /usr/lib/julia/libllvmcalltest.so"
 # Targets for the vendored symlinks mentioned above
 shlib_requires="libgit2.so.1.0 libcurl.so.4 libmpfr.so.6 libgmp.so.10
  libmbedcrypto.so.3 libmbedtls.so.12 libmbedx509.so.0 libpcre2-8.so.0


### PR DESCRIPTION
Also change to using vendored llvm to reduce maintenance burden from julia depending on
versions of llvm which are quickly obsoleted (closes #30490); this should also fix julia's
build being broken on i686. This doesn't address #29964, and a decision should still be made
on whether to accept #30061.

[ci skip] for building llvm

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64 glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
