### PR TITLE
mpg123: update to 1.27.0

### DIFF
--- a/srcpkgs/mpg123/template
+++ b/srcpkgs/mpg123/template
@@ -1,6 +1,6 @@
 # Template file for 'mpg123'
 pkgname=mpg123
-version=1.26.5
+version=1.27.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-optimization=0 --with-default-audio=alsa
@@ -12,11 +12,16 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://www.mpg123.org/"
 distfiles="${SOURCEFORGE_SITE}/mpg123/mpg123-${version}.tar.bz2"
-checksum=502a97e0d935be7e37d987338021d8f301bae35c2884f2a83d59c4b52466ef06
+checksum=52f6ceb962c05db0c043bb27acf5a721381f5f356ac4610e5221f50293891b04
+
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	# No LFS required with musl
+	configure_args+=" --disable-lfs-alias"
+fi
 
 case "$XBPS_TARGET_MACHINE" in
-	# No LFS required with musl
-	*-musl) configure_args+=" --disable-lfs-alias";;
+	ppc64*) configure_args+=" --with-cpu=altivec";;
+	ppc*) configure_args+=" --with-cpu=ppc_nofpu";;
 esac
 
 mpg123-jack_package() {


### PR DESCRIPTION
Enable cpu-specific optimizations.

I didn't test arm and ppc.

`./configure --help` says:
```
  --with-cpu=generic[_fpu]      Use generic processor code with floating point arithmetic
  --with-cpu=generic_float      Plain alias to generic_fpu now... float output is a normal runtime option!
  --with-cpu=generic_nofpu      Use generic processor code with fixed point arithmetic (p.ex. ARM)
  --with-cpu=generic_dither     Use generic processor code with floating point arithmetic and dithering for 1to1 16bit decoding.
  --with-cpu=i386[_fpu]         Use code optimized for i386 processors with floating point arithmetic
  --with-cpu=i386_nofpu         Use code optimized for i386 processors with fixed point arithmetic
  --with-cpu=i486         Use code optimized for i486 processors (only usable alone!)
  --with-cpu=i586         Use code optimized for i586 processors
  --with-cpu=i586_dither  Use code optimized for i586 processors with dithering (noise shaping), adds 256K to binary size
  --with-cpu=3dnow         Use code optimized for 3DNow processors
  --with-cpu=3dnow_vintage Use code optimized for older 3DNow processors (K6 family)
  --with-cpu=3dnowext      Use code optimized for 3DNowExt processors (K6-3+, Athlon)
  --with-cpu=3dnowext_alone     Really only 3DNowExt decoder, without 3DNow fallback for flexible rate
  --with-cpu=3dnow_vintage       Use code optimized for older extended 3DNow processors (like K6-III+)
  --with-cpu=mmx          Use code optimized for MMX processors
  --with-cpu=mmx_alone          Really only MMX decoder, without i586 fallback for flexible rate
  --with-cpu=sse          Use code optimized for SSE processors
  --with-cpu=sse_vintage  Use code optimized for older SSE processors (plain C DCT36)
  --with-cpu=sse_alone          Really only SSE decoder, without i586 fallback for flexible rate
  --with-cpu=avx          Use code optimized for x86-64 with AVX processors
  --with-cpu=x86          Pack all x86 opts into one binary (excluding i486, including dither)
  --with-cpu=x86-64       Use code optimized for x86-64 processors (AMD64 and Intel64, including AVX and dithered generic)
  --with-cpu=altivec      Use code optimized for Altivec processors (PowerPC G4 and G5)
  --with-cpu=ppc_nofpu    Use code optimized for PowerPC processors with fixed point arithmetic
  --with-cpu=neon         Use code optimized for ARM NEON SIMD engine (Cortex-A series)
  --with-cpu=arm_fpu      Pack neon and generic[_dither] decoders, for ARM processors with FPU and/or NEON
  --with-cpu=arm_nofpu    Use code optimized for ARM processors with fixed point arithmetic
  --with-cpu=neon64       Use code optimized for AArch64 NEON SIMD engine
  --with-cpu=aarch64      Pack neon64 and generic[_dither] decoders, for 64bit ARM processors
```

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
