### PR TITLE
nextcloud-client: update to 3.2.1.

### DIFF
--- a/srcpkgs/nextcloud-client/patches/fallback-primary-screen.patch
+++ b/srcpkgs/nextcloud-client/patches/fallback-primary-screen.patch
@@ -1,0 +1,15 @@
+upstream: https://github.com/nextcloud/desktop/commit/aadee15008ca4974e542f3fb6ca1694592d9e6fe
+--- src/gui/wizard/owncloudwizard.cpp
++++ src/gui/wizard/owncloudwizard.cpp
+@@ -116,7 +116,10 @@ OwncloudWizard::OwncloudWizard(QWidget *parent)
+ void OwncloudWizard::centerWindow()
+ {
+     const auto wizardWindow = window();
+-    const auto screenGeometry = QGuiApplication::screenAt(wizardWindow->pos())->geometry();
++    const auto screen = QGuiApplication::screenAt(wizardWindow->pos())
++        ? QGuiApplication::screenAt(wizardWindow->pos())
++        : QGuiApplication::primaryScreen();
++    const auto screenGeometry = screen->geometry();
+     const auto windowGeometry = wizardWindow->geometry();
+     const auto newWindowPosition = screenGeometry.center() - QPoint(windowGeometry.width() / 2, windowGeometry.height() / 2);
+     wizardWindow->move(newWindowPosition);

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.2.0
+version=3.2.1
 revision=1
 wrksrc="desktop-${version}"
 build_style=cmake
@@ -19,7 +19,7 @@ maintainer="yopito <pierre.bourgin@free.fr>"
 license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=da1195b31fec0970121c1567f3cdaf3b9083d46727277116a98e5cd27f57aa60
+checksum=f2d387d35276ea6e6da3ae339ede3d89be81dd4af735739ec280709008eb6645
 
 build_options="dolphin"
 desc_option_dolphin="Build KDE dolphin support"


### PR DESCRIPTION
Also added a patch to close #30713.

The patch `fallback-primary-screen.patch` comes from upstream master,
and should be removed in the next update.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
