### PR TITLE
Omnibus lint pass for SPDX errors - packages in the perl-* family

### DIFF
--- a/srcpkgs/perl-AnyEvent-I3/template
+++ b/srcpkgs/perl-AnyEvent-I3/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-AnyEvent-I3'
 pkgname=perl-AnyEvent-I3
 version=0.17
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl-JSON-XS perl-AnyEvent"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="AnyEvent::I3 - communicate with the i3 window manager"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
-license="Artistic, GPL-1"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/AnyEvent-I3"
 distfiles="${CPAN_SITE}/AnyEvent/AnyEvent-I3-${version}.tar.gz"
 checksum=5382c984c9f138395f29f0c00af81aa0c8f4b765582055c73ede4b13f04a6d63

--- a/srcpkgs/perl-Canary-Stability/template
+++ b/srcpkgs/perl-Canary-Stability/template
@@ -1,15 +1,15 @@
 # Template file for 'perl-Canary-Stability'
 pkgname=perl-Canary-Stability
 version=2013
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="${hostmakedepends}"
 depends="${makedepends}"
-short_desc="Canary::Stability - canary to check perl compatibility for schmorp's modules"
+short_desc="Canary to check perl compatibility for schmorp's modules"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="Artistic, GPL-1"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Canary-Stability"
 distfiles="${CPAN_SITE}/Tree/MLEHMANN//${pkgname/perl-/}-${version}.tar.gz"
 checksum=a5c91c62cf95fcb868f60eab5c832908f6905221013fea2bce3ff57046d7b6ea

--- a/srcpkgs/perl-Config-Simple/template
+++ b/srcpkgs/perl-Config-Simple/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Config-Simple'
 pkgname=perl-Config-Simple
 version=4.59
-revision=2
+revision=3
 wrksrc="${pkgname/perl-//}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="perl"
 depends="perl"
 short_desc="Config::Simple - simple configuration file class"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Unknown"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Config-Simple"
 distfiles="http://search.cpan.org/CPAN/authors/id/S/SH/SHERZODR/Config-Simple-${version}.tar.gz"
 checksum=cb78a975ad8463f992f35f392227aaf188d533c9092373742b3c2bb592781054

--- a/srcpkgs/perl-Crypt-DES/template
+++ b/srcpkgs/perl-Crypt-DES/template
@@ -1,16 +1,16 @@
 # Template file for 'perl-Crypt-DES'
 pkgname=perl-Crypt-DES
 version=2.07
-revision=6
+revision=7
 wrksrc="${pkgname#perl-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl"
-checkdepends="perl-Crypt-CBC"
 depends="perl"
+checkdepends="perl-Crypt-CBC"
 short_desc="Perl interface to DES block cipher"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="Custom"
+license="custom:Custom"
 homepage="https://metacpan.org/release/Crypt-DES"
 distfiles="${CPAN_SITE}/Crypt/Crypt-DES-${version}.tar.gz"
 checksum=2db1ebb5837b4cb20051c0ee5b733b4453e3137df0a92306034c867621edd7e7

--- a/srcpkgs/perl-Crypt-IDEA/template
+++ b/srcpkgs/perl-Crypt-IDEA/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Crypt-IDEA'
 pkgname=perl-Crypt-IDEA
 version=1.10
-revision=6
+revision=7
 wrksrc="${pkgname#perl-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="perl"
 depends="perl"
 short_desc="Perl interface to IDEA block cipher"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="Custom"
+license="custom:Custom"
 homepage="https://metacpan.org/release/Crypt-IDEA"
 distfiles="${CPAN_SITE}/Crypt/Crypt-IDEA-${version}.tar.gz"
 checksum=33bd78c11924a0fc1ff3eedde94078cbbf6b6ca9ede046d2b2f561e9e9a72019

--- a/srcpkgs/perl-Data-OptList/template
+++ b/srcpkgs/perl-Data-OptList/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Data-OptList'
 pkgname=perl-Data-OptList
 version=0.110
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends} perl-Params-Util perl-Sub-Install"
 depends="${makedepends}"
 short_desc="Parse and validate simple name/value option pairs"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Data-OptList"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Data/${pkgname/perl-/}-${version}.tar.gz"
 checksum=366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3

--- a/srcpkgs/perl-Date-Calc/template
+++ b/srcpkgs/perl-Date-Calc/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-Date-Calc'
+# Template file for 'perl-Date-Calc'
 pkgname=perl-Date-Calc
 version=6.4
-revision=3
+revision=4
 wrksrc="Date-Calc-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="perl perl-Carp-Clan perl-Bit-Vector"
 depends="${makedepends}"
 short_desc="Date::Calc - Gregorian calendar date calculations"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
+license="Artistic-1.0-Perl, GPL-2.0-only, LGPL-2.0-only"
 homepage="https://metacpan.org/release/Date-Calc"
-license="Artistic, GPL-2, LGPL-2"
 distfiles="${CPAN_SITE}/Date/Date-Calc-${version}.tar.gz"
 checksum="7ce137b2e797b7c0901f3adf1a05a19343356cd1f04676aa1c56a9f624f859ad"

--- a/srcpkgs/perl-Devel-GlobalDestruction/template
+++ b/srcpkgs/perl-Devel-GlobalDestruction/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Devel-GlobalDestruction'
 pkgname=perl-Devel-GlobalDestruction
 version=0.14
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl-Sub-Exporter-Progressive"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Expose the flag which marks global destruction"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Devel-GlobalDestruction"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Devel/${pkgname/perl-/}-${version}.tar.gz"
 checksum=34b8a5f29991311468fe6913cadaba75fd5d2b0b3ee3bb41fe5b53efab9154ab

--- a/srcpkgs/perl-Devel-Symdump/template
+++ b/srcpkgs/perl-Devel-Symdump/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-Devel-Symdump'.
+# Template file for 'perl-Devel-Symdump'
 pkgname=perl-Devel-Symdump
 version=2.18
-revision=2
+revision=3
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="perl"
 depends="perl"
 short_desc='Devel::Symdump - Dump symbol names or the symbol table'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Devel-Symdump"
-license="GPL-1, Artistic"
 distfiles="$CPAN_SITE/Devel/Devel-Symdump-${version}.tar.gz"
 checksum=826f81a107f5592a2516766ed43beb47e10cc83edc9ea48090b02a36040776c0

--- a/srcpkgs/perl-Eval-Closure/template
+++ b/srcpkgs/perl-Eval-Closure/template
@@ -1,15 +1,16 @@
-# Template build file for 'perl-Eval-Closure'.
+# Template file for 'perl-Eval-Closure'
 pkgname=perl-Eval-Closure
 version=0.14
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
+checkdepends="perl-Test-Fatal perl-Test-Requires"
 short_desc="Safely and cleanly create closures via string eval"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Eval-Closure"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Parse/DOY/Eval-Closure-${version}.tar.gz"
 checksum="ea0944f2f5ec98d895bef6d503e6e4a376fea6383a6bc64c7670d46ff2218cad"

--- a/srcpkgs/perl-ExtUtils-PkgConfig/template
+++ b/srcpkgs/perl-ExtUtils-PkgConfig/template
@@ -1,15 +1,15 @@
 # Template file for 'perl-ExtUtils-PkgConfig'
 pkgname=perl-ExtUtils-PkgConfig
 version=1.16
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl pkg-config"
 makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Simplistic perl interface to pkg-config"
-homepage="https://metacpan.org/release/ExtUtils-PkgConfig"
-license="LGPL-2.1"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-2.1-only"
+homepage="https://metacpan.org/release/ExtUtils-PkgConfig"
 distfiles="${SOURCEFORGE_SITE}/gtk2-perl/ExtUtils-PkgConfig-$version.tar.gz"
 checksum=bbeaced995d7d8d10cfc51a3a5a66da41ceb2bc04fedcab50e10e6300e801c6e

--- a/srcpkgs/perl-File-ShareDir-Install/template
+++ b/srcpkgs/perl-File-ShareDir-Install/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-File-ShareDir-Install'.
+# Template file for 'perl-File-ShareDir-Install'
 pkgname=perl-File-ShareDir-Install
 version=0.13
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,8 +9,8 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="File::ShareDir::Install - Install shared files"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/File-ShareDir-Install"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/File/${pkgname/perl-/}-$version.tar.gz"
 checksum=45befdf0d95cbefe7c25a1daf293d85f780d6d2576146546e6828aad26e580f9
 

--- a/srcpkgs/perl-GooCanvas2/template
+++ b/srcpkgs/perl-GooCanvas2/template
@@ -1,16 +1,16 @@
 # Template file for 'perl-GooCanvas2'
 pkgname=perl-GooCanvas2
 version=0.06
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="perl-Gtk3"
-checkdepends="goocanvas"
 depends="${makedepends} goocanvas"
+checkdepends="goocanvas"
 short_desc="Perl binding for GooCanvas2 widget using Glib::Object::Introspection"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="Artistic-2.0, GPL-1"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/GooCanvas2"
 distfiles="https://cpan.metacpan.org/authors/id/P/PE/PERLMAX/${pkgname/perl-/}-${version}.tar.gz"
 checksum=e24c87873e19063dd4d5e2c709caacf8c0ae8881044395bb865dc2b4fdd63b50

--- a/srcpkgs/perl-IPC-Run3/template
+++ b/srcpkgs/perl-IPC-Run3/template
@@ -1,14 +1,14 @@
 # Template file for 'perl-IPC-Run3'
 pkgname=perl-IPC-Run3
 version=0.048
-revision=3
+revision=4
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 depends="perl"
-short_desc='IPC::Run3 -  run a subprocess and redirect stdin, stdout, and/or stderr'
+short_desc='IPC::Run3 - run a subprocess and redirect stdin, stdout, and/or stderr'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
-license="Aristic-1.0-Perl, GPL-1.0-or-later"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/IPC-Run3"
 distfiles="$CPAN_SITE/IPC/IPC-Run3-${version}.tar.gz"
 checksum=3d81c3cc1b5cff69cca9361e2c6e38df0352251ae7b41e2ff3febc850e463565

--- a/srcpkgs/perl-Linux-DesktopFiles/template
+++ b/srcpkgs/perl-Linux-DesktopFiles/template
@@ -1,7 +1,7 @@
-# Template file for 'perl-Linux-DesktopFiles'.
+# Template file for 'perl-Linux-DesktopFiles'
 pkgname=perl-Linux-DesktopFiles
 version=0.25
-revision=2
+revision=3
 wrksrc="${pkgname#perl-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Perl Linux::DesktopFiles - Get and parse the Linux desktop files"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="Artistic-2.0"
 homepage="https://metacpan.org/release/Linux-DesktopFiles"
-license="Artistic, GPL-1"
 distfiles="https://cpan.metacpan.org/authors/id/T/TR/TRIZEN/Linux-DesktopFiles-${version}.tar.gz"
 checksum=60377a74fba90fa465200ee1c7430dbdde69d454d85f9ee101c039803a07e5f5

--- a/srcpkgs/perl-MP3-Info/template
+++ b/srcpkgs/perl-MP3-Info/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-MP3-Info'
 pkgname=perl-MP3-Info
 version=1.26
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Perl interface to read and manipulate MP3 file information"
 maintainer="Evan Deaubl <evan@deaubl.name>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/MP3-Info"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/MP3/${pkgname/perl-/}-${version}.tar.gz"
 checksum=5762340732421f2502a770d6a126e584f2cd963351d2bc257bd278c39bce8be7

--- a/srcpkgs/perl-MRO-Compat/template
+++ b/srcpkgs/perl-MRO-Compat/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-MRO-Compat'.
+# Template file for 'perl-MRO-Compat'
 pkgname=perl-MRO-Compat
 version=0.13
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
 short_desc="MRO::Compat - mro::* interface compatibility for Perls < 5.9.5"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/MRO-Compat"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/App/HAARG/MRO-Compat-${version}.tar.gz"
 checksum=8a2c3b6ccc19328d5579d02a7d91285e2afd85d801f49d423a8eb16f323da4f8

--- a/srcpkgs/perl-MailTools/template
+++ b/srcpkgs/perl-MailTools/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-MailTools'
 pkgname=perl-MailTools
 version=2.21
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends} perl-TimeDate"
 depends="${makedepends}"
 short_desc="MailTools -- Various e-mail related modules"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/MailTools"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Mail/${pkgname/perl-/}-$version.tar.gz"
 checksum=4ad9bd6826b6f03a2727332466b1b7d29890c8d99a32b4b3b0a8d926ee1a44cb

--- a/srcpkgs/perl-Module-Build/template
+++ b/srcpkgs/perl-Module-Build/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Module-Build'
 pkgname=perl-Module-Build
 version=0.4231
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,8 +9,8 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Module::Build - Build and install Perl modules"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Module-Build"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Module/${pkgname/perl-/}-${version}.tar.gz"
 checksum=7e0f4c692c1740c1ac84ea14d7ea3d8bc798b2fb26c09877229e04f430b2b717
 

--- a/srcpkgs/perl-Module-Manifest/template
+++ b/srcpkgs/perl-Module-Manifest/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-Module-Manifest'.
+# Template file for 'perl-Module-Manifest'
 pkgname=perl-Module-Manifest
 version=1.09
-revision=2
+revision=3
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl perl-Params-Util perl-Test-Warn perl-Test-Exception"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
 short_desc='Module::Manifest: Parse and examine a distribution MANIFEST file'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Module-Manifest"
-license="Artistic, GPL-1"
 distfiles="$CPAN_SITE/Module/Module-Manifest-${version}.tar.gz"
 checksum=a395f80ff15ea0e66fd6c453844b6787ed4a875a3cd8df9f7e29280250bd539b

--- a/srcpkgs/perl-Net-SMTP-SSL/template
+++ b/srcpkgs/perl-Net-SMTP-SSL/template
@@ -1,7 +1,7 @@
-# Template file for 'perl-Net-SMP-SSL'
+# Template file for 'perl-Net-SMTP-SSL'
 pkgname=perl-Net-SMTP-SSL
 version=1.04
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends} perl-IO-Socket-SSL"
 depends="${makedepends}"
 short_desc="Net::SMTP::SSL -- SSL support for Net::SMTP"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Net-SMTP-SSL"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Net/${pkgname/perl-/}-${version}.tar.gz"
 checksum=7b29c45add19d3d5084b751f7ba89a8e40479a446ce21cfd9cc741e558332a00

--- a/srcpkgs/perl-Object-Realize-Later/template
+++ b/srcpkgs/perl-Object-Realize-Later/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Object-Realize-Later'
 pkgname=perl-Object-Realize-Later
 version=0.21
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Perl module to delay creation of objects"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Object-Realize-Later"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Object/${pkgname/perl-/}-${version}.tar.gz"
 checksum=8f7b9640cc8e34ea92bcf6c01049a03c145e0eb46e562275e28dddd3a8d6d8d9

--- a/srcpkgs/perl-Package-DeprecationManager/template
+++ b/srcpkgs/perl-Package-DeprecationManager/template
@@ -1,16 +1,16 @@
-# Template build file for 'perl-Package-DeprecationManager'.
+# Template file for 'perl-Package-DeprecationManager'
 pkgname=perl-Package-DeprecationManager
 version=0.17
-revision=3
+revision=4
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="${hostmakedepends} perl-Package-Stash perl-Params-Util perl-Sub-Install perl-Sub-Name"
-checkdepends="perl-Test-Warnings perl-Test-Fatal"
 depends="${makedepends}"
+checkdepends="perl-Test-Warnings perl-Test-Fatal"
 short_desc="Manage deprecation warnings for your distribution"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-2.0"
 homepage="https://metacpan.org/release/Package-DeprecationManager"
-license="Artistic-2.0, GPL-1"
 distfiles="${CPAN_SITE}/Package/${pkgname/perl-/}-$version.tar.gz"
 checksum="1d743ada482b5c9871d894966e87d4c20edc96931bb949fb2638b000ddd6684b"

--- a/srcpkgs/perl-PatchReader/template
+++ b/srcpkgs/perl-PatchReader/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-PatchReader'
 pkgname=perl-PatchReader
 version=0.9.6
-revision=4
+revision=5
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="perl"
 depends="$makedepends"
 short_desc="PatchReader - Utilities to read and manipulate patches and CVS"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Unknown"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/PatchReader"
 distfiles="https://cpan.metacpan.org/authors/id/T/TM/TMANNERM/PatchReader-${version}.tar.gz"
 checksum=b8de37460347bb5474dc01916ccb31dd2fe0cd92242c4a32d730e8eb087c323c

--- a/srcpkgs/perl-SGMLSpm/template
+++ b/srcpkgs/perl-SGMLSpm/template
@@ -1,15 +1,15 @@
 # Template file for 'perl-SGMLSpm'
 pkgname=perl-SGMLSpm
 version=1.1
-revision=2
+revision=3
 wrksrc=${pkgname/perl-/}-${version}
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
-short_desc="A perl5 class library for use with the sgmls and nsgmls parsers"
+short_desc="Perl5 class library for use with the sgmls and nsgmls parsers"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 # https://metacpan.org/release/SGMLSpm doesn't exist
 homepage="https://metacpan.org/release/RAAB/SGMLSpm-1.1"
 distfiles="https://cpan.metacpan.org/authors/id/R/RA/RAAB/SGMLSpm-${version}.tar.gz"

--- a/srcpkgs/perl-Sort-Versions/template
+++ b/srcpkgs/perl-Sort-Versions/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Sort-Versions'
 pkgname=perl-Sort-Versions
 version=1.62
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
 short_desc="Sort::Versions - a perl 5 module for sorting of revision-like numbers"
 maintainer="WantToHelp <ghostinthecsh@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Sort-Versions"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Sort/${pkgname/perl-/}-$version.tar.gz"
 checksum=bf5f3307406ebe2581237f025982e8c84f6f6625dd774e457c03f8994efd2eaa

--- a/srcpkgs/perl-String-ShellQuote/template
+++ b/srcpkgs/perl-String-ShellQuote/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-String-ShellQuote'
 pkgname=perl-String-ShellQuote
 version=1.04
-revision=4
+revision=5
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Perl module for quote strings for passing through the shell"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/String-ShellQuote"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/String/${pkgname/perl-/}-${version}.tar.gz"
 checksum=e606365038ce20d646d255c805effdd32f86475f18d43ca75455b00e4d86dd35

--- a/srcpkgs/perl-Sub-Exporter-Progressive/template
+++ b/srcpkgs/perl-Sub-Exporter-Progressive/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Sub-Exporter-Progressive'
 pkgname=perl-Sub-Exporter-Progressive
 version=0.001013
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends} perl-Sub-Exporter"
 depends="${makedepends}"
 short_desc="Only use Sub::Exporter if you need it"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Sub-Exporter-Progressive"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Sub/${pkgname/perl-/}-${version}.tar.gz"
 checksum=d535b7954d64da1ac1305b1fadf98202769e3599376854b2ced90c382beac056

--- a/srcpkgs/perl-Test-NoWarnings/template
+++ b/srcpkgs/perl-Test-NoWarnings/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-Test-NoWarnings'.
+# Template file for 'perl-Test-NoWarnings'
 pkgname=perl-Test-NoWarnings
 version=1.04
-revision=3
+revision=4
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
 short_desc='Test::NoWarnings - Make sure you did not emit warnings while testing.'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
+license="LGPL-2.1-only"
 homepage="https://metacpan.org/release/Test-NoWarnings"
-license="LGPL-2.1"
 distfiles="$CPAN_SITE/Test/Test-NoWarnings-${version}.tar.gz"
 checksum=638a57658cb119af1fe5b15e73d47c2544dcfef84af0c6b1b2e97f08202b686c

--- a/srcpkgs/perl-Test-Trap/template
+++ b/srcpkgs/perl-Test-Trap/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Test-Trap'
 pkgname=perl-Test-Trap
 version=v0.3.4
-revision=2
+revision=3
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl perl-Data-Dump"
@@ -9,7 +9,7 @@ makedepends="$hostmakedepends"
 depends="$hostmakedepends"
 short_desc='Test::Trap - Trap exit codes, exceptions, output, etc.'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Test-Trap"
-license="GPL-1, Artistic"
 distfiles="${CPAN_SITE}/Test/Test-Trap-${version}.tar.gz"
 checksum=0b04656f33b6c96da8eec4cffe5286150b4e4b5e2991d3883686b10910105ae2

--- a/srcpkgs/perl-Text-Diff/template
+++ b/srcpkgs/perl-Text-Diff/template
@@ -1,7 +1,7 @@
-# Template build file for 'perl-Text-Diff'.
+# Template file for 'perl-Text-Diff'
 pkgname=perl-Text-Diff
 version=1.45
-revision=2
+revision=3
 wrksrc="${pkgname#*-}-${version}"
 build_style=perl-module
 hostmakedepends="perl perl-Algorithm-Diff"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
 short_desc='Text::Diff - Perform diffs on files and record sets'
 maintainer="Enguerrand de Rochefort <voidlinux@rochefort.de>"
+license="Artistic-1.0-Perl, GPL-2.0-or-later"
 homepage="https://metacpan.org/release/Text-Diff"
-license="GPL-1, Artistic"
 distfiles="$CPAN_SITE/Text/Text-Diff-${version}.tar.gz"
 checksum=e8baa07b1b3f53e00af3636898bbf73aec9a0ff38f94536ede1dbe96ef086f04

--- a/srcpkgs/perl-Text-Glob/template
+++ b/srcpkgs/perl-Text-Glob/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Text-Glob'
 pkgname=perl-Text-Glob
 version=0.11
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${makedepends}"
 short_desc="Text::Glob - match globbing patterns against text"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Text-Glob"
-license="Artistic, GPL-1"
 distfiles="${CPAN_SITE}/Text/Text-Glob-${version}.tar.gz"
 checksum=069ccd49d3f0a2dedb115f4bdc9fbac07a83592840953d1fcdfc39eb9d305287

--- a/srcpkgs/perl-Text-Unidecode/template
+++ b/srcpkgs/perl-Text-Unidecode/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Text-Unidecode'
 pkgname=perl-Text-Unidecode
 version=1.30
-revision=3
+revision=4
 wrksrc="Text-Unidecode-$version"
 build_style=perl-module
 hostmakedepends="perl"
@@ -9,7 +9,7 @@ makedepends="perl"
 depends="perl"
 short_desc="US-ASCII transliterations of Unicode text"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
-license="Artistic-1.0-perl, GPL-1.0-or-later"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/pod/Text::Unidecode"
 distfiles="${CPAN_SITE}/Text/${pkgname/perl-/}-${version}.tar.gz"
 checksum=6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6

--- a/srcpkgs/perl-Text-WrapI18N/template
+++ b/srcpkgs/perl-Text-WrapI18N/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-Text-WrapI18N'
 pkgname=perl-Text-WrapI18N
 version=0.06
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl perl-Text-CharWidth"
@@ -9,7 +9,7 @@ makedepends="${hostmakedepends}"
 depends="${hostmakedepends}"
 short_desc="Line wrapping module with support for multibyte character encodings"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="Artistic, GPL-1"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Text-WrapI18N"
 distfiles="${CPAN_SITE}/Text/${pkgname/perl-/}-${version}.tar.gz"
 checksum=4bd29a17f0c2c792d12c1005b3c276f2ab0fae39c00859ae1741d7941846a488

--- a/srcpkgs/perl-XML-LibXML-PrettyPrint/template
+++ b/srcpkgs/perl-XML-LibXML-PrettyPrint/template
@@ -1,7 +1,7 @@
 # Template file for 'perl-XML-LibXML-PrettyPrint'
 pkgname=perl-XML-LibXML-PrettyPrint
 version=0.006
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
@@ -10,7 +10,7 @@ depends="$makedepends perl-Exporter-Tiny perl-XML-LibXML"
 checkdepends="$depends perl-Test-Warnings"
 short_desc="Perl extension to PrettyPrint XML"
 maintainer="John <me@johnnynator.dev>"
-license="Artistic-1.0-perl, GPL-1.0-or-later"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/pod/XML::LibXML::PrettyPrint"
 distfiles="${CPAN_SITE}/XML/${pkgname/perl-/}-${version}.tar.gz"
 checksum=89fb31725e90ecde0fc3623cb1e22decbaa4dbe30d6af56d38a0a8b45c4789f0

--- a/srcpkgs/perl-XML-Twig/template
+++ b/srcpkgs/perl-XML-Twig/template
@@ -1,15 +1,16 @@
 # Template file for 'perl-XML-Twig'
 pkgname=perl-XML-Twig
 version=3.52
-revision=2
+revision=3
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
 makedepends="$hostmakedepends"
 depends="perl>=5.20 perl-XML-Parser"
-short_desc="A perl module for processing huge XML documents in tree mode"
+checkdepends="$depends perl-IO-CaptureOutput perl-LWP perl-Test-Pod perl-XML-Simple perl-XML-XPath"
+short_desc="Perl module for processing huge XML documents in tree mode"
 maintainer="John Regan <john@jrjrtech.com>"
-license="Artistic"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/XML-Twig"
 distfiles="${CPAN_SITE}/XML/${pkgname/perl-/}-${version}.tar.gz"
 checksum=fef75826c24f2b877d0a0d2645212fc4fb9756ed4d2711614ac15c497e8680ad


### PR DESCRIPTION
Lots of general linting as well, mostly of the template ordering variety but a number of other issues were found. Also a number of broken tests were fixed.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

