### PR TITLE
libusb: fix descriptor parsing

### DIFF
--- a/srcpkgs/libusb/patches/fix-descriptor-parsing.patch
+++ b/srcpkgs/libusb/patches/fix-descriptor-parsing.patch
@@ -1,0 +1,35 @@
+--- libusb/os/linux_usbfs.c
++++ libusb/os/linux_usbfs.c
+@@ -641,7 +641,12 @@ static int seek_to_next_config(struct libusb_context *ctx,
+ 	uint8_t *buffer, size_t len)
+ {
+ 	struct usbi_descriptor_header *header;
+-	int offset = 0;
++	int offset;
++
++	/* Start seeking past the config descriptor */
++	offset = LIBUSB_DT_CONFIG_SIZE;
++	buffer += LIBUSB_DT_CONFIG_SIZE;
++	len -= LIBUSB_DT_CONFIG_SIZE;
+ 
+ 	while (len > 0) {
+ 		if (len < 2) {
+@@ -718,7 +723,7 @@ static int parse_config_descriptors(struct libusb_device *dev)
+ 		}
+ 
+ 		if (priv->sysfs_dir) {
+-			 /*
++			/*
+ 			 * In sysfs wTotalLength is ignored, instead the kernel returns a
+ 			 * config descriptor with verified bLength fields, with descriptors
+ 			 * with an invalid bLength removed.
+@@ -727,8 +732,7 @@ static int parse_config_descriptors(struct libusb_device *dev)
+ 			int offset;
+ 
+ 			if (num_configs > 1 && idx < num_configs - 1) {
+-				offset = seek_to_next_config(ctx, buffer + LIBUSB_DT_CONFIG_SIZE,
+-							     remaining - LIBUSB_DT_CONFIG_SIZE);
++				offset = seek_to_next_config(ctx, buffer, remaining);
+ 				if (offset < 0)
+ 					return offset;
+ 				sysfs_config_len = (uint16_t)offset;

--- a/srcpkgs/libusb/template
+++ b/srcpkgs/libusb/template
@@ -1,7 +1,7 @@
 # Template file for 'libusb'
 pkgname=libusb
 version=1.0.24
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="eudev-libudev-devel"


### PR DESCRIPTION
backported upstream commit
<https://github.com/libusb/libusb/commit/f6d2cb56>

which fixes a regression for multi-configuration devices, e.g. iPhone.

Many other distros have backported this fix, since the bug prevents all iOS devices from connecting.

https://changelogs.ubuntu.com/changelogs/pool/main/libu/libusb-1.0/libusb-1.0_1.0.24-3/changelog
https://koji.fedoraproject.org/koji/buildinfo?buildID=1712858
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
