### PR TITLE
tor: double MAX_OPEN_FILES yet again.

### DIFF
--- a/srcpkgs/tor/files/tor/run
+++ b/srcpkgs/tor/files/tor/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-ulimit -n ${MAX_OPEN_FILES:-8192}
+ulimit -n ${MAX_OPEN_FILES:-16384}
 exec tor ${OPTS:=--quiet} --runasdaemon 0 2>&1

--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,7 +1,7 @@
 # Template file for 'tor'
 pkgname=tor
 version=0.4.5.6
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-zstd"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
@ericonr As said on IRC, you were actually right about setting MAX_OPEN_FILES higher. I just again run into the fd limit and the high CPU usage I mentioned was because of io wait of tor waiting to get free fds. So let's double it just again, it's cheap as you said and should be fine now even with high bandwidth scenarios.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
