### PR TITLE
New package: pHash-20210509

### DIFF
--- a/srcpkgs/pHash/template
+++ b/srcpkgs/pHash/template
@@ -1,0 +1,14 @@
+# Template file for 'pHash'
+pkgname=pHash
+version=20210417
+revision=1
+_commit=6473c3028da063cb75481a534bd7ba0c1f3ffa01
+wrksrc="pHash-$_commit"
+build_style=cmake
+makedepends="libavcodec ffmpeg-devel CImg"
+short_desc="Open source perceptual hash library"
+maintainer="Robert Stancil <robert.stancil@live.com>"
+license="GPL-3.0-or-later"
+homepage="https://phash.org/"
+distfiles="https://github.com/aetilius/pHash/archive/${_commit}.tar.gz"
+checksum="9538e96aea04d9bfbbc6ba08b3d94ed21b2e50670aeddf9984b2d3712df88d5f"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
pHash is maintained, but its last official release is unsupported and maintainers say to use current dev version (https://github.com/aetilius/pHash/issues/6). This is a dependency of https://github.com/rbrich/dedup-images