### PR TITLE
oxygen-gtk+: fix license, other lint

### DIFF
--- a/srcpkgs/oxygen-gtk+/template
+++ b/srcpkgs/oxygen-gtk+/template
@@ -1,14 +1,14 @@
 # Template file for 'oxygen-gtk+'
 pkgname=oxygen-gtk+
 version=1.4.6
-revision=3
+revision=4
 wrksrc="${pkgname//\+/2}-${version}"
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="gtk+-devel"
-short_desc="A port of the default KDE widget theme (Oxygen) to GTK2"
+short_desc="Port of the default KDE widget theme (Oxygen) to GTK2"
 maintainer="TheNumb <me@thenumb.eu>"
-license="LGPL-2.1"
+license="LGPL-2.1-or-later"
 homepage="https://projects.kde.org/projects/playground/artwork/oxygen-gtk/"
-distfiles="http://download.kde.org/stable/${pkgname//\+/2}/${version}/src/${pkgname//\+/2}-${version}.tar.bz2"
+distfiles="${KDE_SITE}/${pkgname//\+/2}/${version}/src/${pkgname//\+/2}-${version}.tar.bz2"
 checksum=a289434347cc96054c75d1e4e4408b84adc2e8c7862f0be4e2da8fafbf26bf26


### PR DESCRIPTION
Kicked out of #30734 because of upstream DNS issues.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

