### PR TITLE
musl: add 0 large file patch

### DIFF
--- a/srcpkgs/musl/patches/fix_missing_O_LARGEFILE_values.patch
+++ b/srcpkgs/musl/patches/fix_missing_O_LARGEFILE_values.patch
@@ -1,0 +1,58 @@
+author	Rich Felker <dalias@aerifal.cx>	2020-09-03 17:37:11 -0400
+committer	Rich Felker <dalias@aerifal.cx>	2020-09-03 17:37:11 -0400
+commit	b8b729bd22c28c9116c2fce65dce207a35299c26
+
+prior to commit 685e40bb09f5f24a2af54ea09c97328808f76990, x86_64 was
+correctly passing O_LARGEFILE to SYS_open; it was removed (defined to
+0 in the public header, and changed to use the public definition) as
+part of that change, probably out of a mistaken belief that it's not
+needed.
+
+however, on a mixed system with 32-bit and 64-bit binaries, it's
+important that all files be opened with O_LARGEFILE, even if the
+opening process is 64-bit, in case a descriptor is passed to a 32-bit
+process. otherwise, attempts to access past 2GB in the 32-bit process
+could produce EOVERFLOW.
+
+most 64-bit archs added later got this right alread, except for
+mips64. x32 was also affected. there are now fixed.
+
+diff --git a/arch/mips64/bits/fcntl.h b/arch/mips64/bits/fcntl.h
+index 3bcec15e..5da1eef8 100644
+--- arch/mips64/bits/fcntl.h
++++ arch/mips64/bits/fcntl.h
+@@ -13,7 +13,7 @@
+
+ #define O_ASYNC      010000
+ #define O_DIRECT    0100000
+-#define O_LARGEFILE       0
++#define O_LARGEFILE  020000
+ #define O_NOATIME  01000000
+ #define O_PATH    010000000
+ #define O_TMPFILE 020200000
+diff --git a/arch/x32/bits/fcntl.h b/arch/x32/bits/fcntl.h
+index 1b88ad39..08627f81 100644
+--- arch/x32/bits/fcntl.h
++++ arch/x32/bits/fcntl.h
+@@ -13,7 +13,7 @@
+
+ #define O_ASYNC      020000
+ #define O_DIRECT     040000
+-#define O_LARGEFILE       0
++#define O_LARGEFILE 0100000
+ #define O_NOATIME  01000000
+ #define O_PATH    010000000
+ #define O_TMPFILE 020200000
+diff --git a/arch/x86_64/bits/fcntl.h b/arch/x86_64/bits/fcntl.h
+index 1b88ad39..08627f81 100644
+--- arch/x86_64/bits/fcntl.h
++++ arch/x86_64/bits/fcntl.h
+@@ -13,7 +13,7 @@
+
+ #define O_ASYNC      020000
+ #define O_DIRECT     040000
+-#define O_LARGEFILE       0
++#define O_LARGEFILE 0100000
+ #define O_NOATIME  01000000
+ #define O_PATH    010000000
+ #define O_TMPFILE 020200000

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=6
+revision=7
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
- musl: add patch for 0 largefile
- musl: revbump

This would allow e.g. building firefox so that it is usable with musl 1.2.2

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

Builds fine on x86_64-musl.