### PR TITLE
shutils/pkgtarget: speed up build dir cleanup.

### DIFF
--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -79,7 +79,7 @@ remove_pkg_autodeps() {
 remove_pkg_wrksrc() {
     if [ -d "$wrksrc" ]; then
         msg_normal "$pkgver: cleaning build directory...\n"
-        chmod -R +wX "$wrksrc" # Needed to delete Go Modules
+        rm -rf "$wrksrc" || chmod -R +wX "$wrksrc" # Needed to delete Go Modules
         rm -rf "$wrksrc"
     fi
 }


### PR DESCRIPTION
We need `chmod -R` to be able to cleanup after Go packages, but it's
unnecessary in most other cases. By only running it when the first `rm
-rf` fails, we optimize for the most common case and get a tiny speedup
for this build step.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
