### PR TITLE
Omnibus lint pass for SPDX warnings - most packages starting with P

### DIFF
--- a/srcpkgs/p0f/template
+++ b/srcpkgs/p0f/template
@@ -1,17 +1,17 @@
 # Template file for 'p0f'
 pkgname=p0f
 version=3.09b
-revision=2
+revision=3
 makedepends="libpcap-devel"
-short_desc="A passive OS fingerprinting tool"
+short_desc="Passive OS fingerprinting tool"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="LGPL-2.1"
-homepage="http://lcamtuf.coredump.cx/p0f3"
-distfiles="http://lcamtuf.coredump.cx/p0f3/releases/${pkgname}-${version}.tgz"
+license="LGPL-2.1-only"
+homepage="https://lcamtuf.coredump.cx/p0f3"
+distfiles="https://lcamtuf.coredump.cx/p0f3/releases/${pkgname}-${version}.tgz"
 checksum=543b68638e739be5c3e818c3958c3b124ac0ccb8be62ba274b4241dbdec00e7f
 
 do_configure() {
-	sed -i "s!\"p0f.fp!\"/usr/share/${pkgname}/p0f.fp!" config.h
+	vsed -i "s!\"p0f.fp!\"/usr/share/${pkgname}/p0f.fp!" config.h
 }
 
 do_build() {

--- a/srcpkgs/paperkey/template
+++ b/srcpkgs/paperkey/template
@@ -1,11 +1,11 @@
 # Template file for 'paperkey'
 pkgname=paperkey
 version=1.6
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="OpenPGP key archiver"
 maintainer="Pulux <pulux@pf4sh.de>"
-license="GPL-2"
-homepage="http://www.jabberwocky.com/software/paperkey/"
-distfiles="http://www.jabberwocky.com/software/paperkey/${pkgname}-${version}.tar.gz"
+license="GPL-2.0-or-later"
+homepage="https://www.jabberwocky.com/software/paperkey/"
+distfiles="https://www.jabberwocky.com/software/paperkey/${pkgname}-${version}.tar.gz"
 checksum=a245fd13271a8d2afa03dde979af3a29eb3d4ebb1fbcad4a9b52cf67a27d05f7

--- a/srcpkgs/pchar/template
+++ b/srcpkgs/pchar/template
@@ -1,11 +1,11 @@
 # Template file for 'pchar'
 pkgname=pchar
 version=1.5
-revision=4
+revision=5
 build_style=gnu-configure
 short_desc="Perform network measurements along an Internet path"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="custom"
+license="custom:Unlicense-like"
 homepage="http://www.kitchenlab.org/www/bmah/Software/pchar/"
 distfiles="http://www.kitchenlab.org/www/bmah/Software/pchar/${pkgname}-${version}.tar.gz"
 checksum=7019297084f1000557a019501532ecae67772851717329cc02227f5c17e36d27

--- a/srcpkgs/pdmenu/template
+++ b/srcpkgs/pdmenu/template
@@ -1,14 +1,14 @@
 # Template file for 'pdmenu'
 pkgname=pdmenu
 version=1.3.4
-revision=3
+revision=4
 wrksrc="${pkgname}"
 build_style=gnu-configure
 hostmakedepends="gettext pkg-config"
 makedepends="slang-devel"
 short_desc="Full screen menuing system for Unix"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-only"
 homepage="https://joeyh.name/code/pdmenu/"
 distfiles="http://http.debian.net/debian/pool/main/p/pdmenu/${pkgname}_${version}.tar.gz"
 checksum=302aa81b8868133ff5a0f3e3e897f71d425bc628c0d7439addb623f12c277bea

--- a/srcpkgs/pen/template
+++ b/srcpkgs/pen/template
@@ -1,13 +1,13 @@
 # Template file for 'pen'
 pkgname=pen
 version=0.34.1
-revision=6
+revision=7
 build_style=gnu-configure
-makedepends="geoip-devel openssl-devel"
 configure_args="--with-docdir=/usr/share/doc/pen"
+makedepends="geoip-devel openssl-devel"
 short_desc="Load balancer for simple TCP/UDP based protocols"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://siag.nu/pen"
 distfiles="http://siag.nu/pub/pen/pen-${version}.tar.gz"
 checksum=2b640795029df9d1672e17202c109cc5d42538f6754a6070dc27da640881e864

--- a/srcpkgs/pidgin-window-merge/template
+++ b/srcpkgs/pidgin-window-merge/template
@@ -1,14 +1,14 @@
 # Template file for 'pidgin-window-merge'
 pkgname=pidgin-window-merge
 version=0.3
-revision=1
+revision=2
+wrksrc="window_merge-${version}"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="pidgin-devel"
 short_desc="Pidgin plugin that merges the Buddy List and the conversation windows"
 maintainer="chinarulezzz <s.alex08@mail.ru>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://github.com/dm0-/window_merge"
 distfiles="https://github.com/downloads/dm0-/window_merge/window_merge-${version}.tar.gz"
 checksum=e890c829f8f074ca0bbf32a0bd3c9b8008802f2795d6f40a19756379e2ce6531
-wrksrc="window_merge-${version}"

--- a/srcpkgs/pilot-link/template
+++ b/srcpkgs/pilot-link/template
@@ -1,7 +1,7 @@
 # Template file for 'pilot-link'
 pkgname=pilot-link
 version=0.12.5
-revision=2
+revision=3
 build_style=gnu-configure
 # XXX: Add perl bindings --with-perl and fix bindings/Perl/Makefile
 configure_args="--enable-conduits --enable-libusb --enable-threads --disable-static
@@ -12,12 +12,10 @@ makedepends="libbluetooth-devel libusb-devel libpng-devel popt-devel
 depends="tk"
 short_desc="Suite of tools to connect your Palm or PalmOS® handheld"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
-homepage="http://www.pilot-link.org/"
-# Main site is unreachable (no address record).
-#distfiles="http://downloads.pilot-link.org/${pkgname}-${version}.tar.bz2"
-distfiles="https://mirrors.slackware.com/slackware/slackware-14.1/source/l/pilot-link/pilot-link-${version}.tar.bz2"
-checksum=d3f99ec04016b38995fb370265200254710318105c792c017d3aaccfb97a84b2
+license="GPL-2.0-or-later, LGPL-2.0-or-later"
+homepage="https://github.com/jichu4n/pilot-link"
+distfiles="https://github.com/jichu4n/pilot-link/archive/refs/tags/${version}.tar.gz"
+checksum=daf1facbd2da5fbf2f77dd85b0108710dfd87545eeae1271650f5d62070a1a16
 
 # Avoid error because of deprecation
 CFLAGS="-Wno-deprecated-declarations"
@@ -31,7 +29,7 @@ post_configure() {
 	# --disable-compile-error does not seem to work so patch Makefiles
 	find -name Makefile -exec sed -i "{}" -e "s;-Werror;-Wno-error;g" \;
 	# Fix wrong perl Config.pm path
-	sed -i bindings/Perl/Makefile \
+	vsed -i bindings/Perl/Makefile \
 		-e "s;/usr/lib/perl/5.10/Config.pm;/usr/lib/perl5/core_perl/Config.pm;"
 }
 

--- a/srcpkgs/pkg-config/template
+++ b/srcpkgs/pkg-config/template
@@ -1,14 +1,14 @@
 # Template file for 'pkg-config'
 pkgname=pkg-config
 version=0.29.2
-revision=2
+revision=3
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--with-internal-glib --disable-host-tool"
 short_desc="System for managing library compile/link flags"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-2"
-homepage="http://pkgconfig.freedesktop.org/wiki/"
+license="GPL-2.0-or-later"
+homepage="http://pkgconfig.freedesktop.org/"
 distfiles="http://pkgconfig.freedesktop.org/releases/${pkgname}-${version}.tar.gz"
 checksum=6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
 alternatives="

--- a/srcpkgs/playitslowly/template
+++ b/srcpkgs/playitslowly/template
@@ -1,14 +1,14 @@
 # Template file for 'playitslowly'
 pkgname=playitslowly
 version=1.5.1
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3"
 depends="python3 python3-gobject gtk+3 gstreamer1 gst-plugins-base1 gst-plugins-good1
  gst-plugins-bad1 gst-libav"
 short_desc="Play back audio files at a different speed or pitch"
 maintainer="Michael Straube <straubem@gmx.de>"
-license="GPL-3"
+license="GPL-3.0-or-later"
 homepage="https://29a.ch/playitslowly"
 distfiles="https://29a.ch/playitslowly/${pkgname}-${version}.tar.gz"
 checksum=7dfe3da5417971183a13002d1e4ba4f30770baaf1ae3f9ef0ac66a6727f476aa

--- a/srcpkgs/pmidi/template
+++ b/srcpkgs/pmidi/template
@@ -1,12 +1,12 @@
 # Template file for 'pmidi'
 pkgname=pmidi
 version=1.7.1
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="alsa-lib-devel"
 short_desc="Command line midi player for ALSA"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
-license="GPL-2"
-homepage="http://www.parabola.me.uk/alsa/pmidi.html"
+license="GPL-2.0-only"
+homepage="https://www.parabola.me.uk/alsa/pmidi.html"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${version}/${pkgname}-${version}.tar.gz"
 checksum=a500d9e41235ea741ffccce9541df9f74318663a62ec18d8081eb1119cd93514

--- a/srcpkgs/pngcrush/template
+++ b/srcpkgs/pngcrush/template
@@ -1,14 +1,14 @@
 # Template file for 'pngcrush'
 pkgname=pngcrush
 version=1.8.13
-revision=2
-build_style=gnu-makefile
+revision=3
 wrksrc=${pkgname}-${version}-nolib
+build_style=gnu-makefile
 makedepends="libpng-devel"
 short_desc="Tool for optimizing the compression of PNG files"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="zlib"
-homepage="http://pmt.sourceforge.net/pngcrush"
+license="Libpng"
+homepage="https://pmt.sourceforge.net/pngcrush"
 distfiles="${SOURCEFORGE_SITE}/pmt/${pkgname}-${version}-nolib.tar.xz"
 checksum=3b4eac8c5c69fe0894ad63534acedf6375b420f7038f7fc003346dd352618350
 

--- a/srcpkgs/pnmixer/template
+++ b/srcpkgs/pnmixer/template
@@ -1,13 +1,13 @@
 # Template file for 'pnmixer'
 pkgname=pnmixer
 version=0.7.2
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config intltool automake glib-devel"
 makedepends="alsa-lib-devel libnotify-devel gtk+3-devel"
 short_desc="Volume mixer for the system tray"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="https://github.com/nicklan/pnmixer"
 distfiles="https://github.com/nicklan/pnmixer/archive/v${version}.tar.gz"
 checksum=433487da386396f8d39244395220992ff73fe5191d0226febaead403a0cd6f2c

--- a/srcpkgs/polyglot/template
+++ b/srcpkgs/polyglot/template
@@ -1,12 +1,12 @@
 # Template file for 'polyglot'
 pkgname=polyglot
 version=2.0.4
-revision=1
+revision=2
 wrksrc="${pkgname}-${version}.orig"
 build_style=gnu-configure
 short_desc="Winboard chess protocol to UCI protocol adapter"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/polyglot"
 distfiles="${DEBIAN_SITE}/main/p/${pkgname}/${pkgname}_${version}.orig.tar.gz"
 checksum=fa43f80d7f956bdf986649d3ff1e487e1c8682a19b30011a55baa89633e3d23d

--- a/srcpkgs/potrace/template
+++ b/srcpkgs/potrace/template
@@ -1,13 +1,13 @@
 # Template file for 'potrace'
 pkgname=potrace
 version=1.16
-revision=1
+revision=2
 build_style=gnu-configure
-makedepends="zlib-devel"
 configure_args="--with-libpotrace"
+makedepends="zlib-devel"
 short_desc="Transforming bitmaps into vector graphics"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://potrace.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/$pkgname/$pkgname-$version.tar.gz"
 checksum=be8248a17dedd6ccbaab2fcc45835bb0502d062e40fbded3bc56028ce5eb7acc

--- a/srcpkgs/premake4/template
+++ b/srcpkgs/premake4/template
@@ -1,14 +1,14 @@
 # Template file for 'premake4'
 pkgname=premake4
 version=4.4beta5
-revision=3
+revision=4
 wrksrc=premake-${version/beta/-beta}
-hostmakedepends="unzip"
 build_style=gnu-makefile
 make_build_args="config=release -C build/gmake.unix"
+hostmakedepends="unzip"
 short_desc="Cross-platform, open-source build system"
 maintainer="Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>"
-license="3-clause-BSD"
+license="BSD-3-Clause"
 homepage="https://premake.github.io/"
 distfiles="${SOURCEFORGE_SITE}/project/premake/Premake/${version/beta*}/premake-${version/beta/-beta}-src.zip"
 checksum=0fa1ed02c5229d931e87995123cdb11d44fcc8bd99bba8e8bb1bbc0aaa798161

--- a/srcpkgs/psutils/template
+++ b/srcpkgs/psutils/template
@@ -1,15 +1,15 @@
 # Template file for 'psutils'
-pkgname="psutils"
-version="p17"
-revision=4
-short_desc="Set of utilities to manipulate PostScript files"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="AJCD-License"
+pkgname=psutils
+version=p17
+revision=5
+wrksrc="psutils"
 hostmakedepends="perl"
 makedepends="ghostscript"
 depends="ghostscript"
+short_desc="Set of utilities to manipulate PostScript files"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="psutils"
 homepage="http://knackered.org/angus/psutils/"
-wrksrc="psutils"
 distfiles="ftp://ftp.knackered.org/pub/psutils/${pkgname}-${version}.tar.gz"
 checksum="3853eb79584ba8fbe27a815425b65a9f7f15b258e0d43a05a856bdb75d588ae4"
 

--- a/srcpkgs/pwgen/template
+++ b/srcpkgs/pwgen/template
@@ -1,11 +1,11 @@
 # Template file for 'pwgen'
 pkgname=pwgen
 version=2.08
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Password Generator"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://pwgen.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=dab03dd30ad5a58e578c5581241a6e87e184a18eb2c3b2e0fffa8a9cf105c97b


### PR DESCRIPTION
Does not include python-* or perl-*, those were fixed elsewhere. Also, P had a surprisingly large number of failures and otherwise broken packages.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
