### PR TITLE
reaver: upgrade to 1.6.6

### DIFF
--- a/srcpkgs/reaver/template
+++ b/srcpkgs/reaver/template
@@ -1,29 +1,13 @@
 # Template file for 'reaver'
 pkgname=reaver
-version=1.6.5
-revision=2
-build_style=gnu-configure
+version=1.6.6
+revision=1
 build_wrksrc="src"
-#conf_files="/etc/reaver/reaver.db"
+build_style=gnu-configure
 makedepends="libpcap-devel"
 short_desc="Brute force attack tool against Wifi Protected Setup (WPS)"
 maintainer="cipr3s <cipr3s@gmx.com>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/t6x/reaver-wps-fork-t6x"
 distfiles="https://github.com/t6x/reaver-wps-fork-t6x/releases/download/v${version}/${pkgname}-${version}.tar.xz"
-checksum=342e9d265cf459bd2387205b73a63d1fc7582e268f0e9aec20613f3ec11b6a6b
-
-post_extract() {
-	case "$XBPS_TARGET_MACHINE" in
-	*-musl) find -type f -exec sed -i "{}" -e"s;u_char;unsigned char;g" \;
-		;;
-	esac
-}
-
-#do_install() {
-#	# The Makefile's install target is broken (ignores destdir)
-#	vmkdir etc/${pkgname}
-#	vinstall ${pkgname}.db 644 etc/${pkgname}
-#	vbin wash
-#	vbin reaver
-#}
+checksum=e329a0da0b6dd888916046535ff86a6aa144644561937954e560bb1810ab6702


### PR DESCRIPTION
Removes a bunch of commented out old template stuff as well. This is tracked in source control so the history is always right there.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

@cipr3s 