### PR TITLE
snoopy: update to 2.4.14

### DIFF
--- a/srcpkgs/snoopy/template
+++ b/srcpkgs/snoopy/template
@@ -1,20 +1,27 @@
 # Template file for 'snoopy'
 pkgname=snoopy
-version=2.4.6
+version=2.4.14
 revision=1
 build_style=gnu-configure
 hostmakedepends="socat"
+checkdepends="procps-ng"
 conf_files="/etc/snoopy.ini"
 short_desc="Log every executed command to syslog"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="https://github.com/a2o/snoopy"
-distfiles="http://source.a2o.si/download/snoopy/snoopy-${version}.tar.gz"
-checksum=6442e1145a5cad725f6aae0887030ee3db34bafc40bbe3bb84da836cbb5f1569
+distfiles="https://github.com/a2o/snoopy/releases/download/snoopy-${version}/snoopy-${version}.tar.gz"
+checksum=6f305f49d87d56906061ded9083dc0308365f966a13edacc3eb59191221ced1a
 
-pre_configure() {
+post_patch() {
 	find . -type f -name Makefile.in -exec sed -i 's| -Werror||' {} +
 }
+
+# some tests are degenerate and blindly source os-release prior to running
+post_build() {
+	[ -f /etc/os-release ] || echo 'ID="void"' > /etc/os-release
+}
+
 post_install() {
 	vconf etc/snoopy.ini
 }


### PR DESCRIPTION
Also fixes the test environment, though maybe not in the best way.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

