### PR TITLE
New packages: intel-compute-runtime-bin-21.18.19737_1 and intel-graphics-compiler-bin-1.0.7181_1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -48,6 +48,7 @@ libpcprofile.so glibc-2.32_1
 libcidn.so.1 glibc-2.32_1
 libmvec.so.1 glibc-2.32_1
 libz.so.1 zlib-1.2.3_1
+libze_intel_gpu.so.1 intel-compute-runtime-bin-21.18.19737_1
 libbz2.so.1 bzip2-1.0.5_1
 libarchive.so.13 libarchive-3.5.1_2
 libcc1.so.0 gcc-6.2.1_1
@@ -3893,6 +3894,7 @@ libptexenc.so.1 texlive-20200406_1
 libsynctex.so.2 libsynctex-20200406_3
 libdolphinvcs.so.5 dolphin-20.04.3_1
 libocl.so.2019.07 opencamlib-2019.07_1
+libocloc.so intel-compute-runtime-bin-21.18.19737_1
 libcglm.so.0 cglm-0.7.6_1
 libfcft.so.3 fcft-2.2.2_1
 libaml.so.0 aml-0.1.0_1

--- a/srcpkgs/intel-compute-runtime-bin/files/LICENSE
+++ b/srcpkgs/intel-compute-runtime-bin/files/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/srcpkgs/intel-compute-runtime-bin/template
+++ b/srcpkgs/intel-compute-runtime-bin/template
@@ -1,0 +1,39 @@
+# Template file for 'intel-compute-runtime-bin'
+pkgname=intel-compute-runtime-bin
+version=21.18.19737
+revision=1
+archs="x86_64"
+depends="intel-graphics-compiler-bin"
+short_desc="Intel Graphics Compute Runtime and OpenCL Driver (precompiled binaries)"
+maintainer="Lucas L. Treffenstädt <lucas@treffenstaedt.de>"
+license="MIT"
+homepage="https://github.com/intel/compute-runtime/"
+_lzver=1.1.19737
+_gmmver=21.1.2
+distfiles="https://github.com/intel/compute-runtime/releases/download/${version}/intel-opencl_${version}_amd64.deb
+ https://github.com/intel/compute-runtime/releases/download/${version}/intel-ocloc_${version}_amd64.deb
+ https://github.com/intel/compute-runtime/releases/download/${version}/intel-level-zero-gpu_${_lzver}_amd64.deb"
+checksum="a17a4f7f4e2e59096a58e131235c508eb49f9086db5bef3ddb47c5ae482e2bac
+ 35a851d44b54f4c948e06edf709c4cd509b17029a03bf58b7ae614062880e352
+ 4bb17c8a23d7a188b6c1194f181d403ef98ea6c0eabf75298feb1fa24c8458f2"
+nostrip=yes
+
+do_extract() {
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-opencl_${version}_amd64.deb \
+		data.tar.xz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-ocloc_${version}_amd64.deb \
+		data.tar.xz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-level-zero-gpu_${_lzver}_amd64.deb \
+		data.tar.xz | bsdtar -x -f -
+	mkdir -p usr
+	mv usr/local/{bin,include,lib} usr
+	rm -r usr/local
+	ln -s $(find usr/lib -regex '.*libze_intel_gpu.so.[0-9]*' -exec basename {} \;) usr/lib/libze_intel_gpu.so
+	sed -i 's|/usr/local|/usr|' "etc/OpenCL/vendors/intel.icd"
+}
+
+do_install() {
+	vmkdir usr
+	vcopy ${wrksrc}/usr/* usr
+	vlicense ${FILESDIR}/LICENSE
+}

--- a/srcpkgs/intel-graphics-compiler-bin/files/LICENSE
+++ b/srcpkgs/intel-graphics-compiler-bin/files/LICENSE
@@ -1,0 +1,23 @@
+<!---======================= begin_copyright_notice ============================
+
+Copyright (c) 2019-2021 Intel Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+============================= end_copyright_notice ==========================-->

--- a/srcpkgs/intel-graphics-compiler-bin/template
+++ b/srcpkgs/intel-graphics-compiler-bin/template
@@ -1,0 +1,40 @@
+# Template file for 'intel-graphics-compiler-bin'
+pkgname=intel-graphics-compiler-bin
+version=1.0.7181
+revision=1
+archs="x86_64"
+depends="zlib libgcc"
+short_desc="Intel Graphics Compiler for OpenCL (pre-compiled binaries)"
+maintainer="Lucas L. Treffenstädt <lucas@treffenstaedt.de>"
+license="MIT"
+homepage="https://github.com/intel/intel-graphics-compiler/"
+distfiles="https://github.com/intel/intel-graphics-compiler/releases/download/igc-${version}/intel-igc-core_${version}_amd64.deb
+ https://github.com/intel/intel-graphics-compiler/releases/download/igc-${version}/intel-igc-media_${version}_amd64.deb
+ https://github.com/intel/intel-graphics-compiler/releases/download/igc-${version}/intel-igc-opencl-devel_${version}_amd64.deb
+ https://github.com/intel/intel-graphics-compiler/releases/download/igc-${version}/intel-igc-opencl_${version}_amd64.deb"
+checksum="49850dabd50c8c6f28b27d9c4561afcbacd53d7e97f141c0adefe2bd567cd46b
+ 0a1b7d90aa0cbc0b46ca903874759835b7bbd4862f43ee90bcb7a8d225fbcd17
+ 93b10ff013223c139e1cb97b64fc99201d14f5dcccf6be299cfaca279b70a0b6
+ f08aff6c07369ecb4758f0385eedc5b8db096d9219b5013217c05f6008a3f1e4
+ 0ddcc820928d5fc03b6c1271de8c0f9e9be74717f872956cc3fc4ae25eca9d9"
+nostrip=yes
+
+do_extract() {
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-igc-core_${version}_amd64.deb \
+		data.tar.gz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-igc-media_${version}_amd64.deb \
+		data.tar.gz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-igc-opencl-devel_${version}_amd64.deb \
+		data.tar.gz | bsdtar -x -f -
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/intel-igc-opencl_${version}_amd64.deb \
+		data.tar.gz | bsdtar -x -f -
+	mkdir -p usr/local/include/igc
+	mv usr/local/include/opencl-c{,-base}.h usr/local/include/igc
+	mv usr/local/{bin,include,lib} usr
+}
+
+do_install() {
+	vmkdir usr
+	vcopy ${wrksrc}/usr/* usr
+	vlicense ${FILESDIR}/LICENSE
+}


### PR DESCRIPTION
#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

These packages are required to have opencl support for newer intel graphics cards (e.g. UHD Graphics 620) which are not supported by beignet. The templates are based on these arch linux packages:
https://aur.archlinux.org/packages/intel-graphics-compiler-bin/
https://aur.archlinux.org/packages/intel-compute-runtime-bin/
