### PR TITLE
strongswan: bump to 5.9.2, fix tests, fix eap-mschapv2.

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,16 +1,18 @@
 # Template file for 'strongswan'
 pkgname=strongswan
-version=5.8.4
-revision=2
+version=5.9.2
+revision=1
 build_style=gnu-configure
 # tpm support waits on libtss2
 configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
- --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5 --enable-eap-identity --enable-eap-dynamic
- --enable-led --enable-ha --enable-dhcp --enable-mediation --enable-soup --disable-des
- --enable-chapoly --enable-nm"
+ --enable-openssl --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5
+ --enable-eap-identity --enable-eap-dynamic --enable-led --enable-ha --enable-dhcp
+ --enable-mediation --enable-soup --disable-des --enable-chapoly --enable-nm"
 hostmakedepends="pkg-config flex bison python"
-makedepends="gmp-devel libsoup-devel libldns-devel unbound-devel libcurl-devel NetworkManager-devel"
+makedepends="gmp-devel libsoup-devel libldns-devel unbound-devel libcurl-devel
+ NetworkManager-devel openssl-devel"
 depends="iproute2 sqlite"
+checkdepends="tzdata"
 conf_files="/etc/*.conf /etc/strongswan.d/*.conf /etc/strongswan.d/charon/*.conf /etc/ipsec.secrets"
 short_desc="IPsec-based VPN solution, supporting IKEv1/IKEv2 and MOBIKE"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
@@ -18,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.strongswan.org/"
 changelog="https://wiki.strongswan.org/projects/strongswan/wiki/Changelog"
 distfiles="https://download.strongswan.org/${pkgname}-${version}.tar.bz2"
-checksum=2d9a57e33813b62d58cba07531c4d5a35c6b823dfe9b8ff7c623b6571f02553c
+checksum=61c72f741edb2c1295a7b7ccce0317a104b3f9d39efd04c52cd05b01b55ab063
 make_dirs="/etc/ipsec.d/ 0755 root root
  /etc/ipsec.d/aacerts 0755 root root
  /etc/ipsec.d/acerts 0755 root root
@@ -28,6 +30,11 @@ make_dirs="/etc/ipsec.d/ 0755 root root
  /etc/ipsec.d/crls 0755 root root
  /etc/ipsec.d/reqs 0755 root root
  /etc/ipsec.d/private 0750 root root"
+
+# CI checks are currently disabled due to a number of tests failing either as a
+# result of GitHub Actions having a networking setup that is incompatible with
+# them, or some other issue that is difficult to reproduce locally.
+make_check=ci-skip
 
 post_install() {
 	vsv strongswan


### PR DESCRIPTION
The test failure in void was due to tzdata being a runtime dependency
of one test indirectly, so we simply add it in makedepends.

For eap-mschapv2 to be loaded at runtime, we need to have
--enable-openssl as a configuration flag. While strongswan will build
and install eap-mschapv2 without it, it will never actually load it as a
plugin and it simply won't work.

<!-- Mark items with [x] where applicable -->
<!--
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)
-->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
