### PR TITLE
ansible-base: bump to 2.10.9

### DIFF
--- a/srcpkgs/ansible-base/template
+++ b/srcpkgs/ansible-base/template
@@ -1,7 +1,7 @@
 # Template file for 'ansible-base'
 pkgname=ansible-base
-version=2.10.8
-revision=2
+version=2.10.9
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="${hostmakedepends} python3-cryptography python3-Jinja2 python3-paramiko
@@ -11,7 +11,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 distfiles="${PYPI_SITE}/a/ansible-base/ansible-base-${version}.tar.gz"
-checksum=f45df824051339d8bec32d7ab4e9e676498c05e2d9cfce6d54c9698a577e15e2
+checksum=04635d3e08fc29358c76b8e7f1e9db0ce443fb09ce30b2acc6cacaad165f2151
 conflicts="ansible<2.10.1_1"
 make_check=no
 


### PR DESCRIPTION
This pull request bumps the ansible-base version to 2.10.9

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
