### PR TITLE
mpdscribble: update to 0.23,

### DIFF
--- a/srcpkgs/mpdscribble/template
+++ b/srcpkgs/mpdscribble/template
@@ -1,16 +1,17 @@
 # Template file for 'mpdscribble'
 pkgname=mpdscribble
-version=0.22
-revision=6
-build_style=gnu-configure
+version=0.23
+revision=1
+build_style=meson
 hostmakedepends="pkg-config"
-makedepends="libmpdclient-devel glib-devel libcurl-devel"
+makedepends="libmpdclient-devel libcurl-devel boost-devel libgcrypt-devel"
 short_desc="MPD audio scrobbler (e.g. last.fm)"
 maintainer="Georg Schabel <gescha@posteo.de>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/MusicPlayerDaemon/mpdscribble"
-distfiles="http://www.musicpd.org/download/${pkgname}/${version}/${pkgname}-${version}.tar.bz2"
-checksum=1cde2b5f8c70f0e3e6f059d01bf0b0f2eac2b29fbcd14b01a8a5103e603feb41
+changelog="https://raw.githubusercontent.com/MusicPlayerDaemon/mpdscribble/master/NEWS"
+distfiles="https://www.musicpd.org/download/mpdscribble/${version}/mpdscribble-${version}.tar.xz"
+checksum=a3387ed9140eb2fca1ccaf9f9d2d9b5a6326a72c9bcd4119429790c534fec668
 
 conf_files="/etc/${pkgname}.conf"
 make_dirs="/var/cache/mpdscribble/ 0755 root root"


### PR DESCRIPTION
- change build system to meson (upstream change),
- add boost-devel and libgcrypt-devel to makedepends (new deps),
- drop glib-devel from makedepends (dropped upstream),
- add changelog.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
