### PR TITLE
sip4: update to 4.19.25

### DIFF
--- a/srcpkgs/sip4/template
+++ b/srcpkgs/sip4/template
@@ -1,7 +1,7 @@
 # Template file for 'sip4'
 pkgname=sip4
-version=4.19.24
-revision=4
+version=4.19.25
+revision=1
 wrksrc="sip-$version"
 hostmakedepends="python3-devel"
 makedepends="${hostmakedepends}"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, GPL-3.0-only, custom:SIP"
 homepage="https://riverbankcomputing.com/software/sip/intro"
 distfiles="https://www.riverbankcomputing.com/static/Downloads/sip/${version}/sip-${version}.tar.gz"
-checksum=edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5
+checksum=b39d93e937647807bac23579edbff25fe46d16213f708370072574ab1f1b4211
 replaces="sip<=${version}_${revision}"
 provides="sip-${version}_${revision}"
 


### PR DESCRIPTION
This is the last release version of sip4 and contains bugfixes.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
