### PR TITLE
gnome-builder: fix tests

### DIFF
--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -4,7 +4,7 @@ version=3.40.2
 revision=1
 build_style=meson
 build_helper=qemu
-configure_args="-Dwith_webkit=true -Dwith_sysprof=true -Dhelp=true"
+configure_args="-Dwith_webkit=true -Dwith_sysprof=true -Dhelp=true -Dnetwork_tests=false"
 hostmakedepends="pkg-config appstream-glib desktop-file-utils flex gobject-introspection
  gspell-devel llvm mm-common vala python3-Sphinx python3-sphinx_rtd_theme gettext"
 makedepends="cairo-devel clang devhelp-devel enchant2-devel flatpak-devel
@@ -13,11 +13,12 @@ makedepends="cairo-devel clang devhelp-devel enchant2-devel flatpak-devel
  libxml2-devel template-glib-devel vala-devel vte3-devel webkit2gtk-devel
  python3-gobject-devel sysprof-devel glade3-devel libportal-devel"
 depends="desktop-file-utils flatpak-builder python3-lxml devhelp python3-gobject"
+checkdepends="xvfb-run"
 short_desc="IDE for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Builder"
-changelog="https://gitlab.gnome.org/GNOME/gnome-builder/raw/gnome-builder-3-36/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-builder/raw/gnome-builder-3-40/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=b2844cfde821311939fb6ed3b18a49cd331413aea720393091583ab6a99e719a
 patch_args="-Np1"
@@ -29,7 +30,6 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 esac
 
-pre_configure() {
-	# this test needs X
-	vsed -i "s/test('test-text-iter'/#&/" src/tests/meson.build
+do_check() {
+	xvfb-run ninja -C build test
 }


### PR DESCRIPTION
validating the appstream file with network can easily time out

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
