### PR TITLE
ksh: update to 1.0.0.beta.1.

### DIFF
--- a/srcpkgs/ksh/template
+++ b/srcpkgs/ksh/template
@@ -1,16 +1,15 @@
 # Template file for 'ksh'
 pkgname=ksh
-version=2020.0.0
+reverts="2020.0.0_1"
+version=1.0.0.beta.1
 revision=1
-wrksrc="ast-${version}"
-build_style=meson
-configure_args="-Dbuild-api-tests=false -Dbuild-api-tests-only=true"
-short_desc="AT&T's Korn shell (ksh93)"
+wrksrc="ksh-${version/.beta/-beta}"
+short_desc="AT&T's Korn shell (ksh93u+m)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="EPL-1.0"
 homepage="http://www.kornshell.com/"
-distfiles="https://github.com/att/ast/archive/${version}.tar.gz"
-checksum=76597c96c4f94423b9225b5de50ea54be08d5bbaa1e0e594a7eec603bd60ecaf
+distfiles="https://github.com/ksh93/ksh/archive/v${version/.beta/-beta}.tar.gz"
+checksum=7d77b59a9352ffe3fc60a1af936e022c1f12cb42753d4a8a116d6c8126915738
 nocross=yes
 
 register_shell="/bin/ksh"
@@ -24,25 +23,20 @@ if [ "$build_option_static" ]; then
 	LDFLAGS+=" -static"
 fi
 
-case "$XBPS_TARGET_MACHINE" in
-*-musl)
-	makedepends+=" musl-fts-devel"
-esac
-
-post_extract() {
-	sed -i -e 's/= library/= static_library/'  \
-		-e 's/install: true/install: false/' src/lib/*/meson.build
-	sed -i 's/vpoi/void*/g' src/cmd/ksh93/include/name.h
-	if [ "$build_option_static" ]; then
-		# Drop tests that use .so
-		sed -i '/some tests/,$d' src/cmd/ksh93/meson.build
-		sed -i '/libsample_files/,$d' src/lib/libdll/meson.build
-	fi
+do_build() {
+	bin/package make CCFLAGS="$CFLAGS" NPROC="$XBPS_MAKEJOBS"
 }
-post_install() {
-	mv ${DESTDIR}/usr/bin/ksh ${DESTDIR}/usr/bin/ksh93
-	mv ${DESTDIR}/usr/share/man/man1/ksh.1 ${DESTDIR}/usr/share/man/man1/ksh93.1
+do_check() {
+	# run inside own pty
+	script -qfc bin/shtests /dev/null
+}
+do_install() {
+	vlicense LICENSE.md LICENSE
+
+	cd arch/*/
+	vbin bin/ksh ksh93
+	vbin bin/shcomp
 	vmkdir usr/share/ksh
-	vcopy src/cmd/ksh93/fun usr/share/ksh/functions
-	vlicense LICENSE
+	vcopy fun usr/share/ksh/functions
+	vman man/man1/sh.1 ksh93.1
 }


### PR DESCRIPTION
Queuing for now until a stable release appears.

Revert to the maintained fork "ksh93u+m".
