### PR TITLE
llvm12: only disable sanitizer for arm*-musl.

### DIFF
--- a/srcpkgs/bcc/template
+++ b/srcpkgs/bcc/template
@@ -20,10 +20,6 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 fi
 
-if [ "${XBPS_TARGET_LIBC}" = musl ]; then
-	makedepends+=" libexecinfo-devel"
-fi
-
 post_extract() {
 	sed -i '/tests/d' CMakeLists.txt  # break on musl
 	sed -i 's/<error.h>/<errno.h>/' examples/cpp/KModRetExample.cc

--- a/srcpkgs/llvm12/files/patches/compiler-rt/compiler-rt-xray-ppc64-musl.patch
+++ b/srcpkgs/llvm12/files/patches/compiler-rt/compiler-rt-xray-ppc64-musl.patch
@@ -44,7 +44,7 @@
 +        if (!ret) {
 +          continue;
 +        }
-+        ret += sizeof("timebase" - 1);
++        ret += sizeof("timebase") - 1;
 +        ret = strchr(ret, ':');
 +        if (!ret) {
 +          continue;

--- a/srcpkgs/llvm12/template
+++ b/srcpkgs/llvm12/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm12'
 pkgname=llvm12
 version=12.0.0
-revision=1
+revision=2
 wrksrc="llvm-${version}.src"
 build_style=cmake
 configure_args="
@@ -60,6 +60,7 @@ python_version=3
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	configure_args+=" -DLIBCXX_HAS_MUSL_LIBC=YES"
 	makedepends+=" libexecinfo-devel"
+	depends+=" libexecinfo-devel"
 fi
 
 # "operand out of range" assembler failures
@@ -233,19 +234,16 @@ post_patch() {
 			;;
 	esac
 
-	# some sanitizer currently only on x86_64 stuff needs backtrace
 	case "$XBPS_TARGET_MACHINE" in
-		x86_64-musl)
+		x86_64-musl) # some sanitizer currently only on x86_64 stuff needs backtrace
 			vsed -i 's,# Set common link flags.,list(APPEND SANITIZER_COMMON_LINK_LIBS execinfo),' \
 				${wrksrc}/projects/compiler-rt/CMakeLists.txt
 			;;
+		arm*-musl) # sanitizer code is broken on arm*-musl since it duplicates some libc bits
+			vsed -i 's/set(COMPILER_RT_HAS_SANITIZER_COMMON TRUE)/set(COMPILER_RT_HAS_SANITIZER_COMMON FALSE)/' \
+				${wrksrc}/projects/compiler-rt/cmake/config-ix.cmake
+			;;
 	esac
-
-	# sanitizer code is broken on arm*-musl since it duplicates some libc bits
-	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-		vsed -i 's/set(COMPILER_RT_HAS_SANITIZER_COMMON TRUE)/set(COMPILER_RT_HAS_SANITIZER_COMMON FALSE)/' \
-			${wrksrc}/projects/compiler-rt/cmake/config-ix.cmake
-	fi
 }
 
 pre_configure() {


### PR DESCRIPTION
The code erroneously disabled sanitizer support for all musl targets.

[ci skip]
@q66 

To merge when the builders have been restarted.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
