### PR TITLE
gnutls: trim down gnutls-devel depends.

### DIFF
--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,7 +1,7 @@
 # Template file for 'gnutls'
 pkgname=gnutls
 version=3.6.15
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-zlib --disable-guile --disable-static
  --disable-valgrind-tests --disable-rpath
@@ -10,9 +10,11 @@ configure_args="--with-zlib --disable-guile --disable-static
 hostmakedepends="gettext libtool pkg-config which"
 # for autoreconf
 #hostmakedepends+=" gettext-devel-tools automake"
+# dependencies listed in pkg-config files
+_develdepends="unbound-devel trousers-devel libunistring-devel nettle-devel
+ libtasn1-devel libidn2-devel p11-kit-devel"
 makedepends="zlib-devel lzo-devel readline-devel libgpg-error-devel
- libtasn1-devel libgcrypt-devel p11-kit-devel nettle-devel libidn2-devel
- libunistring-devel unbound-devel trousers-devel"
+ libgcrypt-devel ${_develdepends}"
 checkdepends="iproute2"
 short_desc="GNU Transport Layer Security library"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -27,7 +29,7 @@ pre_check() {
 }
 
 gnutls-devel_package() {
-	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
+	depends="${_develdepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
Instead of pulling in all makedepends from gnutls into gnutls-devel,
just use those listed in gnutls's pkgconfig files. This can speed up
local builds and avoids potential dependencies conflicts between
unnecessary packages.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
