### PR TITLE
Komikku + python3-keyring update

### DIFF
--- a/srcpkgs/Komikku/template
+++ b/srcpkgs/Komikku/template
@@ -1,15 +1,15 @@
 # Template file for 'Komikku'
 pkgname=Komikku
 version=0.29.2
-revision=1
+revision=2
 wrksrc=Komikku-v${version}
 build_style=meson
 hostmakedepends="gettext glib-devel gobject-introspection pkg-config"
 makedepends="gtk+3-devel libhandy1-devel"
-depends="gtk+3 python3-BeautifulSoup4 python3-requests python3-dateparser
- python3-gobject python3-lxml python3-magic python3-Pillow python3-pure-protobuf
- libhandy1 libnotify libsecret python3-Unidecode python3-keyring
- python3-cloudscraper"
+depends="gtk+3 libhandy1 libnotify libsecret python3-BeautifulSoup4
+ python3-Pillow python3-Unidecode python3-cloudscraper python3-dateparser
+ python3-gobject python3-keyring python3-lxml python3-magic
+ python3-pure-protobuf"
 checkdepends="appstream-glib desktop-file-utils"
 short_desc="Online/offline manga reader for GNOME"
 maintainer="Lorem <notloremipsum@protonmail.com>"

--- a/srcpkgs/python3-cloudscraper/template
+++ b/srcpkgs/python3-cloudscraper/template
@@ -1,0 +1,23 @@
+# Template file for 'python3-cloudscraper'
+pkgname=python3-cloudscraper
+version=1.2.58
+revision=1
+wrksrc=cloudscraper-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-requests-toolbelt"
+short_desc="Python module to bypass Cloudflare's anti-bot page"
+maintainer="Lorem <notloremipsum@protonmail.com>"
+license="MIT"
+homepage="https://github.com/venomous/cloudscraper"
+distfiles="${PYPI_SITE}/c/cloudscraper/cloudscraper-${version}.tar.gz"
+checksum=dda29028c5628b5ba3e4dc43816ed38fd46bd945ef938c420f185586a6d8dff2
+
+do_check() {
+	# Needs unpackaged v8eval
+	:
+}
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-importlib_metadata/template
+++ b/srcpkgs/python3-importlib_metadata/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-importlib_metadata'
+pkgname=python3-importlib_metadata
+version=4.0.1
+revision=1
+wrksrc="importlib_metadata-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm python3-toml"
+depends="python3-zipp"
+short_desc="Read metadata from Python packages (Python 3)"
+maintainer="Lorem <notloremipsum@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/python/importlib_metadata"
+distfiles="${PYPI_SITE}/i/importlib_metadata/importlib_metadata-${version}.tar.gz"
+checksum=8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581
+# Needs unpackaged "pyfakefs"
+make_check=no

--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,18 +1,20 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=21.2.1
-revision=3
+version=23.0.1
+revision=1
 wrksrc="keyring-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm python3-toml"
-depends="python3-setuptools python3-SecretStorage python3-entrypoints"
+depends="python3-SecretStorage python3-importlib_metadata"
+checkdepends="python3-importlib_metadata python3-pytest
+ python3-pytest-flake8 python3-pytest-cov"
 short_desc="Python interface to the system keyring service"
 maintainer="Oliver Kiddle <okiddle@yahoo.co.uk>"
 license="MIT"
 homepage="https://github.com/jaraco/keyring"
 changelog="https://raw.githubusercontent.com/jaraco/keyring/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=c53e0e5ccde3ad34284a40ce7976b5b3a3d6de70344c3f8ee44364cc340976ec
+checksum=045703609dd3fccfcdb27da201684278823b72af515aedec1a8515719a038cb8
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-zipp/template
+++ b/srcpkgs/python3-zipp/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-zipp'
+pkgname=python3-zipp
+version=3.4.1
+revision=1
+wrksrc="zipp-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm python3-toml"
+checkdepends="python3-jaraco"
+short_desc="Pathlib-compatible Zipfile object wrapper (Python 3)"
+maintainer="Lorem <notloremipsum@protonmail.com>"
+license="MIT"
+homepage="https://github.com/jaraco/zipp"
+changelog="https://raw.githubusercontent.com/jaraco/zipp/master/CHANGES.rst"
+distfiles="${PYPI_SITE}/z/zipp/zipp-${version}.tar.gz"
+checksum=3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76
+# Needs unpackaged "jaraco.itertools"
+make_check=no
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -244,7 +244,6 @@ replaces="
  python-sqlite<=2.8.3_1
  python-xlib<0.29_1
  python3-Django<=3.0.7_2
- python3-cloudscraper<=1.2.52_1
  python3-pyPEG2<=2.15.2_7
  python3-pyenet<=5.15.0_2
  python3-pyside<=5.15.0_2


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
#### Komikku:
 This version needs `python3-keyring` >= 21.6.0

#### python3-keyring:
update dependencies

#### python3-importlib_metadata:
This package was dropped earlier as its functionality was added into Python 3.8 standard library.
However, this package contains features that are not (yet) part of Python's standard library.
Those features are needed by `python3-keyring` package. So, re-introduce this package.

See: jaraco/keyring#499 (comment)

#### python3-zipp:
re-introduce since `python3-importlib_metadata` needs it.



#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->