### PR TITLE
perl-Crypt-CBC: update to 3.04

### DIFF
--- a/srcpkgs/perl-Crypt-CBC/template
+++ b/srcpkgs/perl-Crypt-CBC/template
@@ -1,6 +1,6 @@
 # Template file for 'perl-Crypt-CBC'
 pkgname=perl-Crypt-CBC
-version=3.01
+version=3.04
 revision=1
 wrksrc="${pkgname#perl-}-${version}"
 build_style=perl-module
@@ -12,6 +12,6 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/Crypt-CBC"
 distfiles="${CPAN_SITE}/Crypt/Crypt-CBC-${version}.tar.gz"
-checksum=de259c1c94fc1fd2731dfd276e8b05e31edfd2150848afdff09ac6ae9a03e624
+checksum=4026c57d0dbf6496c0d561a26f161b763d3b8edf351139c073492e21b5fbce07
 # check requires a lot of new cascading dependencies
 make_check=no

--- a/srcpkgs/perl-Math-Int128/template
+++ b/srcpkgs/perl-Math-Int128/template
@@ -1,0 +1,20 @@
+# Template file for 'perl-Math-Int128'
+pkgname=perl-Math-Int128
+version=0.22
+revision=1
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl"
+depends="perl perl-Math-Int64"
+checkdepends="perl-Math-Int64"
+short_desc="Add support for 128 bit integers, signed and unsigned, to Perl"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/Math-Int64"
+distfiles="${CPAN_SITE}/Math/Math-Int128-${version}.tar.gz"
+checksum=a630ca401753866955f1173848ab5b4ac4ad5ca6ad9087f11cdf91dde85119bc
+
+if [ "$XBPS_TARGET_WORDSIZE" == "32" ]; then
+	broken="not supported on 32-bit architectures"
+fi

--- a/srcpkgs/perl-Math-Int64/template
+++ b/srcpkgs/perl-Math-Int64/template
@@ -1,0 +1,15 @@
+# Template file for 'perl-Math-Int64'
+pkgname=perl-Math-Int64
+version=0.54
+revision=1
+wrksrc="${pkgname#perl-}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="perl"
+depends="perl"
+short_desc="Add support for 64 bit integers, signed and unsigned, to Perl"
+maintainer="newbluemoon <blaumolch@mailbox.org>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/Math-Int64"
+distfiles="${CPAN_SITE}/Math/Math-Int64-${version}.tar.gz"
+checksum=dcfc51e698437ea6b9cefe0276215c56cdb6a7f85e3e24a2b6b4189f1960d351


### PR DESCRIPTION
There is a change which requires the perl-Math-Int128 module when using 'ctr' (Counter Mode) as block chaining mode, because it’s much faster than the previsously used Math::BigInt (default mode is still 'cbc').

However, Math::Int128 is not available on 32-bit architectures, so this update would break such setups, though probably not many are using it, if anyone at all. But still I’m not sure how to proceed on this.

Tested on x86_64.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
