### PR TITLE
git: not use autotools (prepare for 2.32)

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -4,10 +4,6 @@ version=2.31.1
 revision=1
 bootstrap=yes
 wrksrc="git-${version}"
-build_style=gnu-configure
-configure_args="--without-curl --without-openssl
- --without-python --without-expat --without-tcltk
- ac_cv_lib_curl_curl_global_init=no ac_cv_lib_expat_XML_ParserCreate=no"
 make_check_target=test
 makedepends="zlib-devel"
 short_desc="GIT Tree History Storage Tool -- for xbps-src use"
@@ -23,17 +19,39 @@ else
 	configure_args+=" --with-zlib=${XBPS_MASTERDIR}/usr"
 fi
 
-post_configure() {
+do_configure() {
 	cat <<-EOF >config.mak
+	prefix = /usr
+	CC = $CC
+	AR = $AR
+	TAR = $(command -v bsdtar || command -v tar)
+	CFLAGS = $CFLAGS
+	LDFLAGS = $LDFLAGS
 	CC_LD_DYNPATH=-L
 	NO_INSTALL_HARDLINKS=Yes
 	NO_GETTEXT=Yes
+	NO_OPENSSL = Yes
+	USE_LIBPCRE :=
+	USE_LIBPCRE2 :=
+	NO_CURL = Yes
+	NO_EXPAT = Yes
+	NO_PERL = Yes
+	NO_PYTHON = Yes
+	NO_TCLTK = Yes
 	EOF
+
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		cat <<-EOF >>config.mak
+		ICONV_OMITS_BOM = Yes
+		NO_REGEX = Yes
+		EOF
+	fi
+}
+
+do_build() {
+	make ${makejobs} git
 }
 
 do_install() {
-	# remove unneeded stuff.
-	make DESTDIR=${wrksrc}/build-tmp install
-
-	vbin ${wrksrc}/build-tmp/usr/bin/git chroot-git
+	vbin git chroot-git
 }

--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -2,12 +2,12 @@
 pkgname=git
 version=2.31.1
 revision=1
-build_style=gnu-configure
-configure_args="--with-curl --with-expat --with-tcltk --with-libpcre2"
-hostmakedepends="asciidoc gettext perl pkg-config tar tk xmlto"
+hostmakedepends="asciidoc gettext perl pkg-config tk xmlto"
 makedepends="libglib-devel libcurl-devel libsecret-devel pcre2-devel tk-devel"
 # Required by https://
 depends="ca-certificates perl-Authen-SASL perl-MIME-tools perl-Net-SMTP-SSL"
+checkdepends="tar cvs cvsps2 perl-DBD-SQLite subversion subversion-perl
+ perl-Term-ReadKey tzdata"
 short_desc="Git Tree History Storage Tool"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="GPL-2.0-only"
@@ -21,16 +21,35 @@ python_version=3
 
 subpackages="git-cvs git-svn gitk git-gui git-all git-libsecret git-netrc"
 
-post_configure() {
+do_configure() {
 	cat <<-EOF >config.mak
+	prefix = /usr
+	CC = $CC
+	AR = $AR
+	TAR = bsdtar
+	CFLAGS = $CFLAGS
+	LDFLAGS = $LDFLAGS
+	USE_LIBPCRE2=Yes
 	NO_INSTALL_HARDLINKS=Yes
 	INSTALLDIRS=vendor
 	perllibdir=/usr/share/perl5/vendor_perl
 	PYTHON_PATH=/usr/bin/python3
+	DEFAULT_TEST_TARGET = prove
+	GIT_PROVE_OPTS = $makejobs
 	EOF
+
+	if [ "$XBPS_TARGET_LIBC" = musl ]; then
+		cat <<-EOF >>config.mak
+		ICONV_OMITS_BOM = Yes
+		NO_REGEX = Yes
+		# TZ=CST6CDT date --iso-8601=seconds -d"2005-01-31 18:00:00 -0600"
+		export GIT_SKIP_TESTS=t9604.2
+		EOF
+	fi
 }
 
-post_build() {
+do_build() {
+	make ${makejobs}
 	make ${makejobs} -C Documentation man
 	make ${makejobs} -C contrib/contacts all git-contacts.1
 	make ${makejobs} -C contrib/diff-highlight all
@@ -40,14 +59,14 @@ post_build() {
 }
 
 do_check() {
-	make ${makejobs} test
+	make test
 	make -C contrib/diff-highlight test
 	make -C contrib/subtree test
 	make -C contrib/credential/netrc test
 }
 
-post_install() {
-	make DESTDIR=${DESTDIR} install-doc
+do_install() {
+	make DESTDIR=${DESTDIR} install install-doc
 	vinstall contrib/completion/git-completion.bash 644 \
 		usr/share/bash-completion/completions git
 	vinstall contrib/completion/git-prompt.sh 644 usr/share/git

--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,6 +1,6 @@
 # Template file for 'git'
 pkgname=git
-version=2.31.1
+version=2.32.0
 revision=1
 hostmakedepends="asciidoc gettext perl pkg-config tk xmlto"
 makedepends="libglib-devel libcurl-devel libsecret-devel pcre2-devel tk-devel"
@@ -14,7 +14,7 @@ license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=9f61417a44d5b954a5012b6f34e526a3336dcf5dd720e2bb7ada92ad8b3d6680
+checksum=68a841da3c4389847ecd3301c25eb7e4a51d07edf5f0168615ad6179e3a83623
 replaces="git-perl>=0"
 register_shell=/usr/bin/git-shell
 python_version=3


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
