### PR TITLE
pipewire: update to 0.3.28

### DIFF
--- a/srcpkgs/pipewire/patches/6df32666b4.patch
+++ b/srcpkgs/pipewire/patches/6df32666b4.patch
@@ -1,0 +1,62 @@
+From 6df32666b44b5174aace3dcff39f39a58eba508f Mon Sep 17 00:00:00 2001
+From: Wim Taymans <wtaymans@redhat.com>
+Date: Thu, 20 May 2021 11:22:04 +0200
+Subject: [PATCH] filter-chain: check external ports only once
+
+When we duplicate the pipeline to match the channels, only check
+if a port was used only once for the first instance. Makes
+demonic filter work again.
+---
+ src/modules/module-filter-chain.c | 18 ++++--------------
+ 1 file changed, 4 insertions(+), 14 deletions(-)
+
+diff --git a/src/modules/module-filter-chain.c b/src/modules/module-filter-chain.c
+index b1e727069..bb346b6d8 100644
+--- src/modules/module-filter-chain.c
++++ src/modules/module-filter-chain.c
+@@ -972,16 +972,6 @@ static int parse_link(struct graph *graph, struct spa_json *json)
+ 		pw_log_error("unknown input port %s", input);
+ 		return -ENOENT;
+ 	}
+-	if (in_port->external != SPA_ID_INVALID) {
+-		pw_log_info("%s already used as graph input %d, use mixer",
+-				input, in_port->external);
+-		return -EINVAL;
+-	}
+-	if (out_port->external != SPA_ID_INVALID) {
+-		pw_log_info("%s already used as graph output %d, use copy",
+-				output, out_port->external);
+-		return -EINVAL;
+-	}
+ 	if (in_port->n_links > 0) {
+ 		pw_log_info("Can't have more than 1 link to %s, use a mixer", input);
+ 		return -ENOTSUP;
+@@ -1334,10 +1324,10 @@ static int setup_graph(struct graph *graph, struct spa_json *inputs, struct spa_
+ 				} else {
+ 					desc = port->node->desc;
+ 					d = desc->desc;
+-					if (port->external != SPA_ID_INVALID) {
++					if (i == 0 && port->external != SPA_ID_INVALID) {
+ 						pw_log_error("input port %s[%d]:%s already used as input %d, use mixer",
+ 							port->node->name, i, d->PortNames[port->p],
+-							graph->n_input);
++							port->external);
+ 						res = -EBUSY;
+ 						goto error;
+ 					}
+@@ -1382,10 +1372,10 @@ static int setup_graph(struct graph *graph, struct spa_json *inputs, struct spa_
+ 				} else {
+ 					desc = port->node->desc;
+ 					d = desc->desc;
+-					if (port->external != SPA_ID_INVALID) {
++					if (i == 0 && port->external != SPA_ID_INVALID) {
+ 						pw_log_error("output port %s[%d]:%s already used as output %d, use copy",
+ 							port->node->name, i, d->PortNames[port->p],
+-							graph->n_output);
++							port->external);
+ 						res = -EBUSY;
+ 						goto error;
+ 					}
+-- 
+GitLab
+

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.3.27
+version=0.3.28
 revision=1
 build_style=meson
 configure_args="-Dman=enabled -Dgstreamer=enabled -Ddocs=enabled -Dsystemd=disabled
@@ -18,8 +18,7 @@ license="MIT"
 homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz"
-checksum=657db1b9a29ae17a9f1d9782a45bda2ba5a893fef55e1ca26453e8f7f2d4e64e
-conf_files="/etc/pipewire/*.conf /etc/pipewire/media-session.d/*.conf"
+checksum=1d9271e121a5049aef379e9bb7c50524faa6f971e668806637d7b9df1b7cab88
 
 build_options="sdl2"
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

- The main change here is the move of default configs to `/usr/share`. `xbps` handled this well in my case (I had all default configs, which were deleted as expected). Can anyone verify that modified configs are left?
- I have briefly tried the filter-chains (`pipewire -c filter-chain/<X>.conf` runs a pipewire client that creates these "effect nodes") and they require ladspa plugins (one is not even packaged I think) but I don't think they should be hard dependencies. Also, some are borked still (e.g. `demonic.conf` ~~currently only works with a `audio.channels = 1` workaround~~ patch imported).

<details>
<summary>File diff</summary>

```
--- /tmp/old    2021-05-20 01:30:21.627554276 +0200
+++ /tmp/new    2021-05-20 01:30:37.523553285 +0200
@@ -1,14 +1,3 @@
-/etc/pipewire/client-rt.conf
-/etc/pipewire/client.conf
-/etc/pipewire/jack.conf
-/etc/pipewire/media-session.d/alsa-monitor.conf
-/etc/pipewire/media-session.d/bluez-monitor.conf
-/etc/pipewire/media-session.d/media-session.conf
-/etc/pipewire/media-session.d/v4l2-monitor.conf
-/etc/pipewire/pipewire-pulse.conf
-/etc/pipewire/pipewire.conf
-/etc/pipewire/media-session.d/with-jack
-/etc/pipewire/media-session.d/with-pulseaudio
 /usr/bin/pipewire
 /usr/bin/pipewire-media-session
 /usr/bin/pipewire-pulse
@@ -165,6 +154,22 @@
 /usr/share/man/man1/pw-mon.1
 /usr/share/man/man1/pw-profiler.1
 /usr/share/man/man5/pipewire.conf.5
+/usr/share/pipewire/client-rt.conf
+/usr/share/pipewire/client.conf
+/usr/share/pipewire/filter-chain/demonic.conf
+/usr/share/pipewire/filter-chain/sink-dolby-surround.conf
+/usr/share/pipewire/filter-chain/sink-eq6.conf
+/usr/share/pipewire/filter-chain/sink-matrix-spatialiser.conf
+/usr/share/pipewire/filter-chain/source-rnnoise.conf
+/usr/share/pipewire/jack.conf
+/usr/share/pipewire/media-session.d/alsa-monitor.conf
+/usr/share/pipewire/media-session.d/bluez-monitor.conf
+/usr/share/pipewire/media-session.d/media-session.conf
+/usr/share/pipewire/media-session.d/v4l2-monitor.conf
+/usr/share/pipewire/media-session.d/with-jack
+/usr/share/pipewire/media-session.d/with-pulseaudio
+/usr/share/pipewire/pipewire-pulse.conf
+/usr/share/pipewire/pipewire.conf
 /usr/bin/pw-midiplay -> /usr/bin/pw-cat
 /usr/bin/pw-midirecord -> /usr/bin/pw-cat
 /usr/bin/pw-play -> /usr/bin/pw-cat
```
</details>