### PR TITLE
fetchmail: remove dependency to fetchmailconf

### DIFF
--- a/srcpkgs/fetchmail/template
+++ b/srcpkgs/fetchmail/template
@@ -1,6 +1,6 @@
 # Template file for 'fetchmail'
 pkgname=fetchmail
-version=6.4.21
+version=6.4.22
 revision=1
 build_style=gnu-configure
 configure_args="--with-ssl=${XBPS_CROSS_BASE}/usr"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="http://fetchmail.sourceforge.net/"
 changelog="https://gitlab.com/fetchmail/fetchmail/-/raw/legacy_64/NEWS"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=6a459c1cafd7a1daa5cd137140da60c18c84b5699cd8e7249a79c33342c99d1d
+checksum=cc6818bd59435602169fa292d6d163d56b21c7f53112829470a3aceabe612c84
 
 post_install() {
 	vsed -i -e 's,/usr/bin/python ,/usr/bin/python3 ,' "${DESTDIR}/usr/bin/fetchmailconf"


### PR DESCRIPTION
fetchmail does not depend on fetchmailconf, drop the dependency to avoid
pulling in the python/tk and related dependencies of fetchmailconf when
the utility is not needed.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
