### PR TITLE
glibc: restore localized messages

### DIFF
--- a/srcpkgs/glibc/template
+++ b/srcpkgs/glibc/template
@@ -1,7 +1,7 @@
 # Template file for 'glibc'
 pkgname=glibc
 version=2.32
-revision=1
+revision=2
 bootstrap=yes
 short_desc="GNU C library"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -48,7 +48,7 @@ conf_files="
 	/etc/gai.conf
 	/etc/ld.so.conf"
 if [ "$CHROOT_READY" ]; then
-	hostmakedepends="bison perl python3 texinfo"
+	hostmakedepends="bison gettext perl python3 texinfo"
 fi
 makedepends="kernel-libc-headers"
 lib32files="/usr/lib/gconv/gconv-modules"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

This restores the `/usr/share/locale/*/LC_MESSAGES/libc.mo` files that went missing at some point after `glibc-locales-2.30_1`.

Before: App is localized, glibc isn't:
```
$ ls ...
ls: '...' にアクセスできません: No such file or directory
```

After:
```
$ ls ...
ls: '...' にアクセスできません: そのようなファイルやディレクトリはありません
```