### PR TITLE
bluez: support configs in service, adopt.

### DIFF
--- a/srcpkgs/bluez/INSTALL.msg
+++ b/srcpkgs/bluez/INSTALL.msg
@@ -1,1 +1,0 @@
-You need to be in the bluetooth group to be able to modify the bluetooth state!

--- a/srcpkgs/bluez/files/README.voidlinux
+++ b/srcpkgs/bluez/files/README.voidlinux
@@ -1,0 +1,2 @@
+You need to be in the bluetooth group or have elogind enabled
+to be able to modify the bluetooth state.

--- a/srcpkgs/bluez/files/bluetoothd/run
+++ b/srcpkgs/bluez/files/bluetoothd/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+[ -r ./conf ] && . ./conf
 sv check dbus >/dev/null || exit 1
 exec 2>&1
-exec /usr/libexec/bluetooth/bluetoothd -n
+exec /usr/libexec/bluetooth/bluetoothd -n ${OPTS}

--- a/srcpkgs/bluez/template
+++ b/srcpkgs/bluez/template
@@ -1,7 +1,7 @@
 # Template file for 'bluez'
 pkgname=bluez
 version=5.58
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-udevdir=/usr/lib/udev --disable-systemd
  --enable-sixaxis --enable-threads --enable-library --enable-deprecated
@@ -11,7 +11,7 @@ hostmakedepends="automake flex libtool pkg-config"
 makedepends="cups-devel eudev-libudev-devel libglib-devel libical-devel
  readline-devel ell-devel $(vopt_if mesh json-c-devel)"
 short_desc="Bluetooth tools and daemons"
-maintainer="Doan Tran Cong Danh <congdanhqx@gmail.com>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.bluez.org/"
 distfiles="${KERNEL_SITE}/bluetooth/$pkgname-$version.tar.xz"
@@ -41,6 +41,8 @@ post_install() {
 	if [ "$build_option_mesh" ]; then
 		vsv bluetooth-meshd
 	fi
+
+	vdoc ${FILESDIR}/README.voidlinux
 }
 
 libbluetooth_package() {


### PR DESCRIPTION
Passing options to bluetoothd can be necessary in some cases.

Also move INSTALL.msg to README.voidlinux, and note that elogind can be
enough, instead of requiring group membership.

@sgn you had asked me to adopt it, if that's still the case I can do it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
