### PR TITLE
ldc: update to 1.26.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2161,11 +2161,11 @@ libFcitx5Config.so.6 libfcitx5-5.0.5_1
 libFcitx5GClient.so.2 fcitx5-gtk-5.0.4_1
 libFcitx5Qt5DBusAddons.so.1 fcitx5-qt5-5.0.3_1
 libFcitx5Qt5WidgetsAddons.so.2 fcitx5-qt5-5.0.3_1
-libdruntime-ldc-debug-shared.so.94 ldc-runtime-1.24.0_1
-libdruntime-ldc-shared.so.94 ldc-runtime-1.24.0_1
-libphobos2-ldc-shared.so.94 ldc-runtime-1.24.0_1
-libphobos2-ldc-debug-shared.so.94 ldc-runtime-1.24.0_1
-libldc-jit.so.94 ldc-runtime-1.24.0_1
+libdruntime-ldc-debug-shared.so.96 ldc-runtime-1.26.0_1
+libdruntime-ldc-shared.so.96 ldc-runtime-1.26.0_1
+libphobos2-ldc-shared.so.96 ldc-runtime-1.26.0_1
+libphobos2-ldc-debug-shared.so.96 ldc-runtime-1.26.0_1
+libldc-jit.so.96 ldc-runtime-1.26.0_1
 libmarblewidget-qt5.so.28 marble5-17.12.2_1
 libastro.so.2 marble5-17.12.2_1
 libparrot.so.6.9.0 parrot-6.9.0_1

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,7 +1,7 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
 version=1.18.4
-revision=1
+revision=2
 wrksrc="gstreamer-${version}"
 build_style=meson
 build_helper="gir"
@@ -10,7 +10,7 @@ configure_args="-Dptp-helper-permissions=capabilities
  -Dintrospection=$(vopt_if gir enabled disabled)"
 hostmakedepends="gettext pkg-config flex python3 docbook-xsl glib-devel
  libcap-progs"
-makedepends="libxml2-devel libglib-devel gtk+3-devel libcap-devel libunwind-devel
+makedepends="libxml2-devel libglib-devel gtk+3-devel libcap-devel
  bash-completion"
 checkdepends="gsl-devel gmp-devel valgrind-devel"
 short_desc="Core GStreamer libraries and elements (1.x)"

--- a/srcpkgs/gtkd/template
+++ b/srcpkgs/gtkd/template
@@ -1,7 +1,7 @@
 # Template file for 'gtkd'
 pkgname=gtkd
 version=3.9.0
-revision=4
+revision=5
 wrksrc="GtkD-${version}"
 build_style=gnu-makefile
 make_build_args="LDFLAGS='-linker=bfd' DC=ldc2"

--- a/srcpkgs/ldc/template
+++ b/srcpkgs/ldc/template
@@ -1,27 +1,32 @@
 # Template file for 'ldc'
 pkgname=ldc
-version=1.24.0
-revision=2
+version=1.26.0
+revision=1
 wrksrc="ldc-${version}-src"
 build_style=cmake
 configure_args="
  -DINCLUDE_INSTALL_DIR=/usr/include/dlang/ldc
  -DBUILD_SHARED_LIBS=ON
  -DCMAKE_BUILD_TYPE=RelWithDebInfo
- -DBASH_COMPLETION_COMPLETIONSDIR=/usr/share/bash-completion"
+ -DBASH_COMPLETION_COMPLETIONSDIR=/usr/share/bash-completion
+ -DC_SYSTEM_LIBS='unwind;m;pthread;rt;dl'"
 conf_files="/etc/ldc2.conf"
-hostmakedepends="dmd llvm11 perl pkg-config"
-makedepends="libcurl-devel libffi-devel ncurses-devel zlib-devel"
-depends="ldc-runtime"
+hostmakedepends="dmd llvm12 perl pkg-config"
+makedepends="libcurl-devel libffi-devel ncurses-devel zlib-devel
+ llvm-libunwind-devel"
+depends="ldc-runtime llvm-libunwind-devel"
+checkdepends="python3 tzdata"
 short_desc="Portable D programming language compiler based on LLVM"
 maintainer="Auri <me@aurieh.me>"
 license="BSD-3-Clause, BSL-1.0"
 homepage="https://wiki.dlang.org/LDC"
 changelog="https://raw.githubusercontent.com/ldc-developers/ldc/master/CHANGELOG.md"
 distfiles="https://github.com/ldc-developers/ldc/releases/download/v${version}/ldc-${version}-src.tar.gz"
-checksum=fd9561ade916e9279bdcc166cf0e4836449c24e695ab4470297882588adbba3c
+checksum=c18f4c76869f0196b459dcd6196c7eaea1b097cc422cf3771de394f6c0ef7474
 nopie=yes
 nocross="dmd compilation fails on cross"
+# tests timeout on musl; also require unpackaged python3-lit
+make_check=no
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/onedrive/template
+++ b/srcpkgs/onedrive/template
@@ -1,7 +1,7 @@
 # Template file for 'onedrive'
 pkgname=onedrive
 version=2.4.10
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="DC=ldc2"
 hostmakedepends="ldc pkg-config"

--- a/srcpkgs/tilix/patches/llvm-unwind.patch
+++ b/srcpkgs/tilix/patches/llvm-unwind.patch
@@ -1,0 +1,30 @@
+Use find_library instead of dependency so llvm-libunwind can be used,
+since it doesn't ship a pkg-config file.
+
+diff --git a/meson.build b/meson.build
+index 448e262..1a8ebfb 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,11 +1,12 @@
+ project(
+-    'Tilix', 'd',
++    'Tilix', ['c','d'],
+     version: '1.9.4',
+     license: 'MPL-2.0',
+     meson_version: '>= 0.52'
+ )
+ 
+ compiler = meson.get_compiler('d')
++cc = meson.get_compiler('c')
+ if compiler.get_id() == 'llvm'
+   d_extra_args = ['-vcolumns']
+   d_link_args = []
+@@ -100,7 +101,7 @@ sources_dir = include_directories('source/')
+ gtkd_dep = dependency('gtkd-3', version: '>=3.8.5')
+ vted_dep = dependency('vted-3', version: '>=3.8.5')
+ xlib_dep = dependency('x11')
+-libunwind_dep = dependency('libunwind')
++libunwind_dep = cc.find_library('libunwind')
+ libsecret_dep = dependency('libsecret-1', required: false)
+ 
+ subdir('po')

--- a/srcpkgs/tilix/template
+++ b/srcpkgs/tilix/template
@@ -1,11 +1,12 @@
 # Template file for 'tilix'
 pkgname=tilix
 version=1.9.4
-revision=1
+revision=2
 build_style=meson
+configure_args="-Db_lto=false"
 hostmakedepends="automake gettext-devel gdk-pixbuf glib-devel ldc po4a pkg-config
  librsvg tar AppStream"
-makedepends="dconf-devel gtkd-devel libglib-devel libvted-devel libX11-devel libunwind-devel"
+makedepends="dconf-devel gtkd-devel libglib-devel libvted-devel libX11-devel"
 depends="gsettings-desktop-schemas vte3"
 checkdepends="$depends"
 short_desc="Tiling terminal emulator for Linux"
@@ -14,6 +15,7 @@ license="MPL-2.0"
 homepage="https://gnunn1.github.io/tilix-web/"
 distfiles="https://github.com/gnunn1/${pkgname}/archive/${version}.tar.gz"
 checksum=2a9482770391d11d5edc8351d426c700c2cc6c194a30391ef2ae25bb7095b59b
+patch_args=-Np1
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Also move to llvm12.

@q66

It ends up underlinked, because when I try building corecollector with it I get:

```
Project version: 0.3.5
Error relocating /usr/lib/libdruntime-ldc-shared.so.96: unw_init_local: symbol not found
Error relocating /usr/lib/libdruntime-ldc-shared.so.96: unw_get_proc_name: symbol not found
Error relocating /usr/lib/libdruntime-ldc-shared.so.96: unw_step: symbol not found
Error relocating /usr/lib/libdruntime-ldc-shared.so.96: unw_getcontext: symbol not found
Error relocating /usr/lib/libdruntime-ldc-shared.so.96: unw_get_proc_info: symbol not found

meson.build:1:0: ERROR: Executables created by D compiler ldc2 are not runnable.
```

But running with `LD_PRELOAD=/usr/lib/libunwind.so.1` after installing `llvm-libunwind` makes meson not complain.

Alpine seems to be doing a trick to build with `libunwind` (https://git.alpinelinux.org/aports/tree/community/ldc/APKBUILD): `-DC_SYSTEM_LIBS="unwind;m;pthread;rt;dl"`, which we can probably just appropriate.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
