### PR TITLE
mesa: update aarch64 patch

### DIFF
--- a/srcpkgs/mesa/patches/0001-radeonsi-On-Aarch64-force-persistent-buffers-to-GTT.patch
+++ b/srcpkgs/mesa/patches/0001-radeonsi-On-Aarch64-force-persistent-buffers-to-GTT.patch
@@ -28,7 +28,7 @@ index 6b58aebee2d..c9e983367a0 100644
           res->domains = RADEON_DOMAIN_GTT;
 +
 +#if defined(PIPE_ARCH_AARCH64)
-+      if (size <= 1024 * 512)
++      if (size <= 1024 * 1024)
 +         res->domains = RADEON_DOMAIN_GTT;
 +#endif
     }

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=21.0.3
-revision=3
+revision=4
 wrksrc="mesa-${version}"
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=enabled -Dgbm=enabled -Degl=enabled


### PR DESCRIPTION
On Xorg applications like Firefox, this buffer increase is
not adequate; it continues to artefact. Increase the size to
1024 * 1024.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
