### PR TITLE
[WIP] New package: onivim2-0.5.5

### DIFF
--- a/srcpkgs/onivim2/template
+++ b/srcpkgs/onivim2/template
@@ -1,0 +1,40 @@
+# Template file for 'onivim2'
+pkgname=onivim2
+version=0.5.5
+revision=1
+wrksrc="oni2-${version}"
+hostmakedepends="git nasm m4 ragel yarn curl tar"
+makedepends="libpng-devel bzip2-devel xorg-server-devel glu-devel
+ harfbuzz-devel libXext-devel fontconfig-devel libXrandr-devel libXi-devel
+ libXcursor-devel libXinerama-devel libXxf86vm-devel"
+short_desc="Native, lightweight modal code editor"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="custom:Outrun-Lans-EULA"
+homepage="https://v2.onivim.io"
+distfiles="https://github.com/onivim/oni2/archive/refs/tags/v${version}.tar.gz"
+checksum=a73112c447a6747fc407784d017270a7fd83c13e8b8be9f0ea953316ba2dc76d
+# proprietary license
+restricted=yes
+
+do_configure() {
+	yarn add esy
+	yarn add node-gyp
+	node-gyp install 14.15.4
+	yarn install-node-deps.js
+}
+
+do_build() {
+	esy install
+	esy bootstrap
+	esy build
+}
+
+do_install() {
+	# Not sure how to install yet
+	# pass as : to allow testing of build
+	:
+}
+
+post_install() {
+	vlicense Outrun-Labs-EULA-v1.1.md
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

I tried to put together a template based off of the build instructions from upstream and looking at the AUR PKGBUILD. At the moment the build fails at `node install-node-deps.js` in `do_configure`. I noticed there's no `esy` package, so I had it install in `do_configure` with `npm` from `nodejs` package to test build. Not too sure if I did licensing correctly, was no `COPYING` or `NOTICE` or `LICENSE` file or mention of it in `README.md`. So, just did `vlicense` on `ThirdPartyLicenses.txt`. Upstream build and install instructions don't seem to actually tell how to install. Only states that once it's built, can be ran by `esy run`.