### PR TITLE
tor: update to 0.4.5.8.

### DIFF
--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,7 +1,7 @@
 # Template file for 'tor'
 pkgname=tor
-version=0.4.5.6
-revision=3
+version=0.4.5.8
+revision=1
 build_style=gnu-configure
 configure_args="--enable-zstd"
 hostmakedepends="pkg-config"
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://www.torproject.org/"
 changelog="https://gitweb.torproject.org/tor.git/plain/ReleaseNotes"
 distfiles="https://dist.torproject.org/tor-${version}.tar.gz"
-checksum=22cba3794fedd5fa87afc1e512c6ce2c21bc20b4e1c6f8079d832dc1e545e733
+checksum=57ded091e8bcdcebb0013fe7ef4a4439827cb169358c7874fd05fa00d813e227
 
 conf_files="/etc/tor/torrc"
 system_accounts="tor"


### PR DESCRIPTION
Tests still fail on x86_64-musl as discussed in #29307. I applied the patches Alpine uses but this oddly enough didn't fix them either. I think we should upgrade anyway for now as 0.4.5.7 fixes security issues, see https://lists.torproject.org/pipermail/tor-announce/2021-March/000216.html

cc @daniel-eys 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
