### PR TITLE
musl: backport reallocarray.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -16,7 +16,7 @@
 # PLEASE NOTE: when multiple packages provide the same SONAME, the first
 # one (order top->bottom) is preferred over the next ones.
 #
-libc.so musl-1.1.21_1
+libc.so musl-1.1.24_7
 libc.so.6 glibc-2.32_1
 libm.so.6 glibc-2.32_1
 libpthread.so.0 glibc-2.32_1

--- a/srcpkgs/musl/patches/epoll_cp.patch
+++ b/srcpkgs/musl/patches/epoll_cp.patch
@@ -1,0 +1,28 @@
+From 2c00f95c1ac7dd50f53d9e361847ebd2513c8da0 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Sat, 3 Apr 2021 21:16:41 -0400
+Subject: [PATCH] make epoll_[p]wait a cancellation point
+
+this is a Linux-specific function and not covered by POSIX's
+requirements for which interfaces are cancellation points, but glibc
+makes it one and existing software relies on it being one.
+
+at some point a review for similar functions that should be made
+cancellation points should be done.
+
+diff --git src/linux/epoll.c src/linux/epoll.c
+index deff5b10..93baa814 100644
+--- src/linux/epoll.c
++++ src/linux/epoll.c
+@@ -24,9 +24,9 @@ int epoll_ctl(int fd, int op, int fd2, struct epoll_event *ev)
+ 
+ int epoll_pwait(int fd, struct epoll_event *ev, int cnt, int to, const sigset_t *sigs)
+ {
+-	int r = __syscall(SYS_epoll_pwait, fd, ev, cnt, to, sigs, _NSIG/8);
++	int r = __syscall_cp(SYS_epoll_pwait, fd, ev, cnt, to, sigs, _NSIG/8);
+ #ifdef SYS_epoll_wait
+-	if (r==-ENOSYS && !sigs) r = __syscall(SYS_epoll_wait, fd, ev, cnt, to);
++	if (r==-ENOSYS && !sigs) r = __syscall_cp(SYS_epoll_wait, fd, ev, cnt, to);
+ #endif
+ 	return __syscall_ret(r);
+ }

--- a/srcpkgs/musl/patches/isascii.patch
+++ b/srcpkgs/musl/patches/isascii.patch
@@ -1,0 +1,21 @@
+From e48e99c112246fb580596404074445cb25d7858d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=89rico=20Rolim?= <ericonr@disroot.org>
+Date: Mon, 4 Jan 2021 22:48:34 -0300
+Subject: [PATCH] suppress isascii() macro for C++
+
+analogous to commit a60457c84a4b59ab564d7f4abb660a70283ba98d.
+
+diff --git include/ctype.h include/ctype.h
+index 7936536f..32bcef4d 100644
+--- include/ctype.h
++++ include/ctype.h
+@@ -64,7 +64,9 @@ int   isascii(int);
+ int   toascii(int);
+ #define _tolower(a) ((a)|0x20)
+ #define _toupper(a) ((a)&0x5f)
++#ifndef __cplusplus
+ #define isascii(a) (0 ? isascii(a) : (unsigned)(a) < 128)
++#endif
+ 
+ #endif
+ 

--- a/srcpkgs/musl/patches/reallocarray.patch
+++ b/srcpkgs/musl/patches/reallocarray.patch
@@ -1,0 +1,42 @@
+From 821083ac7b54eaa040d5a8ddc67c6206a175e0ca Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Sat, 1 Aug 2020 08:26:35 -0600
+Subject: [PATCH] implement reallocarray
+
+reallocarray is an extension introduced by OpenBSD, which introduces
+calloc overflow checking to realloc.
+
+glibc 2.28 introduced support for this function behind _GNU_SOURCE,
+while glibc 2.29 allows its usage in _DEFAULT_SOURCE.
+
+diff --git a/include/stdlib.h b/include/stdlib.h
+index 194c2033..b54a051f 100644
+--- include/stdlib.h
++++ include/stdlib.h
+@@ -145,6 +145,7 @@ int getloadavg(double *, int);
+ int clearenv(void);
+ #define WCOREDUMP(s) ((s) & 0x80)
+ #define WIFCONTINUED(s) ((s) == 0xffff)
++void *reallocarray (void *, size_t, size_t);
+ #endif
+ 
+ #ifdef _GNU_SOURCE
+diff --git a/src/malloc/reallocarray.c b/src/malloc/reallocarray.c
+new file mode 100644
+index 00000000..4a6ebe46
+--- /dev/null
++++ src/malloc/reallocarray.c
+@@ -0,0 +1,13 @@
++#define _BSD_SOURCE
++#include <errno.h>
++#include <stdlib.h>
++
++void *reallocarray(void *ptr, size_t m, size_t n)
++{
++	if (n && m > -1 / n) {
++		errno = ENOMEM;
++		return 0;
++	}
++
++	return realloc(ptr, m * n);
++}

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=6
+revision=7
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
It's in POSIX-future and some applications have started depending on it.
It's easier to backport into musl than fix each individual package.

Since we are adding a new interface to libc, update common/shlibs entry
as well. This should probably have been done for all musl updates.

@q66 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
