### PR TITLE
[RFC] linux-firmware: pull from commit hash instead of tag

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,14 +1,16 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
-version=20210511
+version=20210518
 revision=1
+_commit=f8462923ed8fc874f770b8c6dfad49d39b381f14
+wrksrc="${pkgname}-${_commit}"
 depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="See /usr/share/licenses/${pkgname}"
 homepage="https://www.kernel.org/"
-distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=4c38e6a15775e2911e60898804f1d5720f8e3992a79487a5c1b2250df49a11c4
+distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${pkgname}-${_commit}.tar.gz"
+checksum=d88e207528b49e7ddc75cd370f8b7733f0e62ef586bb0d8b8778264fd60837a0
 python_version=3
 nostrip=yes
 


### PR DESCRIPTION
This would enable faster support for new hardware, and avoid waiting for (possibly) two months just for `linux-firmware` to tag.

One can ask for hardware support with firmware not tagged yet but present in master, and we can update the commit hash along with the date of the commit to pull in that new firmware.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
