### PR TITLE
iptables: adjust run scripts for more configuration flexibility

### DIFF
--- a/srcpkgs/iptables/files/ip6tables/run
+++ b/srcpkgs/iptables/files/ip6tables/run
@@ -1,4 +1,10 @@
 #!/bin/sh
-[ ! -e /etc/iptables/ip6tables.rules ] && exit 0
-ip6tables-restore -w 3 /etc/iptables/ip6tables.rules || exit 1
+seen=0
+for rule in /etc/iptables/ip6tables.rules /etc/ip6tables.d/*.rules \
+    /etc/ip6tables.d/*.6rules ; do
+    [ ! -f "$rule" ] && continue
+    ip6tables-restore -nw 3 "$rule" || exit 1
+    seen=$((seen+1))
+done
+[ $seen -eq 0 ] && exit 2
 exec chpst -b ip6tables pause

--- a/srcpkgs/iptables/files/iptables-flush.scripts
+++ b/srcpkgs/iptables/files/iptables-flush.scripts
@@ -2,13 +2,10 @@
 # Usage: iptables-flush [-6]
 
 iptables=/usr/bin/iptables
-tables="filter mangle raw"
+tables="filter mangle nat raw"
 
 if [ "$1" = "-6" ]; then
   iptables=/usr/bin/ip6tables
-else
-  # Only ipv4 has a nat table
-  tables="$tables nat"
 fi
 
 for table in ${tables}; do

--- a/srcpkgs/iptables/files/iptables/run
+++ b/srcpkgs/iptables/files/iptables/run
@@ -1,4 +1,9 @@
 #!/bin/sh
-[ ! -e /etc/iptables/iptables.rules ] && exit 0
-iptables-restore -w 3 /etc/iptables/iptables.rules || exit 1
+seen=0
+for rule in /etc/iptables/iptables.rules /etc/iptables.d/*.rules ; do
+    [ ! -f "$rule" ] && continue
+    iptables-restore -nw 3 "$rule" || exit 1
+    seen=$((seen+1))
+done
+[ $seen -eq 0 ] && exit 2
 exec chpst -b iptables pause

--- a/srcpkgs/iptables/template
+++ b/srcpkgs/iptables/template
@@ -1,7 +1,7 @@
 # Template file for 'iptables'
 pkgname=iptables
 version=1.8.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-libipq --enable-shared --enable-devel --enable-bpf-compiler"
 hostmakedepends="pkg-config flex"


### PR DESCRIPTION
The single configuration file approach that the iptables services
provide precludes using it in more complicated buildouts such as ones
defined with config management tools. This change takes a hybrid
approach of the old method (to preserve backwards compatibility, etc)
and the method taken with void-ansible-roles/network.

Changes:
No longer flush tables prior to loading new data - rely on finish in all
  cases
Load data from /etc/iptables/iptables.rules and all found
  /etc/iptables.d/\*.rules
Ditto ip6 equivalents (ip6rules.rules, ip6tables.d/\*.{,6}rules)
Flush nat table in both v4 and v6 mode (nat table supported on v6 since
  kernel 3.7)

Caveats: the ip6tables.d match is overly explicit since dash does not
provide brace expansion and there is no particularly clean way to match
a single character or empty when expanding globs.

@ailiop-git 
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

