### PR TITLE
updated package python3-gmpy2 to version 2.1

### DIFF
--- a/srcpkgs/python3-gmpy2/template
+++ b/srcpkgs/python3-gmpy2/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-gmpy2'
 pkgname=python3-gmpy2
-version=2.0.8
-revision=8
+version=2.1.0b5
+revision=1
 wrksrc="gmpy2-${version}"
 build_style=python3-module
 hostmakedepends="unzip python3-setuptools
@@ -9,7 +9,7 @@ gmp-devel mpfr-devel libmpc-devel"
 makedepends="python3-devel gmp-devel mpfr-devel libmpc-devel"
 short_desc="Python3 interface to GMP, MPFR and MPC libraries"
 maintainer="Orphaned <orphan@voidlinux.org>"
-homepage="https://github.com/aleaxit/gmpy"
 license="LGPL-3.0-or-later"
-distfiles="${PYPI_SITE}/g/gmpy2/gmpy2-${version}.zip"
-checksum=dd233e3288b90f21b0bb384bcc7a7e73557bb112ccf0032ad52aa614eb373d3f
+homepage="https://github.com/aleaxit/gmpy"
+distfiles="${PYPI_SITE}/g/gmpy2/gmpy2-${version}.tar.gz"
+checksum=8951bcfc61c0f40102b92a4777daf9eb85445b537c4d09086deb0e097190bef0


### PR DESCRIPTION
This package was orphaned and its version is now deprecated. I updated it to the latest version on github.
Have the results of the proposed changes been tested?

- [ x ] I generally don't use the affected packages but briefly tested this PR

Does it build and run successfully? Yes

(Please choose at least one native build and, if supported, at least one cross build. More are better.)

- [ x ] I built this PR locally for my native architecture, (x86_64-glibc)
