### PR TITLE
xdm: enable xft support

### DIFF
--- a/srcpkgs/xdm/template
+++ b/srcpkgs/xdm/template
@@ -1,20 +1,21 @@
 # Template file for 'xdm'
 pkgname=xdm
 version=1.1.12
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--with-random-device=/dev/urandom
  --with-utmp-file=/var/run/utmp
  --with-wtmp-file=/var/log/wtmp
  --with-xdmconfigdir=/etc/X11/xdm
- --with-pam"
+ --with-pam
+ --with-xft"
 conf_files="/etc/pam.d/xdm
  /etc/X11/xdm/Xaccess
  /etc/X11/xdm/xdm-config
  /etc/X11/xdm/Xresources
  /etc/X11/xdm/Xservers"
 hostmakedepends="pkg-config"
-makedepends="pam-devel libXaw-devel"
+makedepends="pam-devel libXaw-devel libXft-devel"
 depends="sessreg xconsole xsm"
 short_desc="X Display Manager"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
Enable Xft support to allow using more fonts with the xlogin widget.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
