### PR TITLE
Telepathy-qt5 - update to 0.9.8

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2248,7 +2248,7 @@ libqt5keychain.so.1 qtkeychain-qt5-0.7.0_1
 libphonon4qt5.so.4 phonon-qt5-4.8.3_1
 libphonon4qt5experimental.so.4 phonon-qt5-4.8.3_1
 libtelepathy-qt5.so.0 telepathy-qt5-0.9.5_1
-libtelepathy-qt5-service.so.0 telepathy-qt5-0.9.7_1
+libtelepathy-qt5-service.so.1 telepathy-qt5-0.9.8_1
 libtelepathy-qt5-farstream.so.0 telepathy-qt5-farstream-0.9.5_1
 libKF5Attica.so.5 attica-5.6.0_1
 libechonest5.so.2.3 libechonest-qt5-2.3.0_1

--- a/srcpkgs/choqok/template
+++ b/srcpkgs/choqok/template
@@ -1,7 +1,7 @@
 # Template file for 'choqok'
 pkgname=choqok
 version=1.7.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext pkg-config"
 makedepends="kcmutils-devel kdewebkit-devel kemoticons-devel knotifyconfig-devel

--- a/srcpkgs/telepathy-qt5/template
+++ b/srcpkgs/telepathy-qt5/template
@@ -1,6 +1,6 @@
 # Template file for 'telepathy-qt5'
 pkgname=telepathy-qt5
-version=0.9.7
+version=0.9.8
 revision=1
 wrksrc=${pkgname//5/}-${version}
 build_style=cmake
@@ -13,10 +13,10 @@ hostmakedepends="python pkg-config"
 makedepends="qt5-devel telepathy-farstream-devel telepathy-glib-devel gstreamer1-devel"
 short_desc="Qt5 bindings for the Telepathy D-Bus protocol"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="LGPL-2.1"
-homepage="http://telepathy.freedesktop.org/"
-distfiles="http://telepathy.freedesktop.org/releases/${pkgname//5/}/${pkgname//5/}-${version}.tar.gz"
-checksum=21bad30be7ebc4ba667d53d92cd1cec1be23114103f2149404d9740721693d4f
+license="LGPL-2.1-or-later"
+homepage="https://telepathy.freedesktop.org/"
+distfiles="https://telepathy.freedesktop.org/releases/${pkgname//5/}/${pkgname//5/}-${version}.tar.gz"
+checksum=bf8e2a09060addb80475a4938105b9b41d9e6837999b7a00e5351783857e18ad
 
 if [ -n "$CROSS_BUILD" ]; then
 	hostmakedepends+=" qt5-host-tools qt5-devel"
@@ -34,7 +34,7 @@ subpackages="telepathy-qt5-farstream telepathy-qt5-devel"
 post_extract() {
 	if [ -n "$CROSS_BUILD" ]; then
 		# cmake/FindPythonLibrary.cmake fails when cross compiling
-		sed -i CMakeLists.txt -e "/find_package(PythonLibrary ${REQUIRED_PY} REQUIRED)/d"
+		vsed -i CMakeLists.txt -e "/find_package(PythonLibrary ${REQUIRED_PY} REQUIRED)/d"
 	fi
 }
 


### PR DESCRIPTION
Includes a revbump for choqok to pick up a new shlib

I was unable to get a proper crossbuild of choqok but I think that's an issue on my side.

@Duncaen 
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

