### PR TITLE
qt6-base: fix QMAKE_LIBS_LIBATOMIC for armv6 

### DIFF
--- a/srcpkgs/qt6-base/patches/libatomic.patch
+++ b/srcpkgs/qt6-base/patches/libatomic.patch
@@ -1,0 +1,14 @@
+Index: cmake/FindWrapAtomic.cmake
+===================================================================
+--- cmake/FindWrapAtomic.cmake.orig
++++ cmake/FindWrapAtomic.cmake
+@@ -38,7 +38,8 @@ endif()
+ 
+ add_library(WrapAtomic::WrapAtomic INTERFACE IMPORTED)
+ if(HAVE_STDATOMIC_WITH_LIB)
+-    target_link_libraries(WrapAtomic::WrapAtomic INTERFACE atomic)
++    find_library(LIBATOMIC atomic REQUIRED)
++    target_link_libraries(WrapAtomic::WrapAtomic INTERFACE ${LIBATOMIC})
+ endif()
+ 
+ set(WrapAtomic_FOUND 1)

--- a/srcpkgs/qt6-base/template
+++ b/srcpkgs/qt6-base/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6-base'
 pkgname=qt6-base
 version=6.1.0
-revision=1
+revision=2
 wrksrc="qtbase-everywhere-src-${version}"
 build_style=cmake
 configure_args="-DINSTALL_DATADIR=share/qt6
@@ -25,7 +25,7 @@ makedepends="zlib-devel libzstd-devel dbus-devel
  sqlite-devel Vulkan-Headers mit-krb5-devel vulkan-loader"
 short_desc="Cross-platform application and UI framework (QT6)"
 maintainer="John <me@johnnynator.dev>"
-license="GPL-3.0-only with Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
+license="GPL-3.0-only WITH Qt-GPL-exception-1.0, LGPL-3.0-only, GPL-2.0-or-later"
 homepage="https://www.qt.io"
 distfiles="https://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtbase-everywhere-src-${version}.tar.xz"
 checksum=f7af3c87e96051d09b5abce6c88277c33031bef241ebfe1db4106d33ed0814c4


### PR DESCRIPTION
Required for #31092 

Re-building all packages depends on qt6-base to check, now.