### PR TITLE
CI: move lint-commits up in action list

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,6 @@ jobs:
       - run: common/travis/fetch-xbps.sh
       - run: common/travis/fetch-xtools.sh
       - run: common/travis/xlint.sh
-      # GitHub Action create a merge commit, ignore it
-      - run: common/scripts/lint-commits FETCH_HEAD HEAD^2
 
   # Build changed packages.
   build:

--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -8,7 +8,9 @@ elif command -v git >/dev/null 2>&1; then
 	GIT_CMD=$(command -v git)
 fi
 
-printf '%s ' "$(git merge-base FETCH_HEAD HEAD)" HEAD  > /tmp/revisions
+printf '%s %s\n' \
+	"$(git merge-base FETCH_HEAD HEAD^2)" \
+	"$(git rev-parse --verify HEAD^2)" > /tmp/revisions
 
 /bin/echo -e '\x1b[32mChanged packages:\x1b[0m'
 $GIT_CMD diff-tree -r --no-renames --name-only --diff-filter=AM \

--- a/common/travis/xlint.sh
+++ b/common/travis/xlint.sh
@@ -6,6 +6,9 @@
 
 EXITCODE=0
 read base tip < /tmp/revisions
+
+common/scripts/lint-commits $base $tip || EXITCODE=$?
+
 for t in $(awk '{ print "srcpkgs/" $0 "/template" }' /tmp/templates); do
 	/bin/echo -e "\x1b[32mLinting $t...\x1b[0m"
 	xlint "$t" || EXITCODE=$?


### PR DESCRIPTION
* CI will stop whenever a step is failing.
* We always want to enforce commit message lint
* `xlint` is reporting some false positive for license with " WITH "

Let's move the lint-commits step up.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
