### PR TITLE
xbps-src: abort bootstrap when tests are enabled

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -712,6 +712,10 @@ case "$XBPS_TARGET" in
         install_base_chroot ${XBPS_TARGET_PKG:=$XBPS_MACHINE}
         ;;
     bootstrap)
+        if [ -n "$XBPS_CHECK_PKGS" ]; then
+            msg_error "xbps-src: disable tests for bootstrap\n"
+            exit 1
+        fi
         # base-chroot building on host
         # check for required host utils
         check_reqhost_utils bootstrap


### PR DESCRIPTION
Tests pull in dependencies that are not marked as bootstrap for some packages, so if the packages have to be built, bootstrap fails.