### PR TITLE
postfix: add build options

### DIFF
--- a/srcpkgs/postfix/template
+++ b/srcpkgs/postfix/template
@@ -1,16 +1,30 @@
 # Template file for 'postfix'
 pkgname=postfix
 version=3.6.1
-revision=1
+revision=2
 hostmakedepends="perl m4"
-makedepends="icu-devel libldap-devel libmariadbclient-devel pcre-devel
- postgresql-libs-devel sqlite-devel"
+makedepends="icu-devel openssl-devel
+ $(vopt_if bdb db-devel)
+ $(vopt_if ldap libldap-devel)
+ $(vopt_if mysql libmariadbclient-devel)
+ $(vopt_if pcre pcre-devel)
+ $(vopt_if pgsql postgresql-libs-devel)
+ $(vopt_if sasl libsasl-devel)
+ $(vopt_if sqlite sqlite-devel)"
 short_desc="High-performance mail transport agent"
 maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="IPL-1.0, EPL-2.0"
 homepage="http://www.postfix.org/"
 distfiles="http://ftp.porcupine.org/mirrors/postfix-release/official/${pkgname}-${version}.tar.gz"
 checksum=20a805625601e7b95989220832c8fa14ce374f0711da054188f8cec6a92fd71c
+
+build_options="bdb ldap mysql pcre pgsql sasl sqlite"
+build_options_default="ldap mysql pcre pgsql sasl sqlite"
+desc_option_bdb="Enable support for BerkeleyDB"
+desc_option_pcre="Enable support for pcre"
+desc_option_pgsql="Enable support for postgresql"
+desc_option_mysql="Enable support for mysql"
+desc_option_sqlite="Enable support for sqlite"
 
 system_accounts="postfix"
 postfix_homedir="/var/spool/postfix"
@@ -57,27 +71,30 @@ do_build() {
 		-i makedefs
 
 	make makefiles CCARGS=" \
-		-DUSE_SASL_AUTH -DUSE_CYRUS_SASL -I${XBPS_CROSS_BASE}/usr/include/sasl \
+		$(vopt_if bdb '' -DNO_DB) \
+		$(vopt_if ldap -DHAS_LDAP) \
+		$(vopt_if mysql '-DHAS_MYSQL -I${XBPS_CROSS_BASE}/usr/include/mysql') \
+		$(vopt_if pgsql '-DHAS_PGSQL -I${XBPS_CROSS_BASE}/usr/include/postgresql') \
+		$(vopt_if sasl '-DUSE_SASL_AUTH -DUSE_CYRUS_SASL -I${XBPS_CROSS_BASE}/usr/include/sasl') \
+		$(vopt_if sqlite -DHAS_SQLITE) \
 		-DNO_NIS \
-		-DHAS_LDAP \
 		-DUSE_TLS \
 		-DHAS_EAI -I${XBPS_CROSS_BASE}/usr/include \
-		-DHAS_MYSQL -I${XBPS_CROSS_BASE}/usr/include/mysql \
-		-DHAS_PGSQL -I${XBPS_CROSS_BASE}/usr/include/postgresql \
-		-DHAS_SQLITE \
 		-DDEF_COMMAND_DIR=\\\"/usr/bin\\\" \
 		-DDEF_SENDMAIL_PATH=\\\"/usr/bin/sendmail\\\" \
 		-DDEF_README_DIR=\\\"/usr/share/doc/postfix\\\" \
 		-DDEF_MANPAGE_DIR=\\\"/usr/share/man\\\" \
-	" AUXLIBS=' \
-		-lsasl2 \
-		-lldap -llber \
+	" AUXLIBS=" \
+		$(vopt_if ldap '-lldap -llber') \
+		$(vopt_if mysql -lmysqlclient) \
+		$(vopt_if pgsql -lpq) \
+		$(vopt_if sasl -lsasl2) \
+		$(vopt_if sqlite -lsqlite3) \
 		-lssl -lcrypto \
-		-lmysqlclient -lz -lm \
-		-lpq \
-		-lsqlite3 -lpthread \
+		-lm \
+		-lpthread \
 		-licuuc \
-	' OPT="${CFLAGS} ${LDFLAGS}"
+	" OPT="${CFLAGS} ${LDFLAGS}"
 
 	make ${makejobs}
 }


### PR DESCRIPTION
Enable build to be more modular by making most of the dependencies
optional. Specifically, mysql, pgsql, sqlite, ldap, sasl and pcre are
not strictly required and are all optional dependencies.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
