### PR TITLE
New package: ydotool-0.2.0

### DIFF
--- a/srcpkgs/ydotool/files/80-uinput.rules
+++ b/srcpkgs/ydotool/files/80-uinput.rules
@@ -1,0 +1,3 @@
+## ydotoold fix
+## https://github.com/ReimuNotMoe/ydotool/issues/25#issuecomment-535842993
+KERNEL=="uinput", GROUP="input", MODE="0660", OPTIONS+="static_node=uinput"

--- a/srcpkgs/ydotool/files/iodash-musl.patch
+++ b/srcpkgs/ydotool/files/iodash-musl.patch
@@ -1,0 +1,24 @@
+upstream PR: https://github.com/YukiWorkshop/IODash/pull/3
+
+--- build/_deps/iodash-src/IODash/Serial.hpp
++++ build/_deps/iodash-src/IODash/Serial.hpp
+@@ -16,6 +16,7 @@
+ #include <system_error>
+ #include <unordered_map>
+ 
++#include <asm/ioctls.h>
+ #include <sys/ioctl.h>
+ 
+ #ifdef __linux__
+
+--- build/_deps/iodash-src/IODash/SocketAddress.hpp
++++ build/_deps/iodash-src/IODash/SocketAddress.hpp
+@@ -18,6 +18,7 @@
+ #include <vector>
+ 
+ #include <cinttypes>
++#include <cstring>
+ 
+ #include <sys/types.h>
+ #include <sys/socket.h>
+

--- a/srcpkgs/ydotool/files/ydotoold/run
+++ b/srcpkgs/ydotool/files/ydotoold/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec chpst -u _ydotoold:input ydotoold --socket-perm 660 2>&1

--- a/srcpkgs/ydotool/template
+++ b/srcpkgs/ydotool/template
@@ -1,0 +1,39 @@
+# Template file for 'ydotool'
+pkgname=ydotool
+version=0.2.0
+revision=1
+build_style=cmake
+hostmakedepends="git scdoc"
+short_desc="Generic command-line automation tool, works on Wayland and X11"
+maintainer="noarchwastaken <noarch@n0ar.ch>"
+license="AGPL-3.0-or-later"
+homepage="https://github.com/ReimuNotMoe/ydotool"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=2311b003d2ff383f3348f17101f0df74f56616d530d66d0a014a52ba85a5dcf1
+
+system_accounts="_ydotoold"
+_ydotoold_groups="input"
+
+# patches a dependency pulled by CPM, so it must be done after configure
+post_configure() {
+	patch -sl -Np0 -i ${FILESDIR}/iodash-musl.patch 2>/dev/null
+}
+
+do_install() {
+	vbin build/ydotool
+	vbin build/ydotoold
+}
+
+post_install() {
+	vsv ydotoold
+
+	vinstall ${FILESDIR}/80-uinput.rules 644 usr/lib/udev/rules.d
+
+	scdoc < manpage/ydotool.1.scd > ydotool.1
+	scdoc < manpage/ydotoold.8.scd > ydotoold.8
+
+	vman ydotool.1
+	vman ydotoold.8
+
+	vlicense LICENSE
+}


### PR DESCRIPTION
It seems like the package uses CPM in its CMake config for statically linking `libevdevPlus` and `libuInputPlus`, both are versioned newer than the existing ones in Void, with breaking changes. There's another dependency called `IODash` which doesn't exist in Void yet.

Is it OK to simply use CPM? Or should we update the first two and add the last one into Void, then build with those? Pinging @steinex for opinions.

We already have #25341, but it's an older version and apparently have some unfixed problems... So I wish this is a friendly takeover of that PR.

closes #31163

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
