### PR TITLE
eid-mw: update to 5.0.22

### DIFF
--- a/srcpkgs/eid-mw/patches/0001-fix-unknown-type-int8_t-errors-when-compiling-for-aa.patch
+++ b/srcpkgs/eid-mw/patches/0001-fix-unknown-type-int8_t-errors-when-compiling-for-aa.patch
@@ -1,0 +1,58 @@
+From 0da930d0d2bf7c3f840cbcdf8d2eb3a411868fae Mon Sep 17 00:00:00 2001
+From: PoroCYon <porocyon@titandemo.org>
+Date: Wed, 2 Jun 2021 13:57:00 +0200
+Subject: [PATCH] fix 'unknown type int8_t' errors when compiling for
+ aarch64-musl
+
+---
+ plugins_tools/eid-viewer/test/testlib.c | 4 ++--
+ tests/unit/testlib.c                    | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git plugins_tools/eid-viewer/test/testlib.c plugins_tools/eid-viewer/test/testlib.c
+index 91b381a8..c1794229 100644
+--- plugins_tools/eid-viewer/test/testlib.c
++++ plugins_tools/eid-viewer/test/testlib.c
+@@ -23,8 +23,6 @@
+ #pragma pack(push, cryptoki, 1)
+ #include "pkcs11.h"
+ #pragma pack(pop, cryptoki)
+-#include <stdio.h>
+-#include <stdint.h>
+ #include <tchar.h>
+ #else
+ #include <unix.h>
+@@ -38,6 +36,8 @@
+ #include <stdarg.h>
+ #include <stdbool.h>
+ #include <errno.h>
++#include <stdio.h>
++#include <stdint.h>
+ 
+ 
+ #include "serial_io.h"
+diff --git tests/unit/testlib.c tests/unit/testlib.c
+index 32c77a73..0c1b0fe2 100644
+--- tests/unit/testlib.c
++++ tests/unit/testlib.c
+@@ -23,8 +23,6 @@
+ #pragma pack(push, cryptoki, 1)
+ #include "pkcs11.h"
+ #pragma pack(pop, cryptoki)
+-#include <stdio.h>
+-#include <stdint.h>
+ #include <tchar.h>
+ #else
+ #include <unix.h>
+@@ -37,6 +35,8 @@
+ #include <stdarg.h>
+ #include <stdbool.h>
+ #include <errno.h>
++#include <stdio.h>
++#include <stdint.h>
+ 
+ #include "testlib.h"
+ 
+-- 
+2.31.1
+

--- a/srcpkgs/eid-mw/template
+++ b/srcpkgs/eid-mw/template
@@ -1,18 +1,23 @@
 # Template file for 'eid-mw'
 pkgname=eid-mw
-version=4.4.16
-revision=4
+version=5.0.22
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config automake gettext gettext-devel libtool glib-devel
- gdk-pixbuf-devel"
-makedepends="gtk+3-devel libcurl-devel openssl-devel libproxy-devel pcsclite-devel"
+ gdk-pixbuf-devel libassuan-devel autoconf-archive"
+makedepends="gtk+3-devel libcurl-devel openssl-devel libproxy-devel
+ pcsclite-devel libassuan-devel"
 depends="pcsc-acsccid pcsc-ccid pcsc-tools"
 short_desc="Middleware for Belgian eID"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="LGPL-3.0-or-later"
 homepage="https://eid.belgium.be/en"
 distfiles="https://github.com/Fedict/eid-mw/archive/v${version}.tar.gz"
-checksum=bed50b2d3161767ef73cb23d5ce63d5039eebfcc7ae3a6045a22dd3ee07b0357
+checksum=c4ed06a4146de95b10de5056b9c174a85cd71c7a794f2f0faf010d51c8792a59
+
+if [ "$XBPS_TARGET_LIBC" = "glibc" ]; then
+	makedepends+=" libbsd-devel"
+fi
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
* new `libassuan-devel` needed (unless we want to use `pinentry` instead?)
  * for cross-compiling, it's needed both as a host and as a target dependency, because the autoconf stuff needs the macros for generating `./configure` from `configure.ac`... this is not ideal, but it's how I got it to work.
* `libbsd` now needed for `strlcpy`
* `autoconf-archive` [now needed as well](https://github.com/Fedict/eid-mw#code-from-git-repository)
* [patch file needed for this issue](https://github.com/Fedict/eid-mw/pull/142/files), should be removed once that's in a new release

-------

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
