### PR TITLE
nnn: update to 4.1

### DIFF
--- a/srcpkgs/nnn/template
+++ b/srcpkgs/nnn/template
@@ -1,7 +1,7 @@
 # Template file for 'nnn'
 pkgname=nnn
-version=4.0
-revision=2
+version=4.1.1
+revision=1
 build_style=gnu-makefile
 make_install_target="install install-desktop"
 hostmakedepends="pkg-config"
@@ -12,7 +12,17 @@ license="BSD-2-Clause"
 homepage="https://github.com/jarun/nnn"
 changelog="https://raw.githubusercontent.com/jarun/nnn/master/CHANGELOG"
 distfiles="https://github.com/jarun/nnn/archive/v${version}.tar.gz"
-checksum=a219ec8fad3dd0512aadae5840176f3265188c4c22da3b17b133bac602b40754
+checksum=f0e02668da6324c12c39db35fe5c26bd45f3e02e5684a351b8ce8a357419ceba
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	makedepends+=" musl-fts-devel"
+fi
+
+pre_build() {
+	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+		export LDLIBS=-lfts
+	fi
+}
 
 post_install() {
 	vinstall misc/auto-completion/bash/nnn-completion.bash 644 \


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

`nnn` now uses fts for disk usage calculation.
They also introduce patching system, and I'm hesitating to include the official git status patch (all we need to do is addding 1 build flag, and `libgit2-devel` to hostmakedepends).
I can compile with `x86_64-linux-musl-gcc` on my system (x86_64-musl), using `cc` fails build. I don't know how to do this nicely in the template.
