### PR TITLE
python3-certifi: update to 2021.05.30.

### DIFF
--- a/srcpkgs/python3-certifi/template
+++ b/srcpkgs/python3-certifi/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-certifi'
 pkgname=python3-certifi
-version=2020.12.05
+version=2021.05.30
 revision=1
 wrksrc="python-certifi-${version}"
 build_style=python3-module
@@ -10,7 +10,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="MPL-2.0"
 homepage="https://certifi.io"
 distfiles="https://github.com/certifi/python-certifi/archive/${version}.tar.gz"
-checksum=2434d33b445587b2f767fc56390589809b799fb218b5fb97697ed93989953adf
+checksum=9bffc4826ac0308591e26852a0404548a9e4e30b7214ebfd86360cd214f51dda
 
 do_check() {
 	cd build/lib


### PR DESCRIPTION

- [x] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 

- [x] I built this PR locally for my native architecture, (x64-glibc)

