### PR TITLE
openjpeg: fix template

### DIFF
--- a/srcpkgs/openjpeg/template
+++ b/srcpkgs/openjpeg/template
@@ -3,7 +3,6 @@ pkgname=openjpeg
 version=1.5.2
 revision=2
 build_style=cmake
-configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="libpng-devel lcms2-devel tiff-devel doxygen"
 short_desc="Open-source JPEG 2000 codec written in C language"


### PR DESCRIPTION
Fixes:
```console
$ ./xbps-src pkg openjpeg
…
=> openjpeg-1.5.2_2: running do_configure ...
CMake Error: Unknown argument --disable-static
CMake Error: Run 'cmake --help' for all supported options.

```

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, x86_64-musl
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
  - [x] ppc-musl
