### PR TITLE
kdeconnect: add qt5-quickcontrols to depends

### DIFF
--- a/srcpkgs/kdeconnect/template
+++ b/srcpkgs/kdeconnect/template
@@ -1,7 +1,7 @@
 # Template file for 'kdeconnect'
 pkgname=kdeconnect
 version=21.04.1
-revision=1
+revision=2
 wrksrc="kdeconnect-kde-${version}"
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-host-tools pkg-config
@@ -9,7 +9,7 @@ hostmakedepends="extra-cmake-modules qt5-host-tools pkg-config
 makedepends="kcmutils-devel qca-qt5-devel frameworkintegration-devel
  qt5-declarative-devel libfakekey-devel kwayland-devel
  qt5-multimedia-devel kpeoplevcard-devel kirigami2-devel pulseaudio-qt-devel"
-depends="kde-cli-tools qca-qt5-ossl fuse-sshfs kirigami2"
+depends="kde-cli-tools qca-qt5-ossl fuse-sshfs kirigami2 qt5-quickcontrols"
 short_desc="Multi-platform app that allows your devices to communicate"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Fixes #31302

I did it for you, @Cnoob41. Is this ok?
