### PR TITLE
go: update to 1.16.5

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.16.4
+version=1.16.5
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="http://golang.org/"
 changelog="https://golang.org/doc/devel/release.html"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=ae4f6b6e2a1677d31817984655a762074b5356da50fb58722b99104870d43503
+checksum=7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
Minor version update, literally works in-place exactly as you'd expect.
