### PR TITLE
ulogd: enable pcap output as a build option

### DIFF
--- a/srcpkgs/ulogd/template
+++ b/srcpkgs/ulogd/template
@@ -1,18 +1,18 @@
 # Template file for 'ulogd'
 pkgname=ulogd
 version=2.0.7
-revision=1
+revision=2
 build_style=gnu-configure
-maintainer="Cameron Nemo <cnemo@tutanota.com>"
+configure_args="--sbindir=/usr/bin"
 hostmakedepends="pkg-config automake"
 makedepends="libnfnetlink-devel libmnl-devel libnetfilter_log-devel
- libnetfilter_conntrack-devel libnetfilter_acct-devel"
+ libnetfilter_conntrack-devel libnetfilter_acct-devel libpcap-devel"
+short_desc="Userspace logging daemon for netfilter/iptables related logging"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-only"
 homepage="http://www.netfilter.org/projects/ulogd/"
-short_desc="A userspace logging daemon for netfilter/iptables related logging"
 distfiles="${homepage}/files/${pkgname}-${version}.tar.bz2"
 checksum=990a05494d9c16029ba0a83f3b7294fc05c756546b8d60d1c1572dc25249a92b
-configure_args="--sbindir=/usr/bin"
 CFLAGS="-D_GNU_SOURCE"
 system_accounts="_ulogd"
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
