### PR TITLE
nyxt: fix dependencies

### DIFF
--- a/srcpkgs/nyxt/template
+++ b/srcpkgs/nyxt/template
@@ -1,13 +1,13 @@
 # Template file for 'nyxt'
 pkgname=nyxt
 version=2.0.0
-revision=1
+revision=2
 wrksrc=nyxt
 build_style=gnu-makefile
 make_build_target=all
-hostmakedepends="sbcl curl pkg-config git"
-makedepends="webkit2gtk-devel libfixposix-devel openssl-devel libgirepository-devel"
-depends="dbus sqlite xclip webkit2gtk-devel libgirepository-devel"
+hostmakedepends="sbcl git"
+makedepends="webkit2gtk-devel libfixposix-devel libgirepository-devel"
+depends="dbus xclip enchant2 webkit2gtk-devel libfixposix-devel libgirepository-devel"
 short_desc="Keyboard-oriented, extensible web-browser"
 maintainer="0x0f0f0f <sudo-woodo3@protonmail.com>"
 license="BSD-3-Clause"


### PR DESCRIPTION
* Remove unneeded dependencies
  - curl
  - pkg-config
  - sqlite (bookmarks stored as s-exps now)
  - openssl-devel

* Add runtime dependency libfixposix-devel

Unhandled SIMPLE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                    {1000FB0103}>:
  Error opening shared object "libfixposix.so":
  libfixposix.so: cannot open shared object file: No such file or directory.

* Add enchant2 dependency for spell checking

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

