### PR TITLE
build-style/python3-{module,pep517}.sh: improve pytest usage

### DIFF
--- a/common/build-style/python3-module.sh
+++ b/common/build-style/python3-module.sh
@@ -24,8 +24,9 @@ do_build() {
 }
 
 do_check() {
-	if python3 -m pytest --help >/dev/null 2>&1; then
-		python3 -m pytest ${make_check_args} ${make_check_target}
+	if python3 -c 'import pytest' >/dev/null 2>&1; then
+		PYTHONPATH="$(cd build/lib* && pwd)" \
+			python3 -m pytest ${make_check_args} ${make_check_target}
 	else
 		# Fall back to deprecated setup.py test orchestration without pytest
 		if [ -z "$make_check_target" ]; then

--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -13,7 +13,7 @@ do_build() {
 }
 
 do_check() {
-	if python3 -m pytest --help >/dev/null 2>&1; then
+	if python3 -c 'import pytest' >/dev/null 2>&1; then
 		python3 -m pytest ${make_check_args} ${make_check_target}
 	else
 		msg_warn "Unable to determine tests for PEP517 Python templates"

--- a/srcpkgs/olm-python3/template
+++ b/srcpkgs/olm-python3/template
@@ -8,7 +8,6 @@ build_style=python3-module
 hostmakedepends="python3-setuptools python3-cffi"
 makedepends="python3-devel libffi-devel olm-devel"
 depends="python3-cffi python3-future"
-checkdepends="python3-pytest python3-future"
 short_desc="Implementation of the Double Ratchet cryptographic ratchet - Python"
 maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
 license="Apache-2.0"
@@ -20,8 +19,4 @@ make_check=no
 
 pre_build() {
 	make include/olm/olm.h
-}
-
-do_check() {
-	PYTHONPATH=$(cd build/lib.linux-* && pwd) python3 -m pytest
 }

--- a/srcpkgs/python3-Flask/template
+++ b/srcpkgs/python3-Flask/template
@@ -16,10 +16,6 @@ distfiles="${PYPI_SITE}/F/Flask/Flask-${version}.tar.gz"
 checksum=1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55
 conflicts="python-Flask>=0"
 
-do_check() {
-	PYTHONPATH=src/ python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE.rst
 }

--- a/srcpkgs/python3-Pebble/template
+++ b/srcpkgs/python3-Pebble/template
@@ -13,7 +13,3 @@ license="LGPL-3.0-or-later"
 homepage="https://pebble.readthedocs.io/en/latest/"
 distfiles="${PYPI_SITE}/P/Pebble/Pebble-${version}.tar.gz"
 checksum=b0abdc8830c21307038d63454584f71c2943e542e4e9d4c86d67aebc06c3519b
-
-do_check() {
-	PYTHONPATH=$(pwd)/build/lib pytest
-}

--- a/srcpkgs/python3-Pillow/template
+++ b/srcpkgs/python3-Pillow/template
@@ -17,10 +17,6 @@ changelog="https://raw.githubusercontent.com/python-pillow/Pillow/master/CHANGES
 distfiles="${PYPI_SITE}/P/Pillow/Pillow-${version}.tar.gz"
 checksum=a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1
 
-do_check() {
-	PYTHONPATH=$(cd build/lib.linux-* && pwd) python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-PyICU/template
+++ b/srcpkgs/python3-PyICU/template
@@ -16,10 +16,6 @@ changelog="https://gitlab.pyicu.org/main/pyicu/-/raw/main/CHANGES"
 distfiles="https://gitlab.pyicu.org/main/pyicu/-/archive/v${version}/pyicu-v${version}.tar.bz2"
 checksum=072672a2403bedb54240494ad8cbb8f443825b6e6c1a98f11a556d8adff96be0
 
-pre_check() {
-	export PYTHONPATH=$(cd build/lib* && pwd)
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-colorclass/template
+++ b/srcpkgs/python3-colorclass/template
@@ -14,10 +14,6 @@ homepage="https://github.com/Robpol86/colorclass"
 distfiles="https://github.com/Robpol86/colorclass/archive/v${version}.tar.gz"
 checksum=@4b1dff3a5736f909f229429396131365d31cffac0c497bdf46a1fa61e8c2d6f7
 
-do_check() {
-	PYTHONPATH="${PWD}/build-${py3_ver}/lib" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-cryptography/template
+++ b/srcpkgs/python3-cryptography/template
@@ -24,10 +24,6 @@ if [ "$CROSS_BUILD" ]; then
 	export PYO3_CROSS_INCLUDE_DIR="${XBPS_CROSS_BASE}/usr/include"
 fi
 
-do_check() {
-	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 	vlicense LICENSE.BSD

--- a/srcpkgs/python3-humanize/template
+++ b/srcpkgs/python3-humanize/template
@@ -20,10 +20,6 @@ do_patch() {
 	sed -i "s/VERSION = .*$/VERSION = '${version}'/" src/humanize/__init__.py
 }
 
-do_check() {
-	PYTHONPATH="${PWD}/build/lib" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENCE
 }

--- a/srcpkgs/python3-hyperframe/template
+++ b/srcpkgs/python3-hyperframe/template
@@ -14,10 +14,6 @@ homepage="https://python-hyper.org/hyperframe/"
 distfiles="https://github.com/python-hyper/hyperframe/archive/v${version}.tar.gz"
 checksum=a126e1e0fb24135aa7ac53cefe11ad197d0c9a5e74f495c1236022b1e578a7a8
 
-do_check() {
-	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-icalendar/template
+++ b/srcpkgs/python3-icalendar/template
@@ -4,6 +4,7 @@ version=4.0.7
 revision=1
 wrksrc="icalendar-${version}"
 build_style=python3-module
+make_check_target=src/icalendar/tests
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-dateutil python3-pytz"
 checkdepends="python3-dateutil python3-pytz python3-pytest python3-hypothesis"
@@ -14,10 +15,6 @@ homepage="https://github.com/collective/icalendar"
 distfiles="${PYPI_SITE}/i/icalendar/icalendar-${version}.tar.gz"
 checksum=0fc18d87f66e0b5da84fa731389496cfe18e4c21304e8f6713556b2e8724a7a4
 conflicts="python-icalendar>=0"
-
-do_check() {
-	PYTHONPATH=src python3 -m pytest src/icalendar/tests
-}
 
 post_install() {
 	vlicense LICENSE.rst LICENSE

--- a/srcpkgs/python3-marshmallow/template
+++ b/srcpkgs/python3-marshmallow/template
@@ -15,10 +15,6 @@ changelog="https://raw.githubusercontent.com/marshmallow-code/marshmallow/dev/CH
 distfiles="${PYPI_SITE}/m/marshmallow/marshmallow-${version}.tar.gz"
 checksum=ba949379cb6ef73655f72075e82b31cf57012a5557ede642fc8614ab0354f869
 
-do_check() {
-	PYTHONPATH="${PWD}/build/lib" pytest3 -v
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-msgpack/template
+++ b/srcpkgs/python3-msgpack/template
@@ -13,7 +13,3 @@ license="Apache-2.0"
 homepage="https://msgpack.org/"
 distfiles="${PYPI_SITE}/m/msgpack/msgpack-${version}.tar.gz"
 checksum=9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0
-
-do_check() {
-	PYTHONPATH=$PWD/build/lib python3 -m pytest
-}

--- a/srcpkgs/python3-outcome/template
+++ b/srcpkgs/python3-outcome/template
@@ -14,10 +14,6 @@ homepage="https://github.com/python-trio/outcome"
 distfiles="${PYPI_SITE}/o/outcome/outcome-${version}.tar.gz"
 checksum=e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967
 
-do_check() {
-	PYTHONPATH=$(cd build/lib* && pwd) pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -18,7 +18,3 @@ checksum=fcbb6e37426564ccaf6bb301616700277d426225895b00a64283a95ff648f3b9
 pre_build() {
 	vsed -e '/setuptools_scm_git_archive/d' -i setup.py
 }
-
-do_check() {
-	PYTHONPATH=$(cd build/lib* && pwd) python3 -m pytest
-}

--- a/srcpkgs/python3-pyxattr/template
+++ b/srcpkgs/python3-pyxattr/template
@@ -14,7 +14,3 @@ license="LGPL-2.1-or-later"
 homepage="http://pyxattr.k1024.org/"
 distfiles="${PYPI_SITE}/p/pyxattr/pyxattr-${version}.tar.gz"
 checksum=68477027e6d3310669f98aaef15393bfcd9b2823d7a7f00a6f1d91a3c971ae64
-
-do_check() {
-	PYTHONPATH=$(cd build/lib* && pwd) python3 -m pytest
-}

--- a/srcpkgs/python3-quart/template
+++ b/srcpkgs/python3-quart/template
@@ -16,9 +16,8 @@ changelog="https://gitlab.com/pgjones/quart/-/blob/master/CHANGELOG.rst"
 distfiles="${homepage}/-/archive/${version}/${pkgname#*-}-${version}.tar.gz"
 checksum=d9fa92cfec967b8730ce75f90a454d0a687871960f5e334885e64bfae9d7cd3a
 
-do_check() {
-	vsed -e '/addopts/d' -i setup.cfg
-	PYTHONPATH=src python3 -m pytest
+pre_check() {
+	sed -e '/addopts/d' -i setup.cfg
 }
 
 post_install() {

--- a/srcpkgs/python3-sniffio/template
+++ b/srcpkgs/python3-sniffio/template
@@ -14,10 +14,6 @@ homepage="https://github.com/python-trio/sniffio"
 distfiles="${PYPI_SITE}/s/sniffio/sniffio-${version}.tar.gz"
 checksum=c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de
 
-do_check() {
-	PYTHONPATH=$(cd build/lib* && pwd) pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-soupsieve/template
+++ b/srcpkgs/python3-soupsieve/template
@@ -13,10 +13,6 @@ homepage="https://facelessuser.github.io/soupsieve/"
 distfiles="${PYPI_SITE}/s/soupsieve/soupsieve-${version}.tar.gz"
 checksum=e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda
 
-do_check() {
-	PYTHONPATH="${PWD}/build/lib" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE.md
 

--- a/srcpkgs/python3-ultrajson/template
+++ b/srcpkgs/python3-ultrajson/template
@@ -15,10 +15,6 @@ homepage="https://github.com/ultrajson/ultrajson"
 distfiles="${PYPI_SITE}/u/ujson/ujson-${version}.tar.gz"
 checksum=c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d
 
-do_check() {
-	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE.txt
 }

--- a/srcpkgs/python3-wsproto/template
+++ b/srcpkgs/python3-wsproto/template
@@ -15,10 +15,6 @@ changelog="https://raw.githubusercontent.com/python-hyper/wsproto/master/CHANGEL
 distfiles="${PYPI_SITE}/w/wsproto/wsproto-${version}.tar.gz"
 checksum=868776f8456997ad0d9720f7322b746bbe9193751b5b290b7f924659377c8c38
 
-do_check() {
-	PYTHONPATH=src python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }

--- a/srcpkgs/python3-xmlschema/template
+++ b/srcpkgs/python3-xmlschema/template
@@ -6,17 +6,13 @@ wrksrc=xmlschema-${version}
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-elementpath"
 depends="python3-elementpath"
-checkdepends="python3-lxml python3-Sphinx"
+checkdepends="python3-lxml python3-Sphinx python3-pytest"
 short_desc="XML Schema validator and decoder for Python"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="MIT"
 homepage="https://github.com/sissaschool/xmlschema"
 distfiles="${PYPI_SITE}/x/xmlschema/xmlschema-${version}.tar.gz"
 checksum=31ddf77a44e4b121de212beeb2cc039e2e8b7a7a4f1678c9b29be1f5341aec52
-
-do_check() {
-	PYTHONPATH=$(pwd)/build/lib python3 -m unittest
-}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/ssh-audit/template
+++ b/srcpkgs/ssh-audit/template
@@ -14,10 +14,6 @@ distfiles="https://github.com/jtesta/ssh-audit/archive/v${version}.tar.gz"
 checksum=87c634171d3e0c69297fceeb98dead9a816d5d56c8dcd138f8411fdf58085b6f
 python_version=3
 
-do_check() {
-	PYTHONPATH=build/lib python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 	vman ssh-audit.1

--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -19,10 +19,6 @@ checksum=c0ead9e961638d41cab9bd9677cdc701f2313bfd4d23cd8158410932839c62db
 
 export STREAMLINK_USE_PYCOUNTRY=1
 
-do_check() {
-	PYTHONPATH="${PWD}/build/lib" python3 -m pytest
-}
-
 post_install() {
 	vlicense LICENSE
 }


### PR DESCRIPTION
1. Relying on `python3 -m pytest --help` to test for pytest can fail
   because the pytest packages's __main__ is still invoked; this can
   trigger import problems and falsely indicate that pytest is missing.
   A simpler test is to just confirm that pytest is importable. If so,
   the interpreter returns 0. Otherwise, an ImportError is thrown and
   the interpreter will return 1.

2. Many templates require a custom do_check just to set PYTHONPATH to
   either a build directory (especially for compiled extensions) or some
   subdirectory of the source tree. Setting PYTHONPATH automatically to
   the build directory should drastically reduce the need for custom
   do_check in py3 templates. (This only applies to python3-module.sh
   because pep517 builders will have unpredictable build directories.)