### PR TITLE
curl: use mdocml instead of groff to build manual

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,20 +1,23 @@
 # Template file for 'curl'
 pkgname=curl
 version=7.77.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
  $(vopt_with rtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnutls)
  $(vopt_enable ldap ldaps) $(vopt_with ssh libssh2) $(vopt_with ssl) $(vopt_with zstd)
- --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt --without-libidn2"
-hostmakedepends="groff perl pkg-config"
+ --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt --without-libidn2
+ ac_cv_path_NROFF=/usr/bin/mandoc"
+# Use mdocml instead of groff to generate builtin manual to avoid cyclic
+# dependencies.
+hostmakedepends="perl pkg-config mdocml"
 makedepends="nghttp2-devel zlib-devel $(vopt_if gnutls 'gnutls-devel')
  $(vopt_if gssapi 'mit-krb5-devel') $(vopt_if ldap 'libldap-devel')
  $(vopt_if rtmp 'librtmp-devel') $(vopt_if ssh 'libssh2-devel')
  $(vopt_if ssl 'openssl-devel') $(vopt_if zstd 'libzstd-devel')"
 depends="ca-certificates"
 # openssh isn't in checkdepends, because test 581 locks up
-checkdepends="perl python3 stunnel nghttp2 groff"
+checkdepends="python3 stunnel nghttp2"
 short_desc="Client that groks URLs"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"


### PR DESCRIPTION
Break circular dependencies:
elfutils > curl > groff > ghostscript
 ^                         v
glib < p11-kit < gnutls < cups

Technically, it's not necessary to bump revision, since diffoscope
reports same contents.

Fix: 10985815eb, (groff: obtain devpdf fonts from ghostscript, 2021-05-25)

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
