### PR TITLE
p11-kit: remove glib-devel from makedepends

### DIFF
--- a/srcpkgs/p11-kit/patches/we-know-glib-prefix.patch
+++ b/srcpkgs/p11-kit/patches/we-know-glib-prefix.patch
@@ -1,0 +1,13 @@
+Index: p11-kit-0.23.22/doc/manual/meson.build
+===================================================================
+--- p11-kit-0.23.22.orig/doc/manual/meson.build
++++ p11-kit-0.23.22/doc/manual/meson.build
+@@ -60,7 +60,7 @@ if get_option('gtk_doc')
+     'annotation-glossary.xml'
+   ]
+ 
+-  glib_prefix = dependency('glib-2.0').get_pkgconfig_variable('prefix')
++  glib_prefix = '/usr'
+   fixxref_args = [
+     '--html-dir=' + (prefix / gnome.gtkdoc_html_dir(meson.project_name())),
+     '--extra-dir=' + (glib_prefix / gnome.gtkdoc_html_dir('glib')),

--- a/srcpkgs/p11-kit/template
+++ b/srcpkgs/p11-kit/template
@@ -7,8 +7,7 @@ configure_args="-Dlibffi=enabled -Dsystemd=disabled -Dbash_completion=disabled
  -Dgtk_doc=true -Dman=true -Dnls=true -Dtrust_module=enabled
  -Dtrust_paths=/etc/ssl/certs/ca-certificates.crt"
 hostmakedepends="pkg-config gettext gtk-doc libxslt libtasn1-tools"
-# glib-devel for gtk-doc
-makedepends="libtasn1-devel libffi-devel glib-devel"
+makedepends="libtasn1-devel libffi-devel"
 short_desc="Provides a way to load and enumerate PKCS#11 modules"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"


### PR DESCRIPTION
Breake this circular:
```
elfutils > libmicrohttpd
   ^               v
p11-kit < glib < gnutls
```
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
