### PR TITLE
ghc-bin: remove i686-musl support.

### DIFF
--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -2,7 +2,7 @@
 pkgname=ghc-bin
 version=8.8.4
 revision=1
-archs="i686* x86_64* ppc64le*"
+archs="i686 x86_64* ppc64le*"
 wrksrc="ghc-${version%[!0-9]}"
 hostmakedepends="perl libffi libnuma"
 depends="ncurses perl gcc libffi-devel gmp-devel"
@@ -27,10 +27,6 @@ i686)
 	distfiles="https://downloads.haskell.org/~ghc/${version%[!0-9]}/ghc-${version}-i386-deb9-linux.tar.xz"
 	checksum=43dd954910c9027694312cef0aabc7774d102d0422b7172802cfb72f7d5da3a0
 	;;
-i686-musl)
-	distfiles="https://distfiles.voidlinux.de/ghc-${version}-i386-unknown-linux-musl.tar.xz"
-	checksum=8d84fbab62b3712bdcfb92f7d258a0d15d8295397d84b48716a3c625f09be782
-	;;
 ppc64le)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux.tar.xz"
 	checksum=4a13d36a3e3d605db02b89269ed727c3ba23c9d03b84b72c1716a910a28f8074
@@ -38,6 +34,8 @@ ppc64le)
 ppc64le-musl)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux-musl.tar.xz"
 	checksum=b35ba0cb20a05555ac6c2c92f9f090c665e55b3d295d58a801eb88bd4f6baab3
+	;;
+*) broken="No distfiles available for this target"
 	;;
 esac
 


### PR DESCRIPTION
voidlinux.de has been shut down, so the distfiles can no longer be
accessed. Someone looking to re-add support will have to create a new
tarball.

Since we are here, add broken= case to catch template mistakes early.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
