### PR TITLE
cross-vpkg-dummy: Fix typo in ld-linux-x86-64.so.2 name

### DIFF
--- a/srcpkgs/cross-vpkg-dummy/template
+++ b/srcpkgs/cross-vpkg-dummy/template
@@ -1,11 +1,11 @@
 # Template file for 'cross-vpkg-dummy'
 pkgname=cross-vpkg-dummy
-version=0.37
+version=0.38
 revision=1
 build_style=meta
 short_desc="Dummy meta-pkg for cross building packages with xbps-src"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Public domain"
+license="Public Domain"
 homepage="https://www.voidlinux.org/"
 
 depends="base-files>=0.126"
@@ -72,7 +72,7 @@ else
 	shlib_provides+=" libc.so.6 libm.so.6 librt.so.1 libpthread.so.0"
 	shlib_provides+=" libcrypt.so.1 libdl.so.2 libresolv.so.2"
 	shlib_provides+=" libanl.so.1 libnsl.so.1 libutil.so.1"
-	shlib_provides+=" ld-linux.so.2 ld-linux.so.3 ld-linux-x86_64.so.2"
+	shlib_provides+=" ld-linux.so.2 ld-linux.so.3 ld-linux-x86-64.so.2"
 	shlib_provides+=" ld-linux-armhf.so.3 ld-linux-aarch64.so.1"
 	shlib_provides+=" ld64.so.2 ld.so.1"
 fi


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (aarch64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] x86_64
-->
