### PR TITLE
iwd: update to 1.15.

### DIFF
--- a/srcpkgs/iwd/patches/resolvconf-default.patch
+++ b/srcpkgs/iwd/patches/resolvconf-default.patch
@@ -1,14 +1,14 @@
 --- src/resolve.c
 +++ src/resolve.c
-@@ -604,7 +604,7 @@ static int resolve_init(void)
- 			l_warn("[General].dns_resolve_method is deprecated, "
- 				"use [Network].NameResolvingService");
- 		else /* Default to systemd-resolved service. */
--			method_name = "systemd";
-+			method_name = "resolvconf";
- 	}
+@@ -596,7 +596,7 @@ static int resolve_init(void)
+ 	method_name = l_settings_get_value(iwd_get_config(), "Network",
+ 						"NameResolvingService");
+ 	if (!method_name)
+-		method_name = "systemd";
++		method_name = "resolvconf";
  
  	for (i = 0; resolve_method_ops_list[i].name; i++) {
+ 		if (strcmp(resolve_method_ops_list[i].name, method_name))
 --- src/iwd.config.rst
 +++ src/iwd.config.rst
 @@ -194,7 +194,7 @@ The group ``[Network]`` contains network configuration related settings.

--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,6 +1,6 @@
 # Template file for 'iwd'
 pkgname=iwd
-version=1.14
+version=1.15
 revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://iwd.wiki.kernel.org/"
 changelog="https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog"
 distfiles="${KERNEL_SITE}/network/wireless/${pkgname}-${version}.tar.xz"
-checksum=21be6ad59ba666ba1e50e01889d647472b9b2f96f4941123db036fd33c257f0b
+checksum=a7ab8e80592da5cb1a8b651b6d41e87e4507a3f07e04246e05bca89c547af659
 make_dirs="/var/lib/iwd 0600 root root
  /var/lib/ead 0600 root root
  /etc/iwd 755 root root"


### PR DESCRIPTION
[Changelog](https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=6d47354e630f770c25b635ae80818ee4d37c050c):
```
Add support for FT-over-DS procedure with multiple BSS.
Add support for estimation of VHT RX data rate.
Add support for exporting Daemon information.
```

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
- [x] I built this PR locally for my native architecture, x86_64-musl
- [x] I built this PR locally for these architectures:
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
  - [x] ppc-musl
  - [x] ppc64le-musl
