### PR TITLE
[pending perl 5.34] biber: update to 2.16

### DIFF
--- a/srcpkgs/biber/template
+++ b/srcpkgs/biber/template
@@ -1,11 +1,12 @@
 # Template file for 'biber'
 pkgname=biber
-version=2.14
-revision=3
+version=2.16
+revision=1
 wrksrc="${pkgname}-${version}"
 build_style=perl-ModuleBuild
 hostmakedepends="perl-Module-Build"
-makedepends="
+makedepends="perl-ExtUtils-LibBuilder"
+depends="
 	perl-autovivification
 	perl-Business-ISBN
 	perl-Business-ISMN
@@ -14,17 +15,20 @@ makedepends="
 	perl-Data-Compare
 	perl-Data-Dump
 	perl-Data-Uniqid
+	perl-Date-Simple
 	perl-DateTime-Calendar-Julian
 	perl-DateTime-Format-Builder
 	perl-Encode-EUCJPASCII
 	perl-Encode-HanExtra
 	perl-Encode-JIS2K
+	perl-ExtUtils-LibBuilder
 	perl-File-Slurper
 	perl-IO-String
 	perl-IPC-Run3
 	perl-Lingua-Translit
 	perl-List-AllUtils
 	perl-List-MoreUtils-XS
+	perl-List-MoreUtils
 	perl-Log-Log4perl
 	perl-LWP-Protocol-https
 	perl-MIME-Charset
@@ -39,15 +43,17 @@ makedepends="
 	perl-Text-CSV_XS
 	perl-Text-Roman
 	perl-Unicode-LineBreak
+	perl-URI
+	perl-XML-LibXML
 	perl-XML-LibXML-Simple
 	perl-XML-LibXSLT
 	perl-XML-Writer"
-depends="${makedepends}"
-checkdepends="${makedepends} perl-File-Which perl-Test-Differences"
+checkdepends="$depends perl-File-Which perl-Test-Most"
 short_desc="BibTeX replacement for users of biblatex, with full Unicode support"
 maintainer="svenper <svenper@tuta.io>"
 license="Artistic-2.0"
-homepage="http://biblatex-biber.sourceforge.net/"
+homepage="http://biblatex-biber.sourceforge.net"
 changelog="https://raw.githubusercontent.com/plk/biber/dev/Changes"
 distfiles="https://github.com/plk/biber/archive/v${version}.tar.gz"
-checksum=8f6b6aa7762a18190ae0acde6d315e3a3bb1fbdf791bece798d99ff3d4f4a71c
+checksum=57111ebc6d0d1933e55d3fe1a92f8ef57c602388ae83598a8073c8a77fd811e2
+make_check=no # test failures with perl < 5.34


### PR DESCRIPTION
builds on x86_64-musl
disabled tests, as they require more recent perl

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
