### PR TITLE
cgdb: fix escape sequences

### DIFF
--- a/srcpkgs/cgdb/patches/fixescape.patch
+++ b/srcpkgs/cgdb/patches/fixescape.patch
@@ -1,0 +1,48 @@
+From 242ea26b6f4aa7ce2ce56cbb1b50cd93a3126a57 Mon Sep 17 00:00:00 2001
+From: meator <coder64@protonmail.com>
+Date: Thu, 17 Jun 2021 21:30:06 +0200
+Subject: [PATCH] Patch
+
+This is a patch for v0.7.1 of cgdb. It fixes bad escape sequences in prompt string. Based of https://github.com/cgdb/cgdb/issues/239#issuecomment-706249589 and https://github.com/cgdb/cgdb/issues/255#issuecomment-820546156.
+
+---
+ cgdb/scroller.cpp | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/cgdb/scroller.cpp b/cgdb/scroller.cpp
+index 2d01e82..d2d36ca 100644
+--- a/cgdb/scroller.cpp
++++ b/cgdb/scroller.cpp
+@@ -106,14 +106,27 @@ static char *parse(struct scroller *scr, struct hl_line_attr **attrs,
+                 /* Carriage return -> Move back to the beginning of the line */
+             case '\r':
+                 i = 0;
+-                if (buf[j + 1] != '\n') {
++                if ((buflen - j) >= 1 && buf[j + 1] != '\n') {
+                     sbfree(*attrs);
+                     *attrs = NULL;
+                 }
+                 break;
+             case '\033':
+                 /* Handle ansi escape characters */
+-                if (hl_ansi_color_support(hl_groups_instance) &&
++                /* see https://conemu.github.io/en/AnsiEscapeCodes.html#SGR_Select_Graphic_Rendition_parameters
++                 */
++                if ((buflen - j) >= 6
++                    && buf[j + 1] == '[' && buf[j + 2] == '?' && buf[j + 3] == '2'
++                    && buf[j + 4] == '0' && buf[j + 5] == '0' && buf[j + 6] == '4') {
++                    /* simply ignore these escape sequences like e.g. "[?2004h" */
++                    j += 7;
++                } else if ((buflen - j) >= 2 && buf[j + 1] == '[' && buf[j + 2] == '?') {
++                    /* simply ignore these escape sequences like e.g. "[?1h" */
++                    j += 4;
++                } else if ((buflen - j) >= 1 && (buf[j + 1] == '=' || buf[j + 1] == '>')) {
++                    /* simply ignore these escape sequences */
++                    j += 1;
++                } else if (hl_ansi_color_support(hl_groups_instance) &&
+                     debugwincolor) {
+                     int attr;
+                     int ansi_count = hl_ansi_get_color_attrs(
+-- 
+2.32.0
+

--- a/srcpkgs/cgdb/template
+++ b/srcpkgs/cgdb/template
@@ -1,7 +1,7 @@
 # Template file for 'cgdb'
 pkgname=cgdb
 version=0.7.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_rl_version=6.3
  ac_cv_file__proc_self_status=yes"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

The current version of cgdb has broken escape sequences (its prompt is `[?2004h(gdb) `). This is already fixed in their Github repo, but the latest official release does not contain the fix. The issue mentioning this is [here](https://github.com/cgdb/cgdb/issues/256). I have created the `fixescape.patch` patch from [these](https://github.com/cgdb/cgdb/issues/239#issuecomment-706249589) patches and from [this](https://github.com/cgdb/cgdb/issues/255#issuecomment-820546156) patch.