### PR TITLE
runc: update to 1.0.0-rc95

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,8 +1,8 @@
 # Template file for 'runc'
 pkgname=runc
 version=1.0.0
-revision=16
-_subver="rc94"
+revision=17
+_subver="rc95"
 _ver="$version-$_subver"
 wrksrc="$pkgname-$_ver"
 build_style=go
@@ -15,7 +15,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${_ver}/runc.tar.xz"
-checksum=87daf369dcac7f1895e72bc0ee22ba9e29d4678d6d0dd795f336e35c222a801a
+checksum=8304b161e1c0ec2cee969b25671a147cd56cb99e6aa534371b2cfb3ec13db2c4
 
 post_build() {
 	make man


### PR DESCRIPTION
Fixes CVE-2021-30465

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
