### PR TITLE
common/build-style: add `dune` (OCaml builder)

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -585,18 +585,22 @@ or `gnu-makefile`, this is the target passed to `${make_cmd}` in the build phase
 when unset the default target is used.
 If `${build_style}` is `python3-pep517`, this is the path of the package
 directory that should be built as a Python wheel; when unset, defaults to `.` (the current
-directory with respect to the build).
+directory with respect to the build). If `${build_style}` is `dune`, this is the target passed to 
+`dune build` in the build phase; when unset, defaults to `@install`.
 
 - `make_check_target` The target to be passed in to `${make_cmd}` at the check phase if
 `${build_style}` is set to `configure`, `gnu-configure` or `gnu-makefile`
-build methods. By default set to `check`.
+build methods; by default set to `check`. If `${build_style}` is `dune`, this
+is the target passed to `dune build` for running tests; when unset, defaults to `@runtest`.
 
 - `make_install_target` The installation target. When `${build_style}` is set to `configure`,
 `gnu-configure` or `gnu-makefile`, this is the target passed to `${make_command}` in the install
 phase; when unset, it defaults to `install`. If `${build_style}` is `python-pep517`, this is the
 path of the Python wheel produced by the build phase that will be installed; when unset, the
 `python-pep517` build style will look for a wheel matching the package name and version in the
-current directory with respect to the install.
+current directory with respect to the install. If `${build_style}` is `dune`, this is the list
+of OCaml packages to install, specified as a comma-separated list; when unset, all packages
+defined in the source project will be installed.
 
 - `patch_args` The arguments to be passed in to the `patch(1)` command when applying
 patches to the package sources during `do_patch()`. Patches are stored in
@@ -919,6 +923,15 @@ the default `build`.
 
 - `configure` For packages that use non-GNU configure scripts, at least `--prefix=/usr`
 should be passed in via `configure_args`.
+
+- `dune` For packages written in OCaml that use Dune for building.
+Arguments to `dune build` can be passed via `make_build_args`, and the build target
+(default `@install`) can be overridden via `make_build_target`.  Arguments to 
+`dune install` can be passed via `make_install_args`, and the list of packages to
+install (defaults to all packages defined in the project) can be overridden via 
+`make_install_target` as a comma-separated list (e.g. `containers,containers-data`).  
+Tests are run using `dune build @runtest`; the target (default `@runtest`) can be 
+overridden via `make_check_target` and arguments passed via `make_check_args`.
 
 - `fetch` For packages that only fetch files and are installed as is via `do_install()`.
 

--- a/common/build-style/dune.sh
+++ b/common/build-style/dune.sh
@@ -1,0 +1,34 @@
+#
+# This helper is for templates using OCaml's dune build system.
+#
+do_build() {
+	: ${make_cmd:=dune}
+	: ${make_build_target:=@install}
+
+	"${make_cmd}" build --release $makejobs $make_build_args $make_build_target
+}
+
+do_check() {
+	: ${make_cmd:=dune}
+	: ${make_check_target:=@runtest}
+
+	"${make_cmd}" build $makejobs $make_check_args $make_check_target
+}
+
+do_install() {
+	: ${make_cmd:=dune}
+
+	"${make_cmd}" install \
+		--prefix="/usr" \
+		--libdir="/usr/lib/ocaml" \
+		--mandir="/usr/share/man" \
+		--destdir="$DESTDIR" \
+		$make_install_args $make_install_target
+
+	# patch: mv /usr/doc to /usr/share/doc because dune does not provide way to
+	# customize doc install path
+	if [ -e "$DESTDIR/usr/doc" ]; then
+		mkdir -p "$DESTDIR/usr/share"
+		mv "$DESTDIR/usr/doc" "$DESTDIR/usr/share"
+	fi
+}

--- a/common/environment/build-style/dune.sh
+++ b/common/environment/build-style/dune.sh
@@ -1,0 +1,1 @@
+hostmakedepends+=" ocaml dune"

--- a/srcpkgs/ocaml-sexplib0/template
+++ b/srcpkgs/ocaml-sexplib0/template
@@ -1,0 +1,17 @@
+# Template file for 'ocaml-sexplib0'
+pkgname=ocaml-sexplib0
+version=0.14.0
+revision=1
+wrksrc="sexplib0-$version"
+build_style="dune"
+short_desc="Minimal-dependency base S-expressions library for OCaml"
+maintainer="Kye Shi <shi.kye@gmail.com>"
+license="MIT"
+homepage="https://github.com/janestreet/sexplib0"
+distfiles="https://github.com/janestreet/sexplib0/archive/refs/tags/v$version.tar.gz"
+checksum="1e2d1c27015809d816d1c707abfbc61f6b55830dedec01de8152d10ab7d6a19e"
+nocross="yes"
+
+post_install() {
+	vlicense "LICENSE.md"
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

This PR defines a `dune.sh` build style to streamline OCaml builds using the [Dune](https://dune.build) builder.  Its purpose is analogous to the `cargo` build style for Rust projects, or `python3-module` build style for Python setup.py projects, etc.

As an example showing how it works, I've also added `ocaml-sexplib0` (a common sexp library for OCaml), which builds using `build_style=dune`.

#### General

- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?

- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!--
#### Does it build and run successfully?
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
