### PR TITLE
New package: esptool-3.1

### DIFF
--- a/srcpkgs/esptool/template
+++ b/srcpkgs/esptool/template
@@ -1,0 +1,14 @@
+# Template file for 'esptool'
+pkgname=esptool
+version=3.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-pip"
+depends="python3-pyserial python3-ecdsa python3-pyaes
+ python3-bitstring python3-reedsolo"
+short_desc="Utility to communicate with the ROM bootloader in ESP8266 & ESP32 chips"
+maintainer="Marcus van Dam <marcus@marcusvandam.nl>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/espressif/esptool"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=5edc768a63df4d73bdeba534146f6b3e41fbbe3c25f08be627733fc38535a976

--- a/srcpkgs/python3-reedsolo/template
+++ b/srcpkgs/python3-reedsolo/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-reedsolo'
+pkgname=python3-reedsolo
+version=1.5.4
+revision=1
+wrksrc="reedsolomon-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-Cython"
+makedepends="python3-devel"
+short_desc="Pure-python Reed Solomon encoder/decoder"
+maintainer="Marcus van Dam <marcus@marcusvandam.nl>"
+license="MIT"
+homepage="https://github.com/tomerfiliba/reedsolomon"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=cbe74633d1e3ff0f3b9c44fac06dff3355c622e93d4a0cd85116c909932af665
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### General
- [X] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR
 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (amd64)


No hardware hackers on Void? Or did I miss the boat on a way better tool to program ESP's?

`esptool` depends on `python3-reedsolo`, I've bundled both new packages in this PR.

I am doubting if I should strip the `.py` extension from the installed binaries, as the help output still references the binaries including the `.py` extension.