### PR TITLE
fossil: fix distfiles url

### DIFF
--- a/srcpkgs/fossil/template
+++ b/srcpkgs/fossil/template
@@ -11,9 +11,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://www.fossil-scm.org"
 changelog="https://www.fossil-scm.org/home/doc/trunk/www/changes.wiki"
-distfiles="https://www.fossil-scm.org/home/tarball/fossil-${version}.tar.gz"
-checksum=1844918eacdfa625e1d7efbec688875a6f89eb6c639edc12f158c46ba585494a
-broken="checksum changed after 4 hours https://github.com/void-linux/void-packages/pull/31609"
+distfiles="https://fossil-scm.org/home/tarball/version-${version}/fossil-${version}.tar.gz"
+checksum=39f5a3960ebaa4984fcc953c3307ead5c0f21da4f66ecad516872f89843fcf79
 
 post_extract() {
 	vsed -i 's/test_system_sqlite$/# &/' auto.def  # failing on cross


### PR DESCRIPTION
Tarballs are [generated on demand](https://fossil-scm.org/home/help?cmd=/tarball) by fossil. The name of the file in the URL only specifies the name of the root directory inside the tarball, while the `release` parameter selects which tree to download.

All the URLs in the download page include a commit hash, which I wanted to avoid when I made #31609. I thought that omitting it was enough, but this resulted in downloading the most recent commit. Using the tag name works too.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
