### PR TITLE
musl: backport crypt_blowfish update.

### DIFF
--- a/srcpkgs/musl/patches/99d5098a885feae3ae8c32b407350d8ca85dd178.patch
+++ b/srcpkgs/musl/patches/99d5098a885feae3ae8c32b407350d8ca85dd178.patch
@@ -1,0 +1,113 @@
+From 99d5098a885feae3ae8c32b407350d8ca85dd178 Mon Sep 17 00:00:00 2001
+From: Julien Ramseier <j.ramseier@gmail.com>
+Date: Sun, 18 Oct 2020 12:15:06 -0400
+Subject: update crypt_blowfish to support $2b$ prefix
+
+Merge changes from Solar Designer's crypt_blowfish v1.3. This makes
+crypt_blowfish fully compatible with OpenBSD's bcrypt by adding
+support for the $2b$ prefix (which behaves the same as
+crypt_blowfish's $2y$).
+---
+ src/crypt/crypt_blowfish.c | 38 +++++++++++++++++++++++---------------
+ 1 file changed, 23 insertions(+), 15 deletions(-)
+
+(limited to 'src/crypt/crypt_blowfish.c')
+
+diff --git a/src/crypt/crypt_blowfish.c b/src/crypt/crypt_blowfish.c
+index d3f79851..d722607b 100644
+--- a/src/crypt/crypt_blowfish.c
++++ b/src/crypt/crypt_blowfish.c
+@@ -15,7 +15,7 @@
+  * No copyright is claimed, and the software is hereby placed in the public
+  * domain.  In case this attempt to disclaim copyright and place the software
+  * in the public domain is deemed null and void, then the software is
+- * Copyright (c) 1998-2012 Solar Designer and it is hereby released to the
++ * Copyright (c) 1998-2014 Solar Designer and it is hereby released to the
+  * general public under the following terms:
+  *
+  * Redistribution and use in source and binary forms, with or without
+@@ -31,12 +31,12 @@
+  * you place this code and any modifications you make under a license
+  * of your choice.
+  *
+- * This implementation is mostly compatible with OpenBSD's bcrypt.c (prefix
+- * "$2a$") by Niels Provos <provos at citi.umich.edu>, and uses some of his
+- * ideas.  The password hashing algorithm was designed by David Mazieres
+- * <dm at lcs.mit.edu>.  For more information on the level of compatibility,
+- * please refer to the comments in BF_set_key() below and to the included
+- * crypt(3) man page.
++ * This implementation is fully compatible with OpenBSD's bcrypt.c for prefix
++ * "$2b$", originally by Niels Provos <provos at citi.umich.edu>, and it uses
++ * some of his ideas.  The password hashing algorithm was designed by David
++ * Mazieres <dm at lcs.mit.edu>.  For information on the level of
++ * compatibility for bcrypt hash prefixes other than "$2b$", please refer to
++ * the comments in BF_set_key() below and to the included crypt(3) man page.
+  *
+  * There's a paper on the algorithm that explains its design decisions:
+  *
+@@ -533,6 +533,7 @@ static void BF_set_key(const char *key, BF_key expanded, BF_key initial,
+  * Valid combinations of settings are:
+  *
+  * Prefix "$2a$": bug = 0, safety = 0x10000
++ * Prefix "$2b$": bug = 0, safety = 0
+  * Prefix "$2x$": bug = 1, safety = 0
+  * Prefix "$2y$": bug = 0, safety = 0
+  */
+@@ -596,12 +597,14 @@ static void BF_set_key(const char *key, BF_key expanded, BF_key initial,
+ 	initial[0] ^= sign;
+ }
+ 
++static const unsigned char flags_by_subtype[26] = {
++	2, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0
++};
++
+ static char *BF_crypt(const char *key, const char *setting,
+ 	char *output, BF_word min)
+ {
+-	static const unsigned char flags_by_subtype[26] =
+-		{2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0};
+ 	struct {
+ 		BF_ctx ctx;
+ 		BF_key expanded_key;
+@@ -746,9 +749,11 @@ char *__crypt_blowfish(const char *key, const char *setting, char *output)
+ {
+ 	const char *test_key = "8b \xd0\xc1\xd2\xcf\xcc\xd8";
+ 	const char *test_setting = "$2a$00$abcdefghijklmnopqrstuu";
+-	static const char test_hash[2][34] =
+-		{"VUrPmXD6q/nVSSp7pNDhCR9071IfIRe\0\x55", /* $2x$ */
+-		"i1D709vfamulimlGcq0qq3UvuUasvEa\0\x55"}; /* $2a$, $2y$ */
++	static const char test_hashes[2][34] = {
++		"i1D709vfamulimlGcq0qq3UvuUasvEa\0\x55", /* 'a', 'b', 'y' */
++		"VUrPmXD6q/nVSSp7pNDhCR9071IfIRe\0\x55", /* 'x' */
++	};
++	const char *test_hash = test_hashes[0];
+ 	char *retval;
+ 	const char *p;
+ 	int ok;
+@@ -768,8 +773,11 @@ char *__crypt_blowfish(const char *key, const char *setting, char *output)
+  * detected by the self-test.
+  */
+ 	memcpy(buf.s, test_setting, sizeof(buf.s));
+-	if (retval)
++	if (retval) {
++		unsigned int flags = flags_by_subtype[setting[2] - 'a'];
++		test_hash = test_hashes[flags & 1];
+ 		buf.s[2] = setting[2];
++	}
+ 	memset(buf.o, 0x55, sizeof(buf.o));
+ 	buf.o[sizeof(buf.o) - 1] = 0;
+ 	p = BF_crypt(test_key, buf.s, buf.o, 1);
+@@ -777,7 +785,7 @@ char *__crypt_blowfish(const char *key, const char *setting, char *output)
+ 	ok = (p == buf.o &&
+ 	    !memcmp(p, buf.s, 7 + 22) &&
+ 	    !memcmp(p + (7 + 22),
+-	    test_hash[buf.s[2] & 1],
++	    test_hash,
+ 	    31 + 1 + 1 + 1));
+ 
+ 	{
+-- 
+cgit v1.2.1
+

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=7
+revision=8
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
Will be necessary in future shadow releases, as seen in
https://github.com/shadow-maint/shadow/pull/360.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
