### PR TITLE
samba: fix nss modules for musl.

### DIFF
--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,7 +1,7 @@
 # Template file for 'samba'
 pkgname=samba
 version=4.13.4
-revision=1
+revision=2
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -34,7 +34,7 @@ make_dirs="/etc/samba/private 0750 root root"
 subpackages="smbclient samba-ctdb samba-cups samba-devel samba-libs samba-python3"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	makedepends+=" musl-legacy-compat"
+	makedepends+=" musl-legacy-compat musl-nscd-devel"
 else
 	makedepends+=" glusterfs-devel"
 	subpackages+=" samba-glusterfs"


### PR DESCRIPTION
nss modules from samba, like libnss_winbind, will be used by
musl-nscd-devel, and therefore should use its headers for the
definitions of return values and others.

Without musl-nscd-devel to provide <nss.h>, samba uses a fallback header
that carries completely incompatible return value definitions.

@ahesford 

Another issue with the package is that it's missing `samba-tools`. We have yet to find it,

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
