### PR TITLE
python3-language-server: fix compatibility with jedi 0.18.0

### DIFF
--- a/srcpkgs/python3-language-server/patches/jedi_compat.patch
+++ b/srcpkgs/python3-language-server/patches/jedi_compat.patch
@@ -1,0 +1,37 @@
+https://github.com/palantir/python-language-server/pull/901
+
+From: bnavigator <code@bnavigator.de>
+Date: Tue, 5 Jan 2021 01:17:33 +0100
+Subject: [PATCH] bump jedi compatibility: compare to Path-like object
+
+---
+ pyls/plugins/symbols.py | 2 +-
+ setup.py                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/pyls/plugins/symbols.py b/pyls/plugins/symbols.py
+index 6468dd83..69a09fe9 100644
+--- a/pyls/plugins/symbols.py
++++ b/pyls/plugins/symbols.py
+@@ -37,7 +37,7 @@ def pyls_document_symbols(config, document):
+                         not sym_full_name.startswith('__main__')):
+                     continue
+
+-        if _include_def(d) and document.path == d.module_path:
++        if _include_def(d) and os.path.samefile(document.path, d.module_path):
+             tuple_range = _tuple_range(d)
+             if tuple_range in exclude:
+                 continue
+diff --git a/setup.py b/setup.py
+index 12782990..99d2b312 100755
+--- a/setup.py
++++ b/setup.py
+@@ -10,7 +10,7 @@
+         'configparser; python_version<"3.0"',
+         'future>=0.14.0; python_version<"3"',
+         'backports.functools_lru_cache; python_version<"3.2"',
+-        'jedi>=0.17.2,<0.18.0',
++        'jedi>=0.17.2,<0.19.0',
+         'python-jsonrpc-server>=0.4.0',
+         'pluggy',
+         'ujson<=2.0.3 ; platform_system!="Windows" and python_version<"3.0"',

--- a/srcpkgs/python3-language-server/template
+++ b/srcpkgs/python3-language-server/template
@@ -1,17 +1,24 @@
 # Template file for 'python3-language-server'
 pkgname=python3-language-server
 version=0.36.1
-revision=1
+revision=2
 wrksrc="${pkgname/3}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-jedi python3-pluggy python3-jsonrpc-server python3-ultrajson"
+checkdepends="${depends} autopep8 python3-coverage python3-flaky python3-matplotlib
+ python3-mccabe python3-mock python3-numpy python3-pandas python3-pycodestyle
+ python3-PyQt5 python3-pyflakes python3-pylint python3-pytest python3-pytest-cov
+ python3-yapf"
 short_desc="Python implementation of the Language Server Protocol"
 maintainer="k4leg <d0xi@inbox.ru>"
 license="MIT"
 homepage="https://github.com/palantir/python-language-server"
 distfiles="${PYPI_SITE}/p/${pkgname/3}/${pkgname/3}-${version}.tar.gz"
 checksum=c85d718ef6860319ad59fd6f2acb1166e9349b782ee8e8908e08ecf241615f52
+# Needs unpackaged rope and versioneer
+# https://github.com/palantir/python-language-server/blob/develop/setup.py#L51
+make_check=no
 
 post_patch() {
 	vsed -i setup.py -e 's/\bujson<=1.35\b/ujson/'


### PR DESCRIPTION
Project seems to be unmaintained at the moment. There's an active fork at
https://github.com/python-lsp/python-lsp-server that we can switch to
in future.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
