### PR TITLE
samba: update to 4.14.5; ldb: update to 2.3.0; cifs-utils: update to 6.13

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3963,7 +3963,7 @@ libndr-krb5pac.so.0 samba-libs-4.13.2_1
 libndr-nbt.so.0 samba-libs-4.13.2_1
 libndr-standard.so.0 samba-libs-4.13.2_1
 libndr.so.1 samba-libs-4.13.2_1
-libsamba-credentials.so.0 samba-libs-4.13.2_1
+libsamba-credentials.so.1 samba-libs-4.13.2_1
 libsamba-errors.so.1 samba-libs-4.13.2_1
 libsamba-hostconfig.so.0 samba-libs-4.13.2_1
 libsamba-passdb.so.0 samba-libs-4.13.2_1

--- a/srcpkgs/cifs-utils/template
+++ b/srcpkgs/cifs-utils/template
@@ -1,6 +1,6 @@
 # Template file for 'cifs-utils'
 pkgname=cifs-utils
-version=6.12
+version=6.13
 revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://wiki.samba.org/index.php/LinuxCIFS_utils"
 distfiles="https://ftp.samba.org/pub/linux-cifs/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=922ddcc3059922e80789312c386b9c569991b4350d3ae3099de3e4b82f3885ef
+checksum=43d8786c8613caccfa84913081c1d62bc2409575854cf895b05b48af0863d056
 python_version=3
 
 pre_configure() {

--- a/srcpkgs/ldb/template
+++ b/srcpkgs/ldb/template
@@ -1,6 +1,6 @@
 # Template file for 'ldb'
 pkgname=ldb
-version=2.2.0
+version=2.3.0
 revision=1
 build_style=waf3
 build_helper="qemu"
@@ -18,7 +18,7 @@ maintainer="Yuusha Spacewolf <xyuusha@paranoici.org>"
 license="LGPL-3.0-or-later"
 homepage="https://www.samba.org/ldb/"
 distfiles="https://www.samba.org/ftp/pub/ldb/ldb-${version}.tar.gz"
-checksum=134bb51769709af59f30bf468e454d1377a8096acd4e80dcb42fd264f558bd5f
+checksum=a4d308b3d0922ef01f3661a69ebc373e772374defa76cf0979ad21b21f91922d
 
 # workaround for cmocka's broken uintptr_t definition on musl
 if [ "$XBPS_TARGET_WORDSIZE" = "64" -a "$XBPS_TARGET_LIBC" = "musl" ]; then

--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,6 +1,6 @@
 # Template file for 'samba'
 pkgname=samba
-version=4.13.4
+version=4.14.5
 revision=1
 build_style=waf3
 build_helper="qemu"
@@ -27,14 +27,14 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.samba.org"
 distfiles="http://download.samba.org/pub/samba/stable/${pkgname}-${version}.tar.gz"
-checksum=a1b34c63f7100cc8626902d80f335c7cb0b45d4707dd3c4b010f7a28ed615c78
+checksum=bb6ef5d2f16b85288d823578abc453d9a80514c42e5a2ea2c4e3c60dc42335c3
 lib32disabled=yes
 conf_files="/etc/pam.d/samba /etc/samba/smb.conf"
 make_dirs="/etc/samba/private 0750 root root"
 subpackages="smbclient samba-ctdb samba-cups samba-devel samba-libs samba-python3"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	makedepends+=" musl-legacy-compat"
+	makedepends+=" musl-legacy-compat musl-nscd-devel"
 else
 	makedepends+=" glusterfs-devel"
 	subpackages+=" samba-glusterfs"


### PR DESCRIPTION
The Samba update builds cleanly and seems to run fine on `x86_64`. There is one shlib bump, `libsamba-credentials.so.1`, but that seems to be used exclusively by sub-packages so I think we can escape revbumping all of the dependants. (It would be good to test some of the dependants for basic Samba functionality.)

This update includes the patch from #31649.

The Samba server in this package appears to work as expected as a Time Machine backup target for a MacOS client; the client in this package appears to browse Windows and Synology (not sure if that's Samba or some other server) hosts.

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

cc: @ericonr

(Note to testers: for some reason I haven't identified, the Samba configure script picks up any Samba libs if they are installed on the host. To properly build this package, make sure *any* existing Samba packages---including `samba-libs`---are removed for your system, or the resulting packages will be broken.)