### PR TITLE
sof-firmware: update to 1.8

### DIFF
--- a/srcpkgs/sof-firmware/template
+++ b/srcpkgs/sof-firmware/template
@@ -1,6 +1,6 @@
 # Template file for 'sof-firmware'
 pkgname=sof-firmware
-version=1.7
+version=1.8
 revision=1
 archs="i686* x86_64*"
 wrksrc="sof-bin-${version}"
@@ -11,13 +11,21 @@ maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://thesofproject.github.io/latest/index.html"
 distfiles="https://github.com/thesofproject/sof-bin/archive/refs/tags/v${version}.tar.gz"
-checksum=895d0199c06fc9b8bd8452fffff4f0d53134af451f63ffd1b78f04b10ef6c251
+checksum=1d4ac18db8d2ec3046fdb56b4155f1c14d69644743b7c0324ba9b02f4308ab22
 
 do_install() {
 	vmkdir usr/lib/firmware/intel/sof
 	vmkdir usr/lib/firmware/intel/sof-tplg
-	rsync -a "sof-v${version}/" "${DESTDIR}/usr/lib/firmware/intel/sof"
-	rsync -a "sof-tplg-v${version}/" "${DESTDIR}/usr/lib/firmware/intel/sof-tplg"
+	rsync -a "v${version}.x/sof-v${version}/" "${DESTDIR}/usr/lib/firmware/intel/sof"
+	rsync -a "v${version}.x/sof-tplg-v${version}/" "${DESTDIR}/usr/lib/firmware/intel/sof-tplg"
 
 	vlicense LICENCE.NXP
+}
+
+sof-tools_package() {
+	pkg_install() {
+		vbin "v${version}.x/tools-v${version}/sof-ctl"
+		vbin "v${version}.x/tools-v${version}/sof-logger"
+		vbin "v${version}.x/tools-v${version}/sof-probes"
+	}
 }

--- a/srcpkgs/sof-tools
+++ b/srcpkgs/sof-tools
@@ -1,0 +1,1 @@
+sof-firmware


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
In addition to updating the firmware to version 1.8, this commit adds the sub-package `sof-tools`, which provides binaries used for testing and development of `sof-firmware`.