### PR TITLE
pulseeffects: update to 5.0.4 & fix greyed-out effects

### DIFF
--- a/srcpkgs/lsp-plugins/patches/00-makefile-test-remove-cflags.patch
+++ b/srcpkgs/lsp-plugins/patches/00-makefile-test-remove-cflags.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 2d9cb79..138d221 100644
+--- a/Makefile
++++ b/Makefile
+@@ -108,8 +108,6 @@ trace: export EXE_FLAGS     += -g3
+ trace: compile
+ 
+ test: OBJDIR                 = $(TESTDIR)
+-test: export CFLAGS         += -O2 -DLSP_TESTING -DLSP_TRACE -g3 -fstack-protector
+-test: export CXXFLAGS       += -O2 -DLSP_TESTING -DLSP_TRACE -g3 -fstack-protector
+ test: export EXE_TEST_FLAGS += -g3
+ test: export MAKE_OPTS      += LSP_TESTING=1
+ test: export BUILD_MODULES   = jack

--- a/srcpkgs/lsp-plugins/template
+++ b/srcpkgs/lsp-plugins/template
@@ -1,0 +1,17 @@
+# Template file for 'lsp-plugins'
+pkgname=lsp-plugins
+version=1.1.30
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkgconf php"
+makedepends="libsndfile-devel libX11-devel libglvnd-devel lv2 cairo-devel ladspa-sdk jack-devel"
+short_desc="Collection of free plugins compatible with LADSPA, LV2 and LinuxVST"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
+license="LGPL-3.0-or-later"
+homepage="https://lsp-plug.in/"
+distfiles="https://github.com/sadko4u/lsp-plugins/archive/refs/tags/${version}.tar.gz"
+checksum=9cf43257729093c240375b3640b1514dff34b092b83b54a5ee68d7e8565c8f80
+
+pre_build() {
+	CXXFLAGS="$CXXFLAGS -std=c++98"
+}

--- a/srcpkgs/pulseeffects-legacy/template
+++ b/srcpkgs/pulseeffects-legacy/template
@@ -4,18 +4,16 @@ version=4.8.5
 revision=1
 wrksrc="pulseeffects-${version}"
 build_style=meson
-hostmakedepends="itstool pkg-config gettext"
+hostmakedepends="itstool pkgconf gettext"
 makedepends="boost-devel glib-devel gsettings-desktop-schemas-devel
  gst-plugins-bad1-devel gtkmm-devel libebur128-devel lilv-devel
- pulseaudio-devel python3-gobject-devel sratom-devel
- libsndfile-devel"
-depends="calf gsettings-desktop-schemas gst-plugins-bad1
- gst-plugins-good1 pulseaudio python3-gobject python3-scipy"
+ pulseaudio-devel sratom-devel zita-convolver-devel
+ rubberband-devel libsamplerate-devel libsndfile-devel"
+depends="calf gst-plugins-good1 lsp-plugins zam-plugins"
 short_desc="Sound effects for systems using PulseAudio (legacy)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/pulseeffects"
 distfiles="https://github.com/wwmm/pulseeffects/archive/v${version}.tar.gz"
 checksum=df1c4c4a9811c62a549822dacde3a9e36233ba3ec58817ae52a236f6181a507c
-python_version=3
 conflicts="pulseeffects"

--- a/srcpkgs/pulseeffects/template
+++ b/srcpkgs/pulseeffects/template
@@ -1,20 +1,18 @@
 # Template file for 'pulseeffects'
 pkgname=pulseeffects
-version=5.0.3
+version=5.0.4
 revision=1
 build_style=meson
-hostmakedepends="itstool pkg-config gettext"
+hostmakedepends="itstool pkgconf gettext"
 makedepends="boost-devel glib-devel gsettings-desktop-schemas-devel
  gst-plugins-bad1-devel gtkmm-devel libebur128-devel lilv-devel
- pipewire-devel python3-gobject-devel sratom-devel zita-convolver-devel
- libsndfile-devel libbs2b-devel"
-depends="calf gsettings-desktop-schemas gst-plugins-bad1
- gst-plugins-good1 pipewire python3-gobject python3-scipy zita-convolver
- gstreamer1-pipewire"
+ pipewire-devel sratom-devel zita-convolver-devel
+ rubberband-devel libsamplerate-devel libsndfile-devel"
+depends="calf gstreamer1-pipewire gst-plugins-good1 lsp-plugins zam-plugins"
 short_desc="Sound effects for systems using PipeWire"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/pulseeffects"
 distfiles="https://github.com/wwmm/pulseeffects/archive/v${version}.tar.gz"
-checksum=2e14858918b54bee5f6e4898cc803ae2170b4d624407fef39e0831b6584c4a4f
-python_version=3
+checksum=3fa482e2261fe467e30c05e85a55904806b0dc141834fe8b5cfeffedb6da65e8
+conflicts="pulseeffects-legacy"

--- a/srcpkgs/zam-plugins/files/zam-plugins.directory
+++ b/srcpkgs/zam-plugins/files/zam-plugins.directory
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=zam-plugins
+Icon=zam-plugins
+Type=Directory
+Keywords=audio;sound;jackd;zam-plugins;

--- a/srcpkgs/zam-plugins/files/zam-plugins.menu
+++ b/srcpkgs/zam-plugins/files/zam-plugins.menu
@@ -1,0 +1,30 @@
+<!DOCTYPE Menu PUBLIC "-//freedesktop//DTD Menu 1.0//EN" "http://www.freedesktop.org/standards/menu-spec/menu-1.0.dtd">
+<Menu>
+  <Name>Applications</Name>
+  <Menu>
+    <Name>Multimedia</Name>
+    <Menu>
+      <Name>zam-plugins</Name>
+      <Directory>zam-plugins.directory</Directory>
+      <Include>
+        <Filename>com.zamaudio.zamautosat.desktop</Filename>
+        <Filename>com.zamaudio.zamaximx2.desktop</Filename>
+        <Filename>com.zamaudio.zamcomp.desktop</Filename>
+        <Filename>com.zamaudio.zamcompx2.desktop</Filename>
+        <Filename>com.zamaudio.zamdelay.desktop</Filename>
+        <Filename>com.zamaudio.zamdynamiceq.desktop</Filename>
+        <Filename>com.zamaudio.zameq2.desktop</Filename>
+        <Filename>com.zamaudio.zamgate.desktop</Filename>
+        <Filename>com.zamaudio.zamgatex2.desktop</Filename>
+        <Filename>com.zamaudio.zamgeq31.desktop</Filename>
+        <Filename>com.zamaudio.zamgrains.desktop</Filename>
+        <Filename>com.zamaudio.zamheadx2.desktop</Filename>
+        <Filename>com.zamaudio.zammulticompx2.desktop</Filename>
+        <Filename>com.zamaudio.zamphono.desktop</Filename>
+        <Filename>com.zamaudio.zamtube.desktop</Filename>
+        <Filename>com.zamaudio.zamulticomp.desktop</Filename>
+        <Filename>com.zamaudio.zamverb.desktop</Filename>
+      </Include>
+    </Menu>
+  </Menu>
+</Menu>

--- a/srcpkgs/zam-plugins/template
+++ b/srcpkgs/zam-plugins/template
@@ -1,0 +1,103 @@
+# Template file for 'zam-plugins'
+pkgname=zam-plugins
+version=3.14
+revision=1
+build_style=gnu-makefile
+make_use_env=yes
+make_build_args="HAVE_ZITA_CONVOLVER=true"
+hostmakedepends="pkgconf git gendesk"
+makedepends="libX11-devel libglvnd-devel liblo-devel jack-devel ladspa-sdk
+ libsamplerate-devel zita-convolver-devel"
+# Use system zita-convolver instead of the vendored one
+short_desc="LADSPA/LV2/VST/JACK audio plugins for high-quality processing"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
+license="GPL-2.0-or-later"
+homepage="http://zamaudio.com/"
+changelog="https://github.com/zamaudio/zam-plugins/blob/${version}/changelog"
+
+do_fetch() {
+	git clone --depth 1 --branch ${version} --single-branch \
+	--recurse-submodules --shallow-submodules https://github.com/zamaudio/zam-plugins \
+	zam-plugins-${version}
+}
+
+# Huge thanks to David Runge <dvzrv@archlinux.org>, maintainer of zam-plugins in Arch Linux
+post_install() {
+	_names=('zamaximx2' 'zamulticomp' 'zammulticompx2' 'zamautosat' 'zamcomp'
+		'zamcompx2' 'zamdelay' 'zamdynamiceq' 'zameq2' 'zamgeq31' 'zamgate'
+		'zamgatex2' 'zamgrains' 'zamheadx2' 'zamphono' 'zamtube' 'zamverb')
+
+	declare -A exec_names=(
+		["zamaximx2"]="ZaMaximX2"
+		["zamulticomp"]="ZaMultiComp"
+		["zamulticompx2"]="ZaMultiCompX2"
+		["zamautosat"]="ZamAutoSat"
+		["zamcomp"]="ZamComp"
+		["zamcompx2"]="ZamCompX2"
+		["zamdelay"]="ZamDelay"
+		["zamdynamiceq"]="ZamDynamicEQ"
+		["zameq2"]="ZamEQ2"
+		["zamgeq31"]="ZamGEQ31"
+		["zamgate"]="ZamGate"
+		["zamgatex2"]="ZamGateX2"
+		["zamgrains"]="ZamGrains"
+		["zamheadx2"]="ZamHeadX2"
+		["zamphono"]="ZamPhono"
+		["zamtube"]="ZamTube"
+		["zamverb"]="ZamVerb"
+	)
+	declare -A comments=(
+		["zamaximx2"]="Acts as a brickwall limiter for mastering in its default state, but can also be tweaked to raise the average level as a stereo maximizer without ever clipping"
+		["zamulticomp"]="Mono multiband compressor, with 3 adjustable bands."
+		["zamulticompx2"]="Stereo version of ZaMultiComp, with individual threshold controls for each band and real-time visualisation of comp curves."
+		["zamautosat"]="An automatic saturation plugin, has been known to provide smooth levelling to live mic channels."
+		["zamcomp"]="A powerful mono compressor strip"
+		["zamcompx2"]="Stereo version of ZamComp with knee slew control"
+		["zamdelay"]="A simple feedback delay unit with sync-to-host BPM feature and filter."
+		["zamdynamiceq"]="A dynamic equalizer that changes its gain based on detecting a narrow band of frequencies."
+		["zameq2"]="Two band parametric equaliser with high and low shelving circuits."
+		["zamgeq31"]="31 band graphic equaliser, good for eq of live spaces, removing unwanted noise from a track etc."
+		["zamgate"]="Gate plugin for ducking low gain sounds."
+		["zamgatex2"]="Gate plugin for ducking low gain sounds, stereo version."
+		["zamgrains"]="Granular Synthesizer"
+		["zamheadx2"]="HRTF acoustic filtering plugin for directional sound."
+		["zamphono"]="A collection of phono filters for restoring vinyl records, or preparing to cut new ones."
+		["zamtube"]="Wave digital filter physical model of a triode tube amplifier stage, with modelled tone stacks from real guitar amplifiers"
+		["zamverb"]="Reverb"
+	)
+	declare -A generic=(
+		["zamaximx2"]="Maximizer and brickwall limiter"
+		["zamulticomp"]="Mono Multiband Compressor"
+		["zamulticompx2"]="Stereo Multiband Compressor"
+		["zamautosat"]="Automatic Saturation"
+		["zamcomp"]="Mono Compressor"
+		["zamcompx2"]="Stereo Compressor"
+		["zamdelay"]="Delay"
+		["zamdynamiceq"]="Dynamic Equalizer"
+		["zameq2"]="2 Band Parametric Equalizer"
+		["zamgeq31"]="31 Band Graphic Equalizer"
+		["zamgate"]="Mono Gate"
+		["zamgatex2"]="Stereo Gate"
+		["zamgrains"]="Granular Synthesizer"
+		["zamheadx2"]="HRTF Acoustic Filtering"
+		["zamphono"]="Phono Filters"
+		["zamtube"]="Tube Amplifier"
+		["zamverb"]="Reverb"
+	)
+
+	# Generate *.desktop files for each plugin
+	for name in "${_names[@]}"; do
+		gendesk -n \
+			--pkgname "com.zamaudio.${name}" \
+			--name "${name}" \
+			--exec "${exec_names[$name]}" \
+			--pkgdesc "${comments[$name]}" \
+			--genericname "${generic[$name]}"
+	done
+
+	install -vDm 644 *.desktop -t ${DESTDIR}/usr/share/applications/
+	vinstall ${FILESDIR}/zam-plugins.directory 644 usr/share/desktop-directories/
+	vinstall ${FILESDIR}/zam-plugins.menu 644 etc/xdg/menus/applications-merged/
+	vdoc README.md
+	vdoc changelog
+}

--- a/srcpkgs/zita-convolver/template
+++ b/srcpkgs/zita-convolver/template
@@ -1,11 +1,11 @@
 # Template file for 'zita-convolver'
 pkgname=zita-convolver
 version=4.0.3
-revision=2
+revision=3
 build_wrksrc="source"
 build_style=gnu-makefile
 make_install_args="LIBDIR=/usr/lib"
-hostmakedepends="pkg-config"
+hostmakedepends="pkgconf"
 makedepends="fftw-devel"
 short_desc="Fast partitioned convolution engine library"
 maintainer="silvernode <mollusk@homebutter.com>"
@@ -14,7 +14,9 @@ homepage="http://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
 checksum=9aa11484fb30b4e6ef00c8a3281eebcfad9221e3937b1beb5fe21b748d89325f
 
-CXXFLAGS="-fPIC -ffast-math -funroll-loops"
+pre_build() {
+	CXXFLAGS="$CXXFLAGS -fPIC"
+}
 
 post_install() {
 	# add missing symlink
@@ -22,7 +24,7 @@ post_install() {
 }
 
 zita-convolver-devel_package() {
-	depends="${sourcepkg}-${version}_${revision}"
+	depends="${sourcepkg}-${version}_${revision} fftw-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
- New package: lsp-plugins-1.1.30
- zita-convolver-devel: add fftw-devel dependency
- New package: zam-plugins-3.14
- pulseeffects: update to 5.0.4 & fix greyed-out effects
- pulseeffects-legacy: fix greyed out effects

<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
