### PR TITLE
New package: lsp-plugins-1.1.30

### DIFF
--- a/srcpkgs/lsp-plugins
+++ b/srcpkgs/lsp-plugins
@@ -1,0 +1,1 @@
+lsp-plugins-lv2

--- a/srcpkgs/lsp-plugins-doc
+++ b/srcpkgs/lsp-plugins-doc
@@ -1,0 +1,1 @@
+lsp-plugins-lv2

--- a/srcpkgs/lsp-plugins-jack
+++ b/srcpkgs/lsp-plugins-jack
@@ -1,0 +1,1 @@
+lsp-plugins-lv2

--- a/srcpkgs/lsp-plugins-ladspa
+++ b/srcpkgs/lsp-plugins-ladspa
@@ -1,0 +1,1 @@
+lsp-plugins-lv2

--- a/srcpkgs/lsp-plugins-lv2/patches/00-patch-all.patch
+++ b/srcpkgs/lsp-plugins-lv2/patches/00-patch-all.patch
@@ -1,0 +1,2098 @@
+diff --git a/.gitignore b/.gitignore
+index 5bc0ecb..4a1edec 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -3,6 +3,7 @@
+ /design/*
+ /.builconfig/*
+ /.build/*
++/.host_build/*
+ /.buildconfig/*
+ /.test/*
+ /.release/*
+diff --git a/.gitmodules b/.gitmodules
+index ac5ea32..4480c1f 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -1,3 +1,3 @@
+ [submodule "Polynomial-Wiener-Hammerstein"]
+ 	path = Polynomial-Wiener-Hammerstein
+-	url = ../../CrocoDuckoDucks/Polynomial-Wiener-Hammerstein.git
++	url = https://github.com/CrocoDuckoDucks/Polynomial-Wiener-Hammerstein
+diff --git a/Makefile b/Makefile
+index 2d9cb79..70cb6a4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ # Common definitions
+ RELEASE_TEXT            = LICENSE.txt README.txt CHANGELOG.txt
+ RELEASE_SRC             = $(RELEASE_TEXT) src build-*.sh include res Makefile release.sh
+@@ -18,8 +24,10 @@ export RESDIR           = ${CURDIR}/res
+ export RELEASE          = ${CURDIR}/.release
+ export RELEASE_BIN      = $(RELEASE)/$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ export BUILDDIR         = ${CURDIR}/.build
++export HOST_BUILDDIR    = ${CURDIR}/.host_build
+ export TESTDIR          = ${CURDIR}/.test
+ OBJDIR                  = $(BUILDDIR)
++export HOST_OBJDIR      = $(HOST_BUILDDIR)
+ 
+ # Installation locations
+ BIN_PATH               ?= $(PREFIX)/bin
+@@ -35,20 +43,23 @@ VST_PATH                = $(LIB_PATH)/vst
+ export BASEDIR          = ${CURDIR}
+ 
+ # Objects
+-export OBJ_CORE         = $(OBJDIR)/core.o
+-export OBJ_DSP          = $(OBJDIR)/dsp.o
+-export OBJ_CTL_CORE     = $(OBJDIR)/ctl_core.o
+-export OBJ_TK_CORE      = $(OBJDIR)/tk_core.o
+-export OBJ_WS_CORE      = $(OBJDIR)/ws_core.o
+-export OBJ_WS_X11_CORE  = $(OBJDIR)/ws_x11_core.o
+-export OBJ_UI_CORE      = $(OBJDIR)/ui_core.o
+-export OBJ_RES_CORE     = $(OBJDIR)/res_core.o
+-export OBJ_TEST_CORE    = $(OBJDIR)/test_core.o
+-export OBJ_TESTING_CORE = $(OBJDIR)/testing_core.o
+-export OBJ_PLUGINS      = $(OBJDIR)/plugins.o
+-export OBJ_PLUGIN_UIS	= $(OBJDIR)/plugin_uis.o
+-export OBJ_METADATA     = $(OBJDIR)/metadata.o
+-export OBJ_FILES        = $(OBJ_CORE) $(OBJ_UI_CORE) $(OBJ_RES_CORE) $(OBJ_PLUGINS) $(OBJ_METADATA)
++export OBJ_CORE          = $(OBJDIR)/core.o
++export HOST_OBJ_CORE     = $(HOST_OBJDIR)/core.o
++export OBJ_DSP           = $(OBJDIR)/dsp.o
++export HOST_OBJ_DSP      = $(HOST_OBJDIR)/dsp.o
++export OBJ_CTL_CORE      = $(OBJDIR)/ctl_core.o
++export OBJ_TK_CORE       = $(OBJDIR)/tk_core.o
++export OBJ_WS_CORE       = $(OBJDIR)/ws_core.o
++export OBJ_WS_X11_CORE   = $(OBJDIR)/ws_x11_core.o
++export OBJ_UI_CORE       = $(OBJDIR)/ui_core.o
++export OBJ_RES_CORE      = $(OBJDIR)/res_core.o
++export OBJ_TEST_CORE     = $(OBJDIR)/test_core.o
++export OBJ_TESTING_CORE  = $(OBJDIR)/testing_core.o
++export OBJ_PLUGINS       = $(OBJDIR)/plugins.o
++export OBJ_PLUGIN_UIS	 = $(OBJDIR)/plugin_uis.o
++export OBJ_METADATA      = $(OBJDIR)/metadata.o
++export HOST_OBJ_METADATA = $(HOST_OBJDIR)/metadata.o
++export OBJ_FILES         = $(OBJ_CORE) $(OBJ_UI_CORE) $(OBJ_RES_CORE) $(OBJ_PLUGINS) $(OBJ_METADATA)
+ 
+ # Libraries
+ export LIB_LADSPA       = $(OBJDIR)/$(ARTIFACT_ID)-ladspa.so
+@@ -62,11 +73,14 @@ export BIN_PROFILE      = $(OBJDIR)/$(ARTIFACT_ID)-profile
+ export BIN_TEST         = $(OBJDIR)/$(ARTIFACT_ID)-test
+ 
+ # Utils
+-export UTL_GENTTL       = $(OBJDIR)/lv2_genttl.exe
+-export UTL_VSTMAKE      = $(OBJDIR)/vst_genmake.exe
+-export UTL_JACKMAKE     = $(OBJDIR)/jack_genmake.exe
+-export UTL_GENPHP       = $(OBJDIR)/gen_php.exe
+-export UTL_RESGEN       = $(OBJDIR)/gen_resources.exe
++ifeq ($(BUILD_SYSTEM),Windows)
++  BIN_SUFFIX := .exe
++endif
++export UTL_GENTTL       = $(HOST_OBJDIR)/lv2_genttl$(BIN_SUFFIX)
++export UTL_VSTMAKE      = $(HOST_OBJDIR)/vst_genmake$(BIN_SUFFIX)
++export UTL_JACKMAKE     = $(HOST_OBJDIR)/jack_genmake$(BIN_SUFFIX)
++export UTL_GENPHP       = $(HOST_OBJDIR)/gen_php$(BIN_SUFFIX)
++export UTL_RESGEN       = $(HOST_OBJDIR)/gen_resources$(BIN_SUFFIX)
+ export UTL_FILES        = $(UTL_GENTTL) $(UTL_VSTMAKE) $(UTL_GENPHP) $(UTL_RESGEN)
+ 
+ # Files
+@@ -84,7 +98,7 @@ SRC_ID                 := $(ARTIFACT_ID)-src-$(LSP_VERSION)
+ DOC_ID                 := $(ARTIFACT_ID)-doc-$(LSP_VERSION)
+ 
+ .DEFAULT_GOAL          := all
+-.PHONY: all experimental trace debug tracefile debugfile profile gdb test testdebug testprofile compile test_compile
++.PHONY: all experimental trace debug tracefile debugfile profile gdb test check testdebug testprofile compile test_compile
+ .PHONY: compile_info
+ .PHONY: install install_ladspa install_lv2 install_vst install_jack install_doc install_xdg
+ .PHONY: uninstall uninstall_ladspa uninstall_lv2 uninstall_vst uninstall_jack uninstall_doc uninstall_xdg
+@@ -98,6 +112,7 @@ all: export CXXFLAGS        += -O2 -DLSP_NO_EXPERIMENTAL
+ all: export EXE_FLAGS       += -pie -fPIE
+ all: compile
+ 
++
+ experimental: export CFLAGS += -O2
+ experimental: export CXXFLAGS += -O2
+ experimental: compile
+@@ -115,9 +130,13 @@ test: export MAKE_OPTS      += LSP_TESTING=1
+ test: export BUILD_MODULES   = jack
+ test: test_compile
+ 
++# Run unit tests
++check: test
++	.test/lsp-plugins-test utest
++
+ testdebug: OBJDIR                 = $(TESTDIR)
+-testdebug: export CFLAGS         += -O0 -DLSP_TESTING -DLSP_TRACE -g3 -fstack-protector
+-testdebug: export CXXFLAGS       += -O0 -DLSP_TESTING -DLSP_TRACE -g3 -fstack-protector
++testdebug: export CFLAGS         += -Og -DLSP_TESTING -DLSP_TRACE -g3 -fstack-protector
++testdebug: export CXXFLAGS       += -Og -DLSP_TESTING -DLSP_TRACE -g3 -fstack-protector
+ testdebug: export EXE_TEST_FLAGS += -g3
+ testdebug: export MAKE_OPTS      += LSP_TESTING=1
+ testdebug: export BUILD_MODULES   = jack
+@@ -142,8 +161,11 @@ debugfile: export CFLAGS    += -DLSP_TRACEFILE
+ debugfile: export CXXFLAGS  += -DLSP_TRACEFILE
+ debugfile: debug
+ 
+-gdb: export CFLAGS          += -O0 -g3 -DLSP_TRACE
+-gdb: export CXXFLAGS        += -O0 -g3 -DLSP_TRACE
++gdb: export CFLAGS          = -std=c++98 -Og -fno-inline -g3 -DLSP_TRACE
++gdb: export CXXFLAGS        = -std=c++98 -Og -fno-inline -g3 -DLSP_TRACE
++gdb: export HOST_CXXFLAGS   = -std=c++98 -Og -fno-inline -g3 -DLSP_TRACE
++gdb: export EXE_FLAGS       = -g3
++gdb: export HOST_EXE_FLAGS  = -g3
+ gdb: compile
+ 
+ profile: export CFLAGS      += -g -pg -DLSP_PROFILING -no-pie -fno-pie -fPIC
+@@ -155,35 +177,53 @@ profile: compile
+ compile_info:
+ 	@echo "-------------------------------------------------------------------------------"
+ 	@echo "Building binaries"
+-	@echo "  target architecture : $(BUILD_PROFILE)"
+-	@echo "  target platform     : $(BUILD_PLATFORM)"
+-	@echo "  target system       : $(BUILD_SYSTEM)"
+-	@echo "  compiler            : $(BUILD_COMPILER)"
+-	@echo "  modules             : $(BUILD_MODULES)"
+-	@echo "  UI                  : LV2=$(LV2_UI), VST=$(VST_UI)"
+-	@echo "  3D rendering        : $(BUILD_R3D_BACKENDS)"
+-	@echo "  build directory     : $(OBJDIR)"
++	@echo "  platform             : $(BUILD_PLATFORM)"
++	@echo "  system               : $(BUILD_SYSTEM)"
++	@echo "  target compiler      : $(CXX)"
++	@echo "  target architecture  : $(BUILD_PROFILE)"
++	@echo "  modules              : $(BUILD_MODULES)"
++	@echo "  UI                   : LV2=$(LV2_UI), VST=$(VST_UI)"
++	@echo "  3D rendering         : $(BUILD_R3D_BACKENDS)"
++	@echo "  build directory      : $(OBJDIR)"
+ 	@echo "-------------------------------------------------------------------------------"
+ 
+-compile: | compile_info
+-	@mkdir -p $(OBJDIR)/src
+-	@mkdir -p $(CFGDIR)
+-	@test -f "$(CFGDIR)/$(PREFIX_FILE)" || echo -n "$(PREFIX)" > "$(CFGDIR)/$(PREFIX_FILE)"
+-	@test -f "$(CFGDIR)/$(MODULES_FILE)" || echo -n "$(BUILD_MODULES)" > "$(CFGDIR)/$(MODULES_FILE)"
+-	@test -f "$(CFGDIR)/$(BUILD_PROFILE)" || echo -n "$(BUILD_PROFILE)" > "$(CFGDIR)/$(BUILD_PROFILE_FILE)"
+-	@test -f "$(CFGDIR)/$(R3D_BACKENDS_FILE)" || echo -n "$(BUILD_R3D_BACKENDS)" > "$(CFGDIR)/$(R3D_BACKENDS_FILE)"
+-	@$(MAKE) $(MAKE_OPTS) -C src all OBJDIR=$(OBJDIR)/src
++compile: utils | compile_info
++	mkdir -p $(OBJDIR)/src
++	mkdir -p $(CFGDIR)
++	test -f "$(CFGDIR)/$(PREFIX_FILE)" || echo -n "$(PREFIX)" > "$(CFGDIR)/$(PREFIX_FILE)"
++	test -f "$(CFGDIR)/$(MODULES_FILE)" || echo -n "$(BUILD_MODULES)" > "$(CFGDIR)/$(MODULES_FILE)"
++	test -f "$(CFGDIR)/$(BUILD_PROFILE)" || echo -n "$(BUILD_PROFILE)" > "$(CFGDIR)/$(BUILD_PROFILE_FILE)"
++	test -f "$(CFGDIR)/$(R3D_BACKENDS_FILE)" || echo -n "$(BUILD_R3D_BACKENDS)" > "$(CFGDIR)/$(R3D_BACKENDS_FILE)"
++	$(MAKE) $(MAKE_OPTS) -C src all OBJDIR=$(OBJDIR)/src
+ 	@echo "Build OK"
+ 	
+-test_compile: | compile_info
+-	@mkdir -p $(OBJDIR)/src
+-	@$(MAKE) $(MAKE_OPTS) -C src all OBJDIR=$(OBJDIR)/src
++test_compile: utils | compile_info
++	mkdir -p $(OBJDIR)/src
++	$(MAKE) $(MAKE_OPTS) -C src all OBJDIR=$(OBJDIR)/src
+ 	@echo "Test Build OK"
+ 
++utils: export BUILD_PROFILE=$(HOST_BUILD_PROFILE)
++utils: export OBJDIR=$(HOST_OBJDIR)
++utils: export OBJ_CORE=$(HOST_OBJ_CORE)
++utils: export OBJ_DSP=$(HOST_OBJ_DSP)
++utils: export OBJ_METADATA=$(HOST_OBJ_METADATA)
++utils: export CXX=$(HOST_CXX)
++utils: export CXXFLAGS=$(HOST_CXXFLAGS)
++utils: export LD=$(HOST_LD)
++utils: export SNDFILE_HEADERS=$(HOST_SNDFILE_HEADERS)
++utils: export SNDFILE_LIBS=$(HOST_SNDFILE_LIBS)
++utils: export LV2_HEADERS=$(HOST_LV2_HEADERS)
++utils: export LV2_LIBS=$(HOST_LV2_LIBS)
++utils: | compile_info
++	mkdir -p $(HOST_OBJDIR)/src/utils
++	$(MAKE) $(MAKE_OPTS) -C src utils
++	@echo "Utils Build OK"
++
+ clean:
+-	@-rm -rf $(BUILDDIR)
+-	@-rm -rf $(TESTDIR)
+-	@-rm -rf $(CFGDIR)
++	rm -rf $(BUILDDIR)
++	rm -rf $(HOST_BUILDDIR)
++	rm -rf $(TESTDIR)
++	rm -rf $(CFGDIR)
+ 	@echo "Clean OK"
+ 
+ # Build targets
+@@ -209,63 +249,63 @@ install: $(INSTALLATIONS)
+ 
+ install_ladspa: all
+ 	@echo "Installing LADSPA plugins to $(DESTDIR)$(LADSPA_PATH)/"
+-	@mkdir -p $(DESTDIR)$(LADSPA_PATH)
+-	@$(INSTALL) $(LIB_LADSPA) $(DESTDIR)$(LADSPA_PATH)/
++	mkdir -p $(DESTDIR)$(LADSPA_PATH)
++	$(INSTALL) $(LIB_LADSPA) $(DESTDIR)$(LADSPA_PATH)/
+ 	
+ install_lv2: all
+ 	@echo "Installing LV2 plugins to $(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2"
+-	@mkdir -p "$(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2"
+-	@$(INSTALL) $(LIB_LV2) "$(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2/"
+-	@test ! "$(BUILD_R3D_BACKENDS)" || $(INSTALL) $(OBJDIR)/$(R3D_ARTIFACT_ID)*.so $(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2/
+-	@$(UTL_GENTTL) "$(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2"
++	mkdir -p "$(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2"
++	$(INSTALL) $(LIB_LV2) "$(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2/"
++	test ! "$(BUILD_R3D_BACKENDS)" || $(INSTALL) $(OBJDIR)/$(R3D_ARTIFACT_ID)*.so $(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2/
++	$(UTL_GENTTL) "$(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2"
+ 	
+ install_vst: all
+ 	@echo "Installing VST plugins to $(DESTDIR)$(VST_PATH)/$(VST_ID)"
+-	@mkdir -p "$(DESTDIR)$(VST_PATH)/$(VST_ID)"
+-	@$(INSTALL) $(LIB_VST) "$(DESTDIR)$(VST_PATH)/$(VST_ID)/"
+-	@test ! "$(BUILD_R3D_BACKENDS)" || $(INSTALL) $(OBJDIR)/$(R3D_ARTIFACT_ID)*.so $(DESTDIR)$(VST_PATH)/$(VST_ID)/
+-	@$(INSTALL) $(OBJDIR)/src/vst/*.so $(DESTDIR)$(VST_PATH)/$(VST_ID)/
++	mkdir -p "$(DESTDIR)$(VST_PATH)/$(VST_ID)"
++	$(INSTALL) $(LIB_VST) "$(DESTDIR)$(VST_PATH)/$(VST_ID)/"
++	test ! "$(BUILD_R3D_BACKENDS)" || $(INSTALL) $(OBJDIR)/$(R3D_ARTIFACT_ID)*.so $(DESTDIR)$(VST_PATH)/$(VST_ID)/
++	$(INSTALL) $(OBJDIR)/src/vst/*.so $(DESTDIR)$(VST_PATH)/$(VST_ID)/
+ 
+ install_jack: all
+ 	@echo "Installing JACK core to $(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)"
+-	@mkdir -p "$(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)"
+-	@$(INSTALL) $(LIB_JACK) "$(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)/"
+-	@test ! "$(BUILD_R3D_BACKENDS)" || $(INSTALL) $(OBJDIR)/$(R3D_ARTIFACT_ID)*.so "$(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)/"
++	mkdir -p "$(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)"
++	$(INSTALL) $(LIB_JACK) "$(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)/"
++	test ! "$(BUILD_R3D_BACKENDS)" || $(INSTALL) $(OBJDIR)/$(R3D_ARTIFACT_ID)*.so "$(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)/"
+ 	@echo "Installing JACK standalone plugins to $(DESTDIR)$(BIN_PATH)"
+-	@mkdir -p "$(DESTDIR)$(BIN_PATH)"
+-	@$(MAKE) $(MAKE_OPTS) -C $(OBJDIR)/src/jack install TARGET_PATH="$(DESTDIR)$(BIN_PATH)" INSTALL="$(INSTALL)"
++	mkdir -p "$(DESTDIR)$(BIN_PATH)"
++	$(MAKE) $(MAKE_OPTS) -C $(OBJDIR)/src/jack install TARGET_PATH="$(DESTDIR)$(BIN_PATH)" INSTALL="$(INSTALL)"
+ 
+ install_xdg:
+ 	@echo "Installing desktop icons to $(DESTDIR)$(SHARE_PATH)/applications"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/applications"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/desktop-directories"
+-	@mkdir -p "$(DESTDIR)$(ETC_PATH)/xdg/menus/applications-merged"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/scalable/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/16x16/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/22x22/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/24x24/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/32x32/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/48x48/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/64x64/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/128x128/apps"
+-	@mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/256x256/apps"
+-	@cp res/xdg/*.desktop "$(DESTDIR)$(SHARE_PATH)/applications/"
+-	@cp res/xdg/lsp-plugins.directory "$(DESTDIR)$(SHARE_PATH)/desktop-directories/"
+-	@cp res/xdg/lsp-plugins.menu "$(DESTDIR)$(ETC_PATH)/xdg/menus/applications-merged/"
+-	@cp -f res/icons/$(ARTIFACT_ID)-16.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/16x16/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-22.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/22x22/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-24.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/24x24/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-32.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/32x32/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-48.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/48x48/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-64.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/64x64/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-128.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/128x128/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-256.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/256x256/apps/$(ARTIFACT_ID).png"
+-	@cp -f res/icons/$(ARTIFACT_ID)-exp.svg "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/scalable/apps/$(ARTIFACT_ID).svg"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/applications"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/desktop-directories"
++	mkdir -p "$(DESTDIR)$(ETC_PATH)/xdg/menus/applications-merged"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/scalable/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/16x16/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/22x22/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/24x24/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/32x32/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/48x48/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/64x64/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/128x128/apps"
++	mkdir -p "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/256x256/apps"
++	cp res/xdg/*.desktop "$(DESTDIR)$(SHARE_PATH)/applications/"
++	cp res/xdg/lsp-plugins.directory "$(DESTDIR)$(SHARE_PATH)/desktop-directories/"
++	cp res/xdg/lsp-plugins.menu "$(DESTDIR)$(ETC_PATH)/xdg/menus/applications-merged/"
++	cp -f res/icons/$(ARTIFACT_ID)-16.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/16x16/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-22.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/22x22/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-24.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/24x24/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-32.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/32x32/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-48.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/48x48/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-64.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/64x64/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-128.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/128x128/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-256.png "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/256x256/apps/$(ARTIFACT_ID).png"
++	cp -f res/icons/$(ARTIFACT_ID)-exp.svg "$(DESTDIR)$(SHARE_PATH)/icons/hicolor/scalable/apps/$(ARTIFACT_ID).svg"
+ 
+ install_doc: all
+ 	@echo "Installing documentation to $(DESTDIR)$(DOC_PATH)"
+-	@mkdir -p $(DESTDIR)$(DOC_PATH)/$(ARTIFACT_ID)
+-	@cp -r $(OBJDIR)/html/* $(DESTDIR)$(DOC_PATH)/$(ARTIFACT_ID)
++	mkdir -p $(DESTDIR)$(DOC_PATH)/$(ARTIFACT_ID)
++	cp -r $(OBJDIR)/html/* $(DESTDIR)$(DOC_PATH)/$(ARTIFACT_ID)
+ 
+ # Release targets
+ dbg_release: export CFLAGS        += -DLSP_TRACE -O2
+@@ -279,67 +319,67 @@ release: $(RELEASES)
+ 
+ release_prepare: all
+ 	@echo "Releasing plugins for architecture $(BUILD_PROFILE)"
+-	@mkdir -p $(RELEASE)
+-	@mkdir -p $(DESTDIR)
++	mkdir -p $(RELEASE)
++	mkdir -p $(DESTDIR)
+ 	
+ release_ladspa: DESTDIR=$(RELEASE_BIN)/$(LADSPA_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ release_ladspa: | release_prepare install_ladspa
+ 	@echo "Releasing LADSPA binaries"
+-	@cp $(RELEASE_TEXT) $(DESTDIR)/
+-	@tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(LADSPA_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(LADSPA_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+-	@rm -rf $(DESTDIR)
++	cp $(RELEASE_TEXT) $(DESTDIR)/
++	tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(LADSPA_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(LADSPA_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
++	rm -rf $(DESTDIR)
+ 	
+ release_lv2: DESTDIR=$(RELEASE_BIN)/$(LV2_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ release_lv2: | release_prepare install_lv2
+ 	@echo "Releasing LV2 binaries"
+-	@cp $(RELEASE_TEXT) $(DESTDIR)/
+-	@tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(LV2_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(LV2_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+-	@rm -rf $(DESTDIR)
++	cp $(RELEASE_TEXT) $(DESTDIR)/
++	tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(LV2_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(LV2_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
++	rm -rf $(DESTDIR)
+ 	
+ release_vst: DESTDIR=$(RELEASE_BIN)/$(VST_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ release_vst: | release_prepare install_vst
+ 	@echo "Releasing VST binaries"
+-	@cp $(RELEASE_TEXT) $(DESTDIR)/
+-	@tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(VST_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(VST_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+-	@rm -rf $(DESTDIR)
++	cp $(RELEASE_TEXT) $(DESTDIR)/
++	tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(VST_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(VST_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
++	rm -rf $(DESTDIR)
+ 	
+ release_jack: DESTDIR=$(RELEASE_BIN)/$(JACK_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ release_jack: | release_prepare install_jack
+ 	@echo "Releasing JACK binaries"
+-	@cp $(RELEASE_TEXT) $(DESTDIR)/
+-	@tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(JACK_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(JACK_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+-	@rm -rf $(DESTDIR)
++	cp $(RELEASE_TEXT) $(DESTDIR)/
++	tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(JACK_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(JACK_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
++	rm -rf $(DESTDIR)
+ 
+ release_profile: DESTDIR=$(RELEASE_BIN)/$(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ release_profile: | release_prepare
+ 	@echo "Releasing PROFILE binaries"
+-	@$(INSTALL) $(BIN_PROFILE) $(DESTDIR)/
+-	@cp $(RELEASE_TEXT) $(DESTDIR)/
+-	@tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+-	@rm -rf $(RELEASE_BIN)/$(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
++	$(INSTALL) $(BIN_PROFILE) $(DESTDIR)/
++	cp $(RELEASE_TEXT) $(DESTDIR)/
++	tar -C $(RELEASE_BIN) -czf $(RELEASE_BIN)/$(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE).tar.gz $(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
++	rm -rf $(RELEASE_BIN)/$(PROFILE_ID)-$(BUILD_SYSTEM)-$(BUILD_PROFILE)
+ 
+ release_src: DESTDIR=$(RELEASE)/$(SRC_ID)
+ release_src: | release_prepare
+ 	@echo "Releasing source code binaries"
+-	@mkdir -p $(DESTDIR)
+-	@mkdir -p $(DESTDIR)/scripts
+-	@cp -R $(RELEASE_SRC) $(DESTDIR)/
+-	@cp -R $(RELEASE_SCRIPTS) $(DESTDIR)/scripts/
+-	@tar -C $(RELEASE) -czf $(RELEASE)/$(SRC_ID).tar.gz $(SRC_ID)
+-	@rm -rf $(DESTDIR)
++	mkdir -p $(DESTDIR)
++	mkdir -p $(DESTDIR)/scripts
++	cp -R $(RELEASE_SRC) $(DESTDIR)/
++	cp -R $(RELEASE_SCRIPTS) $(DESTDIR)/scripts/
++	tar -C $(RELEASE) -czf $(RELEASE)/$(SRC_ID).tar.gz $(SRC_ID)
++	rm -rf $(DESTDIR)
+ 
+ release_doc: DESTDIR=$(RELEASE)/$(DOC_ID)
+ release_doc: | release_prepare
+ 	@echo "Releasing documentation"
+-	@mkdir -p $(DESTDIR)
+-	@cp -r $(OBJDIR)/html/* $(DESTDIR)/
+-	@cp $(RELEASE_TEXT) $(DESTDIR)/
+-	@tar -C $(RELEASE) -czf $(RELEASE)/$(DOC_ID).tar.gz $(DOC_ID)
+-	@rm -rf $(DESTDIR)
++	mkdir -p $(DESTDIR)
++	cp -r $(OBJDIR)/html/* $(DESTDIR)/
++	cp $(RELEASE_TEXT) $(DESTDIR)/
++	tar -C $(RELEASE) -czf $(RELEASE)/$(DOC_ID).tar.gz $(DOC_ID)
++	rm -rf $(DESTDIR)
+ 
+ # Unrelease target
+ unrelease: clean
+-	@-rm -rf $(RELEASE)
++	rm -rf $(RELEASE)
+ 	@echo "Unrelease OK"
+ 
+ # Uninstall target
+@@ -348,41 +388,41 @@ uninstall: $(UNINSTALLATIONS)
+ 	
+ uninstall_ladspa:
+ 	@echo "Uninstalling LADSPA"
+-	@-rm -f $(DESTDIR)$(LADSPA_PATH)/$(ARTIFACT_ID)-ladspa.so
++	rm -f $(DESTDIR)$(LADSPA_PATH)/$(ARTIFACT_ID)-ladspa.so
+ 	
+ uninstall_lv2:
+ 	@echo "Uninstalling LV2"
+-	@-rm -rf $(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2
++	rm -rf $(DESTDIR)$(LV2_PATH)/$(ARTIFACT_ID).lv2
+ 	
+ uninstall_vst:
+ 	@echo "Uninstalling VST"
+-	@-rm -f $(DESTDIR)$(VST_PATH)/$(ARTIFACT_ID)-vst-*.so
+-	@-rm -rf $(DESTDIR)$(VST_PATH)/$(ARTIFACT_ID)-lxvst-*
+-	@-rm -rf $(DESTDIR)$(VST_PATH)/$(VST_ID)
++	rm -f $(DESTDIR)$(VST_PATH)/$(ARTIFACT_ID)-vst-*.so
++	rm -rf $(DESTDIR)$(VST_PATH)/$(ARTIFACT_ID)-lxvst-*
++	rm -rf $(DESTDIR)$(VST_PATH)/$(VST_ID)
+ 	
+ uninstall_jack:
+ 	@echo "Uninstalling JACK"
+-	@-rm -f $(DESTDIR)$(BIN_PATH)/$(ARTIFACT_ID)-*
+-	@-rm -f $(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)-jack-core-*.so
+-	@-rm -f $(DESTDIR)$(LIB_PATH)/$(R3D_ARTIFACT_ID)
+-	@-rm -rf $(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)
++	rm -f $(DESTDIR)$(BIN_PATH)/$(ARTIFACT_ID)-*
++	rm -f $(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)-jack-core-*.so
++	rm -f $(DESTDIR)$(LIB_PATH)/$(R3D_ARTIFACT_ID)
++	rm -rf $(DESTDIR)$(LIB_PATH)/$(ARTIFACT_ID)
+ 
+ uninstall_xdg:
+ 	@echo "Uninstalling desktop icons"
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/applications/in.lsp_plug.*.desktop
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/desktop-directories/lsp-plugins.directory
+-	@-rm -f $(DESTDIR)$(ETC_PATH)/xdg/menus/applications-merged/lsp-plugins.menu
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/16x16/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/22x22/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/24x24/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/32x32/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/48x48/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/64x64/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/128x128/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/256x256/apps/$(ARTIFACT_ID).*
+-	@-rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/scalable/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/applications/in.lsp_plug.*.desktop
++	rm -f $(DESTDIR)$(SHARE_PATH)/desktop-directories/lsp-plugins.directory
++	rm -f $(DESTDIR)$(ETC_PATH)/xdg/menus/applications-merged/lsp-plugins.menu
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/16x16/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/22x22/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/24x24/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/32x32/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/48x48/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/64x64/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/128x128/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/256x256/apps/$(ARTIFACT_ID).*
++	rm -f $(DESTDIR)$(SHARE_PATH)/icons/hicolor/scalable/apps/$(ARTIFACT_ID).*
+ 
+ uninstall_doc:
+ 	@echo "Uninstalling DOC"
+-	@-rm -rf $(DESTDIR)$(DOC_PATH)/$(ARTIFACT_ID)
++	rm -rf $(DESTDIR)$(DOC_PATH)/$(ARTIFACT_ID)
+ 
+diff --git a/TODO.txt b/TODO.txt
+index 4976293..f8562ef 100644
+--- a/TODO.txt
++++ b/TODO.txt
+@@ -28,6 +28,12 @@
+ - Added possibility to change themes in runtime.
+ - Complicated plugin UIs now allow to switch between Advanced and Novice modes.
+ 
++=== 1.1.31 ===
++
++* Fixed X11 error handling routine that could crash under certain conditions.
++* Better support for musl libc (contributed by Artur Sinila).
++* Added support of VERBOSE parameter for build system (contributed by Artur Sinila).
++
+ *******************************************************************************
+ * New plugin check list before release
+ *******************************************************************************
+diff --git a/include/common/types.h b/include/common/types.h
+index dd1816e..59c794e 100644
+--- a/include/common/types.h
++++ b/include/common/types.h
+@@ -563,6 +563,12 @@
+     #define MINIMUM_ALIGN                   DEFAULT_ALIGN
+ #endif /* DEFAULT_ALIGN */
+ 
++//-----------------------------------------------------------------------------
++// Detect some libraries
++#ifdef __GLIBC__
++    #define USE_GLIBC                           __GLIBC__
++#endif /* GLIBC */
++
+ //-----------------------------------------------------------------------------
+ // Type definitions
+ __IF_32( typedef        uint32_t            umword_t );
+diff --git a/include/data/cvector.h b/include/data/cvector.h
+index eccc94a..17fe119 100644
+--- a/include/data/cvector.h
++++ b/include/data/cvector.h
+@@ -25,6 +25,7 @@
+ #include <stddef.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/types.h>
+ 
+ #define CVECTOR_GROW        16
+ 
+diff --git a/include/metadata/metadata.h b/include/metadata/metadata.h
+index 0efaa9d..e009750 100644
+--- a/include/metadata/metadata.h
++++ b/include/metadata/metadata.h
+@@ -73,10 +73,18 @@
+     #define LSP_ARCHITECTURE                                "unknown"
+ #endif /* ARCH */
+ 
++#define STRINGIFY_(x) #x
++#define STRINGIFY(x) STRINGIFY_(x)
++
+ #ifndef LSP_MAIN_VERSION
+     #define LSP_MAIN_VERSION                                "0.0.0"
++#else
++    #define LSP_MAIN_VERSION_STR STRINGIFY(LSP_MAIN_VERSION)
++    #undef LSP_MAIN_VERSION
++    #define LSP_MAIN_VERSION LSP_MAIN_VERSION_STR
+ #endif /* LSP_MAIN_VERSION */
+ 
++
+ #define LSP_LV2_LATENCY_PORT                            "out_latency"
+ #define LSP_LV2_ATOM_PORT_IN                            "in_ui"
+ #define LSP_LV2_MIDI_PORT_IN                            "in_midi"
+@@ -86,7 +94,7 @@
+ #define LSP_LV2_OSC_PORT_OUT                            "out_osc"
+ 
+ #ifdef LSP_INSTALL_PREFIX
+-    #define LSP_LIB_PREFIX(x)       LSP_INSTALL_PREFIX x
++    #define LSP_LIB_PREFIX(x)       STRINGIFY(LSP_INSTALL_PREFIX) x
+ #else
+     #define LSP_LIB_PREFIX(x)       x
+ #endif /* PREFIX */
+diff --git a/include/test/main/executor.h b/include/test/main/executor.h
+index 0faf73f..5a0c016 100644
+--- a/include/test/main/executor.h
++++ b/include/test/main/executor.h
+@@ -633,7 +633,7 @@ namespace lsp
+     }
+ #endif /* PLATFORM_WINDOWS */
+ 
+-#ifdef PLATFORM_LINUX
++#if defined(PLATFORM_LINUX) && defined(USE_GLIBC)
+     void TestExecutor::start_memcheck(test::Test *v)
+     {
+         if (!pCfg->mtrace)
+diff --git a/include/test/main/types.h b/include/test/main/types.h
+index ef15800..0c5d7c2 100644
+--- a/include/test/main/types.h
++++ b/include/test/main/types.h
+@@ -42,7 +42,7 @@
+     #include <fcntl.h>
+ #endif /* PLATFORM_UNIX_COMPATIBLE */
+ 
+-#ifdef PLATFORM_LINUX
++#if defined(PLATFORM_LINUX) && defined(USE_GLIBC)
+     #include <mcheck.h>
+ #endif /* PLATFORM_LINUX */
+ 
+diff --git a/include/testing/mtest/3d/common/X11Renderer.h b/include/testing/mtest/3d/common/X11Renderer.h
+index e8ec205..f0a51e2 100644
+--- a/include/testing/mtest/3d/common/X11Renderer.h
++++ b/include/testing/mtest/3d/common/X11Renderer.h
+@@ -30,7 +30,7 @@
+ #include <X11/X.h>
+ #include <X11/Xlib.h>
+ #include <X11/Xutil.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ #include <rendering/backend.h>
+ #include <core/ipc/Library.h>
+diff --git a/scripts/make/configure.mk b/scripts/make/configure.mk
+index 09aee9a..1f3cf7b 100644
+--- a/scripts/make/configure.mk
++++ b/scripts/make/configure.mk
+@@ -14,7 +14,8 @@ ifndef BUILD_R3D_BACKENDS
+   BUILD_R3D_BACKENDS     := $(shell if (test -f "$(CFGDIR)/$(R3D_BACKENDS_FILE)" )  then cat "$(CFGDIR)/$(R3D_BACKENDS_FILE)" 2>/dev/null; else echo "glx"; fi;)
+ endif
+ 
+-BUILD_COMPILER         := $(shell $(CC) --version | head -n 1 || echo "unknown")
++BUILD_COMPILER         := $(shell $(CXX) --version | head -n 1 || echo "unknown")
++HOST_BUILD_COMPILER    := $(shell $(HOST_CXX) --version | head -n 1 || echo "unknown")
+ 
+ export BUILD_MODULES
+ export BUILD_R3D_BACKENDS
+@@ -23,7 +24,7 @@ export BUILD_R3D_BACKENDS
+ INSTALLATIONS           =
+ UNINSTALLATIONS         = uninstall_xdg
+ RELEASES                =
+-INCLUDE                 = -I"${CURDIR}/include"
++INCLUDE                 := -I"${CURDIR}/include"
+ 
+ ifeq ($(findstring ladspa,$(BUILD_MODULES)),ladspa)
+   INSTALLATIONS          += install_ladspa
+@@ -63,61 +64,64 @@ LD_ARCH         =
+ CC_ARCH         =
+ 
+ # Build profile
+-ifeq ($(BUILD_PROFILE),i586)
+-  CC_ARCH          = -m32
+-  ifeq ($(BUILD_PLATFORM), Linux)
+-    LD_ARCH          = -m elf_i386
++# SKIP_CC_LD_ARCH is set by distro package build systems
++# which manage cross-compilation flags on their own
++ifeq ($(SKIP_CC_LD_ARCH),)
++  ifeq ($(BUILD_PROFILE),i586)
++    CC_ARCH          = -m32
++    ifeq ($(BUILD_PLATFORM), Linux)
++      LD_ARCH          = -m elf_i386
++    endif
++    ifeq ($(BUILD_PLATFORM), BSD)
++      LD_ARCH          = -m elf_i386_fbsd
++    endif
+   endif
++  
++  ifeq ($(BUILD_PROFILE),x86_64)
++    CC_ARCH          = -m64
++    ifeq ($(BUILD_PLATFORM), Linux)
++      LD_ARCH          = -m elf_x86_64
++    endif
++    ifeq ($(BUILD_PLATFORM), BSD)
++      LD_ARCH          = -m elf_x86_64_fbsd
++    endif
++  endif
++  
+   ifeq ($(BUILD_PLATFORM), BSD)
+-    LD_ARCH          = -m elf_i386_fbsd
++    INCLUDE          += -I/usr/local/include
++    ifeq ($(BUILD_PROFILE),arm)
++      CC_ARCH          = -marm
++      ifneq ($(LD_PATH),)
++        CC_ARCH          += -Wl,-rpath=$(LD_PATH)
++      endif
++    endif
+   endif
+-endif
+-
+-ifeq ($(BUILD_PROFILE),x86_64)
+-  CC_ARCH          = -m64
+-  ifeq ($(BUILD_PLATFORM), Linux)
+-    LD_ARCH          = -m elf_x86_64
++  
++  ifeq ($(BUILD_PROFILE),armv6a)
++    CC_ARCH          = -march=armv6-a -marm
+   endif
+-  ifeq ($(BUILD_PLATFORM), BSD)
+-    LD_ARCH          = -m elf_x86_64_fbsd
++  
++  ifeq ($(BUILD_PROFILE),armv7a)
++    CC_ARCH          = -march=armv7-a -marm
+   endif
+-endif
+-
+-ifeq ($(BUILD_PLATFORM), BSD)
+-  INCLUDE          += -I/usr/local/include
+-  ifeq ($(BUILD_PROFILE),arm)
++  
++  ifeq ($(BUILD_PROFILE),armv7ve)
++    CC_ARCH          = -march=armv7ve -marm
++  endif
++  
++  ifeq ($(BUILD_PROFILE),arm32)
+     CC_ARCH          = -marm
+-    ifneq ($(LD_PATH),)
+-      CC_ARCH          += -Wl,-rpath=$(LD_PATH)
+-    endif
++  endif
++  
++  ifeq ($(BUILD_PROFILE),armv8a)
++    CC_ARCH          = -march=armv7-a -marm
++  endif
++  
++  ifeq ($(BUILD_PROFILE),aarch64)
++    CC_ARCH          = -march=armv8-a
+   endif
+ endif
+ 
+-ifeq ($(BUILD_PROFILE),armv6a)
+-  CC_ARCH          = -march=armv6-a -marm
+-endif
+-
+-ifeq ($(BUILD_PROFILE),armv7a)
+-  CC_ARCH          = -march=armv7-a -marm
+-endif
+-
+-ifeq ($(BUILD_PROFILE),armv7ve)
+-  CC_ARCH          = -march=armv7ve -marm
+-endif
+-
+-ifeq ($(BUILD_PROFILE),arm32)
+-  CC_ARCH          = -marm
+-endif
+-
+-ifeq ($(BUILD_PROFILE),armv8a)
+-  CC_ARCH          = -march=armv7-a -marm
+-endif
+-
+-ifeq ($(BUILD_PROFILE),aarch64)
+-  CC_ARCH          = -march=armv8-a
+-endif
+-
+-
+ export CC_ARCH
+ export LD_ARCH
+ export LD_PATH
+@@ -127,21 +131,25 @@ export INCLUDE
+ ifeq ($(BUILD_SYSTEM),Windows)
+ # TODO
+ else
+-  export PTHREAD_LIBS     = -lpthread
+-  export ICONV_LIBS       = -liconv
+-  export MATH_LIBS        = -lm
+-  export DL_LIBS          = -ldl
+-  export CAIRO_HEADERS    = $(shell pkg-config --cflags cairo)
+-  export CAIRO_LIBS       = $(shell pkg-config --libs cairo)
+-  export XLIB_HEADERS     = $(shell pkg-config --cflags x11)
+-  export XLIB_LIBS        = $(shell pkg-config --libs x11)
+-  export LV2_HEADERS      = $(shell pkg-config --cflags lv2)
+-  export LV2_LIBS         = $(shell pkg-config --libs lv2)
+-  export SNDFILE_HEADERS  = $(shell pkg-config --cflags sndfile)
+-  export SNDFILE_LIBS     = $(shell pkg-config --libs sndfile)
+-  export JACK_HEADERS     = $(shell pkg-config --cflags jack)
+-  export JACK_LIBS        = $(shell pkg-config --libs jack)
+-  export OPENGL_HEADERS   = $(shell pkg-config --cflags gl 2>/dev/null || echo "")
+-  export OPENGL_LIBS      = $(shell pkg-config --libs gl 2>/dev/null || echo "")
++  export PTHREAD_LIBS         = -lpthread
++  export ICONV_LIBS           = -liconv
++  export MATH_LIBS            = -lm
++  export DL_LIBS              = -ldl
++  export CAIRO_HEADERS        = $(shell $(PKG_CONFIG) --cflags cairo)
++  export CAIRO_LIBS           = $(shell $(PKG_CONFIG) --libs cairo)
++  export XLIB_HEADERS         = $(shell $(PKG_CONFIG) --cflags x11)
++  export XLIB_LIBS            = $(shell $(PKG_CONFIG) --libs x11)
++  export LV2_HEADERS          = $(shell $(PKG_CONFIG) --cflags lv2)
++  export LV2_HEADERS          = $(shell $(PKG_CONFIG) --libs lv2)
++  export SNDFILE_HEADERS      = $(shell $(PKG_CONFIG) --cflags sndfile)
++  export SNDFILE_LIBS         = $(shell $(PKG_CONFIG) --libs sndfile)
++  export JACK_HEADERS         = $(shell $(PKG_CONFIG) --cflags jack)
++  export JACK_LIBS            = $(shell $(PKG_CONFIG) --libs jack)
++  export OPENGL_HEADERS       = $(shell $(PKG_CONFIG) --cflags gl 2>/dev/null || echo "")
++  export OPENGL_LIBS          = $(shell $(PKG_CONFIG) --libs gl 2>/dev/null || echo "")
++  export HOST_SNDFILE_HEADERS = $(shell $(HOST_PKG_CONFIG) --cflags sndfile)
++  export HOST_SNDFILE_LIBS    = $(shell $(HOST_PKG_CONFIG) --libs sndfile)
++  export HOST_LV2_HEADERS     = $(shell $(HOST_PKG_CONFIG) --cflags lv2)
++  export HOST_LV2_LIBS        = $(shell $(HOST_PKG_CONFIG) --libs lv2)
+ endif
+ 
+diff --git a/scripts/make/set_vars.mk b/scripts/make/set_vars.mk
+index a22531a..93916ea 100644
+--- a/scripts/make/set_vars.mk
++++ b/scripts/make/set_vars.mk
+@@ -37,7 +37,52 @@ export BUILD_PLATFORM
+ export LV2_UI
+ export VST_UI
+ 
+-# Detect processor architecture
++# Detect host processor architecture
++ifeq ($(BUILD_PLATFORM),Windows)
++  ifndef HOST_BUILD_PROFILE
++    HOST_BUILD_ARCH           = i586
++    HOST_BUILD_PROFILE             = i586
++    ifeq ($(PROCESSOR_ARCHITECTURE),x86)
++      HOST_BUILD_ARCH         = i586
++      HOST_BUILD_PROFILE      = i586
++    endif
++    ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
++      HOST_BUILD_ARCH              = x86_64
++      HOST_BUILD_PROFILE           = x86_64
++    endif
++  endif
++else # BUILD_PLATFORM != Windows
++  ifndef HOST_BUILD_PROFILE
++    HOST_BUILD_ARCH    ?= $(shell cat "$(OBJDIR)/$(BUILD_PROFILE_FILE)" 2>/dev/null || uname -m)
++    HOST_BUILD_PROFILE  = $(HOST_BUILD_ARCH)
++    ifeq ($(patsubst armv6%,armv6,$(HOST_BUILD_ARCH)), armv6)
++      HOST_BUILD_PROFILE      = armv6a
++    endif
++    ifeq ($(patsubst armv7%,armv7,$(HOST_BUILD_ARCH)), armv7)
++      HOST_BUILD_PROFILE      = armv7a
++    endif
++    ifeq ($(patsubst armv8%,armv8,$(HOST_BUILD_ARCH)), armv8)
++      HOST_BUILD_PROFILE      = armv8a
++    endif
++    ifeq ($(patsubst aarch64%,aarch64,$(HOST_BUILD_ARCH)), aarch64)
++      HOST_BUILD_PROFILE      = aarch64
++    endif
++    ifeq ($(HOST_BUILD_ARCH),x86_64)
++      HOST_BUILD_PROFILE      = x86_64
++    endif
++    ifeq ($(HOST_BUILD_ARCH),amd64)
++      HOST_BUILD_PROFILE      = x86_64
++    endif
++    ifeq ($(HOST_BUILD_ARCH),i86pc)
++      HOST_BUILD_PROFILE      = x86_64
++    endif
++    ifeq ($(patsubst i%86,i586,$(HOST_BUILD_ARCH)), i586)
++      HOST_BUILD_PROFILE      = i586
++    endif
++  endif
++endif # BUILD_PLATFORM != Windows
++
++# Detect target processor architecture
+ ifeq ($(BUILD_PLATFORM),Windows)
+   ifndef BUILD_PROFILE
+     BUILD_ARCH                = i586
+@@ -53,7 +98,7 @@ ifeq ($(BUILD_PLATFORM),Windows)
+   endif
+ else # BUILD_PLATFORM != Windows
+   ifndef BUILD_PROFILE
+-    BUILD_ARCH              = $(shell cat "$(OBJDIR)/$(BUILD_PROFILE_FILE)" 2>/dev/null || uname -m)
++    BUILD_ARCH              ?= $(shell cat "$(OBJDIR)/$(BUILD_PROFILE_FILE)" 2>/dev/null || uname -m)
+     BUILD_PROFILE           = $(BUILD_ARCH)
+     ifeq ($(patsubst armv6%,armv6,$(BUILD_ARCH)), armv6)
+       BUILD_PROFILE           = armv6a
+@@ -82,5 +127,7 @@ else # BUILD_PLATFORM != Windows
+   endif
+ endif # BUILD_PLATFORM != Windows
+ 
+-export BUILD_PROFILE
++HOST_BUILD_PROFILE ?= $(shell uname -m)
+ 
++export BUILD_PROFILE
++export HOST_BUILD_PROFILE
+diff --git a/scripts/make/tools.mk b/scripts/make/tools.mk
+index 1fb917e..508f829 100644
+--- a/scripts/make/tools.mk
++++ b/scripts/make/tools.mk
+@@ -1,14 +1,18 @@
+ # Setup preferred tools
+ TOOL_LD                 = ld
++TOOL_HOST_LD            = ld
+ TOOL_CC                 = gcc
+ TOOL_CXX                = g++
++TOOL_HOST_CXX           = g++
+ TOOL_PHP                = php
++TOOL_PKG_CONFIG         = pkg-config
++TOOL_HOST_PKG_CONFIG    = PKG_CONFIG_SYSROOT_DIR=/ pkg-config
+ 
+ # Setup preferred flags
+ FLAG_RELRO              = -Wl,-z,relro,-z,now
+ FLAG_VERSION            = -DLSP_MAIN_VERSION=\"$(LSP_VERSION)\" -DLSP_INSTALL_PREFIX=\"$(PREFIX)\"
+-FLAG_CTUNE              = -std=c++98 \
+-                          -fno-exceptions -fno-rtti \
++FLAG_CXXSTANDARD        = -std=c++98
++FLAGS_CTUNE             = -fno-exceptions -fno-rtti \
+                           -fdata-sections -ffunction-sections -fno-asynchronous-unwind-tables \
+                           -fvisibility=hidden \
+                           -pipe -Wall
+@@ -17,21 +21,29 @@ FLAG_CTUNE              = -std=c++98 \
+ ifeq ($(BUILD_PLATFORM),Solaris)
+   FLAG_RELRO              =
+   TOOL_LD                 = gld
++  TOOL_HOST_LD            = gld
+ endif
+ 
+ # Setup system variables
+ CC              		 ?= $(TOOL_CC)
+ CXX                      ?= $(TOOL_CXX)
++HOST_CXX                 ?= $(TOOL_HOST_CXX)
+ PHP                      ?= $(TOOL_PHP)
+ LD                       ?= $(TOOL_LD)
++HOST_LD                  ?= $(TOOL_HOST_LD)
++PKG_CONFIG               ?= $(TOOL_PKG_CONFIG)
++HOST_PKG_CONFIG          ?= $(TOOL_HOST_PKG_CONFIG)
+ 
+-MAKE_OPTS                 = -s
+-CFLAGS                   += $(CC_ARCH) $(FLAG_CTUNE) $(CC_FLAGS) $(FLAG_VERSION)
+-CXXFLAGS                 += $(CC_ARCH) $(FLAG_CTUNE) $(CC_FLAGS) $(FLAG_VERSION)
+-SO_FLAGS                  = $(CC_ARCH) $(FLAG_RELRO) -Wl,--gc-sections -shared -Llibrary -lc -fPIC
+-MERGE_FLAGS               = $(LD_ARCH) -r
+-EXE_TEST_FLAGS            = $(LDFLAGS) $(CC_ARCH)
+-EXE_FLAGS                 = $(LDFLAGS) $(CC_ARCH) $(FLAG_RELRO) -Wl,--gc-sections
++CFLAGS                   += $(CC_ARCH) $(FLAG_CXXSTANDARD) $(FLAGS_CTUNE) \
++                            $(CC_FLAGS) $(FLAG_VERSION)
++CXXFLAGS                 += $(CC_ARCH) $(FLAG_CXXSTANDARD) $(FLAGS_CTUNE) \
++                            $(CC_FLAGS) $(FLAG_VERSION)
++HOST_CXXFLAGS            += $(FLAG_CXXSTANDARD) $(FLAGS_CTUNE) $(CC_FLAGS) $(FLAG_VERSION)
++SO_FLAGS                 += $(CC_ARCH) $(FLAG_RELRO) -Wl,--gc-sections -shared -Llibrary -lc -fPIC
++MERGE_FLAGS              += $(LD_ARCH) -r
++EXE_TEST_FLAGS           += $(LDFLAGS) $(CC_ARCH)
++EXE_FLAGS                += $(LDFLAGS) $(CC_ARCH) $(FLAG_RELRO) -Wl,--gc-sections
++HOST_EXE_FLAGS           += $(HOST_LDFLAGS) $(FLAG_RELRO) -Wl,--gc-sections
+ 
+ ifeq ($(BUILD_PLATFORM), Linux)
+   SO_FLAGS                 += -Wl,--no-undefined
+@@ -59,13 +71,18 @@ endif
+ 
+ export CC
+ export CXX
++export HOST_CXX
+ export PHP
+ export LD
++export HOST_LD
++export PKG_CONFIG
++export HOST_PKG_CONFIG
+ 
+-export MAKE_OPTS
+ export CFLAGS
+ export CXXFLAGS
++export HOST_CXXFLAGS
+ export SO_FLAGS
+ export MERGE_FLAGS
+ export EXE_TEST_FLAGS
+ export EXE_FLAGS
++export HOST_EXE_FLAGS
+diff --git a/src/Makefile b/src/Makefile
+index 8546191..01b9d92 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -1,7 +1,16 @@
++# Estimate different pre-requisites before launching build
++
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ SUBDIRS                 = core metadata utils 
+ MODULES                 = $(SUBDIRS)
+ CONTAINER_DEPS          = $(OBJ_METADATA) $(OBJ_CORE) $(UTL_FILES)
+-UTL_DEPS                = $(OBJ_CORE) $(OBJ_DSP) $(OBJ_METADATA)
++UTL_DEPS                = $(HOST_OBJ_CORE) $(HOST_OBJ_DSP) $(HOST_OBJ_METADATA)
++OBJDIR                  ?= $(BUILDDIR)
+ 
+ NEED_UI                 = 0
+ NEED_PLUGINS            = 0
+@@ -58,6 +67,7 @@ ifeq ($(NEED_UI),1)
+   CONTAINER_DEPS         += $(OBJ_UI_CORE) $(OBJ_RES_CORE) rendering
+ endif
+ 
++.DEFAULT_GOAL          := all
+ .PHONY: all $(MODULES)
+ 
+ all: $(MODULES)
+@@ -66,19 +76,34 @@ target: all
+ 
+ # Rules
+ $(SUBDIRS):
+-	@echo "Building $(@)"
+-	@mkdir -p $(OBJDIR)/$(@)
+-	@$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
++	@echo "$(BUILDDIR)"
++	mkdir -p $(OBJDIR)/$(@)
++	$(MAKE) $(MAKE_OPTS) -C $@ all \
++		CXX="$(CXX)" \
++		CXXFLAGS="$(CXXFLAGS)" \
++		LD="$(LD)" \
++		OBJDIR="$(OBJDIR)/$(@)" \
++		BUILD_PROFILE="$(BUILD_PROFILE)" \
++		SNDFILE_HEADERS="$(SNDFILE_HEADERS)" \
++		SNDFILE_LIBS="$(SNDFILE_LIBS)" \
++		LV2_HEADERS="$(LV2_HEADERS)" \
++		LV2_LIBS="$(LV2_LIBS)"
+ 
+ # Object dependencies
+ $(OBJ_CORE): core
+ 
++$(HOST_OBJ_CORE): core
++
+ $(OBJ_DSP): dsp
+ 
++$(HOST_OBJ_DSP): dsp
++
+ $(OBJ_PLUGINS): plugins
+ 
+ $(OBJ_METADATA): metadata
+ 
++$(HOST_OBJ_METADATA): metadata
++
+ $(OBJ_UI_CORE): ui
+ 
+ $(UTL_FILES): utils
+@@ -93,10 +118,10 @@ $(OBJ_TESTING_CORE): test testing rendering
+ 
+ $(OBJ_RES_CORE): $(OBJ_CORE) $(UTL_RESGEN)
+ 	@echo "Generating builtin resources"
+-	@mkdir -p $(OBJDIR)/res
+-	@$(UTL_RESGEN) $(OBJDIR)/res/builtin_resource.cpp $(RESOURCE_PATHS)
+-	@-rm gmon.out >/dev/null 2>&1
+-	@$(CXX) -o $(OBJ_RES_CORE) -c $(OBJDIR)/res/builtin_resource.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	mkdir -p $(OBJDIR)/res
++	$(UTL_RESGEN) $(OBJDIR)/res/builtin_resource.cpp $(RESOURCE_PATHS)
++	rm -f gmon.out >/dev/null 2>&1
++	$(CXX) -o $(OBJ_RES_CORE) -c $(OBJDIR)/res/builtin_resource.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+ 
+ # Target dependencies
+ container: $(CONTAINER_DEPS)
+@@ -108,18 +133,18 @@ doc: utils $(PHP_PLUGINS)
+ # Additional processing
+ $(PHP_PLUGINS): $(UTL_GENPHP)
+ 	@echo "Generating PHP file $(notdir $(PHP_PLUGINS))"
+-	@$(UTL_GENPHP) $(PHP_PLUGINS)
++	$(UTL_GENPHP) $(PHP_PLUGINS)
+ 
+ vst_stub: $(UTL_VSTMAKE)
+ 	@echo "Building VST stub"
+-	@mkdir -p $(OBJDIR)/vst
+-	@$(UTL_VSTMAKE) $(OBJDIR)/vst
+-	@-rm gmon.out >/dev/null 2>&1
+-	@$(MAKE) $(MAKE_OPTS) -C $(OBJDIR)/vst all OBJDIR=$(OBJDIR)/vst
++	mkdir -p $(OBJDIR)/vst
++	$(UTL_VSTMAKE) $(OBJDIR)/vst
++	rm -f gmon.out >/dev/null 2>&1
++	$(MAKE) $(MAKE_OPTS) -C $(OBJDIR)/vst all OBJDIR=$(OBJDIR)/vst
+ 
+ jack_stub: $(UTL_JACKMAKE)
+ 	@echo "Building JACK stub"
+-	@mkdir -p $(OBJDIR)/jack
+-	@$(UTL_JACKMAKE) $(OBJDIR)/jack
+-	@-rm gmon.out >/dev/null 2>&1
+-	@$(MAKE) $(MAKE_OPTS) -C $(OBJDIR)/jack all OBJDIR=$(OBJDIR)/jack
++	mkdir -p $(OBJDIR)/jack
++	$(UTL_JACKMAKE) $(OBJDIR)/jack
++	rm -f gmon.out >/dev/null 2>&1
++	$(MAKE) $(MAKE_OPTS) -C $(OBJDIR)/jack all OBJDIR=$(OBJDIR)/jack
+diff --git a/src/container/Makefile b/src/container/Makefile
+index 8aa8196..23a2e7a 100644
+--- a/src/container/Makefile
++++ b/src/container/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ OBJ_HELPERS             = $(OBJDIR)/CairoCanvas.o
+@@ -53,46 +59,47 @@ ifeq ($(VST_UI),1)
+   X_VST_LIBS             += $(UI_LIBS)
+ endif
+ 
++.DEFAULT_GOAL          := all
+ .PHONY: all
+ 
+ all: $(MODULES)
+ 
+ $(OBJ_HELPERS):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(CAIRO_HEADERS)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(CAIRO_HEADERS)
+ 
+ $(LIB_LADSPA):
+ 	@echo "  $(CXX) ladspa.cpp"
+-	@$(CXX) -o $(OBJDIR)/ladspa.o -c ladspa.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	$(CXX) -o $(OBJDIR)/ladspa.o -c ladspa.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+ 	@echo "  $(CXX) $(notdir $(LIB_LADSPA))"
+-	@$(CXX) -o $(LIB_LADSPA) $(OBJDIR)/ladspa.o $(OBJFILES) $(SO_FLAGS) $(LIBS)
++	$(CXX) -o $(LIB_LADSPA) $(OBJDIR)/ladspa.o $(OBJFILES) $(SO_FLAGS) $(LIBS)
+ 
+ $(LIB_LV2): $(X_LV2_DEPS)
+ 	@echo "  $(CXX) lv2.cpp"
+-	@$(CXX) -o $(OBJDIR)/lv2.o -c lv2.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(CAIRO_HEADERS) $(LV2_HEADERS)
+-	@echo "  $(CXX) $(notdir $(X_LIB_LV2))"
+-	@$(CXX) -o $(LIB_LV2) $(OBJDIR)/lv2.o $(X_LV2_OBJFILES) $(SO_FLAGS) $(X_LV2_LIBS)
++	$(CXX) -o $(OBJDIR)/lv2.o -c lv2.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(CAIRO_HEADERS) $(LV2_HEADERS)
++	@echo "  $(CXX) $(notdir $(LIB_LV2))"
++	$(CXX) -o $(LIB_LV2) $(OBJDIR)/lv2.o $(X_LV2_OBJFILES) $(SO_FLAGS) $(X_LV2_LIBS)
+ 
+ $(LIB_VST):
+ 	@echo "  $(CXX) vst.cpp"
+-	@$(CXX) -o $(OBJDIR)/vst.o -c vst.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	$(CXX) -o $(OBJDIR)/vst.o -c vst.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+ 	@echo "  $(CXX) $(notdir $(LIB_VST))"
+-	@$(CXX) -o $(LIB_VST) $(OBJDIR)/vst.o $(X_VST_OBJFILES) $(SO_FLAGS) $(X_VST_LIBS) 
++	$(CXX) -o $(LIB_VST) $(OBJDIR)/vst.o $(X_VST_OBJFILES) $(SO_FLAGS) $(X_VST_LIBS) 
+ 
+ $(LIB_JACK): $(OBJ_HELPERS)
+ 	@echo "  $(CXX) jack.cpp"
+-	@$(CXX) -o $(OBJDIR)/jack.o -c jack.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(JACK_HEADERS) $(CAIRO_HEADERS)
++	$(CXX) -o $(OBJDIR)/jack.o -c jack.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(JACK_HEADERS) $(CAIRO_HEADERS)
+ 	@echo "  $(CXX) $(notdir $(LIB_JACK))"
+-	@$(CXX) -o $(LIB_JACK) $(OBJDIR)/jack.o $(OBJ_HELPERS) $(OBJFILES) $(UI_OBJFILES) $(SO_FLAGS) $(LIBS) $(UI_LIBS) $(JACK_LIBS)
++	$(CXX) -o $(LIB_JACK) $(OBJDIR)/jack.o $(OBJ_HELPERS) $(OBJFILES) $(UI_OBJFILES) $(SO_FLAGS) $(LIBS) $(UI_LIBS) $(JACK_LIBS)
+ 
+ $(BIN_PROFILE): $(LIB_JACK)
+ 	@echo "  $(CXX) profile.cpp"
+-	@$(CXX) -o $(OBJDIR)/profile.o -c profile.cpp -fPIC $(CPPFLAGS) -DLSP_PROFILING_MAIN $(CXXFLAGS) $(INCLUDE) $(JACK_HEADERS) 
++	$(CXX) -o $(OBJDIR)/profile.o -c profile.cpp -fPIC $(CPPFLAGS) -DLSP_PROFILING_MAIN $(CXXFLAGS) $(INCLUDE) $(JACK_HEADERS) 
+ 	@echo "  $(CXX) $(notdir $(BIN_PROFILE))"
+-	@$(CXX) -o $(BIN_PROFILE) $(OBJDIR)/jack.o $(OBJDIR)/profile.o $(OBJ_HELPERS) $(OBJFILES) $(UI_OBJFILES) $(EXE_FLAGS) $(LIBS) $(UI_LIBS) $(JACK_LIBS) 
++	$(CXX) -o $(BIN_PROFILE) $(OBJDIR)/jack.o $(OBJDIR)/profile.o $(OBJ_HELPERS) $(OBJFILES) $(UI_OBJFILES) $(EXE_FLAGS) $(LIBS) $(UI_LIBS) $(JACK_LIBS) 
+ 
+ $(BIN_TEST): $(LIB_JACK)
+ 	@echo "  $(CXX) test.cpp"
+-	@$(CXX) -o $(OBJDIR)/test.o -c test.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(JACK_HEADERS) 
++	$(CXX) -o $(OBJDIR)/test.o -c test.cpp -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(JACK_HEADERS) 
+ 	@echo "  $(CXX) $(notdir $(BIN_TEST))"
+-	@$(CXX) -o $(BIN_TEST) $(OBJDIR)/jack.o $(OBJDIR)/test.o $(OBJ_HELPERS) $(OBJFILES) $(UI_OBJFILES) $(EXE_TEST_FLAGS) $(LIBS) $(UI_LIBS) $(JACK_LIBS) $(OPENGL_LIBS) $(DL_LIBS)   
++	$(CXX) -o $(BIN_TEST) $(OBJDIR)/jack.o $(OBJDIR)/test.o $(OBJ_HELPERS) $(OBJFILES) $(UI_OBJFILES) $(EXE_TEST_FLAGS) $(LIBS) $(UI_LIBS) $(JACK_LIBS) $(OPENGL_LIBS) $(DL_LIBS)   
+diff --git a/src/core/Makefile b/src/core/Makefile
+index a9ce1a5..3ad14a5 100644
+--- a/src/core/Makefile
++++ b/src/core/Makefile
+@@ -1,18 +1,25 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ rwildcard				= $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(call rwildcard, , *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ INCLUDE                += $(SNDFILE_HEADERS)
+ LIBS                    = $(PTHREAD_LIBS)
+ 
++.DEFAULT_GOAL          := all
+ .PHONY: all
+ 
+ all: $(OBJ_CORE)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@mkdir -p $(dir $@)
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(LIBS) $(INCLUDE) 
++	mkdir -p $(dir $@)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(LIBS) $(INCLUDE) 
+ 
+ $(OBJ_CORE): $(FILES)
+ 	@echo "  $(LD) $(notdir $(OBJ_CORE))"
+-	@$(LD) -o $(OBJ_CORE) -r $(MERGE_FLAGS) $(FILES)
++	$(LD) -o $(OBJ_CORE) -r $(MERGE_FLAGS) $(FILES)
+diff --git a/src/doc/Makefile b/src/doc/Makefile
+index aac73bf..f7f18a1 100644
+--- a/src/doc/Makefile
++++ b/src/doc/Makefile
+@@ -1,6 +1,13 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ PHPDIR      = $(BUILDDIR)/src/doc
+ HTMLDIR     = $(BUILDDIR)/html
+ 
++.DEFAULT_GOAL          := all
+ .PHONY: all target
+ 
+ target: all
+@@ -8,14 +15,14 @@ target: all
+ # Common rules
+ $(PHPDIR)/Makefile:
+ 	@echo "Preparing PHP documentation generator"
+-	@mkdir -p $(PHPDIR)
+-	@mkdir -p $(HTMLDIR)
+-	@cp -rf * $(PHPDIR)/
+-	@cp -r $(addprefix $(ROOTDIR)/, $(RELEASE_TEXT)) $(PHPDIR)/
+-	@cp -rf $(RESDIR)/doc/* $(HTMLDIR)/
+-	@cp -f $(PHP_PLUGINS) $(PHPDIR)/config/plugins.php
+-	@$(PHP) -f makefile.php $(PHPDIR) >$(PHPDIR)/Makefile
++	mkdir -p $(PHPDIR)
++	mkdir -p $(HTMLDIR)
++	cp -rf * $(PHPDIR)/
++	cp -r $(addprefix $(ROOTDIR)/, $(RELEASE_TEXT)) $(PHPDIR)/
++	cp -rf $(RESDIR)/doc/* $(HTMLDIR)/
++	cp -f $(PHP_PLUGINS) $(PHPDIR)/config/plugins.php
++	$(PHP) -f makefile.php $(PHPDIR) >$(PHPDIR)/Makefile
+ 
+ all: $(PHPDIR)/Makefile
+ 	@echo "Generating HTML documentation"
+-	@$(MAKE) $(MAKE_OPTS) -C $(PHPDIR)
++	$(MAKE) $(MAKE_OPTS) -C $(PHPDIR)
+diff --git a/src/dsp/Makefile b/src/dsp/Makefile
+index f3d9ab1..cc30a37 100644
+--- a/src/dsp/Makefile
++++ b/src/dsp/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ NATIVE_IMPL             = $(OBJDIR)/native.o
+ 
+ X86_IMPL                = $(OBJDIR)/x86.o
+@@ -28,29 +34,35 @@ LINK_OBJECTS            = $(DSP_IMPL) $(BITS_IMPL) $(NATIVE_IMPL)
+ 
+ # Build different DSP modules dependent on architecture
+ ifeq ($(BUILD_PROFILE), i586)
+-LINK_OBJECTS           += $(X86_IMPL) $(SSE_IMPL) $(SSE2_IMPL) $(SSE3_IMPL) $(SSE4_IMPL) $(AVX_IMPL) $(AVX2_IMPL)
++  LINK_OBJECTS           += $(X86_IMPL) $(SSE_IMPL) $(SSE2_IMPL) $(SSE3_IMPL) \
++                            $(SSE4_IMPL) $(AVX_IMPL) $(AVX2_IMPL)
+ endif
+ ifeq ($(BUILD_PROFILE), x86_64)
+-LINK_OBJECTS           += $(X86_IMPL) $(SSE_IMPL) $(SSE2_IMPL) $(SSE3_IMPL) $(SSE4_IMPL) $(AVX_IMPL) $(AVX2_IMPL)
++LINK_OBJECTS           += $(X86_IMPL) $(SSE_IMPL) $(SSE2_IMPL) $(SSE3_IMPL) \
++                          $(SSE4_IMPL) $(AVX_IMPL) $(AVX2_IMPL)
+ endif
+ ifeq ($(BUILD_PLATFORM), BSD)
+   ifeq ($(BUILD_PROFILE), arm)
+-    LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
++    LINK_OBJECTS         += $(ARM_IMPL) $(NEON_D32_IMPL)
+   endif
+ endif
++ifeq ($(BUILD_PROFILE), armv6a)
++  LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
++endif
+ ifeq ($(BUILD_PROFILE), armv7a)
+-LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
++  LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
+ endif
+ ifeq ($(BUILD_PROFILE), armv7ve)
+-LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
++  LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
+ endif
+ ifeq ($(BUILD_PROFILE), arm32)
+-LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
++  LINK_OBJECTS           += $(ARM_IMPL) $(NEON_D32_IMPL)
+ endif
+ ifeq ($(BUILD_PROFILE), aarch64)
+-LINK_OBJECTS           += $(AARCH64_IMPL) $(ASIMD_IMPL)
++  LINK_OBJECTS           += $(AARCH64_IMPL) $(ASIMD_IMPL)
+ endif
+ 
++.DEFAULT_GOAL          := all
+ .PHONY: all target
+ 
+ target: all
+@@ -59,41 +71,41 @@ all: $(OBJ_DSP)
+ 
+ $(OBJ_DSP): $(LINK_OBJECTS)
+ 	@echo "  $(LD) $(notdir $(OBJ_DSP))"
+-	@$(LD) -o $(OBJ_DSP) -r $(MERGE_FLAGS) $(LINK_OBJECTS)
++	$(LD) -o $(OBJ_DSP) -r $(MERGE_FLAGS) $(LINK_OBJECTS)
+ 
+ $(DSP_IMPL) $(BITS_IMPL) $(NATIVE_IMPL) $(X86_IMPL) $(ARM_IMPL) $(AARCH64_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+ 	
+ $(SSE_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE_INSTR_SET) $(INCLUDE)
+ 	
+ $(SSE2_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE2_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE2_INSTR_SET) $(INCLUDE)
+ 	
+ $(SSE3_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE3_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE3_INSTR_SET) $(INCLUDE)
+ 	
+ $(SSE4_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE4_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(SSE4_INSTR_SET) $(INCLUDE)
+ 
+ $(AVX_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(AVX_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(AVX_INSTR_SET) $(INCLUDE)
+ 
+ $(AVX2_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(AVX2_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(AVX2_INSTR_SET) $(INCLUDE)
+ 	
+ $(NEON_D32_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(NEON_D32_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(NEON_D32_INSTR_SET) $(INCLUDE)
+ 	
+ $(ASIMD_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(ASIMD_INSTR_SET) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(ASIMD_INSTR_SET) $(INCLUDE)
+ 
+diff --git a/src/metadata/Makefile b/src/metadata/Makefile
+index 201f89a..403f38a 100644
+--- a/src/metadata/Makefile
++++ b/src/metadata/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ rwildcard               = $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+@@ -10,8 +16,8 @@ target: all
+ 
+ $(OBJ_METADATA): $(FILES)
+ 	@echo "  $(LD) $(notdir $(OBJ_METADATA))"
+-	@$(LD) -o $(OBJ_METADATA) -r $(MERGE_FLAGS) $(FILES) 
++	$(LD) -o $(OBJ_METADATA) -r $(MERGE_FLAGS) $(FILES) 
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+diff --git a/src/plugins/Makefile b/src/plugins/Makefile
+index 1f197dc..85963ba 100644
+--- a/src/plugins/Makefile
++++ b/src/plugins/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ rwildcard               = $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+@@ -8,8 +14,8 @@ all:  $(OBJ_PLUGINS)
+ 
+ $(OBJ_PLUGINS): $(FILES) $(SUBDIRS)
+ 	@echo "  $(LD) $(notdir $(OBJ_PLUGINS))"
+-	@$(LD) -o $(OBJ_PLUGINS) -r $(MERGE_FLAGS) $(FILES) 
++	$(LD) -o $(OBJ_PLUGINS) -r $(MERGE_FLAGS) $(FILES) 
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(FILE)
++	$(CXX) -o $(@) -c -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(FILE)
+diff --git a/src/rendering/Makefile b/src/rendering/Makefile
+index 897e327..65f3237 100644
+--- a/src/rendering/Makefile
++++ b/src/rendering/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ BASE_IMPL             	= $(OBJDIR)/base_backend.o
+ 
+ GLX_IMPL                = $(OBJDIR)/glx/backend.o $(OBJDIR)/glx/factory.o
+@@ -20,15 +26,15 @@ all: $(MODULES)
+ 
+ $(LIB_R3D_GLX): $(BASE_IMPL) $(GLX_IMPL)
+ 	@echo "  $(CXX) $(notdir $(LIB_R3D_GLX))"
+-	@$(CXX) -o $(LIB_R3D_GLX) $(BASE_IMPL) $(GLX_IMPL) $(SO_FLAGS) $(XLIB_LIBS) $(OPENGL_LIBS)
++	$(CXX) -o $(LIB_R3D_GLX) $(BASE_IMPL) $(GLX_IMPL) $(SO_FLAGS) $(XLIB_LIBS) $(OPENGL_LIBS)
+ 
+ $(BASE_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)
+ 	
+ $(GLX_IMPL):
+ 	@echo "  $(CXX) $(FILE)"
+-	@mkdir -p $(dir $(@))
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(XLIB_HEADERS) $(OPENGL_HEADERS)
++	mkdir -p $(dir $(@))
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(XLIB_HEADERS) $(OPENGL_HEADERS)
+ 
+ 
+diff --git a/src/test/Makefile b/src/test/Makefile
+index e8016e1..a89366e 100644
+--- a/src/test/Makefile
++++ b/src/test/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ rwildcard				= $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(call rwildcard, , *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+@@ -8,10 +14,10 @@ all: $(OBJ_TEST_CORE)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@mkdir -p $(dir $@)
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(OPENGL_HEADERS) 
++	mkdir -p $(dir $@)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(OPENGL_HEADERS) 
+ 
+ $(OBJ_TEST_CORE): $(FILES)
+ 	@echo "  $(LD) $(notdir $(OBJ_TEST_CORE))"
+-	@$(LD) -o $(OBJ_TEST_CORE) -r $(MERGE_FLAGS) $(FILES)  
++	$(LD) -o $(OBJ_TEST_CORE) -r $(MERGE_FLAGS) $(FILES)  
+ 
+diff --git a/src/testing/Makefile b/src/testing/Makefile
+index 705913d..d048065 100644
+--- a/src/testing/Makefile
++++ b/src/testing/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ rwildcard				= $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(call rwildcard, , *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+@@ -8,10 +14,10 @@ all: $(OBJ_TESTING_CORE)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@mkdir -p $(dir $@)
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(OPENGL_HEADERS) 
++	mkdir -p $(dir $@)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(OPENGL_HEADERS) 
+ 
+ $(OBJ_TESTING_CORE): $(FILES)
+ 	@echo "  $(LD) $(notdir $(OBJ_TESTING_CORE))"
+-	@$(LD) -o $(OBJ_TESTING_CORE) -r $(MERGE_FLAGS) $(FILES)  
++	$(LD) -o $(OBJ_TESTING_CORE) -r $(MERGE_FLAGS) $(FILES)  
+ 
+diff --git a/src/testing/mtest/3d/boolean3d.cpp b/src/testing/mtest/3d/boolean3d.cpp
+deleted file mode 100644
+index 636dce1..0000000
+--- a/src/testing/mtest/3d/boolean3d.cpp
++++ /dev/null
+@@ -1,253 +0,0 @@
+-/*
+- * Copyright (C) 2020 Linux Studio Plugins Project <https://lsp-plug.in/>
+- *           (C) 2020 Vladimir Sadovnikov <sadko4u@gmail.com>
+- *
+- * This file is part of lsp-plugins
+- * Created on: 24 дек. 2018 г.
+- *
+- * lsp-plugins is free software: you can redistribute it and/or modify
+- * it under the terms of the GNU Lesser General Public License as published by
+- * the Free Software Foundation, either version 3 of the License, or
+- * any later version.
+- *
+- * lsp-plugins is distributed in the hope that it will be useful,
+- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+- * GNU Lesser General Public License for more details.
+- *
+- * You should have received a copy of the GNU Lesser General Public License
+- * along with lsp-plugins. If not, see <https://www.gnu.org/licenses/>.
+- */
+-
+-#if 0
+-
+-#include <test/mtest.h>
+-#include <testing/mtest/3d/common/X11Renderer.h>
+-#include <core/files/Model3DFile.h>
+-#include <core/3d/rt_context.h>
+-#include <core/3d/RayTrace3D.h>
+-
+-#include <core/types.h>
+-#include <core/debug.h>
+-#include <core/sugar.h>
+-#include <core/status.h>
+-#include <stdlib.h>
+-#include <errno.h>
+-#include <data/cstorage.h>
+-
+-#include <X11/X.h>
+-#include <X11/Xlib.h>
+-#include <X11/keysymdef.h>
+-#include <GL/gl.h>
+-#include <GL/glx.h>
+-#include <GL/glu.h>
+-#include <sys/poll.h>
+-
+-//#define TEST_DEBUG
+-
+-#ifndef TEST_DEBUG
+-//    #define BREAKPOINT_STEP     -1
+-//    #define BREAKPOINT_STEP     27
+-//    #define BREAKPOINT_STEP     83
+-    #define BREAKPOINT_STEP     215
+-//    #define BREAKPOINT_STEP     0
+-
+-#else /* DEBUG */
+-    #define BREAKPOINT_STEP     0
+-#endif /* DEBUG */
+-
+-MTEST_BEGIN("3d", boolean)
+-
+-    class Renderer: public X11Renderer
+-    {
+-        private:
+-            Scene3D        *pScene;
+-            ssize_t         nTrace;
+-            bool            bDrawMatched;
+-            bool            bDrawIgnored;
+-            bool            bDrawDebug;
+-
+-        public:
+-            explicit Renderer(Scene3D *scene, View3D *view): X11Renderer(view)
+-            {
+-                pScene = scene;
+-                bDrawMatched    = true;
+-                bDrawIgnored    = true;
+-                bDrawDebug      = true;
+-                bDrawNormals    = false;
+-                nTrace          = BREAKPOINT_STEP;
+-
+-                update_view();
+-            }
+-
+-            virtual ~Renderer()
+-            {
+-            }
+-
+-        public:
+-            virtual void on_key_press(const XKeyEvent &ev, KeySym key)
+-            {
+-                switch (key)
+-                {
+-                    case XK_Up:
+-                        nTrace++;
+-                        lsp_trace("Set trace breakpoint to %d", int(nTrace));
+-                        update_view();
+-                        break;
+-                    case XK_Down:
+-                        if (nTrace >= 0)
+-                        {
+-                            nTrace--;
+-                            lsp_trace("Set trace breakpoint to %d", int(nTrace));
+-                            update_view();
+-                        }
+-                        break;
+-
+-                    case 'm':
+-                    {
+-                        bDrawMatched = ! bDrawMatched;
+-                        update_view();
+-                        break;
+-                    }
+-
+-                    case 'i':
+-                    {
+-                        bDrawIgnored = ! bDrawIgnored;
+-                        update_view();
+-                        break;
+-                    }
+-
+-                    case 'd':
+-                    {
+-                        bDrawDebug = ! bDrawDebug;
+-                        update_view();
+-                        break;
+-                    }
+-
+-                    case '0': case '1': case '2': case '3': case '4':
+-                    case '5': case '6': case '7': case '8': case '9':
+-                    {
+-                        Object3D *obj = pScene->get_object(key - '0');
+-                        if (obj != NULL)
+-                        {
+-                            obj->set_visible(!obj->is_visible());
+-                            update_view();
+-                        }
+-                        break;
+-                    }
+-                    default:
+-                        X11Renderer::on_key_press(ev, key);
+-                        break;
+-                }
+-            }
+-
+-        protected:
+-            status_t perform_boolean(rt_debug_t *shared)
+-            {
+-                if (pScene->num_objects() <= 0)
+-                    return STATUS_OK;
+-
+-                rt_mesh_t mesh;
+-                mesh.set_debug_context(shared, &shared->trace);
+-
+-                Object3D *obj = pScene->object(0);
+-                status_t res = mesh.init(obj, 0, obj->matrix());
+-                if (res != STATUS_OK)
+-                    return res;
+-
+-                for (size_t i=1, n=pScene->num_objects(); i<n; ++i)
+-                {
+-                    obj = pScene->object(i);
+-                    res = mesh.subtract(obj, i, obj->matrix());
+-                    if (res != STATUS_OK)
+-                        return res;
+-                }
+-
+-                return STATUS_OK;
+-            }
+-
+-            status_t    update_view()
+-            {
+-                v_vertex3d_t v[3];
+-                status_t res = STATUS_OK;
+-
+-                if (!pScene->validate())
+-                    return STATUS_BAD_STATE;
+-
+-                // List of ignored and matched triangles
+-                rt_debug_t global;
+-                global.breakpoint   = nTrace;
+-                global.step         = 0;
+-
+-                // Perform raytrace
+-                res     = perform_boolean(&global);
+-                if (res == STATUS_BREAKPOINT)
+-                {
+-                    pView->swap(&global.trace);
+-                    res         = STATUS_OK;
+-                }
+-
+-                if (!bDrawDebug)
+-                    pView->clear_all();
+-
+-                if (!pScene->validate())
+-                    return STATUS_BAD_STATE;
+-
+-                // Build final scene from matched and ignored items
+-                if (bDrawIgnored)
+-                {
+-                    for (size_t i=0, m=global.ignored.size(); i < m; ++i)
+-                        pView->add_triangle_1c(global.ignored.at(i), &C_GRAY);
+-                }
+-
+-                if (bDrawMatched)
+-                {
+-                    for (size_t i=0, m=global.matched.size(); i < m; ++i)
+-                    {
+-                        v_triangle3d_t *t = global.matched.at(i);
+-                        v[0].p     = t->p[0];
+-                        v[0].n     = t->n[0];
+-                        v[0].c     = C_RED;
+-
+-                        v[1].p     = t->p[1];
+-                        v[1].n     = t->n[1];
+-                        v[1].c     = C_GREEN;
+-
+-                        v[2].p     = t->p[2];
+-                        v[2].n     = t->n[2];
+-                        v[2].c     = C_BLUE;
+-
+-                        pView->add_triangle(v);
+-                    }
+-                }
+-
+-                global.ignored.flush();
+-                global.matched.flush();
+-
+-                return res;
+-            }
+-    };
+-
+-    MTEST_MAIN
+-    {
+-        const char *scene_file = (argc < 1) ? "res/test/3d/cross.obj" : argv[0];
+-
+-        // Load scene
+-        Scene3D s;
+-        View3D v;
+-        status_t res = Model3DFile::load(&s, scene_file, true);
+-        MTEST_ASSERT_MSG(res == STATUS_OK, "Error loading scene from file %s", scene_file);
+-
+-        // Initialize renderer
+-        Renderer r(&s, &v);
+-        MTEST_ASSERT_MSG(r.init() == STATUS_OK, "Error initializing renderer");
+-        r.run();
+-        r.destroy();
+-
+-        // Destroy scene
+-        s.destroy();
+-    }
+-
+-MTEST_END
+-
+-#endif
+diff --git a/src/testing/mtest/3d/bsp_context.cpp b/src/testing/mtest/3d/bsp_context.cpp
+index de54427..f7b7a34 100644
+--- a/src/testing/mtest/3d/bsp_context.cpp
++++ b/src/testing/mtest/3d/bsp_context.cpp
+@@ -39,7 +39,7 @@
+ #include <X11/keysymdef.h>
+ #include <GL/gl.h>
+ #include <GL/glx.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ //#define TEST_DEBUG
+ 
+diff --git a/src/testing/mtest/3d/reflections3d.cpp b/src/testing/mtest/3d/reflections3d.cpp
+index e250444..367f86c 100644
+--- a/src/testing/mtest/3d/reflections3d.cpp
++++ b/src/testing/mtest/3d/reflections3d.cpp
+@@ -39,7 +39,7 @@
+ #include <X11/keysymdef.h>
+ #include <GL/gl.h>
+ #include <GL/glx.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ //#define TEST_DEBUG
+ 
+diff --git a/src/ui/Makefile b/src/ui/Makefile
+index 503111d..eb1e4c5 100644
+--- a/src/ui/Makefile
++++ b/src/ui/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ SUBDIRS					= ws tk ctl plugins
+@@ -8,15 +14,15 @@ PACKAGES                = $(OBJ_WS_CORE) $(OBJ_TK_CORE) $(OBJ_CTL_CORE)
+ 
+ $(SUBDIRS):
+ 	@echo "Building $@"
+-	@mkdir -p $(OBJDIR)/$(@)
+-	@$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
++	mkdir -p $(OBJDIR)/$(@)
++	$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)
+ 
+ $(OBJ_UI_CORE): $(FILES) $(SUBDIRS)
+ 	@echo "  $(LD) $(notdir $(@))"
+-	@$(LD) -o $(OBJ_UI_CORE) $(OBJ_PLUGIN_UIS) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
++	$(LD) -o $(OBJ_UI_CORE) $(OBJ_PLUGIN_UIS) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
+ 
+ all: $(OBJ_UI_CORE)
+diff --git a/src/ui/ctl/Makefile b/src/ui/ctl/Makefile
+index 3f727db..692fe9d 100644
+--- a/src/ui/ctl/Makefile
++++ b/src/ui/ctl/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ SUBDIRS					= 
+@@ -6,10 +12,10 @@ SUBDIRS					=
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)  
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)  
+ 
+ $(OBJ_CTL_CORE): $(FILES)
+ 	@echo "  $(LD) $(notdir $(@))"
+-	@$(LD) -o $(OBJ_CTL_CORE) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
++	$(LD) -o $(OBJ_CTL_CORE) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
+ 
+ all: $(OBJ_CTL_CORE) $(SUBDIRS)
+diff --git a/src/ui/plugins/Makefile b/src/ui/plugins/Makefile
+index 8f8db8f..0e6c3d8 100644
+--- a/src/ui/plugins/Makefile
++++ b/src/ui/plugins/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ SUBDIRS					= 
+@@ -6,10 +12,10 @@ SUBDIRS					=
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)  
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)  
+ 
+ $(OBJ_PLUGIN_UIS): $(FILES)
+ 	@echo "  $(LD) $(notdir $(@))"
+-	@$(LD) -o $(OBJ_PLUGIN_UIS) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
++	$(LD) -o $(OBJ_PLUGIN_UIS) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
+ 
+ all: $(OBJ_PLUGIN_UIS) $(SUBDIRS)
+diff --git a/src/ui/tk/Makefile b/src/ui/tk/Makefile
+index 8700f63..cfb4c78 100644
+--- a/src/ui/tk/Makefile
++++ b/src/ui/tk/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ rwildcard				= $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(call rwildcard, , *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+@@ -6,11 +12,11 @@ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@mkdir -p $(dir $@)
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)
++	mkdir -p $(dir $@)
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE)
+ 
+ $(OBJ_TK_CORE): $(FILES)
+ 	@echo "  $(LD) $(notdir $(@))"
+-	@$(LD) -o $(OBJ_TK_CORE) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
++	$(LD) -o $(OBJ_TK_CORE) $(MERGE_FLAGS) $(PACKAGES) $(FILES)
+ 
+ all: $(OBJ_TK_CORE)
+diff --git a/src/ui/ws/Makefile b/src/ui/ws/Makefile
+index 1109752..b9836d8 100644
+--- a/src/ui/ws/Makefile
++++ b/src/ui/ws/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ SUBDIRS					= x11
+@@ -8,15 +14,15 @@ all: $(OBJ_WS_CORE)
+ 
+ $(SUBDIRS):
+ 	@echo "Building $@"
+-	@mkdir -p $(OBJDIR)/$(@)
+-	@$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
++	mkdir -p $(OBJDIR)/$(@)
++	$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+ 
+ $(OBJ_WS_CORE): $(FILES) $(OBJ_WS_X11_CORE)
+ 	@echo "  $(LD) $(notdir $(@))"
+-	@$(LD) -o $(OBJ_WS_CORE) $(MERGE_FLAGS) $(PACKAGES) $(OBJ_WS_X11_CORE) $(FILES)
++	$(LD) -o $(OBJ_WS_CORE) $(MERGE_FLAGS) $(PACKAGES) $(OBJ_WS_X11_CORE) $(FILES)
+ 
+ $(OBJ_WS_X11_CORE): $(SUBDIRS)
+diff --git a/src/ui/ws/x11/Makefile b/src/ui/ws/x11/Makefile
+index b99e93d..7bffca3 100644
+--- a/src/ui/ws/x11/Makefile
++++ b/src/ui/ws/x11/Makefile
+@@ -1,3 +1,9 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
+ FILES                   = $(addprefix $(OBJDIR)/, $(patsubst %.cpp, %.o, $(wildcard *.cpp)))
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ INCLUDE                += $(XLIB_HEADERS) $(CAIRO_HEADERS)
+@@ -8,9 +14,9 @@ all: $(OBJ_WS_X11_CORE)
+ 
+ $(OBJ_WS_X11_CORE): $(FILES)
+ 	@echo "  $(LD) $(notdir $(@))"
+-	@$(LD) -o $(OBJ_WS_X11_CORE) $(MERGE_FLAGS) -r $(FILES)
++	$(LD) -o $(OBJ_WS_X11_CORE) $(MERGE_FLAGS) -r $(FILES)
+ 
+ $(FILES):
+ 	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
++	$(CXX) -o $(@) -c $(FILE) -fPIC $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) 
+ 
+diff --git a/src/ui/ws/x11/X11Display.cpp b/src/ui/ws/x11/X11Display.cpp
+index d85db51..987e8a9 100644
+--- a/src/ui/ws/x11/X11Display.cpp
++++ b/src/ui/ws/x11/X11Display.cpp
+@@ -23,7 +23,7 @@
+ 
+ #ifdef USE_X11_DISPLAY
+ 
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <errno.h>
+ #include <stdlib.h>
+ 
+@@ -233,7 +233,7 @@ namespace lsp
+                 while (!atomic_cas(&hLock, 0, 1)) { /* Wait */ }
+ 
+                 // Dispatch errors between Displays
+-                for (X11Display *dp = pHandlers; dp != NULL; ++dp)
++                for (X11Display *dp = pHandlers; dp != NULL; dp = dp->pNextHandler)
+                     if (dp->pDisplay == dpy)
+                         dp->handle_error(ev);
+ 
+diff --git a/src/utils/Makefile b/src/utils/Makefile
+index 88b3739..4b4fd2e 100644
+--- a/src/utils/Makefile
++++ b/src/utils/Makefile
+@@ -1,12 +1,24 @@
++# Command-line flag to silence nested $(MAKE).
++MAKE_OPTS              += VERBOSE=$(VERBOSE)
++ifneq ($(VERBOSE),1)
++.SILENT:
++endif
++
++CXX                     = $(HOST_CXX)
++CXXFLAGS                = $(HOST_CXXFLAGS)
++MAKE_OPTS              += CXX=$(HOST_CXX) CXXFLAGS=$(HOST_CXXFLAGS)
++
+ MODULES                 = $(UTL_RESGEN) 
+ FILELIST                = resource_gen.o 
+ FILE                    = $(@:$(OBJDIR)/%.o=%.cpp)
+ SUBDIRS                 =
+-OBJ_FILES               = $(OBJ_CORE) $(OBJ_METADATA)
++OBJ_FILES               = $(HOST_OBJ_CORE) $(HOST_OBJ_METADATA) $(HOST_OBJ_DSP)
+ OBJ_LIBS                = $(PTHREAD_LIBS) $(MATH_LIBS)
+ OBJ_EXTRA               =
+ INCLUDE_EXTRA           =
+ 
++export PKG_CONFIG_SYSROOT_DIR = /
++
+ ifeq ($(BUILD_PLATFORM),BSD)
+   OBJ_LIBS               += $(ICONV_LIBS)
+ endif
+@@ -18,7 +30,7 @@ endif
+ ifeq ($(findstring lv2,$(BUILD_MODULES)),lv2)
+   MODULES                += $(UTL_GENTTL)
+   FILELIST               += lv2_genttl.o
+-  INCLUDE_EXTRA          += $(LV2_HEADERS)
++  INCLUDE_EXTRA          += $(HOST_LV2_HEADERS)
+ endif
+ ifeq ($(findstring vst,$(BUILD_MODULES)),vst)
+   MODULES                += $(UTL_VSTMAKE)
+@@ -44,32 +56,30 @@ target: all
+ # Common rules
+ $(SUBDIRS):
+ 	@echo "Building $@"
+-	@mkdir -p $(OBJDIR)/$(@)
+-	@$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
++	mkdir -p $(OBJDIR)/$(@)
++	$(MAKE) $(MAKE_OPTS) -C $@ $(MAKECMDGOALS) OBJDIR=$(OBJDIR)/$(@)
+ 
+ $(FILES):
+-	@echo "  $(CXX) $(FILE)"
+-	@$(CXX) -o $(@) -c $(FILE) $(CPPFLAGS) -fPIC $(CXXFLAGS) $(INCLUDE) $(INCLUDE_EXTRA)
++	@echo "  $(HOST_CXX) $(FILE)"
++	$(HOST_CXX) -o $(@) -c $(FILE) $(CPPFLAGS) -fPIC $(HOST_CXXFLAGS) $(INCLUDE) $(INCLUDE_EXTRA)
+ 
+ # Rules for each utility
+-$(UTL_GENTTL): $(FILES) $(SUBDIRS)
+-	@echo "  $(CXX) $(notdir $(UTL_GENTTL))"
+-	@$(CXX) -o $(UTL_GENTTL) $(OBJDIR)/lv2_genttl.o $(OBJ_FILES) $(EXE_FLAGS) $(SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS) $(LV2_LIBS)
++$(UTL_GENTTL): $(OBJ_FILES) $(FILES) $(SUBDIRS)
++	@echo "  $(HOST_CXX) $(notdir $(UTL_GENTTL))"
++	$(HOST_CXX) -o $(UTL_GENTTL) $(OBJDIR)/lv2_genttl.o $(OBJ_FILES) $(HOST_EXE_FLAGS) $(HOST_SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS) $(LV2_LIBS)
+ 	
+-$(UTL_JACKMAKE): $(FILES) $(SUBDIRS)
+-	@echo "  $(CXX) $(notdir $(UTL_JACKMAKE))"
+-	@$(CXX) -o $(UTL_JACKMAKE) $(OBJDIR)/jack_genmake.o $(OBJ_FILES) $(EXE_FLAGS) $(SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
++$(UTL_JACKMAKE): $(OBJ_FILES) $(FILES) $(SUBDIRS)
++	@echo "  $(HOST_CXX) $(notdir $(UTL_JACKMAKE))"
++	$(HOST_CXX) -o $(UTL_JACKMAKE) $(OBJDIR)/jack_genmake.o $(OBJ_FILES) $(HOST_EXE_FLAGS) $(HOST_SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
+ 	
+-$(UTL_VSTMAKE): $(FILES) $(SUBDIRS)
+-	@echo "  $(CXX) $(notdir $(UTL_VSTMAKE))"
+-	@$(CXX) -o $(UTL_VSTMAKE) $(OBJDIR)/vst_genmake.o $(OBJ_FILES) $(EXE_FLAGS) $(DL_LIBS) $(OBJ_LIBS)
++$(UTL_VSTMAKE): $(OBJ_FILES) $(FILES) $(SUBDIRS)
++	@echo "  $(HOST_CXX) $(notdir $(UTL_VSTMAKE))"
++	$(HOST_CXX) -o $(UTL_VSTMAKE) $(OBJDIR)/vst_genmake.o $(OBJ_FILES) $(HOST_EXE_FLAGS) $(HOST_SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
+ 	
+-$(UTL_GENPHP): $(FILES) $(SUBDIRS)
+-	@echo "  $(CXX) $(notdir $(UTL_GENPHP))"
+-	@$(CXX) -o $(UTL_GENPHP) $(OBJDIR)/gen_php.o $(OBJ_FILES) $(EXE_FLAGS) $(SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
++$(UTL_GENPHP): $(OBJ_FILES) $(FILES) $(SUBDIRS)
++	@echo "  $(HOST_CXX) $(notdir $(UTL_GENPHP))"
++	$(HOST_CXX) -o $(UTL_GENPHP) $(OBJDIR)/gen_php.o $(OBJ_FILES) $(HOST_EXE_FLAGS) $(HOST_SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
+ 	
+-$(UTL_RESGEN): $(FILES) $(SUBDIRS)
+-	@echo "  $(CXX) $(notdir $(UTL_RESGEN))"
+-	@$(CXX) -o $(UTL_RESGEN) $(OBJDIR)/resource_gen.o $(OBJ_FILES) $(OBJ_DSP) $(OBJ_EXTRA) $(EXE_FLAGS) $(SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
+-
+-	
+\ No newline at end of file
++$(UTL_RESGEN): $(OBJ_FILES) $(FILES) $(SUBDIRS)
++	@echo "  $(HOST_CXX) $(notdir $(UTL_RESGEN))"
++	$(HOST_CXX) -o $(UTL_RESGEN) $(OBJDIR)/resource_gen.o $(OBJ_FILES) $(OBJ_EXTRA) $(HOST_EXE_FLAGS) $(HOST_SNDFILE_LIBS) $(DL_LIBS) $(OBJ_LIBS)
+diff --git a/src/utils/jack_genmake.cpp b/src/utils/jack_genmake.cpp
+index 09974b0..3272ad8 100644
+--- a/src/utils/jack_genmake.cpp
++++ b/src/utils/jack_genmake.cpp
+@@ -97,6 +97,11 @@ namespace lsp
+         }
+ 
+         fprintf(out, "# Auto generated makefile, do not edit\n\n");
++        fprintf(out, "MAKE_OPTS              += VERBOSE=$(VERBOSE)\n");
++        fprintf(out, "ifneq ($(VERBOSE),1)\n");
++        fprintf(out, ".SILENT:\n");
++        fprintf(out, "endif\n");
++        fprintf(out, "\n");
+ 
+         fprintf(out, "FILES                   = $(patsubst %%.cpp, %%, $(wildcard *.cpp))\n");
+         fprintf(out, "FILE                    = $(@:%%=%%.cpp)\n");
+@@ -107,11 +112,11 @@ namespace lsp
+         fprintf(out, "all: $(FILES)\n\n");
+ 
+         fprintf(out, "$(FILES):\n");
+-        fprintf(out, "\t@echo \"  $(CXX) $(FILE)\"\n");
+-        fprintf(out, "\t@$(CXX) -o $(@) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(FILE) $(EXE_FLAGS) $(DL_LIBS)\n\n");
++        fprintf(out, "\techo \"  $(CXX) $(FILE)\"\n");
++        fprintf(out, "\t$(CXX) -o $(@) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(FILE) $(EXE_FLAGS) $(DL_LIBS)\n\n");
+ 
+         fprintf(out, "install: $(FILES)\n");
+-        fprintf(out, "\t@$(INSTALL) $(FILES) $(TARGET_PATH)/");
++        fprintf(out, "\t$(INSTALL) $(FILES) $(TARGET_PATH)/");
+ 
+         // Close file
+         fclose(out);
+diff --git a/src/utils/vst_genmake.cpp b/src/utils/vst_genmake.cpp
+index 9eeedeb..f47f783 100644
+--- a/src/utils/vst_genmake.cpp
++++ b/src/utils/vst_genmake.cpp
+@@ -100,6 +100,11 @@ namespace lsp
+         }
+ 
+         fprintf(out, "# Auto generated makefile, do not edit\n\n");
++        fprintf(out, "MAKE_OPTS              += VERBOSE=$(VERBOSE)\n");
++        fprintf(out, "ifneq ($(VERBOSE),1)\n");
++        fprintf(out, ".SILENT:\n");
++        fprintf(out, "endif\n");
++        fprintf(out, "\n");
+ 
+         fprintf(out, "FILES                   = $(patsubst %%.cpp, %%.so, $(wildcard *.cpp))\n");
+         fprintf(out, "FILE                    = $(@:%%.so=%%.cpp)\n");
+@@ -110,8 +115,8 @@ namespace lsp
+         fprintf(out, "all: $(FILES)\n\n");
+ 
+         fprintf(out, "$(FILES):\n");
+-        fprintf(out, "\t@echo \"  $(CXX) $(FILE)\"\n");
+-        fprintf(out, "\t@$(CXX) -o $(@) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(FILE) $(SO_FLAGS) $(DL_LIBS)\n\n");
++        fprintf(out, "\techo \"  $(CXX) $(FILE)\"\n");
++        fprintf(out, "\t$(CXX) -o $(@) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) $(FILE) $(SO_FLAGS) $(DL_LIBS)\n\n");
+ 
+         // Close file
+         fclose(out);
+diff --git a/tmp/.gitignore b/tmp/.gitignore
+index 22e8364..d6b7ef3 100644
+--- a/tmp/.gitignore
++++ b/tmp/.gitignore
+@@ -1 +1,2 @@
+-/*
+\ No newline at end of file
++*
++!.gitignore

--- a/srcpkgs/lsp-plugins-lv2/template
+++ b/srcpkgs/lsp-plugins-lv2/template
@@ -1,0 +1,75 @@
+# Template file for 'lsp-plugins-lv2'
+pkgname=lsp-plugins-lv2
+version=1.1.30
+revision=1
+wrksrc=lsp-plugins-${version}
+build_style=gnu-makefile
+make_build_args="VERBOSE=1 PREFIX=/usr"
+make_check_args=$make_build_args
+make_install_target="install install_xdg"
+make_use_env=yes
+hostmakedepends="pkg-config php lv2 libsndfile-devel"
+makedepends="libsndfile-devel libX11-devel libglvnd-devel lv2 cairo-devel
+ ladspa-sdk jack-devel"
+_desc="Collection of free audio plugins"
+short_desc="${_desc} - LV2"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
+license="LGPL-3.0-or-later"
+homepage="https://lsp-plug.in/"
+distfiles="https://github.com/sadko4u/lsp-plugins/archive/refs/tags/${version}.tar.gz"
+checksum=9cf43257729093c240375b3640b1514dff34b092b83b54a5ee68d7e8565c8f80
+
+export SKIP_CC_LD_ARCH=yes
+export HOST_BUILD_ARCH="${XBPS_MACHINE%-*}"
+export HOST_PKG_CONFIG="$PKG_CONFIG_FOR_BUILD"
+if [ -n "$CROSS_BUILD" ]; then
+	export BUILD_ARCH="${XBPS_TARGET_MACHINE%-*}"
+	export HOST_CXXFLAGS="$CXXFLAGS_host"
+	export HOST_CXX="$CXX_host"
+	export HOST_LD="$LD_host"
+else
+	export BUILD_ARCH="${XBPS_MACHINE%-*}"
+	export HOST_CXXFLAGS="$BUILD_CXXFLAGS"
+	export HOST_CXX="$BUILD_CXX"
+	export HOST_LD="$BUILD_LD"
+fi
+
+lsp-plugins-jack_package() {
+	short_desc="${_desc} - JACK"
+	pkg_install() {
+		vmove usr/bin
+		vmove usr/lib/lsp-plugins/lsp-plugins-jack-core*
+		vmove usr/lib/lsp-plugins/lsp-plugins-r3d-glx.so
+		vmove usr/share/applications
+		vmove usr/share/desktop-directories
+		vmove usr/share/icons
+		vmove etc/xdg/menus
+	}
+}
+
+lsp-plugins-ladspa_package() {
+	short_desc="${_desc} - LADSPA"
+	pkg_install() {
+		vmove usr/lib/ladspa/lsp-plugins-ladspa.so
+	}
+}
+
+lsp-plugins-vst_package() {
+	short_desc="${_desc} - VST"
+	pkg_install() {
+		vmove usr/lib/vst
+	}
+}
+
+lsp-plugins_package() {
+	short_desc="${_desc} - LV2, JACK, LADSPA, VST"
+	depends="lsp-plugins-lv2 lsp-plugins-jack lsp-plugins-ladspa lsp-plugins-vst"
+	build_style=meta
+}
+
+lsp-plugins-doc_package() {
+	short_desc="${_desc} - documentation"
+	pkg_install() {
+		vmove usr/share/doc
+	}
+}

--- a/srcpkgs/lsp-plugins-vst
+++ b/srcpkgs/lsp-plugins-vst
@@ -1,0 +1,1 @@
+lsp-plugins-lv2


### PR DESCRIPTION
Required by `pulseeffects` compressor, equalizer, delay & loudness compensator effects.
Also used by `easyeffects`, `pulseeffects`' successor 
Continuation of https://github.com/void-linux/void-packages/pull/29932

TODO:
- [ ] wait for https://github.com/sadko4u/lsp-plugins/pull/198
- [ ] implement `VERBOSE` option into `lsp-plugins` Makefiles to save my sanity debugging them
https://github.com/sadko4u/lsp-plugins/pull/200
- [ ] polish & upstream cross build patch https://github.com/sadko4u/lsp-plugins/pull/202
- [x] fix `i686`
- [x] fix `armv6`
- [x] split the package (ladspa, lv2, vst, jack, doc)
- [x] remove parallel check commit 

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
