### PR TITLE
zita-convolver: add fftw-devel dependency to zita-convolver-devel

### DIFF
--- a/srcpkgs/zita-convolver/template
+++ b/srcpkgs/zita-convolver/template
@@ -1,7 +1,7 @@
 # Template file for 'zita-convolver'
 pkgname=zita-convolver
 version=4.0.3
-revision=2
+revision=3
 build_wrksrc="source"
 build_style=gnu-makefile
 make_install_args="LIBDIR=/usr/lib"
@@ -14,7 +14,7 @@ homepage="http://kokkinizita.linuxaudio.org/linuxaudio/"
 distfiles="http://kokkinizita.linuxaudio.org/linuxaudio/downloads/${pkgname}-${version}.tar.bz2"
 checksum=9aa11484fb30b4e6ef00c8a3281eebcfad9221e3937b1beb5fe21b748d89325f
 
-CXXFLAGS="-fPIC -ffast-math -funroll-loops"
+CXXFLAGS="$CXXFLAGS -fPIC"
 
 post_install() {
 	# add missing symlink
@@ -22,7 +22,7 @@ post_install() {
 }
 
 zita-convolver-devel_package() {
-	depends="${sourcepkg}-${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} fftw-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

Without this change the packages which depend on `zita-convolver-devel` fail to compile due to missing `ftw3.h` header.

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
