### PR TITLE
pulseeffects: update to 5.0.4

### DIFF
--- a/srcpkgs/pulseeffects-legacy/template
+++ b/srcpkgs/pulseeffects-legacy/template
@@ -1,21 +1,20 @@
 # Template file for 'pulseeffects-legacy'
 pkgname=pulseeffects-legacy
 version=4.8.5
-revision=2
+revision=3
 wrksrc="pulseeffects-${version}"
 build_style=meson
 hostmakedepends="itstool pkg-config gettext"
 makedepends="boost-devel glib-devel gsettings-desktop-schemas-devel
  gst-plugins-bad1-devel gtkmm-devel libebur128-devel lilv-devel
- pulseaudio-devel python3-gobject-devel sratom-devel
- libsndfile-devel rnnoise-devel"
-depends="calf gsettings-desktop-schemas gst-plugins-bad1
- gst-plugins-good1 pulseaudio python3-gobject python3-scipy"
+ pulseaudio-devel sratom-devel zita-convolver-devel libbs2b-devel
+ libsamplerate-devel libsndfile-devel rnnoise-devel"
+depends="calf gst-plugins-good1 gst-plugins-bad1"
 short_desc="Sound effects for systems using PulseAudio (legacy)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/pulseeffects"
+changelog="https://raw.githubusercontent.com/wwmm/pulseeffects/pulseaudio-legacy/CHANGELOG.md"
 distfiles="https://github.com/wwmm/pulseeffects/archive/v${version}.tar.gz"
 checksum=df1c4c4a9811c62a549822dacde3a9e36233ba3ec58817ae52a236f6181a507c
-python_version=3
 conflicts="pulseeffects"

--- a/srcpkgs/pulseeffects/template
+++ b/srcpkgs/pulseeffects/template
@@ -1,20 +1,18 @@
 # Template file for 'pulseeffects'
 pkgname=pulseeffects
-version=5.0.3
-revision=2
+version=5.0.4
+revision=1
 build_style=meson
 hostmakedepends="itstool pkg-config gettext"
 makedepends="boost-devel glib-devel gsettings-desktop-schemas-devel
  gst-plugins-bad1-devel gtkmm-devel libebur128-devel lilv-devel
- pipewire-devel python3-gobject-devel sratom-devel zita-convolver-devel
- libsndfile-devel libbs2b-devel rnnoise-devel"
-depends="calf gsettings-desktop-schemas gst-plugins-bad1
- gst-plugins-good1 pipewire python3-gobject python3-scipy zita-convolver
- gstreamer1-pipewire"
+ pipewire-devel sratom-devel zita-convolver-devel libbs2b-devel
+ libsamplerate-devel libsndfile-devel rnnoise-devel"
+depends="calf gstreamer1-pipewire gst-plugins-good1 gst-plugins-bad1"
 short_desc="Sound effects for systems using PipeWire"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/wwmm/pulseeffects"
+changelog="https://raw.githubusercontent.com/wwmm/pulseeffects/master/CHANGELOG.md"
 distfiles="https://github.com/wwmm/pulseeffects/archive/v${version}.tar.gz"
-checksum=2e14858918b54bee5f6e4898cc803ae2170b4d624407fef39e0831b6584c4a4f
-python_version=3
+checksum=3fa482e2261fe467e30c05e85a55904806b0dc141834fe8b5cfeffedb6da65e8


### PR DESCRIPTION
- pulseeffects: update to 5.0.4 & remove unneded python deps
- pulseeffects-legacy: remove unneded python deps

~~Blocked by https://github.com/void-linux/void-packages/pull/31666, though magically CI passed, I really don't know why!~~
**UPD**: see https://github.com/void-linux/void-packages/pull/31667#issuecomment-869485860

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
