### PR TITLE
[ci skip] New package: mold-0.9.1

### DIFF
--- a/srcpkgs/mold/patches/00-makefile.patch
+++ b/srcpkgs/mold/patches/00-makefile.patch
@@ -1,0 +1,79 @@
+diff --git a/Makefile b/Makefile
+index 3778c00..ef134a9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,14 +2,14 @@ CC = clang
+ CXX = clang++
+ 
+ MIMALLOC_LIB = mimalloc/out/release/libmimalloc.a
+-GIT_HASH = $(shell [ -d .git ] && git rev-parse HEAD)
++GIT_HASH ?= $(shell [ -d .git ] && git rev-parse HEAD)
+ 
+ CPPFLAGS = -g -Imimalloc/include -pthread -std=c++20 \
+            -Wno-deprecated-volatile \
+            -DMOLD_VERSION=\"0.9.1\" \
+            -DGIT_HASH=\"$(GIT_HASH)\" \
+ 	   $(EXTRA_CPPFLAGS)
+-LDFLAGS = $(EXTRA_LDFLAGS)
++LDFLAGS += $(EXTRA_LDFLAGS)
+ LIBS = -Wl,-as-needed -lcrypto -pthread -ltbb -lz -lxxhash -ldl
+ OBJS = main.o object_file.o input_sections.o output_chunks.o \
+        mapfile.o perf.o linker_script.o archive_file.o output_file.o \
+@@ -41,7 +41,11 @@ else
+   # By default, we want to use mimalloc as a memory allocator.
+   # Since replacing the standard malloc is not compatible with ASAN,
+   # we do that only when ASAN is not enabled.
+-  LDFLAGS += -Wl,-whole-archive $(MIMALLOC_LIB) -Wl,-no-whole-archive
++  ifndef SYSTEM_MIMALLOC
++    LIBS += -Wl,-whole-archive $(MIMALLOC_LIB) -Wl,-no-whole-archive
++  else
++    LIBS += -lmimalloc
++  endif
+ endif
+ 
+ ifeq ($(TSAN), 1)
+@@ -51,8 +55,12 @@ endif
+ 
+ all: mold mold-wrapper.so
+ 
++ifdef SYSTEM_MIMALLOC
++  undefine MIMALLOC_LIB
++endif
++
+ mold: $(OBJS) $(MIMALLOC_LIB)
+-	$(CXX) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS) $(LIBS)
++	$(CXX) $(CXXFLAGS) $(OBJS) -o $@ $(LDFLAGS) $(LIBS)
+ 
+ mold-wrapper.so: mold-wrapper.c Makefile
+ 	$(CC) -fPIC -shared -o $@ $< -ldl
+@@ -68,20 +76,21 @@ test tests check: all
+ 	 $(MAKE) -C test --output-sync --no-print-directory
+ 
+ install: all
+-	install -m 755 mold $(PREFIX)/bin
++	install -m 755 mold $(DESTDIR)$(PREFIX)/bin
+ 	strip $(PREFIX)/bin/mold
+ 
+-	install -m 755 -d $(PREFIX)/lib/mold
+-	install -m 644 mold-wrapper.so $(PREFIX)/lib/mold
+-	strip $(PREFIX)/lib/mold/mold-wrapper.so
++	install -m 755 -d $(DESTDIR)$(PREFIX)/lib/mold
++	install -m 644 mold-wrapper.so $(DESTDIR)$(PREFIX)/lib/mold
++	strip $(DESTDIR)$(PREFIX)/lib/mold/mold-wrapper.so
+ 
+-	install -m 644 docs/mold.1 $(PREFIX)/share/man/man1
+-	rm -f $(PREFIX)/share/man/man1/mold.1.gz
+-	gzip -9 $(PREFIX)/share/man/man1/mold.1
++	install -m 755 -d $(DESTDIR)$(PREFIX)/share/man/man1
++	install -m 644 docs/mold.1 $(DESTDIR)$(PREFIX)/share/man/man1
++	rm -f $(DESTDIR)$(PREFIX)/share/man/man1/mold.1.gz
++	gzip -9 $(DESTDIR)$(PREFIX)/share/man/man1/mold.1
+ 
+ uninstall:
+-	rm -rf $(PREFIX)/bin/mold $(PREFIX)/share/man/man1/mold.1.gz \
+-	       $(PREFIX)/lib/mold
++	rm -rf $(DESTDIR)$(PREFIX)/bin/mold $(DESTDIR)$(PREFIX)/share/man/man1/mold.1.gz \
++	       $(DESTDIR)$(PREFIX)/lib/mold
+ 
+ clean:
+ 	rm -rf *.o *~ mold mold-wrapper.so test/tmp

--- a/srcpkgs/mold/template
+++ b/srcpkgs/mold/template
@@ -1,0 +1,36 @@
+# Template file for 'mold'
+pkgname=mold
+version=0.9.1
+revision=1
+build_style=gnu-makefile
+make_build_args="SYSTEM_MIMALLOC=1"
+hostmakedepends="clang"
+makedepends="mimalloc-devel openssl-devel xxHash-devel tbb-devel"
+short_desc="High performance drop-in replacement for existing Unix linkers"
+maintainer="Artur Sinila <freesoftware@logarithmus.dev>"
+license="AGPL-3.0-or-later"
+homepage="https://github.com/rui314/mold"
+changelog="https://github.com/rui314/mold/releases"
+distfiles="https://github.com/rui314/mold/archive/refs/tags/v${version}.tar.gz"
+checksum=02b156de6cd2d94fea4eed9748a7c96955673d810ec672359f603f2f90e2990d
+_commit_hash=9a09c777d9460ebe7eb498d1cc0327915f8bbcdc
+
+pre_build() {
+	# gcc 10.2 doesn't fully support C++20
+ 	export CXX=clang++
+
+ 	# "non-PIE executable found in PIE build" without these lines
+ 	CXXFLAGS+=" -fPIC"
+	LDFLAGS+=" -pie"
+
+	# commit hash for --version
+	export GIT_HASH=$_commit_hash
+}
+
+pre_install() {
+	vmkdir usr/bin
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
[ci skip]

<!-- Mark items with [x] where applicable -->


Blocked on https://github.com/void-linux/void-packages/pull/31706

The package failed to build due to this error:
```
/usr/bin/x86_64-unknown-linux-gnu-ld: /usr/bin/../lib64/gcc/x86_64-unknown-linux-gnu/10.2/crtbegin.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a PIE object
```
Fixed after replacing `-Wl,-pie` with just `-pie`

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
