### PR TITLE
deluge: set config dir to homedir

### DIFF
--- a/srcpkgs/deluge/files/deluged/run
+++ b/srcpkgs/deluge/files/deluged/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r ./conf ] && . ./conf
-exec deluged -d -U deluge -g deluge ${OPTS} 2>&1
+exec chpst -u deluge:deluge deluged -d ${OPTS} 2>&1

--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,7 +1,7 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=2.0.3
-revision=10
+revision=11
 build_style=python3-module
 # TODO package python3-slimit to minify javascript
 hostmakedepends="intltool python3-setuptools python3-wheel"


### PR DESCRIPTION
While we're at it, drop priviledge early.

Fix: https://github.com/void-linux/void-packages/issues/31690

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
