### PR TITLE
qt5-speech: add other solibs to -devel depends.

### DIFF
--- a/srcpkgs/qt5-speech/template
+++ b/srcpkgs/qt5-speech/template
@@ -2,7 +2,7 @@
 pkgname=qt5-speech
 reverts="5.15.3+20210429_1 5.15.3+20210429_2"
 version=5.15.2
-revision=6
+revision=7
 wrksrc="qtspeech-everywhere-src-${version}"
 build_style=qmake
 configure_args="-- -flite -flite-alsa -speechd"
@@ -40,7 +40,9 @@ _cleanup_wrksrc_leak() {
 }
 
 qt5-speech-devel_package() {
-	depends="qt5-devel>=${version} ${sourcepkg}>=${version}_${revision}"
+	depends="qt5-devel>=${version} ${sourcepkg}>=${version}_${revision}
+		${sourcepkg}-plugin-speechd>=${version}_${revision}
+		${sourcepkg}-plugin-flite>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
@@ -57,7 +59,6 @@ qt5-speech-plugin-speechd_package() {
 	short_desc+=" - Speech dispatcher Plugin"
 	pkg_install() {
 		vmove usr/lib/qt5/plugins/texttospeech/libqtexttospeech_speechd.so
-
 	}
 }
 
@@ -65,6 +66,5 @@ qt5-speech-plugin-flite_package() {
 	short_desc+=" - Flite Plugin"
 	pkg_install() {
 		vmove usr/lib/qt5/plugins/texttospeech/libqttexttospeech_flite.so
-
 	}
 }


### PR DESCRIPTION
The cmake file references them and so without this change it breaks
builds using qt5-speech-devel with cmake (eg knotifications,
ktextwidgets).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
