### PR TITLE
libtorrent-rasterbar: update to 1.2.14.

### DIFF
--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -1,7 +1,7 @@
 # Template file for 'libtorrent-rasterbar'
 # Breaks ABI/API without changing soname, revbump all dependants
 pkgname=libtorrent-rasterbar
-version=1.2.13
+version=1.2.14
 revision=1
 build_style=cmake
 configure_args="-DCMAKE_CXX_STANDARD=11 -Dbuild_examples=ON -Dbuild_tools=ON
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://libtorrent.org/"
 distfiles="https://github.com/arvidn/libtorrent/releases/download/v${version}/${pkgname}-${version}.tar.gz"
-checksum=976d2771ffcd564f08a63351e9c22e842aaa8cd29f6f7fe25d169c038a844e85
+checksum=9e27bf359b45236d4490960faffc796528f3adbdea6aeb6881d39f310e27953f
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dbuild_tests=ON"


### PR DESCRIPTION
#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

qBittorrent builds successfully with the new library version.

#### Does it build and run successfully? 
- [X] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl