### PR TITLE
libcaca: enable imlib2 support by default + add opengl build option

### DIFF
--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -1,19 +1,20 @@
 # Template file for 'libcaca'
 pkgname=libcaca
 version=0.99.beta19
-revision=8
+revision=9
 build_style=gnu-configure
+configure_args="$(vopt_if x11 '' '--disable-x11')"
 hostmakedepends="libtool automake pkg-config"
+makedepends="ncurses-devel imlib2-devel $(vopt_if opengl 'libfreeglut-devel')"
 short_desc="Graphics library that outputs text instead of pixels"
 maintainer="Orphaned <orphan@voidlinux.org>"
-makedepends="ncurses-devel $(vopt_if x11 'libX11-devel imlib2-devel')"
-homepage="http://caca.zoy.org/wiki/libcaca"
 license="WTFPL"
+homepage="http://caca.zoy.org/wiki/libcaca"
 distfiles="https://github.com/cacalabs/libcaca/archive/v${version}.tar.gz"
 checksum=7ed29a00cc7f017424d8b2994f001f137ed5bc4441987b711d78c6734fdf3493
 
 # package build options
-build_options="x11"
+build_options="x11 opengl"
 
 pre_configure() {
 	sed -i -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,' configure.ac


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Revived from issue #5159. Without imlib2 support libcaca only works with BMP format, which seems limited.

Rendering with opengl is nice to have, but I make it optional, as x11 rendering option.
