### PR TITLE
Omnibus lint pass for SPDX warnings - packages starting with Y

### DIFF
--- a/srcpkgs/yabause-gtk/template
+++ b/srcpkgs/yabause-gtk/template
@@ -1,16 +1,16 @@
 # Template file for 'yabause-gtk'
 pkgname=yabause-gtk
 version=0.9.15
-revision=1
+revision=2
 wrksrc="${pkgname%-gtk}-${version}"
 build_style=cmake
 configure_args="-DYAB_PORTS=gtk -DYAB_NETWORK=ON -DYAB_OPTIMIZED_DMA=ON"
 hostmakedepends="pkg-config"
 makedepends="libXmu-devel libfreeglut-devel gtkglext-devel libopenal-devel SDL2-devel"
 depends="desktop-file-utils"
-short_desc="A Sega Saturn emulator with GTK UI)"
+short_desc="Sega Saturn emulator with GTK UI)"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://yabause.org/"
 distfiles="https://download.tuxfamily.org/yabause/releases/${version}/yabause-${version}.tar.gz"
 checksum=4334c43fe0f3ff297bac8e91f4e059fe5fd276291faff2489e37b5b3a4ccc2b2

--- a/srcpkgs/yeahconsole/template
+++ b/srcpkgs/yeahconsole/template
@@ -1,12 +1,12 @@
 # Template file for 'yeahconsole'
 pkgname=yeahconsole
 version=0.3.4
-revision=2
+revision=3
 build_style=gnu-makefile
 makedepends="libX11-devel"
 short_desc="Turns an xterm or rxvt-unicode into a game-like console"
 maintainer="Duncaen <duncaen@voidlinux.org>"
-license="GPL-3"
+license="GPL-2.0-or-later"
 homepage="http://phrat.de/yeahtools.html"
 distfiles="http://phrat.de/yeahconsole-${version}.tar.gz"
 checksum=fcf3481f78a263a70f1cb5163630fc22e78bb0915013eb05689c6f4aeb0583ef

--- a/srcpkgs/ykpers-gui/template
+++ b/srcpkgs/ykpers-gui/template
@@ -10,8 +10,8 @@ makedepends="qt5-devel libusb-compat-devel libyubikey-devel libykpers-devel"
 depends="hicolor-icon-theme"
 short_desc="Yubikey Personalization Tools GUI"
 maintainer="yopito <pierre.bourgin@free.fr>"
-license="BSD"
-homepage="https://developers.yubico.com/${_realname}/"
+license="BSD-2-Clause"
+homepage="https://developers.yubico.com/yubikey-personalization-gui"
 distfiles="https://developers.yubico.com/${_realname}/Releases/${_realname}-${version}.tar.gz"
 checksum=680b8ba8251c828847ffddd520165ac14927c2c6ee4ae39cfa9022ad7dd9dece
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

