### PR TITLE
Omnibus lint pass for SPDX warnings - packages starting with Z

### DIFF
--- a/srcpkgs/zisofs-tools/template
+++ b/srcpkgs/zisofs-tools/template
@@ -1,14 +1,14 @@
 # Template file for 'zisofs-tools'
 pkgname=zisofs-tools
 version=1.0.8
-revision=5
+revision=6
 build_style=gnu-configure
 makedepends="zlib-devel"
 short_desc="ISO9660 transparent compression tool"
-homepage="https://www.kernel.org/pub/linux/utils/fs/zisofs/"
-license="GPL-2"
 maintainer="Orphaned <orphan@voidlinux.org>"
-distfiles="http://pkgs.fedoraproject.org/repo/pkgs/zisofs-tools/zisofs-tools-1.0.8.tar.bz2/2d0ed8c9a1f60b45f949b136f9be1f6c/$pkgname-$version.tar.bz2"
+license="GPL-2.0-or-later"
+homepage="https://mirrors.edge.kernel.org/pub/linux/utils/fs/zisofs/README"
+distfiles="http://pkgs.fedoraproject.org/repo/pkgs/zisofs-tools/zisofs-tools-${version}.tar.bz2/2d0ed8c9a1f60b45f949b136f9be1f6c/$pkgname-$version.tar.bz2"
 checksum=ae4e53e4914934d41660248fb59d3c8761f1f1fd180d5ec993c17ddb3afd04f3
 
 do_install() {

--- a/srcpkgs/zmap/template
+++ b/srcpkgs/zmap/template
@@ -1,17 +1,18 @@
 # Template file for 'zmap'
 pkgname=zmap
 version=2.1.1
-revision=4
+revision=5
 build_style=cmake
 conf_files="/etc/zmap/blacklist.conf /etc/zmap/zmap.conf"
 hostmakedepends="flex byacc gengetopt pkg-config"
 makedepends="libpcap-devel gmp-devel json-c-devel"
 short_desc="Fast network scanner designed for Internet-wide network surveys"
 maintainer="Duncaen <mail@duncano.de>"
-license="Apache"
+license="Apache-2.0"
 homepage="https://zmap.io"
 distfiles="https://github.com/zmap/zmap/archive/v${version}.tar.gz"
 checksum=29627520c81101de01b0213434adb218a9f1210bfd3f2dcfdfc1f975dbce6399
+make_check=no # does not define any checks
 
 do_configure() {
 	cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release .
@@ -27,5 +28,4 @@ do_install() {
 	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
 	vmkdir etc/zmap
 	vcopy conf/* etc/zmap
-	vlicense LICENSE
 }

--- a/srcpkgs/zsnes/template
+++ b/srcpkgs/zsnes/template
@@ -1,14 +1,12 @@
 # Template file for 'zsnes'
 #
 # 32bit
-archs="i686"
-lib32mode="full"
-wrksrc="zsnes_1_51"
-build_wrksrc="src"
-
 pkgname=zsnes
 version=1.51
-revision=3
+revision=4
+archs="i686"
+wrksrc="zsnes_1_51"
+build_wrksrc="src"
 build_style=gnu-configure
 configure_args="force_arch=i686"
 hostmakedepends="nasm pkg-config"
@@ -16,10 +14,11 @@ makedepends="MesaLib-devel SDL-devel libpng-devel ncurses-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Super Nintendo emulator"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
-homepage="http://www.zsnes.com/"
+license="GPL-2.0-only"
+homepage="https://www.zsnes.com/"
 distfiles="${SOURCEFORGE_SITE}/zsnes/zsnes151src.tar.bz2"
 checksum=2856dedba272e9eed66cbf68dd4a9ae56797c373686c57371a65c7df35264623
+lib32mode="full"
 
 CFLAGS="-fcommon"
 

--- a/srcpkgs/zsync/template
+++ b/srcpkgs/zsync/template
@@ -1,16 +1,16 @@
 # Template file for 'zsync'
 pkgname=zsync
 version=0.6.2
-revision=3
+revision=4
 build_style=gnu-configure
+checkdepends="perl"
 short_desc="Client-side implementation of the rsync algorithm"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="Artistic"
+license="Artistic-2.0"
 homepage="http://zsync.moria.org.uk/"
 distfiles="http://zsync.moria.org.uk/download/zsync-$version.tar.bz2"
 checksum=0b9d53433387aa4f04634a6c63a5efa8203070f2298af72a705f9be3dda65af2
 
 post_extract() {
-	sed -i "11a#include <sys/types.h>" libzsync/sha1.h
+	vsed -i "11a#include <sys/types.h>" libzsync/sha1.h
 }
-


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

