### PR TITLE
gnome-font-viewer: needs gettext in hostmakedepends.

### DIFF
--- a/srcpkgs/gnome-font-viewer/template
+++ b/srcpkgs/gnome-font-viewer/template
@@ -1,9 +1,9 @@
 # Template file for 'gnome-font-viewer'
 pkgname=gnome-font-viewer
 version=40.0
-revision=1
+revision=2
 build_style=meson
-hostmakedepends="pkg-config glib-devel"
+hostmakedepends="pkg-config glib-devel gettext"
 makedepends="fontconfig-devel freetype-devel glib-devel gtk+3-devel
  gnome-desktop-devel harfbuzz-devel libhandy1-devel"
 depends="desktop-file-utils"


### PR DESCRIPTION
This also fixes the lack of desktop file, as package installs translated file
which was getting ignored when gettext was not found on the host system:
https://gitlab.gnome.org/GNOME/gnome-font-viewer/-/blob/1e5b/src/meson.build#L42

Fixes #31730

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
