### PR TITLE
New package: ART-1.9.3

### DIFF
--- a/srcpkgs/ART/template
+++ b/srcpkgs/ART/template
@@ -1,0 +1,15 @@
+# Template file for 'ART'
+pkgname=ART
+version=1.9.3
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config"
+makedepends="fftw-devel gtkmm-devel lensfun-devel libatomic-devel
+ libcanberra-devel libgomp-devel libiptcdata-devel librsvg-devel exiv2-devel"
+depends="desktop-file-utils hicolor-icon-theme"
+short_desc="Fork of RawTherapee with additional features"
+maintainer="notthewave <winklbauer_m@zoho.eu>"
+license="GPL-3.0-or-later"
+homepage="https://bitbucket.org/agriggio/art/wiki/Home"
+distfiles="https://bitbucket.org/agriggio/art/downloads/${pkgname}-${version}.tar.xz"
+checksum=4e3bacec3f7a01ee72cc565b3f522bb5939c47f0279ac44f85bb344a000bcb8e


### PR DESCRIPTION
ART is a fork of RawTherapee with at least a dozen useful changes. It also takes some code from Darktable.
~~Chose ART as pkgname as art is too conventional (tar.gz has no name in it)~~

#### General
- [x] This is a new package, and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-musl) runs great, edited several photos!
- Did not test on other platforms, but should run fine as the template is basically the same as RawTherapee's, the only difference being exiv2 as an additional dependency.