### PR TITLE
xbps-src: retire XBPS_PKGDESTDIR

### DIFF
--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -144,10 +144,9 @@ _vlicense() {
 
 _vinstall() {
 	local file="$1" mode="$2" targetdir="$3" targetfile="$4"
-	local _destdir=
 
-	if [ -z "$DESTDIR" ]; then
-		msg_red "$pkgver: vinstall: DESTDIR unset, can't continue...\n"
+	if [ -z "$PKGDESTDIR" ]; then
+		msg_red "$pkgver: vinstall: PKGDESTDIR unset, can't continue...\n"
 		return 1
 	fi
 
@@ -161,24 +160,18 @@ _vinstall() {
 		return 1
 	fi
 
-	if [ -n "$XBPS_PKGDESTDIR" ]; then
-		_destdir="$PKGDESTDIR"
-	else
-		_destdir="$DESTDIR"
-	fi
-
 	if [ -z "$targetfile" ]; then
-		install -Dm${mode} "${file}" "${_destdir}/${targetdir}/${file##*/}"
+		install -Dm${mode} "${file}" "${PKGDESTDIR}/${targetdir}/${file##*/}"
 	else
-		install -Dm${mode} "${file}" "${_destdir}/${targetdir}/${targetfile##*/}"
+		install -Dm${mode} "${file}" "${PKGDESTDIR}/${targetdir}/${targetfile##*/}"
 	fi
 }
 
 _vcopy() {
-	local files="$1" targetdir="$2" _destdir
+	local files="$1" targetdir="$2"
 
-	if [ -z "$DESTDIR" ]; then
-		msg_red "$pkgver: vcopy: DESTDIR unset, can't continue...\n"
+	if [ -z "$PKGDESTDIR" ]; then
+		msg_red "$pkgver: vcopy: PKGDESTDIR unset, can't continue...\n"
 		return 1
 	fi
 	if [ $# -ne 2 ]; then
@@ -186,23 +179,20 @@ _vcopy() {
 		return 1
 	fi
 
-	if [ -n "$XBPS_PKGDESTDIR" ]; then
-		_destdir="$PKGDESTDIR"
-	else
-		_destdir="$DESTDIR"
-	fi
-
-	cp -a $files ${_destdir}/${targetdir}
+	cp -a $files ${PKGDESTDIR}/${targetdir}
 }
 
 _vmove() {
-	local f files="$1" _destdir _pkgdestdir _targetdir
+	local f files="$1" _targetdir
 
 	if [ -z "$DESTDIR" ]; then
 		msg_red "$pkgver: vmove: DESTDIR unset, can't continue...\n"
 		return 1
 	elif [ -z "$PKGDESTDIR" ]; then
 		msg_red "$pkgver: vmove: PKGDESTDIR unset, can't continue...\n"
+		return 1
+	elif [ "$DESTDIR" = "$PKGDESTDIR" ]; then
+		msg_red "$pkgver: vmove is intended to be used in pkg_install\n"
 		return 1
 	fi
 	if [ $# -ne 1 ]; then
@@ -214,30 +204,22 @@ _vmove() {
 		break
 	done
 
-	if [ -n "$XBPS_PKGDESTDIR" ]; then
-		_pkgdestdir="$PKGDESTDIR"
-		_destdir="$DESTDIR"
-	else
-		_pkgdestdir="$DESTDIR"
-		_destdir="$DESTDIR"
-	fi
-
 	if [ -z "${_targetdir}" ]; then
-		[ ! -d ${_pkgdestdir} ] && install -d ${_pkgdestdir}
-		mv ${_destdir}/$files ${_pkgdestdir}
+		[ ! -d ${PKGDESTDIR} ] && install -d ${PKGDESTDIR}
+		mv ${DESTDIR}/$files ${PKGDESTDIR}
 	else
-		if [ ! -d ${_pkgdestdir}/${_targetdir} ]; then
-			install -d ${_pkgdestdir}/${_targetdir}
+		if [ ! -d ${PKGDESTDIR}/${_targetdir} ]; then
+			install -d ${PKGDESTDIR}/${_targetdir}
 		fi
-		mv ${_destdir}/$files ${_pkgdestdir}/${_targetdir}
+		mv ${DESTDIR}/$files ${PKGDESTDIR}/${_targetdir}
 	fi
 }
 
 _vmkdir() {
-	local dir="$1" mode="$2" _destdir
+	local dir="$1" mode="$2"
 
-	if [ -z "$DESTDIR" ]; then
-		msg_red "$pkgver: vmkdir: DESTDIR unset, can't continue...\n"
+	if [ -z "$PKGDESTDIR" ]; then
+		msg_red "$pkgver: vmkdir: PKGDESTDIR unset, can't continue...\n"
 		return 1
 	fi
 
@@ -246,16 +228,10 @@ _vmkdir() {
 		return 1
 	fi
 
-	if [ -n "$XBPS_PKGDESTDIR" ]; then
-		_destdir="$PKGDESTDIR"
-	else
-		_destdir="$DESTDIR"
-	fi
-
 	if [ -z "$mode" ]; then
-		install -d ${_destdir}/${dir}
+		install -d ${PKGDESTDIR}/${dir}
 	else
-		install -dm${mode} ${_destdir}/${dir}
+		install -dm${mode} ${PKGDESTDIR}/${dir}
 	fi
 }
 
@@ -264,11 +240,6 @@ _vcompletion() {
 	local _bash_completion_dir=usr/share/bash-completion/completions/
 	local _fish_completion_dir=usr/share/fish/vendor_completions.d/
 	local _zsh_completion_dir=usr/share/zsh/site-functions/
-
-	if [ -z "$DESTDIR" ]; then
-		msg_red "$pkgver: vcompletion: DESTDIR unset, can't continue...\n"
-		return 1
-	fi
 
 	if [ $# -lt 2 ]; then
 		msg_red "$pkgver: vcompletion: 2 arguments expected: <file> <shell>\n"

--- a/common/xbps-src/libexec/xbps-src-doinstall.sh
+++ b/common/xbps-src/libexec/xbps-src-doinstall.sh
@@ -58,7 +58,6 @@ if [ ! -f $XBPS_SUBPKG_INSTALL_DONE ]; then
 
         install -d $PKGDESTDIR
         if declare -f pkg_install >/dev/null; then
-            export XBPS_PKGDESTDIR=1
             run_pkg_hooks pre-install
             run_func pkg_install
         fi


### PR DESCRIPTION
Historically, PKGDESTDIR was only set during pkg_install, and
XBPS_PKGDESTDIR was set to indicate that we're in subpkg's
pkg_install.

However, from 0b95cb8f5d, (Merge xbps-src code to make it usable in
a standalone mode., 2014-03-22), PKGDESTDIR is always set,
regardless of states.

Let's drop all usages of XBPS_PKGDESTDIR.

While we're at it, error out of vmove is used outside of subpkg.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
