### PR TITLE
libcaca: enable imlib2 support without x11

### DIFF
--- a/srcpkgs/libcaca/template
+++ b/srcpkgs/libcaca/template
@@ -1,7 +1,7 @@
 # Template file for 'libcaca'
 pkgname=libcaca
 version=0.99.beta19
-revision=9
+revision=10
 build_style=gnu-configure
 configure_args="$(vopt_enable x11)"
 hostmakedepends="libtool automake pkg-config"
@@ -14,7 +14,6 @@ distfiles="https://github.com/cacalabs/libcaca/archive/v${version}.tar.gz"
 checksum=7ed29a00cc7f017424d8b2994f001f137ed5bc4441987b711d78c6734fdf3493
 
 build_options="x11 opengl"
-build_options_default="x11"
 
 pre_configure() {
 	vsed -i -e 's,AM_CONFIG_HEADER,AC_CONFIG_HEADERS,' configure.ac


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Using ncurses backend is preferable. See https://github.com/void-linux/void-packages/pull/31717#issuecomment-873335867
