### PR TITLE
grub: compile with -Os

### DIFF
--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -1,7 +1,7 @@
 # Template file for 'grub'
 pkgname=grub
 version=2.06
-revision=1
+revision=2
 hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf help2man"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel fuse-devel"
@@ -44,6 +44,13 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 do_configure() {
+	# workaround for https://savannah.gnu.org/bugs/?60458
+	# some more info: https://www.linuxquestions.org/questions/showthread.php?p=6257712
+	# grub 2.06 reboots immediately when compiled with -O2
+	# only effects legacy BIOS
+	export CFLAGS="${CFLAGS/-O2/-Os}"
+	export CXXFLAGS="${CXXFLAGS/-O2/-Os}"
+
 	unset CC AS LD RANLIB CPP
 	local freestanding_cflags="-fno-stack-protector"
 


### PR DESCRIPTION
Avoids being stuck at "GRUB loading." when booting through legacy BIOS

I built and configured the image of a new VM and when starting that image with qemu I was stuck very early with "GRUB loading.". Somebody on IRC was having the same problem and provided links which said it was because of how grub is compiled. (see changed template for sources)
I have created the VM image multiple times with and without the change and it always failed without the change and always succeeded with the change.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
