### PR TITLE
steam: update void specific troubleshooting

### DIFF
--- a/srcpkgs/steam/files/README.voidlinux
+++ b/srcpkgs/steam/files/README.voidlinux
@@ -28,8 +28,15 @@ installed for some games to function.
 If games are running slowly or not at all, or there are issues with network
 streaming, verify that your user belongs to the video group.
 
-If your audio is not working, try installing pulseaudio and
-alsa-plugins-pulseaudio.
+If your audio is not working, try installing pulseaudio,
+alsa-plugins-pulseaudio and their "<package>-32bit" equivalents.
+
+If you are using SteamPlay/Proton and the game crashes or hangs with error
+messages that include "eventfd: Too many open files", the number of open file
+descriptors per process is too low for proper Proton functionality.  In this
+case, consult limits.conf(5) and set a higher nofile limit for your user.  For
+more information, see the upstream documentation in the README.esync file from
+https://github.com/ValveSoftware/wine
 
 If you are encountering runtime errors, the Steam Ubuntu bootstrap tarball might
 be using an incompatible libstdc++ library. You can verify this by running the

--- a/srcpkgs/steam/template
+++ b/srcpkgs/steam/template
@@ -1,6 +1,6 @@
 # Template file for 'steam'
 pkgname=steam
-version=1.0.0.70
+version=1.0.0.71
 revision=2
 archs="i686 x86_64"
 wrksrc=steam-launcher
@@ -11,7 +11,7 @@ maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom: Proprietary license"
 homepage="https://steampowered.com/"
 distfiles="http://repo.steampowered.com/${pkgname}/pool/${pkgname}/s/${pkgname}/${pkgname}_${version}.tar.gz"
-checksum=9ff88a5778c7b00efb18f324d4cd0c282d5f438dad1201bc3e9822e3ff6a2dff
+checksum=39c33d1999f8cc6d4af696479e1d73eee2e93a217bc45887032e18b33535ca21
 repository=nonfree
 
 do_install() {


### PR DESCRIPTION
Void's PAM configuration seems to limit file descriptors per process a little to aggressively leading to game crashes with the "eventfd: Too many open files" diagnostic.
The solution is according to Valve's upstream documentation on Proton's Wine fork to manually raise the limit in
 "/etc/security/limits.conf";
document that specific behavior.
Found by method of elimination by switching from ArchLinux to Void trying to play the same game with near identical configuration of both systems.
For 32bit Games it should also be advisable to pull 32bit audio libraries, preventing for example "This game requires a sound card in order to run" error when starting GTA IV.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
