### PR TITLE
swirc: update to 3.3.0.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.2.7
+version=3.3.0
 revision=1
 build_style=configure
 make_install_args="PREFIX=/usr"
@@ -12,7 +12,7 @@ maintainer="Markus Uhlin <markus.uhlin@bredband.net>"
 license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 distfiles="https://www.nifty-networks.net/swirc/releases/${pkgname}-${version}.tgz"
-checksum="64cad6c7cbf2a5c70737c55ad30c14d994fc6d84db19edcb1c83962414d7099a"
+checksum="4faae10ab3e08d544f5377c7ba94d86d7d6c3a4c79e41b11b1b864faab0e5764"
 
 post_configure() {
 	local _file="options.mk"


### PR DESCRIPTION
Swirc 3.3.0 out

https://github.com/uhlin/swirc/blob/master/CHANGELOG.md#330---2021-06-27
