### PR TITLE
wpa_supplicant: fix wpa_dbus_property_changed

### DIFF
--- a/srcpkgs/wpa_supplicant/patches/roam-properties.patch
+++ b/srcpkgs/wpa_supplicant/patches/roam-properties.patch
@@ -1,0 +1,88 @@
+From 23d87687c2428f3b94865580b0d33e05c03e6756 Mon Sep 17 00:00:00 2001
+From: Matthew Wang <matthewmwang@chromium.org>
+Date: Fri, 11 Oct 2019 13:49:25 -0700
+Subject: dbus: Move roam metrics to the correct interface
+
+These properties were in the wpas_dbus_bss_properties array when they
+should have been in the wpas_dbus_interface_properties array. Move them
+to the right place. This is the logical location for these properties
+and it matches both the other parts of the implementation (e.g., being
+in enum wpas_dbus_prop, not in enum wpas_dbus_bss_prop) and what
+was originally documented for the interface in dbus.doxygen.
+
+Fixes: 2bbad1c7c9cb ("dbus: Export roam time, roam complete, and session length")
+Fixes: 80d06d0ca9f3 ("dbus: Export BSS Transition Management status")
+Signed-off-by: Matthew Wang <matthewmwang@chromium.org>
+---
+ wpa_supplicant/dbus/dbus_new.c | 48 +++++++++++++++++++++---------------------
+ 1 file changed, 24 insertions(+), 24 deletions(-)
+
+diff --git a/wpa_supplicant/dbus/dbus_new.c b/wpa_supplicant/dbus/dbus_new.c
+index 5e6b522..e9e77bd 100644
+--- a/wpa_supplicant/dbus/dbus_new.c
++++ b/wpa_supplicant/dbus/dbus_new.c
+@@ -2855,30 +2855,6 @@ static const struct wpa_dbus_property_desc wpas_dbus_bss_properties[] = {
+ 	  NULL,
+ 	  NULL
+ 	},
+-	{
+-	  "RoamTime", WPAS_DBUS_NEW_IFACE_INTERFACE, "u",
+-	  wpas_dbus_getter_roam_time,
+-	  NULL,
+-	  NULL
+-	},
+-	{
+-	  "RoamComplete", WPAS_DBUS_NEW_IFACE_INTERFACE, "b",
+-	  wpas_dbus_getter_roam_complete,
+-	  NULL,
+-	  NULL
+-	},
+-	{
+-	  "SessionLength", WPAS_DBUS_NEW_IFACE_INTERFACE, "u",
+-	  wpas_dbus_getter_session_length,
+-	  NULL,
+-	  NULL
+-	},
+-	{
+-	  "BSSTMStatus", WPAS_DBUS_NEW_IFACE_INTERFACE, "u",
+-	  wpas_dbus_getter_bss_tm_status,
+-	  NULL,
+-	  NULL
+-	},
+ 	{ NULL, NULL, NULL, NULL, NULL, NULL }
+ };
+ 
+@@ -3786,6 +3762,30 @@ static const struct wpa_dbus_property_desc wpas_dbus_interface_properties[] = {
+ 	  NULL,
+ 	  NULL
+ 	},
++	{
++	  "RoamTime", WPAS_DBUS_NEW_IFACE_INTERFACE, "u",
++	  wpas_dbus_getter_roam_time,
++	  NULL,
++	  NULL
++	},
++	{
++	  "RoamComplete", WPAS_DBUS_NEW_IFACE_INTERFACE, "b",
++	  wpas_dbus_getter_roam_complete,
++	  NULL,
++	  NULL
++	},
++	{
++	  "SessionLength", WPAS_DBUS_NEW_IFACE_INTERFACE, "u",
++	  wpas_dbus_getter_session_length,
++	  NULL,
++	  NULL
++	},
++	{
++	  "BSSTMStatus", WPAS_DBUS_NEW_IFACE_INTERFACE, "u",
++	  wpas_dbus_getter_bss_tm_status,
++	  NULL,
++	  NULL
++	},
+ #ifdef CONFIG_MESH
+ 	{ "MeshPeers", WPAS_DBUS_NEW_IFACE_MESH, "aay",
+ 	  wpas_dbus_getter_mesh_peers,
+-- 
+cgit v0.12
+

--- a/srcpkgs/wpa_supplicant/template
+++ b/srcpkgs/wpa_supplicant/template
@@ -1,7 +1,7 @@
 # Template file for 'wpa_supplicant'
 pkgname=wpa_supplicant
 version=2.9
-revision=5
+revision=6
 build_wrksrc="$pkgname"
 short_desc="WPA/WPA2/IEEE 802.1X Supplicant"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
The current version of wpa_supplicant emits following error message on shutdown:

    dbus: wpa_dbus_property_changed: no property SessionLength in object /fi/w1/wpa_supplicant1/Interfaces/0
This pull reqest adds a patch [stolen from Archlinux](https://github.com/archlinux/svntogit-packages/commit/73ce2847aec510861a041ac369054a9aed5c3406) that fixes the issue.
@Gottox

---
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl