### PR TITLE
certbot: update to 1.17.0.

### DIFF
--- a/srcpkgs/certbot-apache/template
+++ b/srcpkgs/certbot-apache/template
@@ -1,6 +1,6 @@
 # Template file for 'certbot-apache'
 pkgname=certbot-apache
-version=1.16.0
+version=1.17.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,4 +11,4 @@ maintainer="Kartik S. <kartik.ynwa@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot-apache/certbot-apache-${version}.tar.gz"
-checksum=26824b812826d22b3f80377dfc2976a6f37f425c414c50efd8f8bd6e7967d579
+checksum=20a18c28a02138b5c15d5434b230cc102049c0753c0e0caf90fb45c507e02bf2

--- a/srcpkgs/certbot-nginx/template
+++ b/srcpkgs/certbot-nginx/template
@@ -1,6 +1,6 @@
 # Template file for 'certbot-nginx'
 pkgname=certbot-nginx
-version=1.16.0
+version=1.17.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,4 +11,4 @@ maintainer="Kartik Singh <kartik.ynwa@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot-nginx/certbot-nginx-${version}.tar.gz"
-checksum=e0a954d49461e3209173cade9c49e8abfdc697467d1ae312bb230a43f7c60959
+checksum=4d77b220f4cd7d04580cf187e23952f4d54f67bc390227161e0c543de4b7b3c3

--- a/srcpkgs/certbot/template
+++ b/srcpkgs/certbot/template
@@ -1,6 +1,6 @@
 # Template file for 'certbot'
 pkgname=certbot
-version=1.16.0
+version=1.17.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -14,4 +14,4 @@ maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="Apache-2.0"
 homepage="https://certbot.eff.org/"
 distfiles="${PYPI_SITE}/c/certbot/certbot-${version}.tar.gz"
-checksum=04e80e987ca4837169127e1951325a4bcdcaf0b4a51ee2847148cfd52cbb207d
+checksum=ef410a1018f4f1ee775961527c00c4f2e2003428cfc4e09eddd5a1834dbfd173

--- a/srcpkgs/python3-acme/template
+++ b/srcpkgs/python3-acme/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-acme'
 pkgname=python3-acme
-version=1.16.0
+version=1.17.0
 revision=1
 wrksrc="acme-${version}"
 build_style=python3-module
@@ -14,4 +14,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/certbot/certbot"
 distfiles="${PYPI_SITE}/a/acme/acme-${version}.tar.gz"
-checksum=a1f8018820d87fd3f9f264c359e8b6cd6a736a1ed18f4b6ac8af6b303e627857
+checksum=2af48e40679103212532cb3d220df444207e5e7b532e0ccebe7773792e0f320e


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

Updates certbot, certbot-nginx, certbot-apache.

The update to certbot-apache now also includes config for Void Linux, so `certbot --apache` should work out of the box for basic cases. 🎊