### PR TITLE
mkinitcpio: remove dependency on -lvm2 from -encrypt subpackage

### DIFF
--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=30
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
 depends="busybox-static bsdtar bash"
@@ -24,6 +24,9 @@ post_install() {
 	vinstall ${FILESDIR}/udev_hook 644 usr/lib/initcpio/hooks udev
 	vinstall ${FILESDIR}/udev_install 644 usr/lib/initcpio/install udev
 
+	# Install udev rule used by both lvm2 and encrypt hook
+	vinstall ${FILESDIR}/11-dm-initramfs.rules 644 usr/lib/initcpio/udev
+
 	# Remove unneeded systemd bits
 	rm -rf ${DESTDIR}/usr/lib/kernel
 	rm -rf ${DESTDIR}/usr/lib/systemd
@@ -45,15 +48,12 @@ mkinitcpio-lvm2_package() {
 	pkg_install() {
 		vinstall ${FILESDIR}/lvm2_hook 644 usr/lib/initcpio/hooks lvm2
 		vinstall ${FILESDIR}/lvm2_install 644 usr/lib/initcpio/install lvm2
-		for RULES in ${FILESDIR}/*.rules; do
-			vinstall $RULES 644 usr/lib/initcpio/udev $(basename $RULES)
-		done
+		vinstall ${FILESDIR}/69-dm-lvm-metad.rules 644 usr/lib/initcpio/udev
 	}
 }
 
 mkinitcpio-encrypt_package() {
-	depends="${sourcepkg}>=${version}_${revision}
-		${sourcepkg}-lvm2>=${version}_${revision} cryptsetup"
+	depends="${sourcepkg}>=${version}_${revision} cryptsetup"
 	short_desc+=" - encrypt support"
 	pkg_install() {
 		vinstall ${FILESDIR}/encrypt_hook 644 usr/lib/initcpio/hooks encrypt


### PR DESCRIPTION
encrypt hook does not depend on lvm2 nor lvm2 hook. It just needs 11-dm-initramfs.rules, so I moved to the base package.

<!-- Mark items with [x] where applicable -->

<!--
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)
-->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
