### PR TITLE
grml-zsh-config: update to 0.19.0 + fix

### DIFF
--- a/srcpkgs/grml-zsh-config/template
+++ b/srcpkgs/grml-zsh-config/template
@@ -1,14 +1,14 @@
 # Template file for 'grml-zsh-config'
 pkgname=grml-zsh-config
-version=0.18.0
+version=0.19.0
 revision=1
 wrksrc="grml-etc-core-${version}"
 short_desc="Grml's zsh setup"
 maintainer="Christian Poulwey <christian.poulwey@t-online.de>"
 license="GPL-2.0-only"
 homepage="https://grml.org/zsh/"
-distfiles="https://deb.grml.org/pool/main/g/grml-etc-core/grml-etc-core_${version}.tar.gz"
-checksum=81bce54ac1cde04d426182b72ffa9077b26f80bcceca4cb9580de4e031a5088f
+distfiles="https://github.com/grml/grml-etc-core/archive/refs/tags/v${version}.tar.gz"
+checksum=57e406c6c2d588a34b84896ba2f22811cc250d308b264499ebc870bb1ce97122
 
 do_install() {
 	vinstall etc/skel/.zshrc 0644 etc/skel


### PR DESCRIPTION
The current version (0.18.0) was again removed from their repo, like in the previous version (#31478). This means that the build of the current version fails with `Not Found` error. I've [reached out](https://github.com/grml/grml-etc-core/issues/120) to the maintainers, and they said that GitHub releases should be used instead of their debian mirror. This should make grml-zsh-config buildable even if newer versions are available.

---
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
