### PR TITLE
ardour: update to 6.8.

### DIFF
--- a/srcpkgs/ardour/template
+++ b/srcpkgs/ardour/template
@@ -1,8 +1,8 @@
 # Template file for 'ardour'
 pkgname=ardour
-version=6.7
+version=6.8
 revision=1
-_commit="6733a847eeb55b4640a65a8bfebac8c7166521c8"
+_commit="1734fac4105106e02219834d330fa9eb0ceef3cd"
 build_style=waf3
 configure_args="--cxx11 --no-phone-home --with-backends=jack,alsa,dummy
  --libjack=weak --optimize --docs --use-external-libs --freedesktop"
@@ -40,13 +40,5 @@ do_fetch() {
 }
 
 post_install() {
-	vinstall build/gtk2_ardour/ardour.xml 644 usr/share/mime/packages
-	vinstall "build/gtk2_ardour/ardour${version%%.*}.desktop" \
-		644 usr/share/applications
-	for size in 16 22 32 48 256 512; do
-		vinstall gtk2_ardour/resources/Ardour-icon_${size}px.png 644 \
-			usr/share/icons/hicolor/${size}x${size}/apps \
-			ardour${version%%.*}.png
-	done
 	vman ardour.1
 }


### PR DESCRIPTION
Also remove freedesktop integration from template. It's handled by upstream since 6.7.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
