### PR TITLE
usbguard: prevent removal of IPCAccessControl.d directory

### DIFF
--- a/srcpkgs/usbguard/template
+++ b/srcpkgs/usbguard/template
@@ -1,11 +1,13 @@
 # Template file for 'usbguard'
 pkgname=usbguard
 version=1.0.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-crypto-library=sodium --with-bundled-catch --with-bundled-pegtl"
 conf_files="/etc/usbguard/*"
-make_dirs="/var/log/usbguard 0755 root root"
+make_dirs="
+ /var/log/usbguard 0755 root root
+ /etc/usbguard/IPCAccessControl.d 0755 root root"
 hostmakedepends="automake libtool pkg-config asciidoc glib-devel protobuf"
 makedepends="libqb-devel libsodium-devel protobuf-devel polkit-devel libcap-ng-devel libseccomp-devel"
 short_desc="Tool for whitelisting and blacklisting USB devices"


### PR DESCRIPTION
Fixes https://github.com/void-linux/void-packages/issues/31768. The `/etc/usbguard/IPCAccessControl.d` directory is needed by `usbguard-daemon` and will fail to start without it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
