### PR TITLE
gmsh: Added occt and version bump

### DIFF
--- a/srcpkgs/gmsh/template
+++ b/srcpkgs/gmsh/template
@@ -1,13 +1,13 @@
 # Template file for 'gmsh'
 pkgname=gmsh
-version=4.7.1
+version=4.8.4
 revision=1
 wrksrc="${pkgname}-${version}-source"
 build_style=cmake
 configure_args="-DENABLE_SYSTEM_CONTRIB=ON
  -DENABLE_HXT=$(vopt_if hxt ON OFF)
  -DENABLE_ZIPPER=$(vopt_if zipper ON OFF)"
-makedepends="freetype-devel glu-devel gmp-devel
+makedepends="freetype-devel glu-devel gmp-devel $(vopt_if occt occt-devel)
  $(vopt_if fltk fltk-devel) blas-devel lapack-devel"
 short_desc="Three-dimensional finite element mesh generator"
 maintainer="Nathan Owens <ndowens@artixlinux.org>"
@@ -15,13 +15,14 @@ license="GPL-2.0-or-later"
 homepage="https://gmsh.info"
 changelog="http://gmsh.info/CHANGELOG.txt"
 distfiles="https://gmsh.info/src/gmsh-${version}-source.tgz"
-checksum=c984c295116c757ed165d77149bd5fdd1068cbd7835e9bcd077358b503891c6a
+checksum=760dbdc072eaa3c82d066c5ba3b06eacdd3304eb2a97373fe4ada9509f0b6ace
 
-build_options="fltk hxt zipper"
-build_options_default="hxt"
+build_options="fltk occt hxt zipper"
+build_options_default="hxt occt"
 
 desc_option_hxt="Enable HXT library"
 desc_option_fltk="Enable FLTK GUI support"
+desc_option_occt="Enable OpenCASCADE support"
 desc_option_zipper="Enable zip file compression/decompression"
 
 CFLAGS="-fcommon"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

OpenCASCADE is needed for a lot of the functionality of gmsh, and it's suggested as one of the dependencies here: https://gitlab.onelab.info/gmsh/gmsh/-/wikis/Gmsh-compilation

I think it's reasonable to compile support for it by default. 