### PR TITLE
common/shlibs: correct lhasa pkg name

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4017,4 +4017,4 @@ libXcomp.so.3 nx-libs-3.5.99.24_1
 libXcompshad.so.3 nx-libs-3.5.99.24_1
 libNX_X11.so.6 nx-libs-3.5.99.24_1
 librnnoise.so.0 rnnoise-0.4.1_1
-liblhasa.so.0 liblhasa-0.3.1_1
+liblhasa.so.0 lhasa-0.3.1_2

--- a/srcpkgs/lhasa/template
+++ b/srcpkgs/lhasa/template
@@ -1,7 +1,7 @@
 # Template file for 'lhasa'
 pkgname=lhasa
 version=0.3.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool"
 short_desc="Free Software LHA implementation"


### PR DESCRIPTION
To avoid installation failure such as:
[*] Updating repository ...
MISSING: liblhasa>=0.3.1_1
Transaction aborted due to unresolved dependencies.

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-libc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [ ] armv6l-musl
-->
