### PR TITLE
i2pd: update to 2.38.0.

### DIFF
--- a/srcpkgs/i2pd/template
+++ b/srcpkgs/i2pd/template
@@ -1,7 +1,7 @@
 # Template file for 'i2pd'
 pkgname=i2pd
-version=2.37.0
-revision=2
+version=2.38.0
+revision=1
 build_style=gnu-makefile
 make_build_args="USE_UPNP=yes"
 makedepends="zlib-devel boost-devel openssl-devel miniupnpc-devel
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://i2pd.website/"
 changelog="https://raw.githubusercontent.com/PurpleI2P/i2pd/openssl/ChangeLog"
 distfiles="https://github.com/PurpleI2P/i2pd/archive/${version}.tar.gz"
-checksum=072e79e55d4feac9dc3c988000a21ba613eb0c5bc151105cbccebdf84176dced
+checksum=8452f5323795a1846d554096c08fffe5ac35897867b93a5079605df8f80a3089
 disable_parallel_build=yes
 
 conf_files="
@@ -24,7 +24,7 @@ make_dirs="/var/lib/i2pd 0700 _i2pd _i2pd"
 
 case "${XBPS_TARGET_MACHINE}" in
 	x86_64*) ;;
-	*) make_build_args+=" USE_AESNI=no USE_AVX=no" ;;
+	*) make_build_args+=" USE_AESNI=no" ;;
 esac
 
 pre_install() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

From upstream's 2.35.0 releasenote:

>cmake and make flag with AVX switch (USE_AVX in make and -DUSE_AVX=1 in cmake) was deprecated due to changes in code.

so I removed this flag.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!--
#### Does it build and run successfully?
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
