### PR TITLE
ghc: allow building with current Sphinx

### DIFF
--- a/srcpkgs/ghc/patches/sphinx-unicode.patch
+++ b/srcpkgs/ghc/patches/sphinx-unicode.patch
@@ -1,0 +1,17 @@
+diff -rpU2 ghc-8.8.4-orig/docs/users_guide/conf.py ghc-8.8.4/docs/users_guide/conf.py
+--- ghc-8.8.4-orig/docs/users_guide/conf.py	2020-07-08 16:43:03.000000000 +0000
++++ ghc-8.8.4/docs/users_guide/conf.py	2021-07-10 20:25:33.536928487 +0000
+@@ -78,5 +78,5 @@ latex_elements = {
+     'inputenc': '',
+     'utf8extra': '',
+-    'preamble': '''
++    'preamble': r'''
+ \usepackage{fontspec}
+ \usepackage{makeidx}
+@@ -84,5 +84,5 @@ latex_elements = {
+ \setromanfont{DejaVu Serif}
+ \setmonofont{DejaVu Sans Mono}
+-\setlength{\\tymin}{45pt}
++\setlength{\tymin}{45pt}
+ ''',
+ }


### PR DESCRIPTION
./srcpkg build ghc fails with current tools:

"inplace/bin/ghc-stage1" [...] /build/cbits/longlong.p_o
Running Sphinx v4.0.2

Configuration error:
There is a syntax error in your configuration file: (unicode error) 'unicodeescape' codec can't decode bytes in position 1-2: truncated \uXXXX escape (conf.py, line 87)

...
make: *** [Makefile:128: all] Error 2

According to https://gitlab.haskell.org/ghc/ghc/-/issues/19962

>> This fix is to use raw strings, as already done in master:
>> https://gitlab.haskell.org/ghc/ghc/-/blob/master/docs/users_guide/conf.py#L96

Sanitized from commit (only small parts apply)
https://gitlab.haskell.org/ghc/ghc/-/commit/83407ffc7acc00cc025b9f6ed063add9ab9f9bcc

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

[skip CI] build might take over 3 hours with a single CPU - local build/pkg tested

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
