### PR TITLE
boost: new distfiles location

### DIFF
--- a/srcpkgs/boost/template
+++ b/srcpkgs/boost/template
@@ -9,7 +9,7 @@ short_desc="Free peer-reviewed portable C++ source libraries"
 maintainer="John <me@johnnynator.dev>"
 license="BSL-1.0"
 homepage="http://www.boost.org/"
-distfiles="https://dl.bintray.com/boostorg/release/${version}/source/boost_${version//./_}.tar.bz2"
+distfiles="https://boostorg.jfrog.io/artifactory/main/release/${version}/source/boost_${version//./_}.tar.bz2"
 checksum=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
 python_version=3
 


### PR DESCRIPTION
Download location documented to replace the old, non-working one:

https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html
>> Instead of: https://dl.bintray.com/boostorg/release/ you should use https://boostorg.jfrog.io/artifactory/main/release/ to retrieve boost releases.

Tested availability of  the present version:
$ curl -I https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 2>&1|egrep Date\|256
Date: Sat, 10 Jul 2021 21:30:24 GMT
X-Checksum-Sha256: 59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

[skip ci] no package change expected, only the distribution location for future builds

<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64
-->
