### PR TITLE
python3-mpd2: update to 3.0.4, fix bum

### DIFF
--- a/srcpkgs/bum/patches/mpd2-3.patch
+++ b/srcpkgs/bum/patches/mpd2-3.patch
@@ -1,0 +1,17 @@
+based on https://github.com/dylanaraps/bum/pull/24
+--- a/bum/__main__.py
++++ b/bum/__main__.py
+@@ -62,11 +62,8 @@ def main():
+     while True:
+         song.get_art(args.cache_dir, args.size, client)
+         display.launch(disp, args.cache_dir / "current.jpg")
+-        client.send_idle()
+-
+-        if client.fetch_idle(["player"]):
+-            print("album: Received player event from mpd. Swapping cover art.")
+-            continue
++        client.idle("player")
++        print("album: Received player event from mpd. Swapping cover art.")
+ 
+ 
+ if __name__ == "__main__":

--- a/srcpkgs/bum/template
+++ b/srcpkgs/bum/template
@@ -1,17 +1,17 @@
 # Template file for 'bum'
 pkgname=bum
 version=0.1.3
-revision=5
+revision=6
 build_style=python3-module
-pycompile_module="bum"
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-mpd2 python3-musicbrainzngs python3-mpv"
+depends="python3-mpd2 python3-musicbrainzngs python3-mpv"
 short_desc="Daemon that downloads and displays album arts via MPD events"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/dylanaraps/bum"
 distfiles="https://github.com/dylanaraps/bum/archive/${version}.tar.gz"
 checksum=512b64d2fbd0d96b1c242f5e2b916c126671bd16dfbb5c71d164a39b5ebeeebe
+make_check=no # no tests, but check fails with a non-zero exit code
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/python3-mpd2/template
+++ b/srcpkgs/python3-mpd2/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-mpd2'
 pkgname=python3-mpd2
-version=1.0.0
-revision=4
+version=3.0.4
+revision=1
 wrksrc=python-mpd2-$version
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ maintainer="Jens E. Becker <v2px@v2px.de>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/Mic92/python-mpd2"
 distfiles="https://github.com/Mic92/python-mpd2/archive/v${version}.tar.gz"
-checksum=877fa1685a56815107cb0b1eb004e7fe261b620fafd4d38cdaa2b6f3edd35928
+checksum=05ac5d339932f5d0557cb10c43bf4f1df74937f660125cf7fdd0f1691da98278
 
 do_check() {
 	python3 -m unittest mpd.tests


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

I tested almost all the dependants:

* sonata 1.7b1 and 1.7.0 - work fine
* mpdevil - works fine
* python3-mpdnotify - works fine
* bum - works with a small patch, then kind of works, but crashes in different places, but that's not related to a python3-mpd2 update
* mpDris2 - crashes for me, apparently that's an upstream bug specific to my configuration, but I think it's safe to assume it works, because alpine packages only one package which depends on python3-mpd2 - mpdris2, so it's probably well tested there. If someone could test this in a non-GNOME environment, that would be nice.