### PR TITLE
connman: build with --enable-iwd, add build option "nftables", split openconnect plugin, remove runtime dependency on wpa_supplicant

### DIFF
--- a/srcpkgs/connman-openconnect
+++ b/srcpkgs/connman-openconnect
@@ -1,0 +1,1 @@
+connman

--- a/srcpkgs/connman-openvpn
+++ b/srcpkgs/connman-openvpn
@@ -1,0 +1,1 @@
+connman

--- a/srcpkgs/connman-wireguard
+++ b/srcpkgs/connman-wireguard
@@ -1,0 +1,1 @@
+connman

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -11,7 +11,7 @@ configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
 hostmakedepends="automake iptables libtool pkg-config wpa_supplicant"
 makedepends="gnutls-devel libglib-devel libmnl-devel openconnect-devel
  readline-devel $(vopt_if nftables libnftnl-devel iptables-devel)"
-depends="dbus wpa_supplicant"
+depends="dbus"
 short_desc="Open Source CONNection MANager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -43,6 +43,14 @@ post_install() {
 	vinstall ${FILESDIR}/connmand.conf 755 usr/share/dbus-1/system.d/
 }
 
+connman-openconnect_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - support for OpenConnect VPN"
+	pkg_install() {
+		vmove usr/lib/connman/plugins-vpn/openconnect.so
+	}
+}
+
 connman-devel_package() {
 	depends="dbus-devel libglib-devel"
 	short_desc+=" - development files"

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -7,10 +7,10 @@ configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat
  --enable-openvpn --with-openvpn=/usr/bin/openvpn --enable-openconnect
  --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect
- --enable-iwd"
+ --enable-iwd --with-firewall=$(vopt_if nftables nftables iptables)"
 hostmakedepends="automake iptables libtool pkg-config wpa_supplicant"
-makedepends="gnutls-devel iptables-devel libglib-devel libmnl-devel
- openconnect-devel readline-devel"
+makedepends="gnutls-devel libglib-devel libmnl-devel openconnect-devel
+ readline-devel $(vopt_if nftables libnftnl-devel iptables-devel)"
 depends="dbus wpa_supplicant"
 short_desc="Open Source CONNection MANager"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -20,6 +20,10 @@ changelog="https://git.kernel.org/pub/scm/network/connman/connman.git/plain/Chan
 distfiles="${KERNEL_SITE}/network/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=1a57ae7ce234aa3a1744aac3be5c2121d98dce999440ef8ab9cc4edfd5edcb12
 lib32disabled=yes
+
+# Package build options
+build_options="nftables"
+desc_option_nftables="Build with nftables instead of iptables"
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -8,6 +8,7 @@ configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-openvpn --with-openvpn=/usr/bin/openvpn --enable-openconnect
  --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect
  --enable-iwd --with-firewall=$(vopt_if nftables nftables iptables)"
+conf_files="/etc/connman/*"
 hostmakedepends="automake iptables libtool pkg-config wpa_supplicant"
 makedepends="gnutls-devel libglib-devel libmnl-devel openconnect-devel
  readline-devel $(vopt_if nftables libnftnl-devel iptables-devel)"
@@ -36,11 +37,11 @@ pre_configure() {
 	esac
 	autoreconf -fi
 }
+
 post_install() {
-	# Install the client connmanctl.
-	vbin client/connmanctl
 	vsv connmand
 	vinstall ${FILESDIR}/connmand.conf 755 usr/share/dbus-1/system.d/
+	vinstall src/main.conf 644 etc/connman
 }
 
 connman-openconnect_package() {

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -45,9 +45,26 @@ post_install() {
 
 connman-openconnect_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
-	short_desc+=" - support for OpenConnect VPN"
+	short_desc="OpenConnect VPN plugin for ConnMan"
 	pkg_install() {
 		vmove usr/lib/connman/plugins-vpn/openconnect.so
+	}
+}
+
+connman-openvpn_package() {
+	depends="${sourcepkg}>=${version}_${revision} openvpn"
+	short_desc="OpenVPN plugin for ConnMan"
+	pkg_install() {
+		vmove usr/lib/connman/plugins-vpn/openvpn.so
+		vmove usr/lib/connman/scripts/openvpn-script
+	}
+}
+
+connman-wireguard_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc="WireGuard VPN plugin for ConnMan"
+	pkg_install() {
+		vmove usr/lib/connman/plugins-vpn/wireguard.so
 	}
 }
 

--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -1,12 +1,13 @@
 # Template file for 'connman'
 pkgname=connman
 version=1.40
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat
  --enable-openvpn --with-openvpn=/usr/bin/openvpn --enable-openconnect
- --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect"
+ --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect
+ --enable-iwd"
 hostmakedepends="automake iptables libtool pkg-config wpa_supplicant"
 makedepends="gnutls-devel iptables-devel libglib-devel libmnl-devel
  openconnect-devel readline-devel"


### PR DESCRIPTION
1. Build with --enable-iwd

    iwd is a better alternative to wpa_supplicant.

1. Add build option "nftables"

    Allow to build with support for nftables instead of iptables.
    
    From ./configure --help:
    
        --with-firewall=TYPE    specify which firewall type is used iptables or
                                nftables [default=iptables]

1. Split openconnect plugin into subpackage
    
    OpenConnect VPN is not widely used and it adds many dependencies to the connman package. On my system, removing openconnect orphaned the following packages: openconnect trousers vpnc-scripts libpcsclite mit-krb5-libs with total size over 5 MiB.

1. Remove runtime dependency on wpa_supplicant
    
    ConnMan can be used with iwd or even without any WiFi program, because it can be used for Ethernet devices.

1. Split openvpn and wireguard to subpackages
    
    The main motivation to split openvpn into a subpackage is to correctly declare its dependency on "openvpn" package. Wireguard doesn't seem to depend on any other package, that's just for consistency with other VPN plugins.