### PR TITLE
containerd: update to 1.5.2.

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,6 +1,6 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=1.5.1
+version=1.5.2
 revision=1
 build_style=go
 go_import_path=github.com/containerd/containerd
@@ -20,7 +20,7 @@ maintainer="Paul Knopf <pauldotknopf@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=e381c5133feacf7a9d6991c3535103f3c1f7a86b5b8ce2df226c5abde77fb5d8
+checksum=d72a85cbcd60009f41637e97e37a372a2451b369c183e2b58fdab00e1c9fe894
 make_dirs="/var/lib/containerd 0755 root root"
 
 post_build() {


### PR DESCRIPTION
containerd 1.5.2 addresses a security issue: https://github.com/containerd/containerd/releases/tag/v1.5.2

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
