### PR TITLE
avidemux: update to 2.7.8

### DIFF
--- a/srcpkgs/avidemux/template
+++ b/srcpkgs/avidemux/template
@@ -1,6 +1,6 @@
 # Template file for 'avidemux'
 pkgname=avidemux
-version=2.7.6
+version=2.7.8
 revision=1
 # Can't be compiled for aarch64, arm* or mips*
 archs="x86_64* i686*"
@@ -18,7 +18,7 @@ license="GPL-2.0-or-later"
 homepage="http://avidemux.sourceforge.net/"
 changelog="http://avidemux.sourceforge.net/news.html"
 distfiles="${SOURCEFORGE_SITE}/avidemux/avidemux/${version}/${pkgname}_${version}.tar.gz"
-checksum=9a88741f3535443d4bde35d4207ca2ff96d3b136db2e7232cb50dd6b4eb293cf
+checksum=628a404f521ff2812760700ae3e2aa78e5816b0ff3fb6fd05ac3e75248d97401
 
 do_configure() {
 	MAKEFLAGS=${makejobs} \


### PR DESCRIPTION
#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

(I am planning on using the package for a project but found it out of date)

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
