### PR TITLE
j4-dmenu-desktop: add support for checks

### DIFF
--- a/srcpkgs/j4-dmenu-desktop/template
+++ b/srcpkgs/j4-dmenu-desktop/template
@@ -4,11 +4,22 @@ version=2.18
 revision=1
 wrksrc="${pkgname}-r${version}"
 build_style=cmake
-configure_args="-DWITH_TESTS=OFF"
+# The current version (2.18) needs to have /usr/share/applications dir
+# for tests, xterm creates and populates it with its .desktop files,
+# which fixes tests in case the dir does not exist.
+# https://github.com/enkore/j4-dmenu-desktop/pull/123
 depends="dmenu"
+checkdepends="catch2 xterm"
 short_desc="Fast desktop menu"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/enkore/j4-dmenu-desktop"
 distfiles="https://github.com/enkore/j4-dmenu-desktop/archive/r${version}.tar.gz"
 checksum=77c5605d0c1291bcf1e13b186ea3b32ddf4753de0d0e39127b4a7d2098393e25
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args="-DWITH_GIT_CATCH=OFF
+	 -DCATCH_INCLUDE_DIR=$XBPS_CROSS_BASE/usr/include/catch2"
+else
+	configure_args="-DWITH_TESTS=OFF"
+fi


### PR DESCRIPTION
The current version of tests errors out when `/usr/share/applications` does not exist. See https://github.com/enkore/j4-dmenu-desktop/pull/123

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] x86_64-musl
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl