### PR TITLE
crash: depend on binutils

### DIFF
--- a/srcpkgs/crash/template
+++ b/srcpkgs/crash/template
@@ -1,11 +1,12 @@
 # Template file for 'crash'
 pkgname=crash
 version=7.3.0
-revision=1
+revision=2
 archs="i686 x86_64"  # broken on musl
 build_style=gnu-makefile
 hostmakedepends="flex tar wget"
 makedepends="lzo-devel ncurses-devel zlib-devel"
+depends="binutils"
 short_desc="Kernel crash dump debugger and live inspector"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
---
Without `binutils`, `crash` fails due to missing `/usr/bin/strings`:

```
% crash kdump.vmcore vmlinux

...

WARNING: kernel relocated [664MB]: patching 81548 gdb minimal_symbol values

please wait... (patching 81548 gdb minimal_symbol values) sh: 1: /usr/bin/strings: not found
WARNING: kernels compiled by different gcc versions:
  vmlinux: (unknown)
  kdump.vmcore kernel: 7.5.0

WARNING: kernel version inconsistency between vmlinux and dumpfile

crash: incompatible arguments:  vmlinux is not SMP -- kdump.vmcore is SMP

Usage:

  crash [OPTION]... NAMELIST MEMORY-IMAGE[@ADDRESS]     (dumpfile form)
  crash [OPTION]... [NAMELIST]                          (live system form)

Enter "crash -h" for details.
```
