### PR TITLE
connman: add build option "nftables"

### DIFF
--- a/srcpkgs/connman/template
+++ b/srcpkgs/connman/template
@@ -6,10 +6,11 @@ build_style=gnu-configure
 configure_args="--enable-polkit --enable-client --enable-pie --enable-ethernet
  --enable-wifi --enable-bluetooth --enable-loopback --enable-nmcompat
  --enable-openvpn --with-openvpn=/usr/bin/openvpn --enable-openconnect
- --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect"
+ --disable-tools --disable-wispr --with-openconnect=/usr/bin/openconnect
+ --with-firewall=$(vopt_if nftables nftables iptables)"
 hostmakedepends="automake iptables libtool pkg-config wpa_supplicant"
-makedepends="gnutls-devel iptables-devel libglib-devel libmnl-devel
- openconnect-devel readline-devel"
+makedepends="gnutls-devel libglib-devel libmnl-devel openconnect-devel
+ readline-devel $(vopt_if nftables libnftnl-devel iptables-devel)"
 depends="dbus wpa_supplicant"
 short_desc="Open Source CONNection MANager"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -19,6 +20,10 @@ changelog="https://git.kernel.org/pub/scm/network/connman/connman.git/plain/Chan
 distfiles="${KERNEL_SITE}/network/${pkgname}/${pkgname}-${version}.tar.xz"
 checksum=1a57ae7ce234aa3a1744aac3be5c2121d98dce999440ef8ab9cc4edfd5edcb12
 lib32disabled=yes
+
+# Package build options
+build_options="nftables"
+desc_option_nftables="Build with nftables instead of iptables"
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
Allow to build with support for nftables instead of iptables.

From ./configure --help:

    --with-firewall=TYPE    specify which firewall type is used iptables or
                            nftables [default=iptables]

<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
