### PR TITLE
libxcb-devel: install static libraries

### DIFF
--- a/srcpkgs/libxcb/template
+++ b/srcpkgs/libxcb/template
@@ -1,9 +1,9 @@
 # Template file for 'libxcb'
 pkgname=libxcb
 version=1.14
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--disable-build-docs --disable-static --enable-xinput --enable-xkb"
+configure_args="--disable-build-docs --enable-xinput --enable-xkb"
 hostmakedepends="libtool pkg-config xorg-util-macros xcb-proto"
 makedepends="xcb-proto libXdmcp-devel libXau-devel"
 short_desc="X protocol C-language Binding"
@@ -25,5 +25,6 @@ libxcb-devel_package() {
 		vmove usr/share
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+		vmove "usr/lib/*.a"
 	}
 }


### PR DESCRIPTION
So you can statically link against X programs; since libX11 links
against libxcb this is impossible now.

Either I'm not understanding how static linking works (AFAIK you *need*
the .a file?), or this is a very unpopular thing to do as it's been like
this for 9 years (changed in commit 9526648, in 2012) 🤔

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
