### PR TITLE
zlib: remove LDFLAGS workaround.

### DIFF
--- a/srcpkgs/zlib/template
+++ b/srcpkgs/zlib/template
@@ -1,19 +1,16 @@
 # Template file for 'zlib'
 pkgname=zlib
 version=1.2.11
-revision=3
+revision=4
 bootstrap=yes
 build_style=configure
+configure_args="--prefix=/usr --shared"
 short_desc="Compression/decompression Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Zlib"
 homepage="http://www.zlib.net"
 distfiles="$homepage/$pkgname-$version.tar.gz"
 checksum=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-
-do_configure() {
-	LDFLAGS= LDSHAREDLIBC= ./configure --prefix=/usr --shared
-}
 
 zlib-devel_package() {
 	depends="zlib>=${version}_${revision}"


### PR DESCRIPTION
Added in 4d39b701666370b53a7167c00702a1d7a4213a87 without explanation as
to why.

We also revbump to rebuild the binary. On x86_64-musl, old libz.so,
built with gcc 7, is using a 2132KB RE mmap when dynamically linked,
probably because of a 0x200000 alignment required for the RE section.
After rebuilding, 96KB are used, with the actual RE mmap reduced to 56K.
The new alignment is 0x1000.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
