### PR TITLE
iproute2: move usr/bin/tc to -tc-ipt subpackage

### DIFF
--- a/srcpkgs/iproute2/template
+++ b/srcpkgs/iproute2/template
@@ -1,7 +1,7 @@
 # Template file for 'iproute2'
 pkgname=iproute2
 version=5.12.0
-revision=1
+revision=2
 build_style=configure
 make_install_args="SBINDIR=/usr/bin"
 hostmakedepends="pkg-config perl flex"
@@ -35,6 +35,7 @@ post_install() {
 iproute2-tc-ipt_package() {
 	short_desc+=" - tc(8) IPtables support"
 	pkg_install() {
+		vmove usr/bin/tc
 		# m_ipt.so is symlinked to m_xt.so
 		vmove usr/lib/tc/m_ipt.so
 		vmove usr/lib/tc/m_xt.so


### PR DESCRIPTION
/usr/bin/tc is used to configure Traffic Control, it should be part of existing iproute2-tc-ipt subpackage.

The primary motivation to move /usr/bin/tc into subpackage is to remove dependency on iptables package in iproute2, and transitively from base-system. Users who use nftables instead of legacy iptables would not have to blacklist iptables package anymore.

**IMPORTANT**: base-system doesn’t directly depend on iptables, but it depends on iproute2, so iptables is installed by default. It’s described in the [Firewalls documentation](https://docs.voidlinux.org/config/network/firewalls.html):

> By default, the iptables package is installed on the base system. It provides iptables(8)/ip6tables(8). The related services use the /etc/iptables/iptables.rules and /etc/iptables/ip6tables.rules ruleset files, which must be created by the system administrator.

I think that pulling iptables with the base-system by default is wrong. nftables is clearly superior and should be preferred on new installations. I don’t mean that it should be forced, just that iptables should not be the default. Since base-system is supposed to contain really just a base system (there’s not even a cron or syslog included), I think that it should not directly depend on iptables nor nftables.

However, many users probably rely on iptables being installed as transitive dependency of base-system, so effectively removing it from the dependency graph may cause troubles.

What can we do?

a) Inform users about the change, e.g. in post-upgrade message?
a.1) Can we automatically mark iptables as explicit dependency via hook when upgrading iproute2?
b) Add dependency on iptables to the base-system package (lowest effort).
c) Maybe create a virtual _firewall_ and make base-system depend on it? However, I don’t know yet how this works in xbps.
d) …?

/cc @q66 