### PR TITLE
ImageMagick: update to 7.1.0.2 (with soname bump)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -333,8 +333,8 @@ liblcms.so.1 lcms-1.18_1
 libgd.so.3 gd-2.1.0_1
 libcroco-0.6.so.3 libcroco-0.6.2_1
 libgsf-1.so.114 libgsf-1.14.11_1
-libMagickCore-7.Q16HDRI.so.9 libmagick-7.0.11.1_1
-libMagickWand-7.Q16HDRI.so.9 libmagick-7.0.11.1_1
+libMagickCore-7.Q16HDRI.so.10 libmagick-7.1.0.2_1
+libMagickWand-7.Q16HDRI.so.10 libmagick-7.1.0.2_1
 libMagick++-7.Q16HDRI.so.5 libmagick-7.0.11.1_1
 libMagickCore-6.Q16.so.7 libmagick6-6.9.11.61_1
 libMagickWand-6.Q16.so.7 libmagick6-6.9.11.61_1

--- a/srcpkgs/Converseen/template
+++ b/srcpkgs/Converseen/template
@@ -1,7 +1,7 @@
 # Template file for 'Converseen'
 pkgname=Converseen
 version=0.9.9.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
 makedepends="qt5-devel qt5-tools-devel libmagick-devel ImageMagick"

--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,28 +1,26 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
-version=7.0.11.12
-revision=2
+version=7.1.0.2
+revision=1
 _majorver=${version%.*}
 _patchver=${version##*.}
 wrksrc="${pkgname}-${_majorver}-${_patchver}"
 build_style=gnu-configure
-configure_args="--without-autotrace --with-wmf=yes
- --without-dps --without-fpx --without-gvc --without-jbig --with-gslib=yes
- --without-lqr --without-openexr --with-gs-font-dir=/usr/share/fonts/Type1
- --with-magick-plus-plus --with-modules --enable-shared --with-rsvg
- --with-dejavu-font-dir=/usr/share/fonts/TTF --enable-opencl --disable-static
- --with-openjp2"
+configure_args="--disable-static --enable-opencl --with-modules --with-gslib
+ --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF
+ --with-gs-font-dir=/usr/share/fonts/Type1"
 hostmakedepends="automake libtool pkg-config autoconf"
-makedepends="djvulibre-devel fftw-devel ghostscript-devel glib-devel lcms2-devel
- libXt-devel libgomp-devel libltdl-devel librsvg-devel libwebp-devel libwmf-devel
- ocl-icd-devel pango-devel libopenjpeg2-devel"
+makedepends="djvulibre-devel fftw-devel ghostscript-devel glib-devel
+ graphviz-devel lcms2-devel libXt-devel libgomp-devel liblqr-devel libltdl-devel
+ libopenjpeg2-devel libraqm-devel librsvg-devel libwebp-devel libwmf-devel
+ ocl-icd-devel pango-devel"
 short_desc="Package for display and interactive manipulation of images"
 maintainer="Johannes <johannes.brechtmann@gmail.com>"
 license="ImageMagick"
-homepage="https://www.imagemagick.org/"
+homepage="https://www.imagemagick.org"
 changelog="https://imagemagick.org/script/changelog.php"
-distfiles="https://github.com/ImageMagick/ImageMagick/archive/${_majorver}-${_patchver}.tar.gz"
-checksum=b4054e9f6b6692791f37fe6f2ab5819152210e6628e69a8dbd66a41320c3c9d3
+distfiles="https://download.imagemagick.org/ImageMagick/download/ImageMagick-${_majorver}-${_patchver}.tar.xz"
+checksum=039006f616bb326598e7b910932694e2a3ca925586560e1b8d153a7048f52980
 
 subpackages="libmagick libmagick-devel"
 

--- a/srcpkgs/chafa/template
+++ b/srcpkgs/chafa/template
@@ -1,7 +1,7 @@
 # Template file for 'chafa'
 pkgname=chafa
 version=1.6.0
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libglib-devel libmagick-devel libXext-devel libxml2-devel"

--- a/srcpkgs/dmtx-utils/template
+++ b/srcpkgs/dmtx-utils/template
@@ -1,7 +1,7 @@
 # Template file for 'dmtx-utils'
 pkgname=dmtx-utils
 version=0.7.6
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
 makedepends="libdmtx-devel libmagick-devel libXext-devel libxml2-devel"

--- a/srcpkgs/libopenshot/template
+++ b/srcpkgs/libopenshot/template
@@ -1,7 +1,7 @@
 # Template file for 'libopenshot'
 pkgname=libopenshot
 version=0.2.5
-revision=4
+revision=5
 archs="i686 x86_64 ppc64le"
 build_style=cmake
 configure_args="-DENABLE_RUBY=OFF -DUSE_SYSTEM_JSONCPP=ON" # Builds fail with Ruby-2.4.1

--- a/srcpkgs/php-imagick/template
+++ b/srcpkgs/php-imagick/template
@@ -1,7 +1,7 @@
 # Template file for 'php-imagick'
 pkgname=php-imagick
 version=3.4.4
-revision=3
+revision=4
 wrksrc="imagick-$version"
 build_style=gnu-configure
 hostmakedepends="php-devel autoconf pkg-config"

--- a/srcpkgs/sk1/template
+++ b/srcpkgs/sk1/template
@@ -1,7 +1,7 @@
 # Template file for 'sk1'
 pkgname=sk1
 version=2.0rc4
-revision=4
+revision=5
 build_style=python2-module
 pycompile_dirs="/usr/lib/sk1-wx-${version}"
 hostmakedepends="pkg-config python"

--- a/srcpkgs/vapoursynth/template
+++ b/srcpkgs/vapoursynth/template
@@ -1,7 +1,7 @@
 # Template file for 'vapoursynth'
 pkgname=vapoursynth
 version=R52
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="automake libtool nasm pkg-config python3-Cython"
 makedepends="ffmpeg-devel python3-devel zimg-devel libass-devel libmagick-devel

--- a/srcpkgs/zbar/template
+++ b/srcpkgs/zbar/template
@@ -1,7 +1,7 @@
 # Template file for 'zbar'
 pkgname=zbar
 version=0.23.1
-revision=3
+revision=4
 build_style=gnu-configure
 build_helper=gir
 configure_args="$(vopt_with qt) --with-gir --with-python=python3"


### PR DESCRIPTION
- Remove unnecessary configure options
- Add support for graphviz, jbig, lqr and raqm