### PR TITLE
zathura: backport (improved) upstream patch for buffer overflow

### DIFF
--- a/srcpkgs/zathura/patches/fix-buffer-overflow.patch
+++ b/srcpkgs/zathura/patches/fix-buffer-overflow.patch
@@ -1,5 +1,9 @@
+Taken from upstream
+https://git.pwmt.org/pwmt/zathura/-/commit/2713de2f6c810f5f0be3c179944867b5b07ddaed
+with a small correction
+
 diff --git a/zathura/utils.c b/zathura/utils.c
-index b4b058f..6e1910e 100644
+index b4b058f..35abd6b 100644
 --- a/zathura/utils.c
 +++ b/zathura/utils.c
 @@ -401,7 +401,7 @@ rectangle_to_points(void* vrect, void* vlist) {
@@ -7,7 +11,30 @@ index b4b058f..6e1910e 100644
  static void
  append_unique_uint(girara_list_t* list, const unsigned int v) {
 -  double* p = g_try_malloc(sizeof(v));
-+  double* p = g_try_malloc(sizeof(*p));
++  unsigned int* p = g_try_malloc(sizeof *p);
    if (p == NULL) {
      return;
    }
+@@ -433,16 +433,16 @@ cut_rectangle(const zathura_rectangle_t* rect, girara_list_t* points, girara_lis
+   GIRARA_LIST_FOREACH_END(points, zathura_point_t*, i_pt, pt);
+ 
+   double x = ufloor(rect->x1);
+-  GIRARA_LIST_FOREACH(xs, const double*, ix, cx)
++  GIRARA_LIST_FOREACH(xs, const unsigned int*, ix, cx)
+     double y = ufloor(rect->y1);
+-    GIRARA_LIST_FOREACH(ys, const double*, iy, cy)
++    GIRARA_LIST_FOREACH(ys, const unsigned int*, iy, cy)
+       zathura_rectangle_t* r = g_try_malloc(sizeof(zathura_rectangle_t));
+       *r = (zathura_rectangle_t) {x, y, *cx, *cy};
+       y = *cy;
+       girara_list_append_unique(rectangles, cmp_rectangle, r);
+-    GIRARA_LIST_FOREACH_END(ys, const double*, iy, cy);
++    GIRARA_LIST_FOREACH_END(ys, const unsigned int*, iy, cy);
+     x = *cx;
+-  GIRARA_LIST_FOREACH_END(xs, const double*, ix, cx);
++  GIRARA_LIST_FOREACH_END(xs, const unsigned int*, ix, cx);
+ 
+   girara_list_free(xs);
+   girara_list_free(ys);
+-- 
+2.26.2

--- a/srcpkgs/zathura/template
+++ b/srcpkgs/zathura/template
@@ -1,7 +1,7 @@
 # Template file for 'zathura'
 pkgname=zathura
 version=0.4.7
-revision=3
+revision=4
 build_style=meson
 configure_args="-Dsynctex=enabled"
 hostmakedepends="pkg-config intltool python3-Sphinx desktop-file-utils


### PR DESCRIPTION
Tested on x86_64-musl, fixes #31722 