### PR TITLE
Add -DNDEBUG to CFLAGS and CXXFLAGS in CMake build style

### DIFF
--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -63,8 +63,8 @@ _EOF
 	cmake_args+=" -DCMAKE_INSTALL_SBINDIR=bin"
 
 	export CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
-	# Override flags: https://gitlab.kitware.com/cmake/cmake/issues/19590
-	CFLAGS="${CFLAGS/ -pipe / }" CXXFLAGS="${CXXFLAGS/ -pipe / }" \
+	# Remove -pipe: https://gitlab.kitware.com/cmake/cmake/issues/19590
+	CFLAGS="-DNDEBUG ${CFLAGS/ -pipe / }" CXXFLAGS="-DNDEBUG ${CXXFLAGS/ -pipe / }" \
 		cmake ${cmake_args} ${configure_args} ${wrksrc}/${build_wrksrc}
 
 	# Replace -isystem with -I


### PR DESCRIPTION
CMake adds `-DNDEBUG` with build types `Release`, `MinSizeRel` and `RelWithDebInfo` (see https://github.com/Kitware/CMake/blob/master/Modules/Compiler/GNU.cmake#L57). `NDEBUG` disables `assert()`, which can improve performance.