### PR TITLE
wireguard-tools: include contrib/ contents in package.

### DIFF
--- a/srcpkgs/wireguard-tools/template
+++ b/srcpkgs/wireguard-tools/template
@@ -1,11 +1,13 @@
 # Template file for 'wireguard-tools'
 pkgname=wireguard-tools
 version=1.0.20210424
-revision=1
+revision=2
 build_wrksrc="src"
 build_style=gnu-makefile
 make_install_args="WITH_BASHCOMPLETION=yes WITH_WGQUICK=yes"
 depends="openresolv"
+# FIXME: clang-analyzer should depend on perl
+checkdepends="clang-analyzer perl"
 short_desc="Fast, modern, secure VPN tunnel - userland tools"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-only"
@@ -14,10 +16,13 @@ distfiles="https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${vers
 checksum=b288b0c43871d919629d7e77846ef0b47f8eeaa9ebc9cedeee8233fc6cc376ad
 make_dirs="/etc/wireguard 0700 root root"
 
-post_extract() {
-	sed -i 's/^CFLAGS /override &/' ${build_wrksrc}/Makefile
+post_patch() {
+	vsed -i 's/^CFLAGS /override &/' Makefile
 }
 
 post_install() {
 	vsv wireguard
+
+	vmkdir usr/share/$pkgname/examples
+	vcopy ../contrib/* usr/share/$pkgname/examples
 }


### PR DESCRIPTION
Other distros are putting them in /usr/share/wireguard-tools/examples,
so we also do that for consistency.

@leahneukirchen 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
