### PR TITLE
libserialport: add patch to prevent it from using termiox, which has been removed from recent kernels

### DIFF
--- a/srcpkgs/libserialport/patches/0001-Remove-termiox-as-it-has-been-removed-from-recent-ke.patch
+++ b/srcpkgs/libserialport/patches/0001-Remove-termiox-as-it-has-been-removed-from-recent-ke.patch
@@ -1,0 +1,36 @@
+Inspired by this commit from the upstream package:
+https://sigrok.org/gitweb/?p=libserialport.git;a=commit;h=6f9b03e597ea7200eb616a4e410add3dd1690cb1
+
+Applying this patch directly added some extra dependencies (autoconf,
+automake), as the configure script needs to be regenerated with the
+original commit.
+
+original commit message:
+
+termiox was removed from linux in e0efb3168d34
+Some more information available in https://www.spinics.net/lists/linux-serial/msg41926.html
+
+Attempting to use the termiox ioctls on more modern kernels results in
+"Inappropriate IOCTL" errors.
+
+While the "right" solution might be to remove the termiox code from the
+linux path, simply not checking for termiox builds a libserialport that
+functions on modern linux kernels.
+---
+diff --git a/libserialport_internal.h b/libserialport_internal.new.h
+index 669152b..9a57b81 100644
+--- libserialport_internal.h
++++ libserialport_internal.h
+@@ -69,11 +69,6 @@
+ #include "linux/serial.h"
+ #endif
+ #include "linux_termios.h"
+-
+-/* TCGETX/TCSETX is not available everywhere. */
+-#if defined(TCGETX) && defined(TCSETX) && defined(HAVE_STRUCT_TERMIOX)
+-#define USE_TERMIOX
+-#endif
+ #endif
+ 
+ /* TIOCINQ/TIOCOUTQ is not available everywhere. */
+

--- a/srcpkgs/libserialport/template
+++ b/srcpkgs/libserialport/template
@@ -1,7 +1,7 @@
 # Template file for 'libserialport'
 pkgname=libserialport
 version=0.1.1
-revision=2
+revision=3
 build_style=gnu-configure
 short_desc="Cross-platform library for accessing serial ports"
 maintainer="lemmi <lemmi@nerd2nerd.org>"


### PR DESCRIPTION
Without this patch, libserialport will fail opening a tty device with an "No such ioctl for device"-error. This prevents eg. sigrok/pulseview from working with a SUMP-compatible logic analyzer.

EDIT: some clarification: [see here](https://sigrok.org/gitweb/?p=libserialport.git;a=commit;h=6f9b03e597ea7200eb616a4e410add3dd1690cb1), something like their patches would work better, but, honestly, libserialport should have a new release, 0.1.1 is from years ago.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
