### PR TITLE
rhash: update to 1.4.2

### DIFF
--- a/srcpkgs/rhash/template
+++ b/srcpkgs/rhash/template
@@ -1,21 +1,21 @@
 # Template file for 'rhash'
 pkgname=rhash
-version=1.4.1
-revision=2
+version=1.4.2
+revision=1
 wrksrc="RHash-${version}"
 build_style=configure
 configure_args="--enable-openssl --disable-openssl-runtime
  --prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/rhashrc"
+make_build_target="all lib-shared"
+make_install_target="install install-lib-shared"
 makedepends="openssl-devel"
 short_desc="Utility for computing hash sums and creating magnet links"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="0BSD"
 homepage="https://github.com/rhash/RHash"
 distfiles="https://github.com/rhash/RHash/archive/v${version}.tar.gz"
-checksum=430c812733e69b78f07ce30a05db69563450e41e217ae618507a4ce2e144a297
-make_build_target="all lib-shared"
-make_install_target="install install-lib-shared"
+checksum=600d00f5f91ef04194d50903d3c79412099328c42f28ff43a0bdb777b00bec62
 
 post_extract() {
 	sed -i 's/__GLIBC__/__linux__/' librhash/byte_order.h


### PR DESCRIPTION
  - significantly improve file reading performance on Linux/Unix
  - print 'Nothing to verify' when verifying a hash file without a message digest
  - count unparsed lines of a hash file as errors
  - print line numbers of unparsed lines of a hash file
  - Bugfix: fix verification of some hash files containing spaces in file paths

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ x I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64
  - [ x armv7l
  - [ ] armv6l-musl
