### PR TITLE
cross-x86_64-w64-mingw32: update to 9.0.0

### DIFF
--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,9 +1,9 @@
 # Template file for 'cross-x86_64-w64-mingw32'
 pkgname=cross-x86_64-w64-mingw32
-version=8.0.0
+version=9.0.0
 revision=1
-_gcc_version=10.2.0
-_binutils_version=2.34
+_gcc_version=11.1.0
+_binutils_version=2.35.1
 _gmp_version=6.2.0
 _mpfr_version=4.1.0
 _mpc_version=1.1.0
@@ -18,8 +18,8 @@ makedepends="zlib-devel"
 depends="${pkgname}-crt-${version}_${revision}"
 short_desc="Cross toolchain for Win64 (GCC ${_gcc_version})"
 maintainer="Aleksey Tulinov <aleksey.tulinov@gmail.com>"
-homepage="https://sourceforge.net/projects/mingw-w64/"
 license="GPL-2.0-or-later, GPL-3.0-or-later, ZPL-2.1"
+homepage="https://sourceforge.net/projects/mingw-w64/"
 distfiles="
  ${GNU_SITE}/binutils/binutils-${_binutils_version}.tar.xz
  ${GNU_SITE}/gcc/gcc-${_gcc_version}/gcc-${_gcc_version}.tar.xz
@@ -28,13 +28,13 @@ distfiles="
  ${GNU_SITE}/mpfr/mpfr-${_mpfr_version}.tar.xz
  http://isl.gforge.inria.fr/isl-${_isl_version}.tar.bz2
  ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
-checksum="f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952
- b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c
+checksum="3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607
+ 4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf
  6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
  258e6cd51b3fbdfc185c716d55f82c08aff57df0c6fbd143cf6ed561267a1526
  0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
  d18ca11f8ad1a39ab6d03d3dcb3365ab416720fcb65b42d69f34f51bf0a0e859
- 44c740ea6ab3924bc3aa169bad11ad3c5766c5c8459e3126d44eabb8735a5762"
+ 1929b94b402f5ff4d7d37a9fe88daa9cc55515a6134805c104d1794ae22a4181"
 
 nocross=yes
 nopie=yes


### PR DESCRIPTION
[ci skip]

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

* Mingw-w64 9.0.0
* GCC 11.1.0 (sort of future-proofing)
* Binutils harmonized with mainline (with GCC template)
* Homepage placed after license (according to `xlint`)