### PR TITLE
Jdupes 1200

### DIFF
--- a/srcpkgs/jdupes/template
+++ b/srcpkgs/jdupes/template
@@ -1,6 +1,6 @@
 # Template file for 'jdupes'
 pkgname=jdupes
-version=1.19.1
+version=1.20.0
 revision=1
 build_style=gnu-makefile
 make_build_args="ENABLE_BTRFS=1"
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://github.com/jbruchon/jdupes"
 changelog="https://raw.githubusercontent.com/jbruchon/jdupes/master/CHANGES"
 distfiles="https://github.com/jbruchon/jdupes/archive/v${version}.tar.gz"
-checksum=bb7c53cd463ab5e21da85948c4662a3b7ac9b038ae993cc14ccf793d2472e2e9
+checksum=c1f728961ad8aeb074e5767367639e6b418f0ca572f70f7635655da722f1827e
 
 pre_build() {
 	sed -i 's/^CFLAGS +=/override CFLAGS +=/g' Makefile

--- a/srcpkgs/jdupes/template
+++ b/srcpkgs/jdupes/template
@@ -12,6 +12,15 @@ changelog="https://raw.githubusercontent.com/jbruchon/jdupes/master/CHANGES"
 distfiles="https://github.com/jbruchon/jdupes/archive/v${version}.tar.gz"
 checksum=bb7c53cd463ab5e21da85948c4662a3b7ac9b038ae993cc14ccf793d2472e2e9
 
+pre_build() {
+	sed -i 's/^CFLAGS +=/override CFLAGS +=/g' Makefile
+	sed -i 's/^LDFLAGS =/override LDFLAGS +=/g' Makefile
+}
+
 post_install() {
 	vlicense LICENSE
+}
+
+do_check() {
+	./jdupes -V|grep fsdedup
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

Despite the flag ENABLE_BTRFS is enabled for make, this seems to be mishandled by the way the Makefile builds the CFLAGS, so the functionality does not get included.

(It does not depend on any BTRFS headers, libraries, or ioctls, only if the appropriate flag is given on run)

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR


#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-glibc
  - [x] armv7l
  - [ ] armv6l-musl
