### PR TITLE
xournalpp: update to 1.1.0.

### DIFF
--- a/srcpkgs/xournalpp/patches/plugin-path.patch
+++ b/srcpkgs/xournalpp/patches/plugin-path.patch
@@ -1,0 +1,20 @@
+Temporary patch to load plugins from $CONFIG_FOLDER/plugins/,
+usually $HOME/.config/xournalpp/plugins/
+
+Otherwise, the only way to load plugins is to place them in the
+system directory /usr/share/xournalpp/plugins.
+
+A more general approach for plugin paths is planned, see
+https://github.com/xournalpp/xournalpp/issues/1155#issuecomment-623234420
+
+--- a/src/plugin/PluginController.cpp	2021-03-14 00:26:17.633925344 -0300
++++ b/src/plugin/PluginController.cpp	2021-03-14 00:27:08.487299784 -0300
+@@ -15,6 +15,7 @@
+ PluginController::PluginController(Control* control): control(control) {
+ #ifdef ENABLE_PLUGINS
+     auto searchPath = control->getGladeSearchPath()->getFirstSearchPath();
++    loadPluginsFrom(Util::getConfigSubfolder("plugins"));
+     loadPluginsFrom((searchPath /= "../plugins").lexically_normal());
+ #endif
+ }
+

--- a/srcpkgs/xournalpp/template
+++ b/srcpkgs/xournalpp/template
@@ -1,11 +1,11 @@
 # Template file for 'xournalpp'
 pkgname=xournalpp
-version=1.0.20
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config gettext"
 makedepends="libxml2-devel libcppunit-devel poppler-glib-devel gtk+3-devel
- portaudio-cpp-devel libsndfile-devel libzip-devel"
+ portaudio-cpp-devel libsndfile-devel libzip-devel librsvg-devel lua53-devel"
 depends="virtual?tex"
 short_desc="Handwriting Notetaking software with PDF annotation support"
 maintainer="mobinmob <mobinmob@disroot.org>"
@@ -13,7 +13,11 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/xournalpp/xournalpp"
 changelog="https://raw.githubusercontent.com/xournalpp/xournalpp/master/CHANGELOG.md"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/${version}.tar.gz"
-checksum=1abf9925f11f0944c8142194be3e72541e230afa83490b074f5c6e613b0e2a02
+checksum=31b99282bcd1d829f05f1c9ccd07c5d599acc0e69725d135cdc97e1dcaf2baee
+
+if [ -z "$CROSS_BUILD" ]; then
+	hostmakedepends+=" help2man"
+fi
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) makedepends+=" libexecinfo-devel"


### PR DESCRIPTION
#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me

I've been following git HEAD of xournalpp, updating every once in a while, and using it every day to teach, I can say it works and it has several nice improvements over the previous version.

In particular it is now possible to write lua plugins to enhance the program. I'm using plugins and I included a trivial very tiny patch so that plugins can be loaded from user configuration (`$HOME/.config/xournalpp/plugins/`) and not only from system directory (`/usr/share/xournalpp/plugins/`). I hope this is ok, since it is otherwise impossible to load plugins without changing system files. Note that a more general approach for plugin paths is planned (https://github.com/xournalpp/xournalpp/issues/1155#issuecomment-623234420); it should be compatible with my workaround (in the sense that once they implement what they are planning we can remove this temporary patch).