### PR TITLE
OpenRCT2: update to 0.3.4, enable tests

### DIFF
--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -4,13 +4,15 @@
 pkgname=OpenRCT2
 _objects_version=1.0.21
 _titles_version=0.1.2c
-version=0.3.3
-revision=2
+_replays_version=0.0.43
+version=0.3.4
+revision=1
 build_style=cmake
 configure_args="
  -DOPENRCT2_VERSION_TAG=${version}
  -DDOWNLOAD_TITLE_SEQUENCES=0
  -DDOWNLOAD_OBJECTS=0
+ -DDOWNLOAD_REPLAYS=0
  -DDISABLE_DISCORD_RPC=1
  -DDISABLE_GOOGLE_BENCHMARK=1
  $(vopt_if multiplayer '' '-DDISABLE_NETWORK=1')
@@ -22,18 +24,19 @@ makedepends="SDL2-devel fontconfig-devel freetype-devel libzip-devel
  $(vopt_if multiplayer 'libcurl-devel openssl-devel')
  $(vopt_if scripting duktape-devel)"
 depends="zenity"
+checkdepends="gtest-devel"
 short_desc="Open source re-implementation of RollerCoaster Tycoon 2"
 maintainer="klardotsh <josh@klar.sh>"
 license="GPL-3.0-or-later, CC-BY-SA-4.0"
 homepage="https://openrct2.io"
-# use title-sequences.zip to match CMakeLists instruction
+# download objects and title sequences ourselves, instead of letting cmake do it
 distfiles="https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz
  https://github.com/OpenRCT2/objects/releases/download/v${_objects_version}/objects.zip
  https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequences.zip"
-checksum="71f9d1ae8477e1e9881a6f9759bddac71346e8ba42238d22514ae3d872b54fd2
+checksum="755529c797b94279e683b77ffbcfcfe901cca2fff817431632a23019ac95c6ca
  b081f885311f9afebc41d9dd4a68b7db4cf736eb815c04e307e1a426f08cfa35
  5284333fa501270835b5f0cf420cb52155742335f5658d7889ea35d136b52517"
-skip_extraction="objects.zip title-sequences.zip"
+skip_extraction="objects.zip title-sequences.zip replays.zip"
 
 replaces="OpenRCT2-data>=0"
 
@@ -53,16 +56,36 @@ if [ "$CROSS_BUILD" ]; then
 	CXXFLAGS+=" -DHAVE_IMMINTRIN_H=false -DSDL_DISABLE_IMMINTRIN_H=1"
 fi
 
-pre_configure() {
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -DWITH_TESTS=1 -DSYSTEM_GTEST=1"
+	# download replays, used in tests
+	distfiles+=" https://github.com/OpenRCT2/replays/releases/download/v${_replays_version}/replays.zip"
+	checksum+=" 43ba763ee6950a51aa96b26f3007c18b6e2ed09b6003601df6b014d5642c08d8"
+fi
+
+post_extract() {
+	_srcdir="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
+	_builddir="${build_wrksrc:+$build_wrksrc/}${cmake_builddir:=build}"
+	unzip -qd data/object "${_srcdir}/objects.zip"
+	unzip -qd data/sequence "${_srcdir}/title-sequences.zip"
+	if [ "$XBPS_CHECK_PKGS" ]; then
+		unzip -qd test/tests/testdata/replays "${_srcdir}/replays.zip"
+		# CMakeLists seems to assume `install` is run before `check`, and so
+		# doesn't actually make the `data`/`testdata` symlinks in time
+		mkdir -p "${_builddir}"
+		ln -rs data testdata "${_builddir}/"
+	fi
+
+	vsed -i CMakeLists.txt -e "s; -Werror;;"
+}
+
+post_patch() {
 	if [ "$CROSS_BUILD" ]; then
 		sed -i -e 's#COMMAND ./openrct2#COMMAND openrct2#g' CMakeLists.txt
 	fi
 }
 
-post_extract() {
-	_srcdir="${XBPS_SRCDISTDIR}/${pkgname}-${version}"
-	unzip -qd data/object "${_srcdir}/objects.zip"
-	unzip -qd data/sequence "${_srcdir}/title-sequences.zip"
-
-	vsed -i CMakeLists.txt -e "s; -Werror;;"
+post_install() {
+	# remove useless static lib
+	rm "${DESTDIR}/usr/lib/libopenrct2.a"
 }


### PR DESCRIPTION
In the last version, a few of the tests were broken, so I hadn't put in the plumbing for the check step yet. Now the tests all pass, so that's cool.

Also, I removed `/usr/lib/libopenrct2.a`, which only exists to be linked into `openrct2` and `openrct2-cli` and shouldn't have been included in the package itself. (It can also be built as a shared object, but again it's only used to share code between the two binaries, and I'm not going to try to reconcile that with Void policy over 10M of duplicated code.)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR