### PR TITLE
apparmor: add missing dependencies

### DIFF
--- a/srcpkgs/apparmor/template
+++ b/srcpkgs/apparmor/template
@@ -1,7 +1,7 @@
 # Template file for 'apparmor'
 pkgname=apparmor
 version=3.0.1
-revision=5
+revision=6
 wrksrc="${pkgname}-v${version}"
 build_wrksrc=libraries/libapparmor
 build_style=gnu-configure
@@ -9,7 +9,8 @@ conf_files="/etc/apparmor.d/local/* /etc/apparmor/*"
 make_dirs="/etc/apparmor.d/disable 0755 root root"
 hostmakedepends="bison flex autoconf automake libtool gettext swig python3 which"
 makedepends="perl python3-devel"
-depends="runit-void-apparmor libapparmor-${version}_${revision} python3-notify2 python3-psutil"
+depends="runit-void-apparmor libapparmor-${version}_${revision} python3-notify2
+ python3-psutil python3-dbus iproute2"
 checkdepends="dejagnu"
 short_desc="Mandatory access control to restrict programs"
 maintainer="Olivier Mauras <olivier@mauras.ch>"


### PR DESCRIPTION
* python3-dbus is needed for aa-notify, closes #32052
* ss from iproute2 is needed for aa-unconfined

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR