### PR TITLE
vivaldi: update to 4.0.2312.41.

### DIFF
--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -1,9 +1,9 @@
 # Template file for 'vivaldi'
 pkgname=vivaldi
-version=3.8.2259.42
+version=4.0.2312.41
 revision=1
 _release=1
-archs="i686 x86_64"
+archs="x86_64"
 hostmakedepends="curl python3-html2text python3-setuptools"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Advanced browser made with the power user in mind"
@@ -16,19 +16,12 @@ repository=nonfree
 restricted=yes
 nostrip=yes
 
-if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-	_debarch=amd64
-	checksum=cd6648b4a6b45069e7bc4955cc0464abca6bd9c5c70f7a63f3a162e9e002f80c
-else
-	_debarch=i386
-	checksum=68557d8723c3db7acea990524b4c3da895a2a1c150e547fc3bcb2c1590511675
-fi
-
-distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_${_debarch}.deb"
+distfiles="https://downloads.vivaldi.com/stable/vivaldi-stable_${version}-${_release}_amd64.deb"
 _licenseUrl="https://vivaldi.com/privacy/vivaldi-end-user-license-agreement/"
+checksum=70f552d36b520cbfe747b24902a968ad03c359ffa49882869a60f03ca6c131bc
 
 do_extract() {
-	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/vivaldi-stable_${version}-${_release}_${_debarch}.deb
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/vivaldi-stable_${version}-${_release}_amd64.deb
 	bsdtar xf data.tar.xz --exclude={./etc,./opt/vivaldi/cron}
 }
 


### PR DESCRIPTION
Also:
- remove i686 support - the upstream is not updating it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
