### PR TITLE
Rework linux and linux-lts meta packages, also update linux-lts

### DIFF
--- a/srcpkgs/linux-base/template
+++ b/srcpkgs/linux-base/template
@@ -1,0 +1,18 @@
+# Template file for 'linux-base'
+pkgname=linux-base
+version=2021.07.21
+revision=1
+build_style=meta
+short_desc="Linux kernel base dependencies"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
+license="Public Domain"
+homepage="https://voidlinux.org/"
+
+case "$XBPS_TARGET_MACHINE" in
+	i686*|x86_64*)
+		depends="linux-firmware-amd linux-firmware-intel linux-firmware-nvidia linux-firmware-network dracut"
+		;;
+	ppc*|armv7l*|aarch64*)
+		depends="linux-firmware-amd linux-firmware-nvidia linux-firmware-network dracut"
+		;;
+esac

--- a/srcpkgs/linux-lts/template
+++ b/srcpkgs/linux-lts/template
@@ -1,25 +1,15 @@
 # Template file for 'linux-lts'
 pkgname=linux-lts
-version=4.14
-revision=2
+version=5.10
+revision=1
 build_style=meta
-homepage="http://www.voidlinux.org/"
+depends="linux${version} linux-base"
 short_desc="Linux LTS (Long Term Support) kernel meta package"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="Public domain"
-
-case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*)
-		depends="linux${version} linux-firmware-amd linux-firmware-intel linux-firmware-nvidia linux-firmware-network dracut"
-		_depends_headers="linux${version}-headers"
-		;;
-	arm*|aarch64*)
-		depends="linux${version}"
-		_depends_headers="linux${version}-headers"
-		;;
-esac
+license="Public Domain"
+homepage="http://www.voidlinux.org/"
 
 linux-lts-headers_package() {
 	short_desc="Linux longterm support kernel headers meta package"
-	depends="${_depends_headers}"
+	depends="linux${version}-headers"
 }

--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,30 +1,15 @@
 # Template file for 'linux'
 pkgname=linux
-version=5.12
+version=5.13
 revision=1
 build_style=meta
+depends="linux${version} linux-base"
 short_desc="Linux kernel meta package"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Public Domain"
 homepage="http://www.voidlinux.org/"
 
-case "$XBPS_TARGET_MACHINE" in
-	i686*|x86_64*)
-		depends="linux${version} linux-firmware-amd linux-firmware-intel linux-firmware-nvidia linux-firmware-network dracut"
-		_depends_headers="linux${version}-headers"
-		;;
-	ppc*|armv7l*|aarch64*)
-		depends="linux${version} linux-firmware-amd linux-firmware-nvidia linux-firmware-network dracut"
-		_depends_headers="linux${version}-headers"
-		;;
-	arm*)
-		depends="linux${version}"
-		_depends_headers="linux${version}-headers"
-		;;
-	*) ;;
-esac
-
 linux-headers_package() {
 	short_desc="Linux kernel headers meta package"
-	depends="${_depends_headers}"
+	depends="linux${version}-headers"
 }


### PR DESCRIPTION
Our dances for installing a given kernel version but still having firmware and dracut are error prone and unnecessary. This PR aims to solve that.

If we want to split the `dracut` dependency for greater initramfs flexibility, we can discuss that here too.