### PR TITLE
perl-Params-Validate: rebuild for perl 5.34 and add checkdeps

### DIFF
--- a/srcpkgs/perl-Params-Validate/template
+++ b/srcpkgs/perl-Params-Validate/template
@@ -1,12 +1,13 @@
 # Template file for 'perl-Params-Validate'
 pkgname=perl-Params-Validate
 version=1.29
-revision=6
+revision=7
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-ModuleBuild
 hostmakedepends="perl perl-Module-Build"
 makedepends="${hostmakedepends} perl-Module-Implementation"
 depends="perl perl-Module-Implementation"
+checkdepends="perl-Test-Fatal perl-Test-Requires"
 short_desc="Validate method/function parameters"
 maintainer="John Regan <john@jrjrtech.com>"
 license="Artistic-2.0"


### PR DESCRIPTION
This makes `biber` pass all tests on `x86_64`.
