### PR TITLE
dtc: remove git from hostmakedepends

### DIFF
--- a/srcpkgs/dtc/template
+++ b/srcpkgs/dtc/template
@@ -1,18 +1,18 @@
 # Template file for 'dtc'
 pkgname=dtc
-version=1.6.0
+version=1.6.1
 revision=1
 build_style=gnu-makefile
 make_build_args="NO_PYTHON=1"
 make_install_args="$make_build_args"
-hostmakedepends="git flex bison pkg-config"
+hostmakedepends="flex bison pkg-config"
 makedepends="libyaml-devel"
 short_desc="Device Tree Compiler"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-only"
 homepage="https://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 distfiles="https://www.kernel.org/pub/software/utils/dtc/dtc-${version}.tar.xz"
-checksum=10503b0217e1b07933e29e8d347a00015b2431bea5f59afe0bed3af30340c82d
+checksum=65cec529893659a49a89740bb362f507a3b94fc8cd791e76a8d6a2b6f3203473
 
 CFLAGS="-fPIC"
 


### PR DESCRIPTION
Removes a huge dependency chain from cross toolchains. The git dependency is used for getting the version, but then the variable in the Makefile is never used. Maybe the package doesn't have to be revbumped?

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR