### PR TITLE
screen: fix launch.

### DIFF
--- a/srcpkgs/screen/files/20-screen.sh
+++ b/srcpkgs/screen/files/20-screen.sh
@@ -1,0 +1,1 @@
+install -dm 1777 /run/screens

--- a/srcpkgs/screen/template
+++ b/srcpkgs/screen/template
@@ -1,7 +1,7 @@
 # Template file for 'screen'
 pkgname=screen
 version=4.8.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--with-sys-screenrc=/etc/screenrc --enable-pam
  --enable-colors256 --enable-rxvt_osc --enable-telnet
@@ -25,4 +25,6 @@ post_install() {
 	if [ "$build_option_multiuser" ]; then
 		chmod 4755 ${DESTDIR}/usr/bin/screen-${version}
 	fi
+
+	vinstall $FILESDIR/20-screen.sh 644 etc/runit/core-services
 }


### PR DESCRIPTION
When screen isn't suid, it can't create the directory under /run/screens
for sessions to sit in. We went with this approach instead of removing
--with-socket-dir so screen would default to using ~/.screen, becaise it
would require users with currently running screen sessions to launch the
screen client with SCREENDIR set correctly.

Since that approach would be more complicated for users and require
leaving an INSTALL.msg in the package for some time, we went with a
simpler one of always creating the directory at build time.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
