### PR TITLE
musl: allow libraries in /usr/local/lib to override system ones.

### DIFF
--- a/srcpkgs/musl/patches/default-sys_path.patch
+++ b/srcpkgs/musl/patches/default-sys_path.patch
@@ -1,0 +1,17 @@
+Since Void implements usrmerge, /lib is a symlink to /usr/lib. musl's default,
+here, makes it so the libraries under /usr/local/lib won't override the system
+ones, which is not the desired behavior.
+
+diff --git a/ldso/dynlink.c b/ldso/dynlink.c
+index 5b9c8be4..f6532968 100644
+--- a/ldso/dynlink.c
++++ b/ldso/dynlink.c
+@@ -1095,7 +1095,7 @@ static struct dso *load_library(const char *name, struct dso *needed_by)
+ 					sys_path = "";
+ 				}
+ 			}
+-			if (!sys_path) sys_path = "/lib:/usr/local/lib:/usr/lib";
++			if (!sys_path) sys_path = "/usr/local/lib:/usr/lib";
+ 			fd = path_open(name, sys_path, buf, sizeof buf);
+ 		}
+ 		pathname = buf;

--- a/srcpkgs/musl/template
+++ b/srcpkgs/musl/template
@@ -2,7 +2,7 @@
 pkgname=musl
 reverts="1.2.0_1"
 version=1.1.24
-revision=9
+revision=10
 archs="*-musl"
 bootstrap=yes
 build_style=gnu-configure


### PR DESCRIPTION
This was already possible by setting an RPATH, using LD_LIBRARY_PATH or
/etc/ld-musl-$ARCH.path. However, none of these should be necessary,
since that should be the default behavior.

@void-linux/pkg-committers 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
