### PR TITLE
pipewire: remove libpulseaudio-pipewire from repos.

### DIFF
--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,7 +1,7 @@
 # Template file for 'pipewire'
 pkgname=pipewire
 version=0.3.32
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dman=enabled -Dgstreamer=enabled -Ddocs=enabled -Dsystemd=disabled
  -Dbluez5=enabled -Dffmpeg=enabled -Dpipewire-alsa=enabled -Dpipewire-jack=enabled
@@ -23,8 +23,6 @@ make_dirs="/var/lib/pipewire 0755 _pipewire _pipewire"
 system_accounts="_pipewire"
 
 build_options="sdl2"
-
-replaces="libpulseaudio-pipewire>=0"
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,7 +1,7 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
 version=0.1
-revision=46
+revision=47
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
@@ -194,6 +194,7 @@ replaces="
  libfcitx-qt-devel<=4.2.9.8_1
  libgksu<=2.0.12_5
  libglib-static<=2.58.3_5
+ libpulseaudio-pipewire<=0.3.17_1
  libpyside-python3<=5.15.0_2
  libqmatrixclient<=0.5.3.2_1
  libqmatrixclient-devel<=0.5.3.2_1


### PR DESCRIPTION
The packages for this are [still around on repos](https://voidlinux.org/packages/?arch=x86_64&q=libpulseaudio-pipewire), I think it's about time for those to go.
This subpackage [was deprecated with the upgrade to PipeWire 0.3.18](https://github.com/void-linux/void-packages/pull/27279).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
