### PR TITLE
screen: create /run/screens also at install time

### DIFF
--- a/srcpkgs/screen/INSTALL
+++ b/srcpkgs/screen/INSTALL
@@ -1,0 +1,5 @@
+case "${ACTION}" in
+post)
+	install -dm 1777 run/screens
+	;;
+esac

--- a/srcpkgs/screen/template
+++ b/srcpkgs/screen/template
@@ -1,7 +1,7 @@
 # Template file for 'screen'
 pkgname=screen
 version=4.8.0
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--with-sys-screenrc=/etc/screenrc --enable-pam
  --enable-colors256 --enable-rxvt_osc --enable-telnet


### PR DESCRIPTION
After 56db43e, the directory is created at boot time.
This means if one installs screen it won't work until
after the first reboot.

This commit fixes that by creating the directory also
at install time. Note that we still need to create the
directory at boot time, since /run is cleared (tmpfs).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
