### PR TITLE
libX11: patch for new symbols

### DIFF
--- a/srcpkgs/libX11/patches/handle_new_xorgproto_symbols.patch
+++ b/srcpkgs/libX11/patches/handle_new_xorgproto_symbols.patch
@@ -1,0 +1,42 @@
+From e92efc63acd7b377faa9e534f4bf52aaa86be2a9 Mon Sep 17 00:00:00 2001
+From: Peter Hutterer <peter.hutterer@who-t.net>
+Date: Tue, 27 Jul 2021 11:46:19 +1000
+Subject: [PATCH] makekeys: handle the new _EVDEVK xorgproto symbols
+
+These keys are all defined through a macro in the form:
+   #define XF86XK_BrightnessAuto		_EVDEVK(0x0F4)
+
+The _EVDEVK macro is simply an offset of 0x10081000.
+Let's parse these lines correctly so those keysyms end up in our
+hashtables.
+
+Signed-off-by: Peter Hutterer <peter.hutterer@who-t.net>
+---
+ src/util/makekeys.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/util/makekeys.c b/src/util/makekeys.c
+index e847ef4c..4896cc53 100644
+--- a/src/util/makekeys.c
++++ b/src/util/makekeys.c
+@@ -78,6 +78,18 @@ parse_line(const char *buf, char *key, KeySym *val, char *prefix)
+         return 1;
+     }
+ 
++    /* See if we can parse one of the _EVDEVK symbols */
++    i = sscanf(buf, "#define %127s _EVDEVK(0x%lx)", key, val);
++    if (i == 2 && (tmp = strstr(key, "XK_"))) {
++        memcpy(prefix, key, (size_t)(tmp - key));
++        prefix[tmp - key] = '\0';
++        tmp += 3;
++        memmove(key, tmp, strlen(tmp) + 1);
++
++        *val += 0x10081000;
++        return 1;
++    }
++
+     /* Now try to catch alias (XK_foo XK_bar) definitions, and resolve them
+      * immediately: if the target is in the form XF86XK_foo, we need to
+      * canonicalise this to XF86foo before we do the lookup. */
+-- 
+GitLab

--- a/srcpkgs/libX11/template
+++ b/srcpkgs/libX11/template
@@ -1,7 +1,7 @@
 # Template file for 'libX11'
 pkgname=libX11
 version=1.7.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--enable-ipv6 --enable-xlocaledir --without-xmlto
  --enable-static --enable-malloc0returnsnull"


### PR DESCRIPTION
Apply upstream merge request to handle the new _EVDEVK xorgproto symbols,
so that xkbcomp does not generate hundreds of warnings.
See https://gitlab.freedesktop.org/xorg/lib/libx11/-/merge_requests/79

This works for me, and it fixes 
https://github.com/void-linux/void-packages/issues/31870