### PR TITLE
lollypop: update to 1.4.22 and fix runtime deps

### DIFF
--- a/srcpkgs/lollypop/template
+++ b/srcpkgs/lollypop/template
@@ -1,16 +1,17 @@
 # Template file for 'lollypop'
 pkgname=lollypop
-version=1.4.19
+version=1.4.22
 revision=1
 build_style=meson
 hostmakedepends="cmake git glib-devel gobject-introspection intltool itstool pkg-config"
 makedepends="gtk+3-devel libsoup-devel python3-gobject-devel python3-devel"
 depends="dconf gst-libav gst-plugins-good1 libnotify libsecret
  python3-dbus python3-gobject python3-pylast python3-youtube-dl
- python3-Pillow totem-pl-parser python3-BeautifulSoup4 libhandy1"
+ python3-Pillow totem-pl-parser python3-BeautifulSoup4 libhandy1
+ gnome-keyring"
 short_desc="Music player for GNOME"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Lollypop"
 distfiles="https://adishatz.org/lollypop/${pkgname}-${version}.tar.xz"
-checksum=38bc38181e93ad989cb42d8efb2b8dc96223486eb200863d81f3a0b7573e3830
+checksum=cda6b6da1adf242a9be9b6b9d7be0d9732d12a0cdde3aa81d8e8a5761eff9b9d


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
