### PR TITLE
New package: mkbootimg-2021.04.27

### DIFF
--- a/srcpkgs/mkbootimg/template
+++ b/srcpkgs/mkbootimg/template
@@ -1,0 +1,18 @@
+# Template file for 'mkbootimg'
+pkgname=mkbootimg
+version=2021.04.27
+revision=1
+build_style=gnu-makefile
+make_build_args="AR+=rc"
+short_desc="Android mkbootimg + unpackbootimg, updated osm0sis fork"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/osm0sis/mkbootimg"
+distfiles="${homepage}/archive/refs/tags/${version}.tar.gz"
+checksum="a77a2c1a12804ea02cb808c08d80901ff7439d6184fbaa15726fcac4e167303d"
+
+do_install() {
+	vbin mkbootimg
+	vbin unpackbootimg
+	vlicense NOTICE
+}


### PR DESCRIPTION
`abootimg` simply doesn't cut it anymore for newer Android devices which have an [updated boot.img header format](https://source.android.com/devices/bootloader/boot-image-header) with additional required configuration.

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
