### PR TITLE
pylint 2.9.6, astroid 2.6.5

### DIFF
--- a/srcpkgs/pylint/patches/fix-tests.patch
+++ b/srcpkgs/pylint/patches/fix-tests.patch
@@ -1,0 +1,13 @@
+https://github.com/PyCQA/pylint/pull/4781
+
+--- a/tests/lint/unittest_lint.py
++++ b/tests/lint/unittest_lint.py
+@@ -643,7 +643,7 @@ def test_pylint_home():
+             assert config.PYLINT_HOME == pylintd
+         finally:
+             try:
+-                os.remove(pylintd)
++                rmtree(pylintd)
+             except FileNotFoundError:
+                 pass
+     finally:

--- a/srcpkgs/pylint/template
+++ b/srcpkgs/pylint/template
@@ -1,34 +1,26 @@
 # Template file for 'pylint'
 pkgname=pylint
-version=2.7.4
+version=2.9.6
 revision=1
-wrksrc="pylint-${version}"
 build_style=python3-module
+make_check_args="--deselect=tests/benchmark/test_baseline_benchmarks.py"
 hostmakedepends="python3-setuptools"
-depends="python3-astroid python3-six python3-isort python3-mccabe python3-toml"
-checkdepends="python3-astroid python3-isort python3-mccabe python3-pytest python3-toml"
+depends="python3-astroid python3-isort python3-mccabe python3-toml"
+checkdepends="$depends python3-pytest python3-tkinter python3-six"
 short_desc="Python code static checker"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-2.0-or-later"
-homepage="http://www.pylint.org/"
+homepage="https://www.pylint.org/"
 changelog="https://raw.githubusercontent.com/PyCQA/pylint/master/ChangeLog"
-distfiles="${PYPI_SITE}/p/pylint/pylint-${version}.tar.gz"
-checksum=bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee
-make_check=no
+distfiles="https://github.com/PyCQA/pylint/archive/refs/tags/v$version.tar.gz"
+checksum=e6335c810ee3ff4b59e3990db49cf0d1e263e122b766853755436d88133c9496
 
 post_install() {
-	# no tests
-	rm -rf ${DESTDIR}/usr/lib/python*/site-packages/pylint/test
-
 	# install example config and emacs files
 	vsconf examples/pylintrc
 	vsconf examples/pylintrc_camelcase
 	vsconf elisp/pylint.el
 	vsconf elisp/pylint-flymake.el
-
-	for f in man/*; do
-		vman "$f"
-	done
 }
 
 python3-pylint_package() {

--- a/srcpkgs/python3-astroid/template
+++ b/srcpkgs/python3-astroid/template
@@ -1,18 +1,16 @@
 # Template file for 'python3-astroid'
 pkgname=python3-astroid
-version=2.5.3
+version=2.6.5
 revision=1
 wrksrc="astroid-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-six python3-lazy-object-proxy python3-wrapt
- python3-typed-ast"
-checkdepends="$depends python3-attrs python3-pytest python3-wcwidth
- python3-py python3-pluggy python3-more-itertools python3-parsing"
+depends="python3-lazy-object-proxy python3-wrapt"
+checkdepends="$depends python3-pytest python3-numpy"
 short_desc="Abstract syntax tree for Python3"
-maintainer="Alessio Sergi <al3hex@gmail.com>"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/PyCQA/astroid"
 changelog="https://raw.githubusercontent.com/PyCQA/astroid/master/ChangeLog"
-distfiles="${PYPI_SITE}/a/astroid/astroid-${version}.tar.gz"
-checksum=ad63b8552c70939568966811a088ef0bc880f99a24a00834abd0e3681b514f91
+distfiles="https://github.com/PyCQA/astroid/archive/refs/tags/v$version.tar.gz"
+checksum=4e22e703abc1220e6ec4a41740f5d8a51a5484a1b24d61cd4495f995ef2296a7


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

* pylint doesn't install tests anymore, so we don't need to remove them
* manpages were old and so they were removed upstream
* moved distfiles from pypi to github, because pypi releases don't contain tests
* updated python3-astroid, because they are tightly coupled and pylint 2.9 needs astroid 2.6
* adopted both packages