### PR TITLE
xdg-utils: xdg-screensaver needs xset

### DIFF
--- a/srcpkgs/xdg-utils/template
+++ b/srcpkgs/xdg-utils/template
@@ -1,16 +1,16 @@
 # Template file for 'xdg-utils'
 pkgname=xdg-utils
 version=1.1.3
-revision=3
+revision=4
 build_style=gnu-configure
 make_check_target=test
 hostmakedepends="xmlto lynx"
-depends="bash"
+depends="bash xset"
 short_desc="Tools to assist applications with various desktop integration tasks"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://www.freedesktop.org/wiki/Software/xdg-utils/"
-#changelog="https://cgit.freedesktop.org/xdg/xdg-utils/plain/ChangeLog"
+changelog="https://cgit.freedesktop.org/xdg/xdg-utils/plain/ChangeLog"
 distfiles="https://portland.freedesktop.org/download/${pkgname}-${version}.tar.gz"
 checksum=d798b08af8a8e2063ddde6c9fa3398ca81484f27dec642c5627ffcaa0d4051d9
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

`xdg-screensaver` will output the following when `xset` isn't installed manually or pulled in by another package.
```
/bin/xdg-screensaver: 900: xset: not found
/bin/xdg-screensaver: 908: [: Illegal number: 
/bin/xdg-screensaver: 647: xset: not found
```