### PR TITLE
samba: update to 4.14.7 (rebuild might fix smbd on armv6l)

### DIFF
--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,6 +1,6 @@
 # Template file for 'samba'
 pkgname=samba
-version=4.14.5
+version=4.14.7
 revision=1
 build_style=waf3
 build_helper="qemu"
@@ -27,7 +27,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.samba.org"
 distfiles="http://download.samba.org/pub/samba/stable/${pkgname}-${version}.tar.gz"
-checksum=bb6ef5d2f16b85288d823578abc453d9a80514c42e5a2ea2c4e3c60dc42335c3
+checksum=6f50353f9602aa20245eb18ceb00e7e5ec793df0974aebd5254c38f16d8f1906
 lib32disabled=yes
 conf_files="/etc/pam.d/samba /etc/samba/smb.conf"
 make_dirs="/etc/samba/private 0750 root root"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
---
Fixes #32079

Tests:
- `x86_64`: My day job setup with `smbd` on a Void Hyper-V guest serving `/home`
- `armv6l`: A/B/A test of the repro case from #32079 suggests rebuilding `samba` fixes that issue (at least in local builds).