### PR TITLE
fail2ban: update to version 0.11.2

### DIFF
--- a/srcpkgs/fail2ban/template
+++ b/srcpkgs/fail2ban/template
@@ -1,21 +1,23 @@
 # Template file for 'fail2ban'
 pkgname=fail2ban
-version=0.11.1
-revision=2
+version=0.11.2
+revision=1
 build_style=python3-module
 hostmakedepends="pkg-config python3"
 depends="python3"
 short_desc="Authentication failure monitor system"
 maintainer="necrophcodr <necrophcodr@necrophcodr.me>"
 license="GPL-2.0-only"
-homepage="http://www.fail2ban.org/"
-distfiles="https://github.com/${pkgname}/${pkgname}/archive/${version}.tar.gz"
-checksum=71d2a52b66bb0f87ac3812246bdd3819ec561913cd44afd39130a342f043aa6d
+homepage="https://www.fail2ban.org/"
+changelog="https://raw.githubusercontent.com/fail2ban/fail2ban/master/ChangeLog"
+distfiles="https://github.com/fail2ban/fail2ban/archive/${version}.tar.gz"
+checksum=383108e5f8644cefb288537950923b7520f642e7e114efb843f6e7ea9268b1e0
 conf_files="
  /etc/fail2ban/fail2ban.conf
  /etc/fail2ban/jail.conf
  /etc/fail2ban/action.d/*.conf
  /etc/fail2ban/filter.d/*.conf"
+make_dirs="/var/lib/fail2ban 0700 root root"
 
 pre_build() {
 	./fail2ban-2to3


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc))
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

#### Notes:
- this is second PR with this change. I messed up miserably when I tried to squash commits in a previous one, to the state I wasn't able fix, so I decided to close it and create a new one - sorry for the mess;
- `make_dirs` addition is because in previous version this directory was not created and fail2ban didn't start because it was not able to create database. This is just for convenience, now the package can be started right away after installation without any action from the user.