### PR TITLE
waifu2x-converter-cpp: update to 5.3.4 (was opencv: update to 3.4.15)

### DIFF
--- a/srcpkgs/waifu2x-converter-cpp/patches/fix-cross.patch
+++ b/srcpkgs/waifu2x-converter-cpp/patches/fix-cross.patch
@@ -1,12 +1,33 @@
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 12884cc..6139ae2 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -36,7 +36,14 @@ if(UNIX OR MINGW)
- 	set(FILE_SYSTEM_LIB "stdc++fs")
- endif()
+--- a/CMakeLists.txt	2020-12-20 19:39:26.000000000 +0100
++++ b/CMakeLists.txt	2021-08-13 09:50:54.728623869 +0200
+@@ -100,12 +100,12 @@
+ ### On Windows cmake fails to find the opencl.lib, as we only use Khronos Headers which doesn't come with the library
+ ### So we bypass that by not making it required and double check for the header after.
+ ### On linux typically the library always comes with the package.
+-if (WIN32)
+-	FIND_PACKAGE(OpenCL)
+-else()
+-	FIND_PACKAGE(OpenCL REQUIRED)
+-endif()
+-if (WIN32)
++#if (WIN32)
++#	FIND_PACKAGE(OpenCL)
++#else()
++#	FIND_PACKAGE(OpenCL REQUIRED)
++#endif()
++#if (WIN32)
+ 	set(OpenCL_FOUND FALSE)
+ 	foreach(_DIR ${OpenCL_INCLUDE_DIRS})
+ 		if(EXISTS "${_DIR}/CL/cl.h")
+@@ -119,9 +119,17 @@
+ 		message(STATUS "On Windows: Errors about 'missing: OpenCL_LIBRARY' can be ignored, that is not needed.")
+ 		include_directories(${OpenCL_INCLUDE_DIRS})
+ 	endif()
+-endif()
++#endif()
  
 -add_executable(conv conv.c)
++#add_executable(conv conv.c)
 +add_custom_target("conv")
 +add_custom_command(
 +	OUTPUT "build/conv"
@@ -15,16 +36,16 @@ index 12884cc..6139ae2 100644
 +	DEPENDS "build/conv"
 +	COMMENT "Generator"
 +)
- if(UNIX)
- 	set(OPENCV_PREFIX "/usr" CACHE FILEPATH "OpenCV path")
- 	find_package(OpenCV)
-@@ -269,7 +276,7 @@ else() # We are on linux and build for linux
- 	target_link_libraries(w2xc ${OpenCV_LIBS} ${CMAKE_DL_LIBS} pthread stdc++fs stdc++)
+ 
+ set(HAVE_OPENCV FALSE)
+ set(HAVE_OPENCV_3_X FALSE)
+@@ -355,7 +363,8 @@
+ 	target_link_libraries(w2xc ${OPENCV_LIBRARIES} ${CMAKE_DL_LIBS} pthread ${FILE_SYSTEM_LIB})
  endif()
  
 -set(CONV_EXE "$<TARGET_FILE_DIR:conv>/conv")
++#set(CONV_EXE "$<TARGET_FILE_DIR:conv>/conv")
 +set(CONV_EXE ${CMAKE_BINARY_DIR}/conv)
  
  add_custom_command(
  	OUTPUT modelHandler_OpenCL.cl.h
-

--- a/srcpkgs/waifu2x-converter-cpp/patches/fix-cstdio.patch
+++ b/srcpkgs/waifu2x-converter-cpp/patches/fix-cstdio.patch
@@ -1,7 +1,0 @@
---- a/src/threadPool.cpp	2019-03-25 11:44:59.000000000 +0100
-+++ b/src/threadPool.cpp	2020-08-23 21:43:43.087489818 +0200
-@@ -1,3 +1,4 @@
-+#include <cstdio>
- #include <thread>
- #include <atomic>
- #include "threadPool.hpp"

--- a/srcpkgs/waifu2x-converter-cpp/template
+++ b/srcpkgs/waifu2x-converter-cpp/template
@@ -1,9 +1,11 @@
 # Template file for 'waifu2x-converter-cpp'
 pkgname=waifu2x-converter-cpp
-version=5.2.4
+version=5.3.4
 revision=1
 build_style=cmake
-configure_args="-DINSTALL_MODELS=ON"
+configure_args="-DINSTALL_MODELS=ON
+ -DENABLE_TESTS=ON
+ -DOpenCL_INCLUDE_DIRS=${XBPS_CROSS_BASE}/usr/include"
 hostmakedepends="pkg-config"
 makedepends="libopencv-devel opencl2-headers"
 short_desc="Image upscaling using deep convolutional neural networks"
@@ -11,7 +13,7 @@ maintainer="SolitudeSF <solitudesf@protonmail.com>"
 license="MIT"
 homepage="https://github.com/DeadSix27/waifu2x-converter-cpp"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=e10bd5c64015553d1340988cf886aa51ed3cf4108f1a3ba864b3ea818426de7d
+checksum=93e1dca78657c48f9c497a71b9e9d11e88ffadcc20fac27f9c48cdba7f132b51
 
 # silly workaround to prevent vector/bool/etc from being defined
 case "$XBPS_TARGET_MACHINE" in
@@ -23,7 +25,12 @@ pre_configure() {
 	# conv is a generator built with add_executable
 	# build it before so it is built with the correct
 	# toolchain
+	mkdir -p build
 	cc -o build/conv conv.c
+}
+
+pre_check() {
+	cp -a models_rgb build
 }
 
 post_install() {


### PR DESCRIPTION
It’s a dependency of `nomacs` which I tried to build for i686-musl but the build failed. The update seems to have fixed it, nomacs builds fine with this opencv version, but I didn’t/couldn’t test any particular opencv functionality.
Successfully built for i686-musl, armv7l, x86_64-musl.

@q66 I removed the broken for `ppc*` because I got the exact same error on i686-musl which isn’t the case with this version anymore. Can you please have a look? <s>If it is working again then it should probably also be reenabled in mlt7.</s> Sorry, mlt7 depends on opencv4; but it’s likely an update will fix this, too, but that’s for another PR.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
