### PR TITLE
retroarch: disable gles2 by default, add libusb and xdg-utils deps

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,7 +1,7 @@
 # Template file for 'retroarch'
 pkgname=retroarch
 version=1.9.7
-revision=1
+revision=2
 wrksrc="RetroArch-$version"
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
@@ -12,13 +12,13 @@ configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
  $(vopt_enable sdl2) $(vopt_enable vulkan) $(vopt_enable wayland) $(vopt_enable x11)"
 conf_files="/etc/retroarch.cfg"
 hostmakedepends="pkg-config"
-makedepends="alsa-lib-devel eudev-libudev-devel freetype-devel libxkbcommon-devel
+makedepends="alsa-lib-devel eudev-libudev-devel freetype-devel libusb-devel libxkbcommon-devel
  mbedtls-devel zlib-devel $(vopt_if ffmpeg ffmpeg-devel) $(vopt_if flac libflac-devel)
  $(vopt_if glslang 'glslang-devel SPIRV-Tools-devel') $(vopt_if jack jack-devel)
  $(vopt_if miniupnpc miniupnpc-devel) $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if qt5 qt5-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if vulkan vulkan-loader)
  $(vopt_if x11 'libXext-devel libXinerama-devel libXv-devel libXxf86vm-devel')"
-depends="$(vopt_if vulkan 'vulkan-loader')"
+depends="$(vopt_if vulkan vulkan-loader) $(vopt_if x11 xdg-utils)"
 short_desc="Official reference frontend for the libretro API"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -27,12 +27,15 @@ changelog="https://raw.githubusercontent.com/libretro/RetroArch/master/CHANGES.m
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
 checksum=a4a1791dbff796dccfb377f9a61bd4b1bea4f754ab6611f51fa1d0466babbc9e
 
-build_options="ffmpeg flac gles2 glslang jack miniupnpc neon opengl pulseaudio qt5 sdl2 vulkan wayland x11"
-build_options_default="ffmpeg flac gles2 glslang miniupnpc opengl pulseaudio sdl2 vulkan wayland x11"
+build_options="ffmpeg flac glcore gles2 glslang jack miniupnpc neon pulseaudio qt5 sdl2 vulkan wayland x11"
+build_options_default="ffmpeg flac glcore glslang miniupnpc pulseaudio sdl2 vulkan wayland x11"
 
+desc_option_glcore="Enable support for OpenGL 3.2 core+ and OpenGL ES 3+"
 desc_option_glslang="Enable support for GLSL shaders"
 desc_option_miniupnpc="Enable support for NAT traversal"
 desc_option_neon="Enable support for ARM Neon SIMD extension"
+
+vopt_conflict glcore gles2 # gles2 disables glcore support
 
 if [ "$build_option_gles2" ]; then
 	configure_args+=" --enable-opengles --enable-opengles3"
@@ -40,16 +43,16 @@ else
 	configure_args+=" --disable-opengles --disable-opengles3"
 fi
 
-if [ "$build_option_opengl" ]; then
+if [ "$build_option_glcore" ]; then
 	if [ -z "$build_option_glslang" ]; then
-		msg_error "$pkgname: 'opengl' option requires 'glslang'.\n"
+		msg_error "$pkgname: 'glcore' option requires 'glslang'.\n"
 	fi
 	configure_args+=" --enable-opengl_core"
 else
 	configure_args+=" --disable-opengl_core"
 fi
 
-if [ "$build_option_gles2" -o "$build_option_opengl" ]; then
+if [ "$build_option_gles2" -o "$build_option_glcore" ]; then
 	configure_args+=" --enable-egl --enable-kms"
 	makedepends+=" MesaLib-devel"
 fi
@@ -67,8 +70,8 @@ if [ "$build_option_vulkan" ]; then
 fi
 
 if [ "$build_option_wayland" ]; then
-	if [ -z "$build_option_gles2" -a -z "$build_option_opengl" ]; then
-		msg_error "$pkgname: 'wayland' option requires 'gles2' or 'opengl'.\n"
+	if [ -z "$build_option_gles2" -a -z "$build_option_glcore" ]; then
+		msg_error "$pkgname: 'wayland' option requires 'gles2' or 'glcore'.\n"
 	fi
 	makedepends+=" wayland-devel wayland-protocols"
 	if [ "$CROSS_BUILD" ]; then
@@ -77,8 +80,8 @@ if [ "$build_option_wayland" ]; then
 fi
 
 if [ "$build_option_x11" ]; then
-	if [ -z "$build_option_gles2" -a -z "$build_option_opengl" ]; then
-		msg_error "$pkgname: 'x11' option requires 'gles2' or 'opengl'.\n"
+	if [ -z "$build_option_gles2" -a -z "$build_option_glcore" ]; then
+		msg_error "$pkgname: 'x11' option requires 'gles2' or 'glcore'.\n"
 	fi
 fi
 


### PR DESCRIPTION
When both gles2 and opengl options are enabled, RetroArch will only
build with OpenGL ES support. This prevents OpenGL only cores from working.
Disable gles2 by default and use the glcore driver which provides OpenGL 3.2+
and OpenGL ES 3+ support. Fixes: #32246

libusb support is automatic and is currently pulled in when sdl2 is enabled.
Add it to makedepends to ensure it's always enabled.

RetroArch will call xdg-screensaver when it's built with X11 support.
Add xdg-utils to depends when the x11 option is enabled.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
