### PR TITLE
hydroxide: update to 0.2.20

### DIFF
--- a/srcpkgs/hydroxide/template
+++ b/srcpkgs/hydroxide/template
@@ -1,6 +1,6 @@
 # Template file for 'hydroxide'
 pkgname=hydroxide
-version=0.2.18
+version=0.2.20
 revision=1
 build_style=go
 go_import_path=github.com/emersion/hydroxide
@@ -11,7 +11,7 @@ maintainer="DirectorX <void.directorx@protonmail.com>"
 license="MIT"
 homepage="https://github.com/emersion/hydroxide"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=93865423bad0e37fd231d5ee52f9b98d63b6950cfc664e2d557fc579681a400b
+checksum=b454b1d46f90221d12d64b0785307fe1ac14dcaa8e3da299aa787bb008330275
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Bump hydroxide's version from 2.18 to 2.19

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X ] I built this PR locally for my native architecture, (x86_64-musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
