### PR TITLE
timeshift: fix compatibility with util-linux 2.37.1

### DIFF
--- a/srcpkgs/timeshift/patches/d437358a.patch
+++ b/srcpkgs/timeshift/patches/d437358a.patch
@@ -1,0 +1,23 @@
+commit d437358ac3debf7625aefda4d0bd387a91b69df5
+Author: Tony George <teejeetech@gmail.com>
+Date:   Sun Jun 6 12:04:07 2021 +0530
+
+    Fix for #425, #753, #755
+
+diff --git a/src/Utility/Device.vala b/src/Utility/Device.vala
+index 18f09de..b276055 100755
+--- a/src/Utility/Device.vala
++++ b/src/Utility/Device.vala
+@@ -428,10 +428,10 @@ public class Device : GLib.Object{
+ 
+ 			try{
+ 				if (lsblk_is_ancient){
+-					rex = new Regex("""NAME="(.*)" KNAME="(.*)" LABEL="(.*)" UUID="(.*)" TYPE="(.*)" FSTYPE="(.*)" SIZE="(.*)" MOUNTPOINT="(.*)" MODEL="(.*)" RO="([0-9]+)" RM="([0-9]+)" MAJ:MIN="([0-9:]+)"""");
++					rex = new Regex("""NAME="(.*)" KNAME="(.*)" LABEL="(.*)" UUID="(.*)" TYPE="(.*)" FSTYPE="(.*)" SIZE="(.*)" MOUNTPOINT="(.*)" MODEL="(.*)" RO="([0-9]+)" RM="([0-9]+)" MAJ[_:]MIN="([0-9:]+)"""");
+ 				}
+ 				else{
+-					rex = new Regex("""NAME="(.*)" KNAME="(.*)" LABEL="(.*)" UUID="(.*)" TYPE="(.*)" FSTYPE="(.*)" SIZE="(.*)" MOUNTPOINT="(.*)" MODEL="(.*)" RO="([0-9]+)" HOTPLUG="([0-9]+)" MAJ:MIN="([0-9:]+)" PARTLABEL="(.*)" PARTUUID="(.*)" PKNAME="(.*)" VENDOR="(.*)" SERIAL="(.*)" REV="(.*)"""");
++					rex = new Regex("""NAME="(.*)" KNAME="(.*)" LABEL="(.*)" UUID="(.*)" TYPE="(.*)" FSTYPE="(.*)" SIZE="(.*)" MOUNTPOINT="(.*)" MODEL="(.*)" RO="([0-9]+)" HOTPLUG="([0-9]+)" MAJ[_:]MIN="([0-9:]+)" PARTLABEL="(.*)" PARTUUID="(.*)" PKNAME="(.*)" VENDOR="(.*)" SERIAL="(.*)" REV="(.*)"""");
+ 				}
+ 
+ 				if (rex.match (line, 0, out match)){

--- a/srcpkgs/timeshift/template
+++ b/srcpkgs/timeshift/template
@@ -1,7 +1,7 @@
 # Template file for 'timeshift'
 pkgname=timeshift
 version=20.11.1
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="gettext pkg-config vala which"
 makedepends="libgee08-devel json-glib-devel gtk+3-devel vte3-devel libgirepository-devel"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

----

Timeshift is virtually unusable due to a change in util-linux, see:

- https://github.com/teejee2008/timeshift/issues/425
- https://github.com/teejee2008/timeshift/issues/753
- https://github.com/teejee2008/timeshift/issues/755

This PR applies an [official patch](https://github.com/teejee2008/timeshift/commit/d437358ac3debf7625aefda4d0bd387a91b69df5) to make the package usable on Void until the next official release, presumably later [this year](https://github.com/teejee2008/timeshift/issues/648).