### PR TITLE
qtcreator-full: examples and documentation are not available in QTCreator without qt5-doc package

### DIFF
--- a/srcpkgs/qtcreator/template
+++ b/srcpkgs/qtcreator/template
@@ -51,7 +51,7 @@ qtcreator-full_package() {
  qt5-speech-devel qt5-styleplugins-devel qt5-svg-devel
  qt5-tools-devel qt5-virtualkeyboard-devel qt5-wayland-devel qt5-webchannel-devel
  qt5-webglplugin-devel qt5-webkit-devel qt5-websockets-devel qt5-webview-devel
- qt5-x11extras-devel qt5-xmlpatterns-devel qt5-host-tools
+ qt5-x11extras-devel qt5-xmlpatterns-devel qt5-host-tools qt5-doc
  qt5-examples qt5-imageformats qt5-graphicaleffects qt5-translations
  qt5-plugin-mysql qt5-plugin-odbc qt5-plugin-pgsql qt5-plugin-sqlite qt5-plugin-tds"
 	# Not for big endian targets and not if word sizes of host and target differ


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
