### PR TITLE
nvidia: fix proton errors.

### DIFF
--- a/srcpkgs/nvidia/INSTALL
+++ b/srcpkgs/nvidia/INSTALL
@@ -1,0 +1,3 @@
+case "${ACTION}" in
+post) ldconfig -X || : ;;
+esac

--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=470.57.02
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com"


### PR DESCRIPTION
Proton sometimes errors out with:

  The NVIDIA driver was unable to open
  'libnvidia-glvkspirv.so.470.57.02'. This library is required at run
  time.

This is caused by an out of date glibc cache, so we now run ldconfig in
INSTALL. This solution was pointed out by mvf.

Unfortunately, this isn't the entirely correct solution: ldconfig should
always be run after package installations that touch /usr/lib, to avoid
similar issues. Until there's a simple solution for it (maybe general
purpose XBPS hooks), this is the best we can do.

Fixes: #32222

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
