### PR TITLE
shotcut: remove qt5-webkit-devel dep

### DIFF
--- a/srcpkgs/shotcut/template
+++ b/srcpkgs/shotcut/template
@@ -7,8 +7,8 @@ configure_args="SHOTCUT_VERSION=VOID-$version DEFINES+=SHOTCUT_NOUPGRADE"
 hostmakedepends="pkg-config qt5-tools qt5-qmake qt5-host-tools"
 makedepends="gstreamer1-devel lame-devel libvpx-devel mlt7-devel mlt7-python3
  qt5-declarative-devel qt5-graphicaleffects qt5-multimedia-devel
- qt5-quickcontrols2-devel qt5-webkit-devel qt5-websockets-devel
- qt5-x11extras-devel x264-devel"
+ qt5-quickcontrols2-devel qt5-websockets-devel qt5-x11extras-devel
+ x264-devel"
 depends="frei0r-plugins qt5-graphicaleffects qt5-quickcontrols"
 short_desc="Free, open source, cross-platform video editor"
 maintainer="John <me@johnnynator.dev>"


### PR DESCRIPTION
shotcut does not use webkit since
https://github.com/mltframework/shotcut/commit/a44fe75a4dc7410668935cd0d3470994f5997571.
no revbump because this is purely build-time change.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

I have not tested this, but it should result in exactly the same package, which should be shown by CI. Not sure if no-revbump will still trigger CI though.