### PR TITLE
cronie: prevent from failing without sendmail

### DIFF
--- a/srcpkgs/cronie/files/cronie/run
+++ b/srcpkgs/cronie/files/cronie/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-exec cronie-crond -n $OPTS 2>&1
+exec cronie-crond -ns $OPTS 2>&1

--- a/srcpkgs/cronie/template
+++ b/srcpkgs/cronie/template
@@ -1,7 +1,7 @@
 # Template file for 'cronie'
 pkgname=cronie
 version=1.5.7
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-inotify --without-selinux --with-pam
  --enable-anacron --enable-pie --enable-relro"


### PR DESCRIPTION
If a job produces output cronie will attempt to send it's output with
sendmail, failing if the command doesn't exist. sendmail failures are
not handled gracefully and will result in remaining cron scripts to not
be executed. The change makes cronie service use syslog so cron jobs
that produce output are working out of the box.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64, glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
