### PR TITLE
deluge: allow deluged to be run as different user

### DIFF
--- a/srcpkgs/deluge/files/deluged/run
+++ b/srcpkgs/deluge/files/deluged/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 [ -r ./conf ] && . ./conf
-exec chpst -u deluge:deluge deluged -d ${OPTS} 2>&1
+exec deluged -d -U deluge -g deluge -c /var/lib/deluge/.config ${OPTS} 2>&1

--- a/srcpkgs/deluge/patches/drop-priv.patch
+++ b/srcpkgs/deluge/patches/drop-priv.patch
@@ -1,0 +1,40 @@
+From d08c3f72e94a3a2b440b5a1a36dd8f7f8641d4fa Mon Sep 17 00:00:00 2001
+From: Jack O'Sullivan <jackos1998@gmail.com>
+Date: Tue, 24 Sep 2019 11:32:18 +0100
+Subject: [PATCH] Fix privilege dropping when setting process ownership
+
+`os.setgid()` should be called to set the GID, and it should be called
+before `os.setuid()` to prevent reinstatement of privileges.
+---
+ deluge/argparserbase.py | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/deluge/argparserbase.py b/deluge/argparserbase.py
+index af9d568fa4..77866a3ed6 100644
+--- a/deluge/argparserbase.py
++++ b/deluge/argparserbase.py
+@@ -329,18 +329,18 @@ def _handle_ui_options(self, options):
+                     _file.write('%d\n' % os.getpid())
+ 
+             if not common.windows_check():
++                if options.group:
++                    if not options.group.isdigit():
++                        import grp
++
++                        options.group = grp.getgrnam(options.group)[2]
++                    os.setgid(options.group)
+                 if options.user:
+                     if not options.user.isdigit():
+                         import pwd
+ 
+                         options.user = pwd.getpwnam(options.user)[2]
+                     os.setuid(options.user)
+-                if options.group:
+-                    if not options.group.isdigit():
+-                        import grp
+-
+-                        options.group = grp.getgrnam(options.group)[2]
+-                    os.setuid(options.group)
+ 
+         return options
+ 

--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,7 +1,7 @@
 # Template file for 'deluge'
 pkgname=deluge
 version=2.0.3
-revision=11
+revision=12
 build_style=python3-module
 # TODO package python3-slimit to minify javascript
 hostmakedepends="intltool python3-setuptools python3-wheel"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
