### PR TITLE
libid3tag: fix distfiles

### DIFF
--- a/srcpkgs/libid3tag/template
+++ b/srcpkgs/libid3tag/template
@@ -6,10 +6,10 @@ build_style=gnu-configure
 hostmakedepends="pkg-config gperf"
 makedepends="zlib-devel"
 short_desc="ID3 tag library, part of MAD (MPEG Audio Decoder)"
-license="GPL-2.0-or-later"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
 homepage="http://sourceforge.net/projects/mad/"
-distfiles="http://distfiles.exherbo.org/distfiles/libid3tag-${version}.tar.gz"
+distfiles="${SOURCEFORGE_SITE}/mad/libid3tag/libid3tag-${version}.tar.gz"
 checksum=63da4f6e7997278f8a3fef4c6a372d342f705051d1eeb6a46a86b03610e26151
 
 pre_configure() {


### PR DESCRIPTION
used mirror distfiles.exherbo.org doesn’t respond anymore
use original sourceforge download site

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
