### PR TITLE
CLion: Fix removal of files for unsupported OS/archs

### DIFF
--- a/srcpkgs/CLion/template
+++ b/srcpkgs/CLion/template
@@ -1,8 +1,8 @@
 # Template file for 'CLion'
 pkgname=CLion
 version=2021.2
-revision=1
-archs="i686 x86_64"
+revision=2
+archs="x86_64 aarch64"
 wrksrc="clion-${version}"
 depends="jetbrains-jdk-bin giflib libXtst"
 short_desc="Smart cross-platform IDE for C and C++"
@@ -25,36 +25,37 @@ desc_option_bundled_gdb="Install bundled GDB"
 desc_option_bundled_lldb="Install bundled LLDB"
 
 post_extract() {
-	# Remove files for other CPU architectures
-	rm -rf bin/fsnotifier-arm
-	rm -rf lib/pty4j-native/linux/aarch64
-	rm -rf lib/pty4j-native/linux/arm
-	rm -rf lib/pty4j-native/linux/mips64el
-	rm -rf lib/pty4j-native/linux/ppc64le
+	# Remove files for other OSes and/or CPU architectures
+	# Darwin (this is not packaged for macOS)
 	rm -rf plugins/cwm-plugin/quiche-native/darwin-aarch64
 	rm -rf plugins/cwm-plugin/quiche-native/darwin-x86-64
-	rm -rf plugins/cwm-plugin/quiche-native/win32-x86-64
 	rm -rf plugins/performanceTesting/bin/libyjpagent.dylib
+	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86.dylib
+	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86_64.dylib
+	# Windows (this is not packaged for Windows)
+	rm -rf plugins/cwm-plugin/quiche-native/win32-x86-64
 	rm -rf plugins/performanceTesting/bin/yjpagent.dll
 	rm -rf plugins/performanceTesting/bin/yjpagent64.dll
 	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_amd64.dll
 	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86.dll
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86.dylib
-	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_x86_64.dylib
+	# x86 (unsupported after v2021.1)
+	rm -rf bin/clion.vmoptions
+	rm -rf lib/pty4j-native/linux/x86
+	rm -rf plugins/performanceTesting/bin/libyjpagent.so
+	rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
+	# MIPS
+	rm -rf lib/pty4j-native/linux/mips64el
+	# ARM
+	rm -rf lib/pty4j-native/linux/arm
+	# PPC
+	rm -rf lib/pty4j-native/linux/ppc64le
+
 
 	case "$XBPS_TARGET_MACHINE" in
 		x86_64)
-			rm -rf bin/fsnotifier
-			rm -rf bin/clion.vmoptions
-			rm -rf bin/libyjpagent-linux.so
-			rm -rf lib/pty4j-native/linux/x86
-			rm -rf plugins/performanceTesting/bin/libyjpagent.so
-			rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
+			rm -rf lib/pty4j-native/linux/aarch64
 			;;
-		i686)
-			rm -rf bin/fsnotifier64
-			rm -rf bin/clion64.vmoptions
-			rm -rf bin/libyjpagent-linux64.so
+		aarch64)
 			rm -rf lib/pty4j-native/linux/x86-64
 			rm -rf plugins/performanceTesting/bin/libyjpagent64.so
 			rm -rf plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_amd64.so


### PR DESCRIPTION
#### General
2021.2 changed where some files are located, and they ended up being removed erroneously during packaging.
This PR fixes that.

Additionally, it turns out that the product no longer supports 32 bit architecture, so support is removed from `archs`.
Since the product claims support for `aarch64`, it is added to `archs`.

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
