### PR TITLE
New package: libXft-bgra

### DIFF
--- a/srcpkgs/libXft-bgra/template
+++ b/srcpkgs/libXft-bgra/template
@@ -1,0 +1,49 @@
+# Template file for 'libXft-bgra'
+pkgname=libXft-bgra
+version=2.3.4
+revision=1
+build_style=gnu-configure
+hostmakedepends="wget pkg-config"
+makedepends="xorgproto libXrender-devel freetype-devel fontconfig-devel"
+short_desc="Library for configuring and customizing font access"
+maintainer="Timmy Keller <tjk@tjkeller.xyz>"
+license="MIT"
+homepage="$XORG_SITE"
+archive="libXft-${version}.tar.bz2"
+distfiles="${XORG_SITE}/lib/${archive}"
+patchfile="https://gitlab.freedesktop.org/xorg/lib/libxft/-/merge_requests/1.patch"
+checksum=57dedaab20914002146bdae0cb0c769ba3f75214c4c91bd2613d6ef79fc9abdd
+
+pre_extract() {
+	mv "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${archive}" "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}-${version}.tar.bz2" || echo "File exists already.. moving on"
+	archive="${pkgname}-${version}.tar.bz2"
+	distfiles="${XORG_SITE}/lib/${archive}" # Trick do_extract into extracting this file
+}
+
+post_extract() {
+	mv "${XBPS_BUILDDIR}/libXft-${version}" "${XBPS_BUILDDIR}/${pkgname}-${version}" || echo "builddir already moved..."
+}
+
+do_patch() {
+	wget -p "${patchfile}" --output-document "${XBPS_SRCDISTDIR}/${pkgname}-${version}/libXft-bgra.patch"
+	echo "Patching..."
+	pwd
+	patch -p1 < "${XBPS_SRCDISTDIR}/${pkgname}-${version}/libXft-bgra.patch"
+}
+
+post_install() {
+	vlicense COPYING
+}
+
+# Does not install libXft-devel
+#libXft-devel_package() {
+#	depends="${makedepends} ${pkgname}>=${version}_${revision}"
+#	short_desc+=" - development files"
+#	pkg_install() {
+#		vmove usr/include
+#		vmove "usr/lib/*.a"
+#		vmove "usr/lib/*.so"
+#		vmove usr/lib/pkgconfig
+#		vmove usr/share/man/man3
+#	}
+#}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (amd64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

This is just a patched version of libXft that supports BGRA color glyphs and scaling (patch available from [here](https://gitlab.freedesktop.org/xorg/lib/libxft/-/merge_requests/1.patch)). I use st as my terminal emulator, and without this patched version of libXft, st will crash when displaying colored glyphs or emojis. I believe this also applies to dwm and possibly other software as well. 

Back when I used Arch, a similar package was available in the AUR; I've been unable to utilize emojis in my terminal on Void up until now, so having this is extremely nice.