### PR TITLE
protonvpn-cli: add missing dependency

### DIFF
--- a/srcpkgs/protonvpn-cli/template
+++ b/srcpkgs/protonvpn-cli/template
@@ -1,12 +1,13 @@
 # Template file for 'protonvpn-cli'
 pkgname=protonvpn-cli
 version=2.2.11
-revision=1
+revision=2
 wrksrc="linux-cli-community-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
-depends="openvpn python3-pythondialog python3-docopt python3-requests python3-Jinja2"
+depends="openvpn python3-pythondialog python3-docopt python3-requests
+ python3-Jinja2 python3-distro"
 short_desc="Linux command-line client for ProtonVPN written in Python"
 maintainer="svenper <svenper@tuta.io>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
After updating protonvpn-cli (#32299), I started getting `ModuleNotFoundError: No module named 'distro'`. Turns out it's because `protonvpn-cli` uses the new [`distro`](https://github.com/python-distro/distro) dependency starting from version 2.2.8 (see ProtonVPN/linux-cli-community@117f5972ab09d44b5df07ffb88b120db9392c515).

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR