### PR TITLE
portage: update to 3.0.21.

### DIFF
--- a/srcpkgs/portage/template
+++ b/srcpkgs/portage/template
@@ -1,6 +1,6 @@
 # Template file for 'portage'
 pkgname=portage
-version=3.0.20
+version=3.0.21
 revision=1
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="teldra <teldra@rotce.de>"
 license="GPL-2.0-only"
 homepage="https://wiki.gentoo.org/wiki/Portage"
 distfiles="https://github.com/gentoo/${pkgname}/archive/${pkgname}-${version}.tar.gz"
-checksum=f828cec745b616924a64e5f7aae155edf4696dd8806e92aa637cb30c3dd7205e
+checksum=bf1d3d73322dcaa9b9aaf01077dd60ff2ee740c8559fef0b6058bf4b91f076cf
 
 conf_files="
 	/etc/dispatch-conf.conf


### PR DESCRIPTION
#### Have the results of the proposed changes been tested?
- [x] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl