### PR TITLE
New package: gnome-remote-desktop-40.1

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1605,6 +1605,9 @@ libfreerdp-codec.so.1.0 libfreerdp-2.2.0_3
 libfreerdp-gdi.so.1.0 libfreerdp-2.2.0_3
 libfreerdp-cache.so.1.0 libfreerdp-2.2.0_3
 libuwac0.so.0 libfreerdp-2.2.0_3
+libfreerdp-server2.so.2 libfreerdp-server-2.4.0_1
+libfreerdp-shadow-subsystem2.so.2 libfreerdp-server-2.4.0_1
+libfreerdp-shadow2.so.2 libfreerdp-server-2.4.0_1
 libcppunit-1.15.so.1 libcppunit-1.15.1_1
 libcalc.so.2.12.7.1 libcalc-2.12.7.1_1
 libcustcalc.so.2.12.7.1 libcalc-2.12.7.1_1

--- a/srcpkgs/freerdp-server
+++ b/srcpkgs/freerdp-server
@@ -1,0 +1,1 @@
+freerdp

--- a/srcpkgs/freerdp-server-devel
+++ b/srcpkgs/freerdp-server-devel
@@ -1,0 +1,1 @@
+freerdp

--- a/srcpkgs/freerdp/template
+++ b/srcpkgs/freerdp/template
@@ -1,31 +1,40 @@
 # Template file for 'freerdp'
 pkgname=freerdp
 version=2.4.0
-revision=1
+revision=2
 wrksrc="FreeRDP-${version}"
 build_style=cmake
 configure_args="-DWITH_ALSA=ON -DWITH_CUPS=OFF -DWITH_FFMPEG=ON
  -DWITH_GSTREAMER_0_10=OFF -DWITH_GSTREAMER_1_0=OFF -DWITH_JPEG=ON
  -DWITH_LIBSYSTEMD=OFF -DWITH_PCSC=OFF -DWITH_PULSE=ON -DWITH_WAYLAND=ON
  -DWITH_XCURSOR=ON -DWITH_XEXT=ON -DWITH_XI=ON -DWITH_XINERAMA=ON
- -DWITH_XKBFILE=ON -DWITH_XRENDER=ON -DWITH_XV=ON
+ -DWITH_XKBFILE=ON -DWITH_XRENDER=ON -DWITH_XV=ON -DWITH_SERVER=ON
  -DWAYLAND_SCANNER=/usr/bin/wayland-scanner"
 hostmakedepends="pkg-config xmlto wayland-devel"
 makedepends="alsa-lib-devel ffmpeg-devel glib-devel libusb-devel
- libXcursor-devel libXinerama-devel  libXrandr-devel libXv-devel
+ libXcursor-devel libXinerama-devel libXrandr-devel libXv-devel
  libjpeg-turbo-devel openssl-devel libxkbfile-devel pulseaudio-devel
- libxkbcommon-devel wayland-devel cairo-devel"
+ libxkbcommon-devel wayland-devel cairo-devel libXdamage-devel"
 short_desc="Free RDP (Remote Desktop Protocol) client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.freerdp.com/"
 distfiles="https://github.com/FreeRDP/FreeRDP/archive/${version}.tar.gz"
 checksum=80eb7e09e2a106345d07f0985608c480341854b19b6f8fc653cb7043a9531e52
+CFLAGS="-Wno-dev"
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) configure_args+=" -DWITH_SSE2=ON";;
 	armv5tel*) configure_args+=" -DWITH_NEON=OFF";;
 esac
+
+post_install() {
+	rm -f ${DESTDIR}/usr/lib64
+}
+
+# first we want to separate -server, everything else then goes to client
+subpackages="libfreerdp-server freerdp-server freerdp-server-devel libfreerdp
+ freerdp-devel"
 
 libfreerdp_package() {
 	replaces="${sourcepkg}<1.0.2_2"
@@ -43,5 +52,37 @@ freerdp-devel_package() {
 		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
+	}
+}
+
+libfreerdp-server_package() {
+	short_desc="Free RDP (Remote Desktop Protocol) server - runtime files"
+	depends="libfreerdp>=${version}_${revision}"
+	pkg_install() {
+		vmove "usr/lib/libfreerdp-server*.so.*"
+		vmove "usr/lib/libfreerdp-shadow*.so.*"
+	}
+}
+
+freerdp-server_package() {
+	short_desc="Free RDP (Remote Desktop Protocol) server"
+	depends="libfreerdp-server>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/bin/freerdp-proxy
+		vmove usr/bin/freerdp-shadow-cli
+		vmove usr/share/man/man1/freerdp-shadow-cli.1
+	}
+}
+
+freerdp-server-devel_package() {
+	depends="libfreerdp-server>=${version}_${revision}"
+	short_desc="Free RDP (Remote Desktop Protocol) server - development files"
+	pkg_install() {
+		vmove usr/lib/cmake/FreeRDP-Server2
+		vmove usr/lib/cmake/FreeRDP-Shadow2
+		vmove usr/lib/pkgconfig/freerdp-server2.pc
+		vmove usr/lib/pkgconfig/freerdp-shadow2.pc
+		vmove "usr/lib/libfreerdp-server*.so"
+		vmove "usr/lib/libfreerdp-shadow*.so"
 	}
 }

--- a/srcpkgs/gnome-remote-desktop/template
+++ b/srcpkgs/gnome-remote-desktop/template
@@ -1,0 +1,37 @@
+# Template file for 'gnome-remote-desktop'
+pkgname=gnome-remote-desktop
+version=40.1
+revision=1
+build_style=meson
+configure_args="$(vopt_bool rdp rdp) $(vopt_bool vnc vnc)
+ -Dsystemd_user_unit_dir=/tmp"
+hostmakedepends="pkg-config glib-devel"
+makedepends="glib-devel pipewire-devel libsecret-devel libnotify-devel
+ $(vopt_if rdp "freerdp-devel freerdp-server-devel fuse3-devel")
+ $(vopt_if vnc libvncserver-devel)"
+short_desc="GNOME remote desktop server"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.gnome.org/GNOME/gnome-remote-desktop/"
+distfiles="https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/archive/$version/gnome-remote-desktop-$version.tar.gz"
+checksum=3c8466cd40405a6887171ada556a800e467d85bb52a506a33409c803b2d4f746
+make_check=no # xvfb failed to start
+
+build_options="rdp vnc"
+desc_option_rdp="RDP support"
+desc_option_vnc="VNC support"
+# RDP doesn't currently have GUI in gcs, so it's disabled by default
+build_options_default="vnc"
+
+pre_configure() {
+	if [ -z "$build_option_rdp" ] && [ -z "$build_option_vnc" ]; then
+		echo at least one of vnc and rdp options has to be enabled
+		exit 1
+	fi
+
+	vsed -e '/systemd_dep/d' -i meson.build
+}
+
+post_install() {
+	rm -rf ${DESTDIR}/tmp
+}

--- a/srcpkgs/gnome/template
+++ b/srcpkgs/gnome/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome'
 pkgname=gnome
 version=40.0
-revision=1
+revision=2
 build_style=meta
 short_desc="GNOME meta-package for Void Linux"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -25,6 +25,7 @@ depends="
  gnome-font-viewer>=40.0
  gnome-maps>=40.0
  gnome-music>=40.0
+ gnome-remote-desktop>=40.1
  gnome-screenshot>=40.0
  gnome-system-monitor>=40.0
  gnome-terminal>=3.40.0

--- a/srcpkgs/libfreerdp-server
+++ b/srcpkgs/libfreerdp-server
@@ -1,0 +1,1 @@
+freerdp


### PR DESCRIPTION
gnome-remote-desktop adds a Screen Sharing option to GNOME Settings. It can use both RDP and VNC, but the GNOME Settings GUI allows configuring only VNC, so I disabled RDP support (it's still available under a build option).
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
