### PR TITLE
haproxy: enable hitless reloads

### DIFF
--- a/srcpkgs/haproxy/files/haproxy.cfg
+++ b/srcpkgs/haproxy/files/haproxy.cfg
@@ -2,6 +2,7 @@ global
   chroot /var/lib/haproxy
   user haproxy
   group haproxy
+  stats socket /var/run/haproxy.sock mode 0600 level admin expose-fd listeners process 1/1
 
 defaults
   mode http

--- a/srcpkgs/haproxy/files/haproxy/run
+++ b/srcpkgs/haproxy/files/haproxy/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec haproxy -f /etc/haproxy/haproxy.cfg
+exec haproxy -W -f /etc/haproxy/haproxy.cfg

--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'haproxy'
 pkgname=haproxy
 version=2.4.2
-revision=1
+revision=2
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 hostmakedepends="lua53-devel"


### PR DESCRIPTION
Switch HAProxy to a master/worker (-W) model, allowing for correct
handling of HUP signals. To do listening FD handoff, a stats socket with
'expose-fd listeners' needs to be part of the configuration file.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
