### PR TITLE
c-ares: update to 1.17.2.

### DIFF
--- a/srcpkgs/c-ares/template
+++ b/srcpkgs/c-ares/template
@@ -1,15 +1,17 @@
 # Template file for 'c-ares'
 pkgname=c-ares
-version=1.17.1
+version=1.17.2
 revision=1
 build_style=gnu-configure
+checkdepends="iana-etc"
 short_desc="C library that performs DNS requests and name resolves asynchronously"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://c-ares.haxx.se/"
 changelog="https://c-ares.haxx.se/changelog.html"
 distfiles="${homepage}/download/${pkgname}-${version}.tar.gz"
-checksum=d73dd0f6de824afd407ce10750ea081af47eba52b8a6cb307d220131ad93fc40
+checksum=4803c844ce20ce510ef0eb83f8ea41fa24ecaae9d280c468c582d2bb25b3913d
+make_check=ci-skip # segfaults only on CI
 
 pre_configure() {
 	export CFLAGS=${CFLAGS/-D_FORTIFY_SOURCE=?/}


### PR DESCRIPTION
Fixes CVE-2021-3672.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
