### PR TITLE
pari: update to 2.13.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3981,6 +3981,7 @@ libsimavr.so.1 simavr-1.6_2
 libsimavrparts.so.1 simavr-1.6_2
 libsword-1.8.1.so libsword-1.8.1_6
 libpari-gmp.so.7 pari-2.13.0_1
+libpari-gmp-tls.so.7 pari-2.13.2_1
 libtree-sitter.so.0 tree-sitter-0.19.0_1
 libgtkdatabox.so.1 gtkdatabox3-1.0.0_1
 libwayland-client++.so.0 libwaylandpp-0.2.8_1

--- a/srcpkgs/giac/patches/pari_2_13.patch
+++ b/srcpkgs/giac/patches/pari_2_13.patch
@@ -1,0 +1,16 @@
+change in order to pass chk_fhan4 with pari-2.13
+
+This patch is already upstream in giac > 1.6 so it will be
+removed when we update giac.
+
+--- a/src/pari.cc	2019-11-21 13:40:55.000000000 +0000
++++ b/src/pari.cc	2021-08-11 20:51:39.243502400 +0000
+@@ -88,7 +88,7 @@
+   static map<string,entree *> pari_function_table;
+   static void do_giac_pari_init(long maxprime){
+ #ifdef PARI_DYNAMIC_STACK
+-    long pari_mem_size=512000;
++    long pari_mem_size=1024000;
+ #else
+     long pari_mem_size=64000000;
+ #endif

--- a/srcpkgs/giac/template
+++ b/srcpkgs/giac/template
@@ -1,7 +1,7 @@
 # Template file for 'giac'
 pkgname=giac
 version=1.5.0.87
-revision=4
+revision=5
 wrksrc="giac-${version%.*}"
 build_style=gnu-configure
 makedepends="fltk-devel gmp-devel gsl-devel lapack-devel

--- a/srcpkgs/pari/patches/makefile.patch
+++ b/srcpkgs/pari/patches/makefile.patch
@@ -1,0 +1,36 @@
+Add targets to main makefile:
+ - gp-dyn
+ - gp-sta
+ - lib-dyn
+ - lib-sta
+ - install-lib-dyn
+ - install-bin-dyn
+
+Also: define a .NOTPARALLEL target so that top targets are not run in parallel.
+
+Otherwise, running several targets with -j is broken.
+
+Examples:
+
+1. "make -j8 gp lib-sta lib-dyn" fails once in a while
+
+2. "make -j8 doc docpdf" fails every time
+
+With .NOTPARALLEL, both seem to work reliably.
+
+Reference:
+https://www.gnu.org/software/make/manual/html_node/Special-Targets.html#Special-Targets
+
+--- pari-2.13.2.orig/config/TOP_Make.SH	2020-10-26 09:43:04.000000000 -0300
++++ pari-2.13.2/config/TOP_Make.SH	2021-08-14 15:28:04.052670019 -0300
+@@ -42,7 +42,9 @@
+ 	@\$(MAKE) gp
+ 	@-cd doc && \$(MAKE) doc
++
++.NOTPARALLEL:
+ 
+-gp bench test-kernel test-all install cleanall cleanobj cleantest nsis link-data install-bin install-doc install-docpdf install-nodata install-data install-lib-sta install-bin-sta dobench dyntest-all statest-all tune $top_test_extra $top_dotest_extra::
++gp gp-dyn gp-sta lib-dyn lib-sta bench test-kernel test-all install cleanall cleanobj cleantest nsis link-data install-bin install-doc install-docpdf install-nodata install-data install-lib-dyn install-lib-sta install-bin-dyn install-bin-sta dobench dyntest-all statest-all tune $top_test_extra $top_dotest_extra::
+ 	@dir=\`config/objdir\`; echo "Making \$@ in \$\$dir";\\
+ 	 if test ! -d \$\$dir; then echo "Please run Configure first!"; exit 1; fi;\\
+ 	cd \$\$dir && \$(MAKE) \$@

--- a/srcpkgs/pari/template
+++ b/srcpkgs/pari/template
@@ -1,24 +1,29 @@
 # Template file for 'pari'
 pkgname=pari
-version=2.13.1
+version=2.13.2
 revision=1
 build_style=configure
 build_helper=qemu
 configure_script=./Configure
-configure_args="--prefix=/usr"
-make_build_target=all
-make_check_target=test-all
+configure_args="--prefix=/usr $(vopt_if pthreads --mt=pthread) -s"
+make_build_target="gp lib-sta lib-dyn doc"
+make_check_target=statest-all
+make_install_target="install install-lib-sta install-lib-dyn"
 hostmakedepends="perl texlive"
 makedepends="gmp-devel readline-devel $(vopt_if x11 libX11-devel)"
 short_desc="Fast computations library in number theory"
-maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-2.0-or-later"
 homepage="https://pari.math.u-bordeaux.fr"
 distfiles="https://pari.math.u-bordeaux.fr/pub/pari/unix/${pkgname}-${version}.tar.gz"
-checksum=81ecf7d70ccdaae230165cff627c9ce2ec297b8f22f9f40742279d85f86dfcb1
+checksum=1679985094a0b723d14f49aa891dbe5ec967aa4040050a2c50bd764ddb3eba24
 
-build_options="x11"
-build_options_default="x11"
+build_options="x11 pthreads"
+build_options_default="x11 pthreads"
+desc_option_pthreads="Enable support for pthreads"
+
+# reduce speed losses due to pthreads
+CFLAGS="-flto -fno-semantic-interposition"
 
 post_patch() {
 	# sse2 is not available on all i686
@@ -50,6 +55,7 @@ pari-devel_package() {
 	depends="pari>=${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
+		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/qcas/template
+++ b/srcpkgs/qcas/template
@@ -1,13 +1,13 @@
 # Template file for 'qcas'
 pkgname=qcas
 version=0.5.3
-revision=1
+revision=2
 build_style=qmake
 configure_args="qcas.pro"
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
 makedepends="giac-devel qt5-svg-devel"
 depends="desktop-file-utils giac"
-short_desc="The QT frontend to Giac/Xcas"
+short_desc="QT frontend to Giac/Xcas"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://webusers.imj-prg.fr/~frederic.han/qcas/"


### PR DESCRIPTION
- enable pthreads build
- switch gp binary to static link libpari; this offsets the slowdown due to pthreads
- use -flto and -fno-semantic-interposition which improve speed a little bit more
- ship the static library, so external programs can static link
- change of maintainer agreed by sgn
- revbump giac and qcas

**Rationale:**
- pthreads gives an interesting functionality, and recent versions of giac require pari with tls; sagemath requires pari with pthreads.
- The cost for enabling pthreads is quite high, on the order of 30-40% for some tests; `-flto` saves maybe 1-2% at most, `-fno-semantic-interposition` saves 5-7%, but we are still about 25-30% behind.
- On the other hand, switching to static binary yields some savings on the order of 5-10%
- More important: the cost of enabling pthread with -flto for a static binary is only about 5-10%
- In summary: enabling pthread while switching to static is roughly the same speed (even maybe 5-10% better overall) as current binary, with an interesting feature (esp. if one has many cores) and apparently better compatibility.
- Shipping static library as well is easy and allows for external code linking to the static library.

@sgn: if you agree, I am willing to take over maintainership. I have used pari for 25+ years, and I use it almost daily.

<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
