### PR TITLE
R: update to 4.1.1.

### DIFF
--- a/srcpkgs/R/template
+++ b/srcpkgs/R/template
@@ -1,7 +1,7 @@
 # Template file for 'R'
 pkgname=R
-version=4.1.0
-revision=2
+version=4.1.1
+revision=1
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/R rdocdir=/usr/share/doc/R
  --with-blas$(vopt_if openblas '=openblas') --with-lapack
@@ -13,16 +13,16 @@ makedepends="libgomp-devel readline-devel libXmu-devel libXt-devel
  libpng-devel libjpeg-turbo-devel tiff-devel cairo-devel icu-devel
  zlib-devel bzip2-devel pcre2-devel liblzma-devel
  libcurl-devel tcl-devel tk-devel libxml2-devel
- texlive texlive-fontsextra texinfo
  $(vopt_if openblas openblas-devel 'blas-devel lapack-devel')"
 depends="xdg-utils less which"
+checkdepends="texlive texlive-fontsextra texinfo"
 short_desc="System for statistical computation and graphics"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.r-project.org/"
 changelog="https://cran.r-project.org/doc/manuals/r-release/NEWS.html"
 distfiles="https://cran.r-project.org/src/base/R-4/${pkgname}-${version}.tar.gz"
-checksum=e8e68959d7282ca147360fc9644ada9bd161bab781bab14d33b8999a95182781
+checksum=515e03265752257d0b7036f380f82e42b46ed8473f54f25c7b67ed25bbbdd364
 nocross=yes
 shlib_provides="libR.so"
 make_check=extended


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General


#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
- [x] I built this PR locally for my native architecture, (x86_64-glibc)

#### Build Changes

According to the R 4.1.1 changelogs make check now works also without a LaTeX installation. Should we drop the texlive make depends or keep it as it is?