### PR TITLE
New Packages: sequoia cli utilities

### DIFF
--- a/srcpkgs/sequoia-sop/template
+++ b/srcpkgs/sequoia-sop/template
@@ -1,0 +1,21 @@
+# Template file for 'sequoia-sop'
+pkgname=sequoia-sop
+version=0.27.1
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_style=cargo
+configure_args="--bin sqop --features cli"
+hostmakedepends="pkg-config llvm clang"
+makedepends="nettle-devel"
+short_desc="Implementation of the Stateless OpenPGP CLI using Sequoia"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.com/sequoia-pgp/sequoia-sop/"
+distfiles="https://gitlab.com/sequoia-pgp/sequoia-sop/-/archive/v${version}/sequoia-sop-v${version}.tar.gz"
+checksum=5094965da3fb8c67b7224534ddcd94cf3409d4c7c74e53473d7804f2a343e2aa
+
+post_install() {
+	for page in man-sqop/*; do
+		vman ${page}
+	done
+}

--- a/srcpkgs/sequoia-sq/template
+++ b/srcpkgs/sequoia-sq/template
@@ -1,0 +1,31 @@
+# Template file for 'sequoia-sq'
+pkgname=sequoia-sq
+version=0.27.0
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_wrksrc="sq"
+build_style=cargo
+_deps="nettle-devel openssl-devel"
+hostmakedepends="pkg-config llvm clang ${_deps}"
+makedepends="${_deps}"
+short_desc="Command-line frontend for Sequoia, a new OpenPGP implementation"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="GPL-2.0-or-later"
+homepage="https://sequoia-pgp.org/projects/#sq"
+distfiles="https://gitlab.com/sequoia-pgp/sequoia/-/archive/sq/v${version}/sequoia-sq-v${version}.tar.gz"
+checksum=e943528be6af2b14c5b9d3a011335233d985ee69f43700d29d99908359f8c345
+conflicts="squirrel"
+
+case "$XBPS_TARGET_MACHINE" in
+	armv*l) nocross="Requires C libs included in build.rs, which is currently broken in xbps-src. These failures only manifest on a hf archs right now";;
+esac
+
+post_patch() {
+	vsed -e "/-Dwarnings/d" -i "${wrksrc}/.cargo/config.toml"
+}
+
+post_install() {
+	for page in man-sq-autocrypt/*; do
+		vman ${page}
+	done
+}

--- a/srcpkgs/sequoia-sq/update
+++ b/srcpkgs/sequoia-sq/update
@@ -1,0 +1,2 @@
+site="https://gitlab.com/sequoia-pgp/sequoia/-/tags?format=atom"
+pattern="<title>sq/v\K[\d.]+(?=</title>)"

--- a/srcpkgs/sequoia-sqv/template
+++ b/srcpkgs/sequoia-sqv/template
@@ -1,0 +1,14 @@
+# Template file for 'sequoia-sqv'
+pkgname=sequoia-sqv
+version=1.1.0
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_style=cargo
+hostmakedepends="pkg-config llvm clang"
+makedepends="nettle-devel"
+short_desc="Simple PGP signature verification program"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="GPL-2.0-or-later"
+homepage="https://gitlab.com/sequoia-pgp/sequoia-sqv"
+distfiles="https://gitlab.com/sequoia-pgp/sequoia-sqv/-/archive/v${version}/sequoia-sqv-v${version}.tar.gz"
+checksum=58eb8f7f803b7fee3f709821d50a78f376aa7f3dc29cfeea4863b37449de2c29


### PR DESCRIPTION
#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

### TODO
- [x] sq
- [x] sqop
- [x] sqv
- [x] add man pages
- [x] figure out cross compiling (was broken due to nettle-dev being required on the host as well as the target)
- ~~add shell completions~~ will be done after https://gitlab.com/sequoia-pgp/sequoia/-/issues/798 is fixed.
- [x] tell upstream about adding git tags for openpgp-card-tools ([upstream issue](https://gitlab.com/hkos/openpgp-card/-/issues/32))
- ~~figure out building for armv7l (some lib stuff missing, see [log](https://web.archive.org/web/20220409160215/https://pipelines.actions.githubusercontent.com/serviceHosts/8d180b0e-8647-44ca-8431-6b9f11113866/_apis/pipelines/1/runs/49556/signedlogcontent/6?urlExpires=2022-04-09T16%3A02%3A59.1606901Z&urlSigningMethod=HMACV1&urlSignature=gkM%2FhddrZEYzNMnQZqSFJQcD3ARwMfWvTQLNQA30A9g%3D))~~ marked as nocross for armv7l for now, considering neither we nor upstream really know *why* it's failing to cross compile
- [x] figure out building for x86_64-musl (some deprecated musl specific rust code, see [log](https://web.archive.org/web/20220409160239/https://pipelines.actions.githubusercontent.com/serviceHosts/8d180b0e-8647-44ca-8431-6b9f11113866/_apis/pipelines/1/runs/49556/signedlogcontent/8?urlExpires=2022-04-09T16%3A03%3A21.7631273Z&urlSigningMethod=HMACV1&urlSignature=iRYCydXZC%2FxRhVp8pVRbPgkAk8puf85yX5uMTGmzcGM%3D))