### PR TITLE
kernel.d: preremove dkms hook now deletes /lib/modules

### DIFF
--- a/srcpkgs/dkms/files/kernel.d/dkms.prerm
+++ b/srcpkgs/dkms/files/kernel.d/dkms.prerm
@@ -14,8 +14,6 @@ while read line; do
 done < <(/usr/bin/dkms status -k ${VERSION} 2>/dev/null | grep ": installed")
 fi
 
-rmdir \
-	"/lib/modules/${VERSION}/updates/dkms" \
-	"/lib/modules/${VERSION}/updates" 2>/dev/null
+rm -rf "/lib/modules/${VERSION}" 2>/dev/null
 
 exit 0


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
