### PR TITLE
latte-dock: update to 0.10.0

### DIFF
--- a/srcpkgs/latte-dock/template
+++ b/srcpkgs/latte-dock/template
@@ -1,6 +1,6 @@
 # Template file for 'latte-dock'
 pkgname=latte-dock
-version=0.9.12
+version=0.10.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DENABLE_MAKE_UNIQUE=OFF
@@ -11,7 +11,7 @@ makedepends="knewstuff-devel libksysguard-devel libSM-devel plasma-framework-dev
 short_desc="Dock based on plasma frameworks"
 maintainer="Giuseppe Fierro <gspe+void@offlink.xyz>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
-homepage="https://phabricator.kde.org/source/latte-dock/"
-changelog="https://phabricator.kde.org/source/latte-dock/browse/master/CHANGELOG.md"
+homepage="https://invent.kde.org/plasma/latte-dock"
+changelog="https://invent.kde.org/plasma/latte-dock/-/blob/master/CHANGELOG.md"
 distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=b2b8af8c69eb122ccbbe987b00fff4d9d3ac9ccc939cbddae9fd319bca0630be
+checksum=967e129b437a1eb3bff0b045674f06bfacb02f0040da39738b7fc95cb1417812


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] armv7l

Latte Dock has moved from Phabricator to Gitlab. Other KDE projects have made the move as well; their changelogs should be updated to prevent stale packages.