### PR TITLE
i3status-rust: update to 0.20.3.

### DIFF
--- a/srcpkgs/i3status-rust/template
+++ b/srcpkgs/i3status-rust/template
@@ -1,7 +1,7 @@
 # Template file for 'i3status-rust'
 pkgname=i3status-rust
-version=0.20.2
-revision=2
+version=0.20.3
+revision=1
 build_style=cargo
 make_check_args="--bins"
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="GPL-3.0-only"
 homepage="https://github.com/greshake/i3status-rust"
 changelog="https://raw.githubusercontent.com/greshake/i3status-rust/master/NEWS.md"
 distfiles="https://github.com/greshake/i3status-rust/archive/v${version}.tar.gz"
-checksum=8e4a90813d66cf02a51d2d266524fb7b848dc35253b80508c89e49657bd1a83f
+checksum=8282fa2222f6b94f5c4ad7aa3c751e0638e5a902e6a901757640dbf7985b4a4b
 
 post_install() {
 	vmkdir usr/share/i3status-rust


### PR DESCRIPTION
0.20.3 contains several useful fixes, such as the NetworkManager block working for new versions of NM. For more details see https://github.com/greshake/i3status-rust/blob/master/NEWS.md#i3status-rust-0203  

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
