### PR TITLE
Add removal of initramfs backup to kernel hook

### DIFF
--- a/srcpkgs/dkms/files/kernel.d/dkms.prerm
+++ b/srcpkgs/dkms/files/kernel.d/dkms.prerm
@@ -18,4 +18,6 @@ rmdir \
 	"/lib/modules/${VERSION}/updates/dkms" \
 	"/lib/modules/${VERSION}/updates" 2>/dev/null
 
+rm -f /boot/initramfs-${VERSION}.img.old-dkms
+
 exit 0

--- a/srcpkgs/dkms/template
+++ b/srcpkgs/dkms/template
@@ -1,7 +1,7 @@
 # Template file for 'dkms'
 pkgname=dkms
 version=2.8.4
-revision=2
+revision=3
 conf_files="/etc/dkms/framework.conf"
 depends="bash kmod gcc make coreutils"
 short_desc="Dynamic Kernel Modules System"


### PR DESCRIPTION
This is necessary to remove the initramfs backups created by dkms, which otherwise accumulate in /boot.