### PR TITLE
haproxy: update to 2.4.3.

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,7 +1,7 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.4.2
-revision=2
+version=2.4.3
+revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 hostmakedepends="lua53-devel"
@@ -12,7 +12,7 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
 distfiles="${homepage}/download/${version%.*}/src/${pkgname}-${version}.tar.gz"
-checksum=@ef7a20a36812f119d0113a28e0b26b909f8177a224c840082295fae265ba1f81
+checksum=ce479380be5464faa881dcd829618931b60130ffeb01c88bc2bf95e230046405
 
 haproxy_homedir="/var/lib/${pkgname}"
 make_dirs="$haproxy_homedir 0750 ${pkgname} ${pkgname}"
@@ -26,7 +26,7 @@ do_build() {
 	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 		atomic="-latomic"
 	fi
-	make ${makejobs} CC="$CC" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" EXTRA= \
+	make ${makejobs} CC="$CC" DEBUG_CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" EXTRA= \
 		TARGET=$target USE_PCRE=1 USE_PCRE_JIT=1 USE_ZLIB=1 \
 		USE_OPENSSL=1 USE_LIBCRYPT=1 USE_GETADDRINFO=1 USE_LUA=1 \
 		USE_PROMEX=1 ADDLIB="$atomic"


### PR DESCRIPTION
Move to using DEBUG_CFLAGS when passing CFLAGS to makefile, otherwise we
override their required CFLAGS, such as -fwrapv.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

@zdykstra only tested that it starts at all, given the DEBUG_CFLAGS change.