### PR TITLE
pkgconf: update to 1.8.0, split -devel and libpkgconf.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3563,6 +3563,7 @@ libgaminggear.so.0 libgaminggear-0.15.1_1
 libgaminggearfx.so.0 libgaminggear-0.15.1_1
 libgaminggearwidget.so.0 libgaminggear-0.15.1_1
 libopkg.so.1 libopkg-0.4.4_2
+libpkgconf.so.3 libpkgconf-1.8.0_1
 libkodiplatform.so.19.0 kodi-platform-20180302_1
 libQuotient.so.0.6 libQuotient-0.6.6_1
 libipset.so.13 libipset-7.9_1

--- a/srcpkgs/libpkgconf
+++ b/srcpkgs/libpkgconf
@@ -1,0 +1,1 @@
+pkgconf

--- a/srcpkgs/pkgconf-devel
+++ b/srcpkgs/pkgconf-devel
@@ -1,0 +1,1 @@
+pkgconf

--- a/srcpkgs/pkgconf/template
+++ b/srcpkgs/pkgconf/template
@@ -1,10 +1,9 @@
 # Template file for 'pkgconf'
 pkgname=pkgconf
-version=1.7.4
+version=1.8.0
 revision=1
 bootstrap=yes
 build_style=gnu-configure # cmake and meson also available
-configure_args="--disable-shared --disable-static"
 checkdepends="kyua"
 short_desc="Provides compiler and linker configuration"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -12,7 +11,7 @@ license="MIT"
 homepage="http://pkgconf.org/"
 changelog="https://raw.githubusercontent.com/pkgconf/pkgconf/master/NEWS"
 distfiles="https://distfiles.dereferenced.org/pkgconf/pkgconf-${version}.tar.xz"
-checksum=d73f32c248a4591139a6b17777c80d4deab6b414ec2b3d21d0a24be348c476ab
+checksum=ef9c7e61822b7cb8356e6e9e1dca58d9556f3200d78acab35e4347e9d4c2bbaf
 
 alternatives="
  pkg-config:pkg-config:/usr/bin/pkgconf
@@ -22,8 +21,24 @@ alternatives="
 post_install() {
 	vlicense COPYING
 
-	rm -rf $DESTDIR/usr/include
-
 	# Suffix file that conflicts with pkg-config
 	mv ${DESTDIR}/usr/share/aclocal/pkg.m4{,.pkgconf}
+}
+
+libpkgconf_package() {
+	short_desc+=" - runtime library"
+	pkg_install() {
+		vmove "usr/lib/*.so.*"
+	}
+}
+
+pkgconf-devel_package() {
+	depends="libpkgconf>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
 }


### PR DESCRIPTION
We used to ship a static library in the main package, which was
accidental. We now ship it in pkgconf-devel package.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
