### PR TITLE
New package: timelimit 1.9.2

### DIFF
--- a/srcpkgs/timelimit/template
+++ b/srcpkgs/timelimit/template
@@ -1,0 +1,21 @@
+# Template file for 'timelimit'
+pkgname=timelimit
+version=1.9.2
+revision=1
+build_style=gnu-makefile
+make_install_args="STRIP=-s MANDIR=/usr/share/man"
+checkdepends="perl"
+short_desc="Limit command execution time"
+maintainer="J Farkas <chexum+git@gmail.com>"
+license="BSD-2-Clause"
+homepage="http://devel.ringlet.net/sysutils/timelimit/"
+distfiles="https://devel.ringlet.net/files/sys/timelimit/timelimit-${version}.tar.xz"
+checksum=9cdd1f06049b9e1a4b7a8a93a0d4d0e1920bd617e7cd005525261a3f91386796
+
+post_extract() {
+	head -50 timelimit.c |egrep '^ \*($| )'|cut -c4- >LICENSE
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

timelimit is a tool to limit process run times which a few of my scripts, that were developed on other distributions, were using, and it's not very straightforward to implement the functionality otherwise.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-glibc
  - [ ] armv7l
  - [ ] armv6l-musl
-->
