### PR TITLE
libxkbcommon: add subpkg libxkbregistry

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1155,6 +1155,7 @@ libtomcrypt.so.1 libtomcrypt-1.18.0_1
 libHX.so.28 libHX-3.14_1
 libxkbcommon.so.0 libxkbcommon-0.2.0_1
 libxkbcommon-x11.so.0 libxkbcommon-x11-0.4.2_1
+libxkbregistry.so.0 libxkbregistry-1.3.0_3
 libgee-0.8.so.2 libgee08-0.8.2_1
 libnettle.so.8 nettle-3.6_1
 libhogweed.so.6 nettle-3.6_1

--- a/srcpkgs/libxkbcommon/template
+++ b/srcpkgs/libxkbcommon/template
@@ -1,13 +1,14 @@
 # Template file for 'libxkbcommon'
 pkgname=libxkbcommon
 version=1.3.0
-revision=2
+revision=3
 wrksrc="${pkgname}-${pkgname#lib}-${version}"
 build_style=meson
 configure_args="-Denable-x11=true -Denable-docs=false
- -Denable-wayland=true -Denable-xkbregistry=false"
+ -Denable-wayland=true -Denable-xkbregistry=true"
 hostmakedepends="pkg-config bison wayland-protocols wayland-devel"
-makedepends="xkeyboard-config libxcb-devel wayland-devel wayland-protocols xorgproto"
+makedepends="xkeyboard-config libxcb-devel wayland-devel wayland-protocols xorgproto
+ libxml2-devel"
 depends="xkeyboard-config"
 short_desc="Library to handle keyboard descriptions"
 maintainer="Isaac Freund <ifreund@ifreund.xyz>"
@@ -27,8 +28,16 @@ libxkbcommon-x11_package() {
 	}
 }
 
+libxkbregistry_package() {
+	short_desc+=" - RMLVO options"
+	pkg_install() {
+		vmove "usr/lib/libxkbregistry.so.*"
+	}
+}
+
 libxkbcommon-devel_package() {
 	depends="${sourcepkg}-x11>=${version}_${revision}
+	 libxkbregistry>=${version}_${revision}
 	 ${sourcepkg}>=${version}_${revision} libxcb-devel"
 	short_desc+=" - development files"
 	pkg_install() {

--- a/srcpkgs/libxkbregistry
+++ b/srcpkgs/libxkbregistry
@@ -1,0 +1,1 @@
+libxkbcommon


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
---
This addition is necessary for the newest release of Waybar. The reasoning for creating a subpackage as opposed to grouping the files in with existing packages can be found in [upstream's packaging page](https://github.com/xkbcommon/libxkbcommon/blob/master/PACKAGING#L74).
