### PR TITLE
streamlink 2.3.0 and python3-websocket-client 1.2.1

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,21 +1,21 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
 version=1.27.4
-revision=2
+revision=3
 wrksrc="compose-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-jsonschema python3-docker>=3.7.0
- python3-dockerpty python3-websocket-client python3-requests python3-docopt
- python3-yaml python3-six python3-texttable python3-cached-property
- python3-paramiko>=2.4.2 python3-dotenv python3-distro"
+ python3-dockerpty python3-requests python3-docopt python3-yaml python3-six
+ python3-texttable python3-cached-property python3-paramiko>=2.4.2
+ python3-dotenv python3-distro"
 short_desc="Tool to define and run multi-container Docker applications"
 maintainer="pancake <pancake@nopcode.org>"
 license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 distfiles="https://github.com/docker/compose/archive/${version}.tar.gz"
 checksum=1c0458f37e9de4bf2d79fe82c9ab0065c8a6132496c3c2f477599604e294a422
-
+make_check=no # needs ddt which is not packaged
 
 post_install() {
 	vinstall contrib/completion/bash/docker-compose 644 \

--- a/srcpkgs/python-idna/template
+++ b/srcpkgs/python-idna/template
@@ -3,8 +3,8 @@ pkgname=python-idna
 version=2.10
 revision=1
 wrksrc="idna-${version}"
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools"
+build_style=python2-module
+hostmakedepends="python-setuptools"
 depends="python"
 short_desc="Internationalized Domain Names in Applications (IDNA) for Python2"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
@@ -16,13 +16,4 @@ checksum=b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6
 
 post_install() {
 	vlicense LICENSE.rst
-}
-
-python3-idna_package() {
-	depends="python3"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-		vlicense LICENSE.rst
-	}
 }

--- a/srcpkgs/python-requests/template
+++ b/srcpkgs/python-requests/template
@@ -1,6 +1,6 @@
 # Template file for 'python-requests'
 pkgname=python-requests
-version=2.25.1
+version=2.26.0
 revision=1
 wrksrc="requests-${version}"
 build_style=python-module
@@ -12,14 +12,15 @@ license="Apache-2.0"
 homepage="https://python-requests.org/"
 changelog="https://raw.githubusercontent.com/psf/requests/master/HISTORY.md"
 distfiles="${PYPI_SITE}/r/requests/requests-${version}.tar.gz"
-checksum=27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804
+checksum=b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+make_check=no # tests are broken for python2 requests
 
 post_patch() {
 	vsed -i '/certifi/d' setup.py
 }
 
 python3-requests_package() {
-	depends="ca-certificates python3-chardet python3-urllib3 python3-idna"
+	depends="ca-certificates python3-charset-normalizer python3-urllib3 python3-idna"
 	short_desc="${short_desc/Python2/Python3}"
 	pkg_install() {
 		vmove usr/lib/python3*

--- a/srcpkgs/python3-charset-normalizer/template
+++ b/srcpkgs/python3-charset-normalizer/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-charset-normalizer'
+pkgname=python3-charset-normalizer
+version=2.0.4
+revision=1
+wrksrc="charset_normalizer-$version"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Encoding and language detection"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
+license="MIT"
+homepage="https://charset-normalizer.readthedocs.io/"
+distfiles="https://github.com/Ousret/charset_normalizer/archive/refs/tags/$version.tar.gz"
+checksum=3fcde2e1c62bb86ed8e20ce03127ffa5ac09a3e2f2c69cc273834ed6d3e94205
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-idna
+++ b/srcpkgs/python3-idna
@@ -1,1 +1,0 @@
-python-idna

--- a/srcpkgs/python3-idna/template
+++ b/srcpkgs/python3-idna/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-idna'
+pkgname=python3-idna
+version=3.2
+revision=1
+wrksrc="idna-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Internationalized Domain Names in Applications (IDNA) for Python3"
+maintainer="Alessio Sergi <al3hex@gmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/kjd/idna"
+changelog="https://raw.githubusercontent.com/kjd/idna/master/HISTORY.rst"
+distfiles="${PYPI_SITE}/i/idna/idna-${version}.tar.gz"
+checksum=467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3
+
+post_install() {
+	vlicense LICENSE.md
+}

--- a/srcpkgs/python3-websocket-client/template
+++ b/srcpkgs/python3-websocket-client/template
@@ -1,29 +1,18 @@
 # Template file for 'python3-websocket-client'
 pkgname=python3-websocket-client
-version=0.57.0
+version=1.2.1
 revision=1
-wrksrc="websocket_client-${version}"
+wrksrc="websocket-client-${version}"
 build_style=python3-module
+make_check_target="websocket/tests"
 hostmakedepends="python3-setuptools"
-depends="python3-six ca-certificates"
-checkdepends="python3-pytest python3-six"
+depends="ca-certificates"
+checkdepends="python3-pytest"
 short_desc="WebSocket client for Python3"
 maintainer="Sergi Alvarez <pancake@nopcode.org>"
-license="BSD-3-Clause"
+license="Apache-2.0"
 homepage="https://github.com/websocket-client/websocket-client"
 changelog="https://raw.githubusercontent.com/websocket-client/websocket-client/master/ChangeLog"
-distfiles="${PYPI_SITE}/w/websocket-client/websocket_client-${version}.tar.gz"
-checksum=d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010
+distfiles="https://github.com/websocket-client/websocket-client/archive/refs/tags/v$version.tar.gz"
+checksum=8e056ff93c85b1961234d1c36fda8c5277a03f1ba475d93afb8ec46d2a7976de
 alternatives="websocket-client:wsdump:/usr/bin/wsdump.py"
-
-do_check() {
-	python3 -m pytest
-}
-
-pre_build() {
-	vsed -i "s|'backports.ssl_match_hostname'||" setup.py
-}
-
-post_install() {
-	vlicense LICENSE
-}

--- a/srcpkgs/python3-websocket-client/update
+++ b/srcpkgs/python3-websocket-client/update
@@ -1,1 +1,0 @@
-pkgname=websocket_client

--- a/srcpkgs/streamlink/template
+++ b/srcpkgs/streamlink/template
@@ -1,6 +1,6 @@
 # Template file for 'streamlink'
 pkgname=streamlink
-version=2.0.0
+version=2.3.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -15,7 +15,8 @@ license="BSD-2-Clause"
 homepage="https://streamlink.github.io/"
 changelog="https://raw.githubusercontent.com/streamlink/streamlink/master/CHANGELOG.md"
 distfiles="https://github.com/streamlink/streamlink/releases/download/${version}/streamlink-${version}.tar.gz"
-checksum=c0ead9e961638d41cab9bd9677cdc701f2313bfd4d23cd8158410932839c62db
+checksum=1497e6dc5d2fb8c5b17688f20ca2e8989a279de804a4de37d2107af33b9faa04
+make_check=ci-skip # some tests fail when running as root
 
 export STREAMLINK_USE_PYCOUNTRY=1
 


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

python3-websocket-client:
* they changed their license to Apache2
* 0.58.0 was a breaking release, but some distributions didn't notice (alpine had 0.58 for a while), so the update should be without a problem, now they follow semver
* 1.0.0 dropped python2 support

docker-compose:
* I removed websocket-client from dependencies, because they don't use it since 2014, but they still list it in dependencies https://github.com/docker/compose/issues/8455

python3-requests (updated because streamlink needs requests>=2.26):
* python3-chardet was replaced by python3-charset-normalizer in the python3 package (upstream decision)
