### PR TITLE
hcloud: update to 1.28.0, add completions

### DIFF
--- a/srcpkgs/hcloud/template
+++ b/srcpkgs/hcloud/template
@@ -1,9 +1,10 @@
 # Template file for 'hcloud'
 pkgname=hcloud
-version=1.26.1
+version=1.28.0
 revision=1
 wrksrc="cli-${version}"
 build_style=go
+build_helper=qemu
 go_import_path=github.com/hetznercloud/cli
 go_package=github.com/hetznercloud/cli/cmd/hcloud
 go_ldflags="-X github.com/hetznercloud/cli/internal/version.Version=${version}"
@@ -12,9 +13,13 @@ maintainer="Gerardo Di Iorio <arete74@gmail.com>"
 license="MIT"
 homepage="https://github.com/hetznercloud/cli"
 distfiles="https://github.com/hetznercloud/cli/archive/v${version}.tar.gz"
-checksum=ba7fed423b2c437adfb4b98b2fdadaad6b6325f8e31cac2729982b7bf2523c81
+checksum=1e12d771d44b3c25c2b6d96a56465cd3712ec557f5059bad59741108f48f8b3d
 
 post_install() {
 	vlicense LICENSE
 	vdoc README.md
+	for shell in bash fish zsh; do
+		vtargetrun ${DESTDIR}/usr/bin/hcloud completion ${shell} > completions.${shell}
+		vcompletion completions.${shell} ${shell}
+	done
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!--
#### Does it build and run successfully?
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
