### PR TITLE
libmpack: fix license and lint

### DIFF
--- a/srcpkgs/libmpack/template
+++ b/srcpkgs/libmpack/template
@@ -1,18 +1,22 @@
 # Template file for 'libmpack'
 pkgname=libmpack
 version=1.0.5
-revision=1
+revision=2
 build_style=gnu-makefile
+make_check_target=test
 make_build_args="LIBTOOL=${XBPS_CROSS_BASE}/usr/bin/libtool"
 make_install_args="LIBTOOL=${XBPS_CROSS_BASE}/usr/bin/libtool"
 makedepends="libtool"
 short_desc="Simple implementation of msgpack in C"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="MTI"
+license="MIT"
 homepage="https://github.com/libmpack/libmpack"
 distfiles="https://github.com/libmpack/libmpack/archive/${version}.tar.gz"
 checksum=4ce91395d81ccea97d3ad4cb962f8540d166e59d3e2ddce8a22979b49f108956
-make_check_target=test
+
+post_install() {
+	vlicense LICENSE-MIT
+}
 
 libmpack-devel_package() {
 	depends="libmpack-${version}_${revision}"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
This PR fixes a typo in `license`, it adds the license to the package and moves `make_check_target` to make `xlint` happy.
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
