### PR TITLE
gnome-remote-desktop: switch distfiles to GNOME_SITE

### DIFF
--- a/srcpkgs/gnome-remote-desktop/template
+++ b/srcpkgs/gnome-remote-desktop/template
@@ -12,9 +12,9 @@ makedepends="glib-devel pipewire-devel libsecret-devel libnotify-devel
 short_desc="GNOME remote desktop server"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-2.0-or-later"
-homepage="https://gitlab.gnome.org/GNOME/gnome-remote-desktop/"
-distfiles="https://gitlab.gnome.org/GNOME/gnome-remote-desktop/-/archive/$version/gnome-remote-desktop-$version.tar.gz"
-checksum=3c8466cd40405a6887171ada556a800e467d85bb52a506a33409c803b2d4f746
+homepage="https://wiki.gnome.org/Projects/Mutter/RemoteDesktop"
+distfiles="${GNOME_SITE}/gnome-remote-desktop/${version%%.*}/gnome-remote-desktop-${version}.tar.xz"
+checksum=9afa6e525570a372093f9730338270903894f3b1f9f8a9df5f57836ea1d29de9
 make_check=no # xvfb failed to start
 
 build_options="rdp vnc"


### PR DESCRIPTION
Static distfile is less stress for server.
Also, better for update-check.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
