### PR TITLE
Update pari optional packages

### DIFF
--- a/srcpkgs/pari-elldata-small
+++ b/srcpkgs/pari-elldata-small
@@ -1,0 +1,1 @@
+pari-elldata

--- a/srcpkgs/pari-elldata/template
+++ b/srcpkgs/pari-elldata/template
@@ -1,17 +1,32 @@
 # Template file for 'pari-elldata'
 pkgname=pari-elldata
-version=20190912
+version=20210301
 revision=1
 create_wrksrc=yes
-depends="pari"
+depends="pari-elldata-small"
 short_desc="PARI/GP version of J. E. Cremona Elliptic Curve Data"
-maintainer="André Cerqueira <acerqueira021@gmail.com>"
-license="GPL-3.0-or-later"
-homepage="http://pari.math.u-bordeaux.fr/"
-distfiles="http://pari.math.u-bordeaux.fr/pub/pari/packages/elldata.tgz"
-checksum=c5757bbeba779fbf4c69718bccbe039fd98159bf2c8d13017284cf8b5a10ddc4
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tgz>${pkgname}-${version}.tar.gz"
+checksum=dd551e64932d4ab27b3f2b2d1da871c2353672fc1a74705c52e3c0de84bd0cf6
+
+do_build() {
+	# compressed data files work ok (install-size: 156M -> 57M)
+	find data -type f -size +4k -print0 | xargs -0 gzip -9
+}
 
 do_install() {
- vmkdir usr/share/pari
- vcopy data/elldata usr/share/pari
+	vmkdir usr/share/pari
+	vcopy "data/*" usr/share/pari
+}
+
+pari-elldata-small_package() {
+	short_desc+=" - conductors up to 20000"
+	pkg_install() {
+		# a reasonable small subset (1.8M)
+		vmove "usr/share/pari/elldata/ell?.gz"
+		vmove "usr/share/pari/elldata/ell1?.gz"
+		vmove usr/share/pari/elldata/README
+	}
 }

--- a/srcpkgs/pari-elldata/update
+++ b/srcpkgs/pari-elldata/update
@@ -1,0 +1,3 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}

--- a/srcpkgs/pari-galdata/template
+++ b/srcpkgs/pari-galdata/template
@@ -1,17 +1,16 @@
 # Template file for 'pari-galdata'
 pkgname=pari-galdata
 version=20080411
-revision=1
+revision=2
 create_wrksrc=yes
-depends="pari"
-short_desc="PARI database needed to compute Galois group in degrees 8 through 11"
-maintainer="André Cerqueira <acerqueira021@gmail.com>"
-license="GPL-3.0-or-later"
-homepage="https://pari.math.u-bordeaux.fr/"
-distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/galdata.tgz"
+short_desc="PARI/GP database needed to compute Galois group in degrees 8 through 11"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tgz>${pkgname}-${version}.tar.gz"
 checksum=b7c1650099b24a20bdade47a85a928351c586287f0d4c73933313873e63290dd
 
 do_install() {
- vmkdir  usr/share/pari/galdata
- vcopy data/galdata usr/share/pari
+	vmkdir usr/share/pari
+	vcopy "data/*" usr/share/pari
 }

--- a/srcpkgs/pari-galdata/update
+++ b/srcpkgs/pari-galdata/update
@@ -1,0 +1,5 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}
+# the current version 20080411 is reported as 2008-04-12 by website
+ignore=2008-04-12

--- a/srcpkgs/pari-galpol-small
+++ b/srcpkgs/pari-galpol-small
@@ -1,0 +1,1 @@
+pari-galpol

--- a/srcpkgs/pari-galpol/template
+++ b/srcpkgs/pari-galpol/template
@@ -1,18 +1,38 @@
 # Template file for 'pari-galpol'
 pkgname=pari-galpol
 version=20180625
-revision=1
+revision=2
 create_wrksrc=yes
-depends="pari"
-short_desc="PARI package of the GALPOL database of polynomials"
-maintainer="André Cerqueira <acerqueira021@gmail.com>"
-license="GPL-3.0-or-later"
-homepage="http://pari.math.u-bordeaux.fr/"
-distfiles="http://pari.math.u-bordeaux.fr/pub/pari/packages/galpol.tgz"
+depends="pari-galpol-small"
+short_desc="PARI/GP package of the GALPOL database of polynomials"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tgz>${pkgname}-${version}.tar.gz"
 checksum=562af28316ee335ee38c1172c2d5ecccb79f55c368fb9f2c6f40fc0f416bb01b
-nostrip=yes
+# skip slow post-install hooks for 14681 files: saves ~ 3m in install
+nostrip=yes                     # skip 06-strip-and-debug-pkgs
+ignore_elf_dirs=/usr/share/pari # skip 11-pkglint-elf-in-usrshare
+
+do_build() {
+	# compressed data files work ok (install-size: 80M -> 73M)
+	find data -type f -size +4k -print0 | xargs -0 gzip -9
+}
 
 do_install() {
- vmkdir  usr/share/pari
- vcopy data/galpol usr/share/pari
+	vmkdir usr/share/pari
+	vcopy "data/*" usr/share/pari
+}
+
+pari-galpol-small_package() {
+	short_desc+=" - groups of order up to 64"
+	nostrip=yes
+	ignore_elf_dirs=/usr/share/pari
+	pkg_install() {
+		# a subset enough for testing (12M)
+		vmove "usr/share/pari/galpol/?"
+		vmove "usr/share/pari/galpol/[1-5]?"
+		vmove "usr/share/pari/galpol/6[0-4]"
+		vmove usr/share/pari/galpol/README
+	}
 }

--- a/srcpkgs/pari-galpol/update
+++ b/srcpkgs/pari-galpol/update
@@ -1,0 +1,3 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}

--- a/srcpkgs/pari-nflistdata/template
+++ b/srcpkgs/pari-nflistdata/template
@@ -1,0 +1,21 @@
+# Template file for 'pari-nflistdata'
+pkgname=pari-nflistdata
+version=20210527
+revision=1
+create_wrksrc=yes
+short_desc="PARI/GP database needed by nflist"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tgz>${pkgname}-${version}.tar.gz"
+checksum=a123b2a6776a6579108254f5dbe9fd720ddbc7e46456b45e90a69e92a73b0597
+
+do_build() {
+	# compressed data files work ok (install-size: 4.1M -> 2.9M)
+	find data -type f -size +4k -print0 | xargs -0 gzip -9
+}
+
+do_install() {
+	vmkdir usr/share/pari
+	vcopy "data/*" usr/share/pari
+}

--- a/srcpkgs/pari-nflistdata/update
+++ b/srcpkgs/pari-nflistdata/update
@@ -1,0 +1,3 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}

--- a/srcpkgs/pari-nftables/template
+++ b/srcpkgs/pari-nftables/template
@@ -1,0 +1,21 @@
+# Template file for 'pari-nftables'
+pkgname=pari-nftables
+version=20080929
+revision=1
+create_wrksrc=yes
+short_desc="PARI/GP megrez number field tables"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tgz>${pkgname}-${version}.tar.gz"
+checksum=8dd3393ce6b3cfcf599f094f7b22bdffe17c3ba25deb912513d54676bd7cfe92
+
+do_build() {
+	# compressed data files work ok (install-size: 35M -> 8M)
+	find . -type f -size +4k -print0 | xargs -0 gzip -9
+}
+
+do_install() {
+	vmkdir usr/share/pari
+	vcopy "*" usr/share/pari
+}

--- a/srcpkgs/pari-nftables/update
+++ b/srcpkgs/pari-nftables/update
@@ -1,0 +1,3 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}

--- a/srcpkgs/pari-seadata-big/template
+++ b/srcpkgs/pari-seadata-big/template
@@ -1,17 +1,17 @@
 # Template file for 'pari-seadata-big'
 pkgname=pari-seadata-big
 version=20170418
-revision=2
+revision=3
 create_wrksrc=yes
-depends="pari pari-seadata"
+depends="pari-seadata"
 short_desc="PARI/GP package needed by ellap for large primes up to 1100 bits"
-maintainer="André Cerqueira <acerqueira021@gmail.com>"
-license="GPL-3.0-or-later"
-homepage="http://pari.math.u-bordeaux.fr/packages.html"
-distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/seadata-big.tar"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tar>${pkgname}-${version}.tar"
 checksum=7c4db2624808a5bbd2ba00f8b644a439f0508532efd680a247610fdd5822a5f2
 
 do_install() {
- vmkdir  usr/share/pari
- vcopy data/seadata/sea*.gz usr/share/pari
+	vmkdir usr/share/pari
+	vcopy "data/*" usr/share/pari
 }

--- a/srcpkgs/pari-seadata-big/update
+++ b/srcpkgs/pari-seadata-big/update
@@ -1,0 +1,3 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}

--- a/srcpkgs/pari-seadata-small
+++ b/srcpkgs/pari-seadata-small
@@ -1,0 +1,1 @@
+pari-seadata

--- a/srcpkgs/pari-seadata/template
+++ b/srcpkgs/pari-seadata/template
@@ -1,17 +1,33 @@
 # Template file for 'pari-seadata'
 pkgname=pari-seadata
 version=20090618
-revision=3
+revision=4
 create_wrksrc=yes
-depends="pari"
-short_desc="PARI/GP package needed by ellap for large primes up to 750 bit"
-maintainer="André Cerqueira <acerqueira021@gmail.com>"
-license="GPL-3.0-or-later"
-homepage="http://pari.math.u-bordeaux.fr/packages.html"
-distfiles="http://pari.math.u-bordeaux.fr/pub/pari/packages/seadata.tgz"
+depends="pari-seadata-small"
+short_desc="PARI/GP package needed by ellap for large primes up to 750 bits"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pari.math.u-bordeaux.fr/packages.html"
+distfiles="https://pari.math.u-bordeaux.fr/pub/pari/packages/${pkgname#pari-}.tgz>${pkgname}-${version}.tar.gz"
 checksum=c9282a525ea3f92c1f9c6c69e37ac5a87b48fb9ccd943cfd7c881a3851195833
 
+do_build() {
+	# compressed data files work ok (install-size: 40M -> 19M)
+	find data -type f -size +4k -print0 | xargs -0 gzip -9
+}
+
 do_install() {
- vmkdir usr/share/pari/seadata
- vcopy data/seadata/sea* usr/share/pari/seadata
+	vmkdir usr/share/pari
+	vcopy "data/*" usr/share/pari
+}
+
+pari-seadata-small_package() {
+	short_desc="PARI/GP package needed by ellap for large primes up to 350 bits"
+	pkg_install() {
+		# much smaller version suitable for primes up to 350 bits.
+		# identical to seadata-small.tgz in pari packages (668k)
+		vmove usr/share/pari/seadata/sea2
+		vmove usr/share/pari/seadata/sea0.gz
+		vmove usr/share/pari/seadata/README
+	}
 }

--- a/srcpkgs/pari-seadata/update
+++ b/srcpkgs/pari-seadata/update
@@ -1,0 +1,3 @@
+site="http://pari.math.u-bordeaux.fr/pub/pari/packages/"
+pattern="href=\"${pkgname#pari-}.t(ar|gz)\".*\K\d\d\d\d-\d\d-\d\d(?= \d\d:\d\d )"
+version=${version:0:4}.${version:4:2}.${version:6:2}

--- a/srcpkgs/pari/template
+++ b/srcpkgs/pari/template
@@ -11,6 +11,7 @@ make_check_target=statest-all
 make_install_target="install install-lib-sta install-lib-dyn"
 hostmakedepends="perl texlive"
 makedepends="gmp-devel readline-devel $(vopt_if x11 libX11-devel)"
+checkdepends="pari-elldata-small pari-galdata pari-galpol-small pari-seadata-small"
 short_desc="Fast computations library in number theory"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/pari/template
+++ b/srcpkgs/pari/template
@@ -1,6 +1,6 @@
 # Template file for 'pari'
 pkgname=pari
-version=2.13.2
+version=2.13.3
 revision=1
 build_style=configure
 build_helper=qemu
@@ -16,7 +16,7 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-2.0-or-later"
 homepage="https://pari.math.u-bordeaux.fr"
 distfiles="https://pari.math.u-bordeaux.fr/pub/pari/unix/${pkgname}-${version}.tar.gz"
-checksum=1679985094a0b723d14f49aa891dbe5ec967aa4040050a2c50bd764ddb3eba24
+checksum=ccba7f1606c6854f1443637bb57ad0958d41c7f4753f8ae8459f1d64c267a1ca
 
 build_options="x11 pthreads"
 build_options_default="x11 pthreads"


### PR DESCRIPTION
- update pari-elldata
- new pari package pari-nflistdata
- fix license
- change homepage and use https for downloads
- rename distfiles to include version in name
- ~keep the mtime from files in source~
- compress files for installed-size savings
- drop depends of packages on pari, add checkdepends of pari to packages (cf #29159, #32614)
- add a much smaller subpkg seadata-small as in upstream
- add update file for all packages
- skip slow post-install hooks for pari-galpol (14681 data files)

I'm also considering adding packages `pari-elldata-small` and `pari-galpol-small` with small versions of the databases that should be good for testing and small computations.