### PR TITLE
pinktrace: disable on arm*, enable on aarch64*

### DIFF
--- a/srcpkgs/pinktrace/template
+++ b/srcpkgs/pinktrace/template
@@ -3,7 +3,8 @@ pkgname=pinktrace
 version=1.0.0
 revision=1
 # arch list taken from https://dev.exherbo.org/~alip/pinktrace/#supported_platforms
-archs="x86_64* i686* ppc* arm*"
+# build for arm* architectures is broken
+archs="x86_64* i686* ppc* aarch64*"
 wrksrc="$pkgname-1-$version"
 build_style=gnu-configure
 configure_args="--enable-python"
@@ -16,6 +17,7 @@ license="MIT"
 homepage="http://dev.exherbo.org/~alip/pinktrace/"
 distfiles="http://git.exherbo.org/$pkgname-1.git/snapshot/$pkgname-1-$version.tar.gz"
 checksum=a963359c3a66d31f8ac5b75cdc41ff0c4886df48609338771a2016c712b2f48a
+make_check=ci-skip
 
 pre_configure() {
 	./autogen.sh

--- a/srcpkgs/sydbox/template
+++ b/srcpkgs/sydbox/template
@@ -3,6 +3,7 @@ pkgname=sydbox
 version=1.2.1
 revision=1
 wrksrc="$pkgname-1-$version"
+archs="x86_64*"
 build_style=gnu-configure
 hostmakedepends="automake pkg-config libtool pinktrace-devel"
 makedepends="pinktrace-devel"


### PR DESCRIPTION
@thypon pinktrace 1.0.0 breaks when building for arm*, aarch64 is listed in supported architectures and builds fine