### PR TITLE
mpir: fix update-check

### DIFF
--- a/srcpkgs/mpir/update
+++ b/srcpkgs/mpir/update
@@ -1,0 +1,1 @@
+site="http://mpir.org/downloads.html"


### PR DESCRIPTION
This fixes `site` so that update-check works. No update available at this time.