### PR TITLE
intellij-idea-ultimate-edition: fix missing fsnotifier binary

### DIFF
--- a/srcpkgs/intellij-idea-ultimate-edition/template
+++ b/srcpkgs/intellij-idea-ultimate-edition/template
@@ -1,7 +1,7 @@
 # Template file for 'intellij-idea-ultimate-edition'
 pkgname=intellij-idea-ultimate-edition
 version=2021.2
-revision=1
+revision=2
 archs="i686 x86_64"
 wrksrc="idea-IU-212.4746.92"
 depends="giflib libXtst jetbrains-jdk-bin"
@@ -20,13 +20,20 @@ python_version=3
 
 post_extract() {
 	# Remove files for other OSes
-	rm -rf plugins/android/lib/libwebp/win
-	rm -rf plugins/android/lib/libwebp/mac
+	rm -rf plugins/webp/lib/libwebp/win
+	rm -rf plugins/webp/lib/libwebp/mac
 	rm -rf plugins/maven/lib/maven3/lib/jansi-native/freebsd64
 	rm -rf plugins/maven/lib/maven3/lib/jansi-native/freebsd32
+	rm -rf plugins/maven/lib/maven3/lib/jansi-native/osx
+	rm -rf plugins/maven/lib/maven3/lib/jansi-native/windows32
+	rm -rf plugins/maven/lib/maven3/lib/jansi-native/windows64
+	rm -rf plugins/cwm-plugin/quiche-native/win32-x86-64
+	rm -rf plugins/cwm-plugin/quiche-native/darwin-aarch64
+	rm -rf plugins/cwm-plugin/quiche-native/darwin-x86-64
+	rm -rf **/*.dll
+	rm -rf **/*.dylib
 
 	# Remove files for other CPU architectures
-	rm -rf bin/fsnotifier-arm
 	rm -rf lib/pty4j-native/linux/ppc64le
 	rm -rf lib/pty4j-native/linux/aarch64
 	rm -rf lib/pty4j-native/linux/mips64el
@@ -34,18 +41,16 @@ post_extract() {
 
 	case "$XBPS_TARGET_MACHINE" in
 		x86_64)
-			rm -rf bin/fsnotifier
-			rm -rf bin/idea.vmoptions
-			rm -rf bin/libyjpagent-linux.so
-			rm -rf plugins/android/lib/libwebp/linux/libwebp_jni.so
+			rm -rf plugins/webp/lib/libwebp/linux/libwebp_jni.so
 			rm -rf lib/pty4j-native/linux/x86
+			rm -rf plugins/maven/lib/maven3/lib/jansi-native/linux32
+			rm -rf plugins/performanceTesting/bin/libyjpagent.so
 			;;
 		i686)
-			rm -rf bin/fsnotifier64
-			rm -rf bin/idea64.vmoptions
-			rm -rf bin/libyjpagent-linux64.so
-			rm -rf plugins/android/lib/libwebp/linux/libwebp_jni64.so
-			rm -rf lib/pty4j-native/linux/x86_64
+			rm -rf plugins/webp/lib/libwebp/linux/libwebp_jni64.so
+			rm -rf lib/pty4j-native/linux/x86-64
+			rm -rf plugins/maven/lib/maven3/lib/jansi-native/linux64
+			rm -rf plugins/performanceTesting/bin/libyjpagent64.so
 			;;
 	esac
 }


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

Quite a few of the removed files were no longer actually present, and a few new ones have been added which are useless on linux and/or the target architecture.  I would love some feedback from someone using i686 whether the fsnotifier binary (which to me looks like an x86_64 binary and works on x86_64) works on that architecture or could be removed.