### PR TITLE
winetricks: update to 20210825.

### DIFF
--- a/srcpkgs/winetricks/template
+++ b/srcpkgs/winetricks/template
@@ -1,6 +1,6 @@
 # Template file for 'winetricks'
 pkgname=winetricks
-version=20210206
+version=20210825
 revision=1
 build_style=gnu-makefile
 depends="cabextract unzip xmessage" # actually it depends on wine
@@ -9,9 +9,5 @@ maintainer="mater11234 <mater11234@riseup.net>"
 license="LGPL-3.0-or-later"
 homepage="http://wiki.winehq.org/winetricks"
 distfiles="https://github.com/Winetricks/winetricks/archive/$version.tar.gz"
-checksum=705421798b28696f577104ebdf03b068b9343ab096754150f47a6ec06fa8ae65
-
-do_check() {
-	# Needs python3-bashate
-	:
-}
+checksum=bac77918ef4d58c6465a1043fd996d09c3ee2c5a07f56ed089c4c65a71881277
+make_check=no # Needs python3-bashate


### PR DESCRIPTION
Current winetricks, which is from February, is broken all over the place.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

