### PR TITLE
podman: update to 3.3.0

### DIFF
--- a/srcpkgs/podman/template
+++ b/srcpkgs/podman/template
@@ -1,6 +1,6 @@
 # Template file for 'podman'
 pkgname=podman
-version=3.2.3
+version=3.3.0
 revision=1
 build_style=go
 go_import_path="github.com/containers/podman/v3"
@@ -15,7 +15,7 @@ license="Apache-2.0"
 homepage="https://podman.io/"
 changelog="https://raw.githubusercontent.com/containers/podman/main/RELEASE_NOTES.md"
 distfiles="https://github.com/containers/podman/archive/v${version}.tar.gz"
-checksum=ddb8a83d21d2f496512914820525b4c959ff0902d48caaf93a005854a9069b59
+checksum=b92c308471d825facb408e72691f9a62441639f1b1c552efab1645bc5bd3f91b
 
 if [ "$CROSS_BUILD" ]; then
 	go_build_tags+=" containers_image_openpgp"
@@ -23,7 +23,6 @@ fi
 
 post_install() {
 	make install.man DESTDIR="${DESTDIR}" PREFIX="/usr"
-	make install.cni DESTDIR="${DESTDIR}"
 	make install.completions DESTDIR="${DESTDIR}" PREFIX="/usr"
 	sed -e 's|# cgroup_manager = "systemd"|cgroup_manager = "cgroupfs"|g' \
 		vendor/github.com/containers/common/pkg/config/containers.conf \


### PR DESCRIPTION
According to the changelog, the install.cni make target is now gone, and
podman will create the relevant CNI config when it first starts.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
