### PR TITLE
New package: cargo-update-8.1.4

### DIFF
--- a/srcpkgs/cargo-update/template
+++ b/srcpkgs/cargo-update/template
@@ -1,0 +1,24 @@
+# Template file for 'cargo-update'
+pkgname=cargo-update
+version=9.0.0
+revision=1
+build_style=cargo
+hostmakedepends="cmake pkg-config go-md2man"
+makedepends="libgit2-devel libssh2-devel openssl-devel"
+short_desc="Cargo subcommand for updates to installed executables"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://github.com/nabijaczleweli/cargo-update"
+distfiles="https://github.com/nabijaczleweli/cargo-update/archive/refs/tags/v${version}.tar.gz"
+checksum=91667cfa404b6e2c9d0eafdf801f0740b863cc1b0e269e681369a6b6093dec3c
+
+post_install() {
+	vlicense LICENSE
+	vdoc README.md
+
+	cd man
+	for page in *.md; do
+		go-md2man -in ${page} -out ${page%.md}.1
+		vman ${page%.md}.1
+	done
+}


### PR DESCRIPTION
This came up while using topgrade recently, so considering we're shipping topgrade, we should ship this too IMO.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->


#### Remaining TODOs:

-  ~~disable self-update~~ Considering that `cargo-update` uses the same way to update itself as it uses to update other applications, this doesn't matter. When `cargo-update` isn't installed using cargo by the user, it doesn't try to update itself. Therefore: Nothing to do here.