### PR TITLE
hooks/99-pkglint.sh: make missing shlib entry not a warning

### DIFF
--- a/common/hooks/pre-pkg/99-pkglint.sh
+++ b/common/hooks/pre-pkg/99-pkglint.sh
@@ -182,7 +182,7 @@ hook() {
 			if [ -z "$found" ]; then
 				_myshlib="${libname}.so"
 				[ "${_myshlib}" != "${rev}" ] && _myshlib+=".${rev}"
-				msg_warn "${pkgver}: ${_myshlib} not found in common/shlibs!\n"
+				msg_normal "${pkgver}: ${_myshlib} not found in common/shlibs.\n"
 			fi;
 		}
 	done


### PR DESCRIPTION
Message is useful, but when it is a warning, clueless people add *any* missing entry.