### PR TITLE
gtk+3: update to 3.24.30.

### DIFF
--- a/srcpkgs/gtk+3/template
+++ b/srcpkgs/gtk+3/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk+3'
 # Revbump gtk-layer-shell when updating, otherwise it presents a warning message
 pkgname=gtk+3
-version=3.24.29
+version=3.24.30
 revision=1
 wrksrc="gtk+-${version}"
 build_style=gnu-configure
@@ -29,7 +29,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gtk.org/"
 distfiles="${GNOME_SITE}/gtk+/${version%.*}/gtk+-${version}.tar.xz"
-checksum=f57ec4ade8f15cab0c23a80dcaee85b876e70a8823d9105f067ce335a8268caa
+checksum=ba75bfff320ad1f4cfbee92ba813ec336322cc3c660d406aad014b07087a3ba9
 
 # Package build options
 build_options="broadway colord cups gir cloudproviders wayland x11"


### PR DESCRIPTION
> Revbump gtk-layer-shell when updating, otherwise it presents a warning message

@ericonr I am getting the warning whether I rebuild gtk-layer-shell or not. Do you think this is still relevant? They don't mention versions higher than 3.24.26 in [compatibility.md](https://github.com/wmww/gtk-layer-shell/blob/master/compatibility.md), they changed the logic to determine when the warning is shown (https://github.com/wmww/gtk-layer-shell/pull/69) and we have not been revbumping gtk-layer-shell since GTK 3.24.26.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
