### PR TITLE
fontconfig: move default configuration to INSTALL/REMOVE

### DIFF
--- a/srcpkgs/fontconfig/INSTALL
+++ b/srcpkgs/fontconfig/INSTALL
@@ -5,40 +5,21 @@ case "${ACTION}" in
 pre)
 	;;
 post)
-	if [ ! -e etc/fonts/conf.d/.autoconfig ]; then
-		echo "Setting default font configuration"
-		: > etc/fonts/conf.d/.autoconfig
+	_confd="etc/fonts/conf.d"
+	if [ ! -e "${_confd}/.xbps-configured" ] && [ -r "${_confd}/.defconfigs" ]; then
+		echo "Setting default font configuration..."
 
-		_defconfigs="
-		 10-hinting-slight.conf
-		 10-scale-bitmap-fonts.conf
-		 20-unhint-small-vera.conf
-		 30-metric-aliases.conf
-		 40-nonlatin.conf
-		 45-generic.conf
-		 45-latin.conf
-		 49-sansserif.conf
-		 50-user.conf
-		 51-local.conf
-		 60-generic.conf
-		 60-latin.conf
-		 65-fonts-persian.conf
-		 65-nonlatin.conf
-		 69-unifont.conf
-		 80-delicious.conf
-		 90-synthetic.conf
-		"
+		while read -r _f; do
+			_fsrc="usr/share/fontconfig/conf.avail/${_f}"
+			[ -e "${_fsrc}" ] || continue
 
-		for _f in $_defconfigs; do
-			_fsrc="usr/share/fontconfig/conf.avail/$_f"
-			[ -e "$_fsrc" ] || continue
+			[ -e "${_confd}/${_f}" ] || ln -s "/${_fsrc}" "${_confd}/${_f}"
+		done < "${_confd}/.defconfigs"
 
-			ln -s "/$_fsrc" etc/fonts/conf.d
-			echo "$_f" >> etc/fonts/conf.d/.autoconfig
-		done
-
-		unset _f _fsrc _defconfigs
+		: > etc/fonts/conf.d/.xbps-configured
+		unset _f _fsrc
 	fi
+	unset _confd
 
 	echo "Building fonts cache... "
 	fc-cache -f >/dev/null

--- a/srcpkgs/fontconfig/INSTALL
+++ b/srcpkgs/fontconfig/INSTALL
@@ -1,10 +1,45 @@
 #
-# This script builds fontconfig's fonts cache.
+# This script establishes a default config and builds the font cache
 #
 case "${ACTION}" in
 pre)
 	;;
 post)
+	if [ ! -e etc/fonts/conf.d/.autoconfig ]; then
+		echo "Setting default font configuration"
+		: > etc/fonts/conf.d/.autoconfig
+
+		_defconfigs="
+		 10-hinting-slight.conf
+		 10-scale-bitmap-fonts.conf
+		 20-unhint-small-vera.conf
+		 30-metric-aliases.conf
+		 40-nonlatin.conf
+		 45-generic.conf
+		 45-latin.conf
+		 49-sansserif.conf
+		 50-user.conf
+		 51-local.conf
+		 60-generic.conf
+		 60-latin.conf
+		 65-fonts-persian.conf
+		 65-nonlatin.conf
+		 69-unifont.conf
+		 80-delicious.conf
+		 90-synthetic.conf
+		"
+
+		for _f in $_defconfigs; do
+			_fsrc="usr/share/fontconfig/conf.avail/$_f"
+			[ -e "$_fsrc" ] || continue
+
+			ln -s "/$_fsrc" etc/fonts/conf.d
+			echo "$_f" >> etc/fonts/conf.d/.autoconfig
+		done
+
+		unset _f _fsrc _defconfigs
+	fi
+
 	echo "Building fonts cache... "
 	fc-cache -f >/dev/null
 	echo "done."

--- a/srcpkgs/fontconfig/REMOVE
+++ b/srcpkgs/fontconfig/REMOVE
@@ -3,18 +3,19 @@
 #
 case "${ACTION}" in
 pre)
-	if [ -r etc/fonts/conf.d/.autoconfig ]; then
-		echo "Removing default font configuration"
+	_confd="etc/fonts/conf.d"
+	if [ -e "${_confd}/.xbps-configured" ] && [ -r "${_confd}/.defconfigs" ]; then
+		echo "Removing default font configuration..."
 
 		while read -r _f; do
-			_fsrc="etc/fonts/conf.d/$_f"
-			[ -L "$_fsrc" ] && rm "$_fsrc"
-		done < etc/fonts/conf.d/.autoconfig
+			_fsrc="${_confd}/${_f}"
+			[ -L "${_fsrc}" ] && rm "${_fsrc}"
+		done < "${_confd}/.defconfigs"
 
-		rm -f etc/fonts/conf.d/.autoconfig
-
+		rm -f "${_confd}/.xbps-configured"
 		unset _f _fsrc
 	fi
+	unset _confd
 	;;
 post)
 	;;

--- a/srcpkgs/fontconfig/REMOVE
+++ b/srcpkgs/fontconfig/REMOVE
@@ -1,0 +1,21 @@
+#
+# This script removes any default configuration established by INSTALL
+#
+case "${ACTION}" in
+pre)
+	if [ -r etc/fonts/conf.d/.autoconfig ]; then
+		echo "Removing default font configuration"
+
+		while read -r _f; do
+			_fsrc="etc/fonts/conf.d/$_f"
+			[ -L "$_fsrc" ] && rm "$_fsrc"
+		done < etc/fonts/conf.d/.autoconfig
+
+		rm -f etc/fonts/conf.d/.autoconfig
+
+		unset _f _fsrc
+	fi
+	;;
+post)
+	;;
+esac

--- a/srcpkgs/fontconfig/template
+++ b/srcpkgs/fontconfig/template
@@ -21,13 +21,23 @@ pre_build() {
 
 post_install() {
 	if [ "$CROSS_BUILD" ]; then
-		sed -i 's,\(Cflags: -I${includedir}\).*,\1,g' "${DESTDIR}"/usr/lib/pkgconfig/fontconfig.pc
+		sed -i 's,\(Cflags: -I${includedir}\).*,\1,g' "${DESTDIR}/usr/lib/pkgconfig/fontconfig.pc"
 	fi
 
 	vlicense COPYING
 
-	# Default configuration is managed in INSTALL/REMOVE
-	rm -f "${DESTDIR}"/etc/fonts/conf.d/*.conf
+	# Default configuration links are managed in INSTALL/REMOVE
+
+	local _confd="${DESTDIR}/etc/fonts/conf.d" _f= _fb=
+
+	: > "${_confd}/.defconfigs"
+	for _f in "${_confd}"/*.conf; do
+		[ "${_f}" = "${_confd}/*.conf" ] && continue
+		_fb="${_f##*/}"
+		echo "${_fb}" >> "${_confd}/.defconfigs"
+	done
+
+	rm -f "${_confd}"/*.conf
 }
 
 fontconfig-devel_package() {

--- a/srcpkgs/fontconfig/template
+++ b/srcpkgs/fontconfig/template
@@ -1,7 +1,7 @@
 # Template file for 'fontconfig'
 pkgname=fontconfig
 version=2.13.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--enable-static --enable-docs --with-cache-dir=/var/cache/${pkgname}"
 hostmakedepends="gperf pkg-config"
@@ -21,9 +21,13 @@ pre_build() {
 
 post_install() {
 	if [ "$CROSS_BUILD" ]; then
-		sed -i 's,\(Cflags: -I${includedir}\).*,\1,g' ${DESTDIR}/usr/lib/pkgconfig/fontconfig.pc
+		sed -i 's,\(Cflags: -I${includedir}\).*,\1,g' "${DESTDIR}"/usr/lib/pkgconfig/fontconfig.pc
 	fi
+
 	vlicense COPYING
+
+	# Default configuration is managed in INSTALL/REMOVE
+	rm -f "${DESTDIR}"/etc/fonts/conf.d/*.conf
 }
 
 fontconfig-devel_package() {


### PR DESCRIPTION
Encoding /etc/fonts/conf.d configuration symlinks in the package means that upgrades and installations will clobber existing custom configurations. In addition, removing any default configuration files would cause xbps-pkgdb to complain.

Managing default configurations in INSTALL/REMOVE allows custom configurations to persist through upgrades and removals. A guard file, /etc/fonts/conf.d/.autoconfig, serves as an INSTALL guard to prevent configuration modifications during upgrade. It also stores a list of the default configurations that will be removed when the package is uninstalled. This is an extension of an idea from @ericonr.

These scripts should mimic existing behavior through the first subsequent upgrade or installation.