### PR TITLE
New package: jellyfin-10.7.6

### DIFF
--- a/srcpkgs/dotnet-sdk-bin/template
+++ b/srcpkgs/dotnet-sdk-bin/template
@@ -1,0 +1,46 @@
+# Template file for 'dotnet-sdk-bin'
+pkgname=dotnet-sdk-bin
+version=5.0.400
+revision=1
+archs="x86_64 armv7 aarch64"
+wrksrc="${pkgname}-${version}"
+create_wrksrc=yes
+short_desc="Provides the .NET SDK components, precompiled binaries"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="MIT"
+homepage="https://dotnet.microsoft.com"
+nopie=yes
+
+case "${XBPS_TARGET_MACHINE}" in
+	x86_64)
+	_arch="x64"
+	_path="13b9d84c-a35b-4ffe-8f62-447a01403d64/1f9ae31daa0f7d98513e7551246899f2"
+	distfiles="https://download.visualstudio.microsoft.com/download/pr/${_path}/dotnet-sdk-${version}-linux-${_arch}.tar.gz"
+	checksum="0a7dc69528f09d6ccd49bbdbe5ce0e61a3d0becf44146467087f835b9d11928b"
+	;;
+	armv7l)
+	_arch="arm"
+	_path="70bdb5a9-34cc-4f28-aa33-15535f73b593/7d31d53187c8937206bcc3b117b88978"
+	distfiles="https://download.visualstudio.microsoft.com/download/pr/${_path}/dotnet-sdk-${version}-linux-${_arch}.tar.gz"
+	checksum="883b9ac1911464581bdd573385e59518607ccdb595438abd5d21b197814b5412"
+	;;
+	aarch64)
+	_arch="arm64"
+	_path="4d323232-ffcc-4c09-a043-a36b554c883e/096822e81dc29383b649cd015d1ff99a"
+	distfiles="https://download.visualstudio.microsoft.com/download/pr/${_path}/dotnet-sdk-${version}-linux-${_arch}.tar.gz"
+	checksum="62d5aa3cf191e60332037df54163876a526513e516da4b8309d61f4f43454796"
+	;;
+esac
+
+_target='usr/lib/dotnet'
+
+do_install() {
+	vmkdir usr/bin
+	ln -sf "/${_target}/dotnet" "${DESTDIR}/usr/bin/dotnet"
+	vmkdir "${_target}"
+	vcopy dotnet "${_target}"
+	vcopy host "${_target}"
+	vcopy shared "${_target}"
+	vcopy sdk "${_target}"
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/jellyfin/files/jellyfin.default
+++ b/srcpkgs/jellyfin/files/jellyfin.default
@@ -1,0 +1,25 @@
+# Jellyfin default configuration options
+# This is a POSIX shell fragment
+
+# Use this file to override the default configurations; add additional
+# options with JELLYFIN_ADD_OPTS.
+
+#
+# General options
+#
+
+# Program directories
+JELLYFIN_DATA_DIR="/var/lib/jellyfin"
+JELLYFIN_CONFIG_DIR="/etc/jellyfin"
+JELLYFIN_LOG_DIR="/var/log/jellyfin"
+JELLYFIN_CACHE_DIR="/var/cache/jellyfin"
+JELLYFIN_WEB_DIR="/usr/lib/jellyfin/jellyfin-web"
+
+# [OPTIONAL] run Jellyfin as a headless service
+#JELLYFIN_SERVICE_OPT="--service"
+
+# [OPTIONAL] run Jellyfin without the web app
+#JELLYFIN_NOWEBAPP_OPT="--nowebclient"
+
+# [OPTIONAL] add additional options
+JELLYFIN_ADD_OPTS=""

--- a/srcpkgs/jellyfin/files/jellyfin/conf
+++ b/srcpkgs/jellyfin/files/jellyfin/conf
@@ -1,0 +1,1 @@
+[ -f /etc/default/jellyfin ] && . /etc/default/jellyfin

--- a/srcpkgs/jellyfin/files/jellyfin/log/run
+++ b/srcpkgs/jellyfin/files/jellyfin/log/run
@@ -1,0 +1,1 @@
+/usr/bin/logger

--- a/srcpkgs/jellyfin/files/jellyfin/run
+++ b/srcpkgs/jellyfin/files/jellyfin/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+[ -r conf ] && . ./conf
+cd /var/lib/jellyfin
+exec chpst -u _jellyfin /usr/lib/jellyfin/jellyfin --datadir=${JELLYFIN_DATA_DIR} --configdir=${JELLYFIN_CONFIG_DIR} --logdir=${JELLYFIN_LOG_DIR} --cachedir=${JELLYFIN_CACHE_DIR} --webdir=${JELLYFIN_WEB_DIR} ${JELLYFIN_SERVICE_OPT} ${JELLYFIN_NOWEBAPP_OPT} ${JELLYFIN_ADD_OPTS}

--- a/srcpkgs/jellyfin/template
+++ b/srcpkgs/jellyfin/template
@@ -1,0 +1,65 @@
+# Template file for 'jellyfin'
+pkgname=jellyfin
+version=10.7.6
+revision=1
+archs="i686 x86_64 armv7l aarch64"
+wrksrc="${pkgname}-${version}"
+create_wrksrc=yes
+build_style=meta
+hostmakedepends="dotnet-sdk-bin yarn git"
+depends="ffmpeg sqlite"
+short_desc="Free Software Media System"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="GPL-2.0-or-later"
+homepage="https://jellyfin.readthedocs.io"
+distfiles="
+ https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz
+ https://github.com/${pkgname}/${pkgname}-web/archive/v${version}.tar.gz>${pkgname}-web-${version}.tar.gz"
+checksum="
+ fb54ef3862f03ec50f8c6e1c95df98601e53947bb2891f369d1533d8711f2ec9
+ 1013e3be80d744684093ad4c4df3a16bcbeda8364978608d5c65b0bbc7940f77"
+nopie=yes
+make_dirs="/var/lib/jellyfin 0750 _jellyfin _jellyfin
+ /var/log/jellyfin 0750 _jellyfin _jellyfin
+ /var/cache/jellyfin 0750 _jellyfin _jellyfin
+ /etc/jellyfin 0755 _jellyfin _jellyfin"
+
+system_accounts="_jellyfin"
+_jellyfin_homedir="/var/lib/jellyfin"
+
+do_build() {
+	cd jellyfin-web-${version}
+	yarn install
+
+# https://docs.microsoft.com/de-de/dotnet/core/rid-catalog#linux-rids
+	case "${XBPS_TARGET_MACHINE}" in
+		i686) _build_arch="x86";;
+		x86_64) _build_arch="x64";;
+		armv7l) _build_arch="arm";;
+		aarch64) _build_arch="arm64";;
+		esac
+
+	cd ../jellyfin-${version}
+
+	export DOTNET_CLI_TELEMETRY_OPTOUT=1
+	export CLR_OPENSSL_VERSION_OVERRIDE=47
+	dotnet build -r "linux-${_build_arch}" --configuration Release Jellyfin.Server
+	dotnet publish -r "linux-${_build_arch}" --configuration Release Jellyfin.Server --output "$PWD"/publish
+	rm -rfv publish/runtimes/{alpine-*,osx*,tizen-*,win*,linux-musl-x64,linux-armel}
+
+	test "${XBPS_TARGET_MACHINE}" = 'i686' || rm -rfv publish/runtimes/linux-x86
+	test "${XBPS_TARGET_MACHINE}" = 'x86_64' || rm -rfv publish/runtimes/linux-x64
+	test "${XBPS_TARGET_MACHINE}" = 'armv7l' || rm -rfv publish/runtimes/linux-arm
+	test "${XBPS_TARGET_MACHINE}" = 'aarch64' || rm -rfv publish/runtimes/linux-arm64
+
+	mkdir publish/jellyfin-web
+	cp -rv ../jellyfin-web-${version}/dist/. publish/jellyfin-web
+}
+
+do_install() {
+	vmkdir usr/lib/jellyfin
+	vmkdir etc/default
+	vcopy "${FILESDIR}/jellyfin.default" etc/default/jellyfin
+	vcopy "${pkgname}-${version}/publish/." usr/lib/jellyfin
+	vsv jellyfin
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Continuation of https://github.com/void-linux/void-packages/pull/20414 with some clean-up and version bumps. I also added `/etc/default/jellyfin` and `/etc/sv/jellyfin` meaning this is functionally complete and I am using it on my system.
