### PR TITLE
musca: change distfiles and homepage

### DIFF
--- a/srcpkgs/musca/template
+++ b/srcpkgs/musca/template
@@ -1,19 +1,20 @@
 # Template file for 'musca'
 pkgname=musca
 version=0.9.24
-revision=3
+revision=4
 build_style=gnu-makefile
 makedepends="libX11-devel libXcursor-devel"
 short_desc="Tiling window manager, with features nicked from ratpoison and dwm"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
-homepage="http://aerosuidae.net/musca.html"
-distfiles="https://distfiles.voidlinux.de/musca-${version}/musca-${version}.tgz"
+homepage="https://launchpad.net/musca"
+distfiles="https://ftp.netbsd.org/pub/pkgsrc/distfiles/musca-${version}.tgz"
 checksum=c34e37e2df5075a61f8d5268786ab8115816af95c46e063c50f7f1c500527301
 
 pre_build() {
 	cp ${FILESDIR}/Makefile .
 }
+
 do_install() {
 	vbin musca
 	vbin apis


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
Musca seems pretty dead now. Maybe it should be removed. The current `homepage` points to a shady site and the current `distfiles` isn't accessible. This PR fixes both issues.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR