### PR TITLE
oil: bring package contents more inline with the project's install script

### DIFF
--- a/srcpkgs/oil/template
+++ b/srcpkgs/oil/template
@@ -1,7 +1,7 @@
 # Template file for 'oil'
 pkgname=oil
 version=0.10.0
-revision=1
+revision=2
 build_style=configure
 configure_args="--prefix=/usr $(vopt_with readline)"
 hostmakedepends="$(vopt_if readline readline-devel)"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://www.oilshell.org"
 distfiles="${homepage}/download/${pkgname}-${version}.tar.xz"
 checksum=cf7da9494ba9f0f101d27f0d0b5e248f8a54721ddeec13dd54652c9528580296
-register_shell="/usr/bin/osh"
+register_shell="/usr/bin/osh /usr/bin/oil"
 nocross="Build systems gets confused with host and cross toolchains/headers"
 nostrip=yes
 
@@ -27,8 +27,9 @@ pre_build() {
 do_install() {
 	# Install binaries
 	vbin _bin/oil.ovm
-	# Symlink osh, oshc to oil.ovm.
+	vman doc/osh.1
+	# Symlink osh, oil to oil.ovm.
 	cd "${DESTDIR}"/usr/bin
 	ln -s oil.ovm osh
-	ln -s oil.ovm oshc
+	ln -s oil.ovm oil
 }


### PR DESCRIPTION
 Add `oil` symlink as well as man page
Project no longer bothers to symlink `oshc` (seems to be incomplete/broken)

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl