### PR TITLE
rssguard: update to 4.0.1.

### DIFF
--- a/srcpkgs/rssguard/template
+++ b/srcpkgs/rssguard/template
@@ -1,18 +1,18 @@
 # Template file for 'rssguard'
 pkgname=rssguard
-version=3.9.2
+version=4.0.1
 revision=1
 build_style=qmake
 configure_args="CONFIG+=release LRELEASE_EXECUTABLE=lrelease-qt5 USE_WEBENGINE=false"
 hostmakedepends="qt5-qmake qt5-host-tools"
-makedepends="qt5-tools-devel kdeclarative-devel"
+makedepends="qt5-tools-devel kdeclarative-devel qt5-multimedia-devel"
 depends="desktop-file-utils qt5-plugin-sqlite"
 short_desc="Simple (yet powerful) Qt5 feed reader"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="GPL-3.0-only"
 homepage="https://github.com/martinrotter/rssguard"
 distfiles="https://github.com/martinrotter/rssguard/archive/${version}.tar.gz"
-checksum=05eb628ff085ff10056289fd83b5e3b0583c19e3711795ade024bdfe71de5d97
+checksum=658ed9f63d2e3d1b740c8c65e649b28de350f64670c85e954a093345e313a500
 
 post_install() {
 	# Install rssguard icon manually


### PR DESCRIPTION
Also add qt-multimedia-devel to makedepends
(new upstream dep).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [Χ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
