### PR TITLE
libxfce4ui: update to 4.16.1.

### DIFF
--- a/srcpkgs/libxfce4ui/template
+++ b/srcpkgs/libxfce4ui/template
@@ -1,20 +1,20 @@
 # Template file for 'libxfce4ui'
 pkgname=libxfce4ui
-version=4.16.0
-revision=2
+version=4.16.1
+revision=1
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--with-locales-dir=/usr/share/locale --disable-static"
 conf_files="/etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml"
 hostmakedepends="xfce4-dev-tools pkg-config intltool glib-devel gettext-devel"
 makedepends="gtk+-devel gtk+3-devel glade3-devel libxfce4util-devel xfconf-devel
- libxml2-devel startup-notification-devel libSM-devel"
+ libxml2-devel startup-notification-devel libSM-devel libgtop-devel"
 short_desc="Replacement of the old libxfcegui4 library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://xfce.org/"
 distfiles="https://archive.xfce.org/src/xfce/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=8b06c9e94f4be88a9d87c47592411b6cbc32073e7af9cbd64c7b2924ec90ceaa
+checksum=d96946ae5af6bf078dda415419e0021909f763ee0020b42f3e26f603e51585f6
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
Also add libgtop-devel to makedepends
(provide system info).

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
