### PR TITLE
sbcl: fix aarch64 sbcl binary checksum.

### DIFF
--- a/srcpkgs/sbcl/template
+++ b/srcpkgs/sbcl/template
@@ -32,7 +32,7 @@ arm*)
 	;;
 aarch64)
 	distfiles+=" ${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-1.3.9-arm64-linux-binary.tar.bz2"
-	checksum+=" 494829f8e3ea7eb1c308b343cc390daf94a6215030a5f2b9ee0cded67511e918"
+	checksum+=" 14c8fc0f3a03416b5d23763156e2bb28b690fb665af1e6f6112201fd0ddcd512"
 	;;
 ppc*|*-musl)
 	makedepends+=" ecl"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
