### PR TITLE
rc: fix dead links

### DIFF
--- a/srcpkgs/rc/template
+++ b/srcpkgs/rc/template
@@ -1,19 +1,20 @@
 # Template file for 'rc'
 pkgname=rc
 version=1.7.4
-revision=5
+revision=6
 build_style=gnu-configure
 configure_args="ac_cv_sys_restartable_syscalls=no
  $(vopt_if readline --with-edit=gnu)
  $(vopt_if libedit --with-edit=bsd)"
+hostmakedepends="automake"
 makedepends="$(vopt_if readline readline-devel)
  $(vopt_if libedit libedit-devel)"
 short_desc="Alternative implementation of the plan 9 rc shell"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="Zlib"
-homepage="http://tobold.org/article/rc"
-distfiles="http://static.tobold.org/$pkgname/$pkgname-$version.tar.gz"
-checksum=5ed26334dd0c1a616248b15ad7c90ca678ae3066fa02c5ddd0e6936f9af9bfd8
+homepage="https://github.com/rakitzis/rc"
+distfiles="https://github.com/rakitzis/rc/archive/refs/tags/v${version}.tar.gz"
+checksum=0b83f8698dd8ef44ca97b25c4748c087133f53c7fff39b6b70dab65931def8b0
 register_shell="/bin/rc"
 
 build_options="readline libedit static"
@@ -24,6 +25,7 @@ pre_configure() {
 		CFLAGS+=" -static"
 		LDFLAGS+=" -static"
 	fi
+	sh bootstrap
 }
 
 pre_build() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
`rc` seems pretty dead now. `tobold.org` and `static.tobold.org` are down. I have tried to contact the author, but his email seems to be down too. This package should maybe be removed rather than fixed.

This PR fixes dead links and modifies the build process.

@leahneukirchen I'm pinging you since you are the maintainer of `rc`. Do you have any comment on this?
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR