### PR TITLE
fwupd: change deps

### DIFF
--- a/srcpkgs/fwupd/template
+++ b/srcpkgs/fwupd/template
@@ -1,19 +1,19 @@
 # Template file for 'fwupd'
 pkgname=fwupd
 version=1.6.4
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
+configure_args="-Dsupported_build=true -Dconsolekit=false -Dsystemd=false -Delogind=true
+ -Dintrospection=true -Dtests=false"
 # tests require unpackaged umockdev
-configure_args="-Dsupported_build=true -Dconsolekit=false -Dintrospection=true
- -Dsystemd=false -Dplugin_altos=false -Delogind=true -Dtests=false"
 hostmakedepends="dejavu-fonts-ttf gnutls-tools pkg-config gcab gi-docgen
  vala glib-devel polkit gettext pango python3-gobject python3-Pillow"
 makedepends="libxmlb-devel cairo-devel colord-devel libarchive-devel
  gnutls-devel gpgme-devel json-glib-devel libgusb-devel polkit-devel
  sqlite-devel libsoup-devel gcab-devel pango-devel elogind-devel
  tpm2-tss-devel libjcat-devel libcurl-devel"
-depends="udisks2"
+depends="dbus udisks2"
 conf_files="
  /etc/fwupd/*.conf
  /etc/fwupd/remotes.d/*.conf"


### PR DESCRIPTION
drop dep on udisks2, add dep on dbus
drop -Dintrospection=true, which is default
built and checked on x86_64-musl

udisks2 brings in a lot of bloat, just to discover the ESP partition, but it actually does not do the job,
so it would be simpler to just let the user take care of that. (That's also what Alpine does btw.)
Notice even with udisks, I currently have to do
`mount -t efivarfs efivarfs /sys/firmware/efi/efivars`
otherwise fwupd does not find the bios to update.
Instead, dbus seems to be a needed dependency.