### PR TITLE
graphviz: separate x11 binaries and gtk plugin to reduce deps

### DIFF
--- a/srcpkgs/graphviz-gtk
+++ b/srcpkgs/graphviz-gtk
@@ -1,0 +1,1 @@
+graphviz

--- a/srcpkgs/graphviz-x11
+++ b/srcpkgs/graphviz-x11
@@ -1,0 +1,1 @@
+graphviz

--- a/srcpkgs/graphviz/graphviz-gtk.INSTALL
+++ b/srcpkgs/graphviz/graphviz-gtk.INSTALL
@@ -1,0 +1,1 @@
+INSTALL

--- a/srcpkgs/graphviz/graphviz-gtk.REMOVE
+++ b/srcpkgs/graphviz/graphviz-gtk.REMOVE
@@ -1,0 +1,1 @@
+INSTALL

--- a/srcpkgs/graphviz/graphviz-x11.INSTALL
+++ b/srcpkgs/graphviz/graphviz-x11.INSTALL
@@ -1,0 +1,1 @@
+INSTALL

--- a/srcpkgs/graphviz/graphviz-x11.REMOVE
+++ b/srcpkgs/graphviz/graphviz-x11.REMOVE
@@ -1,0 +1,1 @@
+INSTALL

--- a/srcpkgs/graphviz/template
+++ b/srcpkgs/graphviz/template
@@ -1,7 +1,7 @@
 # Template file for 'graphviz'
 pkgname=graphviz
 version=2.49.0
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_args="HOSTCC=$BUILD_CC"
 hostmakedepends="automake flex libltdl-devel libtool perl pkg-config python3"
@@ -16,6 +16,15 @@ homepage="http://www.graphviz.org"
 distfiles="https://gitlab.com/graphviz/graphviz/-/archive/${version}/graphviz-${version}.tar.gz"
 checksum=a062ccd940abbde6e3c45462323b2ede54b9374fed86f464c11bc4c0bd57fd04
 
+# `make check` is broken:
+# https://gitlab.com/graphviz/graphviz/-/issues/2112
+#
+# Testing is via pytest:
+# https://gitlab.com/graphviz/graphviz/-/blob/main/DEVELOPERS.md#testing
+#
+# They expect graphviz already installed before testing, disable
+make_check=no
+
 if [ -z "$CROSS_BUILD" ]; then
 	configure_args+=" --with-gts"
 	makedepends+=" gts-devel"
@@ -29,6 +38,10 @@ post_install() {
 	vlicense epl-v10.txt LICENSE
 
 	rm -rf ${DESTDIR}/usr/share/graphviz/doc
+	# mingle is not compiled so do not install manpage
+	rm -f ${DESTDIR}/usr/share/man/man1/mingle.1
+	# dot_builtins is just dot with preloaded plugins (for testing?)
+	rm -f ${DESTDIR}/usr/bin/dot_builtins
 }
 
 graphviz-libs_package() {
@@ -46,5 +59,26 @@ graphviz-devel_package() {
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
 		vmove usr/share/man/man3
+	}
+}
+
+graphviz-gtk_package() {
+	depends="graphviz>=${version}_${revision}"
+	short_desc+=" - gtk plugin"
+	pkg_install() {
+		vmove "usr/lib/graphviz/libgvplugin_gdk.*"
+		vmove "usr/lib/graphviz/libgvplugin_gtk.*"
+	}
+}
+
+graphviz-x11_package() {
+	depends="graphviz>=${version}_${revision}"
+	short_desc+=" - x11 binaries (lefty)"
+	pkg_install() {
+		for p in lefty lneato dotty ; do
+			vmove usr/bin/$p
+			vmove usr/share/man/man1/$p.1
+		done
+		vmove usr/share/graphviz/lefty
 	}
 }


### PR DESCRIPTION
See #32826.

Arguably, the split of x11 is less important. It saves from `libXaw`, `libXmu` and `libXt`, but `libX11` and `libXrender` are deps via `cairo` anyway.

The split of `gtk` saves a lot of deps which are not usually installed on a server or chroot.

It is possible to make a smaller pkg without `gd`, `rsvg` and `webp` which seems good enough (renders svg and ps via core plugin, images and pdf via cairo), but probably not worth it.

Can't remove `pango` without disabling `cairo` as well; in this case one would want to keep `gd` for images. I wouldn't do this since the gd plugin is deprecated.