### PR TITLE
upwork: update to 5.6.8.0

### DIFF
--- a/srcpkgs/upwork/template
+++ b/srcpkgs/upwork/template
@@ -1,18 +1,18 @@
 # Template file for 'upwork'
 pkgname=upwork
-version=5.5.0.11
+version=5.6.8.0
 revision=1
 _rawver=${version//./_}
-_hashver="61df9c99b6df4e7b"
+_hashver="836f43f6f6be4149"
 archs="x86_64"
 depends="alsa-lib gtk+ GConf gdk-pixbuf nss libXtst libXScrnSaver"
 short_desc="Desktop Upwork app"
 maintainer="Arthur Evstifeev <mail@ap4y.me>"
 license="custom:Upwork"
 homepage="https://upwork.com/"
-distfiles="https://updates-desktopapp.upwork.com/binaries/v${_rawver}_${_hashver}/${pkgname}_${version}_amd64.deb
+distfiles="https://upwork-usw2-desktopapp.upwork.com/binaries/v${_rawver}_${_hashver}/${pkgname}_${version}_amd64.deb
  https://upwork.pactsafe.io/versions/5ab3efef63d65b6a18aab106.pdf>LICENSE.pdf"
-checksum="db83d5fb1b5383992c6156284f6f3cd3a6b23f727ce324ba90c82817553fb4f7
+checksum="b3a52f773d633837882dc107b206006325722ca5d5d5a1e8bdf5453f872e1b6f
  0949da5999c3b948bcc4165e6c55522915d9bab1790d27120eda0915aae143bb"
 repository="nonfree"
 restricted=yes


### PR DESCRIPTION
The download subdomain changed from updates to upwork-usw2.