### PR TITLE
libcdparanoia: byteswap null check

### DIFF
--- a/srcpkgs/cdparanoia/patches/byteswap-null-check.diff
+++ b/srcpkgs/cdparanoia/patches/byteswap-null-check.diff
@@ -1,0 +1,13 @@
+Index: interface/interface.c
+===================================================================
+--- a/interface/interface.c	(revision 15338)
++++ b/interface/interface.c	(revision 15356)
+@@ -118,7 +118,7 @@
+ 	if(d->bigendianp==-1) /* not determined yet */
+ 	  d->bigendianp=data_bigendianp(d);
+ 	
+-	if(d->bigendianp!=bigendianp()){
++	if(buffer && d->bigendianp!=bigendianp()){
+ 	  int i;
+ 	  u_int16_t *p=(u_int16_t *)buffer;
+ 	  long els=sectors*CD_FRAMESIZE_RAW/2;

--- a/srcpkgs/cdparanoia/template
+++ b/srcpkgs/cdparanoia/template
@@ -1,7 +1,7 @@
 # Template file for 'cdparanoia'
 pkgname=cdparanoia
 version=10.2
-revision=14
+revision=15
 wrksrc="${pkgname}-III-${version}"
 build_style=gnu-configure
 hostmakedepends="libtool automake"


### PR DESCRIPTION
From upstream r15356, fixes a segfault when attempting to read discs
on big-endian systems. 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ppc-musl)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [x] armv7l
  - [ ] armv6l-musl
