### PR TITLE
go: update to 1.17.1.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.17
+version=1.17.1
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -8,10 +8,10 @@ hostmakedepends="go1.12-bootstrap"
 short_desc="Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="http://golang.org/"
+homepage="https://golang.org/"
 changelog="https://golang.org/doc/devel/release.html"
 distfiles="https://golang.org/dl/go${version}.src.tar.gz"
-checksum=3a70e5055509f347c0fb831ca07a2bf3b531068f349b14a3c652e9b5b67beb5d
+checksum=49dc08339770acd5613312db8c141eaf61779995577b89d93b541ef83067e5b1
 nostrip=yes
 noverifyrdeps=yes
 
@@ -44,7 +44,7 @@ do_build() {
 
 	cd "src"
 
-	bash make.bash --no-clean -v
+	bash make.bash -v
 }
 
 do_install() {


### PR DESCRIPTION
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

I removed --no-clean because it's deprecated, ignored and forcing this behavior now seems to be hard and probably not worth it.
```
=> go-1.17.1_1: running do_build ...
Building Go cmd/dist using /usr/lib/go1.12. (go1.12.17 linux/amd64)
warning: --no-clean is deprecated and has no effect; use 'go install std cmd' instead
Building Go toolchain1 using /usr/lib/go1.12.
```