### PR TITLE
hooks/fix-permissions: add completion directories

### DIFF
--- a/common/hooks/post-install/14-fix-permissions.sh
+++ b/common/hooks/post-install/14-fix-permissions.sh
@@ -29,5 +29,8 @@ hook() {
 		change_file_perms "/usr/share/metainfo" 133 644
 		change_file_perms "/usr/share/appdata" 133 644
 		change_file_perms "/usr/include" 133 644
+		change_file_perms "/usr/share/bash-completion/completions" 133 644
+		change_file_perms "/usr/share/fish/vendor_completions.d" 133 644
+		change_file_perms "/usr/share/zsh/site-functions" 133 644
 	fi
 }


### PR DESCRIPTION
Completions don't have to be executable and they almost never are. On my system only colord installs an executable bash completion file.