### PR TITLE
New package: fast-syntax-highlighting-1.55

### DIFF
--- a/srcpkgs/fast-syntax-highlighting/template
+++ b/srcpkgs/fast-syntax-highlighting/template
@@ -1,0 +1,20 @@
+# Template file for 'fast-syntax-highlighting'
+pkgname=fast-syntax-highlighting
+version=1.55
+revision=1
+depends="zsh"
+short_desc="Feature rich syntax highlighting for Zsh"
+maintainer="Vapourium <vapourium@riseup.net>"
+license="BSD-3-Clause"
+homepage="https://github.com/zdharma/fast-syntax-highlighting"
+changelog="https://github.com/zdharma/fast-syntax-highlighting/blob/master/CHANGELOG.md"
+distfiles="${homepage}/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=d06cea9c047ce46ad09ffd01a8489a849fc65b8b6310bd08f8bcec9d6f81a898
+
+do_install() {
+	local _prefix=usr/share/zsh
+	vcompletion _fast-theme zsh
+	vcopy "fast*" ${_prefix}
+	vcopy themes ${_prefix}
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Note: fast-syntax-highlighting is an alternative to, and not a fork of zsh-users/zsh-syntax-highlighting