### PR TITLE
clang: add missing file for scan-view

### DIFF
--- a/srcpkgs/llvm12/template
+++ b/srcpkgs/llvm12/template
@@ -1,7 +1,7 @@
 # Template file for 'llvm12'
 pkgname=llvm12
-version=12.0.0
-revision=3
+version=12.0.1
+revision=1
 wrksrc="llvm-project-${version}.src"
 build_wrksrc=llvm
 build_style=cmake
@@ -35,7 +35,7 @@ maintainer="q66 <daniel@octaforge.org>"
 license="Apache-2.0"
 homepage="https://www.llvm.org"
 distfiles="https://github.com/llvm/llvm-project/releases/download/llvmorg-${version}/llvm-project-${version}.src.tar.xz"
-checksum="9ed1688943a4402d7c904cc4515798cdb20080066efa010fe7e1f2551b423628"
+checksum=129cb25cd13677aad951ce5c2deb0fe4afc1e9d98950f53b51bdcfb5a73afa0e
 lib32disabled=yes
 python_version=3
 


### PR DESCRIPTION
This PR fixes an issue with current clang-analyzer where it fails to start the scan-view webinterface:

```
 scan-view /tmp/scan-build-2021-09-16-111211-22764-1
/usr/bin/scan-view:9: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
Traceback (most recent call last):
  File "/usr/bin/scan-view", line 150, in <module>
    main()
  File "/usr/bin/scan-view", line 147, in main
    run(port, args, args.root)
  File "/usr/bin/scan-view", line 74, in run
    import ScanView
  File "/usr/bin/../share/scan-view/ScanView.py", line 29, in <module>
    import Reporter
ModuleNotFoundError: No module named 'Reporter'
```

Upstream context: https://reviews.llvm.org/D96367