### PR TITLE
MultiMC mark restricted

### DIFF
--- a/srcpkgs/MultiMC/template
+++ b/srcpkgs/MultiMC/template
@@ -1,7 +1,7 @@
 # Template file for 'MultiMC'
 pkgname=MultiMC
 version=0.6.12
-revision=2
+revision=3
 wrksrc="${pkgname}5-${version}"
 _commithashnbt="4b305bbd2ac0e7a26987baf7949a484a87b474d4"
 _nbtversion="multimc-0.6.1"
@@ -22,6 +22,10 @@ checksum="c251744b77d93db4ead56940b7b81d30dc5390fb86a1676d3f0364cc4e570185
  36c816e6b1ef8ece52c57dfa9bfda3a23808d0c6c3288b25d8bcf49c7cdb5b07
  ffa60368b1c196859691b637c740f4c60597b2ac47217995082ae8b2a3a9ac18"
 skip_extraction="${_nbtversion}.tar.gz ${_quazipversion}.tar.gz"
+
+# Restricted since we don't have permissions to ship builds with the
+# MultiMC name, artwork or the API endpoints.
+restricted=yes
 
 case "$XBPS_TARGET_MACHINE" in
 	armv*) broken="https://github.com/MultiMC/MultiMC5/issues/2895";;


### PR DESCRIPTION
We are not allowed to use the MultiMC name, artwork or API endpoints for builds from source.
Marking this package as restricted so that we won't ship any binaries for it, users can either download binaries or build the package for personal use.

Also adding it to `removed-packages` so that anyone who has it installed will get it uninstalled instead of being stuck to the version they currently have installed.

https://github.com/void-linux/void-packages/issues/32950