### PR TITLE
R: define __MUSL__ when building for musl libc

### DIFF
--- a/srcpkgs/R/template
+++ b/srcpkgs/R/template
@@ -1,7 +1,7 @@
 # Template file for 'R'
 pkgname=R
 version=4.1.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/R rdocdir=/usr/share/doc/R
  --with-blas$(vopt_if openblas '=openblas') --with-lapack
@@ -36,6 +36,10 @@ case "$XBPS_TARGET_MACHINE" in
 		;;
 	*) ;;
 esac
+
+if [ "$XBPS_TARGET_LIBC" = musl ]; then
+	export CPPFLAGS=-D__MUSL__
+fi
 
 pre_configure() {
 	export R_BROWSER=/usr/bin/xdg-open


### PR DESCRIPTION
R people assumes it's defined for musl libc.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
