### PR TITLE
ncurses: install non-wide pkg-config files

### DIFF
--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template file for 'ncurses'
 pkgname=ncurses
 version=6.2
-revision=4
+revision=5
 bootstrap=yes
 configure_args="--enable-big-core"
 short_desc="System V Release 4.0 curses emulation library"
@@ -49,6 +49,9 @@ do_build() {
 
 do_install() {
 	vlicense COPYING
+
+	cd ${wrksrc}/ncurses-build/misc
+	make DESTDIR=${DESTDIR} install
 
 	cd ${wrksrc}/ncursesw-build
 	make DESTDIR=${DESTDIR} install
@@ -110,11 +113,10 @@ ncurses-devel_package() {
 	pkg_install() {
 		vmove "usr/bin/ncurses*-config"
 		vmove usr/include
-		vmove usr/lib/pkgconfig/ncursesw.pc
-		vmove usr/lib/pkgconfig/formw.pc
-		vmove usr/lib/pkgconfig/menuw.pc
-		vmove usr/lib/pkgconfig/ncurses++w.pc
-		vmove usr/lib/pkgconfig/panelw.pc
+		vmove "usr/lib/pkgconfig/ncurses*.pc"
+		vmove "usr/lib/pkgconfig/form*.pc"
+		vmove "usr/lib/pkgconfig/menu*.pc"
+		vmove "usr/lib/pkgconfig/panel*.pc"
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/libcurses*.so"
 		vmove "usr/lib/libform*.so"


### PR DESCRIPTION
Currently, there are symlinks to fool non-wide users into using the
proper .so/.a files, but pkg-config is unable to make use of them. This
installs the .pc files (which were already being generated). Fixes #32987

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [x] armv7l
  - [ ] armv6l-musl

