### PR TITLE
pycharm-community: update to 2021.2.2.

### DIFF
--- a/srcpkgs/pycharm-community/template
+++ b/srcpkgs/pycharm-community/template
@@ -1,6 +1,6 @@
 # Template file for 'pycharm-community'
 pkgname=pycharm-community
-version=2020.3.3
+version=2021.2.2
 revision=1
 archs="x86_64"
 depends="virtual?java-environment giflib libXtst hicolor-icon-theme"
@@ -9,7 +9,7 @@ maintainer="Felix Van der Jeugt <felix.vanderjeugt@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/pycharm/"
 distfiles="https://download-cf.jetbrains.com/python/${pkgname}-${version}.tar.gz"
-checksum=915a8803db2d47dd0c739da61034eb787f7c9e9e512ebcb02ea1a45cddbb055c
+checksum=5be617a97ab3bd26f0453a7b1e2193c5a042eade2f712f22ded43055ec983369
 repository=nonfree
 nopie=yes
 python_version=3
@@ -37,21 +37,15 @@ do_install() {
 	rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/ppc64le/libpty.so
 	rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/mips64el/libpty.so
 	rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/aarch64/libpty.so
+	rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/arm/libpty.so
 	rmdir -v ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/ppc64le
 	rmdir -v ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/mips64el
 	rmdir -v ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/aarch64
 
-	if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-		rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier
-		rm -vf ${DESTDIR}/usr/lib/pycharm/plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
-		rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86/libpty.so
-		rmdir -v ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86
-	else
-		rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier64
-		rm -vf ${DESTDIR}/usr/lib/pycharm/plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_amd64.so
-		rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86_64/libpty.so
-		rmdir -v ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86_64
-	fi
+	rm -vf ${DESTDIR}/usr/lib/pycharm/bin/fsnotifier
+	rm -vf ${DESTDIR}/usr/lib/pycharm/plugins/python-ce/helpers/pydev/pydevd_attach_to_process/attach_linux_x86.so
+	rm -vf ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86/libpty.so
+	rmdir -v ${DESTDIR}/usr/lib/pycharm/lib/pty4j-native/linux/x86
 
 	ln -sf /usr/lib/pycharm/bin/pycharm.sh ${DESTDIR}/usr/bin/pycharm
 	ln -sf /usr/lib/pycharm/bin/pycharm.png ${DESTDIR}/usr/share/pixmaps


### PR DESCRIPTION
Also:
- remove the arm subdir from the bundled pty4j
- remove unneeded block rm commands.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
