### PR TITLE
common/environment: set debug-prefix-map to prevent ccache cache misses

### DIFF
--- a/common/environment/build/debug-debug-prefix-map.sh
+++ b/common/environment/build/debug-debug-prefix-map.sh
@@ -1,0 +1,1 @@
+../configure/debug-debug-prefix-map.sh

--- a/common/environment/check/debug-debug-prefix-map.sh
+++ b/common/environment/check/debug-debug-prefix-map.sh
@@ -1,0 +1,1 @@
+../configure/debug-debug-prefix-map.sh

--- a/common/environment/configure/debug-debug-prefix-map.sh
+++ b/common/environment/configure/debug-debug-prefix-map.sh
@@ -1,0 +1,2 @@
+CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc=."
+CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc=."

--- a/common/environment/install/debug-debug-prefix-map.sh
+++ b/common/environment/install/debug-debug-prefix-map.sh
@@ -1,0 +1,1 @@
+../configure/debug-debug-prefix-map.sh

--- a/common/environment/patch/debug-debug-prefix-map.sh
+++ b/common/environment/patch/debug-debug-prefix-map.sh
@@ -1,0 +1,1 @@
+../configure/debug-debug-prefix-map.sh


### PR DESCRIPTION
Packages with debug symbols do invalidate their cache with every version
change since $wrksrc does contain the version number and is getting cached

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
