### PR TITLE
abiword: update to 3.0.5

### DIFF
--- a/srcpkgs/abiword/patches/fix-make-check.patch
+++ b/srcpkgs/abiword/patches/fix-make-check.patch
@@ -1,0 +1,33 @@
+From d49d714d8f4cff50681e7e3705ac05dccb785ed3 Mon Sep 17 00:00:00 2001
+From: Hubert Figuiere <hub@figuiere.net>
+Date: Fri, 17 Mar 2017 04:02:47 +0000
+Subject: [PATCH] Fix make check: disable valgrind. Disable widget test
+
+git-svn-id: svn+ssh://svn.abisource.com/svnroot/abiword/trunk@35408 bcba8976-2d24-0410-9c9c-aab3bd5fdfd6
+---
+ src/wp/test/unix/all_test_unix.h | 2 +-
+ src/wp/test/unix/testwrap.sh.in  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/wp/test/unix/all_test_unix.h b/src/wp/test/unix/all_test_unix.h
+index d1fbe7f7f9..1ce045bfa8 100644
+--- a/src/wp/test/unix/all_test_unix.h
++++ b/src/wp/test/unix/all_test_unix.h
+@@ -19,5 +19,5 @@
+ 
+ 
+ 
+-#include "src/af/xap/gtk/t/xap_UnixWidget.t.cpp"
++//#include "src/af/xap/gtk/t/xap_UnixWidget.t.cpp"
+ 
+diff --git a/src/wp/test/unix/testwrap.sh.in b/src/wp/test/unix/testwrap.sh.in
+index 3b27f2b69a..edbf0962cf 100755
+--- a/src/wp/test/unix/testwrap.sh.in
++++ b/src/wp/test/unix/testwrap.sh.in
+@@ -5,5 +5,5 @@ export G_DEBUG
+ G_SLICE=always-malloc
+ export G_SLICE
+ 
+-exec libtool --mode=execute @VALGRIND@ --leak-check=full --log-file=tf-vgdump ./AbiWord-test
++exec libtool --mode=execute ./AbiWord-test
+ 

--- a/srcpkgs/abiword/template
+++ b/srcpkgs/abiword/template
@@ -1,14 +1,13 @@
 # Template file for 'abiword'
 pkgname=abiword
-version=3.0.4
-revision=2
+version=3.0.5
+revision=1
 build_style=gnu-configure
-configure_args="--enable-plugins --enable-clipart --enable-templates
- --with-gtk3 $(vopt_enable goffice)"
+configure_args="--enable-plugins --enable-clipart --enable-templates"
 hostmakedepends="automake libtool flex pkg-config"
 makedepends="libjpeg-turbo-devel libpng-devel fribidi-devel libgsf-devel
  enchant2-devel librsvg-devel wv-devel boost-devel libxslt-devel
- libwmf-devel libchamplain-devel redland-devel libical-devel
+ libwmf-devel $(vopt_if champlain libchamplain-devel) redland-devel libical-devel
  libgcrypt-devel harfbuzz-devel $(vopt_if goffice goffice-devel)
  gtk+3-devel"
 depends="hicolor-icon-theme desktop-file-utils"
@@ -17,10 +16,10 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.abisource.com/"
 distfiles="${homepage}/downloads/${pkgname}/${version}/source/${pkgname}-${version}.tar.gz"
-checksum=e93096cb192e5bc19d62e180fc5eda643206465315a710113ae5036bc2a1a5d7
+checksum=1257247e9970508d6d1456d3e330cd1909c4b42b25e0f0a1bc32526d6f3a21b4
 
-build_options="goffice"
-build_options_default="goffice"
+build_options="goffice champlain"
+build_options_default="goffice champlain"
 
 CXXFLAGS="-std=c++11"
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
Configure flags --enable-goffice and --with-gtk3 are shown as unrecognized and not needed.
 
`libchamplain` pulls in clutter, which is kind of a bit much considering that, IMHO, the appeal of Abiword is that it doesn't come with the baggage of a complete office suite, so I made it a build option, enabled for now in the case that there are those who use the functionality.