### PR TITLE
pipe-viewer: depend on perl-HTML-Parser

### DIFF
--- a/srcpkgs/pipe-viewer/template
+++ b/srcpkgs/pipe-viewer/template
@@ -1,12 +1,12 @@
 # Template file for 'pipe-viewer'
 pkgname=pipe-viewer
 version=0.1.4
-revision=1
+revision=2
 build_style=perl-ModuleBuild
 configure_args="--gtk"
 hostmakedepends="perl-Module-Build"
 depends="perl-Data-Dump perl-JSON perl-LWP-Protocol-https perl-Term-ReadLine-Gnu
- perl-Unicode-LineBreak perl-JSON-XS"
+ perl-Unicode-LineBreak perl-JSON-XS perl-HTML-Parser"
 checkdepends="perl-Test-Pod"
 short_desc="Search and play videos from YouTube without an API key"
 maintainer="Roberto Ricci <ricci@disroot.org>"


### PR DESCRIPTION
Since abb67212933b358f3f4f118a0aa9d94517181156 this must be explicit.
Previously it was implicit through
perl-LWP-Protocol-https -> perl-LWP -> perl-HTTP-Message -> perl-HTML-Parser.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
