### PR TITLE
vivaldi: added xz as dependency

### DIFF
--- a/srcpkgs/vivaldi/template
+++ b/srcpkgs/vivaldi/template
@@ -5,7 +5,7 @@ revision=1
 _release=1
 archs="x86_64"
 hostmakedepends="curl python3-html2text python3-setuptools"
-depends="desktop-file-utils hicolor-icon-theme"
+depends="desktop-file-utils hicolor-icon-theme xz"
 short_desc="Advanced browser made with the power user in mind"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 # EULA: https://vivaldi.com/privacy/vivaldi-end-user-license-agreement/


### PR DESCRIPTION
Without xz, the update-ffmpeg script will fail and user won't be able to play proprietary codec. 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [X] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
