### PR TITLE
New package: libteam 1.31.git20210222

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4023,3 +4023,5 @@ libmt32emu.so.2 libmt32emu-2.5.1_1
 libqrtr-glib.so.0 libqrtr-glib-1.0.0_1
 libstemmer.so.2 libstemmer-2.1.0_1
 libdecor-0.so.0 libdecor-0.1.0_1
+libteam.so.5 libteam-1.31.git20210222_0
+libteamdctl.so.0 libteam-1.31.git20210222_0

--- a/srcpkgs/libteam/files/teamd.conf
+++ b/srcpkgs/libteam/files/teamd.conf
@@ -1,0 +1,14 @@
+{
+    "device": "team0",
+    "ports": {
+        "enp0s0": {
+            "link_watch": {
+                "name": "ethtool"
+            }
+        }
+    },
+    "runner": {
+        "name": "roundrobin"
+    }
+}
+

--- a/srcpkgs/libteam/files/teamd/run
+++ b/srcpkgs/libteam/files/teamd/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+[ -r conf ] && . ./conf
+exec teamd ${OPTS} -f ${CONF_FILE:-/etc/teamd.conf}

--- a/srcpkgs/libteam/template
+++ b/srcpkgs/libteam/template
@@ -1,0 +1,41 @@
+# Template file for 'libteam'
+pkgname=libteam
+version=1.31.git20210222
+revision=1
+archs="~*-musl" # always-enabled tipc needs non-musl sys/queue.h
+_githash=69a7494bb77dc10bb27076add07b380dbd778592
+wrksrc=libteam-${_githash}
+build_style=gnu-configure
+configure_args="--with-user=_teamd --with-group=_teamd"
+conf_files="/etc/teamd.conf"
+hostmakedepends="automake pkg-config libtool"
+makedepends="glib-devel libnl3-devel libdaemon-devel jansson-devel dbus-devel libcap-devel"
+short_desc="Ethernet teaming/bonding/aggregation service"
+maintainer="J Farkas <chexum+git@gmail.com>"
+license="LGPL-2.1-or-later"
+homepage="http://libteam.org/"
+distfiles="https://github.com/jpirko/libteam/archive/${_githash}.tar.gz"
+checksum=600005b5233d21914e0e93c8f548b95219ff37eda8e768b69c4e9be32347bf5b
+
+system_groups="_teamd"
+system_accounts="_teamd"
+_teamd_descr="teamd runtime user"
+_teamd_pgroup="_teamd"
+
+pre_configure() {
+	./autogen.sh
+}
+
+do_install() {
+	make ${makejobs} DESTDIR=${DESTDIR} install
+	vinstall teamd/dbus/teamd.conf 644 etc/dbus-1/system.d
+
+	vmkdir usr/share/examples/${pkgname}
+	for f in teamd/example_configs/*conf; do
+		vsconf "${f}"
+	done
+
+	vconf ${FILESDIR}/teamd.conf
+
+	vsv teamd
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

libteam, the user-space counterpart of the ethernet teaming/bonding device is the modern tool to provide link aggregation for ethernet devices.  Unfortunately, the most recent proper release misses a few important fixes, so I opted to use the git version instead of providing the patches from github.

It also has some incompatibility with musl, TIPC is always enabled, but it uses a header, sys/queue.h which does not seem to be provided by musl, so I disabled all musl platforms for the time being.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86-64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-glibc
  - [ ] aarch64-musl
  - [x] armv7l-glibc
  - [ ] armv6l-musl
-->
