### PR TITLE
New package: xandikos-0.2.8

### DIFF
--- a/srcpkgs/xandikos/template
+++ b/srcpkgs/xandikos/template
@@ -1,0 +1,22 @@
+# Template file for 'xandikos'
+pkgname=xandikos
+version=0.2.8
+revision=1
+build_style="python3-module"
+hostmakedepends="python3-setuptools"
+depends="python3-dulwich python3-defusedxml python3-icalendar python3-Jinja2 python3-aiohttp"
+checkdepends="python3-pytest $depends"
+short_desc="Lightweight CardDAV/CalDAV server that backs onto a Git repository"
+maintainer="Karel Balej <balejk@matfyz.cz>"
+license="GPL-3.0-or-later"
+homepage="https://www.xandikos.org"
+changelog="https://raw.githubusercontent.com/jelmer/xandikos/master/NEWS"
+distfiles="https://github.com/jelmer/xandikos/archive/refs/tags/v${version}.tar.gz"
+checksum="5da2016e93efd5314ea996f5fc0b2ed3b8ca745c7f08f0e6f77d4b5ab19f94fd"
+
+post_install() {
+	for i in examples/*
+	do
+		vsconf "$i"
+	done
+}


### PR DESCRIPTION
Xandikos is a lightweight yet complete CardDAV/CalDAV server that backs onto a Git repository.

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] aarch64
  - [ ] armv7l-musl
  - [ ] armv7l
