### PR TITLE
latte-dock: update to 0.10.2

### DIFF
--- a/srcpkgs/latte-dock/template
+++ b/srcpkgs/latte-dock/template
@@ -1,6 +1,6 @@
 # Template file for 'latte-dock'
 pkgname=latte-dock
-version=0.10.0
+version=0.10.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF -DENABLE_MAKE_UNIQUE=OFF
@@ -14,4 +14,4 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/latte-dock/"
 changelog="https://invent.kde.org/plasma/latte-dock/-/blob/master/CHANGELOG.md"
 distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=967e129b437a1eb3bff0b045674f06bfacb02f0040da39738b7fc95cb1417812
+checksum=29e2ce45894c4ec011c38471900e0c2141b441a3ff6333e102bd157eef8f276a


### PR DESCRIPTION
This is a hotfix needed to fix a segfault between latte-dock 0.10.0 and Plasma Frameworks 5.86.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
