### PR TITLE
discord-ptb: unbreak and update to 0.0.26

### DIFF
--- a/srcpkgs/discord-ptb/template
+++ b/srcpkgs/discord-ptb/template
@@ -1,18 +1,19 @@
 # Template file for 'discord-ptb'
 pkgname=discord-ptb
-version=0.0.25
+version=0.0.26
 revision=1
 archs="x86_64"
 wrksrc="DiscordPTB"
 hostmakedepends="w3m"
-depends="alsa-lib dbus-glib gtk+3 GConf libnotify nss libXtst libcxx libatomic"
-short_desc="Proprietary freeware VoIP application"
+depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
+ xdg-utils webrtc-audio-processing"
+short_desc="Chat and VoIP application (preview version)"
 maintainer="Abel Graham <abel@abelgraham.com>"
 license="custom:Proprietary"
 homepage="https://discord.com/"
 distfiles="https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz"
-checksum=41ac91f87651361816fa49e07c1f25334f9907df03e8b2e76d8d45e6757d5e20
-_license_checksum=9abbd207c86f76a59c0017c131dc7a30089c40b4dacb54a0f339272468344e1e
+checksum=04b33c73a4d55c476c8332bd86e50add6d984c965f0d4b5b759ccb0ebd3992e6
+_license_checksum=03580ea1297c38f31c4437555f2dbf9dae25a91c9e61391d7141cf8cc036aeff
 nopie=yes
 restricted=yes
 repository=nonfree
@@ -20,7 +21,7 @@ repository=nonfree
 post_extract() {
 	$XBPS_FETCH_CMD -o eula https://discord.com/terms; cat eula |
 		w3m -dump -I utf-8 -T text/html |
-		sed -n '/Discord Terms of Service/,/^Your place to talk$/p' > EULA
+		sed -n '/Discord Terms of Service/,/^Imagine a place$/p' > EULA
 
 	filesum="$(xbps-digest EULA)"
 	if [ "$filesum" != "$_license_checksum" ]; then
@@ -31,14 +32,14 @@ post_extract() {
 do_install() {
 	local package_location="usr/lib/$pkgname" item
 	vmkdir usr/share/pixmaps
-	vinstall discord.png 644 /usr/share/pixmap/ discord-ptb.png
+	vinstall discord.png 644 /usr/share/pixmaps/ discord-ptb.png
 	vmkdir usr/share/applications
 	vcopy discord-ptb.desktop /usr/share/applications/
 	vmkdir ${package_location}
 	for item in DiscordPTB chrome_100_percent.pak chrome_200_percent.pak \
 	icudtl.dat libEGL.so libGLESv2.so libffmpeg.so locales resources \
 	resources.pak snapshot_blob.bin swiftshader v8_context_snapshot.bin \
-	discord.png; do
+	discord.png chrome-sandbox libvk_swiftshader.so postinst.sh ; do
 		vcopy "${item}" "${package_location}"
 	done
 	vmkdir usr/bin


### PR DESCRIPTION
- Fix the dependencies (based on the discord package)
- Fix the EULA check (the terms webpage text was cut based on Discord's previous tagline)
- Fix a typo in the pixmap installation
- Update the EULA checksum
- Change the description based on the discord package

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
