### PR TITLE
moreutils: fix manpages

### DIFF
--- a/srcpkgs/moreutils/template
+++ b/srcpkgs/moreutils/template
@@ -1,9 +1,9 @@
 # Template file for 'moreutils'
 pkgname=moreutils
 version=0.66
-revision=1
+revision=2
 build_style=gnu-makefile
-make_build_args="DOCBOOK2XMAN=docbook2man"
+make_build_args="DOCBOOKXSL=/usr/share/xsl/docbook/"
 hostmakedepends="docbook2x"
 depends="perl perl-IPC-Run perl-TimeDate perl-Time-Duration"
 short_desc="Unix tools that nobody thought to write, when Unix was young"


### PR DESCRIPTION
`errno(1)` and some other manpages are broken. This PR fixes them.
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR