### PR TITLE
tree: fix manpage permissions

### DIFF
--- a/srcpkgs/tree/template
+++ b/srcpkgs/tree/template
@@ -1,7 +1,7 @@
 # Template file for 'tree'
 pkgname=tree
 version=1.8.0
-revision=1
+revision=2
 build_style=gnu-makefile
 short_desc="Resursive directory listing program"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
The `tree(1)` (or `/usr/share/man/man1/tree.1`) manpage is executable. This rebuild removes the executable permission.
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR