### PR TITLE
st: add ncurses to st-terminfo dependencies + minor fixes

### DIFF
--- a/srcpkgs/st/st-terminfo.REMOVE
+++ b/srcpkgs/st/st-terminfo.REMOVE
@@ -1,6 +1,9 @@
 case "${ACTION}" in
 pre)
 	rm usr/share/terminfo/s/st
+	rm usr/share/terminfo/s/st-bs
+	rm usr/share/terminfo/s/st-bs-256color
+	rm usr/share/terminfo/s/st-mono
 	rm usr/share/terminfo/s/st-meta
 	rm usr/share/terminfo/s/st-meta-256color
 	rm usr/share/terminfo/s/st-256color

--- a/srcpkgs/st/template
+++ b/srcpkgs/st/template
@@ -1,7 +1,7 @@
 # Template file for 'st'
 pkgname=st
 version=0.8.4
-revision=2
+revision=3
 build_style=gnu-makefile
 make_use_env=compliant
 hostmakedepends="pkg-config"
@@ -18,7 +18,7 @@ pre_build() {
 	sed -i 's|Liberation Mono|Monospace|g' config.def.h
 	[ -e ${FILESDIR}/config.h ] && cp ${FILESDIR}/config.h config.h
 	# We will use tic after install. See INSTALL.
-	sed -i '/tic/d' Makefile
+	vsed -i Makefile -e '/tic/d'
 }
 
 post_install() {
@@ -29,6 +29,7 @@ post_install() {
 
 st-terminfo_package() {
 	short_desc+=" - terminfo data"
+	depends="ncurses"
 	pkg_install() {
 		vmove usr/share/terminfo
 	}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
`st-terminfo.INSTALL` uses `tic`, but `st-terminfo` doesn't depend on `ncurses` (the provider of `tic`). This PR fixes that and it add some missing terminfo entries for removal to `st-terminfo.REMOVE`.
#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR