### PR TITLE
[RFC]: .github: improve the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,22 @@
-<!-- Mark items with [x] where applicable -->
+<!-- Uncomment relevant sections and delete options which are not applicable -->
 
-#### General
-- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)
-
-#### Have the results of the proposed changes been tested?
-- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
-- [ ] I generally don't use the affected packages but briefly tested this PR
+#### Testing the changes
+- I tested the changes in this PR: **YES**|**briefly**|**NO**
 
 <!--
-If GitHub CI cannot be used to validate the build result (for example, if the
-build is likely to take several hours), make sure to
-[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
-When skipping CI, uncomment and fill out the following section.
-Note: for builds that are likely to complete in less than 2 hours, it is not
-acceptable to skip CI.
+#### New package
+- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
+-->
+
+<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
+and test at least one native build and, if supported, at least one cross build.
+Ignore this section if this PR is not skipping CI.
 -->
 <!-- 
-#### Does it build and run successfully? 
-(Please choose at least one native build and, if supported, at least one cross build. More are better.)
-- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
-- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
-  - [ ] aarch64-musl
-  - [ ] armv7l
-  - [ ] armv6l-musl
+#### Local build testing
+- I built this PR locally for my native architecture, (ARCH-LIBC)
+- I built this PR locally for these architectures (if supported. mark crossbuilds):
+  - aarch64-musl
+  - armv7l
+  - armv6l-musl
 -->


### PR DESCRIPTION
Filling out the "Does it run and build successfully" section is
necessary only when the CI is skipped, but this is easy to miss.
Separate it from the rest of the text to make it clearer.

cc @ailiop-git