### PR TITLE
libsixel: update to 1.10.3, switch upstream

### DIFF
--- a/srcpkgs/libsixel/patches/unistd.patch
+++ b/srcpkgs/libsixel/patches/unistd.patch
@@ -1,0 +1,62 @@
+# Remove sys/unistd.h (will be included in next release)
+# https://github.com/libsixel/libsixel/commit/a8d60939d00af520e7139741b58928a9cc2c5f04
+diff --git a/converters/img2sixel.c b/converters/img2sixel.c
+index eeeccdf..5152fa9 100644
+--- a/converters/img2sixel.c
++++ b/converters/img2sixel.c
+@@ -28,7 +28,6 @@
+ #include <string.h>
+ 
+ # include <unistd.h>
+-# include <sys/unistd.h>
+ #include <sys/types.h>
+ # include <getopt.h>
+ # include <inttypes.h>
+diff --git a/meson.build b/meson.build
+index 6a243a3..6e47fcc 100644
+--- a/meson.build
++++ b/meson.build
+@@ -66,7 +66,6 @@ needed_headers = [
+   'string.h',
+   'unistd.h',
+   'stdint.h',
+-  'sys/unistd.h',
+   'getopt.h',
+   'sys/types.h',
+   'sys/stat.h',
+diff --git a/src/decoder.c b/src/decoder.c
+index 7619792..95803fa 100644
+--- a/src/decoder.c
++++ b/src/decoder.c
+@@ -26,7 +26,6 @@
+ # include <stdarg.h>
+ # include <string.h>
+ # include <unistd.h>
+-# include <sys/unistd.h>
+ #include <sys/types.h>
+ #include <sys/select.h>
+ # include <time.h>
+diff --git a/src/encoder.c b/src/encoder.c
+index 9fd289b..ea0714c 100644
+--- a/src/encoder.c
++++ b/src/encoder.c
+@@ -27,7 +27,6 @@
+ # include <stdarg.h>
+ #include <string.h>
+ # include <unistd.h>
+-# include <sys/unistd.h>
+ # include <sys/types.h>
+ # include <time.h>
+ # include <sys/time.h>
+diff --git a/src/tty.c b/src/tty.c
+index 92f9f8e..d020543 100644
+--- a/src/tty.c
++++ b/src/tty.c
+@@ -28,7 +28,6 @@
+ # include <sys/time.h>
+ # include <sys/types.h>
+ # include <unistd.h>
+-# include <sys/unistd.h>
+ # include <sys/select.h>
+ # include <errno.h>
+ # include <termios.h>

--- a/srcpkgs/libsixel/template
+++ b/srcpkgs/libsixel/template
@@ -1,15 +1,16 @@
 # Template file for 'libsixel'
 pkgname=libsixel
-version=1.8.6
+version=1.10.3
 revision=1
-build_style=gnu-configure
-makedepends="libpng-devel zlib-devel libjpeg-turbo-devel"
+build_style=meson
+hostmakedepends="pkg-config"
+makedepends="libjpeg-turbo-devel libpng-devel"
 short_desc="SIXEL encoder/decoder"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="MIT"
-homepage="https://github.com/saitoha/libsixel"
-distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=37611d60c7dbcee701346967336dbf135fdd5041024d5f650d52fae14c731ab9
+homepage="https://github.com/libsixel/libsixel"
+distfiles="https://github.com/libsixel/libsixel/archive/refs/tags/v${version}.tar.gz"
+checksum=028552eb8f2a37c6effda88ee5e8f6d87b5d9601182ddec784a9728865f821e0
 
 libsixel-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
