### PR TITLE
anope update to 2.0.10, orphan package

### DIFF
--- a/srcpkgs/anope/template
+++ b/srcpkgs/anope/template
@@ -1,19 +1,18 @@
 # Template file for 'anope'
 pkgname=anope
-version=2.0.7
-revision=2
-wrksrc="${pkgname}-${version}-source"
+version=2.0.10
+revision=1
 build_style=cmake
 make_cmd=make
 configure_args="-DINSTDIR=../install -DRUNGROUP=_anope -DDEFUMASK=077
  -DUSE_PCH=OFF"
 hostmakedepends="gettext"
 short_desc="Set of IRC Services designed for flexibility and ease of use"
-maintainer="ametisf <ametisf@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://www.anope.org/"
-distfiles="https://github.com/anope/anope/releases/download/${version}/anope-${version}-source.tar.gz"
-checksum=4507d6c127b3bc5a95414217049e01e2b605b1f817d5519b8e5d03acebc5dbab
+distfiles="https://github.com/anope/anope/archive/refs/tags/${version}.tar.gz"
+checksum=9ca27ca990c5e67e55a2f2541d05b20c06e612d8fccd89ad49be7dc825a0f0d2
 
 system_accounts="_anope"
 make_dirs="


### PR DESCRIPTION
I don't use anope anymore but I was asked if I could update it because of security fixes, I've bumped the version and confirmed it builds and runs but I don't have the setup anymore to test it more.

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc, runs)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl (cross build, didn't try running)
  - [x] armv7l (cross build, didn't try running)
  - [x] armv6l-musl (cross build, didn't try running)
