### PR TITLE
common/environment/setup: hide commit signature

### DIFF
--- a/common/environment/setup/git.sh
+++ b/common/environment/setup/git.sh
@@ -17,7 +17,7 @@ elif [ -z "${SOURCE_DATE_EPOCH}" ]; then
 	if [ -n "$basepkg" -a -z "$($XBPS_GIT_CMD -C ${XBPS_SRCPKGDIR}/${basepkg} ls-files template)" ]; then
 		export SOURCE_DATE_EPOCH="$(stat -c %Y ${XBPS_SRCPKGDIR}/${basepkg}/template)"
 	else
-		export SOURCE_DATE_EPOCH="$($XBPS_GIT_CMD -C ${XBPS_DISTDIR} log --pretty='%ct' -n1 HEAD)"
+		export SOURCE_DATE_EPOCH="$($XBPS_GIT_CMD -C ${XBPS_DISTDIR} log --no-show-signature --pretty='%ct' -n1 HEAD)"
 	fi
 fi
 


### PR DESCRIPTION
When using signed commits the signature needs to be removed/hidden to extract the date correctly.