### PR TITLE
arb: update to 2.21.0.

### DIFF
--- a/srcpkgs/arb/patches/450435a84a40acc1871cd84f1caf2ea47c11a18c.patch
+++ b/srcpkgs/arb/patches/450435a84a40acc1871cd84f1caf2ea47c11a18c.patch
@@ -1,0 +1,73 @@
+From 450435a84a40acc1871cd84f1caf2ea47c11a18c Mon Sep 17 00:00:00 2001
+From: fredrik <fredrik.johansson@gmail.com>
+Date: Tue, 28 Sep 2021 12:07:45 +0200
+Subject: [PATCH] fix (hopefully) spurious test failures for gamma_fmpq
+
+---
+ arb_hypgeom/gamma_fmpq.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/arb_hypgeom/gamma_fmpq.c b/arb_hypgeom/gamma_fmpq.c
+index 996a87e5..ee750d0d 100644
+--- a/arb_hypgeom/gamma_fmpq.c
++++ b/arb_hypgeom/gamma_fmpq.c
+@@ -529,22 +529,22 @@ arb_hypgeom_gamma_fmpq_outward(arb_t y, const fmpq_t x, slong prec)
+ 
+     if (q == 1 || q == 2 || q == 3 || q == 4 || q == 6)
+     {
+-        arb_hypgeom_gamma_small_frac(t, p, q, prec);
++        arb_hypgeom_gamma_small_frac(t, p, q, prec + 4 * (m != 0));
+     }
+     else
+     {
+-        arb_hypgeom_gamma_fmpq_hyp(t, a, prec);
++        arb_hypgeom_gamma_fmpq_hyp(t, a, prec + 4 * (m != 0));
+     }
+ 
+     /* argument reduction */
+     if (m >= 0)
+     {
+-        arb_rising_fmpq_ui(u, a, m, prec);
++        arb_rising_fmpq_ui(u, a, m, prec + 4);
+         arb_mul(y, t, u, prec);
+     }
+     else
+     {
+-        arb_rising_fmpq_ui(u, x, -m, prec);
++        arb_rising_fmpq_ui(u, x, -m, prec + 4);
+         arb_div(y, t, u, prec);
+     }
+ 
+@@ -602,7 +602,7 @@ arb_hypgeom_gamma_fmpq_taylor(arb_t y, const fmpq_t x, slong prec)
+     }
+ 
+     arb_set_fmpq(t, a, prec + 4);
+-    success = arb_hypgeom_gamma_taylor(t, t, 0, prec);
++    success = arb_hypgeom_gamma_taylor(t, t, 0, prec + 4);
+ 
+     if (success)
+     {
+@@ -611,12 +611,12 @@ arb_hypgeom_gamma_fmpq_taylor(arb_t y, const fmpq_t x, slong prec)
+ 
+         if (m >= 0)
+         {
+-            arb_rising_fmpq_ui(u, a, m, prec);
++            arb_rising_fmpq_ui(u, a, m, prec + 4);
+             arb_mul(y, t, u, prec);
+         }
+         else
+         {
+-            arb_rising_fmpq_ui(u, x, -m, prec);
++            arb_rising_fmpq_ui(u, x, -m, prec + 4);
+             arb_div(y, t, u, prec);
+         }
+ 
+@@ -684,7 +684,7 @@ arb_hypgeom_gamma_fmpq(arb_t y, const fmpq_t x, slong prec)
+         wp = (slong) fmpz_bits(fmpq_numref(x)) - (slong) fmpz_bits(fmpq_denref(x));
+         wp = FLINT_MAX(wp, 0);
+         wp = FLINT_MIN(wp, 4 * prec);
+-        wp += prec;
++        wp += prec + 4;
+ 
+         arb_set_fmpq(y, x, wp);
+ 

--- a/srcpkgs/arb/template
+++ b/srcpkgs/arb/template
@@ -1,6 +1,6 @@
 # Template file for 'arb'
 pkgname=arb
-version=2.20.0
+version=2.21.0
 revision=1
 build_style=configure
 configure_args="--prefix=/usr --with-gmp=/usr --with-mpfr=/usr --with-flint=/usr"
@@ -10,12 +10,9 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="LGPL-2.1-or-later"
 homepage="https://arblib.org"
 distfiles="https://github.com/fredrik-johansson/arb/archive/${version}.tar.gz"
-checksum=d2f186b10590c622c11d1ca190c01c3da08bac9bc04e84cb591534b917faffe7
+checksum=6493ebcfb1772458db4ca66da4c5536968484a3815cf75d2bb33c600b4471910
 
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	# on glibc this would give a conflict with function fdiv()
-	CFLAGS="-D_GNU_SOURCE" # needed for cpu_set_t
-fi
+CFLAGS="-D_GNU_SOURCE" # needed for cpu_set_t
 
 arb-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"


### PR DESCRIPTION
I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me

- Added a (temporary) patch to fix test on 32bit, already merged upstream, see https://github.com/fredrik-johansson/arb/issues/379
- conditional for musl not needed anymore after https://github.com/fredrik-johansson/arb/commit/c713d91280472d572fc43a64db43def73d650d11 (see https://github.com/fredrik-johansson/arb/pull/376)
