### PR TITLE
discord-ptb: change the maintainer

### DIFF
--- a/srcpkgs/discord-ptb/template
+++ b/srcpkgs/discord-ptb/template
@@ -8,7 +8,7 @@ hostmakedepends="w3m"
 depends="alsa-lib dbus-glib gtk+3 libnotify nss libXtst libcxx libatomic
  xdg-utils webrtc-audio-processing"
 short_desc="Chat and VoIP application (preview version)"
-maintainer="Abel Graham <abel@abelgraham.com>"
+maintainer="0x5c <dev@0x5c.io>"
 license="custom:Proprietary"
 homepage="https://discord.com/"
 distfiles="https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz"


### PR DESCRIPTION
I recently updated and unbroke the discord-ptb package. It is an application I use everyday, which I now need this package for as I am moving to Void.

I am ready to take the responsibility of maintaining the package, and for the following reasons, I propose this change in maintainers:

- The current maintainer has only contributed to this package
- The current maintainer has [last contributed to the repository in early 2018](https://github.com/void-linux/void-packages/commits/master?author=abel@abelgraham.com) (before the current github repository)
- There is no github account associated with the address in the commits
- The package seems to break often, with long periods of time before fixes

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
    (Metadata change)
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
