### PR TITLE
New package: jellyfin-media-player

### DIFF
--- a/srcpkgs/jellyfin-media-player/template
+++ b/srcpkgs/jellyfin-media-player/template
@@ -1,0 +1,28 @@
+# Template file for 'jellyfin-media-player'
+pkgname=jellyfin-media-player
+version=1.6.1
+revision=1
+_jwc_version=10.7.6
+create_wrksrc=yes
+build_wrksrc="${pkgname}-${version}"
+build_style=cmake
+configure_args="-DQTROOT='${XBPS_CROSS_BASE}/usr' -DCMAKE_BUILD_TYPE='Release'"
+hostmakedepends="pkg-config python3 qt5-qmake qt5-host-tools"
+makedepends="qt5-devel qt5-webchannel-devel qt5-declarative-devel qt5-webengine-devel
+ qt5-location-devel qt5-x11extras-devel SDL2-devel mpv-devel libcec-devel zlib-devel"
+depends="qt5-quickcontrols"
+short_desc="Desktop media client for Jellyfin"
+maintainer="Foxlet <foxlet@furcode.co>"
+license="GPL-2.0-only"
+homepage="https://github.com/jellyfin/jellyfin-media-player"
+distfiles="https://github.com/jellyfin/jellyfin-media-player/archive/refs/tags/v${version}.tar.gz>${pkgname}-${version}.tar.gz
+ https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-${_jwc_version}/dist.zip"
+checksum="3c3c91c96c0905ae5984f6d0c86f823807cfe7f1c6b3360350aa5afe8b84f8b0
+ eff3928a20e8123d35233ce82d2ef53e504004b767d98fe3b54e89ee83a2a5c6"
+
+post_extract() {
+	cd "${pkgname}-${version}"
+	mkdir -p build
+	cd build
+	cp -r "../../dist" .
+}

--- a/srcpkgs/jellyfin-media-player/template
+++ b/srcpkgs/jellyfin-media-player/template
@@ -1,8 +1,8 @@
 # Template file for 'jellyfin-media-player'
 pkgname=jellyfin-media-player
-version=1.6.1
+version=1.7.0
 revision=1
-_jwc_version=10.7.6
+_jwc_version=10.8.0
 create_wrksrc=yes
 build_wrksrc="${pkgname}-${version}"
 build_style=cmake
@@ -17,8 +17,8 @@ license="GPL-2.0-only"
 homepage="https://github.com/jellyfin/jellyfin-media-player"
 distfiles="https://github.com/jellyfin/jellyfin-media-player/archive/refs/tags/v${version}.tar.gz>${pkgname}-${version}.tar.gz
  https://github.com/iwalton3/jellyfin-web-jmp/releases/download/jwc-${_jwc_version}/dist.zip"
-checksum="3c3c91c96c0905ae5984f6d0c86f823807cfe7f1c6b3360350aa5afe8b84f8b0
- eff3928a20e8123d35233ce82d2ef53e504004b767d98fe3b54e89ee83a2a5c6"
+checksum="08cbe5ca660a1c14d05f71404dcca9c893a0a2aa4b31d5b69e04b203f577bbd4
+ 3fb94bd9ae827a3391c4d89efea9ada1e646d279b265b2e3abc9787560c954b5"
 
 post_extract() {
 	cd "${pkgname}-${version}"


### PR DESCRIPTION
A media client for Jellyfin-based servers. It provides hardware accelerated playback (using mpv) for video codecs that would otherwise not work inside a browser.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
