### PR TITLE
pulseaudio: enable glib schema installation

### DIFF
--- a/srcpkgs/pulseaudio/template
+++ b/srcpkgs/pulseaudio/template
@@ -1,11 +1,12 @@
 # Template file for 'pulseaudio'
 pkgname=pulseaudio
 version=15.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Djack=enabled -Dlirc=disabled -Dhal-compat=false -Dorc=enabled
  -Dgtk=disabled -Dsystemd=disabled -Dwebrtc-aec=enabled
- -Dbluez5=enabled -Dbluez5-ofono-headset=false -Dbluez5-native-headset=true
+ -Dgsettings=enabled -Dbluez5=enabled
+ -Dbluez5-ofono-headset=false -Dbluez5-native-headset=true
  -Delogind=enabled -Dudevrulesdir=/usr/lib/udev/rules.d
  -Dbashcompletiondir=/usr/share/bash-completion/completions"
 hostmakedepends="cmake m4 gettext libtool orc-devel perl-XML-Parser pkg-config


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->


`paprefs` relies on `org.freedesktop.pulseaudio.gschema.xml` being installed / compiled into `/usr/share/glib-2.0/schemas/` . 

```
(paprefs:8700): GLib-GIO-ERROR **: 13:13:47.730: Settings schema 'org.freedesktop.pulseaudio.module-group' is not installed
fish: Job 1, 'paprefs' terminated by signal SIGTRAP (Trace or breakpoint trap)
```
