### PR TITLE
opera: update to 80.0.4170.72, adopt.

### DIFF
--- a/srcpkgs/opera/template
+++ b/srcpkgs/opera/template
@@ -1,35 +1,33 @@
 # Template file for 'opera'
 pkgname=opera
 version=80.0.4170.72
-revision=1
+revision=2
 archs="x86_64"
+create_wrksrc=yes
+hostmakedepends="rpmextract"
 depends="ffmpeg desktop-file-utils hicolor-icon-theme"
 short_desc="Fast, secure, easy to use browser"
-maintainer="Diogo Leal <diogo@diogoleal.com>"
+maintainer="mobinmob <mobinmob@disroot.org>"
 license="custom:Proprietary"
 homepage="https://www.opera.com/computer"
-distfiles="http://get.geo.opera.com/pub/opera/desktop/${version}/linux/${pkgname}-stable_${version}_amd64.deb"
-checksum=f6b9e132c9cd2f7343ffb5fae1edb80a08087bac90ddb53d5fb2e475f834177a
+distfiles="https://rpm.opera.com/rpm/opera_stable-${version}-linux-release-x64-signed.rpm"
+checksum=3f3ece9bae6576b6ef5e2908733c112695ea535801bc6fb422b9fe7a79c097cc
 repository="nonfree"
 nostrip=yes
 
-do_extract() {
-	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname}-stable_${version}_amd64.deb
-	bsdtar xf data.tar.xz --exclude=./usr/share/{lintian,menu}
-}
-
 do_install() {
-	vmkdir /usr/lib
-	vcopy usr/lib/x86_64-linux-gnu/opera /usr/lib
+	# Create necessary dirs
+	vmkdir usr/bin
+	vmkdir usr/lib
 
-	vmkdir /usr/bin
-	ln -s ../lib/opera/opera ${DESTDIR}/usr/bin/opera
+	# Copy files
+	vcopy usr/lib64/opera /usr/lib/
+	vcopy usr/share /usr/share/
 
-	vlicense usr/share/doc/opera-stable/copyright
-	rm -rf usr/share/doc
+	# Link executable in path
+	ln -s ../lib/opera/opera "${DESTDIR}/usr/bin/opera"
 
-	vcopy usr/share /usr
-
-	# suid opera_sandbox
-	chmod 4755 ${DESTDIR}/usr/lib/opera/opera_sandbox
+	# Install licenses
+	vlicense usr/lib64/opera/resources/eula_desktop_eea.txt
+	vlicense usr/lib64/opera/resources/eula_desktop_row.txt
 }


### PR DESCRIPTION
Also:
 - change distfile to rpm (no need for do_extract() ).
 
 @diogoleal 

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
