### PR TITLE
flintlib: update to 2.8.1.

### DIFF
--- a/srcpkgs/flintlib/template
+++ b/srcpkgs/flintlib/template
@@ -1,17 +1,24 @@
 # Template file for 'flintlib'
 pkgname=flintlib
-version=2.8.0
+version=2.8.1
 revision=1
 wrksrc="flint-${version}"
 build_style=configure
-configure_args="--prefix=/usr --with-gmp=/usr --with-mpfr=/usr --with-ntl=/usr"
-makedepends="mpfr-devel ntl-devel"
+configure_args="--prefix=/usr --with-gmp=/usr --with-mpfr=/usr $(vopt_if ntl --with-ntl=/usr)"
+makedepends="mpfr-devel $(vopt_if ntl ntl-devel)"
 short_desc="Fast Library for Number Theory"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="LGPL-2.1-or-later"
 homepage="https://flintlib.org"
 distfiles="https://flintlib.org/flint-${version}.tar.gz"
-checksum=584235cdc39d779d9920eaef16fe084f3c26ffeeea003a3fff64a20a0f33449e
+checksum=edfdda7a7cb847db4e55e050349259cbc9778589686007fb45602d36ecfb427e
+
+build_options="ntl"
+desc_option_ntl="enable NTL support"
+
+if [ -z "$CROSS_BUILD" ]; then
+	build_options_default+=" ntl"
+fi
 
 CFLAGS="-D_GNU_SOURCE" # needed for cpu_set_t
 


### PR DESCRIPTION
Also: build without ntl when cross-compiling, since ntl is nocross.