### PR TITLE
ecm: update homepage and distfile url

### DIFF
--- a/srcpkgs/ecm/template
+++ b/srcpkgs/ecm/template
@@ -9,8 +9,8 @@ makedepends="gmp-devel libgomp-devel"
 short_desc="Elliptic Curve Method for Integer Factorization"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"
-homepage="http://ecm.gforge.inria.fr/"
-distfiles="https://gforge.inria.fr/frs/download.php/file/36224/ecm-${version}.tar.gz"
+homepage="https://gitlab.inria.fr/zimmerma/ecm"
+distfiles="https://gitlab.inria.fr/zimmerma/ecm/uploads/00c4c691a1ef8605b65bdf794a71539d/ecm-${version}.tar.gz"
 checksum=0cf7b3eee8462cc6f98b418b47630e1eb6b3f4f8c3fc1fb005b08e2a1811ba43
 
 # ppc64 asm only provided for BE and ELFv1, we're ELFv2 for BE and LE

--- a/srcpkgs/ecm/update
+++ b/srcpkgs/ecm/update
@@ -1,2 +1,2 @@
-site="http://ecm.gforge.inria.fr/"
-pattern="GMP-ECM \K[\d\.]*(?= has been released)"
+site="https://gitlab.inria.fr/zimmerma/ecm/-/tags"
+pattern='/archive/[^/]+/\Qecm\E(-git)?-v?\K[\d.]+(?=\.tar\.gz")'


### PR DESCRIPTION
It seems gforge.inria.fr is down (for good?).

This project has moved to gitlab.inria.fr and the original tarball is available there.
