### PR TITLE
xfe: update to 1.44

### DIFF
--- a/srcpkgs/xfe/patches/POTFILES.skip.patch
+++ b/srcpkgs/xfe/patches/POTFILES.skip.patch
@@ -1,0 +1,9 @@
+diff --git a/po/POTFILES.skip b/po/POTFILES.skip
+index 99658a9..8b98d52 100644
+--- a/po/POTFILES.skip
++++ b/po/POTFILES.skip
+@@ -3,3 +3,4 @@ xfe.desktop.in.in
+ xfi.desktop.in.in
+ xfp.desktop.in.in
+ xfw.desktop.in.in
++intl/plural.c

--- a/srcpkgs/xfe/template
+++ b/srcpkgs/xfe/template
@@ -1,14 +1,14 @@
 # Template file for 'xfe'
 pkgname=xfe
-version=1.43.2
+version=1.44
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool"
 makedepends="startup-notification-devel libpng-devel fox-devel xcb-util-devel"
 depends="desktop-file-utils"
-short_desc="The X File Explorer"
+short_desc="Lightweight file manager for X"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://roland65.free.fr/xfe/"
-distfiles="${SOURCEFORGE_SITE}/xfe/xfe-${version}.tar.gz"
-checksum=fa5f38fcac64b91eb5d615620a9607b7e6f8675c4f19f30473798b2acb0c85ba
+distfiles="${SOURCEFORGE_SITE}/xfe/xfe-${version}.tar.xz"
+checksum=594c14d185bdfc7e3132aefda7cf4e233625258ca9a1939359944a2c07c030b6


### PR DESCRIPTION
Also patch to ignore missing po file during check

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
I don't generally use this file manager, but I do sometimes put it on portable media installs to avoid installing a larger toolkit like gtk.  I can confirm that the new version runs and appears to behave as expected.

In case anyone does wonder, I changed the short description to be little more descriptive and so xlint doesn't complain.