### PR TITLE
salt: add contextvars dependency conditional

### DIFF
--- a/srcpkgs/salt/patches/requirements.patch
+++ b/srcpkgs/salt/patches/requirements.patch
@@ -1,0 +1,6 @@
+--- a/requirements/base.txt
++++ b/requirements/base.txt
+@@ -6,2 +6,2 @@
+ distro>=1.0.1
+-contextvars
++contextvars; python_version < "3.7"

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,7 +1,7 @@
 # Template file for 'salt'
 pkgname=salt
 version=3003.3
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-yaml python3-Jinja2 python3-requests python3-pyzmq


### PR DESCRIPTION
The recent update to 3003.3 broke the `salt` package.  This PR intends to fix it.
A description of the issue is in the saltstack repo https://github.com/saltstack/salt/issues/60483

tldr: contextvars is included in recent versions of python.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
