### PR TITLE
New package: digimend-kernel-drivers

### DIFF
--- a/srcpkgs/digimend-kernel-drivers/template
+++ b/srcpkgs/digimend-kernel-drivers/template
@@ -1,0 +1,23 @@
+# Template file for 'digimend-kernel-drivers'
+pkgname=digimend-kernel-drivers
+version=10
+revision=1
+depends="dkms"
+short_desc="Graphics tablet drivers for the Linux kernel"
+maintainer="Foxlet <foxlet@furcode.co>"
+license="GPL-2.0-only"
+homepage="https://github.com/DIGImend/digimend-kernel-drivers"
+distfiles="https://github.com/DIGImend/digimend-kernel-drivers/archive/v${version}.tar.gz"
+checksum=3f4c1e2f66b2c1b12a0895dfdf0fe567381ea92cfe7d62ab4645242dd4e98152
+dkms_modules="digimend ${version}"
+
+do_install() {
+	vmkdir usr/src/digimend-${version}
+	vcopy Makefile usr/src/digimend-${version}
+	vcopy dkms.conf usr/src/digimend-${version}
+	vcopy usbhid usr/src/digimend-${version}
+	vcopy "*.c" usr/src/digimend-${version}
+	vcopy "*.h" usr/src/digimend-${version}
+
+	make DESTDIR="${DESTDIR}/usr" udev_rules_install_files
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
Adds a DKMS module with support for graphics tablets whose drivers have not been upstreamed yet.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR