### PR TITLE
New package: TrenchBroom-2021.1

### DIFF
--- a/srcpkgs/TrenchBroom/files/README.voidlinux
+++ b/srcpkgs/TrenchBroom/files/README.voidlinux
@@ -1,0 +1,8 @@
+TrenchBroom currently does not support wayland.
+If you normally run QT applications using
+
+	QT_QPA_PLATFORM=wayland
+
+you will need to run TrenchBroom like so:
+
+	QT_QPA_PLATFORM=xcb trenchbroom

--- a/srcpkgs/TrenchBroom/patches/musl.patch
+++ b/srcpkgs/TrenchBroom/patches/musl.patch
@@ -1,0 +1,51 @@
+--- a/lib/vecmath/include/vecmath/scalar.h	2021-10-27 17:02:35.220565752 -0500
++++ -	2021-10-27 17:02:50.567780673 -0500
+@@ -27,6 +27,7 @@
+ #include <tuple>
+ #include <type_traits>
+ #include <utility>
++#include <cstdint>
+ 
+ namespace vm {
+     /**
+@@ -377,7 +378,7 @@
+      */
+     template <typename T>
+     constexpr T trunc(const T v) {
+-        return static_cast<T>(static_cast<int64_t>(v));
++        return static_cast<T>(static_cast<std::int64_t>(v));
+     }
+ 
+     /**
+--- a/common/src/TrenchBroomStackWalker.cpp	2021-03-15 12:54:02.000000000 -0500
++++ -	2021-10-29 17:05:18.439743183 -0500
+@@ -23,8 +23,10 @@
+ #include <QMutexLocker>
+ #endif
+ #else
++#if defined(__GLIBC__)
+ #include <execinfo.h>
+ #endif
++#endif
+ 
+ #include "TrenchBroomStackWalker.h"
+ 
+@@ -91,6 +93,7 @@
+     }
+ #endif
+ #else
++#if defined(__GLIBC__)
+     std::string TrenchBroomStackWalker::getStackTrace() {
+         const int MaxDepth = 256;
+         void *callstack[MaxDepth];
+@@ -109,5 +112,10 @@
+         free(strs);
+         return ss.str();
+     }
++#else
++    std::string TrenchBroomStackWalker::getStackTrace() {
++        return "";
++    }
++#endif
+ #endif
+ }

--- a/srcpkgs/TrenchBroom/template
+++ b/srcpkgs/TrenchBroom/template
@@ -1,0 +1,54 @@
+# Template file for 'TrenchBroom'
+pkgname=TrenchBroom
+version=2021.1
+revision=1
+archs="x86_64* i686*"
+wrksrc="${pkgname}-${version}"
+build_style=cmake
+hostmakedepends="git pandoc"
+makedepends="qt5-devel qt5-svg-devel glew-devel MesaLib-devel libfreeglut-devel
+ glm libXxf86vm-devel freeimage-devel freetype-devel libxcb-devel"
+short_desc="Cross-Platform Level Editor"
+maintainer="Kenneth Dodrill <hello@kennydodrill.com>"
+license="GPL-3.0-or-later"
+homepage="https://trenchbroom.github.io/"
+_vecmath_rev=15a858e9fff8030e895d2974244053ada67d30bb
+_Catch2_rev=7f21cc6c5599f59835f769debf13b4c3e6148a28
+_BinaryLibs_rev=bacae0b1b323bf99ea54055744e294d0fa085e53
+_fmt_rev=cc09f1a6798c085c325569ef466bcdcffdc266d4
+distfiles="https://github.com/TrenchBroom/TrenchBroom/archive/refs/tags/v${version}.tar.gz
+ https://github.com/TrenchBroom/vecmath/archive/${_vecmath_rev}.tar.gz
+ https://github.com/catchorg/Catch2/archive/${_Catch2_rev}.tar.gz
+ https://github.com/TrenchBroom/BinaryLibs/archive/${_BinaryLibs_rev}.tar.gz
+ https://github.com/fmtlib/fmt/archive/${_fmt_rev}.tar.gz"
+checksum="6b7fe4b906ecdb67ff52a70aeafaaf39c1fb6f64891f863483ee3fa5316ea7e6
+ f4b7475b8c1ad3b9bde90ad7b2629b3c893ee193f6dfaab1f156d3f290f0e419
+ 3c5a0147726e891d740a3f9de805e1d2f4fae57fbec4fbfb4d26fd9560e2604d
+ 20e5f96c7b8d4295c81b0641f2c2b0a66801d1c09ac708177cf74ab30a94fceb
+ f0da66d8f5949d78a6972f7f884310797b2dc422835a12fd3634697ec8c25acf"
+
+# Allows headless builds, otherwise receive an xcb error.
+export QT_QPA_PLATFORM=offscreen
+
+pre_patch() {
+	rmdir lib/vecmath
+	rmdir lib/Catch2
+	rmdir lib/BinaryLibs
+	rmdir lib/fmt
+
+	mv ../vecmath-${_vecmath_rev} lib/vecmath
+	mv ../Catch2-${_Catch2_rev} lib/Catch2
+	mv ../BinaryLibs-${_BinaryLibs_rev} lib/BinaryLibs
+	mv ../fmt-${_fmt_rev} lib/fmt
+}
+
+post_install() {
+	vinstall app/resources/linux/trenchbroom.desktop 644 usr/share/applications
+
+	for size in 8 16 22 24 32 36 42 48 64 72 96 128 192 256 512; do
+		vinstall app/resources/linux/icons/icon_${size}.png 644 \
+			 usr/share/icons/hicolor/${size}x${size}/apps/ trenchbroom.png
+	done
+
+	vdoc "${FILESDIR}/README.voidlinux"
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

https://github.com/TrenchBroom/TrenchBroom

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
- [x] I built this PR locally for my native architecture, x86_64
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] x86_64-musl - success, added patch
  - [x] armv7l - failed, see [here](https://github.com/TrenchBroom/TrenchBroom/issues/3651) afaik ARM is not supported because of this, but I'm not 100% sure. The error in the builder makes me think a lib is missing, but if that issue is correct - even if we get it working, I don't think the program loads correctly because of shader issues.
  - [x] i686 - success
  - [x] i686 (crossbuild) - failed, `CMake Error: AUTOMOC for target common: Test run of "moc" executable "/usr/i686-pc-linux-gnu/usr/lib/qt5/bin/moc" failed.` any help on this would be appreciated, but I'm not sure how required crossbuilding is for this.

See readme, TB will crash on wayland if `QT_QPA_PLATFORM` is set to `wayland`.

Closes https://github.com/void-linux/void-packages/issues/31317