### PR TITLE
pass-git-helper: update to 1.1.2.

### DIFF
--- a/srcpkgs/pass-git-helper/template
+++ b/srcpkgs/pass-git-helper/template
@@ -1,6 +1,6 @@
 # Template file for 'pass-git-helper'
 pkgname=pass-git-helper
-version=1.1.1
+version=1.1.2
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -11,4 +11,4 @@ maintainer="teldra <teldra@rotce.de>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/languitar/pass-git-helper"
 distfiles="https://github.com/languitar/${pkgname}/archive/v${version}.tar.gz"
-checksum=17a4c36d0fe67a7a4a709da3c0649d10efb02df266e62765661eac2ced4bc03d
+checksum=4acfb486d0873014376383167792ee2b46926386718eb2331a1b4564576a2076


### PR DESCRIPTION
#### Have the results of the proposed changes been tested?
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
