### PR TITLE
New package: pistol-0.3.2

### DIFF
--- a/srcpkgs/pistol/template
+++ b/srcpkgs/pistol/template
@@ -1,0 +1,18 @@
+# Template file for 'pistol'
+pkgname=pistol
+version=0.3.2
+revision=1
+build_style=go
+go_import_path=github.com/doronbehar/pistol/cmd/${pkgname}
+go_ldflags="-X 'main.Version=${version}'"
+makedepends="file-devel"
+short_desc="File previewer for command line file managers"
+maintainer="Daniel Lewan <vision360.daniel@gmail.com>"
+license="MIT"
+homepage="https://github.com/doronbehar/pistol"
+distfiles="https://github.com/doronbehar/pistol/archive/v${version}.tar.gz"
+checksum=7eaf196bbf9f8aaa78a9688ee8c13dbd5c91050e470526e052256a2dd35988d0
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

>Pistol is a file previewer for command line file managers such as Ranger, Lf and nnn, intended to replace the file previewer shell script scope.sh commonly used with Ranger and other previewing methods.

Closes: #33312

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
