### PR TITLE
New package: ntfs2btrfs

### DIFF
--- a/srcpkgs/ntfs2btrfs/patches/0001-Use-GNUInstallDirs-to-determine-sbin.patch
+++ b/srcpkgs/ntfs2btrfs/patches/0001-Use-GNUInstallDirs-to-determine-sbin.patch
@@ -1,0 +1,23 @@
+From f97247434ecda2cd2c451da5c73c3af98dfaea35 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Thu, 7 Oct 2021 17:59:35 +0100
+Subject: [PATCH] CMakeLists.txt: use GNUInstallDirs to determine sbin location
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cfaa571..17ded78 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,5 +89,5 @@ else()
+     target_compile_options(ntfs2btrfs PRIVATE -Wall -Wextra -Wno-address-of-packed-member -Wconversion -Wno-unknown-pragmas -Werror=pointer-arith)
+ endif()
+ 
+-install(TARGETS ntfs2btrfs DESTINATION sbin)
++install(TARGETS ntfs2btrfs DESTINATION ${CMAKE_INSTALL_SBINDIR})
+ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ntfs2btrfs.8 DESTINATION ${CMAKE_INSTALL_MANDIR}/man8)
+-- 
+2.33.0
+

--- a/srcpkgs/ntfs2btrfs/template
+++ b/srcpkgs/ntfs2btrfs/template
@@ -1,0 +1,14 @@
+# Template file for 'ntfs2btrfs'
+pkgname=ntfs2btrfs
+version=20210923
+revision=1
+build_style=cmake
+configure_args="-DCMAKE_INSTALL_SBINDIR=bin"
+hostmakedepends="pkg-config"
+makedepends="fmt-devel zlib-devel lzo-devel libzstd-devel"
+short_desc="Filesystem converter for Microsoft's NTFS"
+maintainer="Foxlet <foxlet@furcode.co>"
+license="GPL-2.0-only"
+homepage="https://github.com/maharmstone/ntfs2btrfs"
+distfiles="https://github.com/maharmstone/ntfs2btrfs/archive/${version}.tar.gz"
+checksum=e07cc1cad634d59e58111bf993683f02a7504913fac1ef8dd33fd06ebf9140c1


### PR DESCRIPTION
Filesystem conversion tool from NTFS to BTRFS (with rollback), useful for users migrating from Windows-based installations while preserving data.

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR