### PR TITLE
iio-sensor-proxy: move daemon back to /usr/bin; fix tests

### DIFF
--- a/srcpkgs/iio-sensor-proxy/template
+++ b/srcpkgs/iio-sensor-proxy/template
@@ -1,11 +1,12 @@
 # Template file for 'iio-sensor-proxy'
 pkgname=iio-sensor-proxy
 version=3.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsystemdsystemunitdir=false"
 hostmakedepends="gtk-doc pkg-config git gnome-common autoconf-archive glib-devel libtool"
 makedepends="libgudev-devel gtk+3-devel"
+checkdepends="dbus python3-dbus python3-psutil"
 short_desc="IIO accelerometer sensor to input device proxy"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-3.0-or-later"
@@ -13,6 +14,10 @@ homepage="https://gitlab.freedesktop.org/hadess/iio-sensor-proxy"
 distfiles="${homepage}/-/archive/${version}/${pkgname}-${version}.tar.gz"
 checksum=cc594a68707bc0700f073753681da60edfddfbe5088e25d336f265a1eb944b2f
 
+do_check() {
+	dbus-run-session ninja -C build test
+}
 post_install() {
 	vsv iio-sensor-proxy
+	mv $DESTDIR/usr/libexec/* $DESTDIR/usr/bin
 }


### PR DESCRIPTION
This fixes an issue where the sv service war unable to start. Also while at it, I fixed the tests for this package.