### PR TITLE
vsv: properly handle symlinks in vsv

### DIFF
--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -20,6 +20,7 @@ done
 _vsv() {
 	local service="$1"
 	local LN_OPTS="-s"
+	local svdir="${PKGDESTDIR}/etc/sv/${service}"
 
 	if [ $# -lt 1 ]; then
 		msg_red "$pkgver: vsv: 1 argument expected: <service>\n"
@@ -32,14 +33,18 @@ _vsv() {
 
 	vmkdir etc/sv
 	vcopy "${FILESDIR}/$service" etc/sv
-	chmod 755 ${PKGDESTDIR}/etc/sv/${service}/run
-	if [ -r ${PKGDESTDIR}/etc/sv/${service}/finish ]; then
-		chmod 755 ${PKGDESTDIR}/etc/sv/${service}/finish
+	if [ ! -L $svdir/run ]; then
+		chmod 755 $svdir/run
 	fi
-	ln ${LN_OPTS} /run/runit/supervise.${service} ${PKGDESTDIR}/etc/sv/${service}/supervise
-	if [ -r ${PKGDESTDIR}/etc/sv/${service}/log/run ]; then
-		chmod 755 ${PKGDESTDIR}/etc/sv/${service}/log/run
-		ln ${LN_OPTS} /run/runit/supervise.${service}-log ${PKGDESTDIR}/etc/sv/${service}/log/supervise
+	if [ -e $svdir/finish ] && [ ! -L $svdir/finish ]; then
+		chmod 755 $svdir/finish
+	fi
+	ln ${LN_OPTS} /run/runit/supervise.${service} $svdir/supervise
+	if [ -d $svdir/log ]; then
+		ln ${LN_OPTS} /run/runit/supervise.${service}-log $svdir/log/supervise
+		if [ -e $svdir/log/run ] && [ ! -L $svdir/log/run ]; then
+			chmod 755 ${PKGDESTDIR}/etc/sv/${service}/log/run
+		fi
 	fi
 }
 


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Fixes https://github.com/void-linux/void-packages/issues/32076.

I added `runit-void` to `hostmakedepends` of all packages where `log/run` pointed to `/usr/bin/vlogger`. I also added tests for -L to ensure that if there is a service file that is a dangling symlink, we error and exit.