### PR TITLE
php: patch to use enchant2

### DIFF
--- a/srcpkgs/php/patches/php-enchant2.patch
+++ b/srcpkgs/php/patches/php-enchant2.patch
@@ -1,0 +1,103 @@
+diff --git a/configure b/configure
+index 3ece7a4..b832a68 100755
+--- a/configure
++++ b/configure
+@@ -28123,19 +28123,19 @@ $as_echo "$ext_output" >&6; }
+ if test "$PHP_ENCHANT" != "no"; then
+ 
+ pkg_failed=no
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for enchant" >&5
+-$as_echo_n "checking for enchant... " >&6; }
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for enchant-2" >&5
++$as_echo_n "checking for enchant-2... " >&6; }
+ 
+ if test -n "$ENCHANT_CFLAGS"; then
+     pkg_cv_ENCHANT_CFLAGS="$ENCHANT_CFLAGS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"enchant\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "enchant") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"enchant-2\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "enchant-2") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_ENCHANT_CFLAGS=`$PKG_CONFIG --cflags "enchant" 2>/dev/null`
++  pkg_cv_ENCHANT_CFLAGS=`$PKG_CONFIG --cflags "enchant-2" 2>/dev/null`
+ 		      test "x$?" != "x0" && pkg_failed=yes
+ else
+   pkg_failed=yes
+@@ -28147,12 +28147,12 @@ if test -n "$ENCHANT_LIBS"; then
+     pkg_cv_ENCHANT_LIBS="$ENCHANT_LIBS"
+  elif test -n "$PKG_CONFIG"; then
+     if test -n "$PKG_CONFIG" && \
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"enchant\""; } >&5
+-  ($PKG_CONFIG --exists --print-errors "enchant") 2>&5
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"enchant-2\""; } >&5
++  ($PKG_CONFIG --exists --print-errors "enchant-2") 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; }; then
+-  pkg_cv_ENCHANT_LIBS=`$PKG_CONFIG --libs "enchant" 2>/dev/null`
++  pkg_cv_ENCHANT_LIBS=`$PKG_CONFIG --libs "enchant-2" 2>/dev/null`
+ 		      test "x$?" != "x0" && pkg_failed=yes
+ else
+   pkg_failed=yes
+@@ -28173,14 +28173,14 @@ else
+         _pkg_short_errors_supported=no
+ fi
+         if test $_pkg_short_errors_supported = yes; then
+-	        ENCHANT_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "enchant" 2>&1`
++	        ENCHANT_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "enchant-2" 2>&1`
+         else
+-	        ENCHANT_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "enchant" 2>&1`
++	        ENCHANT_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "enchant-2" 2>&1`
+         fi
+ 	# Put the nasty error message in config.log where it belongs
+ 	echo "$ENCHANT_PKG_ERRORS" >&5
+ 
+-	as_fn_error $? "Package requirements (enchant) were not met:
++	as_fn_error $? "Package requirements (enchant-2) were not met:
+ 
+ $ENCHANT_PKG_ERRORS
+ 
+diff --git a/ext/enchant/enchant.c b/ext/enchant/enchant.c
+index 6ce9d4b..1923726 100644
+--- a/ext/enchant/enchant.c
++++ b/ext/enchant/enchant.c
+@@ -738,7 +738,7 @@ PHP_FUNCTION(enchant_dict_quick_check)
+ 			for (i = 0; i < n_sugg; i++) {
+ 				add_next_index_string(sugg, suggs[i]);
+ 			}
+-			enchant_dict_free_suggestions(pdict->pdict, suggs);
++			enchant_dict_free_string_list(pdict->pdict, suggs);
+ 		}
+ 
+ 
+@@ -793,7 +793,7 @@ PHP_FUNCTION(enchant_dict_suggest)
+ 			add_next_index_string(return_value, suggs[i]);
+ 		}
+ 
+-		enchant_dict_free_suggestions(pdict->pdict, suggs);
++		enchant_dict_free_string_list(pdict->pdict, suggs);
+ 	}
+ }
+ /* }}} */
+@@ -813,7 +813,7 @@ PHP_FUNCTION(enchant_dict_add_to_personal)
+ 
+ 	PHP_ENCHANT_GET_DICT;
+ 
+-	enchant_dict_add_to_personal(pdict->pdict, word, wordlen);
++	enchant_dict_add(pdict->pdict, word, wordlen);
+ }
+ /* }}} */
+ 
+@@ -851,7 +851,7 @@ PHP_FUNCTION(enchant_dict_is_in_session)
+ 
+ 	PHP_ENCHANT_GET_DICT;
+ 
+-	RETURN_BOOL(enchant_dict_is_in_session(pdict->pdict, word, wordlen));
++	RETURN_BOOL(enchant_dict_is_added(pdict->pdict, word, wordlen));
+ }
+ /* }}} */
+ 

--- a/srcpkgs/php/template
+++ b/srcpkgs/php/template
@@ -1,9 +1,9 @@
 # Template file for 'php'
 pkgname=php
 version=7.4.14
-revision=6
+revision=7
 hostmakedepends="bison pkg-config apache-devel"
-makedepends="apache-devel enchant-devel freetds-devel freetype-devel gdbm-devel
+makedepends="apache-devel enchant2-devel freetds-devel freetype-devel gdbm-devel
  gmp-devel libcurl-devel libjpeg-turbo-devel libmariadbclient-devel
  libsodium-devel libtidy5-devel libxslt-devel libzip-devel net-snmp-devel
  postgresql-libs-devel readline-devel sqlite-devel unixodbc-devel pcre2-devel


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
Motivation is #27710. I think this is the only thing stopping us from moving enchant to enchant2.

~~This still needs to be tested~~, I have briefly tested this, but any help in that area is still appreciated.