### PR TITLE
Solaar: update to 1.0.7

### DIFF
--- a/srcpkgs/Solaar/INSTALL.msg
+++ b/srcpkgs/Solaar/INSTALL.msg
@@ -1,0 +1,3 @@
+To use Solaar without root privileges, copy the file
+    /usr/share/solaar/udev-rules.d/42-logitech-unify-permissions.rules
+into the directory /etc/udev/rules.d/ and reload udev rules.

--- a/srcpkgs/Solaar/template
+++ b/srcpkgs/Solaar/template
@@ -1,7 +1,7 @@
 # Template file for 'Solaar'
 pkgname=Solaar
-version=1.0.6
-revision=2
+version=1.0.7
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-pyudev python3-psutil python3-yaml python3-xlib"
@@ -10,6 +10,6 @@ maintainer="Young Jin Park <youngjinpark20@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://pwr-solaar.github.io/Solaar/"
 distfiles="https://github.com/pwr-Solaar/Solaar/archive/${version}.tar.gz"
-checksum=fb879136911978f8f0183262a86f2b47a50b1816516599ae9a6681ad1d9a4e49
+checksum=39c025b4186b6cb4620bc52d1d20e2d841082982c8be0fed155398faee7a9cd1
 # Package provides no tests
 make_check=no


### PR DESCRIPTION
Fixes #33422.

Solaar currently runs with the error message:
```
ERROR: Solaar depends on a udev file that is not present.
For more information see the Solaar installation directions
at https://pwr-solaar.github.io/Solaar/installation
```

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
