### PR TITLE
New package: font-juliamono-ttf-0.043

### DIFF
--- a/srcpkgs/font-juliamono-ttf/template
+++ b/srcpkgs/font-juliamono-ttf/template
@@ -1,0 +1,20 @@
+# Template file for 'font-juliamono-ttf'
+pkgname=font-juliamono-ttf
+version=0.043
+revision=1
+wrksrc="juliamono-${version}"
+depends="font-util xbps-triggers"
+short_desc="Monospaced font with reasonable Unicode support"
+maintainer="Gadzhi Kharkharov <me@kkga.me>"
+license="OFL-1.1"
+homepage="https://juliamono.netlify.app/"
+changelog="https://github.com/cormullion/juliamono/blob/master/CHANGELOG.md"
+distfiles="https://github.com/cormullion/juliamono/archive/refs/tags/v${version}.tar.gz"
+checksum=be49ac44b16de84a725eb3daf507aa3ee985a7bec352d5255d71b27228750df1
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir usr/share/fonts/TTF
+	install -m644 *.ttf ${DESTDIR}/usr/share/fonts/TTF
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General

- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

This font has a wide range of Unicode coverage (10000+ glyphs vs ~3300 in DejaVu Sans Mono).

#### Have the results of the proposed changes been tested?

- [ ] I use the packages affected by the proposed changes on a regular basis and
  confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!--
#### Does it build and run successfully?
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
