### PR TITLE
python3-frozendict: update to 2.0.6.

### DIFF
--- a/srcpkgs/python3-frozendict/patches/build-py.patch
+++ b/srcpkgs/python3-frozendict/patches/build-py.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 462ee99..c287130 100755
+--- a/setup.py
++++ b/setup.py
+@@ -157,7 +157,7 @@ common_setup_args = dict(
+     keywords = keywords,
+ )
+ 
+-custom_arg = None
++custom_arg = "py"
+ 
+ if len(argv) > 1 and (argv[1] == "py" or argv[1] == "c_debug"):
+     custom_arg = argv[1]

--- a/srcpkgs/python3-frozendict/template
+++ b/srcpkgs/python3-frozendict/template
@@ -1,19 +1,25 @@
 # Template file for 'python3-frozendict'
 pkgname=python3-frozendict
-version=1.2
-revision=4
+version=2.0.6
+revision=1
 wrksrc="frozendict-${version}"
 build_style=python3-module
-pycompile_module="frozendict"
 hostmakedepends="python3-setuptools"
 depends="python3"
+checkdepends="python3-pytest"
 short_desc="Immutable mapping for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="MIT"
-homepage="https://github.com/slezica/python-frozendict"
+license="LGPL-3.0-only"
+homepage="https://github.com/Marco-Sulla/python-frozendict"
 distfiles="${PYPI_SITE}/f/frozendict/frozendict-${version}.tar.gz"
-checksum=774179f22db2ef8a106e9c38d4d1f8503864603db08de2e33be5b778230f6e45
+checksum=3f00de72805cf4c9e81b334f3f04809278b967d2fed84552313a0fcce511beb1
 
-post_install() {
-	vlicense LICENSE.txt
+pre_patch() {
+	# remove c implementation tests
+	cd test
+	rm c_only.py
+	rm test_frozendict_c.py
+	rm test_frozendict_c_subclass.py
+	rm test_coold.py
+	rm test_coold_subclass.py
 }


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Bumping to latest version to fix this deprecation error on Python 3.10:
```
----> 1 import frozendict

/usr/lib/python3.10/site-packages/frozendict/__init__.py in <module>
     14 
     15 
---> 16 class frozendict(collections.Mapping):
     17     """
     18     An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`

AttributeError: module 'collections' has no attribute 'Mapping'
```