### PR TITLE
python3-mpmath: depend on python3-gmpy2

### DIFF
--- a/srcpkgs/python3-mpmath/INSTALL.msg
+++ b/srcpkgs/python3-mpmath/INSTALL.msg
@@ -1,4 +1,0 @@
-If you require plotting capabilities, install python3-matplotlib.
-
-mpmath internally uses Python's builtin long integers by default.
-For much faster high-precision arithmetic, install python3-gmpy2.

--- a/srcpkgs/python3-mpmath/template
+++ b/srcpkgs/python3-mpmath/template
@@ -1,14 +1,14 @@
 # Template file for 'python3-mpmath'
 pkgname=python3-mpmath
 version=1.2.1
-revision=2
+revision=3
 wrksrc="mpmath-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
-depends="python3"
+depends="python3 python3-gmpy2"
 checkdepends="python3-pytest"
 short_desc="Python3 library for arbitrary-precision floating-point arithmetic"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="BSD-3-Clause"
 homepage="http://mpmath.org/"
 distfiles="${PYPI_SITE}/m/mpmath/mpmath-${version}.tar.gz"


### PR DESCRIPTION
By default mpmath uses python's builtin long integers which are very
slow. Installing python3-gmpy2 makes it use gmp, mpfr, mpc for that,
which is asymptotically faster.

After #33481 it was agreed to add it to depends.

Also:
 - remove INSTALL.msg; for plotting, mpmath itself gives a warning.
 - Adopt.

[ci-skip] since this will fail before #33481 is merged, but nothing is really changed