### PR TITLE
yaru: update to 21.10.2, adopt.

### DIFF
--- a/srcpkgs/yaru/template
+++ b/srcpkgs/yaru/template
@@ -1,13 +1,14 @@
 # Template file for 'yaru'
 pkgname=yaru
-version=21.10.1
+version=21.10.2
 revision=1
 build_style=meson
+configure_args="-Dxfwm4=true"
 hostmakedepends="glib-devel sassc pkg-config"
 makedepends="gtk+3-devel libglib-devel"
 short_desc="Default Ubuntu 18.10+ theme"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="mobinmob <mobinmob@disroot.org>"
 license="GPL-3.0-or-later, CC-BY-SA-4.0"
 homepage="https://github.com/ubuntu/yaru"
 distfiles="https://github.com/ubuntu/yaru/archive/$version.tar.gz"
-checksum=8a79e37efed926ddad91532bfa95f9a833e4b843dfb7c100b70cc628b6b8edd3
+checksum=996e4a3e51d438dcb8ec63829de981d9c0a1a893c5553fd5c5a261c936cea551


### PR DESCRIPTION
Also:
- enable building the components for xfce.



https://github.com/void-linux/void-packages/pull/32086
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
