### PR TITLE
libgit2: update to 1.2.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1321,7 +1321,7 @@ libunwind-ppc64.so.8 libunwind-1.5.0_3
 libunwind-setjmp.so.0 libunwind-1.5.0_3
 libmicrohttpd.so.12 libmicrohttpd-0.9.73_1
 libmicrodns.so.1 libmicrodns-0.2.0_1
-libgit2.so.1.0 libgit2-1.0.1_3
+libgit2.so.1.2 libgit2-1.2.0_1
 libgit2-glib-1.0.so.0 libgit2-glib-0.23.4_1
 libagg.so.2 agg-2.5_1
 libzzip-0.so.13 zziplib-0.13.62_1

--- a/srcpkgs/DarkRadiant/template
+++ b/srcpkgs/DarkRadiant/template
@@ -1,7 +1,7 @@
 # Template file for 'DarkRadiant'
 pkgname=DarkRadiant
 version=2.13.0
-revision=2
+revision=3
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 hostmakedepends="pkg-config ruby-asciidoctor"

--- a/srcpkgs/Fritzing/template
+++ b/srcpkgs/Fritzing/template
@@ -1,7 +1,7 @@
 # Template file for 'Fritzing'
 pkgname=Fritzing
 version=0.9.3b
-revision=5
+revision=6
 _partshash=359eb1933622e4c4fa456ad043543681984a4d64 # 2018-03-14
 wrksrc="fritzing-app-${version}"
 build_style=qmake

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.2.1
-revision=5
+revision=6
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON
  -DBUILD_TESTING=OFF"

--- a/srcpkgs/cargo-outdated/template
+++ b/srcpkgs/cargo-outdated/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo-outdated'
 pkgname=cargo-outdated
 version=0.9.9
-revision=3
+revision=4
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="libgit2-devel openssl-devel"

--- a/srcpkgs/geany-plugins/template
+++ b/srcpkgs/geany-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'geany-plugins'
 pkgname=geany-plugins
 version=1.37.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="PYTHON=/usr/bin/python2 --enable-all-plugins --disable-devhelp
  --disable-webhelper --disable-debugger --disable-geanypy --disable-multiterm"

--- a/srcpkgs/git-absorb/template
+++ b/srcpkgs/git-absorb/template
@@ -1,7 +1,7 @@
 # Template file for 'git-absorb'
 pkgname=git-absorb
 version=0.6.6
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="libgit2-devel"

--- a/srcpkgs/git-series/template
+++ b/srcpkgs/git-series/template
@@ -1,7 +1,7 @@
 # Template file for 'git-series'
 pkgname=git-series
 version=0.9.1
-revision=13
+revision=14
 build_style=cargo
 hostmakedepends="cmake pkg-config perl"
 makedepends="libgit2-devel libcurl-devel"

--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-builder'
 pkgname=gnome-builder
 version=3.40.2
-revision=3
+revision=4
 build_style=meson
 build_helper=qemu
 configure_args="-Dwith_webkit=true -Dwith_sysprof=true -Dhelp=true -Dnetwork_tests=false"

--- a/srcpkgs/horizon/template
+++ b/srcpkgs/horizon/template
@@ -1,7 +1,7 @@
 # Template file for 'horizon'
 pkgname=horizon
 version=2.1.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="GOLD="
 make_install_target="install install-man"

--- a/srcpkgs/juCi++/template
+++ b/srcpkgs/juCi++/template
@@ -1,7 +1,7 @@
 # Template file for 'juCi++'
 pkgname=juCi++
 version=1.6.2
-revision=2
+revision=3
 _libclangmm_commit="b342f4dd6de4fe509a692a4b4fcfc7e24aae9590"
 _tiny_commit="c9c8bf810ddad8cd17882b9a9ee628a690e779f5"
 wrksrc="jucipp-v${version}"

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -1,7 +1,7 @@
 # Template file for 'julia'
 pkgname=julia
 version=1.6.1
-revision=1
+revision=2
 archs="i686* x86_64* armv7l* aarch64*"
 build_style=gnu-makefile
 make_build_args="prefix=/usr sysconfdir=/etc datarootdir=/usr/share
@@ -32,7 +32,7 @@ distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/juli
 checksum=71d8e40611361370654e8934c407b2dec04944cf3917c5ecb6482d6b85ed767f
 nocross="build system is a mess"
 # Targets for the vendored symlinks mentioned above
-shlib_requires="libgit2.so.1.0 libcurl.so.4 libmpfr.so.6 libgmp.so.10
+shlib_requires="libgit2.so.1.2 libcurl.so.4 libmpfr.so.6 libgmp.so.10
  libmbedcrypto.so.3 libmbedtls.so.12 libmbedx509.so.0 libpcre2-8.so.0
  libssh2.so.1 libquadmath.so.0 libnghttp2.so.14 libatomic.so.1 libssp.so.0"
 

--- a/srcpkgs/julia/template
+++ b/srcpkgs/julia/template
@@ -30,6 +30,10 @@ license="MIT"
 homepage="https://julialang.org"
 distfiles="https://github.com/JuliaLang/julia/releases/download/v${version}/julia-${version}-full.tar.gz"
 checksum=71d8e40611361370654e8934c407b2dec04944cf3917c5ecb6482d6b85ed767f
+# Checks is disabled due to issues in Unicode testset.
+# See discussion for more details:
+# https://github.com/void-linux/void-packages/pull/33535#issuecomment-946400216
+make_check=no
 nocross="build system is a mess"
 # Targets for the vendored symlinks mentioned above
 shlib_requires="libgit2.so.1.2 libcurl.so.4 libmpfr.so.6 libgmp.so.10

--- a/srcpkgs/ktexteditor/template
+++ b/srcpkgs/ktexteditor/template
@@ -1,7 +1,7 @@
 # Template file for 'ktexteditor'
 pkgname=ktexteditor
 version=5.87.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="
  -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"

--- a/srcpkgs/kup/template
+++ b/srcpkgs/kup/template
@@ -1,7 +1,7 @@
 # Template file for 'kup'
 pkgname=kup
 version=0.8.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules kdoctools qt5-qmake qt5-host-tools kcoreaddons gettext kconfig"
 makedepends="cmake qt5-devel kcoreaddons-devel ki18n-devel kio-devel ksolid-devel

--- a/srcpkgs/libgit2-glib/template
+++ b/srcpkgs/libgit2-glib/template
@@ -1,7 +1,7 @@
 # Template file for 'libgit2-glib'
 pkgname=libgit2-glib
 version=0.99.0.1
-revision=3
+revision=4
 build_style=meson
 build_helper="gir"
 configure_args="-Dintrospection=$(vopt_if gir true false)

--- a/srcpkgs/libgit2/patches/extern_git_remote_name_is_valid.patch
+++ b/srcpkgs/libgit2/patches/extern_git_remote_name_is_valid.patch
@@ -1,0 +1,58 @@
+From 27f50a66124054518d5febe984bccad02ee0846b Mon Sep 17 00:00:00 2001
+From: Miguel Arroz <750683+arroz@users.noreply.github.com>
+Date: Thu, 2 Sep 2021 18:59:19 -0700
+Subject: [PATCH 1/2] #6028: Check if `threadstate->error_t.message` is not
+ `git_buf__initbuf` before freeing.
+
+This follows the same principle as `buffer.c` where the same check is done before freeing the buffer. It fixes the crash described in #6028.
+---
+ src/threadstate.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/threadstate.c b/src/threadstate.c
+index 6031e8280..e2c08975f 100644
+--- a/src/threadstate.c
++++ b/src/threadstate.c
+@@ -36,7 +36,8 @@ static void threadstate_dispose(git_threadstate *threadstate)
+ 	if (!threadstate)
+ 		return;
+ 
+-	git__free(threadstate->error_t.message);
++    if (threadstate->error_t.message != git_buf__initbuf)
++        git__free(threadstate->error_t.message);
+ 	threadstate->error_t.message = NULL;
+ }
+ 
+-- 
+2.33.0
+
+
+From 62ee779ea4cdd877419571442860a0d29896a59c Mon Sep 17 00:00:00 2001
+From: lhchavez <lhchavez@lhchavez.com>
+Date: Sat, 4 Sep 2021 18:01:10 -0700
+Subject: [PATCH 2/2] remote: Mark `git_remote_name_is_valid` as `GIT_EXTERN`
+
+This change makes `git_remote_name_is_valid` be part of the public
+interface of the library. This is needed for other language bindings to
+be able to find this symbol (like in git2go, when linking against
+libgit2 dynamically).
+---
+ include/git2/remote.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/git2/remote.h b/include/git2/remote.h
+index 1f52fcd94..51a7d1cdc 100644
+--- a/include/git2/remote.h
++++ b/include/git2/remote.h
+@@ -971,7 +971,7 @@ GIT_EXTERN(int) git_remote_rename(
+  * @param remote_name name to be checked.
+  * @return 0 on success or an error code
+  */
+-int git_remote_name_is_valid(int *valid, const char *remote_name);
++GIT_EXTERN(int) git_remote_name_is_valid(int *valid, const char *remote_name);
+ 
+ /**
+ * Delete an existing persisted remote.
+-- 
+2.33.0
+

--- a/srcpkgs/libgit2/template
+++ b/srcpkgs/libgit2/template
@@ -1,7 +1,7 @@
 # Template file for 'libgit2'
 pkgname=libgit2
-version=1.0.1
-revision=3
+version=1.2.0
+revision=1
 build_style=cmake
 hostmakedepends="python3 git pkg-config"
 makedepends="zlib-devel openssl-devel http-parser-devel libssh2-devel"
@@ -10,7 +10,7 @@ maintainer="q66 <daniel@octaforge.org>"
 license="custom:GPL-2.0-or-later WITH GCC-exception-2.0"
 homepage="https://libgit2.org"
 distfiles="https://github.com/libgit2/libgit2/archive/v${version}.tar.gz"
-checksum=1775427a6098f441ddbaa5bd4e9b8a043c7401e450ed761e69a415530fea81d2
+checksum=701a5086a968a46f25e631941b99fc23e4755ca2c56f59371ce1d94b9a0cc643
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/slcp/template
+++ b/srcpkgs/slcp/template
@@ -1,7 +1,7 @@
 # Template file for 'slcp'
 pkgname=slcp
 version=0.2
-revision=12
+revision=13
 build_style=gnu-makefile
 makedepends="libgit2-devel"
 short_desc="Simple shell prompt written in C"

--- a/srcpkgs/stagit/template
+++ b/srcpkgs/stagit/template
@@ -1,7 +1,7 @@
 # Template file for 'stagit'
 pkgname=stagit
 version=0.9.5
-revision=1
+revision=2
 build_style=gnu-makefile
 make_install_args="MANPREFIX=/usr/share/man"
 makedepends="libgit2-devel"


### PR DESCRIPTION
Updated libgit2 to `v1.2.0`, added patch with PR
https://github.com/libgit2/libgit2/pull/6032 of
`git_remote_name_is_valid` fix for https://github.com/libgit2/git2go/issues/834 issue.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me: checked with tests of https://github.com/libgit2/git2go (`libgit2` is a dependency there)
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (ARCH-LIBC) (built, installed and tested)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
Ref: #28456
Maintainer: @q66 