### PR TITLE
netbsd-wtf wmutils-core: use alternatives for bin/wtf

### DIFF
--- a/srcpkgs/netbsd-wtf/template
+++ b/srcpkgs/netbsd-wtf/template
@@ -1,7 +1,7 @@
 # Template file for 'netbsd-wtf'
 pkgname=netbsd-wtf
 version=20180621
-revision=3
+revision=4
 _commit=b1e5be48e340146f63b174cc14fef892a783168b
 build_style=gnu-makefile
 short_desc="NetBSD's wtf(6) utility"
@@ -10,6 +10,7 @@ license="Public Domain"
 homepage="https://www.netbsd.org"
 distfiles="https://github.com/void-linux/netbsd-wtf/archive/$_commit.tar.gz"
 checksum=5da7c6c286673baa8cc0ce2840c16895eef3e884e038a6cb7dedabdd15753de7
+alternatives="wtf:/usr/bin/wtf:/usr/bin/netbsd-wtf"
 
 wrksrc="$pkgname-$_commit"
 make_build_args="PREFIX=/usr"

--- a/srcpkgs/wmutils-core/template
+++ b/srcpkgs/wmutils-core/template
@@ -1,7 +1,7 @@
 # Template file for 'wmutils-core'
 pkgname=wmutils-core
 version=1.5
-revision=1
+revision=2
 wrksrc="${pkgname##*-}-${version}"
 build_style=gnu-makefile
 make_use_env=yes
@@ -12,6 +12,7 @@ license="ISC"
 homepage="https://github.com/wmutils/core"
 distfiles="https://github.com/${pkgname%-*}/core/archive/v${version}.tar.gz"
 checksum=72af22ea52bc343bf90a6603ae3e169ed3c15f64635fa42507cc662ab04a6372
+alternatives="wtf:/usr/bin/wtf:/usr/bin/wmutils-wtf"
 conflicts="lsw"
 
 post_extract() {
@@ -23,4 +24,6 @@ post_extract() {
 
 post_install() {
 	vlicense LICENSE
+	mv ${DESTDIR}/usr/bin/{wtf,wmutils-wtf}
+	mv ${DESTDIR}/usr/share/man/man1/{wtf,wmutils-wtf}.1
 }


### PR DESCRIPTION
Avoid clash between two packages and let the user choose wtf they want.

<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
