### PR TITLE
xbps-src: improve error message on dependencies installation

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -69,8 +69,8 @@ setup_pkg_depends() {
 # -1     (255): unexpected error.
 
 install_pkg_from_repos() {
-    local cross="$1" rval tmplogf cmd
-    shift
+    local cross="$1" target="$2" rval tmplogf cmd
+    shift 2
 
     [ $# -eq 0 ] && return 0
 
@@ -91,7 +91,7 @@ install_pkg_from_repos() {
            ;;
         *)
            [ -z "$XBPS_KEEP_ALL" ] && remove_pkg_autodeps
-           msg_red "$pkgver: failed to install '$1' dependency! (error $rval)\n"
+           msg_red "$pkgver: failed to install $target dependencies! (error $rval)\n"
            cat $tmplogf
            rm -f $tmplogf
            msg_error "Please see above for the real error, exiting...\n"
@@ -411,7 +411,7 @@ install_pkg_deps() {
             echo "=> $pkgver: installing host dependencies: ${host_binpkg_deps[@]} ..."
             [[ $NOCOLORS ]] || printf "\033[m"
         fi
-        install_pkg_from_repos "" "${host_binpkg_deps[@]}"
+        install_pkg_from_repos "" host "${host_binpkg_deps[@]}"
     fi
 
     if [[ ${binpkg_deps} ]]; then
@@ -421,7 +421,7 @@ install_pkg_deps() {
             echo "=> $pkgver: installing target dependencies: ${binpkg_deps[@]} ..."
             [[ $NOCOLORS ]] || printf "\033[m"
         fi
-        install_pkg_from_repos "$cross" "${binpkg_deps[@]}"
+        install_pkg_from_repos "$cross" target "${binpkg_deps[@]}"
     fi
 
     return 0


### PR DESCRIPTION
Message contained one of many packages to install,
incorrectly suggesting that this is problematic one.
Remove that. List of packages is printed on previous line.