### PR TITLE
mpd: update to 0.23.2.

### DIFF
--- a/srcpkgs/mpd/template
+++ b/srcpkgs/mpd/template
@@ -1,6 +1,6 @@
 # Template file for 'mpd'
 pkgname=mpd
-version=0.22.11
+version=0.23.2
 revision=1
 build_style=meson
 configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
@@ -15,20 +15,22 @@ configure_args="-Dopus=enabled -Dmikmod=enabled -Dneighbor=true
  -Dsndio=$(vopt_if sndio enabled disabled) -Dpulse=$(vopt_if pulseaudio enabled disabled)
  -Dwavpack=$(vopt_if wavpack enabled disabled) -Dcdio_paranoia=$(vopt_if cdio enabled disabled)
  -Dopenal=$(vopt_if openal enabled disabled) -Dshout=$(vopt_if shoutcast enabled disabled)
- -Dio_uring=$(vopt_if io_uring enabled disabled)"
+ -Dio_uring=$(vopt_if io_uring enabled disabled) -Dopenmpt=$(vopt_if openmpt enabled disabled)
+ -Dpipewire=$(vopt_if pipewire enabled disabled)"
 conf_files="/etc/mpd.conf"
 hostmakedepends="pkg-config python3-Sphinx"
 makedepends="avahi-glib-libs-devel boost-devel faad2-devel ffmpeg-devel
  libcurl-devel libid3tag-devel libmad-devel libmikmod-devel libmms-devel
  libmodplug-devel libmpdclient-devel libnfs-devel libsamplerate-devel
- libupnp-devel mpg123-devel opus-devel yajl-devel
- zziplib-devel libsoxr-devel audiofile-devel twolame-devel
- $(vopt_if io_uring 'liburing-devel')
+ libnpupnp-devel mpg123-devel opus-devel yajl-devel
+ zziplib-devel libsoxr-devel audiofile-devel twolame-devel fmt-devel
+ $(vopt_if io_uring 'liburing-devel') $(vopt_if pipewire 'pipewire-devel')
  $(vopt_if cdio 'libcdio-paranoia-devel') $(vopt_if shoutcast 'libshout-devel')
  $(vopt_if jack 'jack-devel') $(vopt_if lame 'lame-devel')
  $(vopt_if libao 'libao-devel') $(vopt_if mpcdec 'libmpcdec-devel')
  $(vopt_if pulseaudio 'pulseaudio-devel') $(vopt_if sndio 'sndio-devel')
- $(vopt_if wavpack 'wavpack-devel') $(vopt_if openal 'libopenal-devel')"
+ $(vopt_if wavpack 'wavpack-devel') $(vopt_if openal 'libopenal-devel')
+ $(vopt_if openmpt 'libopenmpt-devel')"
 depends="libcap-progs"
 checkdepends="gtest-devel"
 short_desc="Flexible, powerful, server-side application for playing music"
@@ -37,7 +39,7 @@ license="GPL-2.0-or-later"
 homepage="https://www.musicpd.org/"
 changelog="https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/master/NEWS"
 distfiles="https://www.musicpd.org/download/mpd/${version%.*}/mpd-${version}.tar.xz"
-checksum=143f7f34aaee6e87888f3dd35d49aade6656052651b960ca42b46cbb518ca0a0
+checksum=74ec75689746baaeab7c65d70019f96f70b31b658cb25cfd2ebcca03f65acddf
 LDFLAGS="-Wl,-z,stack-size=1048576"
 
 system_accounts="mpd"
@@ -49,11 +51,14 @@ make_dirs="
  /var/lib/mpd/playlists 0755 mpd mpd"
 
 # Package build options
-build_options="jack lame mpcdec pulseaudio libao wavpack sndio cdio openal shoutcast io_uring"
+build_options="jack lame mpcdec pulseaudio libao wavpack sndio cdio openal shoutcast io_uring
+	openmpt pipewire"
 desc_option_cdio="Enable libcdio_paranoia input plugin"
 desc_option_openal="Enable OpenAL output plugin"
 desc_option_io_uring="Enable support for using liburing"
-build_options_default="jack pulseaudio libao sndio cdio shoutcast"
+desc_option_pipewire="Enable Pipewire output plugin"
+desc_option_openmpt="Enable OpenMPT decoder plugin"
+build_options_default="jack pulseaudio libao sndio cdio shoutcast pipewire"
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtest=true"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl

#### Notes

Will probably need some help with this. From the [changelog](https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/master/NEWS), the new things are:

- added fmt-devel as a makedepend
- changed makedepend from libupnp-devel to libnpupnp-devel
- openmpt decoder plugin: I have added openmpt as a build option disabled by default. I built mpd with the build option enabled and the build was successful. But I have no idea where to get mpmt files from to test this with.
- pipewire output plugin: Have added it as a build option that is **enabled by default**. Built using it and is working fine. Edit: Forgot to mention I have set the output to pipewire and it's working dandy.
- snapcast output plugin: This is enabled by default I think. ([Link to meson configuration.](https://github.com/MusicPlayerDaemon/MPD/blob/163c59128ef3182e739d83888afa1caefa8b9616/meson_options.txt#L184)) Doesn't need any makedepends other than yajl and avahi which were already included.