### PR TITLE
vscode: update to 1.61.1

### DIFF
--- a/srcpkgs/vscode/patches/disable-crash-reporter.patch
+++ b/srcpkgs/vscode/patches/disable-crash-reporter.patch
@@ -54,18 +54,5 @@ index ad838aa245e..e6319e100b9 100644
  // Set logs path before app 'ready' event if running portable
  // to ensure that no 'logs' folder is created on disk at a
  // location outside of the portable directory
-diff --git a/src/vs/code/electron-main/app.ts b/src/vs/code/electron-main/app.ts
-index 1d71361b942..6452f501e34 100644
---- a/src/vs/code/electron-main/app.ts
-+++ b/src/vs/code/electron-main/app.ts
-@@ -992,7 +992,7 @@ export class CodeApplication extends Disposable {
- 			if (argvJSON['enable-crash-reporter'] === undefined) {
- 				const telemetryConfig = getTelemetryLevel(this.configurationService);
- 				const enableCrashReporterSetting = telemetryConfig >= TelemetryLevel.ERROR;
--				const enableCrashReporter = typeof enableCrashReporterSetting === 'boolean' ? enableCrashReporterSetting : true;
-+				const enableCrashReporter = typeof enableCrashReporterSetting === 'boolean' ? enableCrashReporterSetting : false;
- 				const additionalArgvContent = [
- 					'',
- 					'	// Allows to disable crash reporting.',
 -- 
 2.32.0

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,6 +1,6 @@
 # Template file for 'vscode'
 pkgname=vscode
-version=1.61.0
+version=1.61.1
 revision=1
 _electronver=13.3.0
 hostmakedepends="pkg-config python nodejs yarn tar git ripgrep"
@@ -11,7 +11,7 @@ maintainer="shizonic <realtiaz@gmail.com>"
 license="MIT"
 homepage="https://code.visualstudio.com/"
 distfiles="https://github.com/Microsoft/vscode/archive/${version}.tar.gz"
-checksum=68bff7284804054cdd38ae3984ecb2a23af86668e23ec2335440dc56a2d1e82a
+checksum=e0aadb434252fd5f7a2ebf979d7e4db138148327c641a0214725eae1c22459c3
 nocross=yes # x64 build does not cut it, it contains native code
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then


### PR DESCRIPTION
disable-crash-reporter.patch:
removed defunct part (which would yield false for `a < b === undefined`, but that can never happen as `<` will always yield a boolean value) -- the mistake was already made in the vscode code, we just adapted it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->