### PR TITLE
update_check/gnome: also check for 2.* and 4.* version

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -131,7 +131,7 @@ update_check() {
                 url="https://bitbucket.org/$pkgurlname/downloads"
                 rx='/(get|downloads)/(v?|\Q'"$pkgname"'\E-)?\K[\d.]+(?=\.tar)';;
             *ftp.gnome.org*|*download.gnome.org*)
-                : ${pattern="\Q$pkgname\E-\K(0|[13]\.[0-9]*[02468]|[4-9][0-9]+)\.[0-9.]*[0-9](?=)"}
+                : ${pattern="\Q$pkgname\E-\K([0-4]\.[0-9]*[02468]|[4-9][0-9]+)\.[0-9.]*[0-9](?=)"}
                 url="https://download.gnome.org/sources/$pkgname/cache.json";;
             *kernel.org/pub/linux/kernel/*)
                 rx=linux-'\K'${version%.*}'[\d.]+(?=\.tar\.xz)';;


### PR DESCRIPTION
Split from #33327.

- check for 2.* (example: `gtk+` currently misses version 2.24.33)
- check for 4.* (example: `gtk4` currently misses version 4.4.0)
- change check for 0.* to ignore devel (e.g. `vala` currently includes 0.53.2 which afaict should be ignored b/c it's development)

Maybe the `[0-4]` I added should be `[0-9]`, or `[0-9]+`.

CC: @paper42, also @sgn since I believe he made the last changes to this regexp. Feel free to redo and drop this PR as you see convenient.