### PR TITLE
Manual.md: require justification for make_check

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -605,8 +605,7 @@ patches to the package sources during `do_patch()`. Patches are stored in
 and `XBPS_MAKEJOBS` has no effect.
 
 - `make_check` Sets the cases in which the `check` phase is run.
-This option should usually be accompanied by a comment explaining why it was set, especially when
-set to `no`.
+This option has to be accompanied by a comment explaining why the tests fail.
 Allowed values:
   - `yes` (the default) to run if `XBPS_CHECK_PKGS` is set.
   - `extended` to run if `XBPS_CHECK_PKGS` is `full`.


### PR DESCRIPTION
Helps to decide if tests can be reenabled.

xlint can check that with https://github.com/Chocimier/xtools/commit/2c9348ee837703994d0f367a4bb478e6b08a519f

Alternatively, we could split make_check into per-current-value variables set to freeform text, then ban `=yes|on|1|true`  on make_check_*, nocross, lib32disabled etc.