### PR TITLE
automake: update to 1.16.5

### DIFF
--- a/srcpkgs/automake/template
+++ b/srcpkgs/automake/template
@@ -1,7 +1,7 @@
 # Template file for 'automake'
 # NOTE: also update common/environment/configure/automake when updating!
 pkgname=automake
-version=1.16.4
+version=1.16.5
 revision=1
 build_style=gnu-configure
 make_check_args="${makejobs}"
@@ -14,7 +14,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.gnu.org/software/automake"
 distfiles="${GNU_SITE}/$pkgname/$pkgname-$version.tar.xz"
-checksum=80facc09885a57e6d49d06972c0ae1089c5fa8f4d4c7cfe5baea58e5085f136d
+checksum=f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469
 
 pre_check() {
 	# taken from http://www.linuxfromscratch.org/lfs/view/development/chapter06/automake.html


### PR DESCRIPTION
and add a patch to restore previous am_cv_python_pythondir
and am_cv_python_pyexecdir behaviour

see #33559

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
