### PR TITLE
xcb-proto: adjust to automake 1.16.4 changes

### DIFF
--- a/srcpkgs/xcb-proto/patches/automake.patch
+++ b/srcpkgs/xcb-proto/patches/automake.patch
@@ -1,0 +1,15 @@
+Adjust to automake 1.16.4 changes
+
+Source:
+https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/merge_requests/25
+
+--- a/xcb-proto.pc.in	2020-10-09 00:29:51.000000000 +0200
++++ b/xcb-proto.pc.in	2021-10-17 08:41:54.133860291 +0200
+@@ -4,6 +4,7 @@
+ datadir=@datadir@
+ libdir=@libdir@
+ xcbincludedir=${pc_sysrootdir}@xcbincludedir@
++PYTHON_PREFIX=@PYTHON_PREFIX@
+ pythondir=${pc_sysrootdir}@pythondir@
+ 
+ Name: XCB Proto

--- a/srcpkgs/xcb-proto/template
+++ b/srcpkgs/xcb-proto/template
@@ -1,7 +1,7 @@
 # Template file for 'xcb-proto'
 pkgname=xcb-proto
 version=1.14.1
-revision=2
+revision=3
 wrksrc="xcbproto-${pkgname}-${version}"
 build_style=gnu-configure
 hostmakedepends="python3 automake"


### PR DESCRIPTION
This fixes `xcb-proto.pc`, see #33559.
The patch is approved upstream, but not merged, yet.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
