### PR TITLE
picard: fix typeerrors with python 3.10

### DIFF
--- a/srcpkgs/picard/patches/0001-Fix-TypeErrors-with-Python-3.10.patch
+++ b/srcpkgs/picard/patches/0001-Fix-TypeErrors-with-Python-3.10.patch
@@ -1,0 +1,64 @@
+From 1a462bf718f9fc4b24a0c8daefe5c7d547712ae9 Mon Sep 17 00:00:00 2001
+From: Louis Sautier <sautier.louis@gmail.com>
+Date: Fri, 27 Aug 2021 00:43:48 +0200
+Subject: [PATCH] Fix TypeErrors with Python 3.10
+
+Without these changes, running Picard with Python 3.10 results in errors
+such as:
+  File "./picard/ui/coverartbox.py", line 74, in __init__
+    self.shadow = self.shadow.scaled(w, h, QtCore.Qt.KeepAspectRatio, QtCore.Qt.SmoothTransformation)
+TypeError: arguments did not match any overloaded call:
+  scaled(self, int, int, aspectRatioMode: Qt.AspectRatioMode = Qt.IgnoreAspectRatio, transformMode: Qt.TransformationMode = Qt.FastTransformation): argument 1 has unexpected type 'float'
+  scaled(self, QSize, aspectRatioMode: Qt.AspectRatioMode = Qt.IgnoreAspectRatio, transformMode: Qt.TransformationMode = Qt.FastTransformation): argument 1 has unexpected type 'float'
+---
+ picard/ui/coverartbox.py | 2 +-
+ picard/ui/itemviews.py   | 6 +++---
+ picard/util/__init__.py  | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/picard/ui/coverartbox.py b/picard/ui/coverartbox.py
+index 2457de5f..cd0cce2a 100644
+--- a/picard/ui/coverartbox.py
++++ b/picard/ui/coverartbox.py
+@@ -136,7 +136,7 @@ class CoverArtThumbnail(ActiveLabel):
+             event.acceptProposedAction()
+ 
+     def scaled(self, *dimensions):
+-        return (self.pixel_ratio * dimension for dimension in dimensions)
++        return (round(self.pixel_ratio * dimension) for dimension in dimensions)
+ 
+     def show(self):
+         self.set_data(self.data, True)
+diff --git a/picard/ui/itemviews.py b/picard/ui/itemviews.py
+index cddbf50a..bb88e984 100644
+--- a/picard/ui/itemviews.py
++++ b/picard/ui/itemviews.py
+@@ -137,9 +137,9 @@ def get_match_color(similarity, basecolor):
+     c1 = (basecolor.red(), basecolor.green(), basecolor.blue())
+     c2 = (223, 125, 125)
+     return QtGui.QColor(
+-        c2[0] + (c1[0] - c2[0]) * similarity,
+-        c2[1] + (c1[1] - c2[1]) * similarity,
+-        c2[2] + (c1[2] - c2[2]) * similarity)
++        int(c2[0] + (c1[0] - c2[0]) * similarity),
++        int(c2[1] + (c1[1] - c2[1]) * similarity),
++        int(c2[2] + (c1[2] - c2[2]) * similarity))
+ 
+ 
+ class MainPanel(QtWidgets.QSplitter):
+diff --git a/picard/util/__init__.py b/picard/util/__init__.py
+index e47af34c..d12ef890 100644
+--- a/picard/util/__init__.py
++++ b/picard/util/__init__.py
+@@ -333,7 +333,7 @@ def throttle(interval):
+             else:
+                 decorator.args = args
+                 decorator.kwargs = kwargs
+-                QtCore.QTimer.singleShot(r, later)
++                QtCore.QTimer.singleShot(int(r), later)
+                 decorator.is_ticking = True
+             mutex.unlock()
+ 
+-- 
+2.32.0
+

--- a/srcpkgs/picard/template
+++ b/srcpkgs/picard/template
@@ -1,7 +1,7 @@
 # Template file for 'picard'
 pkgname=picard
 version=2.5
-revision=3
+revision=4
 wrksrc="${pkgname}-release-${version}"
 build_style=python3-module
 make_install_args="--disable-autoupdate"
@@ -10,6 +10,7 @@ makedepends="python3-devel"
 depends="python3-PyQt5-multimedia chromaprint python3-mutagen
  python3-dateutil python3-discid desktop-file-utils
  hicolor-icon-theme"
+checkdepends="python3-pytest $depends"
 short_desc="MusicBrainz's audio tagger"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
backport of 452bba954c30d5a642f03c02411529f511bda786 in the picard
upstream repository: https://github.com/metabrainz/picard

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] aarch64-glibc
  - [x] x86_64-musl