### PR TITLE
swirc: update to 3.3.2.

### DIFF
--- a/srcpkgs/swirc/template
+++ b/srcpkgs/swirc/template
@@ -1,6 +1,6 @@
 # Template file for 'swirc'
 pkgname=swirc
-version=3.3.1
+version=3.3.2
 revision=1
 build_style=configure
 configure_args="$(vopt_with notify libnotify)"
@@ -15,7 +15,7 @@ license="BSD-3-Clause, ISC, MIT"
 homepage="https://www.nifty-networks.net/swirc"
 changelog="https://raw.githubusercontent.com/uhlin/swirc/master/CHANGELOG.md"
 distfiles="https://www.nifty-networks.net/swirc/releases/${pkgname}-${version}.tgz"
-checksum="6066d3e31bb8d7930989586f7a8ade0a04901bc77befe2bcf58d99689d304685"
+checksum="9c61a2ad1f31d254c0ec1b64bbbf0b42d554cb58b40379bf3dc74ecce1d24c70"
 
 build_options="notify"
 


### PR DESCRIPTION
Swirc 3.3.2 out!
