### PR TITLE
python3-bluez: restore package, update to 0.23+20210920

### DIFF
--- a/srcpkgs/python3-bluez/template
+++ b/srcpkgs/python3-bluez/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-bluez'
+pkgname=python3-bluez
+version=0.23+20210920
+revision=1
+_commit=37d78880179b2a83e7052e0c2b9393499dd3b857
+wrksrc="pybluez-${_commit}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel libbluetooth-devel"
+depends="python3"
+short_desc="Python3 wrapper for the BlueZ Bluetooth stack"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://pybluez.readthedocs.io"
+distfiles="https://github.com/pybluez/pybluez/archive/${_commit}.tar.gz"
+checksum=4201616ce976742fb756baba91197c89f57061d62009875cc9d6459fcacee0bb
+make_check=no	# no tests and running setup.py test fails

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -258,7 +258,6 @@ replaces="
  python-xlib<0.29_1
  python3-Django<=3.0.7_2
  python3-SPARQLWrapper<=1.8.4_4
- python3-bluez<=0.23_2
  python3-grako<=3.99.9_7
  python3-keepalive<=0.5_6
  python3-pyPEG2<=2.15.2_7


### PR DESCRIPTION
Compilation with python 3.10 is fixed upstream as of 20210920.

This reverts commit 5957216.

Other changes
 - update to 20210920; one could _alternatively_ cherry pick the commits that fix the module for python 3.10, but it's more than one (37d7888 is enough to compile but there are other failures due to python 3.10 changes).
 - remove python3-devel from hostmakedepends.
 - add python3 to depends.
 - add make_check=no ; there are no tests and setup.py test fails.
 - adopt

#### General
- I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me

I have a script to read the battery level from my BT headset and it works with this update. This the only way I know how to do it.