### PR TITLE
mbuffer: update to 20211018

### DIFF
--- a/srcpkgs/mbuffer/template
+++ b/srcpkgs/mbuffer/template
@@ -1,6 +1,6 @@
 # Template file for 'mbuffer'
 pkgname=mbuffer
-version=20211004
+version=20211018
 revision=1
 build_style=gnu-configure
 hostmakedepends="which"
@@ -11,5 +11,5 @@ maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.maier-komor.de/mbuffer.html"
 distfiles="https://www.maier-komor.de/software/mbuffer/mbuffer-${version}.tgz"
-checksum=2a8b6b3466d41e6c0dde32ce09eec672525ca9a5cf4150b9a0e9f5c65ee89942
+checksum=e240c1e4e4ac14c28be8c660ec47d44ce16b1e8ec92aa907ad13004ffd5db6e3
 conf_files="/etc/mbuffer.rc"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

CHANGELOG:

20211018:
- fixes related to TCP timeout handling
- enhancement: support setting config file via env var MBUFFERRC
- documentation update

20211004:
- make TCPTimeout=0 disable the TCP timeout
- changed default TCP timeout from 10s to 100s
- TCP timeout now can be give with suffixes ms,s,min,h
- documented option for TCP timeout

