### PR TITLE
hexchat-python3: missing dependency & files

### DIFF
--- a/srcpkgs/hexchat/template
+++ b/srcpkgs/hexchat/template
@@ -1,7 +1,7 @@
 # Template file for 'hexchat'
 pkgname=hexchat
 version=2.16.0
-revision=2
+revision=3
 build_style=meson
 configure_args="-Ddbus=enabled -Dtls=enabled -Dwith-text=false
  -Dwith-perl=/usr/bin/perl -Dwith-python=python3
@@ -49,9 +49,10 @@ hexchat-perl_package() {
 hexchat-python3_package() {
 	lib32disabled=yes
 	short_desc+=" - Python3 plugin"
-	depends="${sourcepkg}-${version}_${revision}"
+	depends="${sourcepkg}-${version}_${revision} python3-cffi"
 	pkg_install() {
 		vmove usr/lib/hexchat/plugins/python.so
+		vmove usr/lib/hexchat/python
 	}
 }
 


### PR DESCRIPTION
- Was missing a dependency on python3-cffi
- The associated python module had been left
  in the main package.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR
I use hexchat (main package) daily, but found the bug in the plugin (subpackage) when attempting to try some python scripts. Now with the fix, the python plugin loads and behaves as expected.
<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
