### PR TITLE
New package: aspell-sk-2.01.2

### DIFF
--- a/srcpkgs/aspell-sk/template
+++ b/srcpkgs/aspell-sk/template
@@ -1,0 +1,13 @@
+# Template file for 'aspell-sk'
+pkgname=aspell-sk
+version=2.01.2
+revision=1
+wrksrc="aspell6-sk-${version%.*}-${version##*.}"
+build_style=configure
+hostmakedepends="aspell-devel which"
+short_desc="Slovak dictionary for aspell"
+maintainer="Ján Priner <jan@priner.net>"
+license="LGPL-2.1-only, GPL-2.0-only, MPL-1.1"
+homepage="http://aspell.net/"
+distfiles="${GNU_SITE}/aspell/dict/sk/aspell6-sk-${version%.*}-${version##*.}.tar.bz2"
+checksum=c6a80a2989c305518e0d71af1196b7484fda26fe53be4e49eec7b15b76a860a6

--- a/srcpkgs/aspell-sk/update
+++ b/srcpkgs/aspell-sk/update
@@ -1,0 +1,1 @@
+pattern="aspell6-sk-\K[\d.-]+(?=\.)"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [x] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

<!--
#### Does it build and run successfully? 
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

Different aspell dictionaries use completely different versioning schemes and usually contain dashes. Versions of void packages can't. I wasn't quite sure how to work around that, aspell-en and aspell-cs do it in different ways.

The `xbps-src update-check` doesn't quite work as i would hoped for,
2.01-2 doesn't compare as a newer version than 2.01-1. (and I believe that this is handled improperly in other aspell dict packages, cause they seem to compare one version with a dash against another where it's replaced with a dot)