### PR TITLE
stremio-shell: fix dependencies.

### DIFF
--- a/srcpkgs/stremio-shell/template
+++ b/srcpkgs/stremio-shell/template
@@ -1,7 +1,7 @@
 # Template file for 'stremio-shell'
 pkgname=stremio-shell
 version=4.4.142
-revision=1
+revision=2
 _singleapplication_hash=4aeac8fa3e7e96385ba556346ebb6020e35ffdd8
 _libmpv_hash=822a41a1087daf2911fc336fbd9509f962158fef
 build_style=qmake
@@ -9,7 +9,8 @@ hostmakedepends="qt5-host-tools qt5-qmake"
 makedepends="mpv-devel qt5-webview-devel qt5-webengine-devel
  qt5-declarative-devel qt5-webchannel-devel qt5-location-devel
  qt5-quickcontrols2-devel qt5-quickcontrols chromaprint-devel"
-depends="qt5-quickcontrols qt5-quickcontrols2 virtual?nodejs-runtime"
+depends="qt5-quickcontrols qt5-quickcontrols2 virtual?nodejs-runtime
+ qt5-webengine"
 short_desc="Hub for video content aggregation"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
qt5-webengine needs to be in depends.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
