### PR TITLE
dmd: update to 2.098.0

### DIFF
--- a/srcpkgs/dmd/template
+++ b/srcpkgs/dmd/template
@@ -1,6 +1,6 @@
 # Template file for 'dmd'
 pkgname=dmd
-version=2.095.0
+version=2.098.0
 revision=1
 create_wrksrc=yes
 hostmakedepends="dmd2.091 which"
@@ -15,14 +15,17 @@ distfiles="
  https://github.com/dlang/druntime/archive/v${version}.tar.gz>druntime-${version}.tar.gz
  https://github.com/dlang/phobos/archive/v${version}.tar.gz>phobos-${version}.tar.gz
  http://downloads.dlang.org/releases/2.x/${version}/dmd.${version}.linux.tar.xz"
-checksum="d8b54cdd885b86e2cc30ccb4ccc6923940b3bd79183b499889b86d34dd22621b
- f8d6346aa13bdc6ff893eb9d9e5aa5e8ff5efe97dbfd92f7ecd8db8172d0c04a
- f5c9606a988917a38b3b9a495c6da0d4e36b60beac8e805f6dea719d042d50d4
- 02853f8a4988f55dab5daa1e0e9910ea91905b85bcaa7a5ffd83079147dc7d93"
+checksum="437e7abae7f747ce8a027e512d2f98f0c27badd623347141c3f6fb0834d85ad0
+ f150400756c7940bc9d67a3ed7f89777e49b42a1ef2dff6f40727f83b3cea6f4
+ f91c6c7f2d5683af2804a183c287bf6991b99c49692759d7844e1919ca59e974
+ 1104e5e59fd47828b798d77a72be547bf086bba1d374a1855c6b5814c4db0145"
 conf_files="/etc/dmd.conf"
 provides="d-compiler-${version}_${revision}"
 conflicts="dmd-bootstrap dmd2.081 dmd2.091"
 nopie=yes
+# from no to very little distinction between host CC and target CC in
+# makefiles or build.d
+nocross="broken build system"
 disable_parallel_build=yes
 LDFLAGS="-lpthread"
 

--- a/srcpkgs/dtools/template
+++ b/srcpkgs/dtools/template
@@ -1,7 +1,7 @@
 # Template file for 'dtools'
 pkgname=dtools
 # keep this synchronized with libphobos and dmd
-version=2.095.0
+version=2.098.0
 revision=1
 wrksrc="tools-${version}"
 hostmakedepends="dmd"
@@ -12,7 +12,7 @@ maintainer="Auri <me@aurieh.me>"
 license="BSL-1.0"
 homepage="http://www.digitalmars.com/d/2.0/"
 distfiles="https://github.com/dlang/tools/archive/v${version}.tar.gz"
-checksum=7688c56285e098b91ec81a3efaaec6d236aa1a1736fe21797d3335175f8fea8c
+checksum=9466e62ed2cf80802158524fc4e7ff80cbefc0fadff23a8933f6f2892b42cb56
 
 do_build() {
 	# rdmd can't be built normally, is used to build others


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->
Also brings `dtools` up to date, as it is dependent on this version of `dmd`.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
- [X] I built this PR locally for my native architecture, (x86_64-glibc)

**Note:** even though the `dmd` template doesn't set `nocross`, the cross build is broken in the current void-packages version (and, by extension, this PR) due to a missing `libphobos2`, hence the draft status.