### PR TITLE
ncmpcpp: fix support for non-inode sockets

### DIFF
--- a/srcpkgs/ncmpcpp/patches/socket-inode.patch
+++ b/srcpkgs/ncmpcpp/patches/socket-inode.patch
@@ -1,0 +1,16 @@
+# Support sockets without a socket inode
+# https://github.com/ncmpcpp/ncmpcpp/commit/40e4f98ee896ea10967eb1c4323bb718331eabea
+diff --git a/src/mpdpp.cpp b/src/mpdpp.cpp
+index ccdee31d..9a92e5df 100644
+--- a/src/mpdpp.cpp
++++ b/src/mpdpp.cpp
+@@ -147,7 +147,7 @@ unsigned Connection::Version() const
+ void Connection::SetHostname(const std::string &host)
+ {
+ 	size_t at = host.find("@");
+-	if (at != std::string::npos)
++	if (at != 0 && at != std::string::npos)
+ 	{
+ 		m_password = host.substr(0, at);
+ 		m_host = host.substr(at+1);
+

--- a/srcpkgs/ncmpcpp/template
+++ b/srcpkgs/ncmpcpp/template
@@ -1,7 +1,7 @@
 # Template file for 'ncmpcpp'
 pkgname=ncmpcpp
 version=0.9.2
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args=" BOOST_LIB_SUFFIX= --enable-clock --enable-outputs
  --enable-unicode --enable-visualizer --with-curl --with-taglib --with-fftw"
@@ -9,7 +9,7 @@ hostmakedepends="pkg-config"
 makedepends="boost-devel fftw-devel icu-devel libcurl-devel libmpdclient-devel
  readline-devel taglib-devel"
 short_desc="Ncurses mpd client inspired by ncmpc"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://rybczak.net/ncmpcpp"
 distfiles="${homepage}/stable/ncmpcpp-${version}.tar.bz2"
@@ -19,7 +19,7 @@ checksum=faabf6157c8cb1b24a059af276e162fa9f9a3b9cd3810c43b9128860c9383a1b
 CXXFLAGS="-D_XOPEN_SOURCE=600"
 
 pre_configure() {
-	vsed -i '/^docdir/d' {,doc/}Makefile.in
+	vsed -e '/^docdir/d' -i {,doc/}Makefile.in
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
