### PR TITLE
util-linux: backport upstream fix for musl until next release

### DIFF
--- a/srcpkgs/util-linux/patches/chfn-flush-stdout-before-reading-stdin-and-fix-unini.patch
+++ b/srcpkgs/util-linux/patches/chfn-flush-stdout-before-reading-stdin-and-fix-unini.patch
@@ -1,0 +1,37 @@
+From 05907d0d9e7c85f33e168feab1eb36b464425054 Mon Sep 17 00:00:00 2001
+From: Lorenzo Beretta <vc.net.loreb@gmail.com>
+Date: Mon, 25 Oct 2021 14:06:00 +0200
+Subject: [PATCH] chfn: flush stdout before reading stdin and fix uninitialized
+ variable
+
+Same problem as described in https://github.com/karelzak/util-linux/pull/1481
+
+Signed-off-by: Lorenzo Beretta <vc.net.loreb@gmail.com>
+---
+ login-utils/chfn.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/login-utils/chfn.c b/login-utils/chfn.c
+index 2508e14c9..ece5cdce0 100644
+--- a/login-utils/chfn.c
++++ b/login-utils/chfn.c
+@@ -227,7 +227,7 @@ static char *ask_new_field(struct chfn_control *ctl, const char *question,
+ 			   char *def_val)
+ {
+ 	int len;
+-	char *buf;
++	char *buf = NULL; /* leave initialized to NULL or getline segfaults */
+ #ifndef HAVE_LIBREADLINE
+ 	size_t dummy = 0;
+ #endif
+@@ -242,6 +242,7 @@ static char *ask_new_field(struct chfn_control *ctl, const char *question,
+ 		if ((buf = readline(" ")) == NULL)
+ #else
+ 		putchar(' ');
++		fflush(stdout);
+ 		if (getline(&buf, &dummy, stdin) < 0)
+ #endif
+ 			errx(EXIT_FAILURE, _("Aborted."));
+-- 
+2.33.0
+

--- a/srcpkgs/util-linux/patches/chsh-fflush-stdout-before-reading-from-stdin.patch
+++ b/srcpkgs/util-linux/patches/chsh-fflush-stdout-before-reading-from-stdin.patch
@@ -1,0 +1,27 @@
+From 0a08200bd5664d1849e477f7f776ab4d13bb8422 Mon Sep 17 00:00:00 2001
+From: Lorenzo Beretta <vc.net.loreb@gmail.com>
+Date: Mon, 25 Oct 2021 15:28:02 +0200
+Subject: [PATCH] chsh: fflush stdout before reading from stdin
+
+Same problem as described in https://github.com/karelzak/util-linux/pull/1481
+
+Signed-off-by: Lorenzo Beretta <vc.net.loreb@gmail.com>
+---
+ login-utils/chsh.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/login-utils/chsh.c b/login-utils/chsh.c
+index 349712072..3b446beeb 100644
+--- a/login-utils/chsh.c
++++ b/login-utils/chsh.c
+@@ -210,6 +210,7 @@ static char *ask_new_shell(char *question, char *oldshell)
+ 	if ((ans = readline(" ")) == NULL)
+ #else
+ 	putchar(' ');
++	fflush(stdout);
+ 	if (getline(&ans, &dummy, stdin) < 0)
+ #endif
+ 		return NULL;
+-- 
+2.33.0
+

--- a/srcpkgs/util-linux/patches/vipw-flush-stdout-before-getting-answer.patch
+++ b/srcpkgs/util-linux/patches/vipw-flush-stdout-before-getting-answer.patch
@@ -1,0 +1,35 @@
+From 34a9b65587a7d704db0344e859511af4a6756c89 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=89rico=20Nogueira?= <erico.erc@gmail.com>
+Date: Fri, 22 Oct 2021 14:28:50 -0300
+Subject: [PATCH] vipw: flush stdout before getting answer.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Otherwise the question is displayed only after the user presses Return,
+and the program looks like it's hanging.
+
+This happens at least on musl libc.
+
+Reported by @loreb.
+
+Signed-off-by: Érico Nogueira <erico.erc@gmail.com>
+---
+ login-utils/vipw.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/login-utils/vipw.c b/login-utils/vipw.c
+index 8e63efde2..f59948a44 100644
+--- a/login-utils/vipw.c
++++ b/login-utils/vipw.c
+@@ -353,6 +353,7 @@ int main(int argc, char *argv[])
+ 		 * which means they can be translated. */
+ 		printf(_("Would you like to edit %s now [y/n]? "), orig_file);
+ 
++		fflush(stdout);
+ 		if (fgets(response, sizeof(response), stdin) &&
+ 		    rpmatch(response) == RPMATCH_YES)
+ 			edit_file(1);
+-- 
+2.33.0
+

--- a/srcpkgs/util-linux/template
+++ b/srcpkgs/util-linux/template
@@ -2,7 +2,7 @@
 # Keep this package sync with util-linux-common
 pkgname=util-linux
 version=2.37.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--exec-prefix=\${prefix} --enable-libuuid --disable-makeinstall-chown
  --enable-libblkid --enable-fsck --disable-rpath --enable-fs-paths-extra=/usr/sbin:/usr/bin


### PR DESCRIPTION
Fixes https://github.com/void-linux/void-packages/issues/33699

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ X] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ X] I built this PR locally for my native architecture, (x86_64-musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
