### PR TITLE
uwsgi: update to 2.0.20

### DIFF
--- a/srcpkgs/uwsgi/template
+++ b/srcpkgs/uwsgi/template
@@ -1,7 +1,7 @@
 # Template file for 'uwsgi'
 pkgname=uwsgi
-version=2.0.19.1
-revision=3
+version=2.0.20
+revision=1
 hostmakedepends="python3"
 makedepends="python3-devel"
 short_desc="Fast, self-healing application container server"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only WITH GCC-exception-2.0"
 homepage="http://projects.unbit.it/uwsgi"
 distfiles="https://github.com/unbit/uwsgi/archive/${version}.tar.gz"
-checksum=bf17cdbb9bd8bcb7c1633e34d9d7308cb4cc19eb0ff2d61057f840c1ba1fc41b
+checksum=88ab9867d8973d8ae84719cf233b7dafc54326fcaec89683c3f9f77c002cdff9
 
 _libdir=usr/lib/uwsgi
 


### PR DESCRIPTION
Fixes uwsgi-python3 not loading properly due to the removal of some deprecated APIs in Python 3.10.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64-musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
