### PR TITLE
nvimpager: update to 0.10.3

### DIFF
--- a/srcpkgs/nvimpager/template
+++ b/srcpkgs/nvimpager/template
@@ -1,6 +1,6 @@
 # Template file for 'nvimpager'
 pkgname=nvimpager
-version=0.10.2
+version=0.10.3
 revision=1
 build_style=gnu-makefile
 hostmakedepends="neovim scdoc"
@@ -10,7 +10,11 @@ maintainer="Adrian Herath <adrianisuru@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://github.com/lucc/nvimpager"
 distfiles="https://github.com/lucc/nvimpager/archive/v${version}.tar.gz"
-checksum=58d77fe301a6451098eef2677011cc99138c3735b34859a17cbaa6caba7e0ef4
+checksum=c369c75f3de0c95d8ceca5ab13deaae22626b08bcd2f98b2b42df85ca60d7609
+
+do_build() {
+	: # nothing to build
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

Besides updating to 0.10.3, this fixes a problem that occurred for me recently (probably from the 0.10.2 update): the script is configured via the makefile, inserting the `PREFIX` to pass the right paths to nvim. But the `gnu-makefile` build style only passes `PREFIX` during `do_install`, not during `do_build`. As the first non-wildcard target in the makefile is `install`, I just skipped `do_build`.
