### PR TITLE
kmod: add zstd module compression support

### DIFF
--- a/srcpkgs/kmod/template
+++ b/srcpkgs/kmod/template
@@ -1,11 +1,11 @@
 # Template file for 'kmod'
 pkgname=kmod
 version=29
-revision=1
+revision=2
 build_style=gnu-configure
-configure_args="--with-zlib --with-xz"
+configure_args="--with-zlib --with-xz --with-zstd"
 hostmakedepends="pkg-config"
-makedepends="zlib-devel liblzma-devel"
+makedepends="zlib-devel liblzma-devel libzstd-devel"
 make_dirs="
  /etc/depmod.d 0755 root root
  /etc/modprobe.d 0755 root root


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

This allows to compile kernel with `CONFIG_MODULE_COMPRESS_ZSTD=y` and load pre-compressed third-party modules.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
