### PR TITLE
mpv: update to 0.34.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3432,7 +3432,7 @@ libSoapySDR.so.0.7 SoapySDR-0.7.0_1
 libeditorconfig.so.0 editorconfig-0.12.2_1
 libcfitsio.so.9 cfitsio-3.480_1
 libapparmor.so.1 libapparmor-2.12.0_1
-libplacebo.so.72 libplacebo-2.72.0_1
+libplacebo.so.157 libplacebo-4.157.0_1
 libw2xc.so waifu2x-converter-cpp-5.2_1
 libnova-0.15.so.0 libnova-0.15.0_1
 libcue.so.2 libcue-2.2.0_1

--- a/srcpkgs/libplacebo/template
+++ b/srcpkgs/libplacebo/template
@@ -1,6 +1,6 @@
 # Template file for 'libplacebo'
 pkgname=libplacebo
-version=2.72.2
+version=4.157.0
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=meson
@@ -14,7 +14,12 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://code.videolan.org/videolan/libplacebo"
 distfiles="https://code.videolan.org/videolan/libplacebo/-/archive/v${version}/libplacebo-v${version}.tar.gz"
-checksum=5d3c51bb98d9727a255234a522f631f00d62a9e87115fb14251d991fc5076979
+checksum=8ee7773fb7813520b6b1e5f8f207cdf0071a7cf48ca0ce871e956ae6f4d0d538
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	LDFLAGS+=" -latomic"
+fi
 
 build_options="lcms opengl"
 build_options_default="lcms opengl"

--- a/srcpkgs/mpv/template
+++ b/srcpkgs/mpv/template
@@ -1,6 +1,6 @@
 # Template file for 'mpv'
 pkgname=mpv
-version=0.33.1
+version=0.34.0
 revision=1
 build_style=waf3
 configure_args="--confdir=/etc/mpv --docdir=/usr/share/examples/mpv
@@ -29,7 +29,7 @@ license="GPL-2.0-or-later"
 homepage="https://mpv.io"
 changelog="https://github.com/mpv-player/mpv/releases"
 distfiles="https://github.com/mpv-player/${pkgname}/archive/v${version}.tar.gz"
-checksum=100a116b9f23bdcda3a596e9f26be3a69f166a4f1d00910d1789b6571c46f3a9
+checksum=f654fb6275e5178f57e055d20918d7d34e19949bc98ebbf4a7371902e88ce309
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"

--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -1,7 +1,7 @@
 # Template file for 'vlc'
 pkgname=vlc
 version=3.0.16
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--disable-gme --disable-libtar --enable-jack
  --enable-live555 --disable-fluidsynth --enable-dvdread


### PR DESCRIPTION
Support for libplacebo older than v3.104.0 was dropped in https://github.com/mpv-player/mpv/commit/7c4465cefb27d4e0d07535d368febdf77b579566.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
