### PR TITLE
chroot-git: allow to fetch from http(s) remotes

### DIFF
--- a/srcpkgs/chroot-git/template
+++ b/srcpkgs/chroot-git/template
@@ -1,7 +1,7 @@
 # Template file for 'chroot-git'
 pkgname=chroot-git
 version=2.33.1
-revision=1
+revision=2
 bootstrap=yes
 wrksrc="git-${version}"
 makedepends="zlib-devel"
@@ -14,6 +14,7 @@ checksum=e054a6e6c2b088bd1bff5f61ed9ba5aa91c9a3cd509539a4b41c5ddf02201f2f
 
 if [ "$CHROOT_READY" ]; then
 	checkdepends="perl gnupg"
+	makedepends+=" libcurl-devel"
 fi
 
 do_configure() {
@@ -30,7 +31,6 @@ do_configure() {
 	NO_OPENSSL = Yes
 	USE_LIBPCRE :=
 	USE_LIBPCRE2 :=
-	NO_CURL = Yes
 	NO_EXPAT = Yes
 	NO_PERL = Yes
 	NO_PYTHON = Yes
@@ -50,12 +50,18 @@ do_configure() {
 		EOF
 	fi
 	if ! [ "$CHROOT_READY" ]; then
-		echo "ZLIB_PATH = ${XBPS_MASTERDIR}/usr" >>config.mak
+		cat <<-EOF >>config.mak
+		ZLIB_PATH = ${XBPS_MASTERDIR}/usr
+		NO_CURL = Yes
+		EOF
 	fi
 }
 
 do_build() {
 	make ${makejobs} git
+	if [ "$CHROOT_READY" ]; then
+		make ${makejobs} git-http-fetch git-remote-http
+	fi
 }
 
 do_check() {
@@ -68,4 +74,10 @@ do_install() {
 	ln -s ../../bin/chroot-git $DESTDIR/usr/libexec/chroot-git/git
 	ln -s git $DESTDIR/usr/libexec/chroot-git/git-upload-pack
 	ln -s git $DESTDIR/usr/libexec/chroot-git/git-receive-pack
+	if [ "$CHROOT_READY" ]; then
+		vinstall git-http-fetch 755 usr/libexec/chroot-git
+		vinstall git-remote-http 755 usr/libexec/chroot-git
+		ln -s git-remote-http \
+			$DESTDIR/usr/libexec/chroot-git/git-remote-https
+	fi
 }


### PR DESCRIPTION
libcurl has been part of stage2 chroot from a long time ago due to:

	binutils -> libdebuginfod -> libcurl

<!-- Mark items with [x] where applicable -->

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me