### PR TITLE
g810-led: install udev rules

### DIFF
--- a/srcpkgs/g810-led/template
+++ b/srcpkgs/g810-led/template
@@ -1,7 +1,7 @@
 # Template file for 'g810-led'
 pkgname=g810-led
 version=0.4.2
-revision=1
+revision=2
 build_style=gnu-makefile
 makedepends="hidapi-devel"
 short_desc="LED controller for Logitech G213,410,512,610,810,910,PRO keyboards"
@@ -18,6 +18,8 @@ do_install() {
 	done
 	vmkdir usr/lib
 	vcopy "lib/*.so.*" usr/lib
+	vmkdir usr/lib/udev/rules.d/70-g810-led.rules
+	vinstall udev/g810-led.rules 0644 usr/lib/udev/rules.d/70-g810-led.rules
 	vdoc README.md
 	vdoc INSTALL.md
 	for i in sample_profiles/*; do


### PR DESCRIPTION
This installs the udev rules for the g810-led package, so that the profile in /etc/g810/profile is automatically applied. Noticed this when moving stuff over from Arch, which installs the rules by default.

I'm new to this, and not sure now to really test this. I can't see the rules file in `masterdir` so I'm a bit confused. However, I built it successfully for a few architectures and ran the xbps-src test for aarch64 which all seemed to come up clean.

Should I install the package from this my repo somehow, to test it? Sorry if I missed that part in the docs.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->

#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (aarch64)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [ ] armv6l-musl

