### PR TITLE
gnome-tweaks: fix libhandy dependency

### DIFF
--- a/srcpkgs/gnome-tweaks/template
+++ b/srcpkgs/gnome-tweaks/template
@@ -1,11 +1,11 @@
 # Template file for 'gnome-tweaks'
 pkgname=gnome-tweaks
 version=40.0
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="gettext"
-depends="gtk+3 dconf gnome-settings-daemon mutter libnotify python3-gobject libhandy"
-short_desc="GNOME3 tool to customize advanced options"
+depends="gtk+3 dconf gnome-settings-daemon mutter libnotify python3-gobject libhandy1"
+short_desc="GNOME tool to customize advanced options"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later, CC0-1.0"
 homepage="https://wiki.gnome.org/Apps/Tweaks"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [x] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
The newest version requires libhandy >= 1.0