### PR TITLE
rdma-core: update to 37.1

### DIFF
--- a/srcpkgs/rdma-core/template
+++ b/srcpkgs/rdma-core/template
@@ -1,17 +1,17 @@
 # Template file for 'rdma-core'
 pkgname=rdma-core
-version=23.3
+version=37.1
 revision=1
 build_style=cmake
 configure_args="-DENABLE_VALGRIND=OFF"
-hostmakedepends="pkg-config python3"
-makedepends="libnl3-devel eudev-libudev-devel python3-devel"
+hostmakedepends="pandoc pkg-config python3 python3-docutils"
+makedepends="libnl3-devel eudev-libudev-devel python3-Cython python3-devel"
 short_desc="RDMA core userspace libraries and daemons"
-maintainer="Rich G <rich@richgannon.net>"
+maintainer="uhohspaghetios <rich@servermonkeys.com>"
 license="GPL-2.0-or-later, BSD-2-Clause-FreeBSD"
 homepage="https://github.com/linux-rdma/rdma-core"
 distfiles="https://github.com/linux-rdma/rdma-core/releases/download/v${version}/rdma-core-${version}.tar.gz"
-checksum=0afb7aa2654ea914c3b5d12e6e8f2fc3f325b0a52da1febf4f66788bf0b2bb14
+checksum=3ff6ff0592eb0ff92e829b39ea6eaf1365f9a9c401e8e2a17e1b915edc535cc2
 
 conf_files="
  /etc/iwpmd.conf


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->


Please confirm I did the hostmakedepends correctly with pandoc and python3-docutils, needed to build the manpages.  Installs and works on my RDMA-enabled storage cluster.