### PR TITLE
qemu: fix typo resulting in broken build when disabling Jack

### DIFF
--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -69,7 +69,7 @@ do_configure() {
 		want_sdl="--enable-sdl"
 		audio_sdl=",sdl"
 	fi
-	if [ $"build_option_jack" ]; then
+	if [ "$build_option_jack" ]; then
 		audio_jack=",jack"
 	fi
 


### PR DESCRIPTION
Oops 🥴
addresses part of #33728

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR
