### PR TITLE
qemu: fix `savevm` when using `-vga qxl`

### DIFF
--- a/srcpkgs/qemu/patches/savevm-qxl.patch
+++ b/srcpkgs/qemu/patches/savevm-qxl.patch
@@ -1,0 +1,37 @@
+From eb94846280df3f1e2a91b6179fc05f9890b7e384 Mon Sep 17 00:00:00 2001
+From: Gerd Hoffmann <kraxel@redhat.com>
+Date: Fri, 10 Sep 2021 11:42:03 +0200
+Subject: [PATCH] qxl: fix pre-save logic
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Oops.  Logic is backwards.
+
+Fixes: 39b8a183e2f3 ("qxl: remove assert in qxl_pre_save.")
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/610
+Resolves: https://bugzilla.redhat.com//show_bug.cgi?id=2002907
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Reviewed-by: Daniel P. Berrangé <berrange@redhat.com>
+Reviewed-by: Marc-André Lureau <marcandre.lureau@redhat.com>
+Message-Id: <20210910094203.3582378-1-kraxel@redhat.com>
+---
+ hw/display/qxl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/display/qxl.c b/hw/display/qxl.c
+index 43482d4364..29c80b4289 100644
+--- a/hw/display/qxl.c
++++ b/hw/display/qxl.c
+@@ -2252,7 +2252,7 @@ static int qxl_pre_save(void *opaque)
+     } else {
+         d->last_release_offset = (uint8_t *)d->last_release - ram_start;
+     }
+-    if (d->last_release_offset < d->vga.vram_size) {
++    if (d->last_release_offset >= d->vga.vram_size) {
+         return 1;
+     }
+ 
+-- 
+GitLab
+

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -2,7 +2,7 @@
 # This package should be updated together with qemu-user-static
 pkgname=qemu
 version=6.1.0
-revision=3
+revision=4
 build_style=configure
 hostmakedepends="gettext pkg-config perl python3 automake libtool flex
  python3-Sphinx python3-sphinx_rtd_theme texinfo ninja"


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

See <https://gitlab.com/qemu-project/qemu/-/commit/eb94846280df3f1e2a91b6179fc05f9890b7e384>, <https://gitlab.com/qemu-project/qemu/-/issues/610>.
I did not test because it would take ages to build on my machine, I hope someone can test it. Since it's a one-line fix I'm confident it will work.

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
