### PR TITLE
update xiate to new home and version

### DIFF
--- a/srcpkgs/xiate/template
+++ b/srcpkgs/xiate/template
@@ -1,7 +1,8 @@
 # Template file for 'xiate'
 pkgname=xiate
-version=18.05
+version=21.05
 revision=1
+wrksrc=xiate-v${version}
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="vte3-devel"
@@ -9,13 +10,11 @@ short_desc="Terminal emulator which uses VTE as a backend"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="MIT"
 homepage="https://www.uninformativ.de/projects/xiate/"
-distfiles="https://github.com/vain/xiate/archive/v${version}.tar.gz"
-checksum=2f7317cc71849cdbf31479be224f9ed20fce25d2fa8320885a5294ed2101411b
+distfiles="https://www.uninformativ.de/git/xiate/archives/xiate-v${version}.tar.gz"
+checksum=487dc53f48494e53a1db9aa36a1e04a594b207d7fcda84908e192bb4e706b7cb
 
 pre_configure() {
-	cp config.def.h config.h
-	[ -e ${FILESDIR}/config.h ] && cp ${FILESDIR}/config.h config.h
-	sed -i 's;/usr/local;/usr;g' Makefile
+	vsed -i 's;/usr/local;/usr;g' Makefile
 }
 
 post_install() {


### PR DESCRIPTION
This fixes https://github.com/void-linux/void-packages/issues/3549;
upstream is no longer using config.h, so we can simplify pre_configure.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ X] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ X] I built this PR locally for my native architecture, (x86_64-musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

I had to set $version to v21.05 (notice the extra 'v') because the tarball extracts to xiate-v21.05;
please let me know if there's a cleaner way.