### PR TITLE
firefox, firefox-esr, thunderbird: fix patch whitespace

### DIFF
--- a/srcpkgs/firefox-esr/patches/fix-i686-ppc-musl.patch
+++ b/srcpkgs/firefox-esr/patches/fix-i686-ppc-musl.patch
@@ -1,11 +1,11 @@
---- a/mozglue/misc/StackWalk.cpp	2017-04-11 04:13:21.000000000 +0200
-+++ b/mozglue/misc/StackWalk.cpp	2017-11-29 15:23:07.218649970 +0100
-@@ -41,7 +41,7 @@
- #define MOZ_STACKWALK_SUPPORTS_MACOSX 0
+--- a/mozglue/misc/StackWalk.cpp	2021-11-05 15:55:03.614609706 +0000
++++ b/mozglue/misc/StackWalk.cpp	2021-10-28 19:03:47.000000000 +0100
+@@ -45,7 +45,7 @@
+ #  define MOZ_STACKWALK_SUPPORTS_MACOSX 0
  #endif
- 
--#if (defined(linux) && \
+
+-#if (defined(linux) &&                                            \
 +#if defined(__GLIBC__) && (defined(linux) && \
       ((defined(__GNUC__) && (defined(__i386) || defined(PPC))) || \
        defined(HAVE__UNWIND_BACKTRACE)))
- #define MOZ_STACKWALK_SUPPORTS_LINUX 1
+ #  define MOZ_STACKWALK_SUPPORTS_LINUX 1

--- a/srcpkgs/firefox/patches/fix-i686-ppc-musl.patch
+++ b/srcpkgs/firefox/patches/fix-i686-ppc-musl.patch
@@ -1,11 +1,11 @@
---- a/mozglue/misc/StackWalk.cpp	2017-04-11 04:13:21.000000000 +0200
-+++ b/mozglue/misc/StackWalk.cpp	2017-11-29 15:23:07.218649970 +0100
-@@ -41,7 +41,7 @@
- #define MOZ_STACKWALK_SUPPORTS_MACOSX 0
+--- a/mozglue/misc/StackWalk.cpp	2021-11-05 15:55:03.614609706 +0000
++++ b/mozglue/misc/StackWalk.cpp	2021-10-28 19:03:47.000000000 +0100
+@@ -45,7 +45,7 @@
+ #  define MOZ_STACKWALK_SUPPORTS_MACOSX 0
  #endif
- 
--#if (defined(linux) && \
+
+-#if (defined(linux) &&                                            \
 +#if defined(__GLIBC__) && (defined(linux) && \
       ((defined(__GNUC__) && (defined(__i386) || defined(PPC))) || \
        defined(HAVE__UNWIND_BACKTRACE)))
- #define MOZ_STACKWALK_SUPPORTS_LINUX 1
+ #  define MOZ_STACKWALK_SUPPORTS_LINUX 1

--- a/srcpkgs/thunderbird/patches/fix-i686-ppc-musl.patch
+++ b/srcpkgs/thunderbird/patches/fix-i686-ppc-musl.patch
@@ -1,11 +1,11 @@
---- a/mozglue/misc/StackWalk.cpp	2017-04-11 04:13:21.000000000 +0200
-+++ b/mozglue/misc/StackWalk.cpp	2017-11-29 15:23:07.218649970 +0100
-@@ -41,7 +41,7 @@
- #define MOZ_STACKWALK_SUPPORTS_MACOSX 0
+--- a/mozglue/misc/StackWalk.cpp	2021-11-05 15:55:03.614609706 +0000
++++ b/mozglue/misc/StackWalk.cpp	2021-10-28 19:03:47.000000000 +0100
+@@ -45,7 +45,7 @@
+ #  define MOZ_STACKWALK_SUPPORTS_MACOSX 0
  #endif
- 
--#if (defined(linux) && \
+
+-#if (defined(linux) &&                                            \
 +#if defined(__GLIBC__) && (defined(linux) && \
       ((defined(__GNUC__) && (defined(__i386) || defined(PPC))) || \
        defined(HAVE__UNWIND_BACKTRACE)))
- #define MOZ_STACKWALK_SUPPORTS_LINUX 1
+ #  define MOZ_STACKWALK_SUPPORTS_LINUX 1


### PR DESCRIPTION
Needed because of https://github.com/void-linux/void-packages/commit/7b4119df5cbc0cc37348164a10c88a32910009d8 
See also https://github.com/void-linux/void-packages/issues/33915
