### PR TITLE
python3-jsonschema: update to 4.2.1.

### DIFF
--- a/srcpkgs/python3-jsonschema/template
+++ b/srcpkgs/python3-jsonschema/template
@@ -1,11 +1,12 @@
 # Template file for 'python3-jsonschema'
 pkgname=python3-jsonschema
-version=3.2.0
-revision=2
+version=4.2.1
+revision=1
 wrksrc="jsonschema-${version}"
-build_style=python3-module
-hostmakedepends="python3-setuptools_scm"
-depends="python3-setuptools python3-six python3-attrs python3-pyrsistent"
+build_style=python3-pep517
+make_check_args="--deselect jsonschema/tests/test_cli.py::TestCLIIntegration::test_license"
+hostmakedepends="python3-setuptools_scm python3-wheel"
+depends="python3-attrs python3-pyrsistent"
 checkdepends="python3-pytest python3-Twisted $depends"
 short_desc="Implementation of JSON Schema for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,7 +14,7 @@ license="MIT"
 homepage="https://github.com/Julian/jsonschema"
 changelog="https://raw.githubusercontent.com/Julian/jsonschema/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/j/jsonschema/jsonschema-${version}.tar.gz"
-checksum=c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
+checksum=390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8
 
 post_install() {
 	vlicense COPYING LICENSE


### PR DESCRIPTION
- Change build style to python3-pep517 because of Julian/jsonschema@112c809e.
- Remove python3-six dependency since py2 support was dropped in Julian/jsonschema@027feac.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
