### PR TITLE
OpenRCT2: update to 0.3.5

### DIFF
--- a/srcpkgs/OpenRCT2/template
+++ b/srcpkgs/OpenRCT2/template
@@ -4,9 +4,9 @@
 pkgname=OpenRCT2
 _objects_version=1.0.21
 _titles_version=0.1.2c
-_replays_version=0.0.43
-version=0.3.4.1
-revision=2
+_replays_version=0.0.57
+version=0.3.5
+revision=1
 build_style=cmake
 configure_args="
  -DOPENRCT2_VERSION_TAG=${version}
@@ -33,7 +33,7 @@ homepage="https://openrct2.io"
 distfiles="https://github.com/OpenRCT2/OpenRCT2/archive/v${version}.tar.gz
  https://github.com/OpenRCT2/objects/releases/download/v${_objects_version}/objects.zip
  https://github.com/OpenRCT2/title-sequences/releases/download/v${_titles_version}/title-sequences.zip"
-checksum="01f286dce2a9668fb87f403a0f53880936d3013fd502f32f9bb1217236c28225
+checksum="daeeef2c1a0d42399ce339a65576a4e005b374d42b0be88c6695d68ab33ccf21
  b081f885311f9afebc41d9dd4a68b7db4cf736eb815c04e307e1a426f08cfa35
  5284333fa501270835b5f0cf420cb52155742335f5658d7889ea35d136b52517"
 skip_extraction="objects.zip title-sequences.zip replays.zip"
@@ -56,14 +56,18 @@ if [ "$CROSS_BUILD" ]; then
 	# for icu mass-rebuild
 	hostmakedepends+=" enchant2 libxml2 webkit2gtk libharfbuzz"
 	hostmakedepends+=" libnuspell libpsl"
-	CXXFLAGS+=" -DHAVE_IMMINTRIN_H=false -DSDL_DISABLE_IMMINTRIN_H=1"
+	CXXFLAGS+=" -DHAVE_IMMINTRIN_H=false -DSDL_DISABLE_IMMINTRIN_H=1 -Wno-old-style-cast"
+
+	if [ "$XBPS_CHECK_PKGS" ]; then
+		makedepends+=" gtest-devel"
+	fi
 fi
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -DWITH_TESTS=1 -DSYSTEM_GTEST=1"
 	# download replays, used in tests
 	distfiles+=" https://github.com/OpenRCT2/replays/releases/download/v${_replays_version}/replays.zip"
-	checksum+=" 43ba763ee6950a51aa96b26f3007c18b6e2ed09b6003601df6b014d5642c08d8"
+	checksum+=" 6fc331f3899fd72a6421ac2196aa67fcacc789c079fcbe91988533fe7d5a9163"
 fi
 
 post_extract() {


### PR DESCRIPTION
This doesn't update to the latest `objects`, despite new upstream being available, because the CMake definitions still target these old versions, and `do_check` fails (almost every single test, at that) with the new packages.

This 0.3.5 build loaded up one of my savegames just fine locally on x86_64-glibc. I was able to x-build for aarch64-musl after applying the `makedepends` fix, but don't have a running arm device to test that build on right now.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [x] I built this PR locally for my native architecture, (x86_64 glibc)
- [x] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
