### PR TITLE
fzf: update installation path for completions and key-bindings

### DIFF
--- a/srcpkgs/fzf/template
+++ b/srcpkgs/fzf/template
@@ -1,7 +1,7 @@
 # Template file for 'fzf'
 pkgname=fzf
 version=0.28.0
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/junegunn/fzf"
 hostmakedepends="git"
@@ -23,9 +23,10 @@ post_install() {
 	sed -i -e 's#source ~/\.fzf\.bash; ##' shell/key-bindings.bash
 	vinstall plugin/fzf.vim 644 usr/share/vim/vimfiles/plugin
 	vinstall plugin/fzf.vim 644 usr/share/nvim/runtime/plugin
-	vinstall shell/completion.bash 644 usr/share/doc/fzf
-	vinstall shell/completion.zsh 644 usr/share/doc/fzf
-	vinstall shell/key-bindings.zsh 644 usr/share/doc/fzf
-	vinstall shell/key-bindings.bash 644 usr/share/doc/fzf
-	vinstall shell/key-bindings.fish 644 usr/share/doc/fzf
+
+	vinstall shell/completion.bash 644 usr/share/fzf
+	vinstall shell/completion.zsh 644 usr/share/fzf
+	vinstall shell/key-bindings.zsh 644 usr/share/fzf
+	vinstall shell/key-bindings.bash 644 usr/share/fzf
+	vinstall shell/key-bindings.fish 644 usr/share/fzf
 }


### PR DESCRIPTION
This changes the installation path of additional files from `/usr/share/doc/fzf` to `usr/share/fzf`.

I'm not sure why they were originally installed in the `doc` folder, since these are not documentation files,
but if there is a reason, please feel free to close.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
