### PR TITLE
procs: fix completion

### DIFF
--- a/srcpkgs/procs/template
+++ b/srcpkgs/procs/template
@@ -1,7 +1,7 @@
 # Template file for 'procs'
 pkgname=procs
 version=0.11.10
-revision=1
+revision=2
 build_style=cargo
 build_helper=qemu
 short_desc="Modern replacement for ps written in Rust"
@@ -14,15 +14,15 @@ checksum=e6a869722181f2122a5a223517a2d1f6505d19b8b9d46ffd59c61fb02f472403
 
 post_build() {
 	PROCS="target/${RUST_TARGET}/release/procs"
-	vtargetrun ${PROCS} --completion bash > procs.bash
-	vtargetrun ${PROCS} --completion fish > procs.fish
-	vtargetrun ${PROCS} --completion zsh > procs.zsh
+	vtargetrun ${PROCS} --completion bash
+	vtargetrun ${PROCS} --completion fish
+	vtargetrun ${PROCS} --completion zsh
 }
 
 post_install() {
 	vcompletion procs.bash bash
 	vcompletion procs.fish fish
-	vcompletion procs.zsh zsh
+	vcompletion _procs zsh
 
 	vlicense LICENSE
 }


### PR DESCRIPTION
Procs prepend generated completion with following string if stdout
of `procs --completion` is redirected to file:

    completion file is generated: ./procs.bash

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
