### PR TITLE
New package: perl-SVG-2.86

### DIFF
--- a/srcpkgs/perl-SVG/template
+++ b/srcpkgs/perl-SVG/template
@@ -1,0 +1,15 @@
+# Template file for 'perl-SVG'
+pkgname=perl-SVG
+version=2.86
+revision=1
+wrksrc="SVG-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="$hostmakedepends"
+depends="perl"
+short_desc="Generate standalone or inline SVG (Scalable Vector Graphics)"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="Artistic-1.0-Perl, GPL-1.0-or-later"
+homepage="https://metacpan.org/release/SVG"
+distfiles="${CPAN_SITE}/SVG/SVG-${version}.tar.gz"
+checksum=72c6eb6f86bb2c330280f9f3d342bb2673ad5da22d1f44fba3e04cfb5d30a67b


### PR DESCRIPTION
Dependency for sage. I compiled sage-9.4 using this.

In fact, sage has a package named `perl_cpan_polymake_prereq` which checks a bunch of perl modules:
```
checking for perl module XML::Writer... ok
checking for perl module XML::LibXML... ok
checking for perl module XML::LibXSLT... ok
checking for perl module File::Slurp... ok
checking for perl module JSON... ok
checking for perl module SVG... ok
```
The first five are already present in void, the only one missing is `SVG`, but sage will install all 6 modules if only one is missing so there's extra credit for having this last one :-)