### PR TITLE
mozjs78: patch to fix building with Python 3.10

### DIFF
--- a/srcpkgs/mozjs78/patches/fix-python3.10.patch
+++ b/srcpkgs/mozjs78/patches/fix-python3.10.patch
@@ -1,0 +1,826 @@
+diff -ur a/python/mach/mach/config.py b/python/mach/mach/config.py
+--- a/python/mach/mach/config.py	2021-09-01 13:26:18.000000000 -0400
++++ b/python/mach/mach/config.py	2021-11-05 15:29:12.000000000 -0400
+@@ -144,7 +144,7 @@
+     return _
+ 
+ 
+-class ConfigSettings(collections.Mapping):
++class ConfigSettings(collections.abc.Mapping):
+     """Interface for configuration settings.
+ 
+     This is the main interface to the configuration.
+@@ -190,7 +190,7 @@
+     will result in exceptions being raised.
+     """
+ 
+-    class ConfigSection(collections.MutableMapping, object):
++    class ConfigSection(collections.abc.MutableMapping, object):
+         """Represents an individual config section."""
+         def __init__(self, config, name, settings):
+             object.__setattr__(self, '_config', config)
+diff -ur a/python/mach/mach/decorators.py b/python/mach/mach/decorators.py
+--- a/python/mach/mach/decorators.py	2021-09-01 13:26:18.000000000 -0400
++++ b/python/mach/mach/decorators.py	2021-11-05 15:29:12.000000000 -0400
+@@ -140,7 +140,7 @@
+               'Conditions argument must take a list ' + \
+               'of functions. Found %s instead.'
+ 
+-        if not isinstance(command.conditions, collections.Iterable):
++        if not isinstance(command.conditions, collections.abc.Iterable):
+             msg = msg % (command.name, type(command.conditions))
+             raise MachError(msg)
+ 
+diff -ur a/python/mach/mach/main.py b/python/mach/mach/main.py
+--- a/python/mach/mach/main.py	2021-09-01 13:26:23.000000000 -0400
++++ b/python/mach/mach/main.py	2021-11-05 15:29:12.000000000 -0400
+@@ -16,7 +16,7 @@
+ import sys
+ import traceback
+ import uuid
+-from collections import Iterable
++from collections.abc import Iterable
+ 
+ from six import string_types
+ 
+diff -ur a/python/mozbuild/mozbuild/backend/configenvironment.py b/python/mozbuild/mozbuild/backend/configenvironment.py
+--- a/python/mozbuild/mozbuild/backend/configenvironment.py	2021-09-01 13:26:34.000000000 -0400
++++ b/python/mozbuild/mozbuild/backend/configenvironment.py	2021-11-05 15:29:12.000000000 -0400
+@@ -9,7 +9,8 @@
+ import sys
+ import json
+ 
+-from collections import Iterable, OrderedDict
++from collections import OrderedDict
++from collections.abc import Iterable
+ from types import ModuleType
+ 
+ import mozpack.path as mozpath
+diff -ur a/python/mozbuild/mozbuild/makeutil.py b/python/mozbuild/mozbuild/makeutil.py
+--- a/python/mozbuild/mozbuild/makeutil.py	2021-09-01 13:26:18.000000000 -0400
++++ b/python/mozbuild/mozbuild/makeutil.py	2021-11-05 15:29:12.000000000 -0400
+@@ -7,7 +7,7 @@
+ import os
+ import re
+ import six
+-from collections import Iterable
++from collections.abc import Iterable
+ 
+ 
+ class Makefile(object):
+diff -ur a/python/mozbuild/mozbuild/util.py b/python/mozbuild/mozbuild/util.py
+--- a/python/mozbuild/mozbuild/util.py	2021-09-01 13:26:18.000000000 -0400
++++ b/python/mozbuild/mozbuild/util.py	2021-11-05 15:29:12.000000000 -0400
+@@ -782,7 +782,7 @@
+         self._strings = StrictOrderingOnAppendList()
+         self._children = {}
+ 
+-    class StringListAdaptor(collections.Sequence):
++    class StringListAdaptor(collections.abc.Sequence):
+         def __init__(self, hsl):
+             self._hsl = hsl
+ 
+diff -ur a/testing/marionette/client/marionette_driver/wait.py b/testing/marionette/client/marionette_driver/wait.py
+--- a/testing/marionette/client/marionette_driver/wait.py	2021-09-01 13:26:30.000000000 -0400
++++ b/testing/marionette/client/marionette_driver/wait.py	2021-11-05 15:29:12.000000000 -0400
+@@ -82,7 +82,7 @@
+ 
+         exceptions = []
+         if ignored_exceptions is not None:
+-            if isinstance(ignored_exceptions, collections.Iterable):
++            if isinstance(ignored_exceptions, collections.abc.Iterable):
+                 exceptions.extend(iter(ignored_exceptions))
+             else:
+                 exceptions.append(ignored_exceptions)
+diff -ur a/testing/mozbase/manifestparser/manifestparser/filters.py b/testing/mozbase/manifestparser/manifestparser/filters.py
+--- a/testing/mozbase/manifestparser/manifestparser/filters.py	2021-09-01 13:26:23.000000000 -0400
++++ b/testing/mozbase/manifestparser/manifestparser/filters.py	2021-11-05 15:29:12.000000000 -0400
+@@ -12,7 +12,8 @@
+ 
+ import itertools
+ import os
+-from collections import defaultdict, MutableSequence
++from collections import defaultdict
++from collections.abc import MutableSequence
+ 
+ import six
+ from six import string_types
+diff -ur a/testing/mozbase/versioninfo.py b/testing/mozbase/versioninfo.py
+--- a/testing/mozbase/versioninfo.py	2021-09-01 13:26:23.000000000 -0400
++++ b/testing/mozbase/versioninfo.py	2021-11-05 15:29:12.000000000 -0400
+@@ -11,7 +11,7 @@
+ 
+ from __future__ import absolute_import, print_function
+ 
+-from collections import Iterable
++from collections.abc import Iterable
+ from distutils.version import StrictVersion
+ import argparse
+ import os
+diff -ur a/testing/web-platform/tests/tools/manifest/typedata.py b/testing/web-platform/tests/tools/manifest/typedata.py
+--- a/testing/web-platform/tests/tools/manifest/typedata.py	2021-09-01 13:26:40.000000000 -0400
++++ b/testing/web-platform/tests/tools/manifest/typedata.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,4 +1,4 @@
+-from collections import MutableMapping
++from collections.abc import MutableMapping
+ 
+ from six import itervalues, iteritems
+ 
+diff -ur a/testing/web-platform/tests/tools/manifest/vcs.py b/testing/web-platform/tests/tools/manifest/vcs.py
+--- a/testing/web-platform/tests/tools/manifest/vcs.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/tools/manifest/vcs.py	2021-11-05 15:29:12.000000000 -0400
+@@ -3,7 +3,7 @@
+ import os
+ import stat
+ from collections import deque
+-from collections import MutableMapping
++from collections.abc import MutableMapping
+ 
+ from six import with_metaclass, PY2
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/attrs/tests/test_funcs.py b/testing/web-platform/tests/tools/third_party/attrs/tests/test_funcs.py
+--- a/testing/web-platform/tests/tools/third_party/attrs/tests/test_funcs.py	2021-09-01 13:26:56.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/attrs/tests/test_funcs.py	2021-11-05 15:29:12.000000000 -0400
+@@ -4,7 +4,8 @@
+ 
+ from __future__ import absolute_import, division, print_function
+ 
+-from collections import Mapping, OrderedDict, Sequence
++from collections import OrderedDict
++from collections.abc import Mapping, Sequence
+ 
+ import pytest
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/h2/h2/settings.py b/testing/web-platform/tests/tools/third_party/h2/h2/settings.py
+--- a/testing/web-platform/tests/tools/third_party/h2/h2/settings.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/h2/h2/settings.py	2021-11-05 15:32:28.817737357 -0400
+@@ -88,7 +88,7 @@
+         )
+ 
+ 
+-class Settings(collections.MutableMapping):
++class Settings(collections.abc.MutableMapping):
+     """
+     An object that encapsulates HTTP/2 settings state.
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/html5lib/html5lib/_trie/_base.py b/testing/web-platform/tests/tools/third_party/html5lib/html5lib/_trie/_base.py
+--- a/testing/web-platform/tests/tools/third_party/html5lib/html5lib/_trie/_base.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/html5lib/html5lib/_trie/_base.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,6 +1,6 @@
+ from __future__ import absolute_import, division, unicode_literals
+ 
+-from collections import Mapping
++from collections.abc import Mapping
+ 
+ 
+ class Trie(Mapping):
+diff -ur a/testing/web-platform/tests/tools/third_party/html5lib/html5lib/treebuilders/dom.py b/testing/web-platform/tests/tools/third_party/html5lib/html5lib/treebuilders/dom.py
+--- a/testing/web-platform/tests/tools/third_party/html5lib/html5lib/treebuilders/dom.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/html5lib/html5lib/treebuilders/dom.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,7 +1,7 @@
+ from __future__ import absolute_import, division, unicode_literals
+ 
+ 
+-from collections import MutableMapping
++from collections.abc import MutableMapping
+ from xml.dom import minidom, Node
+ import weakref
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/hyper/hyper/common/headers.py b/testing/web-platform/tests/tools/third_party/hyper/hyper/common/headers.py
+--- a/testing/web-platform/tests/tools/third_party/hyper/hyper/common/headers.py	2021-09-01 13:27:00.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/hyper/hyper/common/headers.py	2021-11-05 15:29:12.000000000 -0400
+@@ -10,7 +10,7 @@
+ from hyper.common.util import to_bytestring, to_bytestring_tuple
+ 
+ 
+-class HTTPHeaderMap(collections.MutableMapping):
++class HTTPHeaderMap(collections.abc.MutableMapping):
+     """
+     A structure that contains HTTP headers.
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/hyper/hyper/h2/settings.py b/testing/web-platform/tests/tools/third_party/hyper/hyper/h2/settings.py
+--- a/testing/web-platform/tests/tools/third_party/hyper/hyper/h2/settings.py	2021-09-01 13:26:56.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/hyper/hyper/h2/settings.py	2021-11-05 15:29:12.000000000 -0400
+@@ -151,7 +151,7 @@
+         )
+ 
+ 
+-class Settings(collections.MutableMapping):
++class Settings(collections.abc.MutableMapping):
+     """
+     An object that encapsulates HTTP/2 settings state.
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/hyper/hyper/http11/connection.py b/testing/web-platform/tests/tools/third_party/hyper/hyper/http11/connection.py
+--- a/testing/web-platform/tests/tools/third_party/hyper/hyper/http11/connection.py	2021-09-01 13:27:00.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/hyper/hyper/http11/connection.py	2021-11-05 15:29:12.000000000 -0400
+@@ -10,7 +10,7 @@
+ import socket
+ import base64
+ 
+-from collections import Iterable, Mapping
++from collections.abc import Iterable, Mapping
+ 
+ import collections
+ from hyperframe.frame import SettingsFrame
+@@ -295,7 +295,7 @@
+                 return
+ 
+             # Iterables that set a specific content length.
+-            elif isinstance(body, collections.Iterable):
++            elif isinstance(body, collections.abc.Iterable):
+                 for item in body:
+                     try:
+                         self._sock.send(item)
+diff -ur a/testing/web-platform/tests/tools/third_party/hyper/hyper/packages/hyperframe/flags.py b/testing/web-platform/tests/tools/third_party/hyper/hyper/packages/hyperframe/flags.py
+--- a/testing/web-platform/tests/tools/third_party/hyper/hyper/packages/hyperframe/flags.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/hyper/hyper/packages/hyperframe/flags.py	2021-11-05 15:29:12.000000000 -0400
+@@ -11,7 +11,7 @@
+ Flag = collections.namedtuple("Flag", ["name", "bit"])
+ 
+ 
+-class Flags(collections.MutableSet):
++class Flags(collections.abc.MutableSet):
+     """
+     A simple MutableSet implementation that will only accept known flags as elements.
+ 
+diff -ur a/testing/web-platform/tests/tools/third_party/hyperframe/hyperframe/flags.py b/testing/web-platform/tests/tools/third_party/hyperframe/hyperframe/flags.py
+--- a/testing/web-platform/tests/tools/third_party/hyperframe/hyperframe/flags.py	2021-09-01 13:26:39.000000000 -0400
++++ b/testing/web-platform/tests/tools/third_party/hyperframe/hyperframe/flags.py	2021-11-05 15:29:12.000000000 -0400
+@@ -11,7 +11,7 @@
+ Flag = collections.namedtuple("Flag", ["name", "bit"])
+ 
+ 
+-class Flags(collections.MutableSet):
++class Flags(collections.abc.MutableSet):
+     """
+     A simple MutableSet implementation that will only accept known flags as
+     elements.
+diff -ur a/testing/web-platform/tests/tools/wptserve/wptserve/config.py b/testing/web-platform/tests/tools/wptserve/wptserve/config.py
+--- a/testing/web-platform/tests/tools/wptserve/wptserve/config.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/tools/wptserve/wptserve/config.py	2021-11-05 15:29:12.000000000 -0400
+@@ -2,7 +2,8 @@
+ import logging
+ import os
+ 
+-from collections import defaultdict, Mapping
++from collections import defaultdict
++from collections.abc import Mapping
+ from six import integer_types, iteritems, itervalues, string_types
+ 
+ from . import sslutils
+diff -ur a/testing/web-platform/tests/webdriver/tests/support/sync.py b/testing/web-platform/tests/webdriver/tests/support/sync.py
+--- a/testing/web-platform/tests/webdriver/tests/support/sync.py	2021-09-01 13:27:05.000000000 -0400
++++ b/testing/web-platform/tests/webdriver/tests/support/sync.py	2021-11-05 15:29:12.000000000 -0400
+@@ -81,7 +81,7 @@
+ 
+         exceptions = []
+         if ignored_exceptions is not None:
+-            if isinstance(ignored_exceptions, collections.Iterable):
++            if isinstance(ignored_exceptions, collections.abc.Iterable):
+                 exceptions.extend(iter(ignored_exceptions))
+             else:
+                 exceptions.append(ignored_exceptions)
+diff -ur a/third_party/python/gyp/pylib/gyp/common.py b/third_party/python/gyp/pylib/gyp/common.py
+--- a/third_party/python/gyp/pylib/gyp/common.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/gyp/pylib/gyp/common.py	2021-11-05 15:29:12.000000000 -0400
+@@ -494,7 +494,7 @@
+ 
+ 
+ # Based on http://code.activestate.com/recipes/576694/.
+-class OrderedSet(collections.MutableSet):
++class OrderedSet(collections.abc.MutableSet):
+   def __init__(self, iterable=None):
+     self.end = end = []
+     end += [None, end, end]         # sentinel node for doubly linked list
+diff -ur a/third_party/python/gyp/pylib/gyp/msvs_emulation.py b/third_party/python/gyp/pylib/gyp/msvs_emulation.py
+--- a/third_party/python/gyp/pylib/gyp/msvs_emulation.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/gyp/pylib/gyp/msvs_emulation.py	2021-11-05 15:30:47.757760820 -0400
+@@ -91,7 +91,7 @@
+   """Add |prefix| to |element| or each subelement if element is iterable."""
+   if element is None:
+     return element
+-  if (isinstance(element, collections.Iterable) and
++  if (isinstance(element, collections.abc.Iterable) and
+       not isinstance(element, basestring)):
+     return [prefix + e for e in element]
+   else:
+@@ -104,7 +104,7 @@
+   if map is not None and element is not None:
+     if not callable(map):
+       map = map.get # Assume it's a dict, otherwise a callable to do the remap.
+-    if (isinstance(element, collections.Iterable) and
++    if (isinstance(element, collections.abc.Iterable) and
+         not isinstance(element, basestring)):
+       element = filter(None, [map(elem) for elem in element])
+     else:
+@@ -117,7 +117,7 @@
+   then add |element| to it, adding each item in |element| if it's a list or
+   tuple."""
+   if append is not None and element is not None:
+-    if (isinstance(element, collections.Iterable) and
++    if (isinstance(element, collections.abc.Iterable) and
+         not isinstance(element, basestring)):
+       append.extend(element)
+     else:
+diff -ur a/third_party/python/gyp/test/lib/TestGyp.py b/third_party/python/gyp/test/lib/TestGyp.py
+--- a/third_party/python/gyp/test/lib/TestGyp.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/gyp/test/lib/TestGyp.py	2021-11-05 15:30:37.671763157 -0400
+@@ -496,7 +496,7 @@
+     if status is None:
+       kw['status'] = None
+     else:
+-      if not isinstance(status, collections.Iterable): status = (status,)
++      if not isinstance(status, collections.abc.Iterable): status = (status,)
+       kw['status'] = list(itertools.chain((0,), status))
+     self.cmake_build(gyp_file, target, **kw)
+     kw['status'] = status
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/distlib/compat.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/distlib/compat.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/distlib/compat.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/distlib/compat.py	2021-11-05 15:29:12.000000000 -0400
+@@ -319,7 +319,7 @@
+ try:
+     callable = callable
+ except NameError:   # pragma: no cover
+-    from collections import Callable
++    from collections.abc import Callable
+ 
+     def callable(obj):
+         return isinstance(obj, Callable)
+@@ -475,7 +475,7 @@
+ try:
+     from collections import ChainMap
+ except ImportError: # pragma: no cover
+-    from collections import MutableMapping
++    from collections.abc import MutableMapping
+ 
+     try:
+         from reprlib import recursive_repr as _recursive_repr
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/html5lib/treebuilders/dom.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/html5lib/treebuilders/dom.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/html5lib/treebuilders/dom.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/html5lib/treebuilders/dom.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,7 +1,7 @@
+ from __future__ import absolute_import, division, unicode_literals
+ 
+ 
+-from collections import MutableMapping
++from collections.abc import MutableMapping
+ from xml.dom import minidom, Node
+ import weakref
+ 
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/pyparsing.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/pyparsing.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/pyparsing.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/pyparsing.py	2021-11-05 15:29:12.000000000 -0400
+@@ -940,7 +940,7 @@
+     def __dir__(self):
+         return (dir(type(self)) + list(self.keys()))
+ 
+-collections.MutableMapping.register(ParseResults)
++collections.abc.MutableMapping.register(ParseResults)
+ 
+ def col (loc,strg):
+     """Returns current column within a string, counting newlines as line separators.
+@@ -3223,7 +3223,7 @@
+ 
+         if isinstance( exprs, basestring ):
+             self.exprs = [ ParserElement._literalStringClass( exprs ) ]
+-        elif isinstance( exprs, collections.Iterable ):
++        elif isinstance( exprs, collections.abc.Iterable ):
+             exprs = list(exprs)
+             # if sequence of strings provided, wrap with Literal
+             if all(isinstance(expr, basestring) for expr in exprs):
+@@ -4564,7 +4564,7 @@
+     symbols = []
+     if isinstance(strs,basestring):
+         symbols = strs.split()
+-    elif isinstance(strs, collections.Iterable):
++    elif isinstance(strs, collections.abc.Iterable):
+         symbols = list(strs)
+     else:
+         warnings.warn("Invalid argument to oneOf, expected string or iterable",
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/cookies.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/cookies.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/cookies.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/cookies.py	2021-11-05 15:29:12.000000000 -0400
+@@ -169,7 +169,7 @@
+     """
+ 
+ 
+-class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
++class RequestsCookieJar(cookielib.CookieJar, collections.abc.MutableMapping):
+     """Compatibility class; is a cookielib.CookieJar, but exposes a dict
+     interface.
+ 
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/models.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/models.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/models.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/models.py	2021-11-05 15:31:35.745749692 -0400
+@@ -174,10 +174,10 @@
+         if event not in self.hooks:
+             raise ValueError('Unsupported event specified, with event name "%s"' % (event))
+ 
+-        if isinstance(hook, collections.Callable):
++        if isinstance(hook, collections.abc.Callable):
+             self.hooks[event].append(hook)
+         elif hasattr(hook, '__iter__'):
+-            self.hooks[event].extend(h for h in hook if isinstance(h, collections.Callable))
++            self.hooks[event].extend(h for h in hook if isinstance(h, collections.abc.Callable))
+ 
+     def deregister_hook(self, event, hook):
+         """Deregister a previously registered hook.
+@@ -461,7 +461,7 @@
+ 
+         is_stream = all([
+             hasattr(data, '__iter__'),
+-            not isinstance(data, (basestring, list, tuple, collections.Mapping))
++            not isinstance(data, (basestring, list, tuple, collections.abc.Mapping))
+         ])
+ 
+         try:
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/structures.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/structures.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/structures.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/structures.py	2021-11-05 15:29:12.000000000 -0400
+@@ -12,7 +12,7 @@
+ from .compat import OrderedDict
+ 
+ 
+-class CaseInsensitiveDict(collections.MutableMapping):
++class CaseInsensitiveDict(collections.abc.MutableMapping):
+     """A case-insensitive ``dict``-like object.
+ 
+     Implements all methods and operations of
+@@ -71,7 +71,7 @@
+         )
+ 
+     def __eq__(self, other):
+-        if isinstance(other, collections.Mapping):
++        if isinstance(other, collections.abc.Mapping):
+             other = CaseInsensitiveDict(other)
+         else:
+             return NotImplemented
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/utils.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/utils.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/utils.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/requests/utils.py	2021-11-05 15:31:40.157748665 -0400
+@@ -262,7 +262,7 @@
+     if isinstance(value, (str, bytes, bool, int)):
+         raise ValueError('cannot encode objects that are not 2-tuples')
+ 
+-    if isinstance(value, collections.Mapping):
++    if isinstance(value, collections.abc.Mapping):
+         value = value.items()
+ 
+     return list(value)
+diff -ur a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/urllib3/_collections.py b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/urllib3/_collections.py
+--- a/third_party/python/pipenv/pipenv/patched/notpip/_vendor/urllib3/_collections.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/patched/notpip/_vendor/urllib3/_collections.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,5 +1,5 @@
+ from __future__ import absolute_import
+-from collections import Mapping, MutableMapping
++from collections.abc import Mapping, MutableMapping
+ try:
+     from threading import RLock
+ except ImportError:  # Platform-specific: No threads available
+diff -ur a/third_party/python/pipenv/pipenv/vendor/jinja2/sandbox.py b/third_party/python/pipenv/pipenv/vendor/jinja2/sandbox.py
+--- a/third_party/python/pipenv/pipenv/vendor/jinja2/sandbox.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/jinja2/sandbox.py	2021-11-05 15:29:12.000000000 -0400
+@@ -14,7 +14,7 @@
+ """
+ import types
+ import operator
+-from collections import Mapping
++from collections.abc import Mapping
+ from jinja2.environment import Environment
+ from jinja2.exceptions import SecurityError
+ from jinja2._compat import string_types, PY2
+@@ -79,7 +79,7 @@
+     pass
+ 
+ #: register Python 2.6 abstract base classes
+-from collections import MutableSet, MutableMapping, MutableSequence
++from collections.abc import MutableSet, MutableMapping, MutableSequence
+ _mutable_set_types += (MutableSet,)
+ _mutable_mapping_types += (MutableMapping,)
+ _mutable_sequence_types += (MutableSequence,)
+diff -ur a/third_party/python/pipenv/pipenv/vendor/jinja2/utils.py b/third_party/python/pipenv/pipenv/vendor/jinja2/utils.py
+--- a/third_party/python/pipenv/pipenv/vendor/jinja2/utils.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/jinja2/utils.py	2021-11-05 15:29:12.000000000 -0400
+@@ -482,7 +482,7 @@
+ 
+ # register the LRU cache as mutable mapping if possible
+ try:
+-    from collections import MutableMapping
++    from collections.abc import MutableMapping
+     MutableMapping.register(LRUCache)
+ except ImportError:
+     pass
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/distlib/compat.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/distlib/compat.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/distlib/compat.py	2021-09-01 13:27:05.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/distlib/compat.py	2021-11-05 15:29:12.000000000 -0400
+@@ -319,7 +319,7 @@
+ try:
+     callable = callable
+ except NameError:   # pragma: no cover
+-    from collections import Callable
++    from collections.abc import Callable
+ 
+     def callable(obj):
+         return isinstance(obj, Callable)
+@@ -475,7 +475,7 @@
+ try:
+     from collections import ChainMap
+ except ImportError: # pragma: no cover
+-    from collections import MutableMapping
++    from collections.abc import MutableMapping
+ 
+     try:
+         from reprlib import recursive_repr as _recursive_repr
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/html5lib/treebuilders/dom.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/html5lib/treebuilders/dom.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/html5lib/treebuilders/dom.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/html5lib/treebuilders/dom.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,7 +1,7 @@
+ from __future__ import absolute_import, division, unicode_literals
+ 
+ 
+-from collections import MutableMapping
++from collections.abc import MutableMapping
+ from xml.dom import minidom, Node
+ import weakref
+ 
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/pyparsing.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/pyparsing.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/pyparsing.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/pyparsing.py	2021-11-05 15:29:12.000000000 -0400
+@@ -940,7 +940,7 @@
+     def __dir__(self):
+         return (dir(type(self)) + list(self.keys()))
+ 
+-collections.MutableMapping.register(ParseResults)
++collections.abc.MutableMapping.register(ParseResults)
+ 
+ def col (loc,strg):
+     """Returns current column within a string, counting newlines as line separators.
+@@ -3223,7 +3223,7 @@
+ 
+         if isinstance( exprs, basestring ):
+             self.exprs = [ ParserElement._literalStringClass( exprs ) ]
+-        elif isinstance( exprs, collections.Iterable ):
++        elif isinstance( exprs, collections.abc.Iterable ):
+             exprs = list(exprs)
+             # if sequence of strings provided, wrap with Literal
+             if all(isinstance(expr, basestring) for expr in exprs):
+@@ -4564,7 +4564,7 @@
+     symbols = []
+     if isinstance(strs,basestring):
+         symbols = strs.split()
+-    elif isinstance(strs, collections.Iterable):
++    elif isinstance(strs, collections.abc.Iterable):
+         symbols = list(strs)
+     else:
+         warnings.warn("Invalid argument to oneOf, expected string or iterable",
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/cookies.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/cookies.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/cookies.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/cookies.py	2021-11-05 15:29:12.000000000 -0400
+@@ -169,7 +169,7 @@
+     """
+ 
+ 
+-class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
++class RequestsCookieJar(cookielib.CookieJar, collections.abc.MutableMapping):
+     """Compatibility class; is a cookielib.CookieJar, but exposes a dict
+     interface.
+ 
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/models.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/models.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/models.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/models.py	2021-11-05 15:31:52.397745825 -0400
+@@ -174,10 +174,10 @@
+         if event not in self.hooks:
+             raise ValueError('Unsupported event specified, with event name "%s"' % (event))
+ 
+-        if isinstance(hook, collections.Callable):
++        if isinstance(hook, collections.abc.Callable):
+             self.hooks[event].append(hook)
+         elif hasattr(hook, '__iter__'):
+-            self.hooks[event].extend(h for h in hook if isinstance(h, collections.Callable))
++            self.hooks[event].extend(h for h in hook if isinstance(h, collections.abc.Callable))
+ 
+     def deregister_hook(self, event, hook):
+         """Deregister a previously registered hook.
+@@ -461,7 +461,7 @@
+ 
+         is_stream = all([
+             hasattr(data, '__iter__'),
+-            not isinstance(data, (basestring, list, tuple, collections.Mapping))
++            not isinstance(data, (basestring, list, tuple, collections.abc.Mapping))
+         ])
+ 
+         try:
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/structures.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/structures.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/structures.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/structures.py	2021-11-05 15:32:02.765743413 -0400
+@@ -12,7 +12,7 @@
+ from .compat import OrderedDict
+ 
+ 
+-class CaseInsensitiveDict(collections.MutableMapping):
++class CaseInsensitiveDict(collections.abc.MutableMapping):
+     """A case-insensitive ``dict``-like object.
+ 
+     Implements all methods and operations of
+@@ -71,7 +71,7 @@
+         )
+ 
+     def __eq__(self, other):
+-        if isinstance(other, collections.Mapping):
++        if isinstance(other, collections.abc.Mapping):
+             other = CaseInsensitiveDict(other)
+         else:
+             return NotImplemented
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/utils.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/utils.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/utils.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/requests/utils.py	2021-11-05 15:31:57.123744724 -0400
+@@ -262,7 +262,7 @@
+     if isinstance(value, (str, bytes, bool, int)):
+         raise ValueError('cannot encode objects that are not 2-tuples')
+ 
+-    if isinstance(value, collections.Mapping):
++    if isinstance(value, collections.abc.Mapping):
+         value = value.items()
+ 
+     return list(value)
+diff -ur a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/urllib3/_collections.py b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/urllib3/_collections.py
+--- a/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/urllib3/_collections.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/pip9/_vendor/urllib3/_collections.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,5 +1,5 @@
+ from __future__ import absolute_import
+-from collections import Mapping, MutableMapping
++from collections.abc import Mapping, MutableMapping
+ try:
+     from threading import RLock
+ except ImportError:  # Platform-specific: No threads available
+diff -ur a/third_party/python/pipenv/pipenv/vendor/requests/cookies.py b/third_party/python/pipenv/pipenv/vendor/requests/cookies.py
+--- a/third_party/python/pipenv/pipenv/vendor/requests/cookies.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/requests/cookies.py	2021-11-05 15:29:12.000000000 -0400
+@@ -169,7 +169,7 @@
+     """
+ 
+ 
+-class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
++class RequestsCookieJar(cookielib.CookieJar, collections.abc.MutableMapping):
+     """Compatibility class; is a cookielib.CookieJar, but exposes a dict
+     interface.
+ 
+diff -ur a/third_party/python/pipenv/pipenv/vendor/requests/models.py b/third_party/python/pipenv/pipenv/vendor/requests/models.py
+--- a/third_party/python/pipenv/pipenv/vendor/requests/models.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/requests/models.py	2021-11-05 15:32:09.732741793 -0400
+@@ -174,10 +174,10 @@
+         if event not in self.hooks:
+             raise ValueError('Unsupported event specified, with event name "%s"' % (event))
+ 
+-        if isinstance(hook, collections.Callable):
++        if isinstance(hook, collections.abc.Callable):
+             self.hooks[event].append(hook)
+         elif hasattr(hook, '__iter__'):
+-            self.hooks[event].extend(h for h in hook if isinstance(h, collections.Callable))
++            self.hooks[event].extend(h for h in hook if isinstance(h, collections.abc.Callable))
+ 
+     def deregister_hook(self, event, hook):
+         """Deregister a previously registered hook.
+@@ -461,7 +461,7 @@
+ 
+         is_stream = all([
+             hasattr(data, '__iter__'),
+-            not isinstance(data, (basestring, list, tuple, collections.Mapping))
++            not isinstance(data, (basestring, list, tuple, collections.abc.Mapping))
+         ])
+ 
+         try:
+diff -ur a/third_party/python/pipenv/pipenv/vendor/requests/structures.py b/third_party/python/pipenv/pipenv/vendor/requests/structures.py
+--- a/third_party/python/pipenv/pipenv/vendor/requests/structures.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/requests/structures.py	2021-11-05 15:29:12.000000000 -0400
+@@ -12,7 +12,7 @@
+ from .compat import OrderedDict
+ 
+ 
+-class CaseInsensitiveDict(collections.MutableMapping):
++class CaseInsensitiveDict(collections.abc.MutableMapping):
+     """A case-insensitive ``dict``-like object.
+ 
+     Implements all methods and operations of
+@@ -71,7 +71,7 @@
+         )
+ 
+     def __eq__(self, other):
+-        if isinstance(other, collections.Mapping):
++        if isinstance(other, collections.abc.Mapping):
+             other = CaseInsensitiveDict(other)
+         else:
+             return NotImplemented
+diff -ur a/third_party/python/pipenv/pipenv/vendor/requests/utils.py b/third_party/python/pipenv/pipenv/vendor/requests/utils.py
+--- a/third_party/python/pipenv/pipenv/vendor/requests/utils.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/requests/utils.py	2021-11-05 15:32:13.776740860 -0400
+@@ -262,7 +262,7 @@
+     if isinstance(value, (str, bytes, bool, int)):
+         raise ValueError('cannot encode objects that are not 2-tuples')
+ 
+-    if isinstance(value, collections.Mapping):
++    if isinstance(value, collections.abc.Mapping):
+         value = value.items()
+ 
+     return list(value)
+diff -ur a/third_party/python/pipenv/pipenv/vendor/urllib3/_collections.py b/third_party/python/pipenv/pipenv/vendor/urllib3/_collections.py
+--- a/third_party/python/pipenv/pipenv/vendor/urllib3/_collections.py	2021-09-01 13:26:46.000000000 -0400
++++ b/third_party/python/pipenv/pipenv/vendor/urllib3/_collections.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,5 +1,5 @@
+ from __future__ import absolute_import
+-from collections import Mapping, MutableMapping
++from collections.abc import Mapping, MutableMapping
+ try:
+     from threading import RLock
+ except ImportError:  # Platform-specific: No threads available
+diff -ur a/third_party/python/pyyaml/lib3/yaml/constructor.py b/third_party/python/pyyaml/lib3/yaml/constructor.py
+--- a/third_party/python/pyyaml/lib3/yaml/constructor.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/pyyaml/lib3/yaml/constructor.py	2021-11-05 15:29:12.000000000 -0400
+@@ -123,7 +123,7 @@
+         mapping = {}
+         for key_node, value_node in node.value:
+             key = self.construct_object(key_node, deep=deep)
+-            if not isinstance(key, collections.Hashable):
++            if not isinstance(key, collections.abc.Hashable):
+                 raise ConstructorError("while constructing a mapping", node.start_mark,
+                         "found unhashable key", key_node.start_mark)
+             value = self.construct_object(value_node, deep=deep)
+diff -ur a/third_party/python/requests/requests/cookies.py b/third_party/python/requests/requests/cookies.py
+--- a/third_party/python/requests/requests/cookies.py	2021-09-01 13:27:05.000000000 -0400
++++ b/third_party/python/requests/requests/cookies.py	2021-11-05 15:29:12.000000000 -0400
+@@ -161,7 +161,7 @@
+     Use .get and .set and include domain and path args in order to be more specific."""
+ 
+ 
+-class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
++class RequestsCookieJar(cookielib.CookieJar, collections.abc.MutableMapping):
+     """Compatibility class; is a cookielib.CookieJar, but exposes a dict
+     interface.
+ 
+diff -ur a/third_party/python/requests/requests/packages/urllib3/_collections.py b/third_party/python/requests/requests/packages/urllib3/_collections.py
+--- a/third_party/python/requests/requests/packages/urllib3/_collections.py	2021-09-01 13:27:13.000000000 -0400
++++ b/third_party/python/requests/requests/packages/urllib3/_collections.py	2021-11-05 15:29:12.000000000 -0400
+@@ -1,5 +1,5 @@
+ from __future__ import absolute_import
+-from collections import Mapping, MutableMapping
++from collections.abc import Mapping, MutableMapping
+ try:
+     from threading import RLock
+ except ImportError:  # Platform-specific: No threads available
+diff -ur a/third_party/python/requests/requests/structures.py b/third_party/python/requests/requests/structures.py
+--- a/third_party/python/requests/requests/structures.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/requests/requests/structures.py	2021-11-05 15:29:12.000000000 -0400
+@@ -11,7 +11,7 @@
+ import collections
+ 
+ 
+-class CaseInsensitiveDict(collections.MutableMapping):
++class CaseInsensitiveDict(collections.abc.MutableMapping):
+     """
+     A case-insensitive ``dict``-like object.
+ 
+@@ -71,7 +71,7 @@
+         )
+ 
+     def __eq__(self, other):
+-        if isinstance(other, collections.Mapping):
++        if isinstance(other, collections.abc.Mapping):
+             other = CaseInsensitiveDict(other)
+         else:
+             return NotImplemented
+diff -ur a/third_party/python/requests/requests/utils.py b/third_party/python/requests/requests/utils.py
+--- a/third_party/python/requests/requests/utils.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/requests/requests/utils.py	2021-11-05 15:30:55.420759045 -0400
+@@ -189,7 +189,7 @@
+     if isinstance(value, (str, bytes, bool, int)):
+         raise ValueError('cannot encode objects that are not 2-tuples')
+ 
+-    if isinstance(value, collections.Mapping):
++    if isinstance(value, collections.abc.Mapping):
+         value = value.items()
+ 
+     return list(value)
+diff -ur a/third_party/python/virtualenv/__virtualenv__/distlib-0.3.1-py2.py3-none-any/distlib/compat.py b/third_party/python/virtualenv/__virtualenv__/distlib-0.3.1-py2.py3-none-any/distlib/compat.py
+--- a/third_party/python/virtualenv/__virtualenv__/distlib-0.3.1-py2.py3-none-any/distlib/compat.py	2021-09-01 13:27:00.000000000 -0400
++++ b/third_party/python/virtualenv/__virtualenv__/distlib-0.3.1-py2.py3-none-any/distlib/compat.py	2021-11-05 15:29:12.000000000 -0400
+@@ -481,7 +481,7 @@
+ try:
+     from collections import ChainMap
+ except ImportError: # pragma: no cover
+-    from collections import MutableMapping
++    from collections.abc import MutableMapping
+ 
+     try:
+         from reprlib import recursive_repr as _recursive_repr
+diff -ur a/third_party/python/voluptuous/voluptuous/schema_builder.py b/third_party/python/voluptuous/voluptuous/schema_builder.py
+--- a/third_party/python/voluptuous/voluptuous/schema_builder.py	2021-09-01 13:27:09.000000000 -0400
++++ b/third_party/python/voluptuous/voluptuous/schema_builder.py	2021-11-05 15:30:32.399764374 -0400
+@@ -280,7 +280,7 @@
+             return schema.__voluptuous_compile__(self)
+         if isinstance(schema, Object):
+             return self._compile_object(schema)
+-        if isinstance(schema, collections.Mapping):
++        if isinstance(schema, collections.abc.Mapping):
+             return self._compile_dict(schema)
+         elif isinstance(schema, list):
+             return self._compile_list(schema)


### PR DESCRIPTION
mozjs78 also needs @ahesford’s firefox-esr patch

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
