### PR TITLE
btrfs-progs: update to 5.15

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,13 +1,13 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=5.14.1
+version=5.15
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=gnu-configure
 make_check_target=test
 configure_args="--disable-backtrace --disable-python"
 hostmakedepends="asciidoc pkg-config xmlto"
-makedepends="acl-devel libzstd-devel lzo-devel libblkid-devel libuuid-devel
+makedepends="acl-devel libzstd-devel lzo-devel libblkid-devel libudev-devel libuuid-devel
  $(vopt_if e2fs 'e2fsprogs-devel') $(vopt_if reiserfs 'reiserfsprogs')
  zlib-devel"
 short_desc="Btrfs filesystem utilities"
@@ -16,7 +16,7 @@ license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/${pkgname}/${pkgname}-v${version}.tar.xz"
-checksum=d54a9346545ca46df128e3ccb77d60c097d90c93b7e314990236e28cfaf8c55b
+checksum=e185fadd473f65a9557a4c05d923141f87e39ac9628a129193902605885f04fe
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [x] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->

libudev-devel now required to build.