### PR TITLE
gstreamer: update to 1.18.5

### DIFF
--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
-version=1.18.4
+version=1.18.5
 revision=1
 wrksrc="${pkgname}-${version}"
 build_style=meson
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=344a463badca216c2cef6ee36f9510c190862bdee48dc4591c0a430df7e8c396
+checksum=822e008a910e9dd13aedbdd8dc63fedef4040c0ee2e927bab3112e9de693a548
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-omx/template
+++ b/srcpkgs/gst-omx/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-omx'
 pkgname=gst-omx
-version=1.18.4
+version=1.18.5
 revision=1
 build_style=meson
 configure_args="-Dexamples=disabled -Dtarget=generic"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=e35051cf891eb2f31d6fcf176ff37d985f97f33874ac31b0b3ad3b5b95035043
+checksum=2cd457c1e8deb1a9b39608048fb36a44f6c9a864a6b6115b1453a32e7be93b42

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
-version=1.18.4
-revision=4
+version=1.18.5
+revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_helper="gir"
 build_style=meson
@@ -36,7 +36,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=74e806bc5595b18c70e9ca93571e27e79dfb808e5d2e7967afa952b52e99c85f
+checksum=a164923b94f0d08578a6fcaeaac6e0c05da788a46903a1086870e9ca45ad678e
 
 build_options="gir gme"
 build_options_default="gir"

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
-version=1.18.4
+version=1.18.5
 revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
@@ -22,7 +22,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=29e53229a84d01d722f6f6db13087231cdf6113dd85c25746b9b58c3d68e8323
+checksum=960b7af4585700db0fdd5b843554e11e2564fed9e061f591fae88a7be6446fa3
 
 build_options="cdparanoia gir sndio"
 build_options_default="cdparanoia gir"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
-version=1.18.4
+version=1.18.5
 revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
@@ -23,7 +23,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=b6e50e3a9bbcd56ee6ec71c33aa8332cc9c926b0c1fae995aac8b3040ebe39b0
+checksum=3aaeeea7765fbf8801acce4a503a9b05f73f04e8a35352e9d00232cfd555796b
 
 build_options="gtk3"
 build_options_default="gtk3"

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
-version=1.18.4
-revision=2
+version=1.18.5
+revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
 configure_args="-Damrnb=disabled -Damrwbdec=disabled -Dsidplay=disabled"
@@ -16,4 +16,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=218df0ce0d31e8ca9cdeb01a3b0c573172cc9c21bb3d41811c7820145623d13c
+checksum=df32803e98f8a9979373fa2ca7e05e62f977b1097576d3a80619d9f5c69f66d9

--- a/srcpkgs/gst1-editing-services/template
+++ b/srcpkgs/gst1-editing-services/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-editing-services'
 pkgname=gst1-editing-services
-version=1.18.4
+version=1.18.5
 revision=1
 wrksrc="${pkgname/gst1/gst}-${version}"
 build_style=meson
@@ -13,7 +13,7 @@ maintainer="Toyam Cox <Vaelatern@gmail.com>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/gst1/gst}/${pkgname/gst1/gst}-${version}.tar.xz"
-checksum=4687b870a7de18aebf50f45ff572ad9e0138020e3479e02a6f056a0c4c7a1d04
+checksum=8af4a8394d051f3e18280686db49a6efaccc95c0c59a17f0f564e32000590df5
 
 do_check() {
 	: # Tests fail in older versions as well

--- a/srcpkgs/gst1-python3/template
+++ b/srcpkgs/gst1-python3/template
@@ -1,7 +1,7 @@
-# Template file for 'gst1-python3'.
+# Template file for 'gst1-python3'
 pkgname=gst1-python3
-version=1.18.4
-revision=2
+version=1.18.5
+revision=1
 wrksrc="gst-python-${version}"
 build_style=meson
 hostmakedepends="pkg-config python3"
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gst-python/gst-python-${version}.tar.xz"
-checksum=cb68e08a7e825e08b83a12a22dcd6e4f1b328a7b02a7ac84f42f68f4ddc7098e
+checksum=533685871305959d6db89507f3b3aa6c765c2f2b0dacdc32c5a6543e72e5bc52

--- a/srcpkgs/gstreamer-vaapi/template
+++ b/srcpkgs/gstreamer-vaapi/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer-vaapi'
 pkgname=gstreamer-vaapi
-version=1.18.4
+version=1.18.5
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://raw.githubusercontent.com/GStreamer/gstreamer-vaapi/master/ChangeLog"
 distfiles="${homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz"
-checksum=92db98af86f3150d429c9ab17e88d2364f9c07a140c8f445ed739e8f10252aea
+checksum=4a460fb95559f41444eb24864ad2d9e37922b6eea941510310319fc3e0ba727b
 
 pre_check() {
 	# Seems to need certain hardware to pass

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,7 +1,7 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
-version=1.18.4
-revision=2
+version=1.18.5
+revision=1
 wrksrc="gstreamer-${version}"
 build_style=meson
 build_helper="gir"
@@ -18,7 +18,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gstreamer/gstreamer-${version}.tar.xz"
-checksum=9aeec99b38e310817012aa2d1d76573b787af47f8a725a65b833880a094dfbc5
+checksum=55862232a63459bbf56abebde3085ca9aec211b478e891dacea4d6df8cafe80a
 
 pre_check() {
 	# gst_gstdatetime is known to fail according to LFS


### PR DESCRIPTION
Current `gst-plugins-base1` 1.18.4 fails to build right now; an update to 1.18.5 fixes this.
Not runtime-tested, yet.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
