### PR TITLE
ocl-icd: update to 2.3.1

### DIFF
--- a/srcpkgs/ocl-icd/template
+++ b/srcpkgs/ocl-icd/template
@@ -1,7 +1,7 @@
 # Template file for 'ocl-icd'
 pkgname=ocl-icd
-version=2.2.12
-revision=2
+version=2.3.1
+revision=1
 build_style=gnu-configure
 hostmakedepends="ruby xmlto asciidoc automake libtool"
 makedepends="opencl2-headers"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://forge.imag.fr/projects/ocl-icd/"
 distfiles="https://github.com/OCL-dev/${pkgname}/archive/v${version}.tar.gz"
-checksum=17500e5788304eef5b52dbe784cec197bdae64e05eecf38317840d2d05484272
+checksum=a32b67c2d52ffbaf490be9fc18b46428ab807ab11eff7664d7ff75e06cfafd6d
 
 provides="libOpenCL-1.2_1"
 replaces="libOpenCL>=0"


### PR DESCRIPTION
Current `ocl-icd` 2.2.12 fails to build, update to 2.3.1 fixes it.

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
