### PR TITLE
m4ri: add ${makedepends} to m4ri-devel depends

### DIFF
--- a/srcpkgs/m4ri/patches/m4ri-simd_cflags_in_tests.patch
+++ b/srcpkgs/m4ri/patches/m4ri-simd_cflags_in_tests.patch
@@ -1,0 +1,11 @@
+--- a/tests/Makefile.in	2020-01-25 01:34:59.000000000 -0300
++++ b/tests/Makefile.in	2021-11-10 08:13:46.505793446 -0300
+@@ -609,7 +609,7 @@
+ TOPBUILDDIR = $(builddir)/..
+ DEFINES = 
+ # include TOPBUILDIR for m4ri_config.h
+-AM_CFLAGS = -I$(TOPSRCDIR) -I$(TOPBUILDDIR) -D_XOPEN_SOURCE=600 $(DEFINES) @OPENMP_CFLAGS@ @PAPI_CFLAGS@
++AM_CFLAGS = -I$(TOPSRCDIR) -I$(TOPBUILDDIR) -D_XOPEN_SOURCE=600 $(DEFINES) $(SIMD_CFLAGS) $(OPENMP_CFLAGS) $(PAPI_CFLAGS)
+ STAGEDIR := $(realpath -s $(TOPBUILDDIR)/.libs)
+ AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lm4ri $(LIBM) @PAPI_LDFLAGS@ @PAPI_LIBS@ -no-install
+ test_smallops_SOURCES = test_smallops.c testing.c testing.h

--- a/srcpkgs/m4ri/template
+++ b/srcpkgs/m4ri/template
@@ -1,7 +1,7 @@
 # Template file for 'm4ri'
 pkgname=m4ri
 version=20200125
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-openmp ax_cv_have_sse3_ext=no ax_cv_have_ssse3_ext=no"
 hostmakedepends="pkg-config"
@@ -15,7 +15,7 @@ checksum=0dfb34aed351882a0f2281535ea6f81c690a5efeb14edab131d9ba0dffe44863
 
 m4ri-devel_package() {
 	short_desc+=" - development files"
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"


### PR DESCRIPTION
@leahneukirchen we missed this, and now m4rie is not building without libgomp-devel.

I think the proper fix is to add libgomp-devel to depends for m4ri-devel, rather than add it to makedepends for m4rie, which is what this PR implements.