### PR TITLE
pcc: add missing dependencies

### DIFF
--- a/srcpkgs/pcc/template
+++ b/srcpkgs/pcc/template
@@ -1,7 +1,7 @@
 # Template file for 'pcc'
 pkgname=pcc
 version=1.1.0.20190420
-revision=3
+revision=4
 _distver="${version%.*}"
 _snapshot="${version##*.}"
 archs="i686* x86_64*"
@@ -21,6 +21,10 @@ checksum="a114dfca04b8b0559ea5d67b87d2d0fcb2bae2b4d9b9ba16ebc27960b921c812
 nocross=yes
 
 CFLAGS="-fcommon"
+case "$XBPS_TARGET_MACHINE" in
+	*-musl)	 depends+=" musl-devel";;
+	*) 	 depends+=" glibc-devel";;
+esac
 
 post_extract() {
 	mv pcc-${_distver}.BETA pcc


### PR DESCRIPTION
Same as https://github.com/void-linux/void-packages/issues/30630

Tested on a glibc vm - on a fresh void install, it can't find headers & crt.o

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
