### PR TITLE
common/chroot-style: clean up bwrap.sh.

### DIFF
--- a/common/chroot-style/bwrap.sh
+++ b/common/chroot-style/bwrap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# This chroot script uses bubblewrap (see https://github.com/projectatomic/bubblewrap)
+# This chroot script uses bubblewrap (see https://github.com/containers/bubblewrap)
 #
 set -e
 readonly MASTERDIR="$1"
@@ -18,6 +18,6 @@ if [ -z "$MASTERDIR" -o -z "$DISTDIR" ]; then
 	exit 1
 fi
 
-bwrap --dev-bind "$MASTERDIR" / --dev-bind "$DISTDIR" /void-packages \
+exec bwrap --bind "$MASTERDIR" / --ro-bind "$DISTDIR" /void-packages \
 	 --dev /dev --tmpfs /tmp --proc /proc \
-	${HOSTDIR:+--dev-bind "$HOSTDIR" /host} $EXTRA_ARGS "$@"
+	${HOSTDIR:+--bind "$HOSTDIR" /host} $EXTRA_ARGS "$@"


### PR DESCRIPTION
--dev-bind isn't necessary in any case it was being used for. We can
also use --ro-bind for /void-packages.

A possible future improvement would be to mount / read only during the
actual build.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
