### PR TITLE
libnftnl: add libmnl as a dep to the devel subpkg

### DIFF
--- a/srcpkgs/libnftnl/template
+++ b/srcpkgs/libnftnl/template
@@ -1,7 +1,7 @@
 # Template file for 'libnftnl'
 pkgname=libnftnl
 version=1.2.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libmnl-devel"
@@ -13,7 +13,7 @@ distfiles="https://www.netfilter.org/projects/${pkgname}/files/${pkgname}-${vers
 checksum=90b01fddfe9be8c3245c3ba5ff5a4424a8df708828f92b2b361976b658c074f5
 
 libnftnl-devel_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} $makedepends"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
pkgconfig complains about this otherwise.
See: /usr/lib/pkgconfig/libnftnl.pc

> Requires.private: libmnl
