### PR TITLE
ISOEnts: install files with the right permissions

### DIFF
--- a/srcpkgs/ISOEnts/template
+++ b/srcpkgs/ISOEnts/template
@@ -1,7 +1,7 @@
 # Template file for 'ISOEnts'
 pkgname=ISOEnts
 version=1986
-revision=5
+revision=6
 create_wrksrc=yes
 depends="xmlcatmgr"
 short_desc="Character entity sets from ISO 8879:1986 (SGML)"
@@ -13,7 +13,8 @@ checksum=dce4359a3996ed2fd33ad5eaa11a9bcfc24b5b06992e24295132b06db19a99b2
 sgml_entries="CATALOG /usr/share/sgml/iso8879/catalog --"
 
 do_install() {
-	vmkdir usr/share/sgml/iso8879
-	vcopy "*" usr/share/sgml/iso8879
+	for f in *; do
+		vinstall $f 644 usr/share/sgml/iso8879
+	done
 	vinstall ${FILESDIR}/catalog 644 usr/share/sgml/iso8879
 }


### PR DESCRIPTION
Right now installed files under `/usr/share/sgml/iso8879/` are only readable by root.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
