### PR TITLE
po4a: update to 0.66

### DIFF
--- a/srcpkgs/po4a/template
+++ b/srcpkgs/po4a/template
@@ -1,6 +1,6 @@
 # Template file for 'po4a'
 pkgname=po4a
-version=0.63
+version=0.66
 revision=1
 build_style=perl-ModuleBuild
 _perldeps="perl perl-Text-WrapI18N perl-Term-ReadKey perl-Unicode-LineBreak
@@ -9,9 +9,12 @@ hostmakedepends="${_perldeps} perl-Locale-gettext perl-Module-Build gettext
  libxslt docbook-xsl"
 makedepends="${_perldeps} perl-Locale-gettext perl-Module-Build"
 depends="${_perldeps} opensp gettext"
+checkdepends="docbook opensp perl-Test-Pod texlive"
 short_desc="PO for anything (po4a) project to ease translations using gettext tools"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-2.0-or-later"
 homepage="https://po4a.org/"
+changelog="https://raw.githubusercontent.com/mquinson/po4a/master/NEWS"
 distfiles="https://github.com/mquinson/po4a/archive/v${version}.tar.gz"
-checksum=534a050af6e8d8d2acd5dd32b66c9a15f64106f022efef72cd82c175de34e595
+checksum=8ae65c69b3a3e3911c449284aa9f07c80b74484fd211f6e2a7e6b57e09f3afd8
+make_check=ci-skip # cannot repoduce failure locally


### PR DESCRIPTION
Two sgml tests fail because they invoke `onsgmls` from OpenSP to verify a test sgml file against a docbook DTD which errors out.

The `opensp` package adds a sgml catalog entry
`CATALOG /usr/share/OpenSP/catalog`
and in `/usr/share/OpenSP/catalog` there is a sgml declaration:
`SGMLDECL unicode.sd`

When this line or the catalog entry above is removed `onsgmls` falls back to its
default definition and succeeds and all tests are passed.

I’m not sure if the problem is related to Void’s `opensp` package or to `po4a`.
Any ideas are welcome! :)
I also asked upstream: https://github.com/mquinson/po4a/issues/327

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->