### PR TITLE
devilutionX: update to 1.4.1 (maintainer version)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4222,3 +4222,4 @@ libIlmThread-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXR-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXRCore-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXRUtil-3_1.so.30 libopenexr-3.1.5_1
+libstorm.so.9 StormLib-9.24_1

--- a/srcpkgs/StormLib-devel
+++ b/srcpkgs/StormLib-devel
@@ -1,0 +1,1 @@
+StormLib

--- a/srcpkgs/StormLib/template
+++ b/srcpkgs/StormLib/template
@@ -1,0 +1,27 @@
+# Template file for 'StormLib'
+pkgname=StormLib
+version=9.24
+revision=1
+build_style=cmake
+configure_args="-DBUILD_SHARED_LIBS=ON -DWITH_LIBTOMCRYPT=ON"
+hostmakedepends="pkg-config"
+makedepends="bzip2-devel zlib-devel libtomcrypt-devel libtommath-devel"
+short_desc="C/C++ API to read and write MPQ files with support for merged archives"
+maintainer="MarcoAPC <marcoaureliopc@gmail.com>"
+license="MIT"
+homepage="https://github.com/ladislav-zezula/StormLib"
+distfiles="https://github.com/ladislav-zezula/StormLib/archive/v${version}.tar.gz"
+checksum=33e43788f53a9f36ff107a501caaa744fd239f38bb5c6d6af2c845b87c8a2ee1
+
+post_install() {
+	vlicense LICENSE
+}
+
+StormLib-devel_package() {
+	short_desc+=" - development files"
+	depends="StormLib>=${version}_${revision}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/devilutionX/template
+++ b/srcpkgs/devilutionX/template
@@ -3,7 +3,7 @@ pkgname=devilutionX
 version=1.4.1
 revision=1
 build_style=cmake
-configure_args="-DVERSION_NUM=$version -DBINARY_RELEASE=ON -DBUILD_TESTING=OFF -DDISABLE_ZERO_TIER=ON"
+configure_args="-DVERSION_NUM=$version -DBUILD_TESTING=OFF -DDISABLE_ZERO_TIER=ON"
 hostmakedepends="git gettext pkg-config smpq"
 makedepends="SDL2-devel SDL2_image-devel fmt-devel libpng-devel libsodium-devel bzip2-devel"
 short_desc="Diablo I engine for modern operating systems"

--- a/srcpkgs/devilutionX/template
+++ b/srcpkgs/devilutionX/template
@@ -1,16 +1,25 @@
 # Template file for 'devilutionX'
 pkgname=devilutionX
-version=1.2.1
+version=1.4.1
 revision=1
 build_style=cmake
-configure_args="-DVERSION_NUM=$version -DBINARY_RELEASE=ON -DTTF_FONT_PATH=\"/usr/share/fonts/truetype/CharisSILB.ttf\""
-makedepends="SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel"
+configure_args="-DVERSION_NUM=$version -DBINARY_RELEASE=ON -DBUILD_TESTING=OFF -DDISABLE_ZERO_TIER=ON"
+hostmakedepends="git gettext pkg-config smpq"
+makedepends="SDL2-devel SDL2_image-devel fmt-devel libpng-devel libsodium-devel bzip2-devel"
 short_desc="Diablo I engine for modern operating systems"
 maintainer="MarcoAPC <marcoaureliopc@gmail.com>"
 license="Unlicense"
 homepage="https://github.com/diasurgical/devilutionX"
-distfiles="https://github.com/diasurgical/devilutionX/archive/${version}.tar.gz"
-checksum=002dcbd4d4a5bdf8db1a3ec01139e5bfbed46d6a1caa32b17c9f2df161ad3521
+distfiles="https://github.com/diasurgical/devilutionX/archive/${version}.tar.gz
+https://raw.githubusercontent.com/diasurgical/devilutionX/1.2.1/CMake/FindSDL2.cmake"
+checksum="54b9fd496eba5b82d7e64891ab4de808f539c60b3b94bfa49639e0d9580fb7b8
+5df4976281066baf46bcc1d27f4855f1eec0831da43323184b7353aa5eb269a9"
+
+skip_extraction="FindSDL2.cmake"
+
+post_extract() {
+	cp ${XBPS_SRCDISTDIR}/${pkgname}-${version}/FindSDL2.cmake CMake/finders
+}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/smpq/patches/fix-smpq-compilation.patch
+++ b/srcpkgs/smpq/patches/fix-smpq-compilation.patch
@@ -1,0 +1,53 @@
+--- a/CMakeLists.txt	2021-11-17 00:05:26.153515080 -0300
++++ b/CMakeLists.txt	2021-11-17 00:07:09.549884637 -0300
+@@ -18,6 +18,8 @@
+ #
+ 
+ project(SMPQ)
++file(GLOB_RECURSE CFILES "${CMAKE_SOURCE_DIR}/*.c")
++SET_SOURCE_FILES_PROPERTIES(${CFILES} PROPERTIES LANGUAGE CXX)
+ set(VERSION 1.6)
+ cmake_minimum_required(VERSION 2.6)
+ 
+@@ -42,11 +44,7 @@
+ 	endif(NOT STORMLIB_LIBRARY)
+ 
+ 	try_compile(CHECK ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/check.c COMPILE_DEFINITIONS -I${STORMLIB_INCLUDE_DIR})
+-
+-	if(NOT CHECK)
+-		message(FATAL_ERROR "Found old StormLib version")
+-	endif(NOT CHECK)
+-
++	
+ 	message(STATUS "Found StormLib header: ${STORMLIB_INCLUDE_DIR}/StormLib.h")
+ 	message(STATUS "Found StormLib library: ${STORMLIB_LIBRARY}")
+ 
+@@ -93,24 +91,16 @@
+ if(WITH_CMD)
+ 
+ 	add_executable(smpq ${SMPQ_SRCS})
+-	target_link_libraries(smpq ${STORMLIB_LIBRARY})
++	find_package(ZLIB REQUIRED)
++	find_package(BZip2 REQUIRED)
++	target_link_libraries(smpq ${STORMLIB_LIBRARY} ${ZLIB_LIBRARY} ${BZIP2_LIBRARIES})
+ 
+ 	if(WIN32 AND NOT MSVC)
+ 		set_target_properties(smpq PROPERTIES LINK_FLAGS -static)
+ 		target_link_libraries(smpq wininet stdc++)
+ 	endif(WIN32 AND NOT MSVC)
+ 
+-	install(TARGETS smpq DESTINATION bin)
+-
+-	if(NOT CMAKE_CROSSCOMPILING)
+-
+-		add_executable(mangen ${MANGEN_SRCS})
+-		add_custom_command(OUTPUT smpq.1 COMMAND mangen > smpq.1 DEPENDS mangen)
+-		add_custom_target(man ALL DEPENDS smpq.1)
+-
+-		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/smpq.1 DESTINATION share/man/man1)
+-
+-	endif(NOT CMAKE_CROSSCOMPILING)
++	install(TARGETS smpq DESTINATION bin)	
+ 
+ 	if(WIN32 AND WITH_NSIS)
+ 

--- a/srcpkgs/smpq/template
+++ b/srcpkgs/smpq/template
@@ -1,0 +1,14 @@
+# Template file for 'smpq'
+pkgname=smpq
+version=1.6
+revision=1
+build_style=cmake
+configure_args="-DWITH_KDE=OFF"
+makedepends="bzip2-devel zlib-devel StormLib-devel"
+short_desc="StormLib MPQ archiving utility"
+maintainer="MarcoAPC <marcoaureliopc@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://launchpad.net/smpq"
+changelog="https://bazaar.launchpad.net/~pali/smpq/trunk/view/head:/CHANGELOG"
+distfiles="https://launchpad.net/smpq/trunk/${version}/+download/smpq_${version}.orig.tar.gz"
+checksum=b5d2dc8a5de8629b71ee5d3612b6e84d88418b86c5cd39ba315e9eb0462f18cb


### PR DESCRIPTION
Required packages to build devilutionX

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
