### PR TITLE
xorg-server: needs libxshmfence-devel

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -14,9 +14,9 @@ hostmakedepends="pkg-config xkbcomp flex"
 makedepends="MesaLib-devel libXaw-devel libXfont-devel libXfont2-devel
  libXrender-devel libXres-devel libXtst-devel libXv-devel libXxf86dga-devel
  libdmx-devel libepoxy-devel openssl-devel libtirpc-devel libxkbfile-devel
- libxkbui-devel pixman-devel xcb-util-image-devel xcb-util-keysyms-devel
- xcb-util-renderutil-devel xcb-util-wm-devel xkbcomp nettle-devel
- $(vopt_if elogind 'dbus-devel')"
+ libxkbui-devel libxshmfence-devel pixman-devel xcb-util-image-devel
+ xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel xkbcomp
+ nettle-devel $(vopt_if elogind 'dbus-devel')"
 # See hw/xfree86/common/xf86Module.h. Only care for the major version.
 depends="xkeyboard-config $(vopt_if elogind 'elogind') xorg-server-common"
 checkdepends="xkeyboard-config"


### PR DESCRIPTION
otherwise the build fails; it’s missing due to https://github.com/void-linux/void-packages/commit/32b3f0eab82a52fa37bef1a26a9a8d2afd6ccc92

@q66

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
