### PR TITLE
rmapi: update to 0.0.17

### DIFF
--- a/srcpkgs/rmapi/template
+++ b/srcpkgs/rmapi/template
@@ -1,12 +1,12 @@
 # Template file for 'rmapi'
 pkgname=rmapi
-version=0.0.15
+version=0.0.17
 revision=1
 build_style=go
 go_import_path=github.com/juruen/rmapi
 short_desc="CLI for accessing reMarkable table files through the cloud api"
 maintainer="Patrick Pichler <mail@patrickpichler.dev>"
-license="GPL-3.0-or-later"
+license="AGPL-3.0-only"
 homepage="https://github.com/juruen/rmapi"
 distfiles="https://github.com/juruen/rmapi/archive/v${version}${_status}.tar.gz"
-checksum=606101d385c1b396d0e0a3cc06b382f9b3498895e0402f717652c8b3e54a0c86
+checksum=129d627daa9ce66e912e8d0b960078bde9cf13a3da2cdc5788fa220a1230832a


### PR DESCRIPTION
This also fixes a license discrepancy that's existed for quite a few versions, where in https://github.com/juruen/rmapi/pull/89 the project re-licensed from GPL3 to AGPL3.

I've confirmed this works by way of actually being able to login to reMarkable's servers with this build: the URLs are wrong in the 0.0.15 that is currently packaged, and I wasn't able to generate a one-time code.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- I built this PR locally for my native architecture, (x86_64 (glibc))
