### PR TITLE
[RFC] option to skip 03-rewrite-python-shebang

### DIFF
--- a/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
+++ b/common/hooks/pre-pkg/03-rewrite-python-shebang.sh
@@ -4,6 +4,10 @@
 hook() {
 	local pyver= shebang= off=
 
+	if [ -n "$no_python_shebang" ]; then
+		return 0
+	fi
+
 	if [ -d ${PKGDESTDIR}/usr/lib/python* ]; then
 		pyver="$(find ${PKGDESTDIR}/usr/lib/python* -prune -type d | grep -o '[[:digit:]]\.[[:digit:]]\+$')"
 	fi


### PR DESCRIPTION
For #34030 we need to disable `pre-pkg/03-rewrite-python-shebang`, since sagemath ships its own python and rewriting shebangs breaks it (we will work on un-vendoring python, but that's a different story).

This PR adds an option `no_python_shebang=yes` to skip running this hook, similar to `nocross=yes`.

If this goes through, it will have to be added to `Manual.md` and to `xlint`, but I want to get feedback before.

Maybe, as an alternative, a way to skip hooks by name would be more generally useful? Something like `skip_hook="pre-pkg/03-rewrite-python-shebang"` with a space separated list of hooks to skip. That shouldn't be too hard to implement in `run_pkg_hooks()`.