### PR TITLE
GNS3: upgrade to 2.2.27

### DIFF
--- a/srcpkgs/gns3-gui/template
+++ b/srcpkgs/gns3-gui/template
@@ -1,8 +1,10 @@
 # Template file for 'gns3-gui'
 pkgname=gns3-gui
-version=2.2.26
-revision=2
+version=2.2.27
+revision=1
 build_style=python3-module
+# Skip tests/test_link.py::test_create_link test that wasn't updated with the code https://github.com/GNS3/gns3-gui/commit/545a9f53
+make_check_args="-k-test_create_link"
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-psutil python3-jsonschema
  python3-PyQt5-svg python3-PyQt5-websockets xterm inetutils-telnet
@@ -13,7 +15,7 @@ maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
-checksum=b97084e1024dfc23255fa0bdd1023a9b145ba610322a8363cd15d9153837333d
+checksum=c5afadd2932703c38fb6d479be6966af65787ddc6abcb3f9b7c0b3f5722e0fd5
 
 post_install() {
 	vinstall gns3-gui.desktop 644 usr/share/applications

--- a/srcpkgs/gns3-server/patches/requirements.patch
+++ b/srcpkgs/gns3-server/patches/requirements.patch
@@ -9,7 +9,7 @@ diff --git a/requirements.txt b/requirements.txt
  aiohttp-cors==0.7.0
  aiofiles==0.7.0
 -Jinja2==3.0.1
-+Jinja2>=2.0.0<3.0.0
++Jinja2>=3.0.1
 -sentry-sdk==1.3.1
  psutil==5.8.0
  async-timeout==3.0.1

--- a/srcpkgs/gns3-server/template
+++ b/srcpkgs/gns3-server/template
@@ -1,8 +1,10 @@
 # Template file for 'gns3-server'
 pkgname=gns3-server
-version=2.2.26
-revision=2
+version=2.2.27
+revision=1
 build_style=python3-module
+# Skip tests/compute/docker/test_docker_vm.py::test_stop test that wasn't updated with the code https://github.com/GNS3/gns3-server/commit/b1a62dfd
+make_check_args="-k-test_stop"
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-jsonschema python3-aiohttp-cors python3-yarl
  python3-Jinja2 python3-psutil python3-aiofiles
@@ -13,7 +15,7 @@ maintainer="Tim Sandquist <tim.sandquist@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 distfiles="https://github.com/GNS3/gns3-server/archive/v${version}.tar.gz"
-checksum=6d89d91f74d2891de3c7ebec93880af662f835580d2f18a797794eb8e2350bc0
+checksum=ed45ab788ee976474289e9e73c5bbe78cab26ebfcdcc5d2eee086908d14d0c9f
 
 # The source archive contains statically linked artifacts for x86_64
 # glibc, since this is the only architecture supported by upstream, we


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This change upgrades gns3-server and gns3-gui to 2.2.27.  It also updates requirements to work latest python3-Jinja2 package.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
