### PR TITLE
common/environment/build-style: remove nostrip from go.sh

### DIFF
--- a/common/environment/build-style/go.sh
+++ b/common/environment/build-style/go.sh
@@ -16,7 +16,6 @@ else
 		export GCCGO="${XBPS_CROSS_TRIPLET}-gccgo"
 	fi
 fi
-nostrip=yes
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) export GOARCH=arm64;;


### PR DESCRIPTION
Hasn't been necessary in Go for a long time [1], so we should take
advantage of that. For an example of the advantages, the 'micro' editor
went from 15MB to 11MB on disk.

[1] https://honnef.co/posts/2016/10/go-and-strip/

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@the-maldridge

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
