### PR TITLE
sympow: add a patch to avoid printing warnings

### DIFF
--- a/srcpkgs/sympow/patches/sympow-2.023.6-no-pkgdatafilesbindir-warnings.patch
+++ b/srcpkgs/sympow/patches/sympow-2.023.6-no-pkgdatafilesbindir-warnings.patch
@@ -1,0 +1,45 @@
+From cf182287eb4219b03e57352072449885e10543f3 Mon Sep 17 00:00:00 2001
+From: Michael Orlitzky <michael@orlitzky.com>
+Date: Fri, 15 May 2020 16:49:49 -0400
+Subject: [PATCH 1/1] main.c: hide pkgdatafilesbindir warnings behind VERBOSE
+ >= 2.
+
+The default "pkgdatafilesbindir" is something like /var/cache/sympow
+that will never be writable by unprivileged users (and cannot safely
+be made that way). There is already a fallback to $HOME in the code
+that works perfectly well, but by default sympow emits a warning when
+it realizes that it can't write to e.g. /var/cache/sympow on the first
+try. Since that's completely expected, we hide the warnings behind an
+additional level of verbosity (VERBOSE >= 2 instead of VERBOSE >= 1).
+---
+ main.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/main.c b/main.c
+index 1d018df..fecd7d1 100644
+--- a/main.c
++++ b/main.c
+@@ -136,17 +136,17 @@ static void prepare_main(char *argv0)
+  asprintf(&pkgdatafilesbindir,"%s/datafiles/"ENDIANTUPLE,pkgcachedir);
+  if (stat(pkgdatafilesbindir,&infodb)) {mode_t mask=umask(0);
+   if (mkdir(pkgdatafilesbindir,(S_IRWXU|S_IRWXG|S_IRWXO|S_ISVTX)))
+-	{if (VERBOSE>=1) fprintf(stderr,"**WARNING** failed to create data bin package cache folder %s\n",pkgdatafilesbindir);
++	{if (VERBOSE>=2) fprintf(stderr,"**WARNING** failed to create data bin package cache folder %s\n",pkgdatafilesbindir);
+    free(pkgdatafilesbindir); pkgdatafilesbindir=NULL;}
+   else
+   {stat(pkgdatafilesbindir,&infodb); pkgdatamode= infodb.st_mode & ~MASK;}
+ 	umask(mask);}
+  else
+  {if (!S_ISDIR(infodb.st_mode))
+-  {if (VERBOSE>=1) fprintf(stderr,"**WARNING** %s exists but is not a directory\n",pkgdatafilesbindir);
++  {if (VERBOSE>=2) fprintf(stderr,"**WARNING** %s exists but is not a directory\n",pkgdatafilesbindir);
+    free(pkgdatafilesbindir); pkgdatafilesbindir=NULL;}
+   else if (access(pkgdatafilesbindir,(R_OK|W_OK|X_OK)))
+-  {if (VERBOSE>=1) fprintf(stderr,"**WARNING** %s yields insufficient permissions\n",pkgdatafilesbindir);
++  {if (VERBOSE>=2) fprintf(stderr,"**WARNING** %s yields insufficient permissions\n",pkgdatafilesbindir);
+    free(pkgdatafilesbindir); pkgdatafilesbindir=NULL;}
+ 	else {pkgdatamode= infodb.st_mode & ~MASK;}}
+  asprintf(&datafilesdir,"%s/datafiles",cachedir);
+-- 
+2.26.2
+

--- a/srcpkgs/sympow/template
+++ b/srcpkgs/sympow/template
@@ -1,7 +1,7 @@
 # Template file for 'sympow'
 pkgname=sympow
 version=2.023.6
-revision=1
+revision=2
 wrksrc=${pkgname}-v${version}
 build_style=configure
 make_build_target=all


### PR DESCRIPTION
Patch taken from sagemath, without it some sage doctests fail just
because of the extraneous output.

From the patch description:

The default "pkgdatafilesbindir" is something like /var/cache/sympow
that will never be writable by unprivileged users (and cannot safely
be made that way). There is already a fallback to $HOME in the code
that works perfectly well, but by default sympow emits a warning when
it realizes that it can't write to e.g. /var/cache/sympow on the first
try. Since that's completely expected, we hide the warnings behind an
additional level of verbosity (VERBOSE >= 2 instead of VERBOSE >= 1).