### PR TITLE
Manual.md: clarify default build target

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -581,8 +581,9 @@ phase if `${build_style}` is set to `configure`, `gnu-configure` or
 `PREFIX=/usr DESTDIR=${DESTDIR}`.
 
 - `make_build_target` The build target. If `${build_style}` is set to `configure`, `gnu-configure`
-or `gnu-makefile`, this is the target passed to `${make_cmd}` in the build phase; when unset, it
-defaults to `all`. If `${build_style}` is `python3-pep517`, this is the path of the package
+or `gnu-makefile`, this is the target passed to `${make_cmd}` in the build phase;
+when unset the default target is used.
+If `${build_style}` is `python3-pep517`, this is the path of the package
 directory that should be built as a Python wheel; when unset, defaults to `.` (the current
 directory with respect to the build).
 


### PR DESCRIPTION
New text:
  - `make_build_target` The build target. If `${build_style}` is set to `configure`, `gnu-configure` or `gnu-makefile`, this is the target passed to `${make_cmd}` in the build phase; when unset the default target is used.

The previous text incorrectly claims that it defaults to `all`
