### PR TITLE
mdnsd: Conflicts with mDNSResponder

### DIFF
--- a/srcpkgs/mdnsd/template
+++ b/srcpkgs/mdnsd/template
@@ -1,7 +1,7 @@
 # Template file for 'mdnsd'
 pkgname=mdnsd
 version=0.10
-revision=2
+revision=3
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config libtool"
 short_desc="Embeddable Multicast DNS Daemon"
@@ -13,6 +13,7 @@ checksum=2e1a77fc9ff36e993a39b10016fe38723784ca7e3141ca00e4d6f43545d2988c
 
 conf_files="
  /etc/mdns.d/ssh.service"
+conflicts="mDNSResponder"
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
mdnsd and mDNSResponder both provide /usr/bin/mdnsd, so they should be marked as conflicting.

Fixes #33762

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**