### PR TITLE
valgrind: update to 3.18.1.

### DIFF
--- a/srcpkgs/valgrind/patches/str_tester.patch
+++ b/srcpkgs/valgrind/patches/str_tester.patch
@@ -1,0 +1,22 @@
+rawmemchar is not available on musl, guard it with defined(__GLIBC__)
+
+--- a/memcheck/tests/str_tester.c	2021-10-10 14:17:32.000000000 +0000
++++ b/memcheck/tests/str_tester.c	2021-11-16 19:37:26.950006442 +0000
+@@ -504,7 +504,7 @@
+ #endif
+ 
+ // DDD: better done by testing for the function.
+-#if !defined(__APPLE__) && !defined(__sun) && !defined(__FreeBSD__)
++#if defined(__GLIBC__) && !defined(__APPLE__) && !defined(__sun) && !defined(__FreeBSD__)
+ static void
+ test_rawmemchr (void)
+ {
+@@ -1451,7 +1451,7 @@
+   test_strchrnul ();
+ # endif
+ 
+-# if !defined(__APPLE__) && !defined(__sun) && !defined(__FreeBSD__)
++# if defined(__GLIBC__) && !defined(__APPLE__) && !defined(__sun) && !defined(__FreeBSD__)
+   /* rawmemchr.  */
+   test_rawmemchr ();
+ # endif

--- a/srcpkgs/valgrind/patches/tc20_verifywrap_musl.patch
+++ b/srcpkgs/valgrind/patches/tc20_verifywrap_musl.patch
@@ -1,0 +1,11 @@
+--- a/helgrind/tests/tc20_verifywrap.c	2021-11-16 21:01:30.020008847 +0000
++++ b/helgrind/tests/tc20_verifywrap.c	2021-11-16 21:02:22.140008872 +0000
+@@ -20,7 +20,7 @@
+ 
+ #if !defined(__APPLE__) && !defined(__FreeBSD__)
+ 
+-#if defined(__sun__)
++#if defined(__sun__) || !defined(__GLIBC__)
+ /* Fake __GLIBC_PREREQ on Solaris. Pretend glibc >= 2.4. */
+ # define __GLIBC_PREREQ
+ #else

--- a/srcpkgs/valgrind/patches/test_statx.patch
+++ b/srcpkgs/valgrind/patches/test_statx.patch
@@ -1,0 +1,18 @@
+--- a/memcheck/tests/linux/sys-statx.c	2021-01-21 15:09:33.000000000 +0000
++++ b/memcheck/tests/linux/sys-statx.c	2021-11-16 20:26:33.970007848 +0000
+@@ -7,11 +7,15 @@
+ #include <assert.h>
+ #include <string.h>
+ #include <sys/syscall.h>
++#if defined(__GLIBC__)
+ #if __GLIBC_PREREQ(2,28)
+ /* struct statx provided in sys/stat.h */
+ #else
+ #include <linux/stat.h>
+ #endif
++#else
++#include <linux/stat.h>
++#endif
+ #include <errno.h>
+ 
+ int check_stat2;

--- a/srcpkgs/valgrind/patches/throw.patch
+++ b/srcpkgs/valgrind/patches/throw.patch
@@ -1,0 +1,34 @@
+--- a/memcheck/tests/arm64-linux/scalar.h	2021-01-21 15:09:33.000000000 +0000
++++ b/memcheck/tests/arm64-linux/scalar.h	2021-11-16 20:56:18.980008699 +0000
+@@ -14,7 +14,13 @@
+ 
+ // Since we use vki_unistd.h, we can't include <unistd.h>.  So we have to
+ // declare this ourselves.
+-extern long int syscall (long int __sysno, ...) __THROW;
++#ifdef __THROW
++#define THROW __THROW
++#else
++#define THROW
++#endif
++extern long int syscall (long int __sysno, ...) THROW;
++#undef THROW
+ 
+ // Thorough syscall scalar arg checking.  Also serves as thorough checking
+ // for (very) basic syscall use.  Generally not trying to do anything
+--- a/memcheck/tests/x86-linux/scalar.h	2021-01-21 15:09:33.000000000 +0000
++++ b/memcheck/tests/x86-linux/scalar.h	2021-11-16 20:55:24.890008673 +0000
+@@ -14,7 +14,13 @@
+ 
+ // Since we use vki_unistd.h, we can't include <unistd.h>.  So we have to
+ // declare this ourselves.
+-extern long int syscall (long int __sysno, ...) __THROW;
++#ifdef __THROW
++#define THROW __THROW
++#else
++#define THROW
++#endif
++extern long int syscall (long int __sysno, ...) THROW;
++#undef THROW
+ 
+ // Thorough syscall scalar arg checking.  Also serves as thorough checking
+ // for (very) basic syscall use.  Generally not trying to do anything

--- a/srcpkgs/valgrind/template
+++ b/srcpkgs/valgrind/template
@@ -1,6 +1,6 @@
 # Template file for 'valgrind'
 pkgname=valgrind
-version=3.16.1
+version=3.18.1
 revision=1
 build_style=gnu-configure
 configure_args="--enable-tls --without-mpicc --enable-lto=yes"
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://valgrind.org/"
 distfiles="https://sourceware.org/pub/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca
+checksum=00859aa13a772eddf7822225f4b46ee0d39afbe071d32778da4d99984081f7f5
 
 CFLAGS="-fno-stack-protector"
 CXXFLAGS="-fno-stack-protector"
@@ -40,10 +40,6 @@ esac
 if [ "$XBPS_TARGET_MACHINE" = "armv7l" ]; then
 	configure_args+=" ac_cv_host=armv7l-unknown-linux-gnueabihf"
 fi
-
-pre_configure() {
-	autoreconf -fi
-}
 
 valgrind-devel_package() {
 	depends="valgrind>=${version}_${revision}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, (aarch64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl


This superseeds #30380.
To address remarks from the old PR:
 - The musl.supp file is now upstream, no need to patch it in anymore.
 - armv6 was not supported by valgrind in the past, I could not find any hint that this changed. If the code generation in valgrind asumes armv7 patching the configure script likely won't be enough. 
