### PR TITLE
nim: update to 1.6.0, fix non-x86_64/i686 packages, improve template

### DIFF
--- a/srcpkgs/nim/template
+++ b/srcpkgs/nim/template
@@ -1,13 +1,11 @@
 # Template file for 'nim'
 pkgname=nim
-version=1.4.8
+version=1.6.0
 revision=1
-_cversion=0.20.0
-_nimbleversion=0.12.0
-_fusionversion=e942c649892b2ae3802851fba6bc5d251326e5fb
+_c1version=561b417c65791cd8356b5f73620914ceff845d10
+_nimbleversion=0.13.1
 create_wrksrc=yes
 build_wrksrc="Nim-$version"
-hostmakedepends="ed"
 depends="gcc openssl-devel"
 short_desc="Nim programming language"
 maintainer="allan <mail@may.mooo.com>"
@@ -15,31 +13,27 @@ license="MIT"
 homepage="https://nim-lang.org/"
 _ghsite="https://github.com/nim-lang"
 distfiles="${_ghsite}/Nim/archive/v${version}.tar.gz
- ${_ghsite}/csources/archive/v${_cversion}.tar.gz>csources-${_cversion}.tar.gz
- ${_ghsite}/nimble/archive/v${_nimbleversion}.tar.gz>nimble-${_nimbleversion}.tar.gz
- ${_ghsite}/fusion/archive/${_fusionversion}.tar.gz>fusion-${_fusionversion}.tar.gz"
-checksum="8a687beb30670dc4eadcfefd1198d4238af283dc716438ac2342a7d65e07d9e9
- 5e6fd15d90df1a8cb7614c4ffc70aa8c4198cd854d7742016202b96dd0228d3c
- 0b88d91a450f31641f85379f2d76afb0a013cf783e62144a6534525b9cb1cbac
- 76d10a2f0f25ba7fb3393bdb800c75e8084758d8ce69e63d07926cd36f555084"
+ ${_ghsite}/csources_v1/archive/${_c1version}.tar.gz>csources_v1-${_c1version}.tar.gz
+ ${_ghsite}/nimble/archive/v${_nimbleversion}.tar.gz>nimble-${_nimbleversion}.tar.gz"
+checksum="c202cfd24a24480da1cf851e1265b87edb22710bb42286a57b1a99c83b6a8315
+ 71c823444c794a12da9027d19d6a717dd7759521ecbbe28190b08372142607ec
+ e6aa8d9ee4b3ed0321dca329b4a38fa546771b9729984482fb50fe73d3777f5d"
 
 post_extract() {
-	mv csources-$_cversion $build_wrksrc/csources
+	mv csources_v1-$_c1version $build_wrksrc/csources_v1
 	mkdir $build_wrksrc/dist
 	mv nimble-$_nimbleversion $build_wrksrc/dist/nimble
-	mv fusion-$_fusionversion $build_wrksrc/dist/fusion
 }
 
 do_build() {
-	cd csources
 	case "$XBPS_TARGET_MACHINE" in
 		i686*)
 			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
-			sh build.sh --cpu i686;;
+			make -C csources_v1 ucpu=i686 ${makejobs};;
 		*)
-			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= sh build.sh;;
+			CC=cc LD=cc CFLAGS="-Os -pipe" LDFLAGS= \
+			make -C csources_v1 ${makejobs};;
 	esac
-	cd ..
 
 	bin/nim c koch
 	./koch boot -d:release -d:danger
@@ -54,32 +48,15 @@ do_build() {
 
 	case "$XBPS_TARGET_MACHINE"
 	in arm*|aarch64*|ppc*)
-		ed config/nim.cfg <<-EDIT
-			,s/^arm.linux.gcc.exe .*/arm.linux.gcc.exe = "$CC"/
-			,s/^arm.linux.gcc.linkerexe .*/arm.linux.gcc.linkerexe = "$CC"/
-			a
-			arm64.linux.gcc.exe = "$CC"
-			arm64.linux.gcc.linkerexe = "$CC"
-			powerpc.linux.gcc.exe = "$CC"
-			powerpc.linux.gcc.linkerexe = "$CC"
-			powerpc64.linux.gcc.exe = "$CC"
-			powerpc64.linux.gcc.linkerexe = "$CC"
-			powerpc64el.linux.gcc.exe = "$CC"
-			powerpc64el.linux.gcc.linkerexe = "$CC"
-			.
-			w
-			q
+		vsed -i config/nim.cfg -e 's/^arm\.linux\.gcc\.\(linker\)\?exe /#&/'
+		cat >>config/nim.cfg <<-EDIT
+		# VOIDLINUX TEMP
+		$_arch.linux.gcc.exe = "$CC"
+		$_arch.linux.gcc.linkerexe = "$CC"
 		EDIT
 		bin/nim c -d:release -d:danger --os:linux --cpu:$_arch --listCmd compiler/nim
-		for _p in \
-			dist/nimble/src/nimble \
-			tools/nimgrep \
-			nimsuggest/nimsuggest \
-			nimpretty/nimpretty
-		do
-			bin/nim c -d:release --os:linux --cpu:$_arch --listCmd $_p
-			mv $_p bin
-		done
+		./koch tools --os:linux --cpu:$_arch --listCmd
+		vsed -i config/nim.cfg -e '/^# VOIDLINUX TEMP$/,$d'
 	;; *)
 		./koch tools
 	esac
@@ -95,14 +72,13 @@ do_install() {
 	vmkdir usr/bin
 	vmkdir usr/share/nim
 	ln -sf /usr/lib/nim/bin/nim ${DESTDIR}/usr/bin/nim
-	for _f in nimble nimsuggest nimgrep nimpretty; do
+	for _f in nimble nimsuggest nimgrep nimpretty testament; do
 		chmod 0755 bin/$_f
 		cp bin/$_f ${DESTDIR}/usr/lib/nim/bin
 		ln -sf /usr/lib/nim/bin/$_f ${DESTDIR}/usr/bin/$_f
 	done
-	cp -r nimsuggest nimpretty doc examples ${DESTDIR}/usr/lib/nim
+	cp -r nimsuggest nimpretty doc ${DESTDIR}/usr/lib/nim
 	ln -sf /usr/lib/nim/doc ${DESTDIR}/usr/share/nim/doc
-	ln -sf /usr/lib/nim/examples ${DESTDIR}/usr/share/nim/examples
 	ln -sf /usr/lib/nim/nimsuggest ${DESTDIR}/usr/share/nim/nimsuggest
 	ln -sf /usr/lib/nim/nimpretty ${DESTDIR}/usr/share/nim/nimpretty
 	vlicense copying.txt


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (glibc)
- I cross-built it for a few things (aarch64 and arm all glibc)

I think it is about ready.

Old comments below this line.

---

I was mainly putting this up here to gather comments. For background, things which have changed between what is available in the repositories and 1.6.0:

- Nim no longer bundles fusion. It provides a koch command to nimble install it at a specific commit. It might be worth providing it as a separate package but maybe not worth it.
- Nim now uses csources_v1 instead of csources. This is now built with make. We used to pass --cpu to build.sh based on XBPS_TARGET_MACHINE. I removed this temporarily, I think it would have to be re-added setting the ucpu variable instead but I would like to see what CI says first.
- Nim now comes with testament which I am installing like the rest of things
- Nim no longer comes with examples

Other notes:

- I bumped the nimble version but actually I think it would be more correct to figure out which exact commit nim 1.6.0 uses in build_all.sh and mirror that. I simply haven't gotten around to this yet. (update: Looks like it uses 0.13.1 so the template is correct now)
- I noticed build_all.sh passes `--skipUserCfg --skipParentCfg --hints:off` everywhere. I'm not sure if we should mirror that. I think the first two options would be irrelevant inside the build environment and the last option is just removing diagnostics. They're not essential options but I also don't think they hurt.
- It would be nice if someone else had a glance at this. I don't really do void packaging but I think I did almost everything correctly.