### PR TITLE
pipe-viewer: update to 0.1.7.

### DIFF
--- a/srcpkgs/pipe-viewer/template
+++ b/srcpkgs/pipe-viewer/template
@@ -1,12 +1,12 @@
 # Template file for 'pipe-viewer'
 pkgname=pipe-viewer
-version=0.1.5
+version=0.1.7
 revision=1
 build_style=perl-ModuleBuild
 configure_args="--gtk"
 hostmakedepends="perl-Module-Build"
 depends="perl-Data-Dump perl-JSON perl-LWP-Protocol-https perl-Term-ReadLine-Gnu
- perl-Unicode-LineBreak perl-JSON-XS perl-HTML-Parser"
+ perl-Unicode-LineBreak perl-JSON-XS perl-HTML-Parser yt-dlp"
 checkdepends="perl-Test-Pod"
 short_desc="Search and play videos from YouTube without an API key"
 maintainer="Roberto Ricci <ricci@disroot.org>"
@@ -14,7 +14,7 @@ license="Artistic-2.0"
 homepage="https://github.com/trizen/pipe-viewer"
 changelog="https://github.com/trizen/pipe-viewer/releases"
 distfiles="https://github.com/trizen/pipe-viewer/archive/${version}.tar.gz"
-checksum=2b2aaabeba4335e661c9dba0abad3ee7d30a5028446f252100db6e5d3bea90d5
+checksum=f4a17a836503698c6f921f41e018fdae921949d6b9be3ebd1ba500c313474dd0
 
 pipe-viewer-gtk_package() {
 	depends="${sourcepkg}>=${version}_${revision} perl-Gtk3 perl-File-ShareDir"


### PR DESCRIPTION
Also add yt-dlp as a dependency.
Although not strictly required, it is more reliable than
the native parser and it is used by default if installed.

Supersedes #34062.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
