### PR TITLE
monitoring-plugins: build with check_snmp

### DIFF
--- a/srcpkgs/monitoring-plugins/template
+++ b/srcpkgs/monitoring-plugins/template
@@ -1,10 +1,10 @@
 # Template file for 'monitoring-plugins'
 pkgname=monitoring-plugins
 version=2.2
-revision=8
+revision=9
 build_style=gnu-configure
 configure_args="--libexecdir=/usr/lib/monitoring-plugins"
-hostmakedepends="fping openssh postfix procps-ng smbclient"
+hostmakedepends="fping openssh postfix procps-ng smbclient net-snmp"
 makedepends="libldap-devel libmariadbclient-devel postgresql-libs-devel
  zlib-devel"
 depends="iputils procps-ng"


### PR DESCRIPTION
net-snmp needs to be present for configure to include check_snmp

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64