### PR TITLE
routinator: update to 0.10.2

### DIFF
--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,6 +1,6 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.7.1
+version=0.10.2
 revision=1
 build_style=cargo
 depends="rsync"
@@ -9,7 +9,8 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="BSD-3-Clause"
 homepage="https://rpki.readthedocs.io/"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
-checksum=a84589789bdc76322deb29c78d6b14391c859967a4ae8f766a79d6b7a1fd16b2
+conf_files="/etc/routinator/routinator.conf"
+checksum=b85e03447eaffc3ec0df78eeeb5ad87aaaeabc0974d87ea5d516e04c3e1bbbb3
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;


### PR DESCRIPTION
Also add /etc/routinator/routinator.conf to conf_files so it does not
get overwritten in future updates.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
