### PR TITLE
python3-Flask-HTTPAuth: update to 4.5.0, orphan.

### DIFF
--- a/srcpkgs/python3-Flask-HTTPAuth/template
+++ b/srcpkgs/python3-Flask-HTTPAuth/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-Flask-HTTPAuth'
 pkgname=python3-Flask-HTTPAuth
-version=4.4.0
-revision=2
+version=4.5.0
+revision=1
 wrksrc=Flask-HTTPAuth-${version}
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-Flask"
-checkdepends="${depends}"
 short_desc="Basic, Digest and Token HTTP authentication for Flask routes"
-maintainer="mobinmob <mobinmob@disroot.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/miguelgrinberg/Flask-HTTPAuth"
 distfiles="${PYPI_SITE}/f/flask-httpauth/Flask-HTTPAuth-${version}.tar.gz"
-checksum=bcaaa7a35a3cba0b2eafd4f113b3016bf70eb78087456d96484c3c18928b813a
+checksum=395040fda2854df800d15e84bc4a81a5f32f1d4a5e91eee554936f36f330aa29
+make_check=no # needs packages not in repo (asgiref)
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Also:
- disable tests.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
