### PR TITLE
ecl: enable tests

### DIFF
--- a/srcpkgs/ecl/patches/fix-tests.patch
+++ b/srcpkgs/ecl/patches/fix-tests.patch
@@ -1,0 +1,15 @@
+The test config finds the build directory by looking for the file
+'BUILD-STAMP'. However, the build system creates 'build-stamp' instead
+so it will never be found on a case-sensitive filesystem.
+
+--- a/src/tests/config.lsp.in	2021-02-01 09:59:46.000000000 -0300
++++ b/src/tests/config.lsp.in	2021-11-20 18:12:39.318173405 -0300
+@@ -41,7 +41,7 @@
+   (loop with root = (si::get-library-pathname)
+         with lib-name = (format nil "../lib/ecl-~A/" (lisp-implementation-version))
+         for base in (list root (merge-pathnames lib-name root))
+-        when (or (probe-file (merge-pathnames "./BUILD-STAMP" base))
++        when (or (probe-file (merge-pathnames "./build-stamp" base))
+                  (probe-file (merge-pathnames "./COPYING" base)))
+         do (return base)))
+ 

--- a/srcpkgs/ecl/template
+++ b/srcpkgs/ecl/template
@@ -7,7 +7,7 @@ configure_args="--enable-gmp=system --enable-boehm=system
  --enable-libatomic=system --with-dffi=system"
 hostmakedepends="pkg-config"
 makedepends="gc-devel libatomic_ops-devel gmp-devel libffi-devel"
-depends=$makedepends
+depends="$makedepends"
 short_desc="Common-Lisp interpreter as described in the X3J13 Ansi specification"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="LGPL-2.1-or-later"
@@ -20,3 +20,18 @@ if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" ecl"
 	configure_args+=" --with-cross-config=${XBPS_SRCPKGDIR}/ecl/files/cross_config"
 fi
+
+pre_check() {
+	# These settings enable `make check` to run using the compiled ecl.
+	# A few tests fail: out of 18098 tests there are ~10 that fail on
+	# glibc and an additional ~30 fail on musl (the numbers vary as
+	# some failures seem random.)
+	#
+	# The build finishes since `make check` does NOT fail; it is left
+	# for the future to fix the failing tests and patch make check so
+	# it actually fails the build.
+	export ECLDIR=$wrksrc/build/
+	export LD_LIBRARY_PATH=$wrksrc/build/
+	export TEST_IMAGE=$wrksrc/build/bin/ecl
+	make_check_args="ECL=$TEST_IMAGE"
+}


### PR DESCRIPTION
The tests for ecl were not running as `make check` failed to find the binary (according to upstream one should install it before running tests).

OTOH, there's a bunch of tests that fail. Out of 18098 tests there are around 10 that fail on x86_64 and i686 (the number varies as some failures are kind of random. On x86_64-musl there are about 30 more failures but they all seem to be the same (something to do with acosh(-infinity))

I lack the energy to look at this and my lisp-fu is almost nil. I was hoping that everything would pass but... (what can we expect from a test suite that it's not easy to run...)

It's also the case that failures in the test suite will NOT stop make with an error, so packaging with -Q is not broken.

I'm not revbumping b/c this should not change anything at all in the installed files.

cc: @knusbaum