### PR TITLE
python3-language-server: update to 0.36.2

### DIFF
--- a/srcpkgs/python3-language-server/template
+++ b/srcpkgs/python3-language-server/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-language-server'
 pkgname=python3-language-server
-version=0.36.1
-revision=3
+version=0.36.2
+revision=4
 wrksrc="${pkgname/3}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -15,7 +15,7 @@ maintainer="k4leg <d0xi@inbox.ru>"
 license="MIT"
 homepage="https://github.com/palantir/python-language-server"
 distfiles="${PYPI_SITE}/p/${pkgname/3}/${pkgname/3}-${version}.tar.gz"
-checksum=c85d718ef6860319ad59fd6f2acb1166e9349b782ee8e8908e08ecf241615f52
+checksum=9984c84a67ee2c5102c8e703215f407fcfa5e62b0ae86c9572d0ada8c4b417b0
 # Needs unpackaged rope and versioneer
 # https://github.com/palantir/python-language-server/blob/develop/setup.py#L51
 make_check=no


### PR DESCRIPTION
- python3-language-server: update to 0.36.2

- I tested the changes in this PR: YES

- I built this PR locally for my native architecture, (x86_64)
