### PR TITLE
libpurple-facebook: update to 0.9.6.

### DIFF
--- a/srcpkgs/libpurple-facebook/template
+++ b/srcpkgs/libpurple-facebook/template
@@ -1,10 +1,9 @@
 # Template file for 'libpurple-facebook'
 pkgname=libpurple-facebook
 reverts="20160409.66ee77378d82_1 20160125.92885e0456ed_1"
-version=0.9.5.9ff9acf9fa14
+version=0.9.6
 revision=1
-_distver="${version%.*}-${version##*.}"
-wrksrc="purple-facebook-${_distver}"
+wrksrc="purple-facebook-${version}"
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="libpurple-devel json-glib-devel"
@@ -12,5 +11,5 @@ short_desc="Facebook plugin for libpurple"
 maintainer="John Regan <john@jrjrtech.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/dequis/purple-facebook"
-distfiles="https://github.com/dequis/purple-facebook/releases/download/v${_distver}/purple-facebook-${_distver}.tar.gz"
-checksum=7ab652dd0430166465f820e6e72bf6fffe09db936b535c212e571ec1742146dc
+distfiles="https://github.com/dequis/purple-facebook/releases/download/v${version}/purple-facebook-${version}.tar.gz"
+checksum=1db6ed9e8f81cbd4ae10d75c04f5393e5cd4ca11ced74408ca6d07c7b888f3f7


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
More info here: https://www.reddit.com/r/voidlinux/comments/qxvs9z/purplefacebook/?utm_source=share&utm_medium=web2x&context=3
#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
