### PR TITLE
libhtp: update to 0.5.39, suricata: update to 6.0.4

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3626,7 +3626,7 @@ libappmenu-gtk3-parser.so.0 appmenu-gtk3-module-0.7.1_1
 libqhttpengine.so.1 qhttpengine-1.0.1_1
 libqmdnsengine.so.0 qmdnsengine-0.1.0_1
 libyang.so.1 libyang-1.0r5_1
-libhtp.so.2 libhtp-0.5.30_1
+libhtp.so.2 libhtp-0.5.39_1
 libgedit-40.0.so gedit-40.0_1
 libchewing.so.3 libchewing-0.5.1_1
 libdwarves.so.1 pahole-1.12_1

--- a/srcpkgs/libhtp/template
+++ b/srcpkgs/libhtp/template
@@ -1,6 +1,6 @@
 # Template file for 'libhtp'
 pkgname=libhtp
-version=0.5.36
+version=0.5.39
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/OISF/libhtp"
 distfiles="https://github.com/OISF/libhtp/archive/${version}.tar.gz"
-checksum=ab1dd6cfd4ab4c36624a5c74793d80d1b7f50f5791620f47bfd831a79e32bc4b
+checksum=d5956b49314fc6a058864130fbcf040a12584ee1e38f3b6ea52aedfa99d4c14a
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/suricata/template
+++ b/srcpkgs/suricata/template
@@ -1,6 +1,6 @@
 # Template file for 'suricata'
 pkgname=suricata
-version=4.1.8
+version=6.0.4
 revision=1
 build_style=gnu-configure
 build_helper="$(vopt_if rust rust)"
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://suricata-ids.org/"
 distfiles="https://www.openinfosecfoundation.org/download/${pkgname}-${version}.tar.gz"
-checksum=c8a83a05f57cedc0ef81d833ddcfdbbfdcdb6f459a91b1b15dc2d5671f1aecbb
+checksum=a8f197e33d1678689ebbf7bc1abe84934c465d22c504c47c2c7e9b74aa042d0d
 
 build_options="lua rust hiredis"
 build_options_default="hiredis"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures :
  - aarch64-musl
  - armv7l
  - armv6l-musl

#### Note
Update done in prevision of another update for **suricata 6.0.4** which needs **libhtp >= 0.5.39**