### PR TITLE
lrcalc: add patch to fix includes

### DIFF
--- a/srcpkgs/lrcalc/patches/includes.patch
+++ b/srcpkgs/lrcalc/patches/includes.patch
@@ -1,0 +1,90 @@
+From 4a5e1c8c3c11efdb1cbb4239825a6bf4bf1c52f8 Mon Sep 17 00:00:00 2001
+From: Anders Skovsted Buch <asbuch@math.rutgers.edu>
+Date: Sun, 29 Nov 2015 16:25:56 -0500
+Subject: [PATCH] Patch by Jeroen Demeyer to change include <vector.h> to
+ "vector.h", plus similar cases.
+
+---
+ src/lrcalc.c   | 2 +-
+ src/maple.c    | 4 ++--
+ src/schublib.h | 2 +-
+ src/symfcn.c   | 6 +++---
+ src/symfcn.h   | 4 ++--
+ 5 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/lrcalc.c b/src/lrcalc.c
+index aff3f75..60df49e 100644
+--- a/src/lrcalc.c
++++ b/src/lrcalc.c
+@@ -8,7 +8,7 @@
+ #include <stdlib.h>
+ extern char *optarg;
+ 
+-#include <vectarg.h>
++#include "vectarg.h"
+ 
+ #include "symfcn.h"
+ #include "maple.h"
+diff --git a/src/maple.c b/src/maple.c
+index fdc0768..a5f4d14 100644
+--- a/src/maple.c
++++ b/src/maple.c
+@@ -4,8 +4,8 @@
+  */
+ 
+ #include <stdio.h>
+-#include <vector.h>
+-#include <hashtab.h>
++#include "vector.h"
++#include "hashtab.h"
+ #include "maple.h"
+ 
+ 
+diff --git a/src/schublib.h b/src/schublib.h
+index a8e8511..864850c 100644
+--- a/src/schublib.h
++++ b/src/schublib.h
+@@ -1,7 +1,7 @@
+ #ifndef _SCHUBLIB_H
+ #define _SCHUBLIB_H
+ 
+-#include <hashtab.h>
++#include "hashtab.h"
+ 
+ hashtab *trans(vector *w, int vars, hashtab *res);
+ hashtab *monk(int i, hashtab *slc, int rank);
+diff --git a/src/symfcn.c b/src/symfcn.c
+index 4ffbe4b..fd5df5d 100644
+--- a/src/symfcn.c
++++ b/src/symfcn.c
+@@ -5,9 +5,9 @@
+ 
+ #include <stdio.h>
+ 
+-#include <alloc.h>
+-#include <vector.h>
+-#include <hashtab.h>
++#include "alloc.h"
++#include "vector.h"
++#include "hashtab.h"
+ 
+ #include "symfcn.h"
+ 
+diff --git a/src/symfcn.h b/src/symfcn.h
+index b8543b1..29bb00d 100644
+--- a/src/symfcn.h
++++ b/src/symfcn.h
+@@ -1,8 +1,8 @@
+ #ifndef _SYMFCN_H
+ #define _SYMFCN_H
+ 
+-#include <hashtab.h>
+-#include <vector.h>
++#include "hashtab.h"
++#include "vector.h"
+ 
+ int part_itr_sz(vector *part);
+ int part_itr_sub(vector *part, vector *outer);
+-- 
+2.1.1.1.g1fb337f
+

--- a/srcpkgs/lrcalc/template
+++ b/srcpkgs/lrcalc/template
@@ -1,7 +1,7 @@
 # Template file for 'lrcalc'
 pkgname=lrcalc
 version=1.2
-revision=1
+revision=2
 build_style=gnu-configure
 short_desc="Littlewood-Richardson Calculator"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"


### PR DESCRIPTION
In #34186 I forgot to `git add` a patch that is necessary for the include files to work properly.