### PR TITLE
handbrake: update to 1.4.2.

### DIFF
--- a/srcpkgs/handbrake/patches/fix-missing-x265-link-flag.patch
+++ b/srcpkgs/handbrake/patches/fix-missing-x265-link-flag.patch
@@ -1,18 +1,17 @@
 --- a/gtk/configure.ac
 +++ b/gtk/configure.ac
-@@ -199,7 +199,7 @@
+@@ -203,7 +203,7 @@
  
  AM_CONDITIONAL([MINGW], [test "x$mingw_flag" = "xyes"])
  
--HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
-+HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma -ldl"
+-HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -lturbojpeg -llzma -lzimg"
++HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -lturbojpeg -llzma -lzimg -ldl"
  HB_CPPFLAGS="$HB_CPPFLAGS $HBINC"
  
  PKG_CHECK_MODULES([x264], [x264], sys_x264=yes, sys_x264=no)
-
 --- a/test/module.defs
 +++ b/test/module.defs
-@@ -69,6 +69,9 @@ else ifeq ($(HOST.system),linux)
+@@ -69,6 +69,9 @@
  ifeq (1, $(FEATURE.numa))
      TEST.GCC.l += numa
  endif
@@ -21,4 +20,4 @@
 +endif
  else ifeq ($(HOST.system),kfreebsd)
      TEST.GCC.l += pthread dl m
- else ifeq ($(HOST.system),freebsd)
+ else ifneq (,$(filter $(HOST.system),freebsd netbsd))

--- a/srcpkgs/handbrake/patches/remove-faac-dependency.patch
+++ b/srcpkgs/handbrake/patches/remove-faac-dependency.patch
@@ -1,14 +1,14 @@
 --- a/libhb/common.c
 +++ b/libhb/common.c
-@@ -243,7 +243,6 @@
+@@ -375,7 +375,6 @@
  {
      // legacy encoders, back to HB 0.9.4 whenever possible (disabled)
-     { { "",                   "dts",        NULL,                          HB_ACODEC_DCA_PASS,    HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_DTS_PASS,   },
--    { { "AAC (faac)",         "faac",       NULL,                          0,                     HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_AAC,        },
-     { { "AAC (ffmpeg)",       "ffaac",      NULL,                          HB_ACODEC_FFAAC,       HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_AAC,        },
-     { { "AC3 (ffmpeg)",       "ffac3",      NULL,                          HB_ACODEC_AC3,         HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_AC3,        },
-     { { "MP3 (lame)",         "lame",       NULL,                          HB_ACODEC_LAME,        HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_MP3,        },
---- a/scripts/manicure.rb
+     { { "",                   "dts",        NULL,                          HB_ACODEC_DCA_PASS,    HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, 0, HB_GID_ACODEC_DTS_PASS,   },
+-    { { "AAC (faac)",         "faac",       NULL,                          0,                     HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, 0, HB_GID_ACODEC_AAC,        },
+     { { "AAC (ffmpeg)",       "ffaac",      NULL,                          HB_ACODEC_FFAAC,       HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, 0, HB_GID_ACODEC_AAC,        },
+     { { "AC3 (ffmpeg)",       "ffac3",      NULL,                          HB_ACODEC_AC3,         HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, 0, HB_GID_ACODEC_AC3,        },
+     { { "MP3 (lame)",         "lame",       NULL,                          HB_ACODEC_LAME,        HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, 0, HB_GID_ACODEC_MP3,        },
+--- a/scripts/manicure.rb	
 +++ b/scripts/manicure.rb
 @@ -349,7 +349,7 @@
            audioEncoders << "copy:dtshd"
@@ -28,7 +28,7 @@
          audioEncoderFallback << "av_aac"
        when "AAC (FDK)"
          audioEncoderFallback << "fdk_aac"
-@@ -753,7 +753,7 @@
+@@ -748,7 +748,7 @@
            audioEncoders << "copy:dtshd"
          when /AAC Pass/
            audioEncoders << "copy:aac"
@@ -37,7 +37,7 @@
            audioEncoders << "av_aac"
          when "AAC (FDK)"
            audioEncoders << "fdk_aac"
-@@ -870,7 +870,7 @@
+@@ -865,7 +865,7 @@
      case hash["AudioEncoderFallback"]
        when /AC3/
          audioEncoderFallback << "ac3"
@@ -46,7 +46,7 @@
          audioEncoderFallback << "av_aac"
        when "AAC (FDK)"
          audioEncoderFallback << "fdk_aac"
-@@ -1163,7 +1163,7 @@
+@@ -1148,7 +1148,7 @@
            audioEncoders << "copy:dtshd"
          when /AAC Pass/
            audioEncoders << "copy:aac"
@@ -55,7 +55,7 @@
            audioEncoders << "av_aac"
          when "AAC (FDK)"
            audioEncoders << "fdk_aac"
-@@ -1298,7 +1298,7 @@
+@@ -1283,7 +1283,7 @@
      case hash["AudioEncoderFallback"]
        when /AC3/
          audioEncoderFallback << "ac3"
@@ -64,7 +64,7 @@
          audioEncoderFallback << "av_aac"
        when "AAC (FDK)"
          audioEncoderFallback << "fdk_aac"
-@@ -1615,7 +1615,7 @@
+@@ -1600,7 +1600,7 @@
            audioEncoders << "copy:dtshd"
          when /AAC Pass/
            audioEncoders << "copy:aac"
@@ -73,7 +73,7 @@
            audioEncoders << "av_aac"
          when "AAC (FDK)"
            audioEncoders << "fdk_aac"
-@@ -1732,7 +1732,7 @@
+@@ -1717,7 +1717,7 @@
      case hash["AudioEncoderFallback"]
        when /AC3/
          audioEncoderFallback << "ac3"

--- a/srcpkgs/handbrake/template
+++ b/srcpkgs/handbrake/template
@@ -1,7 +1,7 @@
 # Template file for 'handbrake'
 pkgname=handbrake
-version=1.3.3
-revision=4
+version=1.4.2
+revision=1
 wrksrc="HandBrake-${version}"
 build_style=gnu-configure
 configure_args="--force --disable-gtk-update-checks --disable-df-fetch --harden
@@ -13,7 +13,7 @@ makedepends="bzip2-devel ffmpeg-devel gst-plugins-base1-devel gtk+3-devel
  jansson-devel lame-devel libass-devel libbluray-devel libdav1d-devel
  libdvdnav-devel libdvdread-devel libgudev-devel libnuma-devel
  libsamplerate-devel libtheora-devel libvorbis-devel libvpx-devel libxml2-devel
- opus-devel speex-devel x264-devel x265-devel
+ opus-devel speex-devel x264-devel x265-devel zimg-devel
  $(vopt_if fdk_aac fdk-aac-devel)
  $(vopt_if nvenc nv-codec-headers)"
 depends="desktop-file-utils gst-plugins-good1 hicolor-icon-theme"
@@ -22,7 +22,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://handbrake.fr/"
 distfiles="https://github.com/HandBrake/HandBrake/releases/download/${version}/HandBrake-${version}-source.tar.bz2"
-checksum=218a37d95f48b5e7cf285363d3ab16c314d97627a7a710cab3758902ae877f85
+checksum=8b8e81b7dc2e3180f4e94e8c7f5337d2953f69f0d983ccce48096e29ed6dfb61
 nocross=yes
 
 build_options="fdk_aac nvenc"
@@ -38,7 +38,7 @@ pre_configure() {
 	# use system libraries, don't download them
 	rm -rf contrib/
 	for module in fdk-aac ffmpeg libbluray libdav1d libdvdnav libdvdread nvenc \
-		x265; do
+		x265 zimg; do
 	    vsed -i "/MODULES += contrib\/${module}/d" make/include/main.defs
 	done
 }


### PR DESCRIPTION
zimg-devel added as dependency for build to succeed.

template was changed in accordance.
Two patches needed to be rebased.


#### Testing the changes
- I tested the changes in this PR: **briefly**
- I did some tests to determine functionality (transcoding .mkv files from h264 to h265)


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)