### PR TITLE
rtl88x2bu-dkms: Fix Module Compilation Error and Consistency

### DIFF
--- a/srcpkgs/rtl88x2bu-dkms/files/dkms.conf
+++ b/srcpkgs/rtl88x2bu-dkms/files/dkms.conf
@@ -1,0 +1,11 @@
+PACKAGE_NAME="rtl8822bu"
+PACKAGE_VERSION="@VERSION@"
+BUILT_MODULE_NAME="88x2bu"
+PROCS_NUM=$(nproc)
+[ $PROCS_NUM -gt 16 ] && PROCS_NUM=16
+MAKE="'make' -j$PROCS_NUM KVER=${kernelver} 
+KSRC=/lib/modules/${kernelver}/build"
+CLEAN="make clean"
+DEST_MODULE_LOCATION="/kernel/drivers/net/wireless"
+AUTOINSTALL="yes"
+REMAKE_INITRD=no

--- a/srcpkgs/rtl88x2bu-dkms/patches/0001-void-arch-generic-plumbing-bits.patch
+++ b/srcpkgs/rtl88x2bu-dkms/patches/0001-void-arch-generic-plumbing-bits.patch
@@ -1,0 +1,44 @@
+From 9cecd7211e1c41ce0716f923961cc07b119be573 Mon Sep 17 00:00:00 2001
+From: Daniel Kolesa <daniel@octaforge.org>
+Date: Sat, 12 Dec 2020 05:03:29 +0100
+Subject: [PATCH] void arch-generic plumbing bits
+
+---
+ Makefile | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git Makefile Makefile
+index 29da0bf..d58bc95 100644
+--- a/Makefile
++++ b/Makefile
+@@ -97,7 +97,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+ ###################### MP HW TX MODE FOR VHT #######################
+ CONFIG_MP_VHT_HW_TX_MODE = n
+ ###################### Platform Related #######################
+-CONFIG_PLATFORM_I386_PC = y
++CONFIG_PLATFORM_VOID_NATIVE = y
++CONFIG_PLATFORM_I386_PC = n
+ CONFIG_PLATFORM_ARM_RPI = n
+ CONFIG_PLATFORM_ANDROID_X86 = n
+ CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
+@@ -1030,6 +1031,17 @@ endif
+ 
+ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
+ 
++ifeq ($(CONFIG_PLATFORM_VOID_NATIVE), y)
++EXTRA_CFLAGS += -DCONFIG_@@VOID_ENDIAN@@_ENDIAN
++EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++ARCH := @@VOID_ARCH@@
++KVER := $(shell uname -r)
++KSRC := /usr/lib/modules/$(KVER)/build
++MODDESTDIR := /usr/lib/modules/$(KVER)/kernel/drivers/net/wireless/
++INSTALL_PREFIX :=
++STAGINGMODDIR := /usr/lib/modules/$(KVER)/kernel/drivers/staging
++endif
++
+ ifeq ($(CONFIG_PLATFORM_I386_PC), y)
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+-- 
+2.29.2
+

--- a/srcpkgs/rtl88x2bu-dkms/template
+++ b/srcpkgs/rtl88x2bu-dkms/template
@@ -1,0 +1,46 @@
+# Template file for 'rtl88x2bu-dkms'
+pkgname=rtl88x2bu-dkms
+version=20210702
+revision=1
+_gitrev=f033b6fa139103a49c17cccee298593fb849f8c1
+wrksrc="88x2bu-${version}-${_gitrev}"
+depends="dkms"
+short_desc="Realtek 8822BU USB WiFi driver (DKMS)"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-only"
+homepage="https://www.tp-link.com"
+distfiles="https://github.com/morrownr/88x2bu-20210702/archive/${_gitrev}.tar.gz"
+checksum=7f7a9405e68591c3c9ad205b862bc3891c02cca2f19ba25763a2ca9bdb0f170b
+dkms_modules="88x2bu ${version}"
+replaces=rtl8822bu-dkms
+
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*) _karch="x86_64";;
+	i686*) _karch="i386";;
+	aarch64*) _karch="arm64";;
+	arm*) _karch="arm";;
+	ppc*) _karch="powerpc";;
+	mips*) _karch="mips";;
+	*) broken="kernel arch not defined";;
+esac
+
+post_patch() {
+	if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
+		vsed -i 's,@@VOID_ENDIAN@@,BIG,g' Makefile
+	else
+		vsed -i 's,@@VOID_ENDIAN@@,LITTLE,g' Makefile
+	fi
+	vsed -i "s,@@VOID_ARCH@@,${_karch},g" Makefile
+}
+
+do_install() {
+	vmkdir /usr/src/88x2bu-${version}
+	vcopy "*" usr/src/88x2bu-${version}
+	vinstall ${FILESDIR}/dkms.conf 644 usr/src/88x2bu-${version}
+	sed -i -e "s/@VERSION@/${version}-${revision}/" ${PKGDESTDIR}/usr/src/88x2bu-${version}/dkms.conf
+
+	# modules-load.d(5) file.
+	vmkdir usr/lib/modules-load.d
+	echo "88x2bu" > ${DESTDIR}/usr/lib/modules-load.d/88x2bu.conf
+	chmod 644 ${DESTDIR}/usr/lib/modules-load.d/88x2bu.conf
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture: x86_64

In order to resolve #34190, i changed the package base from https://github.com/EntropicEffect/rtl8822bu to https://github.com/morrownr/88x2bu-20210702 which provides both a working and newer module than the previous distfile source. I also changed the package name so that it fits with both the range of support of the driver and the upstream repo itself.

I'm new to packaging for Void so if I made any mistakes please feel free to let me know.