### PR TITLE
WoeUSB: update to 5.2.4.

### DIFF
--- a/srcpkgs/WoeUSB/template
+++ b/srcpkgs/WoeUSB/template
@@ -1,34 +1,28 @@
 # Template file for 'WoeUSB'
 pkgname=WoeUSB
-version=3.3.1
-revision=3
-build_style=gnu-configure
-configure_args="--with-wx-config=wx-config-gtk3"
-hostmakedepends="automake gettext libtool"
-makedepends="wxWidgets-gtk3-devel"
-depends="WoeUSB-cli"
+version=5.2.4
+revision=1
+depends="bash grub parted wget dosfstools ntfs-3g wimlib"
 short_desc="Create a Windows USB stick installer from a real Windows DVD or image"
-maintainer="bra1nwave <bra1nwave@protonmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/slacka/WoeUSB"
-distfiles="https://github.com/slacka/WoeUSB/archive/v${version}.tar.gz"
-checksum=0cab88a1113506f39d2f1c19532b2cd8d968c6a9f59129953c000e29e73f3d4f
+homepage="https://github.com/WoeUSB/WoeUSB"
+distfiles="https://github.com/WoeUSB/WoeUSB/archive/v${version}.tar.gz>${pkgname}-${version}.tar.gz"
+checksum=8305296d49b7b58c200f9d373eac8dd494d03442737183749a0ee166403a7e68
 
-post_patch() {
+do_patch() {
 	vsed -i -e "s/@@WOEUSB_VERSION@@/$version/g" \
-		configure.ac \
-		src/woeusb src/woeusb.1 src/woeusbgui.1
-}
-
-pre_configure() {
-	autoreconf -fi
+		sbin/woeusb \
+		share/man/man1/woeusb.1
 }
 
 WoeUSB-cli_package() {
-	depends="bash grub ntfs-3g parted wget"
-	short_desc+=" - command line only"
-	pkg_install() {
-		vmove usr/bin/woeusb
-		vmove usr/share/man/man1/woeusb.1
-	}
+		build_style=meta
+		short_desc+=" - dummy transitional package"
+		depends="WoeUSB"
+}
+
+do_install() {
+	vbin sbin/woeusb
+	vman share/man/man1/woeusb.1
 }


### PR DESCRIPTION
This commit with heavy changes is made to update the package from version 3.1.1 to 5.2.4.

Due to the absence of updates for a long time the following changes are present:
- the repository has been moved to another organization.
- gui is forked into a separate repository and left unmaintained.
- GNU Auto*hell is no more.
- more dependences: wimlib and dosfstools.
- WoeUSB-cli has lost its purpose (since gui is removed, cli only is left).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl