### PR TITLE
xfce4-power-manager: add upower as dependency

### DIFF
--- a/srcpkgs/xfce4-power-manager/template
+++ b/srcpkgs/xfce4-power-manager/template
@@ -1,12 +1,12 @@
 # Template file for 'xfce4-power-manager'
 pkgname=xfce4-power-manager
 version=4.16.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-locales-dir=/usr/share/locale --disable-static"
 hostmakedepends="pkg-config intltool"
 makedepends="libxfce4ui-devel libnotify-devel upower-devel xfce4-panel-devel"
-depends="hicolor-icon-theme desktop-file-utils"
+depends="hicolor-icon-theme desktop-file-utils upower"
 short_desc="Xfce power manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Xfce4-power-manager itself is interface of upower. Without upower, xfce4-power-manager installed as standalone application is unusable.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
