### PR TITLE
New package: xgifwallpaper-0.3.1

### DIFF
--- a/srcpkgs/xgifwallpaper/template
+++ b/srcpkgs/xgifwallpaper/template
@@ -1,0 +1,12 @@
+# Template file for 'xgifwallpaper'
+pkgname=xgifwallpaper
+version=0.3.1
+revision=1
+build_style=cargo
+makedepends="libX11-devel libXinerama-devel libXext-devel"
+short_desc="Animated gif wallpapers for X"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/calculon102/xgifwallpaper"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=4fc28e7832fd1d39901dcd3b05c1be949d3def01d308b1548d48ac1682f81f61


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

A package for animated wallpapers for X in rust. While the license is a GPL 3.0 license, I couldn't find any comments in the source code / README that would indicate if one could redistribute it under a later version.