### PR TITLE
pcmanfm: add lxmenu-data as dependency

### DIFF
--- a/srcpkgs/pcmanfm/template
+++ b/srcpkgs/pcmanfm/template
@@ -1,12 +1,12 @@
 # Template file for 'pcmanfm'
 pkgname=pcmanfm
 version=1.3.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-gtk=3"
 hostmakedepends="pkg-config intltool"
 makedepends="gtk+3-devel libfm-gtk+3-devel"
-depends="desktop-file-utils"
+depends="desktop-file-utils lxmenu-data"
 short_desc="LXDE file manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Without lxmenu-data, pcmanfm won't show applications list within "Open with..." menu dialog.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
