### PR TITLE
linbox: fix broken linbox.pc

### DIFF
--- a/srcpkgs/linbox/patches/remove-linboxsage-libs-from-pc.patch
+++ b/srcpkgs/linbox/patches/remove-linboxsage-libs-from-pc.patch
@@ -1,0 +1,23 @@
+Backported from:
+
+From 426eb97ba762c7663884f57ead0909f2aa3cd6a5 Mon Sep 17 00:00:00 2001
+From: Cyril Bouvier <cyril.bouvier@lirmm.fr>
+Date: Thu, 17 Jan 2019 16:32:19 +0100
+Subject: [PATCH] Remove @LINBOXSAGE_LIBS@ from linbox.pc.in
+
+---
+ linbox.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/linbox.pc.in b/linbox.pc.in
+index 278f127e4..c6b8091eb 100644
+--- a/linbox.pc.in
++++ b/linbox.pc.in
+@@ -9,6 +9,6 @@ Description: Exact Linear Algebra library
+ URL: http://github.com/linbox-team/linbox
+ Version: @VERSION@
+ Requires: fflas-ffpack >= 2.4.0, givaro >= 4.1.0
+-Libs: -L${libdir} -llinbox @LINBOXSAGE_LIBS@ @NTL_LIBS@ @MPFR_LIBS@ @FPLLL_LIBS@ @IML_LIBS@ @FLINT_LIBS@ @OCL_LIBS@
++Libs: -L${libdir} -llinbox @NTL_LIBS@ @MPFR_LIBS@ @FPLLL_LIBS@ @IML_LIBS@ @FLINT_LIBS@ @OCL_LIBS@
+ Cflags: @DEFAULT_CFLAGS@ -DDISABLE_COMMENTATOR -I${includedir} @NTL_CFLAGS@ @MPFR_CFLAGS@ @FPLLL_CFLAGS@  @IML_CFLAGS@ @FLINT_CFLAGS@ 
+ \-------------------------------------------------------

--- a/srcpkgs/linbox/template
+++ b/srcpkgs/linbox/template
@@ -1,7 +1,7 @@
 # Template file for 'linbox'
 pkgname=linbox
 version=1.6.3
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="fflas-ffpack"


### PR DESCRIPTION
Current linbox.pc contains this line:
```
Libs: -L${libdir} -llinbox @LINBOXSAGE_LIBS@      
```
Which breaks programs trying to use linbox, for instance, this is necessary to use system linbox with sagemath.