### PR TITLE
botan: fix pycompile_module

### DIFF
--- a/srcpkgs/botan/template
+++ b/srcpkgs/botan/template
@@ -2,7 +2,7 @@
 pkgname=botan
 version=2.16.0
 revision=5
-wrksrc="${pkgname^}-${version}"
+wrksrc="Botan-${version}"
 build_style=gnu-makefile
 hostmakedepends="doxygen python3"
 makedepends="openssl-devel bzip2-devel liblzma-devel sqlite-devel zlib-devel"
@@ -15,7 +15,6 @@ checksum=92ed6ebc918d86bd1b04221ca518af4cf29cc326c4760740bd2d22e61cea2628
 python_version=3
 
 LDFLAGS="-pthread"
-CXXFLAGS="-O3"
 
 do_configure() {
 	local _args _cpu
@@ -77,7 +76,7 @@ do_configure() {
 }
 
 do_check() {
-	./botan-test
+	make check
 }
 
 post_install() {

--- a/srcpkgs/botan/template
+++ b/srcpkgs/botan/template
@@ -1,10 +1,9 @@
 # Template file for 'botan'
 pkgname=botan
 version=2.16.0
-revision=4
+revision=5
 wrksrc="${pkgname^}-${version}"
 build_style=gnu-makefile
-pycompile_module="botan.py"
 hostmakedepends="doxygen python3"
 makedepends="openssl-devel bzip2-devel liblzma-devel sqlite-devel zlib-devel"
 short_desc="Crypto library written in C++"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR:**briefly**

before:
```
Byte-compiling python3.10 code for module botan.py...
Can't list 'usr/lib/python3.10/site-packages/botan.py'
Can't list 'usr/lib/python3.10/site-packages/botan.py'
```