### PR TITLE
gnome-keyring: remove libcap-ng, adopt.

### DIFF
--- a/srcpkgs/gnome-keyring/template
+++ b/srcpkgs/gnome-keyring/template
@@ -1,19 +1,19 @@
 # Template file for 'gnome-keyring'
 pkgname=gnome-keyring
 version=40.0
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-pam-dir=/usr/lib/security --disable-schemas-compile"
 hostmakedepends="autoconf docbook-xsl glib-devel intltool libtasn1-tools libxslt
  openssh pkg-config"
-makedepends="gcr-devel libcap-devel libcap-ng-devel libtasn1-devel pam-devel"
-depends="dconf gcr"
+makedepends="gcr-devel pam-devel"
+depends="dconf"
 checkdepends="dbus xvfb-run"
 short_desc="GNOME password and secret manager"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.gnome.org"
-changelog="https://raw.githubusercontent.com/GNOME/gnome-keyring/gnome-40/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gnome-keyring/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/$pkgname/${version%.*}/$pkgname-$version.tar.xz"
 checksum=a3d24db08ee2fdf240fbbf0971a98c8ee295aa0e1a774537f4ea938038a3b931
 make_check=ci-skip


### PR DESCRIPTION
We don't set capabilities on the binary right now, so it's better to
build without libcap-ng, so it doesn't complain on start-up. This is
also done by other distros, see [1].

libcap was no longer used, and neither was libtasn1.

We already depend on gcr via shlibs, so it doesn't need to be in
depends= explicitly.

Also update changelog to canonical URL.

[1] https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/41#note_1277767

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@Not-chicken looks good to you?

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
