### PR TITLE
aerc: update to 0.6.0.

### DIFF
--- a/srcpkgs/aerc/template
+++ b/srcpkgs/aerc/template
@@ -1,6 +1,6 @@
 # Template file for 'aerc'
 pkgname=aerc
-version=0.5.2
+version=0.6.0
 revision=1
 build_style=go
 hostmakedepends="scdoc git"
@@ -9,8 +9,8 @@ short_desc="Terminal email client"
 maintainer="shtayerc <david.murko@mailbox.org>"
 license="MIT"
 homepage="https://aerc-mail.org"
-distfiles="https://git.sr.ht/~sircmpwn/aerc/archive/${version}.tar.gz"
-checksum=87b922440e53b99f260d2332996537decb452c838c774e9340b633296f9f68ee
+distfiles="https://git.sr.ht/~rjarry/aerc/archive/${version}.tar.gz"
+checksum=ec4565609938b314f0343d85dfdab1cb0659c07c2845369ff7cf0132c5faed6e
 
 do_configure() {
 	:


### PR DESCRIPTION
The original upstream maintainer, Drew Devault, has stepped down and a
fork was created (with Drew's approval) under the same name. The fork
has patched in a large backlog of crashes and bug fixes and put out a
new version 0.6.0 recently. I think now that the aerc community has
consolidated on this fork it would be appropriate to update our package
to the new upstream.

More info about the fork and new maintainer can be found in this
discussion: https://lists.sr.ht/~sircmpwn/aerc/%3CCFBVJ3G1Y4YB.ZI6C02D0MS0S%40diabtop%3E

#### Testing the changes
I tested the changes in this PR: YES

#### Local build testing
I built this PR locally for my native architecture, x86_64-libc