### PR TITLE
NOMERGE ca-certificates: Fix busybox compat

### DIFF
--- a/srcpkgs/ca-certificates/patches/busybox-flags.patch
+++ b/srcpkgs/ca-certificates/patches/busybox-flags.patch
@@ -1,0 +1,13 @@
+--- a/work/sbin/update-ca-certificates	2021-11-29 23:24:29.772537834 -0600
++++ b/work/sbin/update-ca-certificates	2021-11-29 23:26:49.158620616 -0600
+@@ -81,8 +81,8 @@
+ # Helper files.  (Some of them are not simple arrays because we spawn
+ # subshells later on.)
+ TEMPBUNDLE="${ETCCERTSDIR}/${CERTBUNDLE}.new"
+-ADDED="$(mktemp --tmpdir "ca-certificates.tmp.XXXXXX")"
+-REMOVED="$(mktemp --tmpdir "ca-certificates.tmp.XXXXXX")"
++ADDED="$(mktemp -p "ca-certificates.tmp.XXXXXX")"
++REMOVED="$(mktemp -p "ca-certificates.tmp.XXXXXX")"
+ 
+ # Adds a certificate to the list of trusted ones.  This includes a symlink
+ # in /etc/ssl/certs to the certificate file and its inclusion into the

--- a/srcpkgs/ca-certificates/template
+++ b/srcpkgs/ca-certificates/template
@@ -1,6 +1,6 @@
 # Template file for 'ca-certificates'
 pkgname=ca-certificates
-version=20211016+3.71
+version=20211016+3.72
 revision=1
 _nss_version=${version#*+}
 bootstrap=yes
@@ -16,7 +16,7 @@ homepage="https://wiki.mozilla.org/NSS:Root_certs"
 distfiles="${DEBIAN_SITE}/main/c/${pkgname}/${pkgname}_${version%+*}.tar.xz
  ${MOZILLA_SITE}/security/nss/releases/NSS_${_nss_version//\./_}_RTM/src/nss-${_nss_version}.tar.gz"
 checksum="2ae9b6dc5f40c25d6d7fe55e07b54f12a8967d1955d3b7b2f42ee46266eeef88
- 99acd315d9af35419cda4a6960f00a7d446bd231bd407174a7b07cb3dba0c253"
+ 6ea60a9ff113e493ea2ab25f41ea75a9fbd10af7903f26f703dac8680732d02e"
 
 post_extract() {
 	cp ${FILESDIR}/* $build_wrksrc/mozilla


### PR DESCRIPTION
This PR also updates the NSS dependency.  I can change the commit
message if desired, it wasn't clear what was more important.

Ideally we'd also try to get this patch upstreamed.
