### PR TITLE
adding shebang to avoid   error in non POSIX shell

### DIFF
--- a/srcpkgs/wpa_supplicant/files/wpa_supplicant/auto
+++ b/srcpkgs/wpa_supplicant/files/wpa_supplicant/auto
@@ -1,3 +1,4 @@
+#!/bin/sh
 # find interface from wpa_supplicant-*.conf files
 for f in /etc/wpa_supplicant/wpa_supplicant-*.conf \
 	/etc/wpa_supplicant-*.conf; do


### PR DESCRIPTION
# UPDATE
```shell
$ for f in /etc/wpa_supplicant/wpa_supplicant-*.conf /etc/wpa_supplicant-*.conf ;do echo $i;done

zsh: no matches found: /etc/wpa_supplicant-*.conf
```
not working in zsh for example
also when I try to install void-linux by wifi from scratch , wpa_supplicant cant connect to wifi with `void-installer` I must connect manually by , 
