### PR TITLE
lighttpd: update to 1.4.63

### DIFF
--- a/srcpkgs/lighttpd/template
+++ b/srcpkgs/lighttpd/template
@@ -1,26 +1,26 @@
 # Template file for 'lighttpd'
 pkgname=lighttpd
-version=1.4.61
+version=1.4.63
 revision=1
 build_style=meson
 configure_args="-Dwith_brotli=false -Dwith_bzip=false
  -Dwith_fam=false -Dwith_gdbm=true
  -Dwith_geoip=false -Dwith_krb5=true -Dwith_ldap=true -Dwith_libev=false
  -Dwith_libunwind=false -Dwith_lua=true -Dwith_memcached=true
- -Dwith_mysql=false -Dwith_openssl=true -Dwith_pcre=true -Dwith_pgsql=false
+ -Dwith_mysql=false -Dwith_openssl=true -Dwith_pcre2=true -Dwith_pgsql=false
  -Dwith_sasl=false -Dwith_webdav_props=true -Dwith_webdav_locks=true
  -Dwith_xattr=true -Dwith_zlib=true -Dwith_zstd=false -Dwith_dbi=false
  -Dmoduledir=lib/lighttpd/modules"
 hostmakedepends="pkg-config"
 makedepends="gdbm-devel libmemcached-devel
- libxml2-devel lua53-devel mit-krb5-devel pcre-devel sqlite-devel"
+ libxml2-devel lua53-devel mit-krb5-devel pcre2-devel sqlite-devel"
 checkdepends="perl"
 short_desc="Secure, fast, compliant and very flexible web-server"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://lighttpd.net"
 distfiles="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${version}.tar.xz"
-checksum=43f0d63d04a1b7c5b8aab07e0612e44ccad0afc0614bab784c5b019872363432
+checksum=2aef7f0102ebf54a1241a1c3ea8976892f8684bfb21697c9fffb8de0e2d6eab9
 
 conf_files="/etc/lighttpd/lighttpd.conf"
 system_accounts="_lighttpd"


### PR DESCRIPTION
lighttpd: update to 1.4.63

use pcre2-devel instead of pcre-devel

#### Testing the changes
- I tested the changes in this PR: **NO** (not on void-linux, but I have tested on other platforms)