### PR TITLE
dunst: update to 1.7.2.

### DIFF
--- a/srcpkgs/dunst/template
+++ b/srcpkgs/dunst/template
@@ -1,21 +1,24 @@
 # Template file for 'dunst'
 pkgname=dunst
-version=1.7.1
+version=1.7.2
 revision=1
 build_style=gnu-makefile
+make_check_target=test
 make_use_env=yes
-make_build_args="SYSTEMD=0 WAYLAND=$(vopt_if wayland 1 0)"
+make_build_args="SYSTEMD=0 WAYLAND=$(vopt_if wayland 1 0) SYSCONFDIR=/etc"
 make_install_args="$make_build_args"
 hostmakedepends="perl pkg-config"
-makedepends="gtk+-devel libXScrnSaver-devel libXinerama-devel libXrandr-devel
+makedepends="gdk-pixbuf-devel libXScrnSaver-devel libXinerama-devel libXrandr-devel
  libxdg-basedir-devel libnotify-devel $(vopt_if wayland 'wayland-devel wayland-protocols')"
+checkdepends="dbus"
+conf_files="/etc/dunst/dunstrc"
 short_desc="Lightweight and customizable notification daemon"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="BSD-3-Clause"
 homepage="https://dunst-project.org"
 changelog="https://raw.githubusercontent.com/dunst-project/dunst/master/CHANGELOG.md"
 distfiles="https://github.com/dunst-project/dunst/archive/v${version}.tar.gz"
-checksum=f61ed3280aee9ec2aac07c44cf3d147df8fe8a6d7b92b6e8ab04e546bff1adce
+checksum=e4fa376d327e8a4cd375d00d4c318c93cc0968d4f184ab40da94ca6b30477181
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Also:
* Enabled tests
* Added conf_files
* Set SYSCONFDIR to not default to /usr/etc
* Dunst doesn't require GTK3 anymore since quite some time so removed from makedepends

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
