### PR TITLE
go: update URLs and install VERSION file

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,16 +1,16 @@
 # Template file for 'go'
 pkgname=go
 version=1.17.2
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc=go
 hostmakedepends="go1.12-bootstrap"
 short_desc="Go Programming Language"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="https://golang.org/"
-changelog="https://golang.org/doc/devel/release.html"
-distfiles="https://golang.org/dl/go${version}.src.tar.gz"
+homepage="https://go.dev/"
+changelog="https://go.dev/doc/devel/release.html"
+distfiles="https://go.dev/dl/go${version}.src.tar.gz"
 checksum=2255eb3e4e824dd7d5fcdc2e7f84534371c186312e546fb1086a34c17752f431
 nostrip=yes
 noverifyrdeps=yes
@@ -63,6 +63,7 @@ do_install() {
 	cp -a pkg src lib ${DESTDIR}/usr/lib/go
 	cp -r doc misc -t ${DESTDIR}/usr/share/go
 	ln -s /usr/share/go/doc ${DESTDIR}/usr/lib/go/doc
+	cp VERSION ${DESTDIR}/usr/lib/go/VERSION
 
 	# This is to make go get code.google.com/p/go-tour/gotour and
 	# then running the gotour executable work out of the box.


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Ping @the-maldridge

`VERSION` is installed to `/usr/lib/go` in other distros, [golds](https://go101.org/article/tool-golds.html) is borked without this file ¯\\\_(ツ)\_/¯

Feel free to include this changes in update to go1.17.4 if you prefer.

#### Testing the changes
- I tested the changes in this PR: **YES**





<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
