### PR TITLE
[wip] new package: firewalld-1.0.2

### DIFF
--- a/srcpkgs/firewalld/files/firewalld/log/run
+++ b/srcpkgs/firewalld/files/firewalld/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec vlogger -t firewalld

--- a/srcpkgs/firewalld/files/firewalld/run
+++ b/srcpkgs/firewalld/files/firewalld/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+sv check dbus >/dev/null || exit 1
+exec firewalld --nofork 2>&1

--- a/srcpkgs/firewalld/template
+++ b/srcpkgs/firewalld/template
@@ -1,0 +1,23 @@
+# Template file for 'firewalld'
+pkgname=firewalld
+version=1.0.2
+revision=1
+build_style=gnu-configure
+hostmakedepends="autoconf pkg-config docbook-xsl xmlcatmgr intltool libxslt
+ python3 docbook-xsl glib-devel"
+depends="python3-gobject python3-dbus nftables ipset"
+short_desc="Dynamically managed firewall with support for network zones"
+maintainer="Robert Lowry <bobertlo@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://firewalld.org/"
+distfiles="https://github.com/firewalld/firewalld/releases/download/v${version}/firewalld-${version}.tar.gz"
+checksum=42d95d9649526dd47e5835b4577230e8a33cbad4bfe9dae6b016bb1777b9c736
+conf_files="/etc/firewalld/*"
+# firewalld does not believe it is root in the chroot and fails
+make_check=no
+
+post_install() {
+	mv ${DESTDIR}/etc/modprobe.d ${DESTDIR}/usr/lib
+	rm -r ${DESTDIR}/etc/sysconfig
+	vsv ${pkgname}
+}


### PR DESCRIPTION
EDIT: set do_check to dummy since the test will not run without root. I could not find any documentation on this and any guidance is appreciated.

Hey all, this is a WIP but *functional* so far. I would appreciate any review/feedback since haven't packaged any services before and I've been mostly grepping around srcpkgs for examples. I have built this and tested briefly (running, functioning, logging) on `x86_64` and `x86_64-musl` as well as cross compiling for some arm archs (it's python and dbus FWIW)

There seems to be some play required in restarting dbus after the initial install and sv link to get it to run but it comes up fine after reboots after that so far. I am wondering if there is anything to be done about networkmanager in the startup and will be experimenting with that interaction.

Now that things are apparently working though I am going to port/test my ansible roles and try to test all the features I can think of. I use this package heavily on other distros and would like to bring it with me while using void.

#### Testing the changes
- I tested the changes in this PR: YES

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): YES

#### Local build testing
- I built this PR locally for my native architecture, x86_64, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64
  - aarch64-musl

