### PR TITLE
aircrack-ng: add libcap to enable more utilities

### DIFF
--- a/srcpkgs/aircrack-ng/template
+++ b/srcpkgs/aircrack-ng/template
@@ -1,10 +1,10 @@
 # Template file for 'aircrack-ng'
 pkgname=aircrack-ng
 version=1.6
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
-makedepends="libnl3-devel openssl-devel sqlite-devel zlib-devel"
+makedepends="libnl3-devel openssl-devel sqlite-devel zlib-devel libcap-devel"
 short_desc="Complete suite of tools to assess WiFi network security"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, BSD-3-Clause, OpenSSL"


### PR DESCRIPTION
This dependency is necessary for building the rest of the suite utilities like besside-ng.

#### Testing the changes
- I tested the changes in this PR: **briefly**