### PR TITLE
etc/conf: implement XBPS_MIRROR for remote repos

### DIFF
--- a/etc/defaults.conf
+++ b/etc/defaults.conf
@@ -15,12 +15,17 @@
 #
 
 # [OPTIONAL]
+# Use an alternative mirror for remote repositories. This is more
+# convenient than modifying etc/xbps.d/repos-remote*.conf.
+#
+#XBPS_MIRROR=https://repo-us.voidlinux.org/current
+
+# [OPTIONAL]
 # Enable optional arguments to xbps-install(1) for the host system.
 # Currently used in the 'binary-bootstrap' and 'bootstrap-update' targets.
 #
 # NOTE: local repositories are handled automatically by xbps-src,
-# but you can modify the default remote repositories at
-# 'etc/xbps.d/repos-remote*.conf'
+# and remote repositories can be changed by setting XBPS_MIRROR
 #
 #XBPS_INSTALL_ARGS=""
 


### PR DESCRIPTION
Setting this variable will make xbps-src use an alternative mirror for remote repositories.

Using this variable one can change the remote repository for all architectures in a single setting and without the need to modify `etc/xbps.d/repos-remote*.conf`. This is much more convenient as it allows changing remote repos without a dirty worktree.

To use just add a line like the following to `etc/conf`:

    XBPS_MIRROR=https://repo-us.voidlinux.org/

We also disable `00-repository-main.conf` for cross so we don't use the remote repo from the xbps package.

#### Testing the changes
- I tested the changes in this PR: **YES**