### PR TITLE
python3-gobject: update to 3.42.0.

### DIFF
--- a/srcpkgs/python3-gobject/patches/restore_gtk_liststore_insert_with_valuesv_with_newer_gtk4.patch
+++ b/srcpkgs/python3-gobject/patches/restore_gtk_liststore_insert_with_valuesv_with_newer_gtk4.patch
@@ -1,0 +1,84 @@
+From db472c14416da879fdd1ba685928be9b7c919e57 Mon Sep 17 00:00:00 2001
+From: Christoph Reiter <reiter.christoph@gmail.com>
+Date: Sun, 19 Sep 2021 16:52:15 +0200
+Subject: [PATCH] gtk overrides: restore Gtk.ListStore.insert_with_valuesv with
+ newer gtk4
+
+It got renamed in gtk 4.1.0, see https://gitlab.gnome.org/GNOME/gtk/-/commit/a1216599ff6b39bca3e936fbf
+To avoid an API break and make porting easier provide both versions for
+all users.
+
+Fixes #467
+---
+ gi/overrides/Gtk.py         |  9 ++++++++-
+ tests/test_docstring.py     |  5 +++--
+ tests/test_overrides_gtk.py | 14 ++++++++++++++
+ 3 files changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/gi/overrides/Gtk.py b/gi/overrides/Gtk.py
+index 7739751e..f53ec6bd 100644
+--- ./gi/overrides/Gtk.py
++++ ./gi/overrides/Gtk.py
+@@ -995,10 +995,17 @@ class ListStore(Gtk.ListStore, TreeModel, TreeSortable):
+         Gtk.ListStore.__init__(self)
+         self.set_column_types(column_types)
+ 
++    # insert_with_valuesv got renamed to insert_with_values with 4.1.0
++    # https://gitlab.gnome.org/GNOME/gtk/-/commit/a1216599ff6b39bca3e9
++    if not hasattr(Gtk.ListStore, "insert_with_valuesv"):
++        insert_with_valuesv = Gtk.ListStore.insert_with_values
++    elif not hasattr(Gtk.ListStore, "insert_with_values"):
++        insert_with_values = Gtk.ListStore.insert_with_valuesv
++
+     def _do_insert(self, position, row):
+         if row is not None:
+             row, columns = self._convert_row(row)
+-            treeiter = self.insert_with_valuesv(position, columns, row)
++            treeiter = self.insert_with_values(position, columns, row)
+         else:
+             treeiter = Gtk.ListStore.insert(self, position)
+ 
+diff --git a/tests/test_docstring.py b/tests/test_docstring.py
+index 29b7e5ef..49d030f5 100644
+--- ./tests/test_docstring.py
++++ ./tests/test_docstring.py
+@@ -93,8 +93,9 @@ class Test(unittest.TestCase):
+     @unittest.skipUnless(Gtk, 'no Gtk')
+     def test_shared_array_length_with_prior_out_arg(self):
+         # Test the 'iter' out argument does not effect length argument skipping.
+-        self.assertEqual(Gtk.ListStore.insert_with_valuesv.__doc__,
+-                         'insert_with_valuesv(self, position:int, columns:list, values:list) -> iter:Gtk.TreeIter')
++        self.assertRegex(
++            Gtk.ListStore.insert_with_valuesv.__doc__,
++            'insert_with_values.*\\(self, position:int, columns:list, values:list\\) -> iter:Gtk.TreeIter')
+ 
+     def test_sub_class_doc(self):
+         class A(GObject.Object):
+diff --git a/tests/test_overrides_gtk.py b/tests/test_overrides_gtk.py
+index 72fd2c8e..6bd2345a 100644
+--- ./tests/test_overrides_gtk.py
++++ ./tests/test_overrides_gtk.py
+@@ -1377,6 +1377,20 @@ class TestCustomSorter():
+             assert result.props.name == member
+ 
+ 
++@unittest.skipUnless(Gtk, 'Gtk not available')
++class TestListStore(unittest.TestCase):
++
++    def test_insert_with_values(self):
++        model = Gtk.ListStore(int)
++        assert hasattr(model, 'insert_with_values')
++        iter_ = model.insert_with_values(0, (0,), [42])
++        assert isinstance(iter_, Gtk.TreeIter)
++        assert hasattr(model, 'insert_with_valuesv')
++        iter_ = model.insert_with_valuesv(0, (0,), [43])
++        assert isinstance(iter_, Gtk.TreeIter)
++        assert len(model) == 2
++
++
+ @ignore_gi_deprecation_warnings
+ @unittest.skipUnless(Gtk, 'Gtk not available')
+ class TestTreeModel(unittest.TestCase):
+-- 
+GitLab
+

--- a/srcpkgs/python3-gobject/template
+++ b/srcpkgs/python3-gobject/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-gobject'
 pkgname=python3-gobject
-version=3.40.1
-revision=2
+version=3.42.0
+revision=1
 wrksrc="pygobject-${version}"
 build_style=meson
 build_helper="gir"
@@ -15,10 +15,10 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://pygobject.readthedocs.io/"
 distfiles="${GNOME_SITE}/pygobject/${version%.*}/pygobject-${version}.tar.xz"
-checksum=00c6d591f4cb40c335ab1fd3e8c17869ba15cfda54416fe363290af766790035
+checksum=9b12616e32cfc792f9dc841d9c472a41a35b85ba67d3a6eb427e307a6fe4367b
 
-pre_check() {
-	make_cmd="xvfb-run ninja"
+do_check() {
+	xvfb-run ninja -C build test
 }
 
 python3-gobject-devel_package() {


### PR DESCRIPTION
* backport fix for GTK 4.1+ incompatibility

cherry-picked and slightly modified from #33337

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
