### PR TITLE
lilypond: update to 2.23.5

### DIFF
--- a/srcpkgs/lilypond-doc/template
+++ b/srcpkgs/lilypond-doc/template
@@ -1,6 +1,6 @@
 # Template file for 'lilypond-doc'
 pkgname=lilypond-doc
-version=2.23.4
+version=2.23.5
 revision=1
 create_wrksrc=yes
 short_desc="Documentation for the lilypond music engraving program"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="https://lilypond.org/"
 distfiles="https://lilypond.org/downloads/binaries/documentation/lilypond-${version}-1.documentation.tar.bz2"
-checksum=b53eed66e8797e45743e3cf507d8395e597f1b4549e8cf2de1804edbbb456a04
+checksum=e2b528b3ce70058b634fd76b097f975760c0ad86148d9ec63b66c73a941b0afd
 
 do_install() {
 	vmkdir usr

--- a/srcpkgs/lilypond/template
+++ b/srcpkgs/lilypond/template
@@ -1,6 +1,6 @@
 # Template file for 'lilypond'
 pkgname=lilypond
-version=2.23.4
+version=2.23.5
 revision=1
 build_wrksrc="build"
 build_style="gnu-configure"
@@ -17,7 +17,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="https://lilypond.org/"
 distfiles="https://lilypond.org/downloads/sources/v2.23/lilypond-${version}.tar.gz"
-checksum=e300cfd7b94d81f1fb782ffee2aca8249002ece2f4868004274cebde32764b1e
+checksum=53fd289eac318356003bf19b2d9e8ec43cb32e2ea926363145c1b26482bd1678
 python_version=3
 
 if [ -n "${CROSS_BUILD}" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

The test on i686 fails like last time with
`.../color.scm:706:3: Wrong type argument in position 1 (expecting list of 3 or 4 numbers in [0.0,1.0]): -1.509384027e-8`
So I think we can ignore it. ;)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
