### PR TITLE
element-desktop: update to 1.9.6.

### DIFF
--- a/srcpkgs/element-desktop/patches/0001-Fixes-compilation-on-a-bunch-of-targets.patch
+++ b/srcpkgs/element-desktop/patches/0001-Fixes-compilation-on-a-bunch-of-targets.patch
@@ -1,23 +1,28 @@
-commit 6253d67b13db2bd075fb6f17e8fffc92efd7fdee
-Author: Jan Christian Grünhage <jan.christian@gruenhage.xyz>
-Date:   Tue Aug 17 17:33:02 2021 +0200
+From bc552079ad526a8b7da12c091e384d640407c7ea Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Tue, 17 Aug 2021 17:33:02 +0200
+Subject: [PATCH] Fixes compilation on a bunch of targets
 
-    Fixes compilation on a bunch of targets
-    
-    Considering that this changes generated files, I've not submitted this
-    patch directly. Instead, the original source has received a PR over at
-    https://github.com/vector-im/element-builder/pull/58.
+Considering that this changes generated files, I've not submitted this
+patch directly. Instead, the original source has received a PR over at
+https://github.com/vector-im/element-builder/pull/58.
+---
+ package.json          |  1 +
+ scripts/hak/target.js | 82 +++++++++++++++++++++++++++++++++++++------
+ yarn.lock             |  2 +-
+ 3 files changed, 74 insertions(+), 11 deletions(-)
 
 diff --git a/package.json b/package.json
-index 4dd59aa..141705b 100644
+index c958137..3b371d2 100644
 --- a/package.json
 +++ b/package.json
 @@ -57,6 +57,7 @@
-     "allchange": "^1.0.0",
+     "allchange": "^1.0.6",
      "asar": "^2.0.1",
      "chokidar": "^3.5.2",
 +    "detect-libc": "^1.0.3",
-     "electron": "^13.1.9",
+     "electron": "13.5",
      "electron-builder": "22.11.4",
      "electron-builder-squirrel-windows": "22.11.4",
 diff --git a/scripts/hak/target.js b/scripts/hak/target.js
@@ -144,10 +149,10 @@ index 0a965fc..07349fc 100644
  exports.getHost = getHost;
  function isHostId(id) {
 diff --git a/yarn.lock b/yarn.lock
-index 37690bb..7e112a8 100644
+index ae661ba..782282f 100644
 --- a/yarn.lock
 +++ b/yarn.lock
-@@ -1775,7 +1775,7 @@ deprecation@^2.0.0, deprecation@^2.3.1:
+@@ -1778,7 +1778,7 @@ deprecation@^2.0.0, deprecation@^2.3.1:
    resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
    integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
  
@@ -156,3 +161,6 @@ index 37690bb..7e112a8 100644
    version "1.0.3"
    resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
    integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+-- 
+2.34.1
+

--- a/srcpkgs/element-desktop/template
+++ b/srcpkgs/element-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'element-desktop'
 pkgname=element-desktop
-version=1.8.4
+version=1.9.6
 revision=1
 wrksrc="element-web-${version}"
 conf_files="/etc/${pkgname}/config.json"
@@ -18,15 +18,15 @@ _ghpage="https://github.com/vector-im"
 _archive="archive/v${version}.tar.gz"
 distfiles="${_ghpage}/element-desktop/${_archive}>element-desktop.tar.gz
  ${_ghpage}/element-web/${_archive}>element-web.tar.gz"
-checksum="3a972531c40da5de922824667ea048f16ee407800b26327542cac1d81357b44f
- 2752b88227c17dfcd3b207db88aba08375f9751851f2ea549115fac7a517a18a"
+checksum="420ac62f306a522170aede01b807aa4b406c7f1e1377165f455851b220c32f7b
+ 07c5575c79a5ddb2a3750528286cfe90ceeb32d985a88eb2b55452d7902e351e"
 
 patch_args="-Np1 -d ../${pkgname}-${version}"
 
 export USE_SYSTEM_APP_BUILDER=true
 
 pre_patch() {
-	ln -s ../element-web-${version}/0001-support-more-architectures.patch ../element-desktop-${version}/
+	ln -s ../element-web-${version}/0001-Fixes-compilation-on-a-bunch-of-targets.patch ../element-desktop-${version}/
 }
 
 pre_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built and used this PR locally for my native architecture, (x86_64-gnu)

#### Other

Obsoletes #34382, this updates to a newer version than that PR.

Aside of the patching: We'll want to update before Monday, because there'll be a security release and the smaller the update on Monday is the less likely it'll be that something breaks then. I'd like to be prepared there :D
