### PR TITLE
New package: 1password-8.4.1

### DIFF
--- a/srcpkgs/1password/INSTALL
+++ b/srcpkgs/1password/INSTALL
@@ -1,0 +1,11 @@
+# INSTALL
+case "${ACTION}" in
+post)
+	chmod 4755 opt/1Password/chrome-sandbox
+	chown :_onepassword opt/1Password/1Password-KeyringHelper
+	chmod u+s opt/1Password/1Password-KeyringHelper
+	chmod g+s opt/1Password/1Password-KeyringHelper
+	chown :_onepassword opt/1Password/1Password-BrowserSupport
+	chmod g+s opt/1Password/1Password-BrowserSupport
+	;;
+esac

--- a/srcpkgs/1password/files/1password
+++ b/srcpkgs/1password/files/1password
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /opt/1Password/1password "$@"

--- a/srcpkgs/1password/template
+++ b/srcpkgs/1password/template
@@ -1,0 +1,52 @@
+# Template file for '1password'
+pkgname=1password
+version=8.4.1
+revision=1
+archs="x86_64"
+create_wrksrc=yes
+hostmakedepends="w3m gnupg"
+short_desc="Password manager"
+maintainer="b-l-a-i-n-e <blaine.gilbreth@gmail.com>"
+license="custom:Proprietary"
+homepage="https://www.1password.com"
+distfiles="https://downloads.1password.com/linux/tar/stable/x86_64/1password-${version}.x64.tar.gz"
+checksum=f5c2468127c363b3a3d2fa5857b6ff0979eeaf1485c1afb114b3929c1fc4a7df
+_filename="${distfiles##*/}"
+_1passworddir="${_filename%.tar.*}"
+_license_checksum=b8f6ff9297488416f3d8063a151109ed5e8a2df6fa546856a4beaa715cbc0fda
+_gpg_key=3FEF9748469ADBE15DA7CA80AC2D62742012EA22
+system_groups="_onepassword"
+repository=nonfree
+restricted=yes
+nostrip=yes
+noshlibprovides=yes
+
+post_extract() {
+	# verify gpg key
+	$XBPS_FETCH_CMD -o "${_filename}.sig" "${distfiles}.sig"
+	if ! gpg --recv-keys "${_gpg_key}"; then
+		msg_error "Incorrect gpg key: ${_gpg_key}\n"
+	fi
+	if ! gpg --verify "${_filename}.sig" "${XBPS_SRCDISTDIR}/${pkgname}-${version}/${_filename}"; then
+		msg_error "gpg verify failed\n"
+	fi
+
+	# verify EULA
+	$XBPS_FETCH_CMD -o eula https://1password.com/legal/terms-of-service/
+	cat eula |
+		w3m -dump -I utf-8 -T text/html |
+		sed -n '/Service Agreement for 1Password/,/We clarified what happens if we part ways./p' > EULA
+	filesum="$($XBPS_DIGEST_CMD EULA)"
+	if [ "$filesum" != "$_license_checksum" ]; then
+		msg_error "SHA256 mismatch for EULA:\n$filesum\n"
+	fi
+}
+
+do_install() {
+	vmkdir opt/1Password
+	vcopy "${_1passworddir}/*" opt/1Password
+	vinstall "${_1passworddir}/com.1password.1Password.policy" 644 usr/share/polkit-1/actions/
+	vinstall "${_1passworddir}/resources/custom_allowed_browsers" 644 usr/share/doc/1password/examples/
+	vbin "${FILESDIR}/1password"
+	vlicense EULA
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): YES

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
