### PR TITLE
opensmtpd-extras: update to 6.7.1, orphan.

### DIFF
--- a/srcpkgs/opensmtpd-extras/template
+++ b/srcpkgs/opensmtpd-extras/template
@@ -1,8 +1,7 @@
 # Template file for 'opensmtpd-extras'
 pkgname=opensmtpd-extras
-version=6.6.0
-revision=4
-wrksrc="OpenSMTPD-extras-${version}"
+version=6.7.1
+revision=1
 build_style=gnu-configure
 configure_args="--with-table-passwd --with-table-ldap --with-table-mysql
  --with-table-postgres --with-table-socketmap --with-table-sqlite"
@@ -11,11 +10,11 @@ makedepends="openssl-devel libevent-devel postgresql-libs-devel
  libmariadbclient-devel sqlite-devel"
 depends="opensmtpd"
 short_desc="Free implementation of the server-side SMTP protocol - extras"
-maintainer="Denis Revin <denis.revin@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://www.opensmtpd.org"
 distfiles="https://www.opensmtpd.org/archives/${pkgname}-${version}.tar.gz"
-checksum=126b023602e8bb222bf24543a056ee0a548343dc86d184669ff9d82dfca1fbdf
+checksum=f84385559a8bb366b2fe25d8b1f78c108f07cc15992350171569d7bdc2e935ac
 
 CFLAGS="-D_DEFAULT_SOURCE"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64-musl