### PR TITLE
dma: fix /etc/dma/*.conf permissions

### DIFF
--- a/srcpkgs/dma/INSTALL
+++ b/srcpkgs/dma/INSTALL
@@ -2,6 +2,7 @@ case ${ACTION} in
 post)
 	# fix permissions and owners
 	chown root:mail usr/bin/dma
+	chown root:mail etc/dma/auth.conf etc/dma/dma.conf
 	chmod 2755 usr/bin/dma
 	chown root:mail usr/lib/dma-mbox-create
 	chmod 4754 usr/lib/dma-mbox-create

--- a/srcpkgs/dma/template
+++ b/srcpkgs/dma/template
@@ -1,7 +1,7 @@
 # Template file for 'dma'
 pkgname=dma
 version=0.13
-revision=3
+revision=4
 conf_files="/etc/dma/*.conf"
 make_dirs="/var/spool/dma 2775 root mail"
 hostmakedepends="flex"


### PR DESCRIPTION
Fixes https://github.com/void-linux/void-packages/issues/34431;
solution due to thenktor

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64-musl)
