### PR TITLE
aircrack-ng: fix dependency name libpcap

### DIFF
--- a/srcpkgs/aircrack-ng/template
+++ b/srcpkgs/aircrack-ng/template
@@ -1,10 +1,10 @@
 # Template file for 'aircrack-ng'
 pkgname=aircrack-ng
 version=1.6
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
-makedepends="libnl3-devel openssl-devel sqlite-devel zlib-devel libcap-devel"
+makedepends="libnl3-devel openssl-devel sqlite-devel zlib-devel libpcap-devel"
 short_desc="Complete suite of tools to assess WiFi network security"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, BSD-3-Clause, OpenSSL"


### PR DESCRIPTION
The dependency that was needed was libpcap-devel instead of libcap-devel.
This PR is a fix to [#34380](https://github.com/void-linux/void-packages/pull/34380)

#### Testing the changes
- I tested the changes in this PR: **briefly**