### PR TITLE
opensc: update to 0.22.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1702,7 +1702,7 @@ libBulletSoftBody.so.3.17 bullet-3.17_1
 libBullet3Common.so.3.17 bullet-3.17_1
 libinotifytools.so.0 libinotify-tools-3.14_2
 libfswatch.so.11 libfswatch-1.13.0_1
-libopensc.so.7 libopensc-0.21.0_2
+libopensc.so.8 libopensc-0.22.0_1
 libSDL2_ttf-2.0.so.0 SDL2_ttf-2.0.12_1
 librtlsdr.so.0 librtlsdr-0.5.3_1
 libSDL2_mixer-2.0.so.0 SDL2_mixer-2.0.0_1

--- a/srcpkgs/opensc/template
+++ b/srcpkgs/opensc/template
@@ -1,7 +1,7 @@
 # Template file for 'opensc'
 pkgname=opensc
-version=0.21.0
-revision=2
+version=0.22.0
+revision=1
 wrksrc="OpenSC-${version}"
 build_style=gnu-configure
 configure_args="--enable-man  --enable-sm --enable-static=no --enable-doc
@@ -13,7 +13,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/OpenSC/OpenSC/wiki"
 distfiles="https://github.com/OpenSC/OpenSC/archive/${version}.tar.gz"
-checksum=d4ee136d1b3a764868433da01857da7347de240e0c82545faa8659c2384ee43d
+checksum=138acf5724573d68bdfaf988bb05c00391edbfe262e69835813ed6bd00748c7a
 conf_files="/etc/opensc.conf"
 CFLAGS="-Wno-error=format-overflow"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I have tested only under x86-glibc, the update is much needed for newer types of smart cards. I have successfully used the new version with older and newer cards. 