### PR TITLE
haproxy: update to 2.4.9

### DIFF
--- a/srcpkgs/haproxy/template
+++ b/srcpkgs/haproxy/template
@@ -1,19 +1,19 @@
 # Template file for 'haproxy'
 pkgname=haproxy
-version=2.4.8
+version=2.4.9
 revision=1
 build_style=gnu-makefile
 make_install_args="SBINDIR=${DESTDIR}/usr/bin DOCDIR=${DESTDIR}/usr/share/doc/${pkgname}"
 hostmakedepends="lua53-devel"
 makedepends="libatomic-devel openssl-devel lua53-devel pcre-devel"
-checkdepends="varnish"
+checkdepends="curl varnish"
 short_desc="Reliable, high performance TCP/HTTP load balancer"
 maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://www.haproxy.org"
 changelog="https://www.haproxy.org/download/2.4/src/CHANGELOG"
 distfiles="${homepage}/download/${version%.*}/src/${pkgname}-${version}.tar.gz"
-checksum=e3e4c1ad293bc25e8d8790cc5e45133213dda008bfd0228bf3077259b32ebaa5
+checksum=d56c7fe3c5afedd1b9a19e1b7f8f954feaf50a9c2f205f99891043858b72a763
 
 haproxy_homedir="/var/lib/${pkgname}"
 make_dirs="$haproxy_homedir 0750 ${pkgname} ${pkgname}"


### PR DESCRIPTION
- I tested the changes in this PR: YES
- I built this PR locally for my native architecture, (amd64-glibc)