### PR TITLE
gsl: update to 2.7.1, adopt.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -830,7 +830,7 @@ libgiblib.so.1 giblib-1.2.4_1
 libgc.so.1 gc-7.6.4_1
 libcord.so.1 gc-7.4_1
 libgslcblas.so.0 gsl-1.15_1
-libgsl.so.25 gsl-2.6_1
+libgsl.so.27 gsl-2.7.1_1
 liblua5.1.so.5.1 lua51-5.1.5_1
 liblua5.2.so.5.2 lua52-5.2.4_2
 liblua5.3.so.5.3 lua53-5.3.5_4

--- a/srcpkgs/Clight/template
+++ b/srcpkgs/Clight/template
@@ -1,7 +1,7 @@
 # Template file for 'Clight'
 pkgname=Clight
 version=4.7
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="popt-devel gsl-devel libconfig-devel elogind-devel bash-completion

--- a/srcpkgs/bogofilter/template
+++ b/srcpkgs/bogofilter/template
@@ -1,7 +1,7 @@
 # Template file for 'bogofilter'
 pkgname=bogofilter
 version=1.2.5
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--sysconfdir=/etc/${pkgname} --with-database=sqlite"
 hostmakedepends="perl"

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.2.1
-revision=5
+revision=6
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON
  -DBUILD_TESTING=OFF"

--- a/srcpkgs/dieharder/template
+++ b/srcpkgs/dieharder/template
@@ -1,14 +1,14 @@
 # Template file for 'dieharder'
 pkgname=dieharder
 version=3.31.1
-revision=7
+revision=8
 build_style=gnu-configure
 makedepends="gsl-devel"
 short_desc="Testing and benchmarking tool for random number generators"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-only"
-homepage="http://www.phy.duke.edu/~rgb/General/dieharder.php"
-distfiles="http://www.phy.duke.edu/~rgb/General/dieharder/${pkgname}-${version}.tgz"
+homepage="http://webhome.phy.duke.edu/~rgb/General/dieharder.php"
+distfiles="http://webhome.phy.duke.edu/~rgb/General/dieharder/${pkgname}-${version}.tgz"
 checksum=6cff0ff8394c553549ac7433359ccfc955fb26794260314620dfa5e4cd4b727f
 disable_parallel_build=yes
 

--- a/srcpkgs/enblend-enfuse/template
+++ b/srcpkgs/enblend-enfuse/template
@@ -1,7 +1,7 @@
 # Template file for 'enblend-enfuse'
 pkgname=enblend-enfuse
 version=4.2
-revision=6
+revision=7
 build_style=gnu-configure
 configure_args="--enable-openmp --with-tcmalloc"
 hostmakedepends="pkg-config perl automake"

--- a/srcpkgs/giac/template
+++ b/srcpkgs/giac/template
@@ -1,6 +1,6 @@
 # Template file for 'giac'
 pkgname=giac
-version=1.7.0.39
+version=1.7.0.45
 revision=1
 wrksrc="giac-${version%.*}"
 build_style=gnu-configure
@@ -13,7 +13,7 @@ maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-3.0-or-later"
 homepage="https://www-fourier.ujf-grenoble.fr/~parisse/giac.html"
 distfiles="https://www-fourier.ujf-grenoble.fr/~parisse/debian/dists/stable/main/source/giac_${version%.*}-${version##*.}.tar.gz"
-checksum=234645e33284969fac5901e6172756ac925a6b93362fa24e86e647a82cfcad56
+checksum=028b9e323d81a261a243c0768d5e12f3d76371eff05fd24cf2eb177b445f1da6
 
 # need more than 4*65536 stack, see try_parse() in gen.cc line 11812
 LDFLAGS="-Wl,-z,stack-size=2097152"

--- a/srcpkgs/gnuradio/patches/596c6495f3bdf579dae0c26531a16f6adcc7fb2f.patch
+++ b/srcpkgs/gnuradio/patches/596c6495f3bdf579dae0c26531a16f6adcc7fb2f.patch
@@ -1,0 +1,46 @@
+From 596c6495f3bdf579dae0c26531a16f6adcc7fb2f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marcus=20M=C3=BCller?= <mmueller@gnuradio.org>
+Date: Mon, 13 Apr 2020 00:11:59 +0200
+Subject: [PATCH] =?UTF-8?q?pmt:=20conditionalize=20testing=20of=20long=20>?=
+ =?UTF-8?q?=202=C2=B3=C2=B2=20on=20sizeof(long)?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ gnuradio-runtime/python/pmt/qa_pmt.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/gnuradio-runtime/python/pmt/qa_pmt.py b/gnuradio-runtime/python/pmt/qa_pmt.py
+index 884bba7dd4b..44f616cdae1 100644
+--- a/gnuradio-runtime/python/pmt/qa_pmt.py
++++ b/gnuradio-runtime/python/pmt/qa_pmt.py
+@@ -18,6 +18,10 @@ class test_pmt(unittest.TestCase):
+     MAXINT32 = (2**31)-1
+     MININT32 = (-MAXINT32)-1
+ 
++    def setUp(self):
++        from ctypes import sizeof, c_long
++        self.sizeof_long = sizeof(c_long)
++
+     def test01(self):
+         a = pmt.intern("a")
+         b = pmt.from_double(123765)
+@@ -112,6 +116,8 @@ def test14(self):
+         self.assertEqual(const,pmt.to_long(deser))
+ 
+     def test15(self):
++        if(self.sizeof_long <= 4):
++            return
+         const = self.MAXINT32 + 1
+         x_pmt = pmt.from_long(const)
+         s = pmt.serialize_str(x_pmt)
+@@ -137,6 +143,8 @@ def test17(self):
+         self.assertEqual(const, x_long)
+ 
+     def test18(self):
++        if(self.sizeof_long <= 4):
++            return
+         const = self.MININT32 - 1
+         x_pmt = pmt.from_long(const)
+         s = pmt.serialize_str(x_pmt)

--- a/srcpkgs/gnuradio/patches/aa4b15d0b26b3c72fab736bcd28a67ab9d1404b7.patch
+++ b/srcpkgs/gnuradio/patches/aa4b15d0b26b3c72fab736bcd28a67ab9d1404b7.patch
@@ -1,0 +1,28 @@
+From aa4b15d0b26b3c72fab736bcd28a67ab9d1404b7 Mon Sep 17 00:00:00 2001
+From: John Sallay <jasallay@gmail.com>
+Date: Sat, 23 Oct 2021 08:26:42 -0400
+Subject: [PATCH] Fix issue 4595 qa_agc Assertion Error.
+
+The number of input elements needs to be disivible by volk_alignment, which it wasn't
+for machines with 512-bit registers.
+
+Signed-off-by: John Sallay <jasallay@gmail.com>
+---
+ gr-analog/python/analog/qa_agc.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/gr-analog/python/analog/qa_agc.py b/gr-analog/python/analog/qa_agc.py
+index a5a8ea47b6a..9368dd5d2a8 100644
+--- a/gr-analog/python/analog/qa_agc.py
++++ b/gr-analog/python/analog/qa_agc.py
+@@ -454,7 +454,9 @@ def test_006(self):
+         tb = self.tb
+ 
+         sampling_freq = 100
+-        N = int(5*sampling_freq)
++        # N must by a multiple of the volk_alignment of the system for this test to work.
++        # For a machine with 512-bit registers, that would be 8 complex-floats.
++        N = int(8 * sampling_freq)
+         src1 = analog.sig_source_c(sampling_freq, analog.GR_SIN_WAVE,
+                                    sampling_freq * 0.10, 100)
+         dst1 = blocks.vector_sink_c()

--- a/srcpkgs/gnuradio/patches/f259befbbe54e55fc4994899e92bcf5bf462fa2f.patch
+++ b/srcpkgs/gnuradio/patches/f259befbbe54e55fc4994899e92bcf5bf462fa2f.patch
@@ -1,0 +1,31 @@
+From f259befbbe54e55fc4994899e92bcf5bf462fa2f Mon Sep 17 00:00:00 2001
+From: alekhgupta1441 <alekhgupta1441@gmail.com>
+Date: Sun, 12 Apr 2020 03:48:14 +0530
+Subject: [PATCH] gr-digital/python : Updated soft_dec_lut_gen.py
+
+---
+ gr-digital/python/digital/soft_dec_lut_gen.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gr-digital/python/digital/soft_dec_lut_gen.py b/gr-digital/python/digital/soft_dec_lut_gen.py
+index 4503c4fea7b..84f6de66e45 100644
+--- a/gr-digital/python/digital/soft_dec_lut_gen.py
++++ b/gr-digital/python/digital/soft_dec_lut_gen.py
+@@ -73,7 +73,7 @@ def soft_dec_table_generator(soft_dec_gen, prec, Es=1):
+ 
+     '''
+ 
+-    npts = 2.0**prec
++    npts = int(2.0**prec)
+     maxd = Es*numpy.sqrt(2.0)/2.0
+     yrng = numpy.linspace(-maxd, maxd, npts)
+     xrng = numpy.linspace(-maxd, maxd, npts)
+@@ -110,7 +110,7 @@ def soft_dec_table(constel, symbols, prec, npwr=1):
+     re_max = max(numpy.array(constel).real)
+     im_max = max(numpy.array(constel).imag)
+ 
+-    npts = 2.0**prec
++    npts = int(2.0**prec)
+     yrng = numpy.linspace(im_min, im_max, npts)
+     xrng = numpy.linspace(re_min, re_max, npts)
+ 

--- a/srcpkgs/gnuradio/patches/skip-test-that-hangs-on-32bit.patch
+++ b/srcpkgs/gnuradio/patches/skip-test-that-hangs-on-32bit.patch
@@ -1,0 +1,26 @@
+Skip one test that hangs forever on 32 bit
+
+See: https://github.com/gnuradio/gnuradio/issues/989
+
+--- a/gr-fec/python/fec/qa_fecapi_ldpc.py	2019-08-09 18:15:36.000000000 -0300
++++ b/gr-fec/python/fec/qa_fecapi_ldpc.py	2021-12-28 12:56:31.635977173 -0300
+@@ -98,6 +98,9 @@
+         self.assertEqual(data_in, data_out)
+ 
+     def test_parallelism0_03(self):
++        from ctypes import sizeof, c_long
++        if sizeof(c_long) <= 4:
++            return
+         filename = LDPC_ALIST_DIR + "n_0100_k_0058_gen_matrix.alist"
+         gap = 4
+         LDPC_matrix_object = fec.ldpc_G_matrix(filename)
+@@ -115,6 +118,9 @@
+         self.assertEqual(data_in, data_out)
+ 
+     def test_parallelism0_03(self):
++        from ctypes import sizeof, c_long
++        if sizeof(c_long) <= 4:
++            return
+         filename = LDPC_ALIST_DIR + "n_0100_k_0058_gen_matrix.alist"
+         gap = 4
+         k = 100 - 58

--- a/srcpkgs/gnuradio/template
+++ b/srcpkgs/gnuradio/template
@@ -1,7 +1,7 @@
 # Template file for 'gnuradio'
 pkgname=gnuradio
 version=3.8.0.0
-revision=8
+revision=9
 build_style=cmake
 conf_files="/etc/gnuradio/conf.d/*"
 configure_args="-DENABLE_INTERNAL_VOLK=OFF -DGR_PYTHON_DIR=/${py3_sitelib}"
@@ -12,6 +12,7 @@ makedepends="SDL-devel boost-devel fftw-devel gsl-devel jack-devel
  python3-gobject-devel log4cpp-devel gmpxx-devel mpir-devel"
 depends="python3-cheetah3 python3-numpy python3-Mako python3-gobject
  python3-yaml"
+checkdepends="python3-scipy"
 short_desc="Framework for software defined radio"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/gsl/template
+++ b/srcpkgs/gsl/template
@@ -1,14 +1,15 @@
 # Template file for 'gsl'
 pkgname=gsl
-version=2.7
+version=2.7.1
 revision=1
 build_style=gnu-configure
 short_desc="Numerical library for C and C++ programmers"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/gsl/gsl.html"
+changelog="http://git.savannah.gnu.org/cgit/gsl.git/plain/NEWS"
 distfiles="${GNU_SITE}/gsl/${pkgname}-${version}.tar.gz"
-checksum=efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b
+checksum=dcb0fbd43048832b757ff9942691a8dd70026d5da0ff85601e52687f6deeb34b
 
 case $XBPS_TARGET_MACHINE in
 	# avoid numerical noise caused by extended-precision of registers

--- a/srcpkgs/guvcview/template
+++ b/srcpkgs/guvcview/template
@@ -1,7 +1,7 @@
 # Template file for 'guvcview'
 pkgname=guvcview
 version=2.0.6
-revision=2
+revision=3
 wrksrc="${pkgname}-src-${version}"
 build_style=gnu-configure
 configure_args="--disable-static --disable-debian-menu"
@@ -18,4 +18,6 @@ checksum=95381cef5ee139e15f90b79d1425cc22bbaae43f87452cdce6674636aff37e85
 
 post_extract() {
 	sed '31a#include <locale.h>' -i  guvcview/guvcview.c
+	# add missing EOL in this file to fix do_check()
+	echo >> po/POTFILES.in
 }

--- a/srcpkgs/igt-gpu-tools/template
+++ b/srcpkgs/igt-gpu-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'igt-gpu-tools'
 pkgname=igt-gpu-tools
 version=1.25
-revision=4
+revision=5
 build_style=meson
 configure_args="-Db_ndebug=false -Db_lto=false"
 # b_lto=true makes the build hang at a random point

--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=1.1.1
-revision=2
+revision=3
 wrksrc="inkscape-${version}_2021-09-20_3bf5ae0d25"
 build_style=cmake
 # builds executables then runs checks

--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -1,7 +1,7 @@
 # Template file for 'ipe'
 pkgname=ipe
 version=7.2.24
-revision=4
+revision=5
 _tools_commit=v7.2.20.1
 hostmakedepends="pkg-config doxygen qt5-qmake qt5-tools qt5-host-tools"
 makedepends="cairo-devel gsl-devel libcurl-devel libjpeg-turbo-devel

--- a/srcpkgs/krita/template
+++ b/srcpkgs/krita/template
@@ -1,7 +1,7 @@
 # Template file for 'krita'
 pkgname=krita
 version=5.0.0
-revision=2
+revision=3
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules gettext pkg-config python3

--- a/srcpkgs/siril/template
+++ b/srcpkgs/siril/template
@@ -1,12 +1,12 @@
 # Template file for 'siril'
 pkgname=siril
 version=0.9.12
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool autoconf automake gettext-devel"
 makedepends="fftw-devel libconfig-devel libopencv-devel libffms2-devel
  gsl-devel libraw-devel tiff-devel libpng-devel libcurl-devel
- ffmpeg-devel gtk+3-devel cfitsio-devel gsl-devel"
+ ffmpeg-devel gtk+3-devel cfitsio-devel gsl-devel libgomp-devel"
 depends="gnuplot"
 short_desc="Free astronomical image processing software"
 maintainer="Andreas Kempe <kempe@lysator.liu.se>"
@@ -20,6 +20,11 @@ if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 fi
 
 CFLAGS="-fcommon"
+
+post_extract() {
+	# add missing check target in this subdir to fix do_check()
+	echo 'check:' >> deps/kplot/Makefile
+}
 
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh


### PR DESCRIPTION
The main change is a soname bump that apparently should have been done on 2.7.

This requires several revbumps. I took the chance to:
 - giac: update to 1.7.0.43 (minor update, no surprises)
 - dieharder: fix URL, since it was failing with a certificate error
 - gnuradio: add missing checkdepends and patch from upstream so `do_check()` succeeds
 - guvcview and siril: trivial fixes so `do_check()` succeeds
 - krita: disable tests since they are broken (70 failures)

I tested pkg -Q on x86_64 and all passes with these fixes.