### PR TITLE
gns3-server: update aiofiles version constraint

### DIFF
--- a/srcpkgs/gns3-server/patches/requirements.patch
+++ b/srcpkgs/gns3-server/patches/requirements.patch
@@ -7,7 +7,8 @@ diff --git a/requirements.txt b/requirements.txt
 -aiohttp==3.7.4.post0
 +aiohttp>=3.7.4
  aiohttp-cors==0.7.0
- aiofiles==0.7.0
+-aiofiles==0.7.0
++aiofiles==0.8.0
 -Jinja2==3.0.1
 +Jinja2>=3.0.1
 -sentry-sdk==1.3.1

--- a/srcpkgs/gns3-server/template
+++ b/srcpkgs/gns3-server/template
@@ -1,7 +1,7 @@
 # Template file for 'gns3-server'
 pkgname=gns3-server
 version=2.2.27
-revision=1
+revision=2
 build_style=python3-module
 # Skip tests/compute/docker/test_docker_vm.py::test_stop test that wasn't updated with the code https://github.com/GNS3/gns3-server/commit/b1a62dfd
 make_check_args="-k-test_stop"


### PR DESCRIPTION
python3-aiofiles was recently updated to [0.8.0](https://github.com/void-linux/void-packages/commit/8c12849a806f36ef6f54a9ddb491f42ff91b777b).  This change updates the version in requirements.txt to allow gns3-server to use the new version of aiofiles.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
