### PR TITLE
Update LXQT homepages and update compton-conf

### DIFF
--- a/srcpkgs/compton-conf/template
+++ b/srcpkgs/compton-conf/template
@@ -1,6 +1,6 @@
 # Template file for 'compton-conf'
 pkgname=compton-conf
-version=0.15.0
+version=0.16.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -9,7 +9,7 @@ depends="compton desktop-file-utils"
 short_desc="LXQt GUI configuration tool for compton"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
+homepage="https://lxqt-project.org/"
 distfiles="https://github.com/lxqt/compton-conf/releases/download/${version}/compton-conf-${version}.tar.xz"
-checksum=09077799b7a3aebae815c94da42e908c34352e6e7af79a5375aaf1a3ad5a21c6
+checksum=7d5354d88ad8cd3342ce237f0cf8b0ed422ee837be31e89ae5e0ca66e1cf4a41
 replaces="lxqt-common>=0"

--- a/srcpkgs/libsysstat/template
+++ b/srcpkgs/libsysstat/template
@@ -1,14 +1,14 @@
 # Template file for 'libsysstat'
 pkgname=libsysstat
 version=0.4.6
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools"
 makedepends="qt5-devel"
 short_desc="Qt-based interface to system statistics"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
+homepage="https://lxqt-project.org/"
 distfiles="https://github.com/lxqt/libsysstat/releases/download/${version}/libsysstat-${version}.tar.xz"
 checksum=e6c6383d6d6e0e67791be812329cb245035eed35e201e01088515e3ffefb13be
 replaces="lxde-libsysstat>=0"

--- a/srcpkgs/obconf-qt/template
+++ b/srcpkgs/obconf-qt/template
@@ -1,7 +1,7 @@
 # Template file for 'obconf-qt'
 pkgname=obconf-qt
 version=0.16.2
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
 makedepends="qt5-x11extras-devel qt5-tools-devel openbox-devel"
@@ -9,6 +9,6 @@ depends="desktop-file-utils hicolor-icon-theme"
 short_desc="LXQt Openbox configuration tool"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://lxqt.org/"
+homepage="https://lxqt-project.org/"
 distfiles="https://github.com/lxqt/obconf-qt/releases/download/${version}/obconf-qt-${version}.tar.xz"
 checksum=7328da1606b289280e2ce0f2279ab30d06f584e4c2d6fc5f01c0f3d9ce714960


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
The `https://lxqt.org/` and `https://www.lxqt.org/` websites are dead. The LXQT website has moved to `https://lxqt-project.org/`. This PR updates `homepage`s of some packages so that it won't use the dead links.

This PR only changes package metadata (and `compton-conf`), not the package contents, so CI shouldn't be needed. I can reenable it if it will be requested.

I have tested this locally just to be sure and only `compton-conf` didn't compile. It wasn't my PR's fault, it had some dependencies missing, so I have updated it and fixed it. The 0.16.0 is the official last release of `compton-conf`.
#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Edit: enabling CI