### PR TITLE
[RFC] build-styles/go.sh: run go test -v ${go_project:-go_import_path} in do_check

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -2,6 +2,13 @@
 # This helper is for templates for Go packages.
 #
 
+do_check() {
+	go_package=${go_package:-$go_import_path}
+	if [ "${go_mod_mode}" != "off" ] && [ -f go.mod ]; then
+		go test -v ${go_package}
+	fi
+}
+
 do_configure() {
 	# $go_import_path must be set, or we can't link $PWD into $GOSRCPATH
 	# nor build from modules


### PR DESCRIPTION
There are 313 build_style=go packages, and currently 8 of them have tests defined in the package template.

I have been testing the go packages with this. So far, I have rebuilt 183 packages and there have been no errors and 64 packages have run tests successfully.

Ideally, more tests would be added (because they are a lot more common on internal libraries than command clients) but this is probably the safest default option.

EDIT: My script was setup wrong and some packages did fail. I am testing with only running tests on packages that have a `go.mod` and the pass rate is very high. I will see how this goes.