### PR TITLE
gnome-backgrounds: update to 41.0

### DIFF
--- a/srcpkgs/eog/template
+++ b/srcpkgs/eog/template
@@ -1,6 +1,6 @@
 # Template file for 'eog'
 pkgname=eog
-version=40.2
+version=41.1
 revision=1
 build_helper="gir"
 build_style=meson
@@ -14,7 +14,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/EyeOfGnome"
 distfiles="${GNOME_SITE}/eog/${version%.*}/eog-${version}.tar.xz"
-checksum=9084e299931fb57de287e57dbd2ee2d297fb6740c0d535b9da8d5f196a8fd195
+checksum=86e1b9ba39dacf74226afa457ab983b41253b89f617bf54139cad0892d02d8a9
 shlib_provides="libeog.so"
 lib32disabled=yes
 

--- a/srcpkgs/gnome-backgrounds/template
+++ b/srcpkgs/gnome-backgrounds/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-backgrounds'
 pkgname=gnome-backgrounds
-version=40.1
+version=41.0
 revision=1
 build_style=meson
 hostmakedepends=gettext
@@ -9,4 +9,4 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, CC-BY-2.0, CC-BY-SA-2.0, CC-BY-SA-3.0"
 homepage="https://gitlab.gnome.org/GNOME/gnome-backgrounds"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=60df8a0da301ce425b7043d42ae32ec4011ff08f18e0fc62f29401305da3a70e
+checksum=1da1ac0d261bedf0fcd2c85b480bc65505e23cf51f1143126c0d37717e693145


### PR DESCRIPTION
Testing the changes
    I tested the changes in this PR: briefly

Local build testing
    I built this PR locally for my native architecture, x86_64-glibc