### PR TITLE
New packages: grype and syft

### DIFF
--- a/srcpkgs/grype/template
+++ b/srcpkgs/grype/template
@@ -1,0 +1,12 @@
+# Template file for 'grype'
+pkgname=grype
+version=0.27.0
+revision=1
+build_style=go
+go_import_path="github.com/anchore/grype"
+short_desc="Vulnerability scanner for container images and filesystems"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0"
+homepage="https://github.com/anchore/grype"
+distfiles="https://github.com/anchore/grype/archive/refs/tags/v${version}.tar.gz"
+checksum=a022046538eb5e0ae60e57973ca301c9b32dfce339b0a3468f94fb26979b0495

--- a/srcpkgs/syft/template
+++ b/srcpkgs/syft/template
@@ -1,0 +1,12 @@
+# Template file for 'syft'
+pkgname=syft
+version=0.32.0
+revision=1
+build_style=go
+go_import_path="github.com/anchore/syft"
+short_desc="SBOM generator CLI for container images, filesystems and more"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0"
+homepage="https://github.com/anchore/syft"
+distfiles="https://github.com/anchore/syft/archive/refs/tags/v${version}.tar.gz"
+checksum=c49f13cb9a97d31cf34219fa7da3a155b59df2bc3a3631cf9dd64c0edafdb22b


### PR DESCRIPTION
This adds two new packages, `syft`, a SBOM generator with support for creating SBOMs from loads of sources, and `grype`, a vulnerability scanner based on `syft`. `grype` includes `syft` as a library, and because go includes those statically, which is why `grype` does not have a dependency on `syft` here.
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**
