### PR TITLE
New package: ttf-julia-mono-0.044

### DIFF
--- a/srcpkgs/ttf-julia-mono/template
+++ b/srcpkgs/ttf-julia-mono/template
@@ -1,0 +1,21 @@
+# Template file for 'ttf-julia-mono'
+pkgname=ttf-julia-mono
+version=0.044
+revision=1
+create_wrksrc=yes
+depends="font-util"
+short_desc="Monospaced font with technical and math Unicode support"
+maintainer="xaltsc <hey@xaltsc.dev>"
+license="OFL-1.1"
+homepage="https://juliamono.netlify.app"
+distfiles="https://github.com/cormullion/juliamono/releases/download/v${version}/JuliaMono-ttf.tar.gz"
+checksum=63c839443d46c775551338c3235abf9ca85e4721740513d90d198ca9916e42a5
+font_dirs="/usr/share/fonts/TTF"
+
+do_install() {
+	vmkdir usr/share/fonts/TTF
+	for i in ${wrksrc}/*.ttf; do
+		vinstall $i 644 usr/share/fonts/TTF/
+	done
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: Over three months of daily use now.

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

Yes, this is a font package, but I believe it conforms to the quality requirements because the main purpose of this font is to provide a monospaced font with math and other technical glyphs built in, such s, for instance, math alphabets, which are often not found in font-package. In this regard, Julia Mono claims to have even more glyphs than DejaVu Mono.

See:
- https://mono-math.netlify.app/#JuliaMono
- https://juliamono.netlify.app


<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, glibc)