### PR TITLE
dnscrypt-proxy: put config in subdirectory of etc/.

### DIFF
--- a/srcpkgs/dnscrypt-proxy/INSTALL.msg
+++ b/srcpkgs/dnscrypt-proxy/INSTALL.msg
@@ -1,0 +1,3 @@
+The dnscrypt-proxy service now installs and looks for the config file in
+/etc/dnscrypt-proxy/dnscrypt-proxy.toml. Any previous configuration will
+need to be moved into this directory manually.

--- a/srcpkgs/dnscrypt-proxy/files/dnscrypt-proxy/run
+++ b/srcpkgs/dnscrypt-proxy/files/dnscrypt-proxy/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec dnscrypt-proxy -config /etc/dnscrypt-proxy.toml
+exec dnscrypt-proxy -config /etc/dnscrypt-proxy/dnscrypt-proxy.toml

--- a/srcpkgs/dnscrypt-proxy/template
+++ b/srcpkgs/dnscrypt-proxy/template
@@ -1,7 +1,7 @@
 # Template file for 'dnscrypt-proxy'
 pkgname=dnscrypt-proxy
 version=2.1.1
-revision=2
+revision=3
 build_style=go
 go_import_path=github.com/dnscrypt/dnscrypt-proxy
 go_package="${go_import_path}/dnscrypt-proxy"
@@ -12,12 +12,12 @@ homepage="https://github.com/DNSCrypt/dnscrypt-proxy"
 changelog="https://raw.githubusercontent.com/DNSCrypt/dnscrypt-proxy/master/ChangeLog"
 distfiles="https://github.com/DNSCrypt/dnscrypt-proxy/archive/${version}.tar.gz"
 checksum=cc4a2f274ce48c3731ff981e940e6475d912fb356a80481e91725e81d67bde14
-conf_files="/etc/dnscrypt-proxy.toml"
+conf_files="/etc/dnscrypt-proxy/dnscrypt-proxy.toml"
 system_accounts="dnscrypt_proxy"
 make_dirs="/var/log/dnscrypt-proxy 0750 dnscrypt_proxy dnscrypt_proxy"
 
 post_install() {
-	vconf dnscrypt-proxy/example-dnscrypt-proxy.toml dnscrypt-proxy.toml
+	vinstall dnscrypt-proxy/example-dnscrypt-proxy.toml 644 /etc/dnscrypt-proxy dnscrypt-proxy.toml
 	vlicense LICENSE
 	vsv dnscrypt-proxy
 	for example in dnscrypt-proxy/example*txt; do


### PR DESCRIPTION
this change prevents dnscrypt-proxy from polluting etc/ with lists of relays, resolvers, etc.

After enabling the service, I was seeing these files show up in etc/:
```
public-resolvers.md
public-resolvers.md.minisig
relays.md
relays.md.minisig
```

Not sure how it should notify that the config location has moved. Should there be an `INSTALL.msg`, or should the config be moved in post in an `INSTALL`?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
