### PR TITLE
black: update to 22.3.0.

### DIFF
--- a/srcpkgs/black/template
+++ b/srcpkgs/black/template
@@ -1,7 +1,7 @@
 # Template file for 'black'
 pkgname=black
-version=21.9b0
-revision=2
+version=22.3.0
+revision=1
 build_style=python3-module
 # Disable tests that require `black` in the search path for commands.
 make_check_args="--deselect tests/test_primer.py::PrimerLibTests::test_gen_check_output
@@ -20,7 +20,7 @@ license="MIT"
 homepage="https://github.com/psf/black"
 changelog="https://raw.githubusercontent.com/psf/black/main/CHANGES.md"
 distfiles="${PYPI_SITE}/b/black/black-${version}.tar.gz"
-checksum=7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91
+checksum=35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79
 
 pre_build() {
 	# <https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-python/black/black-21.8_beta0.ebuild#n45>.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

```
$ black --target-version py310 47cfr97
Usage: black [OPTIONS] SRC ...
Try 'black -h' for help.

Error: Invalid value for '-t' / '--target-version': invalid choice: py310. (choose from py27, py33, py34, py35, py36, py37, py38, py39)

<I update `black`.>

$ black --target-version py310 47cfr97
reformatted 47cfr97
All done! ✨ 🍰 ✨
1 file reformatted.
```
