### PR TITLE
libnice: remove dep gssdp-igd

### DIFF
--- a/srcpkgs/libnice/template
+++ b/srcpkgs/libnice/template
@@ -7,7 +7,7 @@ build_helper="gir"
 configure_args="-Dcrypto-library=openssl -Dgtk_doc=disabled -Dtests=disabled
  -Dexamples=disabled -Dintrospection=$(vopt_if gir enabled disabled)"
 hostmakedepends="glib-devel pkg-config"
-makedepends="gstreamer1-devel gupnp-igd-devel openssl-devel libglib-devel"
+makedepends="gstreamer1-devel openssl-devel libglib-devel"
 short_desc="Implementation of the IETF's draft ICE (for P2P UDP data streams)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
this removes gssdp-igd from the dependencies of libnice, as gssdp will
switch to gtk4 with version 1.4.0. This will introduce a
new dependency loop which will be prevented by this commit:

gst-plugins-bad1-1.18.5_1 -> gtk4-4.4.0_2 -> gssdp-1.4.0.1_1
-> gupnp-igd-0.2.5_3 -> libnice-0.1.18_3 -> gst-plugins-bad1-1.18.5_1
-> ...