### PR TITLE
libdrm: update to 2.4.109.

### DIFF
--- a/srcpkgs/libdrm/template
+++ b/srcpkgs/libdrm/template
@@ -1,6 +1,6 @@
 # Template file for 'libdrm'
 pkgname=libdrm
-version=2.4.107
+version=2.4.109
 revision=1
 wrksrc="drm-libdrm-${version}"
 build_style=meson
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://dri.freedesktop.org/"
 distfiles="https://gitlab.freedesktop.org/mesa/drm/-/archive/libdrm-${version}/drm-libdrm-${version}.tar.gz"
-checksum=16b23932a2b7d41d091cf95662a83f56c680a9bb3456931c0b76fde02ae2d53f
+checksum=5ba126403051b2cad0afa4f1d6f78e08d985543db562f164a5fc63c501e07ffd
 
 case "$XBPS_TARGET_MACHINE" in
 	aarch64*) configure_args+=" -Dvc4=true";;


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

wlroots master now requires `2.4.108` and the next wlroots release is just around the corner.