### PR TITLE
zsh: add alternative for sh

### DIFF
--- a/srcpkgs/zsh/template
+++ b/srcpkgs/zsh/template
@@ -27,6 +27,10 @@ register_shell="/bin/zsh /usr/bin/zsh"
 lib32disabled=yes
 conf_files="/etc/zsh/*"
 
+alternatives="
+ sh:sh:/usr/bin/zsh
+ sh:sh.1:/usr/share/man/man1/zsh.1"
+
 post_patch() {
 	# Set correct keymap path
 	sed -i 's#/usr/share/keymaps#/usr/share/kbd/keymaps#g' \


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

The system boots and basic usage seems to work fine with zsh as `/bin/sh`.


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

