### PR TITLE
scummvm: enable all engines

### DIFF
--- a/srcpkgs/scummvm/template
+++ b/srcpkgs/scummvm/template
@@ -1,14 +1,14 @@
 # Template file for 'scummvm'
 pkgname=scummvm
 version=2.5.0
-revision=1
+revision=2
 build_style=configure
-configure_args="--prefix=/usr --enable-release-mode"
+configure_args="--prefix=/usr --enable-release-mode --enable-all-engines"
 hostmakedepends="pkg-config nasm"
 makedepends="zlib-devel libpng-devel SDL2-devel libmad-devel faad2-devel
  fluidsynth-devel libvorbis-devel libtheora-devel libflac-devel
  freetype-devel libjpeg-turbo-devel libcurl-devel SDL2_net-devel
- libmpeg2-devel liba52-devel gtk+3-devel"
+ libmpeg2-devel liba52-devel gtk+3-devel giflib-devel glew-devel"
 short_desc="Free implementation of LucasArts' SCUMM interpreter"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
Since this package replaces the residualvm package, those engines should be enabled in the SCUMMVM build.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
