### PR TITLE
hstr: update to 2.5

### DIFF
--- a/srcpkgs/hstr/template
+++ b/srcpkgs/hstr/template
@@ -1,6 +1,6 @@
 # Template file for 'hstr'
 pkgname=hstr
-version=2.3
+version=2.5
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake pkg-config"
@@ -11,12 +11,9 @@ license="Apache-2.0"
 homepage="https://github.com/dvorka/hstr"
 changelog="https://raw.githubusercontent.com/dvorka/hstr/master/Changelog"
 distfiles="https://github.com/dvorka/hstr/archive/${version}.tar.gz"
-checksum=c7e7408671757b3f4be9c5a59b4e2d56e7a7b601ace2a94eb6b2b61f20ee890b
+checksum=7f5933fc07d55d09d5f7f9a6fbfdfc556d8a7d8575c3890ac1e672adabd2bec4
 
 pre_configure() {
-	vsed -i 's|ncursesw/curses.h|curses.h|g' src/include/hstr.h
-	vsed -i 's|ncursesw/curses.h|curses.h|g' src/include/hstr_curses.h
-	aclocal
-	automake --force-missing --add-missing
-	autoconf
+	vsed -i 's|ncursesw/curses.h|curses.h|g' src/include/hstr.h src/include/hstr_curses.h
+	autoreconf -fi
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
