### PR TITLE
mesa: switch from i915 to i915g (gallium)

### DIFF
--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=21.2.6
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=enabled -Dgbm=enabled -Degl=enabled
  -Dosmesa=true -Dgles1=enabled -Dgles2=enabled -Dglx=dri -Ddri3=enabled
@@ -91,9 +91,9 @@ fi
 
 if [ "$_have_intel" ]; then
 	_have_vulkan=yes
-	_gallium_drivers+=",crocus,iris"
+	_gallium_drivers+=",crocus,iris,i915"
 	_vulkan_drivers+=",intel"
-	_dri_drivers+=",i915,i965"
+	_dri_drivers+=",i965"
 	subpackages+=" mesa-vulkan-intel"
 	# transitional dummy packages
 	subpackages+=" mesa-intel-dri"


### PR DESCRIPTION
I made this change to get `sway` working on my EeePC 1005HA.  I set `WLR_NO_HARDWARE_CURSORS=1` before starting sway to get the mouse cursor to work.  More information [here](https://github.com/swaywm/wlroots/issues/2506).

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (i686-glibc, native mode with a 32bit masterdir on x86-64)
