### PR TITLE
font-ibm-plex-ttf: update to 6.0.0.

### DIFF
--- a/srcpkgs/font-ibm-plex-ttf/template
+++ b/srcpkgs/font-ibm-plex-ttf/template
@@ -1,6 +1,6 @@
 # Template file for 'font-ibm-plex-ttf'
 pkgname=font-ibm-plex-ttf
-version=5.2.1
+version=6.0.0
 revision=1
 wrksrc="plex-${version}"
 depends="font-util"
@@ -9,13 +9,14 @@ maintainer="Felipe Nogueira <contato.fnog@gmail.com>"
 license="OFL-1.1"
 homepage="https://github.com/IBM/plex"
 distfiles="https://github.com/IBM/plex/archive/v${version}.tar.gz"
-checksum=6b43a97a116a4beba474b9a9c646fb6ded8ba255fa8d3b252e669f67cbeb9d7f
+checksum=e78cc68cb40ccca0318facade727a0deb32f73e931a2e31bb2fcaf8a6d386dff
 
 font_dirs="/usr/share/fonts/TTF"
 
 do_install() {
 	vmkdir usr/share/fonts/TTF
 	vcopy "IBM-Plex-*/fonts/complete/ttf/*.ttf" usr/share/fonts/TTF
+	vcopy "IBM-Plex-*/fonts/complete/ttf/hinted/*.ttf" usr/share/fonts/TTF
 }
 
 font-ibm-plex-otf_package() {
@@ -25,5 +26,6 @@ font-ibm-plex-otf_package() {
 	pkg_install() {
 		vmkdir usr/share/fonts/OTF
 		vcopy "IBM-Plex-*/fonts/complete/otf/*.otf" usr/share/fonts/OTF
+		vcopy "IBM-Plex-*/fonts/complete/otf/hinted/*.otf" usr/share/fonts/OTF
 	}
 }


### PR DESCRIPTION
When there’s a choice between hinted and unhinted variants for a font family, this template chooses the former. This is more or less an arbitrary choice, since I’m unaware of any specific guidelines of this sort. It’s impossible to include both, as the files themselves overlap, and including neither (where applicable) would completely remove support for some languages.

#### Testing the changes
- I tested the changes in this PR: **YES**