### PR TITLE
linux5.15: Add speaker fixup for some Yoga 15ITL5 devices

### DIFF
--- a/srcpkgs/linux5.15/patches/fix-lenovo7i-sound.patch
+++ b/srcpkgs/linux5.15/patches/fix-lenovo7i-sound.patch
@@ -1,0 +1,33 @@
+From 6dc86976220cc904e87ee58e4be19dd90d6a36d5 Mon Sep 17 00:00:00 2001
+From: Arie Geiger <arsgeiger@gmail.com>
+Date: Thu, 23 Dec 2021 15:28:57 -0800
+Subject: ALSA: hda/realtek: Add speaker fixup for some Yoga 15ITL5 devices
+
+This patch adds another possible subsystem ID for the ALC287 used by
+the Lenovo Yoga 15ITL5.
+It uses the same initalization as the others.
+This patch has been tested and works for my device.
+
+Signed-off-by: Arie Geiger <arsgeiger@gmail.com>
+Cc: <stable@vger.kernel.org>
+Link: https://lore.kernel.org/r/20211223232857.30741-1-arsgeiger@gmail.com
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/pci/hda/patch_realtek.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index 28255e752c4a1..08c0529c23105 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -8927,6 +8927,7 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x17aa, 0x3813, "Legion 7i 15IMHG05", ALC287_FIXUP_LEGION_15IMHG05_SPEAKERS),
+ 	SND_PCI_QUIRK(0x17aa, 0x3852, "Lenovo Yoga 7 14ITL5", ALC287_FIXUP_YOGA7_14ITL_SPEAKERS),
+ 	SND_PCI_QUIRK(0x17aa, 0x3853, "Lenovo Yoga 7 15ITL5", ALC287_FIXUP_YOGA7_14ITL_SPEAKERS),
++	SND_PCI_QUIRK(0x17aa, 0x384a, "Lenovo Yoga 7 15ITL5", ALC287_FIXUP_YOGA7_14ITL_SPEAKERS),
+ 	SND_PCI_QUIRK(0x17aa, 0x3819, "Lenovo 13s Gen2 ITL", ALC287_FIXUP_13S_GEN2_SPEAKERS),
+ 	SND_PCI_QUIRK(0x17aa, 0x3902, "Lenovo E50-80", ALC269_FIXUP_DMIC_THINKPAD_ACPI),
+ 	SND_PCI_QUIRK(0x17aa, 0x3977, "IdeaPad S210", ALC283_FIXUP_INT_MIC),
+-- 
+cgit 1.2.3-1.el7
+


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This issue was fixed for some devices in:
https://bugzilla.kernel.org/show_bug.cgi?id=208555

~~However, the subsystem_id for my machine is not in the list, so this just adds it temporarily until it can hopefully be resolved upstream.~~
The patch has since been merged upstream.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
