### PR TITLE
toxcore: update to 0.2.13.

### DIFF
--- a/srcpkgs/toxcore/template
+++ b/srcpkgs/toxcore/template
@@ -1,6 +1,6 @@
 # Template file for 'toxcore'
 pkgname=toxcore
-version=0.2.12
+version=0.2.13
 revision=1
 wrksrc="c-toxcore-${version}"
 build_style=cmake
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://tox.chat"
 changelog="https://raw.githubusercontent.com/TokTok/c-toxcore/master/CHANGELOG.md"
 distfiles="https://github.com/TokTok/c-toxcore/archive/v${version}.tar.gz"
-checksum=30ae3263c9b68d3bef06f799ba9d7a67e3fad447030625f0ffa4bb22684228b0
+checksum=67114fa57504c58b695f5dce8ef85124d555f2c3c353d0d2615e6d4845114ab8
 
 post_install() {
 	vsconf other/bootstrap_daemon/tox-bootstrapd.conf


### PR DESCRIPTION
Fixes CVE-2021-44847.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
