### PR TITLE
synapse: install example config files into examples dir

### DIFF
--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -1,7 +1,7 @@
 # Template file for 'synapse'
 pkgname=synapse
 version=1.49.0
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-jsonschema python3-frozendict python3-canonicaljson
@@ -20,7 +20,6 @@ homepage="https://github.com/matrix-org/synapse"
 changelog="https://raw.githubusercontent.com/matrix-org/synapse/develop/CHANGES.md"
 distfiles="https://github.com/matrix-org/synapse/archive/v${version}.tar.gz"
 checksum=3c1b73eb36ec3af00868707b929f9b9d1faae9ccc4022c2c46bdb025ef0ead8e
-conf_files="/etc/synapse/homeserver.yaml /etc/synapse/log.yaml"
 
 system_accounts="synapse"
 synapse_homedir="/var/lib/synapse"
@@ -36,6 +35,6 @@ do_check() {
 post_install() {
 	vsv synapse
 
-	vinstall docs/sample_config.yaml 644 etc/synapse homeserver.yaml
-	vinstall docs/sample_log_config.yaml 644 etc/synapse log.yaml
+	vsconf docs/sample_config.yaml homeserver.yaml
+	vsconf docs/sample_log_config.yaml log.yaml
 }


### PR DESCRIPTION
Installing them suddenly in target path triggered xbps bug
destroying previous configurations.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@paper42 @ericonr @freshprince 