### PR TITLE
python3-crccheck: update to 1.1

### DIFF
--- a/srcpkgs/python3-crccheck/template
+++ b/srcpkgs/python3-crccheck/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-crccheck'
 pkgname=python3-crccheck
-version=1.0
-revision=3
+version=1.1
+revision=1
 wrksrc="crccheck-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3"
+checkdepends="${depends} python3-pytest python3-nose"
 short_desc="Calculation library for CRCs and Checksums"
 maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://bitbucket.org/martin_scharrer/crccheck"
 distfiles="${PYPI_SITE}/c/crccheck/crccheck-${version}.tar.gz"
-checksum=17c42dc4f069308ae962b682b2974bdbf2f80ee682c7032a9df44880fca3c9ab
+checksum=45962231cab62b82d05160553eebd9b60ef3ae79dc39527caef52e27f979fa96
 
 post_install() {
 	rm -r ${DESTDIR}/${py3_sitelib}/tests


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64, GLIBC
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl