### PR TITLE
LibreCAD: fix missing built-in plugins menu

### DIFF
--- a/srcpkgs/LibreCAD/template
+++ b/srcpkgs/LibreCAD/template
@@ -1,7 +1,7 @@
 # Template file for 'LibreCAD'
 pkgname=LibreCAD
 version=2.1.3
-revision=4
+revision=5
 build_style=qmake
 hostmakedepends="qt5-qmake pkg-config ImageMagick qt5-host-tools"
 makedepends="qt5-devel qt5-svg-devel boost-devel muparser-devel librsvg-devel"
@@ -46,9 +46,14 @@ do_install() {
 	vcopy librecad.svg usr/share/icons/hicolor/scalable/apps
 
 	# install resources
-	for resource in library patterns fonts qm; do
+	for resource in fonts library patterns qm; do
 		vcopy unix/resources/${resource} usr/share/librecad/
 	done
 
-    vcopy unix/resources/plugins usr/lib/librecad/
+	# install plugins
+	vmkdir usr/share/librecad/plugins
+	vcopy unix/resources/plugins usr/lib/librecad/
+	for plugin in $DESTDIR/usr/lib/librecad/*.so ; do
+		ln -sf ../../../lib/librecad/$(basename $plugin) ${DESTDIR}/usr/share/librecad/plugins/$(basename $plugin)
+	done
 }


### PR DESCRIPTION
Solved #32497

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

https://user-images.githubusercontent.com/45872139/147313649-5c5f7710-8f24-4e88-8f6b-b0d7e60a6aee.mp4
