### PR TITLE
python3-injector: update to 0.19.0

### DIFF
--- a/srcpkgs/python3-injector/template
+++ b/srcpkgs/python3-injector/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-injector'
 pkgname=python3-injector
-version=0.18.4
-revision=2
+version=0.19.0
+revision=1
 wrksrc="injector-${version}"
 build_style=python3-module
 hostmakedepends="python3-typing_extensions python3-setuptools"
@@ -12,7 +12,7 @@ maintainer="Duje Mihanovic <mihaduje@pm.me>"
 license="BSD-3-Clause"
 homepage="https://github.com/alecthomas/injector"
 distfiles="https://github.com/alecthomas/injector/archive/${version}.tar.gz"
-checksum=9f00f16bb667142a076073af0df2c30013b1fc4c032c49029ad2f9bcba88d3b9
+checksum=ecc568a4ccb405b7f759db3fdd7c65a6f0435e3ee67ab6149e244f3c214e55bb
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
This will fix an [issue with gwe not working on python 3.10](https://gitlab.com/leinardi/gwe/-/issues/162).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
