### PR TITLE
noto-fonts-emoji: update to 2.034.

### DIFF
--- a/srcpkgs/noto-fonts-emoji/template
+++ b/srcpkgs/noto-fonts-emoji/template
@@ -2,7 +2,7 @@
 pkgname=noto-fonts-emoji
 reverts="20200916_1 20200722_2 20200722_1 20191016_1 20180810_2 20180810_1
 20180301_1 20170311_1 20161020_1"
-version=2.028
+version=2.034
 revision=1
 wrksrc=noto-emoji-${version}
 depends="font-util"
@@ -11,7 +11,7 @@ maintainer="Peter Bui <pnutzh4x0r@gmail.com>"
 license="OFL-1.1"
 homepage="https://www.google.com/get/noto/"
 distfiles="https://github.com/googlefonts/noto-emoji/archive/v${version}.tar.gz"
-checksum=731f3d5eacbe789a72b35180c0ca813ba024609a77788fbb128f5c232e0d09c5
+checksum=a5af92ba8e297e447562d7bdb11453fa40be6d88655e4a647976f0c9be4245ab
 font_dirs="/usr/share/fonts/noto"
 
 do_install() {


### PR DESCRIPTION
This adds support for emojis from Unicode 14.0, like… a [JAR] 🫙, and [melting face] 🫠!

[JAR]: https://emojipedia.org/jar/
[melting face]: https://emojipedia.org/melting-face/

More new emojis can be found here: https://emojipedia.org/emoji-14.0/

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
