### PR TITLE
monitoring-plugins: update to 2.3.1

### DIFF
--- a/srcpkgs/monitoring-plugins/template
+++ b/srcpkgs/monitoring-plugins/template
@@ -1,20 +1,21 @@
 # Template file for 'monitoring-plugins'
 pkgname=monitoring-plugins
-version=2.2
-revision=9
+version=2.3.1
+revision=1
 build_style=gnu-configure
 configure_args="--libexecdir=/usr/lib/monitoring-plugins"
-hostmakedepends="fping openssh postfix procps-ng smbclient net-snmp"
+hostmakedepends="fping openssh postfix procps-ng smbclient net-snmp bind-utils sudo"
 makedepends="libldap-devel libmariadbclient-devel postgresql-libs-devel
- zlib-devel"
+ zlib-devel libcurl-devel uriparser-devel"
 depends="iputils procps-ng"
 #checkdepends="perl"
 short_desc="Monitoring plugins for Nagios and compatible monitoring solutions"
 maintainer="Corné Oppelaar <hello@eaterofco.de>"
 license="GPL-3.0-or-later"
 homepage="https://www.monitoring-plugins.org/"
+changelog="https://www.monitoring-plugins.org/news/index.html"
 distfiles="${homepage}/download/${pkgname}-${version}.tar.gz"
-checksum=296a538f00a9cbef7f528ff2d43af357a44b384dc98a32389a675b62a6dd3665
+checksum=f56eb84871983fd719247249e3532228b37e2efaae657a3979bd14ac1f84a35b
 
 do_configure() {
 	./configure ${configure_args} --with-ping-command='/usr/bin/iputils-ping -n -U -w %d -c %d %s' --with-ping6-command='/usr/bin/iputils-ping6 -n -U -w %d -c %d %s'


### PR DESCRIPTION
also add bind-utils to hostmakedepends as nslookup is needed to build check_dns

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - aarch64
  - armv6l-musl