### PR TITLE
grub: Add quotes to `grub.default`

### DIFF
--- a/srcpkgs/grub/files/grub.default
+++ b/srcpkgs/grub/files/grub.default
@@ -10,7 +10,7 @@ GRUB_CMDLINE_LINUX_DEFAULT="loglevel=4"
 # Uncomment to use basic console
 #GRUB_TERMINAL_INPUT="console"
 # Uncomment to disable graphical terminal
-#GRUB_TERMINAL_OUTPUT=console
+#GRUB_TERMINAL_OUTPUT="console"
 #GRUB_BACKGROUND=/usr/share/void-artwork/splash.png
 #GRUB_GFXMODE=1920x1080x32
 #GRUB_DISABLE_LINUX_UUID=true


### PR DESCRIPTION
Make it more coherent. Useful because `GRUB_TERMINAL_OUTPUT` can take multiple values separated by spaces.
