### PR TITLE
grafana: update to 8.3.3

### DIFF
--- a/srcpkgs/grafana/template
+++ b/srcpkgs/grafana/template
@@ -1,17 +1,19 @@
 # Template file for 'grafana'
 pkgname=grafana
-version=7.1.5
-revision=2
+version=8.3.3
+revision=1
 build_style=go
 go_import_path=github.com/grafana/grafana
 go_package="${go_import_path}/pkg/cmd/grafana-cli ${go_import_path}/pkg/cmd/grafana-server"
-hostmakedepends="nodejs-lts tar yarn"
+hostmakedepends="tar make"
 short_desc="Open platform for beautiful analytics and monitoring"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://grafana.com"
-distfiles="https://github.com/grafana/grafana/archive/v${version}.tar.gz"
-checksum=7ae69011674a5b6a792e8ec84c93e8be9d50ad2e995cc63f3508d0b2e7acb754
+distfiles="https://dl.grafana.com/oss/release/grafana-${version}.linux-amd64.tar.gz
+https://github.com/grafana/grafana/archive/v${version}.tar.gz"
+checksum="89428c520e004bcb9faf7618dd4c81ff62496064cbf2ead3e1b9dbcf476c6f18
+c79e19f056b9c2fc6d29c622edfaf8aff4985cec28ea6a9e74dce5eac077e735"
 
 system_accounts="_grafana"
 _grafana_homedir="/var/lib/grafana"
@@ -19,17 +21,25 @@ make_dirs="/var/log/grafana 0755 _grafana _grafana"
 
 conf_files="/etc/grafana/grafana.ini"
 
-case "$XBPS_TARGET_MACHINE" in
-	i686*) broken="yarn can't be built for i686" ;;
-	ppc*) broken="fails to build v8 in a dependency" ;;
-esac
+go_ldflags="-w -X main.version=${version}"
 
-pre_build() {
-	yarn install --pure-lockfile
+post_extract() {
+	# remove prebuilt binaries
+	rm bin/*
 }
 
-post_build() {
-	yarn run build
+pre_build() {
+	CGO_ENABLED=0 GOARCH= make gen-go
+}
+
+do_install() {
+	# only install grafana binaries - GOPATH/bin contains eg. wire used at
+	# buildtime, which we don't want in the package
+	for f in ${GOPATH}/bin/grafana-* ${GOPATH}/bin/*/grafana-*; do
+		if [ -f "$f" ] && [ -x "$f" ]; then
+			vbin "$f"
+		fi
+	done
 }
 
 post_install() {


### PR DESCRIPTION
switch to using prebuilt js files, dropping the node build requirement.
also fix the baked-in version numbers in the binaries.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64 (musl)
