### PR TITLE
New package: mullvad-vpn-2021.6

### DIFF
--- a/srcpkgs/mullvad-vpn/files/mullvad-vpn/run
+++ b/srcpkgs/mullvad-vpn/files/mullvad-vpn/run
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+/opt/Mullvad-VPN/resources/mullvad-daemon -v

--- a/srcpkgs/mullvad-vpn/template
+++ b/srcpkgs/mullvad-vpn/template
@@ -1,0 +1,33 @@
+# Template file for 'mullvad-vpn'
+pkgname=mullvad-vpn
+version=2021.6
+revision=1
+archs="x86_64"
+short_desc="Mullvad VPN client app"
+depends="dbus"
+maintainer="Tung Anh Vu <vu.tunganh96@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://mullvad.net"
+distfiles="https://github.com/mullvad/mullvadvpn-app/releases/download/$version/MullvadVPN-${version}_amd64.deb"
+checksum=95b9638f304a00d72ce6b6f3a38ff9f623142541cfaa4d6e9aa142c27d86ea6e
+nopie_files="/opt/Mullvad-VPN/resources/app.asar.unpacked/node_modules/grpc-tools/bin/grpc_node_plugin
+ /opt/Mullvad-VPN/resources/app.asar.unpacked/node_modules/grpc-tools/bin/protoc"
+make_dirs="/var/log/mullvad-vpn 755 0 0"
+
+do_extract() {
+	ar p ${XBPS_SRCDISTDIR}/${pkgname}-${version}/MullvadVPN-${version}_amd64.deb \
+		data.tar.xz | bsdtar -x -f -
+
+	mv "opt/Mullvad VPN" opt/Mullvad-VPN
+	mv usr/local/share/zsh usr/share
+}
+
+do_install() {
+	vmkdir usr
+	vcopy ${wrksrc}/usr/* usr
+
+	vmkdir opt
+	vcopy ${wrksrc}/opt/* opt
+
+	vsv mullvad-vpn
+}


### PR DESCRIPTION
Since this packages precompiled binaries (for Debian), maybe the package name should be renamed to something like `mullvad-vpn-bin`. I am not sure what the procedure is, please let me know.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Resolves https://github.com/void-linux/void-packages/issues/21154.