### PR TITLE
libsigrokdecode: fix python3.10 dependency

### DIFF
--- a/srcpkgs/libsigrokdecode/patches/python-3.10.patch
+++ b/srcpkgs/libsigrokdecode/patches/python-3.10.patch
@@ -1,12 +1,3 @@
-From 9b0ad5177bd692f7556a4756bdbd2da81d9c34ce Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Dan=20Hor=C3=A1k?= <dan@danny.cz>
-Date: Tue, 4 Aug 2020 09:19:44 +0200
-Subject: [PATCH] configure.ac: Add support for Python 3.9.
-
----
- configure.ac | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git configure.ac configure.ac
 index f9958b3..2917cb3 100644
 --- a/configure.ac
@@ -16,10 +7,6 @@ index f9958b3..2917cb3 100644
  # https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build
  SR_PKG_CHECK([python3], [SRD_PKGLIBS],
 -	[python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
-+	[python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
++	[python-3.10-embed], [python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
  AS_IF([test "x$sr_have_python3" = xno],
  	[AC_MSG_ERROR([Cannot find Python 3 development headers.])])
- 
--- 
-2.29.2
-

--- a/srcpkgs/libsigrokdecode/template
+++ b/srcpkgs/libsigrokdecode/template
@@ -1,7 +1,7 @@
 # Template file for 'libsigrokdecode'
 pkgname=libsigrokdecode
 version=0.5.3
-revision=4
+revision=5
 build_style=gnu-configure
 hostmakedepends="pkg-config python3 autoconf automake"
 makedepends="glib-devel python3-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-gnu