### PR TITLE
New package: sbcl-doc-2.1.11

### DIFF
--- a/srcpkgs/sbcl/template
+++ b/srcpkgs/sbcl/template
@@ -1,9 +1,9 @@
 # Template file for 'sbcl'
 pkgname=sbcl
 version=2.2.0
-revision=1
+revision=2
 archs="i686 x86_64* armv7l aarch64 ppc64le*"
-hostmakedepends="iana-etc"
+hostmakedepends="iana-etc texinfo"
 makedepends="zlib-devel"
 conf_files="/etc/sbclrc"
 short_desc="Steel Bank Common Lisp"
@@ -48,6 +48,7 @@ do_build() {
 	bash make.sh \
 		"$_bootstrap_lisp" \
 		--without-sb-test --with-sb-core-compression --prefix=/usr
+	make -C ./doc/manual info
 }
 
 do_install() {


### PR DESCRIPTION
Add the GNU Info manual for SBCL and its accompanying ASDF manual.

This package has an issue: it will install the manual with the `sbcl` package as well. This is due to the fact that the `do_install` function of the `sbcl` package runs `install.sh`, which will install the manual if it is available. There does not seem to be a way of suppressing that behaviour.

I tried to define a custom `do_build` function inside the subpackage, but it appears that it is not being run: 

```sh
sbcl-doc_package() {
	short_desc+=" - documentation"
	do_build() {
		(cd ./doc/manual; make info)
	}
	pkg_install() {
		vmkdir 'usr/share/info'
		vcopy "doc/manual/*.info*" 'usr/share/info'
	}
}
```

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**