### PR TITLE
dolphin-emu: embed correct version

### DIFF
--- a/srcpkgs/dolphin-emu/template
+++ b/srcpkgs/dolphin-emu/template
@@ -1,14 +1,17 @@
 # Template file for 'dolphin-emu'
 pkgname=dolphin-emu
 version=5.0.15445
-revision=1
+revision=2
 _dolphin_commit=db02b50d2ecdfbbc21e19aadc57253c353069f77
 _mgba_commit=40d4c430fc36caeb7ea32fd39624947ed487d2f2
 #Version/hash pair can be found at https://dolphin-emu.org/download/
 archs="x86_64* aarch64* ppc64le* i686*"
 wrksrc="dolphin-${_dolphin_commit}"
 build_style=cmake
-configure_args="-DUSE_SHARED_ENET=ON"
+configure_args="-DUSE_SHARED_ENET=ON
+ -DDOLPHIN_WC_DESCRIBE=${version%.*}-${version##*.}
+ -DDOLPHIN_WC_REVISION=$_dolphin_commit
+ -DDOLPHIN_WC_BRANCH=master"
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
 makedepends="
  zlib-devel glew-devel libusb-devel qt5-devel miniupnpc-devel libevdev-devel


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

the version detected when not building from a git repository is not
precise enough to allow netplay to work

I only tested if the version is embedded correctly, not if netplay works, @Hnaguski or @RhymeJob, could you test this?

Closes: #34691
