### PR TITLE
New package: helvum-0.3.2

### DIFF
--- a/srcpkgs/helvum/template
+++ b/srcpkgs/helvum/template
@@ -1,0 +1,14 @@
+# Template file for 'helvum'
+pkgname=helvum
+version=0.3.2
+revision=1
+build_style=meson
+hostmakedepends="cargo clang cmake pkg-config"
+makedepends="glib-devel gtk4-devel pipewire-devel"
+depends="pipewire"
+short_desc="GTK-based patchbay for pipewire, inspired by the JACK tool catia"
+maintainer="Animesh Sahu <animeshsahu19@yahoo.com>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.freedesktop.org/ryuukyu/helvum"
+distfiles="${homepage}/-/archive/${version}/helvum-${version}.tar.gz"
+checksum=6a0c259e25b1908c6bff000a482515641ae0f0ca92e4b66d5f904a96f69420be


### PR DESCRIPTION
A GTK-based patchbay for pipewire, inspired by the JACK tool catia.
Homepage: https://gitlab.freedesktop.org/ryuukyu/helvum

**Note:** This will build after #32555 is merged.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**