### PR TITLE
libglvnd: update to 1.4.0.

### DIFF
--- a/srcpkgs/libglvnd/template
+++ b/srcpkgs/libglvnd/template
@@ -1,6 +1,6 @@
 # Template file for 'libglvnd'
 pkgname=libglvnd
-version=1.3.3
+version=1.4.0
 revision=1
 wrksrc="libglvnd-v${version}"
 build_style=meson
@@ -12,15 +12,10 @@ maintainer="Stefano Ragni <st3r4g@protonmail.com>"
 license="custom:MIT-alike"
 homepage="https://gitlab.freedesktop.org/glvnd/libglvnd"
 distfiles="https://gitlab.freedesktop.org/glvnd/libglvnd/-/archive/v${version}/libglvnd-v${version}.tar.gz"
-checksum=e768f43a0b23d9a8c9f1bed425f7f15d8491a1780253945a4445ddc40e5f6f84
+checksum=33b8b993adf47a21bc1c46bcf970927edeb9884390d5b09b1aed051d600c0b2f
 
 provides="libGL-7.11_1 libEGL-7.11_1 libGLES-7.11_1"
 replaces="libGL>=0 libEGL>=0 libGLES>=0"
-
-# Disable TLS with musl: https://bugs.freedesktop.org/show_bug.cgi?id=35268
-if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
-	configure_args="-Dtls=disabled"
-fi
 
 # ppc64_tsd (used when ppc64_tls is not available)
 # is broken with threads, so disable it on musl


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

After the fix https://gitlab.freedesktop.org/glvnd/libglvnd/-/merge_requests/249 we should be able to enable tls on musl. There is also a similar fix for mesa.
Only tested x86_64 glibc, musl needs testing!

cc @q66 (because of the patch)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
