### PR TITLE
font-firacode: update to 6.2.

### DIFF
--- a/srcpkgs/font-firacode/template
+++ b/srcpkgs/font-firacode/template
@@ -1,6 +1,6 @@
 # Template file for 'font-firacode'
 pkgname=font-firacode
-version=6
+version=6.2
 revision=1
 create_wrksrc=yes
 hostmakedepends="unzip"
@@ -10,7 +10,7 @@ license="OFL-1.1"
 homepage="https://github.com/tonsky/FiraCode"
 changelog="https://github.com/tonsky/FiraCode/raw/master/CHANGELOG.md"
 distfiles="https://github.com/tonsky/FiraCode/releases/download/${version}/Fira_Code_v${version}.zip"
-checksum=a4997c2f905fb20a6d814baf7b9bab7df7de574a8e87d6af509685a43291caf1
+checksum=0949915ba8eb24d89fd93d10a7ff623f42830d7c5ffc3ecbf960e4ecad3e3e79
 font_dirs="/usr/share/fonts/TTF"
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

(https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
