### PR TITLE
libmtp: update to 1.1.19, use plugdev group for r/w access to mtp devices.

### DIFF
--- a/srcpkgs/libmtp/template
+++ b/srcpkgs/libmtp/template
@@ -1,9 +1,10 @@
 # Template file for 'libmtp'
 pkgname=libmtp
-version=1.1.18
+version=1.1.19
 revision=1
 build_style=gnu-configure
-configure_args="--disable-static --with-udev=/usr/lib/udev"
+configure_args="--disable-static --with-udev=/usr/lib/udev
+ --with-udev-group=plugdev"
 hostmakedepends="pkg-config"
 makedepends="libgcrypt-devel libusb-devel"
 short_desc="Library for Microsoft's Media Transfer Protocol (MTP)"
@@ -11,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://libmtp.sourceforge.net"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=7280fe50c044c818a06667f45eabca884deab3193caa8682e0b581e847a281f0
+checksum=deb4af6f63f5e71215cfa7fb961795262920b4ec6cb4b627f55b30b18aa33228
 
 if [ "$CROSS_BUILD" ]; then
 	# XXX needs host mtp-hotplug


### PR DESCRIPTION
Also add a group `_libmtp` with r/w permission to accesss mtp devices.
#### Testing the changes
- I tested the changes in this PR: **YES**