### PR TITLE
python3-texttable: update to 1.6.4.

### DIFF
--- a/srcpkgs/python3-texttable/template
+++ b/srcpkgs/python3-texttable/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-texttable'
 pkgname=python3-texttable
-version=1.6.1
-revision=5
+version=1.6.4
+revision=1
 wrksrc="texttable-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ maintainer="Sergi Alvarez <pancake@nopcode.org>"
 license="LGPL-3.0-or-later"
 homepage="https://github.com/foutaise/texttable/"
 distfiles="${PYPI_SITE}/t/texttable/texttable-${version}.tar.gz"
-checksum=2b60a5304ccfbeac80ffae7350d7c2f5d7a24e9aab5036d0f82489746419d9b2
+checksum=42ee7b9e15f7b225747c3fa08f43c5d6c83bc899f80ff9bae9319334824076e9
 
 do_check() {
 	pytest3 tests.py


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**

This is a dependency of sagemath, which requires `>= 1.6.3`