### PR TITLE
python3-Sphinx: update to 4.3.2.

### DIFF
--- a/srcpkgs/python3-Sphinx/template
+++ b/srcpkgs/python3-Sphinx/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Sphinx'
 pkgname=python3-Sphinx
-version=4.2.0
+version=4.3.2
 revision=1
 wrksrc=Sphinx-${version}
 build_style=python3-module
@@ -17,8 +17,9 @@ short_desc="Python 3 documentation generator"
 maintainer="Đoàn Trần Công Danh <congdanhqx@gmail.com>"
 license="BSD-3-Clause"
 homepage="http://sphinx-doc.org"
+changelog="https://www.sphinx-doc.org/en/master/changes.html"
 distfiles="${PYPI_SITE}/S/Sphinx/Sphinx-${version}.tar.gz"
-checksum=94078db9184491e15bce0a56d9186e0aec95f16ac20b12d00e06d4e36f1058a6
+checksum=0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c
 conflicts="python-Sphinx>=0"
 
 post_install() {


### PR DESCRIPTION
- I tested the changes in this PR: **briefly**

This is a dependency of sagemath, which requires `>=4.3`