### PR TITLE
caddy: add missing dependency

### DIFF
--- a/srcpkgs/caddy/template
+++ b/srcpkgs/caddy/template
@@ -1,10 +1,11 @@
 # Template file for 'caddy'
 pkgname=caddy
 version=2.4.6
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/caddyserver/caddy/v2
 go_package="${go_import_path}/cmd/caddy"
+depends="shared-mime-info"
 short_desc="Fast, cross-platform HTTP/2 web server with automatic HTTPS"
 maintainer="Dominic Monroe <monroef4@googlemail.com>"
 license="Apache-2.0"


### PR DESCRIPTION
Without mime-types installed Caddy silently omits certain headers,
especially Content-Type.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
