### PR TITLE
lollypop: update to 1.4.26

### DIFF
--- a/srcpkgs/lollypop/template
+++ b/srcpkgs/lollypop/template
@@ -1,17 +1,16 @@
 # Template file for 'lollypop'
 pkgname=lollypop
-version=1.4.22
-revision=2
+version=1.4.26
+revision=1
 build_style=meson
-hostmakedepends="cmake git glib-devel gobject-introspection intltool itstool pkg-config"
+hostmakedepends="glib-devel gobject-introspection intltool itstool pkg-config"
 makedepends="gtk+3-devel libsoup-devel python3-gobject-devel python3-devel"
 depends="dconf gst-libav gst-plugins-good1 libnotify libsecret
- python3-dbus python3-gobject python3-pylast python3-youtube-dl
  python3-Pillow totem-pl-parser python3-BeautifulSoup4 libhandy1
- gnome-keyring"
+ python3-gobject python3-pylast youtube-dl gnome-keyring"
 short_desc="Music player for GNOME"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Lollypop"
-distfiles="https://adishatz.org/lollypop/${pkgname}-${version}.tar.xz"
-checksum=cda6b6da1adf242a9be9b6b9d7be0d9732d12a0cdde3aa81d8e8a5761eff9b9d
+distfiles="https://adishatz.org/lollypop/lollypop-${version}.tar.xz"
+checksum=0395f72a3b8650daf6d761a826b0942aee208c5eba8669bc76f5e3a2cd94098d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture
  - `Void 5.10.87-xanmod1_1 x86_64 AuthenticAMD notuptodate hold rrrmFFFFFFFF`