### PR TITLE
update jupyterlab

### DIFF
--- a/srcpkgs/jupyterlab/template
+++ b/srcpkgs/jupyterlab/template
@@ -1,17 +1,17 @@
 # Template file for 'jupyterlab'
 pkgname=jupyterlab
-version=3.2.4
+version=3.2.8
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-jupyterlab_server nodejs python3-nbclassic python3-requests-unixsocket
- python3-jupyter_ipywidgets"
+depends="python3-jupyterlab_server nodejs python3-nbclassic
+ python3-requests-unixsocket python3-jupyter_ipywidgets"
 short_desc="JupyterLab computational environment"
 maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="custom:jupyterlab"
 homepage="https://jupyter.org"
 distfiles="${PYPI_SITE}/j/jupyterlab/jupyterlab-${version}.tar.gz"
-checksum=f692e0d95338d60f72dde660f16f3955a087775c59ec541ddb25952e3f97e9b1
+checksum=5e4e99868c4f385372686767781408acbb9004b690b198b45597ba869802334b
 # Tests require unpackaged dependencies
 make_check=no
 

--- a/srcpkgs/python3-anyio/template
+++ b/srcpkgs/python3-anyio/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-anyio'
 pkgname=python3-anyio
-version=3.4.0
+version=3.5.0
 revision=1
 wrksrc=anyio-${version}
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="MIT"
 homepage="https://github.com/agronholm/anyio"
 distfiles="${PYPI_SITE}/a/anyio/anyio-${version}.tar.gz"
-checksum=24adc69309fb5779bc1e06158e143e0b6d2c56b302a3ac3de3083c705a6ed39d
+checksum=a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6
 # Tests not supported
 make_check=no
 

--- a/srcpkgs/python3-jupyter_server/template
+++ b/srcpkgs/python3-jupyter_server/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jupyter_server'
 pkgname=python3-jupyter_server
-version=1.13.0
+version=1.13.3
 revision=1
 wrksrc="jupyter_server-${version}"
 build_style=python3-module
@@ -14,7 +14,7 @@ maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://jupyter.org"
 distfiles="${PYPI_SITE}/j/jupyter-server/jupyter_server-${version}.tar.gz"
-checksum=05a96dfc5352adf70e88868b4ab3d1fc13e17bd84daf74d02cc6299098855fda
+checksum=4d622161f4d378ff28548b49cc180024ce102d25ba5805821fcc17ab1bc5c754
 # Tarball defines no tests
 make_check=no
 

--- a/srcpkgs/python3-jupyterlab_server/template
+++ b/srcpkgs/python3-jupyterlab_server/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jupyterlab_server'
 pkgname=python3-jupyterlab_server
-version=2.8.2
+version=2.9.0
 revision=1
 wrksrc="jupyterlab_server-${version}"
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://jupyter.org"
 distfiles="${PYPI_SITE}/j/jupyterlab_server/jupyterlab_server-${version}.tar.gz"
-checksum=26d813c8162c83d466df7d155865987dabe70aa452f9187dfb79fd88afc8fa0b
+checksum=b850bbb59977c4e2c99806a892ddc56f24500b847fd3214b2922596ba81abca9
 # Tests require unpackaged dependencies
 make_check=no
 

--- a/srcpkgs/python3-nbclassic/template
+++ b/srcpkgs/python3-nbclassic/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-nbclassic'
 pkgname=python3-nbclassic
-version=0.3.4
+version=0.3.5
 revision=1
 wrksrc=nbclassic-${version}
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://jupyter.org"
 distfiles="${PYPI_SITE}/n/nbclassic/nbclassic-${version}.tar.gz"
-checksum=f00b07ef4908fc38fd332d2676ccd3ceea5076528feaf21bd27e809ef20f5578
+checksum=99444dd63103af23c788d9b5172992f12caf8c3098dd5a35c787f0df31490c29
 # Tarball includes no tests
 make_check=no
 

--- a/srcpkgs/python3-nbclient/template
+++ b/srcpkgs/python3-nbclient/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-nbclient'
 pkgname=python3-nbclient
-version=0.5.9
+version=0.5.10
 revision=1
 wrksrc="${pkgname#python3-}-${version}"
 build_style=python3-module
@@ -12,7 +12,7 @@ maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://nbclient.readthedocs.io/en/latest/"
 distfiles="${PYPI_SITE}/n/nbclient/nbclient-${version}.tar.gz"
-checksum=99e46ddafacd0b861293bf246fed8540a184adfa3aa7d641f89031ec070701e0
+checksum=b5fdea88d6fa52ca38de6c2361401cfe7aaa7cd24c74effc5e489cec04d79088
 # Package might need to be installed for testing
 make_check=no
 

--- a/srcpkgs/python3-pyrsistent/template
+++ b/srcpkgs/python3-pyrsistent/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pyrsistent'
 pkgname=python3-pyrsistent
-version=0.18.0
-revision=2
+version=0.18.1
+revision=1
 wrksrc="pyrsistent-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-devel"
@@ -12,7 +12,7 @@ maintainer="dkwo <nicolopiazzalunga@gmail.com>"
 license="MIT"
 homepage="https://github.com/tobgu/pyrsistent/"
 distfiles="${PYPI_SITE}/p/pyrsistent/pyrsistent-${version}.tar.gz"
-checksum=773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b
+checksum=d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96
 
 post_install() {
 	vlicense LICENSE.mit LICENSE


### PR DESCRIPTION
Minor update.
Currently, to run jupyerlab I need to use
`jupyter lab --app-dir /usr/lib/python3.10/site-packages/jupyterlab`
If I do not specify the application directory,
then it complains it cannot find assets, and does not work.

@ahesford Is there a way to make this simpler for the end-user?