### PR TITLE
[WIP] python3-numpy: update to 1.22.0.

### DIFF
--- a/srcpkgs/python3-numpy/patches/disable_svml.patch
+++ b/srcpkgs/python3-numpy/patches/disable_svml.patch
@@ -1,0 +1,36 @@
+From 4e6e219994e501ef1a4068e3e6b879a44126a9fd Mon Sep 17 00:00:00 2001
+From: "Andrew J. Hesford" <ajh@sideband.org>
+Date: Sat, 1 Jan 2022 10:48:33 -0500
+Subject: [PATCH] BLD: Add NPY_DISABLE_SVML env var to opt out of SVML
+
+---
+ numpy/core/setup.py | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/numpy/core/setup.py b/numpy/core/setup.py
+index 0f2f3c210..a12e183f7 100644
+--- a/numpy/core/setup.py
++++ b/numpy/core/setup.py
+@@ -24,6 +24,10 @@
+ NPY_RELAXED_STRIDES_DEBUG = (os.environ.get('NPY_RELAXED_STRIDES_DEBUG', "0") != "0")
+ NPY_RELAXED_STRIDES_DEBUG = NPY_RELAXED_STRIDES_DEBUG and NPY_RELAXED_STRIDES_CHECKING
+ 
++# Set NPY_DISABLE_SVML=1 in the environment to disable the vendored SVML
++# library. This option only has significance on Linux x86_64.
++NPY_DISABLE_SVML = (os.environ.get('NPY_DISABLE_SVML', "0") == "1")
++
+ # XXX: ugly, we use a class to avoid calling twice some expensive functions in
+ # config.h/numpyconfig.h. I don't see a better way because distutils force
+ # config.h generation inside an Extension class, and as such sharing
+@@ -68,6 +72,8 @@ def can_link_svml():
+     """SVML library is supported only on x86_64 architecture and currently
+     only on linux
+     """
++    if NPY_DISABLE_SVML:
++        return False
+     machine = platform.machine()
+     system = platform.system()
+     return "x86_64" in machine and system == "Linux"
+-- 
+2.34.1
+

--- a/srcpkgs/python3-numpy/template
+++ b/srcpkgs/python3-numpy/template
@@ -2,6 +2,7 @@
 pkgname=python3-numpy
 version=1.22.0
 revision=1
+_svmlver="1c5260a61e7dce6be48073dfa96291edb0a11d79"
 wrksrc="numpy-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-Cython gcc-fortran"
@@ -13,7 +14,7 @@ maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://www.numpy.org/"
 distfiles="https://github.com/numpy/numpy/archive/v${version}.tar.gz"
-checksum="34957b830448ae34b8bed1f5334ad790431b23bf1a16571b5a29dcd49bceafa4"
+checksum=34957b830448ae34b8bed1f5334ad790431b23bf1a16571b5a29dcd49bceafa4
 alternatives="numpy:f2py:/usr/bin/f2py3"
 # Tests do not function propery in a build directory
 make_check="no"
@@ -35,8 +36,26 @@ if [ "$build_option_openblas" ]; then
 	esac
 fi
 
-# SVML AVX-512 functions have limited support; don't build them
-export NPY_DISABLE_SVML=1
+case "$XBPS_TARGET_MACHINE" in
+	x86_64*)
+		distfiles+=" https://github.com/numpy/SVML/archive/${_svmlver}.tar.gz>svml-${_svmlver:0:8}.tar.gz"
+		checksum+=" 7e82c72f9af51ee415826e4b0cf81c75eb335086054c9fd7301bcb7553a7ada5"
+
+		;;
+	*)
+		export NPY_DISABLE_SVML=1
+		;;
+esac
+
+post_extract() {
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64*)
+			rm -rf numpy/core/src/umath/svml
+			mv ../SVML-${_svmlver} numpy/core/src/umath/svml
+			;;
+		*) ;;
+	esac
+}
 
 post_patch() {
 	case "${XBPS_TARGET_MACHINE}" in

--- a/srcpkgs/python3-numpy/template
+++ b/srcpkgs/python3-numpy/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-numpy'
 pkgname=python3-numpy
-version=1.21.5
+version=1.22.0
 revision=1
 wrksrc="numpy-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="Andrew J. Hesford <ajh@sideband.org>"
 license="BSD-3-Clause"
 homepage="https://www.numpy.org/"
 distfiles="https://github.com/numpy/numpy/archive/v${version}.tar.gz"
-checksum=d69b09c335ae6bb661f7e3d8ee2cd9d17bb3879abca0401e310e434b30f12554
+checksum="34957b830448ae34b8bed1f5334ad790431b23bf1a16571b5a29dcd49bceafa4"
 alternatives="numpy:f2py:/usr/bin/f2py3"
 # Tests do not function propery in a build directory
 make_check="no"
@@ -35,6 +35,9 @@ if [ "$build_option_openblas" ]; then
 	esac
 fi
 
+# SVML AVX-512 functions have limited support; don't build them
+export NPY_DISABLE_SVML=1
+
 post_patch() {
 	case "${XBPS_TARGET_MACHINE}" in
 		armv5tel-musl)
@@ -45,13 +48,6 @@ post_patch() {
 
 	if [ "$XBPS_TARGET_LIBC" = musl ] ; then
 		vsed -i 's|"backtrace",||' numpy/core/setup_common.py
-	fi
-
-	if [ "$XBPS_WORDSIZE" != "$XBPS_TARGET_WORDSIZE" ]; then
-		# When host/target word sizes disagree, this $werror header
-		# triggers -Werror failures about redefining SIZEOF_OFF_T from
-		# the wrong host size to the correct target size
-		vsed -e 's/\$werror//' -i numpy/core/src/_simd/_simd.dispatch.c.src
 	fi
 }
 


### PR DESCRIPTION
Upstream adopted some AVX-512 routines for numerics by vendoring (a subset of) Intel's SVML library. This only works for `x86_64*`. I'm currently testing builds with these extensions (both on hardware that should support AVX-512 and hardware that does not) and am working with upstream in https://github.com/numpy/numpy/pull/20695 to allow this dependency to be disabled especially for cross-compilation. When that is resolved, we'll finalize the template here and update.

#### Testing the changes
- I tested the changes in this PR: **YES**