### PR TITLE
xfce4-panel: enable StatusNotifier support.

### DIFF
--- a/srcpkgs/xfce4-panel/template
+++ b/srcpkgs/xfce4-panel/template
@@ -1,13 +1,14 @@
 # Template file for 'xfce4-panel'
 pkgname=xfce4-panel
 version=4.16.3
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--with-locales-dir=/usr/share/locale
  --disable-static --enable-gio-unix --enable-gtk3"
 hostmakedepends="xfce4-dev-tools pkg-config intltool gettext-devel glib-devel"
-makedepends="libwnck-devel libxfce4ui-devel xfconf-devel garcon-devel exo-devel"
+makedepends="libwnck-devel libxfce4ui-devel xfconf-devel garcon-devel exo-devel
+ libdbusmenu-gtk3-devel"
 short_desc="Next generation panel for the XFCE desktop environment"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
The Status Tray plugin then works properly for applications using the
StatusNotifier API. 

Fixes J-Lentz/iwgtk#21

Further background: https://forum.xfce.org/viewtopic.php?pid=65399#p65399

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
