### PR TITLE
gnupg: update to 2.2.34

### DIFF
--- a/srcpkgs/gnupg/template
+++ b/srcpkgs/gnupg/template
@@ -1,6 +1,6 @@
 # Template file for 'gnupg'
 pkgname=gnupg
-version=2.2.32
+version=2.2.34
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable ldap)
@@ -18,7 +18,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnupg.org/"
 distfiles="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2"
-checksum=b2571b35f82c63e7d278aa6a1add0d73453dc14d3f0854be490c844fca7e0614
+checksum=562a3350dcf66cb67c5825c67ff2c2904db1e30ec8e1d353adc14efba9abf43f
 build_options="ldap"
 build_options_default="ldap"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Note
New LTS release : https://lists.gnupg.org/pipermail/gnupg-announce/2021q4/000467.html