### PR TITLE
nvidia: fix linking libnvoptix.so and libnvoptix.so.1

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=470.94
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com"
@@ -219,8 +219,8 @@ do_install() {
 
 	# optix ray racing engine
 	vinstall libnvoptix.so.${version} 755 usr/lib
-	ln -sf libnvoptix.so.${version} /usr/lib/libnvoptix.so
-	ln -sf libnvoptix.so.${version} /usr/lib/libnvoptix.so.1
+	ln -sf libnvoptix.so.${version} ${DESTDIR}/usr/lib/libnvoptix.so
+	ln -sf libnvoptix.so.${version} ${DESTDIR}/usr/lib/libnvoptix.so.1
 
 	# dkms pkg
 	vmkdir usr/src/nvidia-${version}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

now properly linked:

```
masterdir/destdir/nvidia-libs-470.94
└── usr
    └── lib
        ...
        ├── libnvoptix.so -> libnvoptix.so.470.94
        ├── libnvoptix.so.1 -> libnvoptix.so.470.94
        ├── libnvoptix.so.470.94
        ...
```

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
