### PR TITLE
tealdeer: update to 1.5.0

### DIFF
--- a/srcpkgs/tealdeer/template
+++ b/srcpkgs/tealdeer/template
@@ -1,18 +1,17 @@
 # Template file for 'tealdeer'
 pkgname=tealdeer
-version=1.4.1
-revision=2
+version=1.5.0
+revision=1
+# uses rustls/ring
+archs="x86_64* aarch64* i686* armv[67]*"
 build_style=cargo
-hostmakedepends="pkg-config"
-makedepends="openssl-devel"
-depends="openssl"
 short_desc="Very fast implementation of tldr in Rust"
 maintainer="jcgruenhage <jan.christian@gruenhage.xyz>"
 license="MIT, Apache-2.0"
 homepage="https://github.com/dbrgn/tealdeer"
 changelog="https://raw.githubusercontent.com/dbrgn/tealdeer/v${version}/CHANGELOG.md"
 distfiles="https://github.com/dbrgn/tealdeer/archive/v${version}.tar.gz"
-checksum=eaf42fe17be751985cbf46c170ef623fcbd36028c88c2e70823492a9335a4a8e
+checksum=00902a50373ab75fedec4578c6c2c02523fad435486918ad9a86ed01f804358a
 alternatives="tldr:/usr/bin/tldr:/usr/bin/tealdeer"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
---
According to the [changelog](https://github.com/dbrgn/tealdeer/blob/main/CHANGELOG.md), tealdeer switched to rustls for the 1.5.0 release. As such, the archs had to be restricted to those supported by rustls/ring.