### PR TITLE
rust-analyzer: update to 2022.01.03.

### DIFF
--- a/srcpkgs/rust-analyzer/template
+++ b/srcpkgs/rust-analyzer/template
@@ -1,6 +1,6 @@
 # Template file for 'rust-analyzer'
 pkgname=rust-analyzer
-version=2021.08.30
+version=2022.01.03
 revision=1
 _ver=${version//./-}
 wrksrc="${pkgname}-${_ver}"
@@ -11,7 +11,7 @@ maintainer="Gabriel Sanches <gabriel@gsr.dev>"
 license="Apache-2.0, MIT"
 homepage="https://rust-analyzer.github.io/"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/${_ver}.tar.gz"
-checksum=a5c791cd660b46e8fc20c1b268cb25c33658fcd593d81b278c34c97efccddbde
+checksum=3595986c9a988c3eaaa303fdcea6b2100de8467e13863a725d8f9fd463534ce0
 # tests require Rust source code
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc

---

Now that Rust 1.57 is merged, we can update rust-analyzer, which since October 21 has required the 2021 edition (introduced in Rust 1.56).