### PR TITLE
gettext: fix cross compile

### DIFF
--- a/srcpkgs/gettext/template
+++ b/srcpkgs/gettext/template
@@ -1,7 +1,7 @@
 # Template file for 'gettext'
 pkgname=gettext
 version=0.21
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-java --disable-native-java --disable-csharp
  --disable-libasprintf --enable-threads=posix --disable-rpath --without-emacs
@@ -34,13 +34,6 @@ else
 	# on glibc, old gettext-libs conflicts with gettext
 	replaces="gettext-libs>=0"
 	conflicts="gettext-libs>=0"
-fi
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" automake libtool"
-	pre_configure() {
-		autoreconf -fi
-	}
 fi
 
 post_install() {


### PR DESCRIPTION
For gettext-0.21 cross-compile does not work, because the pre-configure step tries to run `autoreconf -fi`, which fails with the error

    configure.ac:25: error: AC_INIT should be called with package and version arguments
    : gl_AM_INIT_AUTOMAKE is expanded from...
    /usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
    configure.ac:25: the top level
    autom4te: /usr/bin/m4 failed with exit status: 1
    aclocal: error: /usr/bin/autom4te failed with exit status: 1
    autoreconf: aclocal failed with exit status: 1

This pre-configure step was added back in commit 17f6ad8b for gettext-0.18.3, but its not clear what the error seen back then was, and now cross-compiling without running autoreconf works fine.

So this PR just removes the pre-configure step, reverting 17f6ad8b. This fixes #34810.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv5tel-musl
  - i686-musl
