### PR TITLE
ruby-build: update to 20211227.

### DIFF
--- a/srcpkgs/ruby-build/template
+++ b/srcpkgs/ruby-build/template
@@ -1,6 +1,6 @@
 # Template file for 'ruby-build'
 pkgname=ruby-build
-version=20211203
+version=20211227
 revision=1
 depends="bash"
 short_desc="Compile and install Ruby"
@@ -8,7 +8,7 @@ maintainer="b-l-a-i-n-e <blaine.gilbreth@gmail.com>"
 license="MIT"
 homepage="https://github.com/rbenv/ruby-build"
 distfiles="https://github.com/rbenv/ruby-build/archive/refs/tags/v${version}.tar.gz"
-checksum=f6a9149b24c7452a512395bc43d9837171de5f43ef0cf191a4a24b013f6a2eed
+checksum=7a07eae6d6948f79a8ffecd7a493fb887e10326c429fe55cfe1bda65146db824
 
 do_install() {
 	vbin bin/ruby-build


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64, glibc
