### PR TITLE
sbt: update to 1.6.1

### DIFF
--- a/srcpkgs/sbt/template
+++ b/srcpkgs/sbt/template
@@ -1,21 +1,29 @@
 # Template file for 'sbt'
 pkgname=sbt
-version=1.3.10
-revision=2
+version=1.6.1
+revision=1
 wrksrc="$pkgname"
 depends="virtual?java-environment"
 short_desc="Interactive build tool for Scala and Java"
 maintainer="Damian Czaja <trojan295@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.scala-sbt.org"
-distfiles="https://sbt-downloads.cdnedge.bluemix.net/releases/v${version}/${pkgname}-${version}.tgz"
-checksum=3060065764193651aa3fe860a17ff8ea9afc1e90a3f9570f0584f2d516c34380
+distfiles="https://github.com/sbt/sbt/releases/download/v${version}/${pkgname}-${version}.tgz"
+checksum=60286bf1b875b31e2955f8a699888cd2612e9afd94d03cde0a2e71efd7492ffc
 
 do_install() {
-	vmkdir usr/share/sbt
+	vmkdir usr/lib/sbt
 	vmkdir usr/bin
-	vcopy "*" usr/share/sbt
-	ln -rs ${DESTDIR}/usr/share/sbt/bin/sbt ${DESTDIR}/usr/bin/sbt
+	vcopy "*" usr/lib/sbt
+	ln -rs ${DESTDIR}/usr/lib/sbt/bin/sbt ${DESTDIR}/usr/bin/sbt
 
-	rm ${DESTDIR}/usr/share/${pkgname}/bin/*.bat
+	rm ${DESTDIR}/usr/lib/${pkgname}/bin/*.bat
+	rm ${DESTDIR}/usr/lib/${pkgname}/bin/*.exe
+	rm ${DESTDIR}/usr/lib/${pkgname}/bin/*apple-darwin
+
+	# Remove x86_64 binaries when it doesn't match the machine.
+	case "$XBPS_TARGET_MACHINE" in
+		x86_64) ;;
+		*) rm ${DESTDIR}/usr/lib/${pkgname}/bin/*x86_64* ;;
+	esac
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This is the latest release of `sbt` and the first to address recent log4j vulnerabilities.

- https://github.com/void-linux/void-packages/issues/34534
- https://github.com/sbt/sbt/releases/tag/v1.6.1

#### Testing the changes
- I tested the changes in this PR: ~~briefly~~ **yes**

~~(Will try to do more testing later. Got some issue with libgomp when I tried updating my xbps-src bootstrap)~~

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
