### PR TITLE
nostrip_files: allow full path

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -644,7 +644,7 @@ Example: `conf_files="/etc/foo.conf /etc/foo2.conf /etc/foo/*.conf"`.
 default all binaries are stripped.
 
 - `nostrip_files` White-space separated list of ELF binaries that won't be stripped of
-debugging symbols.
+debugging symbols. Files can be given by full path or by filename.
 
 - `noshlibprovides` If set, the ELF binaries won't be inspected to collect the provided
 sonames in shared libraries.
@@ -690,7 +690,7 @@ This appends to the generated file rather than replacing it.
   features (PIE, relro, etc). Not necessary for most packages.
 
 - `nopie_files` White-space seperated list of ELF binaries that won't be checked
-for PIE.
+for PIE. Files must be given by full path.
 
 - `reverts` xbps supports a unique feature which allows to downgrade from broken
 packages automatically. In the `reverts` field one can define a list of broken

--- a/common/hooks/post-install/06-strip-and-debug-pkgs.sh
+++ b/common/hooks/post-install/06-strip-and-debug-pkgs.sh
@@ -72,7 +72,7 @@ hook() {
 
 		fname=${f##*/}
 		for x in ${nostrip_files}; do
-			if [ "$x" = "$fname" ]; then
+			if [ "$x" = "$fname" -o "$x" = "${f#$PKGDESTDIR}" ]; then
 				found=1
 				break
 			fi


### PR DESCRIPTION
The option `nostrip_files` takes a filename without path, in contrast to
option `nopie_files` which takes only full path.

This is inconvenient in a case where there are two binaries with the
same name and only one must be stripped.

Case in point: maxima contains executables

    /usr/lib/maxima/5.45.1/binary-ecl/maxima
    /usr/lib/maxima/5.45.1/binary-sbcl/maxima

The second one breaks if stripped, but the first one is ok to strip (desirable: 59M -> 13M).

See: https://github.com/void-linux/void-packages/issues/34861#issuecomment-1006197772

This commit makes it so that `nostrip_files` can take either the
filename or the full path.

