### PR TITLE
pipewire: update to 0.3.43

### DIFF
--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,6 +1,6 @@
 # Template file for 'pipewire'
 pkgname=pipewire
-version=0.3.42
+version=0.3.43
 revision=1
 _pms_version=0.4.1
 build_style=meson
@@ -32,7 +32,7 @@ homepage="https://pipewire.org/"
 changelog="https://gitlab.freedesktop.org/pipewire/pipewire/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${version}/pipewire-${version}.tar.gz
  https://gitlab.freedesktop.org/pipewire/media-session/-/archive/${_pms_version}/media-session-${_pms_version}.tar.gz"
-checksum="726d1f2faed6f1e93c1499cd20ff0d6461bc698166bea3b98d46c291794e6e1c
+checksum="87f692a2cb5b14ee900e102502b5e078a0cd3f7836f03a2e7cb30690ead37b50
  119c9216070b54018217552c7924f9888da270c3c4647c5e2b85ffa6b1574975"
 make_dirs="/var/lib/pipewire 0755 _pipewire _pipewire"
 system_accounts="_pipewire"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

What is the plan to make `wireplumber` the default session manager? If I add it to `depends`, there will be a build cycle.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
