### PR TITLE
inkscape: add missing dependency

### DIFF
--- a/srcpkgs/inkscape/template
+++ b/srcpkgs/inkscape/template
@@ -1,7 +1,7 @@
 # Template file for 'inkscape'
 pkgname=inkscape
 version=1.1.1
-revision=1
+revision=2
 wrksrc="inkscape-${version}_2021-09-20_3bf5ae0d25"
 build_style=cmake
 # builds executables then runs checks
@@ -13,8 +13,8 @@ makedepends="harfbuzz-devel libsoup-devel gsl-devel pango-devel libatomic_ops-de
  double-conversion-devel gc-devel libwpd-devel libcdr-devel libvisio-devel
  poppler-devel libwpd-devel potrace-devel gtkmm-devel gdl-devel gtkspell3-devel
  aspell-devel libxslt-devel libgomp-devel libwpg-devel poppler-glib-devel"
-depends="desktop-file-utils hicolor-icon-theme python3-lxml python3-numpy python3-scour
- python3-Pillow"
+depends="desktop-file-utils hicolor-icon-theme python3-appdirs python3-lxml python3-numpy
+ python3-scour python3-Pillow"
 checkdepends="$depends gtest-devel ImageMagick cantarell-fonts"
 short_desc="Vector-based drawing program"
 maintainer="Alex Lohr <alex.lohr@logmein.com>"


### PR DESCRIPTION
need to add `python3-appdirs` to run menu `Extensions > Manage Extension` properly.

a warning like this will appear:
```
    from appdirs import user_cache_dir
ModuleNotFoundError: No module named 'appdirs'
```

after installing `python3-appdirs`:

![Screenshot_20220107_080621](https://user-images.githubusercontent.com/45872139/148474636-919cd1fa-e92d-4ace-b84f-fe1330603cbb.png)

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @ericonr 