### PR TITLE
samba: update to 4.14.11

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3966,6 +3966,7 @@ libsamba-policy.so.0 samba-4.13.2_1
 libauth-unix-token-samba4.so samba-4.13.2_1
 libauth4-samba4.so samba-4.13.3_1
 libdcerpc-samba4.so samba-4.13.2_1
+libdcerpc-pkt-auth-samba4.so samba-4.14.11_1
 libdsdb-module-samba4.so samba-4.13.2_1
 libgpext-samba4.so samba-4.13.2_1
 libnet-keytab-samba4.so samba-4.13.3_1

--- a/srcpkgs/ldb/template
+++ b/srcpkgs/ldb/template
@@ -1,7 +1,7 @@
 # Template file for 'ldb'
 pkgname=ldb
-version=2.3.0
-revision=2
+version=2.3.2
+revision=1
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -17,8 +17,8 @@ short_desc="LDAP-like database from samba"
 maintainer="Yuusha Spacewolf <xyuusha@paranoici.org>"
 license="LGPL-3.0-or-later"
 homepage="https://www.samba.org/ldb/"
-distfiles="https://www.samba.org/ftp/pub/ldb/ldb-${version}.tar.gz"
-checksum=a4d308b3d0922ef01f3661a69ebc373e772374defa76cf0979ad21b21f91922d
+distfiles="https://download.samba.org/pub/ldb/ldb-${version}.tar.gz"
+checksum=1416c949dc4326e41c0d8a5ecf8ef784f8c0b6e9d3dad8fa971e84ad56227603
 
 # workaround for cmocka's broken uintptr_t definition on musl
 if [ "$XBPS_TARGET_WORDSIZE" = "64" -a "$XBPS_TARGET_LIBC" = "musl" ]; then

--- a/srcpkgs/samba/template
+++ b/srcpkgs/samba/template
@@ -1,7 +1,7 @@
 # Template file for 'samba'
 pkgname=samba
-version=4.14.7
-revision=2
+version=4.14.11
+revision=1
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -26,8 +26,8 @@ short_desc="SMB/CIFS file, print, and login server for Unix"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.samba.org"
-distfiles="http://download.samba.org/pub/samba/stable/${pkgname}-${version}.tar.gz"
-checksum=6f50353f9602aa20245eb18ceb00e7e5ec793df0974aebd5254c38f16d8f1906
+distfiles="https://download.samba.org/pub/samba/stable/${pkgname}-${version}.tar.gz"
+checksum=3d9ebbf3280c7cf5eac1b15aeff8857b31151abaec4d2987be015a66c2945d98
 lib32disabled=yes
 conf_files="/etc/pam.d/samba /etc/samba/smb.conf"
 make_dirs="/etc/samba/private 0750 root root"

--- a/srcpkgs/talloc/template
+++ b/srcpkgs/talloc/template
@@ -1,7 +1,7 @@
 # Template file for 'talloc'
 pkgname=talloc
-version=2.3.2
-revision=2
+version=2.3.3
+revision=1
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -14,8 +14,8 @@ short_desc="Hierarchical pool based memory allocator with destructors"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://talloc.samba.org/"
-distfiles="http://samba.org/ftp/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=27a03ef99e384d779124df755deb229cd1761f945eca6d200e8cfd9bf5297bd7
+distfiles="https://download.samba.org/pub/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=6be95b2368bd0af1c4cd7a88146eb6ceea18e46c3ffc9330bf6262b40d1d8aaa
 
 export PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config"
 

--- a/srcpkgs/tdb/template
+++ b/srcpkgs/tdb/template
@@ -1,7 +1,7 @@
 # Template file for 'tdb'
 pkgname=tdb
-version=1.4.3
-revision=2
+version=1.4.5
+revision=1
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -14,8 +14,8 @@ short_desc="Trivial Database, similar to GDBM but allows simultaneous commits"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://tdb.samba.org/"
-distfiles="http://samba.org/ftp/tdb/tdb-${version}.tar.gz"
-checksum=c8058393dfa15f47e11ebd2f1d132693f0b3b3b8bf22d0201bfb305026f88a1b
+distfiles="https://download.samba.org/pub/tdb/tdb-${version}.tar.gz"
+checksum=bcfced884f7031080998b5c4b1c5dce57567055f79417f86dba40dcde99a0e41
 
 export PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config"
 

--- a/srcpkgs/tevent/template
+++ b/srcpkgs/tevent/template
@@ -1,7 +1,7 @@
 # Template file for 'tevent'
 pkgname=tevent
-version=0.10.2
-revision=3
+version=0.11.0
+revision=1
 build_style=waf3
 build_helper="qemu"
 configure_script="buildtools/bin/waf"
@@ -9,13 +9,13 @@ configure_args="--sysconfdir=/etc --localstatedir=/var
  --disable-rpath --disable-rpath-install --without-gettext
  --builtin-libraries=replace --bundled-libraries=NONE"
 hostmakedepends="pkg-config docbook2x"
-makedepends="python3-devel talloc-devel libxslt gettext-devel"
+makedepends="python3-devel talloc-devel libxslt gettext-devel cmocka-devel"
 short_desc="Event system based on the talloc memory management library"
 maintainer="Yuusha Spacewolf <xyuusha@paranoici.org>"
 license="GPL-3.0-or-later"
 homepage="https://tevent.samba.org"
-distfiles="https://ftp.samba.org/pub/tevent/tevent-${version}.tar.gz"
-checksum=f8427822e5b2878fb8b28d6f50d96848734f3f3130612fb574fdd2d2148a6696
+distfiles="https://download.samba.org/pub/tevent/tevent-${version}.tar.gz"
+checksum=ee9a86c8e808aac2fe1e924eaa139ff7f0269d0e8e4fafa850ae5c7489bc82ba
 
 export PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config"
 


### PR DESCRIPTION

This resolves issue https://github.com/void-linux/void-packages/issues/32761 for me. So it is probably of interest to other people as well. I haven't identified the cause of that issue precisely; I just updated samba and its dependencies before starting to debug, and that fixed it.

However, I barely use samba, and am in no position to properly test it. So someone else should take over with the testing. Note that it may be preferable to skip the samba version up to 4.15.3, and ldb up to 2.4.1, but that will require more work.

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86_64-musl

