### PR TITLE
musikcube: update to 0.96.10

### DIFF
--- a/srcpkgs/musikcube/template
+++ b/srcpkgs/musikcube/template
@@ -1,6 +1,6 @@
 # Template file for 'musikcube'
 pkgname=musikcube
-version=0.96.7
+version=0.96.10
 revision=1
 build_style=cmake
 make_cmd=make
@@ -16,7 +16,7 @@ maintainer="eater <=@eater.me>"
 license="BSD-3-Clause"
 homepage="https://musikcube.com/"
 distfiles="https://github.com/clangen/musikcube/archive/${version}.tar.gz"
-checksum=81922ec6e86c06061dc009be3ec7c4bc8e8fd5ed3bb92231dabede8bbccaf723
+checksum=91fd984e68b6ef66f1be1ecdf0c84607453ec6ec80632ece688ac745c7719ea5
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
