### PR TITLE
logrotate: update to 3.19.0.

### DIFF
--- a/srcpkgs/logrotate/template
+++ b/srcpkgs/logrotate/template
@@ -1,6 +1,6 @@
 # Template file for 'logrotate'
 pkgname=logrotate
-version=3.18.1
+version=3.19.0
 revision=1
 build_style=gnu-configure
 makedepends="acl-devel popt-devel"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/logrotate/logrotate"
 distfiles="${homepage}/releases/download/${version}/logrotate-${version}.tar.xz"
-checksum=14a924e4804b3974e85019a9f9352c2a69726702e6656155c48bcdeace68a5dc
+checksum=ddd5274d684c5c99ca724e8069329f343ebe376e07493d537d9effdc501214ba
 make_dirs="/etc/logrotate.d 0755 root root"
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

```
$ ./xbps-src pkg logrotate
$ xi !$
$ sudo logrotate -dv /etc/logrotate.conf
```

The above sequence of commands ran without error.

The [changelog](https://github.com/logrotate/logrotate/releases/tag/3.19.0) consists mostly of security fixes, the most interesting one being 427.
