### PR TITLE
perl-MRO-Compat: update to 0.15

### DIFF
--- a/srcpkgs/perl-MRO-Compat/template
+++ b/srcpkgs/perl-MRO-Compat/template
@@ -1,15 +1,16 @@
 # Template file for 'perl-MRO-Compat'
 pkgname=perl-MRO-Compat
-version=0.13
-revision=3
+version=0.15
+revision=1
 wrksrc="${pkgname/perl-/}-${version}"
 build_style=perl-module
 hostmakedepends="perl"
-makedepends="${hostmakedepends}"
-depends="${hostmakedepends}"
+makedepends="perl"
+depends="perl"
 short_desc="MRO::Compat - mro::* interface compatibility for Perls < 5.9.5"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="Artistic-1.0-Perl, GPL-1.0-or-later"
 homepage="https://metacpan.org/release/MRO-Compat"
+changelog="https://raw.githubusercontent.com/moose/MRO-Compat/master/Changes"
 distfiles="${CPAN_SITE}/App/HAARG/MRO-Compat-${version}.tar.gz"
-checksum=8a2c3b6ccc19328d5579d02a7d91285e2afd85d801f49d423a8eb16f323da4f8
+checksum=0d4535f88e43babd84ab604866215fc4d04398bd4db7b21852d4a31b1c15ef61


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
