### PR TITLE
rpi*-kernel: update to 5.10.92.

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -8,15 +8,15 @@
 # Commit hash is picked from latest tag [1], if appropriate, or from latest
 # "Merge remote-tracking branch 'stable/linux-5.10.y' into rpi-5.10.y" commit.
 #
-# [1] https://github.com/raspberrypi/linux/releases
+# [1] https://github.com/raspberrypi/linux/tags
 #
 # WARNING: keep all rpi*-kernel packages in sync
 
-_githash="86729e78125d4f3d203457940feee8bc97b11f6c"
+_githash="650082a559a570d6c9d2739ecc62843d6f951059"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=5.10.52
+version=5.10.92
 revision=1
 archs="armv6l*"
 wrksrc="linux-${_githash}"
@@ -27,7 +27,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi zero/1 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=a25a7dfce4c2ca5bdca39ddab5e43539d9b04900b0dbefe19f4f9b053e59968c
+checksum=ae8b1635a33316ef9b85a4f0ce77d0032c74fbe2ef127755b17cd34d265c48d8
 python_version=3
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi2-kernel/template
+++ b/srcpkgs/rpi2-kernel/template
@@ -1,11 +1,11 @@
 # Template file for 'rpi2-kernel'
 # See rpi-kernel for version policy
 
-_githash="86729e78125d4f3d203457940feee8bc97b11f6c"
+_githash="650082a559a570d6c9d2739ecc62843d6f951059"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi2-kernel
-version=5.10.52
+version=5.10.92
 revision=1
 archs="armv7l*"
 wrksrc="linux-${_githash}"
@@ -16,7 +16,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=a25a7dfce4c2ca5bdca39ddab5e43539d9b04900b0dbefe19f4f9b053e59968c
+checksum=ae8b1635a33316ef9b85a4f0ce77d0032c74fbe2ef127755b17cd34d265c48d8
 python_version=3
 
 _kernver="${version}_${revision}"
@@ -81,6 +81,9 @@ do_configure() {
 
 	# LXD 4.2+ support
 	echo "CONFIG_BRIDGE_VLAN_FILTERING=y" >> "$defconfig"
+
+	# Disable GCC plugins
+	echo "# CONFIG_GCC_PLUGINS is not set" >> "$defconfig"
 
 	make ${makejobs} ${_cross} ARCH=${_arch} ${target}
 

--- a/srcpkgs/rpi3-kernel/template
+++ b/srcpkgs/rpi3-kernel/template
@@ -1,11 +1,11 @@
 # Template file for 'rpi3-kernel'
 # See rpi-kernel for version policy
 
-_githash="86729e78125d4f3d203457940feee8bc97b11f6c"
+_githash="650082a559a570d6c9d2739ecc62843d6f951059"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi3-kernel
-version=5.10.52
+version=5.10.92
 revision=1
 archs="aarch64*"
 wrksrc="linux-${_githash}"
@@ -14,9 +14,9 @@ makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
-short_desc="Linux kernel for Raspberry Pi 3 (${version%.*} series [git ${_gitshort}])"
+short_desc="Linux kernel for Raspberry Pi 3 / Zero 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=a25a7dfce4c2ca5bdca39ddab5e43539d9b04900b0dbefe19f4f9b053e59968c
+checksum=ae8b1635a33316ef9b85a4f0ce77d0032c74fbe2ef127755b17cd34d265c48d8
 python_version=3
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi4-kernel/template
+++ b/srcpkgs/rpi4-kernel/template
@@ -1,11 +1,11 @@
 # Template file for 'rpi4-kernel'
 # See rpi-kernel for version policy
 
-_githash="86729e78125d4f3d203457940feee8bc97b11f6c"
+_githash="650082a559a570d6c9d2739ecc62843d6f951059"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi4-kernel
-version=5.10.52
+version=5.10.92
 revision=1
 archs="aarch64*"
 wrksrc="linux-${_githash}"
@@ -16,7 +16,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 4 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=a25a7dfce4c2ca5bdca39ddab5e43539d9b04900b0dbefe19f4f9b053e59968c
+checksum=ae8b1635a33316ef9b85a4f0ce77d0032c74fbe2ef127755b17cd34d265c48d8
 python_version=3
 conflicts=rpi3-kernel
 


### PR DESCRIPTION
This enables support for the Raspberry Pi Zero 2 W (adds `/boot/bcm2710-rpi-zero-2.dtb`) as well as brings the kernels up to the latest stable merge commit on [raspberrypi/linux @ rpi-5.10.y](https://github.com/raspberrypi/linux/commit/1ef86d0084b5fcc6910f8e9aa9a6232457444e92).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (I'd like help here, I don't own any rpis)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
[ci skip] [since everything already built successfully](https://github.com/void-linux/void-packages/actions/runs/1674011782)