### PR TITLE
wxWidgets: correct patch

### DIFF
--- a/srcpkgs/wxWidgets/patches/wxGTK-collision.patch
+++ b/srcpkgs/wxWidgets/patches/wxGTK-collision.patch
@@ -1,9 +1,9 @@
 diff -Naur Makefile.in Makefile.in
 --- a/Makefile.in	2014-10-06 23:33:44.000000000 +0200
 +++ b/Makefile.in	2014-11-19 10:48:18.752319058 +0100
-@@ -15258,9 +15258,11 @@
+@@ -15279,9 +15279,11 @@
  
- install: $(__install_wxregex___depname) $(__install_wxzlib___depname) $(__install_wxpng___depname) $(__install_wxjpeg___depname) $(__install_wxtiff___depname) $(__install_wxexpat___depname) $(__install_wxscintilla___depname) $(__install_monodll___depname) $(__install_monolib___depname) $(__install_basedll___depname) $(__install_baselib___depname) $(__install_netdll___depname) $(__install_netlib___depname) $(__install_coredll___depname) $(__install_corelib___depname) $(__install_advdll___depname) $(__install_advlib___depname) $(__install_mediadll___depname) $(__install_medialib___depname) $(__install_htmldll___depname) $(__install_htmllib___depname) $(__install_webviewdll___depname) $(__install_webviewlib___depname) $(__install_qadll___depname) $(__install_qalib___depname) $(__install_xmldll___depname) $(__install_xmllib___depname) $(__install_xrcdll___depname) $(__install_xrclib___depname) $(__install_auidll___depname) $(__install_auilib___depname) $(__install_ribbondll___depname) $(__install_ribbonlib___depname) $(__install_propgriddll___depname) $(__install_propgridlib___depname) $(__install_richtextdll___depname) $(__install_richtextlib___depname) $(__install_stcdll___depname) $(__install_stclib___depname) $(__install_gldll___depname) $(__install_gllib___depname) $(__install_sound_sdl___depname) $(__install_wxrc___depname) install-wxconfig locale_install locale_msw_install $(__cocoa_res_install___depname)
+ install: $(__install_wxregex___depname) $(__install_wxzlib___depname) $(__install_wxpng___depname) $(__install_wxjpeg___depname) $(__install_wxtiff___depname) $(__install_wxexpat___depname) $(__install_wxscintilla___depname) $(__install_monodll___depname) $(__install_monolib___depname) $(__install_basedll___depname) $(__install_baselib___depname) $(__install_netdll___depname) $(__install_netlib___depname) $(__install_coredll___depname) $(__install_corelib___depname) $(__install_advdll___depname) $(__install_advlib___depname) $(__install_mediadll___depname) $(__install_medialib___depname) $(__install_htmldll___depname) $(__install_htmllib___depname) $(__install_webviewdll___depname) $(__install_webviewlib___depname) $(__install_qadll___depname) $(__install_qalib___depname) $(__install_xmldll___depname) $(__install_xmllib___depname) $(__install_xrcdll___depname) $(__install_xrclib___depname) $(__install_auidll___depname) $(__install_auilib___depname) $(__install_ribbondll___depname) $(__install_ribbonlib___depname) $(__install_propgriddll___depname) $(__install_propgridlib___depname) $(__install_richtextdll___depname) $(__install_richtextlib___depname) $(__install_stcdll___depname) $(__install_stclib___depname) $(__install_gldll___depname) $(__install_gllib___depname) $(__install_sound_sdl___depname) $(__install_webkit2_ext___depname) $(__install_wxrc___depname) install-wxconfig locale_install locale_msw_install
  	$(INSTALL_DIR) $(DESTDIR)$(datadir)/aclocal
 -	(cd $(srcdir) ; $(INSTALL_DATA)  wxwin.m4 $(DESTDIR)$(datadir)/aclocal)
 +	(cd $(srcdir) ; $(INSTALL_DATA)  wxwin.m4 $(DESTDIR)$(datadir)/aclocal/wxwin3.m4)
@@ -15,18 +15,16 @@ diff -Naur Makefile.in Makefile.in
  	$(DYLIB_RPATH_INSTALL)
  	$(INSTALL_DIR) $(DESTDIR)$(libdir)/wx/include/$(TOOLCHAIN_FULLNAME)/wx
  	for f in setup.h $(RCDEFS_H); do \
---- a/Makefile.in.orig    2020-04-30 21:43:35.176560163 +0200
-+++ b/Makefile.in 2020-04-30 21:45:48.927132300 +0200
-@@ -16177,7 +16177,7 @@
-        $(INSTALL_DIR) $(DESTDIR)$(bindir)
-        $(INSTALL_DIR) $(DESTDIR)$(libdir)/wx/config
-        $(INSTALL_SCRIPT) lib/wx/config/$(TOOLCHAIN_FULLNAME) $(DESTDIR)$(libdir)/wx/config
+@@ -16177,7 +16179,7 @@
+ 	$(INSTALL_DIR) $(DESTDIR)$(bindir)
+ 	$(INSTALL_DIR) $(DESTDIR)$(libdir)/wx/config
+ 	$(INSTALL_SCRIPT) lib/wx/config/$(TOOLCHAIN_FULLNAME) $(DESTDIR)$(libdir)/wx/config
 -	(cd $(DESTDIR)$(bindir) && rm -f wx-config && $(LN_S) $(libdir)/wx/config/$(TOOLCHAIN_FULLNAME) wx-config || cp -p $(DESTDIR)$(libdir)/wx/config/$(TOOLCHAIN_FULLNAME) wx-config)
 +	(cd $(DESTDIR)$(bindir) && rm -f wx-config-$(WX_RELEASE) && $(LN_S) $(libdir)/wx/config/$(TOOLCHAIN_FULLNAME) wx-config-$(WX_RELEASE) || cp -p $(DESTDIR)$(libdir)/wx/config/$(TOOLCHAIN_FULLNAME) wx-config-$(WX_RELEASE))
-
- locale_install:
-        $(INSTALL_DIR) $(DESTDIR)$(datadir)/locale
-@@ -16153,7 +16155,7 @@
+ 
+ locale_install: 
+ 	$(INSTALL_DIR) $(DESTDIR)$(datadir)/locale
+@@ -16185,7 +16187,7 @@
  	$(INSTALL_DIR) $(DESTDIR)$(datadir)/locale/$$l ; \
  	$(INSTALL_DIR) $(DESTDIR)$(datadir)/locale/$$l/LC_MESSAGES ; \
  	if test -f $(srcdir)/locale/$$l.mo ; then \
@@ -35,7 +33,7 @@ diff -Naur Makefile.in Makefile.in
  	fi ; \
  	done
  
-@@ -16170,7 +16172,7 @@
+@@ -16202,7 +16204,7 @@
  	$(INSTALL_DIR) $(DESTDIR)$(datadir)/locale/$$l ; \
  	$(INSTALL_DIR) $(DESTDIR)$(datadir)/locale/$$l/LC_MESSAGES ; \
  	if test -f $(srcdir)/locale/msw/$$l.mo ; then \


### PR DESCRIPTION
Tweak the wxWidgets patches so that they apply cleanly to Makefile.in

Unclear why it's needed, perhaps patch(1) has now less tolerance for whitespace mixups.

Without these changes, the patches report fuzz and failure for Makefile.in:

patching file Makefile.in
Hunk #1 succeeded at 15279 with fuzz 2 (offset 21 lines).
patching file Makefile.in
Hunk #1 FAILED at 16177.
Hunk #2 succeeded at 16187 (offset 34 lines).
Hunk #3 succeeded at 16204 (offset 34 lines).
1 out of 3 hunks FAILED -- saving rejects to file Makefile.in.rej
patching file build/bakefiles/wx.bkl
patching file src/common/translation.cpp
patching file utils/wxrc/Makefile.in
Hunk #1 succeeded at 119 (offset -6 lines).

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
