### PR TITLE
New package: lswt-v1.0.2

### DIFF
--- a/srcpkgs/lswt/patches/execinfo.patch
+++ b/srcpkgs/lswt/patches/execinfo.patch
@@ -1,0 +1,43 @@
+From 389b2578b27b1f3dc65952bf0d3f98e12410a8b8 Mon Sep 17 00:00:00 2001
+From: Leon Henrik Plickat <leonhenrik.plickat@stud.uni-goettingen.de>
+Date: Fri, 26 Nov 2021 13:45:06 +0100
+Subject: [PATCH] Only include execinfo.h when GLIBC is used
+
+---
+ lswt.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lswt.c b/lswt.c
+index b61463d..f5fe78a 100644
+--- a/lswt.c
++++ b/lswt.c
+@@ -27,8 +27,11 @@
+ #include <wayland-client.h>
+ 
+ #ifdef __linux__
++#include <features.h>
++#ifdef __GLIBC__
+ #include<execinfo.h>
+ #endif
++#endif
+ 
+ #include "xdg-output-unstable-v1.h"
+ #include "wlr-foreign-toplevel-management-unstable-v1.h"
+@@ -642,6 +645,7 @@ static void handle_error (int signum)
+ 	fputs(msg, stderr);
+ 
+ #ifdef __linux__
++#ifdef __GLIBC__
+ 	fputs("Attempting to get backtrace:\n", stderr);
+ 
+ 	/* In some rare cases, getting a backtrace can also cause a segfault.
+@@ -652,6 +656,7 @@ static void handle_error (int signum)
+ 	const int calls = backtrace(buffer, sizeof(buffer) / sizeof(void *));
+ 	backtrace_symbols_fd(buffer, calls, fileno(stderr));
+ 	fputs("\n", stderr);
++#endif
+ #endif
+ 
+ 	/* Let the default handlers deal with the rest. */
+-- 
+2.32.0

--- a/srcpkgs/lswt/template
+++ b/srcpkgs/lswt/template
@@ -1,0 +1,14 @@
+# Template file for 'lswt'
+pkgname=lswt
+version=v1.0.2
+revision=1
+build_style=gnu-makefile
+hostmakedepends="wayland-devel"
+makedepends="wayland-devel"
+short_desc="List wayland toplevels using foreign-toplevel-management-unstable-v1"
+maintainer="Thijs Wester <void@wester.digital>"
+license="GPL-3.0-only"
+homepage="https://git.sr.ht/~leon_plickat/lswt"
+changelog="https://git.sr.ht/~leon_plickat/lswt/refs/${version}"
+distfiles="https://git.sr.ht/~leon_plickat/lswt/archive/${version}.tar.gz"
+checksum="28810c124c0d017ffe41e4b91461a07692aa12a3cd49261c3297dfb0dcf2f4cf"


### PR DESCRIPTION
Lswt allows one to list wayland toplevels using the foreign-toplevel-management-unstable-v1 protocol
There is one patch to only include execinfo.h when GLIBC is used.
This patch is from the upstream repository but is not present in any release yet.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- I built this PR locally for my native architecture, (aarch64-musl)
