### PR TITLE
New package: bibutils-7.2

### DIFF
--- a/srcpkgs/bibutils/template
+++ b/srcpkgs/bibutils/template
@@ -1,0 +1,13 @@
+# Template file for 'bibutils'
+pkgname=bibutils
+version=7.2
+revision=1
+wrksrc="bibutils_${version}"
+build_style=configure
+short_desc="Convert between various bibliography formats"
+maintainer="<void@wester.digital>"
+license="GPL-2.0-only"
+homepage="https://sourceforge.net/projects/bibutils/"
+changelog="https://sourceforge.net/p/bibutils/home/history_version7/"
+distfiles="https://jztkft.dl.sourceforge.net/project/bibutils/bibutils_${version}_src.tgz"
+checksum="6e028aef1e8a6b3e5acef098584a7bb68708f35cfe74011b341c11fea5e4b5c3"


### PR DESCRIPTION
Bibutils allows for conversion between multiple bibliography formats using XML as an intermediate
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- I built this PR locally for my native architecture, (aarch64-musl)
