### PR TITLE
New package: PolyMC-1.1.1

### DIFF
--- a/srcpkgs/PolyMC/files/README.voidlinux
+++ b/srcpkgs/PolyMC/files/README.voidlinux
@@ -1,0 +1,6 @@
+Void-specific instructions:
+============================
+
+You may not have the correct version of java installed for running specific
+versions of Minecraft. For Minecraft version 1.17 and up install openjdk17-jre
+and for older ones openjdk8-jre.

--- a/srcpkgs/PolyMC/template
+++ b/srcpkgs/PolyMC/template
@@ -1,0 +1,30 @@
+# Template file for 'PolyMC'
+pkgname=PolyMC
+version=1.1.1
+revision=1
+build_style=cmake
+configure_args="-DLauncher_BUILD_PLATFORM=Void -DLauncher_PORTABLE=0
+ -DLauncher_VERSION_BUILD=${revision}"
+hostmakedepends="openjdk8 qt5-host-tools qt5-qmake"
+makedepends="qt5-devel"
+depends="virtual?java-runtime qt5-imageformats xrandr"
+short_desc="Custom launcher for Minecraft"
+maintainer="Philipp David <pd@3b.pm>"
+license="GPL-3.0-only"
+homepage="https://polymc.org/"
+distfiles="https://github.com/PolyMC/PolyMC/releases/download/${version}/PolyMC-${version}.tar.gz"
+checksum=7ade9abc3a6f61ed27a129c10084c783cc9a3266484a53e29dabcc1cbb0ba5c4
+
+case "$XBPS_TARGET_MACHINE" in
+	armv*) broken="https://github.com/MultiMC/MultiMC5/issues/2895";;
+esac
+
+post_patch() {
+	vsed -i buildconfig/BuildConfig.cpp.in \
+		-e 's/"-" + QString/"_" + QString/'
+	rm -rf .git
+}
+
+post_install() {
+	vdoc ${FILESDIR}/README.voidlinux
+}

--- a/srcpkgs/PolyMC/update
+++ b/srcpkgs/PolyMC/update
@@ -1,0 +1,2 @@
+site=https://github.com/PolyMC/PolyMC/tags
+pattern='tag/\K[\d]+\.[\d]+(\.[\d]+)?'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Testing was done on my KDE workstation and also on a clean live booted environment (only manual packages were: base-system, xorg, PolyMC). Logging in with a Microsoft account was not tested, since I don't have one. Minecraft versions 1.16.5 and 21w18a were successfully tested with the system jdk and the latest Minecraft release 1.18.1 with jdk 17 from adoptium.

I wasn't too sure which license to pick, so I just tried to be as comprehensive as possible.

Closes #34933

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
