### PR TITLE
Fix CI since github no longer accepts git:// protocol

### DIFF
--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -9,4 +9,4 @@ elif command -v git >/dev/null 2>&1; then
 fi
 
 /bin/echo -e '\x1b[32mFetching upstream...\x1b[0m'
-$GIT_CMD fetch --depth 200 git://github.com/void-linux/void-packages.git master
+$GIT_CMD fetch --depth 200 https://github.com/void-linux/void-packages.git master


### PR DESCRIPTION
As of today, everything fails on CI with:

```
Run common/travis/fetch_upstream.sh
Fetching upstream...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
Error: Process completed with exit code 128.
```

Switching `git://` to `https://` should fix this.