### PR TITLE
Switch templates from git:// to https://

### DIFF
--- a/srcpkgs/ardour/template
+++ b/srcpkgs/ardour/template
@@ -34,7 +34,7 @@ esac
 # Upstream deletes older release tarballs from their site and
 # GitHub tarballs are empty: https://tracker.ardour.org/view.php?id=7328
 do_fetch() {
-	git clone git://github.com/Ardour/ardour ${wrksrc}
+	git clone https://github.com/Ardour/ardour ${wrksrc}
 	cd ${wrksrc}
 	git checkout ${_commit}
 }

--- a/srcpkgs/ci20-uboot/template
+++ b/srcpkgs/ci20-uboot/template
@@ -11,7 +11,7 @@ homepage="http://www.denx.de/wiki/U-Boot/WebHome"
 archs="mispel*"
 
 do_fetch() {
-	git clone -b ci20-${version} git://github.com/MIPS/CI20_u-boot ${wrksrc}
+	git clone -b ci20-${version} https://github.com/MIPS/CI20_u-boot ${wrksrc}
 	cd $wrksrc
 	git reset --hard 25f5638f961c6bfcc64a1e02f742e60aa13fc1c6
 

--- a/srcpkgs/darch/template
+++ b/srcpkgs/darch/template
@@ -17,7 +17,7 @@ homepage="https://godarch.com/"
 do_fetch() {
 	mkdir -p "$(dirname ${GOSRCPATH})"
 	git clone --branch "v${version}" \
-		git://github.com/godarch/darch \
+		https://github.com/godarch/darch \
 		${GOSRCPATH}
 }
 

--- a/srcpkgs/rdis-git/template
+++ b/srcpkgs/rdis-git/template
@@ -10,7 +10,7 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/endeav0r/rdis"
 
 do_fetch() {
-	git clone git://github.com/endeav0r/rdis.git $wrksrc
+	git clone https://github.com/endeav0r/rdis.git $wrksrc
 	cd $wrksrc
 	git reset --hard 1370ca0f737a790e3ca7d7d9513543d7ea52c3a4
 }


### PR DESCRIPTION
As of today github no longer accepts `git://` so we switch templates that use git clone from `git://github.com/` to `https://github.com`.