### PR TITLE
New package: grapejuice-4.9.2

### DIFF
--- a/srcpkgs/grapejuice/template
+++ b/srcpkgs/grapejuice/template
@@ -1,23 +1,21 @@
 # Template file for 'grapejuice'
 pkgname=grapejuice
-version=4.8.2
+version=4.9.2
 revision=1
-_commit=13b50a946844715f6806f762aaa3aea536c07007
-wrksrc=${pkgname}-${_commit}
+wrksrc=${pkgname}-v${version}
 build_style=python3-module
-hostmakedepends="python3 python3-devel python3-setuptools python3-pip python3-wheel
+hostmakedepends="python3-setuptools python3-pip python3-wheel
  pkg-config cairo-devel gobject-introspection"
 
 depends="gtk+3 python3-pip python3-cairo python3-gobject desktop-file-utils xdg-utils cairo-devel
- xdg-user-dirs gtk-update-icon-cache shared-mime-info pkg-config
- gobject-introspection libgcc-32bit freetype-32bit gnutls-32bit"
+ xdg-user-dirs gtk-update-icon-cache shared-mime-info pkg-config gobject-introspection"
 
 short_desc="Wine+Roblox management tool"
 maintainer="wael <40663@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://brinkervii.gitlab.io/grapejuice/"
-distfiles="https://gitlab.com/brinkervii/${pkgname}/-/archive/${_commit}/${pkgname}-${_commit}.tar.gz"
-checksum=d0ef19d227ccc01af07044e06ab2f2ec32d9186d2cfcf1f3c819723baeec1827
+distfiles="https://gitlab.com/brinkervii/${pkgname}/-/archive/v${version}/${pkgname}-v${version}.tar.gz"
+checksum=2d377a2baa511dd7385c07e459cc278cd7da6d0fa35e5a31cb819e35c24e830c
 
 pre_patch() {
 	vsed -i src/grapejuice_common/assets/desktop/roblox-app.desktop \

--- a/srcpkgs/grapejuice/template
+++ b/srcpkgs/grapejuice/template
@@ -1,0 +1,38 @@
+# Template file for 'grapejuice'
+pkgname=grapejuice
+version=4.8.2
+revision=1
+_commit=13b50a946844715f6806f762aaa3aea536c07007
+wrksrc=${pkgname}-${_commit}
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-pip python3-wheel
+ pkg-config cairo-devel gobject-introspection"
+
+depends="gtk+3 python3-pip python3-cairo python3-gobject desktop-file-utils xdg-utils cairo-devel
+ xdg-user-dirs gtk-update-icon-cache shared-mime-info pkg-config
+ gobject-introspection libgcc-32bit freetype-32bit gnutls-32bit"
+
+short_desc="Wine+Roblox management tool"
+maintainer="wael <40663@protonmail.com>"
+license="GPL-3.0-only"
+homepage="https://brinkervii.gitlab.io/grapejuice/"
+distfiles="https://gitlab.com/brinkervii/grapejuice/-/archive/${_commit}/grapejuice-${_commit}.tar.gz"
+checksum=d0ef19d227ccc01af07044e06ab2f2ec32d9186d2cfcf1f3c819723baeec1827
+
+pre_patch() {
+	vsed -i src/grapejuice_common/assets/desktop/roblox-app.desktop \
+		-e 's|$PLAYER_ICON|grapejuice-roblox-player|g' -e 's|$GRAPEJUICE_EXECUTABLE|/usr/bin/grapejuice|g'
+	vsed -i src/grapejuice_common/assets/desktop/roblox-player.desktop \
+		-e 's|$PLAYER_ICON|grapejuice-roblox-player|g' -e 's|$GRAPEJUICE_EXECUTABLE|/usr/bin/grapejuice|g'
+	vsed -i src/grapejuice_common/assets/desktop/roblox-studio.desktop \
+		-e 's|$STUDIO_ICON|grapejuice-roblox-studio|g' -e 's|$GRAPEJUICE_EXECUTABLE|/usr/bin/grapejuice|g'
+}
+
+post_install() {
+	vmkdir usr/share/applications
+	vmkdir usr/share/icons/hicolor
+	vmkdir usr/share/mime/packages/
+	vcopy src/grapejuice_common/assets/desktop/* usr/share/applications
+	vcopy src/grapejuice_common/assets/icons/hicolor/* usr/share/icons/hicolor
+	vcopy src/grapejuice_common/assets/mime_xml/x-grapejuice-roblox.xml usr/share/mime/packages
+}

--- a/srcpkgs/grapejuice/template
+++ b/srcpkgs/grapejuice/template
@@ -16,7 +16,7 @@ short_desc="Wine+Roblox management tool"
 maintainer="wael <40663@protonmail.com>"
 license="GPL-3.0-only"
 homepage="https://brinkervii.gitlab.io/grapejuice/"
-distfiles="https://gitlab.com/brinkervii/grapejuice/-/archive/${_commit}/grapejuice-${_commit}.tar.gz"
+distfiles="https://gitlab.com/brinkervii/${pkgname}/-/archive/${_commit}/${pkgname}-${_commit}.tar.gz"
 checksum=d0ef19d227ccc01af07044e06ab2f2ec32d9186d2cfcf1f3c819723baeec1827
 
 pre_patch() {

--- a/srcpkgs/grapejuice/template
+++ b/srcpkgs/grapejuice/template
@@ -5,7 +5,7 @@ revision=1
 _commit=13b50a946844715f6806f762aaa3aea536c07007
 wrksrc=${pkgname}-${_commit}
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-pip python3-wheel
+hostmakedepends="python3 python3-devel python3-setuptools python3-pip python3-wheel
  pkg-config cairo-devel gobject-introspection"
 
 depends="gtk+3 python3-pip python3-cairo python3-gobject desktop-file-utils xdg-utils cairo-devel


### PR DESCRIPTION
New package: grapejuice-4.8.2

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-LIBC)
- grapejuice's dependencies `freetype-32bit`, `gnutls-32bit`, `libgcc-32bit` will not work on musl.

