### PR TITLE
lazydocker: update to 0.13.

### DIFF
--- a/srcpkgs/lazydocker/template
+++ b/srcpkgs/lazydocker/template
@@ -1,6 +1,6 @@
 # Template file for 'lazydocker'
 pkgname=lazydocker
-version=0.12
+version=0.13
 revision=1
 wrksrc="lazydocker-${version}"
 build_style=go
@@ -11,7 +11,7 @@ maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="MIT"
 homepage="https://github.com/jesseduffield/lazydocker"
 distfiles="https://github.com/jesseduffield/lazydocker/archive/v${version}.tar.gz"
-checksum=0509fdfffe78a0155cb54f8bbec1c3f9f3791ea5cbf397fb50fa5278954b2fcb
+checksum=4328ddcb3156ff57c1e21c0d2f9d9d67d48237a386d338f1d68831b6056dfe3e
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
