### PR TITLE
j4-dmenu-desktop: remove dmenu dependency

### DIFF
--- a/srcpkgs/j4-dmenu-desktop/template
+++ b/srcpkgs/j4-dmenu-desktop/template
@@ -1,14 +1,13 @@
 # Template file for 'j4-dmenu-desktop'
 pkgname=j4-dmenu-desktop
 version=2.18
-revision=2
+revision=3
 wrksrc="${pkgname}-r${version}"
 build_style=cmake
 # The current version (2.18) needs to have /usr/share/applications dir
 # for tests, xterm creates and populates it with its .desktop files,
 # which fixes tests in case the dir does not exist.
 # https://github.com/enkore/j4-dmenu-desktop/pull/123
-depends="dmenu"
 checkdepends="catch2 xterm"
 short_desc="Fast desktop menu"
 maintainer="Diogo Leal <diogo@diogoleal.com>"


### PR DESCRIPTION
Since there is more than one dmenu implementation (e.g. bemenu for
Wayland) it makes no sense to depend on dmenu here.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
