### PR TITLE
openssh: update ChallengeResponseAuthentication setting.

### DIFF
--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,7 +1,7 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=8.8p1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody
@@ -66,7 +66,7 @@ post_install() {
 	# configure to use PAM
 	vsed -i ${DESTDIR}/etc/ssh/sshd_config \
 		-e 's|^#\(UsePAM\) no|\1 yes|g' \
-		-e 's|^#\(ChallengeResponseAuthentication\) yes|\1 no|g' \
+		-e 's|^#\(KbdInteractiveAuthentication\) yes|\1 no|g' \
 		-e 's|^#\(PrintMotd\) yes|\1 no|g'
 
 	vinstall ${FILESDIR}/sshd.pam 644 etc/pam.d sshd


### PR DESCRIPTION
They renamed it to KbdInteractiveAuthentication, so the sed line
to modify sshd_config is broken.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

- I built this PR locally for my native architecture, (x86_64-musl)
