### PR TITLE
Field3D: fix license

### DIFF
--- a/srcpkgs/Field3D/template
+++ b/srcpkgs/Field3D/template
@@ -1,15 +1,19 @@
 # Template file for 'Field3D'
 pkgname=Field3D
 version=1.7.3
-revision=1
+revision=2
 build_style=cmake
 makedepends="boost-devel hdf5-devel ilmbase-devel"
 short_desc="Library for storing voxel data on disk and in memory"
 maintainer="Enno Boland <gottox@voidlinux.org>"
-license="GPL-3.0-or-later"
+license="BSD-3-Clause"
 homepage="https://github.com/imageworks/Field3D/wiki/Field3D-Home"
 distfiles="https://github.com/imageworks/Field3D/archive/refs/tags/v${version}.tar.gz"
 checksum=b6168bc27abe0f5e9b8d01af7794b3268ae301ac72b753712df93125d51a0fd4
+
+post_install() {
+	vlicense COPYING
+}
 
 Field3D-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} $makedepends"


### PR DESCRIPTION
From the [homepage](https://github.com/imageworks/Field3D/wiki/Field3D-Home):
> # License
>  Field3D is distributed under the New BSD License.

Looking at the COPYING file, it's clauses (distribute notice in source, in binary, and don't use their name to promote stuff) make it a BSD-3-Clause license.