### PR TITLE
ristretto: update to 0.12.2.

### DIFF
--- a/srcpkgs/ristretto/template
+++ b/srcpkgs/ristretto/template
@@ -1,10 +1,10 @@
 # Template file for 'ristretto'
 pkgname=ristretto
-version=0.12.1
+version=0.12.2
 revision=1
 build_style=gnu-configure
 configure_args="--with-locales-dir=/usr/share/locale"
-hostmakedepends="intltool pkg-config"
+hostmakedepends="intltool pkg-config glib-devel"
 makedepends="exo-devel file-devel libexif-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Picture-viewer for the Xfce desktop environment"
@@ -13,4 +13,4 @@ license="GPL-2.0-or-later"
 homepage="https://docs.xfce.org/apps/ristretto/start"
 changelog="https://gitlab.xfce.org/apps/ristretto/-/raw/master/NEWS"
 distfiles="https://archive.xfce.org/src/apps/${pkgname}/${version%.*}/${pkgname}-${version}.tar.bz2"
-checksum=13853f9ca18466a8e4788e92c7bde3388a93e8340283568f5dee1a9396ffd7ee
+checksum=0eee869922ec00a253dafa446c2aad2a2f98e07e1db7262e8337ce9ec2dad969


### PR DESCRIPTION
Also add glib-devel to hostmakedepends (for gdbus-codegen).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
