### PR TITLE
blueman: add libappindicator dependency for blueman-applet.

### DIFF
--- a/srcpkgs/blueman/template
+++ b/srcpkgs/blueman/template
@@ -1,13 +1,13 @@
 # Template file for 'blueman'
 pkgname=blueman
 version=2.2.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="intltool iproute2 pkg-config python3-Cython"
 makedepends="gtk+3-devel libbluetooth-devel python3-devel
  python3-gobject-devel startup-notification-devel"
-depends="bluez libnotify python3-gobject"
+depends="bluez libnotify python3-gobject libappindicator"
 short_desc="GTK+ Bluetooth Manager"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
