### PR TITLE
intermodal: update to 0.1.12.

### DIFF
--- a/srcpkgs/intermodal/template
+++ b/srcpkgs/intermodal/template
@@ -1,11 +1,53 @@
 # Template file for 'intermodal'
 pkgname=intermodal
-version=0.1.10
+version=0.1.12
 revision=1
 build_style=cargo
+make_check_args="-- --skip subcommand::torrent::verify::tests::output_multiple
+ --skip subcommand::torrent::verify::tests::output_color"
 short_desc="User-friendly and featureful command-line BitTorrent metainfo utility"
 maintainer="Pika <pika@lasagna.dev>"
 license="CC0-1.0"
 homepage="https://github.com/casey/intermodal"
 distfiles="https://github.com/casey/intermodal/archive/v${version}.tar.gz"
-checksum=8bb3e4f549e5c4446543babd741fec0cd7c42da4d49eca3e98c5f7611ad59618
+checksum=cd62894e519dc5aa0284a5f48aab86e1a45c3bc96b8a5481741adb6960d4751a
+
+if [ "$CROSS_BUILD" ]; then
+	hostmakedepends="${pkgname}"
+else
+	hostmakedepends="help2man pkg-config"
+	makedepends="openssl-devel"
+fi
+
+post_build() {
+	if [ -z "$CROSS_BUILD" ]; then
+		IMDL="target/${RUST_TARGET}/release/imdl"
+		for target in completion-scripts man readme; do
+			cargo run --package gen -- --bin $IMDL $target
+		done
+	fi
+}
+
+post_install() {
+	if [ -z "$CROSS_BUILD" ]; then
+		vdoc target/gen/README.md
+
+		vcompletion target/gen/completions/_imdl zsh
+		vcompletion target/gen/completions/imdl.bash bash
+		vcompletion target/gen/completions/imdl.fish fish
+
+		for page in target/gen/man/*; do
+			vman $page
+		done
+	else
+		vdoc /usr/share/doc/intermodal/README.md
+
+		vcompletion /usr/share/zsh/site-functions/_intermodal zsh
+		vcompletion /usr/share/bash-completion/completions/intermodal bash
+		vcompletion /usr/share/fish/vendor_completions.d/intermodal.fish fish
+
+		for page in /usr/share/man/man1/imdl*; do
+			vman $page
+		done
+	fi
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### tl;dr: computers are hard
So, the `imdl` package was a bit barebones so far, but I'm not quite sure what the correct way to fix this is. Intermodal does have really nice tooling for automatically generating additional artifacts (completions, man pages, other docs, etc) and does try to make packaging `imdl` easy, but sadly, this additional tooling is not really built with cross compilation in mind (afaict), and it requires access to the git history of the repository (for changelog generation). It would be possible to work around these limitations here, but it probably makes sense to instead think about how to improve this, approach upstream about it (they say "First off, thank you very much! If I can do anything to make packaging Intermodal easier, please don't hesistate to open an issue." in the repo upstream and provide a lot of useful info in the readme already), improve the situation upstream and then use the improved tooling in a package here.

I have still extended the package a tiny bit to ship shell completions, because this is the part that bugged me the most, and doing so was fairly straight forward using our vtargetrun helper. I've cargo-culted those bits from our rustup package, I hope this is the right way to go?

cc @casey (upstream) and @ThatNerdyPikachu (void contributor for this package)