### PR TITLE
New packages: python3-cysignals-1.11.2, python3-cypari2-2.1.2, python3-pplpy-0.8.7, python3-fpylll-0.5.6, python3-primecountpy-0.1.0

### DIFF
--- a/srcpkgs/python3-cypari2/template
+++ b/srcpkgs/python3-cypari2/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-cypari2'
+pkgname=python3-cypari2
+version=2.1.2
+revision=1
+wrksrc=cypari2-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-Cython pari perl"
+makedepends="python3-devel python3-cysignals pari-devel gmp-devel"
+short_desc="Python interface to the number theory library PARI/GP"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/sagemath/cypari2"
+distfiles="${PYPI_SITE}/c/cypari2/cypari2-${version}.tar.gz"
+checksum=03cd45edab8716ebbfdb754e65fea72e873c73dc91aec098fe4a01e35324ac7a
+
+do_check() {
+	PYTHONPATH="$(cd build/lib* && pwd)" \
+		make check
+}

--- a/srcpkgs/python3-cysignals/patches/fix-write.patch
+++ b/srcpkgs/python3-cysignals/patches/fix-write.patch
@@ -1,0 +1,46 @@
+Fix a doctest failure which triggers in i686.
+
+The example is in the function `test_bad_str()` in the file `tests.pyx`.
+The test pases a bad string to `sig_str()` and then raises `SIGILL`. The
+signal handler eventually raises a Python exception which in turn raises
+a `SIGSEGV` when accessing the bad string. An error message is expected,
+but that doesn't happen.
+
+Presumably the segfault happens inside some stdio function which leaves
+stdio buffers in an inconsistent state so the latter `fprintf` doesn't
+work properly. From signal-safety(7):
+
+    Suppose that the main program is in the middle of a call to a
+    stdio function such as printf(3) where the buffer and associated
+    variables have been partially updated.  If, at that moment, the
+    program is interrupted by a signal handler that also calls
+    printf(3), then the second call to printf(3) will operate on
+    inconsistent data, with unpredictable results.
+
+We fix this by replacing the `fprintf` by calls to `write`, which is
+async-signal-safe according to POSIX.
+
+--- a/src/cysignals/implementation.c      2022-01-16 22:36:45.143796872 +0000
++++ b/src/cysignals/implementation.c      2022-01-17 02:22:31.196695043 +0000
+@@ -638,12 +622,15 @@
+ #endif
+ 
+     if (s) {
++        /* Using fprintf from inside a signal handler is undefined, see signal-safety(7) */
++        const char * message =
++            "\n"
++            "This probably occurred because a *compiled* module has a bug\n"
++            "in it and is not properly wrapped with sig_on(), sig_off().\n"
++            "Python will now terminate.\n"
++            "------------------------------------------------------------------------\n";
++        write(2, s, strlen(s));
++        write(2, message, strlen(message));
+-        fprintf(stderr,
+-            "%s\n"
+-            "This probably occurred because a *compiled* module has a bug\n"
+-            "in it and is not properly wrapped with sig_on(), sig_off().\n"
+-            "Python will now terminate.\n", s);
+-        print_sep();
+     }
+ 
+ dienow:

--- a/srcpkgs/python3-cysignals/template
+++ b/srcpkgs/python3-cysignals/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-cysignals'
+pkgname=python3-cysignals
+version=1.11.2
+revision=1
+wrksrc="cysignals-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-Cython autoconf"
+makedepends="python3-devel pari-devel"
+short_desc="Interrupt and signal handling for Cython "
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="LGPL-3.0-or-later"
+homepage="https://github.com/sagemath/cysignals"
+distfiles="${PYPI_SITE}/c/cysignals/cysignals-${version}.tar.gz"
+checksum=5858b1760fbe21848121b826b2463a67ac5a45caf3d73105497a68618c5a6fa6
+nocross=yes # runs binaries built for target
+
+do_check() {
+	make check
+}

--- a/srcpkgs/python3-fpylll/template
+++ b/srcpkgs/python3-fpylll/template
@@ -1,0 +1,25 @@
+# Template file for 'python3-fpylll'
+pkgname=python3-fpylll
+version=0.5.6
+revision=1
+wrksrc="fpylll-${version}"
+build_style=python3-module
+hostmakedepends="python3-Cython"
+makedepends="python3-cysignals python3-devel gmp-devel mpfr-devel fplll-devel
+ pari-devel"
+checkdepends="python3-pytest python3-numpy"
+short_desc="Python wrapper to fplll (floating point lattice algorithms)"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/fplll/fpylll"
+distfiles="${PYPI_SITE}/f/fpylll/fpylll-${version}.tar.gz"
+checksum=6eb8a63fb933c0bf92f290dd66fd884807659214d0ce524afe3687a6a6b13a8b
+
+case $XBPS_TARGET_MACHINE in
+	# skip a test with numerical noise on 32 bit
+	i686*) make_check_args="-k not(averaged_simulate_prob)" ;;
+esac
+
+pre_check() {
+	export PY_IGNORE_IMPORTMISMATCH=1
+}

--- a/srcpkgs/python3-pplpy/template
+++ b/srcpkgs/python3-pplpy/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-pplpy'
+pkgname=python3-pplpy
+version=0.8.7
+revision=1
+wrksrc="pplpy-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-Cython"
+makedepends="python3-cysignals python3-gmpy2 python3-devel gmp-devel
+ gmpxx-devel ppl-devel mpfr-devel libmpc-devel pari-devel"
+short_desc="Python wrapper to the C++ Parma Polyhedra Library (PPL)"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.com/videlec/pplpy"
+changelog="https://gitlab.com/videlec/pplpy/-/raw/master/CHANGES.txt"
+distfiles="${PYPI_SITE}/p/pplpy/pplpy-${version}.tar.gz"
+checksum=500bd0f4ae1a76956fae7fcba77854f5ec3e64fce76803664983763c3f2bd8bd
+
+do_check() {
+	PYTHONPATH=$(cd build/lib* && pwd) \
+		python setup.py test
+}

--- a/srcpkgs/python3-primecountpy/template
+++ b/srcpkgs/python3-primecountpy/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-primecountpy'
+pkgname=python3-primecountpy
+version=0.1.0
+revision=1
+wrksrc=primecountpy-${version}
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-Cython"
+makedepends="python3-cysignals python3-devel primecount-devel pari-devel"
+short_desc="Python interface to the C++ library primecount"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/dimpase/primecountpy"
+distfiles="${PYPI_SITE}/p/primecountpy/primecountpy-${version}.tar.gz"
+checksum=78fe7cc32115f0669a45d7c90faaf39f7ce3939e39e2e7e5f14c17fe4bff0676
+
+make_check=no # no way to check before installing


### PR DESCRIPTION
Dependencies of sagemath.

One PR since they all use cysignals; this also makes everything nocross. All testsuites work and pass.

I tested these with sagemath and everything seems to work ok.

Cc: @dkwo @leahneukirchen 