### PR TITLE
New package: python3-cvxopt-1.2.7

### DIFF
--- a/srcpkgs/python3-cvxopt/template
+++ b/srcpkgs/python3-cvxopt/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-cvxopt'
+pkgname=python3-cvxopt
+version=1.2.7
+revision=1
+wrksrc="cvxopt-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+makedepends="python3-devel blas-devel lapack-devel SuiteSparse-devel gsl-devel glpk-devel"
+checkdepends="python3-pytest"
+short_desc="Python software for convex optimization"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-3.0-or-later"
+homepage="http://cvxopt.org/"
+distfiles="${PYPI_SITE}/c/cvxopt/cvxopt-${version}.tar.gz"
+checksum=3f9db1f4d4e820aaea81d6fc21054c89dc6327c84f935dd5a1eda1af11e1d504
+
+pre_build() {
+	export CVXOPT_BUILD_GSL=1
+	export CVXOPT_BUILD_GLPK=1
+}


### PR DESCRIPTION
Dependency of sagemath.

Testsuite works and passes on all nocross arches. Using this package with sagemath seems to work ok.

Cc: @dkwo @leahneukirchen 