### PR TITLE
New package: python3-memory_allocator-0.1.2

### DIFF
--- a/srcpkgs/python3-memory_allocator/template
+++ b/srcpkgs/python3-memory_allocator/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-memory_allocator'
+pkgname=python3-memory_allocator
+version=0.1.2
+revision=1
+wrksrc=memory_allocator-$version
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-Cython"
+makedepends="python3-devel"
+short_desc="Extension class to allocate memory easily with cython"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/kliem/memory_allocator"
+distfiles="${PYPI_SITE}/m/memory_allocator/memory_allocator-${version}.tar.gz"
+checksum=ddf42a2dcc678062f30c63c868335204d46a4ecdf4db0dc43ed4529f1d0ffab9


### PR DESCRIPTION
Dependency of sagemath.

Testsuite works and passes on all nocross arches. Using this package with sagemath seems to work ok.

Cc: @dkwo @leahneukirchen