### PR TITLE
apache-jmeter: update to 5.4.3.

### DIFF
--- a/srcpkgs/apache-jmeter/template
+++ b/srcpkgs/apache-jmeter/template
@@ -1,6 +1,6 @@
 # Template file for 'apache-jmeter'
 pkgname=apache-jmeter
-version=5.3
+version=5.4.3
 revision=1
 hostmakedepends="openjdk8 gradle"
 depends="virtual?java-runtime"
@@ -9,7 +9,7 @@ maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://jmeter.apache.org/"
 distfiles="http://apache.osuosl.org/jmeter/source/apache-jmeter-${version}_src.tgz"
-checksum=727d7c0cf2b72c0c3983c603a6700df7b797dbcbf19dcd7fa2aa457627324ff0
+checksum=6f5bfa63f90a8e05d23064a6e431bc34ff1d093ac2769283d506430edc141682
 
 case "$XBPS_MACHINE" in
 	ppc64*) ;;
@@ -18,7 +18,7 @@ esac
 
 do_build() {
 	# Tests fail -- they are too dependent on networking environment
-	gradle -PchecksumIgnore -x test createDist
+	JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk/ ./gradlew -PchecksumIgnore -x test createDist
 }
 
 do_install() {
@@ -29,6 +29,7 @@ do_install() {
 	vcopy xdocs/* usr/share/doc/apache-jmeter
 	rm -rf xdocs
 
+	rm -rf src
 	vmkdir usr/libexec/apache-jmeter
 	vcopy * usr/libexec/apache-jmeter
 


### PR DESCRIPTION
This update includes a fix for the log4j vulnerability.

#### Testing the changes
- I tested the changes in this PR:  briefly 

Apache Jmeter starts successfully after package installation.

