### PR TITLE
fail2ban: add patch for python 3.10.

### DIFF
--- a/srcpkgs/fail2ban/patches/python3.10.patch
+++ b/srcpkgs/fail2ban/patches/python3.10.patch
@@ -1,0 +1,103 @@
+From 8ae9208454e426aa87b96ba5df26036c4ae5cefd Mon Sep 17 00:00:00 2001
+From: "Sergey G. Brester" <serg.brester@sebres.de>
+Date: Mon, 8 Feb 2021 16:44:27 +0100
+Subject: [PATCH 1/4] try to provide coverage for 3.10-alpha.5 (#2931)
+
+---
+ .github/workflows/main.yml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.github/workflows/main.yml b/.github/workflows/main.yml
+index 7a1d31df3d..262448c2da 100644
+--- a/.github/workflows/main.yml
++++ b/.github/workflows/main.yml
+@@ -22,7 +22,7 @@ jobs:
+     runs-on: ubuntu-20.04
+     strategy:
+       matrix:
+-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
++        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10.0-alpha.5', pypy2, pypy3]
+       fail-fast: false
+     # Steps represent a sequence of tasks that will be executed as part of the job
+     steps:
+
+From 2b6bb2c1bed8f7009631e8f8c306fa3160324a49 Mon Sep 17 00:00:00 2001
+From: "Sergey G. Brester" <serg.brester@sebres.de>
+Date: Mon, 8 Feb 2021 17:19:24 +0100
+Subject: [PATCH 2/4] follow bpo-37324:
+ :ref:`collections-abstract-base-classes` moved to the :mod:`collections.abc`
+ module
+
+(since 3.10-alpha.5 `MutableMapping` is missing in collections module)
+---
+ fail2ban/server/action.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/fail2ban/server/action.py b/fail2ban/server/action.py
+index 3bc48fe046..f0f1e6f59a 100644
+--- a/fail2ban/server/action.py
++++ b/fail2ban/server/action.py
+@@ -30,7 +30,10 @@
+ import threading
+ import time
+ from abc import ABCMeta
+-from collections import MutableMapping
++try:
++	from collections.abc import MutableMapping
++except ImportError:
++	from collections import MutableMapping
+ 
+ from .failregex import mapTag2Opt
+ from .ipdns import DNSUtils
+
+From 42dee38ad2ac5c3f23bdf297d824022923270dd9 Mon Sep 17 00:00:00 2001
+From: "Sergey G. Brester" <serg.brester@sebres.de>
+Date: Mon, 8 Feb 2021 17:25:45 +0100
+Subject: [PATCH 3/4] amend for `Mapping`
+
+---
+ fail2ban/server/actions.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/fail2ban/server/actions.py b/fail2ban/server/actions.py
+index b7b95b445a..897d907c1a 100644
+--- a/fail2ban/server/actions.py
++++ b/fail2ban/server/actions.py
+@@ -28,7 +28,10 @@
+ import os
+ import sys
+ import time
+-from collections import Mapping
++try:
++	from collections.abc import Mapping
++except ImportError:
++	from collections import Mapping
+ try:
+ 	from collections import OrderedDict
+ except ImportError:
+
+From 9f1d1f4fbd0804695a976beb191f2c49a2739834 Mon Sep 17 00:00:00 2001
+From: "Sergey G. Brester" <serg.brester@sebres.de>
+Date: Mon, 8 Feb 2021 17:35:59 +0100
+Subject: [PATCH 4/4] amend for `Mapping` (jails)
+
+---
+ fail2ban/server/jails.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/fail2ban/server/jails.py b/fail2ban/server/jails.py
+index 972a8c4bd2..27e12ddf65 100644
+--- a/fail2ban/server/jails.py
++++ b/fail2ban/server/jails.py
+@@ -22,7 +22,10 @@
+ __license__ = "GPL"
+ 
+ from threading import Lock
+-from collections import Mapping
++try:
++	from collections.abc import Mapping
++except ImportError:
++	from collections import Mapping
+ 
+ from ..exceptions import DuplicateJailException, UnknownJailException
+ from .jail import Jail

--- a/srcpkgs/fail2ban/template
+++ b/srcpkgs/fail2ban/template
@@ -1,7 +1,7 @@
 # Template file for 'fail2ban'
 pkgname=fail2ban
 version=0.11.2
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="pkg-config python3"
 depends="python3"


### PR DESCRIPTION
This minor change fixes fail2ban against python 3.10.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-glibc.
