### PR TITLE
New package: acme-client-1.3.0

### DIFF
--- a/srcpkgs/acme-client/files/acme-client.conf
+++ b/srcpkgs/acme-client/files/acme-client.conf
@@ -1,0 +1,31 @@
+#
+# $OpenBSD: acme-client.conf,v 1.4 2020/09/17 09:13:06 florian Exp $
+#
+authority letsencrypt {
+	api url "https://acme-v02.api.letsencrypt.org/directory"
+	account key "/etc/acme/letsencrypt-privkey.pem"
+}
+
+authority letsencrypt-staging {
+	api url "https://acme-staging-v02.api.letsencrypt.org/directory"
+	account key "/etc/acme/letsencrypt-staging-privkey.pem"
+}
+
+authority buypass {
+	api url "https://api.buypass.com/acme/directory"
+	account key "/etc/acme/buypass-privkey.pem"
+	contact "mailto:me@example.com"
+}
+
+authority buypass-test {
+	api url "https://api.test4.buypass.no/acme/directory"
+	account key "/etc/acme/buypass-test-privkey.pem"
+	contact "mailto:me@example.com"
+}
+
+domain example.com {
+	alternative names { secure.example.com }
+	domain key "/etc/ssl/private/example.com.key"
+	domain full chain certificate "/etc/ssl/example.com.fullchain.pem"
+	sign with letsencrypt
+}

--- a/srcpkgs/acme-client/template
+++ b/srcpkgs/acme-client/template
@@ -1,0 +1,23 @@
+# Template file for 'acme-client'
+pkgname=acme-client
+version=1.3.0
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config sed"
+makedepends="openssl-devel"
+checkdepends="nginx curl"
+short_desc="Portable version of OpenBSD's acme-client"
+maintainer="Lauri Tirkkonen <lauri@hacktheplanet.fi>"
+license="GPL-2.0-only"
+homepage="https://git.sr.ht/~graywolf/acme-client-portable/"
+distfiles="https://data.wolfsden.cz/sources/acme-client-${version}.tar.gz"
+checksum=ac8796652393fa73f32dfda60ed3a437fc260867df1b81fa3c241bd95c5bc719
+make_check=no # requires https://github.com/letsencrypt/pebble which isn't packaged
+
+pre_install() {
+	sed -i 's,/etc/examples/,/usr/share/examples/acme-client/,g' usr.sbin/acme-client/acme-client.conf.5
+}
+
+post_install() {
+	vsconf ${FILESDIR}/acme-client.conf
+}


### PR DESCRIPTION
portable acme-client existed previously with a different upstream, which
was unmaintained - switch to one that is maintained.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv7l-musl (cross)
  - armv6l-musl (cross)
  - x86_64 (cross)
