### PR TITLE
apache-jmeter: remove gradle dependency

### DIFF
--- a/srcpkgs/apache-jmeter/template
+++ b/srcpkgs/apache-jmeter/template
@@ -1,8 +1,8 @@
 # Template file for 'apache-jmeter'
 pkgname=apache-jmeter
 version=5.4.3
-revision=1
-hostmakedepends="openjdk8 gradle"
+revision=2
+hostmakedepends="openjdk8"
 depends="virtual?java-runtime"
 short_desc="Application to load test functional behavior and measure performance"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"


### PR DESCRIPTION
This template no longer needs gradle as a dependency, but I failed to remove it when I updated it.

#### Testing the changes
- I tested the changes in this PR: YES
