### PR TITLE
notcurses: update to 3.0.5

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3950,9 +3950,10 @@ liburing.so.2 liburing-2.0_1
 libbson-1.0.so.0 libbson-1.17.4_2
 libsonic.so.0 libsonic-0.2.0_1
 libtickit.so.3 libtickit-0.4.1_1
-libnotcurses.so.2 notcurses-2.4.9_1
-libnotcurses-core.so.2 notcurses-2.4.9_1
-libnotcurses++.so.2 notcurses-2.4.9_1
+libnotcurses.so.3 notcurses-3.0.5_1
+libnotcurses-core.so.3 notcurses-3.0.5_1
+libnotcurses-ffi.so.3 notcurses-3.0.5_1
+libnotcurses++.so.3 notcurses-3.0.5_1
 libevemu.so.3 evemu-2.7.0_1
 libantilib.so.1 libantimicrox-3.1.2_1
 libinih.so.0 inih-52_1

--- a/srcpkgs/notcurses-progs
+++ b/srcpkgs/notcurses-progs
@@ -1,1 +1,0 @@
-notcurses

--- a/srcpkgs/notcurses/template
+++ b/srcpkgs/notcurses/template
@@ -39,14 +39,3 @@ notcurses-devel_package() {
 	}
 }
 
-notcurses-progs_package() {
-	depends="notcurses-${version}_${revision}"
-	short_desc+=" - programs"
-	pkg_install() {
-		vmove usr/bin
-		vmove usr/share/notcurses
-		if [ "$build_option_man" ]; then
-			vmove usr/share/man/man1
-		fi
-	}
-}

--- a/srcpkgs/notcurses/template
+++ b/srcpkgs/notcurses/template
@@ -1,9 +1,9 @@
 # Template file for 'notcurses'
 pkgname=notcurses
-version=2.4.9
+version=3.0.5
 revision=1
 build_style=cmake
-configure_args="-DUSE_STATIC=ON $(vopt_bool man USE_PANDOC)"
+configure_args="-DUSE_STATIC=ON $(vopt_bool man USE_PANDOC) -DUSE_DEFLATE:BOOL=OFF"
 hostmakedepends="pkg-config $(vopt_if man pandoc)"
 makedepends="libunistring-devel ffmpeg-devel ncurses-libtinfo-devel qrcodegen-devel doctest-devel
  zlib-devel"
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="https://nick-black.com/dankwiki/index.php/Notcurses"
 changelog="https://raw.githubusercontent.com/dankamongmen/notcurses/master/NEWS.md"
 distfiles="https://github.com/dankamongmen/notcurses/archive/v${version}.tar.gz"
-checksum=a2771ad1633e0158f8273fa8b30b5bce0f12e1205e863045f4ae186b6b52f537
+checksum=accb41b9bad3415017207c0992c791e4d887c505d5aa1b3be0c44456489e537d
 
 build_options="man"
 desc_option_man="Use pandoc for manpages"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR briefly by executing the `notcurses-input` program
  that is part of the notcurses build. This seems to indicate everything is working
  okay.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
