### PR TITLE
pipewire: Add XDG autostart desktop files

### DIFF
--- a/srcpkgs/pipewire/files/pipewire-pulse.desktop
+++ b/srcpkgs/pipewire/files/pipewire-pulse.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=PipeWire Pulse
+Comment=Start the PipeWire Pulse
+Exec=/sbin/dbus-launch --exit-with-session /usr/bin/pipewire-pulse
+Terminal=false
+Type=Application
+X-GNOME-Autostart-Phase=Initialization
+X-KDE-autostart-phase=1

--- a/srcpkgs/pipewire/files/pipewire-session.desktop
+++ b/srcpkgs/pipewire/files/pipewire-session.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=PipeWire Media Session
+Comment=Start the PipeWire Media Session
+Exec=/sbin/dbus-launch --exit-with-session /usr/bin/pipewire-media-session
+Terminal=false
+Type=Application
+X-GNOME-Autostart-Phase=Initialization
+X-KDE-autostart-phase=1
+

--- a/srcpkgs/pipewire/files/pipewire.desktop
+++ b/srcpkgs/pipewire/files/pipewire.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Name=PipeWire Media System
+Comment=Start the PipeWire Media System
+Exec=/sbin/dbus-launch --exit-with-session /usr/bin/pipewire
+Terminal=false
+Type=Application
+X-GNOME-Autostart-Phase=Initialization
+X-KDE-autostart-phase=1
+

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -61,6 +61,7 @@ post_install() {
 	vdoc "${FILESDIR}/README.voidlinux"
 	vsv pipewire
 	vsv pipewire-pulse
+	install -Dm644 $FILESDIR/*.desktop -t $DESTDIR/etc/xdg/autostart
 }
 
 libpipewire_package() {


### PR DESCRIPTION
This adds XDG desktop files for pipewire for session autostart

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (amd64-libc)
