### PR TITLE
shared-mime-info: fix build with meson 0.60

### DIFF
--- a/srcpkgs/shared-mime-info/patches/meson-0.60.patch
+++ b/srcpkgs/shared-mime-info/patches/meson-0.60.patch
@@ -1,0 +1,100 @@
+From 5a406b06792e26a83c7346b3c2443c0bd8d4cdb2 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz@archlinux.org>
+Date: Mon, 8 Nov 2021 18:22:47 -0500
+Subject: [PATCH] migrate from custom itstool to builtin msgfmt for creating
+ translated XML
+
+gettext upstream has supported this for a very long time (since 0.19.7
+via commit b3c2a5a242c36fbbaa0c5b17f975d6c638598a23, released in 2015),
+and itstool is (mostly) a legacy of the time before gettext had proper
+support for these sorts of use cases.
+
+This is similar to the state of intltool, which is described at
+https://wiki.gnome.org/MigratingFromIntltoolToGettext
+
+During the port from autotools to meson, the legacy use of itstool was
+faithfully translated to meson in the only way possible: by jumping
+through hoops to run ninja inside ninja in order to generate the .mo
+files for itstool, because meson's i18n module used a flawed design and
+there was no "real" target to create those files, only a .PHONY
+run_target which other rules cannot depend on.
+
+Although meson 0.60.0 added support for real targets for the built .mo
+files, this changed the rules for output filenames, breaking the script.
+
+But msgfmt does not care, and anyways comes with builtin meson functions
+for convenient use with XML files. So let's take this opportunity to
+drop legacy dependencies and use the modern, builtin tooling, which
+fixes this bug as a side effect.
+
+Fixes #170
+---
+ .gitlab-ci.yml               |  2 --
+ README.md                    |  2 +-
+ data/freedesktop_generate.sh | 12 ------------
+ data/meson.build             | 16 +++++-----------
+ meson.build                  |  1 -
+ 5 files changed, 6 insertions(+), 27 deletions(-)
+ delete mode 100755 data/freedesktop_generate.sh
+
+diff --git a/data/freedesktop_generate.sh b/data/freedesktop_generate.sh
+deleted file mode 100755
+index 62ccffa..0000000
+--- a/data/freedesktop_generate.sh
++++ /dev/null
+@@ -1,12 +0,0 @@
+-#!/bin/sh -e
+-
+-src_root="$1"
+-build_root="$2"
+-
+-ninja -C "${build_root}" shared-mime-info-gmo
+-
+-itstool \
+-    --its "${src_root}/data/its/shared-mime-info.its" \
+-    --join "${src_root}/data/freedesktop.org.xml.in" \
+-    -o "${build_root}/data/freedesktop.org.xml" \
+-    "${build_root}/po/"*".gmo"
+diff --git a/data/meson.build b/data/meson.build
+index 24361c9..09ed7a9 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -1,18 +1,12 @@
+ 
+ install_man('update-mime-database.1')
+ 
+-freedesktop_org_xml = custom_target('freedesktop.org.xml',
+-    input : files(
+-        'freedesktop.org.xml.in',
+-        'its/shared-mime-info.its',
+-        'its/shared-mime-info.loc',
+-    ),
++freedesktop_org_xml = i18n.merge_file(
++    input: 'freedesktop.org.xml.in',
+     output: 'freedesktop.org.xml',
+-    command: [
+-        find_program('freedesktop_generate.sh'),
+-        meson.source_root(),
+-        meson.build_root()
+-    ],
++    data_dirs: '.',
++    po_dir: '../po',
++    type: 'xml',
+     install: true,
+     install_dir: get_option('datadir') / 'mime' / 'packages',
+ )
+diff --git a/meson.build b/meson.build
+index 0d08c8a..60f17ae 100644
+--- a/meson.build
++++ b/meson.build
+@@ -20,7 +20,6 @@ config.set_quoted('VERSION', meson.project_version())
+ ###############################################################################
+ # Find tools
+ 
+-itstool = find_program('itstool')
+ xmllint = find_program('xmllint')
+ xmlto   = find_program('xmlto', required: false)
+ 
+-- 
+GitLab
+

--- a/srcpkgs/shared-mime-info/template
+++ b/srcpkgs/shared-mime-info/template
@@ -1,15 +1,15 @@
 # Template file for 'shared-mime-info'
 pkgname=shared-mime-info
 version=2.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dupdate-mimedb=false"
-hostmakedepends="pkg-config intltool itstool gettext-devel xmlto"
+hostmakedepends="pkg-config gettext xmlto"
 makedepends="libglib-devel libxml2-devel"
 short_desc="Core database of common types"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
-homepage="http://freedesktop.org/Software/shared-mime-info"
+homepage="https://freedesktop.org/Software/shared-mime-info"
+changelog="https://gitlab.freedesktop.org/xdg/shared-mime-info/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/xdg/shared-mime-info/uploads/0ee50652091363ab0d17e335e5e74fbe/shared-mime-info-${version}.tar.xz"
 checksum=b2d40cfcdd84e835d0f2c9107b3f3e77e9cf912f858171fe779946da634e8563
-disable_parallel_build=yes


### PR DESCRIPTION
* remove build dependency on intltool and itstool
* add changelog
* enable parallel build

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
