### PR TITLE
alacritty: update to 0.10.0.

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,7 +1,7 @@
 # Template file for 'alacritty'
 pkgname=alacritty
-version=0.9.0
-revision=2
+version=0.10.0
+revision=1
 build_wrksrc="${pkgname}"
 build_style=cargo
 hostmakedepends="pkg-config python3"
@@ -13,11 +13,15 @@ license="Apache-2.0"
 homepage="https://github.com/alacritty/alacritty"
 changelog="https://raw.githubusercontent.com/alacritty/alacritty/master/CHANGELOG.md"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=6d3aaac9e0477f903563b6fb26e089118407cdbfe952a1e2ffbf4e971b7062b3
+checksum=5dee9c94f944b742b0189dd87c43c87175ffadde8049abb4668ca5a3e68fd65a
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
 	ppc*) broken="ftbfs: thread 'main' panicked at 'slice index starts at 4289555962 but ends at 114', /builddir/rustc-1.46.0-src/src/libstd/io/mod.rs:396:27";;
+esac
+
+case "$XBPS_TARGET_MACHINE" in
+	aarch64*|armv*) broken="ftbfs in serde_yaml dependency, already reported upstream";;
 esac
 
 post_install() {
@@ -28,6 +32,7 @@ post_install() {
 	vinstall ../extra/completions/alacritty.fish 644 usr/share/fish/vendor_completions.d
 	vinstall ../extra/alacritty.info 644 usr/share/terminfo/a
 	vman ../extra/alacritty.man alacritty.1
+	vman ../extra/alacritty-msg.man alacritty-msg.1
 	vsconf ../alacritty.yml
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Marked as broken for now on `aarch64*` and `armv*` because it ftbfs in serde_yaml dependency. There is already an upstream issue open about this.

See https://github.com/steinex/void-packages/runs/4912848476?check_suite_focus=true for error.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
