### PR TITLE
jansson: update to 2.14.

### DIFF
--- a/srcpkgs/jansson/patches/fix-run-suites.patch
+++ b/srcpkgs/jansson/patches/fix-run-suites.patch
@@ -1,0 +1,22 @@
+From 0677666f65b988b2dd44d02966a08fea490d5883 Mon Sep 17 00:00:00 2001
+From: Petri Lehtinen <petri@digip.org>
+Date: Thu, 9 Sep 2021 21:53:11 +0300
+Subject: [PATCH] Fix the check-exports tests for versioned symbols
+
+---
+ test/suites/api/check-exports | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/suites/api/check-exports b/test/suites/api/check-exports
+index 2b6b3c79..5c82064c 100755
+--- a/test/suites/api/check-exports
++++ b/test/suites/api/check-exports
+@@ -15,7 +15,7 @@ grep 'json_\|jansson_' $top_srcdir/src/jansson.def \
+ nm -D $SOFILE >/dev/null >$test_log/symbols 2>/dev/null \
+     || exit 77  # Skip if "nm -D" doesn't seem to work
+ 
+-grep ' [DT] ' $test_log/symbols | cut -d' ' -f3 | grep -v '^_' | sort >$test_log/output
++grep ' [DT] ' $test_log/symbols | cut -d' ' -f3 | grep -v '^_' | sed 's/@@libjansson.*//' | sort >$test_log/output
+ 
+ if ! cmp -s $test_log/exports $test_log/output; then
+     diff -u $test_log/exports $test_log/output >&2

--- a/srcpkgs/jansson/template
+++ b/srcpkgs/jansson/template
@@ -1,20 +1,15 @@
 # Template file for 'jansson'
 pkgname=jansson
-version=2.13.1
+version=2.14
 revision=1
 build_style=gnu-configure
-hostmakedepends="autoconf automake libtool"
 short_desc="Library for encoding, decoding and manipulating JSON data"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jose G Perez Taveras <josegpt27@gmail.com>"
 license="MIT"
 homepage="https://www.digip.org/jansson/"
 changelog="https://github.com/akheron/jansson/raw/master/CHANGES"
-distfiles="https://github.com/akheron/jansson/archive/v${version}.tar.gz"
-checksum=f22901582138e3203959c9257cf83eba9929ac41d7be4a42557213a22ebcc7a0
-
-pre_configure() {
-	autoreconf -vfi
-}
+distfiles="https://github.com/akheron/jansson/releases/download/v${version}/${pkgname}-${version}.tar.gz"
+checksum=5798d010e41cf8d76b66236cfb2f2543c8d082181d16bc3085ab49538d4b9929
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Testing the changes
- I tested the changes in this PR: **YES**

Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - i686