### PR TITLE
New package: kmon-1.6.0

### DIFF
--- a/srcpkgs/kmon/template
+++ b/srcpkgs/kmon/template
@@ -1,0 +1,17 @@
+# Template file for 'kmon'
+pkgname=kmon
+version=1.6.0
+revision=1
+build_style=cargo
+hostmakedepends="python3"
+makedepends="libxcb-devel"
+short_desc="Text-based user interface for managing kernel modules"
+maintainer="Ben Jargowsky <benjar63@gmail.com>"
+license="GPL-3.0-only"
+homepage="https://kmon.cli.rs/"
+distfiles="https://github.com/orhun/kmon/archive/refs/tags/v${version}.tar.gz"
+checksum=b969f861407306e129a8e77f5cdf37962f8ef06b93c5195d0f1b043ece706ad5
+
+post_install() {
+	vman man/kmon.8
+}


### PR DESCRIPTION
- I tested the changes in this PR: **YES**


- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

- I built this PR locally for my native architecture, (x86_64-glibc)
