### PR TITLE
cryptsetup: update to 2.4.3.

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,6 +1,6 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.4.1
+version=2.4.3
 revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --enable-cryptsetup-reencrypt
@@ -16,7 +16,7 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=a356a727a83a464ade566e95239622a22dbe4e0f482b198fdb04ab0d3a5a9c5f
+checksum=fc0df945188172264ec5bf1d0bda08264fadc8a3f856d47eba91f31fe354b507
 make_check=extended
 subpackages="libcryptsetup cryptsetup-devel"
 


### PR DESCRIPTION
CVE-2021-4122

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
