### PR TITLE
abootimg: add no initrd patch

### DIFF
--- a/srcpkgs/abootimg/patches/no-initrd.patch
+++ b/srcpkgs/abootimg/patches/no-initrd.patch
@@ -1,0 +1,37 @@
+This patch incorporates a patch made by John Stultz <https://github.com/johnstultz-work> to allow abootimg to
+work with newer Android aboots that do not include an initrd
+
+Source: https://aur.archlinux.org/cgit/aur.git/tree/no-initrd.patch?h=abootimg
+--- a/abootimg.c	2019-03-12 03:16:42.335616885 -0500
++++ b/abootimg.c	2019-03-12 03:18:01.550892862 -0500
+@@ -163,7 +163,7 @@
+  "\n"
+  "      bootimg has to be valid Android Boot Image, or the update will abort.\n"
+  "\n"
+- " abootimg --create <bootimg> [-c \"param=value\"] [-f <bootimg.cfg>] -k <kernel> -r <ramdisk> [-s <secondstage>]\n"
++ " abootimg --create <bootimg> [-c \"param=value\"] [-f <bootimg.cfg>] -k <kernel> [-r <ramdisk>] [-s <secondstage>]\n"
+  "\n"
+  "      create a new image from scratch.\n"
+  "      if the boot image file is a block device, sanity check will be performed to avoid overwriting a existing\n"
+@@ -291,7 +291,11 @@
+ 
+   if (!(img->header.ramdisk_size)) {
+     fprintf(stderr, "%s: ramdisk size is null\n", img->fname);
+-    return 1;
++    /*
++     * On newer AOSP devices, system can be used as rootfs,
++     * resulting in no initrd being used. Thus this case should
++     * not be fatal.
++     */
+   }
+ 
+   unsigned page_size = img->header.page_size;
+@@ -932,7 +936,7 @@
+       break;
+ 
+     case create:
+-      if (!bootimg->kernel_fname || !bootimg->ramdisk_fname) {
++      if (!bootimg->kernel_fname) {
+         print_usage();
+         break;
+       }

--- a/srcpkgs/abootimg/template
+++ b/srcpkgs/abootimg/template
@@ -1,17 +1,17 @@
 # Template file for 'abootimg'
 pkgname=abootimg
 version=0.6.20160512
-revision=2
+revision=3
 _commit="1ebeb393252ab5aeed62e34bc439b6728444f06e"
-wrksrc="abootimg-$_commit-$_commit"
+wrksrc="abootimg-$_commit"
 build_style=gnu-makefile
 makedepends="libblkid-devel"
 short_desc="Manipulate Android Boot Images"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-or-later"
 homepage="http://gitorious.org/ac100/abootimg"
-distfiles="https://gitlab.com/ajs124/abootimg/repository/archive.tar.gz?ref=$_commit>archive.tar.gz"
-checksum=36efff208101a8d04cc84085849cda3300cea71f062c8d425c534e5f85f6cc3f
+distfiles="https://gitlab.com/ajs124/abootimg/-/archive/$_commit/$_commit.tar.gz"
+checksum=9f6d84b9d1bf9404168145f59754608c7e568138510fb638467c6b822e94ca07
 
 do_install() {
 	local BIN


### PR DESCRIPTION
This makes abootimg usable for newer devices which can potentially have no ramdisk starting with Android 7.

Additionally fixes building the package from source.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
