### PR TITLE
ghc: fix build on big-endian architectures

### DIFF
--- a/srcpkgs/ghc/patches/Disable-unboxed-arrays.patch
+++ b/srcpkgs/ghc/patches/Disable-unboxed-arrays.patch
@@ -1,0 +1,33 @@
+From c74cdea9e6804d10660035700136975cfd39da8d Mon Sep 17 00:00:00 2001
+From: Peter Trommler <ptrommler@acm.org>
+Date: Fri, 31 Dec 2021 18:20:45 +0100
+Subject: [PATCH] Disable unboxed arrays on big-endian
+
+Unboxed arrays are broken on big-endian architectures, see
+https://gitlab.haskell.org/ghc/ghc/-/issues/16998 for details.
+This patch makes the use of unboxed arrays conditional on
+little-endian architecture.
+
+Fixes #673
+
+diff --git a/libraries/containers/containers/include/containers.h b/libraries/containers/containers/include/containers.h
+index cd201ca..fc2a0e8 100644
+--- a/libraries/containers/containers/include/containers.h
++++ b/libraries/containers/containers/include/containers.h
+@@ -35,7 +35,13 @@
+ 
+ #ifdef __GLASGOW_HASKELL__
+ # define USE_ST_MONAD 1
++#ifndef WORDS_BIGENDIAN
++/*
++ * Unboxed arrays are broken on big-endian architectures.
++ * See https://gitlab.haskell.org/ghc/ghc/-/issues/16998
++ */
+ # define USE_UNBOXED_ARRAYS 1
+ #endif
++#endif
+ 
+ #endif
+-- 
+2.31.1
+

--- a/srcpkgs/ghc/patches/ppc64-be-elfv2.patch
+++ b/srcpkgs/ghc/patches/ppc64-be-elfv2.patch
@@ -17,7 +17,7 @@ diff --git a/aclocal.m4 b/aclocal.m4
 index 41cecf0..ba08bd2 100644
 --- a/aclocal.m4
 +++ b/aclocal.m4
-@@ -190,7 +190,7 @@ AC_DEFUN([FPTOOLS_SET_HASKELL_PLATFORM_VARS],
+@@ -199,7 +199,7 @@ AC_DEFUN([FPTOOLS_SET_HASKELL_PLATFORM_V
              test -z "[$]2" || eval "[$]2=ArchPPC"
              ;;
          powerpc64)
@@ -30,7 +30,7 @@ diff --git a/configure b/configure
 index 183e661..8aae1bc 100755
 --- a/configure
 +++ b/configure
-@@ -9868,7 +9868,7 @@ $as_echo "done" >&6; }
+@@ -10296,7 +10296,7 @@ $as_echo "done" >&6; }
              test -z "$2" || eval "$2=ArchPPC"
              ;;
          powerpc64)
@@ -163,7 +163,7 @@ diff --git a/rts/StgCRun.c b/rts/StgCRun.c
 index 934926e..2ff8662 100644
 --- a/rts/StgCRun.c
 +++ b/rts/StgCRun.c
-@@ -717,7 +717,7 @@ StgRunIsImplementedInAssembler(void)
+@@ -726,7 +726,7 @@ StgRunIsImplementedInAssembler(void)
     Everything is in assembler, so we don't have to deal with GCC...
     -------------------------------------------------------------------------- */
 
@@ -172,7 +172,7 @@ index 934926e..2ff8662 100644
 
  static void GNUC3_ATTRIBUTE(used)
  StgRunIsImplementedInAssembler(void)
-@@ -842,7 +842,7 @@ StgRunIsImplementedInAssembler(void)
+@@ -851,7 +851,7 @@ StgRunIsImplementedInAssembler(void)
 
  #endif
 

--- a/srcpkgs/ghc/patches/sphinx-unicode.patch
+++ b/srcpkgs/ghc/patches/sphinx-unicode.patch
@@ -1,14 +1,14 @@
 diff -rpU2 ghc-8.8.4-orig/docs/users_guide/conf.py ghc-8.8.4/docs/users_guide/conf.py
 --- ghc-8.8.4-orig/docs/users_guide/conf.py	2020-07-08 16:43:03.000000000 +0000
 +++ ghc-8.8.4/docs/users_guide/conf.py	2021-07-10 20:25:33.536928487 +0000
-@@ -78,5 +78,5 @@ latex_elements = {
+@@ -101,5 +101,5 @@ latex_elements = {
      'inputenc': '',
      'utf8extra': '',
 -    'preamble': '''
 +    'preamble': r'''
  \usepackage{fontspec}
  \usepackage{makeidx}
-@@ -84,5 +84,5 @@ latex_elements = {
+@@ -107,5 +107,5 @@ latex_elements = {
  \setromanfont{DejaVu Serif}
  \setmonofont{DejaVu Sans Mono}
 -\setlength{\\tymin}{45pt}


### PR DESCRIPTION
Add patch Disable-unboxed-arrays.patch for ghc issue #16998
https://gitlab.haskell.org/ghc/ghc/-/issues/16998.
This patch has been accepted upstream as
https://github.com/haskell/containers/commit/f5a511f1ff2cf16e710342948792cb8d7576e27c

Refresh patches ppc64-be-elfv2.patch, sphinx-unicode.patch so they apply cleanly again.

#### Testing the changes
- I tested the changes in this PR: **YES**

 
#### Local build testing
- I built this PR locally for my native architecture, (ppc64-glibc)

 @q66 perhaps you would like to test this in your PowerPC environment? 