### PR TITLE
ghc-bin: enable build on ppc64

### DIFF
--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -2,7 +2,7 @@
 pkgname=ghc-bin
 version=8.10.4
 revision=1
-archs="i686 x86_64* ppc64le*"
+archs="i686 x86_64* ppc64 ppc64le*"
 wrksrc="ghc-${version%[!0-9]}"
 hostmakedepends="perl libffi libnuma"
 depends="ncurses perl gcc libffi-devel gmp-devel"
@@ -26,6 +26,10 @@ x86_64-musl)
 i686)
 	distfiles="https://downloads.haskell.org/~ghc/${version%[!0-9]}/ghc-${version}-i386-deb9-linux.tar.xz"
 	checksum=0022c5b9ac22825bb7b4745af3d92cef0ba1ecd01fab3ef387ddbd47146569ad
+	;;
+ppc64)
+	distfiles="https://faubox.rrze.uni-erlangen.de/dl/fiLuykeuntXeFzAG5k9RDZP7/ghc-${version}-powerpc64-unknown-linux.tar.xz"
+	checksum=89683855d49d6a879903499885ec56ce8cb9fcfd7abfcda9665469dcd0c165b5
 	;;
 ppc64le)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux.tar.xz"


### PR DESCRIPTION
Provide a binary distribution for ppc64 to bootstrap Haskell (ghc) on ppc64.

#### Testing the changes
- I tested the changes in this PR: **YES**

 
#### Local build testing
- I built this PR locally for my native architecture, (ppc64-glibc)

Tagging @q66 for PowerPC. 
