### PR TITLE
retroarch: update to 1.10.0

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,21 +1,21 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.9.14
+version=1.10.0
 revision=1
 wrksrc="RetroArch-$version"
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
  --enable-udev --disable-builtinflac --disable-builtinglslang
- --disable-builtinmbedtls --disable-builtinminiupnpc --disable-builtinzlib
+ --disable-builtinmbedtls --disable-builtinzlib
  $(vopt_enable ffmpeg) $(vopt_enable flac) $(vopt_enable glslang) $(vopt_enable jack)
- $(vopt_enable miniupnpc) $(vopt_enable pulseaudio pulse) $(vopt_enable qt5 qt)
+ $(vopt_enable pulseaudio pulse) $(vopt_enable qt5 qt)
  $(vopt_enable sdl2) $(vopt_enable vulkan) $(vopt_enable wayland) $(vopt_enable x11)"
 conf_files="/etc/retroarch.cfg"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel eudev-libudev-devel freetype-devel libusb-devel libxkbcommon-devel
  mbedtls-devel zlib-devel $(vopt_if ffmpeg ffmpeg-devel) $(vopt_if flac libflac-devel)
  $(vopt_if glslang 'glslang-devel SPIRV-Tools-devel') $(vopt_if jack jack-devel)
- $(vopt_if miniupnpc miniupnpc-devel) $(vopt_if pulseaudio pulseaudio-devel)
+ $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if qt5 qt5-devel) $(vopt_if sdl2 SDL2-devel) $(vopt_if vulkan vulkan-loader)
  $(vopt_if x11 'libXext-devel libXinerama-devel libXv-devel libXxf86vm-devel')"
 depends="$(vopt_if vulkan vulkan-loader) $(vopt_if x11 xdg-utils)"
@@ -25,14 +25,13 @@ license="GPL-3.0-or-later"
 homepage="https://www.retroarch.com/"
 changelog="https://raw.githubusercontent.com/libretro/RetroArch/master/CHANGES.md"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=874f3e3aca1d12d2cb9d34687eb052eec0ccfc0f335606f61fa6a03c8b6bb90a
+checksum=ff9c31abae19528275e40fbe49ef40be9410b4108513ae7dbf325e210e5b5bec
 
-build_options="ffmpeg flac glcore gles2 glslang jack miniupnpc neon pulseaudio qt5 sdl2 vulkan wayland x11"
-build_options_default="ffmpeg flac glcore glslang miniupnpc pulseaudio sdl2 vulkan wayland x11"
+build_options="ffmpeg flac glcore gles2 glslang jack neon pulseaudio qt5 sdl2 vulkan wayland x11"
+build_options_default="ffmpeg flac glcore glslang pulseaudio sdl2 vulkan wayland x11"
 
 desc_option_glcore="Enable support for OpenGL 3.2 core+ and OpenGL ES 3+"
 desc_option_glslang="Enable support for GLSL shaders"
-desc_option_miniupnpc="Enable support for NAT traversal"
 desc_option_neon="Enable support for ARM Neon SIMD extension"
 
 vopt_conflict glcore gles2 # gles2 disables glcore support
@@ -73,7 +72,7 @@ if [ "$build_option_wayland" ]; then
 	if [ -z "$build_option_gles2" -a -z "$build_option_glcore" ]; then
 		msg_error "$pkgname: 'wayland' option requires 'gles2' or 'glcore'.\n"
 	fi
-	makedepends+=" wayland-devel wayland-protocols"
+	makedepends+=" wayland-devel wayland-protocols libdecor-devel"
 	if [ "$CROSS_BUILD" ]; then
 		hostmakedepends+=" wayland-devel wayland-protocols"
 	fi


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

- Upstream dropped support for miniupnpc in favor of a built-in UPnP implementation
- Added libdecor dependency for Wayland