### PR TITLE
libgit2: update to 1.5.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1328,7 +1328,7 @@ libunwind-ppc64.so.8 libunwind-1.5.0_3
 libunwind-setjmp.so.0 libunwind-1.5.0_3
 libmicrohttpd.so.12 libmicrohttpd-0.9.73_1
 libmicrodns.so.1 libmicrodns-0.2.0_1
-libgit2.so.1.0 libgit2-1.0.1_3
+libgit2.so.1.5 libgit2-1.5.0_1
 libgit2-glib-1.0.so.0 libgit2-glib-0.23.4_1
 libagg.so.2 agg-2.5_1
 libzzip-0.so.13 zziplib-0.13.62_1

--- a/srcpkgs/DarkRadiant/template
+++ b/srcpkgs/DarkRadiant/template
@@ -1,7 +1,7 @@
 # Template file for 'DarkRadiant'
 pkgname=DarkRadiant
 version=2.14.0
-revision=1
+revision=2
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 hostmakedepends="pkg-config ruby-asciidoctor"

--- a/srcpkgs/Fritzing/template
+++ b/srcpkgs/Fritzing/template
@@ -1,7 +1,7 @@
 # Template file for 'Fritzing'
 pkgname=Fritzing
 version=0.9.3b
-revision=5
+revision=6
 _partshash=359eb1933622e4c4fa456ad043543681984a4d64 # 2018-03-14
 wrksrc="fritzing-app-${version}"
 build_style=qmake

--- a/srcpkgs/calligra/template
+++ b/srcpkgs/calligra/template
@@ -1,7 +1,7 @@
 # Template file for 'calligra'
 pkgname=calligra
 version=3.2.1
-revision=8
+revision=9
 build_style=cmake
 configure_args="-Wno-dev -DCALLIGRA_SHOULD_BUILD_UNMAINTAINED=ON
  -DBUILD_TESTING=OFF"

--- a/srcpkgs/geany-plugins/patches/0001-git-changebar-Simplify-libgit2-version-checks.patch
+++ b/srcpkgs/geany-plugins/patches/0001-git-changebar-Simplify-libgit2-version-checks.patch
@@ -1,0 +1,49 @@
+From 668f5d07eef16e227402eab09141c738b315d94b Mon Sep 17 00:00:00 2001
+From: Colomban Wendling <ban@herbesfolles.org>
+Date: Sun, 5 Jun 2022 23:11:20 +0200
+Subject: [PATCH 1/2] git-changebar: Simplify libgit2 version checks
+
+Introduce a custom macro for libgit2 version checks for them to be both
+easier to read and write.
+---
+ git-changebar/src/gcb-plugin.c | 14 +++++++++++---
+ 1 file changed, 11 insertions(+), 3 deletions(-)
+
+diff --git a/git-changebar/src/gcb-plugin.c b/git-changebar/src/gcb-plugin.c
+index f8ce20cd..bee8c865 100644
+--- a/git-changebar/src/gcb-plugin.c
++++ b/git-changebar/src/gcb-plugin.c
+@@ -32,11 +32,19 @@
+ #include <geany.h>
+ #include <document.h>
+ 
+-#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 22) )
++#ifdef LIBGIT2_VER_MINOR
++# define CHECK_LIBGIT2_VERSION(MAJOR, MINOR) \
++  ((LIBGIT2_VER_MAJOR == (MAJOR) && LIBGIT2_VER_MINOR >= (MINOR)) || \
++   LIBGIT2_VER_MAJOR > (MAJOR))
++#else /* ! defined(LIBGIT2_VER_MINOR) */
++# define CHECK_LIBGIT2_VERSION(MAJOR, MINOR) 0
++#endif
++
++#if ! CHECK_LIBGIT2_VERSION(0, 22)
+ # define git_libgit2_init     git_threads_init
+ # define git_libgit2_shutdown git_threads_shutdown
+ #endif
+-#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 23) )
++#if ! CHECK_LIBGIT2_VERSION(0, 23)
+ /* 0.23 added @p binary_cb */
+ # define git_diff_buffers(old_buffer, old_len, old_as_path, \
+                           new_buffer, new_len, new_as_path, options, \
+@@ -45,7 +53,7 @@
+                     new_buffer, new_len, new_as_path, options, \
+                     file_cb, hunk_cb, line_cb, payload)
+ #endif
+-#if ! defined (LIBGIT2_VER_MINOR) || ( (LIBGIT2_VER_MAJOR == 0) && (LIBGIT2_VER_MINOR < 28) )
++#if ! CHECK_LIBGIT2_VERSION(0, 28)
+ # define git_buf_dispose  git_buf_free
+ # define git_error_last   giterr_last
+ #endif
+-- 
+2.38.0
+

--- a/srcpkgs/geany-plugins/patches/0002-git-changebar-Add-support-for-libgit2-1.4.patch
+++ b/srcpkgs/geany-plugins/patches/0002-git-changebar-Add-support-for-libgit2-1.4.patch
@@ -1,0 +1,124 @@
+From 5d9f1bc6d010e6b4c6a21af8a39b90922f89a82c Mon Sep 17 00:00:00 2001
+From: Colomban Wendling <ban@herbesfolles.org>
+Date: Sun, 5 Jun 2022 23:22:59 +0200
+Subject: [PATCH 2/2] git-changebar: Add support for libgit2 1.4
+
+The buffer API changed a lot in libgit2 1.4, so compatibility is a bit
+nastier than one could hope for.
+
+Fixes #1164.
+---
+ git-changebar/src/gcb-plugin.c | 76 ++++++++++++++++++++++++----------
+ 1 file changed, 54 insertions(+), 22 deletions(-)
+
+diff --git a/git-changebar/src/gcb-plugin.c b/git-changebar/src/gcb-plugin.c
+index bee8c865..76208cd0 100644
+--- a/git-changebar/src/gcb-plugin.c
++++ b/git-changebar/src/gcb-plugin.c
+@@ -219,30 +219,19 @@ static const struct {
+ };
+ 
+ 
+-/* workaround https://github.com/libgit2/libgit2/pull/3187 */
+-static int
+-gcb_git_buf_grow (git_buf  *buf,
+-                  size_t    target_size)
+-{
+-  if (buf->asize == 0) {
+-    if (target_size == 0) {
+-      target_size = buf->size;
+-    }
+-    if ((target_size & 7) == 0) {
+-      target_size++;
+-    }
+-  }
+-  return git_buf_grow (buf, target_size);
+-}
+-#define git_buf_grow gcb_git_buf_grow
+-
+ static void
+ buf_zero (git_buf *buf)
+ {
+   if (buf) {
+     buf->ptr = NULL;
+     buf->size = 0;
++#if ! CHECK_LIBGIT2_VERSION(1, 4)
+     buf->asize = 0;
++#else
++    /* we don't really need this field, but the documentation states that all
++     * fields should be set to 0, so fill it as well */
++    buf->reserved = 0;
++#endif
+   }
+ }
+ 
+@@ -256,6 +245,52 @@ clear_cached_blob_contents (void)
+   G_blob_contents_tag = 0;
+ }
+ 
++/* similar to old git_blob_filtered_content() but makes sure the caller owns
++ * the data in the output buffer -- and uses a boolean return */
++static gboolean
++get_blob_contents (git_buf     *out,
++                   git_blob    *blob,
++                   const char  *as_path,
++                   int          check_for_binary_data)
++{
++/* libgit2 1.4 changed buffer API quite a bit */
++#if ! CHECK_LIBGIT2_VERSION(1, 4)
++  gboolean success = TRUE;
++
++  if (git_blob_filtered_content (out, blob, as_path,
++                                 check_for_binary_data) != 0)
++    return FALSE;
++
++  /* Workaround for https://github.com/libgit2/libgit2/pull/3187
++   * We want to own the buffer, which git_buf_grow(buf, 0) was supposed to do,
++   * but there is a corner case where it doesn't do what it should and
++   * truncates the buffer contents, so we fix this manually. */
++  if (out->asize == 0) {
++    size_t target_size = out->size;
++    if ((target_size & 7) == 0) {
++      target_size++;
++    }
++    success = (git_buf_grow (out, target_size) == 0);
++  }
++
++  return success;
++#else /* libgit2 >= 1.4 */
++  /* Here we can assume we will always get a buffer we own (at least as of
++   * 2022-06-05 it is the case), so there's no need for a pendent to the
++   * previous git_buf_grow() shenanigans.
++   * This code path does the same as the older git_blob_filtered_content()
++   * but with non-deprecated API */
++  git_blob_filter_options opts = GIT_BLOB_FILTER_OPTIONS_INIT;
++
++  if (check_for_binary_data)
++    opts.flags |= GIT_BLOB_FILTER_CHECK_FOR_BINARY;
++  else
++    opts.flags &= ~GIT_BLOB_FILTER_CHECK_FOR_BINARY;
++
++  return git_blob_filter(out, blob, as_path, &opts) == 0;
++#endif
++}
++
+ /* get the file blob for @relpath at HEAD */
+ static gboolean
+ repo_get_file_blob_contents (git_repository  *repo,
+@@ -279,11 +314,8 @@ repo_get_file_blob_contents (git_repository  *repo,
+           git_blob *blob;
+           
+           if (git_blob_lookup (&blob, repo, git_tree_entry_id (entry)) == 0) {
+-            if (git_blob_filtered_content (contents, blob, relpath,
+-                                           check_for_binary_data) == 0 &&
+-                git_buf_grow (contents, 0) == 0) {
+-              success = TRUE;
+-            }
++            success = get_blob_contents (contents, blob, relpath,
++                                         check_for_binary_data);
+             git_blob_free (blob);
+           }
+           git_tree_entry_free (entry);
+-- 
+2.38.0
+

--- a/srcpkgs/geany-plugins/template
+++ b/srcpkgs/geany-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'geany-plugins'
 pkgname=geany-plugins
 version=1.38.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="PYTHON=/usr/bin/python2 --enable-all-plugins --disable-devhelp
  --disable-webhelper --disable-debugger --disable-geanypy --disable-multiterm"

--- a/srcpkgs/git-absorb/template
+++ b/srcpkgs/git-absorb/template
@@ -1,7 +1,7 @@
 # Template file for 'git-absorb'
 pkgname=git-absorb
 version=0.6.7
-revision=1
+revision=2
 build_style=cargo
 build_helper=qemu
 hostmakedepends="pkg-config"

--- a/srcpkgs/git-series/template
+++ b/srcpkgs/git-series/template
@@ -1,7 +1,7 @@
 # Template file for 'git-series'
 pkgname=git-series
 version=0.9.1
-revision=13
+revision=14
 build_style=cargo
 hostmakedepends="cmake pkg-config perl"
 makedepends="libgit2-devel libcurl-devel"

--- a/srcpkgs/gnome-builder/template
+++ b/srcpkgs/gnome-builder/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-builder'
 pkgname=gnome-builder
 version=42.1
-revision=1
+revision=2
 build_style=meson
 build_helper=qemu
 configure_args="-Dhelp=true -Dnetwork_tests=false"

--- a/srcpkgs/horizon/template
+++ b/srcpkgs/horizon/template
@@ -1,7 +1,7 @@
 # Template file for 'horizon'
 pkgname=horizon
 version=2.3.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="GOLD="
 make_install_target="install install-man"

--- a/srcpkgs/juCi++/template
+++ b/srcpkgs/juCi++/template
@@ -1,7 +1,7 @@
 # Template file for 'juCi++'
 pkgname=juCi++
 version=1.6.2
-revision=3
+revision=4
 _libclangmm_commit="b342f4dd6de4fe509a692a4b4fcfc7e24aae9590"
 _tiny_commit="c9c8bf810ddad8cd17882b9a9ee628a690e779f5"
 wrksrc="jucipp-v${version}"

--- a/srcpkgs/kup/template
+++ b/srcpkgs/kup/template
@@ -1,7 +1,7 @@
 # Template file for 'kup'
 pkgname=kup
 version=0.9.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="extra-cmake-modules kdoctools qt5-qmake qt5-host-tools kcoreaddons
  kpackage gettext kconfig"

--- a/srcpkgs/libgit2-glib/template
+++ b/srcpkgs/libgit2-glib/template
@@ -1,7 +1,7 @@
 # Template file for 'libgit2-glib'
 pkgname=libgit2-glib
 version=1.1.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dintrospection=$(vopt_if gir true false)

--- a/srcpkgs/libgit2/patches/0001-clar-remove-ftrunacte-from-libgit2-tests.patch
+++ b/srcpkgs/libgit2/patches/0001-clar-remove-ftrunacte-from-libgit2-tests.patch
@@ -1,0 +1,25 @@
+From 12d73c418253a5c396465079c2808e07de17a1db Mon Sep 17 00:00:00 2001
+From: Peter Pettersson <boretrk@hotmail.com>
+Date: Thu, 14 Jul 2022 18:28:58 +0200
+Subject: [PATCH] clar: remove ftrunacte from libgit2 tests
+
+---
+ tests/libgit2/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/libgit2/CMakeLists.txt b/tests/libgit2/CMakeLists.txt
+index 27f421ad6..7f6fafe77 100644
+--- a/tests/libgit2/CMakeLists.txt
++++ b/tests/libgit2/CMakeLists.txt
+@@ -65,7 +65,7 @@ endif()
+ 
+ include(AddClarTest)
+ add_clar_test(libgit2_tests offline             -v -xonline)
+-add_clar_test(libgit2_tests invasive            -v -score::ftruncate -sfilter::stream::bigfile -sodb::largefiles -siterator::workdir::filesystem_gunk -srepo::init -srepo::init::at_filesystem_root)
++add_clar_test(libgit2_tests invasive            -v -sfilter::stream::bigfile -sodb::largefiles -siterator::workdir::filesystem_gunk -srepo::init -srepo::init::at_filesystem_root)
+ add_clar_test(libgit2_tests online              -v -sonline -xonline::customcert)
+ add_clar_test(libgit2_tests online_customcert   -v -sonline::customcert)
+ add_clar_test(libgit2_tests gitdaemon           -v -sonline::push)
+-- 
+2.38.0
+

--- a/srcpkgs/libgit2/patches/disable-test-validate_current_user_ownership.patch
+++ b/srcpkgs/libgit2/patches/disable-test-validate_current_user_ownership.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/util/path.c b/tests/util/path.c
+index 2c39e0887..71a8d6040 100644
+--- a/tests/util/path.c
++++ b/tests/util/path.c
+@@ -757,7 +757,7 @@ void test_path__validate_current_user_ownership(void)
+ 	cl_git_fail(git_fs_path_owner_is_current_user(&is_cur, "c:\\path\\does\\not\\exist"));
+ #else
+ 	cl_git_pass(git_fs_path_owner_is_current_user(&is_cur, "/"));
+-	cl_assert_equal_i(is_cur, 0);
++	//cl_assert_equal_i(is_cur, 0); // xbps-src chroot belongs to $USER, not root
+ 
+ 	cl_git_fail(git_fs_path_owner_is_current_user(&is_cur, "/path/does/not/exist"));
+ #endif

--- a/srcpkgs/libgit2/template
+++ b/srcpkgs/libgit2/template
@@ -1,8 +1,9 @@
 # Template file for 'libgit2'
 pkgname=libgit2
-version=1.0.1
-revision=3
+version=1.5.0
+revision=1
 build_style=cmake
+configure_args="-DENABLE_REPRODUCIBLE_BUILDS=ON -DUSE_SSH=ON"
 hostmakedepends="python3 git pkg-config"
 makedepends="zlib-devel openssl-devel http-parser-devel libssh2-devel"
 short_desc="Git linkable library"
@@ -10,7 +11,20 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="custom:GPL-2.0-or-later WITH GCC-exception-2.0"
 homepage="https://libgit2.org"
 distfiles="https://github.com/libgit2/libgit2/archive/v${version}.tar.gz"
-checksum=1775427a6098f441ddbaa5bd4e9b8a043c7401e450ed761e69a415530fea81d2
+checksum=8de872a0f201b33d9522b817c92e14edb4efad18dae95cf156cf240b2efff93e
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	configure_args+=" -DBUILD_TESTS=ON"
+else
+	configure_args+=" -DBUILD_TESTS=OFF"
+fi
+
+post_patch() {
+	# no online tests
+	vsed \
+		-i tests/libgit2/CMakeLists.txt \
+		-e '/-sonline/s/^/#/'
+}
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/slcp/template
+++ b/srcpkgs/slcp/template
@@ -1,7 +1,7 @@
 # Template file for 'slcp'
 pkgname=slcp
 version=0.2
-revision=12
+revision=13
 build_style=gnu-makefile
 makedepends="libgit2-devel"
 short_desc="Simple shell prompt written in C"

--- a/srcpkgs/stagit/template
+++ b/srcpkgs/stagit/template
@@ -1,7 +1,7 @@
 # Template file for 'stagit'
 pkgname=stagit
 version=1.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_install_args="MANPREFIX=/usr/share/man"
 makedepends="libgit2-devel"


### PR DESCRIPTION
bumping libgit2 is required to package [jami](https://git.jami.net/savoirfairelinux/jami-client-qt/)

#### Testing the changes
- I tested the changes in this PR: **briefly**
- local build for
    - [x] x86_64
    - [x] x86_64-musl
    - [x] i686
    - [x] aarch64
    - [x] aarch64-musl
    - [x] armv7l
    - [x] armv7l-musl
    - [x] armv6l-musl

#### Blocked By
- [x] #39919
- [x] local build for many archs :(

supersedes:
* https://github.com/void-linux/void-packages/pull/28456/
* https://github.com/void-linux/void-packages/pull/33535
