### PR TITLE
New package: nerdctl-0.16.1.

### DIFF
--- a/srcpkgs/nerdctl/template
+++ b/srcpkgs/nerdctl/template
@@ -1,0 +1,13 @@
+# Template file for 'nerdctl'
+pkgname=nerdctl
+version=0.16.1
+revision=1
+build_style=go
+go_import_path=github.com/containerd/nerdctl
+go_package=$go_import_path/cmd/nerdctl
+short_desc="Docker-compatible CLI for containerd"
+maintainer="Michael Aldridge <maldridge@VoidLinux.org>"
+license="Apache-2.0"
+homepage="https://github.com/containerd/nerdctl"
+distfiles="https://github.com/containerd/nerdctl/archive/refs/tags/v$version.tar.gz"
+checksum=be19ceed51703a71f847bfff3afcf25e0efd4c012fd8ec1ff02c545d6773989d


### PR DESCRIPTION
Almost completely untested, mostly just pushed at the moment for the
CI run.
