### PR TITLE
mkvtoolnix-gui: add mediainfo dependency

### DIFF
--- a/srcpkgs/mkvtoolnix/template
+++ b/srcpkgs/mkvtoolnix/template
@@ -1,7 +1,7 @@
 # Template file for 'mkvtoolnix'
 pkgname=mkvtoolnix
 version=64.0.0
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper=qmake
 configure_args="--with-docbook-xsl-root=/usr/share/xsl/docbook --enable-qt
@@ -38,7 +38,7 @@ do_install() {
 
 mkvtoolnix-gui_package() {
 	short_desc+=" - Qt GUI"
-	depends="${sourcepkg}-${version}_${revision}"
+	depends="${sourcepkg}-${version}_${revision} mediainfo"
 	pkg_install() {
 		vmove usr/bin/mkvtoolnix-gui
 		vmove usr/share/applications


### PR DESCRIPTION
need mediainfo to run properly.
![Screenshot_20220202_152928](https://user-images.githubusercontent.com/45872139/152122430-48e2538d-366c-4b76-83e2-50b628fe2f42.png)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
