### PR TITLE
nauty: disable native code (illegal instructions)

### DIFF
--- a/srcpkgs/nauty/template
+++ b/srcpkgs/nauty/template
@@ -1,7 +1,7 @@
 # Template file for 'nauty'
 pkgname=nauty
 version=2.7r3
-revision=1
+revision=2
 wrksrc=${pkgname}${version/./}
 build_style=gnu-configure
 make_install_args="includedir=/usr/include/nauty
@@ -12,6 +12,12 @@ license="Apache-2.0"
 homepage="https://pallini.di.uniroma1.it/"
 distfiles="https://pallini.di.uniroma1.it/nauty${version/./}.tar.gz"
 checksum=4f0665b716a53f7a14ea2ae30059f23d064ce3fe4c12c013404ef6e1ee0b88c2
+
+build_options="native_build"
+
+if [ -z "$build_option_native_build" ]; then
+	configure_args="--enable-generic --disable-popcnt"
+fi
 
 nauty-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"


### PR DESCRIPTION
The package currently shipped in void gives me illegal instructions in a
nehalem cpu.

This commit fixes the issue by disabling native compilation unless a build
option is given; also disable popcnt which, although available on nehalem, is
not available in baseline x86_64.

An easy way to spot the issue is to run something like:
```
$ geng 2
>A geng -d0D1 n=2 e=0-1
Illegal instruction
```

#### Testing the changes
- I tested the changes in this PR: **YES**

I compiled with `./xbps-src build nauty` on a cascade lake cpu, then run `./xbps-src check nauty` on a nehalem cpu. This breaks before the present PR, and works ok after.

I also tested sagemath: previously I was getting a lot of doctest failures which are now fixed.

Cc: @leahneukirchen please merge this before sagemath.