### PR TITLE
sage-data-*: fix update files

### DIFF
--- a/srcpkgs/sage-data-conway_polynomials/update
+++ b/srcpkgs/sage-data-conway_polynomials/update
@@ -1,1 +1,2 @@
 pkgname=conway_polynomials
+site=https://mirrors.mit.edu/sage/spkg/upstream/conway_polynomials/

--- a/srcpkgs/sage-data-elliptic_curves/update
+++ b/srcpkgs/sage-data-elliptic_curves/update
@@ -1,1 +1,2 @@
 pkgname=elliptic_curves
+site=https://mirrors.mit.edu/sage/spkg/upstream/elliptic_curves/


### PR DESCRIPTION
Two of these packages are picking up incorrect versions from an auxiliary site. This fixes it. No revbump necessary.