### PR TITLE
avidemux: remove duplicate .desktop file

### DIFF
--- a/srcpkgs/avidemux/template
+++ b/srcpkgs/avidemux/template
@@ -1,7 +1,7 @@
 # Template file for 'avidemux'
 pkgname=avidemux
 version=2.8.0
-revision=1
+revision=2
 # Can't be compiled for aarch64, arm* or mips*
 archs="x86_64* i686*"
 wrksrc="${pkgname}_${version}"
@@ -42,5 +42,4 @@ do_install() {
 	ln -s avidemux3_qt5 ${DESTDIR}/usr/bin/avidemux
 	vman man/avidemux.1
 	vinstall avidemux_icon.png 644 usr/share/pixmaps avidemux.png
-	vinstall appImage/avidemux.desktop 644 usr/share/applications
 }


### PR DESCRIPTION
By default, avidemux has used `org.avidux.avidux.desktop`. So, I try to delete `avidemux.desktop` because it could not be executed.

```
➜  ~ xbps-query --regex -Rf avidemux | grep desktop
/usr/share/applications/avidemux.desktop
/usr/share/applications/org.avidemux.Avidemux.desktop
```

![Screenshot_20220204_223015](https://user-images.githubusercontent.com/45872139/152559404-c5f1e11d-2377-4c42-89ef-a41209a58ae1.png)

![Screenshot_20220204_223247](https://user-images.githubusercontent.com/45872139/152559487-c00aab85-ae3a-4894-9d83-89b3a0a2f68d.png)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)