### PR TITLE
xorg-server: fix MATE crash with nvidia

### DIFF
--- a/srcpkgs/xorg-server/patches/present-Check-for-NULL-to-prevent-crash.patch
+++ b/srcpkgs/xorg-server/patches/present-Check-for-NULL-to-prevent-crash.patch
@@ -1,0 +1,43 @@
+From 94b4a3d45451d29e9539ea234ce8b5e9ed58546c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?B=C5=82a=C5=BCej=20Szczygie=C5=82?= <spaz16@wp.pl>
+Date: Thu, 13 Jan 2022 00:47:27 +0100
+Subject: [PATCH xserver] present: Check for NULL to prevent crash
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Closes: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1275
+Signed-off-by: Błażej Szczygieł <spaz16@wp.pl>
+Tested-by: Aaron Plattner <aplattner@nvidia.com>
+(cherry picked from commit 22d5818851967408bb7c903cb345b7ca8766094c)
+---
+ present/present_scmd.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/present/present_scmd.c b/present/present_scmd.c
+index 3c68e690b..11391adbb 100644
+--- a/present/present_scmd.c
++++ b/present/present_scmd.c
+@@ -168,6 +168,9 @@ present_scmd_get_crtc(present_screen_priv_ptr screen_priv, WindowPtr window)
+     if (!screen_priv->info)
+         return NULL;
+ 
++    if (!screen_priv->info->get_crtc)
++        return NULL;
++
+     return (*screen_priv->info->get_crtc)(window);
+ }
+ 
+@@ -206,6 +209,9 @@ present_flush(WindowPtr window)
+     if (!screen_priv->info)
+         return;
+ 
++    if (!screen_priv->info->flush)
++        return;
++
+     (*screen_priv->info->flush) (window);
+ }
+ 
+-- 
+2.34.1
+

--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,7 +1,7 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=1.20.14
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb


### PR DESCRIPTION
see:
- https://github.com/mate-desktop/mate-desktop/issues/505
- https://gitlab.freedesktop.org/xorg/xserver/-/issues/1275

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
