### PR TITLE
YACReader: update to 9.8.2, fix Library

### DIFF
--- a/srcpkgs/YACReader/template
+++ b/srcpkgs/YACReader/template
@@ -1,6 +1,6 @@
 # Template file for 'YACReader'
 pkgname=YACReader
-version=9.8.0
+version=9.8.2
 revision=1
 wrksrc=yacreader-${version}
 build_style=qmake
@@ -8,10 +8,11 @@ hostmakedepends="qt5-qmake qt5-host-tools pkg-config"
 makedepends="qt5-script-devel qt5-declarative-devel qt5-quickcontrols
  qt5-multimedia-devel poppler-qt5-devel qrencode-devel
  glu-devel libunarr-devel qt5-svg-devel"
+depends="qt5-plugin-sqlite"
 short_desc="Cross-platform reader and manager for your digital comic library"
 maintainer="Crestwave <crest.wave@yahoo.com>"
 license="GPL-3.0-or-later"
 homepage="http://yacreader.com/"
 changelog="https://raw.githubusercontent.com/YACReader/yacreader/master/CHANGELOG.md"
 distfiles="https://github.com/YACReader/yacreader/archive/${version}.tar.gz"
-checksum=6c67435a029e24af967598b0c3c8d174d152ad398f80b05b7b8ba832eddacf90
+checksum=44268a0c07a5ba3c25202064c088b1deba7cb048f6cbfcf33b3538f18225ae62


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Notes
- Added ``qt5-plugin-sqlite`` as dependency; without it YACReaderLibrary cannot create, open, modify, etc libraries.

