### PR TITLE
New package: 1password-cli-1.12.4

### DIFF
--- a/srcpkgs/1password-cli/template
+++ b/srcpkgs/1password-cli/template
@@ -1,0 +1,38 @@
+# Template file for '1password-cli'
+pkgname=1password-cli
+version=1.12.4
+revision=1
+archs="i686 x86_64 arm* aarch64"
+create_wrksrc=yes
+short_desc="1Password command line tool"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
+license="custom:Proprietary"
+homepage="https://app-updates.agilebits.com/product_history/CLI"
+restricted=yes
+repository=nonfree
+nopie=precompiled
+
+case "$XBPS_TARGET_MACHINE" in
+		*-musl)
+	    broken="Musl builds are not supported";;
+		arm*)
+			distfiles=https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_arm_v${version}.zip
+			checksum=682ccf8bef44b74c330998549e93f18845d29bcd2b29ef965d0aa16d76fc22e1
+			;;
+		aarch64)
+			distfiles=https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_arm64_v${version}.zip
+			checksum=1258b4b29a66c825cb69e2eca49ab9e4e0ac7cc068e676eff99d8952ecd0aabf
+			;;
+		i686)
+			distfiles=https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_386_v${version}.zip
+			checksum=ef10eeb27e4ac4eb586acbf3caff75aa5678bfacdf60186cd519ecd869cc5cc9
+			;;
+		x86_64)
+			distfiles=https://cache.agilebits.com/dist/1P/op/pkg/v${version}/op_linux_amd64_v${version}.zip
+			checksum=35a16122c76bea936383d7597b45bee55e0ea63df94758c3342ff417fb395a87
+			;;
+esac
+
+do_install() {
+	vbin op
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: No

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): No, its proprietary software 

Requested here: #35230 