### PR TITLE
Revert intel-media-driver

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3875,8 +3875,9 @@ libnvpair.so.3 zfs-2.0.3_2
 libgmio.so gmio-0.4.1_1
 libjsonnet.so.0 jsonnet-0.14.0_2
 libjsonnet++.so.0 jsonnet-0.14.0_2
-libigdgmm.so.12 intel-gmmlib-22.0.1_1
+libigdgmm.so.11 intel-gmmlib-21.3.1_1
 libigfxcmrt.so.7 intel-media-driver-21.3.5_1
+libigdgmm.so.11 intel-gmmlib-19.4.1_1
 libigraph.so.0 igraph-0.9.4_1
 libgtk-layer-shell.so.0 gtk-layer-shell-0.1.0_1
 librdkafka.so.1 librdkafka-1.4.4_3

--- a/common/shlibs
+++ b/common/shlibs
@@ -3876,7 +3876,7 @@ libgmio.so gmio-0.4.1_1
 libjsonnet.so.0 jsonnet-0.14.0_2
 libjsonnet++.so.0 jsonnet-0.14.0_2
 libigdgmm.so.12 intel-gmmlib-22.0.1_1
-libigfxcmrt.so.7 intel-media-driver-22.1.1_1
+libigfxcmrt.so.7 intel-media-driver-21.3.5_1
 libigraph.so.0 igraph-0.9.4_1
 libgtk-layer-shell.so.0 gtk-layer-shell-0.1.0_1
 librdkafka.so.1 librdkafka-1.4.4_3

--- a/srcpkgs/intel-gmmlib/template
+++ b/srcpkgs/intel-gmmlib/template
@@ -1,7 +1,8 @@
 # Template file for 'intel-gmmlib'
 pkgname=intel-gmmlib
-version=22.0.1
-revision=1
+reverts="22.0.1_1"
+version=21.3.2
+revision=2
 archs="i686* x86_64*"
 wrksrc=gmmlib-intel-gmmlib-${version}
 build_style=cmake
@@ -19,7 +20,7 @@ maintainer="Stefano Ragni <st3r4g@protonmail.com>"
 license="MIT"
 homepage="https://github.com/intel/gmmlib"
 distfiles="https://github.com/intel/gmmlib/archive/intel-gmmlib-${version}.tar.gz"
-checksum=341eb3fa478e427e5a6f03d4cbc97bc2b02c52728dcf06c4794661d34b7c6e5c
+checksum=a6a61ff7e66cb710be1593f2afbda3b21c679fe953bf5e80a5b3f047c1cbdb6c
 
 lib32disabled=yes
 

--- a/srcpkgs/intel-media-driver/template
+++ b/srcpkgs/intel-media-driver/template
@@ -1,7 +1,8 @@
 # Template file for 'intel-media-driver'
 pkgname=intel-media-driver
-version=22.1.1
-revision=1
+reverts="22.1.1_1"
+version=21.3.5
+revision=2
 archs="x86_64*"
 wrksrc=media-driver-intel-media-${version}
 build_style=cmake
@@ -13,7 +14,7 @@ maintainer="Stefano Ragni <st3r4g@protonmail.com>"
 license="MIT, BSD-3-Clause"
 homepage="https://github.com/intel/media-driver"
 distfiles="https://github.com/intel/media-driver/archive/intel-media-${version}.tar.gz"
-checksum=6eaa4a9caf58faa8934b253adb4b0ece1c7d5de6f084167d5138b4e3ba423683
+checksum=182925ed21c0a9843a63865e34dc35bf713294260d14ceb29e8de0de2e34733f
 
 build_options="nonfree"
 desc_option_nonfree="Enable nonfree kernels"


### PR DESCRIPTION
- Revert "intel-media-driver: update to 22.1.1"
- Revert "intel-gmmlib: update to 22.0.1"

This works around a problem with firefox which crashes with the following message:

```
libva info: VA-API version 1.13.0
libva info: Trying to open /usr/lib64/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_13
   readlink -errno 13
```


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
