### PR TITLE
gitea: update to 1.16.1

### DIFF
--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -1,6 +1,6 @@
 # Template file for 'gitea'
 pkgname=gitea
-version=1.15.8
+version=1.16.1
 revision=1
 create_wrksrc=yes
 build_style=go
@@ -31,8 +31,8 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="MIT"
 homepage="https://gitea.io"
 changelog="https://github.com/go-gitea/gitea/blob/master/CHANGELOG.md"
-distfiles="https://github.com/go-gitea/gitea/releases/download/v${version}/gitea-src-${version}.tar.gz"
-checksum=a05745e5c1b5e9b51caa3d96fd93689176689865a0c249aa477d411e5c082045
+distfiles="https://github.com/go-gitea/gitea/releases/download/v1.16.1/gitea-src-1.16.1.tar.gz"
+checksum=09a27a06bf12cbef06ba823c516c6c9f7a06129e91dd7e64be5f6f0ca641d5b7
 
 system_accounts="_gitea"
 _gitea_homedir="/var/lib/gitea"

--- a/srcpkgs/gitea/template
+++ b/srcpkgs/gitea/template
@@ -31,7 +31,7 @@ maintainer="fosslinux <fosslinux@aussies.space>"
 license="MIT"
 homepage="https://gitea.io"
 changelog="https://github.com/go-gitea/gitea/blob/master/CHANGELOG.md"
-distfiles="https://github.com/go-gitea/gitea/releases/download/v1.16.1/gitea-src-1.16.1.tar.gz"
+distfiles="https://github.com/go-gitea/gitea/releases/download/v${version}/gitea-src-${version}.tar.gz"
 checksum=09a27a06bf12cbef06ba823c516c6c9f7a06129e91dd7e64be5f6f0ca641d5b7
 
 system_accounts="_gitea"


### PR DESCRIPTION
PS: Already released 1.16.1 but not for download src version...

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64 libc
