### PR TITLE
vscode: update to 1.65.1

### DIFF
--- a/srcpkgs/vscode/patches/disable-crash-reporter.patch
+++ b/srcpkgs/vscode/patches/disable-crash-reporter.patch
@@ -13,20 +13,6 @@ So, disable it entirely. No cookies for you, Visual Studio Code team.
  src/vs/code/electron-main/app.ts |  2 +-
  3 files changed, 1 insertion(+), 20 deletions(-)
 
-diff --git a/src/bootstrap-fork.js b/src/bootstrap-fork.js
-index f7b07e49255..576c82f23e8 100644
---- a/src/bootstrap-fork.js
-+++ b/src/bootstrap-fork.js
-@@ -37,9 +37,6 @@ if (process.env['VSCODE_PARENT_PID']) {
- 	terminateWhenParentTerminates();
- }
- 
--// Configure Crash Reporter
--configureCrashReporter();
--
- // Load AMD entry point
- require('./bootstrap-amd').load(process.env['VSCODE_AMD_ENTRYPOINT']);
- 
 diff --git a/src/main.js b/src/main.js
 index ad838aa245e..e6319e100b9 100644
 --- a/src/main.js

--- a/srcpkgs/vscode/patches/product.patch
+++ b/srcpkgs/vscode/patches/product.patch
@@ -1,19 +1,18 @@
 diff --git a/product.json b/product.json
-index 22e93d4b7c3..335cddd4c7c 100644
+index 9d630f23cd7..eea95dce319 100644
 --- a/product.json
 +++ b/product.json
-@@ -25,13 +25,22 @@
+@@ -27,6 +27,9 @@
  	"licenseFileName": "LICENSE.txt",
  	"reportIssueUrl": "https://github.com/microsoft/vscode/issues/new",
  	"urlProtocol": "code-oss",
 +	"quality": "stable",
 +	"documentationUrl": "https://github.com/microsoft/vscode-docs",
 +	"requestFeatureUrl": "https://github.com/Microsoft/vscode/issues",
- 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/insider/c42793d0357ff9c6589cce79a847177fd42852ee/out/vs/workbench/contrib/webview/browser/pre/",
+ 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/insider/93a2a2fa12dd3ae0629eec01c05a28cb60ac1c4b/out/vs/workbench/contrib/webview/browser/pre/",
  	"extensionAllowedProposedApi": [
  		"ms-vscode.vscode-js-profile-flame",
- 		"ms-vscode.vscode-js-profile-table",
-+		"ms-python.python",
+@@ -34,6 +37,11 @@
  		"GitHub.remotehub",
  		"GitHub.remotehub-insiders"
  	],

--- a/srcpkgs/vscode/patches/ripgrep.patch
+++ b/srcpkgs/vscode/patches/ripgrep.patch
@@ -1,32 +1,32 @@
-Ping q66 if this needs updating.
+Ping atk if this needs updating.
 
 This prevents vscode from fetching prebuilt ripgrep from Microsoft
 during build, which unbreaks build on platforms where MS deos not
 ship a prebuilt ripgrep.
 
 diff --git a/package.json b/package.json
-index 6d1fb7cca0c..057ed39ac31 100644
+index 5d6022a2a40..f66ee44eef0 100644
 --- a/package.json
 +++ b/package.json
-@@ -83,7 +83,7 @@
-     "vscode-oniguruma": "1.6.1",
-     "vscode-proxy-agent": "^0.11.0",
-     "vscode-regexpp": "^3.1.0",
--    "vscode-ripgrep": "^1.12.1",
-+    "vscode-ripgrep": "https://github.com/q66/vscode-ripgrep.git",
-     "vscode-textmate": "5.5.0",
-     "xterm": "4.16.0-beta.2",
-     "xterm-addon-search": "0.9.0-beta.6",
+@@ -63,7 +63,7 @@
+     "@parcel/watcher": "2.0.5",
+     "@vscode/debugprotocol": "1.51.0",
+     "@vscode/iconv-lite-umd": "0.7.0",
+-    "@vscode/ripgrep": "^1.14.1",
++    "@vscode/ripgrep": "https://github.com/atk/void-vscode-ripgrep.git",
+     "@vscode/sqlite3": "4.0.12",
+     "@vscode/sudo-prompt": "9.3.1",
+     "@vscode/vscode-languagedetection": "1.0.21",
 diff --git a/remote/package.json b/remote/package.json
-index 662ce3568ab..a79fe3764d9 100644
+index 4bc40998093..9d22d408c02 100644
 --- a/remote/package.json
 +++ b/remote/package.json
-@@ -22,7 +22,7 @@
-     "vscode-oniguruma": "1.6.1",
-     "vscode-proxy-agent": "^0.11.0",
-     "vscode-regexpp": "^3.1.0",
--    "vscode-ripgrep": "^1.12.1",
-+    "vscode-ripgrep": "https://github.com/q66/vscode-ripgrep.git",
-     "vscode-textmate": "5.5.0",
-     "xterm": "4.16.0-beta.2",
-     "xterm-addon-search": "0.9.0-beta.6",
+@@ -6,7 +6,7 @@
+     "@microsoft/applicationinsights-web": "^2.6.4",
+     "@parcel/watcher": "2.0.5",
+     "@vscode/iconv-lite-umd": "0.7.0",
+-    "@vscode/ripgrep": "^1.14.1",
++    "@vscode/ripgrep": "https://github.com/atk/void-vscode-ripgrep.git",
+     "@vscode/vscode-languagedetection": "1.0.21",
+     "applicationinsights": "1.4.2",
+     "cookie": "^0.4.0",

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,17 +1,17 @@
 # Template file for 'vscode'
 pkgname=vscode
-version=1.63.2
+version=1.65.2
 revision=1
-_electronver=13.6.1
-hostmakedepends="pkg-config python nodejs yarn tar git ripgrep"
-makedepends="libxkbfile-devel libsecret-devel electron13"
-depends="libXtst libxkbfile nss dejavu-fonts-ttf xdg-utils ripgrep electron13"
+_electronver=13.6.7
+hostmakedepends="pkg-config python3 nodejs yarn tar git ripgrep"
+makedepends="libxkbfile-devel libsecret-devel libxml2-devel ncurses-devel electron13"
+depends="libXtst ncurses nss dejavu-fonts-ttf xdg-utils ripgrep electron13"
 short_desc="Microsoft Code for Linux"
-maintainer="shizonic <realtiaz@gmail.com>"
+maintainer="shizonic <realtiaz@gmail.com>, Alex Lohr <alex.lohr@logmein.com>"
 license="MIT"
 homepage="https://code.visualstudio.com/"
 distfiles="https://github.com/Microsoft/vscode/archive/${version}.tar.gz"
-checksum=21fc9bc17ba4cf480b1e006f298363d86215c339c480f8d781cabcfedad2d624
+checksum=bd59713f001c06b7f0eb5573dd9c020fc98328880e24e2a4281c57d1028ab06e
 nocross=yes # x64 build does not cut it, it contains native code
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
@@ -61,7 +61,6 @@ do_install() {
 	ln -sf /usr/lib/code-oss/resources/app/resources/linux/code.desktop ${DESTDIR}/usr/share/applications/code-oss.desktop
 	vmkdir usr/share/pixmaps
 	ln -sf /usr/lib/code-oss/resources/app/resources/linux/code.png ${DESTDIR}/usr/share/pixmaps/code-oss.png
-	ln -sf /usr/bin/rg ${DESTDIR}/usr/lib/code-oss/resources/app/node_modules.asar.unpacked/vscode-ripgrep/bin/rg
 	vsed \
 	-e "s|ELECTRON=.*|ELECTRON=/usr/lib/electron${_electronver%%.*}/electron|g" \
 	-e 's|"$CLI"|"$CLI" --app="${VSCODE_PATH}/resources/app"|g' \


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I changed q66's package to replace @vscode/ripgrep to a far simpler version that only exposes the correct path and thus should never need to change and also removes the requirement to copy over files.