### PR TITLE
topgrade: update to 8.2.0.

### DIFF
--- a/srcpkgs/topgrade/template
+++ b/srcpkgs/topgrade/template
@@ -1,6 +1,6 @@
 # Template file for 'topgrade'
 pkgname=topgrade
-version=8.0.3
+version=8.2.0
 revision=1
 build_style=cargo
 short_desc="Meta upgrade tool for pip, flatpak, your distro and everything else"
@@ -8,4 +8,8 @@ maintainer="jcgruenhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-darwish/topgrade"
 distfiles="https://github.com/r-darwish/topgrade/archive/v${version}.tar.gz"
-checksum=c60dd5ae7d1d3bcfe941ead9f088c4b0413b9a4561fb9154429faf86a43e0983
+checksum=54fe60ef70b21b34c50c0d342ec120aff3a9522ef44a9737f42d5700aed7a1c3
+
+post_install() {
+	vman topgrade.8
+}


### PR DESCRIPTION
Version bump, + we're shipping the man page now

#### Testing the changes
- I tested the changes in this PR: **YES**
