### PR TITLE
man-pages: fix links to moved manpages

### DIFF
--- a/srcpkgs/man-pages/template
+++ b/srcpkgs/man-pages/template
@@ -1,7 +1,7 @@
 # Template file for 'man-pages'
 pkgname=man-pages
 version=5.13
-revision=1
+revision=2
 short_desc="Linux Documentation Project (LDP) manual pages"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -37,6 +37,9 @@ do_install() {
 	# openssl-devel
 	mv man3/rand.3 man3/glibc-rand.3
 	mv man3/err.3 man3/glibc-err.3
+	# Fix references to these manpages
+	sed -i -e "s|.so man3/rand.3|.so man3/glibc-rand.3|" \
+	 -e "s|.so man3/err.3|.so man3/glibc-err.3|" man3/*
 	# Rename some glibc specific manpages
 	mv man1/{iconv.1,glibc-iconv.1}
 	mv man1/{ldd.1,glibc-ldd.1}


### PR DESCRIPTION
The template file renames `rand.3` and `err.3` to `glibc-rand.3` and `glibc-err.3` to resolve conflict with openssl manpages, but it doesn't fix manpages linking to the old version. These manpages (`warnx(3)`, `srand(3)` ...) then won't know where the manpages are. This PR redirects them to the renamed version.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**