### PR TITLE
ncurses: update to 6.3.

### DIFF
--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -1,7 +1,7 @@
 # Template file for 'ncurses'
 pkgname=ncurses
-version=6.2
-revision=4
+version=6.3
+revision=1
 bootstrap=yes
 configure_args="--enable-big-core"
 short_desc="System V Release 4.0 curses emulation library"
@@ -9,7 +9,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="http://www.gnu.org/software/ncurses/"
 distfiles="${GNU_SITE}/ncurses/$pkgname-$version.tar.gz"
-checksum=30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d
+checksum=97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059
 
 depends="ncurses-base-${version}_${revision}"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

fix [CVE-2021-39537](https://nvd.nist.gov/vuln/detail/CVE-2021-39537)

#### Testing the changes
- I tested the changes in this PR: **YES**

@Gottox 

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
