### PR TITLE
plasma-workspace: make krunner use the proper cwd

### DIFF
--- a/srcpkgs/plasma-workspace/patches/fix-krunner-cwd.patch
+++ b/srcpkgs/plasma-workspace/patches/fix-krunner-cwd.patch
@@ -1,0 +1,31 @@
+Commit 7ca34e0baa7fa65efc929eee5b6b0c3d2104db8e already reverted one
+change that caused the cwd of all apps spawned by krunner to
+erroneously be set to the root dir.
+
+That regressions is back so it's more robust to fix in within krunner.
+
+Signed-off-by: Andrea Arcangeli <aarcange@redhat.com>
+---
+ krunner/main.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/krunner/main.cpp b/krunner/main.cpp
+index 4593687ca..fa4a62ac4 100644
+--- a/krunner/main.cpp
++++ b/krunner/main.cpp
+@@ -12,6 +12,7 @@
+ #include <QDBusConnection>
+ #include <QDBusMessage>
+ #include <QDebug>
++#include <QDir>
+ #include <QQuickWindow>
+ #include <QSessionManager>
+ #include <QUrl>
+@@ -112,5 +113,6 @@ int main(int argc, char **argv)
+         }
+     });
+ 
++    QDir::setCurrent(QDir::homePath());
+     return app.exec();
+ }
+

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,7 +1,7 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
 version=5.23.5
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner


### PR DESCRIPTION
see:
- https://bugs.kde.org/show_bug.cgi?id=432975
- https://bugs.gentoo.org/767478
- https://gitweb.gentoo.org/proj/kde.git/tree/kde-plasma/plasma-workspace/files/plasma-workspace-5.22.5-krunner-cwd-at-home.patch?id=fdf904d0dbe13b7f91cb00d9720bc53e4b0f53fc

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
