### PR TITLE
Update OTPClient, libcotp and libbaseencode

### DIFF
--- a/srcpkgs/OTPClient/template
+++ b/srcpkgs/OTPClient/template
@@ -1,6 +1,6 @@
 # Template file for 'OTPClient'
 pkgname=OTPClient
-version=2.4.4
+version=2.4.8
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -11,4 +11,4 @@ maintainer="Ulf <void@uw.anonaddy.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/paolostivanin/OTPClient"
 distfiles="https://github.com/paolostivanin/OTPClient/archive/v${version}.tar.gz"
-checksum=5b976782906f15e2a4e001d73909a05f6146010cea83d78e3ad5c850f4049da4
+checksum=252dd4cad71ea19f26686a8c6cfdb12fb25100cb98694fd36eec1a4d28f39a23

--- a/srcpkgs/libbaseencode/template
+++ b/srcpkgs/libbaseencode/template
@@ -1,14 +1,14 @@
 # Template file for 'libbaseencode'
 pkgname=libbaseencode
-version=1.0.9
-revision=2
+version=1.0.12
+revision=1
 build_style=cmake
 short_desc="Library for encoding decoding data use base32 or base64"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/paolostivanin/libbaseencode"
 distfiles="https://github.com/paolostivanin/libbaseencode/archive/v${version}.tar.gz"
-checksum=a183d7cf30d931b2a078d6f0ef64616b71ab26f9258e5f4e191778c7ace7175d
+checksum=ee9d4cc198d48365633274f41bd1b0eae12f9bef49182ea20050aa68f60e09b6
 
 libbaseencode-devel_package() {
 	depends="libbaseencode-${version}_${revision}"

--- a/srcpkgs/libcotp/template
+++ b/srcpkgs/libcotp/template
@@ -1,6 +1,6 @@
 # Template file for 'libcotp'
 pkgname=libcotp
-version=1.2.2
+version=1.2.4
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/paolostivanin/libcotp"
 distfiles="https://github.com/paolostivanin/libcotp/archive/v${version}.tar.gz"
-checksum=25b45ffa4aece5cc689503ebea7356a2f760c194f0c41805934495d2fe7165b1
+checksum=6a077c6a8e785a542262f207fbb760f3d7d03649787c10cb01ea38c280dda070
 
 libcotp-devel_package() {
 	depends="libcotp-${version}_${revision}"


### PR DESCRIPTION
supersedes https://github.com/void-linux/void-packages/pull/35503

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
