### PR TITLE
libproxy: update to 0.4.17.

### DIFF
--- a/srcpkgs/libproxy/template
+++ b/srcpkgs/libproxy/template
@@ -1,18 +1,18 @@
 # Template file for 'libproxy'
 pkgname=libproxy
-version=0.4.15
+version=0.4.17
 revision=1
 build_style=cmake
 configure_args="-DWITH_GNOME=0 -DWITH_KDE4=0 -DWITH_MOZJS=0 -DWITH_NM=0
  -DWITH_PERL=0 -DWITH_PYTHON=1 -DWITH_WEBKIT=0"
 hostmakedepends="pkg-config python"
 makedepends="zlib-devel"
-short_desc="A library handling all the details of proxy configuration"
+short_desc="Library handling all the details of proxy configuration"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-2.1-or-later"
 homepage="http://github.com/libproxy/libproxy"
-license="LGPL-2.1"
 distfiles="https://github.com/libproxy/libproxy/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=18f58b0a0043b6881774187427ead158d310127fc46a1c668ad6d207fb28b4e0
+checksum=88c624711412665515e2800a7e564aabb5b3ee781b9820eca9168035b0de60a9
 
 libproxy-devel_package() {
 	depends="libproxy>=${version}_${revision}"


### PR DESCRIPTION
- fix [CVE-2020-25219](https://nvd.nist.gov/vuln/detail/CVE-2020-25219)
- fix [CVE-2020-26154](https://nvd.nist.gov/vuln/detail/CVE-2020-26154)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

I don't know how to test this since there is almost no documentation on how to use `/usr/bin/proxy` but given there's no soname bump it should probably work fine.

Automated tests fail with same output on the old version.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - i686
