### PR TITLE
monero, monero-gui: update to 0.17.3.0

### DIFF
--- a/srcpkgs/monero-gui/template
+++ b/srcpkgs/monero-gui/template
@@ -1,9 +1,9 @@
 # Template file for 'monero-gui'
 pkgname=monero-gui
-version=0.17.2.3
+version=0.17.3.1
 revision=1
-_monero_version=0.17.2.3
-_randomx_version="1.1.9"
+_monero_version=0.17.3.0
+_randomx_version="1.1.10"
 # the revision monero uses as a submodule for the specific version
 _rapidjson_gitrev="129d19ba7f496df5e33658527a7158c79b99c21c"
 _supercop_gitrev="633500ad8c8759995049ccd022107d1fa8a1bbc9"
@@ -26,9 +26,9 @@ distfiles="https://github.com/monero-project/monero-gui/archive/v${version}.tar.
  https://github.com/Tencent/rapidjson/archive/${_rapidjson_gitrev}.tar.gz
  https://github.com/monero-project/supercop/archive/${_supercop_gitrev}.tar.gz
  https://github.com/dlbeer/quirc/archive/${_quirc_gitrev}.tar.gz"
-checksum="aeab35380282b0403be926b78d5249df2f97f9cbe36bb374ac39daf4f02bb349
- e4462f8909bdc5e66d76f4023374ff759159c15fe7d407f0c21619769e87c35d
- b878fd6ea6d4e1dcdfa085427ce4666c1085e8c5a9e049c04ca2036b4aead0f5
+checksum="91d66f093ada1a434e41f2df070a85a114d20d7de2d937120180de01501d7f49
+ 23d56d0c366576ff49bd785290a3e6377d4e51156e70ce4bb774b3d70f8cada4
+ 051cee65700a10adef84e7946416068bc805757683378a854a1b168ec18da783
  44b007d419ac21b6affec58991e865ee572346ead19b73cf1c3e4e11c7a81273
  b973b9d8269ec4d97c3c3443f0dad96d09f72b1b30e616e0947557adbdbb03f7
  c8366aecb6ba48ec50a7e579a4fa18eb55c3c4be7d3efb2a83726157977f4ca6"

--- a/srcpkgs/monero/patches/system-miniupnpc.patch
+++ b/srcpkgs/monero/patches/system-miniupnpc.patch
@@ -54,8 +54,10 @@ index 9b21705e..76340a22 100644
 -find_package(Miniupnpc REQUIRED)
 -
 -message(STATUS "Using in-tree miniupnpc")
+ set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
 -add_subdirectory(miniupnp/miniupnpc)
 -set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
+-set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 -if(MSVC)
 -  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
 -elseif(NOT MSVC)
@@ -83,6 +85,7 @@ index 9b21705e..76340a22 100644
 +  add_subdirectory(miniupnp/miniupnpc)
 +
 +  set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
++  set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
 +  if(MSVC)
 +    set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
 +  elseif(NOT MSVC)

--- a/srcpkgs/monero/template
+++ b/srcpkgs/monero/template
@@ -1,8 +1,8 @@
 # Template file for 'monero'
 pkgname=monero
-version=0.17.2.3
-revision=2
-_randomx_version="1.1.9"
+version=0.17.3.0
+revision=1
+_randomx_version="1.1.10"
 # the revision monero uses as a submodule for the specific version
 _rapidjson_gitrev="129d19ba7f496df5e33658527a7158c79b99c21c"
 _supercop_gitrev="633500ad8c8759995049ccd022107d1fa8a1bbc9"
@@ -23,8 +23,8 @@ distfiles="https://github.com/monero-project/monero/archive/v${version}.tar.gz
  https://github.com/tevador/RandomX/archive/v${_randomx_version}.tar.gz
  https://github.com/Tencent/rapidjson/archive/${_rapidjson_gitrev}.tar.gz
  https://github.com/monero-project/supercop/archive/${_supercop_gitrev}.tar.gz"
-checksum="e4462f8909bdc5e66d76f4023374ff759159c15fe7d407f0c21619769e87c35d
- b878fd6ea6d4e1dcdfa085427ce4666c1085e8c5a9e049c04ca2036b4aead0f5
+checksum="23d56d0c366576ff49bd785290a3e6377d4e51156e70ce4bb774b3d70f8cada4
+ 051cee65700a10adef84e7946416068bc805757683378a854a1b168ec18da783
  44b007d419ac21b6affec58991e865ee572346ead19b73cf1c3e4e11c7a81273
  b973b9d8269ec4d97c3c3443f0dad96d09f72b1b30e616e0947557adbdbb03f7"
 skip_extraction="v${_randomx_version}.tar.gz ${_rapidjson_gitrev}.tar.gz ${_supercop_gitrev}.tar.gz"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes

I tested the changes in this PR: **YES**

I tested monerod, p2pool is running now, monero-wallet-gui still connects to my local monerod and shows the right balance and generally looks as expected.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing

I built this PR locally for my native architecture, (ARCH-LIBC)

<!-- 
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
