### PR TITLE
xorg-server: enable privilege-less Xorg 

### DIFF
--- a/srcpkgs/xorg-server/template
+++ b/srcpkgs/xorg-server/template
@@ -1,14 +1,14 @@
 # Template file for 'xorg-server'
 pkgname=xorg-server
 version=21.1.3
-revision=3
+revision=4
 build_style=meson
 configure_args="-Dipv6=true -Dxorg=true -Dxnest=true -Dxephyr=true
  -Dxvfb=true -Dhal=false -Dudev=true -Dxkb_dir=/usr/share/X11/xkb
  -Dxkb_output_dir=/var/lib/xkb
  -Dlinux_acpi=true -Dlinux_apm=false -Dsuid_wrapper=true
  -Dxcsecurity=true -Dsystemd_logind=$(vopt_if elogind true false)
- -Dglamor=true -Ddri2=true -Ddri3=true -Dglx=true"
+ -Dglamor=true -Ddri2=true -Ddri3=true -Dglx=true -Ddrm=true"
 hostmakedepends="pkg-config xkbcomp flex"
 makedepends="MesaLib-devel libXaw-devel libXfont-devel libXfont2-devel
  libXrender-devel libXres-devel libXtst-devel libXv-devel libXxf86dga-devel
@@ -17,7 +17,7 @@ makedepends="MesaLib-devel libXaw-devel libXfont-devel libXfont2-devel
  xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel xkbcomp
  nettle-devel libxcvt-devel font-util $(vopt_if elogind 'dbus-devel')"
 # See hw/xfree86/common/xf86Module.h. Only care for the major version.
-depends="xkeyboard-config $(vopt_if elogind 'elogind') xorg-server-common"
+depends="xkeyboard-config xorg-server-common"
 checkdepends="xkeyboard-config"
 short_desc="X11 server from X.org"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
@@ -33,6 +33,7 @@ conf_files="/etc/X11/Xwrapper.config"
 
 build_options="elogind"
 desc_option_elogind="Rootless Xorg support with elogind"
+build_options_default="elogind"
 
 # disable VBE on non-x86 systems
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**  
  I haven't daily driven these changes, but the affected areas I've tested, and I believe anyone who has the right groups should be alright.

There's actually no dependency on any library but DBus when enabling elogind, so I removed that false dependency. Changing `Xwrapper.config` to have `auto` by default should  prevent breaking anyone's system.