### PR TITLE
wine: add xshm build option

### DIFF
--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -6,7 +6,7 @@ _pkgver=${version/r/-r}
 create_wrksrc=yes
 build_wrksrc=wine-${_pkgver}
 build_style=gnu-configure
-configure_args="--bindir=/usr/libexec/wine"
+configure_args="--bindir=/usr/libexec/wine $(vopt_with xshm)"
 short_desc="Run Microsoft Windows applications"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
@@ -16,10 +16,11 @@ distfiles="https://dl.winehq.org/wine/source/${version%.*}.x/wine-${_pkgver}.tar
 checksum="113c130eed2f3256c932ffbb7f482a0533ed3ac5c62c979622a2a6df7f9f636a
  7716daf2a24b61a37d356478639bc8e3a45833a9d9e4d8b7b506fa60f6ce76b2"
 
-build_options="mingw staging"
-build_options_default="mingw"
+build_options="mingw staging xshm"
+build_options_default="mingw xshm"
 desc_option_mingw="Use the MinGW cross compiler to build WinPE DLLs"
 desc_option_staging="Apply the wine-staging patchset"
+desc_option_xshm="Enable support for the X Shared Memory Extension"
 
 lib32mode=full
 archs="i686* x86_64*"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This PR adds the `xshm` build option to control support for the X Shared Memory Extension (Xshm).

The reason for this change is that I run Wine in an LXD container that doesn't have access to the hosts shared memory (`/dev/shm`). Wine will print the error message
```
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  130 (MIT-SHM)
  Minor opcode of failed request:  3 (X_ShmPutImage)
  Value in failed request:  0xb40
  Serial number of failed request:  535
  Current serial number in output stream:  539
```
which results in corrupted graphics, making Wine applications unusable.

To work around this issue I disabled the Xshm extension on the host, but this can result in performance issues. The `xshm` build option allows me to disable Xshm support in Wine, while having it enabled for all other applications.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
