### PR TITLE
lilypond: update to 2.23.6

### DIFF
--- a/srcpkgs/lilypond-doc/template
+++ b/srcpkgs/lilypond-doc/template
@@ -1,6 +1,6 @@
 # Template file for 'lilypond-doc'
 pkgname=lilypond-doc
-version=2.23.5
+version=2.23.6
 revision=1
 create_wrksrc=yes
 short_desc="Documentation for the lilypond music engraving program"
@@ -8,7 +8,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="https://lilypond.org/"
 distfiles="https://lilypond.org/downloads/binaries/documentation/lilypond-${version}-1.documentation.tar.bz2"
-checksum=e2b528b3ce70058b634fd76b097f975760c0ad86148d9ec63b66c73a941b0afd
+checksum=1fada73c22dbcfa6224744a8ad87e10cced784f98fd9243768c96ee5bc0ee45d
 
 do_install() {
 	vmkdir usr

--- a/srcpkgs/lilypond/template
+++ b/srcpkgs/lilypond/template
@@ -1,6 +1,6 @@
 # Template file for 'lilypond'
 pkgname=lilypond
-version=2.23.5
+version=2.23.6
 revision=1
 build_wrksrc="build"
 build_style="gnu-configure"
@@ -17,7 +17,7 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="https://lilypond.org/"
 distfiles="https://lilypond.org/downloads/sources/v2.23/lilypond-${version}.tar.gz"
-checksum=53fd289eac318356003bf19b2d9e8ec43cb32e2ea926363145c1b26482bd1678
+checksum=a179bd974a0e64390efef5bb0cc1e7287f1218237548433adba51c4f25bba2ce
 python_version=3
 
 if [ -n "${CROSS_BUILD}" ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- tested on x86_64 and i686
- check on i686 fails again due to floating point stuff

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
