### PR TITLE
New package: pleroma-2.4.3

### DIFF
--- a/srcpkgs/pleroma/INSTALL
+++ b/srcpkgs/pleroma/INSTALL
@@ -1,0 +1,7 @@
+if [ "${UPDATE}" = "no" ] && [ "${ACTION}" = "post" ]; then
+	if [ ! -e /etc/pleroma/COOKIE ]; then
+		dd if=/dev/urandom bs=40 count=1 | base64 > /etc/pleroma/COOKIE
+	fi
+	chmod 600 /etc/pleroma/COOKIE
+	chown _pleroma:_pleroma /etc/pleroma/COOKIE
+fi

--- a/srcpkgs/pleroma/files/pleroma/finish
+++ b/srcpkgs/pleroma/files/pleroma/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec chpst -u _pleroma:_pleroma pleroma stop

--- a/srcpkgs/pleroma/files/pleroma/log/run
+++ b/srcpkgs/pleroma/files/pleroma/log/run
@@ -1,0 +1,1 @@
+/usr/bin/vlogger

--- a/srcpkgs/pleroma/files/pleroma/run
+++ b/srcpkgs/pleroma/files/pleroma/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+chpst -u _pleroma:_pleroma pleroma_ctl migrate
+exec chpst -u _pleroma:_pleroma pleroma start

--- a/srcpkgs/pleroma/patches/append_flags.patch
+++ b/srcpkgs/pleroma/patches/append_flags.patch
@@ -1,0 +1,15 @@
+diff --git a/deps/crypt/c_src/Makefile b/deps/crypt/c_src/Makefile
+index 9c7e70b..ab31c50 100644
+--- a/deps/crypt/c_src/Makefile
++++ b/deps/crypt/c_src/Makefile
+@@ -25,8 +25,8 @@ else ifeq ($(UNAME_SYS), Linux)
+ 		CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+ 		LDFLAGS ?= -lcrypt
+   else
+-		CFLAGS ?= -DHAVE_CRYPT_R -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+-		LDFLAGS ?= -lpthread -lcrypt
++		CFLAGS += -DHAVE_CRYPT_R -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
++		LDFLAGS += -lpthread -lcrypt
+   endif
+ else ifneq (,$(wildcard /usr/lib/libcrypt.*))
+ 	CC ?= cc

--- a/srcpkgs/pleroma/patches/config.patch
+++ b/srcpkgs/pleroma/patches/config.patch
@@ -1,0 +1,20 @@
+diff --git a/config/config.exs b/config/config.exs
+index b50c910..9cf622b 100644
+--- a/config/config.exs
++++ b/config/config.exs
+@@ -852,6 +852,8 @@
+   {Pleroma.Web.ActivityPub.MRF.MediaProxyWarmingPolicy, [max_running: 5, max_waiting: 5]}
+ ]
+ 
++config :tzdata, :data_dir, "/var/lib/pleroma/elixir_tzdata_data"
++
+ # Import environment specific config. This must remain at the bottom
+ # of this file so it overrides the configuration defined above.
+ import_config "#{Mix.env()}.exs"
+diff --git a/config/prod.secret.exs b/config/prod.secret.exs
+new file mode 100644
+index 0000000..23fd9f1
+--- /dev/null
++++ b/config/prod.secret.exs
+@@ -0,0 +1 @@
++import Mix.Config

--- a/srcpkgs/pleroma/patches/include_system_erts.patch
+++ b/srcpkgs/pleroma/patches/include_system_erts.patch
@@ -1,0 +1,14 @@
+diff --git a/mix.exs b/mix.exs
+index db2f1f0..115817c 100644
+--- a/mix.exs
++++ b/mix.exs
+@@ -38,7 +38,8 @@ def project do
+           include_executables_for: [:unix],
+           applications: [ex_syslogger: :load, syslog: :load, eldap: :transient],
+           steps: [:assemble, &put_otp_version/1, &copy_files/1, &copy_nginx_config/1],
+-          config_providers: [{Pleroma.Config.ReleaseRuntimeProvider, []}]
++          config_providers: [{Pleroma.Config.ReleaseRuntimeProvider, []}],
++          include_erts: "/usr/lib/erlang/erts-12.3"
+         ]
+       ]
+     ]

--- a/srcpkgs/pleroma/template
+++ b/srcpkgs/pleroma/template
@@ -1,0 +1,75 @@
+# Template file for 'pleroma'
+pkgname=pleroma
+version=2.4.3
+revision=1
+wrksrc="pleroma-v${version}"
+hostmakedepends="cmake elixir rebar3 git"
+makedepends="file-devel erlang"
+short_desc="Social networking software compatible with other Fediverse software"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="AGPL-3.0-only,CC-BY-4.0,CC-BY-SA-4.0,custom:Unsplash"
+homepage="https://pleroma.social"
+distfiles="https://git.pleroma.social/pleroma/pleroma/-/archive/v${version}/pleroma-v${version}.tar.gz"
+checksum=4362a8396f588fc611d9dae891e54e9473c34443eb718fe109dab09578809d78
+
+system_accounts="_pleroma"
+_pleroma_homedir="/var/lib/pleroma"
+
+make_dirs="/var/lib/pleroma 0700 _pleroma _pleroma
+ /etc/pleroma 0755 _pleroma _pleroma
+ /etc/pleroma/static 0755 _pleroma _pleroma"
+
+export MIX_ENV=prod
+export MIX_REBAR3=/usr/bin/rebar3
+
+if [ "$CROSS_BUILD" ]; then
+	# fixes linking syslog dependency
+	LDFLAGS+=" -L${XBPS_CROSS_BASE}/usr/lib/erlang/usr/lib"
+fi
+
+post_extract() {
+	mix local.hex --force
+	mix deps.get --only prod
+}
+
+do_configure() {
+	if [ "$CROSS_BUILD" ]; then
+		# fixes building fast_html
+		_erts_path="$(cd ${XBPS_CROSS_BASE}/usr/lib/erlang/erts-* && pwd)"
+		vsed -i "s,ERLANG_PATH =.*,ERLANG_PATH = ${_erts_path}," deps/fast_html/Makefile
+		# additional adjustment to include target erts instead of host erts
+		vsed -i "s,include_erts: \"/usr,include_erts: \"${XBPS_CROSS_BASE}," mix.exs
+	fi
+}
+
+do_build() {
+	# without the DEBUG flag, mix gives unhelpful errors for diagnosing c library
+	# issues
+	DEBUG=1 mix release
+}
+
+do_install() {
+	vlicense COPYING
+	vlicense AGPL-3
+
+	cd _build/prod/rel/pleroma
+	vmkdir usr/lib/pleroma
+	vcopy erts-* usr/lib/pleroma
+	vcopy lib usr/lib/pleroma
+	# the Erlang Distribution cookie needs to be unique to each installation
+	rm releases/COOKIE
+	vcopy releases usr/lib/pleroma
+	ln -s /etc/pleroma/COOKIE ${DESTDIR}/usr/lib/pleroma/releases
+
+	# make entrypoint look in standard location instead of cwd
+	vsed -i 's,^RELEASE_ROOT=.*,RELEASE_ROOT="/usr/lib/pleroma",' bin/pleroma
+	vcopy bin usr/lib/pleroma
+
+	vmkdir usr/bin
+	ln -s /usr/lib/pleroma/bin/pleroma ${DESTDIR}/usr/bin/
+	ln -s /usr/lib/pleroma/bin/pleroma_ctl ${DESTDIR}/usr/bin/
+
+	vsconf installation/pleroma.nginx
+
+	vsv pleroma
+}

--- a/srcpkgs/pleroma/update
+++ b/srcpkgs/pleroma/update
@@ -1,0 +1,1 @@
+site="https://git.pleroma.social/pleroma/pleroma/-/tags"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I've been running this successfully on my x86_64-glibc server, and just tested it briefly on armv7l-glibc (rpi2) and it worked great. 

This does require a PostgreSQL installation with the `postgresql*-contrib` package for it's version, but not a specific version, so I didn't want to enforce a specific version by putting it in depends.

I patched the release to not include ERTS and instead use the ERTS included in the `erlang` package, which is one way to deal with cross-builds. Another would be (I think) instead of patching it as `include_erts: false`, just do `include_erts: /${XBPS_CROSS_BASE}/usr/lib/erlang/erts-*` or something similar depending on whether it's a cross-build or not.

For the licenses, I included every license mentioned in COPYING. If this is too much, I think it would be possible to remove some of the assets without too much work.