### PR TITLE
xkeyboard-config: use intltool again.

### DIFF
--- a/srcpkgs/xkeyboard-config/template
+++ b/srcpkgs/xkeyboard-config/template
@@ -1,10 +1,10 @@
 # Template file for 'xkeyboard-config'
 pkgname=xkeyboard-config
 version=2.35.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dxorg-rules-symlinks=true -Dcompat-rules=true"
-hostmakedepends="pkg-config libxslt python3 perl"
+hostmakedepends="pkg-config libxslt python3 intltool perl"
 makedepends="libX11-devel xkbcomp"
 depends="xkbcomp"
 short_desc="X Keyboard Configuration Database"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Sorry, I missed the locales part @leahneukirchen
I added intltool again. I thought it was part of the autotools build system so I removed it... :/

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
