### PR TITLE
xf86-input-libinput: update to 1.2.1.

### DIFF
--- a/srcpkgs/xf86-input-libinput/template
+++ b/srcpkgs/xf86-input-libinput/template
@@ -1,6 +1,6 @@
 # Template file for 'xf86-input-libinput'
 pkgname=xf86-input-libinput
-version=1.2.0
+version=1.2.1
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
@@ -12,8 +12,8 @@ license="MIT"
 homepage="https://xorg.freedesktop.org/"
 # no official changelog
 #changelog="https://gitlab.freedesktop.org/xorg/driver/xf86-input-libinput/-/commits/master/"
-distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.bz2"
-checksum=f80da3c514fe1cbf57fa1b1bd6ff97f6b0a1f87466ad89247bac59cd0a5869f6
+distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.xz"
+checksum=8151db5b9ddb317c0ce92dcb62da9a8db5079e5b8a95b60abc854da21e7e971b
 lib32disabled=yes
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
