### PR TITLE
shadow: increase maximum group name length to 32 (from 16).

### DIFF
--- a/srcpkgs/shadow/template
+++ b/srcpkgs/shadow/template
@@ -1,12 +1,13 @@
 # Template file for 'shadow'
 pkgname=shadow
 version=4.8.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--bindir=/usr/bin --sbindir=/usr/bin
  --enable-shared --disable-static
  --with-libpam --without-selinux --with-acl --with-attr --without-su
- --disable-nls --enable-subordinate-ids --disable-account-tools-setuid"
+ --disable-nls --enable-subordinate-ids --disable-account-tools-setuid
+ --with-group-name-max-length=32"
 hostmakedepends="libtool"
 makedepends="acl-devel pam-devel"
 depends="pam"


### PR DESCRIPTION
This is already the case for usernames, so why not groups?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
