### PR TITLE
xbps-src: fix wording

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -157,8 +157,8 @@ $(print_cross_targets)
 -C  Do not remove build directory, automatic dependencies and
     package destdir after successful install.
 
--E  If a binary package exists in a local repository for the target package,
-    do not try to build it, exit immediately.
+-E  If a binary package exists in a repository for the target package, do not
+    try to build it, exit immediately.
 
 -f  Force running the specified stage (configure/build/install/pkg)
     even if it ran successfully.


### PR DESCRIPTION
I don't know if I understand this wrong but building is also skipped when its in any repository, not just local ones.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
