### PR TITLE
syncthing-gtk: restore sane versioning, fix tests

### DIFF
--- a/srcpkgs/syncthing-gtk/template
+++ b/srcpkgs/syncthing-gtk/template
@@ -1,18 +1,29 @@
 # Template file for 'syncthing-gtk'
 pkgname=syncthing-gtk
-reverts="0.14.36_1"
-version=0.9.4.4+ds+git20220108+9023143f8b93
-revision=2
+reverts="0.14.36_1 0.9.4.4+ds+git20220108+9023143f8b93_1
+ 0.9.4.4+ds+git20220108+9023143f8b93_2"
+version=0.9.4.4
+revision=4
+_debianver="ds+git20220108+9023143f8b93"
 build_style=python3-module
 hostmakedepends="python3-setuptools gettext"
 depends="syncthing python3-dateutil libnotify librsvg python3-bcrypt
  python3-cairo gtk+3 python3-gobject"
+checkdepends="$depends"
 short_desc="GTK based GUI for Syncthing"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="GPL-2.0-or-later"
 homepage="https://salsa.debian.org/debian/syncthing-gtk/"
-distfiles="${DEBIAN_SITE}/main/s/syncthing-gtk/syncthing-gtk_${version}.orig.tar.xz"
+distfiles="${DEBIAN_SITE}/main/s/syncthing-gtk/syncthing-gtk_${version}+${_debianver}.orig.tar.xz"
 checksum=fc71f390a17b10ea9338a60f7ae813a6d6faa7e881b4b31ff7ea4ffdbbecf7a8
+
+# for checks
+# v0.9.4.4-ds-git20220108-9023143f8b93 is an invalid version and will not be supported in a future release
+# remove windows.py
+post_extract() {
+	mv ${XBPS_BUILDDIR}/syncthing* ${wrksrc}
+	rm ${wrksrc}/syncthing_gtk/windows.py
+}
 
 pre_configure() {
 	./generate-locales.sh


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

cc @paper42 

#### Testing the changes
- I tested the changes in this PR: **briefly**

The new debian version scheme did throw errors like
```
/usr/lib/python3.10/site-packages/pkg_resources/__init__.py:116: PkgResourcesDeprecationWarning: v0.9.4.4-ds-git20220108-9023143f8b93 is an invalid version and will not be supported in a future release
```

This PR restores the old versioning scheme by adding the the following precautions:
* Users on `0.9.4.4` get upgraded to this version due to revision (last in this scheme was 3)
* Users on `0.9.4.4+ds+git20220108+9023143f8b93` get reverted to the old versioning scheme but on this revision

On top of that I added some `checkdepends` to make the checks succeed atleast to a certain point. I'm totally unsure why this wasn't an issue in the past, did anything change there? However, I'm stuck with the check error as seen on CI. Help appreciated.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
