### PR TITLE
mpv-mpris: update to 0.6

### DIFF
--- a/srcpkgs/mpv-mpris/template
+++ b/srcpkgs/mpv-mpris/template
@@ -1,7 +1,7 @@
 # Template file for 'mpv-mpris'
 pkgname=mpv-mpris
-version=0.5
-revision=2
+version=0.6
+revision=1
 build_style=gnu-makefile
 make_build_target=mpris.so
 hostmakedepends="pkg-config"
@@ -12,11 +12,11 @@ maintainer="Alif Rachmawadi <arch@subosito.com>"
 license="MIT"
 homepage="https://github.com/hoyon/mpv-mpris"
 distfiles="https://github.com/hoyon/mpv-mpris/archive/${version}.tar.gz"
-checksum=673aff031e7cc741edea68d7b4b0103d7b031d4a55755abb9e1be5dd4ec4e969
+checksum=8b4493cc29d09f175d6f55e6905e77429228b51241f2ae4c3681e35fefef9ae8
 
 do_install() {
 	vlicense LICENSE
 	vdoc README.md
-	vmkdir usr/lib/${pkgname}
-	vinstall mpris.so 0644 usr/lib/${pkgname}
+	vmkdir etc/mpv/scripts
+	vinstall mpris.so 0644 etc/mpv/scripts
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, aarch64-glibc

I also updated the install directory to `etc/mpv/scripts` as stated in the [package homepage](673aff031e7cc741edea68d7b4b0103d7b031d4a55755abb9e1be5dd4ec4e969) is where mpv actually looks for scripts. It was not being located properly in `/usr/lib/mpv-mpris`. 