### PR TITLE
libpwquality: depend on cracklib

### DIFF
--- a/srcpkgs/libpwquality/template
+++ b/srcpkgs/libpwquality/template
@@ -1,11 +1,12 @@
 # Template file for 'libpwquality'
 pkgname=libpwquality
 version=1.4.2
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-static --enable-pam --with-securedir=/usr/lib/security"
 hostmakedepends="libtool automake gettext-devel python3-devel"
 makedepends="cracklib-devel pam-devel python3-devel"
+depends="cracklib"
 conf_files="/etc/security/pwquality.conf"
 short_desc="Library for password quality checking and generating random passwords"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"


### PR DESCRIPTION
This fixes an issue in which seahorse could not determine the strength of a password:
```
/usr/share/cracklib/pw_dict.pwd: No such file or directory
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
