### PR TITLE
runit-void: Standardise/improve os-release

### DIFF
--- a/srcpkgs/runit-void/files/os-release
+++ b/srcpkgs/runit-void/files/os-release
@@ -1,4 +1,9 @@
-NAME="void"
+NAME="Void"
 ID="void"
+PRETTY_NAME="Void Linux"
+HOME_URL="https://voidlinux.org/"
+DOCUMENTATION_URL="https://docs.voidlinux.org/"
+LOGO="void-logo"
+ANSI_COLOR="0;38;2;71;128;97"
+
 DISTRIB_ID="void"
-PRETTY_NAME="void"

--- a/srcpkgs/runit-void/template
+++ b/srcpkgs/runit-void/template
@@ -1,7 +1,7 @@
 # Template file for 'runit-void'
 pkgname=runit-void
 version=20210314
-revision=2
+revision=3
 wrksrc="void-runit-${version}"
 build_style=gnu-makefile
 short_desc="Void Linux runit scripts"
@@ -32,10 +32,12 @@ post_install() {
 	vmkdir usr/bin
 	mv ${DESTDIR}/usr/sbin/* ${DESTDIR}/usr/bin
 	vconf ${FILESDIR}/hostname
-	vconf ${FILESDIR}/os-release
 	vconf ${FILESDIR}/locale.conf
 	vinstall ${FILESDIR}/apparmor 644 /etc/default/
 	vinstall ${FILESDIR}/09-apparmor.sh 644 /etc/runit/core-services/
+	vmkdir usr/lib
+	vinstall ${FILESDIR}/os-release 644 /usr/lib/
+	ln -s ../usr/lib/os-release ${DESTDIR}/etc/os-release
 	# Enable services at post-install time instead.
 	rm -f ${DESTDIR}/etc/runit/runsvdir/current
 	rm -rf ${DESTDIR}/etc/runit/runsvdir/default


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- - -

This PR aims to bring the `os-release` file up to the same quality and standards as in other distributions.

There was a prior attempt to update `os-release` (#12160), but that included some fairly unusual departures; here I have made a point to change as little as possible while still providing useful and expected functionality.

I did leave the `DISTRIB_ID` variable intact, despite it not being part of the specification. Hopefully this will prevent any compatibility issues.

- - -

Special interest pings (for feedback):
@the-maldridge for Ansible compatibility.
@Vaelatern for Salt Stack compatibility.