### PR TITLE
qjackctl: add portaudio build option

### DIFF
--- a/srcpkgs/qjackctl/template
+++ b/srcpkgs/qjackctl/template
@@ -1,11 +1,13 @@
 # Template file for 'qjackctl'
 pkgname=qjackctl
 version=0.9.6
-revision=1
+revision=2
 build_style=cmake
-configure_args="$(vopt_bool jack_session CONFIG_JACK_SESSION)"
+configure_args="$(vopt_bool jack_session CONFIG_JACK_SESSION)
+ $(vopt_bool portaudio PORTAUDIO)"
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
-makedepends="alsa-lib-devel qt5-devel jack-devel portaudio-devel qt5-tools-devel"
+makedepends="alsa-lib-devel qt5-devel jack-devel qt5-tools-devel
+ $(vopt_if portaudio portaudio-devel)"
 depends="desktop-file-utils hicolor-icon-theme jack"
 short_desc="JACK Audio Connection Kit - Qt GUI Interface"
 maintainer="tibequadorian <tibequadorian@posteo.de>"
@@ -14,6 +16,6 @@ homepage="https://qjackctl.sourceforge.io"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=39ca2b9d83acfdd16a4c9b3eccd80e1483e1f9a446626f5d00ac297e6f8a166b
 
-build_options="jack_session"
-build_options_default="jack_session"
+build_options="jack_session portaudio"
+build_options_default="jack_session portaudio"
 desc_option_jack_session="Enable support for the deprecated Jack Session API"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
