### PR TITLE
WoeUSB: update to 5.2.4.

### DIFF
--- a/srcpkgs/WoeUSB/template
+++ b/srcpkgs/WoeUSB/template
@@ -1,7 +1,9 @@
 # Template file for 'WoeUSB'
 pkgname=WoeUSB
-version=3.3.1
-revision=3
+version=5.2.4
+revision=1
+_gui_version=3.3.0
+wrksrc="WoeUSB-frontend-wxgtk-${_gui_version}"
 build_style=gnu-configure
 configure_args="--with-wx-config=wx-config-gtk3"
 hostmakedepends="automake gettext libtool"
@@ -10,14 +12,18 @@ depends="WoeUSB-cli"
 short_desc="Create a Windows USB stick installer from a real Windows DVD or image"
 maintainer="bra1nwave <bra1nwave@protonmail.com>"
 license="GPL-3.0-or-later"
-homepage="https://github.com/slacka/WoeUSB"
-distfiles="https://github.com/slacka/WoeUSB/archive/v${version}.tar.gz"
-checksum=0cab88a1113506f39d2f1c19532b2cd8d968c6a9f59129953c000e29e73f3d4f
+homepage="https://github.com/WoeUSB/WoeUSB-frontend-wxgtk"
+distfiles="
+ https://github.com/WoeUSB/WoeUSB-frontend-wxgtk/archive/refs/tags/v${_gui_version}.tar.gz
+ https://github.com/WoeUSB/WoeUSB/archive/refs/tags/v${version}.tar.gz"
+checksum="
+ 5fcfd6e86388c3d4daf85a3a226ca4a42a336c862dcfa1c1af1ead5d77d81b63
+ 8305296d49b7b58c200f9d373eac8dd494d03442737183749a0ee166403a7e68"
 
 post_patch() {
+	mv -f "${XBPS_BUILDDIR}/WoeUSB-${version}/sbin/woeusb" src/woeusb
 	vsed -i -e "s/@@WOEUSB_VERSION@@/$version/g" \
-		configure.ac \
-		src/woeusb src/woeusb.1 src/woeusbgui.1
+		configure.ac src/woeusb.1 src/woeusbgui.1
 }
 
 pre_configure() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc

The new update enables you to flash the latest Windows 10 ISO since it support larger EFI partition for UEFI-NTFS (from 512 to 1024)