### PR TITLE
new package: ghcup-0.1.17.8

### DIFF
--- a/srcpkgs/ghcup/INSTALL.msg
+++ b/srcpkgs/ghcup/INSTALL.msg
@@ -1,0 +1,8 @@
+ghcup comes with an internal downloader, but optionally depends on curl and/or
+wget for more advanced usages (e.g., proxying).  To use curl/wget as downloader,
+first make sure they are installed, then run `ghcup config set downloader Curl`.
+
+Also, ghcup requires $GHCUP_INSTALL_BASE_PREFIX/.ghcup/bin to be in your PATH
+(by default, $GHCUP_INSTALL_BASE_PREFIX is $HOME); make sure to update your
+shell launch scripts accordingly. Alternatively, when GHCUP_USE_XDG_DIRS is set,
+GHCUP uses XDG-ish directories.

--- a/srcpkgs/ghcup/patches/ghcup-0.1.17.8-fix-ghc902-fromjson.patch
+++ b/srcpkgs/ghcup/patches/ghcup-0.1.17.8-fix-ghc902-fromjson.patch
@@ -1,0 +1,86 @@
+patch given by hasufell, posted at https://gist.github.com/hasufell/164af24885c6f066291c417a9850388d
+diff --git a/lib/GHCup/Types/JSON.hs b/lib/GHCup/Types/JSON.hs
+index 8d7cd3b..3dd05ee 100644
+--- a/lib/GHCup/Types/JSON.hs
++++ b/lib/GHCup/Types/JSON.hs
+@@ -79,37 +79,6 @@ instance FromJSON Tag where
+ instance ToJSON URI where
+   toJSON = toJSON . E.decodeUtf8With E.lenientDecode . serializeURIRef'
+ 
+-instance FromJSON URLSource where
+-  parseJSON v =
+-        parseGHCupURL v
+-    <|> parseOwnSourceLegacy v
+-    <|> parseOwnSourceNew1 v
+-    <|> parseOwnSourceNew2 v
+-    <|> parseOwnSpec v
+-    <|> legacyParseAddSource v
+-    <|> newParseAddSource v
+-   where
+-    parseOwnSourceLegacy = withObject "URLSource" $ \o -> do
+-      r :: URI <- o .: "OwnSource"
+-      pure (OwnSource [Right r])
+-    parseOwnSourceNew1 = withObject "URLSource" $ \o -> do
+-      r :: [URI] <- o .: "OwnSource"
+-      pure (OwnSource (fmap Right r))
+-    parseOwnSourceNew2 = withObject "URLSource" $ \o -> do
+-      r :: [Either GHCupInfo URI] <- o .: "OwnSource"
+-      pure (OwnSource r)
+-    parseOwnSpec = withObject "URLSource" $ \o -> do
+-      r :: GHCupInfo <- o .: "OwnSpec"
+-      pure (OwnSpec r)
+-    parseGHCupURL = withObject "URLSource" $ \o -> do
+-      _ :: [Value] <- o .: "GHCupURL"
+-      pure GHCupURL
+-    legacyParseAddSource = withObject "URLSource" $ \o -> do
+-      r :: Either GHCupInfo URI <- o .: "AddSource"
+-      pure (AddSource [r])
+-    newParseAddSource = withObject "URLSource" $ \o -> do
+-      r :: [Either GHCupInfo URI] <- o .: "AddSource"
+-      pure (AddSource r)
+ 
+ instance FromJSON URI where
+   parseJSON = withText "URL" $ \t ->
+@@ -349,7 +318,40 @@ deriveJSON defaultOptions { fieldLabelModifier = removeLensFieldLabel } ''GHCupI
+ deriveToJSON defaultOptions { sumEncoding = ObjectWithSingleField } ''URLSource
+ deriveJSON defaultOptions { sumEncoding = ObjectWithSingleField } ''Key
+ deriveJSON defaultOptions { fieldLabelModifier = \str' -> maybe str' T.unpack . T.stripPrefix (T.pack "k-") . T.pack . kebab $ str' } ''UserKeyBindings
+-deriveJSON defaultOptions { fieldLabelModifier = \str' -> maybe str' T.unpack . T.stripPrefix (T.pack "u-") . T.pack . kebab $ str' } ''UserSettings
+-
+ deriveToJSON defaultOptions { fieldLabelModifier = kebab } ''Settings
+ deriveToJSON defaultOptions { fieldLabelModifier = drop 2 . kebab } ''KeyBindings -- move under key-bindings key
++
++instance FromJSON URLSource where
++  parseJSON v =
++        parseGHCupURL v
++    <|> parseOwnSourceLegacy v
++    <|> parseOwnSourceNew1 v
++    <|> parseOwnSourceNew2 v
++    <|> parseOwnSpec v
++    <|> legacyParseAddSource v
++    <|> newParseAddSource v
++   where
++    parseOwnSourceLegacy = withObject "URLSource" $ \o -> do
++      r :: URI <- o .: "OwnSource"
++      pure (OwnSource [Right r])
++    parseOwnSourceNew1 = withObject "URLSource" $ \o -> do
++      r :: [URI] <- o .: "OwnSource"
++      pure (OwnSource (fmap Right r))
++    parseOwnSourceNew2 = withObject "URLSource" $ \o -> do
++      r :: [Either GHCupInfo URI] <- o .: "OwnSource"
++      pure (OwnSource r)
++    parseOwnSpec = withObject "URLSource" $ \o -> do
++      r :: GHCupInfo <- o .: "OwnSpec"
++      pure (OwnSpec r)
++    parseGHCupURL = withObject "URLSource" $ \o -> do
++      _ :: [Value] <- o .: "GHCupURL"
++      pure GHCupURL
++    legacyParseAddSource = withObject "URLSource" $ \o -> do
++      r :: Either GHCupInfo URI <- o .: "AddSource"
++      pure (AddSource [r])
++    newParseAddSource = withObject "URLSource" $ \o -> do
++      r :: [Either GHCupInfo URI] <- o .: "AddSource"
++      pure (AddSource r)
++
++deriveJSON defaultOptions { fieldLabelModifier = \str' -> maybe str' T.unpack . T.stripPrefix (T.pack "u-") . T.pack . kebab $ str' } ''UserSettings
++

--- a/srcpkgs/ghcup/template
+++ b/srcpkgs/ghcup/template
@@ -1,0 +1,29 @@
+# Template file for 'ghcup'
+pkgname=ghcup
+version=0.1.17.8
+revision=1
+#archs='x86_64 i686'
+wrksrc="ghcup-hs-v$version"
+hostmakedepends='tar git cabal-install'
+makedepends='zlib-devel ncurses-libtinfo-devel libarchive-devel'
+depends='zlib ncurses-libtinfo-libs libarchive gcc gmp make perl'
+short_desc='Installer for the general purpose language Haskell'
+maintainer='Kye Shi <shi.kye@gmail.com>'
+license='LGPL-3.0-only'
+homepage='https://www.haskell.org/ghcup/'
+distfiles="https://gitlab.haskell.org/haskell/ghcup-hs/-/archive/v$version/ghcup-hs-v$version.tar.gz"
+checksum='15156760d8593045515002c8c91803cbf67c9eb4bab357c46d2fdedea8c63ab1'
+nopie_files='/usr/bin/ghcup'
+nocross='cannot cross compile haskell yet'
+
+do_build() {
+	cabal update --prefix="$PWD"
+	cabal build --prefix="$PWD" --project-file='cabal.ghc902.project' -f'+internal-downloader' -f'-system-libarchive' -f'+tui'
+}
+
+do_install() {
+	cabal install --prefix="$PWD" --install-method='copy' --installdir="$DESTDIR/usr/bin"
+	for sh in 'bash' 'fish' 'zsh'; do
+		vcompletion "scripts/shell-completions/$sh" "$sh"
+	done
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->


#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package

- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements):

  **YES**:

  1. System-wide: `ghcup` is meant to be installed system-wide, even though it
     manages per-user installations of the Haskell toolchain (essentially
     analogous to `rustup` for Rust or `opam` for OCaml)

  2. Compiled: Yep

  3. Required (by other packages): no, but it's a very useful tool for Haskell
     developers, in the same way that rustup is useful for Rust devs,
     npm/pnpm/yarn is for JS devs, etc.

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- I built this PR locally for my native architecture, (`x86_64-glibc`)
- I couldn't test build this PR locally for other architectures because,
  apparently, we can't cross-compile with Haskell yet.
