### PR TITLE
google-chrome: update to 98.0.4758.102

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,6 +1,6 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
-version=98.0.4758.80
+version=98.0.4758.102
 revision=1
 _channel=stable
 archs="x86_64"
@@ -19,7 +19,7 @@ _chromeUrl="${_baseUrl}/${_filename}"
 _licenseUrl="https://www.google.com/intl/en/chrome/terms/"
 
 distfiles="$_chromeUrl"
-checksum=f1ddb0c3b10b2c345f24b2774a882ee28564c87788f78502f4d03de70a814b5c
+checksum=864ffdeb9402ee82da2786e99c58547598762b281f34a14d8ad670ece654d95d
 
 do_extract() {
 	mkdir -p ${DESTDIR}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I changed q66's package to replace @vscode/ripgrep to a far simpler version that only exposes the correct path and thus should never need to change and also removes the requirement to copy over files.