### PR TITLE
hiawatha: update to 11.1.

### DIFF
--- a/srcpkgs/hiawatha/template
+++ b/srcpkgs/hiawatha/template
@@ -1,19 +1,18 @@
 # Template file for 'hiawatha'
 pkgname=hiawatha
-version=10.12
+version=11.1
 revision=1
 build_style=cmake
 configure_args="-DLOG_DIR=/var/log/hiawatha -DPID_DIR=/run
  -DWEBROOT_DIR=/srv/www/$pkgname -DWORK_DIR=/var/lib/hiawatha
- -DUSE_SYSTEM_MBEDTLS=ON -DUSE_SYSTEM_NGHTTP2=ON
  -DCMAKE_INSTALL_SYSCONFDIR=/etc"
-makedepends="libxslt-devel mbedtls-devel nghttp2-devel"
+makedepends="libxslt-devel"
 short_desc="Advanced and secure webserver for Unix"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://hiawatha-webserver.org"
 distfiles="${homepage}/files/${pkgname}-${version}.tar.gz"
-checksum=61bf41146c51244769984135529fcffd0f6cb92be18dc12d460effc42f19f50d
+checksum=d21722986f64163e30a560283123cdf4d6cb5ff8188ab754387b26724565268d
 conf_files="/etc/${pkgname}/*.conf /etc/${pkgname}/*.xslt"
 make_dirs="/var/log/hiawatha 0755 root root"
 


### PR DESCRIPTION
Also:
- use included mbedtls (bundles a non-LTS branch)
- remove nghttp2 configure arg and dependency.

@Gottox 
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
