### PR TITLE
libgsm: update to 1.0.19.

### DIFF
--- a/srcpkgs/libgsm/template
+++ b/srcpkgs/libgsm/template
@@ -1,15 +1,14 @@
 # Template file for 'libgsm'
 pkgname=libgsm
-version=1.0.18
+version=1.0.19
 revision=1
-wrksrc="gsm-1.0-pl18"
-homepage="http://www.quut.com/gsm/"
-# old distfiles from $homepage are deleted when a new version is released
-distfiles="https://deb.debian.org/debian/pool/main/libg/libgsm/libgsm_$version.orig.tar.gz"
+wrksrc="gsm-${version%.*}-pl${version##*.}"
 short_desc="GSM 06.10 lossy speech compression"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="custom"
-checksum=04f68087c3348bf156b78d59f4d8aff545da7f6e14f33be8f47d33f4efae2a10
+license="TU-Berlin-2.0"
+homepage="http://www.quut.com/gsm/"
+distfiles="http://www.quut.com/gsm/gsm-${version}.tar.gz"
+checksum=4903652f68a8c04d0041f0d19b1eb713ddcd2aa011c5e595b3b8bca2755270f6
 
 do_build() {
 	make CC=$CC LD=$CC AR=$AR CCFLAGS="$CFLAGS -c -DNeedFunctionPrototypes=1"
@@ -22,15 +21,14 @@ do_install() {
 	vmkdir usr/share/man/man3
 	vmkdir usr/share/man/man1
 
-	install -m755 bin/* ${DESTDIR}/usr/bin
-	install -m644 lib/*.a ${DESTDIR}/usr/lib
-	install -m644 inc/* ${DESTDIR}/usr/include/gsm
+	make INSTALL_ROOT="${DESTDIR}"/usr \
+		GSM_INSTALL_INC="${DESTDIR}"/usr/include/gsm \
+		GSM_INSTALL_MAN="${DESTDIR}"/usr/share/man/man3 \
+		TOAST_INSTALL_MAN="${DESTDIR}"/usr/share/man/man1 \
+		install
 
-	vinstall lib/libgsm.so.1.0.13 755 usr/lib
-	vcopy lib/libgsm.so usr/lib
-	vcopy lib/libgsm.so.1 usr/lib
+	vcopy "lib/libgsm.so*" usr/lib
 
-	rm -f ${DESTDIR}/usr/include/gsm/*.orig
 	ln -sfr ${DESTDIR}/usr/include/gsm/gsm.h ${DESTDIR}/usr/include/gsm.h
 
 	vlicense COPYRIGHT
@@ -43,5 +41,6 @@ libgsm-devel_package() {
 		vmove usr/include
 		vmove usr/lib/*.a
 		vmove usr/lib/*.so
+		vmove usr/share/man/man3
 	}
 }


### PR DESCRIPTION
Old distfiles are apparently not deleted, so I changed them to upstream.
I also cleaned up the template a little bit and do the install using the Makefile target instead of doing this manually.
Until now, libgsm-devel contained unnecessary header files, because all header files were just copied over.
Also includes manual pages now, which were not installed before.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
