### PR TITLE
New package: latexmk-4.76

### DIFF
--- a/srcpkgs/texlive-latexmk
+++ b/srcpkgs/texlive-latexmk
@@ -1,0 +1,1 @@
+texlive

--- a/srcpkgs/texlive/template
+++ b/srcpkgs/texlive/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive'
 pkgname=texlive
 version=20210325
-revision=2
+revision=3
 wrksrc="texlive-${version}-source"
 build_wrksrc="build"
 build_style=gnu-configure
@@ -71,7 +71,7 @@ makedepends="cairo-devel freetype-devel gd-devel graphite-devel gmp-devel
  harfbuzz-devel icu-devel libpaper-devel libpng-devel mpfr-devel
  poppler-devel pixman-devel libteckit-devel zlib-devel zziplib-devel
  libXaw-devel"
-depends="dialog ghostscript perl-Tk texlive-core xbps-triggers"
+depends="dialog ghostscript perl-Tk texlive-core texlive-latexmk xbps-triggers"
 short_desc="TeX Live"
 maintainer="fosslinux <fosslinux@aussies.space>"
 license="GPL-2.0-or-later"
@@ -391,5 +391,14 @@ texlive-PythonTeX_package() {
 	pkg_install() {
 		vmove usr/bin/*pythontex
 		vmove usr/share/texmf-dist/scripts/pythontex
+	}
+}
+
+texlive-latexmk_package() {
+	depends="perl"
+	short_desc+=" - script for compiling the correct number of times"
+	pkg_install() {
+		vmove usr/bin/latexmk
+		vmove usr/share/texmf-dist/scripts/latexmk
 	}
 }


### PR DESCRIPTION
This script only works if LaTeX and perl are installed.
- There are many providers for a LaTeX compiler (I assume) so I didn't list it as a dependency.
- As for perl, there are multiple ways of installing perl as well (e.g. via perlbrew into the user's home directory). I did include it as a dependency though.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

Resolves https://github.com/void-linux/void-packages/issues/35626.