### PR TITLE
New package: docker-buildx-0.7.1

### DIFF
--- a/srcpkgs/docker-buildx/template
+++ b/srcpkgs/docker-buildx/template
@@ -1,0 +1,20 @@
+# Template file for 'docker-buildx'
+pkgname=docker-buildx
+version=0.7.1
+revision=1
+wrksrc="buildx-${version}"
+build_style=go
+go_import_path="github.com/docker/buildx/cmd/buildx"
+go_ldflags="-X github.com/docker/buildx/version.Version=v${version}"
+depends="docker-cli"
+short_desc="Docker CLI plugin for extended build capabilities with BuildKit"
+maintainer="Gabriel Sanches <gabriel@gsr.dev>"
+license="Apache-2.0"
+homepage="https://docs.docker.com/buildx/working-with-buildx/"
+distfiles="https://github.com/docker/buildx/archive/refs/tags/v${version}.tar.gz"
+checksum=5df4224eeac5a00d1bef2344660e93415264a64ea4742133f2c2a794c563ef50
+
+post_install() {
+	vmkdir usr/libexec/docker/cli-plugins
+	mv "${DESTDIR}/usr/bin/buildx" "${DESTDIR}/usr/libexec/docker/cli-plugins/docker-buildx"
+}


### PR DESCRIPTION
I had to use this command at work and it simply didn't exist. I had previously used it on Arch and didn't really know why it wasn't available on Void as well.

It happens that this command is a Docker CLI plugin, and comes bundled with Docker when distributed via DEBs or RPMs, but Arch also packages it along with their Docker package.

In my opinion, it makes more sense to package this just like Docker Compose (which since `v2` is also a Docker CLI plugin), that is, as a separate package, easy to install, and which will work out of the box once installed.

P.S.: I based this template off `docker-compose`'s.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- [x] I built this PR locally for my native architecture, (x86_64, both for glibc and musl)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
