### PR TITLE
python3-pikepdf: update to 5.0.1.

### DIFF
--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pikepdf'
 pkgname=python3-pikepdf
-version=4.4.1
+version=5.0.1
 revision=1
 wrksrc="pikepdf-${version}"
 build_style=python3-module
@@ -14,7 +14,7 @@ maintainer="Philipp David <pd@3b.pm>"
 license="MPL-2.0"
 homepage="https://github.com/pikepdf/pikepdf"
 distfiles="${PYPI_SITE}/p/pikepdf/pikepdf-${version}.tar.gz"
-checksum=c25d4c7673f9588d1f98bca498db98ba675070dc89ffffe50b3b124d4a005df9
+checksum=5fae9eeb7a0120d466fb219aea643a94a1423d68ee9171639a44cf0329ebe7aa
 
 pre_build() {
 	vsed -e '/setuptools_scm_git_archive/d' -i setup.py


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

5.0.0 was a breaking release since it requires the latest release of qpdf, which is now in master.
The current version of pikepdf in void (4.4.1) is not compatible with qpdf >=10.6.0, according to the pikepdf release notes.