### PR TITLE
kodi-addon-pvr-zattoo: update to 19.7.11.

### DIFF
--- a/srcpkgs/kodi-addon-pvr-zattoo/template
+++ b/srcpkgs/kodi-addon-pvr-zattoo/template
@@ -1,7 +1,7 @@
 # Template file for 'kodi-addon-pvr-zattoo'
 pkgname=kodi-addon-pvr-zattoo
-version=19.7.8.1
-revision=3
+version=19.7.11
+revision=1
 _kodi_release=Matrix
 wrksrc="pvr.zattoo-${version}-${_kodi_release}"
 build_style=cmake
@@ -14,8 +14,7 @@ maintainer="teldra <teldra@rotce.de>"
 license="GPL-2.0-only"
 homepage="https://github.com/rbuehlma/pvr.zattoo"
 distfiles="https://github.com/rbuehlma/pvr.zattoo/archive/${version}-${_kodi_release}.tar.gz"
-checksum=25dc4ea72b5315a65286ba606e6e26d281fb8eb830d5e0164b66b8d7ae90319a
-make_check=no # No target to "make test"
+checksum=07d96b1b0c3b464c0bf02279fa8cab9ccdf675344129f3a970b14bafce225fb4
 
 if [ -n "${CROSS_BUILD}" ]; then
 	configure_args+=" -DCMAKE_MODULE_PATH=${XBPS_CROSS_BASE}/usr/share/kodi/cmake"

--- a/srcpkgs/kodi-addon-pvr-zattoo/update
+++ b/srcpkgs/kodi-addon-pvr-zattoo/update
@@ -1,2 +1,2 @@
-ignore="19.* 512"
+ignore="20* 512"
 pattern='\K[\d\.]+(?=-[A-Z][a-z])'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
