### PR TITLE
python3-prompt_toolkit: don't handle sigint

### DIFF
--- a/srcpkgs/python3-prompt_toolkit/patches/dont-handle-sigint.patch
+++ b/srcpkgs/python3-prompt_toolkit/patches/dont-handle-sigint.patch
@@ -1,0 +1,27 @@
+This makes handle_sigint default to False
+
+See:
+ - https://github.com/void-linux/void-packages/issues/35712
+ - https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1576
+ - https://trac.sagemath.org/ticket/33360#comment:3
+
+--- a/prompt_toolkit/application/application.py	2022-02-11 05:06:37.000000000 -0300
++++ b/prompt_toolkit/application/application.py	2022-02-21 10:43:13.828058001 -0300
+@@ -634,7 +634,7 @@
+         self,
+         pre_run: Optional[Callable[[], None]] = None,
+         set_exception_handler: bool = True,
+-        handle_sigint: bool = True,
++        handle_sigint: bool = False,
+         slow_callback_duration: float = 0.5,
+     ) -> _AppResult:
+         """
+@@ -859,7 +859,7 @@
+         self,
+         pre_run: Optional[Callable[[], None]] = None,
+         set_exception_handler: bool = True,
+-        handle_sigint: bool = True,
++        handle_sigint: bool = False,
+         in_thread: bool = False,
+     ) -> _AppResult:
+         """

--- a/srcpkgs/python3-prompt_toolkit/template
+++ b/srcpkgs/python3-prompt_toolkit/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-prompt_toolkit'
 pkgname=python3-prompt_toolkit
 version=3.0.28
-revision=1
+revision=2
 wrksrc="prompt_toolkit-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"


### PR DESCRIPTION
Fixes #35712

See also: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1576

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
