### PR TITLE
mininet: update to 2.3.0, move to python 3, adopt.

### DIFF
--- a/srcpkgs/mininet/template
+++ b/srcpkgs/mininet/template
@@ -1,20 +1,19 @@
 # Template file for 'mininet'
 pkgname=mininet
-version=2.2.2
-revision=2
-build_style=python2-module
-hostmakedepends="help2man python-setuptools"
-depends="bash inetutils-telnet iperf iputils libcgroup-utils net-tools openvswitch socat"
+version=2.3.0
+revision=1
+build_style=python3-module
+hostmakedepends="help2man python3-setuptools"
+depends="bash ethtool inetutils-telnet iperf iproute2 iputils libcgroup-utils
+ net-tools openssh openvswitch psmisc python3-tkinter socat xbitmaps xhost xterm"
 short_desc="Emulator for rapid prototyping of Software Defined Networks"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="classabbyamp <dev@kb6.ee>"
 license="custom:MIT-like"
 homepage="http://mininet.org/"
 distfiles="https://github.com/mininet/${pkgname}/archive/${version}.tar.gz"
-checksum=d0aed2ea7a9096ae975694a4b3d0995259ef79268dd8888ba8be28601c100db5
-
-post_extract() {
-	sed -i 's/^\tcc /\t$(CC) /' Makefile
-}
+checksum=1b16ee53ddb9a34a3751a77517643bda2286fc31be123209e84884d0697107b0
+# tests require root
+make_check=no
 
 post_build() {
 	make mnexec


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

the additional deps are based on what upstream's install scripts and other distros require.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
