### PR TITLE
python3-pulsectl: update to 22.1.3.

### DIFF
--- a/srcpkgs/python3-pulsectl/template
+++ b/srcpkgs/python3-pulsectl/template
@@ -1,18 +1,19 @@
 # Template file for 'python3-pulsectl'
 pkgname=python3-pulsectl
-version=20.5.1
-revision=2
+version=22.1.3
+revision=1
 wrksrc="pulsectl-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools"
+checkdepends="pulseaudio"
 short_desc="Python3 high-level interfaces and ctypes bindings for libpulse"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/mk-fg/python-pulse-control"
 changelog="https://github.com/mk-fg/python-pulse-control/raw/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/p/pulsectl/pulsectl-${version}.tar.gz"
-checksum=39b0a0e7974a7d6468d826a838822f78b00ac9c3803f0d7bfa9b1cad08ee22db
+checksum=f28fe4b881dd2cc144d2d94f83ec60d8c59a52642a0ad3635cc4d0f8406f4858
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
