### PR TITLE
geoclue2: update to 2.6.0 + enable it for redshift.

### DIFF
--- a/srcpkgs/geoclue2/template
+++ b/srcpkgs/geoclue2/template
@@ -1,22 +1,23 @@
 # Template file for 'geoclue2'
 pkgname=geoclue2
-version=2.5.6
+version=2.6.0
 revision=1
 wrksrc="geoclue-${version}"
 build_style=meson
 build_helper="gir"
 configure_args="-Ddbus-srv-user=_geoclue2 -Dgtk-doc=false
- -Dintrospection=$(vopt_if gir true false)"
+ $(vopt_bool gir introspection)"
 conf_files="/etc/geoclue/geoclue.conf"
-hostmakedepends="glib-devel intltool pkg-config"
-makedepends="ModemManager-devel avahi-glib-libs-devel eudev-libudev-devel
+hostmakedepends="glib-devel intltool pkg-config vala"
+makedepends="ModemManager-devel avahi-glib-libs-devel
  json-glib-devel libsoup-gnome-devel libnotify-devel"
 short_desc="Geoinformation Service (2.x series)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gitlab.freedesktop.org/geoclue/geoclue/wikis/home"
+changelog="https://gitlab.freedesktop.org/geoclue/geoclue/-/raw/master/NEWS"
 distfiles="https://gitlab.freedesktop.org/geoclue/geoclue/-/archive/${version}/geoclue-${version}.tar.bz2"
-checksum=b310e6ea86c695046e6069a728a2dd65989619827a730f90ec4bfdab4a1f0329
+checksum=cdc9efcb98ce81284d7a6c3c899330481ffdca44bba3c18b9e530618298aa4a0
 system_accounts="_geoclue2"
 lib32disabled=yes
 

--- a/srcpkgs/redshift/template
+++ b/srcpkgs/redshift/template
@@ -1,20 +1,21 @@
 # Template file for 'redshift'
 pkgname=redshift
 version=1.12
-revision=5
+revision=6
 build_style=gnu-configure
-configure_args="--enable-gui --disable-geoclue $(vopt_enable geoclue2)"
+configure_args="--enable-gui --enable-geoclue2"
 hostmakedepends="gettext-devel intltool pkg-config python3-devel"
-makedepends="libXxf86vm-devel libdrm-devel $(vopt_if geoclue2 'geoclue2
- glib-devel')"
-depends="$(vopt_if geoclue2 'geoclue2')"
+makedepends="libXxf86vm-devel libdrm-devel geoclue2 glib-devel"
 short_desc="Adjusts the color temperature of your screen to your surroundings"
 maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="GPL-3.0-or-later"
 homepage="http://jonls.dk/redshift/"
 distfiles="https://github.com/jonls/redshift/releases/download/v${version}/redshift-${version}.tar.xz"
 checksum=d2f8c5300e3ce2a84fe6584d2f1483aa9eadc668ab1951b2c2b8a03ece3a22ba
-build_options="geoclue2"
+
+post_install() {
+	vsconf redshift.conf.sample
+}
 
 redshift-gtk_package() {
 	depends="${sourcepkg}-${version}_${revision} gtk+3 python3-gobject


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

imo the geoclue2 build option is useless because it's no hard dependency and redshift will work fine without it if you change the provider to "manual" in `redshift.conf`, but I'll leave it for now...

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
