### PR TITLE
python3-lxml: update to 4.8.0.

### DIFF
--- a/srcpkgs/python3-lxml/template
+++ b/srcpkgs/python3-lxml/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-lxml'
 pkgname=python3-lxml
-version=4.6.4
-revision=2
+version=4.8.0
+revision=1
 wrksrc="lxml-lxml-${version}"
 build_style=python3-module
 make_build_args="--with-cython"
@@ -14,7 +14,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause, custom:ElementTree"
 homepage="https://lxml.de/"
 distfiles="https://github.com/lxml/lxml/archive/lxml-${version}.tar.gz"
-checksum=5a7cef132353fc36de6f6b26dacde07b22217c6b4f8c11ef48e8bf0011f48160
+checksum=8d2b999f5c8a8a70a28a3875e5d1bf27c0555c922bfa0af34dc46e07913f2a47
 
 do_check() {
 	make test3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (tested with synapse)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
Long list of dependent packages for this one:
- [x] Komikku
- [x] OpenLP (broken with current version 2.4.6_5 in repo due to not supporting Python 3.10, but latest preview version 3.9.4 works fine with it. I'll push the update as soon as it's marked as an actual release)
- [x] beancount
- [x] castero
- [x] cppman
- [x] curseradio
- [x] gcovr
- [x] gnome-builder
- [x] greg
- [x] gtk-doc
- [x] inkscape
- [x] lutris
- [x] manuskript
- [x] nagstamon
- [x] papis
- [x] piper
- [x] python3-MechanicalSoup
- [x] python3-changelogs
- [x] python3-html5-parser
- [x] python3-opcua
- [x] python3-pikepdf
- [x] python3-pyPEG2
- [x] python3-pycollada
- [x] python3-pykeepass
- [x] python3-readability-lxml
- [x] python3-trimesh
- [x] qomui
- [x] sigil
- [x] streamlink
- [x] synapse
- [x] termtosvg
- [x] urlwatch
- [x] variety
- [x] wfuzz
- [x] wpull
- [x] xmldiff
- [x] yelp-tools
- [x] ytcc
- [x] ytmdl