### PR TITLE
python3-openssl: update to 22.0.0.

### DIFF
--- a/srcpkgs/python-openssl/template
+++ b/srcpkgs/python-openssl/template
@@ -3,27 +3,13 @@ pkgname=python-openssl
 version=20.0.1
 revision=2
 wrksrc="pyOpenSSL-${version}"
-build_style=python-module
-hostmakedepends="python-setuptools python3-setuptools"
+build_style=python2-module
+hostmakedepends="python-setuptools"
 depends="python-cryptography python-six"
-checkdepends="python3-cryptography python3-six
- python3-pytest python3-flaky python3-pretend"
 short_desc="Python2 interface to the OpenSSL library"
-maintainer="Alessio Sergi <al3hex@gmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://pyopenssl.org/"
 changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz"
 checksum=4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51
-
-do_check() {
-	PYTHONPATH="$(cd build-${py3_ver}/lib* && pwd)" python3 -m pytest
-}
-
-python3-openssl_package() {
-	depends="python3-cryptography python3-six"
-	short_desc="${short_desc/Python2/Python3}"
-	pkg_install() {
-		vmove usr/lib/python3*
-	}
-}

--- a/srcpkgs/python3-openssl
+++ b/srcpkgs/python3-openssl
@@ -1,1 +1,0 @@
-python-openssl

--- a/srcpkgs/python3-openssl/template
+++ b/srcpkgs/python3-openssl/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-openssl'
+pkgname=python3-openssl
+version=22.0.0
+revision=1
+wrksrc="pyOpenSSL-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-cryptography"
+checkdepends="python3-pytest $depends python3-flaky python3-pretend"
+short_desc="Python3 interface to the OpenSSL library"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://pyopenssl.org/"
+changelog="https://raw.githubusercontent.com/pyca/pyopenssl/master/CHANGELOG.rst"
+distfiles="${PYPI_SITE}/p/pyOpenSSL/pyOpenSSL-${version}.tar.gz"
+checksum=660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf
+
+if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
+	# https://github.com/pyca/pyopenssl/issues/974
+	make_check_args="-k not(test_verify_with_time)"
+fi

--- a/srcpkgs/python3-openssl/update
+++ b/srcpkgs/python3-openssl/update
@@ -1,0 +1,1 @@
+pkgname=pyOpenSSL


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (tested with synapse)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
I had to do the same thing I did for Twisted--drop the python3 subpackage from python-openssl since versions >21.0.0 don't support python2 anymore.

Dependents to test:
- [x] gajim
- [x] impacket
- [x] python3-Twisted
- [x] python3-TxSNI
- [x] python3-acme
- [x] python3-josepy
- [x] python3-nbxmpp
- [x] python3-ndg_httpsclient
- [x] python3-saml2
- [x] ripe-atlas-tools
- [x] synapse
- [x] yubikey-manager