### PR TITLE
steam: fix joining friends' games.

### DIFF
--- a/srcpkgs/steam/template
+++ b/srcpkgs/steam/template
@@ -1,11 +1,11 @@
 # Template file for 'steam'
 pkgname=steam
 version=1.0.0.74
-revision=1
+revision=2
 archs="i686 x86_64"
 wrksrc=steam-launcher
 depends="zenity xz curl dbus freetype gdk-pixbuf hicolor-icon-theme desktop-file-utils
- liberation-fonts-ttf file tar bash coreutils"
+ liberation-fonts-ttf file tar bash coreutils lsof"
 short_desc="Digital distribution client bootstrap package - Valve's steam client"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom: Proprietary license"


### PR DESCRIPTION
This feature requires `lsof` to be installed, the following was printed when opening the context menu of someone in the friends list:
```
sh: 1: lsof: not found
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
