### PR TITLE
kpkpass, kitinerary, kdepim-addons: update to 21.12.2.

### DIFF
--- a/srcpkgs/kdepim-addons/template
+++ b/srcpkgs/kdepim-addons/template
@@ -1,6 +1,6 @@
 # Template file for 'kdepim-addons'
 pkgname=kdepim-addons
-version=21.12.0
+version=21.12.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules python3 kdoctools kcoreaddons
@@ -14,8 +14,9 @@ short_desc="Addons for KDE PIM applications"
 maintainer="Louis Dupré Bertoni <contact@louis.xyz>"
 license="GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.1-or-later, AGPL-3.0-or-later, BSD-3-Clause, BSD-2-Clause"
 homepage="https://invent.kde.org/pim/kdepim-addons"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#kdepim-addons"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=f00ae7ac3311bf31377830f44a44fe0a6b9c09a0749529aefd81254b0a1db603
+checksum=613ea236dd23ea163244bc72eebcbe950132a0c4f117194dcc3ad43d773e4602
 
 do_check() {
 	# failing tests are disabled

--- a/srcpkgs/kitinerary/template
+++ b/srcpkgs/kitinerary/template
@@ -1,6 +1,6 @@
 # Template file for 'kitinerary'
 pkgname=kitinerary
-version=21.12.0
+version=21.12.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kcoreaddons pkg-config qt5-host-tools qt5-qmake qt5-tools-devel"
@@ -10,8 +10,9 @@ short_desc="Data model and extraction system for travel reservation information"
 maintainer="Louis Dupré Bertoni <contact@louisdb.xyz>"
 license="LGPL-2.1-or-later"
 homepage="https://kontact.kde.org"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#kitinerary"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=33f19570aaabe9340bb6f8c8d37e33d1c943644eee5275b9ffc59dfa64dcef37
+checksum=e26a20538c5fbc85bd8eb93c3ad8e7150ac953cba2f56e20293b438b0031ff3c
 
 kitinerary-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/kpkpass/template
+++ b/srcpkgs/kpkpass/template
@@ -1,6 +1,6 @@
 # Template file for 'kpkpass'
 pkgname=kpkpass
-version=21.12.0
+version=21.12.2
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools shared-mime-info"
@@ -9,8 +9,9 @@ short_desc="Apple Wallet Pass reader"
 maintainer="Louis Dupré Bertoni <contact@louisdb.xyz>"
 license="LGPL-2.1-or-later"
 homepage="https://kontact.kde.org"
+changelog="https://kde.org/announcements/changelogs/gear/${version}/#kpkpass"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=b69ba26ef69f72699995425323e55f7064623b3116d806dca65c2713a0e7770a
+checksum=fddf1bcf102626a093909a05bec95a46b37445e7dcb2d4c78f013bbac80f545c
 
 kpkpass-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
@Johnnynator 

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
