### PR TITLE
python3-vint: update to 0.3.21.

### DIFF
--- a/srcpkgs/python3-vint/template
+++ b/srcpkgs/python3-vint/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-vint'
 pkgname=python3-vint
-version=0.3.19
-revision=6
-wrksrc="vim-vint-${version}"
+version=0.3.21
+revision=1
+wrksrc="vint-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-ansicolor python3-chardet python3-yaml"
+checkdepends="python3-pytest ${depends}"
 short_desc="Lint tool for Vim script language (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="https://github.com/Kuniwak/vint"
-distfiles="${PYPI_SITE}/v/vim-vint/vim-vint-${version}.tar.gz"
-checksum=aba8938f4c720e5c70a25f4dc7d845c5ce87aba0b778d1686f18b8da0c88f234
+homepage="https://github.com/Vimjas/vint"
+distfiles="https://github.com/Vimjas/vint/archive/refs/tags/v${version}.tar.gz"
+checksum=ebbb4ffd790324331aabf82d0b8777db8ce41d72d7c4c1c328bc099359ae06d6
 conflicts="python-vint>=0"
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
Switch distfiles to Github source since it includes the tests.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
Fixes error about missing 'PyYAML~=3.11' when running `vint`.