### PR TITLE
mtxclient: update to 0.6.2 for nheko crash

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -421,7 +421,7 @@ libField3D.so.1.7 Field3D-1.7.3_1
 libMAC.so.6 libMAC-5.28_1
 libmad.so.0 libmad-0.15.1b_1
 libmatroska.so.7 libmatroska-1.6.0_1
-libmatrix_client.so.0.6.1 mtxclient-0.6.1_1
+libmatrix_client.so.0.6.2 mtxclient-0.6.2_1
 libebml.so.5 libebml-1.4.0_1
 libdvdread.so.8 libdvdread-6.1.1_1
 libdvdnav.so.4 libdvdnav-4.1.3_1

--- a/srcpkgs/mtxclient/template
+++ b/srcpkgs/mtxclient/template
@@ -1,6 +1,6 @@
 # Template file for 'mtxclient'
 pkgname=mtxclient
-version=0.6.1
+version=0.6.2
 revision=1
 build_style=cmake
 configure_args="-DBUILD_LIB_TESTS=OFF -DBUILD_LIB_EXAMPLES=OFF"
@@ -11,7 +11,7 @@ maintainer="Lorem <notloremipsum@protonmail.com>"
 license="MIT"
 homepage="https://github.com/Nheko-Reborn/mtxclient"
 distfiles="https://github.com/Nheko-Reborn/mtxclient/archive/v${version}.tar.gz"
-checksum=d0c3d86898ade0a0680f57cb920e11f07901085403ebaaa0b085e0067a78529c
+checksum=97e41340c3f03db8a7625dcd54f6c6a3c8726c7b7226630727fea7d2bb2213bf
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/nheko/template
+++ b/srcpkgs/nheko/template
@@ -1,7 +1,7 @@
 # Template file for 'nheko'
 pkgname=nheko
 version=0.9.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="qt5-host-tools qt5-qmake pkg-config qt5-declarative"
 makedepends="qt5-multimedia-devel qt5-svg-devel qt5-tools-devel fmt-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

quoting upstream:
> This release fixes a crash in Nheko if the Matrix server is updated to support the APIs v1.1 and up

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

