### PR TITLE
xterm: update to 372.

### DIFF
--- a/srcpkgs/xterm/template
+++ b/srcpkgs/xterm/template
@@ -1,6 +1,6 @@
 # Template file for 'xterm'
 pkgname=xterm
-version=370
+version=372
 revision=1
 build_style=gnu-configure
 configure_args="--enable-wide-chars --enable-88-color --enable-broken-osc
@@ -17,11 +17,10 @@ makedepends="libXaw-devel libXft-devel libutempter-devel libxkbfile-devel
 short_desc="X Terminal Emulator"
 maintainer="Frank Steinborn <steinex@nognu.de>"
 license="MIT, X11"
-homepage="http://invisible-island.net/xterm/"
-changelog="http://invisible-island.net/xterm/xterm.log.html"
-# using HTTP TEMPORARILY due to cert issues
-distfiles="http://invisible-mirror.net/archives/xterm/xterm-${version}.tgz"
-checksum=963c5d840a0f0f4c077ff284586e8b1f83f3f983dca6f74f4b361975b5388c82
+homepage="https://invisible-island.net/xterm/"
+changelog="https://invisible-island.net/xterm/xterm.log.html"
+distfiles="https://invisible-mirror.net/archives/xterm/xterm-${version}.tgz"
+checksum=c6d08127cb2409c3a04bcae559b7025196ed770bb7bf26630abcb45d95f60ab1
 
 post_install() {
 	for f in {u,}xterm.desktop; do


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

ci fails because of some stupid ratelimiting on xterm servers. Built succesfully for all platforms on my fork.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
