### PR TITLE
jamulus: update to 3.8.2

### DIFF
--- a/srcpkgs/jamulus/template
+++ b/srcpkgs/jamulus/template
@@ -1,6 +1,6 @@
 # Template file for 'jamulus'
 pkgname=jamulus
-version=3.8.1
+version=3.8.2
 revision=1
 _version=r${version//./_}
 wrksrc=${pkgname}-${_version}
@@ -13,4 +13,4 @@ maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://jamulus.io"
 distfiles="https://github.com/corrados/jamulus/archive/${_version}.tar.gz"
-checksum=bc20c6aa8d0d3dd6c98a54cc1759d611fe564a8c73f7da9b09b48d2a3dee1d25
+checksum=4c323db21c896c711f726319b40114d1a0b5a374fd25eb43d9af52c19fc3d55e


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
```
libxml2-2.9.10_5: broken, unresolvable shlib `libicudata.so.69'
libxml2-2.9.10_5: broken, unresolvable shlib `libicui18n.so.69'
libharfbuzz-2.9.1_1: broken, unresolvable shlib `libicuuc.so.69'
libxml2-2.9.10_5: broken, unresolvable shlib `libicuuc.so.69'
Transaction aborted due to unresolved shlibs.
```

Build currently failing due to unresolved shlibs. According to the [docs](https://docs.voidlinux.org/xbps/troubleshooting/common-issues.html):
> If you get an error message saying:
>
> `Transaction aborted due to unresolved shlibs`
>
> the repositories are in the staging state, which can happen due to large builds. The solution is to wait for the builds to finish. You can view the builds' progress in the [Buildbot's Waterfall Display](https://build.voidlinux.org/waterfall).

I'll skip CI and tag WIP until it's resolved. I figured I would make the PR just in case anyone was curious about the status of updating to 3.8.2.