### PR TITLE
peru: update to 1.3.0.

### DIFF
--- a/srcpkgs/peru/template
+++ b/srcpkgs/peru/template
@@ -1,17 +1,18 @@
 # Template file for 'peru'
 pkgname=peru
-version=1.2.0
-revision=4
+version=1.3.0
+revision=1
 build_style=python3-module
-pycompile_module="peru"
 hostmakedepends="python3-setuptools"
-depends="curl git mercurial python3 python3-docopt python3-yaml"
+depends="curl git python3 python3-docopt python3-yaml"
 short_desc="Tool for fetching code"
 maintainer="Andy Weidenbaum <atweiden@tutanota.de>"
 license="MIT"
 homepage="https://github.com/buildinspace/peru"
 distfiles="https://github.com/buildinspace/peru/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=fb0fb02639e1c5403c9a6ddfd9719c5ea5ddf69fb440fbcfafe234470645e1dc
+checksum=ba21eb65c62c1b823ece2a42375fe80d65fbc6130606e2d6850b7746530018f6
+# checks require distfiles come from a git repository
+make_check=no
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Mercurial is an optional dependency (see: https://github.com/buildinspace/peru/pull/224).

#### Testing the changes
- I tested the changes in this PR: **YES**