### PR TITLE
nyxt: remove runtime deps on *-devel

### DIFF
--- a/srcpkgs/nyxt/patches/001-libfixposix.patch
+++ b/srcpkgs/nyxt/patches/001-libfixposix.patch
@@ -1,0 +1,12 @@
+--- a/_build/iolib/src/syscalls/ffi-functions-unix.lisp.orig	2022-02-27 09:44:00.327307802 -0700
++++ b/_build/iolib/src/syscalls/ffi-functions-unix.lisp	2022-02-27 09:48:30.875539336 -0700
+@@ -12,7 +12,8 @@
+ (eval-when (:compile-toplevel :load-toplevel :execute)
+   (define-foreign-library
+       (libfixposix :canary "lfp_buildinfo")
+-    (t (:default "libfixposix")))
++    (:unix "libfixposix.so.3")
++    (t (:default "libfixposix")))
+   (load-foreign-library 'libfixposix))
+ 
+ 

--- a/srcpkgs/nyxt/patches/002-webkit2gtk.patch
+++ b/srcpkgs/nyxt/patches/002-webkit2gtk.patch
@@ -1,0 +1,14 @@
+--- a/_build/cl-webkit/webkit2/webkit2.init.lisp	2022-01-14 03:22:05.000000000 -0700
++++ b/_build/cl-webkit/webkit2/webkit2.init.lisp	2022-02-27 09:59:29.175938024 -0700
+@@ -18,9 +18,9 @@
+               "libwebkit2gtk-4.0.37.dylib"
+               "libwebkit2gtk-4.0.dylib"))
+     (:unix (:or "libwebkit2gtk-4.1.so"
+-                "libwebkit2gtk-4.0.so"
+                 ;; Fedora only has this one?
+-                "libwebkit2gtk-4.0.so.37")))
++                "libwebkit2gtk-4.0.so.37"
++                "libwebkit2gtk-4.0.so")))
+   (use-foreign-library libwebkit2))
+ 
+ (defcfun "webkit_get_major_version" :int)

--- a/srcpkgs/nyxt/template
+++ b/srcpkgs/nyxt/template
@@ -6,8 +6,8 @@ create_wrksrc=yes
 build_style=gnu-makefile
 make_build_target=all
 hostmakedepends="sbcl git"
-makedepends="webkit2gtk-devel libfixposix-devel libgirepository-devel"
-depends="dbus xclip enchant2 webkit2gtk-devel libfixposix-devel libgirepository-devel"
+makedepends="webkit2gtk libfixposix-devel libgirepository-devel"
+depends="dbus xclip enchant2 webkit2gtk libfixposix libgirepository"
 short_desc="Keyboard-oriented, extensible web-browser"
 maintainer="0x0f0f0f <sudo-woodo3@protonmail.com>"
 license="BSD-3-Clause"
@@ -19,6 +19,7 @@ make_check=no
 nostrip=yes
 nopie=yes
 nocross="Cross-compilation fails due to package iolib/syscalls setting incorrect compiler flags"
+shlib_requires="libwebkit2gtk-4.0.so.37 libfixposix.so.3 libgirepository-1.0.so.1"
 
 do_install() {
 	make PREFIX=/usr DESTDIR=${DESTDIR} install


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### About

The current package requires shared libraries referenced inside development packages (`*-devel` because the libraries are referred to by `libXYZ.so` filenames).

This patch fixes this small defect.