### PR TITLE
xbps-src: consistent source style

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -938,12 +938,12 @@ case "$XBPS_TARGET" in
         ;;
     show-var)
         for f in ${XBPS_COMMONDIR}/environment/setup/*.sh; do
-            source $f
+            . $f
         done
         if [ "$XBPS_CROSS_BUILD" ]; then
-            source ${XBPS_COMMONDIR}/cross-profiles/${XBPS_CROSS_BUILD}.sh
+            . ${XBPS_COMMONDIR}/cross-profiles/${XBPS_CROSS_BUILD}.sh
         else
-            source ${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh
+            . ${XBPS_COMMONDIR}/build-profiles/${XBPS_MACHINE}.sh
         fi
         eval value="\${$XBPS_TARGET_PKG}"
         echo $value


### PR DESCRIPTION
On lines: 442, 458,  700, 849, and 873 - the `. FILE` style is used to source in a file. As far as I can tell, `. FILE` and `source FILE` is exactly the same. If `.` is used everywhere else, then it seems `source` should be changed to `.` for consistency unless there is a difference I'm not aware of.

[ci skip]