### PR TITLE
libjpeg-turbo: update to 2.1.3.

### DIFF
--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,6 +1,6 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=2.1.2
+version=2.1.3
 revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1 -DCMAKE_INSTALL_LIBDIR=/usr/lib"
@@ -11,7 +11,7 @@ license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=09b96cb8cbff9ea556a9c2d173485fd19488844d55276ed4f42240e1e2073ce5
+checksum=467b310903832b033fe56cd37720d1b73a6a3bd0171dbf6ff0b620385f4f76d0
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
