### PR TITLE
[RFC]: xbps-src: add make_check_pre

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -600,6 +600,9 @@ path of the Python wheel produced by the build phase that will be installed; whe
 `python-pep517` build style will look for a wheel matching the package name and version in the
 current directory with respect to the install.
 
+- `make_check_pre` The expression in front of `${make_cmd}`. This can be used for wrapper commands
+or for setting environment variables for the check command. By default empty.
+
 - `patch_args` The arguments to be passed in to the `patch(1)` command when applying
 patches to the package sources during `do_patch()`. Patches are stored in
 `srcpkgs/<pkgname>/patches` and must be in `-p1` format. By default set to `-Np1`.

--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -11,7 +11,7 @@ do_build() {
 do_check() {
 	: ${make_cmd:=cargo}
 
-	${make_cmd} test --release --target ${RUST_TARGET} ${configure_args} \
+	${make_check_pre} ${make_cmd} test --release --target ${RUST_TARGET} ${configure_args} \
 		${make_check_args}
 }
 

--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -116,7 +116,7 @@ do_check() {
 
 	: ${make_check_target:=test}
 
-	${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/configure.sh
+++ b/common/build-style/configure.sh
@@ -29,7 +29,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=check}
 
-	${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/gnu-configure.sh
+++ b/common/build-style/gnu-configure.sh
@@ -30,7 +30,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=check}
 
-	${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/gnu-makefile.sh
+++ b/common/build-style/gnu-makefile.sh
@@ -30,7 +30,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=check}
 
-	${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/meson.sh
+++ b/common/build-style/meson.sh
@@ -138,7 +138,7 @@ do_check() {
 	: ${make_check_target:=test}
 	: ${meson_builddir:=build}
 
-	${make_cmd} -C ${meson_builddir} ${makejobs} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} -C ${meson_builddir} ${makejobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/perl-ModuleBuild.sh
+++ b/common/build-style/perl-ModuleBuild.sh
@@ -41,7 +41,7 @@ do_check() {
 	if [ ! -x ./Build ]; then
 		msg_error "$pkgver: cannot find ./Build script!\n"
 	fi
-	./Build test
+	${make_check_pre} ./Build test
 }
 
 do_install() {

--- a/common/build-style/perl-module.sh
+++ b/common/build-style/perl-module.sh
@@ -79,7 +79,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=test}
 
-	${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/python-module.sh
+++ b/common/build-style/python-module.sh
@@ -49,7 +49,7 @@ do_check() {
 			fi
 		fi
 
-		python${pyver} setup.py ${make_check_target:-test} ${make_check_args}
+		${make_check_pre} python${pyver} setup.py ${make_check_target:-test} ${make_check_args}
 		rm build
 	done
 }

--- a/common/build-style/python3-module.sh
+++ b/common/build-style/python3-module.sh
@@ -25,7 +25,7 @@ do_build() {
 
 do_check() {
 	if python3 -c 'import pytest' >/dev/null 2>&1; then
-		PYTHONPATH="$(cd build/lib* && pwd)" \
+		${make_check_pre} PYTHONPATH="$(cd build/lib* && pwd)" \
 			python3 -m pytest ${make_check_args} ${make_check_target}
 	else
 		# Fall back to deprecated setup.py test orchestration without pytest
@@ -37,7 +37,7 @@ do_check() {
 		fi
 
 		: ${make_check_target:=test}
-		python3 setup.py ${make_check_target} ${make_check_args}
+		${make_check_pre} python3 setup.py ${make_check_target} ${make_check_args}
 	fi
 }
 

--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -14,7 +14,7 @@ do_build() {
 
 do_check() {
 	if python3 -c 'import pytest' >/dev/null 2>&1; then
-		python3 -m pytest ${make_check_args} ${make_check_target}
+		${make_check_pre} python3 -m pytest ${make_check_args} ${make_check_target}
 	else
 		msg_warn "Unable to determine tests for PEP517 Python templates"
 		return 0

--- a/common/build-style/raku-dist.sh
+++ b/common/build-style/raku-dist.sh
@@ -3,7 +3,7 @@
 #
 
 do_check() {
-	RAKULIB=lib prove -r -e raku t/
+	${make_check_pre} RAKULIB=lib prove -r -e raku t/
 }
 
 do_install() {

--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -7,7 +7,7 @@ unset -v archs distfiles checksum build_style build_helper nocross broken
 unset -v configure_script configure_args wrksrc build_wrksrc create_wrksrc
 unset -v make_build_args make_check_args make_install_args
 unset -v make_build_target make_check_target make_install_target
-unset -v make_cmd meson_cmd gem_cmd fetch_cmd
+unset -v make_cmd meson_cmd gem_cmd fetch_cmd make_check_pre
 unset -v python_version stackage
 unset -v cmake_builddir meson_builddir
 unset -v meson_crossfile

--- a/srcpkgs/totem/template
+++ b/srcpkgs/totem/template
@@ -12,20 +12,18 @@ makedepends="clutter-gst3-devel clutter-gtk-devel dbus-glib-devel
  gst-plugins-ugly1 libSM-devel libXtst-devel libepc-devel libpeas-devel
  nautilus-devel zeitgeist-devel gst-plugins-base1-devel"
 depends="grilo-plugins gst-libav gst-plugins-good1 gst-plugins-ugly1 tracker3"
+checkdepends="xvfb-run"
 short_desc="GNOME integrated movie player based on Gstreamer"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Videos"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=fce562e2b26cbcfc0c678538dcc81f9dc15ce60d5a89ee4358907bf634304c40
+make_check_pre="xvfb-run"
 
 # XXX xulrunner plugin.
 # XXX reenable python plugin if pylint pkg exists.
 #pycompile_dirs="usr/lib/totem/plugins"
-
-do_check() {
-	:
-}
 
 libtotem_package() {
 	short_desc+=" - runtime library"


### PR DESCRIPTION
$make_check_pre can be used for wrapper commands like xvfb-run or
dbus-run-session which are common ways to make tests work. This way many
templates can avoid defining their own do_check function.