### PR TITLE
make sublime-text3 restricted

### DIFF
--- a/srcpkgs/sublime-text3-bin/template
+++ b/srcpkgs/sublime-text3-bin/template
@@ -1,0 +1,55 @@
+# Template file for 'sublime-text3-bin'
+pkgname=sublime-text3-bin
+version=3211
+revision=1
+archs="i686 x86_64"
+wrksrc="sublime_text_3"
+hostmakedepends="w3m"
+depends="libpng gtk+ hicolor-icon-theme desktop-file-utils"
+short_desc="Sophisticated text editor for code, markup and prose"
+maintainer="Andrea Brancaleoni <miwaxe@pompel.me>"
+license="custom:EULA"
+homepage="http://www.sublimetext.com/3dev"
+_license_checksum=33929b71625d13dacf2a0a5853171b9c04058f71e2955ee660b8d0f8dda45ed1
+repository="nonfree"
+restricted=yes
+nopie=yes
+replaces="sublime-text3>0"
+
+if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
+	distfiles="https://download.sublimetext.com/sublime_text_3_build_${version}_x64.tar.bz2"
+	checksum=0b3c8ca5e6df376c3c24a4b9ac2e3b391333f73b229bc6e87d0b4a5f636d74ee
+else
+	distfiles="https://download.sublimetext.com/sublime_text_3_build_${version}_x32.tar.bz2"
+	checksum=480609962bbbd12128b5332c7831372b8851c13e160512730d1b0a6a835a3071
+fi
+
+post_extract() {
+	$XBPS_FETCH_CMD https://www.sublimehq.com/eula
+	sed -n '
+		/is licensed.*not sold/p
+		/<ol>/,${ /<\/ol>/{x;p;d}; H }
+		$a </ol>
+	' <eula | w3m -dump -I utf-8 -T text/html >EULA
+
+	filesum="$(xbps-digest EULA)"
+	if [ "$filesum" != "$_license_checksum" ]; then
+		msg_error "SHA256 mismatch for EULA:\n$filesum\n"
+	fi
+}
+
+
+do_install() {
+	vmkdir "usr/bin"
+	vmkdir "usr/lib/sublime_text"
+	cp --preserve=mode -r ./* "${DESTDIR}/usr/lib/sublime_text"
+	vinstall "sublime_text.desktop" 644 "usr/share/applications/"
+	for size in 128 16 256 32 48; do
+		vinstall "Icon/${size}x${size}/sublime-text.png" 644 \
+		 "usr/share/icons/hicolor/${size}x${size}/apps/"
+	done
+	ln -s /usr/lib/sublime_text/sublime_text ${DESTDIR}/usr/bin/subl3
+	vsed -e 's:Exec=/opt/sublime_text/:Exec=/usr/lib/sublime_text/:' \
+	 -i ${DESTDIR}/usr/share/applications/sublime_text.desktop
+	vlicense EULA
+}

--- a/srcpkgs/sublime-text3/INSTALL.msg
+++ b/srcpkgs/sublime-text3/INSTALL.msg
@@ -1,0 +1,4 @@
+sublime-text3 is replaced with the restricted sublime-text3-bin
+package, due to its license that restricts redistribution.
+In order to install it you have to build it with xbps-src, please see:
+https://docs.voidlinux.org/xbps/repositories/restricted.html

--- a/srcpkgs/sublime-text3/template
+++ b/srcpkgs/sublime-text3/template
@@ -1,36 +1,15 @@
 # Template file for 'sublime-text3'
 pkgname=sublime-text3
 version=3211
-revision=2
-depends="libpng gtk+ hicolor-icon-theme desktop-file-utils"
-short_desc="Sophisticated text editor for code, markup and prose"
-maintainer="Andrea Brancaleoni <miwaxe@pompel.me>"
-license="custom:Proprietary"
-homepage="http://www.sublimetext.com/3dev"
-
-if [ "$XBPS_TARGET_MACHINE" = "x86_64" ]; then
-	distfiles="https://download.sublimetext.com/sublime_text_3_build_${version}_x64.tar.bz2"
-	checksum=0b3c8ca5e6df376c3c24a4b9ac2e3b391333f73b229bc6e87d0b4a5f636d74ee
-else
-	distfiles="https://download.sublimetext.com/sublime_text_3_build_${version}_x32.tar.bz2"
-	checksum=480609962bbbd12128b5332c7831372b8851c13e160512730d1b0a6a835a3071
-fi
-
-repository="nonfree"
+revision=3
 archs="i686 x86_64"
-wrksrc="sublime_text_3"
-nopie=yes
+build_style=meta
+short_desc="Empty meta-package for sublime-text3"
+maintainer="Andrea Brancaleoni <miwaxe@pompel.me>"
+license="custom:EULA" #no vlicense check
+homepage="http://www.sublimetext.com/3dev"
+repository="nonfree"
 
 do_install() {
-	vmkdir "usr/bin"
-	vmkdir "usr/lib/sublime_text"
-	cp --preserve=mode -r ./* "${DESTDIR}/usr/lib/sublime_text"
-	vinstall "sublime_text.desktop" 644 "usr/share/applications/"
-	for size in 128 16 256 32 48; do
-		vinstall "Icon/${size}x${size}/sublime-text.png" 644 \
-		 "usr/share/icons/hicolor/${size}x${size}/apps/"
-	done
-	ln -s /usr/lib/sublime_text/sublime_text ${DESTDIR}/usr/bin/subl3
-	vsed -e 's:Exec=/opt/sublime_text/:Exec=/usr/lib/sublime_text/:' \
-	 -i ${DESTDIR}/usr/share/applications/sublime_text.desktop
+	vdoc "${XBPS_SRCPKGDIR}/${pkgname}/INSTALL.msg"  README.voidlinux
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

from the [EULA](https://www.sublimehq.com/eula) 2b (emphasis mine):
> **You may not distribute** or sell license keys or **the SOFTWARE PRODUCT to third parties**. Licenses will be revoked if distributed or sold to third parties.

I followed the example of sublime-merge -> sublime-merge-bin

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
