### PR TITLE
New package: lean3-community-3.42.1

### DIFF
--- a/srcpkgs/lean3-community/template
+++ b/srcpkgs/lean3-community/template
@@ -1,6 +1,6 @@
 # Template file for 'lean3-community'
 pkgname=lean3-community
-version=3.40.0
+version=3.42.1
 revision=1
 wrksrc="lean-$version"
 build_wrksrc=src
@@ -14,7 +14,8 @@ license="Apache-2.0"
 homepage="https://leanprover-community.github.io/"
 changelog="https://raw.githubusercontent.com/leanprover-community/lean/master/doc/changes.md"
 distfiles="https://github.com/leanprover-community/lean/archive/v${version}.tar.gz"
-checksum=955496d97b2193fea3609a3f3f7ad9cab6413e0d0ea6c1a03d6c1656a2ec08ef
+checksum=5b8cbfdea6cf4de5488467297958876aa0b3a79ed5806f7d0f01a0c396beb4e2
+nocross=yes # runs binaries built for target (TODO)
 
 if [ -n "$CROSS_BUILD" ]; then
 	configure_args+=" -DCROSS_COMPILE=ON"
@@ -27,5 +28,5 @@ do_check() {
 	#   See: https://github.com/void-linux/void-packages/pull/35907
 	# complete_trailing_period: fails on i686
 	#	See: https://github.com/leanprover-community/lean/issues/685
-	ctest -E 'style_check|complete_trailing_period'
+	ctest -E 'style_check|complete_trailing_period' ${makejobs}
 }

--- a/srcpkgs/lean3-community/template
+++ b/srcpkgs/lean3-community/template
@@ -1,0 +1,31 @@
+# Template file for 'lean3-community'
+pkgname=lean3-community
+version=3.40.0
+revision=1
+wrksrc="lean-$version"
+build_wrksrc=src
+build_style=cmake
+configure_args="-DUSE_GITHASH=OFF"
+hostmakedepends="python3"
+makedepends="gmp-devel"
+short_desc="Lean Theorem Prover, maintained by the Lean community"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="Apache-2.0"
+homepage="https://leanprover-community.github.io/"
+changelog="https://raw.githubusercontent.com/leanprover-community/lean/master/doc/changes.md"
+distfiles="https://github.com/leanprover-community/lean/archive/v${version}.tar.gz"
+checksum=955496d97b2193fea3609a3f3f7ad9cab6413e0d0ea6c1a03d6c1656a2ec08ef
+
+if [ -n "$CROSS_BUILD" ]; then
+	configure_args+=" -DCROSS_COMPILE=ON"
+fi
+
+do_check() {
+	cd ${cmake_builddir:=build}
+	# style_check: fails on (generated file)
+	#	CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp
+	#   See: https://github.com/void-linux/void-packages/pull/35907
+	# complete_trailing_period: fails on i686
+	#	See: https://github.com/leanprover-community/lean/issues/685
+	ctest -E 'style_check|complete_trailing_period'
+}


### PR DESCRIPTION
This is an updated version of #32559.

Recently (maybe a cmake update) there is a test failure that seems to be related to cmake. Here's the relevant part of the output of `./xbps-src check lean-community`:
```
[0/1] Running tests...
Test project /builddir/lean-3.40.0/src/build
          Start    1: style_check
   1/1427 Test    #1: style_check .................................................***Failed   26.22 sec
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:50:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:54:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:130:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:139:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:149:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:154:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:291:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:313:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:670:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:675:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:681:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:688:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:689:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:690:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:699:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:704:  Weird number of spaces at line-start.  Are you using a 2-space indent?  [whitespace/indent] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:710:  Missing space after ,  [whitespace/comma] [3]
/builddir/lean-3.40.0/src/build/CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp:768:  { should almost always be at the end of the previous line  [whitespace/braces] [4]
/builddir/lean-3.40.0/src/build/githash.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
/builddir/lean-3.40.0/src/build/version.h:0:  No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
Total errors found: 21
```

This may be related to the following warning that is output by `./xbps-src configure lean-community`:
```
CMake Warning (dev):
  Policy CMP0058 is not set: Ninja requires custom command byproducts to be
  explicit.  Run "cmake --help-policy CMP0058" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  This project specifies custom command DEPENDS on files in the build tree
  that are not specified as the OUTPUT or BYPRODUCTS of any
  add_custom_command or add_custom_target:

   CMakeFiles/3.22.2/CompilerIdCXX/CMakeCXXCompilerId.cpp

  For compatibility with versions of CMake that did not have the BYPRODUCTS
  option, CMake is generating phony rules for such files to convince 'ninja'
  to build.

  Project authors should add the missing BYPRODUCTS or OUTPUT options to the
  custom commands that produce these files.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Any help with this is appreciated. I'm sure this was working ok recently.

Another issue is a test failing on i686 only (cf https://github.com/leanprover-community/lean/issues/685) is there an easy way to disable a particular test for i686?