### PR TITLE
spotify-qt: add qt5-svg dependency

### DIFF
--- a/srcpkgs/spotify-qt/template
+++ b/srcpkgs/spotify-qt/template
@@ -1,10 +1,11 @@
 # Template file for 'spotify-qt'
 pkgname=spotify-qt
 version=3.8
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config qt5-devel"
 makedepends="qt5-devel qt5-svg-devel"
+depends="qt5-svg"
 short_desc="Lightweight Spotify client using Qt"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
While the application does run without this dependency, a GUI client without icons is barely usable.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)