### PR TITLE
zoom: adds missing libxkbcommon-x11 dependency

### DIFF
--- a/srcpkgs/zoom/template
+++ b/srcpkgs/zoom/template
@@ -7,7 +7,7 @@ wrksrc=zoom
 create_wrksrc=yes
 hostmakedepends="rpmextract"
 depends="$(vopt_if systemqt 'qt5 qt5-graphicaleffects qt5-imageformats qt5-quickcontrols qt5-quickcontrols2 qt5-svg qt5-script qt5-declarative')
- xcb-util-image xcb-util-keysyms"
+ xcb-util-image xcb-util-keysyms libxkbcommon-x11"
 short_desc="Video Conferencing and Web Conferencing Service"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="custom:Proprietary"


### PR DESCRIPTION
zoom currently doesn't start and output nothing.

I found solution in
https://www.reddit.com/r/voidlinux/comments/mhyfha/zoom_wont_start/
and figured out the real missing dep is libxkbcommon-x11

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64