### PR TITLE
google-chrome: add missing gtk+3 dependency

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,10 +1,11 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
 version=99.0.4844.51
-revision=1
+revision=2
 _channel=stable
 archs="x86_64"
 hostmakedepends="curl tar xz python3 python3-html2text python3-setuptools"
+depends="gtk+3"
 short_desc="Attempt at creating a safer, faster, and more stable browser"
 maintainer="Michael Aldridge <maldridge@voidlinux.org>"
 license="custom:chrome"


### PR DESCRIPTION
Google Chrome would crash without gtk+3.

#### Testing the changes
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, x86_64