### PR TITLE
freerdp: update to 2.6.0.

### DIFF
--- a/srcpkgs/freerdp/template
+++ b/srcpkgs/freerdp/template
@@ -1,6 +1,6 @@
 # Template file for 'freerdp'
 pkgname=freerdp
-version=2.4.1
+version=2.6.0
 revision=1
 wrksrc="FreeRDP-${version}"
 build_style=cmake
@@ -20,7 +20,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.freerdp.com/"
 distfiles="https://github.com/FreeRDP/FreeRDP/archive/${version}.tar.gz"
-checksum=20cc4e234613db9bf89f885fc1d0bb820080b1cad66e0650fe3cb6c02ec48a59
+checksum=b9eb850f27bed4362b9a1017d37f6e271f43428948f995e7815e039306cb6ddd
 CFLAGS="-Wno-dev"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
closes #35887

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

Feel free to test it, @hiltjo.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
