### PR TITLE
gifski: update to 1.6.4.

### DIFF
--- a/srcpkgs/gifski/template
+++ b/srcpkgs/gifski/template
@@ -1,6 +1,6 @@
 # Template file for 'gifski'
 pkgname=gifski
-version=1.5.1
+version=1.6.4
 revision=1
 build_style=cargo
 configure_args="--features=openmp"
@@ -10,7 +10,7 @@ maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="AGPL-3.0-only"
 homepage="https://gif.ski"
 distfiles="https://github.com/ImageOptim/gifski/archive/${version}.tar.gz"
-checksum=88beeb896b6a1138046f665c3495f85670a74a527e34743080d8976d3f1b73b7
+checksum=1bcc1bdbfdb206f44de75662ee5a8a8c61d336c04cb62457e02c9fa8456f3928
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: *briefly*

#### Local build testing
- libc x86_64


#### Reason

Previous version 1.5.1 not only makes me want to drink, it glitches a greenish tint flicker (has to do with transparency from what I found?) which is not a problem in 1.6.4

![sonic_intro_bad](https://user-images.githubusercontent.com/8009811/156788814-a1890be0-ee57-46e9-af33-fedf06944272.gif)

![sonic_intro_good](https://user-images.githubusercontent.com/8009811/156788819-04639e98-1b72-4732-81fe-47cfb56cf458.gif)


