### PR TITLE
routinator: update to 0.11.2

### DIFF
--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,6 +1,6 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.10.2
+version=0.11.2
 revision=1
 build_style=cargo
 depends="rsync"
@@ -8,9 +8,10 @@ short_desc="Resource Public Key Infrastructure (RPKI) validator"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="BSD-3-Clause"
 homepage="https://rpki.readthedocs.io/"
+changelog="https://raw.githubusercontent.com/NLnetLabs/routinator/main/Changelog.md"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
 conf_files="/etc/routinator/routinator.conf"
-checksum=b85e03447eaffc3ec0df78eeeb5ad87aaaeabc0974d87ea5d516e04c3e1bbbb3
+checksum=00f825c53168592da0285e8dbd228018e77248d458214a2c0f86cd0ca45438f5
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;
@@ -19,7 +20,6 @@ esac
 
 post_install() {
 	vdoc README.md
-	vdoc doc/misc.md
 	vman doc/routinator.1
 	vinstall etc/routinator.conf.system-service 0644 etc/routinator routinator.conf
 	vlicense LICENSE


### PR DESCRIPTION
in addition:
- upstream has removed doc/misc.md
- add changelog

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (crossbuilds last on 0.11.1):
  - aarch64-musl
  - armv7l
  - armv6l-musl
