### PR TITLE
gcc: add --enable-autolink-libatomic.

### DIFF
--- a/common/build-style/void-cross.sh
+++ b/common/build-style/void-cross.sh
@@ -131,7 +131,7 @@ _void_cross_build_bootstrap_gcc() {
 		--disable-libmudflap \
 		--disable-libssp \
 		--disable-libitm \
-		--disable-libatomic \
+		--disable-libatomic --disable-autolink-libatomic \
 		--disable-threads \
 		--disable-sjlj-exceptions \
 		--enable-languages=c \
@@ -364,6 +364,10 @@ _void_cross_build_gcc() {
 	local ver=$2
 
 	msg_normal "Building gcc for ${tgt}\n"
+
+	# GIANT HACK: create an empty libatomic.a so gcc cross-compile
+	# below works.
+	ar r ${wrksrc}/build_root/usr/${tgt}/usr/lib/libatomic.a
 
 	mkdir -p ${wrksrc}/gcc_build
 	cd ${wrksrc}/gcc_build

--- a/srcpkgs/cross-arm-linux-gnueabihf/template
+++ b/srcpkgs/cross-arm-linux-gnueabihf/template
@@ -5,9 +5,10 @@ _glibc_version=2.32
 _linux_version=5.10.4
 pkgname=cross-arm-linux-gnueabihf
 version=0.34
-revision=1
+revision=2
 build_style=void-cross
-configure_args="--with-arch=armv6 --with-fpu=vfp --with-float=hard"
+configure_args="--with-arch=armv6 --with-fpu=vfp --with-float=hard
+ --enable-autolink-libatomic"
 hostmakedepends="texinfo tar gcc-objc gcc-go flex perl python3"
 makedepends="isl15-devel libmpc-devel zlib-devel gmp-devel mpfr-devel"
 depends="${pkgname}-libc-${version}_${revision}"

--- a/srcpkgs/gcc/patches/libatomic-autolink.patch
+++ b/srcpkgs/gcc/patches/libatomic-autolink.patch
@@ -1,0 +1,251 @@
+Add --enable-autolink-libatomic, to make gcc link -latomic by default.
+
+Taken from Alpine: https://git.alpinelinux.org/aports/plain/main/gcc/0039-configure-Add-enable-autolink-libatomic-use-in-LINK_.patch
+
+From 52ce9c86c0c89ae45e0d08cc232682e1811aa8f2 Mon Sep 17 00:00:00 2001
+From: Drew DeVault <sir@cmpwn.com>
+Date: Wed, 9 Dec 2020 16:07:26 +0000
+Subject: [PATCH] configure: Add --enable-autolink-libatomic, use in
+ LINK_GCC_C_SEQUENCE_SPEC [PR81358]
+
+This fixes issues with RISC-V.
+---
+ Makefile.in           |  1 +
+ gcc/config.in         |  6 ++++++
+ gcc/config/gnu-user.h | 12 +++++++++++-
+ gcc/configure         | 34 +++++++++++++++++++++++++++++++---
+ gcc/configure.ac      | 22 +++++++++++++++++++++-
+ gcc/doc/install.texi  |  8 ++++++++
+ gcc/doc/tm.texi       |  8 +++++++-
+ gcc/doc/tm.texi.in    |  8 +++++++-
+ gcc/gcc.c             | 12 +++++++++++-
+ 9 files changed, 103 insertions(+), 8 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index f97db1ef569..7e577ed3dbb 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -222,6 +222,7 @@ HOST_EXPORTS = \
+ 	RANLIB_FOR_TARGET="$(RANLIB_FOR_TARGET)"; export RANLIB_FOR_TARGET; \
+ 	READELF_FOR_TARGET="$(READELF_FOR_TARGET)"; export READELF_FOR_TARGET; \
+ 	TOPLEVEL_CONFIGURE_ARGUMENTS="$(TOPLEVEL_CONFIGURE_ARGUMENTS)"; export TOPLEVEL_CONFIGURE_ARGUMENTS; \
++	TARGET_CONFIGDIRS="$(TARGET_CONFIGDIRS)"; export TARGET_CONFIGDIRS; \
+ 	HOST_LIBS="$(STAGE1_LIBS)"; export HOST_LIBS; \
+ 	GMPLIBS="$(HOST_GMPLIBS)"; export GMPLIBS; \
+ 	GMPINC="$(HOST_GMPINC)"; export GMPINC; \
+diff --git a/gcc/config.in b/gcc/config.in
+index 059c818c895..2a560417440 100644
+--- a/gcc/config.in
++++ b/gcc/config.in
+@@ -106,6 +106,12 @@
+ #endif
+ 
+ 
++/* Define if libatomic should always be linked. */
++#ifndef USED_FOR_TARGET
++#undef ENABLE_AUTOLINK_LIBATOMIC
++#endif
++
++
+ /* Define to 1 to specify that we are using the BID decimal floating point
+    format instead of DPD */
+ #ifndef USED_FOR_TARGET
+diff --git a/gcc/config/gnu-user.h b/gcc/config/gnu-user.h
+index 902378e1bad..daf7727a01a 100644
+--- a/gcc/config/gnu-user.h
++++ b/gcc/config/gnu-user.h
+@@ -109,8 +109,18 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ #define LINK_EH_SPEC "%{!static|static-pie:--eh-frame-hdr} "
+ #endif
+ 
++#if !defined(LINK_LIBATOMIC_SPEC) && defined(ENABLE_AUTOLINK_LIBATOMIC)
++#  ifdef LD_AS_NEEDED_OPTION
++#    define LINK_LIBATOMIC_SPEC LD_AS_NEEDED_OPTION " -latomic " LD_NO_AS_NEEDED_OPTION
++#  else
++#    define LINK_LIBATOMIC_SPEC "-latomic"
++#  endif
++#elif !defined(LINK_LIBATOMIC_SPEC)
++#  define LINK_LIBATOMIC_SPEC ""
++#endif
++
+ #define GNU_USER_TARGET_LINK_GCC_C_SEQUENCE_SPEC \
+-  "%{static|static-pie:--start-group} %G %{!nolibc:%L} \
++  "%{static|static-pie:--start-group} %G %{!nolibc:" LINK_LIBATOMIC_SPEC " %L} \
+    %{static|static-pie:--end-group}%{!static:%{!static-pie:%G}}"
+ 
+ #undef LINK_GCC_C_SEQUENCE_SPEC
+diff --git a/gcc/configure b/gcc/configure
+index 592e81e40f6..8672298f23f 100755
+--- a/gcc/configure
++++ b/gcc/configure
+@@ -978,5 +978,6 @@ with_changes_root_url
+ enable_languages
+ with_multilib_list
++enable_autolink_libatomic
+ with_zstd
+ with_zstd_include
+ with_zstd_lib
+@@ -1707,6 +1708,9 @@ Optional Features:
+   --disable-shared        don't provide a shared libgcc
+   --disable-gcov          don't provide libgcov and related host tools
+   --enable-languages=LIST specify which front-ends to build
++  --enable-autolink-libatomic
++                          enable automatic linking of libatomic (ignored if
++                          not built)
+   --disable-rpath         do not hardcode runtime library paths
+   --enable-sjlj-exceptions
+                           arrange to use setjmp/longjmp exception handling
+@@ -8078,6 +8081,32 @@ else
+   with_multilib_generator=default
+ fi
+ 
++# If libatomic is available, whether it should be linked automatically
++# Check whether --enable-autolink-libatomic was given.
++if test "${enable_autolink_libatomic+set}" = set; then :
++  enableval=$enable_autolink_libatomic;
++  case $enable_autolink_libatomic in
++    yes | no) ;;
++    *) as_fn_error $? "'$enable_autolink_libatomic' is an invalid value for
++--enable-autolink-libatomic.  Valid choices are 'yes' and 'no'." "$LINENO" 5 ;;
++  esac
++
++else
++  enable_autolink_libatomic=''
++fi
++
++
++if test x$enable_autolink_libatomic = xyes; then
++  if echo " ${TARGET_CONFIGDIRS} " | grep " libatomic " > /dev/null 2>&1 ; then
++
++$as_echo "#define ENABLE_AUTOLINK_LIBATOMIC 1" >>confdefs.h
++
++  else
++    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: libatomic is not build for this target, --enable-autolink-libatomic ignored" >&5
++$as_echo "$as_me: WARNING: libatomic is not build for this target, --enable-autolink-libatomic ignored" >&2;}
++  fi
++fi
++
+ 
+ # -------------------------
+ # Checks for other programs
+diff --git a/gcc/configure.ac b/gcc/configure.ac
+index 1577529ffb7..e96691f69ba 100644
+--- a/gcc/configure.ac
++++ b/gcc/configure.ac
+@@ -1149,6 +1149,27 @@ AC_ARG_WITH(multilib-generator,
+ :,
+ with_multilib_generator=default)
+ 
++# If libatomic is available, whether it should be linked automatically
++AC_ARG_ENABLE(autolink-libatomic,
++[AS_HELP_STRING([--enable-autolink-libatomic],
++		[enable automatic linking of libatomic (ignored if not built)])],
++[
++  case $enable_autolink_libatomic in
++    yes | no) ;;
++    *) AC_MSG_ERROR(['$enable_autolink_libatomic' is an invalid value for
++--enable-autolink-libatomic.  Valid choices are 'yes' and 'no'.]) ;;
++  esac
++], [enable_autolink_libatomic=''])
++
++if test x$enable_autolink_libatomic = xyes; then
++  if echo " ${TARGET_CONFIGDIRS} " | grep " libatomic " > /dev/null 2>&1 ; then
++    AC_DEFINE(ENABLE_AUTOLINK_LIBATOMIC, 1,
++	[Define if libatomic should always be linked.])
++  else
++    AC_MSG_WARN([libatomic is not build for this target, --enable-autolink-libatomic ignored])
++  fi
++fi
++
+ # -------------------------
+ # Checks for other programs
+ # -------------------------
+diff --git a/gcc/doc/install.texi b/gcc/doc/install.texi
+index 4c38244ae58..4a544e6a4ee 100644
+--- a/gcc/doc/install.texi
++++ b/gcc/doc/install.texi
+@@ -2213,6 +2213,14 @@ files, but these changed header paths may conflict with some compilation
+ environments.  Enabled by default, and may be disabled using
+ @option{--disable-canonical-system-headers}.
+ 
++@item --enable-autolink-libatomic
++@itemx --disable-autolink-libatomic
++Tell GCC that it should automatically link libatomic; if supported by
++the linker, the file is only linked as needed. This flag is ignored
++when libatomic is not built. Note that this conigure flag is in particular
++useful when building an offloading-target compiler; as for those, a
++user had to specify @code{-foffload=target=-latomic} otherwise.
++
+ @item --with-glibc-version=@var{major}.@var{minor}
+ Tell GCC that when the GNU C Library (glibc) is used on the target it
+ will be version @var{major}.@var{minor} or later.  Normally this can
+diff --git a/gcc/doc/tm.texi b/gcc/doc/tm.texi
+index b370bc76b25..acc78273983 100644
+--- a/gcc/doc/tm.texi
++++ b/gcc/doc/tm.texi
+@@ -381,7 +381,13 @@ the argument @option{-lgcc} to tell the linker to do the search.
+ 
+ @defmac LINK_GCC_C_SEQUENCE_SPEC
+ The sequence in which libgcc and libc are specified to the linker.
+-By default this is @code{%G %L %G}.
++By default this is @code{%G LINK_LIBATOMIC_SPEC %L %G}.
++@end defmac
++
++@defmac LINK_LIBATOMIC_SPEC
++This macro is used in the default @code{LINK_GCC_C_SEQUENCE_SPEC} to link
++libatomic. By default, it is unset unless @code{ENABLE_AUTOLINK_LIBATOMIC}
++is set.
+ @end defmac
+ 
+ @defmac POST_LINK_SPEC
+diff --git a/gcc/doc/tm.texi.in b/gcc/doc/tm.texi.in
+index 2974dae2701..80e003a38ce 100644
+--- a/gcc/doc/tm.texi.in
++++ b/gcc/doc/tm.texi.in
+@@ -381,7 +381,13 @@ the argument @option{-lgcc} to tell the linker to do the search.
+ 
+ @defmac LINK_GCC_C_SEQUENCE_SPEC
+ The sequence in which libgcc and libc are specified to the linker.
+-By default this is @code{%G %L %G}.
++By default this is @code{%G LINK_LIBATOMIC_SPEC %L %G}.
++@end defmac
++
++@defmac LINK_LIBATOMIC_SPEC
++This macro is used in the default @code{LINK_GCC_C_SEQUENCE_SPEC} to link
++libatomic. By default, it is unset unless @code{ENABLE_AUTOLINK_LIBATOMIC}
++is set.
+ @end defmac
+ 
+ @defmac POST_LINK_SPEC
+diff --git a/gcc/gcc.c b/gcc/gcc.c
+index 22dbbf85850..90aa576037a 100644
+--- a/gcc/gcc.c
++++ b/gcc/gcc.c
+@@ -980,13 +980,23 @@ proper position among the other output files.  */
+ # define ASM_DEBUG_OPTION_SPEC ""
+ #endif
+ 
++#if !defined(LINK_LIBATOMIC_SPEC) && defined(ENABLE_AUTOLINK_LIBATOMIC)
++#  ifdef LD_AS_NEEDED_OPTION
++#    define LINK_LIBATOMIC_SPEC LD_AS_NEEDED_OPTION " -latomic " LD_NO_AS_NEEDED_OPTION
++#  else
++#    define LINK_LIBATOMIC_SPEC "-latomic"
++#  endif
++#elif !defined(LINK_LIBATOMIC_SPEC)
++#  define LINK_LIBATOMIC_SPEC ""
++#endif
++
+ /* Here is the spec for running the linker, after compiling all files.  */
+ 
+ /* This is overridable by the target in case they need to specify the
+    -lgcc and -lc order specially, yet not require them to override all
+    of LINK_COMMAND_SPEC.  */
+ #ifndef LINK_GCC_C_SEQUENCE_SPEC
+-#define LINK_GCC_C_SEQUENCE_SPEC "%G %{!nolibc:%L %G}"
++#define LINK_GCC_C_SEQUENCE_SPEC "%G %{!nolibc:" LINK_LIBATOMIC_SPEC " %L %G}"
+ #endif
+ 
+ #ifdef ENABLE_DEFAULT_SSP
+-- 
+2.35.1
+

--- a/srcpkgs/gcc/patches/libatomic-configure.patch
+++ b/srcpkgs/gcc/patches/libatomic-configure.patch
@@ -1,0 +1,61 @@
+Fix gcc check to build libatomic properly with --enable-autolink-libatomic.
+
+Taken from Alpine: https://git.alpinelinux.org/aports/plain/main/gcc/0040-configure-fix-detection-of-atomic-builtins-in-libato.patch
+
+From 5010fa237897bca92291ba8835123125d4af933a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=B6ren=20Tempel?= <soeren+git@soeren-tempel.net>
+Date: Sun, 29 Aug 2021 09:45:27 +0200
+Subject: [PATCH] configure: fix detection of atomic builtins in libatomic
+ configure script
+
+Alpine's --enable-autolink-libatomic (which is enabled for riscv64 by
+default) causes the libatomic configure script to incorrectly detect
+which builtins are available on riscv64. This then causes incorrect code
+generation for libatomic since it assumes compiler builtins to be
+available which are not actually available on riscv64.
+
+This commit fixes this issue by disabling linking of libatomic configure
+test code entirely, thereby preventing linking against libatomic.
+
+See:
+
+* https://gitlab.alpinelinux.org/alpine/aports/-/issues/12948
+* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101996#c6
+---
+ libatomic/configure.tgt | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/libatomic/configure.tgt b/libatomic/configure.tgt
+index 670b0d72cfe..38c2cd9345f 100644
+--- a/libatomic/configure.tgt
++++ b/libatomic/configure.tgt
+@@ -30,6 +30,26 @@
+ # on ${target_cpu}.  For example to allow proper use of multilibs.
+ configure_tgt_pre_target_cpu_XCFLAGS="${XCFLAGS}"
+ 
++# The libatomic configure script performs several checks to determine
++# whether builtins for atomic operations are available. When compiling
++# with --enable-autolink-libatomic the test code compiled by the
++# configure script is also linked against libatomic. This causes it
++# to think that builtins are available, even if there are not, since
++# the tested symbols are provided by libatomic.
++#
++# This is a hack to ensure that we don't link against libatomic by not
++# linking any configure test code at all when --enable-autolink-libatomic
++# is given.
++#
++# See:
++#
++#   * https://gitlab.alpinelinux.org/alpine/aports/-/issues/12817
++#   * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101996#c4
++#
++if test x$enable_autolink_libatomic = xyes; then
++	gcc_no_link=yes
++fi
++
+ case "${target_cpu}" in
+   alpha*)
+ 	# fenv.c needs this option to generate inexact exceptions.
+-- 
+2.35.1
+

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -7,7 +7,7 @@ pkgname=gcc
 # to get regression fixes not yet incorporate into a stable release
 # it should be possible to switch back to stable with 10.3 or 11
 version=10.2.1pre1
-revision=3
+revision=4
 _patchver="${version%pre*}"
 _minorver="${_patchver%.*}"
 _majorver="${_minorver%.*}"
@@ -196,17 +196,17 @@ do_configure() {
 
 	_hash=gnu
 	case "$XBPS_TARGET_MACHINE" in
-		mipselhf-musl) _args+=" --with-arch=mips32r2 --with-float=hard"; _hash=sysv;;
-		mipsel-musl) _args+=" --with-arch=mips32r2 --with-float=soft"; _hash=sysv;;
-		mipshf-musl) _args+=" --with-arch=mips32r2 --with-float=hard";;
-		mips-musl) _args+=" --with-arch=mips32r2 --with-float=soft";;
-		armv5*) _args+=" --with-arch=armv5te --with-float=soft";;
-		armv6l*) _args+=" --with-arch=armv6 --with-fpu=vfp --with-float=hard";;
+		mipselhf-musl) _args+=" --with-arch=mips32r2 --with-float=hard --enable-autolink-libatomic"; _hash=sysv;;
+		mipsel-musl) _args+=" --with-arch=mips32r2 --with-float=soft --enable-autolink-libatomic"; _hash=sysv;;
+		mipshf-musl) _args+=" --with-arch=mips32r2 --with-float=hard --enable-autolink-libatomic";;
+		mips-musl) _args+=" --with-arch=mips32r2 --with-float=soft --enable-autolink-libatomic";;
+		armv5*) _args+=" --with-arch=armv5te --with-float=soft --enable-autolink-libatomic";;
+		armv6l*) _args+=" --with-arch=armv6 --with-fpu=vfp --with-float=hard --enable-autolink-libatomic";;
 		armv7l*) _args+=" --with-arch=armv7-a --with-fpu=vfpv3 --with-float=hard";;
 		aarch64*) _args+=" --with-arch=armv8-a";;
 		ppc64le*) _args+=" --with-abi=elfv2 --enable-secureplt --enable-targets=powerpcle-linux";;
 		ppc64*) _args+=" --with-abi=elfv2 --enable-secureplt --enable-targets=powerpc-linux";;
-		ppc*) _args+=" --enable-secureplt";;
+		ppc*) _args+=" --enable-secureplt --enable-autolink-libatomic";;
 	esac
 
 	# on ppc64le-musl and all big endian ppc64

--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -54,8 +54,9 @@ else
 	_have_gccgo=no
 fi
 makedepends="zlib-devel"
-depends="binutils libgcc-devel-${version}_${revision}
- libstdc++-devel-${version}_${revision} libssp-devel-${version}_${revision}"
+depends="binutils libatomic-devel-${version}_${revision}
+ libgcc-devel-${version}_${revision} libstdc++-devel-${version}_${revision}
+ libssp-devel-${version}_${revision}"
 checkdepends="dejagnu"
 
 subpackages="libgcc libgomp libgomp-devel libatomic libatomic-devel"


### PR DESCRIPTION
First stab at #35992.

The hack with the empty libatomics.a is pretty ugly, but required for a cross-build, as we cannot build libatomic in the bootstrap gcc due to autoconf limitations. :(