### PR TITLE
autofs: add log service, fix patch args

### DIFF
--- a/srcpkgs/autofs/files/autofs/log/run
+++ b/srcpkgs/autofs/files/autofs/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -p daemon.info -t autofs

--- a/srcpkgs/autofs/files/autofs/run
+++ b/srcpkgs/autofs/files/autofs/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+exec 2>&1
 exec automount -f

--- a/srcpkgs/autofs/patches/musl.patch
+++ b/srcpkgs/autofs/patches/musl.patch
@@ -30,18 +30,18 @@
  #include <dlfcn.h>
 --- a/lib/log.c.orig     2019-03-30 10:49:52.965336128 +0100
 +++ b/lib/log.c  2019-03-30 10:50:43.232710045 +0100
-@@ -38,7 +38,11 @@ static char *prepare_attempt_prefix(cons
-       char buffer[ATTEMPT_ID_SIZE + 1];
-       char *prefixed_msg = NULL;
+@@ -38,7 +38,11 @@
+ 	char buffer[ATTEMPT_ID_SIZE + 1];
+ 	char *prefixed_msg = NULL;
  
--      attempt_id = pthread_getspecific(key_thread_attempt_id);
-+      if (key_thread_attempt_id) {
-+              attempt_id = pthread_getspecific(key_thread_attempt_id);
-+      } else {
-+              attempt_id = 0;
-+      }
-       if (attempt_id) {
-               int len = sizeof(buffer) + 1 + strlen(msg) + 1;
+-	attempt_id = pthread_getspecific(key_thread_attempt_id);
++	if (key_thread_attempt_id) {
++		attempt_id = pthread_getspecific(key_thread_attempt_id);
++	} else {
++		attempt_id = 0;
++	}
+ 	if (attempt_id) {
+ 		int len = sizeof(buffer) + 1 + strlen(msg) + 1;
  
 --- a/include/hash.h	2021-01-31 09:22:19.668222263 +0100
 +++ b/include/hash.h	2021-01-31 09:22:41.390327622 +0100

--- a/srcpkgs/autofs/template
+++ b/srcpkgs/autofs/template
@@ -1,7 +1,7 @@
 # Template file for 'autofs'
 pkgname=autofs
 version=5.1.8
-revision=1
+revision=2
 build_style=gnu-configure
 make_build_args="DONTSTRIP=1"
 configure_args="--with-libtirpc --with-mapdir=/etc/autofs --sbindir=/usr/bin"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

the log service was essential for  successfully debugging my autofs setup

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
