### PR TITLE
nwg-launchers: add makedepends to gtk-layer-shell

### DIFF
--- a/srcpkgs/nwg-launchers/template
+++ b/srcpkgs/nwg-launchers/template
@@ -1,10 +1,10 @@
 # Template file for 'nwg-launchers'
 pkgname=nwg-launchers
 version=0.6.3
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config"
-makedepends="gtkmm-devel json-c++"
+makedepends="gtkmm-devel gtk-layer-shell-devel json-c++"
 short_desc="GTK-based launchers for window managers"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
Adding this dependancy makes nwg-launchers work better under sway and other wlroots-based compositors.
