### PR TITLE
btrfs-progs: update to 5.18.1.

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,22 +1,22 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
-version=5.14.1
-revision=2
+version=5.18.1
+revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=gnu-configure
 make_check_target=test
 configure_args="--disable-backtrace --disable-python"
-hostmakedepends="asciidoc pkg-config xmlto"
+hostmakedepends="pkgconf python3-Sphinx"
 makedepends="acl-devel libzstd-devel lzo-devel libblkid-devel libuuid-devel
- $(vopt_if e2fs 'e2fsprogs-devel') $(vopt_if reiserfs 'reiserfsprogs')
- zlib-devel"
+ eudev-libudev-devel zlib-devel
+ $(vopt_if e2fs 'e2fsprogs-devel') $(vopt_if reiserfs 'reiserfsprogs')"
 short_desc="Btrfs filesystem utilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-only, LGPL-2.1-or-later"
 homepage="https://btrfs.wiki.kernel.org/index.php/Main_Page"
 changelog="https://raw.githubusercontent.com/kdave/btrfs-progs/master/CHANGES"
 distfiles="${KERNEL_SITE}/kernel/people/kdave/${pkgname}/${pkgname}-v${version}.tar.xz"
-checksum=d54a9346545ca46df128e3ccb77d60c097d90c93b7e314990236e28cfaf8c55b
+checksum=6e98a75ccff52e9354daa1ad284c614c490f844273a2fa524cbac9eb841c7255
 # Most of the tests depend on `mount` and `fallocate` commands, which are not
 # presented in chroot-util-linux
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
