### PR TITLE
Signal-Desktop: update to 5.35

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=5.34.0
+version=5.35.0
 revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # discontinued Electron 32-bit support: https://www.electronjs.org/blog/linux-32bit-support
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=54d81b6fa1be05d60a840b9ffcf3f8fc1642863c0a5a6ec2cfa3e02ff6e9e31d
+checksum=12d4766356d50f4eaff907a738860be91bf4c012fd2db62d00757078923dca67
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**
