### PR TITLE
java-commons-io: update to 2.11.0.

### DIFF
--- a/srcpkgs/java-commons-io/template
+++ b/srcpkgs/java-commons-io/template
@@ -1,8 +1,8 @@
 # Template file for 'java-commons-io'
 _origname=commons-io
 pkgname=java-commons-io
-version=2.6
-revision=2
+version=2.11.0
+revision=1
 wrksrc="${_origname}-${version}-src"
 hostmakedepends="openjdk8 apache-maven which"
 depends="virtual?java-runtime"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="http://commons.apache.org/io"
 distfiles="http://archive.apache.org/dist/commons/io/source/${_origname}-${version}-src.tar.gz"
-checksum=f68167938ab15ced969747bc6b4d91c4f923a34ad4fdb2e8c8c3029adaa47e0c
+checksum=5a55361cf2b97228f94b3c65e3a4af784581debe322be551c44b2776db1c6483
 
 case "$XBPS_MACHINE" in
 	ppc64*) ;;
@@ -21,6 +21,10 @@ esac
 do_build() {
 	source /etc/profile.d/10_openjdk8.sh
 	mvn package -Dmaven.test.skip=true
+}
+
+do_check() {
+	mvn test
 }
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (I ran `./xbps-src check java-commons-io`, if that counts)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
 
#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
