### PR TITLE
dbus-glib: update to 0.112.

### DIFF
--- a/srcpkgs/dbus-glib/template
+++ b/srcpkgs/dbus-glib/template
@@ -1,18 +1,19 @@
 # Template file for 'dbus-glib'
 pkgname=dbus-glib
-version=0.110
+version=0.112
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --disable-bash-completion"
 hostmakedepends="pkg-config"
 makedepends="libglib-devel dbus-devel"
 depends="dbus"
+checkdepends="dbus glib-devel"
 short_desc="GLib bindings for D-Bus"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/DBusBindings"
 distfiles="http://dbus.freedesktop.org/releases/$pkgname/$pkgname-$version.tar.gz"
-checksum=7ce4760cf66c69148f6bd6c92feaabb8812dee30846b24cd0f7395c436d7e825
+checksum=7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" --with-dbus-binding-tool=dbus-binding-tool"


### PR DESCRIPTION
Additionally fix `xlint` and tests.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
