### PR TITLE
R cran updates

### DIFF
--- a/srcpkgs/R-cran-R6/template
+++ b/srcpkgs/R-cran-R6/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-R6'
 pkgname=R-cran-R6
-version=2.5.0
+version=2.5.1
 revision=1
 build_style=R-cran
 short_desc="Classes with Reference Semantics"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/r-lib/R6"
-checksum=aec1af9626ec532cb883b544bf9eff4cb2d89c343c7ce0fa31761ec5a7882e02
+checksum=8d92bd29c2ed7bf15f2778618ffe4a95556193d21d8431a7f75e7e5fc102bf48
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-cli/template
+++ b/srcpkgs/R-cran-cli/template
@@ -1,15 +1,15 @@
 # Template file for 'R-cran-cli'
 pkgname=R-cran-cli
-version=2.3.1
+version=3.3.0
 revision=1
 build_style=R-cran
 makedepends="R-cran-assertthat R-cran-glue"
 depends="R-cran-assertthat R-cran-glue"
 short_desc="Helpers for Developing Command Line Interfaces"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/r-lib/cli/"
-checksum=516ce2de54b4a58afa943f31dfdd925e532b67cf5f91aec355e255637b2406ca
+checksum=c3a9ebbcb9017fb9aeda4f7df5ca981e42b169cbd7ce13e592cda2cd74250d63
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-colorspace/template
+++ b/srcpkgs/R-cran-colorspace/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-colorspace'
 pkgname=R-cran-colorspace
-version=1.4r1
-revision=2
+version=2.0r3
+revision=1
 build_style=R-cran
 short_desc="Color Space Manipulation"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="BSD-3-Clause"
 homepage="http://www.hclwizard.org/r-colorspace/"
-checksum=693d713a050f8bfecdb7322739f04b40d99b55aed168803686e43401d5f0d673
+checksum=e75681cc4dd6e4b70303fd96a6d4597065dc6bffcaa4ae4244b73ff19016857f
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-cpp11/template
+++ b/srcpkgs/R-cran-cpp11/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-cpp11'
 pkgname=R-cran-cpp11
-version=0.2.7
+version=0.4.2
 revision=1
 build_style=R-cran
 short_desc="Header only, C++11 interface to R's C interface"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/r-lib/cpp11"
-checksum=1d4154c0d8ef4b564eea828ebebc836b7dbdc89a0848a840dd98173b07f661d4
+checksum=403ce0bf82358d237176053b0fb1e958cb6bfa4d0fb3555bf5801db6a6939b99
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-crayon/template
+++ b/srcpkgs/R-cran-crayon/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-crayon'
 pkgname=R-cran-crayon
-version=1.4.1
+version=1.5.1
 revision=1
 build_style=R-cran
 short_desc="Colored Terminal Output"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/r-lib/crayon/"
-checksum=08b6e42e748d096960b2f32b7ffe690c25742e29fe14c19d1834cd6ff43029c7
+checksum=c025c73b78a8e88e8e4363c8e1a941da5089a7baea39e59ea5342ab9ebe45df9
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-digest/template
+++ b/srcpkgs/R-cran-digest/template
@@ -1,11 +1,11 @@
 # Template file for 'R-cran-digest'
 pkgname=R-cran-digest
-version=0.6.27
+version=0.6.29
 revision=1
 build_style=R-cran
 short_desc="Create Compact Hash Digests of R Objects"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-or-later"
 homepage="http://dirk.eddelbuettel.com/code/digest.html"
 changelog="https://github.com/eddelbuettel/digest/raw/master/ChangeLog"
-checksum=f485f75122907da24c41d4a62c91a232f0c371befd2f77e973342a1bef00253f
+checksum=792c1f14a4c8047745152f5e45ce7351978af8d770c29d2ea39c7acd5d619cd9

--- a/srcpkgs/R-cran-dplyr/template
+++ b/srcpkgs/R-cran-dplyr/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-dplyr'
 pkgname=R-cran-dplyr
-version=1.0.5
+version=1.0.9
 revision=1
 build_style=R-cran
 makedepends="R-cran-ellipsis R-cran-generics R-cran-glue R-cran-lifecycle
@@ -13,7 +13,7 @@ short_desc="Grammar of Data Manipulation for R"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://dplyr.tidyverse.org/"
-checksum=7541a09c66ecb40736e25bc9ec9591f26ec4ee67c99823b4ac855760b5c96e70
+checksum=e2e1f7312618b4e32ada9a1da79cef32eaec12acd408c973a6b069c6be4fb46b
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-ellipsis/template
+++ b/srcpkgs/R-cran-ellipsis/template
@@ -1,12 +1,12 @@
 # Template file for 'R-cran-ellipsis'
 pkgname=R-cran-ellipsis
-version=0.3.1
-revision=2
+version=0.3.2
+revision=1
 build_style=R-cran
 makedepends="R-cran-rlang"
 depends="R-cran-rlang>=0.3.0"
 short_desc="Tools for making ... safer"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-3.0-only"
 homepage="https://ellipsis.r-lib.org/"
-checksum=4f8a15158dfc27cdc0f7554c7a61e92b02e4d70bfc3d968f01a99da2189b75db
+checksum=a90266e5eb59c7f419774d5c6d6bd5e09701a26c9218c5933c9bce6765aa1558

--- a/srcpkgs/R-cran-fansi/template
+++ b/srcpkgs/R-cran-fansi/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-fansi'
 pkgname=R-cran-fansi
-version=0.4.2
+version=1.0.3
 revision=1
 build_style=R-cran
 short_desc="ANSI Control Sequence Aware String Functions"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-or-later"
 homepage="https://cran.r-project.org/web/packages/fansi/index.html"
-checksum=a2edf06cf8b91333a5df4990d50cdb35a63aa4b63c8c8ddf5bedcb499daafc44
+checksum=86a7b83d8c9d28baebbde310cd0b459d0950a9c7ff1a6276ce5858f6a89bc06a

--- a/srcpkgs/R-cran-farver/template
+++ b/srcpkgs/R-cran-farver/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-farver'
 pkgname=R-cran-farver
-version=2.0.3
-revision=2
+version=2.1.1
+revision=1
 build_style=R-cran
 short_desc="High Performance Colour Space Manipulation"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/thomasp85/farver"
-checksum=0e1590df79ec6078f10426411b96216b70568a4eaf3ffd84ca723add0ed8e5cc
+checksum=0dcfda6ca743f465372790bcff1bcbc6a7145fdac1c682b021f654e8c6c996ce
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-generics/template
+++ b/srcpkgs/R-cran-generics/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-generics'
 pkgname=R-cran-generics
-version=0.1.0
+version=0.1.3
 revision=1
 build_style=R-cran
 short_desc="Common generic S3 methods "
 maintainer="luhann <lukehannan@gmail.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/r-lib/generics"
-checksum=ab71d1bdbb66c782364c61cede3c1186d6a94c03635f9af70d926e2c1ac88763
+checksum=75046163bfa8b8a4f4214c1b689e796207f6447182f2e5062cf570302387d053

--- a/srcpkgs/R-cran-ggplot2/template
+++ b/srcpkgs/R-cran-ggplot2/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-ggplot2'
 pkgname=R-cran-ggplot2
-version=3.3.5
+version=3.3.6
 revision=1
 build_style=R-cran
 makedepends="R-cran-digest R-cran-glue R-cran-gtable R-cran-isoband
@@ -11,4 +11,4 @@ short_desc="Create Elegant Data Visualisations Using the Grammar of Graphics"
 maintainer="Florian Wagner <florian@wagner-flo.net>"
 license="GPL-2.0-only"
 homepage="https://ggplot2.tidyverse.org/"
-checksum=b075294faf3af31b18e415f260c62d6000b218770e430484fe38819bdc3224ea
+checksum=bfcb4eb92a0fcd3fab713aca4bb25e916e05914f2540271a45522ad7e43943a9

--- a/srcpkgs/R-cran-glue/template
+++ b/srcpkgs/R-cran-glue/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-glue'
 pkgname=R-cran-glue
-version=1.4.2
+version=1.6.2
 revision=1
 build_style=R-cran
 short_desc="Interpreted String Literals"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/tidyverse/glue/"
-checksum=9f7354132a26e9a876428fa87629b9aaddcd558f9932328e6ac065b95b8ef7ad
+checksum=9da518f12be584c90e75fe8e07f711ee3f6fc0d03d817f72c25dc0f66499fdbf
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-isoband/template
+++ b/srcpkgs/R-cran-isoband/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-isoband'
 pkgname=R-cran-isoband
-version=0.2.4
+version=0.2.5
 revision=1
 build_style=R-cran
 short_desc="Generate Isolines and Isobands from Regularly Spaced Elevation Grids"
 maintainer="Luke Hannan <lukehannan@gmail.com>"
 license="MIT"
 homepage="https://github.com/wilkelab/isoband"
-checksum=96d5bbdbfa4ead40bf30cec5a0d525b6a6b0f21eb92d179289ce2c4459bf387c
+checksum=46f53fa066f0966f02cb2bf050190c0d5e950dab2cdf565feb63fc092c886ba5
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-labeling/template
+++ b/srcpkgs/R-cran-labeling/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-labeling'
 pkgname=R-cran-labeling
-version=0.3
-revision=2
+version=0.4.2
+revision=1
 build_style=R-cran
 short_desc="Axis Labeling"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://cran.r-project.org/web/packages/labeling/"
-checksum=0d8069eb48e91f6f6d6a9148f4e2dc5026cabead15dd15fc343eff9cf33f538f
+checksum=e022d79276173e0d62bf9e37d7574db65ab439eb2ae1833e460b1cff529bd165
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-lifecycle/template
+++ b/srcpkgs/R-cran-lifecycle/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-lifecycle'
 pkgname=R-cran-lifecycle
-version=1.0.0
+version=1.0.1
 revision=1
 build_style=R-cran
 makedepends="R-cran-glue R-cran-rlang"
@@ -9,7 +9,7 @@ short_desc="Manage the Life Cycle of your Package Functions"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/r-lib/lifecycle"
-checksum=03334ab213f2ad49a49e184e73f2051e04d35d43f562db903e68243cd2ec0f8e
+checksum=1da76e1c00f1be96ca34e122ae611259430bf99d6a1b999fdef70c00c30f7ba0
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-magrittr/template
+++ b/srcpkgs/R-cran-magrittr/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-magrittr'
 pkgname=R-cran-magrittr
-version=2.0.1
+version=2.0.3
 revision=1
 build_style=R-cran
 short_desc="Forward-Pipe Operator for R"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://cran.r-project.org/web/packages/magrittr/index.html"
-checksum=75c265d51cc2b34beb27040edb09823c7b954d3990a7a931e40690b75d4aad5f
+checksum=a2bff83f792a1acb801bfe6330bb62724c74d5308832f2cb6a6178336ace55d2
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-pillar/template
+++ b/srcpkgs/R-cran-pillar/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-pillar'
 pkgname=R-cran-pillar
-version=1.5.1
+version=1.7.0
 revision=1
 build_style=R-cran
 makedepends="R-cran-cli R-cran-crayon R-cran-ellipsis R-cran-lifecycle
@@ -8,7 +8,7 @@ makedepends="R-cran-cli R-cran-crayon R-cran-ellipsis R-cran-lifecycle
 depends="R-cran-cli R-cran-crayon R-cran-ellipsis R-cran-lifecycle
  R-cran-rlang R-cran-utf8 R-cran-fansi R-cran-vctrs"
 short_desc="Coloured Formatting for Columns"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/r-lib/pillar/"
-checksum=0ce5d15364dab761dab5b159ec2a4586ed1635f058fa13975725a1921e43e672
+checksum=7841f89658cc8935568c0ff24dc480b4481bac896de2f6447050abc4360a13bb

--- a/srcpkgs/R-cran-rlang/template
+++ b/srcpkgs/R-cran-rlang/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-rlang'
 pkgname=R-cran-rlang
-version=0.4.10
+version=1.0.4
 revision=1
 build_style=R-cran
 short_desc="Functions for Base Types and Core R and 'Tidyverse' Features"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://rlang.r-lib.org/"
-checksum=07530270c4c199f2b7efc5d57a476d99babd9d0c3388a02bb7d57fe312da3576
+checksum=1fb789d46c6a855ce37eba63c353b85aa600c4a2a7ca6075f2632540b42a8696

--- a/srcpkgs/R-cran-svglite/template
+++ b/srcpkgs/R-cran-svglite/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-svglite'
 pkgname=R-cran-svglite
-version=2.0.0
+version=2.1.0
 revision=1
 build_style=R-cran
 makedepends="R-cran-systemfonts R-cran-cpp11 libpng-devel"
@@ -9,4 +9,4 @@ short_desc="Lightweight svg graphics device for R"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-or-later"
 homepage="https://svglite.r-lib.org"
-checksum=76e625fe172a5b7ce99a67b6d631b037b3f7f0021cfe15f2e15e8851b89defa5
+checksum=ad40f590c7e80ae83001a3826b6e8394ba733446ed51fd55faeda974ab839c9b

--- a/srcpkgs/R-cran-systemfonts/template
+++ b/srcpkgs/R-cran-systemfonts/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-systemfonts'
 pkgname=R-cran-systemfonts
-version=1.0.2
+version=1.0.4
 revision=1
 build_style=R-cran
 hostmakedepends="pkg-config"
@@ -9,7 +9,7 @@ short_desc="System Native Font Handling in R"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/r-lib/systemfonts"
-checksum=21ac96412846e06a4062362b159213cb9d83bd60fdf03aa235992b6c49fb36a9
+checksum=ef766c75b942f147d382664a00d6a4930f1bfe0cce9d88943f571682a85a84c0
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-tibble/template
+++ b/srcpkgs/R-cran-tibble/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-tibble'
 pkgname=R-cran-tibble
-version=3.1.0
+version=3.1.7
 revision=1
 build_style=R-cran
 makedepends="R-cran-ellipsis
@@ -10,10 +10,10 @@ depends="R-cran-ellipsis
  R-cran-fansi R-cran-lifecycle R-cran-magrittr
  R-cran-pillar R-cran-rlang R-cran-pkgconfig R-cran-vctrs"
 short_desc="Simple Data Frames"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="http://tibble.tidyverse.org/"
-checksum=959e28dea05181a7cd43a744028892261bda4c7ec78ad35fb148d144dcf5154e
+checksum=e1a50891f476803526960b4c4d736a72e7d9c3d366946744a02d6347f591c872
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-tidyselect/template
+++ b/srcpkgs/R-cran-tidyselect/template
@@ -1,6 +1,6 @@
 # Template file for 'R-cran-tidyselect'
 pkgname=R-cran-tidyselect
-version=1.1.0
+version=1.1.2
 revision=1
 build_style=R-cran
 makedepends="R-cran-ellipsis R-cran-glue R-cran-purrr R-cran-rlang R-cran-vctrs"
@@ -10,4 +10,4 @@ short_desc="Backend for selecting functions of the tidyverse"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-3.0-or-later"
 homepage="https://tidyselect.r-lib.org/"
-checksum=e635ed381fb53f7a53c3fa36bb33e134a3273d272367de2a8d909c821be93893
+checksum=0389a3b15417954a30d6d692f6ebdd3d0f318cb94a5c9b05365df2f4ea1d8270

--- a/srcpkgs/R-cran-utf8/template
+++ b/srcpkgs/R-cran-utf8/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-utf8'
 pkgname=R-cran-utf8
-version=1.1.4
-revision=2
+version=1.2.2
+revision=1
 build_style=R-cran
 short_desc="Unicode Text Processing"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/patperry/r-utf8/"
-checksum=f6da9cadfc683057d45f54b43312a359cf96ec2731c0dda18a8eae31d1e31e54
+checksum=a71aee87d43a9bcf29249c7a5a2e9ca1d2a836e8d5ee3a264d3062f25378d8f4

--- a/srcpkgs/R-cran-vctrs/template
+++ b/srcpkgs/R-cran-vctrs/template
@@ -1,12 +1,12 @@
 # Template file for 'R-cran-vctrs'
 pkgname=R-cran-vctrs
-version=0.3.6
+version=0.4.1
 revision=1
 build_style=R-cran
-makedepends="R-cran-backports R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-zeallot"
-depends="R-cran-backports R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-zeallot"
+makedepends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-cli"
+depends="R-cran-ellipsis R-cran-digest R-cran-glue R-cran-rlang R-cran-cli"
 short_desc="Vector Helpers"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/r-lib/vctrs"
-checksum=df7d368c9f2d2ad14872ba2a09821ec4f5a8ad77c81a0b05e1f440e5ffebad25
+checksum=9676881e009aa1217818f326338e8b35dd9a9438918f8b1ac249f4c8afe460dd

--- a/srcpkgs/R-cran-viridisLite/template
+++ b/srcpkgs/R-cran-viridisLite/template
@@ -1,13 +1,13 @@
 # Template file for 'R-cran-viridisLite'
 pkgname=R-cran-viridisLite
-version=0.3.0
-revision=2
+version=0.4.0
+revision=1
 build_style=R-cran
 short_desc="Default Color Maps from 'matplotlib' (Lite Version)"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://github.com/sjmgarnier/viridisLite"
-checksum=780ea12e7c4024d5ba9029f3a107321c74b8d6d9165262f6e64b79e00aa0c2af
+checksum=849955dc8ad9bc52bdc50ed4867fd92a510696fc8294e6971efa018437c83c6a
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/R-cran-withr/template
+++ b/srcpkgs/R-cran-withr/template
@@ -1,10 +1,10 @@
 # Template file for 'R-cran-withr'
 pkgname=R-cran-withr
-version=2.4.1
+version=2.5.0
 revision=1
 build_style=R-cran
 short_desc="Run Code 'With' Temporarily Modified Global State"
-maintainer="Florian Wagner <florian@wagner-flo.net>"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-or-later"
 homepage="http://withr.r-lib.org/"
-checksum=5f5ed9058d51b676f8b170b32bc0952ace6790e038f2b6d6860c5bb94f67178f
+checksum=37317b3ed790a08407072993a05ab255f6305f95a12a16e0e28aa6aa80fc8bc0


### PR DESCRIPTION
- R-cran-R6: update to 2.5.1
- R-cran-cli: update to 3.2.0
- R-cran-colorspace: update to 2.0r3
- R-cran-cpp11: update to 0.4.2
- R-cran-crayon: update to 1.5.0
- R-cran-digest: update to 0.6.29
- R-cran-dplyr: update to 1.0.8
- R-cran-ellipsis: update to 0.3.2
- R-cran-fansi: update to 1.0.2
- R-cran-farver: update to 2.1.0
- R-cran-generics: update to 0.1.2
- R-cran-glue: update to 1.6.2
- R-cran-isoband: update to 0.2.5
- R-cran-labeling: update to 0.4.2
- R-cran-lifecycle: update to 1.0.1
- R-cran-magrittr: update to 2.0.2
- R-cran-pillar: update to 1.7.0
- R-cran-rlang: update to 1.0.2
- R-cran-svglite: update to 2.1.0
- R-cran-systemfonts: update to 1.0.4
- R-cran-tibble: update to 3.1.6
- R-cran-tidyselect: update to 1.1.2
- R-cran-utf8: update to 1.2.2
- R-cran-vctrs: update to 0.3.8
- R-cran-viridisLite: update to 0.4.0
- R-cran-withr: update to 2.5.0

@luhann

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
