### PR TITLE
fish-shell: update to 3.4.0.

### DIFF
--- a/srcpkgs/fish-shell/template
+++ b/srcpkgs/fish-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'fish-shell'
 pkgname=fish-shell
-version=3.3.1
+version=3.4.0
 revision=1
 wrksrc="fish-${version}"
 build_style=cmake
@@ -14,7 +14,7 @@ license="GPL-2.0-only"
 homepage="https://fishshell.com/"
 changelog="https://github.com/fish-shell/fish-shell/raw/master/CHANGELOG.rst"
 distfiles="https://github.com/fish-shell/fish-shell/releases/download/${version}/fish-${version}.tar.xz"
-checksum=b5b4ee1a5269762cbbe993a4bd6507e675e4100ce9bbe84214a5eeb2b19fae89
+checksum=b5b48ab8486b19ef716a32f7f46b88b9ea5356155f0e967ee99f4093645413c5
 register_shell="/bin/fish /usr/bin/fish"
 # tests don't work as root
 make_check=ci-skip


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

If you use an older Fish version as your shell and update to 3.4.0, you'll get the following (I believe harmless) error after the upgrade command finishes running and in some other instances:
```
/usr/share/fish/functions/fish_title.fish (line 7): $(...) is not supported. In fish, please use '(prompt_hostname)'.
        and set ssh "[$(prompt_hostname | string sub -l 10)]"
                      ^
from sourcing file /usr/share/fish/functions/fish_title.fish
in command substitution
source: Error while reading file “/usr/share/fish/functions/fish_title.fish”
```

Am I supposed to handle that somehow?

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds): 
