### PR TITLE
[WIP] ccextractor: update to 0.94

### DIFF
--- a/srcpkgs/ccextractor/patches/dont-strip-symbols.patch
+++ b/srcpkgs/ccextractor/patches/dont-strip-symbols.patch
@@ -1,0 +1,11 @@
+--- a/linux/Makefile.am	2021-12-15 18:03:45.000000000 +0100
++++ b/linux/Makefile.am	2021-12-16 11:52:15.188381379 +0100
+@@ -349,7 +349,7 @@
+ 	CARGO_TARGET_DIR=../../linux/rust $(CARGO) build $(CARGO_RELEASE_ARGS);
+ 
+ if SYS_IS_LINUX
+-ccextractor_CFLAGS += -O3 -s -DGPAC_CONFIG_LINUX
++ccextractor_CFLAGS += -O2 -DGPAC_CONFIG_LINUX
+ endif
+ 
+ if SYS_IS_MAC

--- a/srcpkgs/ccextractor/template
+++ b/srcpkgs/ccextractor/template
@@ -1,19 +1,19 @@
 # Template file for 'ccextractor'
 pkgname=ccextractor
-version=0.93
+version=0.94
 revision=1
 build_wrksrc="linux"
 build_style=gnu-configure
-configure_args="--enable-ocr --enable-hardsubx"
+configure_args="--enable-ocr --enable-hardsubx --without-rust"
 hostmakedepends="automake pkg-config"
-makedepends="leptonica-devel tesseract-ocr-devel ffmpeg-devel"
+makedepends="ffmpeg-devel freetype-devel leptonica-devel libutf8proc-devel tesseract-ocr-devel"
 short_desc="Extract subtitles from video streams"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.ccextractor.org/"
 changelog="https://raw.githubusercontent.com/CCExtractor/ccextractor/master/docs/CHANGES.TXT"
-distfiles="https://github.com/CCExtractor/${pkgname}/archive/v${version}.tar.gz"
-checksum=0e66d3e360db1b02a88271af11313ca4c9bbda1b03728e264a44c4c9f77192e3
+distfiles="https://github.com/CCExtractor/ccextractor/archive/v${version}.tar.gz"
+checksum=9c7be386257c69b5d8cd9d7466dbf20e3a45cea950cc8ca7486a956c3be54a42
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/tesseract -DPNG_POWERPC_VSX_OPT=0 -fcommon"
 
 pre_configure() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

WIP, because there is a segmentation fault when using the `-hardsubx` option which doesn’t occur in the current version 0.93. I haven’t had the time for a deeper look, any idea is welcome. :)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
