### PR TITLE
protontricks, python3-language-server: update, add missing setuptools dependency

### DIFF
--- a/srcpkgs/protontricks/template
+++ b/srcpkgs/protontricks/template
@@ -1,17 +1,17 @@
 # Template file for 'protontricks'
 pkgname=protontricks
-version=1.6.1
+version=1.8.0
 revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
-depends="python3-vdf winetricks"
+depends="python3-vdf winetricks python3-setuptools"
 short_desc="Simple wrapper that does winetricks things for Proton enabled games"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="https://github.com/Matoking/protontricks"
 changelog="https://raw.githubusercontent.com/Matoking/protontricks/master/CHANGELOG.md"
 distfiles="${PYPI_SITE}/p/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=7fe1bcc4cf029947850d8032b8a389e07ffb4e60e2d25a9c7535fa6e845b3ad8
+checksum=d56b53c4ea4286ae20588072433c30193143a75654ea216db389503a63661b09
 make_check=no # no tests in pypi tarball
 
 post_install() {

--- a/srcpkgs/python3-language-server/template
+++ b/srcpkgs/python3-language-server/template
@@ -1,11 +1,12 @@
 # Template file for 'python3-language-server'
 pkgname=python3-language-server
-version=0.36.1
-revision=3
+version=0.36.2
+revision=1
 wrksrc="${pkgname/3}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-jedi python3-pluggy python3-jsonrpc-server python3-ultrajson"
+depends="python3-jedi python3-pluggy python3-jsonrpc-server python3-ultrajson
+ python3-setuptools"
 checkdepends="${depends} autopep8 python3-coverage python3-flaky python3-matplotlib
  python3-mccabe python3-mock python3-numpy python3-pandas python3-pycodestyle
  python3-PyQt5 python3-pyflakes python3-pylint python3-pytest python3-pytest-cov
@@ -15,7 +16,7 @@ maintainer="k4leg <d0xi@inbox.ru>"
 license="MIT"
 homepage="https://github.com/palantir/python-language-server"
 distfiles="${PYPI_SITE}/p/${pkgname/3}/${pkgname/3}-${version}.tar.gz"
-checksum=c85d718ef6860319ad59fd6f2acb1166e9349b782ee8e8908e08ecf241615f52
+checksum=9984c84a67ee2c5102c8e703215f407fcfa5e62b0ae86c9572d0ada8c4b417b0
 # Needs unpackaged rope and versioneer
 # https://github.com/palantir/python-language-server/blob/develop/setup.py#L51
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

fixes #36129 
fixes #36072

Grouped because they were suffering from the same issue. Both happened to have updates available.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
