### PR TITLE
nbd: update to 3.24

### DIFF
--- a/srcpkgs/nbd/template
+++ b/srcpkgs/nbd/template
@@ -1,6 +1,6 @@
 # Template file for 'nbd'
 pkgname=nbd
-version=3.23
+version=3.24
 revision=1
 build_style=gnu-configure
 configure_args="--enable-syslog"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://nbd.sourceforge.io/"
 distfiles="${SOURCEFORGE_SITE}/nbd/nbd-${version}.tar.gz"
-checksum=3c969cd9cf83dae9276f999b7ff8e31e32411c8cc751221e698861bc05b8f76c
+checksum=a771022599525fd4f5c17c7b1c88696a91927c227e770425a55f67a7384441b6
 
 system_accounts="nbd"
 nbd_homedir="/var/chroot"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

#### Note
3.24 released : https://lists.debian.org/nbd/2022/03/msg00008.html
Fixing two security issues : CVE-2022-26495 / CVE-2022-26496