### PR TITLE
libsigrok: fix missing udev rules

### DIFF
--- a/srcpkgs/libsigrok/template
+++ b/srcpkgs/libsigrok/template
@@ -1,7 +1,7 @@
 # Template file for 'libsigrok'
 pkgname=libsigrok
 version=0.5.2
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config doxygen python3"
 makedepends="glib-devel libzip-devel glibmm-devel libserialport-devel
@@ -20,6 +20,7 @@ esac
 post_install() {
 	vinstall contrib/60-libsigrok.rules 0644 /usr/lib/udev/rules.d
 	vinstall contrib/61-libsigrok-uaccess.rules 0644 /usr/lib/udev/rules.d
+	vinstall contrib/61-libsigrok-plugdev.rules 0644 /usr/lib/udev/rules.d
 }
 
 libsigrok-devel_package() {


### PR DESCRIPTION
Fixes #23580
Closes #23581 (obsoletes the PR)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

### ~~**This PR is dependent on #36238 being merged.**~~