### PR TITLE
musikcube: update to 0.97.0, adopt

### DIFF
--- a/srcpkgs/musikcube-openmpt
+++ b/srcpkgs/musikcube-openmpt
@@ -1,0 +1,1 @@
+musikcube

--- a/srcpkgs/musikcube/patches/fix-install-locations.patch
+++ b/srcpkgs/musikcube/patches/fix-install-locations.patch
@@ -1,11 +1,11 @@
 Currently all ELF files (binaries and libraries), get installed to /usr/share/musikcube.
 This patch moves all those files to their normal locations and fixes the code to expect that
 
-diff --git CMakeLists.txt CMakeLists.txt
-index d685695f..5ac43f1f 100644
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -208,7 +208,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+diff --git a/.cmake/InstallFiles.cmake b/.cmake/InstallFiles.cmake
+index 62d3c003..01ef58ac 100644
+--- a/.cmake/InstallFiles.cmake
++++ b/.cmake/InstallFiles.cmake
+@@ -4,7 +4,7 @@ if (APPLE)
    install(FILES ${plugins} DESTINATION share/musikcube/plugins)
  else ()
    file(GLOB plugins "bin/plugins/*.so")
@@ -13,9 +13,9 @@ index d685695f..5ac43f1f 100644
 +  install(FILES ${plugins} DESTINATION lib/musikcube/plugins)
  endif ()
  
- file(GLOB sdk_headers "src/musikcore/sdk/*.h")
-@@ -237,20 +237,12 @@ endif()
- if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+ if (${BUILD_STANDALONE} MATCHES "true")
+@@ -43,20 +43,12 @@ endif()
+ if (APPLE)
    install(FILES "bin/libmusikcore.dylib" DESTINATION share/musikcube)
  else()
 -  install(FILES "bin/libmusikcore.so" DESTINATION share/musikcube)
@@ -36,7 +36,7 @@ index d685695f..5ac43f1f 100644
    DESTINATION bin/
    PERMISSIONS
      OWNER_EXECUTE OWNER_READ OWNER_WRITE
-@@ -260,14 +252,6 @@ install(
+@@ -66,14 +58,6 @@ install(
  # executable and shell script for daemon
  install(
    FILES bin/musikcubed
@@ -51,12 +51,12 @@ index d685695f..5ac43f1f 100644
    DESTINATION bin/
    PERMISSIONS
      OWNER_EXECUTE OWNER_READ OWNER_WRITE
-diff --git src/musikcore/support/Common.cpp src/musikcore/support/Common.cpp
-index 58bc4d2f..1670c2f7 100644
+diff --git a/src/musikcore/support/Common.cpp b/src/musikcore/support/Common.cpp
+index 31703117..53aa8a88 100644
 --- a/src/musikcore/support/Common.cpp
 +++ b/src/musikcore/support/Common.cpp
-@@ -90,65 +90,11 @@ namespace musik { namespace core {
-     }
+@@ -82,65 +82,11 @@ static inline void silentDelete(const std::string fn) {
+ namespace musik { namespace core {
  
      std::string GetPluginDirectory() {
 -        std::string path(GetApplicationDirectory());

--- a/srcpkgs/musikcube/patches/fix-mpris-detection.patch
+++ b/srcpkgs/musikcube/patches/fix-mpris-detection.patch
@@ -1,0 +1,25 @@
+In Void linux, elogind provides libsystemd
+
+diff --git a/.cmake/AddOsSpecificPlugins.cmake b/.cmake/AddOsSpecificPlugins.cmake
+index ce0eea9b..5b067671 100644
+--- a/.cmake/AddOsSpecificPlugins.cmake
++++ b/.cmake/AddOsSpecificPlugins.cmake
+@@ -6,7 +6,7 @@ endif()
+ 
+ # systemd / MPRIS detection
+ if (NOT ENABLE_MPRIS MATCHES "false")
+-  find_library(LIB_SYSTEMD NAMES systemd)
++  find_library(LIB_SYSTEMD NAMES elogind)
+   if (NOT LIB_SYSTEMD MATCHES "LIB_SYSTEMD-NOTFOUND")
+     message(STATUS "[mpris] systemd found at " ${LIB_SYSTEMD})
+     message(STATUS "[mpris] setting ENABLE_MPRIS=true")
+diff --git a/src/plugins/mpris/CMakeLists.txt b/src/plugins/mpris/CMakeLists.txt
+index fdee62d2..7a941d08 100644
+--- a/src/plugins/mpris/CMakeLists.txt
++++ b/src/plugins/mpris/CMakeLists.txt
+@@ -6,4 +6,4 @@ find_package(PkgConfig)
+ pkg_check_modules (SYSTEMD REQUIRED libsystemd)
+ 
+ add_library(mpris SHARED ${mpris_SOURCES})
+-target_link_libraries(mpris systemd)
++target_link_libraries(mpris elogind)

--- a/srcpkgs/musikcube/template
+++ b/srcpkgs/musikcube/template
@@ -1,40 +1,39 @@
 # Template file for 'musikcube'
 pkgname=musikcube
-version=0.96.10
+version=0.97.0
 revision=1
 build_style=cmake
 make_cmd=make
-configure_args="-DNO_NCURSESW=1 -DENABLE_SNDIO=true -DDISABLE_STRIP=true
- -DENABLE_PIPEWIRE=true -DENABLE_BUNDLED_TAGLIB=false"
+configure_args="-DNO_NCURSESW=1 -DENABLE_SNDIO=true -DENABLE_PIPEWIRE=true
+ -DENABLE_BUNDLED_TAGLIB=false"
 hostmakedepends="pkg-config"
 makedepends="boost-devel libogg-devel libmicrohttpd-devel ffmpeg-devel
  openssl-devel pulseaudio-devel lame-devel zlib-devel alsa-lib-devel
  libvorbis-devel libcurl-devel ncurses-devel libev-devel taglib-devel
- sndio-devel pipewire-devel"
+ sndio-devel pipewire-devel ncurses-libtinfo-devel libopenmpt-devel
+ $(vopt_if elogind elogind-devel)"
 short_desc="Terminal-based music player in c++"
-maintainer="eater <=@eater.me>"
+maintainer="Subhaditya Nath <sn03.general@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://musikcube.com/"
 distfiles="https://github.com/clangen/musikcube/archive/${version}.tar.gz"
-checksum=91fd984e68b6ef66f1be1ecdf0c84607453ec6ec80632ece688ac745c7719ea5
-
-if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
-	makedepends+=" libatomic-devel"
-	configure_args+=" -DCMAKE_EXE_LINKER_FLAGS='-latomic'"
-fi
+checksum=ab170c5100251fcd6c8fd3c32eea45e9854c6c6272c6b0970bffbfc55d0b2ec5
+build_options="elogind"
+desc_option_elogind="Support MPRIS interface via elogind"
+build_options_default="elogind"
 
 export CMAKE_GENERATOR="Unix Makefiles"
 
-#XXX: Otherwise xbps-install ffmpeg-devel will complain about unresolving shlibs
-# SDL2-2.0.10_3: broken, unresolvable shlib 'libGL.so.1'
-makedepends+=" libglvnd"
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
 
 post_install() {
 	vlicense LICENSE.txt
 }
 
 musikcube-devel_package() {
-	depends="musikcube-${version}_${revision}"
+	depends="${sourcepkg}-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
@@ -42,7 +41,7 @@ musikcube-devel_package() {
 }
 
 musikcube-sndio_package() {
-	depends="musikcube>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - sndio output plugin"
 	pkg_install() {
 		vmove usr/lib/musikcube/plugins/libsndioout.so
@@ -50,9 +49,17 @@ musikcube-sndio_package() {
 }
 
 musikcube-pipewire_package() {
-	depends="musikcube>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - pipewire output plugin"
 	pkg_install() {
 		vmove usr/lib/musikcube/plugins/libpipewireout.so
+	}
+}
+
+musikcube-openmpt_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - openmpt decoder plugin"
+	pkg_install() {
+		vmove usr/lib/musikcube/plugins/libopenmptdecoder.so
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Summary
- Update to 0.97.0
- Added MPRIS support
- Moved openmpt plugin to a separate package `musikcube-openmpt`

#### Testing the changes
- I tested the changes in this PR: **YES** (it works properly)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
<!--
  - armv7l
  - armv6l-musl
-->
