### PR TITLE
gopass: update to 1.14.0
Note: This is an auto-generated change as part of the gopass release process.


### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,6 +1,6 @@
 # Template file for 'gopass'
 pkgname=gopass
-version=1.13.0
+version=1.14.0
 revision=1
 build_style=go
 build_helper=qemu
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/v${version}.tar.gz"
-checksum=785ef96a0519a0d91a524036dc982f8e6ee00e6841a7b4faf4c504368cff7d31
+checksum=6e0d58a355a165addb15f9b7961fcbf5938fad1b9b453608461b9677596e7341
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
gopass: update to 1.14.0
Note: This is an auto-generated change as part of the gopass release process.
