### PR TITLE
notion: update to 4.0.2.

### DIFF
--- a/srcpkgs/notion/patches/stdout.patch
+++ b/srcpkgs/notion/patches/stdout.patch
@@ -1,0 +1,89 @@
+From de9e19940c2c88c848b7f849fb014fafd77d7d93 Mon Sep 17 00:00:00 2001
+From: c0dev0id <sh+github@codevoid.de>
+Date: Sat, 10 Apr 2021 02:03:44 +0200
+Subject: [PATCH] Fix compilation on OpenBSD
+
+The variable name "stdout" is defined in stdio.h on OpenBSD already.
+---
+ mod_notionflux/mod_notionflux.c | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/mod_notionflux/mod_notionflux.c b/mod_notionflux/mod_notionflux.c
+index f2bd4427..51949e07 100644
+--- a/mod_notionflux/mod_notionflux.c
++++ b/mod_notionflux/mod_notionflux.c
+@@ -36,7 +36,7 @@
+ 
+ typedef struct{
+     int fd;
+-    FILE *stdout;
++    FILE *stdoutput;
+     int ndata;
+     char *data;
+ } Buf;
+@@ -64,9 +64,9 @@ static void close_conn(Buf *buf)
+     close(buf->fd);
+     buf->fd=-1;
+     buf->ndata=0;
+-    if(buf->stdout!=NULL){
+-        fclose(buf->stdout);
+-        buf->stdout=NULL;
++    if(buf->stdoutput!=NULL){
++        fclose(buf->stdoutput);
++        buf->stdoutput=NULL;
+     }
+     if(buf->data!=NULL){
+         free(buf->data);
+@@ -147,11 +147,11 @@ static void receive_data(int fd, void *buf_)
+     bool success=FALSE;
+     int idx=buf-bufs;
+ 
+-    if(buf->stdout==NULL){ /* no fd received yet, must be the very beginning */
+-        int stdout_fd=unix_recv_fd(fd);
+-        if(stdout_fd==-2)
++    if(buf->stdoutput==NULL){ /* no fd received yet, must be the very beginning */
++        int stdoutput_fd=unix_recv_fd(fd);
++        if(stdoutput_fd==-2)
+             goto closefd;
+-        if(stdout_fd==-3){
++        if(stdoutput_fd==-3){
+             char const *err="Magic number mismatch on notionflux socket - "
+                 "is notionflux the same version as notion?";
+             writes(fd, "E");
+@@ -160,13 +160,13 @@ static void receive_data(int fd, void *buf_)
+             goto closefd;
+         }
+ 
+-        if(stdout_fd==-1) {
++        if(stdoutput_fd==-1) {
+             if(errno==EWOULDBLOCK || errno==EAGAIN)
+                 return; /* try again later */
+             warn("No file descriptor received from notionflux, closing.");
+             goto closefd;
+         }
+-        if((buf->stdout=fdopen(stdout_fd, "w"))==NULL) {
++        if((buf->stdoutput=fdopen(stdoutput_fd, "w"))==NULL) {
+             warn("fdopen() failed on fd from notionflux");
+             goto closefd;
+         }
+@@ -239,9 +239,9 @@ EXTL_SAFE
+ EXTL_EXPORT
+ bool mod_notionflux_xwrite(int idx, const char *str)
+ {
+-    if (idx<0 || idx>=MAX_SERVED || bufs[idx].stdout==NULL)
++    if (idx<0 || idx>=MAX_SERVED || bufs[idx].stdoutput==NULL)
+         return FALSE;
+-    return fputs(str, bufs[idx].stdout)!=EOF;
++    return fputs(str, bufs[idx].stdoutput)!=EOF;
+ }
+ 
+ static void connection_attempt(int lfd, void *UNUSED(data))
+@@ -410,7 +410,7 @@ bool mod_notionflux_init()
+ 
+     for(i=0; i<MAX_SERVED; i++){
+         bufs[i].fd=-1;
+-        bufs[i].stdout=NULL;
++        bufs[i].stdoutput=NULL;
+         bufs[i].data=NULL;
+         bufs[i].ndata=0;
+     }

--- a/srcpkgs/notion/template
+++ b/srcpkgs/notion/template
@@ -1,17 +1,16 @@
 # Template file for 'notion'
-pkgname="notion"
-version=4.0.0
-revision=2
-archs="~*-musl"
+pkgname=notion
+version=4.0.2
+revision=1
+hostmakedepends="pkg-config gettext groff lua54"
+makedepends="libSM-devel libXext-devel libXft-devel libXinerama-devel
+ libXrandr-devel lua54-devel readline-devel"
 short_desc="Tabbed, tiling window manager"
-hostmakedepends="pkg-config gettext groff lua53"
-makedepends="lua53-devel libXext-devel libXft-devel libSM-devel libXinerama-devel libXrandr-devel"
 maintainer="Julian Wiesener <jw@vtoc.de>"
 license="LGPL-2.1-or-later"
-repository="nonfree"
-homepage="https://notionnm.net/"
+homepage="https://notionwm.net/"
 distfiles="https://github.com/raboof/notion/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=13ce5867667ad7a864c79f4cb1e322fa33ebcd872dfce6472026e4d69d1f4138
+checksum=dcefd620d028f6541c15879c3db218de081df7ce8d2e9cb4fc7ddd9b9253b698
 
 do_build() {
 	make CC=$CC PREFIX=/usr ETCDIR=/etc/notion
@@ -21,5 +20,4 @@ do_install() {
 	make DESTDIR=${DESTDIR} PREFIX=/usr ETCDIR=/etc/notion install
 	vman man/notion.1
 	vman man/notionflux.1
-	vlicense LICENSE
 }


### PR DESCRIPTION
- Fix homepage
- Fix musl
- Fix nonfree, upstream should be proper LGPL-2.1-or-later now
- Use Lua 5.4

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc @vtoc 