### PR TITLE
update_check: also work for subpackages

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -4,6 +4,7 @@ update_check() {
     local i p url pkgurlname rx found_version consider
     local update_override=$XBPS_SRCPKGDIR/$XBPS_TARGET_PKG/update
     local original_pkgname=$pkgname
+    local pkgname=$sourcepkg
     local urlpfx urlsfx
     local -A fetchedurls
 


### PR DESCRIPTION
Currently `./xbps-src update-check` fails for many subpackages if the $pkgname or $pattern is not explicitly set in the update file, because it uses the subpackages $pkgname.

Example:
```
$ ./xbps-src update-check alsa-plugins-pulseaudio
NO VERSION found for alsa-plugins-pulseaudio
```

This PR tries to fix that by using $sourcepkg as the $pkgname.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
