### PR TITLE
ghc, ghc-bin: add aarch64* support

### DIFF
--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -2,7 +2,7 @@
 pkgname=ghc-bin
 version=8.10.7
 revision=1
-archs="i686 x86_64* ppc64le* ppc64"
+archs="i686 x86_64* ppc64le* ppc64 aarch64-musl"
 wrksrc="ghc-${version%[!0-9]}"
 hostmakedepends="perl libffi libnuma"
 depends="ncurses perl gcc libffi-devel gmp-devel"
@@ -38,6 +38,11 @@ ppc64le-musl)
 ppc64)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64-void-linux.tar.xz"
 	checksum=b8578e602abd4b453845303fb9cfed0b2186f86f60e3aa45869026ea833726c8
+	;;
+aarch64-musl)
+	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux-musl.tar.xz"
+	checksum=f2c37a5ed028eebd3e69a22ce989f5cdf6f84a408871ff0933ac532414c6c273
+	depends+=" llvm"
 	;;
 *)
 	broken="No distfiles available for this target"

--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -2,7 +2,7 @@
 pkgname=ghc-bin
 version=8.10.7
 revision=1
-archs="i686 x86_64* ppc64le* ppc64 aarch64-musl"
+archs="i686 x86_64* ppc64le* ppc64 aarch64*"
 wrksrc="ghc-${version%[!0-9]}"
 hostmakedepends="perl libffi libnuma"
 depends="ncurses perl gcc libffi-devel gmp-devel"
@@ -38,6 +38,11 @@ ppc64le-musl)
 ppc64)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64-void-linux.tar.xz"
 	checksum=b8578e602abd4b453845303fb9cfed0b2186f86f60e3aa45869026ea833726c8
+	;;
+aarch64)
+	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux.tar.xz"
+	checksum=ed4ef006f89698420587b7103c8bb8b972d124bb27a57e64d33f910afbc1931a
+	depends+=" llvm"
 	;;
 aarch64-musl)
 	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux-musl.tar.xz"

--- a/srcpkgs/ghc/template
+++ b/srcpkgs/ghc/template
@@ -54,6 +54,14 @@ elif [ "${XBPS_MACHINE%-*}" != "${XBPS_TARGET_MACHINE%-*}" ]; then
 	configure_args+=" --host=${XBPS_TRIPLET} --target=${XBPS_CROSS_TRIPLET}"
 fi
 
+case "$XBPS_TARGET_MACHINE" in
+aarch64*)
+	# GHC uses LLVM to generate code on aarch64
+	hostmakedepends+=" llvm"
+	depends+=" llvm"
+	;;
+esac
+
 # Recent safe to use tarball
 # GHC's bundled tarball is from 2017, buggy on some archs
 _ffi_rev=4d6d2866ae43e55325e8ee96561221804602cd7a


### PR DESCRIPTION
GHC uses llvm (specifically `opt` and `llc` executables) to build on aarch64, so that was added as a dependency.

All packages that depend on ghc were built and are available at a [repo I made with signed *.xbps files](https://ftrv.se/_/void/ghc-aarch64-musl) along with the [ghc bindist distfile](https://ftrv.se/_/void/ghc-aarch64-musl/ghc-8.10.7-aarch64-void-linux-musl.tar.xz) required by ghc-bin, which this change assumes is eventually uploaded to `alpha.de.repo.voidlinux.org`. I tested most of the packages, they all work as expected.

I can share the files in some other way if that's preferable.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-musl, aarch64)

[ci skip]