### PR TITLE
octoxbps: fix detection of Void Linux

### DIFF
--- a/srcpkgs/octoxbps/patches/0001-Fix-detection-of-Void-Linux-in-getLinuxDistro.patch
+++ b/srcpkgs/octoxbps/patches/0001-Fix-detection-of-Void-Linux-in-getLinuxDistro.patch
@@ -1,0 +1,42 @@
+From 41e0ba546e85f812d89899a3034d67256ec5f23c Mon Sep 17 00:00:00 2001
+From: chili-b <dexter.gaonshatford@gmail.com>
+Date: Sat, 19 Mar 2022 15:33:41 -0400
+Subject: [PATCH] Fix detection of Void Linux in getLinuxDistro
+
+Before this change, OctoXBPS detects Void Linux based on whether or not
+the string, `PRETTY_NAME="void"`, occurs in the file, `/etc/os-release`.
+As of March 15 2022, the contents of `/etc/os-release` have been changed
+and `PRETTY_NAME="Void Linux"` replaces the previous value.
+(see https://github.com/void-linux/void-packages/commit/1dfc401d1237120e8e936627e7e28d2441916e80)
+
+With this change, Void Linux is detected based on the value of `ID` in
+`/etc/os-release` which is less subject to change.
+
+This change is important because OctoXBPS only checks for the existence
+of the local package db if it detects that it is running on either Void
+Linux or Trident Linux. If OctoXBPS does not detect that it is running
+on either distribution (which it doesn't without this change), it will
+prompt for elevated privileges in order to synchronize the local package
+database with the remote database using `xbps-install -Syy` every time
+it is started, regardless of whether or not there are remote changes
+that need to be synced.
+---
+ src/unixcommand.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/unixcommand.cpp b/src/unixcommand.cpp
+index 8a88a2f..1762c4b 100644
+--- a/src/unixcommand.cpp
++++ b/src/unixcommand.cpp
+@@ -709,7 +709,7 @@ LinuxDistro UnixCommand::getLinuxDistro()
+ 
+       QString contents = file.readAll();
+ 
+-      if (contents.contains("PRETTY_NAME=\"void\""))
++      if (contents.contains("ID=\"void\""))
+       {
+         ret = ectn_VOID;
+       }
+-- 
+2.35.1
+

--- a/srcpkgs/octoxbps/template
+++ b/srcpkgs/octoxbps/template
@@ -1,7 +1,7 @@
 # Template file for 'octoxbps'
 pkgname=octoxbps
 version=0.3.0
-revision=2
+revision=3
 build_style=qmake
 hostmakedepends="qt5-qmake pkg-config qt5-host-tools"
 makedepends="qt5-declarative-devel qtermwidget-devel"


### PR DESCRIPTION
Without this change, OctoXBPS fails to detect that it is running on Void
Linux which causes a password prompt to be shown every time OctoXBPS is
opened.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
