### PR TITLE
vapoursynth: update to R57. 

### DIFF
--- a/srcpkgs/vapoursynth/template
+++ b/srcpkgs/vapoursynth/template
@@ -1,21 +1,22 @@
 # Template file for 'vapoursynth'
 pkgname=vapoursynth
-version=R52
-revision=4
+version=R57
+revision=1
 build_style=gnu-configure
-# configure checks sys.version[:3] for Python versioning, so 3.10 becomes 3.1;
-# until this is fixed upstream, manually define am_cv_python_version to circumvent
-configure_args="am_cv_python_version=${py3_ver}"
 hostmakedepends="automake libtool nasm pkg-config python3-Cython"
-makedepends="ffmpeg-devel python3-devel zimg-devel libass-devel libmagick-devel
- libxml2-devel"
+makedepends="python3-devel zimg-devel"
 short_desc="Application for video manipulation"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="LGPL-2.1-or-later, OFL-1.1"
 homepage="http://www.vapoursynth.com"
 changelog="https://raw.githubusercontent.com/vapoursynth/vapoursynth/master/ChangeLog"
 distfiles="https://github.com/vapoursynth/vapoursynth/archive/${version}.tar.gz"
-checksum=4d5dc7950f4357da695d29708bc98013bc3e0bd72fc5d697f8c91ce3c4a4b2ac
+checksum=9bed2ab1823050cfcbdbb1a57414e39507fd6c73f07ee4b5986fcbf0f6cb2d07
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	LDFLAGS="-latomic"
+fi
 
 pre_configure() {
 	./autogen.sh

--- a/srcpkgs/zimg/template
+++ b/srcpkgs/zimg/template
@@ -1,6 +1,6 @@
 # Template file for 'zimg'
 pkgname=zimg
-version=2.9.3
+version=3.0.3
 revision=1
 wrksrc=zimg-release-${version}
 build_style=gnu-configure
@@ -9,8 +9,13 @@ short_desc="Image processing library"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="WTFPL"
 homepage="https://github.com/sekrit-twc/zimg"
+changelog="https://raw.githubusercontent.com/sekrit-twc/zimg/master/ChangeLog"
 distfiles="https://github.com/sekrit-twc/zimg/archive/release-${version}.tar.gz"
-checksum=a15c0483fbe945ffe695a1a989bc43b3381c8bf33e2d1760464ec21d32cdf30b
+checksum=5e002992bfe8b9d2867fdc9266dc84faca46f0bfd931acc2ae0124972b6170a7
+
+case "$XBPS_TARGET_MACHINE" in
+	armv7*) configure_args+=" --disable-simd";;
+esac
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
@lemmi 

Since R55 many filters were removed from the source tree and moved into seperate repositories. That's the reason why this package contains less files and some dependencies are no longer needed.

**About disabling SIMD:**
It seems that [zimg](https://github.com/sekrit-twc/zimg/blob/d4e32eaf4612589aed9223577c9429ff4c3c8269/configure.ac#L66) enforces correctly `-march=armv7-a -mfpu=neon-vfpv4`, but we override it with `-mfpu=vfpv3` so it doesn't work for us.

This was already discussed in https://github.com/sekrit-twc/zimg/issues/140

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
