### PR TITLE
budgie-desktop: update to 10.6.

### DIFF
--- a/srcpkgs/budgie-control-center-devel
+++ b/srcpkgs/budgie-control-center-devel
@@ -1,0 +1,1 @@
+budgie-control-center

--- a/srcpkgs/budgie-control-center/template
+++ b/srcpkgs/budgie-control-center/template
@@ -1,0 +1,30 @@
+# Template file for 'budgie-control-center'
+pkgname=budgie-control-center
+version=1.0.1
+revision=1
+build_style=meson
+hostmakedepends="glib-devel gsettings-desktop-schemas-devel gettext pkg-config
+ polkit python3 libxml2"
+makedepends="ModemManager-devel NetworkManager-devel accountsservice-devel
+ colord-devel colord-gtk-devel gnome-bluetooth-devel gnome-desktop-devel
+ gnome-online-accounts-devel gnome-settings-daemon-devel ibus-devel
+ libgtop-devel libhandy1-devel libpwquality-devel mit-krb5-devel libnma-devel
+ polkit-devel pulseaudio-devel samba-devel upower-devel libxml2-devel
+ libX11-devel libXi-devel libepoxy-devel gdk-pixbuf-devel gtk+3-devel
+ libglib-devel cups-devel libgudev-devel libwacom-devel libsecret-devel
+ udisks2-devel gsound-devel libsoup-devel gcr-devel cheese-devel"
+depends="desktop-file-utils upower colord cups-pk-helper cracklib iso-codes
+ gsettings-desktop-schemas hicolor-icon-theme sound-theme-freedesktop"
+short_desc="Budgie Control Center"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/BuddiesOfBudgie/budgie-control-center"
+distfiles="https://github.com/BuddiesOfBudgie/budgie-control-center/releases/download/v${version}/budgie-control-center-${version}.tar.xz"
+checksum=6c049d02600f6650238b4376a7eac77d8fcd786e9c603c4e4ec87cad0022028a
+
+budgie-control-center-devel_package() {
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/share/pkgconfig
+	}
+}

--- a/srcpkgs/budgie-desktop-view/template
+++ b/srcpkgs/budgie-desktop-view/template
@@ -1,0 +1,13 @@
+# Template file for 'budgie-desktop-view'
+pkgname=budgie-desktop-view
+version=1.2
+revision=1
+build_style=meson
+hostmakedepends="pkg-config intltool vala glib-devel"
+makedepends="libglib-devel gtk+3-devel vala-devel"
+short_desc="Budgie desktop icons application"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://github.com/BuddiesOfBudgie/budgie-desktop-view"
+distfiles="https://github.com/BuddiesOfBudgie/budgie-desktop-view/releases/download/v${version}/budgie-desktop-view-v${version}.tar.xz"
+checksum=8399fae4326e5a21dda889bd89cb16ed8201f2854dc5cbc12394b90420d4cf2e

--- a/srcpkgs/budgie-desktop/template
+++ b/srcpkgs/budgie-desktop/template
@@ -1,9 +1,7 @@
 # Template file for 'budgie-desktop'
 pkgname=budgie-desktop
-version=10.5.3
-revision=2
-create_wrksrc=yes
-build_wrksrc="$pkgname-$version"
+version=10.6
+revision=1
 build_style=meson
 build_helper=gir
 configure_args="-Dwith-gtk-doc=false"
@@ -13,20 +11,14 @@ makedepends="alsa-lib-devel libnotify-devel accountsservice-devel libpeas-devel
  libwnck-devel mutter-devel ibus-devel gnome-desktop-devel pulseaudio-devel
  upower-devel gtk+3-devel polkit-devel gnome-bluetooth-devel gnome-menus-devel
  gnome-settings-daemon-devel vala libuuid-devel libupower-glib3"
-depends="gnome-session gnome-settings-daemon gnome-control-center elogind
- gnome-themes-extra budgie-screensaver"
+depends="gnome-session gnome-settings-daemon budgie-control-center elogind
+ gnome-themes-extra budgie-screensaver budgie-desktop-view"
 short_desc="Modern desktop environment from the Solus Project"
-maintainer="Lorem <notloremipsum@protonmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only, LGPL-2.1-only"
-homepage="https://github.com/solus-project/budgie-desktop"
-distfiles="${homepage}/releases/download/v${version}/budgie-desktop-v${version}.tar.xz
- ${homepage}/commit/7a2835f2fa247e7201bb9e4a434bade8f4bfe86e.patch>mutter41.patch"
-checksum="878f4e6460c29740bf633c3b11ba97bcb788068c1460f82569938af2f1633b25
- 65430e84e33b1529aebae169ad8e0392abf1b5c4bb1b454d46f17dc37469d763"
-
-post_patch() {
-	patch -Np1 < ../mutter41.patch
-}
+homepage="https://github.com/BuddiesOfBudgie/budgie-desktop"
+distfiles="https://github.com/BuddiesOfBudgie/budgie-desktop/releases/download/v${version}/budgie-desktop-v${version}.tar.xz"
+checksum=ba297a10b547e6d7bf164406750b5c5dae98a7524978b30b4ad3cba9624def9e
 
 budgie-desktop-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/budgie-screensaver/patches/musl.patch
+++ b/srcpkgs/budgie-screensaver/patches/musl.patch
@@ -1,0 +1,12 @@
+diff --git a/src/subprocs.c b/src/subprocs.c
+index a378658..ba37650 100644
+--- a/src/subprocs.c
++++ b/src/subprocs.c
+@@ -36,6 +36,7 @@
+ # define fork  vfork
+ #endif /* VMS */
+ 
++#define _POSIX_SOURCE
+ #include <signal.h>		/* for the signal names */
+ 
+ #include <glib.h>

--- a/srcpkgs/budgie-screensaver/template
+++ b/srcpkgs/budgie-screensaver/template
@@ -1,14 +1,13 @@
 # Template file for 'budgie-screensaver'
 pkgname=budgie-screensaver
-version=4.0
-revision=2
-wrksrc=budgie-screensaver-v${version}
-build_style=gnu-configure
-hostmakedepends="pkg-config intltool glib"
+version=5.0
+revision=1
+build_style=meson
+hostmakedepends="pkg-config intltool glib-devel"
 makedepends="gnome-desktop-devel dbus-glib-devel pam-devel elogind-devel"
 short_desc="Fork of GNOME Screensaver for Budgie 10"
-maintainer="Lorem <notloremipsum@protonmail.com>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
-homepage="https://github.com/getsolus/budgie-screensaver"
-distfiles="https://github.com/getsolus/budgie-screensaver/releases/download/v${version}/budgie-screensaver-v${version}.tar.xz"
-checksum=dde83f355e549b5f6290655f33acd910d2febbb8fd974f922b14814054f80f49
+homepage="https://github.com/BuddiesOfBudgie/budgie-screensaver"
+distfiles="https://github.com/BuddiesOfBudgie/budgie-screensaver/releases/download/v${version}/budgie-screensaver-v${version}.tar.xz"
+checksum=611969a9f53e5d3148cad7445e95c94bfff6ea61c2f339969ecb5d9b51f6b871


### PR DESCRIPTION
musl patch sent upstream https://github.com/BuddiesOfBudgie/budgie-screensaver/pull/4

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
