### PR TITLE
Add plugdev to default groups, drop server_group in templates

### DIFF
--- a/srcpkgs/base-files/files/group
+++ b/srcpkgs/base-files/files/group
@@ -22,6 +22,7 @@ scanner:x:20:
 network:x:21:
 kvm:x:24:
 input:x:25:
+plugdev:x:26:
 nogroup:x:99:
 users:x:100:
 xbuilder:x:101:

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.142
-revision=11
+revision=12
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
@@ -29,7 +29,7 @@ conf_files="
 
 replaces="base-directories>=0"
 # New system groups
-system_groups="kvm:24"
+system_groups="kvm:24 plugdev:26"
 
 do_install() {
 	# Create bin and lib dirs and symlinks.

--- a/srcpkgs/openocd/template
+++ b/srcpkgs/openocd/template
@@ -1,7 +1,7 @@
 # Template file for 'openocd'
 pkgname=openocd
 version=0.11.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="
  --disable-werror
@@ -48,8 +48,6 @@ license="GPL-2.0-or-later"
 homepage="http://openocd.org/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=43a3ce734aff1d3706ad87793a9f3a5371cb0e357f0ffd0a151656b06b3d1e7d
-
-system_groups="plugdev"
 
 CFLAGS="-fcommon"
 

--- a/srcpkgs/openrazer-meta/template
+++ b/srcpkgs/openrazer-meta/template
@@ -1,7 +1,7 @@
 # Template file for 'openrazer-meta'
 pkgname=openrazer-meta
 version=3.0.1
-revision=2
+revision=3
 wrksrc="openrazer-${version}"
 build_style=gnu-makefile
 make_install_target="setup_dkms udev_install daemon_install xdg_install
@@ -36,7 +36,6 @@ openrazer-driver-dkms_package() {
 	short_desc="Kernel driver for Razer devices (DKMS-variant)"
 	depends="dkms"
 	dkms_modules="openrazer-driver $version"
-	system_groups="plugdev"
 	pkg_install() {
 		vmove usr/lib/udev
 		vmove usr/src

--- a/srcpkgs/wally-udev-rules/INSTALL.msg
+++ b/srcpkgs/wally-udev-rules/INSTALL.msg
@@ -1,3 +1,0 @@
-Please add your user to the group 'plugdev' by executing the following:
-
-usermod -aG plugdev "$USER"

--- a/srcpkgs/wally-udev-rules/template
+++ b/srcpkgs/wally-udev-rules/template
@@ -1,7 +1,7 @@
 # Template file for 'wally-udev-rules'
 pkgname=wally-udev-rules
 version=2.1.1
-revision=1
+revision=2
 build_style=fetch
 short_desc="Set of udev rules for ZSA keyboards, for usage with wally and oryx"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
@@ -14,7 +14,6 @@ checksum="6c7d4d27745080269115c58c4c5d863b23c534635975f3bca581c52687721c52
  269c9196bc65b2e62be549e3d34e56768fe702ff099b7780a1661ca4c92a0143
  d2841d63f4e0bdfda102390ab1ca09136230d22f88538863b24b0c7fc68e548e"
 conf_files="/usr/lib/udev/rules.d/50-wally.rules /usr/lib/udev/rules.d/50-oryx.rules"
-system_groups="plugdev"
 
 do_install() {
 	vlicense license.md


### PR DESCRIPTION
Plugdev is used by many packages' udev rules for pluggable devices.
Currently, some of those packages use the system_groups trigger to add it, some forget to add it, and others patch it to "users" or "uaccess" (which breaks the packages on systems that don't use logind).
By adding plugdev to the default groups, we get rid of those problems.

This PR is needed for
- https://github.com/void-linux/void-packages/pull/34757
- https://github.com/void-linux/void-packages/pull/36144

While this pr deals with packages that had the `system_groups` hook to add plugdev, it does not deal with
1. packages that patch their rules to use `uaccess` instead (those packages are broken on systems that don't use logind)
    I do not have the hardware to test any of those: `airspy hackrf libnfc openobex`
2. `libfido2`, which patches its rules to use `users`
    This one works as is (I have hardware and I have to add myself to the `users` group to use it) but could arguably fit more in `plugdev`

#### Testing the changes
- I tested the changes in this PR: **YES** (base-files and openocd), **briefly** (I don't have hardware for openrazer or wally, but I did check that the removal of the hook was done correctly)


### **This PR will require addition of the plugdev group in the void documentation, PR: https://github.com/void-linux/void-docs/pull/663**