### PR TITLE
[RFC] requires libgcc_s.so.1 when libpthread.so.0 is required

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -75,12 +75,13 @@ hook() {
         read -n4 elfmagic < "$f"
         if [ "$elfmagic" = $'\177ELF' ]; then
             for nlib in $($OBJDUMP -p "$f"|awk '/NEEDED/{print $2}'); do
-                [ -z "$verify_deps" ] && verify_deps="$nlib" && continue
-                found=0
-                for j in ${verify_deps}; do
-                    [[ $j == $nlib ]] && found=1 && break
-                done
-                [[ $found -eq 0 ]] && verify_deps="$verify_deps $nlib"
+                case " $verify_deps " in
+                    *" $nlib "*)
+                        ;;
+                    *)
+                        verify_deps="$verify_deps $nlib"
+                        ;;
+                esac
             done
         fi
     done


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
