### PR TITLE
nyxt: fix missing symbol lfp_errno

### DIFF
--- a/srcpkgs/nyxt/patches/001-libfixposix.patch
+++ b/srcpkgs/nyxt/patches/001-libfixposix.patch
@@ -1,12 +1,14 @@
---- a/_build/iolib/src/syscalls/ffi-functions-unix.lisp.orig	2022-02-27 09:44:00.327307802 -0700
-+++ b/_build/iolib/src/syscalls/ffi-functions-unix.lisp	2022-02-27 09:48:30.875539336 -0700
-@@ -12,7 +12,8 @@
+--- a/_build/iolib/src/syscalls/ffi-functions-unix.lisp	2022-03-20 16:37:34.285638580 -0700
++++ b/_build/iolib/src/syscalls/ffi-functions-unix.lisp	2022-03-20 16:45:25.241621564 -0700
+@@ -11,7 +11,10 @@
+ ;; FIXME: move this into an ASDF operation
  (eval-when (:compile-toplevel :load-toplevel :execute)
    (define-foreign-library
-       (libfixposix :canary "lfp_buildinfo")
--    (t (:default "libfixposix")))
-+    (:unix "libfixposix.so.3")
-+    (t (:default "libfixposix")))
+-      (libfixposix :canary "lfp_buildinfo")
++      libfixposix
++       (:unix (:or "libfixposix.so.3.2.0"
++		   "libfixposix.so.3"
++		   "libfixposix.so"))
+     (t (:default "libfixposix")))
    (load-foreign-library 'libfixposix))
  
- 

--- a/srcpkgs/nyxt/patches/002-webkit2gtk.patch
+++ b/srcpkgs/nyxt/patches/002-webkit2gtk.patch
@@ -1,12 +1,13 @@
 --- a/_build/cl-webkit/webkit2/webkit2.init.lisp	2022-01-14 03:22:05.000000000 -0700
 +++ b/_build/cl-webkit/webkit2/webkit2.init.lisp	2022-02-27 09:59:29.175938024 -0700
-@@ -18,9 +18,9 @@
+@@ -18,9 +18,10 @@
                "libwebkit2gtk-4.0.37.dylib"
                "libwebkit2gtk-4.0.dylib"))
      (:unix (:or "libwebkit2gtk-4.1.so"
 -                "libwebkit2gtk-4.0.so"
                  ;; Fedora only has this one?
 -                "libwebkit2gtk-4.0.so.37")))
++                "libwebkit2gtk-4.0.so.37.55.9"
 +                "libwebkit2gtk-4.0.so.37"
 +                "libwebkit2gtk-4.0.so")))
    (use-foreign-library libwebkit2))

--- a/srcpkgs/nyxt/patches/003-libgirepository.patch
+++ b/srcpkgs/nyxt/patches/003-libgirepository.patch
@@ -1,0 +1,11 @@
+--- a/_build/cl-gobject-introspection/src/init.lisp	2022-01-14 03:21:58.000000000 -0700
++++ b/_build/cl-gobject-introspection/src/init.lisp	2022-03-20 12:55:08.298233467 -0700
+@@ -10,7 +10,7 @@
+     (t "libgobject-2.0"))
+   (cffi:define-foreign-library girepository
+     (:darwin "libgirepository-1.0.dylib")
+-    (:unix (:or "libgirepository-1.0.so" "libgirepository-1.0.so.1"))
++    (:unix (:or "libgirepository-1.0.so.1.0.0" "libgirepository-1.0.so.1"))
+     (:windows (:or "libgirepository-1.0.dll" "libgirepository-1.0.0.dll"
+                    "libgirepository-1.0-1.dll"))
+     (t "libgirepository-1.0")))


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64`-`glibc`)
- I built this PR locally inside of a VM, (`x86_64`-`musl`)

#### Notes

This patch is in response to bug report #36243.

Everything seems to check out good on both systems mentioned above.