### PR TITLE
[WIP] ocaml: fix build on aarch64-musl

### DIFF
--- a/srcpkgs/coccinelle/template
+++ b/srcpkgs/coccinelle/template
@@ -1,7 +1,7 @@
 # Template file for 'coccinelle'
 pkgname=coccinelle
 version=1.1.0
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="--without-pdflatex --enable-release --enable-opt
  --with-python=/usr/bin/python3"
@@ -16,6 +16,7 @@ distfiles="https://github.com/coccinelle/coccinelle/archive/${version}.tar.gz"
 checksum=e40bdd51eda84f9bf3154c592ebb4af73a4dd9656c03e7ca1d3aa0247d98d185
 disable_parallel_build=yes
 nocross=yes
+nopie=yes
 
 pre_configure() {
 	autoreconf -fi

--- a/srcpkgs/dune/template
+++ b/srcpkgs/dune/template
@@ -1,7 +1,7 @@
 # Template file for 'dune'
 pkgname=dune
 version=3.0.3
-revision=1
+revision=2
 makedepends="ocaml"
 depends="ocaml"
 short_desc="Composable build system for OCaml"
@@ -11,6 +11,7 @@ homepage="https://dune.build/"
 distfiles="https://github.com/ocaml/dune/archive/refs/tags/${version}.tar.gz"
 checksum=8f5e1570e68f7b2e0a8d1ffea77318e058f125f4cb8ea9a4af9cf9afe4ced893
 nocross="ocaml"
+nopie=yes
 
 _dune_release_pkgs="dune dune-action-plugin dune-build-info dune-configurator
  dune-glob dune-private-libs dune-site dyn stdune ordering xdg fiber"

--- a/srcpkgs/ocaml/template
+++ b/srcpkgs/ocaml/template
@@ -1,7 +1,7 @@
 # Template file for 'ocaml'
 pkgname=ocaml
 version=4.13.1
-revision=2
+revision=3
 build_style="gnu-configure"
 configure_args="--with-pic --libdir=/usr/lib/ocaml"
 make_build_target="world.opt"
@@ -22,7 +22,26 @@ case "$XBPS_TARGET_MACHINE" in
 	ppc-musl) broken="/usr/bin/ocamlc: unsupported relocation type 6";;
 	# https://github.com/ocaml/ocaml/issues/7562
 	# for ppc we solved this separately though
-	*-musl) nopie=yes ;;
+	*-musl)
+		nopie_files+="
+			/usr/bin/ocamlc.opt
+			/usr/bin/ocamlcmt
+			/usr/bin/ocamlcp.opt
+			/usr/bin/ocamldep.opt
+			/usr/bin/ocamldoc.opt
+			/usr/bin/ocamllex.opt
+			/usr/bin/ocamlmklib.opt
+			/usr/bin/ocamlmktop.opt
+			/usr/bin/ocamlobjinfo.opt
+			/usr/bin/ocamlopt.opt
+			/usr/bin/ocamloptp.opt
+			/usr/bin/ocamlprof.opt
+			/usr/bin/ocamlrun
+			/usr/bin/ocamlrund
+			/usr/bin/ocamlruni
+			/usr/bin/ocamlyacc
+		"
+		;;
 esac
 
 post_install() {

--- a/srcpkgs/ocamlbuild/template
+++ b/srcpkgs/ocamlbuild/template
@@ -1,7 +1,7 @@
 # Template file for 'ocamlbuild'
 pkgname=ocamlbuild
 version=0.14.1
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="PREFIX=/usr"
 make_install_args="PREFIX=/usr"
@@ -13,3 +13,4 @@ homepage="https://github.com/ocaml/ocamlbuild"
 distfiles="https://github.com/ocaml/${pkgname}/archive/${version}.tar.gz"
 checksum=4e1279ff0ef80c862eaa5207a77020d741e89ef94f0e4a92a37c4188dbf08256
 nocross=yes
+nopie=yes

--- a/srcpkgs/opam/template
+++ b/srcpkgs/opam/template
@@ -1,7 +1,7 @@
 # Template file for 'opam'
 pkgname=opam
 version=2.1.2
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--docdir=/usr/share/doc/${pkgname}"
 make_build_args="lib-ext all"
@@ -16,6 +16,7 @@ homepage="http://opam.ocamlpro.com"
 distfiles="https://github.com/ocaml/${pkgname}/archive/${version}.tar.gz"
 checksum=735e717532f135064940fe3fef573acce6b1bbdc5e146470c2ac20fc8510a470
 nocross=yes
+nopie=yes
 disable_parallel_build=yes
 
 post_install() {

--- a/srcpkgs/unison/template
+++ b/srcpkgs/unison/template
@@ -1,7 +1,7 @@
 # Template file for 'unison'
 pkgname=unison
 version=2.51.4
-revision=2
+revision=3
 hostmakedepends="ocaml"
 short_desc="File-synchronization tool"
 maintainer="allan <mail@may.mooo.com>"
@@ -10,6 +10,7 @@ homepage="https://www.cis.upenn.edu/~bcpierce/unison/"
 distfiles="https://github.com/bcpierce00/unison/archive/v${version}.tar.gz"
 checksum=d1ecc7581aaf2ed0f3403d4960f468acd7b9f1d92838a17c96e6d1df79b802d5
 nocross="OCaml does not cross compile"
+nopie=yes
 
 do_build() {
 	CFLAGS= make ${makejobs} UISTYLE=text DEBUGGING=false THREADS=true


### PR DESCRIPTION
Earlier fix for *-musl platforms has been "nopie=yes", which disables
PIE by modifying CFLAGS/LDFLAGS/... during build. This results in
OCaml's runtime shared library linking fail.
    
Later OCaml releases incorporated a fix for *-musl platforms that
properly disables PIE only where required.
    
Set nopie_files instead, which respects OCaml's build system choice
of CFLAGS/LDFLAGS/... and fixes aarch64-build.

I am not entirely sure whether `nopie=yes` in every package is a good idea. It seems to only be required on *-musl except x86_64-musl(?).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-musl)

[ci skip]