### PR TITLE
warzone2100: don't install /usr/bin/.portable

### DIFF
--- a/srcpkgs/warzone2100/template
+++ b/srcpkgs/warzone2100/template
@@ -1,7 +1,7 @@
 # Template file for 'warzone2100'
 pkgname=warzone2100
 version=4.2.7
-revision=1
+revision=3
 wrksrc="warzone2100"
 build_style=cmake
 configure_args="-DWZ_ENABLE_WARNINGS_AS_ERRORS=OFF -DWZ_DISTRIBUTOR=void"
@@ -26,6 +26,10 @@ post_extract() {
 	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 		echo "target_link_libraries(warzone2100 atomic)" >> CMakeLists.txt
 	fi
+}
+
+post_install() {
+	rm "$DESTDIR"/usr/bin/.portable
 }
 
 warzone2100-data_package() {


### PR DESCRIPTION
it tricks keepassxc into portable mode

```
...
access("/usr/bin/.portable", F_OK)      = -1 ENOENT (No such file or directory)
...
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

