### PR TITLE
New package: onlyoffice

### DIFF
--- a/srcpkgs/onlyoffice/template
+++ b/srcpkgs/onlyoffice/template
@@ -1,0 +1,25 @@
+# Template file for 'onlyoffice'
+pkgname=onlyoffice
+version=7.0.1
+revision=1
+archs="x86_64"
+hostmakedepends="tar xz"
+depends="libstdc++ curl xdg-utils dejavu-fonts-ttf GConf gtk+3 liberation-fonts-ttf libpulseaudio gstreamer1 nss alsa-lib gst-plugins-base1 gst-plugins-ugly1 nspr hicolor-icon-theme"
+short_desc="Office suite that combines text, spreadsheet and presentation editors"
+maintainer="Toromino <foxhkron@cybre.club>"
+license="AGPL-3.0-only"
+homepage="https://www.onlyoffice.com"
+distfiles="https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb"
+checksum=ea5e97f2558184f17ca3615efe6cd0354716f0919c4646f63cc9c0d4dfe0b779
+nostrip=yes
+
+do_extract() {
+	mkdir -p ${DESTDIR}
+	ar x ${XBPS_SRCDISTDIR}/${pkgname}-${version}/onlyoffice-desktopeditors_amd64.deb
+}
+
+do_install() {
+	tar xf data.tar.xz -C ${DESTDIR}
+	vlicense ${DESTDIR}/opt/onlyoffice/desktopeditors/3DPARTYLICENSE
+	vlicense ${DESTDIR}/opt/onlyoffice/desktopeditors/LICENSE.htm
+}


### PR DESCRIPTION
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

#### Description
This PR adds a new template for OnlyOffice desktop editors.
