### PR TITLE
helvum: clean up patch/template

### DIFF
--- a/srcpkgs/helvum/patches/i686-pipewire.patch
+++ b/srcpkgs/helvum/patches/i686-pipewire.patch
@@ -1,24 +1,11 @@
-From e8703de1c76f50553cedb7a1601e5b808a227604 Mon Sep 17 00:00:00 2001
-From: "Gabor Kecskemeti (sh)" <gabor@simple-help.com>
-Date: Thu, 11 Nov 2021 11:41:09 +0000
-Subject: A possible fix for issue #27
-
----
- pipewire/src/loop_.rs | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/helvum-0.3.4/pipewire/src/loop_.rs b/helvum-0.3.4/pipewire/src/loop_.rs
-index 3e0d9bd..353025f 100644
---- a/helvum-0.3.4/pipewire/src/loop_.rs
-+++ b/helvum-0.3.4/pipewire/src/loop_.rs
-@@ -411,7 +411,7 @@ where
-         fn duration_to_timespec(duration: Duration) -> spa_sys::timespec {
-             spa_sys::timespec {
-                 tv_sec: duration.as_secs().try_into().expect("Duration too long"),
--                tv_nsec: duration.subsec_nanos().into(),
-+                tv_nsec: duration.subsec_nanos().try_into().unwrap(),
-             }
-         }
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -14,7 +14,7 @@
+ # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
  
--- 
-
+ [dependencies]
+-pipewire = "0.4"
++pipewire = "0.5"
+ gtk = { version = "0.4.1", package = "gtk4" }
+ glib = { version = "0.15.1", features = ["log"] }
+ 

--- a/srcpkgs/helvum/template
+++ b/srcpkgs/helvum/template
@@ -1,12 +1,8 @@
 # Template file for 'helvum'
 pkgname=helvum
 version=0.3.4
-revision=1
-create_wrksrc=yes
-build_wrksrc="${pkgname}-${version}"
-_pipewire_rs_version=0.4.1
+revision=2
 build_style=cargo
-build_helper=rust
 hostmakedepends="pkg-config clang libclang"
 makedepends="gtk4-devel pipewire-devel glib-devel"
 depends="pipewire"
@@ -14,21 +10,8 @@ short_desc="GTK patchbay for pipewire"
 maintainer="classabbyamp <dev@kb6.ee>"
 license="GPL-3.0-only"
 homepage="https://gitlab.freedesktop.org/pipewire/helvum"
-distfiles="https://gitlab.freedesktop.org/pipewire/helvum/-/archive/${version}/helvum-${version}.tar.gz
- https://gitlab.freedesktop.org/pipewire/pipewire-rs/-/archive/v${_pipewire_rs_version}/pipewire-rs-v${_pipewire_rs_version}.tar.gz"
-checksum="e19054f3bcd1ba234c451134fe7f4c6afee35f108c122642c1d502fc16785c02
- 7df384c2a98154ae2cea8e14693db92e269437ea60fbcdfb6adb589226d12629"
-
-# XXX: this should not be necessary once the next version of the pipewire crate has been released
-post_extract() {
-	pushd $build_wrksrc
-	echo "[patch.crates-io]" >> Cargo.toml
-	for crate in pipewire pipewire-sys libspa libspa-sys; do
-		mv ../pipewire-rs-*/$crate $crate
-		echo "$crate = { path = './$crate' }" >> Cargo.toml
-	done
-	popd
-}
+distfiles="https://gitlab.freedesktop.org/pipewire/helvum/-/archive/${version}/helvum-${version}.tar.gz"
+checksum="e19054f3bcd1ba234c451134fe7f4c6afee35f108c122642c1d502fc16785c02"
 
 post_install() {
 	# Normally, meson would do this, but it's simpler to use the cargo build style and do this manually


### PR DESCRIPTION
upstream released pipewire-rs v0.5.0 that fixes the underlying issue,
but the Cargo.toml version requirement didn't allow it to be updated.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
