### PR TITLE
iwd: update to 1.26.

### DIFF
--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,6 +1,6 @@
 # Template file for 'iwd'
 pkgname=iwd
-version=1.24
+version=1.26
 revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://iwd.wiki.kernel.org/"
 changelog="https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog"
 distfiles="${KERNEL_SITE}/network/wireless/${pkgname}-${version}.tar.xz"
-checksum=61b5e48380cd3a6d0529f725eb6974157f1410af165f5d266b87add0bf395224
+checksum=0ff4541c2b7f14ec010c3cbd1f02350f1b58cb0c103412db22550e90d8040d6b
 make_dirs="/var/lib/iwd 0600 root root
  /var/lib/ead 0600 root root
  /etc/iwd 755 root root"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - ppc64le-musl

---

[Changelog](https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog):

```
ver 1.26:
	Fix issue with handling BSS that changed frequency.
	Fix issue with handling frequencies in neighbor report.
	Fix issue with operating classes for 802.11ax standard.
	Fix issue with enforcing of MFPR for 6 GHz frequencies.
	Add support for band defined in the WiFi 6E amendment.
	Add support for scanning while in AP mode.

ver 1.25:
	Fix issue with handling abort of periodic scans.
	Fix issue with handling connection when link goes down.
	Fix issue with handling operating channel information.
	Add support for encrypted network profile storage.
	Add support for DPP initiating as a configurator.
```