### PR TITLE
gnome-shell: re-enable optional dependencies

### DIFF
--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
 version=41.4
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dsystemd=false -Dtests=false"
@@ -10,6 +10,7 @@ hostmakedepends="gobject-introspection libxslt pkg-config python3 sassc
 makedepends="gnome-control-center-devel at-spi2-atk-devel
  evolution-data-server-devel mutter-devel gsettings-desktop-schemas-devel
  polkit-devel startup-notification-devel ibus-devel gnome-desktop-devel
+ gnome-bluetooth-devel pipewire-devel gstreamer1-devel
  NetworkManager-devel pulseaudio-devel gtk4-devel gnome-autoar-devel gjs-devel"
 depends="elogind gnome-control-center gsettings-desktop-schemas upower"
 checkdepends="xvfb-run mesa-dri $depends"


### PR DESCRIPTION
+ enable bluetooth indicator
+ enable screencast

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

During the gnome 41 update unused dependencies from gnome-shell were purged. Unfortunately some of the dependencies that were removed were just optional dependencies, this re-enables them.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
