### PR TITLE
.github: improve the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,8 @@
 - This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
 -->
 
-<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
+<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
+https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
 and test at least one native build and, if supported, at least one cross build.
 Ignore this section if this PR is not skipping CI.
 -->


### PR DESCRIPTION
related #36263

Currently the PR template may be a bit confusing because we write [skip CI] as markdown syntax which is very similar to [ci skip].
This syntax in a comment which is not meant to be uncommented is unintuitive so I propose wording it differently.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
