### PR TITLE
i2c-tools: change upstream and add python subpkg

### DIFF
--- a/srcpkgs/i2c-tools/patches/py-smbus_fix-destdir.patch
+++ b/srcpkgs/i2c-tools/patches/py-smbus_fix-destdir.patch
@@ -1,0 +1,35 @@
+I had to add '--root' to the patch for it to not poison the masterdir.
+  That part will still be needed as a patch when the next version gets released.
+  -- 0x5c
+original message below
+
+From a4609318b6fa594f970673d77397f1ca74b4120a Mon Sep 17 00:00:00 2001
+From: Morten Linderud <morten@linderud.pw>
+Date: Mon, 4 Oct 2021 20:01:53 +0200
+Subject: py-smbus/Module.mk: Install with PREFIX defined
+
+If we are building to a defined destdir py-smbus is going to ignore this
+and try install to the actual root. This breaks packaging setups as the
+install section would fail.
+
+Signed-off-by: Morten Linderud <morten@linderud.pw>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+---
+ py-smbus/Module.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/py-smbus/Module.mk b/py-smbus/Module.mk
+index 04ceb64..1e2ded1 100644
+--- a/py-smbus/Module.mk
++++ b/py-smbus/Module.mk
+@@ -22,7 +22,7 @@ clean-python:
+ 	rm -rf py-smbus/build
+ 
+ install-python:
+-	$(DISTUTILS) install
++	$(DISTUTILS) install --prefix="$(PREFIX)" --root="$(DESTDIR)"
+ 
+ all: all-python
+ 
+-- 
+cgit 1.2.3-1.el7

--- a/srcpkgs/i2c-tools/patches/py-smbus_use-setuptools.patch
+++ b/srcpkgs/i2c-tools/patches/py-smbus_use-setuptools.patch
@@ -1,0 +1,33 @@
+From cf3541b8a7ed50782edd05836020d31230fb86c6 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@arm.com>
+Date: Wed, 19 Jan 2022 12:08:53 +0100
+Subject: py-smbus: Use setuptools instead of distutils
+
+As per [1], distutils is deprecated in Python 3.10 and will be removed
+entirely in Python 3.12.
+
+As setuptools is essentially an enhanced version of distutils, it's
+trivial to port to that.
+
+[1] https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated
+
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+Signed-off-by: Jean Delvare <jdelvare@suse.de>
+---
+ py-smbus/setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/py-smbus/setup.py b/py-smbus/setup.py
+index 28a4500..26db33a 100644
+--- a/py-smbus/setup.py
++++ b/py-smbus/setup.py
+@@ -1,6 +1,6 @@
+ #!/usr/bin/env python
+ 
+-from distutils.core import setup, Extension
++from setuptools import setup, Extension
+ 
+ setup(	name="smbus",
+ 	version="1.1",
+-- 
+cgit 1.2.3-1.el7

--- a/srcpkgs/i2c-tools/template
+++ b/srcpkgs/i2c-tools/template
@@ -1,17 +1,35 @@
 # Template file for 'i2c-tools'
 pkgname=i2c-tools
 version=4.3
-revision=1
+revision=2
 build_style=gnu-makefile
-make_install_args="sbindir=/usr/bin"
+make_build_args="EXTRA=py-smbus"
+make_install_args="sbindir=/usr/bin EXTRA=py-smbus"
+hostmakedepends="python3 python3-setuptools"
+makedepends="python3-devel"
 depends="perl"
 short_desc="Heterogeneous set of I2C tools"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"
-homepage="https://packages.debian.org/sid/i2c-tools"
-distfiles="${DEBIAN_SITE}/main/i/${pkgname}/${pkgname}_${version}.orig.tar.xz"
+homepage="https://i2c.wiki.kernel.org/index.php/I2C_Tools"
+distfiles="https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-${version}.tar.xz"
 checksum=1f899e43603184fac32f34d72498fc737952dbc9c97a8dd9467fadfdf4600cf9
 system_groups="i2c"
+
+
+if [ -n "$CROSS_BUILD" ]; then
+	export PYPREFIX="$XBPS_CROSS_BASE"
+	export CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
+	export LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
+	export CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
+	export LDSHARED="${CC} -shared $LDFLAGS"
+	export PYTHONPATH="${XBPS_CROSS_BASE}/${py3_lib}"
+	for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
+			f=${f##*/}
+			_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
+	done
+	export _PYTHON_SYSCONFIGDATA_NAME
+fi
 
 post_install() {
 	vinstall "${FILESDIR}/45-i2c-tools.rules" 644 usr/lib/udev/rules.d
@@ -25,5 +43,14 @@ i2c-tools-devel_package() {
 		vmove usr/share/man/man3
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
+	}
+}
+
+python3-smbus_package() {
+	short_desc+="Python 3 bindings for libi2c from i2c-tools"
+	depends="${sourcepkg}>=${version}_${revision}"
+	lib32disabled=yes
+	pkg_install() {
+		vmove "usr/lib/python3.*"
 	}
 }

--- a/srcpkgs/python3-smbus
+++ b/srcpkgs/python3-smbus
@@ -1,0 +1,1 @@
+i2c-tools


### PR DESCRIPTION
~~Things I am still unsure about:~~
- ~~The subpackage name and short_desc~~
- ~~How to ensure the subpackage's version is the version of the python module (it is versioned separately)~~

Closes #36156

#### Testing the changes
- I tested the changes in this PR: **briefly**
    - [x] Distfile location change had no impact (same exact file as debian's)
    - [x] Package builds fine and with the right files in the right place
    - [x] Crossbuilds fine
    - [x] Tested the python bindings

@leahneukirchen 

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
