### PR TITLE
pianobar: fix build

### DIFF
--- a/srcpkgs/pianobar/template
+++ b/srcpkgs/pianobar/template
@@ -1,12 +1,12 @@
 # Template file for 'pianobar'
 pkgname=pianobar
 version=2020.11.28
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="V=1"
 hostmakedepends="pkg-config"
 makedepends="faad2-devel ffmpeg-devel gnutls-devel json-c-devel libao-devel
- libcurl-devel"
+ libcurl-devel libgcrypt-devel"
 short_desc="Free/open-source, console-based client for Pandora radio"
 maintainer="Ulf <void@uw.anonaddy.com>"
 license="MIT"


### PR DESCRIPTION
Currently build fails with:

```
In file included from src/ui.h:28,
                 from src/ui_act.c:34:
src/libpiano/piano.h:32:10: fatal error: gcrypt.h: No such file or directory
   32 | #include <gcrypt.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [Makefile:109: src/ui_act.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from src/main.c:51:
src/libpiano/piano.h:32:10: fatal error: gcrypt.h: No such file or directory
   32 | #include <gcrypt.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [Makefile:109: src/main.o] Error 1
In file included from src/settings.c:38:
src/libpiano/piano.h:32:10: fatal error: gcrypt.h: No such file or directory
   32 | #include <gcrypt.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [Makefile:109: src/settings.o] Error 1
In file included from src/player.h:37,
                 from src/player.c:61:
src/libpiano/piano.h:32:10: fatal error: gcrypt.h: No such file or directory
   32 | #include <gcrypt.h>
      |          ^~~~~~~~~~
compilation terminated.
make: *** [Makefile:109: src/player.o] Error 1
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
