### PR TITLE
dendrite: update to 0.7.0.

### DIFF
--- a/srcpkgs/dendrite/files/dendrite-monolith-server/run
+++ b/srcpkgs/dendrite/files/dendrite-monolith-server/run
@@ -1,5 +1,6 @@
 #!/bin/sh
 [ -r ./conf ] && . ./conf
+ulimit -n ${MAX_OPEN_FILES:-65535}
 cd /var/lib/dendrite || exit 1
 exec 2>&1
 exec chpst -u _dendrite:_dendrite dendrite-monolith-server \

--- a/srcpkgs/dendrite/template
+++ b/srcpkgs/dendrite/template
@@ -1,6 +1,6 @@
 # Template file for 'dendrite'
 pkgname=dendrite
-version=0.6.5
+version=0.7.0
 revision=1
 build_style=go
 go_import_path="github.com/matrix-org/dendrite"
@@ -12,7 +12,7 @@ license="Apache-2.0"
 homepage="https://matrix.org/docs/projects/server/dendrite"
 changelog="https://raw.githubusercontent.com/matrix-org/dendrite/main/CHANGES.md"
 distfiles="https://github.com/matrix-org/dendrite/archive/v${version}.tar.gz"
-checksum=b74170bd3f81e2f22ff4673bc632e37afeef1121fa90acb03ed2eed17a387133
+checksum=26c378bff1738b0e8422c7bd425be4763f22225f422ae1854c78644e4ca8bc42
 
 system_accounts="_dendrite"
 _dendrite_homedir="/var/lib/dendrite"


### PR DESCRIPTION
add MAX_OPEN_FILES variable with default set to value recommended by
upstream (65535).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please [skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration)
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
