### PR TITLE
zfs: update to 2.1.4.

### DIFF
--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,6 +1,6 @@
 # Template file for 'zfs'
 pkgname=zfs
-version=2.1.3
+version=2.1.4
 revision=1
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
@@ -15,7 +15,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="CDDL-1.0"
 homepage="https://openzfs.github.io/openzfs-docs/"
 distfiles="https://github.com/openzfs/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
-checksum=b61b644547793f409cafd6538a52d78f2f72b0cd013e88340882457c8c9b43fd
+checksum=3b52c0d493f806f638dca87dde809f53861cd318c1ebb0e60daeaa061cf1acf6
 # dkms must be before initramfs-regenerate to build modules before images
 triggers="dkms initramfs-regenerate"
 dkms_modules="zfs ${version}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - x86_64-musl

ZFS 2.1.4 adds a fix for kernel 5.16 on [specific x86 CPUs](https://github.com/openzfs/zfs/issues/13210). I've booted my system with this package, but it could use wider real-world testing on Void systems.