### PR TITLE
sauerbraten: add application menu

### DIFF
--- a/srcpkgs/sauerbraten/files/sauerbraten.desktop
+++ b/srcpkgs/sauerbraten/files/sauerbraten.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Name=Sauerbraten
+Comment=Free multiplayer & singleplayer first person shooter
+Exec=sauerbraten %u
+Icon=sauerbraten
+Terminal=false
+StartupNotify=false
+Categories=Application;Game;ActionGame;

--- a/srcpkgs/sauerbraten/template
+++ b/srcpkgs/sauerbraten/template
@@ -1,7 +1,7 @@
 # Template file for 'sauerbraten'
 pkgname=sauerbraten
 version=2020.12.29
-revision=1
+revision=2
 wrksrc=$pkgname
 build_wrksrc=src
 build_style=gnu-makefile
@@ -21,6 +21,7 @@ archs="i686* x86_64*"
 post_install() {
 	vbin $wrksrc/bin_unix/native_client sauer_client
 	vbin ${FILESDIR}/sauerbraten
+	vinstall ${FILESDIR}/sauerbraten.desktop 0644 usr/share/applications
 }
 
 sauerbraten-data_package() {


### PR DESCRIPTION
[Sauerbraten](http://sauerbraten.org/) is a free multiplayer & singleplayer first person shooter, the successor of the [Cube](http://www.cubeengine.com/) FPS.
`sauerbraten` does not provide a desktop menu, so it can only be opened via the cli.

```
➜  ~ xbps-query --regex -Rf sauerbraten
/usr/bin/sauer_client
/usr/bin/sauerbraten
```
#### Testing the changes
- I tested the changes in this PR: **briefly** (testing by adding .desktop manually. not build package)

![Screenshot_20220326_132604](https://user-images.githubusercontent.com/45872139/160227628-63cd0e47-361f-4cd6-a7e8-795038c5ea19.png)

