### PR TITLE
pijul, rdedup: remove unnecessary build_helper

### DIFF
--- a/srcpkgs/pijul/template
+++ b/srcpkgs/pijul/template
@@ -3,7 +3,6 @@ pkgname=pijul
 version=0.12.2
 revision=5
 build_style=cargo
-build_helper=rust
 _sequoia_ver=0.9.0
 hostmakedepends="pkg-config clang"
 makedepends="libsodium-devel openssl-devel nettle-devel"

--- a/srcpkgs/rdedup/template
+++ b/srcpkgs/rdedup/template
@@ -3,7 +3,6 @@ pkgname=rdedup
 version=3.2.1
 revision=1
 build_style=cargo
-build_helper=rust
 hostmakedepends="pkg-config clang"
 makedepends="openssl-devel liblzma-devel libsodium-devel"
 short_desc="Data deduplication engine"


### PR DESCRIPTION
caused by me in #36125

don't think it's necessary to revbump, it should not change the output package at all

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
