### PR TITLE
python3-sympy: update to 1.10.1.

### DIFF
--- a/srcpkgs/python3-sympy/patches/fix_integer_nthroot.patch
+++ b/srcpkgs/python3-sympy/patches/fix_integer_nthroot.patch
@@ -1,0 +1,26 @@
+Fix integer_nthroot(2, 10**10) in 32 bit.
+
+See: https://github.com/sympy/sympy/issues/18374#issuecomment-1081196879
+
+diff --git a/sympy/core/power.py b/sympy/core/power.py
+index 59ab7c53a4..ae3ee25c93 100644
+--- a/sympy/core/power.py
++++ b/sympy/core/power.py
+@@ -21,6 +21,8 @@
+
+ from mpmath.libmp import sqrtrem as mpmath_sqrtrem
+
++from ctypes import c_ulong
++ULONG_MAX = c_ulong(-1).value
+
+
+ def isqrt(n):
+@@ -74,7 +76,7 @@ def integer_nthroot(y, n):
+         raise ValueError("y must be nonnegative")
+     if n < 1:
+         raise ValueError("n must be positive")
+-    if HAS_GMPY and n < 2**63:
++    if HAS_GMPY and n <= ULONG_MAX:
+         # Currently it works only for n < 2**63, else it produces TypeError
+         # sympy issue: https://github.com/sympy/sympy/issues/18374
+         # gmpy2 issue: https://github.com/aleaxit/gmpy/issues/257

--- a/srcpkgs/python3-sympy/template
+++ b/srcpkgs/python3-sympy/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-sympy'
 pkgname=python3-sympy
-version=1.9
+version=1.10.1
 revision=1
 wrksrc="sympy-${version}"
 build_style=python3-module
@@ -12,7 +12,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://sympy.org/"
 distfiles="${PYPI_SITE}/s/sympy/sympy-${version}.tar.gz"
-checksum=c7a880e229df96759f955d4f3970d4cabce79f60f5b18830c08b90ce77cd5fdc
+checksum=5939eeffdf9e152172601463626c022a2c27e75cf6278de8d401d50c9d58787b
 
 post_install() {
 	vman doc/man/isympy.1


### PR DESCRIPTION
Also fix integer_nthroot(2, 10**10) in 32 bit, reported upstream (https://github.com/sympy/sympy/issues/18374#issuecomment-1081196879 and https://github.com/aleaxit/gmpy/issues/257#issuecomment-1073426165)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**