### PR TITLE
onboard: fix SyntaxWarnings and disable tests

### DIFF
--- a/srcpkgs/onboard/patches/fix-brokenformat.patch
+++ b/srcpkgs/onboard/patches/fix-brokenformat.patch
@@ -1,0 +1,15 @@
+Fix for https://bugs.launchpad.net/onboard/+bug/1948723
+
+
+--
+--- a/Onboard/LayoutLoaderSVG.py
++++ b/Onboard/LayoutLoaderSVG.py
+@@ -445,7 +445,7 @@
+             except KeyError as ex:
+                 (strerror) = ex
+                 raise Exceptions.LayoutFileError("Unrecognized modifier %s in" \
+-                    "definition of %s" (strerror, full_id))
++                    "definition of %s" % (strerror, full_id))
+ 
+         value = attributes.get("action")
+         if value:

--- a/srcpkgs/onboard/template
+++ b/srcpkgs/onboard/template
@@ -1,7 +1,7 @@
 # Template file for 'onboard'
 pkgname=onboard
 version=1.4.1
-revision=9
+revision=10
 build_style=python3-module
 hostmakedepends="intltool pkg-config python3-distutils-extra"
 makedepends="dconf-devel eudev-libudev-devel gtk+3-devel hunspell-devel
@@ -14,3 +14,5 @@ license="GPL-3.0-or-later"
 homepage="https://launchpad.net/onboard"
 distfiles="https://launchpad.net/${pkgname}/${version%.*}/${version}/+download/${pkgname}-${version}.tar.gz"
 checksum=01cae1ac5b1ef1ab985bd2d2d79ded6fc99ee04b1535cc1bb191e43a231a3865
+# Tries to run onboard in tests, using xautomation(7)
+make_check=no


### PR DESCRIPTION
- A missing % operator was breaking a c-style format string, causing a
    SyntaxWarning to be trown twice at package install time (during
    byte-compilation).
- The tests were failing since they try to run 'killall' before executing
    onboard in xautomation(7), both not being possible in xbps-src.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
