### PR TITLE
.github/workflows: Add a workflow for dealing with stale issues/prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+---
+name: Stale Cleanup
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'Issues become stale 90 days after last activity and are closed 7 days after that.  If this issue is still relevant bump it or assign it.'
+          stale-pr-message: 'Pull Requests become stale 90 days after last activity and are closed 7 days after that.  If this pull request is still relevant bump it or assign it.'
+          days-before-stale: 90
+          days-before-close: 7
+          debug-only: true
+          exempt-all-assignees: true
+          operations-per-run: 1000


### PR DESCRIPTION
This PR adds the [stale action](https://github.com/actions/stale) to try and keep an eye on things that are stale due to inactivity.  It will not act on any PR or issue that is assigned.  Right now it won't even make any changes, I just want it to run so we can evaluate what the rough impact would be of switching on a stale PR minder.