### PR TITLE
jitterentropy: update to 3.4.0, fix license, -O0.

### DIFF
--- a/srcpkgs/jitterentropy/template
+++ b/srcpkgs/jitterentropy/template
@@ -1,16 +1,18 @@
 # Template file for 'jitterentropy'
 pkgname=jitterentropy
-version=3.3.1
+version=3.4.0
 revision=1
 wrksrc="${pkgname}-library-${version}"
 build_style=gnu-makefile
 make_use_env=yes
 short_desc="Hardware RNG based on CPU timing jitter"
 maintainer="Piraty <piraty1@inbox.ru>"
-license="BSD-3-Clause"
+license="BSD-3-Clause, GPL-2.0-only"
 homepage="https://www.chronox.de/jent.html"
-distfiles="https://github.com/smuellerDD/jitterentropy-library/archive/v${version}.tar.gz"
-checksum=4a50cb02b4836cd5550016e2fc2263e6982abaa11467a9e1cea260c1c2f7d487
+distfiles="https://www.chronox.de/jent/${pkgname}-library-${version}.tar.xz"
+checksum=979fa4277decf9792f3422b142237e77d8b6ca41e50474083eb2f0976f2479b3
+
+CFLAGS="-O0"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
explicitly disable building with optimizations

jitterentropy-rngd-1.2.7 raises error during build without `CFLAGS=-O0`

#### Testing the changes
- I tested the changes in this PR: **briefly**