### PR TITLE
Trimesh: update to 3.10.7

### DIFF
--- a/srcpkgs/python3-pycollada/template
+++ b/srcpkgs/python3-pycollada/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pycollada'
 pkgname=python3-pycollada
-version=0.7.1
-revision=3
+version=0.7.2
+revision=1
 wrksrc="pycollada-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,7 +12,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://pycollada.readthedocs.io/en/latest/"
 distfiles="https://github.com/pycollada/pycollada/archive/v${version}.tar.gz"
-checksum=b0b8e1fd17e3e5a7c1befcb5ec4fa0ead1318c5ca340bb930f62f9809fbce8a1
+checksum=e3c29857a65b3dd9c0375c1074195195fc3dada95d6b5c78d246b005f2e85c93
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/python3-trimesh/template
+++ b/srcpkgs/python3-trimesh/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-trimesh'
 pkgname=python3-trimesh
-version=3.9.34
+version=3.10.7
 revision=1
 wrksrc="trimesh-${version}"
 build_style=python3-module
@@ -10,14 +10,13 @@ depends="python3-numpy python3-scipy python3-networkx python3-lxml
  python3-pyglet python3-shapely python3-rtree python3-Pillow python3-svg.path
  python3-jsonschema python3-psutil python3-chardet python3-sympy python3-msgpack
  python3-pycollada python3-requests"
-# unit tests fail on x86 https://github.com/mikedh/trimesh/issues/690
 checkdepends="$depends python3-pytest"
 short_desc="Python3 library for loading and using triangular meshes"
 maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="MIT"
 homepage="https://trimsh.org/"
 distfiles="https://github.com/mikedh/trimesh/archive/${version}.tar.gz"
-checksum=713a959be0f93c049d0735f573b814cfa704c5bbfaf0c607facb61ede5a8ab2e
+checksum=e98fd2dff632729fc6fb963653b91d9f4a5a6a9a1f79493dd885e3e4d1f9c4da
 
 post_install() {
 	vlicense LICENSE.md
@@ -29,3 +28,8 @@ do_check() {
 	vsed -i 's/coveralls//' setup.py
 	python3 -m pytest
 }
+
+# disable tests for i686
+if [ "$XBPS_WORDSIZE" -eq "32" ]; then
+	make_check=no # https://github.com/mikedh/trimesh/issues/690;
+fi


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

#### Local build testing
- I built this PR locally for my native architecture, x64_glibc

This PR also updates pycollada

The unit tests throw a few deprecation warnings from the dependencies (numpy, scipy, shapely)