### PR TITLE
[RFC] patch_args: allow use of --directory parameter

### DIFF
--- a/common/hooks/do-patch/00-patches.sh
+++ b/common/hooks/do-patch/00-patches.sh
@@ -31,7 +31,7 @@ _process_patch() {
 
 	cd "$wrksrc"
 	msg_normal "$pkgver: patching: ${_patch}.\n"
-	patch -s ${_args} -i ${_patch} 2>/dev/null
+	patch -s ${_args} <${_patch} 2>/dev/null
 }
 
 hook() {

--- a/srcpkgs/chatterino2/patches/0001-fix-desktop-icon-name.patch
+++ b/srcpkgs/chatterino2/patches/0001-fix-desktop-icon-name.patch
@@ -1,7 +1,7 @@
 diff --git a/resources/com.chatterino.chatterino.desktop b/resources/com.chatterino.chatterino.desktop
 index 6ee45354..ece81f5c 100644
---- a/chatterino2/resources/com.chatterino.chatterino.desktop
-+++ b/chatterino2/resources/com.chatterino.chatterino.desktop
+--- a/resources/com.chatterino.chatterino.desktop
++++ b/resources/com.chatterino.chatterino.desktop
 @@ -4,7 +4,7 @@ Version=1.0
  Name=Chatterino
  Comment=Chat client for Twitch

--- a/srcpkgs/chatterino2/patches/cmake.patch
+++ b/srcpkgs/chatterino2/patches/cmake.patch
@@ -1,7 +1,7 @@
 diff --git a/cmake/FindLRUCache.cmake b/cmake/FindLRUCache.cmake
 index 82905436..b0b89a4e 100644
---- a/chatterino2/cmake/FindLRUCache.cmake
-+++ b/chatterino2/cmake/FindLRUCache.cmake
+--- a/cmake/FindLRUCache.cmake
++++ b/cmake/FindLRUCache.cmake
 @@ -1,6 +1,6 @@
  include(FindPackageHandleStandardArgs)
  
@@ -12,8 +12,8 @@ index 82905436..b0b89a4e 100644
  
 diff --git a/cmake/FindPajladaSerialize.cmake b/cmake/FindPajladaSerialize.cmake
 index 4671874c..119284c2 100644
---- a/chatterino2/cmake/FindPajladaSerialize.cmake
-+++ b/chatterino2/cmake/FindPajladaSerialize.cmake
+--- a/cmake/FindPajladaSerialize.cmake
++++ b/cmake/FindPajladaSerialize.cmake
 @@ -1,6 +1,6 @@
  include(FindPackageHandleStandardArgs)
  
@@ -24,8 +24,8 @@ index 4671874c..119284c2 100644
  
 diff --git a/cmake/FindPajladaSignals.cmake b/cmake/FindPajladaSignals.cmake
 index f4c964ec..75efba20 100644
---- a/chatterino2/cmake/FindPajladaSignals.cmake
-+++ b/chatterino2/cmake/FindPajladaSignals.cmake
+--- a/cmake/FindPajladaSignals.cmake
++++ b/cmake/FindPajladaSignals.cmake
 @@ -1,6 +1,6 @@
  include(FindPackageHandleStandardArgs)
  

--- a/srcpkgs/chatterino2/template
+++ b/srcpkgs/chatterino2/template
@@ -9,7 +9,7 @@ _signals_commit="baf5bb04bd13b090e405e0447c89a811f7e23ddc"
 _qtkeychain_commit="de954627363b0b4bff9a2616f1a409b7e14d5df9"
 _sanitizers_cmake_commit="99e159ec9bc8dd362b08d18436bd40ff0648417b"
 create_wrksrc=yes
-build_wrksrc="chatterino2"
+build_wrksrc="chatterino2-${version}"
 build_style=cmake
 hostmakedepends="qt5-qmake qt5-host-tools"
 makedepends="qt5-tools-devel qt5-multimedia-devel qt5-svg-devel
@@ -40,8 +40,9 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	LIBS="-latomic"
 fi
 
+patch_args="-Np1 --directory=${build_wrksrc}"
+
 post_extract() {
-	mv "chatterino2-${version}" "${build_wrksrc}"
 	rmdir ${build_wrksrc}/lib/libcommuni ${build_wrksrc}/lib/serialize \
 	      ${build_wrksrc}/lib/settings ${build_wrksrc}/lib/signals \
 	      ${build_wrksrc}/lib/rapidjson ${build_wrksrc}/lib/websocketpp \

--- a/srcpkgs/wine/patches/musl-limits.patch
+++ b/srcpkgs/wine/patches/musl-limits.patch
@@ -1,5 +1,5 @@
---- a/wine-7.6/dlls/winebus.sys/bus_udev.c	2021-10-23 15:38:33.225064731 +0200
-+++ b/wine-7.6/dlls/winebus.sys/bus_udev.c	2021-10-23 15:39:06.662064765 +0200
+--- a/dlls/winebus.sys/bus_udev.c	2021-10-23 15:38:33.225064731 +0200
++++ b/dlls/winebus.sys/bus_udev.c	2021-10-23 15:39:06.662064765 +0200
 @@ -29,7 +29,8 @@
  #include <stdlib.h>
  #include <stdio.h>

--- a/srcpkgs/wine/patches/musl-rpath.patch
+++ b/srcpkgs/wine/patches/musl-rpath.patch
@@ -1,7 +1,7 @@
 diff --git a/configure b/configure
 index 774a95ce003..d408e77cc78 100755
---- a/wine-7.6/configure
-+++ b/wine-7.6/configure
+--- a/configure
++++ b/configure
 @@ -11137,6 +11137,38 @@ fi
      LIBWINE_DEPENDS="wine.map"
  
@@ -43,8 +43,13 @@ index 774a95ce003..d408e77cc78 100755
  
 diff --git a/configure.ac b/configure.ac
 index 8c5066a3de6..01ede86df1e 100644
+<<<<<<< HEAD
 --- a/wine-7.6/configure.ac
 +++ b/wine-7.6/configure.ac
+=======
+--- a/configure.ac
++++ b/configure.ac
+>>>>>>> 6dccb4ef9c (wine: patch into $build_wrksrc)
 @@ -916,6 +916,9 @@ case $host_os in
      AC_SUBST(LIBWINE_SHAREDLIB,"libwine.so.$libwine_version")
      AC_SUBST(LIBWINE_DEPENDS,"wine.map")

--- a/srcpkgs/wine/patches/musl-uid-t.patch
+++ b/srcpkgs/wine/patches/musl-uid-t.patch
@@ -1,5 +1,5 @@
---- a/wine-7.6/server/security.h	2022-01-29 08:23:43.759508270 +0100
-+++ b/wine-7.6/server/security.h	2022-01-29 08:24:07.976443565 +0100
+--- a/server/security.h	2022-01-29 08:23:43.759508270 +0100
++++ b/server/security.h	2022-01-29 08:24:07.976443565 +0100
 @@ -22,6 +22,7 @@
  #define __WINE_SERVER_SECURITY_H
  

--- a/srcpkgs/wine/template
+++ b/srcpkgs/wine/template
@@ -25,6 +25,8 @@ desc_option_xshm="Enable support for the X Shared Memory Extension"
 lib32mode=full
 archs="i686* x86_64*"
 
+patch_args="-Np1 --directory=${build_wrksrc}"
+
 _nopie=no
 if [ "$XBPS_TARGET_MACHINE" = i686-musl ]; then
 	# build system adds -fno-PIC for 32bit builds, which,
@@ -48,6 +50,7 @@ makedepends="gettext-devel ncurses-devel glu-devel libSM-devel
 depends="libXi libXinerama libXcomposite libXcursor libOSMesa
  desktop-file-utils hicolor-icon-theme liberation-fonts-ttf
  gnutls SDL2 wine-common>=${version}_${revision} libwine>=${version}_${revision}"
+# This testsuite might hang indefinitely
 make_check=extended
 
 case $XBPS_TARGET_MACHINE in


### PR DESCRIPTION
`patch(1)` has a `-d/--directory` parameter which allows us to specify a directory where the patch will be applied.
This is especially useful when we have multiple distfiles and want to patch in $build_wrksrc because that's where the patch is usually applied. So far, these patches had to be updated if $build_wrksrc changes, which is suboptimal.

Problem is, that the `-i` parameter is also relative to the the `-d` parameter and thus fails to find the patch, when `-d` is set.
This PR tries to solve that by using standard input instead of `-i`.

Included are examples with wine and chatterino2 making use of that change.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
