### PR TITLE
Manual.md: document the check functions

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1101,7 +1101,13 @@ still be passed in if it's a GNU configure script.
 
 - `post_build()` Actions to execute after `do_build()`.
 
-- `pre_install()` Actions to execute after `post_build()`.
+- `pre_check()` Actions to execute after `post_build()`.
+
+- `do_check()` Actions to execute to run checks for the package.
+
+- `post_check()` Actions to execute after `do_check()`.
+
+- `pre_install()` Actions to execute after `post_check()`.
 
 - `do_install()` Actions to execute to install the package files into the `fake destdir`.
 


### PR DESCRIPTION
The pre_/do_/post_check functions were not listed in the list of building
phase functions, and were not mentioned elsewhere (do_check was mentioned
once). This documents their existence.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
