### PR TITLE
hex: change binary name to avoid conflict with helix

### DIFF
--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,7 +1,7 @@
 # Template file for 'helix'
 pkgname=helix
 version=22.03
-revision=1
+revision=2
 build_style=cargo
 make_install_args="--path helix-term"
 hostmakedepends="git"
@@ -12,7 +12,6 @@ homepage="https://helix-editor.com/"
 changelog="https://github.com/helix-editor/helix/blob/master/CHANGELOG.md"
 distfiles="https://github.com/helix-editor/helix/archive/${version}.tar.gz"
 checksum=a21f4d7b6390930a89b59567909ad7c613a1eeeafc813167ff7bc3be603997f4
-conflicts="hex>=0"
 
 # skip problematic doctests on i686
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/hex/template
+++ b/srcpkgs/hex/template
@@ -1,7 +1,7 @@
 # Template file for 'hex'
 pkgname=hex
 version=0.4.2
-revision=1
+revision=2
 build_style=cargo
 short_desc="Futuristic take on hexdump"
 maintainer="SolitudeSF <solitudesf@protonmail.com>"
@@ -11,5 +11,7 @@ distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=a7cc1ece337fc19e77fbbbca145001bc5d447bde4118eb6de2c99407eb1a3b74
 
 post_install() {
+	# avoid conflict with helix
+	mv ${DESTDIR}/usr/bin/hx ${DESTDIR}/usr/bin/hex
 	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
This removes the conflict with `helix` by renaming the binary to the project's name.