### PR TITLE
vala-panel-appmenu: remove gtk2 subpackage

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3631,7 +3631,6 @@ libibverbs.so.1 rdma-core-22.1_1
 librdmacm.so.1 rdma-core-22.1_1
 libdvdcss.so.2 libdvdcss-1.4.2_1
 libvalapanel.so.0 vala-panel-0.4.87_1
-libappmenu-gtk2-parser.so.0 appmenu-gtk-module-0.7.1_1
 libappmenu-gtk3-parser.so.0 appmenu-gtk3-module-0.7.1_1
 libqhttpengine.so.1 qhttpengine-1.0.1_1
 libqmdnsengine.so.0 qmdnsengine-0.1.0_1

--- a/srcpkgs/appmenu-gtk-module
+++ b/srcpkgs/appmenu-gtk-module
@@ -1,1 +1,0 @@
-vala-panel-appmenu

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,7 +1,7 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
 version=0.1
-revision=67
+revision=68
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
 maintainer="Piotr Wójcik <chocimier@tlen.pl>"
@@ -18,6 +18,7 @@ replaces="
  albert<=0.16.1_4
  apg<=2.2.3_5
  appdata-tools<=0.1.8_2
+ appmenu-gtk-module<=0.7.6_1
  arm-mem-git<=20131108_2
  arptables<=0.0.4_3
  atom<=1.44.0_1

--- a/srcpkgs/vala-panel-appmenu/template
+++ b/srcpkgs/vala-panel-appmenu/template
@@ -2,10 +2,10 @@
 pkgname=vala-panel-appmenu
 _glhash=18896e602f40b03fcb0a8437a2e197d4
 version=0.7.6
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config vala bamf glib-devel gettext"
-makedepends="vala-devel bamf-devel gtk+-devel gtk+3-devel
+makedepends="vala-devel bamf-devel gtk+3-devel
  libxkbcommon-devel libpeas-devel libdbusmenu-glib-devel
  xfce4-panel-devel xfconf-devel libmate-panel-devel libXt-devel
  vala-panel-devel"
@@ -19,26 +19,16 @@ checksum=2856added014bb6e5238aacda1016e2520d9a58d4ba6d7b33b2707ea48e1c592
 
 appmenu-gtk-module-devel_package() {
 	short_desc="GTK module for exposing menus - development files"
-	depends="appmenu-gtk-module-${version}_${revision}
-	 appmenu-gtk3-module-${version}_${revision}"
+	depends="appmenu-gtk3-module-${version}_${revision}"
 	pkg_install() {
 		vmove usr/include
 		vmove usr/lib/pkgconfig
-		vmove "usr/lib/libappmenu-gtk2*.so"
 		vmove "usr/lib/libappmenu-gtk3*.so"
 	}
 }
 
-appmenu-gtk-module_package() {
-	short_desc="GTK module for exposing menus"
-	pkg_install() {
-		vmove usr/lib/gtk-2.0
-		vmove "usr/lib/libappmenu-gtk2*.so.*"
-	}
-}
-
 appmenu-gtk3-module_package() {
-	short_desc="GTK3 module for exposing menus"
+	short_desc="GTK module for exposing menus"
 	pkg_install() {
 		vmove usr/lib/gtk-3.0
 		vmove "usr/lib/libappmenu-gtk3*.so.*"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
