### PR TITLE
vte3: update to 0.68.0

### DIFF
--- a/srcpkgs/vte3/template
+++ b/srcpkgs/vte3/template
@@ -1,6 +1,6 @@
 # Template file for 'vte3'
 pkgname=vte3
-version=0.66.2
+version=0.68.0
 revision=1
 wrksrc="vte-${version}"
 build_style=meson
@@ -15,7 +15,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Terminal/VTE"
 distfiles="${GNOME_SITE}/vte/${version%.*}/vte-${version}.tar.xz"
-checksum=e89974673a72a0a06edac6d17830b82bb124decf0cb3b52cebc92ec3ff04d976
+checksum=13e7d4789ca216a33780030d246c9b13ddbfd04094c6316eea7ff92284dd1749
 
 # Suppress warnings as errors for NULL format strings (musl libc)
 CXXFLAGS="-Wno-error=format="


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Required for gnome-terminal 3.44 and gnome-console 42

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
