### PR TITLE
.github/workflows: Enable actions/stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,10 +12,8 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'Issues become stale 90 days after last activity and are closed 7 days after that.  If this issue is still relevant bump it or assign it.'
-          stale-pr-message: 'Pull Requests become stale 90 days after last activity and are closed 7 days after that.  If this pull request is still relevant bump it or assign it.'
+          stale-issue-message: 'Issues become stale 90 days after last activity and are closed 14 days after that.  If this issue is still relevant bump it or assign it.'
+          stale-pr-message: 'Pull Requests become stale 90 days after last activity and are closed 14 days after that.  If this pull request is still relevant bump it or assign it.'
           days-before-stale: 90
-          days-before-close: 7
-          debug-only: true
+          days-before-close: 14
           exempt-all-assignees: true
-          operations-per-run: 1000


### PR DESCRIPTION
This PR enables the actions/stale PR and issue cleaner with a 90 day timeout and 14 day close timeout.

@void-linux/pkg-committers this is your last opportunity to protest this change before it is enabled.  If no opposition is received for this by 2022-04-08 it will be switched on.