### PR TITLE
New package: arx-libertatis-1.2.1

### DIFF
--- a/srcpkgs/arx-libertatis/template
+++ b/srcpkgs/arx-libertatis/template
@@ -1,0 +1,19 @@
+# Template file for 'arx-libertatis'
+pkgname=arx-libertatis
+version=1.2.1
+revision=1
+build_style=cmake
+makedepends='zlib-devel boost-devel glm freetype-devel libopenal-devel SDL2-devel MesaLib-devel libepoxy-devel'
+depends='zlib freetype libopenal SDL2 libepoxy'
+checkdepends='libcppunit-devel'
+short_desc='Improved, cross-platform and open source engine for Arx Fatalis'
+maintainer='HiPhish <hiphish@posteo.de>'
+license="GPL-3.0-or-later, OFL-1.1"
+homepage='https://arx-libertatis.org/'
+distfiles="https://github.com/arx/ArxLibertatis/releases/download/${version}/${pkgname}-${version}.tar.xz"
+checksum='aafd8831ee2d187d7647ad671a03aabd2df3b7248b0bac0b3ac36ffeb441aedf'
+
+post_install() {
+	vlicense LICENSE
+	vlicense LICENSE.DejaVu
+}


### PR DESCRIPTION
This PR adds [Arx Libertatis](https://arx-libertatis.org/), a source port for the video game Arx Fatalis. I have played the game for a few minutes without any issues. Game files from the original game are required (I used the GOG version).

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - armv7l

#### TODO

- License: The code itself is published under `GPLv3+`, it includes the Noto fonts (`OFL`), and the Deja Vu fonts; I only included the former two, I don't know how to best add the latter.
- Runtime dependencies: I ran `readelf -d /usr/bin/arx` to get the list of immediate dynamic libraries, but I don't know which of those really need to be explicitly added. For now I have just taken the ones for which I have a `*-devel` build time dependency. Here is the complete output of `readelf`:

 ```
 Dynamic section at offset 0x2a7ec0 contains 38 entries:
   Tag        Type                         Name/Value
  0x0000000000000003 (PLTGOT)             0x2a9458
  0x0000000000000002 (PLTRELSZ)           8880 (bytes)
  0x0000000000000017 (JMPREL)             0x17d98
  0x0000000000000014 (PLTREL)             RELA
  0x0000000000000007 (RELA)               0x6a70
  0x0000000000000008 (RELASZ)             70440 (bytes)
  0x0000000000000009 (RELAENT)            24 (bytes)
  0x000000006ffffff9 (RELACOUNT)          2627
  0x0000000000000015 (DEBUG)              0x0
  0x0000000000000006 (SYMTAB)             0x2d0
  0x000000000000000b (SYMENT)             24 (bytes)
  0x0000000000000005 (STRTAB)             0x3198
  0x000000000000000a (STRSZ)              12944 (bytes)
  0x000000006ffffef5 (GNU_HASH)           0x6428
  0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
  0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libfreetype.so.6]
  0x0000000000000001 (NEEDED)             Shared library: [libopenal.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libepoxy.so.0]
  0x0000000000000001 (NEEDED)             Shared library: [libSDL2-2.0.so.0]
  0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
  0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
  0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
  0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
  0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
  0x000000000000000c (INIT)               0x1a048
  0x000000000000000d (FINI)               0x23dd84
  0x000000000000001a (FINI_ARRAY)         0x2a6fe0
  0x000000000000001c (FINI_ARRAYSZ)       8 (bytes)
  0x0000000000000019 (INIT_ARRAY)         0x2a6fe8
  0x000000000000001b (INIT_ARRAYSZ)       16 (bytes)
  0x000000000000001e (FLAGS)              BIND_NOW
  0x000000006ffffffb (FLAGS_1)            Flags: NOW PIE
  0x000000006ffffff0 (VERSYM)             0x6468
  0x000000006ffffffe (VERNEED)            0x6850
  0x000000006fffffff (VERNEEDNUM)         7
  0x0000000000000000 (NULL)               0x0
 ```
