### PR TITLE
python3-svg.path: update to 5.1.

### DIFF
--- a/srcpkgs/python3-svg.path/template
+++ b/srcpkgs/python3-svg.path/template
@@ -1,17 +1,20 @@
 # Template file for 'python3-svg.path'
 pkgname=python3-svg.path
-version=4.1
-revision=3
+version=5.1
+revision=1
 wrksrc="svg.path-${version}"
 build_style=python3-module
+# disable failing test
+make_check_args="-k not(ImageTest)"
 hostmakedepends="python3-setuptools"
 depends="python3"
+checkdepends="python3-pytest-cov python3-Pillow"
 short_desc="Python3 SVG path parser"
 maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="MIT"
 homepage="https://github.com/regebro/svg.path"
 distfiles="https://github.com/regebro/svg.path/archive/${version}.tar.gz"
-checksum=8fe78a5ff8f379c78dac4a3ba623068a8a2af434dace24103a053e06525d400d
+checksum=2ea5351a5886f8c55ae8fddb2f7182dca3d5760c03abade9cb256b91e4bb9bb4
 
 post_install() {
 	vlicense LICENSE.txt


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x64_glibc

One test fails because of cross-platform font rendering discrepancies, so I disabled it.
I opened an issue upstream https://github.com/regebro/svg.path/issues/84

