### PR TITLE
wireplumber: update to 0.4.9

### DIFF
--- a/srcpkgs/wireplumber/template
+++ b/srcpkgs/wireplumber/template
@@ -1,7 +1,7 @@
 # Template file for 'wireplumber'
 pkgname=wireplumber
-version=0.4.8
-revision=2
+version=0.4.9
+revision=1
 build_style=meson
 build_helper=gir
 configure_args="-Dintrospection=enabled -Dsystem-lua=true"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://pipewire.pages.freedesktop.org/wireplumber"
 changelog="https://gitlab.freedesktop.org/pipewire/wireplumber/-/raw/master/NEWS.rst"
 distfiles="https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/$version/wireplumber-$version.tar.gz"
-checksum=a7a84c21230c339a905704a9495dda10a4dec41a96bc115a9b33d24310a3f605
+checksum=0b25774a2821286a1fa31afb7db8db0573f493b35c40a7031b6e5a30cec0bbe3
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (aarch64-musl, x86_64)

This version fixes wireplumber for me on aarch64-musl.