### PR TITLE
vpsm: update upstream, clean suid bit

### DIFF
--- a/srcpkgs/vpsm/patches/setuid-fix.patch
+++ b/srcpkgs/vpsm/patches/setuid-fix.patch
@@ -1,0 +1,19 @@
+Do not apply the setuid permission bit on the vpsm script
+
+See https://github.com/void-linux/void-packages/issues/32156
+see https://github.com/sineto/vpsm/pull/2
+
+
+--
+
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@
+ 
+ .PHONY: install
+ install:
+-	install -Dm4755 vpsm $(DESTDIR)$(PREFIX)/bin/vpsm
++	install -Dm755 vpsm $(DESTDIR)$(PREFIX)/bin/vpsm
+ 	install -Dm644 man/vpsm.1 $(DESTDIR)/$(PREFIX)/share/man/man1/vpsm.1
+ 
+ .PHONY: uninstall

--- a/srcpkgs/vpsm/template
+++ b/srcpkgs/vpsm/template
@@ -1,13 +1,13 @@
 # Template file for 'vpsm'
 pkgname=vpsm
 version=0.1.2
-revision=1
+revision=2
 build_style=gnu-makefile
 depends="bash xtools ripgrep hub"
 short_desc="Void-Packages Sources Management wrapper for XBPS-SRC"
 maintainer="Sinésio Neto <sinetoami@gmail.com>"
 license="MIT"
-homepage="https://github.com/sinetoami/vpsm"
+homepage="https://github.com/sineto/vpsm"
 distfiles="${homepage}/archive/v${version}.tar.gz"
 checksum=7317439096f56371397eb1250a81ff83e53740c14163993cf6668e9f0c4bdc2f
 


### PR DESCRIPTION
- The suid permission bit was incorrectly being set. It is now gone.
    See #32156
- The upstream README indicates a move to a new GH account.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@sinetoami @sineto