### PR TITLE
font-cozette: update to 1.13.0, build natively, provide python3-crayons for makedepends

### DIFF
--- a/srcpkgs/font-cozette/template
+++ b/srcpkgs/font-cozette/template
@@ -1,7 +1,7 @@
 # Template file for 'font-cozette'
 pkgname=font-cozette
-version=1.11.3
-revision=2
+version=1.13.0
+revision=1
 create_wrksrc=yes
 hostmakedepends="font-util bdftopcf"
 depends="font-util"
@@ -9,8 +9,9 @@ short_desc="Bitmap programming font optimized for coziness"
 maintainer="Isaac Freund <ifreund@ifreund.xyz>"
 license="MIT"
 homepage="https://github.com/slavfox/Cozette"
+changelog="https://github.com/slavfox/Cozette/raw/master/CHANGELOG.md"
 distfiles="https://github.com/slavfox/Cozette/releases/download/v.${version}/CozetteFonts.zip"
-checksum=0976f61ba68b3a261568819bce0b89d43ae2892ad51e5da399dab8a5894cbbc8
+checksum=11590b29856d9ffb2dc6c606009168ea87a3ecde7bcbe9fe542bc34b406c868d
 font_dirs="/usr/share/fonts/misc /usr/share/fonts/TTF"
 
 do_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
