### PR TITLE
New package: threejs-sage-r122

### DIFF
--- a/srcpkgs/threejs-sage/template
+++ b/srcpkgs/threejs-sage/template
@@ -1,0 +1,16 @@
+# Template file for 'threejs-sage'
+pkgname=threejs-sage
+version=r122
+revision=1
+short_desc="Custom build of three.js for sagemath"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="MIT"
+homepage="https://github.com/sagemath/threejs-sage/"
+distfiles="https://github.com/sagemath/threejs-sage/archive/refs/tags/${version}.tar.gz"
+checksum=718767ab55876a3e957d1cfe89a322c6d9fa680fc737b9ca668aee6a3eac3bb8
+
+do_install() {
+	vlicense LICENSE
+	vinstall version 644 usr/share/sagemath/threejs-sage
+	vinstall build/three.min.js 644 usr/share/sagemath/threejs-sage/$version
+}

--- a/srcpkgs/threejs-sage/update
+++ b/srcpkgs/threejs-sage/update
@@ -1,0 +1,1 @@
+site=https://mirrors.mit.edu/sage/spkg/upstream/threejs/


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

This package was missing before, it is necessary for sagemath to show 3D plots.

Example:
```
sage: cube()
Launched html viewer for Graphics3d Object
```
should launch a browser with a 3d image of a cube that you can interact with (move, rotate, zoom).

Currently it shows a white page.

NOTE: this will require a configuration update to sagemath which I'll do soon as part of #36420. For the time being you can configure the location of threejs using an environment variable (after manually installing `threejs-sage`):
```
$ THREEJS_DIR=/usr/share/sagemath/threejs-sage sage
┌────────────────────────────────────────────────────────────────────┐
│ SageMath version 9.5, Release Date: 2022-01-30                     │
│ Using Python 3.10.4. Type "help()" for help.                       │
└────────────────────────────────────────────────────────────────────┘
sage: cube()
Launched html viewer for Graphics3d Object
```

This also works for me in jupyter notebook.