### PR TITLE
emacs: update to 28.1.

### DIFF
--- a/srcpkgs/emacs/template
+++ b/srcpkgs/emacs/template
@@ -1,6 +1,6 @@
 # Template file for 'emacs'
 pkgname=emacs
-version=27.2
+version=28.1
 revision=1
 build_style=gnu-configure
 configure_args="--with-file-notification=inotify --with-modules
@@ -24,7 +24,7 @@ maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/emacs/"
 distfiles="${GNU_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=b4a7cc4e78e63f378624e0919215b910af5bb2a0afc819fad298272e9f40c1b9
+checksum=28b1b3d099037a088f0a4ca251d7e7262eab5ea1677aabffa6c4426961ad75e1
 nocross=yes
 nopie=yes
 
@@ -33,7 +33,8 @@ build_options="jpeg tiff gif png xpm svg xml imagemagick gnutls sound m17n dbus 
 desc_option_xpm="Enable support for XPM images"
 desc_option_sound="Enable support for sound"
 desc_option_m17n="Enable support for m17n multilingual text processing"
-build_options_default="jpeg tiff gif png xpm svg xml gnutls sound m17n json gmp"
+build_options_default="cairo gif gmp gnutls harfbuzz jpeg json m17n png sound
+ svg tiff xml xpm"
 
 pre_configure() {
 	# Just configuring in different directories results in


### PR DESCRIPTION
Enable cairo and harfbuzz by default, as recommended by upstream.

Nativecomp can be enabled once libgccjit is packaged, we need to figure out if it can be made optional or we split it into a separate subpackage.

#### Testing the changes
- I tested the changes in this PR: **YES**
