### PR TITLE
Pre commit 2.18.1

### DIFF
--- a/srcpkgs/pre-commit/template
+++ b/srcpkgs/pre-commit/template
@@ -1,6 +1,6 @@
 # Template file for 'pre-commit'
 pkgname=pre-commit
-version=2.17.0
+version=2.18.1
 revision=1
 wrksrc="pre_commit-${version}"
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="Joseph Benden <joe@benden.us>"
 license="MIT"
 homepage="https://pre-commit.com/"
 distfiles="${PYPI_SITE}/p/pre-commit/pre_commit-${version}.tar.gz"
-checksum=c1a8040ff15ad3d648c70cc3e55b93e4d2d5b687320955505587fd79bbaed06a
+checksum=5d445ee1fa8738d506881c5d84f83c62bb5be6b2838e32207433647e8e5ebe10
 make_check=no   # No tests available
 
 post_install() {

--- a/srcpkgs/pre-commit/update
+++ b/srcpkgs/pre-commit/update
@@ -1,0 +1,1 @@
+pattern="pre_commit-\K[0-9.]+(?=.tar.gz)"

--- a/srcpkgs/python3-identify/template
+++ b/srcpkgs/python3-identify/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-identify'
 pkgname=python3-identify
-version=2.4.11
+version=2.4.12
 revision=1
 wrksrc="identify-${version}"
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="Joseph Benden <joe@benden.us>"
 license="MIT"
 homepage="https://github.com/chriskuehl/identify"
 distfiles="${PYPI_SITE}/i/identify/identify-${version}.tar.gz"
-checksum=2986942d3974c8f2e5019a190523b0b0e2a07cb8e89bf236727fb4b26f27f8fd
+checksum=3f3244a559290e7d3deb9e9adc7b33594c1bc85a9dd82e0f1be519bf12a1ec17
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64`-`glibc`)

#### Notes

- This includes an update for `python3-identify` to version 2.4.12.
- Includes script to fix version update checking for `pre-commit`.