### PR TITLE
various: Reset default mirror to repo.voidlinux.org

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,4 @@
-<!-- Don't request update of package. We have a script for that. https://alpha.de.repo.voidlinux.org/void-updates/void-updates.txt. However, a quality pull request may help. -->
+<!-- Don't request update of package. We have a script for that. https://repo-default.voidlinux.org/void-updates/void-updates.txt. However, a quality pull request may help. -->
 ### System
 
 * xuname:  

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ xbps-src can be used in any recent Linux distribution matching the CPU architect
 
 To use xbps-src in your Linux distribution use the following instructions. Let's start downloading the xbps static binaries:
 
-    $ wget http://alpha.de.repo.voidlinux.org/static/xbps-static-latest.<arch>-musl.tar.xz
+    $ wget http://repo-default.voidlinux.org/static/xbps-static-latest.<arch>-musl.tar.xz
     $ mkdir ~/XBPS
     $ tar xvf xbps-static-latest.<arch>-musl.tar.xz -C ~/XBPS
     $ export PATH=~/XBPS/usr/bin:$PATH

--- a/common/travis/fetch-xbps.sh
+++ b/common/travis/fetch-xbps.sh
@@ -7,7 +7,7 @@ TAR=tar
 command -v bsdtar >/dev/null && TAR=bsdtar
 ARCH=$(uname -m)-musl
 VERSION=0.59_5
-URL="https://alpha.de.repo.voidlinux.org/static/xbps-static-static-${VERSION}.${ARCH}.tar.xz"
+URL="https://repo-default.voidlinux.org/static/xbps-static-static-${VERSION}.${ARCH}.tar.xz"
 FILE=${URL##*/}
 
 mkdir -p /tmp/bin

--- a/common/travis/set_mirror.sh
+++ b/common/travis/set_mirror.sh
@@ -1,15 +1,8 @@
 #!/bin/sh
 
-TRAVIS_PROTO=http
 TRAVIS_MIRROR=repo-us.voidlinux.org
 
 for _i in etc/xbps.d/repos-remote*.conf ; do
     /bin/echo -e "\x1b[32mUpdating $_i...\x1b[0m"
-    # First fix the proto, ideally we'd serve everything with HTTPS,
-    # but key management and rotation is a pain, and things are signed
-    # so we can afford to be a little lazy at times.
-    sed -i "s:https:$TRAVIS_PROTO:g" $_i
-
-    # Now set the mirror
-    sed -i "s:alpha\.de\.repo\.voidlinux\.org:$TRAVIS_MIRROR:g" $_i
+    sed -i "s:repo\.voidlinux\.org:$TRAVIS_MIRROR:g" $_i
 done

--- a/etc/xbps.d/repos-remote-aarch64-musl.conf
+++ b/etc/xbps.d/repos-remote-aarch64-musl.conf
@@ -1,4 +1,4 @@
 # aarch64 voidlinux remote repositories
-repository=https://alpha.de.repo.voidlinux.org/current/aarch64
-repository=https://alpha.de.repo.voidlinux.org/current/aarch64/nonfree
-repository=https://alpha.de.repo.voidlinux.org/current/aarch64/debug
+repository=https://repo-default.voidlinux.org/current/aarch64
+repository=https://repo-default.voidlinux.org/current/aarch64/nonfree
+repository=https://repo-default.voidlinux.org/current/aarch64/debug

--- a/etc/xbps.d/repos-remote-aarch64.conf
+++ b/etc/xbps.d/repos-remote-aarch64.conf
@@ -1,4 +1,4 @@
 # aarch64 voidlinux remote repositories
-repository=https://alpha.de.repo.voidlinux.org/current/aarch64
-repository=https://alpha.de.repo.voidlinux.org/current/aarch64/nonfree
-repository=https://alpha.de.repo.voidlinux.org/current/aarch64/debug
+repository=https://repo-default.voidlinux.org/current/aarch64
+repository=https://repo-default.voidlinux.org/current/aarch64/nonfree
+repository=https://repo-default.voidlinux.org/current/aarch64/debug

--- a/etc/xbps.d/repos-remote-musl.conf
+++ b/etc/xbps.d/repos-remote-musl.conf
@@ -1,4 +1,4 @@
 # voidlinux remote repositories (musl)
-repository=https://alpha.de.repo.voidlinux.org/current/musl
-repository=https://alpha.de.repo.voidlinux.org/current/musl/nonfree
-repository=https://alpha.de.repo.voidlinux.org/current/musl/debug
+repository=https://repo-default.voidlinux.org/current/musl
+repository=https://repo-default.voidlinux.org/current/musl/nonfree
+repository=https://repo-default.voidlinux.org/current/musl/debug

--- a/etc/xbps.d/repos-remote-x86_64-multilib.conf
+++ b/etc/xbps.d/repos-remote-x86_64-multilib.conf
@@ -1,3 +1,3 @@
 # voidlinux remote repositories (x86_64/glibc)
-repository=https://alpha.de.repo.voidlinux.org/current/multilib
-repository=https://alpha.de.repo.voidlinux.org/current/multilib/nonfree
+repository=https://repo-default.voidlinux.org/current/multilib
+repository=https://repo-default.voidlinux.org/current/multilib/nonfree

--- a/etc/xbps.d/repos-remote.conf
+++ b/etc/xbps.d/repos-remote.conf
@@ -1,4 +1,4 @@
 # voidlinux remote repositories (glibc)
-repository=https://alpha.de.repo.voidlinux.org/current
-repository=https://alpha.de.repo.voidlinux.org/current/nonfree
-repository=https://alpha.de.repo.voidlinux.org/current/debug
+repository=https://repo-default.voidlinux.org/current
+repository=https://repo-default.voidlinux.org/current/nonfree
+repository=https://repo-default.voidlinux.org/current/debug

--- a/srcpkgs/9base/template
+++ b/srcpkgs/9base/template
@@ -13,7 +13,7 @@ license="custom:Plan9"
 homepage="http://git.suckless.org/9base"
 # Checked out from http://git.suckless.org/9base/ and created tarball with
 # git archive -o 9base-${_githash}.tar.gz --prefix=9base/ master .
-distfiles="https://alpha.de.repo.voidlinux.org/distfiles/9base-${_githash}.tar.gz"
+distfiles="https://repo-default.voidlinux.org/distfiles/9base-${_githash}.tar.gz"
 checksum=b315509470c25db88595bd0e9478428dea54d7836fe2ba9d07279ae9496366fb
 conflicts="plan9port"
 provides="plan9port-20160418_4"

--- a/srcpkgs/cargo-bootstrap/template
+++ b/srcpkgs/cargo-bootstrap/template
@@ -19,7 +19,7 @@ _bootver=1.57.0
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686|ppc64le) ;;
 	*)
-		_bootstrap_url="https://alpha.de.repo.voidlinux.org/distfiles"
+		_bootstrap_url="https://repo-default.voidlinux.org/distfiles"
 		_bootver=${version}
 		;;
 esac

--- a/srcpkgs/fastttyrec/template
+++ b/srcpkgs/fastttyrec/template
@@ -7,7 +7,7 @@ short_desc="Compress ttyrec recordings"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://web.archive.org/web/20170709180030/http://www.phong.org/nethack/"
-distfiles="https://alpha.de.repo.voidlinux.org/distfiles/${pkgname}-${version}.tar.bz2"
+distfiles="https://repo-default.voidlinux.org/distfiles/${pkgname}-${version}.tar.bz2"
 checksum=a366562d3a38220779f2da2d4d6ec4c868ab17d6530b9a37c4eb12499e1e911a
 
 do_install() {

--- a/srcpkgs/ghc-bin/template
+++ b/srcpkgs/ghc-bin/template
@@ -21,7 +21,7 @@ x86_64)
 	;;
 x86_64-musl)
 	# create with "make binary-dist"
-	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-x86_64-void-linux-musl.tar.xz"
+	distfiles="https://repo-default.voidlinux.org/distfiles/ghc-${version}-x86_64-void-linux-musl.tar.xz"
 	checksum=e21eaddeffcd5de7abe43b1f3982a3bc2c5b5f408d2574857cb2b0368106e12c
 	;;
 i686)
@@ -29,24 +29,24 @@ i686)
 	checksum=fdeb9f8928fbe994064778a8e1e85bb1a58a6cd3dd7b724fcc2a1dcfda6cad47
 	;;
 ppc64le)
-	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux.tar.xz"
+	distfiles="https://repo-default.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux.tar.xz"
 	checksum=7de8114c991f9a2a3b0f5e472da76e3956be6447efec4b1157f14e707049f22d
 	;;
 ppc64le-musl)
-	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux-musl.tar.xz"
+	distfiles="https://repo-default.voidlinux.org/distfiles/ghc-${version}-powerpc64le-void-linux-musl.tar.xz"
 	checksum=37de8e069712307c9b2039e92f56e540e80ca1390dd27aa247ebe18c40e0c629
 	;;
 ppc64)
-	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-powerpc64-void-linux.tar.xz"
+	distfiles="https://repo-default.voidlinux.org/distfiles/ghc-${version}-powerpc64-void-linux.tar.xz"
 	checksum=6eb8684fdbede0cded7e3f7b93574b968f5f66dd2fcd4ec30ac5f0c402af6602
 	;;
 aarch64)
-	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux.tar.xz"
+	distfiles="https://repo-default.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux.tar.xz"
 	checksum=44a20a896246dce64392b7d0feedd0a28a9d733245a803e95dbe4b4b7e15b4fd
 	depends+=" llvm"
 	;;
 aarch64-musl)
-	distfiles="https://alpha.de.repo.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux-musl.tar.xz"
+	distfiles="https://repo-default.voidlinux.org/distfiles/ghc-${version}-aarch64-void-linux-musl.tar.xz"
 	checksum=de98e2ff33a25cb32a28c738066fecacb736a33cac12688876eec4eb96d88607
 	depends+=" llvm"
 	;;

--- a/srcpkgs/libfetch/template
+++ b/srcpkgs/libfetch/template
@@ -8,7 +8,7 @@ short_desc="File Transfer Library for URLs"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://www.NetBSD.org"
-distfiles="https://alpha.de.repo.voidlinux.org/distfiles/libfetch-${version}.tar.xz"
+distfiles="https://repo-default.voidlinux.org/distfiles/libfetch-${version}.tar.xz"
 checksum=4e6d4541f213c9ab42ea94d49c2573f0a6f54b04f14668530960f1424b04f722
 
 do_build() {

--- a/srcpkgs/lxc/files/lxc-void
+++ b/srcpkgs/lxc/files/lxc-void
@@ -154,7 +154,7 @@ EOF
     rm -f ${vkb64}
 
     mkdir -p ${rootfs}/usr/share/xbps.d
-    echo "repository=http://alpha.de.repo.voidlinux.org/current" > ${rootfs}/usr/share/xbps.d/00-repository-main.conf
+    echo "repository=http://repo-default.voidlinux.org/current" > ${rootfs}/usr/share/xbps.d/00-repository-main.conf
 
     if ! xbps-install ${xbps_cachedir:+ -c $xbps_cachedir} \
 	    ${xbps_config:+-C $xbps_config} -r "${rootfs}" \
@@ -232,7 +232,7 @@ fi
 
 type xbps-install >/dev/null 2>&1
 if [ ${?} -ne 0 ]; then
-    echo "'xbps-install' command is missing, download xbps from http://alpha.de.repo.voidlinux.org/static/"
+    echo "'xbps-install' command is missing, download xbps from http://repo-default.voidlinux.org/static/"
     exit 1
 fi
 

--- a/srcpkgs/rtmpdump/template
+++ b/srcpkgs/rtmpdump/template
@@ -9,7 +9,7 @@ short_desc="Toolkit for RTMP streams"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://rtmpdump.mplayerhq.hu/"
-distfiles="https://alpha.de.repo.voidlinux.org/distfiles/${pkgname}-${version%.*}_p${_patchlevel}.tar.gz"
+distfiles="https://repo-default.voidlinux.org/distfiles/${pkgname}-${version%.*}_p${_patchlevel}.tar.gz"
 checksum=d6da3b683f1045f02d94a81b0c583318dba021f69bdab970c5d5d73e8c38860f
 
 CFLAGS="-Wno-unused-const-variable -Wno-unused-but-set-variable"

--- a/srcpkgs/rust-bootstrap/template
+++ b/srcpkgs/rust-bootstrap/template
@@ -19,7 +19,7 @@ _bootstrap_url="https://static.rust-lang.org/dist"
 
 case "$XBPS_MACHINE" in
 	x86_64*|i686|ppc64le|ppc) ;;
-	*) _bootstrap_url="https://alpha.de.repo.voidlinux.org/distfiles";;
+	*) _bootstrap_url="https://repo-default.voidlinux.org/distfiles";;
 esac
 
 distfiles="

--- a/srcpkgs/rust/template
+++ b/srcpkgs/rust/template
@@ -5,7 +5,7 @@
 # See: https://github.com/rust-lang/core-team/issues/4
 #
 # Always make sure custom distfiles used for bootstrap are
-# uploaded to https://alpha.de.repo.voidlinux.org/distfiles/
+# uploaded to https://repo-default.voidlinux.org/distfiles/
 #
 pkgname=rust
 version=1.57.0

--- a/srcpkgs/void-repo-multilib/template
+++ b/srcpkgs/void-repo-multilib/template
@@ -1,7 +1,7 @@
 # Template file for 'void-repo-multilib'
 pkgname=void-repo-multilib
 version=6
-revision=3
+revision=4
 build_style=meta
 archs="x86_64"
 short_desc="Void Linux drop-in file for the multilib repository"
@@ -12,7 +12,7 @@ homepage="http://www.voidlinux.org"
 do_install() {
 	vmkdir usr/share/xbps.d
 	for f in multilib multilib-nonfree; do
-		echo "repository=https://alpha.de.repo.voidlinux.org/current/${f/-/\/}" > \
+		echo "repository=https://repo-default.voidlinux.org/current/${f/-/\/}" > \
 			${DESTDIR}/usr/share/xbps.d/10-repository-${f}.conf
 	done
 }

--- a/srcpkgs/void-repo-nonfree/template
+++ b/srcpkgs/void-repo-nonfree/template
@@ -1,7 +1,7 @@
 # Template file for 'void-repo-nonfree'
 pkgname=void-repo-nonfree
 version=9
-revision=5
+revision=6
 build_style=meta
 short_desc="Void Linux drop-in file for the nonfree repository"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -12,21 +12,21 @@ do_install() {
 	vmkdir usr/share/xbps.d
 	case "$XBPS_TARGET_MACHINE" in
 		aarch64*)
-			echo "repository=https://alpha.de.repo.voidlinux.org/current/aarch64/nonfree" > \
+			echo "repository=https://repo-default.voidlinux.org/current/aarch64/nonfree" > \
 				${DESTDIR}/usr/share/xbps.d/10-repository-nonfree.conf
-			echo "repository=https://alpha.de.repo.voidlinux.org/current/aarch64/debug" > \
+			echo "repository=https://repo-default.voidlinux.org/current/aarch64/debug" > \
 				${DESTDIR}/usr/share/xbps.d/20-repository-debug.conf
 			;;
 		*-musl)
-			echo "repository=https://alpha.de.repo.voidlinux.org/current/musl/nonfree" > \
+			echo "repository=https://repo-default.voidlinux.org/current/musl/nonfree" > \
 				${DESTDIR}/usr/share/xbps.d/10-repository-nonfree.conf
-			echo "repository=https://alpha.de.repo.voidlinux.org/current/musl/debug" > \
+			echo "repository=https://repo-default.voidlinux.org/current/musl/debug" > \
 				${DESTDIR}/usr/share/xbps.d/20-repository-debug.conf
 			;;
 		*)
-			echo "repository=https://alpha.de.repo.voidlinux.org/current/nonfree" > \
+			echo "repository=https://repo-default.voidlinux.org/current/nonfree" > \
 				${DESTDIR}/usr/share/xbps.d/10-repository-nonfree.conf
-			echo "repository=https://alpha.de.repo.voidlinux.org/current/debug" > \
+			echo "repository=https://repo-default.voidlinux.org/current/debug" > \
 				${DESTDIR}/usr/share/xbps.d/20-repository-debug.conf
 			;;
 	esac

--- a/srcpkgs/xbps/template
+++ b/srcpkgs/xbps/template
@@ -1,7 +1,7 @@
 # Template file for 'xbps'
 pkgname=xbps
 version=0.59.1
-revision=5
+revision=6
 bootstrap=yes
 build_style=configure
 short_desc="XBPS package system utilities"
@@ -35,7 +35,7 @@ do_configure() {
 }
 
 post_install() {
-	local repo="https://alpha.de.repo.voidlinux.org/current" suffix=
+	local repo="https://repo-default.voidlinux.org/current" suffix=
 	case "$XBPS_TARGET_MACHINE" in
 		aarch64*)     suffix="/aarch64";;
 		*-musl)       suffix="/musl";;


### PR DESCRIPTION
I'd like to retire the alpha.de.repo.voidlinux.org name.  The first step of this is removing it from documentation and active automated use.