### PR TITLE
{gnome-settings-daemon,mkchromecast,pasystray}: remove pulseaudio dependency

### DIFF
--- a/srcpkgs/gnome-settings-daemon/template
+++ b/srcpkgs/gnome-settings-daemon/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-settings-daemon'
 pkgname=gnome-settings-daemon
 version=41.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dsystemd=false"
 hostmakedepends="cmake docbook-xsl gettext glib-devel libglib-devel libxslt
@@ -11,7 +11,7 @@ makedepends="NetworkManager-devel alsa-lib-devel colord-devel cups-devel gcr-dev
  libgweather-devel libnotify-devel librsvg-devel libwacom-devel nss-devel
  polkit-devel pulseaudio-devel startup-notification-devel upower-devel
  xf86-input-wacom-devel libXfixes-devel"
-depends="hicolor-icon-theme pulseaudio"
+depends="hicolor-icon-theme"
 checkdepends="elogind libnotify python3-dbusmock python3-gobject
  python3-pycodestyle which hwids eudev"
 short_desc="GNOME settings daemon"

--- a/srcpkgs/mkchromecast/template
+++ b/srcpkgs/mkchromecast/template
@@ -1,11 +1,11 @@
 # Template file for 'mkchromecast'
 pkgname=mkchromecast
 version=0.3.8.1
-revision=4
+revision=5
 pycompile_dirs="/usr/share/mkchromecast/mkchromecast"
 depends="python3-Flask python3-netifaces python3-setuptools python3-requests
  python3-mutagen python3-psutil python3-PyQt5 python3-SoCo python3-chromecast
- python3-gobject pulseaudio python3-youtube-dl ffmpeg"
+ python3-gobject python3-youtube-dl ffmpeg"
 short_desc="Cast Linux Audio/Video to Google cast and Sonos devices"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"

--- a/srcpkgs/pasystray/template
+++ b/srcpkgs/pasystray/template
@@ -1,12 +1,11 @@
 # Template file for 'pasystray'
 pkgname=pasystray
 version=0.7.1
-revision=1
+revision=2
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=gnu-configure
 hostmakedepends="pkg-config intltool automake"
 makedepends="gtk+3-devel pulseaudio-devel libnotify-devel"
-depends="pulseaudio"
 short_desc="PulseAudio System Tray"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

`pipewire-pulse` can be used instead of `pulseaudio`, so there is no need for these packages to depend on `pulseaudio`. This may break sound for people who run something like `xbps-remove -oy` every time, but that's their mistake. This is especially useful in the case of gnome-settings-daemon because this currently makes gnome depend on pulseaudio and it has to be explicitly disabled or people have to use `ignorepkg` and uninstall it.