### PR TITLE
Signal-Desktop: update to 5.38.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=5.37.0
+version=5.38.0
 revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # discontinued Electron 32-bit support: https://www.electronjs.org/blog/linux-32bit-support
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=bd674ea6ba0582862f26a8fed1557d21f68161ef05891e67ca4cb653bf0f8d1a
+checksum=da693cf3fd7535f8569bbdc6f64387e274daab49c2798cacc804c784e401115d
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**
