### PR TITLE
mobile-broadband-provider-info: update to 20220511.

### DIFF
--- a/srcpkgs/mobile-broadband-provider-info/template
+++ b/srcpkgs/mobile-broadband-provider-info/template
@@ -1,6 +1,6 @@
 # Template file for 'mobile-broadband-provider-info'
 pkgname=mobile-broadband-provider-info
-version=20201225
+version=20220511
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libxslt"
@@ -10,7 +10,7 @@ maintainer="Ulf <void@uw.anonaddy.com>"
 license="custom:Creative Commons Public Domain"
 homepage="https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info/"
 distfiles="https://gitlab.gnome.org/GNOME/mobile-broadband-provider-info/-/archive/${version}/mobile-broadband-provider-info-${version}.tar.bz2"
-checksum=0616b3d0580575741d4319ac71ca67c9a378879943d32a67ac0460615767bcdf
+checksum=1ccbf314cac06048fd8c57ffad28c4e4273cc096e4eb8fca9beb38280428450f
 
 pre_configure() {
 	autoreconf -fi


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**