### PR TITLE
Jupyter notebook updates

### DIFF
--- a/srcpkgs/python3-Jinja2/template
+++ b/srcpkgs/python3-Jinja2/template
@@ -1,7 +1,6 @@
 # Template file for 'python3-Jinja2'
 pkgname=python3-Jinja2
-reverts="3.1.1_1"
-version=3.0.3
+version=3.1.1
 revision=2
 wrksrc="Jinja2-${version}"
 build_style=python3-module
@@ -14,7 +13,7 @@ license="BSD-3-Clause"
 homepage="http://jinja.pocoo.org/"
 changelog="https://raw.githubusercontent.com/pallets/jinja/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/J/Jinja2/Jinja2-${version}.tar.gz"
-checksum=611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
+checksum=640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9
 
 post_install() {
 	vlicense LICENSE.rst

--- a/srcpkgs/python3-fastjsonschema/template
+++ b/srcpkgs/python3-fastjsonschema/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-fastjsonschema'
+pkgname=python3-fastjsonschema
+version=2.15.3
+revision=1
+wrksrc=python-fastjsonschema-${version}
+build_style=python3-module
+make_check_args="--deselect tests/benchmarks/test_benchmark.py"
+hostmakedepends="python3-setuptools"
+checkdepends="python3-pytest"
+short_desc="Fastest Python implementation of JSON schema"
+maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
+license="BSD-3-Clause"
+homepage="https://github.com/seznam/python-fastjsonschema"
+changelog="https://raw.githubusercontent.com/horejsek/python-fastjsonschema/master/CHANGELOG.txt"
+distfiles="https://github.com/horejsek/python-fastjsonschema/archive/refs/tags/v${version}.tar.gz"
+checksum=94e59a36c0efbf75a1a790fed15b51c9876b81204a5184c0c89075c68b10e7ec
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/python3-jupyter_nbconvert/template
+++ b/srcpkgs/python3-jupyter_nbconvert/template
@@ -1,13 +1,16 @@
 # Template file for 'python3-jupyter_nbconvert'
 pkgname=python3-jupyter_nbconvert
-version=6.0.7
-revision=2
+version=6.4.5
+revision=1
 wrksrc="nbconvert-${version}"
 build_style=python3-module
+# WebPDF export depends on unpackaged pyppeteer
+make_check_args="-m not(network) -k not(test_webpdf_without_chromium)"
 hostmakedepends="python3-setuptools"
 depends="python3-mistune python3-Jinja2 python3-jupyterlab_pygments
  python3-nbclient python3-jupyter_core python3-entrypoints python3-testpath
- python3-bleach python3-pandocfilters python3-defusedxml"
+ python3-bleach python3-pandocfilters python3-defusedxml
+ python3-BeautifulSoup4"
 checkdepends="python3-pytest python3-ipython_ipykernel
  python3-jupyter_ipywidgets python3-Pebble pandoc inkscape $depends"
 short_desc="Converting Jupyter notebooks"
@@ -15,13 +18,8 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/jupyter/nbconvert"
 distfiles="${PYPI_SITE}/n/nbconvert/nbconvert-${version}.tar.gz"
-checksum=cbbc13a86dfbd4d1b5dee106539de0795b4db156c894c2c5dc382062bbc29002
+checksum=21163a8e2073c07109ca8f398836e45efdba2aacea68d6f75a8a545fef070d4e
 conflicts="python-jupyter_nbconvert<=5.4.1_2"
-
-do_check() {
-	# WebPDF export depends on unpackaged pyppeteer
-	python3 -m pytest -k 'not TestWebPDFExporter and not test_webpdf_with_chromium'
-}
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-jupyter_nbformat/template
+++ b/srcpkgs/python3-jupyter_nbformat/template
@@ -1,25 +1,21 @@
 # Template file for 'python3-jupyter_nbformat'
 pkgname=python3-jupyter_nbformat
-version=5.1.3
-revision=2
+version=5.3.0
+revision=1
 wrksrc="nbformat-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-jsonschema python3-traitlets
- python3-ipython_genutils python3-jupyter_core"
+ python3-ipython_genutils python3-jupyter_core
+ python3-fastjsonschema"
 checkdepends="python3-pytest python3-testpath $depends"
 short_desc="Jupyter notebook format"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/jupyter/nbformat"
 distfiles="${PYPI_SITE}/n/nbformat/nbformat-${version}.tar.gz"
-checksum=b516788ad70771c6250977c1374fcca6edebe6126fd2adb5a69aa5c2356fd1c8
+checksum=fcc5ab8cb74e20b19570b5be809e2dba9b82836fd2761a89066ad43394ba29f5
 conflicts="python-jupyter_nbformat<=4.4.0_3"
-
-do_check() {
-	# Tests require a non-existent notebook file
-	python3 -m pytest -k 'not test_upgrade_v4_to_4_dot_5 and not test_sample_notebook'
-}
 
 post_install() {
 	vlicense COPYING.md LICENSE

--- a/srcpkgs/python3-jupyter_notebook/template
+++ b/srcpkgs/python3-jupyter_notebook/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-jupyter_notebook'
 pkgname=python3-jupyter_notebook
-version=6.3.0
-revision=2
+version=6.4.10
+revision=1
 wrksrc="notebook-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -15,7 +15,7 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
 homepage="https://jupyter.org/"
 distfiles="${PYPI_SITE}/n/notebook/notebook-${version}.tar.gz"
-checksum=cbc9398d6c81473e9cdb891d2cae9c0d3718fca289dda6d26df5cb660fcadc7d
+checksum=2408a76bc6289283a8eecfca67e298ec83c67db51a4c2e1b713dd180bb39e90e
 conflicts="python-jupyter_notebook<=5.7.0_2"
 # Tests require unpackaged selenium
 make_check=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Updates:
 - python3-jupyter_notebook: to 6.4.10.
 - python3-jupyter_nbconvert: to 6.4.5.
 - python3-jupyter_nbformat: to 5.3.0.

The new package python3-fastjsonschema is needed for nbformat.

This also restores the update of Jinja2 to 3.1.1 which was reverted because of incompatibility with nbconvert-6.0.7 (see 3d6eb58)

NOTES:
 - For fastjsonschema I used the tarball from github, instead of pypi, because the latter doesn't include the testsuite.
 - For nbconvert I had to add a PYTHONPATH setting to `do_check()` because the "old" nbconvert will be installed at check-time (circular dependency?) and without this the testsuite will be testing the old nbconvert (which fails!).

What should we do about maintainership? @dkwo I think you use jupyter much more than I do (I'm more of a CLI type) do you want to take over? Otherwise I can do it.

@ahesford 
@dkwo 