### PR TITLE
img2pdf: update to 0.4.4.

### DIFF
--- a/srcpkgs/img2pdf/template
+++ b/srcpkgs/img2pdf/template
@@ -1,6 +1,6 @@
 # Template file for 'img2pdf'
 pkgname=img2pdf
-version=0.4.3
+version=0.4.4
 revision=1
 build_style=python3-module
 hostmakedepends="python3-pikepdf python3-setuptools"
@@ -10,5 +10,5 @@ maintainer="Philipp David <pd@3b.pm>"
 license="GPL-3.0-or-later"
 homepage="https://gitlab.mister-muffin.de/josch/img2pdf"
 distfiles="${PYPI_SITE}/i/img2pdf/img2pdf-${version}.tar.gz"
-checksum=8e51c5043efa95d751481b516071a006f87c2a4059961a9ac43ec238915de09f
+checksum=8ec898a9646523fd3862b154f3f47cd52609c24cc3e2dc1fb5f0168f0cbe793c
 make_check=no # need to patch out some bitdepth checks


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I enabled tests again and patched the remaining failing ones.

EDIT:
Oh well, scratch that about the tests. They still fail on anything but x86_64.