### PR TITLE
kernel-libc-headers: update to 5.15.33

### DIFF
--- a/srcpkgs/kernel-libc-headers/patches/1-4-glibc-specific-inclusion-of-sysinfo.h-in-kernel.h.patch
+++ b/srcpkgs/kernel-libc-headers/patches/1-4-glibc-specific-inclusion-of-sysinfo.h-in-kernel.h.patch
@@ -1,12 +1,12 @@
 --- a/include/uapi/linux/kernel.h
 +++ b/include/uapi/linux/kernel.h
-@@ -1,7 +1,9 @@
+@@ -2,7 +2,9 @@
  #ifndef _UAPI_LINUX_KERNEL_H
  #define _UAPI_LINUX_KERNEL_H
  
 +#ifdef __GLIBC__
  #include <linux/sysinfo.h>
 +#endif
+ #include <linux/const.h>
  
- /*
-  * 'kernel.h' contains some often-used function prototypes etc
+ #endif /* _UAPI_LINUX_KERNEL_H */

--- a/srcpkgs/kernel-libc-headers/template
+++ b/srcpkgs/kernel-libc-headers/template
@@ -1,6 +1,6 @@
 # Template file for 'kernel-libc-headers'
 pkgname=kernel-libc-headers
-version=5.10.4
+version=5.15.33
 revision=1
 bootstrap=yes
 wrksrc=linux-${version}
@@ -9,7 +9,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-only"
 homepage="http://www.kernel.org"
 distfiles="$KERNEL_SITE/kernel/v${version%%.*}.x/linux-${version}.tar.xz"
-checksum=904e396c26e9992a16cd1cc989460171536bed7739bf36049f6eb020ee5d56ec
+checksum=c30a17e6090f9ebf2d8ff58cd6c92c7324b1f4a8b3aa6a7f68850310af05a9c4
 
 if [ "$CHROOT_READY" ]; then
 	hostmakedepends="perl"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuilds)
