### PR TITLE
ndhc: update to 20220308.

### DIFF
--- a/srcpkgs/ndhc/template
+++ b/srcpkgs/ndhc/template
@@ -1,20 +1,22 @@
 # Template file for 'ndhc'
 pkgname=ndhc
-version=20201020
+version=20220308
 revision=1
-_dashversion=2020-10-20
-build_style=cmake
-make_dirs="/var/lib/ndhc/state 0755 root root
+_dashversion="${version:0:4}-${version:4:2}-${version:6:2}"
+wrksrc="ndhc-${_dashversion}"
+build_style=gnu-makefile
+make_dirs="
+ /var/lib/ndhc/state 0755 root root
  /var/lib/ndhc/jail/dev 0755 root root"
-hostmakedepends="ragel"
 makedepends="libcap-devel"
 short_desc="Privilege-seperated secure DHCPv4 client"
-maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="BSD-2-Clause"
+maintainer="Duncaen <duncaen@voidlinux.org>"
+license="MIT"
 homepage="https://github.com/niklata/ndhc"
 distfiles="https://github.com/niklata/ndhc/archive/v${_dashversion}.tar.gz"
-checksum=ca5a37afc3f30c9fd110e97339a10b3c8ed08ae6cad388cec6bdd7f3bb146da0
-wrksrc="ndhc-${_dashversion}"
+checksum=30f595b7c1cc2e60599b8c6aa82e0b1ee4ef2243a67fcebf812b60746db7de4d
+
+export CFLAGS="-std=gnu99 -D_GNU_SOURCE -DNK_USE_CAPABILITY"
 
 # XXX we use only one account for privsep, not three, because they
 # should have the same primary group.  to be verified.
@@ -27,8 +29,8 @@ if [ "$build_option_static" ]; then
 fi
 
 do_install() {
-	vbin build/ndhc
-	vman src/ndhc.8
+	vbin ndhc
+	vman ndhc.8
 	vsv ndhc
 	vlicense LICENSE
 }


### PR DESCRIPTION

- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] armv7l
  - [x] armv6l-musl