### PR TITLE
curl: restore libcurl-gnutls symlink from libcurl.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -366,6 +366,7 @@ libnssdbm3.so nss-3.12.4_1
 libnssckbi.so nss-3.12.4_1
 libnss3.so nss-3.12.4_1
 libcurl.so.4 libcurl-7.75.0_2
+libcurl-gnutls.so.4 libcurl-7.75.0_2
 libdaemon.so.0 libdaemon-0.14_1
 libavahi-common.so.3 avahi-libs-0.6.25_1
 libavahi-core.so.7 avahi-libs-0.6.25_1

--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,7 +1,7 @@
 # Template file for 'curl'
 pkgname=curl
 version=7.82.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
  $(vopt_with rtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnutls)
@@ -66,8 +66,10 @@ post_install() {
 
 libcurl_package() {
 	short_desc="Multiprotocol file transfer library"
+	shlib_provides="libcurl-gnutls.so.4"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
+		ln -sf libcurl.so.4 ${PKGDESTDIR}/usr/lib/libcurl-gnutls.so.4
 	}
 }
 


### PR DESCRIPTION
Without this, many proprietary audio plugins aren't functional.
Removed in https://github.com/void-linux/void-packages/pull/25764