### PR TITLE
python3: enable bluetooth sockets

### DIFF
--- a/srcpkgs/bluez/patches/0010-dont-require-rst2man.patch
+++ b/srcpkgs/bluez/patches/0010-dont-require-rst2man.patch
@@ -1,0 +1,32 @@
+--- a/configure.ac	2022-03-16 12:06:20.000000000 -0300
++++ b/configure.ac	2022-04-11 09:27:53.726166927 -0300
+@@ -335,9 +335,6 @@
+ 					[enable_manpages=${enableval}])
+ if (test "${enable_manpages}" != "no"); then
+ 	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], "no")
+-	if (test "${RST2MAN}" = "no" ); then
+-		AC_MSG_ERROR([rst2man is required])
+-	fi
+ fi
+ AM_CONDITIONAL(MANPAGES, test "${enable_manpages}" != "no")
+ AM_CONDITIONAL(RUN_RST2MAN, test "${enable_manpages}" != "no" &&
+--- a/src/bluetoothd.8	2022-03-16 12:17:56.000000000 -0300
++++ b/src/bluetoothd.8	2022-04-11 17:11:10.093067361 -0300
+@@ -56,7 +56,7 @@
+ .TP
+ .B \-f\fP,\fB  \-\-configfile
+ Specifies an explicit config file path instead of relying
+-on the default path(\fI/usr/local/etc/bluetooth/main.conf\fP)
++on the default path(\fI/etc/bluetooth/main.conf\fP)
+ for the config file.
+ .UNINDENT
+ .INDENT 0.0
+@@ -90,7 +90,7 @@
+ .SH FILES
+ .INDENT 0.0
+ .TP
+-.B \fI/usr/local/etc/bluetooth/main.conf\fP
++.B \fI/etc/bluetooth/main.conf\fP
+ Location of the global configuration file.
+ .UNINDENT
+ .SH RESOURCES

--- a/srcpkgs/bluez/template
+++ b/srcpkgs/bluez/template
@@ -7,7 +7,7 @@ configure_args="--with-udevdir=/usr/lib/udev --disable-systemd
  --enable-sixaxis --enable-threads --enable-library --enable-deprecated
  --enable-external-ell $(vopt_enable mesh) $(vopt_enable nfc)
  $(vopt_enable experimental)"
-hostmakedepends="automake flex libtool pkg-config python3-docutils"
+hostmakedepends="automake flex libtool pkg-config $(vopt_if mesh python3-docutils)"
 makedepends="cups-devel eudev-libudev-devel libglib-devel libical-devel
  readline-devel ell-devel $(vopt_if mesh json-c-devel)"
 short_desc="Bluetooth tools and daemons"

--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -4,7 +4,7 @@
 #
 pkgname=python3
 version=3.10.4
-revision=1
+revision=2
 wrksrc="Python-${version}"
 build_style="gnu-configure"
 configure_args="--enable-shared --enable-ipv6
@@ -14,7 +14,8 @@ configure_args="--enable-shared --enable-ipv6
 pycompile_dirs="usr/lib/python${version%.*}"
 hostmakedepends="pkgconf"
 makedepends="libffi-devel readline-devel gdbm-devel openssl-devel
- expat-devel sqlite-devel bzip2-devel zlib-devel liblzma-devel"
+ expat-devel sqlite-devel bzip2-devel zlib-devel liblzma-devel
+ libbluetooth-devel"
 depends="ca-certificates"
 checkdepends="$depends iana-etc"
 short_desc="Python programming language (${version%.*} series)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I've been using `python3-bluez` for bluetooth sockets, but this package was removed because it was not compatible with python 3.10 (this has been fixed upstream, but not released yet, see #33626)

TIL that bluetooth sockets are available in python stdlib. However, they need to be enabled. That's what this PR does.

Note, however, that this seems to create a circular build dependency, since `bluez` hostmakedepends on `python3-docutils`for its `rst2man` tool. I don't know if this would cause any trouble, and if so what is the standard solution. The tarball of `bluez`contains prebuilt manpages; although a couple would need to be patched for paths, this ought to be easy (I could do it).

CC: @ahesford