### PR TITLE
threejs-sage: make it available as a jupyter nbextension

### DIFF
--- a/srcpkgs/threejs-sage/template
+++ b/srcpkgs/threejs-sage/template
@@ -1,7 +1,7 @@
 # Template file for 'threejs-sage'
 pkgname=threejs-sage
 version=r122
-revision=1
+revision=2
 short_desc="Custom build of three.js for sagemath"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="MIT"
@@ -13,4 +13,8 @@ do_install() {
 	vlicense LICENSE
 	vinstall version 644 usr/share/sagemath/threejs-sage
 	vinstall build/three.min.js 644 usr/share/sagemath/threejs-sage/$version
+
+	# make threejs available as a jupyter notebook extension
+	vmkdir usr/share/jupyter/nbextensions
+	ln -s /usr/share/sagemath/threejs-sage ${DESTDIR}/usr/share/jupyter/nbextensions
 }


### PR DESCRIPTION
Adds a symlink in /usr/share/jupyter/nbextensions, so that the js is available in a jupyter notebook.

Otherwise, using 3d plots in the jupyter notebook will hit jsdelivr.net.

#### Testing the changes
- I tested the changes in this PR: **YES**