### PR TITLE
wireplumber: export $XDG_STATE_HOME to a persistent location

### DIFF
--- a/srcpkgs/wireplumber/files/wireplumber/run
+++ b/srcpkgs/wireplumber/files/wireplumber/run
@@ -6,5 +6,5 @@ sv check dbus >/dev/null 2>&1 || exit 1
 
 exec 2>&1
 
-export HOME=/var/run/pipewire
+export XDG_STATE_HOME=/var/lib/pipewire
 exec chpst -u _pipewire:_pipewire:audio:video -P dbus-run-session wireplumber

--- a/srcpkgs/wireplumber/template
+++ b/srcpkgs/wireplumber/template
@@ -1,7 +1,7 @@
 # Template file for 'wireplumber'
 pkgname=wireplumber
 version=0.4.9
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dintrospection=enabled -Dsystem-lua=true"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

In #36416 I've exported HOME to `/var/run/pipewire` but that directory gets recreated every reboot, it was able to persist volume and other configurations when the service restarts but not across system reboots.

`wireplumber` stores the state configuration in `${XDG_STATE_HOME:-$HOME/.local/state}/wireplumber`. I recently also found, `pipewire-media-session` (the builtin media router) utilized `/var/lib/pipewire` as well to persist its state across reboot. So this simply changes the export to do the same.