### PR TITLE
dbeaver: force jdk11 regardless of alternatives setting

### DIFF
--- a/srcpkgs/dbeaver/patches/force-jdk11.patch
+++ b/srcpkgs/dbeaver/patches/force-jdk11.patch
@@ -1,0 +1,11 @@
+--- a/product/community/DBeaver.product
++++ b/product/community/DBeaver.product
+@@ -9,7 +9,7 @@
+     </configIni>
+ 
+     <launcherArgs>
+-        <programArgs></programArgs>
++        <programArgs>-vm /usr/lib/jvm/openjdk11/bin</programArgs>
+         <programArgsMac>-vm ../Eclipse/jre/Contents/Home/bin/java</programArgsMac>
+ 
+         <vmArgs>-XX:+IgnoreUnrecognizedVMOptions --add-modules=ALL-SYSTEM -Dosgi.requiredJavaVersion=11 -Xms64m -Xmx1024m</vmArgs>

--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,7 +1,7 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
 version=22.0.1
-revision=1
+revision=2
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
 hostmakedepends="apache-maven"


### PR DESCRIPTION
fixes #34857

based on the fix provided in that issue

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
