### PR TITLE
common/hooks/pre-pkg/04-generate-runtime-deps.sh: sort deps for reproducibility

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -34,15 +34,14 @@ add_rundep() {
 
 store_pkgdestdir_rundeps() {
         if [ -n "$run_depends" ]; then
-            : > ${PKGDESTDIR}/rdeps
             for f in ${run_depends}; do
                 _curdep="$(echo "$f" | sed -e 's,\(.*\)?.*,\1,')"
                 if [ -z "$($XBPS_UHELPER_CMD getpkgdepname ${_curdep} 2>/dev/null)" -a \
                      -z "$($XBPS_UHELPER_CMD getpkgname ${_curdep} 2>/dev/null)" ]; then
                     _curdep="${_curdep}>=0"
                 fi
-                printf -- "${_curdep} " >> ${PKGDESTDIR}/rdeps
-            done
+                printf -- "${_curdep}\n"
+            done | sort | xargs > ${PKGDESTDIR}/rdeps
         fi
 }
 
@@ -145,7 +144,7 @@ hook() {
 
         if [ "${_pkgname}" != "${pkgname}" ]; then
             echo "   SONAME: $f <-> ${_sdep}"
-            sorequires+="${f} "
+            sorequires+="${f}\n"
         else
             # Ignore libs by current pkg
             echo "   SONAME: $f <-> ${_rdep} (ignored)"
@@ -163,9 +162,9 @@ hook() {
     store_pkgdestdir_rundeps
 
     for f in ${shlib_requires}; do
-        sorequires+="${f} "
+        sorequires+="${f}\n"
     done
     if [ -n "${sorequires}" ]; then
-        echo "${sorequires}" > ${PKGDESTDIR}/shlib-requires
+        echo "${sorequires}" | sort | xargs > ${PKGDESTDIR}/shlib-requires
     fi
 }


### PR DESCRIPTION
fixes #36641

by "reproducibility", I mean mostly for tools that compare versions/builds of packages.

The solution I have implemented is basically:

1. transform the space-separated list to newline-separated
2. sort
3. transform back to space-separated

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
