### PR TITLE
New package: ki-shell-0.4.5

### DIFF
--- a/srcpkgs/ki-shell/template
+++ b/srcpkgs/ki-shell/template
@@ -1,0 +1,22 @@
+# Template file for 'ki-shell'
+pkgname=ki-shell
+version=0.4.5
+revision=1
+wrksrc="kotlin-interactive-shell-${version}"
+hostmakedepends="openjdk8 curl which"
+depends="virtual?java-environment"
+short_desc="Kotlin interactive shell"
+maintainer="Engolianth <engolianth@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/Kotlin/kotlin-interactive-shell"
+distfiles="https://github.com/kotlin/kotlin-interactive-shell/archive/refs/tags/v${version}.tar.gz"
+checksum=b5e38918ac64216713c64170fd12f7b2c7c00124ba8d8b10ae7e53b386cb4bab
+
+do_build() {
+	./mvnw -DskipTests package
+}
+
+do_install() {
+	vbin bin/ki
+	vinstall lib/ki-shell.jar 644 usr/lib
+}


### PR DESCRIPTION
The [ki-shell](https://blog.jetbrains.com/kotlin/2021/04/ki-the-next-interactive-shell-for-kotlin/) is a better alternative to the built-in REPL of the Kotlin langage (`kotlinc`, which sucks too much to be really useful).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl

This is my first package. Please tell me anything you thing would make this PR or the template better.