### PR TITLE
New package: tuxedo-keyboard-dkms-3.0.9

### DIFF
--- a/srcpkgs/tuxedo-keyboard-dkms/template
+++ b/srcpkgs/tuxedo-keyboard-dkms/template
@@ -2,7 +2,7 @@
 pkgname=tuxedo-keyboard-dkms
 version=3.0.9
 revision=1
-archs="x86_64 x86_64-musl"
+archs="x86_64*"
 wrksrc="tuxedo-keyboard-${version}"
 depends="dkms"
 short_desc="Kernel drivers for certain Tuxedo laptops and other Clevo designs"

--- a/srcpkgs/tuxedo-keyboard-dkms/template
+++ b/srcpkgs/tuxedo-keyboard-dkms/template
@@ -4,17 +4,14 @@ version=3.0.9
 revision=1
 archs="x86_64 x86_64-musl"
 wrksrc="tuxedo-keyboard-${version}"
-
+depends="dkms"
 short_desc="Kernel drivers for certain Tuxedo laptops and other Clevo designs"
 maintainer="Quad <contact@quad.moe>"
-
 license="GPL-3.0-or-later"
 homepage="https://github.com/tuxedocomputers/tuxedo-keyboard"
 distfiles="https://github.com/tuxedocomputers/tuxedo-keyboard/archive/refs/tags/v${version}.tar.gz"
 checksum=2ecaadf55e51c135679869c4fe251626d1bd26765de7622a9d109884c458a584
-
 dkms_modules="tuxedo-keyboard ${version}"
-depends="dkms"
 
 do_install() {
 	vmkdir usr/src/tuxedo-keyboard-${version}

--- a/srcpkgs/tuxedo-keyboard-dkms/template
+++ b/srcpkgs/tuxedo-keyboard-dkms/template
@@ -1,0 +1,22 @@
+# Template file for 'tuxedo-keyboard-dkms'
+pkgname=tuxedo-keyboard-dkms
+version=3.0.9
+revision=1
+archs="x86_64 x86_64-musl"
+wrksrc="tuxedo-keyboard-${version}"
+
+short_desc="Kernel drivers for certain Tuxedo laptops and other Clevo designs"
+maintainer="Quad <contact@quad.moe>"
+
+license="GPL-3.0-or-later"
+homepage="https://github.com/tuxedocomputers/tuxedo-keyboard"
+distfiles="https://github.com/tuxedocomputers/tuxedo-keyboard/archive/refs/tags/v${version}.tar.gz"
+checksum=2ecaadf55e51c135679869c4fe251626d1bd26765de7622a9d109884c458a584
+
+dkms_modules="tuxedo-keyboard ${version}"
+depends="dkms"
+
+do_install() {
+	vmkdir usr/src/tuxedo-keyboard-${version}
+	vcopy "*" usr/src/tuxedo-keyboard-${version}
+}


### PR DESCRIPTION
***This is my first void package, please be strict.***

Same PR as #36465, but I actually remembered to branch it off this time.

DKMS modules developed by Tuxedo Computers for their laptops.  
They provide drivers for many device-specific things such as keyboard backlight, fan control and fn-keys.

Due to the nature of Tuxedo laptops, this module usually also works on other laptops using the same Clevo or TongFang designs.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES** (On [InfinityBook Pro 14](https://www.tuxedocomputers.com/en/Linux-Hardware/Linux-Notebooks/10-14-inch/TUXEDO-InfinityBook-Pro-14-Gen6-US-ANSI-Edition.tuxedo))

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture (x86_64-musl)
