### PR TITLE
[RFC] .github/workflows/build.yaml: only run on changes in srcpkgs/

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,13 @@ name: Check build
 
 on:
   pull_request:
+    paths:
+      - 'srcpkgs/**'
   push:
     branches:
       - 'ci-**'
+    paths:
+      - 'srcpkgs/**'
 
 jobs:
   # Lint changed templates.


### PR DESCRIPTION
Currently, this workflow runs on every pr (and push to branches called `ci-*`). This doesn't give any useful information for changes that only affect other parts of the repo, like common, xbps-src, documentation, etc.
