### PR TITLE
tiptop: fix homepage and distfiles

### DIFF
--- a/srcpkgs/tiptop/template
+++ b/srcpkgs/tiptop/template
@@ -8,8 +8,8 @@ makedepends="ncurses-devel libxml2-devel"
 short_desc="Performance monitoring tool using hardware counters"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-only"
-homepage="http://tiptop.gforge.inria.fr/"
-distfiles="http://tiptop.gforge.inria.fr/releases/${pkgname}-${version}.tar.gz"
+homepage="https://gitlab.inria.fr/rohou/tiptop"
+distfiles="https://files.inria.fr/pacap/tiptop/tiptop-$version.tar.gz"
 checksum=51c4449c95bba34f16b429729c2f58431490665d8093efaa8643b2e1d1084182
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/libxml2"
 


### PR DESCRIPTION
This is the last missing distfile due to the `gforge.inria.fr`  shutdown.

No changes, no revbump.

@leahneukirchen 