### PR TITLE
.github/workflows/stale.yml: increase operations limit

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,3 +17,5 @@ jobs:
           days-before-stale: 90
           days-before-close: 14
           exempt-all-assignees: true
+          ascending: true
+          operations-per-run: 250


### PR DESCRIPTION
By setting [`ascending`](https://github.com/actions/stale#ascending) to `true`, the most stale issues and PRs will be caught first. By increasing the operations limit from the default (30) to 250, more stale issues/PRs will be caught each run, increasing the speed of the burndown.

This implements some of the suggestions from #36657

