### PR TITLE
cni: update to 1.0.1; cni-plugins: update to 1.1.1; New package: cni-plugin-dnsname-1.3.1

### DIFF
--- a/srcpkgs/cni-plugin-dnsname/template
+++ b/srcpkgs/cni-plugin-dnsname/template
@@ -1,0 +1,25 @@
+# Template file for 'cni-plugin-dnsname'
+pkgname=cni-plugin-dnsname
+version=1.3.1
+revision=1
+wrksrc="dnsname-${version}"
+build_style=go
+go_import_path="github.com/containers/dnsname"
+go_package="${go_import_path}/plugins/meta/dnsname"
+depends="cni dnsmasq"
+short_desc="Name resolution for containers"
+maintainer="Enrico Belleri <idesmi@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/containers/dnsname"
+changelog="https://github.com/containers/dnsname/blob/main/RELEASE_NOTES.md"
+distfiles="https://github.com/containers/dnsname/archive/v${version}.tar.gz"
+checksum=a9319a1829e242b4769697650f7df63a635eda7369ba659618d49056b78bf3ce
+
+do_install() {
+	vmkdir usr/libexec/cni
+	for f in ${GOPATH}/bin/* ${GOPATH}/bin/**/*; do
+		if [ -f "$f" ] && [ -x "$f" ]; then
+			vcopy "$f" usr/libexec/cni
+		fi
+	done
+}

--- a/srcpkgs/cni-plugins/template
+++ b/srcpkgs/cni-plugins/template
@@ -1,16 +1,17 @@
 # Template file for 'cni-plugins'
 pkgname=cni-plugins
-version=1.0.1
+version=1.1.1
 revision=1
 wrksrc="plugins-${version}"
 build_style=go
 go_import_path="github.com/containernetworking/plugins"
+depends="cni>=1.0.0"
 short_desc="Container Network Interface (plugins)"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containernetworking/plugins"
 distfiles="https://github.com/containernetworking/plugins/archive/v${version}.tar.gz"
-checksum=2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619
+checksum=c86c44877c47f69cd23611e22029ab26b613f620195b76b3ec20f589367a7962
 
 do_build() {
 	./build_linux.sh

--- a/srcpkgs/cni/template
+++ b/srcpkgs/cni/template
@@ -1,6 +1,6 @@
 # Template file for 'cni'
 pkgname=cni
-version=0.8.0
+version=1.0.1
 revision=1
 build_style=go
 go_import_path="github.com/containernetworking/cni"
@@ -10,4 +10,4 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containernetworking/cni"
 distfiles="https://github.com/containernetworking/cni/archive/v${version}.tar.gz"
-checksum=df8afe3eeae3296ba33ca267041c42f13135c3a067bf2d932761bb02998247a6
+checksum=0e5376f70fb36c26935ddfb90b0da69736592ba8b577fbfb904750034c053d3b


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

For cni-plugin-dnsname:
```
podman network create foo
podman run -dt --name web --network foo docker.io/nginx
podman run -it --name client --network foo docker.io/nginx curl http://web.dns.podman
```

#### New package
- This new package (`cni-plugin-dnsname`) conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I crossbuilt this PR locally for these architectures :
  - aarch64-musl
