### PR TITLE
New package: hut-0.1.0

### DIFF
--- a/srcpkgs/hut/template
+++ b/srcpkgs/hut/template
@@ -1,0 +1,29 @@
+# Template file for 'hut'
+pkgname=hut
+version=0.1.0
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_style=go
+build_helper=qemu
+go_import_path="git.sr.ht/~emersion/hut"
+hostmakedepends="scdoc"
+short_desc="CLI tool for sr.ht"
+maintainer="Dakota Walsh <kota@nilsu.org>"
+license="AGPL-3.0-only"
+homepage="https://git.sr.ht/~emersion/hut"
+changelog="https://git.sr.ht/~emersion/hut/log"
+distfiles="https://git.sr.ht/~emersion/hut/archive/v${version}.tar.gz"
+checksum=5af8f1111f9ec1da9a818978eb1f013dfd50ad4311c79d95b0e62ad428ac1c59
+
+post_install() {
+	hut=$(find $GOPATH/bin -name hut)
+	for sh in bash fish zsh; do
+		vtargetrun $hut completion $sh > hut.$sh
+		vcompletion hut.$sh $sh
+	done
+
+	vlicense LICENSE
+
+	scdoc < doc/hut.1.scd > doc/hut.1
+	vman doc/hut.1
+}


### PR DESCRIPTION
This is the official command line client for https://sourcehut.org/

It's basically the sourcehut equivalent to Github's hub or gh tools.
It's been in development for a while now, but they've put out their
first release earlier this month. I've been using it happily for a while
before this release.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
