### PR TITLE
zlib: Set homepage to https

### DIFF
--- a/srcpkgs/zlib/template
+++ b/srcpkgs/zlib/template
@@ -8,7 +8,7 @@ configure_args="--prefix=/usr --shared"
 short_desc="Compression/decompression Library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Zlib"
-homepage="http://www.zlib.net"
+homepage="https://www.zlib.net"
 distfiles="$homepage/$pkgname-$version.tar.gz"
 checksum=91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 


### PR DESCRIPTION
zlib could not be fetched from the old http homepage. Only the https site works now.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Fixes https://github.com/void-linux/void-packages/issues/36720.