### PR TITLE
texlive2022-bin: install infraonly by default, tweak INSTALL.msg.

### DIFF
--- a/srcpkgs/texlive2022-bin/INSTALL.msg
+++ b/srcpkgs/texlive2022-bin/INSTALL.msg
@@ -1,11 +1,4 @@
-- TeXLive is free software see the files:
-
-  /usr/share/licenses/texlive2022-bin/LICENSE.TL
-  /usr/share/licenses/texlive2022-bin/LICENSE.CTAN
-
-=====================================================================
-
-  To update you TeXLive installation use only the program 
+  To update your TeX Live installation use only the program 
 
   /opt/texlive/2022/bin/<arch>/tlmgr
 
@@ -13,13 +6,12 @@
     - x86_64-linux  ==> x86_64 architecture
     - i386-linux    ==> i386 architecture
 
-  see:
-
+  for details see:
   http://www.tug.org/texlive/doc/tlmgr.html#EXAMPLES
-  
-  for the details and the documentation in 
     		 		 
-  WARNING: To avoid messing up your TeXLive installation, DON'T use
+  WARNING: To avoid messing up your TeX Live installation, DON'T use
   the installation scripts in /opt/texlive-installer.
 
+  This package only installs TeX Live infrastructure now, not TeX Live itself.
+  For a basic installation (previous default), run "tlmgr install scheme-basic".
   For a full installation, run "tlmgr install scheme-full".

--- a/srcpkgs/texlive2022-bin/template
+++ b/srcpkgs/texlive2022-bin/template
@@ -1,7 +1,7 @@
 # Template file for 'texlive2022-bin'
 pkgname=texlive2022-bin
 version=2022
-revision=1
+revision=2
 archs="x86_64* i686 aarch64 arm*"
 create_wrksrc=yes
 depends="cairo pixman graphite gd poppler libsigsegv
@@ -15,8 +15,9 @@ distfiles="ftp://ftp.tug.org/texlive/historic/${version}/install-tl-unx.tar.gz>$
 checksum=e67edec49df6b7c4a987a7d5a9b31bcf41258220f9ac841c7a836080cd334fb5
 
 # Package build options
-build_options="basic small medium full"
-build_options_default="small"
+build_options="infraonly basic small medium full"
+build_options_default="infraonly"
+desc_option_infraonly="Install TeXLive infrastructure only"
 desc_option_basic="Install TeXLive using scheme-basic"
 desc_option_small="Install TeXLive using scheme-small"
 desc_option_medium="Install TeXLive using scheme-medium"
@@ -31,7 +32,9 @@ do_install() {
 	vmkdir opt/texlive${version}-installer
 	vcopy "install-tl-*/*" /opt/texlive${version}-installer
 	vinstall ${FILESDIR}/void.profile 644 opt/texlive${version}-installer
-	if [ "$build_option_basic" ]; then
+	if [ "$build_option_infraonly" ]; then
+		echo "selected_scheme scheme-infraonly"
+	elif [ "$build_option_basic" ]; then
 		echo "selected_scheme scheme-basic"
 	elif [ "$build_option_small" ]; then
 		echo "selected_scheme scheme-small"


### PR DESCRIPTION
This avoids having a long installation time during XBPS run, and allows people to install what they really need.

#### Testing the changes
- I tested the changes in this PR: **YES**
