### PR TITLE
common/travis/fetch_upstream.sh: fix CI for new git version

### DIFF
--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -8,5 +8,8 @@ elif command -v git >/dev/null 2>&1; then
 	GIT_CMD=$(command -v git)
 fi
 
+# required by git 2.35.2+
+$GIT_CMD config --global --add safe.directory /__w/void-packages/void-packages
+
 /bin/echo -e '\x1b[32mFetching upstream...\x1b[0m'
 $GIT_CMD fetch --depth 200 https://github.com/void-linux/void-packages.git master


### PR DESCRIPTION
The newest git versions require [safe.directory](https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory) to work properly for repos owned by others.

#### Testing the changes
- I tested the changes in this PR: **YES**
  Tested by temporarily adding a commit that changed a package to this PR, and [it succeeded](https://github.com/void-linux/void-packages/actions/runs/2177619018).
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
