### PR TITLE
LXQt 1.1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1990,7 +1990,7 @@ libsysstat-qt5.so.0 libsysstat-0.3.2_1
 libpolkit-qt5-agent-1.so.1 polkit-qt5-0.112.0_1
 libpolkit-qt5-gui-1.so.1 polkit-qt5-0.112.0_1
 libpolkit-qt5-core-1.so.1 polkit-qt5-0.112.0_1
-libfm-qt.so.10 libfm-qt-1.0.0_1
+libfm-qt.so.11 libfm-qt-1.1.0_1
 libqtermwidget5.so.1 qtermwidget-1.0.0_1
 libQt6Core.so.6 qt6-core-6.0.0_1
 libQt6OpenGL.so.6 qt6-gui-6.0.0_1

--- a/srcpkgs/libfm-qt/template
+++ b/srcpkgs/libfm-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'libfm-qt'
 pkgname=libfm-qt
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -9,9 +9,9 @@ makedepends="qt5-tools-devel qt5-x11extras-devel libexif-devel
 short_desc="Core library of PCManFM-Qt"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/libfm-qt/releases/download/${version}/libfm-qt-${version}.tar.xz"
-checksum=743d9c8fc30d065d7fefc12e72f31085891733184f1320ba3ade890dae54993b
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/libfm-qt/archive/${version}.tar.gz"
+checksum=8ba16e0db696bb938f675b6d5394ec96726585e8b6130e6a2718a4ffde073d62
 replaces="libfm-qt5>=0"
 
 libfm-qt-devel_package() {

--- a/srcpkgs/liblxqt/template
+++ b/srcpkgs/liblxqt/template
@@ -1,6 +1,6 @@
 # Template file for 'liblxqt'
 pkgname=liblxqt
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools
@@ -10,9 +10,9 @@ makedepends="kwindowsystem-devel libqtxdg-devel libXScrnSaver-devel
 short_desc="Core utility library for all LXQt components"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/liblxqt/releases/download/${version}/liblxqt-${version}.tar.xz"
-checksum=d62820a94839637aedd6a0ceecc232f85d8ccd2173d4ec655cd92c9cbcbcc98c
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/liblxqt/archive/${version}.tar.gz"
+checksum=3b4672cef3906f82444da886557fe0504bf53066e7741c2215592119fbafbb42
 
 liblxqt-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/libqtxdg/template
+++ b/srcpkgs/libqtxdg/template
@@ -1,6 +1,6 @@
 # Template file for 'libqtxdg'
 pkgname=libqtxdg
-version=3.8.0
+version=3.9.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools lxqt-build-tools"
@@ -8,9 +8,9 @@ makedepends="qt5-svg-devel"
 short_desc="Qt implementation of freedesktop.org XDG specifications"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/libqtxdg/releases/download/${version}/libqtxdg-${version}.tar.xz"
-checksum=ce824fb2dda47758b44e57e8e4b63437a5bc5bd476cf37dbba61442990d7ccec
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/libqtxdg/archive/${version}.tar.gz"
+checksum=4dc7e3e65e6bcd50010647ef781ef5601b08ce024b0b1155e6a68316696c5a58
 
 libqtxdg-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/lximage-qt/template
+++ b/srcpkgs/lximage-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'lximage-qt'
 pkgname=lximage-qt
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -9,6 +9,6 @@ makedepends="qt5-x11extras-devel qt5-tools-devel qt5-svg-devel libfm-qt-devel
 short_desc="LXQt image viewer"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lximage-qt/releases/download/${version}/lximage-qt-${version}.tar.xz"
-checksum=04fdff9d0d20dbfeddca2ca8166f7dd14b691badb6ca65909ca8bce75c4a7225
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lximage-qt/archive/${version}.tar.gz"
+checksum=cd1eb058af1c927fac9ac4d2d31435cf46572b2f017cbb0d0b099ad6106c8b91

--- a/srcpkgs/lxqt-about/template
+++ b/srcpkgs/lxqt-about/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-about'
 pkgname=lxqt-about
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -8,6 +8,6 @@ makedepends="qt5-tools-devel liblxqt-devel"
 short_desc="LXQt about application"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-about/releases/download/${version}/lxqt-about-${version}.tar.xz"
-checksum=1c14f68bf65099fbd46b062ffc6c92656620aa1a9eec5a0fd2d1b11888939203
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-about/archive/${version}.tar.gz"
+checksum=d8b5bb348c73e59e000151c5569b46496299155019a3cf9ce7e21a8f641d42b4

--- a/srcpkgs/lxqt-admin/patches/systemd.patch
+++ b/srcpkgs/lxqt-admin/patches/systemd.patch
@@ -1,0 +1,9 @@
+lxqt-admin-time depends on systemd-{timedated,timesyncd}
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,5 +38,4 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD
+     message(WARNING "${CMAKE_SYSTEM_NAME} is not supported by lxqt-admin-time")
+ else()
+     add_subdirectory(lxqt-admin-user)
+-    add_subdirectory(lxqt-admin-time)
+ endif()

--- a/srcpkgs/lxqt-admin/template
+++ b/srcpkgs/lxqt-admin/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-admin'
 pkgname=lxqt-admin
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools polkit-qt5-devel
@@ -9,12 +9,6 @@ makedepends="liblxqt-devel"
 short_desc="LXQt system administration tool"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-admin/releases/download/${version}/lxqt-admin-${version}.tar.xz"
-checksum=f6eebb0da1563f14e9e4d39d3ff2622ee1c8ffa5b130ba26321cfe5261c1411e
-
-post_install() {
-	# depends on systemd-{timedated,timesyncd}
-	rm -f ${DESTDIR}/usr/bin/lxqt-admin-time
-	rm -f ${DESTDIR}/usr/share/applications/lxqt-admin-time.desktop
-}
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-admin/archive/${version}.tar.gz"
+checksum=cf6c41a63b861caacae5ace8bef4781f502cfb0f559fe56afbffe60d13a74775

--- a/srcpkgs/lxqt-archiver/template
+++ b/srcpkgs/lxqt-archiver/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-archiver'
 pkgname=lxqt-archiver
-version=0.5.0
+version=0.6.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools pkg-config qt5-host-tools qt5-qmake perl"
@@ -8,6 +8,6 @@ makedepends="qt5-tools-devel qt5-x11extras-devel libfm-qt-devel json-glib-devel"
 short_desc="Simple & lightweight desktop-agnostic Qt file archiver"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://lxqt.org"
-distfiles="https://github.com/lxqt/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=8ae5259ec00761b1f178e54b9e99bcf64685a6000a148501c4bbe862b4b08fc7
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/${pkgname}/archive/${version}.tar.gz"
+checksum=63029ed0c22dccaa30a7dd7866b6739e7746904cfa97deac836b40da6d56eb8c

--- a/srcpkgs/lxqt-build-tools/template
+++ b/srcpkgs/lxqt-build-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-build-tools'
 pkgname=lxqt-build-tools
-version=0.10.0
+version=0.11.0
 revision=1
 build_style=cmake
 hostmakedepends="qt5-host-tools qt5-qmake pkg-config"
@@ -8,9 +8,9 @@ makedepends="qt5-devel"
 short_desc="LXQt build tools"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="BSD-3-Clause"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-build-tools/releases/download/${version}/lxqt-build-tools-${version}.tar.xz"
-checksum=facb86b0bf3bd4fd20306d3ae965a148ed59785eaf7d73169a82a97473d03bea
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-build-tools/archive/${version}.tar.gz"
+checksum=95da1309ae0111e3b97f775788465f82548a3de09b0e9d5e0a26e5fe715075b2
 
 post_install() {
 	vlicense BSD-3-Clause LICENSE

--- a/srcpkgs/lxqt-config/template
+++ b/srcpkgs/lxqt-config/template
@@ -1,14 +1,14 @@
 # Template file for 'lxqt-config'
 pkgname=lxqt-config
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
-hostmakedepends="pkgconf lxqt-build-tools qt5-qmake qt5-host-tools perl"
+hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
 makedepends="liblxqt-devel libXcursor-devel libkscreen-devel
  xf86-input-libinput-devel libqtxdg-devel"
 short_desc="LXQt System Settings"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-config/releases/download/${version}/lxqt-config-${version}.tar.xz"
-checksum=64d7dd43e5ec1f98f0ba41e99f4438bb1f881fcbc2b2931f798cc82643c2d8a5
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-config/archive/${version}.tar.gz"
+checksum=debe3f51c30e37a8bca37bfdaa0187a68ddd57dad0ecefef169a32c2b042cc58

--- a/srcpkgs/lxqt-globalkeys/template
+++ b/srcpkgs/lxqt-globalkeys/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-globalkeys'
 pkgname=lxqt-globalkeys
-version=1.0.1
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -8,9 +8,9 @@ makedepends="liblxqt-devel"
 short_desc="LXQt daemon and library for global keyboard shortcuts registration"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-globalkeys/releases/download/${version}/lxqt-globalkeys-${version}.tar.xz"
-checksum=b81944cc8d8f20f1eeedb3cd54d4e6ad86a1697d71b4212cf60110af43559a45
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-globalkeys/archive/${version}.tar.gz"
+checksum=ce0cbdbfbddef4ea9b2018b61fb6fc03caeea57fc31bc6f4bb54a04619edb2aa
 replaces="lxqt-common>=0"
 
 lxqt-globalkeys-devel_package() {

--- a/srcpkgs/lxqt-notificationd/template
+++ b/srcpkgs/lxqt-notificationd/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-notificationd'
 pkgname=lxqt-notificationd
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -8,7 +8,7 @@ makedepends="liblxqt-devel"
 short_desc="LXQt notification daemon"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-notificationd/releases/download/${version}/lxqt-notificationd-${version}.tar.xz"
-checksum=94c10fd904995d3eea3b587dd521ed01b839d863ff80205af0af8cab6cb2a660
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-notificationd/archive/${version}.tar.gz"
+checksum=6b29f0163541ba734bcb8d21f0f3579bc36c868fa8afee44d8b7e56ea8ca23ee
 replaces="lxqt-common>=0"

--- a/srcpkgs/lxqt-openssh-askpass/template
+++ b/srcpkgs/lxqt-openssh-askpass/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-openssh-askpass'
 pkgname=lxqt-openssh-askpass
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -9,7 +9,7 @@ depends="openssh"
 short_desc="LXQt ssh-agent helper"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-openssh-askpass/releases/download/${version}/lxqt-openssh-askpass-${version}.tar.xz"
-checksum=9de22a06646cfa50b0ddeef26ac87b510f820501ff8832dc80c7d88a55d878b5
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-openssh-askpass/archive/${version}.tar.gz"
+checksum=77578faf1aaf3e273cd8f92b84ad9570d7aacc88b44663c3373517e790c606b6
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/lxqt-openssh-askpass"

--- a/srcpkgs/lxqt-panel/template
+++ b/srcpkgs/lxqt-panel/template
@@ -1,16 +1,17 @@
 # Template file for 'lxqt-panel'
 pkgname=lxqt-panel
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
 makedepends="libxkbcommon-devel liblxqt-devel ksolid-devel kguiaddons-devel
  lxqt-globalkeys-devel alsa-lib-devel pulseaudio-devel libstatgrab-devel
- libsensors-devel libXcomposite-devel libsysstat-devel libdbusmenu-qt5-devel
- libqtxdg-devel libXdamage-devel"
+ libsensors-devel libsysstat-devel libdbusmenu-qt5-devel
+ libqtxdg-devel libxcb-devel libXtst-devel xcb-util-image-devel"
+depends="lxmenu-data"
 short_desc="LXQt desktop panel"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-panel/releases/download/${version}/lxqt-panel-${version}.tar.xz"
-checksum=ea63939c557fa639d2ab3fae48341c1a59ae8baae1a79d11f15e4bc0e38468d5
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-panel/archive/${version}.tar.gz"
+checksum=f80ccdeb59933d32aab1a425301b9b68458bf0c55567befe1c03263afad20d6d

--- a/srcpkgs/lxqt-policykit/template
+++ b/srcpkgs/lxqt-policykit/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-policykit'
 pkgname=lxqt-policykit
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools polkit-qt5-devel perl"
@@ -8,7 +8,7 @@ makedepends="liblxqt-devel polkit-qt5-devel"
 short_desc="LXQt PolicyKit agent"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-policykit/releases/download/${version}/lxqt-policykit-${version}.tar.xz"
-checksum=8e3ae58196c55c28a5a231f44154a83d6697aa5f6b40dffdedb6b9ea776b4d35
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-policykit/archive/${version}.tar.gz"
+checksum=4866bb843657206b0bb55cc063474941a6d81db578fe3d5143d3760f438b033d
 replaces="lxqt-common>=0"

--- a/srcpkgs/lxqt-powermanagement/template
+++ b/srcpkgs/lxqt-powermanagement/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-powermanagement'
 pkgname=lxqt-powermanagement
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -8,6 +8,6 @@ makedepends="liblxqt-devel ksolid-devel kidletime-devel lxqt-globalkeys-devel"
 short_desc="LXQt power management module"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-powermanagement/releases/download/${version}/lxqt-powermanagement-${version}.tar.xz"
-checksum=c0a444faeed60337c966bfd562e65e936f132f578762c2f01f136038a3f058ee
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-powermanagement/archive/${version}.tar.gz"
+checksum=df59e7b93392863874250a49769dcd7ed395f98548428f9ef6a5b1e728d32e86

--- a/srcpkgs/lxqt-qtplugin/template
+++ b/srcpkgs/lxqt-qtplugin/template
@@ -1,13 +1,13 @@
 # Template file for 'lxqt-qtplugin'
 pkgname=lxqt-qtplugin
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools libfm-devel"
-makedepends="liblxqt-devel libdbusmenu-qt5-devel libfm-qt-devel"
+makedepends="liblxqt-devel libdbusmenu-qt5-devel libfm-qt-devel libqtxdg-devel"
 short_desc="LXQt Qt theme plugin"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-qtplugin/releases/download/${version}/lxqt-qtplugin-${version}.tar.xz"
-checksum=8e789430e1f3b6a354f61d496440a59b797f699320bb8c001d8ef7ac8e1db05e
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-qtplugin/archive/${version}.tar.gz"
+checksum=20eda3ac9319e793c4b1236413f119058771d34915483bed4a048591a59ae990

--- a/srcpkgs/lxqt-runner/template
+++ b/srcpkgs/lxqt-runner/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-runner'
 pkgname=lxqt-runner
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -8,6 +8,6 @@ makedepends="liblxqt-devel lxqt-globalkeys-devel muparser-devel"
 short_desc="LXQt quick launcher"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-runner/releases/download/${version}/lxqt-runner-${version}.tar.xz"
-checksum=24daa86680ef78daf8753b60b3a0c6df391e760b851796a0abeddeed61ae13b9
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-runner/archive/${version}.tar.gz"
+checksum=7c253d338019cb162cddcb606429faa016ac148a16bf720e87e28f756698b731

--- a/srcpkgs/lxqt-session/template
+++ b/srcpkgs/lxqt-session/template
@@ -1,16 +1,16 @@
 # Template file for 'lxqt-session'
 pkgname=lxqt-session
-version=1.0.1
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools xdg-user-dirs
  perl"
-makedepends="liblxqt-devel xdg-user-dirs procps-ng-devel"
+makedepends="kwindowsystem-devel liblxqt-devel procps-ng-devel"
 depends="xdg-user-dirs"
 short_desc="LXQt session handler"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-session/releases/download/${version}/lxqt-session-${version}.tar.xz"
-checksum=3245457cb4a1e59ec62802308c872173baa300fa0f8e517fe14f45112733a6c1
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-session/archive/${version}.tar.gz"
+checksum=6ff41d1c95464fe7b00d3b5493f259323ecad61ae72865cf251ad5db9ae68e4e
 replaces="lxqt-common>=0"

--- a/srcpkgs/lxqt-sudo/template
+++ b/srcpkgs/lxqt-sudo/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-sudo'
 pkgname=lxqt-sudo
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
@@ -9,6 +9,6 @@ depends="sudo"
 short_desc="LXQt GUI frontend for sudo"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-sudo/releases/download/${version}/lxqt-sudo-${version}.tar.xz"
-checksum=6072f6914942fff5884388be9c7c5d38d259fed14358c4c2a9103d0cdd0a43f0
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-sudo/archive/${version}.tar.gz"
+checksum=c31332d056355ff888175ba10556639f436b314579349ca90e555da849ebe22b

--- a/srcpkgs/lxqt-themes/template
+++ b/srcpkgs/lxqt-themes/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt-themes'
 pkgname=lxqt-themes
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools perl"
@@ -8,7 +8,7 @@ depends="hicolor-icon-theme"
 short_desc="Themes, graphics and icons for LXQt"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="LGPL-2.1-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/lxqt-themes/releases/download/${version}/lxqt-themes-${version}.tar.xz"
-checksum=e3a6c96311bbf471ce0af72953b2f34ecf15461ab5e57a6f5b924de41758562b
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/lxqt-themes/archive/${version}.tar.gz"
+checksum=aeb24c1570ae350e4c4ecdea9fb1b67208f641966476bbafd1817a816f665efe
 replaces="lxqt-common>=0"

--- a/srcpkgs/lxqt/template
+++ b/srcpkgs/lxqt/template
@@ -1,6 +1,6 @@
 # Template file for 'lxqt'
 pkgname=lxqt
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=meta
 depends="
@@ -21,15 +21,15 @@ depends="
 	obconf-qt
 	pcmanfm-qt>=${version}
 	lximage-qt>=${version}
-	lxmenu-data
 	lxqt-archiver
 	qterminal>=${version}
 	openbox
 	breeze-icons
+	xdg-desktop-portal-lxqt
 	xdg-utils
 	elogind
 	upower"
 short_desc="LXQt meta-package for Void Linux"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="BSD-2-Clause" # Suppress xlint warning: vlicense
-homepage="https://www.lxqt.org/"
+homepage="https://lxqt-project.org"

--- a/srcpkgs/pavucontrol-qt/template
+++ b/srcpkgs/pavucontrol-qt/template
@@ -1,13 +1,13 @@
 # Template file for 'pavucontrol-qt'
 pkgname=pavucontrol-qt
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config lxqt-build-tools qt5-qmake qt5-host-tools perl"
 makedepends="qt5-tools-devel pulseaudio-devel"
 short_desc="Pulseaudio mixer in Qt"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Enrico Belleri <idesmi@protonmail.com>"
 license="GPL-2.0-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/pavucontrol-qt/releases/download/${version}/pavucontrol-qt-${version}.tar.xz"
-checksum=2407aa55a2d3dc0fdc7074b461c02b97fd455514fbbf9f5b711e68fadd45ac69
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/pavucontrol-qt/archive/${version}.tar.gz"
+checksum=8e4017c584c357fbff75d849e3210fa446edc6e53655b6920221891b8e3dc403

--- a/srcpkgs/pcmanfm-qt/template
+++ b/srcpkgs/pcmanfm-qt/template
@@ -1,15 +1,15 @@
 # Template file for 'pcmanfm-qt'
 pkgname=pcmanfm-qt
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
-hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools libfm-devel perl"
+hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools libfm-qt-devel perl"
 makedepends="qt5-tools-devel qt5-x11extras-devel libfm-qt-devel"
 depends="qt5-translations"
-short_desc="LXQt pcmanfm Qt frontend"
+short_desc="Qt port of PCManFM"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://www.lxqt.org"
-distfiles="https://github.com/lxqt/pcmanfm-qt/releases/download/${version}/pcmanfm-qt-${version}.tar.xz"
-checksum=fa45cc0d3e870db3fb56f474e854aa1284576023082b770b3e4a44410f22cce3
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/pcmanfm-qt/archive/${version}.tar.gz"
+checksum=28b5ff1fb71d9259ae73962892ce04142a750794aa35c4840ed575da08972b9d
 replaces="lxqt-common>=0"

--- a/srcpkgs/qps/template
+++ b/srcpkgs/qps/template
@@ -1,6 +1,6 @@
 # Template file for 'qps'
 pkgname=qps
-version=2.4.0
+version=2.5.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools perl qt5-qmake qt5-host-tools"
@@ -8,6 +8,6 @@ makedepends="liblxqt-devel"
 short_desc="Qt process manager"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://github.com/lxqt/qps"
-distfiles="https://github.com/lxqt/qps/releases/download/${version}/qps-${version}.tar.xz"
-checksum=c2a6c1d5e40e96997cca834f88ca1104aa179bef576a1a8b355b987eaaac69cd
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/qps/archive/${version}.tar.gz"
+checksum=c5f3a27b731eccfae59734c4a3048f9d8632827444e35b773c1a112702666b6a

--- a/srcpkgs/qterminal/template
+++ b/srcpkgs/qterminal/template
@@ -1,14 +1,13 @@
 # Template file for 'qterminal'
 pkgname=qterminal
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools perl"
 makedepends="qtermwidget-devel qt5-tools-devel qt5-x11extras-devel"
-depends="desktop-file-utils"
 short_desc="Lightweight terminal emulator written in Qt"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/qterminal/releases/download/${version}/qterminal-${version}.tar.xz"
-checksum=f169a5279ae5afe386ec3016385c7692b551fea1bae639a8ae438ec90165a643
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/qterminal/archive/${version}.tar.gz"
+checksum=5a72a6f3deb5326618183ddae59989316aa78c86163220f26895df677cbc4479

--- a/srcpkgs/qtermwidget/template
+++ b/srcpkgs/qtermwidget/template
@@ -1,6 +1,6 @@
 # Template file for 'qtermwidget'
 pkgname=qtermwidget
-version=1.0.0
+version=1.1.0
 revision=1
 build_style=cmake
 hostmakedepends="lxqt-build-tools qt5-qmake qt5-host-tools"
@@ -8,9 +8,9 @@ makedepends="qt5-tools-devel"
 short_desc="Terminal widget for QTerminal"
 maintainer="Helmut Pozimski <helmut@pozimski.eu>"
 license="GPL-2.0-or-later"
-homepage="https://lxqt.org/"
-distfiles="https://github.com/lxqt/qtermwidget/releases/download/${version}/qtermwidget-${version}.tar.xz"
-checksum=2af0e9f212932cb36bbbf20722eaf4a1d3acf640dfed9b763ca7d388af8b7fd2
+homepage="https://lxqt-project.org"
+distfiles="https://github.com/lxqt/qtermwidget/archive/${version}.tar.gz"
+checksum=b062e5169bee35c3a8c1d0f67b78b43d63f1041d11e3a5a717f6a54a016bd734
 
 qtermwidget-devel_package() {
 	short_desc+=" - development files"

--- a/srcpkgs/xdg-desktop-portal-lxqt/template
+++ b/srcpkgs/xdg-desktop-portal-lxqt/template
@@ -1,0 +1,14 @@
+# Template file for 'xdg-desktop-portal-lxqt'
+pkgname=xdg-desktop-portal-lxqt
+version=0.2.0
+revision=1
+build_style=cmake
+hostmakedepends="qt5-qmake qt5-host-tools"
+makedepends="kwindowsystem-devel libfm-qt-devel"
+short_desc="Backend implementation for xdg-desktop-portal using Qt/KF5/libfm-qt"
+maintainer="Enrico Belleri <idesmi@protonmail.com>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/lxqt/xdg-desktop-portal-lxqt"
+changelog="https://github.com/lxqt/xdg-desktop-portal-lxqt/raw/master/CHANGELOG"
+distfiles="https://github.com/lxqt/xdg-desktop-portal-lxqt/archive/${version}.tar.gz"
+checksum=9d7ac6fd6980293cb184518642dcc57d842b67105b3d236f893189bd30911ad7


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Update from installed 1.0.0

#### Local build testing
- I built this PR locally for my native architecture,
  - x86_64
  - x86_64-musl

---
On the pattern, I am not sure of adding `breeze-gtk`: none of the newly introduced palettes matches Breeze colors after all.

Runtime dependency on `lxmenu-data` was moved from pattern to `lxqt-panel`.