### PR TITLE
add xpkgdiff to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,6 +94,14 @@ jobs:
           "$here/common/travis/show_files.sh" "$BOOTSTRAP" "$ARCH"
           )
 
+      - name: Compare to previous
+        run: |
+          (
+          here="$(pwd)"
+          cd /
+          "$here/common/travis/xpkgdiff.sh" "$BOOTSTRAP" "$ARCH"
+          )
+
       - name: Check file conflicts
         if: matrix.config.arch == 'x86_64' # the arch indexed in xlocate
         run: |

--- a/common/travis/xpkgdiff.sh
+++ b/common/travis/xpkgdiff.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# xpkgdiff.sh
+
+export XBPS_TARGET_ARCH="$2" XBPS_DISTDIR=/hostrepo XBPS_HOSTDIR="$HOME/hostdir"
+export DIFF='diff --unified=0 --report-identical-files --suppress-common-lines
+ --color=always --label REPO --label BUILT'
+
+while read -r pkg; do
+	for subpkg in $(xsubpkg $pkg); do
+		if xbps-query --repository=$HOME/hostdir/binpkgs \
+					  --repository=$HOME/hostdir/binpkgs/nonfree \
+					  -i "$subpkg" >&/dev/null; then
+			/bin/echo -e "\x1b[34mFile Diff of $subpkg:\x1b[0m"
+			xpkgdiff -f $subpkg
+			/bin/echo -e "\x1b[34mMetadata Diff of $subpkg:\x1b[0m"
+			xpkgdiff -S $subpkg
+			/bin/echo -e "\x1b[34mDependency Diff of $subpkg:\x1b[0m"
+			xpkgdiff -x $subpkg
+		else
+			/bin/echo -e "\x1b[33m$subpkg wasn't found\x1b[0m"
+		fi
+	done
+done < /tmp/templates


### PR DESCRIPTION
- common/travis/xpkgdiff.sh: add script to compare pkgs to previous version
- .github/workflows/build.yaml: add xpkgdiff CI step

#### Testing the changes
- I tested the changes in this PR: **YES**
  See demo PR: classabbyamp/void-packages#3
![image](https://user-images.githubusercontent.com/5366828/167016847-b5f1a57d-3f97-4f1e-9665-8277296e361c.png)

