### PR TITLE
kdeconnect: add breeze-icons & kpeoplevcard to depends

### DIFF
--- a/srcpkgs/kdeconnect/template
+++ b/srcpkgs/kdeconnect/template
@@ -1,7 +1,7 @@
 # Template file for 'kdeconnect'
 pkgname=kdeconnect
 version=22.12.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
 hostmakedepends="extra-cmake-modules qt5-host-tools
@@ -11,7 +11,8 @@ makedepends="kcmutils-devel qca-qt5-devel frameworkintegration-devel
  qt5-declarative-devel libfakekey-devel kwayland-devel
  qt5-multimedia-devel kpeoplevcard-devel kirigami2-devel
  qqc2-desktop-style-devel pulseaudio-qt-devel"
-depends="kde-cli-tools qca-qt5-ossl fuse-sshfs kirigami2 qt5-quickcontrols"
+depends="kde-cli-tools qca-qt5-ossl fuse-sshfs kirigami2 qt5-quickcontrols
+ breeze-icons kpeoplevcard"
 checkdepends="qca-qt5-ossl"
 short_desc="Multi-platform app that allows your devices to communicate"
 maintainer="John <me@johnnynator.dev>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

kdeconnect appears to depend on breeze-icons for it's icons

without breeze-icons installed:
![2022-04-18 22:31:49](https://user-images.githubusercontent.com/486393/163912139-5e22f7fe-bd82-4ce3-8342-fef79e4ada5b.png)
with breeze-icons installed:
![2022-04-18 22:32:36](https://user-images.githubusercontent.com/486393/163912167-cf39261c-0b17-4f67-af70-8eeda711f21a.png)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
