### PR TITLE
openjdk{9,10,12-16}-bootstrap: disable on armv5 and armv6

### DIFF
--- a/srcpkgs/openjdk10-bootstrap/template
+++ b/srcpkgs/openjdk10-bootstrap/template
@@ -35,10 +35,11 @@ distfiles="http://hg.openjdk.java.net/jdk-updates/jdk10u/archive/jdk-${_repo_ver
 checksum="374f7ae35f0a7439a40bd2c765d1f410607c75c6c1e788f1a344a42e59431f51"
 lib32disabled=yes
 
-# no hotspot JIT for arm32 and ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
-	arm*|ppc*) _use_zero=yes ;;
+	# no hotspot JIT for arm32 and ppc32
+	armv7*|ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then

--- a/srcpkgs/openjdk12-bootstrap/template
+++ b/srcpkgs/openjdk12-bootstrap/template
@@ -47,10 +47,11 @@ nocross=yes
 # Build is still parallel, but don't use -jN.
 disable_parallel_build=yes
 
-# no hotspot JIT for ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
+	# no hotspot JIT for ppc32
 	ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then

--- a/srcpkgs/openjdk13-bootstrap/template
+++ b/srcpkgs/openjdk13-bootstrap/template
@@ -47,10 +47,11 @@ nocross=yes
 # Build is still parallel, but don't use -jN.
 disable_parallel_build=yes
 
-# no hotspot JIT for ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
+	# no hotspot JIT for ppc32
 	ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then

--- a/srcpkgs/openjdk14-bootstrap/template
+++ b/srcpkgs/openjdk14-bootstrap/template
@@ -46,10 +46,11 @@ nocross=yes
 # Build is still parallel, but don't use -jN.
 disable_parallel_build=yes
 
-# no hotspot JIT for ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
+	# no hotspot JIT for ppc32
 	ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then

--- a/srcpkgs/openjdk15-bootstrap/template
+++ b/srcpkgs/openjdk15-bootstrap/template
@@ -49,10 +49,11 @@ nocross=yes
 # Build is still parallel, but don't use -jN.
 disable_parallel_build=yes
 
-# no hotspot JIT for ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
+	# no hotspot JIT for ppc32
 	ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then

--- a/srcpkgs/openjdk16-bootstrap/template
+++ b/srcpkgs/openjdk16-bootstrap/template
@@ -49,10 +49,11 @@ nocross=yes
 # Build is still parallel, but don't use -jN.
 disable_parallel_build=yes
 
-# no hotspot JIT for ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
+	# no hotspot JIT for ppc32
 	ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then

--- a/srcpkgs/openjdk9-bootstrap/template
+++ b/srcpkgs/openjdk9-bootstrap/template
@@ -50,10 +50,11 @@ checksum="914183a7eac6a1dfdfa70a98ceb4262244c77ab904c4570bb34c609ecb5f0986
  9cba7f03ebeda4d3cfaffb015f9bf967fcca2c3c113604836073556df6a7b9aa
  c939de46f903ecb283c02155e1415cee98ab66803e17eae0403c399c1a475647"
 
-# no hotspot JIT for arm32 and ppc32
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
-	arm*|ppc*) _use_zero=yes ;;
+	# no hotspot JIT for arm32 and ppc32
+	armv7*|ppc*) _use_zero=yes ;;
+	armv[56]*) broken="Unsupported architecture" ;;
 esac
 
 if [ -n "$_use_zero" ]; then


### PR DESCRIPTION
Openjdk will compile for armv5* and armv6*, but it is not supported at runtime, at least in the configuration we ship.

See [here](https://forums.raspberrypi.com/viewtopic.php?t=232680), [here](https://forums.raspberrypi.com/viewtopic.php?t=323376), and [here](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=255662) for evidence of the incompatibility.

This changes nothing for void's builds because these packages are nocross, but if someone wished to build it for arm natively, this will stop them.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
  https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[ci skip]