### PR TITLE
profanity: update to 0.12.1. libstrophe: update to 0.12.0.

### DIFF
--- a/srcpkgs/libstrophe/template
+++ b/srcpkgs/libstrophe/template
@@ -1,7 +1,7 @@
 # Template file for 'libstrophe'
 pkgname=libstrophe
-version=0.10.1
-revision=2
+version=0.12.0
+revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable cares) $(vopt_enable tls)"
 hostmakedepends="automake libtool pkg-config"
@@ -13,7 +13,7 @@ license="GPL-3.0-only"
 homepage="http://strophe.im/libstrophe/"
 changelog="https://raw.githubusercontent.com/strophe/libstrophe/master/ChangeLog"
 distfiles="https://github.com/strophe/libstrophe/archive/${version}.tar.gz"
-checksum=5bf0bbc555cb6059008f1b748370d4d2ee1e1fabd3eeab68475263556405ba39
+checksum=f645819d8d93711c92454974dd9007c9b9e98ea0b59cb708dc626dd4c6b9d0a8
 
 build_options="cares tls"
 build_options_default="tls"

--- a/srcpkgs/profanity/template
+++ b/srcpkgs/profanity/template
@@ -1,16 +1,16 @@
 # Template file for 'profanity'
 pkgname=profanity
-version=0.11.1
+version=0.12.1
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable notify notifications) $(vopt_enable otr)
  $(vopt_enable pgp) $(vopt_enable python python-plugins) $(vopt_enable plugins)
  $(vopt_with xscreensaver) $(vopt_enable omemo) $(vopt_enable cplugins c-plugins)
  ac_cv_prog_PYTHON_CONFIG_EXISTS=yes PYTHON_VERSION=3"
-hostmakedepends="pkg-config $(vopt_if python python3-devel) $(vopt_if gtk gtk+-devel)"
+hostmakedepends="pkg-config $(vopt_if python python3-devel) $(vopt_if gtk gtk+3-devel)"
 makedepends="libcurl-devel libglib-devel libstrophe-devel readline-devel sqlite-devel
  $(vopt_if notify libnotify-devel) $(vopt_if otr 'libotr-devel libgcrypt-devel')
- $(vopt_if pgp gpgme-devel) $(vopt_if python python3-devel) $(vopt_if gtk gtk+-devel)
+ $(vopt_if pgp gpgme-devel) $(vopt_if python python3-devel) $(vopt_if gtk gtk+3-devel)
  $(vopt_if xscreensaver libXScrnSaver-devel)
  $(vopt_if omemo 'libsignal-protocol-c-devel libgcrypt-devel')"
 checkdepends="cmocka-devel"
@@ -20,7 +20,7 @@ license="GPL-3.0-or-later"
 homepage="https://profanity-im.github.io/"
 changelog="https://raw.githubusercontent.com/profanity-im/profanity/master/CHANGELOG"
 distfiles="https://github.com/boothj5/profanity/releases/download/${version}/profanity-${version}.tar.gz"
-checksum=6f1b4df6c2971f51d03d48d2bfd4f69b4404410d800b43f029ea1cf08a02bd45
+checksum=e344481e7bf3b16baf58a169d321b809c4700becffb70db6f1c39adc3fad306e
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*)


### PR DESCRIPTION
I got this warning when I ran `./xbps-src pkg profanity`, not sure if it's
important:

```
=> WARNING: profanity-0.12.1_1: libprofanity.so.0 not found in common/shlibs!
```

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
