### PR TITLE
mpv-mpris: update to 0.8.1.

### DIFF
--- a/srcpkgs/mpv-mpris/template
+++ b/srcpkgs/mpv-mpris/template
@@ -1,18 +1,22 @@
 # Template file for 'mpv-mpris'
 pkgname=mpv-mpris
-version=0.5
-revision=2
+version=0.8.1
+revision=1
 build_style=gnu-makefile
+make_use_env=yes
 make_build_target=mpris.so
+make_check_target=test
 hostmakedepends="pkg-config"
 makedepends="libglib-devel mpv-devel"
 depends="mpv"
+checkdepends="mpv playerctl sound-theme-freedesktop
+ xvfb-run xauth jq socat dbus"
 short_desc="MPRIS plugin for mpv"
 maintainer="Alif Rachmawadi <arch@subosito.com>"
 license="MIT"
 homepage="https://github.com/hoyon/mpv-mpris"
 distfiles="https://github.com/hoyon/mpv-mpris/archive/${version}.tar.gz"
-checksum=673aff031e7cc741edea68d7b4b0103d7b031d4a55755abb9e1be5dd4ec4e969
+checksum=a208f42ec9df5444f725a55e1b457e62c86d6b93c9c84215e1808ff047695053
 
 do_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Having `bash` as a check dependency (both on my machine and in the CI) seems to really mess things up for reasons I don't know of, and running `./xbps-src check mpv-mpris` seems to work without having it there, so I removed it.