### PR TITLE
New package: adw-gtk3-1.7

### DIFF
--- a/srcpkgs/adw-gtk3/template
+++ b/srcpkgs/adw-gtk3/template
@@ -1,0 +1,12 @@
+# Template file for 'adw-gtk3'
+pkgname=adw-gtk3
+version=1.7
+revision=1
+build_style=meson
+hostmakedepends="sassc"
+short_desc="Theme from libadwaita ported to GTK-3"
+maintainer="tibequadorian <tibequadorian@posteo.de>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/lassekongo83/adw-gtk3"
+distfiles="https://github.com/lassekongo83/adw-gtk3/archive/v${version}.tar.gz"
+checksum=4ba3b8d89fc5e2e8658ebf561458518f0dbc05bedf99c7747735379ae1393eaf


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **NO**

From [Manual.md](https://github.com/void-linux/void-packages/blob/master/Manual.md):
>new themes are highly unlikely to be accepted

but 

>If you believe you have an exception, start a PR and make an argument for why that particular piece of software, while not meeting any of the following requirements, is a good candidate for the Void packages system.

[adw-gtk3](https://github.com/lassekongo83/adw-gtk3) is the theme from libadwaita ported to GTK3. I've been using it for a while and I really like it.
Now that more and more apps switch to libadwaita, this theme can be used to bring consistency to the app appearance. So perhaps this could make an exception to our inclusion policy.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
