### PR TITLE
ncmpc: update to 0.46.

### DIFF
--- a/srcpkgs/ncmpc/template
+++ b/srcpkgs/ncmpc/template
@@ -1,18 +1,18 @@
 # Template file for 'ncmpc'
 pkgname=ncmpc
-version=0.45
-revision=2
+version=0.46
+revision=1
 build_style=meson
 configure_args="-Dlirc=disabled -Dhtml_manual=false"
 hostmakedepends="pkg-config python3-Sphinx"
-makedepends="boost-devel libmpdclient-devel ncurses-devel pcre-devel"
+makedepends="libmpdclient-devel ncurses-devel pcre2-devel"
 short_desc="Ncurses-based mpd client"
 maintainer="Getty Ritter <gettyritter@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.musicpd.org/clients/ncmpc/"
 changelog="https://raw.githubusercontent.com/MusicPlayerDaemon/ncmpc/master/NEWS"
 distfiles="https://www.musicpd.org/download/ncmpc/0/ncmpc-${version}.tar.xz"
-checksum=17ff446447e002f2ed4342b7324263a830df7d76bcf177dce928f7d3a6f1f785
+checksum=177f77cf09dd4ab914e8438be399cdd5d83c9aa992abc8d9abac006bb092934e
 
 post_install() {
 	vmkdir usr/share/examples/ncmpc


### PR DESCRIPTION
Also, remove unneeded boost-devel dependency and
bump to pcre2.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-glibc)