### PR TITLE
xbps-src: add flag to build broken packages

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -147,6 +147,23 @@ msg_normal() {
     fi
 }
 
+report_broken() {
+    if [ "$show_problems" = "ignore-problems" ]; then
+        return
+    fi
+    if [ -z "$XBPS_IGNORE_BROKENNESS" ]; then
+        for line in "$@"; do
+            msg_red "$line"
+        done
+        exit 2
+    elif [ "$XBPS_IGNORE_BROKENNESS" != reported ]; then
+        for line in "$@"; do
+            msg_warn "$line"
+        done
+        XBPS_IGNORE_BROKENNESS=reported
+    fi
+}
+
 msg_normal_append() {
     [ -n "$NOCOLORS" ] || printf "\033[1m"
     printf "$@"
@@ -644,14 +661,14 @@ setup_pkg() {
         wrksrc="$XBPS_BUILDDIR/$wrksrc"
     fi
 
-    if [ "$cross" -a "$nocross" -a "$show_problems" != "ignore-problems" ]; then
-        msg_red "$pkgver: cannot be cross compiled, exiting...\n"
-        msg_red "$pkgver: $nocross\n"
-        exit 2
-    elif [ "$broken" -a "$show_problems" != "ignore-problems" ]; then
-        msg_red "$pkgver: cannot be built, it's currently broken; see the build log:\n"
-        msg_red "$pkgver: $broken\n"
-        exit 2
+    if [ "$cross" -a "$nocross" ]; then
+        report_broken \
+            "$pkgver: cannot be cross compiled...\n" \
+            "$pkgver: $nocross\n"
+    elif [ "$broken" ]; then
+        report_broken \
+            "$pkgver: cannot be built, it's currently broken; see the build log:\n" \
+            "$pkgver: $broken\n"
     fi
 
     if [ -n "$restricted" -a -z "$XBPS_ALLOW_RESTRICTED" -a "$show_problems" != "ignore-problems" ]; then

--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -34,8 +34,7 @@ check_pkg_arch() {
             esac
         done
         if [ -z "$nonegation" -a -n "$match" ] || [ -n "$nonegation" -a -z "$match" ]; then
-            msg_red "${pkgname}-${version}_${revision}: this package cannot be built for ${_arch}.\n"
-            exit 2
+            report_broken "${pkgname}-${version}_${revision}: this package cannot be built for ${_arch}.\n"
         fi
     fi
 }

--- a/xbps-src
+++ b/xbps-src
@@ -150,6 +150,8 @@ Options:
 
 $(print_cross_targets)
 
+-b  Build packages even if marked as broken, nocross, or excluded with archs.
+
 -c  <configuration>
     If specified, etc/conf.<configuration> will be used as the primary config
     file name; etc/conf will only be attempted if that does not exist.
@@ -360,7 +362,7 @@ readonly XBPS_SRC_VERSION="113"
 export XBPS_MACHINE=$(xbps-uhelper -C /dev/null arch)
 
 XBPS_OPTIONS=
-XBPS_OPTSTRING="1a:c:CEfgGhH:iIj:Lm:No:p:qsQKr:tV"
+XBPS_OPTSTRING="1a:bc:CEfgGhH:iIj:Lm:No:p:qsQKr:tV"
 
 # Preprocess arguments in order to allow options before and after XBPS_TARGET.
 eval set -- $(getopt "$XBPS_OPTSTRING" "$@");
@@ -372,6 +374,7 @@ while getopts "$XBPS_OPTSTRING" opt; do
     case $opt in
         1) XBPS_ARG_BUILD_ONLY_ONE_PKG=yes; XBPS_OPTIONS+=" -1";;
         a) XBPS_ARG_CROSS_BUILD="$OPTARG"; XBPS_OPTIONS+=" -a $OPTARG";;
+        b) XBPS_ARG_IGNORE_BROKENNESS=yes; XBPS_OPTIONS+=" -b";;
         c) XBPS_ARG_CONFIG="$OPTARG"; XBPS_OPTIONS+=" -c $OPTARG";;
         C) XBPS_ARG_KEEP_ALL=1; XBPS_OPTIONS+=" -C";;
         E) XBPS_ARG_BINPKG_EXISTS=1; XBPS_OPTIONS+=" -E";;
@@ -463,6 +466,7 @@ fi
 
 # Set options passed on command line, after configuration files have been read
 [ -n "$XBPS_ARG_BUILD_ONLY_ONE_PKG" ] && XBPS_BUILD_ONLY_ONE_PKG=yes
+[ -n "$XBPS_ARG_IGNORE_BROKENNESS" ] && XBPS_IGNORE_BROKENNESS=1
 [ -n "$XBPS_ARG_SKIP_REMOTEREPOS" ] && XBPS_SKIP_REMOTEREPOS=1
 [ -n "$XBPS_ARG_BUILD_FORCEMODE" ] && XBPS_BUILD_FORCEMODE=1
 [ -n "$XBPS_ARG_INFORMATIVE_RUN" ] && XBPS_INFORMATIVE_RUN=1
@@ -484,7 +488,7 @@ export XBPS_BUILD_ONLY_ONE_PKG XBPS_SKIP_REMOTEREPOS XBPS_BUILD_FORCEMODE \
        XBPS_INFORMATIVE_RUN XBPS_TEMP_MASTERDIR XBPS_BINPKG_EXISTS \
        XBPS_USE_GIT_REVS XBPS_CHECK_PKGS XBPS_DEBUG_PKGS XBPS_SKIP_DEPS \
        XBPS_KEEP_ALL XBPS_QUIET XBPS_ALT_REPOSITORY XBPS_STRICT XBPS_CROSS_BUILD \
-       XBPS_MAKEJOBS XBPS_PRINT_VARIABLES
+       XBPS_MAKEJOBS XBPS_PRINT_VARIABLES XBPS_IGNORE_BROKENNESS
 
 # The masterdir/hostdir variables are forced and readonly in chroot
 if [ -z "$IN_CHROOT" ]; then
@@ -644,7 +648,7 @@ export XBPS_SHUTILSDIR XBPS_CROSSPFDIR XBPS_TRIGGERSDIR \
     XBPS_LIBEXECDIR XBPS_DISTDIR XBPS_DISTFILES_MIRROR XBPS_ALLOW_RESTRICTED \
     XBPS_USE_GIT_COMMIT_DATE XBPS_PKG_COMPTYPE XBPS_REPO_COMPTYPE \
     XBPS_BUILDHELPERDIR XBPS_USE_BUILD_MTIME XBPS_BUILD_ENVIRONMENT \
-    XBPS_PRESERVE_PKGS
+    XBPS_PRESERVE_PKGS XBPS_IGNORE_BROKENNESS
 
 for i in REPOSITORY DESTDIR BUILDDIR SRCDISTDIR; do
     eval val="\$XBPS_$i"


### PR DESCRIPTION
helps to check if build can be fixed

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
