### PR TITLE
btrfs-progs: move .pc file to libbtrfsutil-devel

### DIFF
--- a/srcpkgs/btrfs-progs/template
+++ b/srcpkgs/btrfs-progs/template
@@ -1,7 +1,7 @@
 # Template file for 'btrfs-progs'
 pkgname=btrfs-progs
 version=5.14.1
-revision=1
+revision=2
 wrksrc="${pkgname}-v${version}"
 build_style=gnu-configure
 make_check_target=test
@@ -65,6 +65,7 @@ libbtrfsutil-devel_package() {
 	short_desc+=" - libbtrfsutil development files"
 	pkg_install() {
 		vmove usr/include/btrfsutil.h
+		vmove usr/lib/pkgconfig/libbtrfsutil.pc
 		vmove usr/lib/libbtrfsutil.a
 		vmove usr/lib/libbtrfsutil.so
 	}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
