### PR TITLE
lazarus: update to 2.2.0.

### DIFF
--- a/srcpkgs/lazarus/template
+++ b/srcpkgs/lazarus/template
@@ -1,9 +1,9 @@
 # Template file for 'lazarus'
 pkgname=lazarus
-version=2.0.10
+version=2.2.0
 revision=1
 # For adding a revision suffix to version on the source tarball file
-_version_revision_suffix="-2"
+_version_revision_suffix="-0"
 archs="x86_64 i686"
 wrksrc=lazarus
 hostmakedepends="fpc rsync"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, MPL-2.0, LGPL-2.0-or-later"
 homepage="http://www.lazarus.freepascal.org"
 distfiles="${SOURCEFORGE_SITE}/project/lazarus/Lazarus%20Zip%20_%20GZip/Lazarus%20${version}/lazarus-${version}${_version_revision_suffix}.tar.gz"
-checksum=64d5626468dd24a3332b205f3abd0a581ab7de1b060a2d57e21864066cfd43b7
+checksum=b6b5d516511e3dfb34910d7656db068d4bba80f009692500aebbcae79cb12160
 nopie=yes
 lib32disabled=yes
 


### PR DESCRIPTION
I built it for x86_64 and am requesting testing from stevelitt.

Test packages are here:
https://devspace.voidlinux.org/maldridge/please-test/pr/36842/