### PR TITLE
gettext: fix non-cross builds

### DIFF
--- a/srcpkgs/gettext/template
+++ b/srcpkgs/gettext/template
@@ -14,7 +14,7 @@ configure_args="--disable-java --disable-native-java --disable-csharp
 # Either:
 # - Have xz in hostmakedepends; or
 # - Let gettext-devel depends on bzip2
-hostmakedepends="xz"
+hostmakedepends="xz automake libtool"
 short_desc="Internationalized Message Handling Library and tools"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
@@ -36,12 +36,9 @@ else
 	conflicts="gettext-libs>=0"
 fi
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" automake libtool"
-	pre_configure() {
-		autoreconf -fi
-	}
-fi
+pre_configure() {
+	autoreconf -fi
+}
 
 post_install() {
 	# don't overwrite musl's header


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

fixes this error when building:
```
make[2]: Entering directory '/builddir/gettext-0.21/libtextstyle'
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /builddir/gettext-0.21/libtextstyle/build-aux/missing aclocal-1.16 -I m4 -I gnulib-m4
/builddir/gettext-0.21/libtextstyle/build-aux/missing: line 81: aclocal-1.16: command not found
WARNING: 'aclocal-1.16' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <https://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <https://www.gnu.org/software/autoconf>
         <https://www.gnu.org/software/m4/>
         <https://www.perl.org/>
make[2]: *** [Makefile:1748: aclocal.m4] Error 127
make[2]: Leaving directory '/builddir/gettext-0.21/libtextstyle'
make[1]: *** [Makefile:403: all-recursive] Error 1
make[1]: Leaving directory '/builddir/gettext-0.21'
make: *** [Makefile:359: all] Error 2
=> ERROR: gettext-0.21_4: do_build: '${make_cmd} ${makejobs} ${make_build_args} ${make_build_target}' exited with 2
=> ERROR:   in do_build() at common/build-style/gnu-configure.sh:15

```

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
