### PR TITLE
imlib2: update to 1.9.0.

### DIFF
--- a/srcpkgs/imlib2/template
+++ b/srcpkgs/imlib2/template
@@ -1,19 +1,19 @@
 # Template file for 'imlib2'
 pkgname=imlib2
-version=1.8.1
+version=1.9.0
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --sysconfdir=/etc/imlib2 --enable-visibility-hiding"
 hostmakedepends="pkg-config"
 makedepends="freetype-devel libjpeg-turbo-devel libpng-devel libwebp-devel
  tiff-devel libid3tag-devel giflib-devel libXext-devel libSM-devel
- libheif-devel librsvg-devel"
+ libheif-devel librsvg-devel libopenjpeg2-devel libspectre-devel"
 short_desc="Image manipulation library"
 maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="Imlib2"
 homepage="https://sourceforge.net/projects/enlightenment/"
 distfiles="${SOURCEFORGE_SITE}/enlightenment/imlib2-src/imlib2-${version}.tar.xz"
-checksum=522e1e70e65bc0eddfe207617d15c9a395662a7c090661daaa2c294fb7d9fdaa
+checksum=5ac9e8ca7c6700919fe72749ad7243c42de4b22823c81769a1bf8e480e14c650
 
 post_install() {
 	vlicense COPYING


### PR DESCRIPTION
When #31397 is merged I can enable the newly added JXL loader which would close #36415, but this PR is also mergeable in its current state and we can add JXL support later.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
