### PR TITLE
opensc: revbump, move onepin-opensc-pkcs11.so to opensc-pkcs11

### DIFF
--- a/srcpkgs/opensc/template
+++ b/srcpkgs/opensc/template
@@ -28,9 +28,12 @@ post_install() {
 opensc-pkcs11_package() {
 	short_desc+=" - pkcs11 library"
 	pkg_install() {
-		vmove usr/lib/pkcs11
-		vmove "usr/lib/opensc-pkcs11*"
+		vmove usr/lib/onepin-opensc-pkcs11.so
+		vmove usr/lib/opensc-pkcs11.so
 		vmove usr/lib/pkcs11-spy.so
+		vmove usr/lib/pkcs11
+
+		vmove usr/lib/pkgconfig/opensc-pkcs11.pc
 	}
 }
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

`usr/lib/pkgconfig/opensc-pkcs11.pc` and `usr/lib/onepin-opensc-pkcs11.so` were left in the main `opensc` package.

I never noticed it before as I have the full suit installed, but while making another pkg for a pcsc driver, this caught my eye.