### PR TITLE
.github/workflows/cycle.yml: fix error message related to git 2.35.2+

### DIFF
--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -28,6 +28,7 @@ jobs:
          common/travis/prepare.sh
       - name: Find cycles and open issues
         run: |
+         git config --global --add safe.directory "$PWD"
          common/scripts/xbps-cycles.py | tee cycles
          grep 'Cycle:' cycles | while read -r line; do
              if gh issue list -R "$GITHUB_REPOSITORY" -S "$line" | grep .; then

--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -9,7 +9,7 @@ elif command -v git >/dev/null 2>&1; then
 fi
 
 # required by git 2.35.2+
-$GIT_CMD config --global --add safe.directory /__w/void-packages/void-packages
+$GIT_CMD config --global --add safe.directory "$PWD"
 
 /bin/echo -e '\x1b[32mFetching upstream...\x1b[0m'
 $GIT_CMD fetch --depth 200 https://github.com/void-linux/void-packages.git master


### PR DESCRIPTION
the cycles CI has been spitting out 50k lines of:

```
fatal: unsafe repository ('/__w/void-packages/void-packages' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/void-packages/void-packages
```

This should fix that
