### PR TITLE
paper-icon-theme: update to 1.5.0.20200312.

### DIFF
--- a/srcpkgs/paper-icon-theme/template
+++ b/srcpkgs/paper-icon-theme/template
@@ -1,12 +1,13 @@
 # Template file for 'paper-icon-theme'
 pkgname=paper-icon-theme
-version=1.5.0
-revision=2
-wrksrc="${pkgname}-v.${version}"
+version=1.5.0.20200312
+revision=1
+_commit=aa3e8af7a1f0831a51fd7e638a4acb077a1e5188
+wrksrc="${pkgname}-${_commit}"
 build_style=meson
 short_desc="Modern freedesktop icon theme"
 maintainer="travankor <travankor@tuta.io>"
 license="CC-BY-SA-4.0"
 homepage="https://github.com/snwh/paper-icon-theme"
-distfiles="${homepage}/archive/v.${version}.tar.gz"
-checksum=62f21dfe95ece481e5c635480f32347f1ad27ea66b2ef0526fe799090b298ece
+distfiles="https://github.com/snwh/paper-icon-theme/archive/${_commit}.tar.gz"
+checksum=ad76f45266693666df43fab5a381a60899de99e21a85961fa24d60f4cb639b27


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

---

Closes: #21895

Have been using this template for close to 2 years (something broke then - symlinks/svgs metadata/both/something like that), after that never looked at upstream again - turns out development of the icons set got frozen and the upstream github repo is archived. 

I know Void usually doesn't include non tagged releases, but I think this falls under the exceptions.

For the record, if I recall just around 100-150 files got broken (so not a lot of icons, as they are included in several sizes) and probably not a lot of people use it, that can explain why there weren't more complains.