### PR TITLE
libseccomp: update to 2.5.4

### DIFF
--- a/srcpkgs/libseccomp/template
+++ b/srcpkgs/libseccomp/template
@@ -1,22 +1,18 @@
 # Template file for 'libseccomp'
 pkgname=libseccomp
-reverts="2.5.0_1"
-version=2.4.3
-revision=2
+version=2.5.4
+revision=1
 build_style=gnu-configure
-hostmakedepends="automake libtool"
+hostmakedepends="automake libtool gperf"
+checkdepends="which"
 short_desc="High level interface to the Linux Kernel's seccomp filter"
 maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/seccomp/libseccomp/"
+changelog="https://raw.githubusercontent.com/seccomp/libseccomp/main/CHANGELOG"
 distfiles="https://github.com/seccomp/${pkgname}/archive/v${version}.tar.gz"
-checksum=4d86f0bd0847795bf7f7bf6e44cb73edf4417d84f6d8848c23eda99b0c50fce6
+checksum=96bbadb4384716272a6d2be82801dc564f7aab345febfe9b698b70fc606e3f75
 
-post_extract() {
-	case "$XBPS_TARGET_MACHINE" in
-		*-musl) sed -i '/<linux\/prctl.h>/d' src/system.h;;
-	esac
-}
 pre_configure() {
 	NOCONFIGURE=1 ./autogen.sh
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Without this `tracker3-miners-3.3.0` will fail with the following message:
```
/usr/libexec/tracker-extract-3 -f file.mp3

(tracker-extract-3:9677): Tracker-CRITICAL **: 00:38:18.118: Failed to load seccomp rules.
**
Tracker:ERROR:../src/tracker-extract/tracker-extract.c:707:tracker_extract_get_metadata_by_cmdline: code should not be reached
Bail out! Tracker:ERROR:../src/tracker-extract/tracker-extract.c:707:tracker_extract_get_metadata_by_cmdline: code should not be reached
Aborted
```

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
