### PR TITLE
minidlna: update to 1.3.1.

### DIFF
--- a/srcpkgs/minidlna/template
+++ b/srcpkgs/minidlna/template
@@ -1,7 +1,9 @@
 # Template file for 'minidlna'
 pkgname=minidlna
-version=1.3.0
-revision=2
+version=1.3.1
+revision=1
+_hash=66939d5ac4986020764c0518455f55b68422369f
+wrksrc=minidlna-git-${_hash}
 build_style=gnu-configure
 configure_args="
  --sbindir=/usr/bin
@@ -11,7 +13,7 @@ conf_files="/etc/minidlna.conf"
 make_dirs="
  /var/lib/minidlna 0750 minidlna minidlna
  /var/log/minidlna 0750 minidlna minidlna"
-hostmakedepends="pkg-config gettext"
+hostmakedepends="pkg-config gettext automake gettext-devel-tools"
 makedepends="ffmpeg-devel libjpeg-turbo-devel sqlite-devel libexif-devel
  libid3tag-devel libvorbis-devel libflac-devel"
 short_desc="DLNA/UPnP-AV compliant media server"
@@ -19,8 +21,9 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-only, BSD-3-Clause"
 homepage="https://minidlna.sourceforge.net/"
 changelog="https://sourceforge.net/projects/minidlna/files/minidlna/${version}/README/view"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=47d9b06b4c48801a4c1112ec23d24782728b5495e95ec2195bbe5c81bc2d3c63
+#distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
+distfiles="https://sourceforge.net/code-snapshots/git/m/mi/minidlna/git.git/minidlna-git-${_hash}.zip"
+checksum=6e13ecde024885694f37a7cc942032b37a32f8b3043e864ade95f07c2de6fa09
 
 system_accounts="minidlna"
 minidlna_homedir="/var/lib/minidlna"
@@ -30,6 +33,10 @@ CFLAGS="-fcommon"
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"
 fi
+
+pre_configure() {
+	autoreconf -fvi
+}
 
 post_install() {
 	vlicense LICENCE.miniupnpd # This one is BSD. COPYING is GPL-2


### PR DESCRIPTION
The git snapshot had to be used due to [1]. Hopefully a future release
will come with tarballs.

[1] https://sourceforge.net/p/minidlna/support-requests/78/

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

I have only built it natively, so far.

@Duncaen

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
