### PR TITLE
net-tools: update to 2.10, adopt.

### DIFF
--- a/srcpkgs/net-tools/template
+++ b/srcpkgs/net-tools/template
@@ -1,15 +1,15 @@
 # Template file for 'net-tools'
 pkgname=net-tools
-version=1.60.20181103git
+version=2.10
 revision=1
-_githash=0eebece8c964e3cfa8a018f42b2e7e751a7009a0
-wrksrc="${pkgname}-${_githash}"
+build_style="gnu-makefile"
+make_use_env=yes
 short_desc="Basic networking tools"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="0x5c <dev@0x5c.io>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/ecki/net-tools"
-distfiles="https://github.com/ecki/net-tools/archive/${_githash}.tar.gz"
-checksum=795cb4dd2618ed7ff9a48b9cb63b33780b47dfd7464c8e52ba734e6796cbab17
+distfiles="https://github.com/ecki/net-tools/archive/refs/tags/v${version}.tar.gz"
+checksum=8e186f65f0ff304989b3dc8b0067c3a07d36ae777da60667bdd6ccb2730908d2
 
 alternatives="
  ifconfig:ifconfig:/usr/bin/${pkgname}-ifconfig
@@ -17,9 +17,10 @@ alternatives="
  hostname:hostname:/usr/bin/${pkgname}-hostname
  hostname:/usr/share/man/man1/hostname.1:/usr/share/man/man8/${pkgname}-hostname.1"
 
-pre_build() {
-	vsed -i "s#/sbin#/bin#" Makefile
-	vsed -i "s#/usr##" man/Makefile
+post_patch() {
+	# Hacky and flaky, but upstream does not support $PREFIX !
+	vsed -e "s|/sbin|/bin|" -i Makefile
+	vsed -e "s|/bin|/usr/bin|" -i Makefile
 	case "$XBPS_TARGET_MACHINE" in
 		*-musl)
 			# HZ is defined in <asm/param.h>
@@ -27,20 +28,18 @@ pre_build() {
 				-e "/#include <sys\/param.h>/a #include <asm\/param.h>"
 			vsed -i ${wrksrc}/netstat.c \
 				-e "/#include <sys\/param.h>/a #include <asm\/param.h>"
-
 			# Need <termios.h> for tty constants and structure
 			vsed -i ${wrksrc}/slattach.c \
 				-e "/#include <limits.h>/a #include <termios.h>"
 	esac
 }
 
-do_build() {
+do_configure() {
 	replace_interpreter bash configure.sh
-	yes "" | make
+	yes "" | make config
 }
 
-do_install() {
-	make DESTDIR=${DESTDIR}/usr update
+post_install() {
 	# Rename ifconfig for alternatives.
 	mv ${DESTDIR}/usr/bin/{ifconfig,${pkgname}-ifconfig}
 	mv ${DESTDIR}/usr/share/man/man8/{ifconfig,${pkgname}-ifconfig}.8


### PR DESCRIPTION
Also cleaned up the template and made the build system behave slightly better.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
