### PR TITLE
spotify: update to 1.1.84.

### DIFF
--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.1.80
+version=1.1.84
 revision=1
-_ver="${version}.699.gc3dac750_amd64"
+_ver="${version}.716.gc5f8b819_amd64"
 _filename="spotify-client_${_ver}.deb"
 archs="x86_64"
 create_wrksrc=yes
@@ -14,7 +14,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/${_filename}"
-checksum=19f80255b89d768969ff9d6a05d90091a30c05f65eabdd968592d47a7754b80e
+checksum=08e6b2666dc2a39624890e553a3046d05ecebe17bcc2fe930d49314b2fb812c7
 _license_checksum=4465d0bba5deb87866184b04ba76604cd93561c0dc9cd21cacdf5b0295bdae3a
 repository=nonfree
 restricted=yes


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, amd64-glibc

The old (current) deb is already removed from the repo, so all new builds fail now. 
