### PR TITLE
SDL2: update to 2.0.22, adopt

### DIFF
--- a/srcpkgs/SDL2/template
+++ b/srcpkgs/SDL2/template
@@ -1,6 +1,6 @@
 # Template file for 'SDL2'
 pkgname=SDL2
-version=2.0.20
+version=2.0.22
 revision=1
 build_style=gnu-configure
 configure_args="--enable-alsa --disable-esd --disable-rpath --enable-libudev
@@ -10,12 +10,12 @@ hostmakedepends="pkg-config nasm"
 makedepends="alsa-lib-devel dbus-devel eudev-libudev-devel libusb-compat-devel
  libsamplerate-devel"
 short_desc="Simple DirectMedia Layer (version 2)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Sigrid Solveig Haflínudóttir <ftrvxmtrx@gmail.com>"
 license="Zlib"
 homepage="https://www.libsdl.org/"
 changelog="https://raw.githubusercontent.com/libsdl-org/SDL/main/WhatsNew.txt"
 distfiles="https://www.libsdl.org/release/${pkgname}-${version}.tar.gz"
-checksum=c56aba1d7b5b0e7e999e4a7698c70b63a3394ff9704b5f6e1c57e0c16f04dd06
+checksum=fe7cbf3127882e3fc7259a75a0cb585620272c51745d3852ab9dd87960697f2e
 
 # Package build options
 build_options="gles opengl pulseaudio pipewire sndio vulkan wayland x11"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, aarch64-musl)

This one will fail unless pipewire is at 0.3.51 (there was a fix in the headers): https://github.com/void-linux/void-packages/pull/36899