### PR TITLE
Update Spotify new version because fail download the last. OBS needs qt5-wayland as dep to work.

### DIFF
--- a/srcpkgs/obs/template
+++ b/srcpkgs/obs/template
@@ -12,7 +12,7 @@ makedepends="LuaJIT-devel fdk-aac-devel ffmpeg-devel glu-devel jack-devel
  qt5-x11extras-devel qt5-svg-devel speexdsp-devel v4l-utils-devel vlc-devel
  x264-devel mbedtls-devel jansson-devel wayland-devel pipewire-devel
  libxkbcommon-devel pciutils-devel"
-depends="xset xdg-desktop-portal"
+depends="xset xdg-desktop-portal qt5-wayland"
 short_desc="Open Broadcaster Software"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2.0-or-later"

--- a/srcpkgs/spotify/template
+++ b/srcpkgs/spotify/template
@@ -1,8 +1,8 @@
 # Template file for 'spotify'
 pkgname=spotify
-version=1.1.80
+version=1.1.84
 revision=1
-_ver="${version}.699.gc3dac750_amd64"
+_ver="${version}.716.gc5f8b819_amd64"
 _filename="spotify-client_${_ver}.deb"
 archs="x86_64"
 create_wrksrc=yes
@@ -14,7 +14,7 @@ maintainer="Stefan Mühlinghaus <jazzman@alphabreed.com>"
 license="custom:Proprietary"
 homepage="https://www.spotify.com"
 distfiles="http://repository.spotify.com/pool/non-free/s/spotify-client/${_filename}"
-checksum=19f80255b89d768969ff9d6a05d90091a30c05f65eabdd968592d47a7754b80e
+checksum=08e6b2666dc2a39624890e553a3046d05ecebe17bcc2fe930d49314b2fb812c7
 _license_checksum=4465d0bba5deb87866184b04ba76604cd93561c0dc9cd21cacdf5b0295bdae3a
 repository=nonfree
 restricted=yes


### PR DESCRIPTION
Spotify client was updated.

Solve this issue:
```
=> spotify-1.1.80_1: installing host dependencies: curl-7.83.0_1 w3m-0.5.3+git20210102_2 libcurl-7.83.0_1 ...
=> spotify-1.1.80_1: running do-fetch hook: 00-distfiles ...
=> spotify-1.1.80_1: fetching distfile 'spotify-client_1.1.80.699.gc3dac750_amd64.deb'...
http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-client_1.1.80.699.gc3dac750_amd64.deb: Not Found
=> ERROR: spotify-1.1.80_1: failed to fetch spotify-client_1.1.80.699.gc3dac750_amd64.deb.
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

