### PR TITLE
inspircd: update to 3.13.0.

### DIFF
--- a/srcpkgs/inspircd/INSTALL.msg
+++ b/srcpkgs/inspircd/INSTALL.msg
@@ -1,2 +1,2 @@
 You need to create a configuration file before running inspircd.
-Example configuration can be found at /etc/inspircd/examples/
+Example configuration can be found at /usr/share/doc/inspircd

--- a/srcpkgs/inspircd/template
+++ b/srcpkgs/inspircd/template
@@ -1,20 +1,21 @@
 # Template file for 'inspircd'
 pkgname=inspircd
-version=3.10.0
+version=3.13.0
 revision=1
 build_style=gnu-makefile
 hostmakedepends="perl pkg-config"
-makedepends="geoip-devel openssl-devel sqlite-devel gnutls-devel"
+makedepends="gnutls-devel libmaxminddb-devel openssl-devel sqlite-devel"
 short_desc="Modular Internet Relay Chat server"
 maintainer="Alexander Gehrke <void@qwertyuiop.de>"
 license="GPL-2.0-only"
 homepage="http://www.inspircd.org/"
 distfiles="https://github.com/inspircd/inspircd/archive/v${version}.tar.gz"
-checksum=9bbf3581fc1a9443ef4c4595b208e5b8852483cb78b20fe3e98d225fa4538982
+checksum=0a4534114f5db1602c53ca4cfbb5ad623b9f990737d8c8f85890d8de47165729
 
 system_accounts="inspircd"
 inspircd_homedir="/var/lib/inspircd"
 make_dirs="
+ /run/inspircd     0750 ${pkgname} ${pkgname}
  /var/log/inspircd 0750 ${pkgname} ${pkgname}
  /var/lib/inspircd 0750 ${pkgname} ${pkgname}"
 
@@ -26,24 +27,17 @@ pre_configure() {
 }
 
 do_configure() {
-	./configure --enable-extras=m_ssl_openssl.cpp,m_regex_posix.cpp,m_sqlite3.cpp
 	./configure \
-		--prefix=/usr \
-		--config-dir=/etc/inspircd \
-		--log-dir=/var/log/inspircd \
-		--data-dir=/var/lib/inspircd \
-		--manual-dir=/usr/share/man/man1 \
-		--module-dir=/usr/lib/${pkgname}/modules \
-		--binary-dir=/usr/bin \
+		--enable-extras "geo_maxmind regex_posix regex_stdlib ssl_gnutls ssl_openssl sslrehashsignal sqlite3"
+	./configure \
+		--binary-dir /usr/bin \
+		--disable-auto-extras \
+		--disable-ownership \
 		--distribution-label voidlinux-${revision} \
-		--gid 0 \
-		--uid 0 \
-		--disable-interactive
+		--system
 	vsed -i 's/-ldl/& -lm/' GNUmakefile
 }
 
 post_install() {
 	vsv inspircd
-	rm ${DESTDIR}/usr/${pkgname}
-	rm ${DESTDIR}/usr/inspircd.service
 }


### PR DESCRIPTION
#### Testing the changes

- I tested the changes in this PR: **YES**

#### Local build testing

- I built this PR locally for my native architecture, x86-64

---

This updates InspIRCd to v3.13.0 and fixes the following package problems:

- Fixed depending on geoip-devel instead of libmaxminddb-devel. This is a leftover from v2.

- Fixed not passing `--disable-auto-extras` to configure. Without this the previous call to `--enable-extras` would have been overridden and resulted in the enabled extra modules being based on what is installed on the build system.

- Fixed not explicitly enabling modules that would have otherwise been automatically enabled based on the dependent packages.

- Fixed using `--gid 0 --uid 0` instead of `--disable-ownership`. The latter is more appropriate for distribution packages.

- Fixed manually specifying directories in configure instead of using `--system`. Other than `--binary-dir` all of the directories specified were the default for a system-wide install anyway. This also fixes files being installed into /usr.

[Note: I am the upstream for this software but I am not a Void user. I have nonetheless tested in a VM to the best of my abilities. Thanks to @leahneukirchen for the help with this.]