### PR TITLE
xf86-video-amdgpu: update to 22.0.0.

### DIFF
--- a/srcpkgs/xf86-video-amdgpu/template
+++ b/srcpkgs/xf86-video-amdgpu/template
@@ -1,7 +1,7 @@
 # Template file for 'xf86-video-amdgpu'
 pkgname=xf86-video-amdgpu
-version=21.0.0
-revision=2
+version=22.0.0
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config"
 makedepends="xorgproto eudev-libudev-devel libpciaccess-devel libdrm-devel
@@ -11,8 +11,8 @@ short_desc="Xorg AMD Radeon RXXX video driver (amdgpu kernel module)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://wiki.freedesktop.org/xorg"
-distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.bz2"
-checksum=607823034defba6152050e5eb1c4df94b38819ef764291abadd81b620bc2ad88
+distfiles="${XORG_SITE}/driver/${pkgname}-${version}.tar.xz"
+checksum=9d23fb602915dc3ccde92aa4d1e9485e7e54eaae2f41f485e55eb20761778266
 
 lib32disabled=yes
 LDFLAGS="-Wl,-z,lazy"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-glibc)

I have tested this for about a day now , no issues to complain about.
This is a small release: 
https://github.com/freedesktop/xorg-xf86-video-amdgpu/compare/xf86-video-amdgpu-21.0.0...xf86-video-amdgpu-22.0.0