### PR TITLE
haskell-language-server: update to 1.7.0.0

### DIFF
--- a/srcpkgs/haskell-language-server/template
+++ b/srcpkgs/haskell-language-server/template
@@ -1,16 +1,16 @@
 # Template file for 'haskell-language-server'
 pkgname=haskell-language-server
-version=1.6.1.0
+version=1.7.0.0
 revision=1
 build_style="haskell-stack"
-make_build_args="--stack-yaml stack-9.0.2.yaml"
+make_build_args="--stack-yaml stack-9.0.2.yaml --flag=haskell-language-server:-dynamic"
 makedepends="ncurses-devel ncurses-libtinfo-devel icu-devel zlib-devel"
 short_desc="Integration of ghcide and haskell-ide-engine"
 maintainer="Wayne Van Son <waynevanson@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/haskell/haskell-language-server"
 distfiles="https://github.com/haskell/haskell-language-server/archive/${version}.tar.gz"
-checksum=e5c336ad2de8d021c882cdac5bbc26bf6427df8d2a5bd244c05cf18296a9bfdc
+checksum=252fc5ae41ef77bbfa36f42eb38f69c953d5aa8757b510c5c45a03655da95513
 nopie_files="
  /usr/bin/haskell-language-server
  /usr/bin/haskell-language-server-wrapper


### PR DESCRIPTION
The `-dynamic` flag is needed, as with this release[1] we dynamically
compile against GHC and the relevant system libraries by default.

[1]: https://github.com/haskell/haskell-language-server/releases/tag/1.7.0.0

#### Testing the changes
- I tested the changes in this PR: **YES**