### PR TITLE
Update xdg-desktop-portal-gtk

### DIFF
--- a/srcpkgs/xdg-desktop-portal-gtk/template
+++ b/srcpkgs/xdg-desktop-portal-gtk/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-gtk'
 pkgname=xdg-desktop-portal-gtk
-version=1.8.0
+version=1.14.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config libxslt glib-devel xdg-desktop-portal gettext"
@@ -12,7 +12,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/flatpak/xdg-desktop-portal-gtk"
 distfiles="https://github.com/flatpak/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=a52529ed321e044ca9adca5e9718d9ba57c414a2634dd4109df344c5b9eed77f
+checksum=f621210716a9cf821d969eecb1df1e3e46fc687b87f7add83300d35321594954
 
 post_install() {
 	rm -rf "${DESTDIR}/usr/lib/systemd"

--- a/srcpkgs/xdg-desktop-portal/template
+++ b/srcpkgs/xdg-desktop-portal/template
@@ -1,19 +1,19 @@
 # Template file for 'xdg-desktop-portal'
 pkgname=xdg-desktop-portal
-version=1.8.1
+version=1.14.3
 revision=1
 build_style=gnu-configure
-configure_args="--enable-pipewire --enable-geoclue --enable-libportal"
+configure_args="--enable-pipewire --enable-geoclue --enable-libportal --without-systemd"
 hostmakedepends="pkg-config glib-devel"
 makedepends="flatpak-devel fuse-devel pipewire-devel geoclue2-devel
- libportal-devel"
+ libportal-devel fuse3-devel"
 checkdepends="dbus"
 short_desc="Portal frontend service for Flatpak"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/flatpak/xdg-desktop-portal"
 distfiles="https://github.com/flatpak/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=01f5f87d3546b63bad85cdba40619913435235a499af3c48ec7554ce8200dcdf
+checksum=31bcb4b85441d1e628fd675c2455a577baa695b92d01e8227628b0e4a4b54daf
 
 do_check() {
 	# some tests require a dbus session


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
This fixes GTK apps not anti-aliasing fonts when run on Wayland with `GTK_USE_PORTAL=1` (without people needing to pull in gnome-settings-daemon)

see also:
https://github.com/flatpak/flatpak/issues/2861
https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/issues/31

#### Testing the changes
- I tested the changes in this PR: **YES**

@Duncaen 
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
