### PR TITLE
flintlib: update to 2.8.5.

### DIFF
--- a/srcpkgs/flintlib/template
+++ b/srcpkgs/flintlib/template
@@ -1,21 +1,24 @@
 # Template file for 'flintlib'
 pkgname=flintlib
-version=2.8.4
+version=2.8.5
 revision=1
 wrksrc="flint-${version}"
 build_style=configure
-configure_args="--prefix=/usr --with-gmp=/usr --with-mpfr=/usr $(vopt_if ntl --with-ntl=/usr)"
-makedepends="mpfr-devel $(vopt_if ntl ntl-devel)"
+configure_args="--prefix=/usr $(vopt_with ntl)
+ $(vopt_if openblas --with-blas=${XBPS_CROSS_BASE}/usr/include/openblas)"
+makedepends="mpfr-devel $(vopt_if ntl ntl-devel)
+ $(vopt_if openblas openblas-devel)"
 short_desc="Fast Library for Number Theory"
 maintainer="Gonzalo Tornaría <tornaria@cmat.edu.uy>"
 license="LGPL-2.1-or-later"
 homepage="https://flintlib.org"
 changelog="https://raw.githubusercontent.com/wbhart/flint2/trunk/NEWS"
 distfiles="https://flintlib.org/flint-${version}.tar.gz"
-checksum=61df92ea8c8e9dc692d46c71d7f50aaa09a33d4ba08d02a1784730a445e5e4be
+checksum=5911fedff911100f15781f35e3a4fa934fe60e4aea02a8c10cc8918101c1eed8
 
-build_options="ntl"
+build_options="ntl openblas"
 desc_option_ntl="enable NTL support"
+build_options_default="openblas"
 
 if [ -z "$CROSS_BUILD" ]; then
 	build_options_default+=" ntl"


### PR DESCRIPTION
Also, enable openblas (used for matrix multiplication)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I ran sagemath long doctest suite with this. The update by itself is just a bugfix release, but I also took the chance to enable openblas for matrix multiplication so I wanted to make sure I didn't mess up (I had it disabled b/c of a misunderstanding on my part, it seems convenient to have it enabled.)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
