### PR TITLE
common/travis/xlint.sh: print Github annotations

### DIFF
--- a/common/scripts/lint-commits
+++ b/common/scripts/lint-commits
@@ -35,18 +35,18 @@ do
 	/^$/ && !msg { msg = 1; next }
 	!msg { next }
 	# 3: long-line-is-banned-except-footnote-like-this-for-url
-	(NF > 2) && (length > 80) { print C ": long line: " $0; exit 1 }
+	(NF > 2) && (length > 80) { print "::error title=Commit Lint::" C ": long line: " $0; exit 1 }
 	!subject {
-		if (length > 50) { print C ": subject is a bit long" }
-		if (!($0 ~ ":" || $0 ~ "^Take over maintainership " || $0 ~ "^Orphan ")) { print C ": subject does not follow CONTRIBUTING.md guildelines"; exit 1 }
+		if (length > 50) { print "::warning title=Commit Lint::" C ": subject is a bit long" }
+		if (!($0 ~ ":" || $0 ~ "^Take over maintainership " || $0 ~ "^Orphan ")) { print "::error title=Commit Lint::" C ": subject does not follow CONTRIBUTING.md guildelines"; exit 1 }
 		# Below check is too noisy?
 		# if (!($0 ~ "^New package:" || $0 ~ ".*: update to")) {
-		# 	print C ": not new package/update/removal?"
+		# 	print "::warning title=Commit Lint::" C ": not new package/update/removal?"
 		# }
 		subject = 1; next
 	}
 	/^$/ { body = 1; next }
-	!body { print C ": second line must be blank"; exit 1 }
+	!body { print "::error title=Commit Lint::" C ": second line must be blank"; exit 1 }
 	' || status=1
 done
 exit $status

--- a/common/scripts/lint2annotations.awk
+++ b/common/scripts/lint2annotations.awk
@@ -1,0 +1,11 @@
+# Converts xlint/etc format lints into GH Actions annotations
+# The original line is printed alongside the annotation command
+{
+	split($0, a, ": ")
+	split(a[1], b, ":")
+	msg = substr($0, index($0, ": ") + 2)
+	if (b[2]) {
+		line = ",line=" b[2]
+	}
+	printf "::error title=Template Lint,file=%s%s::%s\n", b[1], line, msg
+}

--- a/common/travis/xlint.sh
+++ b/common/travis/xlint.sh
@@ -11,7 +11,8 @@ common/scripts/lint-commits $base $tip || EXITCODE=$?
 
 for t in $(awk '{ print "srcpkgs/" $0 "/template" }' /tmp/templates); do
 	/bin/echo -e "\x1b[32mLinting $t...\x1b[0m"
-	xlint "$t" || EXITCODE=$?
-	common/scripts/lint-version-change "$t" $base $tip || EXITCODE=$?
+	xlint "$t" > /tmp/xlint_out || EXITCODE=$?
+	common/scripts/lint-version-change "$t" $base $tip > /tmp/vlint_out || EXITCODE=$?
+	awk -f common/scripts/lint2annotations.awk /tmp/xlint_out /tmp/vlint_out
 done
 exit $EXITCODE


### PR DESCRIPTION
This turns xlint, version lint, and commit lint messages into warning or error annotations.

Only annotations from the last CI run will show, except on the summary and logs of a run, where they are visible as long as the run exist.

A showcase of the changes can be seen [here](https://github.com/0x5c/void-packages/pull/3).

Ping @the-maldridge since you were interested in this

#### Screenshots
Inline lints (xlint and version lint)
![image](https://user-images.githubusercontent.com/5877043/166205591-4720208d-4bce-479c-aa4c-37d11e5f6151.png)
Lints without line number show at line 1 (misplaced variables now have a line number since https://github.com/leahneukirchen/xtools/pull/240)
![image](https://user-images.githubusercontent.com/5877043/166206105-65ece722-1204-4e3c-8ac1-bc618be74f9d.png)
All lints show on the action run summary
![image](https://user-images.githubusercontent.com/5877043/166206252-701f983c-a92a-4930-ae97-ddd560ef5ff9.png)
and in the log
![image](https://user-images.githubusercontent.com/5877043/166975601-259bfc69-217d-4295-868f-8a87dcf72b39.png)


#### Testing the changes
- I tested the changes in this PR: **YES**

[ci skip]