### PR TITLE
base-files: add alacritty to DIR_COLORS.256color

### DIFF
--- a/srcpkgs/base-files/files/DIR_COLORS.256color
+++ b/srcpkgs/base-files/files/DIR_COLORS.256color
@@ -20,6 +20,7 @@ COLOR tty
 OPTIONS -F -T 0
 
 # Below, there should be one TERM entry for each termtype that is colorizable
+TERM alacritty
 TERM putty-256color
 TERM rxvt-256color
 TERM screen-256color

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.142
-revision=12
+revision=13
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"


### PR DESCRIPTION
this fixes empty `$LS_COLORS` in alacritty

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64 glibc)
