### PR TITLE
kmonad: correct version to 0.4.1.20220321.

### DIFF
--- a/srcpkgs/kmonad/template
+++ b/srcpkgs/kmonad/template
@@ -1,14 +1,17 @@
 # Template file for 'kmonad'
 pkgname=kmonad
-version=65b501defdd0049563752f8af8c8c57f5a1ae38b
+reverts="65b501defdd0049563752f8af8c8c57f5a1ae38b_1"
+_githash=65b501defdd0049563752f8af8c8c57f5a1ae38b
+version=0.4.1.20220321
 revision=1
+wrksrc="${pkgname}-${_githash}"
 build_style=haskell-stack
 stackage=lts-19.0
 short_desc="Keyboard remapping utility providing qmk-like functionality"
 maintainer="slotThe <soliditsallgood@mailbox.org>"
 license="MIT"
 homepage="https://github.com/david-janssen/kmonad"
-distfiles="${homepage}/archive/${version}.tar.gz"
+distfiles="${homepage}/archive/${_githash}.tar.gz"
 checksum=2b0cb0c5d1575bf61b1c442476ad24103028c309d103fedb56214a3bb30f8c0f
 nopie_files="/usr/bin/kmonad"
 nocross=yes


### PR DESCRIPTION
Fixes: 78955200f6

```
Name   Action    Version           New version            Download size
kmonad downgrade 65b501defdd0049563752f8af8c8c57f5a1ae38b_1 0.4.1.20220321_1       -
```

@q66 @slotThe 