### PR TITLE
kdenlive: update to 22.04.1

### DIFF
--- a/srcpkgs/kdenlive/template
+++ b/srcpkgs/kdenlive/template
@@ -1,6 +1,6 @@
 # Template file for 'kdenlive'
 pkgname=kdenlive
-version=21.12.3
+version=22.04.1
 revision=1
 build_style=cmake
 hostmakedepends="
@@ -10,14 +10,14 @@ makedepends="
  kdeclarative-devel kfilemetadata5-devel knewstuff-devel knotifyconfig-devel
  kplotting-devel mlt7-devel qt5-multimedia-devel qt5-webkit-devel purpose-devel
  v4l-utils-devel ksolid-devel qt5-quickcontrols2-devel qt5-networkauth-devel"
-depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit qt5-quickcontrols vlc"
+depends="breeze-icons dvdauthor ffmpeg frei0r-plugins kinit opencv qt5-quickcontrols"
 checkdepends="$depends"
 short_desc="Non-linear video editor"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://kdenlive.org"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=7aa3fee6f2938664f2e35dae97a67ebfdedb6aec2bf4bbabfca5e7b1456c55c1
+checksum=ae879041f18ee89b3fef2dc85cbb6899bf184c433b234d0c2145085767952a4e
 # FIXME: Test #507: RunCMake.file-GET_RUNTIME_DEPENDENCIES fails
 make_check=extended
 


### PR DESCRIPTION
- add opencv (for motion tracking)
- remove vlc (only as optional media player)

#### Testing the changes
- I tested the changes in this PR: **briefly**