### PR TITLE
freecad: update to 0.19.4.

### DIFF
--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -1,7 +1,7 @@
 # Template file for 'freecad'
 pkgname=freecad
-version=0.19.2
-revision=4
+version=0.19.4
+revision=1
 wrksrc="FreeCAD-${version}"
 build_style=cmake
 
@@ -36,7 +36,7 @@ maintainer="yopito <pierre.bourgin@free.fr>"
 license="LGPL-2.0-or-later"
 homepage="https://freecadweb.org/"
 distfiles="https://github.com/FreeCAD/FreeCAD/archive/${version}.tar.gz"
-checksum=47e39e3d6fcafe6e0c68923fb1b86acda16986268e5e6011694057b940139fba
+checksum=e40a1c343956e13c56cc8578d025ae83d68d9d20acda1732953bc8a3883e9722
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	makedepends+=" libexecinfo-devel"

--- a/srcpkgs/python3-pivy/template
+++ b/srcpkgs/python3-pivy/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-pivy'
 pkgname=python3-pivy
-version=0.6.6
-revision=3
+version=0.6.7
+revision=1
 wrksrc="pivy-${version}"
 build_style=cmake
 hostmakedepends="python3-devel swig"
@@ -12,7 +12,7 @@ maintainer="yopito <pierre.bourgin@free.fr>"
 license="ISC"
 homepage="https://github.com/coin3d/pivy"
 distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=27204574d894cc12aba5df5251770f731f326a3e7de4499e06b5f5809cc5659e
+checksum=37e33d85117aac27640e011df74ddcd77f270428300df916b46ee5c50645d582
 
 # still relevant with pivy 0.6.6 ?
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The pivy update fixes important bugs affecting FreeCADs Path workbench.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

[ci skip]

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
