### PR TITLE
freeplane: update to 1.9.14, hard-code jdk11

### DIFF
--- a/srcpkgs/freeplane/patches/jdk11-default.patch
+++ b/srcpkgs/freeplane/patches/jdk11-default.patch
@@ -1,0 +1,15 @@
+freeplane does not work with jdk17, so set jdk11 as the default.
+This can be overridden by the upstream-created method still.
+
+--- a/freeplane_framework/script/freeplane.sh
++++ b/freeplane_framework/script/freeplane.sh
+@@ -5,6 +5,9 @@
+ 	set -x
+ fi
+ 
++# set openjdk11 as the default, regardless of xbps-alternatives
++[ -z "$FREEPLANE_JAVA_HOME" ] && FREEPLANE_JAVA_HOME=/usr/lib/jvm/openjdk11
++
+ ########## FUNCTIONS DEFINITIONS #######################################
+ 
+ _debug() {

--- a/srcpkgs/freeplane/template
+++ b/srcpkgs/freeplane/template
@@ -1,17 +1,16 @@
 # Template file for 'freeplane'
 pkgname=freeplane
-version=1.9.12
-revision=2
+version=1.9.14
+revision=1
 wrksrc="freeplane-release-${version}"
-hostmakedepends="apache-ant openjdk8 unzip gradle"
-depends="virtual?java-runtime"
+hostmakedepends="apache-ant openjdk11 unzip gradle"
+depends="openjdk11-jre"
 short_desc="Application for Mind Mapping, Knowledge Management, Project Management"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-2.0-or-later"
 homepage="http://freeplane.sourceforge.net/"
 distfiles="https://github.com/freeplane/freeplane/archive/release-${version}.tar.gz"
-checksum=200002b5cbe3e3286a7595847d28356d3efd8498ff930fa05e5e90af622e544f
-broken="https://build.voidlinux.org/builders/x86_64_builder/builds/37505/steps/shell_3/logs/stdio"
+checksum=8c463c997675b0e351724673e9ca6357f4ef47bd9df0c49b73645090fb19cd7f
 
 make_dirs="
 /usr/share/freeplane/fwdir/condperm/ 755 root root


### PR DESCRIPTION
- didn't build with jdk8, so updated the makedep to 11
- didn't run with jdk17, so hard-coded jdk11 as the default

#### Testing the changes
- I tested the changes in this PR: **YES**

cc @thypon 