### PR TITLE
vscode: update to 1.69.0

### DIFF
--- a/srcpkgs/vscode/patches/fix_dir.patch
+++ b/srcpkgs/vscode/patches/fix_dir.patch
@@ -1,13 +1,13 @@
 diff --git a/resources/linux/bin/code.sh b/resources/linux/bin/code.sh
-index 06973937f14..78f72c9e9ed 100755
+index 5fe68cb4f3e..2f7eba7b9a3 100755
 --- a/resources/linux/bin/code.sh
 +++ b/resources/linux/bin/code.sh
-@@ -44,7 +44,7 @@ else
+@@ -53,7 +53,7 @@ else
  		VSCODE_PATH="$(dirname "$(readlink -f "$0")")/.."
  	else
  		# else use the standard install location
--		VSCODE_PATH="/usr/share/@@NAME@@"
-+		VSCODE_PATH="/usr/lib/@@NAME@@"
+-		VSCODE_PATH="/usr/share/@@APPNAME@@"
++		VSCODE_PATH="/usr/lib/@@APPNAME@@"
  	fi
  fi
  
@@ -25,7 +25,7 @@ index 7106e0e0969..faaff89d71c 100644
  Type=Application
  NoDisplay=true
 diff --git a/resources/linux/code.desktop b/resources/linux/code.desktop
-index ab3b79a011b..cdc88ef68a4 100755
+index 72488b67700..c16e815d59f 100755
 --- a/resources/linux/code.desktop
 +++ b/resources/linux/code.desktop
 @@ -2,7 +2,7 @@

--- a/srcpkgs/vscode/patches/product.patch
+++ b/srcpkgs/vscode/patches/product.patch
@@ -1,5 +1,5 @@
 diff --git a/product.json b/product.json
-index df18127dcc67..d3006752bd98 100644
+index a50c00f6cf3..8dd13191377 100644
 --- a/product.json
 +++ b/product.json
 @@ -27,7 +27,15 @@
@@ -9,7 +9,7 @@ index df18127dcc67..d3006752bd98 100644
 +	"quality": "stable",
 +	"documentationUrl": "https://github.com/microsoft/vscode-docs",
 +	"requestFeatureUrl": "https://github.com/Microsoft/vscode/issues",
- 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-webview.net/insider/181b43c0e2949e36ecb623d8cc6de29d4fa2bae8/out/vs/workbench/contrib/webview/browser/pre/",
+ 	"webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/3c8520fab514b9f56070214496b26ff68d1b1cb5/out/vs/workbench/contrib/webview/browser/pre/",
 +	"extensionsGallery": {
 +		"serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
 +		"cacheUrl": "https://vscode.blob.core.windows.net/gallery/index",
@@ -17,4 +17,4 @@ index df18127dcc67..d3006752bd98 100644
 +	},
  	"builtInExtensions": [
  		{
- 			"name": "ms-vscode.references-view",
+ 			"name": "ms-vscode.js-debug-companion",

--- a/srcpkgs/vscode/patches/ripgrep.patch
+++ b/srcpkgs/vscode/patches/ripgrep.patch
@@ -5,7 +5,7 @@ during build, which unbreaks build on platforms where MS deos not
 ship a prebuilt ripgrep.
 
 diff --git a/package.json b/package.json
-index de2cf9e04a9b..1995e3bb9a7e 100644
+index 39c3e9f5b10..198dbf3e421 100644
 --- a/package.json
 +++ b/package.json
 @@ -62,7 +62,7 @@
@@ -14,11 +14,11 @@ index de2cf9e04a9b..1995e3bb9a7e 100644
      "@vscode/iconv-lite-umd": "0.7.0",
 -    "@vscode/ripgrep": "^1.14.2",
 +    "@vscode/ripgrep": "https://github.com/atk/void-vscode-ripgrep.git",
-     "@vscode/sqlite3": "5.0.7",
+     "@vscode/sqlite3": "5.0.8",
      "@vscode/sudo-prompt": "9.3.1",
      "@vscode/vscode-languagedetection": "1.0.21",
 diff --git a/remote/package.json b/remote/package.json
-index c7fc7a2e931f..8842b784df2c 100644
+index 936aa5f5bab..152ba516795 100644
 --- a/remote/package.json
 +++ b/remote/package.json
 @@ -6,7 +6,7 @@

--- a/srcpkgs/vscode/template
+++ b/srcpkgs/vscode/template
@@ -1,18 +1,18 @@
 # Template file for 'vscode'
 pkgname=vscode
-version=1.66.2
+version=1.69.0
 revision=1
-_electronver=13.6.7
+_electronver=19.0.8
 _npmver=8.6.0
 hostmakedepends="pkg-config python3 nodejs yarn tar git ripgrep"
-makedepends="libxkbfile-devel libsecret-devel libxml2-devel ncurses-devel electron13"
-depends="libXtst ncurses nss dejavu-fonts-ttf xdg-utils ripgrep electron13"
+makedepends="libxkbfile-devel libsecret-devel libxml2-devel ncurses-devel electron19"
+depends="libXtst ncurses nss dejavu-fonts-ttf xdg-utils ripgrep electron19"
 short_desc="Microsoft Code for Linux"
 maintainer="shizonic <realtiaz@gmail.com>, Alex Lohr <alex.lohr@logmein.com>"
 license="MIT"
 homepage="https://code.visualstudio.com/"
-distfiles="https://github.com/Microsoft/vscode/archive/refs/tags/${version}.tar.gz"
-checksum=1b70f202b570763e85f67abd8693eeb9c88c6a066a4b579aca5c0c42ecb1b47f
+distfiles="https://github.com/microsoft/vscode/archive/refs/tags/${version}.tar.gz"
+checksum=982af5d93198b5437c3c211276c7b5fd7e3ecf19359c9605df2d6feddee93151
 nocross=yes # x64 build does not cut it, it contains native code
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
@@ -29,7 +29,7 @@ do_configure() {
 
 	# redirect telemetry urls to 0.0.0.0
 	# src: vscodium/undo_telemetry.sh
-	_TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)"
+	_TELEMETRY_URLS="(dc\.services\.visualstudio\.com)|(vortex\.data\.microsoft\.com)|(mobile\.events\.data\.microsoft\.com)"
 	_REPLACEMENT="s/$_TELEMETRY_URLS/0\.0\.0\.0/g"
 	grep -rl --exclude-dir=.git -E $_TELEMETRY_URLS | xargs sed -i -E $_REPLACEMENT
 


### PR DESCRIPTION
+ take care of new tracking server

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**, but one error was found: at the moment, the internal terminal does not work.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
