### PR TITLE
Signal-Desktop: update to 5.43.0, adopt.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=5.41.0
+version=5.43.0
 revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # discontinued Electron 32-bit support: https://www.electronjs.org/blog/linux-32bit-support
@@ -10,11 +10,11 @@ archs="x86_64"
 hostmakedepends="git git-lfs nodejs python3 tar yarn"
 depends="cairo gtk+3 libvips pango"
 short_desc="Signal Private Messenger for Linux"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=55a201912f5a41c1a76d210d3942078e734ac619df7ffb56083149ce4995e949
+checksum=9239dfc0356cec3c0aaea93e09d0ac44030037f24c1dcc3725e1e417c74af419
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture: **x86_64**