### PR TITLE
Revert "git: update to 2.36.0."

### DIFF
--- a/srcpkgs/git/template
+++ b/srcpkgs/git/template
@@ -1,7 +1,8 @@
 # Template file for 'git'
 pkgname=git
-version=2.36.0
-revision=1
+reverts="2.36.0_1"
+version=2.35.3
+revision=2
 hostmakedepends="asciidoc gettext perl pkg-config tk xmlto"
 makedepends="libglib-devel libcurl-devel libsecret-devel pcre2-devel tk-devel"
 # Required by https://
@@ -14,7 +15,7 @@ license="GPL-2.0-only"
 homepage="https://git-scm.com/"
 changelog="https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/${version}.txt"
 distfiles="https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz"
-checksum=af5ebfc1658464f5d0d45a2bfd884c935fb607a10cc021d95bc80778861cc1d3
+checksum=15e9db4f9bf2ed9fff30cb62a00c5c7c0901015f5ab048cdb4e8b04ddee00fa2
 replaces="git-perl>=0"
 register_shell=/usr/bin/git-shell
 python_version=3


### PR DESCRIPTION
This reverts commit 0a0487fc3090b5b96e507f4ee2019293f95dd0b3.

See: https://lore.kernel.org/git/xmqqlevfdbiq.fsf@gitster.g/

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!-- 
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
