### PR TITLE
mupdf: update to 1.19.1.

### DIFF
--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -1,6 +1,6 @@
 # Template file for 'mupdf'
 pkgname=mupdf
-version=1.19.0
+version=1.19.1
 revision=1
 wrksrc="${pkgname}-${version}-source"
 hostmakedepends="pkg-config zlib-devel libcurl-devel freetype-devel
@@ -14,8 +14,8 @@ short_desc="Lightweight PDF and XPS viewer"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://mupdf.com"
-distfiles="https://mupdf.com/downloads/archive/${pkgname}-${version}-source.tar.gz"
-checksum=21affcd4fcabf1cc7a896db95ba971552ba9df229ebec7720313a8803185deed
+distfiles="https://mupdf.com/downloads/archive/${pkgname}-${version}-source.tar.xz"
+checksum=b5eac663fe74f33c430eda342f655cf41fa73d71610f0884768a856a82e3803e
 
 pre_build() {
 	# libmupdf-{threads,pkcs7}.a are required by fbpdf


### PR DESCRIPTION
I also switched from a `tar.gz` tarball to a `tar.xz` one since it's
smaller in size (87 MB vs 62 MB).

#### Testing the changes
- I tested the changes in this PR: **briefly** (I tested the `mupdf` command on a PDF file)
