### PR TITLE
nvidia: update to 510.68.02.

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -3,8 +3,8 @@
 _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
-version=510.60.02
-revision=2
+version=510.68.02
+revision=1
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com/en-us/drivers/unix/"
@@ -15,11 +15,11 @@ repository="nonfree"
 create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
 hostmakedepends="tar"
-conflicts="xserver-abi-video>25_1"
+conflicts="xserver-abi-video>25_1 nvidia470>=0 nvidia390>=0"
 
 _pkg="NVIDIA-Linux-x86_64-${version}"
 distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
-checksum=a800dfc0549078fd8c6e8e6780efb8eee87872e6055c7f5f386a4768ce07e003
+checksum=bd2c344ac92b2fc12b06043590a4fe8d4eb0ccb74d0c49352f004cf2d299f4c5
 # subpackages need to be processed in this specific order
 subpackages="nvidia-gtklibs nvidia-dkms nvidia-opencl nvidia-libs nvidia-libs-32bit"
 depends="nvidia-libs-${version}_${revision}
@@ -279,6 +279,7 @@ do_install() {
 
 nvidia-gtklibs_package() {
 	short_desc="${_desc} - GTK+ libraries"
+	conflicts="nvidia470-gtklibs>=0 nvidia390-gtklibs>=0"
 	pkg_install() {
 		vmove "usr/lib/lib*gtk*.so*"
 	}
@@ -288,6 +289,7 @@ nvidia-libs-32bit_package() {
 	short_desc="${_desc} - common libraries (32bit)"
 	# manually set 32bit depends for libglvnd
 	depends="glibc-32bit>=0 libX11-32bit>=0 libXext-32bit>=0 libglvnd-32bit>=0"
+	conflicts="nvidia470-libs-32bit>=0 nvidia390-libs-32bit>=0"
 	repository="multilib/nonfree"
 	pkg_install() {
 		vmove usr/lib32
@@ -298,6 +300,7 @@ nvidia-libs_package() {
 	short_desc="${_desc} - common libraries"
 	depends="libglvnd"
 	nostrip_files="gsp.bin"
+	conflicts="nvidia470-libs>=0 nvidia390-libs>=0"
 	pkg_install() {
 		vmove usr/lib
 	}
@@ -309,6 +312,7 @@ nvidia-dkms_package() {
 	dkms_modules="nvidia ${version}"
 	# dkms must be before initramfs-regenerate to build modules before images
 	triggers="dkms initramfs-regenerate"
+	conflicts="nvidia470-dkms>=0 nvidia390-dkms>=0"
 
 	pkg_install() {
 		vmove usr/src
@@ -319,6 +323,7 @@ nvidia-dkms_package() {
 nvidia-opencl_package() {
 	short_desc="${_desc} - OpenCL implementation"
 	depends="ocl-icd"
+	conflicts="nvidia470-opencl>=0 nvidia390-opencl>=0"
 	pkg_install() {
 		vmove "usr/lib/libnvidia-compiler*"
 		vmove "usr/lib/libnvidia-opencl*"

--- a/srcpkgs/nvidia470/template
+++ b/srcpkgs/nvidia470/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers (GKxxx “Kepler”)"
 
 pkgname=nvidia470
 version=470.103.01
-revision=3
+revision=4
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com/en-us/drivers/unix/"
@@ -15,7 +15,7 @@ repository="nonfree"
 create_wrksrc=yes
 short_desc="${_desc} - Libraries and Utilities"
 hostmakedepends="tar"
-conflicts="xserver-abi-video>25_1"
+conflicts="xserver-abi-video>25_1 nvidia390>=0"
 
 _pkg="NVIDIA-Linux-x86_64-${version}"
 distfiles="http://uk.download.nvidia.com/XFree86/Linux-x86_64/${version}/${_pkg}.run"
@@ -263,6 +263,7 @@ do_install() {
 
 nvidia470-gtklibs_package() {
 	short_desc="${_desc} - GTK+ libraries"
+	conflicts="nvidia390-gtklibs>=0"
 	pkg_install() {
 		vmove "usr/lib/lib*gtk*.so*"
 	}
@@ -273,6 +274,7 @@ nvidia470-libs-32bit_package() {
 	# manually set 32bit depends for libglvnd
 	depends="glibc-32bit>=0 libX11-32bit>=0 libXext-32bit>=0 libglvnd-32bit>=0"
 	repository="multilib/nonfree"
+	conflicts="nvidia390-libs-32bit>=0"
 	pkg_install() {
 		vmove usr/lib32
 	}
@@ -282,6 +284,7 @@ nvidia470-libs_package() {
 	short_desc="${_desc} - common libraries"
 	depends="libglvnd"
 	nostrip_files="gsp.bin"
+	conflicts="nvidia390-libs>=0"
 	pkg_install() {
 		vmove usr/lib
 	}
@@ -293,6 +296,7 @@ nvidia470-dkms_package() {
 	dkms_modules="nvidia ${version}"
 	# dkms must be before initramfs-regenerate to build modules before images
 	triggers="dkms initramfs-regenerate"
+	conflicts="nvidia390-dkms>=0"
 
 	pkg_install() {
 		vmove usr/src
@@ -303,6 +307,7 @@ nvidia470-dkms_package() {
 nvidia470-opencl_package() {
 	short_desc="${_desc} - OpenCL implementation"
 	depends="ocl-icd"
+	conflicts="nvidia390-opencl>=0"
 	pkg_install() {
 		vmove "usr/lib/libnvidia-compiler*"
 		vmove "usr/lib/libnvidia-opencl*"


### PR DESCRIPTION

- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture: (x86_64-glibc)

Please test the update!  Nothing much on the Wayland front.


> Fixed an issue where NvFBC was requesting Vulkan 1.0 while using Vulkan 1.1 core features. This caused NvFBC to fail to initialize with Vulkan loader versions 1.3.204 or newer.