### PR TITLE
Vulkan: update to 1.3.212.

### DIFF
--- a/srcpkgs/Vulkan-Headers/template
+++ b/srcpkgs/Vulkan-Headers/template
@@ -1,6 +1,6 @@
 # Template file for 'Vulkan-Headers'
 pkgname=Vulkan-Headers
-version=1.2.182
+version=1.3.212
 revision=1
 build_style=cmake
 short_desc="Vulkan header files"
@@ -8,4 +8,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Headers/archive/v${version}.tar.gz"
-checksum=38d1c953de7bb2d839556226851feeb690f0d23bc22ac46c823dcb66c97bfdc8
+checksum=deea32809940711be36258e17ac887818f6261c96be27b24a1b82ac6718f0b2b

--- a/srcpkgs/vulkan-loader/template
+++ b/srcpkgs/vulkan-loader/template
@@ -1,6 +1,6 @@
 # Template file for 'vulkan-loader'
 pkgname=vulkan-loader
-version=1.2.182
+version=1.3.212
 revision=1
 wrksrc="Vulkan-Loader-${version}"
 build_style=cmake
@@ -14,4 +14,4 @@ maintainer="Arvin Ignaci <arvin.ignaci@gmail.com>"
 license="Apache-2.0"
 homepage="https://www.khronos.org/vulkan/"
 distfiles="https://github.com/KhronosGroup/Vulkan-Loader/archive/v${version}.tar.gz"
-checksum=0d1f9fde9d21642526e9baa55d30364c95035c4fe3c6db96836631991b44dd90
+checksum=70165622606ed8face4382a23cb8b4cf9dfa023001b01cbc286e0fa40b91047a


### PR DESCRIPTION
Contains `vulkan-loader` and `Vulkan-Headers`, as I was asked to put them in the same commit last time I made a PR like this. Does not include `Vulkan-ValidationLayers` or `Vulkan-Tools` as they did not build with a simple version change, and I do not understand Vulkan well enough to diagnose the issue.

#### Testing the changes
- I tested the changes in this PR: **briefly**

I played through about half a DOOM Eternal mission.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc