### PR TITLE
coin3: disable check_cxx_source_compiles, fix freecad for wayland

### DIFF
--- a/srcpkgs/coin3/patches/disable-check_cxx_source_compiles.patch
+++ b/srcpkgs/coin3/patches/disable-check_cxx_source_compiles.patch
@@ -1,0 +1,20 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -586,11 +586,11 @@ if(NOT (HAVE_WGL OR HAVE_AGL OR HAVE_CGL
+     list(APPEND COIN_TARGET_LINK_LIBRARIES OpenGL::GLX)
+   endif()
+   set(CMAKE_REQUIRED_LIBRARIES ${COIN_TARGET_LINK_LIBRARIES})
+-  check_cxx_source_compiles("
+-    #include <GL/gl.h>
+-    #include <GL/glx.h>
+-    int main() { (void)glXChooseVisual(0L, 0, 0L); glEnd(); return 0; }
+-  " HAVE_GLX)
++#  check_cxx_source_compiles("
++#    #include <GL/gl.h>
++#    #include <GL/glx.h>
++#    int main() { (void)glXChooseVisual(0L, 0, 0L); glEnd(); return 0; }
++#  " HAVE_GLX)
+ endif()
+
+ # Checks specific OpenGL configurations
+

--- a/srcpkgs/coin3/template
+++ b/srcpkgs/coin3/template
@@ -1,7 +1,7 @@
 # Template file for 'coin3'
 pkgname=coin3
 version=4.0.0
-revision=2
+revision=3
 wrksrc="coin-Coin-${version}"
 build_style=cmake
 configure_args="-DCMAKE_INSTALL_INCLUDEDIR=include/Coin3


### PR DESCRIPTION
- fix FreeCAD for wayland (#14626). patch from:
  https://forum.freecadweb.org/viewtopic.php?p=354412&sid=85ff490ba28d18686795d961cf062754#p354412
- previously @paper42 using Gnome Wayland also had the same error.
  https://github.com/void-linux/void-packages/issues/30515#issuecomment-826906957

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

![Screenshot_20220508_051800](https://user-images.githubusercontent.com/45872139/167273542-692606d3-04db-46cf-9c22-c5b24853ad24.png)

