### PR TITLE
common/build-style/cargo.sh: use offline install

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -20,7 +20,7 @@ do_install() {
 	: ${make_install_args:=--path .}
 
 	${make_cmd} install --target ${RUST_TARGET} --root="${DESTDIR}/usr" \
-		--locked ${configure_args} ${make_install_args}
+		--offline --locked ${configure_args} ${make_install_args}
 
 	rm -f "${DESTDIR}"/usr/.crates.toml
 	rm -f "${DESTDIR}"/usr/.crates2.json


### PR DESCRIPTION
This prevents `cargo install` from wasting time fetching the crate registry.

[CI skip]

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
