### PR TITLE
erlang: switch to wxWidgets-gtk3

### DIFF
--- a/srcpkgs/erlang/template
+++ b/srcpkgs/erlang/template
@@ -1,7 +1,7 @@
 # Template file for 'erlang'
 pkgname=erlang
 version=24.3.4
-revision=1
+revision=2
 create_wrksrc=yes
 build_wrksrc="otp-OTP-${version}"
 build_style=gnu-configure
@@ -18,8 +18,8 @@ checksum=e59bedbb871af52244ca5284fd0a572d52128abd4decf4347fe2aef047b65c58
 subpackages="erlang-doc"
 
 if [ -z "$CROSS_BUILD" ]; then
-	configure_args+=" --with-wx-config=wx-config-3.0"
-	makedepends+=" wxWidgets-devel glu-devel"
+	configure_args+=" --with-wx-config=wx-config-gtk3"
+	makedepends+=" wxWidgets-gtk3-devel glu-devel"
 	subpackages+=" erlang-wx"
 fi
 


### PR DESCRIPTION


#### Testing the changes
- I tested the changes in this PR: **briefly** (https://github.com/elixir-desktop/desktop-example-app)

- I built this PR locally for my native architecture, (x86_64-glibc)

This package seems to have been missed by #2664

As an aside, `kerl`/`asdf-erlang` needed `KERL_CONFIGURE_OPTIONS=--with-wx-config=wx-config-gtk3` for wxWebView to work. Not sure where that should be fixed/documented