### PR TITLE
slirp4netns

### DIFF
--- a/srcpkgs/libslirp/template
+++ b/srcpkgs/libslirp/template
@@ -1,6 +1,6 @@
 # Template file for 'libslirp'
 pkgname=libslirp
-version=4.6.1
+version=4.7.0
 revision=1
 wrksrc="libslirp-v${version}"
 build_style=meson
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://gitlab.freedesktop.org/slirp/libslirp"
 changelog="https://gitlab.freedesktop.org/slirp/libslirp/-/blob/master/CHANGELOG.md"
 distfiles="https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v${version}/libslirp-v${version}.tar.gz"
-checksum=69ad4df0123742a29cc783b35de34771ed74d085482470df6313b6abeb799b11
+checksum=9398f0ec5a581d4e1cd6856b88ae83927e458d643788c3391a39e61b75db3d3b
 
 pre_configure() {
 	printf '%s\n' "${version}" > .tarball-version

--- a/srcpkgs/slirp4netns/template
+++ b/srcpkgs/slirp4netns/template
@@ -1,6 +1,6 @@
 # Template file for 'slirp4netns'
 pkgname=slirp4netns
-version=1.1.12
+version=1.2.0
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake pkg-config"
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="GPL-2.0-only"
 homepage="https://github.com/rootless-containers/slirp4netns"
 distfiles="https://github.com/rootless-containers/slirp4netns/archive/v${version}.tar.gz"
-checksum=279dfe58a61b9d769f620b6c0552edd93daba75d7761f7c3742ec4d26aaa2962
+checksum=b584edde686d3cfbac210cbdb93c4b0ba5d8cc0a6a4d92b9dfc3c5baec99c727
 # tests fail due to use of unshare (unavailable with chroot util-linux)
 make_check=no
 


### PR DESCRIPTION
- libslirp: update to 4.7.0
- slirp4netns: update to 1.2.0

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86\_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86\_64-musl
  - aarch64 (cross)
  - aarch64-musl (cross)
