### PR TITLE
ipe: Add qt5-svg to depends

### DIFF
--- a/srcpkgs/ipe/template
+++ b/srcpkgs/ipe/template
@@ -6,6 +6,7 @@ _tools_commit=v7.2.20.1
 hostmakedepends="pkg-config doxygen qt5-qmake qt5-tools qt5-host-tools"
 makedepends="cairo-devel gsl-devel libcurl-devel libjpeg-turbo-devel
  lua53-devel poppler-devel qt5-devel libspiro-devel"
+depends="qt5-svg"
 short_desc="Drawing editor for creating figures in PDF or EPS formats"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
Icons in toolbars (and possibly elsewhere) are not displayed without qt5-svg being present.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - Not supported.
