### PR TITLE
python3-chardet: fix split with python2 pkg, revbump

### DIFF
--- a/srcpkgs/python3-chardet/template
+++ b/srcpkgs/python3-chardet/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-chardet'
 pkgname=python3-chardet
 version=4.0.0
-revision=3
+revision=4
 wrksrc="chardet-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools"
+depends="python3"
 checkdepends="python3-pytest"
 short_desc="Universal encoding detector"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
@@ -13,4 +13,4 @@ license="LGPL-2.1-only"
 homepage="https://github.com/chardet/chardet"
 distfiles="${PYPI_SITE}/c/chardet/chardet-${version}.tar.gz"
 checksum=0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
-alternatives="chardet:chardetect:/usr/bin/chardetect2"
+conflicts="python-chardet"


### PR DESCRIPTION
The current template is broken, and won't build a working package. Currently all works, just because there wasn't a revbump since the split.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, **x86_64-glibc**

I tested an update from the previous rev to this, there were no problems with the alternatives.
Also, as the python2 pkg still exists in the repos, I made them `conflict` to ensure there won't be any strange behaviour with alts. 