### PR TITLE
lazydocker: update to 0.18.1

### DIFF
--- a/srcpkgs/lazydocker/template
+++ b/srcpkgs/lazydocker/template
@@ -1,17 +1,18 @@
 # Template file for 'lazydocker'
 pkgname=lazydocker
-version=0.13
+version=0.18.1
 revision=1
 wrksrc="lazydocker-${version}"
 build_style=go
 go_import_path=github.com/jesseduffield/lazydocker
+go_ldflags="-X main.version=${version}"
 depends="docker docker-compose"
 short_desc="Simple terminal UI for docker and docker-compose, written in Go"
 maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="MIT"
 homepage="https://github.com/jesseduffield/lazydocker"
 distfiles="https://github.com/jesseduffield/lazydocker/archive/v${version}.tar.gz"
-checksum=4328ddcb3156ff57c1e21c0d2f9d9d67d48237a386d338f1d68831b6056dfe3e
+checksum=f5081b846d530818e1f04b9e8479c801f287ac77ebdf063425a142ff50fc395b
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64 libc