### PR TITLE
pijul: update to 1.0.0-beta.2

### DIFF
--- a/srcpkgs/pijul/patches/bindgen.patch
+++ b/srcpkgs/pijul/patches/bindgen.patch
@@ -1,9 +1,0 @@
---- a/Cargo.toml
-+++ b/Cargo.toml
-@@ -133,3 +133,6 @@
- version = "2.0"
- [target."cfg(unix)".dependencies.tokio-uds]
- version = "0.2"
-+
-+[patch.crates-io]
-+"sequoia-rfc2822" = {path = '/builddir/sequoia-v0.9.0/rfc2822'}

--- a/srcpkgs/pijul/template
+++ b/srcpkgs/pijul/template
@@ -1,19 +1,17 @@
 # Template file for 'pijul'
 pkgname=pijul
-version=0.12.2
-revision=5
+version=1.0.0-beta.2
+revision=1
 build_style=cargo
 _sequoia_ver=0.9.0
 hostmakedepends="pkg-config clang"
-makedepends="libsodium-devel openssl-devel nettle-devel"
+makedepends="libgcc-devel openssl-devel libsodium-devel libzstd-devel xxHash-devel"
 short_desc="Distributed version control system based on patches"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://pijul.org/"
-distfiles="https://crates.io/api/v1/crates/pijul/${version}/download>pijul-${version}.tar.gz
- https://gitlab.com/sequoia-pgp/sequoia/-/archive/v${_sequoia_ver}/sequoia-v${_sequoia_ver}.tar.gz"
-checksum="f92a3f4063e780ca45c161ceb0f42baf34dfeddf3359ebf6c2e0442d9abb5889
- 71823c88b9666611f3cfa6b1d923bd66fda92fa6a53368b195bd2f962fdf7f4b"
+distfiles="https://crates.io/api/v1/crates/pijul/${version}/download>pijul-${version}.tar.gz"
+checksum="9e0870af813cdab0a8f8f3687f545714fc0f6aeee47a2447bea3bf3ce6706dc5"
 
 # We only want to install the binary, so don't run cargo install
 do_install() {


### PR DESCRIPTION
This PR updates pijul from 0.12.2 to 1.0.0-beta.2, preparing for 1.0.0.

But since it seems there was non-[backward-compatible](https://pijul.org/posts/2021-06-28-two-changes/) [format change](https://pijul.org/posts/2021-01-05-how-to-survive/) since 0.12.2 and [1.0.0-beta guarantees format stability](https://pijul.org/posts/2022-01-08-beta/), this could be better than current version for future compatibility. 

#### Testing the changes
- I tested the changes in this PR: **briefly**
#### Local build testing