### PR TITLE
New package: glfw-wayland-devel-3.3.7

### DIFF
--- a/srcpkgs/glfw-wayland-devel
+++ b/srcpkgs/glfw-wayland-devel
@@ -1,0 +1,1 @@
+glfw-wayland

--- a/srcpkgs/glfw-wayland/template
+++ b/srcpkgs/glfw-wayland/template
@@ -18,8 +18,15 @@ checksum=fd21a5f65bcc0fc3c76e0f8865776e852de09ef6fbc3620e09ce96d2b2807e04
 provides="glfw-${version}_${revision}"
 replaces="glfw>=0"
 
-do_install() {
-	vmkdir usr/lib
-	install -m755 ${wrksrc}/build/src/libglfw.so.${version%.*} ${DESTDIR}/usr/lib/
-	ln -s libglfw.so.${version%.*} ${DESTDIR}/usr/lib/libglfw.so.3
+glfw-wayland-devel_package() {
+	replaces="glfw-devel>=0"
+	provides="glfw-devel-${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} $makedepends"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove /usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
 }


### PR DESCRIPTION
Executables built with the current glfw-devel links with the default
glfw library and works on X11 only. This package replaces the glfw-devel
package files with the wayland-compatible files, so the executable links
with the wayland-compatible glfw libraries provided by glfw-wayland.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
