### PR TITLE
linux-firmware: update to 20221109

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,6 +1,6 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
-version=20220411
+version=20221109
 revision=1
 depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
@@ -8,7 +8,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="See /usr/share/licenses/${pkgname}"
 homepage="https://www.kernel.org/"
 distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=533ae621b3eacf6a4696dab52a9dbc5727403a175c413b1682ab3f9cfb37872f
+checksum=c23299426d190986ba6eb52a3b22c4e4383b3a055903ff3967fb17afad3edb9b
 python_version=3
 nostrip=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
