### PR TITLE
runc: update to 1.1.2

### DIFF
--- a/srcpkgs/runc/template
+++ b/srcpkgs/runc/template
@@ -1,6 +1,6 @@
 # Template file for 'runc'
 pkgname=runc
-version=1.1.1
+version=1.1.2
 revision=1
 build_style=go
 go_import_path=github.com/opencontainers/runc
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/opencontainers/runc"
 distfiles="https://github.com/opencontainers/runc/releases/download/v${version}/runc.tar.xz"
-checksum=75c1f0bb19b209412c52599e24b33ac306cf7caf772c97577b7ebe964837a54b
+checksum=78ad532465ce4c2802480644a8756c30ae99c1bf779f0243af4bca11c4d041de
 
 post_build() {
 	make man


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Fixes CVE-2022-29162

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
