### PR TITLE
opkg: update to 0.5.0.

### DIFF
--- a/srcpkgs/opkg/template
+++ b/srcpkgs/opkg/template
@@ -1,10 +1,10 @@
 # Template file for 'opkg'
 pkgname=opkg
-version=0.4.5
+version=0.5.0
 revision=1
 build_style=gnu-configure
 configure_args="--enable-sha256 --without-libsolv --with-static-libopkg
- $(vopt_if ssl '--enable-openssl --enable-ssl-curl') $(vopt_enable gpg)"
+ $(vopt_if ssl ' --enable-ssl-curl') $(vopt_enable gpg) --enable-zstd"
 hostmakedepends="pkg-config libtool automake"
 makedepends="libarchive-devel libcurl-devel $(vopt_if gpg gpgme-devel)"
 checkdepends="python3"
@@ -13,7 +13,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-2.0-or-later"
 homepage="http://code.google.com/p/opkg/"
 distfiles="https://downloads.yoctoproject.org/releases/opkg/opkg-${version}.tar.gz"
-checksum=a1214a75fa34fb9228db8da47308e0e711b1c93fd8938cf164c10fd28eb50f1e
+checksum=559c3e1b893abaa1dd473ce3a9a5f7dd3f60ceb6cd14caaef76ddf0f7721ad1c
 
 build_options="gpg lz4 ssl"
 build_options_default="ssl"


### PR DESCRIPTION
Also:
- remove --enable-openssl, as it is automatically enabled with
 --enable-ssl-curl and is not used anymore.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@Piraty 

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
