### PR TITLE
Update tmuxp and libtmux

### DIFF
--- a/srcpkgs/python3-libtmux/template
+++ b/srcpkgs/python3-libtmux/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-libtmux'
 pkgname=python3-libtmux
-version=0.10.3
+version=0.11.0
 revision=1
 wrksrc="libtmux-${version}"
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
 license="MIT"
 homepage="https://github.com/tmux-python/libtmux"
 distfiles="${PYPI_SITE}/l/libtmux/libtmux-${version}.tar.gz"
-checksum=c7fbd837f0a9e4d33a157523e4ca6ef95e80256842e094ffd766c3dbd78d1957
+checksum=d82cf391097eb69d784d889d482bb99284b984aa6225276a3dc1af8c1460dd3c
 # Disable check which uses pip to pull external python packages
 make_check=no
 

--- a/srcpkgs/python3-tmuxp/template
+++ b/srcpkgs/python3-tmuxp/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-tmuxp'
 pkgname=python3-tmuxp
-version=1.9.4
+version=1.10.1
 revision=1
 wrksrc="tmuxp-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
 license="MIT"
 homepage="https://github.com/tmux-python/tmuxp/"
 distfiles="${PYPI_SITE}/t/tmuxp/tmuxp-${version}.tar.gz"
-checksum=4d7e748d58972736438b6d1299798808048e3e4649300abe6e46d285938b1b0e
+checksum=7ac9556d3a92cedf703846532e5ae8004f1c37731d686a54b046fa01f38b7c92
 conflicts="python-tmuxp>=0"
 
 do_check() {


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64,glibc)

Note: tmuxp cannot be updated to v1.11.1 because it depends on click v8.