### PR TITLE
New package: giara-1.0.1

### DIFF
--- a/srcpkgs/giara/template
+++ b/srcpkgs/giara/template
@@ -1,0 +1,15 @@
+# Template file for 'giara'
+pkgname=giara
+version=1.0.1
+revision=1
+build_style=meson
+hostmakedepends="pkg-config gettext blueprint-compiler glib-devel"
+makedepends="gtk4-devel libadwaita-devel libgirepository-devel"
+depends="python3-Pillow python3-praw python3-mistune2 python3-BeautifulSoup4
+ gtksourceview5"
+short_desc="Reddit app with mobile Linux in mind"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="GPL-3.0-or-later"
+homepage="https://gitlab.gnome.org/World/giara"
+distfiles="https://gitlab.gnome.org/World/giara/-/archive/${version}/giara-${version}.tar.gz"
+checksum=fc38e2cec5315e0abaeb1053b18984e7ded5526f026b435a799d63870a1e4c36

--- a/srcpkgs/python3-betamax-serializers/template
+++ b/srcpkgs/python3-betamax-serializers/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-betamax-serializers'
+pkgname=python3-betamax-serializers
+version=0.2.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-betamax"
+checkdepends="${depends} python3-yaml"
+short_desc="Serializers for betamax that may eventually be included in betamax"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0"
+homepage="https://gitlab.com/betamax/serializers"
+changelog="https://gitlab.com/betamax/serializers/-/raw/master/HISTORY.rst"
+distfiles="${PYPI_SITE}/b/betamax-serializers/betamax-serializers-${version}.tar.gz"
+checksum=345c419b1b73171f2951c62ac3c701775ac4b76e13e86464ebf0ff2a978e4949

--- a/srcpkgs/python3-praw/template
+++ b/srcpkgs/python3-praw/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-praw'
+pkgname=python3-praw
+version=7.6.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-prawcore python3-websocket-client"
+checkdepends="${depends} python3-betamax python3-betamax-matchers"
+short_desc="Python Reddit API Wrapper"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="BSD-2-Clause"
+homepage="https://praw.readthedocs.io/en/stable/"
+changelog="https://raw.githubusercontent.com/praw-dev/praw/master/CHANGES.rst"
+distfiles="${PYPI_SITE}/p/praw/praw-${version}.tar.gz"
+checksum=07fc95ffc52187351ab77b81fa6910c66e8fa084faf4b060b90864ad186dfb9e
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-prawcore/template
+++ b/srcpkgs/python3-prawcore/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-prawcore'
+pkgname=python3-prawcore
+version=2.3.0
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-requests"
+checkdepends="${depends} python3-betamax python3-betamax-matchers
+ python3-betamax-serializers python3-mock python3-pytest python3-testfixtures"
+short_desc="Low-level communication layer for PRAW 4+"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="BSD-2-Clause"
+homepage="https://github.com/praw-dev/prawcore"
+changelog="https://raw.githubusercontent.com/praw-dev/prawcore/main/CHANGES.rst"
+distfiles="${PYPI_SITE}/p/prawcore/prawcore-${version}.tar.gz"
+checksum=daf1ccd4b7a80dc4e6567d48336d782e94a9a6dad83770fc2edf76dc9a84f56d
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-testfixtures/template
+++ b/srcpkgs/python3-testfixtures/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-testfixtures'
+pkgname=python3-testfixtures
+version=7.0.3
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Collection of helpers and mock objects for automated tests in Python"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://github.com/Simplistix/testfixtures"
+changelog="https://raw.githubusercontent.com/simplistix/testfixtures/master/CHANGELOG.rst"
+distfiles="${PYPI_SITE}/t/${pkgname/python3-/}/${pkgname/python3-/}-${version}.tar.gz"
+checksum=942bc751d45068658e11277f213ce1868476e141ea4240da0fb6712ae6f96401
+# Requires django and twisted just for running tests
+make_check=no
+
+post_install() {
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Follow up to #28453, which I've discovered after I had already packaged everything and was looking into mistune acting up at runtime. I agree with the sentiment that the packaging is a fragile pita, but with nearly everything in here not having the checks disabled now, I'm a bit more confident that this is actually fine.

One thing that should probably be done here is updating mistune again, because there's a stable 2.0.2 release now, which has also been updated in https://github.com/jupyter/nbconvert/pull/1764, which probably means we can update `python3-mistune` to 2.0.2 once `python3-jupyter_nbconvert` has its next stable release. The 7.0.0-rc.1 has been released 5 days ago after the mistune update had been merged.
