### PR TITLE
dolphin: fix typo version

### DIFF
--- a/srcpkgs/dolphin/template
+++ b/srcpkgs/dolphin/template
@@ -1,6 +1,6 @@
 # Template file for 'dolphin'
 pkgname=dolphin
-version=21.04.1
+version=22.04.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -15,7 +15,7 @@ license="GPL-2.0-or-later, GFDL-1.2-or-later"
 homepage="https://kde.org/applications/en/system/org.kde.dolphin"
 changelog="https://kde.org/announcements/changelogs/gear/${version}/#dolphin"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=292377aca0454189186d4046ed69785d7fda672270362c3b538a001c9daa826e
+checksum=9cf51ac21ffc3d12a919e99cca80f3bb14741eed2a3af54b4499332ccd979a7b
 
 if [ "$CROSS_BUILD" ]; then
 	LDFLAGS=" -Wl,-rpath-link,../bin"


### PR DESCRIPTION
update to 22.04.1

#### Testing the changes
- I tested the changes in this PR: **briefly**