### PR TITLE
pipewire: add pulseaudio-utils to dependencies

### DIFF
--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,7 +1,7 @@
 # Template file for 'pipewire'
 pkgname=pipewire
 version=0.3.51
-revision=1
+revision=2
 _pms_version=0.4.1
 build_style=meson
 configure_args="
@@ -24,7 +24,8 @@ makedepends="$(vopt_if sdl2 SDL2-devel) gst-plugins-base1-devel jack-devel
  readline-devel openssl-devel lilv-devel libcanberra-devel dbus-devel"
 depends="libspa-alsa>=${version}_${revision} libspa-audioconvert>=${version}_${revision}
  libspa-audiomixer>=${version}_${revision} libspa-control>=${version}_${revision}
- libspa-v4l2>=${version}_${revision}"
+ libspa-v4l2>=${version}_${revision} pulseaudio-utils"
+checkdepends="pulseaudio-utils"
 short_desc="Server and user space API to deal with multimedia pipelines"
 maintainer="Stefano Ragni <stefano.ragni@outlook.com>"
 license="MIT"


### PR DESCRIPTION

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

* runtime dependency - pipewire-pulse runs "pactl load-module module-always-sink"
* optional check dependency

@st3r4g

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
