### PR TITLE
cni updates and new cni-plugin-dnsname package

### DIFF
--- a/srcpkgs/cni-plugin-dnsname/template
+++ b/srcpkgs/cni-plugin-dnsname/template
@@ -1,0 +1,24 @@
+# Template file for 'cni-plugin-dnsname'
+pkgname=cni-plugin-dnsname
+version=1.3.1
+revision=1
+wrksrc="dnsname-${version}"
+build_style=go
+go_import_path="github.com/containers/dnsname"
+go_package="${go_import_path}/plugins/meta/dnsname"
+depends="dnsmasq"
+short_desc="Name resolution for containers"
+maintainer="Cameron Nemo <cnemo@tutanota.com>"
+license="Apache-2.0"
+homepage="https://github.com/containers/dnsname"
+changelog="https://github.com/containers/dnsname/blob/main/RELEASE_NOTES.md"
+distfiles="https://github.com/containers/dnsname/archive/v${version}.tar.gz"
+checksum=a9319a1829e242b4769697650f7df63a635eda7369ba659618d49056b78bf3ce
+
+post_install() {
+	vmkdir usr/libexec/cni
+	mv "${DESTDIR}/usr/bin/dnsname" "${DESTDIR}/usr/libexec/cni/dnsname"
+	vdoc README.md
+	vdoc README_PODMAN.md
+	vsconf example/foobar.conflist
+}

--- a/srcpkgs/cni-plugins/template
+++ b/srcpkgs/cni-plugins/template
@@ -1,6 +1,6 @@
 # Template file for 'cni-plugins'
 pkgname=cni-plugins
-version=1.0.1
+version=1.1.1
 revision=1
 wrksrc="plugins-${version}"
 build_style=go
@@ -10,7 +10,7 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containernetworking/plugins"
 distfiles="https://github.com/containernetworking/plugins/archive/v${version}.tar.gz"
-checksum=2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619
+checksum=c86c44877c47f69cd23611e22029ab26b613f620195b76b3ec20f589367a7962
 
 do_build() {
 	./build_linux.sh

--- a/srcpkgs/cni/template
+++ b/srcpkgs/cni/template
@@ -1,6 +1,6 @@
 # Template file for 'cni'
 pkgname=cni
-version=0.8.0
+version=1.0.1
 revision=1
 build_style=go
 go_import_path="github.com/containernetworking/cni"
@@ -10,4 +10,4 @@ maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containernetworking/cni"
 distfiles="https://github.com/containernetworking/cni/archive/v${version}.tar.gz"
-checksum=df8afe3eeae3296ba33ca267041c42f13135c3a067bf2d932761bb02998247a6
+checksum=0e5376f70fb36c26935ddfb90b0da69736592ba8b577fbfb904750034c053d3b


### PR DESCRIPTION
- cni: update to 1.0.1.
- cni-plugins: update to 1.1.1.
- New package: cni-plugin-dnsname-1.3.1

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
