### PR TITLE
CI: cancel previous runs on re-push, update to ubuntu-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
   # Lint changed templates.
   xlint:
     name: Lint templates
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
@@ -34,7 +34,7 @@ jobs:
   # Build changed packages.
   build:
     name: Build packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, '[ci skip]') && !contains(github.event.pull_request.body, '[ci skip]')"
 
     container:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,10 @@ on:
     paths:
       - 'srcpkgs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Lint changed templates.
   xlint:


### PR DESCRIPTION
- .github/workflows/build.yaml: switch to ubuntu-latest
- .github/workflows/build.yaml: auto-cancel in-progress workflows

follow-on to stale-closed #28481

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
  Confirmed that re-pushing cancelled the older run, as expected
![image](https://user-images.githubusercontent.com/5366828/168865143-12a319e8-d8d7-4954-8ecb-f4041a7495d6.png)
