### PR TITLE
openssl: update to 1.1.1o

### DIFF
--- a/srcpkgs/openssl/template
+++ b/srcpkgs/openssl/template
@@ -1,6 +1,6 @@
 # Template file for 'openssl'
 pkgname=openssl
-version=1.1.1n
+version=1.1.1o
 revision=1
 bootstrap=yes
 build_style=configure
@@ -17,7 +17,7 @@ maintainer="John <johnz@posteo.net>"
 license="OpenSSL"
 homepage="https://www.openssl.org"
 distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
-checksum=40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
+checksum=9384a2b0570dd80358841464677115df785edb941c71211f75076d72fe6b438f
 conf_files="/etc/ssl/openssl.cnf"
 replaces="libressl>=0"
 


### PR DESCRIPTION
It builds fine on `x86_64 musl`, where only `test/recipes/01-test_symbol_presence.t` has two failures; they do not seem relevant, though.