### PR TITLE
socat: fix spurious spacing in man page

### DIFF
--- a/srcpkgs/socat/patches/socat.1.patch
+++ b/srcpkgs/socat/patches/socat.1.patch
@@ -1,0 +1,680 @@
+Remove stray newlines from manpage.
+Stray newlines affect the formatting of the manpage rendered by mandoc.
+
+--- a/doc/socat.1
++++ b/doc/socat.1
+@@ -1,5 +1,4 @@
+ .TH "socat" "1" "" "" ""
+-
+ .PP 
+ .SH "NAME"
+ socat \- Multipurpose relay (SOcket CAT)
+@@ -16,7 +15,6 @@
+ \f(CWprocan\fP
+ .PP 
+ .SH "DESCRIPTION"
+-
+ .PP 
+ \fBSocat\fP is a command line based utility that establishes two bidirectional byte
+ streams and transfers data between them\&. Because the streams can be constructed
+@@ -60,7 +58,6 @@
+ the other direction, but then closes all remaining channels and terminates\&.
+ .PP 
+ .SH "OPTIONS"
+-
+ .PP 
+ \fBSocat\fP provides some command line options that modify the behaviour of the
+ program\&. They have nothing to do with so called
+@@ -178,10 +175,8 @@
+ .IP "\fB\f(CW\-6\fP\fP"
+ Use IP version 6 in case that the addresses do not implicitly or explicitly
+ specify a version\&.
+-
+ .PP 
+ .SH "ADDRESS SPECIFICATIONS"
+-
+ .PP 
+ With the address command line arguments, the user gives \fBsocat\fP instructions and
+ the necessary information for establishing the byte streams\&. 
+@@ -235,7 +230,6 @@
+ specially\&. All those characters and strings can be escaped with \e or within \(dq\&\(dq\&
+ .PP 
+ .SH "ADDRESS TYPES"
+-
+ .PP 
+ This section describes the available address types with their keywords,
+ parameters, and semantics\&.
+@@ -383,7 +377,6 @@
+ .br 
+ Option groups: FD,SOCKET,IP6 
+ .br 
+-
+ .IP 
+ .IP "\fB\f(CWIP\-DATAGRAM:<address>:<protocol>\fP\fP"
+ Sends outgoing data to the specified address which may in particular be a
+@@ -429,7 +422,6 @@
+ .br 
+ Option groups: FD,SOCKET,IP6,RANGE 
+ .br 
+-
+ .IP 
+ .IP "\fB\f(CWIP\-RECVFROM:<protocol>\fP\fP"
+ Opens a raw IP socket of <protocol>\&. Depending on option pf, IP protocol version
+@@ -474,7 +466,6 @@
+ .br 
+ Option groups: FD,SOCKET,IP6,CHILD,RANGE 
+ .br 
+-
+ .IP 
+ .IP "\fB\f(CWIP\-RECV:<protocol>\fP\fP"
+ Opens a raw IP socket of <protocol>\&. Depending on option pf, IP protocol version
+@@ -507,7 +498,6 @@
+ .br 
+ Option groups: FD,SOCKET,IP6,RANGE 
+ .br 
+-
+ .IP 
+ .IP "\fB\f(CWOPEN:<filename>\fP\fP"
+ Opens <filename> using the 
+@@ -1613,10 +1603,8 @@
+ prefixed with \(dq\&\e0\(dq\& internally\&. This feature is available (only?) on Linux\&.
+ Option groups are the same as with the related UNIX addresses, except that
+ the ABSTRACT addresses are not member of the NAMED group\&.
+-
+ .PP 
+ .SH "ADDRESS OPTIONS"
+-
+ .PP 
+ Address options can be applied to address specifications to influence the
+ process of opening the addresses and the 
+@@ -1677,10 +1665,8 @@
+ names, alias names, option phases, and platforms see file \fBxio\&.help\fP\&. 
+ .br 
+ .br 
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBFD option group\fP\fP
+ .PP 
+@@ -1914,10 +1900,8 @@
+ Calls \f(CWioctl()\fP with the request value as second argument and a pointer to
+ the given string as third argument\&.
+ <dalan> form\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBNAMED option group\fP\fP
+ .PP 
+@@ -1967,10 +1951,8 @@
+ the default is 1; for created files,
+ opened files, and
+ generic opened files the default is 0\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBOPEN option group\fP\fP
+ .PP 
+@@ -2017,10 +1999,8 @@
+ Opens the file for writing only\&.
+ .IP "\fB\f(CWtrunc\fP\fP"
+ Truncates the file to size 0 during opening it\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBREG and BLK option group\fP\fP
+ .PP 
+@@ -2079,10 +2059,8 @@
+ successors, xfs, or reiserfs\&. See man 1 chattr for information on these
+ options\&. Please note that there might be a race condition between creating
+ the file and applying these options\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBPROCESS option group\fP\fP
+ .PP 
+@@ -2132,10 +2110,8 @@
+ process group\&. 
+ .IP "\fB\f(CWsetsid\fP\fP"
+ Makes the process the leader of a new session (example)\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBREADLINE option group\fP\fP
+ .PP 
+@@ -2161,10 +2137,8 @@
+ prompt when stepping through the history\&. If this string matches a constant
+ prompt issued by an interactive program on the other socat address,
+ consistent look and feel can be achieved\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBAPPLICATION option group\fP\fP
+ .PP 
+@@ -2196,10 +2170,8 @@
+ Specifies the numeric code of a character that triggers EOF on the input
+ stream\&. It is useful with a terminal in raw mode
+ (example)\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBSOCKET option group\fP\fP
+ .PP 
+@@ -2323,10 +2295,8 @@
+ Like \f(CWsetsockopt\fP, but <optval> is a string\&.
+ This string is passed to the function with trailing null character, and the
+ length parameter is automatically derived from the data\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBUNIX option group\fP\fP
+ .PP 
+@@ -2337,7 +2307,6 @@
+ \f(CWstruct sockaddr_un\fP
+ record but (besides other components) only
+ the relevant part of the filename or abstract string\&. Default is 1\&.
+-
+ .PP 
+ \fI\fBIP4 and IP6 option groups\fP\fP
+ .PP 
+@@ -2429,7 +2398,6 @@
+ address they are applied to\&.
+ .IP 
+ .br 
+-
+ .PP 
+ \fI\fBIP6 option group\fP\fP
+ .PP 
+@@ -2464,10 +2432,8 @@
+ .IP "\fB\f(CWipv6\-recvtclass\fP\fP"
+ Sets the IPV6_RECVTCLASS socket option\&. This enables receiving and logging
+ of ancillary messages containing the transfer class\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBTCP option group\fP\fP
+ .PP 
+@@ -2536,10 +2502,8 @@
+ .IP "\fB\f(CWtsoptena\fP\fP"
+ Enables the time stamp option that allows RTT recalculation on existing
+ connections (Tru64)\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBUDP option group\fP\fP
+ .PP 
+@@ -2549,10 +2513,8 @@
+ Address UDP\-DATAGRAM expects incoming responses to come from the port
+ specified in its second parameter\&. With this option, it accepts packets
+ coming from any port\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBSCTP option group\fP\fP
+ .PP 
+@@ -2562,10 +2524,8 @@
+ .IP "\fB\f(CWsctp\-maxseg=<bytes>\fP\fP"
+ Sets the SCTP_MAXSEG socket option to <bytes> [int]\&.  This
+ value is then proposed to the peer with the SYN or SYN/ACK packet\&. 
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBUDP, TCP, and SCTP option group\fP\fP
+ .PP 
+@@ -2589,10 +2549,8 @@
+ TCP and UDP listen addresses with this option immediately shut down the
+ connection if the client does not use a sourceport <= 1023\&.
+ This mechanism can provide limited authorization under some circumstances\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBSOCKS option group\fP\fP
+ .PP 
+@@ -2603,10 +2561,8 @@
+ .IP "\fB\f(CWsocksuser=<user>\fP\fP"
+ Sends the <user> [string] in the username field to the
+ socks server\&. Default is the actual user name ($LOGNAME or $USER) (example)\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBHTTP option group\fP\fP
+ .PP 
+@@ -2639,10 +2595,8 @@
+ target hostname\&. With this option, socat resolves the hostname locally and
+ sends the IP address\&. Please note that, according to RFC 2396, only name
+ resolution to IPv4 addresses is implemented\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBRANGE option group\fP\fP
+ .PP 
+@@ -2672,10 +2626,8 @@
+ Looks for hosts\&.allow and hosts\&.deny in the specified directory\&. Is
+ overridden by options hosts\-allow
+ and hosts\-deny\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBLISTEN option group\fP\fP
+ .PP 
+@@ -2692,7 +2644,6 @@
+ Limits the number of concurrent child processes [int]\&.
+ Default is no limit\&. 
+ .br 
+-
+ .PP 
+ \fI\fBCHILD option group\fP\fP
+ .PP 
+@@ -2712,10 +2663,8 @@
+ On some operating systems (e\&.g\&. FreeBSD) this option does not work for
+ UDP\-LISTEN addresses\&.
+ .br 
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBEXEC option group\fP\fP
+ .PP 
+@@ -2732,10 +2681,8 @@
+ \f(CWexecvp()\fP
+ call with \(cq\&\-\(cq\&, thus making a
+ shell behave as login shell\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBFORK option group\fP\fP
+ .PP 
+@@ -2802,10 +2749,8 @@
+ .IP "\fB\f(CWsighup\fP\fP, \fB\f(CWsigint\fP\fP, \fB\f(CWsigquit\fP\fP"
+ Has \fBsocat\fP pass signals of this type to the sub process\&.
+ If no address has this option, socat terminates on these signals\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBTERMIOS option group\fP\fP
+ .PP 
+@@ -2844,7 +2789,6 @@
+ .IP "\fB\f(CWbs1\fP\fP"
+ .IP "\fB\f(CWbsdly=<0|1>\fP\fP"
+ .IP "\fB\f(CWclocal=<bool>\fP\fP"
+-
+ .IP 
+ \.LP
+ \.nf
+@@ -2860,7 +2804,6 @@
+ .IP "\fB\f(CWcrdly=<0|1|2|3>\fP\fP"
+ .IP "\fB\f(CWcread=<bool>\fP\fP"
+ .IP "\fB\f(CWcrtscts=<bool>\fP\fP"
+-
+ .IP 
+ \.LP
+ \.nf
+@@ -2967,10 +2910,8 @@
+ (string) onto the stack\&. For example, to make sure that a
+ character device on Solaris supports termios etc, use the following options:
+ \f(CWi\-pop\-all,i\-push=ptem,i\-push=ldterm,i\-push=ttcompat\fP
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBPTY option group\fP\fP
+ .PP 
+@@ -3002,10 +2943,8 @@
+ periodically checks the HUP condition using \f(CWpoll()\fP to find if the pty\(cq\&s
+ slave side has been opened\&. The default polling interval is 1s\&. Use the
+ pty\-interval option [timeval] to change this value\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBOPENSSL option group\fP\fP
+ .PP 
+@@ -3146,10 +3085,8 @@
+ This mode might require that the involved certificates are generated with a
+ FIPS enabled version of openssl\&. Setting or clearing this option on one
+ socat address affects all OpenSSL addresses of this process\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBRETRY option group\fP\fP
+ .PP 
+@@ -3164,10 +3101,8 @@
+ [timespec])\&. Default is 1 second\&.
+ .IP "\fB\f(CWforever\fP\fP"
+ Performs an unlimited number of retry attempts\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ \fI\fBTUN option group\fP\fP
+ .PP 
+@@ -3221,13 +3156,10 @@
+ Sets the AUTOMEDIA flag of the TUN device\&.
+ .IP "\fB\f(CWiff\-dynamic\fP\fP"
+ Sets the DYNAMIC flag of the TUN device\&.
+-
+ .PP 
+ .br 
+-
+ .PP 
+ .SH "DATA VALUES"
+-
+ .PP 
+ This section explains the different data types that address parameters and
+ address options can take\&.
+@@ -3422,13 +3354,10 @@
+ with 
+ \f(CWstrtoul()\fP
+ \&.
+-
+ .PP 
+ .SH "EXAMPLES"
+-
+ .PP 
+ .IP "\fB\f(CWsocat \- TCP4:www\&.domain\&.org:80\fP\fP"
+-
+ .IP 
+ transfers data between STDIO (\-) and a
+ TCP4 connection to port 80 of host 
+@@ -3450,7 +3379,6 @@
+ (crnl) instead of NL are used\&.
+ .IP 
+ .IP "\fB\f(CWsocat TCP4\-LISTEN:www TCP4:www\&.domain\&.org:www\fP\fP"
+-
+ .IP 
+ installs a simple TCP port forwarder\&. With
+ TCP4\-LISTEN it listens on local port \(dq\&www\(dq\& until a
+@@ -3520,7 +3448,6 @@
+ at most 512 data bytes per packet (mss)\&. 
+ .IP 
+ .IP "\fB\f(CWsocat \-,escape=0x0f /dev/ttyS0,rawer,crnl\fP\fP"
+-
+ .IP 
+ opens an interactive connection via the serial line, e\&.g\&. for talking with a
+ modem\&. rawer sets the console\(cq\&s and
+@@ -3551,7 +3478,6 @@
+ session with a given set of addresses and ports\&.
+ .IP 
+ .IP "\fB\f(CWsocat \-u /tmp/readdata,seek\-end=0,ignoreeof \-\fP\fP"
+-
+ .IP 
+ this is an example for unidirectional data transfer
+ (\-u)\&. \fBSocat\fP transfers data 
+@@ -3587,7 +3513,6 @@
+ process\&. 
+ .IP 
+ .IP "\fB\f(CWsocat READLINE,noecho=\(cq\&[Pp]assword:\(cq\& EXEC:\(cq\&ftp ftp\&.server\&.com\(cq\&,pty,setsid,ctty\fP\fP"
+-
+ .IP 
+ wraps a command line history (READLINE) around the EXEC\(cq\&uted ftp client utility\&.
+ This allows editing and reuse of FTP commands for relatively comfortable
+@@ -3623,7 +3548,6 @@
+ should establish connections to host www\&.domain\&.org on port 22 then\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- SSL:server:4443,cafile=server\&.crt,cert=client\&.pem\fP\fP"
+-
+ .IP 
+ is an OpenSSL client that tries to establish a secure connection to an SSL
+ server\&. Option cafile specifies a file that
+@@ -3637,7 +3561,6 @@
+ The first address (\(cq\&\-\(cq\&) can be replaced by almost any other socat address\&.
+ .IP 
+ .IP "\fB\f(CWsocat OPENSSL\-LISTEN:4443,reuseaddr,pf=ip4,fork,cert=server\&.pem,cafile=client\&.crt PIPE\fP\fP"
+-
+ .IP 
+ is an OpenSSL server that accepts TCP connections, presents the certificate
+ from the file server\&.pem and forces the client to present a certificate that is
+@@ -3650,7 +3573,6 @@
+ see the additional socat docu \f(CWsocat\-openssl\&.txt\fP\&.
+ .IP 
+ .IP "\fB\f(CWecho |socat \-u \- file:/tmp/bigfile,create,largefile,seek=100000000000\fP\fP"
+-
+ .IP 
+ creates a 100GB sparse file; this requires a file system type that
+ supports this (ext2, ext3, reiserfs, jfs; not minix, vfat)\&. The operation of
+@@ -3659,7 +3581,6 @@
+ 2MB; ext2: 16KB)\&. 
+ .IP 
+ .IP "\fB\f(CWsocat tcp\-l:7777,reuseaddr,fork system:\(cq\&filan \-i 0 \-s >&2\(cq\&,nofork\fP\fP"
+-
+ .IP 
+ listens for incoming TCP connections on port 7777\&. For each accepted
+ connection, invokes a shell\&. This shell has its stdin and stdout directly
+@@ -3667,19 +3588,16 @@
+ stderr (your terminal window)\&.
+ .IP 
+ .IP "\fB\f(CWecho \-e \(dq\&\e0\e14\e0\e0\ec\(dq\& |socat \-u \- file:/usr/bin/squid\&.exe,seek=0x00074420\fP\fP"
+-
+ .IP 
+ functions as primitive binary editor: it writes the 4 bytes 000 014 000 000 to
+ the executable /usr/bin/squid at offset 0x00074420 (this is a real world patch
+ to make the squid executable from Cygwin run under Windows, actual per May 2004)\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- tcp:www\&.blackhat\&.org:31337,readbytes=1000\fP\fP"
+-
+ .IP 
+ connects to an unknown service and prevents being flooded\&.
+ .IP 
+ .IP "\fB\f(CWsocat \-U TCP:target:9999,end\-close TCP\-L:8888,reuseaddr,fork\fP\fP"
+-
+ .IP 
+ merges data arriving from different TCP streams on port 8888 to just one stream
+ to target:9999\&. The end\-close option prevents the child
+@@ -3689,13 +3607,11 @@
+ connection)\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- UDP4\-DATAGRAM:192\&.168\&.1\&.0:123,sp=123,broadcast,range=192\&.168\&.1\&.0/24\fP\fP"
+-
+ .IP 
+ sends a broadcast to the network 192\&.168\&.1\&.0/24 and receives the replies of the
+ timeservers there\&. Ignores NTP packets from hosts outside this network\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- SOCKET\-DATAGRAM:2:2:17:x007bxc0a80100x0000000000000000,bind=x007bx00000000x0000000000000000,setsockopt\-int=1:6:1,range=x0000xc0a80100x0000000000000000:x0000xffffff00x0000000000000000\fP\fP"
+-
+ .IP 
+ is semantically equivalent to the previous
+ example, but all parameters are
+@@ -3703,13 +3619,11 @@
+ \f(CWSO_BROADCAST\fP\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- IP4\-DATAGRAM:255\&.255\&.255\&.255:44,broadcast,range=10\&.0\&.0\&.0/8\fP\fP"
+-
+ .IP 
+ sends a broadcast to the local network(s) using protocol 44\&. Accepts replies
+ from the private address range only\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- UDP4\-DATAGRAM:224\&.255\&.0\&.1:6666,bind=:6666,ip\-add\-membership=224\&.255\&.0\&.1:eth0\fP\fP"
+-
+ .IP 
+ transfers data from stdin to the specified multicast address using UDP\&. Both
+ local and remote ports are 6666\&. Tells the interface eth0 to also accept
+@@ -3720,7 +3634,6 @@
+ operating system, bridges, or a badly configured switch\&.
+ .IP 
+ .IP "\fB\f(CWsocat UDP:host2:4443 TUN:192\&.168\&.255\&.1/24,up\fP\fP"
+-
+ .IP 
+ establishes one side of a virtual (but not private!) network with host2 where a
+ similar process might run, with UDP\-L and tun address 192\&.168\&.255\&.2\&. They can
+@@ -3729,37 +3642,31 @@
+ might thus cause packet loss\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- VSOCK\-CONNECT:2:1234\fP\fP"
+-
+ .IP 
+ establishes a VSOCK connection with the host (host is always reachable with
+ the well\-know CID=2) on 1234 port\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- VSOCK\-LISTEN:1234\fP\fP"
+-
+ .IP 
+ listens for a VSOCK connection on 1234 port\&.
+ .IP 
+ .IP "\fB\f(CWsocat \- VSOCK\-CONNECT:31:4321,bind:5555\fP\fP"
+-
+ .IP 
+ establishes a VSOCK connection with the guest that have CID=31 on 1234 port,
+ binding the local socket to the 5555 port\&.
+ .IP 
+ .IP "\fB\f(CWsocat VSOCK\-LISTEN:3333,reuseaddr,fork VSOCK\-CONNECT:42,3333\fP\fP"
+-
+ .IP 
+ starts a forwarder that accepts VSOCK connections on port 3333, and directs
+ them to the guest with CID=42 on the same port\&.
+ .IP 
+ .IP "\fB\f(CWsocat VSOCK\-LISTEN:22,reuseaddr,fork TCP:localhost:22\fP\fP"
+-
+ .IP 
+ forwards VSOCK connections from 22 port to the local SSH server\&.
+ Running this in a VM allows you to connect via SSH from the host using VSOCK,
+ as in the example below\&.
+ .IP 
+ .IP "\fB\f(CWsocat TCP4\-LISTEN:22222,reuseaddr,fork VSOCK\-CONNECT:33:22\fP\fP"
+-
+ .IP 
+ forwards TCP connections from 22222 port to the guest with CID=33 listening on
+ VSOCK port 22\&.
+@@ -3767,7 +3674,6 @@
+ \(dq\&ssh \-p 22222 user@localhost\(dq\&, if the guest runs the example above\&.
+ .IP 
+ .IP "\fB\f(CWsocat PTY,link=/var/run/ppp,rawer INTERFACE:hdlc0\fP\fP"
+-
+ .IP 
+ circumvents the problem that pppd requires a serial device and thus might not
+ be able to work on a synchronous line that is represented by a network device\&.
+@@ -3776,7 +3682,6 @@
+ both devices\&. Use pppd on device \f(CW/var/run/ppp\fP then\&.
+ .IP 
+ .IP "\fB\f(CWsocat \-T 1 \-d \-d TCP\-L:10081,reuseaddr,fork,crlf SYSTEM:\(dq\&echo \-e \e\(dq\&\e\e\e\(dq\&HTTP/1\&.0 200 OK\e\e\enDocumentType: text/plain\e\e\en\e\e\endate: \e$\e(date\e)\e\e\enserver:\e$SOCAT_SOCKADDR:\e$SOCAT_SOCKPORT\e\e\enclient: \e$SOCAT_PEERADDR:\e$SOCAT_PEERPORT\e\e\en\e\e\e\(dq\&\e\(dq\&; cat; echo \-e \e\(dq\&\e\e\e\(dq\&\e\e\en\e\e\e\(dq\&\e\(dq\&\(dq\&\fP\fP"
+-
+ .IP 
+ creates a simple HTTP echo server: each HTTP client that connects gets a valid
+ HTTP reply that contains information about the client address and port as it is
+@@ -3784,7 +3689,6 @@
+ servers), and the original client request\&.
+ .IP 
+ .IP "\fB\f(CWsocat \-d \-d UDP4\-RECVFROM:9999,so\-broadcast,so\-timestamp,ip\-pktinfo,ip\-recverr,ip\-recvopts,ip\-recvtos,ip\-recvttl!!\- SYSTEM:\(cq\&export; sleep 1\(cq\& |grep SOCAT\fP\fP"
+-
+ .IP 
+ waits for an incoming UDP packet on port 9999 and prints the environment 
+ variables provided by socat\&. On BSD based systems you have to replace
+@@ -3793,16 +3697,13 @@
+ unicast, multicast, or broadcast address\&.
+ .IP 
+ .IP "\fB\f(CWecho \-e \(dq\&M\-SEARCH * HTTP/1\&.1\enHOST: 239\&.255\&.255\&.250:1900\enMAN: \e\(dq\&ssdp:discover\e\(dq\&\enMX: 4\enST: \e\(dq\&ssdp:all\e\(dq\&\en\(dq\& |\&./socat \- UDP\-DATAGRAM:239\&.255\&.255\&.250:1900,crlf\fP\fP"
+-
+ .IP 
+ sends an SSDP (Simple Service Discovery Protocol) query to the local network
+ and collects and outputs the answers received\&.
+ .IP 
+ .IP "\fB\f(CW\fP\fP"
+-
+ .IP 
+ .SH "DIAGNOSTICS"
+-
+ .PP 
+ \fBSocat\fP uses a logging mechanism that allows filtering messages by severity\&. The
+ severities provided are more or less compatible to the appropriate syslog
+@@ -3826,7 +3727,6 @@
+ happens\&. Allows monitoring the lifecycles of file descriptors\&.
+ .IP "DEBUG:"
+ Description of how the program works, all system or library calls and their results\&.
+-
+ .PP 
+ Log messages can be written to stderr, to a file, or to syslog\&.
+ .PP 
+@@ -3835,7 +3735,6 @@
+ error\&. 
+ .PP 
+ .SH "FILES"
+-
+ .PP 
+ /usr/bin/socat 
+ .br 
+@@ -3844,7 +3743,6 @@
+ /usr/bin/procan
+ .PP 
+ .SH "ENVIRONMENT VARIABLES"
+-
+ .PP 
+ Input variables carry information from the environment to socat, output
+ variables are set by socat for use in executed scripts and programs\&.
+@@ -4011,7 +3909,6 @@
+ given user\&.
+ .IP 
+ .SH "CREDITS"
+-
+ .PP 
+ The work of the following groups and organizations was invaluable for this
+ project:
+@@ -4027,12 +3924,10 @@
+ standard specifications available on the Internet for free\&.
+ .PP 
+ .SH "VERSION"
+-
+ .PP 
+ This man page describes version 1\&.7\&.4 of \fBsocat\fP\&.
+ .PP 
+ .SH "BUGS"
+-
+ .PP 
+ Addresses cannot be nested, so a single socat process cannot, e\&.g\&., drive ssl
+ over socks\&.
+@@ -4048,7 +3943,6 @@
+ Send bug reports to <socat@dest\-unreach\&.org>
+ .PP 
+ .SH "SEE ALSO"
+-
+ .PP 
+ nc(1), rinetd(8), openssl(1),
+ stunnel(8), rlwrap(1), setsid(1)
+@@ -4056,6 +3950,5 @@
+ \fBSocat\fP home page http://www\&.dest\-unreach\&.org/socat/
+ .PP 
+ .SH "AUTHOR"
+-
+ .PP 
+ Gerhard Rieger <rieger@dest\-unreach\&.org> and contributors

--- a/srcpkgs/socat/template
+++ b/srcpkgs/socat/template
@@ -1,7 +1,7 @@
 # Template file for 'socat'
 pkgname=socat
 version=1.7.4.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-libwrap --enable-fips
  ac_cv_have_z_modifier=yes"


### PR DESCRIPTION
Only affects man pages rendered by mandoc.
mandb-man isn't affected (it ignores blank lines).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
