### PR TITLE
gstreamer: update packages to 1.20.2

### DIFF
--- a/srcpkgs/gst-libav/template
+++ b/srcpkgs/gst-libav/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-libav'
 pkgname=gst-libav
-version=1.20.1
+version=1.20.2
 revision=1
 wrksrc="${pkgname}-${version}"
 build_style=meson
@@ -12,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=91a71fb633b75e1bd52e22a457845cb0ba563a2972ba5954ec88448f443a9fc7
+checksum=b5c531dd8413bf771c79dab66b8e389f20b3991f745115133f0fa0b8e32809f9
 
 case "$XBPS_TARGET_MACHINE" in
 	*-musl) # Required by musl for M_SQRT1_2

--- a/srcpkgs/gst-omx/template
+++ b/srcpkgs/gst-omx/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-omx'
 pkgname=gst-omx
-version=1.20.1
+version=1.20.2
 revision=1
 build_style=meson
 configure_args="-Dexamples=disabled -Dtarget=generic"
@@ -11,4 +11,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=86b52e30ebd0f59fcb5cf81a163211975f73ef32e5a6782562804646316bcd7c
+checksum=7efed7cc5b0acf9a669e38c5360a7892430a4e86c858daac6faa1ade2b151668

--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
-version=1.20.1
+version=1.20.2
 revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_helper="gir"
@@ -36,7 +36,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=09d3c2cf5911f0bc7da6bf557a55251779243d3de216b6a26cc90c445b423848
+checksum=4adc4c05f41051f8136b80cda99b0d049a34e777832f9fea7c5a70347658745b
 
 build_options="gir gme"
 build_options_default="gir"

--- a/srcpkgs/gst-plugins-base1/template
+++ b/srcpkgs/gst-plugins-base1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-base1'
 pkgname=gst-plugins-base1
-version=1.20.1
-revision=3
+version=1.20.2
+revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
 build_helper="gir"
@@ -23,7 +23,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=96d8a6413ba9394fbec1217aeef63741a729d476a505a797c1d5337d8fa7c204
+checksum=ab0656f2ad4d38292a803e0cb4ca090943a9b43c8063f650b4d3e3606c317f17
 
 build_options="cdparanoia gir sndio"
 build_options_default="cdparanoia gir"

--- a/srcpkgs/gst-plugins-good1/template
+++ b/srcpkgs/gst-plugins-good1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-good1'
 pkgname=gst-plugins-good1
-version=1.20.1
-revision=2
+version=1.20.2
+revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
 configure_args="-Ddv=disabled -Ddv1394=disabled -Dshout2=disabled -Dqt5=enabled
@@ -23,7 +23,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=3c66876f821d507bcdbebffb08b4f31a322727d6753f65a0f02c905ecb7084aa
+checksum=83589007bf002b8f9ef627718f308c16d83351905f0db8e85c3060f304143aae
 
 build_options="gtk3"
 build_options_default="gtk3"

--- a/srcpkgs/gst-plugins-ugly1/template
+++ b/srcpkgs/gst-plugins-ugly1/template
@@ -1,6 +1,6 @@
 # Template file for 'gst-plugins-ugly1'
 pkgname=gst-plugins-ugly1
-version=1.20.1
+version=1.20.2
 revision=1
 wrksrc="${pkgname/1/}-${version}"
 build_style=meson
@@ -16,4 +16,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
-checksum=42035145e29983308d2828207bb4ef933ed0407bb587fb3a569738c6a57fdb19
+checksum=b43fb4df94459afbf67ec22003ca58ffadcd19e763f276dca25b64c848adb7bf

--- a/srcpkgs/gst1-editing-services/template
+++ b/srcpkgs/gst1-editing-services/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-editing-services'
 pkgname=gst1-editing-services
-version=1.20.1
+version=1.20.2
 revision=1
 wrksrc="${pkgname/gst1/gst}-${version}"
 build_style=meson
@@ -13,7 +13,7 @@ maintainer="Toyam Cox <Vaelatern@gmail.com>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/gst1/gst}/${pkgname/gst1/gst}-${version}.tar.xz"
-checksum=6ace1b21b58e0110b7dadd469f79b77e2f47d6207604231492531ae9fd4148df
+checksum=2ddef442cf8313e78477510a4461c8522f180afef26d035a38fea3f5006d012f
 
 do_check() {
 	: # Tests fail in older versions as well

--- a/srcpkgs/gst1-python3/template
+++ b/srcpkgs/gst1-python3/template
@@ -1,6 +1,6 @@
 # Template file for 'gst1-python3'
 pkgname=gst1-python3
-version=1.20.1
+version=1.20.2
 revision=1
 wrksrc="gst-python-${version}"
 build_style=meson
@@ -12,4 +12,4 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gst-python/gst-python-${version}.tar.xz"
-checksum=ba6cd59faa3db3981d8c6982351c239d823c0b8e80b1acf58d2997b050289422
+checksum=853ea35a1088c762fb703e5aea9c30031a19222b59786b6599956e154620fa2f

--- a/srcpkgs/gstreamer-vaapi/template
+++ b/srcpkgs/gstreamer-vaapi/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer-vaapi'
 pkgname=gstreamer-vaapi
-version=1.20.1
+version=1.20.2
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -12,7 +12,7 @@ license="LGPL-2.1-or-later"
 homepage="https://gstreamer.freedesktop.org"
 changelog="https://raw.githubusercontent.com/GStreamer/gstreamer-vaapi/master/ChangeLog"
 distfiles="${homepage}/src/gstreamer-vaapi/gstreamer-vaapi-${version}.tar.xz"
-checksum=87fbf6c537af9079c99a9aefe951da119e16e5bcc9cc8614f5035f062bf21137
+checksum=30126ab6e3105dab8da76bd9951a68886149bcd70c7fee0bac68de564de41d3d
 
 pre_check() {
 	# Seems to need certain hardware to pass

--- a/srcpkgs/gstreamer1/template
+++ b/srcpkgs/gstreamer1/template
@@ -1,6 +1,6 @@
 # Template file for 'gstreamer1'
 pkgname=gstreamer1
-version=1.20.1
+version=1.20.2
 revision=1
 wrksrc="gstreamer-${version}"
 build_style=meson
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/gstreamer/gstreamer-${version}.tar.xz"
-checksum=de094a404a3ad8f4977829ea87edf695a4da0b5c8f613ebe54ab414bac89f031
+checksum=df24e8792691a02dfe003b3833a51f1dbc6c3331ae625d143b17da939ceb5e0a
 
 pre_check() {
 	# gst_gstdatetime is known to fail according to LFS


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **briefly**

only installed and tested packages. rest were only built

```
gst-libav
gst-plugins-bad1
gst-plugins-base1
gst-plugins-good1
gst-plugins-ugly1
gstreamer-vaapi
gstreamer1
gst-libav-32bit
gst-omx-32bit
gst-plugins-bad1-32bit
gst-plugins-base1-32bit
gst-plugins-good1-32bit
gstreamer-vaapi-32bit
gstreamer1-32bit
```

#### Local build testing
- I built this PR locally for my native architecture, **x86_64**
