### PR TITLE
ausweisapp2: update to 1.22.6

### DIFF
--- a/srcpkgs/AusweisApp2/template
+++ b/srcpkgs/AusweisApp2/template
@@ -1,6 +1,6 @@
 # Template file for 'AusweisApp2'
 pkgname=AusweisApp2
-version=1.22.2
+version=1.22.6
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
@@ -11,5 +11,5 @@ short_desc="Official authentication app for German ID cards and residence permit
 maintainer="Justin Jagieniak <justin@jagieniak.net>"
 license="EUPL-1.2"
 homepage="https://www.ausweisapp.bund.de/ausweisapp2/"
-distfiles="https://github.com/Governikus/AusweisApp2/archive/refs/tags/${version}.tar.gz"
-checksum=79d637a976dc1dc5445757a43324f4fe609d844bf90f11c0f62a46c39dc4fea6
+distfiles="https://github.com/Governikus/AusweisApp2/releases/download/${version}/AusweisApp2-${version}.tar.gz"
+checksum=3665502eb9fa5811c58ffd1952e15589216bcaaf88c63458ac5930c9ad588945


### PR DESCRIPTION
Use official tarball to better check hashsums and maybe the signature
someday.