### PR TITLE
NetworkManager: update to 1.38.0

### DIFF
--- a/srcpkgs/NetworkManager/template
+++ b/srcpkgs/NetworkManager/template
@@ -1,6 +1,6 @@
 # Template file for 'NetworkManager'
 pkgname=NetworkManager
-version=1.36.2
+version=1.38.0
 revision=1
 build_style=meson
 build_helper="gir qemu"
@@ -35,7 +35,7 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/NetworkManager"
 changelog="https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/raw/nm-1-36/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=ab855cbe3b41832e9a3b003810e7c7313dfe19e630d29806d14d87fdd1470cab
+checksum=82a4cf07ddfeb0816787b67c0f5058ae6c50d6259c0b0541a24e35156062b2ef
 # TODO: Some tests require network namespaces to run.
 make_check=extended
 lib32disabled=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
