### PR TITLE
mumble: improve murmur package

### DIFF
--- a/srcpkgs/mumble/files/mumble-server/log/run
+++ b/srcpkgs/mumble/files/mumble-server/log/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec logger -p daemon.notice -t murmur

--- a/srcpkgs/mumble/files/mumble-server/run
+++ b/srcpkgs/mumble/files/mumble-server/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+[ -r ./conf ] && . ./conf
+exec chpst -u_murmur:_murmur mumble-server -fg -ini ${CONFIG_FILE:-/etc/murmur.ini} ${OPTS}

--- a/srcpkgs/mumble/patches/config.patch
+++ b/srcpkgs/mumble/patches/config.patch
@@ -1,0 +1,11 @@
+--- a/scripts/murmur.ini
++++ b/scripts/murmur.ini
+@@ -13,7 +13,7 @@
+ 
+ ; Path to database. If blank, will search for
+ ; murmur.sqlite in default locations or create it if not found.
+-database=
++database=/var/lib/murmur/murmur.sqlite
+ 
+ ; Murmur defaults to using SQLite with its default rollback journal.
+ ; In some situations, using SQLite's write-ahead log (WAL) can be

--- a/srcpkgs/mumble/template
+++ b/srcpkgs/mumble/template
@@ -1,7 +1,7 @@
 # Template file for 'mumble'
 pkgname=mumble
 version=1.4.230
-revision=4
+revision=5
 wrksrc=mumble-${version}.src
 build_style=cmake
 make_cmd=make
@@ -29,18 +29,25 @@ build_options_default="jack portaudio"
 export CMAKE_GENERATOR="Unix Makefiles"
 
 post_install() {
-	vbin ${wrksrc}/scripts/murmur-user-wrapper
-	vsconf scripts/murmur.ini
+	rm -f ${DESTDIR}/usr/share/man/man1/murmur-user-wrapper.1
+	vconf scripts/murmur.ini
+	vsv mumble-server
+	ln -sf murmurd.1 ${DESTDIR}/usr/share/man/man1/mumble-server.1
 	vlicense LICENSE
 }
 
 murmur_package() {
+	system_accounts="_murmur"
+	_murmur_homedir="/var/lib/murmur"
+	make_dirs="/var/lib/murmur 0750 _murmur _murmur"
+	conf_files="/etc/murmur.ini"
+	depends="qt5-plugin-sqlite"
 	short_desc+=" - Server software (mumble-server)"
 	pkg_install() {
+		vmove etc/sv/mumble-server
+		vmove etc/murmur.ini
 		vmove usr/bin/mumble-server
-		vmove usr/bin/murmur-user-wrapper
-		vmove usr/share/man/man1/murmur-user-wrapper.1
+		vmove usr/share/man/man1/mumble-server.1
 		vmove usr/share/man/man1/murmurd.1
-		vmove usr/share/examples/mumble/murmur.ini
 	}
 }


### PR DESCRIPTION
* add qt5-plugin-sqlite to dependencies
otherwise, running mumble-server with the default configuration fails
<F>2022-05-21 19:47:53.080 ServerDB: Database driver QSQLITE not available

* add a system service
* remove murmur-user-wrapper

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
