### PR TITLE
New package: spicetify-cli-2.9.9

### DIFF
--- a/srcpkgs/spicetify-cli/template
+++ b/srcpkgs/spicetify-cli/template
@@ -1,0 +1,23 @@
+# Template file for 'spicetify-cli'
+pkgname=spicetify-cli
+version=2.9.9
+revision=1
+archs="x86_64"
+build_style=go
+go_import_path=github.com/spicetify/spicetify-cli
+go_ldflags=" -X main.version=${version}"
+short_desc="Command-line tool to customize Spotify client"
+maintainer="wael <40663@protonmail.com>"
+license="LGPL-2.1-only"
+homepage="https://spicetify.app/"
+distfiles="https://github.com/spicetify/$pkgname/archive/refs/tags/v${version}.tar.gz"
+checksum=e1489ba8413ccf2006f6c761c0aa91a8b6cc4076f7be1c127a517617ed14d948
+
+do_install() {
+	vmkdir usr/lib
+	vmkdir usr/bin
+	for cp in Themes Extensions CustomApps jsHelper globals.d.ts css-map.json ${GOPATH}/bin/spicetify-cli; do
+		vcopy $cp usr/lib/spicetify
+	done
+	ln -sf /usr/lib/spicetify/spicetify-cli ${DESTDIR}/usr/bin/spicetify
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

**NOTE**: as the Spotify package is locked for x86_64-glibc i locked this package for that too, though it _does_ offer aarch64 pre-built binaries.

