### PR TITLE
mutt: update to 2.2.5

### DIFF
--- a/srcpkgs/mutt/template
+++ b/srcpkgs/mutt/template
@@ -1,6 +1,6 @@
 # Template file for 'mutt'
 pkgname=mutt
-version=2.2.4
+version=2.2.5
 revision=1
 build_style=gnu-configure
 configure_args="--enable-pop --enable-imap --enable-smtp --enable-hcache
@@ -18,7 +18,7 @@ license="GPL-2.0-or-later"
 homepage="http://www.mutt.org"
 changelog="http://mutt.org/relnotes/${version%.*}"
 distfiles="http://ftp.mutt.org/pub/mutt/${pkgname}-${version}.tar.gz"
-checksum=b82776bebff0e10820a33fa1e7eafa5cba4ab3a011b08e83b66ed62d75c6e060
+checksum=ff8b781159794adcca126b551d5e419174b7b38a582a159bfe4e13451a757e47
 
 post_install() {
 	# provided by mime-types


### PR DESCRIPTION
Built and briefly tested locally on `x86_64-musl`.