### PR TITLE
zutty: update to 0.12

### DIFF
--- a/srcpkgs/zutty/template
+++ b/srcpkgs/zutty/template
@@ -1,21 +1,17 @@
 # Template file for 'zutty'
 pkgname=zutty
-version=0.11
+version=0.12
 revision=1
 build_style=waf3
 hostmakedepends="pkg-config"
-makedepends="python3-devel libglvnd-devel MesaLib-devel freetype-devel libXmu-devel"
+makedepends="freetype-devel libXmu-devel libglvnd-devel"
 depends="font-misc-misc"
 short_desc="X terminal emulator rendering through OpenGL ES Compute Shaders"
 maintainer="Javier Caballero <jacallo@protonmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://tomscii.sig7.se/zutty"
 distfiles="https://github.com/tomszilagyi/zutty/archive/refs/tags/${version}.tar.gz"
-checksum=3e77abb424f2f6044686fd3a3a22793e537bf5e403fe2b6ca8543daf4f3186f9
-
-post_patch() {
-	vsed -i wscript -e "s|, '-march=native', '-mtune=native'||g"
-}
+checksum=750daed8625a2486a33b872d59242efba7ee21af282ccfd4a7dbf12d21d7cee7
 
 post_install() {
 	# Copy icons


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, _X86_64_
- I built this PR locally for these architectures _aarch64-musl_