### PR TITLE
New package: ruby-webrick-1.7.0

### DIFF
--- a/srcpkgs/ruby-webrick/template
+++ b/srcpkgs/ruby-webrick/template
@@ -1,0 +1,18 @@
+# Template file for 'ruby-webrick'
+pkgname=ruby-webrick
+version=1.7.0
+revision=1
+build_style=gem
+short_desc="Ruby HTTP server toolkit"
+maintainer="Benjamin Lee <benjamin@typ3.tech>"
+license="BSD-2-Clause"
+homepage="https://github.com/ruby/webrick"
+checksum=87e9b8e39947b7925338a5eb55427b11ce1f2b25a3645770ec9f39d8ebdb8cb4
+
+do_check() {
+	rake test
+}
+
+post_install() {
+	vlicense LICENSE.txt
+}


### PR DESCRIPTION
Webrick used to be included in the ruby standard library, but was [removed][1] in version 3.0 due to security and maintenance concerns. It is needed to run the tests for `rset`, which I am attempting to package in #31003.

[1]: https://bugs.ruby-lang.org/issues/17303

#### Testing the changes
- I tested the changes in this PR: **briefly**

In addition to running the built-in tests in the check stage, I ran the minimal example from the webrick README, which went fine. I don't actually use this package myself, and didn't perform any more extensive testing.

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)
