### PR TITLE
svt-av1: update to 1.1.0

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -2,7 +2,7 @@
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
 version=4.4.1
-revision=3
+revision=4
 short_desc="Decoding, encoding and streaming software"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/svt-av1/template
+++ b/srcpkgs/svt-av1/template
@@ -1,6 +1,6 @@
 # Template file for 'svt-av1'
 pkgname=svt-av1
-version=1.0.0
+version=1.1.0
 revision=1
 wrksrc="SVT-AV1-v${version}"
 build_style=cmake
@@ -11,7 +11,7 @@ license="BSD-3-Clause-Clear"
 homepage="https://gitlab.com/AOMediaCodec/SVT-AV1"
 changelog="https://gitlab.com/AOMediaCodec/SVT-AV1/-/raw/master/CHANGELOG.md"
 distfiles="https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${version}/SVT-AV1-v${version}.tar.gz"
-checksum=84030ef7f33645ddfcdd2dc8a08277e49f3c4297fc53711958060c8ce51dc22d
+checksum=1c211b944ac83ef013fe91aee96c01289da4e3762c1e2f265449f3a964f8e4bc
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" ]; then
 	broken="32-bit is not supported"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Without revbumping ffmpeg, `ffmpeg -i in.mp4 -c:v libsvtav1 out.mkv` fails:
```
Svt[info]: -------------------------------------------
Svt[info]: SVT [version]:	SVT-AV1 Encoder Lib v1.1.0
Svt[info]: SVT [build]  :	GCC 10.2.1 20201203	 64 bit
Svt[info]: LIB Build date: May 24 2022 07:28:32
Svt[info]: -------------------------------------------
[libsvtav1 @ 0x56184b8c3500] Error setting encoder parameters: bad parameter (0x80001005)
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
Conversion failed!
```

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
