### PR TITLE
SDL2_ttf: update to 2.0.18, adopt

### DIFF
--- a/srcpkgs/SDL2_ttf/template
+++ b/srcpkgs/SDL2_ttf/template
@@ -1,17 +1,17 @@
 # Template file for 'SDL2_ttf'
 pkgname=SDL2_ttf
-version=2.0.15
+version=2.0.18
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config"
 makedepends="freetype-devel MesaLib-devel SDL2-devel libSM-devel"
 short_desc="Use TrueType fonts in your SDL 2.x applications"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Sigrid Solveig Haflínudóttir <ftrvxmtrx@gmail.com>"
 license="MIT"
 homepage="http://www.libsdl.org/projects/SDL_ttf"
 distfiles="${homepage}/release/${pkgname}-${version}.tar.gz"
-checksum=a9eceb1ad88c1f1545cd7bd28e7cbc0b2c14191d40238f531a15b01b1b22cd33
+checksum=7234eb8883514e019e7747c703e4a774575b18d435c22a4a29d068cb768a2251
 
 post_install() {
 	vlicense COPYING.txt COPYING


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, `aarch64-musl`

Tested with `neverball`.