### PR TITLE
qutebrowser: adopt.

### DIFF
--- a/srcpkgs/qutebrowser/template
+++ b/srcpkgs/qutebrowser/template
@@ -7,7 +7,7 @@ hostmakedepends="python3-setuptools asciidoc"
 depends="python3-PyQt5-quick python3-Jinja2 python3-yaml
  python3-PyQt5-opengl python3-PyQt5-sql qt5-plugin-sqlite"
 short_desc="Keyboard-focused browser with a minimal GUI"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Mohammed Anas <triallax@tutanota.org>"
 license="GPL-3.0-or-later"
 homepage="https://qutebrowser.org/"
 changelog="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/changelog.asciidoc"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[ci skip]

It's okay for me to adopt this, right?

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
