### PR TITLE
Fix xbps-src colours in CI

### DIFF
--- a/common/xbps-src/shutils/build_dependencies.sh
+++ b/common/xbps-src/shutils/build_dependencies.sh
@@ -410,22 +410,12 @@ install_pkg_deps() {
     done
 
     if [[ ${host_binpkg_deps} ]]; then
-        if [ -z "$XBPS_QUIET" ]; then
-            # normal messages in bold
-            [[ $NOCOLORS ]] || printf "\033[1m"
-            echo "=> $pkgver: installing host dependencies: ${host_binpkg_deps[@]} ..."
-            [[ $NOCOLORS ]] || printf "\033[m"
-        fi
+        msg_normal "$pkgver: installing host dependencies: ${host_binpkg_deps[*]} ...\n"
         install_pkg_from_repos "" host "${host_binpkg_deps[@]}"
     fi
 
     if [[ ${binpkg_deps} ]]; then
-        if [ -z "$XBPS_QUIET" ]; then
-            # normal messages in bold
-            [[ $NOCOLORS ]] || printf "\033[1m"
-            echo "=> $pkgver: installing target dependencies: ${binpkg_deps[@]} ..."
-            [[ $NOCOLORS ]] || printf "\033[m"
-        fi
+        msg_normal "$pkgver: installing target dependencies: ${binpkg_deps[*]} ...\n"
         install_pkg_from_repos "$cross" target "${binpkg_deps[@]}"
     fi
 

--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -176,8 +176,13 @@ msg_warn_nochroot() {
 
 msg_normal() {
     if [ -z "$XBPS_QUIET" ]; then
-        # normal messages in bold
-        [ -n "$NOCOLORS" ] || printf "\033[1m"
+        # normal messages in bright bold white
+        if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
+            # Github CI considers '1m' to be just a font bold
+            [ -n "$NOCOLORS" ] || printf "\033[97m\033[1m"
+        else
+            [ -n "$NOCOLORS" ] || printf "\033[1m"
+        fi
         printf "=> $@"
         [ -n "$NOCOLORS" ] || printf "\033[m"
     fi
@@ -201,7 +206,12 @@ report_broken() {
 }
 
 msg_normal_append() {
-    [ -n "$NOCOLORS" ] || printf "\033[1m"
+    if [ "$XBPS_BUILD_ENVIRONMENT" = "void-packages-ci" ]; then
+        # Github CI considers '1m' to be just a font bold
+        [ -n "$NOCOLORS" ] || printf "\033[97m\033[1m"
+    else
+        [ -n "$NOCOLORS" ] || printf "\033[1m"
+    fi
     printf "$@"
     [ -n "$NOCOLORS" ] || printf "\033[m"
 }

--- a/xbps-src
+++ b/xbps-src
@@ -474,6 +474,9 @@ fi
 # Read settings from config file
 [ -s "$XBPS_CONFIG_FILE" ] && . $XBPS_CONFIG_FILE &>/dev/null
 
+# show colors unconditionally in CI
+[ "$XBPS_BUILD_ENVIRONMENT" = void-packages-ci ] && export NOCOLORS=
+
 # Set options passed on command line, after configuration files have been read
 [ -n "$XBPS_ARG_BUILD_ONLY_ONE_PKG" ] && XBPS_BUILD_ONLY_ONE_PKG=yes
 [ -n "$XBPS_ARG_IGNORE_BROKENNESS" ] && XBPS_IGNORE_BROKENNESS=1


### PR DESCRIPTION
~~This PR adds a new config variable `XBPS_FORCE_COLORS`, which overrides the "is this not a tty" and `NO_COLOR` checks, and adds it to config entries for CI.~~
**EDIT** Github has changed the way CI is run; xbps-src now thinks it is running in a terminal and prints with colour. This part of the PR has been removed.

The `msg_normal()` colour is changed from "bold" (`1`) to "bright white, bold" (`97`, `1`) since Github workflows render `1` as bold letters of the current colour. This should have no effect on the vast majority of terminals setups, as `1` is already rendered as bright white with or without bolded font.

![image](https://user-images.githubusercontent.com/5877043/170177533-b0be695f-a9c0-42d5-9ea9-e2f0657b3b68.png)
![image](https://user-images.githubusercontent.com/5877043/170177592-a3c5de00-8bb2-48a9-8b62-65035889d84c.png)

I also setup [a demo](https://github.com/0x5c/void-packages/pull/4/checks) on my fork.

#### Testing the changes
- I tested the changes in this PR: **YES**
