### PR TITLE
mariadb: merge mariadb-client into mariadb

### DIFF
--- a/srcpkgs/mariadb/template
+++ b/srcpkgs/mariadb/template
@@ -1,7 +1,7 @@
 # Template file for 'mariadb'
 pkgname=mariadb
 version=10.5.10
-revision=2
+revision=3
 build_style=cmake
 build_helper=qemu
 configure_args="-DBUILD_CONFIG=mysql_release
@@ -20,7 +20,7 @@ configure_args="-DBUILD_CONFIG=mysql_release
 hostmakedepends="bison perl flex pkg-config"
 makedepends="ncurses-devel gnutls-devel libaio-devel boost-devel pam-devel zlib-devel
  pcre2-devel libatomic-devel"
-depends="mariadb-client"
+depends="perl"
 checkdepends="perl"
 short_desc="Fast SQL database server, drop-in replacement for MySQL"
 maintainer="Justin Jagieniak <justin@jagieniak.net>"
@@ -81,6 +81,7 @@ libmariadbclient_package() {
 		vmove "usr/lib/libmariadb*.so.*"
 	}
 }
+
 libmariadbclient-devel_package() {
 	depends="libmariadbclient>=${version}_${revision} libatomic-devel"
 	provides="libmysqlclient-devel-${version}_${revision}"
@@ -94,31 +95,13 @@ libmariadbclient-devel_package() {
 		vmove "usr/lib/*.so"
 	}
 }
+
 mariadb-client_package() {
-	depends="perl"
+	build_style=meta
+	depends="mariadb"
 	provides="mysql-client-${version}_${revision}"
 	replaces="mysql-client>=0"
-	short_desc+=" - client binaries"
-	pkg_install() {
-		for f in innochecksum innotop myisam_ftdump mysql mysql_client_test \
-			mysql_client_test_embedded mysqldumpslow mysqlbinlog \
-			mysql_find_rows mysql_fix_extensions mysql_waitpid mysqlaccess \
-			mysqladmin mysqlanalyze mysqlbug mysqlcheck mysqldump \
-			mysqlimport mysqloptimize mysqlrepair mysqlreport mysqlshow \
-			mysqlslap mysqltest_embedded mysqlmanager mysqltest \
-			mysqlhotcopy mysql_upgrade mysql_zap; do
-			if [ -f ${DESTDIR}/usr/bin/${f} ]; then
-				vmove usr/bin/${f}
-			elif [ -f ${DESTDIR}/usr/sbin/${f} ]; then
-				vmove usr/sbin/${f}
-			fi
-			if [ -f ${DESTDIR}/usr/share/man/man1/${f}.1 ]; then
-				vmove usr/share/man/man1/${f}.1
-			elif [ -f ${DESTDIR}/usr/share/man/man8/${f}.8 ]; then
-				vmove usr/share/man/man8/${f}.8
-			fi
-		done
-	}
+	short_desc+=" - client binaries (transitional dummy package)"
 }
 
 libmysqlclient_package() {


### PR DESCRIPTION
mariadb-client consisted almost entirely of symlinks to the main package
and manpages, and did not depend on the main package, so the symlinks
were broken if mariadb was not also installed.

fixes #37282

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
