### PR TITLE
New package: gtklock-20220522

### DIFF
--- a/srcpkgs/gtklock/template
+++ b/srcpkgs/gtklock/template
@@ -1,0 +1,20 @@
+# Template file for 'gtklock'
+pkgname=gtklock
+version=20220522
+revision=1
+build_style=gnu-makefile
+make_use_env=1
+hostmakedepends="pkg-config wayland-devel"
+makedepends="gtk+3-devel gtk-layer-shell-devel pam-devel"
+short_desc="GTK-based lockscreen for Wayland"
+maintainer="Brihadeesh S <brihadeesh@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/jovanlanik/gtklock"
+distfiles="https://github.com/jovanlanik/gtklock/archive/refs/tags/${version}.tar.gz"
+checksum=1e5a6a55e97878e97d84cacf011942802a97a544c9842ae8f60e5f5c45664d8c
+
+post_install() {
+	# copying CSS example provided
+	vmkdir /usr/share/gtklock
+	vcopy assets/* /usr/share/gtklock
+}


### PR DESCRIPTION
New package: gtklock-20220522

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
