### PR TITLE
python3-psutil: update to 5.9.1.

### DIFF
--- a/srcpkgs/python3-psutil/template
+++ b/srcpkgs/python3-psutil/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-psutil'
 pkgname=python3-psutil
-version=5.9.0
+version=5.9.1
 revision=1
 wrksrc="psutil-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/giampaolo/psutil"
 changelog="https://raw.githubusercontent.com/giampaolo/psutil/master/HISTORY.rst"
 distfiles="${PYPI_SITE}/p/psutil/psutil-${version}.tar.gz"
-checksum=869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25
+checksum=57f1819b5d9e95cdfb0c881a8a5b7d542ed0b7c522d575706a80bedc848c8954
 # Tests seem to assume package is installed
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
