### PR TITLE
New package: mathlibtools-1.3.2

### DIFF
--- a/srcpkgs/mathlibtools/template
+++ b/srcpkgs/mathlibtools/template
@@ -1,0 +1,17 @@
+# Template file for 'mathlibtools'
+pkgname=mathlibtools
+version=1.3.2
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-toml python3-PyGithub python3-certifi python3-GitPython
+ python3-requests python3-click python3-tqdm python3-networkx python3-pydot
+ python3-yaml python3-atomicwrites python3-paramiko"
+checkdepends="$depends git tox python3-wheel"
+short_desc="Supporting tool for Lean mathlib"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="Apache-2.0"
+homepage="https://github.com/leanprover-community/mathlib-tools"
+changelog="https://raw.githubusercontent.com/leanprover-community/mathlib-tools/master/CHANGELOG.md"
+distfiles="https://github.com/leanprover-community/mathlib-tools/archive/v${version}.tar.gz"
+checksum=edf6eb94d73f3c33ebcdffbc2790aaafa423fd06b77974519bbd244b93713310

--- a/srcpkgs/python3-PyGithub/template
+++ b/srcpkgs/python3-PyGithub/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-PyGithub'
+pkgname=python3-PyGithub
+version=1.58.1
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm"
+depends="python3-deprecated python3-PyJWT python3-requests"
+checkdepends="$depends python3-httpretty python3-nacl python3-pytest"
+short_desc="Python library to access Github API v3"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="LGPL-3.0-or-later"
+homepage="https://github.com/PyGithub/PyGithub"
+distfiles="${PYPI_SITE}/P/PyGithub/PyGithub-${version}.tar.gz"
+checksum=7d528b4ad92bc13122129fafd444ce3d04c47d2d801f6446b6e6ee2d410235b3

--- a/srcpkgs/python3-httpretty/template
+++ b/srcpkgs/python3-httpretty/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-httpretty'
+pkgname=python3-httpretty
+version=1.1.4
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+checkdepends="python3-devel python3-setuptools"
+short_desc="HTTP client mocking tool for Python"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="MIT"
+homepage="https://github.com/gabrielfalcao/HTTPretty"
+distfiles="https://github.com/gabrielfalcao/HTTPretty/archive/${version}.tar.gz"
+checksum=829b98fa7a467ff2f6b20a8dd15aa2e80090c2912d2ba1fd9f47ebfb1b705a74
+make_check=no # requires sphinxcontrib-asciinema
+
+post_install() {
+	vlicense COPYING
+}

--- a/srcpkgs/python3-pydot/template
+++ b/srcpkgs/python3-pydot/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-pydot'
+pkgname=python3-pydot
+version=1.4.2
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-parsing"
+checkdepends="${depends} python3-chardet graphviz"
+short_desc="Python interface to Graphviz's Dot"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="MIT"
+homepage="https://github.com/pydot/pydot"
+distfiles="https://github.com/pydot/pydot/archive/v${version}.tar.gz"
+checksum=a992e01679ae782b08c151b329754d6d9aed61aa0aa8147a3807552cfe2adcf9
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64

I don't know how to make this work:
1. Install `elan` following the instructions from https://leanprover-community.github.io/install/linux.html
2. run `source $HOME/.elan/env`
3. Install `mathlibtools` from this template

This is the output of `leanproject get tutorials`
```
Cloning from git@github.com:leanprover-community/tutorials.git
Error cloning via SSH, trying HTTPS...
Cloning from https://github.com/leanprover-community/tutorials.git
configuring tuto 0.1
WARNING: leanpkg configurations not specifying `path = "src"` are deprecated.
mathlib: cloning https://github.com/leanprover-community/mathlib to _target/deps/mathlib
> git clone https://github.com/leanprover-community/mathlib _target/deps/mathlib
S'està clonant a «_target/deps/mathlib»...
remote: Enumerating objects: 291798, done.
remote: Counting objects: 100% (2157/2157), done.
remote: Compressing objects: 100% (856/856), done.
remote: Total 291798 (delta 1612), reused 1701 (delta 1301), pack-reused 289641
S'estan rebent objectes: 100% (291798/291798), 155.86 MiB | 4.56 MiB/s, fet.
S'estan resolent les diferències: 100% (233183/233183), fet.
> git checkout --detach 178456ffefddf80dec3b26262cebc88c596e4969    # in directory _target/deps/mathlib
HEAD ara és a 178456ffef feat(set_theory/surreal/basic): definition of `≤` and `<` on numeric games (#14169)
Looking for mathlib oleans for 178456ffef
  locally...
  Found local mathlib oleans
Located matching cache
Applying cache
  files extracted: 1 [00:00, 228.29/s]

Aborted!
```

I don't know what is happening. It should download the cached oleans.

Update: This also happens with mathlibtools installed from pipx...