### PR TITLE
New package: pdpmake-1.2.0

### DIFF
--- a/srcpkgs/pdpmake/template
+++ b/srcpkgs/pdpmake/template
@@ -1,0 +1,15 @@
+# Template file for 'pdpmake'
+pkgname=pdpmake
+version=1.2.0
+revision=1
+build_style=gnu-makefile
+short_desc="Pubic domain POSIX make"
+maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+license="Unlicense"
+homepage="https://frippery.org/make"
+distfiles="https://frippery.org/make/pdpmake-${version}.tar.gz"
+checksum=c545301f4031eb2705196e789e19cd83fe954f62f6ebb9e7e8cf3191884ada17
+
+do_install() {
+	vbin make pdpmake
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

**Note**
`xbps-src` can't seem to find the distfiels for some reason - `curl -LO https://frippery.org/make/pdpmake-1.2.0.tar.gz` seems to work locally.

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
