### PR TITLE
libupnp: update to 1.14.12 + gerbera: update to 1.11.0

### DIFF
--- a/srcpkgs/gerbera/template
+++ b/srcpkgs/gerbera/template
@@ -1,7 +1,7 @@
 # Template file for 'gerbera'
 pkgname=gerbera
-version=1.6.4
-revision=5
+version=1.11.0
+revision=1
 build_style=cmake
 configure_args="-DWITH_SYSTEMD=0 -DWITH_AVCODEC=1"
 hostmakedepends="pkg-config"
@@ -12,8 +12,9 @@ short_desc="UPnP Media Server based on MediaTomb"
 maintainer="Alexander Gehrke <void@qwertyuiop.de>"
 license="GPL-2.0-only"
 homepage="http://gerbera.io/"
+changelog="https://raw.githubusercontent.com/gerbera/gerbera/master/ChangeLog.md"
 distfiles="https://github.com/gerbera/gerbera/archive/v${version}.tar.gz"
-checksum=cbe7ea78977db8c02fcca1759ed149f199a590afaf4a6d21ffcca8623d1a0cc5
+checksum=0c13049792a28ec0e3086ba61c7f9675626a1dbadb043650a452192727418be7
 
 # libupnp uses large file support, so users must do that, too
 CXXFLAGS="-D_FILE_OFFSET_BITS=64"

--- a/srcpkgs/libupnp/template
+++ b/srcpkgs/libupnp/template
@@ -1,6 +1,6 @@
 # Template file for 'libupnp'
 pkgname=libupnp
-version=1.14.4
+version=1.14.12
 revision=1
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
@@ -8,8 +8,9 @@ short_desc="Portable Open Source UPnP Development Kit"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://pupnp.github.io/pupnp/"
+changelog="https://pupnp.github.io/pupnp/ChangeLog"
 distfiles="https://github.com/pupnp/pupnp/releases/download/release-$version/$pkgname-$version.tar.bz2"
-checksum=cd649ef53070e9b88680f730ed5b3f919658582d43dd315a2ed8b6105c6fbe63
+checksum=091c80aada1e939c2294245c122be2f5e337cc932af7f7d40504751680b5b5ac
 
 CFLAGS="-D_FILE_OFFSET_BITS=64"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

This PR contains two updates because gerbera depends on libupnp with version of at least 1.14.6.