### PR TITLE
.github/workflows: disable scheduled cron jobs on forks

### DIFF
--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   cycles:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'void-linux')
     container:
         image: 'ghcr.io/void-linux/xbps-src-masterdir:20220527RC01-x86_64-musl'
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'void-linux')
     steps:
       - uses: actions/stale@v4
         with:


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

Donot runs the cron-jobs of `stale.yml` and `cycles.yml` outside the `void-linux` repository-owner.