### PR TITLE
android-tools: depend on python3

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,12 +1,13 @@
 # Template file for 'android-tools'
 pkgname=android-tools
 version=31.0.3p1
-revision=3
+revision=4
 archs="armv* aarch64* x86_64* i686* ppc64le*"
 build_style=cmake
 hostmakedepends="perl go protobuf pkg-config"
 makedepends="gtest-devel zlib-devel libusb-devel pcre2-devel
  liblz4-devel libzstd-devel protobuf-devel brotli-devel"
+depends="python3"
 short_desc="Android platform tools (adb and fastboot)"
 maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"


### PR DESCRIPTION
This is required by the `mkbootimg`, `repack_bootimg` & `unpack_bootimg` tools which this package contains.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
