### PR TITLE
mle: update to 1.5.0.

### DIFF
--- a/srcpkgs/mle/template
+++ b/srcpkgs/mle/template
@@ -1,17 +1,17 @@
 # Template file for 'mle'
 pkgname=mle
-version=1.4.3
+version=1.5.0
 revision=1
 build_style=gnu-makefile
 make_install_args="prefix=/usr"
 hostmakedepends="libtool"
-makedepends="termbox-devel lua53-devel pcre-devel uthash"
+makedepends="lua54-devel pcre-devel uthash"
 short_desc="Flexible terminal-based text editor (C)"
 maintainer="Anjandev Momi <anjan@momi.ca>"
 license="Apache-2.0"
 homepage="https://github.com/adsr/mle"
 distfiles="https://github.com/adsr/mle/archive/v${version}.tar.gz"
-checksum=452b14d63f7d3ccd98263baec2e4840e4093cc42d1f9cedeaf45151b89ac5ff6
+checksum=569316485fa3775d0bb7559ac176a63adb29467c7098b14c0072c821feb6226b
 
 post_install() {
 	vman mle.1


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**


I don't have a void-linux setup to test presently. Summarizing the changes from the last version: Termbox dep is gone. Lua 5.4 instead of 5.3. Several new features and some bug fixes. In this release, `make test` will fail if locale codeset is not UTF-8. In that case, [this patch](https://github.com/adsr/mle/commit/e4dc4314b02a324701d9ae9873461d34cce041e5) will fix.
