### PR TITLE
salt: fix compatibility with pyzmq 23.0.0

### DIFF
--- a/srcpkgs/salt/patches/zeromq-transport.patch
+++ b/srcpkgs/salt/patches/zeromq-transport.patch
@@ -1,0 +1,13 @@
+Code taken from https://github.com/saltstack/salt/pull/62119/
+--- a/salt/transport/zeromq.py 2021-08-24 14:17:07.000000000 -0500
++++ b/salt/transport/zeromq.py 2022-05-31 09:50:44.113967910 -0500
+@@ -977,7 +977,7 @@
+         try:
+             pub_sock.setsockopt(zmq.HWM, self.opts.get("pub_hwm", 1000))
+         # in zmq >= 3.0, there are separate send and receive HWM settings
+-        except AttributeError:
++        except (AttributeError, zmq.error.ZMQError):
+             # Set the High Water Marks. For more information on HWM, see:
+             # http://api.zeromq.org/4-1:zmq-setsockopt
+             pub_sock.setsockopt(zmq.SNDHWM, self.opts.get("pub_hwm", 1000))
+

--- a/srcpkgs/salt/template
+++ b/srcpkgs/salt/template
@@ -1,7 +1,7 @@
 # Template file for 'salt'
 pkgname=salt
 version=3003.3
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-yaml python3-Jinja2 python3-requests python3-pyzmq


### PR DESCRIPTION
The recent update to python3-pyzmq 23.0.0 broke Salt.  salt-master no longer binds to the publisher port.

Issue is described here: https://github.com/saltstack/salt/issues/62092
Proposed fix is here: https://github.com/saltstack/salt/pull/62119

I ported the change to 3003.3.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
