### PR TITLE
python3-asttokens: disable astroid tests

### DIFF
--- a/srcpkgs/python3-asttokens/template
+++ b/srcpkgs/python3-asttokens/template
@@ -4,6 +4,9 @@ version=2.0.5
 revision=1
 wrksrc="${pkgname#python3-}-${version}"
 build_style=python3-module
+# needs a specific astroid version
+# https://github.com/gristlabs/asttokens/issues/79
+make_check_args="--deselect=tests/test_astroid.py"
 hostmakedepends="python3-setuptools_scm"
 depends="python3-six"
 checkdepends="python3-pytest python3-astroid $depends"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

* tests need a specific astroid version that we can't provide https://github.com/gristlabs/asttokens/issues/79

@ahesford

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
