### PR TITLE
xdg-desktop-portal: update to 1.14.4

### DIFF
--- a/srcpkgs/xdg-desktop-portal/template
+++ b/srcpkgs/xdg-desktop-portal/template
@@ -1,11 +1,11 @@
 # Template file for 'xdg-desktop-portal'
 pkgname=xdg-desktop-portal
-version=1.8.1
+version=1.14.4
 revision=1
 build_style=gnu-configure
-configure_args="--enable-pipewire --enable-geoclue --enable-libportal"
+configure_args="--enable-pipewire --enable-geoclue --enable-libportal --without-systemd"
 hostmakedepends="pkg-config glib-devel"
-makedepends="flatpak-devel fuse-devel pipewire-devel geoclue2-devel
+makedepends="flatpak-devel fuse3-devel pipewire-devel geoclue2-devel
  libportal-devel"
 checkdepends="dbus"
 short_desc="Portal frontend service for Flatpak"
@@ -13,7 +13,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/flatpak/xdg-desktop-portal"
 distfiles="https://github.com/flatpak/${pkgname}/releases/download/${version}/${pkgname}-${version}.tar.xz"
-checksum=01f5f87d3546b63bad85cdba40619913435235a499af3c48ec7554ce8200dcdf
+checksum=0590199a65daee7c4f3e5c293e3d5b287610bf9299c4515eacc3d133474f0c73
 
 do_check() {
 	# some tests require a dbus session


### PR DESCRIPTION
Explicitly disable systemd build, and bump fuse-devel version requirement, as fuse3 is now required to properly build xdg-desktop-portal.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-libc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
  - i686-libc

Note: xdp is a host make dependency for xdg-desktop-portal-gtk, I've build it locally too, but as I use xdg-desktop-portal-wlr I can't test it right away.
Note2: [xdp gtk/gnome reference](https://github.com/void-linux/void-packages/pull/36311#issuecomment-1144119094)