### PR TITLE
sfeed: update to 1.5 and orphan

### DIFF
--- a/srcpkgs/sfeed/template
+++ b/srcpkgs/sfeed/template
@@ -1,17 +1,17 @@
 # Template file for 'sfeed'
 pkgname=sfeed
-version=1.4
+version=1.5
 revision=1
 build_style=gnu-makefile
 make_install_args="MANPREFIX=/usr/share/man"
 makedepends="ncurses-devel"
 depends="curl"
 short_desc="RSS and Atom parser"
-maintainer="notthewave <winklbauer_m@zoho.eu>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://git.codemadness.org/sfeed"
 distfiles="https://codemadness.org/releases/sfeed/sfeed-${version}.tar.gz"
-checksum=3c90f4bef1becdf583cc0ae201e694459edcd024e1d76bfeed3f417ecc163498
+checksum=0a0024bd958b9b00f1b7c29501f1580e3859330102ffd75a8922f50ff8955fd1
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
No longer use void as often since it currently does not fit my use-case, might be better maintained by a regular user. @tibequadorian You updated last time, would you be interested in adopting the package?

#### Testing the changes
- I tested the changes in this PR: **YES**

tested on x86_64-musl