### PR TITLE
common: unset CMAKE_GENERATOR before sourcing templates

### DIFF
--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -18,6 +18,7 @@ unset -v reverts subpackages makedepends hostmakedepends checkdepends depends re
 unset -v nopie build_options build_options_default bootstrap repository reverts
 unset -v CFLAGS CXXFLAGS FFLAGS CPPFLAGS LDFLAGS LD_LIBRARY_PATH
 unset -v CC CXX CPP GCC LD AR AS RANLIB NM OBJDUMP OBJCOPY STRIP READELF PKG_CONFIG
+unset -v CMAKE_GENERATOR
 
 # hooks/do-extract/00-distfiles
 unset -v skip_extraction


### PR DESCRIPTION
When building dependencies of packages this has to be unset to avoid using e.g. `CMAKE_GENERATOR="Unix Makefiles"` for a package which expected to build with the default of `make_cmd=ninja`, and would subsequently fail with `ninja: error: loading 'build.ninja': No such file or directory` during `do_build()` if `do_configure()` generated a Makefile instead of a
build.ninja file.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
