### PR TITLE
New package: libguestfs-tools 1.48.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4164,3 +4164,4 @@ liblowdown.so lowdown-0.11.2_1
 libjaylink.so.0 libjaylink-0.2.0_1
 libnvidia-container.so.1 libnvidia-container-1.10.0_1
 libnvidia-container-go.so.1 libnvidia-container-1.10.0_1
+libguestfs.so.0 libguestfs-1.48.1_1

--- a/srcpkgs/libguestfs-tools/template
+++ b/srcpkgs/libguestfs-tools/template
@@ -1,0 +1,38 @@
+# Template file for 'libguestfs-tools'
+pkgname=libguestfs-tools
+_pkg=guestfs-tools
+version=1.48.0
+revision=1
+wrksrc="${_pkg}-${version}"
+build_style=gnu-configure
+configure_args="ac_cv_prog_NCURSES_CONFIG=ncursesw6-config"
+hostmakedepends="flex pkg-config ncurses-devel gettext-devel pcre2-devel libvirt-devel
+ libxml2-devel jansson-devel ncurses-devel ocaml ocaml-findlib perl perl-Locale-TextDomain
+ hivex perl-Module-Build bash-completion qemu cpio"
+makedepends="cdrtools xz sqlite libguestfs-devel"
+depends="cdrtools xz sqlite"
+checkdepends="libguestfs libguestfs-devel curl wget tar procps-ng"
+short_desc="Additional tools for virtual machine disk image manipulation"
+maintainer="J Farkas <chexum+git@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/rwmjones/guestfs-tools"
+distfiles="https://download.libguestfs.org/${_pkg}/${version%.*}-stable/${_pkg}-${version}.tar.gz"
+checksum=7120ea2e939af8d4697015cc8e43acc5d19964fe894dee5bc27df80d48d24cb8
+
+do_check() {
+	# this is roughly what update-libguestfs-appliance does
+	# but with a newer version (1.40.0 does not even exist now)
+	# and does not require root
+#	mkdir -p /var/cache/guestfs
+#	mkdir -p /usr/lib/guestfs
+#	wget --continue --quiet -O /var/cache/guestfs/appliance-1.46.0.tar.xz http://libguestfs.org/download/binaries/appliance/appliance-1.46.0.tar.xz
+#	tar -xvf /var/cache/guestfs/appliance-1.46.0.tar.xz -C /usr/lib/guestfs --strip-components=1
+#	chmod 644 /usr/lib/guestfs/*
+#	export LIBGUESTFS_PATH=/usr/lib/guestfs
+
+	# test-virt-sysprep-script.sh does not work in chroot
+	# fusermount: mount failed: Operation not permitted
+#	export SKIP_TEST_VIRT_SYSPREP_SCRIPT_SH=1
+#	make check
+	exit 0
+}

--- a/srcpkgs/perl-Locale-TextDomain/template
+++ b/srcpkgs/perl-Locale-TextDomain/template
@@ -1,0 +1,16 @@
+# Template file for 'perl-Locale-TextDomain'
+pkgname=perl-Locale-TextDomain
+_pkg=libintl-perl
+version=1.32
+revision=1
+wrksrc="${_pkg}-${version}"
+build_style=perl-module
+hostmakedepends="perl"
+makedepends="${hostmakedepends}"
+depends="${makedepends}"
+short_desc="Perl Interface to Uniforum Message Translation"
+maintainer="J Farkas <chexum+git@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://metacpan.org/release/libintl-perl"
+distfiles="http://search.cpan.org/CPAN/authors/id/G/GU/GUIDO/${_pkg}-${version}.tar.gz"
+checksum=80108298f2564ecbfc7110a3042008e665ed00c2e155b36b0188e6c1135ceba5


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

perl-Locale-TextDomain is only introduced for the script in perl.

libguestfs-tools is not technically now, some time ago it was part of libguestfs.    Some tools were split into their own packages before libguestfs 1.45.2 and split into this package, see:

    https://github.com/libguestfs/libguestfs/commit/733d2182b64df7abc5c5cd7d78177baa6079628c

Without this package, important tools like virt-sysprep were not provided at all.

The package is guestfs-tools but all other distributions align the package name with libguestfs.

Note that the test suite is very resource-intensive, needs to download 100+MB of images, and runs VMs for several of the tests for several minutes, which I don't think are reasonable for commit-time tests.  They have been successful otherwise, apart from test-virt-sysprep-script.sh, which has been disabled.

Part of the test suite is downloading a test VM image, which is roughly the purpose of the `update-libguestfs-appliance` script in  the base libguestfs package, however, it's not designed to run as a normal user in the chroot test pass.

(It also refers to an image which is no longer available, but I'm not sure what's the best approach to make it work, as it's only needed for the test suite, which is not nice at all to be run in a CI environment)

Perhaps to be coordinated with @Hoshpak (I don't insist staying the maintainer for these new entries, but don't mind it either)

---

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- Could not test any other archs, will check the CI
