### PR TITLE
yaml-cpp: update to 0.7.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2231,7 +2231,7 @@ libKF5ThreadWeaver.so.5 threadweaver-5.26.0_1
 libOpenImageIO_Util.so.2.2 openimageio-2.2.13.1_1
 libOpenImageIO.so.2.2 openimageio-2.2.13.1_1
 libOpenColorIO.so.1 opencolorio-1.0.8_1
-libyaml-cpp.so.0.6 yaml-cpp-0.6.2_1
+libyaml-cpp.so.0.7 yaml-cpp-0.7.0_1
 libpaper.so.1 libpaper-1.1.24_1
 libhtsjava.so.2 httrack-3.49.2_7
 libhttrack.so.2 httrack-3.49.2_7

--- a/srcpkgs/OpenXcom/template
+++ b/srcpkgs/OpenXcom/template
@@ -1,7 +1,7 @@
 # Template file for 'OpenXcom'
 pkgname=OpenXcom
 version=1.0
-revision=4
+revision=5
 build_style=gnu-configure
 configure_args="--disable-silent-rules --disable-werror"
 hostmakedepends="automake pkg-config xmlto"

--- a/srcpkgs/facter/template
+++ b/srcpkgs/facter/template
@@ -1,7 +1,7 @@
 # Template file for 'facter'
 pkgname=facter
 version=3.14.16
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DRUBY_CONFIG_INCLUDE_DIR=${XBPS_CROSS_BASE}/usr/include
  -DENABLE_CXX_WERROR=OFF -DCMAKE_INSTALL_LIBDIR=/usr/lib"

--- a/srcpkgs/interception-tools/template
+++ b/srcpkgs/interception-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'interception-tools'
 pkgname=interception-tools
 version=0.6.7
-revision=1
+revision=2
 wrksrc=tools-v${version}
 build_style=cmake
 hostmakedepends="pkg-config"

--- a/srcpkgs/librime/template
+++ b/srcpkgs/librime/template
@@ -1,7 +1,7 @@
 # Template file for 'librime'
 pkgname=librime
 version=1.7.3
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DCMAKE_BUILD_TYPE=None -DENABLE_LOGGING=OFF -DBUILD_TEST=ON
  -DCAPNP_EXECUTABLE=/usr/bin/capnp -DCAPNPC_CXX_EXECUTABLE=/usr/bin/capnpc-c++"

--- a/srcpkgs/rstudio/template
+++ b/srcpkgs/rstudio/template
@@ -1,7 +1,7 @@
 # Template file for 'rstudio'
 pkgname=rstudio
 version=1.4.1717
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DRSTUDIO_TARGET=Desktop
  -DRSTUDIO_USE_SYSTEM_BOOST=ON

--- a/srcpkgs/supercollider/template
+++ b/srcpkgs/supercollider/template
@@ -1,7 +1,7 @@
 # Template file for 'supercollider'
 pkgname=supercollider
 version=3.11.1
-revision=2
+revision=3
 wrksrc="SuperCollider-${version}-Source"
 build_style=cmake
 make_cmd=make

--- a/srcpkgs/thinkfan/template
+++ b/srcpkgs/thinkfan/template
@@ -1,7 +1,7 @@
 # Template file for 'thinkfan'
 pkgname=thinkfan
 version=1.3.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DUSE_ATASMART:BOOL=ON"
 hostmakedepends="pkg-config"

--- a/srcpkgs/yaml-cpp/patches/fix-cmake-exports.patch
+++ b/srcpkgs/yaml-cpp/patches/fix-cmake-exports.patch
@@ -1,0 +1,110 @@
+From 4aad2b1666a4742743b04e765a34742512915674 Mon Sep 17 00:00:00 2001
+From: Felix Schwitzer <flx107809@gmail.com>
+Date: Fri, 1 Apr 2022 05:26:47 +0200
+Subject: [PATCH] Fix CMake export files (#1077)
+
+After configuring the file `yaml-cpp-config.cmake.in`, the result ends up with
+empty variables.  (see also the discussion in #774).
+
+Rework this file and the call to `configure_package_config_file` according the
+cmake documentation
+(https://cmake.org/cmake/help/v3.22/module/CMakePackageConfigHelpers.html?highlight=configure_package_config#command:configure_package_config_file)
+to overcome this issue and allow a simple `find_package` after install.
+
+As there was some discussion about the place where to install the
+`yaml-cpp-config.cmake` file, e.g. #1055, factor out the install location into
+an extra variable to make it easier changing this location in the future.
+
+Also untabify CMakeLists.txt in some places to align with the other code parts in this file.
+---
+ CMakeLists.txt           | 29 ++++++++++++++++++-----------
+ yaml-cpp-config.cmake.in | 10 ++++++----
+ 2 files changed, 24 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 564b7c8d1..ccc1964ea 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -133,10 +133,16 @@ set_target_properties(yaml-cpp PROPERTIES
+   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
+   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
+ 
++# FIXME(felix2012): A more common place for the cmake export would be
++# `CMAKE_INSTALL_LIBDIR`, as e.g. done in ubuntu or in this project for GTest
++set(CONFIG_EXPORT_DIR "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
++set(EXPORT_TARGETS yaml-cpp)
+ configure_package_config_file(
+   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"
+   "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
+-  INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
++  INSTALL_DESTINATION "${CONFIG_EXPORT_DIR}"
++  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CONFIG_EXPORT_DIR)
++unset(EXPORT_TARGETS)
+ 
+ write_basic_package_version_file(
+   "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
+@@ -145,30 +151,31 @@ write_basic_package_version_file(
+ configure_file(yaml-cpp.pc.in yaml-cpp.pc @ONLY)
+ 
+ if (YAML_CPP_INSTALL)
+-	install(TARGETS yaml-cpp
++  install(TARGETS yaml-cpp
+     EXPORT yaml-cpp-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+-	install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
++  install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
+     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+-		FILES_MATCHING PATTERN "*.h")
++                FILES_MATCHING PATTERN "*.h")
+   install(EXPORT yaml-cpp-targets
+-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
+-	install(FILES
+-		"${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
+-		"${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
+-    DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
++    DESTINATION "${CONFIG_EXPORT_DIR}")
++  install(FILES
++      "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
++      "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
++    DESTINATION "${CONFIG_EXPORT_DIR}")
+   install(FILES "${PROJECT_BINARY_DIR}/yaml-cpp.pc"
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+ endif()
++unset(CONFIG_EXPORT_DIR)
+ 
+ if(YAML_CPP_BUILD_TESTS)
+-	add_subdirectory(test)
++  add_subdirectory(test)
+ endif()
+ 
+ if(YAML_CPP_BUILD_TOOLS)
+-	add_subdirectory(util)
++  add_subdirectory(util)
+ endif()
+ 
+ if (YAML_CPP_CLANG_FORMAT_EXE)
+diff --git a/yaml-cpp-config.cmake.in b/yaml-cpp-config.cmake.in
+index 7b41e3f30..a7ace3dc0 100644
+--- a/yaml-cpp-config.cmake.in
++++ b/yaml-cpp-config.cmake.in
+@@ -3,12 +3,14 @@
+ #  YAML_CPP_INCLUDE_DIR - include directory
+ #  YAML_CPP_LIBRARIES    - libraries to link against
+ 
+-# Compute paths
+-get_filename_component(YAML_CPP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+-set(YAML_CPP_INCLUDE_DIR "@CONFIG_INCLUDE_DIRS@")
++@PACKAGE_INIT@
++
++set_and_check(YAML_CPP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+ 
+ # Our library dependencies (contains definitions for IMPORTED targets)
+-include("${YAML_CPP_CMAKE_DIR}/yaml-cpp-targets.cmake")
++include(@PACKAGE_CONFIG_EXPORT_DIR@/yaml-cpp-targets.cmake)
+ 
+ # These are IMPORTED targets created by yaml-cpp-targets.cmake
+ set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
++
++check_required_components(@EXPORT_TARGETS@)

--- a/srcpkgs/yaml-cpp/template
+++ b/srcpkgs/yaml-cpp/template
@@ -2,7 +2,7 @@
 pkgname=yaml-cpp
 # yaml-cpp may break ABI even without changing the soname; when
 # updating, test dependants to determine if revbumps are needed
-version=0.6.3
+version=0.7.0
 revision=1
 wrksrc="${pkgname}-${pkgname}-${version}"
 build_style=cmake
@@ -16,7 +16,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/jbeder/yaml-cpp"
 distfiles="https://github.com/jbeder/${pkgname}/archive/yaml-cpp-${version}.tar.gz"
-checksum=77ea1b90b3718aa0c324207cb29418f5bced2354c2e483a9523d98c3460af1ed
+checksum=43e6a9fcb146ad871515f0d0873947e5d497a1c9c60c58cb102a97b47208b7c3
 
 post_install() {
 	vlicense LICENSE
@@ -27,8 +27,8 @@ yaml-cpp-devel_package() {
 	short_desc+=" - Development files"
 	pkg_install() {
 		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove usr/lib/cmake
+		vmove usr/share/pkgconfig
+		vmove usr/share/cmake
 		vmove "usr/lib/*.so"
 	}
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

A simple CMake project finds new `yaml-cpp` as packaged, compiles a basic program to parse YAML and runs. Both `rstudio` and `facter` launch without complaints and `facter` outputs YAML, but I haven't tested the dependants more thoroughly.

The `yaml-cpp` release broke its own cmake config, but I've pulled an upstream patch to restore functionality. (The patch is necessary to allow `rstudio` to build.)

#### Local build testing
- I built this PR locally for all official archs

cc: @Duncaen 