### PR TITLE
qemu qemu-user-static: Provide binfmt services

### DIFF
--- a/srcpkgs/qemu-user-static/files/qemu-user-static-binfmt/finish
+++ b/srcpkgs/qemu-user-static/files/qemu-user-static-binfmt/finish
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for i in /proc/sys/fs/binfmt_misc/qemu-*; do
+    echo -1 > $i
+done

--- a/srcpkgs/qemu-user-static/files/qemu-user-static-binfmt/run
+++ b/srcpkgs/qemu-user-static/files/qemu-user-static-binfmt/run
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+fi
+
+/usr/share/qemu-user-static/scripts/qemu-binfmt-conf.sh --qemu-suffix "-static" \
+    --qemu-path /usr/bin -c yes -p yes
+exec chpst -b qemu-user-static-binfmt pause

--- a/srcpkgs/qemu-user-static/template
+++ b/srcpkgs/qemu-user-static/template
@@ -2,7 +2,7 @@
 # This package should be updated together with qemu
 pkgname=qemu-user-static
 version=6.2.0
-revision=2
+revision=3
 wrksrc="qemu-${version}"
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec
@@ -125,4 +125,8 @@ post_install() {
 	for f in ${DESTDIR}/usr/bin/*; do
 		mv ${f} ${f}-static
 	done
+
+	vmkdir "usr/share/${pkgname}/scripts"
+	vinstall scripts/qemu-binfmt-conf.sh 755 "usr/share/${pkgname}/scripts"
+	vsv qemu-user-static-binfmt
 }

--- a/srcpkgs/qemu/files/qemu-binfmt/finish
+++ b/srcpkgs/qemu/files/qemu-binfmt/finish
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for i in /proc/sys/fs/binfmt_misc/qemu-*; do
+    echo -1 > $i
+done

--- a/srcpkgs/qemu/files/qemu-binfmt/run
+++ b/srcpkgs/qemu/files/qemu-binfmt/run
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Prioritize static binaries service if present
+sv check qemu-user-static-binfmt && exit 0
+
+if [ ! -f /proc/sys/fs/binfmt_misc/register ]; then
+    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+fi
+
+/usr/share/qemu/scripts/qemu-binfmt-conf.sh --qemu-path /usr/bin -c yes
+exec chpst -b qemu-binfmt pause

--- a/srcpkgs/qemu/template
+++ b/srcpkgs/qemu/template
@@ -2,7 +2,7 @@
 # This package should be updated together with qemu-user-static
 pkgname=qemu
 version=6.2.0
-revision=2
+revision=3
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec --localstatedir=/var
  --disable-glusterfs --disable-xen --enable-docs --enable-kvm --enable-libusb --enable-pie
@@ -79,6 +79,10 @@ post_install() {
 	chmod u+s ${DESTDIR}/usr/libexec/qemu-bridge-helper
 
 	vsv qemu-ga
+
+	vmkdir "usr/share/${pkgname}/scripts"
+	vinstall scripts/qemu-binfmt-conf.sh 755 "usr/share/${pkgname}/scripts"
+	vsv qemu-binfmt
 }
 
 qemu-ga_package() {


### PR DESCRIPTION
`binfmt-support` doesn't work as expected, prioritizes randomly (static & non-static binaries in case both `qemu` & `qemu-user-static` is installed), also does not add `F` flag onto the binfmts which are static (that is required to chroot without copying the binaries to chroot's `/usr/bin`). Ref: https://github.com/void-linux/void-mklive/issues/253#issuecomment-1146786352.

This adds up runit services so that one can easily create the binfmts specific to qemu using [scripts/qemu-binfmt-conf.sh](https://github.com/qemu/qemu/blob/master/scripts/qemu-binfmt-conf.sh) provided in the upstream qemu repository. It also prioritizes static service if symlinked to the service dir.

#### Testing the changes
- I tested the changes in this PR: **briefly**
