### PR TITLE
scaleway-cli: fix version in build

### DIFF
--- a/srcpkgs/scaleway-cli/template
+++ b/srcpkgs/scaleway-cli/template
@@ -1,10 +1,11 @@
 # Template file for 'scaleway-cli'
 pkgname=scaleway-cli
 version=2.5.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/scaleway/scaleway-cli
 go_package=github.com/scaleway/scaleway-cli/cmd/scw
+go_ldflags="-X main.Version=$version-$revision"
 short_desc="Interact with the Scaleway API from the command line"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The version reported by the CLI was "2.0.0-dev" due to a missing build option. It is now the correct version ($VERSION-$REVISION).

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

