### PR TITLE
Qt5: update to newer kde patchset, based on qt 5.15.4

### DIFF
--- a/srcpkgs/qt5-speech/template
+++ b/srcpkgs/qt5-speech/template
@@ -1,9 +1,9 @@
 # Template file for 'qt5-speech'
 pkgname=qt5-speech
-reverts="5.15.3+20210429_1 5.15.3+20210429_2"
-version=5.15.2
-revision=8
-wrksrc="qtspeech-everywhere-src-${version}"
+version=5.15.4
+revision=1
+_commit=c8a1dadc46ccdbeaef45aa805a9dc98d4b3220bd
+wrksrc="qtspeech-${_commit}"
 build_style=qmake
 configure_args="-- -flite -flite-alsa -speechd"
 hostmakedepends="qt5-qmake perl qt5-host-tools pkg-config"
@@ -13,8 +13,8 @@ short_desc="Cross-platform application and UI framework (QT5) - Speech component
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later, LGPL-3.0-or-later"
 homepage="https://qt.io/"
-distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtspeech-everywhere-src-${version}.tar.xz"
-checksum=c810fb9eecb08026434422a32e79269627f3bc2941be199e86ec410bdfe883f5
+distfiles="https://invent.kde.org/qt/qt/qtspeech/-/archive/${_commit}.tar.gz"
+checksum=970ef98f9803965dfebbb1a06ec4a7978389cf20249afed4273e037e7d5ddcf9
 
 _cleanup_wrksrc_leak() {
 	if [ -d "${PKGDESTDIR}/usr/lib/cmake" ]; then
@@ -37,6 +37,10 @@ _cleanup_wrksrc_leak() {
 	# Replace ${wrksrc} in project include files
 	find ${PKGDESTDIR} -iname "*.pri" -exec sed -i "{}" \
 		-e "s;${wrksrc}/qtbase;/usr/lib/qt5;g" \;
+}
+
+post_extract() {
+	mkdir .git
 }
 
 post_install() {

--- a/srcpkgs/qt5-webengine/template
+++ b/srcpkgs/qt5-webengine/template
@@ -1,9 +1,9 @@
 # Template file for 'qt5-webengine'
 pkgname=qt5-webengine
-version=5.15.8
+version=5.15.10
 revision=1
 _version="${version}-lts"
-_chromium_commit=8c0a9b4459f5200a24ab9e687a3fb32e975382e5
+_chromium_commit=caba2fcb0fe8a8d213c4c79d26da3bb88eee61c7
 archs="x86_64* i686* armv[67]* ppc64* aarch64*"
 wrksrc="qtwebengine-${_version}"
 build_style=qmake
@@ -32,8 +32,8 @@ license="GPL-3.0-or-later, LGPL-3.0-or-later"
 homepage="https://qt.io/"
 distfiles="https://github.com/qt/qtwebengine/archive/v${_version}.tar.gz
  https://github.com/qt/qtwebengine-chromium/archive/${_chromium_commit}.tar.gz"
-checksum="2f92476a1b635f441370836ca57855efdbb2cab0983f2d526b80cfb413631480
- 75c79b886cf9c10778c5880754e1cf021e9a5e4fc372e8e6ab252d4ada263062"
+checksum="69ac738ab48eea161ea9b66e3cbde9e74b631125074762adcae0909cdd4dc83d
+ be5f033fa0b3cbb8e39e036d5eed3daa20e426932fb5783dceb8beb375772e83"
 
 no_generic_pkgconfig_link=yes
 build_options="sndio pipewire"

--- a/srcpkgs/qt5-webview/template
+++ b/srcpkgs/qt5-webview/template
@@ -1,8 +1,9 @@
 # Template file for 'qt5-webview'
 pkgname=qt5-webview
-version=5.15.2
+version=5.15.4
 revision=1
-wrksrc="qtwebview-everywhere-src-${version}"
+_commit=826d2a33929c69807917536d48b7861e7682001e
+wrksrc="qtwebview-${_commit}"
 build_style=qmake
 hostmakedepends="qt5-qmake perl qt5-host-tools"
 makedepends="qt5-location-devel qt5-webchannel-devel qt5-tools-devel qt5-declarative-devel
@@ -11,13 +12,17 @@ short_desc="Cross-platform application and UI framework (QT5) - WebEngine compon
 maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later, LGPL-3.0-or-later"
 homepage="https://qt.io/"
-distfiles="http://download.qt.io/official_releases/qt/${version%.*}/${version}/submodules/qtwebview-everywhere-src-${version}.tar.xz"
-checksum=be9f46167e4977ead5ef5ecf883fdb812a4120f2436383583792f65557e481e7
+distfiles="https://invent.kde.org/qt/qt/qtwebview/-/archive/${_commit}.tar.gz"
+checksum=49f7c087e8e3662adf3c271c41c629e547f02b82b305641148f07170d4ea1a67
 
 build_options="webengine"
 if [ "$XBPS_TARGET_ENDIAN" = "le" ] && [ "$XBPS_WORDSIZE" = "$XBPS_TARGET_WORDSIZE" ]; then
 	build_options_default="webengine"
 fi
+
+post_extract() {
+	mkdir -p ${wrksrc}/.git
+}
 
 _cleanup_wrksrc_leak() {
 	if [ -d "${PKGDESTDIR}/usr/lib/cmake" ]; then

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,9 +1,9 @@
 # Template file for 'qt5'
 pkgname=qt5
-version=5.15.3+20220222
-# commit fcca82ca40a5d8a02a4ddd90846d070f2c58cfad
+version=5.15.4+20220606
+# commit 796264600e7f27ac0c88f6df3d312c0b3731772e
 # base repo: https://invent.kde.org/qt/qt/qt5
-revision=3
+revision=1
 build_style=meta
 hostmakedepends="cmake clang flex perl glib-devel pkg-config
  python re2c ruby which"
@@ -28,7 +28,7 @@ homepage="https://qt.io/"
 # to keep the size smaller qtwebengine, qtwebview, qtdocgallery, qtactiveqt and qtpim
 # can be marked with the export-ignore attribute
 distfiles="https://void.johnnynator.dev/distfiles/qt5-${version}.tar.gz"
-checksum=d9a43bb3593f5d80626a25e184544c6be3a9e1945e987522424a14ff51649e90
+checksum=941a0089ec4f9e32eb5ebdf27cc7ce856aee2377b20c9aaff114b218b6303f1d
 python_version=2 #unverified
 replaces="qt5-doc<5.6.0 qt5-quick1<5.6.0 qt5-quick1-devel<5.6.0 qt5-webkit<5.6.0 qt5-webkit-devel<5.6.0
  qt5-enginio<5.7.1 qt5-enginio-devel<5.7.1 qt5-plugin-gtk<5.7.1 qt5-canvas3d<5.13.0"
@@ -178,8 +178,6 @@ _msg_cross() {
 
 post_extract() {
 	find -maxdepth 1 -type d -exec mkdir -p {}/.git \;
-	# just keep module_version at 5.15.2, since some external modules are still 5.15.2
-	find -maxdepth 1 -type d -exec sed -e "/^MODULE_VERSION/s/5.*/5.15.2/" -i {}/.qmake.conf \;
 }
 
 do_configure() {


### PR DESCRIPTION
- qt5: update to 5.15.4+20220606.
- qt5-webgngine: update to 5.15.10.
- qt5-webview: update to 5.15.4.
- qt5-speech: update to 5.15.4.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

[ci skip]
