### PR TITLE
php: update to 7.4.30.

### DIFF
--- a/srcpkgs/php/template
+++ b/srcpkgs/php/template
@@ -1,6 +1,6 @@
 # Template file for 'php'
 pkgname=php
-version=7.4.29
+version=7.4.30
 revision=1
 hostmakedepends="bison pkg-config apache-devel"
 makedepends="apache-devel enchant2-devel freetds-devel freetype-devel gdbm-devel
@@ -12,8 +12,9 @@ short_desc="HTML-embedded scripting language"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="PHP-3.01"
 homepage="https://www.php.net"
+changelog="https://www.php.net/ChangeLog-7.php"
 distfiles="http://www.php.net/distributions/php-${version}.tar.xz"
-checksum=7d0f07869f33311ff3fe1138dc0d6c0d673c37fcb737eaed2c6c10a949f1aed6
+checksum=ea72a34f32c67e79ac2da7dfe96177f3c451c3eefae5810ba13312ed398ba70d
 
 conf_files="/etc/php/php.ini"
 


### PR DESCRIPTION
Looks serious: https://mobile.twitter.com/cfreal_/status/1534940109434507264

> These two CVEs (CVE-2022-31626, CVE-2022-31625) are remotely exploitable [#PHP](https://mobile.twitter.com/hashtag/PHP?src=hashtag_click) bugs that I'll present at [@typhooncon](https://mobile.twitter.com/typhooncon)
 later this month. Please update !