### PR TITLE
enable running tests in parallel

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -613,6 +613,11 @@ and `XBPS_MAKEJOBS` will be set to 1. If a package does not work well with `XBPS
 but still has a mechanism to build in parallel, set `disable_parallel_build` and
 use `XBPS_ORIG_MAKEJOBS` (which holds the original value of `XBPS_MAKEJOBS`) in the template.
 
+- `disable_parallel_check` If set tests for the package won't be built and run in parallel
+and `XBPS_MAKEJOBS` will be set to 1. If a package does not work well with `XBPS_MAKEJOBS`
+but still has a mechanism to run checks in parallel, set `disable_parallel_check` and
+use `XBPS_ORIG_MAKEJOBS` (which holds the original value of `XBPS_MAKEJOBS`) in the template.
+
 - `make_check` Sets the cases in which the `check` phase is run.
 This option has to be accompanied by a comment explaining why the tests fail.
 Allowed values:

--- a/common/build-style/cmake.sh
+++ b/common/build-style/cmake.sh
@@ -116,7 +116,7 @@ do_check() {
 
 	: ${make_check_target:=test}
 
-	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${makejobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/configure.sh
+++ b/common/build-style/configure.sh
@@ -29,7 +29,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=check}
 
-	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${makejobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/gnu-configure.sh
+++ b/common/build-style/gnu-configure.sh
@@ -30,7 +30,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=check}
 
-	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${makejobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/gnu-makefile.sh
+++ b/common/build-style/gnu-makefile.sh
@@ -30,7 +30,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=check}
 
-	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${makejobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/build-style/perl-module.sh
+++ b/common/build-style/perl-module.sh
@@ -79,7 +79,7 @@ do_check() {
 	: ${make_cmd:=make}
 	: ${make_check_target:=test}
 
-	${make_check_pre} ${make_cmd} ${make_check_args} ${make_check_target}
+	${make_check_pre} ${make_cmd} ${makejobs} ${make_check_args} ${make_check_target}
 }
 
 do_install() {

--- a/common/environment/setup/sourcepkg.sh
+++ b/common/environment/setup/sourcepkg.sh
@@ -13,7 +13,8 @@ unset -v cmake_builddir meson_builddir
 unset -v meson_crossfile
 unset -v gemspec
 unset -v go_import_path go_package go_mod_mode
-unset -v patch_args disable_parallel_build keep_libtool_archives make_use_env
+unset -v patch_args disable_parallel_build disable_parallel_check
+unset -v keep_libtool_archives make_use_env
 unset -v reverts subpackages makedepends hostmakedepends checkdepends depends restricted
 unset -v nopie build_options build_options_default bootstrap repository reverts
 unset -v CFLAGS CXXFLAGS FFLAGS CPPFLAGS LDFLAGS LD_LIBRARY_PATH

--- a/common/xbps-src/libexec/xbps-src-docheck.sh
+++ b/common/xbps-src/libexec/xbps-src-docheck.sh
@@ -20,6 +20,13 @@ done
 
 setup_pkg "$PKGNAME" $XBPS_CROSS_BUILD
 
+if [ -n "$disable_parallel_check" ]; then
+    XBPS_MAKEJOBS=1
+else
+    XBPS_MAKEJOBS="$XBPS_ORIG_MAKEJOBS"
+fi
+makejobs="-j$XBPS_MAKEJOBS"
+
 XBPS_CHECK_DONE="${XBPS_STATEDIR}/${sourcepkg}_${XBPS_CROSS_BUILD}_check_done"
 
 if [ -n "$XBPS_CROSS_BUILD" ]; then


### PR DESCRIPTION
- common: add disable_parallel_check
- common/build-style: make do_check run in parallel unless disabled
- Manual.md: document disable_parallel_check

Redux of #31811, incorporating some of the outstanding feedback when it was stale-closed.

Adds `-j$XBPS_MAKEJOBS` to do_check in several build-styles, with the option to disable it if it causes issues.

I did *not* change the `python3-{modules,pep517}` build-styles to opt-out of parallel checks, because they require a 3rd-party library to do it (and it only works with pytest tests). If a python3 package has tests that require `python3-pytest-xdist` to run, but have issues with parallel tests, parallel behaviour can still be disabled by `disable_parallel_check` (which would set the xdist equivalent of `-j1`).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

