### PR TITLE
New package: hatch-1.2.1

### DIFF
--- a/srcpkgs/hatch-vcs/template
+++ b/srcpkgs/hatch-vcs/template
@@ -1,0 +1,24 @@
+# Template file for 'hatch-vcs'
+pkgname=hatch-vcs
+version=0.2.0
+revision=1
+wrksrc="${pkgname/-/_}-${version}"
+build_style=python3-pep517
+make_check_args="--deselect tests/test_build.py::test_basic
+ --deselect tests/test_build.py::test_write
+ --deselect tests/test_build.py::test_fallback"
+hostmakedepends="hatchling"
+depends="hatchling python3-setuptools_scm"
+checkdepends="${depends} python3-pytest git"
+short_desc="Hatch plugin for VCS based versioning"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://github.com/ofek/hatch-vcs"
+changelog="https://github.com/ofek/hatch-vcs/raw/master/HISTORY.md"
+distfiles="${PYPI_SITE}/h/${pkgname/-/_}/${pkgname/-/_}-${version}.tar.gz"
+checksum=9913d733b34eec9bb0345d0626ca32165a4ad2de15d1ce643c36d09ca908abff
+make_check_pre="env PYTHONPATH=./"
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/hatch/template
+++ b/srcpkgs/hatch/template
@@ -1,0 +1,37 @@
+# Template file for 'hatch'
+pkgname=hatch
+version=1.2.1
+revision=1
+build_style=python3-pep517
+make_check_args="--deselect tests/backend/test_build.py::test_editable
+ --deselect tests/backend/builders/test_custom.py::test_default
+ --deselect tests/backend/builders/test_custom.py::test_explicit_path
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_default_auto_detection
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_default
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_default_extra_dependencies
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_default_force_include
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_exact
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_exact_extra_dependencies
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_exact_force_include
+ --deselect tests/backend/builders/test_wheel.py::TestBuildStandard::test_editable_pth
+ --deselect tests/cli/run/test_run.py::test_scripts_no_environment
+ --deselect tests/backend/dep/test_core.py::test_unknown_extra
+ --deselect tests/backend/dep/test_core.py::test_extra_met"
+hostmakedepends="hatchling"
+depends="python3-atomicwrites python3-click hatchling python3-httpx
+ python3-keyring python3-pexpect python3-platformdirs python3-pyperclip
+ python3-rich python3-tomli-w python3-tomlkit python3-userpath
+ python3-virtualenv"
+checkdepends="${depends} python3-pytest python3-pytest-mock
+ python3-pytest-xdist git python3-pip"
+short_desc="Modern, extensible Python project management "
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://hatch.pypa.io/latest/"
+distfiles="${PYPI_SITE}/h/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=61761e1fe14474fb2be7e264555b99fc343b4e63c0ee32aa3497c651e4cdec03
+make_check_pre="env PYTHONPATH=./src"
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/hatchling/template
+++ b/srcpkgs/hatchling/template
@@ -1,0 +1,18 @@
+# Template file for 'hatchling'
+pkgname=hatchling
+version=1.3.1
+revision=1
+build_style=python3-pep517
+_deps="python3-pathspec python3-tomli python3-pluggy python3-packaging"
+hostmakedepends="python3-setuptools ${_deps}"
+depends="${_deps}"
+short_desc="Extensible, standards compliant build backend used by Hatch"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://hatch.pypa.io/latest/"
+distfiles="${PYPI_SITE}/h/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=aaa63019c9d666053d9ff318097335e766123844547c52940155c0401c3c142f
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/python3-tomli-w/template
+++ b/srcpkgs/python3-tomli-w/template
@@ -1,0 +1,20 @@
+# Template file for 'python3-tomli-w'
+pkgname=python3-tomli-w
+version=1.0.0
+revision=1
+wrksrc="${pkgname/python3-/}-${version}"
+build_style=python3-pep517
+hostmakedepends="python3-flit_core"
+depends="python3"
+checkdepends="python3-pytest python3-tomli"
+short_desc="Lil' python TOML writer"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://github.com/hukkin/tomli-w"
+changelog="https://github.com/hukkin/tomli-w/raw/master/CHANGELOG.md"
+distfiles="https://github.com/hukkin/tomli-w/archive/refs/tags/${version}.tar.gz"
+checksum=4fe1fb4696899c01356ef4e028c975103abf62e5fa9472f31f1714100f1b065d
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

### Bikeshedding opportunities
 - ~~As they aren't just libraries, but also CLI tools, do hatch/hatchling need the `python3-` prefix? I personally don't like it, and would argue in favor of removing it.~~ Considering no one commented on this bit, I've decided to just get rid of.
 - ~~There's nearly no testing happening here, but that's due to the deps either requiring git checkouts with submodules, or themselves to be installed for testing. Any opinions on this? I'd prefer to have some amount of automatic testing here and not just a "JC has run this on his laptop once", considering that these are likely to be fairly central Python packages~~ there are a few tests failing now, but they are being run and there's a hundred times more tests that do work as intended. The ones failing where it's expecting to be running /usr/bin/python, but is actually running /usr/bin/python3 or similar things, which is fine IMO.
 - ~~Is a major update of python3-click something that might need additional testing? 29 of our packages depend on it, but on the other hand, it's *probably* fine, right?~~ Has been updated outside of this PR.
 
Fixes #37334