### PR TITLE
kate5: update to 22.04.2.

### DIFF
--- a/srcpkgs/kate5/template
+++ b/srcpkgs/kate5/template
@@ -1,6 +1,6 @@
 # Template file for 'kate5'
 pkgname=kate5
-version=22.04.1
+version=22.04.2
 revision=1
 wrksrc="${pkgname%5}-${version}"
 build_style=cmake
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later, LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://kde.org/applications/en/utilities/org.kde.kate"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname%5}-${version}.tar.xz"
-checksum=f46ec33d7edf8032efcd489cc431ebf3f93e703e0e7d88a51e93941fd8509849
+checksum=7cfec8b6391d89914aa73ead3902fdafab92f73368e0e26743cd4aab1ef117de
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"


### PR DESCRIPTION
Kate 22.04 shipped with a crash when opening the filesystem panel or settings (which accesses filesystem panel settings internally) would crash. There was an attempt to fix it in 22.04.1 (the current Void Linux Kate version), but it still crashed due to dereferencing a null-ish `KConfigPrivate` pointer ([bug report](https://bugs.kde.org/show_bug.cgi?id=453234)). 22.04.2 reverted the changes altogether, fixing the crash ([commits](https://invent.kde.org/utilities/kate/-/commits/v22.04.2/addons/filebrowser/katefilebrowserplugin.cpp)).

This PR updates kate5 to 22.04.2 to fix the crash.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: (edit) **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc