### PR TITLE
libotr: make it compile/test with new tools

### DIFF
--- a/srcpkgs/libotr/patches/regr-socket.patch
+++ b/srcpkgs/libotr/patches/regr-socket.patch
@@ -1,0 +1,11 @@
+diff -urpN libotr-4.1.1/tests/regression/client/client.c libotr-4.1.1/tests/regression/client/client.c
+--- libotr-4.1.1/tests/regression/client/client.c	2015-12-25 17:39:45.000000000 +0000
++++ libotr-4.1.1/tests/regression/client/client.c	2022-06-14 19:36:19.015005905 +0000
+@@ -26,6 +26,7 @@
+ #include <stdlib.h>
+ #include <syscall.h>
+ #include <sys/epoll.h>
++#include <sys/socket.h>
+ #include <sys/types.h>
+ #include <sys/un.h>
+ #include <unistd.h>

--- a/srcpkgs/libotr/template
+++ b/srcpkgs/libotr/template
@@ -1,13 +1,14 @@
-# Template build file for 'libotr'.
+# Template file for 'libotr'
 pkgname=libotr
 version=4.1.1
 revision=1
 build_style=gnu-configure
 makedepends="libgcrypt-devel"
+checkdepends="perl"
 short_desc="Off-the-Record Messaging Library and Toolkit"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later, LGPL-2.1-only"
 homepage="http://www.cypherpunks.ca/otr/"
-license="GPL-2, LGPL-2.1"
 distfiles="http://www.cypherpunks.ca/otr/libotr-${version}.tar.gz"
 checksum=8b3b182424251067a952fb4e6c7b95a21e644fbb27fbd5f8af2b2ed87ca419f5
 

--- a/srcpkgs/libotr/template
+++ b/srcpkgs/libotr/template
@@ -9,7 +9,7 @@ short_desc="Off-the-Record Messaging Library and Toolkit"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-only"
 homepage="http://www.cypherpunks.ca/otr/"
-distfiles="http://www.cypherpunks.ca/otr/libotr-${version}.tar.gz"
+distfiles="https://otr.cypherpunks.ca/${pkgname}-${version}.tar.gz"
 checksum=8b3b182424251067a952fb4e6c7b95a21e644fbb27fbd5f8af2b2ed87ca419f5
 
 pre_build() {

--- a/srcpkgs/libotr/template
+++ b/srcpkgs/libotr/template
@@ -8,7 +8,7 @@ checkdepends="perl"
 short_desc="Off-the-Record Messaging Library and Toolkit"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-only"
-homepage="http://www.cypherpunks.ca/otr/"
+homepage="https://otr.cypherpunks.ca"
 distfiles="https://otr.cypherpunks.ca/${pkgname}-${version}.tar.gz"
 checksum=8b3b182424251067a952fb4e6c7b95a21e644fbb27fbd5f8af2b2ed87ca419f5
 


### PR DESCRIPTION
An irssi update triggered a build of libotr on my system.  It seems the package does
no longer builds.  It was last updated several years ago, toolset was likely more
lax then.

The patch is only needed for the regression test (which is ran by default), so the
code changes don't warrant an actual respin of the binary, it's just needed so
that it can be built from scratch again.

In case other archs fail, I'll check what I can do.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- [x] I built this PR locally for my native architecture, (x86_64-glibc)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
