### PR TITLE
Electron-Cash: update to 4.2.10.

### DIFF
--- a/srcpkgs/Electron-Cash/template
+++ b/srcpkgs/Electron-Cash/template
@@ -1,19 +1,21 @@
 # Template file for 'Electron-Cash'
 pkgname=Electron-Cash
-version=4.2.3
-revision=2
+version=4.2.10
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-PyQt5-devel-tools"
 depends="python3-PyQt5 python3-PyQt5-svg python3-qrcode python3-dateutil
  python3-jsonrpclib python3-protobuf
  python3-dnspython python3-requests python3-pysocks python3-stem
- python3-ecdsa python3-pyaes python3-pycryptodome libbitcoin-secp256k1 libzbar"
+ python3-ecdsa python3-pyaes python3-pycryptodomex libbitcoin-secp256k1 libzbar
+ python3-cryptography>=2.6 python3-pathvalidate python3-psutil"
 short_desc="Lightweight Bitcoin Cash client"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="MIT"
 homepage="https://electroncash.org"
 distfiles="https://github.com/Electron-Cash/Electron-Cash/releases/download/${version}/Electron-Cash-${version}.tar.gz"
-checksum=4c2ea0884ec19a73368eea2081bd763db25cd5760feb23039a4bb61512c4e802
+checksum=2c77258c0e8ccdc42d16cd9bdbc26b47f94b92d9ba8a86d63c25a17ec832b324
+make_check=no # Depends on unpackaged SimpleWebSocketServer
 
 post_install() {
 	# TODO: build these binaries instead of having to remove pre-built ones

--- a/srcpkgs/python3-pathvalidate/template
+++ b/srcpkgs/python3-pathvalidate/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-pathvalidate'
+pkgname=python3-pathvalidate
+version=2.5.0
+revision=1
+wrksrc="pathvalidate-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Python library to sanitize/validate strings such as filenames/paths"
+maintainer="Nikolay Belikov <nb@nbelikov.com>"
+license="MIT"
+homepage="https://github.com/thombashi/pathvalidate"
+changelog="https://github.com/thombashi/pathvalidate/releases"
+distfiles="${PYPI_SITE}/p/pathvalidate/pathvalidate-${version}.tar.gz"
+checksum="119ba36be7e9a405d704c7b7aea4b871c757c53c9adc0ed64f40be1ed8da2781"
+# Tests depend on unpackaged allpairspy, faker, pytest-discord, pytest-md-report.
+make_check=no
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** (I'm not very familiar with this software, but all essential functionality seems to be present)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

-----

The currently packaged version, 4.2.3, crashes at launch due to [this bug](https://github.com/Electron-Cash/Electron-Cash/issues/2368).

A new dependency, `python3-pathvalidate` is added ~~in #37549~~.