### PR TITLE
New package: openssl3

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1757,7 +1757,9 @@ libid3-3.8.so.3 id3lib-3.8.3_1
 libgirara-gtk3.so.3 girara-0.2.8_1
 libjq.so.1 jq-1.6_2
 libcrypto.so.1.1 libcrypto1.1-1.1.1f_1
+libcrypto.so.3 libcrypto3.0-3.0.3_1
 libssl.so.1.1 libssl1.1-1.1.1f_1
+libssl.so.3 libssl3.0-3.0.3_1
 libvamp-hostsdk.so.3 libvamp-plugin-sdk-2.2_6
 libportmidi.so portmidi-217_1
 libWildMidi.so.2 libwildmidi-0.4.3_1

--- a/srcpkgs/libcrypto3.0
+++ b/srcpkgs/libcrypto3.0
@@ -1,0 +1,1 @@
+openssl3

--- a/srcpkgs/libssl3.0
+++ b/srcpkgs/libssl3.0
@@ -1,0 +1,1 @@
+openssl3

--- a/srcpkgs/openssl3.0-devel
+++ b/srcpkgs/openssl3.0-devel
@@ -1,0 +1,1 @@
+openssl3

--- a/srcpkgs/openssl3/template
+++ b/srcpkgs/openssl3/template
@@ -1,0 +1,93 @@
+# Template file for 'openssl3'
+pkgname=openssl3
+version=3.0.4
+revision=1
+# bootstrap=yes
+wrksrc=openssl-${version}
+build_style=configure
+configure_script="./Configure"
+configure_args="--prefix=/usr --openssldir=/etc/ssl3 --libdir=lib
+ shared no-ssl3-method $(vopt_if asm ' ' 'no-asm')
+ -Wa,--noexecstack"
+make_cmd=make
+make_build_args='MAKEDEPPROG="$(CC)'
+make_check_target=test
+make_install_args="MANSUFFIX=ssl"
+short_desc="Toolkit for Secure Sockets Layer and Transport Layer Security"
+maintainer="dkwo <npiazza@disroot.org>"
+license="OpenSSL"
+homepage="https://www.openssl.org"
+distfiles="https://www.openssl.org/source/openssl-${version}.tar.gz"
+checksum=2831843e9a668a0ab478e7020ad63d2d65e51f72977472dc73efcefbafc0c00f
+conf_files="/etc/ssl3/openssl.cnf"
+replaces="libressl>=0"
+
+build_options=asm
+
+if [ "$CHROOT_READY" ]; then
+	hostmakedepends="perl"
+	build_options_default="asm"
+fi
+
+# due to our libatomic issues
+makedepends+=" libatomic-devel"
+
+case $XBPS_TARGET_MACHINE in
+	x86_64*) configure_args+=" enable-ec_nistp_64_gcc_128 linux-x86_64";;
+	i686*) configure_args+=" linux-elf";;
+	aarch64*) configure_args+=" linux-aarch64";;
+	ppc64le*) configure_args+=" linux-ppc64le";;
+	ppc64*) configure_args+=" linux-ppc64";;
+	ppcle*) configure_args+=" linux-ppcle";;
+	ppc*) configure_args+=" linux-ppc";;
+	arm*) configure_args+=" linux-armv4";;
+	mips*) configure_args+=" linux-mips32 -mips32";;
+	*) broken="$XBPS_TARGET_MACHINE";;
+esac
+
+pre_configure() {
+	configure_args+=" ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+}
+
+pre_build() {
+	make ${makejobs} depend
+}
+
+do_check() {
+	# due to our binutils being too old
+	rm -f test/recipes/01-test_symbol_presence.t
+	${make_check_pre} make ${make_check_args} test
+}
+
+post_install() {
+	rm -f "${DESTDIR}/usr/bin/c_rehash"
+}
+
+libcrypto3.0_package() {
+	short_desc+=" - crypto library"
+	pkg_install() {
+		vmove "usr/lib/libcrypto.so.*"
+		vmove usr/lib/engines-3
+	}
+}
+
+libssl3.0_package() {
+	short_desc+=" - SSL/TLS library"
+	pkg_install() {
+		vmove "usr/lib/libssl.so.*"
+	}
+}
+
+openssl3.0-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} libssl3.0>=${version}_${revision} libcrypto3.0>=${version}_${revision}"
+	replaces="libressl-devel>=0"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/share/man/man3
+		vmove usr/share/doc
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.a"
+		vmove "usr/lib/*.so"
+	}
+}


### PR DESCRIPTION
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): YES
- I built this PR locally for my native architecture, `x86_64-musl`
-  removed the c_rehash utility
- added a check for `"$XBPS_TARGET_NO_ATOMIC8" makedepends+=" libatomic-devel"`

It currently fails:
```
01-test_symbol_presence.t        (Wstat: 512 Tests: 4 Failed: 2)                
Failed tests:  2, 4                                                           
Non-zero exit status: 2                                                       
```
This failure is also seen in openssl-1.1.1o update, and it seems related to our having an ancient nm (binutils), and the way it outputs. I can adapt current ppc patches later if needed.