### PR TITLE
Bump cross-arm-none-eabi gcc and binutils to match non-cross packages

### DIFF
--- a/srcpkgs/cross-arm-none-eabi-binutils/template
+++ b/srcpkgs/cross-arm-none-eabi-binutils/template
@@ -2,8 +2,8 @@
 _triplet=arm-none-eabi
 _pkgname=binutils
 pkgname=cross-${_triplet}-${_pkgname}
-version=2.32
-revision=2
+version=2.35
+revision=1
 wrksrc="${_pkgname}-${version}"
 build_style=gnu-configure
 configure_args="
@@ -30,7 +30,7 @@ maintainer="Ivan Sokolov <ivan-p-sokolov@ya.ru>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnu.org/software/${_pkgname}/"
 distfiles="${GNU_SITE}/${_pkgname}/${_pkgname}-${version}.tar.xz"
-checksum=0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
+checksum=1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85
 nocross=yes
 
 post_install() {

--- a/srcpkgs/cross-arm-none-eabi-gcc/template
+++ b/srcpkgs/cross-arm-none-eabi-gcc/template
@@ -2,7 +2,7 @@
 _triplet=arm-none-eabi
 _pkgname=gcc
 pkgname=cross-${_triplet}-gcc
-version=9.3.0
+version=10.2.0
 revision=1
 wrksrc="gcc-${version}"
 build_wrksrc=build
@@ -17,7 +17,7 @@ maintainer="Ivan Sokolov <ivan-p-sokolov@ya.ru>"
 license="GFDL-1.2-or-later, GPL-3.0-or-later, LGPL-2.1-or-later"
 homepage="https://gcc.gnu.org"
 distfiles="${GNU_SITE}/gcc/gcc-${version}/gcc-${version}.tar.xz"
-checksum=71e197867611f6054aa1119b13a0c0abac12834765fe2d81f35ac57f84f742d1
+checksum=b8dd4368bb9c7f0b98188317ee0254dd8cc99d1e3a18d0ff146c855fe16c1d8c
 alternatives="arm-none-eabi:/usr/bin/arm-none-eabi-cc:/usr/bin/arm-none-eabi-gcc"
 nocross=yes
 nopie=yes


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: YES
I tested this with my own personal armv7 projects.  Notably, the version currently in packages has a bug with LTO that makes it discard ISR functions/symbols inappropriately, making LTO useless for some embedded use cases.  This appears fixed in gcc 10.

#### Local build testing
- I built this PR locally for my native architecture, amd64/glibc

