### PR TITLE
mesa: readd HoneyComb LX2K patch

### DIFF
--- a/srcpkgs/mesa/patches/0001-radeonsi-On-Aarch64-force-persistent-buffers-to-GTT.patch
+++ b/srcpkgs/mesa/patches/0001-radeonsi-On-Aarch64-force-persistent-buffers-to-GTT.patch
@@ -1,0 +1,39 @@
+https://gist.github.com/jnettlet/4dd6e43bcd5a551df29b12d3212e6edd
+
+From d72aa8ae74ffb7329003f9f23ffa05833af951ab Mon Sep 17 00:00:00 2001
+From: Jon Nettleton <jon@solid-run.com>
+Date: Fri, 14 Aug 2020 13:36:08 +0200
+Subject: [PATCH] radeonsi: On Aarch64 force persistent buffers to GTT
+
+This fixes a glamore corruption issue on the HoneyComb and by
+internet reports should also fix problems seen on Huaweii
+Kunpeng hardware.
+
+The root cause of the corruption needs to be worked out, but
+this patch also adds a noticable performance improvement. The
+aquarium webgl demo under chromium increases from 39-49 FPS
+when 5000 fish being rendered is selected.  Glmark scores also
+improve by ~200 with no specific tests showing any regression.
+
+Signed-off-by: Jon Nettleton <jon@solid-run.com>
+---
+ src/gallium/drivers/radeonsi/si_buffer.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/gallium/drivers/radeonsi/si_buffer.c b/src/gallium/drivers/radeonsi/si_buffer.c
+index 6b58aebee2d..c9e983367a0 100644
+--- a/src/gallium/drivers/radeonsi/si_buffer.c
++++ b/src/gallium/drivers/radeonsi/si_buffer.c
+@@ -151,6 +151,10 @@ void si_init_resource_fields(struct si_screen *sscreen, struct si_resource *res,
+        */
+       if (!sscreen->info.kernel_flushes_hdp_before_ib || !sscreen->info.is_amdgpu)
+          res->domains = RADEON_DOMAIN_GTT;
++
++#if defined(PIPE_ARCH_AARCH64)
++      res->domains = RADEON_DOMAIN_GTT;
++#endif
+    }
+ 
+    /* Tiled textures are unmappable. Always put them in VRAM. */
+-- 
+2.26.2

--- a/srcpkgs/mesa/template
+++ b/srcpkgs/mesa/template
@@ -1,7 +1,7 @@
 # Template file for 'mesa'
 pkgname=mesa
 version=22.1.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dglvnd=true -Dshared-glapi=enabled -Dgbm=enabled -Degl=enabled
  -Dosmesa=true -Dgles1=enabled -Dgles2=enabled -Dglx=dri -Ddri3=enabled
@@ -32,7 +32,7 @@ fi
 # especially on big endian it's all kinds of broken, and e.g. on
 # 32-bit powerpc it does not work at all, so fall back to softpipe
 case "$XBPS_TARGET_MACHINE" in
-	x86_64*|aarch64*|ppc64le*|arm*) ;;
+	i686*|x86_64*|aarch64*|ppc64le*|arm*) ;;
 	*) configure_args+=" -Ddraw-use-llvm=false" ;;
 esac
 


### PR DESCRIPTION
I'm unsure why the patch was removed, and unsure why it was modified from the original authors.

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - aarch64-musl (cross)
