### PR TITLE
rhash: update to 1.4.3

### DIFF
--- a/srcpkgs/rhash/patches/0001-Fix-version-macro.patch
+++ b/srcpkgs/rhash/patches/0001-Fix-version-macro.patch
@@ -1,0 +1,27 @@
+From 01bcf3b6163a1e43845fbc08efe9ff551534db3c Mon Sep 17 00:00:00 2001
+From: Aleksey Kravchenko <rhash.admin@gmail.com>
+Date: Wed, 15 Jun 2022 06:17:59 +0300
+Subject: [PATCH 1/2] Fix version macro
+
+---
+ bindings/version.properties | 2 +-
+ version.h                   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bindings/version.properties b/bindings/version.properties
+index 162590e..54aef26 100644
+--- a/bindings/version.properties
++++ b/bindings/version.properties
+@@ -1 +1 @@
+-version=1.4.2
++version=1.4.3
+diff --git a/version.h b/version.h
+index af30db7..3fc0325 100644
+--- a/version.h
++++ b/version.h
+@@ -1 +1 @@
+-#define VERSION "1.4.2"
++#define VERSION "1.4.3"
+-- 
+2.36.1
+

--- a/srcpkgs/rhash/template
+++ b/srcpkgs/rhash/template
@@ -1,7 +1,7 @@
 # Template file for 'rhash'
 pkgname=rhash
 version=1.4.3
-revision=1
+revision=2
 wrksrc="RHash-${version}"
 build_style=configure
 configure_args="--enable-openssl --disable-openssl-runtime


### PR DESCRIPTION
Note the vendor tarball misses the version change - exported the next commit from git to fix this as a patch, otherwise rhash -v will be confusing

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
