### PR TITLE
sublime-text4: update license_checksum

### DIFF
--- a/srcpkgs/sublime-text4/template
+++ b/srcpkgs/sublime-text4/template
@@ -1,7 +1,7 @@
 # Template file for 'sublime-text4'
 pkgname=sublime-text4
 version=4126
-revision=1
+revision=2
 archs="x86_64 aarch64"
 wrksrc="sublime_text"
 hostmakedepends="w3m"
@@ -14,7 +14,7 @@ conflicts="sublime-text3"
 repository="nonfree"
 restricted=yes
 nopie=yes
-_license_checksum=33929b71625d13dacf2a0a5853171b9c04058f71e2955ee660b8d0f8dda45ed1
+_license_checksum=287d037b0ecedb68ae1e3138411d54b87172156effecd1987a5f85834aa26a24
 
 case "$XBPS_TARGET_MACHINE" in
 		x86_64)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Previously, the build would fail as the checksum of the license has changed.

I'm not aware of any notice of changes to the text, so it's likely just a minor formatting change in the html which is being check-summed. Additionally, sublime-merge-bin (sublime-text's sister project) uses the same EULA and respective checksum as provided here.

Pull request resubmitted to update the package revision as the package version has not changed.