### PR TITLE
xbps-src: check for existing packages before syncing chroot repodata

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -806,6 +806,7 @@ case "$XBPS_TARGET" in
         if [ -n "$CHROOT_READY" -a -z "$IN_CHROOT" ]; then
             chroot_handler $XBPS_TARGET $XBPS_TARGET_PKG
         else
+            check_existing_pkg
             chroot_sync_repodata
             # prevent update_base_chroot from removing the builddir/destdir
             update_base_chroot keep-all-force


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

This significantly speeds up the package building process for build scripts etc. that run `./xbps-src pkg ...` on a long list of packages that may already have up-to-date local packages built when configured with `XBPS_PRESERVE_PKGS` set.

~~I still have one question: what to do with the existing call to `check_existing_pkg` in [`common/xbps-src/libexec/build.sh`](https://github.com/void-linux/void-packages/blob/master/common/xbps-src/libexec/build.sh#L38)? The script appears to be executed from a [few](https://github.com/void-linux/void-packages/tree/master/common/xbps-src/shutils/cross.sh) [other](https://github.com/void-linux/void-packages/tree/master/common/xbps-src/shutils/build_dependencies.sh) [scripts](https://github.com/void-linux/void-packages/tree/master/common/xbps-src/shutils/bulk.sh) as well so I left it alone for now.~~

#### Example with a single package
Before this patch:
```
void-packages $ time ./xbps-src pkg helvum
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> helvum-0.3.4_2: removing autodeps, please wait...
=> WARNING: helvum-0.3.4_2: skipping build due to existing /host/binpkgs//helvum-0.3.4_2.x86_64.xbps

real	0m1.980s
user	0m0.504s
sys	0m0.113s
```
After this patch:
```
void-packages $ time ./xbps-src pkg helvum
=> WARNING: helvum-0.3.4_2: skipping build due to existing /host/binpkgs//helvum-0.3.4_2.x86_64.xbps

real	0m0.062s
user	0m0.041s
sys	0m0.024s
```
Previously this would add up to about a minute of waiting for essentially no reason if 30 packages already have up-to-date local packages, while with this patch it would only take about 2 seconds to come to the same conclusion with the same package list.