### PR TITLE
tor: update to 0.4.7.8.

### DIFF
--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,6 +1,6 @@
 # Template file for 'tor'
 pkgname=tor
-version=0.4.7.7
+version=0.4.7.8
 revision=1
 build_style=gnu-configure
 configure_args="--enable-zstd"
@@ -14,7 +14,7 @@ license="BSD-3-Clause"
 homepage="https://www.torproject.org/"
 changelog="https://gitlab.torproject.org/tpo/core/tor/-/raw/main/ChangeLog"
 distfiles="https://dist.torproject.org/tor-${version}.tar.gz"
-checksum=3e131158b52b9435d7e43d1c47ef288b96d005342cc44b8c950bb403851a5b44
+checksum=9e9a5c67ad2acdd5f0f8be14ed591fed076b1708abf8344066990a0fa66fe195
 
 conf_files="/etc/tor/torrc"
 system_accounts="tor"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

High severity security update: https://lists.torproject.org/pipermail/tor-packagers/2022-June/000133.html

Test failing on x86_64-musl is already known.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
