### PR TITLE
maxima: enable sbcl option only on supported archs

### DIFF
--- a/srcpkgs/maxima/template
+++ b/srcpkgs/maxima/template
@@ -1,7 +1,7 @@
 # Template file for 'maxima'
 pkgname=maxima
 version=5.45.1
-revision=3
+revision=4
 build_style=gnu-configure
 configure_args="$(vopt_enable clisp) $(vopt_enable sbcl sbcl-exec) $(vopt_enable ecl)"
 hostmakedepends="python3 perl emacs texinfo patchelf"
@@ -28,7 +28,15 @@ build_options="clisp sbcl ecl"
 desc_option_clisp="Build with CLISP"
 desc_option_sbcl="Build with SBCL"
 desc_option_ecl="Build with ECL"
-build_options_default="sbcl ecl"
+build_options_default="ecl"
+
+# sbcl is only available for these architectures
+case "$XBPS_TARGET_MACHINE" in
+	i686|x86_64*|armv7l|aarch64|ppc64le*)
+		build_options_default+=" sbcl"
+		;;
+esac
+
 vopt_conflict clisp sbcl
 
 post_configure() {

--- a/srcpkgs/sbcl/template
+++ b/srcpkgs/sbcl/template
@@ -2,6 +2,7 @@
 pkgname=sbcl
 version=2.2.5
 revision=1
+# make sure the sbcl option in maxima is enabled for the same archs
 archs="i686 x86_64* armv7l aarch64 ppc64le*"
 hostmakedepends="iana-etc texinfo"
 makedepends="zlib-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (only build tested)

@tornaria not having sbcl support in maxima on some archs might break sagemath (?), but this is an overall improvement, the maxima package wasn't built at all for cross archs (arm, ~~ppc~~)
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
