### PR TITLE
New package: waydroid-1.3.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4190,3 +4190,4 @@ libqtquickforkawesome.so.0.0.4 qtforkawesome-0.0.4_1
 libsyncthingwidgets.so.1.2.2 syncthingtray-1.2.2_1
 libsyncthingmodel.so.1.2.2 syncthingtray-1.2.2_1
 libsyncthingconnector.so.1.2.2 syncthingtray-1.2.2_1
+libglibutil.so.1 libglibutil-1.0.64_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -4191,3 +4191,4 @@ libsyncthingwidgets.so.1.2.2 syncthingtray-1.2.2_1
 libsyncthingmodel.so.1.2.2 syncthingtray-1.2.2_1
 libsyncthingconnector.so.1.2.2 syncthingtray-1.2.2_1
 libglibutil.so.1 libglibutil-1.0.64_1
+libgbinder.so.1 libgbinder-1.1.20_1

--- a/srcpkgs/gbinder-python/template
+++ b/srcpkgs/gbinder-python/template
@@ -1,0 +1,15 @@
+# Template file for 'gbinder-python'
+pkgname=gbinder-python
+version=1.1.0
+revision=1
+build_style=python3-module
+make_build_args="--cython"
+hostmakedepends="python3-Cython pkg-config"
+makedepends="libgbinder-devel python3-devel"
+depends="python3"
+short_desc="Python bindings for libgbinder"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/erfanoabdi/gbinder-python"
+distfiles="https://github.com/erfanoabdi/gbinder-python/archive/refs/tags/${version}.tar.gz"
+checksum=930028fd2269df331591a5db155775c301d6fbc1b8d5c933be22c7a22e62d4fb

--- a/srcpkgs/libgbinder-devel
+++ b/srcpkgs/libgbinder-devel
@@ -1,0 +1,1 @@
+libgbinder

--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,0 +1,32 @@
+# Template file for 'libgbinder'
+pkgname=libgbinder
+version=1.1.25
+revision=1
+build_style=gnu-makefile
+make_use_env=1
+make_build_args="KEEP_SYMBOLS=1"
+make_build_target="release pkgconfig"
+make_install_target="install-dev"
+make_check_target="test"
+hostmakedepends="pkg-config bison flex"
+makedepends="libglibutil-devel"
+short_desc="GLib-style interface to binder (Android IPC mechanism)"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/mer-hybris/libgbinder"
+distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
+checksum=92f3eaedba2d9a6d0c9db22cad4d7dea72259770fb4579d92929d34e2012381d
+
+post_install() {
+	vlicense LICENSE
+}
+
+libgbinder-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} libglibutil-devel"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/libglibutil-devel
+++ b/srcpkgs/libglibutil-devel
@@ -1,0 +1,1 @@
+libglibutil

--- a/srcpkgs/libglibutil/template
+++ b/srcpkgs/libglibutil/template
@@ -1,0 +1,32 @@
+# Template file for 'libglibutil'
+pkgname=libglibutil
+version=1.0.66
+revision=1
+build_style=gnu-makefile
+make_use_env=1
+make_build_args="KEEP_SYMBOLS=1"
+make_build_target="release pkgconfig"
+make_check_target="test"
+make_install_target="install-dev"
+hostmakedepends="pkg-config"
+makedepends="glib-devel"
+short_desc="Library of glib utilities"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="BSD-3-Clause"
+homepage="https://github.com/sailfishos/libglibutil"
+distfiles="https://github.com/sailfishos/libglibutil/archive/refs/tags/${version}.tar.gz"
+checksum=421879428ef54aabf7e946f3308f408ad09d9438766882cc038d7bc1bc9761ce
+
+post_install() {
+	vlicense LICENSE
+}
+
+libglibutil-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision} glib-devel"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/python3-pyclip/template
+++ b/srcpkgs/python3-pyclip/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-pyclip'
+pkgname=python3-pyclip
+version=0.6.0
+revision=1
+wrksrc="pyclip-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Cross-platform Clipboard module for Python"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/spyoungtech/pyclip"
+distfiles="https://github.com/spyoungtech/pyclip/archive/refs/tags/v${version}.tar.gz"
+checksum=60b02c936dd8e24dc4e4a15f09e5f1e9b49bcde7e032da120630ab1d74c5fa16
+
+# tests are broken due to "pyclip: error: argument command: invalid choice: 'test' (choose from 'copy', 'paste', 'clear')"
+make_check="no"

--- a/srcpkgs/waydroid/INSTALL
+++ b/srcpkgs/waydroid/INSTALL
@@ -1,0 +1,6 @@
+case "$ACTION" in
+post)
+	echo "Regenerating Waydroid configs..."
+	waydroid upgrade --offline
+	;;
+esac

--- a/srcpkgs/waydroid/files/README.voidlinux
+++ b/srcpkgs/waydroid/files/README.voidlinux
@@ -1,0 +1,18 @@
+To finish Waydroid installation run:
+
+	# waydroid init
+	# ln -s /etc/sv/waydroid-container /var/service
+
+Additionally ensure 'psi=1' is present on your /proc/cmdline (unless the kernel
+is configured with CONFIG_PSI_DEFAULT_DISABLED=n).
+
+Optionally clipboard syncing between the container and host Wayland compositor
+can be enabled with:
+
+	# xbps-install python3-pyclip wl-clipboard
+
+In case of graphical rendering issues etc. make sure to check the Waydroid
+documentation if they have a solution: https://docs.waydro.id/
+
+If not sure confirm your /proc/cpuinfo has the instruction sets required
+by Android: https://developer.android.com/ndk/guides/abis#sa

--- a/srcpkgs/waydroid/files/waydroid-container/finish
+++ b/srcpkgs/waydroid/files/waydroid-container/finish
@@ -1,0 +1,3 @@
+#!/bin/sh
+waydroid session stop
+waydroid container stop

--- a/srcpkgs/waydroid/files/waydroid-container/run
+++ b/srcpkgs/waydroid/files/waydroid-container/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec waydroid -w container start

--- a/srcpkgs/waydroid/template
+++ b/srcpkgs/waydroid/template
@@ -1,0 +1,25 @@
+# Template file for 'waydroid'
+pkgname=waydroid
+version=1.3.0
+revision=1
+# https://developer.android.com/ndk/guides/abis#sa
+archs="aarch64* armv7* i686* x86_64*"
+build_style=gnu-makefile
+make_install_args="USE_NFTABLES=1"
+depends="python3 gbinder-python python3-gobject gtk+3 lxc dnsmasq nftables"
+short_desc="Container-based approach to boot a full Android system"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://waydro.id"
+distfiles="https://github.com/waydroid/waydroid/archive/refs/tags/${version}.tar.gz"
+checksum=1cd2ef0808820879730ddbbde08aa9bc1b16b0b320ca920a9059c2cbd92f637a
+
+python_version=3
+pycompile_dirs="usr/lib/waydroid"
+
+post_install() {
+	vsv waydroid-container
+
+	# Void-specific documentation
+	vdoc ${FILESDIR}/README.voidlinux
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture
  - `x86_64-glibc` / `x86_64-musl`
  - `i686` (tested with `linux5.15` & `linux5-18`, both for some odd reason needed a rebuild twice, they failed on `cd ${DESTDIR}/usr/lib/modules/${_kernver}` in their templates initially)
  - `aarch64` (tested by @CameronNemo and @Johnnynator, thanks!)
<img src="https://i.imgur.com/87hRDmj.jpg" width=500 />

#### To-Do
Test running Waydroid on the following supported archs:
- `armv7l` (glibc or musl)

Supersedes #33135 and closes #33133.