### PR TITLE
xbps-src: fix detecting subpackage availability

### DIFF
--- a/common/xbps-src/shutils/pkgtarget.sh
+++ b/common/xbps-src/shutils/pkgtarget.sh
@@ -16,14 +16,21 @@ check_existing_pkg() {
 check_pkg_arch() {
     local cross="$1" _arch f match nonegation
 
-    if [ -n "$archs" ]; then
-        if [ -n "$cross" ]; then
-            _arch="$XBPS_TARGET_MACHINE"
-        elif [ -n "$XBPS_ARCH" ]; then
-            _arch="$XBPS_ARCH"
-        else
-            _arch="$XBPS_MACHINE"
+    if [ -n "$cross" ]; then
+        _arch="$XBPS_TARGET_MACHINE"
+    elif [ -n "$XBPS_ARCH" ]; then
+        _arch="$XBPS_ARCH"
+    else
+        _arch="$XBPS_MACHINE"
+    fi
+
+    if [ "$pkgname" != "$sourcepkg" ]; then
+        if ! echo "$subpackages" | grep -q -w "$pkgname"; then
+            report_broken "${pkgname}-${version}_${revision}: this subpackage cannot be built for ${_arch}.\n"
         fi
+    fi
+
+    if [ -n "$archs" ]; then
         set -f
         for f in ${archs}; do
             set +f


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This is marked as draft because it doesn't work as expected in all cases, for example when a subpackage is added like in cryptsetup:
```sh
if [ "$XBPS_TARGET_LIBC" = musl ]; then
	configure_args+=" --enable-static-cryptsetup"
	subpackages+=" cryptsetup-static"
...
```

```sh
%: ./xbps-src show-avail cryptsetup-static; echo $?
0
```

fixes #37578

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
