### PR TITLE
ibus: update to 1.5.26

### DIFF
--- a/srcpkgs/ibus/template
+++ b/srcpkgs/ibus/template
@@ -1,19 +1,20 @@
 # Template file for 'ibus'
 pkgname=ibus
-version=1.5.23
-revision=4
+version=1.5.26
+revision=1
 build_style=gnu-configure
 build_helper="gir"
-configure_args="--enable-ui --enable-gtk3 --disable-tests
- --disable-schemas-compile --enable-memconf --enable-dconf
- --enable-wayland --with-python=/usr/bin/python3
+configure_args="--enable-ui --enable-gtk3 --enable-gtk4
+ --disable-tests --disable-schemas-compile --disable-systemd-services
+ --enable-memconf --enable-dconf --enable-wayland
+ --with-python=/usr/bin/python3
  $(vopt_enable dicts emoji-dict) $(vopt_enable dicts unicode-dict)
  --enable-introspection --enable-vala $(vopt_enable ibus_setup setup)"
 hostmakedepends="automake gettext-devel libtool pkg-config intltool dconf
  python3 glib-devel $(vopt_if vala vala)
  $(vopt_if dicts 'cldr-emoji-annotation unicode-character-database unicode-emoji')"
-makedepends="dconf-devel gtk+-devel hicolor-icon-theme iso-codes
- json-glib-devel libnotify-devel librsvg-devel python3-xdg
+makedepends="dconf-devel gtk+-devel gtk4-devel hicolor-icon-theme
+ iso-codes json-glib-devel libnotify-devel librsvg-devel python3-xdg
  $(vopt_if vala vala) libXtst-devel"
 depends="hicolor-icon-theme iso-codes dbus-x11 python3-xdg
  $(vopt_if ibus_setup 'python3-gobject>=3.12.1_3')"
@@ -22,7 +23,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/ibus/ibus"
 distfiles="https://github.com/ibus/ibus/releases/download/${version}/ibus-${version}.tar.gz"
-checksum=b7e8d5bdb7d71a5ba4ee43cdf374675f77121a71c1679c9b9e7e02875bd0e150
+checksum=5c2fd118e7bfd4e9a42c3a20e6175a263426c90b6256f94989ed3d0384f4c9fc
 
 build_options="ibus_setup dicts"
 desc_option_ibus_setup="Enable support for building the ibus setup UI"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I also enabled gtk4 support. Just to address the concerns from a previous PR. Most distros enable it, it is required on X11. On Wayland with GNOME 42, it will not be required since the wayland backend will be preferred there over the gtk backends. I did test it on X11 and with gtk4 support enabled, it does work with gtk4 applications for me (and without it enabled, it does not work).

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
