### PR TITLE
cdrtools: set capabilities

### DIFF
--- a/srcpkgs/cdrtools/INSTALL
+++ b/srcpkgs/cdrtools/INSTALL
@@ -1,0 +1,6 @@
+if [ "$ACTION" = "post" ]
+then
+	setcap cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep /usr/bin/cdrecord
+	setcap cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep /usr/bin/cdda2wav
+	setcap cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep /usr/bin/readcd
+fi

--- a/srcpkgs/cdrtools/template
+++ b/srcpkgs/cdrtools/template
@@ -1,11 +1,12 @@
 # Template file for 'cdrtools'
 pkgname=cdrtools
 version=3.02a09
-revision=2
+revision=3
 wrksrc="${pkgname}-${version%a*}"
 build_helper=qemu
 hostmakedepends="smake"
 makedepends="acl-devel libcap-devel e2fsprogs-devel"
+depends="libcap-progs"
 conf_files="/etc/default/rscsi /etc/default/cdrecord"
 short_desc="Highly portable CD/DVD/BluRay command line recording software"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
---
Some programs of the `cdrtools` suite require certain special privileges to function properly - installing the `cdrtools` package from the Void repository, I'm not able to use for instance the `cdrecord` command obtaining "insufficient privileges" errors. It makes sense to me that it should be possible to use these commands as a normal user without requiring root access.

To achieve this without having to make the respective binaries SUID, [it is recommended](http://cdrtools.sourceforge.net/private/cdrecord.html) to make use of Linux capabilities. I have used the settings published in the [release notes](https://sourceforge.net/projects/cdrtools/files/AN-3.01/view) of `cdrtools` which is also what [Arch Linux does](https://github.com/archlinux/svntogit-community/blob/packages/cdrtools/trunk/cdrtools.install). The programs should be capabilities-aware and should drop the relevant privileges as soon as they are not needed anymore - some relevant discussion can be found [here](https://bugs.archlinux.org/task/67265) and [here](https://bugzilla.opensuse.org/show_bug.cgi?id=550021).