### PR TITLE
radeontop: Update to 1.4

### DIFF
--- a/srcpkgs/radeontop/template
+++ b/srcpkgs/radeontop/template
@@ -1,6 +1,6 @@
 # Template file for 'radeontop'
 pkgname=radeontop
-version=1.3
+version=1.4
 revision=1
 archs="i686* x86_64*"
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Logen K <logen@sudotask.com>"
 license="GPL-3.0-only"
 homepage="https://github.com/clbr/radeontop"
 distfiles="https://github.com/clbr/radeontop/archive/v${version}.tar.gz"
-checksum=0e6abacafa3c795ee783be18b736f6dfc7ff93c6e3c3237cc7c1684863e08100
+checksum=2c1e2aace1a749d8e4530047ce245004e0f7d1d32a99037917e03d83e60f7ad1
 
 do_build() {
 	make CC="$CC" amdgpu=1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Mostly just allows radeontop to detect and display the name of newer GPUs like the RX 6000 series.

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture (x86_64-musl)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
