### PR TITLE
zfs: update to 2.1.5.

### DIFF
--- a/srcpkgs/zfs/patches/0001-only-build-the-module-in-dkms.conf.patch
+++ b/srcpkgs/zfs/patches/0001-only-build-the-module-in-dkms.conf.patch
@@ -1,4 +1,9 @@
-# Patch from https://aur.archlinux.org/cgit/aur.git/tree/0001-only-build-the-module-in-dkms.conf.patch?h=zfs-dkms
+# Patch adapted from
+#
+#    https://aur.archlinux.org/cgit/aur.git/tree/0001-only-build-the-module-in-dkms.conf.patch?h=zfs-dkms
+#
+# rebased for zfs-2.1.5.
+#
 # Avoids recompiling ZFS userland utilities with DKMS rebuilds
 From b4a2c0b184c9c9599421b15a430fb88deb5dbd17 Mon Sep 17 00:00:00 2001
 From: Eli Schwartz <eschwartz@archlinux.org>
@@ -10,10 +15,9 @@ Subject: [PATCH] only build the module in dkms.conf
  1 file changed, 2 insertions(+), 17 deletions(-)
 
 diff --git a/scripts/dkms.mkconf b/scripts/dkms.mkconf
-index 88c289383..5a859a0e0 100755
 --- a/scripts/dkms.mkconf
 +++ b/scripts/dkms.mkconf
-@@ -28,14 +28,7 @@ PACKAGE_CONFIG="${pkgcfg}"
+@@ -28,14 +28,7 @@
  PRE_BUILD="configure
    --prefix=/usr
    --with-config=kernel
@@ -29,15 +33,12 @@ index 88c289383..5a859a0e0 100755
    --with-linux-obj="\${kernel_source_dir}"
    \$(
      [[ -n \"\${ICP_ROOT}\" ]] && \\
-@@ -69,7 +54,7 @@ POST_BUILD="scripts/dkms.postbuild
+@@ -68,7 +61,7 @@
+   -t \${dkms_tree}
  "
  AUTOINSTALL="yes"
- REMAKE_INITRD="no"
 -MAKE[0]="make"
 +MAKE[0]="make -C module/"
  STRIP[0]="\$(
    [[ -r \${PACKAGE_CONFIG} ]] \\
    && source \${PACKAGE_CONFIG} \\
--- 
-2.19.1
-

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,6 +1,6 @@
 # Template file for 'zfs'
 pkgname=zfs
-version=2.1.4
+version=2.1.5
 revision=1
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
@@ -15,7 +15,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="CDDL-1.0"
 homepage="https://openzfs.github.io/openzfs-docs/"
 distfiles="https://github.com/openzfs/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
-checksum=3b52c0d493f806f638dca87dde809f53861cd318c1ebb0e60daeaa061cf1acf6
+checksum=1913041e5c44ff07ca384346ad8145aeedf77e77cd1cea9ec5d533246691e10c
 # dkms must be before initramfs-regenerate to build modules before images
 triggers="dkms initramfs-regenerate"
 dkms_modules="zfs ${version}"


### PR DESCRIPTION
This should clear a (the?) blocker for bumping `linux` to `linux5.18`. Should be tested on `linux5.18`.

cc: @Vaelatern @leahneukirchen @ericonr @zdykstra 

#### Testing the changes
- I tested the changes in this PR: **briefly**