### PR TITLE
curl: move license to libcurl subpackage.

### DIFF
--- a/srcpkgs/curl/template
+++ b/srcpkgs/curl/template
@@ -1,7 +1,7 @@
 # Template file for 'curl'
 pkgname=curl
 version=7.83.1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="ac_cv_sizeof_off_t=8 --enable-threaded-resolver --enable-ipv6
  $(vopt_with rtmp) $(vopt_with gssapi) $(vopt_enable ldap) $(vopt_with gnutls)
@@ -60,14 +60,13 @@ post_install() {
 		vsed -i $DESTDIR/usr/bin/curl-config \
 			-e "/[	 ]*--static-libs)/,/[	 ]*;;/ s,-L$XBPS_CROSS_BASE,-L,"
 	fi
-
-	vlicense COPYING
 }
 
 libcurl_package() {
 	short_desc="Multiprotocol file transfer library"
 	pkg_install() {
 		vmove "usr/lib/*.so.*"
+		vlicense COPYING
 	}
 }
 


### PR DESCRIPTION
Fixes: #33781

Bikeshed: if we do this for libcurl, I feel like it should be done for all library + tools combo, which doesn't like a fun time or particularly escalable. Thoughts?

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
