### PR TITLE
black: update to 22.3.0.

### DIFF
--- a/srcpkgs/black/template
+++ b/srcpkgs/black/template
@@ -1,30 +1,28 @@
 # Template file for 'black'
 pkgname=black
-version=21.9b0
-revision=2
+version=22.3.0
+revision=1
 build_style=python3-module
-# Disable tests that require `black` in the search path for commands.
-make_check_args="--deselect tests/test_primer.py::PrimerLibTests::test_gen_check_output
- --deselect tests/test_primer.py::PrimerLibTests::test_process_queue
- --deselect tests/test_primer.py::PrimerCLITests::test_async_main"
 hostmakedepends="python3-setuptools python3-setuptools_scm"
-depends="python3-click python3-platformdirs python3-tomli
- python3-mypy_extensions python3-pathspec python3-regex
- python3-typing_extensions"
-checkdepends="python3-typed-ast python3-aiohttp python3-aiohttp-cors
- python3-pytest python3-parameterized python3-ipython python3-tokenize-rt
- $depends"
+depends="python3-click python3-platformdirs python3-tomli python3-pathspec python3-mypy_extensions"
+checkdepends="${depends} python3-pytest-xdist python3-aiohttp python3-colorama python3-uvloop
+ python3-ipython python3-tokenize-rt"
 short_desc="Uncompromising Python code formatter"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/psf/black"
 changelog="https://raw.githubusercontent.com/psf/black/main/CHANGES.md"
 distfiles="${PYPI_SITE}/b/black/black-${version}.tar.gz"
-checksum=7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91
+checksum=35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79
 
-pre_build() {
-	# <https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-python/black/black-21.8_beta0.ebuild#n45>.
-	vsed -i '/setuptools_scm/s:~=:>=:' setup.cfg
+do_check() {
+	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest --run-optional jupyter \
+		-m jupyter --deselect=tests/test_ipynb.py::test_set_input
+
+	pyver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+	mv ${XBPS_MASTERDIR}/usr/lib/python${pyver}/site-packages/IPython ${XBPS_MASTERDIR}/tmp/IPython.bak
+	PYTHONPATH="$(cd build/lib* && pwd)" python3 -m pytest --run-optional no_jupyter
+	mv ${XBPS_MASTERDIR}/tmp/IPython.bak ${XBPS_MASTERDIR}/usr/lib/python${pyver}/site-packages/IPython
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

Supersedes https://github.com/void-linux/void-packages/pull/34520. As I mentioned in a comment there, I had to run the tests twice (with jupyter dependencies enabled/disabled) in accordance with the [upstream testing](https://github.com/psf/black/blob/ae2c0758c9e61a385df9700dc9c231bf54887041/tox.ini#L37). I don't know how to remove a dependency installed via `checkdepends` temporarily in `do_check()`. So I moved the module "manually" out of site-packages.