### PR TITLE
ca-certificates: update to 3.79, drop versioned dependence on openssl

### DIFF
--- a/srcpkgs/ca-certificates/template
+++ b/srcpkgs/ca-certificates/template
@@ -1,6 +1,6 @@
 # Template file for 'ca-certificates'
 pkgname=ca-certificates
-version=20211016+3.77
+version=20211016+3.79
 revision=1
 _nss_version=${version#*+}
 bootstrap=yes
@@ -8,7 +8,7 @@ conf_files="/etc/ca-certificates.conf"
 create_wrksrc=yes
 build_wrksrc="work"
 hostmakedepends="openssl"
-depends="openssl<=2.0_1 run-parts"
+depends="openssl run-parts"
 short_desc="Common CA certificates for SSL/TLS from Mozilla"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, MPL-2.0"
@@ -16,7 +16,7 @@ homepage="https://wiki.mozilla.org/NSS:Root_certs"
 distfiles="${DEBIAN_SITE}/main/c/${pkgname}/${pkgname}_${version%+*}.tar.xz
  ${MOZILLA_SITE}/security/nss/releases/NSS_${_nss_version//\./_}_RTM/src/nss-${_nss_version}.tar.gz"
 checksum="2ae9b6dc5f40c25d6d7fe55e07b54f12a8967d1955d3b7b2f42ee46266eeef88
- 825edf5a2fd35b788a23ff80face591f82919ae3ad2b8f77d424a450d618dedd"
+ ebdf2d6a96613b6fe70ad579e9f983e0e94e0110171cfb2999db633d3394a514"
 
 post_extract() {
 	cp ${FILESDIR}/* $build_wrksrc/mozilla


### PR DESCRIPTION
tested on x86_64-musl, useful for openssl update.