### PR TITLE
New packages: mimalloc-2.1.2, mold-1.11.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4323,3 +4323,4 @@ libjxl_threads.so.0.8 libjxl-0.8.2_1
 libtext-engine-0.1.so.0 text-engine-0.1.1_1
 libvmaf.so.1 vmaf-2.3.1_1
 liblc3.so.1 liblc3-1.0.3_1
+libmimalloc.so.2 mimalloc-2.1.2_1

--- a/srcpkgs/mimalloc-devel
+++ b/srcpkgs/mimalloc-devel
@@ -1,0 +1,1 @@
+mimalloc

--- a/srcpkgs/mimalloc/patches/unify-library-name.patch
+++ b/srcpkgs/mimalloc/patches/unify-library-name.patch
@@ -1,0 +1,20 @@
+make sure the library name is the same no matter whether is built as
+secure or not
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -343,15 +343,6 @@ else()
+ endif()
+ 
+ set(mi_basename "mimalloc")
+-if(MI_SECURE)
+-  set(mi_basename "${mi_basename}-secure")
+-endif()
+-if(MI_TRACK_VALGRIND)
+-  set(mi_basename "${mi_basename}-valgrind")
+-endif()
+-if(MI_TRACK_ASAN)
+-  set(mi_basename "${mi_basename}-asan")
+-endif()
+ string(TOLOWER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_LC)
+ if(NOT(CMAKE_BUILD_TYPE_LC MATCHES "^(release|relwithdebinfo|minsizerel|none)$"))
+   set(mi_basename "${mi_basename}-${CMAKE_BUILD_TYPE_LC}") #append build type (e.g. -debug) if not a release version

--- a/srcpkgs/mimalloc/template
+++ b/srcpkgs/mimalloc/template
@@ -1,0 +1,36 @@
+# Template file for 'mimalloc'
+pkgname=mimalloc
+version=2.1.2
+revision=1
+build_style=cmake
+configure_args="$(vopt_bool secure MI_SECURE)"
+short_desc="General purpose allocator with excellent performance characteristics"
+maintainer="Peter Wang <novalazy@gmail.com>"
+license="MIT"
+homepage="https://github.com/microsoft/mimalloc"
+distfiles="https://github.com/microsoft/mimalloc/archive/v${version}.tar.gz"
+checksum=2b1bff6f717f9725c70bf8d79e4786da13de8a270059e4ba0bdd262ae7be46eb
+
+build_options="secure"
+build_options_default="secure"
+desc_option_secure="Build mimalloc in secure mode"
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
+
+post_install() {
+	vlicense LICENSE
+}
+
+mimalloc-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove usr/lib/libmimalloc.so
+		vmove usr/lib/mimalloc-${version%.*}
+		vmove usr/lib/pkgconfig
+	}
+}

--- a/srcpkgs/mold/patches/test-target-machine.patch
+++ b/srcpkgs/mold/patches/test-target-machine.patch
@@ -1,0 +1,19 @@
+Allow tests to run when targeting i686 on a host where uname -m returns x86_64.
+
+diff --git a/test/elf/common.inc b/test/elf/common.inc
+index 1366db94..c67e35e5 100644
+--- a/test/elf/common.inc
++++ b/test/elf/common.inc
+@@ -13,7 +13,11 @@ canonical_name() {
+   esac
+ }
+ 
+-HOST=$(canonical_name $(uname -m))
++if [ -n "$XBPS_TARGET_MACHINE" ]; then
++  HOST=$(canonical_name "${XBPS_TARGET_MACHINE%-musl}")
++else
++  HOST=$(canonical_name $(uname -m))
++fi
+ 
+ if [ -n "$TRIPLE" ]; then
+   MACHINE=$(canonical_name $(echo $TRIPLE | sed 's/-.*//'))

--- a/srcpkgs/mold/template
+++ b/srcpkgs/mold/template
@@ -1,0 +1,27 @@
+# Template file for 'mold'
+pkgname=mold
+version=2.0.0
+revision=1
+build_style=cmake
+configure_args="-DMOLD_USE_SYSTEM_MIMALLOC=ON
+ -Dmimalloc_DIR=${XBPS_CROSS_BASE}/cmake/mimalloc-2.0"
+makedepends="mimalloc-devel openssl-devel zlib-devel libzstd-devel"
+# It's probably not worth pulling in clang/llvm to run the few tests that
+# depend on them.
+checkdepends="tar zstd libdwarf gdb"
+short_desc="Faster drop-in replacement for existing Unix linkers"
+maintainer="Peter Wang <novalazy@gmail.com>"
+license="MIT"
+homepage="https://github.com/rui314/mold"
+distfiles="https://github.com/rui314/mold/archive/refs/tags/v${version}.tar.gz"
+checksum=2ae8a22db09cbff626df74c945079fa29c1e5f60bbe02502dcf69191cf43527b
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
+fi
+
+post_install() {
+	vlicense LICENSE
+	rm -v ${DESTDIR}/usr/share/doc/mold/LICENSE
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (crossbuilds):
  - x86_64-musl
  - i686-glibc
  - aarch64-glibc
  - aarch64-musl
  - armv7l-glibc
  - armv7l-musl
  - armv6l-glibc
  - armv6l-musl

Note:
- I left /usr/lib/libmimalloc.so in the main package because one of the suggested ways to use mimalloc is
`LD_PRELOAD=/usr/lib/libmimalloc.so  myprogram`