### PR TITLE
New package: key-mon-1.20

### DIFF
--- a/srcpkgs/key-mon/template
+++ b/srcpkgs/key-mon/template
@@ -1,0 +1,18 @@
+# Template file for 'key-mon'
+pkgname=key-mon
+version=1.20
+revision=1
+build_style=python3-module
+hostmakedepends="python3"
+depends="dbus-glib pygtk python3-dbus python3-xlib"
+short_desc="Utility to show live keyboard and mouse status"
+maintainer="Hervy Qurrotul Ainur Rozi <hervyqa@proton.me>"
+license="Apache-2.0"
+homepage="https://github.com/scottkirkwood/key-mon"
+distfiles="https://github.com/scottkirkwood/key-mon/archive/refs/tags/${version}.tar.gz"
+checksum=70c0250ec5168de65ac59a48f5f5c62e91480e4f60f9c02f55b4060c55ca6af2
+
+post_install() {
+	vinstall icons/key-mon.desktop 644 usr/share/applications
+	vinstall icons/key-mon.xpm 644 usr/share/pixmaps
+}

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -234,7 +234,6 @@ replaces="
  kadu<=4.3_6
  keepassx2<=2.0.3_2
  keepassx<=0.4.4_2
- key-mon<=1.17_5
  laditools<=1.1.0_3
  libapp<=20140527_2
  libco-devel<=20_1


### PR DESCRIPTION
keymon has been removed in https://github.com/void-linux/void-packages/pull/29179, but this template uses python3.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)