### PR TITLE
New package: lua-language-server-3.5.0

### DIFF
--- a/srcpkgs/lua-language-server/files/lua-language-server
+++ b/srcpkgs/lua-language-server/files/lua-language-server
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+STATE_PATH=${XDG_STATE_HOME:-$HOME/.local/state}/lua-language-server
+
+exec /usr/lib/lua-language-server/bin/lua-language-server /usr/lib/lua-language-server/main.lua \
+	--logpath="$STATE_PATH/log" --metapath="$STATE_PATH/meta" "$@"

--- a/srcpkgs/lua-language-server/patches/enable-cross-compilation.patch
+++ b/srcpkgs/lua-language-server/patches/enable-cross-compilation.patch
@@ -1,0 +1,16 @@
+diff --git a/make/detect_platform.lua b/make/detect_platform.lua
+index 8dba298..fe8ae3e 100644
+--- a/make/detect_platform.lua
++++ b/make/detect_platform.lua
+@@ -22,9 +22,8 @@ elseif platform.OS == 'Windows' then
+     end
+ elseif platform.OS == 'Linux' then
+     if     lm.platform == nil then
+-    elseif lm.platform == "linux-x64" then
+-    elseif lm.platform == "linux-arm64" then
+-        lm.cc = 'aarch64-linux-gnu-gcc'
++    elseif os.getenv("CC") then
++        lm.cc = os.getenv("CC")
+     else
+         error "unknown platform"
+     end

--- a/srcpkgs/lua-language-server/template
+++ b/srcpkgs/lua-language-server/template
@@ -1,0 +1,33 @@
+# Template file for 'lua-language-server'
+pkgname=lua-language-server
+version=3.5.0
+revision=1
+create_wrksrc=yes
+hostmakedepends="ninja"
+short_desc="Lua LSP implementation written in Lua"
+maintainer="icp <pangolin@vivaldi.net>"
+license="MIT"
+homepage="https://github.com/sumneko/lua-language-server"
+changelog="https://raw.githubusercontent.com/sumneko/lua-language-server/master/changelog.md"
+distfiles="${homepage}/releases/download/${version}/${pkgname}-${version}-submodules.zip"
+checksum=b8dbbd7834fb338a36426b11f8f2cac7c995e7ccf846ac0a5a02b8c7d3b55344
+
+do_build() {
+	ninja -C 3rd/luamake -f compile/ninja/linux.ninja
+	./3rd/luamake/luamake -platform ${XBPS_TARGET_MACHINE} rebuild
+}
+
+do_install() {
+	vinstall main.lua 644 usr/lib/${pkgname}
+	vinstall debugger.lua 644 usr/lib/${pkgname}
+	vinstall changelog.md 644 usr/lib/${pkgname}
+	vinstall bin/main.lua 644 usr/lib/${pkgname}/bin
+	vinstall bin/${pkgname} 755 usr/lib/${pkgname}/bin
+
+	vcopy meta usr/lib/${pkgname}
+	vcopy locale usr/lib/${pkgname}
+	vcopy script usr/lib/${pkgname}
+
+	vbin ${FILESDIR}/lua-language-server
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

Fixes https://github.com/void-linux/void-packages/issues/34436. I couldn't figure out a predefined `build-style` that would work for this. So it's likely missing flags required for cross-compilation as there is no `do_configure()`. I didn't put a separate `do_test()` since the tests seem to be running during the build phase itself. I tested via `lspconfig` in neovim  and it works as expected.