### PR TITLE
xbps-src: add update-local and show-local-updates

### DIFF
--- a/common/xbps-src/shutils/bulk.sh
+++ b/common/xbps-src/shutils/bulk.sh
@@ -54,7 +54,7 @@ bulk_sortdeps() {
 }
 
 bulk_build() {
-    local sys="$1"
+    local cmd="$1"
     local NPROCS=$(($(nproc)*2))
     local NRUNNING=0
 
@@ -67,10 +67,17 @@ bulk_build() {
     fi
 
     # Compare installed pkg versions vs srcpkgs
-    if [[ $sys ]]; then
-        bulk_sortdeps $(xbps-checkvers -f '%n' -I -D $XBPS_DISTDIR)
+    case "$cmd" in
+    installed)
+        bulk_sortdeps $(xbps-checkvers -f '%n' -I -D "$XBPS_DISTDIR")
         return $?
-    fi
+        ;;
+    local)
+        bulk_sortdeps $(xbps-checkvers -f '%n' -i -R "${XBPS_REPOSITORY}" -R "${XBPS_REPOSITORY}/nonfree" -D "$XBPS_DISTDIR")
+        return $?
+        ;;
+    esac
+
     # compare repo pkg versions vs srcpkgs
     for f in $(xbps-checkvers -f '%n' -D $XBPS_DISTDIR); do
         if [ $NRUNNING -eq $NPROCS ]; then
@@ -90,9 +97,9 @@ bulk_build() {
 }
 
 bulk_update() {
-    local args="$1" pkgs f rval
+    local cmd="$1" pkgs f rval
 
-    pkgs="$(bulk_build ${args})"
+    pkgs="$(bulk_build "${cmd}")"
     [[ -z $pkgs ]] && return 0
 
     msg_normal "xbps-src: the following packages must be rebuilt and updated:\n"
@@ -112,7 +119,7 @@ bulk_update() {
             msg_error "xbps-src: failed to build $pkgver pkg!\n"
         fi
     done
-    if [ -n "$pkgs" -a -n "$args" ]; then
+    if [ -n "$pkgs" -a "$cmd" == installed ]; then
         echo
         msg_normal "xbps-src: updating your system, confirm to proceed...\n"
         ${XBPS_SUCMD} "xbps-install --repository=$XBPS_REPOSITORY --repository=$XBPS_REPOSITORY/nonfree -u ${pkgs//[$'\n']/ }" || return 1

--- a/xbps-src
+++ b/xbps-src
@@ -122,6 +122,9 @@ show-repo-updates
 show-sys-updates
     Prints the list of outdated packages in your system.
 
+show-local-updates
+    Prints the list of outdated packages in your local repositories.
+
 sort-dependencies <pkg> <pkgN+1> ...
     Given a list of packages specified as additional arguments, a sorted dependency
     list will be returned to stdout.
@@ -131,6 +134,9 @@ update-bulk
 
 update-sys
     Rebuilds all packages in your system that are outdated and updates them.
+
+update-local
+    Rebuilds all packages in your local repositories that are outdated.
 
 update-check <pkgname>
     Check upstream site of <pkgname> for new releases.
@@ -962,7 +968,10 @@ case "$XBPS_TARGET" in
         bulk_build
         ;;
     show-sys-updates)
-        bulk_build -I
+        bulk_build installed
+        ;;
+    show-local-updates)
+        bulk_build local
         ;;
     sort-dependencies)
         bulk_sortdeps ${@/$XBPS_TARGET/}
@@ -971,7 +980,10 @@ case "$XBPS_TARGET" in
         bulk_update
         ;;
     update-sys)
-        bulk_update -I
+        bulk_update installed
+        ;;
+    update-local)
+        bulk_update local
         ;;
     update-check)
         read_pkg ignore-problems


### PR DESCRIPTION
This makes it simple to bulk build all your outdated packages in the local repository, works with `-r` and branch repos.

There are two similar commands that already exist:
1. `update-sys` which builds outdated installed packages.
2. `update-bulk` which builds outdated packages in configured repositories, so depends on having synced the hosts repositories
and depends on builds already being finished in the remote repos.

With `update-local` you can instead just build a packages manually once and then update them with `./xbps-src update-local` without depending on the state of the host system or remote repositories.