### PR TITLE
mupdf: update to 1.20.0.

### DIFF
--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -1,6 +1,6 @@
 # Template file for 'mupdf'
 pkgname=mupdf
-version=1.19.1
+version=1.20.0
 revision=1
 wrksrc="${pkgname}-${version}-source"
 hostmakedepends="pkg-config zlib-devel libcurl-devel freetype-devel
@@ -14,8 +14,8 @@ short_desc="Lightweight PDF and XPS viewer"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="AGPL-3.0-only"
 homepage="https://mupdf.com"
-distfiles="https://mupdf.com/downloads/archive/${pkgname}-${version}-source.tar.xz"
-checksum=b5eac663fe74f33c430eda342f655cf41fa73d71610f0884768a856a82e3803e
+distfiles="https://mupdf.com/downloads/archive/${pkgname}-${version}-source.tar.lz"
+checksum=68dbb1cf5e31603380ce3f1c7f6c431ad442fa735d048700f50ab4de4c3b0f82
 
 pre_build() {
 	# libmupdf-{threads,pkcs7}.a are required by fbpdf


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

In the 1.20.0 changelog:

> Cross compilation should no longer need a host compiler

Do I have to do anything to account for this change? (not that I understand what it means)