### PR TITLE
ffmpeg: update to 4.4.2.

### DIFF
--- a/srcpkgs/ffmpeg/template
+++ b/srcpkgs/ffmpeg/template
@@ -1,15 +1,15 @@
 # Template file for 'ffmpeg'
 # audacity also needs to be bumped when a new ffmpeg version bumps libavformat's soname!
 pkgname=ffmpeg
-version=4.4.1
-revision=6
+version=4.4.2
+revision=1
 short_desc="Decoding, encoding and streaming software"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://www.ffmpeg.org"
 changelog="https://raw.githubusercontent.com/FFmpeg/FFmpeg/master/Changelog"
 distfiles="${homepage}/releases/ffmpeg-${version}.tar.xz"
-checksum=eadbad9e9ab30b25f5520fbfde99fae4a92a1ae3c0257a8d68569a4651e30e02
+checksum=af419a7f88adbc56c758ab19b4c708afbcae15ef09606b82b855291f6a6faa93
 
 hostmakedepends="pkg-config perl yasm"
 makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-devel
@@ -19,7 +19,7 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  speex-devel celt-devel harfbuzz-devel libass-devel opus-devel ocl-icd-devel
  libbs2b-devel libvidstab-devel $(vopt_if pulseaudio pulseaudio-devel)
  $(vopt_if x265 x265-devel) $(vopt_if vaapi libva-devel) $(vopt_if vdpau libvdpau-devel)
- $(vopt_if v4l2 v4l-utils-devel) $(vopt_if faac faac-devel) $(vopt_if fdk_aac fdk-aac-devel)
+ $(vopt_if v4l2 v4l-utils-devel) $(vopt_if fdk_aac fdk-aac-devel)
  $(vopt_if vpx libvpx-devel) $(vopt_if aom libaom-devel)
  $(vopt_if nvenc nv-codec-headers) $(vopt_if sndio sndio-devel)
  $(vopt_if dav1d libdav1d-devel) $(vopt_if zimg zimg-devel)
@@ -29,7 +29,7 @@ makedepends="zlib-devel bzip2-devel freetype-devel alsa-lib-devel libXfixes-deve
  $(vopt_if srt srt-devel) $(vopt_if rist librist-devel)"
 depends="ffplay>=${version}_${revision}"
 
-build_options="x265 v4l2 vaapi vdpau vpx faac fdk_aac aom nvenc sndio pulseaudio
+build_options="x265 v4l2 vaapi vdpau vpx fdk_aac aom nvenc sndio pulseaudio
  dav1d zimg webp sofa vulkan drm svtav1 srt rist"
 build_options_default="x265 v4l2 vpx aom sndio pulseaudio dav1d webp vulkan drm srt rist"
 
@@ -102,7 +102,6 @@ do_configure() {
 		$(vopt_enable pulseaudio libpulse) --enable-libfreetype --enable-libmodplug \
 		--enable-libspeex --enable-libcelt --enable-libass \
 		--enable-libopus --enable-librtmp --enable-libjack  $(vopt_enable nvenc) \
-		$(vopt_if faac '--enable-nonfree --enable-libfaac') \
 		$(vopt_if fdk_aac '--enable-nonfree --enable-libfdk-aac') \
 		--disable-libopencore_amrnb --disable-libopencore_amrwb \
 		--disable-libopenjpeg \


### PR DESCRIPTION
libfaac support was removed way back in ffmpeg 3.2.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
