### PR TITLE
New package: arti-1.0.0

### DIFF
--- a/srcpkgs/arti/template
+++ b/srcpkgs/arti/template
@@ -1,0 +1,31 @@
+# Template file for 'arti'
+pkgname=arti
+version=1.0.0
+revision=1
+wrksrc="arti-arti-v${version}"
+build_style=cargo
+make_check_args="-- --skip internal::test::internal_macro_test" # fails with --release builds
+make_install_args="--path crates/arti"
+hostmakedepends="pkg-config"
+makedepends="openssl-devel sqlite-devel"
+short_desc="Tor implementation in Rust"
+maintainer="Daniel Eyßer <daniel.eysser@gmail.com>"
+license="Apache-2.0, MIT"
+homepage="https://gitlab.torproject.org/tpo/core/arti"
+changelog="https://gitlab.torproject.org/tpo/core/arti/-/raw/main/CHANGELOG.md"
+distfiles="https://gitlab.torproject.org/tpo/core/arti/-/archive/arti-v${version}/arti-arti-v${version}.tar.gz"
+checksum=4aa5f2f8ce98b913a843542f26895b2f4819829fa3dec9082fa1e8da5e274267
+
+if [ "$XBPS_CHECK_PKGS" ]; then
+	case "$XBPS_TARGET_MACHINE" in
+		# Disable LTO for i686 because otherwise tests fail with:
+		# ---- src/address.rs - address::TorAddr (line 79) stdout ----
+		# error: ran out of registers during register allocation
+		# LLVM ERROR: Cannot emit physreg copy instruction
+		i686*) export CARGO_PROFILE_RELEASE_LTO=false ;;
+	esac
+fi
+
+post_install() {
+	vlicense LICENSE-MIT
+}

--- a/srcpkgs/arti/update
+++ b/srcpkgs/arti/update
@@ -1,0 +1,1 @@
+pkgname=arti-arti


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

The Tor Project is re-implementing Tor in Rust.

https://gitlab.torproject.org/tpo/core/arti
https://blog.torproject.org/arti_050_released/

Not yet production ready, nor feature-parity with C Tor but basic SOCKS proxy support via
```
$ arti proxy -p 9150
```
is usable.

When arti is production ready, I'm planning to add a proper runit service.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
