### PR TITLE
New package: hunspell-ca

### DIFF
--- a/srcpkgs/hunspell-ca/template
+++ b/srcpkgs/hunspell-ca/template
@@ -1,0 +1,18 @@
+# Template file for 'hunspell-ca'
+pkgname=hunspell-ca
+version=3.0.6
+revision=1
+create_wrksrc=yes
+hostmakedepends="unzip"
+short_desc="Catalan dictionary for hunspell"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later, LGPL-2.1-or-later"
+homepage="https://www.softcatala.org/projectes/corrector-ortografic/"
+distfiles="https://github.com/Softcatala/catalan-dict-tools/releases/download/v${version}/ca-hunspell.zip"
+checksum=1652bd89c43a17f576470b467da2d4fbe128683d6054d1c6a31f9967ae067fcd
+
+do_install() {
+	vinstall catalan.aff 644 /usr/share/hunspell ca.aff
+	vinstall catalan.dic 644 /usr/share/hunspell ca.dic
+	vdoc README.txt
+}


### PR DESCRIPTION
Add the official catalan language dictionary for hunspell.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)