### PR TITLE
Fix fillets-ng not including game data

### DIFF
--- a/srcpkgs/fillets-ng/template
+++ b/srcpkgs/fillets-ng/template
@@ -1,7 +1,7 @@
 # Template file for 'fillets-ng'
 pkgname=fillets-ng
 version=1.0.1
-revision=2
+revision=3
 create_wrksrc=yes
 build_wrksrc="fillets-ng-${version}"
 build_style=gnu-configure
@@ -16,3 +16,7 @@ distfiles="${SOURCEFORGE_SITE}/fillets/fillets-ng-${version}.tar.gz
 checksum="329a4d9515d60bebdb657d070824933b993b85864b9d3e302e6361accab992da
  f0c979fb35ec550a43246fc209add8f45ca550a382c94d6383bb3f01b1073799"
 replaces="fillets-ng-data>=0"
+post_install() {
+	mkdir -p ${DESTDIR}/usr/share/games/fillets-ng
+	cp -r $wrksrc/fillets-ng-data-${version}/* ${DESTDIR}/usr/share/games/fillets-ng
+}


### PR DESCRIPTION
Basically all I did was copy `do_install` from the `gnu-configure` build style and add a couple lines to copy the game data into `DESTDIR` as well. I chose to install it to `/usr/share/games/fillets-ng` because that is where Fillets looks for the game data by default.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc