### PR TITLE
ibus: fix memory leaks and double unref

### DIFF
--- a/srcpkgs/ibus/patches/src-Fix-refcounting-issues.patch
+++ b/srcpkgs/ibus/patches/src-Fix-refcounting-issues.patch
@@ -1,0 +1,267 @@
+From 17648f0522910480b6c5dd4f5356ca1f6c160bf5 Mon Sep 17 00:00:00 2001
+From: Carlos Garnacho <carlosg@gnome.org>
+Date: Tue, 29 Mar 2022 22:48:19 +0200
+Subject: [PATCH] src: Fix refcounting issues
+
+Commit 5a455b1ead attempted to fix both GLib warnings around
+floating references and other presumed refcounting issues. However
+it missed 2 kinds of bugs:
+
+- The places that take an IBusText created from a static string
+  were made to avoid freeing it afterwards, but the staticness refers
+  to the string content, not the object itself.
+- The places that are documented to emit signals on floating object
+  references used to do the following after signal emission:
+
+  if (g_object_is_floating (object))
+    g_object_unref (object)
+
+  And did possibly trigger GLib warnings were changed to:
+
+  if (g_object_is_floating (object))
+    g_object_sink_ref (object);
+  g_object_unref (object);
+
+  Which fixes the GLib warning for floating references, but do
+  unintendedly steal one reference away for non floating references.
+
+This commit is essentially a revert of commit 5a455b1ead, but
+addressing both things differently:
+
+- All label/tooltip/symbol IBusText properties in IBusProperty do
+  now always sink the reference of the stored object.
+
+- All places documented as maybe using objects with a floating reference
+  on signals changed to doing:
+
+  if (g_object_is_floating (object)) {
+    g_object_ref_sink (object);
+    g_object_unref (object);
+  }
+
+  So the floating reference is owned and unreferenced without warnings,
+  but already owned references are left unchanged.
+
+This addresses the possible GLib warnings, fixes the possible double
+unrefs happening on IBusText used in signals, and fixes the missing
+unrefs on IBusText objects created from static strings.
+
+BUG=https://github.com/ibus/ibus/issues/2393
+BUG=https://github.com/ibus/ibus/issues/2387
+---
+ src/ibusinputcontext.c | 35 +++++++++++++++++++++--------------
+ src/ibusproperty.c     | 32 +++++++++++++++++---------------
+ 2 files changed, 38 insertions(+), 29 deletions(-)
+
+diff --git a/src/ibusinputcontext.c b/src/ibusinputcontext.c
+index 4b27551bd..7981de381 100644
+--- a/src/ibusinputcontext.c
++++ b/src/ibusinputcontext.c
+@@ -549,9 +549,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+         g_variant_unref (variant);
+         g_signal_emit (context, context_signals[COMMIT_TEXT], 0, text);
+ 
+-        if (g_object_is_floating (text))
++        if (g_object_is_floating (text)) {
+             g_object_ref_sink (text);
+-        g_object_unref (text);
++            g_object_unref (text);
++        }
+         return;
+     }
+     if (g_strcmp0 (signal_name, "UpdatePreeditText") == 0) {
+@@ -569,9 +570,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+                        cursor_pos,
+                        visible);
+ 
+-        if (g_object_is_floating (text))
++        if (g_object_is_floating (text)) {
+             g_object_ref_sink (text);
+-        g_object_unref (text);
++            g_object_unref (text);
++        }
+         return;
+     }
+     if (g_strcmp0 (signal_name, "UpdatePreeditTextWithMode") == 0) {
+@@ -592,9 +594,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+                        visible,
+                        mode);
+ 
+-        if (g_object_is_floating (text))
++        if (g_object_is_floating (text)) {
+             g_object_ref_sink (text);
+-        g_object_unref (text);
++            g_object_unref (text);
++        }
+         return;
+     }
+ 
+@@ -621,9 +624,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+                        0,
+                        text,
+                        visible);
+-        if (g_object_is_floating (text))
++        if (g_object_is_floating (text)) {
+             g_object_ref_sink (text);
+-        g_object_unref (text);
++            g_object_unref (text);
++        }
+         return;
+     }
+ 
+@@ -640,9 +644,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+                        0,
+                        table,
+                        visible);
+-        if (g_object_is_floating (table))
++        if (g_object_is_floating (table)) {
+             g_object_ref_sink (table);
+-        g_object_unref (table);
++            g_object_unref (table);
++        }
+         return;
+ 
+     }
+@@ -659,9 +664,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+                        0,
+                        prop_list);
+ 
+-        if (g_object_is_floating (prop_list))
++        if (g_object_is_floating (prop_list)) {
+             g_object_ref_sink (prop_list);
+-        g_object_unref (prop_list);
++            g_object_unref (prop_list);
++        }
+         return;
+     }
+ 
+@@ -673,9 +679,10 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
+ 
+         g_signal_emit (context, context_signals[UPDATE_PROPERTY], 0, prop);
+ 
+-        if (g_object_is_floating (prop))
++        if (g_object_is_floating (prop)) {
+             g_object_ref_sink (prop);
+-        g_object_unref (prop);
++            g_object_unref (prop);
++        }
+         return;
+     }
+ 
+diff --git a/src/ibusproperty.c b/src/ibusproperty.c
+index 6d4ed088e..cd8a0e2a6 100644
+--- a/src/ibusproperty.c
++++ b/src/ibusproperty.c
+@@ -336,20 +336,17 @@ ibus_property_destroy (IBusProperty *prop)
+     prop->priv->icon = NULL;
+ 
+     if (prop->priv->label) {
+-        if (!ibus_text_get_is_static (prop->priv->label))
+-            g_object_unref (prop->priv->label);
++        g_object_unref (prop->priv->label);
+         prop->priv->label = NULL;
+     }
+ 
+     if (prop->priv->symbol) {
+-        if (!ibus_text_get_is_static (prop->priv->symbol))
+-            g_object_unref (prop->priv->symbol);
++        g_object_unref (prop->priv->symbol);
+         prop->priv->symbol = NULL;
+     }
+ 
+     if (prop->priv->tooltip) {
+-        if (!ibus_text_get_is_static (prop->priv->tooltip))
+-            g_object_unref (prop->priv->tooltip);
++        g_object_unref (prop->priv->tooltip);
+         prop->priv->tooltip = NULL;
+     }
+ 
+@@ -404,7 +401,7 @@ ibus_property_deserialize (IBusProperty *prop,
+     g_variant_get_child (variant, retval++, "u", &prop->priv->type);
+ 
+     GVariant *subvar = g_variant_get_child_value (variant, retval++);
+-    if (prop->priv->label && !ibus_text_get_is_static (prop->priv->label)) {
++    if (prop->priv->label) {
+         g_object_unref (prop->priv->label);
+     }
+     prop->priv->label = IBUS_TEXT (ibus_serializable_deserialize (subvar));
+@@ -414,7 +411,7 @@ ibus_property_deserialize (IBusProperty *prop,
+     ibus_g_variant_get_child_string (variant, retval++, &prop->priv->icon);
+ 
+     subvar = g_variant_get_child_value (variant, retval++);
+-    if (prop->priv->tooltip && !ibus_text_get_is_static (prop->priv->tooltip)) {
++    if (prop->priv->tooltip) {
+         g_object_unref (prop->priv->tooltip);
+     }
+     prop->priv->tooltip = IBUS_TEXT (ibus_serializable_deserialize (subvar));
+@@ -435,7 +432,7 @@ ibus_property_deserialize (IBusProperty *prop,
+ 
+     /* Keep the serialized order for the compatibility when add new members. */
+     subvar = g_variant_get_child_value (variant, retval++);
+-    if (prop->priv->symbol && !ibus_text_get_is_static (prop->priv->symbol)) {
++    if (prop->priv->symbol) {
+         g_object_unref (prop->priv->symbol);
+     }
+     prop->priv->symbol = IBUS_TEXT (ibus_serializable_deserialize (subvar));
+@@ -567,7 +564,7 @@ ibus_property_set_label (IBusProperty *prop,
+     g_assert (IBUS_IS_PROPERTY (prop));
+     g_return_if_fail (label == NULL || IBUS_IS_TEXT (label));
+ 
+-    if (prop->priv->label && !ibus_text_get_is_static (prop->priv->label)) {
++    if (prop->priv->label) {
+         g_object_unref (prop->priv->label);
+     }
+ 
+@@ -575,8 +572,10 @@ ibus_property_set_label (IBusProperty *prop,
+         prop->priv->label = ibus_text_new_from_static_string ("");
+     }
+     else {
+-        prop->priv->label = g_object_ref_sink (label);
++        prop->priv->label = label;
+     }
++
++    g_object_ref_sink (prop->priv->label);
+ }
+ 
+ void
+@@ -586,7 +585,7 @@ ibus_property_set_symbol (IBusProperty *prop,
+     g_assert (IBUS_IS_PROPERTY (prop));
+     g_return_if_fail (symbol == NULL || IBUS_IS_TEXT (symbol));
+ 
+-    if (prop->priv->symbol && !ibus_text_get_is_static (prop->priv->symbol)) {
++    if (prop->priv->symbol) {
+         g_object_unref (prop->priv->symbol);
+     }
+ 
+@@ -594,8 +593,10 @@ ibus_property_set_symbol (IBusProperty *prop,
+         prop->priv->symbol = ibus_text_new_from_static_string ("");
+     }
+     else {
+-        prop->priv->symbol = g_object_ref_sink (symbol);
++        prop->priv->symbol = symbol;
+     }
++
++    g_object_ref_sink (prop->priv->symbol);
+ }
+ 
+ void
+@@ -615,7 +616,7 @@ ibus_property_set_tooltip (IBusProperty *prop,
+     g_assert (IBUS_IS_PROPERTY (prop));
+     g_assert (tooltip == NULL || IBUS_IS_TEXT (tooltip));
+ 
+-    if (prop->priv->tooltip && !ibus_text_get_is_static (prop->priv->tooltip)) {
++    if (prop->priv->tooltip) {
+         g_object_unref (prop->priv->tooltip);
+     }
+ 
+@@ -624,8 +625,9 @@ ibus_property_set_tooltip (IBusProperty *prop,
+     }
+     else {
+         prop->priv->tooltip = tooltip;
+-        g_object_ref_sink (prop->priv->tooltip);
+     }
++
++    g_object_ref_sink (prop->priv->tooltip);
+ }
+ 
+ void

--- a/srcpkgs/ibus/template
+++ b/srcpkgs/ibus/template
@@ -1,7 +1,7 @@
 # Template file for 'ibus'
 pkgname=ibus
 version=1.5.26
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--enable-ui --enable-gtk3 --enable-gtk4


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Sorry, this is something I missed during the last ibus update.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
