### PR TITLE
libopenraw: split the pixbuf loader into subpackage

### DIFF
--- a/srcpkgs/libopenraw-pixbuf-loader
+++ b/srcpkgs/libopenraw-pixbuf-loader
@@ -1,0 +1,1 @@
+libopenraw

--- a/srcpkgs/libopenraw/template
+++ b/srcpkgs/libopenraw/template
@@ -1,7 +1,7 @@
 # Template file for 'libopenraw'
 pkgname=libopenraw
 version=0.1.3
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-boost=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="pkg-config curl"
@@ -10,8 +10,8 @@ short_desc="Library for camera RAW files decoding"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-3.0-or-later"
 #changelog="https://raw.githubusercontent.com/hfiguiere/libopenraw/master/NEWS"
-homepage="https://${pkgname}.freedesktop.org/wiki/"
-distfiles="https://${pkgname}.freedesktop.org/download/${pkgname}-${version}.tar.bz2"
+homepage="https://libopenraw.freedesktop.org/wiki/"
+distfiles="https://libopenraw.freedesktop.org/download/libopenraw-${version}.tar.bz2"
 checksum=6405634f555849eb01cb028e2a63936e7b841151ea2a1571ac5b5b10431cfab9
 
 post_install() {
@@ -27,5 +27,13 @@ libopenraw-devel_package() {
 		vmove "usr/lib/*.a"
 		vmove usr/lib/pkgconfig
 		vmove usr/include
+	}
+}
+
+libopenraw-pixbuf-loader_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	description=" - pixbuf loader"
+	pkg_install() {
+		vmove "usr/lib/gdk-pixbuf-2.0"
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Someone had this issue on the GNOME matrix, libopenraw-pixbuf-loader wasn't loading their CR2 file correctly and I can reproduce it.
Without the libopenraw pixbufloader, eog was able to load the CR2 file correctly. The pixbuf loader is currently apart of the libopenraw package which is a dependency of xfce thumbler.

Seeing as the pixbuf loader part isn't needed by xfce or eog and the pixbuf loader is considered deprecated upstream, probably best to split it into its own subpackage so people can install it if they really need it.



https://gitlab.freedesktop.org/libopenraw/libopenraw/-/issues/10

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
