### PR TITLE
nss: package libnsssysinit.so.

### DIFF
--- a/srcpkgs/nss/template
+++ b/srcpkgs/nss/template
@@ -4,7 +4,7 @@ _nsprver=4.34
 
 pkgname=nss
 version=3.80
-revision=1
+revision=2
 hostmakedepends="perl which"
 makedepends="nspr-devel sqlite-devel zlib-devel"
 depends="nspr>=${_nsprver}"
@@ -110,7 +110,7 @@ do_install() {
 	chmod 755 ${DESTDIR}/usr/bin/nss-config
 
 	for f in libsoftokn3.so libfreebl3.so libnss3.so libnssutil3.so \
-		libssl3.so libsmime3.so libnssckbi.so libnssdbm3.so; do
+		libssl3.so libsmime3.so libnssckbi.so libnssdbm3.so libnsssysinit.so; do
 		install -m755 dist/*.OBJ/lib/${f} ${DESTDIR}/usr/lib
 	done
 


### PR DESCRIPTION
I needed this to be able to force Firefox to use a system-wide
nss certificate store.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
- I built this PR locally for my native architecture, (x86_64-musl)
