### PR TITLE
mpg123: update to 1.30.0.

### DIFF
--- a/srcpkgs/mpg123/template
+++ b/srcpkgs/mpg123/template
@@ -1,11 +1,10 @@
 # Template file for 'mpg123'
 pkgname=mpg123
-version=1.29.3
+version=1.30.0
 revision=1
 build_style=gnu-configure
 # --with-cpu not necessary, upstream detects features correctly
-configure_args="--with-optimization=0 --with-default-audio=alsa
- --enable-ipv6=yes --enable-network=yes"
+configure_args="--with-optimization=0 --with-default-audio=alsa"
 hostmakedepends="pkg-config"
 makedepends="alsa-lib-devel jack-devel pulseaudio-devel sndio-devel SDL2-devel"
 short_desc="Fast console MPEG audio decoder/player"
@@ -13,7 +12,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-only"
 homepage="https://www.mpg123.org/"
 distfiles="${SOURCEFORGE_SITE}/mpg123/mpg123-${version}.tar.bz2"
-checksum=963885d8cc77262f28b77187c7d189e32195e64244de2530b798ddf32183e847
+checksum=397ead52f0299475f2cefd38c3835977193fd9b1db6593680346c4e9109ed61c
 
 case "$XBPS_TARGET_MACHINE" in
 	# No LFS required with musl


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Unless explicitly configured to use only the internal network code, it requires either `wget` (default) or `curl` to support HTTP streaming. It doesn't fallback on the internal code when neither are found. What should the package depend on?