### PR TITLE
Ansible 6.0.0

### DIFF
--- a/srcpkgs/ansible-core/patches/0001-use-command-v-instead-of-which-in-Makefile.patch
+++ b/srcpkgs/ansible-core/patches/0001-use-command-v-instead-of-which-in-Makefile.patch
@@ -1,0 +1,32 @@
+From 40acbda0805b0a43d723a1cc73fba8b40b624940 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Thu, 30 Jun 2022 15:33:46 +0200
+Subject: [PATCH 1/2] use 'command -v' instead of 'which' in Makefile
+
+'which' is not standardized and can even be considered problematic [1]
+
+[1] https://lwn.net/Articles/874049/
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 7641344968..45421e88e0 100644
+--- a/Makefile
++++ b/Makefile
+@@ -18,9 +18,9 @@ SDIST_DIR ?= 'dist'
+ # This doesn't evaluate until it's called. The -D argument is the
+ # directory of the target file ($@), kinda like `dirname`.
+ MANPAGES ?= $(patsubst %.rst.in,%,$(wildcard ./docs/man/man1/ansible*.1.rst.in))
+-ifneq ($(shell which rst2man 2>/dev/null),)
++ifneq ($(shell command -v rst2man 2>/dev/null),)
+ ASCII2MAN = rst2man $< $@
+-else ifneq ($(shell which rst2man.py 2>/dev/null),)
++else ifneq ($(shell command -v rst2man.py 2>/dev/null),)
+ ASCII2MAN = rst2man.py $< $@
+ else
+ ASCII2MAN = @echo "ERROR: rst2man from docutils command is not installed but is required to build $(MANPAGES)" && exit 1
+-- 
+2.36.1
+

--- a/srcpkgs/ansible-core/patches/0002-Make-unit-test-for-missing-git-executable-more-gener.patch
+++ b/srcpkgs/ansible-core/patches/0002-Make-unit-test-for-missing-git-executable-more-gener.patch
@@ -1,0 +1,38 @@
+From 9d0ab3aa9d0dd1a3d3885b44448acb262396a57d Mon Sep 17 00:00:00 2001
+From: Sloane Hertel <19572925+s-hertel@users.noreply.github.com>
+Date: Thu, 30 Jun 2022 13:19:44 -0400
+Subject: [PATCH 2/2] Make unit test for missing git executable more generic
+ (#78173)
+
+* Make unit test for missing git executable more generic
+
+* use MagicMock side_effect to raise exception instead
+---
+ test/units/galaxy/test_collection_install.py | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/test/units/galaxy/test_collection_install.py b/test/units/galaxy/test_collection_install.py
+index 7525a194ca..d83fe42054 100644
+--- a/test/units/galaxy/test_collection_install.py
++++ b/test/units/galaxy/test_collection_install.py
+@@ -181,13 +181,14 @@ def test_concrete_artifact_manager_scm_no_executable(monkeypatch):
+     monkeypatch.setattr(collection.concrete_artifact_manager.subprocess, 'check_call', mock_subprocess_check_call)
+     mock_mkdtemp = MagicMock(return_value='')
+     monkeypatch.setattr(collection.concrete_artifact_manager, 'mkdtemp', mock_mkdtemp)
++    mock_get_bin_path = MagicMock(side_effect=[ValueError('Failed to find required executable')])
++    monkeypatch.setattr(collection.concrete_artifact_manager, 'get_bin_path', mock_get_bin_path)
+ 
+     error = re.escape(
+         "Could not find git executable to extract the collection from the Git repository `https://github.com/org/repo`"
+     )
+-    with mock.patch.dict(os.environ, {"PATH": ""}):
+-        with pytest.raises(AnsibleError, match=error):
+-            collection.concrete_artifact_manager._extract_collection_from_git(url, version, b'path')
++    with pytest.raises(AnsibleError, match=error):
++        collection.concrete_artifact_manager._extract_collection_from_git(url, version, b'path')
+ 
+ 
+ @pytest.mark.parametrize(
+-- 
+2.36.1
+

--- a/srcpkgs/ansible-core/template
+++ b/srcpkgs/ansible-core/template
@@ -1,30 +1,40 @@
 # Template file for 'ansible-core'
 pkgname=ansible-core
-version=2.12.6
+version=2.13.1
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="${hostmakedepends} python3-cryptography python3-Jinja2 python3-paramiko
- python3-yaml python3-packaging python3-resolvelib"
+hostmakedepends="python3-setuptools python3-wheel python3-packaging
+ python3-straight.plugin python3-docutils python3-Jinja2 python3-yaml"
+depends="python3-cryptography python3-Jinja2 python3-paramiko python3-yaml
+ python3-packaging python3-resolvelib python3-pytz git"
+checkdepends="${depends} python3-pytest python3-pytest-xdist
+ python3-pytest-forked unzip openssh python3-pytest-mock libselinux"
 short_desc="Simple deployment, configuration management and execution framework"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 distfiles="${PYPI_SITE}/a/ansible-core/ansible-core-${version}.tar.gz"
-checksum=5f366e851159d8f72ce68d32b8c0edda56ee537c01e9f68eca382bd1510af65d
+checksum=abd478ceff1a0aba95e94ceab8dc820f407bcc0f0033dc546840cddc29a36958
 conflicts="ansible<2.10.1_1"
 replaces="ansible-base<2.11.0_1"
-# Tests are currently broken for ansible on python 3.10
-# See https://github.com/ansible/ansible/issues/74658
-# and https://github.com/ansible/ansible/issues/74660
-make_check=no
 
-post_install() {
+do_build() {
+	python setup.py build
+}
+
+do_check() {
+	TEST_FLAGS="${make_check_args}" make tests-py3
+}
+
+do_install() {
+	python setup.py install --root="${DESTDIR}"
+
+	make docs
+	for page in docs/man/man1/*.1; do
+		vman ${page}
+	done
+
 	vsconf examples/ansible.cfg
 	vsconf examples/hosts
-	for m in docs/man/man1/*.1; do
-		vman ${m}
-	done
 }
 
 ansible-base_package() {

--- a/srcpkgs/ansible/template
+++ b/srcpkgs/ansible/template
@@ -1,17 +1,15 @@
 # Template file for 'ansible'
 pkgname=ansible
-version=5.9.0
+version=6.0.0
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style="python3-pep517"
+hostmakedepends="python3-setuptools python3-wheel"
 depends="ansible-core"
 short_desc="Simple deployment, configuration management and execution framework"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.ansible.com/"
 distfiles="${PYPI_SITE}/a/ansible/ansible-${version}.tar.gz"
-checksum=6f2f762fca6cff0401a6d2119b8ba3b2f111ea1a93fd203c86df09bc75570f18
-# Tests are currently broken for ansible on python 3.10
-# See https://github.com/ansible/ansible/issues/74658
-# and https://github.com/ansible/ansible/issues/74660
+checksum=641a2c27bc5768f9a8ad14880f1f6e571c1f2af1d45e76f271d76e3f74754c53
+# Relevant tests happen in ansible-core
 make_check=no

--- a/srcpkgs/python3-straight.plugin/template
+++ b/srcpkgs/python3-straight.plugin/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-straight.plugin'
+pkgname=python3-straight.plugin
+version=1.5.0
+revision=1
+wrksrc="${pkgname/python3-/}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3"
+short_desc="Python plugin loading facility"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT"
+homepage="https://straightplugin.readthedocs.io/"
+distfiles="${PYPI_SITE}/s/${pkgname/python3-/}/${pkgname/python3-/}-${version}.tar.gz"
+checksum=818a7641068932ed6436d0af0a3bb77bbbde29df0a7142c8bd1a249e7c2f0d38
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

First patch has been merged upstream and will become available in 2.14, second patch has been merged upstream and a backport attempt was started as well, so it might arrive in 2.13.2 already.

We finally have tests running on ansible-core again, which surfaced https://github.com/ansible/ansible/issues/78169, which was fixed in under half a day by upstream, so yay :)

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
