### PR TITLE
conmon: update to 2.1.2

### DIFF
--- a/srcpkgs/conmon/template
+++ b/srcpkgs/conmon/template
@@ -1,19 +1,24 @@
 # Template file for 'conmon'
 pkgname=conmon
-version=2.1.1
+version=2.1.2
 revision=1
 build_style=gnu-makefile
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config go-md2man"
 makedepends="libglib-devel libseccomp-devel"
 short_desc="OCI container runtime monitor"
 maintainer="Cameron Nemo <cnemo@tutanota.com>"
 license="Apache-2.0"
 homepage="https://github.com/containers/conmon"
 distfiles="https://github.com/containers/conmon/archive/v${version}.tar.gz"
-checksum=676bcd5eb7d51cd5510ac9b7513726d9d0e42698fb01e763c25aad8f0c7edde4
+checksum=8ba76eb54c319197235fd39c3a5b5a975b5a21e02cd4be985b8619220a497a0e
+
+post_build() {
+	make -C docs GOMD2MAN=go-md2man
+}
 
 do_install() {
 	vbin bin/conmon
 	vmkdir usr/libexec/podman
 	ln -sf ../../bin/conmon "${DESTDIR}/usr/libexec/podman"
+	make -C docs install DESTDIR="$DESTDIR" PREFIX=/usr
 }


### PR DESCRIPTION
Fixes CVE-2022-1708
Include manpage

Supersedes #37764

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
