### PR TITLE
fs-repo-migrations: update to 2.0.2.

### DIFF
--- a/srcpkgs/fs-repo-migrations/template
+++ b/srcpkgs/fs-repo-migrations/template
@@ -1,19 +1,30 @@
 # Template file for 'fs-repo-migrations'
 pkgname=fs-repo-migrations
-version=1.7.1
+version=2.0.2
 revision=1
+wrksrc=fs-repo-migrations-fs-repo-11-to-12-v1.0.2
 build_style=go
 go_import_path="github.com/ipfs/fs-repo-migrations"
 short_desc="Tool to upgrade the IPFS filesystem repository"
 maintainer="Christopher Brannon <chris@the-brannons.com>"
 license="MIT"
 homepage="https://github.com/ipfs/fs-repo-migrations"
-distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=6fbd68a6ae5eabcebdd0dc81e909a069facb112c4fe0421f159ab58112a041c2
+distfiles="https://github.com/ipfs/fs-repo-migrations/archive/refs/tags/fs-repo-11-to-12/v1.0.2.tar.gz"
+checksum=e6d6320e280f3118873dfb194b68681fa2747b7893d99831fa6fa2bbb67ebd71
 
 # fix: collect2: fatal error: cannot find 'ld'
 export LDFLAGS="-fuse-ld=bfd"
 
+do_build() {
+	for migration in fs-repo-*-to-*; do
+		(
+			cd $migration
+			go install -p "$XBPS_MAKEJOBS" -mod="vendor" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}"
+		)
+	done
+	cd fs-repo-migrations
+	go install -p "$XBPS_MAKEJOBS" -x -tags "${go_build_tags}" -ldflags "${go_ldflags}"
+}
 post_install() {
 	vlicense LICENSE
 	vdoc README.md


### PR DESCRIPTION
This got unnecessarily hard to package. But using the auto download just takes ages. The latest release is missing the 11 to 12 migration. So the version number isn't quite correct.
Anyway, I thought I make it available in case someone needs this to try #37561.
#### Testing the changes
- I tested the changes in this PR: **briefly**

