### PR TITLE
RcloneBrowser: do not check for updates by default

### DIFF
--- a/srcpkgs/RcloneBrowser/patches/do-not-check-for-updates.patch
+++ b/srcpkgs/RcloneBrowser/patches/do-not-check-for-updates.patch
@@ -1,0 +1,51 @@
+From 2976c391098c83bce55547db0b8c5d70c046fde1 Mon Sep 17 00:00:00 2001
+From: Michal Vasilek <michal@vasilek.cz>
+Date: Fri, 1 Jul 2022 19:32:55 +0200
+Subject: [PATCH] do not check for updates
+
+---
+ src/main_window.cpp        | 4 ++--
+ src/preferences_dialog.cpp | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/main_window.cpp b/src/main_window.cpp
+index 3bf6340..41d4f93 100644
+--- a/src/main_window.cpp
++++ b/src/main_window.cpp
+@@ -527,7 +527,7 @@ void MainWindow::rcloneGetVersion() {
+         // during first run the key might not exist yet
+         if (!(settings->contains("Settings/checkRcloneUpdates"))) {
+           // if checkRcloneUpdates does not exist create new key
+-          settings->setValue("Settings/checkRcloneUpdates", true);
++          settings->setValue("Settings/checkRcloneUpdates", false);
+         };
+ 
+         bool checkRcloneUpdates =
+@@ -605,7 +605,7 @@ void MainWindow::rcloneGetVersion() {
+         // during first run the key might not exist yet
+         if (!(settings->contains("Settings/checkRcloneBrowserUpdates"))) {
+           // if checkRcloneBrowserUpdates does not exist create new key
+-          settings->setValue("Settings/checkRcloneBrowserUpdates", true);
++          settings->setValue("Settings/checkRcloneBrowserUpdates", false);
+         };
+ 
+         bool checkRcloneBrowserUpdates =
+diff --git a/src/preferences_dialog.cpp b/src/preferences_dialog.cpp
+index 1564621..76eb531 100644
+--- a/src/preferences_dialog.cpp
++++ b/src/preferences_dialog.cpp
+@@ -94,9 +94,9 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
+       settings->value("Settings/defaultRcloneOptions").toString());
+ 
+   ui.checkRcloneBrowserUpdates->setChecked(
+-      settings->value("Settings/checkRcloneBrowserUpdates", true).toBool());
++      settings->value("Settings/checkRcloneBrowserUpdates", false).toBool());
+   ui.checkRcloneUpdates->setChecked(
+-      settings->value("Settings/checkRcloneUpdates", true).toBool());
++      settings->value("Settings/checkRcloneUpdates", false).toBool());
+ 
+   if (QSystemTrayIcon::isSystemTrayAvailable()) {
+     ui.alwaysShowInTray->setChecked(
+-- 
+2.37.0
+

--- a/srcpkgs/RcloneBrowser/template
+++ b/srcpkgs/RcloneBrowser/template
@@ -1,7 +1,7 @@
 # Template file for 'RcloneBrowser'
 pkgname=RcloneBrowser
 version=1.8.0
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="qt5-devel"
 makedepends="qt5-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

It checks once a day and this PR only changes the default = if you ran rclone-browser at least once, the settings are already written and this PR won't change anything for you.

@zdykstra

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
