### PR TITLE
fix(fzf): make neovim plugin optional

### DIFF
--- a/srcpkgs/fzf/template
+++ b/srcpkgs/fzf/template
@@ -21,7 +21,7 @@ post_install() {
 
 	sed -i -e 's#source ~/\.fzf\.bash; ##' shell/key-bindings.bash
 	vinstall plugin/fzf.vim 644 usr/share/vim/vimfiles/plugin
-	vinstall plugin/fzf.vim 644 usr/share/nvim/runtime/plugin
+	vinstall plugin/fzf.vim 644 usr/share/nvim/runtime/pack/fzf/opt/plugin
 
 	vinstall shell/completion.bash 644 usr/share/fzf
 	vinstall shell/completion.zsh 644 usr/share/fzf


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**

Motivation: `fzf` package installs `fzf.vim` in `/usr/share/nvim/runtime/plugin/`, but not all people who use fzf, want to use it inside nvim, so it should be placed in `/usr/share/nvim/runtime/pack/fzf/opt/` to make it optional. Users can load this plugin in their `init.vim`:
```vim
packadd fzf
```