### PR TITLE
goatcounter: update to 2.2.3, add service

### DIFF
--- a/srcpkgs/goatcounter/files/README.voidlinux
+++ b/srcpkgs/goatcounter/files/README.voidlinux
@@ -1,0 +1,16 @@
+The system service /etc/sv/goatcounter runs goatcounter as system user _goatcounter.
+
+By default sqlite database is used. The database will be stored in
+/var/db/goatcounter/db.sqlite3.
+
+To initialize the database, make sure you run goatcounter as the _goatcounter user:
+
+$ sudo -u _goatcounter goatcounter db create site \
+    -user.email 'admin@domain.name' \
+    -vhost site.name \
+    -db sqlite+/var/db/goatcounter/db.sqlite3
+
+By default the service listens on 5000 port and does not use TLS. In production
+envirnment you must adjust service config by creating /var/goatcounter/conf
+
+OPTS=-listen ... -db ...

--- a/srcpkgs/goatcounter/files/goatcounter/log/run
+++ b/srcpkgs/goatcounter/files/goatcounter/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec logger -p daemon.notice -t goatcounter

--- a/srcpkgs/goatcounter/files/goatcounter/run
+++ b/srcpkgs/goatcounter/files/goatcounter/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+[ -r ./conf ] && . ./conf
+
+: "${OPTS:=-db sqlite+/var/db/goatcounter/db.sqlite3?_busy_timeout=200&_journal_mode=wal&cache=shared -listen :5000 -public-port 5000 -tls none}"
+
+exec chpst -u _goatcounter goatcounter serve ${OPTS}

--- a/srcpkgs/goatcounter/template
+++ b/srcpkgs/goatcounter/template
@@ -1,9 +1,9 @@
 # Template file for 'goatcounter'
 pkgname=goatcounter
-version=2.0.3
+version=2.2.3
 revision=1
 build_style=go
-go_import_path=zgo.at/goatcounter
+go_import_path=zgo.at/goatcounter/v2
 go_package="${go_import_path}/cmd/goatcounter"
 go_ldflags="-X zgo.at/goatcounter.Version=${version}"
 depends="tzdata"
@@ -12,4 +12,11 @@ maintainer="Martin Tournoij <martin@arp242.net>"
 license="EUPL-1.2"
 homepage="https://www.goatcounter.com/"
 distfiles="https://github.com/zgoat/goatcounter/archive/v${version}.tar.gz"
-checksum=d7477240602c4d6522fb528276378879cda35dea0ba4b174143e36a410398023
+checksum=5b3b07afda42752d7c9600a8671bbb30e70a98c656505eda99a4e67b309a94fc
+system_accounts="_goatcounter"
+make_dirs="/var/db/goatcounter 0750 _goatcounter _goatcounter"
+
+post_install() {
+	vsv goatcounter
+	vdoc $FILESDIR/README.voidlinux
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

I added the service for convinience.

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
