### PR TITLE
New package: haiti-1.3.0

### DIFF
--- a/srcpkgs/haiti/template
+++ b/srcpkgs/haiti/template
@@ -1,0 +1,84 @@
+# Template file for 'haiti'
+pkgname=haiti
+_gemname=haiti-hash
+version=1.3.0
+revision=1
+build_style=gem
+depends="ruby-docopt ruby-paint"
+short_desc="Hash type identifier (CLI & lib)"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://noraj.github.io/haiti/"
+changelog="https://github.com/noraj/haiti/blob/master/docs/CHANGELOG.md"
+distfiles="https://rubygems.org/downloads/${_gemname}-${version}.gem>${pkgname}-${version}.gem"
+checksum=d2a2808cc1626bc5bb24c34a211645c2b3749af6f7d595a9a2d65d1be0d72a9f
+
+do_install() {
+	: ${gem_cmd:=gem}
+
+	local _GEMDIR _INSTDIR
+	
+	_GEMDIR=$($gem_cmd env gemdir)
+	_INSTDIR=${DESTDIR}/${_GEMDIR}/gems/${_gemname}-${version}
+
+	$gem_cmd install \
+		--local \
+		--install-dir ${DESTDIR}/${_GEMDIR} \
+		--bindir ${DESTDIR}/usr/bin \
+		--ignore-dependencies \
+		--no-document \
+		--verbose \
+		${XBPS_SRCDISTDIR}/${pkgname}-${version}/${pkgname#ruby-}-${version}.gem
+
+	# Remove cache
+	rm -rf ${DESTDIR}/${_GEMDIR}/cache
+
+	# Remove ext directory. they are only source code and configuration
+	# The actual extensions are guarded in an arch path
+	rm -rf ${_INSTDIR}/ext
+
+	# Remove installed tests and benchmarks
+	rm -rf ${_INSTDIR}/{test,tests,autotest,benchmark,benchmarks,script,examples,demo}
+
+	# Remove files shipped on the root of the gem, most of the time they are useless
+	find ${_INSTDIR} -maxdepth 1 -type f -delete
+
+	# Remove unnecessary files
+	find ${DESTDIR}/${_GEMDIR}/extensions \( -name mkmf.log -o -name gem_make.out \) -delete
+
+	# Place manpages in usr/share/man/man[0-9]
+	if [ -d ${_INSTDIR}/man ]; then
+		find ${_INSTDIR}/man -type f -name '*.[0-8n]' | while read -r m; do
+			vman ${m}
+		done
+	fi
+
+	rm -rf "${_INSTDIR}/man"
+
+	# Place executables in /usr/bin
+	if [ -d "${_INSTDIR}/bin" ]; then
+		for f in "${_INSTDIR}"/bin/*; do
+			vbin "${f}"
+		done
+	fi
+
+	rm -rf ${_INSTDIR}/bin
+
+	# Place conf files in their places
+	if [ -d ${_INSTDIR}/etc ]; then
+		find ${_INSTDIR}/etc -type f | while read -r c; do
+			vmkdir ${c%/*}/
+			mv ${c} "${DESTDIR}/${c##*${_INSTDIR}/etc/}/"
+		done
+	fi
+
+	rm -rf ${_INSTDIR}/etc
+
+	# Ignore the ~> operator, replace it with >=
+	sed 's|~>|>=|g' \
+		-i ${DESTDIR}/${_GEMDIR}/specifications/${_gemname}-${version}.gemspec
+}
+
+post_install() {
+	vlicense LICENSE.txt
+}

--- a/srcpkgs/ruby-docopt/template
+++ b/srcpkgs/ruby-docopt/template
@@ -1,0 +1,14 @@
+# Template file for 'ruby-docopt'
+pkgname=ruby-docopt
+version=0.6.1
+revision=1
+build_style=gem
+short_desc="Command line option parser, that will make you smile"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://rubygems.org/gems/docopt"
+checksum=73f837ed376d015971712c17f7aafa021998b964b77d52997dcaff79d6727467
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/ruby-paint/template
+++ b/srcpkgs/ruby-paint/template
@@ -1,0 +1,14 @@
+# Template file for 'ruby-paint'
+pkgname=ruby-paint
+version=2.2.1
+revision=1
+build_style=gem
+short_desc="Ruby paint manages terminal colors and effects"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="MIT"
+homepage="https://github.com/janlelis/paint"
+checksum=fd2c46f7fd1a1389d447e20f0ba2e8624792a7b64f827c146ef459ac5adfd005
+
+post_install() {
+	vlicense MIT-LICENSE.txt
+}


### PR DESCRIPTION
#### Testing the changes

- I tested the changes in this PR: **YES**
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing

- I built this PR locally for my native architecture x86_64 and also for armv7l

#### Note

I have a hard time calling the package `haiti` instead of `ruby-haiti-hash`? see https://github.com/void-linux/void-packages/pull/37804#issuecomment-1173146895