### PR TITLE
.github/workflows/: set token permissions

### DIFF
--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   cycles:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     container:
         image: 'ghcr.io/void-linux/xbps-src-masterdir:20220527RC01-x86_64-musl'
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v4
         with:


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

closes #37612

requires changing the default workflow permissions in the [repository settings](https://github.com/void-linux/void-packages/settings/actions) to:

![image](https://user-images.githubusercontent.com/5366828/177019958-8a12e227-b7a0-482b-a79f-722ff16be681.png)

The default permissions are read-only, which works fine for the build/PR CI workflow. Cycles needed write access to issues to create them if a cycle is detected. Stale needs write access to issues and pull requests, as is [documented upstream](https://github.com/actions/stale#recommended-permissions). This is safe because both those workflows should only run on master.