### PR TITLE
sigi: update to 3.4.2

### DIFF
--- a/srcpkgs/sigi/template
+++ b/srcpkgs/sigi/template
@@ -1,6 +1,6 @@
 # Template file for 'sigi'
 pkgname=sigi
-version=3.4.1
+version=3.4.2
 revision=1
 build_style=cargo
 short_desc="Organization tool for people who hate organization"
@@ -8,12 +8,7 @@ maintainer="J.R. Hill <hiljusti@so.dang.cool>"
 license="GPL-2.0-only"
 homepage="https://github.com/hiljusti/sigi"
 distfiles="https://crates.io/api/v1/crates/sigi/${version}/download>sigi-${version}.tar.gz"
-checksum=81f1171495ca53246df1f271e7bc631454e94c8294b95e277f29136572bef6ad
-
-case "$XBPS_TARGET_MACHINE" in
-	ppc64le*) ;;
-	ppc64*) broken="some rustix junk";;
-esac
+checksum=8bb60ca0fa0fd66aaeef0efb3b34b171dbe0a6e0f69672dafc9cc72fb30a4036
 
 post_install() {
 	vman sigi.1


### PR DESCRIPTION

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Notes

The ppc64 patch was introduced by @q66 here: https://github.com/void-linux/void-packages/commit/b3329ed67a20b00fdb630ff29f0da1249b96e243

And the fix (via updating dependencies) to `sigi` was contributed by @sunfishcode here: https://github.com/hiljusti/sigi/pull/20

Thanks to both!