### PR TITLE
added multimc-bin package

### DIFF
--- a/srcpkgs/multimc-bin/template
+++ b/srcpkgs/multimc-bin/template
@@ -1,0 +1,37 @@
+# Template file for 'multimc-bin'
+pkgname=multimc-bin
+version=1.6
+revision=1
+archs="x86_64 i686"
+short_desc="Free, open source launcher and instance manager for Minecraft."
+maintainer="datsanakas <dimitri@sploshy.net>"
+license="Apache-2.0"
+homepage="https://multimc.org/"
+distfiles="https://files.multimc.org/downloads/multimc_${version}-1.deb https://raw.githubusercontent.com/MultiMC/Launcher/f45f83173662ea8d28a6d69a5312679df76d762b/launcher/package/ubuntu/multimc/usr/share/man/man1/multimc.1"
+checksum="d30b2577463178fd3cbe0dd30e68a30be3f85d8f50f8052e844a43acf4b46e0f c5413141151a5cb114d32c496cf49ba6bc4c755d51b1cad22aac70e38d3d3e46"
+depends="zlib mesa qt5-core qt5-x11extras qt5-svg xrandr zenity wget"
+repository=nonfree
+restricted=yes
+
+do_extract() {
+        ar p "${XBPS_SRCDISTDIR}/${pkgname}-${version}/multimc_${version}-1.deb" data.tar.xz | bsdtar --extract --xz -f - -C .
+        cp "${XBPS_SRCDISTDIR}/${pkgname}-${version}/multimc.1" .
+}
+
+do_install() {
+        vmkdir usr/bin
+        vmkdir usr/share/metainfo
+        vmkdir usr/share/applications
+        vmkdir usr/share/man/man1
+        vmkdir opt/multimc
+
+        vinstall usr/share/applications/multimc.desktop 644 usr/share/applications
+        vinstall usr/share/metainfo/multimc.metainfo.xml 644 usr/share/metainfo
+        vinstall multimc.1 644 usr/share/man/man1
+        vinstall opt/multimc/icon.svg 644 opt/multimc
+        vinstall opt/multimc/run.sh 755 opt/multimc
+
+        ln -sf /opt/multimc/run.sh ${DESTDIR}/usr/bin/multimc
+}
+
+


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture (x86_64), though it should also work for i686 because the included run.sh script downloads the correct binary for the archicetecture

### Notes
- Since MultiMC can no longer be included in the main repo, I thought it might be useful to make a restricted package to allow easy system wide installation for those who want to play minecraft on void.
- The template is based on the official arch PKGBUILD.
   

