### PR TITLE
gperftools: refresh patches

### DIFF
--- a/srcpkgs/gperftools/patches/ppc-musl.patch
+++ b/srcpkgs/gperftools/patches/ppc-musl.patch
@@ -14,7 +14,7 @@ Compatibility fixes for musl.
                          pc_field_found=true)
         elif test "x$ac_cv_header_sys_ucontext_h" = xyes; then
           AC_TRY_COMPILE([#define _GNU_SOURCE 1
--                         #include <sys/ucontext.h>],
+-                        #include <sys/ucontext.h>],
 +                         #include <sys/ucontext.h>
 +                         #include <asm/ptrace.h>],
                          [ucontext_t u; return u.$pc_field == 0;],


### PR DESCRIPTION
Package no longer builds with the patch whitespace changes.

The patches which had any looseness have been regenerated
to ensure clean build.

Let me note that there are new recent versions.  As I can't
test most of those releases on the rest of Void architectures,
I'd rather have a clean build of the current state.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- no code changes are expected, just to make sure the patches
  apply cleanly with stricter options