### PR TITLE
openocd: loosen jimtcl dep version restriction

### DIFF
--- a/srcpkgs/jimtcl/template
+++ b/srcpkgs/jimtcl/template
@@ -1,5 +1,6 @@
 # Template file for 'jimtcl'
 pkgname=jimtcl
+# keep in sync with _jimtcl_version in openocd
 version=0.81
 revision=1
 build_style=gnu-configure

--- a/srcpkgs/openocd/template
+++ b/srcpkgs/openocd/template
@@ -4,6 +4,7 @@ version=0.11.0+1
 revision=1
 # update to a commit that has a compatible jimtcl version
 _commit=830d70bfc66ada2a68c73283b9e4fa4770d408ee
+_jimtcl_version=0.81
 wrksrc="${pkgname}-${_commit}"
 build_style=gnu-configure
 configure_args="
@@ -41,7 +42,8 @@ configure_args="
  --enable-cmsis-dap-v2
  --disable-internal-libjaylink"
 hostmakedepends="automake pkg-config libtool which"
-makedepends="hidapi-devel jimtcl-devel-0.81_1 libftdi1-devel
+makedepends="hidapi-devel libftdi1-devel
+ jimtcl-devel>=${_jimtcl_version}_1<=${_jimtcl_version}_9999
  libusb-devel libjaylink-devel capstone-devel"
 short_desc="Open On-Chip Debugger"
 maintainer="Érico Nogueira <ericonr@disroot.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

@classabbyamp
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
