### PR TITLE
bucklespring: remove unused libinput-devel makedep

### DIFF
--- a/srcpkgs/bucklespring/template
+++ b/srcpkgs/bucklespring/template
@@ -6,7 +6,7 @@ build_style=gnu-makefile
 make_use_env=yes
 make_build_args="PATH_AUDIO=/usr/share/${pkgname}/wav"
 hostmakedepends="pkg-config"
-makedepends="alure-devel libinput-devel libXtst-devel"
+makedepends="alure-devel libXtst-devel"
 short_desc="Emulate the sound of the IBM Model-M while typing"
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="GPL-2.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

@abenson

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
