### PR TITLE
routinator: update to 0.12.1 and add runit service.

### DIFF
--- a/srcpkgs/routinator/files/routinator/log/run
+++ b/srcpkgs/routinator/files/routinator/log/run
@@ -1,0 +1,1 @@
+/usr/bin/vlogger

--- a/srcpkgs/routinator/files/routinator/run
+++ b/srcpkgs/routinator/files/routinator/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+[ -r conf ] && . ./conf
+
+exec routinator --config ${CONF_FILE:-/etc/routinator/routinator.conf} server --user=_routinator --group=_routinator $OPTS 2>&1

--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,17 +1,20 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.11.2
+version=0.12.1
 revision=1
 build_style=cargo
 depends="rsync"
 short_desc="Resource Public Key Infrastructure (RPKI) validator"
 maintainer="Cameron Nemo <cam@nohom.org>"
 license="BSD-3-Clause"
-homepage="https://rpki.readthedocs.io/"
+homepage="https://routinator.docs.nlnetlabs.nl/"
 changelog="https://raw.githubusercontent.com/NLnetLabs/routinator/main/Changelog.md"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
 conf_files="/etc/routinator/routinator.conf"
-checksum=00f825c53168592da0285e8dbd228018e77248d458214a2c0f86cd0ca45438f5
+checksum=8150fe544f89205bb2d65bca46388f055cf13971d3163fe17508bf231f9ab8bc
+system_accounts="_routinator"
+_routinator_homedir="/var/lib/routinator"
+make_dirs="/var/lib/routinator 0755 _routinator _routinator"
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;
@@ -19,6 +22,7 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_install() {
+	vsv routinator
 	vdoc README.md
 	vman doc/routinator.1
 	vinstall etc/routinator.conf.system-service 0644 etc/routinator routinator.conf


### PR DESCRIPTION
Update to 0.12.0 and add runit service.

- [x] Create a runit service

No longer relevant for now: 
- Build and include documentation
- Add missing python packages required for documentation
    - python3-sphinx-tabs
    - python3-sphinx-copybutton

#### Testing the changes
- I tested the changes in this PR: **YES**
Release notes at https://github.com/NLnetLabs/routinator/releases

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc, x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - x86_64-musl