### PR TITLE
gcc: include gdb helpers for libstdc++ [ci skip]

### DIFF
--- a/srcpkgs/gcc/template
+++ b/srcpkgs/gcc/template
@@ -7,7 +7,7 @@ pkgname=gcc
 # to get regression fixes not yet incorporate into a stable release
 # it should be possible to switch back to stable with 10.3 or 11
 version=10.2.1pre1
-revision=3
+revision=4
 _patchver="${version%pre*}"
 _minorver="${_patchver%.*}"
 _majorver="${_minorver%.*}"
@@ -371,13 +371,9 @@ do_install() {
 	rm -f ${DESTDIR}/usr/lib/libffi*
 	rm -f ${DESTDIR}/usr/share/man/man3/ffi*
 
-	# Remove all python scripts in libdir.
-	rm -f ${DESTDIR}/usr/lib/*.py
-
-	# Remove more python stuff.
-	if [ -d ${DESTDIR}/usr/share/gcc-${_patchver}/python ]; then
-		rm -rf ${DESTDIR}/usr/share/gcc-${_patchver}/python
-	fi
+	# Move libstdc++ gdb helpers to location where gdb can autoload them
+	mkdir -p ${DESTDIR}/usr/share/gdb/auto-load/usr/lib
+	mv ${DESTDIR}/usr/lib/*.py ${DESTDIR}/usr/share/gdb/auto-load/usr/lib
 
 	# Install c89 and c99 wrappers and its manpages, from NetBSD.
 	for f in c89 c99; do
@@ -719,5 +715,7 @@ libstdc++_package() {
 	pkg_install() {
 		vmove "usr/lib/libstdc++.so*"
 		vlicense ${wrksrc}/COPYING.RUNTIME RUNTIME.LIBRARY.EXCEPTION
+		vmove usr/share/gdb
+		vmove usr/share/gcc-${_patchver}/python
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

So. Gcc (or more specifically libstdc++) includes extra files to make debugging C++ code in gdb easier. This includes pretty printers and xmethods. These files can significantly improve the experience of debugging C++ code. Debian based distros (and probably other ones) already include this into their libstdc++ package.

But Void explicitly deletes these files that are generated when compiling. Rather than deleting these useful files, I included then into the libstdc++ package like Ubuntu does. This doesn't add any extra dependencies, gdb will try to load it if python is present, otherwise it'll ignore it.

There are some other packages that already include extra info for gdb: `gstreamer1`, `glib-devel`... Interestingly enough, these packages put the files into `/usr/share/gdb/auto-load/usr/lib64` instead of `/usr/share/gdb/auto-load/usr/lib`, which isn't loaded by gdb at all (maybe because `/usr/lib64` is just a symlink).

The files could be moved to `libstdc++-devel`. Maybe it would be more apropriate.

I have built and tested the pretty printers and everything works. It took 5 and a half hours to compile for me (I dont have a very beefy computer), so I'm assigning `[ci skip]`.

I know messing with a `bootstrap=yes` compiler could cause a disaster if something goes wrong but I'm only modifying revelant files and it's working for me (I have it installed on my computer) so I hope everything will be fine.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - I didn't test cross compiling. The python scripts aren't architecture dependent, so there should be no problems.