### PR TITLE
python3-dulwich: update to 0.20.44.

### DIFF
--- a/srcpkgs/python3-dulwich/template
+++ b/srcpkgs/python3-dulwich/template
@@ -1,24 +1,24 @@
 # Template file for 'python3-dulwich'
 pkgname=python3-dulwich
-version=0.19.14
-revision=5
+version=0.20.44
+revision=1
 wrksrc="dulwich-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
-depends="python3-urllib3"
-checkdepends="python3-gevent python3-pbr python3-greenlet"
+depends="python3-urllib3 python3-certifi"
+checkdepends="${depends} python3-gevent python3-gpg gnupg"
 short_desc="Python3 implementation of the Git file formats and protocols"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, Apache-2.0"
 homepage="https://www.dulwich.io/"
 distfiles="${PYPI_SITE}/d/dulwich/dulwich-${version}.tar.gz"
-checksum=d1320232c859ab086fff79eee8fa6ddbcbcbe01ff0c64c9bed48eca470b00b46
+checksum=10e8d73763dd30c86a99a15ade8bfcf3ab8fe96532cdf497e8cb1d11832352b8
 
 conflicts="python-dulwich>=0"
 
 do_check() {
-	python3 setup.py test
+	python3 -m unittest dulwich.tests.test_suite
 }
 
 post_install() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

`xbps-query -RX python3-dulwich` gives `hg-git-0.9.0_3` and `radicale-3.1.7_1`. I tested the first one with the [update PR](https://github.com/void-linux/void-packages/pull/37865). The second one doesn't seem to [require](https://github.com/Kozea/Radicale/blob/v3.1.7/setup.py#L52) it anymore.