### PR TITLE
gtk4: move IconBrowser4 into gtk4-demo

### DIFF
--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,7 +1,7 @@
 # Template file for 'gtk4'
 pkgname=gtk4
 version=4.6.6
-revision=1
+revision=2
 wrksrc="gtk-${version}"
 build_style=meson
 build_helper="gir"
@@ -70,6 +70,7 @@ gtk4-demo_package() {
 	pkg_install() {
 		vmove usr/bin/gtk4-demo
 		vmove usr/bin/gtk4-widget-factory
+		vmove usr/bin/gtk4-icon-browser
 		vmove usr/bin/gtk4-demo-application
 		vmove usr/share/gtk-4.0/gtk4builder.rng
 		vmove usr/share/glib-2.0/schemas/org.gtk.Demo4.gschema.xml
@@ -91,6 +92,10 @@ gtk4-demo_package() {
 		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
 		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.WidgetFactory4-symbolic.svg
 		vmove usr/share/man/man1/gtk4-widget-factory.1
+		vmove usr/share/applications/org.gtk.IconBrowser4.desktop
+		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.IconBrowser4.svg
+		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.IconBrowser4-symbolic.svg
+		vmove usr/share/man/man1/gtk4-icon-browser.1
 	}
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This moves the icon browser demo into `gtk4-demo`.
It isn't really that big of a deal, but it bothers people.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
