### PR TITLE
gerbera: runit service fixes

### DIFF
--- a/srcpkgs/gerbera/files/gerbera/log/run
+++ b/srcpkgs/gerbera/files/gerbera/log/run
@@ -1,0 +1,1 @@
+/usr/bin/vlogger

--- a/srcpkgs/gerbera/files/gerbera/run
+++ b/srcpkgs/gerbera/files/gerbera/run
@@ -1,2 +1,9 @@
 #!/bin/sh
-chpst -u gerbera:gerbera gerbera --home /var/lib/gerbera
+
+if [ ! -d /var/lib/gerbera/.config ]; then
+	mkdir -p /var/lib/gerbera/.config/gerbera
+	chown -R gerbera:gerbera /var/lib/gerbera
+	chpst -u gerbera sh -c 'HOME=/var/lib/gerbera gerbera --create-config > /var/lib/gerbera/.config/gerbera/config.xml'
+fi
+
+exec chpst -u gerbera:gerbera gerbera --home /var/lib/gerbera

--- a/srcpkgs/gerbera/template
+++ b/srcpkgs/gerbera/template
@@ -1,7 +1,7 @@
 # Template file for 'gerbera'
 pkgname=gerbera
 version=1.11.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWITH_SYSTEMD=0 -DWITH_AVCODEC=1"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

The `runit` service was missing `exec` and it did not generate a default config. Combined with the fact that there was no `log` service, it was a little inconvenient to get running.

I left the commits separate for now, but the should probably squashed before merge. 

@crater2150 @octeep 