### PR TITLE
erlang: update to 25.0.2.

### DIFF
--- a/srcpkgs/ejabberd/template
+++ b/srcpkgs/ejabberd/template
@@ -1,6 +1,6 @@
 # Template file for 'ejabberd'
 pkgname=ejabberd
-version=21.07
+version=22.05
 revision=1
 build_style=gnu-configure
 configure_args="--enable-odbc --enable-mysql --enable-pgsql --enable-pam
@@ -15,7 +15,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.process-one.net/en/ejabberd/"
 distfiles="https://github.com/processone/ejabberd/archive/${version}.tar.gz"
-checksum=8b344f727602a28f88bf9e24d39144bc3f324b62e0b03bda51884f8d99084d4e
+checksum=b8e93b51ae3cb650a2870fae1b6705404bb155289e97be7e9a54961a9effb959
 
 build_options="sqlite"
 build_options_default="sqlite"

--- a/srcpkgs/elixir/template
+++ b/srcpkgs/elixir/template
@@ -1,7 +1,7 @@
 # Template file for 'elixir'
 pkgname=elixir
 version=1.14.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_check_target="test"
 hostmakedepends="erlang"

--- a/srcpkgs/erlang/template
+++ b/srcpkgs/erlang/template
@@ -1,6 +1,6 @@
 # Template file for 'erlang'
 pkgname=erlang
-version=24.3.4.1
+version=25.0.4
 revision=1
 create_wrksrc=yes
 build_wrksrc="otp-OTP-${version}"
@@ -14,7 +14,7 @@ license="Apache-2.0"
 homepage="http://www.erlang.org/"
 changelog="https://github.com/erlang/otp/releases"
 distfiles="https://github.com/erlang/otp/archive/OTP-${version}.tar.gz"
-checksum=98363e5489356ed4fb3616e44d430b3daf5bb286be800d1c331fba8ef35ca3a0
+checksum=05878cb51a64b33c86836b12a21903075c300409b609ad5e941ddb0feb8c2120
 subpackages="erlang-doc"
 
 if [ -z "$CROSS_BUILD" ]; then
@@ -28,7 +28,6 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 pre_configure() {
-	./otp_build autoconf
 	if [ "$CROSS_BUILD" ]; then
 		# Build the bootstrap compiler for the host platform.
 		env - PATH=/usr/bin:/usr/sbin ./configure --enable-bootstrap-only

--- a/srcpkgs/lfe/template
+++ b/srcpkgs/lfe/template
@@ -1,7 +1,7 @@
 # Template file for 'lfe'
 pkgname=lfe
 version=2.0.1
-revision=1
+revision=2
 build_style=gnu-makefile
 hostmakedepends="erlang"
 depends="erlang"

--- a/srcpkgs/rebar3/template
+++ b/srcpkgs/rebar3/template
@@ -1,7 +1,7 @@
 # Template file for 'rebar3'
 pkgname=rebar3
 version=3.19.0
-revision=1
+revision=2
 hostmakedepends=erlang
 depends="erlang>=22"
 short_desc="Erlang build tool to compile, test, and release applications"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Some tests fail due to rootdir = "/usr/lib64/erlang" but I don't think it matters. Workarounds welcome.

cc @Vaelatern due to ejabberd bump.