### PR TITLE
pylint: depend on python3-tomli; update homepage

### DIFF
--- a/srcpkgs/pylint/template
+++ b/srcpkgs/pylint/template
@@ -1,18 +1,18 @@
 # Template file for 'pylint'
 pkgname=pylint
 version=2.14.4
-revision=1
+revision=2
 build_style=python3-module
 make_check_args="--deselect=tests/benchmark/test_baseline_benchmarks.py"
 hostmakedepends="python3-setuptools"
 depends="python3-astroid python3-isort python3-mccabe python3-tomlkit
- python3-platformdirs python3-dill"
+ python3-tomli python3-platformdirs python3-dill"
 checkdepends="$depends python3-pytest python3-tkinter python3-six
  python3-GitPython git"
 short_desc="Python code static checker"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-2.0-or-later"
-homepage="https://www.pylint.org/"
+homepage="https://pylint.pycqa.org"
 changelog="https://raw.githubusercontent.com/PyCQA/pylint/main/doc/whatsnew/${version%.*.*}/${version%.*}/summary.rst"
 distfiles="https://github.com/PyCQA/pylint/archive/refs/tags/v$version.tar.gz"
 checksum=fdd513198ccdf96f8b9a70aca3eb80050edf87b433595c67784c0f9ddac80bb5


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

It depends on both `tomlkit` and `tomli`:

```
$ printf 'print("hello")\n' > hello.py
$ pylint hello.py
[...]
pkg_resources.DistributionNotFound: The 'tomli>=1.1.0' distribution was not found and is required by pylint
$ sudo xbps-install python3-tomli
[...]
$ pylint hello.py
************* Module hello
hello.py:1:0: C0114: Missing module docstring (missing-module-docstring)

------------------------------------------------------------------
Your code has been rated at 0.00/10 (previous run: 0.00/10, +0.00)

$ sudo xbps-remove -F python3-tomlkit
[...]
$ pylint hello.py
[...]
ModuleNotFoundError: No module named 'tomlkit'
```

@paper42