### PR TITLE
Fix mutter rpath when cross compiling

### DIFF
--- a/srcpkgs/budgie-desktop/template
+++ b/srcpkgs/budgie-desktop/template
@@ -1,7 +1,7 @@
 # Template file for 'budgie-desktop'
 pkgname=budgie-desktop
 version=10.6.1
-revision=3
+revision=4
 build_style=meson
 build_helper=gir
 configure_args="-Dwith-gtk-doc=false"

--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
 version=42.3
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dsystemd=false -Dtests=false"

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
 version=42.3
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="-Degl_device=true -Dudev=true -Dnative_backend=true
@@ -35,7 +35,6 @@ post_install() {
 	# modify the pkg-config files to respect ${pc_sysrootdir} for variables that are
 	# meant to be called with 'pkg-config --variable'
 	vsed -e 's|^girdir.*|girdir=${pc_sysrootdir}/${libdir}/mutter-10|g' \
-		 -e 's|^typelibdir.*|typelibdir=${pc_sysrootdir}/${libdir}/mutter-10|g' \
 		 -i ${DESTDIR}/usr/lib/pkgconfig/libmutter-10.pc
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Not sure why we are running into this issue *now* since we have been patching it like this since forever, but typelibdir is just used for the rpath and currently it is returning stuff like `/usr/aarch64-linux-musl//usr/lib64/mutter-10` when cross compiling due to `pc_sysrootdir`.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
