### PR TITLE
New package: eiwd-1.29

### DIFF
--- a/srcpkgs/eiwd/files/eiwd/log/run
+++ b/srcpkgs/eiwd/files/eiwd/log/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec vlogger -p daemon.info -t iwd

--- a/srcpkgs/eiwd/files/eiwd/run
+++ b/srcpkgs/eiwd/files/eiwd/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+[ -r ./conf ] && . ./conf
+exec /usr/libexec/iwd ${OPTS} 2>&1

--- a/srcpkgs/eiwd/template
+++ b/srcpkgs/eiwd/template
@@ -1,0 +1,26 @@
+# Template file for 'eiwd'
+pkgname=eiwd
+version=1.29
+revision=1
+wrksrc=iwd-${version}
+build_style=gnu-configure
+configure_args="--disable-dbus --enable-wired --enable-pie"
+hostmakedepends="python3-docutils pkg-config"
+makedepends="readline-devel"
+checkdepends="python3"
+short_desc="Internet Wireless Daemon (iwd) without dbus"
+maintainer="wael <40663@proton.me>"
+license="LGPL-2.1-or-later"
+homepage="https://github.com/illiliti/eiwd"
+changelog="https://github.com/illiliti/eiwd/blob/master/ChangeLog"
+distfiles="https://github.com/illiliti/eiwd/releases/download/${version}-1/iwd-${version}.tar.xz"
+checksum=be110cbbc6ecdbf417b11a6c61ae9d6675e668b985854ba6cfc2dab75cf22e64
+make_dirs="/var/lib/iwd 0600 root root
+ /etc/iwd 755 root root"
+conflicts="iwd"
+# tests depend on kernel features
+make_check=extended
+
+post_install() {
+	vsv eiwd
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

Solves #37622 

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures
  - x86_64-musl
  - i686
  - aarch64-musl
  - armv7l
  - armv6l-musl

I mainly copied the original existing iwd template for this.