### PR TITLE
fsearch: update to 0.1.4

### DIFF
--- a/srcpkgs/fsearch/patches/musl-no-malloc_trim.diff
+++ b/srcpkgs/fsearch/patches/musl-no-malloc_trim.diff
@@ -1,11 +1,39 @@
-diff -ruN fsearch-0.1/src/fsearch_database.c fsearch-0.1-musl/src/fsearch_database.c
---- fsearch-0.1/src/fsearch_database.c	2021-09-25 02:41:49.000000000 +1000
-+++ fsearch-0.1-musl/src/fsearch_database.c	2021-09-25 21:42:00.187684634 +1000
-@@ -1454,7 +1454,9 @@
+diff --git a/meson.build b/meson.build
+index 0e26bf5..9114af6 100644
+--- a/meson.build
++++ b/meson.build
+@@ -12,7 +12,10 @@ cc = meson.get_compiler('c')
+ gnome = import('gnome')
+ i18n = import('i18n')
+ 
++have_malloc_trim = cc.has_function('malloc_trim')
++
+ config_h = configuration_data()
++config_h.set('HAVE_MALLOC_TRIM', have_malloc_trim)
+ config_h.set_quoted('APP_ID', app_id)
+ config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
+ config_h.set_quoted('VERSION', meson.project_version())
+diff --git a/src/fsearch_database.c b/src/fsearch_database.c
+index 8dcc9d0..80518b7 100644
+--- a/src/fsearch_database.c
++++ b/src/fsearch_database.c
+@@ -25,7 +25,11 @@
+ #include <fcntl.h>
+ #include <fnmatch.h>
+ #include <glib/gi18n.h>
++
++#ifdef HAVE_MALLOC_TRIM
+ #include <malloc.h>
++#endif
++
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <string.h>
+@@ -1459,7 +1463,9 @@ db_free(FsearchDatabase *db) {
  
      g_clear_pointer(&db, free);
  
-+#ifdef __GLIBC__
++#ifdef HAVE_MALLOC_TRIM
      malloc_trim(0);
 +#endif
  

--- a/srcpkgs/fsearch/template
+++ b/srcpkgs/fsearch/template
@@ -1,18 +1,13 @@
 # Template file for 'fsearch'
 pkgname=fsearch
-version=0.1.2
-revision=2
-build_style=gnu-configure
-hostmakedepends="autogen automake libtool pkg-config autoconf-archive
- gettext-devel glib-devel"
+version=0.1.4
+revision=1
+build_style=meson
+hostmakedepends="libtool pkg-config glib-devel gettext-devel"
 makedepends="gtk+3-devel"
 short_desc="Fast file search utility based on GTK+3"
-maintainer="a dinosaur <nick@a-dinosaur.com>"
+maintainer="a dinosaur <dino@a-dinosaur.com>"
 license="GPL-2.0-or-later"
 homepage="https://cboxdoerfer.github.io/fsearch/"
 distfiles="https://github.com/cboxdoerfer/fsearch/archive/${version}.tar.gz"
-checksum=f80e10922812169e8437476d5fbe6d05249997c49b98f991d382a6d5566551b4
-
-pre_configure() {
-	./autogen.sh
-}
+checksum=289c19136f89712100ff8f6ad4e7cbbdfbd2938a7c076c85c45658f5c36fc7fd


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


Also fixed me not being able to update due to ```fsearch-0.1.2_2: broken, unresolvable shlib `libicuuc.so.70'``` introduced since last revbump.