### PR TITLE
New package: stgit 1.5

### DIFF
--- a/srcpkgs/stgit/template
+++ b/srcpkgs/stgit/template
@@ -1,0 +1,13 @@
+# Template file for 'stgit'
+pkgname=stgit
+version=1.5
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools git"
+short_desc="Git patch management to keep commits as stack of patches"
+maintainer="J Farkas <chexum+git@gmail.com>"
+license="GPL-2.0-only"
+homepage="https://stacked-git.github.io/"
+changelog="https://raw.githubusercontent.com/stacked-git/stgit/master/CHANGELOG.md"
+distfiles="https://github.com/stacked-git/stgit/releases/download/v${version}/stgit-${version}.tar.gz"
+checksum=ce6f8a3536c8f09aa6b2f1b7c7546279c02c8beeb2ea1b296f29ae9fe0cf1ff3


### PR DESCRIPTION
stgit (command stg) is a git patch management tool that helps manage multiple pending patches without banishing them to a separate branch.

#### Testing the changes
- I tested the changes in this PR: **YES** (daily)

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
