### PR TITLE
polari: allow build with new glib environment

### DIFF
--- a/srcpkgs/polari/template
+++ b/srcpkgs/polari/template
@@ -3,7 +3,7 @@ pkgname=polari
 version=41.0
 revision=1
 build_style=meson
-hostmakedepends="pkg-config itstool gobject-introspection gettext"
+hostmakedepends="pkg-config itstool gobject-introspection gettext glib-devel"
 makedepends="gjs-devel gspell-devel gtk+3-devel libsecret-devel
  libsoup-gnome-devel telepathy-glib-devel telepathy-logger-devel"
 depends="gspell telepathy-idle telepathy-logger telepathy-mission-control"


### PR DESCRIPTION
polari no longer builds with current gnome/glib.  Needs glib-devel
explicitly installed, otherwise won't find glib-compile-resources

Change only to compilation environment, no code/testing changes proposed.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
