### PR TITLE
php8.1: update to 8.1.8, add changelog URL, fix man pages

### DIFF
--- a/srcpkgs/php8.1/patches/fix-manpages.patch
+++ b/srcpkgs/php8.1/patches/fix-manpages.patch
@@ -1,0 +1,25 @@
+This patch fixes .so links in man pages.
+It's needed because of the configure option -
+
+    --program-suffix=${_php_version}
+
+The changes made by this patch should be the same as the changes made by this
+block of code -
+
+    _regexp='^[[:space:]]*\.so[[:space:]]'
+    for file in $(grep -l -e "$_regexp" -R .); do
+    	vsed -i "$file" -e "/$_regexp/"'s=^[[:space:]]*\.[^.]*=&'${_php_version}=
+    done
+
+Where _php_version is defined in the template file.
+
+--- a/ext/phar/phar.phar.1.in
++++ b/ext/phar/phar.phar.1.in
+@@ -1 +1 @@
+-.so man1/phar.1
++.so man1/phar8.1.1
+--- a/sapi/cgi/php-cgi.1.in
++++ b/sapi/cgi/php-cgi.1.in
+@@ -1 +1 @@
+-.so man1/php.1
++.so man1/php8.1.1

--- a/srcpkgs/php8.1/template
+++ b/srcpkgs/php8.1/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.1'
 pkgname=php8.1
-version=8.1.7
-revision=3
+version=8.1.8
+revision=1
 _php_version=8.1
 wrksrc="php-${version}"
 hostmakedepends="bison pkg-config apache-devel"
@@ -14,8 +14,9 @@ short_desc="HTML-embedded scripting language"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="PHP-3.01"
 homepage="https://www.php.net"
+changelog="https://raw.githubusercontent.com/php/php-src/php-${version}/NEWS"
 distfiles="https://www.php.net/distributions/php-${version}.tar.gz"
-checksum=5f0b422a117633c86d48d028934b8dc078309d4247e7565ea34b2686189abdd8
+checksum=889d910558d2492f7f2236921b9bcde620674c8b684ec02d126060f8ca45dc8d
 
 conf_files="/etc/php${_php_version}/php.ini"
 

--- a/srcpkgs/php8.1/template
+++ b/srcpkgs/php8.1/template
@@ -1,7 +1,7 @@
 # Template file for 'php8.1'
 pkgname=php8.1
 version=8.1.7
-revision=2
+revision=3
 _php_version=8.1
 wrksrc="php-${version}"
 hostmakedepends="bison pkg-config apache-devel"


### PR DESCRIPTION
The changelog URL points to the changelog for $version because the
changelog in the master branch contains the details of many alpha and RC
releases, which makes it difficult to find the changelog corresponding
to the current pkgver.

I've also changed the `.so` directives in man pages to point to the
correct man pages. Previously they pointed to the man pages of php 7.4

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
<!--
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
