### PR TITLE
New package: flyctl-0.0.351

### DIFF
--- a/srcpkgs/flyctl/patches/0001-Suppress-update-mechanism.patch
+++ b/srcpkgs/flyctl/patches/0001-Suppress-update-mechanism.patch
@@ -1,0 +1,96 @@
+From efa554240713f81a838dc6d9e3cefa739e4da563 Mon Sep 17 00:00:00 2001
+From: Antonio Gurgel <antonio@goorzhel.com>
+Date: Sun, 24 Jul 2022 12:35:32 -0700
+Subject: [PATCH] Suppress update mechanism
+
+---
+ internal/command/version/update.go  | 50 -----------------------------
+ internal/command/version/version.go |  1 -
+ internal/update/update.go           |  2 +-
+ 3 files changed, 1 insertion(+), 52 deletions(-)
+ delete mode 100644 internal/command/version/update.go
+
+diff --git a/internal/command/version/update.go b/internal/command/version/update.go
+deleted file mode 100644
+index 7a9f1378..00000000
+--- a/internal/command/version/update.go
++++ /dev/null
+@@ -1,50 +0,0 @@
+-package version
+-
+-import (
+-	"context"
+-	"errors"
+-	"fmt"
+-
+-	"github.com/blang/semver"
+-	"github.com/spf13/cobra"
+-
+-	"github.com/superfly/flyctl/internal/buildinfo"
+-	"github.com/superfly/flyctl/internal/cache"
+-	"github.com/superfly/flyctl/internal/command"
+-	"github.com/superfly/flyctl/internal/update"
+-	"github.com/superfly/flyctl/iostreams"
+-)
+-
+-func newUpdate() *cobra.Command {
+-	const (
+-		short = "Checks for available updates and automatically updates"
+-
+-		long = `Checks for update and if one is available, runs the appropriate
+-command to update the application.`
+-	)
+-
+-	return command.New("update", short, long, runUpdate)
+-}
+-
+-func runUpdate(ctx context.Context) error {
+-	release, err := update.LatestRelease(ctx, cache.FromContext(ctx).Channel())
+-	switch {
+-	case err != nil:
+-		return fmt.Errorf("failed determining latest release: %w", err)
+-	case release == nil:
+-		return fmt.Errorf("failed querying latest release information: %w", err)
+-	}
+-
+-	latest, err := semver.ParseTolerant(release.Version)
+-	if err != nil {
+-		return fmt.Errorf("error parsing latest release version number %q: %w",
+-			release.Version, err)
+-	}
+-
+-	if buildinfo.Version().GTE(latest) {
+-		return errors.New("no available update")
+-	}
+-
+-	io := iostreams.FromContext(ctx)
+-	return update.UpgradeInPlace(ctx, io, release.Prerelease)
+-}
+diff --git a/internal/command/version/version.go b/internal/command/version/version.go
+index 5ca34ed1..282b79eb 100644
+--- a/internal/command/version/version.go
++++ b/internal/command/version/version.go
+@@ -41,7 +41,6 @@ number and build date.`
+ 
+ 	version.AddCommand(
+ 		newInitState(),
+-		newUpdate(),
+ 	)
+ 
+ 	return version
+diff --git a/internal/update/update.go b/internal/update/update.go
+index ffb3022c..66134bef 100644
+--- a/internal/update/update.go
++++ b/internal/update/update.go
+@@ -41,7 +41,7 @@ func Check() bool {
+ 	case !cmdutil.IsTerminal(os.Stdout), !cmdutil.IsTerminal(os.Stderr):
+ 		return false
+ 	default:
+-		return true
++		return false
+ 	}
+ }
+ 
+-- 
+2.37.1
+

--- a/srcpkgs/flyctl/template
+++ b/srcpkgs/flyctl/template
@@ -1,0 +1,26 @@
+# Template file for 'flyctl'
+pkgname=flyctl
+version=0.0.351
+revision=1
+build_style=go
+build_helper=qemu
+go_import_path="github.com/superfly/flyctl"
+go_ldflags="
+ -X github.com/superfly/flyctl/internal/buildinfo.environment=production
+ -X github.com/superfly/flyctl/internal/buildinfo.version=$version
+ -X github.com/superfly/flyctl/internal/buildinfo.commit=df8c42a
+"
+short_desc="Command line tools for fly.io services"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="Apache-2.0"
+homepage="https://github.com/superfly/flyctl"
+distfiles="https://github.com/superfly/flyctl/archive/refs/tags/v${version}.tar.gz"
+checksum=fc6fe8fbdd5c6d4b8cea4216770c111a78b06264255345d20c9c768593b6033c
+
+pre_build() {
+	local _date
+	if [ "$SOURCE_DATE_EPOCH" ]; then
+		_date="$(date --utc --date "@$SOURCE_DATE_EPOCH" +"%Y-%m-%dT%H:%M:%SZ")"
+		go_ldflags+=" -X github.com/superfly/flyctl/internal/buildinfo.buildDate=${_date}"
+	fi
+}


### PR DESCRIPTION
`flyctl` is a command-line interface for fly.io.

fly.io is [somewhat](https://xeiaso.net/blog/fly.io-heroku-replacement) like Heroku.

#### Testing the changes
- I tested the changes in this PR **briefly**.

```
❯ ./xbps-src pkg flyctl
<...>
❯ xi -y flyctl
<...>
❯ which flyctl
/usr/bin/flyctl
❯ flyctl version
flyctl v0.0.0-1657391288+dev linux/amd64 Commit: <commit> BuildDate: 2022-07-09T18:28:08Z
```

That `<commit>` seems to be a problem even if I build inside a git repo:
```
❯ gh repo clone superfly/flyctl
<...>
❯ cd flyctl
❯ make
<...>
❯ bin/flyctl version
flyctl v0.0.0-1657392531+dev linux/amd64 Commit: <commit> BuildDate: 2022-07-09T18:48:51Z
```

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements).
