### PR TITLE
aircrack-ng: update to 1.7.

### DIFF
--- a/srcpkgs/aircrack-ng/patches/evalrev.patch
+++ b/srcpkgs/aircrack-ng/patches/evalrev.patch
@@ -1,0 +1,13 @@
+diff --git a/evalrev b/evalrev
+index 19b38d6b..afb4157e 100755
+--- a/evalrev
++++ b/evalrev
+@@ -49,7 +49,7 @@ elif test -d "${DIR}/.svn"; then
+         SCM="_r1"
+     fi
+ else
+-    REVISION="$(cat ${DIR}/AC_VERSION)"
++    REVISION="$(cat ${DIR}/AC_VERSION 2>/dev/null)"
+ fi
+ 
+ if test "x$CMD" = "xscm"; then

--- a/srcpkgs/aircrack-ng/patches/python.patch
+++ b/srcpkgs/aircrack-ng/patches/python.patch
@@ -1,0 +1,49 @@
+diff --git a/build/m4/aircrack_ng_ext_scripts.m4 b/build/m4/aircrack_ng_ext_scripts.m4
+index db464944..4d0e9b62 100644
+--- a/build/m4/aircrack_ng_ext_scripts.m4
++++ b/build/m4/aircrack_ng_ext_scripts.m4
+@@ -39,20 +39,14 @@ dnl program, then also delete it here.
+ 
+ AC_DEFUN([AIRCRACK_NG_EXT_SCRIPTS], [
+ 
+-if test "$cross_compiling" = no;
+-then
+-	AC_CHECK_PROGS([PYTHON], [python python3 python2])
+-	if test $PYTHON = no; then
+-		AC_MSG_FAILURE(failed to find Python)
+-	fi
+-
+-    if test "x$PYTHON" != "x"; then
+-        pc_cv_python_site_dir=`$PYTHON -c 'import site; print(site.getsitepackages()[[-1]])'`
+-        dnl AC_SUBST([pythondir], [\${prefix}/$pc_cv_python_site_dir])
+-        AC_SUBST([pythondir], [$pc_cv_python_site_dir])
+-        AC_SUBST([pkgpythondir], [\${pythondir}/$PACKAGE_NAME])
+-    fi
+-fi
++AC_CHECK_PROGS([PYTHON], [python python3 python2])
++AS_IF([test x"$PYTHON" = x], [
++    AC_MSG_RESULT(failed to find Python)
++], [
++    pc_cv_python_site_dir=`$PYTHON -c 'import site; print(site.getsitepackages()[[-1]])'`
++    AC_SUBST([pythondir], [$pc_cv_python_site_dir])
++    AC_SUBST([pkgpythondir], [\${pythondir}/$PACKAGE_NAME])
++])
+ 
+ AC_CHECK_PROGS([READLINK], [greadlink readlink])
+ 
+@@ -62,12 +56,11 @@ AC_ARG_WITH(ext-scripts,
+ case "$with_ext_scripts" in
+     yes)
+         AC_MSG_CHECKING([for Python requirement for ext-scripts])
+-        if test "x$PYTHON" = x ; then
++        AS_IF([test "x$PYTHON" = x], [
+            AC_MSG_FAILURE([not found])
+-        else
++        ], [
+            AC_MSG_RESULT([found; $PYTHON])
+-        fi
+-
++        ])
+         EXT_SCRIPTS=yes
+         ;;
+     *)

--- a/srcpkgs/aircrack-ng/patches/sqlite3.patch
+++ b/srcpkgs/aircrack-ng/patches/sqlite3.patch
@@ -1,0 +1,25 @@
+diff --git a/build/m4/ax_lib_sqlite3.m4 b/build/m4/ax_lib_sqlite3.m4
+index 5d5c3a8d..fcb1f3c1 100644
+--- a/build/m4/ax_lib_sqlite3.m4
++++ b/build/m4/ax_lib_sqlite3.m4
+@@ -88,7 +88,7 @@ AC_DEFUN([AX_LIB_SQLITE3],
+             ac_sqlite3_cppflags="-I$ac_sqlite3_path/include"
+             AC_MSG_RESULT([explicitly set; $ac_sqlite3_path])
+         else
+-            for ac_sqlite3_path_tmp in /usr /usr/local /opt ; do
++            for ac_sqlite3_path_tmp in /usr /usr/local /opt $lt_sysroot ; do
+                 if test -f "$ac_sqlite3_path_tmp/include/$ac_sqlite3_header" \
+                     && test -r "$ac_sqlite3_path_tmp/include/$ac_sqlite3_header"; then
+                     ac_sqlite3_path=$ac_sqlite3_path_tmp
+@@ -159,9 +159,9 @@ AC_DEFUN([AX_LIB_SQLITE3],
+             dnl Retrieve SQLite release version
+             if test "x$ac_sqlite3_header_path" != "x"; then
+                 ac_sqlite3_version=`cat $ac_sqlite3_header_path \
+-                    | grep '#define.*SQLITE_VERSION.*\"' | sed -e 's/.* "//' \
++                    | grep '#define.*SQLITE_VERSION.*\"' | tail -n 1 | sed -e 's/.* "//' \
+                         | sed -e 's/"//'`
+-                if test $ac_sqlite3_version != ""; then
++                if test "$ac_sqlite3_version" != ""; then
+                     SQLITE3_VERSION=$ac_sqlite3_version
+                 else
+                     AC_MSG_WARN([Cannot find SQLITE_VERSION macro in sqlite3.h header to retrieve SQLite version!])

--- a/srcpkgs/aircrack-ng/template
+++ b/srcpkgs/aircrack-ng/template
@@ -1,30 +1,31 @@
 # Template file for 'aircrack-ng'
 pkgname=aircrack-ng
-version=1.6
-revision=4
+version=1.7
+revision=1
 build_style=gnu-configure
-hostmakedepends="automake libtool pkg-config"
-makedepends="libnl3-devel openssl-devel sqlite-devel zlib-devel libcap-devel"
+hostmakedepends="automake ethtool libtool pkg-config python3"
+makedepends="libhwloc-devel libnl3-devel libpcap-devel libpciaccess-devel
+ libxml2-devel  openssl-devel pcre-devel python3-devel sqlite-devel zlib-devel"
+checkdepends="cmocka-devel expect"
 short_desc="Complete suite of tools to assess WiFi network security"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Joseph Benden <joe@benden.us>"
 license="GPL-2.0-or-later, BSD-3-Clause, OpenSSL"
 homepage="https://www.aircrack-ng.org/"
 changelog="https://www.aircrack-ng.org/doku.php?id=changelog"
 distfiles="https://download.aircrack-ng.org/${pkgname}-${version}.tar.gz"
-checksum=4f0bfd486efc6ea7229f7fbc54340ff8b2094a0d73e9f617e0a39f878999a247
-
-CFLAGS="-fcommon"
+checksum=05a704e3c8f7792a17315080a21214a4448fd2452c1b0dd5226a3a55f90b58c3
+configure_args+="--without-opt --with-experimental --with-ext-scripts"
 
 pre_configure() {
-	ACLOCAL=/usr/bin/aclocal \
-	AUTOCONF=/usr/bin/autoconf \
-	AUTOHEADER=/usr/bin/autoheader \
-	AUTOMAKE=/usr/bin/automake \
-	LIBTOOLIZE=/usr/bin/libtoolize \
-	NOCONFIGURE=1 \
-		./autogen.sh
+	autoreconf -vif
 }
 
 post_install() {
+	vdoc AUTHORS
+	vdoc ChangeLog
+	vdoc README
+	vdoc README.md
+	vdoc SECURITY.md
+	vlicense LICENSE
 	vlicense LICENSE.OpenSSL
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64`-`glibc`)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl
  - [x] x86_64-musl

#### Additional Notes
This patch rolls in all changes (AND supersedes!) as discussed in PR #34452. The extra scripts mentioned in that PR require non-cross builds (use of Python).

On an aside, there are some dependency issues with `libhwloc-devel` package that could be improved in the future. Namely, that `-devel` package requires extra packages for the `pkg-config` file to work. All of these extra dependencies are NOT included by the `-devel` package, nor the `libhwloc` package. It is only the main package `hwloc` that includes some, but still not all.