### PR TITLE
pipewire: fix pipewire-pulse runit service

### DIFF
--- a/srcpkgs/pipewire/files/pipewire-pulse/run
+++ b/srcpkgs/pipewire/files/pipewire-pulse/run
@@ -3,5 +3,5 @@
 # for further information, please refer to the handbook
 ! [ -d /run/pulse ] && install -m 755 -g _pipewire -o _pipewire -d /run/pulse
 umask 002
-export PULSE_RUNTIME_PATH=/run
+export PULSE_RUNTIME_PATH=/run/pulse
 exec chpst -u _pipewire:_pipewire pipewire-pulse

--- a/srcpkgs/pipewire/template
+++ b/srcpkgs/pipewire/template
@@ -1,7 +1,7 @@
 # Template file for 'pipewire'
 pkgname=pipewire
 version=0.3.54
-revision=1
+revision=2
 _pms_version=0.4.1
 build_style=meson
 configure_args="


### PR DESCRIPTION
Append "/pulse" to PULSE_RUNTIME_PATH, since pulse-server doesn't do it
anymore, see:

https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/4821c7ca2fe5e25ba018e9f5d4967f08d6bb816f

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@ftrvxmtrx @Johnnynator @paper42 