### PR TITLE
gnome-chess: update to 42.0.

### DIFF
--- a/srcpkgs/gnome-chess/template
+++ b/srcpkgs/gnome-chess/template
@@ -1,14 +1,14 @@
 # Template file for 'gnome-chess'
 pkgname=gnome-chess
-version=41.1
+version=42.0
 revision=1
 build_style=meson
 hostmakedepends="gettext pkg-config vala glib-devel itstool librsvg-devel"
-makedepends="gtk4-devel librsvg-devel"
+makedepends="gtk4-devel libadwaita-devel librsvg-devel"
 depends="gnuchess"
 short_desc="GNOME chess user interface"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://wiki.gnome.org/Apps/Chess"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=eb619886596396b4033a3f28a3c2e3004b54ebe1b38b40d6422c17b9f2cc17d0
+checksum=12af5493a62205ac6bb74540f0a858413da8928966a346e854330b41d73bc393


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Fixes 
```
$ sudo xbps-install gnome-games-collection
MISSING: gnome-chess>=42.0
Transaction aborted due to unresolved dependencies.
```

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
