### PR TITLE
aisleriot: use gettext instead of intltool 

### DIFF
--- a/srcpkgs/aisleriot/template
+++ b/srcpkgs/aisleriot/template
@@ -6,7 +6,7 @@ build_style=meson
 # build requires assertions to be turned on -> n_debug=false
 configure_args="-Dtheme_pysol_path=/usr/share/PySolFC/cardsets -Dtheme_pysol=true
  -Dtheme_kde=false -Db_ndebug=false"
-hostmakedepends="desktop-file-utils glib-devel guile intltool itstool pkg-config
+hostmakedepends="desktop-file-utils glib-devel guile gettext itstool pkg-config
  pysolfc-cardsets"
 makedepends="guile-devel libcanberra-devel librsvg-devel"
 depends="guile yelp"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
