### PR TITLE
libinput: split libinput-debug-gui to avoid a cycle

### DIFF
--- a/srcpkgs/libinput-debug-gui
+++ b/srcpkgs/libinput-debug-gui
@@ -1,1 +1,0 @@
-libinput

--- a/srcpkgs/libinput-debug-gui/template
+++ b/srcpkgs/libinput-debug-gui/template
@@ -1,0 +1,29 @@
+# Template file for 'libinput-debug-gui'
+# keep in sync with libinput
+# split to avoid cycle: gst-plugins-bad1 -> zbar -> qt5 -> libinput -> gtk4 -> gst-plugins-bad1
+pkgname=libinput-debug-gui
+version=1.21.0
+revision=1
+wrksrc="libinput-${version}"
+build_style=meson
+configure_args="-Db_ndebug=false -Dtests=false -Ddebug-gui=true"
+hostmakedepends="pkg-config wayland-devel"
+makedepends="libevdev-devel libwacom-devel mtdev-devel eudev-libudev-devel
+ gtk4-devel"
+short_desc="Provides handling input devices in Wayland compositors and X"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
+license="MIT"
+homepage="https://www.freedesktop.org/wiki/Software/libinput"
+distfiles="https://gitlab.freedesktop.org/libinput/libinput/-/archive/${version}/libinput-${version}.tar.gz"
+checksum=1b23c180f5b297303ed36f5a549910f5d320b0eb21052eac67a966d4eaa4e01d
+
+post_install() {
+	mv ${DESTDIR}/usr/libexec/libinput/libinput-debug-gui ${DESTDIR}/libinput-debug-gui
+	mv ${DESTDIR}/usr/share/man/man1/libinput-debug-gui.1 ${DESTDIR}/libinput-debug-gui.1
+	rm -r ${DESTDIR}/usr
+	vmkdir usr/libexec/libinput
+	mv ${DESTDIR}/libinput-debug-gui ${DESTDIR}/usr/libexec/libinput/libinput-debug-gui
+	vmkdir usr/share/man/man1
+	mv ${DESTDIR}/libinput-debug-gui.1 ${DESTDIR}/usr/share/man/man1/libinput-debug-gui.1
+	vlicense COPYING
+}

--- a/srcpkgs/libinput/template
+++ b/srcpkgs/libinput/template
@@ -3,10 +3,9 @@ pkgname=libinput
 version=1.21.0
 revision=1
 build_style=meson
-configure_args="-Db_ndebug=false"
-hostmakedepends="pkg-config wayland-devel"
-makedepends="libevdev-devel libwacom-devel mtdev-devel eudev-libudev-devel
- gtk4-devel"
+configure_args="-Db_ndebug=false -Ddebug-gui=false"
+hostmakedepends="pkg-config"
+makedepends="libevdev-devel libwacom-devel mtdev-devel eudev-libudev-devel"
 checkdepends="valgrind check-devel"
 short_desc="Provides handling input devices in Wayland compositors and X"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
@@ -32,13 +31,5 @@ libinput-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
-	}
-}
-
-libinput-debug-gui_package() {
-	short_desc+=" - debug GUI"
-	pkg_install() {
-		vmove usr/libexec/libinput/libinput-debug-gui
-		vmove usr/share/man/man1/libinput-debug-gui.1
 	}
 }


### PR DESCRIPTION

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

gst-plugins-bad1 -> zbar -> qt5 -> libinput -> gtk4 -> gst-plugins-bad1

Closes #37948
Closes #37971

@sgn

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
