### PR TITLE
Docker compose/2.6.1

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.2.3
+version=2.6.1
 revision=1
 wrksrc="compose-${version}"
 build_style=go
@@ -12,7 +12,7 @@ maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=22210187e73732edd9fc02f122ea61481806c703af7b73d0a7351f2e8ed7c0b8
+checksum=7d4ad5354e382809368016210b33c4f6c3bca68da15e36edc671da00fb234666
 
 post_install() {
 	mkdir -p ${DESTDIR}/usr/libexec/docker/cli-plugins


### PR DESCRIPTION
- I tested the changes in this PR: briefly on my machine

```
OS: Void Linux x86_64
Host: ROG Zephyrus G14 GA401IV_GA401IV 1.0
Kernel: 5.18.9_1
Uptime: 5 hours, 49 mins
Packages: 1041 (xbps-query)
Shell: zsh 5.9
Resolution: 2560x1440, 2560x1440
WM: i3
Theme: Gruvbox-Dark-B [GTK2/3]
Icons: Lyra-orange [GTK2/3]
Terminal: alacritty
Terminal Font: envypn
CPU: AMD Ryzen 9 4900HS with Radeon Graphics (16) @ 3.000GHz
GPU: AMD ATI 04:00.0 Renoir
GPU: NVIDIA GeForce RTX 2060 Max-Q
Memory: 10437MiB / 39540MiB
```