### PR TITLE
docker-buildx: update to 0.8.2

### DIFF
--- a/srcpkgs/docker-buildx/template
+++ b/srcpkgs/docker-buildx/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-buildx'
 pkgname=docker-buildx
-version=0.7.1
+version=0.8.2
 revision=1
 wrksrc="buildx-${version}"
 build_style=go
@@ -12,7 +12,7 @@ maintainer="Gabriel Sanches <gabriel@gsr.dev>"
 license="Apache-2.0"
 homepage="https://docs.docker.com/buildx/working-with-buildx/"
 distfiles="https://github.com/docker/buildx/archive/refs/tags/v${version}.tar.gz"
-checksum=5df4224eeac5a00d1bef2344660e93415264a64ea4742133f2c2a794c563ef50
+checksum=5a368ffa7c0fd3df510bbb89f345bea9be490a3783de350d2b79b3ed69c237fe
 
 post_install() {
 	vmkdir usr/libexec/docker/cli-plugins


### PR DESCRIPTION
- I tested the changes in this PR: briefly on my machine

```
OS: Void Linux x86_64
Host: ROG Zephyrus G14 GA401IV_GA401IV 1.0
Kernel: 5.18.9_1
Uptime: 5 hours, 53 mins
Packages: 1041 (xbps-query)
Shell: zsh 5.9
Resolution: 2560x1440, 2560x1440
WM: i3
Theme: Gruvbox-Dark-B [GTK2/3]
Icons: Lyra-orange [GTK2/3]
Terminal: alacritty
Terminal Font: envypn
CPU: AMD Ryzen 9 4900HS with Radeon Graphics (16) @ 3.000GHz
GPU: AMD ATI 04:00.0 Renoir
GPU: NVIDIA GeForce RTX 2060 Max-Q
Memory: 10495MiB / 39540MiB
```