### PR TITLE
gnupg: adopt, update to 2.3.7.

### DIFF
--- a/srcpkgs/gnupg/template
+++ b/srcpkgs/gnupg/template
@@ -1,6 +1,6 @@
 # Template file for 'gnupg'
 pkgname=gnupg
-version=2.2.35
+version=2.3.7
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable ldap)
@@ -14,11 +14,11 @@ makedepends="bzip2-devel gnutls-devel libassuan-devel libcurl-devel
  libgcrypt-devel"
 depends="pinentry"
 short_desc="GNU Privacy Guard (2.x)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-or-later"
 homepage="https://www.gnupg.org/"
 distfiles="https://gnupg.org/ftp/gcrypt/gnupg/gnupg-${version}.tar.bz2"
-checksum=340bc255938971e6e729b3d9956fa2ef4db8215d77693bf300df2bb302498690
+checksum=ee163a5fb9ec99ffc1b18e65faef8d086800c5713d15a672ab57d3799da83669
 build_options="ldap"
 build_options_default="ldap"
 


### PR DESCRIPTION
## Test/Stable/LTS/Legacy?!

GnuPG has a few different development branches, and they do change their mind sometimes about what those are. They used to say this:

> We are pleased to announce the availability of a new GnuPG release:
> version 2.3.0.  This release marks the start of public testing releases
> eventually leading to a new stable version 2.4.

Source: https://lists.gnupg.org/pipermail/gnupg-announce/2021q2/000458.html

But with 2.3.3, they changed their mind:

> Three different series of GnuPG are actively maintained:
> 
> - Version 2.3 is the current stable version with a lot of new features
>   compared to 2.2.  This announcement is about the latest release of
>   this series.
> 
> - Version 2.2 is our LTS (long term support) version and guaranteed to
>   be maintained at least until the end of 2024.
>   See https://gnupg.org/download/index.html#end-of-life
> 
> - Version 1.4 is only maintained to allow decryption of very old data
>   which is, for security reasons, not anymore possible with other GnuPG
>   versions.

Source: https://lists.gnupg.org/pipermail/gnupg-announce/2021q4/000466.html

I'd say packaging stable instead of LTS is fine, and if someone really needs LTS then we should have a separate LTS package instead.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

So, considering this is a bit of a bigger change I selected `briefly` here, but I did do quite a bit of testing on my machine, and I've not noticed any breakage yet. Encryption/decryption still works, I can still authenticate to servers via ssh, with the key residing on a yubikey being accessed through gnupg-agent, everything good.

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
