### PR TITLE
zsh-completions: update to 0.34.0.

### DIFF
--- a/srcpkgs/zsh-completions/template
+++ b/srcpkgs/zsh-completions/template
@@ -1,14 +1,14 @@
 # Template file for 'zsh-completions'
 pkgname=zsh-completions
-version=0.33.0
-revision=2
+version=0.34.0
+revision=1
 depends="zsh"
 short_desc="Additional completions for Zsh"
 maintainer="Alexander Gehrke <void@qwertyuiop.de>"
 license="BSD-3-Clause, Apache-2.0, MIT"
 homepage="https://github.com/zsh-users/zsh-completions"
 distfiles="${homepage}/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=39452d383d0718aa2c830edba1aa32f0ee1e40002ef6932d88699a888bd58c29
+checksum=21b6c194b15ae3992f4c2340ab249aa326a9874d46e3130bb3f292142c217fe2
 
 post_patch() {
 	rm -f src/_composer
@@ -16,7 +16,6 @@ post_patch() {
 
 do_install() {
 	vmkdir usr/share/zsh/site-functions/
-	rm src/_cheat # cheat package includes better one
 	vcopy src/_* usr/share/zsh/site-functions/
 	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

`cheat` completions have been removed upstream, deletion no longer necessary.