### PR TITLE
neatvnc 0.5.1 / wayvnc 0.5.0

### DIFF
--- a/srcpkgs/neatvnc/template
+++ b/srcpkgs/neatvnc/template
@@ -1,6 +1,6 @@
 # Template file for 'neatvnc'
 pkgname=neatvnc
-version=0.4.0
+version=0.5.1
 revision=1
 build_style=meson
 hostmakedepends="pkg-config"
@@ -10,7 +10,7 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="ISC"
 homepage="https://github.com/any1/neatvnc"
 distfiles="https://github.com/any1/neatvnc/archive/v${version}.tar.gz"
-checksum=8a833d488f579e4acf7abb1c7832f8e571bddd6da054e71ed9be3b8396955a81
+checksum=63c4786eefe6f3bd72f89592798e31721235fc959de6ba3a5ac7834a555dad1d
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/wayvnc/template
+++ b/srcpkgs/wayvnc/template
@@ -1,6 +1,6 @@
 # Template file for 'wayvnc'
 pkgname=wayvnc
-version=0.4.1
+version=0.5.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config ninja scdoc wayland-devel"
@@ -10,7 +10,7 @@ maintainer="Zach Dykstra <dykstra.zachary@gmail.com>"
 license="ISC"
 homepage="https://github.com/any1/wayvnc"
 distfiles="https://github.com/any1/wayvnc/archive/v${version}.tar.gz"
-checksum=1813a22644a9043f96a53756bfee68d65f976de8b8f65c86f56782d22286d271
+checksum=d4ea4cee79d13e08e9e7d3573c7f0ccf3709a59cfe582509edc8fe6f406bf88e
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" musl-legacy-compat"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Tested under Sway (wayvnc server) and Sway (TigerVNC client).