### PR TITLE
mc: update to 4.8.29, cleanup, adopt.

### DIFF
--- a/srcpkgs/mc/files/README.voidlinux
+++ b/srcpkgs/mc/files/README.voidlinux
@@ -1,0 +1,50 @@
+MC has a number of "extfs" backend scripts to extend its functionality.
+They depend on various programs to work, which are not marked as dependencies of
+the mc package and must be installed manually for the backends to work properly.
+
+| Backend                                     | Dependencies                                         |
+| ------------------------------------------- | ---------------------------------------------------- |
+| `a+` DOS filesystem access                  | `perl mtools`                                        |
+| `apt+` APT frontend (repository browser?)   | `perl apt dpkg`                                      |
+| `audio` browse audio cdroms+CDDB            | `cdparanoia wget`                                    |
+| `changesetfs` list git revs of curr. file   | `git`                                                |
+| `deb` .deb package viewer                   | `perl dpkg`                                          |
+| `deba` APT frontend (deb browser/installer) | `perl apt dpkg`                                      |
+| `debd` DPKG frontend (also deb browser)     | `perl dpkg`                                          |
+| `dpkg+` DPKG frontend                       | `perl dpkg`                                          |
+| `gitfs+` git repo browser                   | `git`                                                |
+| `iso9660` ISO9660 image browser             | `xorriso cdrtools [common_archivers]`                |
+| `lslR` "For browsing lslR listings"         | `[common_archivers]`                                 |
+| `mailfs` Mailbox browser                    | `[common_archivers] file perl-{TimeDate,Date-Manip}` |
+| `patchfs` patchfile explorer                | `[common_archivers] file perl-TimeDate`              |
+| `patchsetfs` list git patches of curr. file | `git`                                                |
+| `rpm` RPM package viewer                    | `rpm`                                                |
+| `rpms+` RPM frontend                        | `perl rpm`                                           |
+| `trpm` RPM frontend                         | `rpm`                                                |
+| `u7z` 7zip archive support                  | `7zip`                                               |
+| `uar` AR archive support                    | `binutils`                                           |
+| `uc1541` C64/128 disk image support         | `python3 vice`                                       |
+| `ucab` Microsoft CAB archive support        | `cabextract`                                         |
+| `ulib` gputils archive support              | `perl gputils`                                       |
+| `unar` unar wrapper                         | `unar`                                               |
+| `urar` RAR archive support                  | `unrar`                                              |
+| `uwim` Windows WIM archive support          | `wimlib`                                             |
+| `uzip` ZIP archive support                  | `perl zip unzip`                                      |
+
+`[common_archivers]` refers to the following archivers/compressors: `bzip2 gzip lz4 lzip xz zstd`.
+
+Additionally, the following extfs plugins require programs that are not packaged on void.
+
+| Backend                                   | Dependencies                        |
+| ----------------------------------------- | ----------------------------------- |
+| `bpp`   "Bad Penguin" package management  | Unknown executable: `package-setup` |
+| `hp48+` file manager for HP48 calculators | Unknown executable: `kermit`        |
+| `s3+`   AWS S3 client                     | Missing python pkg: `python3-boto`  |
+| `uace`  ACE archive support               | Unknown executable: `unace`         |
+| `ualz`  ALZ archive support               | Unknown executable: `unalz`         |
+| `uarc`  ARC archive support               | Unknown executable: `arc`           |
+| `uarj`  ARJ archive support               | Unknown executable: `arj`           |
+| `uha`   HA archive support                | Unknown executable: `ha`            |
+| `ulha`  LHa archive support               | Unknown executable: `lha`           |
+| `uzoo`  ZOO archive support               | Unknown executable: `zoo`           |
+

--- a/srcpkgs/mc/patches/extfs-python3.patch
+++ b/srcpkgs/mc/patches/extfs-python3.patch
@@ -1,0 +1,80 @@
+Taken from https://src.fedoraproject.org/rpms/mc/blob/rawhide/f/mc-python3.patch
+Also see https://github.com/MidnightCommander/mc/pull/149
+
+--
+
+--- a/src/vfs/extfs/helpers/uc1541
++++ b/src/vfs/extfs/helpers/uc1541
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ """
+ UC1541 Virtual filesystem
+ 
+--- a/src/vfs/extfs/helpers/s3+.in
++++ b/src/vfs/extfs/helpers/s3+.in
+@@ -1,4 +1,4 @@
+-#! @PYTHON@
++#! /usr/bin/env python3
+ # -*- coding: utf-8 -*-
+ 
+ #
+@@ -153,16 +153,16 @@
+ 	Propagates exception safely.
+ 	"""
+ 	from threading import Thread
+-	import Queue
++	import queue
+ 
+ 	items = list(iterable)
+ 	nitems = len(items)
+ 	if nitems < 2:
+-		return map(fun, items)
++		return list(map(fun, items))
+ 
+ 	# Create and fill input queue
+-	input = Queue.Queue()
+-	output = Queue.Queue()
++	input = queue.Queue()
++	output = queue.Queue()
+ 
+ 	for i,item in enumerate(items):
+ 		input.put( (i,item) )
+@@ -181,7 +181,7 @@
+ 						output.put( (i,result) )
+ 					except:
+ 						output.put( (None,sys.exc_info()) )
+-				except Queue.Empty:
++				except queue.Empty:
+ 					return
+ 
+ 	# Start threads
+@@ -196,8 +196,8 @@
+ 		try:
+ 			i,res = output.get()
+ 			if i == None:
+-				raise res[0],res[1],res[2]
+-		except Queue.Empty:
++				raise res[0](res[1]).with_traceback(res[2])
++		except queue.Empty:
+ 			break
+ 		ret.append(res)
+ 
+@@ -241,7 +241,7 @@
+ 		b = s3.get_bucket(name, validate=False)
+ 		b.get_location() # just to raise an exception on error
+ 		return b
+-	except boto.exception.S3ResponseError, e:
++	except boto.exception.S3ResponseError as e:
+ 		# Seems this is the only proper way to switch to the bucket's region.
+ 		# Requesting of the default region for "?location" does not work unfortunately.
+ 		m = re.search(r'<Region>(.*?)</Region>', e.body)
+@@ -340,7 +340,7 @@
+ 	expr = re.compile(r'^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{3}Z$')
+ 	def convDate(awsdatetime):
+ 		m = expr.match(awsdatetime)
+-		ye,mo,da,ho,mi,se = map(int,m.groups())
++		ye,mo,da,ho,mi,se = list(map(int,m.groups()))
+ 
+ 		dt = datetime.datetime(ye,mo,da,ho,mi,se, tzinfo=pytz.utc)
+ 		return dt.astimezone(tz).strftime('%m-%d-%Y %H:%M')

--- a/srcpkgs/mc/template
+++ b/srcpkgs/mc/template
@@ -1,20 +1,18 @@
 # Template file for 'mc'
 pkgname=mc
-version=4.8.29
+version=4.8.30
 revision=1
 build_style=gnu-configure
 configure_args="--with-screen=slang --without-x"
 hostmakedepends="perl pkg-config"
 makedepends="e2fsprogs-devel gpm-devel libglib-devel libssh2-devel slang-devel"
 short_desc="User-friendly file manager and visual shell"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="0x5c <dev@0x5c.io>"
 license="GPL-3.0-or-later"
 homepage="https://midnight-commander.org/"
 changelog="https://midnight-commander.org/wiki/NEWS-${version}"
 distfiles="https://www.midnight-commander.org/downloads/mc-${version}.tar.xz"
-#distfiles="http://fossies.org/linux/misc/mc-${version}.tar.gz"
-checksum=01d8a3b94f58180cca5bf17257b5078d1fd6fd27a9b5c0e970ec767549540ad4
-python_version=2
+checksum=5ebc3cb2144b970c5149fda556c4ad50b78780494696cdf2d14a53204c95c7df
 
 conf_files="
  /etc/mc/filehighlight.ini
@@ -25,3 +23,7 @@ conf_files="
  /etc/mc/mc.menu
  /etc/mc/mcedit.menu
  /etc/mc/sfs.ini"
+
+post_install() {
+	vdoc "${FILESDIR}/README.voidlinux"
+}


### PR DESCRIPTION
Takes care of python2 scripts, and documents what packages are needed for each "extfs" backend script.

#### Testing the changes
- I tested the changes in this PR: **YES**
    It is impossible to test the s3 backend without an AWS S3 account, but the patch is used in other distros.
