### PR TITLE
poppler: add and enable nss build option

### DIFF
--- a/srcpkgs/poppler/template
+++ b/srcpkgs/poppler/template
@@ -4,7 +4,7 @@
 #
 pkgname=poppler
 version=22.07.0
-revision=1
+revision=2
 _testVersion=920c89f8f43bdfe8966c8e397e7f67f5302e9435
 build_style=cmake
 build_helper="gir"
@@ -14,7 +14,7 @@ configure_args="-DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DENABLE_CPP=ON
  -DTESTDATADIR='${XBPS_BUILDDIR}/test-${_testVersion}'"
 hostmakedepends="pkg-config glib-devel"
 makedepends="libpng-devel libglib-devel cairo-devel tiff-devel lcms2-devel
-libcurl-devel libopenjpeg2-devel $(vopt_if boost boost-devel)"
+libcurl-devel libopenjpeg2-devel $(vopt_if boost boost-devel) $(vopt_if nss nss-devel)"
 short_desc="PDF rendering library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, GPL-3.0-or-later"
@@ -25,8 +25,8 @@ distfiles="${homepage}/${pkgname}-${version}.tar.xz
 checksum="420230c5c43782e2151259b3e523e632f4861342aad70e7e20b8773d9eaf3428
  ca35f168a18038a2d817ea30d6c7b4ab8294a40a5f5950f3c2a15183ba08c900"
 
-build_options="gir boost"
-build_options_default="gir boost"
+build_options="gir boost nss"
+build_options_default="gir boost nss"
 
 libpoppler_package() {
 	depends="poppler-data"


### PR DESCRIPTION
Void poppler utils are missing the `pdfsig` utility, after adding nss-devel as a build dependency cmake detects it and builds the utility.

#### Testing the changes
- I tested the changes in this PR: **briefly** ?
I've been running this patch on poppler updated to 22.06 without issues for a few weeks, but void got updated to 22.07 before I made a PR, so here is this patch on its own, I haven't tested it much at all on 22.07.