### PR TITLE
luarocks-lua53: update to 3.9.1

### DIFF
--- a/srcpkgs/luarocks-lua53/template
+++ b/srcpkgs/luarocks-lua53/template
@@ -1,6 +1,6 @@
 # Template file for 'luarocks-lua53'
 pkgname=luarocks-lua53
-version=3.7.0
+version=3.9.1
 revision=1
 wrksrc=luarocks-${version}
 build_style=configure
@@ -17,8 +17,9 @@ short_desc="${_desc} (5.3.x)"
 maintainer="Duncaen <duncaen@voidlinux.org>"
 license="MIT"
 homepage="https://luarocks.org/"
+changelog="https://github.com/luarocks/luarocks/wiki/Release-history"
 distfiles="https://luarocks.org/releases/luarocks-${version}.tar.gz"
-checksum=9255d97fee95cec5b54fc6ac718b11bf5029e45bed7873e053314919cd448551
+checksum=ffafd83b1c42aa38042166a59ac3b618c838ce4e63f4ace9d961a5679ef58253
 alternatives="
  luarocks:luarocks:/usr/bin/luarocks-5.3
  luarocks:luarocks-admin:/usr/bin/luarocks-admin-5.3"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - x86_64-musl
