### PR TITLE
monero+poppler: THREADS_PTHREAD_ARG is no longer needed

### DIFF
--- a/srcpkgs/monero/template
+++ b/srcpkgs/monero/template
@@ -30,10 +30,6 @@ checksum="e4462f8909bdc5e66d76f4023374ff759159c15fe7d407f0c21619769e87c35d
 skip_extraction="v${_randomx_version}.tar.gz ${_rapidjson_gitrev}.tar.gz ${_supercop_gitrev}.tar.gz"
 system_accounts="monero"
 
-if [ "$CROSS_BUILD" ]; then
-	configure_args+=" -DTHREADS_PTHREAD_ARG=OFF"
-fi
-
 case "$XBPS_TARGET_MACHINE" in
 	armv7*) configure_args+=" -DARCH=armv7" ;;
 	armv6*) configure_args+=" -DARCH=armv6" ;;

--- a/srcpkgs/poppler-qt5/template
+++ b/srcpkgs/poppler-qt5/template
@@ -24,10 +24,6 @@ checksum=420230c5c43782e2151259b3e523e632f4861342aad70e7e20b8773d9eaf3428
 # fails to find a bunch of files
 make_check=no
 
-if [ "$CROSS_BUILD" ]; then
-	configure_args+=" -DTHREADS_PTHREAD_ARG=2"
-fi
-
 post_install() {
 	local f
 	rm -f ${DESTDIR}/usr/lib/libpoppler.*


### PR DESCRIPTION
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1109/diffs

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
