### PR TITLE
linux-firmware: update to 20220708.

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,6 +1,6 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
-version=20220411
+version=20220708
 revision=1
 depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
@@ -8,7 +8,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="See /usr/share/licenses/${pkgname}"
 homepage="https://www.kernel.org/"
 distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=533ae621b3eacf6a4696dab52a9dbc5727403a175c413b1682ab3f9cfb37872f
+checksum=67a678f1d0a80fc32703efcea1831f78c410abbd513b5b8985daac6223d9bf91
 python_version=3
 nostrip=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**


#### Local build testing
- I built this PR locally for my native architecture, x86_64, glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64