### PR TITLE
New package: dry-0.11.1

### DIFF
--- a/srcpkgs/dry/template
+++ b/srcpkgs/dry/template
@@ -1,0 +1,18 @@
+# Template file for 'dry'
+pkgname=dry
+version=0.11.1
+revision=1
+build_style=go
+go_import_path=github.com/moncho/dry
+go_ldflags="-X github.com/moncho/dry/version.VERSION=${version}
+ -X github.com/moncho/dry/version.GITCOMMIT=v${version}"
+short_desc="Docker manager for the terminal"
+maintainer="meator <meator.dev@gmail.com>"
+license="MIT"
+homepage="https://moncho.github.io/dry/"
+distfiles="https://github.com/moncho/dry/archive/refs/tags/v${version}.tar.gz"
+checksum=69547e0167db8bf4b1536cdc007d6d27c787f53d5e1662e67adca99600e34435
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
I've included a flag in `go_ldflags` that sets the version, but `dry` also expects `github.com/moncho/dry/version.GITCOMMIT` to contain the git revision of `dry`. I haven't included it because using git to retreive it from the version tag or explicitly specifying the commit in a custom variable isn't worth it in my opinion. Because of this, `dry -v` now shows:
```
dry version 0.11.1, build 
```
without a newline at the end.

#### Testing the changes
- I tested the changes in this PR: **YES**
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**