### PR TITLE
python3-pikepdf: update to 5.4.0.

### DIFF
--- a/srcpkgs/python3-pikepdf/template
+++ b/srcpkgs/python3-pikepdf/template
@@ -1,21 +1,22 @@
 # Template file for 'python3-pikepdf'
 pkgname=python3-pikepdf
-version=5.1.3
+version=5.4.0
 revision=1
 wrksrc="pikepdf-${version}"
 build_style=python3-module
 hostmakedepends="python3-pybind11 python3-setuptools_scm python3-wheel"
 makedepends="libqpdf-devel python3-pybind11"
-depends="python3-lxml python3-packaging python3-Pillow python3-setuptools"
-checkdepends="python3-dateutil python3-hypothesis python3-psutil python3-pytest
- $depends"
+depends="jbig2dec python3-deprecation python3-lxml python3-packaging
+ python3-Pillow python3-setuptools"
+checkdepends="poppler python3-dateutil python3-hypothesis python3-psutil
+ python3-pytest python3-pytest-timeout python3-pytest-xdist $depends"
 short_desc="Python library for reading and writing PDF files"
 maintainer="Philipp David <pd@3b.pm>"
 license="MPL-2.0"
 homepage="https://github.com/pikepdf/pikepdf"
 distfiles="${PYPI_SITE}/p/pikepdf/pikepdf-${version}.tar.gz"
-checksum=c34e4239661d2ddf23caa1c4256f636c866ce8069a5052a2bf8ee06e3cae22f3
+checksum=d397a061959a5cd7d9869a381dda005eccfef59c33dd3eba6a8e19ce036168be
 
-pre_build() {
-	vsed -e '/setuptools_scm_git_archive/d' -i setup.py
+pre_check() {
+	cp -r src/pikepdf.egg-info "$(cd build/lib* && pwd)"
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Plain setuptools_scm is now used, so there's no need to patch out setuptools_scm_git_archive anymore. Since 5.1.4 the egg-info directory needs to be on PYTHONPATH to run tests, so I copy it to the correct location as a workaround. Also added new required and optional depends/checkdepends.