### PR TITLE
.github/issue_template.md: remind issue creators of issue forms

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,4 @@
+<!--
+  if you are creating a bug report or package request, please fill out one of the forms here:
+  https://github.com/void-linux/void-packages/issues/new/choose
+-->


### PR DESCRIPTION
@paper42 noticed that some issue creators were using the blank template for bug reports, so this should remind them to use the forms for those types of issues

#### Testing the changes
- I tested the changes in this PR: **YES**
  see here: https://github.com/classabbyamp/void-packages-test/issues/new

