### PR TITLE
docker-credential-pass: update to 0.6.4

### DIFF
--- a/srcpkgs/docker-credential-pass/template
+++ b/srcpkgs/docker-credential-pass/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-credential-pass'
 pkgname=docker-credential-pass
-version=0.6.3
+version=0.6.4
 revision=1
 archs="x86_64* ppc64le*"
 wrksrc="docker-credential-helpers-${version}"
@@ -13,7 +13,7 @@ maintainer="Hoang Nguyen <hoang@wetrust.io>"
 license="MIT"
 homepage="https://github.com/docker/docker-credential-helpers"
 distfiles="https://${go_import_path}/archive/v${version}.tar.gz"
-checksum=441684cf1d2434aa1024aa2f8455e11502c44858e93ea171b19caa656dd2b2e2
+checksum=b97d27cefb2de7a18079aad31c9aef8e3b8a38313182b73aaf8b83701275ac83
 
 # the build step installed the binary named cmd because
 # the authors structured their code that way.


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

