### PR TITLE
cups-filters: update to 1.28.15.

### DIFF
--- a/srcpkgs/cups-filters/template
+++ b/srcpkgs/cups-filters/template
@@ -1,6 +1,6 @@
 # Template file for 'cups-filters'
 pkgname=cups-filters
-version=1.28.10
+version=1.28.15
 revision=1
 build_style=gnu-configure
 configure_args="--disable-static --with-rcdir=no --enable-avahi
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, MIT"
 homepage="https://wiki.linuxfoundation.org/openprinting/cups-filters"
 distfiles="http://openprinting.org/download/cups-filters/${pkgname}-${version}.tar.xz"
-checksum=cf8c904694c44cf689b5724e46d23da9ae5125d54374b340c642077cc29ca837
+checksum=a907ec769fbb72efbfbf9b540b250a08e33b6e373a8a7c343f9840fba4d0478b
 lib32disabled=yes
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
Have been testing this since the release of cups 2.4.2, it's been fine with my limited selection of printers.