### PR TITLE
bearssl: run tests

### DIFF
--- a/srcpkgs/bearssl/template
+++ b/srcpkgs/bearssl/template
@@ -8,8 +8,8 @@ short_desc="Implementation of the SSL/TLS protocol in C"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="MIT"
 homepage="https://bearssl.org"
-changelog="${homepage}/changelog.html"
-distfiles="${homepage}/${pkgname}-${version}.tar.gz"
+changelog="https://bearssl.org/changelog.html"
+distfiles="https://bearssl.org/${pkgname}-${version}.tar.gz"
 checksum=6705bba1714961b41a728dfc5debbe348d2966c117649392f8c8139efc83ff14
 CFLAGS="-fPIC"
 
@@ -22,6 +22,13 @@ do_install() {
 	vcopy inc usr/include
 	vlicense LICENSE.txt LICENSE
 }
+
+do_check() {
+	cd "${wrksrc}/build"
+	./testx509
+	./testcrypto all
+}
+
 bearssl-devel_package() {
 	short_desc+=" - development files"
 	depends="${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
I added the `do_check` part, which seems to run fine.
Previously it was skipped.