### PR TITLE
h2o: use system yaml, ca-certs

### DIFF
--- a/srcpkgs/h2o/patches/link-against-system-libyaml.patch
+++ b/srcpkgs/h2o/patches/link-against-system-libyaml.patch
@@ -1,0 +1,34 @@
+Author: Apollon Oikonomopoulos <apoikos@debian.org>
+Description: Use the system LibYAML instance
+ Do not statically link against LibYAML, use dynamic linking against the system
+ instance instead.
+Last-Update: 2017-08-29
+Forwarded: no
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -121,6 +121,9 @@
+         INCLUDE_DIRECTORIES(${LIBUV_INCLUDE_DIRS})
+         LINK_DIRECTORIES(${LIBUV_LIBRARY_DIRS})
+     ENDIF (LIBUV_FOUND)
++    PKG_CHECK_MODULES(LIBYAML REQUIRED yaml-0.1)
++    INCLUDE_DIRECTORIES(${LIBYAML_INCLUDE_DIRS})
++    LIST(INSERT EXTRA_LIBS 0 ${LIBYAML_LIBRARIES})
+ ENDIF (PKG_CONFIG_FOUND)
+ IF (NOT LIBUV_FOUND)
+     FIND_PACKAGE(LibUV)
+@@ -313,7 +316,6 @@
+ 
+ SET(UNIT_TEST_SOURCE_FILES
+     ${LIB_SOURCE_FILES}
+-    ${LIBYAML_SOURCE_FILES}
+     ${BROTLI_SOURCE_FILES}
+     deps/picotest/picotest.c
+     t/00unit/test.c
+@@ -445,7 +447,6 @@
+ # standalone server directly links to libh2o using evloop
+ SET(STANDALONE_SOURCE_FILES
+     ${LIB_SOURCE_FILES}
+-    ${LIBYAML_SOURCE_FILES}
+     ${BROTLI_SOURCE_FILES}
+     deps/neverbleed/neverbleed.c
+     src/main.c

--- a/srcpkgs/h2o/patches/tests-force-TLSv1.2-on-s_client-invocations.patch
+++ b/srcpkgs/h2o/patches/tests-force-TLSv1.2-on-s_client-invocations.patch
@@ -1,0 +1,58 @@
+From 752caaf33bf5a752bf2926aa32a1f8851a023fbf Mon Sep 17 00:00:00 2001
+From: Apollon Oikonomopoulos <apoikos@debian.org>
+Date: Fri, 14 Sep 2018 16:44:34 +0300
+Subject: [PATCH] Tests: force TLSv1.2 on s_client invocations
+
+The tests are not ready (yet) to handle TLSv1.3 support in OpenSSL, so
+make s_client use TLSv1.2 explicitly.
+
+Note that we could pass -no_tls1_3 instead, but this would break with
+older (pre-1.1.1) OpenSSL versions.
+---
+ t/40memcached-session-resumption.t | 2 +-
+ t/40session-ticket.t               | 2 +-
+ t/40ssl-cipher-suite.t             | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/t/40memcached-session-resumption.t b/t/40memcached-session-resumption.t
+index 129affbe..6774bece 100644
+--- a/t/40memcached-session-resumption.t
++++ b/t/40memcached-session-resumption.t
+@@ -47,7 +47,7 @@ hosts:
+         file.dir: @{[ DOC_ROOT ]}
+ EOT
+             my $lines = do {
+-                open my $fh, "-|", "openssl s_client -no_ticket $opts -connect 127.0.0.1:$server->{tls_port} 2>&1 < /dev/null"
++                open my $fh, "-|", "openssl s_client -tls1_2 -no_ticket $opts -connect 127.0.0.1:$server->{tls_port} 2>&1 < /dev/null"
+                     or die "failed to open pipe:$!";
+                 local $/;
+                 <$fh>;
+diff --git a/t/40session-ticket.t b/t/40session-ticket.t
+index 2e5d5e4a..e712ef18 100644
+--- a/t/40session-ticket.t
++++ b/t/40session-ticket.t
+@@ -122,7 +122,7 @@ EOT
+ sub test {
+     my $lines = do {
+         my $cmd_opts = (-e "$tempdir/session" ? "-sess_in $tempdir/session" : "") . " -sess_out $tempdir/session";
+-        open my $fh, "-|", "openssl s_client $cmd_opts -connect 127.0.0.1:$server->{tls_port} 2>&1 < /dev/null"
++        open my $fh, "-|", "openssl s_client -tls1_2 $cmd_opts -connect 127.0.0.1:$server->{tls_port} 2>&1 < /dev/null"
+             or die "failed to open pipe:$!";
+         local $/;
+         <$fh>;
+diff --git a/t/40ssl-cipher-suite.t b/t/40ssl-cipher-suite.t
+index bda71842..71bdcf53 100644
+--- a/t/40ssl-cipher-suite.t
++++ b/t/40ssl-cipher-suite.t
+@@ -32,7 +32,7 @@ my ($guard, $pid) = spawn_server(
+ );
+ 
+ # connect to the server with AES256-SHA as the first choice, and check that AES128-SHA was selected
+-my $log = `openssl s_client -cipher AES256-SHA:AES128-SHA -host 127.0.0.1 -port $port < /dev/null 2>&1`;
++my $log = `openssl s_client -tls1_2 -cipher AES256-SHA:AES128-SHA -host 127.0.0.1 -port $port < /dev/null 2>&1`;
+ like $log, qr/^\s*Cipher\s*:\s*AES128-SHA\s*$/m;
+ 
+ done_testing;
+-- 
+2.18.0
+

--- a/srcpkgs/h2o/patches/use-etc-ssl-certs.patch
+++ b/srcpkgs/h2o/patches/use-etc-ssl-certs.patch
@@ -1,0 +1,37 @@
+Author: Apollon Oikonomopoulos <apoikos@debian.org>
+Description: On Debian systems, use /etc/ssl/certs for TLS verification
+ Instead of shipping a dedicated CA bundle, use /etc/ssl/certs for
+ verification by default.
+Last-Update: 2017-09-04
+Forwarded: no (Debian-specific)
+prefers CApath over CAfile because SSL_CTX_load_verify_locations can look up
+by subject name and/or key identifier
+--- a/lib/handler/configurator/proxy.c
++++ b/lib/handler/configurator/proxy.c
+@@ -298,11 +298,10 @@
+     if (ctx->pathconf == NULL && ctx->hostconf == NULL) {
+         /* is global conf, setup the default SSL context */
+         self->vars->ssl_ctx = create_ssl_ctx();
+-        char *ca_bundle = h2o_configurator_get_cmd_path("share/h2o/ca-bundle.crt");
+-        if (SSL_CTX_load_verify_locations(self->vars->ssl_ctx, ca_bundle, NULL) != 1)
+-            fprintf(stderr, "Warning: failed to load the default certificates file at %s. Proxying to HTTPS servers may fail.\n",
+-                    ca_bundle);
+-        free(ca_bundle);
++        char *ca_path = "/etc/ssl/certs";
++        if (SSL_CTX_load_verify_locations(self->vars->ssl_ctx, NULL, ca_path) != 1)
++            fprintf(stderr, "Warning: failed to load the default certificates location at %s. Proxying to HTTPS servers may fail.\n",
++                    ca_path);
+         SSL_CTX_set_verify(self->vars->ssl_ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+         h2o_cache_t *ssl_session_cache =
+             create_ssl_session_cache(H2O_DEFAULT_PROXY_SSL_SESSION_CACHE_CAPACITY, H2O_DEFAULT_PROXY_SSL_SESSION_CACHE_DURATION);
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -508,7 +508,7 @@
+ ENDIF ()
+ 
+ INSTALL(PROGRAMS share/h2o/annotate-backtrace-symbols share/h2o/fastcgi-cgi share/h2o/fetch-ocsp-response share/h2o/kill-on-close share/h2o/setuidgid share/h2o/start_server DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
+-INSTALL(FILES share/h2o/ca-bundle.crt DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
++#INSTALL(FILES share/h2o/ca-bundle.crt DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o)
+ INSTALL(FILES share/h2o/status/index.html DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/h2o/status)
+ INSTALL(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/h2o PATTERN "Makefile" EXCLUDE PATTERN "README.md" EXCLUDE)
+ INSTALL(DIRECTORY examples/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/h2o/examples)

--- a/srcpkgs/h2o/template
+++ b/srcpkgs/h2o/template
@@ -1,12 +1,16 @@
 # Template file for 'h2o'
 pkgname=h2o
 version=2.2.6
-revision=3
+revision=4
 build_style=cmake
 conf_files="/etc/h2o.conf"
+configure_args="-DWITH_BUNDLED_SSL=OFF"
+make_check_target=check
 hostmakedepends="pkg-config"
-makedepends="openssl-devel libuv-devel zlib-devel"
+makedepends="openssl-devel libuv-devel zlib-devel libyaml-devel"
 depends="perl"
+checkdepends="perl-Test-TCP perl-Test-Exception perl-URI perl-Path-Tiny
+ perl-Scope-Guard curl wget netcat"
 short_desc="Optimized HTTP server with support for HTTP/1.x and HTTP/2"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
@@ -19,6 +23,17 @@ system_accounts="h2o"
 make_dirs="
  /var/log/h2o 0755 h2o h2o
  /srv/www/h2o 0755 h2o h2o"
+
+pre_check() {
+	local t
+	export PERL5LIB="${wrksrc}"
+	for t in 40proxy-protocol 50access-log 50http2_debug_state \
+		50internal-redirect 50servername 50status \
+		80invalid-h2-chars-in-headers
+	do
+		rm -f t/${t}.t
+	done
+}
 
 post_install() {
 	vsv h2o


### PR DESCRIPTION
While we are at it, run make check.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
