### PR TITLE
bootchart2: remove systemd service

### DIFF
--- a/srcpkgs/bootchart2/template
+++ b/srcpkgs/bootchart2/template
@@ -1,7 +1,7 @@
 # Template file for 'bootchart2'
 pkgname=bootchart2
 version=0.14.9
-revision=2
+revision=3
 wrksrc="bootchart-${version}"
 build_style=gnu-makefile
 make_install_args="EARLY_PREFIX=/usr DOCDIR=/usr/share/doc/bootchart2"
@@ -19,4 +19,8 @@ conflicts="bootchart>=0"
 
 post_patch() {
 	vsed -i -e 's,\$(EARLY_PREFIX)/sbin/,/usr/bin/,' Makefile
+}
+
+post_install() {
+	rm -r $DESTDIR/usr/lib/systemd/system
 }


### PR DESCRIPTION
`bootchartd` only needs to run once at boot. no need to create a service file.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)