### PR TITLE
mitmproxy: remove unused python3-pyzstd dependency

### DIFF
--- a/srcpkgs/mitmproxy/template
+++ b/srcpkgs/mitmproxy/template
@@ -1,13 +1,13 @@
 # Template file for 'mitmproxy'
 pkgname=mitmproxy
 version=8.1.1
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-Brotli python3-Flask python3-asgiref python3-blinker python3-certifi
  python3-click python3-cryptography python3-h11 python3-h2 python3-hyperframe python3-kaitaistruct
  python3-ldap3 python3-msgpack python3-openssl python3-parsing python3-passlib python3-protobuf
- python3-publicsuffix2 python3-pyperclip python3-pyzstd python3-ruamel.yaml python3-sortedcontainers
+ python3-publicsuffix2 python3-pyperclip python3-ruamel.yaml python3-sortedcontainers
  python3-tornado python3-urwid python3-wsproto python3-zstandard"
 checkdepends="${depends} python3-hypothesis python3-parver
  python3-pytest-asyncio python3-pytest-cov python3-pytest-timeout python3-requests"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
