### PR TITLE
python3-zstandard: use system libzstd

### DIFF
--- a/srcpkgs/python3-zstandard/template
+++ b/srcpkgs/python3-zstandard/template
@@ -1,11 +1,12 @@
 # Template file for 'python3-zstandard'
 pkgname=python3-zstandard
 version=0.18.0
-revision=1
+revision=2
 wrksrc="python-zstandard-${version}"
 build_style=python3-module
+make_build_args="--system-zstd"
 hostmakedepends="python3-setuptools"
-makedepends="python3-devel"
+makedepends="python3-devel libzstd-devel"
 depends="python3"
 checkdepends="python3-hypothesis"
 short_desc="Python bindings to the Zstandard (zstd) compression library"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - ppc64le-musl
