### PR TITLE
tor: raise max open files again

### DIFF
--- a/srcpkgs/tor/files/tor/run
+++ b/srcpkgs/tor/files/tor/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 [ -r conf ] && . ./conf
-ulimit -n ${MAX_OPEN_FILES:-16384}
+ulimit -n ${MAX_OPEN_FILES:-65536}
 exec tor ${OPTS:=--quiet} --runasdaemon 0 2>&1

--- a/srcpkgs/tor/template
+++ b/srcpkgs/tor/template
@@ -1,7 +1,7 @@
 # Template file for 'tor'
 pkgname=tor
 version=0.4.7.8
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--enable-zstd"
 hostmakedepends="pkg-config"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

The current max open files is still not quite enough when running a high speed relay. Raise to 65536 which is also the default in Debian.

Failing test on x86_64-musl is known.

cc @daniel-eys 

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
