### PR TITLE
appstream-glib: update to 0.8.0.

### DIFF
--- a/srcpkgs/appstream-glib/patches/0001-flip-archive_h-and-archive_entry_h-order-on-client-as-util.patch
+++ b/srcpkgs/appstream-glib/patches/0001-flip-archive_h-and-archive_entry_h-order-on-client-as-util.patch
@@ -9,6 +9,6 @@ They are in the wrong order.
 -#include <archive_entry.h>
  #include <archive.h>
 +#include <archive_entry.h>
- #include <libsoup/soup.h>
+ #include <curl/curl.h>
  #include <locale.h>
  #include <stdlib.h>

--- a/srcpkgs/appstream-glib/patches/0002-flip-archive_h-and-archive_entry_h-order-on-libappstream-glib-as-util.patch
+++ b/srcpkgs/appstream-glib/patches/0002-flip-archive_h-and-archive_entry_h-order-on-libappstream-glib-as-util.patch
@@ -9,6 +9,5 @@ They are in the wrong order.
 -#include <archive_entry.h>
  #include <archive.h>
 +#include <archive_entry.h>
- #include <libsoup/soup.h>
  #include <stdlib.h>
  #include <uuid.h>

--- a/srcpkgs/appstream-glib/template
+++ b/srcpkgs/appstream-glib/template
@@ -1,6 +1,6 @@
 # Template file for 'appstream-glib'
 pkgname=appstream-glib
-version=0.7.18
+version=0.8.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -8,14 +8,14 @@ configure_args="-Dgtk-doc=false -Drpm=false -Dstemmer=false
  -Dintrospection=$(vopt_if gir true false)"
 hostmakedepends="gcab gperf pkg-config glib-devel"
 makedepends="gcab-devel gtk+3-devel json-glib-devel libarchive-devel
- libsoup-devel libyaml-devel"
+ libcurl-devel libyaml-devel"
 short_desc="Install and update applications"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://people.freedesktop.org/~hughsient/appstream-glib/"
 changelog="https://raw.githubusercontent.com/hughsie/appstream-glib/master/NEWS"
 distfiles="${homepage}/releases/${pkgname}-${version}.tar.xz"
-checksum=ca1ed22e3bde3912cb903aaa7de085d55771da454f1c0573fd9608e1de9c4002
+checksum=10bac3c3c6d9d27eab7e23872c21158618daa5b132c1d8e3a8154b910049b848
 
 build_options="gir"
 build_options_default="gir"
@@ -26,7 +26,7 @@ post_install() {
 
 appstream-glib-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision} gcab-devel gdk-pixbuf-devel
-	 libarchive-devel libsoup-devel libyaml-devel"
+	 libarchive-devel libcurl-devel libyaml-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64-musl
  - aarch64-glibc
  - x86_64-musl
