### PR TITLE
python3-pymediainfo: remove unused dependency.

### DIFF
--- a/srcpkgs/python3-pymediainfo/template
+++ b/srcpkgs/python3-pymediainfo/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-pymediainfo'
 pkgname=python3-pymediainfo
 version=5.1.0
-revision=1
+revision=2
 wrksrc="pymediainfo-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
-depends="python3-importlib_metadata libmediainfo"
+depends="libmediainfo"
 checkdepends="python3-pytest libmediainfo"
 short_desc="Python wrapper around the MediaInfo library"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"


### PR DESCRIPTION
python3-importlib_metadata is a backport of new-ish importlib APIs for python
versions under 3.10 (3.8 in some cases). Since Void already has python 3.10,
the backport is completely unused and the package is already using the builtin
importlib.metadata (note the dot in place of the underscore).

https://github.com/sbraz/pymediainfo/commit/8af1511195f70ba2776bd9f1c15afbf6d2377b9b

@TinfoilSubmarine

#### Testing the changes
- I tested the changes in this PR: **briefly**
    `importlib.metadata` is mainly used to get the version, and that seems to be working perfectly. I used the library to get info on a png image and it seemed to work fine.
