### PR TITLE
kbd: update to 2.5.1.

### DIFF
--- a/srcpkgs/kbd/template
+++ b/srcpkgs/kbd/template
@@ -1,6 +1,6 @@
 # Template file for 'kbd'
 pkgname=kbd
-version=2.4.0
+version=2.5.1
 revision=1
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/kbd --localedir=/usr/share/kbd/locale"
@@ -11,7 +11,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.kbd-project.org/"
 distfiles="${KERNEL_SITE}/utils/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=55f0740458cfd3a84e775e50d7e8b92dc01846db1edad8e2411ccc293ece9b9f
+checksum=ccdf452387a6380973d2927363e9cbb939fa2068915a6f937ff9d24522024683
 replaces="kbd-data>=0"
 
 post_patch() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-{glibc,musl}


Not sure if I should keep the patches as it seems that lfs no longer uses ` kbd-2.0.2-backspace-1.patch` , but it applies fine so  I kept it. 

Shouldn't we try to get `fix-euro-symbol-es-keymap.patch` upstream ? I don't use a spanish keyboard so I am not sure if it is correct the keyboard that way or if it was a personal preference of whoever added the patch 