### PR TITLE
fossil: update to 2.19.

### DIFF
--- a/srcpkgs/fossil/template
+++ b/srcpkgs/fossil/template
@@ -1,22 +1,24 @@
 # Template file for 'fossil'
 pkgname=fossil
-version=2.18
+version=2.19
 revision=1
 build_style=configure
-configure_args="--disable-internal-sqlite --prefix=/usr --with-sqlite=${XBPS_CROSS_BASE}/usr/include"
+configure_args="--disable-internal-sqlite --prefix=/usr
+ --with-sqlite=${XBPS_CROSS_BASE}/usr/include --json"
 hostmakedepends="tcl"
-makedepends="zlib-devel openssl-devel readline-devel sqlite-devel"
+makedepends="zlib-devel openssl-devel sqlite-devel"
 short_desc="Simple, high-reliability, distributed software configuration management"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="ologantr <mrphyber@protonmail.com>"
 license="BSD-2-Clause"
 homepage="https://www.fossil-scm.org"
 changelog="https://www.fossil-scm.org/home/doc/trunk/www/changes.wiki"
 distfiles="https://fossil-scm.org/home/tarball/version-${version}/fossil-${version}.tar.gz"
-checksum=e89cb9c726348bb14e7736e031d2b08574408c5d4db98e7d3fc814dadc6f3546
+checksum=459f7fedbe25449a855727d7c33bad3bc0bf3dae973f2c6dbe9a7b826106a23e
 
 post_extract() {
 	vsed -i 's/test_system_sqlite$/# &/' auto.def  # failing on cross
 }
+
 post_install() {
 	vman fossil.1
 	vlicense COPYRIGHT-BSD2.txt LICENSE


### PR DESCRIPTION
Also:
- take maintainership
- remove readline-devel (not used)
- add json compile option

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)