### PR TITLE
.github/issue_template: discourage update requests

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,8 @@
 <!--
   if you are creating a bug report or package request, please fill out one of the forms here:
   https://github.com/void-linux/void-packages/issues/new/choose
+
+  Don't request an update of a package, We have a script for that:
+  https://alpha.de.repo.voidlinux.org/void-updates/void-updates.txt
+  However, a quality pull request may help.
 -->


### PR DESCRIPTION
This is only mentioned in the bug report issue template, so some people
miss it because they don't look at the bug report issue template and
just open an issue without a template.