### PR TITLE
rocksdb: update to 7.4.5.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3619,7 +3619,7 @@ libOsiCommonTests.so.1 libClp-1.16.11_1
 libOsi.so.1 libClp-1.16.11_1
 libOGDF.so libogdf-2018.03_1
 libCOIN.so libogdf-2018.03_1
-librocksdb.so.5 rocksdb-5.17.2_1
+librocksdb.so.7 rocksdb-7.4.5_1
 libfrr.so.0 libfrr-6.0_1
 libkaccounts.so.2 kaccounts-integration-20.04.3_1
 libfrrospfapiclient.so.0 libfrrospfapiclient-6.0_1

--- a/srcpkgs/neomutt/template
+++ b/srcpkgs/neomutt/template
@@ -1,7 +1,7 @@
 # Template file for 'neomutt'
 pkgname=neomutt
 version=20220429
-revision=1
+revision=2
 create_wrksrc=true
 build_wrksrc="${pkgname}-${version}"
 build_style=configure

--- a/srcpkgs/rocksdb/patches/toku_time.patch
+++ b/srcpkgs/rocksdb/patches/toku_time.patch
@@ -1,0 +1,17 @@
+From: https://github.com/facebook/rocksdb/issues/8609
+
+diff --git a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+index 225e3fa72..cd5f935f1 100644
+--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
++++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+@@ -131,6 +131,10 @@ static inline tokutime_t toku_time_now(void) {
+   uint64_t result;
+   __asm __volatile__("mrs %[rt], cntvct_el0" : [ rt ] "=r"(result));
+   return result;
++#elif defined(__arm__)
++  uint32_t lo, hi;
++  __asm __volatile__("mrrc p15, 1, %[lo], %[hi], c14" : [ lo ] "=r" (lo), [hi] "=r" (hi));
++  return (uint64_t)hi << 32 | lo;
+ #elif defined(__powerpc__)
+   return __ppc_get_timebase();
+ #elif defined(__s390x__)

--- a/srcpkgs/rocksdb/template
+++ b/srcpkgs/rocksdb/template
@@ -1,31 +1,21 @@
 # Template file for 'rocksdb'
 pkgname=rocksdb
-version=5.18.3
-revision=2
+version=7.4.5
+revision=1
 build_style=cmake
-configure_args="-DPORTABLE=1 -DWITH_TESTS=0 -DUSE_RTTI=0 -DWITH_LZ4=1"
-makedepends="liblz4-devel"
+configure_args="-DPORTABLE=1 -DWITH_TESTS=0 -DUSE_RTTI=0 -DWITH_LZ4=1
+	-DWITH_ZLIB=1 -DWITH_BZ2=1 -DWITH_SNAPPY=1 -DWITH_ZSTD=1"
+makedepends="liblz4-devel gflags-devel snappy-devel libzstd-devel bzip2-devel zlib-devel"
 short_desc="RocksDB is a embeddable, persistent key-value store for fast storage"
 maintainer="magenbluten <mb0@codemonkey.cc>"
 license="GPL-2.0-or-later, Apache-2.0, BSD-3-Clause"
 homepage="https://github.com/facebook/rocksdb"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=7fb6738263d3f2b360d7468cf2ebe333f3109f3ba1ff80115abd145d75287254
-CFLAGS=-DNDEBUG
-CXXFLAGS=-DNDEBUG
+checksum=af237cbdde7b7b7a0ee8a5858e9d49ed71964801cf768052ce0cdfd302943cc2
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 fi
-# Use the C++17 feature to align new
-CXXFLAGS="-faligned-new -Wno-error=deprecated-copy -Wno-error=pessimizing-move"
-
-pre_configure() {
-	if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
-		vsed -i CMakeLists.txt \
-			-e 's;target_link_libraries(${ROCKSDB_SHARED_LIB};& atomic;'
-	fi
-}
 
 post_install() {
 	vcopy "include/rocksdb/*" usr/include/rocksdb


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **Briefly** (recompiled neomutt and used it fine)

#### Local build testing
- I built this PR locally for my native architecture, x86_64-{glibc,musl}

I have also linked rockdb with others compression libraries.

Not sure if another packages need to be rebuilt as well because of the SONAME update, need help on a good way to find this. 
To find the packages that needed to be recompiled I simply used `grep -R rocksdb-devel srcpkgs/` not sure if this is the correct way to do it.

~Can't make armv6l work, going to need help on this arch.~