### PR TITLE
ibus-anthy: update to 1.5.14.

### DIFF
--- a/srcpkgs/ibus-anthy/patches/data-Update-era.t-with-2022.patch
+++ b/srcpkgs/ibus-anthy/patches/data-Update-era.t-with-2022.patch
@@ -1,0 +1,36 @@
+From ed993538c711d817e5365630b65f372e0dfd01a7 Mon Sep 17 00:00:00 2001
+From: fujiwarat <takao.fujiwara1@gmail.com>
+Date: Thu, 27 Jan 2022 15:15:13 +0900
+Subject: [PATCH] data: Update era.t with 2022
+
+---
+ data/era.t | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/data/era.t b/data/era.t
+index a6d297e..686271f 100644
+--- a/data/era.t
++++ b/data/era.t
+@@ -2,7 +2,7 @@
+ #
+ # ibus-anthy - The Anthy engine for IBus
+ #
+-# Copyright (c) 2010-2021 Takao Fujiwara <takao.fujiwara1@gmail.com>
++# Copyright (c) 2010-2022 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ # Copyright (c) 2010-2013 Red Hat, Inc.
+ #
+ # This program is free software; you can redistribute it and/or modify
+@@ -338,6 +338,8 @@
+ れいわ２ #T35*500 2020
+ れいわ３ #T35*500 令和3
+ れいわ３ #T35*500 2021
++れいわ４ #T35*500 令和4
++れいわ４ #T35*500 2022
+ １８６８ #T35*500 明治1
+ １８６９ #T35*500 明治2
+ １８７０ #T35*500 明治3
+@@ -496,3 +498,4 @@
+ ２０１９ #T35*500 平成31
+ ２０２０ #T35*500 令和2
+ ２０２１ #T35*500 令和3
++２０２２ #T35*500 令和4

--- a/srcpkgs/ibus-anthy/patches/setup-Minimum-candidate-window-page-size-to-1.patch
+++ b/srcpkgs/ibus-anthy/patches/setup-Minimum-candidate-window-page-size-to-1.patch
@@ -1,0 +1,37 @@
+From 4ef5ac95e84056ebd5a446e5e21b5f2a99377363 Mon Sep 17 00:00:00 2001
+From: fujiwarat <takao.fujiwara1@gmail.com>
+Date: Thu, 14 Apr 2022 15:23:26 +0900
+Subject: [PATCH] setup: Minimum candidate window page size to 1
+
+IBusLookupTable assert with page_size > 0 (rhbz#2064261)
+---
+ setup/python2/setup.ui | 2 +-
+ setup/python3/setup.ui | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup/python2/setup.ui b/setup/python2/setup.ui
+index 88b19b8..3e82f2e 100644
+--- a/setup/python2/setup.ui
++++ b/setup/python2/setup.ui
+@@ -2,7 +2,7 @@
+ <interface>
+   <object class="GtkAdjustment" id="adjustment1">
+     <property name="upper">10</property>
+-    <property name="lower">0</property>
++    <property name="lower">1</property>
+     <property name="page_increment">0</property>
+     <property name="step_increment">1</property>
+     <property name="page_size">0</property>
+diff --git a/setup/python3/setup.ui b/setup/python3/setup.ui
+index 88b19b8..3e82f2e 100644
+--- a/setup/python3/setup.ui
++++ b/setup/python3/setup.ui
+@@ -2,7 +2,7 @@
+ <interface>
+   <object class="GtkAdjustment" id="adjustment1">
+     <property name="upper">10</property>
+-    <property name="lower">0</property>
++    <property name="lower">1</property>
+     <property name="page_increment">0</property>
+     <property name="step_increment">1</property>
+     <property name="page_size">0</property>

--- a/srcpkgs/ibus-anthy/template
+++ b/srcpkgs/ibus-anthy/template
@@ -1,25 +1,17 @@
 # Template file for 'ibus-anthy'
 pkgname=ibus-anthy
-version=1.5.12
+version=1.5.14
 revision=1
 build_style=gnu-configure
 build_helper=gir
-configure_args="--libexec=/usr/lib/ibus"
-hostmakedepends="automake libtool pkg-config swig intltool gettext-devel"
-makedepends="anthy-devel ibus-devel python3-gobject-devel"
+configure_args="--with-python=python3 --with-layout=default"
+hostmakedepends="automake libtool pkg-config gettext"
+makedepends="anthy-unicode-devel ibus-devel python3-gobject-devel"
 depends="ibus"
+checkdepends="procps-ng python3-pycotap"
 short_desc="Japanese input method Anthy IMEngine for IBus Framework"
 maintainer="7185 <7185@free.fr>"
 license="LGPL-2.1-or-later"
-homepage="https://github.com/ibus/ibus/wiki"
-distfiles="https://github.com/ibus/${pkgname}/archive/${version}.tar.gz"
-checksum=7756216666264b25083adb3a3e53f6a0ff744efc3331fe7ac7becbf4ed17d2ca
-make_check=extended
-
-post_patch() {
-	2to3 -w gir/test.py
-}
-
-pre_configure() {
-	autoreconf -fi
-}
+homepage="https://github.com/fujiwarat/ibus-anthy/wiki"
+distfiles="https://github.com/ibus/ibus-anthy/releases/download/${version}/ibus-anthy-${version}.tar.gz"
+checksum=c8694da18d0b891a48f4d75a0dece37ecbca6d1b1acb64101a7a84cad1046d9b

--- a/srcpkgs/python3-pycotap/template
+++ b/srcpkgs/python3-pycotap/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-pycotap'
+pkgname=python3-pycotap
+version=1.2.2
+revision=1
+wrksrc="pycotap-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+short_desc="Tiny test runner that outputs TAP results to standard output"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
+homepage="https://el-tramo.be/pycotap/"
+distfiles="${PYPI_SITE}/p/pycotap/pycotap-${version}.tar.gz"
+checksum=f938ecd4931ccd19d9598fb633d5eabb7938f08b84717315e52526aa6277c9ec
+
+post_install() {
+	rm -f ${DESTDIR}/usr/COPYING
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

+ This enables tests, although I can disable it again if you want.
+ swig is only needed when building with pygtk.
+ intltool is not needed by ibus-anthy.
+ This removes `--libexec=/usr/lib/ibus`. I'm not sure what it was needed for but most distros used to use it and have since removed it and the preferences popup doesn't work with it.
+ This uses `--with-layout=default` which is used by debian and fedora to tell ibus-anthy to use the default keyboard layout (otherwise it will always use JP).
+ This also moves ibus-anthy from Debian Anthy to anthy-unicode, this is what is also used by fcitx5-anthy.

In the basic testing I did, I didn't notice any issues, but please let me know if I missed something.

cc: @7185 

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
