### PR TITLE
docker-credential-pass: Fix broken post_install

### DIFF
--- a/srcpkgs/docker-credential-pass/template
+++ b/srcpkgs/docker-credential-pass/template
@@ -1,7 +1,7 @@
 # Template file for 'docker-credential-pass'
 pkgname=docker-credential-pass
 version=0.6.4
-revision=1
+revision=2
 wrksrc="docker-credential-helpers-${version}"
 build_style=go
 go_import_path="github.com/docker/docker-credential-helpers"
@@ -16,8 +16,5 @@ checksum=b97d27cefb2de7a18079aad31c9aef8e3b8a38313182b73aaf8b83701275ac83
 
 post_install() {
 	mv ${DESTDIR}/usr/bin/cmd ${DESTDIR}/usr/bin/docker-credential-pass
-}
-
-post_install() {
 	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**
  - Only checked that `xls` shows the right binary after packaging

This was broken [here](https://github.com/void-linux/void-packages/pull/38108/files#diff-7d968ebeea41e0a809c2ac3582c3d263703f1af61ec5b0d5a164660fad3638d9) because a `do_install` was renamed to `post_install` without merging the other `post_install`