### PR TITLE
.github/workflows/stale.yml: do not close issues labelled as bug

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,4 +22,6 @@ jobs:
           exempt-all-assignees: true
           ascending: true
           operations-per-run: 250
-          exempt-issue-labels: request
+          exempt-issue-labels:
+            - request
+            - bug


### PR DESCRIPTION
We need a way to exclude issues form autoclosing. Or stop autoclosing any issues.

PR #36411 was built with excluding [`label:bug -label:needs-testing`](https://github.com/void-linux/void-packages/issues?q=is%3Aopen+is%3Aissue+label%3Abug+-label%3Aneeds-testing+) in mind, but this is not expressible with workflow. Let `bug` label make issues not stale.