### PR TITLE
xbps-src: do not allow `/usr/share/man/man`

### DIFF
--- a/common/hooks/pre-pkg/99-pkglint.sh
+++ b/common/hooks/pre-pkg/99-pkglint.sh
@@ -108,6 +108,11 @@ hook() {
 		error=1
 	fi
 
+	if [[ -d ${PKGDESTDIR}/usr/share/man/man ]]; then
+		msg_red "${pkgver}: /usr/share/man/man is forbidden, use /usr/share/man.\n"
+		error=1
+	fi
+
 	if [ -d ${PKGDESTDIR}/usr/doc ]; then
 		msg_red "${pkgver}: /usr/doc is forbidden. Use /usr/share/doc.\n"
 		error=1

--- a/srcpkgs/coturn/template
+++ b/srcpkgs/coturn/template
@@ -1,9 +1,12 @@
 # Template file for 'coturn'
 pkgname=coturn
 version=4.5.1.3
-revision=3
-build_style=gnu-configure
-configure_args="--libdir=/usr/lib"
+revision=4
+build_style=configure
+configure_args="
+ --prefix=/usr
+ --manprefix=/usr/share
+ --sysconfdir=/etc"
 conf_files="/etc/turnserver.conf"
 makedepends="openssl-devel libevent-devel hiredis-devel sqlite-devel
  postgresql-libs-devel libmariadbclient-devel"


### PR DESCRIPTION
There is only a single package (`coturn`) using the directory because the `--manprefix` configure argument from the `gnu-configure` build style uses `/usr/share/man` while the configure script expected `/usr/share`.