### PR TITLE
gopass-jsonapi: update to 1.14.3.

### DIFF
--- a/srcpkgs/gopass-jsonapi/template
+++ b/srcpkgs/gopass-jsonapi/template
@@ -1,10 +1,11 @@
 # Template file for 'gopass-jsonapi'
 pkgname=gopass-jsonapi
 version=1.14.3
-revision=1
+revision=2
 create_wrksrc=yes
 build_style=go
 go_import_path=github.com/gopasspw/gopass-jsonapi
+go_ldflags="-X main.version=${version}"
 depends="gopass"
 short_desc="Gopass JSON bridge for extensions"
 maintainer="KuhnChris <kuhnchris+voidpackages@kuhnchris.eu>"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

---
Previous revision accidently didn't set the -X main.version=${version} making gopassbridge complain about "please upgrade your gopass version to >1.8.3" despite having 1.13.X installed.

For future references, a test client for this is found in the gopassbridge repository (test-client directory) and a check can be invoked like this:
```
(master) gopassbridge/test-client % echo '{"type": "getVersion"}' | ./test-client | gopass-jsonapi listen                                                                                                
3{"version":"1.14.3","major":1,"minor":14,"patch":3}%       
```