### PR TITLE
qt5: Add patch to remove limit on number of HTTP/2 streams (upstream) [ci skip]

### DIFF
--- a/srcpkgs/qt5/patches/0005-streams-fix.patch
+++ b/srcpkgs/qt5/patches/0005-streams-fix.patch
@@ -1,0 +1,43 @@
+diff --git a/qtbase/src/network/access/http2/http2protocol_p.h b/qtbase/src/network/access/http2/http2protocol_p.h
+index b0af5aa91921bf5229e2d54284687bafb1969eb1..ed5f2bf561f2bd62c6ef7fd1fde29e867d374603 100644
+--- a/qtbase/src/network/access/http2/http2protocol_p.h
++++ b/qtbase/src/network/access/http2/http2protocol_p.h
+@@ -133,9 +133,6 @@ enum Http2PredefinedParameters
+     maxPayloadSize = (1 << 24) - 1, // HTTP/2 6.5.2
+ 
+     defaultSessionWindowSize = 65535, // HTTP/2 6.5.2
+-    // Using 1000 (rather arbitrarily), just to
+-    // impose *some* upper limit:
+-    maxPeerConcurrentStreams  = 1000,
+     maxConcurrentStreams = 100 // HTTP/2, 6.5.2
+ };
+ 
+diff --git a/qtbase/src/network/access/qhttp2protocolhandler.cpp b/qtbase/src/network/access/qhttp2protocolhandler.cpp
+index f513139304bba375ea3c345c74f2c889b5a13938..21f1c91e29513acff83c45b6717cd5aa25609d62 100644
+--- a/qtbase/src/network/access/qhttp2protocolhandler.cpp
++++ b/qtbase/src/network/access/qhttp2protocolhandler.cpp
+@@ -393,7 +393,8 @@ bool QHttp2ProtocolHandler::sendRequest()
+         initReplyFromPushPromise(message, key);
+     }
+ 
+-    const auto streamsToUse = std::min<quint32>(maxConcurrentStreams - activeStreams.size(),
++    const auto streamsToUse = std::min<quint32>(maxConcurrentStreams > activeStreams.size()
++                                                ? maxConcurrentStreams - activeStreams.size() : 0,
+                                                 requests.size());
+     auto it = requests.begin();
+     for (quint32 i = 0; i < streamsToUse; ++i) {
+@@ -1084,13 +1085,8 @@ bool QHttp2ProtocolHandler::acceptSetting(Http2::Settings identifier, quint32 ne
+         QMetaObject::invokeMethod(this, "resumeSuspendedStreams", Qt::QueuedConnection);
+     }
+ 
+-    if (identifier == Settings::MAX_CONCURRENT_STREAMS_ID) {
+-        if (newValue > maxPeerConcurrentStreams) {
+-            connectionError(PROTOCOL_ERROR, "SETTINGS invalid number of concurrent streams");
+-            return false;
+-        }
++    if (identifier == Settings::MAX_CONCURRENT_STREAMS_ID)
+         maxConcurrentStreams = newValue;
+-    }
+ 
+     if (identifier == Settings::MAX_FRAME_SIZE_ID) {
+         if (newValue < Http2::minPayloadLimit || newValue > Http2::maxPayloadSize) {

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -3,7 +3,7 @@ pkgname=qt5
 version=5.15.4+20220606
 # commit 796264600e7f27ac0c88f6df3d312c0b3731772e
 # base repo: https://invent.kde.org/qt/qt/qt5
-revision=1
+revision=2
 build_style=meta
 hostmakedepends="cmake clang flex perl glib-devel pkg-config
  python re2c ruby which"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures:
  - x86

This fixes an issue, particularly in the qt5-network package that doesn't let KDE install any themes. This patch was issued upstream: https://code.qt.io/cgit/qt/qtbase.git/commit/?id=46940ca73791e87e

Fixes #38276 