### PR TITLE
gtk-layer-shell: update to 0.8.0.

### DIFF
--- a/srcpkgs/gtk-layer-shell/template
+++ b/srcpkgs/gtk-layer-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'gtk-layer-shell'
 pkgname=gtk-layer-shell
-version=0.6.0
+version=0.8.0
 revision=1
 build_style=meson
 build_helper="gir"
@@ -11,7 +11,8 @@ maintainer="travankor <travankor@tuta.io>"
 license="LGPL-3.0-or-later, MIT"
 homepage="https://github.com/wmww/gtk-layer-shell"
 distfiles="https://github.com/wmww/gtk-layer-shell/archive/v${version}.tar.gz"
-checksum=9a0ba72cea90e092d6b10ba47e627cd873271d287d9af80a6f66ab131fb34cac
+checksum=e95a03766302fe330ec3c6ff3e8018642849003ccaf160fb6fd0c039c81fa54c
+make_check=no # see upstream: https://github.com/wmww/gtk-layer-shell/issues/130
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	configure_args+=" -Dtests=true"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

I did previously did a [pr](https://github.com/void-linux/void-packages/pull/35863) but close the branch. Now made the same changes and the tests fail, ~so adding the `make_check=ci-skip`~ (Shouldn't do this so trying to understand what went wrong here)

0.8 status

```
SUMMARY                                            
pkg              host         target        cross  result
gtk-layer-shell  x86_64       x86_64        n      FAILED
gtk-layer-shell  x86_64-musl  x86_64-musl   n      FAILED
gtk-layer-shell  i686         i686          n      OK
gtk-layer-shell  x86_64-musl  aarch64-musl  y      OK
gtk-layer-shell  x86_64-musl  aarch64       y      OK
gtk-layer-shell  x86_64-musl  armv7l-musl   y      OK
gtk-layer-shell  x86_64-musl  armv7l        y      OK
gtk-layer-shell  x86_64-musl  armv6l-musl   y      OK
gtk-layer-shell  x86_64-musl  armv6l        y      OK
```