### PR TITLE
[RFC] .github/workflows/build.yaml: add armv6l, armv7l-musl to build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,9 +58,11 @@ jobs:
           - { arch: i686, bootstrap: i686, test: 1 }
           - { arch: aarch64, bootstrap: x86_64, test: 0 }
           - { arch: armv7l, bootstrap: x86_64, test: 0 }
+          - { arch: armv6l, bootstrap: x86_64, test: 0 }
           - { arch: x86_64-musl, bootstrap: x86_64-musl, test: 1 }
-          - { arch: armv6l-musl, bootstrap: x86_64-musl, test: 0 }
           - { arch: aarch64-musl, bootstrap: x86_64-musl, test: 0 }
+          - { arch: armv7l-musl, bootstrap: x86_64-musl, test: 0 }
+          - { arch: armv6l-musl, bootstrap: x86_64-musl, test: 0 }
 
     steps:
       - name: Prepare container


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (but it's a trivial change)

This has been how it's done since at least the switch to github CI (#26095), and how it was done in the travis CI era:

https://github.com/void-linux/void-packages/blob/71a25f3e735c1fef4178422b1a2bb70ec8e84e02/.travis.yml#L15-L21

Should it be changed? Is there a reason why CI isn't currently run on armv6l and armv7l-musl?
