### PR TITLE
ImageMagick: update to 7.1.0.44.

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,7 +1,10 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
-version=7.1.0.43
+version=7.1.0.44
 revision=1
+_release_suffix=${version##*.}
+_upstream_version="${version%.${_release_suffix}}-${_release_suffix}"
+wrksrc=${pkgname}-${_upstream_version}
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
  --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF
@@ -15,9 +18,9 @@ short_desc="Create, edit, compose, or convert bitmap images"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org"
-changelog="https://imagemagick.org/script/changelog.php"
-distfiles="https://github.com/ImageMagick/ImageMagick/archive/${version}.tar.gz"
-checksum=62eccb3e8c89acc66c2b10a2bea843b6659a2ddce275c7d2ffee8c34af6114fd
+changelog="https://raw.githubusercontent.com/ImageMagick/Website/main/ChangeLog.md"
+distfiles="https://github.com/ImageMagick/ImageMagick/archive/${_upstream_version}.tar.gz"
+checksum=1532c08c4f047aaf04e2717aac23c6d866d7e17d60a5d2c320ae29874285d49f
 
 subpackages="libmagick libmagick-devel"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

It seems that upstream changed the way they pack the tarballs to 7.1.0-44, for version 7.1.0.44, so I created the var _release-prefix don't know if this was the best way.  