### PR TITLE
freerdp: add configure flag for cairo

### DIFF
--- a/srcpkgs/freerdp/template
+++ b/srcpkgs/freerdp/template
@@ -1,7 +1,7 @@
 # Template file for 'freerdp'
 pkgname=freerdp
 version=2.7.0
-revision=1
+revision=2
 wrksrc="FreeRDP-${version}"
 build_style=cmake
 configure_args="-DWITH_ALSA=ON -DWITH_CUPS=OFF -DWITH_FFMPEG=ON
@@ -9,7 +9,7 @@ configure_args="-DWITH_ALSA=ON -DWITH_CUPS=OFF -DWITH_FFMPEG=ON
  -DWITH_LIBSYSTEMD=OFF -DWITH_PCSC=OFF -DWITH_PULSE=ON -DWITH_WAYLAND=ON
  -DWITH_XCURSOR=ON -DWITH_XEXT=ON -DWITH_XI=ON -DWITH_XINERAMA=ON
  -DWITH_XKBFILE=ON -DWITH_XRENDER=ON -DWITH_XV=ON -DWITH_SERVER=ON
- -DWAYLAND_SCANNER=/usr/bin/wayland-scanner"
+ -DWAYLAND_SCANNER=/usr/bin/wayland-scanner -DWITH_CAIRO=ON"
 hostmakedepends="pkg-config xmlto wayland-devel"
 makedepends="alsa-lib-devel ffmpeg-devel glib-devel libusb-devel
  libXcursor-devel libXinerama-devel libXrandr-devel libXv-devel


### PR DESCRIPTION
the flag defaults to OFF even though cairo-devel was added as a makedep.

closes #38328

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
     https://github.com/void-linux/void-packages/issues/38328#issuecomment-1197796758 