### PR TITLE
qt5: update to 5.15.5

### DIFF
--- a/srcpkgs/qt5-speech/files/Qt5TextToSpeechConfig.cmake
+++ b/srcpkgs/qt5-speech/files/Qt5TextToSpeechConfig.cmake
@@ -5,7 +5,7 @@ endif()
 get_filename_component(_qt5TextToSpeech_install_prefix "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
 
 # For backwards compatibility only. Use Qt5TextToSpeech_VERSION instead.
-set(Qt5TextToSpeech_VERSION_STRING 5.15.4)
+set(Qt5TextToSpeech_VERSION_STRING 5.15.5)
 
 set(Qt5TextToSpeech_LIBRARIES Qt5::TextToSpeech)
 
@@ -53,8 +53,8 @@ if (NOT TARGET Qt5::TextToSpeech)
 
     set(_Qt5TextToSpeech_OWN_INCLUDE_DIRS "${_qt5TextToSpeech_install_prefix}/include/qt5/" "${_qt5TextToSpeech_install_prefix}/include/qt5/QtTextToSpeech")
     set(Qt5TextToSpeech_PRIVATE_INCLUDE_DIRS
-        "${_qt5TextToSpeech_install_prefix}/include/qt5/QtTextToSpeech/5.15.4"
-        "${_qt5TextToSpeech_install_prefix}/include/qt5/QtTextToSpeech/5.15.4/QtTextToSpeech"
+        "${_qt5TextToSpeech_install_prefix}/include/qt5/QtTextToSpeech/5.15.5"
+        "${_qt5TextToSpeech_install_prefix}/include/qt5/QtTextToSpeech/5.15.5/QtTextToSpeech"
     )
 
     foreach(_dir ${_Qt5TextToSpeech_OWN_INCLUDE_DIRS})
@@ -97,7 +97,7 @@ if (NOT TARGET Qt5::TextToSpeech)
     foreach(_module_dep ${_Qt5TextToSpeech_MODULE_DEPENDENCIES})
         if (NOT Qt5${_module_dep}_FOUND)
             find_package(Qt5${_module_dep}
-                5.15.4 ${_Qt5TextToSpeech_FIND_VERSION_EXACT}
+                5.15.5 ${_Qt5TextToSpeech_FIND_VERSION_EXACT}
                 ${_Qt5TextToSpeech_DEPENDENCIES_FIND_QUIET}
                 ${_Qt5TextToSpeech_FIND_DEPENDENCIES_REQUIRED}
                 PATHS "${CMAKE_CURRENT_LIST_DIR}/.." NO_DEFAULT_PATH
@@ -198,7 +198,7 @@ if (NOT TARGET Qt5::TextToSpeech)
         endif()
     endif()
 
-    _populate_TextToSpeech_target_properties(RELEASE "libQt5TextToSpeech.so.5.15.4" "" FALSE)
+    _populate_TextToSpeech_target_properties(RELEASE "libQt5TextToSpeech.so.5.15.5" "" FALSE)
 
 
 

--- a/srcpkgs/qt5-speech/template
+++ b/srcpkgs/qt5-speech/template
@@ -1,8 +1,8 @@
 # Template file for 'qt5-speech'
 pkgname=qt5-speech
-version=5.15.4
-revision=2
-_commit=c8a1dadc46ccdbeaef45aa805a9dc98d4b3220bd
+version=5.15.5
+revision=1
+_commit=e76b23ad707077647cdb4282cf35a71776efa0f0
 wrksrc="qtspeech-${_commit}"
 build_style=qmake
 configure_args="-- -flite -flite-alsa -speechd"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later, LGPL-3.0-or-later"
 homepage="https://qt.io/"
 distfiles="https://invent.kde.org/qt/qt/qtspeech/-/archive/${_commit}.tar.gz"
-checksum=970ef98f9803965dfebbb1a06ec4a7978389cf20249afed4273e037e7d5ddcf9
+checksum=5dcf10add2118729a0951a15bc353c8b6fe4d441baf9503766bc5ee0a7a9d6fa
 
 _cleanup_wrksrc_leak() {
 	if [ -d "${PKGDESTDIR}/usr/lib/cmake" ]; then

--- a/srcpkgs/qt5-styleplugins/template
+++ b/srcpkgs/qt5-styleplugins/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5-styleplugins'
 pkgname=qt5-styleplugins
 version=5.0.0
-revision=17
+revision=18
 _gitrev=335dbece103e2cbf6c7cf819ab6672c2956b17b3
 wrksrc="qtstyleplugins-${_gitrev}"
 build_style=qmake

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -1,7 +1,7 @@
 # Template file for 'qt5'
 pkgname=qt5
-version=5.15.4+20220606
-# commit 796264600e7f27ac0c88f6df3d312c0b3731772e
+version=5.15.5+20220728
+# commit 1832429ff1e4e224389c7cfa592d50a2fab31e29
 # base repo: https://invent.kde.org/qt/qt/qt5
 revision=1
 build_style=meta
@@ -28,7 +28,7 @@ homepage="https://qt.io/"
 # to keep the size smaller qtwebengine, qtwebview, qtdocgallery, qtactiveqt and qtpim
 # can be marked with the export-ignore attribute
 distfiles="https://void.johnnynator.dev/distfiles/qt5-${version}.tar.gz"
-checksum=941a0089ec4f9e32eb5ebdf27cc7ce856aee2377b20c9aaff114b218b6303f1d
+checksum=bfc97f26853e549f34340bded2b92f745746c04c402d5f4e53d59cae228b6d86
 python_version=2 #unverified
 replaces="qt5-doc<5.6.0 qt5-quick1<5.6.0 qt5-quick1-devel<5.6.0 qt5-webkit<5.6.0 qt5-webkit-devel<5.6.0
  qt5-enginio<5.7.1 qt5-enginio-devel<5.7.1 qt5-plugin-gtk<5.7.1 qt5-canvas3d<5.13.0"


### PR DESCRIPTION
- qt5: update to 5.15.5+20220728.
- qt5-speech: update to 5.15.5.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
[ci skip]
