### PR TITLE
brightnessctl: added elogind build option

### DIFF
--- a/srcpkgs/brightnessctl/template
+++ b/srcpkgs/brightnessctl/template
@@ -4,14 +4,20 @@ version=0.5.1
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
+make_build_args="$(vopt_if elogind ENABLE_SYSTEMD=1)"
 make_install_args="UDEVDIR=/usr/lib/udev/rules.d"
 hostmakedepends="pkg-config"
+makedepends="$(vopt_if elogind elogind-devel)"
+depends="$(vopt_if elogind libelogind)"
 short_desc="Read and control device brightness"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/Hummer12007/brightnessctl"
 distfiles="https://github.com/Hummer12007/brightnessctl/archive/${version}.tar.gz"
 checksum=a68869e23f56ac4f2e28f1783002810ddbf10f95e1af9b48b2912fb169f46994
+
+build_options="elogind"
+desc_option_elogind="Enable logind support"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (amd64-glibc)

This option allows brightnessctl to access backlight devices using the `(e)logind` api. First PR, and I wasn't sure if a revbump was necessary. If I need to change anything lmk.