### PR TITLE
kubernetes: depends+=conntrack-tools

### DIFF
--- a/srcpkgs/kubernetes/template
+++ b/srcpkgs/kubernetes/template
@@ -1,12 +1,12 @@
 # Template file for 'kubernetes'
 pkgname=kubernetes
 version=1.23.7
-revision=1
+revision=2
 archs="x86_64* ppc64le*"
 build_style=go
 go_import_path="github.com/kubernetes/kubernetes"
 hostmakedepends="rsync git go-bindata which"
-depends="kubectl"
+depends="kubectl conntrack-tools"
 short_desc="Container Cluster Manager for Docker"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"


### PR DESCRIPTION
`kubeadm init` needs conntrack, otherwise this fatal error happens

```
error execution phase preflight: [preflight] Some fatal errors occurred:
        [ERROR FileExisting-conntrack]: conntrack not found in system path
```

`xi conntrack-tools` fixes the error.