### PR TITLE
elogind: update to 246.10.

### DIFF
--- a/srcpkgs/elogind/patches/polkit.patch
+++ b/srcpkgs/elogind/patches/polkit.patch
@@ -1,0 +1,27 @@
+commit 2b09e13f7aec13105380d9d9fddc96ae51911b0c
+Author: Daniel Kolesa <daniel@octaforge.org>
+Date:   Sat Dec 18 02:53:26 2021 +0100
+
+    reenable polkit
+
+diff --git a/meson.build b/meson.build
+index 72825a2..b14cb64 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1155,15 +1155,6 @@ if want_polkit != 'false' and not skip_deps
+                 message('Old polkit detected, will install pkla files')
+                 install_polkit_pkla = true
+         endif
+-#if 1 /// Disable polkit completely if libpolkit is not there. See elogind issue #167
+-        if not libpolkit.found()
+-                if want_polkit != 'auto'
+-                        error('Polkit requested but libpolkit was not found.')
+-                endif
+-                install_polkit = false
+-                want_polkit    = false
+-        endif
+-#endif // 1
+ endif
+ conf.set10('ENABLE_POLKIT', install_polkit)
+ 
+

--- a/srcpkgs/elogind/template
+++ b/srcpkgs/elogind/template
@@ -1,13 +1,13 @@
 # Template file for 'elogind'
 pkgname=elogind
-reverts="246.10_1"
-version=246.9.2
-revision=3
+version=246.10
+revision=1
 build_style=meson
 configure_args="-Dcgroup-controller=elogind -Dhalt-path=/usr/bin/halt
  -Drootlibexecdir=/usr/libexec/elogind -Dreboot-path=/usr/bin/reboot
  -Dkexec-path=/usr/bin/kexec -Ddefault-hierarchy=legacy
- -Ddefault-kill-user-processes=false -Dman=true"
+ -Ddefault-kill-user-processes=false -Dman=true
+ -Dpolkit=true"
 hostmakedepends="docbook-xsl gettext-devel gperf intltool libxslt m4
  pkg-config shadow glib-devel"
 makedepends="acl-devel eudev-libudev-devel gettext-devel libglib-devel libcap-devel
@@ -18,7 +18,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="https://github.com/elogind/elogind"
 distfiles="https://github.com/${pkgname}/${pkgname}/archive/v${version}.tar.gz"
-checksum=dd2fcf22a89a078cad22e633d2f14a4cc9f4a9c8bae25c0e39fc4aec3e273bc9
+checksum=c490dc158c8f5bca8d00ecfcc7ad5af24d1c7b9e59990a0b3b1323996221a922
 conf_files="/etc/elogind/*.conf"
 # tests fail differently due to containerization and kernel features
 make_check=ci-skip


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

Going to test on a vm using seatd to see if the errors still occurs 

@Gottox in case you didn't see the message IRC could you check if the problem with libseat still occurs ? Ok my quick test it doesn't, but to be honest I don't have a lot of experience it with 