### PR TITLE
gst-rtsp-server: remove libcgroup-devel from makedepends

### DIFF
--- a/srcpkgs/gst-rtsp-server/template
+++ b/srcpkgs/gst-rtsp-server/template
@@ -1,11 +1,11 @@
 # Template file for 'gst-rtsp-server'
 pkgname=gst-rtsp-server
 version=1.20.3
-revision=1
+revision=2
 build_style=meson
 hostmakedepends="pkg-config python3"
 makedepends="glib-devel gst-plugins-bad1-devel gobject-introspection
- libcgroup-devel ffmpeg-devel gst-plugins-good1 python3-gobject-devel"
+ ffmpeg-devel gst-plugins-good1 python3-gobject-devel"
 short_desc="GStreamer multimedia graph framework - rtsp server"
 maintainer="1is7ac3 <isaac.qa13@gmail.com>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

As discussed on IRC, libcgroup-devel in makedepends is extraneous