### PR TITLE
Update python3-mpv & fix tests

### DIFF
--- a/srcpkgs/python3-mpv/template
+++ b/srcpkgs/python3-mpv/template
@@ -1,18 +1,18 @@
 # Template file for 'python3-mpv'
 pkgname=python3-mpv
-version=0.5.2
-revision=2
+version=1.0.1
+revision=1
 wrksrc="python-mpv-${version}"
 build_style=python3-module
+# this test takes too long and has a low chance of failure
+# https://github.com/jaseg/python-mpv/issues/209#issuecomment-1180248112
+make_check_args="--deselect tests/test_mpv.py::TestLifecycle::test_wait_for_prooperty_event_overflow"
 hostmakedepends="python3-setuptools"
 depends="python3 mpv"
+checkdepends="python3-pytest python3-xvfbwrapper mpv-devel"
 short_desc="Python3 interface to the MPV media player"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="AGPL-3.0-or-later"
+license="GPL-2.0-or-later"
 homepage="https://github.com/jaseg/python-mpv"
 distfiles="https://github.com/jaseg/python-mpv/archive/v${version}.tar.gz"
-checksum=3eacaecef995de7c9bbb80fe30223ab4ca427128384610fa2d87214961085fdb
-
-post_install() {
-	vlicense LICENSE
-}
+checksum=b5dc6dbf2e2b90ec21ffa7e30729eb7d9556296e0617742f24af179377e6bfd9

--- a/srcpkgs/python3-xvfbwrapper/template
+++ b/srcpkgs/python3-xvfbwrapper/template
@@ -1,0 +1,19 @@
+# Template file for 'python3-xvfbwrapper'
+pkgname=python3-xvfbwrapper
+version=0.2.9
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="xorg-server-xvfb"
+checkdepends="${depends} python3-pytest"
+short_desc="Python wrapper for controlling Xvfb"
+maintainer="RunningDroid <runningdroid@zoho.com>"
+license="MIT"
+homepage="https://github.com/cgoldberg/xvfbwrapper"
+distfiles="${PYPI_SITE}/x/xvfbwrapper/xvfbwrapper-${version}.tar.gz"
+checksum=bcf4ae571941b40254faf7a73432dfc119ad21ce688f1fdec533067037ecfc24
+
+pre_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

python3-xvfbwrapper doesn't cross because [common/environment/build-style/python3-module.sh](https://github.com/void-linux/void-packages/blob/master/common/environment/build-style/python3-module.sh#L2) installs python3 as a makedepend instead of a hostmakedepend and I'm not sure if I should patch the build-style or add python3 to hostmakedepends and ignore that it's also in makedepends
<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
