### PR TITLE
pipewire: assure rw permissions in run directories in case its missing

### DIFF
--- a/srcpkgs/pipewire/files/pipewire-pulse/run
+++ b/srcpkgs/pipewire/files/pipewire-pulse/run
@@ -2,6 +2,7 @@
 # this service is experimental and most setups should start pipewire as a user,
 # for further information, please refer to the handbook
 ! [ -d /run/pulse ] && install -m 755 -g _pipewire -o _pipewire -d /run/pulse
+[ $(stat -c %a /run/pulse) -ne 755 ] && chmod 755 /run/pulse
 umask 002
 export PULSE_RUNTIME_PATH=/run/pulse
 exec chpst -u _pipewire:_pipewire pipewire-pulse


### PR DESCRIPTION
Sometimes `/run/pulse` has `rwx------` permission somehow due to old pulseaudio package if installed.

This was causing `pactl info` return

```
Connection failure: Connection refused
pa_context_connect() failed: Connection refused
```

and applets showing `No audio devices`...

Because users in group `_pipewire` were not able to read/open the directory.  This PR would ensure that it has 755 permissions if the directory already exists and not readable by `_pipewire` group.


#### Testing the changes
- I tested the changes in this PR: **YES**
