### PR TITLE
alacritty: Missing dependency libXcursor and libXrandr

### DIFF
--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -1,12 +1,12 @@
 # Template file for 'alacritty'
 pkgname=alacritty
 version=0.10.1
-revision=1
+revision=2
 build_wrksrc="${pkgname}"
 build_style=cargo
 hostmakedepends="pkg-config python3"
 makedepends="freetype-devel fontconfig-devel libxcb-devel libxkbcommon-devel"
-depends="libXi libXxf86vm ncurses alacritty-terminfo-${version}_${revision}"
+depends="libXcursor libXrandr libXi libXxf86vm ncurses alacritty-terminfo-${version}_${revision}"
 short_desc="Cross-platform, GPU-accelerated terminal emulator"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="Apache-2.0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: Tested it with manually installing the two dependencies

Addresses issue #38391