### PR TITLE
scons: update to 4.4.0

### DIFF
--- a/srcpkgs/scons/template
+++ b/srcpkgs/scons/template
@@ -1,18 +1,19 @@
 # Template file for 'scons'
 pkgname=scons
-version=4.0.1
-revision=3
+version=4.4.0
+revision=1
 wrksrc="SCons-${version}"
-build_style=python3-module
+build_style="python3-module"
+make_install_args="--install-data=/usr/share/man/man1/"
 hostmakedepends="python3 python3-setuptools"
 depends="python3"
 short_desc="Software construction tool"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Wilson Birney <wpb@360scada.com>"
 license="MIT"
 homepage="https://www.scons.org/"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=722ed104b5c624ecdc89bd4e02b094d2b14d99d47b5d0501961e47f579a2007c
-
+distfiles="https://github.com/SCons/scons/releases/download/${version}/SCons-${version}.tar.gz"
+checksum=7703c4e9d2200b4854a31800c1dbd4587e1fa86e75f58795c740bcfa7eca7eaa
+make_check=no #SCons dist tarballs do not have tests, confirmed with SCons dev
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl

I also 'adopted' the package as it was orphaned. I still use it for a few packages and would be willing to maintain it