### PR TITLE
New package: openpgp-card-tools-0.9.0

### DIFF
--- a/srcpkgs/openpgp-card-tools/template
+++ b/srcpkgs/openpgp-card-tools/template
@@ -1,0 +1,21 @@
+# Template file for 'openpgp-card-tools'
+pkgname=openpgp-card-tools
+version=0.9.0
+revision=1
+wrksrc="${pkgname}-v${version}"
+build_wrksrc="tools"
+build_style=cargo
+hostmakedepends="pkg-config llvm clang"
+makedepends="nettle-devel pcsclite-devel"
+depends="pcsclite pcsc-ccid"
+short_desc="Tools for inspecting, configuring and using OpenPGP cards"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT, Apache-2.0"
+homepage="https://gitlab.com/openpgp-card/openpgp-card"
+distfiles="${homepage}/-/archive/tools/v${version}/${wrksrc}.tar.gz"
+checksum=62033a23a70065b2d9fba3b55dc0c55c385c0e266a319c1659b21d4ff619f7eb
+
+post_install() {
+	vlicense "../LICENSES/MIT.txt"
+	vdoc "README.md"
+}

--- a/srcpkgs/openpgp-card-tools/update
+++ b/srcpkgs/openpgp-card-tools/update
@@ -1,0 +1,2 @@
+site="https://gitlab.com/openpgp-card/openpgp-card/-/tags?format=atom"
+pattern="<title>(openpgp-card-)?tools/v\K[\d.]+(?=</title>)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

Splitting this out from #32480, as they are related, but don't depend on each
other, at least not necessarily and not in a way that xbps-src cares about.

<del>Aside of that, should I add a section to void-docs, about how to set this up,
next to https://docs.voidlinux.org/config/gnupg.html, as their setup sort-of
depends on each other if you want to use them in parallel? `opgp-card` requires
use of pcscd, which means you have to disable the built-in ccid driver in
GnuPGs scdaemon, install `pcsclite` and `pcsc-ccid` and enable the `pcscd`
service.</del> Added info in https://github.com/void-linux/void-docs/pull/696

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
