### PR TITLE
New package: qtile-0.21.0

### DIFF
--- a/srcpkgs/python3-cairocffi/template
+++ b/srcpkgs/python3-cairocffi/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-cairocffi'
 pkgname=python3-cairocffi
-version=1.2.0
-revision=2
+version=1.3.0
+revision=1
 wrksrc="cairocffi-${version}"
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-cffi python3-wheel"
+hostmakedepends="python3-setuptools python3-cffi python3-wheel $(vopt_if xcb python3-xcffib)"
 depends="python3-cffi cairo"
 checkdepends="python3-pytest python3-numpy gdk-pixbuf $depends"
 short_desc="CFFI-based cairo bindings for Python3"
@@ -13,7 +13,13 @@ license="BSD-3-Clause"
 homepage="https://github.com/Kozea/cairocffi"
 changelog="https://raw.githubusercontent.com/Kozea/cairocffi/master/NEWS.rst"
 distfiles="${PYPI_SITE}/c/cairocffi/cairocffi-${version}.tar.gz"
-checksum=9a979b500c64c8179fec286f337e8fe644eca2f2cd05860ce0b62d25f22ea140
+checksum=108a3a7cb09e203bdd8501d9baad91d786d204561bd71e9364e8b34897c47b91
+
+build_options=xcb
+case "$XBPS_MACHINE" in
+x86_64*|i686|ppc64le*|ppc64)
+	build_options_default="xcb"
+esac
 
 post_patch() {
 	vsed -e '/pytest-runner/d' -i setup.cfg

--- a/srcpkgs/python3-xcffib/template
+++ b/srcpkgs/python3-xcffib/template
@@ -1,0 +1,21 @@
+# Template file for 'python3-xcffib'
+pkgname=python3-xcffib
+version=0.11.1
+revision=1
+wrksrc=xcffib-${version}
+build_style=python3-pep517
+hostmakedepends="python3-setuptools pkg-config cabal-install parallel xcb-proto python3-cffi python3-wheel"
+makedepends="python3-devel libffi-devel libxcb-devel python3-six"
+depends="python3-six python3-cffi libxcb"
+short_desc="Drop-in replacement for xpyb based on cffi"
+maintainer="Kai Stian Olstad <void@olstad.com>"
+license="Apache-2.0"
+homepage="https://github.com/tych0/xcffib"
+distfiles="${homepage}/archive/v${version}.tar.gz"
+checksum=bd89c1e65cf4773fe10d70209ba069e0e1fe82c37c121501fc404aa9867d0ff3
+nocross="Cannot yet cross compile with Haskell"
+
+pre_build() {
+	cabal v2-update
+	PKG_CONFIG_PATH=/usr/lib/pkgconfig make ${makejobs} xcffib
+}

--- a/srcpkgs/qtile/template
+++ b/srcpkgs/qtile/template
@@ -1,0 +1,19 @@
+# Template file for 'qtile'
+pkgname=qtile
+version=0.21.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm python3-cairocffi python3-xcffib python3-wheel pkg-config"
+makedepends="python3-devel libffi-devel pulseaudio-devel"
+depends="python3-cairocffi python3-xcffib pango gdk-pixbuf"
+short_desc="Full-featured tiling window manager written and configured in Python"
+maintainer="Kai Stian Olstad <void@olstad.com>"
+license="MIT"
+homepage="http://www.qtile.org/"
+changelog="https://raw.githubusercontent.com/qtile/qtile/v${version}/CHANGELOG"
+distfiles="${PYPI_SITE}/q/qtile/qtile-${version}.tar.gz"
+checksum=93e1f8216c669b5570333607d5d06de7d7f16033b0e73cf34c896459f2df5254
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Closes #14373

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**



#### Local build testing
  - I built this PR locally for my native architecture, x86_64-glibc
<!--
  - I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I tried to build it for armv7l but failes with
```
      armv7l-linux-gnueabihf-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -g -fdebug-prefix-map=/builddir/Python-3.10.5=. -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2 -pipe -g -fdebug-prefix-map=/builddir/Python-3.10.5=. -fstack-clash-protection -D_FORTIFY_SOURCE=2 -O2 -pipe -march=armv7-a -mfpu=vfpv3 -mfloat-abi=hard -I/usr/armv7l-linux-gnueabihf/usr/include -fdebug-prefix-map=/builddir/qtile-0.21.0=. -fPIC -I/usr/include/python3.10 -c build/temp.linux-x86_64-cpython-310/libqtile.widget._pulse_audio.c -o build/temp.linux-x86_64-cpython-310/build/temp.linux-x86_64-cpython-310/libqtile.widget._pulse_audio.o
      cc1: error: unrecognized -mtune target: generic
      cc1: note: valid arguments are: arm8 arm810 strongarm strongarm110 fa526 fa626 arm7tdmi arm7tdmi-s arm710t arm720t arm740t arm9 arm9tdmi arm920t arm920 arm922t arm940t ep9312 arm10tdmi arm1020t arm9e arm946e-s arm966e-s arm968e-s arm10e arm1020e arm1022e xscale iwmmxt iwmmxt2 fa606te fa626te fmp626 fa726te arm926ej-s arm1026ej-s arm1136j-s arm1136jf-s arm1176jz-s arm1176jzf-s mpcorenovfp mpcore arm1156t2-s arm1156t2f-s cortex-m1 cortex-m0 cortex-m0plus cortex-m1.small-multiply cortex-m0.small-multiply cortex-m0plus.small-multiply generic-armv7-a cortex-a5 cortex-a7 cortex-a8 cortex-a9 cortex-a12 cortex-a15 cortex-a17 cortex-r4 cortex-r4f cortex-r5 cortex-r7 cortex-r8 cortex-m7 cortex-m4 cortex-m3 marvell-pj4 cortex-a15.cortex-a7 cortex-a17.cortex-a7 cortex-a32 cortex-a35 cortex-a53 cortex-a57 cortex-a72 cortex-a73 exynos-m1 xgene1 cortex-a57.cortex-a53 cortex-a72.cortex-a53 cortex-a73.cortex-a35 cortex-a73.cortex-a53 cortex-a55 cortex-a75 cortex-a76 cortex-a76ae cortex-a77 neoverse-n1 cortex-a75.cortex-a55 cortex-a76.cortex-a55 neoverse-v1 neoverse-n2 cortex-m23 cortex-m33 cortex-m35p cortex-m55 cortex-r52
      error: command '/builddir/.xbps-qtile/wrappers/armv7l-linux-gnueabihf-gcc' failed with exit code 1
```
It tries to compile with `-mtune=generic` something `armv7l-linux-gnueabihf-gcc` doesn't support.
I have tried to find a solution, but no luck so far, any suggestions?