### PR TITLE
micro: fix broken resource bundling.

### DIFF
--- a/srcpkgs/micro/template
+++ b/srcpkgs/micro/template
@@ -1,7 +1,7 @@
 # Template file for 'micro'
 pkgname=micro
 version=2.0.11
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/zyedidia/micro/v2"
 go_package="${go_import_path}/cmd/micro"
@@ -14,6 +14,10 @@ license="MIT"
 homepage="https://micro-editor.github.io"
 distfiles="https://github.com/zyedidia/micro/archive/v${version}.tar.gz"
 checksum=1bb499edeaaadf1fe1791a49f96ab672c4e1add31ee125882ccd85a0fc8a4abe
+
+pre_build() {
+	GOARCH= go generate ./runtime
+}
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
The v2.0.11 update changed the way resources are bundled, now requiring an
additional step to 'generate' the bundle. Since I happened to only test the
original update on files that I have custom syntax for, I only realised the
presence of the regression after the update got merged (#38402).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
