### PR TITLE
refind: fix python_version

### DIFF
--- a/srcpkgs/refind/template
+++ b/srcpkgs/refind/template
@@ -1,7 +1,7 @@
 # Template file for 'refind'
 pkgname=refind
 version=0.13.3.1
-revision=1
+revision=2
 archs="x86_64* i686* aarch64*"
 makedepends="gnu-efi-libs"
 depends="bash dosfstools efibootmgr"
@@ -11,7 +11,7 @@ license="GPL-3.0-only, BSD-3-Clause, BSD-2-Clause, GPL-2.0-only, LGPL-2.1-only"
 homepage="https://sourceforge.net/projects/refind/"
 distfiles="${SOURCEFORGE_SITE}/refind/refind-src-${version}.tar.gz"
 checksum=7a3e3f0f81bd4ae95f24e120f44e01319231f488fef7cc8bf03a1aea23c6cfd1
-python_version=2
+python_version=3
 conf_files="/etc/default/refind-kernel-hook.conf"
 make_dirs="/etc/refind.d/keys 0755 root root"
 


### PR DESCRIPTION
for the [entire git history on sourceforge](https://sourceforge.net/p/refind/code/ci/0d46f46ed7a2d453c9320469f211c5348120a1cd/log/?path=/refind-mkdefault), this has been a python3 script, not python2

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

