### PR TITLE
xbps-src: fetch from CRAN archive

### DIFF
--- a/common/environment/build-style/R-cran.sh
+++ b/common/environment/build-style/R-cran.sh
@@ -5,4 +5,10 @@ wrksrc="${XBPS_BUILDDIR}/${pkgname#R-cran-}"
 # default to cran
 if [ -z "$distfiles" ]; then
 	distfiles="https://cran.r-project.org/src/contrib/${pkgname#R-cran-}_${version//r/-}.tar.gz"
+	# Old releases get put into archive, and removed from above location.
+	# Use the archive as a fallback to handle that case.
+	_archive="https://cran.r-project.org/src/contrib/Archive/${pkgname#R-cran-}"
+	if [[ "$XBPS_DISTFILES_MIRROR" != *"$_archive"* ]]; then
+		XBPS_DISTFILES_MIRROR+=" $_archive"
+	fi
 fi


### PR DESCRIPTION
CRAN has a lovely practice of moving the latest releases into an archive
after a new release is made. So when pillar 1.8.0 is released, for
example, version 1.7.0 gets moved into the archive.

Add the CRAN archive as a mirror to handle this case.

See below for an example:

```
=> R-cran-pillar-1.5.1_1: running do-fetch hook: 00-distfiles ...
=> R-cran-pillar-1.5.1_1: fetching distfile 'pillar_1.5.1.tar.gz' from 'https://cran.r-project.org/src/contrib/Archive/pillar'...
```

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
