### PR TITLE
libnotify: update to 0.8.1.

### DIFF
--- a/srcpkgs/libnotify/template
+++ b/srcpkgs/libnotify/template
@@ -1,6 +1,6 @@
 # Template file for 'libnotify'
 pkgname=libnotify
-version=0.7.9
+version=0.8.1
 revision=1
 build_style=meson
 build_helper="gir"
@@ -9,11 +9,12 @@ configure_args="-Dintrospection=$(vopt_if gir enabled disabled)
 hostmakedepends="pkg-config glib-devel libxslt docbook-xsl-ns"
 makedepends="libglib-devel libpng-devel gdk-pixbuf-devel gtk+3-devel"
 short_desc="Desktop notification library"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="LGPL-2.1-or-later"
-homepage="http://library.gnome.org/devel/notification-spec/"
-distfiles="${GNOME_SITE}/${pkgname}/0.7/${pkgname}-${version}.tar.xz"
-checksum=66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761
+homepage="https://gitlab.gnome.org/GNOME/libnotify"
+changelog="https://gitlab.gnome.org/GNOME/libnotify/-/raw/master/NEWS"
+distfiles="https://gitlab.gnome.org/GNOME/${pkgname}/-/archive/${version}/${pkgname}-${version}.tar.gz"
+checksum=7c0b252edecbf08db50d775f9e720ecc03c742fb97c25f3966a8b7a4bedf8133
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

