### PR TITLE
wireless_tools: fix distfiles download

### DIFF
--- a/srcpkgs/wireless_tools/template
+++ b/srcpkgs/wireless_tools/template
@@ -3,15 +3,12 @@ pkgname=wireless_tools
 version=29
 revision=10
 wrksrc="wireless_tools.${version}"
-hostmakedepends="wget"
 short_desc="Set of tools allowing to manipulate the Wireless Extensions"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
-homepage="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html"
-distfiles="http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/wireless_tools.${version}.tar.gz"
+homepage="https://hewlettpackard.github.io/wireless-tools/Tools.html"
+distfiles="https://hewlettpackard.github.io/wireless-tools/wireless_tools.${version}.tar.gz"
 checksum=6fb80935fe208538131ce2c4178221bab1078a1656306bce8909c19887e2e5a1
-
-fetch_cmd="wget --no-check-certificate"
 
 do_build() {
 	sed -i -e 's|CFLAGS=|CFLAGS+=|g' -e 's|-shared|& $(LDFLAGS)|g' Makefile


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
