### PR TITLE
.github/workflows/stale.yml: fix format of exempt-issue-labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,4 @@ jobs:
           exempt-all-assignees: true
           ascending: true
           operations-per-run: 250
-          exempt-issue-labels:
-            - request
-            - bug
+          exempt-issue-labels: 'request,bug'


### PR DESCRIPTION
#38272 used wrong format, and now the action is failing - https://github.com/void-linux/void-packages/actions/runs/2807256939

@Chocimier @classabbyamp 