### PR TITLE
spacefm: remove unused gtk2 build dep

### DIFF
--- a/srcpkgs/spacefm/template
+++ b/srcpkgs/spacefm/template
@@ -5,7 +5,7 @@ revision=2
 build_style=gnu-configure
 configure_args="$(vopt_with gtk3)"
 hostmakedepends="pkg-config intltool"
-makedepends="$(vopt_if gtk3 gtk+3-devel gtk+-devel)
+makedepends="$(vopt_if gtk3 gtk+3-devel)
  startup-notification-devel eudev-libudev-devel ffmpegthumbnailer-devel"
 depends="hicolor-icon-theme desktop-file-utils"
 short_desc="Multi-panel tabbed file manager"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** only build tested

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
