### PR TITLE
liburing: update to 2.2.

### DIFF
--- a/srcpkgs/liburing/template
+++ b/srcpkgs/liburing/template
@@ -1,16 +1,16 @@
 # Template file for 'liburing'
 pkgname=liburing
-version=2.1
+version=2.2
 revision=1
 build_style=configure
 configure_args="--mandir=/usr/share/man"
 make_build_args="-C src"
 short_desc="Linux-native io_uring I/O access library"
-maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
+maintainer="Dragon Friend <friend-dragon@proton.me>"
 license="LGPL-2.1-only"
-homepage="http://git.kernel.dk/cgit/liburing"
-distfiles="${homepage}/snapshot/${pkgname}-${version}.tar.gz"
-checksum=707faff561f6a57ddf4188a98737a80e460b24c1295cd303be39c819da0df1d1
+homepage="https://git.kernel.dk/cgit/liburing"
+distfiles="https://git.kernel.dk/cgit/liburing/snapshot/liburing-${version}.tar.gz"
+checksum=f52bad18e3ff11185165d52d2d7391e90a0fce8f33f2ee611ad9a8ce1feaf914
 
 liburing-devel_package() {
 	short_desc+=" - development files"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: briefly

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv7l-musl (crossbuild)
