### PR TITLE
lighttpd: update to 1.4.66

### DIFF
--- a/srcpkgs/lighttpd/template
+++ b/srcpkgs/lighttpd/template
@@ -1,6 +1,6 @@
 # Template file for 'lighttpd'
 pkgname=lighttpd
-version=1.4.65
+version=1.4.66
 revision=1
 build_style=meson
 configure_args="-Dwith_brotli=false -Dwith_bzip=false
@@ -19,7 +19,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://lighttpd.net"
 distfiles="https://download.lighttpd.net/lighttpd/releases-1.4.x/lighttpd-${version}.tar.xz"
-checksum=bf0fa68a629fbc404023a912b377e70049331d6797bcbb4b3e8df4c3b42328be
+checksum=47ac6e60271aa0196e65472d02d019556dc7c6d09df3b65df2c1ab6866348e3b
 
 conf_files="/etc/lighttpd/lighttpd.conf"
 system_accounts="_lighttpd"


### PR DESCRIPTION
#### Testing the changes
**NO**

#### Local build testing
- I built lighttpd 1.4.66 for arm_cortex-a9 against OpenWrt master