### PR TITLE
[RFC] various: remove -s/-w from go_ldflags

### DIFF
--- a/common/build-style/go.sh
+++ b/common/build-style/go.sh
@@ -22,6 +22,13 @@ do_configure() {
 }
 
 do_build() {
+	# remove -s and -w from go_ldflags, we should let xbps-src strip binaries itself
+	for wd in $go_ldflags; do
+		if [ "$wd" == "-s" ] || [ "$wd" == "-w" ]; then
+			msg_error "$pkgname: remove -s and -w from go_ldflags\n"
+		fi
+	done
+
 	go_package=${go_package:-$go_import_path}
 	# Build using Go modules if there's a go.mod file
 	if [ "${go_mod_mode}" != "off" ] && [ -f go.mod ]; then

--- a/srcpkgs/aws-vault/template
+++ b/srcpkgs/aws-vault/template
@@ -1,10 +1,10 @@
 # Template file for 'aws-vault'
 pkgname=aws-vault
 version=6.3.1
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/99designs/aws-vault/v6
-go_ldflags="-X \"main.Version=${version}\" -s -w"
+go_ldflags="-X main.Version=${version}"
 short_desc="Vault for securely storing and accessing AWS credentials"
 maintainer="klardotsh <josh@klar.sh>"
 license="MIT"

--- a/srcpkgs/circleci-cli/template
+++ b/srcpkgs/circleci-cli/template
@@ -1,12 +1,11 @@
 # Template file for 'circleci-cli'
 pkgname=circleci-cli
 version=0.1.15224
-revision=1
+revision=2
 build_style=go
 build_helper=qemu
 go_import_path=github.com/CircleCI-Public/${pkgname}
-go_ldflags="-s -w
- -X github.com/CircleCI-Public/${pkgname}/version.Version=${version}
+go_ldflags="-X github.com/CircleCI-Public/${pkgname}/version.Version=${version}
  -X github.com/CircleCI-Public/${pkgname}/version.packageManager=xbps"
 hostmakedepends="packr2"
 short_desc="Use CircleCI from the command line"

--- a/srcpkgs/coredns/template
+++ b/srcpkgs/coredns/template
@@ -1,7 +1,7 @@
 # Template file for 'coredns'
 pkgname=coredns
 version=1.8.6
-revision=1
+revision=2
 build_style=go
 go_import_path=github.com/coredns/coredns
 hostmakedepends="git make mmark"
@@ -14,7 +14,7 @@ checksum=cbe3764afe2148b8047ea7e5cbba5108c298dee3a9a0391028e2980e35beaa2b
 make_dirs="/etc/coredns 0750 root root"
 
 _git_commit=f59c03d09c3a3a12f571ad1087b979325f3dae30
-go_ldflags+=" -s -w -X github.com/coredns/coredns/coremain.GitCommit=${_git_commit}"
+go_ldflags+="-X github.com/coredns/coredns/coremain.GitCommit=${_git_commit}"
 
 post_build() {
 	make -f Makefile.doc MMARK="$(command -v mmark) -man" man/coredns.1 man/corefile.5 plugins

--- a/srcpkgs/gotify-cli/template
+++ b/srcpkgs/gotify-cli/template
@@ -1,12 +1,11 @@
 # Template file for 'gotify-cli'
 pkgname=gotify-cli
 version=2.2.2
-revision=1
+revision=2
 wrksrc="cli-$version"
 build_style=go
 go_import_path="github.com/gotify/cli/v2"
-go_ldflags="-w -s -X main.Version=${version} \
- -X main.BuildDate=${SOURCE_DATE_EPOCH} \
+go_ldflags="-X main.Version=${version} -X main.BuildDate=${SOURCE_DATE_EPOCH}
  -X main.Mode=prod"
 short_desc="Command line interface for pushing messages to a Gotify server"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"

--- a/srcpkgs/gotify-server/template
+++ b/srcpkgs/gotify-server/template
@@ -1,14 +1,12 @@
 # Template file for 'gotify-server'
 pkgname=gotify-server
 version=2.1.5
-revision=1
+revision=2
 wrksrc="server-$version"
 build_style=go
 go_import_path="github.com/gotify/server/v2"
-go_ldflags="-w -s -extldflags=-fuse-ld=bfd \
- -X main.Version=${version} \
- -X main.BuildDate=${SOURCE_DATE_EPOCH} \
- -X main.Mode=prod"
+go_ldflags="-extldflags=-fuse-ld=bfd -X main.Version=${version}
+ -X main.BuildDate=${SOURCE_DATE_EPOCH} -X main.Mode=prod"
 hostmakedepends="yarn packr2"
 short_desc="Simple server for sending and receiving messages"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"

--- a/srcpkgs/v2ray/template
+++ b/srcpkgs/v2ray/template
@@ -5,7 +5,9 @@ revision=1
 wrksrc=${pkgname}-core-${version}
 build_style=go
 go_import_path="github.com/v2fly/v2ray-core/v4"
-go_ldflags="-X github.com/v2fly/v2ray-core/v4.codename=$pkgname -X github.com/v2fly/v2ray-core/v4.version=$version -X github.com/v2fly/v2ray-core/v4.build=$SOURCE_DATE_EPOCH -s -w -buildid="
+go_ldflags="-X github.com/v2fly/v2ray-core/v4.codename=$pkgname
+ -X github.com/v2fly/v2ray-core/v4.version=$version
+ -X github.com/v2fly/v2ray-core/v4.build=$SOURCE_DATE_EPOCH -buildid="
 short_desc="Platform for building proxies to bypass network restrictions"
 maintainer="ipkalm <ipkalm@outlook.com>"
 license="MIT"


### PR DESCRIPTION
- aws-vault: remove -w -s from go_ldflags
    - added in #21634
- circleci-cli: remove -w -s from go_ldflags
    - added in #25101
- coredns: remove -w -s from go_ldflags
    - added in #23578
- gotify-cli: remove -w -s from go_ldflags
    - added in #34653
- gotify-server: remove -w -s from go_ldflags
    - added in #34653
- v2ray: remove -w -s from go_ldflags
    - added in #31653
    - not revbumping because of build issues with `quic-go` (see below)
- common/build-style/go.sh: error if -s/-w in go_ldflags
    - this does not fit in an xlint because of multiline-string handling woes

These [go linker flags](https://pkg.go.dev/cmd/link) are:

        -s   Omit the symbol table and debug information.
        -w   Omit the DWARF symbol table.

both are not necessary because xbps-src should strip binaries itself

it's not necessary to check for `-sw` or `-ws` because go doesn't parse combined flags for this

#### Testing the changes
- I tested the changes in this PR: **briefly**
  - all still build except for `v2ray`

[ci skip]