### PR TITLE
xbps-src: explicitly disallow pattern on build deps

### DIFF
--- a/common/xbps-src/shutils/common.sh
+++ b/common/xbps-src/shutils/common.sh
@@ -477,6 +477,12 @@ setup_pkg() {
         fi
     fi
 
+    for x in ${hostmakedepends} ${makedepends} ${checkdepends}; do
+        if [[ $x = *[\<\>]* || $x =~ -[^-_]*[0-9][^-_]*_[0-9_]+$ ]]; then
+            msg_error "$pkgver: specifying version in build dependency '$x' is invalid, template version is used always\n"
+        fi
+    done
+
     FILESDIR=$XBPS_SRCPKGDIR/$sourcepkg/files
     PATCHESDIR=$XBPS_SRCPKGDIR/$sourcepkg/patches
     DESTDIR=$XBPS_DESTDIR/$XBPS_CROSS_TRIPLET/${sourcepkg}-${version}

--- a/srcpkgs/openocd/template
+++ b/srcpkgs/openocd/template
@@ -1,7 +1,7 @@
 # Template file for 'openocd'
 pkgname=openocd
 version=0.11.0+1
-revision=1
+revision=2
 # update to a commit that has a compatible jimtcl version
 _commit=830d70bfc66ada2a68c73283b9e4fa4770d408ee
 _jimtcl_version=0.81
@@ -44,6 +44,7 @@ hostmakedepends="automake pkg-config libtool which"
 makedepends="hidapi-devel libftdi1-devel
  jimtcl-devel
  libusb-devel libjaylink-devel capstone-devel"
+depends="jimtcl-devel>=${_jimtcl_version}_1<=${_jimtcl_version}_9999"
 short_desc="Open On-Chip Debugger"
 maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
It is not possible to use version other than currently in template.

Specifying pattern breaks build if dependency isn't in binary repo
already. That it worked when in repo was a coincidence.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Closes #37837