### PR TITLE
mate-settings-daemon: remove alsa-plugins-pulseaudio dependency

### DIFF
--- a/srcpkgs/mate-settings-daemon/template
+++ b/srcpkgs/mate-settings-daemon/template
@@ -1,14 +1,13 @@
 # Template file for 'mate-settings-daemon'
 pkgname=mate-settings-daemon
 version=1.26.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-schemas-compile --enable-polkit --enable-pulse"
 hostmakedepends="dbus-glib-devel glib-devel intltool itstool pkg-config polkit"
 makedepends="dbus-glib-devel libXt-devel libXxf86misc-devel libcanberra-devel
  libmatekbd-devel libmatemixer-devel libnotify-devel mate-desktop-devel nss-devel
  polkit-devel"
-depends="alsa-plugins-pulseaudio"
 short_desc="MATE Settings daemon (pulseaudio)"
 maintainer="skmpz <dem.procopiou@gmail.com>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)