### PR TITLE
python3-gitlab: update to 3.8.1.

### DIFF
--- a/srcpkgs/python3-gitlab/template
+++ b/srcpkgs/python3-gitlab/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-gitlab'
 pkgname=python3-gitlab
-version=3.6.0
+version=3.8.1
 revision=1
 wrksrc=python-gitlab-$version
 build_style=python3-module
@@ -13,7 +13,7 @@ license="LGPL-3.0-or-later"
 homepage="https://github.com/python-gitlab/python-gitlab"
 changelog="https://raw.githubusercontent.com/python-gitlab/python-gitlab/master/ChangeLog.rst"
 distfiles="${PYPI_SITE}/p/python-gitlab/python-gitlab-${version}.tar.gz"
-checksum=901c54ff926f10479cb591a34d65f0a3022f2bcc41074f9a192c7fa7e4c57061
+checksum=e1db25076520e118c7c26becb0d074a7a68127439870d43b8636342206b1e091
 conflicts="python-gitlab>=0"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl (crossbuilds)
  - [x] aarch64 (crossbuilds)
  - [x] armv7l-musl (crossbuilds)
  - [x] armv7l (crossbuilds)
  - [x] i686 (crossbuilds)
  - [x] x86_64-musl (crossbuilds)