### PR TITLE
glab: update to 1.22.0.

### DIFF
--- a/srcpkgs/glab/template
+++ b/srcpkgs/glab/template
@@ -1,7 +1,8 @@
 # Template file for 'glab'
 pkgname=glab
-version=1.18.1
+version=1.22.0
 revision=1
+wrksrc="cli-v$version"
 build_style=go
 go_ldflags="-X main.version=$version"
 go_import_path=github.com/profclems/glab
@@ -9,9 +10,9 @@ go_package="${go_import_path}/cmd/glab"
 short_desc="Command line tool bringing GitLab's features to your command line"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
-homepage="https://github.com/profclems/glab"
-distfiles="https://github.com/profclems/glab/archive/v$version.tar.gz"
-checksum=ce10c93268eb58fa6d277ebd4ed6de254e4365a1a332122f597e295cc11496c3
+homepage="https://gitlab.com/gitlab-org/cli"
+distfiles="https://gitlab.com/gitlab-org/cli/-/archive/v$version/cli-v$version.tar.gz"
+checksum=4d9bceb6818c8bf9f681119dae3a65f1c895fa21e9da6b38e8f88d245f524e10
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/glab/update
+++ b/srcpkgs/glab/update
@@ -1,0 +1,3 @@
+site="https://gitlab.com/gitlab-org/cli/-/tags?format=atom"
+pattern="(?<=<title>v).*(?=<\/title>)"
+ignore="*pre*"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [x] aarch64-musl (crossbuilds)
  - [x] aarch64 (crossbuilds)
  - [x] armv7l-musl (crossbuilds)
  - [x] armv7l (crossbuilds)
  - [x] i686-musl (crossbuilds)
  - [x] x86_64-musl (crossbuilds)