### PR TITLE
gnutls: update to 3.7.7. (CVE-2022-2509)

### DIFF
--- a/srcpkgs/gnutls/template
+++ b/srcpkgs/gnutls/template
@@ -1,6 +1,6 @@
 # Template file for 'gnutls'
 pkgname=gnutls
-version=3.7.6
+version=3.7.7
 revision=1
 build_style=gnu-configure
 configure_args="--disable-guile --disable-static
@@ -21,7 +21,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only, LGPL-2.1-or-later"
 homepage="https://gnutls.org"
 distfiles="https://www.gnupg.org/ftp/gcrypt/gnutls/v${version%.*}/gnutls-${version}.tar.xz"
-checksum=77065719a345bfb18faa250134be4c53bef70c1bd61f6c0c23ceb8b44f0262ff
+checksum=be9143d0d58eab64dba9b77114aaafac529b6c0d7e81de6bdf1c9b59027d2106
 
 pre_check() {
 	# same as $PASS in tests/cert-tests/certtool.sh


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (Void 5.18.16_1 x86_64 GenuineIntel)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - x86_64-musl (crossbuild)