### PR TITLE
claws-mail: drop unused python-devel in hostmakedepends.

### DIFF
--- a/srcpkgs/claws-mail/template
+++ b/srcpkgs/claws-mail/template
@@ -1,11 +1,11 @@
 # Template file for 'claws-mail'
 pkgname=claws-mail
 version=4.1.0
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--disable-static --disable-python-plugin --disable-perl-plugin
  --enable-enchant --enable-gnutls"
-hostmakedepends="pkg-config python-devel automake libtool gettext-devel"
+hostmakedepends="pkg-config automake libtool gettext-devel"
 makedepends="poppler-glib-devel libarchive-devel libSM-devel
  libnotify-devel libcanberra-devel gpgme-devel gnutls-devel
  enchant2-devel dbus-devel libetpan-devel libldap-devel


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Since `--disable-python-plugin` is set, this dependency isn't used (it should be python3 anyway).