### PR TITLE
bff: change distfile

### DIFF
--- a/srcpkgs/bff/template
+++ b/srcpkgs/bff/template
@@ -3,13 +3,14 @@ pkgname=bff
 reverts=1.0.5_1
 version=1.0
 revision=3
-build_style=fetch
+create_wrksrc="yes"
+hostmakedepends="rpmextract"
 short_desc="Brainfuck interpreter (DBFI dialect)"
 maintainer="ananteris <ananteris@mailinator.com>"
 license="Public Domain"
-homepage="http://mazonka.com/brainf/"
-distfiles="http://mazonka.com/brainf/bff4.c"
-checksum=6139b587a7ac40b0bda023064172e9bbccfce15cd8c879ec601e8ee70b83aec3
+homepage="https://web.archive.org/web/20211106162728/http://mazonka.com/brainf/"
+distfiles="https://download.opensuse.org/repositories/openSUSE:/Factory/standard/src/bff4-1-14.27.src.rpm"
+checksum=7e4ff1e34f19873e700393468585b3e0ab829dd7dac41e2e3d1bd53c3b08d092
 
 do_install() {
 	$CC $CFLAGS $LDFLAGS bff4.c -o bff


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

I've considered moving `bff-apankrat` to `bff` since `bff` is dead but #5947 suggests that they should be kept separate. This has been uncovered by #38555.

#### Testing the changes
- I tested the changes in this PR: **briefly**