### PR TITLE
python3-Flask: update to 2.2.2.

### DIFF
--- a/srcpkgs/python3-Flask/template
+++ b/srcpkgs/python3-Flask/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Flask'
 pkgname=python3-Flask
-version=2.0.2
+version=2.2.2
 revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
@@ -9,11 +9,12 @@ depends="python3-setuptools python3-Jinja2 python3-Werkzeug
  python3-itsdangerous python3-click"
 checkdepends="${depends} python3-pytest python3-hypothesis"
 short_desc="Python3 web microframework"
-maintainer="Markus Berger <pulux@pf4sh.de>"
+maintainer="Pulux <pulux@pf4sh.de>"
 license="BSD-3-Clause"
 homepage="http://flask.pocoo.org"
+changelog="https://raw.githubusercontent.com/pallets/flask/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/F/Flask/Flask-${version}.tar.gz"
-checksum=7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2
+checksum=642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b
 conflicts="python-Flask>=0"
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This need `python3-Werkzeug >= 2.2.2` to check and run