### PR TITLE
khal: update to 0.10.5.

### DIFF
--- a/srcpkgs/khal/patches/01-remove-unecessary-dependcy.patch
+++ b/srcpkgs/khal/patches/01-remove-unecessary-dependcy.patch
@@ -1,0 +1,10 @@
+--- a/doc/source/conf.py
++++ b/doc/source/conf.py
+@@ -107,7 +107,6 @@
+     'sphinx.ext.autodoc',
+     'sphinx.ext.intersphinx',
+     'sphinx.ext.todo',
+-    'sphinxcontrib.newsfeed',
+ ]
+ 
+ # Add any paths that contain templates here, relative to this directory.

--- a/srcpkgs/khal/template
+++ b/srcpkgs/khal/template
@@ -1,28 +1,39 @@
 # Template file for 'khal'
 pkgname=khal
-version=0.10.4
-revision=2
+version=0.10.5
+revision=1
 build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-click python3-click-log python3-configobj
- python3-dateutil python3-icalendar python3-pytz python3-tzlocal
- python3-urwid python3-xdg python3-atomicwrites"
+hostmakedepends="python3-setuptools python3-Sphinx python3-sphinxcontrib
+ python3-click python3-click-log python3-configobj python3-dateutil
+ python3-icalendar python3-pytz python3-tzlocal python3-urwid python3-xdg
+ python3-atomicwrites"
+depends="python3-click python3-click-log python3-configobj python3-dateutil
+ python3-icalendar python3-pytz python3-tzlocal python3-urwid python3-xdg
+ python3-atomicwrites"
 checkdepends="python3-pytest python3-freezegun vdirsyncer $depends"
 short_desc="Command-line calendar build around CalDAV"
 maintainer="Anachron <gith@cron.world>"
 license="MIT"
 homepage="http://lostpackets.de/khal/"
+changelog="https://raw.githubusercontent.com/pimutils/khal/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/k/khal/khal-${version}.tar.gz"
-checksum=3fdb980a9a61c0206d7a82b16f77b408a4f341a2b866b9c9fcf6a641850d129f
-make_check=ci-skip
+checksum=4eefb7ac302a26d8606db392817587a4ed94c27a15bf2ea211614a464fcf0c76
+make_check=ci-skip # some tests fail when running as root
 
 pre_build() {
 	vsed -i setup.py \
 		-e '/setup_requires=/d' \
 		-e "s|use_scm_version=.*|version='${version}',|"
 }
+
 post_install() {
 	vlicense COPYING
-	vinstall misc/__khal 644 usr/share/zsh/site-functions
+	for sh in bash fish zsh; do
+		env PYTHONPATH=$DESTDIR/$py3_sitelib _KHAL_COMPLETE="${sh}_source" $DESTDIR/usr/bin/khal > "khal.${sh}"
+		vcompletion "khal.${sh}" $sh
+	done
 	vsconf khal.conf.sample
+	cd doc/
+	PYTHONPATH=$DESTDIR/$py3_sitelib make man
+	vman build/man/khal.1
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)

Since version 0.10.5 there is no longer a `__khal` file. This is why I deleted line 26.
