### PR TITLE
signify: update to 31.

### DIFF
--- a/srcpkgs/signify/template
+++ b/srcpkgs/signify/template
@@ -1,27 +1,30 @@
 # Template file for 'signify'
 pkgname=signify
 reverts="20141230_3 20141230_2 20141230_1"
-version=30
+version=31
 revision=1
 build_style=gnu-makefile
 make_build_args="BZERO=bundled"
 hostmakedepends="pkg-config"
-makedepends="libbsd-devel"
+makedepends="libbsd-devel libmd-devel"
+checkdepends="tar"
 short_desc="OpenBSD cryptographic signing and verification tool"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
-homepage="http://www.tedunangst.com/flak/post/signify"
+homepage="https://www.tedunangst.com/flak/post/signify"
+changelog="https://raw.githubusercontent.com/aperezdc/signify/master/CHANGELOG.md"
 distfiles="https://github.com/aperezdc/signify/releases/download/v${version}/signify-${version}.tar.xz"
-checksum=f68406c3085ef902e85500e6c0b90e4c3f56347e5efffc0da7b6fb47803c8686
+checksum=1155fd9eeed4a8aa20476b2333d251953ec5d52338d943a770db5b78dd8d2b74
 
 pre_build() {
 	# Allow building with musl
-		cp ${FILESDIR}/void.h .
-		for file in blf.h sha2.h ohash.h; do
-			sed -e '1 i\#include "void.h"' -i $file
-		done
+	cp ${FILESDIR}/void.h .
+	for file in blf.h sha2.h ohash.h; do
+		vsed -e '1 i\#include "void.h"' -i $file
+	done
+
 	# Create license file
-		head -n 16 signify.c > LICENSE
+	sed -E '3,15 !d;s/^ [*] ?//' signify.c > LICENSE
 }
 
 post_install() {

--- a/srcpkgs/signify/update
+++ b/srcpkgs/signify/update
@@ -1,1 +1,0 @@
-pkgname="${pkgname}-portable"


### PR DESCRIPTION
Edit: I also added changelog and removed the UPDATE file, which doesn't seem correct anymore.

Add needed libmd makedepend and tar checkdepend,
use vsed instead of sed for the file patching,
and use sed instead of head to extract a nicer LICENSE file

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
