### PR TITLE
gnome-nibbles: remove unused intltool makedep

### DIFF
--- a/srcpkgs/gnome-nibbles/template
+++ b/srcpkgs/gnome-nibbles/template
@@ -3,13 +3,13 @@ pkgname=gnome-nibbles
 version=3.38.2
 revision=1
 build_style=meson
-hostmakedepends="gettext glib-devel intltool itstool pkg-config vala"
+hostmakedepends="gettext glib-devel itstool pkg-config vala"
 makedepends="clutter-gtk-devel gsound-devel libcanberra-devel
  libgnome-games-support-devel librsvg-devel"
 short_desc="GNOME snake eats diamonds game"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
-changelog="https://github.com/GNOME/gnome-nibbles/raw/gnome-3-24/NEWS"
 homepage="https://wiki.gnome.org/Apps/Nibbles"
+changelog="https://gitlab.gnome.org/GNOME/gnome-nibbles/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=457a64b1c88e2d8d0143c452ffd01f0300d7d3005802954ef5abf9c896b353d9


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
