### PR TITLE
gnome-characters: add libadwaita dependency

### DIFF
--- a/srcpkgs/gnome-characters/template
+++ b/srcpkgs/gnome-characters/template
@@ -1,12 +1,12 @@
 # Template file for 'gnome-characters'
 pkgname=gnome-characters
 version=42.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 hostmakedepends="gettext gjs glib-devel itstool pkg-config"
 makedepends="gjs-devel libglib-devel gtk4-devel libadwaita-devel libunistring-devel"
-depends="gnome-desktop gjs"
+depends="gnome-desktop gjs libadwaita"
 short_desc="Utility to find and insert unusual characters for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Closes: https://github.com/void-linux/void-packages/issues/38599

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
