### PR TITLE
New package: cshatag-2.0

### DIFF
--- a/srcpkgs/cshatag/template
+++ b/srcpkgs/cshatag/template
@@ -1,0 +1,20 @@
+# Template file for 'cshatag'
+pkgname=cshatag
+version=2.0
+revision=1
+build_style=go
+go_import_path="github.com/rfjakob/cshatag"
+depends="attr-progs"
+short_desc="Minimal and fast re-implementation of shatag"
+maintainer="ketlrznt <tansuanyinliao8888@gmail.com>"
+license="MIT"
+homepage="https://github.com/rfjakob/cshatag"
+changelog="https://raw.githubusercontent.com/rfjakob/cshatag/master/CHANGELOG.md"
+distfiles="https://github.com/rfjakob/cshatag/archive/refs/tags/v${version}.tar.gz"
+checksum=ec06106f5bff76f4d7847151b19a1fbfd6934b3a2a292ae8f7f24b0f25907195
+
+post_install() {
+	vman cshatag.1
+	vdoc README.md
+	vlicense LICENSE
+}


### PR DESCRIPTION
Closes #38204 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuilds)
  - i686 (crossbuilds, native masterdir)
  - armv7l-musl (crossbuilds)
 
