### PR TITLE
farstream: drop unused python-devel in *depends, fix tests.

### DIFF
--- a/srcpkgs/farstream/patches/fix_tests_with_gupnp_1.2.patch
+++ b/srcpkgs/farstream/patches/fix_tests_with_gupnp_1.2.patch
@@ -1,0 +1,140 @@
+From e70dcd0a9f89efbdaa011c20737ad550635ea580 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Olivier=20Cr=C3=AAte?= <olivier.crete@collabora.com>
+Date: Tue, 20 Oct 2020 19:51:22 -0400
+Subject: [PATCH] rawudp-upnp test: Also build against new GUPnP 1.2 library if
+ present
+
+Update the configure test to match
+---
+ configure.ac                          | 17 +++++++++++++++++
+ tests/check/Makefile.am               |  7 +++----
+ tests/check/transmitter/rawudp-upnp.c | 16 ++++++++++++++--
+ tests/check/transmitter/rawudp.c      |  4 ++--
+ 4 files changed, 36 insertions(+), 8 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 03afc96b..1efed132 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -370,8 +370,25 @@ fi
+ 
+ if test "x$HAVE_GUPNP" = "xyes"; then
+    AC_DEFINE(HAVE_GUPNP,,[Have the GUPnP IGD library])
++
++    PKG_CHECK_MODULES(GUPNP_CORE, [ gupnp-1.2 ],
++	[ HAVE_GUPNP_CORE_12=yes ],
++	[ HAVE_GUPNP_CORE_12=no
++	  PKG_CHECK_MODULES(GUPNP_CORE, [ gupnp-1.0 ],
++	     [ HAVE_GUPNP_CORE_10=yes ],
++	     [ HAVE_GUPNP_CORE_10=no ])
++    ])
++
++    if test "x$HAVE_GUPNP_CORE_10" = "xyes"; then
++       AC_DEFINE(HAVE_GUPNP_CORE_10,,[Have the GUPnP 1.0 library])
++    fi
++
++    if test "x$HAVE_GUPNP_CORE_12" = "xyes"; then
++       AC_DEFINE(HAVE_GUPNP_CORE_12,,[Have the GUPnP 1.2 library])
++    fi
+ fi
+ 
++
+ dnl build static plugins or not
+ AC_MSG_CHECKING([whether to build static plugins or not])
+ AC_ARG_ENABLE(
+diff --git a/tests/check/Makefile.am b/tests/check/Makefile.am
+index d50fc264..d21687d7 100644
+--- a/tests/check/Makefile.am
++++ b/tests/check/Makefile.am
+@@ -76,9 +76,9 @@ base_fscodec_SOURCES = \
+ 
+ 
+ transmitter_rawudp_CFLAGS = $(AM_CFLAGS) \
+-	$(GUPNP_CFLAGS) $(GIO_CFLAGS) $(NICE_CFLAGS)
++	$(GUPNP_CORE_CFLAGS) $(GIO_CFLAGS) $(NICE_CFLAGS)
+ transmitter_rawudp_LDADD = $(LDADD) \
+-	$(GUPNP_LIBS) \
++	$(GUPNP_CORE_LIBS) \
+ 	$(GIO_LIBS) \
+ 	$(NICE_LIBS)
+ transmitter_rawudp_SOURCES = \
+@@ -113,9 +113,8 @@ transmitter_nice_SOURCES = \
+ transmitter_nice_LDADD = $(LDADD) $(GST_BASE_LIBS)
+ 
+ 
+-transmitter_shm_CFLAGS = $(AM_CFLAGS) $(GUPNP_CFLAGS) $(NICE_CFLAGS)
++transmitter_shm_CFLAGS = $(AM_CFLAGS) $(NICE_CFLAGS)
+ transmitter_shm_LDADD = $(LDADD) \
+-	$(GUPNP_LIBS) \
+ 	$(NICE_LIBS)
+ transmitter_shm_SOURCES = \
+ 	check-threadsafe.h  \
+diff --git a/tests/check/transmitter/rawudp-upnp.c b/tests/check/transmitter/rawudp-upnp.c
+index 4818cd28..9ccf85d8 100644
+--- a/tests/check/transmitter/rawudp-upnp.c
++++ b/tests/check/transmitter/rawudp-upnp.c
+@@ -37,7 +37,7 @@ get_vars (gboolean *out_got_address,
+ }
+ 
+ 
+-#ifdef HAVE_GUPNP
++#if defined(HAVE_GUPNP_CORE_10) || defined(HAVE_GUPNP_CORE_12)
+ 
+ #include <libgupnp/gupnp.h>
+ 
+@@ -126,8 +126,14 @@ start_upnp_server (void)
+   GUPnPDeviceInfo *subdev1;
+   GUPnPDeviceInfo *subdev2;
+   const gchar *upnp_xml_path;
++  GError *gerr = NULL;
+ 
+-  context = gupnp_context_new (NULL, NULL, 0, NULL);
++#ifdef HAVE_GUPNP_CORE_12
++  context = gupnp_context_new (NULL, 0, &gerr);
++#else
++  context = gupnp_context_new (NULL, NULL, 0, &gerr);
++#endif
++  g_assert_no_error (gerr);
+   ts_fail_if (context == NULL, "Can't get gupnp context");
+ 
+   if (g_getenv ("UPNP_XML_PATH"))
+@@ -137,8 +143,14 @@ start_upnp_server (void)
+ 
+   gupnp_context_host_path (context, upnp_xml_path, "");
+ 
++#ifdef HAVE_GUPNP_CORE_12
++  dev = gupnp_root_device_new (context, "InternetGatewayDevice.xml",
++      upnp_xml_path, &gerr);
++  g_assert_no_error (gerr);
++#else
+   dev = gupnp_root_device_new (context, "InternetGatewayDevice.xml",
+       upnp_xml_path);
++#endif
+   ts_fail_if (dev == NULL, "could not get root dev");
+ 
+   subdev1 = gupnp_device_info_get_device (GUPNP_DEVICE_INFO (dev),
+diff --git a/tests/check/transmitter/rawudp.c b/tests/check/transmitter/rawudp.c
+index e1936ac0..d803f347 100644
+--- a/tests/check/transmitter/rawudp.c
++++ b/tests/check/transmitter/rawudp.c
+@@ -637,7 +637,7 @@ GST_START_TEST (test_rawudptransmitter_stop_stream)
+ }
+ GST_END_TEST;
+ 
+-#ifdef HAVE_GUPNP
++#if defined(HAVE_GUPNP_CORE_10) || defined (HAVE_GUPNP_CORE_12)
+ 
+ GST_START_TEST (test_rawudptransmitter_run_upnp_discovery)
+ {
+@@ -967,7 +967,7 @@ rawudptransmitter_suite (void)
+   tcase_add_test (tc_chain, test_rawudptransmitter_stop_stream);
+   suite_add_tcase (s, tc_chain);
+ 
+-#ifdef HAVE_GUPNP
++#if defined(HAVE_GUPNP_CORE_10) || defined (HAVE_GUPNP_CORE_12)
+   if (g_getenv ("UPNP")) {
+     gchar *multicast_addr;
+ 
+-- 
+GitLab
+

--- a/srcpkgs/farstream/patches/nice-agent-keep-main-context-alive.patch
+++ b/srcpkgs/farstream/patches/nice-agent-keep-main-context-alive.patch
@@ -1,0 +1,136 @@
+From 46d7b108179b477a00464fc47dc8aa1c6389ee03 Mon Sep 17 00:00:00 2001
+From: Fabrice Bellet <fabrice@bellet.info>
+Date: Sun, 16 Jun 2019 17:42:45 +0200
+Subject: [PATCH] nice agent: keep the main context alive until the agent is
+ destroyed
+
+Recent addition of async removal of turn refreshes added sources to the
+main context when a stream is removed from the agent. Then, the main
+context must be still running until the nice agent is disposed to
+properly free resources.
+---
+ transmitters/nice/fs-nice-agent.c | 71 +++++++++++++++++++------------
+ 1 file changed, 43 insertions(+), 28 deletions(-)
+
+diff --git a/transmitters/nice/fs-nice-agent.c b/transmitters/nice/fs-nice-agent.c
+index b94e7138..744c9641 100644
+--- a/transmitters/nice/fs-nice-agent.c
++++ b/transmitters/nice/fs-nice-agent.c
+@@ -87,7 +87,8 @@ static void fs_nice_agent_class_init (
+ static void fs_nice_agent_init (FsNiceAgent *self);
+ static void fs_nice_agent_dispose (GObject *object);
+ static void fs_nice_agent_finalize (GObject *object);
+-static void fs_nice_agent_stop_thread (FsNiceAgent *self);
++static void fs_nice_agent_stop_thread (gpointer user_data,
++    GObject *where_the_object_was);
+ 
+ static void fs_nice_agent_set_property (GObject *object,
+     guint prop_id,
+@@ -183,15 +184,34 @@ fs_nice_agent_init (FsNiceAgent *self)
+ }
+ 
+ 
++typedef struct _ThreadData {
++  GMainContext *main_context;
++  GMainLoop *main_loop;
++  GThread *thread;
++} ThreadData;
++
+ static void
+ fs_nice_agent_dispose (GObject *object)
+ {
+   FsNiceAgent *self = FS_NICE_AGENT (object);
+-
+-  fs_nice_agent_stop_thread (self);
++  ThreadData *data;
+ 
+   if (self->agent)
++  {
++    FS_NICE_AGENT_LOCK (self);
++    if (self->priv->thread)
++    {
++      data = g_new0 (ThreadData, 1);
++      data->main_context = g_main_context_ref (self->priv->main_context);
++      data->main_loop = g_main_loop_ref (self->priv->main_loop);
++      data->thread = self->priv->thread;
++      g_object_weak_ref (G_OBJECT (self->agent),
++            fs_nice_agent_stop_thread, data);
++    }
++    self->priv->thread = NULL;
++    FS_NICE_AGENT_UNLOCK (self);
+     g_object_unref (self->agent);
++  }
+   self->agent = NULL;
+ 
+   parent_class->dispose (object);
+@@ -262,47 +282,42 @@ fs_nice_agent_get_property (GObject *object,
+   }
+ }
+ 
+-
+ static gboolean
+-thread_unlock_idler (gpointer data)
++thread_unlock_idler (gpointer user_data)
+ {
+-  FsNiceAgent *self = FS_NICE_AGENT (data);
++  ThreadData *data = user_data;
+ 
+-  g_main_loop_quit (self->priv->main_loop);
++  g_main_loop_quit (data->main_loop);
+ 
+   return TRUE;
+ }
+ 
+ static void
+-fs_nice_agent_stop_thread (FsNiceAgent *self)
++fs_nice_agent_stop_thread (gpointer user_data, GObject *where_the_object_was)
+ {
++  ThreadData *data = user_data;
+   GSource *idle_source;
+ 
+-  g_main_loop_quit (self->priv->main_loop);
+-
+-  FS_NICE_AGENT_LOCK(self);
++  g_main_loop_quit (data->main_loop);
+ 
+-  if (self->priv->thread == NULL ||
+-      self->priv->thread == g_thread_self ())
++  if (data->thread &&
++      data->thread != g_thread_self ())
+   {
+-    FS_NICE_AGENT_UNLOCK (self);
+-    return;
+-  }
+-  FS_NICE_AGENT_UNLOCK (self);
+-
+-  idle_source = g_idle_source_new ();
+-  g_source_set_priority (idle_source, G_PRIORITY_HIGH);
+-  g_source_set_callback (idle_source, thread_unlock_idler, self, NULL);
+-  g_source_attach (idle_source, self->priv->main_context);
++    idle_source = g_idle_source_new ();
++    g_source_set_priority (idle_source, G_PRIORITY_HIGH);
++    g_source_set_callback (idle_source, thread_unlock_idler, user_data, NULL);
++    g_source_attach (idle_source, data->main_context);
+ 
+-  g_thread_join (self->priv->thread);
++    g_thread_join (data->thread);
+ 
+-  g_source_destroy (idle_source);
+-  g_source_unref (idle_source);
++    g_source_destroy (idle_source);
++    g_source_unref (idle_source);
++  } else
++    g_thread_unref (data->thread);
+ 
+-  FS_NICE_AGENT_LOCK (self);
+-  self->priv->thread = NULL;
+-  FS_NICE_AGENT_UNLOCK (self);
++  g_main_context_unref (data->main_context);
++  g_main_loop_unref (data->main_loop);
++  g_free (data);
+ }
+ 
+ static gpointer
+-- 
+GitLab
+

--- a/srcpkgs/farstream/template
+++ b/srcpkgs/farstream/template
@@ -1,20 +1,25 @@
 # Template file for 'farstream'
 pkgname=farstream
 version=0.2.9
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--disable-valgrind --disable-static $(vopt_enable gir introspection)"
-hostmakedepends="automake libtool gettext pkg-config intltool python-devel
+hostmakedepends="automake libtool gettext pkg-config intltool
  glib-devel $(vopt_if gir gobject-introspection)"
-makedepends="python-devel gupnp-igd-devel libnice-devel gst-plugins-base1-devel"
+makedepends="gupnp-igd-devel libnice-devel gst-plugins-base1-devel"
 depends="gst-plugins-good1 gst-plugins-bad1"
+checkdepends="$depends"
 short_desc="GStreamer modules and libraries for videoconferencing"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://www.freedesktop.org/wiki/Software/Farstream"
+changelog="https://gitlab.freedesktop.org/farstream/farstream/-/raw/master/NEWS"
 distfiles="${FREEDESKTOP_SITE}/farstream/releases/$pkgname/$pkgname-$version.tar.gz"
 checksum=cb7d112433cf7c2e37a8ec918fb24f0ea5cb293cfa1002488e431de26482f47b
+# tests sporadically fail, it appears that `rtp/codecs`, `raw/conference`, and
+# `rtp/conference` are especially susceptible to failure
+make_check=extended
 
 build_options="gir"
 build_options_default="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (ran extended tests)

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

python headers haven't been needed since Farstream 0.2: https://gitlab.freedesktop.org/farstream/farstream/-/commit/73891c28fa27d5e65a71762e826f13747d743588

The tests were already broken prior to this change, but the patch I added gets them building, but then they fail when they run...