### PR TITLE
ruby-tmuxinator: update to 3.0.5.

### DIFF
--- a/srcpkgs/ruby-thor/template
+++ b/srcpkgs/ruby-thor/template
@@ -1,13 +1,13 @@
 # Template file for 'ruby-thor'
 pkgname=ruby-thor
-version=0.20.3
-revision=6
+version=1.2.1
+revision=1
 build_style=gem
 short_desc="Toolkit for building powerful command-line interfaces"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
 homepage="http://whatisthor.com/"
-checksum=49bc217fe28f6af34c6e60b003e3405c27595a55689077d82e9e61d4d3b519fa
+checksum=b1752153dc9c6b8d3fcaa665e9e1a00a3e73f28da5e238b81c404502e539d446
 
 post_install() {
 	vlicense LICENSE.md

--- a/srcpkgs/ruby-tmuxinator/patches/xdg.patch
+++ b/srcpkgs/ruby-tmuxinator/patches/xdg.patch
@@ -1,0 +1,50 @@
+diff --git a/lib/tmuxinator/config.rb b/lib/tmuxinator/config.rb
+index 25620bf..fcc61a3 100644
+--- a/lib/tmuxinator/config.rb
++++ b/lib/tmuxinator/config.rb
+@@ -29,7 +29,7 @@ module Tmuxinator
+       # a custom value. (e.g. if $XDG_CONFIG_HOME is set to ~/my-config, the
+       # return value will be ~/my-config/tmuxinator)
+       def xdg
+-        XDG["CONFIG"].to_s + "/tmuxinator"
++        XDG::Config.new.home.to_s + "/tmuxinator"
+       end
+
+       def xdg?
+diff --git a/spec/lib/tmuxinator/config_spec.rb b/spec/lib/tmuxinator/config_spec.rb
+index 71b8da2..d28a60a 100644
+--- a/spec/lib/tmuxinator/config_spec.rb
++++ b/spec/lib/tmuxinator/config_spec.rb
+@@ -53,7 +53,8 @@ describe Tmuxinator::Config do
+
+         Dir.mktmpdir do |dir|
+           config_parent = "#{dir}/non_existant_parent/s"
+-          allow(XDG).to receive(:[]).with("CONFIG").and_return config_parent
++          allow(XDG::Config).to receive_message_chain(:new, :home, :to_s).
++            and_return config_parent
+           expect(described_class.directory).
+             to eq "#{config_parent}/tmuxinator"
+           expect(File.directory?("#{config_parent}/tmuxinator")).to be true
+@@ -134,7 +135,8 @@ describe Tmuxinator::Config do
+
+   describe "#xdg" do
+     it "is $XDG_CONFIG_HOME/tmuxinator" do
+-      expect(described_class.xdg).to eq "#{XDG['CONFIG_HOME']}/tmuxinator"
++      config_home = XDG::Config.new.home.to_s
++      expect(described_class.xdg).to eq "#{config_home}/tmuxinator"
+     end
+   end
+
+diff --git a/tmuxinator.gemspec b/tmuxinator.gemspec
+index 1b02053..3f4c8f8 100644
+--- a/tmuxinator.gemspec
++++ b/tmuxinator.gemspec
+@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
+
+   s.add_dependency "erubis", "~> 2.6"
+   s.add_dependency "thor", "~> 1.2.1"
+-  s.add_dependency "xdg", "~> 2.2", ">= 2.2.5"
++  s.add_dependency "xdg", ">= 4.3.0"
+
+   s.add_development_dependency "activesupport", "< 5.0.0" # Please see issue #432
+   s.add_development_dependency "awesome_print", "~> 1.2"

--- a/srcpkgs/ruby-tmuxinator/template
+++ b/srcpkgs/ruby-tmuxinator/template
@@ -1,16 +1,21 @@
 # Template file for 'ruby-tmuxinator'
 pkgname=ruby-tmuxinator
-version=0.16.0
-revision=5
-build_style=gem
-depends="ruby-erubis>=2.6 ruby-thor>=0.15.0 ruby-xdg>=2.2.3 tmux"
+version=3.0.5
+revision=1
+wrksrc="tmuxinator-${version}"
+build_style=gemspec
+depends="ruby-erubis>=2.6 ruby-thor>=1.2.1 ruby-xdg>=4.3.0 tmux"
 short_desc="Create and manage complex tmux sessions easily"
 maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"
 license="MIT"
 homepage="https://github.com/tmuxinator/tmuxinator"
-checksum=296f370ee7cfffd91ee42ab301479c7e632091097001728f6f2a84b629469538
+changelog="https://raw.githubusercontent.com/tmuxinator/tmuxinator/master/CHANGELOG.md"
+distfiles="https://github.com/tmuxinator/tmuxinator/archive/refs/tags/v${version}.tar.gz"
+checksum=f67296a0b600fb5d8e51bf8fc9f8376a887754fd74cd59b6a8d9c962ad8f80a4
 
 post_install() {
-	$XBPS_FETCH_CMD https://raw.githubusercontent.com/tmuxinator/tmuxinator/v${version}/LICENSE
 	vlicense LICENSE
+	for sh in bash fish zsh; do
+		vcompletion "completion/tmuxinator.${sh}" ${sh}
+	done
 }

--- a/srcpkgs/ruby-xdg/template
+++ b/srcpkgs/ruby-xdg/template
@@ -1,13 +1,14 @@
 # Template file for 'ruby-xdg'
 pkgname=ruby-xdg
-version=5.1.1
-revision=2
+version=6.5.0
+revision=1
 build_style=gem
 short_desc="Module for supporting the XDG Base Directory Standard"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="BSD-2-Clause"
-homepage="http://rubyworks.github.com/xdg"
-checksum=3d050ea585c0d1fdb69bbb9ee58858edbd7ad6e6db830391e08b174eddbe4b15
+license="Hippocratic-2.1"
+homepage="https://www.alchemists.io/projects/xdg"
+changelog="https://raw.githubusercontent.com/bkuhlmann/xdg/main/README.adoc"
+checksum=c6b621087134c6452a19a5817a286b5ca400f8267549294bdffbcc7591b9c9b3
 
 post_install() {
 	vlicense LICENSE.adoc


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)

I've also updated the necessary dependencies and switched from gem to gemspec to apply the patch for xdg. 

That patch is copied from [AUR](https://aur.archlinux.org/cgit/aur.git/tree/xdg.patch?h=tmuxinator).
With the patch ruby-xdg versions >=4.5.0 are working properly with tmuxinator-3.0.5.
