### PR TITLE
gnome-desktop, mutter, gnome-shell: update to 42.4

### DIFF
--- a/srcpkgs/gnome-desktop/template
+++ b/srcpkgs/gnome-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-desktop'
 pkgname=gnome-desktop
-version=42.2
+version=42.4
 revision=1
 build_style=meson
 build_helper="gir"
@@ -17,7 +17,7 @@ license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/gnome-desktop"
 changelog="https://gitlab.gnome.org/GNOME/gnome-desktop/-/raw/gnome-42/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=f42b14eac8d1456c2bfc1fbc97ef6afe49c8dd6f57796e8fd5feb39331ed55bd
+checksum=1ce2c9d5067969dbe0b282ea5a9acfb8698751f03cd07e2c730240f85dc9ad25
 
 build_options="gir"
 build_options_default="gir"

--- a/srcpkgs/gnome-shell/template
+++ b/srcpkgs/gnome-shell/template
@@ -1,6 +1,6 @@
 # Template file for 'gnome-shell'
 pkgname=gnome-shell
-version=42.3.1
+version=42.4
 revision=1
 build_style=meson
 build_helper=gir
@@ -21,7 +21,7 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeShell"
 changelog="https://gitlab.gnome.org/GNOME/gnome-shell/-/raw/gnome-42/NEWS"
 distfiles="${GNOME_SITE}/gnome-shell/${version%%.*}/gnome-shell-${version}.tar.xz"
-checksum=7dfab32dfac3cd64d4612918ca987cfb33238efa092798753c8845ff16935f7d
+checksum=875ff2970ea9fb7a05506e32a0d50dc917f41b4ca37134b41377f9c82873c54e
 
 do_check() {
 	mkdir /tmp/gnome-shell-xdg

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -1,7 +1,7 @@
 # Template file for 'mutter'
 pkgname=mutter
-version=42.3
-revision=2
+version=42.4
+revision=1
 build_helper="gir"
 build_style=meson
 configure_args="-Degl_device=true -Dudev=true -Dnative_backend=true
@@ -20,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://wiki.gnome.org/Projects/Mutter/"
 changelog="https://gitlab.gnome.org/GNOME/mutter/-/raw/gnome-42/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=9da3a63f90282bb59467e7d3dfdc684e70fa055357f6a2dded1db98cdcce10ba
+checksum=c22c7fa3d187061dbf280c3850e118b7b5009065d01de31616acd500c4982a40
 shlib_provides="libmutter-clutter-10.so libmutter-cogl-10.so
  libmutter-cogl-pango-10.so"
 make_check=no # needs a full graphical session


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

https://discourse.gnome.org/t/gnome-42-4-released/10694

<!--
#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
