### PR TITLE
ktoblzcheck: move to python3

### DIFF
--- a/srcpkgs/ktoblzcheck/template
+++ b/srcpkgs/ktoblzcheck/template
@@ -1,11 +1,11 @@
 # Template file for 'ktoblzcheck'
 pkgname=ktoblzcheck
 version=1.53
-revision=2
+revision=3
 build_style=cmake
 configure_args="-DENABLE_BANKDATA_DOWNLOAD=NO"
-hostmakedepends="pkg-config python"
-makedepends="python-devel"
+hostmakedepends="pkg-config python3"
+makedepends="python3-devel"
 short_desc="Tool for verification of account numbers and bank codes"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.1-or-later"
@@ -24,5 +24,6 @@ ktoblzcheck-devel_package() {
 		vmove usr/include
 		vmove "usr/lib/*.so"
 		vmove usr/lib/pkgconfig
+		vmove usr/lib/cmake
 	}
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
    - builds fine, no difference in generated package except python lib location, revdeps build fine still

