### PR TITLE
android-udev-rules: update to 20220611.

### DIFF
--- a/srcpkgs/android-udev-rules/template
+++ b/srcpkgs/android-udev-rules/template
@@ -1,13 +1,13 @@
 # Template file for 'android-udev-rules'
 pkgname=android-udev-rules
-version=20210501
+version=20220611
 revision=1
 short_desc="Android udev rules list aimed to be the most comprehensive on the net"
 maintainer="Rien Maertens <rien.maertens@posteo.be>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/M0Rf30/android-udev-rules"
 distfiles="https://github.com/M0Rf30/android-udev-rules/archive/${version}.tar.gz"
-checksum=efb628c22ef2ab48111a4371914da628a30379a30b6b63ec43be98bbbc8587cd
+checksum=95c4dee7f3e94ddc9b580cd2e6712e7cb36809007d6f25906f863338f3054f6e
 system_groups="adbusers"
 
 do_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
