### PR TITLE
hplip: add missing build dependency

### DIFF
--- a/srcpkgs/hplip/template
+++ b/srcpkgs/hplip/template
@@ -27,7 +27,7 @@ make_dirs="/var/lib/hp 0755 root root"
 hostmakedepends="pkg-config automake libtool python3"
 makedepends="openssl-devel python3-devel libxml2-python3 cups-devel sane-devel
  ghostscript-devel net-snmp-devel libusb-devel libjpeg-turbo-devel dbus-devel
- avahi-libs-devel"
+ avahi-libs-devel zlib-devel"
 depends="python3-gobject python3-dbus desktop-file-utils
  foomatic-db foomatic-db-engine python3-distro"
 short_desc="HP Linux Imaging and Printing"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: NO

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
