### PR TITLE
sbcl: always bootstrap from clisp.

### DIFF
--- a/srcpkgs/sbcl/template
+++ b/srcpkgs/sbcl/template
@@ -1,10 +1,10 @@
 # Template file for 'sbcl'
 pkgname=sbcl
 version=2.2.7
-revision=1
+revision=2
 # make sure the sbcl option in maxima is enabled for the same archs
 archs="i686 x86_64* armv7l aarch64 ppc64le*"
-hostmakedepends="iana-etc texinfo"
+hostmakedepends="iana-etc texinfo clisp"
 makedepends="libzstd-devel zlib-devel"
 conf_files="/etc/sbclrc"
 short_desc="Steel Bank Common Lisp"
@@ -16,28 +16,7 @@ distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}-source.tar.bz2"
 checksum=ec98996fdaa68009d98b4d7db2189271f2ad455ec322ca95a9c6aebf08bead6d
 nocross=yes
 nopie=yes
-
-_bootstrap_lisp="bash ../sbcl-*-linux/run-sbcl.sh --no-sysinit --no-userinit --disable-debugger"
-case "$XBPS_TARGET_MACHINE" in
-x86_64)
-	distfiles+=" ${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}-x86-64-linux-binary.tar.bz2"
-	checksum+=" 4b176dd651437af851f6eb8332b51457f983079d27d347c30c73b3481959be78"
-	;;
-arm*)
-	distfiles+=" ${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-1.2.14-armhf-linux-binary.tar.bz2"
-	checksum+=" a5fbf1d596a909a7719bc4a958f00e8537bf399fa051f83736baee950b21e56a"
-	;;
-aarch64)
-	distfiles+=" ${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-1.3.9-arm64-linux-binary.tar.bz2"
-	checksum+=" 14c8fc0f3a03416b5d23763156e2bb28b690fb665af1e6f6112201fd0ddcd512"
-	;;
-i686*|ppc*|*-musl)
-	# ecl bootstrap is broken since 2.2.0:
-	# https://build.voidlinux.org/builders/x86_64-musl_builder/builds/39694/steps/shell_3/logs/stdio
-	makedepends+=" clisp"
-	_bootstrap_lisp="clisp"
-	;;
-esac
+_bootstrap_lisp="clisp"
 
 do_build() {
 	printf '"%s.void.%s"\n' "$version" "$revision" >version.lisp-expr


### PR DESCRIPTION
Avoid depending on external binaries.

<!-- Uncomment relevant sections and delete options which are not applicable -->

@leahneukirchen what do you think?

#### Testing the changes
- I tested the changes in this PR: **YES** (build side)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
