### PR TITLE
lilypond: update to 2.23.80

### DIFF
--- a/srcpkgs/gsfonts/template
+++ b/srcpkgs/gsfonts/template
@@ -1,19 +1,41 @@
 # Template file for 'gsfonts'
 pkgname=gsfonts
-version=8.11
-revision=7
-makedepends="font-util font-misc-misc"
-depends="${makedepends}"
-short_desc="Ghostscript standard Type1 fonts"
+version=20200910
+revision=1
+depends="font-util"
+short_desc="URW+ base35 fonts"
 maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2.0-or-later"
-homepage="http://sourceforge.net/projects/gs-fonts/"
-distfiles="${SOURCEFORGE_SITE}/ghostscript/ghostscript-fonts-std-${version}.tar.gz"
-distfiles="${SOURCEFORGE_SITE}/gs-fonts/ghostscript-fonts-std-${version}.tar.gz"
-checksum=0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401
-font_dirs="/usr/share/fonts/Type1"
+license="AGPL-3.0-or-later"
+homepage="https://github.com/ArtifexSoftware/urw-base35-fonts"
+distfiles="https://github.com/ArtifexSoftware/urw-base35-fonts/archive/refs/tags/${version}.tar.gz"
+checksum=e0d9b7f11885fdfdc4987f06b2aa0565ad2a4af52b22e5ebf79e1a98abd0ae2f
+font_dirs="/usr/share/fonts/OTF/
+ /usr/share/fonts/TTF
+ /usr/share/fonts/Type1"
 
 do_install() {
-	vmkdir usr/share/fonts/Type1
-	install -m644 ${wrksrc}/*.[ap]f[bm] ${DESTDIR}/usr/share/fonts/Type1
+	for f in ${wrksrc}/fonts/*.otf; do
+		vinstall $f 644 usr/share/fonts/OTF/
+	done
+
+	for f in ${wrksrc}/fonts/*.ttf; do
+		vinstall $f 644 usr/share/fonts/TTF/
+	done
+
+	for f in ${wrksrc}/fonts/*.{afm,t1}; do
+		vinstall $f 644 usr/share/fonts/Type1/
+	done
+
+	for f in ${wrksrc}/appstream/*.xml; do
+		vinstall $f 644 usr/share/metainfo/
+	done
+
+	for f in ${wrksrc}/fontconfig/*.conf; do
+		vmkdir etc/fonts/conf.d
+		install -Dm 644 $f ${DESTDIR}/usr/share/fontconfig/conf.avail/61-${f##*/}
+		ln -sf ../../../usr/share/fontconfig/conf.avail/61-${f##*/} ${DESTDIR}/etc/fonts/conf.d/
+	done
+
+	vlicense COPYING
+	vlicense LICENSE
 }

--- a/srcpkgs/lilypond-doc/template
+++ b/srcpkgs/lilypond-doc/template
@@ -1,14 +1,14 @@
 # Template file for 'lilypond-doc'
 pkgname=lilypond-doc
 # should be kept in sync with 'lilypond'
-version=2.23.10
+version=2.23.80
 revision=1
 short_desc="Documentation for the lilypond music engraving program"
 maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="https://lilypond.org/"
 distfiles="https://gitlab.com/lilypond/lilypond/-/releases/v${version}/downloads/lilypond-${version}-documentation.tar.xz"
-checksum=8927270ec2c2dff2e0984727543a467b49ff7cb3adfd98b81a15b51277bfba75
+checksum=36b6003c4ca0de8e9079342ef7a15459b63a895f072d13852a27f78da0daf7f8
 
 do_install() {
 	vmkdir usr/share

--- a/srcpkgs/lilypond/template
+++ b/srcpkgs/lilypond/template
@@ -1,15 +1,14 @@
 # Template file for 'lilypond'
 pkgname=lilypond
 # should be kept in sync with 'lilypond-doc'
-version=2.23.10
+version=2.23.80
 revision=1
 build_wrksrc="build"
 build_style="gnu-configure"
 configure_script="../configure"
-configure_args="--disable-documentation ac_cv_func_isinf=yes
- --with-texgyre-dir=/usr/share/texmf-dist/fonts/opentype/public/tex-gyre"
+configure_args="--disable-documentation ac_cv_func_isinf=yes"
 hostmakedepends="autogen automake bison flex fontforge gettext perl
- pkg-config python3 t1utils tar texinfo texlive"
+ pkg-config python3 t1utils tar texinfo texlive gsfonts"
 makedepends="gc-devel guile-devel libltdl-devel pango-devel"
 depends="ghostscript guile python3"
 checkdepends="ImageMagick rsync texi2html"
@@ -18,9 +17,9 @@ maintainer="newbluemoon <blaumolch@mailbox.org>"
 license="GPL-3.0-or-later, GFDL-1.3-or-later"
 homepage="https://lilypond.org/"
 distfiles="https://lilypond.org/downloads/sources/v2.23/lilypond-${version}.tar.gz"
-checksum=06ac963df1699598c62f4390b8fc95344a723a88af440c00f5201c4aa8958f68
+checksum=2b0c80d4ca73a7208eb593682a0cef79bae5ee86780f3c24b18c995c9264cff9
 python_version=3
-make_check=ci-skip # ci fails, but all checks pass locally
+make_check=ci-skip # ci sometimes fails, but all checks pass locally
 
 if [ -n "${CROSS_BUILD}" ]; then
 	makedepends+=" libfl-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - armv7l-musl
  - i686
  - aarch64

New font package urw-core35-fonts, because lilypond doesn’t bundle the required OTF fonts anymore and the URW++ ones are used in favour of the TeX Gyre fonts, see

https://git.savannah.gnu.org/cgit/lilypond.git/commit/?id=5689c2721530c6ded22b6291ebb06d10adb5bc28

There is no release, unfortunately, but I hope it is ok to make an exception in this case. :)

