### PR TITLE
nutty: devendor speedtest-cli.

### DIFF
--- a/srcpkgs/nutty/patches/use-system-speedtestcli.patch
+++ b/srcpkgs/nutty/patches/use-system-speedtestcli.patch
@@ -1,0 +1,27 @@
+nutty vendors an old and broken python2-only version of speedtest-cli.
+Since it is already packaged (and python3 already), we can rely on it instead.
+
+--
+
+--- a/src/nutty.vala
++++ b/src/nutty.vala
+@@ -1682,9 +1682,6 @@
+ 			speedtest_list_store.clear();
+ 			TreeIter iter;
+ 			if(shouldExecute){
+-				if(! COMMAND_FOR_SPEED_TEST[0].contains(Constants.NUTTY_SCRIPT_PATH)){
+-					COMMAND_FOR_SPEED_TEST[0] = Constants.NUTTY_SCRIPT_PATH+ "/" + COMMAND_FOR_SPEED_TEST[0];
+-				}
+ 				execute_sync_multiarg_command_pipes(COMMAND_FOR_SPEED_TEST);
+ 				//handle unsucessfull command execution and raise error on infobar
+ 				if(!Utils.isExpectedOutputPresent(
+--- a/data/scripts/meson.build
++++ b/data/scripts/meson.build
+@@ -23,7 +23,6 @@
+     'nutty_vnstat_script.sh',
+     'nutty_traceroute_script.sh',
+     'nutty_ports_script.sh',
+-    'speedtest-cli'
+ ]
+ foreach a_script : script_names
+     install_data(

--- a/srcpkgs/nutty/template
+++ b/srcpkgs/nutty/template
@@ -1,18 +1,18 @@
 # Template file for 'nutty'
 pkgname=nutty
 version=1.1.1
-revision=2
+revision=3
 build_style=meson
 hostmakedepends="pkg-config gettext vala glib-devel"
 makedepends="gtk+3-devel libgee08-devel libnotify-devel granite-devel
  sqlite-devel"
+depends="speedtest-cli"
 short_desc="Network Utility"
 maintainer="linarcx <linarcx@riseup.net>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/babluboy/nutty"
 distfiles="https://github.com/babluboy/nutty/archive/${version}.tar.gz"
 checksum=b6c9ef1966d1c60480943313f20cd66ee1b5d23ac8d6578f457fb99f0898d9ba
-python_version=2
 
 post_install() {
 	vinstall data/com.github.babluboy.nutty.desktop 644 usr/share/applications


### PR DESCRIPTION
Removes python2 remnants, see #38229

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


@LinArcX 
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
