### PR TITLE
fotoxx: update to 22.30.

### DIFF
--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -1,6 +1,6 @@
 # Template file for 'fotoxx'
 pkgname=fotoxx
-version=21.40
+version=22.30
 revision=1
 wrksrc=fotoxx
 build_style=gnu-makefile
@@ -9,11 +9,11 @@ hostmakedepends="pkg-config"
 makedepends="libchamplain-devel libraw-devel"
 depends="desktop-file-utils exiftool xdg-utils dcraw"
 short_desc="Free open source program for image editing and collection management"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.kornelix.net/fotoxx/fotoxx.html"
 distfiles="https://www.kornelix.net/downloads/downloads/fotoxx-${version}.tar.gz"
-checksum=0c16597053ce8e186fb8163839f4f4ed44548bf00e43e88951f4346a9dbbb620
+checksum=418e56bdb4fab90681495859a2c601ddf093a5b194f16e56fc697e256a722788
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/champlain-0.12"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
