### PR TITLE
ngspice: update to 37.

### DIFF
--- a/srcpkgs/ngspice/template
+++ b/srcpkgs/ngspice/template
@@ -1,7 +1,6 @@
 # Template file for 'ngspice'
-# WARNING: if the libngspice.so.x.y.z file changes name, revbump kicad
 pkgname=ngspice
-version=35
+version=37
 revision=1
 build_style=gnu-configure
 configure_args="--enable-xspice --enable-cider"
@@ -11,9 +10,10 @@ checkdepends="perl"
 short_desc="Mixed Mode Mixed Level Circuit Simulator based on Spice3F5"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="BSD-3-Clause"
-homepage="http://ngspice.sourceforge.net"
+homepage="https://ngspice.sourceforge.io"
+changelog="https://sourceforge.net/p/ngspice/ngspice/ci/master/tree/NEWS?format=raw"
 distfiles="${SOURCEFORGE_SITE}/ngspice/ng-spice-rework/${version}/${pkgname}-${version}.tar.gz"
-checksum=c1b7f5c276db579acb3f0a7afb64afdeb4362289a6cab502d4ca302d6e5279ec
+checksum=9beea6741a36a36a70f3152a36c82b728ee124c59a495312796376b30c8becbe
 
 # ngshared binary and shared library can't be built in the same pass
 # --ngshared builds the shared library, and readline should only be enabled for the binary


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

I **_think_** that the current version of kicad can handle the versioned libngspice object better now.  Here is the relevant [commit](https://gitlab.com/kicad/code/kicad/-/commit/b2fbf982a8c32d810dcfcf69b391e118217974f4) and [issue](https://gitlab.com/kicad/code/kicad/-/issues/8878) from kicad upstream  @ericonr, would you be able to verify?

 
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
