### PR TITLE
samba: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/samba/patches/fix-glibc-2.36.patch
+++ b/srcpkgs/samba/patches/fix-glibc-2.36.patch
@@ -1,0 +1,59 @@
+From 766151bf5b7ef95ae4c8c98b8994e5c21c5bbec0 Mon Sep 17 00:00:00 2001
+From: Andreas Schneider <asn@samba.org>
+Date: Tue, 2 Aug 2022 07:55:46 +0200
+Subject: [PATCH] lib:replace: Only include <sys/mount.h> on non-Linux systems
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Details at:
+https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
+
+BUG: https://bugzilla.samba.org/show_bug.cgi?id=15132
+
+Signed-off-by: Andreas Schneider <asn@samba.org>
+Reviewed-by: Ralph Boehme <slow@samba.org>
+
+Autobuild-User(master): Ralph Böhme <slow@samba.org>
+Autobuild-Date(master): Tue Aug  2 11:05:14 UTC 2022 on sn-devel-184
+---
+ lib/replace/system/filesys.h | 4 +++-
+ lib/replace/wscript          | 3 +++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lib/replace/system/filesys.h b/lib/replace/system/filesys.h
+index 034e5d5886c..bb9482c69af 100644
+--- a/lib/replace/system/filesys.h
++++ b/lib/replace/system/filesys.h
+@@ -36,7 +36,8 @@
+ #include <sys/param.h>
+ #endif
+ 
+-#ifdef HAVE_SYS_MOUNT_H
++/* This include is required on UNIX (*BSD, AIX, ...) for statfs() */
++#if !defined(LINUX) && defined(HAVE_SYS_MOUNT_H)
+ #include <sys/mount.h>
+ #endif
+ 
+@@ -44,6 +45,7 @@
+ #include <mntent.h>
+ #endif
+ 
++/* This include is required on Linux for statfs() */
+ #ifdef HAVE_SYS_VFS_H
+ #include <sys/vfs.h>
+ #endif
+diff --git a/lib/replace/wscript b/lib/replace/wscript
+index 4c774d9f0c3..dd9b19219a1 100644
+--- a/lib/replace/wscript
++++ b/lib/replace/wscript
+@@ -31,6 +31,9 @@ def configure(conf):
+ 
+     conf.env.standalone_replace = conf.IN_LAUNCH_DIR()
+ 
++    if sys.platform.rfind('linux') > -1:
++        conf.DEFINE('LINUX', '1')
++
+     conf.DEFINE('BOOL_DEFINED', 1)
+     conf.DEFINE('HAVE_LIBREPLACE', 1)
+     conf.DEFINE('LIBREPLACE_NETWORK_CHECKS', 1)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
