### PR TITLE
pex: update to 2.1.103.

### DIFF
--- a/srcpkgs/pex/template
+++ b/srcpkgs/pex/template
@@ -1,18 +1,17 @@
 # Template file for 'pex'
 pkgname=pex
-version=2.1.15
-revision=3
-wrksrc="pex-${version}"
-build_style=python3-module
-hostmakedepends="python3-setuptools python3-Sphinx"
-depends="python3-setuptools"
+version=2.1.103
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-flit_core python3-Sphinx"
+depends="python3"
 short_desc="Library & tool for generating .pex (Python EXecutable) files"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="Apache-2.0"
 homepage="https://github.com/pantsbuild/pex"
-changelog="https://raw.githubusercontent.com/pantsbuild/pex/master/CHANGES.rst"
+changelog="https://raw.githubusercontent.com/pantsbuild/pex/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/p/pex/pex-${version}.tar.gz"
-checksum=e1092ae52cfdef41c22d98fa98f9225ac21936a7d096131777ca3a7940fe1b2d
+checksum=07bcd633626b7fd6d18eb0d6303acfd0a4fbcb31692e737b15794626da896bf0
 
 post_build() {
 	PYTHONPATH="$PWD" make -C docs man


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

This template effectively enforces `make_check=no` since this has `build_style=python3-pep517` with no explicit `checkdepends`. Running the tests as is requires [bootstrapping different python interpreters](https://github.com/pantsbuild/pex/blob/v2.1.103/pex/testing.py#L453-L459) by building them from source via `pyenv`. I couldn't figure out if there's a way to run the tests only with system installed python. Instead I installed it and run the commands mentioned in their quick start guide which seem to work as intended.