### PR TITLE
rofi: update to 1.7.4.

### DIFF
--- a/srcpkgs/rofi/template
+++ b/srcpkgs/rofi/template
@@ -1,6 +1,6 @@
 # Template file for 'rofi'
 pkgname=rofi
-version=1.7.3
+version=1.7.4
 revision=1
 build_style=gnu-configure
 hostmakedepends="autoconf automake flex glib-devel pkg-config which"
@@ -8,11 +8,11 @@ makedepends="libXinerama-devel librsvg-devel
  libxkbcommon-devel pango-devel startup-notification-devel
  xcb-util-wm-devel xcb-util-xrm-devel xcb-util-cursor-devel"
 short_desc="Window switcher, run dialog and dmenu replacement"
-maintainer="Dave Davenport <qball@gmpclient.org>"
+maintainer="classabbyamp <void@placeviolette.net>"
 license="MIT"
 homepage="https://github.com/davatorium/rofi"
 distfiles="https://github.com/davatorium/rofi/releases/download/${version}/rofi-${version}.tar.xz"
-checksum=25868b68ff98338c5421211fa2f8286f9c5b6f900b4bfb7c99e0fe64eb4db67b
+checksum=1922e7dec6d591335384e4b14e94e592d96be1e4ff07f1506e9c3c367da62cdf
 
 if [ "$XBPS_CHECK_PKGS" ]; then
 	makedepends+=" check-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc


Adding @classabbyamp as the maintainer of the package as talked about in the irc ( current maintainer= of rofi is the upstream dev, who hasn't touched it since 2015)