### PR TITLE
New package: tlpui-1.5.0.5

### DIFF
--- a/srcpkgs/tlpui/template
+++ b/srcpkgs/tlpui/template
@@ -1,0 +1,15 @@
+# Template file for 'tlpui'
+pkgname=tlpui
+version=1.5.0+5
+revision=1
+wrksrc="TLPUI-${pkgname}-${version/+/-}"
+build_style="python3-module"
+hostmakedepends="python3-setuptools"
+depends="gtk+3 tlp python3-gobject"
+short_desc="GTK user interface for TLP"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/d4nj1/TLPUI"
+distfiles="https://github.com/d4nj1/TLPUI/archive/refs/tags/tlpui-${version/+/-}.tar.gz"
+checksum=563794d142acb79d5654aca70af52c5e8da4cf9677e5058d151474d0af47ea77
+make_check=no #tests fail inside chroot


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

There is an already open PR with these package #36982  but the creator of that pr doesn't seem to respond ,,, So opening this since I use the app and want it to be on the main repos. 

make_check=no, since the tests seem to fail on my machine (on chroot `./xbps-src pkg -Q tlpui` with: 

> (setup.py:10388): Gdk-WARNING **: 18:09:04.398: Native Windows wider or taller than 32767 pixels are not supported

And seems to run forever.