### PR TITLE
 busybox: add patches for CVE-2022-28391

### DIFF
--- a/srcpkgs/busybox/patches/0001-libbb-sockaddr2str-ensure-only-printable-characters-.patch
+++ b/srcpkgs/busybox/patches/0001-libbb-sockaddr2str-ensure-only-printable-characters-.patch
@@ -1,0 +1,40 @@
+From 0c8da1bead8ffaf270b4b723ead2c517371405d7 Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Sun, 3 Apr 2022 12:14:33 +0000
+Subject: [PATCH 1/2] libbb: sockaddr2str: ensure only printable characters are
+ returned for the hostname part
+
+CVE: Pending
+Upstream-Status: Pending
+Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>
+---
+ libbb/xconnect.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/libbb/xconnect.c b/libbb/xconnect.c
+index 0e0b247b8..02c061e67 100644
+--- a/libbb/xconnect.c
++++ b/libbb/xconnect.c
+@@ -497,8 +497,9 @@ static char* FAST_FUNC sockaddr2str(const struct sockaddr *sa, int flags)
+ 	);
+ 	if (rc)
+ 		return NULL;
++	/* ensure host contains only printable characters */
+ 	if (flags & IGNORE_PORT)
+-		return xstrdup(host);
++		return xstrdup(printable_string(host));
+ #if ENABLE_FEATURE_IPV6
+ 	if (sa->sa_family == AF_INET6) {
+ 		if (strchr(host, ':')) /* heh, it's not a resolved hostname */
+@@ -509,7 +510,7 @@ static char* FAST_FUNC sockaddr2str(const struct sockaddr *sa, int flags)
+ #endif
+ 	/* For now we don't support anything else, so it has to be INET */
+ 	/*if (sa->sa_family == AF_INET)*/
+-		return xasprintf("%s:%s", host, serv);
++		return xasprintf("%s:%s", printable_string(host), serv);
+ 	/*return xstrdup(host);*/
+ }
+ 
+-- 
+2.35.1
+

--- a/srcpkgs/busybox/patches/0002-nslookup-sanitize-all-printed-strings-with-printable.patch
+++ b/srcpkgs/busybox/patches/0002-nslookup-sanitize-all-printed-strings-with-printable.patch
@@ -1,0 +1,67 @@
+From 812b407e545b70b16cf32aade135b5c32eaf674f Mon Sep 17 00:00:00 2001
+From: Ariadne Conill <ariadne@dereferenced.org>
+Date: Sun, 3 Apr 2022 12:16:45 +0000
+Subject: [PATCH 2/2] nslookup: sanitize all printed strings with
+ printable_string
+
+Otherwise, terminal sequences can be injected, which enables various terminal injection
+attacks from DNS results.
+
+CVE: Pending
+Upstream-Status: Pending
+Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>
+---
+ networking/nslookup.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/networking/nslookup.c b/networking/nslookup.c
+index 6da97baf4..4bdcde1b8 100644
+--- a/networking/nslookup.c
++++ b/networking/nslookup.c
+@@ -407,7 +407,7 @@ static NOINLINE int parse_reply(const unsigned char *msg, size_t len)
+ 				//printf("Unable to uncompress domain: %s\n", strerror(errno));
+ 				return -1;
+ 			}
+-			printf(format, ns_rr_name(rr), dname);
++			printf(format, ns_rr_name(rr), printable_string(dname));
+ 			break;
+ 
+ 		case ns_t_mx:
+@@ -422,7 +422,7 @@ static NOINLINE int parse_reply(const unsigned char *msg, size_t len)
+ 				//printf("Cannot uncompress MX domain: %s\n", strerror(errno));
+ 				return -1;
+ 			}
+-			printf("%s\tmail exchanger = %d %s\n", ns_rr_name(rr), n, dname);
++			printf("%s\tmail exchanger = %d %s\n", ns_rr_name(rr), n, printable_string(dname));
+ 			break;
+ 
+ 		case ns_t_txt:
+@@ -434,7 +434,7 @@ static NOINLINE int parse_reply(const unsigned char *msg, size_t len)
+ 			if (n > 0) {
+ 				memset(dname, 0, sizeof(dname));
+ 				memcpy(dname, ns_rr_rdata(rr) + 1, n);
+-				printf("%s\ttext = \"%s\"\n", ns_rr_name(rr), dname);
++				printf("%s\ttext = \"%s\"\n", ns_rr_name(rr), printable_string(dname));
+ 			}
+ 			break;
+ 
+@@ -454,7 +454,7 @@ static NOINLINE int parse_reply(const unsigned char *msg, size_t len)
+ 			}
+ 
+ 			printf("%s\tservice = %u %u %u %s\n", ns_rr_name(rr),
+-				ns_get16(cp), ns_get16(cp + 2), ns_get16(cp + 4), dname);
++				ns_get16(cp), ns_get16(cp + 2), ns_get16(cp + 4), printable_string(dname));
+ 			break;
+ 
+ 		case ns_t_soa:
+@@ -483,7 +483,7 @@ static NOINLINE int parse_reply(const unsigned char *msg, size_t len)
+ 				return -1;
+ 			}
+ 
+-			printf("\tmail addr = %s\n", dname);
++			printf("\tmail addr = %s\n", printable_string(dname));
+ 			cp += n;
+ 
+ 			printf("\tserial = %lu\n", ns_get32(cp));
+-- 
+2.35.1

--- a/srcpkgs/busybox/template
+++ b/srcpkgs/busybox/template
@@ -1,7 +1,7 @@
 # Template file for 'busybox'
 pkgname=busybox
 version=1.34.1
-revision=1
+revision=2
 hostmakedepends="perl"
 checkdepends="tar which zip"
 short_desc="Swiss Army Knife of Embedded Linux"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
- This two patches are not upstream, made by Alpine Linux Team, but they are reported in https://bugs.busybox.net/show_bug.cgi?id=14811
- Source: https://git.alpinelinux.org/aports/plain/main/busybox/0002-nslookup-sanitize-all-printed-strings-with-printable.patch
- Source:  https://git.alpinelinux.org/aports/plain/main/busybox/0001-libbb-sockaddr2str-ensure-only-printable-characters-.patch
- Check CVE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28391
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
