### PR TITLE
backport meson patch to set lxc-user-nic suid bit

### DIFF
--- a/srcpkgs/lxc/patches/01-meson-docbook2x.patch
+++ b/srcpkgs/lxc/patches/01-meson-docbook2x.patch
@@ -1,49 +1,45 @@
-commit d91b4a300017bdcfbea8d013f05369ebba9a3d1e
+commit 06f99c2599db8140bd839532caa8f6ee0d1c3ff6
 Author: Cameron Nemo <cam@nohom.org>
-Date:   Sun Aug 7 11:10:31 2022 -0700
+Date:   Tue Aug 16 20:30:39 2022 -0700
 
-    meson: add option to force docbook2x format
+    meson: fix docbook2x detection
     
-    Some distros ship docbook2x as docbook2man, which perplexes the logic in
-    the meson.build that chooses the "docdtd" value.
-    
-    Add a build option to always use the newer docbook2x docdtd value.
+    docbook2man can sometimes be docbook2x and other times be docbook-utils.
+    Rather than compare paths, use version constraints to detect version.
     
     Signed-off-by: Cameron Nemo <cam@nohom.org>
 
 diff --git a/meson.build b/meson.build
-index a145faf06..9c0e6e488 100644
+index 666824c5a..2b160d4ac 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -135,6 +135,7 @@ cgrouppattern = get_option('cgroup-pattern')
- coverity = get_option('coverity-build')
- init_script = get_option('init-script')
- sanitize = get_option('b_sanitize')
-+docbook2x_only = get_option('docbook2x-only')
- want_examples = get_option('examples')
- want_io_uring = get_option('io-uring-event-loop')
- want_pam_cgroup = get_option('pam-cgroup')
-@@ -337,7 +338,7 @@ docconf.set('LXCTEMPLATEDIR', lxctemplatedir)
+@@ -324,9 +324,6 @@ endif
+ generate_date = run_command(date, '--utc', '--date=@' + time_epoch, '+%Y-%m-%d', check: true).stdout().strip()
+ 
+ ## Manpages.
+-sgml2man = find_program('docbook2X2man', 'docbook2x-man', 'db2x_docbook2man', 'docbook2man', 'docbook-to-man', required: want_mans)
+-docbook2man = find_program('docbook2man', required: false)
+-
+ docconf = configuration_data()
+ docconf.set('builddir', '.')
+ docconf.set('BINDIR', bindir)
+@@ -341,10 +338,15 @@ docconf.set('LXCTEMPLATEDIR', lxctemplatedir)
  docconf.set('LXC_USERNIC_CONF', lxc_user_network_conf)
  docconf.set('LXC_USERNIC_DB', lxc_user_network_db)
  docconf.set('PACKAGE_VERSION', version_data.get('LXC_VERSION'))
 -if sgml2man.found() and docbook2man.found() and sgml2man.full_path() == docbook2man.full_path()
-+if sgml2man.found() and docbook2man.found() and sgml2man.full_path() == docbook2man.full_path() and not docbook2x_only
-     docconf.set('docdtd', '"-//Davenport//DTD DocBook V3.0//EN"')
- else
-     docconf.set('docdtd', '"-//OASIS//DTD DocBook XML" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"')
-diff --git a/meson_options.txt b/meson_options.txt
-index c14dacf27..ccc4dde5d 100644
---- a/meson_options.txt
-+++ b/meson_options.txt
-@@ -9,6 +9,10 @@ option('cgroup-pattern', type: 'string', value: '',
- option('coverity-build', type: 'boolean', value: 'true',
-        description: 'build for coverity')
+-    docconf.set('docdtd', '"-//Davenport//DTD DocBook V3.0//EN"')
+-else
+-    docconf.set('docdtd', '"-//OASIS//DTD DocBook XML" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"')
++docconf.set('docdtd', '"-//OASIS//DTD DocBook XML" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"')
++sgml2man = find_program('docbook2X2man', 'docbook2x-man', 'db2x_docbook2man', 'docbook2man', 'docbook-to-man', required: false, version: '>=0.8')
++if not sgml2man.found()
++    sgml2man = find_program('docbook2man', required: false, version: '<0.8')
++    if sgml2man.found()
++        docconf.set('docdtd', '"-//Davenport//DTD DocBook V3.0//EN"')
++    elif want_mans
++        error('missing required docbook2x or docbook-utils dependency')
++    endif
+ endif
  
-+# no configure equivalent
-+option('docbook2x-only', type: 'boolean', value: 'false',
-+       description: 'always use DocBook 2x format')
-+
- # was --{disable,enable}-examples in autotools
- option('examples', type: 'boolean', value: 'true',
-        description: 'build and install examples')
+ ## Threads.

--- a/srcpkgs/lxc/template
+++ b/srcpkgs/lxc/template
@@ -1,11 +1,11 @@
 # Template file for 'lxc'
 pkgname=lxc
 version=5.0.1
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dpam-cgroup=true -Drootfs-mount-path=/var/lxc/containers
  -Ddistrosysconfdir=default
- -Dlog-path=/var/lxc/log -Dinit-script=[] -Ddocbook2x-only=true"
+ -Dlog-path=/var/lxc/log -Dinit-script=[]"
 hostmakedepends="pkg-config docbook2x"
 makedepends="libcap-devel libseccomp-devel openssl-devel libapparmor-devel
  pam-devel"

--- a/srcpkgs/meson/patches/10702.patch
+++ b/srcpkgs/meson/patches/10702.patch
@@ -1,0 +1,59 @@
+From 869b95d0c2a854d73db0fceb7d0dbee9dc88cf46 Mon Sep 17 00:00:00 2001
+From: Eli Schwartz <eschwartz@archlinux.org>
+Date: Tue, 16 Aug 2022 22:42:53 -0400
+Subject: [PATCH] minstall: do not trample install_mode by rpath fixer
+
+install_mode can include the setuid bit, which has the special property
+(mentioned in the set_mode logic for minstall itself) of needing to come
+last, because it "will get wiped by chmod" (or at least chown).
+
+In fact, it's not just chown that wipes setuid, but other changes as
+well, such as the file contents. This is not an issue for install_data /
+custom_target, but for compiled outputs, we run depfixer to handle
+rpaths. This may or may not cause edits to the binary, depending on
+whether we have a build rpath to wipe, or an install rpath to add. (We
+also may run `strip`, but that external program already has its own mode
+restoration logic.)
+
+Fix this by switching the order of operations around, so that setting
+the permissions happens last.
+
+Fixes https://github.com/void-linux/void-packages/issues/38682
+---
+ mesonbuild/minstall.py                         | 3 ++-
+ test cases/common/190 install_mode/meson.build | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/mesonbuild/minstall.py b/mesonbuild/minstall.py
+index 551f909c80d..a810ccbbd40 100644
+--- a/mesonbuild/minstall.py
++++ b/mesonbuild/minstall.py
+@@ -693,7 +693,6 @@ def install_targets(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix
+                 raise MesonException(f'File {fname!r} could not be found')
+             elif os.path.isfile(fname):
+                 file_copied = self.do_copyfile(fname, outname, makedirs=(dm, outdir))
+-                self.set_mode(outname, install_mode, d.install_umask)
+                 if should_strip and d.strip_bin is not None:
+                     if fname.endswith('.jar'):
+                         self.log('Not stripping jar target: {}'.format(os.path.basename(fname)))
+@@ -723,6 +722,8 @@ def install_targets(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix
+                         pass
+                     else:
+                         raise
++                # file mode needs to be set last, after strip/depfixer editing
++                self.set_mode(outname, install_mode, d.install_umask)
+ 
+ def rebuild_all(wd: str) -> bool:
+     if not (Path(wd) / 'build.ninja').is_file():
+diff --git a/test cases/common/190 install_mode/meson.build b/test cases/common/190 install_mode/meson.build
+index cae1e91aba3..e877ba75757 100644
+--- a/test cases/common/190 install_mode/meson.build	
++++ b/test cases/common/190 install_mode/meson.build	
+@@ -51,6 +51,7 @@ install_man('foo.1',
+ executable('trivialprog',
+   sources : 'trivial.c',
+   install : true,
++  build_rpath: meson.current_build_dir(),
+   install_mode : ['rwxr-sr-x', 'root', 'root'])
+ 
+ # test install_mode in static_library

--- a/srcpkgs/meson/template
+++ b/srcpkgs/meson/template
@@ -1,7 +1,7 @@
 # Template file for 'meson'
 pkgname=meson
 version=0.62.2
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
 depends="ninja python3-setuptools"


### PR DESCRIPTION
Switch to meson had a small casualty.
Rebuild with patched meson.
Also simplify the docbook2x patch.

https://github.com/mesonbuild/meson/pull/10702
https://github.com/lxc/lxc/pull/4177

Closes #38682

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
