### PR TITLE
boinc-nox: Add the boinc user to boinc-nox

### DIFF
--- a/srcpkgs/boinc/template
+++ b/srcpkgs/boinc/template
@@ -1,7 +1,7 @@
 # Template file for 'boinc'
 pkgname=boinc
 version=7.16.20
-revision=1
+revision=2
 _majorver=${version%.*}
 wrksrc=boinc-client_release-${_majorver}-${version}
 build_style=gnu-configure
@@ -129,6 +129,9 @@ boinc-devel_package() {
 boinc-nox_package() {
 	short_desc+=" - no X"
 	conflicts="boinc>=0"
+	system_accounts="boinc"
+	boinc_homedir="/var/lib/boinc"
+	boinc_shell="/bin/bash"
 	pkg_install() {
 		cd ${wrksrc}/nox
 		make ${makejobs} DESTDIR=${PKGDESTDIR} install


### PR DESCRIPTION
The `boinc` user is created for the boinc package, but not for boinc-nox which breaks it.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**