### PR TITLE
python3-jaraco.functools: update to 3.5.1.

### DIFF
--- a/srcpkgs/python3-jaraco.functools/template
+++ b/srcpkgs/python3-jaraco.functools/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-jaraco.functools'
 pkgname=python3-jaraco.functools
-version=3.5.0
+version=3.5.1
 revision=1
 wrksrc="jaraco.functools-${version}"
 build_style=python3-pep517
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/jaraco/jaraco.functools"
 changelog="https://raw.githubusercontent.com/jaraco/jaraco.functools/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/j/jaraco.functools/jaraco.functools-${version}.tar.gz"
-checksum=31e0e93d1027592b7b0bec6ad468db850338981ebee76ba5e212e235f4c7dda0
+checksum=d0adcf91710a0853efe9f23a78fad586bf67df572f0d6d8e0fa36d289ae1c1d9
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64