### PR TITLE
prometheus: update to 2.38.0.

### DIFF
--- a/srcpkgs/prometheus/template
+++ b/srcpkgs/prometheus/template
@@ -1,6 +1,6 @@
 # Template file for 'prometheus'
 pkgname=prometheus
-version=2.33.1
+version=2.38.0
 revision=1
 build_style=go
 go_import_path="github.com/prometheus/prometheus"
@@ -18,14 +18,14 @@ license="Apache-2.0"
 homepage="https://prometheus.io/"
 changelog="https://raw.githubusercontent.com/prometheus/prometheus/master/CHANGELOG.md"
 distfiles="https://github.com/prometheus/prometheus/archive/v${version}.tar.gz"
-checksum=a3ec7bde701b0663e706c718ea58722544c4a3bbb902d89cf64d3b7f34523ad5
+checksum=311f9f2f867ee0f2bef5c8227bbf672edf4037b6fd5e036c45ed7e947d61c375
 
 system_accounts="_prometheus"
 
 make_dirs="/var/lib/prometheus 700 _prometheus _prometheus"
 
 pre_build() {
-	CGO_ENABLED=0 GOARCH= make assets
+	CGO_ENABLED=0 GOARCH= make assets assets-compress
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
