### PR TITLE
qemu: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/qemu/patches/fix-compat-glibc-2.36.patch
+++ b/srcpkgs/qemu/patches/fix-compat-glibc-2.36.patch
@@ -1,0 +1,100 @@
+From 3cd3df2a9584e6f753bb62a0028bd67124ab5532 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20P=2E=20Berrang=C3=A9?= <berrange@redhat.com>
+Date: Tue, 2 Aug 2022 12:41:34 -0400
+Subject: [PATCH] linux-user: fix compat with glibc >= 2.36 sys/mount.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The latest glibc 2.36 has extended sys/mount.h so that it
+defines the FSCONFIG_* enum constants. These are historically
+defined in linux/mount.h, and thus if you include both headers
+the compiler complains:
+
+In file included from /usr/include/linux/fs.h:19,
+                 from ../linux-user/syscall.c:98:
+/usr/include/linux/mount.h:95:6: error: redeclaration of 'enum fsconfig_command'
+   95 | enum fsconfig_command {
+      |      ^~~~~~~~~~~~~~~~
+In file included from ../linux-user/syscall.c:31:
+/usr/include/sys/mount.h:189:6: note: originally defined here
+  189 | enum fsconfig_command
+      |      ^~~~~~~~~~~~~~~~
+/usr/include/linux/mount.h:96:9: error: redeclaration of enumerator 'FSCONFIG_SET_FLAG'
+   96 |         FSCONFIG_SET_FLAG       = 0,    /* Set parameter, supplying no value */
+      |         ^~~~~~~~~~~~~~~~~
+/usr/include/sys/mount.h:191:3: note: previous definition of 'FSCONFIG_SET_FLAG' with type 'enum fsconfig_command'
+  191 |   FSCONFIG_SET_FLAG       = 0,    /* Set parameter, supplying no value */
+      |   ^~~~~~~~~~~~~~~~~
+...snip...
+
+QEMU doesn't include linux/mount.h, but it does use
+linux/fs.h and thus gets linux/mount.h indirectly.
+
+glibc acknowledges this problem but does not appear to
+be intending to fix it in the forseeable future, simply
+documenting it as a known incompatibility with no
+workaround:
+
+  https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
+  https://sourceware.org/glibc/wiki/Synchronizing_Headers
+
+To address this requires either removing use of sys/mount.h
+or linux/fs.h, despite QEMU needing declarations from
+both.
+
+This patch removes linux/fs.h, meaning we have to define
+various FS_IOC constants that are now unavailable.
+
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+Tested-by: Richard W.M. Jones <rjones@redhat.com>
+Message-Id: <20220802164134.1851910-1-berrange@redhat.com>
+Signed-off-by: Laurent Vivier <laurent@vivier.eu>
+---
+ linux-user/syscall.c | 18 ++++++++++++++++++
+ meson.build          |  2 ++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index ef53feb5ab45..f4091212027c 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -95,7 +95,25 @@
+ #include <linux/soundcard.h>
+ #include <linux/kd.h>
+ #include <linux/mtio.h>
++
++#ifdef HAVE_SYS_MOUNT_FSCONFIG
++/*
++ * glibc >= 2.36 linux/mount.h conflicts with sys/mount.h,
++ * which in turn prevents use of linux/fs.h. So we have to
++ * define the constants ourselves for now.
++ */
++#define FS_IOC_GETFLAGS                _IOR('f', 1, long)
++#define FS_IOC_SETFLAGS                _IOW('f', 2, long)
++#define FS_IOC_GETVERSION              _IOR('v', 1, long)
++#define FS_IOC_SETVERSION              _IOW('v', 2, long)
++#define FS_IOC_FIEMAP                  _IOWR('f', 11, struct fiemap)
++#define FS_IOC32_GETFLAGS              _IOR('f', 1, int)
++#define FS_IOC32_SETFLAGS              _IOW('f', 2, int)
++#define FS_IOC32_GETVERSION            _IOR('v', 1, int)
++#define FS_IOC32_SETVERSION            _IOW('v', 2, int)
++#else
+ #include <linux/fs.h>
++#endif
+ #include <linux/fd.h>
+ #if defined(CONFIG_FIEMAP)
+ #include <linux/fiemap.h>
+diff --git a/meson.build b/meson.build
+index 294e9a8f329e..30a380752c0d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1963,6 +1963,8 @@ config_host_data.set('HAVE_OPTRESET',
+                      cc.has_header_symbol('getopt.h', 'optreset'))
+ config_host_data.set('HAVE_IPPROTO_MPTCP',
+                      cc.has_header_symbol('netinet/in.h', 'IPPROTO_MPTCP'))
++config_host_data.set('HAVE_SYS_MOUNT_FSCONFIG',
++                     cc.has_header_symbol('sys/mount.h', 'FSCONFIG_SET_FLAG'))
+ 
+ # has_member
+ config_host_data.set('HAVE_SIGEV_NOTIFY_THREAD_ID',


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
