### PR TITLE
ntp: fix build with glibc 2.34

### DIFF
--- a/srcpkgs/ntp/patches/compat-glibc-2.34.patch
+++ b/srcpkgs/ntp/patches/compat-glibc-2.34.patch
@@ -1,0 +1,55 @@
+diff -Nru a/libntp/work_thread.c b/libntp/work_thread.c
+--- a/libntp/work_thread.c	2022-01-16 11:35:17.290791372 +0100
++++ b/libntp/work_thread.c	2022-01-16 11:35:17.290791372 +0100
+@@ -41,20 +41,10 @@
+ #ifndef THREAD_MINSTACKSIZE
+ # define THREAD_MINSTACKSIZE	(64U * 1024)
+ #endif
+-#ifndef __sun
+-#if defined(PTHREAD_STACK_MIN) && THREAD_MINSTACKSIZE < PTHREAD_STACK_MIN
+-# undef THREAD_MINSTACKSIZE
+-# define THREAD_MINSTACKSIZE PTHREAD_STACK_MIN
+-#endif
+-#endif
+ 
+ #ifndef THREAD_MAXSTACKSIZE
+ # define THREAD_MAXSTACKSIZE	(256U * 1024)
+ #endif
+-#if THREAD_MAXSTACKSIZE < THREAD_MINSTACKSIZE
+-# undef  THREAD_MAXSTACKSIZE
+-# define THREAD_MAXSTACKSIZE THREAD_MINSTACKSIZE
+-#endif
+ 
+ /* need a good integer to store a pointer... */
+ #ifndef UINTPTR_T
+@@ -594,12 +584,25 @@
+ 			"start_blocking_thread: pthread_attr_getstacksize() -> %s",
+ 			strerror(rc));
+ 	} else {
+-		if (ostacksize < THREAD_MINSTACKSIZE)
+-			nstacksize = THREAD_MINSTACKSIZE;
+-		else if (ostacksize > THREAD_MAXSTACKSIZE)
++		nstacksize = ostacksize;
++		/* order is important here: first clamp on upper limit,
++		 * and the PTHREAD min stack size is ultimate override!
++		 */ 
++		if (nstacksize > THREAD_MAXSTACKSIZE)
+ 			nstacksize = THREAD_MAXSTACKSIZE;
+-		else
+-			nstacksize = ostacksize;
++#            ifdef PTHREAD_STACK_MAX
++		if (nstacksize > PTHREAD_STACK_MAX)
++			nstacksize = PTHREAD_STACK_MAX;
++#            endif
++
++		/* now clamp on lower stack limit. */
++		if (nstacksize < THREAD_MINSTACKSIZE)
++			nstacksize = THREAD_MINSTACKSIZE;
++#            ifdef PTHREAD_STACK_MIN
++		if (nstacksize < PTHREAD_STACK_MIN)
++			nstacksize = PTHREAD_STACK_MIN;
++#            endif
++
+ 		if (nstacksize != ostacksize)
+ 			rc = pthread_attr_setstacksize(&thr_attr, nstacksize);
+ 		if (0 != rc)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

https://bugs.ntp.org/show_bug.cgi?id=3741

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
