### PR TITLE
libarchive: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/libarchive/patches/fix-build-glibc-2.36.patch
+++ b/srcpkgs/libarchive/patches/fix-build-glibc-2.36.patch
@@ -1,0 +1,41 @@
+From a2f68263a1da5ad227bcb9cd8fa91b93c8b6c99f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 25 Jul 2022 10:56:53 -0700
+Subject: [PATCH] libarchive: Do not include sys/mount.h when linux/fs.h is
+ present
+
+These headers are in conflict and only one is needed by
+archive_read_disk_posix.c therefore include linux/fs.h if it exists
+otherwise include sys/mount.h
+
+It also helps compiling with glibc 2.36
+where sys/mount.h conflicts with linux/mount.h see [1]
+
+[1] https://sourceware.org/glibc/wiki/Release/2.36
+---
+ libarchive/archive_read_disk_posix.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/libarchive/archive_read_disk_posix.c b/libarchive/archive_read_disk_posix.c
+index 2b39e672b..a96008db7 100644
+--- a/libarchive/archive_read_disk_posix.c
++++ b/libarchive/archive_read_disk_posix.c
+@@ -34,9 +34,6 @@ __FBSDID("$FreeBSD$");
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif
+-#ifdef HAVE_SYS_MOUNT_H
+-#include <sys/mount.h>
+-#endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
+@@ -54,6 +51,8 @@ __FBSDID("$FreeBSD$");
+ #endif
+ #ifdef HAVE_LINUX_FS_H
+ #include <linux/fs.h>
++#elif HAVE_SYS_MOUNT_H
++#include <sys/mount.h>
+ #endif
+ /*
+  * Some Linux distributions have both linux/ext2_fs.h and ext2fs/ext2_fs.h.


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
