### PR TITLE
gopass: update to 1.14.4.

### DIFF
--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,20 +1,20 @@
 # Template file for 'gopass'
 pkgname=gopass
-version=1.13.0
+version=1.14.4
 revision=1
 build_style=go
 build_helper=qemu
 go_import_path=github.com/gopasspw/gopass
 go_package="${go_import_path} ${go_import_path}/cmd/..."
 makedepends="gnupg2"
-depends="gnupg2 git"
+depends="gnupg2 git age"
 short_desc="Slightly more awesome standard unix password manager for teams"
 maintainer="Felipe Nogueira <contato.fnog@gmail.com>"
 license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/v${version}.tar.gz"
-checksum=785ef96a0519a0d91a524036dc982f8e6ee00e6841a7b4faf4c504368cff7d31
+checksum=6b78a76d82a3eade600c8f2e83ff53d2d369d6e218b3560d518ba61fbc33221a
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

bumping the version to keep it up to date with upstream, 1.13.0 was released November 2021.