### PR TITLE
schroot: update to 1.6.10-12+deb11u1. CVE-2022-2787

### DIFF
--- a/srcpkgs/schroot/patches/musl.patch
+++ b/srcpkgs/schroot/patches/musl.patch
@@ -1,25 +1,30 @@
-From 73936a423227aa78b7682bdd3edc20643763807b Mon Sep 17 00:00:00 2001
-From: Andrea Brancaleoni <abc@pompel.me>
-Date: Wed, 19 Sep 2018 11:22:47 +0200
-Subject: [PATCH] musl
-
----
- sbuild/sbuild-feature.cc | 2 ++
- 1 file changed, 2 insertions(+)
-
-diff --git sbuild/sbuild-feature.cc sbuild/sbuild-feature.cc
-index 5ac4725..9902db3 100644
+--- a/sbuild/sbuild-auth-pam.cc
++++ b/sbuild/sbuild-auth-pam.cc
+@@ -21,6 +21,7 @@
+ #include "sbuild-auth-pam.h"
+ #include "sbuild-auth-pam-conv.h"
+ #include "sbuild-feature.h"
++#include "sbuild-i18n.h"
+ 
+ #include <cassert>
+ #include <cerrno>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -176,7 +176,7 @@ if(GETTEXT_FOUND)
+ endif(GETTEXT_FOUND)
+ option(nls "Enable national language support (requires gettext)" ${NLS_DEFAULT})
+ set(BUILD_NLS ${nls})
+-set(SBUILD_FEATURE_NLS ${pam})
++set(SBUILD_FEATURE_NLS ${nls})
+ 
+ # UUID generation
+ check_include_file_cxx(uuid/uuid.h UUID_HEADER)
 --- a/sbuild/sbuild-feature.cc
 +++ b/sbuild/sbuild-feature.cc
-@@ -20,6 +20,8 @@
- 
+@@ -21,6 +21,7 @@
  #include <iostream>
  
-+#include <libintl.h>
-+
  #include "sbuild-feature.h"
++#include "sbuild-i18n.h"
  
  using namespace sbuild;
--- 
-2.19.0
-

--- a/srcpkgs/schroot/template
+++ b/srcpkgs/schroot/template
@@ -2,70 +2,67 @@
 pkgname=schroot
 reverts="1.7.2_9"
 version=1.6.10
-revision=11
-_debian_version=3+deb9u1
-build_pie=yes
-build_style=gnu-configure
+revision=12
+_debian_version=12+deb11u1
+build_style=cmake
 configure_args="
-	--enable-dchroot
-	--enable-lvm-snapshot
-	--enable-btrfs-snapshot
-	--enable-block-device
-	--enable-loopback
-	--enable-uuid
-	BTRFS=/usr/bin/btrfs
-	BTRFSCTL=/usr/bin/btrfsctl
-	LVCREATE=/usr/sbin/lvcreate
-	LVREMOVE=/usr/sbin/lvremove"
+ -Ddchroot=ON
+ -Dlvm-snapshot=ON
+ -Dbtrfs-snapshot=ON
+ -Dblock-device=ON
+ -Dloopback=ON
+ -Duuid=ON
+ -DBTRFS_EXECUTABLE=/usr/bin/btrfs
+ -DLVCREATE_EXECUTABLE=/usr/sbin/lvcreate
+ -DLVREMOVE_EXECUTABLE=/usr/sbin/lvremove
+ -DZFS_EXECUTABLE=/usr/bin/zfs
+ -Dbash_completion_dir=/usr/share/bash-completion/completions"
 conf_files="
-	/etc/schroot/minimal/nssdatabases
-	/etc/schroot/minimal/fstab
-	/etc/schroot/minimal/copyfiles
-	/etc/schroot/buildd/nssdatabases
-	/etc/schroot/buildd/fstab
-	/etc/schroot/buildd/copyfiles
-	/etc/schroot/default/nssdatabases
-	/etc/schroot/default/fstab
-	/etc/schroot/default/copyfiles
-	/etc/schroot/schroot.conf
-	/etc/schroot/desktop/nssdatabases
-	/etc/schroot/desktop/fstab
-	/etc/schroot/desktop/copyfiles
-	/etc/schroot/sbuild/nssdatabases
-	/etc/schroot/sbuild/fstab
-	/etc/schroot/sbuild/copyfiles"
+ /etc/schroot/minimal/nssdatabases
+ /etc/schroot/minimal/fstab
+ /etc/schroot/minimal/copyfiles
+ /etc/schroot/buildd/nssdatabases
+ /etc/schroot/buildd/fstab
+ /etc/schroot/buildd/copyfiles
+ /etc/schroot/default/nssdatabases
+ /etc/schroot/default/fstab
+ /etc/schroot/default/copyfiles
+ /etc/schroot/schroot.conf
+ /etc/schroot/desktop/nssdatabases
+ /etc/schroot/desktop/fstab
+ /etc/schroot/desktop/copyfiles
+ /etc/schroot/sbuild/nssdatabases
+ /etc/schroot/sbuild/fstab
+ /etc/schroot/sbuild/copyfiles"
 make_dirs="
-	/var/lib/schroot/unpack 0755 root root
-	/var/lib/schroot/union/underlay 0755 root root
-	/var/lib/schroot/union/overlay 0755 root root
-	/var/lib/schroot/session 0755 root root
-	/var/lib/schroot/mount 0755 root root
-	/etc/schroot/chroot.d 0755 root root"
-hostmakedepends="cmake pkg-config automake libtool gettext xz"
-makedepends="boost-devel pam-devel lockdev-devel libuuid-devel e2fsprogs-devel gettext-devel
- libcppunit-devel"
+ /var/lib/schroot/unpack 0755 root root
+ /var/lib/schroot/union/underlay 0755 root root
+ /var/lib/schroot/union/overlay 0755 root root
+ /var/lib/schroot/session 0755 root root
+ /var/lib/schroot/mount 0755 root root
+ /etc/schroot/chroot.d 0755 root root"
+hostmakedepends="pkg-config libtool gettext xz po4a groff"
+makedepends="boost-devel pam-devel lockdev-devel libuuid-devel e2fsprogs-devel
+ gettext-devel libcppunit-devel"
 short_desc="Allows users to execute commands in different chroots"
 maintainer="Andrea Brancaleoni <miwaxe@gmail.com>"
-license="GPL-3"
+license="GPL-3.0-only"
 homepage="https://wiki.debian.org/Schroot"
 distfiles="
-${DEBIAN_SITE}/main/s/${pkgname}/${pkgname}_${version}.orig.tar.xz
-${DEBIAN_SITE}/main/s/${pkgname}/${pkgname}_${version}-${_debian_version}.debian.tar.xz"
+ ${DEBIAN_SITE}/main/s/${pkgname}/${pkgname}_${version}.orig.tar.xz
+ http://security.debian.org/debian-security/pool/main/s/${pkgname}/${pkgname}_${version}-${_debian_version}.debian.tar.xz"
 checksum="
-3ce8dfd9cb97b099e4b6d4ccec421d6cc8c9ef84574681e928a12badb5643d0b
-56bc82fc8ae7f6ca7eef506ccc1dca1211b2c84d83efc50d24670b8bdb9ea8bb"
+ 3ce8dfd9cb97b099e4b6d4ccec421d6cc8c9ef84574681e928a12badb5643d0b
+ 7bd4e0c2709979362c86a86c10d2b23d290d26e1a2d301a602e829327f483ec1"
 nocross=yes
 
 pre_configure() {
 	cat ../debian/patches/series | while read p; do
 		patch -p1 -i ../debian/patches/$p
 	done
-	autoreconf -fi
 }
 
 post_install() {
-	vmkdir usr/share/bash-completion/completions
-	mv ${DESTDIR}/etc/bash_completion.d/* ${DESTDIR}/usr/share/bash-completion/completions
 	# Remove development files
 	rm -rf ${DESTDIR}/usr/include \
 		${DESTDIR}/usr/lib/*.a \


### PR DESCRIPTION
**Fix CVE-2022-2787 and update to Debian Bullseye package**

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)