### PR TITLE
chroot-grep: update to 3.7.

### DIFF
--- a/srcpkgs/chroot-grep/template
+++ b/srcpkgs/chroot-grep/template
@@ -1,19 +1,20 @@
 # Template file for 'chroot-grep'
 pkgname=chroot-grep
-version=3.3
+version=3.7
 revision=1
 wrksrc="grep-${version}"
 bootstrap=yes
 build_style=gnu-configure
 configure_args="--disable-perl-regexp --disable-nls ac_cv_path_GREP=grep"
-short_desc="The GNU grep utility - for use with xbps-src"
+short_desc="GNU grep utility - for use with xbps-src"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="http://www.gnu.org/software/grep/"
 distfiles="${GNU_SITE}/grep/grep-${version}.tar.xz"
-checksum=b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514
+checksum=5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c
 conflicts="grep>=0"
 provides="grep-${version}_${revision}"
+make_check=no # Infinate loop in hash-collision-perf without perl
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	export ac_cv_lib_error_at_line=no


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The regular grep package is 3.7, not sure if there is a specific reason to keep this on 3.3, so feel free to let me know.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
