### PR TITLE
spectacle: update to 22.08.1

### DIFF
--- a/srcpkgs/spectacle/template
+++ b/srcpkgs/spectacle/template
@@ -1,17 +1,18 @@
 # Template file for 'spectacle'
 pkgname=spectacle
-version=22.04.3
+version=22.08.1
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="extra-cmake-modules kdoctools python3 qt5-host-tools qt5-qmake
  kconfig gettext kcoreaddons"
-makedepends="kdeclarative-devel libkipi5-devel xcb-util-image-devel xcb-util-cursor-devel
- kwayland-devel purpose-devel knewstuff-devel"
+makedepends="kColorPicker-devel kImageAnnotator-devel kdeclarative-devel
+ knewstuff-devel kwayland-devel libkipi5-devel purpose-devel
+ xcb-util-cursor-devel xcb-util-image-devel"
 depends="qt5-tools"
 short_desc="KDE screenshot capture utility"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later, GPL-2.0-or-later"
 homepage="https://kde.org/applications/en/utilities/org.kde.spectacle"
 distfiles="${KDE_SITE}/release-service/${version}/src/${pkgname}-${version}.tar.xz"
-checksum=96bb7885bcc26ee6331e414263c93e51499ef1f4db9f701b334629581abb6b9d
+checksum=6cfebb2128689a38f15fc5b7b3e70a1a9e16137b24b3a6b5eb69b052175a8888


### PR DESCRIPTION
support annotation mode (`kColorPicker-devel kImageAnnotator-devel`)

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

![Screenshot_20220820_034915](https://user-images.githubusercontent.com/45872139/185704963-10da2c0d-1048-42ec-94d0-e6a07592ef82.png)

