### PR TITLE
ykpers: fix distfile

### DIFF
--- a/srcpkgs/ykpers/template
+++ b/srcpkgs/ykpers/template
@@ -10,7 +10,7 @@ short_desc="Yubikey Personalization Tools cmdline"
 maintainer="yopito <pierre.bourgin@free.fr>"
 license="BSD-2-Clause"
 homepage="https://developers.yubico.com/yubikey-personalization/"
-distfiles="https://developers.yubico.com/yubikey-personalization/releases/${pkgname}-${version}.tar.gz"
+distfiles="https://developers.yubico.com/yubikey-personalization/Releases/${pkgname}-${version}.tar.gz"
 checksum=0ec84d0ea862f45a7d85a1a3afe5e60b8da42df211bb7d27a50f486e31a79b93
 
 CFLAGS="-fcommon"
@@ -38,4 +38,3 @@ libykpers-devel_package() {
 		vmove /usr/lib/pkgconfig
 	}
 }
-


### PR DESCRIPTION
The current version which uses the nonexistent `releases` doesn't build.

#### Testing the changes
- I tested the changes in this PR: **briefly**