### PR TITLE
fonttools: update to 4.36.0.

### DIFF
--- a/srcpkgs/fonttools/template
+++ b/srcpkgs/fonttools/template
@@ -1,20 +1,22 @@
 # Template file for 'fonttools'
 pkgname=fonttools
-version=4.28.1
+version=4.36.0
 revision=1
 build_style=python3-module
+make_check_args="--deselect Tests/otlLib/optimize_test.py::test_main
+ --ignore Tests/misc/plistlib_test.py --ignore Tests/pens --ignore Tests/ufoLib"
 hostmakedepends="python3-setuptools"
 depends="python3"
+checkdepends="python3-Brotli python3-pytest-xdist"
 short_desc="Library to manipulate font files from Python"
 maintainer="svenper <svenper@tuta.io>"
 license="MIT, OFL-1.1, BSD-3-Clause"
 homepage="https://github.com/fonttools/fonttools"
+changelog="https://raw.githubusercontent.com/fonttools/fonttools/main/NEWS.rst"
 distfiles="https://github.com/fonttools/fonttools/archive/${version}.tar.gz"
-checksum=972be7e3d573cfda4880cd4534ba7695d6c3c4186aab22cee50d3863e25fb4c9
+checksum=7f48433c42351102f25e63778c702be8bed76bfa6c192c67e6d0e985c01f674e
 replaces="python-fonttools>=0 python3-fonttools>=0"
 provides="python-fonttools-${version}_${revision} python3-fonttools-${version}_${revision}"
-# Tests have unpackaged dependencies
-make_check=no
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Rev dep tests
- [x] python3-matplotlib (`make_check=no`, seems fine according to their setup.py)
- [x] liberation-fonts-ttf (hostmakedepends)