### PR TITLE
spotify-tui: fix build with recent rust

### DIFF
--- a/srcpkgs/spotify-tui/template
+++ b/srcpkgs/spotify-tui/template
@@ -13,7 +13,10 @@ distfiles="https://github.com/Rigellute/spotify-tui/archive/v${version}.tar.gz"
 checksum=9d6fa998e625ceff958a5355b4379ab164ba76575143a7b6d5d8aeb6c36d70a7
 
 pre_build() {
-	cargo update --package openssl-sys --precise 0.9.58
+	# fix various compilation issues
+	cargo update --package num-traits:0.2.12 --precise 0.2.15
+	cargo update --package num-integer:0.1.43 --precise 0.1.45
+	cargo update --package autocfg:1.0.0 --precise 1.1.0
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** only compile tested

@abenson I don't use spotify, but this seems to fix compilation issues with recent rust versions

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
