### PR TITLE
New package: bazel-buildtools-5.1.0

### DIFF
--- a/srcpkgs/bazel-buildtools/template
+++ b/srcpkgs/bazel-buildtools/template
@@ -1,0 +1,21 @@
+# Template file for 'bazel-buildtools'
+pkgname=bazel-buildtools
+version=5.1.0
+revision=1
+wrksrc="buildtools-${version}"
+build_style="go"
+go_import_path="github.com/bazelbuild/buildtools"
+go_package="${go_import_path}/unused_deps ${go_import_path}/buildifier ${go_import_path}/buildozer"
+short_desc="Bazel BUILD file formatter and editor"
+maintainer="n1c00o <git.n1c00o@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/bazelbuild/buildtools"
+distfiles="https://github.com/bazelbuild/buildtools/archive/refs/tags/${version}.tar.gz"
+checksum="e3bb0dc8b0274ea1aca75f1f8c0c835adbe589708ea89bf698069d0790701ea3"
+
+post_install() {
+	vdoc ./unused_deps/README.md unused_deps.md
+	vdoc ./buildifier/README.md buildifier.md
+	vdoc WARNINGS.md
+	vdoc ./buildozer/README.md buildozer.md
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - Should support cross compilation using the Go standard toolchain 

> Note: As I specified a few weeks ago in <https://github.com/void-linux/void-packages/pull/38207>, I decided to release the different Bazel buildtools into a single package to avoid polluting the repository, since these tools are often installed together.

> Note: The package is named `bazel-buildtools` to be clear that it is for Bazel, since a lot of ecosystems do have tools under the name "buildtools".

> Note: This is not a sub-package of `bazel` (unpublished yet) since they do not directly require Bazel and building Bazel from source is very long, which could be annoying for those who only needs the build tools (a sub-package is only executed after the main package's installation phase.