### PR TITLE
New packages: fl{aa,amp,cluster,log,msg,net,wkey,wrap}

### DIFF
--- a/srcpkgs/flaa/template
+++ b/srcpkgs/flaa/template
@@ -1,0 +1,14 @@
+# Template file for 'flaa'
+pkgname=flaa
+version=1.0.2
+revision=1
+build_style=gnu-configure
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="Rig Expert Antenna Analyzer control program"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flaa/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=a66faaae0f29d9ecce7ee37c1e0e7fe5731133e625d9e9dd898a5076ed6ecb01

--- a/srcpkgs/flamp/template
+++ b/srcpkgs/flamp/template
@@ -1,0 +1,15 @@
+# Template file for 'flamp'
+pkgname=flamp
+version=2.2.07
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="Amateur Multicast Protocol file transfer program"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flamp/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=807995746f11cdb3e9f2866ae544fc2d6d6b735fa57a2bcdd2f4bf8a28975a51

--- a/srcpkgs/flcluster/template
+++ b/srcpkgs/flcluster/template
@@ -1,0 +1,15 @@
+# Template file for 'flcluster'
+pkgname=flcluster
+version=1.0.7
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="Telnet client to remote DX cluster servers"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flcluster/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=3df2d10b7886b72b857e972a319c6af4f476ba5e60ad200b4de46978395bc161

--- a/srcpkgs/fllog/patches/rm-Bashism.patch
+++ b/srcpkgs/fllog/patches/rm-Bashism.patch
@@ -1,0 +1,25 @@
+From: Antonio Gurgel <antonio@goorzhel.com>
+Date: Sun, 21 Aug 2022 11:11:36 -0700
+Subject: [PATCH] rm Bashism
+
+configure calls for /bin/sh, in which `<<<` is a syntax error.
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index acb390f..a5b4c27 100755
+--- a/configure
++++ b/configure
+@@ -6185,7 +6185,7 @@ $as_echo "$FLTK_CONFIG" >&6; }
+           FLTK_LIBS=`$FLTK_CONFIG --ldflags --use-images`
+           if test "x$target_mingw32" != "xyes"; then
+               if test "x$target_darwin" != "xyes"; then
+-                  if grep -q "lX11" <<< "$FLTK_LIBS"; then
++                  if echo "$FLTK_LIBS" | grep -q "lX11"; then
+                       FLTK_LIBS="$FLTK_LIBS";
+                   else
+                       FLTK_LIBS="$FLTK_LIBS -lm -lX11";
+--
+2.37.2
+

--- a/srcpkgs/fllog/template
+++ b/srcpkgs/fllog/template
@@ -1,0 +1,14 @@
+# Template file for 'fllog'
+pkgname=fllog
+version=1.2.7
+revision=1
+build_style=gnu-configure
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="Logbook server for radio contesting"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/fllog/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=1f14e867e7f52098032863c705e56e4bbad1921dfe29fa72a183c1c1fcaab02f

--- a/srcpkgs/flmsg/template
+++ b/srcpkgs/flmsg/template
@@ -1,0 +1,15 @@
+# Template file for 'flmsg'
+pkgname=flmsg
+version=4.0.20
+revision=1
+build_style=gnu-configure
+hostmakedepends="pkg-config"
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="NBEMS messaging system"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flmsg/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=4ec630776b94189b307a22a28135813d703b3ed22d65e20ec4a937955deccb6e

--- a/srcpkgs/flnet/template
+++ b/srcpkgs/flnet/template
@@ -1,0 +1,13 @@
+# Template file for 'flnet'
+pkgname=flnet
+version=7.5.0
+revision=1
+build_style=gnu-configure
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="Voice net controller database/check-in application"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flnet/"
+distfiles="http://www.w1hkj.com/files/flnet/${pkgname}-${version}.tar.gz"
+checksum=8b8fcf9ce076553c10b730dff628ad30f93f2605bcf0660e2a13d9cada0b2de7

--- a/srcpkgs/flwkey/template
+++ b/srcpkgs/flwkey/template
@@ -1,0 +1,14 @@
+# Template file for 'flwkey'
+pkgname=flwkey
+version=1.2.3
+revision=1
+build_style=gnu-configure
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="Modem program for the K1EL Winkeyer series"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flwkey/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=7431ca23078cb13ddf566c45f79bf2b8544f2df7699f05d884829992686026bf

--- a/srcpkgs/flwrap/template
+++ b/srcpkgs/flwrap/template
@@ -1,0 +1,14 @@
+# Template file for 'flwrap'
+pkgname=flwrap
+version=1.3.5
+revision=1
+build_style=gnu-configure
+makedepends="fltk-devel"
+depends="fltk"
+short_desc="File encapsulation/compression"
+maintainer="Antonio Gurgel <antonio@goorzhel.com>"
+license="GPL-3.0-or-later"
+homepage="http://www.w1hkj.com/files/flwrap/"
+changelog="https://sourceforge.net/p/fldigi/${pkgname}/ci/master/tree/ChangeLog?format=raw"
+distfiles="http://www.w1hkj.com/files/${pkgname}/${pkgname}-${version}.tar.gz"
+checksum=efde2b3011c4394cccf046ce8b3f3b7360e1a7eb809c42e4796cab3c27de1163


### PR DESCRIPTION
/label new-package wip
@classabbyamp (https://github.com/void-linux/void-packages/pull/38771#issuecomment-1221202322)

I need help with:
1. ~~picking a good name for the meta-package (`fldigi-full` was a wild guess),~~
2. ~~`fl{amp,cluster,msg}` failing to set `USE_X` (I left a writeup in the `flamp` template), and~~
3. the applications that _do_ build presenting an all-black theme: black font on black background. Just my machine (running sway), or something wrong with the way I built the programs?

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
