### PR TITLE
libproxy: update to 0.4.18.

### DIFF
--- a/srcpkgs/libproxy/template
+++ b/srcpkgs/libproxy/template
@@ -1,18 +1,22 @@
 # Template file for 'libproxy'
 pkgname=libproxy
-version=0.4.15
+version=0.4.18
 revision=1
 build_style=cmake
 configure_args="-DWITH_GNOME=0 -DWITH_KDE4=0 -DWITH_MOZJS=0 -DWITH_NM=0
  -DWITH_PERL=0 -DWITH_PYTHON=1 -DWITH_WEBKIT=0"
 hostmakedepends="pkg-config python"
 makedepends="zlib-devel"
-short_desc="A library handling all the details of proxy configuration"
+short_desc="Library handling all the details of proxy configuration"
 maintainer="Orphaned <orphan@voidlinux.org>"
+license="LGPL-2.1-or-later"
 homepage="http://github.com/libproxy/libproxy"
-license="LGPL-2.1"
-distfiles="https://github.com/libproxy/libproxy/archive/${version}.tar.gz>${pkgname}-${version}.tar.gz"
-checksum=18f58b0a0043b6881774187427ead158d310127fc46a1c668ad6d207fb28b4e0
+distfiles="https://github.com/libproxy/libproxy/releases/download/${version}/libproxy-${version}.tar.xz"
+checksum=69b5856e9ea42c38ac77e6b8c92ffc86a71d341fef74e77bef85f9cc6c47a4b1
+
+post_patch() {
+	vsed '/add_test(NAME url-test/d' -i libproxy/test/CMakeLists.txt
+}
 
 libproxy-devel_package() {
 	depends="libproxy>=${version}_${revision}"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes build with gcc12:
```
In file included from /builddir/libproxy-0.4.15/libproxy/extension_config.hpp:24,
                 from /builddir/libproxy-0.4.15/libproxy/proxy.cpp:28:
/builddir/libproxy-0.4.15/libproxy/url.hpp:53:32: error: ISO C++17 does not allow dynamic exception specifications
   53 |         url(const string& url) throw (parse_error);
      |                                ^~~~~
/builddir/libproxy-0.4.15/libproxy/url.hpp:56:36: error: ISO C++17 does not allow dynamic exception specifications
   56 |         url& operator=(string url) throw (parse_error);
      |                                    ^~~~~
/builddir/libproxy-0.4.15/libproxy/extension_config.hpp:34:61: error: ISO C++17 does not allow dynamic exception specifications
   34 |         virtual vector<url>      get_config(const url &dst) throw (runtime_error)=0;
      |                                                             ^~~~~
In file included from /builddir/libproxy-0.4.15/libproxy/proxy.cpp:31:
/builddir/libproxy-0.4.15/libproxy/extension_pacrunner.hpp:44:44: error: ISO C++17 does not allow dynamic exception specifications
   44 |         virtual string run(const url& url) throw (bad_alloc)=0;
      |                                            ^~~~~
/builddir/libproxy-0.4.15/libproxy/extension_pacrunner.hpp:50:63: error: ISO C++17 does not allow dynamic exception specifications
   50 |         virtual pacrunner* get(string pac, const url& pacurl) throw (bad_alloc);
      |                                                               ^~~~~
/builddir/libproxy-0.4.15/libproxy/extension_pacrunner.hpp:58:66: error: ISO C++17 does not allow dynamic exception specifications
   58 |         virtual pacrunner* create(string pac, const url& pacurl) throw (bad_alloc)=0;
      |                                                                  ^~~~~
ninja: build stopped: subcommand failed.
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
