### PR TITLE
plymouth: update to 22.02.122.

### DIFF
--- a/srcpkgs/plymouth/patches/fix-glibc-2.36.patch
+++ b/srcpkgs/plymouth/patches/fix-glibc-2.36.patch
@@ -1,0 +1,30 @@
+From 5f1e43c00039a7fe1fff768b91a05a695fb4a53d Mon Sep 17 00:00:00 2001
+From: Ray Strode <rstrode@redhat.com>
+Date: Wed, 3 Aug 2022 15:23:33 -0400
+Subject: [PATCH] ply-utils: Drop linux/fs.h include
+
+It was needed long ago for a function we no longer even have.
+
+Now it's causing compile errors on Fedora 37 because it's conflicting
+with sys/mount.h.
+
+This commit drops it.
+---
+ src/libply/ply-utils.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/libply/ply-utils.c b/src/libply/ply-utils.c
+index c7b165e9..219e2e77 100644
+--- a/src/libply/ply-utils.c
++++ b/src/libply/ply-utils.c
+@@ -46,7 +46,6 @@
+ #include <sys/user.h>
+ #include <sys/wait.h>
+ #include <time.h>
+-#include <linux/fs.h>
+ #include <linux/vt.h>
+ 
+ #include <dlfcn.h>
+-- 
+GitLab
+

--- a/srcpkgs/plymouth/template
+++ b/srcpkgs/plymouth/template
@@ -1,6 +1,6 @@
 # Template file for 'plymouth'
 pkgname=plymouth
-version=0.9.5
+version=22.02.122
 revision=1
 build_style=gnu-configure
 configure_args="--with-system-root-install=no \
@@ -18,7 +18,7 @@ maintainer="William OD <obirik2005@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://www.freedesktop.org/wiki/Software/Plymouth/"
 distfiles="${FREEDESKTOP_SITE}/plymouth/releases/$pkgname-$version.tar.xz"
-checksum=ecae257f351d098340542a5bc06de029404c24dcee87e6ebb2abd5ef117fce86
+checksum=100551442221033ce868c447ad6c74d831d209c18ae232b98ae0207e34eadaeb
 
 build_options="gtk3 pango"
 build_options_default="gtk3 pango"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

This adds a patch for fixing build for glibc 2.36.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
