### PR TITLE
libostree: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/libostree/patches/fix-compat-glibc-2.36.patch
+++ b/srcpkgs/libostree/patches/fix-compat-glibc-2.36.patch
@@ -1,0 +1,143 @@
+From edba4b33be10c05253bfa94895dfbc8477e44d76 Mon Sep 17 00:00:00 2001
+From: Colin Walters <walters@verbum.org>
+Date: Wed, 3 Aug 2022 10:37:40 -0400
+Subject: [PATCH 1/2] Remove unused `linux/fs.h` includes
+
+Prep for fixing conflicts introduced by newer glibc.
+cc https://github.com/ostreedev/ostree/issues/2685
+---
+ src/libostree/ostree-repo-commit.c | 1 -
+ src/ostree/ot-main.c               | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/src/libostree/ostree-repo-commit.c b/src/libostree/ostree-repo-commit.c
+index afab3fdf85..35b16c713b 100644
+--- a/src/libostree/ostree-repo-commit.c
++++ b/src/libostree/ostree-repo-commit.c
+@@ -30,7 +30,6 @@
+ #include <sys/xattr.h>
+ #include <glib/gprintf.h>
+ #include <sys/ioctl.h>
+-#include <linux/fs.h>
+ #include <ext2fs/ext2_fs.h>
+ 
+ #include "otutil.h"
+diff --git a/src/ostree/ot-main.c b/src/ostree/ot-main.c
+index b7b50d67e3..7a4405a50d 100644
+--- a/src/ostree/ot-main.c
++++ b/src/ostree/ot-main.c
+@@ -28,7 +28,6 @@
+ #include <string.h>
+ #include <sys/statvfs.h>
+ #include <sys/mount.h>
+-#include <linux/fs.h>
+ 
+ #include "ot-main.h"
+ #include "ostree.h"
+
+From 0a908a180fcce98c2565b9fb34470e5953918260 Mon Sep 17 00:00:00 2001
+From: Colin Walters <walters@verbum.org>
+Date: Wed, 3 Aug 2022 10:43:43 -0400
+Subject: [PATCH 2/2] Move FIFREEZE/FITHAW ioctl invocations into linuxfsutil.c
+
+Should help avoid conflicts between glibc and linux headers.
+
+Closes: https://github.com/ostreedev/ostree/issues/2685
+---
+ src/libostree/ostree-linuxfsutil.c    | 24 ++++++++++++++++++++++--
+ src/libostree/ostree-linuxfsutil.h    |  3 +++
+ src/libostree/ostree-sysroot-deploy.c |  7 +++----
+ 3 files changed, 28 insertions(+), 6 deletions(-)
+
+diff --git a/src/libostree/ostree-linuxfsutil.c b/src/libostree/ostree-linuxfsutil.c
+index 97f936048a..aa389aaa80 100644
+--- a/src/libostree/ostree-linuxfsutil.c
++++ b/src/libostree/ostree-linuxfsutil.c
+@@ -24,10 +24,12 @@
+ 
+ #include <fcntl.h>
+ #include <sys/ioctl.h>
++// This should be the only file including linux/fs.h; see
++// https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
++// https://github.com/ostreedev/ostree/issues/2685
++#include <linux/fs.h>
+ #include <ext2fs/ext2_fs.h>
+ 
+-#include "otutil.h"
+-
+ /**
+  * _ostree_linuxfs_fd_alter_immutable_flag:
+  * @fd: A file descriptor
+@@ -88,3 +90,21 @@ _ostree_linuxfs_fd_alter_immutable_flag (int            fd,
+ 
+   return TRUE;
+ }
++
++/* Wrapper for FIFREEZE ioctl.
++ * This is split into a separate wrapped API for
++ * reasons around conflicts between glibc and linux/fs.h
++ * includes; see above.
++ */
++int
++_ostree_linuxfs_filesystem_freeze (int fd)
++{
++  return TEMP_FAILURE_RETRY (ioctl (fd, FIFREEZE, 0));
++}
++
++/* Wrapper for FITHAW ioctl.  See above. */
++int
++_ostree_linuxfs_filesystem_thaw (int fd)
++{
++  return TEMP_FAILURE_RETRY (ioctl (fd, FITHAW, 0));
++}
+diff --git a/src/libostree/ostree-linuxfsutil.h b/src/libostree/ostree-linuxfsutil.h
+index 0654b6fc7c..9011c9d869 100644
+--- a/src/libostree/ostree-linuxfsutil.h
++++ b/src/libostree/ostree-linuxfsutil.h
+@@ -29,4 +29,7 @@ _ostree_linuxfs_fd_alter_immutable_flag (int            fd,
+                                          GCancellable  *cancellable,
+                                          GError       **error);
+ 
++int _ostree_linuxfs_filesystem_freeze (int fd);
++int _ostree_linuxfs_filesystem_thaw (int fd);
++
+ G_END_DECLS
+diff --git a/src/libostree/ostree-sysroot-deploy.c b/src/libostree/ostree-sysroot-deploy.c
+index 2dc9f58b16..d86de7dc7b 100644
+--- a/src/libostree/ostree-sysroot-deploy.c
++++ b/src/libostree/ostree-sysroot-deploy.c
+@@ -29,7 +29,6 @@
+ #include <sys/ioctl.h>
+ #include <stdbool.h>
+ #include <sys/poll.h>
+-#include <linux/fs.h>
+ #include <err.h>
+ 
+ #ifdef HAVE_LIBMOUNT
+@@ -1476,7 +1475,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
+            * EOPNOTSUPP: If the filesystem doesn't support it
+            */
+           int saved_errno = errno;
+-          (void) TEMP_FAILURE_RETRY (ioctl (rootfs_dfd, FITHAW, 0));
++          _ostree_linuxfs_filesystem_thaw (rootfs_dfd);
+           errno = saved_errno;
+           /* But if we got an error from poll, let's log it */
+           if (r < 0)
+@@ -1517,7 +1516,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
+           return glnx_throw (error, "aborting due to test-fifreeze");
+         }
+       /* Do a freeze/thaw cycle; TODO add a FIFREEZETHAW ioctl */
+-      if (ioctl (rootfs_dfd, FIFREEZE, 0) != 0)
++      if (_ostree_linuxfs_filesystem_freeze (rootfs_dfd) != 0)
+         {
+           /* Not supported, we're running in the unit tests (as non-root), or
+            * the filesystem is already frozen (EBUSY).
+@@ -1539,7 +1538,7 @@ fsfreeze_thaw_cycle (OstreeSysroot *self,
+             return glnx_throw_errno_prefix (error, "ioctl(FIFREEZE)");
+         }
+       /* And finally thaw, then signal our completion to the watchdog */
+-      if (TEMP_FAILURE_RETRY (ioctl (rootfs_dfd, FITHAW, 0)) != 0)
++      if (_ostree_linuxfs_filesystem_thaw (rootfs_dfd) != 0)
+         {
+           /* Warn but don't error if the filesystem was already thawed */
+           if (errno == EINVAL)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
