### PR TITLE
New package: bazelisk-1.12.2

### DIFF
--- a/srcpkgs/bazelisk/template
+++ b/srcpkgs/bazelisk/template
@@ -1,0 +1,16 @@
+# Template file for 'bazelisk'
+pkgname=bazelisk
+version=1.12.2
+revision=1
+build_style="go"
+go_import_path="github.com/bazelbuild/bazelisk"
+short_desc="User-friendly launcher for Bazel"
+maintainer="n1c00o <git.n1c00o@gmail.com>"
+license="Apache-2.0"
+homepage="https://github.com/bazelbuild/bazelisk"
+distfiles="https://github.com/bazelbuild/bazelisk/archive/refs/tags/v${version}.tar.gz"
+checksum=70a35357a5aedb372fc5b3b3bf2b7b9f60a9a5c266b60d0933a027ae98a44399
+
+post_install() {
+	vdoc README.md
+}


### PR DESCRIPTION
This merge request adds a package description for Bazelisk (<https://github.com/bazelbuild/bazelisk>), which provides an simple and fast way to use and install Bazel.
This can be used by packages requiring Bazel in compilation, without the need of having to bootstrap Bazel, which is time-consuming and error-prone *(I am actively trying to get a cross-compile-ready package of Bazel from source, known as bootstrapping Bazel...)*  

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - should support cross compilation using the Go standard toolchain
