### PR TITLE
mate-themes: Don't pull gtk+ in

### DIFF
--- a/srcpkgs/mate-themes/template
+++ b/srcpkgs/mate-themes/template
@@ -1,11 +1,11 @@
 # Template file for 'mate-themes'
 pkgname=mate-themes
 version=3.22.23
-revision=1
+revision=2
 build_style=gnu-configure
+configure_args="THEME_ENGINE_CFLAGS=unused THEME_ENGINE_LIBS=unused"
 hostmakedepends="pkg-config intltool itstool icon-naming-utils"
-makedepends="gtk+-devel gtk+3-devel"
-depends="gtk2-engines gtk-engine-murrine librsvg mate-icon-theme"
+depends="librsvg mate-icon-theme"
 short_desc="Default themes for the MATE desktop"
 maintainer="skmpz <dem.procopiou@gmail.com>"
 license="LGPL-2.1-or-later"


### PR DESCRIPTION
It's suck to pull the whole gtk+ in just to use Mate,
which is GTK+3 only.

This is not about minimalism or whatsoever, I just want to keep my system away from GTK+

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
