### PR TITLE
python3-dateparser: update to 1.1.1, patch breakage on python3-regex

### DIFF
--- a/srcpkgs/python3-dateparser/patches/fix-python3-regex-incompatibility.patch
+++ b/srcpkgs/python3-dateparser/patches/fix-python3-regex-incompatibility.patch
@@ -1,0 +1,11 @@
+--- a/dateparser/languages/locale.py
++++ b/dateparser/languages/locale.py
+@@ -169,7 +169,7 @@ class Locale:
+             if normalize:
+                 value = list(map(normalize_unicode, value))
+             pattern = '|'.join(sorted(value, key=len, reverse=True))
+-            pattern = DIGIT_GROUP_PATTERN.sub(r'?P<n>\d+', pattern)
++            pattern = pattern.replace(r'\d+', r'?P<n>\d+')
+             pattern = re.compile(r'^(?:{})$'.format(pattern), re.UNICODE | re.IGNORECASE)
+             relative_dictionary[pattern] = key
+         return relative_dictionary

--- a/srcpkgs/python3-dateparser/template
+++ b/srcpkgs/python3-dateparser/template
@@ -1,17 +1,21 @@
 # Template file for 'python3-dateparser'
 pkgname=python3-dateparser
-version=1.0.0
-revision=2
+version=1.1.1
+revision=1
 wrksrc=dateparser-${version}
 build_style=python3-module
+make_check_args="--ignore tests/test_hijri.py --ignore tests/test_jalali.py
+ --ignore tests/test_language_detect.py --ignore tests/test_dateparser_data_integrity.py"
 hostmakedepends="python3-setuptools"
-depends="python3-dateutil python3-regex python3-tzlocal"
+depends="python3-dateutil python3-pytz python3-regex python3-tzlocal"
+checkdepends="${depends} python3-parameterized python3-pytest-xdist"
 short_desc="Python parser for human readable dates"
 maintainer="Lorem <notloremipsum@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/scrapinghub/dateparser"
+changelog="https://raw.githubusercontent.com/scrapinghub/dateparser/master/HISTORY.rst"
 distfiles="${PYPI_SITE}/d/dateparser/dateparser-${version}.tar.gz"
-checksum=159cc4e01a593706a15cd4e269a0b3345edf3aef8bf9278a57dac8adf5bf1e4a
+checksum=038196b1f12c7397e38aad3d61588833257f6f552baa63a1499e6987fa8d42d9
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

Note that the breakage is not caused by updating the package rather due to an API change introduced in [`python3-regex-2022.3.15`](https://github.com/scrapinghub/dateparser/issues/1045#issuecomment-1069484011). Upstream mitigates this by pinning to an older version of that regex library in their setup.py but that doesn't work for [distro packages](https://github.com/scrapinghub/dateparser/issues/1052#issuecomment-1136438340). This patch is deemed sufficient by one of the [dateparser authors](https://github.com/scrapinghub/dateparser/issues/1052#issuecomment-1131559215) as a temporary fix till they make a new release with a proper fix.

Only one package, `Komikku-0.40.0` depends on this currently.