### PR TITLE
Two minor fixes to Travis

### DIFF
--- a/common/travis/build.sh
+++ b/common/travis/build.sh
@@ -14,7 +14,8 @@ PKGS=$(/hostrepo/xbps-src sort-dependencies $(cat /tmp/templates))
 
 for pkg in ${PKGS}; do
 	/hostrepo/xbps-src -j$(nproc) -s -H "$HOME"/hostdir $arch $test pkg "$pkg"
-	[ $? -eq 1 ] && exit 1
+	ret=$?
+	[ $ret -ne 0 ] && exit $ret
 done
 
 exit 0

--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -15,8 +15,8 @@ case "$tip" in
 esac
 
 base="$($GIT_CMD merge-base FETCH_HEAD "$tip")" || {
-	echo "Your branches is based on too old copy."
-	echo "Please rebase to newest copy."
+	echo "Your branch is too far behind the upstream master branch."
+	echo "To retry, rebase your branch and force-push."
 	exit 1
 }
 


### PR DESCRIPTION
<details>
<summary>Before</summary>

```
❯ git log --oneline
6076c6dfb4 New package: radm-0.6.1
9ff585986c liburing: update to 2.2.
83e4219d31 oxipng: update to 5.0.1.
9f175ebf3b so: update to 0.4.8
bd40077123 nemo-image-converter: update to 5.4.1.
❯ cat srcpkgs/radm/template
# Template file for 'radm'
pkgname=radm
version=0.6.1
revision=1
build_style=cargo
makedepends="clang make pam-devel pandoc"
depends="seatd pam"
short_desc="Console-based display manager for Wayland sessions"
maintainer="Antonio Gurgel <antonio@goorzhel.com>"
license="MIT"
homepage="https://sr.ht/~goorzhel/radm/"
distfiles="https://git.sr.ht/~goorzhel/radm/archive/${version}.tar.gz"
checksum=81b87b76f1a59e2675bd4373f03d682b5c7f2b53adc926164f384bae8676c98a

post_install() {
        make res/radm.1

        vinstall res/pam 644 etc/pam.d radm
        vinstall res/rsyslog 644 etc/rsyslog.d radm
        vlicense LICENSE
        vman res/radm.1
        vsv radm
}
❯ sed -i 's/\/hostrepo/./' common/travis/build.sh
❯ sh -x common/travis/build.sh x86_64 aarch64-musl
+ [ x86_64 != aarch64-musl ]
+ arch=-a aarch64-musl
+ [  = 1 ]
+ cat /tmp/templates
+ ./xbps-src sort-dependencies radm
+ PKGS=radm
+ nproc
+ ./xbps-src -j12 -s -H /home/ag/hostdir -a aarch64-musl pkg radm
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-us.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-us.voidlinux.org/current/nonfree/x86_64-repodata' ...
=> xbps-src: updating repositories for target (aarch64-musl)...
[*] Updating repository `https://repo-default.voidlinux.org/current/aarch64/aarch64-musl-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/aarch64/nonfree/aarch64-musl-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/aarch64/debug/aarch64-musl-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> radm-0.6.1_1: removing autodeps, please wait...
=> radm-0.6.1_1: removing autocrossdeps, please wait...
=> radm-0.6.1_1: building [cargo] [rust] for aarch64-musl...
   [host] cargo-1.61.0_1: found (https://repo-default.voidlinux.org/current)
   [target] clang-12.0.1_2: found (https://repo-default.voidlinux.org/current/aarch64)
   [target] make-4.3_3: found (https://repo-default.voidlinux.org/current/aarch64)
   [target] pam-devel-1.5.2_2: found (https://repo-default.voidlinux.org/current/aarch64)
   [target] pandoc-2.17.1.1_1: not found
   [target] rust-std-1.61.0_1: found (https://repo-default.voidlinux.org/current/aarch64)
   [runtime] seatd-0.7.0_1: found (https://repo-default.voidlinux.org/current/aarch64)
   [runtime] pam-1.5.2_2: found (https://repo-default.voidlinux.org/current/aarch64)
=> ERROR: pandoc-2.17.1.1_1: cannot be cross compiled...
=> ERROR: pandoc-2.17.1.1_1: yes
+ [ 2 -eq 1 ]
+ exit 0
```
</details>

<details>
<summary>After</summary>

```
❯ git log --oneline | head -3
6de27dac94 common/travis/build.sh: Handle all retcodes
6076c6dfb4 New package: radm-0.6.1
9ff585986c liburing: update to 2.2.
❯ sh -x common/travis/build.sh x86_64 aarch64-musl
+ [ x86_64 != aarch64-musl ]
+ arch=-a aarch64-musl
+ [  = 1 ]
+ cat /tmp/templates
+ ./xbps-src sort-dependencies radm
+ PKGS=radm
+ nproc
+ ./xbps-src -j12 -s -H /home/ag/hostdir -a aarch64-musl pkg radm
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-us.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-us.voidlinux.org/current/nonfree/x86_64-repodata' ...
=> xbps-src: updating repositories for target (aarch64-musl)...
[*] Updating repository `https://repo-default.voidlinux.org/current/aarch64/aarch64-musl-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/aarch64/nonfree/aarch64-musl-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/aarch64/debug/aarch64-musl-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> radm-0.6.1_1: removing autodeps, please wait...
=> radm-0.6.1_1: removing autocrossdeps, please wait...
=> radm-0.6.1_1: building [cargo] [rust] for aarch64-musl...
   [host] cargo-1.61.0_1: found (https://repo-default.voidlinux.org/current)
   [target] clang-12.0.1_2: found (https://repo-default.voidlinux.org/current/aarch64)
   [target] make-4.3_3: found (https://repo-default.voidlinux.org/current/aarch64)
   [target] pam-devel-1.5.2_2: found (https://repo-default.voidlinux.org/current/aarch64)
   [target] pandoc-2.17.1.1_1: not found
   [target] rust-std-1.61.0_1: found (https://repo-default.voidlinux.org/current/aarch64)
   [runtime] seatd-0.7.0_1: found (https://repo-default.voidlinux.org/current/aarch64)
   [runtime] pam-1.5.2_2: found (https://repo-default.voidlinux.org/current/aarch64)
=> ERROR: pandoc-2.17.1.1_1: cannot be cross compiled...
=> ERROR: pandoc-2.17.1.1_1: yes
+ ret=2
+ [ 2 -ne 0 ]
+ exit 2
```
</details>

@Gottox @sgn