### PR TITLE
libvirt: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/libvirt/patches/lxc-fix-compat-glibc-2.36.patch
+++ b/srcpkgs/libvirt/patches/lxc-fix-compat-glibc-2.36.patch
@@ -1,0 +1,34 @@
+From 9493c9b79dc541ec9e0fd73c6d87bdf8d30aaa90 Mon Sep 17 00:00:00 2001
+From: Cole Robinson <crobinso@redhat.com>
+Date: Mon, 1 Aug 2022 15:20:38 -0400
+Subject: [PATCH] lxc: containter: fix build with glibc 2.36
+
+With glibc 2.36, sys/mount.h and linux/mount.h conflict:
+https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
+
+lxc_container.c imports sys/mount.h and linux/fs.h, which pulls in
+linux/mount.h.
+
+linux/fs.h isn't required here though. glibc sys/mount.h has had
+MS_MOVE since 2.12 in 2010
+
+Reviewed-by: Erik Skultety <eskultet@redhat.com>
+Signed-off-by: Cole Robinson <crobinso@redhat.com>
+---
+ src/lxc/lxc_container.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/src/lxc/lxc_container.c b/src/lxc/lxc_container.c
+index b5278831da7..a5401c2186e 100644
+--- a/src/lxc/lxc_container.c
++++ b/src/lxc/lxc_container.c
+@@ -33,9 +33,6 @@
+ /* Yes, we want linux private one, for _syscall2() macro */
+ #include <linux/unistd.h>
+ 
+-/* For MS_MOVE */
+-#include <linux/fs.h>
+-
+ #if WITH_CAPNG
+ # include <cap-ng.h>
+ #endif

--- a/srcpkgs/libvirt/patches/virfile-fix-compat-glibc-2.36.patch
+++ b/srcpkgs/libvirt/patches/virfile-fix-compat-glibc-2.36.patch
@@ -1,0 +1,39 @@
+From c0d9adf220dc0d223330a7bac37b174132d330ba Mon Sep 17 00:00:00 2001
+From: Cole Robinson <crobinso@redhat.com>
+Date: Mon, 1 Aug 2022 15:24:01 -0400
+Subject: [PATCH] virfile: Fix build with glibc 2.36
+
+With glibc 2.36, sys/mount.h and linux/mount.h conflict:
+https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
+
+virfile.c imports sys/mount.h and linux/fs.h, which pulls in
+linux/mount.h.
+
+Manually define the constants we need from linux/fs.h, like was
+done in llvm:
+
+https://reviews.llvm.org/rGb379129c4beb3f26223288627a1291739f33af02
+
+Reviewed-by: Erik Skultety <eskultet@redhat.com>
+Signed-off-by: Cole Robinson <crobinso@redhat.com>
+---
+ src/util/virfile.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/util/virfile.c b/src/util/virfile.c
+index 99da058db3b..ce541b8946b 100644
+--- a/src/util/virfile.c
++++ b/src/util/virfile.c
+@@ -71,7 +71,11 @@
+ # endif
+ # include <sys/ioctl.h>
+ # include <linux/cdrom.h>
+-# include <linux/fs.h>
++/* These come from linux/fs.h, but that header conflicts with
++ * sys/mount.h on glibc 2.36+ */
++# define FS_IOC_GETFLAGS _IOR('f', 1, long)
++# define FS_IOC_SETFLAGS _IOW('f', 2, long)
++# define FS_NOCOW_FL 0x00800000
+ #endif
+ 
+ #if WITH_LIBATTR


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
