### PR TITLE
gupnp: needs docbook-xsl in hostmakedepends

### DIFF
--- a/srcpkgs/gupnp/template
+++ b/srcpkgs/gupnp/template
@@ -6,7 +6,7 @@ build_style=meson
 build_helper="gir"
 configure_args="$(vopt_bool gir introspection) $(vopt_bool gir vapi)
  -Dexamples=false"
-hostmakedepends="pkg-config glib-devel $(vopt_if gir vala)"
+hostmakedepends="pkg-config glib-devel docbook-xsl $(vopt_if gir vala)"
 makedepends="libglib-devel libxml2-devel libuuid-devel gssdp-devel
  libsoup-devel"
 short_desc="GObject-based library for UPnP"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Fixes build failure due to missing dependency.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
