### PR TITLE
xf86-video-vmware: fix build for gcc12

### DIFF
--- a/srcpkgs/xf86-video-vmware/patches/fix-compat-gcc12.patch
+++ b/srcpkgs/xf86-video-vmware/patches/fix-compat-gcc12.patch
@@ -1,0 +1,30 @@
+From 77b8183b3395333d5d4c73e25c2d011748f15eda Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Sun, 8 May 2022 03:00:10 +0000
+Subject: [PATCH] vmwgfx: fix missing array notation
+
+ Fixes error identified by gcc-12.1.0 compiler
+
+make
+  CC       libvmwgfx_la-vmwgfx_tex_video.lo
+vmwgfx_tex_video.c: In function 'stop_video':
+vmwgfx_tex_video.c:240:20: error: the comparison will always evaluate as 'true' for the address of 'yuv' will never be NULL [-Werror=address]
+  240 |                if (priv->yuv[i]) {
+      |                    ^~~~
+---
+ vmwgfx/vmwgfx_tex_video.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vmwgfx/vmwgfx_tex_video.c b/vmwgfx/vmwgfx_tex_video.c
+index acc2b56..480a5f1 100644
+--- a/vmwgfx/vmwgfx_tex_video.c
++++ b/vmwgfx/vmwgfx_tex_video.c
+@@ -237,7 +237,7 @@ stop_video(ScrnInfoPtr pScrn, pointer data, Bool shutdown)
+ 
+        for (i=0; i<3; ++i) {
+ 	   for (j=0; j<2; ++j) {
+-	       if (priv->yuv[i]) {
++	       if (priv->yuv[j][i]) {
+ 		   xa_surface_destroy(priv->yuv[j][i]);
+ 		   priv->yuv[j][i] = NULL;
+ 	       }

--- a/srcpkgs/xf86-video-vmware/template
+++ b/srcpkgs/xf86-video-vmware/template
@@ -1,7 +1,7 @@
 # Template file for 'xf86-video-vmware'
 pkgname=xf86-video-vmware
 version=13.3.0
-revision=3
+revision=4
 archs="i686* x86_64*"
 build_style=gnu-configure
 configure_args="--enable-vmwarectrl-client"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

Revbump since this is a bugfix from upstream and does slightly change behavior.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
