### PR TITLE
libunique1: relax warnings for gcc12

### DIFF
--- a/srcpkgs/libunique1/template
+++ b/srcpkgs/libunique1/template
@@ -15,7 +15,7 @@ homepage="https://wiki.gnome.org/Attic/LibUnique"
 distfiles="${GNOME_SITE}/libunique/1.1/libunique-${version}.tar.bz2"
 checksum=e5c8041cef8e33c55732f06a292381cb345db946cf792a4ae18aa5c66cdd4fbb
 
-CFLAGS="-Wno-deprecated-declarations"
+CFLAGS="-Wno-deprecated-declarations -Wno-incompatible-pointer-types"
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
