### PR TITLE
openssh: relax warnings for gcc12

### DIFF
--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -40,7 +40,7 @@ if [ "$build_option_ldns" -a -z "$build_option_ssl" ]; then
 	broken="option 'ldns' requires option 'ssl'"
 fi
 
-CFLAGS="-Wno-format-truncation -Wno-stringop-truncation"
+CFLAGS="-Wno-format-truncation -Wno-stringop-truncation -Wno-maybe-uninitialized"
 
 case $XBPS_TARGET_MACHINE in
 	i686-musl)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
