### PR TITLE
.github/workflows/stale.yml: ignore tracking issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,4 +22,4 @@ jobs:
           exempt-all-assignees: true
           ascending: true
           operations-per-run: 250
-          exempt-issue-labels: 'request,bug'
+          exempt-issue-labels: 'request,bug,tracking'


### PR DESCRIPTION
I created a new label for tracking issues. it's logical that they should be excluded from stalebot.

If a tracking label isn't wanted, it can be removed.

Related: should the existing [`inactive`](https://github.com/void-linux/void-packages/labels/inactive) label be merged with the `stale` label? there's only one open issue with it