### PR TITLE
linux-headers: update to 5.19.

### DIFF
--- a/srcpkgs/linux/template
+++ b/srcpkgs/linux/template
@@ -1,6 +1,6 @@
 # Template file for 'linux'
 pkgname=linux
-version=5.18
+version=5.19
 revision=1
 build_style=meta
 depends="linux${version} linux-base"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Packages that depend on `linux-headers` still want the 5.18 kernel header files. Since the new
mainline kernel for void is 5.19 I consider this a bug.
