### PR TITLE
common/xbps-src/shutils/update_check.sh: tweak url and rx for codeberg

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -149,8 +149,8 @@ update_check() {
                 rx='/crates/'${pkgname#rust-}'/\K[0-9.]*(?=/download)' ;;
             *codeberg.org*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
-                url="https://codeberg.org/$pkgurlname/releases"
-                rx='/archive/\K[\d.]+(?=\.tar\.gz)' ;;
+                url="https://codeberg.org/$pkgurlname/tags"
+                rx='/archive/(v-?|\Q'"$pkgname"'\E-)?\K[\d.]+(?=\.tar\.gz)' ;;
             *hg.sr.ht*)
                 pkgurlname="$(printf %s "$url" | cut -d/ -f4,5)"
                 url="https://hg.sr.ht/$pkgurlname/tags"


### PR DESCRIPTION
Exhaustive verification is cheap due to low volume
`grep -lr --include template codeberg srcpkgs/ | cut -d/ -f2 | xargs -n1 ./xbps-src update-check`

On current master `mdcat` and `nsxiv` reports `NO VERSION`.