### PR TITLE
ario: remove unused dependency on libunique1

### DIFF
--- a/srcpkgs/ario/template
+++ b/srcpkgs/ario/template
@@ -6,15 +6,16 @@ build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config intltool"
 makedepends="avahi-glib-libs-devel dbus-glib-devel gnutls-devel gtk+3-devel
- libcurl-devel libmpdclient-devel libnotify-devel libunique1-devel taglib-devel"
+ libcurl-devel libmpdclient-devel libnotify-devel taglib-devel"
 short_desc="GTK client for MPD"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
-license="GPL-2"
+license="GPL-2.0-or-later"
 homepage="http://ario-player.sourceforge.net/?en"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}-player/${pkgname}-${version}.tar.gz"
 checksum=1442ede8eef994384489d72d028d7f7b1a1c81efe737f7147587dd02c772d09a
+make_check=no # Tests still depend on build files that have been removed by upstream
 
-post_extract() {
+post_patch() {
 	vsed -i 's,<glib/gi18n.h>,<glib.h>,g' src/ario-profiles.c
 	vsed -i -e 's/DATADIRNAME=lib/DATADIRNAME=share/' configure
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc: @leahneukirchen 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
