### PR TITLE
shotwell: remove unused dependency on libunique

### DIFF
--- a/srcpkgs/shotwell/template
+++ b/srcpkgs/shotwell/template
@@ -8,7 +8,7 @@ hostmakedepends="gcr-devel gettext glib-devel itstool
 makedepends="gst-plugins-base1-devel libgdata-devel
  libgee08-devel libgexiv2-devel libgphoto2-devel libgudev-devel
  libraw-devel libsecret-devel libchamplain-devel libwebp-devel
- libunique-devel rest-devel vala-devel webkit2gtk-devel"
+ rest-devel vala-devel webkit2gtk-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Open source photo manager for GNOME"
 maintainer="Enno Boland <gottox@voidlinux.org>"


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/shotwell/-/commit/7c2e51d3bbf9457d4dd37c60e3f59055c3923cbf

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

shotwell hasn't depended on libunique since 2012.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
