### PR TITLE
efivar: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/efivar/patches/fix-compat-glibc-2.36.patch
+++ b/srcpkgs/efivar/patches/fix-compat-glibc-2.36.patch
@@ -1,0 +1,55 @@
+From bc65d63ebf8fe6ac8a099ff15ca200986dba1565 Mon Sep 17 00:00:00 2001
+From: Robbie Harwood <rharwood@redhat.com>
+Date: Thu, 28 Jul 2022 16:11:24 -0400
+Subject: [PATCH] Fix glibc 2.36 build (mount.h conflicts)
+
+glibc has decided that sys/mount.h and linux/mount.h are no longer
+usable at the same time.  This broke the build, since linux/fs.h itself
+includes linux/mount.h.  For now, fix the build by only including
+sys/mount.h where we need it.
+
+See-also: https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
+Resolves: #227
+Signed-off-by: Robbie Harwood <rharwood@redhat.com>
+---
+ src/gpt.c   | 1 +
+ src/linux.c | 1 +
+ src/util.h  | 1 -
+ 3 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/gpt.c b/src/gpt.c
+index 1eda0497..21413c3b 100644
+--- a/src/gpt.c
++++ b/src/gpt.c
+@@ -17,6 +17,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/mount.h>
+ #include <sys/param.h>
+ #include <sys/stat.h>
+ #include <sys/utsname.h>
+diff --git a/src/linux.c b/src/linux.c
+index 47e45ae4..1780816f 100644
+--- a/src/linux.c
++++ b/src/linux.c
+@@ -20,6 +20,7 @@
+ #include <stdbool.h>
+ #include <stdio.h>
+ #include <sys/ioctl.h>
++#include <sys/mount.h>
+ #include <sys/socket.h>
+ #include <sys/sysmacros.h>
+ #include <sys/types.h>
+diff --git a/src/util.h b/src/util.h
+index 3300666f..1e67e447 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -23,7 +23,6 @@
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/ioctl.h>
+-#include <sys/mount.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <tgmath.h>


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
