### PR TITLE
grub: fix build for binutils 2.36

### DIFF
--- a/srcpkgs/grub/patches/fix-compat-binutils-2.36.patch
+++ b/srcpkgs/grub/patches/fix-compat-binutils-2.36.patch
@@ -1,0 +1,96 @@
+From b98275138bf4fc250a1c362dfd2c8b1cf2421701 Mon Sep 17 00:00:00 2001
+From: Michael Chang <mchang@suse.com>
+Date: Tue, 28 Sep 2021 13:50:47 +0800
+Subject: build: Fix build error with binutils 2.36
+
+The following procedure to build xen/pvgrub is broken.
+
+  git clone https://git.savannah.gnu.org/git/grub.git
+  cd grub
+  ./bootstrap
+  mkdir build-xen
+  cd build-xen
+  ../configure --with-platform=xen
+  make
+
+It fails with the message:
+
+  /usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld:
+  section .note.gnu.property VMA [0000000000400158,0000000000400187]
+  overlaps section .bss VMA [000000000000f000,000000000041e1af]
+
+The most significant factor is that new assembler (GNU as) generates the
+.note.gnu.property section as default. This note section overlaps with
+.bss because it doesn't reposition with -Wl,-Ttext,0 with which the base
+address of .text section is set, rather the address of .note.gnu.property
+is calculated for some reason from 0x400000 where the ELF executable
+defaults to start.
+
+Using -Ttext-segment doesn't help either, though it is said to set the
+address of the first byte of the text segment according to "man ld".
+What it actually does is to override the default 0x400000, aka the image
+base address, to something else. The entire process can be observed in
+the default linker script used by gcc [1]. Therefore we can't expect it
+to achieve the same thing as -Ttext given that the first segment where
+.text resides is offset by SIZEOF_HEADERS plus some sections may be
+preceding it within the first segment. The end result is .text always
+has to start with non-zero address with -Wl,-Ttext-segment,0 if using
+default linker script.
+
+It is also worth mentioning that binutils upstream apparently doesn't
+seem to consider this as a bug [2] and proposed to use -Wl,-Ttext-segment,0
+which is not fruitful as what has been tested by Gentoo [3].
+
+As long as GRUB didn't use ISA information encoded in .note.gnu.property,
+we can safely drop it via -Wa,-mx86-used-note=no assembler option to
+fix the linker error above.
+
+This is considered a better approach than using custom linker script to
+drop the .note.gnu.property section because object file manipulation can
+also be hampered one way or the other in that linker script may not be
+helpful. See also this commit removing the section in the process of objcopy.
+
+  6643507ce build: Fix GRUB i386-pc build with Ubuntu gcc
+
+[1] In /usr/lib64/ldscripts/elf_x86_64.x or use 'gcc -Wl,--verbose ...'
+    PROVIDE (__executable_start = SEGMENT_START("text-segment", 0x400000));
+    . = SEGMENT_START("text-segment", 0x400000) + SIZEOF_HEADERS;
+[2] https://sourceware.org/bugzilla/show_bug.cgi?id=27377
+[3] https://bugs.gentoo.org/787221
+
+Signed-off-by: Michael Chang <mchang@suse.com>
+Reviewed-by: Daniel Kiper <daniel.kiper@oracle.com>
+---
+ configure.ac | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+(limited to 'configure.ac')
+
+diff --git a/configure.ac b/configure.ac
+index eeb5d22..8d1c81a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -840,6 +840,20 @@ if ( test "x$target_cpu" = xi386 || test "x$target_cpu" = xx86_64 ) && test "x$p
+   TARGET_CFLAGS="$TARGET_CFLAGS -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow"
+ fi
+ 
++if ( test "x$target_cpu" = xi386 || test "x$target_cpu" = xx86_64 ); then
++  AC_CACHE_CHECK([whether -Wa,-mx86-used-note works], [grub_cv_cc_mx86_used_note], [
++    CFLAGS="$TARGET_CFLAGS -Wa,-mx86-used-note=no -Werror"
++    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
++	[grub_cv_cc_mx86_used_note=yes],
++	[grub_cv_cc_mx86_used_note=no])
++  ])
++
++  if test "x$grub_cv_cc_mx86_used_note" = xyes; then
++    TARGET_CFLAGS="$TARGET_CFLAGS -Wa,-mx86-used-note=no"
++    TARGET_CCASFLAGS="$TARGET_CCASFLAGS -Wa,-mx86-used-note=no"
++  fi
++fi
++
+ # GRUB doesn't use float or doubles at all. Yet some toolchains may decide
+ # that floats are a good fit to run instead of what's written in the code.
+ # Given that floating point unit is disabled (if present to begin with)
+-- 
+cgit v1.1
+

--- a/srcpkgs/grub/template
+++ b/srcpkgs/grub/template
@@ -2,7 +2,8 @@
 pkgname=grub
 version=2.06
 revision=2
-hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf help2man"
+hostmakedepends="python3 pkg-config flex freetype-devel font-unifont-bdf help2man
+ automake gettext-devel-tools"
 makedepends="libusb-compat-devel ncurses-devel freetype-devel
  liblzma-devel device-mapper-devel fuse-devel"
 depends="os-prober"
@@ -42,6 +43,10 @@ case "$XBPS_TARGET_MACHINE" in
 		subpackages+=" grub-powerpc-ieee1275"
 		;;
 esac
+
+pre_configure() {
+	autoreconf -fi
+}
 
 do_configure() {
 	# workaround for https://savannah.gnu.org/bugs/?60458


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
