### PR TITLE
syslinux: fix build for glibc 2.36

### DIFF
--- a/srcpkgs/syslinux/patches/fix-build-with-glibc-2.36.patch
+++ b/srcpkgs/syslinux/patches/fix-build-with-glibc-2.36.patch
@@ -1,0 +1,30 @@
+--- a/linux/syslinux.c
++++ b/linux/syslinux.c
+@@ -45,7 +45,6 @@
+ #include <sys/stat.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+-#include <sys/mount.h>
+ 
+ #include "linuxioctl.h"
+ 
+--- a/libinstaller/syslxcom.c
++++ b/libinstaller/syslxcom.c
+@@ -28,7 +28,6 @@
+ #include <errno.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+-#include <sys/mount.h>
+ #include <sys/vfs.h>
+ 
+ #include "linuxioctl.h"
+--- a/extlinux/main.c
++++ b/extlinux/main.c
+@@ -40,7 +40,6 @@
+ #include <sys/stat.h>
+ #include <sys/sysmacros.h>
+ #include <sys/types.h>
+-#include <sys/mount.h>
+ #include <sys/vfs.h>
+ 
+ #include "linuxioctl.h"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
