### PR TITLE
strongswan: update to 5.9.7.

### DIFF
--- a/srcpkgs/strongswan/template
+++ b/srcpkgs/strongswan/template
@@ -1,6 +1,6 @@
 # Template file for 'strongswan'
 pkgname=strongswan
-version=5.9.2
+version=5.9.7
 revision=1
 build_style=gnu-configure
 # tpm support waits on libtss2
@@ -8,7 +8,7 @@ configure_args="--disable-static --enable-blowfish --enable-curl --enable-md4
  --enable-openssl --enable-eap-radius --enable-eap-mschapv2 --enable-eap-md5
  --enable-eap-identity --enable-eap-dynamic --enable-led --enable-ha --enable-dhcp
  --enable-mediation --enable-soup --disable-des --enable-chapoly --enable-nm"
-hostmakedepends="pkg-config flex bison python"
+hostmakedepends="pkg-config flex bison python3"
 makedepends="gmp-devel libsoup-devel libldns-devel unbound-devel libcurl-devel
  NetworkManager-devel openssl-devel"
 depends="iproute2 sqlite"
@@ -17,9 +17,9 @@ short_desc="IPsec-based VPN solution, supporting IKEv1/IKEv2 and MOBIKE"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.strongswan.org/"
-changelog="https://wiki.strongswan.org/projects/strongswan/wiki/Changelog"
+changelog="https://raw.githubusercontent.com/strongswan/strongswan/master/NEWS"
 distfiles="https://download.strongswan.org/${pkgname}-${version}.tar.bz2"
-checksum=61c72f741edb2c1295a7b7ccce0317a104b3f9d39efd04c52cd05b01b55ab063
+checksum=9e64a2ba62efeac81abff1d962522404ebc6ed6c0d352a23ab7c0b2c639e3fcf
 make_dirs="/etc/ipsec.d/ 0755 root root
  /etc/ipsec.d/aacerts 0755 root root
  /etc/ipsec.d/acerts 0755 root root


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

I personally use this package and have been using my locally built updated version for the last 3-4 days without noticing any difference.

This update also upgrades the python version in `hostmakedepends` to python3 as upstream [switched to it](https://github.com/strongswan/strongswan/commit/3e2841572bd6f5dfd0d3641472f00eefa4d83d7a) a few minor versions ago.