### PR TITLE
bluez: update to 5.65

### DIFF
--- a/srcpkgs/bluez/template
+++ b/srcpkgs/bluez/template
@@ -1,6 +1,6 @@
 # Template file for 'bluez'
 pkgname=bluez
-version=5.64
+version=5.65
 revision=1
 build_style=gnu-configure
 configure_args="--with-udevdir=/usr/lib/udev --disable-systemd
@@ -15,7 +15,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="http://www.bluez.org/"
 distfiles="${KERNEL_SITE}/bluetooth/$pkgname-$version.tar.xz"
-checksum=ae437e65b6b3070c198bc5b0109fe9cdeb9eaa387380e2072f9de65fe8a1de34
+checksum=2565a4d48354b576e6ad92e25b54ed66808296581c8abb80587051f9993d96d4
 conf_files="/etc/bluetooth/main.conf"
 system_groups="bluetooth"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**
  - I checked that it fixes [a bug](https://github.com/bluez/bluez/commit/c7955b2099dc6be46e977229d852612c4817f78f) present in 5.64 that affects my [Mooltipass](https://www.themooltipass.com/)

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross)
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)