### PR TITLE
Signal-Desktop: update to 5.56.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=5.55.0
+version=5.56.0
 revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=a239a1b18de43fa9ea7e7ce34709fbc233563a95aedb418defa6a1bd8dfb3e8e
+checksum=ddec149fcb53253a26e8436fd1157e28ccf32673663d3b6a51753af31efa883b
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64