### PR TITLE
gnome-software: don't open irrelevant mimetypes

### DIFF
--- a/srcpkgs/gnome-software/patches/0001-only-associate-flatpak-mimetypes.patch
+++ b/srcpkgs/gnome-software/patches/0001-only-associate-flatpak-mimetypes.patch
@@ -1,0 +1,8 @@
+--- a/src/gnome-software-local-file.desktop.in
++++ b/src/gnome-software-local-file.desktop.in
+@@ -9,4 +9,4 @@ Type=Application
+ Icon=system-software-install
+ StartupNotify=true
+ NoDisplay=true
+-MimeType=application/x-rpm;application/x-redhat-package-manager;application/x-deb;application/x-app-package;application/vnd.ms-cab-compressed;application/vnd.flatpak;application/vnd.flatpak.repo;application/vnd.flatpak.ref;application/vnd.snap;
++MimeType=application/vnd.flatpak;application/vnd.flatpak.repo;application/vnd.flatpak.ref

--- a/srcpkgs/gnome-software/template
+++ b/srcpkgs/gnome-software/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome-software'
 pkgname=gnome-software
 version=42.4
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dvalgrind=false -Dpackagekit=false -Dfwupd=false
  -Dmalcontent=false $(vopt_bool gtk_doc) -Dsoup2=true"


### PR DESCRIPTION
The gnome-software package can only be used for flatpaks, opening rpms,
debs and other package archives will only result in an error message.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO** (todo)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
