### PR TITLE
New package: rpi-usbboot-20221104.153421

### DIFF
--- a/srcpkgs/rpi-usbboot/patches/0001-Use-PREFIX-and-DESTDIR-in-Makefile.patch
+++ b/srcpkgs/rpi-usbboot/patches/0001-Use-PREFIX-and-DESTDIR-in-Makefile.patch
@@ -1,0 +1,51 @@
+From da26cd80362e939510fedd51c9486946a61dc159 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jan=20Christian=20Gr=C3=BCnhage?=
+ <jan.christian@gruenhage.xyz>
+Date: Wed, 24 Aug 2022 23:48:08 +0200
+Subject: [PATCH] Use PREFIX and DESTDIR in Makefile
+
+---
+ Makefile | 25 +++++++++++++------------
+ 1 file changed, 13 insertions(+), 12 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index dc78cfe..845e23b 100755
+--- a/Makefile
++++ b/Makefile
+@@ -13,20 +13,21 @@ bin2c: bin2c.c
+ 	$(CC) -Wall -Wextra -g -o $@ $<
+ 
+ install: rpiboot
+-	install -m 755 rpiboot /usr/bin/
+-	install -d /usr/share/rpiboot
+-	install -m 644 msd/bootcode.bin  /usr/share/rpiboot/
+-	install -m 644 msd/bootcode4.bin /usr/share/rpiboot/
+-	install -m 644 msd/start.elf  /usr/share/rpiboot/
+-	install -m 644 msd/start4.elf /usr/share/rpiboot/
++	install -d $(DESTDIR)$(PREFIX)/bin
++	install -m 755 rpiboot $(DESTDIR)$(PREFIX)/bin/
++	install -d $(DESTDIR)$(PREFIX)/share/rpiboot
++	install -m 644 msd/bootcode.bin $(DESTDIR)$(PREFIX)/share/rpiboot/
++	install -m 644 msd/bootcode4.bin $(DESTDIR)$(PREFIX)/share/rpiboot/
++	install -m 644 msd/start.elf $(DESTDIR)$(PREFIX)/share/rpiboot/
++	install -m 644 msd/start4.elf $(DESTDIR)$(PREFIX)/share/rpiboot/
+ 
+ uninstall:
+-	rm -f /usr/bin/rpiboot
+-	rm -f /usr/share/rpiboot/bootcode.bin
+-	rm -f /usr/share/rpiboot/bootcode4.bin
+-	rm -f /usr/share/rpiboot/start.elf
+-	rm -f /usr/share/rpiboot/start4.elf
+-	rmdir --ignore-fail-on-non-empty /usr/share/rpiboot/
++	rm -f $(DESTDIR)$(PREFIX)/bin/rpiboot
++	rm -f $(DESTDIR)$(PREFIX)/share/rpiboot/bootcode.bin
++	rm -f $(DESTDIR)$(PREFIX)/share/rpiboot/bootcode4.bin
++	rm -f $(DESTDIR)$(PREFIX)/share/rpiboot/start.elf
++	rm -f $(DESTDIR)$(PREFIX)/share/rpiboot/start4.elf
++	rmdir --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/share/rpiboot/
+ 
+ clean:
+ 	rm -f rpiboot msd/*.h bin2c
+-- 
+2.37.2
+

--- a/srcpkgs/rpi-usbboot/template
+++ b/srcpkgs/rpi-usbboot/template
@@ -1,0 +1,17 @@
+# Template file for 'rpi-usbboot'
+pkgname=rpi-usbboot
+version=20221104.153421
+revision=1
+build_style=gnu-makefile
+hostmakedepends="pkg-config"
+makedepends="libusb-devel"
+short_desc="Raspberry Pi USB booting code, moved from tools repository"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0"
+homepage="https://github.com/raspberrypi/usbboot"
+changelog="https://raw.githubusercontent.com/raspberrypi/usbboot/master/debian/changelog"
+distfiles="https://github.com/raspberrypi/usbboot/archive/refs/tags/${version/./-}.tar.gz"
+checksum=f19395f66e358c5bbd9088508df168321ad070fbc46132b36965b4a2f8142c64
+nostrip_files="/usr/share/rpiboot/start.elf /usr/share/rpiboot/start4.elf"
+ignore_elf_files="${nostrip_files}"
+nocross="Makefile requires more patching first"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
