### PR TITLE
New package: tarlz-0.27.1

### DIFF
--- a/srcpkgs/tarlz/template
+++ b/srcpkgs/tarlz/template
@@ -1,0 +1,36 @@
+# Template file for 'tarlz'
+pkgname=tarlz
+version=0.27.1
+revision=1
+build_style=configure
+configure_args="--prefix=/usr"
+makedepends="lzlib-devel"
+checkdepends="lzip"
+short_desc="Archiver with multimember lzip compression"
+maintainer="Matt Boehlke <git@mtboehlke.com>"
+license="GPL-2.0-or-later"
+homepage="https://www.nongnu.org/lzip/tarlz.html"
+distfiles="${NONGNU_SITE}/lzip/tarlz/tarlz-${version}.tar.lz"
+checksum=7091968e8f9b5333730e7a558ebf5aa9089d9f0528e6aea994c6f24a9d46a03f
+
+CPPFLAGS="-D_LARGE_FILE_SOURCE=1 -D_FILE_OFFSET_BITS=64"
+
+do_configure() {
+	./configure ${configure_args} \
+		CXX="${CXX}" \
+		CPPFLAGS="${CPPFLAGS}" \
+		CXXFLAGS="${CXXFLAGS}" \
+		LDFLAGS="${LDFLAGS}"
+}
+
+pre_check() {
+	if [ "$XBPS_TARGET_MACHINE" = "i686" ]; then
+		# EOVERFLOW with i686-glibc until stat is using 64-bit time_t
+		vsed -e 's/\${safe_dates} \${dates}/\${safe_dates}/g' \
+			-e '/2106-02-07T06:28:15/d' \
+			-e 's/2038-01-19T03:14:08//' \
+			-e "s/2242-03-16T12:56:31 2242-03-16T12:56:32 @8589934591 @8589934592//" \
+			-i testsuite/check.sh
+	fi
+	:
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **In progress**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

From the [tarlz homepage](https://www.nongnu.org/lzip/tarlz.html): "Tarlz creates tar archives using a simplified and safer variant of the POSIX pax format compressed in lzip format, keeping the alignment between tar members and lzip members. The resulting multimember tar.lz archive is fully backward compatible with standard tar tools like GNU tar, which treat it like any other tar.lz archive."

Keeping the alignment has advantages, which the webpage explains nicely.

Also from the homepage: "Tarlz does not understand other tar formats like gnu, oldgnu, star or v7. The command 'tarlz -tf archive.tar.lz > /dev/null' can be used to verify that the format of the archive is compatible with tarlz."

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
