### PR TITLE
New package: jruby-9.3.8.0

### DIFF
--- a/srcpkgs/jruby/template
+++ b/srcpkgs/jruby/template
@@ -1,0 +1,50 @@
+# Template file for 'jruby'
+pkgname=jruby
+version=9.3.8.0
+revision=1
+hostmakedepends="apache-ant>=1.8 apache-maven>=3.3.0"
+depends="virtual?java-runtime"
+short_desc="Implementation of the Ruby language using the JVM"
+maintainer="Chloris <chloris@freedommail.ch>"
+license="EPL-2.0, GPL-2.0-only, LGPL-2.1-only"
+homepage="https://www.jruby.org/"
+distfiles="https://repo1.maven.org/maven2/org/jruby/jruby-dist/${version}/${pkgname}-dist-${version}-src.zip"
+checksum=c2ee3b79c29afd86c538e347ba48d935703d0d1ee665010f9ae52adc358429e5
+conflicts="ruby ruby-ri"
+
+do_build() {
+	./mvnw
+}
+
+post_build() {
+	cd bin
+	# Remove Windows scripts, binaries and libraries
+	rm -f *.bat *.exe *.dll
+}
+
+do_install() {
+	for file in bin/*
+	do
+		# Copy symlinks
+		if [ -L "$file" ]
+		then
+			vcopy "$file" usr/bin
+		# Install binaries with correct permissions
+		elif [ -f "$file" ]
+		then
+			vbin "$file"
+		fi
+	done
+
+	vmkdir usr/lib
+	vinstall lib/jruby.jar 644 usr/lib/
+	vcopy lib/ruby usr/lib/
+
+	vdoc README.md
+
+	# Fix file permissions on musl architectures
+	if [ $XBPS_LIBC == 'musl' ]
+	then
+		find "$DESTDIR/usr/lib" -perm /022 -exec chmod go-w {} \;
+	fi
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (crossbuild)

#### Motivation
The reference Ruby interpreter can not execute threads on multiple CPU cores because of [GIL](https://en.wikipedia.org/wiki/Global_interpreter_lock). JRuby is able to perform real threading.
