### PR TITLE
[RFC] create build_helper for python3 cross-building

### DIFF
--- a/common/build-helper/python3.sh
+++ b/common/build-helper/python3.sh
@@ -1,0 +1,16 @@
+# fix building non-pure-python modules on cross
+if [ -n "$CROSS_BUILD" ]; then
+	export PYPREFIX="$XBPS_CROSS_BASE"
+	export CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
+	export LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
+	export CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
+	export LDSHARED="${CC} -shared $LDFLAGS"
+	export PYTHON_CONFIG="${XBPS_CROSS_BASE}/usr/bin/python3-config"
+	export PYTHONPATH="${XBPS_CROSS_BASE}/${py3_lib}"
+	for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
+		[ -f "$f" ] || continue
+		f=${f##*/}
+		_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
+	done
+	[ -n "$_PYTHON_SYSCONFIGDATA_NAME" ] && export _PYTHON_SYSCONFIGDATA_NAME
+fi

--- a/common/build-style/python3-module.sh
+++ b/common/build-style/python3-module.sh
@@ -3,24 +3,7 @@
 #
 
 do_build() {
-	if [ -n "$CROSS_BUILD" ]; then
-		PYPREFIX="$XBPS_CROSS_BASE"
-		CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
-		LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
-		CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
-		LDSHARED="${CC} -shared $LDFLAGS"
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		env CC="$CC" LDSHARED="$LDSHARED" \
-			PYPREFIX="$PYPREFIX" CFLAGS="$CFLAGS" \
-			PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib} \
-			_PYTHON_SYSCONFIGDATA_NAME="$_PYTHON_SYSCONFIGDATA_NAME" \
-			LDFLAGS="$LDFLAGS" python3 setup.py build ${make_build_args}
-	else
-		python3 setup.py build ${make_build_args}
-	fi
+	python3 setup.py build ${make_build_args}
 }
 
 do_check() {
@@ -47,23 +30,5 @@ do_check() {
 }
 
 do_install() {
-	if [ -n "$CROSS_BUILD" ]; then
-		PYPREFIX="$XBPS_CROSS_BASE"
-		CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
-		LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
-		CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
-		LDSHARED="${CC} -shared $LDFLAGS"
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		env CC="$CC" LDSHARED="$LDSHARED" \
-			PYPREFIX="$PYPREFIX" CFLAGS="$CFLAGS" \
-			PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib} \
-			_PYTHON_SYSCONFIGDATA_NAME="$_PYTHON_SYSCONFIGDATA_NAME" \
-			LDFLAGS="$LDFLAGS" python3 setup.py \
-				install --prefix=/usr --root=${DESTDIR} ${make_install_args}
-	else
-		python3 setup.py install --prefix=/usr --root=${DESTDIR} ${make_install_args}
-	fi
+	python3 setup.py install --prefix=/usr --root=${DESTDIR} ${make_install_args}
 }

--- a/common/environment/build-style/python3-module.sh
+++ b/common/environment/build-style/python3-module.sh
@@ -1,2 +1,3 @@
 lib32disabled=yes
 makedepends+=" python3"
+build_helper+=" python3"

--- a/srcpkgs/brltty/template
+++ b/srcpkgs/brltty/template
@@ -1,8 +1,9 @@
 # Template file for 'brltty'
 pkgname=brltty
 version=6.4
-revision=5
+revision=6
 build_style=gnu-configure
+build_helper=python3
 configure_args="--enable-gpm --with-screen-driver=lx,sc
  --with-tables-directory=/usr/share/brltty PYTHON=/usr/bin/python3"
 hostmakedepends="pkg-config python3-Cython"
@@ -10,8 +11,8 @@ makedepends="ncurses-devel alsa-lib-devel gpm-devel icu-devel python3-devel libb
 short_desc="Braille display driver for Linux/Unix"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
-homepage="http://mielke.cc/brltty/"
-distfiles="http://mielke.cc/brltty/archive/brltty-${version}.tar.xz"
+homepage="https://brltty.app"
+distfiles="https://brltty.app/archive/brltty-${version}.tar.xz"
 checksum=bc7573b0d0ab865c36607945b64c209312405571788f3b409397726f6143eaa6
 python_version=3
 
@@ -25,8 +26,8 @@ esac
 
 pre_configure() {
 	case "$XBPS_TARGET_MACHINE" in
-	*-musl) # There is no ldconfig in musl libc
-		sed -e "s;/sbin/ldconfig -n;echo;" -i configure
+		*-musl) # There is no ldconfig in musl libc
+			sed -e "s;/sbin/ldconfig -n;echo;" -i configure ;;
 	esac
 	export PYTHON_LIBS="-L${XBPS_CROSS_BASE}/usr/lib -lpython${py3_ver}${py3_abiver}"
 	export PYTHON_CPPFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
@@ -34,31 +35,17 @@ pre_configure() {
 
 post_configure() {
 	case "$XBPS_TARGET_MACHINE" in
-	arm*-musl) # Fix erroneously detected "#define HAVE_SYS_IO_H 1"
-		sed -i config.h -e"s;#define HAVE_SYS_IO_H 1;#undef HAVE_SYS_IO_H;"
+		arm*-musl) # Fix erroneously detected "#define HAVE_SYS_IO_H 1"
+			sed -i config.h -e"s;#define HAVE_SYS_IO_H 1;#undef HAVE_SYS_IO_H;" ;;
 	esac
-}
-
-pre_build() {
-	if [ "$CROSS_BUILD" ]; then
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			export _PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		export PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib}
-	fi
-}
-
-pre_install() {
-	pre_build
 }
 
 do_install() {
 	make INSTALL_ROOT=${DESTDIR} install
-	vsv $pkgname
+	vsv brltty
 	vsconf Documents/brltty.conf
 	vdoc Documents/ChangeLog
-	vcopy Documents/Manual-BRLTTY usr/share/doc/${pkgname}
+	vcopy Documents/Manual-BRLTTY usr/share/doc/brltty
 }
 
 brltty-devel_package() {

--- a/srcpkgs/i2c-tools/template
+++ b/srcpkgs/i2c-tools/template
@@ -1,8 +1,9 @@
 # Template file for 'i2c-tools'
 pkgname=i2c-tools
 version=4.3
-revision=2
+revision=3
 build_style=gnu-makefile
+build_helper=python3
 make_build_args="EXTRA=py-smbus"
 make_install_args="sbindir=/usr/bin EXTRA=py-smbus"
 hostmakedepends="python3 python3-setuptools"
@@ -15,21 +16,6 @@ homepage="https://i2c.wiki.kernel.org/index.php/I2C_Tools"
 distfiles="https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-${version}.tar.xz"
 checksum=1f899e43603184fac32f34d72498fc737952dbc9c97a8dd9467fadfdf4600cf9
 system_groups="i2c"
-
-
-if [ -n "$CROSS_BUILD" ]; then
-	export PYPREFIX="$XBPS_CROSS_BASE"
-	export CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
-	export LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
-	export CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
-	export LDSHARED="${CC} -shared $LDFLAGS"
-	export PYTHONPATH="${XBPS_CROSS_BASE}/${py3_lib}"
-	for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-	done
-	export _PYTHON_SYSCONFIGDATA_NAME
-fi
 
 post_install() {
 	vinstall "${FILESDIR}/45-i2c-tools.rules" 644 usr/lib/udev/rules.d

--- a/srcpkgs/libpwquality/template
+++ b/srcpkgs/libpwquality/template
@@ -1,10 +1,11 @@
 # Template file for 'libpwquality'
 pkgname=libpwquality
 version=1.4.2
-revision=5
+revision=6
 build_style=gnu-configure
+build_helper=python3
 configure_args="--disable-static --enable-pam --with-securedir=/usr/lib/security"
-hostmakedepends="libtool automake gettext-devel python3-devel"
+hostmakedepends="libtool automake gettext-devel python3"
 makedepends="cracklib-devel pam-devel python3-devel"
 depends="cracklib"
 conf_files="/etc/security/pwquality.conf"
@@ -13,27 +14,11 @@ maintainer="bra1nwave <bra1nwave@protonmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/libpwquality/libpwquality"
 changelog="https://raw.githubusercontent.com/libpwquality/libpwquality/master/NEWS"
-distfiles="${homepage}/releases/download/libpwquality-${version}/libpwquality-${version}.tar.bz2"
+distfiles="https://github.com/libpwquality/libpwquality/releases/download/libpwquality-${version}/libpwquality-${version}.tar.bz2"
 checksum=5263e09ee62269c092f790ac159112aed3e66826a795e3afec85fdeac4281c8e
 
-CFLAGS="-I${XBPS_CROSS_BASE}/${py3_inc}"
-
 pre_configure() {
-	vsed -i python/Makefile.am -e 's|CFLAGS=.*|LDSHARED="${CC} -pthread -shared" &|g'
 	autoreconf -fi
-}
-
-pre_build() {
-	if [ "$CROSS_BUILD" ]; then
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			export _PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		export PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib}
-	fi
-}
-pre_install() {
-	pre_build
 }
 
 libpwquality-devel_package() {

--- a/srcpkgs/tlsh/template
+++ b/srcpkgs/tlsh/template
@@ -1,8 +1,9 @@
 # Template file for 'tlsh'
 pkgname=tlsh
 version=3.19.1
-revision=3
+revision=4
 build_style=cmake
+build_helper=python3
 hostmakedepends="python3"
 makedepends="python3-devel"
 short_desc="Fuzzy matching library"
@@ -19,24 +20,7 @@ pre_configure() {
 
 post_build() {
 	cd py_ext
-	if [ -n "$CROSS_BUILD" ]; then
-		PYPREFIX="$XBPS_CROSS_BASE"
-		CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
-		LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
-		CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
-		LDSHARED="${CC} -shared $LDFLAGS"
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		env CC="$CC" LDSHARED="$LDSHARED" \
-			PYPREFIX="$PYPREFIX" CFLAGS="$CFLAGS" \
-			PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib} \
-			_PYTHON_SYSCONFIGDATA_NAME="$_PYTHON_SYSCONFIGDATA_NAME" \
-			LDFLAGS="$LDFLAGS" python3 setup.py build ${make_build_args}
-	else
-		python3 setup.py build ${make_build_args}
-	fi
+	python3 setup.py build ${make_build_args}
 }
 
 
@@ -47,25 +31,7 @@ pre_check() {
 post_install() {
 	vlicense LICENSE
 	cd py_ext
-	if [ -n "$CROSS_BUILD" ]; then
-		PYPREFIX="$XBPS_CROSS_BASE"
-		CFLAGS+=" -I${XBPS_CROSS_BASE}/${py3_inc} -I${XBPS_CROSS_BASE}/usr/include"
-		LDFLAGS+=" -L${XBPS_CROSS_BASE}/${py3_lib} -L${XBPS_CROSS_BASE}/usr/lib"
-		CC="${XBPS_CROSS_TRIPLET}-gcc -pthread $CFLAGS $LDFLAGS"
-		LDSHARED="${CC} -shared $LDFLAGS"
-		for f in ${XBPS_CROSS_BASE}/${py3_lib}/_sysconfigdata_*; do
-			f=${f##*/}
-			_PYTHON_SYSCONFIGDATA_NAME=${f%.py}
-		done
-		env CC="$CC" LDSHARED="$LDSHARED" \
-			PYPREFIX="$PYPREFIX" CFLAGS="$CFLAGS" \
-			PYTHONPATH=${XBPS_CROSS_BASE}/${py3_lib} \
-			_PYTHON_SYSCONFIGDATA_NAME="$_PYTHON_SYSCONFIGDATA_NAME" \
-			LDFLAGS="$LDFLAGS" python3 setup.py \
-				install --prefix=/usr --root=${DESTDIR} ${make_install_args}
-	else
-		python3 setup.py install --prefix=/usr --root=${DESTDIR} ${make_install_args}
-	fi
+	python3 setup.py install --prefix=/usr --root=${DESTDIR} ${make_install_args}
 }
 
 tlsh-devel_package() {


### PR DESCRIPTION
- common/build-helper/python3.sh: add python3 helper
- common/{,environment}/build_style/python3.sh: use python3 build_helper
- brltty: use python3 build_helper, clean up
- i2c-tools: use python3 build_helper
- libpwquality: use python3 build_helper
- tlsh: use python3 build_helper

My hope with this is to help with cross-building non-python packages that have python3 bindings/modules, but it can be used similar to the `rust` `build_helper` for various common constants, if needed.

One thing I'm not sure on is the usage with the `python3-module` `build_style`. It would cut down on the need to keep those env var definitions up-to-date in multiple places, but I'm open to opinions about it.

There's probably more packages that are marked `nocross`/`broken` because of python3 cross stuff that I didn't find.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**
    - packages changed seem to build the same thing as before, but weren't extensively tested