### PR TITLE
gnome: remove network-manager-applet from -apps

### DIFF
--- a/srcpkgs/gnome/template
+++ b/srcpkgs/gnome/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome'
 pkgname=gnome
 version=42.0
-revision=1
+revision=2
 build_style=meta
 short_desc="GNOME meta-package for Void Linux"
 maintainer="Enno Boland <gottox@voidlinux.org>"
@@ -69,7 +69,6 @@ _apps_depends="
  gnome-text-editor>=${version}
  gnome-todo>=41.0
  gnote>=${version}
- network-manager-applet>=1.24.0
  polari>=3.38.0
  rygel>=0.40.2
  simple-scan>=${version}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
