### PR TITLE
jrnl: update to 3.1.

### DIFF
--- a/srcpkgs/jrnl/template
+++ b/srcpkgs/jrnl/template
@@ -1,19 +1,18 @@
 # Template file for 'jrnl'
 pkgname=jrnl
-version=3.0
+version=3.1
 revision=1
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-ansiwrap python3-asteval python3-colorama python3-cryptography
- python3-dateutil python3-keyring python3-parsedatetime python3-passlib
- python3-pytz python3-tzlocal python3-xdg python3-yaml python3-packaging
- python3-ruamel.yaml"
+build_style=python3-pep517
+hostmakedepends="python3-poetry-core"
+depends="python3-ansiwrap python3-colorama python3-cryptography
+ python3-dateutil python3-keyring python3-parsedatetime python3-rich
+ python3-tzlocal python3-xdg python3-ruamel.yaml"
 short_desc="Simple journal application for your command line"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="https://jrnl.sh"
 changelog="https://raw.githubusercontent.com/jrnl-org/jrnl/develop/CHANGELOG.md"
 distfiles="${PYPI_SITE}/j/jrnl/jrnl-${version}.tar.gz"
-checksum=e676780351fd92a34855b802e6ca3d95041b8b6d4d4ed621b121e66908079e73
+checksum=f1c1438b26f01f09266693870c7e81e2cb9d28b9b4d3b7c60ccda06da4189a8b
 # Tarball provides no tests
 make_check=no


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

Changed the deps as per [upstream requirements](https://github.com/jrnl-org/jrnl/blob/v3.1/pyproject.toml#L29-L43). Tried to make the tests work using a gh tarballs with tests but there are at least 4 unpackaged deps under the fulldeptree for tests. Runtime testing seemed fine with basic operations.