### PR TITLE
ImageMagick: update to 7.1.0.46.

### DIFF
--- a/srcpkgs/ImageMagick/template
+++ b/srcpkgs/ImageMagick/template
@@ -1,25 +1,25 @@
 # Template file for 'ImageMagick'
 pkgname=ImageMagick
-version=7.1.0.45
+version=7.1.0.46
 revision=1
 _upstream_version="${version/.${version##*.}/-${version##*.}}"
 wrksrc=${pkgname}-${_upstream_version}
 build_style=gnu-configure
 configure_args="--disable-static --enable-opencl --with-modules --with-gslib
- --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF
+ --with-rsvg --with-wmf --with-dejavu-font-dir=/usr/share/fonts/TTF --with-openexr
  --with-gs-font-dir=/usr/share/fonts/Type1"
 hostmakedepends="automake libtool pkg-config autoconf"
 makedepends="djvulibre-devel fftw-devel ghostscript-devel glib-devel lcms2-devel
  libXt-devel libgomp-devel libltdl-devel librsvg-devel libwebp-devel libwmf-devel
  ocl-icd-devel pango-devel libopenjpeg2-devel graphviz-devel liblqr-devel
- libraqm-devel"
+ libraqm-devel libopenexr-devel"
 short_desc="Create, edit, compose, or convert bitmap images"
 maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="ImageMagick"
 homepage="https://www.imagemagick.org"
 changelog="https://raw.githubusercontent.com/ImageMagick/Website/main/ChangeLog.md"
 distfiles="https://github.com/ImageMagick/ImageMagick/archive/${_upstream_version}.tar.gz"
-checksum=3df6ca6dff15a4e8a20b4593c60285a59e38890440494d91a344e5c0e2bb3eec
+checksum=51e9863ae4a52d6477da0aecc4f79ebccfc5da2721e7a0e63bf09f41700da43c
 
 subpackages="libmagick libmagick-devel"
 


### PR DESCRIPTION
Added support for openexr

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

