### PR TITLE
root: update to 6.26.06

### DIFF
--- a/srcpkgs/root/template
+++ b/srcpkgs/root/template
@@ -1,7 +1,7 @@
 # Template file for 'root'
 pkgname=root
-version=6.26.04
-revision=2
+version=6.26.06
+revision=1
 # Only i686 and x86_64 seem to be officially supported
 archs="i686* x86_64*"
 build_style=cmake
@@ -29,7 +29,7 @@ maintainer="Ben Jargowsky <benjar63@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://root.cern"
 distfiles="https://root.cern/download/root_v${version}.source.tar.gz"
-checksum=a271cf82782d6ed2c87ea5eef6681803f2e69e17b3036df9d863636e9358421e
+checksum=b1f73c976a580a5c56c8c8a0152582a1dfc560b4dd80e1b7545237b65e6c89cb
 build_options="fortran root7"
 build_options_default="fortran"
 python_version=3


### PR DESCRIPTION

- I tested the changes in this PR: **YES**


- I built this PR locally for my native architecture, (x86_64-glibc)