### PR TITLE
jamulus: update to 3.9.0

### DIFF
--- a/srcpkgs/jamulus/template
+++ b/srcpkgs/jamulus/template
@@ -1,16 +1,16 @@
 # Template file for 'jamulus'
 pkgname=jamulus
-version=3.8.2
+version=3.9.0
 revision=1
 _version=r${version//./_}
 wrksrc=${pkgname}-${_version}
 build_style=qmake
 configure_args="Jamulus.pro"
 hostmakedepends="pkg-config qt5-qmake qt5-host-tools"
-makedepends="qt5-declarative-devel jack-devel"
+makedepends="qt5-declarative-devel jack-devel qt5-multimedia-devel"
 short_desc="Play music online. With friends. For free"
-maintainer="KawaiiAmber <japaneselearning101@gmail.com>"
+maintainer="astralchan <astral@astralchan.xyz>"
 license="GPL-2.0-or-later"
 homepage="https://jamulus.io"
 distfiles="https://github.com/corrados/jamulus/archive/${_version}.tar.gz"
-checksum=4c323db21c896c711f726319b40114d1a0b5a374fd25eb43d9af52c19fc3d55e
+checksum=742b1954111c55b39ea7b2863c762d6731359e2b4793ef2409b150096fb196a5


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)

#### Changes
`qt5-multimedia-devel` should now be explicitly listed in `makedepends`. I've also updated `maintainer` as I no longer use that email / go by that name anymore.
