### PR TITLE
C{,XX}FLAGS: change -fdebug-prefix-map for cmake and meson

### DIFF
--- a/common/environment/configure/debug-debug-prefix-map.sh
+++ b/common/environment/configure/debug-debug-prefix-map.sh
@@ -1,2 +1,13 @@
-CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc=."
-CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc=."
+case "$build_style" in
+cmake)
+	CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc/${cmake_builddir:-build}=."
+	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc/${cmake_builddir:-build}=."
+	;;
+meson)
+	CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc/${meson_builddir:-build}=."
+	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc/${meson_builddir:-build}=."
+	;;
+*)
+	CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc=."
+	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc=."
+esac

--- a/common/environment/configure/debug-debug-prefix-map.sh
+++ b/common/environment/configure/debug-debug-prefix-map.sh
@@ -1,13 +1,16 @@
+local _wrksrc="$wrksrc${build_wrksrc:+/$build_wrksrc}"
 case "$build_style" in
 cmake)
-	CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc/${cmake_builddir:-build}=."
-	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc/${cmake_builddir:-build}=."
+	CFLAGS="${CFLAGS} -fdebug-prefix-map=$_wrksrc/${cmake_builddir:-build}=."
+	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$_wrksrc/${cmake_builddir:-build}=."
 	;;
 meson)
-	CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc/${meson_builddir:-build}=."
-	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc/${meson_builddir:-build}=."
+	CFLAGS="${CFLAGS} -fdebug-prefix-map=$_wrksrc/${meson_builddir:-build}=."
+	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$_wrksrc/${meson_builddir:-build}=."
 	;;
 *)
-	CFLAGS="${CFLAGS} -fdebug-prefix-map=$wrksrc=."
-	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$wrksrc=."
+	CFLAGS="${CFLAGS} -fdebug-prefix-map=$_wrksrc=."
+	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$_wrksrc=."
 esac
+
+unset _wrksrc


### PR DESCRIPTION
Both of them build inside a builddir. This change ease the debugging
process.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
