### PR TITLE
bootiso: depends on exfatprogs

### DIFF
--- a/srcpkgs/bootiso/patches/new-exfat.patch
+++ b/srcpkgs/bootiso/patches/new-exfat.patch
@@ -1,0 +1,11 @@
+--- a/bootiso
++++ b/bootiso
+@@ -507,7 +507,7 @@ function fs_formatPartition() {
+   # These options always end up with the label flag setter
+   local -Ar _mkfsOpts=(
+     ['vfat']="-v -F 32 -n" # Fat32 mode
+-    ['exfat']="-n"
++    ['exfat']="-L"
+     ['ntfs']="-Q -c 4096 -L" # Quick mode + cluster size = 4096 for syslinux support
+     ['ext2']="-O ^64bit -L"  # Disabling pure 64 bits compression for syslinux compatibility
+     ['ext3']="-O ^64bit -L"  # see https://www.syslinux.org/wiki/index.php?title=Filesystem#ext

--- a/srcpkgs/bootiso/template
+++ b/srcpkgs/bootiso/template
@@ -1,11 +1,10 @@
 # Template file for 'bootiso'
 pkgname=bootiso
 version=4.2.0
-revision=2
+revision=3
 build_style=gnu-makefile
-depends="bash bc binutils coreutils curl dosfstools e2fsprogs eudev exfat-utils
- f2fs-tools file findutils gawk grep ncurses ntfs-3g rsync syslinux tar util-linux
- wimlib jq"
+depends="bash bc binutils curl dosfstools e2fsprogs eudev exfatprogs
+ f2fs-tools file ncurses ntfs-3g rsync syslinux wimlib jq"
 short_desc="Create a USB bootable device from an ISO image easily and securely"
 maintainer="Lorem <notloremipsum@protonmail.com>"
 license="GPL-3.0-only"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
