### PR TITLE
rpi-kernel,rpi-firmware: update to 5.15.61. [ci skip]

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -1,10 +1,10 @@
 # Template file for 'rpi-firmware'
-_githash="8f13114b9ea29bd004151d4a8afa500b2df721be"
+_githash="62efc6a69d4e717bf2833c649d622c8298a37e9c"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
-version=20201123
-revision=5
+version=20220823
+revision=1
 archs="armv6l* armv7l* aarch64*"
 wrksrc="firmware-${_githash}"
 provides="linux-firmware-broadcom-${version}_${revision}"
@@ -14,7 +14,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="BSD-3-Clause, custom:Cypress"
 homepage="https://github.com/raspberrypi/firmware"
 distfiles="https://github.com/raspberrypi/firmware/archive/${_githash}.tar.gz"
-checksum=f9be0cc177aae7dddaa0a2967d090ea33a95be9dd519d2eee3bc740af8ffb19e
+checksum=3fc5ab7155bde7221245f439971217558300dcbc988ade861cfef4e737de9909
 
 conf_files="/boot/cmdline.txt /boot/config.txt"
 nostrip=yes
@@ -35,39 +35,39 @@ do_install() {
 	vinstall ${FILESDIR}/cmdline.txt 644 boot
 	vinstall ${FILESDIR}/config.txt 644 boot
 
-	$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/LICENCE.cypress
+	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/LICENCE.cypress
 	vlicense LICENCE.cypress
 
 	# Firmware for rpi3 b and zero wifi chip
 	for f in bin txt; do
-		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43430-sdio.${f}
+		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43430-sdio.${f}
 		vinstall brcmfmac43430-sdio.${f} 0644 usr/lib/firmware/brcm
 	done
 
 	# Firmware for rpi3 b and zero bluetooth chip
-	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM43430A1.hcd
+	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430A1.hcd
 	vinstall BCM43430A1.hcd 0644 usr/lib/firmware/brcm
 
 	# Firmware for rpi3 b+ wifi chip
 	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43455-sdio.${f}
+		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43455-sdio.${f}
 		vinstall brcmfmac43455-sdio.${f} 0644 usr/lib/firmware/brcm
 	done
 
 	# Firmware for rpi3 b+ bluetooth chip
-	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM4345C0.hcd
+	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C0.hcd
 	vinstall BCM4345C0.hcd 0644 usr/lib/firmware/brcm
 
 	# Firmware for rpi4/rpi400 wifi chip
 	for f in bin txt clm_blob; do
-		$XBPS_FETCH_CMD https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm/brcmfmac43456-sdio.${f}
+		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43456-sdio.${f}
 		vinstall brcmfmac43456-sdio.${f} 0644 usr/lib/firmware/brcm
 	done
 
 	# Firmware for rpi4/rpi400 bluetooth chip
-	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM4345C5.hcd
+	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C5.hcd
 	vinstall BCM4345C5.hcd 0644 usr/lib/firmware/brcm
 
-	$XBPS_FETCH_CMD https://github.com/RPi-Distro/bluez-firmware/raw/master/broadcom/BCM43430B0.hcd
+	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM43430B0.hcd
 	vinstall BCM43430B0.hcd 0644 usr/lib/firmware/brcm
 }

--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -1,9 +1,9 @@
 # Template file for 'rpi-kernel'
 #
 # We track the latest Raspberry Pi LTS kernel as that is what is used in the
-# official Raspbian distribution. This is currently 5.10:
+# official Raspberry Pi OS distribution. This is currently 5.15:
 #
-# https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=288234
+# https://forums.raspberrypi.com/viewtopic.php?t=322879
 #
 # Commit hash is picked from latest tag [1], if appropriate, or from latest
 # "Merge remote-tracking branch 'stable/linux-5.10.y' into rpi-5.10.y" commit.
@@ -12,22 +12,22 @@
 #
 # WARNING: keep all rpi*-kernel packages in sync
 
-_githash="82c6f8643398e222099066bfffb2070772f0696f"
+_githash="64ad74084fa44abe8689564071df5729ded4c589"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=5.10.110
+version=5.15.61
 revision=1
 archs="armv6l*"
 wrksrc="linux-${_githash}"
-hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
+hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi zero/1 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=f3ee7782c90ecb3e468e89602248a1de45b466d5d4c1af4748f7ca088c0fcab3
+checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
 python_version=3
 
 _kernver="${version}_${revision}"
@@ -205,10 +205,6 @@ do_install() {
 	# Add wireless headers
 	mkdir -p ${hdrdest}/net/mac80211/
 	cp net/mac80211/*.h ${hdrdest}/net/mac80211
-
-	# add dvb headers for external modules
-	mkdir -p ${hdrdest}/include/config/dvb/
-	cp include/config/dvb/*.h ${hdrdest}/include/config/dvb/
 
 	# Remove unneeded architectures
 	# (save the correct one + Kconfig and delete all others)

--- a/srcpkgs/rpi2-kernel/template
+++ b/srcpkgs/rpi2-kernel/template
@@ -1,7 +1,7 @@
 # Template file for 'rpi2-kernel'
 # See rpi-kernel for version policy
 
-_githash="82c6f8643398e222099066bfffb2070772f0696f"
+_githash="64ad74084fa44abe8689564071df5729ded4c589"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi2-kernel
@@ -16,7 +16,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=f3ee7782c90ecb3e468e89602248a1de45b466d5d4c1af4748f7ca088c0fcab3
+checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
 python_version=3
 
 _kernver="${version}_${revision}"
@@ -197,10 +197,6 @@ do_install() {
 	# Add wireless headers
 	mkdir -p ${hdrdest}/net/mac80211/
 	cp net/mac80211/*.h ${hdrdest}/net/mac80211
-
-	# add dvb headers for external modules
-	mkdir -p ${hdrdest}/include/config/dvb/
-	cp include/config/dvb/*.h ${hdrdest}/include/config/dvb/
 
 	# Remove unneeded architectures
 	# (save the correct one + Kconfig and delete all others)

--- a/srcpkgs/rpi3-kernel/template
+++ b/srcpkgs/rpi3-kernel/template
@@ -1,22 +1,22 @@
 # Template file for 'rpi3-kernel'
 # See rpi-kernel for version policy
 
-_githash="82c6f8643398e222099066bfffb2070772f0696f"
+_githash="64ad74084fa44abe8689564071df5729ded4c589"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi3-kernel
-version=5.10.110
+version=5.15.61
 revision=1
 archs="aarch64*"
 wrksrc="linux-${_githash}"
-hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
+hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 3 / Zero 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=f3ee7782c90ecb3e468e89602248a1de45b466d5d4c1af4748f7ca088c0fcab3
+checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
 python_version=3
 
 _kernver="${version}_${revision}"
@@ -197,10 +197,6 @@ do_install() {
 	# Add wireless headers
 	mkdir -p ${hdrdest}/net/mac80211/
 	cp net/mac80211/*.h ${hdrdest}/net/mac80211
-
-	# add dvb headers for external modules
-	mkdir -p ${hdrdest}/include/config/dvb/
-	cp include/config/dvb/*.h ${hdrdest}/include/config/dvb/
 
 	# Remove unneeded architectures
 	# (save the correct one + Kconfig and delete all others)

--- a/srcpkgs/rpi4-kernel/template
+++ b/srcpkgs/rpi4-kernel/template
@@ -1,22 +1,22 @@
 # Template file for 'rpi4-kernel'
 # See rpi-kernel for version policy
 
-_githash="82c6f8643398e222099066bfffb2070772f0696f"
+_githash="64ad74084fa44abe8689564071df5729ded4c589"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi4-kernel
-version=5.10.110
+version=5.15.61
 revision=1
 archs="aarch64*"
 wrksrc="linux-${_githash}"
-hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
+hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 4 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=f3ee7782c90ecb3e468e89602248a1de45b466d5d4c1af4748f7ca088c0fcab3
+checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
 python_version=3
 conflicts=rpi3-kernel
 
@@ -198,10 +198,6 @@ do_install() {
 	# Add wireless headers
 	mkdir -p ${hdrdest}/net/mac80211/
 	cp net/mac80211/*.h ${hdrdest}/net/mac80211
-
-	# add dvb headers for external modules
-	mkdir -p ${hdrdest}/include/config/dvb/
-	cp include/config/dvb/*.h ${hdrdest}/include/config/dvb/
 
 	# Remove unneeded architectures
 	# (save the correct one + Kconfig and delete all others)


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

I've built rpi4-kernel and rpi-firmware, and created an image for my CM4. It boots, haven't tested anything more so far. I sadly don't have any other Pi products to test on right now, so I'd need some other people to help on this.

cc @Piraty as current maintainer

Resolves https://github.com/void-linux/void-mklive/issues/264
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
