### PR TITLE
common/xbps-src/shutils/update_check.sh: ignore pkgs without distfiles

### DIFF
--- a/common/xbps-src/shutils/update_check.sh
+++ b/common/xbps-src/shutils/update_check.sh
@@ -13,6 +13,11 @@ update_check() {
         if [ "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
             echo "using $XBPS_TARGET_PKG/update overrides" 1>&2
         fi
+    elif [ -z "$distfiles" ]; then
+        if [ "$XBPS_UPDATE_CHECK_VERBOSE" ]; then
+            echo "NO DISTFILES found for $original_pkgname" 1>&2
+        fi
+        return 0
     fi
 
     if ! type curl >/dev/null 2>&1; then


### PR DESCRIPTION
...unless they use the update override file

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
