### PR TITLE
xbps-src: don't export CCACHE_COMPRESS=1

### DIFF
--- a/xbps-src
+++ b/xbps-src
@@ -679,7 +679,7 @@ if [ "$XBPS_CCACHE" ]; then
     export CCACHE_DIR="$XBPS_HOSTDIR/ccache"
     # Avoid not using cached files just due to compiler mtime
     # changes when e.g. bootstrapping
-    export CCACHE_COMPILERCHECK=content CCACHE_COMPRESS=1
+    export CCACHE_COMPILERCHECK=content
     export PATH="$CCACHEPATH:$PATH"
     mkdir -p $CCACHE_DIR
 fi


### PR DESCRIPTION
ccache enables compression by default since version 4.0.
This variable is redundant and prevents disabling compression through
a config file (useful e.g. on compressed filesystems).


AFAIK there's no way to disable compression when `CCACHE_COMPRESS` is present, since the environment has the highest precedence, according to the manual:

```
The priorities of configuration options are as follows (where 1 is highest):

 1. Environment variables.

 2. The primary (cache-specific) configuration file (see below).

 3. The secondary (system-wide read-only) configuration file
     <sysconfdir>/ccache.conf (typically /etc/ccache.conf or
     /usr/local/etc/ccache.conf).

 5. Compile-time defaults.
```

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
