### PR TITLE
fonttools: update to 4.37.1.

### DIFF
--- a/srcpkgs/fonttools/template
+++ b/srcpkgs/fonttools/template
@@ -1,6 +1,6 @@
 # Template file for 'fonttools'
 pkgname=fonttools
-version=4.36.0
+version=4.37.1
 revision=1
 build_style=python3-module
 make_check_args="--deselect Tests/otlLib/optimize_test.py::test_main
@@ -14,7 +14,7 @@ license="MIT, OFL-1.1, BSD-3-Clause"
 homepage="https://github.com/fonttools/fonttools"
 changelog="https://raw.githubusercontent.com/fonttools/fonttools/main/NEWS.rst"
 distfiles="https://github.com/fonttools/fonttools/archive/${version}.tar.gz"
-checksum=7f48433c42351102f25e63778c702be8bed76bfa6c192c67e6d0e985c01f674e
+checksum=9a94f852b602540b11aa520952245ddebc22a490f74d838dbb88f82710a4db20
 replaces="python-fonttools>=0 python3-fonttools>=0"
 provides="python-fonttools-${version}_${revision} python3-fonttools-${version}_${revision}"
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Rev dep checks
- [x] liberation-fonts-ttf