### PR TITLE
xkeyboard-config: fix upstream issue.

### DIFF
--- a/srcpkgs/xkeyboard-config/patches/fix_backlashes.patch
+++ b/srcpkgs/xkeyboard-config/patches/fix_backlashes.patch
@@ -1,0 +1,56 @@
+From 8ac41c50ab0aa7cd3a7e94313074115de2a172d2 Mon Sep 17 00:00:00 2001
+From: Benno Schulenberg <bensberg@telfort.nl>
+Date: Fri, 10 Jun 2022 12:05:52 +0200
+Subject: [PATCH] rules: use backslashes instead of slashes for line
+ continuation  :\
+
+This fixes #324.
+
+Reported-by: Adriaan de Groot
+
+Bug existed since commit c3c5d02a7e from six weeks ago.
+
+Signed-off-by: Benno Schulenberg <bensberg@telfort.nl>
+---
+ rules/0002-base.lists.part | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/rules/0002-base.lists.part b/rules/0002-base.lists.part
+index 0af6db56..cb661240 100644
+--- a/rules/0002-base.lists.part
++++ b/rules/0002-base.lists.part
+@@ -37,18 +37,18 @@
+               unitekkb1925 yahoo
+ 
+ ! $inetmediakbds = \
+-		a4_rfkb23 a4techKB21 a4techKBS8 acer_ferrari4k acer_laptop /
+-		armada asus_laptop benqx btc5090 btc6301urf btc9019u /
+-		cherrybluea cherryblueb cherrycyboard chicony042 /
+-		compalfl90 compaqik13 compaqik18 creativedw7000 /
+-		cymotionlinux dellm65 dellusbmm dexxa diamond dtk2000 /
+-		emachines ennyah_dkb1008 fscaa1667g genius geniuscomfy /
+-		geniuscomfy2 geniuskb19e hp5xx hpdv5 hpi6 hpxe3gc hpxe3gf /
+-		hpxe4xxx hpxt1000 hpzt11xx inspiron latitude /
+-		logidinovo logidinovoedge logitech_base logitech_g15 /
+-		microsoft4000 microsoft7000 microsoftmult microsoftpro /
+-		microsoftprooem mx1998 mx2500 mx2750 pc105 precision_m /
+-		presario propeller samsung4500 samsung4510 scorpius /
+-		silvercrest sk1300 sk2500 sk7100 sp_inet targa_v811 /
+-		thinkpad thinkpad60 tm2030USB-102 tm2030USB-106 /
++		a4_rfkb23 a4techKB21 a4techKBS8 acer_ferrari4k acer_laptop \
++		armada asus_laptop benqx btc5090 btc6301urf btc9019u \
++		cherrybluea cherryblueb cherrycyboard chicony042 \
++		compalfl90 compaqik13 compaqik18 creativedw7000 \
++		cymotionlinux dellm65 dellusbmm dexxa diamond dtk2000 \
++		emachines ennyah_dkb1008 fscaa1667g genius geniuscomfy \
++		geniuscomfy2 geniuskb19e hp5xx hpdv5 hpi6 hpxe3gc hpxe3gf \
++		hpxe4xxx hpxt1000 hpzt11xx inspiron latitude \
++		logidinovo logidinovoedge logitech_base logitech_g15 \
++		microsoft4000 microsoft7000 microsoftmult microsoftpro \
++		microsoftprooem mx1998 mx2500 mx2750 pc105 precision_m \
++		presario propeller samsung4500 samsung4510 scorpius \
++		silvercrest sk1300 sk2500 sk7100 sp_inet targa_v811 \
++		thinkpad thinkpad60 tm2030USB-102 tm2030USB-106 \
+ 		toshiba_s3000 trust trustda trust_slimline unitekkb1925
+-- 
+GitLab

--- a/srcpkgs/xkeyboard-config/template
+++ b/srcpkgs/xkeyboard-config/template
@@ -1,7 +1,7 @@
 # Template file for 'xkeyboard-config'
 pkgname=xkeyboard-config
 version=2.36
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dxorg-rules-symlinks=true -Dcompat-rules=true"
 hostmakedepends="pkg-config libxslt python3 intltool perl"


### PR DESCRIPTION
use backslashes instead of slashes for line continuation

This fixes 324
(https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/324)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):

  - armv6l
