### PR TITLE
nerd-fonts: update to 2.2.1

### DIFF
--- a/srcpkgs/nerd-fonts/template
+++ b/srcpkgs/nerd-fonts/template
@@ -1,14 +1,14 @@
 # Template file for 'nerd-fonts'
 pkgname=nerd-fonts
-version=2.1.0
-revision=3
+version=2.2.1
+revision=1
 depends="font-util xbps-triggers nerd-fonts-ttf nerd-fonts-otf"
 short_desc="Iconic font aggregator, collection and patcher"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="MIT"
 homepage="https://nerdfonts.com"
 distfiles="https://github.com/ryanoasis/nerd-fonts/archive/v${version}.tar.gz"
-checksum="a084ca91a174b547bab4523507824c76aa91ebcf38f9256a4ffd181813f87bd8"
+checksum=05e733b4ac0a6fed997ca3a697c6881d4327991fa57f4376ae17d725413b89f7
 
 do_install() {
 	vmkdir usr/share/fonts/NerdFonts/otf


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Explanation: I did not test every single font included in this package, but I did test several.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
