### PR TITLE
helix: update to 22.08.1

### DIFF
--- a/srcpkgs/helix/template
+++ b/srcpkgs/helix/template
@@ -1,6 +1,6 @@
 # Template file for 'helix'
 pkgname=helix
-version=22.05
+version=22.08.1
 revision=1
 build_style=cargo
 make_install_args="--path helix-term"
@@ -10,8 +10,8 @@ maintainer="Marcin Puc <tranzystorek.io@protonmail.com>"
 license="MPL-2.0"
 homepage="https://helix-editor.com/"
 changelog="https://raw.githubusercontent.com/helix-editor/helix/master/CHANGELOG.md"
-distfiles="https://github.com/helix-editor/helix/archive/${version}.tar.gz"
-checksum=96603cf5504bbd7ebeee1867d65356cccaa2877f697da50c0ad3789a3eb287e4
+distfiles="https://github.com/helix-editor/helix/archive/refs/tags/${version}.tar.gz"
+checksum=c9b184d53bab51e7a9fe81dc8c191a853177abba67ea408e968937f31b50b45a
 
 # skip problematic doctests on i686
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
