### PR TITLE
orphan s6 packages: s6-dns, s6-networking

### DIFF
--- a/srcpkgs/s6-dns/template
+++ b/srcpkgs/s6-dns/template
@@ -9,7 +9,7 @@ configure_args="--prefix=/usr --libdir=/usr/lib
  $(vopt_if static --enable-static-libc)"
 makedepends="execline-devel skalibs-devel"
 short_desc="Suite of DNS client programs and libraries for Unix systems"
-maintainer="lemmi <lemmi@nerd2nerd.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://skarnet.org/software/s6-dns"
 distfiles="${homepage}/${pkgname}-${version}.tar.gz"

--- a/srcpkgs/s6-networking/template
+++ b/srcpkgs/s6-networking/template
@@ -11,7 +11,7 @@ configure_args="--libdir=/usr/lib $(vopt_if libtls --enable-ssl=libtls)
 makedepends="execline-devel $(vopt_if libtls libtls-devel) skalibs-devel
  s6-devel s6-dns-devel $(vopt_if bearssl bearssl-devel)"
 short_desc="Suite of small network utilities for Unix systems"
-maintainer="lemmi <lemmi@nerd2nerd.org>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
 homepage="https://skarnet.org/software/s6-networking"
 changelog="https://skarnet.org/software/s6-networking/upgrade.html"


### PR DESCRIPTION
Haven't used these packages in years. But since they are usually released along a bunch of other skarnet packages, might make sense if someone more familiar with s6 could adopt them in the future. 