### PR TITLE
swh-plugins: orphan

### DIFF
--- a/srcpkgs/swh-plugins/template
+++ b/srcpkgs/swh-plugins/template
@@ -3,19 +3,19 @@ pkgname=swh-plugins
 version=0.4.17
 revision=1
 wrksrc="ladspa-${version}"
-conflicts="swh-lv2"
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config gettext-devel gettext
  perl-Locale-gettext perl-Locale-PO perl-XML-Parser"
 makedepends="fftw-devel libgsm-devel libxml2-devel"
-maintainer="lemmi <lemmi@nerd2nerd.org>"
+short_desc="SWH Plugins package for the LADSPA plugin system"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-2.0-or-later"
 homepage="http://plugin.org.uk/"
-short_desc="The SWH Plugins package for the LADSPA plugin system"
-license="GPL-2"
 distfiles="https://github.com/swh/ladspa/archive/v${version}.tar.gz"
 checksum=d1b090feec4c5e8f9605334b47faaad72db7cc18fe91d792b9161a9e3b821ce7
+conflicts="swh-lv2"
+CFLAGS="-fPIC"
 
 pre_configure() {
 	autoreconf -fi
 }
-


### PR DESCRIPTION
Extracted from #38978:
> `swh-plugins` was also on the remove list, since it hasn't been maintained for a while and there is `swh-lv2`. But there are still 2 other packages depending on it:
> 
> - flowblade is depending on it, but works without. @shizonic
> - I didn't try pulseaudio-equalizer-ladspa, but I guess it is a hard depencency there. @steinex
> 
> If those packages are updated, please check if `swh-plugins` is still needed and contact me or remove the package yourself.
