### PR TITLE
gc: Update to 8.2.2

### DIFF
--- a/srcpkgs/gc/template
+++ b/srcpkgs/gc/template
@@ -1,28 +1,24 @@
 # Template file for 'gc'
 pkgname=gc
-version=8.0.6
-revision=2
+version=8.2.2
+revision=1
 build_style=gnu-configure
 # libatomic_ops is replaced by C11 atomic
-configure_args="--enable-static --enable-mmap --with-libatomic-ops=none"
+configure_args="--enable-static --with-libatomic-ops=none"
 hostmakedepends="pkg-config"
 short_desc="Garbage collector for C and C++"
-maintainer="Orphaned <orphan@voidlinux.org>"
-license="GPL-2.0-or-later"
+maintainer="Ivan Maidanski <ivmai@mail.ru>"
+license="MIT"
 homepage="https://www.hboehm.info/gc/"
 distfiles="https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz"
-checksum=3b4914abc9fa76593596773e4da671d7ed4d5390e3d46fbf2e5f155e121bea11
-
-case "$XBPS_TARGET_MACHINE" in
-*-musl)
-	CFLAGS='-D_GNU_SOURCE -DNO_GETCONTEXT -DSEARCH_FOR_DATA_START -DUSE_MMAP -DHAVE_DL_ITERATE_PHDR'
-esac
+checksum=f30107bcb062e0920a790ffffa56d9512348546859364c23a14be264b38836a0
 
 post_install() {
 	mkdir -p ${DESTDIR}/usr/include/gc/
 	mv ${wrksrc}/include/* ${DESTDIR}/usr/include/gc/
 	mv ${DESTDIR}/usr/include/gc/extra/* ${DESTDIR}/usr/include/
 	rmdir ${DESTDIR}/usr/include/gc/extra
+	vlicense README.QUICK
 }
 
 gc-devel_package() {


### PR DESCRIPTION
Other cleanups:
* Remove --enable-mmap (which is the default configure option now)
* No longer depends on libatomic_ops (provided the compiler is gcc or clang)
* Fix license (it is MIT, not GPL)
* Remove unneeded CFLAGS
* Set maintainer

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x64)
