### PR TITLE
wireproxy: update to 1.0.5

### DIFF
--- a/srcpkgs/wireproxy/template
+++ b/srcpkgs/wireproxy/template
@@ -1,16 +1,17 @@
 # Template file for 'wireproxy'
 pkgname=wireproxy
-version=1.0.1
+version=1.0.5
 revision=1
 build_style=go
 go_import_path="github.com/octeep/wireproxy"
 go_package="${go_import_path}/cmd/wireproxy"
+go_ldflags="-X 'main.version=${version}'"
 short_desc="Wireguard client that exposes itself as a socks5 proxy"
 maintainer="Wind Wong <octeep@pm.me>"
 license="ISC"
 homepage="https://github.com/octeep/wireproxy"
 distfiles="https://github.com/octeep/wireproxy/archive/v${version}.tar.gz"
-checksum=e21eac22ef1b12dc2d7b3e5b58dcff183af9c1547be3e55a7e6c71394f053e1e
+checksum=3779a157713b462a7b5322f1437f768ab69ae446df0ceca76c6dff7c4030e425
 make_dirs="
  /etc/wireproxy 0750 root _wireproxy
  /var/lib/wireproxy 0700 _wireproxy _wireproxy"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, amd64
