### PR TITLE
New package: FreeTube-0.17.1

### DIFF
--- a/srcpkgs/FreeTube/files/FreeTube.desktop
+++ b/srcpkgs/FreeTube/files/FreeTube.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=FreeTube
+GenericName=YouTube Player
+Comment=Open source desktop YouTube player built with privacy in mind
+Exec=FreeTube %U
+Terminal=false
+Type=Application
+Icon=FreeTube
+MimeType=x-scheme-handler/freetube;
+Categories=Network;

--- a/srcpkgs/FreeTube/files/FreeTube.sh
+++ b/srcpkgs/FreeTube/files/FreeTube.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec electron19 /usr/lib/FreeTube/app.asar "$@"

--- a/srcpkgs/FreeTube/patches/do-not-download-electron.diff
+++ b/srcpkgs/FreeTube/patches/do-not-download-electron.diff
@@ -1,0 +1,10 @@
+--- a/_scripts/build.js	2022-08-12 04:09:42.000000000 +0200
++++ b/_scripts/build.js	2022-08-31 21:07:40.837066904 +0200
+@@ -39,6 +39,7 @@
+ const config = {
+   appId: `io.freetubeapp.${name}`,
+   copyright: 'Copyleft © 2020-2021 freetubeapp@protonmail.com',
++  electronDist: '/usr/lib/non-existent-electron',
+   // asar: false,
+   // compression: 'store',
+   productName,

--- a/srcpkgs/FreeTube/patches/package-to-dir.diff
+++ b/srcpkgs/FreeTube/patches/package-to-dir.diff
@@ -1,0 +1,20 @@
+--- a/_scripts/build.js	2022-08-12 04:09:42.000000000 +0200
++++ b/_scripts/build.js	2022-08-31 21:06:38.025503775 +0200
+@@ -33,7 +33,7 @@
+     arch = Arch.armv7l
+   }
+ 
+-  targets = Platform.LINUX.createTarget(['deb', 'zip', 'apk', 'rpm', 'AppImage', 'pacman'], arch)
++  targets = Platform.LINUX.createTarget(['dir'], arch)
+ }
+ 
+ const config = {
+@@ -97,7 +97,7 @@
+   linux: {
+     category: 'Network',
+     icon: '_icons/icon.svg',
+-    target: ['deb', 'zip', 'apk', 'rpm', 'AppImage', 'pacman'],
++    target: ['dir'],
+   },
+   // See the following issues for more information
+   // https://github.com/jordansissel/fpm/issues/1503

--- a/srcpkgs/FreeTube/template
+++ b/srcpkgs/FreeTube/template
@@ -1,0 +1,51 @@
+# Template file for 'FreeTube'
+pkgname=FreeTube
+version=0.17.1
+revision=1
+wrksrc="${pkgname}-${version}-beta"
+hostmakedepends="git nodejs yarn"
+depends="electron19 gtk+3 nss"
+short_desc="Open source desktop YouTube player built with privacy in mind"
+maintainer="Chloris <chloris@freedommail.ch>"
+license="AGPL-3.0-or-later"
+homepage="https://freetubeapp.io/"
+changelog="https://github.com/FreeTubeApp/FreeTube/releases"
+distfiles="https://github.com/FreeTubeApp/FreeTube/archive/refs/tags/v${version}-beta.tar.gz"
+checksum=7ae2e27d38b200c3b9a421bb1b794ef330d21c3e2f1550e50e27ff02a10a7d07
+
+do_build() {
+	yarn --cache-folder './yarn-cache' install
+	npm --cache './npm-cache' run build
+}
+
+do_install() {
+	vmkdir "usr/lib/${pkgname}"
+	vinstall 'build/linux-unpacked/resources/app.asar' 644 "usr/lib/${pkgname}"
+
+	vdoc 'README.md'
+	vlicense 'LICENSE'
+
+	vinstall '_icons/icon.svg' 644 'usr/share/pixmaps' "${pkgname}.svg"
+	vinstall "${FILESDIR}/${pkgname}.desktop" 644 'usr/share/applications'
+	vbin "${FILESDIR}/${pkgname}.sh" "${pkgname}"
+}
+
+#
+# BUILD PROCESS NOTE
+#
+# npm will try to either download Electron or copy local Electron into into the
+# build dir. Since one of the patches directs it to use an unexistent local
+# installation of Electron, the 'copying Electron' step will fail with error
+# 'Error: ENOENT: no such file or directory'.
+#
+# This error can be safely ignored - the only needed product of the build
+# process is 'app.asar'. Once installed, system installation of Electron will
+# be used to run the app.
+#
+
+#
+# DEPENDENCIES NOTE
+#
+# npm packages the app with Electron 16 by default. This version is not
+# available in Void repos, so the package uses Electron 19 instead.
+#


### PR DESCRIPTION
FreeTube is a privacy-focused desktop application for watching YouTube videos allowing for locally-stored history and subscriptions. Sadly, it is an Electron app, but has no real alternatives when privacy is a requirement.

This PR is also answering requests in #13420. The template is based on the AUR package [`freetube`](https://aur.archlinux.org/packages/freetube).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir, VM)
  - ARM architectures were not tested since Electron can not be cross-compiled