### PR TITLE
nm-tray: fix autostart file location

### DIFF
--- a/srcpkgs/nm-tray/template
+++ b/srcpkgs/nm-tray/template
@@ -1,8 +1,9 @@
 # Template file for 'nm-tray'
 pkgname=nm-tray
 version=0.5.0
-revision=1
+revision=2
 build_style=cmake
+configure_args="-DCMAKE_INSTALL_SYSCONFDIR=/etc"
 hostmakedepends="qt5-qmake qt5-host-tools pkg-config"
 makedepends="qt5-tools-devel networkmanager-qt5-devel"
 depends="NetworkManager"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
sysconfdir not set, installs autostart file on /usr/etc/xdg/autostart