### PR TITLE
Signal-Desktop: add support for x86_64-musl

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -5,7 +5,7 @@ revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
 # armv7hf/arm64: https://github.com/signalapp/Signal-Desktop/issues/3410
-archs="x86_64"
+archs="x86_64 x86_64-musl"
 hostmakedepends="git git-lfs nodejs python3 tar yarn"
 depends="cairo gtk+3 libvips pango"
 short_desc="Signal Private Messenger for Linux"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (crossbuild)
