### PR TITLE
xsel: fix dead distfile and upstream webpage

### DIFF
--- a/srcpkgs/xsel/template
+++ b/srcpkgs/xsel/template
@@ -7,8 +7,9 @@ makedepends="libXt-devel"
 short_desc="Command-line getting and setting the contents of the X selection"
 maintainer="Steven R <dev@styez.com>"
 license="HPND-sell-variant"
-homepage="http://www.vergenet.net/~conrad/software/xsel/"
-distfiles="http://www.vergenet.net/~conrad/software/xsel/download/xsel-${version}.tar.gz"
+homepage="http://www.kfish.org/software/xsel/"
+changelog="https://raw.githubusercontent.com/kfish/xsel/master/release_notes/xsel-${version}.txt"
+distfiles="http://www.kfish.org/software/xsel/download/xsel-${version}.tar.gz"
 checksum=b927ce08dc82f4c30140223959b90cf65e1076f000ce95e520419ec32f5b141c
 
 post_install() {


### PR DESCRIPTION
Fixing upstream and distfile download links

Found this as a possible "changelog":

- https://raw.githubusercontent.com/kfish/xsel/master/release_notes/xsel-1.2.0.txt

I wasn't sure if I should added it being a separate file per release