### PR TITLE
liquidwar: move to python3, cleanup.

### DIFF
--- a/srcpkgs/liquidwar/patches/python3-conversion.patch
+++ b/srcpkgs/liquidwar/patches/python3-conversion.patch
@@ -1,0 +1,266 @@
+Author: Reiner Herrmann <reiner@reiner-h.de>
+Description: Port makedoc.py to Python 3
+
+--
+void-packages: patch cleaned up; fixed invalid escape sequences with
+raw string literals
+--
+
+--- a/doc/Makefile.in
++++ b/doc/Makefile.in
+@@ -110,31 +110,31 @@
+ 
+ html/%.html: xml/%.xml makedoc.py html/header.inc html/footer.inc
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_html('$@','$<','html/header.inc','html/footer.inc')"
++	@python3 -c "import makedoc; makedoc.make_html('$@','$<','html/header.inc','html/footer.inc')"
+ 
+ php/%.php: xml/%.xml makedoc.py
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_php('$@','$<')"
++	@python3 -c "import makedoc; makedoc.make_php('$@','$<')"
+ 
+ tex/%.tex: xml/%.xml makedoc.py
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_tex('$@','$<')"
++	@python3 -c "import makedoc; makedoc.make_tex('$@','$<')"
+ 
+ man/%.man: xml/%.xml makedoc.py
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_man('$@','$<')"
++	@python3 -c "import makedoc; makedoc.make_man('$@','$<')"
+ 
+ txt/%.txt: xml/%.xml makedoc.py
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_txt('$@','$<','Liquid War (v$(VERSION))')"
++	@python3 -c "import makedoc; makedoc.make_txt('$@','$<','Liquid War (v$(VERSION))')"
+ 
+ texi/%.texi: xml/%.xml makedoc.py
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_texi('$@','$<')"
++	@python3 -c "import makedoc; makedoc.make_texi('$@','$<')"
+ 
+ uwc/%.uwc: xml/%.xml makedoc.py
+ 	@echo Creating $@ from $<
+-	@python -c "import makedoc; makedoc.make_uwc('$@','$<')"
++	@python3 -c "import makedoc; makedoc.make_uwc('$@','$<')"
+ 
+ %.gz: %
+ 	@if [ -f $< ]; then echo "Compressing $@..."; gzip -c -9 $< > $@; fi
+--- a/doc/makedoc.py
++++ b/doc/makedoc.py
+@@ -16,14 +16,14 @@
+ def remove_duplicate_blanks(text):
+     result=text
+ 
+-    result=string.replace(result,"\t"," ")
+-    result=string.replace(result,"\n"," ")
++    result=result.replace("\t"," ")
++    result=result.replace("\n"," ")
+ 
+     if (result!=""):
+         temp=""
+         while temp!=result:
+             temp=result
+-            result=string.replace(result,"  "," ")
++            result=result.replace("  "," ")
+ 
+     return result
+
+@@ -63,10 +63,10 @@
+ def format_email_and_url(text):
+     result=text	
+ 
+-    email=re.compile('"([\w\-\.]+@[\w\-\.]+)"')
++    email=re.compile(r'"([\w\-\.]+@[\w\-\.]+)"')
+     result=email.sub(r'\1',result);
+ 
+-    url=re.compile('"http://([\w\-\.\~/]+)"', re.I)
++    url=re.compile(r'"http://([\w\-\.\~/]+)"', re.I)
+     result=url.sub(r'http://\1',result);
+ 
+     return result
+@@ -74,11 +74,11 @@
+ def format_html(text):
+     result=text
+ 
+-    result=string.replace(result,"<","ufoot_html_lt")
+-    result=string.replace(result,">","ufoot_html_gt")
+-    result=string.replace(result,"&","&amp;")
+-    result=string.replace(result,"ufoot_html_lt","&lt;")
+-    result=string.replace(result,"ufoot_html_gt","&gt;")    
++    result=result.replace("<","ufoot_html_lt")
++    result=result.replace(">","ufoot_html_gt")
++    result=result.replace("&","&amp;")
++    result=result.replace("ufoot_html_lt","&lt;")
++    result=result.replace("ufoot_html_gt","&gt;")    
+ 
+     # Uncomment this to make mailing list adresses look like "xxx at xxx"
+     # instead of "xxx@xxx". This can prevent spammers from harvesting
+@@ -86,10 +86,10 @@
+     # fakeemail=re.compile('"([\w\.]+\-user)@([\w\-\.]+)"')
+     # result=fakeemail.sub(r'<A HREF="mailto:\1 at \2">\1 at \2</A> (replace "at" by "@")',result);
+ 
+-    email=re.compile('"([\w\-\.]+@[\w\-\.]+)"')
++    email=re.compile(r'"([\w\-\.]+@[\w\-\.]+)"')
+     result=email.sub(r'<A HREF="mailto:\1">\1</A>',result);
+ 
+-    url=re.compile('"http://([\w\-\.\~/]+)"', re.I)
++    url=re.compile(r'"http://([\w\-\.\~/]+)"', re.I)
+     result=url.sub(r'<A HREF="http://\1">\1</A>',result);
+     
+     return result
+@@ -97,31 +97,31 @@
+ def format_tex(text):
+     result=text
+ 
+-    result=string.replace(result,"\\","$\\backslash$")
+-    result=string.replace(result,"_","\\_")
+-    result=string.replace(result,"#","\\#")
+-    result=string.replace(result,"%","\\%")
+-    result=string.replace(result,"}","\\}")
+-    result=string.replace(result,"<","$<$")
+-    result=string.replace(result,">","$>$")
+-    result=string.replace(result,"~","$\\tilde{}$")
++    result=result.replace("\\","$\\backslash$")
++    result=result.replace("_","\\_")
++    result=result.replace("#","\\#")
++    result=result.replace("%","\\%")
++    result=result.replace("}","\\}")
++    result=result.replace("<","$<$")
++    result=result.replace(">","$>$")
++    result=result.replace("~","$\\tilde{}$")
+     
+     return result
+ 
+ def format_texi(text):
+     result=text
+ 
+-    result=string.replace(result,"@","@@")
+-    result=string.replace(result,"}","@}")
+-    result=string.replace(result,"{","@{")
++    result=result.replace("@","@@")
++    result=result.replace("}","@}")
++    result=result.replace("{","@{")
+ 
+     return result
+ 
+ def format_uwc(text):
+     result=text
+ 
+-    result=string.replace(result,"]","]")
+-    result=string.replace(result,"[","[[")
++    result=result.replace("]","]")
++    result=result.replace("[","[[")
+ 
+     return result
+ 
+@@ -139,8 +139,8 @@
+     result=text
+ 
+     result=format_uwc(result)
+-    result=string.replace(result,"\n"," ")
+-    result=string.replace(result,"\r"," ")
++    result=result.replace("\n"," ")
++    result=result.replace("\r"," ")
+     result=remove_duplicate_blanks(result)
+ 
+     return result
+@@ -208,7 +208,7 @@
+         if tag=="code":
+             self.start_code()
+     def endElement(self,tag):
+-        data=string.strip(self.charbuf)
++        data=self.charbuf.strip()
+         if (data!=""):
+             self.write(self.translate(data,self.stack[-1]))
+         self.charbuf=""
+@@ -366,7 +366,7 @@
+         self.write("\n\\end{verbatim}\n")
+     def translate(self,data,tag):
+         result=data
+-	result=format_email_and_url(result)
++        result=format_email_and_url(result)
+         if (tag!="code"):
+             result=format_tex(result)
+         return result
+@@ -405,12 +405,12 @@
+         self.write("\n")
+     def translate(self,data,tag):
+         result=data
+-	result=format_email_and_url(result)
+-        result=string.replace(result,"\\","\\\\")
+-        result=string.replace(result,".","\.")
+-        result=string.replace(result,"-","\-")
++        result=format_email_and_url(result)
++        result=result.replace("\\","\\\\")
++        result=result.replace(".",r"\.")
++        result=result.replace("-",r"\-")
+         if (tag=="code"):
+-            result=string.replace(result,"\n","\n.br\n")
++            result=result.replace("\n","\n.br\n")
+         else:
+             result=remove_duplicate_blanks(result)
+         return result
+@@ -460,10 +460,10 @@
+         self.write("\n")
+     def translate(self,data,tag):
+         result=data
+-	result=format_email_and_url(result)
++        result=format_email_and_url(result)
+         if (tag=="code"):
+             result=" "*self.indent+\
+-                    string.replace(result,"\n","\n"+" "*self.indent)
++                result.replace("\n","\n"+" "*self.indent)
+         else:
+             result=format_text(result,self.indent,80)
+             if (tag=="elem"):
+@@ -505,7 +505,7 @@
+         self.write("\n@end example\n")
+     def translate(self,data,tag):
+         result=data
+-	result=format_email_and_url(result)
++        result=format_email_and_url(result)
+ 
+         if (tag!="code"):
+             result=remove_duplicate_blanks(result)
+@@ -548,7 +548,7 @@
+         self.write("\n")
+     def translate(self,data,tag):
+         result=data
+-	result=format_email_and_url(result)
++        result=format_email_and_url(result)
+ 
+         if (tag=="code"):
+             result=format_uwc_code(result)
+@@ -560,7 +560,7 @@
+         return result
+ 
+ def run_parser(handler,dst,src):
+-    dst_file=open(dst,"w")
++    dst_file=open(dst,"wb")
+     src_file=open(src,"r")
+     #src_code=src_file.read()
+     parser=xml.sax.make_parser()
+@@ -602,8 +602,8 @@
+     run_parser(handler,txt_file,xml_file)
+ 
+ def make_texi(texi_file,xml_file):
+-    node=string.replace(xml_file,".xml","")
+-    node=string.replace(node,"xml/","")
++    node=xml_file.replace(".xml","")
++    node=node.replace("xml/","")
+     parser=xml.sax.make_parser()
+     handler=XMLToTexi(node)
+     run_parser(handler,texi_file,xml_file)
+--- a/configure.ac
++++ b/configure.ac
+@@ -123,7 +123,7 @@
+ 
+ 
+ dnl Various checks which will enable/disable some of the doc targets 
+-AC_CHECK_PROG(PYTHON,python,yes,no)
++AC_CHECK_PROG(PYTHON,python3,yes,no)
+ AC_CHECK_PROG(GZIP,gzip,yes,no)
+ AC_CHECK_PROG(LATEX,latex,yes,no)
+ AC_CHECK_PROG(DVIPS,dvips,yes,no)

--- a/srcpkgs/liquidwar/template
+++ b/srcpkgs/liquidwar/template
@@ -6,15 +6,17 @@ build_style="gnu-configure"
 make_build_args="GAMEDIR=/usr/bin DATADIR=/usr/share/liquidwar"
 make_install_args="GAMEDIR=/usr/bin DATADIR=/usr/share/liquidwar"
 make_install_target="install_nolink"
-hostmakedepends="python"
+hostmakedepends="python3 texinfo"
 makedepends="allegro4-devel"
-short_desc="A unique multiplayer wargame"
+short_desc="Unique multiplayer wargame"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.ufoot.org/liquidwar"
 distfiles="http://www.ufoot.org/download/${pkgname}/v5/${version}/${pkgname}-${version}.tar.gz"
 checksum=dad0aa84dd416cad055421ed9b40df39efae78d3df759c0583c64c54f7f2ff5f
 nocross="run build artifarts"
+# the only check is a linter for documentation sources that requires additional packages
+make_check="no"
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
Added patch from debian (with small tweaks) to convert the documentation
generator script from python2 to python3. Related to #38229

Added texinfo to hostmakedeps. Somehow, something changed outside the template
since last version/revbump that caused info files to no longer be built.

Also fixed an xlint in the description.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
