### PR TITLE
crispy-doom: update to 5.12.0.

### DIFF
--- a/srcpkgs/crispy-doom/template
+++ b/srcpkgs/crispy-doom/template
@@ -1,20 +1,28 @@
 # Template file for 'crispy-doom'
 pkgname=crispy-doom
-version=5.11.1
+version=5.12.0
 revision=1
 wrksrc="crispy-doom-crispy-doom-${version}"
 build_style=gnu-configure
-hostmakedepends="autoconf automake pkg-config"
+hostmakedepends="autoconf automake pkg-config python3"
 makedepends="SDL2-devel SDL2_mixer-devel SDL2_net-devel libsamplerate-devel libpng-devel"
 short_desc="Limit-removing enhanced-resolution Doom source port"
 maintainer="Benjamín Albiñana <benalb@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/fabiangreffrath/crispy-doom"
 distfiles="https://github.com/fabiangreffrath/crispy-doom/archive/crispy-doom-${version}.tar.gz"
-checksum=7c5bb36393dec39b9732e53963dadd6bcc3bd193370c4ec5b1c0121df3b38faa
+checksum=d85d6e76aa949385458b7702e6fb594996745b94032ffb13e1790376eeecb462
 
 CFLAGS="-fcommon"
 
 pre_configure() {
 	autoreconf -fi
+}
+
+post_install() {
+	#Rename default.cfg(5), hexen.cfg(5) and heretic.cfg(5) man pages to avoid conflict
+	#with chocolate-doom
+	mv ${DESTDIR}/usr/share/man/man5/default.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_default.cfg.5
+	mv ${DESTDIR}/usr/share/man/man5/hexen.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_hexen.cfg.5
+	mv ${DESTDIR}/usr/share/man/man5/heretic.cfg.5 ${DESTDIR}/usr/share/man/man5/crispy_heretic.cfg.5
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES*
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (X86-64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
