### PR TITLE
python3-ansible-lint: update to 6.5.2.

### DIFF
--- a/srcpkgs/python3-ansible-lint/template
+++ b/srcpkgs/python3-ansible-lint/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-ansible-lint'
 pkgname=python3-ansible-lint
-version=6.5.1
+version=6.5.2
 revision=1
 wrksrc="${pkgname/python3-/}-${version}"
 build_style=python3-pep517
@@ -26,6 +26,7 @@ make_check_args="--deselect src/ansiblelint/rules/no_loop_var_prefix.py::test_no
  --deselect test/test_formatter_json.py::test_code_climate_parsable_ignored
  --deselect test/test_formatter_sarif.py::test_sarif_parsable_ignored
  --deselect test/test_import_playbook.py::test_task_hook_import_playbook
+ --deselect test/test_include_miss_file_with_role.py::test_cases_warning_message
  --deselect test/test_list_rules.py::test_list_rules_includes_opt_in_rules
  --deselect test/test_list_rules.py::test_list_rules_with_format_option
  --deselect test/test_list_rules.py::test_list_tags_includes_opt_in_rules
@@ -53,7 +54,7 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="GPL-3.0-only"
 homepage="https://github.com/ansible-community/ansible-lint"
 distfiles="${PYPI_SITE}/a/${pkgname/python3-/}/${pkgname/python3-/}-${version}.tar.gz"
-checksum=b02c5222450c469196c9cc28d3128e50f6bcf9549d5dd15c3cfbf47c70b5b06e
+checksum=f4432c74c0f28b2870a188b4999592f6338042f30d0c6f4ee11b32440ca9ffe4
 make_check_pre="env PYTHONPATH=src"
 
 post_patch() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Another release, another deselected test case. This is not going good, I'll need to look deeper into what's going wrong here at some point. It's working great on my machine, and *most* of the test cases also work perfectly fine, but a few just don't.

I've tried the same approach as in `python3-jsonschema` for the issues failing due to not finding the ansiblelint module or ansible-lint binary, but it didn't help at all, just caused more tests that had to be ignored for other reasons.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
