### PR TITLE
base-files: add usbmon group, udev rules

### DIFF
--- a/srcpkgs/base-files/files/90-usbmon.rules
+++ b/srcpkgs/base-files/files/90-usbmon.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usbmon", GROUP="usbmon", MODE="640"

--- a/srcpkgs/base-files/files/group
+++ b/srcpkgs/base-files/files/group
@@ -23,6 +23,7 @@ network:x:21:
 kvm:x:24:
 input:x:25:
 plugdev:x:26:
+usbmon:x:27:
 nogroup:x:99:
 users:x:100:
 xbuilder:x:101:

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.142
-revision=13
+revision=14
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
@@ -29,7 +29,7 @@ conf_files="
 
 replaces="base-directories>=0"
 # New system groups
-system_groups="kvm:24 plugdev:26"
+system_groups="kvm:24 plugdev:26 usbmon:27"
 
 do_install() {
 	# Create bin and lib dirs and symlinks.


### PR DESCRIPTION
this will be useful for wireshark users, whose official documentation says to manually set an ACL for /dev/usbmon* to use it with USB devices. This should make it easier.

Source: https://src.fedoraproject.org/rpms/wireshark/blob/rawhide/f/90-wireshark-usbmon.rules

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

