### PR TITLE
python3-github3: update to 3.2.0.

### DIFF
--- a/srcpkgs/python3-betamax-matchers/template
+++ b/srcpkgs/python3-betamax-matchers/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-betamax-matchers'
+pkgname=python3-betamax-matchers
+version=0.4.0
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-betamax python3-requests-toolbelt"
+checkdepends="$depends"
+short_desc="Group of experimental matchers for Betamax (Python3)"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://github.com/betamaxpy/betamax_matchers"
+changelog="https://raw.githubusercontent.com/betamaxpy/betamax_matchers/master/HISTORY.rst"
+distfiles="${PYPI_SITE}/b/betamax-matchers/betamax-matchers-${version}.tar.gz"
+checksum=83609d39ac25a7eed8ad3bec426cd15e647c89b4f0f1583ec44a4481bde4171f

--- a/srcpkgs/python3-betamax/template
+++ b/srcpkgs/python3-betamax/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-betamax'
+pkgname=python3-betamax
+version=0.8.1
+revision=1
+wrksrc="${pkgname#python3-}-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3-requests"
+checkdepends="$depends python3-pytest"
+short_desc="VCR imitation designed only for python-requests (Python3)"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://betamax.readthedocs.org"
+changelog="https://raw.githubusercontent.com/betamaxpy/betamax/master/HISTORY.rst"
+distfiles="${PYPI_SITE}/b/betamax/betamax-${version}.tar.gz"
+checksum=5bf004ceffccae881213fb722f34517166b84a34919b92ffc14d1dbd050b71c2
+# does some stuff with long-deprecated pytest things
+make_check=no

--- a/srcpkgs/python3-github3/template
+++ b/srcpkgs/python3-github3/template
@@ -1,18 +1,20 @@
 # Template file for 'python3-github3'
 pkgname=python3-github3
-version=1.3.0
-revision=5
+version=3.2.0
+revision=1
 wrksrc="github3.py-${version}"
 build_style=python3-module
+make_check_args="-k not(test_delete_key)"
 hostmakedepends="python3-setuptools"
-depends="python3-requests python3-uritemplate"
+depends="python3-requests python3-uritemplate python3-dateutil python3-PyJWT"
+checkdepends="$depends python3-pytest-xdist python3-betamax-matchers"
 short_desc="Wrapper for GitHub's API (Python3)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github3py.readthedocs.org"
 changelog="https://raw.githubusercontent.com/sigmavirus24/github3.py/master/docs/source/release-notes/${version}.rst"
 distfiles="${PYPI_SITE}/g/github3.py/github3.py-${version}.tar.gz"
-checksum=15a115c18f7bfcf934dfef7ab103844eb9f620c586bad65967708926da47cbda
+checksum=09b72be1497d346b0968cde8360a0d6af79dc206d0149a63cd3ec86c65c377cc
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
- New package: python3-betamax-0.8.1
- New package: python3-betamax-matchers-0.4.0
- python3-github3: update to 3.2.0.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

