### PR TITLE
gnome-bluetooth: update to 42.2.

### DIFF
--- a/srcpkgs/gnome-bluetooth/template
+++ b/srcpkgs/gnome-bluetooth/template
@@ -1,27 +1,27 @@
 # Template file for 'gnome-bluetooth'
 pkgname=gnome-bluetooth
-version=42.1
+version=42.2
 revision=1
 build_helper="gir"
 build_style=meson
-configure_args="-Dgtk_doc=false -Dintrospection=$(vopt_if gir true false)"
-hostmakedepends="pkg-config gettext itstool $(vopt_if gir gobject-introspection) glib-devel"
-makedepends="libXi-devel gtk4-devel libadwaita-devel libnotify-devel dconf-devel
- gvfs-devel bluez eudev-libudev-devel libcanberra-devel gsound-devel upower-devel"
-depends="bluez>=5 dconf>=0.20 gvfs>=1.20 hicolor-icon-theme desktop-file-utils"
-checkdepends="python3-dbus"
+configure_args="-Dgtk_doc=false $(vopt_bool gir introspection)"
+hostmakedepends="pkg-config gettext glib-devel"
+makedepends="gtk4-devel libadwaita-devel gsound-devel libnotify-devel libudev-devel upower-devel"
+depends="bluez"
 short_desc="GNOME Bluetooth Subsystem"
-maintainer="Enno Boland <gottox@voidlinux.org>"
+maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GnomeBluetooth"
+changelog="https://gitlab.gnome.org/GNOME/gnome-bluetooth/-/raw/master/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=d9fe5d673f27a40a86a9e23d93cb99367e7b06df51872e8ac5ecc9938e55b5eb
+checksum=8ce8ecfab28272db1830a63f08f9ccb5304734d1be2dbfce795fe4029e629f0c
 
 build_options="gir"
 build_options_default="gir"
 
 gnome-bluetooth-devel_package() {
-	depends="glib-devel gtk4-devel ${sourcepkg}>=${version}"
+	depends="${sourcepkg}>=${version} glib-devel gtk4-devel
+	 libadwaita-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
