### PR TITLE
qtractor: update to 0.9.28

### DIFF
--- a/srcpkgs/qtractor/template
+++ b/srcpkgs/qtractor/template
@@ -1,8 +1,8 @@
 # Template file for 'qtractor'
 pkgname=qtractor
-version=0.9.27
+version=0.9.28
 revision=1
-_clap_tag=1.0.3
+_clap_tag=1.1.1
 _vst3sdk_tag=3.7.5_build_44
 wrksrc="qtractor-qtractor_${version//./_}"
 create_wrksrc=yes
@@ -27,8 +27,8 @@ distfiles="https://github.com/rncbc/qtractor/archive/qtractor_${version//./_}.ta
  https://github.com/steinbergmedia/vst3_base/archive/v$_vst3sdk_tag.tar.gz>vst3_base-v${_vst3sdk_tag}.tar.gz
  https://github.com/steinbergmedia/vst3_pluginterfaces/archive/v$_vst3sdk_tag.tar.gz>vst3_pluginterfaces-v${_vst3sdk_tag}.tar.gz
  https://github.com/steinbergmedia/vst3_public_sdk/archive/v$_vst3sdk_tag.tar.gz>vst3_public_sdk-v${_vst3sdk_tag}.tar.gz"
-checksum="e3461b1c752fb6e85591f183042c52f03453c95c79aebb9622248b00f93197dd
- 84fef9f2e975177b320ede47365fc8e04a459d34d967eef2afc5a57b6992b0c6
+checksum="988eec4ecba892568d98638264e9369d900213056622c74bba83050dc5334028
+ eef67a38df6c20fd4cb79698772d35d30aefc2e1a8d5275a5169f58cd530333e
  ed359d496796588aa0be86cc902e2472e9624abf6af3a85b2a5711ad069fb9f3
  360c51e3fbb33c0bf389175d07f8f09c175120296e9b0e6a4d222663e92bccf8
  f34e313c7ff6661401275947a8c3d695d9a2c06c84135c9c8d4939f5316393a7


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
