### PR TITLE
srb2: fix build with latest xbps-src

### DIFF
--- a/srcpkgs/srb2/template
+++ b/srcpkgs/srb2/template
@@ -6,10 +6,11 @@ create_wrksrc=true
 build_wrksrc="SRB2-SRB2_release_${version}"
 build_style=gnu-makefile
 make_use_env=yes
-make_build_args=" -C src ECHO=1 LINUX=1 USE_OPENMP=1 EXENAME=${pkgname}
- DBGNAME=${pkgname}-debug NOOBJDUMP=1 NOUPX=1"
+make_build_args="ECHO=1 LINUX=1 USE_OPENMP=1 EXENAME=${pkgname}
+ DBGNAME=${pkgname}-debug NOOBJDUMP=1 NOUPX=1 PREFIX="
 hostmakedepends="pkg-config gettext"
-makedepends="SDL2-devel SDL2_mixer-devel libpng-devel libupnp-devel libcurl-devel libgme-devel libopenmpt-devel"
+makedepends="SDL2-devel SDL2_mixer-devel libpng-devel libupnp-devel
+ libcurl-devel libgme-devel libopenmpt-devel"
 short_desc="3D Sonic fan game based off of Doom Legacy"
 maintainer="oreo639 <oreo6391@gmail.com>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
This fixes a build failure introduced by:
https://github.com/void-linux/void-packages/commit/e14cf6cc7a85fcde7fb3fdb2cdba117bede8bb19

The previously failing line of code:
https://git.do.srb2.org/STJr/SRB2/-/blob/next/src/Makefile.d/util.mk#L72-73

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
