### PR TITLE
common/travis/xpkgdiff.sh: use newly-added arguments

### DIFF
--- a/common/travis/xpkgdiff.sh
+++ b/common/travis/xpkgdiff.sh
@@ -2,9 +2,10 @@
 #
 # xpkgdiff.sh
 
-export XBPS_TARGET_ARCH="$2" XBPS_DISTDIR=/hostrepo XBPS_HOSTDIR="$HOME/hostdir"
+export XBPS_DISTDIR=/hostrepo XBPS_HOSTDIR="$HOME/hostdir"
 export DIFF='diff --unified=0 --report-identical-files --suppress-common-lines
  --color=always --label REPO --label BUILT'
+ARGS="-a $2 -R https://repo-ci.voidlinux.org/current"
 
 while read -r pkg; do
 	for subpkg in $(xsubpkg $pkg); do
@@ -12,11 +13,11 @@ while read -r pkg; do
 					  --repository=$HOME/hostdir/binpkgs/nonfree \
 					  -i "$subpkg" >&/dev/null; then
 			/bin/echo -e "\x1b[34mFile Diff of $subpkg:\x1b[0m"
-			xpkgdiff -f $subpkg
+			xpkgdiff $ARGS -f $subpkg
 			/bin/echo -e "\x1b[34mMetadata Diff of $subpkg:\x1b[0m"
-			xpkgdiff -S $subpkg
+			xpkgdiff $ARGS -S $subpkg
 			/bin/echo -e "\x1b[34mDependency Diff of $subpkg:\x1b[0m"
-			xpkgdiff -x $subpkg
+			xpkgdiff $ARGS -x $subpkg
 		else
 			/bin/echo -e "\x1b[33m$subpkg wasn't found\x1b[0m"
 		fi


### PR DESCRIPTION
it works without this, but it uses repo-default by default, so this should maybe speed some things up.

see also leahneukirchen/xtools#261

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

