### PR TITLE
stunnel: update to 5.65.

### DIFF
--- a/srcpkgs/stunnel/template
+++ b/srcpkgs/stunnel/template
@@ -1,19 +1,24 @@
 # Template file for 'stunnel'
 pkgname=stunnel
-version=5.60
+version=5.65
 revision=1
 build_style=gnu-configure
 configure_args="--enable-ipv6 --with-ssl=${XBPS_CROSS_BASE}/usr"
 hostmakedepends="perl"
 makedepends="openssl-devel"
-checkdepends="nmap procps-ng iproute2"
+checkdepends="nmap procps-ng iproute2 python3"
 short_desc="SSL encryption wrapper"
 maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.stunnel.org/"
 changelog="https://www.stunnel.org/NEWS.html"
 distfiles="https://www.stunnel.org/downloads/stunnel-${version}.tar.gz"
-checksum=c45d765b1521861fea9b03b425b9dd7d48b3055128c0aec673bba5ef9b8f787d
+checksum=60c500063bd1feff2877f5726e38278c086f96c178f03f09d264a2012d6bf7fc
+
+pre_check() {
+	# GitHub's CI doesn't support IPv6
+	rm tests/plugins/p08_ipv6.py
+}
 
 post_install() {
 	rm ${DESTDIR}/usr/share/man/man8/stunnel.??.8


### PR DESCRIPTION
The 5.60 distfile no longer exists. This update makes stunnel buildable.

Ping maintainer: @Vaelatern

#### Testing the changes
- I tested the changes in this PR: **NO**