### PR TITLE
SPIRV, glslang, shaderc: update to 2022.2.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3466,9 +3466,9 @@ liblinphone++.so.10 linphone-4.4.0_1
 libbelr.so.1 belr-0.1.3_1
 libbelcard.so.1 belcard-1.0.2_1
 libshaderc_shared.so.1 shaderc-2018.0_1
-libglslang.so glslang-6.2.2596_1
-libHLSL.so glslang-8.13.3743_1
-libSPIRV.so glslang-6.2.2596_1
+libglslang.so.11 glslang-11.11.0_1
+libHLSL.so glslang-11.11.0_1
+libSPIRV.so glslang-11.11.0_1
 libSPIRV-Tools-shared.so SPIRV-Tools-2022.3_1
 libmaxminddb.so.0 libmaxminddb-1.3.2_1
 libmysqlpp.so.3 mysql++-3.2.5_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -3469,6 +3469,7 @@ libshaderc_shared.so.1 shaderc-2018.0_1
 libglslang.so glslang-6.2.2596_1
 libHLSL.so glslang-8.13.3743_1
 libSPIRV.so glslang-6.2.2596_1
+libSPIRV-Tools-shared.so SPIRV-Tools-2022.3_1
 libmaxminddb.so.0 libmaxminddb-1.3.2_1
 libmysqlpp.so.3 mysql++-3.2.5_1
 libKF5Syndication.so.5 syndication-5.50.0_1

--- a/srcpkgs/SPIRV-Headers/template
+++ b/srcpkgs/SPIRV-Headers/template
@@ -1,7 +1,7 @@
 # Template file for 'SPIRV-Headers'
 pkgname=SPIRV-Headers
 reverts="1.5.4.raytracing.fixed_1 1.5.3_2 1.5.3_1 1.5.1_1 1.4.1_1"
-version=1.3.204.1
+version=1.3.224.1
 revision=1
 wrksrc="SPIRV-Headers-sdk-${version}"
 build_style=cmake
@@ -10,7 +10,7 @@ maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="MIT"
 homepage="https://github.com/KhronosGroup/SPIRV-Headers"
 distfiles="https://github.com/KhronosGroup/SPIRV-Headers/archive/sdk-${version}.tar.gz"
-checksum=262864053968c217d45b24b89044a7736a32361894743dd6cfe788df258c746c
+checksum=c85714bfe62f84007286bd3b3c0471af0a7e06ab66bc2ca4623043011b28737f
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/SPIRV-Tools/template
+++ b/srcpkgs/SPIRV-Tools/template
@@ -1,6 +1,6 @@
 # Template file for 'SPIRV-Tools'
 pkgname=SPIRV-Tools
-version=2022.1
+version=2022.3
 revision=1
 build_style=cmake
 configure_args="-DSPIRV_SKIP_TESTS=ON -DSPIRV_WERROR=OFF
@@ -13,13 +13,15 @@ license="Apache-2.0"
 homepage="https://github.com/KhronosGroup/SPIRV-Tools"
 changelog="https://raw.githubusercontent.com/KhronosGroup/SPIRV-Tools/master/CHANGES"
 distfiles="https://github.com/KhronosGroup/SPIRV-Tools/archive/v${version}.tar.gz"
-checksum=844c0f590a0ab9237cec947e27cfc75bd14f39a68fc3b37d8f1b9e1b21490a58
+checksum=df6dc5ed5351f99aaaa6acc78111342d3400b27b99f18148d3be408570144a70
+LDFLAGS="-Wl,--no-undefined"
 
 SPIRV-Tools-devel_package() {
 	depends="SPIRV-Tools-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/cmake
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"
 	}

--- a/srcpkgs/Vulkan-ValidationLayers/template
+++ b/srcpkgs/Vulkan-ValidationLayers/template
@@ -1,7 +1,7 @@
 # Template file for 'Vulkan-ValidationLayers'
 pkgname=Vulkan-ValidationLayers
 version=1.3.204.1
-revision=1
+revision=2
 wrksrc="Vulkan-ValidationLayers-sdk-${version}"
 build_style=cmake
 configure_args="-Wno-dev -DBUILD_LAYER_SUPPORT_FILES=ON"

--- a/srcpkgs/glslang/template
+++ b/srcpkgs/glslang/template
@@ -1,7 +1,7 @@
 # Template file for 'glslang'
 # Libraries are unversioned, beware of ABI breakage (rebuild shaderc on updates)
 pkgname=glslang
-version=8.13.3743
+version=11.11.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_SHARED_LIBS=ON"
@@ -11,7 +11,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="https://github.com/KhronosGroup/glslang"
 distfiles="https://github.com/KhronosGroup/glslang/archive/${version}.tar.gz"
-checksum=639ebec56f1a7402f2fa094469a5ddea1eceecfaf2e9efe361376a0f73a7ee2f
+checksum=26c216c3062512c018cbdd752224b8dad703b7e5bb90bf338ba2dbb5d4f11438
 
 post_install() {
 	sed -n '2,32p' < glslang/GenericCodeGen/CodeGen.cpp > LICENSE
@@ -24,6 +24,7 @@ glslang-devel_package() {
 	pkg_install() {
 		vmove usr/include
 		vmove "usr/lib/*.a"
+		vmove usr/lib/libglslang.so
 		vmove usr/lib/cmake
 	}
 }

--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,7 +1,7 @@
 # Template file for 'retroarch'
 pkgname=retroarch
 version=1.10.3
-revision=1
+revision=2
 wrksrc="RetroArch-$version"
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking

--- a/srcpkgs/shaderc/patches/fix-glslang-link-order.patch
+++ b/srcpkgs/shaderc/patches/fix-glslang-link-order.patch
@@ -1,43 +1,25 @@
-Original upstream PR: https://github.com/google/shaderc/pull/463
-
-From 21c8be385b3fab5edcb934a6d99f69fd389c4e67 Mon Sep 17 00:00:00 2001
-From: Niklas Haas <git@haasn.xyz>
-Date: Tue, 29 May 2018 07:34:00 +0200
-Subject: [PATCH] Fix the link order of libglslang and libHLSL
-
-libglslang depends on libHLSL, so the latter needs to be specified last.
-This fixes an issue when trying to build shaderc against system-wide
-versions of libglslang/libHLSL, rather than the in-tree versions from
-third_party.
-
-Additionally, libshaderc_util also depends on SPIRV-Tools
----
- glslc/CMakeLists.txt           | 2 +-
- libshaderc_util/CMakeLists.txt | 4 ++--
- 2 files changed, 3 insertions(+), 3 deletions(-)
-
+https://github.com/google/shaderc/pull/463
 --- a/glslc/CMakeLists.txt
 +++ b/glslc/CMakeLists.txt
-@@ -18,7 +18,7 @@ add_library(glslc STATIC
- shaderc_default_compile_options(glslc)
- target_include_directories(glslc PUBLIC ${glslang_SOURCE_DIR})
- target_link_libraries(glslc PRIVATE glslang OSDependent OGLCompiler
--  HLSL glslang SPIRV ${CMAKE_THREAD_LIBS_INIT})
-+  glslang SPIRV HLSL ${CMAKE_THREAD_LIBS_INIT})
- target_link_libraries(glslc PRIVATE shaderc_util shaderc)
-
- add_executable(glslc_exe src/main.cc)
+@@ -43,7 +43,7 @@ if (SHADERC_ENABLE_WGSL_OUTPUT)
+ endif(SHADERC_ENABLE_WGSL_OUTPUT)
+ 
+ target_link_libraries(glslc PRIVATE
+-  glslang OSDependent OGLCompiler HLSL glslang SPIRV    # Glslang libraries
++  glslang OSDependent OGLCompiler glslang SPIRV HLSL    # Glslang libraries
+   $<$<BOOL:${SHADERC_ENABLE_WGSL_OUTPUT}>:libtint>      # Tint libraries, optional
+   shaderc_util shaderc                                  # internal Shaderc libraries
+   ${CMAKE_THREAD_LIBS_INIT})
 --- a/libshaderc_util/CMakeLists.txt
 +++ b/libshaderc_util/CMakeLists.txt
-@@ -34,8 +34,8 @@ endif(SHADERC_ENABLE_INSTALL)
-
+@@ -46,8 +46,8 @@ add_definitions(-DENABLE_HLSL)
+ 
  find_package(Threads)
  target_link_libraries(shaderc_util PRIVATE
 -  glslang OSDependent OGLCompiler HLSL glslang SPIRV
 -  SPIRV-Tools-opt ${CMAKE_THREAD_LIBS_INIT})
 +  glslang OSDependent OGLCompiler glslang HLSL SPIRV
 +  SPIRV-Tools-opt SPIRV-Tools ${CMAKE_THREAD_LIBS_INIT})
-
+ 
  shaderc_add_tests(
    TEST_PREFIX shaderc_util
-

--- a/srcpkgs/shaderc/template
+++ b/srcpkgs/shaderc/template
@@ -1,6 +1,6 @@
 # Template file for 'shaderc'
 pkgname=shaderc
-version=2020.0
+version=2022.2
 revision=1
 build_style=cmake
 configure_args="-DSHADERC_SKIP_TESTS=ON"
@@ -11,9 +11,10 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/google/shaderc"
 distfiles="https://github.com/google/shaderc/archive/v${version}.tar.gz"
-checksum=e02e2a9d4c3960bc629ca8cdcf83d295bec9c80ed08a8c5062e4e294022605ec
+checksum=517d36937c406858164673db696dc1d9c7be7ef0960fbf2965bfef768f46b8c0
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/glslang"
+LDFLAGS="-Wl,--no-undefined"
 
 pre_configure() {
 	# Unbundle glslang, SPIRV-Headers, SPIRV-Tools
@@ -27,9 +28,13 @@ pre_configure() {
 	# Create our own build-version.inc since we disabled git versioning
 	# need to keep this in sync with glslang and SPIRV-Tools versions
 	# this is displayed with 'glslc --version'
+	spirv="$($XBPS_QUERY_XCMD -p pkgver SPIRV-Tools)"
+	spirv=${spirv%_*}
+	glslang=$($XBPS_QUERY_XCMD -p pkgver glslang)
+	glslang=${glslang%_*}
 	cat <<- EOF > glslc/src/build-version.inc
-		"shaderc 2020.0\n"
-		"SPIRV-Tools-2020.3\n"
-		"glslang-8.13.3743\n"
+		"shaderc ${version}\n"
+		"${spirv}\n"
+		"${glslang}\n"
 	EOF
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
