### PR TITLE
betterlockscreen: use loginctl instead of systemctl

### DIFF
--- a/srcpkgs/betterlockscreen/patches/use-loginctl.patch
+++ b/srcpkgs/betterlockscreen/patches/use-loginctl.patch
@@ -1,0 +1,12 @@
+diff -Naur betterlockscreen-4.0.3/betterlockscreen betterlockscreen-4.0.3-patched/betterlockscreen
+--- betterlockscreen-4.0.3/betterlockscreen	2021-08-22 03:39:34.000000000 +0800
++++ betterlockscreen-4.0.3-patched/betterlockscreen	2022-09-05 17:29:51.165948726 +0800
+@@ -965,6 +965,6 @@
+ # Activate lockscreen
+ [[ $runsuspend ]] || lockargs+=(-n)
+ [[ $runlock ]] && lockselect "$lockstyle" && \
+-    { [[ $runsuspend ]] && systemctl suspend; }
++    { [[ $runsuspend ]] && loginctl suspend; }
+ 
+ exit 0
+\ No newline at end of file


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
