### PR TITLE
ddcutil: add back depends on i2c-tools

### DIFF
--- a/srcpkgs/ddcutil/template
+++ b/srcpkgs/ddcutil/template
@@ -1,14 +1,16 @@
 # Template file for 'ddcutil'
 pkgname=ddcutil
 version=1.3.0
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config"
-makedepends="i2c-tools-devel libdrm-devel libgudev-devel libkmod-devel libusb-devel libXrandr-devel"
+makedepends="i2c-tools-devel libdrm-devel libgudev-devel libkmod-devel
+ libusb-devel libXrandr-devel"
+depends="i2c-tools"
 short_desc="Query and change monitor settings using DDC/CI and USB"
 maintainer="lemmi <lemmi@nerd2nerd.org>"
 license="GPL-2.0-or-later"
-homepage="http://www.ddcutil.com"
+homepage="https://www.ddcutil.com"
 changelog="https://www.ddcutil.com/release_notes/"
 distfiles="https://github.com/rockowitz/ddcutil/archive/v${version}.tar.gz"
 checksum=fa439f031c9372360e8d266f4294937dd3ee0a1c812d41e596b5e75a6d73d6d3


### PR DESCRIPTION
Recently, this was removed from depends, and added to makedepends,
but (at least on x86_64-musl) it is not picked up automatically.
 @lemmi 