### PR TITLE
mdocml: hide architecture selector in void.css

### DIFF
--- a/srcpkgs/mdocml/files/void.css
+++ b/srcpkgs/mdocml/files/void.css
@@ -54,3 +54,8 @@ nav#void-nav ul li a:hover,nav#void-nav ul li a:focus {
 	background-color:#000;
 	text-decoration:none
 }
+
+/** Hide architecture selector **/
+select[name="arch"] {
+	display: none;
+}

--- a/srcpkgs/mdocml/template
+++ b/srcpkgs/mdocml/template
@@ -1,7 +1,7 @@
 # Template file for 'mdocml'
 pkgname=mdocml
 version=1.14.6
-revision=4
+revision=5
 wrksrc="mandoc-${version}"
 build_style=configure
 make_build_args="all man.cgi"
@@ -14,8 +14,8 @@ conf_files="/etc/man.conf"
 short_desc="UNIX manpage compiler toolset (mandoc)"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="ISC"
-homepage="http://mandoc.bsd.lv"
-distfiles="http://mandoc.bsd.lv/snapshots/mandoc-${version}.tar.gz"
+homepage="https://mandoc.bsd.lv"
+distfiles="https://mandoc.bsd.lv/snapshots/mandoc-${version}.tar.gz"
 checksum=8bf0d570f01e70a6e124884088870cbed7537f36328d512909eb10cd53179d9c
 provides="man-0_1"
 


### PR DESCRIPTION
this has no meaning for void, so let's hide it

also http -> https for homepage/distfiles

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

![image](https://user-images.githubusercontent.com/5366828/188493596-375ff694-ce71-4345-b610-eedeb215cd29.png)
![image](https://user-images.githubusercontent.com/5366828/188493606-dca19d32-a0de-423f-968f-906e14fffc27.png)
