### PR TITLE
blueprint-compiler: update to 0.4.0.

### DIFF
--- a/srcpkgs/blueprint-compiler/template
+++ b/srcpkgs/blueprint-compiler/template
@@ -1,6 +1,6 @@
 # Template file for 'blueprint-compiler'
 pkgname=blueprint-compiler
-version=0.2.0
+version=0.4.0
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=meson
@@ -10,5 +10,6 @@ short_desc="Blueprint is a markup language and compiler for GTK 4 user interface
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="LGPL-3.0-or-later"
 homepage="https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/"
+changelog="https://gitlab.gnome.org/jwestman/blueprint-compiler/-/raw/main/NEWS.md"
 distfiles="https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v${version}/blueprint-compiler-v${version}.tar.gz"
-checksum=d4e5444c95e8d0060c819d0ab96f79a7ea2673296be95a2fb00359d1d54a0d83
+checksum=c1a5efd8562aca7df259679c6d9cd067ea2a78372069fcc01985619ec3963d8f


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Tested with #37132, new giara build still works as expected when built with blueprint-compiler-0.4.0_1

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
