### PR TITLE
rpi-firmware: add firmware for zero 2w

### DIFF
--- a/srcpkgs/rpi-firmware/template
+++ b/srcpkgs/rpi-firmware/template
@@ -4,7 +4,7 @@ _gitshort="${_githash:0:7}"
 
 pkgname=rpi-firmware
 version=20220823
-revision=1
+revision=2
 archs="armv6l* armv7l* aarch64*"
 wrksrc="firmware-${_githash}"
 provides="linux-firmware-broadcom-${version}_${revision}"
@@ -57,6 +57,16 @@ do_install() {
 	# Firmware for rpi3 b+ bluetooth chip
 	$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/bluez-firmware/master/broadcom/BCM4345C0.hcd
 	vinstall BCM4345C0.hcd 0644 usr/lib/firmware/brcm
+
+	# Firmware for rpi zero 2w wifi chip
+	for f in bin txt clm_blob; do
+		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43436-sdio.${f}
+		vinstall brcmfmac43436-sdio.${f} 0644 usr/lib/firmware/brcm
+	done
+	for f in bin txt; do
+		$XBPS_FETCH_CMD https://raw.githubusercontent.com/RPi-Distro/firmware-nonfree/buster/brcm/brcmfmac43436s-sdio.${f}
+		vinstall brcmfmac43436s-sdio.${f} 0644 usr/lib/firmware/brcm
+	done
 
 	# Firmware for rpi4/rpi400 wifi chip
 	for f in bin txt clm_blob; do


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

This took some figuring out, there's no documentation anywhere except a couple commit messages and blog posts.

- https://picockpit.com/raspberry-pi/raspberry-pi-zero-2-w-wifi-chipset-speeds-monitor-mode/
- https://github.com/RPi-Distro/firmware-nonfree/issues/24
- https://github.com/RPi-Distro/firmware-nonfree/commit/bda9207acee945633464e89614f3717b856579b5

#### Testing the changes
- I tested the changes in this PR: **YES**
```
# dmesg -H | grep brcmfmac
[  +0.105226] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43436-sdio for chip BCM43430/2
[  +0.001051] usbcore: registered new interface driver brcmfmac
[  +0.003262] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43436-sdio.raspberrypi,model-zero-2-w.bin failed with error -2
[  +0.030631] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43436-sdio for chip BCM43430/2
[  +0.005169] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43436-sdio for chip BCM43430/2
[  +0.025214] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM43430/2 wl0: Oct  9 2020 14:44:32 version 9.88.4.65 (test) (f149b32@shgit)  (r679549) FWID 01-f40f3270
[  +0.113385] brcmfmac: brcmf_cfg80211_set_power_mgmt: power save enabled
```

