### PR TITLE
rock64 uboot

### DIFF
--- a/srcpkgs/atf-rk3328-bl31/template
+++ b/srcpkgs/atf-rk3328-bl31/template
@@ -1,15 +1,15 @@
 # Template file for 'atf-rk3328-bl31'
 pkgname=atf-rk3328-bl31
-version=2.4
+version=2.7
 revision=1
 archs="aarch64*"
 wrksrc="trusted-firmware-a-${version}"
 short_desc="ARM Trusted Firmware for Rockchip rk3328 boards (ARMv8, bl31 option)"
-maintainer="Cameron Nemo <cnemo@tutanota.com>"
+maintainer="Cameron Nemo <cam@nohom.org>"
 license="BSD-3-Clause"
 homepage="https://developer.trustedfirmware.org/dashboard/view/6/"
 distfiles="https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/snapshot/trusted-firmware-a-${version}.tar.gz"
-checksum=bf3eb3617a74cddd7fb0e0eacbfe38c3258ee07d4c8ed730deef7a175cc3d55b
+checksum=53422dc649153838e03820330ba17cb10afe3e330ecde0db11e4d5f1361a33e6
 nostrip=yes
 
 do_build() {

--- a/srcpkgs/atf-rk3328-bl31/update
+++ b/srcpkgs/atf-rk3328-bl31/update
@@ -1,0 +1,2 @@
+site=https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/refs/
+pattern="tag/\?h=v\K[\d\.]+"

--- a/srcpkgs/rock64-uboot/template
+++ b/srcpkgs/rock64-uboot/template
@@ -1,17 +1,17 @@
 # Template file for 'rock64-uboot'
 pkgname=rock64-uboot
-version=2020.10
+version=2022.07
 revision=1
 archs="aarch64*"
 wrksrc="u-boot-${version}"
-hostmakedepends="flex bc python3 swig python3-devel dtc"
+hostmakedepends="flex bc dtc python3 openssl-devel swig python3-devel"
 makedepends="atf-rk3328-bl31"
 short_desc="Das U-Boot for the Rock64 SBC"
-maintainer="Cameron Nemo <cnemo@tutanota.com>"
+maintainer="Cameron Nemo <cam@nohom.org>"
 license="GPL-2.0-or-later, BSD-3-Clause"
 homepage="https://www.denx.de/wiki/U-Boot/"
 distfiles="https://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2"
-checksum=0d481bbdc05c0ee74908ec2f56a6daa53166cc6a78a0e4fac2ac5d025770a622
+checksum=92b08eb49c24da14c1adbf70a71ae8f37cc53eeb4230e859ad8b6733d13dcf5e
 
 do_configure() {
 	make rock64-rk3328_defconfig


### PR DESCRIPTION
- atf-rk3328-bl31: update to 2.7
- rock64-uboot: update to 2022.07

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
