### PR TITLE
go: update to 1.19.1.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.19
+version=1.19.1
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=9419cc70dc5a2523f29a77053cafff658ed21ef3561d9b6b020280ebceab28b9
+checksum=27871baa490f3401414ad793fba49086f6c855b1c584385ed7771e1204c7e179
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
## Security fixes in Go 1.19

See: https://go.dev/doc/devel/release#go1.19

> go1.19.1 (released 2022-09-06) includes security fixes to the net/http and net/url packages, as well as bug fixes to the compiler, the go command, the pprof command, the linker, the runtime, and the crypto/tls and crypto/x509 packages.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

