### PR TITLE
android-tools: update to 31.0.3p2.

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,7 +1,7 @@
 # Template file for 'android-tools'
 pkgname=android-tools
-version=31.0.3p1
-revision=5
+version=31.0.3p2
+revision=1
 archs="armv* aarch64* x86_64* i686* ppc64le*"
 build_style=cmake
 hostmakedepends="perl go protobuf pkg-config"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"
 homepage="http://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
-checksum=0ef69f919d58a2bdff2083d2e83a9ef38df079ec82651b2544e9e48086df5ab8
+checksum=2e1274d625368f57128477c2cda8474489443cc56e8738cb71919412a2872fca
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
CC @Johnnynator (maintainer)

#### Changelog
 * Added e2fsdroid and ext2simg
 * Fixed build with GCC 12
 * Bumped minimum required CMake version to 3.13

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)