### PR TITLE
Fix qbittorrent crash on musl

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2094,7 +2094,7 @@ libldns.so.3 libldns-1.7.1_4
 libopenjpeg.so.5 libopenjpeg-1.5.2_1
 liboping.so.0 liboping-1.8.0_1
 libloudmouth-1.so.0 loudmouth-1.5.3_12
-libtorrent-rasterbar.so.10 libtorrent-rasterbar-1.2.17_1
+libtorrent-rasterbar.so.10 libtorrent-rasterbar-1.2.17_2
 libcapstone.so.4 capstone-4.0_1
 libhavege.so.2 libhaveged-1.9.11_1
 libnih.so.1 libnih-1.0.3_1

--- a/srcpkgs/boost/patches/feature-test-macros.patch
+++ b/srcpkgs/boost/patches/feature-test-macros.patch
@@ -1,0 +1,32 @@
+boost/align/aligned_alloc.hpp is wrong, it uses feature test macros to
+determine whether something is available;
+FTMs shouldn't be in user code outside of top level #define's.
+
+This lead to an issue on musl where libtorrent-rasterbar was including this
+header (via boost asio) from two different places, and segfaulting due to
+mismatched implementations -- one's the posix one using posix_memalign, the
+other one's the generic one that stores a pointer to itself.
+
+posix_memalign is always available on the libcs we support and should always be
+used, so we force that. We still leave applications with the option of forcing
+boost specific behavior, if they really want it.
+
+Instead of patching only boost/align/aligned_alloc.hpp, which fix the
+bug if boost::asio is used, but may keep other boost's code use feature tests
+macro, now or later, let's patch boost/config.hpp to always define
+_XOPEN_SOURCE instead.
+
+--- a/boost/config.hpp
++++ b/boost/config.hpp
+@@ -17,6 +17,11 @@
+ #ifndef BOOST_CONFIG_HPP
+ #define BOOST_CONFIG_HPP
+ 
++#ifdef __linux__
++/* for _XOPEN_SOURCE and/or _POSIX_C_SOURCE */
++#include <features.h>
++#endif
++
+ // if we don't have a user config, then use the default location:
+ #if !defined(BOOST_USER_CONFIG) && !defined(BOOST_NO_USER_CONFIG)
+ #  define BOOST_USER_CONFIG <boost/config/user.hpp>

--- a/srcpkgs/boost/template
+++ b/srcpkgs/boost/template
@@ -1,7 +1,7 @@
 # Template file for 'boost'
 pkgname=boost
 version=1.80.0
-revision=1
+revision=2
 wrksrc="${pkgname}_${version//\./_}"
 hostmakedepends="which bzip2-devel icu-devel python3-devel pkg-config"
 makedepends="zlib-devel bzip2-devel icu-devel python3-devel liblzma-devel

--- a/srcpkgs/libtorrent-rasterbar/template
+++ b/srcpkgs/libtorrent-rasterbar/template
@@ -2,7 +2,7 @@
 # Breaks ABI/API without changing soname, revbump all dependants
 pkgname=libtorrent-rasterbar
 version=1.2.17
-revision=1
+revision=2
 build_style=cmake
 configure_args="DCMAKE_CXX_STANDARD=14 -Dbuild_examples=ON -Dbuild_tools=ON
  -Dpython-bindings=ON"

--- a/srcpkgs/qbittorrent/template
+++ b/srcpkgs/qbittorrent/template
@@ -1,7 +1,7 @@
 # Template file for 'qbittorrent'
 pkgname=qbittorrent
 version=4.4.3.1
-revision=2
+revision=3
 create_wrksrc=yes
 build_style=gnu-configure
 build_helper=qmake


### PR DESCRIPTION
- boost: fix segfault in asio+align module.
- libtorrent-rasterbar: rebuild to fix segfault.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
