### PR TITLE
Add aptXand ldac support to gstreamer bad plugins

### DIFF
--- a/srcpkgs/gst-plugins-bad1/template
+++ b/srcpkgs/gst-plugins-bad1/template
@@ -1,7 +1,7 @@
 # Template file for 'gst-plugins-bad1'
 pkgname=gst-plugins-bad1
 version=1.20.3
-revision=2
+revision=3
 wrksrc="${pkgname/1/}-${version}"
 build_helper="gir"
 build_style=meson
@@ -13,6 +13,7 @@ configure_args="-Dpackage-origin=https://voidlinux.org -Ddoc=disabled
  -Dopenh264=disabled -Dopenmpt=disabled -Dopenni2=disabled -Dsctp=disabled
  -Dsrt=disabled -Dteletext=disabled -Dvoaacenc=disabled -Dvoamrwbenc=disabled
  -Dwildmidi=disabled -Dwpe=disabled -Ddirectfb=disabled
+ -Dldac=$(vopt_if ldac enabled disabled) -Dopenaptx=$(vopt_if aptx enabled disabled)
  -Dgme=$(vopt_if gme enabled disabled)
  -Dintrospection=$(vopt_if gir enabled disabled) -Dneon=disabled"
 hostmakedepends="automake gettext libtool pkg-config python3 glib-devel
@@ -29,7 +30,7 @@ makedepends="alsa-lib-devel celt-devel openssl-devel exempi-devel
  fdk-aac-devel flite-devel fluidsynth-devel liblrdf-devel ladspa-sdk
  lilv-devel lv2 libopenjpeg2-devel sbc-devel spandsp-devel vulkan-loader
  Vulkan-Headers webrtc-audio-processing-devel libzbar-devel ffmpeg-devel
- srt-devel
+ $(vopt_if ldac ldacBT-devel) $(vopt_if aptx libopenaptx-devel) srt-devel
  $(vopt_if gme libgme-devel)"
 depends="gst-plugins-base1>=${version}"
 short_desc="GStreamer plugins from the bad set (v1.x)"
@@ -39,9 +40,11 @@ homepage="https://gstreamer.freedesktop.org"
 distfiles="${homepage}/src/${pkgname/1/}/${pkgname/1/}-${version}.tar.xz"
 checksum=7a11c13b55dd1d2386dd902219e41cbfcdda8e1e0aa3e738186c95074b35da4f
 
-build_options="gir gme wayland"
-build_options_default="gir wayland"
+build_options="gir gme wayland aptx ldac"
+build_options_default="gir wayland aptx ldac"
 desc_option_gme="Build with Game Music Emulator support"
+desc_option_apx="Build with AptX codec support"
+desc_option_ldac="Build with ldac codec support"
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
Adds aptx support for gstreamer, if support for gstreamer codecs is added to pulseaudio, this allows the use of aptX or ldac when using bluetooth devices that support this codecs

#### Testing the changes
- I tested the changes in this PR: YES

#### Local build testing
- I built this PR locally for my native architecture, (x86-glibc)

