### PR TITLE
Signal-Desktop: update to 5.58.0.

### DIFF
--- a/srcpkgs/Signal-Desktop/template
+++ b/srcpkgs/Signal-Desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'Signal-Desktop'
 pkgname=Signal-Desktop
-version=5.57.0
+version=5.58.0
 revision=1
 # Signal officially only supports x86_64 (also due to Electron)
 # x86_64-musl fails because of its dependency on 'node-gyp' which depends on a glibc specific extension
@@ -13,7 +13,7 @@ maintainer="akierig <anelki@fastmail.de>"
 license="AGPL-3.0-only"
 homepage="https://github.com/signalapp/Signal-Desktop"
 distfiles="https://github.com/signalapp/Signal-Desktop/archive/v${version}.tar.gz"
-checksum=eeb2a8cfcfb8410fc7ee901cb1b7994421844fb7af1e52b9faad6151b32b152b
+checksum=448f15709f20cb6ea549819fed011dcd9f24683247cd55d826e89d6fc8ad822c
 nostrip_files="signal-desktop"
 
 post_extract() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64