### PR TITLE
source-sans-pro: update to 3.046.

### DIFF
--- a/srcpkgs/source-sans-pro/template
+++ b/srcpkgs/source-sans-pro/template
@@ -1,15 +1,15 @@
 # Template file for 'source-sans-pro'
 pkgname=source-sans-pro
-version=3.028
+version=3.046
 revision=1
-wrksrc="source-sans-pro-${version}R"
+wrksrc="source-sans-${version}R"
 depends="font-util"
 short_desc="Sans serif font family for user interface environments"
 maintainer="WantToHelp <ghostinthecsh@gmail.com>"
 license="OFL-1.1"
-homepage="https://adobe-fonts.github.io/source-sans-pro/"
-distfiles="https://github.com/adobe-fonts/source-sans-pro/archive/${version}R.tar.gz"
-checksum=12faf267e40f1be46daf44afce47facd6efb996e2f2f5abe0a3dde161d54e251
+homepage="https://adobe-fonts.github.io/source-sans/"
+distfiles="https://github.com/adobe-fonts/source-sans/archive/${version}R.tar.gz"
+checksum=7a0a3a0c9ff2740380eddc28a53b4b0dc99491da5f900f4add5af2d1a18e06bc
 font_dirs="/usr/share/fonts/OTF /usr/share/fonts/TTF"
 
 do_install() {


### PR DESCRIPTION
In addition to version update, the font repository seems to have been moved from `adobe-fonts/source-sans-pro` to `adobe-fonts/source-sans`. The change was applied to the template. The list of package files was checked to be identical with the previous version of the package.

Fixes one of the issues in #39072.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - armv6l (cross)
