### PR TITLE
New package: carapace-0.24.1

### DIFF
--- a/srcpkgs/carapace/template
+++ b/srcpkgs/carapace/template
@@ -1,0 +1,27 @@
+# Template file for 'carapace'
+pkgname=carapace
+version=0.24.1
+revision=1
+build_style=go
+go_import_path=github.com/rsteube/carapace-bin
+go_package="${go_import_path}/cmd/carapace"
+go_build_tags="release"
+go_ldflags="-X main.version=${version}"
+short_desc="Multi-shell multi-command argument completer"
+maintainer="icp <pangolin@vivaldi.net>"
+license="MIT"
+homepage="https://github.com/rsteube/carapace-bin"
+distfiles="https://github.com/rsteube/carapace-bin/archive/refs/tags/v${version}.tar.gz"
+checksum=1ed90aa3a00f9b162c9cda0900c7ac54a186374a3322a1c3106c4cb4a35d48bc
+
+pre_build() {
+	GOARCH= go generate ./cmd/...
+}
+
+do_check() {
+	go test ./cmd/carapace/...
+}
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

A nice soft dependency for Nushell (and some other shells in repo).