### PR TITLE
vaultwarden-web: update to 2022.10.2; vaultwarden: update to 1.26.0.

### DIFF
--- a/srcpkgs/vaultwarden-web/template
+++ b/srcpkgs/vaultwarden-web/template
@@ -1,8 +1,8 @@
-# Template file for 'vaultwarden-web' 
+# Template file for 'vaultwarden-web'
 pkgname=vaultwarden-web
-version=2022.8.1
+version=2022.10.2
 revision=1
-_patch_ver=2022.8.0
+_patch_ver=2022.10.0
 create_wrksrc=yes
 build_wrksrc="clients-web-v${version}"
 hostmakedepends="git nodejs"
@@ -12,8 +12,8 @@ license="GPL-3.0-or-later"
 homepage="https://github.com/dani-garcia/bw_web_builds"
 distfiles="https://github.com/bitwarden/clients/archive/web-v${version}.tar.gz
  https://raw.githubusercontent.com/dani-garcia/bw_web_builds/master/patches/v${_patch_ver}.patch"
-checksum="9dff38f13d8be047fe0fd6426bda3c409bb222b787bd6b21a3559f5d29255a92
- 1199bcf5edb0cad2e0fc1e839b5bdc690565d6af5b32cc1c38348f0b13c69ee9"
+checksum="6ec4fcae9ce26ecf55647f58598cbb4c4c0b6b093053f9d208781a4fc0c81fda
+ 83484ec2106cf8b9d2c52b4284e3f3b876a5b9e9e0767eda69a1987304ddbaad"
 
 post_extract() {
 	mv v$_patch_ver.patch ${build_wrksrc}
@@ -28,6 +28,9 @@ do_configure() {
 }
 
 do_build() {
+	case "$XBPS_TARGET_MACHINE" in
+		i686*) export NODE_OPTIONS="--max-old-space-size=2048" ;;
+	esac
 	cd apps/web
 	npm run dist:oss:selfhost
 }

--- a/srcpkgs/vaultwarden-web/update
+++ b/srcpkgs/vaultwarden-web/update
@@ -1,2 +1,2 @@
-pkgname=bw_web
-site="https://github.com/dani-garcia/bw_web_builds/releases"
+site="https://github.com/dani-garcia/bw_web_builds/tags"
+pkgname=v

--- a/srcpkgs/vaultwarden/template
+++ b/srcpkgs/vaultwarden/template
@@ -1,6 +1,6 @@
 # Template file for 'vaultwarden'
 pkgname=vaultwarden
-version=1.25.2
+version=1.26.0
 revision=1
 archs="x86_64* i686* aarch64* arm*" # ring
 build_style=cargo
@@ -13,7 +13,7 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/dani-garcia/vaultwarden"
 distfiles="https://github.com/dani-garcia/vaultwarden/archive/${version}.tar.gz"
-checksum=f4afc2d8aa7aa59dd1ae16497b6a7f9b412ff426a24868e3081054e611d4824d
+checksum=0b9f241cf0e0ba0bf49e5e45aaec4350d7e816e98340d2756b76fa376775592d
 
 system_accounts="_vaultwarden"
 _vaultwarden_homedir="/var/lib/vaultwarden"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
