### PR TITLE
rpi-kernel: update to 5.15.65 [ci skip]

### DIFF
--- a/srcpkgs/rpi-kernel/template
+++ b/srcpkgs/rpi-kernel/template
@@ -12,11 +12,11 @@
 #
 # WARNING: keep all rpi*-kernel packages in sync
 
-_githash="64ad74084fa44abe8689564071df5729ded4c589"
+_githash="cbb47398aebff7605bc23c4727c27d16a566982e"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi-kernel
-version=5.15.61
+version=5.15.65
 revision=1
 archs="armv6l*"
 wrksrc="linux-${_githash}"
@@ -27,7 +27,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi zero/1 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
+checksum=efcfe8c0fddbe2b86a405cca3b79ba8af83d81870ac2ac350cefd3c6387a8e3d
 python_version=3
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi2-kernel/template
+++ b/srcpkgs/rpi2-kernel/template
@@ -1,22 +1,22 @@
 # Template file for 'rpi2-kernel'
 # See rpi-kernel for version policy
 
-_githash="64ad74084fa44abe8689564071df5729ded4c589"
+_githash="cbb47398aebff7605bc23c4727c27d16a566982e"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi2-kernel
-version=5.10.110
+version=5.15.65
 revision=1
 archs="armv7l*"
 wrksrc="linux-${_githash}"
-hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex"
+hostmakedepends="perl kmod uboot-mkimage openssl-devel bc bison flex xz"
 makedepends="ncurses-devel"
 maintainer="Piraty <piraty1@inbox.ru>"
 homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
+checksum=efcfe8c0fddbe2b86a405cca3b79ba8af83d81870ac2ac350cefd3c6387a8e3d
 python_version=3
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi3-kernel/template
+++ b/srcpkgs/rpi3-kernel/template
@@ -1,11 +1,11 @@
 # Template file for 'rpi3-kernel'
 # See rpi-kernel for version policy
 
-_githash="64ad74084fa44abe8689564071df5729ded4c589"
+_githash="cbb47398aebff7605bc23c4727c27d16a566982e"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi3-kernel
-version=5.15.61
+version=5.15.65
 revision=1
 archs="aarch64*"
 wrksrc="linux-${_githash}"
@@ -16,7 +16,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 3 / Zero 2 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
+checksum=efcfe8c0fddbe2b86a405cca3b79ba8af83d81870ac2ac350cefd3c6387a8e3d
 python_version=3
 
 _kernver="${version}_${revision}"

--- a/srcpkgs/rpi4-kernel/template
+++ b/srcpkgs/rpi4-kernel/template
@@ -1,11 +1,11 @@
 # Template file for 'rpi4-kernel'
 # See rpi-kernel for version policy
 
-_githash="64ad74084fa44abe8689564071df5729ded4c589"
+_githash="cbb47398aebff7605bc23c4727c27d16a566982e"
 _gitshort="${_githash:0:7}"
 
 pkgname=rpi4-kernel
-version=5.15.61
+version=5.15.65
 revision=1
 archs="aarch64*"
 wrksrc="linux-${_githash}"
@@ -16,7 +16,7 @@ homepage="http://www.kernel.org"
 license="GPL-2.0-only"
 short_desc="Linux kernel for Raspberry Pi 4 (${version%.*} series [git ${_gitshort}])"
 distfiles="https://github.com/raspberrypi/linux/archive/${_githash}.tar.gz"
-checksum=8257604cc47792007284cc2640d7dd9f70fab062a7c596e92903e99718434244
+checksum=efcfe8c0fddbe2b86a405cca3b79ba8af83d81870ac2ac350cefd3c6387a8e3d
 python_version=3
 conflicts=rpi3-kernel
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (on my Raspberry Pi 1 Rev 2)

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l (cross-built)

#### Notes
- Fixes issue #39129
- I  only have an rpi1, and can thus not test the kernel on newer rpis,
  but I did a quick-and-dirty update of those as well, given input that this is desired.