### PR TITLE
gtklock: update to 1.3.6

### DIFF
--- a/srcpkgs/gtklock/template
+++ b/srcpkgs/gtklock/template
@@ -1,6 +1,6 @@
 # Template file for 'gtklock'
 pkgname=gtklock
-version=1.3.5
+version=1.3.6
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -11,7 +11,7 @@ maintainer="Jovan Lanik <jox969@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/jovanlanik/gtklock"
 distfiles="https://github.com/jovanlanik/gtklock/archive/refs/tags/v${version}.tar.gz"
-checksum=753259cdf4b16dbe2b564a80a919976c2661a028d9d06b22f1da466e615a6766
+checksum=ddc39721e0fc4e2bfb18c17bb5f158af79934f376258137dc78b144ff84c1650
 
 post_install() {
 	# copying CSS example provided


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
