### PR TITLE
webkit2gtk: add patch to resolve unintended gst-plugins-bad1 dependency

### DIFF
--- a/srcpkgs/webkit2gtk/patches/nogstbad.patch
+++ b/srcpkgs/webkit2gtk/patches/nogstbad.patch
@@ -1,0 +1,29 @@
+From c9fa538715b7a40a24ed187d14995ee67a04b718 Mon Sep 17 00:00:00 2001
+From: coolbean <thecoolestofbeans@protonmail.com>
+Date: Fri, 9 Sep 2022 05:22:55 +0200
+Subject: [PATCH] apply patch
+
+---
+ .../graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp      | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+index 3237520e..d612c10a 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+@@ -3402,6 +3402,12 @@ GstElement* MediaPlayerPrivateGStreamer::createVideoSink()
+ 
+     if (!m_player->isVideoPlayer()) {
+         m_videoSink = makeGStreamerElement("fakevideosink", nullptr);
++	if (!m_videoSink) {
++		GST_DEBUG_OBJECT(m_pipeline.get(), "Falling back to fakesink for video rendering");
++		m_videoSink = gst_element_factory_make("fakesink", nullptr);
++		g_object_set(m_videoSink.get(), "sync", TRUE, nullptr);
++	}
++	
+         return m_videoSink.get();
+     }
+ 
+-- 
+2.37.3
+

--- a/srcpkgs/webkit2gtk/patches/nogstbad.patch
+++ b/srcpkgs/webkit2gtk/patches/nogstbad.patch
@@ -1,12 +1,27 @@
-From c9fa538715b7a40a24ed187d14995ee67a04b718 Mon Sep 17 00:00:00 2001
-From: coolbean <thecoolestofbeans@protonmail.com>
-Date: Fri, 9 Sep 2022 05:22:55 +0200
-Subject: [PATCH] apply patch
-
----
- .../graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp      | 6 ++++++
- 1 file changed, 6 insertions(+)
-
+diff --git a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+index abaa20d4..26c68ea9 100644
+--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
++++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+@@ -526,7 +526,8 @@ GstBuffer* gstBufferNewWrappedFast(void* data, size_t length)
+ GstElement* makeGStreamerElement(const char* factoryName, const char* name)
+ {
+     auto* element = gst_element_factory_make(factoryName, name);
+-    RELEASE_ASSERT_WITH_MESSAGE(element, "GStreamer element %s not found. Please install it", factoryName);
++    if (!element)
++	    WTFLogAlways("GStreamer element %s not found. Please install it", factoryName);
+     return element;
+ }
+ 
+@@ -534,7 +535,8 @@ GstElement* makeGStreamerBin(const char* description, bool ghostUnlinkedPads)
+ {
+     GUniqueOutPtr<GError> error;
+     auto* bin = gst_parse_bin_from_description(description, ghostUnlinkedPads, &error.outPtr());
+-    RELEASE_ASSERT_WITH_MESSAGE(bin, "Unable to create bin for description: \"%s\". Error: %s", description, error->message);
++    if (!bin)
++	    WTFLogAlways("Unable to create bin for description: \"%s\". Error: %s", description, error->message);
+     return bin;
+ }
+ 
 diff --git a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
 index 3237520e..d612c10a 100644
 --- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -24,6 +39,3 @@ index 3237520e..d612c10a 100644
          return m_videoSink.get();
      }
  
--- 
-2.37.3
-

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -2,7 +2,7 @@
 # ping q66 before touching this
 pkgname=webkit2gtk
 version=2.34.6
-revision=2
+revision=3
 wrksrc="webkitgtk-${version}"
 build_style=cmake
 build_helper="gir"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR:**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (amd64-glibc)

this would properly resolve issue [#34781](https://github.com/void-linux/void-packages/issues/34781) by applying the final fix already included in webkitgtk versions 2.36.4 and up

full credit for the fix goes to Philippe Normand [here](https://bugs.webkit.org/attachment.cgi?id=451364&action=diff), i just copy-pasted it onto this older version to generate a fitting patch

@q66 you asked to be pinged before touching this package