### PR TITLE
luakit: update to 2.3.1.

### DIFF
--- a/srcpkgs/luakit/patches/Makefile.patch
+++ b/srcpkgs/luakit/patches/Makefile.patch
@@ -1,5 +1,5 @@
---- a/Makefile	2018-12-30 16:13:10.512451500 -0600
-+++ b/Makefile	2018-12-30 16:15:27.507448741 -0600
+--- a/Makefile	2022-08-30 17:17:46.000000000 +0200
++++ b/Makefile	2022-09-09 13:20:16.288047152 +0200
 @@ -17,7 +17,7 @@
  # Must be kept in sync with doc/docgen.ld
  DOC_SRCS = $(filter-out lib/markdown.lua lib/lousy/init.lua,$(shell for d in doc/luadoc lib common/clib; do find $$d -type f; done)) tests/lib.lua
@@ -9,7 +9,7 @@
  
  options:
  	@echo luakit build options:
-@@ -79,27 +79,10 @@
+@@ -80,28 +80,11 @@
  luakit.1.gz: luakit.1
  	@gzip -c $< > $@
  
@@ -27,13 +27,14 @@
 -	rm -rf doc/apidocs doc/html luakit $(OBJS) $(EXT_OBJS) $(TSRC) $(THEAD) buildopts.h luakit.1 luakit.1.gz luakit.so
 -
  install: all
- 	install -d $(DESTDIR)$(PREFIX)/share/luakit/
- 	install -d $(DESTDIR)$(DOCDIR) $(DESTDIR)$(DOCDIR)/classes $(DESTDIR)$(DOCDIR)/modules $(DESTDIR)$(DOCDIR)/pages
+ 	install -d $(DESTDIR)$(DOCDIR)/classes
+ 	install -d $(DESTDIR)$(DOCDIR)/modules
+ 	install -d $(DESTDIR)$(DOCDIR)/pages
  	install -m644 README.md AUTHORS COPYING.GPLv3 $(DESTDIR)$(DOCDIR)
 -	install -m644 doc/apidocs/classes/* $(DESTDIR)$(DOCDIR)/classes
 -	install -m644 doc/apidocs/modules/* $(DESTDIR)$(DOCDIR)/modules
 -	install -m644 doc/apidocs/pages/* $(DESTDIR)$(DOCDIR)/pages
 -	install -m644 doc/apidocs/*.html $(DESTDIR)$(DOCDIR)
- 	install -d $(DESTDIR)$(PREFIX)/share/luakit/lib $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy/widget
+ 	install -d $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy/widget
  	install -m644 lib/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib
  	install -m644 lib/lousy/*.* $(DESTDIR)$(PREFIX)/share/luakit/lib/lousy

--- a/srcpkgs/luakit/template
+++ b/srcpkgs/luakit/template
@@ -1,7 +1,7 @@
 # Template file for 'luakit'
 pkgname=luakit
 reverts="2017.08.10_1"
-version=2.3
+version=2.3.1
 revision=1
 conf_files="/etc/xdg/luakit/*.lua"
 hostmakedepends="pkg-config LuaJIT"
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://luakit.github.io/"
 changelog="https://github.com/luakit/luakit/blob/develop/CHANGELOG.md"
 distfiles="https://github.com/luakit/luakit/archive/${version}.tar.gz"
-checksum=c7026b4f0bdfa44f43798b80f87548d3e7ad56f5b923fc43b9c712bf18496095
+checksum=138fed1eaccab801fae8c32ff2bec6cbcd864a9f527c5c77ad1de402ce1a130e
 
 CFLAGS="-fcommon"
 


### PR DESCRIPTION
I've updated the package version and recreated the makefile patch since the patching failed with the new version. x86_64 package file list was confirmed to be identical to the previous package version.

Update in response to #39072.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl (masterdir)
  - armv6l (cross)
