### PR TITLE
devilutionX: update to 1.4.1.

### DIFF
--- a/srcpkgs/devilutionX/template
+++ b/srcpkgs/devilutionX/template
@@ -1,17 +1,44 @@
 # Template file for 'devilutionX'
 pkgname=devilutionX
-version=1.2.1
+version=1.4.1
 revision=1
 build_style=cmake
-configure_args="-DVERSION_NUM=$version -DBINARY_RELEASE=ON -DTTF_FONT_PATH=\"/usr/share/fonts/truetype/CharisSILB.ttf\""
-makedepends="SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel"
+configure_args="-DVERSION_NUM=$version -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF"
+hostmakedepends="gettext git mpqtool pkgconf"
+makedepends="bzip2-devel fmt-devel libsodium-devel SDL2-devel SDL2_image-devel SDL2_mixer-devel zlib-devel"
 short_desc="Diablo I engine for modern operating systems"
 maintainer="MarcoAPC <marcoaureliopc@gmail.com>"
 license="Unlicense"
 homepage="https://github.com/diasurgical/devilutionX"
 distfiles="https://github.com/diasurgical/devilutionX/archive/${version}.tar.gz"
-checksum=002dcbd4d4a5bdf8db1a3ec01139e5bfbed46d6a1caa32b17c9f2df161ad3521
+checksum=54b9fd496eba5b82d7e64891ab4de808f539c60b3b94bfa49639e0d9580fb7b8
 
-post_install() {
-	vlicense LICENSE
+post_build() {
+	# Create devilutionx.mpq asset archive
+	# (smpq, required by the build script, is not available in Void repos
+	# so an alternative program mpqtool is used to create the MPQ archive)
+	mpqtool new 'build/assets' 'build/devilutionx.mpq'
+}
+
+do_install() {
+	vbin 'build/devilutionx'
+	# Install assets to the directory that is recognized by the binary
+	vinstall 'build/devilutionx.mpq' 644 'usr/share/diasurgical/devilutionx'
+
+	vdoc 'README.md'
+	vlicense 'LICENSE'
+
+	cd 'Packaging'
+	# Install desktop entries
+	vinstall 'nix/devilutionx.desktop' 644 'usr/share/applications'
+	vinstall 'nix/devilutionx-hellfire.desktop' 644 'usr/share/applications'
+	# Install icons
+	vinstall 'resources/icon.png' 644 \
+		'usr/share/icons/hicolor/512x512/apps' 'devilutionx.png'
+	vinstall 'resources/hellfire.png' 644 \
+		'usr/share/icons/hicolor/512x512/apps' 'devilutionx-hellfire.png'
+	vinstall 'resources/icon_32.png' 644 \
+		'usr/share/icons/hicolor/32x32/apps' 'devilutionx.png'
+	vinstall 'resources/hellfire_32.png' 644 \
+		'usr/share/icons/hicolor/32x32/apps' 'devilutionx-hellfire.png'
 }


### PR DESCRIPTION
Updated the package since the packaged version was released more than a year ago. For the most recent release, the template had to be changed for the build to succeed. See notes below.

**Cross builds seem to fail.** See notes below. Help is welcome.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (cross, **failed**)
  - armv6l (cross, **failed**),
  - x86_64-musl (masterdir)

#### Template changes
- Add devel dependencies so that more libs from the repos get dynamically linked instead of built and linked statically.
- Add host dependencies needed for the build process by trial and error.
- Upstream uses `smpq` to create a MPQ archive with game assets. Manually use `mpqtool` from Void repos. If the assets are not in a MPQ archive, the game expects them in something like `/usr/bin/assets`, which is not acceptable.
- Install process did nothing, even when manually calling `cmake --install`. The installation is not complicated so I've created an alternative install script.

#### Failing cross builds
Both `aarch64` and `armv6l` crossbuilds fail with the same error:
```
=> devilutionX-1.4.1_1: running do_build ...
ninja: error: '/usr/lib64/libSDL2main.a', needed by 'devilutionx', missing and no known rule to make it
```

Additionally, when I've tried to move `devel` deps to `hostmakedepends`, the build failed because the binary could not be stripped. I suspect that the build process does not cross-compile, but builds for the host arch instead (looking for libraries in `/usr/lib64` on `armv6l` is suspicious enough). Perhaps some additional arguments for Cmake are required.