### PR TITLE
zfs: downstream patch (dracut fix typo in mount-zfs.sh)

### DIFF
--- a/srcpkgs/zfs/patches/0003-dracut-fix-typo-in-mount-zfs.sh.in.patch
+++ b/srcpkgs/zfs/patches/0003-dracut-fix-typo-in-mount-zfs.sh.in.patch
@@ -1,0 +1,36 @@
+From 07f2793e869196fcbcd5057d9ada377674262fe3 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Wed, 29 Jun 2022 15:33:38 -0700
+Subject: [PATCH] dracut: fix typo in mount-zfs.sh.in
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Format the `zpool get` command correctly.  The -o option must
+be followed by "all" or the requested field name.
+
+Reviewed-by: Ahelenia Ziemiańska <nabijaczleweli@nabijaczleweli.xyz>
+Reviewed-by: George Melikov <mail@gmelikov.ru>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #13602
+Signed-off-by: Alexis Ehret <git@08a.re>
+---
+ contrib/dracut/90zfs/mount-zfs.sh.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/contrib/dracut/90zfs/mount-zfs.sh.in b/contrib/dracut/90zfs/mount-zfs.sh.in
+index fa9f1bb76..b0eb614a6 100755
+--- a/contrib/dracut/90zfs/mount-zfs.sh.in
++++ b/contrib/dracut/90zfs/mount-zfs.sh.in
+@@ -82,7 +82,7 @@ ZFS_DATASET="${ZFS_DATASET:-${root}}"
+ ZFS_POOL="${ZFS_DATASET%%/*}"
+ 
+ 
+-if ! zpool get -Ho name "${ZFS_POOL}" > /dev/null 2>&1; then
++if ! zpool get -Ho value name "${ZFS_POOL}" > /dev/null 2>&1; then
+     info "ZFS: Importing pool ${ZFS_POOL}..."
+     # shellcheck disable=SC2086
+     if ! zpool import -N ${ZPOOL_IMPORT_OPTS} "${ZFS_POOL}"; then
+-- 
+2.37.3
+

--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=2.1.5
-revision=2
+revision=3
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x84_64-glibc)

#####

Without this patch the dracut module can failed to mount the root partition.

PS: I am not the author of the patch. I extracted it from the official zfs repo (`git format-patch -1 07f2793e869196fcbcd5057d9ada377674262fe3`)
