### PR TITLE
gtk4: update to 4.8.0.

### DIFF
--- a/srcpkgs/gtk4/template
+++ b/srcpkgs/gtk4/template
@@ -1,6 +1,6 @@
 # Template file for 'gtk4'
 pkgname=gtk4
-version=4.6.7
+version=4.8.0
 revision=1
 wrksrc="gtk-${version}"
 build_style=meson
@@ -30,9 +30,10 @@ short_desc="GIMP ToolKit (v4)"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="LGPL-2.1-or-later"
 homepage="https://www.gtk.org/"
-changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/gtk-4-6/NEWS"
+#changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/gtk-4-8/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/gtk/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/gtk/${version%.*}/gtk-${version}.tar.xz"
-checksum=effd2e7c4b5e2a5c7fad43e0f24adea68baa4092abb0b752caff278e6bb010e8
+checksum=c8d6203437d1e359d83124dc591546d403f67e3b00544e53dd50a9baacdcbd7f
 
 # Package build options
 build_options="broadway cloudproviders colord cups gir vulkan wayland x11 tracker"
@@ -59,6 +60,13 @@ gtk4-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
+		vmove usr/bin/gtk4-builder-tool
+		vmove usr/share/man/man1/gtk4-builder-tool.1
+		vmove usr/bin/gtk4-encode-symbolic-svg
+		vmove usr/share/man/man1/gtk4-encode-symbolic-svg.1
+		vmove usr/bin/gtk4-query-settings
+		vmove usr/share/man/man1/gtk4-query-settings.1
+		vmove usr/share/gtk-4.0/valgrind
 		vmove usr/include
 		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.so"
@@ -71,29 +79,44 @@ gtk4-devel_package() {
 gtk4-demo_package() {
 	short_desc+=" - demonstration application"
 	pkg_install() {
-		vmove usr/bin/gtk4-demo
-		vmove usr/bin/gtk4-widget-factory
-		vmove usr/bin/gtk4-demo-application
-		vmove usr/share/gtk-4.0/gtk4builder.rng
-		vmove usr/share/glib-2.0/schemas/org.gtk.Demo4.gschema.xml
-
 		# gtk3-icon-browser is in main package,
 		# keep gtk4-icon-browser in main package too
-		vmove usr/share/man/man1/gtk4-demo-application.1
 
+		vmove usr/bin/gtk4-demo
 		vmove usr/share/applications/org.gtk.Demo4.desktop
+		vmove usr/share/glib-2.0/schemas/org.gtk.Demo4.gschema.xml
 		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.Demo4.svg
 		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.Demo4-symbolic.svg
 		vmove usr/share/man/man1/gtk4-demo.1
+		vmove usr/share/metainfo/org.gtk.Demo4.appdata.xml
 
+		vmove usr/share/gtk-4.0/gtk4builder.rng
+
+		vmove usr/bin/gtk4-demo-application
+		vmove usr/share/man/man1/gtk4-demo-application.1
+
+		vmove usr/bin/gtk4-widget-factory
+		vmove usr/share/man/man1/gtk4-widget-factory.1
+		vmove usr/share/applications/org.gtk.WidgetFactory4.desktop
+		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
+		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.WidgetFactory4-symbolic.svg
+		vmove usr/share/metainfo/org.gtk.WidgetFactory4.appdata.xml
+
+		vmove usr/bin/gtk4-print-editor
 		vmove usr/share/applications/org.gtk.PrintEditor4.desktop
 		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.PrintEditor4.svg
 		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.PrintEditor4-symbolic.svg
 		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.PrintEditor4.Devel.svg
-		vmove usr/share/applications/org.gtk.WidgetFactory4.desktop
-		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.WidgetFactory4.svg
-		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.WidgetFactory4-symbolic.svg
-		vmove usr/share/man/man1/gtk4-widget-factory.1
+		vmove usr/share/metainfo/org.gtk.PrintEditor4.appdata.xml
+
+		vmove usr/bin/gtk4-node-editor
+		vmove usr/share/applications/org.gtk.gtk4.NodeEditor.desktop
+		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.gtk4.NodeEditor.Devel.svg
+		vmove usr/share/icons/hicolor/scalable/apps/org.gtk.gtk4.NodeEditor.svg
+		vmove usr/share/icons/hicolor/symbolic/apps/org.gtk.gtk4.NodeEditor-symbolic.svg
+		vmove usr/share/man/man1/gtk4-node-editor.1
+		vmove usr/share/metainfo/org.gtk.gtk4.NodeEditor.appdata.xml
+
 	}
 }
 


### PR DESCRIPTION
* move more example applications to -demo
* move build tools to -devel

now the gtk4 package is 19MB when installed instead of 42MB

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
