### PR TITLE
efibootmgr: add LOADER_PATH to the kernel hook

### DIFF
--- a/srcpkgs/efibootmgr/files/efibootmgr-kernel-hook.confd
+++ b/srcpkgs/efibootmgr/files/efibootmgr-kernel-hook.confd
@@ -2,6 +2,8 @@
 MODIFY_EFI_ENTRIES=0
 # To allow efibootmgr to modify boot entries, set
 # MODIFY_EFI_ENTRIES=1
+# To choose an alternative loader path, set
+# LOADER_PATH=/efi/EFI/void/linux-${VERSION}.efi
 # Kernel command-line options.  Example:
 # OPTIONS="root=/dev/sda3 loglevel=4"
 # Disk where EFI Partition is.  Default is /dev/sda

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -42,4 +42,6 @@ fi
 efibootmgr -qc $args -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"
 
 # restore the boot order
-efibootmgr -qo $bootorder
+if [ -n "$bootorder" ]; then
+    efibootmgr -qo $bootorder
+fi

--- a/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
+++ b/srcpkgs/efibootmgr/files/kernel.d/efibootmgr.post-install
@@ -12,8 +12,6 @@ if [ "x${MODIFY_EFI_ENTRIES}" != x1 ]; then
 	exit 0
 fi
 
-OPTIONS="${OPTIONS} initrd=/initramfs-${VERSION}.img"
-
 args=""
 if [ "x${DISK}" != x ]; then
 	args="-d $DISK"
@@ -39,7 +37,12 @@ if [ "$existing_entry" != "" ]; then
 fi
 
 # create the new entry
-efibootmgr -qc $args -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"
+if [ -z "${LOADER_PATH}" ]; then
+    OPTIONS="${OPTIONS} initrd=/initramfs-${VERSION}.img"
+    efibootmgr -qc $args -L "Void Linux with kernel ${major_version}" -l /vmlinuz-${VERSION} -u "${OPTIONS}"
+else
+    efibootmgr -qc $args -L "Void Linux with kernel ${major_version}" -l "${LOADER_PATH}"
+fi
 
 # restore the boot order
 if [ -n "$bootorder" ]; then

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=18
-revision=1
+revision=2
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel popt-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"

--- a/srcpkgs/efibootmgr/template
+++ b/srcpkgs/efibootmgr/template
@@ -1,7 +1,7 @@
 # Template file for 'efibootmgr'
 pkgname=efibootmgr
 version=18
-revision=2
+revision=3
 hostmakedepends="pkg-config"
 makedepends="libefivar-devel popt-devel"
 short_desc="Tool to modify UEFI Firmware Boot Manager Variables"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

# Description

## efibootmgr: fix when no bootorder is configured

When no bootorder is configured, the script fail because `$bootorder` is empty.

## efibootmgr: add LOADER_PATH to the kernel hook

I use the dracut-uefi hook. It creates an EFI binary to a custom location. Because voidlinux keep olds kernels, I need to update with `efibootmgr` every time. This commit provides a new variable to configure the location of the loader.

PS: In theory, it is the last step for a secure boot ready voidlinux.
