### PR TITLE
polari: fix dependencies

### DIFF
--- a/srcpkgs/polari/template
+++ b/srcpkgs/polari/template
@@ -1,13 +1,13 @@
 # Template file for 'polari'
 pkgname=polari
 version=41.0
-revision=1
+revision=2
 build_style=meson
-hostmakedepends="pkg-config itstool gobject-introspection gettext glib-devel"
-makedepends="gjs-devel gspell-devel gtk+3-devel libsecret-devel
- libsoup-gnome-devel telepathy-glib-devel telepathy-logger-devel"
-depends="gspell telepathy-idle telepathy-logger telepathy-mission-control"
-checkdepends="appstream-glib desktop-file-utils mozjs78"
+build_helper="gir"
+hostmakedepends="pkg-config itstool gettext glib-devel"
+makedepends="gjs-devel telepathy-logger-devel telepathy-glib-devel"
+depends="telepathy-logger telepathy-glib libsecret gtk4"
+checkdepends="appstream-glib desktop-file-utils"
 short_desc="GNOME IRC client"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
@@ -15,7 +15,3 @@ homepage="https://wiki.gnome.org/Apps/Polari"
 changelog="https://gitlab.gnome.org/GNOME/polari/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=a3b05f81660370c67c942b6f44b298c7b78816feb38c926ec2212bde22ea40eb
-
-if [ "$CROSS_BUILD" ] ; then
-	hostmakedepends+=" glib-devel prelink-cross qemu-user-static"
-fi


### PR DESCRIPTION
* remove mozjs78 from checkdepends - polari only needs mozjs because of gjs
  and gjs already depends on mozjs (currently v91)
* add missing, drop unused dependencies
* use the gir build helper

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
