### PR TITLE
vim: build with +sodium feature

### DIFF
--- a/srcpkgs/vim/template
+++ b/srcpkgs/vim/template
@@ -1,9 +1,9 @@
 # Template file for 'vim'
 pkgname=vim
 version=9.0.0335
-revision=1
+revision=2
 hostmakedepends="gettext glib-devel pkg-config"
-makedepends="acl-devel ncurses-devel
+makedepends="acl-devel libsodium-devel ncurses-devel
  $(vopt_if x11 libXt-devel)
  $(vopt_if gtk3 gtk+3-devel)
  $(vopt_if huge 'lua53-devel perl python3-devel ruby-devel')"
@@ -40,8 +40,8 @@ pre_configure() {
 }
 
 do_configure() {
-	args="--enable-cscope --enable-multibyte --with-tlib=ncursesw
-		--with-ex-name=vim-ex --with-view-name=vim-view"
+	args="--enable-cscope --enable-libsodium --enable-multibyte
+		--with-tlib=ncursesw --with-ex-name=vim-ex --with-view-name=vim-view"
 
 	nohuge_args="--disable-perlinterp --disable-pythoninterp
 		--disable-rubyinterp --disable-netbeans --disable-gpm"


### PR DESCRIPTION
    xchacha20  XChaCha20 Cipher with Poly1305 Message Authentication
     Code.  Medium strong till strong encryption.
     Encryption is provided by the libsodium library, it
     requires Vim to be built with |+sodium|.
     It adds a seed and a message authentication code (MAC)
     to the file.  This needs at least a Vim 8.2.3022 to
     read the encrypted file.
     Encryption of swap files is not supported, therefore
     no swap file will be used when xchacha20 encryption is
     enabled.
     Encryption of undo files is not yet supported,
     therefore no undo file will currently be written.
     CURRENTLY EXPERIMENTAL: Files written with this method
     might have to be read back with the same version of
     Vim if the binary format changes later.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
