### PR TITLE
mozjs91: fix update-check

### DIFF
--- a/srcpkgs/mozjs91/update
+++ b/srcpkgs/mozjs91/update
@@ -1,0 +1,2 @@
+site="${MOZILLA_SITE}/firefox/releases/"
+pattern="releases/\K${version%%.*}.*(?=esr/\")"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
This doesn't update the package from `91.7.1` to `91.13.0` but at least we know updates **are available** :)

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
