### PR TITLE
nerd-fonts: update to 2.2.2

### DIFF
--- a/srcpkgs/nerd-fonts/template
+++ b/srcpkgs/nerd-fonts/template
@@ -1,14 +1,14 @@
 # Template file for 'nerd-fonts'
 pkgname=nerd-fonts
-version=2.2.1
+version=2.2.2
 revision=1
-depends="font-util xbps-triggers nerd-fonts-ttf nerd-fonts-otf"
+depends="nerd-fonts-ttf nerd-fonts-otf"
 short_desc="Iconic font aggregator, collection and patcher"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="MIT"
 homepage="https://nerdfonts.com"
 distfiles="https://github.com/ryanoasis/nerd-fonts/archive/v${version}.tar.gz"
-checksum=05e733b4ac0a6fed997ca3a697c6881d4327991fa57f4376ae17d725413b89f7
+checksum=f008adbaa575a9ec55947f3a370c9610f281b91ff0b559b173b2702682d9dce8
 
 do_install() {
 	vmkdir usr/share/fonts/NerdFonts/otf
@@ -33,7 +33,7 @@ do_install() {
 nerd-fonts-otf_package() {
 	short_desc="Iconic font aggregator, collection and patcher - otf fonts"
 	font_dirs="usr/share/fonts/NerdFonts/otf"
-	depends="font-util xbps-triggers"
+	depends="font-util"
 	pkg_install() {
 		vmove usr/share/fonts/NerdFonts/otf
 	}
@@ -42,7 +42,7 @@ nerd-fonts-otf_package() {
 nerd-fonts-ttf_package() {
 	short_desc="Iconic font aggregator, collection and patcher - ttf fonts"
 	font_dirs="usr/share/fonts/NerdFonts/ttf"
-	depends="font-util xbps-triggers"
+	depends="font-util"
 	pkg_install() {
 		vmove usr/share/fonts/NerdFonts/ttf
 	}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Explanation: As before, I haven't tested all the fonts, just a cross section of them.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
