### PR TITLE
New packages: libdecsync-2.2.1, python3-libdecsync-2.2.1, python3-radicale_storage_decsync-2.1.0

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4197,3 +4197,4 @@ libabsl_strings.so.2206.0.0 abseil-cpp-20220623.1_1
 libabsl_throw_delegate.so.2206.0.0 abseil-cpp-20220623.1_1
 libabsl_time_zone.so.2206.0.0 abseil-cpp-20220623.1_1
 libabsl_spinlock_wait.so.2206.0.0 abseil-cpp-20220623.1_1
+libdecsync.so.0 libdecsync-2.2.1_1

--- a/srcpkgs/libdecsync-devel
+++ b/srcpkgs/libdecsync-devel
@@ -1,0 +1,1 @@
+libdecsync

--- a/srcpkgs/libdecsync/template
+++ b/srcpkgs/libdecsync/template
@@ -1,0 +1,35 @@
+# Template file for 'libdecsync'
+pkgname=libdecsync
+version=2.2.1
+revision=1
+archs="x86_64"
+build_style=gnu-makefile
+hostmakedepends="gradle openjdk8 patchelf pkg-config tar"
+makedepends="ncurses-devel"
+short_desc="Multiplatform library for synchronizing using DecSync"
+maintainer="08a <dev@08a.re>"
+license="LGPL-2.0-only"
+homepage="https://github.com/39aldo39/libdecsync"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=3e08b35efed3bafb079aa52a8dcd51217f6602cde64accba1a10cf5c25029d45
+subpackages="libdecsync-devel"
+disable_parallel_build=yes
+
+export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+
+pre_install() {
+	patchelf --set-soname libdecsync.so.0 build/bin/linuxX64/releaseShared/libdecsync.so
+}
+
+post_install() {
+	ln -rsf "${DESTDIR}/usr/lib/libdecsync.so" "${DESTDIR}/usr/lib/libdecsync.so.0"
+}
+
+libdecsync-devel_package() {
+	depends="${sourcepkg}-${version}_${revision}"
+	short_desc+=" - development files"
+		pkg_install() {
+			vmove usr/include
+			vmove usr/share/pkgconfig
+		}
+}

--- a/srcpkgs/python3-libdecsync/patches/0001-hardcode-libpath-for-voidlinux.patch
+++ b/srcpkgs/python3-libdecsync/patches/0001-hardcode-libpath-for-voidlinux.patch
@@ -1,0 +1,64 @@
+From 5a2024669f4cc03e79c2a5ae856edd635bd87b9e Mon Sep 17 00:00:00 2001
+From: Alexis Ehret <git@08a.re>
+Date: Tue, 13 Sep 2022 18:04:32 +0200
+Subject: [PATCH 1/1] hardcode libpath for voidlinux
+
+Signed-off-by: Alexis Ehret <git@08a.re>
+---
+ libdecsync/__init__.py | 27 +--------------------------
+ setup.py               |  1 -
+ 2 files changed, 1 insertion(+), 27 deletions(-)
+
+diff --git a/libdecsync/__init__.py b/libdecsync/__init__.py
+index fa2d14d..484c6dc 100644
+--- a/libdecsync/__init__.py
++++ b/libdecsync/__init__.py
+@@ -29,32 +29,7 @@ import sys
+ class DecsyncException(Exception):
+     pass
+ 
+-os_name = platform.system()
+-machine_type = platform.machine()
+-platform_bits = platform.architecture()[0]
+-if os_name == "Linux":
+-    if machine_type == "x86_64":
+-        libpath = resource_filename(__name__, "libs/libdecsync_amd64.so")
+-    elif machine_type.startswith("arm") or machine_type.startswith("aarch"):
+-        if platform_bits == "64bit":
+-            libpath = resource_filename(__name__, "libs/libdecsync_arm64.so")
+-        else:
+-            libpath = resource_filename(__name__, "libs/libdecsync_arm32.so")
+-    else:
+-        raise Exception("libdecsync: Machine type '" + machine_type + "' not supported")
+-elif os_name == "Windows":
+-    if platform_bits == "64bit":
+-        libpath = resource_filename(__name__, "libs/decsync_x64.dll")
+-    else:
+-        libpath = resource_filename(__name__, "libs/decsync_x86.dll")
+-elif os_name == "Darwin":
+-    if machine_type == "x86_64":
+-        libpath = resource_filename(__name__, "libs/libdecsync_amd64.dylib")
+-    else:
+-        libpath = resource_filename(__name__, "libs/libdecsync_arm64.dylib")
+-else:
+-    raise Exception("libdecsync: Operating system '" + os_name + "' not supported")
+-
++libpath = "/usr/lib/libdecsync.so.0"
+ _libdecsync = CDLL(libpath)
+ 
+ def _errcheckDecsync(result, func, args):
+diff --git a/setup.py b/setup.py
+index a79755a..6853f70 100644
+--- a/setup.py
++++ b/setup.py
+@@ -14,7 +14,6 @@ setup(
+     keywords=["decsync"],
+     license="LGPLv2+",
+     packages=["libdecsync"],
+-    package_data={"libdecsync":["libs/*"]},
+     classifiers=[
+         "Programming Language :: Python :: 3",
+         "Operating System :: POSIX :: Linux",
+-- 
+2.37.3
+

--- a/srcpkgs/python3-libdecsync/template
+++ b/srcpkgs/python3-libdecsync/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-libdecsync'
+pkgname=python3-libdecsync
+version=2.2.1
+revision=1
+archs="x86_64"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3 libdecsync-${version}_${revision}"
+checkdepends="${depends}"
+short_desc="Python3 wrapper around libdecsync for synchronizing using DecSync"
+maintainer="Alexis Ehret <dev@08a.re>"
+license="LGPL-2.0-only"
+homepage="https://github.com/39aldo39/libdecsync-bindings-python3"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=68e0452c128306981dc8e7aa58248cc57855a2de241326b37fbeb5469446d10e

--- a/srcpkgs/python3-radicale_storage_decsync/template
+++ b/srcpkgs/python3-radicale_storage_decsync/template
@@ -1,0 +1,15 @@
+# Template file for 'python3-radicale_storage_decsync'
+pkgname=python3-radicale_storage_decsync
+version=2.1.0
+revision=1
+archs="x86_64"
+build_style=python3-module
+hostmakedepends="python3-setuptools python3-pip"
+depends="radicale>=3 python3-libdecsync>=2.0.0"
+short_desc="Radicale DecSync is an Radicale storage plugin using DecSync"
+maintainer="Alexis Ehret <git@08a.re>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/39aldo39/Radicale-DecSync"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=c5879a447b2d9b73cb12c941504d796bf86a8fd19683df695331f8f5e59188c9
+make_check=no # Empty check


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Questions

I put my email in the maintainer field. I don't know if it is the expected behavior.

#### Test libdecsync
main.c:
````c
#include <libdecsync.h>
#include <stddef.h>


int main() {
	Decsync tmp = NULL;
	return 0;
}
````

````sh
$ gcc main.c $(pkg-config --libs decsync)
$ ldd a.out
        linux-vdso.so.1 (0x00007ffca77d6000)
        libdecsync.so.0 => /usr/lib64/libdecsync.so.0 (0x00007f24572b8000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007f24570f2000)
        libresolv.so.2 => /usr/lib/libresolv.so.2 (0x00007f24570d8000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007f2456f93000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007f2456f72000)
        libutil.so.1 => /usr/lib/libutil.so.1 (0x00007f2456f6d000)
        libcrypt.so.1 => /usr/lib/libcrypt.so.1 (0x00007f2456f31000)
        librt.so.1 => /usr/lib/librt.so.1 (0x00007f2456f26000)
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007f2456f20000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007f2456f06000)
        /lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2 (0x00007f24575f6000)


````

#### Test python3-libdecsync

````sh
$ ./xbps-src -Q pkg python3-libdecsync
````

#### Test all packages

````sh
$ xi python3-radicale_storage_decsync
$ htpasswd -B -c /tmp/radicale-test-passwd void-user # enter a paswd
````

/tmp/radicale.conf:
````
[storage]
type = radicale_storage_decsync
filesystem_folder = /tmp/radicale-collections
decsync_dir = /tmp/decsync

[auth]
type = htpasswd
htpasswd_filename = /tmp/radicale-test-passwd
htpasswd_encryption = bcrypt
````

````sh
$ radicale --config ~/.config/radicale/config
````

Connect to localhost:5232 with your browser (user: void-user, passwd: what you typed)

tested:
* create collection
* delete collection
* create contact
* delete contact

#### PS
This PR is heavily inspired by https://github.com/void-linux/void-packages/pull/34731.

All of the credit should go to @eoli3n.
All of the blame should go to me.


