### PR TITLE
New package: python3-libdecsync

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4161,3 +4161,4 @@ libsyncthingconnector.so.1.2.3 syncthingtray-1.2.3_1
 libglibutil.so.1 libglibutil-1.0.64_1
 libgbinder.so.1 libgbinder-1.1.20_1
 libsunpinyin.so.3 libsunpinyin-3.0.0rc2_1
+libdecsync.so.0 libdecsync-2.2.1_1

--- a/srcpkgs/libdecsync-devel
+++ b/srcpkgs/libdecsync-devel
@@ -1,0 +1,1 @@
+libdecsync

--- a/srcpkgs/libdecsync/template
+++ b/srcpkgs/libdecsync/template
@@ -1,0 +1,33 @@
+# Template file for 'libdecsync'
+pkgname=libdecsync
+version=2.2.1
+revision=1
+archs="x86_64"
+build_style=gnu-makefile
+hostmakedepends="gradle openjdk8 patchelf pkg-config tar"
+makedepends="ncurses-devel"
+short_desc="Multiplatform library for synchronizing using DecSync"
+maintainer="08a <dev@08a.re>"
+license="LGPL-2.0-or-later"
+homepage="https://github.com/39aldo39/libdecsync"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=3e08b35efed3bafb079aa52a8dcd51217f6602cde64accba1a10cf5c25029d45
+disable_parallel_build=yes
+
+export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk
+
+pre_install() {
+	patchelf --set-soname libdecsync.so.0 build/bin/linuxX64/releaseShared/libdecsync.so
+}
+
+post_install() {
+	ln -rsf "${DESTDIR}/usr/lib/libdecsync.so" "${DESTDIR}/usr/lib/libdecsync.so.0"
+}
+
+libdecsync-devel_package() {
+	short_desc+=" - development files"
+		pkg_install() {
+			vmove usr/include
+			vmove usr/share/pkgconfig
+		}
+}

--- a/srcpkgs/python3-libdecsync/patches/0001-hardcode-libpath-for-voidlinux.patch
+++ b/srcpkgs/python3-libdecsync/patches/0001-hardcode-libpath-for-voidlinux.patch
@@ -1,0 +1,64 @@
+From 5a2024669f4cc03e79c2a5ae856edd635bd87b9e Mon Sep 17 00:00:00 2001
+From: Alexis Ehret <git@08a.re>
+Date: Tue, 13 Sep 2022 18:04:32 +0200
+Subject: [PATCH 1/1] hardcode libpath for voidlinux
+
+Signed-off-by: Alexis Ehret <git@08a.re>
+---
+ libdecsync/__init__.py | 27 +--------------------------
+ setup.py               |  1 -
+ 2 files changed, 1 insertion(+), 27 deletions(-)
+
+diff --git a/libdecsync/__init__.py b/libdecsync/__init__.py
+index fa2d14d..484c6dc 100644
+--- a/libdecsync/__init__.py
++++ b/libdecsync/__init__.py
+@@ -29,32 +29,7 @@ import sys
+ class DecsyncException(Exception):
+     pass
+ 
+-os_name = platform.system()
+-machine_type = platform.machine()
+-platform_bits = platform.architecture()[0]
+-if os_name == "Linux":
+-    if machine_type == "x86_64":
+-        libpath = resource_filename(__name__, "libs/libdecsync_amd64.so")
+-    elif machine_type.startswith("arm") or machine_type.startswith("aarch"):
+-        if platform_bits == "64bit":
+-            libpath = resource_filename(__name__, "libs/libdecsync_arm64.so")
+-        else:
+-            libpath = resource_filename(__name__, "libs/libdecsync_arm32.so")
+-    else:
+-        raise Exception("libdecsync: Machine type '" + machine_type + "' not supported")
+-elif os_name == "Windows":
+-    if platform_bits == "64bit":
+-        libpath = resource_filename(__name__, "libs/decsync_x64.dll")
+-    else:
+-        libpath = resource_filename(__name__, "libs/decsync_x86.dll")
+-elif os_name == "Darwin":
+-    if machine_type == "x86_64":
+-        libpath = resource_filename(__name__, "libs/libdecsync_amd64.dylib")
+-    else:
+-        libpath = resource_filename(__name__, "libs/libdecsync_arm64.dylib")
+-else:
+-    raise Exception("libdecsync: Operating system '" + os_name + "' not supported")
+-
++libpath = "/usr/lib/libdecsync.so.0"
+ _libdecsync = CDLL(libpath)
+ 
+ def _errcheckDecsync(result, func, args):
+diff --git a/setup.py b/setup.py
+index a79755a..6853f70 100644
+--- a/setup.py
++++ b/setup.py
+@@ -14,7 +14,6 @@ setup(
+     keywords=["decsync"],
+     license="LGPLv2+",
+     packages=["libdecsync"],
+-    package_data={"libdecsync":["libs/*"]},
+     classifiers=[
+         "Programming Language :: Python :: 3",
+         "Operating System :: POSIX :: Linux",
+-- 
+2.37.3
+

--- a/srcpkgs/python3-libdecsync/template
+++ b/srcpkgs/python3-libdecsync/template
@@ -1,0 +1,16 @@
+# Template file for 'python3-libdecsync'
+pkgname=python3-libdecsync
+version=2.2.1
+revision=1
+archs="x86_64"
+wrksrc="libdecsync-bindings-python3-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools"
+depends="python3 libdecsync-${version}_${revision}"
+checkdepends="${depends}"
+short_desc="Python3 wrapper around libdecsync for synchronizing using DecSync"
+maintainer="Alexis Ehret <dev@08a.re>"
+license="LGPL-2.0-or-later"
+homepage="https://github.com/39aldo39/libdecsync-bindings-python3"
+distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
+checksum=68e0452c128306981dc8e7aa58248cc57855a2de241326b37fbeb5469446d10e


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

# IMPORTANT: https://github.com/void-linux/void-packages/pull/39258 should be merged first. 



#### Testing the changes
- I tested the changes in this PR: **briefly** (`./xbps-src -Q pkg python3-libdecsync`)

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Notes

* The patch forces the python library to use the installed `.so*`.
