### PR TITLE
base-files: don't overwrite existing locale and define default LANG

### DIFF
--- a/srcpkgs/base-files/files/locale.sh
+++ b/srcpkgs/base-files/files/locale.sh
@@ -1,9 +1,16 @@
 # Sets up locale system settings from /etc/locale.conf.
 #
-if [ -s /etc/locale.conf ]; then
-	. /etc/locale.conf
+
+# Don't load locale.conf if locale is already set up
+if [ -z "$LANG" ]; then
+	if [ -s /etc/locale.conf ]; then
+		. /etc/locale.conf
+	fi
 fi
+
+# define default LANG to C.UTF-8 if not already set
+LANG="${LANG:-C.UTF-8}"
 
 export LANG LANGUAGE LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY
 export LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
-export LC_INDENTIFICATION
+export LC_IDENTIFICATION

--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,6 +1,6 @@
 # Template file for 'base-files'
 pkgname=base-files
-version=0.144
+version=0.145
 revision=1
 bootstrap=yes
 depends="xbps-triggers"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Fixes overwriting user/desktop specified locale.

Currently we always overwrite LANG on login, even if it was already set by the desktop or user which causes issues with GDM.

You can see what Arch does here:
https://bugs.archlinux.org/task/42162
https://gitlab.archlinux.org/archlinux/packaging/packages/filesystem/-/blob/main/locale.sh

You can see what Fedora does here:
https://gist.github.com/oreo639/3b83b852ce0db21e21eed102a57c5148
(taken from the setup package)

https://github.com/void-linux/void-packages/issues/15292

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
