### PR TITLE
flatpak: fix setting environment variables on gdm

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -1,7 +1,7 @@
 # Template file for 'flatpak'
 pkgname=flatpak
 version=1.14.0
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="
@@ -9,6 +9,7 @@ configure_args="
  --with-system-dbus-proxy
  --with-system-helper-user=_flatpak
  --enable-selinux-module=no
+ --enable-gdm-env-file
  $(vopt_enable gir introspection)"
 hostmakedepends="bubblewrap gettext glib-devel libxslt pkg-config bison
  python3-parsing xmlto docbook-xml docbook-xsl xdg-dbus-proxy"

--- a/srcpkgs/gdm/template
+++ b/srcpkgs/gdm/template
@@ -1,7 +1,7 @@
 # Template file for 'gdm'
 pkgname=gdm
 version=42.0
-revision=1
+revision=2
 build_helper="gir"
 build_style=meson
 configure_args="
@@ -10,7 +10,8 @@ configure_args="
  -Dplymouth=enabled -Dxauth-dir=/run/gdm -Dpid-file=/run/gdm/gdm.pid
  -Dsystemd-journal=false -Dinitial-vt=7 -Dwayland-support=true
  -Dselinux=disabled -Dlibaudit=disabled
- -Dsystemdsystemunitdir=/tmp -Dsystemduserunitdir=/tmp"
+ -Dsystemdsystemunitdir=/usr/lib/systemd/system
+ -Dsystemduserunitdir=/usr/lib/systemd/user"
 hostmakedepends="dconf gettext itstool pkg-config"
 makedepends="accountsservice-devel elogind-devel gettext-devel glib-devel
  iso-codes libSM-devel libcanberra-devel nss-devel pam-devel upower-devel
@@ -32,6 +33,9 @@ conf_files="
 	/etc/pam.d/gdm-launch-environment
 	/etc/pam.d/gdm-password
 	/etc/pam.d/gdm-smartcard"
+make_dirs="
+	/usr/share/gdm/env.d 0755 root root
+	/etc/gdm/env.d 0755 root root"
 # Create the 'gdm' system user/group.
 system_accounts="gdm"
 gdm_homedir="/var/lib/gdm"
@@ -52,7 +56,6 @@ post_install() {
 			vsed -i "s/pam_systemd\.so/pam_elogind.so/" "$f"
 		fi
 	done
-	rm -rf ${DESTDIR}/tmp
 
 	# runit service
 	vsv gdm


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This doesn't affect `GDM -> gnome` due to: https://github.com/void-linux/void-packages/pull/9126
However it does affect `GDM -> <anything other than gnome>`

See: https://wiki.gnome.org/Initiatives/Wayland/SessionStart

(`/etc/profile` never gets loaded in GDM)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
