### PR TITLE
[RFC] add vdevel helper

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -330,6 +330,23 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	it will default to `pkgname`. The `shell` argument can be one of `bash`,
 	`fish` or `zsh`.
 
+- *vdevel()*
+
+	Installs common development files in the pkg `$DESTDIR`. Prints a warning if files
+	aren't found. Equivalent to:
+```sh
+vmove "usr/lib/*.so"  # unversioned shlibs
+vmove "usr/lib/*.a"  # library archives
+vmove "usr/share/gir-*"  # Gobject introspection XML files
+vmove usr/include  # header files
+vmove usr/lib/cmake  # cmake rules
+vmove usr/share/cmake  # cmake rules
+vmove usr/lib/pkgconfig  # pkgconfig files
+vmove usr/share/pkgconfig  # pkgconfig files
+vmove usr/share/aclocal  # Autoconf macros
+vmove usr/share/vala  # Vala bindings
+```
+
 > Shell wildcards must be properly quoted, Example: `vmove "usr/lib/*.a"`.
 
 <a id="global_vars"></a>
@@ -1438,10 +1455,8 @@ foo-devel_package() {
 	short_desc+=" - development files"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
-		vmove usr/include
-		vmove "usr/lib/*.a"
-		vmove "usr/lib/*.so"
-		vmove usr/lib/pkgconfig
+		vdevel
+		vmove usr/share/gtk-doc
 	}
 }
 ```
@@ -1499,6 +1514,8 @@ following subset of files from the main package:
 * Autoconf macros `usr/share/aclocal`
 * Gobject introspection XML files `usr/share/gir-1.0`
 * Vala bindings `usr/share/vala`
+
+> These common files can be automatically moved to the `-devel` subpackage using `vdevel`
 
 <a id="pkgs_data"></a>
 ### Data packages

--- a/srcpkgs/LimeSuite/template
+++ b/srcpkgs/LimeSuite/template
@@ -64,10 +64,7 @@ LimeSuite-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/cmake
-		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.so"
+		vdevel
 	}
 }
 

--- a/srcpkgs/farstream/template
+++ b/srcpkgs/farstream/template
@@ -32,12 +32,7 @@ farstream-devel_package() {
 	depends="gst-plugins-base1-devel farstream-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove usr/lib/*.so
+		vdevel
 		vmove usr/share/gtk-doc
-		if [ "$build_option_gir" ]; then
-			vmove usr/share/gir-1.0
-		fi
 	}
 }

--- a/srcpkgs/hamlib/template
+++ b/srcpkgs/hamlib/template
@@ -27,9 +27,6 @@ hamlib-devel_package() {
 	short_desc+=" - development files"
 	depends="${sourcepkg}>=${version}_${revision}"
 	pkg_install() {
-		vmove usr/include
-		vmove "usr/lib/*.so"
-		vmove usr/lib/pkgconfig
-		vmove usr/share/aclocal
+		vdevel
 	}
 }

--- a/srcpkgs/libjaylink/template
+++ b/srcpkgs/libjaylink/template
@@ -21,9 +21,6 @@ libjaylink-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.a"
-		vmove "usr/lib/*.so"
+		vdevel
 	}
 }

--- a/srcpkgs/qtforkawesome/template
+++ b/srcpkgs/qtforkawesome/template
@@ -31,9 +31,7 @@ qtforkawesome-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
+		vdevel
 		vmove usr/share
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.so"
 	}
 }

--- a/srcpkgs/syncthingtray/template
+++ b/srcpkgs/syncthingtray/template
@@ -37,9 +37,7 @@ syncthingtray-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
-		vmove "usr/lib/*.so"
+		vdevel
 		for d in connector fileitemaction model plasmoid widgets; do
 			vmove "usr/share/syncthing${d}/cmake"
 		done


### PR DESCRIPTION
This adds a helper for the install phase, `vdevel`, which moves commonly-moved patterns/directories to the subpkg in which it's called using `vmove`.

Based on these Highly Scientific™ stats and the existing list in Manual.md, I came up with a list of patterns and directories to move.

<details><summary>The Numbers</summary>

```
  count  command
   1859  vmove usr/include
   1664  vmove usr/lib/*.so
   1414  vmove usr/lib/pkgconfig
    750  vmove usr/lib/*.a
    331  vmove usr/lib/cmake
    182  vmove usr/share/gir-1.0
    154  vmove usr/share/man/man3
    112  vmove usr/lib/qt5/mkspecs
    101  vmove usr/share/gtk-doc
     94  vmove usr/share/vala
     64  vmove usr/share/aclocal
     17  vmove usr/share/info
     15  vmove usr/share/man
     14  vmove usr/lib/*.la
     12  vmove usr/share/cmake
     10  vmove usr/share/pkgconfig
```

</details>

**(Should `usr/share/gtk-doc` and/or `usr/share/man/man3` be added to the `vdevel` list?)**

If a pattern or directory is not matched, only a warning is printed, describing what wasn't found.

This should be compatible with many `-devel` packages, but not all, and that is okay. Also, if additional files need to be moved, they can be `vmove`d manually.

Some examples of `vdevel` in action are included.

Prior art: #21721

#### Testing the changes
- I tested the changes in this PR: **YES**
