### PR TITLE
id3lib: patch for c99 bool

### DIFF
--- a/srcpkgs/id3lib/patches/fix-abi.patch
+++ b/srcpkgs/id3lib/patches/fix-abi.patch
@@ -1,0 +1,172 @@
+--- a/include/id3.h
++++ b/include/id3.h
+@@ -47,12 +47,12 @@ extern "C"
+   ID3_C_EXPORT ID3Tag*              CCONV ID3Tag_New                  (void);
+   ID3_C_EXPORT void                 CCONV ID3Tag_Delete               (ID3Tag *tag);
+   ID3_C_EXPORT void                 CCONV ID3Tag_Clear                (ID3Tag *tag);
+-  ID3_C_EXPORT bool                 CCONV ID3Tag_HasChanged           (const ID3Tag *tag);
+-  ID3_C_EXPORT void                 CCONV ID3Tag_SetUnsync            (ID3Tag *tag, bool unsync);
+-  ID3_C_EXPORT void                 CCONV ID3Tag_SetExtendedHeader    (ID3Tag *tag, bool ext);
+-  ID3_C_EXPORT void                 CCONV ID3Tag_SetPadding           (ID3Tag *tag, bool pad);
++  ID3_C_EXPORT ID3_Bool                 CCONV ID3Tag_HasChanged           (const ID3Tag *tag);
++  ID3_C_EXPORT void                 CCONV ID3Tag_SetUnsync            (ID3Tag *tag, ID3_Bool unsync);
++  ID3_C_EXPORT void                 CCONV ID3Tag_SetExtendedHeader    (ID3Tag *tag, ID3_Bool ext);
++  ID3_C_EXPORT void                 CCONV ID3Tag_SetPadding           (ID3Tag *tag, ID3_Bool pad);
+   ID3_C_EXPORT void                 CCONV ID3Tag_AddFrame             (ID3Tag *tag, const ID3Frame *frame);
+-  ID3_C_EXPORT bool                 CCONV ID3Tag_AttachFrame          (ID3Tag *tag, ID3Frame *frame);
++  ID3_C_EXPORT ID3_Bool                 CCONV ID3Tag_AttachFrame          (ID3Tag *tag, ID3Frame *frame);
+   ID3_C_EXPORT void                 CCONV ID3Tag_AddFrames            (ID3Tag *tag, const ID3Frame *frames, size_t num);
+   ID3_C_EXPORT ID3Frame*            CCONV ID3Tag_RemoveFrame          (ID3Tag *tag, const ID3Frame *frame);
+   ID3_C_EXPORT ID3_Err              CCONV ID3Tag_Parse                (ID3Tag *tag, const uchar header[ID3_TAGHEADERSIZE], const uchar *buffer);
+@@ -66,7 +66,7 @@ extern "C"
+   ID3_C_EXPORT ID3Frame*            CCONV ID3Tag_FindFrameWithASCII   (const ID3Tag *tag, ID3_FrameID id, ID3_FieldID fld, const char *data);
+   ID3_C_EXPORT ID3Frame*            CCONV ID3Tag_FindFrameWithUNICODE (const ID3Tag *tag, ID3_FrameID id, ID3_FieldID fld, const unicode_t *data);
+   ID3_C_EXPORT size_t               CCONV ID3Tag_NumFrames            (const ID3Tag *tag);
+-  ID3_C_EXPORT bool                 CCONV ID3Tag_HasTagType           (const ID3Tag *tag, ID3_TagType);
++  ID3_C_EXPORT ID3_Bool                 CCONV ID3Tag_HasTagType           (const ID3Tag *tag, ID3_TagType);
+   ID3_C_EXPORT ID3TagIterator*      CCONV ID3Tag_CreateIterator       (ID3Tag *tag);
+   ID3_C_EXPORT ID3TagConstIterator* CCONV ID3Tag_CreateConstIterator  (const ID3Tag *tag);
+ 
+@@ -83,8 +83,8 @@ extern "C"
+   ID3_C_EXPORT void                 CCONV ID3Frame_SetID              (ID3Frame *frame, ID3_FrameID id);
+   ID3_C_EXPORT ID3_FrameID          CCONV ID3Frame_GetID              (const ID3Frame *frame);
+   ID3_C_EXPORT ID3Field*            CCONV ID3Frame_GetField           (const ID3Frame *frame, ID3_FieldID name);
+-  ID3_C_EXPORT void                 CCONV ID3Frame_SetCompression     (ID3Frame *frame, bool comp);
+-  ID3_C_EXPORT bool                 CCONV ID3Frame_GetCompression     (const ID3Frame *frame);
++  ID3_C_EXPORT void                 CCONV ID3Frame_SetCompression     (ID3Frame *frame, ID3_Bool comp);
++  ID3_C_EXPORT ID3_Bool                 CCONV ID3Frame_GetCompression     (const ID3Frame *frame);
+ 
+   /* field wrappers */
+   ID3_C_EXPORT void                 CCONV ID3Field_Clear              (ID3Field *field);
+@@ -116,7 +116,7 @@ extern "C"
+   ID3_C_EXPORT flags_t              CCONV ID3FrameInfo_FieldFlags     (ID3_FrameID frameid, int fieldnum);
+ 
+   /* Deprecated */
+-  ID3_C_EXPORT void                 CCONV ID3Tag_SetCompression       (ID3Tag *tag, bool comp);
++  ID3_C_EXPORT void                 CCONV ID3Tag_SetCompression       (ID3Tag *tag, ID3_Bool comp);
+ 
+ #ifdef __cplusplus
+ }
+--- a/include/id3/globals.h
++++ b/include/id3/globals.h
+@@ -82,14 +82,10 @@
+ 
+ #define ID3_C_VAR extern
+ 
+-#ifndef __cplusplus
+-
+-typedef int bool;
+-#  define false (0)
+-#  define true (!false)
+-
+-#endif /* __cplusplus */
++typedef int ID3_Bool;
++#  define ID3_False 0
++#  define ID3_True  1
+ 
+ ID3_C_VAR const char * const ID3LIB_NAME;
+ ID3_C_VAR const char * const ID3LIB_RELEASE;
+ ID3_C_VAR const char * const ID3LIB_FULL_NAME;
+@@ -532,9 +530,9 @@ ID3_STRUCT(Mp3_Headerinfo)
+   uint32 framesize;
+   uint32 frames;                // nr of frames
+   uint32 time;                  // nr of seconds in song
+-  bool privatebit;
+-  bool copyrighted;
+-  bool original;
++  ID3_Bool privatebit;
++  ID3_Bool copyrighted;
++  ID3_Bool original;
+ };
+ 
+ #define ID3_NR_OF_V1_GENRES 148
+--- a/src/c_wrapper.cpp
++++ b/src/c_wrapper.cpp
+@@ -72,10 +72,10 @@ extern "C"
+   }
+ 
+ 
+-  ID3_C_EXPORT bool CCONV
++  ID3_C_EXPORT ID3_Bool CCONV
+   ID3Tag_HasChanged(const ID3Tag *tag)
+   {
+-    bool changed = false;
++    ID3_Bool changed = ID3_False;
+ 
+     if (tag)
+     {
+@@ -87,7 +87,7 @@ extern "C"
+ 
+ 
+   ID3_C_EXPORT void CCONV
+-  ID3Tag_SetUnsync(ID3Tag *tag, bool unsync)
++  ID3Tag_SetUnsync(ID3Tag *tag, ID3_Bool unsync)
+   {
+     if (tag)
+     {
+@@ -97,7 +97,7 @@ extern "C"
+ 
+ 
+   ID3_C_EXPORT void CCONV
+-  ID3Tag_SetExtendedHeader(ID3Tag *tag, bool ext)
++  ID3Tag_SetExtendedHeader(ID3Tag *tag, ID3_Bool ext)
+   {
+     if (tag)
+     {
+@@ -106,7 +106,7 @@ extern "C"
+   }
+ 
+   ID3_C_EXPORT void CCONV
+-  ID3Tag_SetPadding(ID3Tag *tag, bool pad)
++  ID3Tag_SetPadding(ID3Tag *tag, ID3_Bool pad)
+   {
+     if (tag)
+     {
+@@ -125,10 +125,10 @@ extern "C"
+   }
+ 
+ 
+-  ID3_C_EXPORT bool CCONV
++  ID3_C_EXPORT ID3_Bool CCONV
+   ID3Tag_AttachFrame(ID3Tag *tag, ID3Frame *frame)
+   {
+-    bool b = false;
++    ID3_Bool b = ID3_False;
+     if (tag)
+     {
+       ID3_CATCH(b = reinterpret_cast<ID3_Tag *>(tag)->AttachFrame(reinterpret_cast<ID3_Frame *>(frame)));
+@@ -303,10 +303,10 @@ extern "C"
+   }
+ 
+ 
+-  ID3_C_EXPORT bool CCONV
++  ID3_C_EXPORT ID3_Bool CCONV
+   ID3Tag_HasTagType(const ID3Tag *tag, ID3_TagType tt)
+   {
+-    bool has_tt = false;
++    ID3_Bool has_tt = ID3_False;
+ 
+     if (tag)
+     {
+@@ -459,7 +459,7 @@ extern "C"
+ 
+ 
+   ID3_C_EXPORT void CCONV
+-  ID3Frame_SetCompression(ID3Frame *frame, bool comp)
++  ID3Frame_SetCompression(ID3Frame *frame, ID3_Bool comp)
+   {
+     if (frame)
+     {
+@@ -468,10 +468,10 @@ extern "C"
+   }
+ 
+ 
+-  ID3_C_EXPORT bool CCONV
++  ID3_C_EXPORT ID3_Bool CCONV
+   ID3Frame_GetCompression(const ID3Frame *frame)
+   {
+-    bool compressed = false;
++    ID3_Bool compressed = ID3_False;
+     if (frame)
+     {
+       ID3_CATCH(compressed = reinterpret_cast<const ID3_Frame *>(frame)->GetCompression());

--- a/srcpkgs/id3lib/patches/test-fix.patch
+++ b/srcpkgs/id3lib/patches/test-fix.patch
@@ -1,0 +1,49 @@
+--- a/examples/findeng.cpp
++++ b/examples/findeng.cpp
+@@ -9,7 +9,7 @@
+ using std::cout;
+ using std::endl;
+ 
+-int main(unsigned argc, char* argv[])
++int main(int argc, char* argv[])
+ {
+   ID3D_INIT_DOUT();
+   ID3D_INIT_WARNING();
+--- a/examples/findstr.cpp
++++ b/examples/findstr.cpp
+@@ -9,7 +9,7 @@
+ using std::cout;
+ using std::endl;
+ 
+-int main(unsigned argc, char* argv[])
++int main(int argc, char* argv[])
+ {
+   ID3D_INIT_DOUT();
+   ID3D_INIT_WARNING();
+--- a/examples/test_io.cpp
++++ b/examples/test_io.cpp
+@@ -18,13 +18,13 @@ using std::cerr;
+ using namespace dami;
+ 
+ int
+-main(size_t argc, const char** argv)
++main(int argc, const char** argv)
+ {
+   ID3D_INIT_DOUT();
+   ID3D_INIT_WARNING();
+   ID3D_INIT_NOTICE();
+ 
+-  ID3_IStreamReader isr(cin);
++  ID3_IStreamReader isr(std::cin);
+   BString orig = io::readAllBinary(isr);
+     
+   cout << "input size:    " << orig.size() << endl;
+@@ -116,7 +116,7 @@ main(size_t argc, const char** argv)
+   cout << "binary number:";
+   for (size_t i = 0; i < number.size(); ++i)
+   {
+-    cout << " 0x" << hex << (size_t) (0xFF & number[i]) << dec;
++    cout << " 0x" << std::hex << (size_t) (0xFF & number[i]) << std::dec;
+   }
+   cout << endl;
+ 

--- a/srcpkgs/id3lib/template
+++ b/srcpkgs/id3lib/template
@@ -1,7 +1,7 @@
 # Template file for 'id3lib'
 pkgname=id3lib
 version=3.8.3
-revision=6
+revision=7
 build_style=gnu-configure
 hostmakedepends="libtool automake"
 makedepends="zlib-devel"

--- a/srcpkgs/kid3/template
+++ b/srcpkgs/kid3/template
@@ -1,7 +1,7 @@
 # Template file for 'kid3'
 pkgname=kid3
 version=3.9.1
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DWITH_APPS='CLI;$(vopt_if KDE KDE Qt)'
  -DWITH_DOCBOOKDIR=/usr/share/xsl/docbook -DWITH_FLAC=$(vopt_if flac ON OFF)


### PR DESCRIPTION
id3/globals.h has a typedef for bool which is incompatible with c99 stdbool.
This is a known issue, but upstream is effectively unmaintained.
See [this thread](https://sourceforege.net/p/id3lib/mailman/message/30500558/) from upstream.

This only seems to be an issue for castget while building, and they have already switched to using taglib for the next release.
Castget [issue](https://github.com/mlj/castget/issues/47).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
