### PR TITLE
[RFC] use alternatives to manage initramfs regeneration

### DIFF
--- a/srcpkgs/dracut/template
+++ b/srcpkgs/dracut/template
@@ -1,7 +1,7 @@
 # Template file for 'dracut'
 pkgname=dracut
 version=053
-revision=3
+revision=4
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc"
 conf_files="/etc/dracut.conf"
@@ -14,6 +14,10 @@ license="GPL-2.0-or-later, LGPL-2.0-or-later"
 homepage="http://www.kernel.org/pub/linux/utils/boot/dracut/dracut.html"
 distfiles="${KERNEL_SITE}/utils/boot/dracut/dracut-${version}.tar.xz"
 checksum=d5a1b47cdb07919d8225d5b5f538e6ae604988f3df0afbde99a8dc775277b726
+alternatives="
+ initramfs:/etc/kernel.d/post-install/20-initramfs:/usr/libexec/dracut/kernel-hook-postinst
+ initramfs:/etc/kernel.d/post-remove/20-initramfs:/usr/libexec/dracut/kernel-hook-postrm
+"
 subpackages="dracut-network"
 # Checks require distfiles come from a git repository
 make_check=no
@@ -34,8 +38,8 @@ esac
 
 post_install() {
 	# kernel hooks.
-	vinstall ${FILESDIR}/kernel-hook-postinst 755 etc/kernel.d/post-install 20-dracut
-	vinstall ${FILESDIR}/kernel-hook-postrm 755 etc/kernel.d/post-remove 20-dracut
+	vinstall ${FILESDIR}/kernel-hook-postinst 755 usr/libexec/dracut
+	vinstall ${FILESDIR}/kernel-hook-postrm 755 usr/libexec/dracut
 
 	# We don't need the systemd stuff.
 	rm -rf ${DESTDIR}/usr/lib/dracut/modules.d/*systemd*

--- a/srcpkgs/mkinitcpio/files/kernel-hook-postinst
+++ b/srcpkgs/mkinitcpio/files/kernel-hook-postinst
@@ -13,4 +13,3 @@ fi
 
 umask 0077
 usr/bin/mkinitcpio -g boot/initramfs-${VERSION}.img -k ${VERSION}
-exit $?

--- a/srcpkgs/mkinitcpio/files/kernel-hook-postrm
+++ b/srcpkgs/mkinitcpio/files/kernel-hook-postrm
@@ -8,4 +8,3 @@ PKGNAME="$1"
 VERSION="$2"
 
 rm -f boot/initramfs-${VERSION}.img
-exit $?

--- a/srcpkgs/mkinitcpio/template
+++ b/srcpkgs/mkinitcpio/template
@@ -1,7 +1,7 @@
 # Template file for 'mkinitcpio'
 pkgname=mkinitcpio
 version=31
-revision=2
+revision=3
 build_style=gnu-makefile
 hostmakedepends="asciidoc"
 depends="busybox-static bsdtar bash"
@@ -13,6 +13,10 @@ homepage="https://git.archlinux.org/mkinitcpio.git"
 distfiles="https://sources.archlinux.org/other/${pkgname}/${pkgname}-${version}.tar.gz"
 checksum=8f2811250b852ab78375bf90e1a7430daa132e57e128b0f6eaadddd9b27bbc63
 conf_files="/etc/mkinitcpio.conf"
+alternatives="
+ initramfs:/etc/kernel.d/post-install/20-initramfs:/usr/libexec/mkinitcpio/kernel-hook-postinst
+ initramfs:/etc/kernel.d/post-remove/20-initramfs:/usr/libexec/mkinitcpio/kernel-hook-postrm
+"
 replaces="mkinitcpio-udev>=0"
 
 pre_check() {
@@ -38,8 +42,8 @@ post_install() {
 
 	ln -s /usr/bin/busybox.static $DESTDIR/usr/lib/initcpio/busybox
 
-	vinstall ${FILESDIR}/kernel-hook-postinst 755 etc/kernel.d/post-install 20-mkinitcpio
-	vinstall ${FILESDIR}/kernel-hook-postrm 755 etc/kernel.d/post-remove 20-mkinitcpio
+	vinstall ${FILESDIR}/kernel-hook-postinst 755 usr/libexec/mkinitcpio
+	vinstall ${FILESDIR}/kernel-hook-postrm 755 usr/libexec/mkinitcpio
 }
 
 mkinitcpio-lvm2_package() {

--- a/srcpkgs/xbps-triggers/files/initramfs-regenerate
+++ b/srcpkgs/xbps-triggers/files/initramfs-regenerate
@@ -37,36 +37,21 @@ case "$ACTION" in
 		;;
 esac
 
-# Read the configuration, if it exists
-[ -f etc/default/initramfs-regenerate ] && . etc/default/initramfs-regenerate
+# Prefer the new alternatives-based initramfs hooks
+HOOK="etc/kernel.d/post-install/20-initramfs"
+if [ ! -x "${HOOK}" ]; then
+	# Otherwise, use legacy trigger behavior to find a preferred hook
+	[ -f etc/default/initramfs-regenerate ] && . etc/default/initramfs-regenerate
+	HOOK="etc/kernel.d/post-install/20-${INITRAMFS_GENERATOR:-dracut}"
+	[ -x "${HOOK}" ] || exit 0
+fi
 
-# dracut explicitly sets umask 0077, other generators may not
-umask 0077
+echo "Regenerating initramfs images using kernel hook ${HOOK##*/}"
 
-case "${INITRAMFS_GENERATOR:-dracut}" in
-	dracut)
-		if command -v dracut >/dev/null 2>&1; then
-			echo "Regenerating initramfs with dracut"
-			dracut -f -q --regenerate-all
-		fi
-		;;
-	mkinitcpio)
-		if command -v mkinitcpio >dev/null 2>&1; then
-			echo "Regenerating initramfs with mkinitcpio"
-			# Regenerate images for every kernel version with modules
-			for kdir in usr/lib/modules/*; do
-				[ -d "${kdir}/kernel" ] || continue
-				kver="${kdir##*/}"
-				mkinitcpio -g "boot/initramfs-${kver}.img" -k "${kver}"
-			done
-		fi
-		;;
-	none)
-		;;
-	*)
-		echo "unrecognized INITRAMFS_GENERATOR for initramfs-regenerate hook"
-		exit 1
-		;;
-esac
-
+# Regenerate images for every kernel version with modules
+for kdir in usr/lib/modules/*; do
+	[ -d "${kdir}/kernel" ] || continue
+	kver="${kdir##*/}"
+	"${HOOK}" "${PKGNAME}" "${kver}"
+done
 exit 0

--- a/srcpkgs/xbps-triggers/template
+++ b/srcpkgs/xbps-triggers/template
@@ -1,6 +1,6 @@
 # Template file for 'xbps-triggers'
 pkgname=xbps-triggers
-version=0.123
+version=0.124
 revision=1
 bootstrap=yes
 short_desc="XBPS triggers for Void Linux"


### PR DESCRIPTION
Yes, I know that XBPS alternatives have some problems, but this seems to be the most sensible approach on balance. Rather than dealing with a bunch of potentially competing initramfs hooks, we can let all packages install custom hooks in `/usr/libexec` and use the alternatives system to symlink the preferred hooks in `/etc/kernel.d`. At that point, we can use the generic alternative script in the XBPS regenerator trigger and avoid the need for a conf file, although it falls back to legacy behavior if the alternative isn't set.

Another option I considered, but decided against, was creating a centralized `initramfs-kernel-hooks` package that installs a common hook and reads the `/etc/default/initramfs-regenerate` file used in the existing XBPS trigger to determine what to execute. All initramfs generators (currently only dracut and mkinitcpio) would have to depend on the common package. This has the drawback that all of the generation knowledge must be centralized instead of located in the package that adds the functionality.

This is not really tested at this point, but I want to get some early comments.