### PR TITLE
libva{,-glx,-utils}: update to 2.16.0.

### DIFF
--- a/srcpkgs/libva-glx/template
+++ b/srcpkgs/libva-glx/template
@@ -7,7 +7,7 @@
 # KEEP THIS PACKAGE SYNCHRONIZED WITH "libva".
 #
 pkgname=libva-glx
-version=2.14.0
+version=2.16.0
 revision=1
 wrksrc="libva-${version}"
 build_style=meson
@@ -20,7 +20,7 @@ license="MIT"
 homepage="https://01.org/linuxmedia/vaapi"
 changelog="https://raw.githubusercontent.com/intel/libva/master/NEWS"
 distfiles="https://github.com/intel/libva/archive/${version}.tar.gz"
-checksum=f21152a2170edda9d1c4dd463d52eaf62b553e83e553c0a946654523cca86d5e
+checksum=766edf51fd86efe9e836a4467d4ec7c3af690a3c601b3c717237cee856302279
 
 post_install() {
 	# We are only interested in the glx component, remove everything else.

--- a/srcpkgs/libva-utils/template
+++ b/srcpkgs/libva-utils/template
@@ -1,6 +1,6 @@
 # Template file for 'libva-utils'
 pkgname=libva-utils
-version=2.14.0
+version=2.16.0
 revision=1
 build_style=meson
 configure_args="-Ddrm=true -Dx11=true -Dwayland=true"
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://01.org/linuxmedia/vaapi"
 changelog="https://raw.githubusercontent.com/intel/libva-utils/master/NEWS"
 distfiles="https://github.com/intel/libva-utils/archive/${version}.tar.gz"
-checksum=0ad6410aaa27d7b15dadee0f4d775d54d6394b582bf315353a4657b49c78ac31
+checksum=646c9bfff6a83504c48de2c786c9514ca30c5e916127faf00f143ef8147ee950
 
 post_install() {
 	vlicense COPYING

--- a/srcpkgs/libva/template
+++ b/srcpkgs/libva/template
@@ -1,7 +1,7 @@
 # Template file for 'libva'
 # NOTE: keep this pkg synchronized with libva-glx
 pkgname=libva
-version=2.14.0
+version=2.16.0
 revision=1
 build_style=meson
 configure_args="-Dwith_glx=no"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://01.org/linuxmedia/vaapi"
 changelog="https://raw.githubusercontent.com/intel/libva/master/NEWS"
 distfiles="https://github.com/intel/libva/archive/${version}.tar.gz"
-checksum=f21152a2170edda9d1c4dd463d52eaf62b553e83e553c0a946654523cca86d5e
+checksum=766edf51fd86efe9e836a4467d4ec7c3af690a3c601b3c717237cee856302279
 
 build_options="wayland"
 build_options_default="wayland"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

I tested it in my wayland machine with mpv, firefox, and vivaldi(xwayland). Having used my locally built version for the last couple days didn't notice any difference than before.