### PR TITLE
xsecurelock: update to 1.8.0

### DIFF
--- a/srcpkgs/xsecurelock/template
+++ b/srcpkgs/xsecurelock/template
@@ -1,7 +1,7 @@
 # Template file for 'xsecurelock'
 pkgname=xsecurelock
-version=1.7.0
-revision=2
+version=1.8.0
+revision=1
 build_style=gnu-configure
 configure_args="--with-pam-service-name=system-local-login
  --with-xscreensaver=/usr/libexec/xscreensaver
@@ -17,7 +17,7 @@ maintainer="Sean R. Lang <srlang@ncsu.edu>"
 license="Apache-2.0"
 homepage="https://github.com/google/xsecurelock"
 distfiles="https://github.com/google/xsecurelock/archive/v${version}.tar.gz"
-checksum=9443f0db75a74d319c8e1a6783c568e685a6149a5fdcf53d47a1b1c0d1ad1f54
+checksum=c11a5cc1a9c835749a6fe472a40d12cac10ae4c89a67f153a5492debe7b80633
 
 pre_configure() {
 	sh autogen.sh


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, glibc
