### PR TITLE
got: update to 0.75.1

### DIFF
--- a/srcpkgs/got/template
+++ b/srcpkgs/got/template
@@ -1,18 +1,18 @@
 # Template file for 'got'
 pkgname=got
-version=0.74
+version=0.75.1
 revision=1
 wrksrc=got-portable-${version}
 build_style=gnu-configure
 hostmakedepends="byacc pkg-config"
-makedepends="libmd-devel zlib-devel libuuid-devel libbsd-devel ncurses-devel openssl-devel"
+makedepends="libmd-devel zlib-devel libuuid-devel libbsd-devel ncurses-devel openssl-devel libevent-devel"
 short_desc="VCS which prioritizes ease of use and simplicity over flexibility"
 maintainer="Omar Polo <op@omarpolo.com>"
 license="ISC"
 homepage="https://gameoftrees.org"
 changelog="https://gameoftrees.org/releases/CHANGES"
 distfiles="https://gameoftrees.org/releases/portable/got-portable-${version}.tar.gz"
-checksum="5c495209d161db8adfda0a2c8d2d011be54da8b64d2d8798914cb8b7944876fe"
+checksum="1a511707cf5f64f459030bd45077322821f7263e403af3121c5a1db1529ea524"
 
 post_install() {
 	sed -n '/Copyright/,/PERFORMANCE/p' got/got.c > LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, aarch64-glibc

This update includes `gotwebd`, the FastCGI repository server, that's why now it needs libevent too.  Note that gotwebd in got-portable *at the moment* doesn't work in a chroot, future -portable version will be hopefully better in this regard.