### PR TITLE
ci: update actions/checkout to v3, simplify git finding logic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
+      PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
       XLINT: '1'
       LICENSE_LIST: common/travis/license.lst
 
@@ -44,7 +44,7 @@ jobs:
     container:
       image: 'ghcr.io/void-linux/xbps-src-masterdir:20220527RC01-${{ matrix.config.bootstrap }}'
       env:
-        PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
+        PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
         ARCH: '${{ matrix.config.arch }}'
         BOOTSTRAP: '${{ matrix.config.bootstrap }}'
         TEST: '${{ matrix.config.test }}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       LICENSE_LIST: common/travis/license.lst
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 200
       - run: common/travis/fetch_upstream.sh
@@ -73,7 +73,9 @@ jobs:
           # Upgrade again (in case there was a xbps update)
           xbps-install -yu
 
-      - uses: actions/checkout@v1
+      # workaround until https://github.com/actions/checkout/pull/833 is merged
+      - run: git config --global alias.submodule '!true'
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 200
       - name: Create hostrepo and prepare masterdir

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -11,6 +11,8 @@ jobs:
       issues: write
     container:
         image: 'ghcr.io/void-linux/xbps-src-masterdir:20220527RC01-x86_64-musl'
+        env:
+          PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
     steps:
       - name: Prepare container
         run: |
@@ -33,13 +35,8 @@ jobs:
          common/travis/prepare.sh
       - name: Find cycles and open issues
         run: |
-         if command -v chroot-git >/dev/null 2>&1; then
-             GIT_CMD=$(command -v chroot-git)
-         elif command -v git >/dev/null 2>&1; then
-            GIT_CMD=$(command -v git)
-         fi
          # required by git 2.35.2+
-         $GIT_CMD config --global --add safe.directory "$PWD"
+         git config --global --add safe.directory "$PWD"
          common/scripts/xbps-cycles.py | tee cycles
          grep 'Cycle:' cycles | while read -r line; do
              if gh issue list -R "$GITHUB_REPOSITORY" -S "$line" | grep .; then

--- a/.github/workflows/cycles.yml
+++ b/.github/workflows/cycles.yml
@@ -25,7 +25,9 @@ jobs:
           xbps-install -yu
           # Install script dependencies
           xbps-install -y python3-networkx github-cli
-      - uses: actions/checkout@v1
+      # workaround until https://github.com/actions/checkout/pull/833 is merged
+      - run: git config --global alias.submodule '!true'
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Create hostrepo and prepare masterdir
@@ -35,8 +37,6 @@ jobs:
          common/travis/prepare.sh
       - name: Find cycles and open issues
         run: |
-         # required by git 2.35.2+
-         git config --global --add safe.directory "$PWD"
          common/scripts/xbps-cycles.py | tee cycles
          grep 'Cycle:' cycles | while read -r line; do
              if gh issue list -R "$GITHUB_REPOSITORY" -S "$line" | grep .; then

--- a/common/scripts/lint-commits
+++ b/common/scripts/lint-commits
@@ -5,18 +5,17 @@ die() {
 	exit 1
 }
 
-GIT_CMD=$(command -v chroot-git 2>/dev/null) ||
-GIT_CMD=$(command -v git 2>/dev/null) ||
+command -v git >/dev/null ||
 die "neither chroot-git nor git could be found!"
 
 rev_parse() {
 	if [ -n "$1" ]; then
-		"$GIT_CMD" rev-parse --verify "$1"
+		git rev-parse --verify "$1"
 	else
 		shift
 		while test "$#" != 0
 		do
-			"$GIT_CMD" rev-parse --verify "$1" 2>/dev/null && return
+			git rev-parse --verify "$1" 2>/dev/null && return
 			shift
 		done
 		return 1
@@ -27,9 +26,9 @@ base=$(rev_parse "$1" FETCH_HEAD ORIG_HEAD) || die "base commit not found"
 tip=$(rev_parse "$2" HEAD) || die "tip commit not found"
 status=0
 
-for cmt in $("$GIT_CMD" rev-list --abbrev-commit $base..$tip)
+for cmt in $(git rev-list --abbrev-commit $base..$tip)
 do
-	"$GIT_CMD" cat-file commit "$cmt" |
+	git cat-file commit "$cmt" |
 	awk -vC="$cmt" '
 	# skip header
 	/^$/ && !msg { msg = 1; next }

--- a/common/scripts/lint-version-change
+++ b/common/scripts/lint-version-change
@@ -13,20 +13,15 @@ if ! [ "$base_rev" ]; then
 	die "usage: $0 TEMPLATE BASE-REVISION [TIP-REVISION]"
 fi
 
-if command -v chroot-git >/dev/null 2>&1; then
-	GIT_CMD=$(command -v chroot-git)
-elif command -v git >/dev/null 2>&1; then
-	GIT_CMD=$(command -v git)
-else
+command -v git >/dev/null ||
 	die "neither chroot-git nor git could be found"
-fi
 
 scan() {
 	rx="$1" msg="$2"
 	template_path=$template
 	if [ "$tip_rev" ]; then
 		template_path="${tip_rev}:${template}"
-		maybe_git="$GIT_CMD"
+		maybe_git="git"
 		revspec="[^:]*:"
 	fi
 	$maybe_git grep -P -Hn -e "$rx" "$template_path" |
@@ -37,7 +32,7 @@ scan() {
 show_template() {
 	rev="$1"
 	if [ "$rev" ]; then
-		$GIT_CMD cat-file blob "${rev}:${template}" 2>/dev/null
+		git cat-file blob "${rev}:${template}" 2>/dev/null
 	else
 		cat "${template}" 2>/dev/null
 	fi

--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -2,19 +2,13 @@
 #
 # changed_templates.sh
 
-if command -v chroot-git >/dev/null 2>&1; then
-	GIT_CMD=$(command -v chroot-git)
-elif command -v git >/dev/null 2>&1; then
-	GIT_CMD=$(command -v git)
-fi
-
-tip="$($GIT_CMD rev-list -1 --parents HEAD)"
+tip="$(git rev-list -1 --parents HEAD)"
 case "$tip" in
 	*" "*" "*) tip="${tip##* }" ;;
 	*)         tip="${tip%% *}" ;;
 esac
 
-base="$($GIT_CMD merge-base FETCH_HEAD "$tip")" || {
+base="$(git merge-base FETCH_HEAD "$tip")" || {
 	echo "Your branches is based on too old copy."
 	echo "Please rebase to newest copy."
 	exit 1
@@ -23,7 +17,7 @@ base="$($GIT_CMD merge-base FETCH_HEAD "$tip")" || {
 echo "$base $tip" >/tmp/revisions
 
 /bin/echo -e '\x1b[32mChanged packages:\x1b[0m'
-$GIT_CMD diff-tree -r --no-renames --name-only --diff-filter=AM \
+git diff-tree -r --no-renames --name-only --diff-filter=AM \
 	"$base" "$tip" \
 	-- 'srcpkgs/*/template' |
 	cut -d/ -f 2 |

--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -4,4 +4,6 @@
 
 /bin/echo -e '\x1b[32mFetching upstream...\x1b[0m'
 echo $(pwd)
+echo $HOME
+cat $HOME/.gitconfig
 git fetch --depth 200 https://github.com/void-linux/void-packages.git master

--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -2,9 +2,6 @@
 #
 # changed_templates.sh
 
-# required by git 2.35.2+
-git config --global --add safe.directory "$PWD"
-
 /bin/echo -e '\x1b[32mFetching upstream...\x1b[0m'
 echo $(pwd)
 git fetch --depth 200 https://github.com/void-linux/void-packages.git master

--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -2,14 +2,9 @@
 #
 # changed_templates.sh
 
-if command -v chroot-git >/dev/null 2>&1; then
-	GIT_CMD=$(command -v chroot-git)
-elif command -v git >/dev/null 2>&1; then
-	GIT_CMD=$(command -v git)
-fi
-
 # required by git 2.35.2+
-$GIT_CMD config --global --add safe.directory "$PWD"
+git config --global --add safe.directory "$PWD"
 
 /bin/echo -e '\x1b[32mFetching upstream...\x1b[0m'
-$GIT_CMD fetch --depth 200 https://github.com/void-linux/void-packages.git master
+echo $(pwd)
+git fetch --depth 200 https://github.com/void-linux/void-packages.git master

--- a/srcpkgs/chezmoi/template
+++ b/srcpkgs/chezmoi/template
@@ -1,7 +1,7 @@
 # Template file for 'chezmoi'
 pkgname=chezmoi
 version=2.22.1
-revision=1
+revision=2
 build_style=go
 go_import_path="github.com/twpayne/chezmoi/v2"
 go_build_tags="noembeddocs noupgrade"


### PR DESCRIPTION
`actions/checkout@v3` adds a configuration option to set the checkout dir as a safe directory, a security feature added in git 2.35.2

```yaml
# Add repository path as safe.directory for Git global config by running `git
# config --global --add safe.directory <path>`
# Default: true
set-safe-directory: ''
```

This is set to true by default so we shouldn't need to specify it.

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

