### PR TITLE
haskell-language-server: update to 1.8.0.0

### DIFF
--- a/srcpkgs/haskell-language-server/template
+++ b/srcpkgs/haskell-language-server/template
@@ -1,16 +1,17 @@
 # Template file for 'haskell-language-server'
 pkgname=haskell-language-server
-version=1.7.0.0
+version=1.8.0.0
 revision=1
 build_style="haskell-stack"
-make_build_args="--stack-yaml stack-9.0.2.yaml --flag=haskell-language-server:-dynamic"
+make_build_args="--stack-yaml stack-lts19.yaml --flag=haskell-language-server:-dynamic"
 makedepends="ncurses-devel ncurses-libtinfo-devel icu-devel zlib-devel"
 short_desc="Integration of ghcide and haskell-ide-engine"
 maintainer="Wayne Van Son <waynevanson@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/haskell/haskell-language-server"
+changelog="https://raw.githubusercontent.com/haskell/haskell-language-server/master/ChangeLog.md"
 distfiles="https://github.com/haskell/haskell-language-server/archive/${version}.tar.gz"
-checksum=252fc5ae41ef77bbfa36f42eb38f69c953d5aa8757b510c5c45a03655da95513
+checksum=e1081ac581d21547d835beb8561e815573944aa0babe752a971479da3a207235
 nopie_files="
  /usr/bin/haskell-language-server
  /usr/bin/haskell-language-server-wrapper


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
