### PR TITLE
libtool: update to 2.4.7.

### DIFF
--- a/srcpkgs/libtool/patches/0002-rename-with-sysroot.patch
+++ b/srcpkgs/libtool/patches/0002-rename-with-sysroot.patch
@@ -13,16 +13,16 @@ Jürgen Buchmüller <pullmoll@t-online.de>
 
 --- a/configure	2015-02-15 17:14:34.000000000 +0100
 +++ b/configure	2015-10-20 13:25:12.684906339 +0200
-@@ -824,7 +824,7 @@
+@@ -832,7 +832,7 @@
  enable_fast_install
  with_aix_soname
  with_gnu_ld
 -with_sysroot
 +with_libtool_sysroot
  enable_libtool_lock
+ enable_cross_guesses
  '
-       ac_precious_vars='build_alias
-@@ -1487,7 +1487,8 @@
+@@ -1509,7 +1509,8 @@
                            shared library versioning (aka "SONAME") variant to
                            provide on AIX, [default=aix].
    --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
@@ -32,7 +32,7 @@ Jürgen Buchmüller <pullmoll@t-online.de>
                            compiler's sysroot if not specified).
  
  Some influential environment variables:
-@@ -7389,29 +7390,29 @@
+@@ -7610,29 +7611,29 @@
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sysroot" >&5
  $as_echo_n "checking for sysroot... " >&6; }
  
@@ -57,8 +57,8 @@ Jürgen Buchmüller <pullmoll@t-online.de>
     fi
     ;; #(
   /*)
--   lt_sysroot=`echo "$with_sysroot" | sed -e "$sed_quote_subst"`
-+   lt_sysroot=`echo "$with_libtool_sysroot" | sed -e "$sed_quote_subst"`
+-   lt_sysroot=`echo "$with_sysroot" | $SED -e "$sed_quote_subst"`
++   lt_sysroot=`echo "$with_libtool_sysroot" | $SED -e "$sed_quote_subst"`
     ;; #(
   no|'')
     ;; #(
@@ -72,7 +72,7 @@ Jürgen Buchmüller <pullmoll@t-online.de>
  esac
 --- a/libltdl/configure	2015-02-15 17:15:15.000000000 +0100
 +++ b/libltdl/configure	2015-10-20 13:26:45.747914683 +0200
-@@ -775,7 +775,7 @@
+@@ -777,7 +777,7 @@
  with_aix_soname
  enable_dependency_tracking
  with_gnu_ld
@@ -81,7 +81,7 @@ Jürgen Buchmüller <pullmoll@t-online.de>
  enable_libtool_lock
  enable_ltdl_install
  '
-@@ -1429,7 +1429,8 @@
+@@ -1442,7 +1442,8 @@
                            shared library versioning (aka "SONAME") variant to
                            provide on AIX, [default=aix].
    --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
@@ -91,7 +91,7 @@ Jürgen Buchmüller <pullmoll@t-online.de>
                            compiler's sysroot if not specified).
  
  Some influential environment variables:
-@@ -6275,29 +6276,29 @@
+@@ -6397,29 +6398,29 @@
  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sysroot" >&5
  $as_echo_n "checking for sysroot... " >&6; }
  
@@ -116,8 +116,8 @@ Jürgen Buchmüller <pullmoll@t-online.de>
     fi
     ;; #(
   /*)
--   lt_sysroot=`echo "$with_sysroot" | sed -e "$sed_quote_subst"`
-+   lt_sysroot=`echo "$with_libtool_sysroot" | sed -e "$sed_quote_subst"`
+-   lt_sysroot=`echo "$with_sysroot" | $SED -e "$sed_quote_subst"`
++   lt_sysroot=`echo "$with_libtool_sysroot" | $SED -e "$sed_quote_subst"`
     ;; #(
   no|'')
     ;; #(
@@ -243,14 +243,14 @@ Jürgen Buchmüller <pullmoll@t-online.de>
  ]])
 --- a/m4/libtool.m4	2015-01-20 17:15:19.000000000 +0100
 +++ b/m4/libtool.m4	2015-10-20 15:40:04.020631813 +0200
-@@ -1245,29 +1245,29 @@
- # _LT_WITH_SYSROOT
+@@ -1243,29 +1243,29 @@
  # ----------------
  AC_DEFUN([_LT_WITH_SYSROOT],
--[AC_MSG_CHECKING([for sysroot])
+ [m4_require([_LT_DECL_SED])dnl
+-AC_MSG_CHECKING([for sysroot])
 -AC_ARG_WITH([sysroot],
 -[AS_HELP_STRING([--with-sysroot@<:@=DIR@:>@],
-+[AC_MSG_CHECKING([for libtool-sysroot])
++AC_MSG_CHECKING([for libtool-sysroot])
 +AC_ARG_WITH([libtool-sysroot],
 +[AS_HELP_STRING([--with-libtool-sysroot@<:@=DIR@:>@],
    [Search for dependent libraries within DIR (or the compiler's sysroot
@@ -269,8 +269,8 @@ Jürgen Buchmüller <pullmoll@t-online.de>
     fi
     ;; #(
   /*)
--   lt_sysroot=`echo "$with_sysroot" | sed -e "$sed_quote_subst"`
-+   lt_sysroot=`echo "$with_libtool_sysroot" | sed -e "$sed_quote_subst"`
+-   lt_sysroot=`echo "$with_sysroot" | $SED -e "$sed_quote_subst"`
++   lt_sysroot=`echo "$with_libtool_sysroot" | $SED -e "$sed_quote_subst"`
     ;; #(
   no|'')
     ;; #(

--- a/srcpkgs/libtool/patches/fix-tests-grep-3.8.patch
+++ b/srcpkgs/libtool/patches/fix-tests-grep-3.8.patch
@@ -1,0 +1,18 @@
+--- a/tests/link-order.at
++++ b/tests/link-order.at
+@@ -99,12 +99,12 @@ aix* | interix*) ;;  # These systems hav
+   case $hardcode_direct$hardcode_direct_absolute in
+   yesno)
+     AT_CHECK([if $EGREP relinking stderr; then
+-         $EGREP " .*\/new\/lib/libb$shared_ext .*\/old\/lib/libcee$shared_ext" stdout
++         $EGREP " .*/new/lib/libb$shared_ext .*/old/lib/libcee$shared_ext" stdout
+        else :; fi], [0], [ignore], [], [echo "wrong link order"])
+     ;;
+   *)
+     AT_CHECK([if $EGREP relinking stderr; then
+-         $EGREP " -L.*\/new\/lib -lb -L.*\/old\/lib -lcee" stdout
++         $EGREP " -L.*/new/lib -lb -L.*/old/lib -lcee" stdout
+        else :; fi], [0], [ignore], [], [echo "wrong link order"])
+     ;;
+   esac
+

--- a/srcpkgs/libtool/template
+++ b/srcpkgs/libtool/template
@@ -1,7 +1,7 @@
 # Template file for 'libtool'
 pkgname=libtool
-version=2.4.6
-revision=6
+version=2.4.7
+revision=1
 build_style=gnu-configure
 hostmakedepends="texinfo perl automake help2man xz"
 depends="tar sed"
@@ -10,7 +10,12 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="http://www.gnu.org/software/libtool"
 distfiles="${GNU_SITE}/libtool/$pkgname-$version.tar.xz"
-checksum=7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f
+checksum=4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d
+
+if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
+	# Musl always searches LD_LIBRARY_PATH before RPATH and RUNPATH
+	configure_args="lt_cv_shlibpath_overrides_runpath=yes"
+fi
 
 pre_configure() {
 	touch aclocal.m4 libltdl/aclocal.m4 Makefile.am libltdl/Makefile.am Makefile.in libltdl/Makefile.in
@@ -45,11 +50,16 @@ post_install() {
 		_host_os=$(grep "^host_os=" ${PKGDESTDIR}/usr/bin/libtool | sed 's/host_os=//')
 		vsed -i \
 		 -e "s,^host_alias=.*,host_alias=${_canonical_host}," \
-		 -e "s,^host=.*,host=${_canonical_host}," \
 		 -e "s,^build_alias=.*,build_alias=${_canonical_host}," \
 		 -e "s,^build=.*,build=${_canonical_host}," \
-		 -e "s,^build_os=.*,build_os=${_host_os}," \
 		 ${PKGDESTDIR}/usr/bin/libtool
+
+		# The host_os and build_os can be the same (i.e. linux-musl or linux-gnu)
+		if ! grep "build_os=${_host_os}" ${PKGDESTDIR}/usr/bin/libtool >/dev/null 2>&1; then
+			vsed -i \
+			 -e "s,^build_os=.*,build_os=${_host_os}," \
+			 ${PKGDESTDIR}/usr/bin/libtool
+		fi
 	fi
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Most of the testing for this was done as a part of the [gcc12 PR](https://github.com/void-linux/void-packages/pull/34902), this was split on request.

Most of the build failures experienced were due to hardcoded version-mismatches and the libtool files not getting regenerated properly.
This also defines `lt_cv_shlibpath_overrides_runpath=yes` on musl since it always searches LD_LIBRARY_PATH before RPATH and RUNPATH and not defining it causes some tests to fail which verify this behavior.

Please test this PR before merging.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
