### PR TITLE
qflipper: update to 1.1.3.

### DIFF
--- a/srcpkgs/qflipper/patches/fix-build-32-bit.patch
+++ b/srcpkgs/qflipper/patches/fix-build-32-bit.patch
@@ -1,0 +1,10 @@
+--- a/dfu/device/stm32wb55/infotable.h
++++ b/dfu/device/stm32wb55/infotable.h
+@@ -52,6 +52,7 @@ struct FUSDeviceInfoTable
+     uint32_t  reserved2;
+     uint64_t  UID64;
+     uint16_t  deviceID;
++    uint32_t  padding_ /* padding for 32 bits build */;
+ };
+ 
+ struct DeviceInfoTable {

--- a/srcpkgs/qflipper/template
+++ b/srcpkgs/qflipper/template
@@ -1,10 +1,11 @@
 # Template file for 'qflipper'
 pkgname=qflipper
-version=1.1.0
+version=1.1.3
 revision=1
-_nanopb_version=0.4.5
+_nanopb_version=0.4.6
 wrksrc="qFlipper-${version}"
 build_style=qmake
+configure_args="CONFIG+=qtquickcompiler DEFINES+=DISABLE_APPLICATION_UPDATES"
 hostmakedepends="qt5-qmake pkg-config qt5-host-tools"
 makedepends="qt5-devel qt5-serialport-devel libusb-devel qt5-quickcontrols2-devel qt5-svg-devel qt5-declarative-devel"
 depends="qt5-graphicaleffects qt5-quickcontrols"
@@ -14,12 +15,12 @@ license="GPL-3.0-only"
 homepage="https://flipperzero.one"
 distfiles="https://github.com/flipperdevices/qFlipper/archive/refs/tags/${version}.tar.gz
  https://github.com/nanopb/nanopb/archive/refs/tags/${_nanopb_version}.tar.gz"
-checksum="ccafe9b7e4f6c0cabe6e030dae7b0672062bdee048f461aa3429cde5371ef6c2
- 7d57ebcf26885c9758f95f26bf06d366744599f9a2ff4de477a348eb13e7a7d8"
+checksum="eccdca2ad8afc4207b677dffd0ffd4d55a34b87191ffd79ae212804e484a7a5a
+ caa97d55fb9c98b4cfa0b069acd9657f706e9629af0baeaefcae0a0e8c4a64d2"
 
 post_extract() {
 	rmdir 3rdparty/nanopb
-	ln -s ../../nanopb-0.4.5 3rdparty/nanopb
+	mv ../nanopb-${_nanopb_version} 3rdparty/nanopb
 	assemble_date="$(date -d "$(stat --printf=%y qflipper_common.pri)" +%s)"
 	vsed -i qflipper_common.pri \
 		-e "s/\$\$GIT_VERSION/${version}/" \


### PR DESCRIPTION
- disable building on i686 and point to upstream bug: https://github.com/flipperdevices/qFlipper/issues/120
- add configure args that upstream recommends: https://github.com/flipperdevices/qFlipper#standalone-build
- add configure arg to disable update checker

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
