### PR TITLE
New package: perl-Mail-SpamAssassin-3.4.6.

### DIFF
--- a/srcpkgs/perl-Error/template
+++ b/srcpkgs/perl-Error/template
@@ -1,0 +1,12 @@
+# Template file for 'perl-Error'
+pkgname=perl-Error
+version=0.17029
+revision=1
+wrksrc=${pkgname/perl-/}-$version
+build_style=perl-module
+short_desc="Error/exception handling in an OO-ish way"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="Artistic-1.0-Perl"
+homepage="https://metacpan.org/pod/Error"
+distfiles="https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/Error-$version.tar.gz"
+checksum=1a23f7913032aed6d4b68321373a3899ca66590f4727391a091ec19c95bf7adc

--- a/srcpkgs/perl-Mail-SPF/template
+++ b/srcpkgs/perl-Mail-SPF/template
@@ -1,0 +1,21 @@
+# Template file for 'perl-Mail-SPF'
+pkgname=perl-Mail-SPF
+version=2.9.0
+revision=1
+wrksrc=${pkgname/perl-/}-v$version
+build_style=perl-ModuleBuild
+hostmakedepends="perl-Module-Build"
+makedepends="perl-Net-DNS perl-NetAddr-IP perl-URI perl-Error"
+depends="$makedepends"
+checkdepends="perl-Net-DNS-Resolver-Programmable"
+short_desc="Object-oriented implementation of Sender Policy Framework"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="BSD-3-Clause"
+homepage="https://metacpan.org/pod/Mail::SPF"
+distfiles="https://cpan.metacpan.org/authors/id/J/JM/JMEHNLE/mail-spf/Mail-SPF-v$version.tar.gz"
+checksum=61cb5915f1c7acc7a931ffc1bfc1291bdfac555e2a46eb2391b995ea9ecb6162
+
+post_install() {
+	mv $DESTDIR/usr/{s,}bin/spfd
+	vlicense LICENSE
+}

--- a/srcpkgs/perl-Mail-SpamAssassin/template
+++ b/srcpkgs/perl-Mail-SpamAssassin/template
@@ -1,0 +1,19 @@
+# Template file for 'perl-Mail-SpamAssassin'
+pkgname=perl-Mail-SpamAssassin
+version=3.4.6
+revision=1
+wrksrc=${pkgname/perl-/}-${version}
+build_style=perl-module
+hostmakedepends="re2c curl"
+makedepends="perl-HTML-Parser perl-Net-DNS perl-NetAddr-IP
+ perl-Mail-DKIM perl-Digest-SHA1 perl-IO-String perl-IO-Socket-SSL
+ perl-IO-Socket-INET6 perl-HTTP-Date perl-Archive-Zip perl-Mail-SPF
+ perl-DBI perl-DBD-SQLite"
+depends="$makedepends re2c curl"
+short_desc="#1 Enterprise Open-Source Spam Filter"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="Apache-2.0"
+homepage="https://spamassassin.apache.org/"
+distfiles="https://dlcdn.apache.org/spamassassin/source/Mail-SpamAssassin-$version.tar.gz"
+checksum=500c7e2a7cdf3aa4dd822d97aaff2ab22235a60cf17a68ab817861d215a4e568
+make_check="no" #DNSBL tests crash.

--- a/srcpkgs/perl-Net-DNS-Resolver-Programmable/template
+++ b/srcpkgs/perl-Net-DNS-Resolver-Programmable/template
@@ -1,0 +1,14 @@
+# Template file for 'perl-Net-DNS-Resolver-Programmable'
+pkgname=perl-Net-DNS-Resolver-Programmable
+version=0.009
+revision=1
+wrksrc=${pkgname/perl-/}-$version
+build_style=perl-module
+makedepends="perl-Net-DNS"
+depends="$makedepends"
+short_desc="Programmable DNS resolver class for offline emulation of DNS"
+maintainer="Michael Aldridge <maldridge@voidlinux.org>"
+license="Artistic-1.0-Perl"
+homepage="https://metacpan.org/pod/Net::DNS::Resolver::Programmable"
+distfiles="https://cpan.metacpan.org/authors/id/B/BI/BIGPRESH/${pkgname/perl-/}-$version.tar.gz"
+checksum=8080a2ab776629585911af1179bdb7c4dc2bebfd4b5efd77b11d1dac62454bf8


### PR DESCRIPTION
I want less spam in our mail server, the mail server has built in support for this among other things.  It fails tests due to some DNSBL non-comparables, I'm not sure why. 

The options I have enabled right now include most things, but not GeoIP based checking.