### PR TITLE
caffeine-ng: add libappindicator as a runtime dependency.

### DIFF
--- a/srcpkgs/caffeine-ng/template
+++ b/srcpkgs/caffeine-ng/template
@@ -1,13 +1,13 @@
 # Template file for 'caffeine-ng'
 pkgname=caffeine-ng
 version=4.0.2
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="desktop-file-utils gtk+3 hicolor-icon-theme libnotify
  python3-dbus python3-click python3-ewmh python3-gobject
  python3-setproctitle python3-setuptools python3-xdg
- python3-pulsectl"
+ python3-pulsectl libappindicator"
 short_desc="Temporarily inhibits the screensaver and sleep mode"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
