### PR TITLE
git-cliff: generate and ship man page

### DIFF
--- a/srcpkgs/git-cliff/template
+++ b/srcpkgs/git-cliff/template
@@ -1,7 +1,7 @@
 # Template file for 'git-cliff'
 pkgname=git-cliff
 version=0.9.0
-revision=1
+revision=2
 archs="x86_64* i686* aarch64* arm*" # ring
 build_style=cargo
 build_helper=qemu
@@ -23,4 +23,7 @@ post_install() {
 	vcompletion "_git-cliff" zsh
 	vcompletion "git-cliff.fish" fish
 	vcompletion "git-cliff.bash" bash
+
+	OUT_DIR=${PWD} vtargetrun ${DESTDIR}/usr/bin/git-cliff-mangen
+	vman git-cliff.1
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Motivation here is that running `git cliff --help` doesn't give any reasonable
output (just complains that there is man page on `git-cliff`), while `git-cliff
--help` does. The former is handled by git, which opens `man 1 git-cliff`,
where as the latter is handled by `git-cliff`, giving out the default help
output from clap.

With this change, `git cliff --help` and `git-cliff --help` still differ, but
at least they both give out a sensible result.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
