### PR TITLE
New package: rust-bindgen-0.60.1

### DIFF
--- a/srcpkgs/rust-bindgen/template
+++ b/srcpkgs/rust-bindgen/template
@@ -1,0 +1,19 @@
+# Template file for 'rust-bindgen'
+pkgname=rust-bindgen
+version=0.60.1
+revision=1
+build_style="cargo"
+make_check_args="--bins"
+depends="libclang"
+checkdepends="libclang"
+short_desc="Tool to generate Rust FFI bindings to C (and some C++) libraries"
+maintainer="Erick Vilcica <erick.vilcica@protonmail.com>"
+license="BSD-3-Clause"
+homepage="https://rust-lang.github.io/rust-bindgen/"
+changelog="https://raw.githubusercontent.com/rust-lang/rust-bindgen/master/CHANGELOG.md"
+distfiles="https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v${version}.tar.gz"
+checksum="b521c18af2230d748b1f7eea8f3aab9381a08a07024fc52a6350fee286fae4ec"
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-gnu, also aarch64)
- I built this PR locally for these architectures (crossbuilds):
  - x86_64-musl
  - armv6l

This is a command line tool that generates Rust bindings from C/C++ header files. It is also a build dependency of the new Mesa Rusticl OpenCL driver, so it will be needed in the future when that releases. 
