### PR TITLE
libgweather: silence warnings on musl with metric

### DIFF
--- a/srcpkgs/libgweather/patches/0001-Fix-fallback-metric-unit-detection-logic.patch
+++ b/srcpkgs/libgweather/patches/0001-Fix-fallback-metric-unit-detection-logic.patch
@@ -1,0 +1,32 @@
+From e65f3041b1a14dc7d46935091b35ae6a7236d118 Mon Sep 17 00:00:00 2001
+From: Michal Vasilek <michal@vasilek.cz>
+Date: Sun, 18 Sep 2022 19:32:51 +0200
+Subject: [PATCH] Fix fallback metric unit detection logic
+
+When HAVE__NL_MEASUREMENT_MEASUREMENT is not defined (for example on
+musl systems), the fallback logic checks for units in translation files.
+
+If the unit in translation files is metric, we should use metric and
+not print a warning about missing translation and use metric.
+
+Introduced in 1c140fc8ce08260d5008847945bf345654ad7fa8
+---
+ libgweather/gweather-info.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libgweather/gweather-info.c b/libgweather/gweather-info.c
+index d33d3905..193ee86c 100644
+--- a/libgweather/gweather-info.c
++++ b/libgweather/gweather-info.c
+@@ -880,7 +880,7 @@ is_locale_metric (void)
+ 
+     if (strcmp (e, "default:inch") == 0)
+         return FALSE;
+-    else if (strcmp (e, "default:mm") == 1)
++    else if (strcmp (e, "default:mm") == 0)
+         return TRUE;
+     else {
+         g_warning ("Wrong translation for libgweather; please file "
+-- 
+2.37.3
+

--- a/srcpkgs/libgweather/template
+++ b/srcpkgs/libgweather/template
@@ -2,7 +2,7 @@
 pkgname=libgweather
 reverts="40.0_1"
 version=4.0.0
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="$(vopt_bool gir enable_vala) $(vopt_bool gir introspection)


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

musl systems with metric locales displayed a lot of warnings because of a logic error 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
