### PR TITLE
AppStream: fix segfault when updating the cache

### DIFF
--- a/srcpkgs/AppStream/patches/0001-ascli_refresh_cache-fix-NULL-pointer-dereference.patch
+++ b/srcpkgs/AppStream/patches/0001-ascli_refresh_cache-fix-NULL-pointer-dereference.patch
@@ -1,0 +1,29 @@
+https://github.com/ximion/appstream/pull/432
+From: Roberto Ricci <ricci@disroot.org>
+Date: Mon, 19 Sep 2022 16:02:59 +0200
+Subject: [PATCH] ascli_refresh_cache: fix NULL pointer dereference
+
+The command `appstreamcli refresh-cache --cachepath /tmp/cache`
+segfaults. In this code path, `ret` (initialized to `FALSE`) is not
+updated when `as_pool_load` returns successfully and sets the `error`
+pointer to NULL. Then the code tries to print `error->message`.
+---
+ tools/ascli-actions-mdata.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/ascli-actions-mdata.c b/tools/ascli-actions-mdata.c
+index c77773da..30bfd325 100644
+--- a/tools/ascli-actions-mdata.c
++++ b/tools/ascli-actions-mdata.c
+@@ -81,7 +81,7 @@ ascli_refresh_cache (const gchar *cachepath,
+ 		ret = as_pool_refresh_system_cache (pool, forced, &cache_updated, &error);
+ 	} else {
+ 		as_pool_override_cache_locations (pool, cachepath, NULL);
+-		as_pool_load (pool, NULL, &error);
++		ret = as_pool_load (pool, NULL, &error);
+ 		cache_updated = TRUE;
+ 	}
+ 
+-- 
+2.37.3
+

--- a/srcpkgs/AppStream/template
+++ b/srcpkgs/AppStream/template
@@ -1,7 +1,7 @@
 # Template file for 'AppStream'
 pkgname=AppStream
 version=0.15.5
-revision=1
+revision=2
 wrksrc="appstream-${version}"
 build_style=meson
 build_helper="gir qemu"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

@paper42

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
