### PR TITLE
wesnoth: update to 1.16.6

### DIFF
--- a/srcpkgs/wesnoth/template
+++ b/srcpkgs/wesnoth/template
@@ -1,7 +1,7 @@
 # Template file for 'wesnoth'
 pkgname=wesnoth
-version=1.14.17
-revision=2
+version=1.16.6
+revision=1
 build_style=cmake
 configure_args="-DENABLE_OMP=1"
 hostmakedepends="pkg-config gettext"
@@ -14,7 +14,7 @@ maintainer="Philipp Hirsch <itself@hanspolo.net>"
 license="GPL-2.0-or-later"
 homepage="https://wesnoth.org"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
-checksum=3646cba604e09c12d6900a733bcb78cbf05f2f75f05346630d6529c220f584e1
+checksum=1fce2c625da53adee4ec62b4e0a810bae1a01c9b893027b10beafaa3a0648501
 replaces="wesnoth-data>=0"
 
 CFLAGS="-UNDEBUG"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
- I built this PR locally for my native architecture, x86_64-musl
<!--
#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Tested by playing a few turns locally; big thanks to all those who upgraded boost to 1.80