### PR TITLE
python3-freezegun: update to 1.2.2.

### DIFF
--- a/srcpkgs/python3-freezegun/patches/fix-upstream-issue-396.patch
+++ b/srcpkgs/python3-freezegun/patches/fix-upstream-issue-396.patch
@@ -1,0 +1,30 @@
+From 57d024e4ce2516c55c715448296b9099db68343c Mon Sep 17 00:00:00 2001
+From: Karthikeyan Singaravelan <tir.karthi@gmail.com>
+Date: Fri, 7 May 2021 15:51:33 +0000
+Subject: [PATCH] Fix decorate_class for Python 3.10 where staticmethod is
+ callable.
+
+https://github.com/spulec/freezegun/pull/397 (edited by mgorny for more readable indent)
+---
+ freezegun/api.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/freezegun/api.py b/freezegun/api.py
+index cab9ebe..eb3a931 100644
+--- a/freezegun/api.py
++++ b/freezegun/api.py
+@@ -598,7 +598,10 @@ class _freeze_time(object):
+                         continue
+                     seen.add(attr)
+ 
+-                    if not callable(attr_value) or inspect.isclass(attr_value):
++                    # staticmethods are callable from Python 3.10 . Hence skip them from decoration
++                    if (not callable(attr_value)
++                            or inspect.isclass(attr_value)
++                            or isinstance(attr_value, staticmethod)):
+                         continue
+ 
+                     try:
+-- 
+2.31.1
+

--- a/srcpkgs/python3-freezegun/template
+++ b/srcpkgs/python3-freezegun/template
@@ -1,18 +1,19 @@
 # Template file for 'python3-freezegun'
 pkgname=python3-freezegun
-version=0.3.15
-revision=3
+version=1.2.2
+revision=1
 wrksrc="freezegun-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-six python3-dateutil"
-checkdepends="${depends} python3-nose python3-pytest"
+depends="python3-dateutil"
+checkdepends="${depends} python3-pytest-xdist"
 short_desc="Let your Python tests travel through time"
 maintainer="Aluísio Augusto Silva Gonçalves <aluisio@aasg.name>"
 license="Apache-2.0"
 homepage="https://github.com/spulec/freezegun"
+changelog="https://raw.githubusercontent.com/spulec/freezegun/master/CHANGELOG"
 distfiles="${PYPI_SITE}/f/freezegun/freezegun-${version}.tar.gz"
-checksum=e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b
+checksum=cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446
 
 do_check() {
 	# Timezone needs to be fixed due to


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Rev dep checks
- [x] afew
- [x] bumblebee-status
- [x] khal (2 unrelated test failures, https://github.com/pimutils/khal/commit/f6c9b8a53a0f12222b2ee25c82229b0605b8785a)
- [x] python3-Babel
- [x] python3-humanize
- [x] python3-pendulum (2 unrelated test failures, https://github.com/sdispater/pendulum/issues/644)
- [x] python3-tempora
- [x] remhind
- [x] streamlink
- [x] todoman
- [x] tox