### PR TITLE
gopass{,-jsonapi}: update to 1.14.6.

### DIFF
--- a/srcpkgs/gopass-jsonapi/template
+++ b/srcpkgs/gopass-jsonapi/template
@@ -1,7 +1,7 @@
 # Template file for 'gopass-jsonapi'
 pkgname=gopass-jsonapi
-version=1.14.3
-revision=2
+version=1.14.6
+revision=1
 create_wrksrc=yes
 build_style=go
 go_import_path=github.com/gopasspw/gopass-jsonapi
@@ -13,7 +13,7 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass-jsonapi/v${version}/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass-jsonapi/releases/download/v${version}/gopass-jsonapi-${version}.tar.gz"
-checksum=f09f845d7e50bd691e0f1b889f11429714cbd325c854f7ccb622f26ed65241d5
+checksum=3ce434ee44c2cd17ac241bfc4a62e95d98d0e78e068f78a7d71106a4d555c6b3
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/gopass/template
+++ b/srcpkgs/gopass/template
@@ -1,6 +1,6 @@
 # Template file for 'gopass'
 pkgname=gopass
-version=1.14.4
+version=1.14.6
 revision=1
 build_style=go
 build_helper=qemu
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://www.gopass.pw/"
 changelog="https://raw.githubusercontent.com/gopasspw/gopass/master/CHANGELOG.md"
 distfiles="https://github.com/gopasspw/gopass/archive/v${version}.tar.gz"
-checksum=6b78a76d82a3eade600c8f2e83ff53d2d369d6e218b3560d518ba61fbc33221a
+checksum=80d0a738ad1a4943e7e98a2db7d11e2b9abb890af8986307e1f0e40cbbf0b00d
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64