### PR TITLE
docbook2mdoc: fix build and extract license file

### DIFF
--- a/srcpkgs/docbook2mdoc/patches/Makefile.patch
+++ b/srcpkgs/docbook2mdoc/patches/Makefile.patch
@@ -1,0 +1,33 @@
+diff --git a/Makefile b/Makefile
+index d4d536b..d6fc20e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,6 @@
+ VERSION = 1.1.0
+-CFLAGS += -g -W -Wall -Wstrict-prototypes -Wno-unused-parameter -Wwrite-strings
++override CFLAGS += $(shell pkg-config --cflags libbsd-overlay)
++override LDFLAGS += $(shell pkg-config --libs libbsd-overlay)
+ WWWPREFIX = /var/www/vhosts/mdocml.bsd.lv/htdocs/docbook2mdoc
+ PREFIX = /usr/local
+ 
+@@ -11,7 +12,7 @@ DISTFILES = Makefile NEWS docbook2mdoc.1
+ all: docbook2mdoc
+ 
+ docbook2mdoc: $(OBJS)
+-	$(CC) -g -o $@ $(OBJS)
++	$(CC) -g -o $@ $(OBJS) $(LDFLAGS)
+ 
+ statistics: statistics.o xmalloc.o
+ 	$(CC) -g -o $@ statistics.o xmalloc.o
+@@ -20,9 +21,9 @@ www: docbook2mdoc.1.html docbook2mdoc-$(VERSION).tgz README.txt
+ 
+ install: all
+ 	mkdir -p $(DESTDIR)$(PREFIX)/bin
+-	mkdir -p $(DESTDIR)$(PREFIX)/man/man1
++	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
+ 	install -m 0755 docbook2mdoc $(DESTDIR)$(PREFIX)/bin
+-	install -m 0444 docbook2mdoc.1 $(DESTDIR)$(PREFIX)/man/man1
++	install -m 0444 docbook2mdoc.1 $(DESTDIR)$(PREFIX)/share/man/man1
+ 
+ installwww: www
+ 	mkdir -p $(WWWPREFIX)/snapshots

--- a/srcpkgs/docbook2mdoc/template
+++ b/srcpkgs/docbook2mdoc/template
@@ -1,19 +1,24 @@
 # Template file for 'docbook2mdoc'
 pkgname=docbook2mdoc
 version=1.1.0
-revision=1
+revision=2
 build_style=gnu-makefile
-makedepends="libbsd-devel"
+hostmakedepends="pkg-config"
+makedepends="libbsd-devel libmd-devel"
 short_desc="Converter from DocBook V4.x and v5.x XML into mdoc"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="ISC"
-homepage="http://mdocml.bsd.lv/docbook2mdoc"
-distfiles="http://mdocml.bsd.lv/docbook2mdoc/snapshots/${pkgname}-${version}.tgz"
+homepage="https://mandoc.bsd.lv/docbook2mdoc"
+distfiles="https://mandoc.bsd.lv/docbook2mdoc/snapshots/${pkgname}-${version}.tgz"
 checksum=9fc6411cf041ff10e76f19a50a142075a8df9d343f248e20d8fc98bf8e547c71
 
-LDFLAGS="-lbsd"
+CFLAGS="-D_GNU_SOURCE"
+
 post_extract() {
-	sed -i '/CC.*-o/s/$/ $(LDFLAGS)/' Makefile
-	sed -i 's,/man/man1,/share/man/man1,g' Makefile
-	vsed -e 's:sys/queue.h:bsd/sys/queue.h:' -i node.h
+	# Create License file
+	sed -E '3,16 !d;s/^ [*] ?//' docbook2mdoc.c > LICENSE
+}
+
+post_install() {
+	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Use pkg-config to set flags for libbsd, add missing libmd depend, and install a license file

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
