### PR TITLE
sigi: update to 3.4.3

### DIFF
--- a/srcpkgs/sigi/template
+++ b/srcpkgs/sigi/template
@@ -1,6 +1,6 @@
 # Template file for 'sigi'
 pkgname=sigi
-version=3.4.2
+version=3.4.3
 revision=1
 build_style=cargo
 short_desc="Organization tool for people who hate organization"
@@ -8,7 +8,7 @@ maintainer="J.R. Hill <hiljusti@so.dang.cool>"
 license="GPL-2.0-only"
 homepage="https://github.com/hiljusti/sigi"
 distfiles="https://crates.io/api/v1/crates/sigi/${version}/download>sigi-${version}.tar.gz"
-checksum=8bb60ca0fa0fd66aaeef0efb3b34b171dbe0a6e0f69672dafc9cc72fb30a4036
+checksum=a1a363a3379d53fbc5146f1f4f231c781aa56116548a00ee4af9acfcf7c93084
 
 post_install() {
 	vman sigi.1


### PR DESCRIPTION
I tested the changes in this PR: **YES**

The bump from 3.4.2 to 3.4.3 here is pretty minor. Just some dependency updates and internal cleaning https://github.com/hiljusti/sigi/releases/tag/v3.4.3