### PR TITLE
synapse: update to 1.68.0.

### DIFF
--- a/common/build-style/python3-pep517.sh
+++ b/common/build-style/python3-pep517.sh
@@ -8,7 +8,7 @@ do_build() {
 	: ${make_build_target:=.}
 
 	mkdir -p build
-	TMPDIR=build python3 -m pip wheel --no-deps --use-pep517 --no-clean \
+	TMPDIR="${PWD}/build" python3 -m pip wheel --no-deps --use-pep517 --no-clean \
 		--no-build-isolation ${make_build_args} ${make_build_target}
 }
 
@@ -35,7 +35,7 @@ do_install() {
 
 	# If do_build was overridden, make sure the TMPDIR exists
 	mkdir -p build
-	TMPDIR=build python3 -m pip install --use-pep517 --prefix /usr \
+	TMPDIR="${PWD}/build" python3 -m pip install --use-pep517 --prefix /usr \
 		--root ${DESTDIR} --no-deps --no-build-isolation \
 		--no-clean ${make_install_args} ${make_install_target}
 }

--- a/srcpkgs/python3-canonicaljson/template
+++ b/srcpkgs/python3-canonicaljson/template
@@ -1,10 +1,10 @@
 # Template file for 'python3-canonicaljson'
 pkgname=python3-canonicaljson
-version=1.6.2
+version=1.6.3
 revision=1
 wrksrc="canonicaljson-${version}"
-build_style=python3-module
-hostmakedepends="python3-setuptools"
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-wheel"
 depends="python3-simplejson python3-frozendict"
 checkdepends="${depends} python3-pytest"
 short_desc="Canonical JSON"
@@ -12,4 +12,5 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="Apache-2.0"
 homepage="https://github.com/matrix-org/python-canonicaljson"
 distfiles="${PYPI_SITE}/c/canonicaljson/canonicaljson-${version}.tar.gz"
-checksum=af00be8ce9c589857df176bb94594f0d43b0e027f027a8d7cf8978fdb819024a
+checksum=ca59760bc274a899a0da75809d6909ae43e5123381fd6ef040a44d1952c0b448
+make_check_pre="env PYTHONPATH=src"

--- a/srcpkgs/python3-matrix-common/template
+++ b/srcpkgs/python3-matrix-common/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-matrix-common'
 pkgname=python3-matrix-common
-version=1.2.1
+version=1.3.0
 revision=1
 wrksrc="matrix-python-common-${version}"
 build_style=python3-pep517
@@ -11,5 +11,5 @@ maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
 license="Apache-2.0"
 homepage="https://github.com/matrix-org/matrix-python-common"
 distfiles="https://github.com/matrix-org/matrix-python-common/archive/v${version}.tar.gz"
-checksum=75ccb0de5b5cd551d81770addea1d2b227831f9cb83d46079ee0c74af0fb0a69
+checksum=9792a69b04904cb2da027890fe07229cc6610254268d2a5037e31aaeb7047104
 make_check=no # requires unpackaged python3 module aiounittest

--- a/srcpkgs/python3-phonenumbers/template
+++ b/srcpkgs/python3-phonenumbers/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-phonenumbers'
 pkgname=python3-phonenumbers
-version=8.12.55
+version=8.12.56
 revision=1
 wrksrc="phonenumbers-${version}"
 build_style=python3-module
@@ -12,4 +12,4 @@ license="Apache-2.0"
 homepage="https://github.com/daviddrysdale/python-phonenumbers"
 changelog="https://raw.githubusercontent.com/daviddrysdale/python-phonenumbers/dev/python/HISTORY.md"
 distfiles="${PYPI_SITE}/p/phonenumbers/phonenumbers-${version}.tar.gz"
-checksum=1be3c7353e9325ddeaa909ab17936423c62958d5700d68e5da5be9503c46d087
+checksum=82a4f226c930d02dcdf6d4b29e4cfd8678991fe65c2efd5fdd143557186f0868

--- a/srcpkgs/synapse/template
+++ b/srcpkgs/synapse/template
@@ -1,11 +1,12 @@
 # Template file for 'synapse'
 pkgname=synapse
-version=1.67.0
+version=1.68.0
 revision=1
 build_style=python3-pep517
+build_helper=rust
 make_check_target=tests
 make_install_target="matrix_synapse-${version}-*-*-*.whl"
-hostmakedepends="python3-poetry-core"
+hostmakedepends="python3-poetry-core python3-setuptools-rust cargo"
 depends="python3-jsonschema python3-frozendict python3-canonicaljson
  python3-signedjson python3-pynacl python3-service_identity python3-Twisted
  python3-openssl python3-yaml python3-pyasn1 python3-pyasn1-modules
@@ -22,7 +23,11 @@ license="Apache-2.0"
 homepage="https://github.com/matrix-org/synapse"
 changelog="https://raw.githubusercontent.com/matrix-org/synapse/develop/CHANGES.md"
 distfiles="https://github.com/matrix-org/synapse/archive/v${version}.tar.gz"
-checksum=85eeb24890c4b8e68f1e5ca4d5e69e1eb49e67cc33c450dc7c1fe7e70c023c68
+checksum=3da9f788530905abc1c5db02f0cb2afd01b65463fe6962f1c4394ac153aad8ac
+
+if [ "$CROSS_BUILD" ]; then
+	makedepends+=" rust-std"
+fi
 
 system_accounts="synapse"
 synapse_homedir="/var/lib/synapse"
@@ -32,12 +37,21 @@ make_dirs="
 	/etc/synapse 755 synapse synapse
 	/var/log/synapse 0755 synapse synapse"
 
+post_patch() {
+	vsed -i '/^setuptools_rust/d' pyproject.toml
+}
+
 pre_check() {
 	unzip ${make_install_target} "*.dist-info/*"
+	[ -d build/lib* ] && cp -r tests build/lib*
 }
 
 do_check() {
-	PYTHONPATH="." trial3 ${makejobs} tests
+	PYTHONPATH="$(cd build/lib* && pwd):." trial3 ${makejobs} tests
+}
+
+post_check() {
+	rm -r build/lib*/tests
 }
 
 post_install() {


### PR DESCRIPTION
build-style/python3-*.sh might need more adjusting for this, I already spotted
one problem where rustc consumes the TMPDIR environment variable and breaks the
build process.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
