### PR TITLE
gimp: woraround pango crash with no fonts installed

### DIFF
--- a/srcpkgs/gimp/template
+++ b/srcpkgs/gimp/template
@@ -5,7 +5,7 @@ revision=1
 build_style=gnu-configure
 configure_args="--disable-check-update --datadir=/usr/share"
 hostmakedepends="automake gegl gettext-devel glib-devel gtk+-devel intltool
- libtool pkg-config pygtk-devel perl-XML-Parser gtk-doc iso-codes"
+ libtool pkg-config pygtk-devel perl-XML-Parser gtk-doc iso-codes cantarell-fonts"
 makedepends="aalib-devel alsa-lib-devel babl-devel dbus-glib-devel gegl-devel
  ghostscript-devel jasper-devel lcms2-devel libXcursor-devel libXpm-devel
  libgexiv2-devel libgudev-devel libmng-devel libmypaint-devel


### PR DESCRIPTION
gegl currently crashes in pango when no fonts are installed.
https://gitlab.gnome.org/GNOME/pango/-/issues/701

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
