### PR TITLE
pango: fix gegl crash when no font is installed

### DIFF
--- a/srcpkgs/pango/patches/fix-segfault-no-font.patch
+++ b/srcpkgs/pango/patches/fix-segfault-no-font.patch
@@ -1,0 +1,21 @@
+diff --git a/pango/pango-layout.c b/pango/pango-layout.c
+index a1c47203..b8eeede0 100644
+--- a/pango/pango-layout.c
++++ b/pango/pango-layout.c
+@@ -5707,13 +5707,14 @@ pango_layout_run_get_extents_and_height (PangoLayoutRun *run,
+         }
+       else
+         {
+-          double xscale, yscale;
++          double xscale = 0, yscale = 0;
+ 
+           if (!metrics)
+             metrics = pango_font_get_metrics (run->item->analysis.font,
+                                               run->item->analysis.language);
+ 
+-          pango_font_get_scale_factors (run->item->analysis.font, &xscale, &yscale);
++          if (G_LIKELY(run->item->analysis.font))
++            pango_font_get_scale_factors (run->item->analysis.font, &xscale, &yscale);
+           *height = pango_font_metrics_get_height (metrics) * MAX (xscale, yscale);
+         }
+     }

--- a/srcpkgs/pango/template
+++ b/srcpkgs/pango/template
@@ -1,7 +1,7 @@
 # Template file for 'pango'
 pkgname=pango
 version=1.50.10
-revision=1
+revision=2
 build_style=meson
 build_helper=gir
 configure_args="-Dintrospection=$(vopt_if gir enabled disabled)"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This patch has been submitted upstream: https://gitlab.gnome.org/GNOME/pango/-/merge_requests/639

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
