### PR TITLE
cryptsetup: update to 2.5.0.

### DIFF
--- a/srcpkgs/cryptsetup/template
+++ b/srcpkgs/cryptsetup/template
@@ -1,10 +1,10 @@
 # Template file for 'cryptsetup'
 pkgname=cryptsetup
-version=2.4.3
+version=2.5.0
 revision=1
 build_style=gnu-configure
 configure_args="--with-crypto_backend=openssl --enable-cryptsetup-reencrypt
- --enable-libargon2 $(vopt_enable pwquality)"
+ --disable-asciidoc --enable-libargon2 $(vopt_enable pwquality)"
 make_check_args="-C tests"
 hostmakedepends="pkg-config"
 makedepends="device-mapper-devel json-c-devel openssl-devel popt-devel
@@ -16,12 +16,18 @@ license="GPL-2.0-or-later"
 homepage="https://gitlab.com/cryptsetup/cryptsetup"
 changelog="https://gitlab.com/cryptsetup/cryptsetup/raw/master/docs/v${version}-ReleaseNotes"
 distfiles="${KERNEL_SITE}/utils/cryptsetup/v${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=fc0df945188172264ec5bf1d0bda08264fadc8a3f856d47eba91f31fe354b507
-make_check=extended
+checksum=9184a6ebbd9ce7eb211152e7f741a6c82f2d1cc0e24a84ec9c52939eee0f0542
 subpackages="libcryptsetup cryptsetup-devel"
-
 build_options="pwquality"
 desc_option_pwquality="Enable support for checking password quality via libpwquality"
+
+if [ "$XBPS_LIBC" = "musl" ]
+then
+	make_check=no # Test fail on musl see upstream:
+	# https://gitlab.com/cryptsetup/cryptsetup/-/issues/781
+else
+	make_check=ci-skip # tests depend on acessing /dev/mapper/control fails on CI
+fi
 
 post_patch() {
 	if [ "$XBPS_TARGET_LIBC" = musl ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**, using it on my full disk encrypted system boot included (x86_64-glibc), and its working fine. 

I have also went ahead and compiled it on a VM with musl glibc (x86_64-musl) and cross compiled it with armv6l.

#### Local build testing
- I built this PR locally for my native architecture, x86_64-{musl,glibc}
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

Probably should be marked as tests needed as other people might have different setups than mine. ( and this update broke something).