### PR TITLE
pilot-link: disable python2 support

### DIFF
--- a/srcpkgs/pilot-link/template
+++ b/srcpkgs/pilot-link/template
@@ -1,14 +1,14 @@
 # Template file for 'pilot-link'
 pkgname=pilot-link
 version=0.12.5
-revision=2
+revision=3
 build_style=gnu-configure
 # XXX: Add perl bindings --with-perl and fix bindings/Perl/Makefile
 configure_args="--enable-conduits --enable-libusb --enable-threads --disable-static
- --disable-compile-werror --with-python --with-tcl=${XBPS_CROSS_BASE}/usr/lib"
+ --disable-compile-werror --with-tcl=${XBPS_CROSS_BASE}/usr/lib"
 hostmakedepends="automake libtool perl pkg-config tk"
 makedepends="libbluetooth-devel libusb-devel libpng-devel popt-devel
- python-devel tcl-devel readline-devel"
+ tcl-devel readline-devel"
 depends="tk"
 short_desc="Suite of tools to connect your Palm or PalmOS® handheld"
 maintainer="Orphaned <orphan@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (I don't have access to a palm device, but this is a simple change, so hopefully it should be ok)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
