### PR TITLE
New package: yabridgectl-4.0.2

### DIFF
--- a/srcpkgs/yabridgectl/template
+++ b/srcpkgs/yabridgectl/template
@@ -1,0 +1,16 @@
+# Template file for 'yabridgectl'
+pkgname=yabridgectl
+version=4.0.2
+revision=1
+archs="x86_64"
+wrksrc="yabridge-${version}"
+build_wrksrc="tools/yabridgectl"
+build_style=cargo
+hostmakedepends="grep"
+depends="yabridge"
+short_desc="Yabridgectl oontrols yabridge configurations"
+maintainer="Anthony Thompson <athompson@posteo.net>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/robbert-vdh/yabridge"
+distfiles="https://github.com/robbert-vdh/yabridge/archive/refs/tags/${version}.tar.gz"
+checksum="86fcd65b6f3dd5cf60c2afa476f63959a2cc4ef4d4629810916739d7af645f01"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements):  
- 
xlint check complains about the wrksrc not being top level.  The source of yabridgectl is distributed within the yabridge source and is several levels down. Compiles and works well by keeping the origin source in the correct locations and having the multilevel wrksrc set.


#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
