### PR TITLE
boinc: not depends on GTK+ anymore

### DIFF
--- a/srcpkgs/boinc/patches/boinc-am_conditional.patch
+++ b/srcpkgs/boinc/patches/boinc-am_conditional.patch
@@ -1,4 +1,4 @@
-Add objective c++ program and check for gtk2
+Add objective c++ program and check for gtk+3
 
 --- a/configure.ac
 +++ b/configure.ac
@@ -14,7 +14,7 @@ Add objective c++ program and check for gtk2
  AM_CONDITIONAL(INSTALL_HEADERS, [test "${enable_install_headers}" = yes])
  AM_CONDITIONAL(HAVE_CUDA_LIB, [test "${enable_client}" = yes -a -f ./coprocs/CUDA/posix/${boinc_platform}/libcudart.so])
  
-+PKG_CHECK_MODULES([GTK2], [gtk+-2.0])
++PKG_CHECK_MODULES([GTK3], [gtk+-3.0])
 +
  dnl ======================================================================
  dnl some more vodoo required for building portable client-binary (client, clientgui)

--- a/srcpkgs/boinc/template
+++ b/srcpkgs/boinc/template
@@ -8,7 +8,7 @@ build_style=gnu-configure
 hostmakedepends="automake libtool pkg-config xorgproto shared-mime-info"
 makedepends="glu-devel libfreeglut-devel libcurl-devel
  libjpeg-turbo-devel libnotify-devel sqlite-devel libxcb-devel
- libXmu-devel libXi-devel gtk+-devel webkit2gtk-devel wxWidgets-gtk3-devel"
+ libXmu-devel libXi-devel webkit2gtk-devel wxWidgets-gtk3-devel"
 depends="curl ca-certificates"
 conf_files="/etc/default/boinc-client"
 short_desc="Berkely Infrastructure for Network Computing"

--- a/srcpkgs/codeblocks/template
+++ b/srcpkgs/codeblocks/template
@@ -4,21 +4,18 @@ version=20.03
 revision=2
 build_style=gnu-configure
 configure_args="--with-wx-config=wx-config-gtk3 --with-contrib-plugins
- --with-boost=${XBPS_CROSS_BASE}/usr --with-boost-libdir=${XBPS_CROSS_BASE}/usr/lib"
+ --with-boost=${XBPS_CROSS_BASE}/usr
+ --with-boost-libdir=${XBPS_CROSS_BASE}/usr/lib
+ ac_cv_exeext=no --with-gnu-ld"
 hostmakedepends="libtool pkg-config zip"
 makedepends="gtk+3-devel wxWidgets-gtk3-devel tinyxml-devel hunspell-devel
- gamin-devel boost-devel boost-build"
+ gamin-devel boost-devel boost-build tinyxml-devel"
 short_desc="Free C, C++ and Fortran IDE"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-only"
 homepage="http://www.codeblocks.org"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/Sources/${version}/${pkgname}-${version}.tar.xz"
 checksum=15eeb3e28aea054e1f38b0c7f4671b4d4d1116fd05f63c07aa95a91db89eaac5
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" wxWidgets-devel tinyxml-devel"
-	configure_args+=" ac_cv_exeext=no --with-gnu-ld"
-fi
 
 post_install() {
 	vinstall debian/codeblocks.sharedmime 644 /usr/share/mime/packages codeblocks.xml

--- a/srcpkgs/golly/template
+++ b/srcpkgs/golly/template
@@ -6,11 +6,11 @@ wrksrc="${pkgname}-${version}-src"
 build_wrksrc="gui-wx"
 build_style=gnu-makefile
 make_build_args="-f makefile-gtk GOLLYDIR=/usr/share/golly LUALIB=-llua5.4
- CXXC=\$(CXX)"
+ CXXC=\$(CXX) WX_CONFIG=wx-config-gtk3"
 make_install_args="${make_build_args}"
 hostmakedepends="python3"
-makedepends="MesaLib-devel glu-devel lua54-devel python3-devel wxWidgets-devel
- zlib-devel SDL2-devel"
+makedepends="MesaLib-devel glu-devel lua54-devel python3-devel
+ wxWidgets-gtk3-devel zlib-devel SDL2-devel"
 short_desc="Simulator for Conway's Game of Life and other cellular automata"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
