### PR TITLE
miniserve: update to 0.22.0, add manpage, completions

### DIFF
--- a/srcpkgs/miniserve/template
+++ b/srcpkgs/miniserve/template
@@ -1,16 +1,17 @@
 # Template file for 'miniserve'
 pkgname=miniserve
-version=0.20.0
+version=0.22.0
 revision=1
 build_style=cargo
+build_helper=qemu
 checkdepends="curl"
 short_desc="CLI tool to serve files and dirs over HTTP"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/svenstaro/miniserve"
 changelog="https://raw.githubusercontent.com/svenstaro/miniserve/master/CHANGELOG.md"
-distfiles="https://github.com/svenstaro/miniserve/archive/v${version}.tar.gz"
-checksum=77aca0e3660564cc2b9a7f318c5d9065d471f3c5ab0a7d1b6850a5cb6e21904f
+distfiles="https://github.com/svenstaro/miniserve/archive/refs/tags/v${version}.tar.gz"
+checksum=325f6cde391c468000b1bdcc8455ec2c6950b3c930029187671c536507b185ba
 make_check=ci-skip  # port binding succeeds locally but fails in CI
 
 case "$XBPS_TARGET_MACHINE" in
@@ -19,5 +20,14 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 post_install() {
+	MINISERVE="${DESTDIR}/usr/bin/miniserve"
+	for shell in bash fish zsh; do
+		vtargetrun ${MINISERVE} --print-completions ${shell} > miniserve.${shell}
+		vcompletion miniserve.${shell} ${shell}
+	done
+
+	vtargetrun ${MINISERVE} --print-manpage > miniserve.1
+	vman miniserve.1
+
 	vlicense LICENSE
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
