### PR TITLE
webkit2gtk: update to 2.38.1.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -541,6 +541,10 @@ libgnome-panel.so.0 gnome-panel-3.37.1_1
 libuninum.so.5 libuninum-2.7_1
 libwebkit2gtk-4.0.so.37 webkit2gtk-2.6.2_1
 libjavascriptcoregtk-4.0.so.18 webkit2gtk-2.6.2_1
+libwebkit2gtk-4.1.so.0 libwebkit2gtk41-2.38.0_1
+libjavascriptcoregtk-4.1.so.0 libwebkit2gtk41-2.38.0_1
+libwebkit2gtk-5.0.so.0 libwebkit2gtk50-2.38.0_1
+libjavascriptcoregtk-5.0.so.0 libwebkit2gtk50-2.38.0_1
 libgimp-2.0.so.0 libgimp-2.10.0_1
 libgimpwidgets-2.0.so.0 libgimp-2.10.0_1
 libgimpui-2.0.so.0 libgimp-2.10.0_1

--- a/srcpkgs/libwebkit2gtk41
+++ b/srcpkgs/libwebkit2gtk41
@@ -1,0 +1,1 @@
+webkit2gtk

--- a/srcpkgs/libwebkit2gtk41-devel
+++ b/srcpkgs/libwebkit2gtk41-devel
@@ -1,0 +1,1 @@
+webkit2gtk

--- a/srcpkgs/libwebkit2gtk50
+++ b/srcpkgs/libwebkit2gtk50
@@ -1,0 +1,1 @@
+webkit2gtk

--- a/srcpkgs/libwebkit2gtk50-devel
+++ b/srcpkgs/libwebkit2gtk50-devel
@@ -1,0 +1,1 @@
+webkit2gtk

--- a/srcpkgs/webkit2gtk-common
+++ b/srcpkgs/webkit2gtk-common
@@ -1,0 +1,1 @@
+webkit2gtk

--- a/srcpkgs/webkit2gtk/patches/be-typedarray.patch
+++ b/srcpkgs/webkit2gtk/patches/be-typedarray.patch
@@ -165,42 +165,42 @@ diff --git a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunct
 index df0435f6..3017563c 100644
 --- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
 +++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
-@@ -213,9 +213,36 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncIncludes(VM& vm, JSGl
-     scope.assertNoExceptionExceptTermination();
+@@ -351,9 +351,36 @@ ALWAYS_INLINE EncodedJSValue genericType
      RELEASE_ASSERT(!thisObject->isDetached());
  
--    if (std::isnan(static_cast<double>(*targetOption))) {
-+    double targetOptionLittleEndianAsDouble;
+     if constexpr (ViewClass::Adaptor::isFloat) {
+-        if (std::isnan(static_cast<double>(*targetOption))) {
++        double targetOptionLittleEndianAsDouble;
 +#if CPU(BIG_ENDIAN)
-+    switch (ViewClass::TypedArrayStorageType) {
-+    case TypeFloat32:
-+    case TypeFloat64:
-+        targetOptionLittleEndianAsDouble = static_cast<double>(*targetOption);
-+    default:
-+        // typed array views are commonly expected to be little endian views of the underlying data
-+        targetOptionLittleEndianAsDouble = static_cast<double>(flipBytes(*targetOption));
-+    }
++        switch (ViewClass::TypedArrayStorageType) {
++        case TypeFloat32:
++        case TypeFloat64:
++            targetOptionLittleEndianAsDouble = static_cast<double>(*targetOption);
++        default:
++            // typed array views are commonly expected to be little endian views of the underlying data
++            targetOptionLittleEndianAsDouble = static_cast<double>(flipBytes(*targetOption));
++        }
 +#else
-+    targetOptionLittleEndianAsDouble = static_cast<double>(*targetOption);
++        targetOptionLittleEndianAsDouble = static_cast<double>(*targetOption);
 +#endif
 +
-+    if (std::isnan(targetOptionLittleEndianAsDouble)) {
-         for (; index < length; ++index) {
--            if (std::isnan(static_cast<double>(array[index])))
-+            double arrayElementLittleEndianAsDouble;
++        if (std::isnan(targetOptionLittleEndianAsDouble)) {
+             for (; index < length; ++index) {
+-                if (std::isnan(static_cast<double>(array[index])))
++                double arrayElementLittleEndianAsDouble;
 +#if CPU(BIG_ENDIAN)
-+            switch (ViewClass::TypedArrayStorageType) {
-+            case TypeFloat32:
-+            case TypeFloat64:
-+                arrayElementLittleEndianAsDouble = static_cast<double>(array[index]);
-+            default:
-+                // typed array views are commonly expected to be little endian views of the underlying data
-+                arrayElementLittleEndianAsDouble = static_cast<double>(flipBytes(array[index]));
-+            }
++                switch (ViewClass::TypedArrayStorageType) {
++                case TypeFloat32:
++                case TypeFloat64:
++                    arrayElementLittleEndianAsDouble = static_cast<double>(array[index]);
++                default:
++                    // typed array views are commonly expected to be little endian views of the underlying data
++                    arrayElementLittleEndianAsDouble = static_cast<double>(flipBytes(array[index]));
++                }
 +#else
-+            arrayElementLittleEndianAsDouble = static_cast<double>(array[index]);
++                arrayElementLittleEndianAsDouble = static_cast<double>(array[index]);
 +#endif
-+            if (std::isnan(arrayElementLittleEndianAsDouble))
-                 return JSValue::encode(jsBoolean(true));
-         }
-     } else {
++                if (std::isnan(arrayElementLittleEndianAsDouble))
+                     return JSValue::encode(jsBoolean(true));
+             }
+             return JSValue::encode(jsBoolean(false));

--- a/srcpkgs/webkit2gtk/patches/fix_armv6l.patch
+++ b/srcpkgs/webkit2gtk/patches/fix_armv6l.patch
@@ -4,9 +4,9 @@ and https://bugs.webkit.org/show_bug.cgi?id=141288
 
 --- a/Source/JavaScriptCore/offlineasm/arm.rb	2015-07-22 14:37:57.000000000 +0200
 +++ b/Source/JavaScriptCore/offlineasm/arm.rb	2015-08-08 00:31:21.011824644 +0200
-@@ -546,8 +546,16 @@
-                 $asm.puts "mov #{armFlippedOperands(operands)}"
-             end
+@@ -756,8 +756,16 @@ class Instruction
+             armMoveImmediate(operands[0].value >> 32, operands[1])
+             armMoveImmediate(operands[0].value & 0xffffffff, operands[2])
          when "mvlbl"
 +            if isARMv7 or isARMv7Traditional
                  $asm.puts "movw #{operands[1].armOperand}, \#:lower16:#{operands[0].value}"
@@ -18,6 +18,6 @@ and https://bugs.webkit.org/show_bug.cgi?id=141288
 +                $asm.puts ".equ #{const_label}, (#{operands[0].value})"
 +                $asm.puts "ldr  #{operands[1].armOperand}, =#{const_label}"
 +            end
-         when "nop"
-             $asm.puts "nop"
-         when "bieq", "bpeq", "bbeq"
+         when "sxb2i"
+             $asm.puts "sxtb #{armFlippedOperands(operands)}"
+         when "sxh2i"

--- a/srcpkgs/webkit2gtk/patches/reproducible.patch
+++ b/srcpkgs/webkit2gtk/patches/reproducible.patch
@@ -21,10 +21,10 @@ diff --git a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm b/Source/WebCore
 index be5a5d51..becb2b2f 100644
 --- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
 +++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
-@@ -3163,7 +3163,7 @@ sub GenerateHeader
-     if (%structureFlags) {
-         push(@headerContent, "public:\n");
-         push(@headerContent, "    static constexpr unsigned StructureFlags = Base::StructureFlags");
+@@ -3217,7 +3217,7 @@ sub GenerateHeader
+         } else {
+             push(@headerContent, "    static constexpr unsigned StructureFlags = Base::StructureFlags");
+         }
 -        foreach my $structureFlag (sort (keys %structureFlags)) {
 +        foreach my $structureFlag (sort (sort keys %structureFlags)) {
              push(@headerContent, " | " . $structureFlag);

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,14 +1,13 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
-version=2.36.7
+version=2.38.1
 revision=1
 wrksrc="webkitgtk-${version}"
 build_style=cmake
 build_helper="gir"
 configure_args="-DPORT=GTK -DUSE_LD_GOLD=OFF
  -DCMAKE_LINKER=${XBPS_CROSS_TRIPLET}-gcc -DCMAKE_SKIP_RPATH=ON
- -DENABLE_JOURNALD_LOG=OFF -DUSE_WOFF2=ON -DUSE_SOUP2=ON
- -DENABLE_GTKDOC=OFF -DUSE_WPE_RENDERER=ON
+ -DENABLE_JOURNALD_LOG=OFF -DUSE_WOFF2=ON -DUSE_WPE_RENDERER=ON
  -DENABLE_MINIBROWSER=$(vopt_if minibrowser ON OFF)
  -DENABLE_JIT=$(vopt_if jit ON OFF)
  -DENABLE_C_LOOP=$(vopt_if jit OFF ON)
@@ -19,24 +18,25 @@ configure_args="-DPORT=GTK -DUSE_LD_GOLD=OFF
  -DENABLE_BUBBLEWRAP_SANDBOX=$(vopt_if bubblewrap ON OFF)"
 # Don't remove which from hostmakedepends
 # Otherwise, they invoke /usr/bin/ccache /usr/lib/ccache/bin/$CC
-hostmakedepends="perl python pkg-config gperf flex ruby gettext glib-devel
- geoclue2 libharfbuzz which libpsl
+hostmakedepends="perl python3 pkg-config gperf flex ruby gettext glib-devel
+ geoclue2 libharfbuzz which libpsl gi-docgen
  $(vopt_if wayland 'wayland-devel libxml2-devel')"
 makedepends="at-spi2-core-devel libjpeg-turbo-devel libpng-devel
  harfbuzz-devel gst-plugins-base1-devel gst-plugins-bad1-devel sqlite-devel
- libsoup-devel libxslt-devel gnutls-devel icu-devel enchant2-devel
- dbus-glib-devel libwebp-devel gtk+-devel gtk+3-devel libgudev-devel
+ libsoup-devel libsoup3-devel libxslt-devel gnutls-devel icu-devel enchant2-devel
+ dbus-glib-devel libwebp-devel gtk+3-devel gtk4-devel libgudev-devel
  libsecret-devel ruby-devel geoclue2-devel libnotify-devel hyphen-devel
  woff2-devel freetype-devel libopenjpeg2-devel libatomic-devel
  qt5-devel libmanette-devel libwpe-devel wpebackend-fdo-devel
  libgcrypt-devel libnuspell-devel libpsl-devel $(vopt_if x11 libXt-devel)
  $(vopt_if wayland 'MesaLib-devel libxkbcommon-devel wayland-devel wayland-protocols')"
+depends="webkit2gtk-common"
 short_desc="GTK+3 port of the WebKit2 browser engine"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-2-Clause"
 homepage="https://webkitgtk.org/"
-distfiles="${homepage}/releases/webkitgtk-${version}.tar.xz"
-checksum=0c260cf2b32f0481d017670dfed1b61e554967cd067195606c9f9eb5fe731743
+distfiles="https://webkitgtk.org/releases/webkitgtk-${version}.tar.xz"
+checksum=02e195b3fb9e057743b3364ee7f1eec13f71614226849544c07c32a73b8f1848
 make_check=no
 
 build_options="gir wayland x11 bubblewrap jit sampling_profiler minibrowser
@@ -132,7 +132,30 @@ pre_configure() {
 	esac
 }
 
+post_configure() {
+	mkdir -p webkit2gtk-40 webkit2gtk-50
+	(
+		cd webkit2gtk-40
+		configure_args="${configure_args} -DUSE_SOUP2=ON -DENABLE_WEBDRIVER=OFF" \
+		do_configure
+	)
+
+	(
+		cd webkit2gtk-50
+		configure_args="${configure_args} -DUSE_GTK4=ON -DENABLE_WEBDRIVER=OFF" \
+		do_configure
+	)
+}
+
+post_build() {
+	(cd webkit2gtk-40 && NINJA_STATUS="[2/3][%f/%t] " do_build)
+	(cd webkit2gtk-50 && NINJA_STATUS="[3/3][%f/%t] " do_build)
+}
+
 post_install() {
+	(cd webkit2gtk-40 && do_install)
+	(cd webkit2gtk-50 && do_install)
+
 	vlicense Source/WebCore/LICENSE-APPLE
 	vlicense Source/WebCore/LICENSE-LGPL-2.1
 	vlicense Source/WebCore/LICENSE-LGPL-2
@@ -142,11 +165,75 @@ webkit2gtk-devel_package() {
 	depends="gtk+3-devel libsoup-devel ${sourcepkg}>=${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
-		vmove usr/include
-		vmove usr/lib/pkgconfig
+		vmove usr/include/webkitgtk-4.0
+		vmove "usr/lib/pkgconfig/*-4.0.pc"
 		if [ "$build_option_gir" ]; then
-			vmove usr/share/gir-1.0
+			vmove "usr/share/gir-1.0/*-4.0.gir"
+			vmove "usr/share/gtk-doc/html/*-4.0"
 		fi
-		vmove "usr/lib/*.so"
+		vmove "usr/lib/*-4.0.so"
+	}
+}
+
+webkit2gtk-common_package() {
+	short_desc="GTK port of the WebKit2 browser engine - common files"
+	pkg_install() {
+		vmove usr/share/locale/
+		vmove usr/share/licenses/
+	}
+}
+
+libwebkit2gtk41_package() {
+	depends="${depends}"
+	short_desc="GTK+3 port of the WebKit2 browser engine (soup3)"
+	pkg_install() {
+		vmove usr/bin/WebKitWebDriver
+		vmove usr/libexec/webkit2gtk-4.1
+		vmove usr/lib/webkit2gtk-4.1
+		if [ "$build_option_gir" ]; then
+			vmove "usr/lib/girepository-1.0/*-4.1.typelib"
+		fi
+		vmove "usr/lib/*-4.1.so.*"
+	}
+}
+
+libwebkit2gtk41-devel_package() {
+	depends="gtk+3-devel libsoup3-devel libwebkit2gtk41>=${version}_${revision}"
+	short_desc="GTK+3 port of the WebKit2 browser engine (soup3) - development files"
+	pkg_install() {
+		vmove usr/include/webkitgtk-4.1
+		vmove "usr/lib/pkgconfig/*-4.1.pc"
+		if [ "$build_option_gir" ]; then
+			vmove "usr/share/gir-1.0/*-4.1.gir"
+			vmove "usr/share/gtk-doc/html/*-4.1"
+		fi
+		vmove "usr/lib/*-4.1.so"
+	}
+}
+
+libwebkit2gtk50_package() {
+	depends="${depends}"
+	short_desc="GTK4 port of the WebKit2 browser engine"
+	pkg_install() {
+		vmove usr/libexec/webkit2gtk-5.0
+		vmove usr/lib/webkit2gtk-5.0
+		if [ "$build_option_gir" ]; then
+			vmove "usr/lib/girepository-1.0/*-5.0.typelib"
+		fi
+		vmove "usr/lib/*-5.0.so.*"
+	}
+}
+
+libwebkit2gtk50-devel_package() {
+	depends="gtk4-devel libsoup3-devel libwebkit2gtk50>=${version}_${revision}"
+	short_desc="GTK4 port of the WebKit2 browser engine - development files"
+	pkg_install() {
+		vmove usr/include/webkitgtk-5.0
+		vmove "usr/lib/pkgconfig/*-5.0.pc"
+		if [ "$build_option_gir" ]; then
+			vmove "usr/share/gir-1.0/*-5.0.gir"
+			vmove "usr/share/gtk-doc/html/*-5.0"
+		fi
+		vmove "usr/lib/*-5.0.so"
 	}
 }


### PR DESCRIPTION
[ci skip]

This splits webkit2gtk into 3 packages:
+ webkit2gtk40: GTK+3 and libsoup2
+ webkit2gtk41: GTK+3 and libsoup3
+ webkit2gtk50: GTK4 and libsoup3

This is necessary since libsoup2 and libsoup3 cannot be used by an application at the same time.
Ideally in the future, the packages using webkit2gtk40 would be moved to webkit2gtk41 or 50 (or be dropped).

I tested this PR with epiphany 42 and it seems to work (and it compiles sucessfully).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
