### PR TITLE
routinator: update to 0.12.0

### DIFF
--- a/srcpkgs/routinator/template
+++ b/srcpkgs/routinator/template
@@ -1,6 +1,6 @@
 # Template file for 'routinator'
 pkgname=routinator
-version=0.11.2
+version=0.12.0
 revision=1
 build_style=cargo
 depends="rsync"
@@ -11,7 +11,7 @@ homepage="https://rpki.readthedocs.io/"
 changelog="https://raw.githubusercontent.com/NLnetLabs/routinator/main/Changelog.md"
 distfiles="https://github.com/NLnetLabs/routinator/archive/v${version}.tar.gz"
 conf_files="/etc/routinator/routinator.conf"
-checksum=00f825c53168592da0285e8dbd228018e77248d458214a2c0f86cd0ca45438f5
+checksum=e1e517280b3adca7a976c86bc59ea4cc5b6a6c7a0b8ab0166be6e6bff001c698
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;


### PR DESCRIPTION
I also have a draft PR #37848 and would appreciate feedback on if there's anything else that should be done there.

#### Testing the changes
- I tested the changes in this PR: **YES**
Release notes at https://github.com/NLnetLabs/routinator/releases

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc, x86_64-musl)
- I built this PR locally for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl
  - x86_64-musl