### PR TITLE
rizin: update to 0.4.1

### DIFF
--- a/srcpkgs/rizin/template
+++ b/srcpkgs/rizin/template
@@ -1,6 +1,6 @@
 # Template file for 'rizin'
 pkgname=rizin
-version=0.4.0
+version=0.4.1
 revision=1
 wrksrc="${pkgname}-v${version}"
 build_style=meson
@@ -16,7 +16,7 @@ maintainer="Urs Schulz <voidpkgs@ursschulz.de>"
 license="LGPL-3.0-only"
 homepage="https://github.com/rizinorg/rizin"
 distfiles="https://github.com/rizinorg/${pkgname}/releases/download/v${version}/${pkgname}-src-v${version}.tar.xz"
-checksum=09eba8684fe813cf42a716b59a86d3d65afce013d7e8b275e145e849d3366b5a
+checksum=669d956b997820a36e423cf35d482aa99849254b9658cef6844459912dfdbfb8
 # requires some external files, not clear where they come from
 make_check=no
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **NO**


Rizin 0.4.1 is a security fix release:
- https://github.com/rizinorg/rizin/releases/tag/v0.4.1
- https://repology.org/project/rizin/versions