### PR TITLE
New package: cpux-4.4.0

### DIFF
--- a/srcpkgs/cpux/template
+++ b/srcpkgs/cpux/template
@@ -1,0 +1,16 @@
+# Template file for 'cpux'
+pkgname=cpux
+version=4.4.0
+revision=1
+wrksrc=CPU-X-${version}
+build_style=cmake
+configure_args="-DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release"
+hostmakedepends="pkg-config automake cmake gtk+3 libcpuid libtool ncurses procps-ng "
+makedepends="pkg-config automake cmake gtk+3 gtk+3-devel libcpuid libcpuid-devel libtool ncurses procps-ng procps-ng-devel"
+short_desc="CPU-X gathers information on CPU, motherboard and more"
+maintainer="Orphaned <orphan@voidlinux.org>"
+license="GPL-3.0-or-later"
+homepage="https://x0rg.github.io/CPU-X/"
+distfiles="https://github.com/X0rg/CPU-X/archive/refs/tags/v${version}.tar.gz"
+checksum=5d895ffa80c344cb6887d3fef7d833d20f367a74e35b79dc3f291c2496f060d9
+nopie=yes


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

![cpux_about](https://user-images.githubusercontent.com/8009811/193115449-572358a3-56cf-4459-9849-e3b5dc2aaaee.png)

Did not test 'daemon' only basic CPU info.

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture **x86_64**


#### unsure

- License is `GPL-3.0`, put `-or-later`
- are cmake config args redundant?
- added `nopie=yes` for cpu-x-daemon
