### PR TITLE
rtl8812au-dkms: update to 20210629.

### DIFF
--- a/srcpkgs/rtl8812au-dkms/template
+++ b/srcpkgs/rtl8812au-dkms/template
@@ -1,17 +1,17 @@
 # Template file for 'rtl8812au-dkms'
 pkgname=rtl8812au-dkms
-version=20210427
+version=20210629
 revision=1
-_modver=5.9.3.2
-_gitrev=6ef5d8fcdb0b94b7490a9a38353877708fca2cd4
-wrksrc="rtl8812au-${_modver}-${_gitrev}"
+_modver=5.13.6
+_gitrev=a8450b030a187b71d6be147d004715e6858e0ef9
+wrksrc="8812au-${version}-${_gitrev}"
 depends="dkms"
 short_desc="Realtek 8812AU/8821AU USB WiFi driver (DKMS)"
 maintainer="Renato Aguiar <renato@renag.me>"
 license="GPL-2.0-only"
-homepage="http://www.dlink.com"
-distfiles="https://github.com/gordboy/rtl8812au-${_modver}/archive/${_gitrev}.tar.gz"
-checksum=72b04bb7e1ef01eae653222d6f75f71163f7442fa142198605ed495f30341bd9
+homepage="https://github.com/morrownr/8812au"
+distfiles="https://github.com/morrownr/8812au-${version}/archive/${_gitrev}.tar.gz"
+checksum=a4ebed285b4315284c2ccdeaec1ba12aa6a66d9772b7416c81f055d3ab6f9bb8
 dkms_modules="rtl8812au ${_modver}"
 
 case "$XBPS_TARGET_MACHINE" in

--- a/srcpkgs/rtl8812au-dkms/update
+++ b/srcpkgs/rtl8812au-dkms/update
@@ -1,0 +1,2 @@
+site="https://github.com/morrownr/8812au"
+pattern='8812au-\K[\d.]+(?=">)'


### PR DESCRIPTION
Old upstream stated their version was now obselete, and directed to this new upstream.

The old version also relied on headers that do not exist in 5.15+

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (dkms module builds, don't have the hardware)

@tsjk can you test this?
