### PR TITLE
.github/workflows/stale.yml: update to v6

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v6
         with:
           stale-issue-message: 'Issues become stale 90 days after last activity and are closed 14 days after that.  If this issue is still relevant bump it or assign it.'
           stale-pr-message: 'Pull Requests become stale 90 days after last activity and are closed 14 days after that.  If this pull request is still relevant bump it or assign it.'


### PR DESCRIPTION
This fixes a bug where a stale issue/PR that gets updated without a comment remains stale indefinitely and never gets closed (actions/stale#715).

The only "breaking" change in that update is that the default close reason has changed to "not planned". That seems like a more desirable default anyways.

A current example of the bug can be found in #37283.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
