### PR TITLE
neovim: update to 0.8.0.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -2483,7 +2483,7 @@ libi3ipc-glib-1.0.so.0 i3ipc-glib-0.6.0_1
 libcsound64.so.6.0 csound-6.05.0_1
 libcsnd6.so.6.0 csound-6.05.0_1
 libfko.so.3 libfko-2.6.9_1
-libvterm.so.0 libvterm-0.0.20151005_1
+libvterm.so.0 libvterm-0.3_1
 libboinc_opencl.so.7 boinc-7.16.16_2
 libboinc_api.so.7 boinc-7.16.16_2
 libboinc_graphics2.so.7 boinc-7.16.16_2

--- a/srcpkgs/libvterm/template
+++ b/srcpkgs/libvterm/template
@@ -1,6 +1,6 @@
 # Template file for 'libvterm'
 pkgname=libvterm
-version=0.1.4
+version=0.3
 revision=1
 build_style=gnu-makefile
 make_install_target="install-lib install-inc"
@@ -8,9 +8,9 @@ hostmakedepends="libtool perl pkg-config"
 short_desc="Abstract VT220/xterm/ECMA-48 emulation library"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="MIT"
-homepage="http://www.leonerd.org.uk/code/libvterm"
-distfiles="http://www.leonerd.org.uk/code/libvterm/libvterm-${version}.tar.gz"
-checksum=bc70349e95559c667672fc8c55b9527d9db9ada0fb80a3beda533418d782d3dd
+homepage="https://www.leonerd.org.uk/code/libvterm"
+distfiles="https://www.leonerd.org.uk/code/libvterm/libvterm-${version}.tar.gz"
+checksum=61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358
 
 post_extract() {
 	if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/neovim/template
+++ b/srcpkgs/neovim/template
@@ -1,6 +1,6 @@
 # Template file for 'neovim'
 pkgname=neovim
-version=0.7.2
+version=0.8.0
 revision=1
 build_style=cmake
 build_helper="qemu"
@@ -8,13 +8,12 @@ configure_args="-DCMAKE_BUILD_TYPE=Release -DCOMPILE_LUA=OFF"
 hostmakedepends="pkg-config gettext gperf LuaJIT lua51-lpeg lua51-mpack"
 makedepends="libtermkey-devel libuv-devel libvterm-devel msgpack-devel
  LuaJIT-devel libluv-devel tree-sitter-devel"
-depends="libvterm>=0.1.0"
 short_desc="Fork of Vim aiming to improve user experience, plugins and GUIs"
 maintainer="Steve Prybylski <sa.prybylx@gmail.com>"
 license="Apache-2.0, custom:Vim"
 homepage="https://neovim.io"
 distfiles="https://github.com/neovim/neovim/archive/v${version}.tar.gz"
-checksum=ccab8ca02a0c292de9ea14b39f84f90b635a69282de38a6b4ccc8565bc65d096
+checksum=505e3dfb71e2f73495c737c034a416911c260c0ba9fd2092c6be296655be4d18
 
 alternatives="
  vi:vi:/usr/bin/nvim


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

Neovim now requires [libvterm-0.3](https://github.com/neovim/neovim/pull/20222) to build. Only one other package, `liteide`, depends on it which built successfully for me on top of the update.