### PR TITLE
New package: element-web-1.11.13

### DIFF
--- a/srcpkgs/element-web/template
+++ b/srcpkgs/element-web/template
@@ -1,0 +1,21 @@
+# Template file for 'element-web'
+pkgname=element-web
+version=1.11.13
+revision=1
+wrksrc="element-v${version}"
+conf_files="/etc/webapps/element/config.json"
+short_desc="Glossy Matrix collaboration client - web version"
+maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
+license="Apache-2.0"
+homepage="https://element.io"
+changelog="https://raw.githubusercontent.com/vector-im/element-web/develop/CHANGELOG.md"
+distfiles="https://github.com/vector-im/element-web/releases/download/v${version}/element-v${version}.tar.gz"
+checksum=b76af344abef9059a6a16476e866e37d8f808bff1f38cd47fcf83eb4f1daa2da
+
+do_install() {
+	vmkdir usr/share/webapps/element
+	vcopy . /usr/share/webapps/element
+	vsconf config.sample.json
+	vinstall config.sample.json 644 /etc/webapps/element/ config.json
+	ln -s /etc/webapps/element/config.json "${DESTDIR}"/usr/share/webapps/element/config.json
+}


### PR DESCRIPTION
~Move element-desktop, riot-desktop to subpackage of element-web~

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

I've had `element-desktop` installed on my server and just pointing reverse proxy at `/usr/lib/element-desktop/resources/webapp`, but I also had to `ignorepkg` all of the dependencies. This fixes that :)

~I didn't bump the revision since there aren't any functional changes to `element-desktop`, but I can if needed.~