### PR TITLE
python3-certifi: update to 2022.09.24.

### DIFF
--- a/srcpkgs/python3-certifi/template
+++ b/srcpkgs/python3-certifi/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-certifi'
 pkgname=python3-certifi
-version=2022.06.15
+version=2022.09.24
 revision=1
 wrksrc="python-certifi-${version}"
 build_style=python3-module
@@ -11,7 +11,7 @@ maintainer="Karl Nilsson <karl.robert.nilsson@gmail.com>"
 license="MPL-2.0"
 homepage="https://certifi.io"
 distfiles="https://github.com/certifi/python-certifi/archive/${version}.tar.gz"
-checksum=3ece28ce4177241cd9f752ef5161cd2c67060b80c73c6bcbdab48e504f9df966
+checksum=8c1db7f2a3b272e8a90b2e1910763930fa81e2512fbb96cb7a25787d63765c78
 
 do_check() {
 	cd build/lib


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

- I built this PR locally for my native architecture, x64-glibc
