### PR TITLE
xwinwrap-0.9: update checksum

### DIFF
--- a/srcpkgs/xwinwrap/template
+++ b/srcpkgs/xwinwrap/template
@@ -9,7 +9,7 @@ maintainer="SolitudeSF <solitudesf@protonmail.com>"
 license="MIT"
 homepage="https://github.com/mmhobi7/xwinwrap"
 distfiles="${homepage}/archive/v${version}.tar.gz"
-checksum=0e840586deaf6780d426dc49f7a344366198aead96535cc1eb2ac7ce366777df
+checksum=1792f59c5d85fc766f356f8f903a2081fe4dccc5e8e61cdd946bae0438d15d9a
 
 pre_install() {
 	vsed -i Makefile -e 's|/local||'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Updated checksum per IR #39072. added grep make depend to build.

#### Testing the changes
- I tested the changes in this PR: briefly

#### Local build testing
- I built this PR locally for my native architecture, X86_64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  i686
  x86_64-musl
  armv6l
  armv6l-musl
  aarch64
  aarch64-musl
  ppe64le
  ppe64le-musl
