### PR TITLE
CPU-X: disable tests, don't break base-chroot

### DIFF
--- a/srcpkgs/CPU-X/template
+++ b/srcpkgs/CPU-X/template
@@ -8,7 +8,6 @@ hostmakedepends="pkg-config nasm"
 makedepends="ncurses-devel gettext-devel libcpuid-devel pciutils-devel
  glfw-devel ocl-icd-devel procps-ng-devel libstatgrab
  $(vopt_if gtk3 gtk+3-devel)"
-checkdepends="mawk nawk grep"
 short_desc="Free software that gathers information on CPU, motherboard and more"
 maintainer="Subhaditya Nath <sn03.general@gmail.com>"
 license="GPL-3.0-or-later"
@@ -18,15 +17,11 @@ distfiles="https://github.com/X0rg/CPU-X/archive/v${version}.tar.gz"
 checksum=6ad7a8ac2d6c687a38a895fbbfbf2de690311676ac374d5857588bb983839433
 build_options="gtk3"
 build_options_default="gtk3"
+# needs grep -P which is not available in chroot-grep and replacing it with
+# grep breaks base-chroot
+make_check=no
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	makedepends+=" libexecinfo-devel"
 	LDFLAGS="-lexecinfo"
-fi
-
-# Tests depend on the -P flag of grep, which is not available in chroot-grep
-# and installing grep as checkdepends breaks base-chroot.
-# So, only run tests in CI, where the masterdir is ephemeral anyway.
-if [ "$XBPS_BUILD_ENVIRONMENT" != "void-packages-ci" ]; then
-	make_check=no	# breaks base-chroot
 fi


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

related to #39577
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
