### PR TITLE
cmt: update to 1.18 and make it buildable

### DIFF
--- a/srcpkgs/cmt/template
+++ b/srcpkgs/cmt/template
@@ -1,7 +1,7 @@
 # Template file for 'cmt'
 pkgname=cmt
-version=1.17
-revision=2
+version=1.18
+revision=1
 build_wrksrc="src"
 build_style=gnu-makefile
 make_use_env=yes
@@ -9,9 +9,9 @@ makedepends="ladspa-sdk"
 short_desc="LADSPA plugins for use with software synthesis and recording packages"
 maintainer="Olga Ustuzhanina <me@laserbat.pw>"
 license="GPL-2.0-or-later"
-homepage="http://www.ladspa.org/cmt/overview.html"
-distfiles="http://www.ladspa.org/download/${pkgname}_${version}.tgz"
-checksum=eb56d7abebfdf8a6d0ad65d012238c9fc394dd41eeca11900812a8cb6b07ad1f
+homepage="https://www.ladspa.org/cmt/overview.html"
+distfiles="https://www.ladspa.org/download/${pkgname}_${version}.tgz"
+checksum=a82f8636de1f4ada386a199a017a9cd775a49b49e716b11e8dd3f723c93df6ca
 
 post_extract() {
 	sed -e "/^CFLAGS/ s/-O2/${CFLAGS}/" \


### PR DESCRIPTION
The 1.17 version doesn't build:
```
=> xbps-src: updating repositories for host (x86_64)...
[*] Updating repository `https://repo-default.voidlinux.org/current/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/nonfree/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/debug/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/x86_64-repodata' ...
[*] Updating repository `https://repo-default.voidlinux.org/current/multilib/nonfree/x86_64-repodata' ...
=> xbps-src: updating software in / masterdir...
=> xbps-src: cleaning up / masterdir...
=> cmt-1.17_2: removing autodeps, please wait...
=> cmt-1.17_2: building [gnu-makefile] for x86_64...
   [target] ladspa-sdk-1.15_3: found (https://repo-default.voidlinux.org/current)
=> cmt-1.17_2: installing target dependencies: ladspa-sdk-1.15_3 ...
=> cmt-1.17_2: running do-fetch hook: 00-distfiles ...
=> cmt-1.17_2: fetching distfile 'cmt_1.17.tgz' from 'http://www.ladspa.org/download/cmt_1.17.tgz'...
http://www.ladspa.org/download/cmt_1.17.tgz: Not Found
=> ERROR: cmt-1.17_2: failed to fetch 'cmt_1.17.tgz'.
```

#### Testing the changes
- I tested the changes in this PR: **NO**