### PR TITLE
gnome: remove gnome-recipes from -apps

### DIFF
--- a/srcpkgs/gnome/template
+++ b/srcpkgs/gnome/template
@@ -1,7 +1,7 @@
 # Template file for 'gnome'
 pkgname=gnome
 version=42.0
-revision=4
+revision=5
 build_style=meta
 short_desc="GNOME meta-package for Void Linux"
 maintainer="Michal Vasilek <michal@vasilek.cz>"
@@ -61,7 +61,6 @@ _apps_depends="
  gnome-music>=${version}
  gnome-nettool>=${version}
  gnome-photos>=${version}
- gnome-recipes>=2.0.4
  gnome-screenshot>=41.0
  gnome-sound-recorder>=${version}
  gnome-system-monitor>=${version}


### PR DESCRIPTION
gnome-recipes is not regularly maintained and doesn't might be removed soon because of incompatibility with modern versions of libraries like libsoup 3 and rest 1.0.