### PR TITLE
pkg-config: remove unused bootstrap=yes

### DIFF
--- a/srcpkgs/pkg-config/template
+++ b/srcpkgs/pkg-config/template
@@ -2,7 +2,6 @@
 pkgname=pkg-config
 version=0.29.2
 revision=3
-bootstrap=yes
 build_style=gnu-configure
 configure_args="--with-internal-glib --disable-host-tool"
 short_desc="System for managing library compile/link flags"


### PR DESCRIPTION
all bootstrap packages use pkgconf, so having pkg-config marked with bootstrap=yes doesn't make sense