### PR TITLE
freecad: evade vsed strict mode for flaky version info

### DIFF
--- a/srcpkgs/freecad/template
+++ b/srcpkgs/freecad/template
@@ -44,9 +44,10 @@ fi
 
 post_extract() {
 	# Report exact minor version
+	# Freecad has a record of shipping mismatching version info
 	vminor=${version#*.}
 	vminor=${vminor%%.*}
-	vsed -i -e "s,^\(set(PACKAGE_VERSION_MINOR\) .*,\1 \"${vminor}\")," CMakeLists.txt
+	sed -i -e "s,^\(set(PACKAGE_VERSION_MINOR\) .*,\1 \"${vminor}\")," CMakeLists.txt
 
 	# SubWCRev.py (SCM check) reports "unknown" for these fields
 	vsed -e "s,\${PACKAGE_WCREF},${revision}_voidlinux," \


### PR DESCRIPTION
to fix CI and help https://github.com/void-linux/void-packages/pull/36356/ build correctly