### PR TITLE
hackrf: fix udev rules directory

### DIFF
--- a/srcpkgs/hackrf/patches/fix-device-acess-via-elogind.patch
+++ b/srcpkgs/hackrf/patches/fix-device-acess-via-elogind.patch
@@ -1,0 +1,24 @@
+enable device access via elogind
+
+--- a/host/libhackrf/53-hackrf.rules.in
++++ b/host/libhackrf/53-hackrf.rules.in
+@@ -1,13 +1,13 @@
+ # HackRF Jawbreaker
+-ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-jawbreaker-%k", MODE="660", GROUP="@HACKRF_GROUP@"
++ATTR{idVendor}=="1d50", ATTR{idProduct}=="604b", SYMLINK+="hackrf-jawbreaker-%k", MODE="660", GROUP="@HACKRF_GROUP@", TAG+="uaccess"
+ # HackRF One
+-ATTR{idVendor}=="1d50", ATTR{idProduct}=="6089", SYMLINK+="hackrf-one-%k", MODE="660", GROUP="@HACKRF_GROUP@"
++ATTR{idVendor}=="1d50", ATTR{idProduct}=="6089", SYMLINK+="hackrf-one-%k", MODE="660", GROUP="@HACKRF_GROUP@", TAG+="uaccess"
+ # rad1o
+-ATTR{idVendor}=="1d50", ATTR{idProduct}=="cc15", SYMLINK+="rad1o-%k", MODE="660", GROUP="@HACKRF_GROUP@"
++ATTR{idVendor}=="1d50", ATTR{idProduct}=="cc15", SYMLINK+="rad1o-%k", MODE="660", GROUP="@HACKRF_GROUP@", TAG+="uaccess"
+ # NXP Semiconductors DFU mode (HackRF and rad1o)
+-ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", MODE="660", GROUP="@HACKRF_GROUP@"
++ATTR{idVendor}=="1fc9", ATTR{idProduct}=="000c", SYMLINK+="nxp-dfu-%k", MODE="660", GROUP="@HACKRF_GROUP@", TAG+="uaccess"
+ # rad1o "full flash" mode
+-KERNEL=="sd?", SUBSYSTEM=="block", ENV{ID_VENDOR_ID}=="1fc9", ENV{ID_MODEL_ID}=="0042", SYMLINK+="rad1o-flash-%k", MODE="660", GROUP="@HACKRF_GROUP@"
++KERNEL=="sd?", SUBSYSTEM=="block", ENV{ID_VENDOR_ID}=="1fc9", ENV{ID_MODEL_ID}=="0042", SYMLINK+="rad1o-flash-%k", MODE="660", GROUP="@HACKRF_GROUP@", TAG+="uaccess"
+ # rad1o flash disk
+-KERNEL=="sd?", SUBSYSTEM=="block", ENV{ID_VENDOR_ID}=="1fc9", ENV{ID_MODEL_ID}=="0082", SYMLINK+="rad1o-msc-%k", MODE="660", GROUP="@HACKRF_GROUP@"
++KERNEL=="sd?", SUBSYSTEM=="block", ENV{ID_VENDOR_ID}=="1fc9", ENV{ID_MODEL_ID}=="0082", SYMLINK+="rad1o-msc-%k", MODE="660", GROUP="@HACKRF_GROUP@", TAG+="uaccess"
+ #

--- a/srcpkgs/hackrf/template
+++ b/srcpkgs/hackrf/template
@@ -1,9 +1,10 @@
 # Template file for 'hackrf'
 pkgname=hackrf
 version=2021.03.1
-revision=1
+revision=2
 build_wrksrc=host
 build_style=cmake
+configure_args="-DUDEV_RULES_PATH=/usr/lib/udev/rules.d/ -Wno-dev"
 hostmakedepends="pkg-config"
 makedepends="libusb-devel fftw-devel"
 _desc="Low cost software defined radio (SDR) platform"
@@ -11,12 +12,8 @@ short_desc="${_desc} - tools"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://greatscottgadgets.com/hackrf/"
-distfiles="https://github.com/mossmann/hackrf/releases/download/v${version}/${pkgname}-${version}.tar.xz"
+distfiles="https://github.com/greatscottgadgets/hackrf/releases/download/v${version}/${pkgname}-${version}.tar.xz"
 checksum=a43e5080c11efdfe69ddebcc35a02b018e30e820de0e0ebdc7948cf7b0cd93a3
-
-pre_configure() {
-	vsed -i 's|MODE="660", GROUP="plugdev"|TAG+="uaccess"|g' libhackrf/53-hackrf.rules
-}
 
 post_install() {
 	for f in ../firmware-bin/*.{bin,dfu}; do
@@ -28,7 +25,7 @@ libhackrf_package() {
 	short_desc="${_desc} - library"
 	pkg_install() {
 		vmove usr/lib/*.so.*
-		vinstall libhackrf/53-hackrf.rules 644 usr/lib/udev/rules.d/
+		vmove usr/lib/udev/rules.d
 	}
 }
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

[39083](https://github.com/void-linux/void-packages/issues/39083)