### PR TITLE
phonon-qt5-backend-gstreamer: add libxml2-devel makedepends

### DIFF
--- a/srcpkgs/phonon-qt5-backend-gstreamer/template
+++ b/srcpkgs/phonon-qt5-backend-gstreamer/template
@@ -7,7 +7,7 @@ build_style=cmake
 configure_args="-DPHONON_BUILD_PHONON4QT5=ON"
 hostmakedepends="pkg-config extra-cmake-modules"
 makedepends="MesaLib-devel qt5-devel phonon-qt5-devel gst-plugins-base1-devel
- gst-plugins-good1-qt5 qt5-x11extras-devel qt5-tools-devel"
+ gst-plugins-good1-qt5 qt5-x11extras-devel qt5-tools-devel libxml2-devel"
 depends="desktop-file-utils hicolor-icon-theme gst-plugins-good1-qt5 gst-libav"
 short_desc="Phonon GStreamer backend"
 maintainer="Duncaen <duncaen@voidlinux.org>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
 
https://github.com/void-linux/void-packages/issues/39083
