### PR TITLE
cargo-outdated: update to 0.11.1.

### DIFF
--- a/srcpkgs/cargo-outdated/template
+++ b/srcpkgs/cargo-outdated/template
@@ -1,24 +1,17 @@
 # Template file for 'cargo-outdated'
 pkgname=cargo-outdated
-version=0.9.9
-revision=3
+version=0.11.1
+revision=1
 build_style=cargo
-hostmakedepends="pkg-config"
+hostmakedepends="pkg-config zlib-devel"
 makedepends="libgit2-devel openssl-devel"
 short_desc="Cargo subcommand for displaying when dependencies are out of date"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/kbknapp/cargo-outdated"
+changelog="https://raw.githubusercontent.com/kbknapp/cargo-outdated/master/CHANGELOG.md"
 distfiles="https://github.com/kbknapp/cargo-outdated/archive/v${version}.tar.gz"
-checksum=f23bb266d0f31316817e6350b4a02a91cbb6b02baa280092bbd9719ebfee31b4
-
-# remove with dependency update to cargo 0.44 or newer
-export LIBGIT2_SYS_USE_PKG_CONFIG=1
-
-pre_build() {
-	cargo update --package openssl-sys --precise 0.9.58
-	cargo update --package openssl --precise 0.10.30
-}
+checksum=2d80f0243d70a3563c48644dd3567519c32a733fb5d20f1161fd5d9f8e6e9146
 
 post_install() {
 	vlicense LICENSE-MIT


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64