### PR TITLE
keyd: update to 2.4.2

### DIFF
--- a/srcpkgs/drumkv1/template
+++ b/srcpkgs/drumkv1/template
@@ -1,6 +1,6 @@
 # Template file for 'drumkv1'
 pkgname=drumkv1
-version=0.9.26
+version=0.9.27
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
@@ -11,5 +11,5 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://drumkv1.sourceforge.io/"
 changelog="https://github.com/rncbc/drumkv1/raw/master/ChangeLog"
-distfiles="https://download.sourceforge.net/drumkv1/drumkv1-${version}.tar.gz"
-checksum=1149811ae195dd08e835d87fa23f644660a7dbda271afab4b57c9ec51eee0548
+distfiles="${SOURCEFORGE_SITE}/drumkv1/drumkv1-${version}.tar.gz"
+checksum=433b247794e6fdf9b32929fb52ee7135808b25b8be19d574a3b6068857f92649

--- a/srcpkgs/keyd/files/keyd/run
+++ b/srcpkgs/keyd/files/keyd/run
@@ -1,2 +1,11 @@
 #!/bin/sh
+
+# Sometimes when starting the keyd service, the keyboard can become unresponsive.
+# This is the result of keyd starting when the early udevd process is still running but
+# before the udevd runit service has started. The udevd runit service kills the early udevd
+# process causing the keyboard to become unresponsive until the keyd process has been
+# terminated. The below code verifies that the supervised udevd process is the same as
+# the currently running udevd process.
+[ "$(cat /var/service/udevd/supervise/pid)" = "$(pgrep -x udevd)" ] || exit 1
+
 exec keyd

--- a/srcpkgs/keyd/template
+++ b/srcpkgs/keyd/template
@@ -1,6 +1,6 @@
 # Template file for 'keyd'
 pkgname=keyd
-version=2.4.1
+version=2.4.2
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -10,7 +10,7 @@ license="MIT"
 homepage="https://github.com/rvaiya/keyd"
 changelog="https://raw.githubusercontent.com/rvaiya/keyd/master/docs/CHANGELOG.md"
 distfiles="https://github.com/rvaiya/keyd/archive/refs/tags/v${version}.tar.gz"
-checksum=23e6eac529b0c07ad99420c2a8a75967b7cadb0c3509284cc0f7633056dc50e2
+checksum=877e1a39efaa062c996856d632d6aeedd409422be6c5bdb2064a9b707293c280
 system_groups="keyd"
 
 post_install() {

--- a/srcpkgs/padthv1/template
+++ b/srcpkgs/padthv1/template
@@ -1,6 +1,6 @@
 # Template file for 'padthv1'
 pkgname=padthv1
-version=0.9.26
+version=0.9.27
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
@@ -11,5 +11,5 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://padthv1.sourceforge.io/"
 changelog="https://github.com/rncbc/padthv1/raw/master/ChangeLog"
-distfiles="https://download.sourceforge.net/padthv1/padthv1-${version}.tar.gz"
-checksum=813f818d6c6c66b403937c66a7729ea85226eab17db0992334441613c903ef0a
+distfiles="${SOURCEFORGE_SITE}/padthv1/padthv1-${version}.tar.gz"
+checksum=a4969fc144d4440ecd81e83ddce535a477cae732f27f479c0d77af085e02b579

--- a/srcpkgs/samplv1/template
+++ b/srcpkgs/samplv1/template
@@ -1,6 +1,6 @@
 # Template file for 'samplv1'
 pkgname=samplv1
-version=0.9.26
+version=0.9.27
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
@@ -11,5 +11,5 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://samplv1.sourceforge.io/"
 changelog="https://github.com/rncbc/samplv1/raw/master/ChangeLog"
-distfiles="https://download.sourceforge.net/samplv1/samplv1-${version}.tar.gz"
-checksum=91b680d97efad89dcb98221b9cc7df733dcc8a437666184ba862c2341c1c1fe7
+distfiles="${SOURCEFORGE_SITE}/samplv1/samplv1-${version}.tar.gz"
+checksum=7ef99b6b7912faf7ba7df937d72a463562249daa96126aad9313158d0b67ad73

--- a/srcpkgs/synthv1/template
+++ b/srcpkgs/synthv1/template
@@ -1,6 +1,6 @@
 # Template file for 'synthv1'
 pkgname=synthv1
-version=0.9.26
+version=0.9.27
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
@@ -10,5 +10,5 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://synthv1.sourceforge.io/"
 changelog="https://github.com/rncbc/synthv1/raw/master/ChangeLog"
-distfiles="https://download.sourceforge.net/synthv1/synthv1-${version}.tar.gz"
-checksum=8d551fc7572feeac2f1676b4a8915e1e20f5a7f2075044335d7bb840069c51ab
+distfiles="${SOURCEFORGE_SITE}/synthv1/synthv1-${version}.tar.gz"
+checksum=6fb3edefad2af719b80cdf890780f4dbac95a14ebdf0a471671f2723cb8b0c8f

--- a/srcpkgs/u-boot-tools/patches/fix-build-with-binutils-2.38.patch
+++ b/srcpkgs/u-boot-tools/patches/fix-build-with-binutils-2.38.patch
@@ -1,0 +1,42 @@
+>From version 2.38, binutils default to ISA spec version 20191213. This
+means that the csr read/write (csrr*/csrw*) instructions and fence.i
+instruction has separated from the `I` extension, become two standalone
+extensions: Zicsr and Zifencei. As the kernel uses those instruction,
+this causes the following build failure:
+
+arch/riscv/cpu/mtrap.S: Assembler messages:
+arch/riscv/cpu/mtrap.S:65: Error: unrecognized opcode `csrr a0,scause'
+arch/riscv/cpu/mtrap.S:66: Error: unrecognized opcode `csrr a1,sepc'
+arch/riscv/cpu/mtrap.S:67: Error: unrecognized opcode `csrr a2,stval'
+arch/riscv/cpu/mtrap.S:70: Error: unrecognized opcode `csrw sepc,a0'
+
+Signed-off-by: Alexandre Ghiti <alexandre.ghiti at canonical.com>
+---
+ arch/riscv/Makefile | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/arch/riscv/Makefile b/arch/riscv/Makefile
+index 0b80eb8d86..53d1194ffb 100644
+--- a/arch/riscv/Makefile
++++ b/arch/riscv/Makefile
+@@ -24,7 +24,16 @@ ifeq ($(CONFIG_CMODEL_MEDANY),y)
+ 	CMODEL = medany
+ endif
+ 
+-ARCH_FLAGS = -march=$(ARCH_BASE)$(ARCH_A)$(ARCH_C) -mabi=$(ABI) \
++RISCV_MARCH = $(ARCH_BASE)$(ARCH_A)$(ARCH_C)
++
++# Newer binutils versions default to ISA spec version 20191213 which moves some
++# instructions from the I extension to the Zicsr and Zifencei extensions.
++toolchain-need-zicsr-zifencei := $(call cc-option-yn, -mabi=$(ABI) -march=$(RISCV_MARCH)_zicsr_zifencei)
++ifeq ($(toolchain-need-zicsr-zifencei),y)
++	RISCV_MARCH := $(RISCV_MARCH)_zicsr_zifencei
++endif
++
++ARCH_FLAGS = -march=$(RISCV_MARCH) -mabi=$(ABI) \
+ 	     -mcmodel=$(CMODEL)
+ 
+ PLATFORM_CPPFLAGS	+= $(ARCH_FLAGS)
+-- 
+2.32.0
+

--- a/srcpkgs/u-boot-tools/template
+++ b/srcpkgs/u-boot-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'u-boot-tools'
 pkgname=u-boot-tools
-version=2022.07
+version=2022.10
 revision=1
 wrksrc="u-boot-${version}"
 build_style=gnu-makefile
@@ -13,7 +13,7 @@ maintainer="Duncaen <duncaen@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.denx.de/wiki/U-Boot/"
 distfiles="ftp://ftp.denx.de/pub/u-boot/u-boot-${version}.tar.bz2"
-checksum=92b08eb49c24da14c1adbf70a71ae8f37cc53eeb4230e859ad8b6733d13dcf5e
+checksum=50b4482a505bc281ba8470c399a3c26e145e29b23500bc35c50debd7fa46bdf8
 
 if [ "$CROSS_BUILD" ]; then
 	make_build_args+=" CROSS_BUILD_TOOLS=y CROSS_COMPILE=${XBPS_CROSS_TRIPLET}-"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)

~~Please be aware of this PR: https://github.com/void-linux/void-packages/pull/38467. I suppose it doesn't matter which of these two PRs get merged first, but that PR is crucial for smooth functioning of `keyd`.~~

This PR should be all set to go!