### PR TITLE
xterm: update to 373.

### DIFF
--- a/srcpkgs/xterm/template
+++ b/srcpkgs/xterm/template
@@ -1,6 +1,6 @@
 # Template file for 'xterm'
 pkgname=xterm
-version=372
+version=373
 revision=1
 build_style=gnu-configure
 configure_args="--enable-wide-chars --enable-88-color --enable-broken-osc
@@ -20,7 +20,7 @@ license="MIT, X11"
 homepage="https://invisible-island.net/xterm/"
 changelog="https://invisible-island.net/xterm/xterm.log.html"
 distfiles="https://invisible-mirror.net/archives/xterm/xterm-${version}.tgz"
-checksum=c6d08127cb2409c3a04bcae559b7025196ed770bb7bf26630abcb45d95f60ab1
+checksum=deb0989473a63908b5a8d44dfeea8301c8710f6ce01fb57ce8c30002375746b6
 
 post_install() {
 	for f in {u,}xterm.desktop; do


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

CI just fails due to ratelimiting on xterm servers.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
