### PR TITLE
biber: add patch to fix biber on perl 5.36

### DIFF
--- a/srcpkgs/biber/patches/0001-Adapt_to_Perl_5.36.patch
+++ b/srcpkgs/biber/patches/0001-Adapt_to_Perl_5.36.patch
@@ -1,0 +1,40 @@
+From d9e961710074d266ad6bdf395c98868d91952088 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Petr=20P=C3=ADsa=C5=99?= <ppisar@redhat.com>
+Date: Wed, 25 May 2022 12:41:59 +0200
+Subject: [PATCH] Adapt to Perl 5.36
+
+A developmental release of Perl 5.36.0 fails to run tests with:
+
+    $ perl -Ilib t/basic-misc.t
+    1..72
+    Can't modify undef operator in scalar assignment at lib/Biber/Section.pm line 433, near "undef;"
+    Compilation failed in require at lib/Biber.pm line 24.
+    BEGIN failed--compilation aborted at lib/Biber.pm line 24.
+    Compilation failed in require at t/basic-misc.t line 11.
+    BEGIN failed--compilation aborted at t/basic-misc.t line 11.
+    # Looks like your test exited with 255 before it could output anything.
+
+This is because of a missing semicolon between commands in
+del_everykeys(). The new perl is more strict and raises a compile-time
+error:
+
+    $ perl -e '$a = undef $b = undef;'
+    Can't modify undef operator in scalar assignment at -e line 1, near "undef;"
+    Execution of -e aborted due to compilation errors.
+---
+ lib/Biber/Section.pm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/Biber/Section.pm b/lib/Biber/Section.pm
+index 03ed69a51..a78942f57 100644
+--- a/lib/Biber/Section.pm
++++ b/lib/Biber/Section.pm
+@@ -429,7 +429,7 @@ sub add_everykey {
+ 
+ sub del_everykeys {
+   my $self = shift;
+-  $self->{everykey} = undef
++  $self->{everykey} = undef;
+   $self->{everykey_lc} = undef;
+   return;
+ }

--- a/srcpkgs/biber/template
+++ b/srcpkgs/biber/template
@@ -1,8 +1,7 @@
 # Template file for 'biber'
 pkgname=biber
 version=2.16
-revision=1
-wrksrc="${pkgname}-${version}"
+revision=2
 build_style=perl-ModuleBuild
 hostmakedepends="perl-Module-Build"
 makedepends="perl-ExtUtils-LibBuilder"
@@ -20,13 +19,13 @@ depends="perl-autovivification
 	perl-Encode-EUCJPASCII
 	perl-Encode-HanExtra
 	perl-Encode-JIS2K
- 	perl-ExtUtils-LibBuilder
+	perl-ExtUtils-LibBuilder
 	perl-File-Slurper
 	perl-IO-String
 	perl-IPC-Run3
 	perl-Lingua-Translit
 	perl-List-AllUtils
- 	perl-List-MoreUtils
+	perl-List-MoreUtils
 	perl-List-MoreUtils-XS
 	perl-Log-Log4perl
 	perl-LWP-Protocol-https


### PR DESCRIPTION
With perl 5.36, biber now fails with a syntax error:

This patch was taken directly from biber upstream: https://github.com/plk/biber/commit/d9e961710074d266ad6bdf395c98868d91952088 . A clean fix would be updating biber, but as biber is released in lockstep with biblatex (and has strict version requirements going both ways), updating the TeXLive packages isn't really something I'm able to do.

Without this patch, invoking biber at all results in the following crash:

```
$ biber --help
Can't modify undef operator in scalar assignment at /usr/share/perl5/vendor_perl/Biber/Section.pm line 373, near "undef;"
Compilation failed in require at /usr/share/perl5/vendor_perl/Biber.pm line 24.
BEGIN failed--compilation aborted at /usr/share/perl5/vendor_perl/Biber.pm line 24.
Compilation failed in require at /bin/biber line 17.
BEGIN failed--compilation aborted at /bin/biber line 17.
```

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- [x] I built this PR locally for my native architecture, x86_64-glib
- I did **not** build this PR locally for other architectures, as biber is written in perl and the change is relatively minor.
