### PR TITLE
intellij-idea-community-edition: use jetbrains jdk

### DIFF
--- a/srcpkgs/intellij-idea-community-edition/files/idea.desktop
+++ b/srcpkgs/intellij-idea-community-edition/files/idea.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=IntelliJ IDEA Community Edition
 Comment=Java integrated development environment by JetBrains
-Exec=/usr/bin/idea %f
+Exec=env IDEA_JDK=/usr/lib/jvm/jbrsdk /usr/bin/idea %f
 Icon=idea
 Terminal=false
 Type=Application

--- a/srcpkgs/intellij-idea-community-edition/template
+++ b/srcpkgs/intellij-idea-community-edition/template
@@ -1,9 +1,9 @@
 # Template file for 'intellij-idea-community-edition'
 pkgname=intellij-idea-community-edition
 version=2021.3.3
-revision=1
+revision=2
 archs="i686 x86_64"
-depends="virtual?java-environment giflib libXtst hicolor-icon-theme"
+depends="jetbrains-jdk-bin giflib libXtst hicolor-icon-theme"
 short_desc="Java integrated development environment by JetBrains"
 maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Trying to run intellij with an openjdk will error on startup complaining about missing AWT modules which aren't in that distribution. Instead of depending on any java environment via the `java-environment` virtual package, depend explicitly on the jetbrains jdk and modify the desktop entry to launch intellij with that jdk.

With these changes, intellij is only launched with the jetbrains jdk by default when you use the desktop entry. You can still launch it using any java environment when using the executable directly by setting the `IDEA_JDK` variable on the command line.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
