### PR TITLE
zfs: update to 2.1.6.

### DIFF
--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
-version=2.1.5
-revision=3
+version=2.1.6
+revision=1
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d
@@ -15,7 +15,7 @@ maintainer="Toyam Cox <Vaelatern@voidlinux.org>"
 license="CDDL-1.0"
 homepage="https://openzfs.github.io/openzfs-docs/"
 distfiles="https://github.com/openzfs/zfs/releases/download/zfs-${version}/zfs-${version}.tar.gz"
-checksum=1913041e5c44ff07ca384346ad8145aeedf77e77cd1cea9ec5d533246691e10c
+checksum=15339014f8d2131348eb937bf8893849806b6d2645ea607a18c7f117749dbd7a
 # dkms must be before initramfs-regenerate to build modules before images
 triggers="dkms initramfs-regenerate"
 dkms_modules="zfs ${version}"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

This could use testing by users that do NOT have root-on-ZFS for their ZFS usage. Tested locally on x86_64, no native encryption, root-on-ZFS.

@ahesford @Vaelatern 