### PR TITLE
 libfido2: switch udev rules to the `plugdev` group

### DIFF
--- a/srcpkgs/libfido2/INSTALL.msg
+++ b/srcpkgs/libfido2/INSTALL.msg
@@ -1,0 +1,3 @@
+If you are NOT using a login/seat manager with support for "uaccess"
+tags, you will need to be in the "users" group to take advantage of
+the default udev rules.

--- a/srcpkgs/libfido2/template
+++ b/srcpkgs/libfido2/template
@@ -1,7 +1,7 @@
 # Template file for 'libfido2'
 pkgname=libfido2
 version=1.12.0
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DUDEV_RULES_DIR=/usr/lib/udev/rules.d"
 hostmakedepends="pkg-config"
@@ -10,8 +10,8 @@ short_desc="Library for FIDO 2.0, including communication with a device over USB
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="BSD-2-Clause"
 homepage="https://github.com/Yubico/libfido2"
+changelog="https://raw.githubusercontent.com/Yubico/libfido2/main/NEWS"
 distfiles="https://github.com/Yubico/libfido2/archive/${version}.tar.gz"
-changelog="https://github.com/Yubico/libfido2/blob/main/NEWS"
 checksum=813d6d25116143d16d2e96791718a74825da16b774a8d093d96f06ae1730d9c5
 # udev rules used to be shipped by libu2f-host
 conf_files="/usr/lib/udev/rules.d/70-u2f.rules"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86-64_glibc)

@leahneukirchen

Embarrassingly, I spent a lot of time wondering why my U2F was not showing and then I noticed this switch in the template. 

Most other rules shipped by void, use `plugdev`, and the current docs imply that it should be `plugdev`.
 
```
plugdev | Access to pluggable devices.
users | Ordinary users.
```
from https://docs.voidlinux.org/config/users-and-groups.html


