### PR TITLE
lua54-luaexpat: update to 1.5.0

### DIFF
--- a/srcpkgs/lua54-luaexpat/template
+++ b/srcpkgs/lua54-luaexpat/template
@@ -11,8 +11,8 @@ short_desc="${_desc} (5.4.x)"
 maintainer="Duncaen <mail@duncano.de>"
 license="MIT"
 homepage="https://matthewwild.co.uk/projects/luaexpat/"
-distfiles="https://matthewwild.co.uk/projects/luaexpat/luaexpat-${version}.tar.gz"
-checksum=d060397960d87b2c89cf490f330508b7def1a0677bdc120531c571609fc57dc3
+distfiles="https://github.com/lunarmodules/luaexpat/archive/refs/tags/${version}.tar.gz"
+checksum=9906b1ec81ba141f4cd03e2c8f6c633b15e40b3d341c52a1ef97243e521cdce1
 
 post_extract() {
 	cd "${wrksrc}"

--- a/srcpkgs/lua54-luaexpat/template
+++ b/srcpkgs/lua54-luaexpat/template
@@ -1,7 +1,7 @@
 # Template file for 'lua54-luaexpat'
 pkgname=lua54-luaexpat
-version=1.3.0
-revision=3
+version=1.5.0
+revision=1
 wrksrc=luaexpat-${version}
 make_build_args="EXPAT_INC=-I${XBPS_CROSS_BASE}/usr/include"
 makedepends="lua51-devel lua52-devel lua53-devel lua54-devel expat-devel"
@@ -12,15 +12,11 @@ maintainer="Duncaen <mail@duncano.de>"
 license="MIT"
 homepage="https://matthewwild.co.uk/projects/luaexpat/"
 distfiles="https://github.com/lunarmodules/luaexpat/archive/refs/tags/${version}.tar.gz"
-checksum=9906b1ec81ba141f4cd03e2c8f6c633b15e40b3d341c52a1ef97243e521cdce1
+checksum=ae5710a948831b4260c2910f67d651e247dc3d48a228a31e1e78dd9e4a37aa48
 
 post_extract() {
 	cd "${wrksrc}"
 	mkdir -p lua5.1
-
-	sed -n '/Copyright/,/SOFTWARE\./p' doc/us/license.html > LICENSE
-	# lua 5.3+ does not work with -ansi (integer type detection error)
-	vsed -i 's, -ansi,,' Makefile
 
 	mv * lua5.1 || true
 	cp -a lua5.1 lua5.2


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** ran the following example code sourced from the project's homepage and tested by writing a few xml tags to it's stdin.

```lua
lxp = require"lxp" -- added "lxp =" which was NOT IN the version on the homepage

local count = 0
callbacks = {
    StartElement = function (parser, name)
        io.write("+ ", string.rep(" ", count), name, "\n")
        count = count + 1
    end,
    EndElement = function (parser, name)
        count = count - 1
        io.write("- ", string.rep(" ", count), name, "\n")
    end
}

p = lxp.new(callbacks)

for l in io.lines() do  -- iterate lines
    p:parse(l)          -- parses the line
    p:parse("\n")       -- parses the end of line
end
p:parse()               -- finishes the document
p:close()               -- closes the parser
```

Then I ran:

```shell
 echo '<asdf>one level<noice>two</noice></asdf>' | lua<version> test.lua
```

and got the following every time:

```
+ asdf
+  noice
-  noice
- asdf
```


#### Local build testing
- I built this PR locally for my native architecture, x86_64, glibc
- I build (and tested briefly) packages for lua versions 5.4, 5.3 5.2 and 5.1

Updated this package because it was mentioned on #39072 and go-ipfs turned out to be very hard to upgrade (not really but fs-repo-migration was hard 😡).

