### PR TITLE
nextcloud-client: update to 3.6.0

### DIFF
--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.5.4
+version=3.6.0
 revision=1
 wrksrc="desktop-${version}"
 build_style=cmake
@@ -20,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=f6222403063f83d52577ab4c53060eec8d0dc499e56975e44767b53d9b6e896f
+checksum=d7c1d3f6a867566c1f9a629c8c0d954ba69ebc4107c0faa975a1ccf42842d0df
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 


### PR DESCRIPTION
Testing the changes
- I tested the changes in this PR: **YES**

Local build testing
- I built this PR locally for my native architecture, aarch64