### PR TITLE
python3-Werkzeug: add missing dependency python3-MarkupSafe.

### DIFF
--- a/srcpkgs/python3-Werkzeug/template
+++ b/srcpkgs/python3-Werkzeug/template
@@ -1,12 +1,12 @@
 # Template file for 'python3-Werkzeug'
 pkgname=python3-Werkzeug
 version=2.2.2
-revision=1
+revision=2
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3"
-checkdepends="python3-pytest python3-hypothesis python3-requests python3-MarkupSafe"
+depends="python3-MarkupSafe"
+checkdepends="python3-pytest python3-hypothesis python3-requests ${depends}"
 short_desc="Swiss Army knife of Python web development (Python3)"
 maintainer="Markus Berger <pulux@pf4sh.de>"
 license="BSD-3-Clause"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[2.2.x added it in `install_requires`](https://github.com/pallets/werkzeug/blob/15fcb87d36f4ed45b127692d2d739266b918503c/setup.py#L6)

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
