### PR TITLE
go: update to 1.19.2.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.19.1
+version=1.19.2
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=27871baa490f3401414ad793fba49086f6c855b1c584385ed7771e1204c7e179
+checksum=2ce930d70a931de660fdaf271d70192793b1b240272645bf0275779f6704df6b
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Update go 1.19.2, [release notes](https://go.dev/doc/devel/release#go1.19.2):
> go1.19.2 (released 2022-10-04) includes security fixes to the archive/tar, net/http/httputil, and regexp packages, as well as bug fixes to the compiler, the linker, the runtime, and the go/types package.
