### PR TITLE
python3-redis: update to 4.3.4

### DIFF
--- a/srcpkgs/python3-redis/template
+++ b/srcpkgs/python3-redis/template
@@ -1,17 +1,18 @@
 # Template file for 'python3-redis'
 pkgname=python3-redis
-version=3.5.3
-revision=4
+version=4.3.4
+revision=1
 wrksrc="redis-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3"
+depends="python3 python3-packaging"
 short_desc="Python3 client for Redis key-value store"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="StaticVoidMoon <mem+dev@lnthle.com>"
 license="MIT"
 homepage="https://github.com/andymccurdy/redis-py"
 distfiles="${PYPI_SITE}/r/redis/redis-${version}.tar.gz"
-checksum=0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2
+checksum=ddf27071df4adf3821c4f2ca59d67525c3a82e5f268bed97b813cb4fabf87880
+make_check="no" # Check need running redis instance
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
-- DB Connect
-- Set
-- Get
-- Dump
-- Restore
-- Expire
-- Exists
#### Note: 
- I add 'python3-packaging' dependency due to `import redis` error during test.
- I also presume that I need to change maintainer value from 'orphaned' to 'myself'. 

#### Local build testing
- I built this PR locally for my native architecture, (x86-64)

