### PR TITLE
MEGAcmd: update to 1.5.1 and adopt

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -3120,7 +3120,7 @@ libvted-3.so.0 libvted-3.7.0_2
 libpeasd-3.so.0 libpeasd-3.7.0_2
 libgstreamerd-3.so.0 libgstreamerd-3.7.0_2
 libgtkdgl-3.so.0 libgtkdgl-3.7.0_2
-libmega.so.30703 MEGAsdk-3.7.3c_2
+libmega.so.30911 MEGAsdk-3.9.11d_1
 libopenglrecorder.so.0 libopenglrecorder-0.1.0_1
 libgpod.so.4 libgpod-0.8.3_1
 libi2c.so.0 i2c-tools-4.0_1

--- a/srcpkgs/MEGAcmd/patches/autotools.patch
+++ b/srcpkgs/MEGAcmd/patches/autotools.patch
@@ -6,7 +6,7 @@
  bin_PROGRAMS += $(MEGACMD)
 -$(MEGACMD): $(top_builddir)/sdk/src/libmega.la
 +$(MEGACMD):
- noinst_HEADERS += src/comunicationsmanager.h src/configurationmanager.h src/megacmd.h src/megacmdlogger.h src/megacmdsandbox.h src/megacmdutils.h src/megacmdcommonutils.h src/listeners.h src/megacmdexecuter.h src/megacmdversion.h src/megacmdplatform.h src/comunicationsmanagerportsockets.h
+ noinst_HEADERS += src/comunicationsmanager.h src/configurationmanager.h src/megacmd.h src/megacmdlogger.h src/megacmdsandbox.h src/megacmdutils.h src/megacmdcommonutils.h src/listeners.h src/megacmdexecuter.h src/megacmdtransfermanager.h src/megacmdversion.h src/megacmdplatform.h src/comunicationsmanagerportsockets.h
 -megacmdcompletiondir = $(sysconfdir)/bash_completion.d/
 +megacmdcompletiondir = $(datarootdir)/bash-completion/completions
  megacmdcompletion_DATA = src/client/megacmd_completion.sh
@@ -35,7 +35,7 @@
 -mega_cmd_LDADD = $(RL_LDFLAGS) $(RL_LIBS) $(TERMCAP_LDFLAGS) $(TERMCAP_LIBS) 
 +mega_cmd_LDADD = $(RL_LDFLAGS) $(RL_LIBS) $(TERMCAP_LDFLAGS) $(TERMCAP_LIBS) $(MEGA_LIBS)
  
- mega_cmd_server_CXXFLAGS = $(LMEGAINC)
+ mega_cmd_server_CXXFLAGS = $(LMEGAINC) $(DB_CXXFLAGS)
  if USE_PCRE
 @@ -41,9 +42,7 @@ mega_cmd_server_CXXFLAGS += -DUSE_PCRE=1
  endif
@@ -52,8 +52,8 @@
  
  else
  
--mega_cmd_server_LDADD=$(PCRE_LIBS) $(top_builddir)/sdk/src/libmega.la
-+mega_cmd_server_LDADD=$(PCRE_LIBS) $(MEGA_LIBS)
+-mega_cmd_server_LDADD=$(DB_LDFLAGS) $(DB_LIBS) $(PCRE_LIBS) $(top_builddir)/sdk/src/libmega.la
++mega_cmd_server_LDADD=$(DB_LDFLAGS) $(DB_LIBS) $(PCRE_LIBS) $(MEGA_LIBS)
  
  mega_cmd_server_SOURCES += src/comunicationsmanagerfilesockets.cpp
 -noinst_HEADERS += src/comunicationsmanagerfilesockets.h sdk/include/mega/thread/posixthread.h sdk/include/mega/logging.h
@@ -75,23 +75,23 @@
  #EXTRA_DIST += autogen.sh
 --- a/configure.ac
 +++ b/configure.ac
-@@ -18,9 +18,6 @@
+@@ -18,10 +18,6 @@
  #                                               -*- Autoconf -*-
  # Process this file with autoconf to produce a configure script.
  
 -m4_include([sdk/m4/ax_check_compile_flag.m4])
 -m4_include([sdk/m4/ax_check_link_flag.m4])
 -m4_include([sdk/m4/ax_cxx_compile_stdcxx.m4])
+-m4_include([sdk/m4/ax_atomic.m4])
  
  m4_define([megacmd_major_version], [$(cat src/megacmdversion.h | grep "define MEGACMD_MAJOR" | cut -d" " -f 3)])
  m4_define([megacmd_minor_version], [$(cat src/megacmdversion.h | grep "define MEGACMD_MINOR" | cut -d" " -f 3)])
-@@ -37,20 +34,18 @@ m4_define([megacmd_lt_age], [0])
+@@ -38,18 +34,18 @@ m4_define([megacmd_lt_age], [0])
  
  AC_INIT([MEGAcmd], m4_esyscmd([ grep define < src/megacmdversion.h | awk '{print $3}' | awk 'BEGIN { RS = "" ; FS = "\n" } {printf $1"."$2"."$3}']), [https://github.com/meganz/megacmd])
  
--AM_INIT_AUTOMAKE
 +AM_INIT_AUTOMAKE([1.11 foreign silent-rules])
- 
++
  AC_PROG_CC
  AC_CONFIG_FILES(Makefile)
  AC_OUTPUT
@@ -107,7 +107,13 @@
  AC_CONFIG_HEADERS([src/megacmdconfig.h]) #this avoids inline definitions of stuff already defined in sdk's config.h (e.g: -DPACKAGE_NAME)
  
  LT_INIT([shared disable-static win32-dll])
-@@ -449,7 +444,8 @@ AM_CONDITIONAL([HAVE_PTHREAD], [test "${
+@@ -535,13 +531,11 @@ if test "$HAVE_PTHREAD" = "yes"; then
+ fi
+ AM_CONDITIONAL([HAVE_PTHREAD], [test "${HAVE_PTHREAD}" = "yes"])
+ 
+-# Add -latomic to LDFLAGS if needed
+-CHECK_ATOMIC()
+-
  #This will simulate compilation of sdk and extract the includes defined for it. Thus we can
  # take care of the configuration done for the subproject withtout having to recheck here
  AC_OUTPUT

--- a/srcpkgs/MEGAcmd/template
+++ b/srcpkgs/MEGAcmd/template
@@ -1,17 +1,17 @@
 # Template file for 'MEGAcmd'
 pkgname=MEGAcmd
-version=1.4.0
+version=1.5.1
 revision=1
 wrksrc="${pkgname}-${version}_Linux"
 build_style=gnu-configure
 hostmakedepends="autoconf-archive autogen gettext automake libtool pkg-config"
 makedepends="MEGAsdk-devel readline-devel pcre-devel"
 short_desc="Command Line Interactive and Scriptable Application to access MEGA"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="cultab <rroarck@gmail.com>"
 license="BSD-2-Clause, GPL-3.0-or-later"
 homepage="https://github.com/meganz/MEGAcmd"
 distfiles="https://github.com/meganz/MEGAcmd/archive/${version}_Linux.tar.gz"
-checksum=2a3626a9f1d22303fe2123f984a8ecf3779d6d59ac6c67c1bf43c2423dcb832d
+checksum=911197d777c13bf3ff5c38af0b5fce478a3f96f1fecfc9647b38614512f5c1f3
 replaces="megacmd>=0"
 
 if [ "$CROSS_BUILD" ]; then

--- a/srcpkgs/MEGAsdk/patches/missing_headers.patch
+++ b/srcpkgs/MEGAsdk/patches/missing_headers.patch
@@ -1,0 +1,11 @@
+diff --color -Naru --show-c-function a/include/Makefile.am b/include/Makefile.am
+--- a/include/Makefile.am	2022-06-15 15:24:15.000000000 +0300
++++ b/include/Makefile.am	2022-10-05 12:13:09.443571788 +0300
+@@ -56,6 +56,7 @@ nobase_libmegainclude_HEADERS = \
+ 	mega/gfx/freeimage.h \
+ 	mega/gfx/GfxProcCG.h \
+ 	mega/raid.h \
++	mega/heartbeats.h \
+ 	mega/mediafileattribute.h
+ 
+ if BUILD_MEGAAPI

--- a/srcpkgs/MEGAsdk/template
+++ b/srcpkgs/MEGAsdk/template
@@ -1,7 +1,7 @@
 # Template file for 'MEGAsdk'
 pkgname=MEGAsdk
-version=3.7.3c
-revision=2
+version=3.9.11d
+revision=1
 wrksrc="sdk-${version}"
 build_style=gnu-configure
 configure_args="--enable-chat --disable-examples $(vopt_with libuv)"
@@ -9,14 +9,14 @@ make_build_args='LIBTOOLFLAGS="--tag=CXX"'
 hostmakedepends="autogen doxygen autoconf automake gettext libtool"
 makedepends="libcurl-devel c-ares-devel openssl-devel crypto++-devel
  zlib-devel sqlite-devel freeimage-devel libsodium-devel fuse-devel
- libuv-devel $(vopt_if mediainfo libmediainfo-devel)"
+ libuv-devel readline-devel $(vopt_if mediainfo libmediainfo-devel)"
 checkdepends="gtest-devel"
 short_desc="Official client for cloud service mega.nz"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="cultab <rroarck@gmail.com>"
 license="BSD-2-Clause"
 homepage="https://mega.nz"
 distfiles="https://github.com/meganz/sdk/archive/v${version}.tar.gz"
-checksum=0b55c1752d590a0367b9fcddd2465ea574308eb97e065540121f6261807aa111
+checksum=30e82b1ae1e1cc1b0b525dd88546ad12daa331d2e98fd9bbd85f1b936e404582
 replaces="libmega>=0"
 
 build_options="libuv mediainfo"
@@ -25,6 +25,15 @@ case "$XBPS_TARGET_MACHINE" in
 	*-musl) build_options_default="libuv";;
 	*) build_options_default="libuv mediainfo";;
 esac
+
+if [ "$CROSS_BUILD" ]; then
+	configure_args="--with-libtool-sysroot=${XBPS_CROSS_BASE}"
+fi
+
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+	LDFLAGS+=" -latomic"
+fi
 
 do_check() {
 	: #requires static gtest libs


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**: by running `mega-cmd`, logging in and downloading a file using the `get` command.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)



<!-- I am trying to update `MEGAcmd` to `1.5.1` and `MEGAsdk` to `3.9.11d` (as per the version submoduled in MEGAcmd's repo). 
But am I getting a very peculiar issue with the ./configure script.

```
configure: line 22309: syntax error near unexpected token `cat'
configure: line 22309: `cat >confcache <<\_ACEOF'
```

It doesn't really seem like there is a syntax error there.
It runs just fine when manually run outside of the chroot. So I tried the following:

 - using `chroot-bash` outside the chroot to run `./configure` and replicated the issue. 
 - using `bash` outside the chroot to run `./configure` and replicated the issue. 
 - using `zsh` inside the chroot (by redefining `do_configure` to use `zsh`) which bypasses the issue but creates another issue.
 - using `sh`  outside the chroot works as expected.

_I don't think using another shell is a real solution._


I don't really know how to continue so I'm making a **broken draft pull request** to ask for help.
What could bash be doing differently so as to cause this issue?
Maybe I messed something up when porting `autotools.patch` to the new version of `MEGAcmd`?-->
