### PR TITLE
python3-poetry-core: update to 1.3.1.

### DIFF
--- a/srcpkgs/python3-poetry-core/template
+++ b/srcpkgs/python3-poetry-core/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-poetry-core'
 pkgname=python3-poetry-core
-version=1.1.0
+version=1.3.1
 revision=1
 wrksrc="poetry-core-${version}"
 build_style="python3-pep517"
@@ -14,7 +14,7 @@ license="MIT"
 homepage="https://github.com/python-poetry/poetry-core"
 changelog="https://raw.githubusercontent.com/python-poetry/poetry-core/main/CHANGELOG.md"
 distfiles="https://github.com/python-poetry/poetry-core/archive/refs/tags/${version}.tar.gz"
-checksum=44535d5c20e20189041714a45758774f713e4a53c3db071dca11a59d32aeba44
+checksum=8da8ce8f2e861527f660d7205a77095279d462b44d1d11bcf9e8ce74d96219ee
 make_check_pre="env PYTHONPATH=src"
 
 pre_check() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Rev dep checks
- [x] jrnl
- [x] python3-aiofiles
- [x] python3-hypercorn
- [x] python3-msoffcrypto-tool
- [x] python3-pendulum
- [x] python3-pytest-httpserver
- [x] python3-pytzdata
- [x] python3-quart
- [x] python3-unpaddedbase64
- [x] synapse

A couple of these fail some tests, same as https://github.com/void-linux/void-packages/pull/39136