### PR TITLE
Revert "python3-poetry-core: update to 1.3.1."

### DIFF
--- a/srcpkgs/python3-poetry-core/template
+++ b/srcpkgs/python3-poetry-core/template
@@ -1,7 +1,8 @@
 # Template file for 'python3-poetry-core'
 pkgname=python3-poetry-core
-version=1.3.1
-revision=1
+reverts="1.3.1_1"
+version=1.1.0
+revision=2
 wrksrc="poetry-core-${version}"
 build_style="python3-pep517"
 make_check_args="--deselect tests/masonry/builders/test_sdist.py::test_default_with_excluded_data
@@ -14,7 +15,7 @@ license="MIT"
 homepage="https://github.com/python-poetry/poetry-core"
 changelog="https://raw.githubusercontent.com/python-poetry/poetry-core/main/CHANGELOG.md"
 distfiles="https://github.com/python-poetry/poetry-core/archive/refs/tags/${version}.tar.gz"
-checksum=8da8ce8f2e861527f660d7205a77095279d462b44d1d11bcf9e8ce74d96219ee
+checksum=44535d5c20e20189041714a45758774f713e4a53c3db071dca11a59d32aeba44
 make_check_pre="env PYTHONPATH=src"
 
 pre_check() {


### PR DESCRIPTION
I messed the last commit since I forgot use `XBPS_CHECK_PKGS=yes` while packaging two revdeps today. so even though it builds, it fails test(s) and errs in runtime.