### PR TITLE
xcircuit: update to 3.10.30.

### DIFF
--- a/srcpkgs/xcircuit/template
+++ b/srcpkgs/xcircuit/template
@@ -1,6 +1,6 @@
 # Template file for 'xcircuit'
 pkgname=xcircuit
-version=3.10.23
+version=3.10.30
 revision=1
 build_style=gnu-configure
 make_build_args="ACLOCAL=aclocal AUTOMAKE=automake"
@@ -11,8 +11,9 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="http://opencircuitdesign.com/xcircuit/"
 distfiles="http://opencircuitdesign.com/xcircuit/archive/xcircuit-${version}.tgz"
-checksum=8f43c0f0050819c248cc6925f95228af861ec434dd9d2629ca7d13b8d0a55b51
+checksum=b2f63cba605e79cc2a08714bf3888f7be7174384ed724db3c70f8bf25c36f554
 nocross="menudep: cannot execute binary file"
+make_check=no # what tests are you even running
 
 post_install() {
 	vmkdir usr/share/man/man1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

I might be dumb but honestly  I don't understand what tests is even running on the  `do_check()` by default ... So disabling the tests since upstream don't seem to have tests. 