### PR TITLE
New package: oxygen-sounds-5.26.0

### DIFF
--- a/srcpkgs/oxygen-sounds/template
+++ b/srcpkgs/oxygen-sounds/template
@@ -1,0 +1,12 @@
+# Template file for 'oxygen-sounds'
+pkgname=oxygen-sounds
+version=5.26.0
+revision=1
+build_style=cmake
+makedepends="extra-cmake-modules"
+short_desc="Oxygen sound theme for the Plasma Desktop"
+maintainer="Fries <fries@tar.black>"
+license="LGPL-2.1-or-later"
+homepage="https://invent.kde.org/plasma/oxygen-sounds"
+distfiles="${KDE_SITE}/plasma/${version}/oxygen-sounds-${version}.tar.xz"
+checksum=87b41d0ce41ff30d5d09a59fef5395bf22bcd8d9b2501398e63412d6acb48773


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl

This sound theme is used by KDE Plasma for its sounds.

