### PR TITLE
New Package: python3-aubio-0.4.9

### DIFF
--- a/srcpkgs/aubio/template
+++ b/srcpkgs/aubio/template
@@ -6,6 +6,7 @@ build_style=waf3
 # XXX lash, pure and swig support.
 hostmakedepends="pkg-config txt2man"
 makedepends="libsamplerate-devel fftw-devel jack-devel ffmpeg-devel"
+depends="python3-aubio"
 short_desc="Library for audio labelling"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/python3-aubio/template
+++ b/srcpkgs/python3-aubio/template
@@ -1,0 +1,17 @@
+# Template file for 'python3-aubio'
+pkgname=python3-aubio
+version=0.4.9
+revision=1
+wrksrc="aubio-${version}"
+build_style=python3-module
+hostmakedepends="python3-setuptools pkg-config python3-wheel python3-numpy"
+makedepends="python3-numpy ffmpeg-devel libsndfile-devel libsamplerate-devel
+ blas-devel fftw-devel python3-devel"
+checkdepends="python3-pytest"
+short_desc="Collection of tools for music analysis"
+maintainer="Alex Childs <misuchiru03+github@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://aubio.org"
+distfiles="${PYPI_SITE}/a/aubio/aubio-${version}.tar.gz"
+checksum=df1244f6c4cf5bea382c8c2d35aa43bc31f4cf631fe325ae3992c219546a4202
+CFLAGS="-ffloat-store"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl


I also added `python3-aubio` to `depends` in the `aubio` template as it does actually depend on the python module to provide `/usr/bin/aubio` and `/usr/bin/aubiocut`.