### PR TITLE
python3-zope.hookable: update to 5.2

### DIFF
--- a/srcpkgs/python3-zope.hookable/template
+++ b/srcpkgs/python3-zope.hookable/template
@@ -1,16 +1,17 @@
 # Template file for 'python3-zope.hookable'
 pkgname=python3-zope.hookable
-version=5.1.0
-revision=3
+version=5.2
+revision=1
 wrksrc="zope.hookable-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
 depends="python3"
+checkdepends="${depends} python3-zope.testing python3-zope.testrunner"
 short_desc="Zope hookable architecture for Python3"
 maintainer="Alex Childs <misuchiru03+void@gmail.com>"
 license="ZPL-2.1"
 homepage="https://github.com/zopefoundation/zope.hookable"
 changelog="https://raw.githubusercontent.com/zopefoundation/zope.hookable/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/z/zope.hookable/zope.hookable-${version}.tar.gz"
-checksum=8fc3e6cd0486c6af48e3317c299def719b57538332a194e0b3bc6a772f4faa0e
+checksum=4c3018bcf2b39cf5cccf40826f799b4b8c140056db780f96cb0ca332a243bd29


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
