### PR TITLE
mupdf: add clipboard build option

### DIFF
--- a/srcpkgs/mupdf/template
+++ b/srcpkgs/mupdf/template
@@ -16,6 +16,14 @@ homepage="https://mupdf.com"
 distfiles="https://mupdf.com/downloads/archive/${pkgname}-${version}-source.tar.lz"
 checksum=6f73f63ef8aa81991dfd023d4426a548827d1d74e0bfcf2a013acad63b651868
 
+build_options="clipboard"
+desc_option_clipboard="Enable clipboard support"
+
+_use_system_libs="USE_SYSTEM_LIBS=yes"
+if [ "$build_option_clipboard" ]; then
+	_use_system_libs+=" USE_SYSTEM_GLUT=no"
+fi
+
 pre_build() {
 	# libmupdf-{threads,pkcs7}.a are required by fbpdf
 	sed 's/INSTALL_LIBS :=/& $(THREAD_LIB) $(PKCS7_LIB)/' -i Makefile
@@ -35,12 +43,12 @@ do_build() {
 		_crosscompile="CROSSCOMPILE=yes"
 	fi
 
-	make ${makejobs} USE_SYSTEM_LIBS=yes CURL_LIBS='-lcurl -lpthread' build=release ${_crosscompile} all
+	make ${makejobs} ${_use_system_libs} CURL_LIBS='-lcurl -lpthread' build=release ${_crosscompile} all
 	make ${makejobs} CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" build=release ${_crosscompile} -C thirdparty/mujs
 }
 
 do_install() {
-	make USE_SYSTEM_LIBS=yes build=release prefix=${DESTDIR}/usr install
+	make ${_use_system_libs} build=release prefix=${DESTDIR}/usr install
 	for f in build/release/libmupdf-*.a; do
 		vinstall $f 644 usr/lib
 	done


### PR DESCRIPTION
This option enables clipboard support in mupdf-gl by building with the vendored copy of freeglut instead of the system copy.

Fixes: #13871

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x84_64-glibc
- I built this PR locally for these architectures:
  - aarch64-musl (cross)
  - armv7l (cross)
  - armv6l-musl (cross)