### PR TITLE
qtractor: update to 0.9.29, switch to Qt6

### DIFF
--- a/srcpkgs/qtractor/template
+++ b/srcpkgs/qtractor/template
@@ -1,19 +1,18 @@
 # Template file for 'qtractor'
 pkgname=qtractor
-version=0.9.28
+version=0.9.29
 revision=1
 _clap_tag=1.1.1
-_vst3sdk_tag=3.7.5_build_44
+_vst3sdk_tag=3.7.6_build_18
 wrksrc="qtractor-qtractor_${version//./_}"
 create_wrksrc=yes
 build_wrksrc="qtractor-qtractor_${version//./_}"
 build_style=cmake
 configure_args="-DCONFIG_VST3SDK=$XBPS_BUILDDIR/$build_wrksrc/vst3sdk"
-hostmakedepends="pkg-config qt5-host-tools qt5-qmake"
+hostmakedepends="pkg-config qt6-base-devel qt6-tools-devel"
 makedepends="aubio-devel dssi-devel jack-devel ladspa-sdk liblo-devel
  libmad-devel libsamplerate-devel libsndfile-devel libvorbis-devel lilv-devel
- qt5-svg-devel qt5-tools-devel qt5-x11extras-devel rubberband-devel
- sratom-devel suil-devel"
+ qt6-base-devel qt6-svg-devel rubberband-devel sratom-devel"
 depends="desktop-file-utils dssi hicolor-icon-theme jack lv2"
 short_desc="Audio/MIDI multi-track sequencer application written in C++/Qt"
 maintainer="Matthias von Faber <mvf@gmx.eu>"
@@ -27,12 +26,12 @@ distfiles="https://github.com/rncbc/qtractor/archive/qtractor_${version//./_}.ta
  https://github.com/steinbergmedia/vst3_base/archive/v$_vst3sdk_tag.tar.gz>vst3_base-v${_vst3sdk_tag}.tar.gz
  https://github.com/steinbergmedia/vst3_pluginterfaces/archive/v$_vst3sdk_tag.tar.gz>vst3_pluginterfaces-v${_vst3sdk_tag}.tar.gz
  https://github.com/steinbergmedia/vst3_public_sdk/archive/v$_vst3sdk_tag.tar.gz>vst3_public_sdk-v${_vst3sdk_tag}.tar.gz"
-checksum="988eec4ecba892568d98638264e9369d900213056622c74bba83050dc5334028
+checksum="107aafa1d2353354038b74d0246e0b80f722779b56b753023958b27a843be055
  eef67a38df6c20fd4cb79698772d35d30aefc2e1a8d5275a5169f58cd530333e
- ed359d496796588aa0be86cc902e2472e9624abf6af3a85b2a5711ad069fb9f3
- 360c51e3fbb33c0bf389175d07f8f09c175120296e9b0e6a4d222663e92bccf8
- f34e313c7ff6661401275947a8c3d695d9a2c06c84135c9c8d4939f5316393a7
- 11992e0fddff5173785bcd9a4ce9e57f3262b07e5f2c76a8aa812ef99497e3be"
+ 3432b5ec94a5c87122ae30981e3df1863d1074daa83e493483af3fd33767ab6f
+ 124b70a3ac33d5a8346fee171e7d21a8a8f84280afc47ed9c4738ed4a2c44cd4
+ eba627bbbc5e862e73fb90ddc5503b6a98874074d12f68623924078506a7fdbe
+ 3ac4756ad6993fc9e1a4967cdf132207d98e7132277e37e0de2a199b66b283aa"
 
 post_extract() {
 	cd $wrksrc


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
