### PR TITLE
iwd: update to 1.30.

### DIFF
--- a/srcpkgs/iwd/template
+++ b/srcpkgs/iwd/template
@@ -1,6 +1,6 @@
 # Template file for 'iwd'
 pkgname=iwd
-version=1.29
+version=1.30
 revision=1
 build_style=gnu-configure
 configure_args="--disable-systemd-service --enable-pie
@@ -15,7 +15,7 @@ license="LGPL-2.1-or-later"
 homepage="https://iwd.wiki.kernel.org/"
 changelog="https://git.kernel.org/pub/scm/network/wireless/iwd.git/plain/ChangeLog"
 distfiles="${KERNEL_SITE}/network/wireless/${pkgname}-${version}.tar.xz"
-checksum=71533fe3b8f6381f24832198ba11d00f04a361454770c173b3b66bc3cdf272bd
+checksum=9fd13512dc27d83efb8d341f7df98f5488f70131686021fcd0d93fc97af013b8
 make_dirs="/var/lib/iwd 0600 root root
  /var/lib/ead 0600 root root
  /etc/iwd 755 root root"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l

I tested by installing the new package, restarting iwd, confirming connection, using iwctl to disconnect and reconnect, and confirming connection again.