### PR TITLE
lvm2: update to 2.02.188.

### DIFF
--- a/srcpkgs/lvm2/template
+++ b/srcpkgs/lvm2/template
@@ -1,7 +1,7 @@
 # Template file for 'lvm2'
 pkgname=lvm2
-version=2.02.187
-revision=2
+version=2.02.188
+revision=1
 build_style=gnu-configure
 configure_args="--disable-selinux --enable-readline --enable-pkgconfig
  --enable-fsadm --enable-applib --enable-dmeventd --enable-cmdlib
@@ -18,7 +18,7 @@ license="GPL-2.0-only, LGPL-2.1-only"
 homepage="https://sourceware.org/lvm2/"
 changelog="https://abi-laboratory.pro/?view=changelog&l=lvm2&v=${version}"
 distfiles="https://mirrors.kernel.org/sourceware/lvm2/releases/LVM2.${version}.tgz"
-checksum=0e0d521a863a5db2440f2e1e7627ba82b70273ae4ab0bbe130851db0d58e5af1
+checksum=7101e8b0816ad77e4390fed9749a090214ba520061cd083437871e19e50cc9bd
 conf_files="/etc/lvm/*.conf /etc/lvm/profile/*"
 make_dirs="
  /etc/lvm/archive 0755 root root


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** - my disks are all in LVM; I installed the update, rebooted, and all is still well.

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
  - aarch64-musl
  - x86_64-musl

I don't have the experience to update to 2.03.x, but the latest 2.02.x release seems smart.  Here are the changes: https://mirrors.kernel.org/sourceware/lvm2/WHATS_NEW-2.02