### PR TITLE
dmenu: update to 5.2.

### DIFF
--- a/srcpkgs/dmenu/template
+++ b/srcpkgs/dmenu/template
@@ -1,6 +1,6 @@
 # Template file for 'dmenu'
 pkgname=dmenu
-version=5.1
+version=5.2
 revision=1
 makedepends="libXinerama-devel libXft-devel freetype-devel"
 short_desc="Generic menu for X"
@@ -8,7 +8,7 @@ maintainer="tibequadorian <tibequadorian@posteo.de>"
 license="MIT"
 homepage="https://tools.suckless.org/dmenu/"
 distfiles="https://dl.suckless.org/tools/${pkgname}-${version}.tar.gz"
-checksum=1f4d709ebba37eb7326eba0e665e0f13be4fa24ee35c95b0d79c30f14a348fd5
+checksum=d4d4ca77b59140f272272db537e05bb91a5914f56802652dc57e61a773d43792
 
 build_options="fuzzymatch"
 desc_option_fuzzymatch="Enable Fuzzymatch support"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** - installed and confirmed I could still run programs using `dmenu_run`.

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
