### PR TITLE
psmisc: update to 23.5.

### DIFF
--- a/srcpkgs/psmisc/template
+++ b/srcpkgs/psmisc/template
@@ -1,6 +1,6 @@
 # Template file for 'psmisc'
 pkgname=psmisc
-version=23.4
+version=23.5
 revision=1
 build_style=gnu-configure
 makedepends="ncurses-devel"
@@ -8,5 +8,6 @@ short_desc="Small set of utilities that use the linux proc filesystem"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://gitlab.com/psmisc/psmisc"
+changelog="https://gitlab.com/psmisc/psmisc/-/raw/master/ChangeLog"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=7f0cceeace2050c525f3ebb35f3ba01d618b8d690620580bdb8cd8269a0c1679
+checksum=dc37ecc2f7e4a90a94956accc6e1c77adb71316b7c9cbd39b26738db0c3ae58b


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly** - I checked basic functionality of `pstree` and `killall` specifically, as they were the only programs changed in 23.5, and also checked `fuser`.

#### Local build testing
- I built this PR locally for my native architecture, x86-64 glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv6l
