### PR TITLE
CI: unify path handling

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
+      PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
       XLINT: '1'
       LICENSE_LIST: common/travis/license.lst
 
@@ -44,7 +44,7 @@ jobs:
     container:
       image: 'ghcr.io/void-linux/xbps-src-masterdir:20220527RC01-${{ matrix.config.bootstrap }}'
       env:
-        PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
+        PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
         ARCH: '${{ matrix.config.arch }}'
         BOOTSTRAP: '${{ matrix.config.bootstrap }}'
         TEST: '${{ matrix.config.test }}'

--- a/common/scripts/lint-commits
+++ b/common/scripts/lint-commits
@@ -5,7 +5,6 @@ die() {
 	exit 1
 }
 
-PATH="/usr/libexec/chroot-git:$PATH"
 command -v git >/dev/null 2>&1 ||
 die "neither chroot-git nor git could be found!"
 

--- a/common/scripts/lint-version-change
+++ b/common/scripts/lint-version-change
@@ -13,7 +13,6 @@ if ! [ "$base_rev" ]; then
 	die "usage: $0 TEMPLATE BASE-REVISION [TIP-REVISION]"
 fi
 
-PATH="/usr/libexec/chroot-git:$PATH"
 if ! command -v git >/dev/null 2>&1; then
 	die "neither chroot-git nor git could be found"
 fi

--- a/common/travis/changed_templates.sh
+++ b/common/travis/changed_templates.sh
@@ -2,8 +2,6 @@
 #
 # changed_templates.sh
 
-PATH="/usr/libexec/chroot-git:$PATH"
-
 tip="$(git rev-list -1 --parents HEAD)"
 case "$tip" in
 	# This is a merge commit, pick last parent

--- a/common/travis/fetch_upstream.sh
+++ b/common/travis/fetch_upstream.sh
@@ -2,8 +2,6 @@
 #
 # changed_templates.sh
 
-PATH="/usr/libexec/chroot-git:$PATH"
-
 # required by git 2.35.2+
 git config --global --add safe.directory "$PWD"
 


### PR DESCRIPTION
This `PATH` change was introduced in #39309, and parts of it felt kind of hacked on. This streamlines it

- .github/workflows/build.yaml: add /usr/libexec/chroot-git to PATH
- common/: remove PATH adds from CI scripts

#### Testing the changes
- I tested the changes in this PR: **YES** - https://github.com/void-linux/void-packages/actions/runs/3213065830

