### PR TITLE
xmoto: fix musl build

### DIFF
--- a/srcpkgs/xmoto/patches/fix_gettext_GNU-isms_musl.patch
+++ b/srcpkgs/xmoto/patches/fix_gettext_GNU-isms_musl.patch
@@ -1,0 +1,27 @@
+From 7ce512bf0242182306ceb75d7dbe2370aab838f8 Mon Sep 17 00:00:00 2001
+From: _yui <imbatman0xff@gmail.com>
+Date: Sun, 9 Oct 2022 14:48:05 +0300
+Subject: [PATCH] i18n: Don't use gettext GNU-isms with musl
+
+---
+ src/common/Locales.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/common/Locales.cpp b/src/common/Locales.cpp
+index 5ee395bd..680da00c 100644
+--- a/src/common/Locales.cpp
++++ b/src/common/Locales.cpp
+@@ -66,11 +66,13 @@ std::pair<std::string, std::string> Locales::changeLocale(
+           setlocale(LC_MESSAGES, NULL));
+ #endif
+ 
++#ifdef __GLIBC__
+   /* Make change known.  */
+   {
+     extern int _nl_msg_cat_cntr;
+     ++_nl_msg_cat_cntr;
+   }
++#endif
+ 
+   std::pair<std::string, std::string> locale_str(
+     locale.first == NULL ? std::string("") : std::string(locale.first),


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **Yes** , opened the app on the glibc , didn't test on musl


#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-glibc
  - armv6l * 
