### PR TITLE
Update primesieve to 8.0 and primecount to 7.4.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4046,7 +4046,7 @@ libbraiding.so.0 libbraiding-1.1_1
 libstemmer.so.2 libstemmer-2.1.0_1
 libdecor-0.so.0 libdecor-0.1.0_1
 libprimecount.so.7 primecount-7.2_1
-libprimesieve.so.9 primesieve-7.7_1
+libprimesieve.so.10 primesieve-8.0_1
 libavif.so.14 libavif-0.10.1_1
 libkdumpfile.so.10 libkdumpfile-0.4.1_1
 libamd.so.2 SuiteSparse-5.10.1_1

--- a/srcpkgs/primecount/template
+++ b/srcpkgs/primecount/template
@@ -1,6 +1,6 @@
 # Template file for 'primecount'
 pkgname=primecount
-version=7.3
+version=7.4
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTS=ON -DBUILD_LIBPRIMESIEVE=OFF
@@ -12,7 +12,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/kimwalisch/primecount/"
 changelog="https://raw.githubusercontent.com/kimwalisch/primecount/master/ChangeLog"
 distfiles="https://github.com/kimwalisch/primecount/archive/refs/tags/v${version}.tar.gz"
-checksum=471fe21461e42e5f28404e17ff840fb527b3ec4064853253ee22cf4a81656332
+checksum=6362887e80e849dd1c396ccec773e5a3a7904371b46f1d495d320d31f9c1ae28
 
 build_options="native_build"
 

--- a/srcpkgs/primesieve/template
+++ b/srcpkgs/primesieve/template
@@ -1,6 +1,6 @@
 # Template file for 'primesieve'
 pkgname=primesieve
-version=7.9
+version=8.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTS=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF"
@@ -10,7 +10,7 @@ license="BSD-2-Clause"
 homepage="https://github.com/kimwalisch/primesieve"
 changelog="https://raw.githubusercontent.com/kimwalisch/primesieve/master/ChangeLog"
 distfiles="https://github.com/kimwalisch/primesieve/archive/refs/tags/v${version}.tar.gz"
-checksum=c567f2a1a9d46a70020f920eb2c794142528a31a055995500e7fcb19642b7c91
+checksum=9fba723221535dbf1e30c582c5009eeb032464704da01a0c8541d8cf2a698803
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Note: `primesieve` had a soname bump, but it's only used directly by `primecount`. The latter did not bump soname.

Moreover the only use of these libraries in our repo is in `sagemath`, and only through `python3-primecountpy` which does NOT need revbump. Everything can be tested directly in the cli:
```
$ sage -c 'print(prime_pi(10^15))'
29844570422669
$ python -c 'from primecountpy import prime_pi ; print(prime_pi(10**15))'
29844570422669
$ primecount $[10**15]
29844570422669
$ xbps-query --regex -s 'prime(count|sieve)|sagemath-'
[*] primecount-7.4_1             Fast prime counting function
[*] primecount-devel-7.4_1       Fast prime counting function - development files
[*] primesieve-8.0_1             Fast prime number generator
[*] primesieve-devel-8.0_1       Fast prime number generator - development files
[*] python3-primecountpy-0.1.0_1 Python interface to the C++ library primecount
[*] sagemath-9.5_2               Open source mathematics software
```



<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
