### PR TITLE
Adds xdg-desktop-portal as a dependency for flatpak

### DIFF
--- a/srcpkgs/flatpak/template
+++ b/srcpkgs/flatpak/template
@@ -16,7 +16,7 @@ hostmakedepends="bubblewrap gettext glib-devel libxslt pkg-config bison
 makedepends="AppStream-devel libarchive-devel gpgme-devel json-glib-devel
  libcap-devel libostree-devel libseccomp-devel polkit-devel dconf-devel
  fuse3-devel libsoup-devel libcurl-devel gdk-pixbuf-devel"
-depends="bubblewrap gnupg2 xdg-dbus-proxy"
+depends="bubblewrap gnupg2 xdg-dbus-proxy xdg-desktop-portal"
 checkdepends="attr-progs bubblewrap dbus gnupg2 socat which xdg-dbus-proxy"
 short_desc="Application sandboxing and distribution framework"
 maintainer="Duncaen <duncaen@voidlinux.org>"


### PR DESCRIPTION
Flatpak relies on xdg-desktop-portal heavily, why it isn't a dependency is unknown to me.

Additionally, it would make sense to add xdg-desktop-portal-gtk as a dep, since that's needed for GTK theming and a native filepicker in the event there isn't another xdg-desktop-portal implementation that has one.