### PR TITLE
cross-x86_64-w64-mingw32: update to 10.0.0.

### DIFF
--- a/srcpkgs/cross-x86_64-w64-mingw32/template
+++ b/srcpkgs/cross-x86_64-w64-mingw32/template
@@ -1,13 +1,13 @@
 # Template file for 'cross-x86_64-w64-mingw32'
 pkgname=cross-x86_64-w64-mingw32
-version=9.0.0
+version=10.0.0
 revision=1
-_gcc_version=11.1.0
-_binutils_version=2.35.1
-_gmp_version=6.2.0
+_gcc_version=12.2.0
+_binutils_version=2.39
+_gmp_version=6.2.1
 _mpfr_version=4.1.0
-_mpc_version=1.1.0
-_isl_version=0.21
+_mpc_version=1.2.1
+_isl_version=0.24
 _mingw_version="${version}"
 create_wrksrc=yes
 hostmakedepends="tar flex perl texinfo"
@@ -28,13 +28,13 @@ distfiles="
  ${GNU_SITE}/mpfr/mpfr-${_mpfr_version}.tar.xz
  ${SOURCEFORGE_SITE}/libisl/isl-${_isl_version}.tar.bz2
  ${SOURCEFORGE_SITE}/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v${_mingw_version}.tar.bz2"
-checksum="3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607
- 4c4a6fb8a8396059241c2e674b85b351c26a5d678274007f076957afa1cc9ddf
- 6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e
- 258e6cd51b3fbdfc185c716d55f82c08aff57df0c6fbd143cf6ed561267a1526
+checksum="645c25f563b8adc0a81dbd6a41cffbf4d37083a382e02d5d3df4f65c09516d00
+ e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff
+ 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
+ fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2
  0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f
- d18ca11f8ad1a39ab6d03d3dcb3365ab416720fcb65b42d69f34f51bf0a0e859
- 1929b94b402f5ff4d7d37a9fe88daa9cc55515a6134805c104d1794ae22a4181"
+ fcf78dd9656c10eb8cf9fbd5f59a0b6b01386205fe1934b3b287a0a1898145c0
+ ba6b430aed72c63a3768531f6a3ffc2b0fde2c57a3b251450dcf489a894f0894"
 
 nocross=yes
 nopie=yes
@@ -232,6 +232,7 @@ _install_toolchain() {
 	# remove unnecessary stuff
 	rm -rf ${DESTDIR}/usr/share/
 	rm -rf ${DESTDIR}/usr/lib/libcc1*
+	rm -f ${DESTDIR}/usr/lib/bfd-plugins/libdep.*
 }
 
 _install_crt() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

[ci skip]

#### Testing the changes
- I tested the changes in this PR: **briefly**

Resolves build failure with gcc 12 on musl: https://github.com/void-linux/void-packages/issues/39809

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
