### PR TITLE
singular: update to 4.3.1p2 (fix gcc 12 build)

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4055,11 +4055,11 @@ libumfpack.so.5 SuiteSparse-5.10.1_1
 libecl.so.21.2 ecl-21.2.1_1
 libecm.so.1 ecm-7.0.4_3
 libcliquer.so.1 cliquer-1.22_1
-libSingular-4.3.0.so singular-4.3.0_1
-libfactory-4.3.0.so singular-4.3.0_1
-libpolys-4.3.0.so singular-4.3.0_1
-libomalloc-0.9.6.so singular-4.3.0_1
-libsingular_resources-4.3.0.so singular-4.3.0_1
+libSingular-4.3.1.so singular-4.3.1p2_1
+libfactory-4.3.1.so singular-4.3.1p2_1
+libpolys-4.3.1.so singular-4.3.1p2_1
+libomalloc-0.9.6.so singular-4.3.1p2_1
+libsingular_resources-4.3.1.so singular-4.3.1p2_1
 libbrial.so.3 brial-1.2.10_1
 libbrial_groebner.so.3 brial-1.2.10_1
 libm4ri-0.0.20200125.so m4ri-20200125_1

--- a/srcpkgs/sagemath/template
+++ b/srcpkgs/sagemath/template
@@ -1,7 +1,7 @@
 # Template file for 'sagemath'
 pkgname=sagemath
 version=9.5
-revision=2
+revision=3
 wrksrc=sage-$version
 build_wrksrc=pkgs/sagemath-standard
 build_style=python3-module

--- a/srcpkgs/singular/template
+++ b/srcpkgs/singular/template
@@ -1,25 +1,27 @@
 # Template file for 'singular'
 pkgname=singular
-version=4.3.0
+version=4.3.1p2
 revision=1
+_majver=${version%p*}
+wrksrc=singular-${_majver}
 build_style=gnu-configure
 configure_args="--with-readline=ncurses
-	--enable-gfanlib
-	--enable-Singular
-	--enable-factory
-	--disable-doc
-	--disable-polymake
-	--without-python
-	--with-libparse
-	ac_cv_lib_cddgmp_dd_free_global_constants=yes"
+ --enable-gfanlib
+ --enable-Singular
+ --enable-factory
+ --disable-doc
+ --disable-polymake
+ --without-python
+ --with-libparse
+ ac_cv_lib_cddgmp_dd_free_global_constants=yes"
 hostmakedepends="perl tar doxygen"
 makedepends="flintlib-devel cddlib-devel readline-devel graphviz"
 short_desc="Computer algebra system for polynomial computations"
-maintainer="dkwo <nicolopiazzalunga@gmail.com>"
+maintainer="dkwo <npiazza@disroot.org>"
 license="GPL-2.0-or-later"
 homepage="https://www.singular.uni-kl.de"
-distfiles="https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${version//./-}/singular-${version}.tar.gz"
-checksum=74f38288203720e3f280256f2f8deb94030dd032b4237d844652aff0faab36e7
+distfiles="https://www.singular.uni-kl.de/ftp/pub/Math/Singular/SOURCES/${_majver//./-}/singular-${version}.tar.gz"
+checksum=95814bba0f0bd0290cd9799ec1d2ecc6f4c8a4e6429d9a02eb7f9c4e5649682a
 
 if [ -z "$CROSS_BUILD" ]; then
 	makedepends+=" ntl-devel"


### PR DESCRIPTION
I tested the changes in this PR: built and checked on x86_64 using the gcc 12 PR.
(Even the non-musl version had the same failure with gcc 12.)
Had to use patchversion p2 otherwise it would still fail (with different errors).
@tornaria @leahneukirchen @Duncaen 