### PR TITLE
dosbox-staging: run speexdsp test in cross-builds

### DIFF
--- a/srcpkgs/dosbox-staging/patches/fix_cross.patch
+++ b/srcpkgs/dosbox-staging/patches/fix_cross.patch
@@ -1,55 +1,41 @@
+diff --git a/meson.build b/meson.build
+index 1509deabca..5d517611aa 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -376,24 +376,37 @@
+@@ -377,24 +377,30 @@ speexdsp_dep = dependency(
      static: ('speexdsp' in static_libs_list or prefers_static_libs),
  )
  
 -# The system has SpeexDSP, so test its floating-point handling
 -if speexdsp_dep.found()
--    system_speexdsp_test = cxx.run(
--        files('contrib/check-speexdsp/test_speexdsp_float_api.cpp'),
--        dependencies: speexdsp_dep,
--        name: 'SpeexDSP system library has reliable floating-point API',
--    )
++# The library needs to be available and testable to be trusted
++can_trust_system_speexdsp = (
++    speexdsp_dep.found()
++    and meson.can_run_host_binaries()
++)
++
++# Test the library. Trust is dropped if the test fails.
++if can_trust_system_speexdsp
+     system_speexdsp_test = cxx.run(
+         files('contrib/check-speexdsp/test_speexdsp_float_api.cpp'),
+         dependencies: speexdsp_dep,
+         name: 'SpeexDSP system library has reliable floating-point API',
+     )
 -    is_system_speexdsp_reliable = (
--        system_speexdsp_test.compiled()
--        and system_speexdsp_test.returncode() == 0
--    )
++    can_trust_system_speexdsp = (
+         system_speexdsp_test.compiled()
+         and system_speexdsp_test.returncode() == 0
+     )
 -    if is_system_speexdsp_reliable
--        speexdsp_summary_msg = 'system library'
-+if meson.can_run_host_binaries()
-+    # The system has SpeexDSP, so test its floating-point handling
-+    if speexdsp_dep.found()
-+        system_speexdsp_test = cxx.run(
-+            files('contrib/check-speexdsp/test_speexdsp_float_api.cpp'),
-+            dependencies: speexdsp_dep,
-+            name: 'SpeexDSP system library has reliable floating-point API',
-+        )
-+        is_system_speexdsp_reliable = (
-+            system_speexdsp_test.compiled()
-+            and system_speexdsp_test.returncode() == 0
-+        )
-+        if is_system_speexdsp_reliable
-+            speexdsp_summary_msg = 'system library'
-+        endif
++    if can_trust_system_speexdsp
+         speexdsp_summary_msg = 'system library'
      endif
-+else
-+    speexdsp_summary_msg = 'system library'
  endif
  
 -# The system doesn't have SpeexDSP or it's unreiable, so use the wrap
 -if not speexdsp_dep.found() or not is_system_speexdsp_reliable
-+use_speex_wrap = false
-+# The system doesn't have SpeexDSP or it's unreliable, so use the wrap
-+if not speexdsp_dep.found()
-+    use_speex_wrap = true
-+elif meson.can_run_host_binaries()
-+    if not is_system_speexdsp_reliable
-+        use_speex_wrap = true
-+    endif
-+endif
-+
-+if use_speex_wrap
++# Use the wrap if the system doesn't have SpeexDSP, we couldn't test it, or testing failed
++if not can_trust_system_speexdsp
      speexdsp_dep = subproject(
          'speexdsp',
          default_options: default_wrap_options,

--- a/srcpkgs/dosbox-staging/template
+++ b/srcpkgs/dosbox-staging/template
@@ -3,6 +3,7 @@ pkgname=dosbox-staging
 version=0.79.1
 revision=1
 build_style=meson
+build_helper=qemu
 hostmakedepends="pkg-config"
 makedepends="SDL2-devel SDL2_net-devel alsa-lib-devel fluidsynth-devel libiir1-devel
  libmt32emu-devel libpng-devel libslirp-devel opusfile-devel speexdsp-devel"


### PR DESCRIPTION
Run speexdsp test using qemu-user-static in cross-builds. To be picked up by the next build.

From discussion in https://github.com/dosbox-staging/dosbox-staging/pull/1992.


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
