### PR TITLE
PrusaSlicer: update to 2.5.0

### DIFF
--- a/srcpkgs/PrusaSlicer/patches/cmake-relax-occt-dependency.patch
+++ b/srcpkgs/PrusaSlicer/patches/cmake-relax-occt-dependency.patch
@@ -1,0 +1,11 @@
+--- PrusaSlicer-version_2.5.0/src/occt_wrapper/CMakeLists.txt.orig	2022-09-17 11:47:02.398209546 +0200
++++ PrusaSlicer-version_2.5.0/src/occt_wrapper/CMakeLists.txt	2022-09-17 11:47:30.092595307 +0200
+@@ -19,7 +19,7 @@ include(GenerateExportHeader)
+ 
+ generate_export_header(OCCTWrapper)
+ 
+-find_package(OpenCASCADE 7.6.2 REQUIRED)
++find_package(OpenCASCADE 7.6.2...7.999.999 REQUIRED)
+ 
+ set(OCCT_LIBS
+     TKXDESTEP

--- a/srcpkgs/PrusaSlicer/template
+++ b/srcpkgs/PrusaSlicer/template
@@ -1,7 +1,7 @@
 # Template file for 'PrusaSlicer'
 pkgname=PrusaSlicer
-version=2.4.2
-revision=2
+version=2.5.0
+revision=1
 wrksrc="PrusaSlicer-version_${version}"
 build_style=cmake
 build_helper="qemu cmake-wxWidgets-gtk3"
@@ -11,13 +11,14 @@ hostmakedepends="pkg-config"
 makedepends=" boost-devel cereal cgal-devel dbus-devel eigen glew-devel
  glu-devel gmpxx-devel gtest-devel gtk+3-devel libcurl-devel libglib-devel
  libpng-devel nlopt-devel openvdb-devel tbb-devel wxWidgets-devel
- c-blosc-devel ilmbase-devel libopenexr-devel wxWidgets-gtk3-devel"
+ c-blosc-devel ilmbase-devel libopenexr-devel wxWidgets-gtk3-devel
+ occt-devel"
 short_desc="G-code generator for 3D printers (RepRap, Makerbot, Ultimaker etc.)"
 maintainer="Jasper Chan <jasperchan515@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.prusa3d.com/prusaslicer/"
 distfiles="https://github.com/prusa3d/Prusaslicer/archive/version_${version}.tar.gz"
-checksum=ac3a77212260e8d0baf9df027c29e0ae965bc77f371e59fd27b8fe103ebb1f23
+checksum=dbbf3e10c812d1dc7bae4bd6879e60f864d763b2738b099dd34b9636d0e5eb6a
 
 post_extract() {
 	# Mark tests that fail on certain targets


### PR DESCRIPTION
Updates PrusaSlicer to the latest release. It requires occt-7.6 for STEP import, I couldn't find any option to disable it temporarily. Version bump for occt is posted in PR #36356. Using it I successfully built and used the software on my system.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
