### PR TITLE
New package: mpvpaper-1.3

### DIFF
--- a/srcpkgs/mpvpaper/template
+++ b/srcpkgs/mpvpaper/template
@@ -1,0 +1,21 @@
+# Template file for 'mpvpaper'
+pkgname=mpvpaper
+version=1.3
+revision=1
+build_style=meson
+meson_builddir="build"
+hostmakedepends="ninja pkg-config cmake wayland-devel"
+makedepends="wayland-devel mpv-devel wayland-protocols MesaLib-devel"
+depends="wlroots mpv wayland-protocols mesa"
+short_desc="Video wallpaper program for wlroots compositors"
+maintainer="Seltyk <whhacker.dcx@gmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/GhostNaN/mpvpaper"
+distfiles="${homepage}/archive/refs/tags/${version}.tar.gz"
+checksum=57f7e21a18574813aedfa59259238563f75e8f37a13fd21fca7d2b613dd11e87
+
+do_install() {
+	vbin build/mpvpaper
+	vbin build/mpvpaper-holder
+	vman mpvpaper.man mpvpaper.1
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**, because it is compiled (from C)

#### Local build testing
- I built this PR locally for my native architecture, x86_64
- I built this PR locally (but did not install and test) for these architectures:
  - aarch64-musl
  - armv7l
  - armv6l-musl

I'm pretty sure all of those constitute crossbuilds.  
Trying to build for i686 and x86_64-musl fails if wayland-devel isn't in both hostmakedepends and makedepends, which is why I did that.

I'm not 100% sure what the runtime dependencies are. Considering what mpvpaper does and claims to be, I suspect mpv and wlroots are required at minimum. The Meson output suggests wayland-protocols is also a runtime dependency. Lastly, since MesaLib-devel is required for EGL, mesa is likely also be a runtime dependency.