### PR TITLE
glab: add shell completions

### DIFF
--- a/srcpkgs/glab/template
+++ b/srcpkgs/glab/template
@@ -1,9 +1,10 @@
 # Template file for 'glab'
 pkgname=glab
 version=1.22.0
-revision=1
+revision=2
 wrksrc="cli-v$version"
 build_style=go
+build_helper=qemu
 go_ldflags="-X main.version=$version"
 go_import_path=github.com/profclems/glab
 go_package="${go_import_path}/cmd/glab"
@@ -13,7 +14,18 @@ license="MIT"
 homepage="https://gitlab.com/gitlab-org/cli"
 distfiles="https://gitlab.com/gitlab-org/cli/-/archive/v$version/cli-v$version.tar.gz"
 checksum=4d9bceb6818c8bf9f681119dae3a65f1c895fa21e9da6b38e8f88d245f524e10
+_completions="bash zsh fish"
+
+post_build() {
+	local cli=$(find $GOPATH/bin -name glab)
+	for shell in $_completions; do
+		vtargetrun $cli completion -s $shell > "glab.${shell}"
+	done
+}
 
 post_install() {
 	vlicense LICENSE
+	for shell in $_completions; do
+		vcompletion "glab.${shell}" $shell glab
+	done
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**, but the verdict was that it does not work for me right now on zsh. Not quite sure why, maybe someone else can have a look? The completions are generated, they are written out to the correct place. cc @Gottox 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
