### PR TITLE
os-prober: update to 1.81.

### DIFF
--- a/srcpkgs/os-prober/template
+++ b/srcpkgs/os-prober/template
@@ -1,8 +1,7 @@
 # Template file for 'os-prober'
 pkgname=os-prober
-version=1.79
+version=1.81
 revision=1
-wrksrc="${pkgname}"
 build_style=gnu-makefile
 make_dirs="/var/lib/os-prober 0755 root root"
 short_desc="Utility to detect other OSes on a set of drives"
@@ -10,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-or-later"
 homepage="https://packages.debian.org/sid/os-prober"
 distfiles="${DEBIAN_SITE}/main/o/${pkgname}/${pkgname}_${version}.tar.xz"
-checksum=abe6317d078c4e51e322e62036b6df4a698bfe80c5be110a08894841179810ee
+checksum=2fd928ec86538227711e2adf49cfd6a1ef74f6bb3555c5dad4e0425ccd978883
 
 case "$XBPS_TARGET_MACHINE" in
 	i686*|x86_64*) _ARCH="x86";;


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**, it runs but I don't have any other OSs on my void machine to check if it still detects them.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

