### PR TITLE
smenu: update to 1.0.0.

### DIFF
--- a/srcpkgs/smenu/template
+++ b/srcpkgs/smenu/template
@@ -1,6 +1,6 @@
 # Template file for 'smenu'
 pkgname=smenu
-version=0.9.19
+version=1.0.0
 revision=1
 build_style=gnu-configure
 makedepends="ncurses-devel"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/p-gen/smenu"
 changelog="https://raw.githubusercontent.com/p-gen/smenu/master/ChangeLog"
-distfiles="https://github.com/p-gen/smenu/archive/v${version}.tar.gz"
-checksum=179b0b57db5a9a8606d8d9d364f0662d4e5dd57592bf7896ada4022c9acc83cb
+distfiles="https://github.com/p-gen/smenu/releases/download/v${version}/smenu-${version}.tar.bz2"
+checksum=40e044d4bb39a9258cbb2349e7c5618bdafaa20c39f7d86cc8b6fa3b878ef105
 
 LDFLAGS="-lncurses"


### PR DESCRIPTION
Updated distfiles to use the release assets (smenu-$version.tar.bz2)
    instead of the github generated tarballs.

#### Testing the changes
- I tested the changes in this PR: **YES**, ran the `simple_menu` example provided in the upstream repo.


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

