### PR TITLE
New package: nextdns-1.39.4

### DIFF
--- a/srcpkgs/nextdns/files/nextdns/run
+++ b/srcpkgs/nextdns/files/nextdns/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+exec 2>&1
+[ -r conf ] && . ./conf
+exec /usr/bin/nextdns run ${OPTS:--config-file /etc/nextdns.conf}

--- a/srcpkgs/nextdns/patches/Don't touch files managed by xbps.patch
+++ b/srcpkgs/nextdns/patches/Don't touch files managed by xbps.patch
@@ -1,0 +1,26 @@
+diff --recursive --unified nextdns-1.39.4-clean/host/service/runit/service.go nextdns-1.39.4/host/service/runit/service.go
+--- nextdns-1.39.4-clean/host/service/runit/service.go	2023-04-14 00:46:58.232616533 -0400
++++ nextdns-1.39.4/host/service/runit/service.go	2023-04-14 01:12:43.931927878 -0400
+@@ -31,20 +31,14 @@
+ }
+ 
+ func (s Service) Install() error {
+-	if err := internal.CreateWithTemplate(s.Path, tmpl, 0755, s.Config); err != nil {
+-		return err
+-	}
+-	if err := os.Symlink(strings.TrimSuffix(s.Path, "/run"), "/etc/runit/runsvdir/current/"+s.Config.Name); err != nil {
++	if err := os.Symlink(strings.TrimSuffix(s.Path, "/run"), "/var/service/"+s.Config.Name); err != nil {
+ 		return err
+ 	}
+ 	return nil
+ }
+ 
+ func (s Service) Uninstall() error {
+-	if err := os.RemoveAll("/etc/runit/runsvdir/current/" + s.Config.Name); err != nil {
+-		return err
+-	}
+-	if err := os.RemoveAll(strings.TrimSuffix(s.Path, "/run")); err != nil {
++	if err := os.RemoveAll("/var/service/" + s.Config.Name); err != nil {
+ 		return err
+ 	}
+ 	return nil

--- a/srcpkgs/nextdns/template
+++ b/srcpkgs/nextdns/template
@@ -1,0 +1,18 @@
+# Template file for 'nextdns'
+pkgname=nextdns
+version=1.39.4
+revision=1
+build_style=go
+go_import_path="github.com/nextdns/nextdns"
+go_ldflags="-X main.version=${version}"
+short_desc="NextDNS CLI client (DoH Proxy)"
+maintainer="RunningDroid <runningdroid@zoho.com>"
+license="MIT"
+homepage="https://nextdns.io/"
+distfiles="https://github.com/nextdns/nextdns/archive/refs/tags/v${version}.tar.gz"
+checksum=e24db909fbd732e064be465b74f4004a6f4fc0f422ef7c10e86ff707a016ccac
+
+post_install() {
+	vsv nextdns
+	vlicense LICENSE
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
Closes #19905
Based on #30603, which replaced #20022