### PR TITLE
grml-zsh-config: update to 0.19.4.

### DIFF
--- a/srcpkgs/grml-zsh-config/template
+++ b/srcpkgs/grml-zsh-config/template
@@ -1,6 +1,6 @@
 # Template file for 'grml-zsh-config'
 pkgname=grml-zsh-config
-version=0.19.1
+version=0.19.4
 revision=1
 wrksrc="grml-etc-core-${version}"
 hostmakedepends="make txt2tags"
@@ -9,7 +9,7 @@ maintainer="Christian Poulwey <christian.poulwey@t-online.de>"
 license="GPL-2.0-only"
 homepage="https://grml.org/zsh/"
 distfiles="https://github.com/grml/grml-etc-core/archive/refs/tags/v${version}.tar.gz"
-checksum=ed9dd8101ede34ae0abaa4365cc2a378904a5198e21cdc208001dbd4abfd8d47
+checksum=b3a896bb8f16f4069881e1ae2ee6d7d9220a49b05ecbaab573db038310042ad7
 
 pre_build() {
 	make -C doc/ grmlzshrc.5


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

With the last version (0.19.1), there is a grep warning on every startup: `grep: warning: stray \ before 0`