### PR TITLE
plasma 5.26

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1588,6 +1588,7 @@ libKF5Mime.so.5 kmime-17.12.1_1
 libKF5Kirigami2.so.5 kirigami2-5.47.0_1
 libtaskmanager.so.6 plasma-workspace-5.8.4_1
 libnotificationmanager.so.1 plasma-workspace-5.15.90_1
+libKPipeWire.so.5 kpipewire-5.26.0_1
 libZXing.so.1 zxing-cpp-1.2.0_1
 libfreerdp-client2.so.2 libfreerdp-2.2.0_3
 libfreerdp2.so.2 libfreerdp-2.2.0_3

--- a/srcpkgs/bluedevil/template
+++ b/srcpkgs/bluedevil/template
@@ -1,20 +1,17 @@
 # Template file for 'bluedevil'
 pkgname=bluedevil
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules kcoreaddons qt5-qmake qt5-host-tools
- gettext"
-makedepends="bluez-qt5-devel kded-devel kio-devel plasma-framework-devel"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools
+ kpackage-devel kconfig-devel kcoreaddons-devel gettext
+ kcmutils-devel"
+makedepends="bluez-qt5-devel kded-devel kio-devel plasma-framework-devel
+ kcmutils-devel"
 short_desc="KDE Bluetooth integration"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/bluedevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=656173f9d18ce153dc5b3638006d0eefa809e57c4c66aad1a118d1d272a93615
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel"
-	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-fi
+checksum=b275b33094961f84310de6d37a5ba197bd34f10f1807ee0462ffbfde8fdc23af

--- a/srcpkgs/breeze-gtk/template
+++ b/srcpkgs/breeze-gtk/template
@@ -1,17 +1,13 @@
 # Template file for 'breeze-gtk'
 pkgname=breeze-gtk
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules sassc python3 python3-cairo"
+hostmakedepends="extra-cmake-modules sassc python3 python3-cairo qt5-devel"
 makedepends="qt5-devel breeze"
-short_desc="A GTK Theme Built to Match KDE's Breeze"
+short_desc="GTK Theme Built to Match KDE's Breeze"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/breeze-gtk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d93473f0fa76c1036a5ce361859b36f14f4226ab8f9d54f10282ec1661eeb6da
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" qt5-devel"
-fi
+checksum=c8bb6407ac9e91bf3333fc7eb30439984c05aa09cdb90615e90eb824757174e0

--- a/srcpkgs/breeze/template
+++ b/srcpkgs/breeze/template
@@ -1,11 +1,11 @@
 # Template file for 'breeze'
 pkgname=breeze
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons
- gettext kpackage"
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools
+ gettext kcmutils-devel kpackage-devel kconfig-devel kcoreaddons-devel"
 makedepends="frameworkintegration-devel kcmutils-devel kdecoration-devel
  fftw-devel plasma-framework-devel"
 depends="breeze-icons frameworkintegration breeze-snow-cursor-theme"
@@ -14,10 +14,9 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/breeze"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1c5fdf94cf7cfba0a396b6945639eee28d230213d4bf8e05ccbd31f7262b477d
+checksum=11ed27c9049a0ba1f0a0e506244872972e5cfa961bf9f528fca19ecd5738437c
 
 if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"
 	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
 fi
 

--- a/srcpkgs/kactivitymanagerd/template
+++ b/srcpkgs/kactivitymanagerd/template
@@ -1,6 +1,6 @@
 # Template file for 'kactivitymanagerd'
 pkgname=kactivitymanagerd
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 build_helper="qemu"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kactivitymanagerd"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a7746ec9dbb0dd19d6fffb74ef3b3ff097f91aff33d0d42e75df25f676cd2581
+checksum=d2621bb7ecaa13348d8790d432a1dd4bebd145730550d0fa2e8fcb2818b30dd1

--- a/srcpkgs/kde-cli-tools/template
+++ b/srcpkgs/kde-cli-tools/template
@@ -1,11 +1,11 @@
 # Template file for 'kde-cli-tools'
 pkgname=kde-cli-tools
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules gettext pkg-config
- kpackage kdoctools kcoreaddons python3 qt5-host-tools qt5-qmake"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules gettext pkg-config kcmutils-devel
+ kpackage-devel kdoctools kcoreaddons-devel python3 qt5-host-tools qt5-qmake"
 makedepends="kactivities5-devel kcmutils-devel kdelibs4support-devel
  kdesu-devel plasma-workspace-devel"
 depends="xdg-utils"
@@ -14,7 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kde-cli-tools"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=300c28d36433985152ac88ffb3279af1d1759bc8cd07bead8a92bbfe6c281b55
+checksum=14202b5f8d5751f44d1ad96f0d24971c5c2f6ed100e2dc4f855829debee89670
 
 post_install() {
 	ln -sf ../libexec/kf5/kdesu ${DESTDIR}/usr/bin

--- a/srcpkgs/kde-gtk-config5/template
+++ b/srcpkgs/kde-gtk-config5/template
@@ -1,6 +1,6 @@
 # Template file for 'kde-gtk-config5'
 pkgname=kde-gtk-config5
-version=5.25.3
+version=5.26.0
 revision=1
 wrksrc="${pkgname%5}-${version}"
 build_style=cmake
@@ -15,7 +15,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kde-gtk-config"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=7988a20c5d81c059eda8a820113b6e10a04919bde29055a49b81d7e3dc064b76
+checksum=579c1c538ec72e7e9fa7f7c17a09ad0f2461a12922847d91aa040838f382ce79
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kcoreaddons"

--- a/srcpkgs/kde5/template
+++ b/srcpkgs/kde5/template
@@ -1,6 +1,6 @@
 # Template file for 'kde5'
 pkgname=kde5
-version=5.23.0
+version=5.26.0
 revision=1
 build_style=meta
 depends="bluedevil>=${version}

--- a/srcpkgs/kdecoration/template
+++ b/srcpkgs/kdecoration/template
@@ -1,6 +1,6 @@
 # Template file for 'kdecoration'
 pkgname=kdecoration
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdecoration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=3ef59443be9b602a85710d0de1d39d9e9f5acc98698c0d13628ad66627b6de2c
+checksum=8be1e1442ed7b4e545341b83478261cff800fe0ffaf4b97be80cc78c6b3da631
 
 kdecoration-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/kdeplasma-addons5/template
+++ b/srcpkgs/kdeplasma-addons5/template
@@ -1,22 +1,17 @@
 # Template file for 'kdeplasma-addons5'
 pkgname=kdeplasma-addons5
-version=5.25.3
+version=5.26.0
 revision=1
 wrksrc="${pkgname%5}-${version}"
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcoreaddons
- gettext"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools pkg-config
+ kpackage-devel kconfig-devel kcoreaddons-devel kcmutils-devel gettext"
 makedepends="kross-devel kdesignerplugin-devel kdoctools-devel kholidays-devel
- plasma-workspace-devel purpose-devel"
+ plasma-workspace-devel purpose-devel NetworkManager-devel"
 short_desc="Various Plasma addons"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kdeplasma-addons"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname%5}-${version}.tar.xz"
-checksum=152fafbdbb7e9b68237893ffbe7e7ba349eb7e603ccfa92db27bb5443c36277d
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"
-	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-fi
+checksum=30c0a5577d819a1eacb8f2977f20e1f77cec83d1a406f024d562e523eadad6d9

--- a/srcpkgs/kgamma5/template
+++ b/srcpkgs/kgamma5/template
@@ -1,6 +1,6 @@
 # Template file for 'kgamma5'
 pkgname=kgamma5
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kgamma5"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a03e0fc48be83799fad555576c85b45072a8e42863ca68741a0ca5750d04e580
+checksum=90f8ad111eb32c60218bd6cf5ace3247918a4af8fdedebf6b913fae94de4f784

--- a/srcpkgs/khotkeys/template
+++ b/srcpkgs/khotkeys/template
@@ -1,6 +1,6 @@
 # Template file for 'khotkeys'
 pkgname=khotkeys
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only, LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/khotkeys"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=b2e530a247a4876df170f93df4eac1bac9117aceeb4134673585ee26293d8cec
+checksum=85b539cde1c114abb6198e2ad073850d6e428a57a316f2e21d7c5c9d1dae360a
 
 if [ "$CROSS_BUILD" ]; then
 	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"

--- a/srcpkgs/kinfocenter/template
+++ b/srcpkgs/kinfocenter/template
@@ -1,11 +1,12 @@
 # Template file for 'kinfocenter'
 pkgname=kinfocenter
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext pkg-config qt5-host-tools qt5-qmake
- kauth kpackage-devel kconfig-devel kcoreaddons-devel kdoctools-devel"
+ kauth kpackage-devel kconfig-devel kcoreaddons-devel kdoctools-devel
+ kcmutils-devel"
 makedepends="kdoctools plasma-framework-devel kdesignerplugin-devel kcmutils-devel
  kdelibs4support-devel kwayland-devel glu-devel pciutils-devel libraw1394-devel
  ksolid-devel"
@@ -15,8 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/kinfocenter"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c1aa9db639b8d162870bf6c5ee2ad91eede3972c7c519bc7ce9c918955f6139e
-
-if [ "$CROSS_BUILD" ]; then
-	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-fi
+checksum=02c11b6bae2c00d095c5ef3b846647884fbfc7dfca8636967fd51ea7bb012e5a

--- a/srcpkgs/kmenuedit/template
+++ b/srcpkgs/kmenuedit/template
@@ -1,6 +1,6 @@
 # Template file for 'kmenuedit'
 pkgname=kmenuedit
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kmenuedit"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=f792a1012b10118b13e8baa353fd014fc2051f35b2cb139b2a1b6491a8226778
+checksum=b1ead79128d9183ded58507b411afa88bb329777b420f4a7252c286a92b4d1b1

--- a/srcpkgs/kpipewire-devel
+++ b/srcpkgs/kpipewire-devel
@@ -1,0 +1,1 @@
+kpipewire

--- a/srcpkgs/kpipewire/template
+++ b/srcpkgs/kpipewire/template
@@ -1,0 +1,26 @@
+# Template file for 'kpipewire'
+pkgname=kpipewire
+version=5.26.0
+revision=1
+build_style=cmake
+hostmakedepends="extra-cmake-modules plasma-wayland-protocols gettext
+ qt5-qmake qt5-host-tools pkg-config wayland-devel kcoreaddons
+ kwayland-devel"
+makedepends="ffmpeg-devel kcoreaddons-devel kwayland-devel ki18n-devel
+ libepoxy-devel pipewire-devel"
+short_desc="Components relating to Flatpak 'pipewire' use in Plasma"
+maintainer="John <me@johnnynator.dev>"
+license="GPL-3.0-or-later"
+homepage="https://invent.kde.org/plasma/kpipewire"
+distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=7a09f3325b1be7868135d10fccc27466c5ed5dab75b6c71634940ac7f8b6beee
+
+kpipewire-devel_package() {
+	depends="${sourcepkg}>=${version}_${revision}"
+	short_desc+=" - development files"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/cmake
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/kscreen/template
+++ b/srcpkgs/kscreen/template
@@ -1,22 +1,17 @@
 # Template file for 'kscreen'
 pkgname=kscreen
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules qt5-devel qt5-qmake
- gettext kcmutils kcoreaddons"
+ kpackage-devel kconfig-devel kcoreaddons-devel gettext kcmutils-devel"
 makedepends="kxmlgui-devel libkscreen-devel plasma-framework-devel
- qt5-sensors-devel kcmutils-devel"
+ layer-shell-qt-devel qt5-sensors-devel kcmutils-devel"
 depends="hicolor-icon-theme"
 short_desc="KDE screen management software"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7f534944c81e7ca35b676cff065c64deebe2ec2fe06b31849465254a5ffc375d
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"
-	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-fi
+checksum=26e4295fac92e142b25e97908866860506bf4f52ef5e1d114c788c1506c3c52b

--- a/srcpkgs/kscreenlocker/template
+++ b/srcpkgs/kscreenlocker/template
@@ -1,11 +1,11 @@
 # Template file for 'kscreenlocker'
 pkgname=kscreenlocker
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules pkg-config kcoreaddons qt5-qmake
- qt5-host-tools gettext kcmutils"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules pkg-config kcoreaddons-devel
+ qt5-qmake wayland-devel qt5-host-tools gettext kcmutils-devel"
 makedepends="kdeclarative-devel kidletime-devel kcmutils-devel
  libSM-devel kwayland-devel libXi-devel pam-devel libXcursor-devel
  layer-shell-qt-devel"
@@ -14,13 +14,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kscreenlocker"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=8c8f99c49932e9ebba0738f8fa302718485d26403c730096e75b2524471e31ce
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" wayland-devel"
-	configure_args+=" -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson"
-	configure_args+=" -DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
-fi
+checksum=e412b2cf65d69f80a866d0332397b494243068e270225f7c95de227b913ec73d
 
 kscreenlocker-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/ksshaskpass/template
+++ b/srcpkgs/ksshaskpass/template
@@ -1,6 +1,6 @@
 # Template file for 'ksshaskpass'
 pkgname=ksshaskpass
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,5 +12,5 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/ksshaskpass"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=d31a602cc1375458390b577ce1fd8b7d16789cb565eb07f66109bbfdf539d469
+checksum=cc2756c5453c22d08c4797d2684786ce6c2a4eed398a07887b9097378e6dc5f1
 alternatives="ssh-askpass:/usr/libexec/ssh-askpass:/usr/bin/ksshaskpass"

--- a/srcpkgs/ksystemstats/template
+++ b/srcpkgs/ksystemstats/template
@@ -1,6 +1,6 @@
 # Template file for 'ksystemstats'
 pkgname=ksystemstats
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules qt5-qmake gettext
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only, LGPL-2.1-only OR LGPL-3-only"
 homepage="https://invent.kde.org/plasma/ksystemstats"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=8e34ff0c90722019202d82d74e2db2ea947b62199aaccad8ea3c20c0beaa0868
+checksum=a408e183daf325bf27d08403ed1214beb7a4b2ffd768044e3b02ce87c3026b0c

--- a/srcpkgs/kwallet-pam/template
+++ b/srcpkgs/kwallet-pam/template
@@ -1,6 +1,6 @@
 # Template file for 'kwallet-pam'
 pkgname=kwallet-pam
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 hostmakedepends="qt5-qmake qt5-host-tools extra-cmake-modules"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwallet-pam"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4b8a3388f3496541be376c2b71c0596db1d46bd71041f3eb47ef3b0de82e64c4
+checksum=b8bba12804306f565e5a76eafeea6353aabfabd937b29bb098e777e7adb62ccf

--- a/srcpkgs/kwayland-integration/template
+++ b/srcpkgs/kwayland-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'kwayland-integration'
 pkgname=kwayland-integration
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/kwayland-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4eae00d046542dbcab47568bfd78b1e708837df4a82ae982297b5fdd5fe48534
+checksum=ee1041d400424b7f4116d3395906a3bda752e547f7d3639c589d919fe4ada440

--- a/srcpkgs/kwin/INSTALL
+++ b/srcpkgs/kwin/INSTALL
@@ -1,0 +1,5 @@
+case "${ACTION}" in
+post)
+	setcap CAP_SYS_NICE=+ep usr/bin/kwin_wayland
+	;;
+esac

--- a/srcpkgs/kwin/template
+++ b/srcpkgs/kwin/template
@@ -1,29 +1,28 @@
 # Template file for 'kwin'
 pkgname=kwin
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 build_helper=qemu
-configure_args="-DBUILD_TESTING=OFF
- -DDESKTOPTOJSON_EXECUTABLE=/usr/bin/desktoptojson
- -DFORCE_CROSSCOMPILED_TOOLS=ON"
+configure_args="-DBUILD_TESTING=OFF -DFORCE_CROSSCOMPILED_TOOLS=ON
+ -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules gettext breeze pkg-config
  qt5-qmake qt5-host-tools kcoreaddons kconfig-devel qt5-wayland
- kwayland-devel kpackage-devel kservice-devel"
+ kwayland-devel kpackage-devel kservice-devel kcmutils-devel"
 makedepends="plasma-framework-devel kcmutils-devel knewstuff-devel
  kscreenlocker-devel kinit-devel xcb-util-cursor-devel qt5-multimedia-devel
  kdecoration-devel libxkbcommon-devel libinput-devel libSM-devel
- libICE-devel xcb-util-wm-devel qt5-sensors-devel libcap-devel lcms2-devel
+ libICE-devel xcb-util-wm-devel qt5-sensors-devel lcms2-devel
  pipewire-devel krunner-devel xorg-server-xwayland libxcvt-devel hwids
  libatomic-devel"
 depends="breeze hicolor-icon-theme kinit qt5-core>=5.15.2<5.16.0
- hwids"
+ hwids libcap-progs"
 short_desc="KDE Window manager"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwin"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=52927c7b6a2f28c6b8a515b1eb6f7faeacdc0d53321290887ebaffb9ab2fd0ef
+checksum=3a9f4769c08c568397fbf956019c00de3086a18a263f2a1a2738fd4b344029fd
 replaces="kwayland-server>=0"
 
 kwin-devel_package() {

--- a/srcpkgs/kwrited/template
+++ b/srcpkgs/kwrited/template
@@ -1,6 +1,6 @@
 # Template file for 'kwrited'
 pkgname=kwrited
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -11,4 +11,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/kwrited"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=ec2acf8b08e873ef5339d39a66022393ae2b11792d341a4b45640005dfad6a8c
+checksum=2e104432db211321beab24d55dcf37d69aebb8c1d34251fabbaa16a8ee2d6b9c

--- a/srcpkgs/layer-shell-qt/template
+++ b/srcpkgs/layer-shell-qt/template
@@ -1,6 +1,6 @@
 # Template file for 'layer-shell-qt'
 pkgname=layer-shell-qt
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 confiugre_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/layer-shell-qt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=60c5172a66562f1a12b8d27bc632e80eb721fb7dab89c5f3d7ac12c849c53d1b
+checksum=de043d147e2d900227870c73881015895b4b37d971a5075ffeaa021026cfb61e
 
 layer-shell-qt-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/libkscreen/template
+++ b/srcpkgs/libkscreen/template
@@ -1,18 +1,19 @@
 # Template file for 'libkscreen'
 pkgname=libkscreen
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
 hostmakedepends="pkg-config extra-cmake-modules qt5-host-tools qt5-x11extras-devel
  plasma-wayland-protocols qt5-wayland wayland-devel"
-makedepends="qt5-tools-devel qt5-x11extras-devel libXrandr-devel kwayland-devel"
+makedepends="qt5-tools-devel qt5-x11extras-devel libXrandr-devel kwayland-devel
+ kconfig-devel"
 short_desc="KDE screen management software"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libkscreen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e59fd83678eaa726d72afda7313d081943cb63b9abfbe85627dc334ec0ccb3d7
+checksum=4e9aeb63a89834a2bf46e56f67db44aadcdcc3c9a7852dc3162abc6397115e24
 
 libkscreen-devel_package() {
 	short_desc+=" - development"

--- a/srcpkgs/libksysguard/template
+++ b/srcpkgs/libksysguard/template
@@ -1,6 +1,6 @@
 # Template file for 'libksysguard'
 pkgname=libksysguard
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext kauth qt5-host-tools qt5-qmake
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/libksysguard"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=094503e82a9782e31ed8ed58487cca2fd14da168196fa7b89c3657bc65cf39d7
+checksum=43b2f473edc4680511386674582a25f1261cefd19091253a58b9e1eb8d529296
 
 build_options="webengine"
 

--- a/srcpkgs/milou/template
+++ b/srcpkgs/milou/template
@@ -1,6 +1,6 @@
 # Template file for 'milou'
 pkgname=milou
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -12,7 +12,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LPGL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/milou"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=57915f252b8b14c8387a2a518fe7e0fa1344be848c5214197d9564635b8963f5
+checksum=c0efe738142ade01d6b9730502cee6ab70827e26be403e7a639fc84f7d508fbc
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/oxygen/template
+++ b/srcpkgs/oxygen/template
@@ -1,6 +1,6 @@
 # Template file for 'oxygen'
 pkgname=oxygen
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later, GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/oxygen"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=70993e228481830e4c6f1de34266c52e97a8b3be1b32d28dfd66f4d0aaadd37a
+checksum=9f1905df0ec089fabc8f549faf70e146f7a273b6339f1303db324840b66d6c55

--- a/srcpkgs/plasma-browser-integration/template
+++ b/srcpkgs/plasma-browser-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-browser-integration'
 pkgname=plasma-browser-integration
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-browser-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=e2ef0e026ce7f572776100133444855ebbc7f8ebb9e59f63c8800f0d994b2ecf
+checksum=f46925081ae87bb0991a9fc097486d657f7ec6b5614b8f212f9463a732c4f36f

--- a/srcpkgs/plasma-desktop/template
+++ b/srcpkgs/plasma-desktop/template
@@ -1,16 +1,17 @@
 # Template file for 'plasma-desktop'
 pkgname=plasma-desktop
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
  -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules pkg-config kcoreaddons kdoctools
- kconfig-devel kcoreaddons-devel kded kpackage-devel kcmutils
- plasma-framework gettext qt5-qmake qt5-host-tools"
+ kconfig-devel kcoreaddons-devel kded kpackage-devel kcmutils-devel
+ plasma-framework intltool gettext qt5-qmake qt5-host-tools"
 makedepends="ibus-devel kactivities5-stats-devel kpeople-devel libcanberra-devel
  plasma-workspace-devel pulseaudio-devel xf86-input-evdev-devel
- xf86-input-synaptics-devel xf86-input-libinput-devel ksolid-devel"
+ xf86-input-synaptics-devel xf86-input-libinput-devel ksolid-devel
+ kaccounts-integration-devel libaccounts-qt5-devel"
 depends="kmenuedit polkit-kde-agent powerdevil systemsettings
  accountsservice ksystemstats"
 short_desc="KDE Plasma Desktop"
@@ -18,6 +19,6 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.2"
 homepage="https://invent.kde.org/plasma/plasma-desktop"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=48a3b70bffcb25647d0a11dfa3ff841891091c1a4152fb8f20a395a9307e8d8c
+checksum=7d9f7ecebed04e72c7346ee061010e7bfcca5cedb4121a6bfd3aa09e44d7ac74
 replaces="user-manager>=0"
 python_version=3

--- a/srcpkgs/plasma-disks/template
+++ b/srcpkgs/plasma-disks/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-disks'
 pkgname=plasma-disks
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-disks"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=9c2a25836f363952eea30ad8cb0671d232bb6b628c9b929075889b4d7a51ddb7
+checksum=b5b3aa3b661874fd3cab7a449a2cb4f51a4345945cf10368e7452f04ed0e6371

--- a/srcpkgs/plasma-firewall/template
+++ b/srcpkgs/plasma-firewall/template
@@ -1,14 +1,15 @@
 # Template file for 'plasma-firewall'
 pkgname=plasma-firewall
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools kcmutils
- kauth kcoreaddons gettext"
+configure_args="-DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules qt5-qmake qt5-host-tools
+ kcmutils-devel kauth-devel kcoreaddons-devel gettext"
 makedepends="kcmutils-devel plasma-framework-devel"
 short_desc="Control Panel for ufw (Uncomplicated Firewall)"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only"
 homepage="https://invent.kde.org/network/plasma-firewall"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=7b46ff95a2f5a6b687b8f69794026a84f9c783cd33ab91f66997cca698269333
+checksum=f95e8ee3f66b0cc4b35bf519f6171014c48cf4a39f94320ec12409a808725e21

--- a/srcpkgs/plasma-integration/template
+++ b/srcpkgs/plasma-integration/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-integration'
 pkgname=plasma-integration
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-integration"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=53aec648aa30e5de4e4ba32e4a76fc20fd6e984f8afd030529444eb0d6065ff3
+checksum=af61b043d696799acd6991b59f590c9e36c7ea3aa08b1993c0e356ab144c1b57

--- a/srcpkgs/plasma-nm/template
+++ b/srcpkgs/plasma-nm/template
@@ -1,11 +1,12 @@
 # Template file for 'plasma-nm'
 pkgname=plasma-nm
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules mobile-broadband-provider-info pkg-config
- gettext qt5-qmake qt5-host-tools kcoreaddons"
+ gettext qt5-qmake qt5-host-tools kpackage-devel kconfig-devel
+ kcoreaddons-devel plasma-framework kcmutils-devel"
 makedepends="plasma-workspace-devel networkmanager-qt5-devel kdelibs4support-devel
  kdesignerplugin-devel qca-qt5-devel modemmanager-qt5-devel kdoctools-devel
  openconnect-devel ksolid-devel"
@@ -15,9 +16,4 @@ maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-nm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a74bd66009712a52aa2b7dfc1c895e5a4e234b7723f84975b8b434e4a5e41f4d
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"
-	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-fi
+checksum=7e9adf6bbbd565227871f80716b46d86deddad32628b150185d38a1d70245eae

--- a/srcpkgs/plasma-pa/template
+++ b/srcpkgs/plasma-pa/template
@@ -1,22 +1,18 @@
 # Template file for 'plasma-pa'
 pkgname=plasma-pa
-version=5.25.3
-revision=2
+version=5.26.0
+revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules kcoreaddons kdoctools pkg-config
- gettext qt5-host-tools qt5-qmake"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules kdoctools pkg-config qt5-qmake
+ kpackage-devel kconfig-devel kcoreaddons-devel gettext qt5-host-tools
+ kcmutils-devel"
 makedepends="plasma-framework-devel kdoctools-devel pulseaudio-devel
- libcanberra-devel"
+ kcmutils-devel libcanberra-devel"
 depends="sound-theme-freedesktop"
 short_desc="PulseAudio Plasma applet"
 maintainer="John <me@johnnynator.dev>"
 license="LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-pa"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=41603522d62cb329a4a77c3219317565d434a150a4bf6ce05bb538e7c00e089d
-
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel"
-	configure_args+=" -DKF5_HOST_TOOLING=/usr/lib/cmake"
-fi
+checksum=ffb380e26cd4f5797d4bc724c1442ee35d9e13005957955e77b0cbed65965201

--- a/srcpkgs/plasma-sdk/template
+++ b/srcpkgs/plasma-sdk/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-sdk'
 pkgname=plasma-sdk
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-sdk"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=bce833bb9dd7184bad75ce75e037edd33a62c1caedacb3d1f30dd2bef1760ec2
+checksum=19b82e957cc6f0e674473ff4f6003af833162d8edf875e4c33f8f9a39b9e4ff3
 
 if [ "$CROSS_BUILD" ]; then
 	hostmakedepends+=" kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"

--- a/srcpkgs/plasma-systemmonitor/template
+++ b/srcpkgs/plasma-systemmonitor/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-systemmonitor'
 pkgname=plasma-systemmonitor
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules gettext qt5-host-tools qt5-qmake
@@ -12,4 +12,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-only OR GPL-3.0-only, LGPL-2.1-only OR LGPL-3.0-only"
 homepage="https://invent.kde.org/plasma/plasma-systemmonitor"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=1d9ac656721ae82795f6299790214ae1f4c0089338921b188e1d60eb419dbd1e
+checksum=41bf6b7e24d39b4e429a2dbf4389d86229f15997ad680f4405557e10291647fa

--- a/srcpkgs/plasma-thunderbolt/template
+++ b/srcpkgs/plasma-thunderbolt/template
@@ -1,10 +1,11 @@
 # Template file for 'plasma-thunderbolt'
 pkgname=plasma-thunderbolt
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-hostmakedepends="extra-cmake-modules kcoreaddons kcmutils
- gettext qt5-host-tools qt5-qmake"
+configure_args="-DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules kcoreaddons-devel
+ kcmutils-devel gettext qt5-host-tools qt5-qmake"
 makedepends="kcmutils-devel"
 depends="bolt"
 short_desc="Plasma integration for controlling Thunderbolt devices"
@@ -12,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-thunderbolt"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=a74854db87743f2fb7f46cc14f90537643a957431591bb9fcbde5fdef6c16d15
+checksum=a51c0ee41b4b4b9fad948789830d5945a7c6ff1b4fa35db4a95c3717fbdeaa1d
 
 do_check() {
 	: # Requires running dbus and bolt services

--- a/srcpkgs/plasma-vault/template
+++ b/srcpkgs/plasma-vault/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-vault'
 pkgname=plasma-vault
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args=" -DKF5_HOST_TOOLING=/usr/lib/cmake
@@ -14,4 +14,4 @@ maintainer="Giuseppe Fierro <gspe@ae-design.ws>"
 license="GPL-2.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later"
 homepage="https://github.com/KDE/plasma-vault"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=06105ca3329f50b99e56d13b3b077657857afb90be17e781054cd4fd7c3e0bde
+checksum=4daac65bd5f3a593af6405233bd2ca564c573d8dc045a639b7b084f8fb89a74b

--- a/srcpkgs/plasma-wayland-protocols/template
+++ b/srcpkgs/plasma-wayland-protocols/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-wayland-protocols'
 pkgname=plasma-wayland-protocols
-version=1.7.0
+version=1.9.0
 revision=1
 build_style=cmake
 hostmakedepends="extra-cmake-modules"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://invent.kde.org/libraries/plasma-wayland-protocols"
 distfiles="${KDE_SITE}/${pkgname}/${pkgname}-${version}.tar.xz"
-checksum=084e2685caa61d94c6fe86dce006b22474d7bb4b34c4cb96bd763b97e305fad6
+checksum=a4275b9a854716fa5ed9c2ba2d697df2b0749fc45a28ad965e68d0aa36c5d4c8
 
 post_install() {
 	vsed -e '/NOT CMAKE_SIZEOF_VOID_P STREQUAL/,+5d' \

--- a/srcpkgs/plasma-workspace-wallpapers/template
+++ b/srcpkgs/plasma-workspace-wallpapers/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace-wallpapers'
 pkgname=plasma-workspace-wallpapers
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -10,4 +10,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace-wallpapers"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=905e56406b21dde5161ef39a8d35d48e123aee8144c30bb89cbff726b1be5c97
+checksum=db9c9fe6fc7849c3b09d3b8ea5e063cfa2a3291ef0a7e5c349d60a546f1faa81

--- a/srcpkgs/plasma-workspace/template
+++ b/srcpkgs/plasma-workspace/template
@@ -1,6 +1,6 @@
 # Template file for 'plasma-workspace'
 pkgname=plasma-workspace
-version=5.25.3.1
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF
@@ -8,22 +8,22 @@ configure_args="-DBUILD_TESTING=OFF
  -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules iso-codes pkg-config kdoctools kcoreaddons
  qt5-wayland plasma-wayland-protocols gettext wayland-devel
- kcmutils kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"
+ kcmutils-devel kpackage-devel kconfig-devel kcoreaddons-devel plasma-framework"
 makedepends="qt5-devel qt5-declarative-devel qt5-script-devel plasma-framework-devel
  krunner-devel kjsembed-devel knotifyconfig-devel kdesu-devel knewstuff-devel
  kcmutils-devel kidletime-devel kdelibs4support-devel libksysguard-devel
  baloo5-devel ktexteditor-devel kwin-devel libxcb-devel libXtst-devel
  libqalculate-devel prison-devel kholidays-devel ksolid-devel kpeople-devel
  libXft-devel libkscreen-devel kactivities5-stats-devel
- $(vopt_if pipewire pipewire-devel)"
+ $(vopt_if pipewire kpipewire-devel)"
 depends="kactivitymanagerd kwin iso-codes milou plasma-integration
  kquickcharts qt5-wayland xorg-server-xwayland"
 short_desc="KDE Window manager"
 maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-or-later, LGPL-2.1-or-later"
 homepage="https://invent.kde.org/plasma/plasma-workspace"
-distfiles="${KDE_SITE}/plasma/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=a150355ff35a98e17afca3c2239b826817aa178cf89040140aba240066680f26
+distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
+checksum=841fd34bc55fa18c4d4373ba33b3ad6464f8f43a4db698aa8c83791f185556b2
 
 build_options="pipewire"
 build_options_default="pipewire"

--- a/srcpkgs/polkit-kde-agent/template
+++ b/srcpkgs/polkit-kde-agent/template
@@ -1,6 +1,6 @@
 # Template file for 'polkit-kde-agent'
 pkgname=polkit-kde-agent
-version=5.25.3
+version=5.26.0
 revision=1
 wrksrc="${pkgname}-1-${version}"
 build_style=cmake
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://commits.kde.org/polkit-kde-agent"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-1-${version}.tar.xz"
-checksum=95dd7433f42a6afbd01e03783fb36d4fc55ec7d8d7b1ab4146637e83f43d0648
+checksum=aa43650accd6bacab633e95b9b9c9d607dd22f265ac15ef7c0eda0e713c488bb

--- a/srcpkgs/powerdevil/template
+++ b/srcpkgs/powerdevil/template
@@ -1,11 +1,11 @@
 # Template file for 'powerdevil'
 pkgname=powerdevil
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
-hostmakedepends="extra-cmake-modules pkg-config kdoctools kauth
- gettext kconfig qt5-qmake qt5-host-tools"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
+hostmakedepends="extra-cmake-modules pkg-config kdoctools kauth-devel
+ gettext kconfig-devel kcmutils-devel qt5-qmake qt5-host-tools"
 makedepends="bluez-qt5-devel libkscreen-devel networkmanager-qt5-devel
  kdesignerplugin-devel kdoctools-devel plasma-workspace-devel ksolid-devel"
 short_desc="Power consumption settings of a Plasma"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/powerdevil"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=02ae3c4eef7d254aac687557f7f092e1a89beb3390ac77eadb784d2133d0dcd1
+checksum=76ee034a1515c3af2692c4f3cda0719195acf22f0872de852d2b0b6ede2cf0ae

--- a/srcpkgs/sddm-kcm/template
+++ b/srcpkgs/sddm-kcm/template
@@ -1,11 +1,11 @@
 # Template file for 'sddm-kcm'
 pkgname=sddm-kcm
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
-configure_args="-DBUILD_TESTING=OFF"
+configure_args="-DBUILD_TESTING=OFF -DKF5_HOST_TOOLING=/usr/lib/cmake"
 hostmakedepends="extra-cmake-modules pkg-config qt5-devel qt5-qmake
- kpackage gettext kauth kconfig"
+ kpackage-devel gettext kauth-devel kconfig-devel kcmutils-devel"
 makedepends="kio-devel xcb-util-image-devel libXcursor-devel
  kcmutils-devel knewstuff-devel"
 depends="sddm"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://invent.kde.org/plasma/sddm-kcm"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=4d5fb732630bf1eb1d997eba4fcc985c8ff3ce26d7469638cf0dca5d84db37d6
+checksum=271eaf95f73daa46f6517e385611196dfe5cf951959aab2d6ca7e9b058c6a6c3

--- a/srcpkgs/systemsettings/template
+++ b/srcpkgs/systemsettings/template
@@ -1,6 +1,6 @@
 # Template file for 'systemsettings'
 pkgname=systemsettings
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DBUILD_TESTING=OFF"
@@ -14,4 +14,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later, GFDL-1.2-only"
 homepage="https://invent.kde.org/plasma/systemsettings"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=99d0ec23f63934c93ce3de99e61bd21f9552b615eaebdcb4e36c808b43c9c402
+checksum=bf2f10c0b51454d567d94f912e7d7cb6b01a87f935a70399643da4962b884fcc

--- a/srcpkgs/xdg-desktop-portal-kde/template
+++ b/srcpkgs/xdg-desktop-portal-kde/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-kde'
 pkgname=xdg-desktop-portal-kde
-version=5.25.3
+version=5.26.0
 revision=1
 build_style=cmake
 configure_args="-DWaylandScanner_EXECUTABLE=/usr/bin/wayland-scanner"
@@ -13,4 +13,4 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-3.0-or-later"
 homepage="https://phabricator.kde.org/source/xdg-desktop-portal-kde/"
 distfiles="${KDE_SITE}/plasma/${version}/${pkgname}-${version}.tar.xz"
-checksum=c79ebabcd7a5c418de396a6e4e454cac91037db4021bdd381766057970bfec1e
+checksum=9e9a673fc9055f4c63d4f4b00264385f978be15f58868c1ef6cf4751bb472f9e


### PR DESCRIPTION
- bluedevil: update to 5.26.0.
- breeze-gtk: update to 5.26.0.
- breeze: update to 5.26.0.
- kactivitymanagerd: update to 5.26.0.
- kde-cli-tools: update to 5.26.0.
- kde-gtk-config5: update to 5.26.0.
- kdecoration: update to 5.26.0.
- kdeplasma-addons5: update to 5.26.0.
- kgamma5: update to 5.26.0.
- khotkeys: update to 5.26.0.
- kinfocenter: update to 5.26.0.
- kmenuedit: update to 5.26.0.
- kscreen: update to 5.26.0.
- kscreenlocker: update to 5.26.0.
- ksshaskpass: update to 5.26.0.
- ksystemstats: update to 5.26.0.
- kwallet-pam: update to 5.26.0.
- kwayland-integration: update to 5.26.0.
- kwin: update to 5.26.0.
- kwrited: update to 5.26.0.
- layer-shell-qt: update to 5.26.0.
- libkscreen: update to 5.26.0.
- libksysguard: update to 5.26.0.
- milou: update to 5.26.0.
- oxygen: update to 5.26.0.
- plasma-browser-integration: update to 5.26.0.
- plasma-desktop: update to 5.26.0.
- plasma-disks: update to 5.26.0.
- plasma-firewall: update to 5.26.0.
- plasma-integration: update to 5.26.0.
- plasma-nm: update to 5.26.0.
- plasma-pa: update to 5.26.0.
- plasma-sdk: update to 5.26.0.
- plasma-systemmonitor: update to 5.26.0.
- plasma-thunderbolt: update to 5.26.0.
- plasma-vault: update to 5.26.0.
- plasma-workspace-wallpapers: update to 5.26.0.
- plasma-workspace: update to 5.26.0.
- polkit-kde-agent: update to 5.26.0.
- powerdevil: update to 5.26.0.
- sddm-kcm: update to 5.26.0.
- systemsettings: update to 5.26.0.
- xdg-desktop-portal-kde: update to 5.26.0.
- plasma-wayland-protocols: update to 1.9.0.
- New package: kpipewire-5.26.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
