### PR TITLE
pari-nflistdata: update to 20220729.

### DIFF
--- a/srcpkgs/pari-nflistdata/template
+++ b/srcpkgs/pari-nflistdata/template
@@ -1,6 +1,6 @@
 # Template file for 'pari-nflistdata'
 pkgname=pari-nflistdata
-version=20220326
+version=20220729
 revision=1
 create_wrksrc=yes
 short_desc="PARI/GP database needed by nflist"


### PR DESCRIPTION
Note that upstream doesn't change the filenames on updates. We use the timestamp in the http server to manage the version.

In b7a1bbcde8d5277e7c9186928aca11bbd2d67dc2 the checksum was "fixed" (i.e. changed to the checksum of the new version) but the package in the void packages repository was not rebuilt.

Now we change the version so it's rebuilt.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
