### PR TITLE
intellij-idea-community-edition: Orphan package, remove i686 snippets

### DIFF
--- a/srcpkgs/intellij-idea-community-edition/template
+++ b/srcpkgs/intellij-idea-community-edition/template
@@ -1,11 +1,11 @@
 # Template file for 'intellij-idea-community-edition'
 pkgname=intellij-idea-community-edition
 version=2022.2.2
-revision=1
-archs="i686 x86_64"
+revision=2
+archs="x86_64"
 depends="jetbrains-jdk-bin giflib libXtst hicolor-icon-theme"
 short_desc="Java integrated development environment by JetBrains"
-maintainer="John <me@johnnynator.dev>"
+maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://www.jetbrains.org/"
 distfiles="https://download.jetbrains.com/idea/ideaIC-${version}-no-jbr.tar.gz"
@@ -39,31 +39,13 @@ do_install() {
 	rm ${DESTDIR}/usr/lib/intellij-idea/plugins/maven/lib/maven3/lib/jansi-native/osx -rf
 	rm ${DESTDIR}/usr/lib/intellij-idea/plugins/maven/lib/maven3/lib/jansi-native/freebsd32 -rf
 	rm ${DESTDIR}/usr/lib/intellij-idea/plugins/maven/lib/maven3/lib/jansi-native/freebsd64 -rf
-	case $XBPS_TARGET_MACHINE in
-		x86_64)
-		rm ${DESTDIR}/usr/lib/intellij-idea/bin/fsnotifier
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/x86 -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/aarch64 -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/mips64el -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/ppc64le -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/arm -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/plugins/webp/lib/libwebp/linux/libwebp_jni.so
-		rm ${DESTDIR}/usr/lib/intellij-idea/plugins/maven/lib/maven3/lib/jansi-native/linux32 -rf
-		;;
-		i686)
-		rm ${DESTDIR}/usr/lib/intellij-idea/bin/idea64.vmoptions
-		rm ${DESTDIR}/usr/lib/intellij-idea/bin/libdbm64.so
-		rm ${DESTDIR}//usr/lib/intellij-idea/plugins/cwm-plugin/quiche-native/linux-x86-64/ -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/x86-64 -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/aarch64 -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/mips64el -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/ppc64le -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/arm -rf
-		rm ${DESTDIR}/usr/lib/intellij-idea/plugins/webp/lib/libwebp/linux/libwebp_jni64.so
-		rm ${DESTDIR}/usr/lib/intellij-idea/plugins/maven/lib/maven3/lib/jansi-native/linux64 -rf
-		;;
-	esac
-
+	rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/x86 -rf
+	rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/aarch64 -rf
+	rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/mips64el -rf
+	rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/ppc64le -rf
+	rm ${DESTDIR}/usr/lib/intellij-idea/lib/pty4j-native/linux/arm -rf
+	rm ${DESTDIR}/usr/lib/intellij-idea/plugins/webp/lib/libwebp/linux/libwebp_jni.so
+	rm ${DESTDIR}/usr/lib/intellij-idea/plugins/maven/lib/maven3/lib/jansi-native/linux32 -rf
 	ln -sf /usr/lib/intellij-idea/bin/idea.sh ${DESTDIR}/usr/bin/idea
 	ln -sf /usr/lib/intellij-idea/bin/idea.png ${DESTDIR}/usr/share/pixmaps
 	ln -sf /usr/lib/intellij-idea/bin/idea.svg ${DESTDIR}/usr/share/icons/hicolor/scalable/apps


### PR DESCRIPTION
the i686 was essentially dead, since jetbrains-jdk-bin is x86_64 only,
also it was essentially untested and might have resulted in a broken pacakge either way

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
