### PR TITLE
New package: lite-1.11

### DIFF
--- a/srcpkgs/lite/patches/lite-build-fix.patch
+++ b/srcpkgs/lite/patches/lite-build-fix.patch
@@ -1,0 +1,22 @@
+(Patch from @classabbyamp on GitHub)
+--- a/build.sh
++++ b/build.sh
+@@ -1,7 +1,7 @@
+ #!/bin/bash
+ 
+-cflags="-Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc"
+-lflags="-lSDL2 -lm"
++cflags="$CFLAGS -Wall -O3 -g -std=gnu11 -fno-strict-aliasing -Isrc"
++lflags="$LDFLAGS -lSDL2 -lm"
+ 
+ if [[ $* == *windows* ]]; then
+   platform="windows"
+@@ -14,7 +14,7 @@
+ else
+   platform="unix"
+   outfile="lite"
+-  compiler="gcc"
++  compiler="$CC"
+   cflags="$cflags -DLUA_USE_POSIX"
+   lflags="$lflags -o $outfile"
+ fi

--- a/srcpkgs/lite/patches/lite-path-fix.patch
+++ b/srcpkgs/lite/patches/lite-path-fix.patch
@@ -1,0 +1,73 @@
+Upstream Issue: https://github.com/rxi/lite/issues/49
+
+(Patch adapted from Alpine Linux, updated for 1.06)
+
+diff --git a/data/core/commands/core.lua b/data/core/commands/core.lua
+index 5c9d622..568f0ef 100644
+--- a/data/core/commands/core.lua
++++ b/data/core/commands/core.lua
+@@ -85,7 +85,7 @@ command.add(nil, {
+   end,
+ 
+   ["core:open-user-module"] = function()
+-    core.root_view:open_doc(core.open_doc(EXEDIR .. "/data/user/init.lua"))
++    core.root_view:open_doc(core.open_doc("/usr/share/lite/user/init.lua"))
+   end,
+ 
+   ["core:open-project-module"] = function()
+diff --git a/data/core/init.lua b/data/core/init.lua
+index a25cdb5..3bea486 100644
+--- a/data/core/init.lua
++++ b/data/core/init.lua
+@@ -150,7 +150,7 @@ end
+ 
+ function core.load_plugins()
+   local no_errors = true
+-  local files = system.list_dir(EXEDIR .. "/data/plugins")
++  local files = system.list_dir("/usr/share/lite/plugins")
+   for _, filename in ipairs(files) do
+     local modname = "plugins." .. filename:gsub(".lua$", "")
+     local ok = core.try(require, modname)
+@@ -421,7 +421,7 @@ end
+ 
+ function core.on_error(err)
+   -- write error to file
+-  local fp = io.open(EXEDIR .. "/error.txt", "wb")
++  local fp = io.open("/tmp/lite-editor-error.txt", "wb")
+   fp:write("Error: " .. tostring(err) .. "\n")
+   fp:write(debug.traceback(nil, 4))
+   fp:close()
+diff --git a/data/core/style.lua b/data/core/style.lua
+index ab597c2..23b551f 100644
+--- a/data/core/style.lua
++++ b/data/core/style.lua
+@@ -7,10 +7,10 @@ style.scrollbar_size = common.round(4 * SCALE)
+ style.caret_width = common.round(2 * SCALE)
+ style.tab_width = common.round(170 * SCALE)
+ 
+-style.font = renderer.font.load(EXEDIR .. "/data/fonts/font.ttf", 14 * SCALE)
+-style.big_font = renderer.font.load(EXEDIR .. "/data/fonts/font.ttf", 34 * SCALE)
+-style.icon_font = renderer.font.load(EXEDIR .. "/data/fonts/icons.ttf", 14 * SCALE)
+-style.code_font = renderer.font.load(EXEDIR .. "/data/fonts/monospace.ttf", 13.5 * SCALE)
++style.font = renderer.font.load("/usr/share/lite/fonts/font.ttf", 14 * SCALE)
++style.big_font = renderer.font.load("/usr/share/lite/fonts/font.ttf", 34 * SCALE)
++style.icon_font = renderer.font.load("/usr/share/lite/fonts/icons.ttf", 14 * SCALE)
++style.code_font = renderer.font.load("/usr/share/lite/fonts/monospace.ttf", 13.5 * SCALE)
+ 
+ style.background = { common.color "#2e2e32" }
+ style.background2 = { common.color "#252529" }
+diff --git a/src/main.c b/src/main.c
+index c739f5f..0b796fa 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -119,8 +119,8 @@ int main(int argc, char **argv) {
+     "  SCALE = tonumber(os.getenv(\"LITE_SCALE\")) or SCALE\n"
+     "  PATHSEP = package.config:sub(1, 1)\n"
+     "  EXEDIR = EXEFILE:match(\"^(.+)[/\\\\].*$\")\n"
+-    "  package.path = EXEDIR .. '/data/?.lua;' .. package.path\n"
+-    "  package.path = EXEDIR .. '/data/?/init.lua;' .. package.path\n"
++    "  package.path = '/usr/share/lite/?.lua;' .. package.path\n"
++    "  package.path = '/usr/share/lite/?/init.lua;' .. package.path\n"
+     "  core = require('core')\n"
+     "  core.init()\n"
+     "  core.run()\n"

--- a/srcpkgs/lite/template
+++ b/srcpkgs/lite/template
@@ -1,0 +1,22 @@
+# Template file for 'lite'
+pkgname=lite
+version=1.11
+revision=1
+makedepends="SDL2-devel"
+short_desc="Lightweight text editor written mostly in Lua"
+maintainer="Dakota Richline <drichline@protonmail.com>"
+license="MIT"
+homepage="https://github.com/rxi/lite"
+distfiles="https://github.com/rxi/lite/archive/refs/tags/v${version}.tar.gz"
+checksum=2fd9466663182da56a36a557d05925d226dc1c5de6fb24e423a7b0056db2eec4
+
+do_build() {
+	bash build.sh
+}
+
+do_install() {
+	vlicense LICENSE
+	vmkdir usr/share/${pkgname}
+	vbin lite
+	vcopy data/* usr/share/${pkgname}
+}


### PR DESCRIPTION
Note: even though lite is a GUI app, it is meant to be launched from the terminal, e.g. `lite project-dir/`; upstream does not provide an svg icon or .desktop file. 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
