### PR TITLE
New package: superd-0.7

### DIFF
--- a/srcpkgs/superd/patches/add-installmisc-target.patch
+++ b/srcpkgs/superd/patches/add-installmisc-target.patch
@@ -1,0 +1,50 @@
+From 0983f081efada98a6b61d70de10bbf01d5f430bd Mon Sep 17 00:00:00 2001
+From: Jami Kettunen <jamipkettunen@gmail.com>
+Date: Sun, 16 Oct 2022 20:51:39 +0300
+Subject: [PATCH] makefile: add installmisc target to install everything except
+ binaries
+
+The "install" target still behaves like before but now one can
+"make installmisc" to not install the binaries in case they're being
+handled (built and installed) outside the makefile in e.g. a
+distribution's package build environment.
+
+Link: https://lists.sr.ht/~craftyguy/superd/patches/36158
+---
+ Makefile | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 0a7b0d2..8bd6946 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,12 +58,14 @@ doc: $(DOCS)
+ clean:
+ 	$(RM) $(DOCS) superd superctl
+ 
+-install: $(DOCS) superd superctl
++installbins: superd superctl
++	install -Dm755 superd -t $(DESTDIR)$(BINDIR)/
++	install -Dm755 superctl -t $(DESTDIR)$(BINDIR)/
++
++installmisc: $(DOCS)
+ 	mkdir -m755 -p \
+ 		$(DESTDIR)$(SYSCONFDIR)/superd/services \
+ 		$(DESTDIR)$(SHAREDIR)/superd/services
+-	install -Dm755 superd -t $(DESTDIR)$(BINDIR)/
+-	install -Dm755 superctl -t $(DESTDIR)$(BINDIR)/
+ 	install -Dm644 superd.1 -t $(DESTDIR)$(MANDIR)/man1/
+ 	install -Dm644 superd.service.5 -t $(DESTDIR)$(MANDIR)/man5/
+ 	install -Dm644 superctl.1 -t $(DESTDIR)$(MANDIR)/man1/
+@@ -72,6 +74,8 @@ install: $(DOCS) superd superctl
+ 	install -Dm644 completions/bash/superctl \
+ 		$(DESTDIR)$(SHAREDIR)/bash-completion/completions/superctl
+ 
++install: installbins installmisc
++
+ .PHONY: checkinstall
+ checkinstall:
+ 	$(DESTDIR)$(BINDIR)/superd -v
+-- 
+2.38.0
+

--- a/srcpkgs/superd/template
+++ b/srcpkgs/superd/template
@@ -1,0 +1,24 @@
+# Template file for 'superd'
+pkgname=superd
+version=0.7
+revision=1
+build_style=go
+go_import_path="sr.ht/~craftyguy/superd"
+go_package="${go_import_path}/cmd/superd ${go_import_path}/cmd/superctl"
+go_ldflags="-X 'main.Version=${version}'"
+make_dirs="/etc/superd/services 0755 root root"
+hostmakedepends="scdoc"
+short_desc="Lightweight user service supervising daemon"
+maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
+license="GPL-3.0-or-later"
+homepage="https://sr.ht/~craftyguy/superd/"
+distfiles="https://git.sr.ht/~craftyguy/superd/archive/${version}.tar.gz"
+checksum=7563647dd5303752237e1b8453c770dd83c908a239da73f48b11e2151109586b
+
+do_check() {
+	go test ./...
+}
+
+post_install() {
+	make PREFIX=/usr DESTDIR=${DESTDIR} installmisc
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

~~Since I had to add a `do_check()` myself it made me wonder if the go build-style should have a default of some kind. Thoughts?~~ As per conversation on `#xbps` IRC we should `: ${make_check_target:=./...}` and `go test -v ${make_check_target}`, but I'll reserve that for another PR and tweak all `build_style=go` packages as needed.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
