### PR TITLE
godot: update to 3.5.1 and enable PulseAudio backend

### DIFF
--- a/srcpkgs/godot/template
+++ b/srcpkgs/godot/template
@@ -1,6 +1,6 @@
 # Template file for 'godot'
 pkgname=godot
-version=3.5
+version=3.5.1
 revision=1
 archs="x86_64* i686* aarch64* armv7* ppc64*"
 build_style=scons
@@ -9,7 +9,7 @@ build_style=scons
 # Use builtin bullet for now as it's too old in repos (needs 2.89)
 # Toggle to not use builtin once bullet has been updated
 make_build_args="platform=x11 tools=yes target=release_debug dev=no progress=no
- pulseaudio=no builtin_bullet=false builtin_libpng=false builtin_libvpx=false
+ builtin_bullet=false builtin_libpng=false builtin_libvpx=false
  builtin_libwebp=false builtin_libogg=false builtin_libtheora=false
  builtin_opus=false builtin_libvorbis=false builtin_enet=false
  builtin_zlib=false builtin_freetype=false builtin_mbedtls=false
@@ -20,13 +20,13 @@ makedepends="
  libXinerama-devel libXrender-devel libXrandr-devel libX11-devel
  bullet-devel libpng-devel libvpx-devel libwebp-devel libogg-devel libtheora-devel
  opus-devel opusfile-devel libvorbis-devel libenet-devel zlib-devel mbedtls-devel
- miniupnpc-devel pcre2-devel"
+ miniupnpc-devel pcre2-devel pulseaudio-devel"
 short_desc="Multiplatform 2D and 3D engine"
 maintainer="Nick Hahn <nick.hahn@hotmail.de>"
 license="MIT"
 homepage="https://www.godotengine.org/"
-distfiles="https://github.com/godotengine/${pkgname}/archive/${version}-stable.tar.gz"
-checksum=c65425e1d56a7097990f231c27c9271b7159f763dc59f0eaba9273633e59da36
+distfiles="https://github.com/godotengine/godot/archive/${version}-stable.tar.gz"
+checksum=164523c1c8aef0b69b135645794f5bece3f63788556a56aa293c118cde457023
 nocross=https://build.voidlinux.org/builders/armv7l_builder/builds/6342/steps/shell_3/logs/stdio
 
 CFLAGS+=" -fPIE -fPIC"


### PR DESCRIPTION
Enabling Godot's PulseAudio driver fixes audio playback on PipeWire. Previously, the package's only enabled audio driver was ALSA, but Godot on alsa-pipewire stutters, and Godot on HW ALSA devices prevents PipeWire apps from playing audio.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - none, `./xbps-src -a armv6l pkg godot` claims godot can't cross-compile and I didn't try native building

Fixes #39936.