### PR TITLE
cocogitto, exa, cargo-outdated: rebuild for libgit2

### DIFF
--- a/srcpkgs/cargo-outdated/template
+++ b/srcpkgs/cargo-outdated/template
@@ -1,16 +1,16 @@
 # Template file for 'cargo-outdated'
 pkgname=cargo-outdated
 version=0.11.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config zlib-devel"
-makedepends="libgit2-devel openssl-devel"
+makedepends="libcurl-devel libgit2-devel openssl-devel"
 short_desc="Cargo subcommand for displaying when dependencies are out of date"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="MIT"
 homepage="https://github.com/kbknapp/cargo-outdated"
 changelog="https://raw.githubusercontent.com/kbknapp/cargo-outdated/master/CHANGELOG.md"
-distfiles="https://github.com/kbknapp/cargo-outdated/archive/v${version}.tar.gz"
+distfiles="https://github.com/kbknapp/cargo-outdated/archive/refs/tags/v${version}.tar.gz"
 checksum=2d80f0243d70a3563c48644dd3567519c32a733fb5d20f1161fd5d9f8e6e9146
 
 post_install() {

--- a/srcpkgs/cocogitto/template
+++ b/srcpkgs/cocogitto/template
@@ -1,7 +1,7 @@
 # Template file for 'cocogitto'
 pkgname=cocogitto
 version=5.2.0
-revision=1
+revision=2
 build_style=cargo
 build_helper=qemu
 hostmakedepends="pkg-config"
@@ -17,19 +17,13 @@ checksum=99f9dee05597d7721f6d046dbfefba5cb8d1c4ae22ced415f724affb3a6bd0cc
 # Test suite is not atomic, relies on user environment such as git user configuration
 make_check=no
 
-post_build() {
-	TARGET_DIR="target/${RUST_TARGET}/release"
-
-	for shell in bash zsh fish; do
-		vtargetrun ${TARGET_DIR}/cog generate-completions ${shell} > cog.${shell}
-	done
-}
-
 post_install() {
-	vlicense LICENSE
-	vdoc README.md
-
+	COG="${DESTDIR}/usr/bin/cog"
 	for shell in bash zsh fish; do
+		vtargetrun ${COG} generate-completions ${shell} > cog.${shell}
 		vcompletion cog.${shell} ${shell} cog
 	done
+
+	vdoc README.md
+	vlicense LICENSE
 }

--- a/srcpkgs/exa/template
+++ b/srcpkgs/exa/template
@@ -1,7 +1,7 @@
 # Template file for 'exa'
 pkgname=exa
 version=0.10.1
-revision=1
+revision=2
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="libgit2-devel"
@@ -9,7 +9,7 @@ short_desc="Modern replacement for ls"
 maintainer="Marcin Puc <tranzystorek.io@protonmail.com>"
 license="MIT"
 homepage="https://the.exa.website/"
-distfiles="https://github.com/ogham/exa/archive/v${version}.tar.gz
+distfiles="https://github.com/ogham/exa/archive/refs/tags/v${version}.tar.gz
  https://github.com/ogham/exa/releases/download/v${version}/exa-accoutrements-v${version}.zip"
 checksum="ff0fa0bfc4edef8bdbbb3cabe6fdbd5481a71abbbcc2159f402dea515353ae7c
  531596a1ef2a757c7728087529528150e6eb52bb8224fe575aa00a5f1b762849"
@@ -21,10 +21,10 @@ post_extract() {
 }
 
 post_install() {
-	vman accoutrements/man/exa.1
-	vman accoutrements/man/exa_colors.5
 	vcompletion completions/completions.bash bash
 	vcompletion completions/completions.fish fish
 	vcompletion completions/completions.zsh zsh
 	vlicense LICENCE
+	vman accoutrements/man/exa.1
+	vman accoutrements/man/exa_colors.5
 }


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
