### PR TITLE
Use unique names for bulk update commands

### DIFF
--- a/common/xbps-src/shutils/bulk.sh
+++ b/common/xbps-src/shutils/bulk.sh
@@ -54,7 +54,7 @@ bulk_sortdeps() {
 }
 
 bulk_build() {
-    local cmd="$1"
+    local bulk_build_cmd="$1"
     local NPROCS=$(($(nproc)*2))
     local NRUNNING=0
 
@@ -67,7 +67,7 @@ bulk_build() {
     fi
 
     # Compare installed pkg versions vs srcpkgs
-    case "$cmd" in
+    case "$bulk_build_cmd" in
     installed)
         bulk_sortdeps $(xbps-checkvers -f '%n' -I -D "$XBPS_DISTDIR")
         return $?
@@ -97,9 +97,9 @@ bulk_build() {
 }
 
 bulk_update() {
-    local cmd="$1" pkgs f rval
+    local bulk_update_cmd="$1" pkgs f rval
 
-    pkgs="$(bulk_build "${cmd}")"
+    pkgs="$(bulk_build "${bulk_update_cmd}")"
     [[ -z $pkgs ]] && return 0
 
     msg_normal "xbps-src: the following packages must be rebuilt and updated:\n"
@@ -119,7 +119,7 @@ bulk_update() {
             msg_error "xbps-src: failed to build $pkgver pkg!\n"
         fi
     done
-    if [ -n "$pkgs" -a "$cmd" == installed ]; then
+    if [ -n "$pkgs" -a "$bulk_update_cmd" == installed ]; then
         echo
         msg_normal "xbps-src: updating your system, confirm to proceed...\n"
         ${XBPS_SUCMD} "xbps-install --repository=$XBPS_REPOSITORY --repository=$XBPS_REPOSITORY/nonfree -u ${pkgs//[$'\n']/ }" || return 1


### PR DESCRIPTION
A regression introduced in 4c43245e0b (#37700) is causing the `xbps-src update-sys` command to skip the final step of installing the updated packages.

This happens because the `cmd` variable name clashes with a loop variable used in common/environment/setup/install.sh script [line 16](/void-linux/void-packages/blob/4c43245e0b989fa85fe57090a1a584d6e6650546/common/environment/setup/install.sh#L16). Thus the `"$cmd" == installed` comparison ([common/xbps-src/shutils/bulk.sh line 122](/void-linux/void-packages/blob/4c43245e0b989fa85fe57090a1a584d6e6650546/common/xbps-src/shutils/bulk.sh#L122)) fails and the installation step is skipped.

Using unique variable names in `bulk.sh` avoids this problem.

#### Testing the changes
- I tested the changes in this PR: **YES**