### PR TITLE
python3-Babel: update to 2.10.3.

### DIFF
--- a/srcpkgs/python3-Babel/template
+++ b/srcpkgs/python3-Babel/template
@@ -1,20 +1,19 @@
 # Template file for 'python3-Babel'
 pkgname=python3-Babel
-version=2.9.1
+version=2.10.3
 revision=1
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-pytz"
+depends="python3-pytz"
 checkdepends="python3-pytest python3-pytz python3-freezegun"
 short_desc="Tools for internationalizing Python applications (Python3)"
 maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="BSD-3-Clause"
-homepage="http://babel.pocoo.org/"
+homepage="https://babel.pocoo.org"
+changelog="https://raw.githubusercontent.com/python-babel/babel/master/CHANGES.rst"
 distfiles="${PYPI_SITE}/B/Babel/Babel-${version}.tar.gz"
-checksum=bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
-# test_extract_error_code fails: https://github.com/python-babel/babel/issues/802#issuecomment-1029132391
-make_check=no
+checksum=7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-Flask-Babel/template
+++ b/srcpkgs/python3-Flask-Babel/template
@@ -1,11 +1,12 @@
 # Template file for 'python3-Flask-Babel'
 pkgname=python3-Flask-Babel
 version=2.0.0
-revision=3
+revision=4
 wrksrc="${pkgname#*-}-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="python3-setuptools python3-Jinja2 python3-Babel python3-Flask"
+depends="python3-pytz python3-Jinja2 python3-Babel python3-Flask"
+checkdepends="${depends} python3-pytest-mock"
 short_desc="Python3 i18n and l10n support for Flask based on Babel and pytz"
 maintainer="pulux <pulux@pf4sh.de>"
 license="BSD-3-Clause"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Rev dep checks
- [x] fava
- [x] python3-Flask-Babel
- [x] python3-Sphinx
- [x] python3-WTForms
- [x] python3-jupyterlab_server
- [x] safeeyes
- [x] screenkey
- [x] wicd