### PR TITLE
New package: CalculiX-2.20

### DIFF
--- a/srcpkgs/CalculiX-ccx/template
+++ b/srcpkgs/CalculiX-ccx/template
@@ -1,0 +1,35 @@
+# Template file for 'CalculiX-ccx'
+pkgname=CalculiX-ccx
+version=2.20
+revision=1
+wrksrc=CalculiX
+build_wrksrc="ccx_${version}/src"
+hostmakedepends="gcc-fortran"
+makedepends="spooles arpack-ng-devel libgomp-devel openblas-devel"
+short_desc="3D Structural Finite Element Program - Solver"
+maintainer="Phicem <phicem@gmx.com>"
+license="GPL-2.0-or-later"
+homepage="http://www.dhondt.de/"
+distfiles="http://www.dhondt.de/ccx_${version}.src.tar.bz2"
+checksum=63bf6ea09e7edcae93e0145b1bb0579ea7ae82e046f6075a27c8145b72761bcf
+
+FFLAGS="-fallow-argument-mismatch"
+CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/spooles -DARCH=Linux -DSPOOLES -DARPACK -DMATRIXSTORAGE -DNETWORKOUT"
+
+post_patch() {
+	vsed -e 's,./date.pl; ,,' -i Makefile
+	# taken from date.pl, changed for reproducibility
+	vsed -e 's/You are using an executable made on.*/You are using an executable made on '"$(date --utc --date @$SOURCE_DATE_EPOCH +%Y-%m-%d)"'\\n");/g' \
+		-i ccx_$version.c -i CalculiXstep.c
+	vsed -e 's/COMPILETIME.*/COMPILETIME       '"$(date --utc --date @$SOURCE_DATE_EPOCH +%Y-%m-%d)"'\\n",p1);/g' \
+		-i frd.c
+}
+
+do_build() {
+	make CC="$CC" FC="$FC" CFLAGS="$CFLAGS" FFLAGS="$FFLAGS" \
+		LIBS="${XBPS_CROSS_BASE}/usr/lib/spooles.a ${XBPS_CROSS_BASE}/usr/lib/libarpack.so ${XBPS_CROSS_BASE}/usr/lib/libopenblas.so -lpthread -lm -lc"
+}
+
+do_install() {
+	vbin ccx_${version} ccx
+}

--- a/srcpkgs/CalculiX-cgx/patches/Makefile.patch
+++ b/srcpkgs/CalculiX-cgx/patches/Makefile.patch
@@ -1,0 +1,12 @@
+--- a/CalculiX/cgx_2.20/src/Makefile
++++ b/CalculiX/cgx_2.20/src/Makefile
+@@ -67,7 +67,7 @@
+ OUTIL = $(SUTIL:.c=.o)
+ 
+ cgx: $(OLIB) $(OUTIL) $(OULIB)
+-	g++  $(OULIB)  $(OLIB) $(OUTIL)  $(CFLAGS) $(LFLAGS) -o  $@
++	$(CXX)  $(OULIB)  $(OLIB) $(OUTIL)  $(CFLAGS) $(LFLAGS) -o  $@
+ 
+ 
+ 
+

--- a/srcpkgs/CalculiX-cgx/template
+++ b/srcpkgs/CalculiX-cgx/template
@@ -1,0 +1,35 @@
+# Template file for 'CalculiX-cgx'
+pkgname=CalculiX-cgx
+version=2.20
+revision=1
+create_wrksrc=yes
+build_wrksrc="CalculiX/cgx_${version}/src"
+build_style="gnu-makefile"
+makedepends="glu-devel libglvnd-devel libXmu-devel libXi-devel"
+short_desc="3D Structural Finite Element Program - Graphical interface"
+maintainer="Phicem <phicem@gmx.com>"
+license="GPL-2.0-or-later, custom:GLUT"
+homepage="http://www.dhondt.de/"
+distfiles="http://www.dhondt.de/cgx_${version}.all.tar.bz2"
+checksum=f4c840c3633718547e33f86b2d7bc6b35608dd8d6cbf9fa192cecef34f2dc908
+CFLAGS="-DSEMINIT -I. -I${XBPS_CROSS_BASE}/usr/include/GL -I${XBPS_CROSS_BASE}/usr/X11/include -I../../libSNL/src -I../../glut-3.5/src"
+_tetgen_version=1.5.1
+_tetgen_dir=${XBPS_BUILDDIR}/${pkgname}-${version}/tetgen${_tetgen_version}
+
+post_build() {
+	make -C ${_tetgen_dir}  CC=$CC CXX=$CXX CFLAGS="$CFLAGS" tetgen tetlib
+}
+
+do_install() {
+	vbin cgx
+	vlicense ../README CGX_LICENSE
+	vlicense ../../glut-3.5/NOTICE GLUT_LICENSE
+	vbin ${_tetgen_dir}/tetgen
+	vinstall ${_tetgen_dir}/libtet.a 644 usr/lib
+	vlicense ${_tetgen_dir}/LICENSE TETGEN_LICENSE
+}
+
+post_extract() {
+	bsdtar -xvf tetgen${_tetgen_version}.tar
+	rm tetgen${_tetgen_version}.tar
+}

--- a/srcpkgs/CalculiX/template
+++ b/srcpkgs/CalculiX/template
@@ -1,0 +1,10 @@
+# Template file for 'CalculiX'
+pkgname=CalculiX
+version=2.20
+revision=1
+build_style=meta
+depends="CalculiX-cgx-${version}_${revision} CalculiX-ccx-${version}_${revision}"
+short_desc="3D Structural Finite Element Program"
+maintainer="Phicem <phicem@gmx.com>"
+license="GPL-2.0-only"
+homepage="http://www.dhondt.de/"

--- a/srcpkgs/spooles/template
+++ b/srcpkgs/spooles/template
@@ -1,0 +1,24 @@
+# Template file for 'spooles'
+pkgname=spooles
+version=2.2
+revision=1
+create_wrksrc=yes
+build_style="gnu-makefile"
+make_build_target="lib"
+hostmakedepends="perl"
+short_desc="SParse Object Oriented Linear Equations Solver"
+maintainer="Phicem <phicem@gmx.com>"
+license="Public Domain"
+homepage="https://netlib.org/linalg/spooles/spooles.2.2.html"
+distfiles="https://netlib.org/linalg/spooles/spooles.${version}.tgz"
+checksum=a84559a0e987a1e423055ef4fdf3035d55b65bbe4bf915efaa1a35bef7f8c5dd
+
+do_install() {
+	vinstall spooles.a 644 usr/lib
+	for file in *.h; do
+		vinstall ${file} 644 usr/include/$pkgname
+	done
+	for file in */*.h; do
+		vinstall ${file} 644 "usr/include/$pkgname/$(dirname $file)"
+	done
+}


### PR DESCRIPTION
### NEW PACKAGE - CalculiX

This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

CalculiX is a 3D finite element program. It is an optional but important dependency of FreeCAD (for mechanical and thermal calculations). This PR is related to issue https://github.com/void-linux/void-packages/issues/5603.

CalculiX is split in two parts: the solver (CalculiX-ccx) and the graphical interface and pre/post-processing (CalculiX-cgx).

This PR includes 4 packages, each in a separate commit:
- spooles (build dependency for CalculiX-ccx)
- CalculiX-ccx
- CalculiX-cgx (including tetgen binary)
- CalculiX meta-package (which brings CalculiX-ccx and CalculiX-cgx)


### Tests
#### Local build testing
- Native x86_64 (glibc and musl): **OK**
- Native i686 (glibc) (from an x86_64 machine) : **OK**
- Native armv7l (glibc): **OK**

#### Cross build testing (from x86_64 machine)
- Cross-compiling to armv7l: **OK** (requires using `./xbps-src binary-boostrap i686` on an x86_64 system, otherwise it fails)
- Cross-compiling to aarch64: **OK**

#### Runtime testing
- On x86_64 (glibc): **OK** (for CalculiX-ccx: some calculation tests differ from the official reference results files)
- On armv7l: **OK** (for CalculiX-ccx: some calculation differences too)
- On i686: **NOT TESTED** 


