### PR TITLE
libgbinder: update to 1.1.26.

### DIFF
--- a/srcpkgs/libgbinder/template
+++ b/srcpkgs/libgbinder/template
@@ -1,6 +1,6 @@
 # Template file for 'libgbinder'
 pkgname=libgbinder
-version=1.1.25
+version=1.1.26
 revision=1
 build_style=gnu-makefile
 make_use_env=1
@@ -14,8 +14,9 @@ short_desc="GLib-style interface to binder (Android IPC mechanism)"
 maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/mer-hybris/libgbinder"
+changelog="https://raw.githubusercontent.com/mer-hybris/libgbinder/master/debian/changelog"
 distfiles="https://github.com/mer-hybris/libgbinder/archive/refs/tags/${version}.tar.gz"
-checksum=92f3eaedba2d9a6d0c9db22cad4d7dea72259770fb4579d92929d34e2012381d
+checksum=6c3704eabf094d423ecb862e604c2bbc9211c7544530620b730d83d9a147b2ce
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
