### PR TITLE
New package: lziprecover-1.23

### DIFF
--- a/srcpkgs/lziprecover/template
+++ b/srcpkgs/lziprecover/template
@@ -1,0 +1,20 @@
+# Template file for 'lziprecover'
+pkgname=lziprecover
+version=1.23
+revision=1
+build_style=configure
+checkdepends="lzip"
+short_desc="Data recovery tool and decompressor for files in the lzip format"
+maintainer="Matt Boehlke <mtboehlke@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://www.nongnu.org/lzip/lziprecover.html"
+distfiles="${NONGNU_SITE}/lzip/lziprecover/${pkgname}-${version}.tar.lz"
+checksum=9a41c9823670541573b160945c23783b644e84eb940c2c803b6b8d11b2c3d208
+
+do_configure() {
+	./configure --prefix=/usr \
+		CXX="${CXX}" \
+		CPPFLAGS="${CPPFLAGS}" \
+		CXXFLAGS="${CXXFLAGS}" \
+		LDFLAGS="${LDFLAGS}"
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

[Lziprecover](https://lzip.nongnu.org/lziprecover.html) is a data recovery tool and decompressor for files in the lzip format. From the website: "Lziprecover is not a replacement for regular backups, but a last line of defense for the case where the backups are also damaged."

Lziprecover can remove the damaged members from multimember files created using tarlz (see #38898), a format which is designed to minimize the amount of data lost in case of corruption.

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
