### PR TITLE
LimeSuite: update to 22.09.1.

### DIFF
--- a/srcpkgs/LimeSuite/template
+++ b/srcpkgs/LimeSuite/template
@@ -1,7 +1,7 @@
 # Template file for 'LimeSuite'
 pkgname=LimeSuite
-version=22.09.0
-revision=2
+version=22.09.1
+revision=1
 build_style=cmake
 build_helper=cmake-wxWidgets-gtk3
 configure_args="
@@ -33,7 +33,7 @@ license="Apache-2.0"
 homepage="https://myriadrf.org/projects/lime-suite/"
 changelog="https://raw.githubusercontent.com/myriadrf/LimeSuite/master/Changelog.txt"
 distfiles="https://github.com/myriadrf/LimeSuite/archive/refs/tags/v${version}.tar.gz"
-checksum=521e45298e1ffd0fd65006598e1edf37bd92a13667afaab262582fc681f1cf16
+checksum=a90e112004bcf2b3eec1ab80321bc345824aaceff00e31ca5e2b8e8ac35ecd26
 shlib_provides="libLimeSuite.so.22.09-1"
 
 build_options="octave"


### PR DESCRIPTION
holding off on merging until they make a full release, it seems they tag early sometimes

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

