### PR TITLE
openjdk10-bootstrap: fix build with gcc 12 and glibc 2.36

### DIFF
--- a/srcpkgs/openjdk10-bootstrap/patches/fix-path-exception-glibc.patch
+++ b/srcpkgs/openjdk10-bootstrap/patches/fix-path-exception-glibc.patch
@@ -1,0 +1,31 @@
+Fixes the following issue with glibc 2.36:
+
+Error occurred during initialization of boot layer
+java.lang.AssertionError: java.net.URISyntaxException: Illdk-k.internal.jvmstat/
+Caused by: java.net.URISyntaxException: Illegal character in path at index 32: file:///builddir/jdk11u-jdk-11-2er-release/jdk/modules/jdk.internal.jvmstat/
+make[3]: *** [ExplodedImageOptimize.gmk:41: /builddir/jdk11u-jdk-11-27/build/linux-x86_64-normal-server-release/jdk/_packages_attribute.done] Error 1
+make[2]: *** [make/Main.gmk:347: exploded-image-optimize] Error 2
+
+From 789b6089954d04a0222434916c93b1ed33c629c8 Mon Sep 17 00:00:00 2001
+From: Vladimir Kozlov <kvn@openjdk.org>
+Date: Mon, 20 Aug 2018 15:10:20 -0700
+Subject: [PATCH] 8209735: Disable avx512 by default
+
+Reviewed-by: iveresov, ecaspole
+---
+ src/hotspot/cpu/x86/globals_x86.hpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/hotspot/cpu/x86/globals_x86.hpp b/src/hotspot/cpu/x86/globals_x86.hpp
+index 423e1b1e478..49073f1834a 100644
+--- a/src/hotspot/cpu/x86/globals_x86.hpp
++++ b/src/hotspot/cpu/x86/globals_x86.hpp
+@@ -119,7 +119,7 @@ define_pd_global(bool, ThreadLocalHandshakes, false);
+   product(bool, UseStoreImmI16, true,                                       \
+           "Use store immediate 16-bits value instruction on x86")           \
+                                                                             \
+-  product(intx, UseAVX, 3,                                                  \
++  product(intx, UseAVX, 2,                                                  \
+           "Highest supported AVX instructions set on x86/x64")              \
+           range(0, 99)                                                      \
+                                                                             \

--- a/srcpkgs/openjdk10-bootstrap/patches/fix-pointer-comparison-gcc12.patch
+++ b/srcpkgs/openjdk10-bootstrap/patches/fix-pointer-comparison-gcc12.patch
@@ -1,0 +1,294 @@
+From 5287d9a366791793b644d765ece783496b011119 Mon Sep 17 00:00:00 2001
+From: Robbin Ehn <rehn@openjdk.org>
+Date: Tue, 27 Feb 2018 14:15:30 +0100
+Subject: [PATCH] 8197408: Bad pointer comparison and small cleanup in
+ os_linux.cpp
+
+Reviewed-by: bobv, stuefe
+---
+ src/hotspot/os/linux/osContainer_linux.cpp    |   4 +-
+ src/hotspot/os/linux/osContainer_linux.hpp    |   2 +-
+ src/hotspot/os/linux/os_linux.cpp             | 120 ++++++++----------
+ .../runtime/containers/cgroup/PlainRead.java  |  80 ++++++++++++
+ 4 files changed, 135 insertions(+), 71 deletions(-)
+ create mode 100644 test/hotspot/jtreg/runtime/containers/cgroup/PlainRead.java
+
+diff --git a/src/hotspot/os/linux/osContainer_linux.cpp b/src/hotspot/os/linux/osContainer_linux.cpp
+index c2f135a9e2c7..0b35bb32c5d1 100644
+--- a/src/hotspot/os/linux/osContainer_linux.cpp
++++ b/src/hotspot/os/linux/osContainer_linux.cpp
+@@ -414,9 +414,9 @@ void OSContainer::init() {
+ 
+ }
+ 
+-char * OSContainer::container_type() {
++const char * OSContainer::container_type() {
+   if (is_containerized()) {
+-    return (char *)"cgroupv1";
++    return "cgroupv1";
+   } else {
+     return NULL;
+   }
+diff --git a/src/hotspot/os/linux/osContainer_linux.hpp b/src/hotspot/os/linux/osContainer_linux.hpp
+index 5ace80165d92..0a81364fc8d9 100644
+--- a/src/hotspot/os/linux/osContainer_linux.hpp
++++ b/src/hotspot/os/linux/osContainer_linux.hpp
+@@ -40,7 +40,7 @@ class OSContainer: AllStatic {
+  public:
+   static void init();
+   static inline bool is_containerized();
+-  static char * container_type();
++  static const char * container_type();
+ 
+   static jlong memory_limit_in_bytes();
+   static jlong memory_and_swap_limit_in_bytes();
+diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.cpp
+index 4544baa8f762..6d530afcc30a 100644
+--- a/src/hotspot/os/linux/os_linux.cpp
++++ b/src/hotspot/os/linux/os_linux.cpp
+@@ -177,20 +177,17 @@ julong os::Linux::available_memory() {
+ 
+   if (OSContainer::is_containerized()) {
+     jlong mem_limit, mem_usage;
+-    if ((mem_limit = OSContainer::memory_limit_in_bytes()) > 0) {
+-      if ((mem_usage = OSContainer::memory_usage_in_bytes()) > 0) {
+-        if (mem_limit > mem_usage) {
+-          avail_mem = (julong)mem_limit - (julong)mem_usage;
+-        } else {
+-          avail_mem = 0;
+-        }
+-        log_trace(os)("available container memory: " JULONG_FORMAT, avail_mem);
+-        return avail_mem;
+-      } else {
+-        log_debug(os,container)("container memory usage call failed: " JLONG_FORMAT, mem_usage);
+-      }
+-    } else {
+-      log_debug(os,container)("container memory unlimited or failed: " JLONG_FORMAT, mem_limit);
++    if ((mem_limit = OSContainer::memory_limit_in_bytes()) < 1) {
++      log_debug(os, container)("container memory limit %s: " JLONG_FORMAT ", using host value",
++                             mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
++    }
++    if (mem_limit > 0 && (mem_usage = OSContainer::memory_usage_in_bytes()) < 1) {
++      log_debug(os, container)("container memory usage failed: " JLONG_FORMAT ", using host value", mem_usage);
++    }
++    if (mem_limit > 0 && mem_usage > 0 ) {
++      avail_mem = mem_limit > mem_usage ? (julong)mem_limit - (julong)mem_usage : 0;
++      log_trace(os)("available container memory: " JULONG_FORMAT, avail_mem);
++      return avail_mem;
+     }
+   }
+ 
+@@ -201,22 +198,18 @@ julong os::Linux::available_memory() {
+ }
+ 
+ julong os::physical_memory() {
++  jlong phys_mem = 0;
+   if (OSContainer::is_containerized()) {
+     jlong mem_limit;
+     if ((mem_limit = OSContainer::memory_limit_in_bytes()) > 0) {
+       log_trace(os)("total container memory: " JLONG_FORMAT, mem_limit);
+-      return (julong)mem_limit;
+-    } else {
+-      if (mem_limit == OSCONTAINER_ERROR) {
+-        log_debug(os,container)("container memory limit call failed");
+-      }
+-      if (mem_limit == -1) {
+-        log_debug(os,container)("container memory unlimited, using host value");
+-      }
++      return phys_mem;
+     }
++    log_debug(os, container)("container memory limit %s: " JLONG_FORMAT ", using host value",
++                            mem_limit == OSCONTAINER_ERROR ? "failed" : "unlimited", mem_limit);
+   }
+ 
+-  jlong phys_mem = Linux::physical_memory();
++  phys_mem = Linux::physical_memory();
+   log_trace(os)("total system memory: " JLONG_FORMAT, phys_mem);
+   return phys_mem;
+ }
+@@ -2135,63 +2128,54 @@ void os::Linux::print_full_memory_info(outputStream* st) {
+ }
+ 
+ void os::Linux::print_container_info(outputStream* st) {
+-  if (OSContainer::is_containerized()) {
+-    st->print("container (cgroup) information:\n");
++  if (!OSContainer::is_containerized()) {
++    return;
++  }
+ 
+-    char *p = OSContainer::container_type();
+-    if (p == NULL)
+-      st->print("container_type() failed\n");
+-    else {
+-      st->print("container_type: %s\n", p);
+-    }
++  st->print("container (cgroup) information:\n");
+ 
+-    p = OSContainer::cpu_cpuset_cpus();
+-    if (p == NULL)
+-      st->print("cpu_cpuset_cpus() failed\n");
+-    else {
+-      st->print("cpu_cpuset_cpus: %s\n", p);
+-      free(p);
+-    }
++  const char *p_ct = OSContainer::container_type();
++  st->print("container_type: %s\n", p_ct != NULL ? p_ct : "failed");
+ 
+-    p = OSContainer::cpu_cpuset_memory_nodes();
+-    if (p < 0)
+-      st->print("cpu_memory_nodes() failed\n");
+-    else {
+-      st->print("cpu_memory_nodes: %s\n", p);
+-      free(p);
+-    }
++  char *p = OSContainer::cpu_cpuset_cpus();
++  st->print("cpu_cpuset_cpus: %s\n", p != NULL ? p : "failed");
++  free(p);
+ 
+-    int i = OSContainer::active_processor_count();
+-    if (i < 0)
+-      st->print("active_processor_count() failed\n");
+-    else
+-      st->print("active_processor_count: %d\n", i);
++  p = OSContainer::cpu_cpuset_memory_nodes();
++  st->print("cpu_memory_nodes: %s\n", p != NULL ? p : "failed");
++  free(p);
+ 
+-    i = OSContainer::cpu_quota();
+-    st->print("cpu_quota: %d\n", i);
++  int i = OSContainer::active_processor_count();
++  if (i > 0) {
++    st->print("active_processor_count: %d\n", i);
++  } else {
++    st->print("active_processor_count: failed\n");
++  }
+ 
+-    i = OSContainer::cpu_period();
+-    st->print("cpu_period: %d\n", i);
++  i = OSContainer::cpu_quota();
++  st->print("cpu_quota: %d\n", i);
+ 
+-    i = OSContainer::cpu_shares();
+-    st->print("cpu_shares: %d\n", i);
++  i = OSContainer::cpu_period();
++  st->print("cpu_period: %d\n", i);
+ 
+-    jlong j = OSContainer::memory_limit_in_bytes();
+-    st->print("memory_limit_in_bytes: " JLONG_FORMAT "\n", j);
++  i = OSContainer::cpu_shares();
++  st->print("cpu_shares: %d\n", i);
+ 
+-    j = OSContainer::memory_and_swap_limit_in_bytes();
+-    st->print("memory_and_swap_limit_in_bytes: " JLONG_FORMAT "\n", j);
++  jlong j = OSContainer::memory_limit_in_bytes();
++  st->print("memory_limit_in_bytes: " JLONG_FORMAT "\n", j);
+ 
+-    j = OSContainer::memory_soft_limit_in_bytes();
+-    st->print("memory_soft_limit_in_bytes: " JLONG_FORMAT "\n", j);
++  j = OSContainer::memory_and_swap_limit_in_bytes();
++  st->print("memory_and_swap_limit_in_bytes: " JLONG_FORMAT "\n", j);
+ 
+-    j = OSContainer::OSContainer::memory_usage_in_bytes();
+-    st->print("memory_usage_in_bytes: " JLONG_FORMAT "\n", j);
++  j = OSContainer::memory_soft_limit_in_bytes();
++  st->print("memory_soft_limit_in_bytes: " JLONG_FORMAT "\n", j);
+ 
+-    j = OSContainer::OSContainer::memory_max_usage_in_bytes();
+-    st->print("memory_max_usage_in_bytes: " JLONG_FORMAT "\n", j);
+-    st->cr();
+-  }
++  j = OSContainer::OSContainer::memory_usage_in_bytes();
++  st->print("memory_usage_in_bytes: " JLONG_FORMAT "\n", j);
++
++  j = OSContainer::OSContainer::memory_max_usage_in_bytes();
++  st->print("memory_max_usage_in_bytes: " JLONG_FORMAT "\n", j);
++  st->cr();
+ }
+ 
+ void os::print_memory_info(outputStream* st) {
+diff --git a/test/hotspot/jtreg/runtime/containers/cgroup/PlainRead.java b/test/hotspot/jtreg/runtime/containers/cgroup/PlainRead.java
+new file mode 100644
+index 000000000000..be16dab76b7a
+--- /dev/null
++++ b/test/hotspot/jtreg/runtime/containers/cgroup/PlainRead.java
+@@ -0,0 +1,80 @@
++/*
++ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++/*
++ * @test PlainRead
++ * @requires os.family == "linux"
++ * @library /testlibrary /test/lib
++ * @build sun.hotspot.WhiteBox
++ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
++ *                              sun.hotspot.WhiteBox$WhiteBoxPermission
++ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI PlainRead
++ */
++
++import jdk.test.lib.process.ProcessTools;
++import jdk.test.lib.process.OutputAnalyzer;
++import jdk.test.lib.Platform;
++import sun.hotspot.WhiteBox;
++
++public class PlainRead {
++
++    static public void match(OutputAnalyzer oa, String what, String value) {
++       oa.shouldMatch("^.*" + what + " *" + value + ".*$");
++    }
++
++    static public void noMatch(OutputAnalyzer oa, String what, String value) {
++       oa.shouldNotMatch("^.*" + what + " *" + value + ".*$");
++    }
++
++    static final String good_value = "(\\d+|-1|Unlimited)";
++    static final String bad_value = "(failed)";
++
++    static final String[] variables = {"Memory Limit is:", "CPU Shares is:", "CPU Quota is:", "CPU Period is:", "active_processor_count:"};
++
++    static public void isContainer(OutputAnalyzer oa) {
++        for (String v: variables) {
++            match(oa, v, good_value);
++        }
++        for (String v: variables) {
++            noMatch(oa, v, bad_value);
++        }
++    }
++
++    static public void isNotContainer(OutputAnalyzer oa) {
++       oa.shouldMatch("^.*Can't open /proc/self/mountinfo.*$");
++    }
++
++    public static void main(String[] args) throws Exception {
++        WhiteBox wb = WhiteBox.getWhiteBox();
++        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder("-Xlog:os+container=trace", "-version");
++        OutputAnalyzer output = new OutputAnalyzer(pb.start());
++
++        if (wb.isContainerized()) {
++            System.out.println("Inside a cgroup, testing...");
++            isContainer(output);
++        } else {
++            System.out.println("Not in a cgroup, testing...");
++            isNotContainer(output);
++        }
++    }
++}

--- a/srcpkgs/openjdk10-bootstrap/template
+++ b/srcpkgs/openjdk10-bootstrap/template
@@ -2,10 +2,10 @@
 _final_jdk_home="usr/lib/jvm/java-10-openjdk"
 pkgname=openjdk10-bootstrap
 version=10.0.2p13
-revision=2
+revision=3
 _repo_ver=${version/p/+}
 archs="x86_64* i686* aarch64* arm* ppc64*"
-wrksrc="jdk10u-jdk-${_repo_ver}"
+wrksrc="jdk10u-jdk-${_repo_ver/+/-}"
 build_style=gnu-configure
 configure_args="
  --prefix=${XBPS_DESTDIR}/${pkgname}-${version}/usr/lib
@@ -32,8 +32,8 @@ short_desc="OpenJDK Java Development Kit (bootstrap version 10)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only WITH Classpath-exception-2.0"
 homepage="http://openjdk.java.net/"
-distfiles="http://hg.openjdk.java.net/jdk-updates/jdk10u/archive/jdk-${_repo_ver}.tar.bz2"
-checksum="374f7ae35f0a7439a40bd2c765d1f410607c75c6c1e788f1a344a42e59431f51"
+distfiles="https://github.com/openjdk/jdk10u/archive/refs/tags/jdk-${_repo_ver}.tar.gz"
+checksum="39ce1238d5b2066ffe1c1a09d87c170766309fe18290f27a4ab7d15844d34dc1"
 lib32disabled=yes
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Revbump because the glibc fix requires a rebuild.

https://github.com/void-linux/void-packages/issues/39809

The distfiles address was changed on request to github since the official mirror tends to error out.

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
