### PR TITLE
New package: kubectx-bash 0.9.5

### DIFF
--- a/srcpkgs/kubectx-bash/template
+++ b/srcpkgs/kubectx-bash/template
@@ -1,0 +1,22 @@
+# Template file for 'kubectx-bash'
+pkgname=kubectx-bash
+version=0.9.5
+revision=1
+depends="bash fzf"
+short_desc="Faster way to switch between clusters and namespaces in kubectl"
+maintainer="fanyx <fanyx@posteo.net>"
+license="Apache-2.0"
+homepage="https://github.com/ahmetb/kubectx"
+distfiles="https://github.com/ahmetb/kubectx/archive/v${version}.tar.gz"
+checksum=c94392fba8dfc5c8075161246749ef71c18f45da82759084664eb96027970004
+conflicts="kubectx"
+
+do_install() {
+	for bin in kubectx kubens; do
+		vbin $bin
+		for sh in bash fish; do
+			vcompletion completion/$bin.$sh $sh $bin
+		done
+		vcompletion completion/_$bin.zsh zsh $bin
+	done
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **POSSIBLY?**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Bash version of kubectx #39732
Go version is lacking some features I only realised after using it for some days, so i would prefer this version over Go version for now.
Open for discussion.

Of course i can use this package for myself using xbps-src but having it available to others would be great.