### PR TITLE
66: revbump, add s6-rc to the depends array.

### DIFF
--- a/srcpkgs/66/template
+++ b/srcpkgs/66/template
@@ -1,7 +1,7 @@
 # Template file for '66'
 pkgname=66
 version=0.6.2.0
-revision=2
+revision=3
 wrksrc="66-v${version}"
 build_style=configure
 configure_args="--prefix=/usr
@@ -12,12 +12,13 @@ configure_args="--prefix=/usr
  --with-system-dir=/etc/66/lib"
 hostmakedepends="pkg-config lowdown"
 makedepends="oblibs-devel skalibs-devel execline-devel s6-devel s6-rc-devel"
+depends="s6-rc"
 short_desc="Small tools built around s6 and s6-rc programs"
 maintainer="mobinmob <mobinmob@disroot.org>"
 license="ISC"
 homepage="http://web.obarun.org/software/"
-changelog="https://framagit.org/Obarun/66/raw/master/NEWS.md"
-distfiles="https://framagit.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
+changelog="https://git.obarun.org/Obarun/66/-/raw/master/doc/upgrade.md"
+distfiles="https://git.obarun.org/Obarun/66/-/archive/v${version}/66-v${version}.tar.bz2"
 checksum=f63600e9f8e53211e421707aae7f98d2fa9d1b0d0b4b39162cf180df12b99c28
 patch_args="-Np1"
 


### PR DESCRIPTION
It is not picked up as a dependency from s6-rc-devel in the makedepends array (thanks @NymanMatthias).

Also:
- change changelog and distfiles to the new gitlab instance,
- change the changelog path in the git repo.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
