### PR TITLE
PolyMC: switch to a more trusted meta server

### DIFF
--- a/srcpkgs/PolyMC/template
+++ b/srcpkgs/PolyMC/template
@@ -1,10 +1,10 @@
 # Template file for 'PolyMC'
 pkgname=PolyMC
 version=1.4.2
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DLauncher_BUILD_PLATFORM=Void
- -DLauncher_VERSION_BUILD=${revision}"
+ -DLauncher_VERSION_BUILD=${revision} -DLauncher_META_URL=https://meta.scrumplex.rocks/v1/"
 hostmakedepends="extra-cmake-modules openjdk8 pkg-config qt5-host-tools
  qt5-qmake scdoc"
 makedepends="qt5-devel"


### PR DESCRIPTION
the person currently in control of the polymc meta server might not have the best intentions

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
