### PR TITLE
libreoffice: fix build with gpgme 2.18

### DIFF
--- a/srcpkgs/libreoffice/patches/gpgme-2.18.0.patch
+++ b/srcpkgs/libreoffice/patches/gpgme-2.18.0.patch
@@ -1,0 +1,47 @@
+From f7e170eb084cd4e92818de966b287330184749a8 Mon Sep 17 00:00:00 2001
+From: Rene Engelhard <rene@debian.org>
+Date: Wed, 24 Aug 2022 09:55:33 +0200
+Subject: [PATCH] Make configure work with gpgme >= 1.18
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Sam James wrote:
+> gpgme-1.18.0 dropped a bunch of internal symbols,
+> including progress_callback (see e.g. callbacks.h
+> which has a comment at the top saying it's internal).
+
+Plausibly the workaround to not link against older KDE-specific distro
+packages is not needed anymore.
+
+Check for main as a workaround as we do for other C++ libraries, too.
+
+Change-Id: I57065a5b5b23b9eadb73b01e4f3a289552c3bde4
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/138667
+Tested-by: Jenkins
+Reviewed-by: Sam James <sam@gentoo.org>
+Reviewed-by: René Engelhard <rene@debian.org>
+---
+ configure.ac | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 24cb01aa0db02..61806988b94b7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -12539,12 +12539,11 @@ elif test \( \( "$_os" = "Linux" -o "$_os" = "Darwin" \) -a "$ENABLE_NSS" = TRUE
+         # C++ library doesn't come with fancy gpgmepp-config, check for headers the old-fashioned way
+         AC_CHECK_HEADER(gpgme++/gpgmepp_version.h, [ GPGMEPP_CFLAGS=-I/usr/include/gpgme++ ],
+             [AC_MSG_ERROR([gpgmepp headers not found, install gpgmepp >= 1.14 development package])], [])
+-        # progress_callback is the only func with plain C linkage
+-        # checking for it also filters out older, KDE-dependent libgpgmepp versions
+-        AC_CHECK_LIB(gpgmepp, progress_callback, [ GPGMEPP_LIBS=-lgpgmepp ],
+-            [AC_MSG_ERROR(gpgmepp not found or not functional)], [])
+         AC_CHECK_HEADER(gpgme.h, [],
+             [AC_MSG_ERROR([gpgme headers not found, install gpgme development package])], [])
++        AC_CHECK_LIB(gpgmepp, main, [],
++            [AC_MSG_ERROR(gpgmepp not found or not functional)], [])
++	GPGMEPP_LIBS=-lgpgmepp
+     else
+         AC_MSG_RESULT([internal])
+         BUILD_TYPE="$BUILD_TYPE LIBGPGERROR LIBASSUAN GPGMEPP"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

The clucene build failure was fixed by: https://github.com/void-linux/void-packages/commit/5aeb4c0ce0d27cfead4bcc9982cb249a48d48bf2

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
