### PR TITLE
python3-chardet: update to 5.0.0

### DIFF
--- a/srcpkgs/python3-chardet/template
+++ b/srcpkgs/python3-chardet/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-chardet'
 pkgname=python3-chardet
-version=4.0.0
-revision=4
+version=5.0.0
+revision=1
 wrksrc="chardet-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
@@ -12,5 +12,5 @@ maintainer="Alessio Sergi <al3hex@gmail.com>"
 license="LGPL-2.1-only"
 homepage="https://github.com/chardet/chardet"
 distfiles="${PYPI_SITE}/c/chardet/chardet-${version}.tar.gz"
-checksum=0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
+checksum=0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa
 conflicts="python-chardet"


### PR DESCRIPTION
[Changelog](https://github.com/chardet/chardet/releases/tag/5.0.0): no breaking changes relevant to Void.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)