### PR TITLE
python3-pynacl: update to 1.5.0

### DIFF
--- a/srcpkgs/python3-pynacl/template
+++ b/srcpkgs/python3-pynacl/template
@@ -1,20 +1,20 @@
 # Template file for 'python3-pynacl'
 pkgname=python3-pynacl
-version=1.4.0
-revision=2
+version=1.5.0
+revision=1
 wrksrc="PyNaCl-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-cffi python3-wheel"
 makedepends="python3-devel python3-cffi libsodium-devel"
-depends="python3-cffi python3-six"
-checkdepends="${depends}"
+depends="python3-cffi"
+checkdepends="${depends} python3-pytest python3-hypothesis"
 short_desc="Python3 binding to the Networking and Cryptography (NaCl) library"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://github.com/pyca/pynacl/"
 changelog="https://raw.githubusercontent.com/pyca/pynacl/master/CHANGELOG.rst"
 distfiles="${PYPI_SITE}/P/PyNaCl/PyNaCl-${version}.tar.gz"
-checksum=54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505
+checksum=8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba
 
 export SODIUM_INSTALL=system
 


### PR DESCRIPTION
[Changelog](https://github.com/pyca/pynacl/blob/main/CHANGELOG.rst#150-2022-01-07): no breaking changes relevant to Void.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
