### PR TITLE
python3-mutagen: update to 1.46.0

### DIFF
--- a/srcpkgs/python3-mutagen/template
+++ b/srcpkgs/python3-mutagen/template
@@ -1,7 +1,7 @@
 # Template file for 'python3-mutagen'
 pkgname=python3-mutagen
-version=1.45.1
-revision=2
+version=1.46.0
+revision=1
 wrksrc="mutagen-${version}"
 build_style=python3-module
 hostmakedepends="python3-devel python3-setuptools"
@@ -14,4 +14,4 @@ license="GPL-2.0-or-later"
 homepage="https://github.com/quodlibet/mutagen"
 changelog="https://raw.githubusercontent.com/quodlibet/mutagen/master/NEWS"
 distfiles="${PYPI_SITE}/m/mutagen/mutagen-${version}.tar.gz"
-checksum=6397602efb3c2d7baebd2166ed85731ae1c1d475abca22090b7141ff5034b3e1
+checksum=6e5f8ba84836b99fe60be5fb27f84be4ad919bbb6b49caa6ae81e70584b55e58


### PR DESCRIPTION
[Changelog](https://mutagen.readthedocs.io/en/latest/changelog.html#release-1-46-0): no breaking changes relevant to Void.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)