### PR TITLE
python3-Unidecode: update to 1.3.6

### DIFF
--- a/srcpkgs/python3-Unidecode/template
+++ b/srcpkgs/python3-Unidecode/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-Unidecode'
 pkgname=python3-Unidecode
-version=1.3.3
+version=1.3.6
 revision=1
 wrksrc="Unidecode-${version}"
 build_style=python3-module
@@ -12,9 +12,5 @@ license="GPL-2.0-or-later"
 homepage="https://pypi.org/project/Unidecode/"
 changelog="https://raw.githubusercontent.com/avian2/unidecode/master/ChangeLog"
 distfiles="${PYPI_SITE}/U/Unidecode/Unidecode-${version}.tar.gz"
-checksum=8521f2853fd250891dc27d156a9d30e61c4e76319da963c4a1c27083a909ac30
+checksum=fed09cf0be8cf415b391642c2a5addfc72194407caee4f98719e40ec2a72b830
 conflicts="python-Unidecode>=0"
-
-do_check() {
-	python3 setup.py test
-}


### PR DESCRIPTION
[Changelog](https://github.com/avian2/unidecode/blob/414199246e4871669896756279e3460ff0364839/ChangeLog#L1): no breaking changes.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
