### PR TITLE
python3-blinker: update to 1.5

### DIFF
--- a/srcpkgs/python3-blinker/template
+++ b/srcpkgs/python3-blinker/template
@@ -1,19 +1,21 @@
 # Template file for 'python3-blinker'
 pkgname=python3-blinker
-version=1.4
-revision=7
+version=1.5
+revision=1
 wrksrc="blinker-${version}"
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 makedepends="python3-devel"
 depends="python3"
+checkdepends="python3-pytest"
 short_desc="Fast, simple object-to-object and broadcast signaling for Python3"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="MIT"
-homepage="http://pythonhosted.org/blinker/"
+homepage="https://blinker.readthedocs.io/en/stable/"
+changelog="https://raw.githubusercontent.com/pallets-eco/blinker/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/b/blinker/blinker-${version}.tar.gz"
-checksum=471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
+checksum=923e5e2f69c155f2cc42dafbbd70e16e3fde24d2d4aa2ab72fbe386238892462
 
 post_install() {
-	vlicense LICENSE
+	vlicense LICENSE.rst
 }


### PR DESCRIPTION
[Changelog](https://blinker.readthedocs.io/en/stable/#version-1-5), [diff](https://github.com/pallets-eco/blinker/compare/rel-1.4...1.5): no breaking changes.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)