### PR TITLE
mupen64plus: Fix crash due to SDL_SetVideoMode in SDL 2 compatibility code

### DIFF
--- a/srcpkgs/mupen64plus/patches/0001-Fix-wrong-pitch-argument-in-call-to-SDL_CreateRGBSur.patch
+++ b/srcpkgs/mupen64plus/patches/0001-Fix-wrong-pitch-argument-in-call-to-SDL_CreateRGBSur.patch
@@ -1,0 +1,34 @@
+From 9d016ace855b88916746837b1a424cf9e5960c3b Mon Sep 17 00:00:00 2001
+From: Dexter Gaon-Shatford <dexter@gaonshatford.ca>
+Date: Thu, 20 Oct 2022 20:06:16 -0400
+Subject: [PATCH] Fix wrong pitch argument in call to SDL_CreateRGBSurfaceFrom.
+
+This patch makes the change in
+https://github.com/mupen64plus/mupen64plus-core/pull/970 compatible with
+the source distribution of mupen64plus v2.5.9.
+
+This patch should be removed when the next version of mupen64plus is
+released since it will already contain the changes from the PR mentioned
+above.
+---
+ src/api/vidext_sdl2_compat.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/source/mupen64plus-core/src/api/vidext_sdl2_compat.h b/source/mupen64plus-core/src/api/vidext_sdl2_compat.h
+index 06d778dd..7cbd5963 100644
+--- a/source/mupen64plus-core/src/api/vidext_sdl2_compat.h
++++ b/source/mupen64plus-core/src/api/vidext_sdl2_compat.h
+@@ -474,8 +474,9 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags)
+         if (SDL_GL_MakeCurrent(SDL_VideoWindow, SDL_VideoContext) < 0) {
+             return NULL;
+         }
++        int pitch = (bpp + 7) / 8 * width;
+         SDL_VideoSurface =
+-            SDL_CreateRGBSurfaceFrom(NULL, width, height, bpp, 0, 0, 0, 0, 0);
++            SDL_CreateRGBSurfaceFrom(NULL, width, height, bpp, pitch, 0, 0, 0, 0);
+         if (!SDL_VideoSurface) {
+             return NULL;
+         }
+-- 
+2.38.1
+

--- a/srcpkgs/mupen64plus/template
+++ b/srcpkgs/mupen64plus/template
@@ -1,7 +1,7 @@
 # Template file for 'mupen64plus'
 pkgname=mupen64plus
 version=2.5.9
-revision=2
+revision=3
 archs="x86_64* i686*"
 wrksrc="mupen64plus-bundle-src-${version}"
 hostmakedepends="pkg-config which nasm"


### PR DESCRIPTION
Add a patch which applies the change from https://github.com/mupen64plus/mupen64plus-core/pull/970 so that mupen64plus still works after updating to SDL 2.24

The patch should be removed after the next release of mupen64plus since the fix will already be included.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
