### PR TITLE
pdf.js: update to 2.16.105, switch to legacy build

### DIFF
--- a/srcpkgs/pdf.js/template
+++ b/srcpkgs/pdf.js/template
@@ -1,15 +1,14 @@
 # Template file for 'pdf.js'
 pkgname=pdf.js
-reverts="2.16.105_1"
-version=2.14.305
+version=2.16.105
 revision=2
 create_wrksrc=yes
 short_desc="Portable Document Format (PDF) viewer built with HTML5"
 maintainer="Daniel Santana <daniel@santana.tech>"
 license="Apache-2.0"
 homepage="https://mozilla.github.io/pdf.js/"
-distfiles="https://github.com/mozilla/pdf.js/releases/download/v${version}/pdfjs-${version}-dist.zip"
-checksum=1929a00d26d7cd631033ab5a06dcd7d6c283b7d3b06c76083fb840bd1e014896
+distfiles="https://github.com/mozilla/pdf.js/releases/download/v${version}/pdfjs-${version}-legacy-dist.zip"
+checksum=4fce357e8c665a25d44498f466ad93829f672f782eb95d6db8f20ee479dd6af4
 
 do_install() {
 	vmkdir usr/share/$pkgname/


### PR DESCRIPTION
The legacy build fixes the regression in #40061. I don't know whether there is a reason *not* to use the legacy build; if so, we'll need a separate package.

Closes #40061.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

cc: @heittpr 