### PR TITLE
python3-psutil: update to 5.9.3.

### DIFF
--- a/srcpkgs/python3-psutil/template
+++ b/srcpkgs/python3-psutil/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-psutil'
 pkgname=python3-psutil
-version=5.9.2
+version=5.9.3
 revision=1
 wrksrc="psutil-${version}"
 build_style=python3-module
@@ -13,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/giampaolo/psutil"
 changelog="https://raw.githubusercontent.com/giampaolo/psutil/master/HISTORY.rst"
 distfiles="${PYPI_SITE}/p/psutil/psutil-${version}.tar.gz"
-checksum=feb861a10b6c3bb00701063b37e4afc754f8217f0f09c42280586bd6ac712b5c
+checksum=7ccfcdfea4fc4b0a02ca2c31de7fcd186beb9cff8207800e14ab66f79c773af6
 # Tests seem to assume package is installed
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
