### PR TITLE
libbsd-devel: depend on libmd-devel.

### DIFF
--- a/srcpkgs/libbsd/template
+++ b/srcpkgs/libbsd/template
@@ -1,7 +1,7 @@
 # Template file for 'libbsd'
 pkgname=libbsd
 version=0.11.7
-revision=1
+revision=2
 build_style=gnu-configure
 makedepends="libmd-devel"
 short_desc="Provides useful functions commonly found on BSD system"
@@ -16,7 +16,7 @@ post_install() {
 }
 
 libbsd-devel_package() {
-	depends="${sourcepkg}>=${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} libmd-devel"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
It is used in the pkgconfig Libs.private.
