### PR TITLE
webkit2gtk: remove webkit2gtk-common subpackage

### DIFF
--- a/srcpkgs/webkit2gtk-common
+++ b/srcpkgs/webkit2gtk-common
@@ -1,1 +1,0 @@
-webkit2gtk

--- a/srcpkgs/webkit2gtk/template
+++ b/srcpkgs/webkit2gtk/template
@@ -1,7 +1,7 @@
 # Template file for 'webkit2gtk'
 pkgname=webkit2gtk
 version=2.38.1
-revision=1
+revision=2
 wrksrc="webkitgtk-${version}"
 build_style=cmake
 build_helper="gir"
@@ -31,7 +31,6 @@ makedepends="at-spi2-core-devel libjpeg-turbo-devel libpng-devel
  qt5-devel libmanette-devel libwpe-devel wpebackend-fdo-devel
  libgcrypt-devel libnuspell-devel libpsl-devel $(vopt_if x11 libXt-devel)
  $(vopt_if wayland 'MesaLib-devel libxkbcommon-devel wayland-devel wayland-protocols')"
-depends="webkit2gtk-common"
 short_desc="GTK+3 port of the WebKit2 browser engine"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later, BSD-2-Clause"
@@ -39,6 +38,8 @@ homepage="https://webkitgtk.org/"
 distfiles="https://webkitgtk.org/releases/webkitgtk-${version}.tar.xz"
 checksum=02e195b3fb9e057743b3364ee7f1eec13f71614226849544c07c32a73b8f1848
 make_check=no
+
+replaces="webkit2gtk-common>0"
 
 build_options="gir wayland x11 bubblewrap jit sampling_profiler minibrowser
  clang lto gtk_doc"
@@ -67,7 +68,7 @@ fi
 if [ "$build_option_bubblewrap" ]; then
 	hostmakedepends+=" bubblewrap xdg-dbus-proxy"
 	makedepends+=" libseccomp-devel"
-	depends+=" bubblewrap xdg-dbus-proxy"
+	depends="bubblewrap xdg-dbus-proxy"
 fi
 
 if [ "$build_option_lto" -a -z "$build_option_clang" ]; then
@@ -182,14 +183,6 @@ webkit2gtk-devel_package() {
 	}
 }
 
-webkit2gtk-common_package() {
-	short_desc="GTK port of the WebKit2 browser engine - common files"
-	pkg_install() {
-		vmove usr/share/locale/
-		vmove usr/share/licenses/
-	}
-}
-
 libwebkit2gtk41_package() {
 	depends="${depends}"
 	short_desc="GTK+3 port of the WebKit2 browser engine (soup3)"
@@ -201,6 +194,12 @@ libwebkit2gtk41_package() {
 			vmove "usr/lib/girepository-1.0/*-4.1.typelib"
 		fi
 		vmove "usr/lib/*-4.1.so.*"
+		for file in $(find ${DESTDIR}/usr/share/locale -name "*-4.1.mo"); do
+			vmove ${file/$DESTDIR/}
+		done
+		vlicense Source/WebCore/LICENSE-APPLE
+		vlicense Source/WebCore/LICENSE-LGPL-2.1
+		vlicense Source/WebCore/LICENSE-LGPL-2
 	}
 }
 
@@ -230,6 +229,12 @@ libwebkit2gtk50_package() {
 			vmove "usr/lib/girepository-1.0/*-5.0.typelib"
 		fi
 		vmove "usr/lib/*-5.0.so.*"
+		for file in $(find ${DESTDIR}/usr/share/locale -name "*-5.0.mo"); do
+			vmove ${file/$DESTDIR/}
+		done
+		vlicense Source/WebCore/LICENSE-APPLE
+		vlicense Source/WebCore/LICENSE-LGPL-2.1
+		vlicense Source/WebCore/LICENSE-LGPL-2
 	}
 }
 


### PR DESCRIPTION
[ci skip]
webkit2gtk generates unique locale files for each version so the common package is redundant.

The locale files also got installed to the wrong location in the common package, i.e. /usr/share/locale/locale instead of /usr/share/locale

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
