### PR TITLE
python3-pip: update to 22.3

### DIFF
--- a/srcpkgs/python3-pip/template
+++ b/srcpkgs/python3-pip/template
@@ -1,6 +1,6 @@
 # Template file for 'python3-pip'
 pkgname=python3-pip
-version=22.2.2
+version=22.3
 revision=1
 wrksrc="pip-${version}"
 build_style=python3-module
@@ -12,7 +12,7 @@ license="MIT"
 homepage="https://pip.pypa.io/"
 changelog="https://raw.githubusercontent.com/pypa/pip/master/NEWS.rst"
 distfiles="${PYPI_SITE}/p/pip/pip-${version}.tar.gz"
-checksum=3fd1929db052f056d7a998439176d3333fa1b3f6c1ad881de1885c0717608a4b
+checksum=8182aec21dad6c0a49a2a3d121a87cd524b950e0b6092b181625f07ebdde7530
 # Tests have unpackaged dependencies
 make_check=no
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
