### PR TITLE
environment: set -ffile-prefix-map

### DIFF
--- a/common/environment/configure/debug-debug-prefix-map.sh
+++ b/common/environment/configure/debug-debug-prefix-map.sh
@@ -1,16 +1,16 @@
 local _wrksrc="$wrksrc${build_wrksrc:+/$build_wrksrc}"
 case "$build_style" in
 cmake)
-	CFLAGS="${CFLAGS} -fdebug-prefix-map=$_wrksrc/${cmake_builddir:-build}=."
-	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$_wrksrc/${cmake_builddir:-build}=."
+	CFLAGS="${CFLAGS} -ffile-prefix-map=$_wrksrc/${cmake_builddir:-build}=."
+	CXXFLAGS="${CXXFLAGS} -ffile-prefix-map=$_wrksrc/${cmake_builddir:-build}=."
 	;;
 meson)
-	CFLAGS="${CFLAGS} -fdebug-prefix-map=$_wrksrc/${meson_builddir:-build}=."
-	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$_wrksrc/${meson_builddir:-build}=."
+	CFLAGS="${CFLAGS} -ffile-prefix-map=$_wrksrc/${meson_builddir:-build}=."
+	CXXFLAGS="${CXXFLAGS} -ffile-prefix-map=$_wrksrc/${meson_builddir:-build}=."
 	;;
 *)
-	CFLAGS="${CFLAGS} -fdebug-prefix-map=$_wrksrc=."
-	CXXFLAGS="${CXXFLAGS} -fdebug-prefix-map=$_wrksrc=."
+	CFLAGS="${CFLAGS} -ffile-prefix-map=$_wrksrc=."
+	CXXFLAGS="${CXXFLAGS} -ffile-prefix-map=$_wrksrc=."
 esac
 
 unset _wrksrc

--- a/srcpkgs/python3/template
+++ b/srcpkgs/python3/template
@@ -121,6 +121,7 @@ do_install() {
 			${DESTDIR}/usr/bin/python${version%.*}-config
 	fi
 	sed -i -e "s,-fdebug-prefix-map=[^[:space:]]*=[.],," \
+		-e "s,-ffile-prefix-map=[^[:space:]]*=[.],," \
 		-e "s,-I./External,," \
 		${DESTDIR}/usr/bin/python${version%.*}-config \
 		${DESTDIR}/usr/lib/python${version%.*}/_sysconfigdata_*_*.py \


### PR DESCRIPTION
We're setting -fdebug-prefix-map to strip directory prefixes from debug info, which will help ccache and reproducibility.

However, -fdebug-prefix-map doesn't help with those macros like __FILE__ and __BASE_FILE__, which needs another flags: -fmacro-prefix-map.

Replaces -fdebug-prefix-map with -ffile-prefix-map which is an alias for both `-fdebug-prefix-map` and `-fmacro-prefix-map`. (This flag is available since GCC 8 and Clang 10)

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
