### PR TITLE
pinebookpro-uboot: fixed kernel.d script

### DIFF
--- a/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
+++ b/srcpkgs/pinebookpro-uboot/files/kernel.d/uboot
@@ -1,20 +1,27 @@
 #!/bin/sh
 
 kver=${2}
-uuid=$(cat /etc/fstab | awk '$2 == "/" { print $1 }' | sed 's/^UUID=//')
+uuid=$(cat /etc/fstab | sed -r '/^\s*#/d' | awk '$2 == "/" { print $1 }' | sed 's/^UUID=//')
 dev=$(blkid -U "${uuid}")
 partuuid=$(blkid -o value -s PARTUUID "${dev}")
 bootpart=$(df -P /boot | tail -1 | awk '{ print $6 }')
 bootstrip() {
     echo ${1} | sed "s,^${bootpart}/,/,"
 }
+root="PARTUUID=$partuuid"
+
+[ -z "$partuuid" ] && {
+  # UUID search failed, trying fstab directly
+  root=$(cat /etc/fstab | sed -r '/^\s*#/d;s/UUID=/PARTUUID=/' | awk '$2 == "/" {print $1}')
+}
+
 
 cat > /boot/boot.txt <<EOF
 # MAC address (use spaces instead of colons)
 setenv macaddr da 19 c8 7a 6d f4
 
 part uuid \${devtype} \${devnum}:\${bootpart} uuid
-setenv bootargs console=ttyS2,1500000 console=tty1 root=PARTUUID=${partuuid} rootwait video=eDP-1:1920x1080@60 loglevel=4
+setenv bootargs console=ttyS2,1500000 console=tty1 root=${root} rootwait video=eDP-1:1920x1080@60 loglevel=4
 setenv fdtfile rockchip/rk3399-pinebook-pro.dtb
 
 if load \${devtype} \${devnum}:\${bootpart} \${kernel_addr_r} $(bootstrip /boot/vmlinux-${kver}); then

--- a/srcpkgs/pinebookpro-uboot/template
+++ b/srcpkgs/pinebookpro-uboot/template
@@ -2,7 +2,7 @@
 pkgname=pinebookpro-uboot
 reverts="20200212_1 20200212_2"
 version=2022.04
-revision=2
+revision=3
 archs="aarch64*"
 wrksrc="u-boot-${version}"
 hostmakedepends="flex bc dtc python3 openssl-devel"


### PR DESCRIPTION
The original (rev. 2) does not work e. g. with encrypted root and also fails if there are certain commented out lines in /etc/fstab. This proposed version fixes both issues. If the / line in fstab does not include UUID, the device is taken directly from fstab.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (arm64-glibc)
- This package is specifically designed for Pinebook Pro which only employs arm64.