### PR TITLE
rust-bindgen: update to 0.61.0.

### DIFF
--- a/srcpkgs/rust-bindgen/template
+++ b/srcpkgs/rust-bindgen/template
@@ -1,9 +1,10 @@
 # Template file for 'rust-bindgen'
 pkgname=rust-bindgen
-version=0.60.1
+version=0.61.0
 revision=1
 build_style="cargo"
-make_check_args="--bins"
+configure_args="--bins"
+make_install_args="--path bindgen-cli"
 depends="libclang"
 checkdepends="libclang"
 short_desc="Tool to generate Rust FFI bindings to C (and some C++) libraries"
@@ -12,7 +13,7 @@ license="BSD-3-Clause"
 homepage="https://rust-lang.github.io/rust-bindgen/"
 changelog="https://raw.githubusercontent.com/rust-lang/rust-bindgen/master/CHANGELOG.md"
 distfiles="https://github.com/rust-lang/rust-bindgen/archive/refs/tags/v${version}.tar.gz"
-checksum="b521c18af2230d748b1f7eea8f3aab9381a08a07024fc52a6350fee286fae4ec"
+checksum="889ef7f1edd5db50e4e3e39b84e52b360ebe2f42a916adaf0ac97586419d885e"
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built and tested this PR locally for my native architecture, (x86_64-gnu)
- I built this PR locally for these architectures (all crossbuilds):
  - aarch64-musl
  - armv6l
  - i686

