### PR TITLE
mupen64plus: Fix default Logitech F310 controller bindings.

### DIFF
--- a/srcpkgs/mupen64plus/patches/0001-Fix-default-configuration-for-Logitech-F310.patch
+++ b/srcpkgs/mupen64plus/patches/0001-Fix-default-configuration-for-Logitech-F310.patch
@@ -1,0 +1,38 @@
+From 5e2cedb10b77766db1a2f2a51167e91245d27de0 Mon Sep 17 00:00:00 2001
+From: Dexter Gaon-Shatford <dexter@gaonshatford.ca>
+Date: Sat, 22 Oct 2022 10:56:36 -0400
+Subject: [PATCH] Fix default configuration for Logitech F310
+
+The default configuration for the Logitech F310 gamepad is incorrect in
+the 2.5.9 release. This patch applies the (correct) configuration from
+the project upstream.
+---
+ data/InputAutoCfg.ini | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/data/InputAutoCfg.ini b/data/InputAutoCfg.ini
+index 4db5576..368a761 100644
+--- a/source/mupen64plus-input-sdl/data/InputAutoCfg.ini
++++ b/source/mupen64plus-input-sdl/data/InputAutoCfg.ini
+@@ -597,15 +597,15 @@ DPad L = hat(0 Left)
+ DPad D = hat(0 Down)
+ DPad U = hat(0 Up)
+ Start = button(7)
+-Z Trig = button(5)
++Z Trig = axis(5+)
+ B Button = button(2)
+ A Button = button(0)
+ C Button R = axis(3+)
+ C Button L = axis(3-)
+ C Button D = axis(4+)
+ C Button U = axis(4-)
+-R Trig = axis(5-)
+-L Trig = axis(2-)
++R Trig = button(5)
++L Trig = button(4)
+ Mempak switch = button(1)
+ Rumblepak switch = button(3)
+ X Axis = axis(0-,0+)
+-- 
+2.38.1
+

--- a/srcpkgs/mupen64plus/template
+++ b/srcpkgs/mupen64plus/template
@@ -1,7 +1,7 @@
 # Template file for 'mupen64plus'
 pkgname=mupen64plus
 version=2.5.9
-revision=3
+revision=4
 archs="x86_64* i686*"
 wrksrc="mupen64plus-bundle-src-${version}"
 hostmakedepends="pkg-config which nasm"


### PR DESCRIPTION
The default bindings for the Logitch F310 gamepad are incorrect in mupen64plus v2.5.9. This patch applies the corrected bindings from upstream: https://github.com/mupen64plus/mupen64plus-input-sdl/commit/ad2af4cff4909d341049c25b8d77be14c4bd16de

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
