### PR TITLE
v4l2loopback: update to 0.12.7

### DIFF
--- a/srcpkgs/v4l2loopback/patches/0001-Backport-PR-477-1.patch
+++ b/srcpkgs/v4l2loopback/patches/0001-Backport-PR-477-1.patch
@@ -1,0 +1,37 @@
+From 3407c4262b1d72307a8106008874c112de1e3549 Mon Sep 17 00:00:00 2001
+From: Rodrigo Oliveira <mdkcore@qtrnn.io>
+Date: Thu, 20 Oct 2022 18:41:43 -0300
+Subject: [PATCH 1/2] Backport PR #477 [1]
+
+[1] https://github.com/umlaeute/v4l2loopback/pull/477/commits/3312a6d0461d6d2d82a411f26c34e380bd3cee27
+---
+ v4l2loopback.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/v4l2loopback.c b/v4l2loopback.c
+index 7e47a43..22e9795 100644
+--- a/v4l2loopback.c
++++ b/v4l2loopback.c
+@@ -2038,15 +2038,17 @@ static ssize_t v4l2_loopback_read(struct file *file, char __user *buf,
+ static ssize_t v4l2_loopback_write(struct file *file, const char __user *buf,
+ 				   size_t count, loff_t *ppos)
+ {
++    struct v4l2_loopback_opener *opener;
+ 	struct v4l2_loopback_device *dev;
+ 	int write_index;
+ 	struct v4l2_buffer *b;
+ 	MARK();
+ 
+ 	dev = v4l2loopback_getdevice(file);
++    opener = fh_to_opener(file->private_data);
+ 
+-	/* there's at least one writer, so don'stop announcing output capabilities */
+-	dev->ready_for_output = 0;
++    if (WRITER != opener->type)
++        return -EINVAL;
+ 
+ 	if (!dev->ready_for_capture) {
+ 		int ret = allocate_buffers(dev);
+-- 
+2.38.1
+

--- a/srcpkgs/v4l2loopback/patches/0002-Backport-PR-485-1.patch
+++ b/srcpkgs/v4l2loopback/patches/0002-Backport-PR-485-1.patch
@@ -1,0 +1,68 @@
+From 40a880b4640486262ca0b5171dec88d633278366 Mon Sep 17 00:00:00 2001
+From: Rodrigo Oliveira <mdkcore@qtrnn.io>
+Date: Thu, 20 Oct 2022 18:44:11 -0300
+Subject: [PATCH 2/2] Backport PR #485 [1]
+
+[1] https://github.com/umlaeute/v4l2loopback/pull/485
+---
+ v4l2loopback.c | 22 +++++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/v4l2loopback.c b/v4l2loopback.c
+index 22e9795..1be694c 100644
+--- a/v4l2loopback.c
++++ b/v4l2loopback.c
+@@ -1730,19 +1730,19 @@ static int vidioc_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
+ 
+ 	switch (type) {
+ 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
+-		opener->type = WRITER;
+-		dev->ready_for_output = 0;
+ 		if (!dev->ready_for_capture) {
+ 			int ret = allocate_buffers(dev);
+ 			if (ret < 0)
+ 				return ret;
++            opener->type = WRITER;
++            dev->ready_for_output = 0;
+ 			dev->ready_for_capture = 1;
+ 		}
+ 		return 0;
+ 	case V4L2_BUF_TYPE_VIDEO_CAPTURE:
+-		opener->type = READER;
+ 		if (!dev->ready_for_capture)
+ 			return -EIO;
++		opener->type = READER;
+ 		return 0;
+ 	default:
+ 		return -EINVAL;
+@@ -2042,11 +2042,27 @@ static ssize_t v4l2_loopback_write(struct file *file, const char __user *buf,
+ 	struct v4l2_loopback_device *dev;
+ 	int write_index;
+ 	struct v4l2_buffer *b;
++    int err = 0;
++
+ 	MARK();
+ 
+ 	dev = v4l2loopback_getdevice(file);
+     opener = fh_to_opener(file->private_data);
+ 
++	if (UNNEGOTIATED == opener->type) {
++		spin_lock(&dev->lock);
++
++		if (dev->ready_for_output) {
++			err = vidioc_streamon(file, file->private_data, V4L2_BUF_TYPE_VIDEO_OUTPUT);
++		}
++
++		spin_unlock(&dev->lock);
++
++		if (err < 0)
++			return err;
++	}
++
++
+     if (WRITER != opener->type)
+         return -EINVAL;
+ 
+-- 
+2.38.1
+

--- a/srcpkgs/v4l2loopback/patches/dkms-patch.patch
+++ b/srcpkgs/v4l2loopback/patches/dkms-patch.patch
@@ -1,0 +1,33 @@
+From e7edf2f55b7eb71b69984110f3c8e31b8ac6285e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?IOhannes=20m=20zm=C3=B6lnig?=
+ <zmoelnig@umlautS.umlaeute.mur.at>
+Date: Fri, 5 Aug 2022 18:42:22 +0200
+Subject: [PATCH] Backported dkms-patch from Ubuntu
+
+Closes: https://github.com/umlaeute/v4l2loopback/issues/498
+---
+ dkms.conf | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index f697db2b..7d5ed75c 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -3,8 +3,15 @@ PACKAGE_VERSION="0.12.7"
+ 
+ if [ -f $kernel_source_dir/.config ]; then
+     . $kernel_source_dir/.config
+-    if [ "${CONFIG_VIDEO_V4L2:-n}" = "n" ]; then
+-        BUILD_EXCLUSIVE_KERNEL="REQUIRES CONFIG_VIDEO_V4L2"
++    if ! { echo "$kernelver"; echo 5.18; } | sort -V -C; then
++        # for linux>=5.18, CONFIG_VIDEO_V4L2 has been renamed to CONFIG_VIDEO_DEV
++        if [ "${CONFIG_VIDEO_DEV:-n}" = "n" ]; then
++            BUILD_EXCLUSIVE_KERNEL="REQUIRES CONFIG_VIDEO_DEV"
++        fi
++    else
++        if [ "${CONFIG_VIDEO_V4L2:-n}" = "n" ]; then
++            BUILD_EXCLUSIVE_KERNEL="REQUIRES CONFIG_VIDEO_V4L2"
++        fi
+     fi
+ fi
+ 

--- a/srcpkgs/v4l2loopback/template
+++ b/srcpkgs/v4l2loopback/template
@@ -1,6 +1,6 @@
 # Template file for 'v4l2loopback'
 pkgname=v4l2loopback
-version=0.12.5
+version=0.12.7
 revision=1
 hostmakedepends="help2man"
 depends="dkms"
@@ -9,7 +9,7 @@ maintainer="John <me@johnnynator.dev>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/umlaeute/v4l2loopback"
 distfiles="https://github.com/umlaeute/v4l2loopback/archive/v${version}.tar.gz"
-checksum=e152cd6df6a8add172fb74aca3a9188264823efa5a2317fe960d45880b9406ae
+checksum=e0782b8abe8f2235e2734f725dc1533a0729e674c4b7834921ade43b9f04939b
 dkms_modules="v4l2loopback ${version}"
 
 do_install() {


### PR DESCRIPTION
Added the following patches:
- Backported dkms-patch from Ubuntu (support for kernel >= 5.18) [1]
- Limit v4l2_loopback_write calls to (streaming) writers [2]
- Reintroduce previous behavior for write call [3]

[1] https://github.com/umlaeute/v4l2loopback/commit/e7edf2f55b7eb71b69984110f3c8e31b8ac6285e
[2] https://github.com/umlaeute/v4l2loopback/pull/477/commits
[3] https://github.com/umlaeute/v4l2loopback/pull/485/commits

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
  - i686-libc
