### PR TITLE
tree-sitter: update to 0.20.7

### DIFF
--- a/srcpkgs/tree-sitter/template
+++ b/srcpkgs/tree-sitter/template
@@ -1,6 +1,6 @@
 # Template file for 'tree-sitter'
 pkgname=tree-sitter
-version=0.20.6
+version=0.20.7
 revision=1
 build_style=cargo
 make_install_args="--path=cli"
@@ -9,12 +9,12 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="MIT"
 homepage="https://tree-sitter.github.io"
 distfiles="https://github.com/tree-sitter/tree-sitter/archive/v${version}.tar.gz"
-checksum=4d37eaef8a402a385998ff9aca3e1043b4a3bba899bceeff27a7178e1165b9de
+checksum=b355e968ec2d0241bbd96748e00a9038f83968f85d822ecb9940cbe4c42e182e
 make_check=no # tests require generating fixtures from remote repositories
 
 post_patch() {
 	# fixes an indexmap error when cross compiling
-	cargo update --package autocfg --precise 1.1.0
+	cargo update --package autocfg:1.0.1 --precise 1.1.0
 }
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l
  - i686-libc
