### PR TITLE
linux-firmware: update to 20221012

### DIFF
--- a/srcpkgs/linux-firmware/template
+++ b/srcpkgs/linux-firmware/template
@@ -1,6 +1,6 @@
 # Template file for 'linux-firmware'
 pkgname=linux-firmware
-version=20220411
+version=20221012
 revision=1
 depends="${pkgname}-amd>=${version}_${revision} ${pkgname}-network>=${version}_${revision}"
 short_desc="Binary firmware blobs for the Linux kernel"
@@ -8,7 +8,7 @@ maintainer="Érico Nogueira <ericonr@disroot.org>"
 license="See /usr/share/licenses/${pkgname}"
 homepage="https://www.kernel.org/"
 distfiles="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=533ae621b3eacf6a4696dab52a9dbc5727403a175c413b1682ab3f9cfb37872f
+checksum=dacb1ba79754c1804feb862c4a012a7a33d419f92d4a80e4b5cafee9301a732a
 python_version=3
 nostrip=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686-libc (crossbuild)
