### PR TITLE
dbeaver: update to 22.2.3.

### DIFF
--- a/srcpkgs/dbeaver/template
+++ b/srcpkgs/dbeaver/template
@@ -1,17 +1,17 @@
 # Template file for 'dbeaver'
 pkgname=dbeaver
-version=22.1.3
+version=22.2.3
 revision=1
 # the build downloads binaries linked to glibc
 archs="x86_64 aarch64"
-hostmakedepends="apache-maven"
-depends="openjdk11" # openjdk11 or later version, when available
+hostmakedepends="apache-maven openjdk17"
+depends="openjdk17"
 short_desc="Free Universal Database Tool"
 maintainer="Kyle Nusbaum <knusbaum+void@sdf.org>"
 license="Apache-2.0"
 homepage="https://dbeaver.io"
 distfiles="https://github.com/dbeaver/dbeaver/archive/${version}.tar.gz"
-checksum=874921bad8bdcf37e4c9cb94f0b599f5d561de3934cecfef5ae2da3603a970a8
+checksum=07b31dfa46b9c1d0d67ec06040cedeac1b0431123acd426a62808c6df0c4b2ea
 nopie=true
 
 if [ "$XBPS_TARGET_MACHINE" = aarch64 ]; then


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

Had to update the Java version used and add it to hostmakedepends. The build log is full of warnings which I think are new:
> [INFO] --- tycho-compiler-plugin:3.0.0:compile (default-compile) @ org.jkiss.dbeaver.ext.test ---
> [WARNING] Using JavaSE-17 to fulfill requested profile of JavaSE-11 this might lead to faulty dependency resolution, consider define a suitable JDK in the toolchains.xml

Asking in the DBeaver issue queue to be sure: https://github.com/dbeaver/dbeaver/issues/18038.