### PR TITLE
alsa-{lib,utils,ucm-conf}: update to 1.2.8

### DIFF
--- a/srcpkgs/alsa-lib/template
+++ b/srcpkgs/alsa-lib/template
@@ -1,6 +1,6 @@
 # Template file for 'alsa-lib'
 pkgname=alsa-lib
-version=1.2.7.2
+version=1.2.8
 revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config libtool"
@@ -9,7 +9,7 @@ maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="LGPL-2.1-or-later"
 homepage="http://www.alsa-project.org"
 distfiles="https://www.alsa-project.org/files/pub/lib/${pkgname}-${version}.tar.bz2"
-checksum=8a35b7218e50f2a2c79342d0de98ded81439ce19e12809385ec9be9596de7c2f
+checksum=1ab01b74e33425ca99c2e36c0844fd6888273193bd898240fe8f93accbcbf347
 
 alsa-lib-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"

--- a/srcpkgs/alsa-ucm-conf/template
+++ b/srcpkgs/alsa-ucm-conf/template
@@ -1,13 +1,13 @@
 # Template file for 'alsa-ucm-conf'
 pkgname=alsa-ucm-conf
-version=1.2.7.2
+version=1.2.8
 revision=1
 short_desc="ALSA Use Case Manager topology configurations"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="BSD-3-Clause"
 homepage="https://github.com/alsa-project/alsa-ucm-conf"
 distfiles="https://github.com/alsa-project/${pkgname}/archive/refs/tags/v${version}.tar.gz"
-checksum=a671dc3bc75d4e93b1bc225bc69e07345721261cd2bf0bead56a9dc05dc7caef
+checksum=711ca92a17d7519755bfd633ca819e2a4e5e40eddbde6b66d18aa1d9a5346ced
 
 do_install() {
 	vdoc ucm2/README.md

--- a/srcpkgs/alsa-utils/template
+++ b/srcpkgs/alsa-utils/template
@@ -1,6 +1,6 @@
 # Template file for 'alsa-utils'
 pkgname=alsa-utils
-version=1.2.7
+version=1.2.8
 revision=1
 build_style=gnu-configure
 configure_args="--with-udev-rules-dir=/usr/lib/udev/rules.d --disable-alsaconf
@@ -14,7 +14,7 @@ maintainer="Anthony Iliopoulos <ailiop@altatus.com>"
 license="GPL-2.0-only"
 homepage="http://www.alsa-project.org"
 distfiles="https://www.alsa-project.org/files/pub/utils/${pkgname}-${version}.tar.bz2"
-checksum=e906bf2404ff04c448eaa3d226d283a62b9a283f12e4fd8457fb24bac274e678
+checksum=e140fa604c351f36bd72167c8860c69d81b964ae6ab53992d6434dde38e9333c
 
 post_install() {
 	# Install required udev rules file.


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

Currently successfully testing with the following audio devices on x86_64-GLIBC:

* Intel Corporation Comet Lake PCH-LP cAVS
* Intel Corporation Alder Lake PCH-P High Definition Audio Controller (rev 01)