### PR TITLE
Add vterminfo template function

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -328,12 +328,19 @@ The following functions are defined by `xbps-src` and can be used on any templat
 	Note that vsed will call the sed command for every regex specified against
 	every file specified, in the order that they are given.
 
-- *vcompletion()* `<file> <shell> [<command>]`
+- *vcompletion()* `vcompletion <file> <shell> [<command>]`
 
 	Installs shell completion from `file` for `command`, in the correct location
 	and with the appropriate filename for `shell`. If `command` isn't specified,
 	it will default to `pkgname`. The `shell` argument can be one of `bash`,
 	`fish` or `zsh`.
+
+- *vterminfo()* `vterminfo <file> [entries]`
+
+	Processes `file` document via `tic(1)` to generate a terminfo database entry,
+	optionally for each of the specified `entries` terminfo entries. The produced
+	terminfo file is written to `masterdir/destdir` ready for package inclusion,
+	using say `vmove usr/share/terminfo`.
 
 > Shell wildcards must be properly quoted, Example: `vmove "usr/lib/*.a"`.
 

--- a/common/environment/setup/install.sh
+++ b/common/environment/setup/install.sh
@@ -13,7 +13,7 @@ _noglob_helper() {
 }
 
 # Apply _noglob to v* commands
-for cmd in vinstall vcopy vcompletion vmove vmkdir vbin vman vdoc vconf vsconf vlicense vsv; do
+for cmd in vinstall vcopy vcompletion vmove vmkdir vbin vman vdoc vconf vsconf vlicense vsv vterminfo; do
        alias ${cmd}="set -f; _noglob_helper _${cmd}"
 done
 
@@ -273,4 +273,34 @@ _vcompletion() {
 			return 1
 			;;
 	esac
+}
+
+_vterminfo() {
+	local file="$1" entries="$2"
+	local _terminfo_dir=usr/share/terminfo
+	local _args=
+
+	if [ $# -lt 1 ]; then
+		msg_red "$pkgver: vterminfo: at least 1 argument expected: <file> [entries]\n"
+		return 1
+	elif ! [ -f "$file" ]; then
+		msg_red "$pkgver: vterminfo: file '$file' does not exist.\n"
+		return 1
+	elif ! [ -r "$file" ]; then
+		msg_red "$pkgver: vterminfo: file '$file' is not readable.\n"
+		return 1
+	elif  [ -z "$PKGDESTDIR" ]; then
+		msg_red "$pkgver: vterminfo: PKGDESTDIR unset, can't continue...\n"
+		return 1
+	elif ! [ -x /usr/bin/tic ]; then
+		msg_red "$pkgver: vterminfo: 'tic' binary is missing, can't continue...\n"
+		return 1
+	fi
+
+	if [ -n "$entries" ]; then
+		_args="-e ${entries}"
+	fi
+
+	vmkdir "${_terminfo_dir}"
+	/usr/bin/tic -sx ${_args} -o "${PKGDESTDIR}/${_terminfo_dir}" "$file"
 }

--- a/srcpkgs/alacritty/template
+++ b/srcpkgs/alacritty/template
@@ -30,8 +30,7 @@ post_install() {
 	vinstall extra/logo/alacritty-term.svg 644 usr/share/icons/hicolor/scalable/apps Alacritty.svg
 	vman extra/alacritty.man alacritty.1
 	vsconf alacritty.yml
-
-	tic -o ${DESTDIR}/usr/share/terminfo -xe alacritty,alacritty-direct extra/alacritty.info
+	vterminfo extra/alacritty.info alacritty,alacritty-direct
 }
 
 alacritty-terminfo_package() {

--- a/srcpkgs/mtm/template
+++ b/srcpkgs/mtm/template
@@ -17,8 +17,7 @@ do_build() {
 
 do_install() {
 	vbin mtm
-	mkdir -p ${DESTDIR}/usr/share/terminfo
-	tic -sx -o ${DESTDIR}/usr/share/terminfo mtm.ti
+	vterminfo mtm.ti mtm,mtm-256color,mtm-noutf
 	vman mtm.1
 }
 

--- a/srcpkgs/ncurses/template
+++ b/srcpkgs/ncurses/template
@@ -103,6 +103,7 @@ post_install() {
 	rm ${DESTDIR}/usr/share/terminfo/d/dvtm{,-256color}
 	rm ${DESTDIR}/usr/share/terminfo/s/st{,-256color}
 	rm ${DESTDIR}/usr/share/terminfo/f/foot{,-direct,+base}
+	rm -f ${DESTDIR}/usr/share/terminfo/w/wezterm
 }
 
 ncurses-libs_package() {

--- a/srcpkgs/wezterm/template
+++ b/srcpkgs/wezterm/template
@@ -48,8 +48,7 @@ do_install() {
 	vcompletion assets/shell-completion/fish fish
 	vcompletion assets/shell-completion/zsh zsh
 
-	vmkdir usr/share/terminfo
-	tic -sx -o ${DESTDIR}/usr/share/terminfo termwiz/data/wezterm.terminfo
+	vterminfo termwiz/data/wezterm.terminfo
 
 	vdoc README.md
 	vlicense LICENSE.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (`x86_64`-`glibc`)

#### Notes
During development of the `wezterm` package, it became apparent that no helpers exists to assist in the creation of terminfo compilation databases and multiple packages did their own "thing"(tm). This patch aims to resolve this situation.

This patch *includes* changes from another PR. It must **NOT** be merged until #36903.

@classabbyamp  