### PR TITLE
mopidy-local: add missing dependency on uritools

### DIFF
--- a/srcpkgs/mopidy-local/template
+++ b/srcpkgs/mopidy-local/template
@@ -1,10 +1,10 @@
 # Template file for 'mopidy-local'
 pkgname=mopidy-local
 version=3.1.1
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools"
-depends="mopidy python3-pykka python3-setuptools"
+depends="mopidy python3-pykka python3-setuptools python3-uritools"
 checkdepends="${depends} python3-gobject python3-pytest"
 short_desc="Mopidy extension for playing music from your local music archive"
 maintainer="Nick Hahn <nick.hahn@posteo.de>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
