### PR TITLE
rusty-diceware: update to 0.5.8.

### DIFF
--- a/srcpkgs/rusty-diceware/template
+++ b/srcpkgs/rusty-diceware/template
@@ -1,16 +1,16 @@
 # Template file for 'rusty-diceware'
 pkgname=rusty-diceware
-version=0.5.3
+version=0.5.8
 revision=1
-wrksrc="${pkgname}-v${version}"
+wrksrc="${pkgname}-diceware-v${version}"
 build_style=cargo
 short_desc="Commandline diceware, sans dice, written in rustlang"
 maintainer="jcgruenhage <jan.christian@gruenhage.xyz>"
 license="AGPL-3.0-only"
 homepage="https://gitlab.com/yuvallanger/rusty-diceware"
 changelog="https://gitlab.com/yuvallanger/rusty-diceware/-/raw/master/CHANGELOG.md"
-distfiles="https://gitlab.com/yuvallanger/rusty-diceware/-/archive/v${version}/rusty-diceware-v${version}.tar.gz"
-checksum=88f921c304eced0c5b8b4ce535695d45b0b298b0f7fbb9b6da5f1c67e6acea1d
+distfiles="https://gitlab.com/yuvallanger/rusty-diceware/-/archive/diceware-v${version}/rusty-diceware-diceware-v${version}.tar.gz"
+checksum=a3301f585149af8818d10972238656b9586a3fd78a6842150aec6d0ae8e4dbe8
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
