### PR TITLE
nextcloud-client: update to 3.6.1

### DIFF
--- a/srcpkgs/nextcloud-client/patches/check-for-updates-disabled-as-default.patch
+++ b/srcpkgs/nextcloud-client/patches/check-for-updates-disabled-as-default.patch
@@ -1,0 +1,24 @@
+Set check for updates option as false by default
+
+--- a/src/gui/generalsettings.ui
++++ b/src/gui/generalsettings.ui
+@@ -114,7 +114,7 @@
+            <string>&amp;Automatically check for Updates</string>
+           </property>
+           <property name="checked">
+-           <bool>true</bool>
++           <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+--- a/src/libsync/configfile.cpp
++++ b/src/libsync/configfile.cpp
+@@ -631,7 +631,7 @@ bool ConfigFile::autoUpdateCheck(const QString &connection) const
+     if (connection.isEmpty())
+         con = defaultConnection();
+ 
+-    QVariant fallback = getValue(QLatin1String(autoUpdateCheckC), con, true);
++    QVariant fallback = getValue(QLatin1String(autoUpdateCheckC), con, false);
+     fallback = getValue(QLatin1String(autoUpdateCheckC), QString(), fallback);
+ 
+     QVariant value = getPolicySetting(QLatin1String(autoUpdateCheckC), fallback);

--- a/srcpkgs/nextcloud-client/patches/testfolderman-within-chroot.patch
+++ b/srcpkgs/nextcloud-client/patches/testfolderman-within-chroot.patch
@@ -2,14 +2,14 @@ is wrong if running within a user's chroot
 
 --- a/test/testfolderman.cpp	2020-09-24 14:51:48.000000000 +0200
 +++ b/test/testfolderman.cpp	2020-10-02 20:33:32.248359240 +0200
-@@ -119,10 +119,6 @@
+@@ -127,10 +127,6 @@
          // Subfolder of links
-         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + "/link1/subfolder").isNull());
-         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + "/link2/free/subfolder").isNull());
+         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + "/link1/subfolder").second.isNull());
+         QVERIFY(folderman->checkPathValidityForNewFolder(dirPath + "/link2/free/subfolder").second.isNull());
 -
 -        // Should not have the rights
--        QVERIFY(!folderman->checkPathValidityForNewFolder("/").isNull());
--        QVERIFY(!folderman->checkPathValidityForNewFolder("/usr/bin/somefolder").isNull());
+-        QVERIFY(!folderman->checkPathValidityForNewFolder("/").second.isNull());
+-        QVERIFY(!folderman->checkPathValidityForNewFolder("/usr/bin/somefolder").second.isNull());
  #endif
  
-         // Invalid paths
+ #ifdef Q_OS_WIN // drive-letter tests

--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.6.0
+version=3.6.1
 revision=1
 wrksrc="desktop-${version}"
 build_style=cmake
@@ -20,7 +20,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=d7c1d3f6a867566c1f9a629c8c0d954ba69ebc4107c0faa975a1ccf42842d0df
+checksum=c7ea1ed2d0f44a3b8b645a67f21af164bf1024b6872570a61c62994d2a8c1b5b
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 


### PR DESCRIPTION
Also:
- update testfolderman patch
- add patch to disable update check by default
  this affects new installations only

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686-libc
