### PR TITLE
i2pd: increase open files limit

### DIFF
--- a/srcpkgs/i2pd/files/i2pd/run
+++ b/srcpkgs/i2pd/files/i2pd/run
@@ -1,4 +1,6 @@
 #!/bin/sh
+[ -r conf ] && . ./conf
+ulimit -n ${MAX_OPEN_FILES:-16384}
 exec chpst -u _i2pd:_i2pd i2pd --service \
 	--conf=/etc/i2pd/i2pd.conf \
 	--tunconf=/etc/i2pd/tunnels.conf 2>&1

--- a/srcpkgs/i2pd/template
+++ b/srcpkgs/i2pd/template
@@ -1,7 +1,7 @@
 # Template file for 'i2pd'
 pkgname=i2pd
 version=2.43.0
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="USE_UPNP=yes"
 makedepends="zlib-devel boost-devel openssl-devel miniupnpc-devel


### PR DESCRIPTION
To run i2pd as a "floodfill" (special mode which contributes to the network more) we need a higher open files limit. 8192 is recommended by upstream but let's just double it to be on the safe side.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
