### PR TITLE
epson-inkjet-printer-escpr2: update to 1.1.53.

### DIFF
--- a/srcpkgs/epson-inkjet-printer-escpr2/template
+++ b/srcpkgs/epson-inkjet-printer-escpr2/template
@@ -1,25 +1,26 @@
 # Template file for 'epson-inkjet-printer-escpr2'
 pkgname=epson-inkjet-printer-escpr2
-version=1.1.24
+version=1.1.53
 revision=1
 archs="x86_64 i686 aarch64 armv7l"
 create_wrksrc=yes
-build_wrksrc="${pkgname}-${version}"
 build_style=gnu-configure
-configure_args="--with-cupsfilterdir=/usr/lib/cups/filter --with-cupsppddir=/usr/share/ppd"
-hostmakedepends="automake rpmextract "
+configure_args="--with-cupsfilterdir=/usr/lib/cups/filter
+ --with-cupsppddir=/usr/share/ppd"
+hostmakedepends="automake rpmextract"
 makedepends="cups-devel ghostscript-devel"
 short_desc="Epson Inkjet Printer Driver 2 (ESC/P-R) for Linux"
 maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="custom:Proprietary"
 homepage="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX"
-distfiles="https://download3.ebz.epson.net/dsc/f/03/00/12/09/63/b7d2bb6a97c9ad99a96ebc68f8abcb1254888e94/${pkgname}-${version}-1lsb3.2.src.rpm"
-checksum=0cfce328ab1359b7c393532c54f5cdb0ee43ec2fd188d7a09b0ab6b04331d9ca
+distfiles="https://download3.ebz.epson.net/dsc/f/03/00/14/04/43/912b0e6f8a4a51379d983f23abc3db087ef20bc6/epson-inkjet-printer-escpr2-${version}-1lsb3.2.src.rpm"
+checksum=e72c5b47a77ef8e952846ca70b18aa88823149bd982d061257be07845d9ad3c6
 restricted=yes
 repository=nonfree
 
 post_extract() {
-	bsdtar xf ${pkgname}-${version}-1lsb3.2.tar.gz
+	bsdtar --strip-components=1 -xf \
+		epson-inkjet-printer-escpr2-${version}-1lsb3.2.tar.gz
 }
 
 post_install() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (~~x86_64-musl~~)
Edit: it contains precompiled binaries built with glibc so it shouldn't be available on musl.
