### PR TITLE
hackrf: update to 2022.09.1, adopt.

### DIFF
--- a/srcpkgs/hackrf/template
+++ b/srcpkgs/hackrf/template
@@ -1,7 +1,7 @@
 # Template file for 'hackrf'
 pkgname=hackrf
-version=2021.03.1
-revision=3
+version=2022.09.1
+revision=1
 build_wrksrc=host
 build_style=cmake
 configure_args="-DUDEV_RULES_PATH=/usr/lib/udev/rules.d/ -DUDEV_RULES_GROUP=plugdev
@@ -10,11 +10,11 @@ hostmakedepends="pkg-config"
 makedepends="libusb-devel fftw-devel"
 _desc="Low cost software defined radio (SDR) platform"
 short_desc="${_desc} - tools"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="DragonGhost7 <darkiridiumghost@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://greatscottgadgets.com/hackrf/"
 distfiles="https://github.com/greatscottgadgets/hackrf/releases/download/v${version}/${pkgname}-${version}.tar.xz"
-checksum=a43e5080c11efdfe69ddebcc35a02b018e30e820de0e0ebdc7948cf7b0cd93a3
+checksum=bacd4e7937467ffa14654624444c8b5c716ab470d8c1ee8d220d2094ae2adb3e
 
 post_install() {
 	for f in ../firmware-bin/*.{bin,dfu}; do


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64-musl
  - aarch64
  - aarch64-musl
  - armv6l
  - armv6l-musl
  - armv7l
  - armv7l-musl

