### PR TITLE
lua54-lualdap: fix build for lua 5.4

### DIFF
--- a/srcpkgs/lua54-lualdap/patches/c89-is-broken.patch
+++ b/srcpkgs/lua54-lualdap/patches/c89-is-broken.patch
@@ -1,0 +1,15 @@
+Index: lua54-lualdap-1.2.5/lua54/Makefile
+===================================================================
+--- lua54-lualdap-1.2.5.orig/lua54/Makefile
++++ lua54-lualdap-1.2.5/lua54/Makefile
+@@ -15,8 +15,8 @@ endif
+ 
+ CFLAGS_WARN := -pedantic -Wall -W -Waggregate-return -Wcast-align -Wmissing-prototypes -Wnested-externs -Wshadow -Wwrite-strings
+ 
+-override CPPFLAGS := -DPACKAGE_STRING="\"$(PACKAGE_STRING)\"" -DLUA_C89_NUMBERS $(CPPFLAGS)
+-override CFLAGS := -O2 -fPIC -std=c89 $(CFLAGS_WARN) $(CFLAGS)
++override CPPFLAGS := -DPACKAGE_STRING="\"$(PACKAGE_STRING)\"" $(CPPFLAGS)
++override CFLAGS := -O2 -fPIC $(CFLAGS_WARN) $(CFLAGS)
+ 
+ ifdef BUILD_VARIANT
+ REPORT_DIR := test-reports/$(BUILD_VARIANT)

--- a/srcpkgs/lua54-lualdap/patches/lua54.patch
+++ b/srcpkgs/lua54-lualdap/patches/lua54.patch
@@ -1,5 +1,5 @@
---- a/src/compat-5.3.h
-+++ b/src/compat-5.3.h
+--- a/lua54/src/compat-5.3.h
++++ b/lua54/src/compat-5.3.h
 @@ -399,11 +399,11 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
  
  

--- a/srcpkgs/lua54-lualdap/template
+++ b/srcpkgs/lua54-lualdap/template
@@ -2,7 +2,7 @@
 pkgname=lua54-lualdap
 version=1.2.5
 revision=3
-wrksrc="lualdap-${version}"
+create_wrksrc=yes
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="lua51-devel lua52-devel lua53-devel lua54-devel libldap-devel"
@@ -14,13 +14,12 @@ homepage="https://github.com/lualdap/lualdap"
 distfiles="https://github.com/lualdap/lualdap/archive/v${version}.tar.gz"
 checksum=3e028faa6a5798cf2f3d50b9853b9b3fb6eb562b62010747bd5b6f50b57bb1cc
 
-post_patch() {
-	cd ${wrksrc}
-	mkdir -p lua51
-	mv * lua51 || true
-	cp -a lua51 lua52
-	cp -a lua51 lua53
-	cp -a lua51 lua54
+post_extract() {
+	mv lualdap-${version} lua
+	cp -a lua lua51
+	cp -a lua lua52
+	cp -a lua lua53
+	cp -a lua lua54
 }
 
 do_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
@jprjr 
#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
