### PR TITLE
rtl8822bu-dkms: update to 20221030.

### DIFF
--- a/srcpkgs/rtl8822bu-dkms/patches/0001-void-arch-generic-plumbing-bits.patch
+++ b/srcpkgs/rtl8822bu-dkms/patches/0001-void-arch-generic-plumbing-bits.patch
@@ -11,17 +11,17 @@ diff --git Makefile Makefile
 index 29da0bf..d58bc95 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -97,7 +97,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
+@@ -120,7 +120,8 @@ CONFIG_RTW_SDIO_PM_KEEP_POWER = y
  ###################### MP HW TX MODE FOR VHT #######################
  CONFIG_MP_VHT_HW_TX_MODE = n
  ###################### Platform Related #######################
 -CONFIG_PLATFORM_I386_PC = y
 +CONFIG_PLATFORM_VOID_NATIVE = y
 +CONFIG_PLATFORM_I386_PC = n
- CONFIG_PLATFORM_ARM_RPI = n
  CONFIG_PLATFORM_ANDROID_X86 = n
  CONFIG_PLATFORM_ANDROID_INTEL_X86 = n
-@@ -1030,6 +1031,17 @@ endif
+ CONFIG_PLATFORM_JB_X86 = n
+@@ -1289,6 +1289,17 @@ endif
  
  EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
  
@@ -36,9 +36,9 @@ index 29da0bf..d58bc95 100644
 +STAGINGMODDIR := /usr/lib/modules/$(KVER)/kernel/drivers/staging
 +endif
 +
- ifeq ($(CONFIG_PLATFORM_I386_PC), y)
- EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
- EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+ ifeq ($(CONFIG_RTW_VHT_2G4), y)
+ EXTRA_CFLAGS += -DRTW_VHT_2G4=1
+ else
 -- 
 2.29.2
 

--- a/srcpkgs/rtl8822bu-dkms/template
+++ b/srcpkgs/rtl8822bu-dkms/template
@@ -1,16 +1,16 @@
 # Template file for 'rtl8822bu-dkms'
 pkgname=rtl8822bu-dkms
-version=20201222
-revision=2
-_gitrev=fcfd4ecca1512d4cd2db4aa91679576d2a5ab8eb
-wrksrc="rtl8822bu-${_gitrev}"
-depends="dkms"
+version=20221030
+revision=1
+_gitrev=f77c4e55cc1852b9f6e5aec416a34abcdabcd825
+wrksrc="rtl88x2bu-${_gitrev}"
+depends="dkms bc"
 short_desc="Realtek 8822BU USB WiFi driver (DKMS)"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://www.tp-link.com"
-distfiles="https://github.com/EntropicEffect/rtl8822bu/archive/${_gitrev}.tar.gz"
-checksum=fb2dbcd0385d558af6c74571aaac9020d7cbb9e56cc4780299bd420559f29bb1
+distfiles="https://github.com/cilynx/rtl88x2bu/archive/${_gitrev}.tar.gz"
+checksum=d1ed87d40cb47c1ac011a9e57aba84d8efecead84f0ddab4ea2847281c2749ca
 dkms_modules="88x2bu ${version}"
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
switch upstream (current one is archived), fixes build on newer kernels

fixes #40234

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (don't have the hardware, but the dkms module builds)

