### PR TITLE
google-chrome: don't depend on qt5-{core,gui,widgets}

### DIFF
--- a/srcpkgs/google-chrome/template
+++ b/srcpkgs/google-chrome/template
@@ -1,7 +1,7 @@
 # Template file for 'google-chrome'
 pkgname=google-chrome
 version=107.0.5304.87
-revision=1
+revision=2
 _channel=stable
 archs="x86_64"
 hostmakedepends="tar xz python3 python3-html2text python3-setuptools"
@@ -13,6 +13,7 @@ homepage="https://www.google.com/chrome/"
 nostrip=yes
 restricted=yes
 repository=nonfree
+skiprdeps="/opt/google/chrome/libqt5_shim.so"
 
 _baseUrl="https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable"
 _filename="google-chrome-${_channel}_${version}-1_amd64.deb"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES** (on a machine without any `qt5*` packages)

---

This disables rdep scanning for `libqt5_shim.so`, as does upstream:

https://chromium.googlesource.com/chromium/src/+/8fcee9b26219683fb20bc51826629cac2e3584a0%5E%21/#F0

Otherwise it pulls in `qt5-widgets`, etc.:

```
# xbps-install -R . google-chrome

Name                Action    Version           New version            Download size
double-conversion   install   -                 3.1.5_1                29KB
qt5-core            install   -                 5.15.5+20220728_1      2408KB
libevdev            install   -                 1.12.0_1               38KB
libwacom            install   -                 1.12_1                 92KB
mtdev               install   -                 1.1.6_1                12KB
libinput            install   -                 1.21.0_1               253KB
libxkbcommon-x11    install   -                 1.4.1_1                13KB
qt5-dbus            install   -                 5.15.5+20220728_1      194KB
qt5-network         install   -                 5.15.5+20220728_1      692KB
tslib               install   -                 1.22_1                 50KB
xcb-util-image      install   -                 0.4.0_3                9436B
xcb-util-renderutil install   -                 0.3.9_3                7632B
qt5-gui             install   -                 5.15.5+20220728_1      3935KB
qt5-widgets         install   -                 5.15.5+20220728_1      2587KB
google-chrome       update    106.0.5249.119_1  107.0.5304.87_1        -

Size to download:               10MB
Size required on disk:         321MB
Space available on disk:       112GB
```

Maintainer ping: @atk