### PR TITLE
mobile-config-firefox: update to 3.1.0.

### DIFF
--- a/srcpkgs/mobile-config-firefox/template
+++ b/srcpkgs/mobile-config-firefox/template
@@ -1,11 +1,11 @@
 # Template file for 'mobile-config-firefox'
 pkgname=mobile-config-firefox
-version=3.0.0
+version=3.1.0
 revision=1
 build_style=gnu-makefile
 short_desc="Mobile and privacy friendly configuration for Firefox"
 maintainer="Jami Kettunen <jami.kettunen@protonmail.com>"
-license="GPL-3.0-or-later"
+license="MPL-2.0"
 homepage="https://gitlab.com/postmarketOS/mobile-config-firefox"
 distfiles="${homepage}/-/archive/${version}/${pkgname}-${version}.tar.gz"
-checksum=7821edce47cd0fe02639e76ae8145ed28924771d409fca012c42e49057288fb7
+checksum=93bd77a47133e75e77a0e03622df0a62ddd37125ff3db9670d550e3e19bc709e


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
Also change license to `MPL-2.0` as per https://gitlab.com/postmarketOS/mobile-config-firefox/-/commit/75c57aa3.

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
