### PR TITLE
superd: touch template to build for x86_64-glibc

### DIFF
--- a/srcpkgs/superd/template
+++ b/srcpkgs/superd/template
@@ -1,4 +1,4 @@
-# Template file for 'superd'
+# Template file for 'superd' 
 pkgname=superd
 version=0.7
 revision=1


### PR DESCRIPTION
This is currently available in repos for all arches ([including `x86_64-musl`](https://voidlinux.org/packages/?arch=x86_64-musl&q=superd)), but [not x86_64-glibc](https://voidlinux.org/packages/?arch=x86_64&q=superd) which appears to have failed build for reasons unrelated to the packaging.

Ping @paper42 who already responded to me about this on `#xbps`:
> the build failed and the builder doesn't attempt it again for new pkgs
> failed because of transient resolver error iirc
> touching the template will help, not sure if there is a better way

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
