### PR TITLE
libpng: update to 1.6.38

### DIFF
--- a/srcpkgs/libpng/template
+++ b/srcpkgs/libpng/template
@@ -1,6 +1,6 @@
 # Template file for 'libpng'
 pkgname=libpng
-version=1.6.37
+version=1.6.38
 revision=1
 build_style=gnu-configure
 makedepends="zlib-devel"
@@ -9,7 +9,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="Libpng"
 homepage="http://www.libpng.org/pub/png/libpng.html"
 distfiles="${SOURCEFORGE_SITE}/libpng/libpng-${version}.tar.xz"
-checksum=505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca
+checksum=b3683e8b8111ebf6f1ac004ebb6b0c975cd310ec469d98364388e9cedbfa68be
 
 case "$XBPS_TARGET_MACHINE" in
 	arm*|aarch64*) configure_args="--enable-arm-neon=no";;


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686-libc
