### PR TITLE
taplo: update to 0.8.0

### DIFF
--- a/srcpkgs/taplo/template
+++ b/srcpkgs/taplo/template
@@ -1,18 +1,21 @@
 # Template file for 'taplo'
 pkgname=taplo
-version=0.7.0
+version=0.8.0
 revision=1
-archs="x86_64* i686* aarch64* arm*" # ring
 build_wrksrc="crates/taplo-cli"
 build_style=cargo
+# no-default-features: allows selecting custom feature set
+# lsp: builds TOML language server
+# native-tls: Enables linking against system SSL instead of rustls/ring
+configure_args="--no-default-features --features lsp,native-tls"
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"
 short_desc="TOML toolkit written in Rust"
 maintainer="cinerea0 <cinerea0@protonmail.com>"
 license="MIT"
 homepage="https://taplo.tamasfe.dev/"
-distfiles="https://github.com/tamasfe/taplo/archive/refs/tags/release-${pkgname}-cli-${version}.tar.gz"
-checksum=6b6d06220dabc3a63e17b87ca4be1b9dfde97dc3c6bd6e8115cc5d2e2dad9bbe
+distfiles="https://github.com/tamasfe/taplo/archive/refs/tags/${version}.tar.gz"
+checksum=079fab82f48e4f71379f0d2e249b7bd402af8ddf84ea16b65ba2742811a8d951
 
 post_install() {
 	vlicense ../../LICENSE.md


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

I've enabled a feature that should remove the arch restriction. If someone with ppc equipment could test, I'd be grateful.
