### PR TITLE
lightdm: enable cross-build of liblightdm-qt5

### DIFF
--- a/srcpkgs/lightdm/template
+++ b/srcpkgs/lightdm/template
@@ -1,16 +1,17 @@
 # Template file for 'lightdm'
 pkgname=lightdm
 version=1.32.0
-revision=1
+revision=2
 build_style=gnu-configure
 build_helper="gir"
 configure_args="--sbindir=/usr/bin --with-greeter-session=lightdm-gtk-greeter
  --with-greeter-user=lightdm --disable-static --disable-tests
  $(vopt_enable gir introspection)"
-hostmakedepends="pkg-config intltool itstool $(vopt_if gir 'gobject-introspection vala')"
+hostmakedepends="pkg-config intltool itstool $(vopt_if gir 'gobject-introspection vala')
+ qt5-host-tools"
 makedepends="dbus-glib-devel libxklavier-devel libxml2-devel
  gtk+3-devel libxcb-devel libXdmcp-devel pam-devel vala-devel
- libgcrypt-devel accountsservice-devel"
+ libgcrypt-devel accountsservice-devel qt5-devel"
 depends="dbus accountsservice"
 short_desc="Light Display Manager"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -22,19 +23,12 @@ checksum=12f5ab432748f0387c7cf8b94430495a558a035a4f8465e5181af6faff133e4b
 conf_files="/etc/${pkgname}/*.conf /etc/pam.d/*"
 system_accounts="lightdm"
 lightdm_homedir="/var/lib/lightdm"
-subpackages="liblightdm-gobject lightdm-devel"
 make_dirs="
 	/var/lib/lightdm 0755 lightdm lightdm
 	/var/lib/lightdm-data 0755 lightdm lightdm"
 
 build_options="gir"
 build_options_default="gir"
-
-if [ -z "$CROSS_BUILD" ]; then
-	configure_args+=" MOC5=/usr/lib/qt5/bin/moc"
-	makedepends+=" qt5-devel"
-	subpackages+=" liblightdm-qt5"
-fi
 
 post_install() {
 	# Remove provided init file and use our own.
@@ -69,10 +63,8 @@ liblightdm-qt5_package() {
 }
 
 lightdm-devel_package() {
-	depends="libglib-devel liblightdm-gobject-${version}_${revision}"
-	if [ -z "$CROSS_BUILD" ]; then
-		depends+=" liblightdm-qt5-${version}_${revision}"
-	fi
+	depends="libglib-devel liblightdm-gobject-${version}_${revision}
+ liblightdm-qt5-${version}_${revision}"
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include


### PR DESCRIPTION
This was excluded way back in Qt4 days of early 2015 to enable cross-building of `lightdm` but doesn't appear to be a problem anymore.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
