### PR TITLE
New packages: grype and syft

### DIFF
--- a/srcpkgs/grype/template
+++ b/srcpkgs/grype/template
@@ -1,0 +1,12 @@
+# Template file for 'grype'
+pkgname=grype
+version=0.51.0
+revision=1
+build_style=go
+go_import_path="github.com/anchore/grype"
+short_desc="Vulnerability scanner for container images and filesystems"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0"
+homepage="https://github.com/anchore/grype"
+distfiles="https://github.com/anchore/grype/archive/refs/tags/v${version}.tar.gz"
+checksum=5d7260f15fe8cee30253894c0c4bae0451053585da45df72aef30dab7c14d0e0

--- a/srcpkgs/syft/template
+++ b/srcpkgs/syft/template
@@ -1,0 +1,12 @@
+# Template file for 'syft'
+pkgname=syft
+version=0.60.0
+revision=1
+build_style=go
+go_import_path="github.com/anchore/syft/cmd/syft"
+short_desc="SBOM generator CLI for container images, filesystems and more"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0"
+homepage="https://github.com/anchore/syft"
+distfiles="https://github.com/anchore/syft/archive/refs/tags/v${version}.tar.gz"
+checksum=b20634a8e7cdaf8b6fd741390800ae8fe2eead9d468a75437a7cae2712777ba3


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Follow-up on https://github.com/void-linux/void-packages/pull/34511.

I had lost interest in it, but the yet to be published OpenSSL vulnerability means that I had to scan all my container images for installed OpenSSL versions. `syft` handles that job very well.


#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
