### PR TITLE
New package: cargo-auditable-0.5.2

### DIFF
--- a/srcpkgs/cargo-auditable/template
+++ b/srcpkgs/cargo-auditable/template
@@ -1,0 +1,16 @@
+# Template file for 'cargo-auditable'
+pkgname=cargo-auditable
+version=0.5.2
+revision=1
+build_wrksrc=cargo-auditable
+build_style=cargo
+short_desc="Tool for embedding dependency information in rust binaries"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT,Apache-2.0"
+homepage="https://github.com/rust-secure-code/cargo-auditable"
+distfiles="https://github.com/rust-secure-code/cargo-auditable/archive/refs/tags/v${version}.tar.gz"
+checksum=fee70e8d2354e47eba1fed767430c12423c2a93c37307ae4c7d977c7693b88dd
+
+post_install() {
+	vlicense ../LICENSE-MIT
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Allows the user to embed dependency information into the binary. This information can be read by a few different tools, for example `syft` (see https://github.com/void-linux/void-packages/pull/40264) and `rust-audit-info` (see https://github.com/void-linux/void-packages/pull/40266). I'd like to follow this PR up with a change to the cargo build style, so that we can include that dependency information in all rust binaries we ship.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
