### PR TITLE
New package: rust-audit-info-0.5.1

### DIFF
--- a/srcpkgs/rust-audit-info/template
+++ b/srcpkgs/rust-audit-info/template
@@ -1,0 +1,18 @@
+# Template file for 'rust-audit-info'
+pkgname=rust-audit-info
+version=0.5.1
+revision=1
+_commit=8622e6fe844d1d5ae10e894d9c8a05afff97e6da
+wrksrc="cargo-auditable-${_commit}"
+build_wrksrc=rust-audit-info
+build_style=cargo
+short_desc="CLI tool for extracting cargo-auditable dependency trees"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT, Apache-2.0"
+homepage="https://github.com/rust-secure-code/cargo-auditable"
+distfiles="https://github.com/rust-secure-code/cargo-auditable/archive/${_commit}.tar.gz"
+checksum=f89b19e1df2f0b27c1e9bb474fa754ece117e1f561cc32beb296190eb70908f3
+
+post_install() {
+	vlicense ../LICENSE-MIT
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

Ideally, we'd have git tags here. I've created an issue upstream about this: https://github.com/rust-secure-code/cargo-auditable/issues/81

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
