### PR TITLE
RFC: build-style/cargo: produce auditable binaries

### DIFF
--- a/common/build-style/cargo.sh
+++ b/common/build-style/cargo.sh
@@ -3,20 +3,20 @@
 #
 
 do_build() {
-	: ${make_cmd:=cargo}
+	: ${make_cmd:=cargo auditable}
 
 	${make_cmd} build --release --target ${RUST_TARGET} ${configure_args}
 }
 
 do_check() {
-	: ${make_cmd:=cargo}
+	: ${make_cmd:=cargo auditable}
 
 	${make_check_pre} ${make_cmd} test --release --target ${RUST_TARGET} ${configure_args} \
 		${make_check_args}
 }
 
 do_install() {
-	: ${make_cmd:=cargo}
+	: ${make_cmd:=cargo auditable}
 	: ${make_install_args:=--path .}
 
 	${make_cmd} install --target ${RUST_TARGET} --root="${DESTDIR}/usr" \

--- a/common/environment/build-style/cargo.sh
+++ b/common/environment/build-style/cargo.sh
@@ -1,5 +1,9 @@
 hostmakedepends+=" cargo"
 
+if ! [[ "$pkgname" =~ ^cargo-auditable(-bootstrap)?$ ]]; then
+	hostmakedepends+=" cargo-auditable"
+fi
+
 if [ "$CROSS_BUILD" ]; then
 	makedepends+=" rust-std"
 fi

--- a/srcpkgs/cargo-auditable-bootstrap/template
+++ b/srcpkgs/cargo-auditable-bootstrap/template
@@ -1,0 +1,20 @@
+# Template file for 'cargo-auditable-bootstrap'
+# Keep synced with cargo-auditable
+pkgname=cargo-auditable-bootstrap
+version=0.5.2
+revision=1
+wrksrc=cargo-auditable-${version}
+build_wrksrc=cargo-auditable
+build_style=cargo
+# Required for bootstrapping purposes
+make_cmd=cargo
+short_desc="Bootstrap package for cargo-auditable"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="MIT,Apache-2.0"
+homepage="https://github.com/rust-secure-code/cargo-auditable"
+distfiles="https://github.com/rust-secure-code/cargo-auditable/archive/refs/tags/v${version}.tar.gz"
+checksum=fee70e8d2354e47eba1fed767430c12423c2a93c37307ae4c7d977c7693b88dd
+
+post_install() {
+	vlicense ../LICENSE-MIT
+}

--- a/srcpkgs/cargo-auditable/template
+++ b/srcpkgs/cargo-auditable/template
@@ -1,15 +1,18 @@
 # Template file for 'cargo-auditable'
+# Keep synced with cargo-auditable-bootstrap
 pkgname=cargo-auditable
 version=0.5.2
-revision=1
+revision=2
 build_wrksrc=cargo-auditable
 build_style=cargo
+hostmakedepends="cargo-auditable-bootstrap"
 short_desc="Tool for embedding dependency information in rust binaries"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT,Apache-2.0"
 homepage="https://github.com/rust-secure-code/cargo-auditable"
 distfiles="https://github.com/rust-secure-code/cargo-auditable/archive/refs/tags/v${version}.tar.gz"
 checksum=fee70e8d2354e47eba1fed767430c12423c2a93c37307ae4c7d977c7693b88dd
+conflicts=cargo-auditable-bootstrap
 
 post_install() {
 	vlicense ../LICENSE-MIT


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

In contrast to other distros like f.ex. Fedora, we don't ship each crate in the
dependency tree of a rust project as its own (source) package, which means that
xbps isn't aware of those dependencies. Recovering what versions of specific
libraries are used on a system is made very hard by this, which leaves people
clueless what to do in a situation when a library has a CVE for example.

This change embeds a table of dependencies that went into this binary into the
binary itself, which means recovering what binaries contain which libraries
becomes fairly trivial. Go does this by default, and the long-term goal is to
do the same with Rust, but we aren't there yet.

An example for how usage could look like:

```text
❯ syft packages --catalogers all --output syft-json /usr/bin | jq '.artifacts[] | select(.metadata.name=="tokio") | .locations[].path'
 ✔ Indexed /usr/bin        
 ✔ Cataloged packages      [1905 packages]

"sq"
```

This shows me that the only auditable rust binary depending on tokio on my
system right now is `sq`, and with different jq filters I can get out any info
I might need.
