### PR TITLE
eva: bump revision and update checksum

### DIFF
--- a/srcpkgs/eva/template
+++ b/srcpkgs/eva/template
@@ -1,14 +1,14 @@
 # Template file for 'eva'
 pkgname=eva
 version=0.3.0
-revision=1
+revision=2
 build_style=cargo
 short_desc="Simple calculator REPL, similar to bc(1)"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT"
 homepage="https://github.com/NerdyPepper/eva"
-distfiles="https://github.com/NerdyPepper/eva/archive/v${version}.tar.gz"
-checksum=05e2cdcfd91e6abef91cb01ad3074583b8289f6e74054e070bfbf6a4e684865e
+distfiles="https://github.com/NerdyPepper/eva/archive/refs/tags/v${version}.tar.gz"
+checksum=5ee80a64de05ff952e9fd69fff6050d8e5c602428ad8ad3b357db6b813e1372f
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

<del>Checksum changed since this was packaged. Does a revbump for stuff like this make sense? Probably not, right?</del>

Upstream re-released v0.3.0, so the builds fail with bad checksum right now.
    
#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
