### PR TITLE
WIP: New package: osquery-5.6.0

### DIFF
--- a/srcpkgs/osquery-bin/files/osqueryd/log/run
+++ b/srcpkgs/osquery-bin/files/osqueryd/log/run
@@ -1,0 +1,1 @@
+/usr/bin/vlogger

--- a/srcpkgs/osquery-bin/files/osqueryd/run
+++ b/srcpkgs/osquery-bin/files/osqueryd/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+FLAG_FILE=/etc/osquery/osquery.flags
+CONFIG_FILE=/etc/osquery/osquery.conf
+[ -r conf ] && . ./conf
+[ ! -f /etc/osquery/ ] && -p mkdir /etc/osquery/
+[ ! -f ${FLAG_FILE} ] && touch "${FLAG_FILE}"
+exec /usr/bin/osqueryd --flagfile ${FLAG_FILE} --config_path ${CONFIG_FILE} --tls_server_certs /etc/ssl/certs.pem $OPTS 2>&1

--- a/srcpkgs/osquery-bin/template
+++ b/srcpkgs/osquery-bin/template
@@ -1,0 +1,39 @@
+# Template file for 'osquery-bin'
+pkgname=osquery-bin
+version=5.5.1
+revision=1
+archs="x86_64"
+#wrksrc=
+create_wrksrc=yes
+#create_wrksrc=yes
+#build_style=fetch
+#configure_args=""
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends=""
+makedepends=""
+depends=""
+short_desc="osquery binary releases"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="Apache-2.0 OR GPL-2.0-only"
+homepage="https://osquery.io/"
+changelog="https://github.com/osquery/osquery/raw/master/CHANGELOG.md"
+distfiles="https://pkg.osquery.io/linux/osquery-${version}_${revision}.linux_${archs}.tar.gz"
+checksum=5e21502cfd0ce042ce4acb2c20ae64c20296a5deb10ff053e12a5e342e163b7e
+
+do_install() {
+	vbin opt/osquery/bin/osqueryd
+	vbin opt/osquery/bin/osqueryctl
+	ln -s /usr/bin/osqueryd ${PKGDESTDIR}/usr/bin/osqueryi
+
+	vsconf opt/osquery/share/osquery/osquery.example.conf osquery.conf
+
+	install -d -Dm0644 opt/osquery/share/osquery/lenses ${PKGDESTDIR}/usr/share/osquery
+	install -d -Dm0644 opt/osquery/share/osquery/packs ${PKGDESTDIR}/usr/share/osquery
+
+	vmkdir /etc/osquery 0644
+
+	vsv osqueryd
+}

--- a/srcpkgs/osquery-voidlinux/template
+++ b/srcpkgs/osquery-voidlinux/template
@@ -1,0 +1,17 @@
+# Template file for 'osquery-voidlinux'
+pkgname=osquery-voidlinux
+version=0.1.0
+revision=1
+build_style=cargo
+short_desc="Extension for osquery to provide Void Linux specific information"
+maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
+license="AGPL-3.0-or-later"
+homepage="https://git.jcg.re/jcgruenhage/osquery-voidlinux"
+changelog="https://git.jcg.re/jcgruenhage/osquery-voidlinux/raw/branch/main/CHANGELOG.md"
+distfiles="https://git.jcg.re/jcgruenhage/osquery-voidlinux/archive/v${version}.tar.gz"
+checksum=1608d0932711c25361267975130000e0d51a605a297cab8006af4b8a7854d922
+
+do_install() {
+	vbin target/${RUST_TARGET}/release/osquery-voidlinux osquery-voidlinux.ext
+	vlicense LICENSE.md
+}

--- a/srcpkgs/osquery/patches/0001-locate-libraries-with-pkg-config.patch
+++ b/srcpkgs/osquery/patches/0001-locate-libraries-with-pkg-config.patch
@@ -1,0 +1,132 @@
+From e9f104a8eb1f1e61240b11359c9bf5e0fff1019b Mon Sep 17 00:00:00 2001
+From: Piraty <piraty1@inbox.ru>
+Date: Wed, 19 Oct 2022 15:16:02 +0200
+Subject: [PATCH] locate libraries with pkg-config
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Co-authored-by: Jan Christian Grünhage <jan.christian@gruenhage.xyz>
+---
+ .../cmake/source/modules/Findaugeas.cmake     | 15 +---
+ .../cmake/source/modules/Findboost.cmake      | 84 +------------------
+ 2 files changed, 4 insertions(+), 95 deletions(-)
+
+diff --git a/libraries/cmake/source/modules/Findaugeas.cmake b/libraries/cmake/source/modules/Findaugeas.cmake
+index 77186b9df..c5d1cfa47 100644
+--- a/libraries/cmake/source/modules/Findaugeas.cmake
++++ b/libraries/cmake/source/modules/Findaugeas.cmake
+@@ -7,16 +7,5 @@
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
+ 
+-importSourceSubmodule(
+-  NAME "augeas/gnulib"
+-
+-  SHALLOW_SUBMODULES "src"
+-)
+-
+-importSourceSubmodule(
+-  NAME "augeas"
+-
+-  NO_RECURSIVE
+-
+-  SHALLOW_SUBMODULES "src"
+-)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(augeas REQUIRED "augeas")
+diff --git a/libraries/cmake/source/modules/Findboost.cmake b/libraries/cmake/source/modules/Findboost.cmake
+index b7fc8d94f..48152fd76 100644
+--- a/libraries/cmake/source/modules/Findboost.cmake
++++ b/libraries/cmake/source/modules/Findboost.cmake
+@@ -7,85 +7,5 @@
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
+ 
+-importSourceSubmodule(
+-  NAME "boost"
+-
+-  NO_RECURSIVE
+-
+-  SUBMODULES
+-    "src"
+-
+-  SHALLOW_SUBMODULES
+-    "src/libs/algorithm"
+-    "src/libs/align"
+-    "src/libs/any"
+-    "src/libs/array"
+-    "src/libs/asio"
+-    "src/libs/assert"
+-    "src/libs/atomic"
+-    "src/libs/beast"
+-    "src/libs/bind"
+-    "src/libs/chrono"
+-    "src/libs/concept_check"
+-    "src/libs/config"
+-    "src/libs/container"
+-    "src/libs/container_hash"
+-    "src/libs/context"
+-    "src/libs/conversion"
+-    "src/libs/core"
+-    "src/libs/coroutine2"
+-    "src/libs/date_time"
+-    "src/libs/detail"
+-    "src/libs/dynamic_bitset"
+-    "src/libs/endian"
+-    "src/libs/exception"
+-    "src/libs/filesystem"
+-    "src/libs/foreach"
+-    "src/libs/format"
+-    "src/libs/function"
+-    "src/libs/function_types"
+-    "src/libs/fusion"
+-    "src/libs/integer"
+-    "src/libs/intrusive"
+-    "src/libs/io"
+-    "src/libs/iterator"
+-    "src/libs/lexical_cast"
+-    "src/libs/locale"
+-    "src/libs/logic"
+-    "src/libs/move"
+-    "src/libs/mp11"
+-    "src/libs/mpl"
+-    "src/libs/multi_index"
+-    "src/libs/numeric/conversion"
+-    "src/libs/optional"
+-    "src/libs/phoenix"
+-    "src/libs/pool"
+-    "src/libs/predef"
+-    "src/libs/preprocessor"
+-    "src/libs/property_tree"
+-    "src/libs/proto"
+-    "src/libs/random"
+-    "src/libs/range"
+-    "src/libs/ratio"
+-    "src/libs/rational"
+-    "src/libs/regex"
+-    "src/libs/scope_exit"
+-    "src/libs/serialization"
+-    "src/libs/smart_ptr"
+-    "src/libs/spirit"
+-    "src/libs/static_assert"
+-    "src/libs/system"
+-    "src/libs/thread"
+-    "src/libs/throw_exception"
+-    "src/libs/tokenizer"
+-    "src/libs/tti"
+-    "src/libs/tuple"
+-    "src/libs/type_index"
+-    "src/libs/typeof"
+-    "src/libs/type_traits"
+-    "src/libs/unordered"
+-    "src/libs/utility"
+-    "src/libs/uuid"
+-    "src/libs/variant"
+-    "src/libs/winapi"
+-)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(boost REQUIRED "boost")
+-- 
+2.38.1
+

--- a/srcpkgs/osquery/template
+++ b/srcpkgs/osquery/template
@@ -1,0 +1,29 @@
+# Template file for 'osquery'
+pkgname=osquery
+version=5.6.0
+revision=1
+#archs="i686 x86_64"
+#wrksrc=
+#create_wrksrc=yes
+build_style=cmake
+configure_args="-DOSQUERY_VERSION=${version}"
+#make_build_args=""
+#make_install_args=""
+#conf_files=""
+#make_dirs="/var/log/dir 0755 root root"
+hostmakedepends="pkg-config python3 git"
+makedepends="augeas-devel boost-devel"
+depends=""
+short_desc="SQL powered operating system instrumentation, monitoring, and analytics"
+maintainer="Piraty <piraty1@inbox.ru>"
+license="GPL-3.0-or-later"  #FIXME
+homepage="https://osquery.io/"
+#changelog=""
+distfiles="https://github.com/osquery/osquery/archive/refs/tags/${version}.tar.gz"
+checksum=5694d54c8bab3d7c3706e177242a6dff5bb17a04b860de3a116103d99388ffa7
+
+# debug
+# configure_args+=" -LAH"
+
+# no tests for now
+configure_args+=" -DOSQUERY_BUILD_TESTS=OFF"


### PR DESCRIPTION
osquery is a major PITA to package "properly", but considering I need it for work, I've started with an `osquery-bin` package for now. Stuff like the service should be reusable for a proper `osquery` package later, so I thought pushing my current state might already be useful to someone, but this is definitely in no state to be merged at all.

Help on the `osquery` package for getting it to build with system libraries would be really appreciated, my C++/CMake foo is not strong enough for this I'm afraid.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
