### PR TITLE
go: update to 1.19.3.

### DIFF
--- a/srcpkgs/go/template
+++ b/srcpkgs/go/template
@@ -1,6 +1,6 @@
 # Template file for 'go'
 pkgname=go
-version=1.19.2
+version=1.19.3
 revision=1
 create_wrksrc=yes
 build_wrksrc=go
@@ -12,7 +12,7 @@ license="BSD-3-Clause"
 homepage="https://go.dev/"
 changelog="https://go.dev/doc/devel/release.html"
 distfiles="https://go.dev/dl/go${version}.src.tar.gz"
-checksum=2ce930d70a931de660fdaf271d70192793b1b240272645bf0275779f6704df6b
+checksum=18ac263e39210bcf68d85f4370e97fb1734166995a1f63fb38b4f6e07d90d212
 nostrip=yes
 noverifyrdeps=yes
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

Go 1.19.3 contains security fixes:
> go1.19.3 (released 2022-11-01) includes security fixes to the os/exec and syscall packages, as well as bug fixes to the compiler and the runtime. See the [Go 1.19.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.3+label%3ACherryPickApproved) on our issue tracker for details.

https://go.dev/doc/devel/release
