### PR TITLE
bc-gh: update to 6.1.0

### DIFF
--- a/srcpkgs/bc-gh/template
+++ b/srcpkgs/bc-gh/template
@@ -1,6 +1,6 @@
 # Template file for 'bc-gh'
 pkgname=bc-gh
-version=5.2.2
+version=6.1.0
 revision=1
 wrksrc="bc-${version}"
 short_desc="Implementation of POSIX bc with GNU extensions"
@@ -9,7 +9,7 @@ license="BSD-2-Clause"
 homepage="https://git.yzena.com/gavin/bc"
 changelog="https://git.yzena.com/gavin/bc/raw/branch/master/NEWS.md"
 distfiles="https://github.com/gavinhoward/bc/releases/download/${version}/bc-${version}.tar.xz"
-checksum=480249fc0e6a54cb2dc0059734ce433bff344d27b40b8591ae410068e1573352
+checksum=fa7fc70dd67f25ca6f03251ae95302b933a98a5bc302045196ce861e9d2338e3
 alternatives="
  bc:bc:/usr/bin/bc-gh
  bc:bc.1:/usr/share/man/man1/bc-gh.1
@@ -21,7 +21,7 @@ alternatives="
 do_configure() {
 	PREFIX=/usr DESTDIR="${DESTDIR}" EXECSUFFIX=-gh CC="${CC}" CFLAGS="${CFLAGS}" \
 	HOSTCC="${CC_FOR_BUILD}" HOSTCFLAGS="${CFLAGS_FOR_BUILD}" ./configure.sh -GM \
-	-sbc.banner -sdc.tty_mode
+	-pGNU
 }
 do_build() {
 	make ${makejobs}


### PR DESCRIPTION
This also changes the build to use a predefined build setup, which will build a bc that defaults to the behavior of the GNU bc and dc.

Signed-off-by: Gavin Howard <gavin@yzena.com>

#### Testing the changes
- I tested the changes in this PR: **NO**