### PR TITLE
fotoxx: update to 22.40.

### DIFF
--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -1,6 +1,6 @@
 # Template file for 'fotoxx'
 pkgname=fotoxx
-version=22.35
+version=22.40
 revision=1
 wrksrc=fotoxx
 build_style=gnu-makefile
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.kornelix.net/fotoxx/fotoxx.html"
 changelog="https://www.kornelix.net/downloads/recent_changes.txt"
 distfiles="https://www.kornelix.net/downloads/downloads/fotoxx-${version}.tar.gz"
-checksum=7c2760c7a499684973156b6a22e5787ae1dbb4925a1ddc8d1f463088a5c9b6ac
+checksum=d2f3add4727a9ff230b8604f32c84536f0a6232127605fbd2194dcb5702e36f7
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/champlain-0.12"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one crod2f3add4727a9ff230b8604f32c84536f0a6232127605fbd2194dcb5702e36f7ss build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
