### PR TITLE
xdg-desktop-portal-gnome: update to 43.1.

### DIFF
--- a/srcpkgs/xdg-desktop-portal-gnome/template
+++ b/srcpkgs/xdg-desktop-portal-gnome/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-gnome'
 pkgname=xdg-desktop-portal-gnome
-version=43.0
+version=43.1
 revision=1
 build_style=meson
 configure_args="-Dsystemduserunitdir=/usr/lib/systemd/user"
@@ -13,7 +13,7 @@ short_desc="GNOME portal backend for xdg-desktop-portal"
 maintainer="oreo639 <oreo6391@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome"
-#changelog="https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/raw/gnome-43/NEWS"
-changelog="https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/raw/main/NEWS"
-distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=0e1867a45bcaa5ddb240a4cfdb22dd055cf87f07210b9e3bb70949f3c7be16a6
+#changelog="https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/raw/main/NEWS"
+changelog="https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/raw/gnome-43/NEWS"
+distfiles="${GNOME_SITE}/xdg-desktop-portal-gnome/${version%.*}/xdg-desktop-portal-gnome-${version}.tar.xz"
+checksum=09adb66c6d9153e6f05df66daa2ad62a5de0e36665e9d2295173bb0ddc53b4cd


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
