### PR TITLE
lightdm-mini-greeter: update to 0.5.1.

### DIFF
--- a/srcpkgs/lightdm-mini-greeter/template
+++ b/srcpkgs/lightdm-mini-greeter/template
@@ -1,17 +1,19 @@
 # Template file for 'lightdm-mini-greeter'
 pkgname=lightdm-mini-greeter
-version=0.3.4
+version=0.5.1
 revision=1
 build_style=gnu-configure
+conf_files="/etc/lightdm/lightdm-mini-greeter.conf"
 hostmakedepends="pkg-config automake"
 makedepends="gtk+3-devel lightdm-devel libxklavier-devel"
 depends="lightdm hicolor-icon-theme"
-short_desc="A Minimal, Configurable, Single-User GTK3 LightDM Greeter"
+short_desc="Minimal, Configurable, Single-User GTK3 LightDM Greeter"
 maintainer="Alif Rachmawadi <arch@subosito.com>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/prikhi/lightdm-mini-greeter"
-distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=6276b5ce6c97b7685788a41969c01335007cfc0163d9d6fd16462cff70622831
+changelog="https://raw.githubusercontent.com/prikhi/lightdm-mini-greeter/master/CHANGELOG.md"
+distfiles="https://github.com/prikhi/lightdm-mini-greeter/archive/${version}.tar.gz"
+checksum=2c48b6686209d9e2940da4dcbb7d5fea2caf68f5a2a11270f536bbdb625ca677
 
 pre_configure() {
 	./autogen.sh


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->

When testing the build locally I noticed this overwrote the `/etc/lightdm/lightdm-mini-greeter.conf`. I don't know if this is an issue? If so how do I fix this behavior?
