### PR TITLE
got: update to 0.78

### DIFF
--- a/srcpkgs/got/template
+++ b/srcpkgs/got/template
@@ -1,6 +1,6 @@
 # Template file for 'got'
 pkgname=got
-version=0.77
+version=0.78
 revision=1
 wrksrc=got-portable-${version}
 build_style=gnu-configure
@@ -12,7 +12,7 @@ license="ISC"
 homepage="https://gameoftrees.org"
 changelog="https://gameoftrees.org/releases/CHANGES"
 distfiles="https://gameoftrees.org/releases/portable/got-portable-${version}.tar.gz"
-checksum="fcef6eec48ba7f4ac6afb2d159c1bd15441ded9faaa6adbfe87d358cd4750bba"
+checksum="7e2d181746023adcc0d36231e36054e9f8b550a805fd7ea61b74b47cffd9c311"
 
 post_install() {
 	sed -n '/Copyright/,/PERFORMANCE/p' got/got.c > LICENSE


### PR DESCRIPTION
- I tested the changes in this PR: **YES**
- I built this PR locally for my native architecture, (x86-64-musl)
