### PR TITLE
lingot: remove libglade-devel from makedepends

### DIFF
--- a/srcpkgs/lingot/template
+++ b/srcpkgs/lingot/template
@@ -1,10 +1,10 @@
 # Template file for 'lingot'
 pkgname=lingot
 version=1.1.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="intltool pkg-config glib-devel"
-makedepends="alsa-lib-devel gtk+3-devel jack-devel json-c-devel fftw-devel libglade-devel
+makedepends="alsa-lib-devel gtk+3-devel jack-devel json-c-devel fftw-devel
  pulseaudio-devel"
 short_desc="Musical instrument tuner"
 maintainer="David <kalichakra@zoho.com>"


### PR DESCRIPTION
The package does not use this library.

#### Testing the changes

- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl