### PR TITLE
dropbox: remove libglade from dependencies

### DIFF
--- a/srcpkgs/dropbox/template
+++ b/srcpkgs/dropbox/template
@@ -1,13 +1,13 @@
 # Template file for 'dropbox'
 pkgname=dropbox
 version=2020.03.04
-revision=1
+revision=2
 _fullname="nautilus-dropbox"
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="pkg-config python3-gobject python3-docutils gdk-pixbuf-devel"
-makedepends="nautilus-devel python3-devel python3-gobject-devel libglade-devel"
-depends="libxslt python3-gobject python3-gpg libglade gdk-pixbuf"
+makedepends="nautilus-devel python3-devel python3-gobject-devel"
+depends="libxslt python3-gobject python3-gpg gdk-pixbuf"
 short_desc="Dropbox file sharing"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
libglade is not used by this package.

#### Testing the changes
- I tested the changes in this PR: **briefly**