### PR TITLE
gtk-sharp: remove libglade from makedepends, fix xlint

### DIFF
--- a/srcpkgs/gtk-sharp/template
+++ b/srcpkgs/gtk-sharp/template
@@ -1,18 +1,18 @@
 # Template file for 'gtk-sharp'
 pkgname=gtk-sharp
 version=2.99.3
-revision=2
-lib32disabled=yes
+revision=3
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake libtool mono pkg-config"
-makedepends="mono-devel gtk+3-devel libglade-devel"
-maintainer="Enno Boland <gottox@voidlinux.org>"
-homepage="https://www.mono-project.com/GtkSharp"
-license="LGPL-2.1-or-later"
+makedepends="mono-devel gtk+3-devel"
 short_desc="Graphical User Interface Toolkit for mono and .Net (Gtk#)"
+maintainer="Enno Boland <gottox@voidlinux.org>"
+license="LGPL-2.1-or-later"
+homepage="https://www.mono-project.com/GtkSharp"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
 checksum=6440f571416267ae0cb5698071d087b31e3084693fa2c829b1db37ca7ea2c3a2
+lib32disabled=yes
 
 if [ "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	_have_mdoc="no"


### PR DESCRIPTION
libglade-devel is not used by this package.

#### Testing the changes
- I tested the changes in this PR: **briefly**

cc: @Gottox 