### PR TITLE
nestopia: update to 1.52.0.

### DIFF
--- a/srcpkgs/nestopia/template
+++ b/srcpkgs/nestopia/template
@@ -1,11 +1,11 @@
 # Template file for 'nestopia'
 pkgname=nestopia
-version=1.50
-revision=2
+version=1.52.0
+revision=1
 build_style=gnu-configure
-configure_args="--enable-gui --with-ao"
 hostmakedepends="autoconf-archive automake pkg-config"
-makedepends="SDL2-devel gtk+3-devel libao-devel libarchive-devel"
+makedepends="SDL2-devel gtk+3-devel libao-devel libarchive-devel
+ fltk-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Portable NES/Famicom emulator written in C++"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -13,7 +13,7 @@ license="GPL-2.0-only"
 homepage="http://0ldsk00l.ca/nestopia/"
 changelog="https://raw.githubusercontent.com/0ldsk00l/nestopia/master/ChangeLog"
 distfiles="https://github.com/0ldsk00l/nestopia/archive/${version}.tar.gz"
-checksum=f0274f8b033852007c67237897c69725b811c0df8a6d0120f39c23e990662aae
+checksum=eae1d2f536ae8585edb8d723caf905f4ae65349edee4ffbee45f9f52b5e3b06c
 
 pre_configure() {
 	autoreconf -vif


### PR DESCRIPTION
Also:
- remove non-existent configure args
- add fltk-devel in makedepends.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
