### PR TITLE
darktable: remove libglade from makedepends

### DIFF
--- a/srcpkgs/darktable/template
+++ b/srcpkgs/darktable/template
@@ -1,7 +1,7 @@
 # Template file for 'darktable'
 pkgname=darktable
 version=4.0.1
-revision=1
+revision=2
 # upstream only supports these archs:
 archs="x86_64* aarch64* ppc64le*"
 build_style=cmake
@@ -9,7 +9,7 @@ build_style=cmake
 configure_args="-DBINARY_PACKAGE_BUILD=ON -DBUILD_NOISE_TOOLS=ON
  -DRAWSPEED_ENABLE_LTO=ON"
 hostmakedepends="pkg-config intltool libxslt-devel desktop-file-utils"
-makedepends="gtk+3-devel glib-devel exiv2-devel libglade-devel libxslt-devel
+makedepends="gtk+3-devel glib-devel exiv2-devel libxslt-devel
  dbus-glib-devel libcurl-devel libgphoto2-devel libwebp-devel libsoup-devel
  lensfun-devel sqlite-devel librsvg-devel lua54-devel json-glib-devel
  libgomp-devel libopenjpeg2-devel libopenexr-devel libgraphicsmagick-devel


### PR DESCRIPTION
This library is not used by darktable.

#### Testing the changes

- I tested the changes in this PR: **briefly**

cc: @lemmi 
