### PR TITLE
jdupes: update to 1.21.0.

### DIFF
--- a/srcpkgs/jdupes/template
+++ b/srcpkgs/jdupes/template
@@ -1,6 +1,6 @@
 # Template file for 'jdupes'
 pkgname=jdupes
-version=1.20.2
+version=1.21.0
 revision=1
 build_style=gnu-makefile
 make_build_args="ENABLE_BTRFS=1"
@@ -10,17 +10,14 @@ license="MIT"
 homepage="https://github.com/jbruchon/jdupes"
 changelog="https://raw.githubusercontent.com/jbruchon/jdupes/master/CHANGES"
 distfiles="https://github.com/jbruchon/jdupes/archive/v${version}.tar.gz"
-checksum=d079d22dc77e1d181abcb8a59216520633a8712d197d007a9a9fb64c72610824
+checksum=13e56c608354f10f9314c99cf37b034dde14e6bf4a9303c77391323e2ef4f549
 
-pre_build() {
-	sed -i 's/^CFLAGS +=/override CFLAGS +=/g' Makefile
-	sed -i 's/^LDFLAGS =/override LDFLAGS +=/g' Makefile
-}
+CFLAGS="-DENABLE_DEDUPE"
 
 post_install() {
 	vlicense LICENSE
 }
 
 do_check() {
-	./jdupes -V|grep fsdedup
+	./jdupes -v | grep 'Compile-time extensions:.*fsdedup'
 }


### PR DESCRIPTION
CFLAGS="-DENABLE_DEDUPE" is enough to enable --dedupe. See a92952dbd0aaa34b72792c362f002e9f19a3d84c and #32048.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly** (I don't have a BTRFS filesystem to test it)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
