### PR TITLE
safeeyes: remove pip from build depends

### DIFF
--- a/srcpkgs/safeeyes/template
+++ b/srcpkgs/safeeyes/template
@@ -3,7 +3,7 @@ pkgname=safeeyes
 version=2.1.4
 revision=2
 build_style=python3-module
-hostmakedepends="python3-setuptools python3-pip python3-devel pkg-config"
+hostmakedepends="python3-setuptools python3-devel pkg-config"
 makedepends="python3-devel cairo-devel libgirepository-devel"
 depends="python3-psutil libayatana-appindicator python3-gobject python3-Babel
  python3-dbus xprop alsa-utils python3-xlib"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@leahneukirchen is there a reason for borg to have pip in hostmakedepends?
<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
