### PR TITLE
ogmrip: remove libglade-devel from makedepends

### DIFF
--- a/srcpkgs/ogmrip/template
+++ b/srcpkgs/ogmrip/template
@@ -1,12 +1,12 @@
 # Template file for 'ogmrip'
 pkgname=ogmrip
 version=1.0.1
-revision=9
+revision=10
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="intltool pkg-config"
 makedepends="dbus-glib-devel enca-devel enchant2-devel lame-devel
- libdvdread-devel libglade-devel libnotify-devel libtheora-devel mplayer
+ libdvdread-devel libnotify-devel libtheora-devel mplayer
  vorbis-tools x264-devel xvidcore-devel"
 depends="desktop-file-utils mplayer vorbis-tools ogmtools mkvtoolnix tesseract-ocr"
 short_desc="Application to rip and encode DVDs into AVI, OGM, MP4, or Matroska"


### PR DESCRIPTION
It would be used for building GTK2 GUI which is not enabled.

#### Testing the changes
- I tested the changes in this PR: **YES**