### PR TITLE
php: brokeness with the new extraction because they have a package.xml on top level

### DIFF
--- a/srcpkgs/php-ast/template
+++ b/srcpkgs/php-ast/template
@@ -16,6 +16,10 @@ distfiles="https://pecl.php.net/get/ast-${version}.tgz"
 checksum=ee3d4f67e24d82e4d340806a24052012e4954d223122949377665427443e6d13
 make_check_pre="env NO_INTERACTION=1"
 
+post_extract() {
+	mv ast-$version/* .
+}
+
 pre_configure() {
 	phpize
 }

--- a/srcpkgs/php-imagick/template
+++ b/srcpkgs/php-imagick/template
@@ -14,6 +14,10 @@ homepage="https://pecl.php.net/package/imagick"
 distfiles="https://pecl.php.net/get/imagick-$version.tgz"
 checksum=8dd5aa16465c218651fc8993e1faecd982e6a597870fd4b937e9ece02d567077
 
+post_extract() {
+	mv imagick-$version/* .
+}
+
 pre_configure() {
 	phpize
 }

--- a/srcpkgs/php8.0-apcu/template
+++ b/srcpkgs/php8.0-apcu/template
@@ -15,6 +15,10 @@ homepage="https://pecl.php.net/package/APCu"
 distfiles="https://pecl.php.net/get/apcu-${version}.tgz"
 checksum=1033530448696ee7cadec85050f6df5135fb1330072ef2a74569392acfecfbc1
 
+post_extract() {
+	mv apcu-$version/* .
+}
+
 pre_configure() {
 	phpize8.0
 }

--- a/srcpkgs/php8.0-ast/template
+++ b/srcpkgs/php8.0-ast/template
@@ -17,6 +17,10 @@ distfiles="https://pecl.php.net/get/ast-${version}.tgz"
 checksum=ee3d4f67e24d82e4d340806a24052012e4954d223122949377665427443e6d13
 make_check_pre="env NO_INTERACTION=1"
 
+post_extract() {
+	mv ast-$version/* .
+}
+
 pre_configure() {
 	phpize8.0
 }

--- a/srcpkgs/php8.0-imagick/template
+++ b/srcpkgs/php8.0-imagick/template
@@ -15,6 +15,10 @@ homepage="https://pecl.php.net/package/imagick"
 distfiles="https://pecl.php.net/get/imagick-$version.tgz"
 checksum=5a364354109029d224bcbb2e82e15b248be9b641227f45e63425c06531792d3e
 
+post_extract() {
+	mv imagick-$version/* .
+}
+
 pre_configure() {
 	phpize8.0
 }

--- a/srcpkgs/php8.1-apcu/template
+++ b/srcpkgs/php8.1-apcu/template
@@ -15,6 +15,10 @@ homepage="https://pecl.php.net/package/APCu"
 distfiles="https://pecl.php.net/get/apcu-${version}.tgz"
 checksum=1033530448696ee7cadec85050f6df5135fb1330072ef2a74569392acfecfbc1
 
+post_extract() {
+	mv apcu-$version/* .
+}
+
 pre_configure() {
 	phpize8.1
 }

--- a/srcpkgs/php8.1-ast/template
+++ b/srcpkgs/php8.1-ast/template
@@ -17,6 +17,10 @@ distfiles="https://pecl.php.net/get/ast-${version}.tgz"
 checksum=ee3d4f67e24d82e4d340806a24052012e4954d223122949377665427443e6d13
 make_check_pre="env NO_INTERACTION=1"
 
+post_extract() {
+	mv ast-$version/* .
+}
+
 pre_configure() {
 	phpize8.1
 }

--- a/srcpkgs/php8.1-imagick/template
+++ b/srcpkgs/php8.1-imagick/template
@@ -15,6 +15,10 @@ homepage="https://pecl.php.net/package/imagick"
 distfiles="https://pecl.php.net/get/imagick-$version.tgz"
 checksum=5a364354109029d224bcbb2e82e15b248be9b641227f45e63425c06531792d3e
 
+post_extract() {
+	mv imagick-$version/* .
+}
+
 pre_configure() {
 	phpize8.1
 }

--- a/srcpkgs/xdebug/template
+++ b/srcpkgs/xdebug/template
@@ -3,7 +3,7 @@ pkgname=xdebug
 version=2.9.3
 revision=1
 build_style=gnu-configure
-hostmakedepends="autoconf"
+hostmakedepends="autoconf php-devel"
 makedepends="php-devel"
 short_desc="PHP debugging extension"
 maintainer="Alexander Mamay <alexander@mamay.su>"
@@ -12,9 +12,9 @@ homepage="http://xdebug.org"
 distfiles="http://xdebug.org/files/${pkgname}-${version,,}.tgz"
 checksum=a63f567f2238d75a2244c2a4bd6f5abee817280b3567f9006c99481488dc977c
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" php-devel"
-fi
+post_extract() {
+	mv xdebug-$version/* .
+}
 
 pre_configure() {
 	phpize

--- a/srcpkgs/xdebug8.0/template
+++ b/srcpkgs/xdebug8.0/template
@@ -4,7 +4,7 @@ version=3.1.5
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.0"
-hostmakedepends="autoconf"
+hostmakedepends="autoconf php8.0-devel"
 makedepends="php8.0-devel"
 short_desc="PHP debugging extension"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
@@ -14,9 +14,9 @@ changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
 checksum=55f6ef381245da079b2fc5ce1cfbcb7961197d0c0e04f9d977613cf9aa969a79
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" php8.0-devel"
-fi
+post_extract() {
+	mv xdebug-$version/* .
+}
 
 pre_configure() {
 	phpize8.0

--- a/srcpkgs/xdebug8.1/template
+++ b/srcpkgs/xdebug8.1/template
@@ -4,7 +4,7 @@ version=3.1.5
 revision=1
 build_style=gnu-configure
 configure_args="--with-php-config=/usr/bin/php-config8.1"
-hostmakedepends="autoconf"
+hostmakedepends="autoconf php8.1-devel"
 makedepends="php8.1-devel"
 short_desc="PHP debugging extension"
 maintainer="Joel Beckmeyer <joel@beckmeyer.us>"
@@ -14,9 +14,9 @@ changelog="https://xdebug.org/updates"
 distfiles="http://xdebug.org/files/xdebug-${version}.tgz"
 checksum=55f6ef381245da079b2fc5ce1cfbcb7961197d0c0e04f9d977613cf9aa969a79
 
-if [ "$CROSS_BUILD" ]; then
-	hostmakedepends+=" php8.1-devel"
-fi
+post_extract() {
+	mv xdebug-$version/* .
+}
 
 pre_configure() {
 	phpize8.1


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
