### PR TITLE
python3 lsp server 1.6.0

### DIFF
--- a/srcpkgs/python3-docstring-to-markdown/template
+++ b/srcpkgs/python3-docstring-to-markdown/template
@@ -1,0 +1,12 @@
+# Template file for 'python3-docstring-to-markdown'
+pkgname=python3-docstring-to-markdown
+version=0.10
+revision=1
+build_style=python3-module
+hostmakedepends="python3-setuptools_scm"
+short_desc="Python implementation of the Language Server Protocol"
+maintainer="Cameron Nemo <cam@nohom.org>"
+license="LGPL-2.1-only"
+homepage="https://github.com/python-lsp/docstring-to-markdown"
+distfiles="${PYPI_SITE}/d/docstring-to-markdown/docstring-to-markdown-${version}.tar.gz"
+checksum=12f75b0c7b7572defea2d9e24b57ef7ac38c3e26e91c0e5547cfc02b1c168bf6

--- a/srcpkgs/python3-lsp-server/template
+++ b/srcpkgs/python3-lsp-server/template
@@ -1,11 +1,11 @@
 # Template file for 'python3-lsp-server'
 pkgname=python3-lsp-server
-version=1.5.0
-revision=2
+version=1.6.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-setuptools_scm python3-wheel"
 depends="python3-jedi python3-pluggy python3-lsp-jsonrpc python3-ultrajson
- python3-setuptools"
+ python3-setuptools python3-docstring-to-markdown"
 checkdepends="${depends} autopep8 python3-coverage python3-flaky python3-matplotlib
  python3-mccabe python3-mock python3-numpy python3-pandas python3-pycodestyle
  python3-PyQt5 python3-pyflakes python3-pylint python3-pytest python3-pytest-cov
@@ -15,8 +15,8 @@ maintainer="Cameron Nemo <cam@nohom.org>"
 license="MIT"
 homepage="https://github.com/python-lsp/python-lsp-server"
 changelog="https://raw.githubusercontent.com/python-lsp/python-lsp-server/develop/CHANGELOG.md"
-distfiles="${PYPI_SITE}/p/${pkgname/3}/${pkgname/3}-${version}.tar.gz"
-checksum=e5c094c19925022a27c4068f414b2bb653243f8fb0d768e39735289d7a89380d
+distfiles="${PYPI_SITE}/p/python-lsp-server/python-lsp-server-${version}.tar.gz"
+checksum=d75cdff9027c4212e5b9e861e9a0219219c8e2c69508d9f24949951dabd0dc1b
 
 do_check() {
 	python3 -m pytest \


### PR DESCRIPTION
- New package: python3-docstring-to-markdown-0.10 (new dependency)
- python3-lsp-server: update to 1.6.0

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
