### PR TITLE
common/scripts/lint-commits: check commit author github account

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
       PATH: '/usr/libexec/chroot-git:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
       XLINT: '1'
       LICENSE_LIST: common/travis/license.lst
+      GH_PR_NUM: ${{ github.event.number }}
 
     steps:
       - uses: actions/checkout@v1

--- a/common/scripts/lint-commits
+++ b/common/scripts/lint-commits
@@ -37,7 +37,7 @@ do
 	(NF > 2) && (length > 80) { print "::error title=Commit Lint::" C ": long line: " $0; exit 1 }
 	!subject {
 		if (length > 50) { print "::warning title=Commit Lint::" C ": subject is a bit long" }
-		if (!($0 ~ ":" || $0 ~ "^Take over maintainership " || $0 ~ "^Orphan ")) { print "::error title=Commit Lint::" C ": subject does not follow CONTRIBUTING.md guildelines"; exit 1 }
+		if (!($0 ~ ":" || $0 ~ "^Take over maintainership " || $0 ~ "^Orphan ")) { print "::error title=Commit Lint::" C ": subject does not follow CONTRIBUTING.md guidelines"; exit 1 }
 		# Below check is too noisy?
 		# if (!($0 ~ "^New package:" || $0 ~ ".*: update to")) {
 		# 	print "::warning title=Commit Lint::" C ": not new package/update/removal?"
@@ -48,4 +48,14 @@ do
 	!body { print "::error title=Commit Lint::" C ": second line must be blank"; exit 1 }
 	' || status=1
 done
+
+if [ "$GITHUB_ACTIONS" = "true" ] && [ "$GH_PR_NUM" ]; then
+	gh api repos/void-linux/void-packages/pulls/$GH_PR_NUM/commits -t "{{range .}}{{slice .sha 0 8}}:{{.committer.login}}:{{.author.login}}{{end}}" |
+		awk -F: '
+		BEGIN { E=0 }
+		($1 ~ /^$/) { print "::error title=Commit Lint::" $0 ": no GitHub account associated with committer"; E=1 }
+		($2 ~ /^$/) { print "::error title=Commit Lint::" $0 ": no GitHub account associated with commit author"; E=1 }
+		END { exit $E }' || status=1
+fi
+
 exit $status


### PR DESCRIPTION
Recently, CONTRIBUTING.md added a line about ensuring the email used to commit is associated with a github account. This should be able to lint all commits in a PR to ensure that condition.

While it is using API calls, it should only cost 1 call per CI run.

Will test this soon and refine the implementation.

#### Testing the changes
- I tested the changes in this PR: **NO**

