### PR TITLE
GNS3 2.2.35 - new version supports Python 3.11

### DIFF
--- a/srcpkgs/gns3-gui/template
+++ b/srcpkgs/gns3-gui/template
@@ -1,7 +1,7 @@
 # Template file for 'gns3-gui'
 pkgname=gns3-gui
-version=2.2.34
-revision=2
+version=2.2.35
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-psutil python3-jsonschema
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 changelog="https://raw.githubusercontent.com/GNS3/gns3-gui/master/CHANGELOG"
 distfiles="https://github.com/GNS3/${pkgname}/archive/v${version}.tar.gz"
-checksum=bf66313a4808fdb1cd9b06c72d34fd9fc4bcf5abe990dfd8de70d8128a2c26dc
+checksum=5dee30a6be10a4463d16c3cec516bf81717fc6f37f4f53386347d98de9a1f43b
 
 
 post_patch() {

--- a/srcpkgs/gns3-server/patches/importlib.patch
+++ b/srcpkgs/gns3-server/patches/importlib.patch
@@ -1,0 +1,65 @@
+diff --git a/gns3server/controller/__init__.py b/gns3server/controller/__init__.py
+index 5c5236b9..971e3452 100644
+--- a/gns3server/controller/__init__.py
++++ b/gns3server/controller/__init__.py
+@@ -22,7 +22,11 @@ import uuid
+ import socket
+ import shutil
+ import aiohttp
+-import importlib_resources
++
++try:
++    from importlib import resources as importlib_resources
++except ImportError:
++    import importlib_resources
+ 
+ from ..config import Config
+ from .project import Project
+diff --git a/gns3server/controller/appliance_manager.py b/gns3server/controller/appliance_manager.py
+index d15fc69b..41b73104 100644
+--- a/gns3server/controller/appliance_manager.py
++++ b/gns3server/controller/appliance_manager.py
+@@ -21,9 +21,13 @@ import json
+ import uuid
+ import asyncio
+ import aiohttp
+-import importlib_resources
+ import shutil
+ 
++try:
++    from importlib import resources as importlib_resources
++except ImportError:
++    import importlib_resources
++
+ from .appliance import Appliance
+ from ..config import Config
+ from ..utils.asyncio import locking
+diff --git a/gns3server/utils/get_resource.py b/gns3server/utils/get_resource.py
+index b4b599bd..f4054cd3 100644
+--- a/gns3server/utils/get_resource.py
++++ b/gns3server/utils/get_resource.py
+@@ -19,7 +19,11 @@ import atexit
+ import logging
+ import os
+ import sys
+-import importlib_resources
++
++try:
++    from importlib import resources as importlib_resources
++except ImportError:
++    import importlib_resources
+ 
+ from contextlib import ExitStack
+ resource_manager = ExitStack()
+diff --git a/requirements.txt b/requirements.txt
+index 53f1200d..5eda661b 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -11,6 +11,6 @@ psutil==5.9.2
+ async-timeout>=4.0.2,<4.1
+ distro>=1.7.0
+ py-cpuinfo>=9.0.0,<10.0
+-importlib-resources>=1.3
++importlib-resources>=1.3; python_version < '3.9'
+ setuptools>=60.8.1; python_version >= '3.7'
+ setuptools==59.6.0; python_version < '3.7'  # v59.6.0 is the last version to support Python 3.6

--- a/srcpkgs/gns3-server/template
+++ b/srcpkgs/gns3-server/template
@@ -1,7 +1,7 @@
 # Template file for 'gns3-server'
 pkgname=gns3-server
-version=2.2.34
-revision=2
+version=2.2.35
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-setuptools python3-jsonschema python3-aiohttp python3-aiohttp-cors
@@ -14,7 +14,7 @@ license="GPL-3.0-or-later"
 homepage="https://gns3.com"
 changelog="https://raw.githubusercontent.com/GNS3/gns3-server/master/CHANGELOG"
 distfiles="https://github.com/GNS3/gns3-server/archive/v${version}.tar.gz"
-checksum=8bd61a0777df7cf195b2670ab81139f3029d9b33cf329cfa612d2b2ea3def947
+checksum=2c20ddc968a24fd8a77c272071d35304bac0706266a3f9e643658555e634c489
 
 # The source archive contains statically linked artifacts for x86_64
 # glibc, since this is the only architecture supported by upstream, we


### PR DESCRIPTION
Python 3.11 support was added to GNS3 2.2.35.
A new required library was added to 2.2.35 so a new Void package was created.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)

For reference, `gns3` 2.2.34 fails 