### PR TITLE
discord-ptb: update to 0.0.35.

### DIFF
--- a/srcpkgs/discord-ptb/template
+++ b/srcpkgs/discord-ptb/template
@@ -1,6 +1,6 @@
 # Template file for 'discord-ptb'
 pkgname=discord-ptb
-version=0.0.34
+version=0.0.35
 revision=1
 archs="x86_64"
 hostmakedepends="w3m"
@@ -11,15 +11,15 @@ maintainer="0x5c <dev@0x5c.io>"
 license="custom:Proprietary"
 homepage="https://discord.com/"
 distfiles="https://dl-ptb.discordapp.net/apps/linux/${version}/discord-ptb-${version}.tar.gz"
-checksum=083e9d2e806796f869c0415f2c8f4eaa386f8993e3df1343c8f2bda81254a9c9
-_license_checksum=b64b3fdcd86d70df0e4dffa8d4aa4a7aa3e87204059902f1680100f5ee2f2ef4
+checksum=6e7a79c1f711db5b3b2cc3f11608f91b752cc4f5a5163e2de826dea2c8ae7c76
+_license_checksum=45e63af835972e94b311bc44d515ca11a919d6a8f127ec801267b0a8fba10847
 nopie=yes
 restricted=yes
 repository=nonfree
 
 post_extract() {
-	$XBPS_FETCH_CMD -o eula https://discord.com/terms; cat eula |
-		w3m -dump -I utf-8 -T text/html |
+	$XBPS_FETCH_CMD -o eula https://discord.com/terms
+	w3m -dump -I utf-8 -T text/html eula |
 		sed -n '/Discord.s Terms of Service/,/^Imagine a place$/p' > EULA
 
 	filesum="$(xbps-digest EULA)"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
---
The EULA hash has been giving me trouble for weeks. Perhaps this is only an issue on my machine? The CI will confirm. Also, there is no need to `cat` into `w3m`, it can read files directly.