### PR TITLE
root: add upstream patch to fix pyroot for python 3.11

### DIFF
--- a/srcpkgs/root/patches/python3.11_2.patch
+++ b/srcpkgs/root/patches/python3.11_2.patch
@@ -1,0 +1,81 @@
+Patch is from: https://github.com/root-project/root/pull/11457
+
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+index 73fb8099b5..f2eea396af 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CPPInstance.cxx
+@@ -764,7 +764,6 @@ PyTypeObject CPPInstance_Type = {
+     0,                             // tp_as_buffer
+     Py_TPFLAGS_DEFAULT |
+         Py_TPFLAGS_BASETYPE |
+-        Py_TPFLAGS_HAVE_GC |
+         Py_TPFLAGS_CHECKTYPES,     // tp_flags
+     (char*)"cppyy object proxy (internal)", // tp_doc
+     0,                             // tp_traverse
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+index 97ce06daa7..ed41b1637c 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+@@ -78,8 +78,7 @@ PyTypeObject TypedefPointerToClass_Type = {
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     (ternaryfunc)tpc_call,        // tp_call
+     0, 0, 0, 0,
+-    Py_TPFLAGS_DEFAULT |
+-        Py_TPFLAGS_HAVE_GC,       // tp_flags
++    Py_TPFLAGS_DEFAULT,           // tp_flags
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+ #if PY_VERSION_HEX >= 0x02030000
+     , 0                           // tp_del
+diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+index f9e92f9c8c..510d65f88a 100644
+--- a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
++++ b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+@@ -45,7 +45,7 @@ struct InitCPyCppyy_NoneType_t {
+         ((PyVarObject&)CPyCppyy_NoneType).ob_size = 0;
+ 
+         CPyCppyy_NoneType.tp_name        = const_cast<char*>("CPyCppyy_NoneType");
+-        CPyCppyy_NoneType.tp_flags       = Py_TPFLAGS_HAVE_RICHCOMPARE | Py_TPFLAGS_HAVE_GC;
++        CPyCppyy_NoneType.tp_flags       = Py_TPFLAGS_HAVE_RICHCOMPARE;
+ 
+         CPyCppyy_NoneType.tp_traverse    = (traverseproc)0;
+         CPyCppyy_NoneType.tp_clear       = (inquiry)0;
+@@ -135,6 +135,7 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
+             CPyCppyy_NoneType.tp_traverse   = Py_TYPE(pyobj)->tp_traverse;
+             CPyCppyy_NoneType.tp_clear      = Py_TYPE(pyobj)->tp_clear;
+             CPyCppyy_NoneType.tp_free       = Py_TYPE(pyobj)->tp_free;
++            CPyCppyy_NoneType.tp_flags      = Py_TYPE(pyobj)->tp_flags;
+         } else if (CPyCppyy_NoneType.tp_traverse != Py_TYPE(pyobj)->tp_traverse) {
+         // TODO: SystemError?
+             std::cerr << "in CPyCppyy::MemoryRegulater, unexpected object of type: "
+diff --git a/bindings/pyroot/cppyy/patches/gc_flags.patch b/bindings/pyroot/cppyy/patches/gc_flags.patch
+new file mode 100644
+index 0000000000..68f0718629
+--- /dev/null
++++ b/bindings/pyroot/cppyy/patches/gc_flags.patch
+@@ -0,0 +1,26 @@
++diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
++index 97ce06daa7..ed41b1637c 100644
++--- a/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
+++++ b/bindings/pyroot/cppyy/CPyCppyy/src/CustomPyTypes.cxx
++@@ -78,8 +78,7 @@ PyTypeObject TypedefPointerToClass_Type = {
++     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
++     (ternaryfunc)tpc_call,        // tp_call
++     0, 0, 0, 0,
++-    Py_TPFLAGS_DEFAULT |
++-        Py_TPFLAGS_HAVE_GC,       // tp_flags
+++    Py_TPFLAGS_DEFAULT,           // tp_flags
++     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
++ #if PY_VERSION_HEX >= 0x02030000
++     , 0                           // tp_del
++diff --git a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
++index f9e92f9c8c..510d65f88a 100644
++--- a/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
+++++ b/bindings/pyroot/cppyy/CPyCppyy/src/MemoryRegulator.cxx
++@@ -135,6 +135,7 @@ bool CPyCppyy::MemoryRegulator::RecursiveRemove(
++             CPyCppyy_NoneType.tp_traverse   = Py_TYPE(pyobj)->tp_traverse;
++             CPyCppyy_NoneType.tp_clear      = Py_TYPE(pyobj)->tp_clear;
++             CPyCppyy_NoneType.tp_free       = Py_TYPE(pyobj)->tp_free;
+++            CPyCppyy_NoneType.tp_flags      = Py_TYPE(pyobj)->tp_flags;
++         } else if (CPyCppyy_NoneType.tp_traverse != Py_TYPE(pyobj)->tp_traverse) {
++         // TODO: SystemError?
++             std::cerr << "in CPyCppyy::MemoryRegulater, unexpected object of type: "

--- a/srcpkgs/root/template
+++ b/srcpkgs/root/template
@@ -1,7 +1,7 @@
 # Template file for 'root'
 pkgname=root
 version=6.26.06
-revision=1
+revision=2
 # Only i686 and x86_64 seem to be officially supported
 archs="i686* x86_64*"
 build_style=cmake


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

Added patch taken from upstream to fix a breaking issue in pyroot from python 3.11. See root-project/root#11457
