### PR TITLE
arandr: replace inspect.getargspec() with inspect.getfullargspec()

### DIFF
--- a/srcpkgs/arandr/patches/getfullargspec.patch
+++ b/srcpkgs/arandr/patches/getfullargspec.patch
@@ -1,0 +1,13 @@
+diff --git a/screenlayout/gui.py b/screenlayout/gui.py
+index 275dbdf..bc598cf 100644
+--- a/screenlayout/gui.py
++++ b/screenlayout/gui.py
+@@ -48,7 +48,7 @@ def actioncallback(function):
+ 
+     A first argument called 'self' is passed through.
+     """
+-    argnames = inspect.getargspec(function)[0]
++    argnames = inspect.getfullargspec(function)[0]
+     if argnames[0] == 'self':
+         has_self = True
+         argnames.pop(0)

--- a/srcpkgs/arandr/template
+++ b/srcpkgs/arandr/template
@@ -1,10 +1,11 @@
 # Template file for 'arandr'
 pkgname=arandr
 version=0.1.10
-revision=7
+revision=8
 build_style=python3-module
 hostmakedepends="gettext python3-setuptools python3-docutils"
 depends="python3-gobject gtk+3 xrandr"
+checkdepends="${depends}"
 short_desc="Graphical frontend for XRandR"
 maintainer="mid-kid <esteve.varela@gmail.com>"
 license="GPL-3.0-or-later"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)

This change should fix this error:
```
Traceback (most recent call last):
  File "/usr/bin/arandr", line 41, in <module>
    from screenlayout.gui import main
  File "/usr/lib/python3.11/site-packages/screenlayout/gui.py", line 76, in <module>
    class Application:
  File "/usr/lib/python3.11/site-packages/screenlayout/gui.py", line 185, in Application
    @actioncallback
     ^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/screenlayout/gui.py", line 48, in actioncallback
    argnames = inspect.getargspec(function)[0]
               ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```