### PR TITLE
python3-cssutils: update to 2.6.0.

### DIFF
--- a/srcpkgs/python3-cssutils/template
+++ b/srcpkgs/python3-cssutils/template
@@ -1,16 +1,17 @@
 # Template file for 'python3-cssutils'
 pkgname=python3-cssutils
-version=1.0.2
-revision=7
-build_style=python3-module
-hostmakedepends="python3-setuptools"
-depends="python3-setuptools"
+version=2.6.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools python3-setuptools_scm python3-wheel"
+depends="python3"
 short_desc="CSS Cascading Style Sheets library for Python3"
 maintainer="Farhad Shahbazi <grauwolf@geekosphere.org>"
 # source files write 3.0-or-later, PKG-INFO writes 2.1
 license="LGPL-3.0-or-later"
 homepage="https://pypi.org/project/cssutils/"
+changelog="https://raw.githubusercontent.com/jaraco/cssutils/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/c/cssutils/cssutils-${version}.tar.gz"
-checksum=a2fcf06467553038e98fea9cfe36af2bf14063eb147a70958cfcaa8f5786acaf
+checksum=f7dcd23c1cec909fdf3630de346e1413b7b2555936dec14ba2ebb9913bf0818e
 
 conflicts="python-cssutils>=0"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**
- I built this PR locally for my native architecture, amd64

This package was strange, when I was updating to python3.11, byte-compile thrown errors about syntax, code looked like python2