### PR TITLE
gen-runtime-deps: verify rdeps for shlib_requires too

### DIFF
--- a/common/hooks/pre-pkg/04-generate-runtime-deps.sh
+++ b/common/hooks/pre-pkg/04-generate-runtime-deps.sh
@@ -46,7 +46,7 @@ store_pkgdestdir_rundeps() {
 }
 
 hook() {
-    local depsftmp f lf j mapshlibs sorequires _curdep elfmagic broken_shlibs
+    local depsftmp f lf j mapshlibs sorequires _curdep elfmagic broken_shlibs verify_deps
 
     # Disable trap on ERR, xbps-uhelper cmd might return error... but not something
     # to be worried about because if there are broken shlibs this hook returns
@@ -62,6 +62,10 @@ hook() {
 
     depsftmp=$(mktemp) || exit 1
     find ${PKGDESTDIR} -type f -perm -u+w > $depsftmp 2>/dev/null
+
+    for f in ${shlib_requires}; do
+        verify_deps+=" ${f}"
+    done
 
     exec 3<&0 # save stdin
     exec < $depsftmp
@@ -161,9 +165,6 @@ hook() {
 
     store_pkgdestdir_rundeps
 
-    for f in ${shlib_requires}; do
-        sorequires+="${f} "
-    done
     if [ -n "${sorequires}" ]; then
         echo "${sorequires}" | xargs -n1 | sort | xargs > ${PKGDESTDIR}/shlib-requires
     fi


### PR DESCRIPTION
While we're at it, mark one more variables as local

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
