### PR TITLE
openssh: fix broken gssapi on musl

### DIFF
--- a/srcpkgs/openssh/patches/ssh-musl-gssapi.patch
+++ b/srcpkgs/openssh/patches/ssh-musl-gssapi.patch
@@ -1,0 +1,10 @@
+--- a/gss-serv.c	2022-10-03 16:51:42.000000000 +0200
++++ b/gss-serv.c	2022-11-09 13:28:59.124968270 +0100
+@@ -33,6 +33,7 @@
+ #include <stdarg.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <sys/param.h>
+ 
+ #include "openbsd-compat/sys-queue.h"
+ #include "xmalloc.h"

--- a/srcpkgs/openssh/template
+++ b/srcpkgs/openssh/template
@@ -1,7 +1,7 @@
 # Template file for 'openssh'
 pkgname=openssh
 version=9.1p1
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--datadir=/usr/share/openssh
  --sysconfdir=/etc/ssh --without-selinux --with-privsep-user=nobody


### PR DESCRIPTION
I noticed that openssh does not build with gssapi option on musl (or crosscompiled from glibc). Seems it's complaining about missing definition `MAXHOSTNAMELEN` in `gss-serv.c`. in the headers included in `mit-krb5-devel` it's defined in `/usr/include/gssrpc/types.h` (also included in `musl-devel` in `/usr/include/sys/param.h` but using that the build fails crosscompiling from glibc complaining of unresolvable shlibs and `mit-krb5-devel` is already a makedepend with gssapi option).

Patching `#include <gssrpc/types.h>` into `gss-serv.c` seems to fix the problem both for native musl compile and crosscompiling from glibc. I also confirmed that compiling natively on glibc still works.

Don't know if there's an issue in the configure script that causes this, seems to be checking for `rpc/types.h`:
```
checking for rpc/types.h... no
```
which is similar to `gssrpc/types.h`. The configure script also contains mentions of `sys/param.h` but adding `musl-devel` to the makedepends without v1 patch does not fix it.

#### Testing the changes
- I tested the changes in this PR: **YES**

sshd main server instance seemed to crash after update on x86_64-musl and had to be restarted with `sv x sshd` (`sv t sshd` didn't seem to do anything). Don't know how much impact that would have as gssapi option is not enabled by default.
GSSAPI authentication seems to work from what I've tested with the patch.

The server crash on x86_64-musl could be unrelated but this should probably be tested by someone else anyway before merging to see if there's any other side-effects I've missed.

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl, x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl
  - aarch64
  - armv6l-musl (tested on a rpi1, sshd seemed to restart properly with `sv t sshd`)
  - armv6l

Attaching logs from builds for reference (v1 is using /usr/include/sys/param.h from musl-devel):

[glibc-cross-x86_64-musl-no-patch.log](https://github.com/void-linux/void-packages/files/9971765/glibc-cross-x86_64-musl-no-patch.log)
[glibc-cross-x86_64-musl-v1-patch.log](https://github.com/void-linux/void-packages/files/9971766/glibc-cross-x86_64-musl-v1-patch.log)
[glibc-cross-x86_64-musl-v2-patch.log](https://github.com/void-linux/void-packages/files/9971767/glibc-cross-x86_64-musl-v2-patch.log)
[glibc-no-patch.log](https://github.com/void-linux/void-packages/files/9971768/glibc-no-patch.log)
[glibc-v1-patch.log](https://github.com/void-linux/void-packages/files/9971769/glibc-v1-patch.log)
[glibc-v2-patch.log](https://github.com/void-linux/void-packages/files/9971770/glibc-v2-patch.log)
[musl-no-patch.log](https://github.com/void-linux/void-packages/files/9971771/musl-no-patch.log)
[musl-v1-patch.log](https://github.com/void-linux/void-packages/files/9971772/musl-v1-patch.log)
[musl-v2-patch.log](https://github.com/void-linux/void-packages/files/9971773/musl-v2-patch.log)