### PR TITLE
minikube: update to 1.28.0.

### DIFF
--- a/srcpkgs/minikube/template
+++ b/srcpkgs/minikube/template
@@ -1,6 +1,6 @@
 # Template file for 'minikube'
 pkgname=minikube
-version=1.27.0
+version=1.28.0
 revision=1
 archs="x86_64* i686* aarch64*"
 build_style=go
@@ -16,7 +16,7 @@ license="Apache-2.0"
 homepage="https://github.com/kubernetes/minikube"
 changelog="https://raw.githubusercontent.com/kubernetes/minikube/master/CHANGELOG.md"
 distfiles="https://github.com/kubernetes/minikube/archive/v$version.tar.gz"
-checksum=8978a27cff9bf1450c0cd56e28306e8272150f599a017ba31c2bad57fd9248d2
+checksum=0e64c007b7423999da506aa4fb4002b1ef5847cefafd29d800cc56dbd2b38cc4
 
 pre_build() {
 	local storage_provisioner_tag= iso_version=


### PR DESCRIPTION
I tested the changes in this PR: **briefly**

```
ag@server ~ ❯ minikube start
* minikube 1.28.0 on Void
  - MINIKUBE_IN_STYLE=false
  - MINIKUBE_HOME=/zpool/vm/minikube
* Automatically selected the kvm2 driver
* Starting control plane node minikube in cluster minikube
* Downloading Kubernetes v1.25.3 preload ...
    > preloaded-images-k8s-v18-v1...:  385.44 MiB / 385.44 MiB  100.00% 55.16 M
* Creating kvm2 VM (CPUs=2, Memory=6000MB, Disk=20000MB) ...
* Preparing Kubernetes v1.25.3 on Docker 20.10.20 ...
  - Generating certificates and keys ...
  - Booting up control plane ...
  - Configuring RBAC rules ...
* Verifying Kubernetes components...
  - Using image gcr.io/k8s-minikube/storage-provisioner:v5
* Enabled addons: storage-provisioner, default-storageclass
* Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
ag@server ~ ❯ virsh list
 Id   Name       State
--------------------------
 1    minikube   running
ag@server ~ at ⎈ minikube ❯ k get no
NAME       STATUS   ROLES           AGE   VERSION
minikube   Ready    control-plane   69s   v1.25.3
```
