### PR TITLE
linux-tools: correct the functional detection

### DIFF
--- a/srcpkgs/linux-tools/template
+++ b/srcpkgs/linux-tools/template
@@ -48,7 +48,6 @@ post_extract() {
 pre_configure() {
 	echo "#define PERF_VERSION \"${version}_${revision}\"" \
 		>tools/perf/PERF-VERSION-FILE
-	vsed -i 's/usbip_bind_driver.8//' tools/usb/usbip/Makefile.am
 }
 
 do_build() {
@@ -65,9 +64,9 @@ do_build() {
 	esac
 
 	make -C tools/build V=1 \
-		CC=$CC_FOR_BUILD LD=$LD_FOR_BUILD \
-		CFLAGS="$CFLAGS_FOR_BUILD" EXTRA_CFLAGS="$CFLAGS_FOR_BUILD" \
-		LDFLAGS="$LDFLAGS_FOR_BUILD" \
+		CC=$CC LD=$LD \
+		CFLAGS="$CFLAGS" EXTRA_CFLAGS="$CFLAGS" \
+		LDFLAGS="$LDFLAGS" \
 		WERROR=0 NO_GTK2=1 NO_SDT=1 PYTHON=python3
 
 	make -C tools/perf ${makejobs} V=1 ARCH=$arch \


### PR DESCRIPTION
They're build as part of tools/build.
fixdep will be built by HOSTCC anyway.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
