### PR TITLE
cherrytree: update to 0.99.51

### DIFF
--- a/srcpkgs/cherrytree/template
+++ b/srcpkgs/cherrytree/template
@@ -1,19 +1,20 @@
 # Template file for 'cherrytree'
 pkgname=cherrytree
-version=0.99.39
-revision=3
+version=0.99.51
+revision=1
 build_style=cmake
-hostmakedepends="gettext pkg-config desktop-file-utils python3 glib-devel"
-makedepends="cpputest uchardet-devel libcurl-devel sqlite-devel
- libxml++-devel gtksourceviewmm-devel gspell-devel gtkmm-devel
- fmt-devel spdlog"
+# Tests are built during the normal build process and require access to X server
+configure_args="-DBUILD_TESTING=OFF"
+hostmakedepends="gettext glib-devel pkg-config python3"
+makedepends="fmt-devel fribidi-devel gtkmm-devel gtksourceviewmm-devel
+ gspell-devel libcurl-devel libxml++-devel spdlog sqlite-devel uchardet-devel
+ vte3-devel"
 depends="desktop-file-utils"
 short_desc="Hierarchial note taking application with syntax highlighting"
 maintainer="Logen K <logen@sudotask.com>"
 license="GPL-3.0-or-later"
 homepage="https://www.giuspen.com/cherrytree/"
-distfiles="https://github.com/giuspen/cherrytree/releases/download/${version}/cherrytree_${version}.tar.xz"
-checksum=7af0adc2e2edf3f8797ba6b1bcb534f2309ba8297c4b235835ea969bae457d62
-configure_args+=" -DBUILD_GMOCK:BOOL='OFF'
- -DBUILD_GTEST:BOOL='OFF'
- -DBUILD_TESTING:BOOL='OFF'"
+changelog="https://raw.githubusercontent.com/giuspen/cherrytree/master/changelog.txt"
+distfiles="https://github.com/giuspen/cherrytree/archive/refs/tags/${version}.tar.gz"
+checksum=5c88bd8d709226006819cc7bba8445bab7bc5d2795364110d9ce59ecb69c7bcb
+make_check=no  # Tests are run during build step


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

---

To explain the changes, cherrytree now has tests that run as part of the build process right after building the program. These tests require access to an X server, and I don't think it would be good to run the entire build under `xvfb-run` or something like that. Cherrytree also uses a bundled version of gtest and will attempt to build it regardless of whether tests are enabled unless a configure arg is set and gtest is available in the environment.