### PR TITLE
deluge: update to 2.1.1 (and fix boost for Python 3.11)

### DIFF
--- a/srcpkgs/deluge/template
+++ b/srcpkgs/deluge/template
@@ -1,22 +1,21 @@
 # Template file for 'deluge'
 pkgname=deluge
-version=2.0.5
-revision=3
+version=2.1.1
+revision=1
 build_style=python3-module
 # TODO package python3-slimit to minify javascript
 hostmakedepends="intltool python3-setuptools python3-wheel"
 depends="python3-setuptools python3-chardet python3-Twisted python3-Mako
  python3-xdg python3-rencode python3-setproctitle libtorrent-rasterbar-python3
  python3-Pillow python3-pyasn1 python3-openssl python3-six python3-zope.interface"
-checkdepends="python3-pytest $depends python3-pytest-mock python3-mock gtk+3
- python3-gobject xvfb-run cantarell-fonts"
 short_desc="Fully-featured cross-platform BitTorrent client"
 maintainer="Alexey Rochev <equeim@gmail.com>"
 license="GPL-3.0-or-later"
 homepage="https://deluge-torrent.org/"
 changelog="https://raw.githubusercontent.com/deluge-torrent/deluge/develop/CHANGELOG.md"
-distfiles="https://ftp.osuosl.org/pub/deluge/source/2.0/deluge-${version}.tar.xz"
-checksum=c4bd04abfd211b65218be03f3c46d26f44024884de10e01859fb856fdd6f25d8
+distfiles="https://ftp.osuosl.org/pub/deluge/source/2.1/deluge-${version}.tar.xz"
+checksum=768dd319802e42437ab3794ebe75b497142e08ed5b0fb2503bad62cef442dff7
+make_check=no # requires unpackaged pytest_twisted
 
 system_accounts="deluge"
 deluge_homedir="/var/lib/deluge"
@@ -26,11 +25,6 @@ make_dirs="
  /var/lib/deluge/.config 0755 deluge deluge
  /var/lib/deluge/.config/deluge 0755 deluge deluge
  "
-
-do_check() {
-	rm deluge/tests/test_torrentview.py deluge/tests/test_files_tab.py
-	xvfb-run python3 -m pytest
-}
 
 post_install() {
 	vsv deluged


### PR DESCRIPTION
I had to pull a patch from upstream boost to fix, the current deluge version in repo doesn't actually work because of this, might be affecting others as well.

I don't know what else I need to do as far as bumping dependents of boost and libtorrent-rasterbar, I just wanted to put this up here since apparently deluge is currently unusable.

https://github.com/boostorg/python/pull/385

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
