### PR TITLE
cups: add support for gnutls to enable https

### DIFF
--- a/srcpkgs/cups/template
+++ b/srcpkgs/cups/template
@@ -1,14 +1,14 @@
 # Template file for 'cups'
 pkgname=cups
 version=2.4.2
-revision=1
+revision=2
 build_style=gnu-configure
 make_install_args="BUILDROOT=${DESTDIR}"
 hostmakedepends="gnutls-devel pkg-config
  $(vopt_if avahi avahi-libs-devel)"
 makedepends="acl-devel gnutls-devel libpaper-devel libusb-devel pam-devel
  zlib-devel $(vopt_if avahi avahi-libs-devel) $(vopt_if gssapi mit-krb5-devel)"
-depends="xdg-utils"
+depends="xdg-utils gnutls"
 short_desc="Common Unix Printing System"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Apache-2.0"
@@ -41,7 +41,7 @@ do_configure() {
 		--with-system-groups="lpadmin sys root" --enable-relro \
 		--enable-libpaper --with-menudir=/usr/share/applications \
 		--with-xinetd=/etc/xinetd.d --with-optim="${CFLAGS}" \
-		--with-rcdir=no \
+		--with-rcdir=no --with-tls=gnutls \
 		$(vopt_if avahi '--with-dnssd=avahi') $(vopt_enable gssapi)
 }
 


### PR DESCRIPTION
Without gnutls CUPS defaults to the MacOS path for certificates. https://github.com/OpenPrinting/cups/blob/19047059/scheduler/conf.c#L607-L612

When administering printers in CUPS UI (localhost:631) I noticed that the connection could not upgrade to HTTPS.  Upon investigation with `strace` I saw that CUPS was trying to load certificates from `/Library/Keychains/System.keychain`.
```
openat(AT_FDCWD, "/Library/Keychains/System.keychain/void.key", O_WRONLY|O_CREAT|O_TRUNC, 0666) = -1 ENOENT (No such file or directory)
```
Enabling GNUTLS causes CUPS to look in the correct location for certificates.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-GLIBC)
