### PR TITLE
bzip2-devel: add pkgconfig file

### DIFF
--- a/srcpkgs/bzip2/files/bzip2.pc
+++ b/srcpkgs/bzip2/files/bzip2.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: A file compression library
+Version: @VERSION@
+Libs: -L${libdir} -lbz2
+Cflags: -I${includedir}

--- a/srcpkgs/bzip2/template
+++ b/srcpkgs/bzip2/template
@@ -1,7 +1,7 @@
 # Template file for 'bzip2'
 pkgname=bzip2
 version=1.0.8
-revision=1
+revision=2
 bootstrap=yes
 short_desc="Freely available, patent free, high-quality data compressor"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -35,6 +35,9 @@ do_install() {
 	vinstall libbz2.a 644 usr/lib
 	vinstall bzlib.h 644 usr/include
 
+	vinstall "${FILESDIR}/bzip2.pc" 644 usr/lib/pkgconfig
+	vsed -i "s/@VERSION@/${version}/" "${DESTDIR}/usr/lib/pkgconfig/bzip2.pc"
+
 	vman bzip2.1
 	ln -sf bzip2.1 ${DESTDIR}/usr/share/man/man1/bunzip2.1
 	ln -sf bzip2.1 ${DESTDIR}/usr/share/man/man1/bzcat.1
@@ -46,6 +49,7 @@ bzip2-devel_package() {
 	short_desc+=" - development files"
 	pkg_install() {
 		vmove usr/include
+		vmove usr/lib/pkgconfig
 		vmove "usr/lib/*.a"
 		vmove "usr/lib/*.so"
 	}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Adapted from [Arch Linux](https://github.com/archlinux/svntogit-packages/commit/e2cc08098f31fc7110131782626d22939731b7d5)

Context: upstream has been unresponsive about requests for pkgconfig files in the past, but Arch and Alpine include their own, at least.
Also, the experimental future development project added the file back in 2019: https://gitlab.com/bzip2/bzip2/-/commit/70ec984159c8263fdd4aac7c4670977aff0fe5b3

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
