### PR TITLE
ccls: update to 0.20220729.

### DIFF
--- a/srcpkgs/ccls/template
+++ b/srcpkgs/ccls/template
@@ -1,16 +1,16 @@
 # Template file for 'ccls'
 pkgname=ccls
-version=0.20210330
-revision=2
+version=0.20220729
+revision=1
 build_style=cmake
 hostmakedepends="clang-tools-extra"
-makedepends="llvm ncurses-devel rapidjson zlib-devel clang-tools-extra"
+makedepends="clang-tools-extra libxml2-devel llvm ncurses-devel rapidjson zlib-devel"
 short_desc="C/C++/ObjC language server"
-maintainer="Nathan Owens <ndowens@artixlinux.org>"
+maintainer="André Cerqueira <acerqueira021@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/MaskRay/ccls"
 distfiles="https://github.com/MaskRay/ccls/archive/${version}.tar.gz"
-checksum=28c228f49dfc0f23cb5d581b7de35792648f32c39f4ca35f68ff8c9cb5ce56c2
+checksum=af19be36597c2a38b526ce7138c72a64c7fb63827830c4cff92256151fc7a6f4
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (X) means crossbuilded:
 - x86_64
 - i686 
 - aarch64-musl (X)
 - aarch64 (X)
 - armv7l-mus (X)l
 - armv7l (X)
 - armv6l-musl (X)
 - armv6l (X)


