### PR TITLE
teeworlds: replace python with python3 in hostmakedepends

### DIFF
--- a/srcpkgs/teeworlds/template
+++ b/srcpkgs/teeworlds/template
@@ -2,7 +2,7 @@
 pkgname=teeworlds
 version=0.7.5
 revision=2
-hostmakedepends="bam python pkg-config"
+hostmakedepends="bam python3 pkg-config"
 makedepends="zlib-devel SDL2-devel glu-devel freetype-devel"
 short_desc="Retro multiplayer shooter"
 maintainer="Leah Neukirchen <leah@vuxu.org>"


### PR DESCRIPTION
Build instructions in readme.md mention python 3 as a build dependency in section "Building on Linux or macOS (CMake)", subsection "Installing dependencies".

Related to void-linux/void-packages#38229.

cc: @leahneukirchen 

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
