### PR TITLE
moby: update to 20.10.21.

### DIFF
--- a/srcpkgs/docker-cli/template
+++ b/srcpkgs/docker-cli/template
@@ -1,4 +1,5 @@
 # Template file for 'docker-cli'
+# should be kept in sync with moby
 pkgname=docker-cli
 version=20.10.21
 revision=2

--- a/srcpkgs/moby/template
+++ b/srcpkgs/moby/template
@@ -1,8 +1,10 @@
 # Template file for 'moby'
+# should be kept in sync with docker-cli
 pkgname=moby
-version=20.10.17
+version=20.10.21
 revision=1
-_libnetwork_commit=f6ccccb1c082a432c2a5814aaedaca56af33d9ea
+# libnetwork commit is mentioned in vendor.conf
+_libnetwork_commit=0dde5c895075df6e3630e76f750a447cf63f4789
 create_wrksrc=yes
 build_style=go
 go_import_path="github.com/docker/docker"
@@ -15,8 +17,8 @@ license="Apache-2.0"
 homepage="https://www.docker.com"
 distfiles="https://github.com/moby/moby/archive/v${version}.tar.gz>moby-$version.tar.gz
  https://github.com/moby/libnetwork/archive/$_libnetwork_commit.tar.gz>libnetwork-$_libnetwork_commit.tar.gz"
-checksum="061cf8579aa3c813c353c80fa480744e2f6cca2e6392f546bd0942a6a10c7a14
- 05bf95637bae134d12d02bd7a7854cd0c768e6fccb662c2c64523f05b997b204"
+checksum="61f4c3a2d0426e1bbbda1b0e5dd33ec203776f7d99d1a61522c77c04c4ed09fe
+ 9b0d97166a34e01c467e8e14a23a568de1c7771b45a6d745d12be11acf376508"
 system_groups="docker"
 
 _moby_builddir="moby-$version"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)

docker was updates to 20.10.21 but the docker server (moby) is still on 20.10.17. Also I found out that btrfs >= 5.19 as a storage driver is only supported by the newer version.

In the future it would make sense to update moby together with the other docker packages.