### PR TITLE
containerd: update to 1.6.10.

### DIFF
--- a/srcpkgs/containerd/template
+++ b/srcpkgs/containerd/template
@@ -1,6 +1,6 @@
 # Template file for 'containerd'
 pkgname=containerd
-version=1.6.8
+version=1.6.10
 revision=1
 build_style=go
 go_import_path=github.com/containerd/containerd
@@ -20,7 +20,7 @@ maintainer="Paul Knopf <pauldotknopf@gmail.com>"
 license="Apache-2.0"
 homepage="https://github.com/containerd/containerd"
 distfiles="https://github.com/containerd/containerd/archive/v${version}.tar.gz"
-checksum=f5f938513c28377f64f85e84f2750d39f26b01262f3a062b7e8ce35b560ca407
+checksum=57be0d7b448abc83f2d1e0045864ffec83e6afa0c7e54548b50d67152686745e
 make_dirs="/var/lib/containerd 0755 root root"
 
 post_build() {


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)