### PR TITLE
spice: update to 0.15.1.

### DIFF
--- a/srcpkgs/spice/template
+++ b/srcpkgs/spice/template
@@ -1,11 +1,11 @@
 # Template file for 'spice'
 pkgname=spice
-version=0.15.0
+version=0.15.1
 revision=1
 build_style=gnu-configure
 configure_args="--disable-tunnel --disable-opengl --enable-smartcard
  --with-sasl --disable-static --enable-xinerama --disable-celt051"
-hostmakedepends="pkg-config python"
+hostmakedepends="pkg-config python3"
 makedepends="spice-protocol libjpeg-turbo-devel pixman-devel
  openssl-devel opus-devel alsa-lib-devel libXfixes-devel libXrender-devel
  libXrandr-devel libsasl-devel libXinerama-devel libglib-devel libcacard-devel
@@ -14,9 +14,10 @@ checkdepends="glib-networking"
 short_desc="Implements the SPICE protocol"
 maintainer="Anachron <gith@cron.world>"
 license="LGPL-2.1-or-later"
-homepage="http://www.spice-space.org"
+homepage="https://www.spice-space.org/"
+changelog="https://gitlab.freedesktop.org/spice/spice/-/raw/master/CHANGELOG.md"
 distfiles="https://www.spice-space.org/download/releases/spice-server/spice-${version}.tar.bz2"
-checksum=b320cf8f4bd2852750acb703c15b72856027e5a8554f8217dfbb3cc09deba0f5
+checksum=ada9af67ab321916bd7eb59e3d619a4a7796c08a28c732edfc7f02fc80b1a37a
 
 if [ "$XBPS_TARGET_ENDIAN" != "le" ]; then
 	broken="SPICE server only works on little endian architectures"
@@ -29,10 +30,6 @@ if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	# musl errors out instead, thus failing the tests
 	make_check=no
 fi
-
-post_extract() {
-	sed -i 's/armv6hl/arm/g' configure	# "detects" cpu from triplet.
-}
 
 spice-devel_package() {
 	depends="${makedepends} ${sourcepkg}>=${version}_${revision}"


### PR DESCRIPTION
Updated, and removed python 2 dependency (#38229).

#### Testing the changes
- I tested the changes in this PR: **briefly**
  I didn't do much testing other than making sure that the tests pass and that `qemu-system-x86_64` doesn't crash.
  The python scripts as far as I can tell are only involved in unit testing; moreover, upstream [uses python3](https://gitlab.freedesktop.org/spice/spice/-/blob/master/.gitlab-ci.yml) in their CI. 

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64 (crossbuild)