### PR TITLE
textadept: update to 11.4.

### DIFF
--- a/srcpkgs/textadept/template
+++ b/srcpkgs/textadept/template
@@ -1,8 +1,10 @@
 # Template file for 'textadept'
 pkgname=textadept
-version=11.1
+version=11.4
 revision=1
 build_wrksrc="src"
+build_style="gnu-makefile"
+make_use_env=yes
 hostmakedepends="tar unzip pkg-config"
 makedepends="gtk+3-devel ncurses-devel"
 short_desc="Fast, minimalist, and extensible text editor for programmers"
@@ -14,34 +16,37 @@ homepage="https://orbitalquark.github.io/textadept/"
 # checksums updated accordingly). This is so that XBPS can cache them. Details:
 # https://github.com/void-linux/void-packages/pull/15627#issuecomment-549018252
 distfiles="https://github.com/orbitalquark/textadept/archive/textadept_${version}.tar.gz
- https://www.scintilla.org/scintilla445.tgz
- https://github.com/orbitalquark/scinterm/archive/6a774158d8a3c7bc7ea120bc01cdb016fa351a7e.zip
- https://github.com/orbitalquark/scintillua/archive/scintillua_4.4.5-2.zip
- https://www.lua.org/ftp/lua-5.3.5.tar.gz
+ https://www.scintilla.org/scintilla524.tgz
+ https://www.scintilla.org/lexilla510.tgz
+ https://github.com/orbitalquark/scinterm/archive/475d8d43f3418590c28bd2fb07ee9229d1fa2d07.zip
+ https://github.com/orbitalquark/scintillua/archive/9088723504b19f8611b66c119933a4dc7939d7b8.zip
+ https://www.lua.org/ftp/lua-5.4.4.tar.gz
  http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz
  https://github.com/keplerproject/luafilesystem/archive/v1_8_0.zip
- https://github.com/orbitalquark/gtdialog/archive/64587546482a1a6324706d75c80b77d2f87118a4.zip
+ https://github.com/orbitalquark/gtdialog/archive/444af9ca8a73151dbf759e6676d1035af469f01a.zip
  https://invisible-mirror.net/archives/cdk/cdk-5.0-20200923.tgz
- http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.20.tar.gz"
-checksum="55d153fba03aa2e12c2865f38f378154bbc7d2d3e3448a3682b46ee17056fb4c
- 4f2168684b4024dc3d6b267320fff1d729192047f4a1b79aeab9ec7c64f733ec
- 3b1e3cc3ee48bb158d1d666c7c86d190905c973918914876f6ab3712f8dd7d20
- ccd5b3d615116b8c4376086cf1d03b6ef1f67a565e57446b15eba3f39ef0c180
- 0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac
+ https://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz"
+checksum="fe10cbe9949e3a2ec4445ace16e26eb4b905cee2e36de76295ea9a7ca6c3aba8
+ 4aef1488c9a43b172e05ab762566049e135d1b91ca9d5d5f9f50a59c985acc66
+ 6b3595274005498671b854cf57bdeec2254966f371712fcf3a716d97aa7f3fd8
+ 94d30ad1115c38b83d4511396ba55e9614b3518565e538808977237b624e79d1
+ 576b7592debe4a9650bd04b32e187c9fe5a2027037d92455167adb4da26b1d1a
+ 164c7849653b80ae67bec4b7473b884bf5cc8d2dca05653475ec2ed27b9ebf61
  48d66576051b6c78388faad09b70493093264588fcd0f258ddaab1cdd4a15ffe
  e3a6beca7a8a90522eed31db6ccdc5ed65a433826500c6862784e27671b9e18a
- 093a4f973196083610c4489e8d9272f340ebf82d48c064f1542c6464eda2af82
+ ec0917ece59726dccaab7878b8978bcc7a5fea6aeccfaed25ed3ef9b2039c718
  007f5de880cb2eebd8556df7e4cd8673d5e64c9970147eee6923a814c29faaed
- 6c0d87c94ab9915e76ecd313baec08dedf3bd56de83743d9aa923a081935d2f5"
-skip_extraction="scintilla445.tgz
- 6a774158d8a3c7bc7ea120bc01cdb016fa351a7e.zip
- scintillua_4.4.5-2.zip
- lua-5.3.5.tar.gz
+ 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600"
+skip_extraction="scintilla524.tgz
+ lexilla510.tgz
+ 475d8d43f3418590c28bd2fb07ee9229d1fa2d07.zip
+ 9088723504b19f8611b66c119933a4dc7939d7b8.zip
+ lua-5.4.4.tar.gz
  lpeg-1.0.2.tar.gz
  v1_8_0.zip
- 64587546482a1a6324706d75c80b77d2f87118a4.zip
+ 444af9ca8a73151dbf759e6676d1035af469f01a.zip
  cdk-5.0-20200923.tgz
- libtermkey-0.20.tar.gz"
+ libtermkey-0.22.tar.gz"
 
 post_extract() {
 	# We copy the downloaded dep files to src directory so that they are found
@@ -57,38 +62,23 @@ post_extract() {
 pre_configure() {
 	# For cross builds
 	vsed -i \
-		-e '/^CC =/d' \
-		-e '/^CFLAGS =/d' \
-		-e '/^CXX =/d' \
-		-e 's/^CXXFLAGS =.*/CXXFLAGS += -std=c++17/' Makefile
+		-e '/CC :=/d' \
+		-e '/^CFLAGS :=/d' \
+		-e '/CXX :=/d' \
+		-e 's/^CXXFLAGS :=.*/CXXFLAGS += -std=c++17/' Makefile
 }
 
-do_build() {
+pre_build() {
 	make deps
-	# fix build with gcc 12 https://github.com/orbitalquark/textadept/issues/110
-	# from https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=textadept&id=c07c879175c8bea2f43169c71887bd9ebdf8969d
-	vsed -i '1008s/volatile//;1099s/volatile//;' scintilla/gtk/ScintillaGTKAccessible.cxx
-	make ${makejobs} GTK3=1
-	make ${makejobs} curses
 }
 
-do_install() {
-	make PREFIX=/usr DESTDIR="${DESTDIR}" install
-	make curses PREFIX=/usr DESTDIR="${DESTDIR}" install
-
+post_install() {
 	# Binaries in /usr/share/textadept are not allowed
 	# So we relocate to /usr/lib/textadept
 	mv "${DESTDIR}/usr/share/textadept" "${DESTDIR}/usr/lib/textadept"
 	ln -sf "/usr/lib/textadept/textadept" "${DESTDIR}/usr/bin/textadept"
 	ln -sf "/usr/lib/textadept/textadept-curses" \
 		"${DESTDIR}/usr/bin/textadept-curses"
-
-	# For icons
-	mkdir -p "${DESTDIR}/usr/share/pixmaps"
-	ln -s "/usr/lib/textadept/core/images/textadept.svg" \
-		"${DESTDIR}/usr/share/pixmaps/textadept.svg"
-	ln -s "/usr/lib/textadept/core/images/ta_48x48.png" \
-		"${DESTDIR}/usr/share/pixmaps/textadept.png"
 
 	vlicense ../LICENSE
 }


### PR DESCRIPTION
The package was built using GCC 12. No errors to report.

[textadept.txt](https://github.com/void-linux/void-packages/files/10036369/textadept.txt)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl