### PR TITLE
rust-cargo-audit: update to 0.17.4.

### DIFF
--- a/srcpkgs/rust-cargo-audit/template
+++ b/srcpkgs/rust-cargo-audit/template
@@ -1,7 +1,7 @@
 # Template file for 'rust-cargo-audit'
 pkgname=rust-cargo-audit
-version=0.13.1
-revision=2
+version=0.17.4
+revision=1
 build_style=cargo
 hostmakedepends="pkg-config"
 makedepends="openssl-devel libssh2-devel zlib-devel"
@@ -9,17 +9,13 @@ short_desc="Audit Cargo.lock for crates with security vulnerabilities"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="Apache-2.0, MIT"
 homepage="https://rustsec.org"
+changelog="https://github.com/rustsec/rustsec/raw/main/cargo-audit/CHANGELOG.md"
 distfiles="https://static.crates.io/crates/cargo-audit/cargo-audit-${version}.crate"
-checksum=5c04240c97606ef511e5df2e26eb8c7c30031d015613c1f01c59068b50da7df2
+checksum=d081c816d0ad00c75527ea30e1bb10d5ac15a741b945c23a56acde67bb04a7c9
 
 if [ "$XBPS_TARGET_WORDSIZE" = "32" -a "$XBPS_TARGET_ENDIAN" = "be" ]; then
 	broken="smartstring crate does not build on 32-bit BE architectures"
 fi
-
-pre_build() {
-	# fixes an indexmap error when cross compiling
-	cargo update --package autocfg:1.0.1 --precise 1.1.0
-}
 
 post_install() {
 	vlicense LICENSE-APACHE


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

This update includes scanning of binaries (feature has been turned on by
default upstream, we previously didn't ship that), so together with the
recently merged #40272, this allows us to check binaries shipped by Void for
rustsec advisories like so:

```
void-packages on  rust-cargo-audit-0.17.4_1 [$!?] took 3m58s 
❯ cargo audit bin /usr/bin/comrak
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 469 security advisories (from /home/jcgruenhage/.cargo/advisory-db)
    Updating crates.io index
       Found 'cargo auditable' data in /usr/bin/comrak (83 dependencies)
Crate:     xml-rs
Version:   0.8.4
Warning:   unmaintained
Title:     xml-rs is Unmaintained
Date:      2022-01-26
ID:        RUSTSEC-2022-0048
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0048
Dependency tree:
xml-rs 0.8.4
└── plist 1.3.1
    └── syntect 5.0.0
        └── comrak 0.15.0

warning: 1 allowed warning found in /usr/bin/comrak
```

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
