### PR TITLE
New package: pdfarranger-1.9.1

### DIFF
--- a/srcpkgs/pdfarranger/template
+++ b/srcpkgs/pdfarranger/template
@@ -1,0 +1,15 @@
+# Template file for 'pdfarranger'
+pkgname=pdfarranger
+version=1.9.1
+revision=1
+build_style=python3-module
+hostmakedepends="intltool python3-distutils-extra python3-setuptools"
+depends="img2pdf poppler-glib python3-dateutil python3-gobject python3-pikepdf"
+short_desc="Simple application for PDF Merging, Rearranging, and Splitting"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/pdfarranger/pdfarranger"
+distfiles="https://github.com/pdfarranger/pdfarranger/archive/refs/tags/${version}.tar.gz"
+checksum=a0d91226d19977c5e12fdaac5c1e65dbd0685ef75d1be545f1a595bf020c9894
+# tests require involved xvfb setup
+make_check=no


### PR DESCRIPTION
closes #40138

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
