### PR TITLE
cargo-auditable: update to 0.5.4.

### DIFF
--- a/srcpkgs/cargo-auditable-bootstrap/template
+++ b/srcpkgs/cargo-auditable-bootstrap/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo-auditable-bootstrap'
 # Keep synced with cargo-auditable
 pkgname=cargo-auditable-bootstrap
-version=0.5.3
+version=0.5.4
 revision=1
 build_wrksrc=cargo-auditable
 build_style=cargo
@@ -11,8 +11,9 @@ short_desc="Bootstrap package for cargo-auditable"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT,Apache-2.0"
 homepage="https://github.com/rust-secure-code/cargo-auditable"
+changelog="https://github.com/rust-secure-code/cargo-auditable/raw/master/cargo-auditable/CHANGELOG.md"
 distfiles="https://github.com/rust-secure-code/cargo-auditable/archive/refs/tags/v${version}.tar.gz"
-checksum=a73e55fb887a0a019d13fa87983e8825ca16d46076bf89d623fa060876ca4f3f
+checksum=8827a3810721e36df38dcdc28b2291760dc70609e57a9c7245ba1bf1932e1ced
 
 post_install() {
 	vlicense ../LICENSE-MIT

--- a/srcpkgs/cargo-auditable/template
+++ b/srcpkgs/cargo-auditable/template
@@ -1,7 +1,7 @@
 # Template file for 'cargo-auditable'
 # Keep synced with cargo-auditable-bootstrap
 pkgname=cargo-auditable
-version=0.5.3
+version=0.5.4
 revision=1
 build_wrksrc=cargo-auditable
 build_style=cargo
@@ -10,8 +10,9 @@ short_desc="Tool for embedding dependency information in rust binaries"
 maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="MIT,Apache-2.0"
 homepage="https://github.com/rust-secure-code/cargo-auditable"
+changelog="https://github.com/rust-secure-code/cargo-auditable/raw/master/cargo-auditable/CHANGELOG.md"
 distfiles="https://github.com/rust-secure-code/cargo-auditable/archive/refs/tags/v${version}.tar.gz"
-checksum=a73e55fb887a0a019d13fa87983e8825ca16d46076bf89d623fa060876ca4f3f
+checksum=8827a3810721e36df38dcdc28b2291760dc70609e57a9c7245ba1bf1932e1ced
 conflicts=cargo-auditable-bootstrap
 
 post_install() {


### PR DESCRIPTION
- cargo-auditable-bootstrap: update to 0.5.4.
- cargo-auditable: update to 0.5.4.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
