### PR TITLE
glslViewer: update to 3.0.7.

### DIFF
--- a/srcpkgs/glslViewer/patches/liblo.patch
+++ b/srcpkgs/glslViewer/patches/liblo.patch
@@ -1,0 +1,33 @@
+--- a/glslViewer/CMakeLists.txt
++++ b/glslViewer/CMakeLists.txt
+@@ -31,7 +31,10 @@
+ 
+ add_executable(glslViewer ${ROOT_SOURCE})
+ 
+-include_directories(deps/liblo)
++include(FindPkgConfig)
++pkg_search_module(LIBLO REQUIRED liblo>=0.31)
++include_directories(glslViewer PRIVATE ${LIBLO_INCLUDE_DIRS})
++target_link_libraries(glslViewer PRIVATE ${LIBLO_LIBRARIES})
+ target_include_directories(glslViewer PRIVATE deps)
+ target_link_libraries(glslViewer PRIVATE vera)
+ target_compile_definitions(glslViewer PRIVATE GLSLVIEWER_VERSION_MAJOR=${VERSION_MAJOR})
+@@ -151,7 +154,7 @@
+         set(CPACK_GENERATOR "ZIP")
+ 
+     else()
+-        target_link_libraries(glslViewer PRIVATE pthread dl lo_static)
++        target_link_libraries(glslViewer PRIVATE pthread dl)
+         install(TARGETS glslViewer DESTINATION bin)
+ 
+         if (NOT APPLE)
+--- a/glslViewer/deps/CMakeLists.txt
++++ b/glslViewer/deps/CMakeLists.txt
+@@ -1,6 +1,2 @@
+ ## Ada
+ add_subdirectory(vera)
+-
+-if (NOT EMSCRIPTEN) 
+-    add_subdirectory(liblo/cmake)
+-endif()
+\ No newline at end of file

--- a/srcpkgs/glslViewer/template
+++ b/srcpkgs/glslViewer/template
@@ -1,31 +1,39 @@
 # Template file for 'glslViewer'
 pkgname=glslViewer
-version=1.6.8
+version=3.0.7
 revision=1
-build_style=gnu-makefile
-make_use_env=yes
+_vera_gitrev="a3538e06ecbfe0694e2a64fc51ce6c4ee018a9a0"
+build_wrksrc=${pkgname}
+build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="glfw-devel glu-devel MesaLib-devel libX11-devel libXrandr-devel
  libXi-devel libXxf86vm-devel libXcursor-devel libXinerama-devel libXext-devel
- libXrender-devel libXdamage-devel"
+ libXrender-devel libXdamage-devel ncurses-devel liblo-devel"
 short_desc="Live GLSL coding render"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-3-Clause"
 homepage="http://patriciogonzalezvivo.com/2015/glslViewer/"
-distfiles="https://github.com/patriciogonzalezvivo/glslViewer/archive/${version}.tar.gz"
-checksum=3792984457c9487cd1f87374b7698f3b66f4480b3eeac7d940a2ecf9e74dee3e
+distfiles="https://github.com/patriciogonzalezvivo/glslViewer/archive/${version}.tar.gz
+ https://github.com/patriciogonzalezvivo/vera/archive/${_vera_gitrev}.tar.gz"
+checksum="4d8bac6a801fa61b81e472a8dabfe5469a43c44547d558849a078ed2c26c8034
+ a71f149e84afdf12aa88555efef09d0e420c5d5c6ba9c2d67126ecc49fddaff0"
 
-pre_build() {
-	# can obscure real errors
-	vsed -e 's|-fpermissive||g' \
-		 -e 's|^CXX =.*||g' \
-		 -i Makefile
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
 
-	vsed -e '/window = glfwCreateWindow/i glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);' \
-		-i src/window.cpp
+post_extract() {
+	mv ${pkgname}-${version} ${build_wrksrc}
+	mv vera-${_vera_gitrev}/* ${build_wrksrc}/deps/vera
 }
 
-do_install() {
-	vbin bin/glslViewer
+pre_configure() {
+	if [ -z "$XBPS_TARGET_NO_ATOMIC8" ]; then
+		vsed -e '/target_link_libraries(glslViewer PRIVATE atomic)/d' \
+			 -i CMakeLists.txt
+	fi
+}
+
+post_install() {
 	vlicense LICENSE
 }


### PR DESCRIPTION
This package was built with GCC 12. No errors to report.

[glslviewer.txt](https://github.com/void-linux/void-packages/files/10036481/glslviewer.txt)

In reference to #39809.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl