### PR TITLE
buku: fix cgi deprecation warning for python3>=3.11

### DIFF
--- a/srcpkgs/buku/patches/remove-cgi-warning.patch
+++ b/srcpkgs/buku/patches/remove-cgi-warning.patch
@@ -1,0 +1,38 @@
+adapted from https://github.com/jarun/buku/pull/605
+--- a/buku
++++ b/buku
+@@ -19,10 +19,10 @@
+ 
+ import argparse
+ import calendar
+-import cgi
+ import codecs
+ import collections
+ import contextlib
++import email.message
+ import json
+ import locale
+ import logging
+@@ -3811,15 +3811,17 @@
+         if soup.meta and soup.meta.get('charset') is not None:
+             charset = soup.meta.get('charset')
+         elif 'content-type' in resp.headers:
+-            _, params = cgi.parse_header(resp.headers['content-type'])
+-            if params.get('charset') is not None:
+-                charset = params.get('charset')
++            m = email.message.Message()
++            m['content-type'] = resp.headers['content-type']
++            if m.get_param('charset') is not None:
++                charset = m.get_param('charset')
+ 
+         if not charset and soup:
+             meta_tag = soup.find('meta', attrs={'http-equiv': 'Content-Type'})
+             if meta_tag:
+-                _, params = cgi.parse_header(meta_tag.attrs['content'])
+-                charset = params.get('charset', charset)
++                m = email.message.Message()
++                m['content'] = meta_tag.attrs['content']
++                charset = m.get_param('charset', charset)
+ 
+         if charset:
+             LOGDBG('charset: %s', charset)

--- a/srcpkgs/buku/template
+++ b/srcpkgs/buku/template
@@ -1,7 +1,7 @@
 # Template file for 'buku'
 pkgname=buku
 version=4.7
-revision=1
+revision=2
 depends="python3-urllib3 python3-BeautifulSoup4 python3-cryptography
  python3-html5lib"
 short_desc="Cmdline bookmark management utility"


### PR DESCRIPTION
#### Changes

Followup of #40551.

Add the necessary patch to remove the DeprecationWarning `'cgi' is deprecated and slated for removal in Python 3.13` in buku caused by Python3 version update (3.11 as of writing).

#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - armv6l 
- `xlint` also reports no error.