### PR TITLE
hplip: prevent conflicts with the GUI package

### DIFF
--- a/srcpkgs/hplip/INSTALL
+++ b/srcpkgs/hplip/INSTALL
@@ -1,0 +1,5 @@
+case "${ACTION}" in
+post)
+	# Link to the no-GUI config if there is none
+	[ -e etc/hp/hplip.conf ] || ln -sf hplip-nogui.conf etc/hp/hplip.conf
+esac

--- a/srcpkgs/hplip/REMOVE
+++ b/srcpkgs/hplip/REMOVE
@@ -1,0 +1,10 @@
+case "${ACTION}" in
+pre)
+	# Remove a configuration symlink if it points to the non-GUI config
+	if [ -L etc/hp/hplip.conf ]; then
+		case "$(readlink etc/hp/hplip.conf 2>/dev/null)" in
+			""|hplip-nogui.conf) rm etc/hp/hplip.conf ;;
+
+		esac
+	fi
+esac

--- a/srcpkgs/hplip/hplip-gui.INSTALL
+++ b/srcpkgs/hplip/hplip-gui.INSTALL
@@ -1,0 +1,7 @@
+case "${ACTION}" in
+post)
+	# Link to GUI config if there is none or it is a symlink
+	if [ ! -e etc/hp/hplip.conf ] || [ -L etc/hp/hplip.conf ]; then
+		ln -sf hplip-gui.conf etc/hp/hplip.conf
+	fi
+esac

--- a/srcpkgs/hplip/hplip-gui.REMOVE
+++ b/srcpkgs/hplip/hplip-gui.REMOVE
@@ -1,0 +1,18 @@
+case "${ACTION}" in
+pre)
+	# Handle the configuration symlink, if it points to the GUI config.
+	# The link will be replaced to the non-GUI config if that exists;
+	# otherwise, it will just be removed.
+	if [ -L etc/hp/hplip.conf ]; then
+		case "$(readlink etc/hp/hplip.conf 2>/dev/null)" in
+			""|hplip-gui.conf)
+				# Replace with no-gui symlink
+				if [ -e etc/hp/hplip-nogui.conf ]; then
+					ln -sf hplip-nogui.conf etc/hp/hplip.conf
+				else
+					rm etc/hp/hplip.conf
+				fi
+			;;
+		esac
+	fi
+esac

--- a/srcpkgs/hplip/template
+++ b/srcpkgs/hplip/template
@@ -1,7 +1,7 @@
 # Template file for 'hplip'
 pkgname=hplip
 version=3.22.6
-revision=2
+revision=3
 build_style=gnu-configure
 pycompile_dirs="usr/share/hplip"
 # configure checks sys.version[:3] for Python versioning, so 3.10 becomes 3.1;
@@ -22,7 +22,7 @@ configure_args="
  --disable-imageProcessor-build
  --with-mimedir=/usr/share/cups/mime
  am_cv_python_version=${py3_ver}"
-conf_files="/etc/hp/hplip.conf"
+conf_files="/etc/hp/hplip-nogui.conf"
 make_dirs="/var/lib/hp 0755 root root"
 hostmakedepends="pkg-config automake libtool python3"
 makedepends="openssl-devel python3-devel libxml2-python3 cups-devel sane-devel
@@ -37,7 +37,6 @@ homepage="https://developers.hp.com/hp-linux-imaging-and-printing"
 changelog="https://developers.hp.com/hp-linux-imaging-and-printing/release_notes"
 distfiles="${SOURCEFORGE_SITE}/hplip/hplip/${version}/hplip-${version}.tar.gz"
 checksum=27ed0d492febb0b47c656234820d3ce573b24ff5b62e3bf4b2c47f82868d6bb4
-conflicts="hplip-gui"
 
 CFLAGS="-I${XBPS_CROSS_BASE}/usr/include/libusb-1.0 -I${XBPS_CROSS_BASE}/${py3_inc}"
 
@@ -71,30 +70,40 @@ do_install() {
 	# remove systemd service file
 	rm -rf ${DESTDIR}/usr/lib/systemd
 	# save gui-version of hplip.conf
-	cp -p ${DESTDIR}/etc/hp/hplip.conf /tmp/hplip.conf
+	local _confdir="${DESTDIR}/etc/hp"
+	mv "${_confdir}/hplip.conf" "${_confdir}/hplip-gui.conf"
 	# adjust values to non-gui version
-	sed -i ${PKGDESTDIR}/etc/hp/hplip.conf \
-	 -e "s/\(gui-build=\).*/\1no/" \
-	 -e "s/\(ui-toolkit=\).*/\1no/" \
-	 -e "s/\(qt5=\).*/\1no/"
+	sed -e "s/\(gui-build=\).*/\1no/" \
+		-e "s/\(ui-toolkit=\).*/\1no/" \
+		-e "s/\(qt5=\).*/\1no/" \
+		"${_confdir}/hplip-gui.conf" > "${_confdir}/hplip-nogui.conf"
 	# licenses
 	vlicense COPYING
 	vlicense copyright
 }
 
 hplip-gui_package() {
-	depends="python3-gobject python3-dbus desktop-file-utils
-	 foomatic-db foomatic-db-engine python3-distro python3-PyQt5-dbus"
-	short_desc+=" (with GUI)"
-	conflicts="${sourcepkg}"
-	provides="${sourcepkg}-${version}_${revision}"
+	depends="${sourcepkg}>=${version}_${revision} python3-gobject
+	 python3-dbus desktop-file-utils foomatic-db foomatic-db-engine
+	 python3-distro python3-PyQt5-dbus"
+	short_desc+=" (GUI utilities)"
+	python_version=3
+	conf_files="/etc/hp/hplip-gui.conf"
 	pkg_install() {
-		vmove usr/bin/hp-toolbox
+		local _app _apps
+
+		_apps="devicesettings faxsetup linefeedcal toolbox
+		 print printsettings pqdiag uiscan wificonfig"
+
+		for _app in ${_apps}; do
+			vmove "usr/bin/hp-${_app}"
+			vmove "usr/share/hplip/${_app}.py"
+		done
+
 		vmove usr/share/applications
 		vmove usr/share/hplip/ui5
 		vmove usr/share/hplip/data/images
-		cp -a ${DESTDIR}/. ${PKGDESTDIR}/
-		# restore gui-version of hplip.conf
-		mv /tmp/hplip.conf ${PKGDESTDIR}/etc/hp/
+
+		vmove etc/hp/hplip-gui.conf
 	}
 }


### PR DESCRIPTION
The `hplip-gui` package uses the exact same files as the regular `hplip` package, plus a few extra for the UI and three changes in the configuration file. Rather than copy the entire package contents and register `conflict=` and `provides=` to fool the package manager, we can make `hplip-gui` depend on `hplip` and just manage a symlink between two alternative configuration files.

The only really sophisticated part is handling the configuration symlink when removing `hplip-gui`. Because a  user might remove the GUI package and want to keep the non-GUI version installed, the remove hook should detect whether a) it owns the existing symlink (*i.e.*, the link points at the GUI configuration) and b) whether the non-GUI configuration exists (in which case the link should be moved to the non-GUI config; otherwise, it should be removed). The rest of the hooks are very basic:
- `hplip` only claims the configuration symlink on installation if *no* valid configuration symlink exists, to avoid clobbering, *e.g.*, the existing GUI link on an upgrade.
- `hplip-gui` claims any configuration symlink (but leaves regular files alone) because a user installing the GUI package probably wants it to work.
- `hplip` just removes any configuration symlink it owns when the package is removed.

The removal hooks also treat a failure of `readlink` (which really ought to never happen) as if they "own" the symlink.

I've run through a few installation and removal cycles, and this seems to do what I expect.