### PR TITLE
juCi++: update to 1.7.2.

### DIFF
--- a/srcpkgs/juCi++/template
+++ b/srcpkgs/juCi++/template
@@ -1,9 +1,9 @@
 # Template file for 'juCi++'
 pkgname=juCi++
-version=1.6.2
-revision=4
-_libclangmm_commit="b342f4dd6de4fe509a692a4b4fcfc7e24aae9590"
-_tiny_commit="c9c8bf810ddad8cd17882b9a9ee628a690e779f5"
+version=1.7.2
+revision=1
+_libclangmm_commit="9704b9b6de0982a588fa41741157d5640afedf30"
+_tiny_commit="839ff806dc447ff49af80f9a9eaa7949f770f8e5"
 create_wrksrc=yes
 build_style=cmake
 hostmakedepends="pkg-config"
@@ -16,9 +16,9 @@ homepage="https://gitlab.com/cppit/jucipp"
 distfiles="https://gitlab.com/cppit/jucipp/-/archive/v${version}/jucipp-v${version}.tar.gz
 https://gitlab.com/cppit/libclangmm/-/archive/${_libclangmm_commit}/libclangmm-${_libclangmm_commit}.tar.gz
 https://gitlab.com/eidheim/tiny-process-library/-/archive/${_tiny_commit}/tiny-process-library-${_tiny_commit}.tar.gz"
-checksum="b2dc1d3ad6182c43dc23193e2c2ccb2c1e5eb66da361e66342f12aaeecdacad9
- 33f17a21b8949f93ab9cdc1ab13d239867767fe2988f040ad96f6a173f46883b
- 0bb5bd57f1b909a08d883a5a06a15bb55cfa34b2056bc63fe26ea2d5ff13fa38"
+checksum="e792ddb95328ab055b0a4b7eb18669b3337648a4a931ee6ede541c2e95a686e9
+ 4ed79294cb67ae56a4d72e50c4188c49215df51c8b9a466fc0aeeaab2dbc7a3f
+ a808e5e3bdb43a04c862da968588ceffb1e46b85a32b430d5e27f243b37f5098"
 nocross=yes #clang cannot be installed as makedepends when cross compiling
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
This package was built with GCC 12. No errors to report.

[jucixx.txt](https://github.com/void-linux/void-packages/files/10026430/jucixx.txt)

Related to #39809.

#### Testing the changes
- I tested the changes in this PR: **briefly**