### PR TITLE
nextcloud-client: update to 3.6.2

### DIFF
--- a/srcpkgs/nextcloud-client/template
+++ b/srcpkgs/nextcloud-client/template
@@ -1,6 +1,6 @@
 # Template file for 'nextcloud-client'
 pkgname=nextcloud-client
-version=3.6.1
+version=3.6.2
 revision=1
 build_style=cmake
 configure_args="-Wno-dev"
@@ -19,7 +19,7 @@ license="GPL-2.0-or-later"
 homepage="https://nextcloud.com/clients/"
 changelog="https://github.com/nextcloud/desktop/releases"
 distfiles="https://github.com/nextcloud/desktop/archive/v${version}.tar.gz"
-checksum=c7ea1ed2d0f44a3b8b645a67f21af164bf1024b6872570a61c62994d2a8c1b5b
+checksum=55ddd5c3b6f7c9859416897cc89597906513e2bc62721c63fe4f1476eea27762
 # https://github.com/void-linux/void-packages/pull/33358#discussion_r724518549
 make_check=ci-skip
 


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-libc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - armv7l (crossbuild)
  - i686
