### PR TITLE
toot: update to 0.29.0

### DIFF
--- a/srcpkgs/toot/template
+++ b/srcpkgs/toot/template
@@ -1,14 +1,20 @@
 # Template file for 'toot'
 pkgname=toot
-version=0.27.0
-revision=4
+version=0.29.0
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-BeautifulSoup4 python3-requests python3-setuptools python3-wcwidth
  python3-urwid"
+checkdepends="python3-wheel python3-pytest ${depends}"
 short_desc="Mastodon CLI client"
-maintainer="Nathan Owens <ndowens04@gmail.com>"
+maintainer="Jon Levin <jon@jefferiestube.net>"
 license="GPL-3.0-or-later"
 homepage="https://github.com/ihabunek/toot"
+changelog="https://raw.githubusercontent.com/ihabunek/toot/master/CHANGELOG.md"
 distfiles="https://github.com/ihabunek/toot/archive/${version}.tar.gz"
-checksum=65007187059fe17fae29796dd813cd3bbd8c44f72b5bfec0bc9ef20c65e69410
+checksum=821d549798453da8ad669a605cddc1ead8a797d716723158526534549a4b0d4d
+
+pre_check() {
+	make dist
+}


### PR DESCRIPTION
Also change maintainer to me, since Nathan no longer uses Void.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

Note, I'm using it as my main client, but have only tested the musl version. I did test cross-builds for `i686`, `armv6l` and `x86_64` though, without problem. And xlint gave no errors (trivial change).

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-MUSL)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64 (crossbuild)
  - armv6l (crossbuild)
  - i686 (crossbuild)
