### PR TITLE
docker-compose: update to 2.12.2.

### DIFF
--- a/srcpkgs/docker-compose/template
+++ b/srcpkgs/docker-compose/template
@@ -1,6 +1,6 @@
 # Template file for 'docker-compose'
 pkgname=docker-compose
-version=2.10.2
+version=2.12.2
 revision=1
 build_style=go
 go_import_path="github.com/docker/compose/v2/cmd"
@@ -11,7 +11,7 @@ maintainer="Michal Vasilek <michal@vasilek.cz>"
 license="Apache-2.0"
 homepage="https://docs.docker.com/compose/"
 distfiles="https://github.com/docker/compose/archive/refs/tags/v${version}.tar.gz"
-checksum=74c86d544fcfb80bb2d3b58187bd017adb0e62863d22114a66c14fc94fdbc421
+checksum=311131c5d930fdb1f5e86de19ea2ad1705d23e5745b780c0b10b2eb3f964fc69
 
 post_install() {
 	mkdir -p ${DESTDIR}/usr/libexec/docker/cli-plugins


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)

Update to 2.12.2 is also necessary to fix a CVE.
