### PR TITLE
fcitx5-qt: remove unused conditional block

### DIFF
--- a/srcpkgs/fcitx5-qt/template
+++ b/srcpkgs/fcitx5-qt/template
@@ -17,11 +17,6 @@ distfiles="https://download.fcitx-im.org/fcitx5/fcitx5-qt/fcitx5-qt-${version}.t
 checksum=21743c4353c793934222fa7115493cd30da9843b4baed22e64bddfa6dd7341a8
 lib32disabled=yes
 
-if [ "$XBPS_TARGET_NOATOMIC8" ]; then
-	configure_args+=" -DCMAKE_CXX_STANDARD_LIBRARIES=-latomic"
-	makedepends+=" libatomic-devel"
-fi
-
 post_install() {
 	local _file
 	for _file in $(grep -rl 'SPDX-License-Identifier: BSD-3-Clause' qt5 qt6)


### PR DESCRIPTION
added in #30714, but it seems to have never been necessary.

the test on this block always evaluates false because `XBPS_TARGET_NOATOMIC8` is never set, so it is never run (the variable is actually `XBPS_TARGET_NO_ATOMIC8`).

Because it was never active it should not change the resultant package on armv6 or other no atomic8 platforms.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

