### PR TITLE
libnma: remove path from EAP schema

### DIFF
--- a/srcpkgs/libnma/patches/remove-path-from-eap-schema.patch
+++ b/srcpkgs/libnma/patches/remove-path-from-eap-schema.patch
@@ -1,0 +1,14 @@
+# path prevents creating new VPN connections
+# https://gitlab.gnome.org/GNOME/libnma/-/commit/0ab5c1e39e94e158650da847f8512ab5e2b03593
+diff --git a/org.gnome.nm-applet.eap.gschema.xml.in b/org.gnome.nm-applet.eap.gschema.xml.in
+index 0fc3ca9f1f..f4a56ea672 100644
+--- a/org.gnome.nm-applet.eap.gschema.xml.in
++++ b/org.gnome.nm-applet.eap.gschema.xml.in
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <schemalist>
+-  <schema id="org.gnome.nm-applet.eap" path="/org/gnome/nm-applet/eap/" gettext-domain="nm-applet">
++  <schema id="org.gnome.nm-applet.eap" gettext-domain="nm-applet">
+     <key name="ignore-ca-cert" type="b">
+       <default>false</default>
+       <summary>Ignore CA certificate</summary>

--- a/srcpkgs/libnma/template
+++ b/srcpkgs/libnma/template
@@ -1,7 +1,7 @@
 # Template file for 'libnma'
 pkgname=libnma
 version=1.10.4
-revision=1
+revision=2
 build_style=meson
 build_helper="gir"
 configure_args="-Dlibnma_gtk4=true"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

The path in the EAP schema file is preventing people from creating new VPN connections.