### PR TITLE
libtool: fix include paths when cross compiling

### DIFF
--- a/srcpkgs/libtool/template
+++ b/srcpkgs/libtool/template
@@ -1,7 +1,7 @@
 # Template file for 'libtool'
 pkgname=libtool
 version=2.4.7
-revision=3
+revision=4
 build_style=gnu-configure
 hostmakedepends="texinfo perl automake help2man xz gnulib tar"
 depends="tar sed grep"
@@ -38,8 +38,8 @@ post_install() {
 	# things that need to go; the target libtool script is meant to be used
 	# in native environments, not in cross environments, so patch the script
 	if [ "$CROSS_BUILD" ]; then
-		# e.g. AR="armv7l-linux-gnueabihf-ar" becomes AR="${AR:=ar}"
-		vsed -i -e "s,\([A-Z]\+\)=\"${XBPS_CROSS_TRIPLET}\-\(.*\)\",\1=\$\{\1:=\2\},g" \
+		# e.g. AR="armv7l-linux-gnueabihf-ar" becomes AR="ar"
+		vsed -i -e "s,\([A-Z]\+\)=\"${XBPS_CROSS_TRIPLET}\-\(.*\)\",\1=\"\2\",g" \
 		 ${PKGDESTDIR}/usr/bin/libtool
 
 		# clear out any sysroot present
@@ -49,6 +49,20 @@ post_install() {
 		# clear out sysroot include path
 		vsed -i -e "s,\-I${XBPS_CROSS_BASE}/usr/include,,g" \
 		 ${PKGDESTDIR}/usr/bin/libtool
+
+		# Strip cross sysroot from paths
+		vsed -i -e "s,${XBPS_CROSS_BASE},,g" \
+		 ${PKGDESTDIR}/usr/bin/libtool
+
+		if [ "$XBPS_TARGET_WORDSIZE" = "64" ]; then
+			vsed -i \
+			 -e "s,/${XBPS_CROSS_TRIPLET}/lib/../lib64,/lib64,g" \
+			 ${PKGDESTDIR}/usr/bin/libtool
+		else
+			vsed -i \
+			 -e "s,/${XBPS_CROSS_TRIPLET}/lib,/lib,g" \
+			 ${PKGDESTDIR}/usr/bin/libtool
+		fi
 
 		# canonicalize host_alias, replace build(_alias,_os)
 		_canonical_host=$(grep "^host=" ${PKGDESTDIR}/usr/bin/libtool | sed 's/host=//')


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

@dkwo Can you test this? (whenever you are available ofc)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
