### PR TITLE
audacious: update to 4.2

### DIFF
--- a/srcpkgs/audacious/template
+++ b/srcpkgs/audacious/template
@@ -1,7 +1,7 @@
 # Template file for 'audacious'
 #Keep in sync with audacious-plugins!
 pkgname=audacious
-version=4.1
+version=4.2
 revision=1
 build_style=gnu-configure
 configure_args="$(vopt_enable gtk) $(vopt_enable qt) --enable-libarchive"
@@ -14,7 +14,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://audacious-media-player.org/"
 distfiles="https://distfiles.${pkgname}-media-player.org/${pkgname}-${version}.tar.bz2"
-checksum=1f58858f9789e867c513b5272987f13bdfb09332b03c2814ad4c6e29f525e35c
+checksum=feb304e470a481fe2b3c4ca1c9cb3b23ec262540c12d0d1e6c22a5eb625e04b3
 
 build_options="gtk qt"
 build_options_default="qt"


### PR DESCRIPTION
I've changed the version, alongside the checksum, and succesfully compiled and run the package. It will not launch without audacious-plugins, which I have also updated and succesfully compiled.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
-->

<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
-->
