### PR TITLE
dragon: name of executable file is the same as dragon-player's

### DIFF
--- a/srcpkgs/dragon/template
+++ b/srcpkgs/dragon/template
@@ -1,7 +1,7 @@
 # Template file for 'dragon'
 pkgname=dragon
 version=1.2.0
-revision=2
+revision=3
 build_style=gnu-makefile
 hostmakedepends="pkg-config"
 makedepends="gtk+3-devel"
@@ -13,6 +13,6 @@ distfiles="https://github.com/mwh/dragon/archive/v${version}.tar.gz"
 checksum=9bda28e96d715c759c8a1db754bdfde5e7d83671e13cd25a892f6b5e29357994
 
 do_install() {
-	vbin dragon
+	vbin dragon dragon-drop
 	vdoc README
 }


### PR DESCRIPTION
dragon (drag and drop) and dragon-player have the same name for their executable files (dragon). This changes dragon's executable file to dragon-drop so they can both be installed.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

