### PR TITLE
qt6ct: qt6ct.sh should not set QT_QPA_PLATFORMTHEME=qt5ct

### DIFF
--- a/srcpkgs/qt6ct/files/qt6ct.sh
+++ b/srcpkgs/qt6ct/files/qt6ct.sh
@@ -1,6 +1,9 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
-export QT_QPA_PLATFORMTHEME=qt5ct
+if [ "$XDG_CURRENT_DESKTOP" != "KDE" ]; then
+	export QT_QPA_PLATFORMTHEME=qt5ct
+fi
+
 if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 	export QT_QPA_PLATFORM=wayland
 fi

--- a/srcpkgs/qt6ct/template
+++ b/srcpkgs/qt6ct/template
@@ -1,7 +1,7 @@
 # Template file for 'qt6ct'
 pkgname=qt6ct
 version=0.7
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DQT_HOST_PATH=/usr"
 hostmakedepends="qt6-tools-devel"


### PR DESCRIPTION
qt6ct.sh should not set QT_QPA_PLATFORMTHEME=qt5ct unconditionally because it is already set in qt5ct.sh conditionally.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
