### PR TITLE
xdm: fix build with glibc 2.36

### DIFF
--- a/srcpkgs/xdm/patches/glibc-2.36.patch
+++ b/srcpkgs/xdm/patches/glibc-2.36.patch
@@ -1,0 +1,36 @@
+From 468b76023a2dfb750c4d5e9b184f230c5b6ec670 Mon Sep 17 00:00:00 2001
+From: Callum Farmer <gmbr3@opensuse.org>
+Date: Sun, 11 Sep 2022 12:57:05 +0100
+Subject: [PATCH] genauth: fix build with arc4random in glibc 2.36
+
+HAVE_ARC4RANDOM is defined under glibc 2.36 but this will attempt to include
+<bsd/stdlib.h> from libbsd instead of <stdlib.h> from glibc
+
+Signed-off-by: Callum Farmer <gmbr3@opensuse.org>
+---
+ xdm/genauth.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/xdm/genauth.c b/xdm/genauth.c
+index 38a0215..de7abfc 100644
+--- a/xdm/genauth.c
++++ b/xdm/genauth.c
+@@ -42,7 +42,15 @@ from The Open Group.
+ 
+ #ifdef HAVE_ARC4RANDOM
+ # ifdef __linux__
+-#  include <bsd/stdlib.h>
++#  if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
++#   if __GLIBC_PREREQ(2, 36)
++#    include <stdlib.h>
++#   else
++#    include <bsd/stdlib.h>
++#   endif
++#  else
++#   include <bsd/stdlib.h>
++#  endif
+ # else
+ #  include <stdlib.h>
+ # endif
+-- 
+GitLab


### PR DESCRIPTION
Refer to #39960.

[xdm.txt](https://github.com/void-linux/void-packages/files/10048371/xdm.txt)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
