### PR TITLE
libssh: update to 0.10.4, adopt

### DIFF
--- a/srcpkgs/libssh/template
+++ b/srcpkgs/libssh/template
@@ -1,18 +1,18 @@
 # Template file for 'libssh'
 pkgname=libssh
-version=0.9.6
+version=0.10.4
 revision=1
 build_style=cmake
 hostmakedepends="pkg-config python3"
 makedepends="zlib-devel openssl-devel cmocka-devel"
 checkdepends="openssh"
 short_desc="Multiplatform C library implementing the SSH v2 protocol"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="skmpz <dem.procopiou@gmail.com>"
 license="LGPL-2.1-or-later"
 homepage="https://www.libssh.org/"
-changelog="https://git.libssh.org/projects/libssh.git/plain/ChangeLog?h=stable-${version%.*}"
-distfiles="https://git.libssh.org/projects/libssh.git/snapshot/${pkgname}-${version}.tar.gz"
-checksum=63ddcb340e0898eb5c874418c1ff421cf90236fcb3fe5166675e79fa8a7511e4
+changelog="https://git.libssh.org/projects/libssh.git/plain/CHANGELOG"
+distfiles="https://git.libssh.org/projects/libssh.git/snapshot/libssh-${version}.tar.gz"
+checksum=c0c1f732a2f3d37f60889fa8d3a7a3b45e3b20cec3c96e1b2ffdf18ec2376968
 make_check=ci-skip # some tests fail when running as root
 
 case "$XBPS_TARGET_MACHINE" in


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
