### PR TITLE
libjpeg-turbo: update to 2.1.4.

### DIFF
--- a/srcpkgs/libjpeg-turbo/template
+++ b/srcpkgs/libjpeg-turbo/template
@@ -1,6 +1,6 @@
 # Template file for 'libjpeg-turbo'
 pkgname=libjpeg-turbo
-version=2.1.3
+version=2.1.4
 revision=1
 build_style=cmake
 configure_args="-DWITH_JPEG8=1 -DCMAKE_INSTALL_LIBDIR=/usr/lib"
@@ -10,8 +10,8 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="IJG, BSD-3-Clause, Zlib"
 homepage="https://libjpeg-turbo.org/"
 changelog="https://raw.githubusercontent.com/libjpeg-turbo/libjpeg-turbo/main/ChangeLog.md"
-distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=467b310903832b033fe56cd37720d1b73a6a3bd0171dbf6ff0b620385f4f76d0
+distfiles="${SOURCEFORGE_SITE}/libjpeg-turbo/libjpeg-turbo-${version}.tar.gz"
+checksum=d3ed26a1131a13686dfca4935e520eb7c90ae76fbc45d98bb50a8dc86230342b
 
 provides="jpeg-8_1"
 replaces="jpeg>=0"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
