### PR TITLE
libblockdev: update to 2.28.

### DIFF
--- a/srcpkgs/libblockdev/template
+++ b/srcpkgs/libblockdev/template
@@ -1,7 +1,7 @@
 # Template file for 'libblockdev'
 pkgname=libblockdev
-version=2.26
-revision=2
+version=2.28
+revision=1
 build_style=gnu-configure
 hostmakedepends="pkg-config python3"
 makedepends="cryptsetup-devel device-mapper-devel dmraid-devel libbytesize-devel
@@ -11,9 +11,10 @@ short_desc="Library for manipulating block devices"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="https://github.com/storaged-project/libblockdev"
-changelog="https://raw.githubusercontent.com/storaged-project/libblockdev/master/NEWS.rst"
+# changelog needs to be adjusted on major version changes
+changelog="https://raw.githubusercontent.com/storaged-project/libblockdev/2.x-branch/NEWS.rst"
 distfiles="https://github.com/storaged-project/libblockdev/releases/download/${version}-1/libblockdev-${version}.tar.gz"
-checksum=c4c0e10b35ac632bda8ce6d200b5601184984dec387fe59185921eb42432e069
+checksum=82c9c841e28a74fecadedebfae6a772df623cecdf652e5376650fa26da5b7df4
 conf_files="/etc/libblockdev/conf.d/10-lvm-dbus.cfg
  /etc/libblockdev/conf.d/00-default.cfg"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
