### PR TITLE
fakeroot: update to 1.29.

### DIFF
--- a/srcpkgs/fakeroot/patches/cross-dont-run-sysv-ipc-test.patch
+++ b/srcpkgs/fakeroot/patches/cross-dont-run-sysv-ipc-test.patch
@@ -27,7 +27,7 @@ diff --git a/configure.ac b/configure.ac
 index 73415d2..ddde5c9 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -25,42 +25,6 @@ AC_CACHE_CHECK([which IPC method to use],
+@@ -26,50 +26,6 @@ AC_CACHE_CHECK([which IPC method to use],
  	       [ac_cv_use_ipc],
  	       [ac_cv_use_ipc=sysv])
  
@@ -35,7 +35,7 @@ index 73415d2..ddde5c9 100644
 -  AC_MSG_CHECKING([whether SysV IPC message queues are actually working on the host])
 -
 -  AC_LANG_PUSH(C)
--  AC_TRY_RUN([
+-  AC_RUN_IFELSE([AC_LANG_SOURCE([[
 -#include <stdlib.h>
 -#include <sys/types.h>
 -#include <sys/ipc.h>
@@ -56,9 +56,17 @@ index 73415d2..ddde5c9 100644
 -    return 0;
 -  }
 -
--}], [ac_cv_use_ipc=sysv], [ac_cv_use_ipc=tcp])
+-}]])],[ac_cv_use_ipc=sysv],[ac_cv_use_ipc=tcp],[ac_cv_use_ipc=cross])
 -
--  if test $ac_cv_use_ipc = "tcp"; then
+-  if test $ac_cv_use_ipc = cross; then
+-    if test "$host_os" = linux-gnu; then
+-      ac_cv_use_ipc=sysv
+-      AC_MSG_RESULT([cross, guessing yes])
+-    else
+-      (set -o posix; set)
+-      AC_MSG_ERROR([cross compiling, unknown result for $host_os])
+-    fi
+-  elif test $ac_cv_use_ipc = "tcp"; then
 -    AC_MSG_RESULT([No, using TCP])
 -  else
 -    AC_MSG_RESULT([Yes])

--- a/srcpkgs/fakeroot/patches/do-not-redefine-id_t.patch
+++ b/srcpkgs/fakeroot/patches/do-not-redefine-id_t.patch
@@ -1,0 +1,23 @@
+musl defines id_t as unsigned but doesn't use the _ID_T to detect its
+definition. This causes the type to be redefined as an int by fakeroot
+which causes a compilation error.
+
+--
+Taken from Alpine Linux ports.
+
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -133,13 +133,6 @@
+ #define INT_SEND_STAT(a,b) SEND_STAT(a,b,_STAT_VER)
+ #define INT_SEND_GET_XATTR(a,b) SEND_GET_XATTR(a,b,_STAT_VER)
+ #define INT_SEND_GET_STAT(a,b) SEND_GET_STAT(a,b)
+-
+-/* 10.10 uses id_t in getpriority/setpriority calls, so pretend
+-   id_t is used everywhere, just happens to be int on some OSes */
+-#ifndef _ID_T
+-#define _ID_T
+-typedef int id_t;
+-#endif
+ #endif
+ 
+ #include <sys/types.h>

--- a/srcpkgs/fakeroot/patches/fakeroot-stdint.patch
+++ b/srcpkgs/fakeroot/patches/fakeroot-stdint.patch
@@ -1,5 +1,13 @@
 --- a/faked.c
 +++ b/faked.c
+@@ -121,6 +121,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <signal.h>
++#include <inttypes.h>
+ #ifdef HAVE_STDINT_H
+ # include <stdint.h>
+ #endif
 @@ -514,11 +514,11 @@
  
  #ifdef FAKEROOT_DB_PATH
@@ -32,3 +40,12 @@
              &stdev, &stino, &stmode, &stuid, &stgid, &stnlink, &strdev);
      if (r != 7)
        break;
+@@ -687,7 +688,7 @@ int load_database(const uint32_t remote)
+ /*                               */
+ /*********************************/
+ void debug_stat(const struct fakestat *st){
+-  fprintf(stderr,"dev:ino=(%llx:%lli), mode=0%lo, own=(%li,%li), nlink=%li, rdev=%lli\n",
++  fprintf(stderr,"dev:ino=(%"PRIx64":%"PRIu64"), mode=0%lo, own=(%li,%li), nlink=%li, rdev=%"PRIu64"\n",
+ 	  st->dev,
+ 	  st->ino,
+ 	  (long)st->mode,

--- a/srcpkgs/fakeroot/template
+++ b/srcpkgs/fakeroot/template
@@ -1,7 +1,7 @@
 # Template file for 'fakeroot'
 pkgname=fakeroot
-version=1.25.3
-revision=2
+version=1.29
+revision=1
 build_style=gnu-configure
 configure_args="--disable-static"
 hostmakedepends="automake libtool"
@@ -12,7 +12,7 @@ maintainer="Piraty <piraty1@inbox.ru>"
 license="GPL-3.0-or-later"
 homepage="https://salsa.debian.org/clint/fakeroot"
 distfiles="${DEBIAN_SITE}/main/f/fakeroot/${pkgname}_${version}.orig.tar.gz"
-checksum=8e903683357f7f5bcc31b879fd743391ad47691d4be33d24a76be3b6c21e956c
+checksum=8fbbafb780c9173e3ace4a04afbc1d900f337f3216883939f5c7db3431be7c20
 
 lib32disabled=yes
 
@@ -29,8 +29,9 @@ post_patch() {
 
 	# disable failing tests
 	#
-	# depends on chown which dosn't work in chroot
-	vsed -i test/Makefile.am -e '/  t\.tar/d'
+	# depends on chown which doesn't work in chroot
+	vsed -i test/Makefile.am \
+		-e '/  t\.tar/d'
 	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 		#mknod: Operation not permitted
 		vsed -i test/Makefile.am \
@@ -45,7 +46,7 @@ post_patch() {
 }
 
 pre_configure() {
-	sh ./bootstrap
+	./bootstrap
 }
 
 pre_check() {


### PR DESCRIPTION
This package was built with GCC 12 unless noted otherwise. No errors to report.

* [fakeroot.x86_64.txt](https://github.com/void-linux/void-packages/files/10051287/fakeroot.x86_64.txt)
* [fakeroot.x86_64-musl.txt](https://github.com/void-linux/void-packages/files/10051288/fakeroot.x86_64-musl.txt)
* [fakeroot.armv6l-musl-gcc10.2.txt](https://github.com/void-linux/void-packages/files/10051289/fakeroot.armv6l-musl-gcc10.2.txt)

Refer to #39960.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - armv6l-musl (crossbuild; GCC 10.2)
