### PR TITLE
android-tools: update to 33.0.3p1, fix update-check

### DIFF
--- a/srcpkgs/android-tools/template
+++ b/srcpkgs/android-tools/template
@@ -1,6 +1,6 @@
 # Template file for 'android-tools'
 pkgname=android-tools
-version=33.0.3
+version=33.0.3p1
 revision=1
 archs="armv* aarch64* x86_64* i686* ppc64le*"
 build_style=cmake
@@ -13,7 +13,7 @@ maintainer="John <me@johnnynator.dev>"
 license="Apache-2.0, ISC, GPL-2.0-only, MIT"
 homepage="http://developer.android.com/tools/help/adb.html"
 distfiles="https://github.com/nmeum/android-tools/releases/download/${version}/android-tools-${version}.tar.xz"
-checksum=8ce174dab781d5debd29ed0f96572231f777bee19b8ef3c167e33d3ea7670bc5
+checksum=be2047cf256051674af5aeb4bbfed276989512f80d1191e2864c919061f961d8
 
 if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"

--- a/srcpkgs/android-tools/update
+++ b/srcpkgs/android-tools/update
@@ -1,2 +1,2 @@
-site="https://android.googlesource.com/platform/system/core/+refs"
-pattern='platform-tools-\K[\d._r]+'
+site='https://github.com/nmeum/android-tools/tags'
+pattern='/tags/\K.*(?=.tar.gz")'


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

Ping @Johnnynator 

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
