### PR TITLE
base-files: don't include lib32 files for musl

### DIFF
--- a/srcpkgs/base-files/template
+++ b/srcpkgs/base-files/template
@@ -1,7 +1,7 @@
 # Template file for 'base-files'
 pkgname=base-files
 version=0.143
-revision=3
+revision=4
 bootstrap=yes
 depends="xbps-triggers"
 short_desc="Void Linux base system files"
@@ -46,8 +46,8 @@ do_install() {
 		ln -snrf "${DESTDIR}/usr/lib" \
 			"${DESTDIR}/${d}${XBPS_TARGET_WORDSIZE}"
 	done
-	# Populate 32-bit lib files on 64-bit systems, for multilib.
-	if [ "${XBPS_TARGET_WORDSIZE}" = "64" ]; then
+	# Populate 32-bit lib files on 64-bit glibc systems, for multilib.
+	if [ "${XBPS_TARGET_WORDSIZE}" = "64" ] && [ "${XBPS_TARGET_LIBC}" = "glibc" ]; then
 		vmkdir usr/lib32
 		ln -snrf "${DESTDIR}/usr/lib32" "${DESTDIR}/lib32"
 		ln -sf ../lib/locale "${DESTDIR}/usr/lib32/locale"


### PR DESCRIPTION
Multilib on Void is [already only supported on glibc](https://docs.voidlinux.org/xbps/repositories/index.html#subrepositories) and as per the musl libc FAQ [there is no ldconfig](https://wiki.musl-libc.org/faq.html) (`/bin/ldconfig: symbolic link to true`).

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
