### PR TITLE
EternalTerminal: update to 6.2.1.

### DIFF
--- a/srcpkgs/EternalTerminal/patches/disable-tests.patch
+++ b/srcpkgs/EternalTerminal/patches/disable-tests.patch
@@ -1,0 +1,30 @@
+--- a/EternalTerminal/CMakeLists.txt
++++ b/EternalTerminal/CMakeLists.txt
+@@ -519,17 +519,8 @@
+       ${CORE_LIBRARIES})
+   decorate_target(htmd)
+ 
+-  enable_testing()
+-
+-  file(GLOB TEST_SRCS test/*Test.cpp)
+-  add_executable(
+-  et-test
+-  ${TEST_SRCS}
+-  test/Main.cpp
+-  )
+-  add_dependencies(et-test TerminalCommon et-lib)
++  add_dependencies(TerminalCommon et-lib)
+   target_link_libraries(
+-    et-test
+     TerminalCommon
+     et-lib
+     ${CMAKE_THREAD_LIBS_INIT}
+@@ -539,8 +530,6 @@
+     ${UTEMPTER_LIBRARIES}
+     ${Boost_LIBRARIES}
+       ${CORE_LIBRARIES})
+-  add_test(et-test et-test)
+-  decorate_target(et-test)
+ 
+   if(FUZZING)
+     add_executable(

--- a/srcpkgs/EternalTerminal/patches/fix-cflags.patch
+++ b/srcpkgs/EternalTerminal/patches/fix-cflags.patch
@@ -1,17 +1,17 @@
 Index: EternalTerminal-et-v6.0.13/CMakeLists.txt
 ===================================================================
---- EternalTerminal-et-v6.0.13.orig/CMakeLists.txt
-+++ EternalTerminal-et-v6.0.13/CMakeLists.txt
-@@ -26,12 +26,6 @@ if(DISABLE_CRASH_LOG)
- SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DELPP_DISABLE_DEFAULT_CRASH_HANDLING")
- ENDIF(DISABLE_CRASH_LOG)
+--- a/EternalTerminal/CMakeLists.txt
++++ b/EternalTerminal/CMakeLists.txt
+@@ -187,12 +187,6 @@
+       "${CMAKE_CXX_FLAGS} -DELPP_DISABLE_DEFAULT_CRASH_HANDLING")
+ endif(DISABLE_CRASH_LOG)
  
 -if(UNIX)
 -  # Enable debug info
--  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -ggdb3")
--  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -ggdb3")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -ggdb3")
+-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -ggdb3")
 -endif()
 -
- # Enable C++-11
- set(CMAKE_CXX_STANDARD 11)
+ # Enable C++-17
+ set(CMAKE_CXX_STANDARD 17)
  set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/srcpkgs/EternalTerminal/template
+++ b/srcpkgs/EternalTerminal/template
@@ -1,17 +1,31 @@
 # Template file for 'EternalTerminal'
 pkgname=EternalTerminal
-version=6.0.13
-revision=7
+version=6.2.1
+revision=1
+# revisions used for the specific versions of submodules.
+# they can be found in the external/ directory of the source code.
+_sanitizers_gitrev="99e159ec9bc8dd362b08d18436bd40ff0648417b"
+_threadpool_gitrev="9a42ec1329f259a5f4881a291db1dcb8f2ad9040"
+build_wrksrc=${pkgname}
 build_style=cmake
+configure_args="-DDISABLE_VCPKG=ON -DDISABLE_TELEMETRY=ON -DDISABLE_SENTRY=ON"
 hostmakedepends="protobuf"
-makedepends="gflags-devel libsodium-devel protobuf-devel"
+makedepends="gflags-devel libsodium-devel protobuf-devel openssl-devel
+ zlib-devel"
 short_desc="Re-Connectable secure remote shell"
 maintainer="Nathan Owens <ndowens@artixlinux.org>"
 license="Apache-2.0"
 homepage="https://eternalterminal.dev/"
-distfiles="https://github.com/MisterTea/EternalTerminal/archive/et-v${version}.tar.gz"
-checksum=728c3a444d666897c710e33fe473d8d289263a59574451b13aa53ec3c6ac88b3
+distfiles="https://github.com/MisterTea/EternalTerminal/archive/et-v${version}.tar.gz
+ https://github.com/arsenm/sanitizers-cmake/archive/${_sanitizers_gitrev}.tar.gz
+ https://github.com/progschj/ThreadPool/archive/${_threadpool_gitrev}.tar.gz"
+checksum="fdf68a51cb8b62b3dbbacd1d2aeba5d5491e5142e65c97713c2f1ce61d4fdbed
+ f9cf386638f455c5d2e7a835b95941201387d2531b8682942d59827663b58341
+ 954e0ecdac1aa0da1e0fa78577ff0d352e53094df43762fbc1884f76a7e1dcd2"
 system_accounts="_eternal"
+# UnixSocketHandler.cpp:53 Error reading: 104 Connection reset by peer
+# SocketHandler.cpp:91 Failed a call to writeAll: Broken pipe
+make_check=no
 
 LDFLAGS="-lgflags"
 
@@ -19,11 +33,26 @@ if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"
 fi
 
+if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
+	makedepends+=" libatomic-devel"
+fi
+
+post_extract() {
+	mv EternalTerminal-et-v${version} ${build_wrksrc}
+	mv sanitizers-cmake-${_sanitizers_gitrev}/* \
+		${build_wrksrc}/external/sanitizers-cmake
+	mv ThreadPool-${_threadpool_gitrev}/* ${build_wrksrc}/external/ThreadPool
+}
+
 post_patch() {
 	if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 		# Use external libexecinfo
 		vsed -i CMakeLists.txt \
-			-e '/execinfo/!s/CORE_LIBRARIES util resolv/& execinfo/'
+			-e '/execinfo/!s/CORE_LIBRARIES$/& execinfo/'
+	fi
+	if [ -z "$XBPS_TARGET_NO_ATOMIC8" ]; then
+		# Remove libatomic from LD if target arch supports atomics
+		vsed -e '/  atomic$/d' -i CMakeLists.txt
 	fi
 }
 


### PR DESCRIPTION
This package was built with GCC 12 unless noted otherwise. No errors to report.

* [eternalterminal-x86_64.txt](https://github.com/void-linux/void-packages/files/10057240/eternalterminal-x86_64.txt)
* [eternalterminal-x86_64-musl.txt](https://github.com/void-linux/void-packages/files/10057241/eternalterminal-x86_64-musl.txt)
* [eternalterminal-armv6l-musl-gcc10.txt](https://github.com/void-linux/void-packages/files/10057238/eternalterminal-armv6l-musl-gcc10.txt)

Refer to #39960.

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - x86_64
  - armv6l-musl (cross; GCC 10.2)
