### PR TITLE
python3-cypari2: reenable full testsuite

### DIFF
--- a/srcpkgs/python3-cypari2/template
+++ b/srcpkgs/python3-cypari2/template
@@ -15,5 +15,7 @@ distfiles="https://github.com/sagemath/cypari2/archive/refs/tags/${version}.tar.
 checksum=6f6f6ca2b2c2dbef4444727e8fb8652b090cfac4297ba959e94b3a91bbd86548
 
 do_check() {
-	PYTHONPATH=$(cd build/lib* && pwd) pytest
+	# Please do not disable this custom check;
+	# This will run many more tests than just running pytest
+	PYTHONPATH=$(cd build/lib* && pwd) make check
 }


### PR DESCRIPTION
Note that running pytest will run a few tests, but running `make check` will run many more tests (including all the pytest tests).

No need to revbump as there are no changes to package itself.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
