### PR TITLE
ruby-build: update to 20221124.

### DIFF
--- a/srcpkgs/ruby-build/template
+++ b/srcpkgs/ruby-build/template
@@ -1,6 +1,6 @@
 # Template file for 'ruby-build'
 pkgname=ruby-build
-version=20211227
+version=20221124
 revision=1
 depends="bash"
 short_desc="Compile and install Ruby"
@@ -8,7 +8,7 @@ maintainer="b-l-a-i-n-e <blaine.gilbreth@gmail.com>"
 license="MIT"
 homepage="https://github.com/rbenv/ruby-build"
 distfiles="https://github.com/rbenv/ruby-build/archive/refs/tags/v${version}.tar.gz"
-checksum=7a07eae6d6948f79a8ffecd7a493fb887e10326c429fe55cfe1bda65146db824
+checksum=4fb3817ee0ecc2c46cce526a4b07fe97dfa56975a1767a4d454bc4c3afbc60cf
 
 do_install() {
 	vbin bin/ruby-build


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64-musl