### PR TITLE
element-desktop: update to 1.11.15.

### DIFF
--- a/srcpkgs/element-desktop/template
+++ b/srcpkgs/element-desktop/template
@@ -1,6 +1,6 @@
 # Template file for 'element-desktop'
 pkgname=element-desktop
-version=1.11.14
+version=1.11.15
 revision=1
 create_wrksrc=yes
 conf_files="/etc/${pkgname}/config.json"
@@ -15,10 +15,10 @@ maintainer="Jan Christian Grünhage <jan.christian@gruenhage.xyz>"
 license="Apache-2.0"
 homepage="https://element.io"
 changelog="https://raw.githubusercontent.com/vector-im/element-desktop/develop/CHANGELOG.md"
-distfiles="https://github.com/vector-im/element-desktop/archive/v${version}.tar.gz>element-desktop.tar.gz
- https://github.com/vector-im/element-web/archive/v${version}.tar.gz>element-web.tar.gz"
-checksum="ceda8fee7a4abc842c02db07bf7b4f4949b6663589527a26b4345d3a40e92016
- a822cba13112f1a23aacf4d801026ced6260e7c9514c44ab7453fd162839c8b1"
+distfiles="https://github.com/vector-im/element-desktop/archive/v${version}.tar.gz>element-desktop-v${version}.tar.gz
+ https://github.com/vector-im/element-web/archive/v${version}.tar.gz>element-web-v${version}.tar.gz"
+checksum="29cf841c2a8a1ab38272fcd515c20a6c7b269f74d34ac95a00ed895c40786213
+ f39c2524cb94d75d54328ccbe995621784be96b698220e43825d445f7a5d3127"
 
 export USE_SYSTEM_APP_BUILDER=true
 
@@ -42,7 +42,7 @@ post_patch() {
 	jq '.update_base_url = ""' element.io/app/config.json | sponge element.io/app/config.json
 
 	cd ../${pkgname}
-	vsed -i 's/"target": "deb"/"target": "dir"/g' package.json
+	jq '.build.linux.target = ["dir"]' package.json | sponge package.json
 }
 
 pre_build() {


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**


I'm a bit unhappy about the two `jq` lines. Working with `vsed` wouldn't have been any easier here, but checking that the file actually changes with something like `vjq` would make me a lot happier. Any opinions on that?

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
