### PR TITLE
New package: ibus-chewing

### DIFF
--- a/srcpkgs/ibus-chewing/template
+++ b/srcpkgs/ibus-chewing/template
@@ -1,0 +1,26 @@
+# Template file for 'ibus-chewing'
+pkgname=ibus-chewing
+version=1.5.2
+revision=1
+archs="x86_64"
+build_wrksrc=ibus-chewing-1-${version}
+build_style=cmake
+configure_args="-DLIBEXEC_DIR=/usr/libexec"
+make_cmd=make
+hostmakedepends="git cmake pkg-config findutils gettext-devel"
+makedepends="libchewing-devel ibus-devel gob2 libX11-devel gtk+3-devel glib-devel"
+depends="ibus libchewing"
+short_desc="Chewing input method for ibus"
+maintainer="ctoid <funk443@yandex.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/definite/ibus-chewing"
+distfiles="https://github.com/funk443/ibus-chewing-1/archive/refs/tags/${version}.tar.gz https://pagure.io/cmake-fedora/archive/2.9.3/cmake-fedora-2.9.3.tar.gz"
+checksum="ea1c750dd1bda11f67870cf102d176a34d0759f27121985f12c86593c09c465b
+ 291b6d6ea1381d6d7f7d49e9b9a6f5ca5cbfeaed81b58f591dfcd0781e5de68c"
+nocross=yes
+make_check=no  # No idea how to fix
+
+pre_configure() {
+	mv ../cmake-fedora-2.9.3/* ./cmake-fedora
+	export CMAKE_GENERATOR="Unix Makefiles"
+}


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, x86_64-glibc

