### PR TITLE
octave: update to 7.3.0.

### DIFF
--- a/srcpkgs/octave/template
+++ b/srcpkgs/octave/template
@@ -1,20 +1,24 @@
 # Template file for 'octave'
 pkgname=octave
-version=6.3.0
+version=7.3.0
 revision=1
 build_style=gnu-configure
-hostmakedepends="perl gcc-fortran pkg-config gnuplot texinfo texlive-dvi tar"
+configure_args="--disable-docs"
+hostmakedepends="perl gcc-fortran pkg-config"
 makedepends="pcre-devel readline-devel libSM-devel libltdl-devel lcms2-devel
- glpk-devel"
-depends="$(vopt_if gui qt5-plugin-sqlite) texinfo"
-checkdepends="zip unzip"
+ glpk-devel SuiteSparse-devel rapidjson"
+depends="$(vopt_if gui qt5-plugin-sqlite)"
+checkdepends="zip unzip ghostscript gnuplot tar texinfo"
 short_desc="High-level language, primarily intended for numerical computations"
 maintainer="Diogo Leal <diogo@diogoleal.com>"
 license="GPL-3.0-or-later"
 homepage="https://gnu.org/software/octave/"
-changelog="https://www.gnu.org/software/octave/NEWS-6.1.html"
+changelog="https://www.gnu.org/software/octave/NEWS-7.html"
 distfiles="${GNU_SITE}/octave/octave-${version}.tar.gz"
-checksum=232065f3a72fc3013fe9f17f429a3df69d672c1f6b6077029a31c8f3cd58a66e
+checksum=6e14a4649d70af45ab660f8cbbf645aaf1ec33f25f88bfda4697cb17e440c4f5
+
+# avoid warnings due to egrep deprecation
+export EGREP="grep -E"
 
 # Use OpenBLAS on platforms where it is available and fallback to regular BLAS
 # on all others.
@@ -22,29 +26,40 @@ case "$XBPS_TARGET_MACHINE" in
 	# List of supported architectures copied from openblas.
 	armv[67]*|aarch64*|i686*|x86_64*|ppc64*)
 		makedepends+=" openblas-devel"
-		configure_args=" --with-blas=openblas --with-lapack=openblas"
+		configure_args+=" --with-blas=openblas --with-lapack=openblas"
 		;;
 	*)
 		makedepends+=" blas-devel lapack-devel"
 		;;
 esac
 
+case $XBPS_TARGET_MACHINE in
+	i686*)
+	# spqr is broken on i686; running `qr(sparse(1,1))` yields a segfault:
+	#
+	#		octave:1> qr(sparse(1,1));
+	#		fatal: caught signal Segmentation fault -- stopping myself...
+	#		Segmentation fault
+	#
+	configure_args+=" --without-spqr"
+	;;
+esac
+
 # Package build options
-# TODO: some options are still missing, such as
-# java, qrupdate, suitesparse
+# TODO: some options are still missing, such as java, qrupdate
 build_options="
-	arpack
-	audio
-	curl
-	fftw3
-	graphicsmagick
-	gui
-	hdf5
-	imagemagick
-	opengl
-	openmp
-	qhull
-	zlib"
+ arpack
+ audio
+ curl
+ fftw3
+ graphicsmagick
+ gui
+ hdf5
+ imagemagick
+ opengl
+ openmp
+ qhull
+ zlib"
 
 vopt_conflict graphicsmagick imagemagick
 
@@ -61,31 +76,42 @@ desc_option_openmp="Enable support for OpenMP SMP multi-threading"
 desc_option_zlib="Support for compressed data."
 
 build_options_default="
-	arpack
-	audio
-	curl
-	fftw3
-	graphicsmagick
-	gui
-	hdf5
-	opengl
-	openmp
-	qhull
-	zlib"
+ arpack
+ audio
+ curl
+ fftw3
+ graphicsmagick
+ gui
+ opengl
+ openmp
+ qhull
+ zlib"
+
+if [ -z "$CROSS_BUILD" ]; then
+	# hdf5 is nocross
+	build_options_default+=" hdf5"
+fi
+
+if [ -n "$CROSS_BUILD" ];then
+	# cross build cannot determine integer size for BLAS
+	# our BLAS (lapack and openblas) are built with 32 bit ints
+	# even in 64 bit architectures
+	configure_args+=" ax_blas_integer_size=4"
+fi
 
 makedepends+="
-	$(vopt_if arpack arpack-ng-devel)
-	$(vopt_if audio 'libsndfile-devel portaudio-devel')
-	$(vopt_if curl libcurl-devel)
-	$(vopt_if fftw3 fftw-devel)
-	$(vopt_if graphicsmagick libgraphicsmagick-devel)
-	$(vopt_if gui 'qt5-devel qt5-plugin-sqlite qscintilla-qt5-devel qt5-tools-devel')
-	$(vopt_if hdf5 hdf5-devel)
-	$(vopt_if imagemagick libmagick-devel)
-	$(vopt_if opengl "glu-devel fltk-devel fontconfig-devel freetype-devel gl2ps-devel")
-	$(vopt_if openmp libgomp-devel)
-	$(vopt_if qhull libqhull-devel)
-	$(vopt_if zlib zlib-devel)"
+ $(vopt_if arpack arpack-ng-devel)
+ $(vopt_if audio 'libsndfile-devel portaudio-devel')
+ $(vopt_if curl libcurl-devel)
+ $(vopt_if fftw3 fftw-devel)
+ $(vopt_if graphicsmagick libgraphicsmagick-devel)
+ $(vopt_if gui 'qt5-devel qt5-plugin-sqlite qscintilla-qt5-devel qt5-tools-devel')
+ $(vopt_if hdf5 hdf5-devel)
+ $(vopt_if imagemagick libmagick-devel)
+ $(vopt_if opengl "glu-devel fltk-devel fontconfig-devel freetype-devel gl2ps-devel")
+ $(vopt_if openmp libgomp-devel)
+ $(vopt_if qhull libqhull-devel)
+ $(vopt_if zlib zlib-devel)"
 
 case "$XBPS_TARGET_MACHINE" in
 	ppc64*) ;;
@@ -100,4 +126,14 @@ post_install() {
 	# add helper to launch octave from dmenu etc.
 	printf "#!/bin/sh\noctave --gui" > octave-gui
 	vbin octave-gui
+
+	# install man pages
+	for f in doc/*/*.1; do
+		vman $f
+	done
+
+	# install info files
+	vmkdir usr/share/info
+	touch ${DESTDIR}/usr/share/info/dir
+	vcopy "doc/*/*.info*" usr/share/info
 }

--- a/srcpkgs/rapidjson/patches/5d9d0f78b53dd8cd1ec757fd8ef07211ee114161.patch
+++ b/srcpkgs/rapidjson/patches/5d9d0f78b53dd8cd1ec757fd8ef07211ee114161.patch
@@ -1,0 +1,13 @@
+See: https://github.com/Tencent/rapidjson/pull/909
+
+--- a/include/rapidjson/prettywriter.h
++++ b/include/rapidjson/prettywriter.h
+@@ -47,7 +47,7 @@ enum PrettyFormatOptions {
+ template<typename OutputStream, typename SourceEncoding = UTF8<>, typename TargetEncoding = UTF8<>, typename StackAllocator = CrtAllocator, unsigned writeFlags = kWriteDefaultFlags>
+ class PrettyWriter : public Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator, writeFlags> {
+ public:
+-    typedef Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator> Base;
++    typedef Writer<OutputStream, SourceEncoding, TargetEncoding, StackAllocator, writeFlags> Base;
+     typedef typename Base::Ch Ch;
+ 
+     //! Constructor

--- a/srcpkgs/rapidjson/template
+++ b/srcpkgs/rapidjson/template
@@ -1,7 +1,7 @@
 # Template file for 'rapidjson'
 pkgname=rapidjson
 version=1.1.0
-revision=4
+revision=5
 build_style=cmake
 short_desc="Fast JSON parser/generator for C++ with both SAX/DOM style API"
 maintainer="Alexander Egorenkov <egorenar-dev@posteo.net>"


### PR DESCRIPTION
- Fix cross build
- Use SuiteSparse
- Use rapidjson
- Use --disable-docs to skip building docs, instead install the docs in
  the tarball. This way we don't need texlive/texinfo/gnuplot to build.
- Avoid warnings due to egrep deprecation
- xlint fixes


<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

---

I wonder if we really want all those build options. I am tempted to remove almost all of them.

I also wonder if the choice of `GraphicsMagick` over `ImageMagick` is the best one.

NOTE: this PR includes #39846 for the current SuiteSparse. Could work with the current SuiteSparse, but I didn't try (#39846 is ready to merge IMO; the CI failures in that PR are addressed in the comments)

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
