### PR TITLE
jsoncpp: update to 1.9.5.

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1324,7 +1324,7 @@ libspeechd.so.2 speech-dispatcher-0.8_1
 libre2.so.7 re2-2020.06.01_1
 libminizip.so.1 minizip-1.2.7_1
 libsrtp2.so.1 libsrtp-2.1.0_1
-libjsoncpp.so.24 jsoncpp-1.9.4_1
+libjsoncpp.so.25 jsoncpp-1.9.5_1
 libesmtp.so.6 libesmtp-1.0.6_21
 libcaca.so.0 libcaca-0.99.beta18_3
 libcaca++.so.0 libcaca-0.99.beta18_3

--- a/srcpkgs/LGOGDownloader/template
+++ b/srcpkgs/LGOGDownloader/template
@@ -1,7 +1,7 @@
 # Template file for 'LGOGDownloader'
 pkgname=LGOGDownloader
 version=3.9
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="htmlcxx-devel tinyxml2-devel libcurl-devel rhash-devel

--- a/srcpkgs/Waybar/template
+++ b/srcpkgs/Waybar/template
@@ -1,7 +1,7 @@
 # Template file for 'Waybar'
 pkgname=Waybar
 version=0.9.13
-revision=3
+revision=4
 _date_version=3.0.0
 create_wrksrc=yes
 build_style=meson

--- a/srcpkgs/cmake-gui/template
+++ b/srcpkgs/cmake-gui/template
@@ -1,7 +1,7 @@
 # Template file for 'cmake-gui'
 pkgname=cmake-gui
 version=3.24.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DCMAKE_DOC_DIR=/share/doc/cmake
  -DSPHINX_MAN=1 -DCMAKE_MAN_DIR=/share/man

--- a/srcpkgs/cmake/template
+++ b/srcpkgs/cmake/template
@@ -1,7 +1,7 @@
 # Template file for 'cmake'
 pkgname=cmake
 version=3.24.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DCMAKE_DOC_DIR=/share/doc/cmake
  -DSPHINX_MAN=1 -DCMAKE_MAN_DIR=/share/man

--- a/srcpkgs/jsoncpp/template
+++ b/srcpkgs/jsoncpp/template
@@ -1,14 +1,14 @@
 # Template file for 'jsoncpp'
 pkgname=jsoncpp
-version=1.9.4
-revision=2
+version=1.9.5
+revision=1
 build_style=meson
 short_desc="JSON implementation in C++"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="Public Domain, MIT"
 homepage="https://github.com/open-source-parsers/jsoncpp"
-distfiles="https://github.com/open-source-parsers/${pkgname}/archive/${version}.tar.gz"
-checksum=e34a628a8142643b976c7233ef381457efad79468c67cb1ae0b83a33d7493999
+distfiles="https://github.com/open-source-parsers/jsoncpp/archive/${version}.tar.gz"
+checksum=f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2
 
 CXXFLAGS="-D_GLIBCXX_USE_C99_STDIO=1"
 

--- a/srcpkgs/libopenshot/template
+++ b/srcpkgs/libopenshot/template
@@ -1,7 +1,7 @@
 # Template file for 'libopenshot'
 pkgname=libopenshot
 version=0.2.7
-revision=2
+revision=3
 build_style=cmake
 # Builds fail with Ruby-2.4.1
 configure_args="-DENABLE_RUBY=OFF -DUSE_SYSTEM_JSONCPP=ON"

--- a/srcpkgs/polybar/template
+++ b/srcpkgs/polybar/template
@@ -1,7 +1,7 @@
 # Template file for 'polybar'
 pkgname=polybar
 version=3.6.3
-revision=1
+revision=2
 build_style=cmake
 configure_args="-DBUILD_CONFIG=OFF -DBUILD_DOC_HTML=OFF
  $(vopt_bool alsa ENABLE_ALSA)

--- a/srcpkgs/sysdig/template
+++ b/srcpkgs/sysdig/template
@@ -1,7 +1,7 @@
 # Template file for 'sysdig'
 pkgname=sysdig
 version=0.28.0
-revision=7
+revision=8
 build_style=cmake
 configure_args="-DSYSDIG_VERSION=${version} -DUSE_BUNDLED_DEPS=OFF
  -DUSE_BUNDLED_B64=ON -DUSE_BUNDLED_JQ=ON -DBUILD_DRIVER=OFF

--- a/srcpkgs/upmpdcli/template
+++ b/srcpkgs/upmpdcli/template
@@ -1,7 +1,7 @@
 # Template file for 'upmpdcli'
 pkgname=upmpdcli
 version=1.6.1
-revision=1
+revision=2
 build_style=gnu-configure
 hostmakedepends="pkg-config tar"
 makedepends="jsoncpp-devel libmicrohttpd-devel libmpdclient-devel libupnpp-devel"

--- a/srcpkgs/vtk/template
+++ b/srcpkgs/vtk/template
@@ -1,7 +1,7 @@
 # Template file for 'vtk'
 pkgname=vtk
 version=9.0.1
-revision=8
+revision=9
 build_style=cmake
 # vtk can be huge, especially with -DVTK_BUILD_ALL_MODULES=ON"
 # Build only the core modules plus python bindings for now


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built all the changed packages for the following architectures:
  - x86_64 (+ tests)
  - i686  (+ tests)
  - aarch64 (cross on x86_64)
  - armv7l (cross on x86_64)
  - x86_64-musl  (+ tests)
  - aarch64-musl (cross on x86_64-musl)
  - armv6l-musl (cross on x86_64-musl)

- Except **sysdig** and **vtk** which are marked nocross, so were built for:
  - x86_64 (+ tests)
  - i686  (+ tests)
  - x86_64-musl  (+ tests)

[ci skip]