### PR TITLE
linux-firmware-dvb: remove now unnecessary license files

### DIFF
--- a/srcpkgs/linux-firmware-dvb/template
+++ b/srcpkgs/linux-firmware-dvb/template
@@ -1,7 +1,7 @@
 # Template file for 'linux-firmware-dvb'
 pkgname=linux-firmware-dvb
 version=20170329
-revision=5
+revision=6
 _gitrev=3fef04a4a4bfeba88ae3b20aff9d3a1fabf1c159
 short_desc="Linux TV firmware package"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -29,13 +29,11 @@ do_build() {
 do_install() {
 	local dir f licenses firmwares
 
-	licenses+=" LICENCE.go7007"
 	licenses+=" LICENCE.siano"
 	licenses+=" LICENCE.xc5000"
 	licenses+=" LICENSE.dib0700"
 	firmwares+=" NXP7164-2010-03-10.1.fw"
 	firmwares+=" NXP7164-2010-04-01.1.fw"
-	licenses+=" README.as102"
 	firmwares+=" af9005.fw"
 	firmwares+=" bootcode.bin"
 	firmwares+=" drxd-a2-1.1.fw"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)

With the latest revision 5 I've removed firmware but forgot to remove the license files.

This PR does remove the no longer necessary files.