### PR TITLE
New package: qsv-0.70.0.

### DIFF
--- a/srcpkgs/qsv/template
+++ b/srcpkgs/qsv/template
@@ -1,0 +1,14 @@
+# Template file for 'qsv'
+pkgname=qsv
+version=0.70.0
+revision=1
+build_style=cargo
+configure_args="--no-default-features --features=full"
+make_check_args="-- --skip test_sample::sample_seed" # fails in i686
+short_desc="CLI toolkit for CSV data-wrangling"
+maintainer="icp <pangolin@vivaldi.net>"
+license="Unlicense"
+homepage="https://github.com/jqnatividad/qsv"
+changelog="https://raw.githubusercontent.com/jqnatividad/qsv/master/CHANGELOG.md"
+distfiles="https://github.com/jqnatividad/qsv/archive/refs/tags/${version}.tar.gz"
+checksum=e49dcc2060925fd600c1b2f1dee4fbf8a6874f8749c4838f446cda2038bcba04


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

I was not quite sure whether to submit `qsv` as a new package or rename `xsv`. I went with the later option for now as their [README](https://github.com/jqnatividad/qsv/blob/0.70.0/README.md) states:

> NOTE: qsv is a fork of the popular [xsv](https://github.com/BurntSushi/xsv) utility, merging several pending PRs https://github.com/BurntSushi/xsv/issues/267. On top of xsv's 20 commands, it adds numerous new features, 28 additional commands, 6 apply subcommands & 33 apply operations (for a total of 87). See [FAQ](https://github.com/jqnatividad/qsv/discussions/categories/faq) for more details.

cc: @leahneukirchen 