### PR TITLE
mercurial: update to 6.3.1.

### DIFF
--- a/srcpkgs/mercurial/template
+++ b/srcpkgs/mercurial/template
@@ -3,7 +3,7 @@ pkgname=mercurial
 version=6.3.1
 revision=1
 build_style=python3-module
-hostmakedepends="python3 python3-setuptools python3-devel gettext"
+hostmakedepends="python3 python3-setuptools python3-devel gettext git"
 makedepends="python3-devel"
 depends="python3 ca-certificates"
 # cvs tests fail

--- a/srcpkgs/mercurial/template
+++ b/srcpkgs/mercurial/template
@@ -1,7 +1,7 @@
 # Template file for 'mercurial'
 pkgname=mercurial
-version=6.2.3
-revision=2
+version=6.3.1
+revision=1
 build_style=python3-module
 hostmakedepends="python3 python3-setuptools python3-devel gettext"
 makedepends="python3-devel"
@@ -14,7 +14,7 @@ maintainer="dataCobra <datacobra@thinkbot.de>"
 license="GPL-2.0-or-later"
 homepage="https://www.mercurial-scm.org/"
 distfiles="https://www.mercurial-scm.org/release/mercurial-${version}.tar.gz"
-checksum=98d1ae002f68adf53d65c5947fe8b7a379f98cf05d9b8ea1f4077d2ca5dce9db
+checksum=6c39ab8732948d89cf1208751dd7d85d4042aa82153977451b9eb13367585072
 
 pre_check() {
 	if [ "$XBPS_TARGET_LIBC" = musl ]; then


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl (crossbuild)
  - armv7l (crossbuild)
  - armv6l-musl (crossbuild)
  - i686 (crossbuild)

This version does also fix some issues with Python 3.11.