### PR TITLE
wezterm: default to system monospace font

### DIFF
--- a/srcpkgs/wezterm/patches/monospace.patch
+++ b/srcpkgs/wezterm/patches/monospace.patch
@@ -1,0 +1,11 @@
+--- a/config/src/font.rs	2022-09-05 10:28:02.000000000 -0700
++++ b/config/src/font.rs	2022-11-24 11:27:15.115251410 -0700
+@@ -407,7 +407,7 @@
+ impl Default for FontAttributes {
+     fn default() -> Self {
+         Self {
+-            family: "JetBrains Mono".into(),
++            family: "monospace".into(),
+             weight: FontWeight::default(),
+             stretch: FontStretch::default(),
+             style: FontStyle::Normal,

--- a/srcpkgs/wezterm/template
+++ b/srcpkgs/wezterm/template
@@ -1,7 +1,7 @@
 # Template file for 'wezterm'
 pkgname=wezterm
 version=20221119
-revision=1
+revision=2
 _srcver=${version}-145034-49b9839f
 archs="x86_64* i686* aarch64* arm*" # ring
 build_style=cargo
@@ -27,7 +27,9 @@ do_check() {
 	cargo test --target ${RUST_TARGET} --workspace --locked -- \
 		--skip e2e::sftp \
 		--skip escape::action_size \
-		--skip surface::line::storage::test::memory_usage
+		--skip surface::line::storage::test::memory_usage \
+		--skip shapecache::test::ligatures_fira \
+		--skip shapecache::test::ligatures_jetbrains
 }
 
 do_install() {


### PR DESCRIPTION
#### Details
This patches Wezterm to always select the `monospace` font; as opposed to requiring the `JetBrains Mono` font.

#### Testing
- I tested the changes in this PR: **YES**

I tested the modifications on Void x86_64-musl, ensured no user fonts were installed - which by proxy include no `JetBrains Mono`.

#### References
See: #40736
