### PR TITLE
rust-sccache: update to 0.3.1.

### DIFF
--- a/srcpkgs/rust-sccache/template
+++ b/srcpkgs/rust-sccache/template
@@ -1,8 +1,10 @@
 # Template file for 'rust-sccache'
 pkgname=rust-sccache
-version=0.2.13
-revision=3
+version=0.3.1
+revision=1
 build_style=cargo
+# fails in musl
+make_check_args="-- --skip dist::pkg::toolchain_imp::test_ldd_parse_v2_30"
 hostmakedepends="pkg-config"
 makedepends="openssl-devel"
 short_desc="Sccache is a ccache-like tool"
@@ -10,7 +12,7 @@ maintainer="Enno Boland <gottox@voidlinux.org>"
 license="Apache-2.0"
 homepage="https://crates.io/crates/sccache"
 distfiles="https://static.crates.io/crates/sccache/sccache-${version}.crate"
-checksum=34b8eaab25eb467e9796c2f3ad7524c8548bf3afed962a922dd0b40ed2472ef7
+checksum=10ee186f1d2f069ce3c62a2995b3cb50a6671b13d65dfbd35d3f62591040184d
 
 case "$XBPS_TARGET_MACHINE" in
 	x86_64*|i686*|arm*|aarch64*) ;;
@@ -18,6 +20,12 @@ case "$XBPS_TARGET_MACHINE" in
 esac
 
 pre_build() {
-	# fixes an indexmap error when cross compiling
-	cargo update --package autocfg:0.1.7 --precise 0.1.8
+	# fixes the usage of yanked versions of crates
+	cargo update --package cpufeatures:0.2.1 --precise 0.2.5
+	cargo update --package textwrap:0.15.1 --precise 0.15.2
+}
+
+pre_check() {
+	# tries to spawn /usr/bin/cargo and fails
+	rm -f tests/sccache_cargo.rs
 }


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

supersedes https://github.com/void-linux/void-packages/pull/39767