### PR TITLE
fluidsynth, libcanberra, qt5, sox, vlc: add build option for pulseaudio

### DIFF
--- a/srcpkgs/fluidsynth/template
+++ b/srcpkgs/fluidsynth/template
@@ -5,15 +5,20 @@ revision=1
 build_style=cmake
 make_check_target=check
 configure_args="-DLIB_SUFFIX=
- -DDEFAULT_SOUNDFONT:STRING=/usr/share/soundfonts/default.sf2"
+ -DDEFAULT_SOUNDFONT:STRING=/usr/share/soundfonts/default.sf2
+ $(vopt_bool pulseaudio enable-pulseaudio)"
 hostmakedepends="pkg-config"
-makedepends="SDL2-devel glib-devel jack-devel libsndfile-devel pipewire-devel pulseaudio-devel readline-devel"
+makedepends="SDL2-devel glib-devel jack-devel libsndfile-devel pipewire-devel readline-devel
+ $(vopt_if pulseaudio pulseaudio-devel)"
 short_desc="Real-time software synthesizer based on the SoundFont 2 specifications"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="LGPL-2.1-or-later"
 homepage="http://www.fluidsynth.org/"
 distfiles="https://github.com/FluidSynth/fluidsynth/archive/v${version}.tar.gz"
 checksum=1df5a1afb91acf3b945b7fdb89ac0d99877622161d9b5155533da59113eaaa20
+
+build_options="pulseaudio"
+build_options_default="pulseaudio"
 
 libfluidsynth_package() {
 	short_desc+=" - runtime library"

--- a/srcpkgs/libcanberra/template
+++ b/srcpkgs/libcanberra/template
@@ -4,11 +4,11 @@ version=0.30
 revision=11
 build_style=gnu-configure
 configure_args="--enable-alsa --enable-null --disable-lynx
- --enable-gstreamer --disable-oss --with-builtin=dso"
+ --enable-gstreamer --disable-oss --with-builtin=dso $(vopt_enable pulseaudio pulse)"
 hostmakedepends="automake libtool gettext-devel pkg-config intltool gtk-doc"
 makedepends="
  gtk+-devel gtk+3-devel libvorbis-devel libltdl-devel
- gstreamer1-devel alsa-lib-devel tdb-devel pulseaudio-devel
+ gstreamer1-devel alsa-lib-devel tdb-devel $(vopt_if pulseaudio pulseaudio-devel)
  eudev-libudev-devel vala-devel"
 short_desc="XDG Sound Theme and Name Specification library implementation"
 maintainer="Orphaned <orphan@voidlinux.org>"
@@ -16,6 +16,9 @@ license="LGPL-2.1-or-later"
 homepage="http://0pointer.de/lennart/projects/libcanberra/"
 distfiles="http://pkgs.fedoraproject.org/repo/pkgs/libcanberra/libcanberra-${version}.tar.xz/34cb7e4430afaf6f447c4ebdb9b42072/libcanberra-${version}.tar.xz"
 checksum=c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72
+
+build_options="pulseaudio"
+build_options_default="pulseaudio"
 
 pre_configure() {
 	autoreconf -if

--- a/srcpkgs/qt5/template
+++ b/srcpkgs/qt5/template
@@ -9,12 +9,12 @@ hostmakedepends="cmake clang flex perl glib-devel pkg-config
  python re2c ruby which"
 makedepends="SDL2-devel Vulkan-Headers alsa-lib-devel double-conversion-devel
  eudev-libudev-devel ffmpeg-devel freetds-devel glib-devel gst-plugins-base1-devel
- gtk+3-devel icu-devel libXv-devel libbluetooth-devel libcap-devel
+ gtk+3-devel icu-devel libXv-devel libxkbcommon-devel libbluetooth-devel libcap-devel
  libinput-devel libmng-devel libmariadbclient-devel libproxy-devel
  libvpx-devel libwebp-devel libxkbcommon-devel
  libxslt-devel libxml2-devel cups-devel minizip-devel
  opus-devel pciutils-devel pcre2-devel postgresql-libs-devel
- protobuf-devel pulseaudio-devel tslib-devel openssl-devel
+ protobuf-devel $(vopt_if pulseaudio pulseaudio-devel) tslib-devel openssl-devel
  unixodbc-devel xcb-util-image-devel xcb-util-keysyms-devel
  xcb-util-renderutil-devel xcb-util-wm-devel libzstd-devel harfbuzz-devel"
 depends="qt5-dbus qt5-gui qt5-core qt5-widgets qt5-network qt5-xml
@@ -33,6 +33,9 @@ python_version=2 #unverified
 replaces="qt5-doc<5.6.0 qt5-quick1<5.6.0 qt5-quick1-devel<5.6.0 qt5-webkit<5.6.0 qt5-webkit-devel<5.6.0
  qt5-enginio<5.7.1 qt5-enginio-devel<5.7.1 qt5-plugin-gtk<5.7.1 qt5-canvas3d<5.13.0"
 lib32mode=full
+
+build_options="pulseaudio"
+build_options_default="pulseaudio"
 
 CXXFLAGS="-Wno-deprecated-declarations -Wno-class-memaccess -Wno-packed-not-aligned"
 # Required for musl libc

--- a/srcpkgs/sox/template
+++ b/srcpkgs/sox/template
@@ -3,11 +3,11 @@ pkgname=sox
 version=14.4.2
 revision=5
 build_style=gnu-configure
-configure_args="--with-distro=Void"
+configure_args="--with-distro=Void $(vopt_with pulseaudio)"
 hostmakedepends="pkg-config"
 makedepends="lame-devel libao-devel libgomp-devel libid3tag-devel libltdl-devel
- libmad-devel libpng-devel libsndfile-devel opusfile-devel pulseaudio-devel
- sndio-devel wavpack-devel"
+ libmad-devel libpng-devel libsndfile-devel opusfile-devel sndio-devel wavpack-devel
+ $(vopt_if pulseaudio pulseaudio-devel)"
 short_desc="Sound eXchange, the Swiss Army knife of audio manipulation"
 maintainer="Leah Neukirchen <leah@vuxu.org>"
 license="GPL-2.0-or-later, LGPL-2.1-or-later"
@@ -15,9 +15,13 @@ homepage="http://sox.sourceforge.net/"
 distfiles="${SOURCEFORGE_SITE}/${pkgname}/${pkgname}-${version}.tar.bz2"
 checksum=81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c
 
+build_options="pulseaudio"
+build_options_default="pulseaudio"
+
 post_extract() {
 	sed -i '/error FIX NEEDED HERE/d' src/formats.c
 }
+
 sox-devel_package() {
 	depends="${sourcepkg}>=${version}_${revision}"
 	short_desc+=" -- development files"

--- a/srcpkgs/vlc/template
+++ b/srcpkgs/vlc/template
@@ -31,7 +31,7 @@ makedepends="
  libmatroska-devel libmodplug-devel libmpcdec-devel libmpeg2-devel
  libmtp-devel libplacebo-devel libproxy-devel libsamplerate-devel
  libSM-devel libsysfs-devel libtheora-devel libupnp-devel
- libXinerama-devel libXpm-devel libXvMC-devel ncurses-devel opus-devel pulseaudio-devel
+ libXinerama-devel libXpm-devel libXvMC-devel ncurses-devel opus-devel
  sndio-devel speex-devel taglib-devel wayland-protocols x264-devel
  xcb-util-devel xcb-util-keysyms-devel live555-devel libdvdread-devel
  chromaprint-devel
@@ -41,14 +41,15 @@ makedepends="
  $(vopt_if lua lua52-devel) $(vopt_if vaapi libva-devel)
  $(vopt_if vdpau libvdpau-devel) $(vopt_if x265 x265-devel)
  $(vopt_if svg librsvg-devel) $(vopt_if sndio sndio-devel)
- $(vopt_if chromecast protobuf-devel) $(vopt_if chromecast libmicrodns-devel)"
+ $(vopt_if chromecast protobuf-devel) $(vopt_if chromecast libmicrodns-devel)
+ $(vopt_if pulseaudio pulseaudio-devel)"
 depends="freefont-ttf hicolor-icon-theme desktop-file-utils"
 # test/run_vlc.sh fail on CI
 make_check=ci-skip
 
 # Package build options
-build_options="lua notify opengl qt rpi smb svg v4l2 vaapi vdpau x265 sndio chromecast"
-build_options_default="lua smb v4l2 x265 sndio chromecast qt"
+build_options="lua notify opengl qt rpi smb svg v4l2 vaapi vdpau x265 sndio chromecast pulseaudio"
+build_options_default="lua smb v4l2 x265 sndio chromecast qt pulseaudio"
 
 CFLAGS="-fcommon"
 CXXFLAGS="-fcommon"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-musl)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
-->
