### PR TITLE
gdk-pixbuf: update to 2.42.10.

### DIFF
--- a/srcpkgs/gdk-pixbuf/template
+++ b/srcpkgs/gdk-pixbuf/template
@@ -1,21 +1,21 @@
 # Template file for 'gdk-pixbuf'
 pkgname=gdk-pixbuf
-version=2.42.6
+version=2.42.10
 revision=1
 build_style=meson
 build_helper="gir"
-configure_args="-Dintrospection=$(vopt_if gir enabled disabled) -Dpng=true
+configure_args="-Dintrospection=$(vopt_if gir enabled disabled) -Dpng=enabled
  -Dinstalled_tests=false"
 hostmakedepends="gettext-devel glib-devel pkg-config libxslt docbook-xsl"
 makedepends="libglib-devel libpng-devel tiff-devel
- shared-mime-info"
+ shared-mime-info python3-docutils"
 depends="shared-mime-info"
 short_desc="Image loading library for The GTK+ toolkit (v2)"
-maintainer="Orphaned <orphan@voidlinux.org>"
+maintainer="Eloi Torrents <eloitor@disroot.org>"
 license="LGPL-2.1-or-later"
 homepage="https://wiki.gnome.org/Projects/GdkPixbuf"
 distfiles="${GNOME_SITE}/${pkgname}/${version%.*}/${pkgname}-${version}.tar.xz"
-checksum=c4a6b75b7ed8f58ca48da830b9fa00ed96d668d3ab4b1f723dcf902f78bde77f
+checksum=ee9b6c75d13ba096907a2e3c6b27b61bcd17f5c7ebeab5a5b439d2f2e39fe44b
 
 # Package build options
 build_options="gir"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

I'm adopting this package since I'll use it to try to package `gotktrix`.
