### PR TITLE
tracebox: fix build with glibc 2.36

### DIFF
--- a/srcpkgs/tracebox/template
+++ b/srcpkgs/tracebox/template
@@ -24,7 +24,7 @@ checksum="
  d3a182a06b86a0bff7f9f5792876f8da9db9dd7936f36ef1b40770c400f43b97"
 nocross=yes
 
-CXXFLAGS="-DHAVE_LUA_PUSHGLOBALTABLE=1"
+CXXFLAGS="-std=c++14 -DHAVE_LUA_PUSHGLOBALTABLE=1"
 
 pre_configure() {
 	mv tracebox-${version}/* .


### PR DESCRIPTION
Credits go to Duncan Overbruck for suggesting to use -std=c++14 (see #40751).

[tracebox.txt](https://github.com/void-linux/void-packages/files/10093587/tracebox.txt)

#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64