### PR TITLE
Ayatana indicators

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -4225,3 +4225,4 @@ libOpenEXRCore-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXRUtil-3_1.so.30 libopenexr-3.1.5_1
 libdate-tz.so.3 chrono-date-3.0.1_1
 libayatana-ido3-0.4.so.0 ayatana-ido-0.9.2_1
+libayatana-indicator3.so.7 libayatana-indicator-0.9.3_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -4226,3 +4226,4 @@ libOpenEXRUtil-3_1.so.30 libopenexr-3.1.5_1
 libdate-tz.so.3 chrono-date-3.0.1_1
 libayatana-ido3-0.4.so.0 ayatana-ido-0.9.2_1
 libayatana-indicator3.so.7 libayatana-indicator-0.9.3_1
+libayatana-appindicator3.so.1 libayatana-appindicator-0.5.91_1

--- a/common/shlibs
+++ b/common/shlibs
@@ -4224,3 +4224,4 @@ libOpenEXR-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXRCore-3_1.so.30 libopenexr-3.1.5_1
 libOpenEXRUtil-3_1.so.30 libopenexr-3.1.5_1
 libdate-tz.so.3 chrono-date-3.0.1_1
+libayatana-ido3-0.4.so.0 ayatana-ido-0.9.2_1

--- a/srcpkgs/ayatana-ido-devel
+++ b/srcpkgs/ayatana-ido-devel
@@ -1,0 +1,1 @@
+ayatana-ido

--- a/srcpkgs/ayatana-ido/template
+++ b/srcpkgs/ayatana-ido/template
@@ -1,0 +1,27 @@
+# Template file for 'ayatana-ido'
+pkgname=ayatana-ido
+version=0.9.2
+revision=1
+build_helper="gir"
+build_style=cmake
+hostmakedepends="pkg-config gobject-introspection vala"
+makedepends="gtk+3-devel glib-devel"
+short_desc="Ayatana Indicator Display Objects"
+maintainer="tibequadorian <tibequadorian@posteo.de>"
+license="LGPL-3.0-or-later"
+homepage="https://ayatanaindicators.github.io/"
+changelog="https://github.com/AyatanaIndicators/ayatana-ido/raw/main/ChangeLog"
+distfiles="https://github.com/AyatanaIndicators/ayatana-ido/archive/${version}.tar.gz"
+checksum=b166e7a160458e4a71f6086d2e4e97e18cf1ac584231a4b9f1f338914203884c
+
+ayatana-ido-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+		vmove usr/share/gir-1.0
+		vmove usr/share/vala
+	}
+}

--- a/srcpkgs/caffeine-ng/patches/use-ayatana-appindicator.patch
+++ b/srcpkgs/caffeine-ng/patches/use-ayatana-appindicator.patch
@@ -1,0 +1,16 @@
+diff --git a/caffeine/main.py b/caffeine/main.py
+index 516a138..f48653b 100644
+--- a/caffeine/main.py
++++ b/caffeine/main.py
+@@ -32,9 +32,9 @@ try:
+     gi.require_version("Notify", "0.7")
+ except ValueError:
+     gi.require_version("Notify", "0.8")
+-gi.require_version("AppIndicator3", "0.1")
++gi.require_version("AyatanaAppIndicator3", "0.1")
+ 
+-from gi.repository import AppIndicator3  # noqa: E402
++from gi.repository import AyatanaAppIndicator3 as AppIndicator3  # noqa: E402
+ from gi.repository import GdkPixbuf  # noqa: E402
+ from gi.repository import Gtk  # noqa: E402
+ from gi.repository.Notify import Notification  # noqa: E402

--- a/srcpkgs/caffeine-ng/template
+++ b/srcpkgs/caffeine-ng/template
@@ -1,13 +1,13 @@
 # Template file for 'caffeine-ng'
 pkgname=caffeine-ng
 version=4.0.2
-revision=3
+revision=4
 build_style=python3-module
 hostmakedepends="python3-setuptools_scm"
 depends="desktop-file-utils gtk+3 hicolor-icon-theme libnotify
  python3-dbus python3-click python3-ewmh python3-gobject
  python3-setproctitle python3-setuptools python3-xdg
- python3-pulsectl libappindicator"
+ python3-pulsectl libayatana-appindicator"
 short_desc="Temporarily inhibits the screensaver and sleep mode"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/droidcam/patches/use-ayatana-appindicator.patch
+++ b/srcpkgs/droidcam/patches/use-ayatana-appindicator.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile b/Makefile
+index 7be3c15..b7f16c4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -13,7 +13,7 @@ JPEG_LIB ?= $(JPEG_DIR)/lib`getconf LONG_BIT`
+ CC   = gcc
+ CFLAGS = -Wall -O2
+ GTK   = `pkg-config --libs --cflags gtk+-3.0` `pkg-config --libs x11`
+-GTK  += `pkg-config --cflags --libs appindicator3-0.1`
++GTK  += `pkg-config --cflags --libs ayatana-appindicator3-0.1`
+ LIBAV = `pkg-config --libs --cflags libswscale libavutil`
+ LIBS  =  -lspeex -lasound -lpthread -lm
+ JPEG  = -I$(JPEG_INCLUDE) $(JPEG_LIB)/libturbojpeg.a
+diff --git a/src/droidcam.c b/src/droidcam.c
+index cad1ee4..28f4000 100644
+--- a/src/droidcam.c
++++ b/src/droidcam.c
+@@ -7,7 +7,7 @@
+  */
+ 
+ #include <gtk/gtk.h>
+-#include <libappindicator/app-indicator.h>
++#include <libayatana-appindicator/app-indicator.h>
+ #include <X11/Xlib.h>
+ #include <stdint.h>
+ 

--- a/srcpkgs/droidcam/template
+++ b/srcpkgs/droidcam/template
@@ -1,12 +1,13 @@
 # Template file for 'droidcam'
 pkgname=droidcam
 version=1.8.2
-revision=1
+revision=2
 build_style=gnu-makefile
 make_build_args="USBMUXD=-lusbmuxd-2.0 JPEG=-lturbojpeg"
 hostmakedepends="pkg-config"
 makedepends="pkg-config libjpeg-turbo-devel ffmpeg-devel alsa-lib-devel
- speex-devel libusbmuxd-devel libplist-devel gtk+3-devel libappindicator-devel"
+ speex-devel libusbmuxd-devel libplist-devel gtk+3-devel
+ libayatana-appindicator-devel"
 depends="v4l2loopback"
 short_desc="Tool for using your android device as a wireless/usb webcam"
 maintainer="ibrokemypie <ibrokemypie@bastardi.net>"

--- a/srcpkgs/element-desktop/template
+++ b/srcpkgs/element-desktop/template
@@ -5,7 +5,7 @@ revision=1
 create_wrksrc=yes
 conf_files="/etc/${pkgname}/config.json"
 hostmakedepends="git yarn nodejs rust cargo python3 curl
- sqlcipher-devel libappindicator-devel libnotify-devel pkg-config
+ sqlcipher-devel libnotify-devel pkg-config
  app-builder jq moreutils"
 makedepends="libsecret-devel"
 depends="c-ares ffmpeg gtk+3 http-parser libevent

--- a/srcpkgs/gromit-mpx/template
+++ b/srcpkgs/gromit-mpx/template
@@ -1,10 +1,10 @@
 # Template file for 'gromit-mpx'
 pkgname=gromit-mpx
 version=1.4.3
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="pkg-config"
-makedepends="gtk+3-devel libappindicator-devel libdbusmenu-glib-devel"
+makedepends="gtk+3-devel libayatana-appindicator-devel libdbusmenu-glib-devel"
 short_desc="Multi-pointer annotation tool"
 maintainer="Toyam Cox <Vaelatern@gmail.com>"
 license="GPL-2.0-only"

--- a/srcpkgs/gwe/patches/use-ayatana-appindicator.patch
+++ b/srcpkgs/gwe/patches/use-ayatana-appindicator.patch
@@ -1,0 +1,15 @@
+diff --git a/gwe/view/main_view.py b/gwe/view/main_view.py
+index 61c891d..6f573c2 100644
+--- a/gwe/view/main_view.py
++++ b/gwe/view/main_view.py
+@@ -31,8 +31,8 @@ from gwe.model.fan_profile import FanProfile
+ try:  # AppIndicator3 may not be installed
+     import gi
+ 
+-    gi.require_version('AppIndicator3', '0.1')
+-    from gi.repository import AppIndicator3
++    gi.require_version('AyatanaAppIndicator3', '0.1')
++    from gi.repository import AyatanaAppIndicator3 as AppIndicator3
+ except (ImportError, ValueError):
+     AppIndicator3 = None
+ from gwe.di import MainBuilder

--- a/srcpkgs/gwe/template
+++ b/srcpkgs/gwe/template
@@ -1,14 +1,14 @@
 # Template file for 'gwe'
 pkgname=gwe
 version=0.15.2
-revision=3
+revision=4
 build_style=meson
 hostmakedepends="pkg-config meson ninja glib-devel gtk+3-devel python3 python3-devel
  python3-matplotlib python3-peewee python3-gobject python3-xlib python3-xdg
  python3-requests python3-rx python3-nvml python3-injector python3-urllib3 python3-six
  python3-chardet python3-idna python3-xlib python3-numpy python3-parsing python3-cycler python3-dateutil python3-Pillow"
 makedepends="gobject-introspection appstream-glib"
-depends="python3 gobject-introspection libappindicator libdazzle python3-matplotlib
+depends="python3 gobject-introspection libayatana-appindicator libdazzle python3-matplotlib
  python3-peewee python3-gobject python3-xlib python3-xdg python3-requests python3-rx
  python3-nvml python3-injector python3-urllib3 python3-six python3-chardet python3-idna
  python3-xlib python3-numpy python3-parsing python3-cycler python3-dateutil python3-Pillow"

--- a/srcpkgs/indicator-doom-cpu/patches/use-ayatana-appindicator.patch
+++ b/srcpkgs/indicator-doom-cpu/patches/use-ayatana-appindicator.patch
@@ -1,0 +1,13 @@
+diff --git a/indicator-doom-cpu b/indicator-doom-cpu
+index a1528e3..c4ff4d2 100755
+--- a/indicator-doom-cpu
++++ b/indicator-doom-cpu
+@@ -27,7 +27,7 @@ import time
+ from gi.repository import Gtk, GObject, GdkPixbuf
+ 
+ try:
+-    from gi.repository import AppIndicator3 as AppIndicator
++    from gi.repository import AyatanaAppIndicator3 as AppIndicator
+     appindicator_imported = True
+ except ImportError:
+     appindicator_imported = False

--- a/srcpkgs/indicator-doom-cpu/template
+++ b/srcpkgs/indicator-doom-cpu/template
@@ -1,8 +1,8 @@
 # Template file for 'indicator-doom-cpu'
 pkgname=indicator-doom-cpu
 version=1.0.1
-revision=3
-depends="python3-gobject gtk+3 libappindicator"
+revision=4
+depends="python3-gobject gtk+3 libayatana-appindicator"
 short_desc="CPU load indicator showing the dying face from the video game DOOM"
 maintainer="Andrea Brancaleoni <abc@pompel.me>"
 license="GPL-3.0-only"

--- a/srcpkgs/libayatana-appindicator-devel
+++ b/srcpkgs/libayatana-appindicator-devel
@@ -1,0 +1,1 @@
+libayatana-appindicator

--- a/srcpkgs/libayatana-appindicator/template
+++ b/srcpkgs/libayatana-appindicator/template
@@ -1,0 +1,32 @@
+# Template file for 'libayatana-appindicator'
+pkgname=libayatana-appindicator
+version=0.5.91
+revision=1
+build_helper="gir"
+build_style=cmake
+configure_args="-DENABLE_BINDINGS_MONO=OFF -DENABLE_BINDINGS_VALA=$(vopt_if vala ON OFF)"
+hostmakedepends="pkg-config gobject-introspection $(vopt_if vala vala)"
+makedepends="glib-devel gtk+3-devel libdbusmenu-gtk3-devel libayatana-indicator-devel"
+short_desc="Ayatana Application Indicators Shared Library"
+maintainer="tibequadorian <tibequadorian@posteo.de>"
+license="LGPL-3.0-or-later"
+homepage="https://ayatanaindicators.github.io/"
+distfiles="https://github.com/AyatanaIndicators/libayatana-appindicator/archive/${version}.tar.gz"
+checksum=52eb5d0c0de07177833e50fbaee592dcb3939e96c6b789921e2a8caf40a1ed26
+
+build_options="vala"
+build_options_default="vala"
+
+libayatana-appindicator-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
+	pkg_install() {
+		vmove usr/include
+		vmove "usr/lib/*.so"
+		vmove usr/lib/pkgconfig
+		vmove usr/share/gir-1.0
+		if [ "$build_option_vala" ]; then
+			vmove usr/share/vala
+		fi
+	}
+}

--- a/srcpkgs/libayatana-indicator-devel
+++ b/srcpkgs/libayatana-indicator-devel
@@ -1,0 +1,1 @@
+libayatana-indicator

--- a/srcpkgs/libayatana-indicator/template
+++ b/srcpkgs/libayatana-indicator/template
@@ -1,0 +1,24 @@
+# Template file for 'libayatana-indicator'
+pkgname=libayatana-indicator
+version=0.9.3
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config python3"
+makedepends="glib-devel gtk+3-devel ayatana-ido-devel"
+short_desc="Ayatana Indicators Shared Library"
+maintainer="tibequadorian <tibequadorian@posteo.de>"
+license="GPL-3.0-or-later"
+homepage="https://ayatanaindicators.github.io/"
+changelog="https://github.com/AyatanaIndicators/libayatana-indicator/raw/main/ChangeLog"
+distfiles="https://github.com/AyatanaIndicators/libayatana-indicator/archive/${version}.tar.gz"
+checksum=09c5456fcb430b6ee0626fafdf99a32eb8746b267d56ab2bd4c8a8dd6ca731da
+
+libayatana-indicator-devel_package() {
+	short_desc+=" - development files"
+	depends="${sourcepkg}>=${version}_${revision} ${makedepends}"
+	pkg_install() {
+		vmove usr/include
+		vmove usr/lib/pkgconfig
+		vmove "usr/lib/*.so"
+	}
+}

--- a/srcpkgs/network-manager-applet/template
+++ b/srcpkgs/network-manager-applet/template
@@ -1,12 +1,12 @@
 # Template file for 'network-manager-applet'
 pkgname=network-manager-applet
 version=1.30.0
-revision=1
+revision=2
 build_style=meson
 configure_args="-Dselinux=false"
 hostmakedepends="dbus-glib-devel glib-devel intltool pkg-config"
 makedepends="ModemManager-devel NetworkManager-devel iso-codes jansson-devel
- libappindicator-devel libapparmor-devel libdbusmenu-gtk3-devel
+ libayatana-appindicator-devel libapparmor-devel libdbusmenu-gtk3-devel
  libgudev-devel libnotify-devel libnma-devel libsecret-devel
  polkit-devel mobile-broadband-provider-info"
 depends="NetworkManager hicolor-icon-theme iso-codes"

--- a/srcpkgs/psensor/patches/use-ayatana-appindicator.patch
+++ b/srcpkgs/psensor/patches/use-ayatana-appindicator.patch
@@ -1,0 +1,53 @@
+From d84498639263d6a8f8d4b4adddf3dab66631876b Mon Sep 17 00:00:00 2001
+From: tibequadorian <tibequadorian@posteo.de>
+Date: Sat, 22 Jan 2022 00:15:13 +0100
+Subject: [PATCH] Use ayatana appindicator
+
+---
+ configure.ac          | 2 +-
+ src/ui.h              | 2 +-
+ src/ui_appindicator.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 48b10eb..2ff857d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -117,7 +117,7 @@ AC_SUBST(LIBNOTIFY_LIBS)
+ 
+ # Checks AppIndicator 
+ APPINDICATOR_LIBS=
+-PKG_CHECK_MODULES(APPINDICATOR, appindicator3-0.1,
++PKG_CHECK_MODULES(APPINDICATOR, ayatana-appindicator3-0.1,
+      [AC_DEFINE([HAVE_APPINDICATOR],[1],[Use AppIndicator3-0.1])],
+      [AC_MSG_WARN(AppIndicator 3-0.1 not present")])
+ AM_CONDITIONAL(APPINDICATOR, test -n "$APPINDICATOR_LIBS")
+diff --git a/src/ui.h b/src/ui.h
+index 426f29c..43ae4be 100644
+--- a/src/ui.h
++++ b/src/ui.h
+@@ -27,7 +27,7 @@
+ #include <gtk/gtk.h>
+ 
+ #if defined(HAVE_APPINDICATOR)
+-#include <libappindicator/app-indicator.h>
++#include <libayatana-appindicator/app-indicator.h>
+ #endif
+ 
+ #include "psensor.h"
+diff --git a/src/ui_appindicator.c b/src/ui_appindicator.c
+index ed4cc64..b3179c0 100644
+--- a/src/ui_appindicator.c
++++ b/src/ui_appindicator.c
+@@ -21,7 +21,7 @@
+ #include <string.h>
+ 
+ #include <gtk/gtk.h>
+-#include <libappindicator/app-indicator.h>
++#include <libayatana-appindicator/app-indicator.h>
+ 
+ #include <cfg.h>
+ #include <psensor.h>
+-- 
+2.34.1
+

--- a/srcpkgs/psensor/template
+++ b/srcpkgs/psensor/template
@@ -1,12 +1,12 @@
 # Template file for 'psensor'
 pkgname=psensor
 version=1.2.1
-revision=1
+revision=2
 build_style=gnu-configure
-hostmakedepends="pkg-config glib-devel"
+hostmakedepends="pkg-config glib-devel automake"
 makedepends="gtk+3-devel udisks2-devel libgtop-devel json-c-devel
  libsensors-devel libatasmart-devel libcurl-devel libnotify-devel
- libappindicator-devel libmicrohttpd-devel"
+ libayatana-appindicator-devel libmicrohttpd-devel"
 depends="lm_sensors"
 short_desc="Graphical hardware temperature monitor for Linux"
 maintainer="Foxlet <foxlet@furcode.co>"

--- a/srcpkgs/remmina/template
+++ b/srcpkgs/remmina/template
@@ -1,9 +1,9 @@
 # Template file for 'remmina'
 pkgname=remmina
 version=1.4.29
-revision=1
+revision=2
 build_style=cmake
-configure_args="-DWITH_APPINDICATOR=OFF -DCMAKE_USE_PTHREADS_INIT=ON"
+configure_args="-DCMAKE_USE_PTHREADS_INIT=ON"
 hostmakedepends="glib-devel intltool pkg-config shared-mime-info"
 makedepends="avahi-glib-libs-devel avahi-ui-libs-devel freerdp-devel
  gobject-introspection gstreamermm-devel json-glib-devel
@@ -11,7 +11,7 @@ makedepends="avahi-glib-libs-devel avahi-ui-libs-devel freerdp-devel
  libsecret-devel libsodium-devel libsoup3-devel libssh-devel libva-devel
  libvncserver-devel libxkbfile-devel opus-devel phodav-devel
  spice-gtk-devel spice-protocol telepathy-glib-devel usbredir-devel
- vte3-devel libappindicator-devel libwebkit2gtk41-devel python3-devel"
+ vte3-devel libayatana-appindicator-devel libwebkit2gtk41-devel python3-devel"
 depends="desktop-file-utils hicolor-icon-theme"
 short_desc="Remote desktop client written in GTK+"
 maintainer="Frank Steinborn <steinex@nognu.de>"

--- a/srcpkgs/safeeyes/template
+++ b/srcpkgs/safeeyes/template
@@ -1,11 +1,11 @@
 # Template file for 'safeeyes'
 pkgname=safeeyes
 version=2.1.4
-revision=1
+revision=2
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-pip python3-devel pkg-config"
 makedepends="python3-devel cairo-devel libgirepository-devel"
-depends="python3-psutil libappindicator python3-gobject python3-Babel
+depends="python3-psutil libayatana-appindicator python3-gobject python3-Babel
  python3-dbus xprop alsa-utils python3-xlib"
 checkdepends="$depends"
 short_desc="Tool to reduce and prevent repetitive strain injury"

--- a/srcpkgs/ulauncher/template
+++ b/srcpkgs/ulauncher/template
@@ -1,12 +1,12 @@
 # Template file for 'ulauncher'
 pkgname=ulauncher
 version=5.14.3
-revision=2
+revision=3
 build_style=python3-module
 hostmakedepends="python3-distutils-extra intltool python3-Levenshtein
  python3-dbus python3-gobject python3-inotify python3-websocket-client
  python3-xdg"
-depends="libappindicator>=12.10.0_2 libkeybinder3 python3-Levenshtein python3-dbus
+depends="libayatana-appindicator libkeybinder3 python3-Levenshtein python3-dbus
  python3-gobject python3-inotify python3-websocket-client python3-xdg webkit2gtk"
 short_desc="Linux application launcher with fuzzy search and extensions"
 maintainer="Alberto Pau <me@albertopau.com>"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Continuation of #35135

`libappindicator` hasn't seen a release since 2012 (more than 10 years!)
Debian has removed it in buster and switched to [libayatana-appindicator](https://ayatanaindicators.github.io/).
This PR tries to replace `libappindicator` with `libayatana-appindicator`.

#### Testing the changes
- I tested the changes in this PR: **YES**

#### TODO:
- [x] `droidcam` - only [supported](https://github.com/dev47apps/droidcam/commit/71a74d22ed700650a83b7cb653bd92b0ed3cd01a) in master, patched
- [x] `gromit-mpx` - [supported](https://github.com/bk138/gromit-mpx/commit/2a838303154df4a90495c4f93741846cbd63d37f)
- [x] `network-manager-applet` - supported
- [x] `psensor` - not supported, patched
- [x] `remmina` - [supported](https://github.com/FreeRDP/Remmina/commit/a34133add92c217943acad64bb0e41de0f2f619c)
- [x] `ulauncher` - supported
- [x] `gwe` - [not supported](https://gitlab.com/leinardi/gwe/-/issues/156), [merge request](https://gitlab.com/leinardi/gwe/-/merge_requests/73), patched
- [x] `caffeine-ng` - only [supported](https://codeberg.org/WhyNotHugo/caffeine-ng/commit/d13b2b97160649b465213e691a8df2e958ecf739) in master, patched
- [x] `indicator-doom-cpu` - not supported, patched
- [x] `element-desktop` - [not supported](https://github.com/electron/electron/issues/27527) but works fine without it and uses systray instead, removed dependency,
see https://github.com/vector-im/element-desktop/pull/170
and https://github.com/signalapp/Signal-Desktop/pull/5031#issuecomment-788068627.
_No revbump needed because not the package but only the template required libappindicator._
- [x] `safeeyes` - [supported](https://github.com/slgobinath/SafeEyes/commit/c784000e694f9fa508a2535f5d23d04456b4ff86) in 2.1.4, #40763 

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
