### PR TITLE
safeeyes: update to 2.1.4 and fix error.

### DIFF
--- a/srcpkgs/safeeyes/patches/fix-getargspec.patch
+++ b/srcpkgs/safeeyes/patches/fix-getargspec.patch
@@ -1,0 +1,13 @@
+diff --git a/safeeyes/utility.py b/safeeyes/utility.py
+index bf2dede..7e08735 100644
+--- a/safeeyes/utility.py
++++ b/safeeyes/utility.py
+@@ -666,7 +666,7 @@ def has_method(module, method_name, no_of_args=0):
+     Check whether the given function is defined in the module or not.
+     """
+     if hasattr(module, method_name):
+-        if len(inspect.getargspec(getattr(module, method_name)).args) == no_of_args:
++        if len(inspect.getfullargspec(getattr(module, method_name)).args) == no_of_args:
+             return True
+     return False
+ 

--- a/srcpkgs/safeeyes/template
+++ b/srcpkgs/safeeyes/template
@@ -1,7 +1,7 @@
 # Template file for 'safeeyes'
 pkgname=safeeyes
-version=2.1.3
-revision=3
+version=2.1.4
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools python3-pip python3-devel pkg-config"
 makedepends="python3-devel cairo-devel libgirepository-devel"
@@ -12,5 +12,5 @@ short_desc="Tool to reduce and prevent repetitive strain injury"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-3.0-or-later"
 homepage="https://slgobinath.github.io/SafeEyes/"
-distfiles="${PYPI_SITE}/s/${pkgname}/${pkgname}-${version}.tar.gz"
-checksum=3db101a4ae86e824937b7ddfb56e7e464f5b2dc96a351feaccadee080f42bcac
+distfiles="${PYPI_SITE}/s/safeeyes/safeeyes-${version}.tar.gz"
+checksum=4ac651c8e0de611424da956ca4acdf25b4915ffce30fe33e69a2be6173eee821


### PR DESCRIPTION
Also fix getargspec error with python 3.11. See https://github.com/slgobinath/SafeEyes/issues/491

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
