### PR TITLE
budgie-screensaver: update to 5.1.0.

### DIFF
--- a/srcpkgs/budgie-screensaver/patches/fix-musl.patch
+++ b/srcpkgs/budgie-screensaver/patches/fix-musl.patch
@@ -1,0 +1,14 @@
+diff --git a/src/subprocs.c b/src/subprocs.c
+index cc82047..3af405a 100644
+--- a/src/subprocs.c
++++ b/src/subprocs.c
+@@ -36,6 +36,9 @@
+ # define fork  vfork
+ #endif /* VMS */
+ 
++#ifndef _POSIX_SOURCE
++# define _POSIX_SOURCE
++#endif
+ #include <signal.h>		/* for the signal names */
+ 
+ #include <glib.h>

--- a/srcpkgs/budgie-screensaver/template
+++ b/srcpkgs/budgie-screensaver/template
@@ -1,14 +1,14 @@
 # Template file for 'budgie-screensaver'
 pkgname=budgie-screensaver
-version=5.0.2
+version=5.1.0
 revision=1
 build_style=meson
 hostmakedepends="pkg-config intltool glib-devel"
 makedepends="gnome-desktop-devel dbus-glib-devel pam-devel elogind-devel
- libgnomekbd-devel"
+ libgnomekbd-devel libXxf86vm-devel"
 short_desc="Fork of GNOME Screensaver for Budgie 10"
 maintainer="Orphaned <orphan@voidlinux.org>"
 license="GPL-2.0-only"
 homepage="https://github.com/BuddiesOfBudgie/budgie-screensaver"
 distfiles="https://github.com/BuddiesOfBudgie/budgie-screensaver/releases/download/v${version}/budgie-screensaver-v${version}.tar.xz"
-checksum=01d204947159f9fedc8e7511c72bf916e6244371262892c8fe004ce9e56f7bb0
+checksum=563ac3f845729e9e6d184d2dbf036ab3f51ff244c27f5b286cfcb89acc147f0c


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

Patch reported upstream: https://github.com/BuddiesOfBudgie/budgie-screensaver/pull/15

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
