### PR TITLE
zfs: do not ship autotools cache, ship initramfs-tools

### DIFF
--- a/srcpkgs/zfs/template
+++ b/srcpkgs/zfs/template
@@ -1,7 +1,7 @@
 # Template file for 'zfs'
 pkgname=zfs
 version=2.1.6
-revision=1
+revision=2
 build_style=gnu-configure
 configure_args="--with-config=user --with-mounthelperdir=/usr/bin
  --with-udevdir=/usr/lib/udev --with-udevruledir=/usr/lib/udev/rules.d
@@ -26,19 +26,9 @@ if [ "$XBPS_TARGET_NO_ATOMIC8" ]; then
 	makedepends+=" libatomic-devel"
 fi
 
-post_patch() {
-	# When collecting a "clean" tree for DKMS, don't leave patches in place
-	local _f
-	for _f in "${XBPS_SRCPKGDIR}/${pkgname}"/patches/*.patch; do
-		rm -f "${_f##*/}"
-	done
-}
-
 pre_configure() {
 	export CFLAGS+=" -I${XBPS_CROSS_BASE}/usr/include/tirpc/"
 	autoreconf -fi
-
-	tar czf ../clean.tar.gz .
 }
 
 post_install() {
@@ -48,13 +38,13 @@ post_install() {
 
 	vsv zed
 
-	vmkdir usr/src/${pkgname}-${version}
-	tar xf ../clean.tar.gz -C ${DESTDIR}/usr/src/${pkgname}-${version}
+	make dist-gzip
+	vmkdir usr/src/
+	tar xf ${pkgname}-${version}.tar.gz -C ${DESTDIR}/usr/src/
 	scripts/dkms.mkconf -v ${version} -f ${DESTDIR}/usr/src/${pkgname}-${version}/dkms.conf -n zfs
 
 	# Remove init and service control pieces not used in Void
 	rm -rf ${DESTDIR}/usr/lib/systemd
-	rm -rf ${DESTDIR}/usr/share/initramfs-tools
 	rm -rf ${DESTDIR}/etc/init.d
 	rm -rf ${DESTDIR}/etc/default
 	rm -f ${DESTDIR}/etc/zfs/zfs-functions
@@ -87,11 +77,6 @@ zfs-pam_package() {
 	pkg_install() {
 		vmove usr/lib/security/pam_zfs_key.so
 	}
-}
-
-
-do_clean() {
-	rm -f ../clean.tar.gz
 }
 
 # REMARKS:


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
