### PR TITLE
nvidia: nvidia: fix wayland performance

### DIFF
--- a/srcpkgs/nvidia/template
+++ b/srcpkgs/nvidia/template
@@ -4,7 +4,7 @@ _desc="NVIDIA drivers for linux"
 
 pkgname=nvidia
 version=515.86.01
-revision=1
+revision=2
 maintainer="Andrew Benson <abenson+void@gmail.com>"
 license="custom:NVIDIA Proprietary"
 homepage="https://www.nvidia.com/en-us/drivers/unix/"
@@ -133,8 +133,8 @@ do_install() {
 	ln -sf libnvidia-egl-gbm.so.1.1.0 \
 		${DESTDIR}/usr/lib/libnvidia-egl-gbm.so.1
 
-	vmkdir usr/share/glvnd/egl_vendor.d
-	vinstall 15_nvidia_gbm.json 755 usr/share/glvnd/egl_vendor.d
+	vmkdir usr/share/egl/egl_external_platform.d
+	vinstall 15_nvidia_gbm.json 755 usr/share/egl/egl_external_platform.d
 
 	vmkdir usr/lib/gbm
 	ln -sf /usr/lib/libnvidia-allocator.so.${version} \


### PR DESCRIPTION
moved 15_nvidia-gbm.json from /usr/share/glvnd/egl_vendor.d/ to /usr/share/egl/egl_external_platform.d/ to resolve #40235 per the fix suggested by furryfixer.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: YES

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing

- I built this PR locally for my native architecture, x86_64 glibc
