### PR TITLE
retroarch: update to 1.13.0

### DIFF
--- a/srcpkgs/retroarch/template
+++ b/srcpkgs/retroarch/template
@@ -1,7 +1,7 @@
 # Template file for 'retroarch'
 pkgname=retroarch
-version=1.10.3
-revision=2
+version=1.13.0
+revision=1
 build_style=configure
 configure_args="--prefix=/usr --sysconfdir=/etc --enable-networking
  --enable-udev --disable-builtinflac --disable-builtinglslang
@@ -24,7 +24,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.retroarch.com/"
 changelog="https://raw.githubusercontent.com/libretro/RetroArch/master/CHANGES.md"
 distfiles="https://github.com/libretro/RetroArch/archive/v$version.tar.gz"
-checksum=2af44294e55f5636262284d650cb5fff55c9070ac3a700d4fa55c1f152dcb3f2
+checksum=7f33bfb821440b2e30eb6c9d63eb4e2da1d2910ae90b43f691e3c28759739710
 
 build_options="ffmpeg flac glcore gles2 glslang jack neon pulseaudio qt5 sdl2 vulkan wayland x11"
 build_options_default="ffmpeg flac glcore glslang pulseaudio sdl2 vulkan wayland x11"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **briefly**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures:
  - aarch64-musl (crossbuild)
