### PR TITLE
New package: spek-X-0.9.0

### DIFF
--- a/srcpkgs/spek-X/template
+++ b/srcpkgs/spek-X/template
@@ -1,0 +1,25 @@
+# Template file for 'spek-X'
+pkgname=spek-X
+version=0.9.0
+revision=1
+build_style=gnu-configure
+hostmakedepends="automake gettext-devel intltool libtool pkg-config wxWidgets-common"
+makedepends="ffmpeg-devel wxWidgets-gtk3-devel"
+depends="ffmpeg"
+short_desc="Acoustic spectrum analyser (fork of spek-alternative)"
+maintainer="tibequadorian <tibequadorian@posteo.de>"
+license="GPL-3.0-or-later"
+homepage="https://github.com/MikeWang000000/spek-X"
+distfiles="https://github.com/MikeWang000000/spek-X/archive/v${version}.tar.gz"
+checksum=d6cf8dac3b0a3749c0128d204393a633c28f863d9886fbec97e5d5924dad53ef
+conflicts="spek-alternative"
+
+# Tests are outdated
+make_check=no
+
+# Tell autogen.sh to use "wx-config-gtk3" instead of "wx-config"
+export WX_CONFIG_NAME="wx-config-gtk3"
+
+pre_configure() {
+	NOCONFIGURE=1 ./autogen.sh
+}

--- a/srcpkgs/spek-alternative/template
+++ b/srcpkgs/spek-alternative/template
@@ -13,6 +13,8 @@ homepage="https://github.com/withmorten/spek-alternative"
 distfiles="https://github.com/withmorten/spek-alternative/archive/${version}.tar.gz"
 checksum="007ba4b84a310b078e378aa84c8e80783db5821437a757a488c3ecec377e6b2a"
 
+conflicts="spek-X"
+
 # Tell autogen.sh to use "wx-config-gtk3" instead of "wx-config"
 export WX_CONFIG_NAME="wx-config-gtk3"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

spek-alternative had its last release in 2017.
This is an actively maintained fork of spek-alternative compatible with ffmpeg 5 and other improvements.

#### Testing the changes
- I tested the changes in this PR: **YES**

Tests also fail for spek-alternative. I assume the testsuite is not really maintained. Opened an issue about this anyway: https://github.com/MikeWang000000/spek-X/issues/8

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->
<!--
#### Local build testing
- I built this PR locally for my native architecture, (ARCH-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl
-->
