### PR TITLE
doomretro: recompile with newer SDL2

### DIFF
--- a/srcpkgs/doomretro/template
+++ b/srcpkgs/doomretro/template
@@ -1,7 +1,7 @@
 # Template file for 'doomretro'
 pkgname=doomretro
 version=4.6.2
-revision=2
+revision=3
 build_style=cmake
 hostmakedepends="pkg-config"
 makedepends="SDL2_image-devel SDL2_mixer-devel"


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->
The current version fails with:
```
The wrong version of SDL2.so was found. DOOM Retro requires v2.24.0.

```
#### Testing the changes
- I tested the changes in this PR: **YES**