### PR TITLE
fotoxx: update to 22.50.

### DIFF
--- a/srcpkgs/fotoxx/template
+++ b/srcpkgs/fotoxx/template
@@ -1,6 +1,6 @@
 # Template file for 'fotoxx'
 pkgname=fotoxx
-version=22.41
+version=22.50
 revision=1
 build_style=gnu-makefile
 make_use_env=yes
@@ -13,7 +13,7 @@ license="GPL-3.0-or-later"
 homepage="https://www.kornelix.net/fotoxx/fotoxx.html"
 changelog="https://www.kornelix.net/downloads/recent_changes.txt"
 distfiles="https://www.kornelix.net/downloads/downloads/fotoxx-${version}.tar.gz"
-checksum=649a1964df2b4c1efa45ee2260ccff7a68075ef149873d5362857ed2ac95040b
+checksum=ed272dcdc3094908fd4eb2ae165f0e2746a7fb30081539dad66a3d6b8252dba0
 
 CXXFLAGS="-I${XBPS_CROSS_BASE}/usr/include/champlain-0.12"
 


### PR DESCRIPTION
<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**|**NO**
-->

<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (X86_64-LIBC)
- I built this PR locally for these architectures (if supported. mark crossbuilds):
  - aarch64-musl
  - armv7l
  - armv6l-musl

