### PR TITLE
python3-keyring: update to 23.11.0.

### DIFF
--- a/srcpkgs/pantalaimon/template
+++ b/srcpkgs/pantalaimon/template
@@ -1,17 +1,17 @@
 # Template file for 'pantalaimon'
 pkgname=pantalaimon
-version=0.8.0
-revision=3
+version=0.10.5
+revision=1
 build_style=python3-module
 hostmakedepends="python3-setuptools"
 depends="python3-attrs python3-aiohttp python3-appdirs python3-click
  python3-keyring python3-logbook python3-peewee python3-janus
  python3-cachetools python3-prompt_toolkit python3-matrix-nio
  python3-dbus python3-gobject python3-pydbus python3-notify2"
-checkdepends="${depends}"
+checkdepends="${depends} python3-Faker python3-aioresponses python3-pytest-aiohttp"
 short_desc="Proxy daemon for matrix.org clients supporting end-to-end encryption"
 maintainer="Adam Beckmeyer <adam_gpg@thebeckmeyers.xyz>"
 license="Apache-2.0"
 homepage="https://github.com/matrix-org/pantalaimon"
-distfiles="${homepage}/archive/${version}.tar.gz"
-checksum=82437a6265a3c747618b422d55138181e799da906111e02e7577853b33f5433b
+distfiles="https://github.com/matrix-org/pantalaimon/archive/refs/tags/${version}.tar.gz"
+checksum=970e79db0692a23c0e2d7f6ee9e3cd67b482b5a3fcb739cc899806494748db77

--- a/srcpkgs/python3-importlib_metadata/template
+++ b/srcpkgs/python3-importlib_metadata/template
@@ -1,0 +1,14 @@
+# Template file for 'python3-importlib_metadata'
+pkgname=python3-importlib_metadata
+version=5.1.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm python3-wheel"
+depends="python3-zipp"
+short_desc="Read metadata from python3 packages"
+maintainer="icp <pangolin@vivaldi.net>"
+license="Apache-2.0"
+homepage="https://pypi.org/project/importlib-metadata/"
+changelog="https://raw.githubusercontent.com/python/importlib_metadata/main/CHANGES.rst"
+distfiles="${PYPI_SITE}/i/importlib_metadata/importlib_metadata-${version}.tar.gz"
+checksum=d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b

--- a/srcpkgs/python3-keyring/template
+++ b/srcpkgs/python3-keyring/template
@@ -1,18 +1,19 @@
 # Template file for 'python3-keyring'
 pkgname=python3-keyring
-version=23.9.3
-revision=2
+version=23.11.0
+revision=1
 build_style=python3-pep517
 hostmakedepends="python3-wheel python3-setuptools_scm"
-depends="python3-SecretStorage python3-jeepney python3-jaraco.classes"
+depends="python3-SecretStorage python3-jeepney python3-importlib_metadata
+ python3-jaraco.classes"
 checkdepends="${depends} python3-pytest-xdist"
 short_desc="Python interface to the system keyring service"
 maintainer="icp <pangolin@vivaldi.net>"
 license="MIT"
-homepage="https://github.com/jaraco/keyring"
-changelog="https://raw.githubusercontent.com/jaraco/keyring/master/CHANGES.rst"
+homepage="https://pypi.org/project/keyring/"
+changelog="https://raw.githubusercontent.com/jaraco/keyring/main/CHANGES.rst"
 distfiles="${PYPI_SITE}/k/keyring/keyring-${version}.tar.gz"
-checksum=69b01dd83c42f590250fe7a1f503fc229b14de83857314b1933a3ddbf595c4a5
+checksum=ad192263e2cdd5f12875dedc2da13534359a7e760e77f8d04b50968a821c2361
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/python3-zipp/template
+++ b/srcpkgs/python3-zipp/template
@@ -1,0 +1,18 @@
+# Template file for 'python3-zipp'
+pkgname=python3-zipp
+version=3.11.0
+revision=1
+build_style=python3-pep517
+hostmakedepends="python3-setuptools_scm python3-wheel"
+depends="python3"
+short_desc="Pathlib-compatible Zipfile object wrapper (Python 3)"
+maintainer="icp <pangolin@vivaldi.net>"
+license="MIT"
+homepage="https://pypi.org/project/zipp/"
+changelog="https://raw.githubusercontent.com/jaraco/zipp/main/CHANGES.rst"
+distfiles="${PYPI_SITE}/z/zipp/zipp-${version}.tar.gz"
+checksum=a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766
+
+post_install() {
+	vlicense LICENSE
+}

--- a/srcpkgs/removed-packages/template
+++ b/srcpkgs/removed-packages/template
@@ -1,6 +1,6 @@
 # Template file for 'removed-packages'
 pkgname=removed-packages
-version=0.1.20221205
+version=0.1.20221217
 revision=1
 build_style=meta
 short_desc="Uninstalls packages removed from repository"
@@ -430,7 +430,6 @@ replaces="
  python3-docker-pycreds<=0.4.0_4
  python3-grako<=3.99.9_7
  python3-idna-ssl<=1.1.0_3
- python3-importlib_metadata<=4.8.1_2
  python3-jaraco<=1.0_4
  python3-jsonrpc-server<=0.4.0_2
  python3-keepalive<=0.5_6
@@ -442,7 +441,6 @@ replaces="
  python3-pyside<=5.15.0_2
  python3-shiboken<=5.15.0_3
  python3-txacme<=0.9.3_3
- python3-zipp<=3.6.0_1
  qimageblitz<=0.0.6_4
  qt-designer-devel<=4.8.7_29
  qt-designer-libs<=4.8.7_29


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, x86_64

#### Rev dep checks
- [x] mcg
- [x] pantalaimon
- [x] Komikku
- [x] jrnl
- [x] gajim
- [x] coursera-dl
- [x] python3-keyrings-alt
- [x] cura
- [x] hatch
- [x] nagstamon
- [x] backintime
- [x] urlwatch

I noticed that `importlib_metadata` got removed in https://github.com/void-linux/void-packages/pull/38287 but keyring again has it as a dependency. As per my understanding, `importlib_metadata` will always have backports from future python version(s) to the current one. For example, features introduced in `v5.*.*` are set to be merged in python3.12 stdlib.