### PR TITLE
Manual.md: note that gnu-configure build_style should be for autotools

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -906,8 +906,8 @@ should be passed in via `configure_args`.
 
 - `fetch` For packages that only fetch files and are installed as is via `do_install()`.
 
-- `gnu-configure` For packages that use GNU configure scripts, additional configuration
-arguments can be passed in via `configure_args`.
+- `gnu-configure` For packages that use GNU autotools-compatible configure scripts,
+additional configuration arguments can be passed in via `configure_args`.
 
 - `gnu-makefile` For packages that use GNU make, build arguments can be passed in via
 `make_build_args` and install arguments via `make_install_args`. The build


### PR DESCRIPTION
as is indicated in the configure/gnu-configure build_style scripts:

https://github.com/void-linux/void-packages/blob/c33c4b5974e14bc9bacf1b37a846a4633ec7cf80/common/build-style/configure.sh#L2-L3

