### PR TITLE
New package: libudunits-2.2.28

### DIFF
--- a/srcpkgs/libudunits/template
+++ b/srcpkgs/libudunits/template
@@ -1,0 +1,17 @@
+# Template file for 'libudunits'
+pkgname=libudunits
+version=2.2.28
+revision=1
+build_style=gnu-configure
+hostmakedepends="texinfo"
+makedepends="expat-devel"
+short_desc="C library for physical unit-definition and value-conversion utility"
+maintainer="Brihadeesh <brihadeesh@protonmail.com>"
+license="MIT"
+homepage="https://www.unidata.ucar.edu/software/udunits/"
+distfiles="https://artifacts.unidata.ucar.edu/repository/downloads-udunits/${version}/udunits-${version}.tar.gz"
+checksum=590baec83161a3fd62c00efa66f6113cec8a7c461e3f61a5182167e0cc5d579e
+
+post_install() {
+	vlicense COPYRIGHT
+}


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **YES**

#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)

#### Notes:

There are some issues with the license. I've marked this as MIT, but the only available file (COPYRIGHT) doesn't state this explicitly. It appears to be a modified MIT license but Fedora wiki suggests it's compatible with MIT, GPL v2 and v3. 

Based on what we discussed on the IRC, this appears to be "nonfree", so are there any changes I'll have to make for this?